### PR TITLE
feat(multitable): localize API token manager chrome (T3C-2c)

### DIFF
--- a/apps/web/src/multitable/components/MetaApiTokenManager.vue
+++ b/apps/web/src/multitable/components/MetaApiTokenManager.vue
@@ -14,7 +14,7 @@
           :class="{ 'meta-api-mgr__tab--active': activeTab === 'tokens' }"
           @click="activeTab = 'tokens'"
         >
-          API Tokens
+          {{ a('tab.tokens') }}
         </button>
         <button
           role="tab"
@@ -23,7 +23,7 @@
           :class="{ 'meta-api-mgr__tab--active': activeTab === 'webhooks' }"
           @click="activeTab = 'webhooks'"
         >
-          Webhooks
+          {{ a('tab.webhooks') }}
         </button>
         <button
           v-if="canManageDingTalkGroups"
@@ -33,7 +33,7 @@
           :class="{ 'meta-api-mgr__tab--active': activeTab === 'dingtalk-groups' }"
           @click="activeTab = 'dingtalk-groups'"
         >
-          DingTalk Groups
+          {{ a('tab.dingtalkGroups') }}
         </button>
       </div>
 
@@ -45,63 +45,63 @@
           role="note"
           data-dingtalk-groups-permission-note="true"
         >
-          DingTalk group bindings require automation management permission for this table.
+          {{ a('notice.dingtalkPermission') }}
         </div>
 
         <!-- ===== TOKENS TAB ===== -->
         <template v-if="activeTab === 'tokens'">
           <!-- Newly created token (show once) -->
           <div v-if="newTokenPlaintext" class="meta-api-mgr__new-token" data-new-token="true">
-            <strong>Your new API token (shown once):</strong>
+            <strong>{{ a('token.newShownOnce') }}</strong>
             <div class="meta-api-mgr__token-display">
               <code data-new-token-value="true">{{ newTokenPlaintext }}</code>
               <button class="meta-api-mgr__btn meta-api-mgr__btn--primary" type="button" data-copy-new-token="true" @click="onCopyNewToken">
-                {{ copiedNewToken ? 'Copied!' : 'Copy' }}
+                {{ copiedNewToken ? a('token.action.copied') : a('token.action.copy') }}
               </button>
             </div>
-            <p class="meta-api-mgr__warning">Save this token now. You will not be able to see it again.</p>
-            <button class="meta-api-mgr__btn" type="button" @click="newTokenPlaintext = null">Dismiss</button>
+            <p class="meta-api-mgr__warning">{{ a('token.saveWarning') }}</p>
+            <button class="meta-api-mgr__btn" type="button" @click="newTokenPlaintext = null">{{ m('action.dismiss') }}</button>
           </div>
 
           <!-- Create form -->
           <section v-if="showTokenForm" class="meta-api-mgr__form" data-token-form="true">
-            <div class="meta-api-mgr__form-title">New API Token</div>
-            <label class="meta-api-mgr__label">Name</label>
-            <input v-model="tokenDraft.name" class="meta-api-mgr__input" type="text" placeholder="Token name" data-token-name="true" />
-            <label class="meta-api-mgr__label">Scopes</label>
+            <div class="meta-api-mgr__form-title">{{ a('token.newTitle') }}</div>
+            <label class="meta-api-mgr__label">{{ a('token.name') }}</label>
+            <input v-model="tokenDraft.name" class="meta-api-mgr__input" type="text" :placeholder="a('token.namePlaceholder')" data-token-name="true" />
+            <label class="meta-api-mgr__label">{{ a('token.scopes') }}</label>
             <div class="meta-api-mgr__checkboxes">
               <label v-for="scope in availableScopes" :key="scope" class="meta-api-mgr__checkbox-label">
                 <input type="checkbox" :value="scope" :checked="tokenDraft.scopes.includes(scope)" @change="onToggleScope(scope)" :data-token-scope="scope" />
-                {{ scope }}
+                {{ apiScopeLabel(scope, isZh) }}
               </label>
             </div>
-            <label class="meta-api-mgr__label">Expiry (optional)</label>
+            <label class="meta-api-mgr__label">{{ a('token.expiryOptional') }}</label>
             <input v-model="tokenDraft.expiresAt" class="meta-api-mgr__input" type="date" data-token-expiry="true" />
             <div class="meta-api-mgr__form-actions">
-              <button class="meta-api-mgr__btn meta-api-mgr__btn--primary" type="button" :disabled="!tokenDraft.name.trim() || busy" data-token-create="true" @click="onCreateToken">Create</button>
-              <button class="meta-api-mgr__btn" type="button" @click="showTokenForm = false">Cancel</button>
+              <button class="meta-api-mgr__btn meta-api-mgr__btn--primary" type="button" :disabled="!tokenDraft.name.trim() || busy" data-token-create="true" @click="onCreateToken">{{ a('token.action.create') }}</button>
+              <button class="meta-api-mgr__btn" type="button" @click="showTokenForm = false">{{ m('action.cancel') }}</button>
             </div>
           </section>
 
-          <button v-if="!showTokenForm" class="meta-api-mgr__btn meta-api-mgr__btn--primary meta-api-mgr__btn-add" type="button" data-token-new="true" @click="openTokenForm">+ New Token</button>
+          <button v-if="!showTokenForm" class="meta-api-mgr__btn meta-api-mgr__btn--primary meta-api-mgr__btn-add" type="button" data-token-new="true" @click="openTokenForm">{{ a('token.newButton') }}</button>
 
           <!-- Token list -->
-          <div v-if="tokensLoading" class="meta-api-mgr__empty">Loading tokens&#x2026;</div>
-          <div v-else-if="!tokens.length && !showTokenForm" class="meta-api-mgr__empty" data-tokens-empty="true">No API tokens yet.</div>
+          <div v-if="tokensLoading" class="meta-api-mgr__empty">{{ a('token.loading') }}</div>
+          <div v-else-if="!tokens.length && !showTokenForm" class="meta-api-mgr__empty" data-tokens-empty="true">{{ a('token.empty') }}</div>
           <div v-for="token in tokens" :key="token.id" class="meta-api-mgr__card" :data-token-id="token.id">
             <div class="meta-api-mgr__card-header">
               <strong class="meta-api-mgr__card-name">{{ token.name }}</strong>
               <code class="meta-api-mgr__card-prefix">{{ token.prefix }}...</code>
             </div>
             <div class="meta-api-mgr__card-meta">
-              <span>Scopes: {{ token.scopes.join(', ') || 'none' }}</span>
-              <span>Created: {{ formatDate(token.createdAt) }}</span>
-              <span v-if="token.lastUsedAt">Last used: {{ formatDate(token.lastUsedAt) }}</span>
-              <span v-if="token.expiresAt">Expires: {{ formatDate(token.expiresAt) }}</span>
+              <span>{{ a('token.meta.scopes') }}: {{ apiScopesText(token.scopes, isZh) }}</span>
+              <span>{{ a('token.meta.created') }}: {{ formatDate(token.createdAt) }}</span>
+              <span v-if="token.lastUsedAt">{{ a('token.meta.lastUsed') }}: {{ formatDate(token.lastUsedAt) }}</span>
+              <span v-if="token.expiresAt">{{ a('token.meta.expires') }}: {{ formatDate(token.expiresAt) }}</span>
             </div>
             <div class="meta-api-mgr__card-actions">
-              <button class="meta-api-mgr__btn" type="button" :disabled="busy" data-token-rotate="true" @click="onRotateToken(token.id)">Rotate</button>
-              <button class="meta-api-mgr__btn meta-api-mgr__btn--danger" type="button" :disabled="busy" data-token-revoke="true" @click="onRevokeToken(token.id)">Revoke</button>
+              <button class="meta-api-mgr__btn" type="button" :disabled="busy" data-token-rotate="true" @click="onRotateToken(token.id)">{{ a('token.action.rotate') }}</button>
+              <button class="meta-api-mgr__btn meta-api-mgr__btn--danger" type="button" :disabled="busy" data-token-revoke="true" @click="onRevokeToken(token.id)">{{ a('token.action.revoke') }}</button>
             </div>
           </div>
         </template>
@@ -110,64 +110,64 @@
         <template v-if="activeTab === 'webhooks'">
           <!-- Create/Edit form -->
           <section v-if="showWebhookForm" class="meta-api-mgr__form" data-webhook-form="true">
-            <div class="meta-api-mgr__form-title">{{ editingWebhookId ? 'Edit Webhook' : 'New Webhook' }}</div>
-            <label class="meta-api-mgr__label">Name</label>
-            <input v-model="webhookDraft.name" class="meta-api-mgr__input" type="text" placeholder="Webhook name" data-webhook-name="true" />
-            <label class="meta-api-mgr__label">URL (HTTPS required)</label>
-            <input v-model="webhookDraft.url" class="meta-api-mgr__input" type="url" placeholder="https://example.com/webhook" data-webhook-url="true" />
-            <label class="meta-api-mgr__label">Events</label>
+            <div class="meta-api-mgr__form-title">{{ editingWebhookId ? a('webhook.editTitle') : a('webhook.newTitle') }}</div>
+            <label class="meta-api-mgr__label">{{ a('webhook.name') }}</label>
+            <input v-model="webhookDraft.name" class="meta-api-mgr__input" type="text" :placeholder="a('webhook.namePlaceholder')" data-webhook-name="true" />
+            <label class="meta-api-mgr__label">{{ a('webhook.url') }}</label>
+            <input v-model="webhookDraft.url" class="meta-api-mgr__input" type="url" :placeholder="a('webhook.urlPlaceholder')" data-webhook-url="true" />
+            <label class="meta-api-mgr__label">{{ a('webhook.events') }}</label>
             <div class="meta-api-mgr__checkboxes">
               <label v-for="evt in availableEvents" :key="evt" class="meta-api-mgr__checkbox-label">
                 <input type="checkbox" :value="evt" :checked="webhookDraft.events.includes(evt)" @change="onToggleEvent(evt)" :data-webhook-event="evt" />
-                {{ evt }}
+                {{ apiWebhookEventLabel(evt, isZh) }}
               </label>
             </div>
