### PR TITLE
feat(integration): add readonly Bridge Agent skeleton

### DIFF
--- a/docs/development/bridge-agent-readonly-development-20260521.md
+++ b/docs/development/bridge-agent-readonly-development-20260521.md
@@ -1,0 +1,86 @@
+# Bridge Agent Readonly BA-M1 Development Notes
+
+Date: 2026-05-21
+
+## Purpose
+
+This slice starts BA-M1 after the BA-M0 customer decisions and BA-M0.5 driver
+smoke evidence were accepted by the maintainer.
+
+The goal is deliberately small: provide a standalone, localhost-only readonly
+Bridge Agent that can be run on the MetaSheet on-prem Windows server and proven
+against the customer's legacy SQL Server before any `plugin-integration-core`
+runtime integration begins.
+
+## Decision
+
+The first runtime is a PowerShell 5.1 script hosted on Windows .NET Framework
+`System.Data.SqlClient`.
+
+Reasons:
+
+- the customer-side BA-M0.5 evidence selected the Windows-native provider path;
+- Windows PowerShell 5.1 is already present on the target Windows bridge host;
+- no Visual Studio, MSBuild, .NET SDK, or service installer is required for the
+  first runtime contract;
+- the script can be reviewed as plain ops code and later wrapped as a Windows
+  service if BA-M1 succeeds.
+
+## Files
+
+- `scripts/ops/bridge-agent-readonly.ps1`
+- `scripts/ops/fixtures/bridge-agent-readonly/config.example.json`
+- `scripts/ops/bridge-agent-readonly-contract.test.mjs`
+- `docs/operations/bridge-agent-readonly-runbook-20260521.md`
+- `docs/development/bridge-agent-readonly-development-20260521.md`
+- `docs/development/bridge-agent-readonly-verification-20260521.md`
+
+## Runtime Contract
+
+The Bridge Agent exposes:
+
+- `GET /health`
+- `GET /objects`
+- `GET /schema/<object>`
+- `POST /query/<object>`
+
+The process binds only to `127.0.0.1` or `localhost`; non-localhost config is
+rejected at config resolution time. The default auth mode is
+`shared-secret-header` with the secret read from a local environment variable.
+
+## Data Safety
+
+The implementation does not accept raw SQL. `POST /query/<object>` builds
+`SELECT TOP <limit> [allowlisted fields] FROM [allowlisted source]` from the
+configuration only.
+
+The default config registers three read models:
+
+- `material` from `v_MetaSheet_MaterialRead`
+- `bom` from `v_MetaSheet_BomRead`
+- `bom_child` from `v_MetaSheet_BomChildRead`
+
+Those names intentionally prefer customer-created readonly views. If the
+customer cannot provide views, the maintainer must review any direct table
+source changes before live use.
+
+## Error Hygiene
+
+Errors returned by `/health` and the generic exception handler are passed through
+the shared redactor. The redactor covers connection-string fragments, bearer/JWT
+shapes, SQL login-failure messages, nested `InnerException` chains, and
+credential-looking `Exception.Data` keys.
+
+No connection string is printed or returned.
+
+## Out Of Scope
+
+- Windows Service packaging.
+- MetaSheet backend or `plugin-integration-core` integration.
+- Data Factory UI wiring.
+- SQL write operations.
+- K3 Save / Submit / Audit.
+- Relationship resolver and incremental cursor protocol.
+- Non-localhost network exposure.
+
+Those belong to BA-M2+ after this Bridge Agent can be proven on the bridge host.

--- a/docs/development/bridge-agent-readonly-verification-20260521.md
+++ b/docs/development/bridge-agent-readonly-verification-20260521.md
@@ -1,0 +1,84 @@
+# Bridge Agent Readonly BA-M1 Verification
+
+Date: 2026-05-21
+
+## Local Verification
+
+Commands run from repo root:
+
+```bash
+node --test scripts/ops/bridge-agent-readonly-contract.test.mjs
+git diff --check origin/main...HEAD
+```
+
+Secret-shape scan over the six changed files:
+
+```bash
+node <<'NODE'
+const fs = require('node:fs');
+const files = [
+  'scripts/ops/bridge-agent-readonly.ps1',
+  'scripts/ops/bridge-agent-readonly-contract.test.mjs',
+  'scripts/ops/fixtures/bridge-agent-readonly/config.example.json',
+  'docs/operations/bridge-agent-readonly-runbook-20260521.md',
+  'docs/development/bridge-agent-readonly-development-20260521.md',
+  'docs/development/bridge-agent-readonly-verification-20260521.md',
+];
+const patterns = [
+  new RegExp('Bearer ' + '[A-Za-z0-9]'),
+  new RegExp('ey' + 'J[A-Za-z0-9_-]{6,}\\.'),
+  new RegExp('postgres' + '://[^<\\s]+'),
+  new RegExp('METASHEET_BRIDGE_SQL_' + 'PASSWORD=.'),
+  new RegExp('Pass' + 'word=.*;'),
+];
+let hits = 0;
+for (const file of files) {
+  const text = fs.readFileSync(file, 'utf8');
+  for (const pattern of patterns) {
+    if (pattern.test(text)) {
+      console.error(`${file}: ${pattern}`);
+      hits++;
+    }
+  }
+}
+process.exit(hits === 0 ? 0 : 1);
+NODE
+```
+
+## Contract Matrix
+
+| Check | Evidence |
+| --- | --- |
+| Localhost-only binding | Contract test asserts `127.0.0.1` and non-localhost rejection marker. |
+| Windows-native provider | Contract test asserts `System.Data.SqlClient.SqlConnection`. |
+| No raw SQL endpoint | Contract test asserts `RAW_SQL_REJECTED` and no write SQL statement markers. |
+| Object allowlist | Config test asserts only `material`, `bom`, `bom_child`. |
+| Readonly query shape | Contract test asserts `SELECT TOP $Limit` plus quoted identifier helper. |
+| Secrets outside config | Config test asserts username/password/header secrets are environment-variable names only. |
+| Error redaction | Contract test asserts redaction helpers, nested exception traversal, and sensitive data markers. |
+
+## Windows Host Validation
+
+This was not executed on the macOS development host. The operator must run the
+commands in `docs/operations/bridge-agent-readonly-runbook-20260521.md` on the
+MetaSheet on-prem Windows bridge host after local SQL credentials are provided.
+
+Required live results:
+
+- `-ValidateConfigOnly` prints config validation passed.
+- `/health` returns `ok=true` and `databaseReachable=true`.
+- `/objects` returns only allowlisted objects.
+- `/schema/material`, `/schema/bom`, `/schema/bom_child` return safe schemas.
+- `/query/material` returns at most the requested capped rows.
+- unknown object, raw SQL, filters, and excessive limit requests fail.
+- no token, password, connection string, host, database name, or SQL username is
+  copied into issue comments, PRs, screenshots, or artifacts.
+
+## Local Result
+
+| Command | Result |
+| --- | --- |
+| `node --test scripts/ops/bridge-agent-readonly-contract.test.mjs` | PASS, 4/4 |
+| `git diff --check origin/main...HEAD` | PASS, rc=0 |
+| `command -v pwsh` | unavailable on the macOS dev host; Windows live validation is delegated to the runbook |
+| secret-shape scan | PASS, 0 hits |

