### PR TITLE
feat(ops): summarize staging migration schema probe results

### DIFF
--- a/docs/development/staging-migration-schema-probe-summary-development-20260520.md
+++ b/docs/development/staging-migration-schema-probe-summary-development-20260520.md
@@ -1,0 +1,92 @@
+# Staging Migration Schema Probe Summary Development
+
+Date: 2026-05-20
+
+## Summary
+
+This slice adds an offline summary step after `schema-probes.sql`. Operators can
+run the SQL against a cloned or backed-up rehearsal database, export the result
+as CSV or TSV, then summarize the output without giving the script database
+credentials.
+
+The new script does not connect to PostgreSQL, run migrations, call Docker, or
+write `kysely_migration`. It only reads text and writes local summary artifacts.
+
+## Files
+
+| File | Change |
+| --- | --- |
+| `scripts/ops/staging-migration-schema-probe-summary.mjs` | New read-only CSV/TSV parser and summary generator. |
+| `scripts/ops/staging-migration-schema-probe-summary.test.mjs` | Unit coverage for CSV, TSV, ambiguity, invalid inputs, and output boundary. |
+| `docs/operations/staging-migration-alignment-runbook.md` | Documents the offline summary command after `schema-probes.sql`. |
+| `docs/development/staging-migration-schema-probe-summary-development-20260520.md` | This development record. |
+| `docs/development/staging-migration-schema-probe-summary-verification-20260520.md` | Verification record for this slice. |
+
+## CLI Contract
+
+```bash
+node scripts/ops/staging-migration-schema-probe-summary.mjs \
+  --input output/staging-migration-alignment-report/<run>/schema-probe-results.csv \
+  --format csv \
+  --out-dir output/staging-migration-alignment-report/<run>
+```
+
+Stdin is also supported:
+
+```bash
+psql "$REHEARSAL_DATABASE_URL" \
+  -X --set ON_ERROR_STOP=1 --csv \
+  -f output/staging-migration-alignment-report/<run>/schema-probes.sql \
+  | node scripts/ops/staging-migration-schema-probe-summary.mjs --format csv
+```
+
+Supported input columns:
+
+- `probe_type`
+- `migration`
+- `target`
+- `exists`
+- `match_count`
+- `matched_schemas`
+
+Supported formats:
+
+- `auto` (default)
+- `csv`
+- `tsv`
+
+Outputs:
+
+- `schema-probe-summary.json`
+- `schema-probe-summary.md`
+
+## Classification
+
+| Status | Rule |
+| --- | --- |
+| `matched` | `exists=true` and `match_count === 1` |
+| `missing` | `exists=false` or `match_count === 0` |
+| `ambiguous` | `match_count > 1` or multiple `matched_schemas` |
+
+The report decision is:
+
+| Decision | Meaning |
+| --- | --- |
+| `schema_probe_targets_present` | Every emitted probe target matched exactly once. Still not a replay safety proof. |
+| `manual_review_required` | At least one target is missing or ambiguous. Review before any alignment write. |
+
+Per-migration rollups also emit:
+
+- `all_matched`
+- `has_missing`
+- `has_ambiguous`
+- `mixed_missing_and_ambiguous`
+
+## Guardrails
+
+- No DB URL is accepted by the script.
+- No `psql`, Docker, `pnpm`, or migration command is spawned.
+- Missing or ambiguous targets do not make the script fail; they are successful
+  parsed results requiring human review.
+- Malformed input fails with exit code 1 and a direct error message.
+- JSON keeps all parsed rows; Markdown is a human summary.

