### PR TITLE
feat(attendance): warn on calendar policy override conflicts

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1408,6 +1408,23 @@
                       {{ tr('Role matching uses the platform user role plus assigned RBAC role IDs/names; role tags use the same resolver aliases until a dedicated role-tag catalog exists.', '角色匹配使用用户平台角色及已分配 RBAC 角色 ID/名称；在独立角色标签目录落地前，角色标签使用同一解析别名。') }}
                     </p>
                     <AttendanceCalendarPolicyPreviewPanel :tr="tr" />
+                    <div
+                      v-if="calendarPolicyOverrideDiagnostics.length"
+                      class="attendance__calendar-policy-diagnostics"
+                      data-attendance-calendar-policy-diagnostics
+                      role="alert"
+                    >
+                      <strong>{{ tr('Calendar rule checks', '日历规则检查') }}</strong>
+                      <ul>
+                        <li
+                          v-for="diagnostic in calendarPolicyOverrideDiagnostics"
+                          :key="diagnostic.key"
+                          :data-calendar-policy-diagnostic="diagnostic.code"
+                        >
+                          {{ calendarPolicyDiagnosticMessage(diagnostic) }}
+                        </li>
+                      </ul>
+                    </div>
                     <div v-if="settingsForm.calendarPolicyOverrides.length === 0" class="attendance__empty">
                       {{ tr('No effective calendar overrides configured.', '暂无有效日历覆盖规则。') }}
                     </div>
@@ -4813,9 +4830,11 @@ import AttendanceHolidayDataSection from './attendance/AttendanceHolidayDataSect
 import AttendanceUserPickerField from './attendance/AttendanceUserPickerField.vue'
 import AttendanceReportFieldsSection from './attendance/AttendanceReportFieldsSection.vue'
 import {
+  buildCalendarPolicyOverrideDiagnostics,
   calendarPolicyOverridesFromForm,
   calendarPolicyOverridesToForm,
   createDefaultCalendarPolicyOverrideForm,
+  type CalendarPolicyOverrideDiagnostic,
   type CalendarPolicyOverrideFormState,
   type CalendarPolicyOverrideWire,
 } from './attendance/attendanceCalendarPolicyOverrides'
@@ -7641,6 +7660,37 @@ const settingsForm = reactive({
   geoFenceRadius: '',
   minPunchIntervalMinutes: 1,
 })