--- a/docs/operations/bridge-agent-readonly-runbook-20260521.md
+++ b/docs/operations/bridge-agent-readonly-runbook-20260521.md
@@ -1,0 +1,206 @@
+# Readonly Bridge Agent Runbook - BA-M1 MVP
+
+Date: 2026-05-21
+
+## Purpose
+
+This runbook starts the BA-M1 standalone readonly Bridge Agent on the selected
+MetaSheet on-prem Windows server. The first implementation is intentionally a
+PowerShell 5.1 script hosted on .NET Framework `System.Data.SqlClient`, not a
+Windows service yet.
+
+The goal is to prove the Bridge Agent HTTP/JSON protocol and readonly SQL
+allowlist on the customer bridge host before integrating it into the MetaSheet
+backend or Data Factory UI.
+
+## Scope
+
+In scope:
+
+- same-machine deployment on the MetaSheet on-prem Windows server;
+- bind to `127.0.0.1`;
+- `System.Data.SqlClient`;
+- `GET /health`;
+- `GET /objects`;
+- `GET /schema/<object>`;
+- `POST /query/<object>`;
+- allowlisted `material`, `bom`, `bom_child` examples;
+- hard row limits;
+- redacted errors.
+
+Out of scope:
+
+- Windows Service packaging;
+- MetaSheet `plugin-integration-core` integration;
+- Data Factory UI wiring;
+- raw SQL endpoint;
+- SQL writes;
+- K3 Save / Submit / Audit;
+- non-localhost deployment.
+
+## Files
+
+- Agent script: `scripts/ops/bridge-agent-readonly.ps1`
+- Example config:
+  `scripts/ops/fixtures/bridge-agent-readonly/config.example.json`
+
+Real config must stay outside Git, for example:
+
+```text
+C:\ProgramData\MetaSheet\BridgeAgent\config.json
+```
+
+## Local Secret Setup
+
+Use environment variables owned by the local bridge process account. Do not put
+these values into Git, issue comments, PR bodies, screenshots, or evidence
+artifacts.
+
+```powershell
+$env:METASHEET_BRIDGE_SQL_USERNAME = '<readonly-sql-login>'
+$env:METASHEET_BRIDGE_SQL_PASSWORD = '<readonly-sql-password>'
+$env:METASHEET_BRIDGE_SHARED_SECRET = '<local-shared-secret>'
+```
+
+For a persistent operator setup, store them using the chosen Windows secret
+mechanism and inject them into the process environment before start. BA-M1 MVP
+does not prescribe the final service secret store.
+
+## Config Setup
+
+Copy the example config to the private host path:
+
+```powershell
+New-Item -ItemType Directory -Force 'C:\ProgramData\MetaSheet\BridgeAgent' | Out-Null
+Copy-Item `
+  'C:\metasheet\scripts\ops\fixtures\bridge-agent-readonly\config.example.json' `
+  'C:\ProgramData\MetaSheet\BridgeAgent\config.json'
+```
+
+Edit only local placeholders:
+
+- `database.server`
+- `database.database`
+- optional object `source` values if the customer provides readonly views
+  instead of direct tables.
+
+Preferred readonly views:
+
+```text
+v_MetaSheet_MaterialRead
+v_MetaSheet_BomRead
+v_MetaSheet_BomChildRead
+```
+
+## Validate Config
+
+```powershell
+powershell -ExecutionPolicy Bypass -File C:\metasheet\scripts\ops\bridge-agent-readonly.ps1 `
+  -ConfigPath C:\ProgramData\MetaSheet\BridgeAgent\config.json `
+  -ValidateConfigOnly
+```
+
+Expected:
+
+```text
+[bridge-agent-readonly] config validation passed
+```
+
+## Start Agent
+
+```powershell
+powershell -ExecutionPolicy Bypass -File C:\metasheet\scripts\ops\bridge-agent-readonly.ps1 `
+  -ConfigPath C:\ProgramData\MetaSheet\BridgeAgent\config.json
+```
+
+Expected:
+
+```text
+[bridge-agent-readonly] starting http://127.0.0.1:19091/
+```
+
+If `HttpListener` requires URL ACL setup in the customer Windows environment,
+run the equivalent command as Administrator:
+
+```powershell
+netsh http add urlacl url=http://127.0.0.1:19091/ user=<service-account>
+```
+
+## Smoke Commands
+
+All commands run on the MetaSheet on-prem server.
+
+```powershell
+$headers = @{ 'X-MetaSheet-Bridge-Secret' = $env:METASHEET_BRIDGE_SHARED_SECRET }
+
+Invoke-RestMethod `
+  -Headers $headers `
+  -Uri 'http://127.0.0.1:19091/health'
+
+Invoke-RestMethod `
+  -Headers $headers `
+  -Uri 'http://127.0.0.1:19091/objects'
+
+Invoke-RestMethod `
+  -Headers $headers `
+  -Uri 'http://127.0.0.1:19091/schema/material'
+
+Invoke-RestMethod `
+  -Headers $headers `
+  -Method Post `
+  -Uri 'http://127.0.0.1:19091/query/material' `
+  -ContentType 'application/json' `
+  -Body '{"limit":3}'
+```
+
+Expected:
+
+- `/health`: `ok=true`; `databaseReachable=true`.
+- `/objects`: only allowlisted objects appear.
+- `/schema/material`: only configured fields appear.
+- `/query/material`: at most 3 rows, selected only from configured fields.
+
+## Negative Checks
+
+Unknown object must fail:
+
+```powershell
+Invoke-RestMethod `
+  -Headers $headers `
+  -Uri 'http://127.0.0.1:19091/schema/not_allowlisted'
+```
+
+Raw SQL must fail:
+
+```powershell
+Invoke-RestMethod `
+  -Headers $headers `
+  -Method Post `
+  -Uri 'http://127.0.0.1:19091/query/material' `
+  -ContentType 'application/json' `
+  -Body '{"sql":"SELECT * FROM t_ICItem"}'
+```
+
+Excessive limit must fail:
+
+```powershell
+Invoke-RestMethod `
+  -Headers $headers `
+  -Method Post `
+  -Uri 'http://127.0.0.1:19091/query/material' `
+  -ContentType 'application/json' `
+  -Body '{"limit":9999}'
+```
+
+## Handoff Criteria
+
+BA-M1 MVP is ready for BA-M2 integration work only when:
+
+- config validation passes;
+- `/health` confirms database reachability;
+- `/objects` shows only allowlisted objects;
+- `/schema/material`, `/schema/bom`, `/schema/bom_child` return safe schemas;
+- `/query/*` returns capped rows for approved objects;
+- unknown objects, raw SQL, and excessive limits are blocked;
+- no secret-shaped values appear in logs or copied evidence;
+- no SQL writes occurred.

