### PR TITLE
feat(multitable): localize form-share manager chrome (T3C-2b)

### DIFF
--- a/apps/web/src/multitable/components/MetaFormShareManager.vue
+++ b/apps/web/src/multitable/components/MetaFormShareManager.vue
@@ -2,13 +2,13 @@
   <div v-if="visible" class="meta-form-share__overlay" @click.self="$emit('close')">
     <div class="meta-form-share">
       <div class="meta-form-share__header">
-        <h4 class="meta-form-share__title">Public Form Sharing</h4>
+        <h4 class="meta-form-share__title">{{ f('title') }}</h4>
         <button class="meta-form-share__close" type="button" @click="$emit('close')">&times;</button>
       </div>
 
       <div class="meta-form-share__body">
         <div v-if="error" class="meta-form-share__error" role="alert">{{ error }}</div>
-        <div v-if="loading" class="meta-form-share__empty">Loading share settings&#x2026;</div>
+        <div v-if="loading" class="meta-form-share__empty">{{ f('state.loading') }}</div>
 
         <template v-else>
           <div class="meta-form-share__toggle-row">
@@ -19,7 +19,7 @@
                 data-form-share-toggle="true"
                 @change="onToggleEnabled"
               />
-              <span>{{ config?.enabled ? 'Sharing enabled' : 'Sharing disabled' }}</span>
+              <span>{{ config?.enabled ? f('toggle.enabled') : f('toggle.disabled') }}</span>
             </label>
             <span
               class="meta-form-share__status"
@@ -31,7 +31,7 @@
 
           <template v-if="config?.enabled && config.publicToken">
             <div class="meta-form-share__auth-section">
-              <label class="meta-form-share__label" for="meta-form-share-access-mode">Access mode</label>
+              <label class="meta-form-share__label" for="meta-form-share-access-mode">{{ f('access.label') }}</label>
               <select
                 id="meta-form-share-access-mode"
                 class="meta-form-share__input"
@@ -40,9 +40,9 @@
                 :disabled="busy"
                 @change="onAccessModeChange"
               >
-                <option value="public">Anyone with the link</option>
-                <option value="dingtalk">Bound DingTalk users only</option>
-                <option value="dingtalk_granted">DingTalk-authorized users only</option>
+                <option value="public">{{ f('access.option.public') }}</option>
+                <option value="dingtalk">{{ f('access.option.dingtalk') }}</option>
+                <option value="dingtalk_granted">{{ f('access.option.dingtalkGranted') }}</option>
               </select>
               <p class="meta-form-share__hint">{{ accessModeHint }}</p>
               <div
@@ -59,9 +59,9 @@
             <div v-if="showAllowlistSection" class="meta-form-share__allowlist-section">
               <div class="meta-form-share__allowlist-header">
                 <div>
-                  <label class="meta-form-share__label" for="meta-form-share-allowlist-search">Allowed system users and member groups</label>
+                  <label class="meta-form-share__label" for="meta-form-share-allowlist-search">{{ f('allowlist.label') }}</label>
                   <p class="meta-form-share__hint">
-                    DingTalk is only the sign-in and delivery channel. The allowlist still targets your local users and member groups.
+                    {{ f('allowlist.hint') }}
                   </p>
                   <p
                     class="meta-form-share__allowlist-summary"
@@ -79,13 +79,13 @@
                 v-model.trim="candidateQuery"
                 class="meta-form-share__input"
                 type="search"
-                placeholder="Search local users or member groups"
+                :placeholder="f('allowlist.searchPlaceholder')"
                 data-form-share-allowlist-search="true"
                 :disabled="busy"
               />
 
               <div class="meta-form-share__allowlist-subsection">
-                <label class="meta-form-share__label">Allowed users</label>
+                <label class="meta-form-share__label">{{ f('allowlist.users') }}</label>
                 <div v-if="allowedUsers.length > 0" class="meta-form-share__chip-list">
                   <span
                     v-for="user in allowedUsers"
@@ -96,7 +96,7 @@
                     <span class="meta-form-share__chip-text">
                       {{ user.label }}
                       <span v-if="user.subtitle" class="meta-form-share__chip-subtitle">{{ user.subtitle }}</span>
-                      <span v-if="!user.isActive" class="meta-form-share__chip-subtitle">Inactive user</span>
+                      <span v-if="!user.isActive" class="meta-form-share__chip-subtitle">{{ f('allowlist.inactiveUser') }}</span>
                       <span
                         v-if="subjectDingTalkStatus(user)"
                         class="meta-form-share__chip-subtitle"
@@ -112,17 +112,17 @@
                       :data-form-share-remove-user="user.subjectId"
                       @click="void removeAllowedSubject('user', user.subjectId)"
                     >
-                      Remove
+                      {{ m('action.remove') }}
                     </button>
                   </span>
                 </div>
                 <div v-else class="meta-form-share__empty">
-                  No local user allowlist configured. Access is still gated by the selected DingTalk mode; add local users or member groups to narrow who can fill this form.
+                  {{ f('allowlist.userEmpty') }}
                 </div>
               </div>
 
               <div class="meta-form-share__allowlist-subsection">
-                <label class="meta-form-share__label">Allowed member groups</label>
+                <label class="meta-form-share__label">{{ f('allowlist.groups') }}</label>
                 <div v-if="allowedMemberGroups.length > 0" class="meta-form-share__chip-list">
                   <span
                     v-for="group in allowedMemberGroups"
@@ -148,19 +148,19 @@
                       :data-form-share-remove-group="group.subjectId"
                       @click="void removeAllowedSubject('member-group', group.subjectId)"
                     >
-                      Remove
+                      {{ m('action.remove') }}
                     </button>
                   </span>
                 </div>
                 <div v-else class="meta-form-share__empty">
-                  No local member-group allowlist configured. Add a local member group to let its members fill this form.
+                  {{ f('allowlist.groupEmpty') }}
                 </div>
               </div>
 
               <div class="meta-form-share__allowlist-subsection">
-                <label class="meta-form-share__label">Add from eligible people and groups</label>
-                <div v-if="candidatesLoading" class="meta-form-share__empty">Searching users and member groups&#x2026;</div>
-                <div v-else-if="filteredCandidates.length === 0" class="meta-form-share__empty">No matching candidates.</div>
+                <label class="meta-form-share__label">{{ f('candidate.addSection') }}</label>
+                <div v-if="candidatesLoading" class="meta-form-share__empty">{{ f('candidate.loading') }}</div>
+                <div v-else-if="filteredCandidates.length === 0" class="meta-form-share__empty">{{ f('candidate.empty') }}</div>
                 <div v-else class="meta-form-share__candidate-list">
                   <button
                     v-for="candidate in filteredCandidates"
