### PR TITLE
feat(attendance): protect manual holidays during sync

### DIFF
--- a/docs/development/attendance-holidays-origin-sync-protection-development-20260520.md
+++ b/docs/development/attendance-holidays-origin-sync-protection-development-20260520.md
@@ -1,0 +1,91 @@
+# Attendance Holidays Origin Sync Protection Development
+
+Date: 2026-05-20
+Branch: `runtime/attendance-holidays-origin-sync-protection-20260520`
+Base: `origin/main@3e76aa7c6`
+Commit: branch tip `feat(attendance): protect manual holidays during sync`
+RFC: `docs/development/attendance-effective-calendar-rfc-20260520.md`
+
+## Goal
+
+Implement Step 2 of the Attendance Effective Calendar RFC:
+
+- add a base-layer origin marker to `attendance_holidays`;
+- make national holiday sync write only `origin = 'national'` rows;
+- protect admin/manual holiday rows from sync overwrite;
+- expose applied/skipped/ignored sync counters;
+- add a DB-backed regression test for the sync matrix.
+
+This slice does not implement `settings.calendarPolicy`, the effective-calendar resolver, frontend calendar consumption, or calc-chain cutover.
+
+## Changed Files
+
+| File | Change |
+| --- | --- |
+| `packages/core-backend/src/db/migrations/zzzz20260520020000_add_origin_to_attendance_holidays.ts` | Adds `attendance_holidays.origin text not null default 'manual'` plus `national/manual` check constraint; down migration drops the constraint and column. |
+| `packages/core-backend/src/db/types.ts` | Adds `origin: 'national' \| 'manual'` to `AttendanceHolidaysTable`. |
+| `plugins/plugin-attendance/index.cjs` | Maps holiday row origin, writes admin-created holidays as manual, writes sync holidays as national, pre-classifies manual conflicts, and returns/applies sync counters. |
+| `packages/core-backend/tests/integration/attendance-plugin.test.ts` | Adds a DB-backed integration test covering manual protection and sync counter semantics. |
+
+## Runtime Semantics
+
+`attendance_holidays` remains one row per `(org_id, holiday_date)`.
+
+`origin` means:
+
+- `national`: row was created or updated by `/api/attendance/holidays/sync`;
+- `manual`: row was created by an admin or existed before this migration.
+
+Admin create/update/delete remains the manual holiday management surface. Sync cannot downgrade a manual row to national.
+
+## Sync Algorithm
+
+`upsertHolidayRows()` now returns:
+
+```ts
+{
+  applied: number
+  skipped: number
+  ignored: number
+}
+```
+
+For each sync chunk:
+
+1. Pre-pass query existing rows by date:
+   ```sql
+   SELECT holiday_date, COALESCE(origin, 'manual') AS origin
+   FROM attendance_holidays
+   WHERE org_id = $1 AND holiday_date = ANY($2::date[])
+   ```
+2. Classify existing `manual` conflicts as `ignored`.
+3. When `overwrite = false`, classify existing non-manual rows as `skipped`.
+4. Insert/update remaining rows as `origin = 'national'`.
+5. Count SQL `RETURNING` rows as `applied`.
+6. Treat race-time non-applied rows as `ignored` for overwrite mode and `skipped` for no-overwrite mode.
+
+The sync response, per-year `results[]`, auto-sync event payload, logs, and `holidaySync.lastRun` now include `totalSkipped` and `totalIgnored` next to the existing fetched/applied counters.
+
+## Scope Boundaries
+
+Implemented:
+
+- migration and type shape for `origin`;
+- sync writer protection for national/manual rows;
+- admin CRUD compatibility;
+- sync response counter compatibility;
+- DB-required regression test for the Step 2 sync matrix.
+
+Not implemented:
+
+- `settings.calendarPolicy.overrides[]`;
+- shared `matchScopeFilters`;
+- `/api/attendance/effective-calendar`;
+- frontend layer-chain tooltip or calendar source colors;
+- `resolveWorkContext` / payroll / import cutover.
+
+## Risk Notes
+
+- The migration defaults existing rows to `manual`, matching the RFC backfill policy.
+- Sync uses a pre-pass query because SQL `RETURNING` alone cannot distinguish manual conflicts from skipped no-overwrite rows.
+- The new integration test requires a real PostgreSQL URL. Without `DATABASE_URL` or `ATTENDANCE_TEST_DATABASE_URL`, the existing integration harness returns early, so local "passed" output is only a load check.

