### PR TITLE
feat(multitable): localize automation log and delivery chrome (T3D-1)

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue
+++ b/apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue
@@ -2,26 +2,26 @@
   <div v-if="visible" class="meta-group-delivery__overlay" @click.self="$emit('close')">
     <div class="meta-group-delivery">
       <div class="meta-group-delivery__header">
-        <h4 class="meta-group-delivery__title">DingTalk Group Deliveries</h4>
+        <h4 class="meta-group-delivery__title">{{ automationLabel('delivery.groupTitle', isZh) }}</h4>
         <button class="meta-group-delivery__close" type="button" @click="$emit('close')">&times;</button>
       </div>
 
       <div class="meta-group-delivery__body">
         <div class="meta-group-delivery__toolbar">
           <select v-model="statusFilter" class="meta-group-delivery__select" data-field="statusFilter">
-            <option value="">All statuses</option>
-            <option value="success">Success</option>
-            <option value="failed">Failed</option>
+            <option value="">{{ automationLabel('status.all', isZh) }}</option>
+            <option value="success">{{ automationStatusLabel('success', isZh) }}</option>
+            <option value="failed">{{ automationStatusLabel('failed', isZh) }}</option>
           </select>
-          <button class="meta-group-delivery__btn" type="button" :disabled="loading" data-action="refresh" @click="loadData">Refresh</button>
+          <button class="meta-group-delivery__btn" type="button" :disabled="loading" data-action="refresh" @click="loadData">{{ automationLabel('log.refresh', isZh) }}</button>
         </div>
 
-        <div v-if="loading" class="meta-group-delivery__empty">Loading deliveries...</div>
+        <div v-if="loading" class="meta-group-delivery__empty">{{ automationLabel('delivery.loading', isZh) }}</div>
         <div v-else-if="errorMessage" class="meta-group-delivery__error-state" data-group-delivery-error="true">
           {{ errorMessage }}
         </div>
         <div v-else-if="filteredDeliveries.length === 0" class="meta-group-delivery__empty" data-empty="true">
-          No DingTalk group deliveries found.
+          {{ automationLabel('delivery.emptyGroup', isZh) }}
         </div>
 
         <div
@@ -37,7 +37,7 @@
               :class="delivery.success ? 'meta-group-delivery__badge--success' : 'meta-group-delivery__badge--failed'"
               :data-status="delivery.success ? 'success' : 'failed'"
             >
-              {{ delivery.success ? 'success' : 'failed' }}
+              {{ automationStatusLabel(delivery.success ? 'success' : 'failed', isZh) }}
             </span>
             <span class="meta-group-delivery__time">{{ formatTime(delivery.createdAt) }}</span>
           </div>
@@ -51,8 +51,10 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type { DingTalkGroupDelivery } from '../types'
 import type { MultitableApiClient } from '../api/client'
