### PR TITLE
feat(attendance): add effective calendar preview panel

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1407,6 +1407,7 @@
                     <p class="attendance__field-hint attendance__field-hint--warn">
                       {{ tr('Role and role-tag matching is reserved until role context is loaded by the resolver; keep new rules scoped to org, group, or user.', '角色与角色标签匹配需等待解析器加载角色上下文；新增规则请先使用组织、考勤组或用户范围。') }}
                     </p>
+                    <AttendanceCalendarPolicyPreviewPanel :tr="tr" />
                     <div v-if="settingsForm.calendarPolicyOverrides.length === 0" class="attendance__empty">
                       {{ tr('No effective calendar overrides configured.', '暂无有效日历覆盖规则。') }}
                     </div>
@@ -4798,6 +4799,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue'
 import AttendanceAdminRail from './attendance/AttendanceAdminRail.vue'
+import AttendanceCalendarPolicyPreviewPanel from './attendance/AttendanceCalendarPolicyPreviewPanel.vue'
 import AttendanceImportBatchesSection from './attendance/AttendanceImportBatchesSection.vue'
 import AttendanceHolidayDataSection from './attendance/AttendanceHolidayDataSection.vue'
 import AttendanceUserPickerField from './attendance/AttendanceUserPickerField.vue'