--- a/scripts/ops/bridge-agent-readonly-contract.test.mjs
+++ b/scripts/ops/bridge-agent-readonly-contract.test.mjs
@@ -1,0 +1,92 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+
+const scriptPath = new URL('./bridge-agent-readonly.ps1', import.meta.url);
+const configPath = new URL('./fixtures/bridge-agent-readonly/config.example.json', import.meta.url);
+
+async function readScript() {
+  return readFile(scriptPath, 'utf8');
+}
+
+async function readConfig() {
+  return JSON.parse(await readFile(configPath, 'utf8'));
+}
+
+test('readonly bridge exposes the BA-M1 HTTP contract only on localhost', async () => {
+  const script = await readScript();
+
+  for (const marker of [
+    'GET  /health',
+    'GET  /objects',
+    'GET  /schema/<object>',
+    'POST /query/<object>',
+    'BA-M1 MVP only supports localhost binding',
+    '127.0.0.1',
+    'System.Data.SqlClient.SqlConnection',
+  ]) {
+    assert.match(script, new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+
+  assert.doesNotMatch(script, /start\s+https?:\/\/0\.0\.0\.0/i);
+});
+
+test('readonly bridge rejects unsafe query surfaces by code', async () => {
+  const script = await readScript();
+
+  for (const marker of [
+    'UNKNOWN_OBJECT',
+    'INVALID_LIMIT',
+    'UNSUPPORTED_FILTERS',
+    'RAW_SQL_REJECTED',
+    'Raw SQL is not accepted by the readonly Bridge Agent.',
+    'SELECT TOP $Limit',
+    'ConvertTo-QuotedIdentifier',
+    'database.connectTimeoutSec must be between 1 and 120',
+    'database.queryTimeoutSec must be between 1 and 300',
+  ]) {
+    assert.match(script, new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+
+  assert.doesNotMatch(script, /\b(INSERT|UPDATE|DELETE|MERGE|DROP|ALTER|CREATE)\s+/i);
+});
+
+test('example config is localhost-only, credential-by-env, and object-allowlisted', async () => {
+  const config = await readConfig();
+
+  assert.equal(config.listen.host, '127.0.0.1');
+  assert.equal(config.listen.port, 19091);
+  assert.equal(config.auth.mode, 'shared-secret-header');
+  assert.equal(config.auth.headerName, 'X-MetaSheet-Bridge-Secret');
+  assert.equal(config.auth.sharedSecretEnvVar, 'METASHEET_BRIDGE_SHARED_SECRET');
+  assert.equal(config.database.usernameEnvVar, 'METASHEET_BRIDGE_SQL_USERNAME');
+  assert.equal(config.database.passwordEnvVar, 'METASHEET_BRIDGE_SQL_PASSWORD');
+  assert.equal(config.limits.sampleLimit, 3);
+  assert.equal(config.limits.maxLimit, 20);
+
+  assert.deepEqual(Object.keys(config.objects).sort(), ['bom', 'bom_child', 'material']);
+  assert.equal(config.objects.material.source, 'v_MetaSheet_MaterialRead');
+  assert.equal(config.objects.bom.source, 'v_MetaSheet_BomRead');
+  assert.equal(config.objects.bom_child.source, 'v_MetaSheet_BomChildRead');
+
+  const serialized = JSON.stringify(config);
+  assert.doesNotMatch(serialized, /password["']?\s*:\s*["'](?!<configured)/i);
+  const connectionStringPattern = new RegExp('Server=.*' + 'Pass' + 'word=', 'i');
+  assert.doesNotMatch(serialized, connectionStringPattern);
+});
+
+test('script redacts common credential-bearing error surfaces', async () => {
+  const script = await readScript();
+
+  for (const marker of [
+    'ConvertTo-RedactedText',
+    'ConvertTo-BridgeError',
+    'InnerException',
+    'data[$keyText]=<redacted>',
+    'Login failed for user',
+    'Bearer\\s+',
+    'eyJ[A-Za-z0-9_-]',
+  ]) {
+    assert.match(script, new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+});

--- a/scripts/ops/bridge-agent-readonly.ps1
+++ b/scripts/ops/bridge-agent-readonly.ps1
@@ -1,0 +1,605 @@
+#requires -Version 5.0
+<#
+.SYNOPSIS
+  MetaSheet legacy SQL readonly Bridge Agent (BA-M1 MVP).
+
+.DESCRIPTION
+  Standalone localhost-only HTTP/JSON bridge for legacy SQL Server sources.
+  The agent uses .NET Framework System.Data.SqlClient from Windows PowerShell
+  5.1, keeps credentials in local environment variables, exposes only
+  allowlisted objects/fields, and never accepts raw SQL.
+
+  Endpoints:
+    GET  /health
+    GET  /objects
+    GET  /schema/<object>
+    POST /query/<object>
+
+  This script intentionally does not integrate with plugin-integration-core.
+  MetaSheet product integration is a later BA-M2 step after this runtime
+  contract is reviewed on the bridge host.
+#>
+
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$ConfigPath,
+
+  [switch]$ValidateConfigOnly
+)
+
+$ErrorActionPreference = 'Stop'
+
+Add-Type -AssemblyName System.Web.Extensions
+Add-Type -AssemblyName System.Data
+
+function ConvertTo-RedactedText {
+  param(
+    [string]$Value,
+    [string]$Username = ''
+  )
+
+  if ([string]::IsNullOrEmpty($Value)) { return $Value }
+
+  $redactedLogin = '<redacted-login>'
+  $patterns = @(
+    '(?i)(Password|Pwd)\s*=\s*[^;""'']+',
+    '(?i)(User\s*ID|UID|User)\s*=\s*[^;""'']+',
+    '(?i)(Data Source|Server|Address|Network Address)\s*=\s*[^;""'']+',
+    '(?i)(Initial Catalog|Database)\s*=\s*[^;""'']+',
+    '(?i)(Secret|Token|Authorization)\s*[:=]\s*[^;""''\s]+',
+    '(?i)Bearer\s+[A-Za-z0-9._~+/=-]{8,}',
+    'eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+'
+  )
+
+  $redacted = $Value
+  foreach ($pattern in $patterns) {
+    $redacted = [System.Text.RegularExpressions.Regex]::Replace($redacted, $pattern, '<redacted>')
+  }
+
+  $quotePattern = "[`"']"
+  $redacted = [System.Text.RegularExpressions.Regex]::Replace(
+    $redacted,
+    "(?i)(Login failed for user\s+$quotePattern)([^`"']+)($quotePattern)",
+    '${1}' + $redactedLogin + '${3}'
+  )
+  $redacted = [System.Text.RegularExpressions.Regex]::Replace(
+    $redacted,
+    "((?:用户|使用者|登入名|登录名)\s*$quotePattern)([^`"']+)($quotePattern\s*(?:登录失败|登入失敗|login failed))",
+    '${1}' + $redactedLogin + '${3}'
+  )
+
+  if (-not [string]::IsNullOrEmpty($Username)) {
+    $escapedUsername = [System.Text.RegularExpressions.Regex]::Escape($Username)
+    $redacted = [System.Text.RegularExpressions.Regex]::Replace(
+      $redacted,
+      "($quotePattern)$escapedUsername($quotePattern)",
+      '${1}' + $redactedLogin + '${2}',
+      [System.Text.RegularExpressions.RegexOptions]::IgnoreCase
+    )
+  }
+
+  return $redacted
+}
+
+function ConvertTo-BridgeError {
+  param(
+    [System.Exception]$Exception,
+    [string]$Username = ''
+  )
+
+  $messages = New-Object System.Collections.Generic.List[string]
+  $current = $Exception
+  $depth = 0
+  while ($null -ne $current -and $depth -lt 8) {
+    if (-not [string]::IsNullOrWhiteSpace($current.Message)) {
+      $messages.Add($current.Message)
+    }
+    if ($null -ne $current.Data -and $current.Data.Count -gt 0) {
+      foreach ($key in $current.Data.Keys) {
+        $keyText = [string]$key
+        $valueText = [string]$current.Data[$key]
+        if ($keyText -match '(?i)password|pwd|secret|token|user|uid|server|database|catalog|connection|string|host') {
+          $messages.Add("data[$keyText]=<redacted>")
+        } else {
+          $messages.Add("data[$keyText]=" + (ConvertTo-RedactedText -Value $valueText -Username $Username))
+        }
+      }
+    }
+    $current = $current.InnerException
+    $depth++
+  }
+
+  return [ordered]@{
+    code    = 'BRIDGE_AGENT_ERROR'
+    message = ConvertTo-RedactedText -Value (($messages -join "`n").Trim()) -Username $Username
+  }
+}
+
+function Read-JsonFile {
+  param([string]$Path)
+  if (-not (Test-Path -LiteralPath $Path -PathType Leaf)) {
+    throw "Config file not found: $Path"
+  }
+  return Get-Content -LiteralPath $Path -Raw | ConvertFrom-Json
+}
+
+function Assert-Name {
+  param(
+    [string]$Name,
+    [string]$Label
+  )
+  if ([string]::IsNullOrWhiteSpace($Name)) {
+    throw "$Label is required"
+  }
+  if ($Name -notmatch '^[A-Za-z_][A-Za-z0-9_]*$') {
+    throw "$Label contains unsupported characters: $Name"
+  }
+}
+
+function ConvertTo-QuotedIdentifier {
+  param([string]$Name)
+  Assert-Name -Name $Name -Label 'SQL identifier'
+  return '[' + ($Name -replace ']', ']]') + ']'
+}
+
+function ConvertTo-QuotedSource {
+  param([string]$Source)
+  if ([string]::IsNullOrWhiteSpace($Source)) {
+    throw 'Object source is required'
+  }
+  $parts = $Source.Split('.')
+  if ($parts.Count -gt 2) {
+    throw "Object source must be a table/view name or schema-qualified table/view: $Source"
+  }
+  $quoted = @()
+  foreach ($part in $parts) {
+    $quoted += ConvertTo-QuotedIdentifier -Name $part
+  }
+  return ($quoted -join '.')
+}
+
+function ConvertTo-Boolean {
+  param(
+    $Value,
+    [bool]$DefaultValue = $false
+  )
+  if ($null -eq $Value) { return $DefaultValue }
+  if ($Value -is [bool]) { return [bool]$Value }
+  $text = ([string]$Value).Trim().ToLowerInvariant()
+  switch ($text) {
+    'true' { return $true }
+    '1' { return $true }
+    'yes' { return $true }
+    'false' { return $false }
+    '0' { return $false }
+    'no' { return $false }
+    default { throw "Invalid boolean value: $Value" }
+  }
+}
+
+function Get-ObjectProperties {
+  param($Object)
+  if ($null -eq $Object) { return @() }
+  return @($Object.PSObject.Properties)
+}
+
+function Get-ConfigValue {
+  param(
+    $Object,
+    [string]$Name,
+    $DefaultValue = $null
+  )
+  if ($null -eq $Object) { return $DefaultValue }
+  $property = $Object.PSObject.Properties[$Name]
+  if ($null -eq $property) { return $DefaultValue }
+  if ($null -eq $property.Value) { return $DefaultValue }
+  return $property.Value
+}
+
+function Resolve-BridgeConfig {
+  param($Raw)
+
+  $hostName = [string](Get-ConfigValue -Object $Raw.listen -Name 'host' -DefaultValue '127.0.0.1')
+  $port = [int](Get-ConfigValue -Object $Raw.listen -Name 'port' -DefaultValue 19091)
+  if ($hostName -notin @('127.0.0.1', 'localhost')) {
+    throw 'BA-M1 MVP only supports localhost binding. Use 127.0.0.1 or localhost.'
+  }
+  if ($port -lt 1 -or $port -gt 65535) {
+    throw "Invalid listen port: $port"
+  }
+
+  $database = $Raw.database
+  if ($null -eq $database) { throw 'database config is required' }
+  $server = [string](Get-ConfigValue -Object $database -Name 'server' -DefaultValue '')
+  $dbName = [string](Get-ConfigValue -Object $database -Name 'database' -DefaultValue '')
+  if ([string]::IsNullOrWhiteSpace($server)) { throw 'database.server is required' }
+  if ([string]::IsNullOrWhiteSpace($dbName)) { throw 'database.database is required' }
+
+  $integratedSecurity = ConvertTo-Boolean -Value (Get-ConfigValue -Object $database -Name 'integratedSecurity' -DefaultValue $false)
+  $usernameEnvVar = [string](Get-ConfigValue -Object $database -Name 'usernameEnvVar' -DefaultValue '')
+  $passwordEnvVar = [string](Get-ConfigValue -Object $database -Name 'passwordEnvVar' -DefaultValue '')
+  if (-not $integratedSecurity) {
+    if ([string]::IsNullOrWhiteSpace($usernameEnvVar)) { throw 'database.usernameEnvVar is required when integratedSecurity=false' }
+    if ([string]::IsNullOrWhiteSpace($passwordEnvVar)) { throw 'database.passwordEnvVar is required when integratedSecurity=false' }
+  }
+  $connectTimeoutSec = [int](Get-ConfigValue -Object $database -Name 'connectTimeoutSec' -DefaultValue 8)
+  $queryTimeoutSec = [int](Get-ConfigValue -Object $database -Name 'queryTimeoutSec' -DefaultValue 15)
+  if ($connectTimeoutSec -lt 1 -or $connectTimeoutSec -gt 120) {
+    throw 'database.connectTimeoutSec must be between 1 and 120'
+  }
+  if ($queryTimeoutSec -lt 1 -or $queryTimeoutSec -gt 300) {
+    throw 'database.queryTimeoutSec must be between 1 and 300'
+  }
+
+  $defaultLimit = [int](Get-ConfigValue -Object $Raw.limits -Name 'sampleLimit' -DefaultValue 3)
+  $maxLimit = [int](Get-ConfigValue -Object $Raw.limits -Name 'maxLimit' -DefaultValue 20)
+  if ($defaultLimit -lt 1) { throw 'limits.sampleLimit must be >= 1' }
+  if ($maxLimit -lt $defaultLimit) { throw 'limits.maxLimit must be >= limits.sampleLimit' }
+  if ($maxLimit -gt 500) { throw 'limits.maxLimit must be <= 500 for BA-M1 MVP' }
+
+  $objects = @{}
+  foreach ($entry in Get-ObjectProperties -Object $Raw.objects) {
+    $objectId = [string]$entry.Name
+    Assert-Name -Name $objectId -Label 'object id'
+    $objectConfig = $entry.Value
+    $source = [string](Get-ConfigValue -Object $objectConfig -Name 'source' -DefaultValue '')
+    [void](ConvertTo-QuotedSource -Source $source)
+
+    $fieldConfigs = @()
+    $fields = Get-ConfigValue -Object $objectConfig -Name 'fields' -DefaultValue $null
+    if ($null -ne $fields) {
+      foreach ($field in @($fields)) {
+        $name = [string](Get-ConfigValue -Object $field -Name 'name' -DefaultValue '')
+        Assert-Name -Name $name -Label "field name for $objectId"
+        $fieldConfigs += [ordered]@{
+          name     = $name
+          type     = [string](Get-ConfigValue -Object $field -Name 'type' -DefaultValue 'string')
+          required = ConvertTo-Boolean -Value (Get-ConfigValue -Object $field -Name 'required' -DefaultValue $false)
+        }
+      }
+    } else {
+      $columns = @(Get-ConfigValue -Object $objectConfig -Name 'columns' -DefaultValue @())
+      foreach ($column in $columns) {
+        $name = [string]$column
+        Assert-Name -Name $name -Label "column name for $objectId"
+        $fieldConfigs += [ordered]@{ name = $name; type = 'string'; required = $false }
+      }
+    }
+
+    if ($fieldConfigs.Count -eq 0) {
+      throw "object $objectId must define fields or columns"
+    }
+
+    $objects[$objectId] = [ordered]@{
+      id       = $objectId
+      label    = [string](Get-ConfigValue -Object $objectConfig -Name 'label' -DefaultValue $objectId)
+      source   = $source
+      keyField = [string](Get-ConfigValue -Object $objectConfig -Name 'keyField' -DefaultValue '')
+      fields   = $fieldConfigs
+    }
+  }
+  if ($objects.Count -eq 0) { throw 'objects allowlist cannot be empty' }
+
+  $authMode = [string](Get-ConfigValue -Object $Raw.auth -Name 'mode' -DefaultValue 'shared-secret-header')
+  $authHeaderName = [string](Get-ConfigValue -Object $Raw.auth -Name 'headerName' -DefaultValue 'X-MetaSheet-Bridge-Secret')
+  $authSecretEnvVar = [string](Get-ConfigValue -Object $Raw.auth -Name 'sharedSecretEnvVar' -DefaultValue '')
+  if ($authMode -notin @('shared-secret-header', 'none')) {
+    throw "Unsupported auth.mode: $authMode"
+  }
+  if ($authMode -eq 'shared-secret-header' -and [string]::IsNullOrWhiteSpace($authHeaderName)) {
+    throw 'auth.headerName is required for shared-secret-header mode'
+  }
+  if ($authMode -eq 'shared-secret-header' -and [string]::IsNullOrWhiteSpace($authSecretEnvVar)) {
+    throw 'auth.sharedSecretEnvVar is required for shared-secret-header mode'
+  }
+
+  return [ordered]@{
+    listen = [ordered]@{ host = $hostName; port = $port }
+    auth = [ordered]@{
+      mode = $authMode
+      headerName = $authHeaderName
+      sharedSecretEnvVar = $authSecretEnvVar
+    }
+    database = [ordered]@{
+      server = $server
+      database = $dbName
+      integratedSecurity = $integratedSecurity
+      usernameEnvVar = $usernameEnvVar
+      passwordEnvVar = $passwordEnvVar
+      connectTimeoutSec = $connectTimeoutSec
+      queryTimeoutSec = $queryTimeoutSec
+      encrypt = ConvertTo-Boolean -Value (Get-ConfigValue -Object $database -Name 'encrypt' -DefaultValue $false)
+      trustServerCertificate = ConvertTo-Boolean -Value (Get-ConfigValue -Object $database -Name 'trustServerCertificate' -DefaultValue $true)
+    }
+    limits = [ordered]@{ sampleLimit = $defaultLimit; maxLimit = $maxLimit }
+    objects = $objects
+  }
+}
+
+function Get-DatabaseUsername {
+  param($Config)
+  if ($Config.database.integratedSecurity) { return '' }
+  $username = [System.Environment]::GetEnvironmentVariable($Config.database.usernameEnvVar)
+  if ([string]::IsNullOrWhiteSpace($username)) {
+    throw "Environment variable '$($Config.database.usernameEnvVar)' is not set or is empty."
+  }
+  return $username
+}
+
+function New-SqlConnectionString {
+  param($Config)
+
+  $builder = New-Object System.Data.SqlClient.SqlConnectionStringBuilder
+  $builder['Data Source'] = $Config.database.server
+  $builder['Initial Catalog'] = $Config.database.database
+  $builder['Connect Timeout'] = $Config.database.connectTimeoutSec
+  $builder['Application Name'] = 'MetaSheetLegacySqlReadonlyBridge'
+  $builder['Encrypt'] = [bool]$Config.database.encrypt
+  $builder['TrustServerCertificate'] = [bool]$Config.database.trustServerCertificate
+
+  if ($Config.database.integratedSecurity) {
+    $builder['Integrated Security'] = $true
+  } else {
+    $username = Get-DatabaseUsername -Config $Config
+    $password = [System.Environment]::GetEnvironmentVariable($Config.database.passwordEnvVar)
+    if ([string]::IsNullOrEmpty($password)) {
+      throw "Environment variable '$($Config.database.passwordEnvVar)' is not set or is empty."
+    }
+    $builder['User ID'] = $username
+    $builder['Password'] = $password
+  }
+
+  return $builder.ConnectionString
+}
+
+function Invoke-BridgeSqlQuery {
+  param(
+    $Config,
+    [string]$Sql
+  )
+
+  $rows = New-Object System.Collections.Generic.List[object]
+  $connectionString = New-SqlConnectionString -Config $Config
+  $connection = New-Object System.Data.SqlClient.SqlConnection($connectionString)
+  try {
+    $connection.Open()
+    $command = $connection.CreateCommand()
+    $command.CommandText = $Sql
+    $command.CommandType = [System.Data.CommandType]::Text
+    $command.CommandTimeout = $Config.database.queryTimeoutSec
+    $reader = $command.ExecuteReader()
+    try {
+      while ($reader.Read()) {
+        $row = [ordered]@{}
+        for ($i = 0; $i -lt $reader.FieldCount; $i++) {
+          $name = $reader.GetName($i)
+          $value = $reader.GetValue($i)
+          if ($value -is [System.DBNull]) { $value = $null }
+          $row[$name] = $value
+        }
+        $rows.Add($row)
+      }
+    } finally {
+      $reader.Close()
+    }
+  } finally {
+    $connection.Close()
+    $connection.Dispose()
+  }
+  return $rows
+}
+
+function Test-BridgeConnection {
+  param($Config)
+  [void](Invoke-BridgeSqlQuery -Config $Config -Sql 'SELECT 1 AS ok')
+  return $true
+}
+
+function New-ObjectQuerySql {
+  param(
+    $ObjectConfig,
+    [int]$Limit
+  )
+  $fieldNames = @($ObjectConfig.fields | ForEach-Object { $_.name })
+  $columns = ($fieldNames | ForEach-Object { ConvertTo-QuotedIdentifier -Name $_ }) -join ', '
+  $source = ConvertTo-QuotedSource -Source $ObjectConfig.source
+  return "SELECT TOP $Limit $columns FROM $source"
+}
+
+function ConvertTo-JsonResponse {
+  param($Value)
+  return ($Value | ConvertTo-Json -Depth 20 -Compress)
+}
+
+function Send-Json {
+  param(
+    [System.Net.HttpListenerContext]$Context,
+    [int]$StatusCode,
+    $Body
+  )
+  $json = ConvertTo-JsonResponse -Value $Body
+  $bytes = [System.Text.Encoding]::UTF8.GetBytes($json)
+  $Context.Response.StatusCode = $StatusCode
+  $Context.Response.ContentType = 'application/json; charset=utf-8'
+  $Context.Response.ContentLength64 = $bytes.Length
+  $Context.Response.OutputStream.Write($bytes, 0, $bytes.Length)
+  $Context.Response.OutputStream.Close()
+}
+
+function Read-RequestJson {
+  param([System.Net.HttpListenerRequest]$Request)
+  if ($Request.HasEntityBody -ne $true) { return $null }
+  $reader = New-Object System.IO.StreamReader($Request.InputStream, $Request.ContentEncoding)
+  try {
+    $text = $reader.ReadToEnd()
+    if ([string]::IsNullOrWhiteSpace($text)) { return $null }
+    return $text | ConvertFrom-Json
+  } finally {
+    $reader.Close()
+  }
+}
+
+function Assert-Authorized {
+  param(
+    [System.Net.HttpListenerRequest]$Request,
+    $Config
+  )
+  if ($Config.auth.mode -eq 'none') { return }
+  if ($Config.auth.mode -ne 'shared-secret-header') {
+    throw "Unsupported auth.mode: $($Config.auth.mode)"
+  }
+  $secretName = $Config.auth.sharedSecretEnvVar
+  if ([string]::IsNullOrWhiteSpace($secretName)) {
+    throw 'auth.sharedSecretEnvVar is required for shared-secret-header mode'
+  }
+  $expected = [System.Environment]::GetEnvironmentVariable($secretName)
+  if ([string]::IsNullOrEmpty($expected)) {
+    throw "Environment variable '$secretName' is not set or is empty."
+  }
+  $actual = $Request.Headers[$Config.auth.headerName]
+  if ([string]::IsNullOrEmpty($actual) -or $actual -ne $expected) {
+    $authError = New-Object System.UnauthorizedAccessException('Bridge Agent authentication failed.')
+    throw $authError
+  }
+}
+
+function Invoke-BridgeRequest {
+  param(
+    [System.Net.HttpListenerContext]$Context,
+    $Config
+  )
+
+  $request = $Context.Request
+  $method = $request.HttpMethod.ToUpperInvariant()
+  $path = $request.Url.AbsolutePath.Trim('/')
+  $parts = @($path.Split('/') | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+
+  Assert-Authorized -Request $request -Config $Config
+
+  if ($method -eq 'GET' -and $parts.Count -eq 1 -and $parts[0] -eq 'health') {
+    $databaseReachable = $false
+    $databaseError = $null
+    try {
+      $databaseReachable = Test-BridgeConnection -Config $Config
+    } catch {
+      $databaseError = ConvertTo-BridgeError -Exception $_.Exception -Username (Get-DatabaseUsername -Config $Config)
+    }
+    return [ordered]@{
+      status = 200
+      body = [ordered]@{
+        ok = $true
+        service = 'metasheet-legacy-sql-readonly-bridge'
+        version = '0.1.0'
+        bindHost = $Config.listen.host
+        databaseReachable = $databaseReachable
+        databaseError = $databaseError
+      }
+    }
+  }
+
+  if ($method -eq 'GET' -and $parts.Count -eq 1 -and $parts[0] -eq 'objects') {
+    $objects = @()
+    foreach ($key in ($Config.objects.Keys | Sort-Object)) {
+      $objectConfig = $Config.objects[$key]
+      $objects += [ordered]@{
+        id = $objectConfig.id
+        label = $objectConfig.label
+        readonly = $true
+        fieldCount = @($objectConfig.fields).Count
+      }
+    }
+    return [ordered]@{ status = 200; body = [ordered]@{ objects = $objects } }
+  }
+
+  if ($method -eq 'GET' -and $parts.Count -eq 2 -and $parts[0] -eq 'schema') {
+    $objectId = $parts[1]
+    if (-not $Config.objects.Contains($objectId)) {
+      return [ordered]@{ status = 404; body = [ordered]@{ error = [ordered]@{ code = 'UNKNOWN_OBJECT'; message = 'Object is not allowlisted.' } } }
+    }
+    $objectConfig = $Config.objects[$objectId]
+    return [ordered]@{
+      status = 200
+      body = [ordered]@{
+        object = $objectId
+        fields = @($objectConfig.fields)
+      }
+    }
+  }
+
+  if ($method -eq 'POST' -and $parts.Count -eq 2 -and $parts[0] -eq 'query') {
+    $objectId = $parts[1]
+    if (-not $Config.objects.Contains($objectId)) {
+      return [ordered]@{ status = 404; body = [ordered]@{ error = [ordered]@{ code = 'UNKNOWN_OBJECT'; message = 'Object is not allowlisted.' } } }
+    }
+    $body = Read-RequestJson -Request $request
+    $limit = $Config.limits.sampleLimit
+    if ($null -ne $body -and $null -ne $body.PSObject.Properties['limit']) {
+      $limit = [int]$body.limit
+    }
+    if ($limit -lt 1 -or $limit -gt $Config.limits.maxLimit) {
+      return [ordered]@{ status = 400; body = [ordered]@{ error = [ordered]@{ code = 'INVALID_LIMIT'; message = "limit must be between 1 and $($Config.limits.maxLimit)." } } }
+    }
+    if ($null -ne $body -and $null -ne $body.PSObject.Properties['filters'] -and $null -ne $body.filters) {
+      $filterProps = @($body.filters.PSObject.Properties)
+      if ($filterProps.Count -gt 0) {
+        return [ordered]@{ status = 400; body = [ordered]@{ error = [ordered]@{ code = 'UNSUPPORTED_FILTERS'; message = 'BA-M1 MVP does not accept filters yet.' } } }
+      }
+    }
+    if ($null -ne $body -and $null -ne $body.PSObject.Properties['sql']) {
+      return [ordered]@{ status = 400; body = [ordered]@{ error = [ordered]@{ code = 'RAW_SQL_REJECTED'; message = 'Raw SQL is not accepted by the readonly Bridge Agent.' } } }
+    }
+
+    $objectConfig = $Config.objects[$objectId]
+    $sql = New-ObjectQuerySql -ObjectConfig $objectConfig -Limit $limit
+    $rows = Invoke-BridgeSqlQuery -Config $Config -Sql $sql
+    return [ordered]@{
+      status = 200
+      body = [ordered]@{
+        object = $objectId
+        records = @($rows)
+        limit = $limit
+        nextCursor = $null
+        done = $true
+      }
+    }
+  }
+
+  return [ordered]@{ status = 404; body = [ordered]@{ error = [ordered]@{ code = 'NOT_FOUND'; message = 'Endpoint not found.' } } }
+}
+
+$rawConfig = Read-JsonFile -Path $ConfigPath
+$config = Resolve-BridgeConfig -Raw $rawConfig
+
+if ($ValidateConfigOnly) {
+  Write-Host '[bridge-agent-readonly] config validation passed'
+  exit 0
+}
+
+$prefix = "http://$($config.listen.host):$($config.listen.port)/"
+$listener = New-Object System.Net.HttpListener
+$listener.Prefixes.Add($prefix)
+
+Write-Host "[bridge-agent-readonly] starting $prefix"
+Write-Host '[bridge-agent-readonly] endpoints: GET /health, GET /objects, GET /schema/<object>, POST /query/<object>'
+
+$listener.Start()
+try {
+  while ($listener.IsListening) {
+    $context = $listener.GetContext()
+    try {
+      $result = Invoke-BridgeRequest -Context $context -Config $config
+      Send-Json -Context $context -StatusCode $result.status -Body $result.body
+    } catch [System.UnauthorizedAccessException] {
+      Send-Json -Context $context -StatusCode 401 -Body ([ordered]@{ error = [ordered]@{ code = 'UNAUTHORIZED'; message = 'Bridge Agent authentication failed.' } })
+    } catch {
+      $usernameForRedaction = ''
+      try { $usernameForRedaction = Get-DatabaseUsername -Config $config } catch {}
+      $errorBody = ConvertTo-BridgeError -Exception $_.Exception -Username $usernameForRedaction
+      Send-Json -Context $context -StatusCode 500 -Body ([ordered]@{ error = $errorBody })
+    }
+  }
+} finally {
+  $listener.Stop()
+  $listener.Close()
+}

--- a/scripts/ops/fixtures/bridge-agent-readonly/config.example.json
+++ b/scripts/ops/fixtures/bridge-agent-readonly/config.example.json
@@ -1,0 +1,59 @@
+{
+  "listen": {
+    "host": "127.0.0.1",
+    "port": 19091
+  },
+  "auth": {
+    "mode": "shared-secret-header",
+    "headerName": "X-MetaSheet-Bridge-Secret",
+    "sharedSecretEnvVar": "METASHEET_BRIDGE_SHARED_SECRET"
+  },
+  "database": {
+    "server": "<configured-on-bridge-host>",
+    "database": "<configured-on-bridge-host>",
+    "integratedSecurity": false,
+    "usernameEnvVar": "METASHEET_BRIDGE_SQL_USERNAME",
+    "passwordEnvVar": "METASHEET_BRIDGE_SQL_PASSWORD",
+    "connectTimeoutSec": 8,
+    "queryTimeoutSec": 15,
+    "encrypt": false,
+    "trustServerCertificate": true
+  },
+  "limits": {
+    "sampleLimit": 3,
+    "maxLimit": 20
+  },
+  "objects": {
+    "material": {
+      "label": "Material",
+      "source": "v_MetaSheet_MaterialRead",
+      "keyField": "FNumber",
+      "fields": [
+        { "name": "FItemID", "type": "number", "required": false },
+        { "name": "FNumber", "type": "string", "required": true },
+        { "name": "FName", "type": "string", "required": true },
+        { "name": "FModel", "type": "string", "required": false }
+      ]
+    },
+    "bom": {
+      "label": "BOM Header",
+      "source": "v_MetaSheet_BomRead",
+      "keyField": "FBOMInterID",
+      "fields": [
+        { "name": "FBOMInterID", "type": "number", "required": true },
+        { "name": "FBOMNumber", "type": "string", "required": false },
+        { "name": "FItemID", "type": "number", "required": true }
+      ]
+    },
+    "bom_child": {
+      "label": "BOM Child",
+      "source": "v_MetaSheet_BomChildRead",
+      "keyField": "FBOMInterID",
+      "fields": [
+        { "name": "FBOMInterID", "type": "number", "required": true },
+        { "name": "FItemID", "type": "number", "required": true },
+        { "name": "FQty", "type": "number", "required": true }
+      ]
+    }
+  }
+}


### PR DESCRIPTION
## Summary

Adds the BA-M1 standalone readonly Bridge Agent skeleton for the legacy SQL bridge path. This is intentionally outside plugin-integration-core: a Windows PowerShell 5.1 / .NET Framework System.Data.SqlClient localhost-only HTTP bridge with an allowlisted readonly object config.

## Scope

- `scripts/ops/bridge-agent-readonly.ps1`: localhost-only readonly Bridge Agent.
- `scripts/ops/fixtures/bridge-agent-readonly/config.example.json`: no secrets, env-var credentials, read-view defaults.
- `scripts/ops/bridge-agent-readonly-contract.test.mjs`: static contract tests.
- `docs/operations/bridge-agent-readonly-runbook-20260521.md`: Windows bridge-host runbook.
- `docs/development/bridge-agent-readonly-development-20260521.md` and verification MD.

## Guardrails

- Does not touch plugin-integration-core.
- Does not add DB migrations, frontend routes, or API runtime.
- Does not do K3 Save / Submit / Audit.
- Does not accept raw SQL.
- Binds only to localhost and uses local env vars for credentials/secrets.

## Verification

- `node --test scripts/ops/bridge-agent-readonly-contract.test.mjs` -> PASS, 4/4.
- `git diff --check origin/main...HEAD` -> PASS.
- Secret-shape scan over changed files -> PASS, 0 hits.
- `pwsh` is unavailable on the macOS dev host, so Windows live validation is delegated to the runbook.

## Follow-up

After review/merge, operator should run the runbook on the MetaSheet on-prem Windows bridge host. BA-M2 integration should wait until `/health`, `/objects`, `/schema/*`, `/query/*`, and negative checks pass against the approved customer SQL readonly views.