### PR TITLE
feat(multitable): localize import modal chrome

### DIFF
--- a/apps/web/src/multitable/components/MetaImportModal.vue
+++ b/apps/web/src/multitable/components/MetaImportModal.vue
@@ -3,15 +3,15 @@
     <div v-if="visible" class="meta-import-overlay" @click.self="requestClose">
       <div class="meta-import-modal">
         <div class="meta-import__header">
-          <strong>Import Records</strong>
+          <strong>{{ l('import.title') }}</strong>
           <button class="meta-import__close" @click="requestClose">&times;</button>
         </div>
 
         <div v-if="step === 'paste'" class="meta-import__body">
           <div v-if="restoredDraft" class="meta-import__warning">
-            <span>Recovered your previous import draft for this sheet.</span>
+            <span>{{ l('import.recoveredDraft') }}</span>
           </div>
-          <p class="meta-import__hint">Paste tab-separated data from Excel or Google Sheets (first row = headers):</p>
+          <p class="meta-import__hint">{{ l('import.pasteHint') }}</p>
           <label class="meta-import__file-drop" @dragover.prevent @drop.prevent="onFileDrop">
             <input
               class="meta-import__file-input"
@@ -19,40 +19,40 @@
               accept=".csv,text/csv,.tsv,text/tab-separated-values,.txt,text/plain,.xlsx,application/vnd.openxmlformats-officedocument.spreadsheetml.sheet,.xls,application/vnd.ms-excel"
               @change="onFileSelect"
             />
-            <span>Choose a CSV/TSV/Excel file or drop it here</span>
+            <span>{{ l('import.fileDrop') }}</span>
           </label>
           <textarea
             ref="textareaRef"
             class="meta-import__textarea"
-            placeholder="Name&#x9;Age&#x9;Email&#x0A;Alice&#x9;30&#x9;alice@example.com"
+            :placeholder="l('import.textareaPlaceholder')"
             :value="rawText"
             @input="rawText = ($event.target as HTMLTextAreaElement).value"
           ></textarea>
           <div v-if="parseError" class="meta-import__error">{{ parseError }}</div>
           <div class="meta-import__actions">
-            <button class="meta-import__btn" :disabled="isImporting" @click="requestClose">Cancel</button>
-            <button class="meta-import__btn meta-import__btn--primary" :disabled="!rawText.trim()" @click="parseAndPreview">Preview</button>
+            <button class="meta-import__btn" :disabled="isImporting" @click="requestClose">{{ l('import.cancel') }}</button>
+            <button class="meta-import__btn meta-import__btn--primary" :disabled="!rawText.trim()" @click="parseAndPreview">{{ l('import.preview') }}</button>
           </div>
         </div>
 
         <div v-else-if="step === 'preview'" class="meta-import__body">
           <div v-if="restoredDraft" class="meta-import__warning">
-            <span>Recovered your previous import draft for this sheet.</span>
+            <span>{{ l('import.recoveredDraft') }}</span>
           </div>
           <div v-if="parseWarning" class="meta-import__warning">
             <span>{{ parseWarning }}</span>
           </div>
-          <p class="meta-import__hint">{{ parsedRows.length }} record(s) detected. Map columns to fields:</p>
+          <p class="meta-import__hint">{{ detectedRows(parsedRows.length, isZh) }}</p>
           <div v-if="hasImportDraftIssues" class="meta-import__warning">
             <span>{{ importDraftIssueText }}</span>
-            <button class="meta-import__btn-inline" @click="reconcileImportDraft">Reconcile draft</button>
+            <button class="meta-import__btn-inline" @click="reconcileImportDraft">{{ l('import.reconcileDraft') }}</button>
           </div>
           <div class="meta-import__mapping">
             <div v-for="(header, i) in parsedHeaders" :key="i" class="meta-import__map-row">
               <span class="meta-import__col-name">{{ header }}</span>
               <span class="meta-import__arrow">&rarr;</span>
               <select class="meta-import__field-select" :value="fieldMapping[i] ?? ''" @change="fieldMapping[i] = ($event.target as HTMLSelectElement).value">
-                <option value="">(skip)</option>
+                <option value="">{{ l('import.skip') }}</option>
                 <option v-for="f in importableFields" :key="f.id" :value="f.id">{{ f.name }}</option>
               </select>
             </div>
@@ -64,23 +64,23 @@
                 <tr v-for="(row, ri) in parsedRows.slice(0, 5)" :key="ri">
                   <td v-for="(cell, ci) in row" :key="ci">{{ cell }}</td>
                 </tr>
-                <tr v-if="parsedRows.length > 5"><td :colspan="parsedHeaders.length" class="meta-import__more">... and {{ parsedRows.length - 5 }} more</td></tr>
+                <tr v-if="parsedRows.length > 5"><td :colspan="parsedHeaders.length" class="meta-import__more">{{ moreRows(parsedRows.length - 5, isZh) }}</td></tr>
               </tbody>
             </table>
           </div>
           <div class="meta-import__actions">
