### PR TITLE
feat(multitable): localize permission manager chrome (T3C-2a)

### DIFF
--- a/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaRecordPermissionManager.vue
@@ -3,8 +3,8 @@
     <div class="meta-record-perm">
       <div class="meta-record-perm__header">
         <div>
-          <h4 class="meta-record-perm__title">Record Permissions</h4>
-          <p class="meta-record-perm__subtitle">Manage who can access this record and at what level.</p>
+          <h4 class="meta-record-perm__title">{{ p('record.title') }}</h4>
+          <p class="meta-record-perm__subtitle">{{ p('record.subtitle') }}</p>
         </div>
         <button class="meta-record-perm__close" type="button" @click="requestClose">&times;</button>
       </div>
@@ -16,10 +16,10 @@
         <!-- Current permissions -->
         <section class="meta-record-perm__section">
           <div class="meta-record-perm__section-header">
-            <strong>Current access</strong>
+            <strong>{{ p('record.currentAccess') }}</strong>
           </div>
-          <div v-if="loading" class="meta-record-perm__empty">Loading permissions&#x2026;</div>
-        <div v-else-if="!entries.length" class="meta-record-perm__empty">No record-specific permissions yet.</div>
+          <div v-if="loading" class="meta-record-perm__empty">{{ p('record.loadingPermissions') }}</div>
+        <div v-else-if="!entries.length" class="meta-record-perm__empty">{{ p('record.empty') }}</div>
           <template v-else>
           <div
             v-for="entry in entries"
@@ -35,18 +35,18 @@
                   class="meta-record-perm__lifecycle"
                   data-lifecycle="inactive"
                 >
-                  Inactive user
+                  {{ p('subject.inactiveUser') }}
                 </span>
                 <span
                   v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
                   class="meta-record-perm__hint"
                 >
-                  Cleanup only
+                  {{ p('subject.cleanupOnly') }}
                 </span>
               </div>
-            <span class="meta-record-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeLabel(entry.subjectType) }}</span>
+            <span class="meta-record-perm__subject" :data-subject-type="entry.subjectType">{{ recordSubjectLabel(entry.subjectType) }}</span>
             <span class="meta-record-perm__badge" :data-access-level="entryDrafts[entry.id] ?? entry.accessLevel">
-              {{ accessLevelLabel(entryDrafts[entry.id] ?? entry.accessLevel) }}
+              {{ recordAccessLabel(entryDrafts[entry.id] ?? entry.accessLevel) }}
             </span>
             <select
               :value="entryDrafts[entry.id] ?? entry.accessLevel"
@@ -54,9 +54,13 @@
               :disabled="busyKey === entry.id || subjectMutationBlocked(entry.subjectType, entry.isActive)"
               @change="setEntryDraft(entry.id, $event)"
             >
-              <option value="read">Read</option>
-              <option value="write">Write</option>
-              <option value="admin">Admin</option>
+              <option
+                v-for="option in recordAccessOptions"
+                :key="option.value"
+                :value="option.value"
+              >
+                {{ option.label }}
+              </option>
             </select>
             <button
               class="meta-record-perm__action"
@@ -64,7 +68,7 @@
               :disabled="busyKey === entry.id || subjectMutationBlocked(entry.subjectType, entry.isActive) || (entryDrafts[entry.id] ?? entry.accessLevel) === entry.accessLevel"
               @click="saveEntry(entry)"
             >
-              Save
+              {{ m('action.save') }}
             </button>
             <button
               class="meta-record-perm__action meta-record-perm__action--danger"
@@ -72,7 +76,7 @@
               :disabled="busyKey === entry.id"
               @click="removeEntry(entry)"
             >
-              Remove
+              {{ m('action.remove') }}
             </button>
           </div>
           </template>
@@ -81,22 +85,22 @@
         <!-- Add permission -->
         <section class="meta-record-perm__section">
           <div class="meta-record-perm__section-header">
-            <strong>Grant to people, member groups, or roles</strong>
+            <strong>{{ p('record.grantSection') }}</strong>
           </div>
           <input
             v-model="candidateSearch"
             class="meta-record-perm__search"
             type="search"
-            placeholder="Search people, member groups, or roles"
+            :placeholder="p('record.searchPlaceholder')"
             data-record-permission-search="true"
           />
-          <div v-if="candidatesLoading" class="meta-record-perm__empty">Loading eligible people, member groups, and roles&#x2026;</div>
-          <div v-else-if="!availableCandidates.length" class="meta-record-perm__empty">No matching eligible people, member groups, or roles.</div>
+          <div v-if="candidatesLoading" class="meta-record-perm__empty">{{ p('record.loadingCandidates') }}</div>
+          <div v-else-if="!availableCandidates.length" class="meta-record-perm__empty">{{ p('record.noCandidates') }}</div>
           <template v-else>
             <div class="meta-record-perm__section-header">
-              <strong>People</strong>
+              <strong>{{ p('subject.people') }}</strong>
             </div>
-            <div v-if="!peopleCandidates.length" class="meta-record-perm__empty">No matching people.</div>
+            <div v-if="!peopleCandidates.length" class="meta-record-perm__empty">{{ p('subject.noPeople') }}</div>
             <div
               v-for="candidate in peopleCandidates"
               :key="`people-${subjectKey(candidate.subjectType, candidate.subjectId)}`"
@@ -111,25 +115,29 @@
                   class="meta-record-perm__lifecycle"
                   data-lifecycle="inactive"
                 >
-                  Inactive user
+                  {{ p('subject.inactiveUser') }}
                 </span>
                 <span
                   v-if="candidateGrantBlocked(candidate)"
                   class="meta-record-perm__hint"
                 >
-                  Grant blocked
+                  {{ p('subject.grantBlocked') }}
                 </span>
               </div>
-              <span class="meta-record-perm__subject" data-subject-type="user">User</span>
+              <span class="meta-record-perm__subject" data-subject-type="user">{{ p('subject.user') }}</span>
               <select
                 :value="candidateDrafts[subjectKey(candidate.subjectType, candidate.subjectId)] ?? candidate.accessLevel ?? 'read'"
                 class="meta-record-perm__select"
                 :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId) || candidateGrantBlocked(candidate)"
                 @change="setCandidateDraft(candidate.subjectType, candidate.subjectId, $event)"
               >
-                <option value="read">Read</option>
-                <option value="write">Write</option>
-                <option value="admin">Admin</option>
+                <option
+                  v-for="option in recordAccessOptions"
+                  :key="option.value"
+                  :value="option.value"
+                >
+                  {{ option.label }}
+                </option>
               </select>
               <button
                 class="meta-record-perm__action meta-record-perm__action--primary"
@@ -137,14 +145,14 @@
                 :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId) || candidateGrantBlocked(candidate)"
                 @click="grantCandidate(candidate.subjectType, candidate.subjectId)"
               >
-                Grant
+                {{ p('action.grant') }}
               </button>
             </div>
 
             <div class="meta-record-perm__section-header">
-              <strong>Member groups</strong>
+              <strong>{{ p('subject.memberGroups') }}</strong>
             </div>
-            <div v-if="!memberGroupCandidates.length" class="meta-record-perm__empty">No matching member groups.</div>
+            <div v-if="!memberGroupCandidates.length" class="meta-record-perm__empty">{{ p('subject.noMemberGroups') }}</div>
             <div
               v-for="candidate in memberGroupCandidates"
               :key="`member-group-${subjectKey(candidate.subjectType, candidate.subjectId)}`"
@@ -155,16 +163,20 @@
                 <strong>{{ candidate.label }}</strong>
                 <span>{{ candidate.subtitle || candidate.subjectId }}</span>
               </div>
-              <span class="meta-record-perm__subject" data-subject-type="member-group">Member group</span>
+              <span class="meta-record-perm__subject" data-subject-type="member-group">{{ p('subject.memberGroup') }}</span>
               <select
                 :value="candidateDrafts[subjectKey(candidate.subjectType, candidate.subjectId)] ?? candidate.accessLevel ?? 'read'"
                 class="meta-record-perm__select"
                 :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
                 @change="setCandidateDraft(candidate.subjectType, candidate.subjectId, $event)"
               >
-                <option value="read">Read</option>
-                <option value="write">Write</option>
-                <option value="admin">Admin</option>
+                <option
+                  v-for="option in recordAccessOptions"
+                  :key="option.value"
+                  :value="option.value"
+                >
+                  {{ option.label }}
+                </option>
               </select>
               <button
                 class="meta-record-perm__action meta-record-perm__action--primary"
@@ -172,14 +184,14 @@
                 :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
                 @click="grantCandidate(candidate.subjectType, candidate.subjectId)"
               >
-                Grant
+                {{ p('action.grant') }}
               </button>
             </div>
 
             <div class="meta-record-perm__section-header">
-              <strong>Roles</strong>
+              <strong>{{ p('subject.roles') }}</strong>
             </div>
-            <div v-if="!roleCandidates.length" class="meta-record-perm__empty">No matching roles.</div>
+            <div v-if="!roleCandidates.length" class="meta-record-perm__empty">{{ p('subject.noRoles') }}</div>
             <div
               v-for="candidate in roleCandidates"
               :key="`role-${subjectKey(candidate.subjectType, candidate.subjectId)}`"
@@ -190,16 +202,20 @@
                 <strong>{{ candidate.label }}</strong>
                 <span>{{ candidate.subtitle || candidate.subjectId }}</span>
               </div>
-              <span class="meta-record-perm__subject" data-subject-type="role">Role</span>
+              <span class="meta-record-perm__subject" data-subject-type="role">{{ p('subject.role') }}</span>
               <select
                 :value="candidateDrafts[subjectKey(candidate.subjectType, candidate.subjectId)] ?? candidate.accessLevel ?? 'read'"
                 class="meta-record-perm__select"
                 :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
                 @change="setCandidateDraft(candidate.subjectType, candidate.subjectId, $event)"
               >
-                <option value="read">Read</option>
-                <option value="write">Write</option>
-                <option value="admin">Admin</option>
+                <option
+                  v-for="option in recordAccessOptions"
+                  :key="option.value"
+                  :value="option.value"
+                >
+                  {{ option.label }}
+                </option>
               </select>
               <button
                 class="meta-record-perm__action meta-record-perm__action--primary"
@@ -207,7 +223,7 @@
                 :disabled="busyKey === subjectKey(candidate.subjectType, candidate.subjectId)"
                 @click="grantCandidate(candidate.subjectType, candidate.subjectId)"
               >
-                Grant
+                {{ p('action.grant') }}
               </button>
             </div>
           </template>
@@ -219,8 +235,11 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type { MultitableApiClient } from '../api/client'
 import type { MetaSheetPermissionCandidate, MetaSheetPermissionEntry, RecordPermissionAccessLevel, RecordPermissionEntry } from '../types'
