### PR TITLE
feat(multitable): localize bulk edit and conditional formatting chrome (T3E-3)

### DIFF
--- a/apps/web/src/multitable/components/ConditionalFormattingDialog.vue
+++ b/apps/web/src/multitable/components/ConditionalFormattingDialog.vue
@@ -1,14 +1,14 @@
 <template>
   <div v-if="visible" class="cf-dlg__overlay" @click.self="close">
-    <div class="cf-dlg" role="dialog" aria-label="Conditional formatting rules">
+    <div class="cf-dlg" role="dialog" :aria-label="ml('formatting.ariaTitle')">
       <div class="cf-dlg__header">
-        <h4 class="cf-dlg__title">Conditional formatting</h4>
+        <h4 class="cf-dlg__title">{{ ml('formatting.title') }}</h4>
         <span class="cf-dlg__count">{{ draftRules.length }} / {{ ruleLimit }}</span>
-        <button class="cf-dlg__close" aria-label="Close" @click="close">&times;</button>
+        <button class="cf-dlg__close" :aria-label="ml('formatting.close')" @click="close">&times;</button>
       </div>
       <div class="cf-dlg__body">
         <p v-if="!draftRules.length" class="cf-dlg__empty">
-          No rules yet. Add a rule to color cells or rows based on field values.
+          {{ ml('formatting.empty') }}
         </p>
         <div v-else class="cf-dlg__rule-list">
           <div
@@ -36,7 +36,7 @@
                     class="cf-dlg__input cf-dlg__input--mini"
                     :value="getBetweenValue(rule, 0)"
                     @input="setBetweenValue(rule, 0, ($event.target as HTMLInputElement).value)"
-                    placeholder="min"
+                    :placeholder="ml('formatting.minPlaceholder')"
                   />
                   <span class="cf-dlg__sep">–</span>
                   <input
@@ -44,12 +44,12 @@
                     class="cf-dlg__input cf-dlg__input--mini"
                     :value="getBetweenValue(rule, 1)"
                     @input="setBetweenValue(rule, 1, ($event.target as HTMLInputElement).value)"
-                    placeholder="max"
+                    :placeholder="ml('formatting.maxPlaceholder')"
                   />
                 </template>
                 <template v-else-if="isSelectField(rule.fieldId)">
                   <select v-model="rule.value" class="cf-dlg__select cf-dlg__select--value">
-                    <option value="">(pick)</option>
+                    <option value="">{{ ml('formatting.pickOption') }}</option>
                     <option
                       v-for="opt in selectOptionsFor(rule.fieldId)"
                       :key="opt.value"
@@ -77,7 +77,7 @@
               <span v-else class="cf-dlg__no-value">—</span>
             </div>
             <div class="cf-dlg__rule-row cf-dlg__rule-row--secondary">
-              <span class="cf-dlg__label">Color</span>
+              <span class="cf-dlg__label">{{ ml('formatting.color') }}</span>
               <div class="cf-dlg__palette">
                 <button
                   v-for="preset in PALETTE"
@@ -86,7 +86,7 @@
                   class="cf-dlg__swatch"
                   :class="{ 'cf-dlg__swatch--active': rule.style.backgroundColor === preset }"
                   :style="{ backgroundColor: preset }"
-                  :aria-label="`Pick color ${preset}`"
+                  :aria-label="pickColorLabel(preset)"
                   @click="rule.style.backgroundColor = preset"
                 />
                 <input
@@ -100,11 +100,11 @@
               </div>
               <label class="cf-dlg__check-inline">
                 <input type="checkbox" :checked="rule.style.applyToRow === true" @change="rule.style.applyToRow = ($event.target as HTMLInputElement).checked" />
-                <span>Apply to whole row</span>
+                <span>{{ ml('formatting.applyToRow') }}</span>
               </label>
               <label class="cf-dlg__check-inline">
                 <input type="checkbox" :checked="rule.enabled" @change="rule.enabled = ($event.target as HTMLInputElement).checked" />
-                <span>Enabled</span>
+                <span>{{ ml('formatting.enabled') }}</span>
               </label>
             </div>
             <div class="cf-dlg__rule-row cf-dlg__rule-row--actions">
@@ -113,14 +113,14 @@
                 class="cf-dlg__btn cf-dlg__btn--ghost"
                 :disabled="index === 0"
                 @click="moveRule(index, -1)"
-              >&#x25B2; Up</button>
+              >{{ ml('formatting.up') }}</button>
               <button
                 type="button"
                 class="cf-dlg__btn cf-dlg__btn--ghost"
                 :disabled="index === draftRules.length - 1"
                 @click="moveRule(index, 1)"
-              >&#x25BC; Down</button>
-              <button type="button" class="cf-dlg__btn cf-dlg__btn--danger" @click="removeRule(index)">Remove</button>
+              >{{ ml('formatting.down') }}</button>
+              <button type="button" class="cf-dlg__btn cf-dlg__btn--danger" @click="removeRule(index)">{{ ml('action.remove') }}</button>
             </div>
           </div>
         </div>
@@ -129,12 +129,12 @@
           class="cf-dlg__btn cf-dlg__btn--primary"
           :disabled="draftRules.length >= ruleLimit || !selectableFields.length"
           @click="addRule"
-        >+ Add rule</button>
-        <p v-if="!selectableFields.length" class="cf-dlg__hint">Add fields to the sheet to create formatting rules.</p>
+        >{{ ml('formatting.addRule') }}</button>
+        <p v-if="!selectableFields.length" class="cf-dlg__hint">{{ ml('formatting.noFieldsHint') }}</p>
       </div>
       <div class="cf-dlg__footer">
-        <button type="button" class="cf-dlg__btn" @click="close">Cancel</button>
-        <button type="button" class="cf-dlg__btn cf-dlg__btn--primary" :disabled="!dirty" @click="save">Save rules</button>
+        <button type="button" class="cf-dlg__btn" @click="close">{{ ml('action.cancel') }}</button>
+        <button type="button" class="cf-dlg__btn cf-dlg__btn--primary" :disabled="!dirty" @click="save">{{ ml('formatting.saveRules') }}</button>
       </div>
     </div>
   </div>
