### PR TITLE
feat(attendance): add calendar policy admin editor

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1393,6 +1393,121 @@
                     </div>
                   </div>
                 </div>
+                <div class="attendance__field attendance__field--full">
+                  <div class="attendance__admin-subsection">
+                    <div class="attendance__admin-subsection-header">
+                      <h5>{{ tr('Effective calendar overrides', '有效日历覆盖规则') }}</h5>
+                      <button class="attendance__btn" type="button" @click="addCalendarPolicyOverride">
+                        {{ tr('Add calendar override', '新增日历覆盖') }}
+                      </button>
+                    </div>
+                    <p class="attendance__field-hint">
+                      {{ tr('These overrides feed the effective-calendar API and attendance calculation chain. Rest-to-work changes can create auto-absence rows after the auto-absence job runs.', '这些规则会进入有效日历 API 与考勤计算链。休息日改为工作日后，自动缺勤任务运行时可能生成缺勤记录。') }}
+                    </p>
+                    <p class="attendance__field-hint attendance__field-hint--warn">
+                      {{ tr('Role and role-tag matching is reserved until role context is loaded by the resolver; keep new rules scoped to org, group, or user.', '角色与角色标签匹配需等待解析器加载角色上下文；新增规则请先使用组织、考勤组或用户范围。') }}
+                    </p>
+                    <div v-if="settingsForm.calendarPolicyOverrides.length === 0" class="attendance__empty">
+                      {{ tr('No effective calendar overrides configured.', '暂无有效日历覆盖规则。') }}
+                    </div>
+                    <div v-else class="attendance__table-wrapper">
+                      <table class="attendance__table">
+                        <thead>
+                          <tr>
+                            <th>{{ tr('Date / range', '日期 / 范围') }}</th>
+                            <th>{{ tr('Holiday name match', '节假日名称匹配') }}</th>
+                            <th>{{ tr('Scope', '范围') }}</th>
+                            <th>{{ tr('Effective day', '生效日类型') }}</th>
+                            <th>{{ tr('Label', '标签') }}</th>
+                            <th></th>
+                          </tr>
+                        </thead>
+                        <tbody>
+                          <template v-for="(override, index) in settingsForm.calendarPolicyOverrides" :key="`calendar-policy-override-${override.id || index}`">
+                            <tr>
+                              <td>
+                                <div class="attendance__inline-fields">
+                                  <input v-model="override.date" type="date" :aria-label="tr('Single date', '单日')" />
+                                  <input v-model="override.from" type="date" :aria-label="tr('From date', '开始日期')" />
+                                  <input v-model="override.to" type="date" :aria-label="tr('To date', '结束日期')" />
+                                </div>
+                              </td>
+                              <td>
+                                <input v-model="override.name" type="text" placeholder="春节" />
+                                <select v-model="override.match">
+                                  <option value="contains">{{ tr('Contains', '包含') }}</option>
+                                  <option value="equals">{{ tr('Equals', '等于') }}</option>
+                                  <option value="regex">{{ tr('Regex', '正则') }}</option>
+                                </select>
+                              </td>
+                              <td>
+                                <select v-model="override.source">
+                                  <option value="org">{{ tr('Organization', '组织') }}</option>
+                                  <option value="group">{{ tr('Attendance group', '考勤组') }}</option>
+                                  <option value="user">{{ tr('User', '用户') }}</option>
+                                  <option value="role" disabled>{{ tr('Role (reserved)', '角色（预留）') }}</option>
+                                </select>
+                              </td>
+                              <td>
+                                <select v-model="override.isWorkingDay">
+                                  <option :value="true">{{ tr('Working day', '工作日') }}</option>
+                                  <option :value="false">{{ tr('Rest day', '休息日') }}</option>
+                                </select>
+                              </td>
+                              <td><input v-model="override.label" type="text" :placeholder="tr('Policy label', '规则标签')" /></td>
+                              <td>
+                                <button class="attendance__btn attendance__btn--danger" type="button" @click="removeCalendarPolicyOverride(index)">
+                                  {{ tr('Remove', '移除') }}
+                                </button>
+                              </td>
+                            </tr>
+                            <tr class="attendance__table-row--meta">
+                              <td colspan="6">
+                                <div class="attendance__override-filters">
+                                  <label class="attendance__override-field">
+                                    <span>{{ tr('Attendance groups', '考勤组') }}</span>
+                                    <input v-model="override.attendanceGroups" type="text" placeholder="单休办公,白班" />
+                                    <small v-if="attendanceGroupOptions.length" class="attendance__field-hint">
+                                      {{ tr('Known groups', '已知分组') }}: {{ attendanceGroupOptions.join(', ') }}
+                                    </small>
+                                  </label>
+                                  <label class="attendance__override-field">
+                                    <span>{{ tr('User IDs', '用户ID') }}</span>
+                                    <input v-model="override.userIds" type="text" placeholder="uuid1,uuid2" />
+                                  </label>
+                                  <label class="attendance__override-field">
+                                    <span>{{ tr('User names', '用户名') }}</span>
+                                    <input v-model="override.userNames" type="text" placeholder="张三,李四" />
+                                  </label>
+                                  <label class="attendance__override-field">
+                                    <span>{{ tr('Exclude user IDs', '排除用户ID') }}</span>
+                                    <input v-model="override.excludeUserIds" type="text" placeholder="uuid3" />
+                                  </label>
+                                  <label class="attendance__override-field">
+                                    <span>{{ tr('Exclude user names', '排除用户名') }}</span>
+                                    <input v-model="override.excludeUserNames" type="text" placeholder="王五" />
+                                  </label>
+                                  <label class="attendance__override-field">
+                                    <span>{{ tr('Day index start', '节假日序号起始') }}</span>
+                                    <input v-model.number="override.dayIndexStart" type="number" min="1" />
+                                  </label>
+                                  <label class="attendance__override-field">
+                                    <span>{{ tr('Day index end', '节假日序号结束') }}</span>
+                                    <input v-model.number="override.dayIndexEnd" type="number" min="1" />
+                                  </label>
+                                  <label class="attendance__override-field">
+                                    <span>{{ tr('Day index list', '节假日序号列表') }}</span>
+                                    <input v-model="override.dayIndexList" type="text" placeholder="1,2,3" />
+                                  </label>
+                                </div>
+                              </td>
+                            </tr>
+                          </template>
+                        </tbody>
+                      </table>
+                    </div>
+                  </div>
+                </div>
                 <label class="attendance__field" for="attendance-min-punch-interval">
                   <span>{{ tr('Min punch interval (min)', '最小打卡间隔（分钟）') }}</span>
                   <input
@@ -4687,6 +4802,13 @@ import AttendanceImportBatchesSection from './attendance/AttendanceImportBatches
 import AttendanceHolidayDataSection from './attendance/AttendanceHolidayDataSection.vue'
 import AttendanceUserPickerField from './attendance/AttendanceUserPickerField.vue'
 import AttendanceReportFieldsSection from './attendance/AttendanceReportFieldsSection.vue'
