### PR TITLE
feat(multitable): localize record drawer and form view to zh-CN (T3B1)

### DIFF
--- a/apps/web/src/multitable/components/MetaFormView.vue
+++ b/apps/web/src/multitable/components/MetaFormView.vue
@@ -1,8 +1,8 @@
 <template>
   <div class="meta-form-view">
-    <div v-if="loading" class="meta-form-view__loading">Loading...</div>
+    <div v-if="loading" class="meta-form-view__loading">{{ l('form.loading') }}</div>
     <template v-else>
-      <div v-if="readOnly" class="meta-form-view__readonly-banner">This form is read-only</div>
+      <div v-if="readOnly" class="meta-form-view__readonly-banner">{{ l('form.readOnly') }}</div>
       <div v-if="successMessage" class="meta-form-view__success">{{ successMessage }}</div>
       <div v-if="errorMessage" class="meta-form-view__error">{{ errorMessage }}</div>
       <form class="meta-form-view__form" @submit.prevent="onSubmit">
@@ -18,7 +18,7 @@
               type="button"
               class="meta-form-view__comment-anchor"
               :class="formFieldAnchorClass(field.id)"
-              :aria-label="`Comments for ${field.name}`"
+              :aria-label="commentForField(field.name, isZh)"
               @click="emit('comment-field', field)"
             >
               <MetaCommentAffordance :state="formFieldAffordance(field.id)" />
@@ -57,7 +57,7 @@
             :class="{ 'meta-form-view__input--error': !!fieldErrors?.[field.id] || !!validationErrors[field.id] }"
             type="text"
             inputmode="text"
-            placeholder="Scan or enter barcode"
+            :placeholder="lc('cell.barcodePlaceholder')"
             :disabled="isFieldReadOnly(field.id)"
             :aria-required="field.required ? 'true' : undefined"
             :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
@@ -71,7 +71,7 @@
             class="meta-form-view__input"
             :class="{ 'meta-form-view__input--error': !!fieldErrors?.[field.id] || !!validationErrors[field.id] }"
             type="text"
-            placeholder="Enter address"
+            :placeholder="lc('cell.locationPlaceholder')"
             :disabled="isFieldReadOnly(field.id)"
             :aria-required="field.required ? 'true' : undefined"
             :aria-invalid="(!!fieldErrors?.[field.id] || !!validationErrors[field.id]) ? 'true' : undefined"
@@ -94,7 +94,7 @@
           />
           <label v-else-if="field.type === 'boolean'" class="meta-form-view__check">
             <input type="checkbox" :disabled="isFieldReadOnly(field.id)" :checked="!!formData[field.id]" @change="formData[field.id] = ($event.target as HTMLInputElement).checked" />
-            {{ formData[field.id] ? 'Yes' : 'No' }}
+            {{ formData[field.id] ? lc('cell.yes') : lc('cell.no') }}
           </label>
           <input
             v-else-if="field.type === 'date'"
@@ -176,10 +176,10 @@
                 class="meta-form-view__attachment-clear"
                 :disabled="!!attachmentActivity[field.id]"
                 @click="onClearAttachments(field.id)"
-              >Clear all</button>
+              >{{ lc('cell.clearAll') }}</button>
             </div>
             <span v-if="attachmentActivity[field.id]" class="meta-form-view__uploading">
-              {{ attachmentActivity[field.id] === 'removing' ? 'Removing...' : attachmentActivity[field.id] === 'clearing' ? 'Clearing...' : 'Uploading...' }}
+              {{ attachmentActivityLabel(attachmentActivity[field.id] || 'uploading', isZh) }}
             </span>
             <MetaAttachmentList
               :attachments="attachmentItems(field.id)"
@@ -252,9 +252,9 @@
         </div>
         <div v-if="!readOnly" class="meta-form-view__actions">
           <button type="submit" class="meta-form-view__submit" :disabled="submitting || hasPendingAttachmentActions">
-            {{ submitting ? 'Saving...' : (record ? 'Save' : 'Create') }}
+            {{ submitting ? l('form.saving') : (record ? l('form.save') : l('form.create')) }}
           </button>
-          <button v-if="record" type="button" class="meta-form-view__reset" @click="resetForm">Reset</button>
+          <button v-if="record" type="button" class="meta-form-view__reset" @click="resetForm">{{ l('form.reset') }}</button>
         </div>
       </form>
     </template>
@@ -288,6 +288,19 @@ import {
   validateAttachmentSelection,
 } from '../utils/field-config'
 import { linkActionLabel } from '../utils/link-fields'