-            <button class="meta-import__btn" :disabled="isImporting" @click="goBackToPaste">Back</button>
+            <button class="meta-import__btn" :disabled="isImporting" @click="goBackToPaste">{{ l('import.back') }}</button>
             <button class="meta-import__btn meta-import__btn--primary" :disabled="!canImportPreview" @click="doImport">
-              Import {{ parsedRows.length }} record(s)
+              {{ importRecords(parsedRows.length, isZh) }}
             </button>
           </div>
         </div>
 
         <div v-else-if="step === 'importing'" class="meta-import__body meta-import__importing">
           <div class="meta-import__spinner"></div>
-          <p>Importing {{ pendingRecordCount }} record(s)...</p>
+          <p>{{ importingRecords(pendingRecordCount, isZh) }}</p>
           <div class="meta-import__actions meta-import__actions--center">
-            <button class="meta-import__btn" @click="requestClose">Cancel import</button>
+            <button class="meta-import__btn" @click="requestClose">{{ l('import.cancelImport') }}</button>
           </div>
         </div>
 
@@ -89,37 +89,37 @@
             <strong>{{ resultSummaryText }}</strong>
             <p v-if="hasFailedImports">
               <template v-if="retryableFailureCount > 0">
-                Review the failed rows below, then retry just those rows or return to mapping.
+                {{ l('import.failedReviewRetry') }}
               </template>
               <template v-else>
-                Review the failed rows below and return to mapping to fix the source data.
+                {{ l('import.failedReviewMapping') }}
               </template>
             </p>
             <p v-else-if="hasSkippedImports">
-              Some rows were skipped as duplicates.
+              {{ l('import.skippedDuplicates') }}
             </p>
-            <p v-else>The selected records were imported successfully.</p>
+            <p v-else>{{ l('import.success') }}</p>
           </div>
           <div v-if="hasImportDraftIssues" class="meta-import__warning">
             <span>{{ importDraftIssueText }}</span>
-            <button class="meta-import__btn-inline" @click="reconcileImportDraft">Reconcile draft</button>
+            <button class="meta-import__btn-inline" @click="reconcileImportDraft">{{ l('import.reconcileDraft') }}</button>
           </div>
           <div v-if="failedPreviewRows.length" class="meta-import__failures">
             <div v-for="failure in failedPreviewRows" :key="`${failure.originalIndex}:${failure.fieldId ?? 'row'}`" class="meta-import__failure">
               <div class="meta-import__failure-head">
-                <strong>Row {{ failure.rowNumber }}</strong>
+                <strong>{{ rowLabel(failure.rowNumber, isZh) }}</strong>
                 <span>{{ failure.message }}</span>
               </div>
-              <div class="meta-import__failure-row">{{ failure.values.join(' | ') || '(empty row)' }}</div>
+              <div class="meta-import__failure-row">{{ failure.values.join(' | ') || l('import.emptyRow') }}</div>
             </div>
             <div v-if="remainingFailedCount > 0" class="meta-import__more">
-              ... and {{ remainingFailedCount }} more failed row(s)
+              {{ moreFailedRows(remainingFailedCount, isZh) }}
             </div>
           </div>
           <div v-if="manualFixRows.length" class="meta-import__fixes">
             <div v-for="failure in manualFixRows" :key="`${failure.rowIndex}:${failure.fieldId ?? 'row'}`" class="meta-import__fix">
               <div class="meta-import__failure-head">
-                <strong>Fix Row {{ failure.rowNumber }}</strong>
+                <strong>{{ fixRowLabel(failure.rowNumber, isZh) }}</strong>
                 <span>{{ failure.message }}</span>
               </div>
               <div class="meta-import__fix-grid">
@@ -129,12 +129,12 @@
                   class="meta-import__fix-cell"
                   :class="{ 'meta-import__fix-cell--problem': failure.problemColumnIndexes.includes(ci) }"
                 >
-                  <span>{{ parsedHeaders[ci] || `Column ${ci + 1}` }}</span>
+                  <span>{{ parsedHeaders[ci] || columnLabel(ci, isZh) }}</span>
                   <input class="meta-import__fix-input" :value="cell" @input="updateFailedCell(failure.rowIndex, ci, ($event.target as HTMLInputElement).value)" />
                 </label>
               </div>
               <div v-if="failure.showPeopleHint" class="meta-import__fix-hint">
-                Use an exact email address or person record ID for this field.
+                {{ l('import.peopleExactHint') }}
               </div>
               <div v-if="failure.canUsePicker" class="meta-import__fix-picker-row">
                 <button class="meta-import__btn meta-import__btn--primary" @click="openPickerForFailure(failure)">
@@ -147,14 +147,14 @@
             </div>
           </div>
           <div class="meta-import__actions">
-            <button class="meta-import__btn" :disabled="isImporting" @click="goBackToPreview">Back to mapping</button>
+            <button class="meta-import__btn" :disabled="isImporting" @click="goBackToPreview">{{ l('import.backToMapping') }}</button>
             <button v-if="hasFailedImports && retryableFailureCount > 0" class="meta-import__btn meta-import__btn--primary" :disabled="!canRetryFailedRows" @click="retryFailedRows">