--- a/apps/web/src/views/attendance/AttendanceCalendarPolicyPreviewPanel.vue
+++ b/apps/web/src/views/attendance/AttendanceCalendarPolicyPreviewPanel.vue
@@ -1,0 +1,378 @@
+<template>
+  <div class="attendance__calendar-preview" data-attendance-calendar-policy-preview>
+    <div class="attendance__calendar-preview-header">
+      <div>
+        <h5>{{ tr('Preview effective calendar', '预览有效日历') }}</h5>
+        <p class="attendance__field-hint">
+          {{ tr('Uses the saved effective-calendar resolver. Unsaved edits must be saved first.', '使用已保存的有效日历解析器；未保存的修改需先保存。') }}
+        </p>
+      </div>
+      <button
+        class="attendance__btn"
+        type="button"
+        :disabled="previewLoading"
+        data-attendance-calendar-policy-preview-run
+        @click="runPreview"
+      >
+        {{ previewLoading ? tr('Previewing...', '预览中...') : tr('Preview', '预览') }}
+      </button>
+    </div>
+
+    <div class="attendance__calendar-preview-controls">
+      <label class="attendance__field">
+        <span>{{ tr('From', '开始日期') }}</span>
+        <input v-model="previewFrom" type="date" data-attendance-calendar-policy-preview-from />
+      </label>
+      <label class="attendance__field">
+        <span>{{ tr('To', '结束日期') }}</span>
+        <input v-model="previewTo" type="date" data-attendance-calendar-policy-preview-to />
+      </label>
+      <label class="attendance__field">
+        <span>{{ tr('Scope', '范围') }}</span>
+        <select v-model="previewMode" data-attendance-calendar-policy-preview-mode>
+          <option value="orgOnly">{{ tr('Organization', '组织') }}</option>
+          <option value="groupId">{{ tr('Attendance group', '考勤组') }}</option>
+          <option value="userId">{{ tr('User', '用户') }}</option>
+        </select>
+      </label>
+      <label v-if="previewMode === 'groupId'" class="attendance__field">
+        <span>{{ tr('Group ID or code', '考勤组 ID 或编码') }}</span>
+        <input v-model="previewGroupId" type="text" placeholder="group_1" data-attendance-calendar-policy-preview-group />
+      </label>
+      <label v-if="previewMode === 'userId'" class="attendance__field">
+        <span>{{ tr('User ID', '用户 ID') }}</span>
+        <input v-model="previewUserId" type="text" placeholder="user_1" data-attendance-calendar-policy-preview-user />
+      </label>
+    </div>
+
+    <p v-if="previewError" class="attendance__status attendance__status--error" data-attendance-calendar-policy-preview-error>
+      {{ previewError }}
+    </p>
+
+    <div v-if="previewResult" class="attendance__calendar-preview-result" data-attendance-calendar-policy-preview-result>
+      <div class="attendance__admin-meta">
+        <strong>{{ tr('Result', '结果') }}</strong>
+        <span>{{ modeLabel(previewResult.mode) }}</span>
+        <span>{{ previewResult.from }} → {{ previewResult.to }}</span>
+        <span>{{ previewResult.timezone }}</span>
+        <span>{{ previewResult.items.length }} {{ tr('day(s)', '天') }}</span>
+      </div>
+      <div v-if="previewResult.items.length === 0" class="attendance__empty">
+        {{ tr('No calendar rows returned.', '暂无日历结果。') }}
+      </div>
+      <div v-else class="attendance__table-wrapper">
+        <table class="attendance__table">
+          <thead>
+            <tr>
+              <th>{{ tr('Date', '日期') }}</th>
+              <th>{{ tr('Base', '基础') }}</th>
+              <th>{{ tr('Effective', '生效') }}</th>
+              <th>{{ tr('Label / policy', '标签 / 规则') }}</th>
+              <th>{{ tr('Layers', '层级') }}</th>
+              <th>{{ tr('Overlays', '叠加') }}</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr v-for="item in previewResult.items" :key="item.date">
+              <td>{{ item.date }}</td>
+              <td>
+                <span :class="dayClass(item.base.isWorkingDay)">{{ dayLabel(item.base.isWorkingDay) }}</span>
+                <small>{{ sourceLabel(item.base.source) }}</small>
+              </td>
+              <td>
+                <span :class="dayClass(item.effective.isWorkingDay)">{{ dayLabel(item.effective.isWorkingDay) }}</span>
+                <small>{{ sourceLabel(item.effective.source) }}</small>
+              </td>
+              <td>
+                <span>{{ item.effective.label || item.base.name || '--' }}</span>
+                <small v-if="item.effective.policyId">{{ item.effective.policyId }}</small>
+              </td>
+              <td>{{ layerSummary(item) }}</td>
+              <td>{{ overlaySummary(item) }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import {
+  EffectiveCalendarFetchError,
+  fetchEffectiveCalendar,
+  type CalendarEffectiveItem,
+  type CalendarEffectiveMode,
+  type CalendarEffectiveSource,
+  type CalendarEffectiveResponse,
+  type FetchEffectiveCalendarOptions,
+} from '../../services/attendance/effectiveCalendar'
+
+type Translate = (en: string, zh: string) => string
+type PreviewMode = CalendarEffectiveMode
+
+const props = defineProps<{
+  tr: Translate
+}>()
+
+const tr = props.tr
+
+const today = () => new Date().toISOString().slice(0, 10)
+const previewFrom = ref(today())
+const previewTo = ref(today())
+const previewMode = ref<PreviewMode>('orgOnly')
+const previewGroupId = ref('')
+const previewUserId = ref('')
+const previewLoading = ref(false)
+const previewError = ref('')
+const previewResult = ref<CalendarEffectiveResponse | null>(null)
+
+const SOURCE_LABELS: Record<CalendarEffectiveSource, [string, string]> = {
+  rule: ['Rule', '规则'],
+  shift: ['Shift', '班次'],
+  rotation: ['Rotation', '轮班'],
+  national: ['National holiday', '法定节假日'],
+  manual: ['Manual holiday', '手动节假日'],
+  org: ['Organization policy', '组织规则'],
+  group: ['Group policy', '考勤组规则'],
+  role: ['Role policy', '角色规则'],
+  user: ['User policy', '用户规则'],
+}
+
+const MODE_LABELS: Record<PreviewMode, [string, string]> = {
+  orgOnly: ['Organization', '组织'],
+  groupId: ['Attendance group', '考勤组'],
+  userId: ['User', '用户'],
+}
+
+function dayLabel(isWorkingDay: boolean): string {
+  return isWorkingDay ? tr('Working day', '工作日') : tr('Rest day', '休息日')
+}
+
+function dayClass(isWorkingDay: boolean): string {
+  return isWorkingDay ? 'attendance__calendar-preview-day attendance__calendar-preview-day--work' : 'attendance__calendar-preview-day attendance__calendar-preview-day--rest'
+}
+
+function sourceLabel(source: CalendarEffectiveSource): string {
+  const label = SOURCE_LABELS[source]
+  return label ? tr(label[0], label[1]) : source
+}
+
+function modeLabel(mode: PreviewMode): string {
+  const label = MODE_LABELS[mode]
+  return label ? tr(label[0], label[1]) : mode
+}
+
+function layerSummary(item: CalendarEffectiveItem): string {
+  if (!item.layers.length) return '--'
+  return item.layers
+    .map((layer) => `${sourceLabel(layer.source)}:${dayLabel(layer.isWorkingDay)}`)
+    .join(' / ')
+}
+
+function overlaySummary(item: CalendarEffectiveItem): string {
+  if (!item.overlays.length) return '--'
+  return item.overlays
+    .map((overlay) => overlay.label || overlay.requestType || overlay.kind)
+    .join(' / ')
+}
+
+function buildPreviewOptions(): FetchEffectiveCalendarOptions | null {
+  const from = previewFrom.value.trim()
+  const to = previewTo.value.trim()
+  if (!from || !to) {
+    previewError.value = tr('From and to dates are required.', '开始和结束日期不能为空。')
+    return null
+  }
+  if (from > to) {
+    previewError.value = tr('From date must be before or equal to to date.', '开始日期必须早于或等于结束日期。')
+    return null
+  }
+
+  const options: FetchEffectiveCalendarOptions = {
+    from,
+    to,
+    suppressUnauthorizedRedirect: true,
+  }
+  if (previewMode.value === 'orgOnly') {
+    options.orgOnly = true
+    return options
+  }
+  if (previewMode.value === 'groupId') {
+    const groupId = previewGroupId.value.trim()
+    if (!groupId) {
+      previewError.value = tr('Group ID or code is required.', '考勤组 ID 或编码不能为空。')
+      return null
+    }
+    options.groupId = groupId
+    return options
+  }
+  const userId = previewUserId.value.trim()
+  if (!userId) {
+    previewError.value = tr('User ID is required.', '用户 ID 不能为空。')
+    return null
+  }
+  options.userId = userId
+  return options
+}
+
+async function runPreview() {
+  previewError.value = ''
+  const options = buildPreviewOptions()
+  if (!options) return
+
+  previewLoading.value = true
+  previewResult.value = null
+  try {
+    previewResult.value = await fetchEffectiveCalendar(options)
+  } catch (error) {
+    if (error instanceof EffectiveCalendarFetchError) {
+      previewError.value = error.code ? `${error.message} (${error.code})` : error.message
+    } else if (error instanceof Error) {
+      previewError.value = error.message
+    } else {
+      previewError.value = String(error)
+    }
+  } finally {
+    previewLoading.value = false
+  }
+}
+</script>
+
+<style scoped>
+.attendance__calendar-preview {
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+  padding-top: 12px;
+  border-top: 1px solid #e5e7eb;
+}
+
+.attendance__calendar-preview-header {
+  display: flex;
+  align-items: flex-start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.attendance__calendar-preview-header h5 {
+  margin: 0 0 4px;
+}
+
+.attendance__calendar-preview-controls {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(160px, 1fr));
+  gap: 10px;
+}
+
+.attendance__calendar-preview-result {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.attendance__calendar-preview-day {
+  display: inline-flex;
+  align-items: center;
+  min-height: 20px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  font-size: 12px;
+  font-weight: 600;
+}
+
+.attendance__calendar-preview-day--work {
+  background: #e8f5e9;
+  color: #1b5e20;
+}
+
+.attendance__calendar-preview-day--rest {
+  background: #fff3e0;
+  color: #8a4b00;
+}
+
+.attendance__calendar-preview td small {
+  display: block;
+  margin-top: 4px;
+  color: #6b7280;
+}
+
+.attendance__field {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+  color: #555;
+}
+
+.attendance__field input,
+.attendance__field select {
+  min-width: 0;
+  padding: 6px 10px;
+  border: 1px solid #d0d0d0;
+  border-radius: 6px;
+}
+
+.attendance__field-hint {
+  margin: 0;
+  color: #777;
+  font-size: 11px;
+}
+
+.attendance__btn {
+  padding: 8px 14px;
+  border-radius: 6px;
+  border: 1px solid #d0d0d0;
+  background: #fff;
+  cursor: pointer;
+}
+
+.attendance__btn:disabled {
+  opacity: 0.6;
+  cursor: not-allowed;
+}
+
+.attendance__status {
+  margin: 0;
+  font-size: 12px;
+  color: #2e7d32;
+}
+
+.attendance__status--error {
+  color: #c62828;
+}
+
+.attendance__admin-meta {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  align-items: center;
+  color: #555;
+  font-size: 13px;
+}
+
+.attendance__table-wrapper {
+  width: 100%;
+  overflow-x: auto;
+}
+
+.attendance__table {
+  width: 100%;
+  border-collapse: collapse;
+}
+
+.attendance__table th,
+.attendance__table td {
+  border-bottom: 1px solid #e0e0e0;
+  padding: 8px;
+  text-align: left;
+  font-size: 13px;
+  vertical-align: top;
+}
+
+.attendance__empty {
+  color: #888;
+  font-size: 13px;
+}
+</style>

--- a/apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue
+++ b/apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue
@@ -119,6 +119,7 @@
           <p class="attendance__field-hint attendance__field-hint--warn">
             {{ tr('Role and role-tag matching is reserved until role context is loaded by the resolver; keep new rules scoped to org, group, or user.', '角色与角色标签匹配需等待解析器加载角色上下文；新增规则请先使用组织、考勤组或用户范围。') }}
           </p>
+          <AttendanceCalendarPolicyPreviewPanel :tr="tr" />
           <div v-if="calendarPolicyOverridesExpanded">
             <div v-if="settingsForm.calendarPolicyOverrides.length === 0" class="attendance__empty">{{ tr('No effective calendar overrides configured.', '暂无有效日历覆盖规则。') }}</div>
             <div v-else class="attendance__table-wrapper">
@@ -280,6 +281,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch, type Ref } from 'vue'
+import AttendanceCalendarPolicyPreviewPanel from './AttendanceCalendarPolicyPreviewPanel.vue'
 import type { CalendarPolicyOverrideFormState } from './attendanceCalendarPolicyOverrides'
 import { buildTimezoneOptionGroups } from './attendanceTimezones'
 

--- a/apps/web/tests/AttendanceCalendarPolicyPreviewPanel.spec.ts
+++ b/apps/web/tests/AttendanceCalendarPolicyPreviewPanel.spec.ts
@@ -1,0 +1,171 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App } from 'vue'
+
+vi.mock('../src/services/attendance/effectiveCalendar', () => {
+  class EffectiveCalendarFetchError extends Error {
+    status: number
+    code?: string
+    constructor(message: string, status: number, code?: string) {
+      super(message)
+      this.name = 'EffectiveCalendarFetchError'
+      this.status = status
+      this.code = code
+    }
+  }
+  return {
+    EffectiveCalendarFetchError,
+    fetchEffectiveCalendar: vi.fn(),
+  }
+})
+
+import AttendanceCalendarPolicyPreviewPanel from '../src/views/attendance/AttendanceCalendarPolicyPreviewPanel.vue'
+import {
+  EffectiveCalendarFetchError,
+  fetchEffectiveCalendar,
+  type CalendarEffectiveResponse,
+} from '../src/services/attendance/effectiveCalendar'
+
+const fetchEffectiveCalendarMock = vi.mocked(fetchEffectiveCalendar)
+
+function flushUi(cycles = 4): Promise<void> {
+  return Promise.all(Array.from({ length: cycles }).map(() => Promise.resolve().then(() => nextTick()))).then(
+    () => undefined
+  )
+}
+
+function buildResult(overrides: Partial<CalendarEffectiveResponse> = {}): CalendarEffectiveResponse {
+  return {
+    mode: 'orgOnly',
+    from: '2026-10-01',
+    to: '2026-10-07',
+    timezone: 'Asia/Shanghai',
+    items: [
+      {
+        date: '2026-10-06',
+        base: { isWorkingDay: false, source: 'national', name: '国庆节', holidayId: 'h_1' },
+        effective: { isWorkingDay: true, source: 'org', label: '调休上班', policyId: 'policy_1' },
+        layers: [
+          { kind: 'holiday', source: 'national', isWorkingDay: false, label: '国庆节' },
+          { kind: 'calendar_policy', source: 'org', isWorkingDay: true, label: '调休上班', refId: 'policy_1' },
+        ],
+        overlays: [
+          { kind: 'overtime', source: 'attendance_requests', requestType: 'overtime', minutes: 120, label: '加班' },
+        ],
+      },
+    ],
+    ...overrides,
+  }
+}
+
+function setInput(container: HTMLElement, selector: string, value: string): void {
+  const input = container.querySelector<HTMLInputElement>(selector)
+  expect(input, `expected input ${selector}`).toBeTruthy()
+  input!.value = value
+  input!.dispatchEvent(new Event('input'))
+}
+
+function setSelect(container: HTMLElement, selector: string, value: string): void {
+  const select = container.querySelector<HTMLSelectElement>(selector)
+  expect(select, `expected select ${selector}`).toBeTruthy()
+  select!.value = value
+  select!.dispatchEvent(new Event('change'))
+}
+
+function clickPreview(container: HTMLElement): void {
+  const button = container.querySelector<HTMLButtonElement>('[data-attendance-calendar-policy-preview-run]')
+  expect(button).toBeTruthy()
+  button!.click()
+}
+
+describe('AttendanceCalendarPolicyPreviewPanel', () => {
+  let app: App<Element> | null = null
+  let container: HTMLDivElement | null = null
+  const tr = (_en: string, zh: string) => zh
+
+  beforeEach(() => {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    fetchEffectiveCalendarMock.mockReset()
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+    vi.clearAllMocks()
+  })
+
+  function mountPanel(): HTMLElement {
+    app = createApp(AttendanceCalendarPolicyPreviewPanel, { tr })
+    app.mount(container!)
+    return container!
+  }
+
+  it('previews org-level effective calendar rows through the backend resolver', async () => {
+    fetchEffectiveCalendarMock.mockResolvedValueOnce(buildResult())
+    const root = mountPanel()
+    await flushUi()
+
+    setInput(root, '[data-attendance-calendar-policy-preview-from]', '2026-10-01')
+    setInput(root, '[data-attendance-calendar-policy-preview-to]', '2026-10-07')
+    clickPreview(root)
+    await flushUi(8)
+
+    expect(fetchEffectiveCalendarMock).toHaveBeenCalledTimes(1)
+    expect(fetchEffectiveCalendarMock).toHaveBeenCalledWith({
+      from: '2026-10-01',
+      to: '2026-10-07',
+      orgOnly: true,
+      suppressUnauthorizedRedirect: true,
+    })
+    expect(root.querySelector('[data-attendance-calendar-policy-preview-result]')?.textContent).toContain('2026-10-06')
+    expect(root.textContent).toContain('调休上班')
+    expect(root.textContent).toContain('policy_1')
+    expect(root.textContent).toContain('加班')
+  })
+
+  it('requires a target id for group/user preview modes before calling the API', async () => {
+    const root = mountPanel()
+    await flushUi()
+
+    setInput(root, '[data-attendance-calendar-policy-preview-from]', '2026-10-01')
+    setInput(root, '[data-attendance-calendar-policy-preview-to]', '2026-10-07')
+    setSelect(root, '[data-attendance-calendar-policy-preview-mode]', 'userId')
+    await flushUi()
+    clickPreview(root)
+    await flushUi()
+
+    expect(fetchEffectiveCalendarMock).not.toHaveBeenCalled()
+    expect(root.querySelector('[data-attendance-calendar-policy-preview-error]')?.textContent).toContain('用户 ID 不能为空')
+
+    setInput(root, '[data-attendance-calendar-policy-preview-user]', 'user_42')
+    fetchEffectiveCalendarMock.mockResolvedValueOnce(buildResult({ mode: 'userId' }))
+    clickPreview(root)
+    await flushUi(8)
+
+    expect(fetchEffectiveCalendarMock).toHaveBeenCalledWith({
+      from: '2026-10-01',
+      to: '2026-10-07',
+      userId: 'user_42',
+      suppressUnauthorizedRedirect: true,
+    })
+  })
+
+  it('shows backend preview errors without mutating the settings editor state', async () => {
+    fetchEffectiveCalendarMock.mockRejectedValueOnce(
+      new EffectiveCalendarFetchError('No access to this user.', 403, 'FORBIDDEN'),
+    )
+    const root = mountPanel()
+    await flushUi()
+
+    setInput(root, '[data-attendance-calendar-policy-preview-from]', '2026-10-01')
+    setInput(root, '[data-attendance-calendar-policy-preview-to]', '2026-10-07')
+    clickPreview(root)
+    await flushUi(8)
+
+    const error = root.querySelector('[data-attendance-calendar-policy-preview-error]')
+    expect(error?.textContent).toContain('No access to this user. (FORBIDDEN)')
+    expect(root.querySelector('[data-attendance-calendar-policy-preview-result]')).toBeNull()
+  })
+})