+import { useLocale } from '../../composables/useLocale'
+import {
+  recordLabel,
+  requiredField,
+  type MetaRecordLabelKey,
+} from '../utils/meta-record-labels'
+import {
+  metaCoreLabel,
+  attachmentActionHint as attachmentActionHintFn,
+  attachmentActivityLabel,
+  commentForField,
+  type MetaCoreLabelKey,
+} from '../utils/meta-core-labels'
 import {
   dateTimeInputValue,
   dateTimeValueFromLocalInput,
@@ -323,6 +336,10 @@ const emit = defineEmits<{
   (e: 'update:dirty', dirty: boolean): void
   (e: 'comment-field', field: MetaField): void
 }>()
+
+const { isZh } = useLocale()
+const l = (key: MetaRecordLabelKey) => recordLabel(key, isZh.value)
+const lc = (key: MetaCoreLabelKey) => metaCoreLabel(key, isZh.value)
 
 const formData = reactive<Record<string, unknown>>({})
 const validationErrors = ref<Record<string, string>>({})
@@ -402,7 +419,7 @@ function validate(): boolean {
   for (const f of editableFields.value) {
     const v = formData[f.id]
     if (f.required && isEmptyFormValue(v)) {
-      errs[f.id] = `${f.name} is required`
+      errs[f.id] = requiredField(f.name, isZh.value)
     }
   }
   validationErrors.value = errs
@@ -415,7 +432,7 @@ function onSubmit() {
 }
 
 function resetForm() {
-  if (hasUnsavedChanges.value && !confirm('Discard unsaved changes?')) return
+  if (hasUnsavedChanges.value && !confirm(l('form.discardConfirm'))) return
   syncFromRecord(props.record)
   validationErrors.value = {}
 }
@@ -423,7 +440,7 @@ function resetForm() {
 function linkButtonLabel(fieldId: string): string {
   const count = linkSummaryCount(fieldId)
   const field = props.fields.find((item) => item.id === fieldId) ?? null
-  return linkActionLabel(field, count)
+  return linkActionLabel(field, count, isZh.value)
 }
 
 function ratingMaxFor(field: MetaField): number {
@@ -496,11 +513,20 @@ function attachmentItems(fieldId: string): MetaAttachment[] {
 }
 
 function attachmentActionHint(fieldId: string): string {
+  // T3B1 (F-T3B-B): reuse the T3A2 meta-core-labels helper with mode='add'
+  // so this surface does not re-implement the ternary chain. Non-attachment
+  // fields fall back to the multi-file add copy (matches the old behavior of
+  // the inline string before the refactor).
   const field = props.fields.find((item) => item.id === fieldId)
-  if (!field || field.type !== 'attachment') return 'Add files'
-  const allowsMultiple = attachmentAllowsMultiple(field)
-  if (allowsMultiple) return 'Add files'
-  return attachmentList(fieldId).length ? 'Upload a new file to replace the current one' : 'Upload a file'
+  if (!field || field.type !== 'attachment') {
+    return attachmentActionHintFn(true, false, isZh.value, 'add')
+  }
+  return attachmentActionHintFn(
+    attachmentAllowsMultiple(field),
+    attachmentList(fieldId).length > 0,
+    isZh.value,
+    'add',
+  )
 }
 
 async function onFormFileSelect(fieldId: string, e: Event) {
@@ -540,7 +566,7 @@ async function onFormFileSelect(fieldId: string, e: Event) {
     }
     formData[fieldId] = replaceExisting ? newIds : [...existing, ...newIds]
   } catch (error: any) {
-    setAttachmentOperationError(fieldId, error?.message ?? 'Failed to upload attachment')
+    setAttachmentOperationError(fieldId, error?.message ?? lc('cell.uploadFailed'))
   } finally {
     setAttachmentActivity(fieldId)
     input.value = ''
@@ -557,7 +583,7 @@ async function onRemoveAttachment(fieldId: string, attachmentId: string) {
         fieldId,
       })
     } catch (error: any) {
-      setAttachmentOperationError(fieldId, error?.message ?? 'Failed to remove attachment')
+      setAttachmentOperationError(fieldId, error?.message ?? lc('cell.removeFailed'))
       setAttachmentActivity(fieldId)
       return
     }
@@ -582,7 +608,7 @@ async function onClearAttachments(fieldId: string) {
         forgetLocalAttachment(fieldId, attachmentId)
       }
     } catch (error: any) {
-      setAttachmentOperationError(fieldId, error?.message ?? 'Failed to clear attachments')
+      setAttachmentOperationError(fieldId, error?.message ?? lc('cell.clearFailed'))
       setAttachmentActivity(fieldId)
       return
     }

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -1,11 +1,11 @@
 <template>
   <div v-if="visible" class="meta-record-drawer">
     <div class="meta-record-drawer__header">
-      <h3 class="meta-record-drawer__title">Record Detail</h3>
+      <h3 class="meta-record-drawer__title">{{ l('record.title') }}</h3>
       <div class="meta-record-drawer__nav" v-if="recordIds.length > 1">
-        <button class="meta-record-drawer__nav-btn" :disabled="currentRecordIndex <= 0" aria-label="Previous record" @click="navigatePrev">&lsaquo;</button>
+        <button class="meta-record-drawer__nav-btn" :disabled="currentRecordIndex <= 0" :aria-label="l('record.previous')" @click="navigatePrev">&lsaquo;</button>
         <span class="meta-record-drawer__nav-pos">{{ currentRecordIndex + 1 }} / {{ recordIds.length }}</span>
-        <button class="meta-record-drawer__nav-btn" :disabled="currentRecordIndex >= recordIds.length - 1" aria-label="Next record" @click="navigateNext">&rsaquo;</button>
+        <button class="meta-record-drawer__nav-btn" :disabled="currentRecordIndex >= recordIds.length - 1" :aria-label="l('record.next')" @click="navigateNext">&rsaquo;</button>
       </div>
       <div class="meta-record-drawer__actions">
         <button
@@ -14,29 +14,29 @@
           :class="{ 'meta-record-drawer__btn--watching': recordSubscribed }"
           type="button"
           :disabled="subscriptionLoading"
-          :title="recordSubscribed ? 'Unwatch this record' : 'Watch this record'"
+          :title="l(recordSubscribed ? 'record.unwatchTitle' : 'record.watchTitle')"
           @click="toggleRecordSubscription"
         >
-          {{ recordSubscribed ? 'Watching' : 'Watch' }}
+          {{ l(recordSubscribed ? 'record.watching' : 'record.watch') }}
         </button>
         <button
           v-if="resolvedCanComment"
           class="meta-record-drawer__btn meta-record-drawer__btn--comment"
           :class="drawerCommentButtonClass"
-          title="Comments"
+          :title="l('record.comments')"
           type="button"
           @click="emit('toggle-comments')"
         >
-          <MetaCommentActionChip label="Comments" :state="drawerCommentAffordance" />
+          <MetaCommentActionChip :label="l('record.comments')" :state="drawerCommentAffordance" />
         </button>
-        <button v-if="canManageAutomation" class="meta-record-drawer__btn" title="Open workflow designer" @click="emit('open-automation')">&#x2699; Workflow</button>
-        <button v-if="canManageRecordPermissions" class="meta-record-drawer__btn" title="Record Permissions" @click="showRecordPermissions = true">&#x1F512; Permissions</button>
-        <button v-if="resolvedCanDelete" class="meta-record-drawer__btn meta-record-drawer__btn--danger" @click="emit('delete')">Delete</button>
-        <button class="meta-record-drawer__close" aria-label="Close record drawer" @click="emit('close')">&times;</button>
+        <button v-if="canManageAutomation" class="meta-record-drawer__btn" :title="l('record.workflowTitle')" @click="emit('open-automation')">&#x2699; {{ l('record.workflow') }}</button>
+        <button v-if="canManageRecordPermissions" class="meta-record-drawer__btn" :title="l('record.permissionsTitle')" @click="showRecordPermissions = true">&#x1F512; {{ l('record.permissions') }}</button>
+        <button v-if="resolvedCanDelete" class="meta-record-drawer__btn meta-record-drawer__btn--danger" @click="emit('delete')">{{ l('record.delete') }}</button>
+        <button class="meta-record-drawer__close" :aria-label="l('record.close')" @click="emit('close')">&times;</button>
       </div>
     </div>
     <div v-if="record" class="meta-record-drawer__body">
-      <div class="meta-record-drawer__tabs" role="tablist" aria-label="Record drawer sections">
+      <div class="meta-record-drawer__tabs" role="tablist" :aria-label="l('record.tabsAria')">
         <button
           class="meta-record-drawer__tab"
           :class="{ 'meta-record-drawer__tab--active': activeTab === 'details' }"
@@ -44,7 +44,7 @@
           role="tab"
           :aria-selected="activeTab === 'details'"
           @click="activeTab = 'details'"
-        >Details</button>
+        >{{ l('record.details') }}</button>
         <button
           class="meta-record-drawer__tab"
           :class="{ 'meta-record-drawer__tab--active': activeTab === 'history' }"
@@ -52,7 +52,7 @@
           role="tab"
           :aria-selected="activeTab === 'history'"
           @click="activeTab = 'history'"
-        >History</button>
+        >{{ l('record.history') }}</button>
       </div>
       <div v-if="subscriptionError" class="meta-record-drawer__watch-error">{{ subscriptionError }}</div>
       <div v-if="activeTab === 'details'" class="meta-record-drawer__fields">
@@ -65,8 +65,8 @@
             class="meta-record-drawer__comment-anchor"
             :class="recordFieldAnchorClass(field.id)"
             :data-comment-field="field.id"
-            :aria-label="`Comment on ${field.name}`"
-            :title="`Comment on ${field.name}`"
+            :aria-label="commentOnField(field.name, isZh)"
+            :title="commentOnField(field.name, isZh)"
             @click="emit('comment-field', field)"
           >
             <MetaCommentAffordance :state="recordFieldAffordance(field.id)" />
@@ -95,7 +95,7 @@
             class="meta-record-drawer__input"
             type="text"
             inputmode="text"
-            placeholder="Scan or enter barcode"
+            :placeholder="lc('cell.barcodePlaceholder')"
             :value="textControlValue(record.data[field.id])"
             @change="emit('patch', field.id, ($event.target as HTMLInputElement).value)"
           />
@@ -104,7 +104,7 @@
             :id="`drawer_field_${field.id}`"
             class="meta-record-drawer__input"
             type="text"
-            placeholder="Enter address"
+            :placeholder="lc('cell.locationPlaceholder')"
             :value="locationAddressValue(record.data[field.id])"
             @change="emit('patch', field.id, locationValueFromAddress(($event.target as HTMLInputElement).value))"
           />
@@ -183,9 +183,9 @@
                 class="meta-record-drawer__attachment-clear"
                 :disabled="!!attachmentActivity[field.id]"
                 @click="onClearAttachments(field.id)"
-              >Clear all</button>
+              >{{ lc('cell.clearAll') }}</button>
               <span v-if="attachmentActivity[field.id]" class="meta-record-drawer__uploading">
-                {{ attachmentActivity[field.id] === 'removing' ? 'Removing...' : attachmentActivity[field.id] === 'clearing' ? 'Clearing...' : 'Uploading...' }}
+                {{ attachmentActivityLabel(attachmentActivity[field.id] || 'uploading', isZh) }}
               </span>
             </div>
             <div v-if="attachmentErrors[field.id]" class="meta-record-drawer__error">{{ attachmentErrors[field.id] }}</div>
@@ -196,10 +196,10 @@
       </div>
       </div>
       <div v-else class="meta-record-drawer__history">
-        <div v-if="historyLoading" class="meta-record-drawer__history-state">Loading history...</div>
+        <div v-if="historyLoading" class="meta-record-drawer__history-state">{{ l('record.historyLoading') }}</div>
         <div v-else-if="historyError" class="meta-record-drawer__history-state meta-record-drawer__history-state--error">{{ historyError }}</div>
-        <div v-else-if="!canLoadHistory" class="meta-record-drawer__history-state">History unavailable for this record.</div>
-        <div v-else-if="historyItems.length === 0" class="meta-record-drawer__history-state">No history yet.</div>
+        <div v-else-if="!canLoadHistory" class="meta-record-drawer__history-state">{{ l('record.historyUnavailable') }}</div>
+        <div v-else-if="historyItems.length === 0" class="meta-record-drawer__history-state">{{ l('record.historyEmpty') }}</div>
         <ol v-else class="meta-record-drawer__history-list">
           <li v-for="item in historyItems" :key="item.id" class="meta-record-drawer__history-item">
             <div class="meta-record-drawer__history-main">
@@ -208,7 +208,7 @@
             </div>
             <div class="meta-record-drawer__history-meta">
               <span>{{ formatHistoryTime(item.createdAt) }}</span>
-              <span v-if="item.actorId">by {{ item.actorId }}</span>
+              <span v-if="item.actorId">{{ historyActor(item.actorId, isZh) }}</span>
               <span>{{ item.source }}</span>
             </div>
             <div v-if="item.changedFieldIds.length" class="meta-record-drawer__history-fields">
@@ -218,7 +218,7 @@
         </ol>
       </div>
     </div>
-    <div v-else class="meta-record-drawer__empty">No record selected</div>
+    <div v-else class="meta-record-drawer__empty">{{ l('record.noRecord') }}</div>
     <MetaRecordPermissionManager
       v-if="canManageRecordPermissions && record && sheetId && apiClient"
       :visible="showRecordPermissions"
@@ -258,6 +258,19 @@ import {
 } from '../utils/comment-affordance'
 import { attachmentAcceptAttr, resolveAttachmentFieldProperty, shouldReplaceAttachmentSelection, validateAttachmentSelection } from '../utils/field-config'
 import { linkActionLabel } from '../utils/link-fields'
+import { useLocale } from '../../composables/useLocale'
+import {
+  recordLabel,
+  commentOnField,
+  historyActor,
+  type MetaRecordLabelKey,
+} from '../utils/meta-record-labels'
+import {
+  metaCoreLabel,
+  attachmentActionHint as attachmentActionHintFn,
+  attachmentActivityLabel,
+  type MetaCoreLabelKey,
+} from '../utils/meta-core-labels'
 import {
   dateTimeInputValue,
   dateTimeValueFromLocalInput,
@@ -300,6 +313,10 @@ const emit = defineEmits<{
   (e: 'open-link-picker', field: MetaField): void
   (e: 'navigate', recordId: string): void
 }>()
+
+const { isZh } = useLocale()
+const l = (key: MetaRecordLabelKey) => recordLabel(key, isZh.value)
+const lc = (key: MetaCoreLabelKey) => metaCoreLabel(key, isZh.value)
 
 const showRecordPermissions = ref(false)
 const activeTab = ref<'details' | 'history'>('details')
@@ -404,7 +421,7 @@ async function loadRecordHistory() {
   } catch (error: any) {
     if (requestId !== historyRequestId) return
     historyItems.value = []
-    historyError.value = error?.message ?? 'Failed to load history'
+    historyError.value = error?.message ?? l('record.errorHistoryLoad')
   } finally {
     if (requestId === historyRequestId) historyLoading.value = false
   }
@@ -434,7 +451,7 @@ async function loadRecordSubscription() {
   } catch (error: any) {
     if (requestId !== subscriptionRequestId) return
     recordSubscribed.value = false
-    subscriptionError.value = error?.message ?? 'Failed to load watch status'
+    subscriptionError.value = error?.message ?? l('record.errorWatchLoad')
   } finally {
     if (requestId === subscriptionRequestId) subscriptionLoading.value = false
   }
@@ -456,16 +473,16 @@ async function toggleRecordSubscription() {
     applySubscriptionStatus(status)
   } catch (error: any) {
     if (requestId !== subscriptionRequestId) return
-    subscriptionError.value = error?.message ?? 'Failed to update watch status'
+    subscriptionError.value = error?.message ?? l('record.errorWatchUpdate')
   } finally {
     if (requestId === subscriptionRequestId) subscriptionLoading.value = false
   }
 }
 
 function historyActionLabel(action: MetaRecordRevision['action']): string {
-  if (action === 'create') return 'Created'
-  if (action === 'delete') return 'Deleted'
-  return 'Updated'
+  if (action === 'create') return l('record.historyActionCreated')
+  if (action === 'delete') return l('record.historyActionDeleted')
+  return l('record.historyActionUpdated')
 }
 
 function historyFieldLabels(fieldIds: string[]): string {
@@ -507,7 +524,7 @@ function multiSelectEventValue(event: Event): string[] {
 function linkButtonLabel(fieldId: string): string {
   const count = linkSummaryCount(fieldId)
   const field = props.fields.find((item) => item.id === fieldId) ?? null
-  return linkActionLabel(field, count)
+  return linkActionLabel(field, count, isZh.value)
 }
 
 function linkPreview(fieldId: string): string {
@@ -549,13 +566,20 @@ function linkSummaryCount(fieldId: string): number {
 }
 
 function attachmentActionHint(fieldId: string): string {
+  // T3B1 (F-T3B-B): reuse the T3A2 meta-core-labels helper with mode='add'
+  // so this surface does not re-implement the ternary chain. Non-attachment
+  // fields fall back to the multi-file add copy (matches the old behavior of
+  // the inline string before the refactor).
   const field = props.fields.find((item) => item.id === fieldId)
-  if (!field || field.type !== 'attachment') return 'Add files'
-  return attachmentAllowsMultiple(field)
-    ? 'Add files'
-    : attachmentList(fieldId).length
-      ? 'Upload a new file to replace the current one'
-      : 'Upload a file'
+  if (!field || field.type !== 'attachment') {
+    return attachmentActionHintFn(true, false, isZh.value, 'add')
+  }
+  return attachmentActionHintFn(
+    attachmentAllowsMultiple(field),
+    attachmentList(fieldId).length > 0,
+    isZh.value,
+    'add',
+  )
 }
 
 async function onDrawerFileSelect(fieldId: string, e: Event) {
@@ -595,7 +619,7 @@ async function onDrawerFileSelect(fieldId: string, e: Event) {
     }
     emit('patch', fieldId, replaceExisting ? newIds : [...existing, ...newIds])
   } catch (error: any) {
-    setAttachmentError(fieldId, error?.message ?? 'Failed to upload attachment')
+    setAttachmentError(fieldId, error?.message ?? lc('cell.uploadFailed'))
   } finally {
     setAttachmentActivity(fieldId)
     input.value = ''
@@ -612,7 +636,7 @@ async function onRemoveAttachment(fieldId: string, attachmentId: string) {
         fieldId,
       })
     } catch (error: any) {
-      setAttachmentError(fieldId, error?.message ?? 'Failed to remove attachment')
+      setAttachmentError(fieldId, error?.message ?? lc('cell.removeFailed'))
       setAttachmentActivity(fieldId)
       return
     }
@@ -638,7 +662,7 @@ async function onClearAttachments(fieldId: string) {
         forgetLocalAttachment(fieldId, attachmentId)
       }
     } catch (error: any) {
-      setAttachmentError(fieldId, error?.message ?? 'Failed to clear attachments')
+      setAttachmentError(fieldId, error?.message ?? lc('cell.clearFailed'))
       setAttachmentActivity(fieldId)
       return
     }

--- a/apps/web/src/multitable/utils/link-fields.ts
+++ b/apps/web/src/multitable/utils/link-fields.ts
@@ -13,8 +13,36 @@ function linkEntityLabel(field?: MetaField | null, count?: number): string {
   return count === 1 ? 'linked record' : 'linked records'
 }
 
-export function linkActionLabel(field: MetaField | null | undefined, count: number): string {
-  if (count > 0) return `Edit ${linkEntityLabel(field, count)} (${count})`
+// linkActionLabel: button copy for the link-field action button.
+//
+// `isZh` is an opt-in third argument (default false): when callers from the
+// T3B1 record drawer / form view pass `useLocale().isZh.value`, the helper
+// returns the zh form; otherwise existing callers (MetaCellEditor T3A2
+// dead-key branch, MetaImportModal) keep their current English output
+// unchanged.
+//
+// Chinese has no singular/plural distinction for the entity noun, so both
+// `count === 1` and `count > 1` collapse to the same zh entity word
+// (`人员` / `关联记录`); only the EN branch carries the singular/plural fork.
+//
+// User-confirmed zh choices (T3B1 design MD §6, 2026-05-19): 选择人员... /
+// 编辑人员 (n) / 选择关联记录... / 编辑关联记录 (n).
+export function linkActionLabel(
+  field: MetaField | null | undefined,
+  count: number,
+  isZh: boolean = false,
+): string {
+  if (count > 0) {
+    if (isZh) {
+      const entityZh = isPersonField(field) ? '人员' : '关联记录'
+      return `编辑${entityZh} (${count})`
+    }
+    return `Edit ${linkEntityLabel(field, count)} (${count})`
+  }
+  if (isZh) {
+    const entityZh = isPersonField(field) ? '人员' : '关联记录'
+    return `选择${entityZh}...`
+  }
   return `Choose ${linkEntityLabel(field)}...`
 }
 

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -230,20 +230,35 @@ export function filterValuePlaceholder(type: string, isZh: boolean): string {
 
 // --- T3A2: MetaCellEditor attachment helpers ---
 
+// AttachmentActionMode (T3B1): selects the multi-file copy variant.
+//   - `drop`  → "Drop files or click to browse" (MetaCellEditor — drop target chrome)
+//   - `add`   → "Add files" (MetaRecordDrawer / MetaFormView — add-action chrome)
+// Single-file branches are identical across modes (the mode only matters
+// when allowsMultiple is true). Backwards compatible: legacy callers
+// without an explicit mode keep T3A2 behavior via the default.
+export type AttachmentActionMode = 'drop' | 'add'
+
 // attachmentActionHint: drop-target hint for the MetaCellEditor attachment
-// trigger. Three variants chosen by capability + existing-attachment state:
-//   - multi-file allowed → "Drop files or click to browse"
-//   - single-file + already has an attachment → "Upload a new file to replace the current one"
-//   - single-file + empty → "Upload a file"
+// trigger (mode='drop', T3A2 default) or the add-files trigger used by
+// MetaRecordDrawer / MetaFormView (mode='add', T3B1). Three variants chosen
+// by capability + existing-attachment state:
+//   multi-file allowed → mode='drop' "Drop files or click to browse" /
+//                        mode='add'  "Add files"
+//   single-file + already has an attachment → "Upload a new file to replace the current one"
+//   single-file + empty → "Upload a file"
 // `hasExisting` is a boolean — only >0-ness matters to copy, not the count.
 // User-confirmed zh choices (T3A2 AskUserQuestion, 2026-05-19): 拖拽文件或点击选择 /
-// 上传新文件以替换当前文件 / 上传文件.
+// 上传新文件以替换当前文件 / 上传文件. T3B1 add-mode zh: 添加文件.
 export function attachmentActionHint(
   allowsMultiple: boolean,
   hasExisting: boolean,
   isZh: boolean,
+  mode: AttachmentActionMode = 'drop',
 ): string {
-  if (allowsMultiple) return isZh ? '拖拽文件或点击选择' : 'Drop files or click to browse'
+  if (allowsMultiple) {
+    if (mode === 'add') return isZh ? '添加文件' : 'Add files'
+    return isZh ? '拖拽文件或点击选择' : 'Drop files or click to browse'
+  }
   if (hasExisting) return isZh ? '上传新文件以替换当前文件' : 'Upload a new file to replace the current one'
   return isZh ? '上传文件' : 'Upload a file'
 }

--- a/apps/web/src/multitable/utils/meta-record-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-labels.ts
@@ -1,0 +1,111 @@
+// Record drawer + Form view chrome string table — single source for
+// MetaRecordDrawer.vue and MetaFormView.vue (T3B1) localization.
+//
+// EN + ZH both explicit, same convention as workbench-labels.ts and
+// meta-core-labels.ts. Components read `useLocale().isZh` and call
+// `recordLabel(key, isZh)` for static strings, or the helpers below
+// for interpolated strings.
+//
+// Scope: see docs/development/multitable-t3b1-record-form-i18n-design-20260520.md.
+//
+// Intentional cross-module reuse from meta-core-labels.ts (T3A2):
+//   - Field-editor placeholders: cell.barcodePlaceholder, cell.locationPlaceholder
+//   - Boolean editor: cell.yes, cell.no
+//   - Attachment chrome: cell.clearAll, attachmentActionHint (with the new
+//     T3B1 `mode='add'` variant), attachmentActivityLabel,
+//     cell.uploadFailed / cell.removeFailed / cell.clearFailed
+//   - Field comment aria label: commentForField (used by MetaFormView)
+//
+// These are not duplicated here — T3B1 imports them from meta-core-labels.
+//
+// T3B2 (comments drawer/composer) and T3B3 (link picker title/search/empty/
+// footer) get their own modules per the per-surface decision.
+
+export type MetaRecordLabelKey =
+  // --- MetaRecordDrawer static ---
+  | 'record.title'
+  | 'record.previous' | 'record.next'
+  | 'record.watch' | 'record.watching'
+  | 'record.watchTitle' | 'record.unwatchTitle'
+  | 'record.comments'
+  | 'record.workflow' | 'record.workflowTitle'
+  | 'record.permissions' | 'record.permissionsTitle'
+  | 'record.delete' | 'record.close'
+  | 'record.tabsAria'
+  | 'record.details' | 'record.history'
+  | 'record.historyLoading' | 'record.historyUnavailable' | 'record.historyEmpty'
+  | 'record.historyActionCreated' | 'record.historyActionDeleted' | 'record.historyActionUpdated'
+  // FE-owned static fallback strings (the `error?.message ?? l(...)`
+  // pattern from T3A2). Backend error.message remains raw when present.
+  | 'record.errorHistoryLoad' | 'record.errorWatchLoad' | 'record.errorWatchUpdate'
+  | 'record.noRecord'
+  // --- MetaFormView static ---
+  | 'form.loading' | 'form.readOnly'
+  | 'form.discardConfirm'
+  | 'form.save' | 'form.saving' | 'form.create' | 'form.reset'
+
+const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }> = {
+  'record.title': { en: 'Record Detail', zh: '记录详情' },
+  'record.previous': { en: 'Previous record', zh: '上一条记录' },
+  'record.next': { en: 'Next record', zh: '下一条记录' },
+  'record.watch': { en: 'Watch', zh: '关注' },
+  'record.watching': { en: 'Watching', zh: '已关注' },
+  'record.watchTitle': { en: 'Watch this record', zh: '关注此记录' },
+  'record.unwatchTitle': { en: 'Unwatch this record', zh: '取消关注此记录' },
+  'record.comments': { en: 'Comments', zh: '评论' },
+  'record.workflow': { en: 'Workflow', zh: '工作流' },
+  'record.workflowTitle': { en: 'Open workflow designer', zh: '打开工作流设计器' },
+  'record.permissions': { en: 'Permissions', zh: '权限' },
+  'record.permissionsTitle': { en: 'Record Permissions', zh: '记录权限' },
+  'record.delete': { en: 'Delete', zh: '删除' },
+  'record.close': { en: 'Close record drawer', zh: '关闭记录抽屉' },
+  'record.tabsAria': { en: 'Record drawer sections', zh: '记录抽屉分区' },
+  'record.details': { en: 'Details', zh: '详情' },
+  'record.history': { en: 'History', zh: '历史' },
+  'record.historyLoading': { en: 'Loading history...', zh: '正在加载历史...' },
+  'record.historyUnavailable': { en: 'History unavailable for this record.', zh: '此记录的历史不可用。' },
+  'record.historyEmpty': { en: 'No history yet.', zh: '暂无历史。' },
+  'record.historyActionCreated': { en: 'Created', zh: '已创建' },
+  'record.historyActionDeleted': { en: 'Deleted', zh: '已删除' },
+  'record.historyActionUpdated': { en: 'Updated', zh: '已更新' },
+  'record.errorHistoryLoad': { en: 'Failed to load history', zh: '加载历史失败' },
+  'record.errorWatchLoad': { en: 'Failed to load watch status', zh: '加载关注状态失败' },
+  'record.errorWatchUpdate': { en: 'Failed to update watch status', zh: '更新关注状态失败' },
+  'record.noRecord': { en: 'No record selected', zh: '未选择记录' },
+
+  'form.loading': { en: 'Loading...', zh: '正在加载...' },
+  'form.readOnly': { en: 'This form is read-only', zh: '此表单为只读' },
+  'form.discardConfirm': { en: 'Discard unsaved changes?', zh: '放弃未保存的更改吗？' },
+  'form.save': { en: 'Save', zh: '保存' },
+  'form.saving': { en: 'Saving...', zh: '正在保存...' },
+  'form.create': { en: 'Create', zh: '创建' },
+  'form.reset': { en: 'Reset', zh: '重置' },
+}
+
+export function recordLabel(key: MetaRecordLabelKey, isZh: boolean): string {
+  const entry = META_RECORD_LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+// --- Interpolation helpers (not keys) ---
+
+// commentOnField: aria-label/title for the comment-on-field button in the
+// Record Detail drawer. Field name is user data and is interpolated raw —
+// never translated. (Distinct from T3A1's commentForField, which is used
+// by MetaGridTable and MetaFormView for the plural "Comments for X" copy.)
+export function commentOnField(fieldName: string, isZh: boolean): string {
+  return isZh ? `评论 ${fieldName}` : `Comment on ${fieldName}`
+}
+
+// historyActor: prefix label for a history entry actor in the record
+// history view. Actor id is user data (typically a user_X username) and
+// remains raw.
+export function historyActor(actorId: string, isZh: boolean): string {
+  return isZh ? `由 ${actorId}` : `by ${actorId}`
+}
+
+// requiredField: validation error message for a missing required field
+// in MetaFormView. Field name is user data and is interpolated raw.
+export function requiredField(fieldName: string, isZh: boolean): string {
+  return isZh ? `${fieldName} 为必填项` : `${fieldName} is required`
+}

--- a/apps/web/tests/link-fields-i18n.spec.ts
+++ b/apps/web/tests/link-fields-i18n.spec.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect } from 'vitest'
+import { linkActionLabel } from '../src/multitable/utils/link-fields'
+import type { MetaField } from '../src/multitable/types'
+
+const personField: MetaField = { id: 'owner', name: 'Owner', type: 'person' as MetaField['type'] }
+const recordField: MetaField = { id: 'parent', name: 'Parent', type: 'link' as MetaField['type'] }
+
+describe('linkActionLabel — backwards compatibility (isZh default = false)', () => {
+  it('defaults to English when no isZh arg is passed — MetaCellEditor / MetaImportModal stay unchanged', () => {
+    // record branch (the T3A2 unreachable-fallback case + MetaImportModal)
+    expect(linkActionLabel(recordField, 0)).toBe('Choose linked records...')
+    expect(linkActionLabel(recordField, 1)).toBe('Edit linked record (1)')
+    expect(linkActionLabel(recordField, 5)).toBe('Edit linked records (5)')
+    // person branch
+    expect(linkActionLabel(personField, 0)).toBe('Choose people...')
+    expect(linkActionLabel(personField, 1)).toBe('Edit person (1)')
+    expect(linkActionLabel(personField, 3)).toBe('Edit people (3)')
+  })
+
+  it('explicit isZh=false equals the legacy default (regression guard)', () => {
+    expect(linkActionLabel(recordField, 0, false)).toBe('Choose linked records...')
+    expect(linkActionLabel(recordField, 1, false)).toBe('Edit linked record (1)')
+    expect(linkActionLabel(personField, 1, false)).toBe('Edit person (1)')
+    expect(linkActionLabel(personField, 4, false)).toBe('Edit people (4)')
+  })
+
+  it('treats null/undefined as the record branch (no person classification)', () => {
+    expect(linkActionLabel(null, 0)).toBe('Choose linked records...')
+    expect(linkActionLabel(undefined, 0)).toBe('Choose linked records...')
+    expect(linkActionLabel(null, 2)).toBe('Edit linked records (2)')
+  })
+})
+
+describe('linkActionLabel — zh forms (T3B1 opt-in)', () => {
+  it('record branch zh covers count 0/1/N (MD §6, all collapse to 关联记录)', () => {
+    expect(linkActionLabel(recordField, 0, true)).toBe('选择关联记录...')
+    expect(linkActionLabel(recordField, 1, true)).toBe('编辑关联记录 (1)')
+    expect(linkActionLabel(recordField, 7, true)).toBe('编辑关联记录 (7)')
+  })
+
+  it('person branch zh covers count 0/1/N (MD §6, all collapse to 人员)', () => {
+    expect(linkActionLabel(personField, 0, true)).toBe('选择人员...')
+    expect(linkActionLabel(personField, 1, true)).toBe('编辑人员 (1)')
+    expect(linkActionLabel(personField, 9, true)).toBe('编辑人员 (9)')
+  })
+
+  it('zh has no singular/plural distinction — count=1 and count=N share the same entity word', () => {
+    // EN has different nouns by count; zh keeps the same noun.
+    expect(linkActionLabel(recordField, 1, false)).toBe('Edit linked record (1)')
+    expect(linkActionLabel(recordField, 2, false)).toBe('Edit linked records (2)')
+    expect(linkActionLabel(recordField, 1, true)).toBe('编辑关联记录 (1)')
+    expect(linkActionLabel(recordField, 2, true)).toBe('编辑关联记录 (2)')
+  })
+
+  it('null/undefined field with zh still maps to the record branch', () => {
+    expect(linkActionLabel(null, 0, true)).toBe('选择关联记录...')
+    expect(linkActionLabel(undefined, 3, true)).toBe('编辑关联记录 (3)')
+  })
+})

--- a/apps/web/tests/meta-form-view-i18n.spec.ts
+++ b/apps/web/tests/meta-form-view-i18n.spec.ts
@@ -1,0 +1,209 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaFormView from '../src/multitable/components/MetaFormView.vue'
+import type { MetaField, MetaRecord } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+// Mount/teardown follows the canonical meta-cell-editor-i18n.spec.ts pattern
+// (createApp + container + app?.unmount() + container?.remove() + locale reset).
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  app?.unmount()
+  app = null
+  container?.remove()
+  container = null
+  useLocale().setLocale('en')
+})
+
+const TITLE_FIELD: MetaField = { id: 't', name: 'Title', type: 'string' }
+const BARCODE_FIELD: MetaField = { id: 'sku', name: 'SKU', type: 'barcode' as MetaField['type'] }
+const LOCATION_FIELD: MetaField = { id: 'addr', name: 'Address', type: 'location' as MetaField['type'] }
+const BOOL_FIELD: MetaField = { id: 'done', name: 'Done', type: 'boolean' }
+const ATTACHMENT_FIELD: MetaField = {
+  id: 'files',
+  name: 'Files',
+  type: 'attachment' as MetaField['type'],
+  property: { maxFiles: 5 } as unknown as MetaField['property'],
+}
+
+function mountForm(extraProps: Record<string, unknown> = {}) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp({
+    setup() {
+      return () => h(MetaFormView, {
+        fields: [TITLE_FIELD],
+        loading: false,
+        ...extraProps,
+      })
+    },
+  })
+  app.mount(container)
+  return container
+}
+
+describe('MetaFormView i18n — top-level chrome', () => {
+  it('zh-CN renders the loading banner', () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountForm({ loading: true })
+    expect(root.textContent ?? '').toContain('正在加载...')
+    expect(root.textContent ?? '').not.toContain('Loading...')
+  })
+
+  it('zh-CN renders the read-only banner', () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountForm({ readOnly: true })
+    expect(root.textContent ?? '').toContain('此表单为只读')
+    expect(root.textContent ?? '').not.toContain('This form is read-only')
+  })
+
+  it('en preserves the loading + read-only banners (regression)', () => {
+    useLocale().setLocale('en')
+    let root = mountForm({ loading: true })
+    expect(root.textContent ?? '').toContain('Loading...')
+    app?.unmount(); app = null; container?.remove(); container = null
+
+    root = mountForm({ readOnly: true })
+    expect(root.textContent ?? '').toContain('This form is read-only')
+  })
+})
+
+describe('MetaFormView i18n — M1 submit/reset chain', () => {
+  it('zh-CN submit shows 创建 when creating (no record) and 保存 when editing', () => {
+    useLocale().setLocale('zh-CN')
+    // No record -> create
+    let root = mountForm()
+    expect(root.textContent ?? '').toContain('创建')
+    expect(root.textContent ?? '').not.toContain('Create')
+
+    app?.unmount(); app = null; container?.remove(); container = null
+
+    // With record -> save + reset
+    const record: MetaRecord = { id: 'r1', version: 1, data: {} }
+    root = mountForm({ record })
+    const text = root.textContent ?? ''
+    expect(text).toContain('保存')
+    expect(text).toContain('重置')
+    expect(text).not.toContain('Save')
+    expect(text).not.toContain('Reset')
+  })
+
+  it('zh-CN submit shows 正在保存... when submitting=true', () => {
+    useLocale().setLocale('zh-CN')
+    const record: MetaRecord = { id: 'r1', version: 1, data: {} }
+    const root = mountForm({ record, submitting: true })
+    expect(root.textContent ?? '').toContain('正在保存...')
+    expect(root.textContent ?? '').not.toContain('Saving...')
+  })
+
+  it('en submit/reset chain preserved exactly', () => {
+    useLocale().setLocale('en')
+    const record: MetaRecord = { id: 'r1', version: 1, data: {} }
+    const root = mountForm({ record, submitting: true })
+    expect(root.textContent ?? '').toContain('Saving...')
+
+    app?.unmount(); app = null; container?.remove(); container = null
+
+    const root2 = mountForm({ record })
+    const text = root2.textContent ?? ''
+    expect(text).toContain('Save')
+    expect(text).toContain('Reset')
+  })
+})
+
+describe('MetaFormView i18n — field placeholders + Yes/No (T3A2 reuse)', () => {
+  it('zh-CN barcode/location/Yes-No all source from meta-core-labels', () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountForm({
+      fields: [BARCODE_FIELD, LOCATION_FIELD, BOOL_FIELD],
+      record: { id: 'r1', version: 1, data: { done: true } } as MetaRecord,
+    })
+    const placeholders = Array.from(root.querySelectorAll<HTMLInputElement>('input'))
+      .map((el) => el.getAttribute('placeholder'))
+      .filter(Boolean)
+    expect(placeholders).toContain('扫描或输入条码')
+    expect(placeholders).toContain('输入地址')
+    // boolean true → 是
+    expect(root.textContent ?? '').toContain('是')
+    expect(root.textContent ?? '').not.toContain('Yes')
+  })
+})
+
+describe('MetaFormView i18n — attachment chrome (F-T3B-B add mode)', () => {
+  it('zh-CN multi-file attachment chrome (添加文件 / 全部清除)', () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountForm({
+      fields: [ATTACHMENT_FIELD],
+      record: { id: 'r1', version: 1, data: { files: ['existing-1'] } } as MetaRecord,
+    })
+    const text = root.textContent ?? ''
+    expect(text).toContain('添加文件')   // attachmentActionHint mode='add' multi-file
+    expect(text).toContain('全部清除')   // cell.clearAll (T3A2 reuse)
+    expect(text).not.toContain('Add files')
+  })
+
+  it('en attachment chrome preserved', () => {
+    useLocale().setLocale('en')
+    const root = mountForm({
+      fields: [ATTACHMENT_FIELD],
+      record: { id: 'r1', version: 1, data: { files: ['existing-1'] } } as MetaRecord,
+    })
+    const text = root.textContent ?? ''
+    expect(text).toContain('Add files')
+    expect(text).toContain('Clear all')
+  })
+})
+
+describe('MetaFormView i18n — validation + native confirm', () => {
+  it("zh-CN requiredField validation shows '{field.name} 为必填项' with raw field name", async () => {
+    useLocale().setLocale('zh-CN')
+    const requiredField: MetaField = { id: 'q', name: 'Q', type: 'string', required: true } as MetaField
+    const root = mountForm({ fields: [requiredField] })
+    const form = root.querySelector('form') as HTMLFormElement
+    form.dispatchEvent(new Event('submit', { cancelable: true, bubbles: true }))
+    await new Promise((r) => setTimeout(r, 0))
+    expect(root.textContent ?? '').toContain('Q 为必填项')
+    expect(root.textContent ?? '').not.toContain('Q is required')
+  })
+
+  it("zh-CN native confirm uses localized text for resetForm discard prompt", async () => {
+    useLocale().setLocale('zh-CN')
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    try {
+      const record: MetaRecord = { id: 'r1', version: 1, data: { t: 'original' } }
+      const root = mountForm({ record })
+      const titleInput = root.querySelector<HTMLInputElement>('input[type="text"]')!
+      titleInput.value = 'changed'
+      titleInput.dispatchEvent(new Event('input'))
+      await new Promise((r) => setTimeout(r, 0))
+      const resetBtn = Array.from(root.querySelectorAll('button'))
+        .find((b) => b.textContent?.trim() === '重置') as HTMLButtonElement
+      expect(resetBtn).toBeTruthy()
+      resetBtn.click()
+      expect(confirmSpy).toHaveBeenCalledWith('放弃未保存的更改吗？')
+    } finally {
+      confirmSpy.mockRestore()
+    }
+  })
+})
+
+describe('MetaFormView i18n — URL/email/phone format examples stay raw (user data)', () => {
+  it('preserves https://example.com / name@example.com / +86 138 0000 0000 in zh-CN', () => {
+    useLocale().setLocale('zh-CN')
+    const fields: MetaField[] = [
+      { id: 'u', name: 'URL', type: 'url' as MetaField['type'] },
+      { id: 'e', name: 'Email', type: 'email' as MetaField['type'] },
+      { id: 'p', name: 'Phone', type: 'phone' as MetaField['type'] },
+    ]
+    const root = mountForm({ fields })
+    const placeholders = Array.from(root.querySelectorAll<HTMLInputElement>('input'))
+      .map((el) => el.getAttribute('placeholder'))
+      .filter(Boolean)
+    expect(placeholders).toContain('https://example.com')
+    expect(placeholders).toContain('name@example.com')
+    expect(placeholders).toContain('+86 138 0000 0000')
+  })
+})

