### PR TITLE
feat(attendance): personal calendar + holiday chip on effective-calendar

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -6,6 +6,10 @@ import { createPinia } from 'pinia'
 import { createRouter, createWebHistory } from 'vue-router'
 import ElementPlus from 'element-plus'
 import 'element-plus/dist/index.css'
+// Shared border-left accent palette for effective-calendar chips. Imported
+// here once so multitable Calendar view, attendance personal calendar, and
+// holiday admin section all see the same `--calendar-source-accent` vars.
+import './styles/calendar-source-palette.css'
 import App from './App.vue'
 import { useAuth } from './composables/useAuth'
 import { appRoutes } from './router/appRoutes'

--- a/apps/web/src/multitable/components/MetaCalendarView.vue
+++ b/apps/web/src/multitable/components/MetaCalendarView.vue
@@ -64,6 +64,7 @@
                   holiday.isWorkingDay ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest',
                   hasOverrideMarker(holiday) ? 'meta-calendar__holiday--overridden' : null,
                   holiday.overlays && holiday.overlays.length ? 'meta-calendar__holiday--with-overlay' : null,
+                  calendarChipSourceClassName(holiday.effective?.source),
                 ]"
                 :title="buildHolidayTooltip(holiday)"
               >
@@ -150,6 +151,7 @@
                   holiday.isWorkingDay ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest',
                   hasOverrideMarker(holiday) ? 'meta-calendar__holiday--overridden' : null,
                   holiday.overlays && holiday.overlays.length ? 'meta-calendar__holiday--with-overlay' : null,
+                  calendarChipSourceClassName(holiday.effective?.source),
                 ]"
                 :title="buildHolidayTooltip(holiday)"
               >
@@ -218,6 +220,7 @@
                   holiday.isWorkingDay ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest',
                   hasOverrideMarker(holiday) ? 'meta-calendar__holiday--overridden' : null,
                   holiday.overlays && holiday.overlays.length ? 'meta-calendar__holiday--with-overlay' : null,
+                  calendarChipSourceClassName(holiday.effective?.source),
                 ]"
                 :title="buildHolidayTooltip(holiday)"
               >
@@ -303,9 +306,13 @@ import {
 } from '../../composables/useCalendarDays'
 import type {
   CalendarEffectiveChip,
-  CalendarEffectiveLayer,
-  CalendarEffectiveOverlay,
 } from '../../services/attendance/effectiveCalendar'
+import {
+  buildCalendarChipTooltip,
+  calendarChipSourceClassName,
+  fallbackChipName,
+  hasCalendarChipOverrideMarker,
+} from '../../services/attendance/calendarChipDisplay'
 import MetaAttachmentList from './MetaAttachmentList.vue'
 import MetaCommentActionChip from './MetaCommentActionChip.vue'
 import MetaCommentAffordance from './MetaCommentAffordance.vue'
@@ -610,56 +617,16 @@ function rangeFromCells(cells: CalendarCell[]): CalendarVisibleRange | null {
   }
 }
 
-function fallbackHolidayName(holiday: CalendarEffectiveChip): string {
-  return holiday.isWorkingDay ? 'Working day' : 'Holiday'
-}
+// PR2: chip-display helpers (fallback name, override marker, tooltip,
+// source class) are extracted to apps/web/src/services/attendance/calendarChipDisplay.ts
+// so the multitable Calendar view and attendance personal calendar share one
+// implementation. The PR1 visual contract (red/green base + dotted override
+// + overlay dot) is preserved; PR2 adds the source border-left accent via
+// the shared `calendar-source--{source}` class.
 
