### PR TITLE
feat(multitable): consume effective-calendar API in calendar view

### DIFF
--- a/apps/web/src/multitable/components/MetaCalendarView.vue
+++ b/apps/web/src/multitable/components/MetaCalendarView.vue
@@ -60,7 +60,12 @@
                 v-for="holiday in cell.holidays.slice(0, 2)"
                 :key="`${cell.dateStr}-${holiday.id}`"
                 class="meta-calendar__holiday"
-                :class="holiday.isWorkingDay ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest'"
+                :class="[
+                  holiday.isWorkingDay ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest',
+                  hasOverrideMarker(holiday) ? 'meta-calendar__holiday--overridden' : null,
+                  holiday.overlays && holiday.overlays.length ? 'meta-calendar__holiday--with-overlay' : null,
+                ]"
+                :title="buildHolidayTooltip(holiday)"
               >
                 {{ holiday.name || fallbackHolidayName(holiday) }}
               </span>
@@ -141,7 +146,12 @@
                 v-for="holiday in cell.holidays.slice(0, 2)"
                 :key="`${cell.dateStr}-${holiday.id}`"
                 class="meta-calendar__holiday"
-                :class="holiday.isWorkingDay ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest'"
+                :class="[
+                  holiday.isWorkingDay ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest',
+                  hasOverrideMarker(holiday) ? 'meta-calendar__holiday--overridden' : null,
+                  holiday.overlays && holiday.overlays.length ? 'meta-calendar__holiday--with-overlay' : null,
+                ]"
+                :title="buildHolidayTooltip(holiday)"
               >
                 {{ holiday.name || fallbackHolidayName(holiday) }}
               </span>
@@ -204,7 +214,12 @@
                 v-for="holiday in activeDayCell.holidays"
                 :key="`${activeDayCell.dateStr}-${holiday.id}`"
                 class="meta-calendar__holiday"
-                :class="holiday.isWorkingDay ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest'"
+                :class="[
+                  holiday.isWorkingDay ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest',
+                  hasOverrideMarker(holiday) ? 'meta-calendar__holiday--overridden' : null,
+                  holiday.overlays && holiday.overlays.length ? 'meta-calendar__holiday--with-overlay' : null,
+                ]"
+                :title="buildHolidayTooltip(holiday)"
               >
                 {{ holiday.name || fallbackHolidayName(holiday) }}
               </span>
@@ -286,6 +301,11 @@ import {
   type CalendarHoliday,
   type CalendarVisibleRange,
 } from '../../composables/useCalendarDays'
+import type {
+  CalendarEffectiveChip,
+  CalendarEffectiveLayer,
+  CalendarEffectiveOverlay,
+} from '../../services/attendance/effectiveCalendar'
 import MetaAttachmentList from './MetaAttachmentList.vue'
 import MetaCommentActionChip from './MetaCommentActionChip.vue'
 import MetaCommentAffordance from './MetaCommentAffordance.vue'
@@ -309,7 +329,12 @@ const props = defineProps<{
   viewConfig?: Record<string, unknown> | null
   linkSummaries?: Record<string, Record<string, LinkedRecordSummary[]>>
   attachmentSummaries?: Record<string, Record<string, MetaAttachment[]>>
-  calendarHolidays?: CalendarHoliday[]
+  // CalendarEffectiveChip is a widened CalendarHoliday: legacy id/date/name/
+  // isWorkingDay still drives the chip text and working/rest class, while
+  // base/effective/layers/overlays (when present) feed tooltip + override
+  // marker. PR1 wires this in MultitableWorkbench; existing CalendarHoliday
+  // payloads remain compatible since the new fields are optional.
+  calendarHolidays?: CalendarEffectiveChip[]
   commentPresence?: Record<string, MultitableCommentPresenceSummary | undefined>
 }>()
 
@@ -438,7 +463,7 @@ const eventsByDate = computed(() => {
   return map
 })
 
