### PR TITLE
feat(attendance): effective calendar resolver + calendarPolicy overrides

### DIFF
--- a/docs/development/attendance-calendar-policy-resolver-development-20260520.md
+++ b/docs/development/attendance-calendar-policy-resolver-development-20260520.md
@@ -1,0 +1,156 @@
+# Attendance Calendar Policy Resolver — Development Notes
+
+Date: 2026-05-20
+Branch: `runtime/attendance-calendar-policy-resolver-20260520`
+Base: `origin/main@f8b9a5f2e`
+Implements: RFC v3 (`docs/development/attendance-effective-calendar-rfc-20260520.md`)
+Builds on: Step 2 PR #1698 (`12918362f`) which added `attendance_holidays.origin`.
+
+## Scope
+
+Step 3 of the effective-calendar slice. Read-only resolver that composes a
+multi-layer calendar without touching the existing calculation chain
+(`resolveWorkContext` / payroll / import / auto-absence). The cutover is Step 5.
+
+Delivered:
+
+- Shared `matchScopeFilters` and `matchDayIndexFilter` predicates (single source
+  of truth for both `holidayPolicy.overrides[]` and `calendarPolicy.overrides[]`).
+- `settings.calendarPolicy.overrides[]` schema + normalize + merge + zod.
+- `EffectiveCalendarResolver` + `GET /api/attendance/effective-calendar` (read-only).
+- Integration tests covering RFC §6.1/§6.2/§6.3 + RBAC + validation.
+
+Not delivered (intentionally, per RFC §7 step 5):
+
+- `resolveWorkContext` cutover. Payroll/import/auto-absence still use the
+  pre-existing hard-override behavior.
+- Materialization or batch resolver. Step 3 resolves per-user-per-day in real
+  time; batch use cases (>500 users × monthly) are Phase 2.
+
+## Key Code Anchors
+
+| Concern | File:line (post-change) |
+| --- | --- |
+| Shared `matchDayIndexFilter` predicate | `plugins/plugin-attendance/index.cjs` near `matchHolidayOverrideFilters` (~8327) |
+| Shared `matchScopeFilters` predicate (supports import `attendanceGroup` single-value + resolver `attendanceGroups` array; both paths use `matchListValue` so case/whitespace normalization is symmetric between import and resolver) | `plugins/plugin-attendance/index.cjs` next to `matchDayIndexFilter` |
+| `matchHolidayOverrideFilters` refactor (now delegates to both shared predicates; behavior preserved) | `plugins/plugin-attendance/index.cjs` near 8327 |
+| `DEFAULT_SETTINGS.calendarPolicy` | `plugins/plugin-attendance/index.cjs` near 57 |
+| `normalizeCalendarPolicyOverrides` (drops invalid entries; generates `randomUUID()` for missing `id`) | `plugins/plugin-attendance/index.cjs` after `normalizeHolidayPolicyOverrides` |
+| `normalizeSettings` wiring of `calendarPolicy` | `plugins/plugin-attendance/index.cjs` inside `normalizeSettings` |
+| `mergeSettings` `calendarPolicy` branch | `plugins/plugin-attendance/index.cjs` inside `mergeSettings` |
+| Zod `settingsSchema.calendarPolicy` | `plugins/plugin-attendance/index.cjs` next to `holidayPolicy` zod (~12050) |
+| `resolveEffectiveCalendar` + `matchCalendarOverride` + `loadApprovedRequestsForOverlay` + `loadAttendanceScopeContextForUser` + `loadAttendanceGroupByIdOrCode` + helpers | `plugins/plugin-attendance/index.cjs` after `loadRotationAssignmentMapForUsersRange` |
+| Route `GET /api/attendance/effective-calendar` | `plugins/plugin-attendance/index.cjs` just before holidays GET (~24131) |
+| Integration tests (4 cases) | `packages/core-backend/tests/integration/attendance-plugin.test.ts` (appended at end of describe) |
+
+## Design Pins
+
+### Source priority (RFC §4.2)
+
+```
+base layers:    rule = shift = rotation = national = manual = 0
+policy layers:  org = 1 < group = 2 < role = 3 < user = 4
+```
+
+Higher numeric priority wins. Equal priority: later array index of
+`settings.calendarPolicy.overrides[]` wins (declaration-order tie-breaker).
+Documented so that admin UI can promise stable behavior when two same-source
+overrides target the same date.
+
+### Mode → allowed sources
+
+| Mode | Allowed `effective.source` | Profile (base) | Overlays |
+| --- | --- | --- | --- |
+| `userId` | `org` / `group` / `role` / `user` | `rotation.shift` ?? `shift.assignment` ?? `defaultRule` | `personal_leave` / `overtime` / `attendance_correction` from `attendance_requests` (approved) |
+| `groupId` | `group` only | `defaultRule` | none |
+| `orgOnly` | `org` only | `defaultRule` | none |
+
+`groupId` does **not** apply org-level overrides; this is the strict reading
+of RFC §4.1 (mode resolves only group-level policies on top of base holidays).
+
+### Time-zone chain (RFC §4.3)
+
+```
+rotation.timezone -> shift.timezone -> defaultRule.timezone -> group.timezone -> 'UTC'
+```
+
+Date-only holidays are not auto-converted across timezones.
+
+### Normalize semantics
+
+`normalizeCalendarPolicyOverrides` is intentionally **silent-drop** (no thrown
+error) for invalid raw entries:
+
+- No constraint provided (must declare at least one of `date` / `from`+`to` /
+  `name` / `dayIndex*`).
+- Missing or non-boolean `effective.isWorkingDay`.
+- `effective.source = 'group'` without non-empty `filters.attendanceGroups`.
+- `effective.source = 'role'` without non-empty `filters.roles` or
+  `filters.roleTags`.
+- `effective.source = 'user'` without non-empty `filters.userIds` or
+  `filters.userNames`.
+
+Each surviving override is assigned `id: randomUUID()` if missing. Once
+persisted, the id is stable across reads (`normalize` preserves existing `id`).
+
+## Known Limitations (v1)
+
+1. **`role` / `roleTags` filters do not fire in resolver mode.** The current DB
+   schema has no attendance-scoped user profile table that backs role /
+   roleTags. `buildHolidayPolicyContext` populates them from import rows /
+   profileSnapshots; the resolver has no equivalent source. `calendarPolicy.overrides[]`
+   with `effective.source = 'role'` remain **valid config** (normalize keeps
+   them) but `effective-calendar` will not match them. The filter remains useful
+   for `holidayPolicy.overrides[]` in payroll/import paths. The integration
+   test `role/roleTags override is valid config but silently inert in resolver
+   mode` guards this contract so a future "role context" loader does not
+   silently begin firing without a deliberate decision.
+2. **`groupId` mode does not apply group `rule_set` working days.** Base
+   profile is the org's `attendance_rules` default rule. `attendance_groups.rule_set_id`
+   is ignored by the v1 resolver. Document for future Step 5 or a separate slice.
+3. **Performance.** Per-user-per-day resolution executed in real time. For
+   batch reports over >500 users × monthly ranges, plan a cache/materialization
+   slice (Phase 2). The route bounds inclusive range to ≤ 366 days.
+
+## Overlay Mapping
+
+| `attendance_requests.request_type` | Overlay `kind` | Overlay `source` |
+| --- | --- | --- |
+| `leave` | `personal_leave` | `attendance_requests` |
+| `overtime` | `overtime` | `attendance_requests` |
+| `missed_check_in` / `missed_check_out` / `time_correction` | `attendance_correction` | `attendance_requests` |
+
+`business_trip` and `training` are reserved per RFC §4.4; not implemented
+because there is no current data source in `attendance_requests.request_type`
+(business trip lives in `attendance_records` report fields; training has no
+source yet). Implementing either requires its own slice and is out of scope.
+
+## API Surface
+
+```
+GET /api/attendance/effective-calendar?from=YYYY-MM-DD&to=YYYY-MM-DD&userId=...
+GET /api/attendance/effective-calendar?from=YYYY-MM-DD&to=YYYY-MM-DD&groupId=...
+GET /api/attendance/effective-calendar?from=YYYY-MM-DD&to=YYYY-MM-DD&orgOnly=true
+```
+
+- `from` / `to` are **required**; missing or invalid → 400.
+- Range > 366 days → 400.
+- Exactly one mode must be provided → 400 otherwise.
+- `userId` mode: requester must be self **or** have `attendance:approve` /
+  `attendance:admin` (resolved by `canAccessOtherUsers`).
+- `groupId` mode: requires `attendance:admin`.
+- `orgOnly` mode: only requires the outer `attendance:read` gate.
+- `groupId` that does not exist → 404.
+
+Response shape conforms to RFC §4.4 (`mode` / `from` / `to` / `timezone` /
+`items[]` with `base` / `effective` / `layers[]` / `overlays[]`).
+
+`PUT /api/attendance/settings` accepts `calendarPolicy` via the existing
+settings update path; `mergeSettings` was extended so a partial PATCH does not
+shallow-merge away nested overrides arrays.
+
+## Holiday Sync Boundary
+
+This slice does not change `attendance_holidays.origin` semantics or
+`/api/attendance/holidays/sync`. Manual rows remain protected per Step 2;
+calendarPolicy overrides live in settings, not in `attendance_holidays`.