-// PR1 scope C: minimal visual — keep legacy --working/--rest classes and add
-// (1) an `--overridden` marker class when a calendar_policy layer fired, and
-// (2) a native `title` tooltip with the full layer chain + overlay summary so
-// users can see "national rest day → org override changed to working" without
-// a new tooltip component. Source coloring palette is deferred to PR2.
-function hasOverrideMarker(chip: CalendarEffectiveChip): boolean {
-  if (!Array.isArray(chip.layers)) return false
-  return chip.layers.some((layer) => layer.kind === 'calendar_policy')
-}
-
-function describeLayerForTooltip(layer: CalendarEffectiveLayer): string {
-  const verdict = layer.isWorkingDay ? 'work' : 'rest'
-  const label = layer.label ? ` ${layer.label}` : ''
-  return `${layer.source}:${label} (${verdict})`
-}
-
-function describeOverlayForTooltip(overlay: CalendarEffectiveOverlay): string {
-  const parts: string[] = [overlay.kind]
-  if (typeof overlay.minutes === 'number' && Number.isFinite(overlay.minutes)) {
-    parts.push(`${overlay.minutes}m`)
-  }
-  if (overlay.status) parts.push(overlay.status)
-  return parts.join(' · ')
-}
-
-function buildHolidayTooltip(chip: CalendarEffectiveChip): string | undefined {
-  // Only build a tooltip when the chip carries effective-calendar context;
-  // legacy CalendarHoliday payloads (no base/effective/layers) get no title.
-  if (!chip.effective && !chip.base && !chip.layers?.length && !chip.overlays?.length) {
-    return undefined
-  }
-  const lines: string[] = []
-  const verdict = chip.effective?.isWorkingDay ?? chip.isWorkingDay
-  const verdictWord = verdict === true ? 'Working day' : verdict === false ? 'Rest day' : 'Unknown'
-  const sourceTag = chip.effective?.source ? ` · ${chip.effective.source}` : ''
-  lines.push(`${chip.date} — ${verdictWord}${sourceTag}`)
-  if (chip.layers?.length) {
-    const chain = chip.layers.map(describeLayerForTooltip).join(' → ')
-    lines.push(`Layers: ${chain}`)
-  }
-  if (chip.overlays?.length) {
-    const summary = chip.overlays.map(describeOverlayForTooltip).join('; ')
-    lines.push(`Overlays: ${summary}`)
-  }
-  return lines.join('\n')
-}
+const fallbackHolidayName = fallbackChipName
+const hasOverrideMarker = hasCalendarChipOverrideMarker
+const buildHolidayTooltip = buildCalendarChipTooltip
 
 function onPickDateField(e: Event) {
   const val = (e.target as HTMLSelectElement).value

--- a/apps/web/src/services/attendance/calendarChipDisplay.ts
+++ b/apps/web/src/services/attendance/calendarChipDisplay.ts
@@ -1,0 +1,117 @@
+// Display-side helpers shared by every calendar surface that consumes
+// /api/attendance/effective-calendar items (multitable Calendar view +
+// attendance personal calendar + holiday admin chip badges).
+//
+// Extracted from MetaCalendarView's PR1 inline helpers so the attendance
+// consumers do not duplicate "same logic" (Codex Should-Fix #1 on PR2 plan).
+// Pure functions — no DOM, no Vue, no i18n state. Both UIs accept the same
+// string outputs and decide for themselves how to localize labels later if
+// needed; matching PR1's English fallback convention keeps the contract
+// stable until PR3 introduces i18n.
+
+import type {
+  CalendarEffectiveChip,
+  CalendarEffectiveLayer,
+  CalendarEffectiveOverlay,
+  CalendarEffectiveSource,
+} from './effectiveCalendar'
+
+/**
+ * Class fragment for the chip's source border accent. UI surfaces apply this
+ * alongside their existing working/rest class; the shared
+ * `apps/web/src/styles/calendar-source-palette.css` resolves the CSS variable
+ * `--calendar-source-accent` per source token. Returns `undefined` for plain
+ * rule/shift/rotation days so an accent is only painted for rows the user
+ * should pay attention to.
+ */
+export function calendarChipSourceClassName(
+  source: CalendarEffectiveSource | undefined,
+): string | undefined {
+  if (!source) return undefined
+  switch (source) {
+    case 'national':
+    case 'manual':
+    case 'org':
+    case 'group':
+    case 'role':
+    case 'user':
+      return `calendar-source--${source}`
+    // rule / shift / rotation: no accent — handled by the calling chip's
+    // working/rest class only.
+    default:
+      return undefined
+  }
+}
+
+/** Generic chip-name fallback when neither effective.label nor base.name set. */
+export function fallbackChipName(chip: CalendarEffectiveChip): string {
+  return chip.isWorkingDay ? 'Working day' : 'Holiday'
+}
+
+/**
+ * Holiday-origin helpers for the admin Holiday CRUD chip badge (PR2 Block B).
+ * `national` rows come from /holidays/sync; `manual` rows from admin CRUD.
+ * Missing origin (legacy rows or older backends) is treated as `manual` so
+ * the badge always has a definite value — matching the backend's Step 2
+ * default. The badge letter is intentionally a short single character so it
+ * fits inside the existing chip without re-laying out the calendar grid.
+ */
+export type AttendanceHolidayOrigin = 'national' | 'manual'
+
+export function calendarChipOriginClassName(origin: AttendanceHolidayOrigin | undefined | null): string {
+  return origin === 'national' ? 'calendar-source--national' : 'calendar-source--manual'
+}
+
+export function calendarChipOriginBadge(origin: AttendanceHolidayOrigin | undefined | null): 'N' | 'M' {
+  return origin === 'national' ? 'N' : 'M'
+}
+
+/**
+ * True when a calendar_policy layer fired on top of the base; UIs use this
+ * to add a `--overridden` style (dotted bottom border + cursor:help in PR1).
+ */
+export function hasCalendarChipOverrideMarker(chip: CalendarEffectiveChip): boolean {
+  if (!Array.isArray(chip.layers)) return false
+  return chip.layers.some((layer) => layer.kind === 'calendar_policy')
+}
+
+function describeLayerForTooltip(layer: CalendarEffectiveLayer): string {
+  const verdict = layer.isWorkingDay ? 'work' : 'rest'
+  const label = layer.label ? ` ${layer.label}` : ''
+  return `${layer.source}:${label} (${verdict})`
+}
+
+function describeOverlayForTooltip(overlay: CalendarEffectiveOverlay): string {
+  const parts: string[] = [overlay.kind]
+  if (typeof overlay.minutes === 'number' && Number.isFinite(overlay.minutes)) {
+    parts.push(`${overlay.minutes}m`)
+  }
+  if (overlay.status) parts.push(overlay.status)
+  return parts.join(' · ')
+}
+
+/**
+ * Build a multi-line text suitable for a native `title` tooltip:
+ *   line 1 — "<date> — Working day · <source>" (or Rest day)
+ *   line 2 — "Layers: national: National Day (rest) → org: Org swap (work)"
+ *   line 3 — "Overlays: personal_leave · 240m · approved; overtime · 180m"
+ * Returns undefined for legacy CalendarHoliday payloads that lack the
+ * effective-calendar context fields (backward-compat).
+ */
+export function buildCalendarChipTooltip(chip: CalendarEffectiveChip): string | undefined {
+  if (!chip.effective && !chip.base && !chip.layers?.length && !chip.overlays?.length) {
+    return undefined
+  }
+  const lines: string[] = []
+  const verdict = chip.effective?.isWorkingDay ?? chip.isWorkingDay
+  const verdictWord = verdict === true ? 'Working day' : verdict === false ? 'Rest day' : 'Unknown'
+  const sourceTag = chip.effective?.source ? ` · ${chip.effective.source}` : ''
+  lines.push(`${chip.date} — ${verdictWord}${sourceTag}`)
+  if (chip.layers?.length) {
+    lines.push(`Layers: ${chip.layers.map(describeLayerForTooltip).join(' → ')}`)
+  }
+  if (chip.overlays?.length) {
+    lines.push(`Overlays: ${chip.overlays.map(describeOverlayForTooltip).join('; ')}`)
+  }
+  return lines.join('\n')
+}

--- a/apps/web/src/styles/calendar-source-palette.css
+++ b/apps/web/src/styles/calendar-source-palette.css
@@ -1,0 +1,33 @@
+/*
+ * Shared source palette for effective-calendar chips across multitable
+ * Calendar view, attendance personal calendar, and holiday admin section.
+ *
+ * Imported once globally from apps/web/src/main.ts so per-SFC scoped @imports
+ * do not silently drift. Components apply the source class via
+ * calendarChipSourceClassName(chip.effective?.source) and resolve the CSS
+ * variable in their own scoped style block, typically as:
+ *   border-left: 4px solid var(--calendar-source-accent, transparent);
+ * Working/rest base colors stay intact on each surface; this palette adds an
+ * orthogonal source channel.
+ */
+
+.calendar-source--national { --calendar-source-accent: #d73a4a; }
+.calendar-source--manual   { --calendar-source-accent: #6e7681; }
+.calendar-source--org      { --calendar-source-accent: #fb8500; }
+.calendar-source--group    { --calendar-source-accent: #3a86ff; }
+.calendar-source--role     { --calendar-source-accent: #9b5de5; }
+.calendar-source--user     { --calendar-source-accent: #063070; }
+
+/* Generic consume: any element carrying a calendar-source--<kind> class gets
+ * a 4px left border accent in the resolved color. Surfaces opt in by adding
+ * the source class (no per-component CSS duplication needed). The accent is
+ * orthogonal to working/rest base colors and stacks with PR1's
+ * --overridden dotted bottom and --with-overlay dot. */
+.calendar-source--national,
+.calendar-source--manual,
+.calendar-source--org,
+.calendar-source--group,
+.calendar-source--role,
+.calendar-source--user {
+  border-left: 4px solid var(--calendar-source-accent, transparent);
+}

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -644,7 +644,7 @@
               <span v-if="day.statusLabel" class="attendance__calendar-status">{{ day.statusLabel }}</span>
               <span v-else class="attendance__calendar-status attendance__calendar-status--empty">--</span>
               <span v-if="showLunarLabel && day.lunarLabel" class="attendance__calendar-lunar">{{ day.lunarLabel }}</span>
-              <span v-if="showHolidayBadge && day.holidayName" class="attendance__calendar-holiday">{{ day.holidayName }}</span>
+              <span v-if="showHolidayBadge && day.holidayName" class="attendance__calendar-holiday" :class="day.sourceClass">{{ day.holidayName }}</span>
             </div>
           </div>
         </div>
@@ -4711,6 +4711,19 @@ import {
   type AttendancePayrollSummaryFieldOption,
 } from './attendance/useAttendanceAdminPayroll'
 import { useLocale } from '../composables/useLocale'
+import { useAuth } from '../composables/useAuth'
+import { getCalendarVisibleRange } from '../composables/useCalendarDays'
+import {
+  EffectiveCalendarFetchError,
+  effectiveCalendarItemToChip,
+  fetchEffectiveCalendar,
+  isCalendarEffectiveItemNoteworthy,
+  type CalendarEffectiveChip,
+} from '../services/attendance/effectiveCalendar'
+import {
+  buildCalendarChipTooltip,
+  calendarChipSourceClassName,
+} from '../services/attendance/calendarChipDisplay'
 import { usePlugins } from '../composables/usePlugins'
 import { apiFetch } from '../utils/api'
 import { readErrorMessage } from '../utils/error'
@@ -5448,6 +5461,10 @@ interface AttendanceRotationAssignmentItem {
   rotation: AttendanceRotationRule
 }
 
+// PR2 adds `sourceClass` carrying `calendar-source--{national|manual|org|group|role|user}`
+// (or undefined for plain rule/shift days). The shared palette in
+// apps/web/src/styles/calendar-source-palette.css resolves it to a 4px
+// border-left accent; UI surfaces apply the class without per-component CSS.
 interface CalendarDay {
   key: string
   day: number
@@ -5458,6 +5475,7 @@ interface CalendarDay {
   tooltip: string
   holidayName?: string
   lunarLabel?: string
+  sourceClass?: string
 }
 
 interface AttendanceApiError extends Error {
@@ -5700,6 +5718,29 @@ const provisionRolePermissions: Record<ProvisionRole, string[]> = {
 const shifts = ref<AttendanceShift[]>([])
 const assignments = ref<AttendanceAssignmentItem[]>([])
 const holidays = ref<AttendanceHoliday[]>([])
+// PR2 raw/effective split (Codex Must-Fix #1): `holidays` keeps feeding the
+// admin Holiday CRUD section (holidaySectionBindings); the personal overview
+// calendar grid now reads from `calendarEffectiveChips` so each cell can
+// expose source + layer chain + overlays without polluting the admin CRUD
+// payload. Mixing them would break edit/delete (admin edits raw rows by id).
+const calendarEffectiveChips = ref<CalendarEffectiveChip[]>([])
+const currentUserId = ref<string | null>(null)
+// PR2 review fix (Codex Blocking #1): `committedCalendarUserId` is the userId
+// the overview is currently rendered against. It is set ONLY by refreshAll()
+// (when the user clicks Refresh, after typing into targetUserId) and by the
+// initial auth resolution — NOT by live v-model edits to the targetUserId
+// input. This keeps calendar chips in sync with summary/records/requests
+// which all use a refreshAll-committed view of the userId rather than the
+// live input value.
+const committedCalendarUserId = ref<string | null>(null)
+const lastCalendarEffectiveRange = ref<{ from: string; to: string } | null>(null)
+let calendarEffectiveCacheKey: string | null = null
+// PR2 review fix (Codex Blocking #2): stale-response guard. A bumped version
+// is captured before the await; after the response we discard it if the
+// counter advanced (rapid month/user switches) so older responses can never
+// overwrite newer chip data.
+let calendarEffectiveLoadVersion = 0
+const auth = useAuth()
 const requestReport = ref<AttendanceRequestReportItem[]>([])
 const requestReportTotal = computed(() =>
   requestReport.value.reduce((sum, row) => sum + (Number(row.total) || 0), 0)
@@ -7289,6 +7330,81 @@ const holidayMap = computed(() => {
   return map
 })
 
+// PR2 effective-calendar consumer state (Codex Must-Fix #2: AttendanceView
+// has no currentUserId — populate `committedCalendarUserId` via useAuth on
+// mount + on every refreshAll). The fetcher gates on the committed value
+// and a watcher replays the cached range when auth resolves later.
+
+const calendarEffectiveChipMap = computed(() => {
+  const map = new Map<string, CalendarEffectiveChip>()
+  for (const chip of calendarEffectiveChips.value) {
+    const key = normalizeDateKey(chip.date)
+    if (key) map.set(key, chip)
+  }
+  return map
+})
+
+async function loadEffectiveCalendarForOverview(
+  range: { from: string; to: string },
+  options?: { force?: boolean },
+): Promise<void> {
+  const from = String(range.from || '').trim()
+  const to = String(range.to || '').trim()
+  if (!from || !to) return
+  // Record the latest emitted range BEFORE the auth gate so the watcher can
+  // replay once committedCalendarUserId populates (the page often mounts
+  // before useAuth resolves; we must not silently skip).
+  lastCalendarEffectiveRange.value = { from, to }
+  const userId = committedCalendarUserId.value
+  if (!userId) return
+  const cacheKey = `${from}|${to}|${userId}`
+  if (!options?.force && calendarEffectiveCacheKey === cacheKey) return
+  calendarEffectiveCacheKey = cacheKey
+  const loadVersion = ++calendarEffectiveLoadVersion
+  try {
+    const result = await fetchEffectiveCalendar({
+      from,
+      to,
+      userId,
+      suppressUnauthorizedRedirect: true,
+    })
+    // Stale-response guard (Codex Blocking #2): if another call started after
+    // this one (e.g. user switched months or clicked Refresh during await),
+    // drop this result so the newer one wins.
+    if (loadVersion !== calendarEffectiveLoadVersion) return
+    const items = Array.isArray(result?.items) ? result.items : []
+    calendarEffectiveChips.value = items
+      .filter(isCalendarEffectiveItemNoteworthy)
+      .map(effectiveCalendarItemToChip)
+  } catch (error) {
+    // Failure must not block calendar grid rendering — clear chips, bust the
+    // cache key so a later auth/retry succeeds. Only the most recent failed
+    // version mutates state so older failures cannot blank a newer success.
+    if (loadVersion === calendarEffectiveLoadVersion) {
+      calendarEffectiveChips.value = []
+      calendarEffectiveCacheKey = null
+    }
+    if (error instanceof EffectiveCalendarFetchError) {
+      console.debug('[AttendanceView] effective-calendar load failed', error.status, error.message)
+    }
+  }
+}
+
+watch(committedCalendarUserId, (next) => {
+  if (next && lastCalendarEffectiveRange.value) {
+    void loadEffectiveCalendarForOverview(lastCalendarEffectiveRange.value)
+  }
+})
+
+watch(
+  calendarMonth,
+  (month) => {
+    const range = getCalendarVisibleRange(month)
+    void loadEffectiveCalendarForOverview(range)
+  },
+  { immediate: true },
+)
+
 const calendarDays = computed<CalendarDay[]>(() => {
   const year = calendarMonth.value.getFullYear()
   const month = calendarMonth.value.getMonth()
@@ -7303,22 +7419,35 @@ const calendarDays = computed<CalendarDay[]>(() => {
     const date = new Date(year, month, index - startOffset + 1)
     const key = toDateKey(date)
     const record = recordMap.value.get(key)
-    const holiday = holidayMap.value.get(key)
+    // PR2: read from effective-calendar chips (not raw `holidayMap`) so
+    // each cell reflects the viewing user's effective layer chain (national/
+    // manual/org/group/user policies + approved overlays). Admin CRUD still
+    // reads `holidays`/`holidayMap` for its own raw-row workflow.
+    const chip = calendarEffectiveChipMap.value.get(key)
     let status = record?.status
     let statusLabel = status ? formatStatus(status) : undefined
-    const holidayName = typeof holiday?.name === 'string' && holiday.name.trim().length > 0
-      ? holiday.name.trim()
+    const holidayName = typeof chip?.name === 'string' && chip.name.trim().length > 0
+      ? chip.name.trim()
       : undefined
     const lunarLabel = formatLunarDayLabel(date)
+    const chipTooltip = chip ? buildCalendarChipTooltip(chip) : undefined
+    const sourceClass = calendarChipSourceClassName(chip?.effective?.source)
     let tooltip = record
       ? `${key} · ${statusLabel} · ${record.work_minutes} min`
       : key
-    if (!record && holiday && holiday.isWorkingDay === false) {
+    if (!record && chip && chip.isWorkingDay === false) {
       status = 'off'
       statusLabel = tr('Holiday', '休息日')
-      tooltip = holidayName ? `${key} · ${holidayName}` : `${key} · ${tr('Holiday', '休息日')}`
+      // Prefer the layer-chain tooltip when the chip exposes effective fields
+      // so users can see "national rest → org override" without leaving the
+      // cell; fall back to the legacy text otherwise.
+      tooltip = chipTooltip
+        ?? (holidayName ? `${key} · ${holidayName}` : `${key} · ${tr('Holiday', '休息日')}`)
     } else if (record && status === 'off' && holidayName) {
-      tooltip = `${key} · ${holidayName} · ${record.work_minutes} min`
+      tooltip = chipTooltip
+        ?? `${key} · ${holidayName} · ${record.work_minutes} min`
+    } else if (chipTooltip) {
+      tooltip = chipTooltip
     }
     return {
       key,
@@ -7330,6 +7459,7 @@ const calendarDays = computed<CalendarDay[]>(() => {
       tooltip,
       holidayName,
       lunarLabel,
+      sourceClass,
     }
   })
 })
@@ -11768,9 +11898,19 @@ async function refreshAll(): Promise<boolean> {
   loading.value = true
   recordsPage.value = 1
   calendarMonth.value = new Date(`${toDate.value}T00:00:00`)
+  // PR2 review fix (Codex Blocking #1): commit the userId for the overview
+  // calendar HERE — same moment summary/records/requests are refreshed —
+  // instead of reacting to live targetUserId v-model edits. The watcher on
+  // committedCalendarUserId will fire when it actually changes; we also
+  // force a fresh effective-calendar load below so Refresh on the same
+  // (from, to, userId) tuple still discards the cache (Blocking #2 part 2).
+  committedCalendarUserId.value = normalizedUserId() ?? currentUserId.value ?? null
   let success = true
   try {
     await Promise.all([loadSummary(), loadRecords(), loadRequests(), loadAnomalies(), loadRequestReport(), loadHolidays()])
+    if (lastCalendarEffectiveRange.value) {
+      void loadEffectiveCalendarForOverview(lastCalendarEffectiveRange.value, { force: true })
+    }
   } catch (error: any) {
     success = false
     setStatusFromError(error, tr('Refresh failed', '刷新失败'), 'refresh')
@@ -14332,6 +14472,23 @@ async function loadAdminData() {
 }
 
 onMounted(() => {
+  // Populate currentUserId for the effective-calendar fetcher. If refreshAll
+  // ran first and could not commit a userId (auth still resolving),
+  // backfill committedCalendarUserId now so the watcher replays the cached
+  // visible range and the personal calendar grid does not stay empty. We
+  // intentionally do NOT touch committedCalendarUserId when the user has
+  // already typed a targetUserId — refreshAll will commit that the next
+  // time it runs.
+  auth.getCurrentUserId().then((id) => {
+    if (!id) return
+    currentUserId.value = id
+    if (!committedCalendarUserId.value && !normalizedUserId()) {
+      committedCalendarUserId.value = id
+    }
+  }).catch(() => {
+    // Auth failures are surfaced elsewhere; calendar simply waits for a
+    // userId and will not call the API without one.
+  })
   fetchPlugins()
     .then(() => {
       pluginsLoaded.value = true
@@ -14874,6 +15031,14 @@ const holidaySectionBindings = {
   color: #b45309;
   background: #fff7ed;
   border: 1px solid #fed7aa;
+  /* PR2 review fix (Codex Medium #3): the `border` shorthand above resets
+   * any left-edge accent painted by the shared palette
+   * apps/web/src/styles/calendar-source-palette.css. The scoped selector
+   * has higher specificity than the global `.calendar-source--*` rule, so
+   * we re-declare `border-left` here to consume the same CSS variable.
+   * When no source class is present, the variable resolves to the original
+   * 1px #fed7aa value via fallback. */
+  border-left: 4px solid var(--calendar-source-accent, #fed7aa);
   border-radius: 6px;
   padding: 2px 4px;
   line-height: 1.2;

--- a/apps/web/src/views/attendance/AttendanceHolidayDataSection.vue
+++ b/apps/web/src/views/attendance/AttendanceHolidayDataSection.vue
@@ -54,9 +54,16 @@
               v-for="holiday in day.holidays.slice(0, 2)"
               :key="`${day.date}-${holiday.id}`"
               class="attendance__holiday-chip"
-              :class="holiday.isWorkingDay ? 'attendance__holiday-chip--working' : 'attendance__holiday-chip--holiday'"
+              :class="[
+                holiday.isWorkingDay ? 'attendance__holiday-chip--working' : 'attendance__holiday-chip--holiday',
+                calendarChipOriginClassName(holiday.origin),
+              ]"
+              :title="holiday.origin === 'national'
+                ? tr('Synced from national holiday source', '来自国家节假日同步')
+                : tr('Manually added by administrator', '管理员手工添加')"
             >
               {{ holiday.name || fallbackHolidayName(holiday.isWorkingDay) }}
+              <small class="attendance__holiday-chip-origin">{{ calendarChipOriginBadge(holiday.origin) }}</small>
             </span>
             <span v-if="day.holidays.length > 2" class="attendance__holiday-more">
               +{{ day.holidays.length - 2 }}
@@ -139,6 +146,10 @@ import {
   toDateInput,
   type CalendarDayCell as SharedCalendarDayCell,
 } from '../../composables/useCalendarDays'
+import {
+  calendarChipOriginBadge,
+  calendarChipOriginClassName,
+} from '../../services/attendance/calendarChipDisplay'
 
 type Translate = (en: string, zh: string) => string
 type MaybePromise<T> = T | Promise<T>
@@ -322,6 +333,10 @@ void syncMonthRange(calendarMonth.value)
 .attendance__holiday-chip { display: inline-flex; align-items: center; max-width: 100%; padding: 2px 6px; border-radius: 999px; font-size: 11px; line-height: 1.3; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .attendance__holiday-chip--holiday { background: #ffe8e8; color: #9a1a1a; }
 .attendance__holiday-chip--working { background: #e5f7ec; color: #15693a; }
+/* PR2: tiny origin badge inside the chip (N = national/sync, M = manual/admin).
+ * The chip also receives a `calendar-source--{national|manual}` class from
+ * the shared palette, painting a 4px border-left accent in the source color. */
+.attendance__holiday-chip-origin { margin-left: 4px; font-size: 9px; opacity: 0.65; letter-spacing: 0.5px; }
 .attendance__holiday-more { color: #666; font-size: 11px; }
 .attendance__holiday-side { display: flex; flex-direction: column; gap: 12px; }
 .attendance__holiday-panel { border: 1px solid #e0e0e0; border-radius: 10px; padding: 12px; background: #fff; display: flex; flex-direction: column; gap: 10px; }

--- a/apps/web/src/views/attendance/useAttendanceAdminScheduling.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminScheduling.ts
@@ -43,6 +43,13 @@ export interface AttendanceHoliday {
   date: string
   name: string | null
   isWorkingDay: boolean
+  // PR2: surface the row's `origin` (`national` for /holidays/sync rows,
+  // `manual` for admin CRUD). The backend has populated this since Step 2
+  // (#1698); existing legacy clients see it as optional. Admin CRUD POST/PUT
+  // bodies intentionally do NOT include `origin` — the backend keeps
+  // `manual` as the authoritative default for manual writes (PR2 Should-Fix
+  // #4).
+  origin?: 'national' | 'manual'
 }
 
 export interface AttendanceRotationRule {

--- a/apps/web/tests/attendance-selfservice-dashboard.spec.ts
+++ b/apps/web/tests/attendance-selfservice-dashboard.spec.ts
@@ -415,4 +415,39 @@ describe('Attendance self-service dashboard', () => {
     expect(pageText).toContain('Minimum punch interval is enforced by policy. Retry after the interval.')
     expect(pageText).toContain('Retry refresh')
   })
+
+  // PR2 review fix (Codex Blocking #1): the personal calendar must read a
+  // userId committed at Refresh-time, NOT the live v-model value of the
+  // targetUserId input. This test types into the input without refreshing
+  // and asserts that no new effective-calendar fetch fired for the typed
+  // value; then clicks Refresh and asserts the fetch URL carries the typed
+  // userId — same commit point as summary/records/requests.
+  it('PR2 review #1: typing targetUserId does not request effective-calendar until Refresh commits it', async () => {
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    const effectiveCalls = () => vi.mocked(apiFetch).mock.calls.filter((call) =>
+      typeof call[0] === 'string' && call[0].includes('/api/attendance/effective-calendar'),
+    )
+    const baselineCalls = effectiveCalls().length
+    expect(effectiveCalls().some((call) => String(call[0]).includes('userId=typed-user-pr2'))).toBe(false)
+
+    const targetInput = container?.querySelector('input[name="targetUserId"]') as HTMLInputElement | null
+    expect(targetInput).toBeTruthy()
+    targetInput!.value = 'typed-user-pr2'
+    targetInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    // Typing must NOT have produced a new effective-calendar fetch
+    expect(effectiveCalls().length).toBe(baselineCalls)
+    expect(effectiveCalls().some((call) => String(call[0]).includes('userId=typed-user-pr2'))).toBe(false)
+
+    findButton(container!, 'Refresh').click()
+    await flushUi(12)
+
+    const afterRefresh = effectiveCalls()
+    expect(afterRefresh.length).toBeGreaterThan(baselineCalls)
+    expect(afterRefresh.some((call) => String(call[0]).includes('userId=typed-user-pr2'))).toBe(true)
+  })
 })

--- a/apps/web/tests/calendarChipDisplay.spec.ts
+++ b/apps/web/tests/calendarChipDisplay.spec.ts
@@ -1,0 +1,120 @@
+// Layer-1 unit coverage for the shared chip-display helpers extracted from
+// MetaCalendarView (PR1) into apps/web/src/services/attendance/calendarChipDisplay.ts
+// for PR2. The contract pinned here is:
+//   - source class derivation maps API source values 1:1 to CSS hooks
+//   - override marker only fires when a calendar_policy layer is present
+//   - tooltip stays empty for legacy CalendarHoliday payloads
+//   - tooltip composes date/effective/layers/overlays in a stable order
+//   - holiday origin badge defaults to manual when missing
+
+import { describe, expect, it } from 'vitest'
+import {
+  buildCalendarChipTooltip,
+  calendarChipOriginBadge,
+  calendarChipOriginClassName,
+  calendarChipSourceClassName,
+  fallbackChipName,
+  hasCalendarChipOverrideMarker,
+} from '../src/services/attendance/calendarChipDisplay'
+import type {
+  CalendarEffectiveChip,
+} from '../src/services/attendance/effectiveCalendar'
+
+describe('calendarChipSourceClassName', () => {
+  it('maps each calendar_policy/base source to the matching CSS hook', () => {
+    expect(calendarChipSourceClassName('national')).toBe('calendar-source--national')
+    expect(calendarChipSourceClassName('manual')).toBe('calendar-source--manual')
+    expect(calendarChipSourceClassName('org')).toBe('calendar-source--org')
+    expect(calendarChipSourceClassName('group')).toBe('calendar-source--group')
+    expect(calendarChipSourceClassName('role')).toBe('calendar-source--role')
+    expect(calendarChipSourceClassName('user')).toBe('calendar-source--user')
+  })
+  it('returns undefined for plain rule/shift/rotation days so no accent is painted', () => {
+    expect(calendarChipSourceClassName('rule')).toBeUndefined()
+    expect(calendarChipSourceClassName('shift')).toBeUndefined()
+    expect(calendarChipSourceClassName('rotation')).toBeUndefined()
+    expect(calendarChipSourceClassName(undefined)).toBeUndefined()
+  })
+})
+
+describe('hasCalendarChipOverrideMarker', () => {
+  it('returns true only when at least one calendar_policy layer fired', () => {
+    expect(hasCalendarChipOverrideMarker({
+      id: '1', date: '2026-10-05',
+      layers: [
+        { kind: 'holiday', source: 'national', isWorkingDay: false },
+        { kind: 'calendar_policy', source: 'org', isWorkingDay: true },
+      ],
+    } as CalendarEffectiveChip)).toBe(true)
+  })
+  it('returns false for chips with only base layers', () => {
+    expect(hasCalendarChipOverrideMarker({
+      id: '1', date: '2026-10-05',
+      layers: [{ kind: 'holiday', source: 'national', isWorkingDay: false }],
+    } as CalendarEffectiveChip)).toBe(false)
+    expect(hasCalendarChipOverrideMarker({ id: '1', date: '2026-10-05' } as CalendarEffectiveChip)).toBe(false)
+  })
+})
+
+describe('buildCalendarChipTooltip', () => {
+  it('returns undefined for a legacy CalendarHoliday payload (no effective/base/layers/overlays)', () => {
+    expect(buildCalendarChipTooltip({
+      id: 'h1', date: '2026-02-17', name: 'Spring Festival', isWorkingDay: false,
+    } as CalendarEffectiveChip)).toBeUndefined()
+  })
+  it('composes date + verdict + source on line 1', () => {
+    const text = buildCalendarChipTooltip({
+      id: '1', date: '2026-10-01',
+      effective: { isWorkingDay: false, source: 'national', label: 'National Day' },
+      layers: [{ kind: 'holiday', source: 'national', isWorkingDay: false, label: 'National Day' }],
+      overlays: [],
+    } as CalendarEffectiveChip) ?? ''
+    expect(text.split('\n')[0]).toBe('2026-10-01 — Rest day · national')
+  })
+  it('renders layer chain on line 2 and overlay summary on line 3 in stable order', () => {
+    const text = buildCalendarChipTooltip({
+      id: '1', date: '2026-10-05',
+      effective: { isWorkingDay: true, source: 'org', label: 'Org swap' },
+      layers: [
+        { kind: 'holiday', source: 'national', isWorkingDay: false, label: 'National Day' },
+        { kind: 'calendar_policy', source: 'org', isWorkingDay: true, label: 'Org swap' },
+      ],
+      overlays: [
+        { kind: 'personal_leave', source: 'attendance_requests', minutes: 240, status: 'approved' },
+        { kind: 'overtime', source: 'attendance_requests', minutes: 180 },
+      ],
+    } as CalendarEffectiveChip) ?? ''
+    const lines = text.split('\n')
+    expect(lines[1]).toContain('Layers:')
+    expect(lines[1]).toContain('national:')
+    expect(lines[1]).toContain('National Day')
+    expect(lines[1]).toContain('org:')
+    expect(lines[2]).toContain('Overlays:')
+    expect(lines[2]).toContain('personal_leave · 240m · approved')
+    expect(lines[2]).toContain('overtime · 180m')
+  })
+})
+
+describe('fallbackChipName', () => {
+  it('returns "Working day" / "Holiday" by isWorkingDay', () => {
+    expect(fallbackChipName({ id: '1', date: '2026-01-01', isWorkingDay: true } as CalendarEffectiveChip)).toBe('Working day')
+    expect(fallbackChipName({ id: '1', date: '2026-01-01', isWorkingDay: false } as CalendarEffectiveChip)).toBe('Holiday')
+  })
+})
+
+describe('attendance holiday origin helpers', () => {
+  it('maps origin=national/manual to the matching shared palette class', () => {
+    expect(calendarChipOriginClassName('national')).toBe('calendar-source--national')
+    expect(calendarChipOriginClassName('manual')).toBe('calendar-source--manual')
+  })
+  it('defaults to manual when origin is missing (legacy rows / older backends)', () => {
+    expect(calendarChipOriginClassName(undefined)).toBe('calendar-source--manual')
+    expect(calendarChipOriginClassName(null)).toBe('calendar-source--manual')
+  })
+  it('returns the short N/M badge letter for the chip', () => {
+    expect(calendarChipOriginBadge('national')).toBe('N')
+    expect(calendarChipOriginBadge('manual')).toBe('M')
+    expect(calendarChipOriginBadge(undefined)).toBe('M')
+    expect(calendarChipOriginBadge(null)).toBe('M')
+  })
+})

--- a/apps/web/tests/useAttendanceAdminScheduling.spec.ts
+++ b/apps/web/tests/useAttendanceAdminScheduling.spec.ts
@@ -484,6 +484,73 @@ describe('useAttendanceAdminScheduling', () => {
     expect(scheduling.holidays.value[0]?.id).toBe('holiday-2')
   })
 
+  it('preserves the holiday row origin (national/manual) loaded from /api/attendance/holidays for PR2 admin chip badge', async () => {
+    const adminForbidden = ref(false)
+    const apiFetch = vi.fn().mockResolvedValue(jsonResponse(200, {
+      ok: true,
+      data: {
+        items: [
+          { id: 'h-nat', date: '2026-10-01', name: 'National Day', isWorkingDay: false, origin: 'national' },
+          { id: 'h-man', date: '2026-10-08', name: 'Office party', isWorkingDay: false, origin: 'manual' },
+          { id: 'h-legacy', date: '2026-10-15', name: 'Legacy row', isWorkingDay: false },
+        ],
+      },
+    }))
+
+    const scheduling = useAttendanceAdminScheduling({
+      adminForbidden,
+      apiFetch,
+      defaultTimezone: 'UTC',
+      getOrgId: () => 'org-pr2',
+      getDateRange: () => ({ from: '2026-10-01', to: '2026-10-31' }),
+    })
+
+    await scheduling.loadHolidays()
+
+    expect(scheduling.holidays.value).toHaveLength(3)
+    expect(scheduling.holidays.value[0]?.origin).toBe('national')
+    expect(scheduling.holidays.value[1]?.origin).toBe('manual')
+    // Legacy rows without `origin` keep the field undefined — the UI badge
+    // treats undefined as 'manual' (the backend default since Step 2).
+    expect(scheduling.holidays.value[2]?.origin).toBeUndefined()
+  })
+
+  it('does NOT send origin in the holiday save body — backend keeps manual as authoritative default', async () => {
+    const adminForbidden = ref(false)
+    const setStatus = vi.fn()
+    const apiFetch = vi.fn().mockResolvedValue(jsonResponse(200, {
+      ok: true,
+      data: { holiday: { id: 'h-new', date: '2026-11-11', name: 'Single Day', isWorkingDay: false, origin: 'manual' } },
+    }))
+
+    const scheduling = useAttendanceAdminScheduling({
+      adminForbidden,
+      apiFetch,
+      setStatus,
+      defaultTimezone: 'UTC',
+      getOrgId: () => 'org-pr2',
+      getDateRange: () => ({ from: '2026-11-01', to: '2026-11-30' }),
+    })
+
+    scheduling.holidayForm.date = '2026-11-11'
+    scheduling.holidayForm.name = 'Single Day'
+    scheduling.holidayForm.isWorkingDay = false
+
+    await scheduling.saveHoliday()
+
+    // Find the create call (POST /api/attendance/holidays). Inspect its body
+    // and assert `origin` is absent — Should-Fix #4: backend default reigns.
+    const saveCall = apiFetch.mock.calls.find((call) => {
+      const [, init] = call as [string, RequestInit | undefined]
+      return typeof init?.method === 'string' && /post|put|patch/i.test(init.method)
+    })
+    expect(saveCall).toBeDefined()
+    const init = saveCall?.[1] as RequestInit | undefined
+    const body = typeof init?.body === 'string' ? JSON.parse(init.body) : null
+    expect(body).toBeTruthy()
+    expect(Object.prototype.hasOwnProperty.call(body!, 'origin')).toBe(false)
+  })
+
   it('requires a holiday name before saving', async () => {
     const adminForbidden = ref(false)
     const setStatus = vi.fn()

--- a/docs/development/attendance-views-effective-calendar-development-20260520.md
+++ b/docs/development/attendance-views-effective-calendar-development-20260520.md
@@ -1,0 +1,187 @@
+# Attendance Views — Effective Calendar Integration (PR2)
+
+Date: 2026-05-20
+Branch: `frontend/attendance-views-effective-calendar-20260520`
+Base: `origin/main@bf44e3688` (includes PR1 #1712 and #1714)
+Implements: RFC §7 Step 4 — frontend lane, follow-up to PR1.
+Builds on: Step 3 PR #1707 (resolver + read-only API) + Step 4 PR1 #1712
+(multitable Calendar consumer + shared service + chip mapper).
+
+## Scope
+
+PR2 finishes Step 4 by wiring the **personal attendance calendar** and the
+**holiday admin chip** to the same effective-calendar surface PR1 built for
+multitable, and ships the full source palette across all three calendar
+surfaces in one cohesive visual landing.
+
+Delivered:
+
+- AttendanceView personal calendar reads `/api/attendance/effective-calendar`
+  (userId mode), with a raw/effective split that keeps the admin Holiday CRUD
+  page using `/api/attendance/holidays` for editing.
+- AttendanceHolidayDataSection chips expose holiday `origin` (national vs
+  manual) as a small `N`/`M` badge + a shared source-palette border accent.
+- Shared `apps/web/src/styles/calendar-source-palette.css` consumed by all
+  three calendar consumers; `border-left: 4px` accent per source layer.
+- Chip-display helpers (`buildCalendarChipTooltip`, `hasCalendarChipOverrideMarker`,
+  `calendarChipSourceClassName`, `fallbackChipName`, plus the new
+  `calendarChipOriginClassName` / `calendarChipOriginBadge`) extracted to
+  `apps/web/src/services/attendance/calendarChipDisplay.ts` so multitable
+  + attendance consumers share one implementation.
+
+Not delivered:
+
+- Step 5 calc-chain cutover — still planned as the last slice.
+- Translation surface for the chip tooltip text (currently English fallback,
+  matching PR1's convention). A separate i18n slice can localize.
+
+## Codex review constraints honored
+
+### Must-Fix #1: Raw/effective split in AttendanceView
+
+`holidays` (`AttendanceHoliday[]`) keeps feeding the admin CRUD page via
+`holidaySectionBindings`; it is loaded by `loadHolidays()` and posted/put
+through the existing flow. The new `calendarEffectiveChips`
+(`CalendarEffectiveChip[]`) feeds **only** the personal `calendarDays`
+computed via the parallel `calendarEffectiveChipMap`. Editing a holiday
+still goes through the raw-row endpoint with the original row id.
+
+### Must-Fix #2: `useAuth()` for `currentUserId`
+
+AttendanceView has no `currentUserId` ref; it has `targetUserId` + a
+`normalizedUserId()` helper for the optional manual selector. PR2 imports
+`useAuth()`, populates `currentUserId` on mount via `getCurrentUserId()`,
+and uses `committedCalendarUserId` (see PR2 review Blocking #1 below) as
+the gated input to the fetcher. The fetcher returns early when
+`committedCalendarUserId.value` is null; a watch on `committedCalendarUserId`
+replays the cached `lastCalendarEffectiveRange` once it resolves.
+
+### PR2 review Blocking #1: live v-model vs Refresh-committed userId
+
+The initial PR2 used `effectiveUserId = computed(() => normalizedUserId() ?? currentUserId.value ?? null)`,
+which means every keystroke in the targetUserId input would update the
+computed and immediately trigger an effective-calendar fetch. That
+desynced calendar chips from summary/records/requests (those only update
+on Refresh). Fix: `committedCalendarUserId` ref is set ONLY by
+`refreshAll()` and by the initial auth resolution; live input edits do
+nothing to it. Layer 3 mount test pins the contract.
+
+### PR2 review Blocking #2: stale-response guard + Refresh force
+
+Initial PR2 had no `loadVersion` counter; rapid month/user switches could
+let an older response overwrite a newer one. Also, `refreshAll()` did not
+bypass the cache when (from, to, userId) was unchanged, so chips could
+stay stale even after explicit Refresh. Fix: bump
+`calendarEffectiveLoadVersion` per call and discard responses whose
+version no longer matches; `loadEffectiveCalendarForOverview(range, { force })`
+accepts a force flag; `refreshAll()` passes `force: true`.
+
+### PR2 review Medium #3: scoped border specificity
+
+`apps/web/src/styles/calendar-source-palette.css` applies
+`border-left: 4px solid var(--calendar-source-accent, transparent)` via a
+single global selector, but AttendanceView's scoped
+`.attendance__calendar-holiday` selector has higher specificity (scoped
+selectors carry a `[data-v-...]` attribute) and its `border: 1px solid`
+shorthand wins. Fix: the scoped rule now redeclares
+`border-left: 4px solid var(--calendar-source-accent, #fed7aa)` so it
+consumes the same variable; the fallback to `#fed7aa` preserves the
+original chip border color when no source class is present.
+
+### Should-Fix #1: Shared tooltip / source-class helper
+
+PR1's tooltip + override-marker helpers (which lived inside MetaCalendarView)
+moved to `apps/web/src/services/attendance/calendarChipDisplay.ts`.
+MetaCalendarView now imports the shared exports; AttendanceView imports the
+same set; HolidayDataSection imports the origin helpers. Three consumers,
+one implementation.
+
+### Should-Fix #2 + #3: Border-left accent palette in a single shared CSS
+
+`apps/web/src/styles/calendar-source-palette.css` is imported once from
+`apps/web/src/main.ts`. It both sets `--calendar-source-accent` per source
+class and applies `border-left: 4px solid var(--calendar-source-accent, transparent)`
+to any element carrying a `calendar-source--{kind}` class — no per-SFC
+duplication or scoped/import drift.
+
+### Should-Fix #4: `origin` is read, never written by admin POST/PUT
+
+`AttendanceHoliday.origin?: 'national' | 'manual'` is optional and only
+parsed from the API response. The admin create form (`holidayForm`) does
+not carry an `origin` field, and the new contract test asserts the save
+body has no `origin` key — Step 2 backend's `manual` default stays
+authoritative.
+
+## Key code anchors
+
+| Concern | File:line (post-PR2) |
+| --- | --- |
+| Shared chip-display helpers (extracted from MetaCalendarView) | `apps/web/src/services/attendance/calendarChipDisplay.ts` (new) |
+| Source palette CSS + border-left consume rule | `apps/web/src/styles/calendar-source-palette.css` (new), imported in `apps/web/src/main.ts` |
+| `AttendanceHoliday.origin?` type | `apps/web/src/views/attendance/useAttendanceAdminScheduling.ts:40+` |
+| Holiday CRUD chip — origin badge + source class + tooltip | `apps/web/src/views/attendance/AttendanceHolidayDataSection.vue` chip render area + chip-origin CSS |
+| AttendanceView raw `holidays` (CRUD, unchanged) | `apps/web/src/views/AttendanceView.vue` `holidays` ref + `loadHolidays` |
+| AttendanceView NEW `calendarEffectiveChips` / `loadEffectiveCalendarForOverview` / `committedCalendarUserId` / watchers | `AttendanceView.vue` near `holidayMap` computed |
+| AttendanceView `calendarDays` switched to read `calendarEffectiveChipMap` + `sourceClass` + chip tooltip | `AttendanceView.vue` calendarDays computed |
+| MetaCalendarView refactor — helpers imported from `calendarChipDisplay.ts`; source class applied to chip | `apps/web/src/multitable/components/MetaCalendarView.vue` |
+
+## Visual contract (PR1 + PR2 combined)
+
+| Cell state | Classes | Notes |
+| --- | --- | --- |
+| National/manual rest day | `--rest` (existing red) + `calendar-source--{national\|manual}` | source-color border-left from shared palette |
+| Working-day override row | `--working` (existing green) + `calendar-source--{national\|manual}` | |
+| Calendar policy fired on top | above + `--overridden` (dotted bottom, PR1) + `calendar-source--{org\|group\|role\|user}` | tooltip carries layer chain |
+| Overlay present | above + `--with-overlay` (dot suffix, PR1) | tooltip carries overlay summary |
+| Plain rule day with overlay | `--working` + `--with-overlay` (no source class) | chip name derives from first overlay (PR1 fallback) |
+| Admin holiday chip | `attendance__holiday-chip` + `--working`/`--holiday` + `calendar-source--{national\|manual}` + `N`/`M` text badge | hover discloses sync vs manual source |
+
+## Source palette
+
+| Source | Border accent | Semantic |
+| --- | --- | --- |
+| `national` | `#d73a4a` red | from `/holidays/sync` |
+| `manual` | `#6e7681` gray | org baseline (admin handwritten) |
+| `org` | `#fb8500` orange | company override of national/manual |
+| `group` | `#3a86ff` blue | group calendar policy override |
+| `role` | `#9b5de5` purple | role-based override (v1 inert in resolver, valid config) |
+| `user` | `#063070` deep blue | user-specific override |
+| `rule` / `shift` / `rotation` | (no accent) | default working day |
+
+## Known limitations (carried forward)
+
+- `role` / `roleTags` calendarPolicy entries are still inert in the
+  effective-calendar resolver (no DB-backed role context in v1). PR1's
+  test guards this contract.
+- `groupId` resolver mode uses the org default rule for base; group
+  `rule_set` working days are not applied in v1.
+- AttendanceView fetch gating + replay mirrors PR1 Workbench's stale-response
+  protection while committing `targetUserId` only on Refresh. A dedicated
+  selfservice-dashboard mount test pins that typing in the user field does not
+  trigger an effective-calendar fetch until Refresh commits the value.
+
+## Test surface (PR2 contributions)
+
+- `apps/web/tests/calendarChipDisplay.spec.ts` (new) — 11 unit cases covering
+  source class derivation, override marker, tooltip composition, fallback
+  name, holiday origin class + badge.
+- `apps/web/tests/useAttendanceAdminScheduling.spec.ts` (extended) — origin
+  roundtrip from `/api/attendance/holidays` response into `holidays.value`;
+  admin save body asserts no `origin` field (Should-Fix #4).
+- PR1's existing specs (multitable Calendar view + effectiveCalendar client)
+  continue passing unchanged — `calendarChipDisplay` extraction did not
+  alter behavior; MetaCalendarView simply imports the same helpers it
+  used to declare inline.
+
+## Migration / rollout notes
+
+- The shared CSS is loaded globally at `main.ts`; no per-page bundling cost
+  beyond a few KB.
+- AttendanceView's personal calendar will briefly show no chips during the
+  auth-resolving window (compared to the old flow which always rendered
+  holidays from `/api/attendance/holidays` immediately). This is acceptable
+  by design — the personal view depends on knowing who the user is. Once
+  PR2 lands, the watch+replay pattern ensures the chips populate as soon as
+  auth resolves.
+- Admin CRUD is unchanged in observable behavior; only the chip layer gains
+  the origin badge + border accent.

--- a/docs/development/attendance-views-effective-calendar-verification-20260520.md
+++ b/docs/development/attendance-views-effective-calendar-verification-20260520.md
@@ -1,0 +1,117 @@
+# Attendance Views — Effective Calendar Integration (PR2) — Verification
+
+Date: 2026-05-20
+Branch: `frontend/attendance-views-effective-calendar-20260520`
+Base: `origin/main@bf44e3688` (includes PR1 #1712 and #1714)
+Commit: branch tip `feat(attendance): personal calendar + holiday chip on effective-calendar`
+
+## Definition of Done (gate)
+
+PR2 is merge-ready when:
+
+1. New + extended specs print their concrete passing case names below.
+2. `vue-tsc --noEmit` (web) completes with no new errors.
+3. Full `vitest run` over `apps/web` shows the same 9 baseline-failing
+   files reproducible on pristine `origin/main`; PR2 adds zero new
+   regressions.
+
+The current run satisfies all three.
+
+## Commands Run (local)
+
+| Command | Result |
+| --- | --- |
+| `pnpm install` (fresh worktree) | OK |
+| `pnpm --filter @metasheet/web exec vue-tsc -b` | PASS (TypeScript clean) |
+| `pnpm --filter @metasheet/web exec vitest run tests/calendarChipDisplay.spec.ts tests/useAttendanceAdminScheduling.spec.ts --reporter=dot` | PASS — 34 tests (11 chip display + 23 scheduling, including 2 new origin tests). |
+| `pnpm --filter @metasheet/web exec vitest run tests/multitable-calendar-view.spec.ts tests/effectiveCalendar.spec.ts --reporter=dot` | PASS — 26 tests (PR1 specs unchanged). |
+| `pnpm --filter @metasheet/web exec vitest run tests/attendance-selfservice-dashboard.spec.ts --reporter=dot` | PASS — 6 tests (5 pre-existing + 1 new PR2-review test verifying targetUserId is not committed until Refresh). |
+| `pnpm --filter @metasheet/web exec vitest run --reporter=dot` (full web suite) | 274 passed / 9 failed (282); the 9 fail files match PR1's baseline list exactly. |
+| `git diff --check origin/main..HEAD` (post-commit) | clean (planned) |
+
+## Concrete pass evidence
+
+```
+✓ tests/calendarChipDisplay.spec.ts > calendarChipSourceClassName > maps each calendar_policy/base source to the matching CSS hook
+✓ tests/calendarChipDisplay.spec.ts > calendarChipSourceClassName > returns undefined for plain rule/shift/rotation days so no accent is painted
+✓ tests/calendarChipDisplay.spec.ts > hasCalendarChipOverrideMarker > returns true only when at least one calendar_policy layer fired
+✓ tests/calendarChipDisplay.spec.ts > hasCalendarChipOverrideMarker > returns false for chips with only base layers
+✓ tests/calendarChipDisplay.spec.ts > buildCalendarChipTooltip > returns undefined for a legacy CalendarHoliday payload (no effective/base/layers/overlays)
+✓ tests/calendarChipDisplay.spec.ts > buildCalendarChipTooltip > composes date + verdict + source on line 1
+✓ tests/calendarChipDisplay.spec.ts > buildCalendarChipTooltip > renders layer chain on line 2 and overlay summary on line 3 in stable order
+✓ tests/calendarChipDisplay.spec.ts > fallbackChipName > returns "Working day" / "Holiday" by isWorkingDay
+✓ tests/calendarChipDisplay.spec.ts > attendance holiday origin helpers > maps origin=national/manual to the matching shared palette class
+✓ tests/calendarChipDisplay.spec.ts > attendance holiday origin helpers > defaults to manual when origin is missing (legacy rows / older backends)
+✓ tests/calendarChipDisplay.spec.ts > attendance holiday origin helpers > returns the short N/M badge letter for the chip
+✓ tests/useAttendanceAdminScheduling.spec.ts > preserves the holiday row origin (national/manual) loaded from /api/attendance/holidays for PR2 admin chip badge
+✓ tests/useAttendanceAdminScheduling.spec.ts > does NOT send origin in the holiday save body — backend keeps manual as authoritative default
+```
+
+Existing PR1 specs continue passing unchanged after PR2's helper extraction:
+
+```
+✓ tests/effectiveCalendar.spec.ts  (16 tests)
+✓ tests/multitable-calendar-view.spec.ts  (10 tests)
+```
+
+PR2 review Layer 3 add:
+
+```
+✓ tests/attendance-selfservice-dashboard.spec.ts > Attendance self-service dashboard > PR2 review #1: typing targetUserId does not request effective-calendar until Refresh commits it
+```
+
+## Regression matrix
+
+| Codex Must-Fix / Should-Fix | Covered by |
+| --- | --- |
+| Must-Fix #1: raw/effective split | `AttendanceView.vue` keeps `holidays` ref + `loadHolidays()` for admin CRUD; new `calendarEffectiveChips` + `loadEffectiveCalendarForOverview()` for overview only; `calendarDays` switched to `calendarEffectiveChipMap`. selfservice-dashboard spec confirms admin path still works. |
+| Must-Fix #2: useAuth + currentUserId gate + replay | `useAuth()` imported, `currentUserId` populated in `onMounted`, `committedCalendarUserId` is set by auth bootstrap or Refresh, fetcher early-returns when null, `watch(committedCalendarUserId, …)` replays `lastCalendarEffectiveRange`. Layer 3 mount test covers the committed-user contract. |
+| Should-Fix #1: shared tooltip helper, no duplication | `calendarChipDisplay.ts` consolidates the 4 PR1 helpers; MetaCalendarView no longer declares them inline; AttendanceView + HolidayDataSection import the same set. Unit test pinning the helper contract. |
+| Should-Fix #2: border-left accent | Global CSS in `calendar-source-palette.css`. Test: chip rendering tests pass after adding `calendar-source--{kind}` class; calendarChipDisplay unit asserts the class mapping. |
+| Should-Fix #3: shared CSS via main.ts (not per-SFC @import) | `main.ts` imports the file once globally; no per-component `<style>` `@import` for the palette. |
+| Should-Fix #4: POST/PUT no `origin` | New scheduling spec inspects the save body and asserts `origin` is absent. |
+| Should-Fix #5 (3-layer tests) | Layers 1 (chip display) + 2 (scheduling/holiday) covered. Layer 3 added in PR2 review pass: new `attendance-selfservice-dashboard.spec.ts` case "typing targetUserId does not request effective-calendar until Refresh commits it" mounts AttendanceView, dispatches an input event on the targetUserId field, asserts no new fetch fired, then clicks Refresh and asserts the fetch URL carries the typed userId. |
+| **PR2 review Blocking #1** (typing v-model triggers fetch) | `effectiveUserId` computed removed; `committedCalendarUserId` ref set ONLY by refreshAll() (and the initial auth resolution when no targetUserId is typed). Layer 3 test pins the contract. |
+| **PR2 review Blocking #2** (no stale-response guard + Refresh does not force) | `calendarEffectiveLoadVersion` counter checked after each await; `loadEffectiveCalendarForOverview(range, { force })` accepts a force flag; refreshAll passes `force: true` so same-(from,to,userId) Refresh discards the cache. |
+| **PR2 review Medium #3** (global accent overridden by scoped border) | AttendanceView's scoped `.attendance__calendar-holiday` now redeclares `border-left: 4px solid var(--calendar-source-accent, #fed7aa)`. Fallback to the existing chip border color when no source class is applied. |
+
+## Pre-existing failures (zero PR2 regression)
+
+The 9 failing files in `pnpm vitest run` for `@metasheet/web` are the same
+set documented in PR1's verification MD; PR2 introduces no new failures.
+
+| # | File | Status on PR2 worktree | Notes |
+| --- | --- | --- | --- |
+| 1 | `tests/multitable-workbench-manager-flow.spec.ts` | Fails identically | Stale select count, pre-PR1 |
+| 2 | `tests/multitable-workbench-view.spec.ts` | Fails identically | Workflow designer spy expectation, pre-PR1 |
+| 3 | `tests/approval-center.spec.ts` | Fails identically | Untouched by PR2 |
+| 4 | `tests/attendance-import-batch-timezone-status.spec.ts` | Fails identically (4 tests) | Untouched by PR2 |
+| 5 | `tests/attendance-record-timeline.spec.ts` | Fails identically (4 tests) | Untouched by PR2 |
+| 6 | `tests/featureFlags.spec.ts` | Fails identically (3 tests) | Untouched by PR2 |
+| 7 | `tests/multitable-phase11.spec.ts` | Fails identically | Untouched by PR2 |
+| 8 | `tests/multitable-comment-inbox-realtime.spec.ts` | Fails identically (file-level) | Untouched by PR2 |
+| 9 | `tests/useAttendanceAdminRail.spec.ts` | Fails identically | Untouched by PR2 |
+
+## Remaining gate
+
+None for this slice. PR2 is ready for `frontend/...` lane PR review.
+
+## Static evidence
+
+- `apps/web/src/services/attendance/effectiveCalendar.ts` unchanged from PR1
+  for fetcher + types; PR2 only extracts the previously-inline display
+  helpers into the sibling `calendarChipDisplay.ts`.
+- `MultitableWorkbench.vue` is **not** modified by PR2 (only PR1 surface).
+- Existing admin CRUD endpoints under `/api/attendance/holidays*` see no
+  body/payload changes; the only schema change is `AttendanceHoliday.origin?`
+  becoming a known TypeScript field on the response shape.
+- `MultitableEmbedHost.vue` is **not** modified (mirrors PR1 constraint).
+
+## What Step 5 inherits
+
+- Shared `effectiveCalendar.ts` types + fetcher + chip mapper continue as
+  the resolver contract surface; the calc-chain cutover (`resolveWorkContext`
+  → effective resolver) reads the same item shape.
+- The 3 calendar UI surfaces now consume the same data source, so the
+  cutover only changes the source of truth on the backend without
+  re-engineering the frontend.


### PR DESCRIPTION
## Summary
- Wire AttendanceView personal calendar to /api/attendance/effective-calendar with raw holiday CRUD kept separate from effective-calendar chips.
- Add shared calendar chip display helpers and global source palette used by multitable Calendar, AttendanceView, and holiday admin chips.
- Surface national/manual holiday origin badges in the admin holiday calendar without sending origin in POST/PUT bodies.
- Close review fixes: committed userId only on Refresh, stale-response guard + force refresh, and scoped border-left source accent.

## Verification
- pnpm --filter @metasheet/web exec vitest run --watch=false tests/calendarChipDisplay.spec.ts tests/useAttendanceAdminScheduling.spec.ts tests/effectiveCalendar.spec.ts tests/multitable-calendar-view.spec.ts tests/attendance-selfservice-dashboard.spec.ts --reporter=dot
  - PASS: 5 files / 66 tests
- pnpm --filter @metasheet/web type-check
  - PASS
- pnpm --filter @metasheet/web build
  - PASS
- pnpm --filter @metasheet/web exec vitest run --reporter=dot
  - 274 passed / 9 baseline-failing files, same baseline set documented in verification MD
- git diff --check origin/main..HEAD and origin/main...HEAD
  - clean

## Docs
- docs/development/attendance-views-effective-calendar-development-20260520.md
- docs/development/attendance-views-effective-calendar-verification-20260520.md

## Notes
- No backend or migration changes in this PR.
- Worktree still has uncommitted pnpm node_modules noise only; it is not part of the PR diff.