### PR TITLE
feat(multitable): localize attachment list chrome

### DIFF
--- a/apps/web/src/multitable/components/MetaAttachmentList.vue
+++ b/apps/web/src/multitable/components/MetaAttachmentList.vue
@@ -7,7 +7,7 @@
           v-if="isPreviewableImage(attachment)"
           type="button"
           class="meta-attachment-list__card meta-attachment-list__card--preview"
-          :title="`Preview ${attachment.filename}`"
+          :title="previewAttachmentTitle(attachment.filename, isZh)"
           @click="previewAttachment = attachment"
         >
           <img
@@ -36,7 +36,7 @@
           v-if="removable"
           type="button"
           class="meta-attachment-list__remove"
-          :title="`Remove ${attachment.filename}`"
+          :title="removeAttachmentTitle(attachment.filename, isZh)"
           @click="emit('remove', attachment.id)"
         >&times;</button>
       </div>
@@ -57,11 +57,11 @@
                 :href="previewAttachment.url"
                 target="_blank"
                 rel="noopener noreferrer"
-              >Open original</a>
+              >{{ attachmentLabel('attachment.openOriginal', isZh) }}</a>
               <button
                 type="button"
                 class="meta-attachment-list__lightbox-close"
-                aria-label="Close attachment preview"
+                :aria-label="attachmentLabel('attachment.closePreview', isZh)"
                 @click="previewAttachment = null"
               >&times;</button>
             </div>
@@ -79,7 +79,9 @@
 
 <script setup lang="ts">
 import { ref } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type { MetaAttachment } from '../types'