--- a/docs/development/attendance-calendar-policy-resolver-verification-20260520.md
+++ b/docs/development/attendance-calendar-policy-resolver-verification-20260520.md
@@ -1,0 +1,133 @@
+# Attendance Calendar Policy Resolver — Verification
+
+Date: 2026-05-20
+Branch: `runtime/attendance-calendar-policy-resolver-20260520`
+Base: `origin/main@f8b9a5f2e`
+Commit: branch tip `feat(attendance): effective calendar resolver + calendarPolicy.overrides + read-only API`
+
+## Definition of Done (gate)
+
+This slice is merge-ready only when the DB-backed effective-calendar
+integration tests are executed against a real PostgreSQL database and print
+the concrete test case names:
+
+```
+✓ tests/integration/attendance-plugin.test.ts > Attendance Plugin Integration > effective-calendar §6.1 baseline equals resolveWorkContext for rule + holiday rows
+✓ tests/integration/attendance-plugin.test.ts > Attendance Plugin Integration > effective-calendar §6.2 applies calendarPolicy with mode gates, priority, and normalize drops invalid
+✓ tests/integration/attendance-plugin.test.ts > Attendance Plugin Integration > effective-calendar §6.3 returns approved request overlays additively without merging
+✓ tests/integration/attendance-plugin.test.ts > Attendance Plugin Integration > effective-calendar validates strictly, enforces RBAC, and 404s missing group
+✓ tests/integration/attendance-plugin.test.ts > Attendance Plugin Integration > effective-calendar role/roleTags override is valid config but silently inert in resolver mode
+```
+
+A passing run also asserts that the existing Step 2 sync test
+(`protects manual holiday origins ...`) is unaffected.
+
+## Commands Run (local, no DB)
+
+| Command | Result |
+| --- | --- |
+| `pnpm --filter @metasheet/core-backend test:unit` | PASS: 170 files / 2245 tests. |
+| `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "effective-calendar" --reporter=dot` | Load check: 4 effective-calendar tests load and early-return without DB URL (auto-skip path). |
+| `node --check plugins/plugin-attendance/index.cjs` | PASS. |
+| `git diff --check` | PASS. |
+
+## DB-Backed Run
+
+The hard gate is **satisfied** on scratch PostgreSQL 15.17 (Homebrew).
+
+### Environment
+
+```text
+PostgreSQL: 15.17 (Homebrew, 127.0.0.1:5432)
+Scratch DB: effcal_test_<epoch> (created and dropped within the same test run)
+ATTENDANCE_TEST_DATABASE_URL=postgresql://127.0.0.1:5432/effcal_test_<epoch>
+DATABASE_URL=postgresql://127.0.0.1:5432/effcal_test_<epoch>
+```
+
+### Command (verbatim)
+
+```bash
+ATTENDANCE_TEST_DATABASE_URL=postgresql://127.0.0.1:5432/<scratch-db> \
+  DATABASE_URL=postgresql://127.0.0.1:5432/<scratch-db> \
+  pnpm --filter @metasheet/core-backend exec vitest \
+    --config vitest.integration.config.ts \
+    run tests/integration/attendance-plugin.test.ts \
+    -t "effective-calendar|protects manual holiday origins" \
+    --reporter=verbose
+```
+
+### Result (real run, 2026-05-20)
+
+```
+✓ tests/integration/attendance-plugin.test.ts > Attendance Plugin Integration > protects manual holiday origins during national holiday sync
+✓ tests/integration/attendance-plugin.test.ts > Attendance Plugin Integration > effective-calendar §6.1 baseline equals resolveWorkContext for rule + holiday rows
+✓ tests/integration/attendance-plugin.test.ts > Attendance Plugin Integration > effective-calendar §6.2 applies calendarPolicy with mode gates, priority, and normalize drops invalid
+✓ tests/integration/attendance-plugin.test.ts > Attendance Plugin Integration > effective-calendar §6.3 returns approved request overlays additively without merging
+✓ tests/integration/attendance-plugin.test.ts > Attendance Plugin Integration > effective-calendar validates strictly, enforces RBAC, and 404s missing group
+✓ tests/integration/attendance-plugin.test.ts > Attendance Plugin Integration > effective-calendar role/roleTags override is valid config but silently inert in resolver mode
+
+ Test Files  1 passed (1)
+      Tests  6 passed | 66 skipped (72)
+```
+
+The Step 2 sync regression (`protects manual holiday origins ...`) ran first
+and passes unchanged — confirming the resolver / shared-predicate refactor did
+not touch the existing holiday-sync writer or its counters.
+
+## Regression Matrix
+
+| RFC Section | Case | Covered by test |
+| --- | --- | --- |
+| §6.1 default-working day equivalence | weekday in [1..5] without holiday or override | "baseline equals resolveWorkContext" |
+| §6.1 default rest day equivalence | weekday in [0, 6] without holiday or override | same |
+| §6.1 national/manual holiday overrides profile | `is_working_day=false` row | same |
+| §6.1 working-day-override row | `is_working_day=true` row | same |
+| §6.2 org policy changes national to working day | `effective.source='org'`, base remains national | "applies calendarPolicy with mode gates" |
+| §6.2 group policy applies only to group members | `effective.source='group'` | same |
+| §6.2 user policy overrides group policy | priority `user(4) > group(2) > org(1)` | same |
+| §6.2 mode gates strict | userId={org,group,user}; groupId={group}; orgOnly={org} | same |
+| §6.2 normalize drops invalid | 3 invalid + 3 valid overrides POSTed; only 3 returned | same |
+| §6.3 leave / overtime / correction overlays | additive, no merge, sources tagged | "returns approved request overlays additively" |
+| Validation: missing from/to | 400 | "validates strictly" |
+| Validation: invalid date | 400 | same |
+| Validation: no mode | 400 | same |
+| Validation: two modes | 400 | same |
+| Validation: range > 366 days | 400 | same |
+| RBAC: read-only querying other user | 403 | same |
+| RBAC: read-only querying self | 200 | same |
+| RBAC: read+approve querying other user | 200 | same |
+| RBAC: read-only using groupId | 403 | same |
+| groupId not found | 404 | same |
+| Known Limitation: `effective.source='role'` config is preserved but resolver does not match | role override stays in saved settings; no `calendar_policy` layer produced; `effective.source='rule'` (base) | "role/roleTags override is valid config but silently inert in resolver mode" |
+
+## Static Evidence
+
+- `attendance_holidays.origin` semantics from Step 2 are untouched; the
+  resolver reads `origin` but never writes it.
+- `resolveWorkContext` and its prefetch sibling remain unchanged; calc-chain
+  cutover is deferred to Step 5.
+- New shared predicates (`matchScopeFilters`, `matchDayIndexFilter`) are
+  consumed by both `matchHolidayOverrideFilters` (existing payroll callers)
+  and `matchCalendarOverride` (new resolver). Unit suite confirms no
+  behavioral regression on `holidayPolicy.*` callers (170 files / 2245 tests
+  pass after refactor).
+- `mergeSettings` adds a `calendarPolicy` branch so a partial PATCH does not
+  shallow-merge away nested `overrides`.
+
+## Remaining Gate
+
+No DB gate remains for this slice. The scratch PostgreSQL run above executed
+all 5 effective-calendar assertions (including the role/roleTags inert-mode
+limitation guard) plus the Step 2 sync regression.
+
+## Known Limitations
+
+See `attendance-calendar-policy-resolver-development-20260520.md` § "Known
+Limitations (v1)":
+
+1. `role` / `roleTags` filters silently inert in resolver mode (no DB context
+   loader; documented).
+2. `groupId` mode uses default rule for base; group `rule_set` working days
+   not applied in v1.
+3. Per-user-per-day real-time resolve; large batch use cases deferred to
+   Phase 2 materialization.

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -7346,4 +7346,464 @@ describe('Attendance Plugin Integration', () => {
     expect(code).toBe('EXPIRED')
   })
 
