### PR TITLE
feat(multitable): localize workbench dynamic toast fallbacks (T3E-2)

### DIFF
--- a/apps/web/src/multitable/utils/workbench-labels.ts
+++ b/apps/web/src/multitable/utils/workbench-labels.ts
@@ -8,8 +8,7 @@
 //
 // Scope: see docs/development/multitable-workbench-i18n-t2-development-20260519.md.
 // `<kbd>` physical key names are NOT translated and are NOT in this table.
-// Dynamic / interpolated / permission / host-context / "Failed to ..." toasts
-// are T3 and intentionally absent here.
+// Dynamic helpers and fallback toasts are added incrementally in T3E.
 
 export type WorkbenchLabelKey =
   // §3.0 script-computed shell (interpolated variants live in the helpers)
@@ -31,12 +30,30 @@ export type WorkbenchLabelKey =
   | 'toast.recordCreateBlocked' | 'toast.recordEditBlocked' | 'toast.recordDeleteBlocked'
   | 'toast.datesUpdated' | 'toast.hierarchyUpdated' | 'toast.recordDeleted'
   | 'toast.loadedLatest' | 'toast.changeReapplied' | 'toast.recordUpdated'
-  | 'toast.formSubmitted' | 'toast.commentUpdated' | 'toast.commentAdded'
+  | 'toast.commentUpdated' | 'toast.commentAdded'
   | 'toast.commentResolved' | 'toast.commentDeleted' | 'toast.linkedRecordsUpdated'
   | 'toast.viewSettingsSaved'
   // T3E-1 template-library fallback/toast residuals
   | 'toast.templateInstallBlocked' | 'toast.templateRefreshFailed'
   | 'toast.templateInstallFailed'
+  // T3E-2 Workbench dynamic fallback/confirm residuals
+  | 'toast.timelineDatesUpdateFailed' | 'toast.hierarchyParentUpdateFailed'
+  | 'toast.formSubmitFailed'
+  | 'toast.commentUpdateFailed' | 'toast.commentAddFailed'
+  | 'toast.commentResolveFailed' | 'toast.commentDeleteFailed'
+  | 'toast.linkedRecordsUpdateFailed'
+  | 'toast.fieldCreateFailed' | 'toast.fieldUpdateFailed' | 'toast.fieldDeleteFailed'
+  | 'toast.viewCreateFailed' | 'toast.viewUpdateFailed' | 'toast.viewDeleteFailed'
+  | 'toast.sheetAccessRefreshFailed'
+  | 'toast.sheetCreateBlocked' | 'toast.sheetRefreshFailed' | 'toast.sheetCreateFailed'
+  | 'toast.baseLoadFailed' | 'toast.contextSyncFailed'
+  | 'toast.externalContextBusy' | 'toast.externalContextUnsaved'
+  | 'toast.baseCreateBlocked' | 'toast.baseCreateFailed'
+  | 'toast.importCancelled' | 'toast.importFailed'
+  | 'toast.excelExportFailed' | 'toast.bulkDeleteFailed'
+  | 'toast.workbenchInitFailed'
+  | 'confirm.discardContextChanges' | 'confirm.discardRecordChanges'
+  | 'confirm.pageLeaveBusy' | 'confirm.pageLeaveDirty'
   // §3.6 MetaTemplateCard button (counts use the card* helpers below)
   | 'card.install' | 'card.installing'
 
@@ -98,7 +115,6 @@ const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = 
   'toast.loadedLatest': { en: 'Loaded the latest row state', zh: '已加载最新行状态' },
   'toast.changeReapplied': { en: 'Change reapplied', zh: '修改已重新应用' },
   'toast.recordUpdated': { en: 'Record updated', zh: '记录已更新' },
-  'toast.formSubmitted': { en: 'Form submitted', zh: '表单已提交' },
   'toast.commentUpdated': { en: 'Comment updated', zh: '评论已更新' },
   'toast.commentAdded': { en: 'Comment added', zh: '评论已添加' },
   'toast.commentResolved': { en: 'Comment resolved', zh: '评论已解决' },
@@ -116,6 +132,67 @@ const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = 
   'toast.templateInstallFailed': {
     en: 'Failed to install template',
     zh: '安装模板失败',
+  },
+  'toast.timelineDatesUpdateFailed': { en: 'Failed to update timeline dates', zh: '更新时间线日期失败' },
+  'toast.hierarchyParentUpdateFailed': { en: 'Failed to update hierarchy parent', zh: '更新层级父记录失败' },
+  'toast.formSubmitFailed': { en: 'Form submit failed', zh: '表单提交失败' },
+  'toast.commentUpdateFailed': { en: 'Failed to update comment', zh: '更新评论失败' },
+  'toast.commentAddFailed': { en: 'Failed to add comment', zh: '添加评论失败' },
+  'toast.commentResolveFailed': { en: 'Failed to resolve comment', zh: '解决评论失败' },
+  'toast.commentDeleteFailed': { en: 'Failed to delete comment', zh: '删除评论失败' },
+  'toast.linkedRecordsUpdateFailed': { en: 'Failed to update linked records', zh: '更新关联记录失败' },
+  'toast.fieldCreateFailed': { en: 'Failed to create field', zh: '创建字段失败' },
+  'toast.fieldUpdateFailed': { en: 'Failed to update field', zh: '更新字段失败' },
+  'toast.fieldDeleteFailed': { en: 'Failed to delete field', zh: '删除字段失败' },
+  'toast.viewCreateFailed': { en: 'Failed to create view', zh: '创建视图失败' },
+  'toast.viewUpdateFailed': { en: 'Failed to update view', zh: '更新视图失败' },
+  'toast.viewDeleteFailed': { en: 'Failed to delete view', zh: '删除视图失败' },
+  'toast.sheetAccessRefreshFailed': { en: 'Failed to refresh sheet access', zh: '刷新 Sheet 权限失败' },
+  'toast.sheetCreateBlocked': {
+    en: 'Sheet creation requires multitable write access.',
+    zh: '创建 Sheet 需要多维表写入权限。',
+  },
+  'toast.sheetRefreshFailed': {
+    en: 'Created sheet but failed to refresh workbench context',
+    zh: 'Sheet 已创建，但刷新工作台上下文失败',
+  },
+  'toast.sheetCreateFailed': { en: 'Failed to create sheet', zh: '创建 Sheet 失败' },
+  'toast.baseLoadFailed': { en: 'Failed to load base', zh: '加载 Base 失败' },
+  'toast.contextSyncFailed': { en: 'Failed to sync workbench context', zh: '同步工作台上下文失败' },
+  'toast.externalContextBusy': {
+    en: 'Host multitable context change is waiting for the current save or import to finish.',
+    zh: '宿主多维表上下文变更正在等待当前保存或导入完成。',
+  },
+  'toast.externalContextUnsaved': {
+    en: 'Host multitable context changed while unsaved drafts are open. Resolve or discard changes to continue.',
+    zh: '宿主多维表上下文已变更。请处理或放弃未保存草稿后继续。',
+  },
+  'toast.baseCreateBlocked': {
+    en: 'Base creation requires multitable write access.',
+    zh: '创建 Base 需要多维表写入权限。',
+  },
+  'toast.baseCreateFailed': { en: 'Failed to create base', zh: '创建 Base 失败' },
+  'toast.importCancelled': { en: 'Import cancelled', zh: '导入已取消' },
+  'toast.importFailed': { en: 'Import failed', zh: '导入失败' },
+  'toast.excelExportFailed': { en: 'Excel export failed', zh: 'Excel 导出失败' },
+  'toast.bulkDeleteFailed': { en: 'Bulk delete failed', zh: '批量删除失败' },
+  'toast.workbenchInitFailed': { en: 'Failed to initialize workbench', zh: '初始化工作台失败' },
+
+  'confirm.discardContextChanges': {
+    en: 'Discard unsaved changes before leaving the current sheet or view?',
+    zh: '离开当前 Sheet 或视图前放弃未保存的更改吗？',
+  },
+  'confirm.discardRecordChanges': {
+    en: 'Discard unsaved record changes?',
+    zh: '放弃未保存的记录更改吗？',
+  },
+  'confirm.pageLeaveBusy': {
+    en: 'Leave the multitable while the current save or import is still running?',
+    zh: '当前保存或导入仍在进行，确定离开多维表吗？',
+  },
+  'confirm.pageLeaveDirty': {
+    en: 'Discard unsaved multitable changes before leaving this page?',
+    zh: '离开此页面前放弃未保存的多维表更改吗？',
   },
 
   'card.install': { en: 'Use template', zh: '使用模板' },
