### PR TITLE
feat(attendance): enable effective calendar role matching

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1405,7 +1405,7 @@
                       {{ tr('These overrides drive the effective-calendar API and attendance calculation chain. Rest-to-work changes can create auto-absence rows after the auto-absence job runs.', '这些规则会影响有效日历 API 与考勤计算链。休息日改为工作日后，自动缺勤任务运行时可能生成缺勤记录。') }}
                     </p>
                     <p class="attendance__field-hint attendance__field-hint--warn">
-                      {{ tr('Role and role-tag matching is reserved until role context is loaded by the resolver; keep new rules scoped to org, group, or user.', '角色与角色标签匹配需等待解析器加载角色上下文；新增规则请先使用组织、考勤组或用户范围。') }}
+                      {{ tr('Role matching uses the platform user role plus assigned RBAC role IDs/names; role tags use the same resolver aliases until a dedicated role-tag catalog exists.', '角色匹配使用用户平台角色及已分配 RBAC 角色 ID/名称；在独立角色标签目录落地前，角色标签使用同一解析别名。') }}
                     </p>
                     <AttendanceCalendarPolicyPreviewPanel :tr="tr" />
                     <div v-if="settingsForm.calendarPolicyOverrides.length === 0" class="attendance__empty">
@@ -1446,7 +1446,7 @@
                                   <option value="org">{{ tr('Organization', '组织') }}</option>
                                   <option value="group">{{ tr('Attendance group', '考勤组') }}</option>
                                   <option value="user">{{ tr('User', '用户') }}</option>
-                                  <option value="role" disabled>{{ tr('Role (reserved)', '角色（预留）') }}</option>
+                                  <option value="role">{{ tr('Role', '角色') }}</option>
                                 </select>
                               </td>
                               <td>
@@ -1471,6 +1471,14 @@
                                     <small v-if="attendanceGroupOptions.length" class="attendance__field-hint">
                                       {{ tr('Known groups', '已知分组') }}: {{ attendanceGroupOptions.join(', ') }}
                                     </small>
+                                  </label>
+                                  <label class="attendance__override-field">
+                                    <span>{{ tr('Roles', '角色') }}</span>
+                                    <input v-model="override.roles" type="text" placeholder="attendance_admin,班组长" />
+                                  </label>
+                                  <label class="attendance__override-field">
+                                    <span>{{ tr('Role tags', '角色标签') }}</span>
+                                    <input v-model="override.roleTags" type="text" placeholder="attendance_admin,班组长" />
                                   </label>
                                   <label class="attendance__override-field">
                                     <span>{{ tr('User IDs', '用户ID') }}</span>

--- a/apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue
+++ b/apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue
@@ -117,7 +117,7 @@
             {{ tr('These overrides drive the effective-calendar API and attendance calculation chain. Rest-to-work changes can create auto-absence rows after the auto-absence job runs.', '这些规则会影响有效日历 API 与考勤计算链。休息日改为工作日后，自动缺勤任务运行时可能生成缺勤记录。') }}
           </p>
           <p class="attendance__field-hint attendance__field-hint--warn">
-            {{ tr('Role and role-tag matching is reserved until role context is loaded by the resolver; keep new rules scoped to org, group, or user.', '角色与角色标签匹配需等待解析器加载角色上下文；新增规则请先使用组织、考勤组或用户范围。') }}
+            {{ tr('Role matching uses the platform user role plus assigned RBAC role IDs/names; role tags use the same resolver aliases until a dedicated role-tag catalog exists.', '角色匹配使用用户平台角色及已分配 RBAC 角色 ID/名称；在独立角色标签目录落地前，角色标签使用同一解析别名。') }}
           </p>
           <AttendanceCalendarPolicyPreviewPanel :tr="tr" />
           <div v-if="calendarPolicyOverridesExpanded">
@@ -157,7 +157,7 @@
                           <option value="org">{{ tr('Organization', '组织') }}</option>
                           <option value="group">{{ tr('Attendance group', '考勤组') }}</option>
                           <option value="user">{{ tr('User', '用户') }}</option>
-                          <option value="role" disabled>{{ tr('Role (reserved)', '角色（预留）') }}</option>
+                          <option value="role">{{ tr('Role', '角色') }}</option>
                         </select>
                       </td>
                       <td>
@@ -177,6 +177,8 @@
                             <input v-model="override.attendanceGroups" type="text" placeholder="单休办公,白班" />
                             <small v-if="attendanceGroupOptions.length" class="attendance__field-hint">{{ tr('Known groups', '已知分组') }}: {{ attendanceGroupOptions.join(', ') }}</small>
                           </label>