+import { automationLabel, automationStatusLabel } from '../utils/meta-automation-labels'
 
 const props = defineProps<{
   visible: boolean
@@ -69,6 +71,7 @@ const loading = ref(false)
 const deliveries = ref<DingTalkGroupDelivery[]>([])
 const statusFilter = ref('')
 const errorMessage = ref('')
+const { isZh } = useLocale()
 
 const filteredDeliveries = computed(() => {
   if (!statusFilter.value) return deliveries.value
@@ -87,7 +90,7 @@ function formatTime(ts: string): string {
 function readErrorMessage(error: unknown): string {
   return error instanceof Error && error.message.trim()
     ? error.message
-    : 'Failed to load DingTalk group deliveries.'
+    : automationLabel('error.loadGroupDeliveries', isZh.value)
 }
 
 async function loadData() {

--- a/apps/web/src/multitable/components/MetaAutomationLogViewer.vue
+++ b/apps/web/src/multitable/components/MetaAutomationLogViewer.vue
@@ -2,7 +2,7 @@
   <div v-if="visible" class="meta-log-viewer__overlay" @click.self="$emit('close')">
     <div class="meta-log-viewer">
       <div class="meta-log-viewer__header">
-        <h4 class="meta-log-viewer__title">Execution Logs</h4>
+        <h4 class="meta-log-viewer__title">{{ automationLabel('log.title', isZh) }}</h4>
         <button class="meta-log-viewer__close" type="button" @click="$emit('close')">&times;</button>
       </div>
 
@@ -10,19 +10,19 @@
         <!-- Stats bar -->
         <div v-if="stats" class="meta-log-viewer__stats" data-stats="true">
           <div class="meta-log-viewer__stat">
-            <span class="meta-log-viewer__stat-label">Total</span>
+            <span class="meta-log-viewer__stat-label">{{ automationLabel('log.total', isZh) }}</span>
             <span class="meta-log-viewer__stat-value">{{ stats.total }}</span>
           </div>
           <div class="meta-log-viewer__stat">
-            <span class="meta-log-viewer__stat-label">Success</span>
+            <span class="meta-log-viewer__stat-label">{{ automationLabel('log.success', isZh) }}</span>
             <span class="meta-log-viewer__stat-value meta-log-viewer__stat-value--success">{{ stats.success }}</span>
           </div>
           <div class="meta-log-viewer__stat">
-            <span class="meta-log-viewer__stat-label">Failed</span>
+            <span class="meta-log-viewer__stat-label">{{ automationLabel('log.failed', isZh) }}</span>
             <span class="meta-log-viewer__stat-value meta-log-viewer__stat-value--failed">{{ stats.failed }}</span>
           </div>
           <div class="meta-log-viewer__stat">
-            <span class="meta-log-viewer__stat-label">Avg duration</span>
+            <span class="meta-log-viewer__stat-label">{{ automationLabel('log.avgDuration', isZh) }}</span>
             <span class="meta-log-viewer__stat-value">{{ stats.avgDuration }}ms</span>
           </div>
         </div>
@@ -30,12 +30,12 @@
         <!-- Toolbar -->
         <div class="meta-log-viewer__toolbar">
           <select v-model="statusFilter" class="meta-log-viewer__select" data-field="statusFilter">
-            <option value="">All statuses</option>
-            <option value="success">Success</option>
-            <option value="failed">Failed</option>
-            <option value="skipped">Skipped</option>
+            <option value="">{{ automationLabel('status.all', isZh) }}</option>
+            <option value="success">{{ automationStatusLabel('success', isZh) }}</option>
+            <option value="failed">{{ automationStatusLabel('failed', isZh) }}</option>
+            <option value="skipped">{{ automationStatusLabel('skipped', isZh) }}</option>
           </select>
-          <button class="meta-log-viewer__btn" type="button" data-action="refresh" @click="loadData">Refresh</button>
+          <button class="meta-log-viewer__btn" type="button" data-action="refresh" @click="loadData">{{ automationLabel('log.refresh', isZh) }}</button>
         </div>
 
         <!-- Load error (replaces previous silent catch) -->
@@ -45,19 +45,19 @@
           data-error="true"
           role="alert"
         >
-          <span class="meta-log-viewer__error-label">Failed to load logs:</span>
+          <span class="meta-log-viewer__error-label">{{ automationLabel('log.errorPrefix', isZh) }}</span>
           <span class="meta-log-viewer__error-message" data-field="error-message">{{ loadError }}</span>
           <button
             type="button"
             class="meta-log-viewer__btn meta-log-viewer__btn--retry"
             data-action="retry"
             @click="loadData"
-          >Retry</button>
+          >{{ automationLabel('log.retry', isZh) }}</button>
         </div>
 
         <!-- Log list -->
-        <div v-if="loading" class="meta-log-viewer__empty">Loading logs...</div>
-        <div v-else-if="!loadError && filteredLogs.length === 0" class="meta-log-viewer__empty" data-empty="true">No execution logs found.</div>
+        <div v-if="loading" class="meta-log-viewer__empty">{{ automationLabel('log.loading', isZh) }}</div>
+        <div v-else-if="!loadError && filteredLogs.length === 0" class="meta-log-viewer__empty" data-empty="true">{{ automationLabel('log.empty', isZh) }}</div>
         <div
           v-for="log in filteredLogs"
           :key="log.id"
@@ -71,7 +71,7 @@
               class="meta-log-viewer__badge"
               :class="`meta-log-viewer__badge--${log.status}`"
               :data-status="log.status"
-            >{{ log.status }}</span>
+            >{{ automationStatusLabel(log.status, isZh) }}</span>
             <span class="meta-log-viewer__log-trigger" data-field="triggeredBy">{{ log.triggeredBy }}</span>
             <span class="meta-log-viewer__log-duration">{{ log.duration ?? '-' }}ms</span>
           </div>
@@ -82,13 +82,13 @@
                 type="button"
                 data-action="copy-support-packet"
                 @click.stop="copySupportPacket(log)"
-              >Copy redacted packet</button>
+              >{{ automationLabel('support.copyPacket', isZh) }}</button>
               <button
                 class="meta-log-viewer__btn meta-log-viewer__btn--support"
                 type="button"
                 data-action="download-support-packet"
                 @click.stop="downloadSupportPacket(log)"
-              >Download JSON</button>
+              >{{ automationLabel('support.downloadJson', isZh) }}</button>
               <span
                 v-if="supportPacketStatus[log.id]"
                 class="meta-log-viewer__support-status"
@@ -101,11 +101,11 @@
               class="meta-log-viewer__step"
             >
               <span class="meta-log-viewer__step-num">{{ idx + 1 }}.</span>
-              <span class="meta-log-viewer__step-type">{{ step.actionType }}</span>
+              <span class="meta-log-viewer__step-type">{{ automationActionTypeLabel(step.actionType, isZh) }}</span>
               <span
                 class="meta-log-viewer__badge meta-log-viewer__badge--sm"
                 :class="`meta-log-viewer__badge--${step.status}`"
-              >{{ step.status }}</span>
+              >{{ automationStatusLabel(step.status, isZh) }}</span>
               <span v-if="step.durationMs" class="meta-log-viewer__step-dur">{{ step.durationMs }}ms</span>
               <div
                 v-if="step.error"
@@ -127,8 +127,16 @@
 
 <script setup lang="ts">
 import { ref, computed, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type { AutomationExecution, AutomationStats } from '../types'
 import type { MultitableApiClient } from '../api/client'
+import {
+  automationActionTypeLabel,
+  automationLabel,
+  automationStatusLabel,
+  supportCopyFailed,
+  supportDownloadFailed,
+} from '../utils/meta-automation-labels'
 import {
   redactString,
   summarizeStepError,
@@ -158,6 +166,7 @@ const statusFilter = ref('')
 const expandedId = ref<string | null>(null)
 const loadError = ref<string | null>(null)
 const supportPacketStatus = ref<Record<string, string>>({})
+const { isZh } = useLocale()
 
 const filteredLogs = computed(() => {
   if (!statusFilter.value) return logs.value
@@ -187,13 +196,13 @@ async function copySupportPacket(log: AutomationExecution) {
   try {
     const clipboard = navigator?.clipboard
     if (!clipboard?.writeText) {
-      throw new Error('Clipboard unavailable')
+      throw new Error(automationLabel('support.clipboardUnavailable', isZh.value))
     }
     await clipboard.writeText(renderAutomationLogSupportPacketMarkdown(log))
-    setSupportPacketStatus(log.id, 'Redacted packet copied.')
+    setSupportPacketStatus(log.id, automationLabel('support.copied', isZh.value))
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err)
-    setSupportPacketStatus(log.id, redactString(`Copy failed: ${message}`))
+    setSupportPacketStatus(log.id, redactString(supportCopyFailed(message, isZh.value)))
   }
 }
 
@@ -208,10 +217,10 @@ function downloadSupportPacket(log: AutomationExecution) {
     link.download = createAutomationLogSupportPacketFilename(log)
     link.click()
     URL.revokeObjectURL(url)
-    setSupportPacketStatus(log.id, 'Redacted JSON downloaded.')
+    setSupportPacketStatus(log.id, automationLabel('support.downloaded', isZh.value))
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err)
-    setSupportPacketStatus(log.id, redactString(`Download failed: ${message}`))
+    setSupportPacketStatus(log.id, redactString(supportDownloadFailed(message, isZh.value)))
   }
 }
 
@@ -232,7 +241,7 @@ async function loadData() {
     // when fetches actually failed (the user could not tell the difference
     // between an empty rule and a backend / network error).
     const message = err instanceof Error ? err.message : String(err)
-    loadError.value = redactString(message) || 'Unknown error'
+    loadError.value = redactString(message) || automationLabel('error.unknown', isZh.value)
     logs.value = []
     stats.value = null
   } finally {

--- a/apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue
+++ b/apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue
@@ -2,27 +2,27 @@
   <div v-if="visible" class="meta-person-delivery__overlay" @click.self="$emit('close')">
     <div class="meta-person-delivery">
       <div class="meta-person-delivery__header">
-        <h4 class="meta-person-delivery__title">DingTalk Person Deliveries</h4>
+        <h4 class="meta-person-delivery__title">{{ automationLabel('delivery.personTitle', isZh) }}</h4>
         <button class="meta-person-delivery__close" type="button" @click="$emit('close')">&times;</button>
       </div>
 
       <div class="meta-person-delivery__body">
         <div class="meta-person-delivery__toolbar">
           <select v-model="statusFilter" class="meta-person-delivery__select" data-field="statusFilter">
-            <option value="">All statuses</option>
-            <option value="success">Success</option>
-            <option value="failed">Failed</option>
-            <option value="skipped">Skipped / unbound</option>
+            <option value="">{{ automationLabel('status.all', isZh) }}</option>
+            <option value="success">{{ automationStatusLabel('success', isZh) }}</option>
+            <option value="failed">{{ automationStatusLabel('failed', isZh) }}</option>
+            <option value="skipped">{{ automationLabel('delivery.statusSkippedUnbound', isZh) }}</option>
           </select>
-          <button class="meta-person-delivery__btn" type="button" :disabled="loading" data-action="refresh" @click="loadData">Refresh</button>
+          <button class="meta-person-delivery__btn" type="button" :disabled="loading" data-action="refresh" @click="loadData">{{ automationLabel('log.refresh', isZh) }}</button>
         </div>
 
-        <div v-if="loading" class="meta-person-delivery__empty">Loading deliveries...</div>
+        <div v-if="loading" class="meta-person-delivery__empty">{{ automationLabel('delivery.loading', isZh) }}</div>
         <div v-else-if="errorMessage" class="meta-person-delivery__error-state" data-person-delivery-error="true">
           {{ errorMessage }}
         </div>
         <div v-else-if="filteredDeliveries.length === 0" class="meta-person-delivery__empty" data-empty="true">
-          No DingTalk person deliveries found.
+          {{ automationLabel('delivery.emptyPerson', isZh) }}
         </div>
 
         <div
@@ -34,7 +34,7 @@
           <div class="meta-person-delivery__summary">
             <span class="meta-person-delivery__recipient">
               {{ delivery.localUserLabel || delivery.localUserId }}
-              <em v-if="!delivery.localUserIsActive">Inactive user</em>
+              <em v-if="!delivery.localUserIsActive">{{ automationLabel('delivery.inactiveUser', isZh) }}</em>
             </span>
             <span
               class="meta-person-delivery__badge"
@@ -47,7 +47,7 @@
           </div>
           <div v-if="delivery.localUserSubtitle || delivery.dingtalkUserId" class="meta-person-delivery__detail">
             <span v-if="delivery.localUserSubtitle">{{ delivery.localUserSubtitle }}</span>
-            <span v-if="delivery.dingtalkUserId">DingTalk: {{ delivery.dingtalkUserId }}</span>
+            <span v-if="delivery.dingtalkUserId">{{ automationLabel('delivery.dingtalkPrefix', isZh) }}{{ isZh ? '：' : ': ' }}{{ delivery.dingtalkUserId }}</span>
           </div>
           <div class="meta-person-delivery__subject">{{ delivery.subject }}</div>
           <div v-if="deliveryStatus(delivery) !== 'success' && deliveryReason(delivery)" class="meta-person-delivery__error">
@@ -61,8 +61,10 @@
 
 <script setup lang="ts">
 import { computed, ref, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type { DingTalkPersonDelivery } from '../types'
 import type { MultitableApiClient } from '../api/client'
+import { automationLabel, automationStatusLabel } from '../utils/meta-automation-labels'
 
 const props = defineProps<{
   visible: boolean
@@ -79,6 +81,7 @@ const loading = ref(false)
 const deliveries = ref<DingTalkPersonDelivery[]>([])
 const statusFilter = ref('')
 const errorMessage = ref('')
+const { isZh } = useLocale()
 
 const filteredDeliveries = computed(() => {
   if (!statusFilter.value) return deliveries.value
@@ -98,13 +101,14 @@ function deliveryStatus(delivery: DingTalkPersonDelivery): DeliveryStatus {
 
 function deliveryStatusLabel(delivery: DingTalkPersonDelivery): string {
   const status = deliveryStatus(delivery)
-  if (status === 'skipped') return 'skipped'
-  return status
+  return automationStatusLabel(status, isZh.value)
 }
 
 function deliveryReason(delivery: DingTalkPersonDelivery): string {
   if (deliveryStatus(delivery) === 'skipped') {
-    return delivery.errorMessage || UNBOUND_DINGTALK_REASON
+    return delivery.errorMessage === UNBOUND_DINGTALK_REASON || !delivery.errorMessage
+      ? automationLabel('delivery.unboundReason', isZh.value)
+      : delivery.errorMessage
   }
   return delivery.errorMessage || ''
 }
@@ -120,7 +124,7 @@ function formatTime(ts: string): string {
 function readErrorMessage(error: unknown): string {
   return error instanceof Error && error.message.trim()
     ? error.message
-    : 'Failed to load DingTalk person deliveries.'
+    : automationLabel('error.loadPersonDeliveries', isZh.value)
 }
 
 async function loadData() {

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -1,0 +1,157 @@
+// Automation chrome string table (T3D).
+//
+// Scope: automation manager/editor/log/delivery UI. Rule names, field/view
+// names, IDs, persisted enum values, backend/runtime errors, and redacted
+// support-packet content stay raw.
+
+import type { AutomationActionType, AutomationExecution } from '../types'
+
+export type AutomationStatus = AutomationExecution['status'] | 'running'
+
+export type AutomationLabelKey =
+  | 'log.title'
+  | 'log.total'
+  | 'log.success'
+  | 'log.failed'
+  | 'log.avgDuration'
+  | 'log.refresh'
+  | 'log.errorPrefix'
+  | 'log.retry'
+  | 'log.loading'
+  | 'log.empty'
+  | 'support.copyPacket'
+  | 'support.downloadJson'
+  | 'support.clipboardUnavailable'
+  | 'support.copied'
+  | 'support.downloaded'
+  | 'delivery.groupTitle'
+  | 'delivery.personTitle'
+  | 'delivery.loading'
+  | 'delivery.emptyGroup'
+  | 'delivery.emptyPerson'
+  | 'delivery.inactiveUser'
+  | 'delivery.dingtalkPrefix'
+  | 'delivery.statusSkippedUnbound'
+  | 'delivery.unboundReason'
+  | 'error.loadGroupDeliveries'
+  | 'error.loadPersonDeliveries'
+  | 'error.unknown'
+  | 'status.all'
+  | 'status.success'
+  | 'status.failed'
+  | 'status.skipped'
+
+export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
+  'log.title',
+  'log.total',
+  'log.success',
+  'log.failed',
+  'log.avgDuration',
+  'log.refresh',
+  'log.errorPrefix',
+  'log.retry',
+  'log.loading',
+  'log.empty',
+  'support.copyPacket',
+  'support.downloadJson',
+  'support.clipboardUnavailable',
+  'support.copied',
+  'support.downloaded',
+  'delivery.groupTitle',
+  'delivery.personTitle',
+  'delivery.loading',
+  'delivery.emptyGroup',
+  'delivery.emptyPerson',
+  'delivery.inactiveUser',
+  'delivery.dingtalkPrefix',
+  'delivery.statusSkippedUnbound',
+  'delivery.unboundReason',
+  'error.loadGroupDeliveries',
+  'error.loadPersonDeliveries',
+  'error.unknown',
+  'status.all',
+  'status.success',
+  'status.failed',
+  'status.skipped',
+]
+
+const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
+  'log.title': { en: 'Execution Logs', zh: '执行日志' },
+  'log.total': { en: 'Total', zh: '总计' },
+  'log.success': { en: 'Success', zh: '成功' },
+  'log.failed': { en: 'Failed', zh: '失败' },
+  'log.avgDuration': { en: 'Avg duration', zh: '平均耗时' },
+  'log.refresh': { en: 'Refresh', zh: '刷新' },
+  'log.errorPrefix': { en: 'Failed to load logs:', zh: '加载日志失败：' },
+  'log.retry': { en: 'Retry', zh: '重试' },
+  'log.loading': { en: 'Loading logs...', zh: '正在加载日志...' },
+  'log.empty': { en: 'No execution logs found.', zh: '暂无执行日志。' },
+  'support.copyPacket': { en: 'Copy redacted packet', zh: '复制脱敏包' },
+  'support.downloadJson': { en: 'Download JSON', zh: '下载 JSON' },
+  'support.clipboardUnavailable': { en: 'Clipboard unavailable', zh: '剪贴板不可用' },
+  'support.copied': { en: 'Redacted packet copied.', zh: '已复制脱敏包。' },
+  'support.downloaded': { en: 'Redacted JSON downloaded.', zh: '已下载脱敏 JSON。' },
+  'delivery.groupTitle': { en: 'DingTalk Group Deliveries', zh: '钉钉群投递记录' },
+  'delivery.personTitle': { en: 'DingTalk Person Deliveries', zh: '钉钉个人投递记录' },
+  'delivery.loading': { en: 'Loading deliveries...', zh: '正在加载投递记录...' },
+  'delivery.emptyGroup': { en: 'No DingTalk group deliveries found.', zh: '暂无钉钉群投递记录。' },
+  'delivery.emptyPerson': { en: 'No DingTalk person deliveries found.', zh: '暂无钉钉个人投递记录。' },
+  'delivery.inactiveUser': { en: 'Inactive user', zh: '已停用用户' },
+  'delivery.dingtalkPrefix': { en: 'DingTalk', zh: '钉钉' },
+  'delivery.statusSkippedUnbound': { en: 'Skipped / unbound', zh: '跳过 / 未绑定' },
+  'delivery.unboundReason': { en: 'DingTalk account is not linked or user is inactive', zh: '钉钉账号未绑定或用户已停用' },
+  'error.loadGroupDeliveries': { en: 'Failed to load DingTalk group deliveries.', zh: '加载钉钉群投递记录失败。' },
+  'error.loadPersonDeliveries': { en: 'Failed to load DingTalk person deliveries.', zh: '加载钉钉个人投递记录失败。' },
+  'error.unknown': { en: 'Unknown error', zh: '未知错误' },
+  'status.all': { en: 'All statuses', zh: '全部状态' },
+  'status.success': { en: 'success', zh: '成功' },
+  'status.failed': { en: 'failed', zh: '失败' },
+  'status.skipped': { en: 'skipped', zh: '跳过' },
+}
+
+export function automationLabel(key: AutomationLabelKey, isZh: boolean): string {
+  const entry = LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+export function automationStatusLabel(status: AutomationStatus | (string & {}), isZh: boolean): string {
+  if (status === 'success') return automationLabel('status.success', isZh)
+  if (status === 'failed') return automationLabel('status.failed', isZh)
+  if (status === 'skipped') return automationLabel('status.skipped', isZh)
+  if (status === 'running') return isZh ? '运行中' : 'running'
+  return String(status)
+}
+
+export function automationActionTypeLabel(type: AutomationActionType | (string & {}), isZh: boolean): string {
+  switch (type) {
+    case 'update_record':
+      return isZh ? '更新记录' : 'Update record'
+    case 'create_record':
+      return isZh ? '创建记录' : 'Create record'
+    case 'send_webhook':
+      return isZh ? '发送 Webhook' : 'Send webhook'
+    case 'send_notification':
+    case 'notify':
+      return isZh ? '发送通知' : 'Send notification'
+    case 'send_email':
+      return isZh ? '发送邮件' : 'Send email'
+    case 'send_dingtalk_group_message':
+      return isZh ? '发送钉钉群消息' : 'Send DingTalk group message'
+    case 'send_dingtalk_person_message':
+      return isZh ? '发送钉钉个人消息' : 'Send DingTalk person message'
+    case 'lock_record':
+      return isZh ? '锁定记录' : 'Lock record'
+    case 'update_field':
+      return isZh ? '更新字段值' : 'Update field value'
+    default:
+      return String(type)
+  }
+}
+
+export function supportCopyFailed(message: string, isZh: boolean): string {
+  return isZh ? `复制失败：${message}` : `Copy failed: ${message}`
+}
+
+export function supportDownloadFailed(message: string, isZh: boolean): string {
+  return isZh ? `下载失败：${message}` : `Download failed: ${message}`
+}

--- a/apps/web/tests/MetaAutomationLogViewer.spec.ts
+++ b/apps/web/tests/MetaAutomationLogViewer.spec.ts
@@ -3,6 +3,7 @@ import { createApp, h, nextTick } from 'vue'
 
 import MetaAutomationLogViewer from '../src/multitable/components/MetaAutomationLogViewer.vue'
 import type { AutomationExecution, AutomationStats } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
 
 interface MockClientOptions {
   logs?: AutomationExecution[]
@@ -100,9 +101,69 @@ afterEach(() => {
     mounted.container.remove()
     mounted = null
   }
+  useLocale().setLocale('en')
 })
 
 describe('MetaAutomationLogViewer — backend contract normalization', () => {
+  it('localizes log chrome in zh-CN while preserving raw status selectors', async () => {
+    useLocale().setLocale('zh-CN')
+    const client = makeMockClient({
+      logs: [PASS_EXECUTION],
+      stats: { total: 1, success: 1, failed: 0, skipped: 0, avgDuration: 42 },
+    })
+    mounted = mount({ visible: true, sheetId: 's', ruleId: 'rule-1', client })
+    await flushPromises()
+
+    const text = mounted.container.textContent ?? ''
+    expect(text).toContain('执行日志')
+    expect(text).toContain('总计')
+    expect(text).toContain('成功')
+    expect(text).toContain('失败')
+    expect(text).toContain('平均耗时')
+    expect(text).toContain('全部状态')
+    expect(text).toContain('刷新')
+    expect(text).not.toContain('Execution Logs')
+    expect(text).not.toContain('All statuses')
+
+    const statusBadge = mounted.container.querySelector('[data-log-id="exec-pass"] [data-status="success"]')
+    expect(statusBadge).not.toBeNull()
+    expect(statusBadge?.textContent?.trim()).toBe('成功')
+  })
+
+  it('localizes expanded step and support actions in zh-CN without changing data-action attributes', async () => {
+    useLocale().setLocale('zh-CN')
+    const writeText = vi.fn().mockResolvedValue(undefined)
+    Object.defineProperty(navigator, 'clipboard', {
+      value: { writeText },
+      configurable: true,
+    })
+    const client = makeMockClient({ logs: [PASS_EXECUTION] })
+    mounted = mount({ visible: true, sheetId: 's', ruleId: 'rule-1', client })
+    await flushPromises()
+
+    const item = mounted.container.querySelector('[data-log-id="exec-pass"]') as HTMLElement
+    item.click()
+    await nextTick()
+
+    expect(item.textContent ?? '').toContain('发送邮件')
+    expect(item.querySelector('[data-action="copy-support-packet"]')?.textContent).toContain('复制脱敏包')
+    expect(item.querySelector('[data-action="download-support-packet"]')?.textContent).toContain('下载 JSON')
+
+    ;(item.querySelector('[data-action="copy-support-packet"]') as HTMLButtonElement).click()
+    await flushPromises()
+    expect(item.querySelector('[data-field="support-packet-status"]')?.textContent).toContain('已复制脱敏包')
+  })
+
+  it('does not add aria-label, title, or placeholder attributes for the log viewer fixture', async () => {
+    const client = makeMockClient({ logs: [PASS_EXECUTION] })
+    mounted = mount({ visible: true, sheetId: 's', ruleId: 'rule-1', client })
+    await flushPromises()
+
+    expect(mounted.container.querySelectorAll('[aria-label]')).toHaveLength(0)
+    expect(mounted.container.querySelectorAll('[title]')).toHaveLength(0)
+    expect(mounted.container.querySelectorAll('[placeholder]')).toHaveLength(0)
+  })
+
   it('renders `triggeredAt` as the log time, not the removed `startedAt`', async () => {
     const client = makeMockClient({ logs: [PASS_EXECUTION] })
     mounted = mount({ visible: true, sheetId: 's', ruleId: 'rule-1', client })

--- a/apps/web/tests/meta-automation-delivery-viewers-i18n.spec.ts
+++ b/apps/web/tests/meta-automation-delivery-viewers-i18n.spec.ts
@@ -1,0 +1,182 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+
+import MetaAutomationGroupDeliveryViewer from '../src/multitable/components/MetaAutomationGroupDeliveryViewer.vue'
+import MetaAutomationPersonDeliveryViewer from '../src/multitable/components/MetaAutomationPersonDeliveryViewer.vue'
+import { useLocale } from '../src/composables/useLocale'
+import type { DingTalkGroupDelivery, DingTalkPersonDelivery } from '../src/multitable/types'
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+function flushPromises() {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0)).then(() => nextTick())
+}
+
+function mount(component: typeof MetaAutomationGroupDeliveryViewer | typeof MetaAutomationPersonDeliveryViewer, client: Record<string, unknown>) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp({
+    render: () => h(component, {
+      visible: true,
+      sheetId: 'sheet_1',
+      ruleId: 'rule_1',
+      client,
+    }),
+  })
+  app.mount(container)
+  return container
+}
+
+afterEach(() => {
+  app?.unmount()
+  app = null
+  container?.remove()
+  container = null
+  useLocale().setLocale('en')
+})
+
+const GROUP_DELIVERIES: DingTalkGroupDelivery[] = [
+  {
+    id: 'group_delivery_1',
+    destinationId: 'dt_group_1',
+    destinationName: 'Ops Group',
+    sourceType: 'automation',
+    subject: 'Ticket rec_1 pending',
+    content: 'Please process.',
+    success: true,
+    createdAt: '2026-05-01T10:00:00.000Z',
+  },
+  {
+    id: 'group_delivery_2',
+    destinationId: 'dt_group_2',
+    sourceType: 'automation',
+    subject: 'Ticket rec_2 pending',
+    content: 'Please process.',
+    success: false,
+    errorMessage: 'Robot webhook rejected request',
+    createdAt: '2026-05-01T10:01:00.000Z',
+  },
+]
+
+const PERSON_DELIVERIES: DingTalkPersonDelivery[] = [
+  {
+    id: 'person_delivery_1',
+    localUserId: 'user_1',
+    localUserLabel: 'Lin Lan',
+    localUserSubtitle: 'lin@example.com',
+    localUserIsActive: true,
+    dingtalkUserId: 'dt_user_1',
+    sourceType: 'automation',
+    subject: 'Ticket rec_1 ready',
+    content: 'Please review.',
+    success: true,
+    status: 'success',
+    createdAt: '2026-05-01T10:00:00.000Z',
+  },
+  {
+    id: 'person_delivery_2',
+    localUserId: 'user_2',
+    localUserLabel: 'Inactive User',
+    localUserIsActive: false,
+    sourceType: 'automation',
+    subject: 'Ticket rec_2 ready',
+    content: 'Please review.',
+    success: false,
+    status: 'skipped',
+    errorMessage: 'DingTalk account is not linked or user is inactive',
+    createdAt: '2026-05-01T10:01:00.000Z',
+  },
+]
+
+describe('automation delivery viewers i18n', () => {
+  it('localizes DingTalk group delivery chrome while keeping raw status attributes', async () => {
+    useLocale().setLocale('zh-CN')
+    const root = mount(MetaAutomationGroupDeliveryViewer, {
+      getAutomationDingTalkGroupDeliveries: async () => GROUP_DELIVERIES,
+    })
+    await flushPromises()
+
+    const text = root.textContent ?? ''
+    expect(text).toContain('钉钉群投递记录')
+    expect(text).toContain('全部状态')
+    expect(text).toContain('成功')
+    expect(text).toContain('失败')
+    expect(text).toContain('刷新')
+    expect(text).toContain('Ops Group')
+    expect(text).toContain('Robot webhook rejected request')
+    expect(text).not.toContain('DingTalk Group Deliveries')
+
+    expect(root.querySelector('[data-status="success"]')?.textContent?.trim()).toBe('成功')
+    expect(root.querySelector('[data-status="failed"]')?.textContent?.trim()).toBe('失败')
+    expect(root.querySelectorAll('[aria-label]')).toHaveLength(0)
+    expect(root.querySelectorAll('[title]')).toHaveLength(0)
+    expect(root.querySelectorAll('[placeholder]')).toHaveLength(0)
+  })
+
+  it('localizes DingTalk person delivery chrome while preserving raw IDs and status attributes', async () => {
+    useLocale().setLocale('zh-CN')
+    const root = mount(MetaAutomationPersonDeliveryViewer, {
+      getAutomationDingTalkPersonDeliveries: async () => PERSON_DELIVERIES,
+    })
+    await flushPromises()
+
+    const text = root.textContent ?? ''
+    expect(text).toContain('钉钉个人投递记录')
+    expect(text).toContain('全部状态')
+    expect(text).toContain('跳过 / 未绑定')
+    expect(text).toContain('已停用用户')
+    expect(text).toContain('钉钉：dt_user_1')
+    expect(text).toContain('钉钉账号未绑定或用户已停用')
+    expect(text).toContain('lin@example.com')
+    expect(text).not.toContain('DingTalk Person Deliveries')
+    expect(text).not.toContain('Inactive user')
+
+    expect(root.querySelector('[data-status="success"]')?.textContent?.trim()).toBe('成功')
+    expect(root.querySelector('[data-status="skipped"]')?.textContent?.trim()).toBe('跳过')
+    expect(root.querySelectorAll('[aria-label]')).toHaveLength(0)
+    expect(root.querySelectorAll('[title]')).toHaveLength(0)
+    expect(root.querySelectorAll('[placeholder]')).toHaveLength(0)
+  })
+
+  it('keeps English labels available when locale is en', async () => {
+    useLocale().setLocale('en')
+    const root = mount(MetaAutomationPersonDeliveryViewer, {
+      getAutomationDingTalkPersonDeliveries: async () => PERSON_DELIVERIES,
+    })
+    await flushPromises()
+
+    const text = root.textContent ?? ''
+    expect(text).toContain('DingTalk Person Deliveries')
+    expect(text).toContain('All statuses')
+    expect(text).toContain('Skipped / unbound')
+    expect(text).toContain('Inactive user')
+    expect(text).toContain('DingTalk: dt_user_1')
+    expect(text).not.toContain('钉钉个人投递记录')
+  })
+
+  it('uses localized static load fallback while preserving backend error messages raw', async () => {
+    useLocale().setLocale('zh-CN')
+    const fallbackRoot = mount(MetaAutomationGroupDeliveryViewer, {
+      getAutomationDingTalkGroupDeliveries: async () => {
+        throw 'no details'
+      },
+    })
+    await flushPromises()
+    expect(fallbackRoot.textContent ?? '').toContain('加载钉钉群投递记录失败。')
+
+    app?.unmount()
+    fallbackRoot.remove()
+    app = null
+    container = null
+
+    const rawRoot = mount(MetaAutomationPersonDeliveryViewer, {
+      getAutomationDingTalkPersonDeliveries: async () => {
+        throw new Error('upstream timeout')
+      },
+    })
+    await flushPromises()
+    expect(rawRoot.textContent ?? '').toContain('upstream timeout')
+    expect(rawRoot.textContent ?? '').not.toContain('加载钉钉个人投递记录失败。')
+  })
+})

--- a/apps/web/tests/meta-automation-labels.spec.ts
+++ b/apps/web/tests/meta-automation-labels.spec.ts
@@ -1,0 +1,46 @@
+import { describe, expect, it } from 'vitest'
+
+import {
+  AUTOMATION_LABEL_KEYS,
+  automationActionTypeLabel,
+  automationLabel,
+  automationStatusLabel,
+  supportCopyFailed,
+  supportDownloadFailed,
+} from '../src/multitable/utils/meta-automation-labels'
+
+describe('meta-automation-labels', () => {
+  it('keeps the exported key list unique and fully readable in both locales', () => {
+    expect(new Set(AUTOMATION_LABEL_KEYS).size).toBe(AUTOMATION_LABEL_KEYS.length)
+
+    for (const key of AUTOMATION_LABEL_KEYS) {
+      expect(automationLabel(key, false), key).toBeTruthy()
+      expect(automationLabel(key, true), key).toBeTruthy()
+    }
+  })
+
+  it('localizes automation statuses and preserves unknown status values raw', () => {
+    expect(automationStatusLabel('success', false)).toBe('success')
+    expect(automationStatusLabel('success', true)).toBe('成功')
+    expect(automationStatusLabel('failed', true)).toBe('失败')
+    expect(automationStatusLabel('skipped', true)).toBe('跳过')
+    expect(automationStatusLabel('running', true)).toBe('运行中')
+    expect(automationStatusLabel('custom_status', true)).toBe('custom_status')
+  })
+
+  it('localizes known action types and preserves unknown action types raw', () => {
+    expect(automationActionTypeLabel('send_email', false)).toBe('Send email')
+    expect(automationActionTypeLabel('send_email', true)).toBe('发送邮件')
+    expect(automationActionTypeLabel('send_dingtalk_group_message', true)).toBe('发送钉钉群消息')
+    expect(automationActionTypeLabel('notify', true)).toBe('发送通知')
+    expect(automationActionTypeLabel('update_field', true)).toBe('更新字段值')
+    expect(automationActionTypeLabel('future_action', true)).toBe('future_action')
+  })
+
+  it('keeps support failure messages as localized chrome plus raw detail', () => {
+    expect(supportCopyFailed('Network down', false)).toBe('Copy failed: Network down')
+    expect(supportCopyFailed('Network down', true)).toBe('复制失败：Network down')
+    expect(supportDownloadFailed('Disk full', false)).toBe('Download failed: Disk full')
+    expect(supportDownloadFailed('Disk full', true)).toBe('下载失败：Disk full')
+  })
+})

--- a/docs/development/multitable-t3d-automation-i18n-design-20260521.md
+++ b/docs/development/multitable-t3d-automation-i18n-design-20260521.md
@@ -1,0 +1,473 @@
+# Multitable T3D Automation I18n Design (2026-05-21)
+
+## 1. Decision Summary
+
+T3D is the remaining automation surface after T3A/T3B/T3C/T3E landed. The scout shows it is materially larger than the prior cleanup slices:
+
+| Surface | File | Size | Main i18n risk |
+| --- | --- | ---: | --- |
+| Automation manager | `MetaAutomationManager.vue` | 2,283 lines | Legacy quick form, rule cards, DingTalk preview strings, dynamic summaries |
+| Rule editor | `MetaAutomationRuleEditor.vue` | 2,748 lines | Trigger/action/condition enums, nested condition builder, DingTalk action config |
+| Log viewer | `MetaAutomationLogViewer.vue` | 423 lines | Status/action labels, support packet status, redaction boundary |
+| Group deliveries | `MetaAutomationGroupDeliveryViewer.vue` | 269 lines | Delivery status chrome, error fallback |
+| Person deliveries | `MetaAutomationPersonDeliveryViewer.vue` | 322 lines | Success/failed/skipped labels, inactive-user chrome |
+| Shared DingTalk helpers | `dingtalk*.ts` utils | 6 files | Warning strings, template token labels, access summaries |
+
+Recommended implementation shape: split T3D into four PRs. This keeps each review small while preserving a single automation-domain label module.
+
+| Slice | Scope | Rationale |
+| --- | --- | --- |
+| T3D-1 | `meta-automation-labels.ts` foundation + log viewer + group/person delivery viewers | Lowest coupling; validates enum label helpers, redaction boundary, and status raw/data split first. |
+| T3D-2 | `MetaAutomationRuleEditor.vue` core editor | Largest enum-heavy surface; should land alone. Includes trigger/action/condition/operator labels and non-DingTalk action chrome. |
+| T3D-3 | `MetaAutomationManager.vue` shell/card/legacy quick form | Parent manager has separate card summaries and legacy form semantics; separate from rule editor to avoid a 5k-line review. |
+| T3D-4 | DingTalk automation shared chrome and helper utilities | Template token labels, warning helpers, public/internal link access summaries, preset buttons, preview labels across manager + rule editor. |
+
+Design choice: create `apps/web/src/multitable/utils/meta-automation-labels.ts` and extend it across all T3D sub-slices. Automation is a single domain with shared persisted enums and shared DingTalk copy, so a per-component module would duplicate trigger/action/status helpers. This differs from T3C per-manager modules because automation rule editor, manager cards, logs, and delivery viewers all render the same rule/action/status concepts.
+
+## 2. Files In Scope
+
+T3D-1 in scope:
+
+| File | Change |
+| --- | --- |
+| `apps/web/src/multitable/utils/meta-automation-labels.ts` | New typed label module; initial status/action/log/delivery helpers. |
+| `apps/web/src/multitable/components/MetaAutomationLogViewer.vue` | Localize visible chrome; keep redacted content raw. |
+| `apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue` | Localize delivery viewer chrome and status labels. |
+| `apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue` | Localize delivery viewer chrome and status labels. |
+| `apps/web/tests/meta-automation-labels.spec.ts` | New helper spec. |
+| `apps/web/tests/MetaAutomationLogViewer.spec.ts` | Extend existing spec for zh/en labels and raw-boundary checks. |
+| `apps/web/tests/meta-automation-delivery-viewers-i18n.spec.ts` | New direct render spec for group/person delivery viewers. |
+| `docs/development/multitable-t3d-automation-i18n-verification-20260521.md` | Verification report for T3D-1. |
+
+T3D-2/T3D-3/T3D-4 deferred from the first PR but covered by this design:
+
+| Surface | Files |
+| --- | --- |
+| Rule editor | `MetaAutomationRuleEditor.vue`, `multitable-automation-rule-editor.spec.ts` |
+| Manager | `MetaAutomationManager.vue`, `multitable-automation-manager.spec.ts` |
+| DingTalk helpers | `dingtalkNotificationTemplateTokens.ts`, `dingtalkNotificationTemplateLint.ts`, `dingtalkRecipientFieldWarnings.ts`, `dingtalkPublicFormLinkWarnings.ts`, `dingtalkInternalViewLinkWarnings.ts`, `dingtalkNotificationPresets.ts` |
+| Automation composable fallbacks | `useMultitableAutomations.ts` |
+
+Out of scope for all T3D slices:
+
+| Area | Reason |
+| --- | --- |
+| Backend automation runtime | T3D is frontend i18n only. No contract/API/migration changes. |
+| Automation execution behavior | Rule semantics, delivery behavior, log redaction logic, and support-packet payloads remain unchanged. |
+| T3 final audit | Runs after T3D implementation. |
+| K3/attendance/integration-core | K3 PoC stage-1 lock remains active. |
+
+## 3. Label Module
+
+New module:
+
+```ts
+// apps/web/src/multitable/utils/meta-automation-labels.ts
+export type AutomationLabelKey = ...
+export function automationLabel(key: AutomationLabelKey, isZh: boolean): string
+export function automationStatusLabel(status: AutomationExecutionStatus, isZh: boolean): string
+export function automationActionTypeLabel(type: AutomationActionType, isZh: boolean): string
+export function automationTriggerTypeLabel(type: AutomationTriggerType, isZh: boolean): string
+export function automationConditionOperatorLabel(op: ConditionOperator, isZh: boolean): string
+export type AutomationConditionValueWidget =
+  | 'text'
+  | 'number'
+  | 'date'
+  | 'dateTime'
+  | 'boolean'
+  | 'booleanMultiSelect'
+  | 'select'
+  | 'multiSelect'
+export function automationConditionValuePlaceholder(widget: AutomationConditionValueWidget, isArray: boolean, isZh: boolean): string
+```
+
+The `AutomationConditionValueWidget` union mirrors the real `ConditionValueWidget` in `MetaAutomationRuleEditor.vue`: `text`, `number`, `date`, `dateTime`, `boolean`, `booleanMultiSelect`, `select`, and `multiSelect`. Do not accept free strings.
+
+Initial T3D-1 key groups:
+
+| Namespace | Examples |
+| --- | --- |
+| `log.*` | `log.title`, `log.total`, `log.success`, `log.failed`, `log.avgDuration`, `log.loading`, `log.empty`, `log.retry` |
+| `status.*` | `status.all`, `status.success`, `status.failed`, `status.skipped` |
+| `support.*` | `support.copyPacket`, `support.downloadJson`, `support.clipboardUnavailable`, `support.copied`, `support.copyFailed`, `support.downloaded`, `support.downloadFailed` |
+| `delivery.*` | `delivery.groupTitle`, `delivery.personTitle`, `delivery.loading`, `delivery.emptyGroup`, `delivery.emptyPerson`, `delivery.refresh`, `delivery.inactiveUser`, `delivery.dingtalkPrefix` |
+| `error.*` | `error.loadLogs`, `error.loadStats`, `error.loadGroupDeliveries`, `error.loadPersonDeliveries`, `error.unknown` |
+
+Future T3D-2/T3D-3/T3D-4 key groups:
+
+| Namespace | Examples |
+| --- | --- |
+| `manager.*` | `manager.title`, `manager.empty`, `manager.newAutomation`, `manager.quickLegacyForm`, `manager.enabled`, `manager.disabled` |
+| `editor.*` | `editor.newTitle`, `editor.editTitle`, `editor.name`, `editor.save`, `editor.saving`, `editor.cancel`, `editor.testRun` |
+| `trigger.*` | `trigger.recordCreated`, `trigger.recordUpdated`, `trigger.recordDeleted`, `trigger.fieldValueChanged`, `trigger.scheduleCron`, `trigger.scheduleInterval`, `trigger.webhookReceived`, legacy `trigger.fieldChanged` |
+| `action.*` | `action.updateRecord`, `action.createRecord`, `action.sendWebhook`, `action.sendNotification`, `action.sendEmail`, `action.sendDingTalkGroup`, `action.sendDingTalkPerson`, `action.lockRecord`, legacy `action.notify`, `action.updateField` |
+| `condition.*` | `condition.equals`, `condition.notEquals`, `condition.contains`, `condition.notContains`, `condition.greaterThan`, `condition.isEmpty`, etc. |
+| `dingtalk.*` | preset buttons, recipient labels, template placeholders, dynamic warning fallbacks, preview labels |
+
+Legacy `action.notify` and `action.updateField` keys coexist with the newer action keys for persisted legacy automation data and the manager quick legacy form. New V1 rule-editor actions use `action.sendNotification`, `action.updateRecord`, and related V1 keys; do not retire the legacy labels until the legacy quick form is removed.
+
+No cross-module redeclare:
+
+| Existing module | Rule |
+| --- | --- |
+| `meta-manager-labels.ts` | Do not add automation labels here, even if a word like `action.cancel` exists. Automation owns its own button labels because rule editor and manager do not import manager panels. |
+| `meta-api-token-labels.ts` | Do not reuse DingTalk group labels from API token manager. API-token DingTalk group management and automation delivery config are separate consumer surfaces. |
+| `workbench-labels.ts` | Do not add automation manager labels here. Workbench owns outer shell/toasts; automation modal owns its chrome. |
+| `meta-core-labels.ts` | Do not add automation status/action enums here. Meta core remains grid/table/cell cross-surface infrastructure. |
+
+## 4. Raw Boundary
+
+Persisted values and user/admin-authored data stay raw. This is the most important T3D rule because existing specs heavily depend on raw selectors and enum values.
+
+Always raw:
+
+| Category | Examples |
+| --- | --- |
+| Persisted enums in values/config | `record.created`, `field.value_changed`, `send_dingtalk_group_message`, `equals`, `POST`, `success` |
+| `data-*` and CSS-class suffixes | `:data-status="log.status"`, `:data-access-level="accessState.level"`, `meta-log-viewer__badge--${log.status}` |
+| User/admin content | rule names, field names, view names, destination names, webhook URLs, email addresses, template bodies, notification messages |
+| Identifiers | rule IDs, record IDs, sheet IDs, field IDs, user IDs, member group IDs, destination IDs |
+| Backend/runtime error text | `error.message`, `errorMessage`, redacted step errors, support packet text |
+| Redacted support output | Keep `summarizeStepError`, `summarizeStepOutput`, and support-packet payload content semantically unchanged. |
+
+Visible enum labels may be localized only through helper functions with raw fallback:
+
+```ts
+automationActionTypeLabel(action.type, isZh.value) // known enum -> localized label, unknown -> String(type)
+automationStatusLabel(log.status, isZh.value)      // visible badge text only
+```
+
+The raw selector must remain separate:
+
+```vue
+<span
+  :class="`meta-log-viewer__badge--${log.status}`"
+  :data-status="log.status"
+>
+  {{ automationStatusLabel(log.status, isZh) }}
+</span>
+```
+
+## 5. Exact Chrome Targets
+
+### 5.1 T3D-1: Log Viewer
+
+Real source: `MetaAutomationLogViewer.vue`.
+
+| Current EN | Proposed zh | Notes |
+| --- | --- | --- |
+| Execution Logs | 执行日志 | `log.title` |
+| Total / Success / Failed / Avg duration | 总计 / 成功 / 失败 / 平均耗时 | stats labels |
+| All statuses / Success / Failed / Skipped | 全部状态 / 成功 / 失败 / 跳过 | visible option labels; option values stay raw |
+| Refresh | 刷新 | `delivery.refresh` or shared `log.refresh` |
+| Failed to load logs: | 加载日志失败： | prefix only; `loadError` raw/redacted |
+| Retry | 重试 | button |
+| Loading logs... | 正在加载日志... | loading state |
+| No execution logs found. | 暂无执行日志。 | empty state |
+| Copy redacted packet | 复制脱敏包 | support action |
+| Download JSON | 下载 JSON | support action |
+| Clipboard unavailable | 剪贴板不可用 | thrown fallback |
+| Redacted packet copied. | 已复制脱敏包。 | support status |
+| Copy failed: `message` | 复制失败：`message` | `message` raw |
+| Redacted JSON downloaded. | 已下载脱敏 JSON。 | support status |
+| Download failed: `message` | 下载失败：`message` | `message` raw |
+| Unknown error | 未知错误 | fallback only |
+
+Status badges:
+
+| Raw status | EN label | zh label |
+| --- | --- | --- |
+| `success` | success | 成功 |
+| `failed` | failed | 失败 |
+| `skipped` | skipped | 跳过 |
+
+Action type labels inside step rows use `automationActionTypeLabel`. Unknown action types display raw `String(actionType)`.
+
+### 5.2 T3D-1: Delivery Viewers
+
+Real source: `MetaAutomationGroupDeliveryViewer.vue` and `MetaAutomationPersonDeliveryViewer.vue`.
+
+| Current EN | Proposed zh | Notes |
+| --- | --- | --- |
+| DingTalk Group Deliveries | 钉钉群投递记录 | group title |
+| DingTalk Person Deliveries | 钉钉个人投递记录 | person title |
+| All statuses | 全部状态 | select option; value raw |
+| Success / Failed / Skipped / unbound | 成功 / 失败 / 跳过 / 未绑定 | visible labels |
+| Refresh | 刷新 | shared |
+| Loading deliveries... | 正在加载投递记录... | loading state |
+| No DingTalk group deliveries found. | 暂无钉钉群投递记录。 | empty group |
+| No DingTalk person deliveries found. | 暂无钉钉个人投递记录。 | empty person |
+| Inactive user | 已停用用户 | visible tag |
+| DingTalk: `id` | 钉钉：`id` | prefix localized, ID raw |
+| Failed to load DingTalk group deliveries. | 加载钉钉群投递记录失败。 | static fallback only; error.message wins |
+| Failed to load DingTalk person deliveries. | 加载钉钉个人投递记录失败。 | static fallback only; error.message wins |
+| DingTalk account is not linked or user is inactive | 钉钉账号未绑定或用户已停用 | This is a frontend sentinel constant; localize visible fallback but keep comparison against raw constant. |
+
+### 5.3 T3D-2: Rule Editor
+
+Real source: `MetaAutomationRuleEditor.vue`.
+
+This slice is intentionally not part of T3D-1. It needs a dedicated PR because it includes nested condition groups, typed discriminator helpers, test-run confirmation, and action-specific config panels.
+
+Representative target groups:
+
+| Group | Examples |
+| --- | --- |
+| Shell | `Edit Automation Rule`, `New Automation Rule`, `Name`, `Automation name`, `Save`, `Saving...`, `Cancel`, `Test Run`, `Running...` |
+| Trigger | `When record created`, `When record updated`, `When record deleted`, `When field value changed`, `Schedule (cron)`, `Schedule (interval)`, `Webhook received` |
+| Schedule | `Preset`, `Every 5 minutes`, `Every hour`, `Daily at midnight`, `Weekly (Monday)`, `Custom`, `Cron expression`, `Interval (minutes)` |
+| Conditions | `Conditions`, `(optional)`, `AND`, `OR`, `Group`, `+ Condition`, `+ Group`, `Remove group`, `Remove condition`, `Comma-separated values`, `Number`, `Date and time` |
+| Operators | `Equals`, `Not equals`, `Contains`, `Not contains`, `Greater than`, `Less than`, `Greater or equal`, `Less or equal`, `Is empty`, `Is not empty`, `In list`, `Not in list` |
+| Actions | `Update record`, `Create record`, `Send webhook`, `Send notification`, `Send email`, `Send DingTalk group message`, `Send DingTalk person message`, `Lock record` |
+| Footer/test | `Test Run executes...`, `Save this automation before running a test.`, confirm message, status messages |
+
+Typed discriminator requirements:
+
+| Helper | Required type |
+| --- | --- |
+| `automationTriggerTypeLabel(type, isZh)` | `AutomationTriggerType` with raw fallback |
+| `automationActionTypeLabel(type, isZh)` | `AutomationActionType` with raw fallback |
+| `automationConditionOperatorLabel(op, isZh)` | `ConditionOperator` with raw fallback |
+| `automationConditionValuePlaceholder(widget, isArray, isZh)` | explicit literal union, no free string |
+
+### 5.4 T3D-3: Automation Manager
+
+Real source: `MetaAutomationManager.vue`.
+
+Representative target groups:
+
+| Group | Examples |
+| --- | --- |
+| Shell | `Automations`, `Edit Automation`, `New Automation`, `+ New Automation`, `Quick legacy form` |
+| Legacy quick form | `Name`, `Trigger`, `Action`, `Message`, `Target field`, `Value`, `Update`, `Create`, `Cancel` |
+| Rule list | `Loading automations...`, `No automations yet. Create your first automation rule.`, `Enabled`, `Disabled`, `Edit`, `View Logs`, `View Deliveries`, `Delete` |
+| Card summaries | `When a record is created`, `When "field" changes`, `Send notification`, `Update "field"`, `Public form: ...`, `Internal processing: ...`, `ok`, `fail` |
+| Test run status | `Running test.`, `Running test. DingTalk actions may send real messages.`, `Test run succeeded`, `failed`, `skipped` |
+| Composable fallbacks | `Failed to load/create/update/delete automation rule` from `useMultitableAutomations.ts` |
+
+Manager cards must keep all rule names and field/view names raw. Description helpers should accept raw names and interpolate them without translation.
+
+### 5.5 T3D-4: DingTalk Automation Chrome
+
+Real source: shared code paths in `MetaAutomationManager.vue`, `MetaAutomationRuleEditor.vue`, and `dingtalk*.ts` helpers.
+
+This is separated because manager and rule editor duplicate the same DingTalk group/person UI. The implementation should first extract/reuse shared automation label helpers, then wire both consumers.
+
+Representative targets:
+
+| Group | Examples |
+| --- | --- |
+| Presets | `Message preset`, `Form request`, `Internal processing`, `Form + processing` |
+| Group config | `Add DingTalk groups`, `-- add DingTalk group --`, `Record group field paths (optional)`, `Pick group field` |
+| Person config | `Search and add users or member groups`, `Local user IDs`, `Member group IDs (optional)`, `Pick recipient field`, `Pick member group field` |
+| Template chrome | `Title template`, `Body template`, `Template tokens`, `Copy`, `Copied`, `Rendered title`, `No rendered title` |
+| Link chrome | `Public form view (optional)`, `Internal processing view (optional)`, `Public form access`, `Allowed audience` |
+| Warning helpers | unsupported placeholder, unknown placeholder, field path warnings, public/internal view link warnings |
+| Existing zh-only placeholders | `例如：...`, `支持 ...`, `使用逗号...` must become bilingual through the label module. |
+
+Scout-locked zh-only placeholders for T3D-4:
+
+| File:line | Current zh-only text | Planned treatment |
+| --- | --- | --- |
+| `MetaAutomationManager.vue:169` | `例如：{{record.title}} 待处理` | bilingual title-template example placeholder |
+| `MetaAutomationManager.vue:360` | `使用逗号或换行分隔本地 userId` | bilingual local-user-IDs placeholder |
+| `MetaAutomationManager.vue:368` | `使用逗号或换行分隔成员组 ID` | bilingual member-group-IDs placeholder |
+| `MetaAutomationManager.vue:376` | `例如：record.assigneeUserIds, record.reviewerUserId` | bilingual recipient-field-path placeholder |
+| `MetaAutomationManager.vue:421` | `例如：record.watcherGroupIds, record.escalationGroupId` | bilingual member-group-field-path placeholder |
+| `MetaAutomationManager.vue:466` | `例如：{{record.title}} 待处理` | bilingual person-title-template example placeholder |
+| `MetaAutomationRuleEditor.vue:415` | `例如：{{record.title}} 待处理` | bilingual title-template example placeholder |
+| `MetaAutomationRuleEditor.vue:627` | `使用逗号或换行分隔本地 userId` | bilingual local-user-IDs placeholder |
+| `MetaAutomationRuleEditor.vue:635` | `使用逗号或换行分隔成员组 ID` | bilingual member-group-IDs placeholder |
+| `MetaAutomationRuleEditor.vue:643` | `例如：record.assigneeUserIds, record.reviewerUserId` | bilingual recipient-field-path placeholder |
+| `MetaAutomationRuleEditor.vue:688` | `例如：record.watcherGroupIds, record.escalationGroupId` | bilingual member-group-field-path placeholder |
+| `MetaAutomationRuleEditor.vue:733` | `例如：{{record.title}} 待处理` | bilingual person-title-template example placeholder |
+
+Template token labels should become locale-aware:
+
+| Token | EN | zh |
+| --- | --- | --- |
+| `recordId` | Record ID | 记录 ID |
+| `sheetId` | Sheet ID | 表 ID |
+| `actorId` | Actor ID | 操作者 ID |
+| `recordField` | Record field | 记录字段 |
+
+## 6. A11y and Selector Boundary
+
+T3D localizes existing text, placeholders, and `title` attributes where already present. It must not add new aria/title/placeholder attributes unless a separate accessibility bug is explicitly found and reviewed.
+
+Known existing a11y-related attributes:
+
+| File | Existing attributes |
+| --- | --- |
+| `MetaAutomationRuleEditor.vue` | `title="Remove group"`, `title="Remove condition"`, `title="Move up"`, `title="Move down"`, `title="Remove action"`, many placeholders |
+| `MetaAutomationManager.vue` | placeholders in form inputs/textareas |
+| `MetaAutomationLogViewer.vue` | no aria/title/placeholder additions required |
+| Delivery viewers | no aria/title/placeholder additions required |
+
+Each slice must lock the "no new a11y attributes" boundary with fixture-computed sentinel counts:
+
+| Slice | Sentinel requirement |
+| --- | --- |
+| T3D-1 | Log viewer and delivery viewer specs assert `[aria-label]`, `[title]`, and `[placeholder]` counts for the mounted fixtures, even when the expected count is `0`. |
+| T3D-2 | Rule editor spec asserts `[title]` count for the 5 existing title buttons and fixture-computed `[placeholder]` count. The test localizes existing text but must not create new attributes. |
+| T3D-3 | Manager spec asserts fixture-computed `[placeholder]` count and `[aria-label]`/`[title]` counts. |
+| T3D-4 | DingTalk wiring must not alter the counts already locked by T3D-2/T3D-3; verification records the before/after count for the touched fixtures. |
+
+Selector boundary:
+
+| Raw selector | Must remain raw |
+| --- | --- |
+| `data-action` | `refresh`, `retry`, `save`, `test`, `copy-support-packet`, etc. |
+| `data-status` | `success`, `failed`, `skipped`, `running` |
+| `data-field` / `data-automation-field` | field identifiers used by tests |
+| class suffixes | `--success`, `--failed`, `--skipped`, `--running`, `--dingtalk_granted` |
+
+## 7. Preflight Grep
+
+Before each implementation slice, run a slice-specific grep and paste the output into the verification MD.
+
+T3D-1 preflight:
+
+```bash
+rg -n "Execution Logs|Total|Success|Failed|Avg duration|All statuses|Skipped|Refresh|Failed to load logs|Retry|Loading logs|No execution logs|Copy redacted packet|Download JSON|Clipboard unavailable|Redacted packet copied|Copy failed|Redacted JSON downloaded|Download failed|DingTalk Group Deliveries|DingTalk Person Deliveries|Loading deliveries|No DingTalk group deliveries|No DingTalk person deliveries|Inactive user|DingTalk:|Failed to load DingTalk .* deliveries|DingTalk account is not linked" \
+  apps/web/src/multitable/components/MetaAutomationLogViewer.vue \
+  apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue \
+  apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue
+```
+
+T3D-2/T3D-3/T3D-4 must use equivalent grep commands for their planned keys before writing labels. Any planned key without a real call-site must be removed or explicitly deferred before implementation.
+
+No dead-key rule:
+
+| Rule | Enforcement |
+| --- | --- |
+| Every new static key has a call-site | helper spec plus `rg "automationLabel\\('key'"` or equivalent in verification |
+| Every helper has render or unit coverage | `meta-automation-labels.spec.ts` plus surface specs |
+| Retired string keys are removed lockstep | union type, label map, and ALL_KEYS-style helper spec updated in same commit |
+
+## 8. Test Plan
+
+Shared test pattern:
+
+| Requirement | Pattern |
+| --- | --- |
+| Locale reset | `useLocale().setLocale('en')` in `afterEach`, same as T3A/T3B/T3C/T3E specs |
+| Mount/teardown | Canonical `createApp + container + app.unmount() + container.remove()` pattern |
+| Raw/data checks | Assert `data-status`, `data-action`, `data-field`, and class suffixes remain raw |
+| EN baseline | Existing English UI remains available when locale is `en` |
+| zh render | Switch `useLocale().setLocale('zh-CN')`, assert visible Chinese chrome |
+| Raw data | Assert rule names, field names, IDs, backend errors, and redacted text remain raw where expected |
+| A11y sentinel counts | Assert fixture-computed `[aria-label]`, `[title]`, and `[placeholder]` counts; localizing existing text is allowed, adding attributes is not. |
+
+T3D-1 tests:
+
+| Spec | Coverage |
+| --- | --- |
+| `meta-automation-labels.spec.ts` | all initial keys, status helpers, action helper fallback, support status helpers |
+| `MetaAutomationLogViewer.spec.ts` | zh title/stats/status/filter/buttons; raw `data-status`; raw `triggeredBy`; redacted step content unchanged; support packet status localized |
+| `meta-automation-delivery-viewers-i18n.spec.ts` | group/person zh titles, filters, status labels, empty/loading states, `DingTalk:` prefix, raw IDs and `data-status`; `[aria-label]`/`[title]`/`[placeholder]` counts locked |
+
+T3D-2 tests:
+
+| Spec | Coverage |
+| --- | --- |
+| `meta-automation-labels.spec.ts` | trigger/action/operator helpers and raw fallback |
+| `multitable-automation-rule-editor.spec.ts` | zh render sentinel for trigger/action/condition sections; raw option values; `data-action`, `data-field`, `data-status` unchanged; test-run confirm localized; `[title]` and `[placeholder]` counts locked |
+
+T3D-3 tests:
+
+| Spec | Coverage |
+| --- | --- |
+| `multitable-automation-manager.spec.ts` | zh manager shell/card actions; enabled/disabled labels; card summary helpers; composable fallback labels; raw rule/field/view names; `[aria-label]`/`[title]`/`[placeholder]` counts locked |
+
+T3D-4 tests:
+
+| Spec | Coverage |
+| --- | --- |
+| `meta-automation-labels.spec.ts` | DingTalk helper labels, token labels, warning helper labels |
+| `multitable-automation-rule-editor.spec.ts` | DingTalk group/person action chrome in zh; warning strings localized; template raw values unchanged |
+| `multitable-automation-manager.spec.ts` | legacy quick-form DingTalk chrome in zh; preview labels localized; copied/copy states localized |
+| existing DingTalk warning specs | update to accept locale-aware helpers while preserving raw field/view names |
+
+Validation commands, package-relative because `--filter @metasheet/web exec` runs with `apps/web` as cwd:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/meta-automation-labels.spec.ts tests/MetaAutomationLogViewer.spec.ts tests/meta-automation-delivery-viewers-i18n.spec.ts --reporter=dot
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web build
+git diff --check origin/main..HEAD
+```
+
+For T3D-2/T3D-3/T3D-4, add the relevant existing specs:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts tests/multitable-automation-manager.spec.ts --reporter=dot
+```
+
+## 9. Implementation Order
+
+T3D-1:
+
+1. Run the T3D-1 preflight grep in section 7.
+2. Add `meta-automation-labels.ts` with status/action/log/delivery keys and helpers.
+3. Add `meta-automation-labels.spec.ts`.
+4. Wire `MetaAutomationLogViewer.vue`.
+5. Wire group/person delivery viewers.
+6. Extend existing log viewer spec and add delivery viewer i18n spec.
+7. Write verification MD with grep evidence, helper reachability evidence, and test output.
+8. Run targeted tests, `vue-tsc`, build, and `git diff --check`.
+9. Commit, stop before push.
+
+T3D-2:
+
+1. Extend `meta-automation-labels.ts` with trigger/action/operator/editor core keys.
+2. Refactor `conditionOperators` labels so values remain raw while labels call helper.
+3. Wire rule editor shell, trigger, schedule, conditions, and non-DingTalk action panels.
+4. Localize test-run confirm and footer copy.
+5. Extend rule editor tests.
+6. Commit, stop before push.
+
+T3D-3:
+
+1. Extend module with manager shell/card/legacy-form keys.
+2. Wire manager visible chrome and description helpers.
+3. Wire `useMultitableAutomations.ts` static fallbacks only; backend errors remain raw when present.
+4. Extend manager tests.
+5. Commit, stop before push.
+
+T3D-4:
+
+1. Extend module with DingTalk-specific labels and helper functions.
+2. Make template token labels locale-aware without changing token values.
+3. Make warning helpers locale-aware; raw field/view/template values stay interpolated raw.
+4. Wire DingTalk group/person config branches in both manager and rule editor.
+5. Extend DingTalk warning/token tests and the manager/rule-editor specs.
+6. Commit, stop before push.
+
+## 10. Risk Register
+
+| Risk | Mitigation |
+| --- | --- |
+| Display text leaks into `data-*` or CSS selectors | Keep helper calls only in visible text/placeholder/title positions; spec asserts raw `data-status` and option values. |
+| Persisted enum values accidentally localized | Select `value` attributes remain literal raw enums; helper only controls option text. |
+| Unknown future enum values disappear | Helper functions must return `String(value)` for unknown values. |
+| Redaction/support-packet semantics change | Do not alter redaction utility behavior; tests keep sentinel leak checks. |
+| Existing tests assert English strings | Update only tests for localized chrome; raw behavior assertions must remain. |
+| Warning helpers translate user data | Helper functions interpolate raw names/IDs without translating them. |
+| T3D single PR becomes unreviewable | Four-slice plan; T3D-1 proves module/test shape before large editor/manager changes. |
+| Existing zh-only placeholders remain asymmetric | T3D-4 converts them to bilingual helpers instead of leaving zh-only literals. |
+| Four back-to-back PRs share `meta-automation-labels.ts`, so mid-flight rebase can conflict in the union type or label map | Before pushing T3D-2/T3D-3/T3D-4, run `git fetch origin && git rebase origin/main`; if the PR is already pushed and becomes BEHIND, use `git push --force-with-lease`; after rebase, inspect `git diff --name-status origin/main..HEAD` to confirm the slice scope is unchanged. |
+
+## 11. Approval Gate
+
+T3D-1 can start implementation when reviewers accept:
+
+1. One automation-domain label module instead of per-component modules.
+2. Four PR split: log/delivery first, rule editor second, manager third, DingTalk helpers fourth.
+3. Visible enum labels localized while option values, `data-*`, class suffixes, and persisted config remain raw.
+4. Backend/runtime/redacted error content remains raw except static frontend fallback labels.
+5. T3D-1 test surface: helper spec + log viewer spec + delivery viewer spec.
+
+T3D-2/T3D-3/T3D-4 each require a short implementation note in their verification MD that maps planned keys to real call-sites and confirms no dead keys were introduced.
+
+T3D-2/T3D-3/T3D-4 verification MDs must also include reuse-grep evidence for helpers consumed from earlier T3D slices, for example proving `automationStatusLabel`, `automationActionTypeLabel`, or `automationConditionOperatorLabel` still exists in `meta-automation-labels.ts` before the later slice extends it.

--- a/docs/development/multitable-t3d1-automation-log-delivery-i18n-verification-20260521.md
+++ b/docs/development/multitable-t3d1-automation-log-delivery-i18n-verification-20260521.md
@@ -1,0 +1,177 @@
+# T3D-1 Automation Log + Delivery I18n Verification - 2026-05-21
+
+## DoD
+
+T3D-1 is limited to the automation execution log viewer, DingTalk group delivery viewer, DingTalk person delivery viewer, and the initial automation i18n label module.
+
+PASS:
+- `meta-automation-labels.ts` added with log, delivery, status, support, and error chrome labels plus typed helpers.
+- `MetaAutomationLogViewer.vue`, `MetaAutomationGroupDeliveryViewer.vue`, and `MetaAutomationPersonDeliveryViewer.vue` render zh-CN chrome while preserving raw IDs, statuses, backend error messages, data attributes, and CSS suffixes.
+- A11y boundary is locked by sentinel counts: no new `aria-label`, `title`, or `placeholder` attributes in the T3D-1 fixtures.
+- Targeted Vitest: 3 files / 25 tests passed.
+- `vue-tsc --noEmit`: exit 0 / no output.
+- `pnpm --filter @metasheet/web build`: passed.
+- `git diff --check origin/main..HEAD` and `git diff --check`: clean.
+
+## Scope
+
+In scope:
+- `apps/web/src/multitable/utils/meta-automation-labels.ts`
+- `apps/web/src/multitable/components/MetaAutomationLogViewer.vue`
+- `apps/web/src/multitable/components/MetaAutomationGroupDeliveryViewer.vue`
+- `apps/web/src/multitable/components/MetaAutomationPersonDeliveryViewer.vue`
+- `apps/web/tests/meta-automation-labels.spec.ts`
+- `apps/web/tests/meta-automation-delivery-viewers-i18n.spec.ts`
+- `apps/web/tests/MetaAutomationLogViewer.spec.ts`
+- `docs/development/multitable-t3d-automation-i18n-design-20260521.md`
+- This verification note.
+
+Out of scope:
+- T3D-2 rule editor.
+- T3D-3 automation manager shell/cards.
+- T3D-4 DingTalk rule configuration copy.
+- Backend, contracts, migrations, attendance, K3.
+
+## Preflight Grep
+
+Command:
+
+```bash
+rg -n "DingTalk Group Deliveries|All statuses|Success|Failed|Refresh|Loading deliveries|No DingTalk group deliveries|DingTalk Person Deliveries|Skipped / unbound|Inactive user|DingTalk account is not linked|Failed to load DingTalk|Execution Logs|Total|Avg duration|Failed to load logs|Retry|Loading logs|No execution logs found|Copy redacted packet|Download JSON|Clipboard unavailable|Redacted packet copied|Redacted JSON downloaded|Copy failed|Download failed" apps/web/src/multitable/components
+```
+
+Initial source hit set was confined to:
+- `MetaAutomationLogViewer.vue`
+- `MetaAutomationGroupDeliveryViewer.vue`
+- `MetaAutomationPersonDeliveryViewer.vue`
+
+Classification:
+- Localized chrome: titles, status labels, buttons, loading/empty states, support-action labels.
+- Raw data retained: IDs, usernames, backend error messages, DingTalk destination/user IDs, redacted packet content.
+- Deferred: T3D-2/T3D-3/T3D-4 automation surfaces.
+
+## Helper Reachability
+
+Command:
+
+```bash
+rg -n "automationLabel\(|automationStatusLabel\(|automationActionTypeLabel\(|supportCopyFailed\(|supportDownloadFailed\(" apps/web/src/multitable apps/web/tests
+```
+
+Evidence:
+- `automationLabel(...)`: label module + all 3 target components + label tests.
+- `automationStatusLabel(...)`: log viewer, group delivery viewer, person delivery viewer, label tests.
+- `automationActionTypeLabel(...)`: log viewer expanded step rows + label tests.
+- `supportCopyFailed(...)`: log viewer catch path + label tests.
+- `supportDownloadFailed(...)`: log viewer catch path + label tests.
+
+T3D-1 is the first automation i18n slice, so there is no earlier T3D helper to reuse yet. This self-grep is the baseline reachability record for T3D-2/3/4.
+
+## Tests
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/meta-automation-labels.spec.ts \
+  tests/MetaAutomationLogViewer.spec.ts \
+  tests/meta-automation-delivery-viewers-i18n.spec.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+✓ tests/meta-automation-labels.spec.ts  (4 tests)
+✓ tests/meta-automation-delivery-viewers-i18n.spec.ts  (4 tests)
+✓ tests/MetaAutomationLogViewer.spec.ts  (17 tests)
+
+Test Files  3 passed (3)
+Tests       25 passed (25)
+```
+
+Coverage points:
+- Helper key list uniqueness and en/zh readability.
+- Status helper localization and unknown raw fallback.
+- Action-type helper localization, legacy action aliases, and unknown raw fallback.
+- Support failure helpers as localized prefix + raw detail.
+- zh-CN log viewer chrome, raw `data-status`, raw `triggeredBy`, and support action behavior.
+- zh-CN group/person delivery chrome, raw status attributes, raw user/subtitle/DingTalk IDs, localized static fallback, backend error raw preservation.
+- English baseline remains available.
+
+## A11y Sentinels
+
+T3D-1 localizes existing visible text only. It does not add new a11y attributes.
+
+Spec-locked fixture counts:
+- Log viewer: `[aria-label] = 0`, `[title] = 0`, `[placeholder] = 0`.
+- Group delivery viewer: `[aria-label] = 0`, `[title] = 0`, `[placeholder] = 0`.
+- Person delivery viewer: `[aria-label] = 0`, `[title] = 0`, `[placeholder] = 0`.
+
+## Raw Boundary
+
+Preserved raw:
+- `data-status` values (`success`, `failed`, `skipped`).
+- CSS class suffixes derived from status values.
+- `<option value="...">` status values.
+- `triggeredBy`.
+- log IDs, delivery IDs, rule IDs, and sheet IDs.
+- DingTalk destination/user IDs.
+- backend `Error.message` values.
+- redacted support-packet content and filenames.
+- unknown status/action enum values via `String(value)` fallback.
+
+Localized:
+- visible status text.
+- target component chrome labels.
+- static fallback messages where no backend message exists.
+- support-copy/support-download success and failure prefixes.
+
+## Typecheck And Build
+
+Typecheck:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result: exit 0 / no output.
+
+Build:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result:
+
+```text
+✓ built in 5.68s
+```
+
+Known build warnings:
+- Existing Vite chunk-size warnings.
+- Existing `WorkflowDesigner.vue` dynamic/static import warning.
+
+Neither warning is introduced by this slice.
+
+## Diff Hygiene
+
+Commands:
+
+```bash
+git diff --check origin/main..HEAD
+git diff --check
+```
+
+Result: both clean.
+
+Dependency note:
+- The T3D worktree did not have local dependencies installed.
+- An ignored symlink `apps/web/node_modules -> /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules` was used only to run web Vitest/typecheck/build from this worktree.
+- Root `node_modules` symlink was removed.
+- No `node_modules` path is staged or part of the PR diff.
+
+## Conclusion
+
+T3D-1 is ready for implementation review. It establishes `meta-automation-labels.ts`, localizes the smallest automation surface first, and preserves the raw runtime/config boundaries needed by later T3D slices.


### PR DESCRIPTION
## Summary

T3D-1 introduces the automation i18n foundation and localizes the smallest automation surface first:

- Add `meta-automation-labels.ts` as the single automation-domain label module.
- Localize `MetaAutomationLogViewer`, `MetaAutomationGroupDeliveryViewer`, and `MetaAutomationPersonDeliveryViewer` chrome.
- Preserve raw runtime/config boundaries: `data-status`, CSS suffixes, status option values, `triggeredBy`, IDs, backend error messages, redacted support-packet content, and the unbound DingTalk sentinel comparison.
- Add helper/render coverage and T3D design + verification notes.

## Design Notes

- New automation module follows `docs/development/multitable-t3d-automation-i18n-design-20260521.md`.
- T3D remains split into four PRs. This PR only covers log + delivery viewers; T3D-2 rule editor is next.
- Automation intentionally does not reuse `meta-manager-labels.ts` `action.*` hub because this is a separate automation domain.

## Verification

See `docs/development/multitable-t3d1-automation-log-delivery-i18n-verification-20260521.md`.

Local results:

```text
✓ tests/meta-automation-labels.spec.ts  (4 tests)
✓ tests/meta-automation-delivery-viewers-i18n.spec.ts  (4 tests)
✓ tests/MetaAutomationLogViewer.spec.ts  (17 tests)

Test Files  3 passed (3)
Tests       25 passed (25)
```

Additional checks:

- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` - clean
- `pnpm --filter @metasheet/web build` - passed (`built in 5.68s`)
- `git diff --check origin/main..HEAD` - clean

A11y boundary:

- `[aria-label] = 0`, `[title] = 0`, `[placeholder] = 0` for the log, group delivery, and person delivery fixtures.

## Scope Guard

No backend, contract, migration, attendance, K3, rule-editor, automation-manager shell, or DingTalk rule-configuration changes.