--- a/docs/development/staging-migration-schema-probe-summary-verification-20260520.md
+++ b/docs/development/staging-migration-schema-probe-summary-verification-20260520.md
@@ -1,0 +1,53 @@
+# Staging Migration Schema Probe Summary Verification
+
+Date: 2026-05-20
+
+## Scope
+
+Verify the offline `schema-probes.sql` result summarizer.
+
+No staging DB migration was executed. No database connection was opened. No
+`kysely_migration` row was written.
+
+## Checks
+
+| Check | Result |
+| --- | --- |
+| `node --check scripts/ops/staging-migration-schema-probe-summary.mjs` | PASS |
+| `node --test scripts/ops/staging-migration-schema-probe-summary.test.mjs` | PASS, 8 tests |
+| `git diff --check` | PASS |
+
+## Unit Coverage
+
+The test suite locks:
+
+- CSV input with matched, missing, and ambiguous targets;
+- TSV input from stdin;
+- quoted CSV fields containing commas;
+- per-migration statuses: `all_matched`, `has_missing`, `has_ambiguous`, and
+  `mixed_missing_and_ambiguous`;
+- output boundary: exactly `schema-probe-summary.json` and
+  `schema-probe-summary.md` are written;
+- missing required headers fail clearly;
+- invalid boolean and numeric fields fail clearly;
+- unsupported `--format` fails clearly;
+- missing input fails clearly.
+
+## Boundary Verification
+
+- The script only imports `fs`, `path`, and `url`.
+- It does not import `child_process`.
+- It does not accept a DB URL argument.
+- It does not run migrations or write `kysely_migration`.
+- No token/JWT paths were used or committed.
+
+## Live Evidence Status
+
+No live rehearsal DB probe output was available in this slice. The live DB work
+remains an operator-controlled step:
+
+1. run `schema-probes.sql` against a cloned or backed-up rehearsal DB;
+2. export CSV or TSV;
+3. run this summary script on that local artifact;
+4. review `manual_review_required` vs `schema_probe_targets_present` before any
+   migration alignment write.

--- a/docs/operations/staging-migration-alignment-runbook.md
+++ b/docs/operations/staging-migration-alignment-runbook.md
@@ -33,6 +33,26 @@ you need a machine-readable table/column/index existence matrix. Unqualified
 targets are not assumed to be in `public`; the output includes `match_count` and
 `matched_schemas` so operators can see ambiguity explicitly.
 
+After running `schema-probes.sql`, summarize the probe output offline:
+
+```bash
+psql "$REHEARSAL_DATABASE_URL" \
+  -X --set ON_ERROR_STOP=1 --csv \
+  -f output/staging-migration-alignment-report/<run>/schema-probes.sql \
+  > output/staging-migration-alignment-report/<run>/schema-probe-results.csv
+
+node scripts/ops/staging-migration-schema-probe-summary.mjs \
+  --input output/staging-migration-alignment-report/<run>/schema-probe-results.csv \
+  --format csv \
+  --out-dir output/staging-migration-alignment-report/<run>
+```
+
+Read `schema-probe-summary.md` before deciding which migration names can be
+synthetic marked as applied. A `schema_probe_targets_present` result means the
+emitted targets matched exactly once; it is still not a replay safety proof. A
+`manual_review_required` result means at least one target was missing or matched
+multiple schemas and must be investigated before any alignment write.
+
 Do **not** apply Option A or run full `migrate --latest` when the report says
 `do_not_run_full_migrate`. Use a cloned or backed-up rehearsal DB first.
 

