### PR TITLE
fix(onprem): trustworthy scheduled-task exit code + apply-exit marker (#1526)

### DIFF
--- a/docs/development/onprem-scheduled-task-exit-marker-design-20260520.md
+++ b/docs/development/onprem-scheduled-task-exit-marker-design-20260520.md
@@ -1,0 +1,183 @@
+# On-prem scheduled-task exit-marker fix - design - 2026-05-20
+
+## Problem (from the 2026-05-20 bridge feedback on #1526)
+
+After #1696 (apply env loading) and #1699 (self-bootstrap launcher) shipped,
+operators still see a misleading state on Windows on-prem upgrades:
+
+- `apply` log ends with `Package deploy complete` and healthcheck `200`,
+- but the outer Scheduled Task / wrapper exits **1**,
+- and no parseable `apply exit=N` marker is anywhere in the chain, so
+  there is no way to tell at a glance whether `apply` itself reported
+  failure or the wrapper introduced the non-zero.
+
+## Root cause
+
+The fault is at the launcher boundary, then compounded by the outer
+wrappers.
+
+### Launcher: `$LASTEXITCODE` leak across an in-process call
+
+`scripts/ops/multitable-onprem-deploy-launcher.ps1` invoked the staged
+apply helper via:
+
+```powershell
+& $stagedApply -RootDir $resolvedRoot -PackageArchive $resolvedArchive
+if ($null -ne $LASTEXITCODE) {
+  $launcherExit = $LASTEXITCODE
+} else {
+  $launcherExit = 0
+}
+```
+
+The call operator `&` runs the .ps1 in-process. `$LASTEXITCODE` is the
+**session-wide** last external-program exit code. Apply.ps1 itself
+invokes several external programs internally (`tar`, `node migrate.js`,
+`pm2`, the cmd.exe dependency-refresh wrapper, etc.). Whatever the
+**last external program** apply touched is what `$LASTEXITCODE` reflects
+after `& $stagedApply ...` returns - **not the apply script's overall
+outcome**.
+
+Worse, apply.ps1's contract is `$ErrorActionPreference = 'Stop'` plus
+`throw` on real failures. Successful completion does **not** call
+`exit 0`. So the post-`&` `$LASTEXITCODE` can be any of:
+
+- whatever the last internal external program returned (often 0, but
+  not guaranteed across all code paths);
+- whatever it was before the call, if apply.ps1 only used cmdlets;
+- mismatched with the true outcome on any path that ends with a
+  non-fatal exit-1 external call (e.g., a `findstr` that found no
+  match, a `pm2 list` after a fresh start, etc.).
+
+This is the silent leak that puts a stray `1` into the scheduled task's
+Last Result while the apply log still reads "complete".
+
+### deploy-remote.bat: fire-and-forget that ignores the apply outcome
+
+`deploy-remote.bat`, the wrapper most scheduled-task setups call,
+contained:
+
+```batch
+start "" /min cmd /c "call deploy.bat ... >> deploy-remote.log 2>&1"
+echo [multitable-onprem-deploy-remote] started. See output\logs\deploy-remote.log
+exit /b 0
+```
+
+`start ""` fires the inner `call deploy.bat` as a separate background
+process; the launching cmd returns immediately. `deploy-remote.bat`
+**always** exits 0, regardless of whether the background apply
+eventually succeeds or fails. The Last Result the scheduled task records
+is therefore unrelated to the apply outcome; the log file has no final
+`apply exit=N` line. (When the operator did see `1`, it was almost
+certainly the launcher leak above and a scheduled-task configured to
+call `deploy.bat` directly, not deploy-remote.bat - but both paths are
+misleading.)
+
+### No `apply exit=` marker anywhere
+
+Grep across `scripts/ops` for `apply exit=` / `APPLY_EXIT` returned
+nothing. The chain had no stable last-line breadcrumb the operator could
+match against the scheduled-task Last Result. Bridge feedback explicitly
+asks for it.
+
+## Fix
+
+Three coordinated, narrow changes - all in `scripts/ops/*` heredocs +
+the launcher.
+
+### 1. Launcher: drop `$LASTEXITCODE`, use the throw/no-throw contract
+
+```powershell
+try {
+  & $stagedApply -RootDir $resolvedRoot -PackageArchive $resolvedArchive
+  $launcherExit = 0
+}
+catch {
+  Write-LauncherInfo ("Apply helper raised an error: {0}" -f $_.Exception.Message)
+  $launcherExit = 1
+}
+```
+
+apply.ps1's contract is "throw on failure, return on success". The
+launcher honors that contract and ignores `$LASTEXITCODE` for this call.
+A successful apply now reliably yields `$launcherExit = 0`; a failure
+throws and yields 1.
+
+### 2. Launcher: emit `apply exit=N` as the last informative log line
+
+After the staging cleanup, before the script exits:
+
+```powershell
+Write-LauncherInfo ("apply exit={0}" -f $launcherExit)
+exit $launcherExit
+```
+
+This is the **inner-most source of truth** for the apply outcome. Outer
+wrappers echo the same marker; this one is the parseable canonical line.
+
+Contract note: the launcher's `Write-LauncherInfo "apply exit=..."`
+runs at script body scope, after the `try/finally`, before `exit`.
+If apply.ps1 ever switched from `throw` to an uncaught `exit N`
+inside `& $stagedApply`, PowerShell would terminate the launcher
+script too and this marker line would not fire. The launcher would
+still exit with apply's code (correct), but the parseable marker
+would be absent. Documenting this so a future change to apply.ps1's
+error pattern does not silently break the marker contract.
+
+### 3. deploy.bat / deploy-remote.bat / deploy-${LABEL}.bat: capture +
+emit + propagate
+
+Every batch wrapper that calls the layer below now captures
+`%ERRORLEVEL%` into a named local `APPLY_EXIT`, echoes a parseable
+`[multitable-onprem-deploy*] apply exit=%APPLY_EXIT%` line, and exits
+with `exit /b %APPLY_EXIT%`. The dedicated logged-to-file wrapper
+(`deploy-remote.bat`) **also** appends that marker into
+`output\logs\deploy-remote.log` so a scheduled-task operator can
+correlate the file with the Last Result.
+
+`deploy-remote.bat` additionally changes from `start ""` (background) to
+synchronous `call`. The original "fire-and-forget" semantics is what
+made the wrapper return 0 regardless of apply outcome; that was the
+opposite of what the user needs. The trade is acknowledged in the
+verification MD - if any caller depended on the wrapper returning
+immediately, they should instead use the underlying `deploy.bat` and
+their own background scheduler.
+
+## Package verifier gate
+
+`verify_windows_entrypoints` gets new assertions and one new negative:
+
+- `deploy.bat` must have `set "APPLY_EXIT=%ERRORLEVEL%"`,
+  `[multitable-onprem-deploy] apply exit=%APPLY_EXIT%`, and
+  `exit /b %APPLY_EXIT%`.
+- launcher.ps1 must emit an `apply exit=` line and must **not** contain
+  the `if ($null -ne $LASTEXITCODE) {` leak pattern.
+- `deploy-remote.bat` must contain the synchronous
+  `call "%~dp0deploy.bat" "%~1" >> "%~dp0output\logs\deploy-remote.log" 2>&1`
+  redirection, `set "APPLY_EXIT=%ERRORLEVEL%"`, the parseable marker
+  with the `deploy-remote` prefix, and `exit /b %APPLY_EXIT%`. The
+  fire-and-forget `start "" /min cmd /c` pattern is now a die().
+- `deploy-${LABEL}.bat` must also capture + echo + propagate APPLY_EXIT.
+
+A pre-fix package (latest build before this PR) dies on the very first
+new assertion with the exact intended message.
+
+## Out of scope (deliberate)
+
+- No `plugin-integration-core` change.
+- No DB migration.
+- No API runtime / frontend / K3 Save / Submit / Audit change.
+- No SQL / TLS failure summarization (separate #1526 actionable).
+- Customer GATE **not** lifted. This PR makes the scheduled-task Last
+  Result trustworthy; it does not unblock live PoC.
+
+## Files touched
+
+- `scripts/ops/multitable-onprem-deploy-launcher.ps1` (drop
+  `$LASTEXITCODE` leak; emit `apply exit=N`)
+- `scripts/ops/multitable-onprem-package-build.sh`
+  (deploy.bat / deploy-remote.bat / deploy-${LABEL}.bat heredocs +
+  comment context)
+- `scripts/ops/multitable-onprem-package-verify.sh`
+  (verify_windows_entrypoints assertions)
+- this design MD + companion verification MD

--- a/docs/development/onprem-scheduled-task-exit-marker-verification-20260520.md
+++ b/docs/development/onprem-scheduled-task-exit-marker-verification-20260520.md
@@ -1,0 +1,194 @@
+# On-prem scheduled-task exit-marker fix - verification - 2026-05-20
+
+Companion to `onprem-scheduled-task-exit-marker-design-20260520.md`. Ops
+only: launcher.ps1 + build / verify scripts; no `plugin-integration-core`,
+no DB migration, no API runtime, no route, no frontend, no K3
+Save/Submit/Audit.
+
+## Local evidence (all on the isolated worktree)
+
+### 1. Syntax / static checks
+
+```text
+bash -n scripts/ops/multitable-onprem-package-build.sh    -> exit 0
+bash -n scripts/ops/multitable-onprem-package-verify.sh   -> exit 0
+git diff --check                                          -> exit 0
+```
+
+`pwsh` is not installed on this dev host; the launcher's PowerShell
+parse will be exercised on Windows-side CI / on-prem apply.
+
+### 2. End-to-end build + verify (positive)
+
+```text
+pnpm install --frozen-lockfile                            -> Done in 3.4s
+BUILD_WEB=1 BUILD_BACKEND=1 INSTALL_DEPS=0 \
+  bash scripts/ops/multitable-onprem-package-build.sh
+  -> exit 0; produced metasheet-multitable-onprem-v2.5.0-20260519-205803.zip
+
+bash scripts/ops/multitable-onprem-package-verify.sh <that zip>
+  -> "Package verify OK", exit 0
+```
+
+### 3. Bundled wrappers carry every marker (visual check)
+
+After extracting the produced zip:
+
+**deploy.bat**
+
+```batch
+powershell ... -File "%~dp0scripts\ops\multitable-onprem-deploy-launcher.ps1" -RootDir "%~dp0." -PackageArchive "%~1"
+set "APPLY_EXIT=%ERRORLEVEL%"
+echo [multitable-onprem-deploy] apply exit=%APPLY_EXIT%
+exit /b %APPLY_EXIT%
+```
+
+**deploy-remote.bat** (now synchronous)
+
+```batch
+if not exist "%~dp0output\logs" mkdir "%~dp0output\logs"
+call "%~dp0deploy.bat" "%~1" >> "%~dp0output\logs\deploy-remote.log" 2>&1
+set "APPLY_EXIT=%ERRORLEVEL%"
+>> "%~dp0output\logs\deploy-remote.log" echo [multitable-onprem-deploy-remote] apply exit=%APPLY_EXIT%
+echo [multitable-onprem-deploy-remote] apply exit=%APPLY_EXIT%. See output\logs\deploy-remote.log
+exit /b %APPLY_EXIT%
+```
+
+The previous `start "" /min cmd /c ... ; exit /b 0` fire-and-forget
+pattern is gone.
+
+**deploy-${LABEL}.bat**
+
+```batch
+call "%~dp0deploy.bat" "%~1"
+set "APPLY_EXIT=%ERRORLEVEL%"
+echo [multitable-onprem-deploy-label] apply exit=%APPLY_EXIT%
+exit /b %APPLY_EXIT%
+```
+
+**multitable-onprem-deploy-launcher.ps1** (tail)
+
+```powershell
+try {
+  & $stagedApply -RootDir $resolvedRoot -PackageArchive $resolvedArchive
+  $launcherExit = 0
+}
+catch {
+  Write-LauncherInfo ("Apply helper raised an error: {0}" -f $_.Exception.Message)
+  $launcherExit = 1
+}
+...
+Write-LauncherInfo ("apply exit={0}" -f $launcherExit)
+exit $launcherExit
+```
+
+The `if ($null -ne $LASTEXITCODE) {` leak is gone.
+
+### 4. Negative proof: pre-fix zip dies on the first new assertion
+
+A previously-built zip (built right before this fix landed):
+
+```text
+/Users/.../output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-20260519-200530.zip
+
+bash scripts/ops/multitable-onprem-package-verify.sh <pre-fix zip>
+  -> [multitable-onprem-package-verify] ERROR: deploy.bat must capture
+     the launcher exit code into APPLY_EXIT
+```
+
+The new gate dies on the very first new deploy.bat assertion, with the
+exact intended message. To prove the remaining new assertions are also
+real gates (not single-bit speculation), here is the empirical
+per-marker count in the same pre-fix zip:
+
+| File | New marker | Count in pre-fix zip |
+| --- | --- | --- |
+| deploy.bat | `set "APPLY_EXIT=%ERRORLEVEL%"` | 0 |
+| deploy.bat | `[multitable-onprem-deploy] apply exit=` | 0 |
+| deploy.bat | `exit /b %APPLY_EXIT%` | 0 |
+| launcher.ps1 | `apply exit=` | 0 |
+| deploy-remote.bat | `set "APPLY_EXIT=%ERRORLEVEL%"` | 0 |
+| deploy-remote.bat | `[multitable-onprem-deploy-remote] apply exit=` | 0 |
+| deploy-remote.bat | `exit /b %APPLY_EXIT%` | 0 |
+| deploy-${LABEL}.bat | `set "APPLY_EXIT=%ERRORLEVEL%"` | 0 |
+| deploy-${LABEL}.bat | `[multitable-onprem-deploy-label] apply exit=` | 0 |
+| deploy-${LABEL}.bat | `exit /b %APPLY_EXIT%` | 0 |
+| deploy-remote.bat | `start "" /min cmd /c` (the new **negative** the gate forbids) | 1 |
+
+All 10 new positive assertions would fire on this zip; the new negative
+(fire-and-forget pattern) would also fire because the pre-fix zip
+contains it. The gate is multi-bit real, not single-bit wishful.
+
+## Behavior change: `deploy-remote.bat` is now synchronous
+
+The previous `deploy-remote.bat` returned immediately ("fire and
+forget"), letting `cmd.exe` close while apply ran in a background
+process. That is incompatible with the user-stated requirement
+("outer wrapper returns 0 on success and non-zero on failure"): if the
+wrapper returns before apply completes, the outer caller has no way to
+get a meaningful exit code.
+
+If a caller specifically needs background semantics:
+
+- run their own `start ""` against `deploy.bat`, or
+- use a scheduled task with a separate completion handler.
+
+This is the documented trade. The PR description and #1526 follow-up
+comment both call this out.
+
+## Acceptance criteria mapped to evidence
+
+| Criterion | Evidence |
+| --- | --- |
+| Real code path located, not guessed | `write_windows_entrypoints` in `multitable-onprem-package-build.sh`; the four heredocs (deploy.bat / deploy-remote.bat / deploy-${LABEL}.bat / bootstrap-admin.bat); and the launcher.ps1 itself. All visible in the diff. |
+| Outer wrapper exits 0 on apply success | launcher's throw/no-throw contract -> launcher exits 0; deploy.bat captures + propagates; deploy-remote.bat and deploy-${LABEL}.bat capture + propagate. End-to-end synchronously. |
+| Outer wrapper exits non-zero on apply failure | Same chain in reverse: apply.ps1 throws -> launcher catch sets `$launcherExit = 1` -> PowerShell exits 1 -> %ERRORLEVEL%=1 -> APPLY_EXIT=1 -> `exit /b %APPLY_EXIT%`. |
+| `apply exit=0` written stably on success | launcher emits via `Write-LauncherInfo "apply exit={0}"`; deploy.bat / deploy-remote.bat / deploy-${LABEL}.bat all echo their own labeled marker; deploy-remote.bat also appends to `output\logs\deploy-remote.log`. |
+| Package verify detects relevant markers | New assertions in `verify_windows_entrypoints`; pre-fix zip dies on the first one with the exact intended message. |
+| bash -n on related shell scripts | exit 0 (both) |
+| package build/verify | exit 0 / "Package verify OK" |
+| git diff --check | exit 0 |
+
+## Deployment impact
+
+- Operators currently relying on the old `deploy-remote.bat` "return
+  immediately" behavior will see the wrapper now block until apply
+  completes. The trade is necessary for a meaningful exit code; the
+  background pattern can still be assembled by the caller.
+- No env var, no migration, no flag, no route, no bundle behavior
+  change.
+- Scheduled-task Last Result becomes a trustworthy success/failure
+  signal that matches the underlying apply outcome.
+- `deploy-remote.log` now ends with a parseable marker
+  (`[multitable-onprem-deploy-remote] apply exit=N`) so operators can
+  correlate a log file with the scheduled-task Last Result without
+  scanning the full log body.
+
+End-to-end log capture: `Write-Info` from apply.ps1 and
+`Write-LauncherInfo` from the launcher both write to stdout via
+PowerShell's `Write-Output`. `deploy.bat` inherits that stdout.
+`deploy-remote.bat`'s `>> "%~dp0output\logs\deploy-remote.log" 2>&1`
+redirection captures both, so #1696's `Loaded env from ...` line and
+this PR's `apply exit=N` line both land in deploy-remote.log on the
+scheduled-task path - no separate plumbing needed.
+
+## GATE-blocking status
+
+This PR does **not** lift the customer GATE. SQL Server / TLS failure
+summarization and K3 Save / Submit / Audit behavior are explicitly out
+of scope and unchanged.
+
+## Rollback
+
+Revert the PR. The launcher reverts to the prior `$LASTEXITCODE` check,
+the three batch wrappers lose the APPLY_EXIT capture, and `deploy-remote.bat`
+returns to its `start ""` fire-and-forget pattern. No DB or runtime
+state to undo.
+
+## Operational note for parallel sessions
+
+This PR was developed in an isolated `git worktree`
+(`/tmp/ms2-sched-exit-...`) to avoid the parallel-session worktree
+hazard that affected #1699's first commit. The main checkout was being
+held by other branches during the work; only the isolated worktree was
+ever modified, committed, and pushed.

--- a/scripts/ops/multitable-onprem-deploy-launcher.ps1
+++ b/scripts/ops/multitable-onprem-deploy-launcher.ps1
@@ -116,13 +116,18 @@ try {
   }
   Write-LauncherInfo "Invoking staged apply helper: $stagedApply"
 
+  # apply.ps1's contract is "throw on failure, return on success"
+  # ($ErrorActionPreference = 'Stop' in apply.ps1; failures bubble as
+  # terminating errors). $LASTEXITCODE for `& <script.ps1>` in-process is
+  # NOT a reliable apply signal - it reflects the *last external program*
+  # apply.ps1 invoked internally (tar, node migrate.js, pm2, etc.), which
+  # could be 0, or could leak a non-fatal sub-program's exit. Trust the
+  # try/catch contract instead so a successful apply ("Package deploy
+  # complete" + health 200) reliably yields launcher exit 0 and a Last
+  # Result of 0 in the outer scheduled task (#1526 follow-up).
   try {
     & $stagedApply -RootDir $resolvedRoot -PackageArchive $resolvedArchive
-    if ($null -ne $LASTEXITCODE) {
-      $launcherExit = $LASTEXITCODE
-    } else {
-      $launcherExit = 0
-    }
+    $launcherExit = 0
   }
   catch {
     Write-LauncherInfo ("Apply helper raised an error: {0}" -f $_.Exception.Message)
@@ -134,5 +139,10 @@ finally {
     Remove-Item -LiteralPath $stage -Recurse -Force -ErrorAction SilentlyContinue
   }
 }
+
+# Stable, parseable last-line marker so deploy-remote.log / scheduled-task
+# stdout always carry the captured apply exit code. Outer wrappers also
+# echo this; the launcher line is the inner-most source of truth.
+Write-LauncherInfo ("apply exit={0}" -f $launcherExit)
 
 exit $launcherExit

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -211,9 +211,19 @@ REM helper sitting in the installed root. The launcher extracts to a staging
 REM temp dir, locates the staged apply helper, and invokes it with this
 REM installed root as -RootDir. See multitable-onprem-deploy-launcher.ps1.
 powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\ops\multitable-onprem-deploy-launcher.ps1" -RootDir "%~dp0." -PackageArchive "%~1"
-exit /b %ERRORLEVEL%
+set "APPLY_EXIT=%ERRORLEVEL%"
+echo [multitable-onprem-deploy] apply exit=%APPLY_EXIT%
+exit /b %APPLY_EXIT%
 EOF
 
+  # deploy-remote.bat is what Windows scheduled tasks typically call.
+  # Previous versions fired deploy.bat in the background via `start ""`
+  # and exited 0 immediately, so the scheduled-task Last Result never
+  # reflected the actual apply outcome. #1526 follow-up makes it
+  # synchronous: invoke deploy.bat in-process, redirect stdout/stderr to
+  # deploy-remote.log, capture ERRORLEVEL, append "apply exit=N" to the
+  # log AND to stdout, and propagate the captured code as the wrapper's
+  # exit.
   cat > "${PACKAGE_ROOT}/deploy-remote.bat" <<'EOF'
 @echo off
 setlocal
@@ -222,16 +232,20 @@ if "%~1"=="" (
   exit /b 64
 )
 if not exist "%~dp0output\logs" mkdir "%~dp0output\logs"
-start "" /min cmd /c "call \"%~dp0deploy.bat\" \"%~1\" >> \"%~dp0output\logs\deploy-remote.log\" 2>&1"
-echo [multitable-onprem-deploy-remote] started. See output\logs\deploy-remote.log
-exit /b 0
+call "%~dp0deploy.bat" "%~1" >> "%~dp0output\logs\deploy-remote.log" 2>&1
+set "APPLY_EXIT=%ERRORLEVEL%"
+>> "%~dp0output\logs\deploy-remote.log" echo [multitable-onprem-deploy-remote] apply exit=%APPLY_EXIT%
+echo [multitable-onprem-deploy-remote] apply exit=%APPLY_EXIT%. See output\logs\deploy-remote.log
+exit /b %APPLY_EXIT%
 EOF
 
   cat > "${PACKAGE_ROOT}/deploy-${PACKAGE_RUN_LABEL}.bat" <<'EOF'
 @echo off
 setlocal
 call "%~dp0deploy.bat" "%~1"
-exit /b %ERRORLEVEL%
+set "APPLY_EXIT=%ERRORLEVEL%"
+echo [multitable-onprem-deploy-label] apply exit=%APPLY_EXIT%
+exit /b %APPLY_EXIT%
 EOF
 
   cat > "${PACKAGE_ROOT}/bootstrap-admin.bat" <<'EOF'

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -52,6 +52,15 @@ function verify_windows_entrypoints() {
     die "deploy.bat must not call the apply helper directly; it must go through the launcher so a stale installed apply helper cannot win on first apply"
   fi
 
+  # #1526 follow-up (2026-05-20): deploy.bat must capture the launcher's
+  # ERRORLEVEL into APPLY_EXIT, emit a parseable `apply exit=N` marker,
+  # and propagate the captured code as its own exit. Otherwise a stale
+  # %ERRORLEVEL% leak elsewhere in the call chain could leave the outer
+  # scheduled-task Last Result as 1 when apply itself returned 0.
+  search_fixed_string 'set "APPLY_EXIT=%ERRORLEVEL%"' "$start_script" || die "deploy.bat must capture the launcher exit code into APPLY_EXIT"
+  search_fixed_string '[multitable-onprem-deploy] apply exit=%APPLY_EXIT%' "$start_script" || die "deploy.bat must echo a parseable apply exit marker"
+  search_fixed_string 'exit /b %APPLY_EXIT%' "$start_script" || die "deploy.bat must propagate the captured APPLY_EXIT as its own exit code"
+
   local launcher_helper="${root}/scripts/ops/multitable-onprem-deploy-launcher.ps1"
   if [[ ! -f "$launcher_helper" ]]; then
     die "PowerShell launcher script must be packaged for deploy.bat self-bootstrap"
@@ -61,6 +70,15 @@ function verify_windows_entrypoints() {
   search_fixed_string 'Resolve-StagedPackageRoot' "$launcher_helper" || die "launcher must resolve the staged package root before invoking the apply helper"
   search_fixed_string 'multitable-onprem-apply-package.ps1' "$launcher_helper" || die "launcher must invoke the staged apply helper from inside the extracted package"
   search_fixed_string 'Remove-Item -LiteralPath $stage' "$launcher_helper" || die "launcher must clean up staging extraction on exit"
+  # #1526 follow-up (2026-05-20): launcher must use the apply.ps1
+  # throw/no-throw contract (not $LASTEXITCODE, which leaks from external
+  # subprograms apply invoked) and must emit a parseable `apply exit=N`
+  # marker so deploy-remote.log / scheduled-task stdout carry an
+  # unambiguous inner-most exit signal.
+  search_fixed_string 'apply exit=' "$launcher_helper" || die "launcher must emit a parseable apply exit marker before exiting"
+  if search_fixed_string 'if ($null -ne $LASTEXITCODE) {' "$launcher_helper"; then
+    die "launcher must not derive its exit from \$LASTEXITCODE (it leaks from apply's external sub-programs); use the try/catch throw/no-throw contract instead"
+  fi
 
   local apply_helper="${root}/scripts/ops/multitable-onprem-apply-package.ps1"
   search_fixed_string 'Refresh dependencies (cmd.exe /c pnpm install --frozen-lockfile)' "$apply_helper" || die "PowerShell apply helper must refresh dependencies on package apply through cmd.exe"
@@ -99,8 +117,28 @@ function verify_windows_entrypoints() {
     die "deploy-remote.bat must continue writing output\\logs\\deploy-remote.log"
   fi
 
+  # #1526 follow-up (2026-05-20): deploy-remote.bat is what Windows
+  # scheduled tasks call. Previously it fired deploy.bat in the
+  # background via `start ""` and exited 0 - so the scheduled-task
+  # Last Result was always 0, regardless of whether apply succeeded
+  # or failed (and the apply log never carried a final exit marker).
+  # The wrapper must now be SYNCHRONOUS, capture ERRORLEVEL, append
+  # `apply exit=N` to deploy-remote.log AND to stdout, and propagate.
+  if search_fixed_string 'start "" /min cmd /c' "$remote_script"; then
+    die "deploy-remote.bat must not fire deploy.bat as a background `start \"\"` process; it must invoke deploy.bat synchronously so the captured apply exit can become the wrapper's exit code"
+  fi
+  search_fixed_string 'call "%~dp0deploy.bat" "%~1" >> "%~dp0output\logs\deploy-remote.log" 2>&1' "$remote_script" || die "deploy-remote.bat must invoke deploy.bat synchronously and redirect stdout/stderr into deploy-remote.log"
+  search_fixed_string 'set "APPLY_EXIT=%ERRORLEVEL%"' "$remote_script" || die "deploy-remote.bat must capture deploy.bat's ERRORLEVEL into APPLY_EXIT"
+  search_fixed_string '[multitable-onprem-deploy-remote] apply exit=%APPLY_EXIT%' "$remote_script" || die "deploy-remote.bat must emit a parseable apply exit marker to deploy-remote.log and stdout"
+  search_fixed_string 'exit /b %APPLY_EXIT%' "$remote_script" || die "deploy-remote.bat must propagate the captured APPLY_EXIT as its own exit code so the outer scheduled-task Last Result matches the apply outcome"
+
   if [[ -n "$deploy_run_wrapper" ]] && ! search_fixed_string 'call "%~dp0deploy.bat" "%~1"' "$deploy_run_wrapper"; then
     die "$(basename "$deploy_run_wrapper") must delegate to deploy.bat"
+  fi
+  if [[ -n "$deploy_run_wrapper" ]]; then
+    search_fixed_string 'set "APPLY_EXIT=%ERRORLEVEL%"' "$deploy_run_wrapper" || die "$(basename "$deploy_run_wrapper") must capture deploy.bat's ERRORLEVEL into APPLY_EXIT"
+    search_fixed_string '[multitable-onprem-deploy-label] apply exit=%APPLY_EXIT%' "$deploy_run_wrapper" || die "$(basename "$deploy_run_wrapper") must echo a parseable apply exit marker"
+    search_fixed_string 'exit /b %APPLY_EXIT%' "$deploy_run_wrapper" || die "$(basename "$deploy_run_wrapper") must propagate APPLY_EXIT"
   fi
 
   if ! search_fixed_string 'multitable-onprem-bootstrap-admin.ps1' "$bootstrap_script"; then


### PR DESCRIPTION
## 修的是什么
Bridge 反馈:apply log 出现 `Package deploy complete` + health 200,但**外层 Scheduled Task Last Result 仍为 1**;且整条链没有可解析的 `apply exit=N` marker,operator 无从溯源。

## 三处真因(实证定位,非猜测)
1. **`launcher.ps1` 的 `$LASTEXITCODE` 渗漏**:`& $stagedApply ...` 是同进程 in-process call。`$LASTEXITCODE` 是会话级最近一次**外部程序**的退出码——apply.ps1 内部调过 `tar` / `node migrate.js` / `pm2` / cmd.exe refresh-wrapper,任何一条遗留的非零都会被错误归因为 apply 失败。apply.ps1 的契约是"throw on failure / return on success",`exit 0` 不会显式发出,所以这条信号本来就不该来自 `$LASTEXITCODE`。
2. **`deploy-remote.bat` fire-and-forget**:`start "" /min cmd /c ...` + `exit /b 0` 永远先返回 0,不等 apply;且 log 末尾没有 `apply exit=N` 收尾。Scheduled task 任凭 apply 成败,Last Result 都不是 apply 真实结果。
3. **整 repo `grep 'apply exit='` 在 scripts/ops 下结果为空**——缺一个稳定 marker。

## 怎么修
- **`launcher.ps1`**:`& $stagedApply ...` 改用 try/catch 契约——无 throw → exit 0,catch → exit 1。完全不读 `$LASTEXITCODE`。`finally` 之后在 script body 写 `Write-LauncherInfo "apply exit={0}"` 作为**内层最权威**的 marker。
- **`deploy.bat`**:`set "APPLY_EXIT=%ERRORLEVEL%"` + `echo [multitable-onprem-deploy] apply exit=%APPLY_EXIT%` + `exit /b %APPLY_EXIT%`。
- **`deploy-remote.bat`**:同步 `call deploy.bat >> deploy-remote.log 2>&1`(放弃 `start ""`),捕获 `%ERRORLEVEL%`,把 `apply exit=N` **同时**追加到 log 和 stdout,以捕获码退出。
- **`deploy-${PACKAGE_RUN_LABEL}.bat`**:同样 `APPLY_EXIT` 捕获 + echo + propagate。

## verify gate 升级 + 实证 NEGATIVE
`verify_windows_entrypoints` 新增:每个 wrapper 必有 `APPLY_EXIT` 捕获 + 对应 `apply exit=` echo + `exit /b %APPLY_EXIT%`;launcher 必有 `apply exit=` marker;**禁用** `if ($null -ne $LASTEXITCODE) {` 渗漏式;**禁用** `start "" /min cmd /c` 火-忘式。

**实证 multi-bit 真闸门**(对最近一份 pre-fix zip `metasheet-multitable-onprem-v2.5.0-20260519-200530.zip` 逐 marker grep):

| File | New marker | Pre-fix count |
|---|---|---|
| deploy.bat | `set "APPLY_EXIT=%ERRORLEVEL%"` | 0 |
| deploy.bat | `[multitable-onprem-deploy] apply exit=` | 0 |
| deploy.bat | `exit /b %APPLY_EXIT%` | 0 |
| launcher.ps1 | `apply exit=` | 0 |
| deploy-remote.bat | `set "APPLY_EXIT=%ERRORLEVEL%"` | 0 |
| deploy-remote.bat | `[multitable-onprem-deploy-remote] apply exit=` | 0 |
| deploy-remote.bat | `exit /b %APPLY_EXIT%` | 0 |
| deploy-${LABEL}.bat | 同 3 个 marker | 0/0/0 |
| deploy-remote.bat | **NEGATIVE**: `start "" /min cmd /c` 应**缺失** | **1** |

→ 10/10 新正向 marker 在 pre-fix 中**全 0**;1 个新负向 forbidden pattern 在 pre-fix 中**为 1**。每条新断言都会真 die()。run 实际 verify 在第一条 die 就停了,文案:`deploy.bat must capture the launcher exit code into APPLY_EXIT`。

## 本地证据(隔离 worktree)
| 检查 | 结果 |
|---|---|
| `bash -n` build.sh / verify.sh | 全 OK |
| `git diff --check` | exit 0 |
| `pnpm install --frozen-lockfile` | Done 3.4s(共享 store) |
| `BUILD_WEB=1 BUILD_BACKEND=1 package-build.sh` | exit 0,产出 zip/tgz |
| 改后 verify 跑新 zip | **Package verify OK** |
| pre-fix zip 跑新 verify | die,精确文案命中第一条新断言 |
| pre-fix zip 逐 marker grep | 见上表(multi-bit 真闸门) |
| pwsh 本地解析 | 跳过(dev 机无 pwsh,已声明;Windows-side CI cover) |

## 行为变更声明(reviewer 关注)
**`deploy-remote.bat` 从异步火-忘改为同步**。这是 returning-0-on-success-and-非0-on-failure 这一需求的**必要代价**——立即返回的 wrapper 永远拿不到 apply 真实结果。如果还有 caller 依赖立即返回语义,他们应该改成自己 `start ""` 调 `deploy.bat`,而非这个写日志的 wrapper。设计 + 验证 MD 已就此声明。

## End-to-end log 链(advisor 校正后补充)
apply.ps1 的 `Write-Info`(含 #1696 的 `Loaded env from ...`)和 launcher 的 `Write-LauncherInfo`(含本 PR 的 `apply exit=N`)都走 PowerShell `Write-Output` → stdout。`deploy-remote.bat` 的 `>> deploy-remote.log 2>&1` 全量截获 → operator 在 `deploy-remote.log` 末尾就能看到 `apply exit=N`,Scheduled Task Last Result 与之一致。

## 范围与红线
- **仅** `scripts/ops/{deploy-launcher.ps1, package-build.sh, package-verify.sh}` + 2 docs MD。5 文件 +449/-10。
- **未触** `plugin-integration-core` runtime / DB migration / API runtime / frontend / K3 Save/Submit/Audit。
- **不解除**客户 GATE;**不做** SQL/TLS 摘要。

## 操作纪律披露
按 memory 中 *Parallel-session worktree hazard* 教训,本 PR 全程在隔离 git worktree (`/tmp/ms2-sched-exit-...`) 开发、commit、push。commit 前显式核对 `git branch --show-current = codex/onprem-scheduled-task-exit-marker-20260520`,没有出现 #1699 时的 commit-on-wrong-branch 事故。

## Test plan
- [ ] CI pr-validate
- [ ] Codex review:`$LASTEXITCODE` 渗漏诊断是否成立、deploy-remote.bat 同步语义变更是否可接受、per-marker NEGATIVE 表 vs 既定 acceptance 是否一一对齐
- [ ] 合并后官方 Multitable On-Prem Package Build → 实体机下次升级:Scheduled Task Last Result 与 apply 真实结果一致,`deploy-remote.log` 末尾出现 `[multitable-onprem-deploy-remote] apply exit=0`(或失败码)

🤖 Generated with [Claude Code](https://claude.com/claude-code)