--- a/docs/development/attendance-holidays-origin-sync-protection-verification-20260520.md
+++ b/docs/development/attendance-holidays-origin-sync-protection-verification-20260520.md
@@ -1,0 +1,101 @@
+# Attendance Holidays Origin Sync Protection Verification
+
+Date: 2026-05-20
+Branch: `runtime/attendance-holidays-origin-sync-protection-20260520`
+Base: `origin/main@3e76aa7c6`
+Commit: branch tip `feat(attendance): protect manual holidays during sync`
+
+## Definition of Done
+
+This slice is merge-ready only when the DB-backed test below is executed against a real PostgreSQL database and prints the concrete test case name:
+
+```text
+✓ tests/integration/attendance-plugin.test.ts > Attendance Plugin Integration > protects manual holiday origins during national holiday sync
+```
+
+That gate is now satisfied on scratch PostgreSQL 15.17.
+
+## Summary
+
+Step 2 is implemented locally and passes non-DB validation plus the DB-backed holiday sync regression on scratch PostgreSQL.
+
+## Commands Run
+
+| Command | Result |
+| --- | --- |
+| `pnpm --filter @metasheet/core-backend test:unit` | PASS: 170 files / 2245 tests. |
+| `pnpm --filter @metasheet/core-backend build` | PASS. |
+| `pnpm --filter @metasheet/core-backend exec tsc -p tsconfig.json --noEmit` | PASS. |
+| `node --check plugins/plugin-attendance/index.cjs` | PASS. |
+| `ATTENDANCE_TEST_DATABASE_URL=postgresql://127.0.0.1:5432/<scratch-db> DATABASE_URL=postgresql://127.0.0.1:5432/<scratch-db> pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "protects manual holiday origins" --reporter=verbose` | PASS on scratch PostgreSQL: concrete target test executed and passed. |
+| `git diff --check` | PASS. |
+| `psql ... information_schema / pg_constraint probe` | PASS: `origin` is `text not null default 'manual'::text`; `attendance_holidays_origin_check` allows `national/manual`. |
+
+## Environment Checks
+
+```text
+PostgreSQL: 15.17 (Homebrew)
+Scratch DB: metasheet_att_origin_sync_20260519193942
+Migration: zzzz20260520020000_add_origin_to_attendance_holidays executed successfully
+```
+
+Target test output:
+
+```text
+✓ tests/integration/attendance-plugin.test.ts > Attendance Plugin Integration > protects manual holiday origins during national holiday sync
+
+Test Files  1 passed (1)
+Tests  1 passed | 66 skipped (67)
+Duration  2.82s
+```
+
+Schema probe:
+
+```text
+origin|text|'manual'::text|NO
+attendance_holidays_origin_check|CHECK ((origin = ANY (ARRAY['national'::text, 'manual'::text])))
+```
+
+## Regression Matrix
+
+The added integration test `protects manual holiday origins during national holiday sync` covers the RFC Step 2 matrix when run with a real DB:
+
+| Case | Covered by test assertion |
+| --- | --- |
+| Empty table sync | `Synced Empty` is inserted as `origin = 'national'`. |
+| National row update | Existing national row updates name/workday and remains `origin = 'national'`. |
+| Manual row conflict | Existing manual row remains unchanged and increments `totalIgnored`. |
+| Manual deleted then sync | Deleted manual date is re-created as `origin = 'national'`. |
+| `overwrite = false` | Existing national row remains unchanged and increments `totalSkipped`. |
+| Backfill/default | Insert without `origin` defaults to manual and is protected from sync. |
+
+Expected counters in the DB-backed test:
+
+| Sync mode | totalFetched | totalApplied | totalIgnored | totalSkipped |
+| --- | ---: | ---: | ---: | ---: |
+| `overwrite = true` | 5 | 3 | 2 | 0 |
+| `overwrite = false` | 1 | 0 | 0 | 1 |
+
+## Static Evidence
+
+- Migration adds/drops `attendance_holidays_origin_check` and the `origin` column.
+- Sync writer inserts `origin = 'national'`.
+- Sync writer updates only when `attendance_holidays.origin = 'national'`.
+- Admin create inserts `origin = 'manual'`.
+- Holiday list/detail/update queries return `origin`.
+- Sync response and `holidaySync.lastRun` expose `totalSkipped` and `totalIgnored`.
+
+## Remaining Gate
+
+No DB gate remains for this slice. The scratch PostgreSQL target test above executed the manual protection and counter assertions against real Postgres.
+
+If the branch is rebased again before PR, rerun:
+
+```bash
+ATTENDANCE_TEST_DATABASE_URL=postgres://... \
+  pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts \
+  run tests/integration/attendance-plugin.test.ts \
+  -t "protects manual holiday origins" \
+  --reporter=dot
+```