+import { managerLabel, type MetaManagerLabelKey } from '../utils/meta-manager-labels'
+import { permissionLabel, recordAccessText, subjectText, type MetaPermissionLabelKey } from '../utils/meta-permission-labels'
 
 const props = defineProps<{
   visible: boolean
@@ -246,17 +265,29 @@ const subjectCandidates = ref<MetaSheetPermissionCandidate[]>([])
 const candidateDrafts = ref<Record<string, RecordPermissionAccessLevel>>({})
 let candidateLoadVersion = 0
 
-function accessLevelLabel(level: string): string {
-  if (level === 'read') return 'Read'
-  if (level === 'write') return 'Write'
-  if (level === 'admin') return 'Admin'
-  return level
+const { isZh } = useLocale()
+const recordAccessLevels: RecordPermissionAccessLevel[] = ['read', 'write', 'admin']
+const recordAccessOptions = computed(() =>
+  recordAccessLevels.map((value) => ({
+    value,
+    label: recordAccessText(value, isZh.value),
+  })),
+)
+
+function p(key: MetaPermissionLabelKey): string {
+  return permissionLabel(key, isZh.value)
 }
 
-function subjectTypeLabel(subjectType: string): string {
-  if (subjectType === 'role') return 'Role'
-  if (subjectType === 'member-group') return 'Member group'
-  return 'User'
+function m(key: MetaManagerLabelKey): string {
+  return managerLabel(key, isZh.value)
+}
+
+function recordAccessLabel(level: string): string {
+  return recordAccessText(level, isZh.value)
+}
+
+function recordSubjectLabel(subjectType: string): string {
+  return subjectText(subjectType, isZh.value)
 }
 
 function subjectIsInactive(subjectType: string, isActive: boolean) {
@@ -343,7 +374,7 @@ async function loadPermissions() {
     entries.value = await props.client.listRecordPermissions(props.sheetId, props.recordId)
     syncEntryDrafts()
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to load record permissions'
+    error.value = cause?.message ?? p('record.error.loadPermissions')
   } finally {
     loading.value = false
   }
@@ -378,7 +409,7 @@ async function loadCandidates() {
     syncCandidateDrafts()
   } catch (cause: any) {
     if (currentVersion !== candidateLoadVersion) return
-    error.value = cause?.message ?? 'Failed to load permission candidates'
+    error.value = cause?.message ?? p('record.error.loadCandidates')
   } finally {
     if (currentVersion === candidateLoadVersion) {
       candidatesLoading.value = false
@@ -393,10 +424,10 @@ async function saveEntry(entry: RecordPermissionEntry) {
   try {
     await props.client.updateRecordPermission(props.sheetId, props.recordId, entry.subjectType, entry.subjectId, nextLevel)
     await loadPermissions()
-    status.value = 'Permission updated'
+    status.value = p('record.status.updated')
     emit('updated')
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to update permission'
+    error.value = cause?.message ?? p('record.error.update')
   } finally {
     busyKey.value = null
   }
@@ -408,10 +439,10 @@ async function removeEntry(entry: RecordPermissionEntry) {
   try {
     await props.client.deleteRecordPermission(props.sheetId, props.recordId, entry.id)
     entries.value = entries.value.filter((e) => e.id !== entry.id)
-    status.value = 'Permission removed'
+    status.value = p('record.status.removed')
     emit('updated')
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to remove permission'
+    error.value = cause?.message ?? p('record.error.remove')
   } finally {
     busyKey.value = null
   }
@@ -438,10 +469,10 @@ async function grantCandidate(subjectType: RecordPermissionEntry['subjectType'],
       candidateDrafts.value[key] ?? 'read',
     )
     await Promise.all([loadPermissions(), loadCandidates()])
-    status.value = 'Permission granted'
+    status.value = p('record.status.granted')
     emit('updated')
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to grant permission'
+    error.value = cause?.message ?? p('record.error.grant')
   } finally {
     busyKey.value = null
   }

--- a/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+++ b/apps/web/src/multitable/components/MetaSheetPermissionManager.vue
@@ -3,8 +3,8 @@
     <div class="meta-sheet-perm">
       <div class="meta-sheet-perm__header">
         <div>
-          <h4 class="meta-sheet-perm__title">Manage Access</h4>
-          <p class="meta-sheet-perm__subtitle">Override sheet-level access for eligible people, member groups, or roles. Admin includes sharing and sheet deletion. Write-own remains user-only.</p>
+          <h4 class="meta-sheet-perm__title">{{ p('sheet.title') }}</h4>
+          <p class="meta-sheet-perm__subtitle">{{ p('sheet.subtitle') }}</p>
         </div>
         <button class="meta-sheet-perm__close" type="button" @click="requestClose">&times;</button>
       </div>
@@ -31,10 +31,10 @@
         <template v-if="activeTab === 'sheet'">
           <section class="meta-sheet-perm__section">
             <div class="meta-sheet-perm__section-header">
-              <strong>Current access</strong>
+              <strong>{{ p('sheet.currentAccess') }}</strong>
             </div>
-            <div v-if="loading" class="meta-sheet-perm__empty">Loading access list&#x2026;</div>
-            <div v-else-if="!entries.length" class="meta-sheet-perm__empty">No sheet-specific access grants yet.</div>
+            <div v-if="loading" class="meta-sheet-perm__empty">{{ p('sheet.loadingAccess') }}</div>
+            <div v-else-if="!entries.length" class="meta-sheet-perm__empty">{{ p('sheet.emptyAccess') }}</div>
             <div
               v-for="entry in entries"
               :key="subjectKey(entry.subjectType, entry.subjectId)"
@@ -49,13 +49,13 @@
                   class="meta-sheet-perm__lifecycle"
                   data-lifecycle="inactive"
                 >
-                  Inactive user
+                  {{ p('subject.inactiveUser') }}
                 </span>
                 <span
                   v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
                   class="meta-sheet-perm__hint"
                 >
-                  Cleanup only
+                  {{ p('subject.cleanupOnly') }}
                 </span>
                 <span
                   v-if="hasSubjectOverrides(entry.subjectType, entry.subjectId)"
@@ -64,8 +64,8 @@
                   {{ subjectOverrideSummaryLabel(entry.subjectType, entry.subjectId) }}
                 </span>
               </div>
-              <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
-              <span class="meta-sheet-perm__badge" :data-access-level="entry.accessLevel">{{ accessLevelLabel(entry.accessLevel) }}</span>
+              <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ sheetSubjectText(entry.subjectType) }}</span>
+              <span class="meta-sheet-perm__badge" :data-access-level="entry.accessLevel">{{ sheetAccessLabel(entry.accessLevel) }}</span>
               <select
                 :value="entryDrafts[subjectKey(entry.subjectType, entry.subjectId)] ?? entry.accessLevel"
                 class="meta-sheet-perm__select"
@@ -86,7 +86,7 @@
                 :disabled="busySubjectKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive) || (entryDrafts[subjectKey(entry.subjectType, entry.subjectId)] ?? entry.accessLevel) === entry.accessLevel"
                 @click="applyEntry(entry.subjectType, entry.subjectId)"
               >
-                Save
+                {{ m('action.save') }}
               </button>
               <button
                 v-if="hasSubjectOverrides(entry.subjectType, entry.subjectId)"
@@ -96,7 +96,7 @@
                 :disabled="busySubjectKey === subjectKey(entry.subjectType, entry.subjectId)"
                 @click="clearSubjectOverrides(entry.subjectType, entry.subjectId)"
               >
-                Clear overrides
+                {{ p('action.clearOverrides') }}
               </button>
               <template v-if="entry.subjectType === 'member-group'">
                 <select
@@ -106,7 +106,7 @@
                   :disabled="busySubjectAclCopyKey === entry.subjectId || memberGroupTemplateSourceOptions(entry.subjectId).length === 0"
                   @change="setSubjectAclTemplateSource(entry.subjectId, $event)"
                 >
-                  <option value="">Copy downstream ACL…</option>
+                  <option value="">{{ p('permission.copyDownstreamPlaceholder') }}</option>
                   <option
                     v-for="option in memberGroupTemplateSourceOptions(entry.subjectId)"
                     :key="`sp-copy-${entry.subjectId}-${option.subjectId}`"
@@ -122,7 +122,7 @@
                   :disabled="busySubjectAclCopyKey === entry.subjectId || subjectAclTemplateSourceValue(entry.subjectId).length === 0"
                   @click="copySubjectAclFromMemberGroup(entry.subjectId)"
                 >
-                  Copy field+view ACL
+                  {{ p('action.copyFieldViewAcl') }}
                 </button>
               </template>
               <button
@@ -131,29 +131,29 @@
                 :disabled="busySubjectKey === subjectKey(entry.subjectType, entry.subjectId)"
                 @click="removeEntry(entry.subjectType, entry.subjectId)"
               >
-                Remove
+                {{ m('action.remove') }}
               </button>
             </div>
           </section>
 
           <section class="meta-sheet-perm__section">
             <div class="meta-sheet-perm__section-header">
-              <strong>Eligible people, member groups, or roles</strong>
+              <strong>{{ p('sheet.eligibleSection') }}</strong>
             </div>
             <input
               v-model="search"
               class="meta-sheet-perm__search"
               type="search"
-              placeholder="Search people or roles"
+              :placeholder="p('sheet.searchPlaceholder')"
               data-sheet-permission-search="true"
             />
-            <div v-if="candidatesLoading" class="meta-sheet-perm__empty">Searching eligible people, member groups, and roles&#x2026;</div>
-            <div v-else-if="!availableCandidates.length" class="meta-sheet-perm__empty">No matching eligible people, member groups, or roles.</div>
+            <div v-if="candidatesLoading" class="meta-sheet-perm__empty">{{ p('sheet.searchingCandidates') }}</div>
+            <div v-else-if="!availableCandidates.length" class="meta-sheet-perm__empty">{{ p('sheet.noCandidates') }}</div>
             <template v-else>
               <div class="meta-sheet-perm__section-header">
-                <strong>People</strong>
+                <strong>{{ p('subject.people') }}</strong>
               </div>
-              <div v-if="!peopleCandidates.length" class="meta-sheet-perm__empty">No matching people.</div>
+              <div v-if="!peopleCandidates.length" class="meta-sheet-perm__empty">{{ p('subject.noPeople') }}</div>
               <div
                 v-for="candidate in peopleCandidates"
                 :key="subjectKey(candidate.subjectType, candidate.subjectId)"
@@ -168,16 +168,16 @@
                     class="meta-sheet-perm__lifecycle"
                     data-lifecycle="inactive"
                   >
-                    Inactive user
+                    {{ p('subject.inactiveUser') }}
                   </span>
                   <span
                     v-if="candidateGrantBlocked(candidate)"
                     class="meta-sheet-perm__hint"
                   >
-                    Grant blocked
+                    {{ p('subject.grantBlocked') }}
                   </span>
                 </div>
-                <span class="meta-sheet-perm__subject" data-subject-type="user">Person</span>
+                <span class="meta-sheet-perm__subject" data-subject-type="user">{{ p('subject.person') }}</span>
                 <select
                   :value="candidateDrafts[subjectKey(candidate.subjectType, candidate.subjectId)] ?? candidate.accessLevel ?? 'read'"
                   class="meta-sheet-perm__select"
@@ -198,14 +198,14 @@
                   :disabled="busySubjectKey === subjectKey(candidate.subjectType, candidate.subjectId) || candidateGrantBlocked(candidate)"
                   @click="grantCandidate(candidate.subjectType, candidate.subjectId)"
                 >
-                  Apply
+                  {{ m('action.apply') }}
                 </button>
               </div>
 
               <div class="meta-sheet-perm__section-header">
-                <strong>Member groups</strong>
+                <strong>{{ p('subject.memberGroups') }}</strong>
               </div>
-              <div v-if="!memberGroupCandidates.length" class="meta-sheet-perm__empty">No matching member groups.</div>
+              <div v-if="!memberGroupCandidates.length" class="meta-sheet-perm__empty">{{ p('subject.noMemberGroups') }}</div>
               <div
                 v-for="candidate in memberGroupCandidates"
                 :key="subjectKey(candidate.subjectType, candidate.subjectId)"
@@ -216,7 +216,7 @@
                   <strong>{{ candidate.label }}</strong>
                   <span>{{ candidate.subtitle || candidate.subjectId }}</span>
                 </div>
-                <span class="meta-sheet-perm__subject" data-subject-type="member-group">Member group</span>
+                <span class="meta-sheet-perm__subject" data-subject-type="member-group">{{ p('subject.memberGroup') }}</span>
                 <select
                   :value="candidateDrafts[subjectKey(candidate.subjectType, candidate.subjectId)] ?? candidate.accessLevel ?? 'read'"
                   class="meta-sheet-perm__select"
@@ -237,14 +237,14 @@
                   :disabled="busySubjectKey === subjectKey(candidate.subjectType, candidate.subjectId)"
                   @click="grantCandidate(candidate.subjectType, candidate.subjectId)"
                 >
-                  Apply
+                  {{ m('action.apply') }}
                 </button>
               </div>
 
               <div class="meta-sheet-perm__section-header">
-                <strong>Roles</strong>
+                <strong>{{ p('subject.roles') }}</strong>
               </div>
-              <div v-if="!roleCandidates.length" class="meta-sheet-perm__empty">No matching roles.</div>
+              <div v-if="!roleCandidates.length" class="meta-sheet-perm__empty">{{ p('subject.noRoles') }}</div>
               <div
                 v-for="candidate in roleCandidates"
                 :key="subjectKey(candidate.subjectType, candidate.subjectId)"
@@ -255,7 +255,7 @@
                   <strong>{{ candidate.label }}</strong>
                   <span>{{ candidate.subtitle || candidate.subjectId }}</span>
                 </div>
-                <span class="meta-sheet-perm__subject" data-subject-type="role">Role</span>
+                <span class="meta-sheet-perm__subject" data-subject-type="role">{{ p('subject.role') }}</span>
                 <select
                   :value="candidateDrafts[subjectKey(candidate.subjectType, candidate.subjectId)] ?? candidate.accessLevel ?? 'read'"
                   class="meta-sheet-perm__select"
@@ -276,7 +276,7 @@
                   :disabled="busySubjectKey === subjectKey(candidate.subjectType, candidate.subjectId)"
                   @click="grantCandidate(candidate.subjectType, candidate.subjectId)"
                 >
-                  Apply
+                  {{ m('action.apply') }}
                 </button>
               </div>
             </template>
@@ -287,14 +287,14 @@
         <template v-if="activeTab === 'fields'">
           <section class="meta-sheet-perm__section">
             <div class="meta-sheet-perm__section-header">
-              <strong>Field-level permissions</strong>
-            </div>
-            <div v-if="!fields.length" class="meta-sheet-perm__empty">No fields available.</div>
-            <div v-else-if="!entries.length && !hasFieldOrphans" class="meta-sheet-perm__empty">No subjects with sheet access. Grant sheet access first to configure field permissions.</div>
+                  <strong>{{ p('field.title') }}</strong>
+                </div>
+            <div v-if="!fields.length" class="meta-sheet-perm__empty">{{ p('field.noFields') }}</div>
+            <div v-else-if="!entries.length && !hasFieldOrphans" class="meta-sheet-perm__empty">{{ p('field.noSubjects') }}</div>
             <template v-else>
               <div v-if="entries.length" class="meta-sheet-perm__section">
                 <div class="meta-sheet-perm__section-header">
-                  <strong>Bulk apply to all fields</strong>
+                  <strong>{{ p('field.bulkApply') }}</strong>
                 </div>
                 <div
                   v-for="entry in entries"
@@ -310,25 +310,25 @@
                       class="meta-sheet-perm__lifecycle"
                       data-lifecycle="inactive"
                     >
-                      Inactive user
+                      {{ p('subject.inactiveUser') }}
                     </span>
                     <span
                       v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
                       class="meta-sheet-perm__hint"
                     >
-                      Cleanup only
+                      {{ p('subject.cleanupOnly') }}
                     </span>
                   </div>
-                  <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
+                  <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ sheetSubjectText(entry.subjectType) }}</span>
                   <select
                     :value="fieldTemplateDraftValue(entry.subjectType, entry.subjectId)"
                     class="meta-sheet-perm__select"
                     :disabled="busyFieldTemplateKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @change="setFieldTemplateDraft(entry.subjectType, entry.subjectId, $event)"
                   >
-                    <option value="default">Default</option>
-                    <option value="hidden">Hidden</option>
-                    <option value="readonly">Read-only</option>
+                    <option value="default">{{ p('field.state.default') }}</option>
+                    <option value="hidden">{{ p('field.state.hidden') }}</option>
+                    <option value="readonly">{{ p('field.state.readonly') }}</option>
                   </select>
                   <button
                     class="meta-sheet-perm__action meta-sheet-perm__action--primary"
@@ -336,7 +336,7 @@
                     :disabled="busyFieldTemplateKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @click="applyFieldTemplate(entry.subjectType, entry.subjectId)"
                   >
-                    Apply to all fields
+                    {{ p('field.applyAll') }}
                   </button>
                   <template v-if="entry.subjectType === 'member-group'">
                     <select
@@ -346,7 +346,7 @@
                       :disabled="busyFieldTemplateCopyKey === entry.subjectId || memberGroupTemplateSourceOptions(entry.subjectId).length === 0"
                       @change="setFieldTemplateSource(entry.subjectId, $event)"
                     >
-                      <option value="">Copy from member group…</option>
+                      <option value="">{{ p('permission.copyFromMemberGroup') }}</option>
                       <option
                         v-for="option in memberGroupTemplateSourceOptions(entry.subjectId)"
                         :key="`fp-copy-${entry.subjectId}-${option.subjectId}`"
@@ -362,7 +362,7 @@
                       :disabled="busyFieldTemplateCopyKey === entry.subjectId || fieldTemplateSourceValue(entry.subjectId).length === 0"
                       @click="copyFieldTemplateFromMemberGroup(entry.subjectId)"
                     >
-                      Copy ACL
+                      {{ p('action.copyAcl') }}
                     </button>
                   </template>
                 </div>
@@ -384,7 +384,7 @@
                       :disabled="busyFieldOrphanBulkKey === field.id"
                       @click="clearFieldOrphans(field.id)"
                     >
-                      Clear orphan overrides
+                      {{ p('permission.clearOrphanOverrides') }}
                     </button>
                   </div>
                 </div>
@@ -396,24 +396,24 @@
                 >
                   <div class="meta-sheet-perm__identity">
                     <strong>{{ entry.label }}</strong>
-                    <span>{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
+                    <span>{{ sheetSubjectText(entry.subjectType) }}</span>
                     <span
                       v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
                       class="meta-sheet-perm__lifecycle"
                       data-lifecycle="inactive"
                     >
-                      Inactive user
+                      {{ p('subject.inactiveUser') }}
                     </span>
                     <span
                       v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
                       class="meta-sheet-perm__hint"
                     >
-                      Cleanup only
+                      {{ p('subject.cleanupOnly') }}
                     </span>
                   </div>
                   <span
                     class="meta-sheet-perm__badge"
-                    :data-access-level="fieldPermDraftLabel(field.id, entry.subjectType, entry.subjectId)"
+                    :data-access-level="fieldPermDraftValue(field.id, entry.subjectType, entry.subjectId)"
                   >
                     {{ fieldPermDraftLabel(field.id, entry.subjectType, entry.subjectId) }}
                   </span>
@@ -423,9 +423,9 @@
                     :disabled="busyFieldPermKey === fieldPermKey(field.id, entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @change="setFieldPermDraft(field.id, entry.subjectType, entry.subjectId, $event)"
                   >
-                    <option value="default">Default</option>
-                    <option value="hidden">Hidden</option>
-                    <option value="readonly">Read-only</option>
+                    <option value="default">{{ p('field.state.default') }}</option>
+                    <option value="hidden">{{ p('field.state.hidden') }}</option>
+                    <option value="readonly">{{ p('field.state.readonly') }}</option>
                   </select>
                   <button
                     class="meta-sheet-perm__action meta-sheet-perm__action--primary"
@@ -433,7 +433,7 @@
                     :disabled="busyFieldPermKey === fieldPermKey(field.id, entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @click="applyFieldPerm(field.id, entry.subjectType, entry.subjectId)"
                   >
-                    Save
+                    {{ m('action.save') }}
                   </button>
                 </div>
                 <div
@@ -444,29 +444,29 @@
                 >
                 <div class="meta-sheet-perm__identity">
                   <strong>{{ orphan.subjectLabel || orphan.subjectId }}</strong>
-                  <span>{{ orphan.subjectSubtitle || `Orphan ${subjectTypeBadgeLabel(orphan.subjectType)}` }}</span>
+                  <span>{{ orphan.subjectSubtitle || orphanSubjectLabel(orphan.subjectType) }}</span>
                   <span
                     v-if="subjectMutationBlocked(orphan.subjectType, orphan.isActive)"
                     class="meta-sheet-perm__lifecycle"
                     data-lifecycle="inactive"
                   >
-                    Inactive user
+                    {{ p('subject.inactiveUser') }}
                   </span>
                 </div>
                   <span
                     class="meta-sheet-perm__badge"
-                    :data-access-level="fieldPermDraftLabel(field.id, orphan.subjectType, orphan.subjectId)"
+                    :data-access-level="fieldPermDraftValue(field.id, orphan.subjectType, orphan.subjectId)"
                   >
                     {{ fieldPermDraftLabel(field.id, orphan.subjectType, orphan.subjectId) }}
                   </span>
-                  <span class="meta-sheet-perm__hint">No current sheet access</span>
+                  <span class="meta-sheet-perm__hint">{{ p('permission.noCurrentSheetAccess') }}</span>
                   <button
                     class="meta-sheet-perm__action meta-sheet-perm__action--danger"
                     type="button"
                     :disabled="busyFieldPermKey === fieldPermKey(field.id, orphan.subjectType, orphan.subjectId)"
                     @click="clearFieldPerm(field.id, orphan.subjectType, orphan.subjectId)"
                   >
-                    Clear
+                    {{ m('action.clear') }}
                   </button>
                 </div>
               </div>
@@ -478,14 +478,14 @@
         <template v-if="activeTab === 'views'">
           <section class="meta-sheet-perm__section">
             <div class="meta-sheet-perm__section-header">
-              <strong>View-level permissions</strong>
-            </div>
-            <div v-if="!views.length" class="meta-sheet-perm__empty">No views available.</div>
-            <div v-else-if="!entries.length && !hasViewOrphans" class="meta-sheet-perm__empty">No subjects with sheet access. Grant sheet access first to configure view permissions.</div>
+                  <strong>{{ p('view.title') }}</strong>
+                </div>
+            <div v-if="!views.length" class="meta-sheet-perm__empty">{{ p('view.noViews') }}</div>
+            <div v-else-if="!entries.length && !hasViewOrphans" class="meta-sheet-perm__empty">{{ p('view.noSubjects') }}</div>
             <template v-else>
               <div v-if="entries.length" class="meta-sheet-perm__section">
                 <div class="meta-sheet-perm__section-header">
-                  <strong>Bulk apply to all views</strong>
+                  <strong>{{ p('view.bulkApply') }}</strong>
                 </div>
                 <div
                   v-for="entry in entries"
@@ -501,26 +501,26 @@
                       class="meta-sheet-perm__lifecycle"
                       data-lifecycle="inactive"
                     >
-                      Inactive user
+                      {{ p('subject.inactiveUser') }}
                     </span>
                     <span
                       v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
                       class="meta-sheet-perm__hint"
                     >
-                      Cleanup only
+                      {{ p('subject.cleanupOnly') }}
                     </span>
                   </div>
-                  <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
+                  <span class="meta-sheet-perm__subject" :data-subject-type="entry.subjectType">{{ sheetSubjectText(entry.subjectType) }}</span>
                   <select
                     :value="viewTemplateDraftValue(entry.subjectType, entry.subjectId)"
                     class="meta-sheet-perm__select"
                     :disabled="busyViewTemplateKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @change="setViewTemplateDraft(entry.subjectType, entry.subjectId, $event)"
                   >
-                    <option value="none">None</option>
-                    <option value="read">Read</option>
-                    <option value="write">Write</option>
-                    <option value="admin">Admin</option>
+                    <option value="none">{{ p('view.state.none') }}</option>
+                    <option value="read">{{ p('access.read') }}</option>
+                    <option value="write">{{ p('access.write') }}</option>
+                    <option value="admin">{{ p('access.admin') }}</option>
                   </select>
                   <button
                     class="meta-sheet-perm__action meta-sheet-perm__action--primary"
@@ -528,7 +528,7 @@
                     :disabled="busyViewTemplateKey === subjectKey(entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @click="applyViewTemplate(entry.subjectType, entry.subjectId)"
                   >
-                    Apply to all views
+                    {{ p('view.applyAll') }}
                   </button>
                   <template v-if="entry.subjectType === 'member-group'">
                     <select
@@ -538,7 +538,7 @@
                       :disabled="busyViewTemplateCopyKey === entry.subjectId || memberGroupTemplateSourceOptions(entry.subjectId).length === 0"
                       @change="setViewTemplateSource(entry.subjectId, $event)"
                     >
-                      <option value="">Copy from member group…</option>
+                      <option value="">{{ p('permission.copyFromMemberGroup') }}</option>
                       <option
                         v-for="option in memberGroupTemplateSourceOptions(entry.subjectId)"
                         :key="`vp-copy-${entry.subjectId}-${option.subjectId}`"
@@ -554,7 +554,7 @@
                       :disabled="busyViewTemplateCopyKey === entry.subjectId || viewTemplateSourceValue(entry.subjectId).length === 0"
                       @click="copyViewTemplateFromMemberGroup(entry.subjectId)"
                     >
-                      Copy ACL
+                      {{ p('action.copyAcl') }}
                     </button>
                   </template>
                 </div>
@@ -576,7 +576,7 @@
                       :disabled="busyViewOrphanBulkKey === view.id"
                       @click="clearViewOrphans(view.id)"
                     >
-                      Clear orphan overrides
+                      {{ p('permission.clearOrphanOverrides') }}
                     </button>
                   </div>
                 </div>
@@ -588,19 +588,19 @@
                 >
                   <div class="meta-sheet-perm__identity">
                     <strong>{{ entry.label }}</strong>
-                    <span>{{ subjectTypeBadgeLabel(entry.subjectType) }}</span>
+                    <span>{{ sheetSubjectText(entry.subjectType) }}</span>
                     <span
                       v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
                       class="meta-sheet-perm__lifecycle"
                       data-lifecycle="inactive"
                     >
-                      Inactive user
+                      {{ p('subject.inactiveUser') }}
                     </span>
                     <span
                       v-if="subjectMutationBlocked(entry.subjectType, entry.isActive)"
                       class="meta-sheet-perm__hint"
                     >
-                      Cleanup only
+                      {{ p('subject.cleanupOnly') }}
                     </span>
                   </div>
                   <span
@@ -615,10 +615,10 @@
                     :disabled="busyViewPermKey === viewPermKey(view.id, entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @change="setViewPermDraft(view.id, entry.subjectType, entry.subjectId, $event)"
                   >
-                    <option value="none">None</option>
-                    <option value="read">Read</option>
-                    <option value="write">Write</option>
-                    <option value="admin">Admin</option>
+                    <option value="none">{{ p('view.state.none') }}</option>
+                    <option value="read">{{ p('access.read') }}</option>
+                    <option value="write">{{ p('access.write') }}</option>
+                    <option value="admin">{{ p('access.admin') }}</option>
                   </select>
                   <button
                     class="meta-sheet-perm__action meta-sheet-perm__action--primary"
@@ -626,7 +626,7 @@
                     :disabled="busyViewPermKey === viewPermKey(view.id, entry.subjectType, entry.subjectId) || subjectMutationBlocked(entry.subjectType, entry.isActive)"
                     @click="applyViewPerm(view.id, entry.subjectType, entry.subjectId)"
                   >
-                    Save
+                    {{ m('action.save') }}
                   </button>
                 </div>
                 <div
@@ -637,13 +637,13 @@
                 >
                 <div class="meta-sheet-perm__identity">
                   <strong>{{ orphan.subjectLabel || orphan.subjectId }}</strong>
-                  <span>{{ orphan.subjectSubtitle || `Orphan ${subjectTypeBadgeLabel(orphan.subjectType)}` }}</span>
+                  <span>{{ orphan.subjectSubtitle || orphanSubjectLabel(orphan.subjectType) }}</span>
                   <span
                     v-if="subjectMutationBlocked(orphan.subjectType, orphan.isActive)"
                     class="meta-sheet-perm__lifecycle"
                     data-lifecycle="inactive"
                   >
-                    Inactive user
+                    {{ p('subject.inactiveUser') }}
                   </span>
                 </div>
                   <span
@@ -652,14 +652,14 @@
                   >
                     {{ viewPermDisplayLabel(viewPermDraftValue(view.id, orphan.subjectType, orphan.subjectId)) }}
                   </span>
-                  <span class="meta-sheet-perm__hint">No current sheet access</span>
+                  <span class="meta-sheet-perm__hint">{{ p('permission.noCurrentSheetAccess') }}</span>
                   <button
                     class="meta-sheet-perm__action meta-sheet-perm__action--danger"
                     type="button"
                     :disabled="busyViewPermKey === viewPermKey(view.id, orphan.subjectType, orphan.subjectId)"
                     @click="clearViewPerm(view.id, orphan.subjectType, orphan.subjectId)"
                   >
-                    Clear
+                    {{ m('action.clear') }}
                   </button>
                 </div>
               </div>
@@ -673,6 +673,7 @@
 
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type { MultitableApiClient } from '../api/client'
 import type {
   MetaField,
@@ -684,21 +685,28 @@ import type {
   MetaSheetPermissionEntry,
   MetaSheetPermissionSubjectType,
 } from '../types'
+import { managerLabel, type MetaManagerLabelKey } from '../utils/meta-manager-labels'
+import {
+  clearedSubjectOverrides,
+  fieldStateText,
+  fieldStatusApplied,
+  fieldStatusClearedAll,
+  fieldStatusClearedOrphans,
+  orphanSubjectText,
+  permissionLabel,
+  sheetAccessText,
+  subjectOverrideSummary,
+  subjectText,
+  viewPermissionText,
+  viewStatusApplied,
+  viewStatusClearedOrphans,
+  type MetaPermissionLabelKey,
+} from '../utils/meta-permission-labels'
 
-const ACCESS_LEVEL_OPTIONS: Array<{ value: MetaSheetPermissionAccessLevel; label: string }> = [
-  { value: 'read', label: 'Read' },
-  { value: 'write', label: 'Write' },
-  { value: 'write-own', label: 'Write own' },
-  { value: 'admin', label: 'Admin' },
-]
-const ROLE_ACCESS_LEVEL_OPTIONS = ACCESS_LEVEL_OPTIONS.filter((option) => option.value !== 'write-own')
+const ACCESS_LEVEL_VALUES: MetaSheetPermissionAccessLevel[] = ['read', 'write', 'write-own', 'admin']
+const ROLE_ACCESS_LEVEL_VALUES = ACCESS_LEVEL_VALUES.filter((value) => value !== 'write-own')
 
 type TabId = 'sheet' | 'fields' | 'views'
-const tabs: Array<{ id: TabId; label: string }> = [
-  { id: 'sheet', label: 'Sheet Access' },
-  { id: 'fields', label: 'Field Permissions' },
-  { id: 'views', label: 'View Permissions' },
-]
 
 const props = withDefaults(defineProps<{
   visible: boolean
@@ -723,6 +731,32 @@ const emit = defineEmits<{
 }>()
 
 const activeTab = ref<TabId>('sheet')
+const { isZh } = useLocale()
+const accessLevelOptions = computed(() =>
+  ACCESS_LEVEL_VALUES.map((value) => ({
+    value,
+    label: sheetAccessText(value, isZh.value),
+  })),
+)
+const roleAccessLevelOptions = computed(() =>
+  ROLE_ACCESS_LEVEL_VALUES.map((value) => ({
+    value,
+    label: sheetAccessText(value, isZh.value),
+  })),
+)
+const tabs = computed<Array<{ id: TabId; label: string }>>(() => [
+  { id: 'sheet', label: p('sheet.tab.sheet') },
+  { id: 'fields', label: p('sheet.tab.fields') },
+  { id: 'views', label: p('sheet.tab.views') },
+])
+
+function p(key: MetaPermissionLabelKey): string {
+  return permissionLabel(key, isZh.value)
+}
+
+function m(key: MetaManagerLabelKey): string {
+  return managerLabel(key, isZh.value)
+}
 
 const entries = ref<MetaSheetPermissionEntry[]>([])
 const candidates = ref<MetaSheetPermissionCandidate[]>([])
@@ -792,10 +826,7 @@ function fieldPermDraftValue(fieldId: string, subjectType: string, subjectId: st
 }
 
 function fieldPermDraftLabel(fieldId: string, subjectType: string, subjectId: string): string {
-  const val = fieldPermDraftValue(fieldId, subjectType, subjectId)
-  if (val === 'hidden') return 'Hidden'
-  if (val === 'readonly') return 'Read-only'
-  return 'Default'
+  return fieldStateText(fieldPermDraftValue(fieldId, subjectType, subjectId), isZh.value)
 }
 
 function fieldTemplateDraftValue(subjectType: string, subjectId: string): string {
@@ -845,11 +876,11 @@ async function applyFieldPerm(fieldId: string, subjectType: string, subjectId: s
       ? { remove: true }
       : fieldPermFromDraftValue(val)
     await props.client.updateFieldPermission(props.sheetId, fieldId, subjectType as MetaSheetPermissionSubjectType, subjectId, perm)
-    status.value = isDefault ? 'Field permission cleared' : 'Field permission updated'
+    status.value = isDefault ? p('field.status.cleared') : p('field.status.updated')
     emit('update-field-permission', fieldId, subjectType, subjectId, isDefault ? { visible: true, readOnly: false } : perm)
     emit('updated')
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to update field permission'
+    error.value = cause?.message ?? p('field.error.update')
   } finally {
     busyFieldPermKey.value = null
   }
@@ -861,11 +892,11 @@ async function clearFieldPerm(fieldId: string, subjectType: string, subjectId: s
   clearMessages()
   try {
     await props.client.updateFieldPermission(props.sheetId, fieldId, subjectType as MetaSheetPermissionSubjectType, subjectId, { remove: true })
-    status.value = 'Field permission cleared'
+    status.value = p('field.status.cleared')
     emit('update-field-permission', fieldId, subjectType, subjectId, { visible: true, readOnly: false })
     emit('updated')
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to clear field permission'
+    error.value = cause?.message ?? p('field.error.clear')
   } finally {
     busyFieldPermKey.value = null
   }
@@ -882,10 +913,10 @@ async function clearFieldOrphans(fieldId: string) {
         props.client.updateFieldPermission(props.sheetId, fieldId, entry.subjectType, entry.subjectId, { remove: true }),
       ),
     )
-    status.value = `Cleared ${orphans.length} orphan field override${orphans.length === 1 ? '' : 's'}`
+    status.value = fieldStatusClearedOrphans(orphans.length, isZh.value)
     emit('updated')
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to clear orphan field overrides'
+    error.value = cause?.message ?? p('field.error.clearOrphans')
   } finally {
     busyFieldOrphanBulkKey.value = null
   }
@@ -913,11 +944,11 @@ async function applyFieldTemplate(subjectType: string, subjectId: string) {
       ),
     )
     status.value = draft === 'default'
-      ? `Cleared field permission overrides on ${props.fields.length} fields`
-      : `Applied field permission to ${props.fields.length} fields`
+      ? fieldStatusClearedAll(props.fields.length, isZh.value)
+      : fieldStatusApplied(props.fields.length, isZh.value)
     emit('updated')
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to apply field permission template'
+    error.value = cause?.message ?? p('field.error.applyTemplate')
   } finally {
     busyFieldTemplateKey.value = null
   }
@@ -932,11 +963,11 @@ async function copyFieldTemplateFromMemberGroup(targetSubjectId: string) {
   try {
     const operationCount = await syncFieldTemplateBetweenMemberGroups(sourceSubjectId, targetSubjectId)
     status.value = operationCount > 0
-      ? 'Copied field ACL template from source member group'
-      : 'Field ACL template already matches source member group'
+      ? p('field.status.copiedTemplate')
+      : p('field.status.copyTemplateNoop')
     emit('updated')
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to copy field ACL template'
+    error.value = cause?.message ?? p('field.error.copyTemplate')
   } finally {
     busyFieldTemplateCopyKey.value = null
   }
@@ -968,10 +999,7 @@ function viewTemplateDraftValue(subjectType: string, subjectId: string): string 
 }
 
 function viewPermDisplayLabel(val: string): string {
-  if (val === 'read') return 'Read'
-  if (val === 'write') return 'Write'
-  if (val === 'admin') return 'Admin'
-  return 'None'
+  return viewPermissionText(val, isZh.value)
 }
 
 function setViewPermDraft(viewId: string, subjectType: string, subjectId: string, event: Event) {
@@ -1008,11 +1036,11 @@ async function applyViewPerm(viewId: string, subjectType: string, subjectId: str
       subjectId,
       permission,
     )
-    status.value = 'View permission updated'
+    status.value = p('view.status.updated')
     emit('update-view-permission', viewId, subjectType, subjectId, permission)
     emit('updated')
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to update view permission'
+    error.value = cause?.message ?? p('view.error.update')
   } finally {
     busyViewPermKey.value = null
   }
@@ -1024,11 +1052,11 @@ async function clearViewPerm(viewId: string, subjectType: string, subjectId: str
   clearMessages()
   try {
     await props.client.updateViewPermission(viewId, subjectType as MetaSheetPermissionSubjectType, subjectId, 'none')
-    status.value = 'View permission cleared'
+    status.value = p('view.status.cleared')
     emit('update-view-permission', viewId, subjectType, subjectId, 'none')
     emit('updated')
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to clear view permission'
+    error.value = cause?.message ?? p('view.error.clear')
   } finally {
     busyViewPermKey.value = null
   }
@@ -1045,10 +1073,10 @@ async function clearViewOrphans(viewId: string) {
         props.client.updateViewPermission(viewId, entry.subjectType, entry.subjectId, 'none'),
       ),
     )
-    status.value = `Cleared ${orphans.length} orphan view override${orphans.length === 1 ? '' : 's'}`
+    status.value = viewStatusClearedOrphans(orphans.length, isZh.value)
     emit('updated')
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to clear orphan view overrides'
+    error.value = cause?.message ?? p('view.error.clearOrphans')
   } finally {
     busyViewOrphanBulkKey.value = null
   }
@@ -1071,10 +1099,10 @@ async function applyViewTemplate(subjectType: string, subjectId: string) {
         ),
       ),
     )
-    status.value = `Applied view permission to ${props.views.length} views`
+    status.value = viewStatusApplied(props.views.length, isZh.value)
     emit('updated')
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to apply view permission template'
+    error.value = cause?.message ?? p('view.error.applyTemplate')
   } finally {
     busyViewTemplateKey.value = null
   }
@@ -1089,11 +1117,11 @@ async function copyViewTemplateFromMemberGroup(targetSubjectId: string) {
   try {
     const operationCount = await syncViewTemplateBetweenMemberGroups(sourceSubjectId, targetSubjectId)
     status.value = operationCount > 0
-      ? 'Copied view ACL template from source member group'
-      : 'View ACL template already matches source member group'
+      ? p('view.status.copiedTemplate')
+      : p('view.status.copyTemplateNoop')
     emit('updated')
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to copy view ACL template'
+    error.value = cause?.message ?? p('view.error.copyTemplate')
   } finally {
     busyViewTemplateCopyKey.value = null
   }
@@ -1141,11 +1169,11 @@ async function copySubjectAclFromMemberGroup(targetSubjectId: string) {
     ])
     const totalOperationCount = fieldOperationCount + viewOperationCount
     status.value = totalOperationCount > 0
-      ? 'Copied downstream field and view ACL from source member group'
-      : 'Downstream field and view ACL already matches source member group'
+      ? p('sheet.status.copiedDownstreamAcl')
+      : p('sheet.status.copyDownstreamNoop')
     emit('updated')
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to copy downstream member-group ACL'
+    error.value = cause?.message ?? p('sheet.error.copyDownstreamAcl')
   } finally {
     busySubjectAclCopyKey.value = null
   }
