### PR TITLE
feat(multitable): localize base picker chrome

### DIFF
--- a/apps/web/src/multitable/components/MetaBasePicker.vue
+++ b/apps/web/src/multitable/components/MetaBasePicker.vue
@@ -4,7 +4,7 @@
       <span class="meta-base-picker__icon" :style="activeBase ? { background: activeBase.color ?? '#409eff' } : {}">
         {{ activeBase?.icon ?? '📋' }}
       </span>
-      <span class="meta-base-picker__name">{{ activeBase?.name ?? 'Select Base' }}</span>
+      <span class="meta-base-picker__name">{{ activeBase?.name ?? l('basePicker.selectBase') }}</span>
       <span class="meta-base-picker__arrow">{{ open ? '▲' : '▼' }}</span>
     </div>
 
@@ -13,7 +13,7 @@
         <input
           v-model="search"
           class="meta-base-picker__search-input"
-          placeholder="Search bases..."
+          :placeholder="l('basePicker.searchPlaceholder')"
           @keydown.escape="open = false"
         />
       </div>
@@ -29,27 +29,27 @@
           <span class="meta-base-picker__item-copy">
             <span class="meta-base-picker__item-name">{{ base.name }}</span>
             <span v-if="base.isFavorite || base.lastOpenedAt" class="meta-base-picker__badges">
-              <span v-if="base.isFavorite">收藏</span>
-              <span v-if="base.lastOpenedAt">最近打开</span>
+              <span v-if="base.isFavorite">{{ l('basePicker.favoriteBadge') }}</span>
+              <span v-if="base.lastOpenedAt">{{ l('basePicker.recentBadge') }}</span>
             </span>
           </span>
           <button
             type="button"
             class="meta-base-picker__favorite"
             :aria-pressed="base.isFavorite"
-            :aria-label="base.isFavorite ? `取消收藏 ${base.name}` : `收藏 ${base.name}`"
+            :aria-label="favoriteAriaLabel(base.name, base.isFavorite === true, isZh)"
             @click.stop="onToggleFavorite(base.id)"
           >
             {{ base.isFavorite ? '★' : '☆' }}
           </button>
         </div>
-        <div v-if="!filteredBases.length" class="meta-base-picker__empty">No bases found</div>
+        <div v-if="!filteredBases.length" class="meta-base-picker__empty">{{ l('basePicker.empty') }}</div>
       </div>
       <div v-if="canCreate" class="meta-base-picker__create">
         <input
           v-model="newBaseName"
           class="meta-base-picker__create-input"
-          placeholder="New base name..."
+          :placeholder="l('basePicker.newBasePlaceholder')"
           @keydown.enter="onCreate"
         />
         <button class="meta-base-picker__create-btn" :disabled="!newBaseName.trim()" @click="onCreate">+</button>
@@ -60,7 +60,9 @@
 
 <script setup lang="ts">
 import { ref, computed } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type { DecoratedBase } from '../utils/base-local-state'