@@ -174,6 +251,44 @@ export function mentionsRecords(n: number, isZh: boolean): string {
 // Template names are user/data values and pass through raw.
 export function templateInstalled(templateName: string, isZh: boolean): string {
   return isZh ? `已安装 ${templateName}` : `Installed ${templateName}`
+}
+
+export function formSubmitSuccess(mode: 'create' | 'update', isZh: boolean): string {
+  if (mode === 'create') return isZh ? '记录已创建' : 'Record created'
+  return isZh ? '更改已保存' : 'Changes saved'
+}
+
+export function recordsImported(n: number, isZh: boolean): string {
+  return isZh ? `${n} 条记录已导入` : `${n} record${n === 1 ? '' : 's'} imported`
+}
+
+export function recordsFailedToImport(
+  n: number,
+  rowNumbers: number[],
+  firstError: string,
+  isZh: boolean,
+): string {
+  const errorPart = firstError.trim()
+  if (isZh) {
+    const rows = rowNumbers.length > 0 ? `（${rowNumbers.map((row) => `第 ${row} 行`).join('，')}）` : ''
+    const error = errorPart ? `。${errorPart}` : ''
+    return `${n} 条记录导入失败${rows}${error}`.trim()
+  }
+  const rows = rowNumbers.length > 0 ? ` (${rowNumbers.map((row) => `row ${row}`).join(', ')})` : ''
+  const error = errorPart ? `. ${errorPart}` : ''
+  return `${n} record${n === 1 ? '' : 's'} failed to import${rows}${error}`.trim()
+}
+
+export function duplicateRowsSkipped(n: number, isZh: boolean): string {
+  return isZh ? `${n} 条重复行已跳过` : `${n} duplicate row${n === 1 ? '' : 's'} skipped`
+}
+
+export function recordsDeleted(n: number, isZh: boolean): string {
+  return isZh ? `${n} 条记录已删除` : `${n} record${n === 1 ? '' : 's'} deleted`
+}
+
+export function recordNotFound(recordId: string, isZh: boolean): string {
+  return isZh ? `未找到记录：${recordId}` : `Record not found: ${recordId}`
 }
 
 // MetaTemplateCard counts: zh "{n} 个 Sheet/字段/视图"; en pluralized.

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -421,6 +421,12 @@ import {
   mentionsUnread as fmtMentionsUnread,
   mentionsRecords as fmtMentionsRecords,
   templateInstalled as fmtTemplateInstalled,
+  formSubmitSuccess as fmtFormSubmitSuccess,
+  recordsImported as fmtRecordsImported,
+  recordsFailedToImport as fmtRecordsFailedToImport,
+  duplicateRowsSkipped as fmtDuplicateRowsSkipped,
+  recordsDeleted as fmtRecordsDeleted,
+  recordNotFound as fmtRecordNotFound,
 } from '../utils/workbench-labels'
 import { commentLabel } from '../utils/meta-comment-labels'
 import type {
@@ -1372,7 +1378,7 @@ async function onTimelinePatchDates(payload: {
     }
     showSuccess(wb('toast.datesUpdated', isZh.value))
   } catch (error: any) {
-    showError(error?.message ?? 'Failed to update timeline dates')
+    showError(error?.message ?? wb('toast.timelineDatesUpdateFailed', isZh.value))
   }
 }
 async function onHierarchyReparentRecord(payload: {
@@ -1401,7 +1407,7 @@ async function onHierarchyReparentRecord(payload: {
     }
     showSuccess(wb('toast.hierarchyUpdated', isZh.value))
   } catch (error: any) {
-    showError(error?.message ?? 'Failed to update hierarchy parent')
+    showError(error?.message ?? wb('toast.hierarchyParentUpdateFailed', isZh.value))
   }
 }
 async function onAddRecord() {
@@ -1486,11 +1492,11 @@ async function onFormSubmit(data: Record<string, unknown>) {
       selectedRecordId.value = result.record.id
       formDirty.value = false
       await grid.loadViewData(grid.page.value.offset)
-      formSuccessMessage.value = result.mode === 'create' ? 'Record created' : 'Changes saved'
+      formSuccessMessage.value = fmtFormSubmitSuccess(result.mode, isZh.value)
       formFieldErrors.value = {}
-      showSuccess(wb('toast.formSubmitted', isZh.value))
+      showSuccess(formSuccessMessage.value)
     } catch (e: any) {
-      const message = e.message ?? 'Form submit failed'
+      const message = e.message ?? wb('toast.formSubmitFailed', isZh.value)
       formErrorMessage.value = message
       formFieldErrors.value = e.fieldErrors ?? {}
       showError(message)
@@ -1536,7 +1542,7 @@ async function onSubmitComment(payload: { content: string; mentions: string[] })
     selectedReplyCommentId.value = null
     selectedEditingCommentId.value = null
   } catch (e: any) {
-    showError(commentsState.error.value ?? e.message ?? (selectedEditingCommentId.value ? 'Failed to update comment' : 'Failed to add comment'))
+    showError(commentsState.error.value ?? e.message ?? (selectedEditingCommentId.value ? wb('toast.commentUpdateFailed', isZh.value) : wb('toast.commentAddFailed', isZh.value)))
   }
 }
 
@@ -1545,7 +1551,7 @@ async function onResolveComment(commentId: string) {
     await commentsState.resolveComment(commentId)
     showSuccess(wb('toast.commentResolved', isZh.value))
   } catch (e: any) {
-    showError(commentsState.error.value ?? e.message ?? 'Failed to resolve comment')
+    showError(commentsState.error.value ?? e.message ?? wb('toast.commentResolveFailed', isZh.value))
   }
 }
 
@@ -1574,7 +1580,7 @@ async function onDeleteComment(commentId: string) {
     }
     showSuccess(wb('toast.commentDeleted', isZh.value))
   } catch (e: any) {
-    showError(commentsState.error.value ?? e.message ?? 'Failed to delete comment')
+    showError(commentsState.error.value ?? e.message ?? wb('toast.commentDeleteFailed', isZh.value))
   }
 }
 
@@ -1615,7 +1621,7 @@ async function onLinkPickerConfirm(payload: { recordIds: string[]; summaries: Li
       }
       applyLocalLinkSummaries(recordId, fieldId, result.linkSummaries?.[recordId]?.[fieldId] ?? payload.summaries)
     } catch (e: any) {
-      showError(e.message ?? 'Failed to update linked records')
+      showError(e.message ?? wb('toast.linkedRecordsUpdateFailed', isZh.value))
       return
     }
   } else {
@@ -1648,7 +1654,7 @@ async function onCreateField(input: { sheetId: string; name: string; type: MetaF
     }
     await workbench.loadSheetMeta(workbench.activeSheetId.value)
     await grid.loadViewData(grid.page.value.offset)
-  } catch (e: any) { showError(e.message ?? 'Failed to create field') }
+  } catch (e: any) { showError(e.message ?? wb('toast.fieldCreateFailed', isZh.value)) }
 }
 
 async function onUpdateField(fieldId: string, input: { name?: string; order?: number; type?: string; property?: Record<string, unknown> }) {
@@ -1656,7 +1662,7 @@ async function onUpdateField(fieldId: string, input: { name?: string; order?: nu
     await workbench.client.updateField(fieldId, input)
     await workbench.loadSheetMeta(workbench.activeSheetId.value)
     await grid.loadViewData(grid.page.value.offset)
-  } catch (e: any) { showError(e.message ?? 'Failed to update field') }
+  } catch (e: any) { showError(e.message ?? wb('toast.fieldUpdateFailed', isZh.value)) }
 }
 
 async function onDeleteField(fieldId: string) {
@@ -1664,7 +1670,7 @@ async function onDeleteField(fieldId: string) {
     await workbench.client.deleteField(fieldId)
     await workbench.loadSheetMeta(workbench.activeSheetId.value)
     await grid.loadViewData(grid.page.value.offset)
-  } catch (e: any) { showError(e.message ?? 'Failed to delete field') }
+  } catch (e: any) { showError(e.message ?? wb('toast.fieldDeleteFailed', isZh.value)) }
 }
 
 // --- View management ---