--- a/scripts/ops/staging-migration-schema-probe-summary.mjs
+++ b/scripts/ops/staging-migration-schema-probe-summary.mjs
@@ -1,0 +1,387 @@
+#!/usr/bin/env node
+import { mkdirSync, readFileSync, writeFileSync } from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+
+const __filename = fileURLToPath(import.meta.url)
+const __dirname = path.dirname(__filename)
+const REPO_ROOT = path.resolve(__dirname, '../..')
+
+const REQUIRED_COLUMNS = ['probe_type', 'migration', 'target', 'exists', 'match_count', 'matched_schemas']
+
+function parseArgs(argv) {
+  const opts = {
+    format: 'auto',
+    inputFile: '',
+    outDir: 'output/staging-migration-alignment-report',
+    title: 'Staging migration schema probe results',
+  }
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--input' || arg === '--probe-results-file') {
+      opts.inputFile = argv[++i] || ''
+    } else if (arg === '--format') {
+      opts.format = argv[++i] || 'auto'
+      if (!['auto', 'csv', 'tsv'].includes(opts.format)) {
+        throw new Error(`Unsupported --format value: ${opts.format}`)
+      }
+    } else if (arg === '--out-dir') {
+      opts.outDir = argv[++i] || ''
+    } else if (arg === '--title') {
+      opts.title = argv[++i] || opts.title
+    } else if (arg === '--help' || arg === '-h') {
+      opts.help = true
+    } else {
+      throw new Error(`Unknown argument: ${arg}`)
+    }
+  }
+
+  return opts
+}
+
+function printHelp() {
+  console.log(`Usage:
+  node scripts/ops/staging-migration-schema-probe-summary.mjs --input <csv-or-tsv> [--format auto|csv|tsv] [--out-dir <dir>]
+  cat schema-probe-results.tsv | node scripts/ops/staging-migration-schema-probe-summary.mjs --format tsv [--out-dir <dir>]
+
+This script is read-only. It parses CSV/TSV output produced by running
+schema-probes.sql on a cloned or backed-up rehearsal database and writes
+schema-probe-summary.json + schema-probe-summary.md. It does not connect to a
+database or run migrations.`)
+}
+
+function readStdinIfAvailable() {
+  if (process.stdin.isTTY) return ''
+  return readFileSync(0, 'utf8')
+}
+
+function readProbeResults(opts) {
+  if (opts.inputFile) {
+    return readFileSync(path.resolve(opts.inputFile), 'utf8')
+  }
+  const stdin = readStdinIfAvailable()
+  if (stdin.trim()) return stdin
+  throw new Error('Provide --input or pipe schema probe CSV/TSV output on stdin.')
+}
+
+function normalizeNewlines(text) {
+  return String(text || '').replace(/\r\n/g, '\n').replace(/\r/g, '\n')
+}
+
+function parseCsvRows(text) {
+  const rows = []
+  let row = []
+  let value = ''
+  let inQuotes = false
+
+  const input = normalizeNewlines(text)
+  for (let i = 0; i < input.length; i += 1) {
+    const ch = input[i]
+    const next = input[i + 1]
+
+    if (inQuotes) {
+      if (ch === '"' && next === '"') {
+        value += '"'
+        i += 1
+      } else if (ch === '"') {
+        inQuotes = false
+      } else {
+        value += ch
+      }
+      continue
+    }
+
+    if (ch === '"') {
+      inQuotes = true
+    } else if (ch === ',') {
+      row.push(value)
+      value = ''
+    } else if (ch === '\n') {
+      row.push(value)
+      rows.push(row)
+      row = []
+      value = ''
+    } else {
+      value += ch
+    }
+  }
+
+  if (inQuotes) throw new Error('CSV input ended inside a quoted field.')
+  if (value || row.length > 0) {
+    row.push(value)
+    rows.push(row)
+  }
+
+  return rows.filter((it) => it.some((cell) => String(cell).trim() !== ''))
+}
+
+function parseTsvRows(text) {
+  return normalizeNewlines(text)
+    .split('\n')
+    .filter((line) => line.trim() !== '')
+    .map((line) => line.split('\t'))
+}
+
+function detectDelimiter(text, format = 'auto') {
+  if (format === 'csv') return ','
+  if (format === 'tsv') return '\t'
+  const firstLine = normalizeNewlines(text).split('\n').find((line) => line.trim() !== '') || ''
+  if (firstLine.includes('\t') && !firstLine.includes(',')) return '\t'
+  return ','
+}
+
+function normalizeHeader(value) {
+  return String(value || '').trim().replace(/^\uFEFF/, '').toLowerCase()
+}
+
+function parseBoolean(value, rowNumber) {
+  const normalized = String(value || '').trim().toLowerCase()
+  if (['true', 't', '1', 'yes', 'y'].includes(normalized)) return true
+  if (['false', 'f', '0', 'no', 'n', ''].includes(normalized)) return false
+  throw new Error(`Invalid exists value on row ${rowNumber}: ${value}`)
+}
+
+function parseInteger(value, rowNumber) {
+  const normalized = String(value || '').trim()
+  if (!/^\d+$/.test(normalized)) {
+    throw new Error(`Invalid match_count value on row ${rowNumber}: ${value}`)
+  }
+  return Number.parseInt(normalized, 10)
+}
+
+function parseSchemas(value) {
+  return String(value || '')
+    .split(',')
+    .map((it) => it.trim())
+    .filter(Boolean)
+}
+
+function parseProbeResultRows(text, format = 'auto') {
+  const delimiter = detectDelimiter(text, format)
+  const rawRows = delimiter === '\t' ? parseTsvRows(text) : parseCsvRows(text)
+  if (rawRows.length === 0) throw new Error('Probe results input is empty.')
+
+  const headers = rawRows[0].map(normalizeHeader)
+  const missing = REQUIRED_COLUMNS.filter((column) => !headers.includes(column))
+  if (missing.length > 0) {
+    throw new Error(`Probe results input is missing required column(s): ${missing.join(', ')}`)
+  }
+
+  return rawRows.slice(1).map((cells, index) => {
+    const rowNumber = index + 2
+    const data = {}
+    headers.forEach((header, headerIndex) => {
+      data[header] = cells[headerIndex] ?? ''
+    })
+    const matchCount = parseInteger(data.match_count, rowNumber)
+    const exists = parseBoolean(data.exists, rowNumber)
+    const matchedSchemas = parseSchemas(data.matched_schemas)
+    const status = !exists || matchCount === 0
+      ? 'missing'
+      : matchCount > 1 || matchedSchemas.length > 1
+        ? 'ambiguous'
+        : 'matched'
+
+    return {
+      probeType: String(data.probe_type || '').trim(),
+      migration: String(data.migration || '').trim(),
+      target: String(data.target || '').trim(),
+      exists,
+      matchCount,
+      matchedSchemas,
+      status,
+    }
+  })
+}
+
+function emptyStatusCounts() {
+  return {
+    total: 0,
+    matched: 0,
+    missing: 0,
+    ambiguous: 0,
+  }
+}
+
+function addStatus(counts, row) {
+  counts.total += 1
+  counts[row.status] += 1
+}
+
+function groupCounts(rows, keyFn) {
+  const groups = new Map()
+  for (const row of rows) {
+    const key = keyFn(row) || '(empty)'
+    if (!groups.has(key)) groups.set(key, emptyStatusCounts())
+    addStatus(groups.get(key), row)
+  }
+  return Object.fromEntries([...groups.entries()].sort(([a], [b]) => a.localeCompare(b)))
+}
+
+function buildByMigration(rows) {
+  const groups = new Map()
+  for (const row of rows) {
+    const key = row.migration || '(empty)'
+    if (!groups.has(key)) {
+      groups.set(key, {
+        migration: key,
+        status: 'all_matched',
+        ...emptyStatusCounts(),
+        missingTargets: [],
+        ambiguousTargets: [],
+      })
+    }
+    const group = groups.get(key)
+    addStatus(group, row)
+    if (row.status === 'missing') group.missingTargets.push(row.target)
+    if (row.status === 'ambiguous') group.ambiguousTargets.push(row.target)
+    if (group.missing > 0 && group.ambiguous > 0) {
+      group.status = 'mixed_missing_and_ambiguous'
+    } else if (group.missing > 0) {
+      group.status = 'has_missing'
+    } else if (group.ambiguous > 0) {
+      group.status = 'has_ambiguous'
+    } else {
+      group.status = 'all_matched'
+    }
+  }
+  return [...groups.values()].sort((a, b) => a.migration.localeCompare(b.migration))
+}
+
+function buildReport(rows, opts) {
+  const counts = emptyStatusCounts()
+  for (const row of rows) addStatus(counts, row)
+  const decision = counts.missing > 0 || counts.ambiguous > 0
+    ? 'manual_review_required'
+    : 'schema_probe_targets_present'
+
+  return {
+    ok: true,
+    title: opts.title,
+    generatedAt: new Date().toISOString(),
+    decision,
+    recommendation: decision === 'schema_probe_targets_present'
+      ? 'All emitted schema probe targets matched exactly once. Continue with migration alignment review; this is still not a replay safety proof.'
+      : 'Review missing and ambiguous targets before marking migrations as applied or replaying migrations.',
+    counts,
+    byProbeType: groupCounts(rows, (row) => row.probeType),
+    byMigration: buildByMigration(rows),
+    missing: rows.filter((row) => row.status === 'missing'),
+    ambiguous: rows.filter((row) => row.status === 'ambiguous'),
+    rows,
+  }
+}
+
+function markdownTable(rows, columns) {
+  const header = `| ${columns.map((col) => col.label).join(' | ')} |`
+  const sep = `| ${columns.map(() => '---').join(' | ')} |`
+  const body = rows.map((row) => `| ${columns.map((col) => String(col.value(row)).replace(/\|/g, '\\|')).join(' | ')} |`)
+  return [header, sep, ...body].join('\n')
+}
+
+function renderMarkdown(report) {
+  const lines = [
+    `# ${report.title}`,
+    '',
+    `Generated at: ${report.generatedAt}`,
+    '',
+    '## Summary',
+    '',
+    `- Decision: \`${report.decision}\``,
+    `- Total probes: ${report.counts.total}`,
+    `- Matched: ${report.counts.matched}`,
+    `- Missing: ${report.counts.missing}`,
+    `- Ambiguous: ${report.counts.ambiguous}`,
+    `- Recommendation: ${report.recommendation}`,
+    '',
+    '## By Probe Type',
+    '',
+  ]
+
+  lines.push(markdownTable(Object.entries(report.byProbeType).map(([probeType, counts]) => ({
+    probeType,
+    ...counts,
+  })), [
+    { label: 'Probe type', value: (row) => row.probeType },
+    { label: 'Total', value: (row) => row.total },
+    { label: 'Matched', value: (row) => row.matched },
+    { label: 'Missing', value: (row) => row.missing },
+    { label: 'Ambiguous', value: (row) => row.ambiguous },
+  ]))
+
+  lines.push('', '## By Migration', '')
+  lines.push(markdownTable(report.byMigration, [
+    { label: 'Migration', value: (row) => row.migration },
+    { label: 'Status', value: (row) => row.status },
+    { label: 'Total', value: (row) => row.total },
+    { label: 'Matched', value: (row) => row.matched },
+    { label: 'Missing', value: (row) => row.missing },
+    { label: 'Ambiguous', value: (row) => row.ambiguous },
+  ]))
+
+  lines.push('', '## Missing Targets', '')
+  if (report.missing.length === 0) {
+    lines.push('No missing targets were reported.')
+  } else {
+    lines.push(markdownTable(report.missing.slice(0, 100), [
+      { label: 'Migration', value: (row) => row.migration },
+      { label: 'Type', value: (row) => row.probeType },
+      { label: 'Target', value: (row) => row.target },
+    ]))
+  }
+
+  lines.push('', '## Ambiguous Targets', '')
+  if (report.ambiguous.length === 0) {
+    lines.push('No ambiguous targets were reported.')
+  } else {
+    lines.push(markdownTable(report.ambiguous.slice(0, 100), [
+      { label: 'Migration', value: (row) => row.migration },
+      { label: 'Type', value: (row) => row.probeType },
+      { label: 'Target', value: (row) => row.target },
+      { label: 'Match count', value: (row) => row.matchCount },
+      { label: 'Matched schemas', value: (row) => row.matchedSchemas.join(', ') },
+    ]))
+  }
+
+  lines.push(
+    '',
+    '## Boundary',
+    '',
+    'This report is offline analysis of schema probe output. It does not connect to a database, run migrations, or write `kysely_migration`.',
+    '',
+  )
+  return `${lines.join('\n')}`
+}
+
+function writeOutputs(report, outDir) {
+  const absoluteOut = path.resolve(REPO_ROOT, outDir)
+  mkdirSync(absoluteOut, { recursive: true })
+  const jsonPath = path.join(absoluteOut, 'schema-probe-summary.json')
+  const mdPath = path.join(absoluteOut, 'schema-probe-summary.md')
+  writeFileSync(jsonPath, `${JSON.stringify(report, null, 2)}\n`, 'utf8')
+  writeFileSync(mdPath, renderMarkdown(report), 'utf8')
+  return { jsonPath, mdPath }
+}
+
+function main() {
+  try {
+    const opts = parseArgs(process.argv.slice(2))
+    if (opts.help) {
+      printHelp()
+      return
+    }
+    const text = readProbeResults(opts)
+    const rows = parseProbeResultRows(text, opts.format)
+    const report = buildReport(rows, opts)
+    const outputs = writeOutputs(report, opts.outDir)
+    console.log(`[staging-migration-schema-probe-summary] decision=${report.decision}`)
+    console.log(`[staging-migration-schema-probe-summary] JSON: ${outputs.jsonPath}`)
+    console.log(`[staging-migration-schema-probe-summary] MD: ${outputs.mdPath}`)
+  } catch (error) {
+    console.error(`[staging-migration-schema-probe-summary] ERROR: ${error.message}`)
+    process.exitCode = 1
+  }
+}
+
+main()