+                          <label class="attendance__override-field"><span>{{ tr('Roles', '角色') }}</span><input v-model="override.roles" type="text" placeholder="attendance_admin,班组长" /></label>
+                          <label class="attendance__override-field"><span>{{ tr('Role tags', '角色标签') }}</span><input v-model="override.roleTags" type="text" placeholder="attendance_admin,班组长" /></label>
                           <label class="attendance__override-field"><span>{{ tr('User IDs', '用户ID') }}</span><input v-model="override.userIds" type="text" placeholder="uuid1,uuid2" /></label>
                           <label class="attendance__override-field"><span>{{ tr('User names', '用户名') }}</span><input v-model="override.userNames" type="text" placeholder="张三,李四" /></label>
                           <label class="attendance__override-field"><span>{{ tr('Exclude user IDs', '排除用户ID') }}</span><input v-model="override.excludeUserIds" type="text" placeholder="uuid3" /></label>

--- a/apps/web/tests/useAttendanceAdminConfig.spec.ts
+++ b/apps/web/tests/useAttendanceAdminConfig.spec.ts
@@ -145,12 +145,12 @@ describe('useAttendanceAdminConfig', () => {
       dayIndexStart: 2,
       dayIndexEnd: null,
       dayIndexList: '2 3',
-      source: 'group',
+      source: 'role',
       isWorkingDay: false,
       label: 'Group rest',
       attendanceGroups: 'day-shift',
-      roles: '',
-      roleTags: '',
+      roles: 'attendance_admin',
+      roleTags: 'Night Shift Lead',
       userIds: '',
       userNames: '',
       excludeUserIds: 'user-9',
@@ -179,12 +179,14 @@ describe('useAttendanceAdminConfig', () => {
       dayIndexList: [2, 3],
       filters: {
         attendanceGroups: ['day-shift'],
+        roles: ['attendance_admin'],
+        roleTags: ['Night Shift Lead'],
         excludeUserIds: ['user-9'],
       },
       effective: {
         isWorkingDay: false,
         label: 'Group rest',
-        source: 'group',
+        source: 'role',
       },
     })
     expect(payload.holidaySync.years).toEqual([2026, 2027])

--- a/apps/web/tests/useAttendanceHolidayRuleSection.spec.ts
+++ b/apps/web/tests/useAttendanceHolidayRuleSection.spec.ts
@@ -312,12 +312,14 @@ describe('AttendanceHolidayRuleSection', () => {
     expect(config.addCalendarPolicyOverride).toHaveBeenCalledTimes(1)
     expect(container!.textContent).toContain('有效日历覆盖规则')
     expect(container!.textContent).toContain('自动缺勤任务运行时可能生成缺勤记录')
-    const sourceSelect = Array.from(container!.querySelectorAll('select')).find((select) => (
-      Array.from(select.options).some((option) => option.value === 'role' && option.disabled)
-    ))
-    expect(sourceSelect).toBeTruthy()
+    expect(container!.textContent).toContain('角色匹配使用用户平台角色')
+    const roleOption = Array.from(container!.querySelectorAll('option')).find((option) => option.value === 'role')
+    expect(roleOption).toBeTruthy()
+    expect(roleOption?.disabled).toBe(false)
     expect(container!.querySelector('input[placeholder="规则标签"]')).toBeTruthy()
     expect(container!.querySelector('.attendance__override-field input[placeholder="单休办公,白班"]')).toBeTruthy()
+    const roleInputs = container!.querySelectorAll('.attendance__override-field input[placeholder="attendance_admin,班组长"]')
+    expect(roleInputs.length).toBeGreaterThanOrEqual(2)
   })
 
   it('shows the auto-sync timezone as a select with UTC offset labels', async () => {

--- a/docs/development/attendance-effective-calendar-role-context-development-20260521.md
+++ b/docs/development/attendance-effective-calendar-role-context-development-20260521.md
@@ -1,0 +1,98 @@
+# Attendance Effective Calendar Role Context Development
+
+Date: 2026-05-21
+Branch: `codex/attendance-effective-calendar-role-context-20260521`
+Base: `origin/main@5565a5cd3`
+
+## Summary
+
+This slice removes the last inert scope in `calendarPolicy.overrides[]`: role
+and role-tag filters now participate in the effective-calendar resolver and the
+attendance calculation chain. The facts remain in `attendance_*` SQL tables;
+settings still live in the existing attendance settings payload; no migration
+or direct `meta_*` write is introduced.
+
+## Scope
+
+Delivered:
+
+- Single-user resolver context now loads role aliases from:
+  - `users.role`
+  - assigned `user_roles.role_id`
+  - assigned `roles.name`
+- Batch prefetch context (`loadAttendanceScopeContextMapForUsers`) loads the
+  same aliases so payroll/import/auto-absence/range calculations observe the
+  same calendar policy as `/api/attendance/effective-calendar`.
+- `matchScopeFilters` now checks `filters.roles` against both `ctx.role` and
+  `ctx.roles[]`.
+- `filters.roleTags` now works in resolver mode via the same alias set.
+- Admin UI no longer marks role-scoped effective-calendar overrides as
+  reserved; both production `AttendanceView.vue` and extracted
+  `AttendanceHolidayRuleSection.vue` show the active resolver semantics.
+
+Not delivered:
+
+- A dedicated role-tag catalog/table. Current RBAC schema has no role-tag
+  column, so v1 exposes role ids/names as tag-like aliases.
+- Any new attendance fact table, migration, or persistence path.
+
+## Design Decisions
+
+### Role Alias Corpus
+
+The RBAC schema provides `users.role`, `user_roles.role_id`, and `roles.name`.
+There is no independent `role_tags` table. To keep behavior deterministic and
+avoid silent inert fields, resolver-mode `roleTags` intentionally uses the same
+normalized alias corpus as `roles`.
+
+This mirrors the existing import/profile path, where DingTalk `职位` can populate
+both `role` and `roleTags`.
+
+### Resolver Parity
+
+The implementation updates both:
+
+- `loadAttendanceScopeContextForUser` for single-user API/punch paths.
+- `loadAttendanceScopeContextMapForUsers` for prefetch paths.
+
+This keeps Step 5 cutover parity intact: read-only effective-calendar, punch
+writeback, payroll/import, auto-absence, and summary consumers all see the same
+role-scoped calendar policy.
+
+### Degraded Compatibility
+
+Role context loading follows the existing attendance scope loader posture:
+schema absence degrades to empty role arrays instead of failing calendar
+resolution. User name loading retains a fallback query when `users.role` is not
+available on older environments.
+
+## Changed Files
+
+- `plugins/plugin-attendance/index.cjs`
+  - Added role alias accumulator helpers.
+  - Extended single and batch scope context loaders.
+  - Extended `matchScopeFilters` to evaluate `ctx.roles[]`.
+  - Exported scope helpers in the unit-test surface.
+- `apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue`
+  - Enabled role scope option.
+  - Replaced reserved warning with active resolver semantics.
+- `apps/web/src/views/AttendanceView.vue`
+  - Same production UI copy/option update.
+- `packages/core-backend/tests/unit/attendance-effective-calendar-role-context.test.ts`
+  - New unit coverage for single/batch role context and scope matching.
+- `packages/core-backend/tests/integration/attendance-plugin.test.ts`
+  - Replaced inert-role effective-calendar test with active role/roleTag
+    matching.
+  - Updated punch cutover test so role-scoped override flips `is_workday`.
+- `apps/web/tests/useAttendanceHolidayRuleSection.spec.ts`
+  - Role source option is enabled and role inputs remain visible.
+- `apps/web/tests/useAttendanceAdminConfig.spec.ts`
+  - Save payload preserves role/roleTag filters for role-scoped overrides.
+
+## Boundaries
+
+- No `attendance_*` migration.
+- No direct `meta_*` writes.
+- No new settings route or storage shape.
+- No client-side calendar-policy validator.
+- No change to org/group/user precedence or same-source tie order.

--- a/docs/development/attendance-effective-calendar-role-context-verification-20260521.md
+++ b/docs/development/attendance-effective-calendar-role-context-verification-20260521.md
@@ -1,0 +1,50 @@
+# Attendance Effective Calendar Role Context Verification
+
+Date: 2026-05-21
+Branch: `codex/attendance-effective-calendar-role-context-20260521`
+Base: `origin/main@5565a5cd3`
+
+## Verification Matrix
+
+| Layer | Command | Result |
+| --- | --- | --- |
+| Plugin syntax | `node --check plugins/plugin-attendance/index.cjs` | PASS |
+| Backend role-context unit | `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` | PASS, 2 tests |
+| Backend catalog/formula regression | `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` | PASS, 58 tests |
+| Backend attendance calendar integration smoke | `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "effective-calendar role/roleTags|resolveWorkContext applies calendarPolicy" --reporter=dot` | PASS, 2 selected tests loaded/passed, 72 skipped by existing integration gating |
+| Frontend focused specs | `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/useAttendanceHolidayRuleSection.spec.ts tests/useAttendanceAdminConfig.spec.ts tests/AttendanceCalendarPolicyPreviewPanel.spec.ts --watch=false` | PASS, 12 tests |
+| Frontend admin regression | `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/useAttendanceHolidayRuleSection.spec.ts tests/useAttendanceAdminConfig.spec.ts tests/AttendanceCalendarPolicyPreviewPanel.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` | PASS, 23 tests |
+| Frontend type-check | `pnpm --filter @metasheet/web type-check` | PASS |
+| Backend build | `pnpm --filter @metasheet/core-backend build` | PASS |
+| Whitespace | `git diff --check` | PASS |
+
+## Acceptance Criteria
+
+- `filters.roles` matches a user whose resolver context contains the target
+  value in either `users.role`, `user_roles.role_id`, or `roles.name`.
+- `filters.roleTags` matches the same resolver alias corpus in v1, because no
+  dedicated role-tag catalog exists yet.
+- Single-user and batch prefetch paths produce the same role alias arrays.
+- A role-scoped effective-calendar override produces a `calendar_policy` layer
+  and `effective.source = "role"`.
+- Punch-time `resolveWorkContext` writes `attendance_records.is_workday` using
+  the role-scoped override.
+- Admin UI no longer disables the role source option.
+- Settings save payload keeps `filters.roles` and `filters.roleTags` for
+  role-scoped calendar overrides.
+
+## Boundary Checks
+
+- No migration files added or changed.
+- No `attendance_*` fact-source migration.
+- No direct `meta_*` SQL write.
+- No new frontend-only validator that could drift from the backend resolver.
+- Existing org/group/user calendar override paths remain untouched except for
+  shared role-aware scope matching.
+
+## Notes
+
+The integration smoke command followed the existing integration-file gating:
+the selected tests loaded and passed, while unrelated DB-heavy cases were
+skipped. The new unit tests cover the role-context loader logic without
+requiring a database.

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -7739,7 +7739,7 @@ describe('Attendance Plugin Integration', () => {
     expect(groupDenyRes.status).toBe(403)
   })
 
-  it('effective-calendar role/roleTags override is valid config but silently inert in resolver mode', async () => {
+  it('effective-calendar role/roleTags override matches DB-backed role context in resolver mode', async () => {
     if (!baseUrl) return
     const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
     if (!dbUrl) return
@@ -7747,8 +7747,11 @@ describe('Attendance Plugin Integration', () => {
     const runSuffix = Date.now().toString(36)
     const year = 3030 + (Number.parseInt(runSuffix.slice(-3), 36) % 500)
     const targetDate = `${year}-09-12`
-    const testUserId = `attendance-effcal-roleinert-user-${runSuffix}`
-    const adminUserId = `attendance-effcal-roleinert-admin-${runSuffix}`
+    const targetTagDate = `${year}-09-13`
+    const testUserId = `attendance-effcal-role-user-${runSuffix}`
+    const adminUserId = `attendance-effcal-role-admin-${runSuffix}`
+    const roleId = `attendance-effcal-role-${runSuffix}`
+    const roleName = `Effective Calendar Role ${runSuffix}`
 
     const adminTokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&roles=admin&perms=attendance:read,attendance:admin`
@@ -7756,12 +7759,29 @@ describe('Attendance Plugin Integration', () => {
     const adminToken = (adminTokenRes.body as { token?: string } | undefined)?.token
     expect(adminToken).toBeTruthy()
     if (!adminToken) return
+    const pool = new Pool({ connectionString: dbUrl })
 
     try {
-      // POST a role-source override targeting a role the resolver cannot load
-      // for a user; per Known Limitation (v1), role/roleTags filters require
-      // a DB context loader that does not exist yet, so the override stays as
-      // valid persisted config but does not fire in resolver mode.
+      await pool.query(
+        `INSERT INTO users (id, email, password_hash, name, role, is_active)
+         VALUES ($1, $2, 'no-login', 'Effective Calendar Role User', $3, true)
+         ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, role = EXCLUDED.role, is_active = true`,
+        [testUserId, `${testUserId}@example.com`, roleId],
+      )
+      await pool.query(
+        `INSERT INTO roles (id, name) VALUES ($1, $2)
+         ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name`,
+        [roleId, roleName],
+      )
+      await pool.query(
+        `INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2)
+         ON CONFLICT DO NOTHING`,
+        [testUserId, roleId],
+      )
+
+      // Role and roleTags both resolve from the DB-backed role alias set:
+      // users.role + assigned RBAC role ids/names. There is no dedicated
+      // role-tag table yet, so roleTags intentionally use the same alias set.
       const putRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
         method: 'PUT',
         headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
@@ -7770,8 +7790,13 @@ describe('Attendance Plugin Integration', () => {
             overrides: [
               {
                 date: targetDate,
-                filters: { roles: ['production_lead'] },
-                effective: { isWorkingDay: true, label: 'Role-inert in resolver', source: 'role' },
+                filters: { roles: [roleId] },
+                effective: { isWorkingDay: true, label: 'Role resolver match', source: 'role' },
+              },
+              {
+                date: targetTagDate,
+                filters: { roleTags: [roleName] },
+                effective: { isWorkingDay: false, label: 'Role tag resolver match', source: 'role' },
               },
             ],
           },
@@ -7779,23 +7804,24 @@ describe('Attendance Plugin Integration', () => {
       })
       expect(putRes.status).toBe(200)
       const saved = ((putRes.body as any)?.data?.calendarPolicy?.overrides ?? []) as any[]
-      // Config remains valid + persisted (normalize keeps it)
-      expect(saved.length).toBe(1)
+      expect(saved.length).toBe(2)
       expect(saved[0].effective?.source).toBe('role')
+      expect(saved[1].filters?.roleTags).toEqual([roleName])
 
       const res = await requestJson(
-        `${baseUrl}/api/attendance/effective-calendar?from=${targetDate}&to=${targetDate}&userId=${encodeURIComponent(testUserId)}`,
+        `${baseUrl}/api/attendance/effective-calendar?from=${targetDate}&to=${targetTagDate}&userId=${encodeURIComponent(testUserId)}`,
         { headers: { Authorization: `Bearer ${adminToken}` } }
       )
       expect(res.status).toBe(200)
-      const item = ((res.body as any)?.data?.items ?? [])[0]
-      expect(item.date).toBe(targetDate)
-      // No calendar_policy layer present — the role override silently did not fire
-      const policyLayers = item.layers.filter((l: any) => l.kind === 'calendar_policy')
-      expect(policyLayers.length).toBe(0)
-      // effective falls back to base (rule)
-      expect(item.effective.source).toBe('rule')
-      expect(item.effective.policyId).toBeUndefined()
+      const items = ((res.body as any)?.data?.items ?? []) as any[]
+      const roleItem = items.find((item) => item.date === targetDate)
+      const tagItem = items.find((item) => item.date === targetTagDate)
+      expect(roleItem?.effective.source).toBe('role')
+      expect(roleItem?.effective.policyId).toBeTruthy()
+      expect(roleItem?.layers.some((l: any) => l.kind === 'calendar_policy' && l.source === 'role')).toBe(true)
+      expect(tagItem?.effective.source).toBe('role')
+      expect(tagItem?.effective.label).toBe('Role tag resolver match')
+      expect(tagItem?.layers.some((l: any) => l.kind === 'calendar_policy' && l.source === 'role')).toBe(true)
     } finally {
       const cleanupRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
         method: 'PUT',
@@ -7803,6 +7829,10 @@ describe('Attendance Plugin Integration', () => {
         body: JSON.stringify({ calendarPolicy: { overrides: [] } }),
       })
       expect(cleanupRes.status).toBe(200)
+      await pool.query(`DELETE FROM user_roles WHERE user_id = $1`, [testUserId]).catch(() => undefined)
+      await pool.query(`DELETE FROM roles WHERE id = $1`, [roleId]).catch(() => undefined)
+      await pool.query(`DELETE FROM users WHERE id = $1`, [testUserId]).catch(() => undefined)
+      await pool.end()
     }
   })
 
@@ -7817,7 +7847,7 @@ describe('Attendance Plugin Integration', () => {
   // same date:
   //   (a) baseline — no policy → is_workday tracks the holiday row
   //   (b) org override flips holiday → is_workday flips with it
-  //   (c) role-source override stays inert (D6 known limitation)
+  //   (c) role-source override flips holiday after loading DB role context
   // §5.1 / §5.7 / §5.11 negative protection (no-policy equivalence) is
   // already covered by all 71 existing tests continuing to pass after the
   // Block A/B/C integration.
@@ -7840,6 +7870,8 @@ describe('Attendance Plugin Integration', () => {
     expect(targetDate < todayUtc).toBe(true)
     const userId = `attendance-step5-user-${runSuffix}`
     const adminId = `attendance-step5-admin-${runSuffix}`
+    const roleId = `attendance-step5-role-${runSuffix}`
+    const roleName = `Step 5 Role ${runSuffix}`
     const orgId = 'default'
     const occurredAt = `${targetDate}T01:00:00.000Z` // 09:00 in Asia/Shanghai
 
@@ -7889,6 +7921,23 @@ describe('Attendance Plugin Integration', () => {
     }
 
     try {
+      await pool.query(
+        `INSERT INTO users (id, email, password_hash, name, role, is_active)
+         VALUES ($1, $2, 'no-login', 'Step5 Role User', $3, true)
+         ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name, role = EXCLUDED.role, is_active = true`,
+        [userId, `${userId}@example.com`, roleId],
+      )
+      await pool.query(
+        `INSERT INTO roles (id, name) VALUES ($1, $2)
+         ON CONFLICT (id) DO UPDATE SET name = EXCLUDED.name`,
+        [roleId, roleName],
+      )
+      await pool.query(
+        `INSERT INTO user_roles (user_id, role_id) VALUES ($1, $2)
+         ON CONFLICT DO NOTHING`,
+        [userId, roleId],
+      )
+
       // Setup: a national holiday on targetDate (is_working_day=false). The
       // pre-Step-5 calc would always treat this day as rest; Step 5 lets
       // calendarPolicy flip it.
@@ -7925,16 +7974,16 @@ describe('Attendance Plugin Integration', () => {
       const flippedWorkday = await punchAndReadIsWorkday(userToken)
       expect(flippedWorkday).toBe(true)
 
-      // --- (c) role-source override stays inert (D6: no DB role context in v1) ---
+      // --- (c) role-source override flips after resolver loads DB role context ---
       await putCalendarPolicy(adminToken, [
         {
           date: targetDate,
-          filters: { roles: ['production'] },
+          filters: { roles: [roleId] },
           effective: { isWorkingDay: true, label: 'Step 5 role flip', source: 'role' },
         },
       ])
       const roleWorkday = await punchAndReadIsWorkday(userToken)
-      expect(roleWorkday).toBe(false)
+      expect(roleWorkday).toBe(true)
     } finally {
       const cleanToken = await tokenFor(`${adminId}-cleanup`, 'admin', 'attendance:admin')
       if (cleanToken) {
@@ -7947,6 +7996,9 @@ describe('Attendance Plugin Integration', () => {
       await pool.query(`DELETE FROM attendance_events WHERE user_id = $1`, [userId]).catch(() => undefined)
       await pool.query(`DELETE FROM attendance_records WHERE user_id = $1`, [userId]).catch(() => undefined)
       await pool.query(`DELETE FROM attendance_holidays WHERE org_id = $1 AND holiday_date = $2`, [orgId, targetDate]).catch(() => undefined)
+      await pool.query(`DELETE FROM user_roles WHERE user_id = $1`, [userId]).catch(() => undefined)
+      await pool.query(`DELETE FROM roles WHERE id = $1`, [roleId]).catch(() => undefined)
+      await pool.query(`DELETE FROM users WHERE id = $1`, [userId]).catch(() => undefined)
       await pool.end()
     }
   })

--- a/packages/core-backend/tests/unit/attendance-effective-calendar-role-context.test.ts
+++ b/packages/core-backend/tests/unit/attendance-effective-calendar-role-context.test.ts
@@ -1,0 +1,70 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it, vi } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceReportFieldCatalogForTests
+
+describe('attendance effective calendar role context', () => {
+  it('loads role aliases from users.role and assigned RBAC roles for single-user matching', async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('SELECT name, role FROM users')) {
+        return [{ name: 'Lin Mei', role: 'platform_lead' }]
+      }
+      if (sql.includes('attendance_group_members')) return []
+      if (sql.includes('FROM user_roles ur')) {
+        return [
+          { role_id: 'attendance_admin', role_name: 'Attendance Admin' },
+          { role_id: 'night_shift_lead', role_name: 'Night Shift Lead' },
+        ]
+      }
+      return []
+    })
+
+    const context = await helpers.loadAttendanceScopeContextForUser({ query }, 'default', 'user-1')
+
+    expect(context).toMatchObject({
+      userId: 'user-1',
+      userName: 'Lin Mei',
+      role: 'platform_lead',
+      roles: ['platform_lead', 'attendance_admin', 'Attendance Admin', 'night_shift_lead', 'Night Shift Lead'],
+      roleTags: ['platform_lead', 'attendance_admin', 'Attendance Admin', 'night_shift_lead', 'Night Shift Lead'],
+    })
+    expect(helpers.matchScopeFilters({ roles: ['night shift lead'] }, context)).toBe(true)
+    expect(helpers.matchScopeFilters({ roleTags: ['attendance_admin'] }, context)).toBe(true)
+    expect(helpers.matchScopeFilters({ roles: ['finance'] }, context)).toBe(false)
+    expect(helpers.matchScopeFilters({ roleTags: ['finance'] }, context)).toBe(false)
+  })
+
+  it('batch-loads the same role aliases for prefetch calendar matching', async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('SELECT id, name, role FROM users')) {
+        return [
+          { id: 'user-1', name: 'Lin Mei', role: 'platform_lead' },
+          { id: 'user-2', name: 'Wang Lei', role: 'operator' },
+        ]
+      }
+      if (sql.includes('attendance_group_members')) {
+        return [{ user_id: 'user-2', name: 'Day Shift', code: 'day_shift' }]
+      }
+      if (sql.includes('FROM user_roles ur')) {
+        return [
+          { user_id: 'user-1', role_id: 'night_shift_lead', role_name: 'Night Shift Lead' },
+          { user_id: 'user-2', role_id: 'attendance_employee', role_name: 'Attendance Employee' },
+        ]
+      }
+      return []
+    })
+
+    const contexts = await helpers.loadAttendanceScopeContextMapForUsers({ query }, 'default', ['user-1', 'user-2'])
+    const user1 = contexts.get('user-1')
+    const user2 = contexts.get('user-2')
+
+    expect(user1?.roles).toEqual(['platform_lead', 'night_shift_lead', 'Night Shift Lead'])
+    expect(user1?.roleTags).toEqual(['platform_lead', 'night_shift_lead', 'Night Shift Lead'])
+    expect(user2?.attendanceGroups).toEqual(['Day Shift', 'day_shift'])
+    expect(user2?.roles).toEqual(['operator', 'attendance_employee', 'Attendance Employee'])
+    expect(helpers.matchScopeFilters({ roles: ['attendance employee'] }, user2)).toBe(true)
+    expect(helpers.matchScopeFilters({ roleTags: ['operator'] }, user2)).toBe(true)
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8331,6 +8331,46 @@ function matchAnyTag(values, list) {
   return values.some((value) => normalizedList.includes(normalizeMatchKey(value)))
 }
 
+function pushUniqueMatchValue(target, seen, value) {
+  const text = normalizeMatchValue(value)
+  if (!text) return
+  const key = normalizeMatchKey(text)
+  if (!key || seen.has(key)) return
+  seen.add(key)
+  target.push(text)
+}
+
+function appendRoleContextValue(context, value) {
+  if (!context || value === null || value === undefined) return
+  const values = Array.isArray(value) ? value : ensureStringArray(value)
+  for (const item of values) {
+    pushUniqueMatchValue(context.roles, context.roleSeen, item)
+    // There is no dedicated role-tag table in the current RBAC schema. For
+    // resolver-mode matching, expose assigned role ids/names as tag-like
+    // aliases too; this mirrors the import/profile path where "职位" can feed
+    // both role and roleTags.
+    pushUniqueMatchValue(context.roleTags, context.roleTagSeen, item)
+  }
+}
+
+function createAttendanceRoleContextAccumulator() {
+  return {
+    roles: [],
+    roleTags: [],
+    roleSeen: new Set(),
+    roleTagSeen: new Set(),
+  }
+}
+
+function finalizeAttendanceRoleContext(accumulator) {
+  if (!accumulator) return { role: undefined, roles: [], roleTags: [] }
+  return {
+    role: accumulator.roles[0],
+    roles: accumulator.roles.slice(),
+    roleTags: accumulator.roleTags.slice(),
+  }
+}
+
 // Shared day-index predicate (RFC §2.3): both holidayPolicy and calendarPolicy
 // MUST use this; no duplicate implementations allowed.
 function matchDayIndexFilter(filter, dayIndex) {
@@ -8380,8 +8420,12 @@ function matchScopeFilters(filters, context) {
       return false
     }
   }
-  if (Array.isArray(filters.roles) && filters.roles.length && !matchListValue(ctx.role, filters.roles)) {
-    return false
+  if (Array.isArray(filters.roles) && filters.roles.length) {
+    const roleValues = [
+      ctx.role,
+      ...(Array.isArray(ctx.roles) ? ctx.roles : []),
+    ].filter((value) => value !== undefined && value !== null && value !== '')
+    if (!roleValues.some((value) => matchListValue(value, filters.roles))) return false
   }
   if (Array.isArray(filters.roleTags) && filters.roleTags.length && !matchAnyTag(ctx.roleTags, filters.roleTags)) {
     return false
@@ -10416,14 +10460,22 @@ async function loadApprovedRequestsForOverlay(db, orgId, userId, fromDate, toDat
 }
 
 async function loadAttendanceScopeContextForUser(db, orgId, userId) {
-  if (!userId) return { userId: null, userName: undefined, attendanceGroups: [] }
+  if (!userId) return { userId: null, userName: undefined, attendanceGroups: [], roles: [], roleTags: [] }
   const targetOrg = orgId || DEFAULT_ORG_ID
   let userName
+  const roleAccumulator = createAttendanceRoleContextAccumulator()
   try {
-    const rows = await db.query('SELECT name FROM users WHERE id = $1', [userId])
+    const rows = await db.query('SELECT name, role FROM users WHERE id = $1', [userId])
     if (rows.length && typeof rows[0].name === 'string') userName = rows[0].name
+    if (rows.length) appendRoleContextValue(roleAccumulator, rows[0].role)
   } catch (error) {
     if (!isDatabaseSchemaError(error)) throw error
+    try {
+      const rows = await db.query('SELECT name FROM users WHERE id = $1', [userId])
+      if (rows.length && typeof rows[0].name === 'string') userName = rows[0].name
+    } catch (fallbackError) {
+      if (!isDatabaseSchemaError(fallbackError)) throw fallbackError
+    }
   }
   const attendanceGroups = []
   try {
@@ -10446,37 +10498,72 @@ async function loadAttendanceScopeContextForUser(db, orgId, userId) {
   } catch (error) {
     if (!isDatabaseSchemaError(error)) throw error
   }
-  // role/roleTags: NOT loaded in v1 — Step 3 Known Limitation (see dev MD).
-  // calendarPolicy.overrides[] with effective.source='role' remain valid
-  // config but the resolver cannot match them without DB-backed role context.
-  return { userId, userName, attendanceGroups }
+  try {
+    const rows = await db.query(
+      `SELECT ur.role_id, r.name AS role_name
+       FROM user_roles ur
+       LEFT JOIN roles r ON r.id = ur.role_id
+       WHERE ur.user_id = $1`,
+      [userId]
+    )
+    for (const row of rows) {
+      appendRoleContextValue(roleAccumulator, row.role_id)
+      appendRoleContextValue(roleAccumulator, row.role_name)
+    }
+  } catch (error) {
+    if (!isDatabaseSchemaError(error)) throw error
+  }
+  const roleContext = finalizeAttendanceRoleContext(roleAccumulator)
+  return {
+    userId,
+    userName,
+    attendanceGroups,
+    role: roleContext.role,
+    roles: roleContext.roles,
+    roleTags: roleContext.roleTags,
+  }
 }
 
 // Step 5: batch range version mirroring loadShiftAssignmentMapForUsersRange.
 // Used by buildWorkContextPrefetch to populate scopeContextByUser so the
 // calc-chain prefetch path can resolve calendarPolicy.overrides without a
-// per-user round-trip. Same role/roleTags limitation as the single-user
-// variant — D6 pinned.
+// per-user round-trip.
 async function loadAttendanceScopeContextMapForUsers(db, orgId, userIds) {
   const list = Array.isArray(userIds) ? Array.from(new Set(userIds.filter(Boolean))) : []
   const result = new Map()
   if (list.length === 0) return result
   const targetOrg = orgId || DEFAULT_ORG_ID
+  const rolesByUser = new Map()
   for (const id of list) {
-    result.set(id, { userId: id, userName: undefined, attendanceGroups: [] })
+    result.set(id, { userId: id, userName: undefined, attendanceGroups: [], roles: [], roleTags: [] })
+    rolesByUser.set(id, createAttendanceRoleContextAccumulator())
   }
   try {
     const userRows = await db.query(
-      'SELECT id, name FROM users WHERE id = ANY($1::text[])',
+      'SELECT id, name, role FROM users WHERE id = ANY($1::text[])',
       [list],
     )
     for (const row of userRows) {
       const id = row?.id
       if (!id || !result.has(id)) continue
       if (typeof row.name === 'string') result.get(id).userName = row.name
+      appendRoleContextValue(rolesByUser.get(id), row.role)
     }
   } catch (error) {
     if (!isDatabaseSchemaError(error)) throw error
+    try {
+      const userRows = await db.query(
+        'SELECT id, name FROM users WHERE id = ANY($1::text[])',
+        [list],
+      )
+      for (const row of userRows) {
+        const id = row?.id
+        if (!id || !result.has(id)) continue
+        if (typeof row.name === 'string') result.get(id).userName = row.name
+      }
+    } catch (fallbackError) {
+      if (!isDatabaseSchemaError(fallbackError)) throw fallbackError
+    }
   }
   try {
     const memberRows = await db.query(
@@ -10505,6 +10592,32 @@ async function loadAttendanceScopeContextMapForUsers(db, orgId, userIds) {
     }
   } catch (error) {
     if (!isDatabaseSchemaError(error)) throw error
+  }
+  try {
+    const roleRows = await db.query(
+      `SELECT ur.user_id, ur.role_id, r.name AS role_name
+       FROM user_roles ur
+       LEFT JOIN roles r ON r.id = ur.role_id
+       WHERE ur.user_id = ANY($1::text[])`,
+      [list],
+    )
+    for (const row of roleRows) {
+      const id = row?.user_id
+      if (!id || !rolesByUser.has(id)) continue
+      const accumulator = rolesByUser.get(id)
+      appendRoleContextValue(accumulator, row.role_id)
+      appendRoleContextValue(accumulator, row.role_name)
+    }
+  } catch (error) {
+    if (!isDatabaseSchemaError(error)) throw error
+  }
+  for (const [id, accumulator] of rolesByUser.entries()) {
+    const target = result.get(id)
+    if (!target) continue
+    const roleContext = finalizeAttendanceRoleContext(accumulator)
+    target.role = roleContext.role
+    target.roles = roleContext.roles
+    target.roleTags = roleContext.roleTags
   }
   return result
 }
@@ -12613,6 +12726,9 @@ module.exports = {
     buildAttendanceReportFieldConfig,
     buildAttendanceReportFieldConfigHeaders,
     buildAttendanceReportFieldConfigFingerprint,
+    matchScopeFilters,
+    loadAttendanceScopeContextForUser,
+    loadAttendanceScopeContextMapForUsers,
   },
 
   async activate(context) {


### PR DESCRIPTION
## Summary

Enables role-scoped effective-calendar overrides by loading DB-backed role context into both single-user and batch prefetch resolver paths.

- Role aliases now come from `users.role`, assigned `user_roles.role_id`, and `roles.name`.
- `filters.roles` matches `ctx.role` plus `ctx.roles[]`; `filters.roleTags` uses the same resolver alias set in v1 because there is no dedicated role-tag catalog yet.
- Admin UI no longer marks role scope as reserved and exposes role/roleTag inputs for calendar-policy overrides.
- Adds development and verification docs for the slice.

## Test plan

- [x] `node --check plugins/plugin-attendance/index.cjs`
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` — 58 pass
- [x] `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "effective-calendar role/roleTags|resolveWorkContext applies calendarPolicy" --reporter=dot` — 2 selected tests loaded/passed; existing integration gating skipped unrelated DB-heavy cases
- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/useAttendanceHolidayRuleSection.spec.ts tests/useAttendanceAdminConfig.spec.ts tests/AttendanceCalendarPolicyPreviewPanel.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` — 23 pass
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `pnpm --filter @metasheet/core-backend build`
- [x] `git diff --check`

## Boundaries

- No `attendance_*` migration
- No direct `meta_*` writes
- No new frontend-only validator
- No change to org/group/user calendar override priority or tie-order