### PR TITLE
feat(multitable): localize link picker chrome

### DIFF
--- a/apps/web/src/multitable/components/MetaLinkPicker.vue
+++ b/apps/web/src/multitable/components/MetaLinkPicker.vue
@@ -3,15 +3,15 @@
     <div class="meta-link-picker" @keydown.esc.stop.prevent="emit('close')" @keydown.enter.stop.prevent="onConfirm">
       <div class="meta-link-picker__header">
         <h4 class="meta-link-picker__title">{{ titleText }}</h4>
-        <button class="meta-link-picker__close" @click="emit('close')">&times;</button>
+        <button class="meta-link-picker__close" :aria-label="lp('linkPicker.close')" @click="emit('close')">&times;</button>
       </div>
       <div class="meta-link-picker__search">
         <input v-model="search" class="meta-link-picker__input" :placeholder="searchPlaceholder" @input="onSearch" />
       </div>
       <div v-if="selectedSummaries.length" class="meta-link-picker__selected">
         <div class="meta-link-picker__selected-header">
-          <span class="meta-link-picker__selected-label">Selected</span>
-          <button class="meta-link-picker__clear" @click="clearSelection">Clear</button>
+          <span class="meta-link-picker__selected-label">{{ lp('linkPicker.selected') }}</span>
+          <button class="meta-link-picker__clear" @click="clearSelection">{{ lp('linkPicker.clear') }}</button>
         </div>
         <div class="meta-link-picker__chips">
           <span v-for="item in selectedSummaries" :key="item.id" class="meta-link-picker__chip">
@@ -21,22 +21,22 @@
         </div>
       </div>
       <div class="meta-link-picker__body">
-        <div v-if="loading" class="meta-link-picker__loading">Loading...</div>
+        <div v-if="loading" class="meta-link-picker__loading">{{ lp('linkPicker.loading') }}</div>
         <div v-else-if="errorMessage" class="meta-link-picker__error">{{ errorMessage }}</div>
         <label v-for="rec in records" :key="rec.id" class="meta-link-picker__item">
           <input type="checkbox" :checked="selected.has(rec.id)" @change="toggleSelect(rec.id)" />
           <span>{{ rec.display || rec.id }}</span>
         </label>
-        <div v-if="!loading && !errorMessage && !records.length" class="meta-link-picker__empty">No records found</div>
+        <div v-if="!loading && !errorMessage && !records.length" class="meta-link-picker__empty">{{ lp('linkPicker.empty') }}</div>
         <button v-if="!loading && !errorMessage && hasMore" type="button" class="meta-link-picker__load-more" @click="loadMore">
-          Load more
+          {{ lp('linkPicker.loadMore') }}
         </button>
       </div>
       <div class="meta-link-picker__footer">
-        <span class="meta-link-picker__count">{{ selected.size }} selected</span>
+        <span class="meta-link-picker__count">{{ selectedCountText }}</span>
         <div class="meta-link-picker__actions">
-          <button class="meta-link-picker__cancel" @click="emit('close')">Cancel</button>
-          <button class="meta-link-picker__confirm" @click="onConfirm">Confirm</button>
+          <button class="meta-link-picker__cancel" @click="emit('close')">{{ lp('linkPicker.cancel') }}</button>
+          <button class="meta-link-picker__confirm" @click="onConfirm">{{ lp('linkPicker.confirm') }}</button>
         </div>
       </div>
     </div>
@@ -45,9 +45,15 @@
 
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type { LinkedRecordSummary, MetaField } from '../types'
 import { multitableClient } from '../api/client'
 import { linkPickerSearchPlaceholder, linkPickerTitle } from '../utils/link-fields'