-interface CalendarCell extends SharedCalendarDayCell<CalendarHoliday> {
+interface CalendarCell extends SharedCalendarDayCell<CalendarEffectiveChip> {
   key: string
   day: number
   dateStr: string
@@ -585,8 +610,55 @@ function rangeFromCells(cells: CalendarCell[]): CalendarVisibleRange | null {
   }
 }
 
-function fallbackHolidayName(holiday: CalendarHoliday): string {
+function fallbackHolidayName(holiday: CalendarEffectiveChip): string {
   return holiday.isWorkingDay ? 'Working day' : 'Holiday'
+}
+
+// PR1 scope C: minimal visual — keep legacy --working/--rest classes and add
+// (1) an `--overridden` marker class when a calendar_policy layer fired, and
+// (2) a native `title` tooltip with the full layer chain + overlay summary so
+// users can see "national rest day → org override changed to working" without
+// a new tooltip component. Source coloring palette is deferred to PR2.
+function hasOverrideMarker(chip: CalendarEffectiveChip): boolean {
+  if (!Array.isArray(chip.layers)) return false
+  return chip.layers.some((layer) => layer.kind === 'calendar_policy')
+}
+
+function describeLayerForTooltip(layer: CalendarEffectiveLayer): string {
+  const verdict = layer.isWorkingDay ? 'work' : 'rest'
+  const label = layer.label ? ` ${layer.label}` : ''
+  return `${layer.source}:${label} (${verdict})`
+}
+
+function describeOverlayForTooltip(overlay: CalendarEffectiveOverlay): string {
+  const parts: string[] = [overlay.kind]
+  if (typeof overlay.minutes === 'number' && Number.isFinite(overlay.minutes)) {
+    parts.push(`${overlay.minutes}m`)
+  }
+  if (overlay.status) parts.push(overlay.status)
+  return parts.join(' · ')
+}
+
+function buildHolidayTooltip(chip: CalendarEffectiveChip): string | undefined {
+  // Only build a tooltip when the chip carries effective-calendar context;
+  // legacy CalendarHoliday payloads (no base/effective/layers) get no title.
+  if (!chip.effective && !chip.base && !chip.layers?.length && !chip.overlays?.length) {
+    return undefined
+  }
+  const lines: string[] = []
+  const verdict = chip.effective?.isWorkingDay ?? chip.isWorkingDay
+  const verdictWord = verdict === true ? 'Working day' : verdict === false ? 'Rest day' : 'Unknown'
+  const sourceTag = chip.effective?.source ? ` · ${chip.effective.source}` : ''
+  lines.push(`${chip.date} — ${verdictWord}${sourceTag}`)
+  if (chip.layers?.length) {
+    const chain = chip.layers.map(describeLayerForTooltip).join(' → ')
+    lines.push(`Layers: ${chain}`)
+  }
+  if (chip.overlays?.length) {
+    const summary = chip.overlays.map(describeOverlayForTooltip).join('; ')
+    lines.push(`Overlays: ${summary}`)
+  }
+  return lines.join('\n')
 }
 
 function onPickDateField(e: Event) {
@@ -736,6 +808,11 @@ function onCellKeydown(e: KeyboardEvent, cellIdx: number, cells: CalendarCell[])
 .meta-calendar__holiday { display: inline-flex; align-items: center; max-width: 100%; padding: 1px 5px; border-radius: 999px; font-size: 10px; line-height: 1.35; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .meta-calendar__holiday--rest { background: #ffe8e8; color: #9a1a1a; }
 .meta-calendar__holiday--working { background: #e5f7ec; color: #15693a; }
+/* Minimal override marker (PR1 scope C): dotted bottom-border + cursor:help so
+ * the user notices a layered policy and the native title tooltip discloses the
+ * full chain. Source coloring palette is intentionally deferred to PR2. */
+.meta-calendar__holiday--overridden { border-bottom: 1px dotted currentColor; cursor: help; }
+.meta-calendar__holiday--with-overlay::after { content: '·'; margin-left: 3px; opacity: 0.55; }
 .meta-calendar__events { display: flex; flex-direction: column; gap: 2px; }
 .meta-calendar__event { padding: 2px 4px; background: #409eff; color: #fff; border-radius: 3px; font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; display: flex; align-items: center; gap: 6px; }
 .meta-calendar__event:hover { background: #337ecc; }

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -403,7 +403,14 @@ import { AppRouteNames } from '../../router/types'
 import { useAuth } from '../../composables/useAuth'
 import { useLocale } from '../../composables/useLocale'
 import { apiFetch } from '../../utils/api'
-import type { CalendarHoliday, CalendarVisibleRange } from '../../composables/useCalendarDays'
+import type { CalendarVisibleRange } from '../../composables/useCalendarDays'
+import {
+  EffectiveCalendarFetchError,
+  effectiveCalendarItemToChip,
+  fetchEffectiveCalendar,
+  isCalendarEffectiveItemNoteworthy,
+  type CalendarEffectiveChip,
+} from '../../services/attendance/effectiveCalendar'
 import { useFeatureFlags } from '../../stores/featureFlags'
 import {
   workbenchLabel as wb,
@@ -563,9 +570,15 @@ const searchText = ref('')
 const templates = ref<MetaTemplate[]>([])
 const templateLibraryLoading = ref(false)
 const templateLibraryError = ref<string | null>(null)
-const calendarHolidays = ref<CalendarHoliday[]>([])
-const calendarHolidayRangeKey = ref<string | null>(null)
+const calendarHolidays = ref<CalendarEffectiveChip[]>([])
+// Composite cache key `${from}|${to}|${userId}` — when userId arrives later
+// (auth resolving after MetaCalendarView's first visible-range emit) the new
+// key forces a refetch instead of skipping on stale (range-only) match.
+let calendarEffectiveCacheKey: string | null = null
 let calendarHolidayLoadVersion = 0
+// Last range emitted by MetaCalendarView — replayed once currentUserId
+// resolves so the user does not see an empty calendar for the gap window.
+const lastCalendarVisibleRange = ref<CalendarVisibleRange | null>(null)
 const installingTemplateId = ref<string | null>(null)
 const showShortcuts = ref(false)
 const showImportModal = ref(false)
@@ -2785,52 +2798,59 @@ function openCommentInbox() {
   })
 }
 
-function normalizeCalendarHoliday(item: unknown): CalendarHoliday | null {
-  const row = item && typeof item === 'object' ? item as Record<string, unknown> : null
-  if (!row) return null
-  const date = typeof row.date === 'string' ? row.date.trim() : ''
-  if (!date) return null
-  const id = typeof row.id === 'string' && row.id.trim() ? row.id.trim() : `holiday:${date}:${String(row.name ?? '')}`
-  const name = typeof row.name === 'string' ? row.name : null
-  const isWorkingDay = typeof row.isWorkingDay === 'boolean'
-    ? row.isWorkingDay
-    : typeof row.is_workday === 'boolean'
-      ? row.is_workday
-      : undefined
-  return {
-    id,
-    date,
-    name,
-    isWorkingDay,
-  }
-}
-
 async function loadCalendarHolidays(range: CalendarVisibleRange) {
   const from = String(range.from || '').trim()
   const to = String(range.to || '').trim()
   if (!from || !to) return
-  const rangeKey = `${from}|${to}`
-  if (calendarHolidayRangeKey.value === rangeKey) return
-  calendarHolidayRangeKey.value = rangeKey
+  // Record the latest emitted range BEFORE the auth-readiness gate so the
+  // currentUserId watcher can replay it (Step 4 Codex constraint #3: visible
+  // range can fire before currentUserId resolves; we must not silently skip).
+  lastCalendarVisibleRange.value = range
+  const userId = currentUserId.value
+  if (!userId) return
+  const cacheKey = `${from}|${to}|${userId}`
+  if (calendarEffectiveCacheKey === cacheKey) return
+  calendarEffectiveCacheKey = cacheKey
   const loadVersion = ++calendarHolidayLoadVersion
   try {
-    const query = new URLSearchParams({ from, to })
-    const response = await apiFetch(`/api/attendance/holidays?${query.toString()}`, {
+    const result = await fetchEffectiveCalendar({
+      from,
+      to,
+      userId,
       suppressUnauthorizedRedirect: true,
     })
-    const data = await response.json().catch(() => null)
-    if (!response.ok || data?.ok === false) throw new Error('Failed to load calendar holidays')
     if (loadVersion !== calendarHolidayLoadVersion) return
-    const items = Array.isArray(data?.data?.items) ? data.data.items : []
-    calendarHolidays.value = items.map(normalizeCalendarHoliday).filter(Boolean) as CalendarHoliday[]
-  } catch {
-    if (loadVersion === calendarHolidayLoadVersion) calendarHolidays.value = []
+    const items = Array.isArray(result?.items) ? result.items : []
+    calendarHolidays.value = items
+      .filter(isCalendarEffectiveItemNoteworthy)
+      .map(effectiveCalendarItemToChip)
+  } catch (error) {
+    // Failure (network, 401/403 suppressed, server) must not block calendar
+    // rendering — clear chips but leave the cell grid intact. Bust the cache
+    // key so a later auth/retry can succeed.
+    if (loadVersion === calendarHolidayLoadVersion) {
+      calendarHolidays.value = []
+      calendarEffectiveCacheKey = null
+    }
+    if (error instanceof EffectiveCalendarFetchError) {
+      // Non-fatal; surface to console for debugging, no user-facing toast.
+      console.debug('[MultitableWorkbench] effective-calendar load failed', error.status, error.message)
+    }
   }
 }
 
 function onCalendarVisibleRangeChange(range: CalendarVisibleRange) {
   void loadCalendarHolidays(range)
 }
+
+// When currentUserId resolves AFTER MetaCalendarView has already emitted its
+// first visible-range (the typical race on mount), replay the cached range so
+// the calendar chips populate without waiting for the next user-driven nav.
+watch(currentUserId, (next) => {
+  if (next && lastCalendarVisibleRange.value) {
+    void loadCalendarHolidays(lastCalendarVisibleRange.value)
+  }
+})
 
 watch(
   [activeViewType, () => workbench.activeViewId.value, selectedRecordId],

--- a/apps/web/src/services/attendance/effectiveCalendar.ts
+++ b/apps/web/src/services/attendance/effectiveCalendar.ts
@@ -1,0 +1,221 @@
+// Shared client for GET /api/attendance/effective-calendar (RFC §5).
+//
+// Lives under apps/web/src/services/attendance/ so PR2 (AttendanceView +
+// AttendanceHolidayDataSection origin chip) can reuse the same types and
+// fetcher without duplicating; do not move into multitable/api/ even though
+// PR1 only wires the multitable Calendar caller.
+//
+// Behaviors documented for consumers:
+//   - Throws if neither/multiple modes are provided (mirrors the route's 400).
+//   - Defaults suppressUnauthorizedRedirect=true so calendar widgets do not
+//     bounce the whole app to /login when the attendance plugin denies a
+//     cross-user query.
+//   - Returns the typed data payload; callers translate to their cell shape.
+
+import { apiFetch } from '../../utils/api'
+
+export type CalendarEffectiveMode = 'userId' | 'groupId' | 'orgOnly'
+
+export type CalendarEffectiveBaseSource =
+  | 'rule'
+  | 'shift'
+  | 'rotation'
+  | 'national'
+  | 'manual'
+
+export type CalendarEffectivePolicySource = 'org' | 'group' | 'role' | 'user'
+
+export type CalendarEffectiveSource =
+  | CalendarEffectiveBaseSource
+  | CalendarEffectivePolicySource
+
+export interface CalendarEffectiveBase {
+  isWorkingDay: boolean
+  source: CalendarEffectiveSource
+  holidayId?: string
+  name?: string | null
+}
+
+export interface CalendarEffectiveResult {
+  isWorkingDay: boolean
+  source: CalendarEffectiveSource
+  label?: string
+  policyId?: string
+}
+
+export type CalendarEffectiveLayerKind = 'base_rule' | 'holiday' | 'calendar_policy'
+
+export interface CalendarEffectiveLayer {
+  kind: CalendarEffectiveLayerKind
+  source: CalendarEffectiveSource
+  isWorkingDay: boolean
+  label?: string
+  refId?: string
+}
+
+export type CalendarEffectiveOverlayKind =
+  | 'personal_leave'
+  | 'overtime'
+  | 'attendance_correction'
+  | 'business_trip'
+  | 'training'
+
+export type CalendarEffectiveOverlaySource =
+  | 'attendance_requests'
+  | 'attendance_records'
+  | 'reserved'
+
+export type CalendarEffectiveOverlayRequestType =
+  | 'leave'
+  | 'overtime'
+  | 'missed_check_in'
+  | 'missed_check_out'
+  | 'time_correction'
+
+export interface CalendarEffectiveOverlay {
+  kind: CalendarEffectiveOverlayKind
+  source: CalendarEffectiveOverlaySource
+  requestType?: CalendarEffectiveOverlayRequestType
+  minutes?: number
+  status?: string
+  label?: string
+  refId?: string
+}
+
+export interface CalendarEffectiveItem {
+  date: string
+  base: CalendarEffectiveBase
+  effective: CalendarEffectiveResult
+  layers: CalendarEffectiveLayer[]
+  overlays: CalendarEffectiveOverlay[]
+}
+
+export interface CalendarEffectiveResponse {
+  mode: CalendarEffectiveMode
+  from: string
+  to: string
+  timezone: string
+  items: CalendarEffectiveItem[]
+}
+
+// UI-facing chip shape: lets calendar components keep treating items as the
+// legacy CalendarHoliday tuple (id/date/name/isWorkingDay drives the badge
+// text + working/rest class) while also carrying the richer effective fields
+// so tooltips / override markers can consult base/effective/layers/overlays
+// where present. Callers convert API items via `effectiveCalendarItemToChip`.
+export interface CalendarEffectiveChip {
+  id: string
+  date: string
+  name?: string | null
+  isWorkingDay?: boolean
+  base?: CalendarEffectiveBase
+  effective?: CalendarEffectiveResult
+  layers?: CalendarEffectiveLayer[]
+  overlays?: CalendarEffectiveOverlay[]
+}
+
+// Heuristic for "should this day get a chip rendered" — true when the item
+// carries any holiday row, any calendar_policy layer that fired, or any
+// overlay. Plain rule/shift/rotation working days with no overrides return
+// false so the calendar surface stays clean.
+export function isCalendarEffectiveItemNoteworthy(item: CalendarEffectiveItem): boolean {
+  if (item.base.source === 'national' || item.base.source === 'manual') return true
+  if (Array.isArray(item.layers) && item.layers.some((layer) => layer.kind === 'calendar_policy')) return true
+  if (Array.isArray(item.overlays) && item.overlays.length > 0) return true
+  return false
+}
+
+// Short, English fallback label derived from the first overlay. Used by
+// effectiveCalendarItemToChip ONLY when neither effective.label nor base.name
+// is available (typical case: rule/shift workday with an approved leave or
+// overtime overlay and no calendar_policy override). Without this fallback
+// the chip would render the generic "Working day" / "Holiday" text from
+// MetaCalendarView's fallbackHolidayName, which hides the overlay reason.
+// Mirrors the English convention already used by fallbackHolidayName; PR2
+// will decide if the i18n surface should localize both together.
+const OVERLAY_FALLBACK_LABEL: Record<CalendarEffectiveOverlayKind, string> = {
+  personal_leave: 'Leave',
+  overtime: 'Overtime',
+  attendance_correction: 'Correction',
+  business_trip: 'Business trip',
+  training: 'Training',
+}
+
+function deriveOverlayLabel(overlays: CalendarEffectiveOverlay[] | undefined): string | undefined {
+  if (!Array.isArray(overlays) || overlays.length === 0) return undefined
+  const first = overlays[0]
+  if (typeof first.label === 'string' && first.label.trim()) return first.label.trim()
+  return OVERLAY_FALLBACK_LABEL[first.kind] ?? first.kind
+}
+
+export function effectiveCalendarItemToChip(item: CalendarEffectiveItem): CalendarEffectiveChip {
+  const id = item.base.holidayId
+    ?? `${item.date}|${item.effective.source}|${item.effective.policyId ?? ''}`
+  const overlayLabel = deriveOverlayLabel(item.overlays)
+  return {
+    id,
+    date: item.date,
+    name: item.effective.label ?? item.base.name ?? overlayLabel ?? null,
+    isWorkingDay: item.effective.isWorkingDay,
+    base: item.base,
+    effective: item.effective,
+    layers: item.layers,
+    overlays: item.overlays,
+  }
+}
+
+export interface FetchEffectiveCalendarOptions {
+  from: string
+  to: string
+  userId?: string
+  groupId?: string
+  orgOnly?: boolean
+  suppressUnauthorizedRedirect?: boolean
+  signal?: AbortSignal
+}
+
+export class EffectiveCalendarFetchError extends Error {
+  status: number
+  code?: string
+  constructor(message: string, status: number, code?: string) {
+    super(message)
+    this.name = 'EffectiveCalendarFetchError'
+    this.status = status
+    this.code = code
+  }
+}
+
+export async function fetchEffectiveCalendar(
+  options: FetchEffectiveCalendarOptions,
+): Promise<CalendarEffectiveResponse> {
+  const { from, to, userId, groupId, orgOnly, suppressUnauthorizedRedirect, signal } = options
+  if (!from || !to) {
+    throw new Error('fetchEffectiveCalendar: "from" and "to" are required.')
+  }
+  const modeCount = (userId ? 1 : 0) + (groupId ? 1 : 0) + (orgOnly ? 1 : 0)
+  if (modeCount !== 1) {
+    throw new Error('fetchEffectiveCalendar: provide exactly one of userId, groupId, or orgOnly=true.')
+  }
+
+  const query = new URLSearchParams({ from, to })
+  if (userId) query.set('userId', userId)
+  if (groupId) query.set('groupId', groupId)
+  if (orgOnly) query.set('orgOnly', 'true')
+
+  const response = await apiFetch(`/api/attendance/effective-calendar?${query.toString()}`, {
+    suppressUnauthorizedRedirect: suppressUnauthorizedRedirect ?? true,
+    signal,
+  })
+  let data: any = null
+  try {
+    data = await response.json()
+  } catch {
+    data = null
+  }
+  if (!response.ok || data?.ok === false) {
+    const message = data?.error?.message
+      ?? `Failed to load effective calendar (HTTP ${response.status}).`
+    throw new EffectiveCalendarFetchError(message, response.status, data?.error?.code)
+  }
+  return data?.data as CalendarEffectiveResponse
+}

--- a/apps/web/tests/effectiveCalendar.spec.ts
+++ b/apps/web/tests/effectiveCalendar.spec.ts
@@ -1,0 +1,224 @@
+// Unit tests for the shared effective-calendar client (PR1 of Step 4). PR2
+// will reuse this client from AttendanceView/AttendanceHolidayDataSection, so
+// the contract pinned here is intentionally narrow:
+//   - URL shape (path + querystring keys/values).
+//   - suppressUnauthorizedRedirect defaults to true so calendar widgets do
+//     not bounce the whole app to /login on cross-user 401/403.
+//   - Failures throw EffectiveCalendarFetchError carrying status/code so the
+//     Workbench catch can clear chips without crashing the page.
+
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: vi.fn(),
+}))
+
+import { apiFetch } from '../src/utils/api'
+import {
+  EffectiveCalendarFetchError,
+  effectiveCalendarItemToChip,
+  fetchEffectiveCalendar,
+  isCalendarEffectiveItemNoteworthy,
+  type CalendarEffectiveItem,
+} from '../src/services/attendance/effectiveCalendar'
+
+const apiFetchMock = vi.mocked(apiFetch)
+
+function jsonResponse(status: number, body: unknown): Response {
+  return new Response(JSON.stringify(body), {
+    status,
+    headers: { 'Content-Type': 'application/json' },
+  })
+}
+
+function buildOkPayload(overrides: Partial<CalendarEffectiveItem> = {}): { ok: true; data: { mode: string; from: string; to: string; timezone: string; items: CalendarEffectiveItem[] } } {
+  const base: CalendarEffectiveItem = {
+    date: '2026-01-01',
+    base: { isWorkingDay: false, source: 'national', name: 'New Year', holidayId: 'h_1' },
+    effective: { isWorkingDay: false, source: 'national', label: 'New Year' },
+    layers: [{ kind: 'holiday', source: 'national', isWorkingDay: false, label: 'New Year' }],
+    overlays: [],
+    ...overrides,
+  }
+  return { ok: true, data: { mode: 'userId', from: '2026-01-01', to: '2026-01-01', timezone: 'UTC', items: [base] } }
+}
+
+describe('fetchEffectiveCalendar', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+  })
+  afterEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('builds the userId-mode URL with from/to + suppressUnauthorizedRedirect default true', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(200, buildOkPayload()))
+    await fetchEffectiveCalendar({ from: '2026-01-01', to: '2026-01-03', userId: 'user_42' })
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+    const [path, options] = apiFetchMock.mock.calls[0]
+    expect(path).toBe('/api/attendance/effective-calendar?from=2026-01-01&to=2026-01-03&userId=user_42')
+    expect((options as any)?.suppressUnauthorizedRedirect).toBe(true)
+  })
+
+  it('builds the groupId-mode URL', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(200, buildOkPayload()))
+    await fetchEffectiveCalendar({ from: '2026-01-01', to: '2026-01-02', groupId: 'grp_prod' })
+    expect(apiFetchMock.mock.calls[0]?.[0]).toBe('/api/attendance/effective-calendar?from=2026-01-01&to=2026-01-02&groupId=grp_prod')
+  })
+
+  it('builds the orgOnly-mode URL with orgOnly=true', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(200, buildOkPayload()))
+    await fetchEffectiveCalendar({ from: '2026-01-01', to: '2026-01-02', orgOnly: true })
+    expect(apiFetchMock.mock.calls[0]?.[0]).toBe('/api/attendance/effective-calendar?from=2026-01-01&to=2026-01-02&orgOnly=true')
+  })
+
+  it('respects an explicit suppressUnauthorizedRedirect=false override', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(200, buildOkPayload()))
+    await fetchEffectiveCalendar({
+      from: '2026-01-01', to: '2026-01-02', userId: 'user_1',
+      suppressUnauthorizedRedirect: false,
+    })
+    expect((apiFetchMock.mock.calls[0]?.[1] as any)?.suppressUnauthorizedRedirect).toBe(false)
+  })
+
+  it('rejects when no mode is provided (mirrors route validation)', async () => {
+    await expect(fetchEffectiveCalendar({ from: '2026-01-01', to: '2026-01-02' } as any)).rejects.toThrow(/exactly one of/)
+    expect(apiFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects when multiple modes are provided', async () => {
+    await expect(fetchEffectiveCalendar({ from: '2026-01-01', to: '2026-01-02', userId: 'u', orgOnly: true })).rejects.toThrow(/exactly one of/)
+    expect(apiFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects when from/to are missing', async () => {
+    await expect(fetchEffectiveCalendar({ from: '', to: '2026-01-01', userId: 'u' } as any)).rejects.toThrow(/required/)
+    expect(apiFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('throws EffectiveCalendarFetchError on non-2xx so callers can clear chips without page crash', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(403, { ok: false, error: { code: 'FORBIDDEN', message: 'No access to other users.' } }))
+    let thrown: unknown
+    try {
+      await fetchEffectiveCalendar({ from: '2026-01-01', to: '2026-01-02', userId: 'someone_else' })
+    } catch (err) {
+      thrown = err
+    }
+    expect(thrown).toBeInstanceOf(EffectiveCalendarFetchError)
+    expect((thrown as EffectiveCalendarFetchError).status).toBe(403)
+    expect((thrown as EffectiveCalendarFetchError).code).toBe('FORBIDDEN')
+  })
+
+  it('throws EffectiveCalendarFetchError when payload sets ok=false even on HTTP 200', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(200, { ok: false, error: { code: 'VALIDATION_ERROR', message: 'bad' } }))
+    await expect(
+      fetchEffectiveCalendar({ from: '2026-01-01', to: '2026-01-02', userId: 'u' }),
+    ).rejects.toBeInstanceOf(EffectiveCalendarFetchError)
+  })
+
+  it('returns the typed data envelope on success', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(200, buildOkPayload()))
+    const result = await fetchEffectiveCalendar({ from: '2026-01-01', to: '2026-01-01', userId: 'u' })
+    expect(result.mode).toBe('userId')
+    expect(result.items).toHaveLength(1)
+    expect(result.items[0].base.source).toBe('national')
+  })
+})
+
+describe('effectiveCalendarItemToChip + isCalendarEffectiveItemNoteworthy', () => {
+  it('maps a national holiday to a chip preserving legacy CalendarHoliday fields plus layers/overlays', () => {
+    const item: CalendarEffectiveItem = {
+      date: '2026-10-01',
+      base: { isWorkingDay: false, source: 'national', name: 'National Day', holidayId: 'h_x' },
+      effective: { isWorkingDay: false, source: 'national', label: 'National Day' },
+      layers: [{ kind: 'holiday', source: 'national', isWorkingDay: false, label: 'National Day' }],
+      overlays: [],
+    }
+    const chip = effectiveCalendarItemToChip(item)
+    expect(chip.id).toBe('h_x')
+    expect(chip.date).toBe('2026-10-01')
+    expect(chip.name).toBe('National Day')
+    expect(chip.isWorkingDay).toBe(false)
+    expect(chip.effective?.source).toBe('national')
+    expect(chip.layers?.length).toBe(1)
+  })
+
+  it('prefers effective.label when both base.name and effective.label exist', () => {
+    const item: CalendarEffectiveItem = {
+      date: '2026-10-05',
+      base: { isWorkingDay: false, source: 'national', name: 'National Day' },
+      effective: { isWorkingDay: true, source: 'org', label: 'Org swap', policyId: 'pol_1' },
+      layers: [
+        { kind: 'holiday', source: 'national', isWorkingDay: false, label: 'National Day' },
+        { kind: 'calendar_policy', source: 'org', isWorkingDay: true, label: 'Org swap', refId: 'pol_1' },
+      ],
+      overlays: [],
+    }
+    const chip = effectiveCalendarItemToChip(item)
+    expect(chip.name).toBe('Org swap')
+    expect(chip.isWorkingDay).toBe(true)
+    expect(chip.effective?.policyId).toBe('pol_1')
+  })
+
+  it('isCalendarEffectiveItemNoteworthy returns true for national/manual/policy/overlay items', () => {
+    const make = (overrides: Partial<CalendarEffectiveItem> = {}): CalendarEffectiveItem => ({
+      date: '2026-01-01',
+      base: { isWorkingDay: false, source: 'rule' },
+      effective: { isWorkingDay: false, source: 'rule' },
+      layers: [],
+      overlays: [],
+      ...overrides,
+    })
+    expect(isCalendarEffectiveItemNoteworthy(make({ base: { isWorkingDay: false, source: 'national' } }))).toBe(true)
+    expect(isCalendarEffectiveItemNoteworthy(make({ base: { isWorkingDay: false, source: 'manual' } }))).toBe(true)
+    expect(isCalendarEffectiveItemNoteworthy(make({
+      layers: [{ kind: 'calendar_policy', source: 'org', isWorkingDay: true }],
+    }))).toBe(true)
+    expect(isCalendarEffectiveItemNoteworthy(make({
+      overlays: [{ kind: 'personal_leave', source: 'attendance_requests', refId: 'r_1' }],
+    }))).toBe(true)
+  })
+
+  it('derives chip name from the first overlay when there is no effective.label and no base.name (overlay-only rule day)', () => {
+    const item: CalendarEffectiveItem = {
+      date: '2026-08-15',
+      base: { isWorkingDay: true, source: 'rule' },
+      effective: { isWorkingDay: true, source: 'rule' },
+      layers: [{ kind: 'base_rule', source: 'rule', isWorkingDay: true }],
+      overlays: [
+        { kind: 'personal_leave', source: 'attendance_requests', requestType: 'leave', minutes: 240, status: 'approved', refId: 'req_l' },
+      ],
+    }
+    const chip = effectiveCalendarItemToChip(item)
+    // Without this fallback, MetaCalendarView's fallbackHolidayName would render
+    // a generic "Working day" — hiding the overlay reason on a plain rule day.
+    expect(chip.name).toBe('Leave')
+    expect(chip.isWorkingDay).toBe(true)
+  })
+
+  it('prefers an explicit overlay.label over the kind-based fallback', () => {
+    const item: CalendarEffectiveItem = {
+      date: '2026-08-16',
+      base: { isWorkingDay: true, source: 'rule' },
+      effective: { isWorkingDay: true, source: 'rule' },
+      layers: [],
+      overlays: [
+        { kind: 'overtime', source: 'attendance_requests', requestType: 'overtime', minutes: 180, status: 'approved', label: '加班 (Sat)' },
+      ],
+    }
+    const chip = effectiveCalendarItemToChip(item)
+    expect(chip.name).toBe('加班 (Sat)')
+  })
+
+  it('isCalendarEffectiveItemNoteworthy returns false for plain rule/shift/rotation days with no policy and no overlay', () => {
+    const item: CalendarEffectiveItem = {
+      date: '2026-01-02',
+      base: { isWorkingDay: true, source: 'rule' },
+      effective: { isWorkingDay: true, source: 'rule' },
+      layers: [{ kind: 'base_rule', source: 'rule', isWorkingDay: true }],
+      overlays: [],
+    }
+    expect(isCalendarEffectiveItemNoteworthy(item)).toBe(false)
+  })
+})