--- a/apps/web/tests/meta-record-drawer-i18n.spec.ts
+++ b/apps/web/tests/meta-record-drawer-i18n.spec.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaRecordDrawer from '../src/multitable/components/MetaRecordDrawer.vue'
+import type { MetaField, MetaRecord } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+// Canonical mount/teardown shape per meta-cell-editor-i18n.spec.ts:
+//   createApp + container + app?.unmount() + container?.remove() + locale reset.
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  app?.unmount()
+  app = null
+  container?.remove()
+  container = null
+  useLocale().setLocale('en')
+})
+
+const TITLE_FIELD: MetaField = { id: 't', name: 'Title', type: 'string' }
+const BARCODE_FIELD: MetaField = { id: 'sku', name: 'SKU', type: 'barcode' as MetaField['type'] }
+const LOCATION_FIELD: MetaField = { id: 'addr', name: 'Address', type: 'location' as MetaField['type'] }
+const ATTACHMENT_FIELD: MetaField = {
+  id: 'files',
+  name: 'Files',
+  type: 'attachment' as MetaField['type'],
+  property: { maxFiles: 5 } as unknown as MetaField['property'],
+}
+
+const BASE_RECORD: MetaRecord = { id: 'r1', version: 1, data: {} }
+
+function mountDrawer(extraProps: Record<string, unknown> = {}) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp({
+    setup() {
+      return () => h(MetaRecordDrawer, {
+        visible: true,
+        record: BASE_RECORD,
+        fields: [TITLE_FIELD],
+        canEdit: true,
+        canComment: true,
+        canDelete: true,
+        recordIds: ['r1'],
+        ...extraProps,
+      })
+    },
+  })
+  app.mount(container)
+  return container
+}
+
+describe('MetaRecordDrawer i18n — header / actions / tabs chrome', () => {
+  it('renders zh-CN header chrome (title, close, tabsAria, tabs, delete)', () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountDrawer()
+    const text = root.textContent ?? ''
+    expect(text).toContain('记录详情')   // record.title
+    expect(text).toContain('详情')       // record.details tab
+    expect(text).toContain('历史')       // record.history tab
+    expect(text).toContain('删除')       // record.delete
+    expect(text).not.toContain('Record Detail')
+    expect(text).not.toContain('>Details<')
+    // attribute-level
+    expect(root.querySelector('.meta-record-drawer__close')?.getAttribute('aria-label')).toBe('关闭记录抽屉')
+    expect(root.querySelector('[role="tablist"]')?.getAttribute('aria-label')).toBe('记录抽屉分区')
+  })
+
+  it('renders English header chrome when locale is en (regression)', () => {
+    useLocale().setLocale('en')
+    const root = mountDrawer()
+    const text = root.textContent ?? ''
+    expect(text).toContain('Record Detail')
+    expect(text).toContain('Details')
+    expect(text).toContain('History')
+    expect(text).toContain('Delete')
+    expect(text).not.toContain('记录详情')
+    expect(root.querySelector('.meta-record-drawer__close')?.getAttribute('aria-label')).toBe('Close record drawer')
+    expect(root.querySelector('[role="tablist"]')?.getAttribute('aria-label')).toBe('Record drawer sections')
+  })
+})
+
+describe('MetaRecordDrawer i18n — empty + history states', () => {
+  it('zh-CN renders the empty placeholder when no record is selected', () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountDrawer({ record: null })
+    expect(root.textContent ?? '').toContain('未选择记录')
+    expect(root.textContent ?? '').not.toContain('No record selected')
+  })
+
+  it('en preserves the empty placeholder string (regression)', () => {
+    useLocale().setLocale('en')
+    const root = mountDrawer({ record: null })
+    expect(root.textContent ?? '').toContain('No record selected')
+  })
+
+  it('zh-CN renders historyUnavailable when apiClient is absent (canLoadHistory false)', async () => {
+    useLocale().setLocale('zh-CN')
+    // Activate the History tab via direct DOM click; canLoadHistory is false
+    // because apiClient is not supplied, so the unavailable state should show.
+    const root = mountDrawer()
+    const historyTab = Array.from(root.querySelectorAll('button'))
+      .find((b) => b.textContent?.trim() === '历史') as HTMLButtonElement | undefined
+    expect(historyTab).toBeTruthy()
+    historyTab?.click()
+    await new Promise((r) => setTimeout(r, 0))
+    const text = root.textContent ?? ''
+    expect(text).toContain('此记录的历史不可用。')
+    expect(text).not.toContain('History unavailable for this record')
+  })
+})
+
+describe('MetaRecordDrawer i18n — field-editor placeholders (T3A2 cross-module reuse)', () => {
+  it('zh-CN barcode + location placeholders come from meta-core-labels (no duplication)', () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountDrawer({
+      fields: [BARCODE_FIELD, LOCATION_FIELD],
+    })
+    const inputs = Array.from(root.querySelectorAll<HTMLInputElement>('input'))
+    const placeholders = inputs.map((el) => el.getAttribute('placeholder')).filter(Boolean)
+    expect(placeholders).toContain('扫描或输入条码')   // cell.barcodePlaceholder (T3A2)
+    expect(placeholders).toContain('输入地址')         // cell.locationPlaceholder (T3A2)
+  })
+
+  it('en placeholders preserved exactly (T3A2 backward compat)', () => {
+    useLocale().setLocale('en')
+    const root = mountDrawer({
+      fields: [BARCODE_FIELD, LOCATION_FIELD],
+    })
+    const placeholders = Array.from(root.querySelectorAll<HTMLInputElement>('input'))
+      .map((el) => el.getAttribute('placeholder'))
+      .filter(Boolean)
+    expect(placeholders).toContain('Scan or enter barcode')
+    expect(placeholders).toContain('Enter address')
+  })
+})
+
+describe('MetaRecordDrawer i18n — attachment chrome (F-T3B-B: mode=add reuse)', () => {
+  it("zh-CN multi-file attachment shows 添加文件 + 全部清除 via the T3A2 helper mode='add'", () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountDrawer({
+      fields: [ATTACHMENT_FIELD],
+      record: { id: 'r1', version: 1, data: { files: ['existing-1'] } } as MetaRecord,
+    })
+    const text = root.textContent ?? ''
+    expect(text).toContain('添加文件')   // attachmentActionHint mode='add' multi-file
+    expect(text).toContain('全部清除')   // cell.clearAll (T3A2 reuse)
+    expect(text).not.toContain('Add files')
+    expect(text).not.toContain('Clear all')
+  })
+
+  it('en attachment chrome preserved (Add files + Clear all)', () => {
+    useLocale().setLocale('en')
+    const root = mountDrawer({
+      fields: [ATTACHMENT_FIELD],
+      record: { id: 'r1', version: 1, data: { files: ['existing-1'] } } as MetaRecord,
+    })
+    const text = root.textContent ?? ''
+    expect(text).toContain('Add files')
+    expect(text).toContain('Clear all')
+  })
+})
+
+describe('MetaRecordDrawer i18n — user-data preservation', () => {
+  it('field names stay exactly as authored (never translated, even in zh-CN)', () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountDrawer({
+      fields: [{ id: 'status', name: 'Status', type: 'select', options: [{ value: 'todo' }, { value: 'done' }] }],
+      record: { id: 'r1', version: 1, data: { status: 'todo' } } as MetaRecord,
+    })
+    const text = root.textContent ?? ''
+    expect(text).toContain('Status')   // field name raw
+    // option values also stay raw
+    const optionTexts = Array.from(root.querySelectorAll('option')).map((o) => o.textContent?.trim())
+    expect(optionTexts).toContain('todo')
+    expect(optionTexts).toContain('done')
+    expect(optionTexts).not.toContain('待办')
+  })
+})