+import {
+  linkPickerLabel,
+  selectedCount,
+  type MetaLinkPickerLabelKey,
+} from '../utils/meta-link-picker-labels'
 
 const props = defineProps<{
   visible: boolean
@@ -68,10 +74,13 @@ const errorMessage = ref('')
 const page = ref({ offset: 0, limit: 50, total: 0, hasMore: false })
 const selected = reactive(new Set<string>())
 const summaryById = reactive<Record<string, LinkedRecordSummary>>({})
+const { isZh } = useLocale()
+const lp = (key: MetaLinkPickerLabelKey) => linkPickerLabel(key, isZh.value)
 const singleSelect = computed(() => props.field?.property?.limitSingleRecord === true || props.field?.property?.refKind === 'user')
-const titleText = computed(() => linkPickerTitle(props.field))
-const searchPlaceholder = computed(() => linkPickerSearchPlaceholder(props.field))
+const titleText = computed(() => linkPickerTitle(props.field, isZh.value))
+const searchPlaceholder = computed(() => linkPickerSearchPlaceholder(props.field, isZh.value))
 const hasMore = computed(() => page.value.hasMore)
+const selectedCountText = computed(() => selectedCount(selected.size, isZh.value))
 
 watch(() => props.visible, async (visible) => {
   if (!visible) {
@@ -111,7 +120,7 @@ async function loadRecords(reset = false) {
     for (const record of data.records ?? []) summaryById[record.id] = record
   } catch (error: any) {
     if (reset) records.value = []
-    errorMessage.value = error?.message ?? 'Failed to load records'
+    errorMessage.value = error?.message ?? lp('linkPicker.errorLoad')
   } finally {
     loading.value = false
   }

--- a/apps/web/src/multitable/utils/link-fields.ts
+++ b/apps/web/src/multitable/utils/link-fields.ts
@@ -46,11 +46,14 @@ export function linkActionLabel(
   return `Choose ${linkEntityLabel(field)}...`
 }
 
-export function linkPickerTitle(field?: MetaField | null): string {
-  const prefix = isPersonField(field) ? 'Select People' : 'Link Records'
+export function linkPickerTitle(field?: MetaField | null, isZh: boolean = false): string {
+  const prefix = isPersonField(field)
+    ? (isZh ? '选择人员' : 'Select People')
+    : (isZh ? '选择关联记录' : 'Link Records')
   return field?.name ? `${prefix} — ${field.name}` : prefix
 }
 
-export function linkPickerSearchPlaceholder(field?: MetaField | null): string {
-  return isPersonField(field) ? 'Search people...' : 'Search records...'
+export function linkPickerSearchPlaceholder(field?: MetaField | null, isZh: boolean = false): string {
+  if (isPersonField(field)) return isZh ? '搜索人员...' : 'Search people...'
+  return isZh ? '搜索记录...' : 'Search records...'
 }

--- a/apps/web/src/multitable/utils/meta-link-picker-labels.ts
+++ b/apps/web/src/multitable/utils/meta-link-picker-labels.ts
@@ -1,0 +1,36 @@
+// Link picker modal chrome string table (T3B3).
+//
+// Scope: MetaLinkPicker.vue static UI only. Field names and linked-record
+// display values are user data and pass through unchanged.
+
+export type MetaLinkPickerLabelKey =
+  | 'linkPicker.selected'
+  | 'linkPicker.clear'
+  | 'linkPicker.loading'
+  | 'linkPicker.empty'
+  | 'linkPicker.loadMore'
+  | 'linkPicker.cancel'
+  | 'linkPicker.confirm'
+  | 'linkPicker.close'
+  | 'linkPicker.errorLoad'
+
+const META_LINK_PICKER_LABELS: Record<MetaLinkPickerLabelKey, { en: string; zh: string }> = {
+  'linkPicker.selected': { en: 'Selected', zh: '已选择' },
+  'linkPicker.clear': { en: 'Clear', zh: '清除' },
+  'linkPicker.loading': { en: 'Loading...', zh: '正在加载...' },
+  'linkPicker.empty': { en: 'No records found', zh: '未找到记录' },
+  'linkPicker.loadMore': { en: 'Load more', zh: '加载更多' },
+  'linkPicker.cancel': { en: 'Cancel', zh: '取消' },
+  'linkPicker.confirm': { en: 'Confirm', zh: '确认' },
+  'linkPicker.close': { en: 'Close link picker', zh: '关闭关联记录选择器' },
+  'linkPicker.errorLoad': { en: 'Failed to load records', zh: '加载记录失败' },
+}
+
+export function linkPickerLabel(key: MetaLinkPickerLabelKey, isZh: boolean): string {
+  const entry = META_LINK_PICKER_LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+export function selectedCount(count: number, isZh: boolean): string {
+  return isZh ? `已选择 ${count} 条` : `${count} selected`
+}

--- a/apps/web/tests/link-fields-i18n.spec.ts
+++ b/apps/web/tests/link-fields-i18n.spec.ts
@@ -1,5 +1,9 @@
 import { describe, it, expect } from 'vitest'
-import { linkActionLabel } from '../src/multitable/utils/link-fields'
+import {
+  linkActionLabel,
+  linkPickerSearchPlaceholder,
+  linkPickerTitle,
+} from '../src/multitable/utils/link-fields'
 import type { MetaField } from '../src/multitable/types'
 
 const personField: MetaField = { id: 'owner', name: 'Owner', type: 'person' as MetaField['type'] }
@@ -55,5 +59,33 @@ describe('linkActionLabel — zh forms (T3B1 opt-in)', () => {
   it('null/undefined field with zh still maps to the record branch', () => {
     expect(linkActionLabel(null, 0, true)).toBe('选择关联记录...')
     expect(linkActionLabel(undefined, 3, true)).toBe('编辑关联记录 (3)')
+  })
+})
+
+describe('link picker helper labels — T3B3', () => {
+  it('keeps picker title/search helpers English by default', () => {
+    expect(linkPickerTitle(recordField)).toBe('Link Records — Parent')
+    expect(linkPickerSearchPlaceholder(recordField)).toBe('Search records...')
+    expect(linkPickerTitle(personField)).toBe('Select People — Owner')
+    expect(linkPickerSearchPlaceholder(personField)).toBe('Search people...')
+  })
+
+  it('localizes picker title/search helpers when isZh=true', () => {
+    expect(linkPickerTitle(recordField, true)).toBe('选择关联记录 — Parent')
+    expect(linkPickerSearchPlaceholder(recordField, true)).toBe('搜索记录...')
+    expect(linkPickerTitle(personField, true)).toBe('选择人员 — Owner')
+    expect(linkPickerSearchPlaceholder(personField, true)).toBe('搜索人员...')
+  })
+
+  it('preserves field names raw in picker titles', () => {
+    const zhNamedRecordField: MetaField = { id: 'parent', name: '父级记录', type: 'link' as MetaField['type'] }
+    expect(linkPickerTitle(zhNamedRecordField, true)).toBe('选择关联记录 — 父级记录')
+    expect(linkPickerTitle(zhNamedRecordField, false)).toBe('Link Records — 父级记录')
+  })
+
+  it('falls back to the record branch when field is absent', () => {
+    expect(linkPickerTitle(null)).toBe('Link Records')
+    expect(linkPickerTitle(undefined, true)).toBe('选择关联记录')
+    expect(linkPickerSearchPlaceholder(null, true)).toBe('搜索记录...')
   })
 })

--- a/apps/web/tests/meta-link-picker-i18n.spec.ts
+++ b/apps/web/tests/meta-link-picker-i18n.spec.ts
@@ -1,0 +1,176 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
+import MetaLinkPicker from '../src/multitable/components/MetaLinkPicker.vue'
+
+const { mockListLinkOptions } = vi.hoisted(() => ({
+  mockListLinkOptions: vi.fn(),
+}))
+
+vi.mock('../src/multitable/api/client', () => ({
+  multitableClient: {
+    listLinkOptions: mockListLinkOptions,
+  },
+}))
+
+const linkField = {
+  id: 'fld_vendor',
+  name: 'Vendor',
+  type: 'link',
+}
+
+const personField = {
+  id: 'fld_owner',
+  name: 'Owner',
+  type: 'link',
+  property: {
+    refKind: 'user',
+    limitSingleRecord: true,
+  },
+}
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  app?.unmount()
+  app = null
+  container?.remove()
+  container = null
+  mockListLinkOptions.mockReset()
+  useLocale().setLocale('en')
+})
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let index = 0; index < cycles; index += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+async function mountPicker(props: Record<string, unknown> = {}) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+
+  const Harness = defineComponent({
+    setup() {
+      const visible = ref(false)
+      return {
+        visible,
+        onClose: () => {
+          visible.value = false
+        },
+      }
+    },
+    render() {
+      return h(MetaLinkPicker, {
+        visible: this.visible,
+        field: linkField,
+        currentValue: [],
+        onClose: this.onClose,
+        onConfirm: vi.fn(),
+        ...props,
+      })
+    },
+  })
+
+  app = createApp(Harness)
+  const vm = app.mount(container) as { visible: boolean }
+  vm.visible = true
+  await flushUi()
+  return container
+}
+
+describe('MetaLinkPicker i18n', () => {
+  it('renders zh-CN record-link chrome and preserves linked record display values raw', async () => {
+    useLocale().setLocale('zh-CN')
+    mockListLinkOptions.mockResolvedValue({
+      field: linkField,
+      targetSheet: { id: 'sheet_vendors', baseId: 'base_1', name: 'Vendors' },
+      selected: [{ id: 'vendor_1', display: 'Acme Supply' }],
+      records: [
+        { id: 'vendor_1', display: 'Acme Supply' },
+        { id: 'vendor_2', display: 'Beacon Labs' },
+      ],
+      page: { offset: 0, limit: 50, total: 2, hasMore: true },
+    })
+
+    const root = await mountPicker({ currentValue: ['vendor_1'] })
+    const text = root.textContent ?? ''
+
+    expect(text).toContain('选择关联记录 — Vendor')
+    expect(root.querySelector<HTMLInputElement>('.meta-link-picker__input')?.getAttribute('placeholder')).toBe('搜索记录...')
+    expect(root.querySelector<HTMLButtonElement>('.meta-link-picker__close')?.getAttribute('aria-label')).toBe('关闭关联记录选择器')
+    expect(text).toContain('已选择')
+    expect(text).toContain('清除')
+    expect(text).toContain('已选择 1 条')
+    expect(text).toContain('加载更多')
+    expect(text).toContain('取消')
+    expect(text).toContain('确认')
+    expect(text).toContain('Acme Supply')
+    expect(text).toContain('Beacon Labs')
+    expect(text).not.toContain('Selected')
+    expect(text).not.toContain('Load more')
+  })
+
+  it('renders zh-CN person picker title and search placeholder', async () => {
+    useLocale().setLocale('zh-CN')
+    mockListLinkOptions.mockResolvedValue({
+      field: personField,
+      targetSheet: { id: 'sheet_people', baseId: 'base_1', name: 'People' },
+      selected: [],
+      records: [{ id: 'user_1', display: 'Amy' }],
+      page: { offset: 0, limit: 50, total: 1, hasMore: false },
+    })
+
+    const root = await mountPicker({ field: personField })
+
+    expect(root.textContent ?? '').toContain('选择人员 — Owner')
+    expect(root.querySelector<HTMLInputElement>('.meta-link-picker__input')?.getAttribute('placeholder')).toBe('搜索人员...')
+  })
+
+  it('renders zh-CN empty and fallback error states', async () => {
+    useLocale().setLocale('zh-CN')
+    mockListLinkOptions.mockResolvedValueOnce({
+      field: linkField,
+      targetSheet: { id: 'sheet_vendors', baseId: 'base_1', name: 'Vendors' },
+      selected: [],
+      records: [],
+      page: { offset: 0, limit: 50, total: 0, hasMore: false },
+    })
+
+    let root = await mountPicker()
+    expect(root.textContent ?? '').toContain('未找到记录')
+    app?.unmount()
+    container?.remove()
+    app = null
+    container = null
+
+    mockListLinkOptions.mockRejectedValueOnce({})
+    root = await mountPicker()
+    expect(root.textContent ?? '').toContain('加载记录失败')
+  })
+
+  it('preserves English picker chrome as the default locale regression', async () => {
+    useLocale().setLocale('en')
+    mockListLinkOptions.mockResolvedValue({
+      field: linkField,
+      targetSheet: { id: 'sheet_vendors', baseId: 'base_1', name: 'Vendors' },
+      selected: [],
+      records: [],
+      page: { offset: 0, limit: 50, total: 0, hasMore: false },
+    })
+
+    const root = await mountPicker()
+    const text = root.textContent ?? ''
+
+    expect(text).toContain('Link Records — Vendor')
+    expect(root.querySelector<HTMLInputElement>('.meta-link-picker__input')?.getAttribute('placeholder')).toBe('Search records...')
+    expect(root.querySelector<HTMLButtonElement>('.meta-link-picker__close')?.getAttribute('aria-label')).toBe('Close link picker')
+    expect(text).toContain('No records found')
+    expect(text).toContain('0 selected')
+    expect(text).toContain('Cancel')
+    expect(text).toContain('Confirm')
+    expect(text).not.toContain('选择关联记录')
+  })
+})

--- a/apps/web/tests/meta-link-picker-labels.spec.ts
+++ b/apps/web/tests/meta-link-picker-labels.spec.ts
@@ -1,0 +1,36 @@
+import { describe, expect, it } from 'vitest'
+import {
+  linkPickerLabel,
+  selectedCount,
+  type MetaLinkPickerLabelKey,
+} from '../src/multitable/utils/meta-link-picker-labels'
+
+describe('meta-link-picker-labels static keys', () => {
+  it('localizes link picker modal chrome', () => {
+    const expectations: Array<[MetaLinkPickerLabelKey, string, string]> = [
+      ['linkPicker.selected', 'Selected', '已选择'],
+      ['linkPicker.clear', 'Clear', '清除'],
+      ['linkPicker.loading', 'Loading...', '正在加载...'],
+      ['linkPicker.empty', 'No records found', '未找到记录'],
+      ['linkPicker.loadMore', 'Load more', '加载更多'],
+      ['linkPicker.cancel', 'Cancel', '取消'],
+      ['linkPicker.confirm', 'Confirm', '确认'],
+      ['linkPicker.close', 'Close link picker', '关闭关联记录选择器'],
+      ['linkPicker.errorLoad', 'Failed to load records', '加载记录失败'],
+    ]
+
+    for (const [key, en, zh] of expectations) {
+      expect(linkPickerLabel(key, false)).toBe(en)
+      expect(linkPickerLabel(key, true)).toBe(zh)
+    }
+  })
+
+  it('formats selected counts with zh-CN neutral count copy', () => {
+    expect(selectedCount(0, false)).toBe('0 selected')
+    expect(selectedCount(1, false)).toBe('1 selected')
+    expect(selectedCount(2, false)).toBe('2 selected')
+    expect(selectedCount(0, true)).toBe('已选择 0 条')
+    expect(selectedCount(1, true)).toBe('已选择 1 条')
+    expect(selectedCount(2, true)).toBe('已选择 2 条')
+  })
+})

--- a/docs/development/multitable-t3b3-link-picker-i18n-design-20260520.md
+++ b/docs/development/multitable-t3b3-link-picker-i18n-design-20260520.md
@@ -1,0 +1,80 @@
+# T3B3 — Link Picker i18n Design
+
+- **Date**: 2026-05-20
+- **Type**: implementation-ready design packet
+- **Status**: implemented; paired verification in `docs/development/multitable-t3b3-link-picker-i18n-verification-20260520.md`
+- **Preceded by**:
+  - `docs/development/multitable-t3b1-record-form-i18n-design-20260520.md`
+  - `docs/development/multitable-t3b2-comments-i18n-design-20260520.md`
+- **Goal**: localize the link-record picker modal without changing link payload semantics, search behavior, API calls, or selected record display data.
+
+## Scope
+
+| File | Role |
+|---|---|
+| `apps/web/src/multitable/components/MetaLinkPicker.vue` | Modal chrome: title/search placeholder, selected header, clear/loading/empty/load-more/count/footer, close aria, FE fallback error. |
+| `apps/web/src/multitable/utils/link-fields.ts` | Extend existing `linkPickerTitle` and `linkPickerSearchPlaceholder` with optional `isZh=false`, preserving all existing English callers. |
+| `apps/web/src/multitable/utils/meta-link-picker-labels.ts` | New picker-surface static labels and selected-count helper. |
+| `apps/web/tests/link-fields-i18n.spec.ts` | Extend helper coverage for picker title/search. |
+| `apps/web/tests/meta-link-picker-labels.spec.ts` | New label/helper unit spec. |
+| `apps/web/tests/meta-link-picker-i18n.spec.ts` | New render spec for zh-CN/en picker chrome. |
+
+Out of scope:
+
+- Backend `/api/multitable/fields/:id/link-options` behavior.
+- `MetaCellEditor.vue` unreachable fallback comment.
+- `MetaImportModal.vue` link picker usage beyond receiving localized picker chrome when the modal opens.
+- User-authored field names and linked record display values. Those stay raw in every locale.
+
+## Labels
+
+T3B3 creates `meta-link-picker-labels.ts` for modal-owned static chrome:
+
+| Key | EN | ZH |
+|---|---|---|
+| `linkPicker.selected` | Selected | 已选择 |
+| `linkPicker.clear` | Clear | 清除 |
+| `linkPicker.loading` | Loading... | 正在加载... |
+| `linkPicker.empty` | No records found | 未找到记录 |
+| `linkPicker.loadMore` | Load more | 加载更多 |
+| `linkPicker.cancel` | Cancel | 取消 |
+| `linkPicker.confirm` | Confirm | 确认 |
+| `linkPicker.close` | Close link picker | 关闭关联记录选择器 |
+| `linkPicker.errorLoad` | Failed to load records | 加载记录失败 |
+
+Helper:
+
+- `selectedCount(n, isZh)` returns `${n} selected` in English and `已选择 ${n} 条` in zh-CN.
+
+`link-fields.ts` keeps the picker title/search helper names and adds an optional locale parameter:
+
+| Helper branch | EN | ZH |
+|---|---|---|
+| `linkPickerTitle(personField, false)` | `Select People — {field.name}` | — |
+| `linkPickerTitle(personField, true)` | — | `选择人员 — {field.name}` |
+| `linkPickerTitle(linkField, false)` | `Link Records — {field.name}` | — |
+| `linkPickerTitle(linkField, true)` | — | `选择关联记录 — {field.name}` |
+| `linkPickerSearchPlaceholder(personField, false)` | Search people... | — |
+| `linkPickerSearchPlaceholder(personField, true)` | — | 搜索人员... |
+| `linkPickerSearchPlaceholder(linkField, false)` | Search records... | — |
+| `linkPickerSearchPlaceholder(linkField, true)` | — | 搜索记录... |
+
+Field names remain raw user data, including Chinese-authored names.
+
+## Component Wiring
+
+`MetaLinkPicker.vue` imports `useLocale`, `linkPickerLabel`, and the new selected-count helper.
+
+- `titleText = linkPickerTitle(props.field, isZh.value)`
+- `searchPlaceholder = linkPickerSearchPlaceholder(props.field, isZh.value)`
+- selected header/clear/loading/empty/load-more/cancel/confirm use `linkPickerLabel`.
+- footer count uses `selectedCount(selected.size, isZh.value)`.
+- close button keeps the `×` glyph but gains localized `aria-label`.
+- `error?.message` stays raw. Only the component-owned fallback for non-Error throws uses `linkPicker.errorLoad`.
+
+## Acceptance
+
+- Existing picker behavior remains unchanged: open resets selection from `currentValue`, clear+confirm emits an empty array, person fields remain single-select.
+- English remains the default for helpers when no `isZh` argument is passed.
+- zh-CN render covers title/search, selected header, count, clear, empty, load-more, footer actions, close aria, and fallback load error.
+- No API, backend, migration, `attendance_*`, or direct `meta_*` change.

--- a/docs/development/multitable-t3b3-link-picker-i18n-verification-20260520.md
+++ b/docs/development/multitable-t3b3-link-picker-i18n-verification-20260520.md
@@ -1,0 +1,81 @@
+# T3B3 — Link Picker i18n Verification
+
+- **Date**: 2026-05-20
+- **Scope**: `MetaLinkPicker.vue`, `link-fields.ts` picker helper branches, and the new `meta-link-picker-labels.ts` label module.
+- **Design packet**: `docs/development/multitable-t3b3-link-picker-i18n-design-20260520.md`
+- **Status**: implemented and locally verified.
+
+## Implementation Summary
+
+- Added `apps/web/src/multitable/utils/meta-link-picker-labels.ts` for picker-owned static chrome and selected-count formatting.
+- Extended `linkPickerTitle(field, isZh = false)` and `linkPickerSearchPlaceholder(field, isZh = false)` while preserving English defaults for existing callers.
+- Wired `MetaLinkPicker.vue` to `useLocale()` for:
+  - title and search placeholder,
+  - selected header / clear,
+  - loading / empty / load more,
+  - footer count / cancel / confirm,
+  - close button aria-label,
+  - FE-owned fallback load error.
+- Preserved raw data: field names, linked record display labels, record IDs, and backend/API error messages remain untranslated.
+
+## Boundary Check
+
+| Area | Result |
+|---|---|
+| Backend/API | Not touched |
+| Link picker payload / confirm semantics | Not changed |
+| `attendance_*` / migrations | Not touched |
+| `meta_*` direct writes | Not touched |
+| `MetaImportModal.vue` | Not touched |
+| `MetaCellEditor.vue` unreachable link fallback comment | Not touched |
+
+## Test Coverage Added
+
+| File | Coverage |
+|---|---|
+| `apps/web/tests/meta-link-picker-labels.spec.ts` | Picker static keys and selected-count helper |
+| `apps/web/tests/link-fields-i18n.spec.ts` | Title/search helpers in EN and zh-CN, absent-field fallback, raw field names |
+| `apps/web/tests/meta-link-picker-i18n.spec.ts` | zh-CN record/person picker chrome, empty/fallback-error states, English regression |
+
+## Verification Commands
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/link-fields-i18n.spec.ts \
+  tests/meta-link-picker-labels.spec.ts \
+  tests/meta-link-picker-i18n.spec.ts \
+  tests/multitable-link-picker.spec.ts \
+  tests/meta-record-drawer-i18n.spec.ts \
+  tests/meta-form-view-i18n.spec.ts \
+  tests/meta-cell-editor-i18n.spec.ts \
+  tests/meta-comments-drawer-i18n.spec.ts \
+  tests/meta-comment-composer-i18n.spec.ts --watch=false
+```
+
+Result: PASS, 62 tests across 9 files.
+
+```bash
+pnpm --filter @metasheet/web type-check
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: PASS. Vite emitted existing chunk-size / dynamic-import warnings only.
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+## Acceptance Notes
+
+- Record-link picker title/search zh-CN: `选择关联记录 — {field.name}` / `搜索记录...`.
+- Person picker title/search zh-CN: `选择人员 — {field.name}` / `搜索人员...`.
+- Field names remain raw, including Chinese-authored field names.
+- Selected count uses `${n} selected` in English and `已选择 ${n} 条` in zh-CN.
+- API error messages are raw; only the component fallback for non-Error throws localizes to `加载记录失败`.


### PR DESCRIPTION
## Summary

- Localize MetaLinkPicker modal chrome for zh-CN while keeping English as the default.
- Add a small picker label module and extend link picker title/search helpers with an optional locale flag.
- Preserve raw field names, linked record display values, record IDs, payload semantics, and backend/API error messages.

## Verification

- NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/link-fields-i18n.spec.ts tests/meta-link-picker-labels.spec.ts tests/meta-link-picker-i18n.spec.ts tests/multitable-link-picker.spec.ts tests/meta-record-drawer-i18n.spec.ts tests/meta-form-view-i18n.spec.ts tests/meta-cell-editor-i18n.spec.ts tests/meta-comments-drawer-i18n.spec.ts tests/meta-comment-composer-i18n.spec.ts --watch=false
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web build
- git diff --check
- git diff --cached --check + staged secret/home-path scan

## Boundaries

- No backend/API changes.
- No migrations, attendance_* changes, or direct meta_* writes.
- No node_modules/scratch/output files staged.