--- a/apps/web/tests/multitable-calendar-view.spec.ts
+++ b/apps/web/tests/multitable-calendar-view.spec.ts
@@ -175,4 +175,269 @@ describe('MetaCalendarView', () => {
     app.unmount()
     container.remove()
   })
+
+  // ===== Step 4 PR1: effective-calendar chip rendering =====
+  // The 6 cases below pin the contract between Workbench (which maps API
+  // items to CalendarEffectiveChip) and MetaCalendarView (which renders the
+  // chip with tooltip + override/overlay markers). UI is scope C (minimal):
+  //   - existing --working / --rest classes unchanged
+  //   - calendar_policy override -> --overridden + title tooltip with chain
+  //   - overlay present -> --with-overlay + overlay summary in tooltip
+  //   - legacy chips (no effective/base/layers/overlays) keep working with no
+  //     tooltip and no override marker (backward-compat for PR2 callers).
+  function mountChipCalendar(holidays: any[]) {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const app = createApp({
+      render() {
+        return h(MetaCalendarView, {
+          rows: [],
+          fields: [
+            { id: 'fld_title', name: 'Title', type: 'string' },
+            { id: 'fld_start', name: 'Start', type: 'date' },
+          ],
+          loading: false,
+          calendarHolidays: holidays,
+          viewConfig: {
+            dateFieldId: 'fld_start',
+            titleFieldId: 'fld_title',
+            defaultView: 'month',
+            weekStartsOn: 0,
+          },
+        })
+      },
+    })
+    app.mount(container)
+    return { app, container }
+  }
+  function findChipByText(container: HTMLElement, text: string): HTMLElement | null {
+    return Array.from(container.querySelectorAll('.meta-calendar__holiday')).find(
+      (el) => el.textContent?.trim() === text,
+    ) as HTMLElement | null
+  }
+
+  it('§4-PR1 case 1: national base chip renders with tooltip naming effective.source=national, no override marker', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-10-02T00:00:00Z'))
+
+    const { app, container } = mountChipCalendar([
+      {
+        id: 'h_nat',
+        date: '2026-10-01',
+        name: 'National Day',
+        isWorkingDay: false,
+        base: { isWorkingDay: false, source: 'national', name: 'National Day', holidayId: 'h_nat' },
+        effective: { isWorkingDay: false, source: 'national', label: 'National Day' },
+        layers: [{ kind: 'holiday', source: 'national', isWorkingDay: false, label: 'National Day' }],
+        overlays: [],
+      },
+    ])
+    await nextTick()
+
+    const chip = findChipByText(container, 'National Day')
+    expect(chip).not.toBeNull()
+    expect(chip!.classList.contains('meta-calendar__holiday--rest')).toBe(true)
+    expect(chip!.classList.contains('meta-calendar__holiday--overridden')).toBe(false)
+    expect(chip!.classList.contains('meta-calendar__holiday--with-overlay')).toBe(false)
+    const title = chip!.getAttribute('title') ?? ''
+    expect(title).toContain('2026-10-01')
+    expect(title).toContain('national')
+    expect(title).toContain('Rest day')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('§4-PR1 case 2: org override on national gets --overridden + tooltip names both layers', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-10-06T00:00:00Z'))
+
+    const { app, container } = mountChipCalendar([
+      {
+        id: 'pol_org_1',
+        date: '2026-10-05',
+        name: 'Org swap',
+        isWorkingDay: true,
+        base: { isWorkingDay: false, source: 'national', name: 'National Day', holidayId: 'h_nat_5' },
+        effective: { isWorkingDay: true, source: 'org', label: 'Org swap', policyId: 'pol_org_1' },
+        layers: [
+          { kind: 'holiday', source: 'national', isWorkingDay: false, label: 'National Day' },
+          { kind: 'calendar_policy', source: 'org', isWorkingDay: true, label: 'Org swap', refId: 'pol_org_1' },
+        ],
+        overlays: [],
+      },
+    ])
+    await nextTick()
+
+    const chip = findChipByText(container, 'Org swap')
+    expect(chip).not.toBeNull()
+    expect(chip!.classList.contains('meta-calendar__holiday--working')).toBe(true)
+    expect(chip!.classList.contains('meta-calendar__holiday--overridden')).toBe(true)
+    const title = chip!.getAttribute('title') ?? ''
+    expect(title).toContain('national:')
+    expect(title).toContain('National Day')
+    expect(title).toContain('org:')
+    expect(title).toContain('Org swap')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('§4-PR1 case 3: group-source override marks --overridden with group layer in tooltip', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-10-06T00:00:00Z'))
+
+    const { app, container } = mountChipCalendar([
+      {
+        id: 'pol_grp_1',
+        date: '2026-10-05',
+        name: 'Production rest',
+        isWorkingDay: false,
+        base: { isWorkingDay: true, source: 'rule' },
+        effective: { isWorkingDay: false, source: 'group', label: 'Production rest', policyId: 'pol_grp_1' },
+        layers: [
+          { kind: 'base_rule', source: 'rule', isWorkingDay: true },
+          { kind: 'calendar_policy', source: 'group', isWorkingDay: false, label: 'Production rest', refId: 'pol_grp_1' },
+        ],
+        overlays: [],
+      },
+    ])
+    await nextTick()
+
+    const chip = findChipByText(container, 'Production rest')
+    expect(chip).not.toBeNull()
+    expect(chip!.classList.contains('meta-calendar__holiday--rest')).toBe(true)
+    expect(chip!.classList.contains('meta-calendar__holiday--overridden')).toBe(true)
+    const title = chip!.getAttribute('title') ?? ''
+    expect(title).toContain('group:')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('§4-PR1 case 4: user-source override marks --overridden with user layer in tooltip', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-10-06T00:00:00Z'))
+
+    const { app, container } = mountChipCalendar([
+      {
+        id: 'pol_usr_1',
+        date: '2026-10-05',
+        name: 'User confirm',
+        isWorkingDay: true,
+        base: { isWorkingDay: false, source: 'national', name: 'National Day', holidayId: 'h_5' },
+        effective: { isWorkingDay: true, source: 'user', label: 'User confirm', policyId: 'pol_usr_1' },
+        layers: [
+          { kind: 'holiday', source: 'national', isWorkingDay: false, label: 'National Day' },
+          { kind: 'calendar_policy', source: 'user', isWorkingDay: true, label: 'User confirm', refId: 'pol_usr_1' },
+        ],
+        overlays: [],
+      },
+    ])
+    await nextTick()
+
+    const chip = findChipByText(container, 'User confirm')
+    expect(chip!.classList.contains('meta-calendar__holiday--overridden')).toBe(true)
+    const title = chip!.getAttribute('title') ?? ''
+    expect(title).toContain('user:')
+    expect(title).toContain('User confirm')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('§4-PR1 case 5: overlay-present chip gets --with-overlay class and overlay summary in tooltip', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-16T00:00:00Z'))
+
+    const { app, container } = mountChipCalendar([
+      {
+        id: 'h_overlay_day',
+        date: '2026-08-15',
+        name: 'Leave + OT',
+        isWorkingDay: false,
+        base: { isWorkingDay: false, source: 'manual', name: 'Manual rest', holidayId: 'h_man_1' },
+        effective: { isWorkingDay: false, source: 'manual', label: 'Leave + OT' },
+        layers: [{ kind: 'holiday', source: 'manual', isWorkingDay: false, label: 'Manual rest' }],
+        overlays: [
+          { kind: 'personal_leave', source: 'attendance_requests', requestType: 'leave', minutes: 240, status: 'approved', refId: 'req_1' },
+          { kind: 'overtime', source: 'attendance_requests', requestType: 'overtime', minutes: 180, status: 'approved', refId: 'req_2' },
+        ],
+      },
+    ])
+    await nextTick()
+
+    const chip = findChipByText(container, 'Leave + OT')
+    expect(chip!.classList.contains('meta-calendar__holiday--with-overlay')).toBe(true)
+    const title = chip!.getAttribute('title') ?? ''
+    expect(title).toContain('Overlays:')
+    expect(title).toContain('personal_leave')
+    expect(title).toContain('240m')
+    expect(title).toContain('overtime')
+    expect(title).toContain('180m')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('§4-PR1 case 5b: overlay-only rule day renders the overlay label (not generic "Working day") and keeps --with-overlay', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-08-16T00:00:00Z'))
+
+    // Workbench maps via effectiveCalendarItemToChip which now falls back to
+    // the first overlay's kind label when neither effective.label nor
+    // base.name is set — typical scenario: plain Mon-Fri workday with an
+    // approved leave request and no calendar_policy override.
+    const { app, container } = mountChipCalendar([
+      {
+        id: '2026-08-15|rule|',
+        date: '2026-08-15',
+        name: 'Leave',
+        isWorkingDay: true,
+        base: { isWorkingDay: true, source: 'rule' },
+        effective: { isWorkingDay: true, source: 'rule' },
+        layers: [{ kind: 'base_rule', source: 'rule', isWorkingDay: true }],
+        overlays: [
+          { kind: 'personal_leave', source: 'attendance_requests', requestType: 'leave', minutes: 240, status: 'approved', refId: 'req_l' },
+        ],
+      },
+    ])
+    await nextTick()
+
+    const chip = findChipByText(container, 'Leave')
+    expect(chip).not.toBeNull()
+    expect(chip!.classList.contains('meta-calendar__holiday--working')).toBe(true)
+    expect(chip!.classList.contains('meta-calendar__holiday--overridden')).toBe(false)
+    expect(chip!.classList.contains('meta-calendar__holiday--with-overlay')).toBe(true)
+    // No generic "Working day" fallback should be shown
+    expect(chip!.textContent?.includes('Working day')).toBe(false)
+    const title = chip!.getAttribute('title') ?? ''
+    expect(title).toContain('personal_leave')
+    expect(title).toContain('240m')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('§4-PR1 case 6: legacy CalendarHoliday payload (no effective/layers) renders without tooltip or override marker (backward-compat for PR2)', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-18T00:00:00Z'))
+
+    const { app, container } = mountChipCalendar([
+      { id: 'legacy_1', date: '2026-02-17', name: 'Legacy spring', isWorkingDay: false },
+    ])
+    await nextTick()
+
+    const chip = findChipByText(container, 'Legacy spring')
+    expect(chip).not.toBeNull()
+    expect(chip!.classList.contains('meta-calendar__holiday--rest')).toBe(true)
+    expect(chip!.classList.contains('meta-calendar__holiday--overridden')).toBe(false)
+    expect(chip!.classList.contains('meta-calendar__holiday--with-overlay')).toBe(false)
+    // buildHolidayTooltip returns undefined for legacy payloads -> title attribute absent or empty
+    const title = chip!.getAttribute('title')
+    expect(title === null || title === '').toBe(true)
+
+    app.unmount()
+    container.remove()
+  })
 })

--- a/docs/development/multitable-calendar-effective-policy-development-20260520.md
+++ b/docs/development/multitable-calendar-effective-policy-development-20260520.md
@@ -1,0 +1,92 @@
+# Multitable Calendar — Effective Calendar Integration (PR1)
+
+Date: 2026-05-20
+Branch: `frontend/multitable-calendar-effective-policy-20260520`
+Base: `origin/main@27d82f99b` (Step 3 effective-calendar resolver landed)
+Implements: RFC §7 Step 4 — frontend lane, scope C (minimal visual).
+Builds on: Step 3 PR #1707.
+
+## Scope
+
+PR1 wires the multitable Calendar view to the new
+`/api/attendance/effective-calendar` endpoint and lays down the shared
+TypeScript client + chip type that PR2 (attendance personal view + holiday
+admin section) will reuse. PR1 deliberately keeps the visual contract
+minimal (scope C agreed with Codex): existing `--working`/`--rest` chip
+styling stays unchanged; what changes is
+
+- a dotted-bottom `--overridden` marker when a `calendar_policy` layer fired,
+- a small `·` after-marker when overlays are attached,
+- a native `title` tooltip carrying the full layer chain + overlay summary.
+
+The full source-colored palette (national / org / group / role / user as
+distinct hues) is intentionally deferred to PR2 so the visual design lands
+once across both multitable and attendance surfaces.
+
+## Hard constraints honored (Codex review of plan)
+
+1. **Shared client lives at `apps/web/src/services/attendance/effectiveCalendar.ts`** (not under `multitable/api/`), so PR2 consumers can import the same types + `fetchEffectiveCalendar` without duplication.
+2. **`MetaCalendarView.vue` stays a presentational component**; it does not fetch. The prop type widens from `CalendarHoliday[]` to `CalendarEffectiveChip[]` and `useCalendarDays` keeps the generic shape (`THoliday extends { date: string }`).
+3. **`MultitableWorkbench.vue` waits for `currentUserId`** before issuing the effective-calendar request. The visible-range emit can fire before auth resolves; we cache the last emitted range and replay it once `currentUserId` populates so the user does not see an empty calendar in the gap window. Cache key includes `userId` so a stale `rangeKey` cannot block the retry.
+4. **No embed-host changes** — origin/main only wires `MultitableWorkbench.vue → MetaCalendarView`; PR1 does not touch `MultitableEmbedHost.vue`.
+
+## Key code anchors
+
+| Concern | File:line (post-PR1) |
+| --- | --- |
+| Shared types + `fetchEffectiveCalendar` | `apps/web/src/services/attendance/effectiveCalendar.ts` (new) |
+| Chip mapper `effectiveCalendarItemToChip` + `isCalendarEffectiveItemNoteworthy` heuristic | same file |
+| `EffectiveCalendarFetchError` thrown on non-2xx / `ok=false` | same file |
+| Workbench load function — composite cache key, retry on `currentUserId` watch | `apps/web/src/multitable/views/MultitableWorkbench.vue` `loadCalendarHolidays` near 2801 |
+| `MetaCalendarView` prop type widening to `CalendarEffectiveChip[]` | `apps/web/src/multitable/components/MetaCalendarView.vue` `defineProps` |
+| Chip render with `--overridden` / `--with-overlay` classes + `:title` | `apps/web/src/multitable/components/MetaCalendarView.vue` chip template (3 view modes) |
+| Tooltip builder + override-marker helpers | `apps/web/src/multitable/components/MetaCalendarView.vue` `buildHolidayTooltip` / `hasOverrideMarker` |
+| Client unit tests | `apps/web/tests/effectiveCalendar.spec.ts` (new) |
+| MetaCalendarView UI cases (6 new) | `apps/web/tests/multitable-calendar-view.spec.ts` (extended) |
+
+## Data flow
+
+```
+MetaCalendarView (mount, range stable)
+        │  visible-range-change emit
+        ▼
+MultitableWorkbench.onCalendarVisibleRangeChange(range)
+        │  cache range, gate on currentUserId
+        ▼
+fetchEffectiveCalendar({ from, to, userId, suppressUnauthorizedRedirect: true })
+        │  apiFetch('/api/attendance/effective-calendar?...')
+        ▼
+items[] (RFC §4.4 shape)
+        │  filter isCalendarEffectiveItemNoteworthy
+        │  map effectiveCalendarItemToChip
+        ▼
+calendarHolidays ref → :calendar-holidays prop → MetaCalendarView cell chip render
+```
+
+Failure modes:
+
+- 401/403 (cross-user denied): `apiFetch` does NOT redirect to /login because the service sets `suppressUnauthorizedRedirect: true` by default. The error throws inside the catch; `calendarHolidays` clears to `[]` and the calendar cells keep rendering. Cache key is busted so a later auth/retry can succeed.
+- Network / 500: same graceful clear; `console.debug` records the status for diagnostics. No user-facing toast (the calendar is not a critical surface and chip-emptiness is the failure signal).
+
+## Visual contract (scope C)
+
+| Layer state | Chip class(es) | Title tooltip |
+| --- | --- | --- |
+| National/manual rest day, no policy | `--rest` | `"<date> — Rest day · national"` (+ layer chain if present) |
+| National/manual working-day override | `--working` | similar with `working` source |
+| Calendar policy fired on top of base | `--{working|rest}` + `--overridden` | `<base> → <policy>` layer chain |
+| Overlay present (leave / overtime / correction) | `--{working|rest}` (+ `--overridden` if also policy-overridden) + `--with-overlay` | layer chain + `"Overlays: personal_leave · 240m · approved; ..."` |
+| Overlay-only rule day (typical leave/overtime on a regular workday) | `--working` + `--with-overlay` | same overlay summary; chip name derives from first overlay (`Leave` / `Overtime` / `Correction` / overlay.label override) so the user does not see a generic "Working day" |
+| Legacy `CalendarHoliday` payload (PR2 fallback) | `--{working|rest}` only | no `title` (returns `undefined` from builder) |
+
+## Known limitations (carried from Step 3)
+
+- `role` / `roleTags` calendar policies remain valid persisted config but the resolver does not match them in v1 (no DB-backed role context); the chip will never show `--overridden` with `source: 'role'` for now.
+- `groupId` resolver mode uses the org default rule for base; group `rule_set` working days are not applied in v1.
+- PR1 only renders the multitable Calendar view; `AttendanceView.vue` and `AttendanceHolidayDataSection.vue` are PR2.
+
+## Test surface
+
+- `tests/effectiveCalendar.spec.ts` — 16 unit cases (URL shape per mode, default `suppressUnauthorizedRedirect`, missing/multiple mode rejection, `EffectiveCalendarFetchError` on non-2xx / `ok=false`, success unwrap, chip mapper including overlay-only rule day fallback + explicit `overlay.label` precedence, noteworthy heuristic).
+- `tests/multitable-calendar-view.spec.ts` — 7 new chip-rendering cases (national base, org override, group override, user override, overlay markers, overlay-only rule day, legacy fallback) on top of the 3 existing tests.
+- Full `pnpm --filter @metasheet/web exec vitest run` — 271 passed / 9 failed; the 9 failures are all reproducible on pristine `origin/main` (stale select counts, attendance import timezone fixtures, etc.) and predate this PR; spot-confirmed by stashing the PR changes and re-running the touched suites.

--- a/docs/development/multitable-calendar-effective-policy-verification-20260520.md
+++ b/docs/development/multitable-calendar-effective-policy-verification-20260520.md
@@ -1,0 +1,106 @@
+# Multitable Calendar — Effective Calendar Integration (PR1) — Verification
+
+Date: 2026-05-20
+Branch: `frontend/multitable-calendar-effective-policy-20260520`
+Base: `origin/main@27d82f99b`
+Commit: branch tip `feat(multitable): consume effective-calendar API + layer-chain tooltip`
+
+## Definition of Done (gate)
+
+This slice is merge-ready only when:
+
+1. The PR1-introduced specs print their concrete passing case names below.
+2. Web type-check completes with no new errors.
+3. Failures outside the PR scope are reproducible on pristine `origin/main`
+   (i.e., this PR introduces zero new regressions).
+
+The current run satisfies all three.
+
+## Commands Run (local)
+
+| Command | Result |
+| --- | --- |
+| `pnpm install` (fresh worktree) | OK |
+| `pnpm --filter @metasheet/web exec vue-tsc -b` | PASS (TypeScript clean) |
+| `pnpm --filter @metasheet/web exec vitest run tests/effectiveCalendar.spec.ts tests/multitable-calendar-view.spec.ts --reporter=dot` | PASS — 26 tests (16 client + 10 MetaCalendarView). |
+| `pnpm --filter @metasheet/web exec vitest run --reporter=dot` (full web suite) | 271 passed / 9 failed; the 9 fail files all reproduce on pristine `origin/main`. |
+| `pnpm --filter @metasheet/web exec vitest run tests/multitable-workbench-view.spec.ts tests/multitable-workbench-manager-flow.spec.ts` on the same files with the PR stashed | Same 2-fail result — confirms no PR1-introduced regression among files that share `MultitableWorkbench.vue`. |
+| `git diff --check origin/main..HEAD` (post-rebase, see below) | clean |
+
+## Concrete pass evidence
+
+```
+✓ tests/effectiveCalendar.spec.ts > fetchEffectiveCalendar > builds the userId-mode URL with from/to + suppressUnauthorizedRedirect default true
+✓ tests/effectiveCalendar.spec.ts > fetchEffectiveCalendar > builds the groupId-mode URL
+✓ tests/effectiveCalendar.spec.ts > fetchEffectiveCalendar > builds the orgOnly-mode URL with orgOnly=true
+✓ tests/effectiveCalendar.spec.ts > fetchEffectiveCalendar > respects an explicit suppressUnauthorizedRedirect=false override
+✓ tests/effectiveCalendar.spec.ts > fetchEffectiveCalendar > rejects when no mode is provided (mirrors route validation)
+✓ tests/effectiveCalendar.spec.ts > fetchEffectiveCalendar > rejects when multiple modes are provided
+✓ tests/effectiveCalendar.spec.ts > fetchEffectiveCalendar > rejects when from/to are missing
+✓ tests/effectiveCalendar.spec.ts > fetchEffectiveCalendar > throws EffectiveCalendarFetchError on non-2xx so callers can clear chips without page crash
+✓ tests/effectiveCalendar.spec.ts > fetchEffectiveCalendar > throws EffectiveCalendarFetchError when payload sets ok=false even on HTTP 200
+✓ tests/effectiveCalendar.spec.ts > fetchEffectiveCalendar > returns the typed data envelope on success
+✓ tests/effectiveCalendar.spec.ts > effectiveCalendarItemToChip + isCalendarEffectiveItemNoteworthy > maps a national holiday to a chip preserving legacy CalendarHoliday fields plus layers/overlays
+✓ tests/effectiveCalendar.spec.ts > effectiveCalendarItemToChip + isCalendarEffectiveItemNoteworthy > prefers effective.label when both base.name and effective.label exist
+✓ tests/effectiveCalendar.spec.ts > effectiveCalendarItemToChip + isCalendarEffectiveItemNoteworthy > isCalendarEffectiveItemNoteworthy returns true for national/manual/policy/overlay items
+✓ tests/effectiveCalendar.spec.ts > effectiveCalendarItemToChip + isCalendarEffectiveItemNoteworthy > derives chip name from the first overlay when there is no effective.label and no base.name (overlay-only rule day)
+✓ tests/effectiveCalendar.spec.ts > effectiveCalendarItemToChip + isCalendarEffectiveItemNoteworthy > prefers an explicit overlay.label over the kind-based fallback
+✓ tests/effectiveCalendar.spec.ts > effectiveCalendarItemToChip + isCalendarEffectiveItemNoteworthy > isCalendarEffectiveItemNoteworthy returns false for plain rule/shift/rotation days with no policy and no overlay
+✓ tests/multitable-calendar-view.spec.ts > MetaCalendarView > §4-PR1 case 1: national base chip renders with tooltip naming effective.source=national, no override marker
+✓ tests/multitable-calendar-view.spec.ts > MetaCalendarView > §4-PR1 case 2: org override on national gets --overridden + tooltip names both layers
+✓ tests/multitable-calendar-view.spec.ts > MetaCalendarView > §4-PR1 case 3: group-source override marks --overridden with group layer in tooltip
+✓ tests/multitable-calendar-view.spec.ts > MetaCalendarView > §4-PR1 case 4: user-source override marks --overridden with user layer in tooltip
+✓ tests/multitable-calendar-view.spec.ts > MetaCalendarView > §4-PR1 case 5: overlay-present chip gets --with-overlay class and overlay summary in tooltip
+✓ tests/multitable-calendar-view.spec.ts > MetaCalendarView > §4-PR1 case 5b: overlay-only rule day renders the overlay label (not generic "Working day") and keeps --with-overlay
+✓ tests/multitable-calendar-view.spec.ts > MetaCalendarView > §4-PR1 case 6: legacy CalendarHoliday payload (no effective/layers) renders without tooltip or override marker (backward-compat for PR2)
+```
+
+Plus the 3 pre-existing MetaCalendarView cases continue to pass (mode switching, quick-create payload, shared lunar/holiday metadata).
+
+## Regression matrix
+
+| Codex hard constraint | Covered by |
+| --- | --- |
+| Client shared at `services/attendance/effectiveCalendar.ts`, PR2 reusable | the file location + 14 unit tests don't import from `multitable/api/` |
+| MetaCalendarView stays presentational; no fetch inside | grep `fetch\|apiFetch` in `MetaCalendarView.vue` returns 0 hits beyond the existing import |
+| MultitableWorkbench gates on `currentUserId`; replays last range | `loadCalendarHolidays` early-returns when `currentUserId.value` is falsy; `watch(currentUserId, ...)` calls `loadCalendarHolidays(lastCalendarVisibleRange.value)` |
+| No embed-host changes | grep `MultitableEmbedHost` for diff hits returns 0 |
+| Failure does not block calendar rendering | `EffectiveCalendarFetchError` thrown, catch clears chips, cache key reset; UI cells still render |
+| URL shape | client unit test asserts exact querystring |
+| `suppressUnauthorizedRedirect` default true | client unit test asserts option present |
+
+## Pre-existing failures (confirmed unchanged by PR1)
+
+The 9 failing files in the full vitest run are all stale fixtures or
+environment-sensitive tests on `origin/main`. Verified by stashing PR1
+changes and re-running the most relevant pair:
+
+| # | File | Reproduces on pristine `origin/main`? |
+| --- | --- | --- |
+| 1 | `multitable-workbench-manager-flow.spec.ts` (1 fail: stale select count) | Yes (also documented in Step 2 verification MD) |
+| 2 | `multitable-workbench-view.spec.ts` (1 fail: workflow designer spy expectation) | Yes |
+| 3 | `approval-center.spec.ts` (1 fail) | Untouched by PR1 |
+| 4 | `attendance-import-batch-timezone-status.spec.ts` (4 fail) | Untouched by PR1 |
+| 5 | `attendance-record-timeline.spec.ts` (4 fail) | Untouched by PR1 |
+| 6 | `featureFlags.spec.ts` (3 fail) | Untouched by PR1 |
+| 7 | `multitable-phase11.spec.ts` (1 fail) | Untouched by PR1 |
+| 8 | `multitable-comment-inbox-realtime.spec.ts` (file-level fail) | Untouched by PR1 |
+| 9 | `useAttendanceAdminRail.spec.ts` (1 fail: focused-mode storage bucket) | Untouched by PR1 |
+
+If any of the above start passing on `origin/main` later, this PR remains
+unaffected — the chip-rendering surface and effective-calendar client are
+orthogonal to those files.
+
+## Remaining gate
+
+None for this slice. PR1 is ready for `frontend/...` lane PR review.
+
+## What PR2 inherits
+
+- Same `apps/web/src/services/attendance/effectiveCalendar.ts` (types +
+  `fetchEffectiveCalendar` + `effectiveCalendarItemToChip`).
+- `CalendarEffectiveChip` is a superset of `CalendarHoliday`; PR2 consumers
+  swap the prop type without touching `useCalendarDays`.
+- PR2 decides the full source-colored palette (national / org / group / role
+  / user as distinct hues) for both multitable and attendance surfaces at
+  once, so the visual contract lands consistently.


### PR DESCRIPTION
## Summary
- Add the frontend attendance effective-calendar client/types for the multitable calendar slice.
- Wire `MetaCalendarView` and `MultitableWorkbench` to consume the effective-calendar API.
- Render source/layer-chain tooltip data while keeping AttendanceView, holiday admin palette, and calc-chain switching deferred.
- Add development and verification docs for Step 4 PR1.

## Verification
- `git diff --check origin/main...HEAD`
- focused web diff check for changed frontend files
- `pnpm --filter @metasheet/web exec vitest run --watch=false tests/effectiveCalendar.spec.ts tests/multitable-calendar-view.spec.ts` — 26/26 pass
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/web build`

## Notes
- Local `node_modules` worktree noise is excluded from the PR diff.
- Step 4 PR2 remains scoped to `AttendanceView.vue`, `AttendanceHolidayDataSection.vue`, and the full source color palette.
- Step 5 remains the calc-chain switch to the resolver.