+  it('effective-calendar §6.1 baseline equals resolveWorkContext for rule + holiday rows', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const year = 3030 + (Number.parseInt(runSuffix.slice(-3), 36) % 500)
+    const testUserId = `attendance-effcal-baseline-${runSuffix}`
+    const orgId = 'default'
+    const rangeFrom = `${year}-06-01`
+    const rangeTo = `${year}-06-08`
+    const holidayDate = `${year}-06-03`
+    const workdayOverrideDate = `${year}-06-07`
+
+    const weekdays = new Map<string, number>()
+    for (let i = 1; i <= 8; i += 1) {
+      const d = `${year}-06-${String(i).padStart(2, '0')}`
+      weekdays.set(d, new Date(`${d}T00:00:00Z`).getUTCDay())
+    }
+
+    const pool = new Pool({ connectionString: dbUrl })
+    try {
+      await pool.query(
+        'DELETE FROM attendance_holidays WHERE org_id = $1 AND holiday_date BETWEEN $2 AND $3',
+        [orgId, rangeFrom, rangeTo]
+      )
+      await pool.query(
+        `INSERT INTO attendance_holidays (id, org_id, holiday_date, name, is_working_day, origin)
+         VALUES ($1, 'default', $2, 'Test Holiday', false, 'manual'),
+                ($3, 'default', $4, 'Saturday Work', true, 'manual')`,
+        [randomUuidV4(), holidayDate, randomUuidV4(), workdayOverrideDate]
+      )
+
+      const tokenRes = await requestJson(
+        `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(testUserId)}&roles=admin&perms=attendance:read,attendance:admin`
+      )
+      const token = (tokenRes.body as { token?: string } | undefined)?.token
+      expect(token).toBeTruthy()
+      if (!token) return
+
+      const res = await requestJson(
+        `${baseUrl}/api/attendance/effective-calendar?from=${rangeFrom}&to=${rangeTo}&userId=${encodeURIComponent(testUserId)}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      expect(res.status).toBe(200)
+      const data = (res.body as any)?.data
+      expect(data?.mode).toBe('userId')
+      expect(data.from).toBe(rangeFrom)
+      expect(data.to).toBe(rangeTo)
+      expect(Array.isArray(data.items)).toBe(true)
+      expect(data.items.length).toBe(8)
+
+      const byDate = new Map<string, any>(data.items.map((it: any) => [it.date, it]))
+
+      const holidayItem = byDate.get(holidayDate)
+      expect(holidayItem.base.source).toBe('manual')
+      expect(holidayItem.base.isWorkingDay).toBe(false)
+      expect(holidayItem.effective.source).toBe('manual')
+      expect(holidayItem.effective.isWorkingDay).toBe(false)
+      expect(holidayItem.layers.some((l: any) => l.kind === 'holiday' && l.source === 'manual')).toBe(true)
+
+      const overrideItem = byDate.get(workdayOverrideDate)
+      expect(overrideItem.base.source).toBe('manual')
+      expect(overrideItem.base.isWorkingDay).toBe(true)
+      expect(overrideItem.effective.source).toBe('manual')
+      expect(overrideItem.effective.isWorkingDay).toBe(true)
+
+      const defaultWorkingDays = [1, 2, 3, 4, 5]
+      for (const item of data.items) {
+        if (item.date === holidayDate || item.date === workdayOverrideDate) continue
+        const expectedWorkday = defaultWorkingDays.includes(weekdays.get(item.date)!)
+        expect(item.base.source).toBe('rule')
+        expect(item.base.isWorkingDay).toBe(expectedWorkday)
+        expect(item.effective.source).toBe('rule')
+        expect(item.effective.isWorkingDay).toBe(expectedWorkday)
+      }
+
+      for (const item of data.items) {
+        const policyLayers = item.layers.filter((l: any) => l.kind === 'calendar_policy')
+        expect(policyLayers.length).toBe(0)
+        expect(item.overlays).toEqual([])
+      }
+    } finally {
+      await pool.query(
+        'DELETE FROM attendance_holidays WHERE org_id = $1 AND holiday_date BETWEEN $2 AND $3',
+        [orgId, rangeFrom, rangeTo]
+      ).catch(() => undefined)
+      await pool.end()
+    }
+  })
+
+  it('effective-calendar §6.2 applies calendarPolicy with mode gates, priority, and normalize drops invalid', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const year = 3030 + (Number.parseInt(runSuffix.slice(-3), 36) % 500)
+    const testUserId = `attendance-effcal-policy-${runSuffix}`
+    const orgId = 'default'
+    const targetDate = `${year}-07-04`
+    const groupName = `effcal-prod-${runSuffix}`
+    const adminUserId = `attendance-effcal-policy-admin-${runSuffix}`
+    let groupId: string | null = null
+    let originalSettings: any = null
+
+    const pool = new Pool({ connectionString: dbUrl })
+    try {
+      // Setup: holiday on targetDate (national)
+      await pool.query(
+        'DELETE FROM attendance_holidays WHERE org_id = $1 AND holiday_date = $2',
+        [orgId, targetDate]
+      )
+      await pool.query(
+        `INSERT INTO attendance_holidays (id, org_id, holiday_date, name, is_working_day, origin)
+         VALUES ($1, 'default', $2, 'National Day Test', false, 'national')`,
+        [randomUuidV4(), targetDate]
+      )
+      // Group + member
+      const groupRows = await pool.query(
+        `INSERT INTO attendance_groups (org_id, name, code, timezone)
+         VALUES ('default', $1, $2, 'UTC')
+         RETURNING id`,
+        [groupName, groupName]
+      )
+      groupId = String(groupRows.rows[0].id)
+      await pool.query(
+        `INSERT INTO attendance_group_members (org_id, group_id, user_id)
+         VALUES ('default', $1, $2)`,
+        [groupId, testUserId]
+      )
+
+      const adminTokenRes = await requestJson(
+        `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin,attendance:approve`
+      )
+      const adminToken = (adminTokenRes.body as { token?: string } | undefined)?.token
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+
+      // Preserve current settings to restore later
+      const settingsRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        headers: { Authorization: `Bearer ${adminToken}` },
+      })
+      originalSettings = (settingsRes.body as any)?.data ?? null
+
+      const overridesPayload = [
+        // valid: org override that flips the national rest day to working day
+        { date: targetDate, effective: { isWorkingDay: true, label: 'Org swap', source: 'org' } },
+        // valid: group override (production) -> rest day
+        { date: targetDate, filters: { attendanceGroups: [groupName] }, effective: { isWorkingDay: false, label: 'Group rest', source: 'group' } },
+        // valid: user override -> working day (highest priority)
+        { date: targetDate, filters: { userIds: [testUserId] }, effective: { isWorkingDay: true, label: 'User confirm', source: 'user' } },
+        // INVALID 1: source='group' missing attendanceGroups filter -> normalize drops
+        { date: targetDate, effective: { isWorkingDay: false, label: 'Bad group', source: 'group' } },
+        // INVALID 2: no constraint at all -> normalize drops
+        { effective: { isWorkingDay: false, label: 'Bad blanket', source: 'org' } },
+        // INVALID 3: source='user' missing user filter -> normalize drops
+        { date: targetDate, effective: { isWorkingDay: true, label: 'Bad user', source: 'user' } },
+      ]
+
+      const putRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ calendarPolicy: { overrides: overridesPayload } }),
+      })
+      expect(putRes.status).toBe(200)
+      const savedOverrides = ((putRes.body as any)?.data?.calendarPolicy?.overrides ?? []) as any[]
+      // 3 invalid entries dropped at normalize
+      expect(savedOverrides.length).toBe(3)
+      const labels = savedOverrides.map((o: any) => o.effective?.label).sort()
+      expect(labels).toEqual(['Group rest', 'Org swap', 'User confirm'])
+      // Each saved override has a stable id assigned at normalize
+      for (const o of savedOverrides) expect(typeof o.id).toBe('string')
+
+      // Mode: userId — user override wins (priority 4 > group 2 > org 1)
+      const userRes = await requestJson(
+        `${baseUrl}/api/attendance/effective-calendar?from=${targetDate}&to=${targetDate}&userId=${encodeURIComponent(testUserId)}`,
+        { headers: { Authorization: `Bearer ${adminToken}` } }
+      )
+      expect(userRes.status).toBe(200)
+      const userItem = ((userRes.body as any)?.data?.items ?? [])[0]
+      expect(userItem.date).toBe(targetDate)
+      expect(userItem.base.source).toBe('national')
+      expect(userItem.base.isWorkingDay).toBe(false)
+      expect(userItem.effective.source).toBe('user')
+      expect(userItem.effective.isWorkingDay).toBe(true)
+      const userPolicyLayers = userItem.layers.filter((l: any) => l.kind === 'calendar_policy').map((l: any) => l.source)
+      expect(userPolicyLayers).toEqual(['org', 'group', 'user'])
+
+      // Mode: groupId — only 'group' source is in allowed set; org/user don't apply
+      const groupRes = await requestJson(
+        `${baseUrl}/api/attendance/effective-calendar?from=${targetDate}&to=${targetDate}&groupId=${encodeURIComponent(groupId!)}`,
+        { headers: { Authorization: `Bearer ${adminToken}` } }
+      )
+      expect(groupRes.status).toBe(200)
+      const groupItem = ((groupRes.body as any)?.data?.items ?? [])[0]
+      expect(groupItem.effective.source).toBe('group')
+      expect(groupItem.effective.isWorkingDay).toBe(false)
+      const groupPolicyLayers = groupItem.layers.filter((l: any) => l.kind === 'calendar_policy').map((l: any) => l.source)
+      expect(groupPolicyLayers).toEqual(['group'])
+
+      // Mode: orgOnly — only 'org' source applies
+      const orgRes = await requestJson(
+        `${baseUrl}/api/attendance/effective-calendar?from=${targetDate}&to=${targetDate}&orgOnly=true`,
+        { headers: { Authorization: `Bearer ${adminToken}` } }
+      )
+      expect(orgRes.status).toBe(200)
+      const orgItem = ((orgRes.body as any)?.data?.items ?? [])[0]
+      expect(orgItem.effective.source).toBe('org')
+      expect(orgItem.effective.isWorkingDay).toBe(true)
+      const orgPolicyLayers = orgItem.layers.filter((l: any) => l.kind === 'calendar_policy').map((l: any) => l.source)
+      expect(orgPolicyLayers).toEqual(['org'])
+    } finally {
+      if (originalSettings) {
+        const cleanupTokenRes = await requestJson(
+          `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(`${adminUserId}-cleanup`)}&roles=admin&perms=attendance:admin`
+        )
+        const cleanupToken = (cleanupTokenRes.body as { token?: string } | undefined)?.token
+        if (cleanupToken) {
+          await requestJson(`${baseUrl}/api/attendance/settings`, {
+            method: 'PUT',
+            headers: { Authorization: `Bearer ${cleanupToken}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify({ calendarPolicy: { overrides: [] } }),
+          }).catch(() => undefined)
+        }
+      }
+      if (groupId) {
+        await pool.query('DELETE FROM attendance_group_members WHERE group_id = $1', [groupId]).catch(() => undefined)
+        await pool.query('DELETE FROM attendance_groups WHERE id = $1', [groupId]).catch(() => undefined)
+      }
+      await pool.query(
+        'DELETE FROM attendance_holidays WHERE org_id = $1 AND holiday_date = $2',
+        [orgId, targetDate]
+      ).catch(() => undefined)
+      await pool.end()
+    }
+  })
+
+  it('effective-calendar §6.3 returns approved request overlays additively without merging', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const year = 3030 + (Number.parseInt(runSuffix.slice(-3), 36) % 500)
+    const testUserId = `attendance-effcal-overlays-${runSuffix}`
+    const orgId = 'default'
+    const targetDate = `${year}-08-15`
+    const pool = new Pool({ connectionString: dbUrl })
+
+    try {
+      await pool.query(
+        `DELETE FROM attendance_requests WHERE user_id = $1`,
+        [testUserId]
+      )
+      // Insert approved leave, overtime, and correction (time_correction) requests on the same date
+      const leaveId = randomUuidV4()
+      const overtimeId = randomUuidV4()
+      const correctionId = randomUuidV4()
+      await pool.query(
+        `INSERT INTO attendance_requests (id, org_id, user_id, work_date, request_type, status, metadata, created_at)
+         VALUES
+           ($1, 'default', $2, $3, 'leave', 'approved', '{"minutes":240}'::jsonb, now()),
+           ($4, 'default', $2, $3, 'overtime', 'approved', '{"minutes":180}'::jsonb, now() + interval '1 second'),
+           ($5, 'default', $2, $3, 'time_correction', 'approved', '{}'::jsonb, now() + interval '2 second')`,
+        [leaveId, testUserId, targetDate, overtimeId, correctionId]
+      )
+
+      const tokenRes = await requestJson(
+        `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(testUserId)}&roles=admin&perms=attendance:read,attendance:admin`
+      )
+      const token = (tokenRes.body as { token?: string } | undefined)?.token
+      expect(token).toBeTruthy()
+      if (!token) return
+
+      const res = await requestJson(
+        `${baseUrl}/api/attendance/effective-calendar?from=${targetDate}&to=${targetDate}&userId=${encodeURIComponent(testUserId)}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      expect(res.status).toBe(200)
+      const item = ((res.body as any)?.data?.items ?? [])[0]
+      expect(item.date).toBe(targetDate)
+      expect(Array.isArray(item.overlays)).toBe(true)
+      expect(item.overlays.length).toBe(3)
+      // additive: kinds preserved, no merge
+      const kinds = item.overlays.map((o: any) => o.kind)
+      expect(kinds).toEqual(['personal_leave', 'overtime', 'attendance_correction'])
+      // sources all attendance_requests
+      for (const ov of item.overlays) expect(ov.source).toBe('attendance_requests')
+      // requestType preserved per overlay
+      expect(item.overlays[0].requestType).toBe('leave')
+      expect(item.overlays[0].minutes).toBe(240)
+      expect(item.overlays[1].requestType).toBe('overtime')
+      expect(item.overlays[1].minutes).toBe(180)
+      expect(item.overlays[2].requestType).toBe('time_correction')
+      // refId carries attendance_requests.id for client audit
+      expect(item.overlays[0].refId).toBe(leaveId)
+      expect(item.overlays[1].refId).toBe(overtimeId)
+      expect(item.overlays[2].refId).toBe(correctionId)
+      // effective workday is NOT changed by overlays (no calendarPolicy here)
+      expect(item.effective.source).toBe('rule')
+    } finally {
+      await pool.query(`DELETE FROM attendance_requests WHERE user_id = $1`, [testUserId]).catch(() => undefined)
+      await pool.end()
+    }
+  })
+
+  it('effective-calendar validates strictly, enforces RBAC, and 404s missing group', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const requesterId = `attendance-effcal-rbac-req-${runSuffix}`
+    const targetId = `attendance-effcal-rbac-tgt-${runSuffix}`
+    const adminId = `attendance-effcal-rbac-adm-${runSuffix}`
+
+    // Read-only token for cross-user RBAC negative case
+    const readOnlyRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(requesterId)}&roles=user&perms=attendance:read`
+    )
+    const readOnlyToken = (readOnlyRes.body as { token?: string } | undefined)?.token
+    // Read + approve token for cross-user RBAC positive case
+    const approveRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(requesterId)}&roles=user&perms=attendance:read,attendance:approve`
+    )
+    const approveToken = (approveRes.body as { token?: string } | undefined)?.token
+    // Admin token for groupId / 404 case
+    const adminRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminId)}&roles=admin&perms=attendance:read,attendance:admin`
+    )
+    const adminToken = (adminRes.body as { token?: string } | undefined)?.token
+    expect(readOnlyToken).toBeTruthy()
+    expect(approveToken).toBeTruthy()
+    expect(adminToken).toBeTruthy()
+    if (!readOnlyToken || !approveToken || !adminToken) return
+
+    const base = `${baseUrl}/api/attendance/effective-calendar`
+    const dateRange = `from=2030-01-01&to=2030-01-03`
+
+    // 400: missing from/to
+    const missingRes = await requestJson(`${base}?to=2030-01-01&orgOnly=true`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    })
+    expect(missingRes.status).toBe(400)
+    // 400: invalid date
+    const badDateRes = await requestJson(`${base}?from=bogus&to=2030-01-01&orgOnly=true`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    })
+    expect(badDateRes.status).toBe(400)
+    // 400: no mode
+    const noModeRes = await requestJson(`${base}?${dateRange}`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    })
+    expect(noModeRes.status).toBe(400)
+    // 400: two modes
+    const twoModesRes = await requestJson(`${base}?${dateRange}&userId=x&orgOnly=true`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    })
+    expect(twoModesRes.status).toBe(400)
+    // 400: range too big
+    const bigRangeRes = await requestJson(`${base}?from=2030-01-01&to=2031-06-01&orgOnly=true`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    })
+    expect(bigRangeRes.status).toBe(400)
+    // 404: groupId not found
+    const noGroupRes = await requestJson(`${base}?${dateRange}&groupId=group-does-not-exist-${runSuffix}`, {
+      headers: { Authorization: `Bearer ${adminToken}` },
+    })
+    expect(noGroupRes.status).toBe(404)
+
+    // RBAC: read-only token querying another user → 403
+    const denyRes = await requestJson(`${base}?${dateRange}&userId=${encodeURIComponent(targetId)}`, {
+      headers: { Authorization: `Bearer ${readOnlyToken}` },
+    })
+    expect(denyRes.status).toBe(403)
+    // RBAC: same user (self) querying own calendar → 200
+    const selfRes = await requestJson(`${base}?${dateRange}&userId=${encodeURIComponent(requesterId)}`, {
+      headers: { Authorization: `Bearer ${readOnlyToken}` },
+    })
+    expect(selfRes.status).toBe(200)
+    // RBAC: read+approve token querying another user → 200
+    const approveOtherRes = await requestJson(`${base}?${dateRange}&userId=${encodeURIComponent(targetId)}`, {
+      headers: { Authorization: `Bearer ${approveToken}` },
+    })
+    expect(approveOtherRes.status).toBe(200)
+    // RBAC: read-only token using groupId → 403 (groupId requires attendance:admin)
+    const groupDenyRes = await requestJson(`${base}?${dateRange}&groupId=anything`, {
+      headers: { Authorization: `Bearer ${readOnlyToken}` },
+    })
+    expect(groupDenyRes.status).toBe(403)
+  })
+
+  it('effective-calendar role/roleTags override is valid config but silently inert in resolver mode', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const year = 3030 + (Number.parseInt(runSuffix.slice(-3), 36) % 500)
+    const targetDate = `${year}-09-12`
+    const testUserId = `attendance-effcal-roleinert-user-${runSuffix}`
+    const adminUserId = `attendance-effcal-roleinert-admin-${runSuffix}`
+
+    const adminTokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&roles=admin&perms=attendance:read,attendance:admin`
+    )
+    const adminToken = (adminTokenRes.body as { token?: string } | undefined)?.token
+    expect(adminToken).toBeTruthy()
+    if (!adminToken) return
+
+    try {
+      // POST a role-source override targeting a role the resolver cannot load
+      // for a user; per Known Limitation (v1), role/roleTags filters require
+      // a DB context loader that does not exist yet, so the override stays as
+      // valid persisted config but does not fire in resolver mode.
+      const putRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          calendarPolicy: {
+            overrides: [
+              {
+                date: targetDate,
+                filters: { roles: ['production_lead'] },
+                effective: { isWorkingDay: true, label: 'Role-inert in resolver', source: 'role' },
+              },
+            ],
+          },
+        }),
+      })
+      expect(putRes.status).toBe(200)
+      const saved = ((putRes.body as any)?.data?.calendarPolicy?.overrides ?? []) as any[]
+      // Config remains valid + persisted (normalize keeps it)
+      expect(saved.length).toBe(1)
+      expect(saved[0].effective?.source).toBe('role')
+
+      const res = await requestJson(
+        `${baseUrl}/api/attendance/effective-calendar?from=${targetDate}&to=${targetDate}&userId=${encodeURIComponent(testUserId)}`,
+        { headers: { Authorization: `Bearer ${adminToken}` } }
+      )
+      expect(res.status).toBe(200)
+      const item = ((res.body as any)?.data?.items ?? [])[0]
+      expect(item.date).toBe(targetDate)
+      // No calendar_policy layer present — the role override silently did not fire
+      const policyLayers = item.layers.filter((l: any) => l.kind === 'calendar_policy')
+      expect(policyLayers.length).toBe(0)
+      // effective falls back to base (rule)
+      expect(item.effective.source).toBe('rule')
+      expect(item.effective.policyId).toBeUndefined()
+    } finally {
+      const cleanupRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ calendarPolicy: { overrides: [] } }),
+      })
+      expect(cleanupRes.status).toBe(200)
+    }
+  })
+
 })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -61,6 +61,12 @@ const DEFAULT_SETTINGS = {
     overtimeSource: 'approval',
     overrides: [],
   },
+  // calendarPolicy answers "is this day a working day for whom?" (date-level
+  // effective workday + display source); kept separate from holidayPolicy which
+  // answers "how do work hours / overtime compute on a holiday day".
+  calendarPolicy: {
+    overrides: [],
+  },
   holidaySync: {
     source: 'holiday-cn',
     baseUrl: 'https://fastly.jsdelivr.net/gh/NateScarlet/holiday-cn@master',
@@ -8325,39 +8331,70 @@ function matchAnyTag(values, list) {
   return values.some((value) => normalizedList.includes(normalizeMatchKey(value)))
 }
 
-function matchHolidayOverrideFilters(override, holidayMeta, policyContext) {
-  if (!override) return true
-  const dayIndex = holidayMeta?.dayIndex
-  if (override.dayIndexStart != null || override.dayIndexEnd != null || (override.dayIndexList && override.dayIndexList.length)) {
-    if (!dayIndex) return false
-    if (Array.isArray(override.dayIndexList) && override.dayIndexList.length && !override.dayIndexList.includes(dayIndex)) {
+// Shared day-index predicate (RFC §2.3): both holidayPolicy and calendarPolicy
+// MUST use this; no duplicate implementations allowed.
+function matchDayIndexFilter(filter, dayIndex) {
+  if (!filter) return true
+  const hasFilter = filter.dayIndexStart != null
+    || filter.dayIndexEnd != null
+    || (Array.isArray(filter.dayIndexList) && filter.dayIndexList.length > 0)
+  if (!hasFilter) return true
+  if (dayIndex == null) return false
+  if (Array.isArray(filter.dayIndexList) && filter.dayIndexList.length && !filter.dayIndexList.includes(dayIndex)) {
+    return false
+  }
+  if (Number.isFinite(filter.dayIndexStart) && dayIndex < filter.dayIndexStart) return false
+  if (Number.isFinite(filter.dayIndexEnd) && dayIndex > filter.dayIndexEnd) return false
+  return true
+}
+
+// Shared scope predicate (RFC §2.3): both holidayPolicy.overrides[] (filters
+// at top level of override) and calendarPolicy.overrides[] (filters under
+// override.filters) MUST call this; no duplicate scope implementations allowed.
+// Context supports both shapes:
+//   - import path: context.attendanceGroup (single value)
+//   - resolver path: context.attendanceGroups (string[])
+function matchScopeFilters(filters, context) {
+  if (!filters) return true
+  const ctx = context ?? {}
+  if (Array.isArray(filters.userIds) && filters.userIds.length && !matchListValue(ctx.userId, filters.userIds)) {
+    return false
+  }
+  if (Array.isArray(filters.userNames) && filters.userNames.length && !matchListValue(ctx.userName, filters.userNames)) {
+    return false
+  }
+  if (Array.isArray(filters.excludeUserIds) && filters.excludeUserIds.length && matchListValue(ctx.userId, filters.excludeUserIds)) {
+    return false
+  }
+  if (Array.isArray(filters.excludeUserNames) && filters.excludeUserNames.length && matchListValue(ctx.userName, filters.excludeUserNames)) {
+    return false
+  }
+  if (Array.isArray(filters.attendanceGroups) && filters.attendanceGroups.length) {
+    if (Array.isArray(ctx.attendanceGroups)) {
+      // resolver path: any of user's groups must match the filter list. Use
+      // matchListValue per group so case/whitespace normalization mirrors the
+      // import path; a naive `includes` here would be case-sensitive and
+      // silently miss "Production" vs "production" / trailing-space drift.
+      if (!ctx.attendanceGroups.some((g) => matchListValue(g, filters.attendanceGroups))) return false
+    } else if (!matchListValue(ctx.attendanceGroup, filters.attendanceGroups)) {
       return false
     }
-    if (Number.isFinite(override.dayIndexStart) && dayIndex < override.dayIndexStart) return false
-    if (Number.isFinite(override.dayIndexEnd) && dayIndex > override.dayIndexEnd) return false
   }
-  const context = policyContext ?? {}
-  if (Array.isArray(override.userIds) && override.userIds.length && !matchListValue(context.userId, override.userIds)) {
+  if (Array.isArray(filters.roles) && filters.roles.length && !matchListValue(ctx.role, filters.roles)) {
     return false
   }
-  if (Array.isArray(override.userNames) && override.userNames.length && !matchListValue(context.userName, override.userNames)) {
+  if (Array.isArray(filters.roleTags) && filters.roleTags.length && !matchAnyTag(ctx.roleTags, filters.roleTags)) {
     return false
   }
-  if (Array.isArray(override.excludeUserIds) && override.excludeUserIds.length && matchListValue(context.userId, override.excludeUserIds)) {
-    return false
-  }
-  if (Array.isArray(override.excludeUserNames) && override.excludeUserNames.length && matchListValue(context.userName, override.excludeUserNames)) {
-    return false
-  }
-  if (Array.isArray(override.attendanceGroups) && override.attendanceGroups.length && !matchListValue(context.attendanceGroup, override.attendanceGroups)) {
-    return false
-  }
-  if (Array.isArray(override.roles) && override.roles.length && !matchListValue(context.role, override.roles)) {
-    return false
-  }
-  if (Array.isArray(override.roleTags) && override.roleTags.length && !matchAnyTag(context.roleTags, override.roleTags)) {
-    return false
-  }
+  return true
+}
+
+function matchHolidayOverrideFilters(override, holidayMeta, policyContext) {
+  if (!override) return true
+  if (!matchDayIndexFilter(override, holidayMeta?.dayIndex)) return false
+  // holidayPolicy.overrides[] keeps scope fields flat on the override itself
+  // (legacy schema); pass the override directly as ScopeFilters.
+  if (!matchScopeFilters(override, policyContext)) return false
   return true
 }
 
@@ -9221,10 +9258,99 @@ function normalizeHolidayPolicyOverrides(rawOverrides) {
     .filter(Boolean)
 }
 
+// calendarPolicy.overrides[] (RFC §2.2): "is this day a working day for whom?"
+// Distinct from holidayPolicy.overrides[]; do NOT merge into the same array.
+// Drops invalid entries (silently, by design — caller passes raw config):
+//   - no constraint (must provide at least one of date/from/to/name/dayIndex*)
+//   - no `effective.isWorkingDay`
+//   - source/filters mismatch:
+//       source='group' must declare filters.attendanceGroups (non-empty)
+//       source='role'  must declare filters.roles OR filters.roleTags
+//       source='user'  must declare filters.userIds OR filters.userNames
+//       source='org'   has no filter requirement
+// Generates randomUUID() for entries missing `id` so client-side audit (and
+// effective.policyId in responses) can reference a stable handle once saved.
+function normalizeCalendarPolicyOverrides(rawOverrides) {
+  if (!Array.isArray(rawOverrides)) return []
+  return rawOverrides
+    .map((override) => {
+      if (!override || typeof override !== 'object') return null
+      const effectiveRaw = override.effective && typeof override.effective === 'object' ? override.effective : null
+      if (!effectiveRaw || typeof effectiveRaw.isWorkingDay !== 'boolean') return null
+      const source = ['org', 'group', 'role', 'user'].includes(effectiveRaw.source) ? effectiveRaw.source : 'org'
+
+      const filtersRaw = override.filters && typeof override.filters === 'object' ? override.filters : {}
+      const userIds = ensureStringArray(filtersRaw.userIds)
+      const userNames = ensureStringArray(filtersRaw.userNames)
+      const excludeUserIds = ensureStringArray(filtersRaw.excludeUserIds)
+      const excludeUserNames = ensureStringArray(filtersRaw.excludeUserNames)
+      const attendanceGroups = ensureStringArray(filtersRaw.attendanceGroups)
+      const roles = ensureStringArray(filtersRaw.roles)
+      const roleTags = ensureStringArray(filtersRaw.roleTags)
+
+      // source/filters consistency — invalid means drop (silent, by design)
+      if (source === 'group' && attendanceGroups.length === 0) return null
+      if (source === 'role' && roles.length === 0 && roleTags.length === 0) return null
+      if (source === 'user' && userIds.length === 0 && userNames.length === 0) return null
+
+      const date = typeof override.date === 'string' ? override.date.trim() : ''
+      const from = typeof override.from === 'string' ? override.from.trim() : ''
+      const to = typeof override.to === 'string' ? override.to.trim() : ''
+      const name = typeof override.name === 'string' ? override.name.trim() : ''
+      const matchRaw = typeof override.match === 'string' ? override.match.trim() : 'contains'
+      const match = ['contains', 'regex', 'equals'].includes(matchRaw) ? matchRaw : 'contains'
+      const dayIndexStart = parseNumber(override.dayIndexStart, null)
+      const dayIndexEnd = parseNumber(override.dayIndexEnd, null)
+      const dayIndexList = ensureNumberArray(override.dayIndexList)
+      const hasDayIndexFilter = Number.isFinite(dayIndexStart)
+        || Number.isFinite(dayIndexEnd)
+        || dayIndexList.length > 0
+
+      // Must constrain by at least one of date / from-to / name / dayIndex*
+      const hasConstraint = !!date || !!from || !!to || !!name || hasDayIndexFilter
+      if (!hasConstraint) return null
+
+      const filters = {}
+      if (userIds.length) filters.userIds = userIds
+      if (userNames.length) filters.userNames = userNames
+      if (excludeUserIds.length) filters.excludeUserIds = excludeUserIds
+      if (excludeUserNames.length) filters.excludeUserNames = excludeUserNames
+      if (attendanceGroups.length) filters.attendanceGroups = attendanceGroups
+      if (roles.length) filters.roles = roles
+      if (roleTags.length) filters.roleTags = roleTags
+
+      const id = typeof override.id === 'string' && override.id.trim()
+        ? override.id.trim()
+        : randomUUID()
+
+      return {
+        id,
+        date: date || undefined,
+        from: from || undefined,
+        to: to || undefined,
+        name: name || undefined,
+        match: name ? match : undefined,
+        dayIndexStart: Number.isFinite(dayIndexStart) ? Math.max(1, dayIndexStart) : undefined,
+        dayIndexEnd: Number.isFinite(dayIndexEnd) ? Math.max(1, dayIndexEnd) : undefined,
+        dayIndexList: dayIndexList.length ? dayIndexList.map((item) => Math.max(1, item)) : undefined,
+        filters: Object.keys(filters).length ? filters : undefined,
+        effective: {
+          isWorkingDay: effectiveRaw.isWorkingDay,
+          label: typeof effectiveRaw.label === 'string' && effectiveRaw.label.trim()
+            ? effectiveRaw.label.trim()
+            : undefined,
+          source,
+        },
+      }
+    })
+    .filter(Boolean)
+}
+
 function normalizeSettings(raw) {
   if (!raw || typeof raw !== 'object') return { ...DEFAULT_SETTINGS }
   const autoAbsence = raw.autoAbsence ?? {}
   const holidayPolicy = raw.holidayPolicy ?? {}
+  const calendarPolicy = raw.calendarPolicy ?? {}
   const holidaySync = raw.holidaySync ?? {}
   const holidaySyncAuto = holidaySync.auto ?? {}
   const holidaySyncLastRun = holidaySync.lastRun ?? null
@@ -9286,6 +9412,7 @@ function normalizeSettings(raw) {
       }
     : null
   const holidayPolicyOverrides = normalizeHolidayPolicyOverrides(holidayPolicy.overrides)
+  const calendarPolicyOverrides = normalizeCalendarPolicyOverrides(calendarPolicy.overrides)
   return {
     autoAbsence: {
       enabled: parseBoolean(autoAbsence.enabled, DEFAULT_SETTINGS.autoAbsence.enabled),
@@ -9300,6 +9427,9 @@ function normalizeSettings(raw) {
       overtimeAdds: parseBoolean(holidayPolicy.overtimeAdds, DEFAULT_SETTINGS.holidayPolicy.overtimeAdds),
       overtimeSource,
       overrides: holidayPolicyOverrides,
+    },
+    calendarPolicy: {
+      overrides: calendarPolicyOverrides,
     },
     holidaySync: {
       source: 'holiday-cn',
@@ -9337,6 +9467,10 @@ function mergeSettings(base, update) {
     holidayPolicy: {
       ...(base?.holidayPolicy || {}),
       ...(update?.holidayPolicy || {}),
+    },
+    calendarPolicy: {
+      ...(base?.calendarPolicy || {}),
+      ...(update?.calendarPolicy || {}),
     },
     holidaySync: {
       ...(base?.holidaySync || {}),
@@ -10110,6 +10244,395 @@ async function loadRotationAssignmentMapForUsersRange(db, orgId, userIds, fromDa
       return { assignmentsByUser: new Map(), shiftsById: new Map() }
     }
     throw error
+  }
+}
+
+// ===== EffectiveCalendarResolver (RFC §4) =====
+// Read-only resolver for `GET /api/attendance/effective-calendar`. Composes
+// base layer (rotation/shift/rule + national/manual holidays) with
+// calendarPolicy.overrides[] and (userId mode only) per-user request overlays.
+// Does NOT mutate `resolveWorkContext`; calc-chain cutover is Step 5.
+
+const CALENDAR_BASE_SOURCE_PRIORITY = 0
+const CALENDAR_POLICY_SOURCE_PRIORITY = {
+  // strictly ascending; same-source ties broken by array order — see RFC §4.2.
+  org: 1,
+  group: 2,
+  role: 3,
+  user: 4,
+}
+
+const CALENDAR_MODE_ALLOWED_SOURCES = {
+  userId: new Set(['org', 'group', 'role', 'user']),
+  groupId: new Set(['group']),
+  orgOnly: new Set(['org']),
+}
+
+const CALENDAR_OVERLAY_REQUEST_TYPES = ['leave', 'overtime', 'missed_check_in', 'missed_check_out', 'time_correction']
+
+function calendarOverlayKindFromRequestType(requestType) {
+  if (requestType === 'leave') return 'personal_leave'
+  if (requestType === 'overtime') return 'overtime'
+  if (
+    requestType === 'missed_check_in'
+    || requestType === 'missed_check_out'
+    || requestType === 'time_correction'
+  ) return 'attendance_correction'
+  return null
+}
+
+function matchCalendarOverride(override, dayContext, mode) {
+  if (!override || !override.effective) return false
+  const allowed = CALENDAR_MODE_ALLOWED_SOURCES[mode]
+  if (!allowed || !allowed.has(override.effective.source)) return false
+
+  const dateKey = dayContext.date
+  if (override.date && override.date !== dateKey) return false
+  if (override.from && dateKey < override.from) return false
+  if (override.to && dateKey > override.to) return false
+
+  const holiday = dayContext.holiday ?? null
+  if (override.name) {
+    if (!holiday || !holiday.name) return false
+    if (!matchHolidayOverride(holiday.name, override)) return false
+  }
+
+  if (!matchDayIndexFilter(override, holiday?.dayIndex ?? null)) return false
+  if (!matchScopeFilters(override.filters, dayContext.scopeContext)) return false
+  return true
+}
+
+async function loadApprovedRequestsForOverlay(db, orgId, userId, fromDate, toDate) {
+  if (!userId || !fromDate || !toDate) return []
+  const targetOrg = orgId || DEFAULT_ORG_ID
+  try {
+    const rows = await db.query(
+      `SELECT id, request_type, work_date, status, metadata, created_at
+       FROM attendance_requests
+       WHERE user_id = $1
+         AND org_id = $2
+         AND work_date BETWEEN $3 AND $4
+         AND status = 'approved'
+         AND request_type = ANY($5::text[])
+       ORDER BY work_date ASC, created_at ASC NULLS LAST, id ASC`,
+      [userId, targetOrg, fromDate, toDate, CALENDAR_OVERLAY_REQUEST_TYPES]
+    )
+    return rows.map((row) => ({
+      id: row.id,
+      requestType: row.request_type,
+      workDate: normalizeDateOnly(row.work_date) ?? row.work_date,
+      status: row.status,
+      metadata: normalizeMetadata(row.metadata),
+      createdAt: row.created_at instanceof Date ? row.created_at.toISOString() : row.created_at ?? null,
+    }))
+  } catch (error) {
+    if (isDatabaseSchemaError(error)) return []
+    throw error
+  }
+}
+
+async function loadAttendanceScopeContextForUser(db, orgId, userId) {
+  if (!userId) return { userId: null, userName: undefined, attendanceGroups: [] }
+  const targetOrg = orgId || DEFAULT_ORG_ID
+  let userName
+  try {
+    const rows = await db.query('SELECT name FROM users WHERE id = $1', [userId])
+    if (rows.length && typeof rows[0].name === 'string') userName = rows[0].name
+  } catch (error) {
+    if (!isDatabaseSchemaError(error)) throw error
+  }
+  const attendanceGroups = []
+  try {
+    const rows = await db.query(
+      `SELECT g.name, g.code
+       FROM attendance_group_members m
+       JOIN attendance_groups g ON g.id = m.group_id
+       WHERE m.user_id = $1 AND m.org_id = $2`,
+      [userId, targetOrg]
+    )
+    const seen = new Set()
+    for (const row of rows) {
+      for (const candidate of [row.name, row.code]) {
+        if (typeof candidate === 'string' && candidate && !seen.has(candidate)) {
+          seen.add(candidate)
+          attendanceGroups.push(candidate)
+        }
+      }
+    }
+  } catch (error) {
+    if (!isDatabaseSchemaError(error)) throw error
+  }
+  // role/roleTags: NOT loaded in v1 — Step 3 Known Limitation (see dev MD).
+  // calendarPolicy.overrides[] with effective.source='role' remain valid
+  // config but the resolver cannot match them without DB-backed role context.
+  return { userId, userName, attendanceGroups }
+}
+
+async function loadAttendanceGroupByIdOrCode(db, orgId, identifier) {
+  if (!identifier) return null
+  const targetOrg = orgId || DEFAULT_ORG_ID
+  try {
+    const rows = await db.query(
+      `SELECT id, name, code, timezone
+       FROM attendance_groups
+       WHERE org_id = $1 AND (id::text = $2 OR code = $2)
+       LIMIT 1`,
+      [targetOrg, String(identifier)]
+    )
+    return rows.length ? { id: rows[0].id, name: rows[0].name, code: rows[0].code, timezone: rows[0].timezone } : null
+  } catch (error) {
+    if (isDatabaseSchemaError(error)) return null
+    throw error
+  }
+}
+
+function enumerateAttendanceCalendarDateRange(fromDate, toDate) {
+  const out = []
+  const start = normalizeDateOnly(fromDate)
+  const end = normalizeDateOnly(toDate)
+  if (!start || !end || start > end) return out
+  let cursor = start
+  // hard cap at 366 to match route validation; never iterate forever
+  for (let i = 0; i <= 366 && cursor <= end; i += 1) {
+    out.push(cursor)
+    cursor = addDaysToDateKey(cursor, 1)
+  }
+  return out
+}
+
+function buildCalendarBaseFromProfile(profile, weekday, source) {
+  const isWorkingDay = Array.isArray(profile?.workingDays) && profile.workingDays.includes(weekday)
+  return {
+    isWorkingDay,
+    source: source ?? 'rule',
+  }
+}
+
+function buildCalendarBaseFromHoliday(holiday) {
+  const meta = resolveHolidayMeta(holiday)
+  const origin = holiday?.origin === 'national' ? 'national' : 'manual'
+  return {
+    isWorkingDay: holiday?.isWorkingDay === true,
+    source: origin,
+    holidayId: holiday?.id ?? undefined,
+    name: meta.name ?? holiday?.name ?? undefined,
+    dayIndex: meta.dayIndex ?? undefined,
+  }
+}
+
+function pushCalendarLayer(layers, layer) {
+  layers.push(layer)
+}
+
+function resolveCalendarTimezone({ rotation, shift, defaultRule, group, defaultTimezone }) {
+  const candidates = [
+    rotation?.timezone,
+    shift?.timezone,
+    defaultRule?.timezone,
+    group?.timezone,
+    defaultTimezone,
+  ]
+  for (const tz of candidates) {
+    if (typeof tz === 'string' && tz.trim()) return tz.trim()
+  }
+  return 'UTC'
+}
+
+// resolveEffectiveCalendar implements RFC §4. Returns { mode, from, to, timezone, items[] }.
+// Throws on invalid inputs (route handler converts to 400/404).
+async function resolveEffectiveCalendar(db, args) {
+  const orgId = args.orgId || DEFAULT_ORG_ID
+  const from = normalizeDateOnlyStrict(args.from)
+  const to = normalizeDateOnlyStrict(args.to)
+  if (!from) throw new Error('VALIDATION:from')
+  if (!to) throw new Error('VALIDATION:to')
+  if (from > to) throw new Error('VALIDATION:range')
+  const modeCount = [args.userId, args.groupId, args.orgOnly === true].filter((v) => v != null && v !== false).length
+  if (modeCount !== 1) throw new Error('VALIDATION:mode')
+
+  let mode
+  if (args.userId) mode = 'userId'
+  else if (args.groupId) mode = 'groupId'
+  else mode = 'orgOnly'
+
+  const settings = await getSettings(db)
+  const calendarOverrides = Array.isArray(settings?.calendarPolicy?.overrides)
+    ? settings.calendarPolicy.overrides
+    : []
+  const defaultRule = await loadDefaultRule(db, orgId)
+  const dates = enumerateAttendanceCalendarDateRange(from, to)
+  const holidaysByDate = await loadHolidayMapByDates(db, orgId, dates)
+
+  // Mode-specific loads
+  let scopeContext = {}
+  let shiftAssignmentsByUser = new Map()
+  let rotationByUser = new Map()
+  let rotationShiftsById = new Map()
+  let overlays = []
+  let groupContext = null
+
+  if (mode === 'userId') {
+    scopeContext = await loadAttendanceScopeContextForUser(db, orgId, args.userId)
+    shiftAssignmentsByUser = await loadShiftAssignmentMapForUsersRange(db, orgId, [args.userId], from, to)
+    const rotationPrefetch = await loadRotationAssignmentMapForUsersRange(db, orgId, [args.userId], from, to)
+    rotationByUser = rotationPrefetch.assignmentsByUser
+    rotationShiftsById = rotationPrefetch.shiftsById
+    overlays = await loadApprovedRequestsForOverlay(db, orgId, args.userId, from, to)
+  } else if (mode === 'groupId') {
+    groupContext = await loadAttendanceGroupByIdOrCode(db, orgId, args.groupId)
+    if (!groupContext) throw new Error('NOT_FOUND:group')
+    const groupRefs = []
+    if (groupContext.name) groupRefs.push(groupContext.name)
+    if (groupContext.code) groupRefs.push(groupContext.code)
+    scopeContext = { attendanceGroups: groupRefs }
+  } else {
+    scopeContext = {}
+  }
+
+  // RFC §4.3 timezone chain. For userId mode we sample the rotation/shift
+  // active at `from` so the response carries a representative tz (rather than
+  // always falling through to defaultRule.timezone). Per-day rotation/shift
+  // can drift inside the range; documented choice is the `from` snapshot.
+  let firstDateRotation = null
+  let firstDateShift = null
+  if (mode === 'userId') {
+    const firstDate = dates[0] ?? from
+    const rotationInfo = resolveRotationInfoFromPrefetch(rotationByUser.get(args.userId), firstDate, rotationShiftsById)
+    const shiftInfo = resolveShiftAssignmentFromPrefetch(shiftAssignmentsByUser.get(args.userId), firstDate)
+    firstDateRotation = rotationInfo?.rotation ?? null
+    firstDateShift = rotationInfo?.shift ?? shiftInfo?.shift ?? null
+  }
+  const timezone = resolveCalendarTimezone({
+    rotation: firstDateRotation,
+    shift: firstDateShift,
+    defaultRule,
+    group: groupContext,
+    defaultTimezone: undefined,
+  })
+
+  const overlaysByDate = new Map()
+  for (const row of overlays) {
+    const kind = calendarOverlayKindFromRequestType(row.requestType)
+    if (!kind) continue
+    const key = row.workDate
+    if (!overlaysByDate.has(key)) overlaysByDate.set(key, [])
+    const minutesRaw = row.metadata?.minutes
+    const minutes = typeof minutesRaw === 'string' && /^[0-9]+(\.[0-9]+)?$/.test(minutesRaw)
+      ? Number(minutesRaw)
+      : Number.isFinite(minutesRaw) ? Number(minutesRaw) : undefined
+    overlaysByDate.get(key).push({
+      kind,
+      source: 'attendance_requests',
+      requestType: row.requestType,
+      minutes,
+      status: row.status,
+      refId: row.id,
+    })
+  }
+
+  const items = dates.map((date) => {
+    const weekday = getWeekdayFromDateKey(date)
+    let profileSource = 'rule'
+    let profile = defaultRule
+
+    if (mode === 'userId') {
+      const rotationInfo = resolveRotationInfoFromPrefetch(rotationByUser.get(args.userId), date, rotationShiftsById)
+      const shiftInfo = resolveShiftAssignmentFromPrefetch(shiftAssignmentsByUser.get(args.userId), date)
+      if (rotationInfo?.shift) {
+        profile = rotationInfo.shift
+        profileSource = 'rotation'
+      } else if (shiftInfo?.shift) {
+        profile = shiftInfo.shift
+        profileSource = 'shift'
+      }
+    }
+
+    const holiday = holidaysByDate.get(date) ?? null
+    const layers = []
+    let base
+    if (holiday) {
+      base = buildCalendarBaseFromHoliday(holiday)
+      layers.push({
+        kind: 'holiday',
+        source: base.source,
+        isWorkingDay: base.isWorkingDay,
+        label: base.name,
+        refId: base.holidayId,
+      })
+    } else {
+      base = buildCalendarBaseFromProfile(profile, weekday, profileSource)
+      layers.push({
+        kind: 'base_rule',
+        source: profileSource,
+        isWorkingDay: base.isWorkingDay,
+      })
+    }
+
+    let effective = {
+      isWorkingDay: base.isWorkingDay,
+      source: base.source,
+      label: base.name,
+    }
+    let effectivePriority = CALENDAR_BASE_SOURCE_PRIORITY
+
+    const holidayMeta = holiday ? { name: holiday.name ?? null, dayIndex: resolveHolidayMeta(holiday).dayIndex } : null
+    const dayContext = {
+      date,
+      holiday: holidayMeta,
+      scopeContext,
+    }
+    for (const override of calendarOverrides) {
+      if (!matchCalendarOverride(override, dayContext, mode)) continue
+      const overridePriority = CALENDAR_POLICY_SOURCE_PRIORITY[override.effective.source] ?? 0
+      const label = override.effective.label ?? override.name ?? undefined
+      pushCalendarLayer(layers, {
+        kind: 'calendar_policy',
+        source: override.effective.source,
+        isWorkingDay: override.effective.isWorkingDay,
+        label,
+        refId: override.id,
+      })
+      // Higher priority wins; same priority -> later in array order wins
+      if (overridePriority >= effectivePriority) {
+        effective = {
+          isWorkingDay: override.effective.isWorkingDay,
+          source: override.effective.source,
+          label,
+          policyId: override.id,
+        }
+        effectivePriority = overridePriority
+      }
+    }
+
+    const baseOut = {
+      isWorkingDay: base.isWorkingDay,
+      source: base.source,
+    }
+    if (base.holidayId) baseOut.holidayId = base.holidayId
+    if (base.name) baseOut.name = base.name
+
+    const effectiveOut = {
+      isWorkingDay: effective.isWorkingDay,
+      source: effective.source,
+    }
+    if (effective.label) effectiveOut.label = effective.label
+    if (effective.policyId) effectiveOut.policyId = effective.policyId
+
+    return {
+      date,
+      base: baseOut,
+      effective: effectiveOut,
+      layers,
+      overlays: overlaysByDate.get(date) ?? [],
+    }
+  })
+
+  return {
+    mode,
+    from,
+    to,
+    timezone,
+    items,
   }
 }
 
@@ -11913,6 +12436,35 @@ module.exports = {
             firstDayBaseHours: z.number().min(0).optional(),
             overtimeAdds: z.boolean().optional(),
             overtimeSource: z.enum(['approval', 'clock', 'both']).optional(),
+          })
+        ).optional(),
+      }).optional(),
+      calendarPolicy: z.object({
+        overrides: z.array(
+          z.object({
+            id: z.string().optional(),
+            name: z.string().optional(),
+            match: z.enum(['contains', 'regex', 'equals']).optional(),
+            date: z.string().optional(),
+            from: z.string().optional(),
+            to: z.string().optional(),
+            dayIndexStart: z.number().int().min(1).optional(),
+            dayIndexEnd: z.number().int().min(1).optional(),
+            dayIndexList: z.array(z.number().int().min(1)).optional(),
+            filters: z.object({
+              userIds: z.array(z.string()).optional(),
+              userNames: z.array(z.string()).optional(),
+              excludeUserIds: z.array(z.string()).optional(),
+              excludeUserNames: z.array(z.string()).optional(),
+              attendanceGroups: z.array(z.string()).optional(),
+              roles: z.array(z.string()).optional(),
+              roleTags: z.array(z.string()).optional(),
+            }).optional(),
+            effective: z.object({
+              isWorkingDay: z.boolean(),
+              label: z.string().optional(),
+              source: z.enum(['org', 'group', 'role', 'user']),
+            }),
           })
         ).optional(),
       }).optional(),
@@ -23588,6 +24140,103 @@ module.exports = {
           }
           logger.error('Attendance assignment delete failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete assignment' } })
+        }
+      })
+    )
+
+    // RFC §5: read-only effective calendar.
+    // Validation is inline (does NOT reuse resolveAttendanceDateRange, which
+    // silently defaults missing from/to to a 30-day window). from/to MUST be
+    // provided and the inclusive range MUST be <= 366 days.
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/effective-calendar',
+      withPermission('attendance:read', async (req, res) => {
+        const fromRaw = typeof req.query.from === 'string' ? req.query.from.trim() : ''
+        const toRaw = typeof req.query.to === 'string' ? req.query.to.trim() : ''
+        const userIdRaw = typeof req.query.userId === 'string' ? req.query.userId.trim() : ''
+        const groupIdRaw = typeof req.query.groupId === 'string' ? req.query.groupId.trim() : ''
+        const orgOnlyRaw = typeof req.query.orgOnly === 'string' ? req.query.orgOnly.trim().toLowerCase() : ''
+        const orgOnly = orgOnlyRaw === 'true' || orgOnlyRaw === '1'
+
+        if (!fromRaw || !toRaw) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: '"from" and "to" are required (YYYY-MM-DD).' } })
+          return
+        }
+        const from = normalizeDateOnlyStrict(fromRaw)
+        const to = normalizeDateOnlyStrict(toRaw)
+        if (!from) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid "from" date. Use YYYY-MM-DD.' } })
+          return
+        }
+        if (!to) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid "to" date. Use YYYY-MM-DD.' } })
+          return
+        }
+        if (from > to) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: '"from" must be on or before "to".' } })
+          return
+        }
+        const rangeDays = diffDays(from, to) + 1
+        if (rangeDays > 366) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Range must be <= 366 days.' } })
+          return
+        }
+
+        const modeCount = (userIdRaw ? 1 : 0) + (groupIdRaw ? 1 : 0) + (orgOnly ? 1 : 0)
+        if (modeCount !== 1) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Provide exactly one of userId, groupId, or orgOnly=true.' } })
+          return
+        }
+
+        const requesterId = getUserId(req)
+        if (!requesterId) {
+          res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found.' } })
+          return
+        }
+        const orgId = getOrgId(req)
+
+        // Per-mode RBAC. Outer withPermission('attendance:read') already
+        // gates entry; cross-user / admin checks layer on top.
+        if (userIdRaw && userIdRaw !== requesterId) {
+          const allowed = await canAccessOtherUsers(requesterId)
+          if (!allowed) {
+            res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'No access to other users.' } })
+            return
+          }
+        }
+        if (groupIdRaw) {
+          const allowed = await hasAttendanceAdminAccess(requesterId)
+          if (!allowed) {
+            res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'Attendance admin required for groupId mode.' } })
+            return
+          }
+        }
+
+        try {
+          const result = await resolveEffectiveCalendar(db, {
+            orgId,
+            from,
+            to,
+            userId: userIdRaw || undefined,
+            groupId: groupIdRaw || undefined,
+            orgOnly: orgOnly === true ? true : undefined,
+            logger,
+          })
+          res.json({ ok: true, data: result })
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          if (message === 'NOT_FOUND:group') {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Group not found.' } })
+            return
+          }
+          if (message.startsWith('VALIDATION:')) {
+            // resolver-level validation; route validation should normally catch first
+            res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message } })
+            return
+          }
+          logger.error('Attendance effective-calendar resolve failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to resolve effective calendar.' } })
         }
       })
     )


### PR DESCRIPTION
## Summary

Step 3 of the attendance effective-calendar RFC.

- Adds `settings.calendarPolicy.overrides[]` with normalization, source/filter consistency checks, zod validation, and settings merge support.
- Adds shared `matchScopeFilters` + `matchDayIndexFilter` predicates used by both holidayPolicy and calendarPolicy paths.
- Adds read-only `resolveEffectiveCalendar` and `GET /api/attendance/effective-calendar` for `userId`, `groupId`, and `orgOnly` modes.
- Returns base/effective/layers/overlays without cutting over `resolveWorkContext`, payroll, import, or auto-absence.
- Adds DB-backed integration coverage and development/verification docs.

## Verification

Local targeted checks recorded in `docs/development/attendance-calendar-policy-resolver-verification-20260520.md`:

- `pnpm --filter @metasheet/core-backend test:unit` — PASS, 170 files / 2245 tests.
- `node --check plugins/plugin-attendance/index.cjs` — PASS.
- `git diff --check origin/main..HEAD` — PASS.
- Scratch PostgreSQL 15.17 integration run — PASS:
  - `protects manual holiday origins during national holiday sync`
  - `effective-calendar §6.1 baseline equals resolveWorkContext for rule + holiday rows`
  - `effective-calendar §6.2 applies calendarPolicy with mode gates, priority, and normalize drops invalid`
  - `effective-calendar §6.3 returns approved request overlays additively without merging`
  - `effective-calendar validates strictly, enforces RBAC, and 404s missing group`
  - `effective-calendar role/roleTags override is valid config but silently inert in resolver mode`

## Boundaries

- No calc-chain cutover; that remains Step 5.
- No frontend consumer changes; that remains Step 4.
- No holiday sync behavior change; Step 2 regression is covered.
- Known v1 limitations are documented: role/roleTags are inert in resolver mode, groupId uses default rule for base, large batch materialization is deferred.