-            <label class="meta-api-mgr__label">Secret (optional)</label>
-            <input v-model="webhookDraft.secret" class="meta-api-mgr__input" type="text" placeholder="HMAC secret" data-webhook-secret="true" />
+            <label class="meta-api-mgr__label">{{ a('webhook.secretOptional') }}</label>
+            <input v-model="webhookDraft.secret" class="meta-api-mgr__input" type="text" :placeholder="a('webhook.secretPlaceholder')" data-webhook-secret="true" />
             <div class="meta-api-mgr__form-actions">
               <button class="meta-api-mgr__btn meta-api-mgr__btn--primary" type="button" :disabled="!canSaveWebhook || busy" data-webhook-save="true" @click="onSaveWebhook">
-                {{ editingWebhookId ? 'Update' : 'Create' }}
+                {{ editingWebhookId ? a('webhook.action.update') : a('webhook.action.create') }}
               </button>
-              <button class="meta-api-mgr__btn" type="button" @click="cancelWebhookForm">Cancel</button>
+              <button class="meta-api-mgr__btn" type="button" @click="cancelWebhookForm">{{ m('action.cancel') }}</button>
             </div>
           </section>
 
-          <button v-if="!showWebhookForm" class="meta-api-mgr__btn meta-api-mgr__btn--primary meta-api-mgr__btn-add" type="button" data-webhook-new="true" @click="openWebhookForm">+ New Webhook</button>
+          <button v-if="!showWebhookForm" class="meta-api-mgr__btn meta-api-mgr__btn--primary meta-api-mgr__btn-add" type="button" data-webhook-new="true" @click="openWebhookForm">{{ a('webhook.newButton') }}</button>
 
           <!-- Webhook list -->
-          <div v-if="webhooksLoading" class="meta-api-mgr__empty">Loading webhooks&#x2026;</div>
-          <div v-else-if="!webhooks.length && !showWebhookForm" class="meta-api-mgr__empty" data-webhooks-empty="true">No webhooks yet.</div>
+          <div v-if="webhooksLoading" class="meta-api-mgr__empty">{{ a('webhook.loading') }}</div>
+          <div v-else-if="!webhooks.length && !showWebhookForm" class="meta-api-mgr__empty" data-webhooks-empty="true">{{ a('webhook.empty') }}</div>
           <div v-for="wh in webhooks" :key="wh.id" class="meta-api-mgr__card" :data-webhook-id="wh.id">
             <div class="meta-api-mgr__card-header">
               <strong class="meta-api-mgr__card-name">{{ wh.name }}</strong>
               <span class="meta-api-mgr__card-status" :data-webhook-status="wh.active ? 'active' : 'disabled'">
-                {{ wh.active ? 'Active' : 'Disabled' }}
+                {{ apiWebhookStatusLabel(wh.active, isZh) }}
               </span>
             </div>
             <div class="meta-api-mgr__card-meta">
-              <span>URL: {{ wh.url }}</span>
-              <span>Events: {{ wh.events.join(', ') }}</span>
-              <span v-if="wh.failureCount > 0" class="meta-api-mgr__card-failures">Failures: {{ wh.failureCount }}</span>
+              <span>{{ a('webhook.meta.url') }}: {{ wh.url }}</span>
+              <span>{{ a('webhook.meta.events') }}: {{ apiWebhookEventsText(wh.events, isZh) }}</span>
+              <span v-if="wh.failureCount > 0" class="meta-api-mgr__card-failures">{{ a('webhook.meta.failures') }}: {{ wh.failureCount }}</span>
             </div>
             <div class="meta-api-mgr__card-actions">
-              <button class="meta-api-mgr__btn" type="button" data-webhook-edit="true" @click="openEditWebhook(wh)">Edit</button>
+              <button class="meta-api-mgr__btn" type="button" data-webhook-edit="true" @click="openEditWebhook(wh)">{{ a('webhook.action.edit') }}</button>
               <button class="meta-api-mgr__btn" type="button" data-webhook-toggle="true" :disabled="busy" @click="onToggleWebhook(wh)">
-                {{ wh.active ? 'Disable' : 'Enable' }}
+                {{ apiToggleLabel(wh.active, isZh) }}
               </button>
-              <button class="meta-api-mgr__btn" type="button" data-webhook-deliveries="true" @click="onViewDeliveries(wh.id)">Deliveries</button>
-              <button class="meta-api-mgr__btn meta-api-mgr__btn--danger" type="button" :disabled="busy" data-webhook-delete="true" @click="onDeleteWebhook(wh.id)">Delete</button>
+              <button class="meta-api-mgr__btn" type="button" data-webhook-deliveries="true" @click="onViewDeliveries(wh.id)">{{ a('webhook.action.deliveries') }}</button>
+              <button class="meta-api-mgr__btn meta-api-mgr__btn--danger" type="button" :disabled="busy" data-webhook-delete="true" @click="onDeleteWebhook(wh.id)">{{ m('action.delete') }}</button>
             </div>
 
             <!-- Delivery history (inline) -->
             <div v-if="deliveriesWebhookId === wh.id && deliveries.length" class="meta-api-mgr__deliveries" data-deliveries="true">
-              <strong class="meta-api-mgr__label">Recent Deliveries</strong>
+              <strong class="meta-api-mgr__label">{{ a('webhook.delivery.recent') }}</strong>
               <div v-for="d in deliveries" :key="d.id" class="meta-api-mgr__delivery-row" :data-delivery-id="d.id">
                 <span :class="d.success ? 'meta-api-mgr__delivery--ok' : 'meta-api-mgr__delivery--fail'">
-                  {{ d.success ? 'OK' : 'FAIL' }}
+                  {{ apiDeliveryResultLabel(d.success, isZh) }}
                 </span>
-                <span>{{ d.event }}</span>
+                <span>{{ apiWebhookEventLabel(d.event, isZh) }}</span>
                 <span>HTTP {{ d.httpStatus ?? '-' }}</span>
-                <span v-if="d.retryCount > 0">Retries: {{ d.retryCount }}</span>
+                <span v-if="d.retryCount > 0">{{ a('webhook.delivery.retries') }}: {{ d.retryCount }}</span>
                 <span>{{ formatDate(d.timestamp) }}</span>
               </div>
             </div>
@@ -177,34 +177,34 @@
         <!-- ===== DINGTALK GROUPS TAB ===== -->
         <template v-if="canManageDingTalkGroups && activeTab === 'dingtalk-groups'">
           <section class="meta-api-mgr__notice" data-dingtalk-groups-scope-note="true">
-            <strong>Table-scoped DingTalk groups</strong>
-            <span>Groups created here are bound to this table. You can add multiple groups and choose one or more in automations; organization catalog groups are listed read-only when shared with your organization.</span>
-            <span>Register DingTalk robot webhooks as send destinations for this table. This does not import DingTalk group members or control form access.</span>
+            <strong>{{ a('dingtalk.scopeNote.title') }}</strong>
+            <span>{{ a('dingtalk.scopeNote.bound') }}</span>
+            <span>{{ a('dingtalk.scopeNote.delivery') }}</span>
           </section>
 
           <section v-if="showDingTalkGroupForm" class="meta-api-mgr__form" data-dingtalk-group-form="true">
             <div class="meta-api-mgr__form-title">
-              {{ editingDingTalkGroupId ? 'Edit DingTalk Group' : 'New DingTalk Group' }}
+              {{ editingDingTalkGroupId ? a('dingtalk.editTitle') : a('dingtalk.newTitle') }}
             </div>
-            <label class="meta-api-mgr__label">Name</label>
+            <label class="meta-api-mgr__label">{{ a('dingtalk.name') }}</label>
             <input
               v-model="dingTalkGroupDraft.name"
               class="meta-api-mgr__input"
               type="text"
-              placeholder="Support group"
+              :placeholder="a('dingtalk.namePlaceholder')"
               data-dingtalk-group-name="true"
             />
-            <label class="meta-api-mgr__label">Webhook URL</label>
+            <label class="meta-api-mgr__label">{{ a('dingtalk.webhookUrl') }}</label>
             <input
               v-model="dingTalkGroupDraft.webhookUrl"
               class="meta-api-mgr__input"
               type="url"
-              placeholder="https://oapi.dingtalk.com/robot/send?access_token=..."
+              :placeholder="a('dingtalk.webhookPlaceholder')"
               aria-describedby="dingtalk-group-webhook-help"
               data-dingtalk-group-webhook-url="true"
             />
             <p id="dingtalk-group-webhook-help" class="meta-api-mgr__help" data-dingtalk-group-webhook-help="true">
-              Paste the robot webhook from the target DingTalk group robot settings. After saving, this destination appears in this table's automation rule editor. The access token is stored for delivery but masked in this UI.
+              {{ a('dingtalk.webhookHelp') }}
             </p>
             <p
               v-if="dingTalkGroupWebhookValidationMessage && dingTalkGroupDraft.webhookUrl.trim()"
@@ -213,12 +213,12 @@
             >
               {{ dingTalkGroupWebhookValidationMessage }}
             </p>
-            <label class="meta-api-mgr__label">Secret (optional)</label>
+            <label class="meta-api-mgr__label">{{ a('dingtalk.secretOptional') }}</label>
             <input
               v-model="dingTalkGroupDraft.secret"
               class="meta-api-mgr__input"
               type="text"
-              placeholder="SEC..."
+              :placeholder="a('dingtalk.secretPlaceholder')"
               :disabled="dingTalkGroupDraft.clearSecret"
               aria-describedby="dingtalk-group-secret-help"
               data-dingtalk-group-secret="true"
@@ -243,7 +243,7 @@
                 type="checkbox"
                 data-dingtalk-group-clear-secret="true"
               />
-              Clear saved SEC secret
+              {{ a('dingtalk.clearSecret') }}
             </label>
             <label class="meta-api-mgr__checkbox-label">
               <input
@@ -251,7 +251,7 @@
                 type="checkbox"
                 data-dingtalk-group-enabled="true"
               />
-              Enabled
+              {{ a('dingtalk.enabled') }}
             </label>
             <div class="meta-api-mgr__form-actions">
               <button
@@ -261,9 +261,9 @@
                 data-dingtalk-group-save="true"
                 @click="onSaveDingTalkGroup"
               >