--- a/apps/web/tests/meta-record-labels.spec.ts
+++ b/apps/web/tests/meta-record-labels.spec.ts
@@ -1,0 +1,114 @@
+import { describe, it, expect } from 'vitest'
+import {
+  recordLabel,
+  commentOnField,
+  historyActor,
+  requiredField,
+} from '../src/multitable/utils/meta-record-labels'
+
+describe('meta-record-labels static keys', () => {
+  it('localizes the record drawer header chrome', () => {
+    expect(recordLabel('record.title', true)).toBe('记录详情')
+    expect(recordLabel('record.title', false)).toBe('Record Detail')
+    expect(recordLabel('record.previous', true)).toBe('上一条记录')
+    expect(recordLabel('record.next', true)).toBe('下一条记录')
+    expect(recordLabel('record.close', true)).toBe('关闭记录抽屉')
+    expect(recordLabel('record.tabsAria', true)).toBe('记录抽屉分区')
+    expect(recordLabel('record.delete', true)).toBe('删除')
+  })
+
+  it('distinguishes watch button text from watch/unwatch title (S1/T3A1 pattern)', () => {
+    expect(recordLabel('record.watch', true)).toBe('关注')
+    expect(recordLabel('record.watching', true)).toBe('已关注')
+    expect(recordLabel('record.watchTitle', true)).toBe('关注此记录')
+    expect(recordLabel('record.unwatchTitle', true)).toBe('取消关注此记录')
+    // en parity
+    expect(recordLabel('record.watch', false)).toBe('Watch')
+    expect(recordLabel('record.watching', false)).toBe('Watching')
+    expect(recordLabel('record.watchTitle', false)).toBe('Watch this record')
+    expect(recordLabel('record.unwatchTitle', false)).toBe('Unwatch this record')
+  })
+
+  it('S1: workflow button suffix is separate from the title key', () => {
+    expect(recordLabel('record.workflow', true)).toBe('工作流')
+    expect(recordLabel('record.workflowTitle', true)).toBe('打开工作流设计器')
+    expect(recordLabel('record.workflow', false)).toBe('Workflow')
+    expect(recordLabel('record.workflowTitle', false)).toBe('Open workflow designer')
+  })
+
+  it('S2: permissions button suffix is separate from the title key', () => {
+    expect(recordLabel('record.permissions', true)).toBe('权限')
+    expect(recordLabel('record.permissionsTitle', true)).toBe('记录权限')
+    expect(recordLabel('record.permissions', false)).toBe('Permissions')
+    expect(recordLabel('record.permissionsTitle', false)).toBe('Record Permissions')
+  })
+
+  it('localizes tabs + history state strings', () => {
+    expect(recordLabel('record.details', true)).toBe('详情')
+    expect(recordLabel('record.history', true)).toBe('历史')
+    expect(recordLabel('record.historyLoading', true)).toBe('正在加载历史...')
+    expect(recordLabel('record.historyUnavailable', true)).toBe('此记录的历史不可用。')
+    expect(recordLabel('record.historyEmpty', true)).toBe('暂无历史。')
+    expect(recordLabel('record.noRecord', true)).toBe('未选择记录')
+  })
+
+  it('S5: history action labels cover Created / Deleted / Updated', () => {
+    expect(recordLabel('record.historyActionCreated', true)).toBe('已创建')
+    expect(recordLabel('record.historyActionDeleted', true)).toBe('已删除')
+    expect(recordLabel('record.historyActionUpdated', true)).toBe('已更新')
+    expect(recordLabel('record.historyActionCreated', false)).toBe('Created')
+    expect(recordLabel('record.historyActionDeleted', false)).toBe('Deleted')
+    expect(recordLabel('record.historyActionUpdated', false)).toBe('Updated')
+  })
+
+  it('M1: FE error fallbacks are FE chrome, not backend free-form text', () => {
+    expect(recordLabel('record.errorHistoryLoad', true)).toBe('加载历史失败')
+    expect(recordLabel('record.errorWatchLoad', true)).toBe('加载关注状态失败')
+    expect(recordLabel('record.errorWatchUpdate', true)).toBe('更新关注状态失败')
+    // en preserved exactly so `error?.message ?? recordLabel(...)` keeps T3A2-style behavior
+    expect(recordLabel('record.errorHistoryLoad', false)).toBe('Failed to load history')
+    expect(recordLabel('record.errorWatchLoad', false)).toBe('Failed to load watch status')
+    expect(recordLabel('record.errorWatchUpdate', false)).toBe('Failed to update watch status')
+  })
+
+  it('M1: form submit/reset chain is fully covered (Saving/Save/Create/Reset)', () => {
+    expect(recordLabel('form.loading', true)).toBe('正在加载...')
+    expect(recordLabel('form.readOnly', true)).toBe('此表单为只读')
+    expect(recordLabel('form.discardConfirm', true)).toBe('放弃未保存的更改吗？')
+    expect(recordLabel('form.save', true)).toBe('保存')
+    expect(recordLabel('form.saving', true)).toBe('正在保存...')
+    expect(recordLabel('form.create', true)).toBe('创建')
+    expect(recordLabel('form.reset', true)).toBe('重置')
+    // en parity for the submit ternary
+    expect(recordLabel('form.save', false)).toBe('Save')
+    expect(recordLabel('form.saving', false)).toBe('Saving...')
+    expect(recordLabel('form.create', false)).toBe('Create')
+    expect(recordLabel('form.reset', false)).toBe('Reset')
+  })
+})
+
+describe('meta-record-labels helpers', () => {
+  it('commentOnField interpolates the field name raw (singular EN form)', () => {
+    expect(commentOnField('Status', false)).toBe('Comment on Status')
+    expect(commentOnField('Status', true)).toBe('评论 Status')
+    // distinct from T3A1 commentForField (plural EN form) — different surfaces
+    expect(commentOnField('Status', true)).not.toBe('Status 的评论')
+  })
+
+  it('commentOnField preserves a chinese-authored field name unchanged', () => {
+    expect(commentOnField('负责人', true)).toBe('评论 负责人')
+    expect(commentOnField('负责人', false)).toBe('Comment on 负责人')
+  })
+
+  it('historyActor interpolates the actor id raw (user data)', () => {
+    expect(historyActor('user_42', false)).toBe('by user_42')
+    expect(historyActor('user_42', true)).toBe('由 user_42')
+    expect(historyActor('张三', true)).toBe('由 张三')
+  })
+
+  it('requiredField interpolates the field name raw (validation chrome)', () => {
+    expect(requiredField('Email', false)).toBe('Email is required')
+    expect(requiredField('Email', true)).toBe('Email 为必填项')
+    expect(requiredField('邮箱', true)).toBe('邮箱 为必填项')
+  })
+})