+import {
+  calendarPolicyOverridesFromForm,
+  calendarPolicyOverridesToForm,
+  createDefaultCalendarPolicyOverrideForm,
+  type CalendarPolicyOverrideFormState,
+  type CalendarPolicyOverrideWire,
+} from './attendance/attendanceCalendarPolicyOverrides'
 import { useAttendanceAdminImportBatches } from './attendance/useAttendanceAdminImportBatches'
 import {
   buildRuleSetPreviewRecommendations,
@@ -5076,6 +5198,9 @@ interface AttendanceSettings {
     overtimeAdds?: boolean
     overtimeSource?: 'approval' | 'clock' | 'both'
     overrides?: HolidayPolicyOverride[]
+  }
+  calendarPolicy?: {
+    overrides?: CalendarPolicyOverrideWire[]
   }
   holidaySync?: {
     source?: 'holiday-cn'
@@ -7489,6 +7614,7 @@ const settingsForm = reactive({
   holidayOvertimeAdds: true,
   holidayOvertimeSource: 'approval' as 'approval' | 'clock' | 'both',
   holidayOverrides: [] as HolidayPolicyOverrideForm[],
+  calendarPolicyOverrides: [] as CalendarPolicyOverrideFormState[],
   holidaySyncBaseUrl: 'https://fastly.jsdelivr.net/gh/NateScarlet/holiday-cn@master',
   holidaySyncYears: '',
   holidaySyncAddDayIndex: true,
@@ -12352,6 +12478,7 @@ function applySettingsToForm(settings: AttendanceSettings) {
         }
       })
     : []
+  settingsForm.calendarPolicyOverrides = calendarPolicyOverridesToForm(settings.calendarPolicy?.overrides)
   settingsForm.holidaySyncBaseUrl = settings.holidaySync?.baseUrl
     || 'https://fastly.jsdelivr.net/gh/NateScarlet/holiday-cn@master'
   settingsForm.holidaySyncYears = Array.isArray(settings.holidaySync?.years)
@@ -12398,6 +12525,14 @@ function addHolidayOverride() {
 
 function removeHolidayOverride(index: number) {
   settingsForm.holidayOverrides.splice(index, 1)
+}
+
+function addCalendarPolicyOverride() {
+  settingsForm.calendarPolicyOverrides.push(createDefaultCalendarPolicyOverrideForm())
+}
+
+function removeCalendarPolicyOverride(index: number) {
+  settingsForm.calendarPolicyOverrides.splice(index, 1)
 }
 
 async function loadSettings() {
@@ -12487,6 +12622,9 @@ async function saveSettings() {
               : undefined,
           }))
           .filter((override) => override.name.length > 0),
+      },
+      calendarPolicy: {
+        overrides: calendarPolicyOverridesFromForm(settingsForm.calendarPolicyOverrides),
       },
       holidaySync: {
         source: 'holiday-cn',
@@ -14673,6 +14811,10 @@ const holidaySectionBindings = {
   color: #c0392b;
 }
 
+.attendance__field-hint--warn {
+  color: #9a6700;
+}
+
 .attendance__btn {
   padding: 8px 14px;
   border-radius: 6px;
@@ -15337,6 +15479,12 @@ const holidaySectionBindings = {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
   gap: 8px;
+}
+
+.attendance__inline-fields {
+  display: grid;
+  grid-template-columns: repeat(3, minmax(120px, 1fr));
+  gap: 6px;
 }
 
 .attendance__override-field {

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1402,7 +1402,7 @@
                       </button>
                     </div>
                     <p class="attendance__field-hint">
-                      {{ tr('These overrides feed the effective-calendar API and attendance calculation chain. Rest-to-work changes can create auto-absence rows after the auto-absence job runs.', '这些规则会进入有效日历 API 与考勤计算链。休息日改为工作日后，自动缺勤任务运行时可能生成缺勤记录。') }}
+                      {{ tr('These overrides drive the effective-calendar API and attendance calculation chain. Rest-to-work changes can create auto-absence rows after the auto-absence job runs.', '这些规则会影响有效日历 API 与考勤计算链。休息日改为工作日后，自动缺勤任务运行时可能生成缺勤记录。') }}
                     </p>
                     <p class="attendance__field-hint attendance__field-hint--warn">
                       {{ tr('Role and role-tag matching is reserved until role context is loaded by the resolver; keep new rules scoped to org, group, or user.', '角色与角色标签匹配需等待解析器加载角色上下文；新增规则请先使用组织、考勤组或用户范围。') }}
@@ -1427,21 +1427,21 @@
                             <tr>
                               <td>
                                 <div class="attendance__inline-fields">
-                                  <input v-model="override.date" type="date" :aria-label="tr('Single date', '单日')" />
-                                  <input v-model="override.from" type="date" :aria-label="tr('From date', '开始日期')" />
-                                  <input v-model="override.to" type="date" :aria-label="tr('To date', '结束日期')" />
+                                  <input v-model="override.date" class="attendance__table-input" type="date" :aria-label="tr('Single date', '单日')" />
+                                  <input v-model="override.from" class="attendance__table-input" type="date" :aria-label="tr('From date', '开始日期')" />
+                                  <input v-model="override.to" class="attendance__table-input" type="date" :aria-label="tr('To date', '结束日期')" />
                                 </div>
                               </td>
                               <td>
-                                <input v-model="override.name" type="text" placeholder="春节" />
-                                <select v-model="override.match">
+                                <input v-model="override.name" class="attendance__table-input" type="text" placeholder="春节" />
+                                <select v-model="override.match" class="attendance__table-input">
                                   <option value="contains">{{ tr('Contains', '包含') }}</option>
                                   <option value="equals">{{ tr('Equals', '等于') }}</option>
                                   <option value="regex">{{ tr('Regex', '正则') }}</option>
                                 </select>
                               </td>
                               <td>
-                                <select v-model="override.source">
+                                <select v-model="override.source" class="attendance__table-input">
                                   <option value="org">{{ tr('Organization', '组织') }}</option>
                                   <option value="group">{{ tr('Attendance group', '考勤组') }}</option>
                                   <option value="user">{{ tr('User', '用户') }}</option>
@@ -1449,12 +1449,12 @@
                                 </select>
                               </td>
                               <td>
-                                <select v-model="override.isWorkingDay">
+                                <select v-model="override.isWorkingDay" class="attendance__table-input">
                                   <option :value="true">{{ tr('Working day', '工作日') }}</option>
                                   <option :value="false">{{ tr('Rest day', '休息日') }}</option>
                                 </select>
                               </td>
-                              <td><input v-model="override.label" type="text" :placeholder="tr('Policy label', '规则标签')" /></td>
+                              <td><input v-model="override.label" class="attendance__table-input" type="text" :placeholder="tr('Policy label', '规则标签')" /></td>
                               <td>
                                 <button class="attendance__btn attendance__btn--danger" type="button" @click="removeCalendarPolicyOverride(index)">
                                   {{ tr('Remove', '移除') }}

--- a/apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue
+++ b/apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue
@@ -101,6 +101,98 @@
           </div>
         </div>
       </div>
+      <div class="attendance__field attendance__field--full">
+        <div class="attendance__admin-subsection">
+          <div class="attendance__admin-subsection-header attendance__admin-subsection-header--accordion">
+            <button class="attendance__accordion" type="button" :aria-expanded="calendarPolicyOverridesExpanded ? 'true' : 'false'" @click="toggleCalendarPolicyOverrides">
+              <span class="attendance__accordion-copy">
+                <strong>{{ tr('Effective calendar overrides', '有效日历覆盖规则') }}</strong>
+                <small>{{ calendarPolicyOverrideSummary }}</small>
+              </span>
+              <span class="attendance__accordion-indicator">{{ calendarPolicyOverridesExpanded ? tr('Collapse', '收起') : tr('Expand', '展开') }}</span>
+            </button>
+            <button class="attendance__btn" type="button" @click="addCalendarPolicyOverrideAndExpand">{{ tr('Add calendar override', '新增日历覆盖') }}</button>
+          </div>
+          <p class="attendance__field-hint">
+            {{ tr('These overrides drive the effective-calendar API and attendance calculation chain. Rest-to-work changes can create auto-absence rows after the auto-absence job runs.', '这些规则会影响有效日历 API 与考勤计算链。休息日改为工作日后，自动缺勤任务运行时可能生成缺勤记录。') }}
+          </p>
+          <p class="attendance__field-hint attendance__field-hint--warn">
+            {{ tr('Role and role-tag matching is reserved until role context is loaded by the resolver; keep new rules scoped to org, group, or user.', '角色与角色标签匹配需等待解析器加载角色上下文；新增规则请先使用组织、考勤组或用户范围。') }}
+          </p>
+          <div v-if="calendarPolicyOverridesExpanded">
+            <div v-if="settingsForm.calendarPolicyOverrides.length === 0" class="attendance__empty">{{ tr('No effective calendar overrides configured.', '暂无有效日历覆盖规则。') }}</div>
+            <div v-else class="attendance__table-wrapper">
+              <table class="attendance__table">
+                <thead>
+                  <tr>
+                    <th>{{ tr('Date / range', '日期 / 范围') }}</th>
+                    <th>{{ tr('Holiday name match', '节假日名称匹配') }}</th>
+                    <th>{{ tr('Scope', '范围') }}</th>
+                    <th>{{ tr('Effective day', '生效日类型') }}</th>
+                    <th>{{ tr('Label', '标签') }}</th>
+                    <th></th>
+                  </tr>
+                </thead>
+                <tbody>
+                  <template v-for="(override, index) in settingsForm.calendarPolicyOverrides" :key="`calendar-policy-override-${override.id || index}`">
+                    <tr>
+                      <td>
+                        <div class="attendance__inline-fields">
+                          <input v-model="override.date" class="attendance__table-input" type="date" :aria-label="tr('Single date', '单日')" />
+                          <input v-model="override.from" class="attendance__table-input" type="date" :aria-label="tr('From date', '开始日期')" />
+                          <input v-model="override.to" class="attendance__table-input" type="date" :aria-label="tr('To date', '结束日期')" />
+                        </div>
+                      </td>
+                      <td>
+                        <input v-model="override.name" class="attendance__table-input" type="text" placeholder="春节" />
+                        <select v-model="override.match" class="attendance__table-input">
+                          <option value="contains">{{ tr('Contains', '包含') }}</option>
+                          <option value="equals">{{ tr('Equals', '等于') }}</option>
+                          <option value="regex">{{ tr('Regex', '正则') }}</option>
+                        </select>
+                      </td>
+                      <td>
+                        <select v-model="override.source" class="attendance__table-input">
+                          <option value="org">{{ tr('Organization', '组织') }}</option>
+                          <option value="group">{{ tr('Attendance group', '考勤组') }}</option>
+                          <option value="user">{{ tr('User', '用户') }}</option>
+                          <option value="role" disabled>{{ tr('Role (reserved)', '角色（预留）') }}</option>
+                        </select>
+                      </td>
+                      <td>
+                        <select v-model="override.isWorkingDay" class="attendance__table-input">
+                          <option :value="true">{{ tr('Working day', '工作日') }}</option>
+                          <option :value="false">{{ tr('Rest day', '休息日') }}</option>
+                        </select>
+                      </td>
+                      <td><input v-model="override.label" class="attendance__table-input" type="text" :placeholder="tr('Policy label', '规则标签')" /></td>
+                      <td><button class="attendance__btn attendance__btn--danger" type="button" @click="removeCalendarPolicyOverride(index)">{{ tr('Remove', '移除') }}</button></td>
+                    </tr>
+                    <tr class="attendance__table-row--meta">
+                      <td colspan="6">
+                        <div class="attendance__override-filters">
+                          <label class="attendance__override-field">
+                            <span>{{ tr('Attendance groups', '考勤组') }}</span>
+                            <input v-model="override.attendanceGroups" type="text" placeholder="单休办公,白班" />
+                            <small v-if="attendanceGroupOptions.length" class="attendance__field-hint">{{ tr('Known groups', '已知分组') }}: {{ attendanceGroupOptions.join(', ') }}</small>
+                          </label>
+                          <label class="attendance__override-field"><span>{{ tr('User IDs', '用户ID') }}</span><input v-model="override.userIds" type="text" placeholder="uuid1,uuid2" /></label>
+                          <label class="attendance__override-field"><span>{{ tr('User names', '用户名') }}</span><input v-model="override.userNames" type="text" placeholder="张三,李四" /></label>
+                          <label class="attendance__override-field"><span>{{ tr('Exclude user IDs', '排除用户ID') }}</span><input v-model="override.excludeUserIds" type="text" placeholder="uuid3" /></label>
+                          <label class="attendance__override-field"><span>{{ tr('Exclude user names', '排除用户名') }}</span><input v-model="override.excludeUserNames" type="text" placeholder="王五" /></label>
+                          <label class="attendance__override-field"><span>{{ tr('Day index start', '节假日序号起始') }}</span><input v-model.number="override.dayIndexStart" type="number" min="1" /></label>
+                          <label class="attendance__override-field"><span>{{ tr('Day index end', '节假日序号结束') }}</span><input v-model.number="override.dayIndexEnd" type="number" min="1" /></label>
+                          <label class="attendance__override-field"><span>{{ tr('Day index list', '节假日序号列表') }}</span><input v-model="override.dayIndexList" type="text" placeholder="1,2,3" /></label>
+                        </div>
+                      </td>
+                    </tr>
+                  </template>
+                </tbody>
+              </table>
+            </div>
+          </div>
+        </div>
+      </div>
     </div>
     <button class="attendance__btn attendance__btn--primary" :disabled="settingsLoading" @click="saveSettings">
       {{ settingsLoading ? tr('Saving...', '保存中...') : tr('Save holiday settings', '保存节假日设置') }}
@@ -188,6 +280,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch, type Ref } from 'vue'
+import type { CalendarPolicyOverrideFormState } from './attendanceCalendarPolicyOverrides'
 import { buildTimezoneOptionGroups } from './attendanceTimezones'
 
 type Translate = (en: string, zh: string) => string
@@ -227,6 +320,7 @@ interface SettingsFormState {
   holidayOvertimeAdds: boolean
   holidayOvertimeSource: 'approval' | 'clock' | 'both'
   holidayOverrides: HolidayOverrideFormState[]
+  calendarPolicyOverrides: CalendarPolicyOverrideFormState[]
   holidaySyncBaseUrl: string
   holidaySyncYears: string
   holidaySyncAddDayIndex: boolean
@@ -240,10 +334,12 @@ interface SettingsFormState {
 }
 
 interface HolidayRuleBindings {
+  addCalendarPolicyOverride: () => MaybePromise<void>
   addHolidayOverride: () => MaybePromise<void>
   holidaySyncLastRun: Ref<HolidaySyncLastRun | null>
   holidaySyncLoading: Ref<boolean>
   removeHolidayOverride: (index: number) => MaybePromise<void>
+  removeCalendarPolicyOverride: (index: number) => MaybePromise<void>
   saveSettings: () => MaybePromise<void>
   settingsForm: SettingsFormState
   settingsLoading: Ref<boolean>
@@ -270,9 +366,14 @@ const settingsLoading = props.config.settingsLoading
 const syncHolidays = () => props.config.syncHolidays()
 const syncHolidaysForYears = (years: number[]) => props.config.syncHolidaysForYears(years)
 const holidayOverridesExpanded = ref((settingsForm.holidayOverrides?.length ?? 0) > 0)
+const calendarPolicyOverridesExpanded = ref((settingsForm.calendarPolicyOverrides?.length ?? 0) > 0)
 
 watch(() => settingsForm.holidayOverrides.length, (next, prev) => {
   if (next > prev) holidayOverridesExpanded.value = true
+})
+
+watch(() => settingsForm.calendarPolicyOverrides.length, (next, prev) => {
+  if (next > prev) calendarPolicyOverridesExpanded.value = true
 })
 
 const holidayOverrideSummary = computed(() => {
@@ -280,8 +381,17 @@ const holidayOverrideSummary = computed(() => {
   return count === 0 ? tr('No overrides configured', '暂无覆盖规则') : tr(`${count} override(s) configured`, `已配置 ${count} 条规则`)
 })
 
+const calendarPolicyOverrideSummary = computed(() => {
+  const count = settingsForm.calendarPolicyOverrides.length
+  return count === 0 ? tr('No effective calendar overrides configured', '暂无有效日历覆盖规则') : tr(`${count} effective override(s) configured`, `已配置 ${count} 条有效日历规则`)
+})
+
 const toggleHolidayOverrides = () => {
   holidayOverridesExpanded.value = !holidayOverridesExpanded.value
+}
+
+const toggleCalendarPolicyOverrides = () => {
+  calendarPolicyOverridesExpanded.value = !calendarPolicyOverridesExpanded.value
 }
 
 const addHolidayOverrideAndExpand = () => {
@@ -289,7 +399,13 @@ const addHolidayOverrideAndExpand = () => {
   props.config.addHolidayOverride()
 }
 
+const addCalendarPolicyOverrideAndExpand = () => {
+  calendarPolicyOverridesExpanded.value = true
+  props.config.addCalendarPolicyOverride()
+}
+
 const removeHolidayOverride = (index: number) => props.config.removeHolidayOverride(index)
+const removeCalendarPolicyOverride = (index: number) => props.config.removeCalendarPolicyOverride(index)
 const currentYear = new Date().getFullYear()
 const syncCurrentYear = () => syncHolidaysForYears([currentYear])
 const syncNextYear = () => syncHolidaysForYears([currentYear + 1])
@@ -306,6 +422,7 @@ const syncNextYear = () => syncHolidaysForYears([currentYear + 1])
 .attendance__field--full { grid-column: 1 / -1; }
 .attendance__field--checkbox { justify-content: flex-end; }
 .attendance__field-hint { color: #777; font-size: 11px; }
+.attendance__field-hint--warn { color: #9a6700; }
 .attendance__accordion { flex: 1; display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 12px 14px; border-radius: 10px; border: 1px solid #d0d0d0; background: #fff; cursor: pointer; text-align: left; }
 .attendance__accordion-copy small, .attendance__accordion-indicator { color: #666; font-size: 12px; }
 .attendance__btn { padding: 8px 14px; border-radius: 6px; border: 1px solid #d0d0d0; background: #fff; cursor: pointer; }
@@ -318,6 +435,7 @@ const syncNextYear = () => syncHolidaysForYears([currentYear + 1])
 .attendance__table th, .attendance__table td { border-bottom: 1px solid #e0e0e0; padding: 8px; text-align: left; font-size: 13px; }
 .attendance__table-row--meta td { background: #fafafa; }
 .attendance__table-input { width: 100%; min-width: 0; box-sizing: border-box; }
+.attendance__inline-fields { display: grid; grid-template-columns: repeat(3, minmax(120px, 1fr)); gap: 6px; }
 .attendance__empty { color: #888; font-size: 13px; margin-top: 8px; }
 .attendance__admin-meta { color: #555; font-size: 13px; }
 </style>

--- a/apps/web/src/views/attendance/attendanceCalendarPolicyOverrides.ts
+++ b/apps/web/src/views/attendance/attendanceCalendarPolicyOverrides.ts
@@ -1,0 +1,199 @@
+export type CalendarPolicySource = 'org' | 'group' | 'role' | 'user'
+export type CalendarPolicyMatch = 'contains' | 'regex' | 'equals'
+
+export interface CalendarPolicyOverrideWire {
+  id?: string
+  name?: string
+  match?: CalendarPolicyMatch
+  date?: string
+  from?: string
+  to?: string
+  dayIndexStart?: number
+  dayIndexEnd?: number
+  dayIndexList?: number[]
+  filters?: {
+    userIds?: string[]
+    userNames?: string[]
+    excludeUserIds?: string[]
+    excludeUserNames?: string[]
+    attendanceGroups?: string[]
+    roles?: string[]
+    roleTags?: string[]
+  }
+  effective: {
+    isWorkingDay: boolean
+    label?: string
+    source: CalendarPolicySource
+  }
+}
+
+export interface CalendarPolicyOverrideFormState {
+  id?: string
+  name: string
+  match: CalendarPolicyMatch
+  date: string
+  from: string
+  to: string
+  dayIndexStart?: number | null
+  dayIndexEnd?: number | null
+  dayIndexList?: string
+  source: CalendarPolicySource
+  isWorkingDay: boolean
+  label: string
+  attendanceGroups?: string
+  roles?: string
+  roleTags?: string
+  userIds?: string
+  userNames?: string
+  excludeUserIds?: string
+  excludeUserNames?: string
+}
+
+function listToText(list?: Array<string | number>): string {
+  return Array.isArray(list) ? list.join(',') : ''
+}
+
+function splitListText(value?: string): string[] {
+  if (!value) return []
+  return value
+    .split(/[\n,]+/)
+    .map((item) => item.trim())
+    .filter(Boolean)
+}
+
+function splitNumberList(value?: string): number[] {
+  if (!value) return []
+  return value
+    .split(/[\n,\s]+/)
+    .map((item) => Number(item))
+    .filter((item) => Number.isFinite(item) && item >= 1)
+}
+
+function normalizeOptionalNumber(value: unknown): number | undefined {
+  const num = typeof value === 'number' ? value : Number(value)
+  return Number.isFinite(num) && num >= 1 ? num : undefined
+}
+
+function normalizeCalendarPolicySource(value: unknown): CalendarPolicySource {
+  return value === 'group' || value === 'role' || value === 'user' ? value : 'org'
+}
+
+function normalizeCalendarPolicyMatch(value: unknown): CalendarPolicyMatch {
+  return value === 'regex' || value === 'equals' ? value : 'contains'
+}
+
+export function createDefaultCalendarPolicyOverrideForm(): CalendarPolicyOverrideFormState {
+  return {
+    name: '',
+    match: 'contains',
+    date: '',
+    from: '',
+    to: '',
+    dayIndexStart: null,
+    dayIndexEnd: null,
+    dayIndexList: '',
+    source: 'org',
+    isWorkingDay: true,
+    label: '',
+    attendanceGroups: '',
+    roles: '',
+    roleTags: '',
+    userIds: '',
+    userNames: '',
+    excludeUserIds: '',
+    excludeUserNames: '',
+  }
+}
+
+export function calendarPolicyOverridesToForm(
+  overrides: CalendarPolicyOverrideWire[] | undefined,
+): CalendarPolicyOverrideFormState[] {
+  if (!Array.isArray(overrides)) return []
+  return overrides.map((override) => ({
+    id: typeof override.id === 'string' && override.id.trim() ? override.id.trim() : undefined,
+    name: typeof override.name === 'string' ? override.name : '',
+    match: normalizeCalendarPolicyMatch(override.match),
+    date: typeof override.date === 'string' ? override.date : '',
+    from: typeof override.from === 'string' ? override.from : '',
+    to: typeof override.to === 'string' ? override.to : '',
+    dayIndexStart: override.dayIndexStart ?? null,
+    dayIndexEnd: override.dayIndexEnd ?? null,
+    dayIndexList: listToText(override.dayIndexList),
+    source: normalizeCalendarPolicySource(override.effective?.source),
+    isWorkingDay: override.effective?.isWorkingDay === true,
+    label: typeof override.effective?.label === 'string' ? override.effective.label : '',
+    attendanceGroups: listToText(override.filters?.attendanceGroups),
+    roles: listToText(override.filters?.roles),
+    roleTags: listToText(override.filters?.roleTags),
+    userIds: listToText(override.filters?.userIds),
+    userNames: listToText(override.filters?.userNames),
+    excludeUserIds: listToText(override.filters?.excludeUserIds),
+    excludeUserNames: listToText(override.filters?.excludeUserNames),
+  }))
+}
+
+function hasCalendarPolicyConstraint(form: CalendarPolicyOverrideFormState): boolean {
+  return Boolean(
+    form.date?.trim()
+    || form.from?.trim()
+    || form.to?.trim()
+    || form.name?.trim()
+    || normalizeOptionalNumber(form.dayIndexStart)
+    || normalizeOptionalNumber(form.dayIndexEnd)
+    || splitNumberList(form.dayIndexList).length > 0,
+  )
+}
+
+function hasRequiredSourceFilter(form: CalendarPolicyOverrideFormState): boolean {
+  if (form.source === 'group') return splitListText(form.attendanceGroups).length > 0
+  if (form.source === 'role') {
+    return splitListText(form.roles).length > 0 || splitListText(form.roleTags).length > 0
+  }
+  if (form.source === 'user') {
+    return splitListText(form.userIds).length > 0 || splitListText(form.userNames).length > 0
+  }
+  return true
+}
+
+export function calendarPolicyOverridesFromForm(
+  forms: CalendarPolicyOverrideFormState[] | undefined,
+): CalendarPolicyOverrideWire[] {
+  if (!Array.isArray(forms)) return []
+  return forms
+    .filter((form) => hasCalendarPolicyConstraint(form) && hasRequiredSourceFilter(form))
+    .map((form) => {
+      const filters: NonNullable<CalendarPolicyOverrideWire['filters']> = {}
+      const userIds = splitListText(form.userIds)
+      const userNames = splitListText(form.userNames)
+      const excludeUserIds = splitListText(form.excludeUserIds)
+      const excludeUserNames = splitListText(form.excludeUserNames)
+      const attendanceGroups = splitListText(form.attendanceGroups)
+      const roles = splitListText(form.roles)
+      const roleTags = splitListText(form.roleTags)
+      if (userIds.length) filters.userIds = userIds
+      if (userNames.length) filters.userNames = userNames
+      if (excludeUserIds.length) filters.excludeUserIds = excludeUserIds
+      if (excludeUserNames.length) filters.excludeUserNames = excludeUserNames
+      if (attendanceGroups.length) filters.attendanceGroups = attendanceGroups
+      if (roles.length) filters.roles = roles
+      if (roleTags.length) filters.roleTags = roleTags
+
+      return {
+        id: form.id?.trim() || undefined,
+        name: form.name?.trim() || undefined,
+        match: form.name?.trim() ? form.match || 'contains' : undefined,
+        date: form.date?.trim() || undefined,
+        from: form.from?.trim() || undefined,
+        to: form.to?.trim() || undefined,
+        dayIndexStart: normalizeOptionalNumber(form.dayIndexStart),
+        dayIndexEnd: normalizeOptionalNumber(form.dayIndexEnd),
+        dayIndexList: splitNumberList(form.dayIndexList),
+        filters: Object.keys(filters).length > 0 ? filters : undefined,
+        effective: {
+          isWorkingDay: form.isWorkingDay === true,
+          label: form.label?.trim() || undefined,
+          source: normalizeCalendarPolicySource(form.source),
+        },
+      }
+    })
+}

--- a/apps/web/src/views/attendance/useAttendanceAdminConfig.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminConfig.ts
@@ -1,4 +1,11 @@
 import { reactive, ref, type Ref } from 'vue'
+import {
+  calendarPolicyOverridesFromForm,
+  calendarPolicyOverridesToForm,
+  createDefaultCalendarPolicyOverrideForm,
+  type CalendarPolicyOverrideFormState,
+  type CalendarPolicyOverrideWire,
+} from './attendanceCalendarPolicyOverrides'
 
 type Translate = (en: string, zh: string) => string
 type SetStatusFn = (message: string, kind?: 'info' | 'error') => void
@@ -41,6 +48,9 @@ interface AttendanceSettings {
     overtimeAdds?: boolean
     overtimeSource?: 'approval' | 'clock' | 'both'
     overrides?: HolidayPolicyOverride[]
+  }
+  calendarPolicy?: {
+    overrides?: CalendarPolicyOverrideWire[]
   }
   holidaySync?: {
     source?: 'holiday-cn'
@@ -180,6 +190,7 @@ export function useAttendanceAdminConfig({
     holidayOvertimeAdds: true,
     holidayOvertimeSource: 'approval' as 'approval' | 'clock' | 'both',
     holidayOverrides: [] as HolidayPolicyOverrideForm[],
+    calendarPolicyOverrides: [] as CalendarPolicyOverrideFormState[],
     holidaySyncBaseUrl: 'https://fastly.jsdelivr.net/gh/NateScarlet/holiday-cn@master',
     holidaySyncYears: '',
     holidaySyncAddDayIndex: true,
@@ -243,6 +254,7 @@ export function useAttendanceAdminConfig({
           }
         })
       : []
+    settingsForm.calendarPolicyOverrides = calendarPolicyOverridesToForm(settings.calendarPolicy?.overrides)
     settingsForm.holidaySyncBaseUrl = settings.holidaySync?.baseUrl
       || 'https://fastly.jsdelivr.net/gh/NateScarlet/holiday-cn@master'
     settingsForm.holidaySyncYears = Array.isArray(settings.holidaySync?.years)
@@ -289,6 +301,14 @@ export function useAttendanceAdminConfig({
 
   function removeHolidayOverride(index: number) {
     settingsForm.holidayOverrides.splice(index, 1)
+  }
+
+  function addCalendarPolicyOverride() {
+    settingsForm.calendarPolicyOverrides.push(createDefaultCalendarPolicyOverrideForm())
+  }
+
+  function removeCalendarPolicyOverride(index: number) {
+    settingsForm.calendarPolicyOverrides.splice(index, 1)
   }
 
   async function loadSettings() {
@@ -378,6 +398,9 @@ export function useAttendanceAdminConfig({
                 : undefined,
             }))
             .filter((override) => override.name.length > 0),
+        },
+        calendarPolicy: {
+          overrides: calendarPolicyOverridesFromForm(settingsForm.calendarPolicyOverrides),
         },
         holidaySync: {
           source: 'holiday-cn',
@@ -566,11 +589,13 @@ export function useAttendanceAdminConfig({
   }
 
   return {
+    addCalendarPolicyOverride,
     addHolidayOverride,
     holidaySyncLastRun,
     holidaySyncLoading,
     loadRule,
     loadSettings,
+    removeCalendarPolicyOverride,
     removeHolidayOverride,
     ruleForm,
     ruleLoading,

--- a/apps/web/tests/useAttendanceAdminConfig.spec.ts
+++ b/apps/web/tests/useAttendanceAdminConfig.spec.ts
@@ -61,6 +61,16 @@ describe('useAttendanceAdminConfig', () => {
               },
             ],
           },
+          calendarPolicy: {
+            overrides: [
+              {
+                id: 'policy-1',
+                date: '2026-10-04',
+                filters: { attendanceGroups: ['day-shift'] },
+                effective: { isWorkingDay: true, label: 'Make-up workday', source: 'group' },
+              },
+            ],
+          },
           holidaySync: {
             baseUrl: 'https://example.com',
             years: [2026],
@@ -82,6 +92,10 @@ describe('useAttendanceAdminConfig', () => {
     expect(config.settingsForm.autoAbsenceRunAt).toBe('01:30')
     expect(config.settingsForm.holidayOverrides).toHaveLength(1)
     expect(config.settingsForm.holidayOverrides[0]?.attendanceGroups).toBe('ops')
+    expect(config.settingsForm.calendarPolicyOverrides).toHaveLength(1)
+    expect(config.settingsForm.calendarPolicyOverrides[0]?.source).toBe('group')
+    expect(config.settingsForm.calendarPolicyOverrides[0]?.attendanceGroups).toBe('day-shift')
+    expect(config.settingsForm.calendarPolicyOverrides[0]?.label).toBe('Make-up workday')
     expect(config.settingsForm.holidaySyncBaseUrl).toBe('https://example.com')
     expect(config.settingsForm.ipAllowlist).toBe('10.0.0.1')
     expect(config.holidaySyncLastRun.value?.totalApplied).toBe(3)
@@ -121,6 +135,27 @@ describe('useAttendanceAdminConfig', () => {
       overtimeAdds: true,
       overtimeSource: 'approval',
     })
+    config.settingsForm.calendarPolicyOverrides.push({
+      id: 'policy-1',
+      name: '国庆',
+      match: 'contains',
+      date: '',
+      from: '2026-10-01',
+      to: '2026-10-07',
+      dayIndexStart: 2,
+      dayIndexEnd: null,
+      dayIndexList: '2 3',
+      source: 'group',
+      isWorkingDay: false,
+      label: 'Group rest',
+      attendanceGroups: 'day-shift',
+      roles: '',
+      roleTags: '',
+      userIds: '',
+      userNames: '',
+      excludeUserIds: 'user-9',
+      excludeUserNames: '',
+    })
 
     await config.saveSettings()
 
@@ -134,6 +169,23 @@ describe('useAttendanceAdminConfig', () => {
       attendanceGroups: ['ops'],
       roles: ['manager'],
       dayIndexList: [1, 2],
+    })
+    expect(payload.calendarPolicy.overrides[0]).toMatchObject({
+      id: 'policy-1',
+      name: '国庆',
+      from: '2026-10-01',
+      to: '2026-10-07',
+      dayIndexStart: 2,
+      dayIndexList: [2, 3],
+      filters: {
+        attendanceGroups: ['day-shift'],
+        excludeUserIds: ['user-9'],
+      },
+      effective: {
+        isWorkingDay: false,
+        label: 'Group rest',
+        source: 'group',
+      },
     })
     expect(payload.holidaySync.years).toEqual([2026, 2027])
     expect(payload.ipAllowlist).toEqual(['10.0.0.1', '10.0.0.2'])

--- a/apps/web/tests/useAttendanceHolidayRuleSection.spec.ts
+++ b/apps/web/tests/useAttendanceHolidayRuleSection.spec.ts
@@ -21,12 +21,35 @@ interface HolidayOverrideState {
   overtimeSource: 'approval' | 'clock' | 'both'
 }
 
+interface CalendarPolicyOverrideState {
+  id?: string
+  name: string
+  match: 'contains' | 'regex' | 'equals'
+  date: string
+  from: string
+  to: string
+  dayIndexStart: number | null
+  dayIndexEnd: number | null
+  dayIndexList: string
+  source: 'org' | 'group' | 'role' | 'user'
+  isWorkingDay: boolean
+  label: string
+  attendanceGroups: string
+  roles: string
+  roleTags: string
+  userIds: string
+  userNames: string
+  excludeUserIds: string
+  excludeUserNames: string
+}
+
 interface HolidaySettingsState {
   holidayFirstDayEnabled: boolean
   holidayFirstDayBaseHours: number
   holidayOvertimeAdds: boolean
   holidayOvertimeSource: 'approval' | 'clock' | 'both'
   holidayOverrides: HolidayOverrideState[]
+  calendarPolicyOverrides: CalendarPolicyOverrideState[]
   holidaySyncBaseUrl: string
   holidaySyncYears: string
   holidaySyncAddDayIndex: boolean
@@ -40,10 +63,12 @@ interface HolidaySettingsState {
 }
 
 type HolidayConfig = {
+  addCalendarPolicyOverride: () => void
   addHolidayOverride: () => void
   holidaySyncLastRun: { value: null }
   holidaySyncLoading: { value: boolean }
   removeHolidayOverride: (index: number) => void
+  removeCalendarPolicyOverride: (index: number) => void
   saveSettings: () => void
   settingsForm: HolidaySettingsState
   settingsLoading: { value: boolean }
@@ -72,6 +97,7 @@ function createDefaultSettings(): HolidaySettingsState {
     holidayOvertimeAdds: false,
     holidayOvertimeSource: 'approval',
     holidayOverrides: [],
+    calendarPolicyOverrides: [],
     holidaySyncBaseUrl: '',
     holidaySyncYears: '',
     holidaySyncAddDayIndex: false,
@@ -108,9 +134,11 @@ describe('AttendanceHolidayRuleSection', () => {
     const settingsForm = reactive<HolidaySettingsState>(createDefaultSettings())
 
     const config = {
+      addCalendarPolicyOverride: vi.fn(),
       addHolidayOverride: vi.fn(),
       holidaySyncLastRun: { value: null },
       holidaySyncLoading: { value: false },
+      removeCalendarPolicyOverride: vi.fn(),
       removeHolidayOverride: vi.fn(),
       saveSettings: vi.fn(),
       settingsForm,
@@ -139,9 +167,11 @@ describe('AttendanceHolidayRuleSection', () => {
     const settingsForm = reactive<HolidaySettingsState>(createDefaultSettings())
 
     const config = {
+      addCalendarPolicyOverride: vi.fn(),
       addHolidayOverride: vi.fn(),
       holidaySyncLastRun: { value: null },
       holidaySyncLoading: { value: false },
+      removeCalendarPolicyOverride: vi.fn(),
       removeHolidayOverride: vi.fn(),
       saveSettings: vi.fn(),
       settingsForm,
@@ -176,6 +206,7 @@ describe('AttendanceHolidayRuleSection', () => {
     const settingsForm = reactive<HolidaySettingsState>(createDefaultSettings())
 
     const config = {
+      addCalendarPolicyOverride: vi.fn(),
       addHolidayOverride: vi.fn(() => {
         settingsForm.holidayOverrides.push({
           name: '',
@@ -198,6 +229,7 @@ describe('AttendanceHolidayRuleSection', () => {
       }),
       holidaySyncLastRun: { value: null },
       holidaySyncLoading: { value: false },
+      removeCalendarPolicyOverride: vi.fn(),
       removeHolidayOverride: vi.fn(),
       saveSettings: vi.fn(),
       settingsForm,
@@ -227,13 +259,76 @@ describe('AttendanceHolidayRuleSection', () => {
     expect(container!.querySelector('.attendance__override-field input[placeholder="单休办公,白班"]')).toBeTruthy()
   })
 
+  it('expands and shows effective calendar override controls after adding one rule', async () => {
+    const settingsForm = reactive<HolidaySettingsState>(createDefaultSettings())
+
+    const config = {
+      addCalendarPolicyOverride: vi.fn(() => {
+        settingsForm.calendarPolicyOverrides.push({
+          name: '',
+          match: 'contains',
+          date: '',
+          from: '2026-10-01',
+          to: '2026-10-07',
+          dayIndexStart: null,
+          dayIndexEnd: null,
+          dayIndexList: '',
+          source: 'group',
+          isWorkingDay: false,
+          label: '国庆调休',
+          attendanceGroups: 'day-shift',
+          roles: '',
+          roleTags: '',
+          userIds: '',
+          userNames: '',
+          excludeUserIds: '',
+          excludeUserNames: '',
+        })
+      }),
+      addHolidayOverride: vi.fn(),
+      holidaySyncLastRun: { value: null },
+      holidaySyncLoading: { value: false },
+      removeCalendarPolicyOverride: vi.fn(),
+      removeHolidayOverride: vi.fn(),
+      saveSettings: vi.fn(),
+      settingsForm,
+      settingsLoading: { value: false },
+      syncHolidays: vi.fn(),
+      syncHolidaysForYears: vi.fn(),
+    } as HolidayConfig
+
+    app = createApp(AttendanceHolidayRuleSection, {
+      attendanceGroupOptions: ['day-shift'],
+      config,
+      formatDateTime,
+      tr,
+    })
+    app.mount(container!)
+    await flushUi()
+
+    findButton(container!, '新增日历覆盖').click()
+    await flushUi(6)
+
+    expect(config.addCalendarPolicyOverride).toHaveBeenCalledTimes(1)
+    expect(container!.textContent).toContain('有效日历覆盖规则')
+    expect(container!.textContent).toContain('自动缺勤任务运行时可能生成缺勤记录')
+    const sourceSelect = Array.from(container!.querySelectorAll('select')).find((select) => (
+      Array.from(select.options).some((option) => option.value === 'role' && option.disabled)
+    ))
+    expect(sourceSelect).toBeTruthy()
+    expect(container!.querySelector('input[placeholder="规则标签"]')).toBeTruthy()
+    expect(container!.querySelector('.attendance__override-field input[placeholder="单休办公,白班"]')).toBeTruthy()
+  })
+
   it('shows the auto-sync timezone as a select with UTC offset labels', async () => {
     const settingsForm = reactive<HolidaySettingsState>(createDefaultSettings())
 
     const config = {
+      addCalendarPolicyOverride: vi.fn(),
       addHolidayOverride: vi.fn(),
       holidaySyncLastRun: { value: null },
       holidaySyncLoading: { value: false },
+      removeCalendarPolicyOverride: vi.fn(),
       removeHolidayOverride: vi.fn(),
       saveSettings: vi.fn(),
       settingsForm,

--- a/docs/development/attendance-calendar-policy-admin-ui-development-20260520.md
+++ b/docs/development/attendance-calendar-policy-admin-ui-development-20260520.md
@@ -1,0 +1,88 @@
+# Attendance Calendar Policy Admin UI
+
+Date: 2026-05-20
+Branch: `codex/attendance-calendar-policy-admin-ui-20260520`
+Base: `origin/main@37013f269`
+
+## Summary
+
+This slice adds an admin editor for `settings.calendarPolicy.overrides[]`,
+the policy layer introduced by the effective-calendar resolver and then
+routed into the attendance calculation chain. Before this slice, operators
+could see effective calendar results but still had to edit the policy array
+through raw settings JSON. The new UI exposes the same persisted shape through
+the attendance holiday/settings surface.
+
+No backend route, migration, `attendance_*` fact table, or `meta_*` write path
+changed. The save path remains the existing `PUT /api/attendance/settings`
+route, which already normalizes and validates `calendarPolicy.overrides[]`.
+
+## Scope
+
+Delivered:
+
+- Shared frontend helper:
+  `apps/web/src/views/attendance/attendanceCalendarPolicyOverrides.ts`
+  handles wire-to-form and form-to-wire mapping.
+- `useAttendanceAdminConfig` now loads/saves `calendarPolicy.overrides[]`
+  alongside existing holiday settings.
+- `AttendanceHolidayRuleSection.vue` gets an accordion editor for effective
+  calendar overrides.
+- `AttendanceView.vue` gets the same editor in the currently mounted
+  monolithic admin settings section, so the production route has the entry
+  point immediately.
+- Focused tests cover load/save serialization and component rendering.
+
+Not delivered:
+
+- A new backend preview endpoint. Operators can verify behavior through the
+  existing effective-calendar surfaces after save.
+- Role / roleTag matching. The option is shown as reserved/disabled because
+  the backend resolver still does not load role context.
+- Bulk import/export of policy overrides.
+
+## UI Contract
+
+The editor supports:
+
+- Constraints: single `date`, `from`/`to`, holiday `name` with match mode,
+  `dayIndexStart`, `dayIndexEnd`, `dayIndexList`.
+- Scope source: organization, attendance group, user. Role is displayed as
+  reserved and disabled for new rules.
+- Filters: attendance groups, user IDs/names, excluded user IDs/names.
+- Effective result: working day vs rest day, plus optional display label.
+
+Rows are serialized only when they have at least one date/name/day-index
+constraint and satisfy the backend source/filter requirement:
+
+| Source | Required filter |
+| --- | --- |
+| `org` | none |
+| `group` | `attendanceGroups` |
+| `user` | `userIds` or `userNames` |
+| `role` | `roles` or `roleTags` (reserved/inert in v1) |
+
+This mirrors the backend normalizer and avoids silently saving rows that the
+backend would drop.
+
+## Boundary Notes
+
+- `holidayPolicy.overrides[]` and `calendarPolicy.overrides[]` stay separate.
+  The former affects holiday pay/overtime interpretation; the latter answers
+  whether a date is effectively a working day for org/group/user scope.
+- The editor explicitly warns that rest-to-work policy changes feed the
+  calculation chain and can produce auto-absence rows after the auto-absence
+  job runs.
+- Role and roleTag policy rows remain configuration-compatible but resolver
+  inert until a future role-context loader exists.
+
+## Files Changed
+
+| File | Purpose |
+| --- | --- |
+| `apps/web/src/views/attendance/attendanceCalendarPolicyOverrides.ts` | Shared wire/form mapper and source/filter guard |
+| `apps/web/src/views/attendance/useAttendanceAdminConfig.ts` | Load/save calendar policy through existing settings API |
+| `apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue` | Extracted-section UI editor |
+| `apps/web/src/views/AttendanceView.vue` | Mounted admin settings UI editor |
+| `apps/web/tests/useAttendanceAdminConfig.spec.ts` | Load/save serialization coverage |
+| `apps/web/tests/useAttendanceHolidayRuleSection.spec.ts` | Render/add-control coverage |

--- a/docs/development/attendance-calendar-policy-admin-ui-verification-20260520.md
+++ b/docs/development/attendance-calendar-policy-admin-ui-verification-20260520.md
@@ -33,6 +33,14 @@ Base: `origin/main@37013f269`
 
 ## Boundaries Verified
 
+- Backend settings support is inherited from the effective-calendar work already
+  on `origin/main`: `DEFAULT_SETTINGS.calendarPolicy`, `settingsSchema.calendarPolicy`,
+  and `normalizeCalendarPolicyOverrides()` are present in
+  `plugins/plugin-attendance/index.cjs`; the existing integration test
+  `effective-calendar §6.2 applies calendarPolicy with mode gates, priority, and
+  normalize drops invalid` round-trips `PUT /api/attendance/settings` with
+  `calendarPolicy.overrides[]` and asserts the normalized response keeps three
+  valid nested `{ filters, effective }` entries while dropping invalid ones.
 - No backend code changes beyond syntax checking the existing plugin file.
 - No `attendance_*` migration or fact-source move.
 - No direct `meta_*` writes.

--- a/docs/development/attendance-calendar-policy-admin-ui-verification-20260520.md
+++ b/docs/development/attendance-calendar-policy-admin-ui-verification-20260520.md
@@ -1,0 +1,50 @@
+# Attendance Calendar Policy Admin UI — Verification
+
+Date: 2026-05-20
+Branch: `codex/attendance-calendar-policy-admin-ui-20260520`
+Base: `origin/main@37013f269`
+
+## Test Matrix
+
+| Check | Result |
+| --- | --- |
+| `node --check plugins/plugin-attendance/index.cjs` | PASS |
+| `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/useAttendanceAdminConfig.spec.ts tests/useAttendanceHolidayRuleSection.spec.ts --watch=false` | PASS — 2 files / 9 tests |
+| `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false` | PASS — 1 file / 11 tests |
+| `pnpm --filter @metasheet/web type-check` | PASS |
+| `pnpm --filter @metasheet/web build` | PASS |
+| `git diff --check` | PASS |
+
+## Coverage Notes
+
+- `useAttendanceAdminConfig.spec.ts` verifies:
+  - API `settings.calendarPolicy.overrides[]` loads into the reactive form.
+  - The save payload writes `calendarPolicy.overrides[]` with date/range,
+    day-index constraints, filters, and `effective` metadata.
+  - Existing holiday policy and holiday sync payload behavior remains intact.
+- `useAttendanceHolidayRuleSection.spec.ts` verifies:
+  - The effective-calendar accordion opens when a rule is added.
+  - The auto-absence impact warning is visible.
+  - The role source option is present but disabled/reserved.
+  - Existing holiday override accordion behavior remains intact.
+- `attendance-admin-regressions.spec.ts` verifies the mounted
+  `AttendanceView.vue` admin surface still renders and exercises existing
+  admin regressions after the monolithic settings section was updated.
+
+## Boundaries Verified
+
+- No backend code changes beyond syntax checking the existing plugin file.
+- No `attendance_*` migration or fact-source move.
+- No direct `meta_*` writes.
+- Existing `PUT /api/attendance/settings` remains the only persistence path.
+- `node_modules` symlink changes were produced by `pnpm install` in the
+  isolated worktree and are intentionally excluded from the slice boundary.
+
+## Deferred
+
+- Inline preview inside the settings editor. The current safe path is:
+  save settings, then inspect the existing effective-calendar surfaces. A
+  future preview panel can call `GET /api/attendance/effective-calendar` with
+  explicit org/group/user mode after UX for preview target selection is pinned.
+- Role / roleTag resolver context. The UI keeps this source reserved until the
+  backend loads role context for effective-calendar matching.


### PR DESCRIPTION
## Summary

Adds an admin editor for `settings.calendarPolicy.overrides[]` so attendance admins can configure effective-calendar workday/rest-day overrides without editing raw settings JSON.

- Adds a shared wire/form mapper for `calendarPolicy.overrides[]`
- Loads/saves calendar policy through the existing `PUT /api/attendance/settings` path
- Adds effective calendar override controls to both the mounted `AttendanceView.vue` admin settings section and the extracted `AttendanceHolidayRuleSection.vue`
- Keeps role/role-tag matching visibly reserved because the backend resolver still does not load role context
- Documents the auto-absence impact of rest-to-work overrides

No backend route changes, no migrations, no direct `meta_*` writes, and no `attendance_*` fact-source migration.

## Test plan

- [x] `node --check plugins/plugin-attendance/index.cjs`
- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/useAttendanceAdminConfig.spec.ts tests/useAttendanceHolidayRuleSection.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false`
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `pnpm --filter @metasheet/web build`
- [x] `git diff --check`

## Docs

- `docs/development/attendance-calendar-policy-admin-ui-development-20260520.md`
- `docs/development/attendance-calendar-policy-admin-ui-verification-20260520.md`