@@ -174,7 +174,7 @@
                     <span class="meta-form-share__candidate-title">
                       {{ candidate.label }}
                       <span class="meta-form-share__candidate-badge">
-                        {{ candidate.subjectType === 'user' ? 'User' : 'Member group' }}
+                        {{ candidate.subjectType === 'user' ? f('candidate.user') : f('candidate.memberGroup') }}
                       </span>
                     </span>
                     <span v-if="candidate.subtitle" class="meta-form-share__candidate-subtitle">{{ candidate.subtitle }}</span>
@@ -186,7 +186,7 @@
                       {{ subjectDingTalkStatus(candidate) }}
                     </span>
                     <span v-if="candidate.subjectType === 'user' && !candidate.isActive" class="meta-form-share__candidate-subtitle">
-                      Inactive users cannot be added
+                      {{ f('candidate.inactiveUser') }}
                     </span>
                   </button>
                 </div>
@@ -194,7 +194,7 @@
             </div>
 
             <div class="meta-form-share__link-section">
-              <label class="meta-form-share__label">Public link</label>
+              <label class="meta-form-share__label">{{ f('link.label') }}</label>
               <div class="meta-form-share__link-row">
                 <input
                   class="meta-form-share__input"
@@ -209,7 +209,7 @@
                   data-form-share-copy="true"
                   @click="onCopyLink"
                 >
-                  {{ copied ? 'Copied!' : 'Copy' }}
+                  {{ copied ? f('link.copied') : f('link.copy') }}
                 </button>
               </div>
             </div>
@@ -222,7 +222,7 @@
                 :disabled="busy"
                 @click="onRegenerate"
               >
-                Regenerate token
+                {{ f('link.regenerate') }}
               </button>
               <button
                 class="meta-form-share__btn"
@@ -230,12 +230,12 @@
                 data-form-share-preview="true"
                 @click="onPreview"
               >
-                Preview
+                {{ f('link.preview') }}
               </button>
             </div>
 
             <div class="meta-form-share__expiry-section">
-              <label class="meta-form-share__label">Expiry</label>
+              <label class="meta-form-share__label">{{ f('expiry.label') }}</label>
               <div class="meta-form-share__expiry-row">
                 <input
                   class="meta-form-share__input"
@@ -252,7 +252,7 @@
                   :disabled="busy"
                   @click="onClearExpiry"
                 >
-                  No expiry
+                  {{ f('expiry.none') }}
                 </button>
               </div>
             </div>
@@ -265,8 +265,19 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type { FormShareConfig, MetaSheetPermissionCandidate } from '../types'
 import type { MultitableApiClient } from '../api/client'