@@ -142,6 +142,7 @@
 
 <script setup lang="ts">
 import { computed, reactive, ref, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type {
   ConditionalFormattingOperator,
   ConditionalFormattingRule,
@@ -149,6 +150,11 @@ import type {
 } from '../types'
 import { CONDITIONAL_FORMATTING_RULE_LIMIT } from '../types'
 import { extractRulesFromConfig, operatorRequiresValue } from '../utils/conditional-formatting'
+import {
+  formattingOperatorLabel,
+  formattingPickColor,
+  managerLabel,
+} from '../utils/meta-manager-labels'
 
 const props = defineProps<{
   visible: boolean
@@ -164,6 +170,9 @@ const emit = defineEmits<{
 }>()
 
 const ruleLimit = CONDITIONAL_FORMATTING_RULE_LIMIT
+const { isZh } = useLocale()
+const ml = (key: Parameters<typeof managerLabel>[0]) => managerLabel(key, isZh.value)
+const pickColorLabel = (color: string) => formattingPickColor(color, isZh.value)
 
 const PALETTE = [
   '#fce4e4',
@@ -235,51 +244,53 @@ function isNumberOperator(op: ConditionalFormattingOperator): boolean {
 }
 
 function operatorsForField(fieldId: string): Array<{ value: ConditionalFormattingOperator; label: string }> {
+  const fieldType = fieldsById.value.get(fieldId)?.type
+  const label = (value: ConditionalFormattingOperator) => formattingOperatorLabel(value, fieldType, isZh.value)
   const baseEmpty = [
-    { value: 'is_empty' as const, label: 'is empty' },
-    { value: 'is_not_empty' as const, label: 'is not empty' },
+    { value: 'is_empty' as const, label: label('is_empty') },
+    { value: 'is_not_empty' as const, label: label('is_not_empty') },
   ]
   if (isNumberField(fieldId)) {
     return [
-      { value: 'gt', label: '>' },
-      { value: 'gte', label: '>=' },
-      { value: 'lt', label: '<' },
-      { value: 'lte', label: '<=' },
-      { value: 'eq', label: '=' },
-      { value: 'neq', label: '!=' },
-      { value: 'between', label: 'between' },
+      { value: 'gt', label: label('gt') },
+      { value: 'gte', label: label('gte') },
+      { value: 'lt', label: label('lt') },
+      { value: 'lte', label: label('lte') },
+      { value: 'eq', label: label('eq') },
+      { value: 'neq', label: label('neq') },
+      { value: 'between', label: label('between') },
       ...baseEmpty,
     ]
   }
   if (isDateField(fieldId)) {
     return [
-      { value: 'is_today', label: 'is today' },
-      { value: 'is_overdue', label: 'is overdue' },
-      { value: 'is_in_last_n_days', label: 'is in last N days' },
-      { value: 'is_in_next_n_days', label: 'is in next N days' },
+      { value: 'is_today', label: label('is_today') },
+      { value: 'is_overdue', label: label('is_overdue') },
+      { value: 'is_in_last_n_days', label: label('is_in_last_n_days') },
+      { value: 'is_in_next_n_days', label: label('is_in_next_n_days') },
       ...baseEmpty,
     ]
   }
   if (isBooleanField(fieldId)) {
     return [
-      { value: 'is_true', label: 'is checked' },
-      { value: 'is_false', label: 'is unchecked' },
+      { value: 'is_true', label: label('is_true') },
+      { value: 'is_false', label: label('is_false') },
       ...baseEmpty,
     ]
   }
   if (isSelectField(fieldId)) {
     return [
-      { value: 'eq', label: 'is' },
-      { value: 'neq', label: 'is not' },
-      { value: 'contains', label: 'contains' },
+      { value: 'eq', label: label('eq') },
+      { value: 'neq', label: label('neq') },
+      { value: 'contains', label: label('contains') },
       ...baseEmpty,
     ]
   }
   return [
-    { value: 'eq', label: '=' },
-    { value: 'neq', label: '!=' },
-    { value: 'contains', label: 'contains' },
-    { value: 'not_contains', label: 'does not contain' },
+    { value: 'eq', label: label('eq') },
+    { value: 'neq', label: label('neq') },
+    { value: 'contains', label: label('contains') },
+    { value: 'not_contains', label: label('not_contains') },
     ...baseEmpty,
   ]
 }
@@ -367,7 +378,7 @@ function updateHex(rule: ConditionalFormattingRule, key: 'backgroundColor' | 'te
 }
 
 function close() {
-  if (dirty.value && !window.confirm('Discard unsaved formatting rules?')) return
+  if (dirty.value && !window.confirm(ml('view.discardFormattingConfirm'))) return
   emit('close')
 }
 

--- a/apps/web/src/multitable/components/MetaBulkEditDialog.vue
+++ b/apps/web/src/multitable/components/MetaBulkEditDialog.vue
@@ -4,32 +4,32 @@
       <div class="meta-bulk-edit-modal" role="dialog" :aria-label="title">
         <div class="meta-bulk-edit__header">
           <strong>{{ title }}</strong>
-          <button class="meta-bulk-edit__close" aria-label="Close" @click="onCancel">&times;</button>
+          <button class="meta-bulk-edit__close" :aria-label="b('bulk.close')" @click="onCancel">&times;</button>
         </div>
 
         <div class="meta-bulk-edit__body">
           <p class="meta-bulk-edit__hint">{{ summary }}</p>
 
           <label class="meta-bulk-edit__row">
-            <span class="meta-bulk-edit__label">Field</span>
+            <span class="meta-bulk-edit__label">{{ b('bulk.field') }}</span>
             <select
               v-model="selectedFieldId"
               class="meta-bulk-edit__select"
-              aria-label="Field to update"
+              :aria-label="b('bulk.fieldAria')"
               @change="onFieldChange"
             >
-              <option value="">(choose a field)</option>
+              <option value="">{{ b('bulk.chooseField') }}</option>
               <option v-for="field in eligibleFields" :key="field.id" :value="field.id">
                 {{ field.name }}
               </option>
             </select>
           </label>
           <p v-if="!eligibleFields.length" class="meta-bulk-edit__hint meta-bulk-edit__hint--muted">
-            No bulk-editable fields are available for the current selection.
+            {{ b('bulk.noEditableFields') }}
           </p>
 
           <div v-if="mode === 'set' && selectedField" class="meta-bulk-edit__row">
-            <span class="meta-bulk-edit__label">Value</span>
+            <span class="meta-bulk-edit__label">{{ b('bulk.value') }}</span>
             <div class="meta-bulk-edit__value-wrap">
               <!--
                 Intentionally NOT wiring @confirm to onApply: MetaCellEditor
@@ -47,9 +47,9 @@
             </div>
           </div>
           <div v-else-if="mode === 'clear' && selectedField" class="meta-bulk-edit__row">
-            <span class="meta-bulk-edit__label">Action</span>
+            <span class="meta-bulk-edit__label">{{ b('bulk.action') }}</span>
             <span class="meta-bulk-edit__hint">
-              Will clear <strong>{{ selectedField.name }}</strong> on {{ recordIds.length }} record(s).
+              <span>{{ clearHintPrefix }}</span><strong>{{ selectedField.name }}</strong><span>{{ clearHintSuffix }}</span>
             </span>
           </div>
 
@@ -58,7 +58,7 @@
         </div>
 
         <div class="meta-bulk-edit__actions">
-          <button class="meta-bulk-edit__btn" :disabled="busy" @click="onCancel">Cancel</button>
+          <button class="meta-bulk-edit__btn" :disabled="busy" @click="onCancel">{{ b('bulk.cancel') }}</button>
           <button
             class="meta-bulk-edit__btn meta-bulk-edit__btn--primary"
             :disabled="!canSubmit || busy"
@@ -74,7 +74,14 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type { MetaField } from '../types'
+import {
+  bulkClearHintPrefix,
+  bulkClearHintSuffix,
+  bulkEditLabel,
+  bulkSummary,
+} from '../utils/meta-bulk-edit-labels'
 import { isFieldBulkEditable } from '../utils/field-permissions'
 import MetaCellEditor from './cells/MetaCellEditor.vue'
 
@@ -97,6 +104,8 @@ const emit = defineEmits<{
 
 const selectedFieldId = ref<string>('')
 const value = ref<unknown>('')
+const { isZh } = useLocale()
+const b = (key: Parameters<typeof bulkEditLabel>[0]) => bulkEditLabel(key, isZh.value)
 
 const eligibleFields = computed(() =>
   props.fields.filter((field) =>
@@ -112,13 +121,11 @@ const selectedField = computed<MetaField | null>(
   () => eligibleFields.value.find((f) => f.id === selectedFieldId.value) ?? null,
 )
 
-const title = computed(() => (props.mode === 'clear' ? 'Clear field for selected records' : 'Set field for selected records'))
-const summary = computed(() =>
-  props.mode === 'clear'
-    ? `Pick a field to clear on ${props.recordIds.length} selected record(s).`
-    : `Pick a field and a value to set on ${props.recordIds.length} selected record(s).`,
-)
-const submitLabel = computed(() => (props.mode === 'clear' ? 'Clear' : 'Set value'))
+const title = computed(() => b(props.mode === 'clear' ? 'bulk.titleClear' : 'bulk.titleSet'))
+const summary = computed(() => bulkSummary(props.mode, props.recordIds.length, isZh.value))
+const clearHintPrefix = computed(() => bulkClearHintPrefix(props.recordIds.length, isZh.value))
+const clearHintSuffix = computed(() => bulkClearHintSuffix(props.recordIds.length, isZh.value))
+const submitLabel = computed(() => b(props.mode === 'clear' ? 'bulk.submitClear' : 'bulk.submitSet'))
 const canSubmit = computed(() => Boolean(selectedField.value) && (props.mode === 'clear' || hasMeaningfulValue(value.value)))
 
 watch(

--- a/apps/web/src/multitable/utils/meta-bulk-edit-labels.ts
+++ b/apps/web/src/multitable/utils/meta-bulk-edit-labels.ts
@@ -1,0 +1,96 @@
+// Bulk-edit dialog chrome string table (T3E-3).
+//
+// Scope: MetaBulkEditDialog.vue and Workbench-owned bulk edit result fallbacks.
+// Field names, record ids, backend/runtime errors, and failure reasons stay raw.
+
+export type BulkEditMode = 'set' | 'clear'
+
+export type MetaBulkEditLabelKey =
+  | 'bulk.titleSet'
+  | 'bulk.titleClear'
+  | 'bulk.field'
+  | 'bulk.fieldAria'
+  | 'bulk.chooseField'
+  | 'bulk.noEditableFields'
+  | 'bulk.value'
+  | 'bulk.action'
+  | 'bulk.close'
+  | 'bulk.cancel'
+  | 'bulk.submitSet'
+  | 'bulk.submitClear'
+  | 'bulk.errorFailed'
+
+const LABELS: Record<MetaBulkEditLabelKey, { en: string; zh: string }> = {
+  'bulk.titleSet': { en: 'Set field for selected records', zh: '为所选记录设置字段' },
+  'bulk.titleClear': { en: 'Clear field for selected records', zh: '清空所选记录的字段' },
+  'bulk.field': { en: 'Field', zh: '字段' },
+  'bulk.fieldAria': { en: 'Field to update', zh: '要更新的字段' },
+  'bulk.chooseField': { en: '(choose a field)', zh: '（选择字段）' },
+  'bulk.noEditableFields': {
+    en: 'No bulk-editable fields are available for the current selection.',
+    zh: '当前选择没有可批量编辑的字段。',
+  },
+  'bulk.value': { en: 'Value', zh: '值' },
+  'bulk.action': { en: 'Action', zh: '操作' },
+  'bulk.close': { en: 'Close', zh: '关闭' },
+  'bulk.cancel': { en: 'Cancel', zh: '取消' },
+  'bulk.submitSet': { en: 'Set value', zh: '设置值' },
+  'bulk.submitClear': { en: 'Clear', zh: '清空' },
+  'bulk.errorFailed': { en: 'Bulk edit failed', zh: '批量编辑失败' },
+}
+
+export function bulkEditLabel(key: MetaBulkEditLabelKey, isZh: boolean): string {
+  const entry = LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+function recordWord(count: number): string {
+  return count === 1 ? 'record' : 'records'
+}
+
+function modePast(mode: BulkEditMode): string {
+  return mode === 'clear' ? 'cleared' : 'updated'
+}
+
+export function bulkSummary(mode: BulkEditMode, count: number, isZh: boolean): string {
+  if (mode === 'clear') {
+    return isZh
+      ? `选择要在 ${count} 条所选记录中清空的字段。`
+      : `Pick a field to clear on ${count} selected ${recordWord(count)}.`
+  }
+  return isZh
+    ? `选择字段和值，应用到 ${count} 条所选记录。`
+    : `Pick a field and a value to set on ${count} selected ${recordWord(count)}.`
+}
+
+export function bulkClearHintPrefix(count: number, isZh: boolean): string {
+  return isZh ? `将在 ${count} 条记录中清空 ` : 'Will clear '
+}
+
+export function bulkClearHintSuffix(count: number, isZh: boolean): string {
+  return isZh ? '。' : ` on ${count} ${recordWord(count)}.`
+}
+
+export function bulkSuccess(count: number, mode: BulkEditMode, isZh: boolean): string {
+  if (isZh) return mode === 'clear' ? `已清空 ${count} 条记录` : `已更新 ${count} 条记录`
+  return `${count} ${recordWord(count)} ${modePast(mode)}`
+}
+
+export function bulkPartialSuccess(updated: number, requested: number, mode: BulkEditMode, isZh: boolean): string {
+  if (isZh) return `${requested} 条记录中已${mode === 'clear' ? '清空' : '更新'} ${updated} 条`
+  return `${updated} of ${requested} ${recordWord(requested)} ${modePast(mode)}`
+}
+
+export function bulkFailure(failed: number, requested: number, sampleFailures: string, isZh: boolean): string {
+  const detail = sampleFailures ? (isZh ? `（${sampleFailures}）` : ` (${sampleFailures})`) : ''
+  return isZh
+    ? `${requested} 条记录中有 ${failed} 条失败${detail}`
+    : `${failed} of ${requested} ${recordWord(requested)} failed${detail}`
+}
+
+export function bulkVersionConflict(message: string, isZh: boolean): string {
+  const detail = message ? (isZh ? `（${message}）` : ` (${message})`) : ''
+  return isZh
+    ? `部分记录已在其他位置修改。请重新加载后重试。${detail}`
+    : `Some records were modified elsewhere. Reload and retry.${detail}`
+}

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -14,6 +14,12 @@ export type MetaManagerLabelKey =
   | 'action.cancel' | 'action.reloadLatest' | 'action.dismiss'
   | 'action.add' | 'action.addOption' | 'action.save' | 'action.remove'
   | 'action.clear' | 'action.apply'
+  | 'formatting.title' | 'formatting.ariaTitle' | 'formatting.close'
+  | 'formatting.empty' | 'formatting.minPlaceholder'
+  | 'formatting.maxPlaceholder' | 'formatting.pickOption'
+  | 'formatting.color' | 'formatting.applyToRow' | 'formatting.enabled'
+  | 'formatting.up' | 'formatting.down' | 'formatting.addRule'
+  | 'formatting.noFieldsHint' | 'formatting.saveRules'
   | 'field.title' | 'field.empty' | 'field.options' | 'field.optionValue'
   | 'field.targetSheet' | 'field.selectSheet' | 'field.limitSingleLinkedRecord'
   | 'field.personHint' | 'field.limitSinglePerson'
@@ -108,6 +114,25 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'action.remove': { en: 'Remove', zh: '移除' },
   'action.clear': { en: 'Clear', zh: '清除' },
   'action.apply': { en: 'Apply', zh: '应用' },
+
+  'formatting.title': { en: 'Conditional formatting', zh: '条件格式' },
+  'formatting.ariaTitle': { en: 'Conditional formatting rules', zh: '条件格式规则' },
+  'formatting.close': { en: 'Close', zh: '关闭' },
+  'formatting.empty': {
+    en: 'No rules yet. Add a rule to color cells or rows based on field values.',
+    zh: '暂无规则。添加规则后，可根据字段值为单元格或整行着色。',
+  },
+  'formatting.minPlaceholder': { en: 'min', zh: '最小值' },
+  'formatting.maxPlaceholder': { en: 'max', zh: '最大值' },
+  'formatting.pickOption': { en: '(pick)', zh: '（选择）' },
+  'formatting.color': { en: 'Color', zh: '颜色' },
+  'formatting.applyToRow': { en: 'Apply to whole row', zh: '应用到整行' },
+  'formatting.enabled': { en: 'Enabled', zh: '启用' },
+  'formatting.up': { en: '\u25B2 Up', zh: '\u25B2 上移' },
+  'formatting.down': { en: '\u25BC Down', zh: '\u25BC 下移' },
+  'formatting.addRule': { en: '+ Add rule', zh: '+ 添加规则' },
+  'formatting.noFieldsHint': { en: 'Add fields to the sheet to create formatting rules.', zh: '请先向 Sheet 添加字段，再创建格式规则。' },
+  'formatting.saveRules': { en: 'Save rules', zh: '保存规则' },
 
   'field.title': { en: 'Manage Fields', zh: '管理字段' },
   'field.empty': { en: 'No fields defined', zh: '暂无字段' },
@@ -369,4 +394,30 @@ export function filterOperatorLabel(value: string, fallback: string, isZh: boole
     case 'lessEqual': return '\u2264'
     default: return fallback
   }
+}
+
+export function formattingOperatorLabel(operator: string, fieldType: string | undefined, isZh: boolean): string {
+  const isSelectLike = fieldType === 'select' || fieldType === 'multiSelect'
+  if (operator === 'gt') return '>'
+  if (operator === 'gte') return '>='
+  if (operator === 'lt') return '<'
+  if (operator === 'lte') return '<='
+  if (operator === 'eq') return isSelectLike ? (isZh ? '是' : 'is') : '='
+  if (operator === 'neq') return isSelectLike ? (isZh ? '不是' : 'is not') : '!='
+  if (operator === 'between') return isZh ? '介于' : 'between'
+  if (operator === 'contains') return isZh ? '包含' : 'contains'
+  if (operator === 'not_contains') return isZh ? '不包含' : 'does not contain'
+  if (operator === 'is_empty') return isZh ? '为空' : 'is empty'
+  if (operator === 'is_not_empty') return isZh ? '不为空' : 'is not empty'
+  if (operator === 'is_today') return isZh ? '是今天' : 'is today'
+  if (operator === 'is_overdue') return isZh ? '已逾期' : 'is overdue'
+  if (operator === 'is_in_last_n_days') return isZh ? '最近 N 天内' : 'is in last N days'
+  if (operator === 'is_in_next_n_days') return isZh ? '未来 N 天内' : 'is in next N days'
+  if (operator === 'is_true') return isZh ? '已勾选' : 'is checked'
+  if (operator === 'is_false') return isZh ? '未勾选' : 'is unchecked'
+  return operator
+}
+
+export function formattingPickColor(color: string, isZh: boolean): string {
+  return isZh ? `选择颜色 ${color}` : `Pick color ${color}`
 }

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -429,6 +429,13 @@ import {
   recordNotFound as fmtRecordNotFound,
 } from '../utils/workbench-labels'
 import { commentLabel } from '../utils/meta-comment-labels'
+import {
+  bulkFailure as fmtBulkFailure,
+  bulkPartialSuccess as fmtBulkPartialSuccess,
+  bulkSuccess as fmtBulkSuccess,
+  bulkVersionConflict as fmtBulkVersionConflict,
+  bulkEditLabel,
+} from '../utils/meta-bulk-edit-labels'
 import type {
   LinkedRecordSummary,
   MetaAttachment,
@@ -2568,14 +2575,14 @@ async function onBulkEditApply(payload: { mode: 'set' | 'clear'; fieldId: string
         .slice(0, 3)
         .map((failure) => `${failure.recordId}: ${failure.reason}`)
         .join('; ')
-      bulkEditDialog.error = `${result.failed.length} of ${requestedCount} record(s) failed${sampleFailures ? ` (${sampleFailures})` : ''}`
+      bulkEditDialog.error = fmtBulkFailure(result.failed.length, requestedCount, sampleFailures, isZh.value)
       if (updatedCount > 0) {
-        bulkEditDialog.resultMessage = `${updatedCount} of ${requestedCount} record(s) ${payload.mode === 'clear' ? 'cleared' : 'updated'}`
+        bulkEditDialog.resultMessage = fmtBulkPartialSuccess(updatedCount, requestedCount, payload.mode, isZh.value)
       }
     } else if (updatedCount < requestedCount) {
-      bulkEditDialog.resultMessage = `${updatedCount} of ${requestedCount} record(s) updated`
+      bulkEditDialog.resultMessage = fmtBulkPartialSuccess(updatedCount, requestedCount, payload.mode, isZh.value)
     } else {
-      bulkEditDialog.resultMessage = `${updatedCount} record(s) ${payload.mode === 'clear' ? 'cleared' : 'updated'}`
+      bulkEditDialog.resultMessage = fmtBulkSuccess(updatedCount, payload.mode, isZh.value)
     }
     if (updatedCount > 0 && bulkEditDialog.resultMessage) showSuccess(bulkEditDialog.resultMessage)
     if (result.failed.length > 0 && bulkEditDialog.error) showError(bulkEditDialog.error)
@@ -2583,9 +2590,9 @@ async function onBulkEditApply(payload: { mode: 'set' | 'clear'; fieldId: string
       bulkEditDialog.visible = false
     }
   } catch (e: any) {
-    const message = e?.message ?? 'Bulk edit failed'
+    const message = e?.message ?? bulkEditLabel('bulk.errorFailed', isZh.value)
     const errorMessage = e?.code === 'VERSION_CONFLICT'
-      ? `Some records were modified elsewhere. Reload and retry. (${message})`
+      ? fmtBulkVersionConflict(message, isZh.value)
       : message
     bulkEditDialog.error = errorMessage
     showError(errorMessage)

--- a/apps/web/tests/conditional-formatting-dialog-i18n.spec.ts
+++ b/apps/web/tests/conditional-formatting-dialog-i18n.spec.ts
@@ -1,0 +1,180 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+
+import { useLocale } from '../src/composables/useLocale'
+import ConditionalFormattingDialog from '../src/multitable/components/ConditionalFormattingDialog.vue'
+import type { ConditionalFormattingRule, MetaField } from '../src/multitable/types'
+
+const fields: MetaField[] = [
+  { id: 'fld_amount', name: 'Amount', type: 'number', property: {} },
+  { id: 'fld_title', name: 'Title', type: 'string', property: {} },
+  {
+    id: 'fld_status',
+    name: 'Status',
+    type: 'select',
+    options: [{ value: 'Pending' }, { value: 'Done' }],
+    property: {},
+  },
+  {
+    id: 'fld_tags',
+    name: 'Tags',
+    type: 'multiSelect',
+    options: [{ value: '未处理' }, { value: 'Escalated' }],
+    property: {},
+  },
+  { id: 'fld_done', name: 'Done', type: 'boolean', property: {} },
+  { id: 'fld_due', name: 'Due', type: 'date', property: {} },
+]
+
+function rule(partial: Partial<ConditionalFormattingRule>): ConditionalFormattingRule {
+  return {
+    id: 'rule_1',
+    order: 0,
+    fieldId: 'fld_amount',
+    operator: 'between',
+    value: [1, 5],
+    style: { backgroundColor: '#fce4e4', applyToRow: true },
+    enabled: true,
+    ...partial,
+  }
+}
+
+function mountDialog(propsOverride: Partial<{
+  visible: boolean
+  fields: MetaField[]
+  viewConfig: Record<string, unknown>
+  onClose: () => void
+  onSave: (rules: ConditionalFormattingRule[]) => void
+  'onUpdate:dirty': (dirty: boolean) => void
+}> = {}) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const props = {
+    visible: true,
+    fields,
+    viewConfig: {
+      conditionalFormattingRules: [
+        rule({ id: 'rule_number', order: 0, fieldId: 'fld_amount', operator: 'between', value: [1, 5] }),
+        rule({ id: 'rule_text', order: 1, fieldId: 'fld_title', operator: 'contains', value: 'Alpha' }),
+        rule({ id: 'rule_select', order: 2, fieldId: 'fld_status', operator: 'eq', value: 'Pending' }),
+        rule({ id: 'rule_multi', order: 3, fieldId: 'fld_tags', operator: 'contains', value: '未处理' }),
+        rule({ id: 'rule_bool', order: 4, fieldId: 'fld_done', operator: 'is_true', value: undefined }),
+        rule({ id: 'rule_date', order: 5, fieldId: 'fld_due', operator: 'is_today', value: undefined }),
+      ],
+    },
+    onClose: vi.fn(),
+    onSave: vi.fn(),
+    'onUpdate:dirty': vi.fn(),
+    ...propsOverride,
+  }
+  const app: App = createApp({ render: () => h(ConditionalFormattingDialog, props) })
+  app.mount(container)
+  return { app, container, props }
+}
+
+async function flush() {
+  await nextTick()
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await nextTick()
+}
+
+describe('ConditionalFormattingDialog i18n', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    useLocale().setLocale('en')
+    vi.restoreAllMocks()
+  })
+
+  it('renders conditional-formatting chrome in zh-CN while preserving raw fields/options/colors', async () => {
+    useLocale().setLocale('zh-CN')
+    const { app, container } = mountDialog()
+    await flush()
+
+    expect(container.querySelector('.cf-dlg')?.getAttribute('aria-label')).toBe('条件格式规则')
+    expect(container.textContent).toContain('条件格式')
+    expect(container.querySelector('.cf-dlg__close')?.getAttribute('aria-label')).toBe('关闭')
+    expect(container.textContent).toContain('颜色')
+    expect(container.textContent).toContain('应用到整行')
+    expect(container.textContent).toContain('启用')
+    expect(container.textContent).toContain('▲ 上移')
+    expect(container.textContent).toContain('▼ 下移')
+    expect(container.textContent).toContain('+ 添加规则')
+    expect(container.textContent).toContain('取消')
+    expect(container.textContent).toContain('保存规则')
+
+    expect(container.textContent).toContain('Amount')
+    expect(container.textContent).toContain('Status')
+    expect(container.textContent).toContain('Pending')
+    expect(container.textContent).toContain('未处理')
+    expect(container.querySelector('.cf-dlg__swatch')?.getAttribute('aria-label')).toBe('选择颜色 #fce4e4')
+    expect(container.querySelector('.cf-dlg__hex')?.getAttribute('placeholder')).toBe('#RRGGBB')
+
+    const numberInputs = Array.from(container.querySelectorAll('.cf-dlg__input--mini')) as HTMLInputElement[]
+    expect(numberInputs.map((input) => input.getAttribute('placeholder'))).toEqual(['最小值', '最大值'])
+
+    const optionLabels = Array.from(container.querySelectorAll('option')).map((option) => option.textContent ?? '')
+    expect(optionLabels).toContain('=')
+    expect(optionLabels).toContain('介于')
+    expect(optionLabels).toContain('包含')
+    expect(optionLabels).toContain('是')
+    expect(optionLabels).toContain('已勾选')
+    expect(optionLabels).toContain('是今天')
+
+    app.unmount()
+  })
+
+  it('preserves English conditional-formatting chrome by default', async () => {
+    const { app, container } = mountDialog()
+    await flush()
+
+    expect(container.querySelector('.cf-dlg')?.getAttribute('aria-label')).toBe('Conditional formatting rules')
+    expect(container.textContent).toContain('Conditional formatting')
+    expect(container.textContent).toContain('Apply to whole row')
+    expect(container.textContent).toContain('▲ Up')
+    expect(container.textContent).toContain('▼ Down')
+    expect(container.querySelector('.cf-dlg__swatch')?.getAttribute('aria-label')).toBe('Pick color #fce4e4')
+
+    const optionLabels = Array.from(container.querySelectorAll('option')).map((option) => option.textContent ?? '')
+    expect(optionLabels).toContain('between')
+    expect(optionLabels).toContain('contains')
+    expect(optionLabels).toContain('is')
+
+    app.unmount()
+  })
+
+  it('uses the localized dirty-confirm message without adding aria attributes', async () => {
+    useLocale().setLocale('zh-CN')
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const { app, container, props } = mountDialog()
+    await flush()
+
+    const applyToRow = container.querySelector('.cf-dlg__check-inline input[type=checkbox]') as HTMLInputElement
+    applyToRow.checked = false
+    applyToRow.dispatchEvent(new Event('change', { bubbles: true }))
+    await flush()
+
+    const close = container.querySelector('.cf-dlg__close') as HTMLButtonElement
+    close.click()
+    await flush()
+
+    expect(confirmSpy).toHaveBeenCalledWith('放弃未保存的格式规则吗？')
+    expect(props.onClose).not.toHaveBeenCalled()
+    expect(container.querySelectorAll('[aria-label]')).toHaveLength(50)
+
+    app.unmount()
+  })
+
+  it('renders empty/no-field states in zh-CN', async () => {
+    useLocale().setLocale('zh-CN')
+    const { app, container } = mountDialog({
+      fields: [],
+      viewConfig: { conditionalFormattingRules: [] },
+    })
+    await flush()
+
+    expect(container.textContent).toContain('暂无规则。添加规则后，可根据字段值为单元格或整行着色。')
+    expect(container.textContent).toContain('请先向 Sheet 添加字段，再创建格式规则。')
+
+    app.unmount()
+  })
+})

--- a/apps/web/tests/meta-bulk-edit-labels.spec.ts
+++ b/apps/web/tests/meta-bulk-edit-labels.spec.ts
@@ -1,0 +1,56 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  bulkClearHintPrefix,
+  bulkClearHintSuffix,
+  bulkEditLabel,
+  bulkFailure,
+  bulkPartialSuccess,
+  bulkSuccess,
+  bulkSummary,
+  bulkVersionConflict,
+} from '../src/multitable/utils/meta-bulk-edit-labels'
+
+describe('meta-bulk-edit-labels', () => {
+  it('returns static bulk edit labels in en and zh', () => {
+    expect(bulkEditLabel('bulk.titleSet', false)).toBe('Set field for selected records')
+    expect(bulkEditLabel('bulk.titleSet', true)).toBe('为所选记录设置字段')
+    expect(bulkEditLabel('bulk.noEditableFields', true)).toBe('当前选择没有可批量编辑的字段。')
+  })
+
+  it('formats set and clear summaries with real English pluralization', () => {
+    expect(bulkSummary('set', 1, false)).toBe('Pick a field and a value to set on 1 selected record.')
+    expect(bulkSummary('clear', 3, false)).toBe('Pick a field to clear on 3 selected records.')
+    expect(bulkSummary('set', 3, true)).toBe('选择字段和值，应用到 3 条所选记录。')
+    expect(bulkSummary('clear', 3, true)).toBe('选择要在 3 条所选记录中清空的字段。')
+  })
+
+  it('keeps clear-hint prefix and suffix whitespace byte-exact', () => {
+    expect(bulkClearHintPrefix(3, false)).toBe('Will clear ')
+    expect(bulkClearHintSuffix(3, false)).toBe(' on 3 records.')
+    expect(bulkClearHintPrefix(3, true)).toBe('将在 3 条记录中清空 ')
+    expect(bulkClearHintSuffix(3, true)).toBe('。')
+  })
+
+  it('formats success and partial-success messages', () => {
+    expect(bulkSuccess(1, 'set', false)).toBe('1 record updated')
+    expect(bulkSuccess(3, 'clear', false)).toBe('3 records cleared')
+    expect(bulkSuccess(3, 'clear', true)).toBe('已清空 3 条记录')
+    expect(bulkPartialSuccess(2, 3, 'set', false)).toBe('2 of 3 records updated')
+    expect(bulkPartialSuccess(2, 3, 'clear', true)).toBe('3 条记录中已清空 2 条')
+  })
+
+  it('formats failure details without empty parentheses', () => {
+    expect(bulkFailure(1, 3, 'rec_1: conflict', false)).toBe('1 of 3 records failed (rec_1: conflict)')
+    expect(bulkFailure(1, 3, '', false)).toBe('1 of 3 records failed')
+    expect(bulkFailure(1, 3, 'rec_1: conflict', true)).toBe('3 条记录中有 1 条失败（rec_1: conflict）')
+    expect(bulkFailure(1, 3, '', true)).toBe('3 条记录中有 1 条失败')
+  })
+
+  it('formats version conflicts without empty parentheses', () => {
+    expect(bulkVersionConflict('v2', false)).toBe('Some records were modified elsewhere. Reload and retry. (v2)')
+    expect(bulkVersionConflict('', false)).toBe('Some records were modified elsewhere. Reload and retry.')
+    expect(bulkVersionConflict('v2', true)).toBe('部分记录已在其他位置修改。请重新加载后重试。（v2）')
+    expect(bulkVersionConflict('', true)).toBe('部分记录已在其他位置修改。请重新加载后重试。')
+  })
+})

--- a/apps/web/tests/multitable-bulk-edit-dialog.spec.ts
+++ b/apps/web/tests/multitable-bulk-edit-dialog.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
 import MetaBulkEditDialog from '../src/multitable/components/MetaBulkEditDialog.vue'
 import type { MetaField } from '../src/multitable/types'
 
@@ -60,6 +61,7 @@ function mountDialog(propsOverride: Partial<{
 describe('MetaBulkEditDialog', () => {
   afterEach(() => {
     document.body.innerHTML = ''
+    useLocale().setLocale('en')
     vi.restoreAllMocks()
   })
 
@@ -75,6 +77,46 @@ describe('MetaBulkEditDialog', () => {
     const { app, root } = mountDialog({ mode: 'clear' })
     await nextTick()
     expect(root.querySelector('.meta-bulk-edit__header strong')?.textContent).toBe('Clear field for selected records')
+    app.unmount()
+  })
+
+  it('renders bulk edit chrome in zh-CN while preserving raw field names', async () => {
+    useLocale().setLocale('zh-CN')
+    const { app, root } = mountDialog({ mode: 'clear' })
+    await nextTick()
+
+    expect(root.querySelector('.meta-bulk-edit__header strong')?.textContent).toBe('清空所选记录的字段')
+    expect(root.querySelector('.meta-bulk-edit__close')?.getAttribute('aria-label')).toBe('关闭')
+    expect(root.textContent).toContain('字段')
+    expect(root.textContent).toContain('（选择字段）')
+    expect(root.textContent).toContain('选择要在 3 条所选记录中清空的字段。')
+
+    const select = root.querySelector('.meta-bulk-edit__select') as HTMLSelectElement
+    expect(select.getAttribute('aria-label')).toBe('要更新的字段')
+    select.value = 'fld_notes'
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    expect(root.textContent).toContain('操作')
+    expect(root.textContent).toContain('将在 3 条记录中清空 Notes。')
+    expect(root.textContent).toContain('取消')
+    expect(root.textContent).toContain('清空')
+    app.unmount()
+  })
+
+  it('preserves English bulk edit chrome by default', async () => {
+    const { app, root } = mountDialog({ mode: 'clear' })
+    await nextTick()
+
+    expect(root.querySelector('.meta-bulk-edit__header strong')?.textContent).toBe('Clear field for selected records')
+    expect(root.querySelector('.meta-bulk-edit__close')?.getAttribute('aria-label')).toBe('Close')
+
+    const select = root.querySelector('.meta-bulk-edit__select') as HTMLSelectElement
+    select.value = 'fld_notes'
+    select.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    expect(root.textContent).toContain('Will clear Notes on 3 records.')
     app.unmount()
   })
 

--- a/apps/web/tests/multitable-manager-panels-i18n.spec.ts
+++ b/apps/web/tests/multitable-manager-panels-i18n.spec.ts
@@ -4,6 +4,11 @@ import { useLocale } from '../src/composables/useLocale'
 import MetaFieldManager from '../src/multitable/components/MetaFieldManager.vue'
 import MetaFieldValidationPanel from '../src/multitable/components/MetaFieldValidationPanel.vue'
 import MetaViewManager from '../src/multitable/components/MetaViewManager.vue'
+import {
+  formattingOperatorLabel,
+  formattingPickColor,
+  managerLabel,
+} from '../src/multitable/utils/meta-manager-labels'
 
 function mount(render: () => ReturnType<typeof h>) {
   const container = document.createElement('div')
@@ -136,5 +141,19 @@ describe('multitable manager panel i18n', () => {
     expect(container.querySelector('.meta-view-mgr__action[title="Configure"]')).toBeTruthy()
 
     app.unmount()
+  })
+
+  it('formats conditional-formatting manager labels and preserves raw values', () => {
+    expect(managerLabel('formatting.title', false)).toBe('Conditional formatting')
+    expect(managerLabel('formatting.title', true)).toBe('条件格式')
+    expect(formattingOperatorLabel('eq', 'select', false)).toBe('is')
+    expect(formattingOperatorLabel('eq', 'multiSelect', true)).toBe('是')
+    expect(formattingOperatorLabel('eq', 'number', true)).toBe('=')
+    expect(formattingOperatorLabel('between', 'number', true)).toBe('介于')
+    expect(formattingOperatorLabel('contains', 'string', true)).toBe('包含')
+    expect(formattingOperatorLabel('is_true', 'boolean', true)).toBe('已勾选')
+    expect(formattingOperatorLabel('is_today', 'date', true)).toBe('是今天')
+    expect(formattingOperatorLabel('unknown_operator', 'string', true)).toBe('unknown_operator')
+    expect(formattingPickColor('#fce4e4', true)).toBe('选择颜色 #fce4e4')
   })
 })

--- a/docs/development/multitable-t3e3-bulk-formatting-i18n-design-20260521.md
+++ b/docs/development/multitable-t3e3-bulk-formatting-i18n-design-20260521.md
@@ -1,0 +1,343 @@
+# T3E-3 Bulk Edit + Conditional Formatting i18n Design
+
+Date: 2026-05-21
+Branch: docs/multitable-t3e3-bulk-formatting-i18n-design-20260521
+Status: design draft; no implementation yet
+
+## 1. Decision Summary
+
+T3E-3 localizes the remaining dialog-level multitable chrome that is still visible after T3E-2:
+
+| Decision | Choice | Reason |
+| --- | --- | --- |
+| Scope | `MetaBulkEditDialog.vue` + Workbench `bulkEditDialog.*` parent messages + `ConditionalFormattingDialog.vue` | These are the two T3E-3 residual surfaces; bulk dialog parent-generated success/error messages must ship with the dialog |
+| PR shape | One PR | Two dialogs plus parent helpers are still smaller than T3D and share the same "dialog residual" verification surface |
+| Bulk label home | New `meta-bulk-edit-labels.ts` with `bulk.*` keys/helpers | `MetaBulkEditDialog` is a modal overlay like `MetaImportModal`, not inline grid chrome; per-dialog module keeps discovery clear and avoids bloating `meta-core-labels.ts` |
+| Conditional-formatting label home | Extend `meta-manager-labels.ts` with `formatting.*` keys/helpers | Conditional formatting is opened from `MetaViewManager`; `view.discardFormattingConfirm` already lives in manager labels |
+| Shared manager actions | Reuse `managerLabel('action.cancel'/'action.remove')` only inside `ConditionalFormattingDialog.vue` | Stays within manager domain; do not redeclare manager shared action keys |
+| Raw values | Preserve field names, select option values, record IDs, failure reasons, backend/runtime `e.message`, color hex values | User/authored/runtime data must not be translated |
+| A11y | Localize existing `aria-label`/placeholder text; do not add new a11y attributes | Localizing text that screen readers already read is required i18n behavior; the boundary forbids adding new a11y attributes or changing interaction semantics |
+| Deferred | T3D automation and final audit remain deferred | No automation/rule-editor/log-viewer work in this PR |
+
+## 2. Files In Scope
+
+Implementation:
+
+| File | Planned change |
+| --- | --- |
+| `apps/web/src/multitable/utils/meta-bulk-edit-labels.ts` | New typed EN/ZH label module for `MetaBulkEditDialog.vue` and Workbench parent-generated bulk result messages |
+| `apps/web/src/multitable/utils/meta-manager-labels.ts` | Add `formatting.*` keys and conditional-formatting operator/color helpers |
+| `apps/web/src/multitable/components/MetaBulkEditDialog.vue` | Use `useLocale()` + `bulkEditLabel`/bulk helpers; localize visible text and existing aria labels |
+| `apps/web/src/multitable/views/MultitableWorkbench.vue` | Replace parent-generated `bulkEditDialog.error/resultMessage` strings with bulk helpers |
+| `apps/web/src/multitable/components/ConditionalFormattingDialog.vue` | Use `useLocale()` + `managerLabel`/formatting helpers; localize visible text, placeholders, existing aria labels, and dirty confirm |
+
+Tests/docs:
+
+| File | Planned change |
+| --- | --- |
+| `apps/web/tests/meta-bulk-edit-labels.spec.ts` | New helper/key spec for bulk edit labels, whitespace-sensitive helpers, and raw-boundary behavior |
+| `apps/web/tests/multitable-manager-panels-i18n.spec.ts` | Add conditional-formatting manager helper tests or render smoke if cheap |
+| `apps/web/tests/multitable-bulk-edit-dialog.spec.ts` | Preserve EN baseline and add zh-CN render/raw/a11y assertions |
+| `apps/web/tests/conditional-formatting-dialog-i18n.spec.ts` | New direct render spec for zh-CN/EN conditional-formatting dialog chrome |
+| `docs/development/multitable-t3e3-bulk-formatting-i18n-verification-20260521.md` | Verification report after implementation |
+
+Out of scope:
+
+| Surface | Reason |
+| --- | --- |
+| T3D automation manager/rule editor/log viewer | Larger rule-domain surface; requires separate design MD |
+| Final multitable i18n audit | Best after T3D and this slice land |
+| Backend/contracts/migrations/attendance/K3 | K3 PoC stage-1 lock; this is frontend i18n only |
+
+## 3. Preflight Grep
+
+Before implementation, run:
+
+```bash
+rg -n "Set field for selected records|Clear field for selected records|Pick a field|No bulk-editable|Field to update|choose a field|Will clear|Set value|Bulk edit failed|Some records were modified elsewhere|record\\(s\\) failed|record\\(s\\) updated|record\\(s\\) cleared|Conditional formatting rules|Conditional formatting|No rules yet|Add a rule|Color|Apply to whole row|Enabled|Up|Down|Remove|Save rules|Discard unsaved formatting rules|between|is today|is overdue|is in last N days|is in next N days|is checked|is unchecked|does not contain|is empty|is not empty|\\(pick\\)|Pick color|min|max|#RRGGBB" \
+  apps/web/src/multitable apps/web/tests
+```
+
+Acceptance:
+
+| Category | Expected result |
+| --- | --- |
+| T3E-3 call-sites | Every planned source string maps to a real call-site in `MetaBulkEditDialog.vue`, `MultitableWorkbench.vue`, or `ConditionalFormattingDialog.vue` |
+| Existing tests | EN baseline assertions updated, not deleted without replacement |
+| Raw values | Field names, option values, color values, record IDs, and failure reasons stay raw |
+| Deferred | Any remaining hits after implementation must be either label definitions/tests or explicitly deferred |
+
+Reuse-key reachability check:
+
+```bash
+rg -n "'view\\.discardFormattingConfirm'|'action\\.conditionalFormatting'|'action\\.cancel'|'action\\.remove'" \
+  apps/web/src/multitable/utils/meta-manager-labels.ts
+```
+
+These four keys must exist before implementation and should be cited in the verification MD:
+
+| Key | Purpose |
+| --- | --- |
+| `action.conditionalFormatting` | Confirms T3C-1 already placed conditional formatting in manager label domain |
+| `view.discardFormattingConfirm` | Dirty confirm string already exists and should be reused |
+| `action.cancel` | Shared manager action reused by `ConditionalFormattingDialog.vue` |
+| `action.remove` | Shared manager action reused by `ConditionalFormattingDialog.vue` |
+
+## 4. Label Module Plan
+
+### 4.1 `meta-bulk-edit-labels.ts` Bulk Keys
+
+Add a new scoped module because `MetaBulkEditDialog` is structurally closer to `MetaImportModal` than to inline grid/cell chrome:
+
+- It is a modal overlay invoked by Workbench.
+- It operates on grid records but is visually independent from the grid table.
+- Future readers will naturally look for `meta-bulk-edit-labels.ts`, matching the existing `meta-import-labels.ts` pattern.
+- `meta-core-labels.ts` remains the cross-surface core-table module for toolbar/grid/cell-editor/presence primitives, not an arbitrary home for every grid-related modal.
+
+Module shape:
+
+```ts
+export type MetaBulkEditLabelKey = ...
+export function bulkEditLabel(key: MetaBulkEditLabelKey, isZh: boolean): string
+```
+
+| Key/helper | EN | zh-CN | Notes |
+| --- | --- | --- | --- |
+| `bulk.titleSet` | `Set field for selected records` | `为所选记录设置字段` | Dialog title + aria label |
+| `bulk.titleClear` | `Clear field for selected records` | `清空所选记录的字段` | Dialog title + aria label |
+| `bulk.field` | `Field` | `字段` | Label |
+| `bulk.fieldAria` | `Field to update` | `要更新的字段` | Existing aria-label |
+| `bulk.chooseField` | `(choose a field)` | `（选择字段）` | Empty option |
+| `bulk.noEditableFields` | `No bulk-editable fields are available for the current selection.` | `当前选择没有可批量编辑的字段。` | Empty state |
+| `bulk.value` | `Value` | `值` | Set mode label |
+| `bulk.action` | `Action` | `操作` | Clear mode label |
+| `bulk.close` | `Close` | `关闭` | Existing close-button aria-label |
+| `bulk.cancel` | `Cancel` | `取消` | Bulk dialog is not a manager panel, so use scoped key |
+| `bulk.submitSet` | `Set value` | `设置值` | Primary button, set mode |
+| `bulk.submitClear` | `Clear` | `清空` | Primary button, clear mode |
+| `bulk.errorFailed` | `Bulk edit failed` | `批量编辑失败` | Fallback only; `e.message` stays raw first |
+
+Bulk helpers:
+
+| Helper | EN | zh-CN | Raw boundary |
+| --- | --- | --- | --- |
+| `bulkSummary(mode: 'set' | 'clear', count: number, isZh: boolean)` | `Pick a field and a value to set on 3 selected records.` / `Pick a field to clear on 3 selected records.` | `选择字段和值，应用到 3 条所选记录。` / `选择要在 3 条所选记录中清空的字段。` | Count only |
+| `bulkClearHintPrefix(count: number, isZh: boolean)` + `bulkClearHintSuffix(count: number, isZh: boolean)` | `Will clear ` + ` on 3 records.` | `将在 3 条记录中清空 ` + `。` | Keeps `<strong>{{ selectedField.name }}</strong>` raw and visually emphasized |
+| `bulkSuccess(count: number, mode: 'set' | 'clear', isZh: boolean)` | `3 records updated` / `3 records cleared` | `已更新 3 条记录` / `已清空 3 条记录` | Count only |
+| `bulkPartialSuccess(updated: number, requested: number, mode: 'set' | 'clear', isZh: boolean)` | `2 of 3 records updated` | `3 条记录中已更新 2 条` | Count only |
+| `bulkFailure(failed: number, requested: number, sampleFailures: string, isZh: boolean)` | `1 of 3 record failed (rec_1: conflict)` or `1 of 3 record failed` | `3 条记录中有 1 条失败（rec_1: conflict）` or `3 条记录中有 1 条失败` | `sampleFailures` raw; empty string must not produce empty parentheses |
+| `bulkVersionConflict(message: string, isZh: boolean)` | `Some records were modified elsewhere. Reload and retry. (${message})` or `Some records were modified elsewhere. Reload and retry.` | `部分记录已在其他位置修改。请重新加载后重试。（${message}）` or `部分记录已在其他位置修改。请重新加载后重试。` | `message` raw; empty string must not produce empty parentheses |
+
+Implementation note:
+
+- Use real English pluralization (`record` vs `records`), not `record(s)`.
+- Keep `sampleFailures` assembly in Workbench as raw `${recordId}: ${reason}` and pass the joined raw string into the helper.
+- Preserve `<strong>{{ selectedField.name }}</strong>` in the clear hint by using prefix/suffix helpers instead of returning HTML from a helper.
+- `bulkClearHintPrefix/Suffix` return values include intentional leading/trailing whitespace that MUST NOT be trimmed; specs must assert byte-exact output:
+  `bulkClearHintPrefix(3, false) === 'Will clear '`,
+  `bulkClearHintSuffix(3, false) === ' on 3 records.'`,
+  `bulkClearHintPrefix(3, true) === '将在 3 条记录中清空 '`,
+  `bulkClearHintSuffix(3, true) === '。'`.
+- `bulkFailure(...)` and `bulkVersionConflict(...)` must conditionally append parentheses only when their raw detail string is non-empty.
+
+### 4.2 `meta-manager-labels.ts` Conditional Formatting Keys
+
+Add `formatting.*` keys under the manager domain.
+
+| Key/helper | EN | zh-CN | Notes |
+| --- | --- | --- | --- |
+| `formatting.title` | `Conditional formatting` | `条件格式` | Header |
+| `formatting.ariaTitle` | `Conditional formatting rules` | `条件格式规则` | Existing dialog aria-label |
+| `formatting.close` | `Close` | `关闭` | Existing close-button aria-label |
+| `formatting.empty` | `No rules yet. Add a rule to color cells or rows based on field values.` | `暂无规则。添加规则后，可根据字段值为单元格或整行着色。` | Empty state |
+| `formatting.minPlaceholder` | `min` | `最小值` | Existing placeholder |
+| `formatting.maxPlaceholder` | `max` | `最大值` | Existing placeholder |
+| `formatting.pickOption` | `(pick)` | `（选择）` | Empty option for select values |
+| `formatting.color` | `Color` | `颜色` | Label |
+| `formatting.applyToRow` | `Apply to whole row` | `应用到整行` | Checkbox |
+| `formatting.enabled` | `Enabled` | `启用` | Checkbox |
+| `formatting.up` | `▲ Up` | `▲ 上移` | Keep arrow glyph |
+| `formatting.down` | `▼ Down` | `▼ 下移` | Keep arrow glyph |
+| `formatting.addRule` | `+ Add rule` | `+ 添加规则` | Primary action |
+| `formatting.noFieldsHint` | `Add fields to the sheet to create formatting rules.` | `请先向 Sheet 添加字段，再创建格式规则。` | Empty field hint |
+| `formatting.saveRules` | `Save rules` | `保存规则` | Footer primary action |
+
+Reuse existing manager keys:
+
+| Existing key | Current EN/ZH | Consumer |
+| --- | --- | --- |
+| `action.cancel` | `Cancel` / `取消` | Dialog footer |
+| `action.remove` | `Remove` / `移除` | Rule remove button |
+| `view.discardFormattingConfirm` | `Discard unsaved formatting rules?` / `放弃未保存的格式规则吗？` | Dirty close confirm |
+
+Helpers:
+
+| Helper | EN | zh-CN | Raw boundary |
+| --- | --- | --- | --- |
+| `formattingOperatorLabel(operator, fieldType, isZh)` | Existing labels by field type | Localized labels by field type | Operator enum value stays raw |
+| `formattingPickColor(color, isZh)` | `Pick color ${color}` | `选择颜色 ${color}` | Color hex raw |
+
+Operator label mapping:
+
+| Operator/context | EN | zh-CN |
+| --- | --- | --- |
+| `gt` / `gte` / `lt` / `lte` | `>` / `>=` / `<` / `<=` | same raw symbols |
+| `eq`, number/text | `=` | `=` |
+| `neq`, number/text | `!=` | `!=` |
+| `between` | `between` | `介于` |
+| `contains` | `contains` | `包含` |
+| `not_contains` | `does not contain` | `不包含` |
+| `is_empty` | `is empty` | `为空` |
+| `is_not_empty` | `is not empty` | `不为空` |
+| `is_today` | `is today` | `是今天` |
+| `is_overdue` | `is overdue` | `已逾期` |
+| `is_in_last_n_days` | `is in last N days` | `最近 N 天内` |
+| `is_in_next_n_days` | `is in next N days` | `未来 N 天内` |
+| `is_true` | `is checked` | `已勾选` |
+| `is_false` | `is unchecked` | `未勾选` |
+| `eq`, select/multiSelect | `is` | `是` |
+| `neq`, select/multiSelect | `is not` | `不是` |
+
+Do not translate:
+
+| Value | Reason |
+| --- | --- |
+| Select option values (`opt.value`) | User-authored data |
+| Field names | User-authored schema |
+| `#RRGGBB` placeholder | Format token, not prose |
+| Palette hex values | Raw color data |
+| Rule ids / persisted operator enum values | Contract data |
+
+## 5. Exact Chrome Targets
+
+### 5.1 `MetaBulkEditDialog.vue`
+
+| Line | Current string | Plan |
+| --- | --- | --- |
+| L4/L115 | `Set field for selected records` / `Clear field for selected records` | `bulk.titleSet/titleClear` |
+| L7 | `Close` | `bulk.close` |
+| L14 | `Field` | `bulk.field` |
+| L18 | `Field to update` | `bulk.fieldAria` |
+| L21 | `(choose a field)` | `bulk.chooseField` |
+| L28 | `No bulk-editable fields are available for the current selection.` | `bulk.noEditableFields` |
+| L32 | `Value` | `bulk.value` |
+| L50 | `Action` | `bulk.action` |
+| L52 | `Will clear <field> on N record(s).` | `bulkClearHintPrefix(...)` + raw `<strong>{{ selectedField.name }}</strong>` + `bulkClearHintSuffix(...)` |
+| L61 | `Cancel` | `bulk.cancel` |
+| L121 | `Clear` / `Set value` | `bulk.submitClear/submitSet` |
+| L116-L119 | Set/clear summaries | `bulkSummary(...)` |
+
+### 5.2 `MultitableWorkbench.vue` Bulk Edit Parent Messages
+
+| Line | Current string | Plan |
+| --- | --- | --- |
+| L2571 | `${failed} of ${requested} record(s) failed (...)` | `bulkFailure(failed, requested, sampleFailures, isZh.value)` |
+| L2573 | `${updated} of ${requested} record(s) cleared/updated` | `bulkPartialSuccess(updated, requested, mode, isZh.value)` |
+| L2576 | `${updated} of ${requested} record(s) updated` | Same helper with `mode='set'` |
+| L2578 | `${updated} record(s) cleared/updated` | `bulkSuccess(updated, mode, isZh.value)` |
+| L2586 | `Bulk edit failed` | `bulkEditLabel('bulk.errorFailed', isZh.value)` fallback after raw `e?.message` |
+| L2588 | `Some records were modified elsewhere. Reload and retry. (${message})` | `bulkVersionConflict(message, isZh.value)` |
+
+Raw boundary:
+
+- Keep `failure.recordId` and `failure.reason` raw.
+- Keep `e?.message` raw for non-version-conflict errors.
+- Version conflict wraps the raw message in localized surrounding chrome.
+
+### 5.3 `ConditionalFormattingDialog.vue`
+
+| Line | Current string | Plan |
+| --- | --- | --- |
+| L3 | `Conditional formatting rules` | `formatting.ariaTitle` |
+| L5 | `Conditional formatting` | `formatting.title` |
+| L7 | `Close` | `formatting.close` |
+| L11 | Empty state | `formatting.empty` |
+| L39/L47 | `min` / `max` | `formatting.minPlaceholder/maxPlaceholder` |
+| L52 | `(pick)` | `formatting.pickOption` |
+| L80 | `Color` | `formatting.color` |
+| L89 | `Pick color ${preset}` | `formattingPickColor(preset, isZh.value)` |
+| L97 | `#RRGGBB` | Keep raw format token |
+| L103 | `Apply to whole row` | `formatting.applyToRow` |
+| L107 | `Enabled` | `formatting.enabled` |
+| L116/L122 | `▲ Up` / `▼ Down` | `formatting.up/down` |
+| L123 | `Remove` | `managerLabel('action.remove')` |
+| L132 | `+ Add rule` | `formatting.addRule` |
+| L133 | No fields hint | `formatting.noFieldsHint` |
+| L136 | `Cancel` | `managerLabel('action.cancel')` |
+| L137 | `Save rules` | `formatting.saveRules` |
+| L370 | `Discard unsaved formatting rules?` | Existing `managerLabel('view.discardFormattingConfirm')` |
+| L237-L284 | operator labels | `formattingOperatorLabel(...)` |
+
+## 6. Implementation Order
+
+1. Preflight grep from §3 and resolve any missing call-site before code changes.
+2. Add `meta-bulk-edit-labels.ts` with `bulk.*` keys and helpers.
+3. Extend `meta-manager-labels.ts` with `formatting.*` keys and helper functions.
+4. Wire `MetaBulkEditDialog.vue` to `useLocale()` and bulk edit labels.
+5. Wire Workbench `bulkEditDialog.*` parent messages to `meta-bulk-edit-labels.ts` helpers.
+6. Wire `ConditionalFormattingDialog.vue` to `useLocale()` and manager formatting labels.
+7. Add/extend helper specs, including byte-exact whitespace tests for `bulkClearHintPrefix/Suffix` and empty-detail tests for `bulkFailure` / `bulkVersionConflict`.
+8. Extend `multitable-bulk-edit-dialog.spec.ts` for zh-CN render, EN baseline, raw field names, and existing aria labels.
+9. Add `conditional-formatting-dialog-i18n.spec.ts` for zh-CN render, EN baseline, raw field/option/hex values, operator labels, existing aria labels, and dirty confirm text. Operator coverage must include at least number, text, select, multiSelect, boolean, and date field types with representative operators; specifically assert select/multiSelect `eq` renders `is` / `是`, while number `eq` remains `=`.
+10. Run validation commands from §8.
+11. Write verification MD with exact PASS lines and residual grep classification.
+12. Commit targeted files only; stop before push.
+
+## 7. Risk Register
+
+| Risk | Severity | Mitigation |
+| --- | --- | --- |
+| Helper/domain leakage: using manager labels from bulk edit | Medium | Bulk edit labels live in dedicated `meta-bulk-edit-labels.ts`; conditional formatting remains manager domain |
+| Raw failure details accidentally translated | Medium | Parent Workbench helpers accept raw `sampleFailures` and raw `message`; specs assert raw record IDs/reasons remain |
+| Conditional operator labels lose field-type-specific wording | Medium | `formattingOperatorLabel(operator, fieldType, isZh)` includes select-specific `is/is not` and symbol-preserving numeric/text variants |
+| CSS/data selector trap | Low | Neither dialog uses display text in `data-*`; class names remain raw/static |
+| A11y drift | Low | Only localize existing `aria-label`/placeholder strings; spec asserts counts/values for representative labels |
+| Existing tests depend on English copy | Medium | Update tests lockstep; keep EN baseline assertions so English behavior remains explicit |
+| New module churn | Low | One new module is intentional because bulk edit is a modal overlay, following `meta-import-labels.ts` precedent |
+
+## 8. Validation Plan
+
+Commands use package-relative spec paths because `pnpm --filter @metasheet/web exec` runs in `apps/web`.
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/meta-bulk-edit-labels.spec.ts \
+  tests/multitable-manager-panels-i18n.spec.ts \
+  tests/multitable-bulk-edit-dialog.spec.ts \
+  tests/conditional-formatting-dialog-i18n.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web build
+git diff --check origin/main..HEAD
+```
+
+Optional regression checks if implementation touches Workbench parent messages substantially:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-workbench-view.spec.ts \
+  -t "bulk" \
+  --watch=false
+```
+
+Known baseline from T3E-2 remains out of scope:
+
+- Full `multitable-workbench-view.spec.ts` currently has a workflow-designer feature-flag baseline failure on `origin/main`; do not fix it in T3E-3.
+
+## 9. Approval Gate
+
+T3E-3 is implementation-ready when review accepts:
+
+1. Bulk edit labels under new `meta-bulk-edit-labels.ts`, not `meta-core-labels.ts` or `meta-manager-labels.ts`.
+2. Conditional formatting labels under `meta-manager-labels.ts`, including operator/color helpers.
+3. Parent Workbench `bulkEditDialog.error/resultMessage` included in T3E-3 scope.
+4. Raw boundaries in §4-§5.
+5. Test plan in §8, especially direct dialog render specs and helper specs.
+
+## 10. Deferred After T3E-3
+
+| Deferred | Trigger |
+| --- | --- |
+| T3D automation | Start with design MD after T3E-3 lands |
+| Final global audit | Run after T3D and T3E-3 complete |

--- a/docs/development/multitable-t3e3-bulk-formatting-i18n-verification-20260521.md
+++ b/docs/development/multitable-t3e3-bulk-formatting-i18n-verification-20260521.md
@@ -1,0 +1,127 @@
+# T3E-3 Bulk Edit + Conditional Formatting i18n Verification
+
+Date: 2026-05-21
+Branch: `frontend/multitable-t3e3-bulk-formatting-i18n-20260521`
+Status: implementation verified locally; not pushed
+
+## 1. DoD
+
+PASS criteria:
+
+- Bulk edit dialog chrome is locale-aware via new `meta-bulk-edit-labels.ts`.
+- Workbench bulk edit parent result/error messages use bulk helper fallbacks and keep record ids/reasons raw.
+- Conditional formatting dialog chrome is locale-aware via `meta-manager-labels.ts` `formatting.*` keys/helpers.
+- Existing aria/placeholder text is localized where present; no new a11y attributes or selector-bearing data attributes are introduced.
+- Targeted specs, `vue-tsc`, build, and `git diff --check` pass.
+
+## 2. Local Verification
+
+Targeted specs:
+
+```text
+✓ tests/meta-bulk-edit-labels.spec.ts  (6 tests)
+✓ tests/conditional-formatting-dialog-i18n.spec.ts  (4 tests)
+✓ tests/multitable-bulk-edit-dialog.spec.ts  (15 tests)
+✓ tests/multitable-manager-panels-i18n.spec.ts  (5 tests)
+
+Test Files  4 passed (4)
+Tests       30 passed (30)
+```
+
+Type check:
+
+```text
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+exit=0
+```
+
+Build:
+
+```text
+pnpm --filter @metasheet/web build
+✓ built in 6.00s
+```
+
+Diff check:
+
+```text
+git diff --check
+exit=0
+```
+
+Build warning note: Vite reported the existing WorkflowDesigner dynamic/static import chunking warning and large chunk warnings. These are pre-existing build warnings and not T3E-3 regressions.
+
+## 3. Preflight / Reachability Evidence
+
+Manager reuse-key reachability:
+
+```text
+apps/web/src/multitable/utils/meta-manager-labels.ts:11:  | 'action.configure' | 'action.conditionalFormatting' | 'action.rename'
+apps/web/src/multitable/utils/meta-manager-labels.ts:14:  | 'action.cancel' | 'action.reloadLatest' | 'action.dismiss'
+apps/web/src/multitable/utils/meta-manager-labels.ts:15:  | 'action.add' | 'action.addOption' | 'action.save' | 'action.remove'
+apps/web/src/multitable/utils/meta-manager-labels.ts:72:  | 'view.discardFormattingConfirm'
+apps/web/src/multitable/utils/meta-manager-labels.ts:101:  'action.conditionalFormatting': { en: 'Conditional formatting', zh: '条件格式' },
+apps/web/src/multitable/utils/meta-manager-labels.ts:108:  'action.cancel': { en: 'Cancel', zh: '取消' },
+apps/web/src/multitable/utils/meta-manager-labels.ts:114:  'action.remove': { en: 'Remove', zh: '移除' },
+apps/web/src/multitable/utils/meta-manager-labels.ts:248:  'view.discardFormattingConfirm': { en: 'Discard unsaved formatting rules?', zh: '放弃未保存的格式规则吗？' },
+```
+
+Residual source-string grep classification:
+
+| Residual | Classification |
+| --- | --- |
+| Bulk edit source strings under `meta-bulk-edit-labels.ts` | Expected label definitions |
+| Conditional formatting source strings under `meta-manager-labels.ts` | Expected label definitions |
+| Bulk/formatting source strings under tests | Expected EN baseline assertions |
+| `record(s)` under `meta-import-labels.ts` / import modal tests | Pre-existing import-modal surface, out of T3E-3 scope |
+| `does not contain` under `useMultitableGrid.ts` | Pre-existing grid filter operator surface, out of T3E-3 scope |
+
+## 4. Design Fidelity
+
+Bulk edit:
+
+- Added `apps/web/src/multitable/utils/meta-bulk-edit-labels.ts`.
+- Did not add bulk edit keys to `meta-core-labels.ts` or `meta-manager-labels.ts`.
+- `MetaBulkEditDialog.vue` now uses `useLocale()` and `bulkEditLabel(...)`.
+- The clear hint keeps `<strong>{{ selectedField.name }}</strong>` in the template; no HTML helper or `v-html`.
+- `bulkClearHintPrefix/Suffix` preserve intentional whitespace and are byte-exact tested.
+- `bulkFailure(...)` and `bulkVersionConflict(...)` conditionally omit parentheses when raw details are empty.
+
+Conditional formatting:
+
+- Extended `meta-manager-labels.ts` with `formatting.*` keys plus `formattingOperatorLabel(...)` and `formattingPickColor(...)`.
+- Reused `managerLabel('action.cancel')`, `managerLabel('action.remove')`, and `managerLabel('view.discardFormattingConfirm')`.
+- Operator render spec covers number, text, select, multiSelect, boolean, and date field types with representative labels.
+- Select option values, field names, and color hex values remain raw.
+- `▲ Up` / `▼ Down` keep the glyph and localize the visible word; no new aria-label was needed because the button text is still readable.
+
+## 5. A11y Boundary
+
+T3E-3 localizes existing aria/placeholder text:
+
+- `MetaBulkEditDialog.vue`: dialog aria label, close aria label, field select aria label.
+- `ConditionalFormattingDialog.vue`: dialog aria label, close aria label, min/max placeholders, color swatch aria labels.
+
+T3E-3 does not add new aria/title/placeholder attributes. The conditional-formatting render spec locks the current aria-bearing node count for the 6-rule fixture at `50` (dialog + close + 6 rules * 8 palette swatches).
+
+## 6. Raw Boundary
+
+Preserved raw:
+
+- Bulk field names through mustache rendering.
+- Bulk failure record ids and reasons in `sampleFailures`.
+- Bulk runtime/backend `e?.message` for non-version-conflict errors.
+- Conditional formatting field names.
+- Conditional formatting select option values, including user-authored Chinese values.
+- Conditional formatting color hex values and `#RRGGBB` format token.
+- Persisted operator enum values and rule ids.
+
+## 7. Worktree Note
+
+This alt-worktree initially had no `node_modules`, so `pnpm --filter @metasheet/web exec vitest ...` failed before tests with:
+
+```text
+ERR_PNPM_RECURSIVE_EXEC_FIRST_FAIL Command "vitest" not found
+```
+
+I ran `pnpm install` in this worktree to enable local verification. It produced tracked `node_modules` symlink noise under plugin/tool package folders. Those paths are not part of the T3E-3 slice and must not be staged; use targeted `git add` for the T3E-3 files only.


### PR DESCRIPTION
## Summary

- add a dedicated `meta-bulk-edit-labels.ts` module for `MetaBulkEditDialog` chrome and Workbench-owned bulk edit result fallbacks
- extend `meta-manager-labels.ts` with conditional-formatting `formatting.*` keys plus operator/color helpers
- wire `MetaBulkEditDialog.vue`, `ConditionalFormattingDialog.vue`, and Workbench bulk edit parent messages to locale-aware helpers
- add design and verification docs for T3E-3

## Design Notes

- Bulk edit uses its own per-dialog module, aligned with the existing `MetaImportModal` / `meta-import-labels.ts` pattern.
- Conditional formatting stays in the manager-label domain because `view.discardFormattingConfirm` and `action.conditionalFormatting` already live in `meta-manager-labels.ts`.
- Bulk helper discriminator is explicit: `BulkEditMode = 'set' | 'clear'`.
- No key retirement in this slice.
- Raw boundaries are preserved: field names, select option values, record IDs, failure reasons, runtime/backend messages, and hex colors stay raw.
- A11y boundary is locked by localizing existing aria/placeholder text only; the conditional formatting render spec asserts `[aria-label] = 50` for the 6-rule fixture.

Docs:

- `docs/development/multitable-t3e3-bulk-formatting-i18n-design-20260521.md`
- `docs/development/multitable-t3e3-bulk-formatting-i18n-verification-20260521.md`

## Verification

```text
✓ tests/meta-bulk-edit-labels.spec.ts  (6 tests)
✓ tests/conditional-formatting-dialog-i18n.spec.ts  (4 tests)
✓ tests/multitable-bulk-edit-dialog.spec.ts  (15 tests)
✓ tests/multitable-manager-panels-i18n.spec.ts  (5 tests)

Test Files  4 passed (4)
Tests       30 passed (30)
```

```text
pnpm --filter @metasheet/web exec vue-tsc --noEmit
exit=0
```

```text
pnpm --filter @metasheet/web build
✓ built in 6.00s
```

```text
git diff --check origin/main..HEAD
exit=0
```

## Notes

- Known baseline: the workflow-designer feature-flag drift remains pre-existing and is not touched here.
- This worktree required `pnpm install` to run local verification; tracked `node_modules` symlink noise was not staged and is not part of the PR diff.