+import { attachmentLabel, previewAttachmentTitle, removeAttachmentTitle } from '../utils/meta-attachment-labels'
 
 withDefaults(defineProps<{
   attachments: MetaAttachment[]
@@ -97,6 +99,7 @@ const emit = defineEmits<{
 }>()
 
 const previewAttachment = ref<MetaAttachment | null>(null)
+const { isZh } = useLocale()
 
 function isPreviewableImage(attachment: MetaAttachment): boolean {
   return attachment.mimeType.startsWith('image/') && !!(attachment.thumbnailUrl || attachment.url)

--- a/apps/web/src/multitable/utils/meta-attachment-labels.ts
+++ b/apps/web/src/multitable/utils/meta-attachment-labels.ts
@@ -1,0 +1,26 @@
+// Attachment list chrome string table (T3C3).
+//
+// Scope: MetaAttachmentList.vue static UI only. Attachment filenames, URLs,
+// and caller-provided empty labels pass through unchanged.
+
+export type MetaAttachmentLabelKey =
+  | 'attachment.openOriginal'
+  | 'attachment.closePreview'
+
+const META_ATTACHMENT_LABELS: Record<MetaAttachmentLabelKey, { en: string; zh: string }> = {
+  'attachment.openOriginal': { en: 'Open original', zh: '打开原文件' },
+  'attachment.closePreview': { en: 'Close attachment preview', zh: '关闭附件预览' },
+}
+
+export function attachmentLabel(key: MetaAttachmentLabelKey, isZh: boolean): string {
+  const entry = META_ATTACHMENT_LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+export function previewAttachmentTitle(filename: string, isZh: boolean): string {
+  return isZh ? `预览 ${filename}` : `Preview ${filename}`
+}
+
+export function removeAttachmentTitle(filename: string, isZh: boolean): string {
+  return isZh ? `移除 ${filename}` : `Remove ${filename}`
+}

--- a/apps/web/tests/multitable-attachment-list.spec.ts
+++ b/apps/web/tests/multitable-attachment-list.spec.ts
@@ -1,8 +1,13 @@
-import { describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
 import MetaAttachmentList from '../src/multitable/components/MetaAttachmentList.vue'
 
 describe('MetaAttachmentList', () => {
+  afterEach(() => {
+    useLocale().setLocale('en')
+  })
+
   it('renders thumbnails for image attachments', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)
@@ -27,8 +32,10 @@ describe('MetaAttachmentList', () => {
     await nextTick()
 
     const image = container.querySelector('img') as HTMLImageElement | null
+    const previewButton = container.querySelector('button.meta-attachment-list__card--preview') as HTMLButtonElement | null
     expect(image).not.toBeNull()
     expect(image?.getAttribute('src')).toContain('thumbnail=true')
+    expect(previewButton?.getAttribute('title')).toBe('Preview photo.png')
 
     app.unmount()
     container.remove()
@@ -65,6 +72,7 @@ describe('MetaAttachmentList', () => {
     expect(lightbox).not.toBeNull()
     expect(lightboxImage?.getAttribute('src')).toContain('/api/multitable/attachments/att_img_2')
     expect(document.body.textContent).toContain('Open original')
+    expect(document.body.querySelector('.meta-attachment-list__lightbox-close')?.getAttribute('aria-label')).toBe('Close attachment preview')
 
     app.unmount()
     container.remove()
@@ -100,6 +108,49 @@ describe('MetaAttachmentList', () => {
     await nextTick()
 
     expect(removed).toEqual(['att_doc_1'])
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('localizes zh-CN attachment chrome while preserving filenames raw', async () => {
+    useLocale().setLocale('zh-CN')
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaAttachmentList, {
+          attachments: [{
+            id: 'att_img_zh',
+            filename: 'diagram.png',
+            mimeType: 'image/png',
+            size: 4096,
+            url: '/api/multitable/attachments/att_img_zh',
+            thumbnailUrl: '/api/multitable/attachments/att_img_zh?thumbnail=true',
+            uploadedAt: '2026-03-21T11:00:00.000Z',
+          }],
+          removable: true,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const previewButton = container.querySelector('button.meta-attachment-list__card--preview') as HTMLButtonElement | null
+    const removeButton = container.querySelector('.meta-attachment-list__remove') as HTMLButtonElement | null
+    expect(previewButton?.getAttribute('title')).toBe('预览 diagram.png')
+    expect(removeButton?.getAttribute('title')).toBe('移除 diagram.png')
+    expect(container.textContent).toContain('diagram.png')
+
+    previewButton?.click()
+    await nextTick()
+
+    expect(document.body.textContent).toContain('打开原文件')
+    expect(document.body.textContent).not.toContain('Open original')
+    expect(document.body.querySelector('.meta-attachment-list__lightbox-close')?.getAttribute('aria-label')).toBe('关闭附件预览')
+    expect(document.body.querySelector('.meta-attachment-list__lightbox-title')?.textContent).toBe('diagram.png')
 
     app.unmount()
     container.remove()

--- a/docs/development/multitable-t3c3-attachment-list-i18n-design-20260520.md
+++ b/docs/development/multitable-t3c3-attachment-list-i18n-design-20260520.md
@@ -1,0 +1,45 @@
+# T3C3 - Attachment List i18n Design
+
+- **Date**: 2026-05-20
+- **Type**: small implementation slice
+- **Status**: implemented; paired verification in `docs/development/multitable-t3c3-attachment-list-i18n-verification-20260520.md`
+- **Preceded by**:
+  - `docs/development/multitable-t3c-import-modal-i18n-design-20260520.md`
+  - `docs/development/multitable-t3c2-base-picker-i18n-design-20260520.md`
+- **Goal**: localize `MetaAttachmentList.vue` chrome while preserving attachment filenames, URLs, thumbnails, removal events, and caller-controlled empty labels.
+
+## Scope
+
+This slice covers the shared attachment-list component only:
+
+| Surface | Localized |
+|---|---|
+| Image preview title | `Preview <filename>` / `预览 <filename>` |
+| Remove button title | `Remove <filename>` / `移除 <filename>` |
+| Lightbox original-file link | `Open original` / `打开原文件` |
+| Lightbox close aria label | `Close attachment preview` / `关闭附件预览` |
+
+## Boundaries
+
+Out of scope:
+
+- Attachment upload, delete, previewability, thumbnail selection, URL opening, and Teleport/lightbox behavior.
+- Backend, API routes, OpenAPI, migrations, `attendance_*`, or direct `meta_*` writes.
+- User data: attachment filenames, URLs, thumbnails, MIME-derived icons, and caller-provided `emptyLabel` remain raw.
+- Attachment editor, import repair flows, and broader record-drawer chrome.
+
+## Implementation Notes
+
+- Added `apps/web/src/multitable/utils/meta-attachment-labels.ts` as a tiny per-surface label module.
+- `MetaAttachmentList.vue` now reads `useLocale().isZh` and calls:
+  - `attachmentLabel(...)` for static lightbox copy.
+  - `previewAttachmentTitle(filename, isZh)` for preview button titles.
+  - `removeAttachmentTitle(filename, isZh)` for removable attachment titles.
+- The label helpers interpolate filenames without translating or normalizing them.
+
+## Acceptance
+
+- zh-CN renders localized attachment-list chrome.
+- English/default locale remains backward-compatible.
+- Attachment filenames remain raw in titles and lightbox content.
+- Existing image preview, original-link, and remove event behavior remain unchanged.

--- a/docs/development/multitable-t3c3-attachment-list-i18n-verification-20260520.md
+++ b/docs/development/multitable-t3c3-attachment-list-i18n-verification-20260520.md
@@ -1,0 +1,36 @@
+# T3C3 - Attachment List i18n Verification
+
+- **Date**: 2026-05-20
+- **Design**: `docs/development/multitable-t3c3-attachment-list-i18n-design-20260520.md`
+- **Scope**: `MetaAttachmentList.vue` chrome i18n only.
+
+## Changed Files
+
+| File | Purpose |
+|---|---|
+| `apps/web/src/multitable/components/MetaAttachmentList.vue` | Reads locale and renders localized preview/remove/lightbox chrome. |
+| `apps/web/src/multitable/utils/meta-attachment-labels.ts` | Small EN/ZH label helper module for attachment-list chrome. |
+| `apps/web/tests/multitable-attachment-list.spec.ts` | Adds zh-CN coverage and pins English/default compatibility. |
+
+## Verification Matrix
+
+| Check | Command | Result |
+|---|---|---|
+| Focused attachment tests | `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/multitable-attachment-list.spec.ts tests/multitable-attachment-editor.spec.ts tests/meta-record-drawer-i18n.spec.ts --watch=false` | PASS, 17 tests |
+| Helper syntax check | `node --check apps/web/src/multitable/utils/meta-attachment-labels.ts` | PASS |
+| Web type-check | `pnpm --filter @metasheet/web type-check` | PASS |
+| Web build | `pnpm --filter @metasheet/web build` | PASS; existing Vite dynamic-import and large chunk warnings only |
+| Whitespace | `git diff --check` | PASS |
+
+## Assertions Covered
+
+- English/default image preview title remains `Preview photo.png`.
+- English/default lightbox link and close aria label remain `Open original` and `Close attachment preview`.
+- zh-CN preview title, remove title, original-file link, and close aria label are localized.
+- Attachment filename `diagram.png` remains raw in zh-CN titles and lightbox content.
+- Existing remove event behavior remains covered.
+
+## Staging Boundary
+
+- Stage only this slice's files; exclude existing node_modules and scratch/output noise.
+- No backend, API, migration, `attendance_*`, or direct `meta_*` writes are part of this slice.


### PR DESCRIPTION
## Summary

Localizes the shared multitable attachment-list chrome while preserving attachment filenames and caller-controlled data raw.

- adds a small `meta-attachment-labels` helper for EN/ZH preview/remove/lightbox labels
- wires `MetaAttachmentList.vue` to `useLocale()` for preview titles, remove titles, original-link text, and close aria labels
- extends attachment-list tests for default English compatibility and zh-CN chrome
- adds paired design and verification markdown

## Test plan

- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/multitable-attachment-list.spec.ts tests/multitable-attachment-editor.spec.ts tests/meta-record-drawer-i18n.spec.ts --watch=false`
- [x] `node --check apps/web/src/multitable/utils/meta-attachment-labels.ts`
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `pnpm --filter @metasheet/web build`
- [x] `git diff --check`

## Boundaries

- no backend/API/OpenAPI/migration changes
- no `attendance_*` or direct `meta_*` writes
- attachment filenames, URLs, MIME icons, and caller-provided `emptyLabel` remain raw
- existing node_modules/scratch/output noise intentionally excluded
