### PR TITLE
feat(multitable): localize alt view comment chips

### DIFF
--- a/apps/web/src/multitable/components/MetaCalendarView.vue
+++ b/apps/web/src/multitable/components/MetaCalendarView.vue
@@ -92,7 +92,7 @@
                     @click.stop="emit('open-comments', ev.id)"
                     @keydown="onRowCommentKeydown($event, ev.id)"
                   >
-                    <MetaCommentActionChip label="Comments" :state="rowCommentAffordance(ev.id)" />
+                    <MetaCommentActionChip :label="commentsChipLabel" :state="rowCommentAffordance(ev.id)" />
                   </button>
                   <button
                     v-if="dateField"
@@ -173,7 +173,7 @@
                     @click.stop="emit('open-comments', ev.id)"
                     @keydown="onRowCommentKeydown($event, ev.id)"
                   >
-                    <MetaCommentActionChip label="Comments" :state="rowCommentAffordance(ev.id)" />
+                    <MetaCommentActionChip :label="commentsChipLabel" :state="rowCommentAffordance(ev.id)" />
                   </button>
                   <button
                     v-if="dateField"
@@ -248,7 +248,7 @@
                   @click.stop="emit('open-comments', ev.id)"
                   @keydown="onRowCommentKeydown($event, ev.id)"
                 >
-                  <MetaCommentActionChip label="Comments" :state="rowCommentAffordance(ev.id)" />
+                  <MetaCommentActionChip :label="commentsChipLabel" :state="rowCommentAffordance(ev.id)" />
                 </button>
                 <button
                   v-if="dateField"