-                {{ editingDingTalkGroupId ? 'Update' : 'Create' }}
+                {{ editingDingTalkGroupId ? a('dingtalk.action.update') : a('dingtalk.action.create') }}
               </button>
-              <button class="meta-api-mgr__btn" type="button" @click="cancelDingTalkGroupForm">Cancel</button>
+              <button class="meta-api-mgr__btn" type="button" @click="cancelDingTalkGroupForm">{{ m('action.cancel') }}</button>
             </div>
           </section>
 
@@ -274,16 +274,16 @@
             data-dingtalk-group-new="true"
             @click="openDingTalkGroupForm"
           >
-            + New DingTalk Group
+            {{ a('dingtalk.newButton') }}
           </button>
 
-          <div v-if="dingTalkGroupsLoading" class="meta-api-mgr__empty">Loading DingTalk groups&#x2026;</div>
+          <div v-if="dingTalkGroupsLoading" class="meta-api-mgr__empty">{{ a('dingtalk.loading') }}</div>
           <div
             v-else-if="!dingTalkGroups.length && !showDingTalkGroupForm"
             class="meta-api-mgr__empty"
             data-dingtalk-groups-empty="true"
           >
-            No DingTalk group destinations yet. Add a group robot webhook before configuring group-message automations.
+            {{ a('dingtalk.empty') }}
           </div>
           <div
             v-for="group in dingTalkGroups"
@@ -294,40 +294,40 @@
             <div class="meta-api-mgr__card-header">
               <strong class="meta-api-mgr__card-name">{{ group.name }}</strong>
               <span class="meta-api-mgr__card-status" :data-dingtalk-group-status="group.enabled ? 'enabled' : 'disabled'">
-                {{ group.enabled ? 'Enabled' : 'Disabled' }}
+                {{ apiDingTalkEnabledLabel(group.enabled, isZh) }}
               </span>
             </div>
             <div class="meta-api-mgr__card-meta">
-              <span>Webhook: {{ maskDingTalkWebhookUrl(group.webhookUrl) }}</span>
-              <span>Secret: {{ group.hasSecret ? 'configured' : 'not configured' }}</span>
+              <span>{{ a('dingtalk.meta.webhook') }}: {{ maskDingTalkWebhookUrl(group.webhookUrl) }}</span>
+              <span>{{ a('dingtalk.meta.secret') }}: {{ apiDingTalkSecretStateLabel(group.hasSecret === true, isZh) }}</span>
               <span>{{ dingTalkGroupScopeLabel(group) }}</span>
-              <span>Created: {{ formatDate(group.createdAt) }}</span>
-              <span v-if="group.lastTestedAt">Last test: {{ formatDate(group.lastTestedAt) }}</span>
+              <span>{{ a('dingtalk.meta.created') }}: {{ formatDate(group.createdAt) }}</span>
+              <span v-if="group.lastTestedAt">{{ a('dingtalk.meta.lastTest') }}: {{ formatDate(group.lastTestedAt) }}</span>
               <span v-if="group.lastTestStatus" :data-dingtalk-group-test-status="group.lastTestStatus">
-                Test status: {{ group.lastTestStatus }}
+                {{ a('dingtalk.meta.testStatus') }}: {{ group.lastTestStatus }}
               </span>
             </div>
             <div v-if="group.lastTestError" class="meta-api-mgr__card-meta meta-api-mgr__card-failures">
-              <span>Last error: {{ group.lastTestError }}</span>
+              <span>{{ a('dingtalk.meta.lastError') }}: {{ group.lastTestError }}</span>
             </div>
             <div class="meta-api-mgr__card-actions">
               <button v-if="canMutateDingTalkGroup(group)" class="meta-api-mgr__btn" type="button" data-dingtalk-group-edit="true" @click="openEditDingTalkGroup(group)">
-                Edit
+                {{ a('dingtalk.action.edit') }}
               </button>
               <button v-if="canMutateDingTalkGroup(group)" class="meta-api-mgr__btn" type="button" :disabled="busy" data-dingtalk-group-toggle="true" @click="onToggleDingTalkGroup(group)">
-                {{ group.enabled ? 'Disable' : 'Enable' }}
+                {{ apiDingTalkToggleLabel(group.enabled, isZh) }}
               </button>
               <button class="meta-api-mgr__btn" type="button" data-dingtalk-group-deliveries="true" @click="onViewDingTalkDeliveries(group)">
-                Deliveries
+                {{ a('dingtalk.action.deliveries') }}
               </button>
               <button v-if="canMutateDingTalkGroup(group)" class="meta-api-mgr__btn" type="button" :disabled="busy" data-dingtalk-group-test-send="true" @click="onTestDingTalkGroup(group)">
-                Test send
+                {{ a('dingtalk.action.testSend') }}
               </button>
               <button v-if="canMutateDingTalkGroup(group)" class="meta-api-mgr__btn meta-api-mgr__btn--danger" type="button" :disabled="busy" data-dingtalk-group-delete="true" @click="onDeleteDingTalkGroup(group)">
-                Delete
+                {{ m('action.delete') }}
               </button>
               <span v-else class="meta-api-mgr__card-readonly" data-dingtalk-group-readonly="true">
-                Managed by organization admins
+                {{ a('dingtalk.readonly') }}
               </span>
             </div>
 
@@ -336,16 +336,16 @@
               class="meta-api-mgr__deliveries"
               data-dingtalk-deliveries="true"
             >
-              <strong class="meta-api-mgr__label">Recent Deliveries</strong>
+              <strong class="meta-api-mgr__label">{{ a('dingtalk.delivery.recent') }}</strong>
               <div v-if="dingTalkDeliveriesLoading" class="meta-api-mgr__empty" data-dingtalk-deliveries-loading="true">
-                Loading DingTalk deliveries…
+                {{ a('dingtalk.delivery.loading') }}
               </div>
               <div
                 v-else-if="!dingTalkDeliveries.length"
                 class="meta-api-mgr__empty"
                 data-dingtalk-deliveries-empty="true"
               >
-                No DingTalk deliveries yet.
+                {{ a('dingtalk.delivery.empty') }}
               </div>
               <template v-else>
                 <div
@@ -355,9 +355,9 @@
                   :data-dingtalk-delivery-id="delivery.id"
                 >
                   <span :class="delivery.success ? 'meta-api-mgr__delivery--ok' : 'meta-api-mgr__delivery--fail'">
-                    {{ delivery.success ? 'OK' : 'FAIL' }}
+                    {{ apiDeliveryResultLabel(delivery.success, isZh) }}
                   </span>
-                  <span>{{ delivery.sourceType === 'manual_test' ? 'Manual test' : 'Automation' }}</span>
+                  <span>{{ apiDingTalkDeliverySourceLabel(delivery.sourceType, isZh) }}</span>
                   <span>{{ delivery.subject }}</span>
                   <span>HTTP {{ delivery.httpStatus ?? '-' }}</span>
                   <span>{{ formatDate(delivery.createdAt) }}</span>