+import { managerLabel, type MetaManagerLabelKey } from '../utils/meta-manager-labels'
+import {
+  formShareAccessModeHint,
+  formShareAllowlistSummary,
+  formShareAudienceRule,
+  formShareDingTalkStatusLabel,
+  formShareLabel,
+  formShareStatusLabel,
+  type MetaFormShareLabelKey,
+} from '../utils/meta-form-share-labels'
 
 const props = defineProps<{
   sheetId: string
@@ -289,15 +300,18 @@ const candidateQuery = ref('')
 const candidates = ref<MetaSheetPermissionCandidate[]>([])
 const candidatesLoading = ref(false)
 let candidateTimer: number | null = null
+const { isZh } = useLocale()
+
+function f(key: MetaFormShareLabelKey): string {
+  return formShareLabel(key, isZh.value)
+}
+
+function m(key: MetaManagerLabelKey): string {
+  return managerLabel(key, isZh.value)
+}
 
 const statusLabel = computed(() => {
-  if (!config.value) return 'Disabled'
-  switch (config.value.status) {
-    case 'active': return 'Active'
-    case 'expired': return 'Expired'
-    case 'disabled': return 'Disabled'
-    default: return 'Disabled'
-  }
+  return formShareStatusLabel(config.value?.status, isZh.value)
 })
 
 const publicLink = computed(() => {
@@ -316,13 +330,7 @@ const showAllowlistSection = computed(() =>
 )
 
 const accessModeHint = computed(() => {
-  if (config.value?.accessMode === 'dingtalk_granted') {
-    return 'The form opens only for DingTalk-bound users whose DingTalk grant is enabled by an administrator.'
-  }
-  if (config.value?.accessMode === 'dingtalk') {
-    return 'The form opens only after DingTalk sign-in, and the user must already be bound to a local account.'
-  }
-  return 'Anyone who has the link can open and submit this form.'
+  return formShareAccessModeHint(config.value?.accessMode, isZh.value)
 })
 
 const allowedUsers = computed(() => config.value?.allowedUsers ?? [])
@@ -332,48 +340,10 @@ const allowedMemberGroupCount = computed(() => config.value?.allowedMemberGroupI
 const hasLocalAllowlist = computed(() => allowedUserCount.value > 0 || allowedMemberGroupCount.value > 0)
 const audienceRule = computed(() => {
   const mode = config.value?.accessMode ?? 'public'
-  if (mode === 'public') {
-    return {
-      title: 'Fully public anonymous form',
-      description: 'Anyone with the link can open and submit without local login or DingTalk binding.',
-    }
-  }
-  if (mode === 'dingtalk_granted') {
-    return hasLocalAllowlist.value
-      ? {
-          title: 'Selected authorized DingTalk users',
-          description: 'Only selected local users or group members can fill, and each user must be DingTalk-bound with form authorization enabled.',
-        }
-      : {
-          title: 'All authorized DingTalk users',
-          description: 'Any DingTalk-bound local user can fill after an administrator enables their DingTalk form authorization.',
-        }
-  }
-  return hasLocalAllowlist.value
-    ? {
-        title: 'Selected DingTalk-bound users',
-        description: 'Only selected local users or group members can fill, and each user must be bound to DingTalk.',
-      }
-    : {
-        title: 'All DingTalk-bound users',
-        description: 'Any local user can fill after DingTalk sign-in when their account is bound to DingTalk.',
-      }
+  return formShareAudienceRule(mode, hasLocalAllowlist.value, isZh.value)
 })
 const allowlistAudienceSummary = computed(() => {
-  const userCount = allowedUserCount.value
-  const memberGroupCount = allowedMemberGroupCount.value
-  if (userCount === 0 && memberGroupCount === 0) {
-    return 'No local allowlist limits are set; all users allowed by the selected DingTalk mode can fill this form.'
-  }
-
-  const parts: string[] = []
-  if (userCount > 0) {
-    parts.push(`${userCount} ${userCount === 1 ? 'local user' : 'local users'}`)
-  }
-  if (memberGroupCount > 0) {
-    parts.push(`${memberGroupCount} ${memberGroupCount === 1 ? 'local member group' : 'local member groups'}`)
-  }
-  return `Local allowlist limits: ${parts.join(' and ')} can fill after passing the selected DingTalk mode.`
+  return formShareAllowlistSummary(allowedUserCount.value, allowedMemberGroupCount.value, isZh.value)
 })
 const selectedSubjectKeys = computed(() => new Set([
   ...allowedUsers.value.map((user) => `user:${user.subjectId}`),
@@ -387,17 +357,7 @@ function subjectDingTalkStatus(
   subject: Pick<MetaSheetPermissionCandidate, 'subjectType' | 'dingtalkBound' | 'dingtalkGrantEnabled' | 'dingtalkPersonDeliveryAvailable'>,
 ): string {
   const mode = config.value?.accessMode ?? 'public'
-  if (mode === 'public') return ''
-  if (subject.subjectType === 'member-group') return 'Members are checked individually'
-  if (subject.subjectType !== 'user') return ''
-  if (subject.dingtalkBound === false) return 'DingTalk not bound'
-  if (mode === 'dingtalk_granted') {
-    if (subject.dingtalkGrantEnabled === true) return 'DingTalk bound and authorized'
-    if (subject.dingtalkBound === true && subject.dingtalkGrantEnabled === false) return 'DingTalk authorization not enabled'
-  }
-  if (subject.dingtalkBound === true) return 'DingTalk bound'
-  if (subject.dingtalkPersonDeliveryAvailable === true) return 'DingTalk delivery linked'
-  return ''
+  return formShareDingTalkStatusLabel(subject, mode, isZh.value)
 }
 
 async function loadConfig() {
@@ -407,7 +367,7 @@ async function loadConfig() {
   try {
     config.value = await props.client.getFormShareConfig(props.sheetId, props.viewId)
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to load share config'
+    error.value = err instanceof Error ? err.message : f('error.loadConfig')
   } finally {
     loading.value = false
   }
@@ -426,7 +386,7 @@ async function loadCandidates() {
     })
     candidates.value = response.items
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to load allowlist candidates'
+    error.value = err instanceof Error ? err.message : f('error.loadCandidates')
   } finally {
     candidatesLoading.value = false
   }
@@ -448,7 +408,7 @@ async function persistAllowlist(update: Pick<FormShareConfig, 'allowedUserIds' |
     emit('updated')
     await loadCandidates()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to update allowlist'
+    error.value = err instanceof Error ? err.message : f('error.updateAllowlist')
   } finally {
     busy.value = false
   }
@@ -494,7 +454,7 @@ async function onToggleEnabled() {
     })
     emit('updated')
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to update'
+    error.value = err instanceof Error ? err.message : f('error.update')
   } finally {
     busy.value = false
   }
@@ -508,7 +468,7 @@ async function onAccessModeChange(event: Event) {
     select.value === 'public'
     && (config.value.allowedUserIds.length > 0 || config.value.allowedMemberGroupIds.length > 0)
   ) {
-    error.value = 'Clear the allowed users and member groups before switching back to a fully public form.'
+    error.value = f('error.clearBeforePublic')
     select.value = config.value.accessMode
     return
   }
@@ -521,7 +481,7 @@ async function onAccessModeChange(event: Event) {
     emit('updated')
     await loadCandidates()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to update access mode'
+    error.value = err instanceof Error ? err.message : f('error.updateAccessMode')
   } finally {
     busy.value = false
   }
@@ -538,7 +498,7 @@ async function onRegenerate() {
     }
     emit('updated')
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to regenerate token'
+    error.value = err instanceof Error ? err.message : f('error.regenerate')
   } finally {
     busy.value = false
   }
@@ -569,7 +529,7 @@ async function onExpiryChange(event: Event) {
     })
     emit('updated')
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to update expiry'
+    error.value = err instanceof Error ? err.message : f('error.updateExpiry')
   } finally {
     busy.value = false
   }
@@ -585,7 +545,7 @@ async function onClearExpiry() {
     })
     emit('updated')
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to clear expiry'
+    error.value = err instanceof Error ? err.message : f('error.clearExpiry')
   } finally {
     busy.value = false
   }