-              Retry failed rows
+              {{ l('import.retryFailedRows') }}
             </button>
             <button v-if="manualFixRows.length" class="meta-import__btn meta-import__btn--primary" :disabled="!canApplyFixes" @click="applyFixesAndRetry">
-              Apply fixes and retry
+              {{ l('import.applyFixes') }}
             </button>
-            <button class="meta-import__btn" :disabled="isImporting" @click="requestClose">Close</button>
+            <button class="meta-import__btn" :disabled="isImporting" @click="requestClose">{{ l('import.close') }}</button>
           </div>
         </div>
       </div>
@@ -173,11 +173,32 @@
 <script setup lang="ts">
 import { computed, nextTick, onBeforeUnmount, ref, watch } from 'vue'
 import MetaLinkPicker from './MetaLinkPicker.vue'
+import { useLocale } from '../../composables/useLocale'
 import type { LinkedRecordSummary, MetaField } from '../types'
 import { buildImportedRecords, parseDelimitedText } from '../import/delimited'
 import type { ImportBuildFailure, ImportBuildResult, ImportFieldOverrides, ImportValueResolver } from '../import/delimited'
 import { XLSX_MAX_BYTES, XLSX_MAX_ROWS, mapXlsxColumnsToFields, parseXlsxBuffer } from '../import/xlsx-mapping'
 import { isLinkField, isPersonField, linkActionLabel } from '../utils/link-fields'