@@ -1690,7 +1696,7 @@ async function onCreateView(input: {
     await workbench.loadSheetMeta(workbench.activeSheetId.value)
     workbench.selectView(res.view.id)
     await grid.loadViewData(grid.page.value.offset)
-  } catch (e: any) { showError(e.message ?? 'Failed to create view') }
+  } catch (e: any) { showError(e.message ?? wb('toast.viewCreateFailed', isZh.value)) }
 }
 
 async function onUpdateView(viewId: string, input: {
@@ -1730,7 +1736,7 @@ async function updateViewInternal(
     await workbench.loadSheetMeta(workbench.activeSheetId.value)
     await grid.loadViewData(grid.page.value.offset)
     if (notify) showSuccess(wb('toast.viewSettingsSaved', isZh.value))
-  } catch (e: any) { showError(e.message ?? 'Failed to update view') }
+  } catch (e: any) { showError(e.message ?? wb('toast.viewUpdateFailed', isZh.value)) }
 }
 
 async function onDeleteView(viewId: string) {
@@ -1738,7 +1744,7 @@ async function onDeleteView(viewId: string) {
     await workbench.client.deleteView(viewId)
     await workbench.loadSheetMeta(workbench.activeSheetId.value)
     if (workbench.activeViewId.value === viewId) workbench.selectView(workbench.views.value[0]?.id ?? '')
-  } catch (e: any) { showError(e.message ?? 'Failed to delete view') }
+  } catch (e: any) { showError(e.message ?? wb('toast.viewDeleteFailed', isZh.value)) }
 }
 
 async function onSheetPermissionsUpdated() {
@@ -1749,7 +1755,7 @@ async function onSheetPermissionsUpdated() {
       await refreshSelectedRecordContext(selectedRecordId.value)
     }
   } catch (e: any) {
-    showError(e.message ?? 'Failed to refresh sheet access')
+    showError(e.message ?? wb('toast.sheetAccessRefreshFailed', isZh.value))
   }
 }
 
@@ -1786,7 +1792,7 @@ async function onViewPermissionUpdated() {
 // --- Sheet management ---
 async function onCreateSheet(name: string) {
   if (!canCreateBasesAndSheets.value) {
-    showError('Sheet creation requires multitable write access.')
+    showError(wb('toast.sheetCreateBlocked', isZh.value))
     return
   }
   if (!confirmDiscardContextChanges()) return
@@ -1797,10 +1803,10 @@ async function onCreateSheet(name: string) {
       sheetId: res.sheet.id,
     })
     if (!ok) {
-      showError(workbench.error.value ?? 'Created sheet but failed to refresh workbench context')
+      showError(workbench.error.value ?? wb('toast.sheetRefreshFailed', isZh.value))
       return
     }
-  } catch (e: any) { showError(e.message ?? 'Failed to create sheet') }
+  } catch (e: any) { showError(e.message ?? wb('toast.sheetCreateFailed', isZh.value)) }
 }
 
 // --- Base management ---