--- a/packages/core-backend/src/db/migrations/zzzz20260520020000_add_origin_to_attendance_holidays.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260520020000_add_origin_to_attendance_holidays.ts
@@ -1,0 +1,39 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'attendance_holidays')
+  if (!exists) return
+
+  await sql`
+    ALTER TABLE attendance_holidays
+    ADD COLUMN IF NOT EXISTS origin text NOT NULL DEFAULT 'manual'
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE attendance_holidays
+    DROP CONSTRAINT IF EXISTS attendance_holidays_origin_check
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE attendance_holidays
+    ADD CONSTRAINT attendance_holidays_origin_check
+    CHECK (origin IN ('national', 'manual'))
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'attendance_holidays')
+  if (!exists) return
+
+  await sql`
+    ALTER TABLE attendance_holidays
+    DROP CONSTRAINT IF EXISTS attendance_holidays_origin_check
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE attendance_holidays
+    DROP COLUMN IF EXISTS origin
+  `.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1116,6 +1116,7 @@ export interface AttendanceHolidaysTable {
   holiday_date: ColumnType<string, string | undefined, string>
   name: string | null
   is_working_day: boolean
+  origin: 'national' | 'manual'
   created_at: CreatedAt
   updated_at: UpdatedAt
 }

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -3825,6 +3825,142 @@ describe('Attendance Plugin Integration', () => {
     expect(invalidHolidayTypeRes.status).toBe(400)
   })
 
+  it('protects manual holiday origins during national holiday sync', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const syncYear = 3030 + (Number.parseInt(runSuffix.slice(-3), 36) % 500)
+    const dates = {
+      empty: `${syncYear}-01-01`,
+      national: `${syncYear}-01-02`,
+      manual: `${syncYear}-01-03`,
+      manualDeleted: `${syncYear}-01-04`,
+      defaultManual: `${syncYear}-01-05`,
+      overwriteFalse: `${syncYear}-01-06`,
+    }
+    const targetDates = Object.values(dates)
+    const pool = new Pool({ connectionString: dbUrl })
+    let fetchDays: Array<{ date: string; name: string; isOffDay: boolean }> = []
+    const fetchSpy = vi.spyOn(globalThis, 'fetch').mockImplementation(async () => ({
+      ok: true,
+      json: async () => ({ days: fetchDays }),
+    }) as any)
+
+    async function readHolidayRows() {
+      const rows = await pool.query(
+        `SELECT to_char(holiday_date, 'YYYY-MM-DD') AS date, name, is_working_day, origin
+         FROM attendance_holidays
+         WHERE org_id = $1 AND holiday_date = ANY($2::date[])`,
+        ['default', targetDates]
+      )
+      return new Map(rows.rows.map(row => [String(row.date), row]))
+    }
+
+    try {
+      await pool.query('DELETE FROM attendance_holidays WHERE org_id = $1 AND holiday_date = ANY($2::date[])', ['default', targetDates])
+      await pool.query(
+        `INSERT INTO attendance_holidays (id, org_id, holiday_date, name, is_working_day, origin)
+         VALUES
+           ($1, 'default', $2, 'Old National', false, 'national'),
+           ($3, 'default', $4, 'Manual Protected', false, 'manual'),
+           ($5, 'default', $6, 'Manual Deleted', false, 'manual'),
+           ($7, 'default', $8, 'Overwrite Disabled', false, 'national')`,
+        [
+          randomUuidV4(),
+          dates.national,
+          randomUuidV4(),
+          dates.manual,
+          randomUuidV4(),
+          dates.manualDeleted,
+          randomUuidV4(),
+          dates.overwriteFalse,
+        ]
+      )
+      await pool.query(
+        `INSERT INTO attendance_holidays (id, org_id, holiday_date, name, is_working_day)
+         VALUES ($1, 'default', $2, 'Default Manual', false)`,
+        [randomUuidV4(), dates.defaultManual]
+      )
+      await pool.query('DELETE FROM attendance_holidays WHERE org_id = $1 AND holiday_date = $2', ['default', dates.manualDeleted])
+
+      const tokenRes = await requestJson(
+        `${baseUrl}/api/auth/dev-token?userId=attendance-holiday-sync-${runSuffix}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+      )
+      const token = (tokenRes.body as { token?: string } | undefined)?.token
+      expect(token).toBeTruthy()
+      if (!token) return
+
+      fetchDays = [
+        { date: dates.empty, name: 'Synced Empty', isOffDay: true },
+        { date: dates.national, name: 'Synced National Update', isOffDay: false },
+        { date: dates.manual, name: 'Synced Manual Conflict', isOffDay: true },
+        { date: dates.manualDeleted, name: 'Synced Deleted Manual', isOffDay: true },
+        { date: dates.defaultManual, name: 'Synced Default Manual Conflict', isOffDay: true },
+      ]
+      const overwriteTrueRes = await requestJson(`${baseUrl}/api/attendance/holidays/sync`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          years: [syncYear],
+          baseUrl: 'https://attendance-sync.test',
+          addDayIndex: false,
+          overwrite: true,
+        }),
+      })
+      expect(overwriteTrueRes.status).toBe(200)
+      const overwriteTrueData = (overwriteTrueRes.body as { data?: Record<string, any> } | undefined)?.data ?? {}
+      expect(overwriteTrueData.totalFetched).toBe(5)
+      expect(overwriteTrueData.totalApplied).toBe(3)
+      expect(overwriteTrueData.totalIgnored).toBe(2)
+      expect(overwriteTrueData.totalSkipped).toBe(0)
+      expect(overwriteTrueData.results?.[0]).toMatchObject({ fetched: 5, applied: 3, ignored: 2, skipped: 0 })
+      expect(overwriteTrueData.lastRun).toMatchObject({ totalFetched: 5, totalApplied: 3, totalIgnored: 2, totalSkipped: 0 })
+
+      let rowsByDate = await readHolidayRows()
+      expect(rowsByDate.get(dates.empty)).toMatchObject({ name: 'Synced Empty', origin: 'national' })
+      expect(rowsByDate.get(dates.national)).toMatchObject({ name: 'Synced National Update', origin: 'national', is_working_day: true })
+      expect(rowsByDate.get(dates.manual)).toMatchObject({ name: 'Manual Protected', origin: 'manual' })
+      expect(rowsByDate.get(dates.manualDeleted)).toMatchObject({ name: 'Synced Deleted Manual', origin: 'national' })
+      expect(rowsByDate.get(dates.defaultManual)).toMatchObject({ name: 'Default Manual', origin: 'manual' })
+
+      fetchDays = [
+        { date: dates.overwriteFalse, name: 'Should Not Overwrite', isOffDay: false },
+      ]
+      const overwriteFalseRes = await requestJson(`${baseUrl}/api/attendance/holidays/sync`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          years: [syncYear],
+          baseUrl: 'https://attendance-sync.test',
+          addDayIndex: false,
+          overwrite: false,
+        }),
+      })
+      expect(overwriteFalseRes.status).toBe(200)
+      const overwriteFalseData = (overwriteFalseRes.body as { data?: Record<string, any> } | undefined)?.data ?? {}
+      expect(overwriteFalseData.totalFetched).toBe(1)
+      expect(overwriteFalseData.totalApplied).toBe(0)
+      expect(overwriteFalseData.totalIgnored).toBe(0)
+      expect(overwriteFalseData.totalSkipped).toBe(1)
+      expect(overwriteFalseData.results?.[0]).toMatchObject({ fetched: 1, applied: 0, ignored: 0, skipped: 1 })
+
+      rowsByDate = await readHolidayRows()
+      expect(rowsByDate.get(dates.overwriteFalse)).toMatchObject({ name: 'Overwrite Disabled', origin: 'national', is_working_day: false })
+    } finally {
+      fetchSpy.mockRestore()
+      await pool.query('DELETE FROM attendance_holidays WHERE org_id = $1 AND holiday_date = ANY($2::date[])', ['default', targetDates]).catch(() => undefined)
+      await pool.end()
+    }
+  })
+
   it('rejects negative leave type daily_minutes aliases, empty holiday names, and exposes holiday type fields', async () => {
     if (!baseUrl) return
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -7413,12 +7413,14 @@ function mapShiftFromAssignmentRow(row) {
 
 function mapHolidayRow(row) {
   const holidayType = row.is_working_day === true ? 'working_day_override' : 'holiday'
+  const origin = row.origin === 'national' ? 'national' : 'manual'
   return {
     id: row.id,
     orgId: row.org_id ?? DEFAULT_ORG_ID,
     date: normalizeDateOnly(row.holiday_date) ?? row.holiday_date,
     name: row.name ?? null,
     isWorkingDay: row.is_working_day ?? false,
+    origin,
     type: holidayType,
     holidayType,
   }
@@ -8592,33 +8594,76 @@ async function fetchHolidayCnYear({ year, baseUrl }) {
 }
 
 async function upsertHolidayRows(db, { orgId, rows, overwrite }) {
-  if (!rows.length) return 0
+  if (!rows.length) return { applied: 0, skipped: 0, ignored: 0 }
   const chunkSize = 200
   let applied = 0
+  let skipped = 0
+  let ignored = 0
 
   for (let i = 0; i < rows.length; i += chunkSize) {
     const chunk = rows.slice(i, i + chunkSize)
+    const dates = chunk.map(row => row.date).filter(Boolean)
+    const existingRows = dates.length
+      ? await db.query(
+        `SELECT holiday_date, COALESCE(origin, 'manual') AS origin
+         FROM attendance_holidays
+         WHERE org_id = $1 AND holiday_date = ANY($2::date[])`,
+        [orgId, dates]
+      )
+      : []
+    const existingByDate = new Map()
+    for (const existing of existingRows) {
+      const date = normalizeDateOnly(existing.holiday_date) ?? String(existing.holiday_date ?? '').slice(0, 10)
+      if (!date) continue
+      existingByDate.set(date, existing.origin === 'national' ? 'national' : 'manual')
+    }
+
+    const writeRows = []
+    for (const row of chunk) {
+      const existingOrigin = existingByDate.get(row.date)
+      if (existingOrigin === 'manual') {
+        ignored += 1
+        continue
+      }
+      if (!overwrite && existingOrigin) {
+        skipped += 1
+        continue
+      }
+      writeRows.push(row)
+    }
+    if (!writeRows.length) continue
+
     const values = []
     const params = []
-    chunk.forEach((row, index) => {
-      const baseIndex = index * 5
-      values.push(`($${baseIndex + 1}, $${baseIndex + 2}, $${baseIndex + 3}, $${baseIndex + 4}, $${baseIndex + 5})`)
-      params.push(randomUUID(), orgId, row.date, row.name ?? null, row.isWorkingDay)
+    writeRows.forEach((row, index) => {
+      const baseIndex = index * 6
+      values.push(`($${baseIndex + 1}, $${baseIndex + 2}, $${baseIndex + 3}, $${baseIndex + 4}, $${baseIndex + 5}, $${baseIndex + 6})`)
+      params.push(randomUUID(), orgId, row.date, row.name ?? null, row.isWorkingDay, 'national')
     })
     const conflictAction = overwrite
-      ? 'DO UPDATE SET name = EXCLUDED.name, is_working_day = EXCLUDED.is_working_day'
+      ? `DO UPDATE SET
+           name = EXCLUDED.name,
+           is_working_day = EXCLUDED.is_working_day,
+           origin = 'national',
+           updated_at = now()
+         WHERE attendance_holidays.origin = 'national'`
       : 'DO NOTHING'
     const rowsInserted = await db.query(
-      `INSERT INTO attendance_holidays (id, org_id, holiday_date, name, is_working_day)
+      `INSERT INTO attendance_holidays (id, org_id, holiday_date, name, is_working_day, origin)
        VALUES ${values.join(', ')}
        ON CONFLICT (org_id, holiday_date) ${conflictAction}
        RETURNING holiday_date`,
       params
     )
     applied += rowsInserted.length
+    const notApplied = writeRows.length - rowsInserted.length
+    if (notApplied > 0) {
+      if (overwrite) ignored += notApplied
+      else skipped += notApplied
+    }
   }
 
-  return applied
+  return { applied, skipped, ignored }
 }
 
 function getZonedParts(date, timeZone) {
@@ -8723,6 +8768,8 @@ async function performHolidaySync({ db, logger, orgId, settings, payload }) {
   const years = resolveHolidaySyncYears(settings, payload)
   let totalFetched = 0
   let totalApplied = 0
+  let totalSkipped = 0
+  let totalIgnored = 0
   const results = []
 
   for (const year of years) {
@@ -8734,13 +8781,22 @@ async function performHolidaySync({ db, logger, orgId, settings, payload }) {
       dayIndexMaxDays: syncConfig.dayIndexMaxDays,
       dayIndexFormat: syncConfig.dayIndexFormat,
     })
-    const applied = await upsertHolidayRows(db, {
+    const syncResult = await upsertHolidayRows(db, {
       orgId,
       rows,
       overwrite: syncConfig.overwrite,
     })
-    totalApplied += applied
-    results.push({ year, url, fetched: days.length, applied })
+    totalApplied += syncResult.applied
+    totalSkipped += syncResult.skipped
+    totalIgnored += syncResult.ignored
+    results.push({
+      year,
+      url,
+      fetched: days.length,
+      applied: syncResult.applied,
+      skipped: syncResult.skipped,
+      ignored: syncResult.ignored,
+    })
   }
 
   const lastRun = {
@@ -8749,6 +8805,8 @@ async function performHolidaySync({ db, logger, orgId, settings, payload }) {
     years,
     totalFetched,
     totalApplied,
+    totalSkipped,
+    totalIgnored,
     error: null,
   }
   await saveSettings(db, {
@@ -8759,7 +8817,7 @@ async function performHolidaySync({ db, logger, orgId, settings, payload }) {
     },
   })
 
-  return { syncConfig, years, totalFetched, totalApplied, results, lastRun }
+  return { syncConfig, years, totalFetched, totalApplied, totalSkipped, totalIgnored, results, lastRun }
 }
 
 function matchesNumberGte(actual, expected) {
@@ -9218,6 +9276,12 @@ function normalizeSettings(raw) {
         totalApplied: Number.isFinite(holidaySyncLastRun.totalApplied)
           ? Number(holidaySyncLastRun.totalApplied)
           : null,
+        totalSkipped: Number.isFinite(holidaySyncLastRun.totalSkipped)
+          ? Number(holidaySyncLastRun.totalSkipped)
+          : null,
+        totalIgnored: Number.isFinite(holidaySyncLastRun.totalIgnored)
+          ? Number(holidaySyncLastRun.totalIgnored)
+          : null,
         error: typeof holidaySyncLastRun.error === 'string' ? holidaySyncLastRun.error : null,
       }
     : null
@@ -9592,7 +9656,7 @@ async function loadHoliday(db, orgId, workDate) {
   const targetOrg = orgId || DEFAULT_ORG_ID
   try {
     const rows = await db.query(
-      `SELECT id, org_id, holiday_date, name, is_working_day
+      `SELECT id, org_id, holiday_date, name, is_working_day, origin
        FROM attendance_holidays
        WHERE org_id = $1 AND holiday_date = $2
        LIMIT 1`,
@@ -9928,7 +9992,7 @@ async function loadHolidayMapByDates(db, orgId, workDates) {
   if (!Array.isArray(workDates) || workDates.length === 0) return new Map()
   try {
     const rows = await db.query(
-      `SELECT id, org_id, holiday_date, name, is_working_day
+      `SELECT id, org_id, holiday_date, name, is_working_day, origin
        FROM attendance_holidays
        WHERE org_id = $1 AND holiday_date = ANY($2::date[])`,
       [targetOrg, workDates]
@@ -11526,12 +11590,16 @@ function scheduleHolidaySync({ db, logger, emit }) {
           years: result.years,
           totalFetched: result.totalFetched,
           totalApplied: result.totalApplied,
+          totalSkipped: result.totalSkipped,
+          totalIgnored: result.totalIgnored,
         })
         logger.info('Auto holiday sync completed', {
           orgId,
           years: result.years,
           totalFetched: result.totalFetched,
           totalApplied: result.totalApplied,
+          totalSkipped: result.totalSkipped,
+          totalIgnored: result.totalIgnored,
         })
       }
     } catch (error) {
@@ -11868,6 +11936,8 @@ module.exports = {
           years: z.array(z.number().int()).optional(),
           totalFetched: z.number().optional(),
           totalApplied: z.number().optional(),
+          totalSkipped: z.number().optional(),
+          totalIgnored: z.number().optional(),
           error: z.string().optional(),
         }).nullable().optional(),
       }).optional(),
@@ -23561,7 +23631,7 @@ module.exports = {
           const total = Number(countRows[0]?.total ?? 0)
 
           const rows = await db.query(
-            `SELECT id, org_id, holiday_date, name, is_working_day
+            `SELECT id, org_id, holiday_date, name, is_working_day, origin
              FROM attendance_holidays
              WHERE org_id = $1 AND holiday_date BETWEEN $2 AND $3
              ORDER BY holiday_date ASC`,
@@ -23618,7 +23688,7 @@ module.exports = {
 
         try {
           const rows = await db.query(
-            'SELECT id, org_id, holiday_date, name, is_working_day FROM attendance_holidays WHERE id = $1 AND org_id = $2',
+            'SELECT id, org_id, holiday_date, name, is_working_day, origin FROM attendance_holidays WHERE id = $1 AND org_id = $2',
             [holidayId, orgId]
           )
           if (!rows.length) {
@@ -23651,7 +23721,7 @@ module.exports = {
         const years = resolveHolidaySyncYears(settings, parsed.data)
 
         try {
-          const { syncConfig, totalFetched, totalApplied, results, lastRun } = await performHolidaySync({
+          const { syncConfig, totalFetched, totalApplied, totalSkipped, totalIgnored, results, lastRun } = await performHolidaySync({
             db,
             logger,
             orgId,
@@ -23672,6 +23742,8 @@ module.exports = {
               overwrite: syncConfig.overwrite,
               totalFetched,
               totalApplied,
+              totalSkipped,
+              totalIgnored,
               results,
               lastRun,
             },
@@ -23683,6 +23755,8 @@ module.exports = {
             years,
             totalFetched: 0,
             totalApplied: 0,
+            totalSkipped: 0,
+            totalIgnored: 0,
             error: error instanceof Error ? error.message : 'Holiday sync failed',
           }
           try {
@@ -23718,9 +23792,9 @@ module.exports = {
           const payload = resolveHolidayWritePayload(parsed.data)
           const rows = await db.query(
             `INSERT INTO attendance_holidays
-             (id, org_id, holiday_date, name, is_working_day)
-             VALUES ($1, $2, $3, $4, $5)
-             RETURNING id, org_id, holiday_date, name, is_working_day`,
+             (id, org_id, holiday_date, name, is_working_day, origin)
+             VALUES ($1, $2, $3, $4, $5, 'manual')
+             RETURNING id, org_id, holiday_date, name, is_working_day, origin`,
             [
               randomUUID(),
               orgId,
@@ -23766,7 +23840,7 @@ module.exports = {
 
         try {
           const existingRows = await db.query(
-            'SELECT id, org_id, holiday_date, name, is_working_day FROM attendance_holidays WHERE id = $1 AND org_id = $2',
+            'SELECT id, org_id, holiday_date, name, is_working_day, origin FROM attendance_holidays WHERE id = $1 AND org_id = $2',
             [holidayId, orgId]
           )
           if (!existingRows.length) {
@@ -23784,7 +23858,7 @@ module.exports = {
                  is_working_day = $5,
                  updated_at = now()
              WHERE id = $1 AND org_id = $2
-             RETURNING id, org_id, holiday_date, name, is_working_day`,
+             RETURNING id, org_id, holiday_date, name, is_working_day, origin`,
             [holidayId, orgId, payload.date, payload.name, payload.isWorkingDay]
           )
 


### PR DESCRIPTION
## Summary
- add attendance_holidays.origin with national/manual values and manual default
- make holiday sync write national rows only while protecting manual/admin rows
- expose totalSkipped/totalIgnored in sync response, results, scheduler event, and lastRun
- add DB-backed integration coverage for manual conflict, national update, overwrite=false, deleted-manual reinsert, and default-manual backfill

## Verification
- pnpm --filter @metasheet/core-backend test:unit
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/core-backend exec tsc -p tsconfig.json --noEmit
- node --check plugins/plugin-attendance/index.cjs
- ATTENDANCE_TEST_DATABASE_URL=postgresql://127.0.0.1:5432/<scratch-db> DATABASE_URL=postgresql://127.0.0.1:5432/<scratch-db> pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "protects manual holiday origins" --reporter=verbose
- git diff --check

DB gate passed on scratch PostgreSQL 15.17; see docs/development/attendance-holidays-origin-sync-protection-verification-20260520.md.

## Docs
- docs/development/attendance-holidays-origin-sync-protection-development-20260520.md
- docs/development/attendance-holidays-origin-sync-protection-verification-20260520.md