### PR TITLE
feat(multitable): localize residual presence and template chrome (T3E-1)

### DIFF
--- a/apps/web/src/multitable/components/MetaYjsPresenceChip.vue
+++ b/apps/web/src/multitable/components/MetaYjsPresenceChip.vue
@@ -1,6 +1,8 @@
 <script setup lang="ts">
 import { computed } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type { YjsPresenceUser } from '../types'
+import { metaCoreLabel } from '../utils/meta-core-labels'
 
 const props = withDefaults(defineProps<{
   users: YjsPresenceUser[]
@@ -10,8 +12,10 @@ const props = withDefaults(defineProps<{
 }>(), {
   currentUserId: null,
   fieldId: null,
-  label: 'Collaborating now',
 })
+
+const { isZh } = useLocale()
+const resolvedLabel = computed(() => props.label ?? metaCoreLabel('presence.collaboratingNow', isZh.value))
 
 const filteredUsers = computed(() => {
   const normalizedFieldId = props.fieldId?.trim() || null
@@ -35,10 +39,10 @@ const summary = computed(() => {
   <div
     v-if="filteredUsers.length > 0"
     class="mt-yjs-presence-chip"
-    :title="`${label}: ${filteredUsers.map((user) => user.id).join(', ')}`"
+    :title="`${resolvedLabel}: ${filteredUsers.map((user) => user.id).join(', ')}`"
   >
     <span class="mt-yjs-presence-chip__dot" aria-hidden="true" />
-    <span class="mt-yjs-presence-chip__label">{{ label }}</span>
+    <span class="mt-yjs-presence-chip__label">{{ resolvedLabel }}</span>
     <span class="mt-yjs-presence-chip__users">{{ summary }}</span>
   </div>
 </template>

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -17,6 +17,8 @@
 // "(No value)" fallback (see groupNoValue / MetaGridTable __ungrouped__).
 
 export type MetaCoreLabelKey =
+  // --- Shared presence chrome (T3E-1) ---
+  | 'presence.collaboratingNow'
   // --- MetaToolbar static ---
   | 'toolbar.aria'
   | 'toolbar.fields'
@@ -61,6 +63,8 @@ export type MetaCoreLabelKey =
   | 'cell.uploadFailed' | 'cell.removeFailed' | 'cell.clearFailed'
 
 const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
+  'presence.collaboratingNow': { en: 'Collaborating now', zh: '正在协作' },
+
   'toolbar.aria': { en: 'Grid toolbar', zh: '表格工具栏' },
   'toolbar.fields': { en: 'Fields', zh: '字段' },
   'toolbar.sort': { en: 'Sort', zh: '排序' },

--- a/apps/web/src/multitable/utils/workbench-labels.ts
+++ b/apps/web/src/multitable/utils/workbench-labels.ts
@@ -22,7 +22,7 @@ export type WorkbenchLabelKey =
   | 'toolbar.dashboard' | 'toolbar.shareForm' | 'toolbar.apiWebhooks'
   | 'toolbar.mentions'
   // §3.3 template library modal
-  | 'tpl.title' | 'tpl.subtitle' | 'tpl.loading' | 'tpl.more'
+  | 'tpl.title' | 'tpl.subtitle' | 'tpl.loading' | 'tpl.more' | 'tpl.errorLoad'
   // §3.4 keyboard shortcuts modal (explanatory text only)
   | 'kbd.title' | 'kbd.navigateCells' | 'kbd.editCell' | 'kbd.cancelClose'
   | 'kbd.nextCell' | 'kbd.copy' | 'kbd.paste' | 'kbd.undo' | 'kbd.redo'
@@ -34,6 +34,9 @@ export type WorkbenchLabelKey =
   | 'toast.formSubmitted' | 'toast.commentUpdated' | 'toast.commentAdded'
   | 'toast.commentResolved' | 'toast.commentDeleted' | 'toast.linkedRecordsUpdated'
   | 'toast.viewSettingsSaved'
+  // T3E-1 template-library fallback/toast residuals
+  | 'toast.templateInstallBlocked' | 'toast.templateRefreshFailed'
+  | 'toast.templateInstallFailed'
   // §3.6 MetaTemplateCard button (counts use the card* helpers below)
   | 'card.install' | 'card.installing'
 
@@ -64,6 +67,7 @@ const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = 
   },
   'tpl.loading': { en: 'Loading templates...', zh: '正在加载模板...' },
   'tpl.more': { en: 'More templates →', zh: '更多模板 →' },
+  'tpl.errorLoad': { en: 'Failed to load templates', zh: '加载模板失败' },
 
   'kbd.title': { en: 'Keyboard Shortcuts', zh: '键盘快捷键' },
   'kbd.navigateCells': { en: 'Navigate cells', zh: '导航单元格' },
@@ -101,6 +105,18 @@ const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = 
   'toast.commentDeleted': { en: 'Comment deleted', zh: '评论已删除' },
   'toast.linkedRecordsUpdated': { en: 'Linked records updated', zh: '关联记录已更新' },
   'toast.viewSettingsSaved': { en: 'View settings saved', zh: '视图设置已保存' },
+  'toast.templateInstallBlocked': {
+    en: 'Template installation requires multitable write access.',
+    zh: '安装模板需要多维表写入权限。',
+  },
+  'toast.templateRefreshFailed': {
+    en: 'Installed template but failed to refresh workbench context',
+    zh: '模板已安装，但刷新工作台上下文失败',
+  },
+  'toast.templateInstallFailed': {
+    en: 'Failed to install template',
+    zh: '安装模板失败',
+  },
 
   'card.install': { en: 'Use template', zh: '使用模板' },
   'card.installing': { en: 'Installing...', zh: '创建中...' },
@@ -153,6 +169,11 @@ export function mentionsUnread(n: number, isZh: boolean): string {
 
 export function mentionsRecords(n: number, isZh: boolean): string {
   return isZh ? `${n} 条记录` : `${n} record${n === 1 ? '' : 's'}`
+}
+
+// Template names are user/data values and pass through raw.
+export function templateInstalled(templateName: string, isZh: boolean): string {
+  return isZh ? `已安装 ${templateName}` : `Installed ${templateName}`
 }
 
 // MetaTemplateCard counts: zh "{n} 个 Sheet/字段/视图"; en pluralized.

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -420,6 +420,7 @@ import {
   commentInboxTitle as fmtCommentInboxTitle,
   mentionsUnread as fmtMentionsUnread,
   mentionsRecords as fmtMentionsRecords,
+  templateInstalled as fmtTemplateInstalled,
 } from '../utils/workbench-labels'
 import { commentLabel } from '../utils/meta-comment-labels'
 import type {
@@ -2153,7 +2154,7 @@ async function loadTemplateLibrary() {
     const data = await workbench.client.listTemplates()
     templates.value = data.templates ?? []
   } catch (e: any) {
-    templateLibraryError.value = e.message ?? 'Failed to load templates'
+    templateLibraryError.value = e.message ?? wb('tpl.errorLoad', isZh.value)
   } finally {
     templateLibraryLoading.value = false
   }
@@ -2161,7 +2162,7 @@ async function loadTemplateLibrary() {
 
 async function openTemplateLibrary() {
   if (!canCreateBasesAndSheets.value) {
-    showError('Template installation requires multitable write access.')
+    showError(wb('toast.templateInstallBlocked', isZh.value))
     return
   }
   showTemplateLibrary.value = true
@@ -2172,7 +2173,7 @@ async function openTemplateLibrary() {
 
 async function onInstallTemplate(template: MetaTemplate) {
   if (!canCreateBasesAndSheets.value) {
-    showError('Template installation requires multitable write access.')
+    showError(wb('toast.templateInstallBlocked', isZh.value))
     return
   }
   if (!confirmDiscardContextChanges()) return
@@ -2188,14 +2189,14 @@ async function onInstallTemplate(template: MetaTemplate) {
       viewId: result.views[0]?.id,
     })
     if (!ok) {
-      showError(workbench.error.value ?? 'Installed template but failed to refresh workbench context')
+      showError(workbench.error.value ?? wb('toast.templateRefreshFailed', isZh.value))
       return
     }
     rememberWorkbenchBaseOpen(result.base.id)
     showTemplateLibrary.value = false
-    showSuccess(`Installed ${result.template.name}`)
+    showSuccess(fmtTemplateInstalled(result.template.name, isZh.value))
   } catch (e: any) {
-    showError(e.message ?? 'Failed to install template')
+    showError(e.message ?? wb('toast.templateInstallFailed', isZh.value))
   } finally {
     installingTemplateId.value = null
   }

--- a/apps/web/tests/multitable-core-i18n.spec.ts
+++ b/apps/web/tests/multitable-core-i18n.spec.ts
@@ -14,6 +14,8 @@ import {
 
 describe('meta-core-labels static keys', () => {
   it('returns zh for isZh=true and en for isZh=false', () => {
+    expect(metaCoreLabel('presence.collaboratingNow', true)).toBe('正在协作')
+    expect(metaCoreLabel('presence.collaboratingNow', false)).toBe('Collaborating now')
     expect(metaCoreLabel('toolbar.fields', true)).toBe('字段')
     expect(metaCoreLabel('toolbar.fields', false)).toBe('Fields')
     expect(metaCoreLabel('grid.aria', true)).toBe('数据表格')

--- a/apps/web/tests/multitable-workbench-i18n.spec.ts
+++ b/apps/web/tests/multitable-workbench-i18n.spec.ts
@@ -7,6 +7,7 @@ import {
   commentInboxTitle,
   mentionsUnread,
   mentionsRecords,
+  templateInstalled,
   cardSheets,
   cardFields,
   cardViews,
@@ -22,7 +23,7 @@ const ALL_KEYS: WorkbenchLabelKey[] = [
   'toolbar.workflow', 'toolbar.automations', 'toolbar.templates',
   'toolbar.dashboard', 'toolbar.shareForm', 'toolbar.apiWebhooks',
   'toolbar.mentions',
-  'tpl.title', 'tpl.subtitle', 'tpl.loading', 'tpl.more',
+  'tpl.title', 'tpl.subtitle', 'tpl.loading', 'tpl.more', 'tpl.errorLoad',
   'kbd.title', 'kbd.navigateCells', 'kbd.editCell', 'kbd.cancelClose',
   'kbd.nextCell', 'kbd.copy', 'kbd.paste', 'kbd.undo', 'kbd.redo',
   'kbd.toggleHelp',
@@ -31,7 +32,8 @@ const ALL_KEYS: WorkbenchLabelKey[] = [
   'toast.loadedLatest', 'toast.changeReapplied', 'toast.recordUpdated',
   'toast.formSubmitted', 'toast.commentUpdated', 'toast.commentAdded',
   'toast.commentResolved', 'toast.commentDeleted', 'toast.linkedRecordsUpdated',
-  'toast.viewSettingsSaved',
+  'toast.viewSettingsSaved', 'toast.templateInstallBlocked', 'toast.templateRefreshFailed',
+  'toast.templateInstallFailed',
   'card.install', 'card.installing',
 ]
 
@@ -118,5 +120,11 @@ describe('workbench-labels interpolation helpers', () => {
     expect(cardFields(0, false)).toBe('0 fields')
     expect(cardViews(3, true)).toBe('3 个视图')
     expect(cardViews(1, false)).toBe('1 view')
+  })
+
+  it('templateInstalled localizes surrounding chrome and keeps template name raw', () => {
+    expect(templateInstalled('CRM Pipeline', false)).toBe('Installed CRM Pipeline')
+    expect(templateInstalled('CRM Pipeline', true)).toBe('已安装 CRM Pipeline')
+    expect(templateInstalled('合同管理', true)).toBe('已安装 合同管理')
   })
 })

--- a/apps/web/tests/yjs-awareness-presence.spec.ts
+++ b/apps/web/tests/yjs-awareness-presence.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, defineComponent, h, nextTick, ref, type App } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
 import { useYjsDocument } from '../src/multitable/composables/useYjsDocument'
 import { useYjsTextField } from '../src/multitable/composables/useYjsTextField'
 import MetaYjsPresenceChip from '../src/multitable/components/MetaYjsPresenceChip.vue'
@@ -41,6 +42,7 @@ describe('Yjs awareness presence', () => {
   let container: HTMLDivElement | null = null
 
   beforeEach(() => {
+    useLocale().setLocale('en')
     handlers.clear()
     emitMock.mockReset()
     disconnectMock.mockReset()
@@ -54,6 +56,7 @@ describe('Yjs awareness presence', () => {
     if (container) container.remove()
     app = null
     container = null
+    useLocale().setLocale('en')
   })
 
   it('tracks collaborators per field and emits active field presence', async () => {
@@ -153,5 +156,29 @@ describe('Yjs awareness presence', () => {
     expect(container?.textContent).toContain('user_alpha, user_beta')
     expect(container?.textContent).not.toContain('user_self')
     expect(container?.textContent).not.toContain('user_gamma')
+  })
+
+  it('localizes the default chip label while preserving raw collaborator ids', async () => {
+    useLocale().setLocale('zh-CN')
+
+    app = createApp(defineComponent({
+      setup() {
+        return () => h(MetaYjsPresenceChip, {
+          currentUserId: 'user_self',
+          fieldId: 'fld_body',
+          users: [
+            { id: 'user_self', fieldIds: ['fld_body'] },
+            { id: 'user_alpha', fieldIds: ['fld_body'] },
+          ],
+        })
+      },
+    }))
+    app.mount(container!)
+    await flushUi(2)
+
+    const chip = container?.querySelector('.mt-yjs-presence-chip')
+    expect(container?.textContent).toContain('正在协作')
+    expect(container?.textContent).toContain('user_alpha')
+    expect(chip?.getAttribute('title')).toBe('正在协作: user_alpha')
   })
 })

--- a/docs/development/multitable-t3e1-presence-template-residual-i18n-design-20260520.md
+++ b/docs/development/multitable-t3e1-presence-template-residual-i18n-design-20260520.md
@@ -1,0 +1,236 @@
+# T3E-1 Presence + Template Residual i18n Design
+
+Date: 2026-05-20
+Branch: docs/multitable-t3e1-residual-i18n-design-20260520
+Status: design only; no code changes yet
+
+## 1. Decision Summary
+
+T3E-1 is a small residual i18n slice. It intentionally avoids opening the larger manager/dialog surfaces.
+
+| Decision | Outcome |
+| --- | --- |
+| Scope | Localize `MetaYjsPresenceChip` default copy and Workbench template-library fallback/toast strings |
+| Module placement | Reuse existing label modules: `meta-core-labels.ts` for presence default, `workbench-labels.ts` for template-library copy |
+| Raw data boundary | User IDs, template names, and server/runtime `error.message` values remain raw |
+| Out of scope | Workbench dynamic toast bulk, `MetaBulkEditDialog`, `ConditionalFormattingDialog`, T3D automation |
+| Implementation gate | Design MD review first, then code + verification MD, stop before push |
+
+## 2. Files In Scope
+
+Implementation files:
+
+| File | Planned change |
+| --- | --- |
+| `apps/web/src/multitable/components/MetaYjsPresenceChip.vue` | Replace hard-coded default label with locale-aware computed default |
+| `apps/web/src/multitable/utils/meta-core-labels.ts` | Add `presence.collaboratingNow` |
+| `apps/web/src/multitable/views/MultitableWorkbench.vue` | Replace template-library fallback strings and install toasts with workbench labels/helpers |
+| `apps/web/src/multitable/utils/workbench-labels.ts` | Add template-library error/toast keys and `templateInstalled()` helper |
+
+Test files:
+
+| File | Planned change |
+| --- | --- |
+| `apps/web/tests/multitable-core-i18n.spec.ts` | Cover the new core presence key |
+| `apps/web/tests/yjs-awareness-presence.spec.ts` | Cover zh-CN default label and explicit-label preservation |
+| `apps/web/tests/multitable-workbench-i18n.spec.ts` | Cover new Workbench keys and `templateInstalled()` helper |
+
+Docs:
+
+| File | Planned change |
+| --- | --- |
+| `docs/development/multitable-t3e1-presence-template-residual-i18n-design-20260520.md` | This design plan |
+| `docs/development/multitable-t3e1-presence-template-residual-i18n-verification-20260520.md` | To be created during implementation |
+
+## 3. Exact Chrome Targets
+
+### 3.1 MetaYjsPresenceChip
+
+| Source | Current EN | zh-CN | Key/helper | Notes |
+| --- | --- | --- | --- | --- |
+| `MetaYjsPresenceChip.vue` default prop label | `Collaborating now` | `正在协作` | `presence.collaboratingNow` | Only used when caller does not pass `label` |
+
+Current template also builds a title from the label plus raw user IDs:
+
+```vue
+:title="`${label}: ${filteredUsers.map((user) => user.id).join(', ')}`"
+```
+
+Implementation should use the resolved label for both visible text and title, but must keep the user IDs raw.
+
+### 3.2 Workbench Template Library
+
+| Source | Current EN | zh-CN | Key/helper | Notes |
+| --- | --- | --- | --- | --- |
+| `loadTemplateLibrary()` fallback | `Failed to load templates` | `加载模板失败` | `tpl.errorLoad` | Only used when `e.message` is absent |
+| install permission toast | `Template installation requires multitable write access.` | `安装模板需要多维表写入权限。` | `toast.templateInstallBlocked` | Appears in both `openTemplateLibrary()` and `onInstallTemplate()` |
+| install sync fallback | `Installed template but failed to refresh workbench context` | `模板已安装，但刷新工作台上下文失败` | `toast.templateRefreshFailed` | Only used when `workbench.error.value` is absent |
+| install success | `Installed ${templateName}` | `已安装 ${templateName}` | `templateInstalled(templateName, isZh)` | Template name remains raw data |
+| install failure fallback | `Failed to install template` | `安装模板失败` | `toast.templateInstallFailed` | Only used when `e.message` is absent |
+
+## 4. Label Module Plan
+
+### 4.1 `meta-core-labels.ts`
+
+Add one key to the existing core label module instead of creating a one-string module:
+
+```ts
+| 'presence.collaboratingNow'
+```
+
+Planned mapping:
+
+```ts
+'presence.collaboratingNow': {
+  en: 'Collaborating now',
+  zh: '正在协作',
+}
+```
+
+Rationale: `MetaYjsPresenceChip` is a shared low-level Meta* component and this residual label belongs with existing core chrome such as cell/table labels.
+
+### 4.2 `workbench-labels.ts`
+
+Add static keys:
+
+```ts
+| 'tpl.errorLoad'
+| 'toast.templateInstallBlocked'
+| 'toast.templateRefreshFailed'
+| 'toast.templateInstallFailed'
+```
+
+Add helper:
+
+```ts
+export function templateInstalled(templateName: string, isZh: boolean): string {
+  return isZh ? `已安装 ${templateName}` : `Installed ${templateName}`
+}
+```
+
+Rationale: Workbench template-library strings already sit inside the Workbench shell. The helper preserves the template name as raw user/data content while localizing the surrounding chrome.
+
+## 5. Implementation Notes
+
+### 5.1 MetaYjsPresenceChip Default Must Be Reactive
+
+Do not keep the label in `withDefaults()` as a string default, because that default is not locale-reactive.
+
+Planned shape:
+
+```ts
+const props = withDefaults(defineProps<{
+  users?: PresenceUser[]
+  currentUserId?: string | null
+  fieldId?: string | null
+  label?: string
+}>(), {
+  users: () => [],
+  currentUserId: null,
+  fieldId: null,
+})
+
+const { isZh } = useLocale()
+const resolvedLabel = computed(() => props.label ?? coreLabel('presence.collaboratingNow', isZh.value))
+```
+
+The template should use `resolvedLabel` for both visible text and title.
+
+### 5.2 Explicit Label Prop Remains Caller-Controlled
+
+Existing consumers that pass a label must keep full control. Example: `MetaCellEditor.vue` passes the T3A2-localized `cell.editing` label and should not be overridden by the new default logic.
+
+Test requirement: keep or add a spec proving an explicit label such as `Editing now` remains visible as-is.
+
+### 5.3 Workbench Error Values Are Event-Time Strings
+
+`templateLibraryError` stores a string at the time the async failure occurs. If the user changes locale after the error was stored, the stored fallback will not retranslate until a reload/retry. This is acceptable for this slice because existing toast/error behavior is event-time based.
+
+Server/runtime `e.message` and `workbench.error.value` remain raw when present. Only frontend fallback strings are localized.
+
+Same event-time semantic applies to `templateInstalled()` after its return value enters the toast queue. A locale toggle after install will not retranslate the success toast, which is acceptable for ephemeral toasts.
+
+### 5.4 Preflight Grep
+
+Before module changes, run:
+
+```bash
+rg -n "Collaborating now|Failed to load templates|Template installation requires|Installed template but failed|Installed |Failed to install template" apps/web/src/multitable/ apps/web/tests/
+```
+
+Confirm each planned key maps to a real call-site; resolve any miss before wiring.
+
+## 6. Raw Data / Do-Not-Translate Boundary
+
+| Value | Boundary |
+| --- | --- |
+| Presence user IDs in `MetaYjsPresenceChip` title | Raw identifiers, not translated |
+| Explicit `label` prop passed to `MetaYjsPresenceChip` | Caller-owned, not retranslated by the component |
+| Template names in install success toast | Raw template data, only the surrounding sentence is translated |
+| `e.message` from runtime/server errors | Raw error value preserved when present |
+| `workbench.error.value` | Raw runtime value preserved when present |
+
+## 7. Test Plan
+
+Targeted frontend tests:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-core-i18n.spec.ts \
+  tests/yjs-awareness-presence.spec.ts \
+  tests/multitable-workbench-i18n.spec.ts \
+  --watch=false
+```
+
+Type/build gates:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web build
+```
+
+Diff hygiene:
+
+```bash
+git diff --check origin/main..HEAD
+```
+
+Expected new/updated coverage:
+
+| Spec | Coverage |
+| --- | --- |
+| `multitable-core-i18n.spec.ts` | New `presence.collaboratingNow` key is covered in the exhaustive key list |
+| `yjs-awareness-presence.spec.ts` | zh-CN default renders `正在协作`; explicit labels remain unchanged; raw IDs remain in title |
+| `multitable-workbench-i18n.spec.ts` | New Workbench static keys plus `templateInstalled()` en/zh helper behavior |
+
+## 8. Risks and Mitigations
+
+| Risk | Mitigation |
+| --- | --- |
+| Default presence label is not locale-reactive | Remove string default from `withDefaults()` and use a computed fallback from `useLocale()` |
+| Explicit label consumers regress | Keep existing explicit-label spec and add default-only spec separately |
+| Template name accidentally translated or normalized | `templateInstalled()` accepts and preserves raw `templateName` |
+| Runtime/server error text accidentally translated | Use localized fallback only behind `e.message ?? ...` and `workbench.error.value ?? ...` |
+| Workbench heavy render tests become brittle | Keep this slice covered by label-helper tests plus the narrow presence component spec; do not mount full Workbench for these static fallbacks |
+
+## 9. Deferred Surfaces
+
+These were found during scout but are intentionally out of T3E-1:
+
+| Deferred slice | Surface | Reason |
+| --- | --- | --- |
+| T3E-2 | Workbench dynamic toasts/fallbacks | Many interpolated and workflow-dependent strings; needs separate grep classification |
+| T3E-3 | `MetaBulkEditDialog.vue` | Full dialog chrome, parent-generated bulk-edit messages, and action/count grammar belong together |
+| T3E-3 | `ConditionalFormattingDialog.vue` | Rule editor dialog with operator/color/confirm strings; should not be mixed into T3E-1 |
+| T3D | Automation manager/rule editor/log viewer | Larger rule-domain surface with enum semantics; requires design MD first |
+| Final audit | Global multitable i18n grep | Best after T3D/T3E residual slices are complete |
+
+## 10. Acceptance Gate
+
+Implementation can start after design review if these conditions remain true:
+
+1. Scope stays limited to presence default + Workbench template-library fallback/toasts.
+2. No `MetaBulkEditDialog.vue` or `ConditionalFormattingDialog.vue` code changes in T3E-1.
+3. No backend, contract, migration, attendance, or K3 files touched.
+4. All added keys have real call-sites; no dead keys.
+5. Implementation stops before push for review.

--- a/docs/development/multitable-t3e1-presence-template-residual-i18n-verification-20260520.md
+++ b/docs/development/multitable-t3e1-presence-template-residual-i18n-verification-20260520.md
@@ -1,0 +1,155 @@
+# T3E-1 Presence + Template Residual i18n Verification
+
+Date: 2026-05-20
+Branch: docs/multitable-t3e1-residual-i18n-design-20260520
+Status: implementation verified locally; not pushed
+
+## 1. Definition Of Done
+
+T3E-1 is complete when:
+
+1. `MetaYjsPresenceChip` default label is locale-reactive and renders zh-CN as `正在协作`.
+2. Explicit `label` props remain caller-controlled.
+3. Workbench template-library load/install fallback strings use `workbench-labels.ts`.
+4. User/data values remain raw: presence user IDs, template names, `e.message`, and `workbench.error.value`.
+5. Targeted i18n specs, type-check, build, and diff hygiene pass.
+
+## 2. Scope Verified
+
+Implementation files:
+
+| File | Verification |
+| --- | --- |
+| `apps/web/src/multitable/components/MetaYjsPresenceChip.vue` | Removed string default from `withDefaults()` and uses computed fallback via `metaCoreLabel('presence.collaboratingNow', isZh.value)` |
+| `apps/web/src/multitable/utils/meta-core-labels.ts` | Added `presence.collaboratingNow` with explicit EN/ZH |
+| `apps/web/src/multitable/views/MultitableWorkbench.vue` | Template-library fallback/toast strings now call `wb(...)` or `templateInstalled(...)` |
+| `apps/web/src/multitable/utils/workbench-labels.ts` | Added `tpl.errorLoad`, 3 template-install toast keys, and `templateInstalled()` |
+
+Test/doc files:
+
+| File | Verification |
+| --- | --- |
+| `apps/web/tests/multitable-core-i18n.spec.ts` | Covers `presence.collaboratingNow` |
+| `apps/web/tests/yjs-awareness-presence.spec.ts` | Covers zh-CN default label, explicit label preservation, and raw user IDs in title |
+| `apps/web/tests/multitable-workbench-i18n.spec.ts` | Covers new Workbench keys and `templateInstalled()` raw template-name behavior |
+| `docs/development/multitable-t3e1-presence-template-residual-i18n-design-20260520.md` | Includes preflight grep and event-time toast semantics |
+
+## 3. Preflight Grep
+
+Command:
+
+```bash
+rg -n "Collaborating now|Failed to load templates|Template installation requires|Installed template but failed|Installed |Failed to install template" apps/web/src/multitable apps/web/src/views apps/web/tests
+```
+
+Result:
+
+```text
+apps/web/src/multitable/views/MultitableWorkbench.vue:2156:    templateLibraryError.value = e.message ?? 'Failed to load templates'
+apps/web/src/multitable/views/MultitableWorkbench.vue:2164:    showError('Template installation requires multitable write access.')
+apps/web/src/multitable/views/MultitableWorkbench.vue:2175:    showError('Template installation requires multitable write access.')
+apps/web/src/multitable/views/MultitableWorkbench.vue:2191:      showError(workbench.error.value ?? 'Installed template but failed to refresh workbench context')
+apps/web/src/multitable/views/MultitableWorkbench.vue:2196:    showSuccess(`Installed ${result.template.name}`)
+apps/web/src/multitable/views/MultitableWorkbench.vue:2198:    showError(e.message ?? 'Failed to install template')
+apps/web/src/multitable/components/MetaYjsPresenceChip.vue:13:  label: 'Collaborating now',
+```
+
+Other `Installed` hits were under `AfterSalesView` and unrelated tests, so they are out of scope.
+
+## 4. Test Evidence
+
+### Targeted Vitest
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-core-i18n.spec.ts \
+  tests/yjs-awareness-presence.spec.ts \
+  tests/multitable-workbench-i18n.spec.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+✓ tests/multitable-workbench-i18n.spec.ts  (9 tests)
+✓ tests/multitable-core-i18n.spec.ts  (23 tests)
+✓ tests/yjs-awareness-presence.spec.ts  (3 tests)
+
+Test Files  3 passed (3)
+Tests       35 passed (35)
+```
+
+### Type Check
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result:
+
+```text
+exit 0 / no output
+```
+
+### Build
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result:
+
+```text
+✓ 2412 modules transformed.
+✓ built in 5.86s
+```
+
+Vite emitted existing chunk-size / mixed dynamic-static import warnings; no build failure.
+
+## 5. Raw Boundary Checks
+
+| Boundary | Verification |
+| --- | --- |
+| Explicit presence label | Existing `Editing now` spec remains and passes; default logic does not override caller-provided labels |
+| Presence user IDs | zh-CN default spec asserts title `正在协作: user_alpha`; ID remains raw |
+| Template names | `templateInstalled('CRM Pipeline', true)` returns `已安装 CRM Pipeline`; raw name preserved |
+| Runtime errors | Workbench still uses `e.message ?? localizedFallback` and `workbench.error.value ?? localizedFallback` |
+| Event-time toasts | `templateInstalled()` returns a string for the toast queue; later locale toggles do not retranslate old toasts, matching existing toast semantics |
+
+## 6. Dependency Note
+
+This was a fresh worktree without local `node_modules`, so the first Vitest attempt failed with:
+
+```text
+ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "vitest" not found
+```
+
+`pnpm install --frozen-lockfile` fixed the local tool resolution. As in previous metasheet2 worktrees, install touched tracked plugin/tool `node_modules` symlinks. Those files are not part of this slice and must remain unstaged/uncommitted.
+
+## 7. Deferred Surfaces
+
+Deferred exactly as design-scoped:
+
+| Deferred | Reason |
+| --- | --- |
+| T3E-2 Workbench dynamic toasts/fallbacks | Many interpolated strings; should be grep-classified separately |
+| T3E-3 `MetaBulkEditDialog.vue` | Full dialog plus parent-generated messages belong together |
+| T3E-3 `ConditionalFormattingDialog.vue` | Rule dialog/operator/color/confirm surface belongs together |
+| T3D automation | Larger rule-domain surface; design MD required first |
+| Final audit | Best after T3D/T3E residual slices complete |
+
+## 8. Closeout
+
+T3E-1 local implementation meets the design gate. Remaining push/PR gate:
+
+```bash
+git diff --check origin/main..HEAD
+```
+
+Run after committing the targeted T3E-1 files only, excluding local `node_modules` install noise.


### PR DESCRIPTION
## Summary

T3E-1 residual multitable i18n cleanup:

- localize `MetaYjsPresenceChip` default label via `meta-core-labels.ts` while preserving explicit `label` props
- localize Workbench template-library load/install fallback strings via `workbench-labels.ts`
- preserve raw boundaries for collaborator IDs, template names, `e.message`, and `workbench.error.value`
- add design + verification docs for the slice

## Scope

Included:

- `MetaYjsPresenceChip.vue`
- `meta-core-labels.ts`
- `MultitableWorkbench.vue`
- `workbench-labels.ts`
- focused specs for core labels, Yjs presence, and Workbench labels

Deferred by design:

- Workbench dynamic toasts/fallbacks (T3E-2)
- `MetaBulkEditDialog.vue` + `ConditionalFormattingDialog.vue` (T3E-3)
- T3D automation
- final i18n audit

## Verification

Local verification in clean T3E-1 worktree:

```text
pnpm --filter @metasheet/web exec vitest run \
  tests/multitable-core-i18n.spec.ts \
  tests/yjs-awareness-presence.spec.ts \
  tests/multitable-workbench-i18n.spec.ts \
  --watch=false

✓ tests/multitable-workbench-i18n.spec.ts  (9 tests)
✓ tests/multitable-core-i18n.spec.ts  (23 tests)
✓ tests/yjs-awareness-presence.spec.ts  (3 tests)

Test Files  3 passed (3)
Tests       35 passed (35)
```

```text
pnpm --filter @metasheet/web exec vue-tsc --noEmit
exit 0 / no output
```

```text
pnpm --filter @metasheet/web build
✓ 2412 modules transformed.
✓ built in 5.86s
```

```text
git diff --check origin/main..HEAD
clean
```

Note: this fresh worktree required `pnpm install --frozen-lockfile`; local tracked `node_modules` symlink noise remains unstaged and is not part of the PR diff.