--- a/scripts/ops/staging-migration-schema-probe-summary.test.mjs
+++ b/scripts/ops/staging-migration-schema-probe-summary.test.mjs
@@ -1,0 +1,176 @@
+import assert from 'node:assert/strict'
+import { mkdtempSync, readFileSync, readdirSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import { test } from 'node:test'
+
+const REPO_ROOT = path.resolve(import.meta.dirname, '../..')
+const SCRIPT = path.join(REPO_ROOT, 'scripts/ops/staging-migration-schema-probe-summary.mjs')
+
+function run(args, input = '') {
+  return spawnSync('node', [SCRIPT, ...args], {
+    cwd: REPO_ROOT,
+    input,
+    encoding: 'utf8',
+  })
+}
+
+function makeTmp() {
+  return mkdtempSync(path.join(tmpdir(), 'ms2-migration-probe-results-'))
+}
+
+test('summarizes CSV probe results into json and markdown', () => {
+  const tmp = makeTmp()
+  try {
+    const resultsFile = path.join(tmp, 'schema-probe-results.csv')
+    const outDir = path.join(tmp, 'out')
+    writeFileSync(resultsFile, [
+      'probe_type,migration,target,exists,match_count,matched_schemas',
+      'table,008_plugin_infrastructure,plugin_registry,t,1,public',
+      'column,008_plugin_infrastructure,plugin_registry.error,t,1,public',
+      'column,20250926_create_audit_tables,audit_logs.event_id,f,0,',
+      'index,zzzz20260519070000_create_plugin_attendance_report_sync_jobs,plugin_attendance_report_sync_jobs.uq_job,t,2,"public, archive"',
+      '',
+    ].join('\n'))
+
+    const result = run(['--input', resultsFile, '--out-dir', outDir])
+    assert.equal(result.status, 0, result.stderr)
+
+    const report = JSON.parse(readFileSync(path.join(outDir, 'schema-probe-summary.json'), 'utf8'))
+    const markdown = readFileSync(path.join(outDir, 'schema-probe-summary.md'), 'utf8')
+    assert.deepEqual(readdirSync(outDir).sort(), ['schema-probe-summary.json', 'schema-probe-summary.md'])
+    assert.equal(report.decision, 'manual_review_required')
+    assert.deepEqual(report.counts, {
+      total: 4,
+      matched: 2,
+      missing: 1,
+      ambiguous: 1,
+    })
+    assert.equal(report.byProbeType.column.missing, 1)
+    assert.equal(report.byProbeType.index.ambiguous, 1)
+    assert.equal(report.byMigration.find((it) => it.migration === '008_plugin_infrastructure').status, 'all_matched')
+    assert.equal(report.byMigration.find((it) => it.migration === '20250926_create_audit_tables').status, 'has_missing')
+    assert.equal(
+      report.byMigration.find((it) => it.migration === 'zzzz20260519070000_create_plugin_attendance_report_sync_jobs').status,
+      'has_ambiguous',
+    )
+    assert.equal(report.missing[0].target, 'audit_logs.event_id')
+    assert.deepEqual(report.ambiguous[0].matchedSchemas, ['public', 'archive'])
+    assert.match(markdown, /manual_review_required/)
+    assert.match(markdown, /audit_logs\.event_id/)
+    assert.match(markdown, /public, archive/)
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('classifies mixed per-migration status without failing the process', () => {
+  const tmp = makeTmp()
+  try {
+    const outDir = path.join(tmp, 'out')
+    const input = [
+      'probe_type,migration,target,exists,match_count,matched_schemas',
+      'table,mixed_migration,missing_table,false,0,',
+      'index,mixed_migration,ambiguous_index,true,2,"public, shadow"',
+      '',
+    ].join('\n')
+
+    const result = run(['--out-dir', outDir], input)
+    assert.equal(result.status, 0, result.stderr)
+
+    const report = JSON.parse(readFileSync(path.join(outDir, 'schema-probe-summary.json'), 'utf8'))
+    assert.equal(report.decision, 'manual_review_required')
+    assert.equal(report.byMigration[0].status, 'mixed_missing_and_ambiguous')
+    assert.deepEqual(report.byMigration[0].missingTargets, ['missing_table'])
+    assert.deepEqual(report.byMigration[0].ambiguousTargets, ['ambiguous_index'])
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('accepts TSV probe results from stdin', () => {
+  const tmp = makeTmp()
+  try {
+    const outDir = path.join(tmp, 'out')
+    const input = [
+      'probe_type\tmigration\ttarget\texists\tmatch_count\tmatched_schemas',
+      'table\t008_plugin_infrastructure\tplugin_registry\ttrue\t1\tpublic',
+      'column\t008_plugin_infrastructure\tplugin_registry.error\ttrue\t1\tpublic',
+      '',
+    ].join('\n')
+
+    const result = run(['--format', 'tsv', '--out-dir', outDir], input)
+    assert.equal(result.status, 0, result.stderr)
+
+    const report = JSON.parse(readFileSync(path.join(outDir, 'schema-probe-summary.json'), 'utf8'))
+    assert.equal(report.decision, 'schema_probe_targets_present')
+    assert.deepEqual(report.counts, {
+      total: 2,
+      matched: 2,
+      missing: 0,
+      ambiguous: 0,
+    })
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('keeps quoted CSV fields with embedded commas intact', () => {
+  const tmp = makeTmp()
+  try {
+    const outDir = path.join(tmp, 'out')
+    const input = [
+      'probe_type,migration,target,exists,match_count,matched_schemas',
+      'table,quoted_target,"audit_logs, legacy",t,1,public',
+      'index,quoted_schema,idx,t,2,"public, shadow"',
+      '',
+    ].join('\n')
+
+    const result = run(['--out-dir', outDir], input)
+    assert.equal(result.status, 0, result.stderr)
+
+    const report = JSON.parse(readFileSync(path.join(outDir, 'schema-probe-summary.json'), 'utf8'))
+    assert.equal(report.rows[0].target, 'audit_logs, legacy')
+    assert.deepEqual(report.rows[1].matchedSchemas, ['public', 'shadow'])
+    assert.equal(report.rows[1].status, 'ambiguous')
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('fails clearly when required columns are missing', () => {
+  const result = run([], 'probe_type,migration,target\ncolumn,m,t\n')
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /missing required column/)
+  assert.match(result.stderr, /exists/)
+  assert.match(result.stderr, /match_count/)
+})
+
+test('fails clearly on invalid booleans and counts', () => {
+  const invalidBoolean = run([], [
+    'probe_type,migration,target,exists,match_count,matched_schemas',
+    'table,m,t,maybe,1,public',
+  ].join('\n'))
+  assert.equal(invalidBoolean.status, 1)
+  assert.match(invalidBoolean.stderr, /Invalid exists value/)
+
+  const invalidCount = run([], [
+    'probe_type,migration,target,exists,match_count,matched_schemas',
+    'table,m,t,true,nope,public',
+  ].join('\n'))
+  assert.equal(invalidCount.status, 1)
+  assert.match(invalidCount.stderr, /Invalid match_count value/)
+})
+
+test('fails clearly when no input is provided', () => {
+  const result = run([])
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /Provide --input/)
+})
+
+test('fails clearly for unsupported format', () => {
+  const result = run(['--format', 'json'], 'probe_type,migration,target,exists,match_count,matched_schemas\n')
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /Unsupported --format value/)
+})


### PR DESCRIPTION
## Summary

Adds an offline `schema-probe-summary` step for the staging migration alignment workflow. Operators can run `schema-probes.sql` on a cloned or backed-up rehearsal database, export CSV/TSV, then use this script to summarize matched / missing / ambiguous targets without giving the script any database access.

Outputs:
- `schema-probe-summary.json`
- `schema-probe-summary.md`

## Boundaries

- No DB URL accepted by the script
- No `psql`, Docker, pnpm, or migration command spawned by the script
- No migration execution
- No `kysely_migration` writes
- Missing / ambiguous targets are parsed results, not process failures

## Verification

- [x] `node --check scripts/ops/staging-migration-schema-probe-summary.mjs`
- [x] `node --test scripts/ops/staging-migration-schema-probe-summary.test.mjs` — 8 tests
- [x] `node --check scripts/ops/staging-migration-alignment-report.mjs`
- [x] `node --test scripts/ops/staging-migration-alignment-report.test.mjs` — 7 tests
- [x] `git diff --check`
- [x] Staged secret scan clean

Design and verification docs:
- `docs/development/staging-migration-schema-probe-summary-development-20260520.md`
- `docs/development/staging-migration-schema-probe-summary-verification-20260520.md`