@@ -373,6 +373,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type {
   ApiToken,
   DingTalkGroupDelivery,
@@ -381,6 +382,24 @@ import type {
   WebhookDelivery,
 } from '../types'
 import type { MultitableApiClient } from '../api/client'
+import { managerLabel, type MetaManagerLabelKey } from '../utils/meta-manager-labels'
+import {
+  apiDeliveryResultLabel,
+  apiDingTalkDeliverySourceLabel,
+  apiDingTalkEnabledLabel,
+  apiDingTalkScopeLabel,
+  apiDingTalkSecretStateLabel,
+  apiDingTalkToggleLabel,
+  apiManagerTitle,
+  apiScopeLabel,
+  apiScopesText,
+  apiTokenLabel,
+  apiToggleLabel,
+  apiWebhookEventLabel,
+  apiWebhookEventsText,
+  apiWebhookStatusLabel,
+  type MetaApiTokenLabelKey,
+} from '../utils/meta-api-token-labels'
 
 const props = withDefaults(defineProps<{
   visible: boolean
@@ -398,6 +417,15 @@ const emit = defineEmits<{
 const activeTab = ref<'tokens' | 'webhooks' | 'dingtalk-groups'>('tokens')
 const error = ref<string | null>(null)
 const busy = ref(false)
+const { isZh } = useLocale()
+
+function a(key: MetaApiTokenLabelKey): string {
+  return apiTokenLabel(key, isZh.value)
+}
+
+function m(key: MetaManagerLabelKey): string {
+  return managerLabel(key, isZh.value)
+}
 
 // ---- Tokens ----
 const tokens = ref<ApiToken[]>([])
@@ -437,9 +465,7 @@ const dingTalkGroupDraft = ref({
 })
 
 const canManageDingTalkGroups = computed(() => props.canManageAutomation !== false)
-const managerTitle = computed(() => canManageDingTalkGroups.value
-  ? 'API Tokens, Webhooks & DingTalk Groups'
-  : 'API Tokens & Webhooks')
+const managerTitle = computed(() => apiManagerTitle(canManageDingTalkGroups.value, isZh.value))
 
 const canSaveWebhook = computed(() => {
   return webhookDraft.value.name.trim() && webhookDraft.value.url.startsWith('https://') && webhookDraft.value.events.length > 0
@@ -462,9 +488,9 @@ const dingTalkGroupSecretValidationMessage = computed(() =>
 )
 const dingTalkGroupSecretHelpText = computed(() => {
   if (editingDingTalkGroupOriginal.value?.hasSecret) {
-    return 'A SEC secret is already saved. Leave blank to keep it, enter a new SEC secret to replace it, or clear it below.'
+    return a('dingtalk.secretHelp.saved')
   }
-  return 'Fill this only when the DingTalk robot uses signature security. Leave empty for robots without a SEC secret.'
+  return a('dingtalk.secretHelp.new')
 })
 const canSaveDingTalkGroup = computed(() => {
   return canManageDingTalkGroups.value
@@ -500,19 +526,19 @@ function maskDingTalkWebhookUrl(url: string): string {
 
 function validateDingTalkGroupWebhookUrl(value: string): string {
   const webhookUrl = value.trim()
-  if (!webhookUrl) return 'Webhook URL is required'
+  if (!webhookUrl) return a('validation.webhookRequired')
   let parsed: URL
   try {
     parsed = new URL(webhookUrl)
   } catch {
-    return 'Webhook URL is not a valid URL'
+    return a('validation.webhookInvalid')
   }
-  if (parsed.protocol !== 'https:') return 'DingTalk robot webhook URL must use HTTPS'
+  if (parsed.protocol !== 'https:') return a('validation.webhookHttps')
   if (parsed.hostname !== 'oapi.dingtalk.com' || parsed.pathname !== '/robot/send') {
-    return 'Use the DingTalk group robot webhook from https://oapi.dingtalk.com/robot/send'
+    return a('validation.webhookDingTalkUrl')
   }
   if (!parsed.searchParams.get('access_token')?.trim()) {
-    return 'DingTalk group robot webhook must include access_token'
+    return a('validation.webhookAccessToken')
   }
   return ''
 }
@@ -520,7 +546,7 @@ function validateDingTalkGroupWebhookUrl(value: string): string {
 function validateDingTalkGroupSecret(value: string): string {
   const secret = value.trim()
   if (!secret) return ''
-  if (!secret.startsWith('SEC')) return 'DingTalk robot secret must start with SEC'
+  if (!secret.startsWith('SEC')) return a('validation.secretPrefix')
   return ''
 }
 
@@ -532,9 +558,7 @@ function dingTalkGroupScope(group: DingTalkGroupDestination): 'private' | 'sheet
 
 function dingTalkGroupScopeLabel(group: DingTalkGroupDestination): string {
   const scope = dingTalkGroupScope(group)
-  if (scope === 'org') return group.orgId ? `Organization catalog group: ${group.orgId}` : 'Organization catalog group'
-  if (scope === 'sheet') return group.sheetId ? `Shared with sheet: ${group.sheetId}` : 'Shared with this sheet'
-  return 'Private legacy group'
+  return apiDingTalkScopeLabel(scope, { sheetId: group.sheetId, orgId: group.orgId }, isZh.value)
 }
 
 function canMutateDingTalkGroup(group: DingTalkGroupDestination): boolean {
@@ -549,7 +573,7 @@ async function loadTokens() {
   try {
     tokens.value = await props.client.listApiTokens()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to load tokens'
+    error.value = err instanceof Error ? err.message : a('error.loadTokens')
   } finally {
     tokensLoading.value = false
   }
@@ -583,7 +607,7 @@ async function onCreateToken() {
     showTokenForm.value = false
     await loadTokens()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to create token'
+    error.value = err instanceof Error ? err.message : a('error.createToken')
   } finally {
     busy.value = false
   }
@@ -604,7 +628,7 @@ async function onRevokeToken(tokenId: string) {
     await props.client.revokeApiToken(tokenId)
     await loadTokens()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to revoke token'
+    error.value = err instanceof Error ? err.message : a('error.revokeToken')
   } finally {
     busy.value = false
   }
@@ -619,7 +643,7 @@ async function onRotateToken(tokenId: string) {
     newTokenPlaintext.value = result.plaintext
     await loadTokens()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to rotate token'
+    error.value = err instanceof Error ? err.message : a('error.rotateToken')
   } finally {
     busy.value = false
   }
@@ -633,7 +657,7 @@ async function loadWebhooks() {
   try {
     webhooks.value = await props.client.listWebhooks()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to load webhooks'
+    error.value = err instanceof Error ? err.message : a('error.loadWebhooks')
   } finally {
     webhooksLoading.value = false
   }
@@ -689,7 +713,7 @@ async function onSaveWebhook() {
     cancelWebhookForm()
     await loadWebhooks()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to save webhook'
+    error.value = err instanceof Error ? err.message : a('error.saveWebhook')
   } finally {
     busy.value = false
   }
@@ -703,7 +727,7 @@ async function onToggleWebhook(wh: Webhook) {
     await props.client.updateWebhook(wh.id, { active: !wh.active })
     await loadWebhooks()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to toggle webhook'
+    error.value = err instanceof Error ? err.message : a('error.toggleWebhook')
   } finally {
     busy.value = false
   }
@@ -721,7 +745,7 @@ async function onDeleteWebhook(id: string) {
     }
     await loadWebhooks()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to delete webhook'
+    error.value = err instanceof Error ? err.message : a('error.deleteWebhook')
   } finally {
     busy.value = false
   }
@@ -739,7 +763,7 @@ async function onViewDeliveries(webhookId: string) {
     deliveries.value = await props.client.getWebhookDeliveries(webhookId)
     deliveriesWebhookId.value = webhookId
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to load deliveries'
+    error.value = err instanceof Error ? err.message : a('error.loadDeliveries')
   }
 }
 
@@ -756,7 +780,7 @@ async function loadDingTalkGroups() {
   try {
     dingTalkGroups.value = await props.client.listDingTalkGroups(props.sheetId)
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to load DingTalk groups'
+    error.value = err instanceof Error ? err.message : a('error.loadDingTalkGroups')
   } finally {
     dingTalkGroupsLoading.value = false
   }
@@ -845,7 +869,7 @@ async function onSaveDingTalkGroup() {
     cancelDingTalkGroupForm()
     await loadDingTalkGroups()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to save DingTalk group'
+    error.value = err instanceof Error ? err.message : a('error.saveDingTalkGroup')
   } finally {
     busy.value = false
   }
@@ -859,7 +883,7 @@ async function onToggleDingTalkGroup(group: DingTalkGroupDestination) {
     await props.client.updateDingTalkGroup(group.id, { enabled: !group.enabled }, props.sheetId)
     await loadDingTalkGroups()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to toggle DingTalk group'
+    error.value = err instanceof Error ? err.message : a('error.toggleDingTalkGroup')
   } finally {
     busy.value = false
   }
@@ -877,7 +901,7 @@ async function onTestDingTalkGroup(group: DingTalkGroupDestination) {
       await loadDingTalkDeliveries(group)
     }
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to test DingTalk group'
+    error.value = err instanceof Error ? err.message : a('error.testDingTalkGroup')
   } finally {
     busy.value = false
   }
@@ -902,7 +926,7 @@ async function loadDingTalkDeliveries(group: DingTalkGroupDestination) {
     if (requestToken !== dingTalkDeliveriesRequestToken || dingTalkDeliveriesGroupId.value !== groupId) {
       return
     }
-    error.value = err instanceof Error ? err.message : 'Failed to load DingTalk deliveries'
+    error.value = err instanceof Error ? err.message : a('error.loadDingTalkDeliveries')
   } finally {
     if (requestToken === dingTalkDeliveriesRequestToken && dingTalkDeliveriesGroupId.value === groupId) {
       dingTalkDeliveriesLoading.value = false
@@ -938,7 +962,7 @@ async function onDeleteDingTalkGroup(group: DingTalkGroupDestination) {
     }
     await loadDingTalkGroups()
   } catch (err) {
-    error.value = err instanceof Error ? err.message : 'Failed to delete DingTalk group'
+    error.value = err instanceof Error ? err.message : a('error.deleteDingTalkGroup')
   } finally {
     busy.value = false
   }

--- a/apps/web/src/multitable/utils/meta-api-token-labels.ts
+++ b/apps/web/src/multitable/utils/meta-api-token-labels.ts
@@ -1,0 +1,298 @@
+// API token / webhook / DingTalk destination manager chrome string table (T3C-2c).
+//
+// Scope: MetaApiTokenManager.vue. Token names, webhook names/URLs, DingTalk
+// destination names, subjects, timestamps, persisted enum values, HTTP status,
+// secrets/tokens, and backend error messages stay raw.
+
+export type MetaApiTokenLabelKey =
+  | 'title.full' | 'title.basic'
+  | 'tab.tokens' | 'tab.webhooks' | 'tab.dingtalkGroups'
+  | 'notice.dingtalkPermission'
+  | 'token.newShownOnce' | 'token.saveWarning'
+  | 'token.newTitle' | 'token.name' | 'token.namePlaceholder'
+  | 'token.scopes' | 'token.expiryOptional' | 'token.newButton'
+  | 'token.loading' | 'token.empty' | 'token.meta.scopes'
+  | 'token.meta.created' | 'token.meta.lastUsed' | 'token.meta.expires'
+  | 'token.scope.none' | 'token.scope.read' | 'token.scope.write' | 'token.scope.admin'
+  | 'token.action.copy' | 'token.action.copied' | 'token.action.create'
+  | 'token.action.rotate' | 'token.action.revoke'
+  | 'webhook.newTitle' | 'webhook.editTitle' | 'webhook.name'
+  | 'webhook.namePlaceholder' | 'webhook.url' | 'webhook.urlPlaceholder'
+  | 'webhook.events' | 'webhook.secretOptional' | 'webhook.secretPlaceholder'
+  | 'webhook.newButton' | 'webhook.loading' | 'webhook.empty'
+  | 'webhook.status.active' | 'webhook.status.disabled'
+  | 'webhook.meta.url' | 'webhook.meta.events' | 'webhook.meta.failures'
+  | 'webhook.action.create' | 'webhook.action.update' | 'webhook.action.edit'
+  | 'webhook.action.enable' | 'webhook.action.disable' | 'webhook.action.deliveries'
+  | 'webhook.delivery.recent' | 'webhook.delivery.ok' | 'webhook.delivery.fail'
+  | 'webhook.delivery.retries'
+  | 'webhook.event.recordCreated' | 'webhook.event.recordUpdated'
+  | 'webhook.event.recordDeleted' | 'webhook.event.fieldChanged'
+  | 'dingtalk.scopeNote.title' | 'dingtalk.scopeNote.bound'
+  | 'dingtalk.scopeNote.delivery'
+  | 'dingtalk.newTitle' | 'dingtalk.editTitle'
+  | 'dingtalk.name' | 'dingtalk.namePlaceholder'
+  | 'dingtalk.webhookUrl' | 'dingtalk.webhookPlaceholder'
+  | 'dingtalk.webhookHelp' | 'dingtalk.secretOptional'
+  | 'dingtalk.secretPlaceholder' | 'dingtalk.secretHelp.new'
+  | 'dingtalk.secretHelp.saved' | 'dingtalk.clearSecret'
+  | 'dingtalk.enabled' | 'dingtalk.newButton'
+  | 'dingtalk.loading' | 'dingtalk.empty'
+  | 'dingtalk.status.enabled' | 'dingtalk.status.disabled'
+  | 'dingtalk.meta.webhook' | 'dingtalk.meta.secret'
+  | 'dingtalk.meta.secretConfigured' | 'dingtalk.meta.secretNotConfigured'
+  | 'dingtalk.meta.created' | 'dingtalk.meta.lastTest'
+  | 'dingtalk.meta.testStatus' | 'dingtalk.meta.lastError'
+  | 'dingtalk.scope.org' | 'dingtalk.scope.orgWithId'
+  | 'dingtalk.scope.sheet' | 'dingtalk.scope.sheetWithId'
+  | 'dingtalk.scope.private'
+  | 'dingtalk.action.create' | 'dingtalk.action.update'
+  | 'dingtalk.action.edit' | 'dingtalk.action.enable' | 'dingtalk.action.disable'
+  | 'dingtalk.action.deliveries' | 'dingtalk.action.testSend'
+  | 'dingtalk.readonly'
+  | 'dingtalk.delivery.recent' | 'dingtalk.delivery.loading'
+  | 'dingtalk.delivery.empty' | 'dingtalk.delivery.manualTest'
+  | 'dingtalk.delivery.automation'
+  | 'error.loadTokens' | 'error.createToken' | 'error.revokeToken'
+  | 'error.rotateToken' | 'error.loadWebhooks' | 'error.saveWebhook'
+  | 'error.toggleWebhook' | 'error.deleteWebhook' | 'error.loadDeliveries'
+  | 'error.loadDingTalkGroups' | 'error.saveDingTalkGroup'
+  | 'error.toggleDingTalkGroup' | 'error.testDingTalkGroup'
+  | 'error.loadDingTalkDeliveries' | 'error.deleteDingTalkGroup'
+  | 'validation.webhookRequired' | 'validation.webhookInvalid'
+  | 'validation.webhookHttps' | 'validation.webhookDingTalkUrl'
+  | 'validation.webhookAccessToken' | 'validation.secretPrefix'
+
+const LABELS: Record<MetaApiTokenLabelKey, { en: string; zh: string }> = {
+  'title.full': { en: 'API Tokens, Webhooks & DingTalk Groups', zh: 'API 令牌、Webhook 与钉钉群' },
+  'title.basic': { en: 'API Tokens & Webhooks', zh: 'API 令牌与 Webhook' },
+  'tab.tokens': { en: 'API Tokens', zh: 'API 令牌' },
+  'tab.webhooks': { en: 'Webhooks', zh: 'Webhook' },
+  'tab.dingtalkGroups': { en: 'DingTalk Groups', zh: '钉钉群' },
+  'notice.dingtalkPermission': {
+    en: 'DingTalk group bindings require automation management permission for this table.',
+    zh: '钉钉群绑定需要此表的自动化管理权限。',
+  },
+  'token.newShownOnce': { en: 'Your new API token (shown once):', zh: '新的 API 令牌（仅显示一次）：' },
+  'token.saveWarning': { en: 'Save this token now. You will not be able to see it again.', zh: '请立即保存此令牌。之后将无法再次查看。' },
+  'token.newTitle': { en: 'New API Token', zh: '新建 API 令牌' },
+  'token.name': { en: 'Name', zh: '名称' },
+  'token.namePlaceholder': { en: 'Token name', zh: '令牌名称' },
+  'token.scopes': { en: 'Scopes', zh: '权限范围' },
+  'token.expiryOptional': { en: 'Expiry (optional)', zh: '过期时间（可选）' },
+  'token.newButton': { en: '+ New Token', zh: '+ 新建令牌' },
+  'token.loading': { en: 'Loading tokens...', zh: '正在加载令牌...' },
+  'token.empty': { en: 'No API tokens yet.', zh: '暂无 API 令牌。' },
+  'token.meta.scopes': { en: 'Scopes', zh: '权限范围' },
+  'token.meta.created': { en: 'Created', zh: '创建时间' },
+  'token.meta.lastUsed': { en: 'Last used', zh: '上次使用' },
+  'token.meta.expires': { en: 'Expires', zh: '过期时间' },
+  'token.scope.none': { en: 'none', zh: '无' },
+  'token.scope.read': { en: 'read', zh: '读取' },
+  'token.scope.write': { en: 'write', zh: '写入' },
+  'token.scope.admin': { en: 'admin', zh: '管理' },
+  'token.action.copy': { en: 'Copy', zh: '复制' },
+  'token.action.copied': { en: 'Copied!', zh: '已复制！' },
+  'token.action.create': { en: 'Create', zh: '创建' },
+  'token.action.rotate': { en: 'Rotate', zh: '轮换' },
+  'token.action.revoke': { en: 'Revoke', zh: '撤销' },
+  'webhook.newTitle': { en: 'New Webhook', zh: '新建 Webhook' },
+  'webhook.editTitle': { en: 'Edit Webhook', zh: '编辑 Webhook' },
+  'webhook.name': { en: 'Name', zh: '名称' },
+  'webhook.namePlaceholder': { en: 'Webhook name', zh: 'Webhook 名称' },
+  'webhook.url': { en: 'URL (HTTPS required)', zh: 'URL（必须使用 HTTPS）' },
+  'webhook.urlPlaceholder': { en: 'https://example.com/webhook', zh: 'https://example.com/webhook' },
+  'webhook.events': { en: 'Events', zh: '事件' },
+  'webhook.secretOptional': { en: 'Secret (optional)', zh: '密钥（可选）' },
+  'webhook.secretPlaceholder': { en: 'HMAC secret', zh: 'HMAC 密钥' },
+  'webhook.newButton': { en: '+ New Webhook', zh: '+ 新建 Webhook' },
+  'webhook.loading': { en: 'Loading webhooks...', zh: '正在加载 Webhook...' },
+  'webhook.empty': { en: 'No webhooks yet.', zh: '暂无 Webhook。' },
+  'webhook.status.active': { en: 'Active', zh: '有效' },
+  'webhook.status.disabled': { en: 'Disabled', zh: '已停用' },
+  'webhook.meta.url': { en: 'URL', zh: 'URL' },
+  'webhook.meta.events': { en: 'Events', zh: '事件' },
+  'webhook.meta.failures': { en: 'Failures', zh: '失败次数' },
+  'webhook.action.create': { en: 'Create', zh: '创建' },
+  'webhook.action.update': { en: 'Update', zh: '更新' },
+  'webhook.action.edit': { en: 'Edit', zh: '编辑' },
+  'webhook.action.enable': { en: 'Enable', zh: '启用' },
+  'webhook.action.disable': { en: 'Disable', zh: '停用' },
+  'webhook.action.deliveries': { en: 'Deliveries', zh: '投递记录' },
+  'webhook.delivery.recent': { en: 'Recent Deliveries', zh: '最近投递' },
+  'webhook.delivery.ok': { en: 'OK', zh: '成功' },
+  'webhook.delivery.fail': { en: 'FAIL', zh: '失败' },
+  'webhook.delivery.retries': { en: 'Retries', zh: '重试次数' },
+  'webhook.event.recordCreated': { en: 'record.created', zh: '记录已创建' },
+  'webhook.event.recordUpdated': { en: 'record.updated', zh: '记录已更新' },
+  'webhook.event.recordDeleted': { en: 'record.deleted', zh: '记录已删除' },
+  'webhook.event.fieldChanged': { en: 'field.changed', zh: '字段已变更' },
+  'dingtalk.scopeNote.title': { en: 'Table-scoped DingTalk groups', zh: '表级钉钉群' },
+  'dingtalk.scopeNote.bound': {
+    en: 'Groups created here are bound to this table. You can add multiple groups and choose one or more in automations; organization catalog groups are listed read-only when shared with your organization.',
+    zh: '此处创建的群会绑定到当前表。你可以添加多个群，并在自动化中选择一个或多个；组织共享的目录群会以只读方式展示。',
+  },
+  'dingtalk.scopeNote.delivery': {
+    en: 'Register DingTalk robot webhooks as send destinations for this table. This does not import DingTalk group members or control form access.',
+    zh: '将钉钉机器人 Webhook 注册为此表的发送目标。此功能不会导入钉钉群成员，也不会控制表单访问。',
+  },
+  'dingtalk.newTitle': { en: 'New DingTalk Group', zh: '新建钉钉群' },
+  'dingtalk.editTitle': { en: 'Edit DingTalk Group', zh: '编辑钉钉群' },
+  'dingtalk.name': { en: 'Name', zh: '名称' },
+  'dingtalk.namePlaceholder': { en: 'Support group', zh: '支持群' },
+  'dingtalk.webhookUrl': { en: 'Webhook URL', zh: 'Webhook URL' },
+  'dingtalk.webhookPlaceholder': { en: 'https://oapi.dingtalk.com/robot/send?access_token=...', zh: 'https://oapi.dingtalk.com/robot/send?access_token=...' },
+  'dingtalk.webhookHelp': {
+    en: "Paste the robot webhook from the target DingTalk group robot settings. After saving, this destination appears in this table's automation rule editor. The access token is stored for delivery but masked in this UI.",
+    zh: '粘贴目标钉钉群机器人设置中的 Webhook。保存后，该目标会出现在此表的自动化规则编辑器中。access_token 会用于投递存储，但在界面中脱敏显示。',
+  },
+  'dingtalk.secretOptional': { en: 'Secret (optional)', zh: '密钥（可选）' },
+  'dingtalk.secretPlaceholder': { en: 'SEC...', zh: 'SEC...' },
+  'dingtalk.secretHelp.new': {
+    en: 'Fill this only when the DingTalk robot uses signature security. Leave empty for robots without a SEC secret.',
+    zh: '仅当钉钉机器人启用签名安全时填写。没有 SEC 密钥的机器人请留空。',
+  },
+  'dingtalk.secretHelp.saved': {
+    en: 'A SEC secret is already saved. Leave blank to keep it, enter a new SEC secret to replace it, or clear it below.',
+    zh: '已保存 SEC 密钥。留空表示保留；输入新的 SEC 密钥可替换；也可在下方清除。',
+  },
+  'dingtalk.clearSecret': { en: 'Clear saved SEC secret', zh: '清除已保存的 SEC 密钥' },
+  'dingtalk.enabled': { en: 'Enabled', zh: '已启用' },
+  'dingtalk.newButton': { en: '+ New DingTalk Group', zh: '+ 新建钉钉群' },
+  'dingtalk.loading': { en: 'Loading DingTalk groups...', zh: '正在加载钉钉群...' },
+  'dingtalk.empty': {
+    en: 'No DingTalk group destinations yet. Add a group robot webhook before configuring group-message automations.',
+    zh: '暂无钉钉群目标。请先添加群机器人 Webhook，再配置群消息自动化。',
+  },
+  'dingtalk.status.enabled': { en: 'Enabled', zh: '已启用' },
+  'dingtalk.status.disabled': { en: 'Disabled', zh: '已停用' },
+  'dingtalk.meta.webhook': { en: 'Webhook', zh: 'Webhook' },
+  'dingtalk.meta.secret': { en: 'Secret', zh: '密钥' },
+  'dingtalk.meta.secretConfigured': { en: 'configured', zh: '已配置' },
+  'dingtalk.meta.secretNotConfigured': { en: 'not configured', zh: '未配置' },
+  'dingtalk.meta.created': { en: 'Created', zh: '创建时间' },
+  'dingtalk.meta.lastTest': { en: 'Last test', zh: '上次测试' },
+  'dingtalk.meta.testStatus': { en: 'Test status', zh: '测试状态' },
+  'dingtalk.meta.lastError': { en: 'Last error', zh: '最近错误' },
+  'dingtalk.scope.org': { en: 'Organization catalog group', zh: '组织目录群' },
+  'dingtalk.scope.orgWithId': { en: 'Organization catalog group', zh: '组织目录群' },
+  'dingtalk.scope.sheet': { en: 'Shared with this sheet', zh: '与此表共享' },
+  'dingtalk.scope.sheetWithId': { en: 'Shared with sheet', zh: '共享到表' },
+  'dingtalk.scope.private': { en: 'Private legacy group', zh: '私有旧版群' },
+  'dingtalk.action.create': { en: 'Create', zh: '创建' },
+  'dingtalk.action.update': { en: 'Update', zh: '更新' },
+  'dingtalk.action.edit': { en: 'Edit', zh: '编辑' },
+  'dingtalk.action.enable': { en: 'Enable', zh: '启用' },
+  'dingtalk.action.disable': { en: 'Disable', zh: '停用' },
+  'dingtalk.action.deliveries': { en: 'Deliveries', zh: '投递记录' },
+  'dingtalk.action.testSend': { en: 'Test send', zh: '测试发送' },
+  'dingtalk.readonly': { en: 'Managed by organization admins', zh: '由组织管理员管理' },
+  'dingtalk.delivery.recent': { en: 'Recent Deliveries', zh: '最近投递' },
+  'dingtalk.delivery.loading': { en: 'Loading DingTalk deliveries...', zh: '正在加载钉钉投递...' },
+  'dingtalk.delivery.empty': { en: 'No DingTalk deliveries yet.', zh: '暂无钉钉投递。' },
+  'dingtalk.delivery.manualTest': { en: 'Manual test', zh: '手动测试' },
+  'dingtalk.delivery.automation': { en: 'Automation', zh: '自动化' },
+  'error.loadTokens': { en: 'Failed to load tokens', zh: '加载令牌失败' },
+  'error.createToken': { en: 'Failed to create token', zh: '创建令牌失败' },
+  'error.revokeToken': { en: 'Failed to revoke token', zh: '撤销令牌失败' },
+  'error.rotateToken': { en: 'Failed to rotate token', zh: '轮换令牌失败' },
+  'error.loadWebhooks': { en: 'Failed to load webhooks', zh: '加载 Webhook 失败' },
+  'error.saveWebhook': { en: 'Failed to save webhook', zh: '保存 Webhook 失败' },
+  'error.toggleWebhook': { en: 'Failed to toggle webhook', zh: '切换 Webhook 状态失败' },
+  'error.deleteWebhook': { en: 'Failed to delete webhook', zh: '删除 Webhook 失败' },
+  'error.loadDeliveries': { en: 'Failed to load deliveries', zh: '加载投递记录失败' },
+  'error.loadDingTalkGroups': { en: 'Failed to load DingTalk groups', zh: '加载钉钉群失败' },
+  'error.saveDingTalkGroup': { en: 'Failed to save DingTalk group', zh: '保存钉钉群失败' },
+  'error.toggleDingTalkGroup': { en: 'Failed to toggle DingTalk group', zh: '切换钉钉群状态失败' },
+  'error.testDingTalkGroup': { en: 'Failed to test DingTalk group', zh: '测试钉钉群失败' },
+  'error.loadDingTalkDeliveries': { en: 'Failed to load DingTalk deliveries', zh: '加载钉钉投递失败' },
+  'error.deleteDingTalkGroup': { en: 'Failed to delete DingTalk group', zh: '删除钉钉群失败' },
+  'validation.webhookRequired': { en: 'Webhook URL is required', zh: 'Webhook URL 为必填项' },
+  'validation.webhookInvalid': { en: 'Webhook URL is not a valid URL', zh: 'Webhook URL 不是有效 URL' },
+  'validation.webhookHttps': { en: 'DingTalk robot webhook URL must use HTTPS', zh: '钉钉机器人 Webhook URL 必须使用 HTTPS' },
+  'validation.webhookDingTalkUrl': {
+    en: 'Use the DingTalk group robot webhook from https://oapi.dingtalk.com/robot/send',
+    zh: '请使用来自 https://oapi.dingtalk.com/robot/send 的钉钉群机器人 Webhook',
+  },
+  'validation.webhookAccessToken': { en: 'DingTalk group robot webhook must include access_token', zh: '钉钉群机器人 Webhook 必须包含 access_token' },
+  'validation.secretPrefix': { en: 'DingTalk robot secret must start with SEC', zh: '钉钉机器人密钥必须以 SEC 开头' },
+}
+
+export function apiTokenLabel(key: MetaApiTokenLabelKey, isZh: boolean): string {
+  const entry = LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+export function apiManagerTitle(canManageDingTalkGroups: boolean, isZh: boolean): string {
+  return apiTokenLabel(canManageDingTalkGroups ? 'title.full' : 'title.basic', isZh)
+}
+
+export function apiScopeLabel(scope: string, isZh: boolean): string {
+  if (scope === 'read') return apiTokenLabel('token.scope.read', isZh)
+  if (scope === 'write') return apiTokenLabel('token.scope.write', isZh)
+  if (scope === 'admin') return apiTokenLabel('token.scope.admin', isZh)
+  return scope
+}
+
+export function apiScopesText(scopes: readonly string[], isZh: boolean): string {
+  if (scopes.length === 0) return apiTokenLabel('token.scope.none', isZh)
+  return scopes.map((scope) => apiScopeLabel(scope, isZh)).join(', ')
+}
+
+export function apiWebhookEventLabel(event: string, isZh: boolean): string {
+  if (event === 'record.created') return apiTokenLabel('webhook.event.recordCreated', isZh)
+  if (event === 'record.updated') return apiTokenLabel('webhook.event.recordUpdated', isZh)
+  if (event === 'record.deleted') return apiTokenLabel('webhook.event.recordDeleted', isZh)
+  if (event === 'field.changed') return apiTokenLabel('webhook.event.fieldChanged', isZh)
+  return event
+}
+
+export function apiWebhookEventsText(events: readonly string[], isZh: boolean): string {
+  return events.map((event) => apiWebhookEventLabel(event, isZh)).join(', ')
+}
+
+export function apiWebhookStatusLabel(active: boolean, isZh: boolean): string {
+  return apiTokenLabel(active ? 'webhook.status.active' : 'webhook.status.disabled', isZh)
+}
+
+export function apiDingTalkEnabledLabel(enabled: boolean, isZh: boolean): string {
+  return apiTokenLabel(enabled ? 'dingtalk.status.enabled' : 'dingtalk.status.disabled', isZh)
+}
+
+export function apiToggleLabel(enabled: boolean, isZh: boolean): string {
+  return apiTokenLabel(enabled ? 'webhook.action.disable' : 'webhook.action.enable', isZh)
+}
+
+export function apiDingTalkToggleLabel(enabled: boolean, isZh: boolean): string {
+  return apiTokenLabel(enabled ? 'dingtalk.action.disable' : 'dingtalk.action.enable', isZh)
+}
+
+export function apiDeliveryResultLabel(success: boolean, isZh: boolean): string {
+  return apiTokenLabel(success ? 'webhook.delivery.ok' : 'webhook.delivery.fail', isZh)
+}
+
+export function apiDingTalkScopeLabel(
+  scope: 'private' | 'sheet' | 'org',
+  ids: { sheetId?: string; orgId?: string },
+  isZh: boolean,
+): string {
+  if (scope === 'org') {
+    const label = apiTokenLabel(ids.orgId ? 'dingtalk.scope.orgWithId' : 'dingtalk.scope.org', isZh)
+    return ids.orgId ? `${label}: ${ids.orgId}` : label
+  }
+  if (scope === 'sheet') {
+    const label = apiTokenLabel(ids.sheetId ? 'dingtalk.scope.sheetWithId' : 'dingtalk.scope.sheet', isZh)
+    return ids.sheetId ? `${label}: ${ids.sheetId}` : label
+  }
+  return apiTokenLabel('dingtalk.scope.private', isZh)
+}
+
+export function apiDingTalkSecretStateLabel(hasSecret: boolean, isZh: boolean): string {
+  return apiTokenLabel(hasSecret ? 'dingtalk.meta.secretConfigured' : 'dingtalk.meta.secretNotConfigured', isZh)
+}
+
+export function apiDingTalkDeliverySourceLabel(sourceType: string, isZh: boolean): string {
+  if (sourceType === 'manual_test') return apiTokenLabel('dingtalk.delivery.manualTest', isZh)
+  if (sourceType === 'automation') return apiTokenLabel('dingtalk.delivery.automation', isZh)
+  return sourceType
+}

--- a/apps/web/tests/meta-api-token-labels.spec.ts
+++ b/apps/web/tests/meta-api-token-labels.spec.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  apiDeliveryResultLabel,
+  apiDingTalkDeliverySourceLabel,
+  apiDingTalkEnabledLabel,
+  apiDingTalkScopeLabel,
+  apiDingTalkSecretStateLabel,
+  apiDingTalkToggleLabel,
+  apiManagerTitle,
+  apiScopeLabel,
+  apiScopesText,
+  apiTokenLabel,
+  apiToggleLabel,
+  apiWebhookEventLabel,
+  apiWebhookEventsText,
+  apiWebhookStatusLabel,
+} from '../src/multitable/utils/meta-api-token-labels'
+
+describe('meta-api-token-labels', () => {
+  it('returns static API-token manager labels in en and zh', () => {
+    expect(apiTokenLabel('title.full', false)).toBe('API Tokens, Webhooks & DingTalk Groups')
+    expect(apiTokenLabel('title.full', true)).toBe('API 令牌、Webhook 与钉钉群')
+    expect(apiTokenLabel('dingtalk.empty', true)).toContain('暂无钉钉群目标')
+  })
+
+  it('selects the manager title by DingTalk group capability', () => {
+    expect(apiManagerTitle(true, false)).toBe('API Tokens, Webhooks & DingTalk Groups')
+    expect(apiManagerTitle(false, true)).toBe('API 令牌与 Webhook')
+  })
+
+  it('localizes known token scopes and preserves unknown raw scopes', () => {
+    expect(apiScopeLabel('read', true)).toBe('读取')
+    expect(apiScopeLabel('admin', true)).toBe('管理')
+    expect(apiScopeLabel('custom.scope', true)).toBe('custom.scope')
+    expect(apiScopesText([], true)).toBe('无')
+    expect(apiScopesText(['read', 'custom.scope'], true)).toBe('读取, custom.scope')
+  })
+
+  it('localizes known webhook events and preserves unknown raw events', () => {
+    expect(apiWebhookEventLabel('record.created', true)).toBe('记录已创建')
+    expect(apiWebhookEventLabel('field.changed', true)).toBe('字段已变更')
+    expect(apiWebhookEventLabel('custom.event', true)).toBe('custom.event')
+    expect(apiWebhookEventsText(['record.deleted', 'custom.event'], true)).toBe('记录已删除, custom.event')
+  })
+
+  it('formats webhook status, toggles, and delivery results', () => {
+    expect(apiWebhookStatusLabel(true, true)).toBe('有效')
+    expect(apiWebhookStatusLabel(false, true)).toBe('已停用')
+    expect(apiToggleLabel(true, true)).toBe('停用')
+    expect(apiToggleLabel(false, true)).toBe('启用')
+    expect(apiDeliveryResultLabel(true, true)).toBe('成功')
+    expect(apiDeliveryResultLabel(false, true)).toBe('失败')
+  })
+
+  it('formats DingTalk group status and actions', () => {
+    expect(apiDingTalkEnabledLabel(true, true)).toBe('已启用')
+    expect(apiDingTalkEnabledLabel(false, true)).toBe('已停用')
+    expect(apiDingTalkToggleLabel(true, true)).toBe('停用')
+    expect(apiDingTalkToggleLabel(false, true)).toBe('启用')
+    expect(apiDingTalkSecretStateLabel(true, true)).toBe('已配置')
+    expect(apiDingTalkSecretStateLabel(false, true)).toBe('未配置')
+  })
+
+  it('formats DingTalk group scope labels with raw ids preserved', () => {
+    expect(apiDingTalkScopeLabel('org', { orgId: 'org_1' }, true)).toBe('组织目录群: org_1')
+    expect(apiDingTalkScopeLabel('org', {}, true)).toBe('组织目录群')
+    expect(apiDingTalkScopeLabel('sheet', { sheetId: 'sheet_1' }, true)).toBe('共享到表: sheet_1')
+    expect(apiDingTalkScopeLabel('sheet', {}, true)).toBe('与此表共享')
+    expect(apiDingTalkScopeLabel('private', {}, true)).toBe('私有旧版群')
+  })
+
+  it('formats DingTalk delivery source labels', () => {
+    expect(apiDingTalkDeliverySourceLabel('manual_test', true)).toBe('手动测试')
+    expect(apiDingTalkDeliverySourceLabel('automation', true)).toBe('自动化')
+    expect(apiDingTalkDeliverySourceLabel('future_source', true)).toBe('future_source')
+  })
+})

--- a/apps/web/tests/multitable-api-token-manager.spec.ts
+++ b/apps/web/tests/multitable-api-token-manager.spec.ts
@@ -1,4 +1,4 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
 
 async function flushPromises() {
@@ -10,6 +10,7 @@ async function flushPromises() {
 
 import MetaApiTokenManager from '../src/multitable/components/MetaApiTokenManager.vue'
 import { MultitableApiClient } from '../src/multitable/api/client'
+import { useLocale } from '../src/composables/useLocale'
 import type {
   ApiToken,
   DingTalkGroupDelivery,
@@ -203,8 +204,13 @@ function mount(props: Record<string, unknown>) {
 }
 
 describe('MetaApiTokenManager', () => {
+  beforeEach(() => {
+    useLocale().setLocale('en')
+  })
+
   afterEach(() => {
     document.body.innerHTML = ''
+    useLocale().setLocale('en')
     vi.restoreAllMocks()
   })
 
@@ -440,6 +446,67 @@ describe('MetaApiTokenManager', () => {
     expect(tabLabels).toEqual(['API Tokens', 'Webhooks'])
     expect(document.querySelector('[data-dingtalk-groups-permission-note]')?.textContent).toContain('DingTalk group bindings require automation management permission')
     expect(fetchFn.mock.calls.some(([url]) => String(url).includes('/dingtalk-groups'))).toBe(false)
+  })
+
+  it('localizes API token, webhook, and DingTalk group chrome while preserving raw enum data', async () => {
+    useLocale().setLocale('zh-CN')
+    const { client } = mockClient(
+      [fakeToken({ scopes: ['read', 'admin'] })],
+      [fakeWebhook({ events: ['record.created', 'field.changed'] })],
+      [fakeDelivery({ event: 'field.changed', retryCount: 2 })],
+      [fakeDingTalkGroup({ hasSecret: true })],
+      [fakeDingTalkDelivery({ sourceType: 'manual_test' })],
+    )
+    mount({ visible: true, client })
+    await flushPromises()
+
+    expect(document.querySelector('.meta-api-mgr__title')?.textContent).toBe('API 令牌、Webhook 与钉钉群')
+    const tabLabels = Array.from(document.querySelectorAll('[role="tab"]')).map((tab) => tab.textContent?.trim())
+    expect(tabLabels).toEqual(['API 令牌', 'Webhook', '钉钉群'])
+    expect(document.body.textContent).toContain('Test token')
+    expect(document.body.textContent).toContain('mst_abc...')
+    expect(document.body.textContent).toContain('权限范围: 读取, 管理')
+
+    const newTokenBtn = document.querySelector('[data-token-new]') as HTMLButtonElement
+    newTokenBtn.click()
+    await flushPromises()
+    expect(document.querySelector('[data-token-scope="read"]')).toBeTruthy()
+    expect(document.querySelector('[data-token-form]')?.textContent).toContain('权限范围')
+
+    const webhookTab = document.querySelectorAll('[role="tab"]')[1] as HTMLButtonElement
+    webhookTab.click()
+    await flushPromises()
+    const webhookCard = document.querySelector('[data-webhook-id="wh_1"]') as HTMLElement
+    expect(webhookCard.textContent).toContain('Test webhook')
+    expect(webhookCard.textContent).toContain('事件: 记录已创建, 字段已变更')
+    expect(webhookCard.querySelector('[data-webhook-status="active"]')?.textContent).toContain('有效')
+    const newWebhookBtn = document.querySelector('[data-webhook-new]') as HTMLButtonElement
+    newWebhookBtn.click()
+    await flushPromises()
+    expect(document.querySelector('[data-webhook-event="record.created"]')).toBeTruthy()
+    expect(document.querySelector('[data-webhook-form]')?.textContent).toContain('记录已创建')
+    document.querySelector('[data-webhook-deliveries]')?.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flushPromises()
+    expect(document.querySelector('[data-deliveries]')?.textContent).toContain('最近投递')
+    expect(document.querySelector('[data-deliveries]')?.textContent).toContain('字段已变更')
+    expect(document.querySelector('[data-deliveries]')?.textContent).toContain('重试次数: 2')
+
+    const dingTalkTab = document.querySelectorAll('[role="tab"]')[2] as HTMLButtonElement
+    dingTalkTab.click()
+    await flushPromises()
+    const dingTalkCard = document.querySelector('[data-dingtalk-group-id="dt_1"]') as HTMLElement
+    expect(document.querySelector('[data-dingtalk-groups-scope-note]')?.textContent).toContain('表级钉钉群')
+    expect(dingTalkCard.textContent).toContain('Ops DingTalk Group')
+    expect(dingTalkCard.textContent).toContain('Webhook: https://oapi.dingtalk.com/robot/send?access_token=***')
+    expect(dingTalkCard.textContent).toContain('密钥: 已配置')
+    expect(dingTalkCard.textContent).toContain('共享到表: sheet_1')
+    expect(dingTalkCard.querySelector('[data-dingtalk-group-status="enabled"]')?.textContent).toContain('已启用')
+    const dingTalkDeliveriesBtn = dingTalkCard.querySelector('[data-dingtalk-group-deliveries]') as HTMLButtonElement
+    dingTalkDeliveriesBtn.click()
+    await flushPromises()
+    expect(document.querySelector('[data-dingtalk-deliveries]')?.textContent).toContain('最近投递')
+    expect(document.querySelector('[data-dingtalk-deliveries]')?.textContent).toContain('手动测试')
+    expect(document.querySelector('[data-dingtalk-deliveries]')?.textContent).toContain('Please fill incident details')
   })
 
   it('shows readable permission errors when DingTalk group loading is forbidden', async () => {

--- a/docs/development/multitable-t3c2c-api-token-manager-i18n-design-20260520.md
+++ b/docs/development/multitable-t3c2c-api-token-manager-i18n-design-20260520.md
@@ -1,0 +1,117 @@
+# T3C-2c API Token Manager I18n Design
+
+Date: 2026-05-20
+
+Branch: `codex/multitable-t3c2c-api-token-i18n-20260520`
+
+## Decision Summary
+
+T3C-2c localizes the `MetaApiTokenManager.vue` chrome to zh-CN while preserving raw product data, persisted enum values, token material, URLs, backend error messages, and existing accessibility structure.
+
+This slice covers three surfaces in one component:
+
+| Surface | Scope |
+| --- | --- |
+| API Tokens | Tabs, form labels/placeholders, scope display, empty/loading states, token action labels, token meta labels |
+| Webhooks | Form/list chrome, known event labels, status labels, delivery panel chrome, delivery result labels |
+| DingTalk Groups | Scope note, group form chrome, validation fallback copy, group status/meta labels, delivery panel chrome |
+
+## Files In Scope
+
+| File | Purpose |
+| --- | --- |
+| `apps/web/src/multitable/components/MetaApiTokenManager.vue` | Wire labels into the API token, webhook, and DingTalk group manager chrome |
+| `apps/web/src/multitable/utils/meta-api-token-labels.ts` | New T3C-2c label module and enum-display helpers |
+| `apps/web/tests/meta-api-token-labels.spec.ts` | Unit coverage for static labels and helper behavior |
+| `apps/web/tests/multitable-api-token-manager.spec.ts` | Existing component spec plus zh-CN render assertions and raw-boundary checks |
+
+Out of scope:
+
+| Surface | Reason |
+| --- | --- |
+| `MetaAutomationRuleEditor.vue` | T3D automation domain |
+| Backend/API contracts | This is frontend chrome-only i18n |
+| Token/webhook/DingTalk user-authored names and URLs | User data must remain raw |
+| Backend `err.message` | Server-provided messages remain raw; only frontend fallback strings are localized |
+
+## Label Module
+
+New module:
+
+`apps/web/src/multitable/utils/meta-api-token-labels.ts`
+
+The module exports:
+
+| Export | Role |
+| --- | --- |
+| `apiTokenLabel(key, isZh)` | Static chrome lookup |
+| `apiManagerTitle(canManageDingTalkGroups, isZh)` | Title variant for full vs reduced permission mode |
+| `apiScopeLabel(scope, isZh)` / `apiScopesText(scopes, isZh)` | Known token scopes localized; unknown scopes preserved raw |
+| `apiWebhookEventLabel(event, isZh)` / `apiWebhookEventsText(events, isZh)` | Known webhook events localized; unknown events preserved raw |
+| `apiWebhookStatusLabel(active, isZh)` | Webhook enabled/disabled display |
+| `apiToggleLabel(active, isZh)` | Webhook enable/disable action text |
+| `apiDingTalkEnabledLabel(enabled, isZh)` | DingTalk group enabled/disabled display |
+| `apiDingTalkToggleLabel(enabled, isZh)` | DingTalk group enable/disable action text |
+| `apiDeliveryResultLabel(success, isZh)` | Delivery success/failure display |
+| `apiDingTalkScopeLabel(scope, ids, isZh)` | DingTalk scope label while preserving raw IDs |
+| `apiDingTalkSecretStateLabel(hasSecret, isZh)` | SEC secret configured/not configured display |
+| `apiDingTalkDeliverySourceLabel(sourceType, isZh)` | Known DingTalk delivery source labels; unknown source types preserved raw |
+
+Shared manager actions continue to come from `meta-manager-labels.ts`:
+
+| Shared key | Used for |
+| --- | --- |
+| `action.cancel` | Cancel buttons |
+| `action.delete` | Delete buttons |
+| `action.dismiss` | Dismiss new-token panel |
+
+This avoids redeclaring shared action helpers inside the T3C-2c domain.
+
+## Raw Boundary
+
+The following values stay raw and must not be translated:
+
+| Category | Examples |
+| --- | --- |
+| Persisted enum/data attributes | `data-token-scope="read"`, `data-webhook-event="record.created"`, `data-webhook-status="active"`, `data-dingtalk-group-status="enabled"` |
+| User-authored names | Token names, webhook names, DingTalk group names |
+| Sensitive/token material | New token plaintext, token prefix, DingTalk `access_token`, SEC secret state values |
+| URLs and IDs | Webhook URLs, masked DingTalk robot URLs, `sheetId`, `orgId` |
+| Delivery payloads | Delivery subject/content, HTTP status, timestamps |
+| Backend error messages | `err.message` when supplied by API client |
+
+Frontend fallback strings are localized through the label module.
+
+## Test Plan
+
+Run from repo root:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/meta-api-token-labels.spec.ts \
+  tests/multitable-api-token-manager.spec.ts \
+  --watch=false
+```
+
+Expected coverage:
+
+| Spec | Assertions |
+| --- | --- |
+| `meta-api-token-labels.spec.ts` | Static labels, known enum mapping, unknown enum raw preservation, DingTalk scope/source helpers |
+| `multitable-api-token-manager.spec.ts` | Existing English behavior plus zh-CN render assertions across all three tabs |
+
+Additional gates:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web build
+git diff --check origin/main..HEAD
+```
+
+## Acceptance Criteria
+
+- API token manager title, tabs, form chrome, empty/loading states, validation fallbacks, action labels, and delivery panels render in zh-CN when locale is `zh-CN`.
+- Existing English behavior remains unchanged when locale is `en`.
+- Raw enum/data attributes remain unchanged and are asserted in component tests.
+- Unknown token scopes, webhook events, and DingTalk delivery source types remain raw.
+- No backend/API contract, migration, K3, or attendance code is touched.

--- a/docs/development/multitable-t3c2c-api-token-manager-i18n-verification-20260520.md
+++ b/docs/development/multitable-t3c2c-api-token-manager-i18n-verification-20260520.md
@@ -1,0 +1,91 @@
+# T3C-2c API Token Manager I18n Verification
+
+Date: 2026-05-20
+
+Branch: `codex/multitable-t3c2c-api-token-i18n-20260520`
+
+## Definition Of Done
+
+| Gate | Status |
+| --- | --- |
+| Target label/helper spec passes | PASS |
+| API token manager component spec passes | PASS |
+| `vue-tsc --noEmit` | PASS |
+| `pnpm --filter @metasheet/web build` | PASS |
+| `git diff --check` and `git diff --check origin/main..HEAD` | PASS |
+| Raw enum/data attributes preserved | PASS via component spec |
+| Shared action helper redeclare avoided | PASS via code review |
+
+## Target Test Evidence
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/meta-api-token-labels.spec.ts \
+  tests/multitable-api-token-manager.spec.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+✓ tests/meta-api-token-labels.spec.ts  (8 tests)
+✓ tests/multitable-api-token-manager.spec.ts  (26 tests)
+
+Test Files  2 passed (2)
+Tests       34 passed (34)
+```
+
+## Coverage Notes
+
+`meta-api-token-labels.spec.ts` covers:
+
+- Static en/zh label lookup.
+- Full/reduced manager title variants.
+- Known token scope localization and unknown scope raw preservation.
+- Known webhook event localization and unknown event raw preservation.
+- Webhook status/action/delivery labels.
+- DingTalk enabled/disabled, secret-state, scope, and delivery-source helpers.
+- Unknown DingTalk delivery source raw preservation.
+
+`multitable-api-token-manager.spec.ts` covers:
+
+- Existing token, webhook, and DingTalk group manager behavior.
+- `zh-CN` render assertions across API token, webhook, and DingTalk group tabs.
+- Raw `data-token-scope`, `data-webhook-event`, `data-webhook-status`, and `data-dingtalk-group-status` preservation.
+- User data/raw payload preservation for token name/prefix, webhook URL, DingTalk group name, masked access token, delivery subject, and HTTP status.
+
+## Scope Audit
+
+Expected PR files:
+
+```text
+apps/web/src/multitable/components/MetaApiTokenManager.vue
+apps/web/src/multitable/utils/meta-api-token-labels.ts
+apps/web/tests/meta-api-token-labels.spec.ts
+apps/web/tests/multitable-api-token-manager.spec.ts
+docs/development/multitable-t3c2c-api-token-manager-i18n-design-20260520.md
+docs/development/multitable-t3c2c-api-token-manager-i18n-verification-20260520.md
+```
+
+Out-of-scope paths intentionally untouched:
+
+```text
+packages/core-backend/**
+plugins/plugin-attendance/**
+plugins/plugin-integration-core/**
+lib/adapters/k3-wise-*
+apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+apps/web/src/multitable/components/MetaFormShareManager.vue
+apps/web/src/multitable/components/MetaRecordPermissionManager.vue
+```
+
+## Final Gate Output
+
+```text
+pnpm --filter @metasheet/web exec vue-tsc --noEmit: PASS (exit 0, no output)
+pnpm --filter @metasheet/web build: PASS (Vite build completed; existing chunk-size warnings only)
+git diff --check: PASS (exit 0)
+git diff --check origin/main..HEAD: PASS (exit 0)
+```


### PR DESCRIPTION
## Summary

- Localize `MetaApiTokenManager.vue` chrome for API Tokens, Webhooks, and DingTalk Groups.
- Add `meta-api-token-labels.ts` with api-token / webhook / DingTalk helper buckets.
- Preserve raw enum/data-* values, user-authored data, token material, URLs, backend errors, and existing aria/title/placeholder structure.
- Reuse `meta-manager-labels.ts` shared actions for Cancel/Delete/Dismiss instead of redeclaring them.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/meta-api-token-labels.spec.ts tests/multitable-api-token-manager.spec.ts --watch=false` — 34/34 pass
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` — pass
- `pnpm --filter @metasheet/web build` — pass
- `git diff --check origin/main..HEAD` — pass

## Scope Notes

- Frontend i18n only; no backend/API contract/migration/K3/attendance changes.
- Raw boundaries are asserted in tests: token scopes, webhook events/status, DingTalk group status, names, URLs, masked token values, delivery subjects, and HTTP status remain raw.