--- a/docs/development/attendance-calendar-policy-preview-ui-development-20260521.md
+++ b/docs/development/attendance-calendar-policy-preview-ui-development-20260521.md
@@ -1,0 +1,64 @@
+# Attendance Calendar Policy Preview UI
+
+Date: 2026-05-21
+Branch: `codex/attendance-calendar-policy-preview-ui-20260521`
+Base: `origin/main@d611bb6bb`
+
+## Summary
+
+This slice adds a read-only preview panel beside the effective-calendar
+override editor. Operators can choose a date range and an org / attendance-group
+/ user scope, then run the already-shipped
+`GET /api/attendance/effective-calendar` resolver directly from the settings
+surface.
+
+The panel is intentionally frontend-only. It does not add a backend route,
+write settings, migrate `attendance_*`, or introduce any direct `meta_*` write.
+It previews saved policy behavior; unsaved editor changes still need to be
+saved through the existing settings path before they affect the resolver.
+
+## Key Changes
+
+| File | Purpose |
+| --- | --- |
+| `apps/web/src/views/attendance/AttendanceCalendarPolicyPreviewPanel.vue` | New shared preview panel, local state, validation, resolver call, result table |
+| `apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue` | Mounts the shared preview panel in the extracted holiday-rule section |
+| `apps/web/src/views/AttendanceView.vue` | Mounts the same preview panel in the currently routed monolithic admin view |
+| `apps/web/tests/AttendanceCalendarPolicyPreviewPanel.spec.ts` | Focused frontend coverage for org preview, target validation, and backend error rendering |
+
+## UI Contract
+
+The preview panel supports:
+
+- Date range: `from` and `to`, with client-side guard that `from <= to`.
+- Scope mode: organization, attendance group, or user.
+- Target requirement: group mode requires a group ID/code; user mode requires a
+  user ID; organization mode sends `orgOnly=true`.
+- Result display: date, base day type/source, effective day type/source, label
+  or policy id, layer summary, and overlay summary.
+
+The panel always sends `suppressUnauthorizedRedirect: true`, matching the shared
+effective-calendar client contract used by calendar widgets. Authorization and
+resolver semantics remain backend-owned.
+
+## Boundaries
+
+- No backend code changed.
+- No new client-side resolver or validator was introduced.
+- No `attendance_*` migration or fact-source migration.
+- No direct `meta_*` reads or writes.
+- No save-path change. The only persistence path remains
+  `PUT /api/attendance/settings`.
+- The extracted section and the production `AttendanceView.vue` mount the same
+  component to avoid UI drift.
+
+## Deferred
+
+- Previewing unsaved draft overrides. That would require a backend simulation
+  endpoint or a clearly scoped draft-payload resolver and is intentionally not
+  part of this slice.
+- Role / role-tag target preview. The backend resolver still treats role-based
+  calendar policy as configuration-compatible but inert until role context is
+  loaded.
+- Live staging evidence. This frontend slice is covered by unit tests; staging
+  confirmation can reuse the existing saved-policy flow after deployment.