@@ -289,12 +289,14 @@ import {
 import MetaAttachmentList from './MetaAttachmentList.vue'
 import MetaCommentActionChip from './MetaCommentActionChip.vue'
 import MetaCommentAffordance from './MetaCommentAffordance.vue'
+import { useLocale } from '../../composables/useLocale'
 import {
   handleCommentAffordanceKeydown,
   resolveCommentAffordanceStateClass,
   resolveFieldCommentAffordance,
   resolveRecordCommentAffordance,
 } from '../utils/comment-affordance'
+import { commentLabel } from '../utils/meta-comment-labels'
 
 const MAX_EVENTS_PER_CELL = 3
 
@@ -324,6 +326,8 @@ const dateFieldId = ref<string | null>(null)
 const viewMode = ref<'month' | 'week' | 'day'>('month')
 const viewDate = ref(new Date())
 const pendingConfigKey = ref<string | null>(null)
+const { isZh } = useLocale()
+const commentsChipLabel = computed(() => commentLabel('comment.title', isZh.value))
 
 const baseWeekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 const calendarConfig = computed<Required<MetaCalendarViewConfig>>(() =>

--- a/apps/web/src/multitable/components/MetaGalleryView.vue
+++ b/apps/web/src/multitable/components/MetaGalleryView.vue
@@ -79,7 +79,7 @@
             @click.stop="emit('open-comments', row.id)"
             @keydown="onRowCommentKeydown($event, row.id)"
           >
-            <MetaCommentActionChip label="Comments" :state="rowCommentAffordance(row.id)" />
+            <MetaCommentActionChip :label="commentsChipLabel" :state="rowCommentAffordance(row.id)" />
           </button>
         </div>
         <div class="meta-gallery__card-body">
@@ -130,6 +130,7 @@ import { computed, reactive, ref, watch } from 'vue'
 import type { LinkedRecordSummary, MetaAttachment, MetaField, MetaGalleryViewConfig, MetaRecord, MultitableCommentPresenceSummary } from '../types'
 import { resolveGalleryViewConfig } from '../utils/view-config'
 import { formatFieldDisplay } from '../utils/field-display'
+import { useLocale } from '../../composables/useLocale'
 import MetaAttachmentList from './MetaAttachmentList.vue'
 import MetaCommentActionChip from './MetaCommentActionChip.vue'
 import MetaCommentAffordance from './MetaCommentAffordance.vue'
@@ -139,6 +140,7 @@ import {
   resolveFieldCommentAffordance,
   resolveRecordCommentAffordance,
 } from '../utils/comment-affordance'
+import { commentLabel } from '../utils/meta-comment-labels'
 
 const props = defineProps<{
   rows: MetaRecord[]
@@ -167,6 +169,8 @@ const galleryConfig = computed<Required<MetaGalleryViewConfig>>(() =>
   resolveGalleryViewConfig(props.fields, props.viewConfig),
 )
 const pendingConfigKey = ref<string | null>(null)
+const { isZh } = useLocale()
+const commentsChipLabel = computed(() => commentLabel('comment.title', isZh.value))
 
 const galleryDraft = reactive<Required<MetaGalleryViewConfig>>({
   titleFieldId: null,

--- a/apps/web/src/multitable/components/MetaHierarchyView.vue
+++ b/apps/web/src/multitable/components/MetaHierarchyView.vue
@@ -64,6 +64,7 @@
           :can-create="canCreate"
           :can-edit="canEdit"
           :can-comment="canComment"
+          :comment-label="commentsChipLabel"
           :dragging-record-id="draggingRecordId"
           :comment-presence="commentPresence"
           @toggle="toggleNode"
@@ -87,12 +88,14 @@ import { computed, defineComponent, h, reactive, ref, watch, type PropType, type
 import type { MetaField, MetaHierarchyViewConfig, MetaRecord, MultitableCommentPresenceSummary } from '../types'
 import { formatFieldDisplay } from '../utils/field-display'
 import { resolveHierarchyViewConfig } from '../utils/view-config'
+import { useLocale } from '../../composables/useLocale'
 import MetaCommentActionChip from './MetaCommentActionChip.vue'
 import {
   handleCommentAffordanceKeydown,
   resolveCommentAffordanceStateClass,
   resolveRecordCommentAffordance,
 } from '../utils/comment-affordance'
+import { commentLabel } from '../utils/meta-comment-labels'
 
 type HierarchyNodeModel = {
   record: MetaRecord
@@ -134,6 +137,8 @@ const pendingConfigKey = ref<string | null>(null)
 const expandedIds = ref<Set<string>>(new Set())
 const draggingRecordId = ref<string | null>(null)
 const dragWarning = ref<string | null>(null)
+const { isZh } = useLocale()
+const commentsChipLabel = computed(() => commentLabel('comment.title', isZh.value))
 
 const hierarchyConfig = computed<Required<MetaHierarchyViewConfig>>(() =>
   resolveHierarchyViewConfig(props.fields, props.viewConfig),
@@ -400,6 +405,7 @@ const HierarchyNode: ReturnType<typeof defineComponent> = defineComponent({
     canCreate: { type: Boolean, default: false },
     canEdit: { type: Boolean, default: false },
     canComment: { type: Boolean, default: false },
+    commentLabel: { type: String, default: 'Comments' },
     draggingRecordId: { type: String as PropType<string | null>, default: null },
     commentPresence: { type: Object as PropType<Record<string, MultitableCommentPresenceSummary | undefined> | undefined>, default: undefined },
   },
@@ -466,7 +472,7 @@ const HierarchyNode: ReturnType<typeof defineComponent> = defineComponent({
               'aria-label': `Open comments for ${title}`,
               onClick: () => nodeEmit('open-comments', node.record.id),
               onKeydown: (event: KeyboardEvent) => handleCommentAffordanceKeydown(event, () => nodeEmit('open-comments', node.record.id)),
-            }, [h(MetaCommentActionChip, { label: 'Comments', state: rowCommentAffordance(node.record.id) })])
+            }, [h(MetaCommentActionChip, { label: nodeProps.commentLabel, state: rowCommentAffordance(node.record.id) })])
             : null,
           nodeProps.canCreate
             ? h('button', {
@@ -486,6 +492,7 @@ const HierarchyNode: ReturnType<typeof defineComponent> = defineComponent({
               canCreate: nodeProps.canCreate,
               canEdit: nodeProps.canEdit,
               canComment: nodeProps.canComment,
+              commentLabel: nodeProps.commentLabel,
               draggingRecordId: nodeProps.draggingRecordId,
               commentPresence: nodeProps.commentPresence,
               onToggle: (recordId: string) => nodeEmit('toggle', recordId),

--- a/apps/web/src/multitable/components/MetaKanbanView.vue
+++ b/apps/web/src/multitable/components/MetaKanbanView.vue
@@ -68,7 +68,7 @@
                   @click.stop="emit('open-comments', row.id)"
                   @keydown="onRowCommentKeydown($event, row.id)"
                 >
-                  <MetaCommentActionChip label="Comments" :state="rowCommentAffordance(row.id)" />
+                  <MetaCommentActionChip :label="commentsChipLabel" :state="rowCommentAffordance(row.id)" />
                 </button>
               </div>
               <div class="meta-kanban__card-fields">
@@ -127,7 +127,7 @@
                   @click.stop="emit('open-comments', row.id)"
                   @keydown="onRowCommentKeydown($event, row.id)"
                 >
-                  <MetaCommentActionChip label="Comments" :state="rowCommentAffordance(row.id)" />
+                  <MetaCommentActionChip :label="commentsChipLabel" :state="rowCommentAffordance(row.id)" />
                 </button>
               </div>
               <div class="meta-kanban__card-fields">
@@ -168,6 +168,7 @@ import { computed, reactive, ref, watch } from 'vue'
 import type { LinkedRecordSummary, MetaAttachment, MetaField, MetaKanbanViewConfig, MetaRecord, MultitableCommentPresenceSummary } from '../types'
 import { resolveKanbanViewConfig } from '../utils/view-config'
 import { formatFieldDisplay } from '../utils/field-display'
+import { useLocale } from '../../composables/useLocale'
 import MetaCommentActionChip from './MetaCommentActionChip.vue'
 import MetaCommentAffordance from './MetaCommentAffordance.vue'
 import {
@@ -176,6 +177,7 @@ import {
   resolveFieldCommentAffordance,
   resolveRecordCommentAffordance,
 } from '../utils/comment-affordance'
+import { commentLabel } from '../utils/meta-comment-labels'
 
 const props = defineProps<{
   rows: MetaRecord[]
@@ -208,6 +210,8 @@ const kanbanDraft = reactive<Required<MetaKanbanViewConfig>>({
 let dragRecordId: string | null = null
 let dragVersion = 0
 const dragOverColumn = ref<string | null>(null)
+const { isZh } = useLocale()
+const commentsChipLabel = computed(() => commentLabel('comment.title', isZh.value))
 
 const kanbanConfig = computed<Required<MetaKanbanViewConfig>>(() =>
   resolveKanbanViewConfig(props.fields, props.viewConfig, props.groupInfo),

--- a/apps/web/src/multitable/components/MetaTimelineView.vue
+++ b/apps/web/src/multitable/components/MetaTimelineView.vue
@@ -92,7 +92,7 @@
                 @click.stop="emit('open-comments', item.record.id)"
                 @keydown="onRowCommentKeydown($event, item.record.id)"
               >
-                <MetaCommentActionChip label="Comments" :state="rowCommentAffordance(item.record.id)" />
+                <MetaCommentActionChip :label="commentsChipLabel" :state="rowCommentAffordance(item.record.id)" />
               </button>
               <button
                 v-if="displayField"
@@ -151,7 +151,7 @@
                 @click.stop="emit('open-comments', row.id)"
                 @keydown="onRowCommentKeydown($event, row.id)"
               >
-                <MetaCommentActionChip label="Comments" :state="rowCommentAffordance(row.id)" />
+                <MetaCommentActionChip :label="commentsChipLabel" :state="rowCommentAffordance(row.id)" />
               </button>
               <button
                 v-if="displayField"
@@ -182,6 +182,7 @@ import { ref, computed, watch } from 'vue'
 import type { LinkedRecordSummary, MetaAttachment, MetaField, MetaRecord, MetaTimelineViewConfig, MultitableCommentPresenceSummary } from '../types'
 import { resolveTimelineViewConfig } from '../utils/view-config'
 import { formatFieldDisplay } from '../utils/field-display'
+import { useLocale } from '../../composables/useLocale'
 import MetaAttachmentList from './MetaAttachmentList.vue'
 import MetaCommentActionChip from './MetaCommentActionChip.vue'
 import MetaCommentAffordance from './MetaCommentAffordance.vue'
@@ -191,6 +192,7 @@ import {
   resolveFieldCommentAffordance,
   resolveRecordCommentAffordance,
 } from '../utils/comment-affordance'
+import { commentLabel } from '../utils/meta-comment-labels'
 
 const props = defineProps<{
   rows: MetaRecord[]
@@ -234,6 +236,8 @@ const dragState = ref<{
   startMs: number
   endMs: number
 } | null>(null)
+const { isZh } = useLocale()
+const commentsChipLabel = computed(() => commentLabel('comment.title', isZh.value))
 
 const timelineConfig = computed<Required<MetaTimelineViewConfig>>(() =>
   resolveTimelineViewConfig(props.fields, props.viewConfig),

--- a/apps/web/src/multitable/utils/meta-comment-labels.ts
+++ b/apps/web/src/multitable/utils/meta-comment-labels.ts
@@ -1,8 +1,8 @@
 // Comments drawer + composer chrome string table (T3B2).
 //
-// Scope: MetaCommentsDrawer.vue and MetaCommentComposer.vue only. User
-// content, author names, mention labels, and backend/composable error bodies
-// stay raw and are never translated here.
+// Scope: comment drawer/composer chrome plus row-comment action chip labels in
+// alternative views. User content, author names, mention labels, and
+// backend/composable error bodies stay raw and are never translated here.
 
 export type MetaCommentLabelKey =
   | 'comment.title'

--- a/apps/web/tests/multitable-alt-view-comment-chip-i18n.spec.ts
+++ b/apps/web/tests/multitable-alt-view-comment-chip-i18n.spec.ts
@@ -1,0 +1,132 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, nextTick, type Component } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
+import MetaCalendarView from '../src/multitable/components/MetaCalendarView.vue'
+import MetaGalleryView from '../src/multitable/components/MetaGalleryView.vue'
+import MetaHierarchyView from '../src/multitable/components/MetaHierarchyView.vue'
+import MetaKanbanView from '../src/multitable/components/MetaKanbanView.vue'
+import MetaTimelineView from '../src/multitable/components/MetaTimelineView.vue'
+
+const titleField = { id: 'fld_title', name: 'Title', type: 'string' }
+const dateField = { id: 'fld_date', name: 'Date', type: 'date' }
+const endDateField = { id: 'fld_end', name: 'End', type: 'date' }
+const parentField = { id: 'fld_parent', name: 'Parent', type: 'link' }
+const statusField = {
+  id: 'fld_status',
+  name: 'Status',
+  type: 'select',
+  options: [{ value: 'Todo', color: '#409eff' }],
+}
+
+function todayIso(): string {
+  const today = new Date()
+  return `${today.getFullYear()}-${String(today.getMonth() + 1).padStart(2, '0')}-${String(today.getDate()).padStart(2, '0')}`
+}
+
+async function mountComponent(component: Component, props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({
+    render() {
+      return h(component, props)
+    },
+  })
+  app.mount(container)
+  await nextTick()
+  return {
+    container,
+    chipLabels: () => Array.from(container.querySelectorAll('.meta-comment-action-chip__label')).map((item) => item.textContent?.trim()),
+    unmount: () => {
+      app.unmount()
+      container.remove()
+    },
+  }
+}
+
+async function mountAltViews() {
+  const date = todayIso()
+  const record = {
+    id: 'rec_1',
+    version: 1,
+    data: {
+      fld_title: 'Roadmap',
+      fld_date: date,
+      fld_end: date,
+      fld_status: 'Todo',
+    },
+  }
+  const mounted = [
+    await mountComponent(MetaCalendarView, {
+      rows: [record],
+      fields: [titleField, dateField],
+      loading: false,
+      canComment: true,
+      viewConfig: { dateFieldId: 'fld_date', titleFieldId: 'fld_title', defaultView: 'day' },
+    }),
+    await mountComponent(MetaGalleryView, {
+      rows: [record],
+      fields: [titleField],
+      loading: false,
+      canComment: true,
+      currentPage: 1,
+      totalPages: 1,
+      viewConfig: { titleFieldId: 'fld_title', fieldIds: [], columns: 1, cardSize: 'small' },
+    }),
+    await mountComponent(MetaHierarchyView, {
+      rows: [record],
+      fields: [titleField, parentField],
+      loading: false,
+      canComment: true,
+      viewConfig: { parentFieldId: 'fld_parent', titleFieldId: 'fld_title', defaultExpandDepth: 1 },
+    }),
+    await mountComponent(MetaTimelineView, {
+      rows: [record],
+      fields: [titleField, dateField, endDateField],
+      loading: false,
+      canComment: true,
+      viewConfig: { startFieldId: 'fld_date', endFieldId: 'fld_end', labelFieldId: 'fld_title', zoom: 'week' },
+    }),
+    await mountComponent(MetaKanbanView, {
+      rows: [record],
+      fields: [titleField, statusField],
+      loading: false,
+      canComment: true,
+      viewConfig: { groupFieldId: 'fld_status', cardFieldIds: [] },
+    }),
+  ]
+  return mounted
+}
+
+afterEach(() => {
+  useLocale().setLocale('en')
+})
+
+describe('alternative view comment chip i18n', () => {
+  it('localizes row comment chip labels in zh-CN across non-grid views', async () => {
+    useLocale().setLocale('zh-CN')
+    const mounted = await mountAltViews()
+
+    try {
+      for (const view of mounted) {
+        expect(view.chipLabels()).toContain('评论')
+        expect(view.chipLabels()).not.toContain('Comments')
+      }
+    } finally {
+      mounted.forEach((view) => view.unmount())
+    }
+  })
+
+  it('keeps English row comment chip labels as the default', async () => {
+    useLocale().setLocale('en')
+    const mounted = await mountAltViews()
+
+    try {
+      for (const view of mounted) {
+        expect(view.chipLabels()).toContain('Comments')
+        expect(view.chipLabels()).not.toContain('评论')
+      }
+    } finally {
+      mounted.forEach((view) => view.unmount())
+    }
+  })
+})

--- a/docs/development/multitable-t3b4-alt-view-comment-chip-i18n-design-20260520.md
+++ b/docs/development/multitable-t3b4-alt-view-comment-chip-i18n-design-20260520.md
@@ -1,0 +1,52 @@
+# T3B4 - Alternative View Comment Chip i18n Design
+
+- **Date**: 2026-05-20
+- **Type**: small implementation slice
+- **Status**: implemented; paired verification in `docs/development/multitable-t3b4-alt-view-comment-chip-i18n-verification-20260520.md`
+- **Preceded by**:
+  - `docs/development/multitable-t3b2-comments-i18n-design-20260520.md`
+  - `docs/development/multitable-t3b3-link-picker-i18n-design-20260520.md`
+- **Goal**: close the T3B2 S1 deferred row-comment action-chip label in non-grid views without expanding into full view chrome localization.
+
+## Scope
+
+T3B2 intentionally left `MetaCommentActionChip label="Comments"` hardcoded in five alternative views. T3B4 rewires only that visible chip label to the existing comment namespace:
+
+| Component | Sites |
+|---|---:|
+| `MetaCalendarView.vue` | 3 |
+| `MetaGalleryView.vue` | 1 |
+| `MetaHierarchyView.vue` | 1 render-function site |
+| `MetaTimelineView.vue` | 2 |
+| `MetaKanbanView.vue` | 2 |
+
+The localized value is `commentLabel('comment.title', isZh.value)`, reusing the T3B2 key:
+
+| Locale | Chip label |
+|---|---|
+| en | Comments |
+| zh-CN | 评论 |
+
+## Boundaries
+
+This slice deliberately does not localize the rest of those views.
+
+Out of scope:
+
+- Calendar/timeline/gallery/kanban/hierarchy toolbar labels.
+- Empty states, date labels, zoom labels, field-comment aria labels, drag/drop hints, and view configuration copy.
+- Backend, API, routes, OpenAPI, migrations, `attendance_*`, or direct `meta_*` writes.
+- User data: record titles, field names, option values, attachment filenames, and linked-record display values remain raw.
+
+## Implementation Notes
+
+- Each template-based view imports `useLocale()` and `commentLabel`, then passes a computed `commentsChipLabel` into `MetaCommentActionChip`.
+- `MetaHierarchyView.vue` uses an inner render-function component, so the parent passes `commentLabel` as a prop to `HierarchyNode`; recursive child rendering forwards the same prop.
+- `meta-comment-labels.ts` header comment now includes alternative-view action-chip labels in its scope. No new label key was needed.
+
+## Acceptance
+
+- In zh-CN, every row comment chip in the five alternative views renders `评论`.
+- In English/default locale, every row comment chip remains `Comments`.
+- Existing view behavior and events remain unchanged.
+- T3B2's S1 deferred chip-label item is closed, while broader alternative-view chrome remains a future T3C/T3D view-localization slice.

--- a/docs/development/multitable-t3b4-alt-view-comment-chip-i18n-verification-20260520.md
+++ b/docs/development/multitable-t3b4-alt-view-comment-chip-i18n-verification-20260520.md
@@ -1,0 +1,72 @@
+# T3B4 - Alternative View Comment Chip i18n Verification
+
+- **Date**: 2026-05-20
+- **Scope**: row-comment action chip labels in calendar, gallery, hierarchy, timeline, and kanban views.
+- **Design packet**: `docs/development/multitable-t3b4-alt-view-comment-chip-i18n-design-20260520.md`
+- **Status**: implemented and locally verified.
+
+## Implementation Summary
+
+- Reused existing `commentLabel('comment.title', isZh)` for the row-comment chip label.
+- Wired `MetaCalendarView.vue`, `MetaGalleryView.vue`, `MetaTimelineView.vue`, and `MetaKanbanView.vue` with `useLocale()` and a `commentsChipLabel` computed.
+- Wired `MetaHierarchyView.vue` by passing the localized label from the parent into the render-function `HierarchyNode` component and through recursive child rendering.
+- Updated the `meta-comment-labels.ts` module comment so its declared scope includes alternative-view row-comment chip labels.
+
+## Boundary Check
+
+| Area | Result |
+|---|---|
+| Backend/API/OpenAPI | Not touched |
+| Migrations / `attendance_*` | Not touched |
+| Direct `meta_*` writes | Not touched |
+| View events / emitted payloads | Not changed |
+| User-authored data | Not translated |
+| Broader alternative-view chrome | Deferred by design |
+
+## Test Coverage Added
+
+| File | Coverage |
+|---|---|
+| `apps/web/tests/multitable-alt-view-comment-chip-i18n.spec.ts` | Mounts all five alternative views and asserts zh-CN row-comment chip labels are `评论`; also asserts English default remains `Comments`. |
+
+## Verification Commands
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-alt-view-comment-chip-i18n.spec.ts \
+  tests/multitable-calendar-view.spec.ts \
+  tests/multitable-gallery-view.spec.ts \
+  tests/multitable-hierarchy-view.spec.ts \
+  tests/multitable-timeline-view.spec.ts \
+  tests/multitable-kanban-view.spec.ts \
+  tests/meta-comment-labels.spec.ts \
+  tests/meta-comments-drawer-i18n.spec.ts \
+  tests/meta-comment-composer-i18n.spec.ts --watch=false
+```
+
+Result: PASS, 30 tests across 9 files.
+
+```bash
+pnpm --filter @metasheet/web type-check
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: PASS. Vite emitted the existing dynamic-import and large-chunk warnings only.
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+## Acceptance Notes
+
+- T3B2 S1's nine hardcoded `Comments` chip sites are now locale-aware.
+- `MetaCommentActionChip.vue` remains prop-driven; consumers still own the label text.
+- The hierarchy render-function site keeps the default `Comments` fallback for direct internal use, but production parent wiring passes the localized prop.
+- Field-comment affordance aria labels and other view-level English strings remain intentionally deferred to a broader alternative-view chrome slice.


### PR DESCRIPTION
## Summary

- Localize row-comment action chip labels in calendar, gallery, hierarchy, timeline, and kanban views.
- Reuse the existing T3B2 comment namespace (`comment.title`) instead of adding a duplicate label key.
- Keep all broader alternative-view chrome, field names, record titles, option values, aria strings, and backend text unchanged.

## Verification

- NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/multitable-alt-view-comment-chip-i18n.spec.ts tests/multitable-calendar-view.spec.ts tests/multitable-gallery-view.spec.ts tests/multitable-hierarchy-view.spec.ts tests/multitable-timeline-view.spec.ts tests/multitable-kanban-view.spec.ts tests/meta-comment-labels.spec.ts tests/meta-comments-drawer-i18n.spec.ts tests/meta-comment-composer-i18n.spec.ts --watch=false
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web build
- git diff --check
- git diff --cached --check + staged secret/home-path scan

## Boundaries

- No backend/API/OpenAPI changes.
- No migrations, attendance_* changes, or direct meta_* writes.
- No node_modules/scratch/output files staged.
