### PR TITLE
fix(ops): redact BA-M0.5 SQL login identifiers

### DIFF
--- a/docs/development/bridge-agent-driver-smoke-design-20260520.md
+++ b/docs/development/bridge-agent-driver-smoke-design-20260520.md
@@ -97,6 +97,11 @@ driver can negotiate pre-login, authenticate, and execute a read.
   `Password=`, `User ID=`, `Server=`, `Data Source=`, `Initial Catalog=`,
   `Bearer ...`, and JWT-shape substring before being written to the
   evidence files.
+- SQL login-failure messages are handled as a separate error shape:
+  English `Login failed for user '...'`, Chinese `用户 '...' 登录失败`,
+  and quoted occurrences of the supplied `-Username` are masked to
+  `<redacted-login>`. This keeps failed BA-M0.5 evidence shareable even
+  when a provider localizes its authentication error text.
 - The evidence files capture only structural facts: provider name,
   driver assembly version, OS / PS / CLR version, elapsed milliseconds,
   PASS / FAIL per check, and a defensively-redacted `@@VERSION` echo.
@@ -125,7 +130,9 @@ Inherited verbatim from the Bridge Agent plan's `## Security Model`:
   harness writes,
 - evidence redaction is layered: in-process credential acquisition,
   in-memory-only connection string, regex redaction of error
-  messages, harness output that captures only structural facts.
+  messages, login-identifier redaction for localized SQL Server
+  authentication failures, and harness output that captures only
+  structural facts.
 
 ## What this PR proves
 

--- a/docs/development/bridge-agent-driver-smoke-verification-20260520.md
+++ b/docs/development/bridge-agent-driver-smoke-verification-20260520.md
@@ -193,3 +193,26 @@ grep -n 'SQL Server Native Client 11.0|SQLNCLI11|SQLOLEDB' \
 
 The PR (#1721) auto-updates with the new commit on push; no second PR
 opened.
+
+## Follow-up after #1723 entity-machine smoke
+
+#1723 surfaced one more evidence-hygiene gap during real operator-side
+failure handling: localized SQL Server login-failure messages can echo
+the rejected login identifier without using a `User ID=...` connection
+string shape. Operator evidence was manually scrubbed before handoff, but
+the harness should not require that extra manual step.
+
+Follow-up fix:
+
+- `ConvertTo-RedactedText` now masks English
+  `Login failed for user '...'` messages to
+  `Login failed for user '<redacted-login>'`.
+- It also masks Chinese localized forms such as
+  `用户 '...' 登录失败` / `登入名 '...' 登入失敗`.
+- When `-Username` is provided, quoted exact occurrences of that login
+  are masked case-insensitively as `<redacted-login>`.
+
+This is intentionally limited to error/evidence redaction. The smoke
+query remains exactly `SELECT @@VERSION`; no provider selection,
+connection, SQL, business-table sampling, or Bridge Agent runtime logic
+changes.

--- a/docs/operations/bridge-agent-driver-smoke-runbook-20260520.md
+++ b/docs/operations/bridge-agent-driver-smoke-runbook-20260520.md
@@ -57,6 +57,11 @@ implementation) does not start**.
 - The harness's evidence files contain **no** server / database / user /
   password values. Inspect both files before handing them off; they
   should not require further redaction.
+- SQL Server login-failure messages may quote the rejected login name in
+  localized provider text. The harness redacts the common English and
+  Chinese shapes before writing evidence, but if an operator still sees a
+  login identifier in either evidence file, stop the handoff and treat it
+  as a harness defect.
 
 ## Primary path: PowerShell harness on Windows (preferred)
 

--- a/scripts/ops/bridge-agent-driver-smoke.ps1
+++ b/scripts/ops/bridge-agent-driver-smoke.ps1
@@ -120,6 +120,7 @@ $ErrorActionPreference = 'Stop'
 function ConvertTo-RedactedText {
   param([string]$Value)
   if ([string]::IsNullOrEmpty($Value)) { return $Value }
+  $redactedLogin = '<redacted-login>'
   $patterns = @(
     '(?i)(Password|Pwd)\s*=\s*[^;""'']+',
     '(?i)(User\s*ID|UID|User)\s*=\s*[^;""'']+',
@@ -131,6 +132,26 @@ function ConvertTo-RedactedText {
   $redacted = $Value
   foreach ($p in $patterns) {
     $redacted = [System.Text.RegularExpressions.Regex]::Replace($redacted, $p, '<redacted>')
+  }
+  $quotePattern = "[`"']"
+  $redacted = [System.Text.RegularExpressions.Regex]::Replace(
+    $redacted,
+    "(?i)(Login failed for user\s+$quotePattern)([^`"']+)($quotePattern)",
+    '${1}' + $redactedLogin + '${3}'
+  )
+  $redacted = [System.Text.RegularExpressions.Regex]::Replace(
+    $redacted,
+    "((?:用户|使用者|登入名|登录名)\s*$quotePattern)([^`"']+)($quotePattern\s*(?:登录失败|登入失敗|login failed))",
+    '${1}' + $redactedLogin + '${3}'
+  )
+  if (-not [string]::IsNullOrEmpty($Username)) {
+    $escapedUsername = [System.Text.RegularExpressions.Regex]::Escape($Username)
+    $redacted = [System.Text.RegularExpressions.Regex]::Replace(
+      $redacted,
+      "($quotePattern)$escapedUsername($quotePattern)",
+      '${1}' + $redactedLogin + '${2}',
+      [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+    )
   }
   return $redacted
 }


### PR DESCRIPTION
## Summary

Harden the BA-M0.5 driver-smoke evidence redactor after #1723 showed that localized SQL Server login-failure messages can echo the rejected login identifier without using a `User ID=...` connection-string shape.

Changes:
- Masks English `Login failed for user '...'` messages to `<redacted-login>`.
- Masks Chinese localized login-failure forms such as `用户 '...' 登录失败` / `登入名 '...' 登入失敗`.
- Masks quoted exact occurrences of the supplied `-Username` case-insensitively.
- Updates the BA-M0.5 runbook, design MD, and verification MD with the new redaction boundary.

## Scope

Docs/scripts only:
- `scripts/ops/bridge-agent-driver-smoke.ps1`
- `docs/operations/bridge-agent-driver-smoke-runbook-20260520.md`
- `docs/development/bridge-agent-driver-smoke-design-20260520.md`
- `docs/development/bridge-agent-driver-smoke-verification-20260520.md`

No `plugin-integration-core`, DB migration, API runtime, frontend runtime, Bridge Agent BA-M1 implementation, SQL sampling, or K3 Save / Submit / Audit change.

## Verification

- `git diff --check` -> pass
- Secret-shape sweep over the 4 changed files -> 0 hits for JWT shape, populated password JSON, Bearer token, raw PG userinfo, populated secret query values
- Marker grep confirms `redacted-login`, English login-failure, Chinese login-failure, and quoted `-Username` redaction paths are present
- `pwsh` parser check was not run because this development host does not have `pwsh`; the existing BA-M0.5 runbook still expects PowerShell 5.1+ / 7+ on the Windows bridge host

## #1723 status

This PR does not sign off BA-M0.5 evidence. It only removes the need for operator-side manual scrub when a future failed smoke returns a localized SQL login-failure message. BA-M1 remains gated by #1723 evidence sign-off.
