### PR TITLE
fix(onprem): self-bootstrap launcher avoids stale apply on first run (#1526)

### DIFF
--- a/docs/development/onprem-apply-self-bootstrap-launcher-design-20260520.md
+++ b/docs/development/onprem-apply-self-bootstrap-launcher-design-20260520.md
@@ -1,0 +1,122 @@
+# On-prem apply self-bootstrap launcher - design - 2026-05-20
+
+## Problem (from the 2026-05-20 bridge feedback on #1526)
+
+The 3e76aa7c6 package (which contains the #1696 env-loading fix) deployed
+PASS on its **second** `official apply`. The **first** apply still
+executed the stale apply helper already installed in the root - because
+`deploy.bat` invokes
+`%~dp0scripts\ops\multitable-onprem-apply-package.ps1`, which is the
+helper present **before** the new package contents land on disk. The new
+helper only arrives after the running apply finishes its
+extraction+copy step, so on an upgrade from a broken or older helper the
+first apply is always running stale code. Operators have to rerun apply
+("first fails, second succeeds").
+
+## Fix: self-bootstrapping launcher
+
+Insert a small, stable launcher between `deploy.bat` and the apply
+helper. `deploy.bat` now invokes
+`scripts/ops/multitable-onprem-deploy-launcher.ps1`. The launcher:
+
+1. extracts the supplied package archive into a fresh temp staging dir
+   (Expand-Archive for .zip, `tar -xzf` for .tgz / .tar.gz);
+2. locates the staged package root (preferring a directory named
+   `metasheet-multitable-onprem-*` for safety);
+3. resolves the staged apply helper at
+   `<staged>\scripts\ops\multitable-onprem-apply-package.ps1`;
+4. invokes it with `-RootDir <installed-root> -PackageArchive <orig>`,
+   so apply runs from the **freshest** helper but writes into the
+   **same installed root** that deploy.bat targets;
+5. cleans up the staging directory and propagates the apply exit code.
+
+Result: on any upgrade where the installed `deploy.bat` is `>=` this PR,
+the first apply uses the apply helper inside the supplied package -
+even if the helper sitting in the installed root is older or broken.
+
+This is intentionally a *forward* fix. The literal upgrade from a
+pre-this-PR install still goes through the old `deploy.bat` -> old
+apply.ps1 once, lands the new files (including the new launcher and
+the new deploy.bat), and from then on every upgrade is first-apply
+correct.
+
+## Why launcher (extract-first) and not self-refresh (copy-files-first)
+
+A self-refresh approach (deploy.bat copies just the new apply.ps1 from
+the package into the installed root before invoking it) was considered
+and rejected:
+
+- self-refresh has its own chicken-and-egg: the OLD `deploy.bat` is
+  still the one running on a stale install, so the OLD copy-files
+  logic is what executes. Whatever invariant we want to establish at
+  the top of the chain must live in `deploy.bat` itself.
+- self-refresh leaves a partially-overwritten installed root if it
+  fails mid-copy (e.g., one file replaced, helpers not), which is
+  harder to recover from than a self-contained staging directory the
+  launcher always wipes.
+- the launcher does *not* mutate the installed root - it only stages
+  to a temp dir and invokes apply. apply continues to do the
+  copy-into-root step exactly as before, so on success the installed
+  root ends up in the same shape today's apply produces, with no new
+  partial-write states to worry about.
+
+## What the launcher does not do
+
+- It does not load env (still apply.ps1's job - #1696).
+- It does not run migrations (apply.ps1).
+- It does not start PM2 (apply.ps1 -> attendance-onprem-start-pm2.ps1).
+- It does not touch the DB.
+- It does not call any K3 endpoint.
+- It does not run dependency-refresh; the staged apply.ps1 still
+  generates and runs the dependency-refresh wrapper exactly as #1684
+  established.
+
+## #1684 / #1696 preserved (diff scope)
+
+This PR adds one new file
+(`scripts/ops/multitable-onprem-deploy-launcher.ps1`), adds two lines
+to the build script (REQUIRED_PATHS + the INSTALL.txt note), rewrites
+the build script's `deploy.bat` heredoc to call the launcher, and
+adjusts the package verifier. **No line of
+`multitable-onprem-apply-package.ps1` is changed.** The #1684
+dependency-refresh wrapper + exit-marker behavior and the #1696 env
+loader behavior are inherited unchanged when the staged apply.ps1
+runs.
+
+## Package verifier gate (lock-safe ops hygiene)
+
+`verify_windows_entrypoints` is updated:
+
+- the previous "deploy.bat must call apply-package.ps1" assertion
+  becomes "deploy.bat must call deploy-launcher.ps1" (the launcher is
+  now the canonical PS entry point);
+- a new positive assertion ensures `deploy.bat` does NOT call the
+  apply helper directly (a stale build that bypasses the launcher
+  would fail verify);
+- the launcher file must exist in the package;
+- the launcher must contain the self-identification marker
+  `[multitable-onprem-deploy-launcher]`, the `Expand-StagingArchive`
+  and `Resolve-StagedPackageRoot` function names, the reference to
+  the staged `multitable-onprem-apply-package.ps1`, and the staging
+  cleanup `Remove-Item -LiteralPath $stage`.
+
+This proves at build/verify time that an attempt to ship a stale
+package without the launcher fix would die() in CI rather than reach
+an operator's machine.
+
+## Out of scope (deliberate)
+
+- No change to `plugin-integration-core` runtime.
+- No SQL Server / TLS failure summarization (separate #1526 actionable).
+- No K3 Save / Submit / Audit behavior change.
+- No customer GATE lifted. This PR removes the "first apply uses
+  stale helper" failure mode; it does not unblock live PoC.
+
+## Files touched
+
+- `scripts/ops/multitable-onprem-deploy-launcher.ps1` (new)
+- `scripts/ops/multitable-onprem-package-build.sh`
+  (REQUIRED_PATHS entry + deploy.bat heredoc + INSTALL.txt note)
+- `scripts/ops/multitable-onprem-package-verify.sh`
+  (verify_windows_entrypoints assertions)
+- this design MD + companion verification MD

--- a/docs/development/onprem-apply-self-bootstrap-launcher-verification-20260520.md
+++ b/docs/development/onprem-apply-self-bootstrap-launcher-verification-20260520.md
@@ -1,0 +1,129 @@
+# On-prem apply self-bootstrap launcher - verification - 2026-05-20
+
+Companion to `onprem-apply-self-bootstrap-launcher-design-20260520.md`.
+Ops only: build script + verify script + a new self-contained launcher
+ps1; no `plugin-integration-core`, no DB migration, no API runtime, no
+route.
+
+## Local evidence
+
+### 1. Syntax
+
+```text
+bash -n scripts/ops/multitable-onprem-package-build.sh   -> exit 0
+bash -n scripts/ops/multitable-onprem-package-verify.sh  -> exit 0
+```
+
+`pwsh` is not installed on this dev host; the launcher's PowerShell
+parse will be exercised on Windows-side CI / on-prem apply.
+
+### 2. Positive markers inside the new launcher
+
+```text
+[multitable-onprem-deploy-launcher]         -> 1 occurrence
+Expand-StagingArchive                       -> 2 (definition + call)
+Resolve-StagedPackageRoot                   -> 2 (definition + call)
+multitable-onprem-apply-package.ps1         -> 2 (Join-Path + reference)
+Remove-Item -LiteralPath $stage             -> 1 (finally cleanup)
+```
+
+### 3. Negative proof: pre-fix package fails on the new gate
+
+Took the previous (pre-launcher) zip already sitting in
+`output/releases/multitable-onprem/`:
+
+```text
+metasheet-multitable-onprem-v2.5.0-20260519-191605.zip
+  (built from origin/main without this PR; contains the #1696 env-loading
+   fix but no launcher and no launcher reference in deploy.bat)
+
+bash scripts/ops/multitable-onprem-package-verify.sh <that pre-fix zip>
+  -> [multitable-onprem-package-verify] ERROR: deploy.bat must call the
+     self-bootstrapping PowerShell launcher (multitable-onprem-deploy-launcher.ps1)
+     so first apply on an upgrade uses the freshest apply helper from the
+     supplied package
+```
+
+The new gate dies with the exact intended message. It is a real gate,
+not a no-op.
+
+### 4. End-to-end: build the new package and re-verify
+
+```text
+BUILD_WEB=1 BUILD_BACKEND=1 INSTALL_DEPS=0 \
+  bash scripts/ops/multitable-onprem-package-build.sh
+  -> exit 0; produced metasheet-multitable-onprem-v2.5.0-20260519-200530.zip
+
+bash scripts/ops/multitable-onprem-package-verify.sh <new zip>
+  -> "Package verify OK", exit 0
+```
+
+### 5. Tar-branch coverage note
+
+The launcher handles both `.zip` (`Expand-Archive`) and `.tgz` /
+`.tar.gz` (`tar -xzf`). The end-to-end + negative-proof tests above
+exercise the `.zip` branch; the `tar` branch is exercised
+structurally by the same build (which produces both `.tgz` and
+`.zip` archives) and by the same launcher file shipping with the
+package, but no live tgz extraction was driven from this dev host.
+The tar code is six lines of standard PowerShell relying on the
+Windows-10+ built-in `tar.exe`; review-time scrutiny of that branch
+is intentional rather than test-skipped.
+
+### 6. Bundled artifacts (smoke-look at the produced zip)
+
+After extracting the new zip:
+
+- `deploy.bat` now begins with the explanatory comment block and ends
+  with the `powershell ... multitable-onprem-deploy-launcher.ps1`
+  invocation (no direct apply.ps1 call), matching the design.
+- `scripts/ops/multitable-onprem-deploy-launcher.ps1` is present.
+- `scripts/ops/multitable-onprem-apply-package.ps1` is untouched
+  compared to origin/main (diff confirmed by code review; this PR
+  doesn't modify the apply helper at all).
+
+## Acceptance criteria mapped to evidence
+
+| Criterion | Evidence |
+| --- | --- |
+| First apply uses new package's apply.ps1 (or self-refreshes) | `deploy.bat` calls `multitable-onprem-deploy-launcher.ps1`; the launcher extracts the supplied package to staging temp and invokes the staged `multitable-onprem-apply-package.ps1` with `-RootDir = installed root` |
+| Preserve #1684 dependency-refresh wrapper | `multitable-onprem-apply-package.ps1` not touched by this PR; the staged apply helper is the one already containing #1684 logic |
+| Preserve #1696 env loading | Same: apply.ps1 not modified; env loading runs inside the staged apply |
+| package verify detects launcher / self-refresh behavior | `verify_windows_entrypoints` updated: deploy.bat must reference the launcher, must NOT call apply directly, launcher file must exist + contain self-id + extract / resolve / invoke / cleanup markers. Real-gate negative proven on a pre-fix zip |
+| design MD + verification MD produced | this PR |
+
+## Deployment impact
+
+- The first upgrade from a pre-this-PR install still routes through
+  the OLD `deploy.bat` -> OLD apply.ps1 once (unchanged by this PR -
+  cannot retroactively rewrite already-shipped artifacts). After
+  that single landing of new files, every subsequent upgrade enters
+  through the new `deploy.bat` -> new launcher -> staged apply.
+- **The launcher file lands in the installed root as part of the
+  first apply's normal copy step**, no extra logic required.
+  Confirmed: apply.ps1's copy step (lines 466-468) iterates the
+  top-level items of the extracted package
+  (`Get-ChildItem ... -Force`) and runs `Copy-Item -Recurse -Force`
+  on each into the installed root, with no exclusion list. The
+  `scripts/` directory is one of those top-level items, and
+  `scripts/ops/multitable-onprem-deploy-launcher.ps1` rides in with
+  it. Verified by extracting the freshly-built zip and locating the
+  file at the expected path.
+- No env, no migration, no flag, no route, no bundle behavior
+  change. The launcher writes only to a fresh temp staging dir and
+  cleans it up on exit.
+
+## GATE-blocking status
+
+This PR does **not** lift the customer GATE. It removes the first-run
+self-overwrite failure mode so future official applies do not need a
+manual rerun. SQL/TLS failure summarization and K3 Save / Submit /
+Audit are explicitly out of scope and unchanged.
+
+## Rollback
+
+Revert the PR. The launcher file goes away; the build script's
+`deploy.bat` reverts to its previous form; verify-script reverts to
+the previous assertions. The two existing apply helpers
+(`multitable-onprem-apply-package.ps1`) are untouched, so there is no
+behavioral rollback to manage.

--- a/scripts/ops/multitable-onprem-deploy-launcher.ps1
+++ b/scripts/ops/multitable-onprem-deploy-launcher.ps1
@@ -1,0 +1,138 @@
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$PackageArchive,
+  [string]$RootDir = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path
+)
+
+$ErrorActionPreference = 'Stop'
+
+# multitable-onprem-deploy-launcher.ps1
+#
+# Self-bootstrapping launcher for the Windows on-prem apply path.
+#
+# Why this exists: before this launcher, deploy.bat invoked the
+# multitable-onprem-apply-package.ps1 sitting in the already-installed root.
+# When upgrading from an older install whose apply helper had a bug, the
+# first apply would still execute the stale helper because the new package
+# contents only land on disk *after* extraction inside the running apply.
+# Operators had to rerun apply ("first fails, second succeeds").
+#
+# This launcher closes that gap. deploy.bat now calls THIS file, which:
+#   1. extracts the supplied package archive into a temp staging directory,
+#   2. locates the apply helper *inside the staged extraction*,
+#   3. invokes that newest apply helper with -RootDir = installed root,
+#   4. cleans up staging on exit and propagates the apply exit code.
+#
+# The launcher is intentionally small and self-contained. It does not load
+# env, does not touch DB, does not call PM2. It is the bootstrap step only.
+# All migration / dependency-refresh / PM2 / healthcheck behavior continues
+# to live in the staged apply helper (including #1684 wrapper / exit-marker
+# and #1696 env loading).
+
+function Write-LauncherInfo {
+  param([string]$Message)
+  Write-Output ("[multitable-onprem-deploy-launcher] {0}" -f $Message)
+}
+
+function Resolve-LauncherPath {
+  param([string]$Candidate, [string]$Label)
+
+  $trimmed = $Candidate.Trim().Trim('"')
+  if ([string]::IsNullOrWhiteSpace($trimmed)) {
+    throw "$Label is empty after normalization"
+  }
+  if (-not (Test-Path -LiteralPath $trimmed)) {
+    throw "$Label not found: $trimmed"
+  }
+  return (Resolve-Path -LiteralPath $trimmed).Path
+}
+
+function New-StagingDirectory {
+  $base = if ($env:TEMP) { $env:TEMP } else { [System.IO.Path]::GetTempPath() }
+  $name = 'msdl-' + ([System.Guid]::NewGuid().ToString('N').Substring(0, 8))
+  $path = Join-Path $base $name
+  New-Item -ItemType Directory -Path $path -Force | Out-Null
+  return (Resolve-Path -LiteralPath $path).Path
+}
+
+function Expand-StagingArchive {
+  param([string]$Archive, [string]$Stage)
+
+  $lower = $Archive.ToLowerInvariant()
+  if ($lower.EndsWith('.zip')) {
+    Write-LauncherInfo "Extracting zip via Expand-Archive"
+    Expand-Archive -LiteralPath $Archive -DestinationPath $Stage -Force
+    return
+  }
+
+  if ($lower.EndsWith('.tgz') -or $lower.EndsWith('.tar.gz')) {
+    if (-not (Get-Command tar -ErrorAction SilentlyContinue)) {
+      throw "tar command is required to extract tgz/tar.gz archives"
+    }
+    Write-LauncherInfo "Extracting tar archive via tar -xzf"
+    & tar -xzf $Archive -C $Stage
+    if ($LASTEXITCODE -ne 0) {
+      throw "tar extraction failed with exit code $LASTEXITCODE"
+    }
+    return
+  }
+
+  throw "Unsupported package extension (expected .zip, .tgz, or .tar.gz): $Archive"
+}
+
+function Resolve-StagedPackageRoot {
+  param([string]$Stage)
+
+  $children = Get-ChildItem -LiteralPath $Stage -Directory -ErrorAction Stop
+  if ($null -eq $children -or @($children).Count -lt 1) {
+    throw "No package root directory found inside staging extraction at $Stage"
+  }
+
+  $preferred = @($children) | Where-Object { $_.Name -like 'metasheet-multitable-onprem-*' } | Select-Object -First 1
+  if ($null -ne $preferred) {
+    return $preferred.FullName
+  }
+  return @($children)[0].FullName
+}
+
+$resolvedArchive = Resolve-LauncherPath -Candidate $PackageArchive -Label 'PackageArchive'
+$resolvedRoot = Resolve-LauncherPath -Candidate $RootDir -Label 'RootDir'
+
+Write-LauncherInfo "Package archive: $resolvedArchive"
+Write-LauncherInfo "Install root:    $resolvedRoot"
+
+$stage = New-StagingDirectory
+$launcherExit = 1
+try {
+  Write-LauncherInfo "Staging extraction root: $stage"
+  Expand-StagingArchive -Archive $resolvedArchive -Stage $stage
+
+  $packageRoot = Resolve-StagedPackageRoot -Stage $stage
+  Write-LauncherInfo "Staged package root: $packageRoot"
+
+  $stagedApply = Join-Path $packageRoot 'scripts\ops\multitable-onprem-apply-package.ps1'
+  if (-not (Test-Path -LiteralPath $stagedApply)) {
+    throw "Staged package does not contain apply helper at $stagedApply"
+  }
+  Write-LauncherInfo "Invoking staged apply helper: $stagedApply"
+
+  try {
+    & $stagedApply -RootDir $resolvedRoot -PackageArchive $resolvedArchive
+    if ($null -ne $LASTEXITCODE) {
+      $launcherExit = $LASTEXITCODE
+    } else {
+      $launcherExit = 0
+    }
+  }
+  catch {
+    Write-LauncherInfo ("Apply helper raised an error: {0}" -f $_.Exception.Message)
+    $launcherExit = 1
+  }
+}
+finally {
+  if (Test-Path -LiteralPath $stage) {
+    Remove-Item -LiteralPath $stage -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}
+
+exit $launcherExit

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -52,6 +52,7 @@ REQUIRED_PATHS=(
   "scripts/ops/multitable-onprem-deploy-easy.sh"
   "scripts/ops/multitable-onprem-apply-package.sh"
   "scripts/ops/multitable-onprem-apply-package.ps1"
+  "scripts/ops/multitable-onprem-deploy-launcher.ps1"
   "scripts/ops/multitable-onprem-package-install.sh"
   "scripts/ops/multitable-onprem-package-upgrade.sh"
   "scripts/ops/multitable-onprem-healthcheck.sh"
@@ -204,7 +205,12 @@ if "%~1"=="" (
   echo Usage: deploy.bat ^<package.zip^|package.tgz^>
   exit /b 64
 )
-powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\ops\multitable-onprem-apply-package.ps1" -RootDir "%~dp0." -PackageArchive "%~1"
+REM Call the self-bootstrapping launcher so the FIRST apply on an upgrade uses
+REM the freshest apply helper from inside the supplied package, not the stale
+REM helper sitting in the installed root. The launcher extracts to a staging
+REM temp dir, locates the staged apply helper, and invokes it with this
+REM installed root as -RootDir. See multitable-onprem-deploy-launcher.ps1.
+powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\ops\multitable-onprem-deploy-launcher.ps1" -RootDir "%~dp0." -PackageArchive "%~1"
 exit /b %ERRORLEVEL%
 EOF
 
@@ -411,6 +417,11 @@ Server-side apply helpers:
   deploy-${PACKAGE_RUN_LABEL}.bat <package.zip|package.tgz>
   bootstrap-admin.bat <admin-email> <admin-password> [admin-name]
   bootstrap-admin-${PACKAGE_RUN_LABEL}.bat <admin-email> <admin-password> [admin-name]
+
+deploy.bat now calls scripts/ops/multitable-onprem-deploy-launcher.ps1 first,
+which extracts the supplied package to a staging temp dir and invokes the
+apply helper *from inside the new package*. This avoids the prior
+"first apply uses the stale installed helper" issue on upgrades.
 
 K3 WISE PoC operator tools (Node only; no Docker needed to run these):
   Runtime plugin:

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -40,13 +40,27 @@ function verify_windows_entrypoints() {
   local remote_script="${root}/deploy-remote.bat"
   local bootstrap_script="${root}/bootstrap-admin.bat"
 
-  if ! search_fixed_string 'multitable-onprem-apply-package.ps1' "$start_script"; then
-    die "deploy.bat must call the PowerShell-native multitable apply helper"
+  if ! search_fixed_string 'multitable-onprem-deploy-launcher.ps1' "$start_script"; then
+    die "deploy.bat must call the self-bootstrapping PowerShell launcher (multitable-onprem-deploy-launcher.ps1) so first apply on an upgrade uses the freshest apply helper from the supplied package"
   fi
 
   if search_fixed_string 'multitable-onprem-apply-package.sh' "$start_script"; then
     die "deploy.bat must not require bash or the .sh apply helper"
   fi
+
+  if search_fixed_string 'multitable-onprem-apply-package.ps1' "$start_script"; then
+    die "deploy.bat must not call the apply helper directly; it must go through the launcher so a stale installed apply helper cannot win on first apply"
+  fi
+
+  local launcher_helper="${root}/scripts/ops/multitable-onprem-deploy-launcher.ps1"
+  if [[ ! -f "$launcher_helper" ]]; then
+    die "PowerShell launcher script must be packaged for deploy.bat self-bootstrap"
+  fi
+  search_fixed_string '[multitable-onprem-deploy-launcher]' "$launcher_helper" || die "launcher must self-identify in its logs"
+  search_fixed_string 'Expand-StagingArchive' "$launcher_helper" || die "launcher must extract the supplied package into a staging directory before invoking the apply helper"
+  search_fixed_string 'Resolve-StagedPackageRoot' "$launcher_helper" || die "launcher must resolve the staged package root before invoking the apply helper"
+  search_fixed_string 'multitable-onprem-apply-package.ps1' "$launcher_helper" || die "launcher must invoke the staged apply helper from inside the extracted package"
+  search_fixed_string 'Remove-Item -LiteralPath $stage' "$launcher_helper" || die "launcher must clean up staging extraction on exit"
 
   local apply_helper="${root}/scripts/ops/multitable-onprem-apply-package.ps1"
   search_fixed_string 'Refresh dependencies (cmd.exe /c pnpm install --frozen-lockfile)' "$apply_helper" || die "PowerShell apply helper must refresh dependencies on package apply through cmd.exe"


### PR DESCRIPTION
## 修的是什么
3e76aa7c6 包第二次 apply 已 PASS,**第一次 apply 仍跑陈旧的已安装 apply.ps1**——因为 `deploy.bat` 调用 `%~dp0scripts\ops\multitable-onprem-apply-package.ps1`(installed root 里的旧 helper);新 helper 要等当前 apply 自己 extract+copy 完成后才落盘。结果:升级时永远是"first fails, second succeeds"。

## 怎么修(launcher 模式,非 self-refresh)
新增 `scripts/ops/multitable-onprem-deploy-launcher.ps1`,小而自洽:
1. extract 传入的包到 `$TEMP\msdl-<short-guid>` staging
2. 定位 staging 包根(优先 `metasheet-multitable-onprem-*`)
3. 用 `& <staged>\scripts\ops\multitable-onprem-apply-package.ps1 -RootDir <installed-root> -PackageArchive <orig>` 调用 staging 里的最新 apply
4. `finally` 清理 staging,返回 apply 退出码

`deploy.bat` 改为调 launcher。**`multitable-onprem-apply-package.ps1` 0 改动** —— #1684 dependency-refresh wrapper 与 #1696 env loading 全部继承自 staged apply。

## 为什么不是 self-refresh
self-refresh(先 copy 新 apply.ps1 进 root,再调它)还是**同样的 chicken-and-egg**:OLD `deploy.bat` 的"copy-which-files"逻辑也是旧的。要在调用链顶部建立不变量,必须在 `deploy.bat` 自己里实现。launcher 完全不动 installed root,只用 temp staging,出错也不会留半新半旧的 root。

## 前向 fix(必须 acknowledge)
从 pre-this-PR 装的实体机第一次升级仍走旧 deploy.bat → 旧 apply.ps1 一次 —— 无法追溯修改已发出的包。但 apply.ps1 拷贝步骤(:466-468)是 `Get-ChildItem | Copy-Item -Recurse -Force`,无 exclusion,所以 `scripts/ops/multitable-onprem-deploy-launcher.ps1` 跟着 `scripts/` 一起落盘到 root。**从此次升级起,后续每次都首次 apply 即新**。

## Package-verify gate 全面升级
`verify_windows_entrypoints` 现要求:
- `deploy.bat` 引用 `multitable-onprem-deploy-launcher.ps1`
- `deploy.bat` **不**直接调用 apply.ps1(防绕过 launcher 的退化包)
- launcher 文件存在
- launcher 含自标识 `[multitable-onprem-deploy-launcher]` + `Expand-StagingArchive` + `Resolve-StagedPackageRoot` + 引用 apply.ps1 + `Remove-Item -LiteralPath $stage` 清理段
- #1684 / #1696 所有既有断言保留

## 本地证据
| 检查 | 结果 |
|---|---|
| `bash -n` build.sh + verify.sh | OK |
| launcher 内 5 个 marker | 全部 ≥1 次出现 |
| **NEGATIVE**: 用新 verify 跑预存的 pre-launcher zip | DIE 在精确文案:`deploy.bat must call the self-bootstrapping PowerShell launcher (multitable-onprem-deploy-launcher.ps1)...` —— 真闸门 |
| `BUILD_WEB=1 BUILD_BACKEND=1 package-build.sh` | exit 0,产出 zip/tgz |
| 修改后 verify 对产出 zip | **Package verify OK**,exit 0 |
| 产出 zip 内 `deploy.bat` | 含 launcher 注释块 + launcher 调用,**不**含直接 apply.ps1 调用 |
| 产出 zip 内 launcher 文件 | 存在 |
| apply.ps1 拷贝步行为(:466-468) | `Get-ChildItem | Copy-Item -Recurse -Force`,无 exclusion → launcher 必随 `scripts/` 落盘 |
| pwsh 本地解析 | 跳过(dev 机无 pwsh,已声明) |

## 范围与红线
- **仅 ops/deploy/package verify/docs**;5 文件 +417/-3。
- **未触** `plugin-integration-core` runtime;无 DB migration;无 API runtime;无 route 变更。
- **不解除客户 GATE**;不做 SQL/TLS 摘要;不动 K3 Save/Submit/Audit。
- `multitable-onprem-apply-package.ps1` 完全未改 —— `git diff origin/main -- scripts/ops/multitable-onprem-apply-package.ps1` 空。

## 透明披露(本次操作过程)
合并前坦诚说明:本仓库存在并行 Claude session,首次提交意外落到他们的工作分支(parallel-session worktree hazard,我的 memory 里记录的)。已通过隔离 git worktree + cherry-pick 同一 SHA 内容到本恢复分支(`codex/onprem-apply-self-bootstrap-launcher-recovery-20260520`)。文件字节与 review 文档对应一致。

## Test plan
- [ ] CI pr-validate
- [ ] Codex review:确认 launcher 设计、apply.ps1 0 行改动、verify gate 真实有效、前向 fix 表述准确
- [ ] 合并 → 官方 Multitable On-Prem Package Build → 实体机下次升级一次走完,无需 rerun

🤖 Generated with [Claude Code](https://claude.com/claude-code)