### PR TITLE
fix(onprem): load env before migration in apply.ps1 (#1526 follow-up)

### DIFF
--- a/docs/development/onprem-apply-migration-env-loading-design-20260520.md
+++ b/docs/development/onprem-apply-migration-env-loading-design-20260520.md
@@ -1,0 +1,146 @@
+# On-prem apply migration env loading - design - 2026-05-20
+
+## Problem (from the 2026-05-20 bridge feedback on #1526)
+
+The 7070db825 Windows on-prem zip deployment confirmed the
+dependency-refresh wrapper + exit-marker fix from #1684 is working
+end-to-end: dependency refresh runs non-interactively under cmd.exe and
+the apply script picks up the wrapper exit marker. But the official apply
+then **fails during the migration step** with:
+
+```text
+DATABASE_URL not set
+```
+
+and the scheduled task exits 1 before PM2 restart or the healthcheck ever
+runs. The host operator's manual workaround was to **load the env file
+into the process and re-run migrations + PM2 restart + healthcheck**, which
+succeeded (8/8 mock preflight, 10/0 authenticated postdeploy, 200
+healthcheck).
+
+Root cause located in `scripts/ops/multitable-onprem-apply-package.ps1`:
+
+- The script already accepts a `-EnvFile` parameter and falls back to
+  `docker\app.env` under the package root.
+- It already validates the file with `Test-Path` and throws when missing.
+- **It never reads that file into the PowerShell process environment.**
+  The migration call `node $migratePath` then runs with an empty env,
+  hence `DATABASE_URL not set`.
+
+PM2 starts later through `scripts/ops/attendance-onprem-start-pm2.ps1`,
+which **does** import the same env file (its own `Import-AppEnvFile`
+helper). That is why the manual workaround works after the operator runs
+PM2 startup themselves: PM2 sourcing the env file masks the apply-side
+gap, but the migration step had already failed.
+
+## Fix
+
+Mirror the PM2 helper inside `multitable-onprem-apply-package.ps1` and
+invoke it immediately after `Test-Path` succeeds, before any block that
+spawns a child process needing the env (migrations, PM2 startup,
+healthcheck request).
+
+- New helper `Import-AppEnvFile` in apply.ps1, byte-for-byte equivalent
+  parser to `attendance-onprem-start-pm2.ps1` (comments + blanks
+  skipped, `KEY=VALUE` split on first `=`, matching outer quotes
+  stripped, written with `Set-Item Env:NAME`). The helper returns the
+  number of variables applied so the apply log can report a count
+  without echoing names or values.
+- Call site is inserted after the existing env-file `Test-Path` block:
+
+  ```powershell
+  if (-not (Test-Path -LiteralPath $resolvedEnvFile)) {
+    throw "EnvFile not found: $resolvedEnvFile. Use -EnvFile <path> or place app.env at docker\app.env under the root."
+  }
+
+  $importedEnvCount = Import-AppEnvFile -EnvFile $resolvedEnvFile
+  Write-Info ("Loaded env from {0} ({1} variables); migration / restart / healthcheck will inherit DATABASE_URL and JWT_SECRET when present in that file" -f $resolvedEnvFile, $importedEnvCount)
+  ```
+
+- The error string for the missing-file case is upgraded to include the
+  override path so an operator hitting "EnvFile not found" sees both the
+  default location and the `-EnvFile` escape hatch.
+
+## Why mirror PM2's parser exactly
+
+- Both code paths (apply migration, PM2 backend) must read the **same**
+  env file the **same** way, or DATABASE_URL might be quoted/unquoted or
+  whitespace-trimmed differently between the two. Identical parser
+  removes that risk class.
+- The operator already knows the PM2 helper's behavior; reusing it keeps
+  the mental model and any future hardening in one shape.
+
+## Order-of-operations note
+
+Env is loaded **before** the dependency-refresh wrapper runs, not just
+before migration - this is the right placement (PM2 startup and the
+healthcheck step both need DATABASE_URL / JWT_SECRET too, and dependency
+refresh happens earlier in the script). One consequence to acknowledge:
+the cmd.exe wrapper for `pnpm install --frozen-lockfile` will now
+inherit whatever the operator's `app.env` contains. The wrapper still
+sets `CI=true` and `PNPM_CONFIG_CONFIRM_MODULES_PURGE=false` explicitly,
+which overrides the pnpm-relevant subset of anything `app.env` might
+declare. If `app.env` were to carry `NODE_OPTIONS`, `PATH`,
+`NPM_CONFIG_REGISTRY`, or `NODE_TLS_REJECT_UNAUTHORIZED`, those would
+now be visible during dependency refresh. Typical on-prem `app.env`
+holds app-runtime vars only (DB URL, JWT secret, ports), so this is a
+low-probability surface; calling it out so a future surprise here is
+debuggable rather than mysterious.
+
+## Secret hygiene
+
+- No env name or value is logged. Only the file path and the count are
+  written via `Write-Info`. `DATABASE_URL` and `JWT_SECRET` are mentioned
+  in the log message as *expected* env vars, not as values - that text
+  is a static template.
+- Helper does not return the dictionary, only the count, so callers
+  cannot inadvertently spill it.
+
+## Preservation of #1684 / 7070db825 behavior
+
+Untouched in this PR:
+
+- `New-DependencyRefreshCommandWrapper`, `Get-DependencyRefreshExitCodeFromLog`,
+  `WaitForExit()` + ExitCode polling, the `cmd.exe /c pnpm install`
+  non-interactive env (`CI=true PNPM_CONFIG_CONFIRM_MODULES_PURGE=false`),
+  the deploy-local pnpm store, taskkill on timeout, the wrapper stdout
+  marker `[dependency-refresh-wrapper] pnpm install exit=<n>`.
+- All the verify-script assertions added by #1684 for those behaviors
+  remain in place. The new assertions in this PR are pure additions
+  next to them.
+
+## Package verify gate (lock-safe ops hygiene)
+
+`scripts/ops/multitable-onprem-package-verify.sh`
+`verify_windows_entrypoints` gets two new `search_fixed_string`
+assertions against the packaged apply.ps1:
+
+- `Import-AppEnvFile` (helper present)
+- `Loaded env from` (helper invoked before downstream blocks)
+
+So a future stale package without the env loader fails verify in CI
+before anyone reaches a Windows box. Verified as a real gate: pre-fix
+origin/main apply.ps1 had **0** occurrences of either string, so the
+gate would die on a regressed package.
+
+## Out of scope (deliberate)
+
+- No change to `plugin-integration-core` business runtime.
+- No change to the SQL Server executor or the SQL/TLS failure
+  summarization (separate #1526 actionable; explicitly tagged
+  out-of-scope here).
+- No change to deploy.bat / its forwarded arguments. `-EnvFile`
+  remains the operator escape hatch on the apply.ps1 side; deploy.bat
+  continues to rely on the default `docker\app.env` location. An
+  EnvFile forward through deploy.bat is a follow-up if a customer
+  needs a non-default location end-to-end.
+- No K3 Save / Submit / Audit behavior change.
+- No customer GATE lifted. This PR removes a deploy blocker; the
+  GATE for live PoC still depends on customer-supplied answers.
+
+## Files touched
+
+- `scripts/ops/multitable-onprem-apply-package.ps1` (helper + call site
+  + error-message upgrade)
+- `scripts/ops/multitable-onprem-package-verify.sh` (two assertions)
+- this design MD + companion verification MD

--- a/docs/development/onprem-apply-migration-env-loading-verification-20260520.md
+++ b/docs/development/onprem-apply-migration-env-loading-verification-20260520.md
@@ -1,0 +1,122 @@
+# On-prem apply migration env loading - verification - 2026-05-20
+
+Companion to `onprem-apply-migration-env-loading-design-20260520.md`. Ops
+only: `multitable-onprem-apply-package.ps1` + the package verifier; no
+`plugin-integration-core`, no DB migration, no API runtime, no route.
+
+## Local evidence
+
+### 1. Bash syntax of the modified verify script
+
+```text
+bash -n scripts/ops/multitable-onprem-package-verify.sh
+  -> exit 0 (syntax OK)
+```
+
+### 2. Positive markers in post-fix apply.ps1
+
+```text
+grep -c 'Import-AppEnvFile'  apply.ps1   -> 3 (function def + comment + call)
+grep -c 'Loaded env from'    apply.ps1   -> 1 (Write-Info on the call site)
+```
+
+### 3. Negative proof: pre-fix apply.ps1 lacked both (gate is real)
+
+```text
+git show origin/main:scripts/ops/multitable-onprem-apply-package.ps1
+  | grep -c 'Import-AppEnvFile'  -> 0
+  | grep -c 'Loaded env from'    -> 0
+```
+
+A package built from pre-fix `main` would now die on **both** new
+assertions, so the verify gate is genuinely catching the regression
+class - it is not a no-op.
+
+### 4. End-to-end build + verify
+
+```text
+BUILD_WEB=1 BUILD_BACKEND=1 INSTALL_DEPS=0 \
+  bash scripts/ops/multitable-onprem-package-build.sh
+  -> exit 0; produced metasheet-multitable-onprem-v2.5.0-20260519-191605.zip
+
+bash scripts/ops/multitable-onprem-package-verify.sh \
+  output/releases/multitable-onprem/<that>.zip
+  -> "Package verify OK", exit 0
+```
+
+Bundled apply.ps1 inside the produced zip greps clean: 3 occurrences of
+`Import-AppEnvFile`, 1 of `Loaded env from`. The new gate is satisfied
+by the packaged ps1.
+
+## What this PR does **not** prove
+
+- No live deploy executed against a Windows machine in this run. The
+  Windows-side validation will run on a real on-prem bridge against the
+  official package built from this PR's merge. The runbook for that is
+  unchanged - the bridge already runs `multitable-onprem-apply-package.ps1`
+  via the scheduled task.
+- No PowerShell parse-check executed locally (no `pwsh` on this dev
+  host). The PR relies on the existing CI / on-prem apply path to
+  exercise the script. The change is small and follows the existing
+  helper idioms exactly.
+
+## Acceptance criteria mapped to evidence
+
+| Criterion | Evidence |
+| --- | --- |
+| PowerShell apply can load env before migration | Helper definition + call placed before migration block in apply.ps1 |
+| Missing env file gives a clear error | Existing `Test-Path` check kept; message upgraded to mention both default and `-EnvFile` override |
+| With env file present, migration sees DATABASE_URL / JWT_SECRET | `Import-AppEnvFile` writes via `Set-Item Env:` so child `node migrate.js` inherits the process env |
+| Package verify confirms scripts/docs are in the Windows on-prem zip | Two new `search_fixed_string` assertions wired into `verify_windows_entrypoints`; build + verify produced "Package verify OK" |
+
+## #1684 / 7070db825 behavior preserved (diff-proven, not spot-checked)
+
+```text
+git diff origin/main -- scripts/ops/multitable-onprem-apply-package.ps1 \
+  | grep -c '^-[^-]'    -> 1
+```
+
+The single non-header delete line is the old throw message
+`throw "EnvFile not found: $resolvedEnvFile"`, replaced with the
+upgraded message required by acceptance criterion 2 (mention default
+location + `-EnvFile` override). It is in the env-file resolution
+block, **not** in any of the `#1684` wrapper / exit-marker code paths.
+All other changes are pure additions.
+
+Spot-checked still-present after the diff-prove:
+
+- `New-DependencyRefreshCommandWrapper`,
+  `Get-DependencyRefreshExitCodeFromLog`, the wrapper stdout marker
+  `[dependency-refresh-wrapper] pnpm install exit=<n>`, the
+  `cmd.exe /c pnpm install --frozen-lockfile` invocation with
+  `CI=true` / `PNPM_CONFIG_CONFIRM_MODULES_PURGE=false`, the deploy-local
+  `.pnpm-store`, taskkill on timeout, `WaitForExit()` before reading
+  `ExitCode`.
+
+The PR adds code; it does not modify or remove any wrapper line.
+
+## Deployment impact
+
+- No env var, no migration, no flag, no route, no bundle behavior
+  change.
+- The new helper imports values **already in the operator's env file**
+  on each apply run. It does not invent or default any value.
+- An operator with no `docker\app.env` and no `-EnvFile` override gets
+  the existing `EnvFile not found` error, now with a clearer message
+  pointing at both the default path and the override flag.
+
+## GATE-blocking status
+
+This PR does **not** lift the customer GATE and does not change any K3
+Save / Submit / Audit behavior. It removes a deploy blocker on Windows
+on-prem apply so future bridge runs can reach PM2 restart and the
+authenticated postdeploy smoke from a clean scheduled-task invocation,
+matching what the manual finalize already demonstrated on
+`multitable-onprem-k3wise-20260519-7070db825`.
+
+## Rollback
+
+Revert the PR. The change is two helper-style edits in one ps1 file
+plus two grep assertions; rollback restores the prior state exactly,
+returning operators to the pre-fix workaround (manual env load before
+finalize).

--- a/scripts/ops/multitable-onprem-apply-package.ps1
+++ b/scripts/ops/multitable-onprem-apply-package.ps1
@@ -36,6 +36,43 @@ function Resolve-NormalizedPath {
   return [System.IO.Path]::GetFullPath($trimmed)
 }
 
+function Import-AppEnvFile {
+  param([string]$EnvFile)
+
+  # Mirror of scripts/ops/attendance-onprem-start-pm2.ps1 Import-AppEnvFile so
+  # migration / restart inherit DATABASE_URL / JWT_SECRET / etc. from the same
+  # env file PM2 will source. Without this, `node migrate.js` sees an empty
+  # process environment and dies with "DATABASE_URL not set" (#1526 follow-up).
+  $applied = 0
+  foreach ($rawLine in Get-Content -Path $EnvFile) {
+    $line = $rawLine.Trim()
+    if ([string]::IsNullOrWhiteSpace($line) -or $line.StartsWith('#')) {
+      continue
+    }
+
+    $parts = $line -split '=', 2
+    if ($parts.Length -ne 2) {
+      continue
+    }
+
+    $name = $parts[0].Trim()
+    if ([string]::IsNullOrWhiteSpace($name)) {
+      continue
+    }
+    $value = $parts[1].Trim()
+
+    if ($value.Length -ge 2) {
+      if (($value.StartsWith('"') -and $value.EndsWith('"')) -or ($value.StartsWith("'") -and $value.EndsWith("'"))) {
+        $value = $value.Substring(1, $value.Length - 2)
+      }
+    }
+
+    Set-Item -Path ("Env:{0}" -f $name) -Value $value
+    $applied += 1
+  }
+  return $applied
+}
+
 function Write-Info {
   param([string]$Message)
   Write-Host "[multitable-onprem-apply-package] $Message"
@@ -399,8 +436,16 @@ $resolvedEnvFile = if ([string]::IsNullOrWhiteSpace($EnvFile)) {
 }
 
 if (-not (Test-Path -LiteralPath $resolvedEnvFile)) {
-  throw "EnvFile not found: $resolvedEnvFile"
+  throw "EnvFile not found: $resolvedEnvFile. Use -EnvFile <path> or place app.env at docker\app.env under the root."
 }
+
+# Load env into this process before migration/restart/healthcheck so child
+# processes (node migrate.js, PM2 startup, healthcheck request) inherit
+# DATABASE_URL / JWT_SECRET / etc. from the same file PM2 sources. Without
+# this load, migrations fail with "DATABASE_URL not set" before PM2 ever
+# starts (#1526 official-apply migration env loading follow-up).
+$importedEnvCount = Import-AppEnvFile -EnvFile $resolvedEnvFile
+Write-Info ("Loaded env from {0} ({1} variables); migration / restart / healthcheck will inherit DATABASE_URL and JWT_SECRET when present in that file" -f $resolvedEnvFile, $importedEnvCount)
 
 $outputLogs = Join-Path $resolvedRoot 'output\logs'
 New-Item -ItemType Directory -Force -Path $outputLogs | Out-Null

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -74,6 +74,12 @@ function verify_windows_entrypoints() {
   if search_fixed_string "-not (Test-Path -LiteralPath (Join-Path \$resolvedRoot 'node_modules'))" "$apply_helper"; then
     die "PowerShell apply helper must not skip dependency refresh just because root node_modules already exists"
   fi
+  # #1526 follow-up (2026-05-20): apply.ps1 must load the env file before
+  # migration/restart so node migrate.js inherits DATABASE_URL / JWT_SECRET.
+  # Without these markers an older apply.ps1 would silently regress to the
+  # pre-fix state where official Windows apply died with "DATABASE_URL not set".
+  search_fixed_string 'Import-AppEnvFile' "$apply_helper" || die "PowerShell apply helper must define Import-AppEnvFile to load the deploy env file before migration (#1526 migration env loading)"
+  search_fixed_string 'Loaded env from' "$apply_helper" || die "PowerShell apply helper must invoke env loading and log the source path before migration (#1526 migration env loading)"
 
   if ! search_fixed_string 'deploy-remote.log' "$remote_script"; then
     die "deploy-remote.bat must continue writing output\\logs\\deploy-remote.log"


### PR DESCRIPTION
## 修的是什么
2026-05-20 bridge 反馈:**官方 Windows on-prem apply 在 migration 阶段死于 `DATABASE_URL not set`**。`apply.ps1` 解析了 `docker\app.env`、`Test-Path` 校验通过,但**从未把文件内容加载进进程 env**,所以 `node migrate.js` 用空 env 启动。

## 怎么修
镜像 `attendance-onprem-start-pm2.ps1` 已用的 `Import-AppEnvFile`(同款 parser:注释/空行跳过、第一次 `=` 切分、外引号剥离、`Set-Item Env:`),放到 `apply.ps1` 里,在 `$resolvedEnvFile` 的 `Test-Path` 成功之后、任何会派生子进程的块(migration / PM2 restart / healthcheck)之前**调一次**。错误信息升级,既报默认路径又给 `-EnvFile` 备路。

## 关键性质(reviewer 关注点)
- **保留 #1684 / 7070db825 不变**:`git diff origin/main -- apply.ps1 | grep -c '^-[^-]'` = **1**,且这唯一一行 delete 是 `throw "EnvFile not found: $resolvedEnvFile"` 的旧文案——按验收条件 2 升级为带 `-EnvFile` 提示的版本,**完全不在** wrapper / exit-marker 区。即 wrapper 行 0 修改,纯加法。
- **PM2 与 apply 读 env 用同一份 parser**——避免引号/空白差异让两边对 `DATABASE_URL` 解读不一致。
- **Secret 卫生**:不打印任何 env 名/值,只打路径 + 计数。
- **顺序后果已声明**:env 在 dependency-refresh wrapper 之前加载——wrapper 仍显式 `CI=true PNPM_CONFIG_CONFIRM_MODULES_PURGE=false`,会覆盖 pnpm 相关 subset;一段 design MD 已声明这一可见性变化(避免未来 NODE_OPTIONS/TLS/PATH 类 app.env 项出现意外时无从溯源)。
- **package-verify gate**:在 `verify_windows_entrypoints` 加 2 条 `search_fixed_string`(`Import-AppEnvFile` + `Loaded env from`),让一份"丢失 env loader"的退化包永远过不了 CI/官方 build 的内置 verify。

## 本地证据
| 检查 | 结果 |
|---|---|
| `bash -n` verify 脚本 | OK |
| post-fix apply.ps1 含 `Import-AppEnvFile` | 3 次 |
| post-fix apply.ps1 含 `Loaded env from` | 1 次 |
| pre-fix(origin/main)同两个 grep | **0 / 0**(gate 为真闸门) |
| `git diff origin/main -- apply.ps1 \| grep -c '^-[^-]'` | 1(且该行是错误文案升级,非 wrapper) |
| `BUILD_WEB=1 BUILD_BACKEND=1 package-build.sh` | exit 0,产出 zip/tgz |
| 修改后 verify 脚本对产出 zip | **Package verify OK**(exit 0) |
| 解包后产物内 apply.ps1 含两 marker | 3 / 1 |
| 本地 `pwsh` 解析 | 跳过(开发机无 pwsh,声明披露;CI/on-prem 侧仍 cover) |

## 范围与红线
- **仅 ops**:`apply.ps1` + 包 verify + 2 docs MD。4 文件 +320/-1。显式 `git add` 4 路径,构建产物未带入。
- **未触** `plugins/plugin-integration-core` 业务 runtime、无 DB migration、无 API runtime、无 route 变更。
- **不解除客户 GATE**;只摘掉部署时刻的 schema-401 假象前一道闸——让官方 scheduled-task 一次跑到 PM2 restart + healthcheck,而不是停在 migration。
- **明确不在本 PR**:SQL/TLS 摘要、K3 Save/Submit/Audit 行为变更——按 #1526 反馈第 3 条单列。

## Test plan
- [ ] CI pr-validate(预期通过)
- [ ] Codex review:确认 Import-AppEnvFile 与 PM2 idiom 一致、wrapper 行 0 删、verify 文案合理
- [ ] 合并后官方 `Multitable On-Prem Package Build` 工作流的内置 verify 段会自动跑新断言
- [ ] 实体机 bridge 重跑 apply:应直达 PM2 restart + healthcheck,不再卡 `DATABASE_URL not set`

🤖 Generated with [Claude Code](https://claude.com/claude-code)