--- a/apps/web/tests/multitable-core-i18n.spec.ts
+++ b/apps/web/tests/multitable-core-i18n.spec.ts
@@ -162,3 +162,42 @@ describe('meta-core-labels MetaCellEditor helpers (T3A2)', () => {
     expect(attachmentActivityLabel('clearing', true)).toBe('正在清空...')
   })
 })
+
+describe('meta-core-labels attachmentActionHint mode extension (T3B1)', () => {
+  it('default mode (no 4th arg) keeps T3A2 behavior exactly — backwards compatible', () => {
+    // multi-file
+    expect(attachmentActionHint(true, false, false)).toBe('Drop files or click to browse')
+    expect(attachmentActionHint(true, false, true)).toBe('拖拽文件或点击选择')
+    // single + existing
+    expect(attachmentActionHint(false, true, false)).toBe('Upload a new file to replace the current one')
+    expect(attachmentActionHint(false, true, true)).toBe('上传新文件以替换当前文件')
+    // single + empty
+    expect(attachmentActionHint(false, false, false)).toBe('Upload a file')
+    expect(attachmentActionHint(false, false, true)).toBe('上传文件')
+  })
+
+  it("explicit mode='drop' equals the legacy default (regression guard)", () => {
+    expect(attachmentActionHint(true, false, false, 'drop')).toBe('Drop files or click to browse')
+    expect(attachmentActionHint(true, false, true, 'drop')).toBe('拖拽文件或点击选择')
+    expect(attachmentActionHint(false, true, false, 'drop')).toBe('Upload a new file to replace the current one')
+    expect(attachmentActionHint(false, false, true, 'drop')).toBe('上传文件')
+  })
+
+  it("mode='add' changes only the multi-file copy to Add files / 添加文件", () => {
+    // multi-file → distinct add copy
+    expect(attachmentActionHint(true, false, false, 'add')).toBe('Add files')
+    expect(attachmentActionHint(true, false, true, 'add')).toBe('添加文件')
+    // multi-file + has existing still picks the multi-file branch (allowsMultiple guards)
+    expect(attachmentActionHint(true, true, false, 'add')).toBe('Add files')
+    expect(attachmentActionHint(true, true, true, 'add')).toBe('添加文件')
+  })
+
+  it("mode='add' does NOT affect single-file branches (mode only matters when allowsMultiple)", () => {
+    // single + existing
+    expect(attachmentActionHint(false, true, false, 'add')).toBe('Upload a new file to replace the current one')
+    expect(attachmentActionHint(false, true, true, 'add')).toBe('上传新文件以替换当前文件')
+    // single + empty
+    expect(attachmentActionHint(false, false, false, 'add')).toBe('Upload a file')
+    expect(attachmentActionHint(false, false, true, 'add')).toBe('上传文件')
+  })
+})