+import {
+  columnLabel,
+  detectedRows,
+  fieldNoLongerImportable,
+  fileTooLarge,
+  fixRowLabel,
+  importComplete,
+  importLabel,
+  importRecords,
+  importResultSummary,
+  importingRecords,
+  manualRepairFieldRemoved,
+  mappedFieldRemoved,
+  moreDraftIssues,
+  moreFailedRows,
+  moreRows,
+  rowLabel,
+  selectedRepairInvalid,
+  xlsxTruncated,
+} from '../utils/meta-import-labels'
 
 type ImportResultFailure = ImportBuildFailure & {
   index?: number
@@ -227,6 +248,9 @@ const emit = defineEmits<{
   (e: 'import', payload: ImportBuildResult): void
   (e: 'update:dirty', dirty: boolean): void
 }>()
+
+const { isZh } = useLocale()
+const l = (key: Parameters<typeof importLabel>[0]) => importLabel(key, isZh.value)
 
 const step = ref<'paste' | 'preview' | 'importing' | 'result'>('paste')
 const rawText = ref('')
@@ -281,17 +305,14 @@ const manualFixRows = computed(() => (props.result?.failures ?? [])
       problemField: field,
       showPeopleHint: !!field && isPersonField(field) && /exact match|people value/i.test(failure.message),
       canUsePicker: !!field && isLinkField(field),
-      pickerButtonLabel: linkActionLabel(field, selectedSummaries.length),
+      pickerButtonLabel: linkActionLabel(field, selectedSummaries.length, isZh.value),
       selectedSummaries,
     }
   }))
 const resultSummaryText = computed(() => {
-  if (!props.result) return 'Import complete'
+  if (!props.result) return importComplete(isZh.value)
   const skipped = props.result.skipped ?? 0
-  if (props.result.failed > 0 && skipped > 0) return `${props.result.succeeded} imported, ${skipped} skipped, ${props.result.failed} failed`
-  if (props.result.failed > 0) return `${props.result.succeeded} imported, ${props.result.failed} failed`
-  if (skipped > 0) return `${props.result.succeeded} imported, ${skipped} skipped`
-  return `Imported ${props.result.succeeded} record(s)`
+  return importResultSummary(props.result.succeeded, skipped, props.result.failed, isZh.value)
 })
 const failedPreviewRows = computed(() => (props.result?.failures ?? []).slice(0, 5).map((failure) => ({
   ...failure,
@@ -325,12 +346,12 @@ const importDraftIssues = computed<ImportDraftIssue[]>(() => {
   for (const [columnIndex, fieldId] of Object.entries(fieldMapping.value)) {
     if (!fieldId) continue
     const field = fieldsById.value.get(fieldId)
-    const header = parsedHeaders.value[Number(columnIndex)] || `Column ${Number(columnIndex) + 1}`
+    const header = parsedHeaders.value[Number(columnIndex)] || columnLabel(Number(columnIndex), isZh.value)
     if (!field) {
       issues.set(`mapping:${fieldId}`, {
         kind: 'mapping-missing',
         fieldId,
-        message: `Mapped field for ${header} was removed in the background. Reconcile the draft before importing.`,
+        message: mappedFieldRemoved(header, isZh.value),
       })
       continue
     }
@@ -338,7 +359,7 @@ const importDraftIssues = computed<ImportDraftIssue[]>(() => {
       issues.set(`mapping:${fieldId}`, {
         kind: 'mapping-not-importable',
         fieldId,
-        message: `${field.name} is no longer an importable field. Reconcile the draft before importing.`,
+        message: fieldNoLongerImportable(field.name, isZh.value),
       })
     }
   }
@@ -349,7 +370,7 @@ const importDraftIssues = computed<ImportDraftIssue[]>(() => {
         issues.set(`override:${rowIndexText}:${fieldId}`, {
           kind: 'manual-override-invalid',
           fieldId,
-          message: 'A manual repair targets a field that was removed in the background. Reconcile the draft before importing.',
+          message: manualRepairFieldRemoved(isZh.value),
         })
         continue
       }
@@ -357,7 +378,7 @@ const importDraftIssues = computed<ImportDraftIssue[]>(() => {
         issues.set(`override:${rowIndexText}:${fieldId}`, {
           kind: 'manual-override-invalid',
           fieldId,
-          message: `A selected linked-record repair for ${field.name} is no longer valid because the field changed type. Reconcile the draft before importing.`,
+          message: selectedRepairInvalid(field.name, isZh.value),
         })
       }
     }
@@ -368,7 +389,7 @@ const hasImportDraftIssues = computed(() => importDraftIssues.value.length > 0)
 const importDraftIssueText = computed(() => {
   if (!importDraftIssues.value.length) return ''
   const [first, ...rest] = importDraftIssues.value
-  return rest.length > 0 ? `${first.message} ${rest.length} more issue(s) need review.` : first.message
+  return moreDraftIssues(first.message, rest.length, isZh.value)
 })
 const canImportPreview = computed(() => hasMappedFields.value && props.importing !== true && !hasImportDraftIssues.value)
 const canRetryFailedRows = computed(() => !props.importing && !hasImportDraftIssues.value && failedPreviewRows.value.length > 0)
@@ -517,13 +538,13 @@ function parseAndPreview() {
   const parsed = parseDelimitedText(rawText.value)
   const lines = parsed.rows
   if (lines.length < 2) {
-    parseError.value = 'Need at least one header row and one data row'
+    parseError.value = l('import.errorNeedRows')
     return
   }
   parsedHeaders.value = lines[0]
   parsedRows.value = lines.slice(1).filter((row) => row.some((cell) => cell.trim()))
   if (!parsedRows.value.length) {
-    parseError.value = 'No importable rows found'
+    parseError.value = l('import.errorNoRows')
     return
   }
 
@@ -541,7 +562,7 @@ async function readAndSetText(file: File) {
   try {
     rawText.value = await file.text()
   } catch (error: any) {
-    parseError.value = error.message ?? 'Failed to read file'
+    parseError.value = error.message ?? l('import.errorReadFile')
   }
 }
 
@@ -559,7 +580,7 @@ async function readAndSetXlsx(file: File) {
   parseError.value = ''
   parseWarning.value = ''
   if (file.size > XLSX_MAX_BYTES) {
-    parseError.value = `File too large (max ${(XLSX_MAX_BYTES / (1024 * 1024)).toFixed(0)} MB)`
+    parseError.value = fileTooLarge((XLSX_MAX_BYTES / (1024 * 1024)).toFixed(0), isZh.value)
     return
   }
   try {
@@ -567,7 +588,7 @@ async function readAndSetXlsx(file: File) {
     const buffer = await file.arrayBuffer()
     const result = parseXlsxBuffer(xlsx, buffer)
     if (!result.headers.length || !result.rows.length) {
-      parseError.value = 'No importable rows found in spreadsheet'
+      parseError.value = l('import.errorSpreadsheetEmpty')
       return
     }
     rawText.value = ''
@@ -575,11 +596,11 @@ async function readAndSetXlsx(file: File) {
     parsedRows.value = result.rows
     fieldMapping.value = mapXlsxColumnsToFields(result.headers, importableFields.value).mapping
     if (result.truncated) {
-      parseWarning.value = `Imported the first ${parsedRows.value.length} rows; remaining rows were skipped (limit ${XLSX_MAX_ROWS}).`
+      parseWarning.value = xlsxTruncated(parsedRows.value.length, XLSX_MAX_ROWS, isZh.value)
     }
     step.value = 'preview'
   } catch (error: any) {
-    parseError.value = error?.message ?? 'Failed to read Excel file'
+    parseError.value = error?.message ?? l('import.errorReadExcel')
   }
 }
 
@@ -628,7 +649,7 @@ function requestClose() {
     emit('cancel-import')
     return
   }
-  if (importDraftDirty.value && !window.confirm('Discard unsaved import changes?')) return
+  if (importDraftDirty.value && !window.confirm(l('import.discardConfirm'))) return
   clearImportDraft()
   emit('close')
 }

--- a/apps/web/src/multitable/utils/meta-import-labels.ts
+++ b/apps/web/src/multitable/utils/meta-import-labels.ts
@@ -1,0 +1,195 @@
+// Import modal chrome string table (T3C).
+//
+// Scope: MetaImportModal.vue UI chrome and frontend-owned fallback messages.
+// Imported headers, field names, cell values, selected linked-record labels,
+// and backend/import failure messages are user data and pass through unchanged.
+
+export type MetaImportLabelKey =
+  | 'import.title'
+  | 'import.recoveredDraft'
+  | 'import.pasteHint'
+  | 'import.fileDrop'
+  | 'import.textareaPlaceholder'
+  | 'import.cancel'
+  | 'import.preview'
+  | 'import.skip'
+  | 'import.reconcileDraft'
+  | 'import.back'
+  | 'import.cancelImport'
+  | 'import.failedReviewRetry'
+  | 'import.failedReviewMapping'
+  | 'import.skippedDuplicates'
+  | 'import.success'
+  | 'import.backToMapping'
+  | 'import.retryFailedRows'
+  | 'import.applyFixes'
+  | 'import.close'
+  | 'import.emptyRow'
+  | 'import.peopleExactHint'
+  | 'import.discardConfirm'
+  | 'import.errorNeedRows'
+  | 'import.errorNoRows'
+  | 'import.errorReadFile'
+  | 'import.errorSpreadsheetEmpty'
+  | 'import.errorReadExcel'
+
+const META_IMPORT_LABELS: Record<MetaImportLabelKey, { en: string; zh: string }> = {
+  'import.title': { en: 'Import Records', zh: '导入记录' },
+  'import.recoveredDraft': {
+    en: 'Recovered your previous import draft for this sheet.',
+    zh: '已恢复此表的上次导入草稿。',
+  },
+  'import.pasteHint': {
+    en: 'Paste tab-separated data from Excel or Google Sheets (first row = headers):',
+    zh: '粘贴来自 Excel 或 Google Sheets 的制表符分隔数据（第一行为表头）：',
+  },
+  'import.fileDrop': {
+    en: 'Choose a CSV/TSV/Excel file or drop it here',
+    zh: '选择 CSV/TSV/Excel 文件，或拖到这里',
+  },
+  'import.textareaPlaceholder': {
+    en: 'Name\tAge\tEmail\nAlice\t30\talice@example.com',
+    zh: '姓名\t年龄\t邮箱\n张三\t30\tzhangsan@example.com',
+  },
+  'import.cancel': { en: 'Cancel', zh: '取消' },
+  'import.preview': { en: 'Preview', zh: '预览' },
+  'import.skip': { en: '(skip)', zh: '(跳过)' },
+  'import.reconcileDraft': { en: 'Reconcile draft', zh: '修复草稿' },
+  'import.back': { en: 'Back', zh: '返回' },
+  'import.cancelImport': { en: 'Cancel import', zh: '取消导入' },
+  'import.failedReviewRetry': {
+    en: 'Review the failed rows below, then retry just those rows or return to mapping.',
+    zh: '请检查下方失败行，然后仅重试这些行，或返回映射。',
+  },
+  'import.failedReviewMapping': {
+    en: 'Review the failed rows below and return to mapping to fix the source data.',
+    zh: '请检查下方失败行，并返回映射以修正源数据。',
+  },
+  'import.skippedDuplicates': {
+    en: 'Some rows were skipped as duplicates.',
+    zh: '部分重复行已跳过。',
+  },
+  'import.success': {
+    en: 'The selected records were imported successfully.',
+    zh: '所选记录已成功导入。',
+  },
+  'import.backToMapping': { en: 'Back to mapping', zh: '返回映射' },
+  'import.retryFailedRows': { en: 'Retry failed rows', zh: '重试失败行' },
+  'import.applyFixes': { en: 'Apply fixes and retry', zh: '应用修正并重试' },
+  'import.close': { en: 'Close', zh: '关闭' },
+  'import.emptyRow': { en: '(empty row)', zh: '(空行)' },
+  'import.peopleExactHint': {
+    en: 'Use an exact email address or person record ID for this field.',
+    zh: '请为此字段使用精确邮箱地址或人员记录 ID。',
+  },
+  'import.discardConfirm': {
+    en: 'Discard unsaved import changes?',
+    zh: '放弃未保存的导入更改吗？',
+  },
+  'import.errorNeedRows': {
+    en: 'Need at least one header row and one data row',
+    zh: '至少需要一行表头和一行数据',
+  },
+  'import.errorNoRows': { en: 'No importable rows found', zh: '未找到可导入的行' },
+  'import.errorReadFile': { en: 'Failed to read file', zh: '读取文件失败' },
+  'import.errorSpreadsheetEmpty': {
+    en: 'No importable rows found in spreadsheet',
+    zh: '电子表格中未找到可导入的行',
+  },
+  'import.errorReadExcel': { en: 'Failed to read Excel file', zh: '读取 Excel 文件失败' },
+}
+
+export function importLabel(key: MetaImportLabelKey, isZh: boolean): string {
+  const entry = META_IMPORT_LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+export function detectedRows(count: number, isZh: boolean): string {
+  return isZh
+    ? `已识别 ${count} 条记录。请将列映射到字段：`
+    : `${count} record(s) detected. Map columns to fields:`
+}
+
+export function moreRows(count: number, isZh: boolean): string {
+  return isZh ? `... 另有 ${count} 行` : `... and ${count} more`
+}
+
+export function importingRecords(count: number, isZh: boolean): string {
+  return isZh ? `正在导入 ${count} 条记录...` : `Importing ${count} record(s)...`
+}
+
+export function importRecords(count: number, isZh: boolean): string {
+  return isZh ? `导入 ${count} 条记录` : `Import ${count} record(s)`
+}
+
+export function importComplete(isZh: boolean): string {
+  return isZh ? '导入完成' : 'Import complete'
+}
+
+export function importResultSummary(succeeded: number, skipped: number, failed: number, isZh: boolean): string {
+  if (failed > 0 && skipped > 0) {
+    return isZh
+      ? `${succeeded} 条已导入，${skipped} 条已跳过，${failed} 条失败`
+      : `${succeeded} imported, ${skipped} skipped, ${failed} failed`
+  }
+  if (failed > 0) return isZh ? `${succeeded} 条已导入，${failed} 条失败` : `${succeeded} imported, ${failed} failed`
+  if (skipped > 0) return isZh ? `${succeeded} 条已导入，${skipped} 条已跳过` : `${succeeded} imported, ${skipped} skipped`
+  return isZh ? `已导入 ${succeeded} 条记录` : `Imported ${succeeded} record(s)`
+}
+
+export function rowLabel(rowNumber: number, isZh: boolean): string {
+  return isZh ? `第 ${rowNumber} 行` : `Row ${rowNumber}`
+}
+
+export function fixRowLabel(rowNumber: number, isZh: boolean): string {
+  return isZh ? `修正第 ${rowNumber} 行` : `Fix Row ${rowNumber}`
+}
+
+export function columnLabel(index: number, isZh: boolean): string {
+  return isZh ? `第 ${index + 1} 列` : `Column ${index + 1}`
+}
+
+export function moreFailedRows(count: number, isZh: boolean): string {
+  return isZh ? `... 另有 ${count} 个失败行` : `... and ${count} more failed row(s)`
+}
+
+export function moreDraftIssues(firstMessage: string, restCount: number, isZh: boolean): string {
+  if (restCount <= 0) return firstMessage
+  return isZh
+    ? `${firstMessage} 另有 ${restCount} 个问题需要检查。`
+    : `${firstMessage} ${restCount} more issue(s) need review.`
+}
+
+export function mappedFieldRemoved(header: string, isZh: boolean): string {
+  return isZh
+    ? `${header} 映射的字段已在后台被删除。请先修复草稿再导入。`
+    : `Mapped field for ${header} was removed in the background. Reconcile the draft before importing.`
+}
+
+export function fieldNoLongerImportable(fieldName: string, isZh: boolean): string {
+  return isZh
+    ? `${fieldName} 不再是可导入字段。请先修复草稿再导入。`
+    : `${fieldName} is no longer an importable field. Reconcile the draft before importing.`
+}
+
+export function manualRepairFieldRemoved(isZh: boolean): string {
+  return isZh
+    ? '一个手动修复项指向了后台已删除的字段。请先修复草稿再导入。'
+    : 'A manual repair targets a field that was removed in the background. Reconcile the draft before importing.'
+}
+
+export function selectedRepairInvalid(fieldName: string, isZh: boolean): string {
+  return isZh
+    ? `为 ${fieldName} 选择的关联记录修复项已失效，因为该字段类型已变更。请先修复草稿再导入。`
+    : `A selected linked-record repair for ${fieldName} is no longer valid because the field changed type. Reconcile the draft before importing.`
+}
+
+export function fileTooLarge(maxMegabytes: string, isZh: boolean): string {
+  return isZh ? `文件过大（最大 ${maxMegabytes} MB）` : `File too large (max ${maxMegabytes} MB)`
+}
+
+export function xlsxTruncated(importedRows: number, maxRows: number, isZh: boolean): string {
+  return isZh
+    ? `已导入前 ${importedRows} 行；其余行已跳过（上限 ${maxRows}）。`
+    : `Imported the first ${importedRows} rows; remaining rows were skipped (limit ${maxRows}).`
+}

--- a/apps/web/tests/link-fields-i18n.spec.ts
+++ b/apps/web/tests/link-fields-i18n.spec.ts
@@ -10,8 +10,9 @@ const personField: MetaField = { id: 'owner', name: 'Owner', type: 'person' as M
 const recordField: MetaField = { id: 'parent', name: 'Parent', type: 'link' as MetaField['type'] }
 
 describe('linkActionLabel — backwards compatibility (isZh default = false)', () => {
-  it('defaults to English when no isZh arg is passed — MetaCellEditor / MetaImportModal stay unchanged', () => {
-    // record branch (the T3A2 unreachable-fallback case + MetaImportModal)
+  it('defaults to English when no isZh arg is passed — legacy callers stay unchanged', () => {
+    // record branch (the T3A2 unreachable-fallback case and any caller that
+    // intentionally omits locale)
     expect(linkActionLabel(recordField, 0)).toBe('Choose linked records...')
     expect(linkActionLabel(recordField, 1)).toBe('Edit linked record (1)')
     expect(linkActionLabel(recordField, 5)).toBe('Edit linked records (5)')

--- a/apps/web/tests/multitable-import-modal.spec.ts
+++ b/apps/web/tests/multitable-import-modal.spec.ts
@@ -1,5 +1,6 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, ref } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
 import MetaImportModal from '../src/multitable/components/MetaImportModal.vue'
 
 const { mockListLinkOptions } = vi.hoisted(() => ({
@@ -21,6 +22,7 @@ async function flushUi() {
 describe('MetaImportModal', () => {
   beforeEach(() => {
     mockListLinkOptions.mockReset()
+    useLocale().setLocale('en')
     window.localStorage.clear()
   })
 
@@ -213,6 +215,100 @@ describe('MetaImportModal', () => {
     expect(mappingOptions).toContain('Title')
     expect(mappingOptions).not.toContain('Locked')
     expect(mappingOptions).not.toContain('Score')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('renders zh-CN import chrome while preserving imported headers, field names, and cells raw', async () => {
+    useLocale().setLocale('zh-CN')
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaImportModal, {
+          visible: true,
+          fields: [
+            { id: 'fld_name', name: 'Name', type: 'string' },
+            { id: 'fld_status', name: 'Status', type: 'select', options: [{ value: 'Open' }] },
+          ],
+          importing: false,
+          result: null,
+          onClose: vi.fn(),
+          onImport: vi.fn(),
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const initialText = document.body.textContent ?? ''
+    expect(initialText).toContain('导入记录')
+    expect(initialText).toContain('粘贴来自 Excel 或 Google Sheets 的制表符分隔数据')
+    expect(initialText).toContain('选择 CSV/TSV/Excel 文件，或拖到这里')
+    expect(initialText).not.toContain('Import Records')
+    expect(document.body.querySelector<HTMLTextAreaElement>('.meta-import__textarea')?.getAttribute('placeholder')).toBe('姓名\t年龄\t邮箱\n张三\t30\tzhangsan@example.com')
+
+    const textarea = document.body.querySelector('.meta-import__textarea') as HTMLTextAreaElement
+    textarea.value = 'Name\tStatus\nAlpha\tOpen'
+    textarea.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    ;(document.body.querySelector('.meta-import__btn--primary') as HTMLButtonElement)?.click()
+    await flushUi()
+
+    const previewText = document.body.textContent ?? ''
+    expect(previewText).toContain('已识别 1 条记录。请将列映射到字段：')
+    expect(previewText).toContain('导入 1 条记录')
+    expect(previewText).toContain('(跳过)')
+    expect(previewText).toContain('Name')
+    expect(previewText).toContain('Status')
+    expect(previewText).toContain('Alpha')
+    expect(previewText).toContain('Open')
+    expect(previewText).not.toContain('Map columns to fields')
+    expect(previewText).not.toContain('Import 1 record(s)')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('localizes zh-CN result repair chrome while preserving backend failure text raw', async () => {
+    useLocale().setLocale('zh-CN')
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaImportModal, {
+          visible: true,
+          fields: [{ id: 'fld_owner', name: 'Owner', type: 'link', property: { refKind: 'user', foreignSheetId: 'sheet_people' } }],
+          importing: false,
+          result: {
+            attempted: 1,
+            succeeded: 0,
+            failed: 1,
+            firstError: 'Backend raw failure',
+            failures: [{ rowIndex: 0, fieldId: 'fld_owner', retryable: false, message: 'Backend raw failure' }],
+          },
+          onClose: vi.fn(),
+          onImport: vi.fn(),
+        })
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const text = document.body.textContent ?? ''
+    expect(text).toContain('0 条已导入，1 条失败')
+    expect(text).toContain('请检查下方失败行，并返回映射以修正源数据。')
+    expect(text).toContain('修正第 2 行')
+    expect(text).toContain('选择人员...')
+    expect(text).toContain('Backend raw failure')
+    expect(text).not.toContain('Review the failed rows below')
+    expect(text).not.toContain('Choose people')
 
     app.unmount()
     container.remove()

--- a/docs/development/multitable-t3c-import-modal-i18n-design-20260520.md
+++ b/docs/development/multitable-t3c-import-modal-i18n-design-20260520.md
@@ -1,0 +1,47 @@
+# T3C - Import Modal i18n Design
+
+- **Date**: 2026-05-20
+- **Type**: small implementation slice
+- **Status**: implemented; paired verification in `docs/development/multitable-t3c-import-modal-i18n-verification-20260520.md`
+- **Preceded by**:
+  - `docs/development/multitable-t3b3-link-picker-i18n-design-20260520.md`
+  - `docs/development/multitable-t3b4-alt-view-comment-chip-i18n-design-20260520.md`
+- **Goal**: localize the record import modal chrome without changing import behavior, parsing, repair flow, or backend contracts.
+
+## Scope
+
+This slice covers `MetaImportModal.vue` only:
+
+| Area | Localized |
+|---|---|
+| Paste step | title, hint, file drop copy, placeholder, cancel/preview buttons |
+| Preview step | restored-draft banner, detected-row hint, skip option, reconcile action, back/import buttons, overflow row count |
+| Importing step | progress text and cancel-import button |
+| Result/repair step | success/warning summary, failed-row guidance, row/fix labels, empty-row fallback, repair actions, close button |
+| Frontend-owned fallback errors | no rows, file too large, read fallback, spreadsheet empty, truncated XLSX warning |
+| Linked-record repair button | `linkActionLabel(field, count, isZh.value)` |
+
+## Boundaries
+
+Out of scope:
+
+- Import parsing, XLSX mapping, record building, retry behavior, draft persistence, and link picker data fetching.
+- Backend, API routes, OpenAPI, migrations, attendance tables, and direct `meta_*` writes.
+- User-authored data: imported headers, cell values, field names, selected linked-record display values, option values, file contents, and backend/import failure messages remain raw.
+- Full field/view manager i18n and broader workbench chrome beyond the import modal.
+
+## Implementation Notes
+
+- Added `apps/web/src/multitable/utils/meta-import-labels.ts` as a per-surface label module, matching the existing T3B modules.
+- `MetaImportModal.vue` now reads `useLocale().isZh` and uses:
+  - `importLabel(...)` for static copy.
+  - helper functions for count/field-name interpolation.
+  - raw interpolation for field names, imported data, and failure messages.
+- The modal now passes locale into `linkActionLabel`, while the helper's default remains English for legacy callers that intentionally omit the third argument.
+
+## Acceptance
+
+- zh-CN renders localized import modal chrome across paste, preview, importing, and result/repair states.
+- English/default locale remains backward-compatible.
+- Imported table data and backend failure strings are not translated.
+- The existing import flow and picker repair behavior remain unchanged.

--- a/docs/development/multitable-t3c-import-modal-i18n-verification-20260520.md
+++ b/docs/development/multitable-t3c-import-modal-i18n-verification-20260520.md
@@ -1,0 +1,75 @@
+# T3C - Import Modal i18n Verification
+
+- **Date**: 2026-05-20
+- **Scope**: `MetaImportModal.vue` import modal chrome.
+- **Design packet**: `docs/development/multitable-t3c-import-modal-i18n-design-20260520.md`
+- **Status**: implemented and locally verified.
+
+## Implementation Summary
+
+- Added `meta-import-labels.ts` with English/zh-CN static labels and interpolation helpers.
+- Rewired `MetaImportModal.vue` to use `useLocale().isZh`, `importLabel`, and helper functions.
+- Passed `isZh.value` into `linkActionLabel` for import repair picker buttons.
+- Updated the link helper compatibility spec wording so legacy English default coverage no longer claims the import modal omits locale.
+
+## Boundary Check
+
+| Area | Result |
+|---|---|
+| Backend/API/OpenAPI | Not touched |
+| Migrations / `attendance_*` | Not touched |
+| Direct `meta_*` writes | Not touched |
+| Import parser / record builder | Not changed |
+| Link picker API calls | Not changed |
+| User-authored data | Preserved raw |
+
+## Test Coverage Added
+
+| File | Coverage |
+|---|---|
+| `apps/web/tests/multitable-import-modal.spec.ts` | Adds zh-CN paste/preview assertions, raw header/cell/field-name preservation, zh-CN repair-result chrome, and raw backend failure preservation. |
+| `apps/web/tests/link-fields-i18n.spec.ts` | Keeps helper default-English regression coverage while reflecting that the import modal now opts into locale. |
+
+## Verification Commands
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-import-modal.spec.ts \
+  tests/link-fields-i18n.spec.ts --watch=false
+```
+
+Result: PASS, 24 tests across 2 files.
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-import-modal.spec.ts \
+  tests/link-fields-i18n.spec.ts \
+  tests/meta-link-picker-i18n.spec.ts \
+  tests/meta-link-picker-labels.spec.ts --watch=false
+```
+
+Result: PASS, 30 tests across 4 files.
+
+```bash
+pnpm --filter @metasheet/web type-check
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: PASS. Vite emitted the existing dynamic-import and large-chunk warnings only.
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+## Acceptance Notes
+
+- The slice is intentionally additive: no new client-side validator, import adapter, or API behavior was introduced.
+- `MetaLinkPicker` remains localized by T3B3; this slice only localizes the import modal's button that opens it.
+- Backend/import failure messages remain raw by design because they may contain source-specific diagnostics or user data.


### PR DESCRIPTION
## Summary

Localizes the multitable import modal chrome for zh-CN while preserving import behavior and user data:

- adds `meta-import-labels.ts` for import-modal static copy and interpolation helpers
- wires `MetaImportModal.vue` to `useLocale().isZh`
- passes locale into `linkActionLabel` for import repair picker buttons
- keeps imported headers, cell values, field names, selected linked-record labels, and backend/import failure messages raw
- adds design and verification MD for the T3C import-modal slice

## Boundaries

- No backend/API/OpenAPI changes
- No migrations, `attendance_*` changes, or direct `meta_*` writes
- No parser, record-builder, draft-persistence, retry, or link-picker API behavior changes
- No broad field/view manager i18n in this slice

## Test plan

- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/multitable-import-modal.spec.ts tests/link-fields-i18n.spec.ts --watch=false` — 24 tests PASS
- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/multitable-import-modal.spec.ts tests/link-fields-i18n.spec.ts tests/meta-link-picker-i18n.spec.ts tests/meta-link-picker-labels.spec.ts --watch=false` — 30 tests PASS
- [x] `pnpm --filter @metasheet/web type-check` — PASS
- [x] `pnpm --filter @metasheet/web build` — PASS, existing Vite chunk/dynamic-import warnings only
- [x] `git diff --check` / `git diff --cached --check` — PASS