+import { basePickerLabel, favoriteAriaLabel } from '../utils/meta-base-picker-labels'
 
 const props = defineProps<{
   bases: DecoratedBase[]
@@ -77,6 +79,8 @@ const emit = defineEmits<{
 const open = ref(false)
 const search = ref('')
 const newBaseName = ref('')
+const { isZh } = useLocale()
+const l = (key: Parameters<typeof basePickerLabel>[0]) => basePickerLabel(key, isZh.value)
 
 const activeBase = computed(() => props.bases.find((b) => b.id === props.activeBaseId) ?? null)
 

--- a/apps/web/src/multitable/utils/meta-base-picker-labels.ts
+++ b/apps/web/src/multitable/utils/meta-base-picker-labels.ts
@@ -1,0 +1,31 @@
+// Base picker chrome string table (T3C2).
+//
+// Scope: MetaBasePicker.vue static UI only. Base names and icons are user data
+// and pass through unchanged.
+
+export type MetaBasePickerLabelKey =
+  | 'basePicker.selectBase'
+  | 'basePicker.searchPlaceholder'
+  | 'basePicker.favoriteBadge'
+  | 'basePicker.recentBadge'
+  | 'basePicker.empty'
+  | 'basePicker.newBasePlaceholder'
+
+const META_BASE_PICKER_LABELS: Record<MetaBasePickerLabelKey, { en: string; zh: string }> = {
+  'basePicker.selectBase': { en: 'Select Base', zh: '选择多维表' },
+  'basePicker.searchPlaceholder': { en: 'Search bases...', zh: '搜索多维表...' },
+  'basePicker.favoriteBadge': { en: 'Favorite', zh: '收藏' },
+  'basePicker.recentBadge': { en: 'Recent', zh: '最近打开' },
+  'basePicker.empty': { en: 'No bases found', zh: '未找到多维表' },
+  'basePicker.newBasePlaceholder': { en: 'New base name...', zh: '新多维表名称...' },
+}
+
+export function basePickerLabel(key: MetaBasePickerLabelKey, isZh: boolean): string {
+  const entry = META_BASE_PICKER_LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+export function favoriteAriaLabel(baseName: string, isFavorite: boolean, isZh: boolean): string {
+  if (isZh) return isFavorite ? `取消收藏 ${baseName}` : `收藏 ${baseName}`
+  return isFavorite ? `Remove ${baseName} from favorites` : `Add ${baseName} to favorites`
+}

--- a/apps/web/tests/meta-base-picker.spec.ts
+++ b/apps/web/tests/meta-base-picker.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, type App as VueApp, type Component } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
 import MetaBasePicker from '../src/multitable/components/MetaBasePicker.vue'
 import type { DecoratedBase } from '../src/multitable/utils/base-local-state'
 
@@ -19,6 +20,7 @@ describe('MetaBasePicker', () => {
     if (container) container.remove()
     app = null
     container = null
+    useLocale().setLocale('en')
   })
 
   function mountPicker(options?: {
@@ -26,6 +28,7 @@ describe('MetaBasePicker', () => {
     activeBaseId?: string
     onSelect?: (baseId: string) => void
     onToggleFavorite?: (baseId: string) => void
+    canCreate?: boolean
   }) {
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -35,6 +38,7 @@ describe('MetaBasePicker', () => {
         { id: 'base_ops', name: 'Ops Base', isFavorite: false, lastOpenedAt: '2026-05-18T08:00:00.000Z' },
       ],
       activeBaseId: options?.activeBaseId ?? 'base_ops',
+      canCreate: options?.canCreate,
       onSelect: options?.onSelect,
       onToggleFavorite: options?.onToggleFavorite,
     })
@@ -52,8 +56,10 @@ describe('MetaBasePicker', () => {
     const names = Array.from(root.querySelectorAll('.meta-base-picker__item-name'))
       .map((node) => node.textContent?.trim())
     expect(names).toEqual(['Sales Base', 'Ops Base'])
-    expect(root.textContent).toContain('收藏')
-    expect(root.textContent).toContain('最近打开')
+    expect(root.textContent).toContain('Favorite')
+    expect(root.textContent).toContain('Recent')
+    expect(root.textContent).not.toContain('收藏')
+    expect(root.textContent).not.toContain('最近打开')
   })
 
   it('emits favorite toggles without selecting the base', async () => {
@@ -65,7 +71,7 @@ describe('MetaBasePicker', () => {
     root.querySelector<HTMLElement>('.meta-base-picker__current')?.click()
     await flushUi()
 
-    root.querySelector<HTMLButtonElement>('[aria-label="取消收藏 Sales Base"]')?.click()
+    root.querySelector<HTMLButtonElement>('[aria-label="Remove Sales Base from favorites"]')?.click()
     await flushUi()
 
     expect(onToggleFavorite).toHaveBeenCalledWith('base_sales')
@@ -76,5 +82,46 @@ describe('MetaBasePicker', () => {
 
     expect(onSelect).toHaveBeenCalledWith('base_sales')
   })
-})
 
+  it('renders zh-CN picker chrome while preserving base names raw', async () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountPicker({ canCreate: true })
+    await flushUi()
+
+    root.querySelector<HTMLElement>('.meta-base-picker__current')?.click()
+    await flushUi()
+
+    expect(root.querySelector<HTMLInputElement>('.meta-base-picker__search-input')?.getAttribute('placeholder')).toBe('搜索多维表...')
+    expect(root.querySelector<HTMLInputElement>('.meta-base-picker__create-input')?.getAttribute('placeholder')).toBe('新多维表名称...')
+    expect(root.textContent).toContain('Sales Base')
+    expect(root.textContent).toContain('Ops Base')
+    expect(root.textContent).toContain('收藏')
+    expect(root.textContent).toContain('最近打开')
+    expect(root.textContent).not.toContain('Favorite')
+    expect(root.textContent).not.toContain('Recent')
+    expect(root.querySelector<HTMLButtonElement>('[aria-label="取消收藏 Sales Base"]')).toBeTruthy()
+  })
+
+  it('localizes the empty and no-active-base states', async () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountPicker({
+      activeBaseId: 'missing',
+      bases: [{ id: 'base_sales', name: 'Sales Base', isFavorite: false, lastOpenedAt: null }],
+    })
+    await flushUi()
+
+    expect(root.querySelector('.meta-base-picker__name')?.textContent).toBe('选择多维表')
+
+    root.querySelector<HTMLElement>('.meta-base-picker__current')?.click()
+    await flushUi()
+
+    const search = root.querySelector<HTMLInputElement>('.meta-base-picker__search-input')
+    expect(search).toBeTruthy()
+    search!.value = 'none'
+    search!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    expect(root.textContent).toContain('未找到多维表')
+    expect(root.textContent).not.toContain('No bases found')
+  })
+})

--- a/docs/development/multitable-t3c2-base-picker-i18n-design-20260520.md
+++ b/docs/development/multitable-t3c2-base-picker-i18n-design-20260520.md
@@ -1,0 +1,46 @@
+# T3C2 - Base Picker i18n Design
+
+- **Date**: 2026-05-20
+- **Type**: small implementation slice
+- **Status**: implemented; paired verification in `docs/development/multitable-t3c2-base-picker-i18n-verification-20260520.md`
+- **Preceded by**:
+  - `docs/development/multitable-t3c-import-modal-i18n-design-20260520.md`
+- **Goal**: localize `MetaBasePicker.vue` chrome while preserving base names, icons, ordering, selection, create, and favorite behavior.
+
+## Scope
+
+This slice covers the base switcher only:
+
+| Surface | Localized |
+|---|---|
+| No active base fallback | `Select Base` / `选择多维表` |
+| Search input | placeholder |
+| Base badges | favorite and recent badges |
+| Favorite toggle | aria-label, with base name interpolated raw |
+| Empty state | no matching bases |
+| Create input | placeholder |
+
+## Boundaries
+
+Out of scope:
+
+- Workbench routing, base loading, favorite persistence, recent ordering, and create/select event behavior.
+- Backend, API routes, OpenAPI, migrations, `attendance_*`, or direct `meta_*` writes.
+- User data: base names and icons remain raw.
+- Larger manager surfaces such as field/view/permission managers.
+
+## Implementation Notes
+
+- Added `apps/web/src/multitable/utils/meta-base-picker-labels.ts` as a small per-surface label module.
+- `MetaBasePicker.vue` now reads `useLocale().isZh` and calls:
+  - `basePickerLabel(...)` for static copy.
+  - `favoriteAriaLabel(base.name, base.isFavorite, isZh)` for favorite toggle aria text.
+- This also fixes the pre-existing mixed-locale default where English UI showed Chinese `收藏` / `最近打开` badges. Default English now renders `Favorite` / `Recent`; zh-CN preserves `收藏` / `最近打开`.
+
+## Acceptance
+
+- zh-CN renders localized picker chrome.
+- English/default locale renders English picker chrome.
+- Base names and icons are not translated.
+- Favorite toggle remains click-isolated and does not select the base.
+- No BasePicker event payloads or local-state helpers changed.

--- a/docs/development/multitable-t3c2-base-picker-i18n-verification-20260520.md
+++ b/docs/development/multitable-t3c2-base-picker-i18n-verification-20260520.md
@@ -1,0 +1,73 @@
+# T3C2 - Base Picker i18n Verification
+
+- **Date**: 2026-05-20
+- **Scope**: `MetaBasePicker.vue` base switcher chrome.
+- **Design packet**: `docs/development/multitable-t3c2-base-picker-i18n-design-20260520.md`
+- **Status**: implemented and locally verified.
+
+## Implementation Summary
+
+- Added `meta-base-picker-labels.ts` with English/zh-CN labels and favorite aria helper.
+- Rewired `MetaBasePicker.vue` to use `useLocale().isZh`.
+- Updated `meta-base-picker.spec.ts` to assert:
+  - English default badges are `Favorite` / `Recent`.
+  - zh-CN chrome renders localized search/create placeholders, badges, favorite aria text, and empty/no-active-base states.
+  - Base names stay raw in zh-CN.
+  - Favorite toggle still does not emit a base selection.
+
+## Boundary Check
+
+| Area | Result |
+|---|---|
+| Backend/API/OpenAPI | Not touched |
+| Migrations / `attendance_*` | Not touched |
+| Direct `meta_*` writes | Not touched |
+| Base persistence/order helpers | Not changed |
+| Selection/create/favorite emits | Not changed |
+| User-authored base names/icons | Preserved raw |
+
+## Verification Commands
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/meta-base-picker.spec.ts \
+  tests/multitable-base-local-state.spec.ts --watch=false
+```
+
+Result: PASS, 8 tests across 2 files.
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/meta-base-picker.spec.ts \
+  tests/multitable-base-local-state.spec.ts --watch=false
+```
+
+Result: PASS, 8 tests across 2 files.
+
+```bash
+pnpm --filter @metasheet/web type-check
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: PASS. Vite emitted the existing dynamic-import and large-chunk warnings only.
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+## Out-of-Scope Probe
+
+I also probed `tests/multitable-workbench-view.spec.ts` as a broader adjacent suite. It currently fails locally on the existing `opens workflow designer with multitable context when automation is enabled` assertion because the workflow entry is gated by the `workflow` feature and the test searches the English `Workflow` button. That file mocks `MetaBasePicker`, so the failure is outside this slice and is not used as a BasePicker acceptance gate.
+
+## Acceptance Notes
+
+- The slice intentionally corrects a mixed-locale default: Chinese badges no longer appear in the English/default picker.
+- The favorite aria helper interpolates raw base names; it only localizes surrounding action copy.
+- This is independent from the broader field/view/permission manager i18n backlog.


### PR DESCRIPTION
## Summary

Localizes the multitable base picker chrome while preserving base data and behavior:

- adds `meta-base-picker-labels.ts` for picker labels and favorite aria text
- wires `MetaBasePicker.vue` to `useLocale().isZh`
- fixes the mixed-locale default where English UI showed Chinese favorite/recent badges
- keeps base names and icons raw
- adds design and verification MD for the T3C2 base-picker slice

## Boundaries

- No backend/API/OpenAPI changes
- No migrations, `attendance_*` changes, or direct `meta_*` writes
- No base ordering, persistence, create/select/favorite event behavior changes
- No field/view/permission manager i18n in this slice

## Test plan

- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/meta-base-picker.spec.ts tests/multitable-base-local-state.spec.ts --watch=false` — 8 tests PASS
- [x] `pnpm --filter @metasheet/web type-check` — PASS
- [x] `pnpm --filter @metasheet/web build` — PASS, existing Vite chunk/dynamic-import warnings only
- [x] `git diff --check` / `git diff --cached --check` — PASS

Note: I probed `tests/multitable-workbench-view.spec.ts` as a broader adjacent suite; its existing workflow-designer feature-gate assertion fails locally and the file mocks `MetaBasePicker`, so it is not used as this slice's acceptance gate. Details are recorded in the verification MD.