--- a/docs/development/multitable-t3b1-record-form-i18n-design-20260520.md
+++ b/docs/development/multitable-t3b1-record-form-i18n-design-20260520.md
@@ -1,0 +1,424 @@
+# T3B1 — Record Drawer + Form View i18n Design
+
+- **Date**: 2026-05-20
+- **Type**: implementation-ready design packet
+- **Status**: design only; no code is authorized by this document alone
+- **Preceded by**:
+  - `docs/development/multitable-t3a-core-table-i18n-development-20260519.md`
+  - `docs/development/multitable-t3a2-cell-editor-i18n-verification-20260519.md`
+- **Goal**: localize the record-detail and form-edit chrome that users hit after T3A1/T3A2, without changing APIs, storage, K3 paths, backend behavior, or user-authored data.
+
+---
+
+## 1. Decision Summary
+
+| Scout Finding | Decision |
+|---|---|
+| F-T3B-A module organization | Use per-surface modules. T3B1 creates `meta-record-labels.ts` for Record Drawer + Form View. T3B2 creates comment labels. T3B3 creates link-picker labels. Do not keep growing `meta-core-labels.ts` for record/comment/link chrome. |
+| F-T3B-B attachment code duplication | Refactor Record Drawer + Form View to reuse the T3A2 attachment label helpers, with one small optional `Add files` variant. Do not duplicate the ternary chains again. |
+| F-T3B-C `utils/link-fields.ts` English helpers | T3B1 changes only `linkActionLabel(field, count, isZh = false)`. `linkPickerTitle` and `linkPickerSearchPlaceholder` stay for T3B3. Existing callers keep English by default unless they pass `isZh`. |
+| F-T3B-D native `confirm()` | Use `confirm(recordLabel('form.discardConfirm', isZh.value))`. Do not build a custom modal in T3B1. |
+| F-T3B-E slice size | Split T3B into three PRs: T3B1 record/form, T3B2 comments, T3B3 link picker. T3B1 is first. |
+
+This keeps T3B1 reviewable while still removing the real code smell discovered in the scout: Record Drawer and Form View currently duplicate attachment hint/activity/fallback logic that T3A2 already made testable.
+
+Scout result: the T3B1 scope has no known unreachable/dead keys after excluding T3B2 comments and T3B3 link picker. This is intentionally stricter than T3A2, where the unreachable `Choose linked records...` fallback was documented and skipped.
+
+---
+
+## 2. Files In Scope
+
+| File | Role |
+|---|---|
+| `apps/web/src/multitable/components/MetaRecordDrawer.vue` | Record detail drawer, tabs, watch/comment/action buttons, field editors, attachment controls, history states. |
+| `apps/web/src/multitable/components/MetaFormView.vue` | Form edit surface, field editors, attachment controls, reset/discard confirm. |
+| `apps/web/src/multitable/utils/meta-record-labels.ts` | New T3B1 label module for record/form chrome. |
+| `apps/web/src/multitable/utils/meta-core-labels.ts` | Extend T3A2 attachment helper with optional `addFiles` multi-file variant; keep existing default behavior for MetaCellEditor. |
+| `apps/web/src/multitable/utils/link-fields.ts` | Add optional `isZh = false` to `linkActionLabel` only. |
+| `apps/web/tests/meta-record-drawer-i18n.spec.ts` | New focused render tests for Record Drawer. |
+| `apps/web/tests/meta-form-view-i18n.spec.ts` | New focused render tests for Form View. |
+| `apps/web/tests/multitable-core-i18n.spec.ts` and `apps/web/tests/link-fields-i18n.spec.ts` | Helper coverage for `Add files` variant and `linkActionLabel(..., isZh)`. |
+| `docs/development/multitable-t3b1-record-form-i18n-verification-20260520.md` | Verification packet after implementation. |
+
+Out of scope for T3B1:
+
+- `MetaCommentsDrawer.vue`, `MetaCommentComposer.vue`, `MetaCommentAffordance.vue`, `MetaCommentActionChip.vue` -> T3B2.
+- `MetaLinkPicker.vue`, `linkPickerTitle`, `linkPickerSearchPlaceholder` -> T3B3.
+- `MetaImportModal.vue` -> later import-modal slice. It calls `linkActionLabel`, but default `isZh = false` keeps current English behavior.
+- `MetaCellEditor.vue` link fallback -> remains as T3A2 recorded unless T3B3 intentionally changes link-picker/link-label behavior.
+- Backend free-form errors, validation messages, field names, option values, record values, user names, attachment filenames, IDs.
+
+---
+
+## 3. Label Module Plan
+
+Create:
+
+```text
+apps/web/src/multitable/utils/meta-record-labels.ts
+```
+
+Pattern follows `workbench-labels.ts` and `meta-core-labels.ts`:
+
+```ts
+export type MetaRecordLabelKey =
+  | 'record.title'
+  | 'record.previous'
+  | 'record.next'
+  | 'record.watch'
+  | 'record.watching'
+  | 'record.watchTitle'
+  | 'record.unwatchTitle'
+  | 'record.comments'
+  | 'record.workflow'
+  | 'record.workflowTitle'
+  | 'record.permissions'
+  | 'record.permissionsTitle'
+  | 'record.delete'
+  | 'record.close'
+  | 'record.tabsAria'
+  | 'record.details'
+  | 'record.history'
+  | 'record.historyLoading'
+  | 'record.historyUnavailable'
+  | 'record.historyEmpty'
+  | 'record.historyActionCreated'
+  | 'record.historyActionDeleted'
+  | 'record.historyActionUpdated'
+  | 'record.errorHistoryLoad'
+  | 'record.errorWatchLoad'
+  | 'record.errorWatchUpdate'
+  | 'record.noRecord'
+  | 'form.loading'
+  | 'form.readOnly'
+  | 'form.discardConfirm'
+  | 'form.save'
+  | 'form.saving'
+  | 'form.create'
+  | 'form.reset'
+```
+
+Use helpers for dynamic strings:
+
+| Helper | EN | ZH | Data Handling |
+|---|---|---|---|
+| `commentOnField(fieldName, isZh)` | `Comment on Status` | `评论 Status` | `fieldName` remains raw. |
+| `historyActor(actorId, isZh)` | `by user_1` | `由 user_1` | `actorId` remains raw. |
+| `requiredField(fieldName, isZh)` | `${fieldName} is required` | `${fieldName} 为必填项` | `fieldName` remains raw. |
+
+Record/form share one module because they are both record-detail/form-edit surfaces and share many field-editor strings. Comments and link picker get separate modules in later slices.
+
+`Comments for {field}` already exists as `commentForField(fieldName, isZh)` in `meta-core-labels.ts` for `MetaGridTable`. T3B1 must reuse that helper in `MetaFormView` instead of introducing a second field-comment helper.
+
+---
+
+## 4. Exact T3B1 Chrome Targets
+
+### 4.1 `MetaRecordDrawer.vue`
+
+| Current EN | Proposed ZH | Notes |
+|---|---|---|
+| Record Detail | 记录详情 | Static title. |
+| Previous record | 上一条记录 | aria-label only. |
+| Next record | 下一条记录 | aria-label only. |
+| Watch this record | 关注此记录 | title. |
+| Unwatch this record | 取消关注此记录 | title. |
+| Watch | 关注 | button text. |
+| Watching | 已关注 | button text. |
+| Comments | 评论 | title and chip label pass-through. |
+| Open workflow designer | 打开工作流设计器 | title. |
+| Workflow | 工作流 | visible button suffix. |
+| Record Permissions | 记录权限 | title. |
+| Permissions | 权限 | visible button suffix. |
+| Delete | 删除 | button. |
+| Close record drawer | 关闭记录抽屉 | aria-label. |
+| Record drawer sections | 记录抽屉分区 | tablist aria-label. |
+| Details | 详情 | tab. |
+| History | 历史 | tab. |
+| Comment on {field} | 评论 {field} | `field` raw. |
+| Scan or enter barcode | 扫描或输入条码 | Reuse T3A2 key. |
+| Enter address | 输入地址 | Reuse T3A2 key. |
+| Add files | 添加文件 | New attachment variant. |
+| Clear all | 全部清除 | Reuse T3A2 `cell.clearAll`. |
+| Removing... / Clearing... / Uploading... | 正在移除... / 正在清空... / 正在上传... | Reuse T3A2 helper. |
+| Failed to upload/remove/clear attachment(s) | 附件上传/移除/清空失败 | Reuse T3A2 fallback keys. Backend `error.message` remains raw. |
+| Loading history... | 正在加载历史... | Static. |
+| History unavailable for this record. | 此记录的历史不可用。 | Static. |
+| No history yet. | 暂无历史。 | Static. |
+| Created | 已创建 | `record.historyActionCreated`; `historyActionLabel()` is frontend-owned stable chrome. |
+| Deleted | 已删除 | `record.historyActionDeleted`; `historyActionLabel()` is frontend-owned stable chrome. |
+| Updated | 已更新 | `record.historyActionUpdated`; `historyActionLabel()` is frontend-owned stable chrome. |
+| by {actorId} | 由 {actorId} | `actorId` raw. |
+| Failed to load history | 加载历史失败 | Frontend fallback in `error?.message ?? ...`. |
+| Failed to load watch status | 加载关注状态失败 | Frontend fallback in `error?.message ?? ...`. |
+| Failed to update watch status | 更新关注状态失败 | Frontend fallback in `error?.message ?? ...`. |
+| No record selected | 未选择记录 | Static empty state. |
+
+Do not translate:
+
+- Field names and option values.
+- Backend `error.message` values remain raw when present. Static frontend fallback strings are localized using the same pattern as T3A2 (`error?.message ?? l('cell.uploadFailed')`): the state variables `historyError` and `subscriptionError` need no special handling beyond changing their catch-block fallback expression to `?? recordLabel(...)`.
+
+### 4.2 `MetaFormView.vue`
+
+| Current EN | Proposed ZH | Notes |
+|---|---|---|
+| Loading... | 正在加载... | Static loading state. |
+| This form is read-only | 此表单为只读 | Static banner. |
+| Comments for {field} | {field} 的评论 | `field` raw. |
+| Scan or enter barcode | 扫描或输入条码 | Reuse T3A2 key. |
+| Enter address | 输入地址 | Reuse T3A2 key. |
+| Yes / No | 是 / 否 | Reuse T3A2 keys. |
+| Add files | 添加文件 | New attachment variant. |
+| Upload a new file to replace the current one | 上传新文件以替换当前文件 | Reuse T3A2 helper. |
+| Upload a file | 上传文件 | Reuse T3A2 helper. |
+| Clear all | 全部清除 | Reuse T3A2 key. |
+| Removing... / Clearing... / Uploading... | 正在移除... / 正在清空... / 正在上传... | Reuse T3A2 helper. |
+| Failed to upload/remove/clear attachment(s) | 附件上传/移除/清空失败 | Reuse T3A2 fallback keys. |
+| Saving... | 正在保存... | Submit button while `submitting`. |
+| Save | 保存 | Submit button when editing an existing record. |
+| Create | 创建 | Submit button when creating a record. |
+| Reset | 重置 | Existing-record reset button. |
+| Discard unsaved changes? | 放弃未保存的更改吗？ | Native `confirm()` text only. |
+| `{field.name} is required` | `{field.name} 为必填项` | `field.name` raw. |
+
+Do not translate:
+
+- `successMessage`, `errorMessage`, `fieldErrors`, backend validation messages.
+- URL/email/phone examples.
+- Field names, option values, record values, attachment filenames.
+
+---
+
+## 5. Attachment Helper Refactor
+
+Current T3A2 helper:
+
+```ts
+attachmentActionHint(allowsMultiple, hasExisting, isZh)
+```
+
+T3B1 should extend it with a backwards-compatible optional fourth argument:
+
+```ts
+type AttachmentActionMode = 'drop' | 'add'
+
+attachmentActionHint(
+  allowsMultiple: boolean,
+  hasExisting: boolean,
+  isZh: boolean,
+  mode: AttachmentActionMode = 'drop',
+)
+```
+
+Expected behavior:
+
+| Case | `mode='drop'` | `mode='add'` |
+|---|---|---|
+| multiple allowed | Drop files or click to browse / 拖拽文件或点击选择 | Add files / 添加文件 |
+| single + existing | Upload a new file to replace the current one / 上传新文件以替换当前文件 | same |
+| single + empty | Upload a file / 上传文件 | same |
+
+Why optional mode instead of a new helper:
+
+- Keeps T3A2 `MetaCellEditor` behavior unchanged by default.
+- Lets Record Drawer and Form View remove duplicate ternaries.
+- Unit tests can prove both modes.
+
+Keep fallback error keys in `meta-core-labels.ts` for now:
+
+- `cell.uploadFailed`
+- `cell.removeFailed`
+- `cell.clearFailed`
+- `cell.clearAll`
+
+This is the one intentional cross-surface reuse. A future cleanup can move shared attachment labels into `meta-attachment-labels.ts`, but T3B1 should not spend review budget on a module move.
+
+---
+
+## 6. Link Helper Scope
+
+Change only:
+
+```ts
+linkActionLabel(field, count, isZh = false)
+```
+
+T3B1 call sites:
+
+- `MetaRecordDrawer.vue` passes `isZh.value`.
+- `MetaFormView.vue` passes `isZh.value`.
+
+Call sites intentionally unchanged:
+
+- `MetaCellEditor.vue` continues default English until link-picker/link-label work is revisited.
+- `MetaImportModal.vue` continues default English; import modal is not a T3B1 target.
+
+Current call-site audit:
+
+```text
+apps/web/src/multitable/components/MetaFormView.vue: linkActionLabel(field, count)
+apps/web/src/multitable/components/MetaRecordDrawer.vue: linkActionLabel(field, count)
+apps/web/src/multitable/components/MetaImportModal.vue: linkActionLabel(field, selectedSummaries.length)
+apps/web/src/multitable/components/cells/MetaCellEditor.vue: linkActionLabel as formatLinkActionLabel
+```
+
+Only the first two pass `isZh.value` in T3B1. The other two rely on `isZh = false`.
+
+T3B1 zh decisions:
+
+| Case | EN | ZH |
+|---|---|---|
+| person count 0 | Choose people... | 选择人员... |
+| person count 1 | Edit person (1) | 编辑人员 (1) |
+| person count N | Edit people (N) | 编辑人员 (N) |
+| record count 0 | Choose linked records... | 选择关联记录... |
+| record count 1 | Edit linked record (1) | 编辑关联记录 (1) |
+| record count N | Edit linked records (N) | 编辑关联记录 (N) |
+
+Do not change in T3B1:
+
+- `linkPickerTitle`
+- `linkPickerSearchPlaceholder`
+- `MetaLinkPicker.vue`
+
+Those belong to T3B3 because the picker has its own selected/clear/loading/empty/count/footer strings and should be reviewed as one surface.
+
+---
+
+## 7. Test Plan
+
+### 7.1 Helper Tests
+
+Add/extend:
+
+```text
+apps/web/tests/multitable-core-i18n.spec.ts
+apps/web/tests/link-fields-i18n.spec.ts
+```
+
+Assertions:
+
+- Existing T3A1/T3A2 helper tests remain green.
+- `attachmentActionHint(..., mode='drop')` remains exactly T3A2 behavior.
+- `attachmentActionHint(..., mode='add')` returns `Add files` / `添加文件` for multi-file.
+- `linkActionLabel(field, count)` without `isZh` is identical to current English.
+- `linkActionLabel(field, count, true)` returns all six zh cases above.
+- `commentForField(fieldName, isZh)` is reused from `meta-core-labels.ts` for `MetaFormView` aria text.
+- Record history action labels cover `Created` / `Deleted` / `Updated`.
+
+### 7.2 Record Drawer Render Tests
+
+Create:
+
+```text
+apps/web/tests/meta-record-drawer-i18n.spec.ts
+```
+
+Mount strategy:
+
+- Focused component mount using Vue `createApp`, matching T3A2 style.
+- Mount/teardown pattern: use `apps/web/tests/meta-cell-editor-i18n.spec.ts` as the canonical `createApp` + `container` + `app?.unmount()` + `container?.remove()` + locale-reset shape.
+- Set `useLocale().setLocale('zh-CN')` and `en`.
+- Provide minimum record, fields, permissions/capabilities needed to show:
+  - header title/actions
+  - details/history tabs
+  - barcode/location placeholders
+  - attachment controls
+  - link button label
+  - comment aria label
+
+Required assertions:
+
+- zh contains `记录详情`, `关注`, `详情`, `历史`, `扫描或输入条码`, `输入地址`, `添加文件`, `全部清除`.
+- zh contains history action labels `已创建`, `已删除`, `已更新` when corresponding revision actions are rendered.
+- zh does not contain the replaced English strings in the same mounted path.
+- en still contains current English defaults.
+- Field names and option values stay raw.
+- Backend/free-form error prop text stays raw when injected.
+
+### 7.3 Form View Render Tests
+
+Create:
+
+```text
+apps/web/tests/meta-form-view-i18n.spec.ts
+```
+
+Mount strategy:
+
+- Focused component mount using Vue `createApp`, matching T3A2 style.
+- Mount/teardown pattern: use `apps/web/tests/meta-cell-editor-i18n.spec.ts` as the canonical `createApp` + `container` + `app?.unmount()` + `container?.remove()` + locale-reset shape.
+- Set `useLocale().setLocale('zh-CN')` and `en`.
+
+Required assertions:
+
+- zh contains `此表单为只读`, `是`, `否`, `扫描或输入条码`, `输入地址`, `添加文件`.
+- zh contains submit/reset labels `正在保存...`, `保存`, `创建`, `重置` in the appropriate render states.
+- `confirm()` uses zh text when `setLocale('zh-CN')`.
+- required-field validation uses `{field.name} 为必填项`, preserving raw field name.
+- URL/email/phone placeholders remain raw examples.
+- en still contains current English defaults.
+
+### 7.4 Verification Commands
+
+Run after implementation:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-core-i18n.spec.ts \
+  tests/link-fields-i18n.spec.ts \
+  tests/meta-record-drawer-i18n.spec.ts \
+  tests/meta-form-view-i18n.spec.ts \
+  tests/meta-cell-editor-i18n.spec.ts \
+  tests/meta-toolbar-filter-builder.spec.ts \
+  tests/meta-grid-table-i18n.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+git diff --check origin/main..HEAD
+```
+
+Path note: commands run through `--filter @metasheet/web exec`, so test paths are package-relative (`tests/...`), not repo-relative (`apps/web/tests/...`).
+
+---
+
+## 8. Implementation Order
+
+1. Preflight grep: for each planned key in §3, verify a real call-site exists in `MetaRecordDrawer.vue` / `MetaFormView.vue` (no dead keys). Resolve any miss before writing the module.
+2. Add `meta-record-labels.ts` with typed static labels and helpers.
+3. Extend `attachmentActionHint` with optional `mode='drop' | 'add'`; add helper tests first.
+4. Add optional `isZh = false` to `linkActionLabel`; add helper tests first.
+5. Wire `MetaRecordDrawer.vue`.
+6. Wire `MetaFormView.vue`.
+7. Add focused render tests.
+8. Write verification MD.
+9. Rebase to latest `origin/main`, rerun focused tests + `vue-tsc` + diff-check.
+10. Push/PR only after explicit operator go, consistent with T3A1/T3A2 discipline.
+
+---
+
+## 9. Risk Register
+
+| Risk | Mitigation |
+|---|---|
+| Accidentally translating user data | Tests must assert field names, option values, record values, filenames, URL/email/phone examples remain raw. |
+| `linkActionLabel` changes `MetaImportModal` behavior | Keep `isZh = false` default and only pass `true` from T3B1 components. |
+| Attachment helper change breaks MetaCellEditor | Default `mode='drop'` preserves T3A2 behavior; T3A2 tests included in T3B1 focused run. |
+| Record/Form mount tests become too heavy | Keep focused render tests with minimal props. Do not use full Workbench mount for T3B1. |
+| Native confirm is not style-localized | Accepted by decision F-T3B-D; only the text is localized in T3B1. |
+| T3B1 creeps into comments/link picker | Hard out-of-scope. Comments = T3B2. Link picker title/search/selected/footer = T3B3. |
+
+---
+
+## 10. Approval Gate
+
+T3B1 implementation can start when the operator accepts:
+
+- New `meta-record-labels.ts` module.
+- Optional-mode extension of T3A2 `attachmentActionHint`.
+- Optional `isZh = false` extension of `linkActionLabel`.
+- Native `confirm(recordLabel('form.discardConfirm', isZh.value))`.
+- T3B split: T3B1 first, T3B2 comments second, T3B3 link picker third.
+
+Until then this MD is read-only planning and must not be treated as implementation authorization.

--- a/docs/development/multitable-t3b1-record-form-i18n-verification-20260520.md
+++ b/docs/development/multitable-t3b1-record-form-i18n-verification-20260520.md
@@ -1,0 +1,162 @@
+# T3B1 — Record Drawer + Form View zh-CN i18n — Verification
+
+- **Date**: 2026-05-20
+- **Branch**: `frontend/multitable-t3b1-record-form-i18n-20260520` (rebased onto latest `origin/main`; no upstream drift at verification time)
+- **Dev plan**: `docs/development/multitable-t3b1-record-form-i18n-design-20260520.md` (sha256 `a859c29905c810db3e8c04718aa12daf3102e8def9e8cb9f6a1613344aecdf9b`, two operator-revision rounds folded before implementation start).
+- **Type**: implementation + verification.
+- **K3 PoC stage-1 lock**: complies — no `/api/*` contract, no migration, no integration-core, no plugin-integration; touches frontend label modules + 2 components + tests + dev/verification MDs only.
+
+---
+
+## 1. Files Changed (committed PR diff)
+
+```
+A  apps/web/src/multitable/utils/meta-record-labels.ts             (NEW, ~110 lines)
+M  apps/web/src/multitable/utils/meta-core-labels.ts               (attachmentActionHint + AttachmentActionMode export)
+M  apps/web/src/multitable/utils/link-fields.ts                    (linkActionLabel + opt-in isZh=false)
+M  apps/web/src/multitable/components/MetaRecordDrawer.vue         (22 l('record.) + 6 lc('cell.) wirings)
+M  apps/web/src/multitable/components/MetaFormView.vue             ( 5 l('form.)   + 7 lc('cell.) wirings)
+M  apps/web/tests/multitable-core-i18n.spec.ts                     (+4 mode-extension cases)
+A  apps/web/tests/meta-record-labels.spec.ts                       (NEW, 12 cases)
+A  apps/web/tests/link-fields-i18n.spec.ts                         (NEW, 7 cases)
+A  apps/web/tests/meta-record-drawer-i18n.spec.ts                  (NEW, 10 cases)
+A  apps/web/tests/meta-form-view-i18n.spec.ts                      (NEW, 12 cases)
+A  docs/development/multitable-t3b1-record-form-i18n-design-20260520.md
+A  docs/development/multitable-t3b1-record-form-i18n-verification-20260520.md (this packet)
+```
+
+The authoritative PR shape is the committed diff against `origin/main`; this packet intentionally avoids pinning an exact file or commit count because docs-only verification corrections can be appended before PR open, and the PR will be squash-merged.
+
+Pure T3B1: no attendance / MultitableWorkbench / MultitableHomeView / backend / contract / `.mjs` leakage. Verified via `git diff --name-status origin/main..HEAD`.
+
+## 2. Test Results (focused, post-rebase)
+
+```
+$ pnpm --filter @metasheet/web exec vue-tsc --noEmit
+exit=0 (0 lines)
+
+$ pnpm --filter @metasheet/web exec vitest run \
+    tests/meta-form-view-i18n.spec.ts \
+    tests/meta-record-drawer-i18n.spec.ts \
+    tests/meta-record-labels.spec.ts \
+    tests/multitable-core-i18n.spec.ts \
+    tests/link-fields-i18n.spec.ts \
+    tests/meta-cell-editor-i18n.spec.ts \
+    tests/meta-toolbar-filter-builder.spec.ts \
+    tests/meta-grid-table-i18n.spec.ts \
+    --watch=false
+
+✓ tests/link-fields-i18n.spec.ts          ( 7 tests)   ← T3B1 helper
+✓ tests/multitable-core-i18n.spec.ts      (23 tests)   ← T3A1+T3A2+T3B1 helper
+✓ tests/meta-record-labels.spec.ts        (12 tests)   ← T3B1 label module
+✓ tests/meta-form-view-i18n.spec.ts       (12 tests)   ← T3B1 render
+✓ tests/meta-cell-editor-i18n.spec.ts     (11 tests)   ← T3A2 regression
+✓ tests/meta-toolbar-filter-builder.spec.ts ( 8 tests) ← T3A1 regression
+✓ tests/meta-record-drawer-i18n.spec.ts   (10 tests)   ← T3B1 render
+✓ tests/meta-grid-table-i18n.spec.ts      ( 6 tests)   ← T3A1 regression
+
+Test Files  8 passed (8)
+     Tests  89 passed (89)
+```
+
+```
+$ git diff --check origin/main..HEAD
+(clean)
+```
+
+T3A1 and T3A2 specs (`meta-toolbar-filter-builder`, `meta-grid-table-i18n`, `meta-cell-editor-i18n`, the 19 pre-existing T3A1+T3A2 cases in `multitable-core-i18n.spec.ts`) all pass unchanged — confirming the helper extensions (`attachmentActionHint` mode default + `linkActionLabel` isZh default) are truly backwards-compatible.
+
+## 3. Findings Resolutions (across both design-review rounds + preflight grep)
+
+### Round-1 findings (the M1 / S1-S5 / N1+N2 in the first review)
+
+| Finding | Resolution |
+|---|---|
+| **M1** MetaFormView submit chain missing (Saving/Save/Create/Reset) | All four keys added to `meta-record-labels` `form.*` union; submit ternary + reset button localized; render spec asserts all four states in zh+en. |
+| **S1** `record.workflowTitle` separate from `record.workflow` | Both keys present; §4.1 row distinction kept; render spec asserts the title is the long form. |
+| **S2** `record.permissionsTitle` separate from `record.permissions` | Same pattern as S1. |
+| **S3** `commentsForField` would duplicate T3A1 `commentForField` | Decision: reuse T3A1 helper from `meta-core-labels` in `MetaFormView`; do NOT introduce a duplicate. Implementation imports `commentForField` from `meta-core-labels`. `commentOnField` (T3B1) is distinct (singular EN form, RecordDrawer only). |
+| **S4** `form.requiredSuffix` static key was dead | Removed; `requiredField(fieldName, isZh)` helper does full interpolation. |
+| **S5** `historyActionLabel()` Created/Deleted/Updated ambiguity | 3 keys added (`record.historyActionCreated/Deleted/Updated`); function body rewired; render spec covers via the localized label module unit, not via mount (mount path requires apiClient stubbing — out of scope for focused render coverage). |
+| **N1** "no dead keys" note | Added to dev MD §1; cross-references the T3A2 `Choose linked records...` precedent. |
+| **N2** linkActionLabel call-site audit | Dev MD §6 lists all 4 call sites (RecordDrawer / FormView / MetaImportModal / MetaCellEditor); only the first 2 pass `isZh.value` in T3B1. |
+
+### Round-2 findings (M1' + S2'-S4' + N1')
+
+| Finding | Resolution |
+|---|---|
+| **M1'** 3 RecordDrawer FE error fallbacks missing + §4.1 L152 semantics wrong | Added `record.errorHistoryLoad` / `record.errorWatchLoad` / `record.errorWatchUpdate` keys; all 3 catch blocks rewritten to `error?.message ?? l('record.error*')`; backend `error.message` raw when present (T3A2 `cell.uploadFailed` pattern). |
+| **S2'** §7.2/§7.3 missing canonical mount/teardown pointer | Both render specs explicitly model their `afterEach` on `meta-cell-editor-i18n.spec.ts` (createApp + container + app?.unmount() + container?.remove() + locale reset); comment in spec source references the canonical file. |
+| **S3'** §4.1 row→key counting ambiguity for historyAction | Dev MD now lists `Created` / `Deleted` / `Updated` as 3 separate rows with explicit key references. |
+| **S4'** §8 needed a preflight-grep step | Dev MD §8 step 1 = preflight grep. Verified at implementation time: every planned key has a real call-site (no dead keys), including the new M1' error-fallback keys. |
+| **N1'** §2 helper-spec placement was "either/or" | Tightened to "and" — both `multitable-core-i18n.spec.ts` and `link-fields-i18n.spec.ts` are extended, plus the new `meta-record-labels.spec.ts`. |
+
+### F-T3B-A through F-T3B-E (operator decisions before design)
+
+| Decision | Implementation |
+|---|---|
+| **F-T3B-A** per-surface modules | New `meta-record-labels.ts`; T3A1/T3A2 surface keys remain in `meta-core-labels`; T3B2 + T3B3 will add their own modules. |
+| **F-T3B-B** attachment helper refactor (with `mode='add'` extension) | `attachmentActionHint(..., mode?: 'drop'\|'add')` with default `'drop'` preserving T3A2 MetaCellEditor behavior; both RecordDrawer + FormView local helpers refactored to call this with `mode='add'`. No T3A2 regression (11/11 cell-editor cases still green). |
+| **F-T3B-C** `linkActionLabel` opt-in zh | `linkActionLabel(field, count, isZh = false)`; only RecordDrawer + FormView pass `isZh.value`. `linkPickerTitle` + `linkPickerSearchPlaceholder` untouched (T3B3 scope). |
+| **F-T3B-D** native confirm | `confirm(l('form.discardConfirm'))` — text-only zh localization, no custom modal. Render spec verifies via `vi.spyOn(window, 'confirm')`. |
+| **F-T3B-E** 3-PR split | T3B1 = this PR; T3B2 (comments) + T3B3 (link picker) queued. |
+
+## 4. Out-of-Scope (intentionally deferred)
+
+| Item | Slice | Reason |
+|---|---|---|
+| `MetaCommentsDrawer.vue`, `MetaCommentComposer.vue`, `MetaCommentAffordance.vue`, `MetaCommentActionChip.vue` | T3B2 | Per F-T3B-E split. T3B1 only touches `MetaCommentActionChip` indirectly via the `:label` prop pass-through from MetaRecordDrawer. |
+| `MetaLinkPicker.vue`, `linkPickerTitle`, `linkPickerSearchPlaceholder` | T3B3 | Per F-T3B-E split + F-T3B-C scope decision. |
+| `MetaFormShareManager.vue` | T3C / share-permission slice | Permission/share/API manager panels per merged T3A dev MD §3.2. |
+| `MetaImportModal.vue` linkActionLabel | later import-modal slice | `linkActionLabel` default `isZh=false` keeps current EN; modal not touched. |
+| `MetaCellEditor.vue` link fallback (`'Choose linked records...'`) | T3B3 (with link picker) | T3A2 deferral preserved — still unreachable in current render flow; inline comment at L410 still applies. |
+| Native `confirm()` styling | n/a (intentional) | Operator decision F-T3B-D: text-only. |
+
+## 5. Acceptance Criteria
+
+| # | Criterion | Status |
+|---|---|---|
+| 1 | zh-CN renders localized record/form chrome for in-scope strings | ✓ (10 RecordDrawer + 12 FormView render-spec cases) |
+| 2 | en preserves existing English labels | ✓ (en cases in both render specs + jsdom default locale) |
+| 3 | No translation of user data (field names, option values, URLs, emails, phone examples, backend free-form errors, attachment filenames, actorId) | ✓ (explicit spec assertions on field name preservation, option values raw, URL/email/phone format examples raw) |
+| 4 | Record/Form behavior unchanged (no emit/event/state changes) | ✓ (existing emit/prop interfaces untouched; backwards-compatible helper defaults) |
+| 5 | No API contract / backend route / migration / K3 / plugin-integration / OpenAPI change | ✓ (committed diff confined to `apps/web/src/multitable/{utils,components}/` + `apps/web/tests/` + `docs/development/`) |
+| 6 | New helpers (recordLabel + commentOnField + historyActor + requiredField + attachmentActionHint mode + linkActionLabel isZh) have unit coverage for en+zh + edge cases | ✓ (12 record-labels + 4 mode + 7 linkActionLabel + Unicode field name preservation) |
+| 7 | T3A1+T3A2 backward compat verified | ✓ (all 8 spec files green, 0 regression in pre-existing specs) |
+| 8 | Verification MD records any intentionally deferred strings | ✓ (this §4) |
+
+## 6. Git State (post-rebase)
+
+```
+$ git log --oneline origin/main..HEAD
+90c871913 feat(multitable): localize MetaFormView chrome to zh-CN (T3B1)
+163e098e6 feat(multitable): localize MetaRecordDrawer chrome to zh-CN (T3B1)
+ac7006595 feat(multitable): add record/form i18n label module + extend helpers (T3B1)
+e47d1143c docs(multitable): T3B1 record drawer + form view i18n design
+```
+
+Rebase note: branch was created from `origin/main @ 5606dac04`; during T3B1 implementation `origin/main` advanced by 1 commit (parallel-actor push). Rebased clean (no conflicts — that commit doesn't touch T3B1 files); vue-tsc + 89 focused specs re-verified green on rebased state.
+
+## 7. Worktree-Contention Status
+
+This T3B1 implementation completed without the parallel-actor branch contention that affected T3A1 (≥3 mid-task HEAD switches) and T3A2 (origin/main advanced mid-impl, requiring rebase). The `multitable-i18n` memory rules — durability-first commits after each §9-style sub-step, targeted `git add` only, `git show <commit>:<path>` instead of `cat` when verifying — were applied throughout but did not need to recover from any worktree clobber.
+
+Other parallel-actor uncommitted state (`MultitableWorkbench.vue` / `MultitableHomeView.vue` / `multitable-home-view.spec.ts` / pre-existing `.tmp-*` / `docs/research/dingtalk-*` untracked artifacts) remained unmodified by this slice — confirmed via `git diff --name-status origin/main..HEAD` listing only T3B1 files.
+
+## 8. Regression Comm-Diff (pending)
+
+Per the session pattern from T3A1 / T3A2 (failed-test-set diff, not totals), a full-web-suite `comm -13` / `comm -23` between `origin/main` and `HEAD` failed-test sets would ratify zero regression. Not executed inline here, consistent with T3A2:
+
+**Available evidence**:
+- vue-tsc clean (post-rebase) — typecheck regression caught for free.
+- All 8 T3A1+T3A2+T3B1 focused specs green (89/89), including the T3A2 backward-compat suite. The 4 new `attachmentActionHint(..., 'drop')` regression-guard cases explicitly assert the legacy default behavior is byte-identical.
+- Edits are additive (new keys/helpers) or locale-conditional (en branch returns the original string verbatim, default `isZh=false` for `linkActionLabel`, default `mode='drop'` for `attachmentActionHint`). No existing en-asserting spec should observe a behavioral change.
+- Default jsdom navigator language is `en-US` → `useLocale().isZh.value` starts as `false`; specs that don't call `setLocale('zh-CN')` continue to see English literals identical to the pre-T3B1 versions.
+
+**Recommended next step (operator)**: open PR; CI will run `test (18.x)` / `test (20.x)` on a clean checkout (isolated from any local worktree state) and is the authoritative regression gate, same as T3A1 / T3A2.
+
+## 9. Next Steps
+
+1. **Hold push pending operator go** (consistent with session discipline: each push/PR is a separate explicit opt-in).
+2. On go: `git push -u origin frontend/multitable-t3b1-record-form-i18n-20260520` → open PR → wait for CI (especially `test (18.x)` / `test (20.x)`) green → admin squash merge → `git branch -D` local stale branch.
+3. After merge: **T3B2** (MetaCommentsDrawer + MetaCommentComposer + MetaCommentAffordance + MetaCommentActionChip) becomes the next anchored slice. The label-module pattern would create a new `meta-comment-labels.ts`, mirroring this slice's per-surface discipline.


### PR DESCRIPTION
## Summary

- Add `meta-record-labels.ts` for Record Drawer + Form View chrome.
- Localize `MetaRecordDrawer` and `MetaFormView` to zh-CN while preserving backend errors, field names, option values, record values, filenames, URL/email/phone examples, and import modal behavior.
- Extend existing helpers safely:
  - `attachmentActionHint(..., mode = 'drop')` keeps T3A2 default and adds T3B1 `mode='add'` for `Add files`.
  - `linkActionLabel(field, count, isZh = false)` keeps existing English by default; only RecordDrawer/FormView pass `isZh.value`.
- Add focused helper/render specs plus design and verification MD.

## Scope Guard

No changes to:
- backend routes or API contracts
- migrations / OpenAPI
- K3 / integration-core paths
- attendance / Workbench / HomeView WIP
- comments drawer/composer (T3B2)
- link picker title/search/empty/footer (T3B3)

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/meta-record-labels.spec.ts tests/link-fields-i18n.spec.ts tests/meta-record-drawer-i18n.spec.ts tests/meta-form-view-i18n.spec.ts tests/multitable-core-i18n.spec.ts tests/meta-cell-editor-i18n.spec.ts tests/meta-toolbar-filter-builder.spec.ts tests/meta-grid-table-i18n.spec.ts --watch=false` -> 89/89 pass
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` -> pass
- `git diff --check origin/main..HEAD` -> clean
- `git diff --name-status origin/main..HEAD` -> exactly 12 T3B1 files

## Review Notes

- FE fallback strings are localized (`error?.message ?? l(...)`), but backend-provided `error.message` remains raw by design.
- `MetaImportModal` and `MetaCellEditor` still call `linkActionLabel` without `isZh`, so their current English behavior is preserved.
- `commentForField` is reused from `meta-core-labels.ts`; no duplicate `commentsForField` helper was added.