--- a/docs/development/attendance-calendar-policy-preview-ui-verification-20260521.md
+++ b/docs/development/attendance-calendar-policy-preview-ui-verification-20260521.md
@@ -1,0 +1,50 @@
+# Attendance Calendar Policy Preview UI — Verification
+
+Date: 2026-05-21
+Branch: `codex/attendance-calendar-policy-preview-ui-20260521`
+Base: `origin/main@d611bb6bb`
+
+## Test Matrix
+
+| Check | Result |
+| --- | --- |
+| `node --check plugins/plugin-attendance/index.cjs` | PASS |
+| `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/AttendanceCalendarPolicyPreviewPanel.spec.ts tests/useAttendanceHolidayRuleSection.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` | PASS — 3 files / 19 tests |
+| `pnpm --filter @metasheet/web type-check` | PASS |
+| `pnpm --filter @metasheet/web build` | PASS |
+| `curl -sS -I http://localhost:8899/` after `pnpm --filter @metasheet/web dev -- --host 127.0.0.1 --port 8899` | PASS — HTTP 200 |
+| `git diff --check` | PASS |
+
+## Coverage Notes
+
+- `AttendanceCalendarPolicyPreviewPanel.spec.ts` covers:
+  - organization-mode preview calls `fetchEffectiveCalendar()` with
+    `orgOnly=true` and `suppressUnauthorizedRedirect=true`;
+  - resolver results render date, effective label, policy id, and overlay
+    summary;
+  - user mode requires a target user ID before calling the API;
+  - backend `EffectiveCalendarFetchError` messages render without producing a
+    result table.
+- `useAttendanceHolidayRuleSection.spec.ts` remains in the matrix because the
+  extracted holiday section now mounts the shared preview panel.
+- `attendance-admin-regressions.spec.ts` remains in the matrix because the
+  routed monolithic `AttendanceView.vue` also mounts the shared preview panel.
+
+## Boundary Checks
+
+- Backend plugin is syntax-checked only; no backend file is part of the diff.
+- The preview component imports the existing shared client from
+  `apps/web/src/services/attendance/effectiveCalendar.ts`.
+- The panel does not mutate `settingsForm` or call `saveSettings`.
+- No `attendance_*` migration, no direct `meta_*` write, and no new persistence
+  path are introduced.
+
+## Result Notes
+
+- `pnpm install` was required in the isolated worktree to restore the workspace
+  test/build binaries. It rewrote tracked `node_modules` symlink entries under
+  plugin/tool folders; those generated changes were restored before validation
+  and are not part of the slice.
+- `pnpm --filter @metasheet/web build` emitted the existing Vite warnings about
+  `WorkflowDesigner.vue` mixed dynamic/static imports and large chunks. The
+  command exited successfully.


### PR DESCRIPTION
## Summary

Adds a read-only effective-calendar preview panel next to the calendarPolicy override editor. The same shared component is mounted in both the extracted holiday-rule section and the currently routed monolithic AttendanceView so the production admin page and test surface stay aligned.

Boundary: frontend-only. It reuses GET /api/attendance/effective-calendar, introduces no backend route, no save-path change, no attendance_* migration, and no direct meta_* writes. The preview reflects saved settings; unsaved rule edits still need to be saved first.

## Test plan

- [x] node --check plugins/plugin-attendance/index.cjs
- [x] NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/AttendanceCalendarPolicyPreviewPanel.spec.ts tests/useAttendanceHolidayRuleSection.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false
- [x] pnpm --filter @metasheet/web type-check
- [x] pnpm --filter @metasheet/web build
- [x] curl -sS -I http://localhost:8899/ after starting the web dev server
- [x] git diff --check

## Docs

- docs/development/attendance-calendar-policy-preview-ui-development-20260521.md
- docs/development/attendance-calendar-policy-preview-ui-verification-20260521.md