@@ -1828,7 +1834,7 @@ async function onSelectBase(baseId: string) {
   if (!confirmDiscardContextChanges()) return
   const ok = await workbench.switchBase(baseId)
   if (!ok) {
-    showError(workbench.error.value ?? 'Failed to load base')
+    showError(workbench.error.value ?? wb('toast.baseLoadFailed', isZh.value))
     return
   }
   rememberWorkbenchBaseOpen(baseId)
@@ -1941,12 +1947,12 @@ function onCloseComments() {
 
 function confirmDiscardContextChanges() {
   if (!hasUnsavedWorkbenchDrafts.value) return true
-  return window.confirm('Discard unsaved changes before leaving the current sheet or view?')
+  return window.confirm(wb('confirm.discardContextChanges', isZh.value))
 }
 
 function confirmDiscardRecordChanges() {
   if (!hasRecordScopedDrafts.value) return true
-  return window.confirm('Discard unsaved record changes?')
+  return window.confirm(wb('confirm.discardRecordChanges', isZh.value))
 }
 
 function confirmDiscardCommentDraft() {
@@ -1977,10 +1983,10 @@ function discardWorkbenchDraftsForExternalContextChange() {
 
 function confirmPageLeave() {
   if (formSubmitting.value || importSubmitting.value) {
-    return window.confirm('Leave the multitable while the current save or import is still running?')
+    return window.confirm(wb('confirm.pageLeaveBusy', isZh.value))
   }
   if (!hasUnsavedWorkbenchDrafts.value) return true
-  return window.confirm('Discard unsaved multitable changes before leaving this page?')
+  return window.confirm(wb('confirm.pageLeaveDirty', isZh.value))
 }
 
 function normalizeExternalContext(input: { baseId?: string; sheetId?: string; viewId?: string }) {
@@ -2014,7 +2020,7 @@ async function applyExternalContext(input: { baseId: string; sheetId: string; vi
   pendingExternalContextReason.value = null
   pendingExternalContextNoticeKey.value = ''
   const ok = await workbench.syncExternalContext(input)
-  if (!ok) showError(workbench.error.value ?? 'Failed to sync workbench context')
+  if (!ok) showError(workbench.error.value ?? wb('toast.contextSyncFailed', isZh.value))
   return ok
 }
 
@@ -2080,9 +2086,9 @@ function deferExternalContextSync(
   if (pendingExternalContextNoticeKey.value !== noticeKey) {
     pendingExternalContextNoticeKey.value = noticeKey
     if (reason === 'busy') {
-      showError('Host multitable context change is waiting for the current save or import to finish.')
+      showError(wb('toast.externalContextBusy', isZh.value))
     } else {
-      showError('Host multitable context changed while unsaved drafts are open. Resolve or discard changes to continue.')
+      showError(wb('toast.externalContextUnsaved', isZh.value))
     }
   }
   return { status: 'deferred', context: input, reason, requestId }
@@ -2137,14 +2143,14 @@ async function requestExternalContextSync(
 
 async function onCreateBase(name: string) {
   if (!canCreateBasesAndSheets.value) {
-    showError('Base creation requires multitable write access.')
+    showError(wb('toast.baseCreateBlocked', isZh.value))
     return
   }
   try {
     const res = await workbench.client.createBase({ name })
     bases.value.push(res.base)
     await onSelectBase(res.base.id)
-  } catch (e: any) { showError(e.message ?? 'Failed to create base') }
+  } catch (e: any) { showError(e.message ?? wb('toast.baseCreateFailed', isZh.value)) }
 }
 
 async function loadTemplateLibrary() {
@@ -2279,32 +2285,33 @@ async function onBulkImport(payload: ImportBuildResult) {
     }
     if (result.failed === 0 && result.skipped === 0) {
       closeImportModal()
-      showSuccess(`${result.succeeded} record(s) imported`)
+      showSuccess(fmtRecordsImported(result.succeeded, isZh.value))
       return
     }
     if (result.succeeded > 0) {
-      const failedRows = actualFailures.slice(0, 3).map((failure) => `row ${failure.rowIndex + 2}`).join(', ')
+      // rowIndex is 0-based in import failures; +2 converts to 1-based UI row plus the header row.
+      const failedRowNumbers = actualFailures.slice(0, 3).map((failure) => failure.rowIndex + 2)
       if (result.failed > 0) {
-        showError(`${result.failed} record(s) failed to import${failedRows ? ` (${failedRows})` : ''}. ${result.firstError ?? ''}`.trim())
+        showError(fmtRecordsFailedToImport(result.failed, failedRowNumbers, result.firstError ?? '', isZh.value))
       } else if (result.skipped > 0) {
-        showError(`${result.skipped} duplicate row(s) were skipped`)
+        showError(fmtDuplicateRowsSkipped(result.skipped, isZh.value))
       }
-      showSuccess(`${result.succeeded} record(s) imported`)
+      showSuccess(fmtRecordsImported(result.succeeded, isZh.value))
       return
     }
     if (result.skipped > 0) {
-      showError(`${result.skipped} duplicate row(s) were skipped`)
+      showError(fmtDuplicateRowsSkipped(result.skipped, isZh.value))
       return
     }
-    showError(result.firstError ?? 'Import failed')
+    showError(result.firstError ?? wb('toast.importFailed', isZh.value))
   } catch (e: any) {
     if (e?.name === 'AbortError') {
       closeImportModal()
       await grid.loadViewData(grid.page.value.offset)
-      showError('Import cancelled')
+      showError(wb('toast.importCancelled', isZh.value))
       return
     }
-    const fallbackMessage = e?.message ?? 'Import failed'
+    const fallbackMessage = e?.message ?? wb('toast.importFailed', isZh.value)
     const failures = [
       ...payload.failures.map((failure) => ({ ...failure, retryable: false })),
       ...payload.rowIndexes.map((rowIndex, index) => ({
@@ -2402,7 +2409,7 @@ async function onExportXlsx() {
     a.click()
     URL.revokeObjectURL(url)
   } catch (err: any) {
-    showError(err?.message ?? 'Excel export failed')
+    showError(err?.message ?? wb('toast.excelExportFailed', isZh.value))
   }
 }
 
@@ -2514,8 +2521,8 @@ async function onBulkDelete(recordIds: string[]) {
   try {
     await Promise.all(recordIds.map((rid) => grid.deleteRecord(rid)))
     if (selectedRecordId.value && recordIds.includes(selectedRecordId.value)) selectedRecordId.value = null
-    showSuccess(`${recordIds.length} record(s) deleted`)
-  } catch (e: any) { showError(e.message ?? 'Bulk delete failed') }
+    showSuccess(fmtRecordsDeleted(recordIds.length, isZh.value))
+  } catch (e: any) { showError(e.message ?? wb('toast.bulkDeleteFailed', isZh.value)) }
 }
 
 const bulkEditDialog = reactive<{
@@ -2612,7 +2619,7 @@ async function resolveDeepLink(recordId: string, options?: { openComments?: bool
     deepLinkedRecordRowActions.value = ctx.rowActions ?? null
     await selectRecord(recordId, options)
   } catch (e: any) {
-    showError(`Record not found: ${recordId}`)
+    showError(fmtRecordNotFound(recordId, isZh.value))
   }
 }
 
@@ -2990,7 +2997,7 @@ onMounted(async () => {
       await loadStandaloneForm()
     }
   } catch (e: any) {
-    showError(e.message ?? 'Failed to initialize workbench')
+    showError(e.message ?? wb('toast.workbenchInitFailed', isZh.value))
   } finally {
     workbenchReady.value = true
     emit('ready', {

--- a/apps/web/tests/multitable-workbench-i18n.spec.ts
+++ b/apps/web/tests/multitable-workbench-i18n.spec.ts
@@ -8,6 +8,12 @@ import {
   mentionsUnread,
   mentionsRecords,
   templateInstalled,
+  formSubmitSuccess,
+  recordsImported,
+  recordsFailedToImport,
+  duplicateRowsSkipped,
+  recordsDeleted,
+  recordNotFound,
   cardSheets,
   cardFields,
   cardViews,
@@ -30,10 +36,27 @@ const ALL_KEYS: WorkbenchLabelKey[] = [
   'toast.recordCreateBlocked', 'toast.recordEditBlocked', 'toast.recordDeleteBlocked',
   'toast.datesUpdated', 'toast.hierarchyUpdated', 'toast.recordDeleted',
   'toast.loadedLatest', 'toast.changeReapplied', 'toast.recordUpdated',
-  'toast.formSubmitted', 'toast.commentUpdated', 'toast.commentAdded',
+  'toast.commentUpdated', 'toast.commentAdded',
   'toast.commentResolved', 'toast.commentDeleted', 'toast.linkedRecordsUpdated',
   'toast.viewSettingsSaved', 'toast.templateInstallBlocked', 'toast.templateRefreshFailed',
   'toast.templateInstallFailed',
+  'toast.timelineDatesUpdateFailed', 'toast.hierarchyParentUpdateFailed',
+  'toast.formSubmitFailed',
+  'toast.commentUpdateFailed', 'toast.commentAddFailed',
+  'toast.commentResolveFailed', 'toast.commentDeleteFailed',
+  'toast.linkedRecordsUpdateFailed',
+  'toast.fieldCreateFailed', 'toast.fieldUpdateFailed', 'toast.fieldDeleteFailed',
+  'toast.viewCreateFailed', 'toast.viewUpdateFailed', 'toast.viewDeleteFailed',
+  'toast.sheetAccessRefreshFailed',
+  'toast.sheetCreateBlocked', 'toast.sheetRefreshFailed', 'toast.sheetCreateFailed',
+  'toast.baseLoadFailed', 'toast.contextSyncFailed',
+  'toast.externalContextBusy', 'toast.externalContextUnsaved',
+  'toast.baseCreateBlocked', 'toast.baseCreateFailed',
+  'toast.importCancelled', 'toast.importFailed',
+  'toast.excelExportFailed', 'toast.bulkDeleteFailed',
+  'toast.workbenchInitFailed',
+  'confirm.discardContextChanges', 'confirm.discardRecordChanges',
+  'confirm.pageLeaveBusy', 'confirm.pageLeaveDirty',
   'card.install', 'card.installing',
 ]
 
@@ -126,5 +149,38 @@ describe('workbench-labels interpolation helpers', () => {
     expect(templateInstalled('CRM Pipeline', false)).toBe('Installed CRM Pipeline')
     expect(templateInstalled('CRM Pipeline', true)).toBe('已安装 CRM Pipeline')
     expect(templateInstalled('合同管理', true)).toBe('已安装 合同管理')
+  })
+
+  it('formSubmitSuccess switches on the explicit create/update discriminator', () => {
+    expect(formSubmitSuccess('create', false)).toBe('Record created')
+    expect(formSubmitSuccess('update', false)).toBe('Changes saved')
+    expect(formSubmitSuccess('create', true)).toBe('记录已创建')
+    expect(formSubmitSuccess('update', true)).toBe('更改已保存')
+  })
+
+  it('dynamic count helpers pluralize en and keep zh count forms stable', () => {
+    expect(recordsImported(1, false)).toBe('1 record imported')
+    expect(recordsImported(3, false)).toBe('3 records imported')
+    expect(recordsImported(3, true)).toBe('3 条记录已导入')
+
+    expect(duplicateRowsSkipped(1, false)).toBe('1 duplicate row skipped')
+    expect(duplicateRowsSkipped(2, false)).toBe('2 duplicate rows skipped')
+    expect(duplicateRowsSkipped(2, true)).toBe('2 条重复行已跳过')
+
+    expect(recordsDeleted(1, false)).toBe('1 record deleted')
+    expect(recordsDeleted(4, false)).toBe('4 records deleted')
+    expect(recordsDeleted(4, true)).toBe('4 条记录已删除')
+  })
+
+  it('recordsFailedToImport formats row chrome and preserves raw firstError', () => {
+    expect(recordsFailedToImport(1, [2], 'Bad value', false)).toBe('1 record failed to import (row 2). Bad value')
+    expect(recordsFailedToImport(2, [2, 3], 'Invalid SKU', false)).toBe('2 records failed to import (row 2, row 3). Invalid SKU')
+    expect(recordsFailedToImport(2, [2, 3], 'Invalid SKU', true)).toBe('2 条记录导入失败（第 2 行，第 3 行）。Invalid SKU')
+    expect(recordsFailedToImport(2, [], '', true)).toBe('2 条记录导入失败')
+  })
+
+  it('recordNotFound localizes surrounding chrome and keeps record id raw', () => {
+    expect(recordNotFound('rec_abc123', false)).toBe('Record not found: rec_abc123')
+    expect(recordNotFound('rec_abc123', true)).toBe('未找到记录：rec_abc123')
   })
 })

--- a/apps/web/tests/multitable-workbench-import-flow.spec.ts
+++ b/apps/web/tests/multitable-workbench-import-flow.spec.ts
@@ -336,7 +336,7 @@ describe('MultitableWorkbench import flow', () => {
       data: { fld_name: 'Beta' },
     }, expect.objectContaining({ signal: expect.any(AbortSignal) }))
     expect(gridMock.loadViewData).toHaveBeenCalled()
-    expect(showSuccessSpy).toHaveBeenCalledWith('2 record(s) imported')
+    expect(showSuccessSpy).toHaveBeenCalledWith('2 records imported')
     expect(document.body.querySelector('.meta-import-modal')).toBeNull()
   })
 
@@ -418,7 +418,7 @@ describe('MultitableWorkbench import flow', () => {
       data: { fld_vendor: ['rec_vendor_1'] },
     }, expect.objectContaining({ signal: expect.any(AbortSignal) }))
     expect(gridMock.loadViewData).toHaveBeenCalled()
-    expect(showSuccessSpy).toHaveBeenCalledWith('1 record(s) imported')
+    expect(showSuccessSpy).toHaveBeenCalledWith('1 record imported')
     expect(document.body.querySelector('.meta-import-modal')).toBeNull()
   })
 
@@ -526,7 +526,7 @@ describe('MultitableWorkbench import flow', () => {
       data: { fld_vendor: ['rec_vendor_fixed'] },
     }, expect.objectContaining({ signal: expect.any(AbortSignal) }))
     expect(gridMock.loadViewData).toHaveBeenCalledTimes(2)
-    expect(showSuccessSpy).toHaveBeenLastCalledWith('1 record(s) imported')
+    expect(showSuccessSpy).toHaveBeenLastCalledWith('1 record imported')
     expect(document.body.querySelector('.meta-import-modal')).toBeNull()
   })
 
@@ -575,7 +575,7 @@ describe('MultitableWorkbench import flow', () => {
       viewId: 'view_grid',
       data: { fld_name: 'Alpha' },
     }, expect.objectContaining({ signal: expect.any(AbortSignal) }))
-    expect(showSuccessSpy).toHaveBeenLastCalledWith('1 record(s) imported')
+    expect(showSuccessSpy).toHaveBeenLastCalledWith('1 record imported')
     expect(document.body.querySelector('.meta-import-modal')).toBeNull()
   })
 
@@ -710,7 +710,7 @@ describe('MultitableWorkbench import flow', () => {
       data: { fld_title: 'Alpha', fld_owner: 'Owner Person' },
     }, expect.objectContaining({ signal: expect.any(AbortSignal) }))
     expect(gridMock.loadViewData).toHaveBeenCalled()
-    expect(showSuccessSpy).toHaveBeenLastCalledWith('1 record(s) imported')
+    expect(showSuccessSpy).toHaveBeenLastCalledWith('1 record imported')
     expect(document.body.querySelector('.meta-import-modal')).toBeNull()
   })
 

--- a/apps/web/tests/multitable-workbench-view.spec.ts
+++ b/apps/web/tests/multitable-workbench-view.spec.ts
@@ -1361,7 +1361,34 @@ describe('MultitableWorkbench view wiring', () => {
         { fld_title: 'alpha', fld_status: 'Closed' },
       ],
     }))
-    expect(showSuccessSpy).toHaveBeenCalledWith('2 record(s) imported')
+    expect(showSuccessSpy).toHaveBeenCalledWith('2 records imported')
+  })
+
+  it('localizes workbench import success toast in zh-CN', async () => {
+    useLocale().setLocale('zh-CN')
+    bulkImportRecordsMock.mockResolvedValue({
+      attempted: 2,
+      succeeded: 2,
+      failed: 0,
+      firstError: null,
+      failures: [],
+    })
+    workbenchMock.fields.value = [
+      { id: 'fld_title', name: 'Title', type: 'string', order: 1 },
+      { id: 'fld_status', name: 'Status', type: 'string', order: 2 },
+    ]
+    gridMock.fields.value = [...workbenchMock.fields.value]
+
+    mountWorkbench()
+    await flushUi()
+
+    container!.querySelector<HTMLButtonElement>('[data-open-import="true"]')!.click()
+    await flushUi()
+
+    container!.querySelector<HTMLButtonElement>('[data-import-submit="true"]')!.click()
+    await flushUi()
+
+    expect(showSuccessSpy).toHaveBeenCalledWith('2 条记录已导入')
   })
 
   it('exports only scoped visible grid fields', async () => {

--- a/docs/development/multitable-t3e2-workbench-dynamic-toasts-design-20260520.md
+++ b/docs/development/multitable-t3e2-workbench-dynamic-toasts-design-20260520.md
@@ -1,0 +1,296 @@
+# T3E-2 Workbench Dynamic Toasts/Fallbacks i18n Design
+
+Date: 2026-05-20
+Branch: docs/multitable-t3e2-workbench-dynamic-toasts-design-20260520
+Status: design/scout only; no implementation code changes yet
+
+## 1. Decision Summary
+
+T3E-2 localizes Workbench-owned dynamic toast/fallback/confirm chrome that remains after T2 and T3E-1.
+
+| Decision | Outcome |
+| --- | --- |
+| Scope | `MultitableWorkbench.vue` script-level dynamic chrome: fallback errors, confirms, external-context notices, import/bulk-delete count messages |
+| Label home | Extend existing `workbench-labels.ts`; do not create a new Workbench dynamic-label module |
+| Raw boundary | Runtime/server/user data remains raw: `e.message`, `grid.error.value`, `commentsState.error.value`, `workbench.error.value`, import failure messages, record IDs, field names |
+| Deferred | `MetaBulkEditDialog` result/error wiring and `ConditionalFormattingDialog` stay T3E-3; automation stays T3D |
+| Implementation gate | Design MD review first; implementation + verification MD later; stop before push |
+
+## 2. Files In Scope
+
+Implementation files:
+
+| File | Planned change |
+| --- | --- |
+| `apps/web/src/multitable/views/MultitableWorkbench.vue` | Replace Workbench-owned fallback strings with `workbenchLabel()` or interpolation helpers |
+| `apps/web/src/multitable/utils/workbench-labels.ts` | Add static keys and dynamic helpers for T3E-2 |
+
+Test/doc files:
+
+| File | Planned change |
+| --- | --- |
+| `apps/web/tests/multitable-workbench-i18n.spec.ts` | Extend static key list and helper coverage |
+| `apps/web/tests/multitable-workbench-view.spec.ts` | Run as regression; update only if existing English default assertions are touched |
+| `docs/development/multitable-t3e2-workbench-dynamic-toasts-design-20260520.md` | This design plan |
+| `docs/development/multitable-t3e2-workbench-dynamic-toasts-verification-20260520.md` | To be created during implementation |
+
+## 3. Preflight Grep
+
+Use quoted patterns to avoid shell glob expansion:
+
+```bash
+rg -n 'show(Success|Error)\(|window\.confirm\(|formSuccessMessage|bulkEditDialog\.resultMessage|Record not found|Import failed|record\\(s\\)|Failed to' \
+  apps/web/src/multitable/views/MultitableWorkbench.vue
+```
+
+Current scout found the active Workbench-owned residual clusters around:
+
+| Area | Lines |
+| --- | --- |
+| timeline / hierarchy / drawer / form / comments / links | `1375`, `1404`, `1493`, `1539`, `1548`, `1577`, `1618` |
+| field/view/sheet/base/context | `1651`, `1659`, `1667`, `1693`, `1733`, `1741`, `1752`, `1789`, `1800`, `1803`, `1831`, `2017`, `2083`, `2085`, `2140`, `2147` |
+| import/export | `2282`, `2288`, `2290`, `2292`, `2296`, `2299`, `2304`, `2307`, `2326`, `2405` |
+| bulk delete / deep link / init | `2517`, `2518`, `2615`, `2993` |
+| deferred bulk-edit result/error | `2566`, `2569`, `2571`, `2579` |
+
+Implementation must rerun the grep before editing and account for every hit as one of:
+
+1. localized in T3E-2,
+2. raw pass-through by design,
+3. deferred to T3E-3/T3D.
+
+## 4. Exact Targets
+
+### 4.1 Static Fallback Keys
+
+Add static `WorkbenchLabelKey` entries for Workbench-owned fallback strings:
+
+| Source | EN | zh-CN |
+| --- | --- | --- |
+| timeline patch fallback | `Failed to update timeline dates` | `更新时间线日期失败` |
+| hierarchy reparent fallback | `Failed to update hierarchy parent` | `更新层级父记录失败` |
+| form submit fallback | `Form submit failed` | `表单提交失败` |
+| comment update fallback | `Failed to update comment` | `更新评论失败` |
+| comment add fallback | `Failed to add comment` | `添加评论失败` |
+| comment resolve fallback | `Failed to resolve comment` | `解决评论失败` |
+| comment delete fallback | `Failed to delete comment` | `删除评论失败` |
+| link picker fallback | `Failed to update linked records` | `更新关联记录失败` |
+| field create fallback | `Failed to create field` | `创建字段失败` |
+| field update fallback | `Failed to update field` | `更新字段失败` |
+| field delete fallback | `Failed to delete field` | `删除字段失败` |
+| view create fallback | `Failed to create view` | `创建视图失败` |
+| view update fallback | `Failed to update view` | `更新视图失败` |
+| view delete fallback | `Failed to delete view` | `删除视图失败` |
+| sheet access refresh fallback | `Failed to refresh sheet access` | `刷新 Sheet 权限失败` |
+| sheet create permission | `Sheet creation requires multitable write access.` | `创建 Sheet 需要多维表写入权限。` |
+| sheet create sync fallback | `Created sheet but failed to refresh workbench context` | `Sheet 已创建，但刷新工作台上下文失败` |
+| sheet create fallback | `Failed to create sheet` | `创建 Sheet 失败` |
+| base load fallback | `Failed to load base` | `加载 Base 失败` |
+| context sync fallback | `Failed to sync workbench context` | `同步工作台上下文失败` |
+| external context busy notice | `Host multitable context change is waiting for the current save or import to finish.` | `宿主多维表上下文变更正在等待当前保存或导入完成。` |
+| external context unsaved notice | `Host multitable context changed while unsaved drafts are open. Resolve or discard changes to continue.` | `宿主多维表上下文已变更。请处理或放弃未保存草稿后继续。` |
+| base create permission | `Base creation requires multitable write access.` | `创建 Base 需要多维表写入权限。` |
+| base create fallback | `Failed to create base` | `创建 Base 失败` |
+| import cancelled | `Import cancelled` | `导入已取消` |
+| import fallback | `Import failed` | `导入失败` |
+| Excel export fallback | `Excel export failed` | `Excel 导出失败` |
+| bulk delete fallback | `Bulk delete failed` | `批量删除失败` |
+| workbench init fallback | `Failed to initialize workbench` | `初始化工作台失败` |
+
+Naming suggestion:
+
+```ts
+| 'toast.timelineDatesUpdateFailed'
+| 'toast.hierarchyParentUpdateFailed'
+| 'toast.formSubmitFailed'
+| 'toast.commentUpdateFailed'
+| 'toast.commentAddFailed'
+| 'toast.commentResolveFailed'
+| 'toast.commentDeleteFailed'
+| 'toast.linkedRecordsUpdateFailed'
+| 'toast.fieldCreateFailed'
+| 'toast.fieldUpdateFailed'
+| 'toast.fieldDeleteFailed'
+| 'toast.viewCreateFailed'
+| 'toast.viewUpdateFailed'
+| 'toast.viewDeleteFailed'
+| 'toast.sheetAccessRefreshFailed'
+| 'toast.sheetCreateBlocked'
+| 'toast.sheetRefreshFailed'
+| 'toast.sheetCreateFailed'
+| 'toast.baseLoadFailed'
+| 'toast.contextSyncFailed'
+| 'toast.externalContextBusy'
+| 'toast.externalContextUnsaved'
+| 'toast.baseCreateBlocked'
+| 'toast.baseCreateFailed'
+| 'toast.importCancelled'
+| 'toast.importFailed'
+| 'toast.excelExportFailed'
+| 'toast.bulkDeleteFailed'
+| 'toast.workbenchInitFailed'
+```
+
+### 4.2 Confirm Keys
+
+Native confirm dialogs are browser-rendered, but the text is Workbench chrome and should be localized.
+
+| Source | EN | zh-CN |
+| --- | --- | --- |
+| `confirmDiscardContextChanges()` | `Discard unsaved changes before leaving the current sheet or view?` | `离开当前 Sheet 或视图前放弃未保存的更改吗？` |
+| `confirmDiscardRecordChanges()` | `Discard unsaved record changes?` | `放弃未保存的记录更改吗？` |
+| `confirmPageLeave()` busy branch | `Leave the multitable while the current save or import is still running?` | `当前保存或导入仍在进行，确定离开多维表吗？` |
+| `confirmPageLeave()` dirty branch | `Discard unsaved multitable changes before leaving this page?` | `离开此页面前放弃未保存的多维表更改吗？` |
+
+Naming suggestion:
+
+```ts
+| 'confirm.discardContextChanges'
+| 'confirm.discardRecordChanges'
+| 'confirm.pageLeaveBusy'
+| 'confirm.pageLeaveDirty'
+```
+
+Comment draft confirm is already handled by `commentLabel('comment.discardDraftConfirm', isZh.value)` and is out of scope.
+
+### 4.3 Dynamic Helpers
+
+Add interpolation helpers in `workbench-labels.ts`. These are not `WorkbenchLabelKey` entries.
+
+| Helper | EN behavior | zh-CN behavior | Raw boundary |
+| --- | --- | --- | --- |
+| `formSubmitSuccess(mode: 'create' \| 'update', isZh: boolean)` | `Record created` / `Changes saved` | `记录已创建` / `更改已保存` | mode is Workbench submit result enum |
+| `recordsImported(count, isZh)` | pluralized `${n} record(s) imported` | `${n} 条记录已导入` | count only |
+| `recordsFailedToImport(count, rowNumbers, firstError, isZh)` | `${n} record(s) failed to import (row 2, row 3). ${firstError}` | `${n} 条记录导入失败（第 2 行，第 3 行）。${firstError}` | `firstError` raw |
+| `duplicateRowsSkipped(count, isZh)` | pluralized `${n} duplicate row(s) were skipped` | `${n} 条重复行已跳过` | count only |
+| `recordsDeleted(count, isZh)` | pluralized `${n} record(s) deleted` | `${n} 条记录已删除` | count only |
+| `recordNotFound(recordId, isZh)` | `Record not found: ${recordId}` | `未找到记录：${recordId}` | `recordId` raw |
+
+Implementation detail for import failures:
+
+```ts
+const failedRowNumbers = actualFailures.slice(0, 3).map((failure) => failure.rowIndex + 2)
+showError(recordsFailedToImport(result.failed, failedRowNumbers, result.firstError ?? '', isZh.value))
+```
+
+The row numbers are UI-generated and safe to format. The error text remains raw.
+
+### 4.4 T2 Static Key Disposition
+
+T3E-2 must not leave dead static keys behind.
+
+| Existing key | Current call-site | T3E-2 disposition |
+| --- | --- | --- |
+| `toast.formSubmitted` | `onFormSubmit()` after `formSuccessMessage.value = result.mode === 'create' ? 'Record created' : 'Changes saved'` | Retire from `WorkbenchLabelKey` and `WORKBENCH_LABELS`; replace the toast with `formSubmitSuccess(result.mode, isZh.value)` so the toast and `formSuccessMessage` share the same mode-specific copy |
+| `toast.recordDeleted` | `onDeleteRecord()` single-record delete only | Keep. `recordsDeleted(count, isZh)` is for bulk delete only; the single-record delete toast remains semantically distinct |
+
+Implementation must update `ALL_KEYS` in `multitable-workbench-i18n.spec.ts` in lockstep. If a static key is retired, remove it from both the union and the exhaustive test list.
+
+## 5. Raw / Do-Not-Translate Boundary
+
+These values must remain raw and should not get labels/helpers in T3E-2:
+
+| Value | Reason |
+| --- | --- |
+| `e.message` / `error?.message` / `err?.message` | Runtime/server detail; localized fallback only behind `??` |
+| `grid.error.value` | Composable/runtime error value; pass through |
+| `commentsState.error.value` | Comment service/runtime error value; pass through |
+| `workbench.error.value` | Workbench composable runtime error; pass through |
+| `result.firstError` | Import row failure text; pass through |
+| `actualFailures[].message` / `failure.reason` | Row-specific/import/bulk failure detail; pass through |
+| `recordId` in deep-link fallback | Identifier; interpolate raw |
+| field names / view names / base names / tokens | User/data content; pass through |
+| thrown link import errors at `1152` / `1174` | Data-specific validation that flows into import failure details; pass through as raw error message |
+
+## 6. Deferred From T3E-2
+
+| Deferred | Reason |
+| --- | --- |
+| `bulkEditDialog.error` and `bulkEditDialog.resultMessage` (`2566`, `2569`, `2571`, `2579`) | Parent-generated messages are tied to `MetaBulkEditDialog`; keep with T3E-3 |
+| `MetaBulkEditDialog.vue` chrome | T3E-3 scope |
+| `ConditionalFormattingDialog.vue` chrome and confirm | T3E-3 scope |
+| `MetaAutomationManager` / rule editor / log viewer | T3D scope; enum semantics heavier |
+| Final global grep/audit | After T3D/T3E residual slices complete |
+
+Bulk delete (`onBulkDelete`) is included in T3E-2 because it is a Workbench toast only and does not depend on `MetaBulkEditDialog`.
+
+## 7. A11y Boundary
+
+T3E-2 modifies script-level `showSuccess(...)`, `showError(...)`, and `window.confirm(...)` calls only.
+
+No component template changes are planned, and no new `aria`, `title`, or `placeholder` attributes should be added. Native `window.confirm` dialogs remain browser-rendered; this slice localizes their text but does not attempt to add custom accessibility instrumentation.
+
+## 8. Implementation Order
+
+1. Rerun preflight grep and classify each hit into localized/raw/deferred.
+2. Extend `WorkbenchLabelKey` and `WORKBENCH_LABELS` with the static fallback/confirm keys.
+3. Add dynamic helpers: `formSubmitSuccess`, `recordsImported`, `recordsFailedToImport`, `duplicateRowsSkipped`, `recordsDeleted`, `recordNotFound`.
+4. Wire `MultitableWorkbench.vue` fallbacks and confirm calls.
+5. Leave all raw pass-through branches untouched except the localized fallback behind `??`.
+6. Do not touch `bulkEditDialog` result/error or dialog components.
+7. Extend `multitable-workbench-i18n.spec.ts`.
+8. Add 1-2 Workbench render sentinel specs if existing mocks can reach the path without heavy harness churn.
+9. Run targeted specs and regression spec.
+10. Create verification MD and stop before push.
+
+## 9. Test Plan
+
+Primary tests:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-workbench-i18n.spec.ts \
+  tests/multitable-workbench-view.spec.ts \
+  --watch=false
+```
+
+Type/build gates:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web build
+```
+
+Diff hygiene:
+
+```bash
+git diff --check origin/main..HEAD
+```
+
+Expected assertions:
+
+| Spec | Required coverage |
+| --- | --- |
+| `multitable-workbench-i18n.spec.ts` | All new static keys resolve to non-empty EN/ZH and differ |
+| `multitable-workbench-i18n.spec.ts` | Helpers cover EN singular/plural and zh count forms |
+| `multitable-workbench-i18n.spec.ts` | Raw values are preserved: `recordId`, `firstError`, template-style data not normalized |
+| `multitable-workbench-view.spec.ts` | Existing Workbench behavior still passes; if an English string assertion exists, EN branch should keep it stable |
+
+Sentinel render coverage target:
+
+| Case | Purpose |
+| --- | --- |
+| zh-CN import failure fallback, if reachable with existing Workbench mocks | Proves at least one high-frequency dynamic fallback wire renders localized text through the real Workbench toast path |
+| zh-CN bulk delete count or deep-link record-not-found, if import path is too heavy | Alternative low-churn sentinel for helper wiring; do not add data attributes to production code solely for this test |
+
+If both sentinels require disproportionate harness churn, implementation may keep coverage helper-only, but verification MD must explicitly document that decision and list manual grep evidence for each Workbench wire.
+
+## 10. Risk Register
+
+| Risk | Mitigation |
+| --- | --- |
+| T3E-2 expands into bulk-edit/dialog scope | Hard defer `bulkEditDialog` result/error and all dialog chrome to T3E-3 |
+| Accidentally translating backend/runtime errors | Only localize fallback branches after `??`; keep raw message variables first |
+| Import failure helper hides row-specific details | Preserve `firstError` raw and only localize surrounding count/row chrome |
+| Existing Workbench view tests assert English strings | EN branch stays byte-compatible where tests already assert English; run `multitable-workbench-view.spec.ts` |
+| `workbench-labels.ts` grows large | Accept for this slice: all strings are Workbench shell chrome and existing module already owns T2/T3E-1 Workbench labels |
+
+## 11. Approval Gate
+
+Implementation can start when:
+
+1. T3E-2 scope remains Workbench script-level dynamic chrome only.
+2. `bulkEditDialog` result/error remains deferred to T3E-3.
+3. No backend, contract, migration, attendance, K3, or manager dialog files are touched.
+4. Raw pass-through boundaries in §5 are preserved.
+5. Verification MD is produced and implementation stops before push.

--- a/docs/development/multitable-t3e2-workbench-dynamic-toasts-verification-20260520.md
+++ b/docs/development/multitable-t3e2-workbench-dynamic-toasts-verification-20260520.md
@@ -1,0 +1,189 @@
+# T3E-2 Workbench Dynamic Toast i18n Verification
+
+Date: 2026-05-20
+Branch: docs/multitable-t3e2-workbench-dynamic-toasts-design-20260520
+Status: implementation verified locally; not pushed
+
+## 1. Definition Of Done
+
+T3E-2 is complete when:
+
+1. Workbench script-level dynamic toasts, fallback errors, and `window.confirm(...)` text use `workbench-labels.ts`.
+2. `toast.formSubmitted` is retired and replaced by explicit `formSubmitSuccess(mode, isZh)`.
+3. Dynamic count helpers use pluralized English and stable zh-CN count copy.
+4. Raw runtime values remain raw: `e.message`, `workbench.error.value`, `grid.error.value`, `commentsState.error.value`, `result.firstError`, row indexes, record IDs, and template/user content.
+5. Deferred surfaces remain untouched: `MetaBulkEditDialog.vue`, `ConditionalFormattingDialog.vue`, automation/T3D, and final audit.
+6. Targeted tests, type-check, build, and diff hygiene pass; any known baseline failures are documented separately.
+
+## 2. Scope Verified
+
+Implementation files:
+
+| File | Verification |
+| --- | --- |
+| `apps/web/src/multitable/utils/workbench-labels.ts` | Added T3E-2 fallback/confirm keys and 6 helpers; retired `toast.formSubmitted` |
+| `apps/web/src/multitable/views/MultitableWorkbench.vue` | Replaced script-level hard-coded fallback/confirm/toast strings with `wb(...)` or dynamic helpers |
+
+Test/doc files:
+
+| File | Verification |
+| --- | --- |
+| `apps/web/tests/multitable-workbench-i18n.spec.ts` | Lockstep `ALL_KEYS` update; helper coverage for `formSubmitSuccess`, import/delete count helpers, failed-row formatting, and raw record ID |
+| `apps/web/tests/multitable-workbench-import-flow.spec.ts` | Updated expected English import-count copy from `record(s)` to pluralized helper output |
+| `apps/web/tests/multitable-workbench-view.spec.ts` | Added zh-CN sentinel for import success toast and updated English import-count baseline |
+| `docs/development/multitable-t3e2-workbench-dynamic-toasts-design-20260520.md` | Approved design and scope gate |
+
+## 3. Preflight And Residual Grep
+
+Command:
+
+```bash
+rg -n "Failed to update timeline dates|Failed to update hierarchy parent|Form submit failed|Failed to update comment|Failed to add comment|Failed to resolve comment|Failed to delete comment|Failed to update linked records|Failed to create field|Failed to update field|Failed to delete field|Failed to create view|Failed to update view|Failed to delete view|Failed to refresh sheet access|Sheet creation requires|Created sheet but failed|Failed to create sheet|Failed to load base|Discard unsaved changes before leaving|Discard unsaved record changes|Leave the multitable while|Discard unsaved multitable changes|Failed to sync workbench context|Host multitable context|Base creation requires|Failed to create base|record\\(s\\) imported|duplicate row\\(s\\)|Import cancelled|Import failed|Excel export failed|record\\(s\\) deleted|Bulk delete failed|Record not found:|Failed to initialize workbench|toast\\.formSubmitted" \
+  apps/web/src/multitable apps/web/tests docs/development/multitable-t3e2-workbench-dynamic-toasts-design-20260520.md
+```
+
+Classification:
+
+| Category | Result |
+| --- | --- |
+| T3E-2 Workbench call-sites | Rewired to `wb(...)` or helper functions in `MultitableWorkbench.vue` |
+| Label definitions | Expected hits in `workbench-labels.ts` |
+| Test baselines | Expected hits in updated specs for English baseline and helper assertions |
+| Raw lower-layer errors | Expected hits remain in `useMultitableComments.ts`, `useMultitableWorkbench.ts`, and `bulk-import.ts`; Workbench keeps `raw ?? localizedFallback` semantics |
+| Adjacent manager surfaces | `meta-permission-labels.ts` field/view permission errors are already owned by T3C-2a and out of scope |
+| Retired key | No source call-site remains for `toast.formSubmitted`; `ALL_KEYS` was updated lockstep |
+
+## 4. Test Evidence
+
+### Targeted Vitest
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-workbench-i18n.spec.ts \
+  tests/multitable-workbench-import-flow.spec.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+✓ tests/multitable-workbench-i18n.spec.ts  (13 tests)
+✓ tests/multitable-workbench-import-flow.spec.ts  (7 tests)
+
+Test Files  2 passed (2)
+Tests       20 passed (20)
+```
+
+The import-flow spec still emits existing `router-link` resolution warnings from the mock harness; exit code is 0.
+
+### zh-CN Sentinel Render
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-workbench-view.spec.ts \
+  -t "localizes workbench import success toast in zh-CN" \
+  --watch=false
+```
+
+Result:
+
+```text
+✓ tests/multitable-workbench-view.spec.ts  (57 tests | 56 skipped)
+
+Test Files  1 passed (1)
+Tests       1 passed | 56 skipped (57)
+```
+
+### Known Workbench-View Baseline
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-workbench-view.spec.ts --watch=false
+```
+
+Result:
+
+```text
+Test Files  1 failed (1)
+Tests       1 failed | 56 passed (57)
+
+FAIL tests/multitable-workbench-view.spec.ts > MultitableWorkbench view wiring > opens workflow designer with multitable context when automation is enabled
+expected "spy" to be called with arguments: [ { name: 'workflow-designer', ... } ]
+Number of calls: 0
+```
+
+This is a current baseline issue unrelated to T3E-2. The test sets `canManageAutomation = true`, but `apps/web/src/stores/featureFlags.ts` defaults `workflow: false`, and `MultitableWorkbench.vue` gates navigation with `featureFlags.hasFeature('workflow')`.
+
+## 5. Type Check And Build
+
+### Type Check
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result:
+
+```text
+exit 0 / no output
+```
+
+### Build
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result:
+
+```text
+✓ 2412 modules transformed.
+✓ built in 6.28s
+```
+
+Vite emitted existing chunk-size and mixed dynamic/static import warnings; no build failure.
+
+## 6. Raw Boundary Checks
+
+| Boundary | Verification |
+| --- | --- |
+| Runtime errors | `e.message`, `workbench.error.value`, `grid.error.value`, and `commentsState.error.value` remain first-choice raw strings |
+| Import failures | `result.firstError` stays raw; row chrome is localized around the raw error |
+| Row numbers | Import failure helper receives UI row numbers; code comment documents `rowIndex + 2` as 0-based row plus header offset |
+| Record IDs | `recordNotFound(recordId, isZh)` localizes only surrounding chrome and keeps `recordId` raw |
+| Confirm dialogs | Native browser dialogs remain browser-rendered; only their text is localized |
+| Accessibility | T3E-2 modifies script-level `showSuccess`, `showError`, and `window.confirm` calls only; no new `aria`, `title`, or `placeholder` attributes were added |
+
+## 7. Dependency Note
+
+This was a fresh worktree. `pnpm install --frozen-lockfile` was required for local tools and touched tracked plugin/tool `node_modules` symlinks, matching previous metasheet2 worktree behavior. Those files are not part of this slice and must remain unstaged/uncommitted.
+
+## 8. Deferred Surfaces
+
+Deferred exactly as design-scoped:
+
+| Deferred | Reason |
+| --- | --- |
+| `MetaBulkEditDialog.vue` and parent `bulkEditDialog.*` messages | T3E-3 owns bulk edit dialog copy and parent-generated dialog result strings together |
+| `ConditionalFormattingDialog.vue` | T3E-3 owns condition-formatting rule/operator/color dialog chrome |
+| T3D automation | Larger automation rule-domain surface; design MD required first |
+| Final audit | Best after T3D and remaining T3E residual slices complete |
+
+## 9. Closeout
+
+T3E-2 local implementation meets the approved design gate. Remaining push/PR gate:
+
+```bash
+git diff --check origin/main..HEAD
+```
+
+Run after committing the targeted T3E-2 files only, excluding local `node_modules` install noise.


### PR DESCRIPTION
## Summary

T3E-2 localizes Workbench script-level dynamic toast fallbacks and confirm dialog copy.

- Adds Workbench fallback/confirm keys and six dynamic helpers in `workbench-labels.ts`.
- Retires `toast.formSubmitted` lockstep from the key union/map/tests; form submit success now uses `formSubmitSuccess(mode, isZh)`.
- Rewires Workbench `showSuccess(...)`, `showError(...)`, and `window.confirm(...)` fallback copy to locale-aware labels while preserving raw runtime errors first.
- Updates import-flow expectations from `record(s)` copy to real English pluralization and adds a zh-CN render sentinel.

Design / verification docs:

- `docs/development/multitable-t3e2-workbench-dynamic-toasts-design-20260520.md`
- `docs/development/multitable-t3e2-workbench-dynamic-toasts-verification-20260520.md`

## Verification

Post-rebase onto `origin/main@1869c4a9d`:

```bash
pnpm --filter @metasheet/web exec vue-tsc --noEmit
pnpm --filter @metasheet/web exec vitest run tests/multitable-workbench-i18n.spec.ts tests/multitable-workbench-import-flow.spec.ts --watch=false
pnpm --filter @metasheet/web exec vitest run tests/multitable-workbench-view.spec.ts -t "localizes workbench import success toast in zh-CN" --watch=false
git diff --check origin/main..HEAD
```

Results:

- `vue-tsc --noEmit`: clean
- `multitable-workbench-i18n.spec.ts` + `multitable-workbench-import-flow.spec.ts`: 20/20 pass
- zh-CN Workbench render sentinel: 1/1 pass
- `git diff --check origin/main..HEAD`: clean
- Earlier build before the final rebase: `pnpm --filter @metasheet/web build` passed in 6.28s

Known baseline, documented in verification MD:

- Full `multitable-workbench-view.spec.ts` remains 56/57 because `opens workflow designer with multitable context when automation is enabled` is gated by `featureFlags.workflow`, which defaults false on current `origin/main`. This PR does not touch workflow, feature flags, automation, or `canManageAutomation`.

## Scope Guard

- Frontend-only multitable i18n slice.
- No backend, contract, migration, attendance, K3, workflow, or feature flag changes.
- Deferred surfaces remain deferred: `MetaBulkEditDialog.vue`, `ConditionalFormattingDialog.vue`, T3D automation, final audit.