--- a/apps/web/src/multitable/utils/meta-form-share-labels.ts
+++ b/apps/web/src/multitable/utils/meta-form-share-labels.ts
@@ -1,0 +1,276 @@
+// Form-share manager chrome string table (T3C-2b).
+//
+// Scope: MetaFormShareManager.vue. User/group names, subtitles, public token
+// values, backend error messages, and persisted access-mode values stay raw.
+
+export type MetaFormShareLabelKey =
+  | 'title'
+  | 'state.loading'
+  | 'toggle.enabled'
+  | 'toggle.disabled'
+  | 'status.active'
+  | 'status.expired'
+  | 'status.disabled'
+  | 'access.label'
+  | 'access.option.public'
+  | 'access.option.dingtalk'
+  | 'access.option.dingtalkGranted'
+  | 'access.hint.public'
+  | 'access.hint.dingtalk'
+  | 'access.hint.dingtalkGranted'
+  | 'audience.public.title'
+  | 'audience.public.description'
+  | 'audience.dingtalk.selected.title'
+  | 'audience.dingtalk.selected.description'
+  | 'audience.dingtalk.all.title'
+  | 'audience.dingtalk.all.description'
+  | 'audience.granted.selected.title'
+  | 'audience.granted.selected.description'
+  | 'audience.granted.all.title'
+  | 'audience.granted.all.description'
+  | 'allowlist.label'
+  | 'allowlist.hint'
+  | 'allowlist.summary.none'
+  | 'allowlist.summary.prefix'
+  | 'allowlist.summary.suffix'
+  | 'allowlist.localUser'
+  | 'allowlist.localUsers'
+  | 'allowlist.localMemberGroup'
+  | 'allowlist.localMemberGroups'
+  | 'allowlist.join'
+  | 'allowlist.searchPlaceholder'
+  | 'allowlist.users'
+  | 'allowlist.groups'
+  | 'allowlist.inactiveUser'
+  | 'allowlist.userEmpty'
+  | 'allowlist.groupEmpty'
+  | 'candidate.addSection'
+  | 'candidate.loading'
+  | 'candidate.empty'
+  | 'candidate.user'
+  | 'candidate.memberGroup'
+  | 'candidate.inactiveUser'
+  | 'dingtalk.memberGroup'
+  | 'dingtalk.notBound'
+  | 'dingtalk.boundAuthorized'
+  | 'dingtalk.authorizationMissing'
+  | 'dingtalk.bound'
+  | 'dingtalk.deliveryLinked'
+  | 'link.label'
+  | 'link.copy'
+  | 'link.copied'
+  | 'link.regenerate'
+  | 'link.preview'
+  | 'expiry.label'
+  | 'expiry.none'
+  | 'error.loadConfig'
+  | 'error.loadCandidates'
+  | 'error.updateAllowlist'
+  | 'error.update'
+  | 'error.clearBeforePublic'
+  | 'error.updateAccessMode'
+  | 'error.regenerate'
+  | 'error.updateExpiry'
+  | 'error.clearExpiry'
+
+const LABELS: Record<MetaFormShareLabelKey, { en: string; zh: string }> = {
+  title: { en: 'Public Form Sharing', zh: '公开表单分享' },
+  'state.loading': { en: 'Loading share settings...', zh: '正在加载分享设置...' },
+  'toggle.enabled': { en: 'Sharing enabled', zh: '分享已启用' },
+  'toggle.disabled': { en: 'Sharing disabled', zh: '分享已停用' },
+  'status.active': { en: 'Active', zh: '有效' },
+  'status.expired': { en: 'Expired', zh: '已过期' },
+  'status.disabled': { en: 'Disabled', zh: '已停用' },
+  'access.label': { en: 'Access mode', zh: '访问模式' },
+  'access.option.public': { en: 'Anyone with the link', zh: '持有链接的任何人' },
+  'access.option.dingtalk': { en: 'Bound DingTalk users only', zh: '仅已绑定钉钉用户' },
+  'access.option.dingtalkGranted': { en: 'DingTalk-authorized users only', zh: '仅已授权钉钉用户' },
+  'access.hint.public': { en: 'Anyone who has the link can open and submit this form.', zh: '持有链接的人都可以打开并提交此表单。' },
+  'access.hint.dingtalk': {
+    en: 'The form opens only after DingTalk sign-in, and the user must already be bound to a local account.',
+    zh: '用户需先钉钉登录，且本地账户已绑定钉钉后才能打开此表单。',
+  },
+  'access.hint.dingtalkGranted': {
+    en: 'The form opens only for DingTalk-bound users whose DingTalk grant is enabled by an administrator.',
+    zh: '仅允许已绑定钉钉且管理员已启用钉钉授权的用户打开此表单。',
+  },
+  'audience.public.title': { en: 'Fully public anonymous form', zh: '完全公开匿名表单' },
+  'audience.public.description': {
+    en: 'Anyone with the link can open and submit without local login or DingTalk binding.',
+    zh: '任何持有链接的人无需本地登录或钉钉绑定即可打开并提交。',
+  },
+  'audience.dingtalk.selected.title': { en: 'Selected DingTalk-bound users', zh: '已选已绑定钉钉用户' },
+  'audience.dingtalk.selected.description': {
+    en: 'Only selected local users or group members can fill, and each user must be bound to DingTalk.',
+    zh: '只有已选本地用户或组成员可以填写，且每个用户必须已绑定钉钉。',
+  },
+  'audience.dingtalk.all.title': { en: 'All DingTalk-bound users', zh: '全部已绑定钉钉用户' },
+  'audience.dingtalk.all.description': {
+    en: 'Any local user can fill after DingTalk sign-in when their account is bound to DingTalk.',
+    zh: '任意本地用户在钉钉登录且账户已绑定钉钉后即可填写。',
+  },
+  'audience.granted.selected.title': { en: 'Selected authorized DingTalk users', zh: '已选授权钉钉用户' },
+  'audience.granted.selected.description': {
+    en: 'Only selected local users or group members can fill, and each user must be DingTalk-bound with form authorization enabled.',
+    zh: '只有已选本地用户或组成员可以填写，且每个用户必须已绑定钉钉并启用表单授权。',
+  },
+  'audience.granted.all.title': { en: 'All authorized DingTalk users', zh: '全部授权钉钉用户' },
+  'audience.granted.all.description': {
+    en: 'Any DingTalk-bound local user can fill after an administrator enables their DingTalk form authorization.',
+    zh: '任意已绑定钉钉的本地用户，在管理员启用其钉钉表单授权后即可填写。',
+  },
+  'allowlist.label': { en: 'Allowed system users and member groups', zh: '允许的系统用户和成员组' },
+  'allowlist.hint': {
+    en: 'DingTalk is only the sign-in and delivery channel. The allowlist still targets your local users and member groups.',
+    zh: '钉钉仅用于登录和投递通道；允许名单仍以本地用户和成员组为准。',
+  },
+  'allowlist.summary.none': {
+    en: 'No local allowlist limits are set; all users allowed by the selected DingTalk mode can fill this form.',
+    zh: '未设置本地允许名单限制；所有通过当前钉钉模式的用户都可以填写此表单。',
+  },
+  'allowlist.summary.prefix': { en: 'Local allowlist limits:', zh: '本地允许名单限制：' },
+  'allowlist.summary.suffix': { en: 'can fill after passing the selected DingTalk mode.', zh: '通过当前钉钉模式后可以填写此表单。' },
+  'allowlist.localUser': { en: 'local user', zh: '个本地用户' },
+  'allowlist.localUsers': { en: 'local users', zh: '个本地用户' },
+  'allowlist.localMemberGroup': { en: 'local member group', zh: '个本地成员组' },
+  'allowlist.localMemberGroups': { en: 'local member groups', zh: '个本地成员组' },
+  'allowlist.join': { en: ' and ', zh: '和 ' },
+  'allowlist.searchPlaceholder': { en: 'Search local users or member groups', zh: '搜索本地用户或成员组' },
+  'allowlist.users': { en: 'Allowed users', zh: '允许的用户' },
+  'allowlist.groups': { en: 'Allowed member groups', zh: '允许的成员组' },
+  'allowlist.inactiveUser': { en: 'Inactive user', zh: '已停用用户' },
+  'allowlist.userEmpty': {
+    en: 'No local user allowlist configured. Access is still gated by the selected DingTalk mode; add local users or member groups to narrow who can fill this form.',
+    zh: '未配置本地用户允许名单。访问仍受当前钉钉模式限制；可添加本地用户或成员组来缩小可填写范围。',
+  },
+  'allowlist.groupEmpty': {
+    en: 'No local member-group allowlist configured. Add a local member group to let its members fill this form.',
+    zh: '未配置本地成员组允许名单。添加本地成员组后，其成员即可填写此表单。',
+  },
+  'candidate.addSection': { en: 'Add from eligible people and groups', zh: '从可添加人员和组中选择' },
+  'candidate.loading': { en: 'Searching users and member groups...', zh: '正在搜索用户和成员组...' },
+  'candidate.empty': { en: 'No matching candidates.', zh: '没有匹配的候选项。' },
+  'candidate.user': { en: 'User', zh: '用户' },
+  'candidate.memberGroup': { en: 'Member group', zh: '成员组' },
+  'candidate.inactiveUser': { en: 'Inactive users cannot be added', zh: '已停用用户不能添加' },
+  'dingtalk.memberGroup': { en: 'Members are checked individually', zh: '成员会逐个校验' },
+  'dingtalk.notBound': { en: 'DingTalk not bound', zh: '未绑定钉钉' },
+  'dingtalk.boundAuthorized': { en: 'DingTalk bound and authorized', zh: '已绑定钉钉并已授权' },
+  'dingtalk.authorizationMissing': { en: 'DingTalk authorization not enabled', zh: '未启用钉钉授权' },
+  'dingtalk.bound': { en: 'DingTalk bound', zh: '已绑定钉钉' },
+  'dingtalk.deliveryLinked': { en: 'DingTalk delivery linked', zh: '已关联钉钉投递' },
+  'link.label': { en: 'Public link', zh: '公开链接' },
+  'link.copy': { en: 'Copy', zh: '复制' },
+  'link.copied': { en: 'Copied!', zh: '已复制！' },
+  'link.regenerate': { en: 'Regenerate token', zh: '重新生成令牌' },
+  'link.preview': { en: 'Preview', zh: '预览' },
+  'expiry.label': { en: 'Expiry', zh: '过期时间' },
+  'expiry.none': { en: 'No expiry', zh: '无过期时间' },
+  'error.loadConfig': { en: 'Failed to load share config', zh: '加载分享配置失败' },
+  'error.loadCandidates': { en: 'Failed to load allowlist candidates', zh: '加载允许名单候选项失败' },
+  'error.updateAllowlist': { en: 'Failed to update allowlist', zh: '更新允许名单失败' },
+  'error.update': { en: 'Failed to update', zh: '更新失败' },
+  'error.clearBeforePublic': {
+    en: 'Clear the allowed users and member groups before switching back to a fully public form.',
+    zh: '切换回完全公开表单前，请先清除允许的用户和成员组。',
+  },
+  'error.updateAccessMode': { en: 'Failed to update access mode', zh: '更新访问模式失败' },
+  'error.regenerate': { en: 'Failed to regenerate token', zh: '重新生成令牌失败' },
+  'error.updateExpiry': { en: 'Failed to update expiry', zh: '更新过期时间失败' },
+  'error.clearExpiry': { en: 'Failed to clear expiry', zh: '清除过期时间失败' },
+}
+
+export function formShareLabel(key: MetaFormShareLabelKey, isZh: boolean): string {
+  const entry = LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+export function formShareStatusLabel(status: string | undefined, isZh: boolean): string {
+  if (status === 'active') return formShareLabel('status.active', isZh)
+  if (status === 'expired') return formShareLabel('status.expired', isZh)
+  return formShareLabel('status.disabled', isZh)
+}
+
+export function formShareAccessModeHint(mode: string | undefined, isZh: boolean): string {
+  if (mode === 'dingtalk_granted') return formShareLabel('access.hint.dingtalkGranted', isZh)
+  if (mode === 'dingtalk') return formShareLabel('access.hint.dingtalk', isZh)
+  return formShareLabel('access.hint.public', isZh)
+}
+
+export function formShareAudienceRule(
+  mode: string | undefined,
+  hasLocalAllowlist: boolean,
+  isZh: boolean,
+): { title: string; description: string } {
+  if (mode === 'dingtalk_granted') {
+    return hasLocalAllowlist
+      ? {
+          title: formShareLabel('audience.granted.selected.title', isZh),
+          description: formShareLabel('audience.granted.selected.description', isZh),
+        }
+      : {
+          title: formShareLabel('audience.granted.all.title', isZh),
+          description: formShareLabel('audience.granted.all.description', isZh),
+        }
+  }
+  if (mode === 'dingtalk') {
+    return hasLocalAllowlist
+      ? {
+          title: formShareLabel('audience.dingtalk.selected.title', isZh),
+          description: formShareLabel('audience.dingtalk.selected.description', isZh),
+        }
+      : {
+          title: formShareLabel('audience.dingtalk.all.title', isZh),
+          description: formShareLabel('audience.dingtalk.all.description', isZh),
+        }
+  }
+  return {
+    title: formShareLabel('audience.public.title', isZh),
+    description: formShareLabel('audience.public.description', isZh),
+  }
+}
+
+export function formShareAllowlistSummary(userCount: number, memberGroupCount: number, isZh: boolean): string {
+  if (userCount === 0 && memberGroupCount === 0) {
+    return formShareLabel('allowlist.summary.none', isZh)
+  }
+
+  const parts: string[] = []
+  if (userCount > 0) {
+    parts.push(`${userCount} ${formShareLabel(userCount === 1 ? 'allowlist.localUser' : 'allowlist.localUsers', isZh)}`)
+  }
+  if (memberGroupCount > 0) {
+    parts.push(`${memberGroupCount} ${formShareLabel(memberGroupCount === 1 ? 'allowlist.localMemberGroup' : 'allowlist.localMemberGroups', isZh)}`)
+  }
+
+  const prefix = formShareLabel('allowlist.summary.prefix', isZh)
+  const suffix = formShareLabel('allowlist.summary.suffix', isZh)
+  return isZh
+    ? `${prefix}${parts.join(formShareLabel('allowlist.join', isZh))}${suffix}`
+    : `${prefix} ${parts.join(formShareLabel('allowlist.join', isZh))} ${suffix}`
+}
+
+export function formShareDingTalkStatusLabel(
+  subject: {
+    subjectType?: string
+    dingtalkBound?: boolean | null
+    dingtalkGrantEnabled?: boolean | null
+    dingtalkPersonDeliveryAvailable?: boolean | null
+  },
+  mode: string | undefined,
+  isZh: boolean,
+): string {
+  if (mode === 'public') return ''
+  if (subject.subjectType === 'member-group') return formShareLabel('dingtalk.memberGroup', isZh)
+  if (subject.subjectType !== 'user') return ''
+  if (subject.dingtalkBound === false) return formShareLabel('dingtalk.notBound', isZh)
+  if (mode === 'dingtalk_granted') {
+    if (subject.dingtalkGrantEnabled === true) return formShareLabel('dingtalk.boundAuthorized', isZh)
+    if (subject.dingtalkBound === true && subject.dingtalkGrantEnabled === false) {
+      return formShareLabel('dingtalk.authorizationMissing', isZh)
+    }
+  }
+  if (subject.dingtalkBound === true) return formShareLabel('dingtalk.bound', isZh)
+  if (subject.dingtalkPersonDeliveryAvailable === true) return formShareLabel('dingtalk.deliveryLinked', isZh)
+  return ''
+}

--- a/apps/web/tests/meta-form-share-labels.spec.ts
+++ b/apps/web/tests/meta-form-share-labels.spec.ts
@@ -1,0 +1,60 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formShareAccessModeHint,
+  formShareAllowlistSummary,
+  formShareAudienceRule,
+  formShareDingTalkStatusLabel,
+  formShareLabel,
+  formShareStatusLabel,
+} from '../src/multitable/utils/meta-form-share-labels'
+
+describe('meta-form-share-labels', () => {
+  it('maps static form-share chrome in English and zh-CN', () => {
+    expect(formShareLabel('title', false)).toBe('Public Form Sharing')
+    expect(formShareLabel('title', true)).toBe('公开表单分享')
+    expect(formShareLabel('access.option.dingtalkGranted', false)).toBe('DingTalk-authorized users only')
+    expect(formShareLabel('access.option.dingtalkGranted', true)).toBe('仅已授权钉钉用户')
+    expect(formShareLabel('link.regenerate', true)).toBe('重新生成令牌')
+    expect(formShareLabel('error.clearBeforePublic', true)).toBe('切换回完全公开表单前，请先清除允许的用户和成员组。')
+  })
+
+  it('formats status and access-mode helper text', () => {
+    expect(formShareStatusLabel('active', true)).toBe('有效')
+    expect(formShareStatusLabel('expired', true)).toBe('已过期')
+    expect(formShareStatusLabel('disabled', false)).toBe('Disabled')
+    expect(formShareAccessModeHint('public', true)).toBe('持有链接的人都可以打开并提交此表单。')
+    expect(formShareAccessModeHint('dingtalk', true)).toContain('钉钉登录')
+    expect(formShareAccessModeHint('dingtalk_granted', true)).toContain('钉钉授权')
+  })
+
+  it('formats audience rules for all access-mode combinations', () => {
+    expect(formShareAudienceRule('public', false, false).title).toBe('Fully public anonymous form')
+    expect(formShareAudienceRule('public', false, true).title).toBe('完全公开匿名表单')
+    expect(formShareAudienceRule('dingtalk', false, true).title).toBe('全部已绑定钉钉用户')
+    expect(formShareAudienceRule('dingtalk', true, true).title).toBe('已选已绑定钉钉用户')
+    expect(formShareAudienceRule('dingtalk_granted', false, true).title).toBe('全部授权钉钉用户')
+    expect(formShareAudienceRule('dingtalk_granted', true, true).title).toBe('已选授权钉钉用户')
+  })
+
+  it('formats allowlist summaries with English plural forks and zh neutral counts', () => {
+    expect(formShareAllowlistSummary(0, 0, false)).toBe(
+      'No local allowlist limits are set; all users allowed by the selected DingTalk mode can fill this form.',
+    )
+    expect(formShareAllowlistSummary(1, 2, false)).toBe(
+      'Local allowlist limits: 1 local user and 2 local member groups can fill after passing the selected DingTalk mode.',
+    )
+    expect(formShareAllowlistSummary(2, 1, true)).toBe(
+      '本地允许名单限制：2 个本地用户和 1 个本地成员组通过当前钉钉模式后可以填写此表单。',
+    )
+  })
+
+  it('formats DingTalk status labels without touching public-mode subjects', () => {
+    expect(formShareDingTalkStatusLabel({ subjectType: 'member-group' }, 'dingtalk', true)).toBe('成员会逐个校验')
+    expect(formShareDingTalkStatusLabel({ subjectType: 'user', dingtalkBound: false }, 'dingtalk', true)).toBe('未绑定钉钉')
+    expect(formShareDingTalkStatusLabel({ subjectType: 'user', dingtalkBound: true }, 'dingtalk', true)).toBe('已绑定钉钉')
+    expect(formShareDingTalkStatusLabel({ subjectType: 'user', dingtalkBound: true, dingtalkGrantEnabled: true }, 'dingtalk_granted', true)).toBe('已绑定钉钉并已授权')
+    expect(formShareDingTalkStatusLabel({ subjectType: 'user', dingtalkBound: true, dingtalkGrantEnabled: false }, 'dingtalk_granted', true)).toBe('未启用钉钉授权')
+    expect(formShareDingTalkStatusLabel({ subjectType: 'user', dingtalkPersonDeliveryAvailable: true }, 'dingtalk', true)).toBe('已关联钉钉投递')
+    expect(formShareDingTalkStatusLabel({ subjectType: 'user', dingtalkBound: true }, 'public', true)).toBe('')
+  })
+})