+
+const calendarPolicyOverrideDiagnostics = computed(() => buildCalendarPolicyOverrideDiagnostics(settingsForm.calendarPolicyOverrides))
+
+function calendarPolicySourceRequirement(source: CalendarPolicyOverrideFormState['source']): string {
+  if (source === 'group') return tr('attendance groups', '考勤组')
+  if (source === 'role') return tr('roles or role tags', '角色或角色标签')
+  if (source === 'user') return tr('user IDs or user names', '用户ID或用户名')
+  return tr('a date, range, holiday name, or day index', '日期、范围、节假日名称或序号')
+}
+
+function calendarPolicyDiagnosticMessage(diagnostic: CalendarPolicyOverrideDiagnostic): string {
+  const row = diagnostic.primaryIndex + 1
+  if (diagnostic.code === 'missing_scope') {
+    const requirement = calendarPolicySourceRequirement(diagnostic.source)
+    return tr(
+      `Rule #${row} will not be saved because its source requires ${requirement}.`,
+      `第 ${row} 条规则不会被保存：该范围需要填写${requirement}。`,
+    )
+  }
+  if (diagnostic.code === 'invalid_date_range') {
+    return tr(
+      `Rule #${row} has a start date after the end date.`,
+      `第 ${row} 条规则的开始日期晚于结束日期。`,
+    )
+  }
+  const winner = (diagnostic.secondaryIndex ?? diagnostic.primaryIndex) + 1
+  return tr(
+    `Rule #${row} overlaps rule #${winner} with the same source and scope; the later rule wins on overlapping days.`,
+    `第 ${row} 条规则与第 ${winner} 条规则的范围和来源重叠；重叠日期以后面的规则为准。`,
+  )
+}
 
 const provisionForm = reactive({
   userId: '',
@@ -14823,6 +14873,20 @@ const holidaySectionBindings = {
 
 .attendance__field-hint--warn {
   color: #9a6700;
+}
+
+.attendance__calendar-policy-diagnostics {
+  border: 1px solid #f2c94c;
+  background: #fff8e1;
+  color: #7a4f00;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 12px;
+}
+
+.attendance__calendar-policy-diagnostics ul {
+  margin: 6px 0 0;
+  padding-left: 18px;
 }
 
 .attendance__btn {

--- a/apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue
+++ b/apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue
@@ -120,6 +120,23 @@
             {{ tr('Role matching uses the platform user role plus assigned RBAC role IDs/names; role tags use the same resolver aliases until a dedicated role-tag catalog exists.', '角色匹配使用用户平台角色及已分配 RBAC 角色 ID/名称；在独立角色标签目录落地前，角色标签使用同一解析别名。') }}
           </p>
           <AttendanceCalendarPolicyPreviewPanel :tr="tr" />
+          <div
+            v-if="calendarPolicyOverrideDiagnostics.length"
+            class="attendance__calendar-policy-diagnostics"
+            data-attendance-calendar-policy-diagnostics
+            role="alert"
+          >
+            <strong>{{ tr('Calendar rule checks', '日历规则检查') }}</strong>
+            <ul>
+              <li
+                v-for="diagnostic in calendarPolicyOverrideDiagnostics"
+                :key="diagnostic.key"
+                :data-calendar-policy-diagnostic="diagnostic.code"
+              >
+                {{ calendarPolicyDiagnosticMessage(diagnostic) }}
+              </li>
+            </ul>
+          </div>
           <div v-if="calendarPolicyOverridesExpanded">
             <div v-if="settingsForm.calendarPolicyOverrides.length === 0" class="attendance__empty">{{ tr('No effective calendar overrides configured.', '暂无有效日历覆盖规则。') }}</div>
             <div v-else class="attendance__table-wrapper">
@@ -284,7 +301,11 @@
 <script setup lang="ts">
 import { computed, ref, watch, type Ref } from 'vue'
 import AttendanceCalendarPolicyPreviewPanel from './AttendanceCalendarPolicyPreviewPanel.vue'
-import type { CalendarPolicyOverrideFormState } from './attendanceCalendarPolicyOverrides'
+import {
+  buildCalendarPolicyOverrideDiagnostics,
+  type CalendarPolicyOverrideDiagnostic,
+  type CalendarPolicyOverrideFormState,
+} from './attendanceCalendarPolicyOverrides'
 import { buildTimezoneOptionGroups } from './attendanceTimezones'
 
 type Translate = (en: string, zh: string) => string
@@ -390,6 +411,37 @@ const calendarPolicyOverrideSummary = computed(() => {
   return count === 0 ? tr('No effective calendar overrides configured', '暂无有效日历覆盖规则') : tr(`${count} effective override(s) configured`, `已配置 ${count} 条有效日历规则`)
 })
 
+const calendarPolicyOverrideDiagnostics = computed(() => buildCalendarPolicyOverrideDiagnostics(settingsForm.calendarPolicyOverrides))
+
+function calendarPolicySourceRequirement(source: CalendarPolicyOverrideFormState['source']): string {
+  if (source === 'group') return tr('attendance groups', '考勤组')
+  if (source === 'role') return tr('roles or role tags', '角色或角色标签')
+  if (source === 'user') return tr('user IDs or user names', '用户ID或用户名')
+  return tr('a date, range, holiday name, or day index', '日期、范围、节假日名称或序号')
+}
+
+function calendarPolicyDiagnosticMessage(diagnostic: CalendarPolicyOverrideDiagnostic): string {
+  const row = diagnostic.primaryIndex + 1
+  if (diagnostic.code === 'missing_scope') {
+    const requirement = calendarPolicySourceRequirement(diagnostic.source)
+    return tr(
+      `Rule #${row} will not be saved because its source requires ${requirement}.`,
+      `第 ${row} 条规则不会被保存：该范围需要填写${requirement}。`,
+    )
+  }
+  if (diagnostic.code === 'invalid_date_range') {
+    return tr(
+      `Rule #${row} has a start date after the end date.`,
+      `第 ${row} 条规则的开始日期晚于结束日期。`,
+    )
+  }
+  const winner = (diagnostic.secondaryIndex ?? diagnostic.primaryIndex) + 1
+  return tr(
+    `Rule #${row} overlaps rule #${winner} with the same source and scope; the later rule wins on overlapping days.`,
+    `第 ${row} 条规则与第 ${winner} 条规则的范围和来源重叠；重叠日期以后面的规则为准。`,
+  )
+}
+
 const toggleHolidayOverrides = () => {
   holidayOverridesExpanded.value = !holidayOverridesExpanded.value
 }
@@ -427,6 +479,8 @@ const syncNextYear = () => syncHolidaysForYears([currentYear + 1])
 .attendance__field--checkbox { justify-content: flex-end; }
 .attendance__field-hint { color: #777; font-size: 11px; }
 .attendance__field-hint--warn { color: #9a6700; }
+.attendance__calendar-policy-diagnostics { border: 1px solid #f2c94c; background: #fff8e1; color: #7a4f00; border-radius: 6px; padding: 10px 12px; font-size: 12px; }
+.attendance__calendar-policy-diagnostics ul { margin: 6px 0 0; padding-left: 18px; }
 .attendance__accordion { flex: 1; display: flex; justify-content: space-between; align-items: center; gap: 12px; padding: 12px 14px; border-radius: 10px; border: 1px solid #d0d0d0; background: #fff; cursor: pointer; text-align: left; }
 .attendance__accordion-copy small, .attendance__accordion-indicator { color: #666; font-size: 12px; }
 .attendance__btn { padding: 8px 14px; border-radius: 6px; border: 1px solid #d0d0d0; background: #fff; cursor: pointer; }

--- a/apps/web/src/views/attendance/attendanceCalendarPolicyOverrides.ts
+++ b/apps/web/src/views/attendance/attendanceCalendarPolicyOverrides.ts
@@ -49,6 +49,20 @@ export interface CalendarPolicyOverrideFormState {
   excludeUserNames?: string
 }
 
+export type CalendarPolicyOverrideDiagnosticCode =
+  | 'missing_scope'
+  | 'invalid_date_range'
+  | 'shadowed_same_source'
+
+export interface CalendarPolicyOverrideDiagnostic {
+  key: string
+  code: CalendarPolicyOverrideDiagnosticCode
+  severity: 'warning'
+  primaryIndex: number
+  secondaryIndex?: number
+  source: CalendarPolicySource
+}
+
 function listToText(list?: Array<string | number>): string {
   return Array.isArray(list) ? list.join(',') : ''
 }
@@ -72,6 +86,73 @@ function splitNumberList(value?: string): number[] {
 function normalizeOptionalNumber(value: unknown): number | undefined {
   const num = typeof value === 'number' ? value : Number(value)
   return Number.isFinite(num) && num >= 1 ? num : undefined
+}
+
+function normalizeListKey(value?: string): string {
+  return splitListText(value)
+    .map((item) => item.toLocaleLowerCase())
+    .sort((left, right) => left.localeCompare(right))
+    .join(',')
+}
+
+function normalizeTextKey(value?: string): string {
+  return (value ?? '').trim().toLocaleLowerCase()
+}
+
+function dateKey(value?: string): string {
+  const trimmed = (value ?? '').trim()
+  return /^\d{4}-\d{2}-\d{2}$/.test(trimmed) ? trimmed : ''
+}
+
+function getDateSpan(form: CalendarPolicyOverrideFormState): { start: string; end: string } | null {
+  const singleDate = dateKey(form.date)
+  if (singleDate) return { start: singleDate, end: singleDate }
+  const from = dateKey(form.from)
+  const to = dateKey(form.to)
+  if (!from || !to || from > to) return null
+  return { start: from, end: to }
+}
+
+function hasInvalidDateRange(form: CalendarPolicyOverrideFormState): boolean {
+  const from = dateKey(form.from)
+  const to = dateKey(form.to)
+  return Boolean(from && to && from > to)
+}
+
+function dateSpansOverlap(
+  left: { start: string; end: string },
+  right: { start: string; end: string },
+): boolean {
+  return left.start <= right.end && right.start <= left.end
+}
+
+function dayIndexKey(form: CalendarPolicyOverrideFormState): string {
+  return [
+    normalizeOptionalNumber(form.dayIndexStart) ?? '',
+    normalizeOptionalNumber(form.dayIndexEnd) ?? '',
+    splitNumberList(form.dayIndexList).sort((left, right) => left - right).join(','),
+  ].join(':')
+}
+
+function calendarPolicyTargetKey(form: CalendarPolicyOverrideFormState): string {
+  const source = normalizeCalendarPolicySource(form.source)
+  return [
+    source,
+    normalizeTextKey(form.name),
+    normalizeCalendarPolicyMatch(form.match),
+    dayIndexKey(form),
+    normalizeListKey(form.attendanceGroups),
+    normalizeListKey(form.roles),
+    normalizeListKey(form.roleTags),
+    normalizeListKey(form.userIds),
+    normalizeListKey(form.userNames),
+    normalizeListKey(form.excludeUserIds),
+    normalizeListKey(form.excludeUserNames),
+  ].join('|')
+}
+
+function effectiveValueKey(form: CalendarPolicyOverrideFormState): string {
+  return `${form.isWorkingDay === true ? 'work' : 'rest'}:${normalizeTextKey(form.label)}`
 }
 
 function normalizeCalendarPolicySource(value: unknown): CalendarPolicySource {
@@ -153,6 +234,78 @@ function hasRequiredSourceFilter(form: CalendarPolicyOverrideFormState): boolean
     return splitListText(form.userIds).length > 0 || splitListText(form.userNames).length > 0
   }
   return true
+}
+
+export function buildCalendarPolicyOverrideDiagnostics(
+  forms: CalendarPolicyOverrideFormState[] | undefined,
+): CalendarPolicyOverrideDiagnostic[] {
+  if (!Array.isArray(forms)) return []
+
+  const diagnostics: CalendarPolicyOverrideDiagnostic[] = []
+  const comparableRows: Array<{
+    index: number
+    source: CalendarPolicySource
+    span: { start: string; end: string }
+    targetKey: string
+    effectiveKey: string
+  }> = []
+
+  forms.forEach((form, index) => {
+    if (!hasCalendarPolicyConstraint(form)) return
+    const source = normalizeCalendarPolicySource(form.source)
+    if (!hasRequiredSourceFilter(form)) {
+      diagnostics.push({
+        key: `missing-scope:${index}`,
+        code: 'missing_scope',
+        severity: 'warning',
+        primaryIndex: index,
+        source,
+      })
+      return
+    }
+    if (hasInvalidDateRange(form)) {
+      diagnostics.push({
+        key: `invalid-date-range:${index}`,
+        code: 'invalid_date_range',
+        severity: 'warning',
+        primaryIndex: index,
+        source,
+      })
+      return
+    }
+    const span = getDateSpan(form)
+    if (!span) return
+    comparableRows.push({
+      index,
+      source,
+      span,
+      targetKey: calendarPolicyTargetKey(form),
+      effectiveKey: effectiveValueKey(form),
+    })
+  })
+
+  for (let leftIndex = 0; leftIndex < comparableRows.length; leftIndex += 1) {
+    const left = comparableRows[leftIndex]
+    if (!left) continue
+    for (let rightIndex = leftIndex + 1; rightIndex < comparableRows.length; rightIndex += 1) {
+      const right = comparableRows[rightIndex]
+      if (!right) continue
+      if (left.source !== right.source) continue
+      if (left.targetKey !== right.targetKey) continue
+      if (left.effectiveKey === right.effectiveKey) continue
+      if (!dateSpansOverlap(left.span, right.span)) continue
+      diagnostics.push({
+        key: `shadowed-same-source:${left.index}:${right.index}`,
+        code: 'shadowed_same_source',
+        severity: 'warning',
+        primaryIndex: left.index,
+        secondaryIndex: right.index,
+        source: left.source,
+      })
+    }
+  }
+
+  return diagnostics
 }
 
 export function calendarPolicyOverridesFromForm(

--- a/apps/web/tests/attendanceCalendarPolicyOverrides.spec.ts
+++ b/apps/web/tests/attendanceCalendarPolicyOverrides.spec.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildCalendarPolicyOverrideDiagnostics,
+  calendarPolicyOverridesFromForm,
+  type CalendarPolicyOverrideFormState,
+} from '../src/views/attendance/attendanceCalendarPolicyOverrides'
+
+function overrideForm(overrides: Partial<CalendarPolicyOverrideFormState> = {}): CalendarPolicyOverrideFormState {
+  return {
+    name: '',
+    match: 'contains',
+    date: '',
+    from: '2026-10-01',
+    to: '2026-10-07',
+    dayIndexStart: null,
+    dayIndexEnd: null,
+    dayIndexList: '',
+    source: 'org',
+    isWorkingDay: false,
+    label: '',
+    attendanceGroups: '',
+    roles: '',
+    roleTags: '',
+    userIds: '',
+    userNames: '',
+    excludeUserIds: '',
+    excludeUserNames: '',
+    ...overrides,
+  }
+}
+
+describe('attendance calendar policy override diagnostics', () => {
+  it('warns when a scoped override would be dropped by save normalization', () => {
+    const diagnostics = buildCalendarPolicyOverrideDiagnostics([
+      overrideForm({ source: 'role', roles: '', roleTags: '', label: 'Role rest day' }),
+    ])
+
+    expect(calendarPolicyOverridesFromForm([
+      overrideForm({ source: 'role', roles: '', roleTags: '', label: 'Role rest day' }),
+    ])).toEqual([])
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'missing_scope',
+        primaryIndex: 0,
+        source: 'role',
+      }),
+    ])
+  })
+
+  it('warns when a date range is inverted', () => {
+    expect(buildCalendarPolicyOverrideDiagnostics([
+      overrideForm({ from: '2026-10-07', to: '2026-10-01' }),
+    ])).toEqual([
+      expect.objectContaining({
+        code: 'invalid_date_range',
+        primaryIndex: 0,
+      }),
+    ])
+  })
+
+  it('warns when a later same-source rule shadows an earlier overlapping target', () => {
+    const diagnostics = buildCalendarPolicyOverrideDiagnostics([
+      overrideForm({
+        source: 'group',
+        attendanceGroups: 'day-shift',
+        from: '2026-10-01',
+        to: '2026-10-07',
+        isWorkingDay: false,
+        label: 'Rest',
+      }),
+      overrideForm({
+        source: 'group',
+        attendanceGroups: 'day-shift',
+        from: '2026-10-03',
+        to: '2026-10-04',
+        isWorkingDay: true,
+        label: 'Make-up',
+      }),
+    ])
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'shadowed_same_source',
+        primaryIndex: 0,
+        secondaryIndex: 1,
+        source: 'group',
+      }),
+    ])
+  })
+
+  it('does not warn for non-overlapping or equivalent same-source rules', () => {
+    const diagnostics = buildCalendarPolicyOverrideDiagnostics([
+      overrideForm({
+        source: 'group',
+        attendanceGroups: 'day-shift',
+        from: '2026-10-01',
+        to: '2026-10-02',
+        isWorkingDay: false,
+        label: 'Rest',
+      }),
+      overrideForm({
+        source: 'group',
+        attendanceGroups: 'day-shift',
+        from: '2026-10-03',
+        to: '2026-10-04',
+        isWorkingDay: true,
+        label: 'Make-up',
+      }),
+      overrideForm({
+        source: 'group',
+        attendanceGroups: 'night-shift',
+        from: '2026-10-01',
+        to: '2026-10-02',
+        isWorkingDay: true,
+        label: 'Make-up',
+      }),
+      overrideForm({
+        source: 'group',
+        attendanceGroups: 'day-shift',
+        from: '2026-10-01',
+        to: '2026-10-02',
+        isWorkingDay: false,
+        label: 'Rest',
+      }),
+    ])
+
+    expect(diagnostics).toEqual([])
+  })
+})

--- a/apps/web/tests/useAttendanceHolidayRuleSection.spec.ts
+++ b/apps/web/tests/useAttendanceHolidayRuleSection.spec.ts
@@ -322,6 +322,103 @@ describe('AttendanceHolidayRuleSection', () => {
     expect(roleInputs.length).toBeGreaterThanOrEqual(2)
   })
 
+  it('shows effective calendar override diagnostics for unsaved and shadowed rules', async () => {
+    const settingsForm = reactive<HolidaySettingsState>(createDefaultSettings())
+    settingsForm.calendarPolicyOverrides.push(
+      {
+        name: '',
+        match: 'contains',
+        date: '',
+        from: '2026-10-01',
+        to: '2026-10-07',
+        dayIndexStart: null,
+        dayIndexEnd: null,
+        dayIndexList: '',
+        source: 'role',
+        isWorkingDay: false,
+        label: '角色休息日',
+        attendanceGroups: '',
+        roles: '',
+        roleTags: '',
+        userIds: '',
+        userNames: '',
+        excludeUserIds: '',
+        excludeUserNames: '',
+      },
+      {
+        name: '',
+        match: 'contains',
+        date: '',
+        from: '2026-10-01',
+        to: '2026-10-07',
+        dayIndexStart: null,
+        dayIndexEnd: null,
+        dayIndexList: '',
+        source: 'group',
+        isWorkingDay: false,
+        label: '休息日',
+        attendanceGroups: 'day-shift',
+        roles: '',
+        roleTags: '',
+        userIds: '',
+        userNames: '',
+        excludeUserIds: '',
+        excludeUserNames: '',
+      },
+      {
+        name: '',
+        match: 'contains',
+        date: '',
+        from: '2026-10-03',
+        to: '2026-10-04',
+        dayIndexStart: null,
+        dayIndexEnd: null,
+        dayIndexList: '',
+        source: 'group',
+        isWorkingDay: true,
+        label: '调休工作日',
+        attendanceGroups: 'day-shift',
+        roles: '',
+        roleTags: '',
+        userIds: '',
+        userNames: '',
+        excludeUserIds: '',
+        excludeUserNames: '',
+      },
+    )
+
+    const config = {
+      addCalendarPolicyOverride: vi.fn(),
+      addHolidayOverride: vi.fn(),
+      holidaySyncLastRun: { value: null },
+      holidaySyncLoading: { value: false },
+      removeCalendarPolicyOverride: vi.fn(),
+      removeHolidayOverride: vi.fn(),
+      saveSettings: vi.fn(),
+      settingsForm,
+      settingsLoading: { value: false },
+      syncHolidays: vi.fn(),
+      syncHolidaysForYears: vi.fn(),
+    } as HolidayConfig
+
+    app = createApp(AttendanceHolidayRuleSection, {
+      attendanceGroupOptions: ['day-shift'],
+      config,
+      formatDateTime,
+      tr,
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const diagnostics = container!.querySelector('[data-attendance-calendar-policy-diagnostics]')
+    expect(diagnostics).toBeTruthy()
+    expect(diagnostics?.textContent).toContain('日历规则检查')
+    expect(diagnostics?.textContent).toContain('第 1 条规则不会被保存')
+    expect(diagnostics?.textContent).toContain('第 2 条规则与第 3 条规则')
+    expect(container!.querySelector('[data-calendar-policy-diagnostic="missing_scope"]')).toBeTruthy()
+    expect(container!.querySelector('[data-calendar-policy-diagnostic="shadowed_same_source"]')).toBeTruthy()
+  })
+
   it('shows the auto-sync timezone as a select with UTC offset labels', async () => {
     const settingsForm = reactive<HolidaySettingsState>(createDefaultSettings())
 

--- a/docs/development/attendance-calendar-policy-conflict-hints-development-20260521.md
+++ b/docs/development/attendance-calendar-policy-conflict-hints-development-20260521.md
@@ -1,0 +1,96 @@
+# Attendance Calendar Policy Conflict Hints Development
+
+Date: 2026-05-21
+Branch: `codex/attendance-calendar-conflict-hints-20260521`
+Base: `origin/main@515fd8f9a`
+
+## Summary
+
+This slice adds admin-side diagnostics for effective-calendar override rows.
+It catches the two highest-risk configuration mistakes before save:
+
+- scoped rows that would be silently dropped by
+  `calendarPolicyOverridesFromForm()` because the required source filter is
+  empty;
+- overlapping same-source/same-target rows where the later row changes the
+  effective result and therefore wins on overlapping days.
+
+It also flags inverted date ranges. The effective-calendar backend resolver,
+attendance calculation chain, facts, settings storage shape, and preview API are
+unchanged.
+
+## Scope
+
+Delivered:
+
+- A pure helper,
+  `buildCalendarPolicyOverrideDiagnostics(forms)`, in
+  `attendanceCalendarPolicyOverrides.ts`.
+- Warning UI in both the production `AttendanceView.vue` section and the
+  extracted `AttendanceHolidayRuleSection.vue` component.
+- Focused unit coverage for the helper and component rendering.
+- Development and verification notes for this slice.
+
+Not delivered:
+
+- No backend validator or new settings route.
+- No resolver priority change. Existing source priority and same-source
+  later-row tie behavior remain authoritative.
+- No auto-fix, reorder, dedupe, or delete behavior.
+
+## Diagnostic Semantics
+
+### Missing Scope
+
+`group`, `role`, and `user` rows already require a matching source filter before
+they are included in the save payload:
+
+- `group`: `attendanceGroups`
+- `role`: `roles` or `roleTags`
+- `user`: `userIds` or `userNames`
+
+The new UI warning mirrors that existing save normalization. It does not block
+save, but tells the admin that the row will not be persisted.
+
+### Invalid Date Range
+
+Rows with both `from` and `to` set are checked lexically as `YYYY-MM-DD`. If
+`from > to`, the row gets a warning. Single-date rows and open-ended partial
+ranges are not treated as overlap candidates.
+
+### Same-Source Shadowing
+
+The backend selector uses source priority and later-array-order wins for
+same-priority ties. The frontend helper therefore only warns when all of these
+are true:
+
+- both rows have concrete overlapping dates;
+- both rows use the same `effective.source`;
+- normalized target filters match exactly, including holiday name/match,
+  day-index filters, attendance groups, roles, role tags, users, and excludes;
+- effective output differs (`isWorkingDay` or label).
+
+Different-source overlaps are expected priority behavior and are not flagged in
+this slice.
+
+## Changed Files
+
+- `apps/web/src/views/attendance/attendanceCalendarPolicyOverrides.ts`
+  - Added diagnostic types and pure helper functions.
+- `apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue`
+  - Displays diagnostics in the extracted holiday/effective-calendar section.
+- `apps/web/src/views/AttendanceView.vue`
+  - Displays the same diagnostics in the current production admin UI.
+- `apps/web/tests/attendanceCalendarPolicyOverrides.spec.ts`
+  - New helper coverage.
+- `apps/web/tests/useAttendanceHolidayRuleSection.spec.ts`
+  - Component rendering coverage for diagnostics.
+
+## Boundaries
+
+- No `attendance_*` migration.
+- No direct `meta_*` writes.
+- No plugin/backend route changes.
+- No new client-side resolver. The helper only explains existing save and
+  resolver semantics.
+- No staging/prod write operation.

--- a/docs/development/attendance-calendar-policy-conflict-hints-verification-20260521.md
+++ b/docs/development/attendance-calendar-policy-conflict-hints-verification-20260521.md
@@ -1,0 +1,46 @@
+# Attendance Calendar Policy Conflict Hints Verification
+
+Date: 2026-05-21
+Branch: `codex/attendance-calendar-conflict-hints-20260521`
+Base: `origin/main@515fd8f9a`
+
+## Verification Matrix
+
+| Layer | Command | Result |
+| --- | --- | --- |
+| Frontend focused specs | `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceCalendarPolicyOverrides.spec.ts tests/useAttendanceHolidayRuleSection.spec.ts --watch=false` | PASS, 10 tests |
+| Frontend type-check | `pnpm --filter @metasheet/web type-check` | PASS |
+| Frontend admin regression | `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceCalendarPolicyOverrides.spec.ts tests/useAttendanceHolidayRuleSection.spec.ts tests/useAttendanceAdminConfig.spec.ts tests/AttendanceCalendarPolicyPreviewPanel.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` | PASS, 28 tests |
+| Frontend build | `pnpm --filter @metasheet/web build` | PASS |
+| Whitespace | `git diff --check` | PASS |
+
+## Acceptance Criteria
+
+- A role/group/user-scoped effective-calendar row with a date or range but no
+  required source filter surfaces a visible warning before save.
+- The warning mirrors current save behavior: incomplete scoped rows are still
+  omitted by `calendarPolicyOverridesFromForm()`.
+- Inverted `from` / `to` ranges are reported.
+- Overlapping same-source, same-target rows with different effective outputs
+  report that the later row wins on overlapping days.
+- Equivalent same-source rows and non-overlapping rows do not emit a false
+  warning.
+- Both the extracted `AttendanceHolidayRuleSection.vue` and production
+  `AttendanceView.vue` render the same diagnostic block.
+
+## Boundary Checks
+
+- No backend file changed.
+- No `plugins/plugin-attendance/index.cjs` change.
+- No migration file added or changed.
+- No direct `meta_*` SQL write.
+- No staging/prod write operation.
+
+## Notes
+
+This is an advisory UI slice. It intentionally does not block save or
+re-implement the backend resolver. The source of truth remains the existing
+save normalization and effective-calendar backend selector.
+
+The frontend build emitted the existing Vite chunk-size/dynamic-import warnings;
+the build completed successfully.


### PR DESCRIPTION
## Summary

Adds admin-side diagnostics for effective-calendar override rows. The UI now warns when a scoped row would be dropped by save normalization, when a date range is inverted, and when a later same-source/same-target rule changes the effective result on overlapping days.

This is a pure frontend/docs slice: no backend resolver changes, no attendance_* migration, no direct meta_* writes, and no staging/prod write.

## Test plan

- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceCalendarPolicyOverrides.spec.ts tests/useAttendanceHolidayRuleSection.spec.ts --watch=false` (10 tests)
- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceCalendarPolicyOverrides.spec.ts tests/useAttendanceHolidayRuleSection.spec.ts tests/useAttendanceAdminConfig.spec.ts tests/AttendanceCalendarPolicyPreviewPanel.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` (28 tests)
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `pnpm --filter @metasheet/web build`
- [x] `git diff --check`

## Notes

The frontend build completed successfully and emitted the existing Vite chunk-size/dynamic-import warnings.