@@ -1212,28 +1240,27 @@ function hasSubjectOverrides(subjectType: MetaSheetPermissionSubjectType, subjec
 
 function subjectOverrideSummaryLabel(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
   const counts = subjectOverrideCountsFor(subjectType, subjectId)
-  const parts: string[] = []
-  if (counts.fieldCount > 0) parts.push(`${counts.fieldCount} field override${counts.fieldCount === 1 ? '' : 's'}`)
-  if (counts.viewCount > 0) parts.push(`${counts.viewCount} view override${counts.viewCount === 1 ? '' : 's'}`)
-  return parts.join(' · ')
+  return subjectOverrideSummary(counts.fieldCount, counts.viewCount, isZh.value)
 }
 
 function memberGroupTemplateSourceOptions(targetSubjectId: string) {
   return memberGroupEntries.value.filter((entry) => entry.subjectId !== targetSubjectId)
 }
 
-function accessLevelLabel(accessLevel: MetaSheetPermissionAccessLevel) {
-  return ACCESS_LEVEL_OPTIONS.find((option) => option.value === accessLevel)?.label ?? accessLevel
+function sheetAccessLabel(accessLevel: MetaSheetPermissionAccessLevel) {
+  return sheetAccessText(accessLevel, isZh.value)
 }
 
 function accessLevelOptionsFor(subjectType: MetaSheetPermissionSubjectType) {
-  return subjectType === 'user' ? ACCESS_LEVEL_OPTIONS : ROLE_ACCESS_LEVEL_OPTIONS
+  return subjectType === 'user' ? accessLevelOptions.value : roleAccessLevelOptions.value
 }
 
-function subjectTypeBadgeLabel(subjectType: MetaSheetPermissionSubjectType) {
-  if (subjectType === 'role') return 'Role'
-  if (subjectType === 'member-group') return 'Member group'
-  return 'Person'
+function sheetSubjectText(subjectType: MetaSheetPermissionSubjectType) {
+  return subjectText(subjectType, isZh.value, 'person')
+}
+
+function orphanSubjectLabel(subjectType: MetaSheetPermissionSubjectType) {
+  return orphanSubjectText(sheetSubjectText(subjectType), isZh.value)
 }
 
 function subjectIsInactive(subjectType: MetaSheetPermissionSubjectType, isActive: boolean | undefined) {
@@ -1283,7 +1310,7 @@ async function loadEntries() {
     entries.value = response.items
     syncEntryDrafts(response.items)
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to load sheet access'
+    error.value = cause?.message ?? p('sheet.error.loadAccess')
   } finally {
     loading.value = false
   }
@@ -1304,7 +1331,7 @@ async function loadCandidates(query?: string) {
     candidates.value = response.items
     syncCandidateDrafts(response.items)
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to load permission candidates'
+    error.value = cause?.message ?? p('sheet.error.loadCandidates')
   } finally {
     candidatesLoading.value = false
   }
@@ -1354,7 +1381,7 @@ async function updateSubjectAccess(
     status.value = successMessage
     emit('updated')
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to update sheet access'
+    error.value = cause?.message ?? p('sheet.error.updateAccess')
   } finally {
     busySubjectKey.value = null
   }
@@ -1363,16 +1390,16 @@ async function updateSubjectAccess(
 async function applyEntry(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
   const nextAccessLevel = entryDrafts.value[subjectKey(subjectType, subjectId)]
   if (!nextAccessLevel) return
-  await updateSubjectAccess(subjectType, subjectId, nextAccessLevel, 'Sheet access override updated')
+  await updateSubjectAccess(subjectType, subjectId, nextAccessLevel, p('sheet.status.updated'))
 }
 
 async function removeEntry(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
-  await updateSubjectAccess(subjectType, subjectId, 'none', 'Sheet access override removed')
+  await updateSubjectAccess(subjectType, subjectId, 'none', p('sheet.status.removed'))
 }
 
 async function grantCandidate(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
   const key = subjectKey(subjectType, subjectId)
-  await updateSubjectAccess(subjectType, subjectId, candidateDrafts.value[key] ?? 'read', 'Sheet access override saved')
+  await updateSubjectAccess(subjectType, subjectId, candidateDrafts.value[key] ?? 'read', p('sheet.status.saved'))
 }
 
 async function clearSubjectOverrides(subjectType: MetaSheetPermissionSubjectType, subjectId: string) {
@@ -1396,10 +1423,10 @@ async function clearSubjectOverrides(subjectType: MetaSheetPermissionSubjectType
         props.client.updateViewPermission(entry.viewId, subjectType, subjectId, 'none'),
       ),
     ])
-    status.value = `Cleared ${subjectOverrideSummaryLabel(subjectType, subjectId)}`
+    status.value = clearedSubjectOverrides(subjectOverrideSummaryLabel(subjectType, subjectId), isZh.value)
     emit('updated')
   } catch (cause: any) {
-    error.value = cause?.message ?? 'Failed to clear subject overrides'
+    error.value = cause?.message ?? p('sheet.error.clearSubjectOverrides')
   } finally {
     busySubjectKey.value = null
   }
@@ -1633,12 +1660,12 @@ onBeforeUnmount(() => {
   color: #334155;
 }
 
-.meta-sheet-perm__badge[data-access-level='Hidden'] {
+.meta-sheet-perm__badge[data-access-level='hidden'] {
   background: #fef2f2;
   color: #b91c1c;
 }
 
-.meta-sheet-perm__badge[data-access-level='Read-only'] {
+.meta-sheet-perm__badge[data-access-level='readonly'] {
   background: #fef3c7;
   color: #92400e;
 }

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -12,7 +12,8 @@ export type MetaManagerLabelKey =
   | 'action.moveUp' | 'action.moveDown' | 'action.delete'
   | 'action.confirmRename' | 'action.cancelRename'
   | 'action.cancel' | 'action.reloadLatest' | 'action.dismiss'
-  | 'action.add' | 'action.addOption'
+  | 'action.add' | 'action.addOption' | 'action.save' | 'action.remove'
+  | 'action.clear' | 'action.apply'
   | 'field.title' | 'field.empty' | 'field.options' | 'field.optionValue'
   | 'field.targetSheet' | 'field.selectSheet' | 'field.limitSingleLinkedRecord'
   | 'field.personHint' | 'field.limitSinglePerson'
@@ -103,6 +104,10 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'action.dismiss': { en: 'Dismiss', zh: '忽略' },
   'action.add': { en: '+ Add', zh: '+ 添加' },
   'action.addOption': { en: '+ Add option', zh: '+ 添加选项' },
+  'action.save': { en: 'Save', zh: '保存' },
+  'action.remove': { en: 'Remove', zh: '移除' },
+  'action.clear': { en: 'Clear', zh: '清除' },
+  'action.apply': { en: 'Apply', zh: '应用' },
 
   'field.title': { en: 'Manage Fields', zh: '管理字段' },
   'field.empty': { en: 'No fields defined', zh: '暂无字段' },

--- a/apps/web/src/multitable/utils/meta-permission-labels.ts
+++ b/apps/web/src/multitable/utils/meta-permission-labels.ts
@@ -1,0 +1,300 @@
+// Permission manager chrome string table (T3C-2a).
+//
+// Scope: MetaRecordPermissionManager.vue and MetaSheetPermissionManager.vue.
+// User, role, member-group, field, view, permission code, backend error, and
+// persisted ACL values stay raw. This module only maps UI chrome.
+
+export type MetaPermissionLabelKey =
+  | 'action.clearOverrides'
+  | 'action.copyAcl'
+  | 'action.copyFieldViewAcl'
+  | 'action.grant'
+  | 'access.admin'
+  | 'access.read'
+  | 'access.write'
+  | 'access.writeOwn'
+  | 'field.applyAll'
+  | 'field.bulkApply'
+  | 'field.error.applyTemplate'
+  | 'field.error.clear'
+  | 'field.error.clearOrphans'
+  | 'field.error.copyTemplate'
+  | 'field.error.update'
+  | 'field.noFields'
+  | 'field.noSubjects'
+  | 'field.state.default'
+  | 'field.state.hidden'
+  | 'field.state.readonly'
+  | 'field.status.cleared'
+  | 'field.status.copiedTemplate'
+  | 'field.status.copyTemplateNoop'
+  | 'field.status.updated'
+  | 'field.title'
+  | 'permission.clearOrphanOverrides'
+  | 'permission.copyDownstreamPlaceholder'
+  | 'permission.copyFromMemberGroup'
+  | 'permission.noCurrentSheetAccess'
+  | 'record.currentAccess'
+  | 'record.empty'
+  | 'record.error.grant'
+  | 'record.error.loadCandidates'
+  | 'record.error.loadPermissions'
+  | 'record.error.remove'
+  | 'record.error.update'
+  | 'record.grantSection'
+  | 'record.loadingCandidates'
+  | 'record.loadingPermissions'
+  | 'record.noCandidates'
+  | 'record.noMemberGroups'
+  | 'record.noPeople'
+  | 'record.noRoles'
+  | 'record.searchPlaceholder'
+  | 'record.status.granted'
+  | 'record.status.removed'
+  | 'record.status.updated'
+  | 'record.subtitle'
+  | 'record.title'
+  | 'sheet.currentAccess'
+  | 'sheet.eligibleSection'
+  | 'sheet.emptyAccess'
+  | 'sheet.error.clearSubjectOverrides'
+  | 'sheet.error.copyDownstreamAcl'
+  | 'sheet.error.loadAccess'
+  | 'sheet.error.loadCandidates'
+  | 'sheet.error.updateAccess'
+  | 'sheet.loadingAccess'
+  | 'sheet.noCandidates'
+  | 'sheet.searchingCandidates'
+  | 'sheet.searchPlaceholder'
+  | 'sheet.status.copyDownstreamNoop'
+  | 'sheet.status.copiedDownstreamAcl'
+  | 'sheet.status.removed'
+  | 'sheet.status.saved'
+  | 'sheet.status.updated'
+  | 'sheet.subtitle'
+  | 'sheet.tab.fields'
+  | 'sheet.tab.sheet'
+  | 'sheet.tab.views'
+  | 'sheet.title'
+  | 'subject.cleanupOnly'
+  | 'subject.grantBlocked'
+  | 'subject.inactiveUser'
+  | 'subject.memberGroup'
+  | 'subject.memberGroups'
+  | 'subject.noMemberGroups'
+  | 'subject.noPeople'
+  | 'subject.noRoles'
+  | 'subject.people'
+  | 'subject.person'
+  | 'subject.role'
+  | 'subject.roles'
+  | 'subject.user'
+  | 'view.applyAll'
+  | 'view.bulkApply'
+  | 'view.error.applyTemplate'
+  | 'view.error.clear'
+  | 'view.error.clearOrphans'
+  | 'view.error.copyTemplate'
+  | 'view.error.update'
+  | 'view.noSubjects'
+  | 'view.noViews'
+  | 'view.state.none'
+  | 'view.status.cleared'
+  | 'view.status.copiedTemplate'
+  | 'view.status.copyTemplateNoop'
+  | 'view.status.updated'
+  | 'view.title'
+
+const LABELS: Record<MetaPermissionLabelKey, { en: string; zh: string }> = {
+  'action.clearOverrides': { en: 'Clear overrides', zh: '清除覆盖' },
+  'action.copyAcl': { en: 'Copy ACL', zh: '复制 ACL' },
+  'action.copyFieldViewAcl': { en: 'Copy field+view ACL', zh: '复制字段+视图 ACL' },
+  'action.grant': { en: 'Grant', zh: '授权' },
+  'access.admin': { en: 'Admin', zh: '管理员' },
+  'access.read': { en: 'Read', zh: '读取' },
+  'access.write': { en: 'Write', zh: '写入' },
+  'access.writeOwn': { en: 'Write own', zh: '仅写入自己' },
+  'field.applyAll': { en: 'Apply to all fields', zh: '应用到所有字段' },
+  'field.bulkApply': { en: 'Bulk apply to all fields', zh: '批量应用到所有字段' },
+  'field.error.applyTemplate': { en: 'Failed to apply field permission template', zh: '应用字段权限模板失败' },
+  'field.error.clear': { en: 'Failed to clear field permission', zh: '清除字段权限失败' },
+  'field.error.clearOrphans': { en: 'Failed to clear orphan field overrides', zh: '清除孤立字段覆盖失败' },
+  'field.error.copyTemplate': { en: 'Failed to copy field ACL template', zh: '复制字段 ACL 模板失败' },
+  'field.error.update': { en: 'Failed to update field permission', zh: '更新字段权限失败' },
+  'field.noFields': { en: 'No fields available.', zh: '暂无可用字段。' },
+  'field.noSubjects': {
+    en: 'No subjects with sheet access. Grant sheet access first to configure field permissions.',
+    zh: '暂无拥有表访问权限的对象。请先授予表访问权限，再配置字段权限。',
+  },
+  'field.state.default': { en: 'Default', zh: '默认' },
+  'field.state.hidden': { en: 'Hidden', zh: '隐藏' },
+  'field.state.readonly': { en: 'Read-only', zh: '只读' },
+  'field.status.cleared': { en: 'Field permission cleared', zh: '字段权限已清除' },
+  'field.status.copiedTemplate': { en: 'Copied field ACL template from source member group', zh: '已从源成员组复制字段 ACL 模板' },
+  'field.status.copyTemplateNoop': { en: 'Field ACL template already matches source member group', zh: '字段 ACL 模板已与源成员组一致' },
+  'field.status.updated': { en: 'Field permission updated', zh: '字段权限已更新' },
+  'field.title': { en: 'Field-level permissions', zh: '字段级权限' },
+  'permission.clearOrphanOverrides': { en: 'Clear orphan overrides', zh: '清除孤立覆盖' },
+  'permission.copyDownstreamPlaceholder': { en: 'Copy downstream ACL...', zh: '复制下游 ACL...' },
+  'permission.copyFromMemberGroup': { en: 'Copy from member group...', zh: '从成员组复制...' },
+  'permission.noCurrentSheetAccess': { en: 'No current sheet access', zh: '当前无表访问权限' },
+  'record.currentAccess': { en: 'Current access', zh: '当前访问权限' },
+  'record.empty': { en: 'No record-specific permissions yet.', zh: '暂无记录专属权限。' },
+  'record.error.grant': { en: 'Failed to grant permission', zh: '授予权限失败' },
+  'record.error.loadCandidates': { en: 'Failed to load permission candidates', zh: '加载权限候选项失败' },
+  'record.error.loadPermissions': { en: 'Failed to load record permissions', zh: '加载记录权限失败' },
+  'record.error.remove': { en: 'Failed to remove permission', zh: '移除权限失败' },
+  'record.error.update': { en: 'Failed to update permission', zh: '更新权限失败' },
+  'record.grantSection': { en: 'Grant to people, member groups, or roles', zh: '授权给人员、成员组或角色' },
+  'record.loadingCandidates': { en: 'Loading eligible people, member groups, and roles...', zh: '正在加载可授权的人员、成员组和角色...' },
+  'record.loadingPermissions': { en: 'Loading permissions...', zh: '正在加载权限...' },
+  'record.noCandidates': { en: 'No matching eligible people, member groups, or roles.', zh: '没有匹配的可授权人员、成员组或角色。' },
+  'record.noMemberGroups': { en: 'No matching member groups.', zh: '没有匹配的成员组。' },
+  'record.noPeople': { en: 'No matching people.', zh: '没有匹配的人员。' },
+  'record.noRoles': { en: 'No matching roles.', zh: '没有匹配的角色。' },
+  'record.searchPlaceholder': { en: 'Search people, member groups, or roles', zh: '搜索人员、成员组或角色' },
+  'record.status.granted': { en: 'Permission granted', zh: '权限已授予' },
+  'record.status.removed': { en: 'Permission removed', zh: '权限已移除' },
+  'record.status.updated': { en: 'Permission updated', zh: '权限已更新' },
+  'record.subtitle': { en: 'Manage who can access this record and at what level.', zh: '管理谁可以访问此记录以及访问级别。' },
+  'record.title': { en: 'Record Permissions', zh: '记录权限' },
+  'sheet.currentAccess': { en: 'Current access', zh: '当前访问权限' },
+  'sheet.eligibleSection': { en: 'Eligible people, member groups, or roles', zh: '可授权人员、成员组或角色' },
+  'sheet.emptyAccess': { en: 'No sheet-specific access grants yet.', zh: '暂无表专属访问授权。' },
+  'sheet.error.clearSubjectOverrides': { en: 'Failed to clear subject overrides', zh: '清除对象覆盖失败' },
+  'sheet.error.copyDownstreamAcl': { en: 'Failed to copy downstream member-group ACL', zh: '复制下游成员组 ACL 失败' },
+  'sheet.error.loadAccess': { en: 'Failed to load sheet access', zh: '加载表访问权限失败' },
+  'sheet.error.loadCandidates': { en: 'Failed to load permission candidates', zh: '加载权限候选项失败' },
+  'sheet.error.updateAccess': { en: 'Failed to update sheet access', zh: '更新表访问权限失败' },
+  'sheet.loadingAccess': { en: 'Loading access list...', zh: '正在加载访问列表...' },
+  'sheet.noCandidates': { en: 'No matching eligible people, member groups, or roles.', zh: '没有匹配的可授权人员、成员组或角色。' },
+  'sheet.searchingCandidates': { en: 'Searching eligible people, member groups, and roles...', zh: '正在搜索可授权人员、成员组和角色...' },
+  'sheet.searchPlaceholder': { en: 'Search people or roles', zh: '搜索人员或角色' },
+  'sheet.status.copyDownstreamNoop': { en: 'Downstream field and view ACL already matches source member group', zh: '下游字段和视图 ACL 已与源成员组一致' },
+  'sheet.status.copiedDownstreamAcl': { en: 'Copied downstream field and view ACL from source member group', zh: '已从源成员组复制下游字段和视图 ACL' },
+  'sheet.status.removed': { en: 'Sheet access override removed', zh: '表访问覆盖已移除' },
+  'sheet.status.saved': { en: 'Sheet access override saved', zh: '表访问覆盖已保存' },
+  'sheet.status.updated': { en: 'Sheet access override updated', zh: '表访问覆盖已更新' },
+  'sheet.subtitle': {
+    en: 'Override sheet-level access for eligible people, member groups, or roles. Admin includes sharing and sheet deletion. Write-own remains user-only.',
+    zh: '为可授权人员、成员组或角色覆盖表级访问权限。管理员包含分享和删除表权限；仅写入自己仍只适用于用户。',
+  },
+  'sheet.tab.fields': { en: 'Field Permissions', zh: '字段权限' },
+  'sheet.tab.sheet': { en: 'Sheet Access', zh: '表访问权限' },
+  'sheet.tab.views': { en: 'View Permissions', zh: '视图权限' },
+  'sheet.title': { en: 'Manage Access', zh: '管理访问权限' },
+  'subject.cleanupOnly': { en: 'Cleanup only', zh: '仅可清理' },
+  'subject.grantBlocked': { en: 'Grant blocked', zh: '授权已阻止' },
+  'subject.inactiveUser': { en: 'Inactive user', zh: '已停用用户' },
+  'subject.memberGroup': { en: 'Member group', zh: '成员组' },
+  'subject.memberGroups': { en: 'Member groups', zh: '成员组' },
+  'subject.noMemberGroups': { en: 'No matching member groups.', zh: '没有匹配的成员组。' },
+  'subject.noPeople': { en: 'No matching people.', zh: '没有匹配的人员。' },
+  'subject.noRoles': { en: 'No matching roles.', zh: '没有匹配的角色。' },
+  'subject.people': { en: 'People', zh: '人员' },
+  'subject.person': { en: 'Person', zh: '人员' },
+  'subject.role': { en: 'Role', zh: '角色' },
+  'subject.roles': { en: 'Roles', zh: '角色' },
+  'subject.user': { en: 'User', zh: '用户' },
+  'view.applyAll': { en: 'Apply to all views', zh: '应用到所有视图' },
+  'view.bulkApply': { en: 'Bulk apply to all views', zh: '批量应用到所有视图' },
+  'view.error.applyTemplate': { en: 'Failed to apply view permission template', zh: '应用视图权限模板失败' },
+  'view.error.clear': { en: 'Failed to clear view permission', zh: '清除视图权限失败' },
+  'view.error.clearOrphans': { en: 'Failed to clear orphan view overrides', zh: '清除孤立视图覆盖失败' },
+  'view.error.copyTemplate': { en: 'Failed to copy view ACL template', zh: '复制视图 ACL 模板失败' },
+  'view.error.update': { en: 'Failed to update view permission', zh: '更新视图权限失败' },
+  'view.noSubjects': {
+    en: 'No subjects with sheet access. Grant sheet access first to configure view permissions.',
+    zh: '暂无拥有表访问权限的对象。请先授予表访问权限，再配置视图权限。',
+  },
+  'view.noViews': { en: 'No views available.', zh: '暂无可用视图。' },
+  'view.state.none': { en: 'None', zh: '无' },
+  'view.status.cleared': { en: 'View permission cleared', zh: '视图权限已清除' },
+  'view.status.copiedTemplate': { en: 'Copied view ACL template from source member group', zh: '已从源成员组复制视图 ACL 模板' },
+  'view.status.copyTemplateNoop': { en: 'View ACL template already matches source member group', zh: '视图 ACL 模板已与源成员组一致' },
+  'view.status.updated': { en: 'View permission updated', zh: '视图权限已更新' },
+  'view.title': { en: 'View-level permissions', zh: '视图级权限' },
+}
+
+export function permissionLabel(key: MetaPermissionLabelKey, isZh: boolean): string {
+  const entry = LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+export function recordAccessText(level: string, isZh: boolean): string {
+  if (level === 'read') return permissionLabel('access.read', isZh)
+  if (level === 'write') return permissionLabel('access.write', isZh)
+  if (level === 'admin') return permissionLabel('access.admin', isZh)
+  return level
+}
+
+export function sheetAccessText(level: string, isZh: boolean): string {
+  if (level === 'read') return permissionLabel('access.read', isZh)
+  if (level === 'write') return permissionLabel('access.write', isZh)
+  if (level === 'write-own') return permissionLabel('access.writeOwn', isZh)
+  if (level === 'admin') return permissionLabel('access.admin', isZh)
+  return level
+}
+
+export function subjectText(subjectType: string, isZh: boolean, userLabel: 'user' | 'person' = 'user'): string {
+  if (subjectType === 'role') return permissionLabel('subject.role', isZh)
+  if (subjectType === 'member-group') return permissionLabel('subject.memberGroup', isZh)
+  return permissionLabel(userLabel === 'person' ? 'subject.person' : 'subject.user', isZh)
+}
+
+export function fieldStateText(value: string, isZh: boolean): string {
+  if (value === 'hidden') return permissionLabel('field.state.hidden', isZh)
+  if (value === 'readonly') return permissionLabel('field.state.readonly', isZh)
+  return permissionLabel('field.state.default', isZh)
+}
+
+export function viewPermissionText(value: string, isZh: boolean): string {
+  if (value === 'read') return permissionLabel('access.read', isZh)
+  if (value === 'write') return permissionLabel('access.write', isZh)
+  if (value === 'admin') return permissionLabel('access.admin', isZh)
+  return permissionLabel('view.state.none', isZh)
+}
+
+export function fieldStatusClearedOrphans(count: number, isZh: boolean): string {
+  if (isZh) return `已清除 ${count} 个孤立字段覆盖`
+  return `Cleared ${count} orphan field override${count === 1 ? '' : 's'}`
+}
+
+export function viewStatusClearedOrphans(count: number, isZh: boolean): string {
+  if (isZh) return `已清除 ${count} 个孤立视图覆盖`
+  return `Cleared ${count} orphan view override${count === 1 ? '' : 's'}`
+}
+
+export function subjectOverrideSummary(fieldCount: number, viewCount: number, isZh: boolean): string {
+  const parts: string[] = []
+  if (fieldCount > 0) {
+    parts.push(isZh ? `${fieldCount} 个字段覆盖` : `${fieldCount} field override${fieldCount === 1 ? '' : 's'}`)
+  }
+  if (viewCount > 0) {
+    parts.push(isZh ? `${viewCount} 个视图覆盖` : `${viewCount} view override${viewCount === 1 ? '' : 's'}`)
+  }
+  return parts.join(' · ')
+}
+
+export function clearedSubjectOverrides(summary: string, isZh: boolean): string {
+  return isZh ? `已清除 ${summary}` : `Cleared ${summary}`
+}
+
+export function fieldStatusClearedAll(count: number, isZh: boolean): string {
+  if (isZh) return `已清除 ${count} 个字段上的权限覆盖`
+  return `Cleared field permission overrides on ${count} fields`
+}
+
+export function fieldStatusApplied(count: number, isZh: boolean): string {
+  if (isZh) return `已将字段权限应用到 ${count} 个字段`
+  return `Applied field permission to ${count} fields`
+}
+
+export function viewStatusApplied(count: number, isZh: boolean): string {
+  if (isZh) return `已将视图权限应用到 ${count} 个视图`
+  return `Applied view permission to ${count} views`
+}
+
+export function orphanSubjectText(subjectLabel: string, isZh: boolean): string {
+  return isZh ? `孤立的 ${subjectLabel}` : `Orphan ${subjectLabel}`
+}

--- a/apps/web/tests/meta-permission-labels.spec.ts
+++ b/apps/web/tests/meta-permission-labels.spec.ts
@@ -1,0 +1,64 @@
+import { describe, expect, it } from 'vitest'
+import { managerLabel } from '../src/multitable/utils/meta-manager-labels'
+import {
+  fieldStateText,
+  fieldStatusClearedOrphans,
+  orphanSubjectText,
+  permissionLabel,
+  recordAccessText,
+  sheetAccessText,
+  subjectOverrideSummary,
+  subjectText,
+  viewPermissionText,
+  viewStatusClearedOrphans,
+} from '../src/multitable/utils/meta-permission-labels'
+
+describe('meta-permission-labels', () => {
+  it('maps static permission manager chrome in English and zh-CN', () => {
+    expect(permissionLabel('record.title', false)).toBe('Record Permissions')
+    expect(permissionLabel('record.title', true)).toBe('记录权限')
+    expect(permissionLabel('sheet.title', false)).toBe('Manage Access')
+    expect(permissionLabel('sheet.title', true)).toBe('管理访问权限')
+    expect(permissionLabel('action.copyAcl', true)).toBe('复制 ACL')
+  })
+
+  it('keeps common manager actions in meta-manager-labels', () => {
+    expect(managerLabel('action.save', true)).toBe('保存')
+    expect(managerLabel('action.remove', true)).toBe('移除')
+    expect(managerLabel('action.clear', true)).toBe('清除')
+    expect(managerLabel('action.apply', true)).toBe('应用')
+  })
+
+  it('keeps access and state values display-only while preserving unknown raw values', () => {
+    expect(recordAccessText('write', false)).toBe('Write')
+    expect(recordAccessText('write', true)).toBe('写入')
+    expect(sheetAccessText('write-own', true)).toBe('仅写入自己')
+    expect(viewPermissionText('none', true)).toBe('无')
+    expect(fieldStateText('readonly', true)).toBe('只读')
+    expect(recordAccessText('custom_acl', true)).toBe('custom_acl')
+  })
+
+  it('localizes subject badges without touching raw identities', () => {
+    expect(subjectText('user', false)).toBe('User')
+    expect(subjectText('user', true)).toBe('用户')
+    expect(subjectText('user', true, 'person')).toBe('人员')
+    expect(subjectText('member-group', true)).toBe('成员组')
+    expect(orphanSubjectText('Member group', false)).toBe('Orphan Member group')
+    expect(orphanSubjectText('成员组', true)).toBe('孤立的 成员组')
+  })
+
+  it('preserves English singular/plural forks for orphan overrides', () => {
+    expect(fieldStatusClearedOrphans(1, false)).toBe('Cleared 1 orphan field override')
+    expect(fieldStatusClearedOrphans(2, false)).toBe('Cleared 2 orphan field overrides')
+    expect(fieldStatusClearedOrphans(2, true)).toBe('已清除 2 个孤立字段覆盖')
+    expect(viewStatusClearedOrphans(1, false)).toBe('Cleared 1 orphan view override')
+    expect(viewStatusClearedOrphans(2, false)).toBe('Cleared 2 orphan view overrides')
+    expect(viewStatusClearedOrphans(2, true)).toBe('已清除 2 个孤立视图覆盖')
+  })
+
+  it('formats field/view override summaries with English plural forks and zh neutral counts', () => {
+    expect(subjectOverrideSummary(1, 2, false)).toBe('1 field override · 2 view overrides')
+    expect(subjectOverrideSummary(2, 1, false)).toBe('2 field overrides · 1 view override')
+    expect(subjectOverrideSummary(2, 1, true)).toBe('2 个字段覆盖 · 1 个视图覆盖')
+  })
+})

--- a/apps/web/tests/multitable-record-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-record-permission-manager.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, type App as VueApp } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
 import MetaRecordPermissionManager from '../src/multitable/components/MetaRecordPermissionManager.vue'
 
 let app: VueApp | null = null
@@ -52,9 +53,81 @@ afterEach(() => {
   container?.remove()
   app = null
   container = null
+  useLocale().setLocale('en')
 })
 
 describe('MetaRecordPermissionManager', () => {
+  it('preserves English record permission chrome as the default locale', async () => {
+    const client = makeClient()
+
+    mountManager({ client })
+    await flushUi()
+
+    const text = container!.textContent ?? ''
+    expect(text).toContain('Record Permissions')
+    expect(text).toContain('Current access')
+    expect(text).toContain('No record-specific permissions yet.')
+    expect(text).toContain('Grant to people, member groups, or roles')
+    expect(container!.querySelector<HTMLInputElement>('[data-record-permission-search]')?.getAttribute('placeholder'))
+      .toBe('Search people, member groups, or roles')
+  })
+
+  it('localizes record permission chrome in zh-CN while preserving raw subjects and data attributes', async () => {
+    useLocale().setLocale('zh-CN')
+    const client = makeClient({
+      listRecordPermissions: vi.fn().mockResolvedValue([
+        {
+          id: 'perm_zh',
+          sheetId: 'sheet_1',
+          recordId: 'record_1',
+          subjectType: 'user',
+          subjectId: 'user_alice',
+          accessLevel: 'write',
+          label: 'Alice',
+          subtitle: 'alice@example.com',
+          isActive: false,
+        },
+      ]),
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'member-group',
+            subjectId: 'group_north',
+            accessLevel: 'read',
+            permissions: ['spreadsheet:read'],
+            label: 'North Region',
+            subtitle: 'Regional operations',
+            isActive: true,
+          },
+        ],
+      }),
+    })
+
+    mountManager({ client })
+    await flushUi()
+
+    const text = container!.textContent ?? ''
+    expect(text).toContain('记录权限')
+    expect(text).toContain('当前访问权限')
+    expect(text).toContain('写入')
+    expect(text).toContain('已停用用户')
+    expect(text).toContain('仅可清理')
+    expect(text).toContain('授权给人员、成员组或角色')
+    expect(text).toContain('成员组')
+    expect(text).toContain('授权')
+    expect(text).toContain('Alice')
+    expect(text).toContain('alice@example.com')
+    expect(text).toContain('North Region')
+    expect(text).toContain('Regional operations')
+    expect(container!.querySelector<HTMLInputElement>('[data-record-permission-search]')?.getAttribute('placeholder'))
+      .toBe('搜索人员、成员组或角色')
+
+    const entry = container!.querySelector('[data-record-permission-entry="perm_zh"]')!
+    expect(entry.querySelector('.meta-record-perm__badge')?.getAttribute('data-access-level')).toBe('write')
+    const candidateSelect = container!.querySelector('[data-record-permission-candidate="member-group:group_north"] select') as HTMLSelectElement
+    expect(Array.from(candidateSelect.options).map((option) => option.value)).toEqual(['read', 'write', 'admin'])
+  })
+
   it('renders permission list when visible', async () => {
     const client = makeClient({
       listRecordPermissions: vi.fn().mockResolvedValue([

--- a/apps/web/tests/multitable-sheet-permission-manager.spec.ts
+++ b/apps/web/tests/multitable-sheet-permission-manager.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, type App as VueApp } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
 import MetaSheetPermissionManager from '../src/multitable/components/MetaSheetPermissionManager.vue'
 
 let app: VueApp | null = null
@@ -47,9 +48,136 @@ afterEach(() => {
   container?.remove()
   app = null
   container = null
+  useLocale().setLocale('en')
 })
 
 describe('MetaSheetPermissionManager', () => {
+  it('preserves English sheet permission chrome as the default locale', async () => {
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({ items: [] }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({ items: [] }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({ client })
+    await flushUi()
+
+    const text = container!.textContent ?? ''
+    expect(text).toContain('Manage Access')
+    expect(text).toContain('Override sheet-level access for eligible people, member groups, or roles. Admin includes sharing and sheet deletion. Write-own remains user-only.')
+    expect(text).toContain('Sheet Access')
+    expect(text).toContain('Field Permissions')
+    expect(text).toContain('View Permissions')
+    expect(text).toContain('No sheet-specific access grants yet.')
+    expect(container!.querySelector<HTMLInputElement>('[data-sheet-permission-search]')?.getAttribute('placeholder')).toBe('Search people or roles')
+  })
+
+  it('localizes sheet, field, and view permission chrome in zh-CN while preserving raw ACL data', async () => {
+    useLocale().setLocale('zh-CN')
+    const client = {
+      listSheetPermissions: vi.fn().mockResolvedValue({
+        items: [
+          {
+            subjectType: 'user',
+            subjectId: 'user_1',
+            accessLevel: 'write',
+            permissions: ['spreadsheet.read', 'spreadsheet.write'],
+            label: 'Alex',
+            subtitle: 'alex@example.com',
+            isActive: true,
+          },
+        ],
+      }),
+      listSheetPermissionCandidates: vi.fn().mockResolvedValue({
+        items: [
+          { subjectType: 'member-group', subjectId: 'group_north', label: 'North Region', subtitle: '12 members', isActive: true, accessLevel: null },
+        ],
+      }),
+      updateSheetPermission: vi.fn().mockResolvedValue({}),
+      updateFieldPermission: vi.fn().mockResolvedValue({}),
+      updateViewPermission: vi.fn().mockResolvedValue({}),
+    }
+
+    mountManager({
+      client,
+      fields: [
+        { id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 0, options: [] },
+      ],
+      views: [
+        { id: 'view_grid', name: 'Grid View', type: 'grid', sheetId: 'sheet_orders' },
+      ],
+      fieldPermissionEntries: [
+        {
+          fieldId: 'fld_title',
+          subjectType: 'user',
+          subjectId: 'user_1',
+          subjectLabel: 'Alex',
+          subjectSubtitle: 'alex@example.com',
+          visible: true,
+          readOnly: true,
+          isActive: true,
+        },
+      ],
+      viewPermissionEntries: [
+        {
+          viewId: 'view_grid',
+          subjectType: 'user',
+          subjectId: 'user_1',
+          subjectLabel: 'Alex',
+          subjectSubtitle: 'alex@example.com',
+          permission: 'admin',
+          isActive: true,
+        },
+      ],
+    })
+    await flushUi()
+
+    let text = container!.textContent ?? ''
+    expect(text).toContain('管理访问权限')
+    expect(text).toContain('为可授权人员、成员组或角色覆盖表级访问权限')
+    expect(text).toContain('表访问权限')
+    expect(text).toContain('字段权限')
+    expect(text).toContain('视图权限')
+    expect(text).toContain('当前访问权限')
+    expect(text).toContain('写入')
+    expect(text).toContain('应用')
+    expect(text).toContain('Alex')
+    expect(text).toContain('alex@example.com')
+    expect(text).toContain('North Region')
+    expect(container!.querySelector<HTMLInputElement>('[data-sheet-permission-search]')?.getAttribute('placeholder')).toBe('搜索人员或角色')
+    expect(container!.querySelector('[data-sheet-permission-entry="user:user_1"] .meta-sheet-perm__badge')?.getAttribute('data-access-level')).toBe('write')
+    const sheetSelect = container!.querySelector('[data-sheet-permission-entry="user:user_1"] .meta-sheet-perm__select') as HTMLSelectElement
+    expect(Array.from(sheetSelect.options).map((option) => option.value)).toEqual(['read', 'write', 'write-own', 'admin'])
+
+    const tabs = Array.from(container!.querySelectorAll('[role="tab"]'))
+    ;(tabs.find((tab) => tab.textContent?.includes('字段权限')) as HTMLElement).click()
+    await flushUi()
+
+    text = container!.textContent ?? ''
+    expect(text).toContain('字段级权限')
+    expect(text).toContain('批量应用到所有字段')
+    expect(text).toContain('Title')
+    expect(text).toContain('string')
+    expect(text).toContain('只读')
+    expect(container!.querySelector('[data-field-permission-row="fld_title:user:user_1"] .meta-sheet-perm__badge')?.getAttribute('data-access-level')).toBe('readonly')
+    const fieldSelect = container!.querySelector('[data-field-permission-row="fld_title:user:user_1"] .meta-sheet-perm__select') as HTMLSelectElement
+    expect(Array.from(fieldSelect.options).map((option) => option.value)).toEqual(['default', 'hidden', 'readonly'])
+
+    ;(tabs.find((tab) => tab.textContent?.includes('视图权限')) as HTMLElement).click()
+    await flushUi()
+
+    text = container!.textContent ?? ''
+    expect(text).toContain('视图级权限')
+    expect(text).toContain('Grid View')
+    expect(text).toContain('grid')
+    expect(text).toContain('管理员')
+    expect(container!.querySelector('[data-view-permission-row="view_grid:user:user_1"] .meta-sheet-perm__badge')?.getAttribute('data-access-level')).toBe('admin')
+    const viewSelect = container!.querySelector('[data-view-permission-row="view_grid:user:user_1"] .meta-sheet-perm__select') as HTMLSelectElement
+    expect(Array.from(viewSelect.options).map((option) => option.value)).toEqual(['none', 'read', 'write', 'admin'])
+  })
+
   it('loads entries and filters active users out of candidate results', async () => {
     const client = {
       listSheetPermissions: vi.fn().mockResolvedValue({

--- a/docs/development/multitable-t3c2a-permission-managers-i18n-design-20260520.md
+++ b/docs/development/multitable-t3c2a-permission-managers-i18n-design-20260520.md
@@ -1,0 +1,368 @@
+# T3C-2a - Permission Managers i18n Design
+
+- **Date**: 2026-05-20
+- **Type**: implementation-ready design packet
+- **Status**: design only; no code implementation in this slice
+- **Base inspected**: `origin/main@27d82f99b`
+- **Goal**: localize the multitable permission manager chrome for record permissions and sheet permissions without changing permission semantics, API payloads, ACL persistence values, or accessibility structure.
+
+## 1. Decision Summary
+
+| Finding / Decision | Resolution |
+|---|---|
+| T3C-2a scope | Only `MetaRecordPermissionManager.vue` and `MetaSheetPermissionManager.vue`, plus their label helpers and tests. |
+| PR split | Keep T3C-2a separate from T3C-2b form-share and T3C-2c API-token. Do not touch `MetaFormShareManager.vue` or `MetaApiTokenManager.vue` in this PR. |
+| Label module shape | Create `apps/web/src/multitable/utils/meta-permission-labels.ts` for permission-specific copy. Extend `meta-manager-labels.ts` only for genuinely shared manager actions. |
+| Common-vs-specific boundary | `Save`, `Remove`, `Clear`, `Apply`, `Copy ACL`, and similar reusable action chrome may live in `meta-manager-labels.ts`. Permission-domain nouns, tabs, empty states, access levels, subject badges, ACL-template messages, and permission statuses belong in `meta-permission-labels.ts`. |
+| No helper redeclare | Do not redeclare cross-module helpers. T3C-1 almost duplicated `fieldTypeLabel`; this slice must grep for existing label helpers before adding new ones. |
+| `fieldTypeLabel` anti-pattern | `meta-core-labels.ts` remains the single source for field-type labels; `boolean` must stay `checkbox` / `复选框`. Permission code must not introduce another field type table. |
+| Raw data | Permission codes, subject ids, user/member-group/role names, field/view names, persisted enum values, backend error text, timestamps, and ACL scope strings stay raw. |
+| Existing specs | Earlier scout said 0 specs, but current `origin/main` has behavior specs: `multitable-record-permission-manager.spec.ts` and `multitable-sheet-permission-manager.spec.ts`. i18n assertions are still greenfield and must be added explicitly. |
+| Spec strategy | Add i18n-focused cases to the existing permission manager specs, or create adjacent `*-i18n.spec.ts` files if the existing files become too large. Either way, use the real component props and existing client shape. |
+| A11y boundary | This PR localizes existing text/placeholder chrome only. Current inspected files have `placeholder=2`, `aria-label=0`, `title=0`; do not add new a11y structure or new aria/title attributes here. |
+
+## 2. Files In Scope
+
+| File | Role |
+|---|---|
+| `apps/web/src/multitable/components/MetaRecordPermissionManager.vue` | Record-level permission modal. Current static chrome includes header, current access, grant section, access-level labels, subject badges, loading/empty states, status/error fallbacks, and one search placeholder. |
+| `apps/web/src/multitable/components/MetaSheetPermissionManager.vue` | Sheet-level permission modal with sheet / field / view tabs. Current static chrome includes access grants, candidates, field/view ACL templates, orphan cleanup, downstream copy flows, status/error fallbacks, and one search placeholder. |
+| `apps/web/src/multitable/utils/meta-permission-labels.ts` | New permission-domain label module for T3C-2a. |
+| `apps/web/src/multitable/utils/meta-manager-labels.ts` | Existing manager chrome module. Extend only when an action is reusable beyond permission managers. |
+| `apps/web/tests/multitable-record-permission-manager.spec.ts` | Existing behavior spec. Add record permission i18n regression cases or keep it unchanged and add an adjacent i18n spec. |
+| `apps/web/tests/multitable-sheet-permission-manager.spec.ts` | Existing behavior spec. Add sheet/field/view permission i18n regression cases or keep it unchanged and add an adjacent i18n spec. |
+| `docs/development/multitable-t3c2a-permission-managers-i18n-design-20260520.md` | This design packet. |
+| `docs/development/multitable-t3c2a-permission-managers-i18n-verification-20260520.md` | Verification packet after implementation. |
+
+Out of scope:
+
+- `MetaFormShareManager.vue` and form-share labels.
+- `MetaApiTokenManager.vue` and API-token labels.
+- Permission backend routes, ACL persistence, migrations, OpenAPI, or API contracts.
+- Adding new aria/title coverage where none exists today.
+- Rewording user, role, group, field, view, permission-code, or backend-error data.
+
+## 3. Scout Anchors
+
+| Anchor | Current evidence |
+|---|---|
+| Record component size | `MetaRecordPermissionManager.vue`: 707 lines. |
+| Sheet component size | `MetaSheetPermissionManager.vue`: 1750 lines. |
+| Placeholder count | 2 total: record search placeholder at line 90, sheet search placeholder at line 147. |
+| Existing aria/title | `aria-label=0`, `title=0` in the two component files. |
+| Button/action chrome | Earlier scout catalog counted 34 button/action text labels; static `<button>` nodes on current `origin/main` are 25 because the sheet tab/candidate templates collapse runtime multiplicity. Implementation must localize the action copy catalog, not just count literal `<button>` tags. |
+| Existing behavior specs | `apps/web/tests/multitable-record-permission-manager.spec.ts` and `apps/web/tests/multitable-sheet-permission-manager.spec.ts` exist on current `origin/main`. They do not provide zh-CN i18n coverage. |
+| Real record props | `visible`, `sheetId`, `recordId`, `client`; emits `close` and `updated`. |
+| Real sheet props | `visible`, `sheetId`, `client`, `fields`, `views`, `fieldPermissionEntries`, `viewPermissionEntries`; emits `close`, `updated`, `update-field-permission`, `update-view-permission`. |
+
+## 4. Raw Preserve List
+
+Do not translate or normalize these values:
+
+| Value class | Examples / source |
+|---|---|
+| User-authored identity labels | `entry.label`, `entry.subtitle`, candidate labels, user names, member-group names, role names. |
+| Stable subject ids | `user_alice`, `role_ops`, UUID member-group ids, fallback `subjectId`. |
+| Permission and ACL persisted values | `read`, `write`, `write-own`, `admin`, `default`, `hidden`, `readonly`, `none`, `visible`, `readOnly`, `{ remove: true }`. Display labels localize; values stay raw. |
+| Permission codes / scopes | `spreadsheet:read`, `spreadsheet.read`, `spreadsheet.admin`, `view.records`, `record.delete`, etc. |
+| Field and view names | `field.name`, `view.name`, field ids, view ids. |
+| Field/view raw type ids | `field.type`, `view.type` currently render as badges. Do not introduce a local field-type table in this slice; if future UX wants humanized field types here, it must call existing `fieldTypeLabel`. |
+| Backend/API error text | `cause?.message` stays raw. Only component-owned fallback strings are localized. |
+| Runtime counts and timestamps | Numeric counts interpolate into localized templates; raw timestamps/version strings stay as data. |
+
+## 5. Label Module Boundary
+
+### 5.1 New permission module
+
+Create:
+
+```text
+apps/web/src/multitable/utils/meta-permission-labels.ts
+```
+
+Expected exports:
+
+```ts
+export type MetaPermissionLabelKey = ...
+export function permissionLabel(key: MetaPermissionLabelKey, isZh: boolean): string
+export function permissionCountLabel(kind: 'fieldOverride' | 'viewOverride' | 'orphanFieldOverride' | 'orphanViewOverride', count: number, isZh: boolean): string
+export function fieldStatusClearedOrphans(count: number, isZh: boolean): string
+export function viewStatusClearedOrphans(count: number, isZh: boolean): string
+```
+
+The orphan-status helpers must preserve the existing English singular/plural fork, not render a parenthesized suffix literally:
+
+```ts
+export function fieldStatusClearedOrphans(count: number, isZh: boolean): string {
+  if (isZh) return `已清除 ${count} 个孤立字段覆盖`
+  return `Cleared ${count} orphan field override${count === 1 ? '' : 's'}`
+}
+
+export function viewStatusClearedOrphans(count: number, isZh: boolean): string {
+  if (isZh) return `已清除 ${count} 个孤立视图覆盖`
+  return `Cleared ${count} orphan view override${count === 1 ? '' : 's'}`
+}
+```
+
+Permission-specific labels should live here:
+
+- record/sheet titles and subtitles
+- tab labels
+- section labels
+- loading/empty states
+- subject badges (`Person`/`User`, `Member group`, `Role`)
+- access labels (`Read`, `Write`, `Write own`, `Admin`, `None`)
+- field/view ACL state labels (`Default`, `Hidden`, `Read-only`)
+- permission status/fallback error messages
+- ACL copy/status templates
+- orphan override labels
+
+### 5.2 Existing manager module
+
+`meta-manager-labels.ts` already owns field/view manager chrome and shared manager actions. Extend it only for action chrome that is broadly reusable:
+
+| Candidate | Module |
+|---|---|
+| `action.save` | `meta-manager-labels.ts` if absent. |
+| `action.remove` | `meta-manager-labels.ts` if absent. |
+| `action.clear` | `meta-manager-labels.ts` if absent. |
+| `action.apply` | `meta-manager-labels.ts` if absent. |
+| `action.copyAcl` | Prefer `meta-permission-labels.ts` unless another manager already uses ACL copy semantics. |
+| `permission.sheet.title`, `permission.record.title` | `meta-permission-labels.ts`. |
+| `permission.access.read`, `permission.access.writeOwn` | `meta-permission-labels.ts`. |
+
+### 5.3 No redeclare self-check
+
+Before implementation, run:
+
+```bash
+rg -n "fieldTypeLabel|accessLevelLabel|subjectType.*Label|const .*LABELS|function .*Label" apps/web/src/multitable
+```
+
+Rules:
+
+- Do not duplicate `fieldTypeLabel`; import from `meta-core-labels.ts` if field-type display is ever needed.
+- Do not create separate record-permission and sheet-permission label modules. T3C-2a owns both in one `meta-permission-labels.ts`.
+- If a helper naturally crosses permission managers and other manager panels, place it in `meta-manager-labels.ts`; otherwise keep it permission-specific.
+
+## 6. Copy Plan
+
+### 6.1 Record Permission Manager
+
+| Existing EN | Proposed key | ZH |
+|---|---|---|
+| `Record Permissions` | `record.title` | 记录权限 |
+| `Manage who can access this record and at what level.` | `record.subtitle` | 管理谁可以访问此记录以及访问级别。 |
+| `Current access` | `record.currentAccess` | 当前访问权限 |
+| `Loading permissions...` | `record.loadingPermissions` | 正在加载权限... |
+| `No record-specific permissions yet.` | `record.empty` | 暂无记录专属权限。 |
+| `Grant to people, member groups, or roles` | `record.grantSection` | 授权给人员、成员组或角色 |
+| `Search people, member groups, or roles` | `record.searchPlaceholder` | 搜索人员、成员组或角色 |
+| `Loading eligible people, member groups, and roles...` | `record.loadingCandidates` | 正在加载可授权的人员、成员组和角色... |
+| `No matching eligible people, member groups, or roles.` | `record.noCandidates` | 没有匹配的可授权人员、成员组或角色。 |
+| `No matching people.` | `record.noPeople` | 没有匹配的人员。 |
+| `No matching member groups.` | `record.noMemberGroups` | 没有匹配的成员组。 |
+| `No matching roles.` | `record.noRoles` | 没有匹配的角色。 |
+| `Inactive user` | `subject.inactiveUser` | 已停用用户 |
+| `Cleanup only` | `subject.cleanupOnly` | 仅可清理 |
+| `Grant blocked` | `subject.grantBlocked` | 授权已阻止 |
+| `User` | `subject.user` | 用户 |
+| `Member group` | `subject.memberGroup` | 成员组 |
+| `Role` | `subject.role` | 角色 |
+| `Read` | `access.read` | 读取 |
+| `Write` | `access.write` | 写入 |
+| `Admin` | `access.admin` | 管理员 |
+| `Permission updated` | `record.status.updated` | 权限已更新 |
+| `Permission removed` | `record.status.removed` | 权限已移除 |
+| `Permission granted` | `record.status.granted` | 权限已授予 |
+| `Failed to load record permissions` | `record.error.loadPermissions` | 加载记录权限失败 |
+| `Failed to load permission candidates` | `record.error.loadCandidates` | 加载权限候选项失败 |
+| `Failed to update permission` | `record.error.update` | 更新权限失败 |
+| `Failed to remove permission` | `record.error.remove` | 移除权限失败 |
+| `Failed to grant permission` | `record.error.grant` | 授予权限失败 |
+
+### 6.2 Sheet Permission Manager
+
+| Existing EN | Proposed key | ZH |
+|---|---|---|
+| `Manage Access` | `sheet.title` | 管理访问权限 |
+| `Override sheet-level access for eligible people, member groups, or roles. Admin includes sharing and sheet deletion. Write-own remains user-only.` | `sheet.subtitle` | 为可授权人员、成员组或角色覆盖表级访问权限。管理员包含分享和删除表权限；仅写入自己仍只适用于用户。 |
+| `Sheet Access` | `sheet.tab.sheet` | 表访问权限 |
+| `Field Permissions` | `sheet.tab.fields` | 字段权限 |
+| `View Permissions` | `sheet.tab.views` | 视图权限 |
+| `Current access` | `sheet.currentAccess` | 当前访问权限 |
+| `Loading access list...` | `sheet.loadingAccess` | 正在加载访问列表... |
+| `No sheet-specific access grants yet.` | `sheet.emptyAccess` | 暂无表专属访问授权。 |
+| `Clear overrides` | `sheet.clearOverrides` | 清除覆盖 |
+| `Copy downstream ACL...` | `sheet.copyDownstreamPlaceholder` | 复制下游 ACL... |
+| `Copy field+view ACL` | `sheet.copyFieldViewAcl` | 复制字段+视图 ACL |
+| `Eligible people, member groups, or roles` | `sheet.eligibleSection` | 可授权人员、成员组或角色 |
+| `Search people or roles` | `sheet.searchPlaceholder` | 搜索人员或角色 |
+| `Searching eligible people, member groups, and roles...` | `sheet.searchingCandidates` | 正在搜索可授权人员、成员组和角色... |
+| `No matching eligible people, member groups, or roles.` | `sheet.noCandidates` | 没有匹配的可授权人员、成员组或角色。 |
+| `People` | `subject.people` | 人员 |
+| `Person` | `subject.person` | 人员 |
+| `Member groups` | `subject.memberGroups` | 成员组 |
+| `Roles` | `subject.roles` | 角色 |
+| `Write own` | `access.writeOwn` | 仅写入自己 |
+| `Sheet access override updated` | `sheet.status.updated` | 表访问覆盖已更新 |
+| `Sheet access override removed` | `sheet.status.removed` | 表访问覆盖已移除 |
+| `Sheet access override saved` | `sheet.status.saved` | 表访问覆盖已保存 |
+| `Failed to load sheet access` | `sheet.error.loadAccess` | 加载表访问权限失败 |
+| `Failed to update sheet access` | `sheet.error.updateAccess` | 更新表访问权限失败 |
+| `Failed to clear subject overrides` | `sheet.error.clearSubjectOverrides` | 清除对象覆盖失败 |
+
+### 6.3 Field and View Permission Tabs
+
+| Existing EN | Proposed key | ZH |
+|---|---|---|
+| `Field-level permissions` | `field.title` | 字段级权限 |
+| `No fields available.` | `field.noFields` | 暂无可用字段。 |
+| `No subjects with sheet access. Grant sheet access first to configure field permissions.` | `field.noSubjects` | 暂无拥有表访问权限的对象。请先授予表访问权限，再配置字段权限。 |
+| `Bulk apply to all fields` | `field.bulkApply` | 批量应用到所有字段 |
+| `Default` | `field.state.default` | 默认 |
+| `Hidden` | `field.state.hidden` | 隐藏 |
+| `Read-only` | `field.state.readonly` | 只读 |
+| `Apply to all fields` | `field.applyAll` | 应用到所有字段 |
+| `Copy from member group...` | `permission.copyFromMemberGroup` | 从成员组复制... |
+| `Copy ACL` | `permission.copyAcl` | 复制 ACL |
+| `Clear orphan overrides` | `permission.clearOrphanOverrides` | 清除孤立覆盖 |
+| `No current sheet access` | `permission.noCurrentSheetAccess` | 当前无表访问权限 |
+| `Orphan ${subject}` | `permission.orphanSubject(subjectLabel)` | 孤立的 {subjectLabel} |
+| `Field permission updated` | `field.status.updated` | 字段权限已更新 |
+| `Field permission cleared` | `field.status.cleared` | 字段权限已清除 |
+| `Cleared 1 orphan field override` / `Cleared {n} orphan field overrides` | `field.status.clearedOrphans(n)` | 已清除 {n} 个孤立字段覆盖 |
+| `Applied field permission to {n} fields` | `field.status.applied(n)` | 已将字段权限应用到 {n} 个字段 |
+| `Cleared field permission overrides on {n} fields` | `field.status.clearedAll(n)` | 已清除 {n} 个字段上的权限覆盖 |
+| `Copied field ACL template from source member group` | `field.status.copiedTemplate` | 已从源成员组复制字段 ACL 模板 |
+| `Field ACL template already matches source member group` | `field.status.copyTemplateNoop` | 字段 ACL 模板已与源成员组一致 |
+| `View-level permissions` | `view.title` | 视图级权限 |
+| `No views available.` | `view.noViews` | 暂无可用视图。 |
+| `No subjects with sheet access. Grant sheet access first to configure view permissions.` | `view.noSubjects` | 暂无拥有表访问权限的对象。请先授予表访问权限，再配置视图权限。 |
+| `Bulk apply to all views` | `view.bulkApply` | 批量应用到所有视图 |
+| `None` | `view.state.none` | 无 |
+| `Apply to all views` | `view.applyAll` | 应用到所有视图 |
+| `View permission updated` | `view.status.updated` | 视图权限已更新 |
+| `View permission cleared` | `view.status.cleared` | 视图权限已清除 |
+| `Cleared 1 orphan view override` / `Cleared {n} orphan view overrides` | `view.status.clearedOrphans(n)` | 已清除 {n} 个孤立视图覆盖 |
+| `Applied view permission to {n} views` | `view.status.applied(n)` | 已将视图权限应用到 {n} 个视图 |
+| `Copied view ACL template from source member group` | `view.status.copiedTemplate` | 已从源成员组复制视图 ACL 模板 |
+| `View ACL template already matches source member group` | `view.status.copyTemplateNoop` | 视图 ACL 模板已与源成员组一致 |
+| `Copied downstream field and view ACL from source member group` | `sheet.status.copiedDownstreamAcl` | 已从源成员组复制下游字段和视图 ACL |
+| `Downstream field and view ACL already matches source member group` | `sheet.status.copyDownstreamNoop` | 下游字段和视图 ACL 已与源成员组一致 |
+
+## 7. Component Wiring Plan
+
+Both components should import:
+
+```ts
+import { useLocale } from '../../composables/useLocale'
+import { permissionLabel, ... } from '../utils/meta-permission-labels'
+```
+
+Use:
+
+```ts
+const { isZh } = useLocale()
+const p = (key: MetaPermissionLabelKey) => permissionLabel(key, isZh.value)
+```
+
+Implementation notes:
+
+- Keep raw select option `value` attributes unchanged.
+- Replace display labels only.
+- For `ACCESS_LEVEL_OPTIONS`, replace `label: 'Read'` style objects with computed label helpers, or keep raw values in constants and derive labels at render time.
+- For `fieldPermDraftLabel()` and `viewPermDisplayLabel()`, return localized display labels while preserving the raw `data-access-level` values. The current CSS uses display strings `Hidden` / `Read-only` in `data-access-level`; implementation should change these data attributes to raw state values (`hidden`, `readonly`, `default`) before localizing visible text, or leave them raw if already present. Do not put localized Chinese into styling selectors.
+- `subjectOverrideSummaryLabel()` and orphan-count messages need helper functions because English has singular/plural while zh does not.
+- `cause?.message ?? fallback` should become `cause?.message ?? p('...')`. Do not wrap `cause?.message`.
+- `field.type` and `view.type` badges remain raw in this slice.
+
+## 8. Spec Plan
+
+### 8.1 Existing behavior specs
+
+Current `origin/main` has:
+
+- `apps/web/tests/multitable-record-permission-manager.spec.ts`
+- `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+
+Keep the existing behavior assertions. Add i18n coverage without weakening the behavior tests.
+
+### 8.2 Required i18n matrix
+
+| Case | Required assertions |
+|---|---|
+| Record EN baseline | `useLocale().setLocale('en')`; original English chrome still renders: `Record Permissions`, `Current access`, `Grant`, `Remove`, `Search people, member groups, or roles`. |
+| Record zh chrome | `useLocale().setLocale('zh-CN')`; title, current access, empty/loading, subject badges, access labels, grant/remove/save actions, placeholder, status/fallback errors render in zh. |
+| Record raw preserve | In zh-CN, user names, emails, role names, member-group ids/names, and `subjectId` fallback remain unchanged. |
+| Sheet EN baseline | English default stays stable across sheet / field / view tabs: `Manage Access`, `Sheet Access`, `Field Permissions`, `View Permissions`, `Apply`, `Copy ACL`, `Clear orphan overrides`. |
+| Sheet zh chrome | Sheet tab, candidate section, field tab, view tab, ACL copy, orphan cleanup, and status/fallback errors render in zh. |
+| Sheet raw preserve | In zh-CN, field names, view names, raw `field.type`, raw `view.type`, permission codes/scopes, subject labels, ids, and backend error text remain unchanged. |
+| Data attribute safety | Select values and `data-*` keys remain raw (`read`, `write-own`, `hidden`, `readonly`, `none`, subject ids). Styling selectors must not depend on localized visible text. |
+| Helper unit coverage | `meta-permission-labels.spec.ts` covers all static keys, count helpers for `n=1` and `n=2`, and unknown/raw fallback behavior where applicable. |
+
+### 8.3 Fixture discipline
+
+- Use real component props from the current components; do not invent props.
+- Use existing `createApp + container + app?.unmount() + useLocale().setLocale('en')` pattern from nearby i18n specs.
+- Reuse or extend existing permission manager mock clients so calls still assert the real API shape.
+- Do not add production-only data attrs just for i18n tests. Existing `data-record-permission-*`, `data-sheet-permission-*`, `data-field-permission-*`, and `data-view-permission-*` selectors are enough.
+
+## 9. A11y Boundary
+
+Current inspected permission managers have:
+
+- `placeholder=2`
+- `aria-label=0`
+- `title=0`
+
+This PR localizes the two existing placeholders. It must not add new aria-label/title coverage, new focus behavior, or structural accessibility changes. The close buttons currently render `×` / `&times;` without aria labels; that is an a11y follow-up slice, not T3C-2a.
+
+Verification MD should explicitly state:
+
+```text
+A11y note: no new aria/title structure was introduced. Existing placeholder chrome was localized; close-button aria is deferred to a dedicated a11y slice.
+```
+
+## 10. Implementation Checklist
+
+1. Rebase branch onto latest `origin/main` before writing code.
+2. Add/extend label modules:
+   - new `meta-permission-labels.ts`
+   - only necessary shared action keys in `meta-manager-labels.ts`
+3. Wire `useLocale()` into both permission manager components.
+4. Replace visible chrome and fallback strings; preserve raw values and raw error messages.
+5. Add label helper unit tests.
+6. Add i18n render assertions for record and sheet managers.
+7. Run helper redeclare grep and record it in verification.
+8. Run targeted tests and type-check.
+9. Write verification MD.
+10. Rebase again before push; if PR goes behind during CI, use `git push --force-with-lease`, never plain `--force`.
+
+## 11. Verification Commands
+
+Minimum local matrix:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false \
+  tests/meta-permission-labels.spec.ts \
+  tests/multitable-record-permission-manager.spec.ts \
+  tests/multitable-sheet-permission-manager.spec.ts
+
+pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+If the implementation chooses adjacent i18n spec files instead of extending existing specs, replace the test paths with the actual file names and keep the existing behavior specs in the same run.
+
+## 12. Reviewer Checklist
+
+- The PR does not touch form-share, API-token, automation, backend routes, migrations, or a11y structure.
+- `meta-permission-labels.ts` owns permission-domain copy.
+- Shared action labels are not duplicated across modules.
+- No new `fieldTypeLabel` or field-type label map exists outside `meta-core-labels.ts`.
+- Existing behavior specs still pass.
+- i18n specs cover EN regression, zh-CN chrome, and raw data preservation.
+- Select values, API call arguments, `data-*` identifiers, and persisted enum values remain raw.
+- Verification MD records the current origin/main base, helper-redeclare grep, exact test commands, and a11y deferral.

--- a/docs/development/multitable-t3c2a-permission-managers-i18n-verification-20260520.md
+++ b/docs/development/multitable-t3c2a-permission-managers-i18n-verification-20260520.md
@@ -1,0 +1,134 @@
+# T3C-2a - Permission Managers i18n Verification
+
+- **Date**: 2026-05-20
+- **Branch**: `codex/multitable-t3c2a-permission-i18n-20260520`
+- **Base**: `origin/main@27d82f99b`
+- **Design**: `docs/development/multitable-t3c2a-permission-managers-i18n-design-20260520.md`
+- **Design SHA256**: `a88463acdc2a63125e5ac94fef0814b3a91219fe4917ca5f13aa66ca68ae883d`
+
+## Scope Verified
+
+Implemented:
+
+- New permission chrome label module:
+  - `apps/web/src/multitable/utils/meta-permission-labels.ts`
+- Localized permission manager components:
+  - `apps/web/src/multitable/components/MetaRecordPermissionManager.vue`
+  - `apps/web/src/multitable/components/MetaSheetPermissionManager.vue`
+- Test coverage:
+  - `apps/web/tests/meta-permission-labels.spec.ts`
+  - `apps/web/tests/multitable-record-permission-manager.spec.ts`
+  - `apps/web/tests/multitable-sheet-permission-manager.spec.ts`
+
+Out of scope and not touched:
+
+- `MetaFormShareManager.vue`
+- `MetaApiTokenManager.vue`
+- backend routes, migrations, OpenAPI, automation, K3, approval, attendance runtime
+- new a11y structure or new close-button aria/title coverage
+
+## Design Gates
+
+| Gate | Result |
+|---|---|
+| EN baseline | PASS. Existing English chrome remains the default locale. |
+| zh-CN chrome | PASS. Record, sheet, field, and view permission chrome localizes. |
+| Raw preserve | PASS. Subject names, ids, field names, view names, raw field/view type ids, and ACL values stay raw. |
+| Data-attr safety | PASS. `data-access-level` remains raw. Field permission badges use `hidden` / `readonly` raw values, not localized display text. |
+| Helper redeclare | PASS. No new `fieldTypeLabel`, `accessLevelLabel`, `subjectType*Label`, or field-type map was introduced in the T3C-2a module/components. |
+| Plural fork | PASS. `fieldStatusClearedOrphans` and `viewStatusClearedOrphans` keep the English `count === 1 ? '' : 's'` fork. |
+| A11y boundary | PASS. Existing placeholders were localized; no new aria/title structure was added. |
+
+## M1-Class Trap
+
+The design review pre-caught the CSS-selector binding trap before implementation:
+
+- Before: field permission badge `data-access-level` used display strings such as `Hidden` and `Read-only`.
+- Risk: zh-CN localization could put localized strings into `data-access-level`, breaking CSS selectors.
+- Fix: component now binds `data-access-level` to raw values from `fieldPermDraftValue(...)`; CSS selectors use `hidden` and `readonly`.
+
+This is an M1-class literal-coupled UI trap caught during design, not during implementation review.
+
+## Commands Run
+
+Dependency setup for this isolated worktree:
+
+```bash
+pnpm install --frozen-lockfile --prefer-offline
+```
+
+Result: PASS. Reused local pnpm store, downloaded 0 packages. The install rewrote several tracked plugin/tool `node_modules` shims; those generated verification-environment changes were restored and are not part of this slice.
+
+Targeted tests:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false \
+  tests/meta-permission-labels.spec.ts \
+  tests/multitable-record-permission-manager.spec.ts \
+  tests/multitable-sheet-permission-manager.spec.ts
+```
+
+Result:
+
+```text
+Test Files  3 passed (3)
+Tests       32 passed (32)
+```
+
+Type-check:
+
+```bash
+pnpm --filter @metasheet/web type-check
+```
+
+Result: PASS.
+
+Build:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: PASS.
+
+Note: Vite emitted the existing chunk-size warnings and the existing `WorkflowDesigner.vue` dynamic/static import warning. No T3C-2a-specific build error occurred.
+
+Whitespace:
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+Focused helper/selector grep:
+
+```bash
+rg -n "fieldTypeLabel|function accessLevelLabel|function subjectType.*Label|FIELD_TYPE_LABELS|data-access-level='Hidden'|data-access-level='Read-only'|data-access-level=\"fieldPermDraftLabel" \
+  apps/web/src/multitable/utils/meta-permission-labels.ts \
+  apps/web/src/multitable/components/MetaRecordPermissionManager.vue \
+  apps/web/src/multitable/components/MetaSheetPermissionManager.vue
+```
+
+Result: PASS, no matches.
+
+Shared action placement grep:
+
+```bash
+rg -n "action\\.(save|remove|clear|apply)'" apps/web/src/multitable/utils/meta-permission-labels.ts
+rg -n "action\\.(save|remove|clear|apply)'" apps/web/src/multitable/utils/meta-manager-labels.ts
+```
+
+Result: PASS. `meta-permission-labels.ts` has 0 matches; `meta-manager-labels.ts` owns the four shared manager actions (`save`, `remove`, `clear`, `apply`).
+
+## Test Matrix Detail
+
+| Test file | Added / verified coverage |
+|---|---|
+| `meta-permission-labels.spec.ts` | Static label mapping, access/state display helpers, subject badge helpers, orphan singular/plural helpers, field/view override summary helpers. |
+| `multitable-record-permission-manager.spec.ts` | EN default chrome, zh-CN record chrome, raw user/email/group data preserve, raw `data-access-level`, raw select option values. |
+| `multitable-sheet-permission-manager.spec.ts` | EN default chrome, zh-CN sheet/field/view tabs, raw subject/field/view data preserve, raw `data-access-level`, raw select option values for sheet/field/view ACL states. |
+
+## Final State
+
+The implementation is ready for review/push after a final `git fetch origin && git rebase origin/main` check. If the PR goes `BEHIND` during CI due to parallel i18n merges, update with `git push --force-with-lease`, not plain `--force`.


### PR DESCRIPTION
## Summary

- Localize `MetaRecordPermissionManager` and `MetaSheetPermissionManager` chrome for zh-CN while preserving raw ACL values, subjects, user/group/role labels, field/view names, permission codes, and backend errors.
- Add `meta-permission-labels.ts` for permission-domain copy and tests for static labels, access/state helpers, subject labels, orphan plural helpers, and override summaries.
- Keep shared manager actions (`Save`, `Remove`, `Clear`, `Apply`) in `meta-manager-labels.ts` instead of permission-specific labels, so T3C-2b/T3C-2c can reuse the same action keys without cross-domain imports.
- Add development and verification notes for the T3C-2a permission manager i18n slice.

## Verification

Local checks run after rebasing on latest `origin/main`:

```bash
pnpm --filter @metasheet/web exec vitest run \
  tests/meta-permission-labels.spec.ts \
  tests/multitable-record-permission-manager.spec.ts \
  tests/multitable-sheet-permission-manager.spec.ts \
  --watch=false
# PASS: 33/33

pnpm --filter @metasheet/web exec vue-tsc --noEmit
# PASS

pnpm --filter @metasheet/web build
# PASS

git diff --check origin/main..HEAD
git diff --check origin/main...HEAD
# PASS
```

Additional grep gate:

```bash
rg -n "action\\.(save|remove|clear|apply)'" apps/web/src/multitable/utils/meta-permission-labels.ts
# PASS: 0 exact shared-action matches

rg -n "action\\.(save|remove|clear|apply)'" apps/web/src/multitable/utils/meta-manager-labels.ts
# PASS: manager module owns all 4 shared actions
```

## Scope Guard

- No backend, attendance, K3, API contract, migration, or workbench-home changes.
- Permission persisted values stay raw: `data-access-level` uses raw access values, not translated labels.
- `fieldTypeLabel`, field/view manager helpers, and access-level display helpers are not redeclared in the permission label module.