--- a/apps/web/tests/multitable-form-share-manager.spec.ts
+++ b/apps/web/tests/multitable-form-share-manager.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
 
 async function flushPromises() {
@@ -10,6 +10,7 @@ async function flushPromises() {
 
 import MetaFormShareManager from '../src/multitable/components/MetaFormShareManager.vue'
 import { MultitableApiClient } from '../src/multitable/api/client'
+import { useLocale } from '../src/composables/useLocale'
 
 function fakeConfig(overrides: Record<string, unknown> = {}) {
   return {
@@ -68,9 +69,14 @@ function mount(props: Record<string, unknown>) {
 }
 
 describe('MetaFormShareManager', () => {
+  beforeEach(() => {
+    useLocale().setLocale('en')
+  })
+
   afterEach(() => {
     document.body.innerHTML = ''
     vi.restoreAllMocks()
+    useLocale().setLocale('en')
   })
 
   it('renders share config when visible', async () => {
@@ -371,6 +377,51 @@ describe('MetaFormShareManager', () => {
     expect(statuses).toContain('DingTalk authorization not enabled')
     expect(statuses).toContain('DingTalk not bound')
     expect(statuses).toContain('Members are checked individually')
+  })
+
+  it('localizes form-share chrome to zh-CN without translating raw subjects', async () => {
+    useLocale().setLocale('zh-CN')
+    const { client } = mockClient(fakeConfig({
+      accessMode: 'dingtalk_granted',
+      allowedUserIds: ['user_authorized', 'user_needs_grant'],
+      allowedUsers: [
+        { subjectType: 'user', subjectId: 'user_authorized', label: 'Authorized User', subtitle: 'authorized@test.local', isActive: true, dingtalkBound: true, dingtalkGrantEnabled: true, dingtalkPersonDeliveryAvailable: true },
+        { subjectType: 'user', subjectId: 'user_needs_grant', label: 'Needs Grant', subtitle: 'needs-grant@test.local', isActive: true, dingtalkBound: true, dingtalkGrantEnabled: false, dingtalkPersonDeliveryAvailable: true },
+      ],
+      allowedMemberGroupIds: ['group_ops'],
+      allowedMemberGroups: [{ subjectType: 'member-group', subjectId: 'group_ops', label: 'Ops', subtitle: 'Operations', isActive: true }],
+    }))
+    mount({ visible: true, sheetId: 'sh_1', viewId: 'v_1', client })
+    await flushPromises()
+
+    const search = document.querySelector('[data-form-share-allowlist-search]') as HTMLInputElement
+    const audience = document.querySelector('[data-form-share-audience-rule]') as HTMLElement
+    const removeButtons = Array.from(document.querySelectorAll('[data-form-share-remove-user], [data-form-share-remove-group]'))
+
+    expect(document.body.textContent).toContain('公开表单分享')
+    expect(document.body.textContent).toContain('分享已启用')
+    expect(document.body.textContent).toContain('有效')
+    expect(document.body.textContent).toContain('访问模式')
+    expect(document.body.textContent).toContain('仅已授权钉钉用户')
+    expect(document.body.textContent).toContain('仅允许已绑定钉钉且管理员已启用钉钉授权的用户打开此表单。')
+    expect(audience.textContent).toContain('已选授权钉钉用户')
+    expect(audience.textContent).toContain('只有已选本地用户或组成员可以填写，且每个用户必须已绑定钉钉并启用表单授权。')
+    expect(document.body.textContent).toContain('钉钉仅用于登录和投递通道；允许名单仍以本地用户和成员组为准。')
+    expect(document.body.textContent).toContain('本地允许名单限制：2 个本地用户和 1 个本地成员组通过当前钉钉模式后可以填写此表单。')
+    expect(search.placeholder).toBe('搜索本地用户或成员组')
+    expect(document.body.textContent).toContain('允许的用户')
+    expect(document.body.textContent).toContain('允许的成员组')
+    expect(document.body.textContent).toContain('已绑定钉钉并已授权')
+    expect(document.body.textContent).toContain('未启用钉钉授权')
+    expect(document.body.textContent).toContain('成员会逐个校验')
+    expect(document.body.textContent).toContain('公开链接')
+    expect(document.body.textContent).toContain('复制')
+    expect(document.body.textContent).toContain('重新生成令牌')
+    expect(document.body.textContent).toContain('预览')
+    expect(document.body.textContent).toContain('过期时间')
+    expect(removeButtons.every((button) => button.textContent?.trim() === '移除')).toBe(true)
+    expect(document.body.textContent).toContain('Authorized User')
+    expect(document.body.textContent).toContain('Ops')
   })
 
   it('adds an allowed user through the allowlist controls', async () => {

--- a/docs/development/multitable-t3c2b-form-share-i18n-design-20260520.md
+++ b/docs/development/multitable-t3c2b-form-share-i18n-design-20260520.md
@@ -1,0 +1,91 @@
+# T3C-2b Form Share Manager i18n Design
+
+Date: 2026-05-20
+Branch: `codex/multitable-t3c2b-form-share-i18n-20260520`
+Base: `origin/main@62e179de3`
+
+## Decision Summary
+
+T3C-2b localizes `MetaFormShareManager.vue` chrome to zh-CN while preserving raw user-authored and backend-owned values.
+
+Key decisions:
+
+- Add `apps/web/src/multitable/utils/meta-form-share-labels.ts` as the form-share specific label module.
+- Reuse `meta-manager-labels.ts` for shared manager actions where applicable. This slice uses `action.remove` for allowlist chip removal.
+- Do not extend `meta-permission-labels.ts`; that module remains T3C-2a permission-only.
+- Keep access-mode enum values, public token values, user names, member-group names, subtitles, and backend `err.message` text raw.
+- Localize frontend fallback errors only when no backend `Error.message` is available.
+
+## Files In Scope
+
+- `apps/web/src/multitable/components/MetaFormShareManager.vue`
+- `apps/web/src/multitable/utils/meta-form-share-labels.ts`
+- `apps/web/tests/meta-form-share-labels.spec.ts`
+- `apps/web/tests/multitable-form-share-manager.spec.ts`
+- This design MD and the paired verification MD
+
+Out of scope:
+
+- `MetaApiTokenManager.vue` (T3C-2c)
+- Permission managers (T3C-2a, already shipped)
+- Backend routes, contracts, migrations, DingTalk policy behavior, and public-form auth semantics
+
+## Label Module Contract
+
+`meta-form-share-labels.ts` owns:
+
+- Static chrome labels: title, loading state, access mode labels, allowlist labels, link/expiry labels.
+- Access-mode helper text.
+- Audience-rule helper text for all 5 visible combinations:
+  - public
+  - dingtalk + no local allowlist
+  - dingtalk + local allowlist
+  - dingtalk_granted + no local allowlist
+  - dingtalk_granted + local allowlist
+- Allowlist count summary with English singular/plural forks and zh neutral counts.
+- DingTalk status labels for selected users/groups.
+- Frontend fallback errors.
+
+The module does not translate persisted values such as `public`, `dingtalk`, `dingtalk_granted`, subject IDs, token values, or backend-provided error strings.
+
+## Exact Chrome Targets
+
+`MetaFormShareManager.vue` chrome covered by T3C-2b:
+
+- `Public Form Sharing`
+- `Loading share settings...`
+- `Sharing enabled` / `Sharing disabled`
+- `Active` / `Expired` / `Disabled`
+- Access-mode label and option labels
+- Access-mode hints
+- Audience-rule title and description strings
+- Allowlist label, explanatory hint, summary, empty states, search placeholder
+- Candidate loading/empty states, candidate type badges, inactive-user warning
+- DingTalk binding / grant / member-group status labels
+- Public link, copy/copied, regenerate, preview, expiry/no-expiry labels
+- Frontend fallback errors
+
+The chip removal button uses `managerLabel('action.remove', isZh)`, not a form-share duplicate.
+
+## Testing Plan
+
+- `meta-form-share-labels.spec.ts`
+  - Static label mapping
+  - Status/access-mode helpers
+  - Audience-rule matrix
+  - Allowlist count formatter
+  - DingTalk status formatter
+- `multitable-form-share-manager.spec.ts`
+  - Existing English behavior remains covered with `useLocale().setLocale('en')`
+  - New zh-CN render assertion verifies visible modal chrome, DingTalk status text, allowlist summary, shared manager `Remove`, and raw subject names
+
+## Risk Controls
+
+- No dead-key discipline: every label key maps to a concrete `MetaFormShareManager.vue` call-site or helper branch covered by specs.
+- Cross-module discipline: common manager action stays in `meta-manager-labels.ts`; form-share-specific chrome stays in `meta-form-share-labels.ts`.
+- Raw data boundary: subject labels/subtitles and backend errors remain unchanged.
+- Package-relative test paths are used for `pnpm --filter @metasheet/web exec vitest`.
+
+## Follow-Up
+
+T3C-2c should localize `MetaApiTokenManager.vue` and continue reusing `meta-manager-labels.ts` shared actions instead of redeclaring them.

--- a/docs/development/multitable-t3c2b-form-share-i18n-verification-20260520.md
+++ b/docs/development/multitable-t3c2b-form-share-i18n-verification-20260520.md
@@ -1,0 +1,83 @@
+# T3C-2b Form Share Manager i18n Verification
+
+Date: 2026-05-20
+Branch: `codex/multitable-t3c2b-form-share-i18n-20260520`
+Base: `origin/main@62e179de3`
+
+## DoD
+
+T3C-2b is complete only if all of these hold:
+
+- `MetaFormShareManager.vue` responds to `useLocale().isZh`.
+- Shared `Remove` action comes from `meta-manager-labels.ts`.
+- User/group names, subtitles, token values, access-mode enum values, and backend errors stay raw.
+- Targeted specs pass.
+- Frontend type-check and production build pass.
+- `git diff --check` is clean.
+
+## Verification Commands
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/meta-form-share-labels.spec.ts \
+  tests/multitable-form-share-manager.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Results
+
+Targeted specs:
+
+```text
+✓ tests/meta-form-share-labels.spec.ts  (5 tests)
+✓ tests/multitable-form-share-manager.spec.ts  (18 tests)
+
+Test Files  2 passed (2)
+Tests       23 passed (23)
+```
+
+Type-check:
+
+```text
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+exit 0
+```
+
+Build:
+
+```text
+pnpm --filter @metasheet/web build
+✓ built in 6.09s
+```
+
+Build warnings:
+
+- Existing Vite chunk warning for `WorkflowDesigner.vue` dynamic/static import.
+- Existing chunk-size warnings.
+- No T3C-2b-specific build failure.
+
+Diff check:
+
+```text
+git diff --check
+exit 0
+```
+
+## Regression Matrix
+
+| Area | Evidence |
+| --- | --- |
+| English form-share behavior | Existing `multitable-form-share-manager.spec.ts` cases still pass under explicit `en` locale. |
+| zh-CN visible chrome | New render assertion covers title, toggle, status, access mode, audience rule, allowlist summary, DingTalk status labels, link/expiry/action text. |
+| Raw subject values | zh-CN render assertion still sees `Authorized User` and `Ops`. |
+| Shared action hub | `Remove` buttons render through `managerLabel('action.remove', isZh)`. |
+| Backend error boundary | Component still prefers `err.message` before localized fallback errors. |
+| API/contract scope | No backend, OpenAPI, migration, or API client changes. |
+
+## Worktree Noise
+
+This worktree required `pnpm install` before running `vitest/vue-tsc`. That created the known tracked `node_modules` symlink noise under plugin/tool workspaces. Those paths are not part of the T3C-2b PR and must not be staged.


### PR DESCRIPTION
## Summary

T3C-2b localizes the public form-share manager chrome to zh-CN.

- Adds `meta-form-share-labels.ts` for form-share-specific labels and helpers.
- Wires `MetaFormShareManager.vue` to `useLocale().isZh`.
- Reuses `meta-manager-labels.ts` for the shared `action.remove` button instead of redeclaring shared manager actions.
- Preserves raw subject labels/subtitles, public token values, access-mode enum values, and backend `err.message` text.

## Scope

Changed files are limited to the form-share component, its form-share label module/spec, existing form-share spec, and the paired design/verification docs.

No backend, OpenAPI, migration, attendance, Workbench, permission-manager, or API-token manager changes.

## Verification

```bash
pnpm --filter @metasheet/web exec vitest run \
  tests/meta-form-share-labels.spec.ts \
  tests/multitable-form-share-manager.spec.ts \
  --watch=false
# 2 files, 23 tests passed

pnpm --filter @metasheet/web exec vue-tsc --noEmit
# pass

pnpm --filter @metasheet/web build
# pass, only existing Vite chunk warnings

git diff --check origin/main..HEAD
git diff --check origin/main...HEAD
# clean
```

## Notes

`pnpm install` in this isolated worktree created the known tracked `node_modules` symlink noise under plugin/tool workspaces. Those paths are not staged and are not part of this PR diff.
