### PR TITLE
fix(ops): preflight deploy host disk before sync

### DIFF
--- a/.github/workflows/docker-build.yml
+++ b/.github/workflows/docker-build.yml
@@ -74,6 +74,7 @@ jobs:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_SYNC_MIN_FREE_KB: ${{ vars.DEPLOY_SYNC_MIN_FREE_KB || '1048576' }}
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
@@ -81,9 +82,10 @@ jobs:
           chmod 600 ~/.ssh/deploy_key
           ssh_opts="-o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ~/.ssh/deploy_key"
           DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
+          DEPLOY_SYNC_MIN_FREE_KB="${DEPLOY_SYNC_MIN_FREE_KB:-1048576}"
 
           remote_repo_path="$(
-            ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" "DEPLOY_PATH='${DEPLOY_PATH}' bash -s" <<'EOF'
+            ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" "DEPLOY_PATH='${DEPLOY_PATH}' DEPLOY_SYNC_MIN_FREE_KB='${DEPLOY_SYNC_MIN_FREE_KB}' bash -s" <<'EOF'
           set -euo pipefail
           if [[ "${DEPLOY_PATH}" == /* ]]; then
             DEPLOY_REPO_PATH="${DEPLOY_PATH}"
@@ -93,6 +95,29 @@ jobs:
             DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH}"
           fi
           mkdir -p "${DEPLOY_REPO_PATH}"
+          required_free_kb="${DEPLOY_SYNC_MIN_FREE_KB:-1048576}"
+          if ! [[ "${required_free_kb}" =~ ^[0-9]+$ ]]; then
+            echo "[host-sync][error] DEPLOY_SYNC_MIN_FREE_KB must be an integer, got: ${required_free_kb}" >&2
+            exit 78
+          fi
+          available_kb="$(df -Pk "${DEPLOY_REPO_PATH}" | awk 'NR == 2 { print $4 }')"
+          use_percent="$(df -Pk "${DEPLOY_REPO_PATH}" | awk 'NR == 2 { print $5 }')"
+          if [[ -z "${available_kb}" ]]; then
+            echo "[host-sync][error] failed to read free space for ${DEPLOY_REPO_PATH}" >&2
+            df -Pk "${DEPLOY_REPO_PATH}" >&2 || true
+            exit 78
+          fi
+          if ! [[ "${available_kb}" =~ ^[0-9]+$ ]]; then
+            echo "[host-sync][error] deploy host df returned a non-integer available_kb value: ${available_kb}" >&2
+            df -Pk "${DEPLOY_REPO_PATH}" >&2 || true
+            exit 78
+          fi
+          echo "[host-sync] disk_available_kb=${available_kb} required_kb=${required_free_kb} use=${use_percent:-unknown}" >&2
+          if (( available_kb < required_free_kb )); then
+            echo "[host-sync][error] deploy host free space is below the sync gate: available_kb=${available_kb}, required_kb=${required_free_kb}, path=${DEPLOY_REPO_PATH}" >&2
+            echo "[host-sync][error] free disk space on the deploy host before rerunning; see docs/deployment/onprem-docker-gc-20260403.md" >&2
+            exit 78
+          fi
           printf '%s' "${DEPLOY_REPO_PATH}"
           EOF
           )"

--- a/docs/deployment/onprem-docker-gc-20260403.md
+++ b/docs/deployment/onprem-docker-gc-20260403.md
@@ -55,6 +55,67 @@ JSON_OUTPUT=true bash scripts/ops/dingtalk-onprem-docker-gc.sh
 
 - `/home/mainuser/docker-gc-runs/docker-gc-*.json`
 
+## GitHub deploy host sync 空间门禁
+
+`Build and Push Docker Images` 在 deploy job 的 `Sync deploy host files`
+阶段会先检查 deploy host 上 `DEPLOY_PATH` 所在文件系统的可用空间，再解包
+`docker-compose.app.yml`、`docker/nginx.conf` 和 `scripts/ops/attendance-preflight.sh`。
+
+默认门槛：
+
+- `DEPLOY_SYNC_MIN_FREE_KB=1048576`（1 GiB）
+- 低于这个值时，deploy host
+  通常已经接近无法可靠完成镜像拉取、解包和日志写入。
+
+可通过 GitHub repository variable `DEPLOY_SYNC_MIN_FREE_KB` 调整。这个门槛只用于
+deploy host 文件同步前置检查；它不会清理磁盘，也不会停止容器。
+
+如果 workflow 在 `Sync deploy host files` 阶段失败并出现类似输出：
+
+```text
+[host-sync] disk_available_kb=...
+[host-sync][error] deploy host free space is below the sync gate
+```
+
+处理顺序：
+
+1. SSH 到 deploy host。
+2. 先查看根分区和 Docker 占用：
+
+   ```bash
+   df -h /
+   docker system df
+   ```
+
+3. 执行一次手工 GC：
+
+   ```bash
+   bash scripts/ops/dingtalk-onprem-docker-gc.sh
+   ```
+
+   如果希望直接从 GitHub Actions 触发既有远端 GC，也可以手工运行
+   `Attendance Remote Docker GC (Prod)` workflow；它会输出 `df -h` 和
+   `docker system df` 证据。
+
+4. 再确认空间：
+
+   ```bash
+   df -h /
+   docker system df
+   ```
+
+5. 重新运行失败的 `Build and Push Docker Images` workflow。
+
+如果 workflow 仍然显示：
+
+```text
+tar: ... Cannot write: No space left on device
+```
+
+说明磁盘在 preflight 之后、解包期间仍被占满，或门槛设得过低。先继续释放
+deploy host 空间；必要时把 repository variable `DEPLOY_SYNC_MIN_FREE_KB`
+调高后再重跑。
+
 ## 验证
 
 执行：

--- a/docs/development/deploy-host-sync-disk-preflight-development-20260521.md
+++ b/docs/development/deploy-host-sync-disk-preflight-development-20260521.md
@@ -1,0 +1,87 @@
+# Deploy Host Sync Disk Preflight Development - 2026-05-21
+
+## Context
+
+Main push workflow `Build and Push Docker Images` for commit `02aa089185`
+failed in the deploy job before remote deploy or smoke ran:
+
+```text
+tar: ... Cannot write: No space left on device
+deploy_rc missing; failing deploy job.
+```
+
+The retry proved the image build/push path itself was healthy: backend and
+frontend image pushes passed. The remaining failure was the deploy host file
+sync step writing a small archive into `DEPLOY_PATH` on a full filesystem.
+
+## Goal
+
+Fail before extraction with a clear deploy-host storage diagnostic instead of
+letting `tar -xzf` emit a low-context write error. This is an operations guard,
+not a product runtime change.
+
+## Scope
+
+Changed:
+
+- `.github/workflows/docker-build.yml`
+- `docs/deployment/onprem-docker-gc-20260403.md`
+
+Not changed:
+
+- `plugin-integration-core`
+- database migrations
+- backend or frontend runtime
+- K3 WISE Save / Submit / Audit behavior
+- Bridge Agent BA-M1 runtime
+
+## Implementation
+
+`Sync deploy host files` now passes `DEPLOY_SYNC_MIN_FREE_KB` to the deploy host
+resolver shell. The remote script:
+
+1. resolves `DEPLOY_PATH` to the same `DEPLOY_REPO_PATH` as before;
+2. creates the destination directory;
+3. reads `df -Pk "$DEPLOY_REPO_PATH"`;
+4. logs:
+
+   ```text
+   [host-sync] disk_available_kb=<n> required_kb=<n> use=<percent>
+   ```
+
+5. exits before archive extraction when available space is below the gate.
+
+Default gate:
+
+```text
+DEPLOY_SYNC_MIN_FREE_KB=1048576
+```
+
+That is 1 GiB by default, configurable through a GitHub repository variable with
+the same name.
+
+## Operator Recovery
+
+The existing Docker GC runbook now has a GitHub deploy-host sync section. It
+directs the operator to:
+
+1. check `df -h /`;
+2. check `docker system df`;
+3. run `scripts/ops/dingtalk-onprem-docker-gc.sh`;
+4. recheck free space;
+5. rerun the failed workflow.
+
+## Risk Notes
+
+- This gate only checks free space before sync. It does not guarantee Docker
+  image pull/deploy will have enough space later.
+- The threshold is intentionally low to avoid blocking healthy small hosts.
+  Operators can raise `DEPLOY_SYNC_MIN_FREE_KB` if the deploy host repeatedly
+  fills between preflight and extraction.
+- If the remote `df` command fails, the step fails closed with the filesystem
+  diagnostic output.
+
+## Follow-up
+
+The deploy host that failed `02aa089185` still needs capacity cleanup. This PR
+only makes future failures easier to identify and rerun safely.

--- a/docs/development/deploy-host-sync-disk-preflight-verification-20260521.md
+++ b/docs/development/deploy-host-sync-disk-preflight-verification-20260521.md
@@ -1,0 +1,127 @@
+# Deploy Host Sync Disk Preflight Verification - 2026-05-21
+
+## Static Checks
+
+Result on the implementation branch:
+
+- workflow YAML parse: PASS
+- targeted contract tests: 5/5 PASS
+- `git diff --check`: PASS
+- marker grep: PASS
+
+### Diff Check
+
+Command:
+
+```bash
+git diff --check origin/main...HEAD
+```
+
+Expected:
+
+```text
+exit 0
+```
+
+### Workflow Marker Check
+
+Command:
+
+```bash
+rg -n "DEPLOY_SYNC_MIN_FREE_KB|disk_available_kb|deploy host free space is below the sync gate|onprem-docker-gc-20260403.md" .github/workflows/docker-build.yml
+```
+
+Expected:
+
+- `DEPLOY_SYNC_MIN_FREE_KB` is defined in the `Sync deploy host files` step.
+- The default threshold is `1048576` KB.
+- The remote resolver prints `disk_available_kb`.
+- The remote resolver exits before `tar -xzf` when free space is below the
+  gate.
+- The error points operators to `docs/deployment/onprem-docker-gc-20260403.md`.
+
+### Runbook Marker Check
+
+Command:
+
+```bash
+rg -n "GitHub deploy host sync|DEPLOY_SYNC_MIN_FREE_KB|Cannot write: No space left on device|docker system df" docs/deployment/onprem-docker-gc-20260403.md
+```
+
+Expected:
+
+- The runbook has an explicit GitHub deploy-host sync section.
+- The default threshold is documented.
+- The `tar: ... Cannot write` fallback case is documented.
+- The operator recovery sequence includes `df -h /`, `docker system df`, and
+  manual GC.
+
+## Behavioral Reasoning
+
+The deploy failure that motivated this change happened before these later
+stages:
+
+- remote deploy;
+- migration;
+- K3 WISE token mint;
+- K3 WISE postdeploy smoke.
+
+The new check runs in the same early sync step, before archive extraction. When
+the deploy host is already full, the workflow now fails at the storage gate
+instead of failing indirectly through `tar -xzf`.
+
+## Non-Goals Verified By Diff Scope
+
+Command:
+
+```bash
+git diff --name-only origin/main...HEAD
+```
+
+Expected files only:
+
+```text
+.github/workflows/docker-build.yml
+docs/deployment/onprem-docker-gc-20260403.md
+docs/development/deploy-host-sync-disk-preflight-development-20260521.md
+docs/development/deploy-host-sync-disk-preflight-verification-20260521.md
+scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+```
+
+This confirms no product runtime, schema, API, frontend, Bridge Agent BA-M1,
+or K3 write-path files changed.
+
+## Contract Test
+
+Command:
+
+```bash
+node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+```
+
+Expected:
+
+- Existing K3 WISE postdeploy workflow contract tests pass.
+- New deploy-host sync disk preflight test confirms the gate is present before
+  archive extraction and links to the Docker GC runbook.
+
+## Live Verification Plan After Merge
+
+1. Rerun `Build and Push Docker Images` on the merged commit.
+2. If deploy host space has been cleaned, expect the workflow to advance past
+   `Sync deploy host files`.
+3. If deploy host space is still below the gate, expect a clear failure:
+
+   ```text
+   [host-sync] disk_available_kb=...
+   [host-sync][error] deploy host free space is below the sync gate
+   ```
+
+4. Clean deploy host space using
+   `docs/deployment/onprem-docker-gc-20260403.md`, then rerun.
+
+## Secret Hygiene
+
+The change does not print deploy host credentials, SSH keys, tokens, database
+URLs, or K3 credentials. The new log values are filesystem capacity numbers and
+the resolved deploy repository path, matching the existing workflow behavior.

--- a/scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
+++ b/scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs
@@ -178,3 +178,21 @@ test('deploy workflow keeps K3 WISE smoke evidence wired into deploy summary and
   assertContains(raw, 'K3 WISE postdeploy smoke input check failed', 'deploy final gate')
   assertContains(raw, 'K3 WISE postdeploy smoke failed', 'deploy final gate')
 })
+
+test('deploy workflow checks deploy host disk before sync archive extraction', () => {
+  const raw = readFileSync(deployWorkflowPath, 'utf8')
+
+  assertContains(raw, '- name: Sync deploy host files', 'deploy host sync step')
+  assertContains(raw, "DEPLOY_SYNC_MIN_FREE_KB: ${{ vars.DEPLOY_SYNC_MIN_FREE_KB || '1048576' }}", 'deploy host sync disk gate env')
+  assertContains(raw, 'DEPLOY_SYNC_MIN_FREE_KB="${DEPLOY_SYNC_MIN_FREE_KB:-1048576}"', 'deploy host sync disk gate default')
+  assertContains(raw, 'DEPLOY_SYNC_MIN_FREE_KB=\'${DEPLOY_SYNC_MIN_FREE_KB}\' bash -s', 'deploy host sync remote env')
+  assertContains(raw, 'required_free_kb="${DEPLOY_SYNC_MIN_FREE_KB:-1048576}"', 'deploy host sync remote default')
+  assertContains(raw, 'df -Pk "${DEPLOY_REPO_PATH}"', 'deploy host sync disk probe')
+  assertContains(raw, '[host-sync] disk_available_kb=', 'deploy host sync disk log')
+  assertContains(raw, 'deploy host free space is below the sync gate', 'deploy host sync fail-fast message')
+  assertContains(raw, 'docs/deployment/onprem-docker-gc-20260403.md', 'deploy host sync recovery pointer')
+  assert.ok(
+    raw.indexOf('deploy host free space is below the sync gate') < raw.indexOf('tar -czf - \\'),
+    'deploy host sync disk gate must run before tar extraction',
+  )
+})


### PR DESCRIPTION
## Summary

Adds a fail-fast disk-space preflight to the `Build and Push Docker Images` deploy-host sync step. The recent main workflow failure reached `Sync deploy host files` and then failed with `tar: ... Cannot write: No space left on device`; this change turns that into a clear `[host-sync]` storage gate before archive extraction.

## What changed

- `docker-build.yml`: check `df -Pk "$DEPLOY_REPO_PATH"` on the deploy host before `tar -xzf`.
- Default gate: `DEPLOY_SYNC_MIN_FREE_KB=1048576` (1 GiB), overrideable via repository variable.
- Recovery message points to `docs/deployment/onprem-docker-gc-20260403.md`.
- Docker GC runbook now documents the GitHub deploy-host sync failure path and rerun sequence.
- Contract test locks the gate before archive extraction.
- Adds development + verification MDs.

## Verification

- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/docker-build.yml"); puts "workflow yaml ok"'` ✅
- `node --test scripts/ops/integration-k3wise-postdeploy-workflow-contract.test.mjs scripts/ops/remote-summary-pipefail-contract.test.mjs scripts/ops/attendance-remote-docker-gc-workflow-contract.test.mjs` ✅ 5/5
- `git diff --check origin/main...HEAD` ✅
- secret-shape grep across changed files ✅ 0 hits

## Scope / Non-goals

No product runtime changes, no DB/API/frontend changes, no `plugin-integration-core`, no Bridge Agent BA-M1 runtime, and no K3 Save/Submit/Audit changes.
