### PR TITLE
feat(attendance): preview scheduling assignment conflicts

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -4457,6 +4457,23 @@
                   {{ rotationAssignmentLoading ? tr('Loading...', '加载中...') : tr('Reload rotations', '重载轮班分配') }}
                 </button>
               </div>
+              <div
+                v-if="scheduleConflictDiagnostics.length"
+                class="attendance__schedule-conflict-diagnostics"
+                data-attendance-schedule-conflict-diagnostics
+                role="alert"
+              >
+                <strong>{{ tr('Schedule conflict checks', '排班冲突检查') }}</strong>
+                <ul>
+                  <li
+                    v-for="diagnostic in scheduleConflictDiagnostics"
+                    :key="`rotation-${diagnostic.key}`"
+                    :data-schedule-conflict-diagnostic="diagnostic.code"
+                  >
+                    {{ formatScheduleConflictDiagnostic(diagnostic) }}
+                  </li>
+                </ul>
+              </div>
               <div class="attendance__admin-grid">
                 <label class="attendance__field" for="attendance-rotation-user">
                   <span>{{ tr('User ID', '用户 ID') }}</span>
@@ -4700,6 +4717,23 @@
                   {{ assignmentLoading ? tr('Loading...', '加载中...') : tr('Reload assignments', '重载分配') }}
                 </button>
               </div>
+              <div
+                v-if="scheduleConflictDiagnostics.length"
+                class="attendance__schedule-conflict-diagnostics"
+                data-attendance-schedule-conflict-diagnostics
+                role="alert"
+              >
+                <strong>{{ tr('Schedule conflict checks', '排班冲突检查') }}</strong>
+                <ul>
+                  <li
+                    v-for="diagnostic in scheduleConflictDiagnostics"
+                    :key="`assignment-${diagnostic.key}`"
+                    :data-schedule-conflict-diagnostic="diagnostic.code"
+                  >
+                    {{ formatScheduleConflictDiagnostic(diagnostic) }}
+                  </li>
+                </ul>
+              </div>
               <div class="attendance__admin-grid">
                 <label class="attendance__field" for="attendance-assignment-user-id">
                   <span>{{ tr('User ID', '用户 ID') }}</span>
@@ -4875,6 +4909,11 @@ import {
   buildCalendarChipTooltip,
   calendarChipSourceClassName,
 } from '../services/attendance/calendarChipDisplay'
+import {
+  buildAttendanceScheduleConflictDiagnostics,
+  formatAttendanceScheduleConflictDiagnostic,
+  type AttendanceScheduleConflictDiagnostic,
+} from './attendance/attendanceScheduleConflictDiagnostics'
 import { usePlugins } from '../composables/usePlugins'
 import { apiFetch } from '../utils/api'
 import { readErrorMessage } from '../utils/error'
@@ -7772,6 +7811,33 @@ const rotationAssignmentForm = reactive({
   endDate: '',
   isActive: true,
 })
+
+const scheduleConflictDiagnostics = computed(() => buildAttendanceScheduleConflictDiagnostics({
+  assignments: assignments.value,
+  rotationAssignments: rotationAssignments.value,
+  assignmentDraft: {
+    id: assignmentEditingId.value,
+    userId: assignmentForm.userId,
+    refId: assignmentForm.shiftId,
+    refLabel: shifts.value.find(shift => shift.id === assignmentForm.shiftId)?.name || assignmentForm.shiftId,
+    startDate: assignmentForm.startDate,
+    endDate: assignmentForm.endDate || null,
+    isActive: assignmentForm.isActive,
+  },
+  rotationAssignmentDraft: {
+    id: rotationAssignmentEditingId.value,
+    userId: rotationAssignmentForm.userId,
+    refId: rotationAssignmentForm.rotationRuleId,
+    refLabel: rotationRules.value.find(rule => rule.id === rotationAssignmentForm.rotationRuleId)?.name || rotationAssignmentForm.rotationRuleId,
+    startDate: rotationAssignmentForm.startDate,
+    endDate: rotationAssignmentForm.endDate || null,
+    isActive: rotationAssignmentForm.isActive,
+  },
+}))
+
+function formatScheduleConflictDiagnostic(diagnostic: AttendanceScheduleConflictDiagnostic): string {
+  return formatAttendanceScheduleConflictDiagnostic(diagnostic, tr)
+}
 
 const ruleSetForm = reactive({
   name: '',
@@ -14885,6 +14951,20 @@ const holidaySectionBindings = {
 }
 
 .attendance__calendar-policy-diagnostics ul {
+  margin: 6px 0 0;
+  padding-left: 18px;
+}
+
+.attendance__schedule-conflict-diagnostics {
+  border: 1px solid #f2c94c;
+  background: #fff8e1;
+  color: #7a4f00;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 12px;
+}
+
+.attendance__schedule-conflict-diagnostics ul {
   margin: 6px 0 0;
   padding-left: 18px;
 }

--- a/apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue
+++ b/apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue
@@ -183,6 +183,23 @@
       {{ tr('Rotation assignments', '轮班分配') }}: {{ rotationAssignments.length }}
       <span v-if="rotationAssignmentEditingId"> · {{ rotationAssignmentEditingLabel }}</span>
     </div>
+    <div
+      v-if="scheduleConflictDiagnostics.length"
+      class="attendance__schedule-conflict-diagnostics"
+      data-attendance-schedule-conflict-diagnostics
+      role="alert"
+    >
+      <strong>{{ tr('Schedule conflict checks', '排班冲突检查') }}</strong>
+      <ul>
+        <li
+          v-for="diagnostic in scheduleConflictDiagnostics"
+          :key="diagnostic.key"
+          :data-schedule-conflict-diagnostic="diagnostic.code"
+        >
+          {{ formatScheduleConflictDiagnostic(diagnostic) }}
+        </li>
+      </ul>
+    </div>
     <div class="attendance__admin-grid">
       <AttendanceUserPickerField
         v-model="rotationAssignmentForm.userId"
@@ -542,6 +559,11 @@ import {
   buildTimezoneOptionGroups,
   formatTimezoneOptionLabel,
 } from './attendanceTimezones'
+import {
+  buildAttendanceScheduleConflictDiagnostics,
+  formatAttendanceScheduleConflictDiagnostic,
+  type AttendanceScheduleConflictDiagnostic,
+} from './attendanceScheduleConflictDiagnostics'
 
 type Translate = (en: string, zh: string) => string
 type MaybePromise<T> = T | Promise<T>
@@ -692,6 +714,32 @@ const editAssignment = (item: AttendanceAssignmentItem) => props.scheduling.edit
 const loadAssignments = () => props.scheduling.loadAssignments()
 const saveAssignment = () => props.scheduling.saveAssignment()
 const deleteAssignment = (id: string) => props.scheduling.deleteAssignment(id)
+const scheduleConflictDiagnostics = computed(() => buildAttendanceScheduleConflictDiagnostics({
+  assignments: assignments.value,
+  rotationAssignments: rotationAssignments.value,
+  assignmentDraft: {
+    id: assignmentEditingId.value,
+    userId: assignmentForm.userId,
+    refId: assignmentForm.shiftId,
+    refLabel: shifts.value.find(shift => shift.id === assignmentForm.shiftId)?.name || assignmentForm.shiftId,
+    startDate: assignmentForm.startDate,
+    endDate: assignmentForm.endDate || null,
+    isActive: assignmentForm.isActive,
+  },
+  rotationAssignmentDraft: {
+    id: rotationAssignmentEditingId.value,
+    userId: rotationAssignmentForm.userId,
+    refId: rotationAssignmentForm.rotationRuleId,
+    refLabel: rotationRules.value.find(rule => rule.id === rotationAssignmentForm.rotationRuleId)?.name || rotationAssignmentForm.rotationRuleId,
+    startDate: rotationAssignmentForm.startDate,
+    endDate: rotationAssignmentForm.endDate || null,
+    isActive: rotationAssignmentForm.isActive,
+  },
+}))
+
+function formatScheduleConflictDiagnostic(diagnostic: AttendanceScheduleConflictDiagnostic): string {
+  return formatAttendanceScheduleConflictDiagnostic(diagnostic, tr)
+}
 
 function parseShiftSequence(value: string): string[] {
   return value
@@ -790,6 +838,20 @@ const assignmentEditingLabel = computed(() => {
 .attendance__field-hint {
   color: #666;
   font-size: 12px;
+}
+
+.attendance__schedule-conflict-diagnostics {
+  border: 1px solid #f2c94c;
+  background: #fff8e1;
+  color: #7a4f00;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 12px;
+}
+
+.attendance__schedule-conflict-diagnostics ul {
+  margin: 6px 0 0;
+  padding-left: 18px;
 }
 
 .attendance__field--checkbox .attendance__field-hint {

--- a/apps/web/src/views/attendance/attendanceScheduleConflictDiagnostics.ts
+++ b/apps/web/src/views/attendance/attendanceScheduleConflictDiagnostics.ts
@@ -1,0 +1,270 @@
+type Translate = (en: string, zh: string) => string
+
+export interface AttendanceScheduleAssignmentLike {
+  assignment: {
+    id: string
+    userId: string
+    shiftId?: string
+    startDate: string
+    endDate: string | null
+    isActive: boolean
+  }
+  shift?: {
+    id?: string
+    name?: string
+  }
+}
+
+export interface AttendanceScheduleRotationAssignmentLike {
+  assignment: {
+    id: string
+    userId: string
+    rotationRuleId?: string
+    startDate: string
+    endDate: string | null
+    isActive: boolean
+  }
+  rotation?: {
+    id?: string
+    name?: string
+  }
+}
+
+export interface AttendanceScheduleAssignmentDraft {
+  id?: string | null
+  userId: string
+  refId: string
+  refLabel?: string
+  startDate: string
+  endDate: string | null
+  isActive: boolean
+}
+
+export type AttendanceScheduleConflictDiagnosticCode =
+  | 'shift_assignment_overlap'
+  | 'rotation_assignment_overlap'
+  | 'rotation_overrides_shift'
+
+export interface AttendanceScheduleConflictDiagnostic {
+  key: string
+  code: AttendanceScheduleConflictDiagnosticCode
+  severity: 'warning'
+  userId: string
+  primaryLabel: string
+  secondaryLabel: string
+  overlapStart: string
+  overlapEnd: string | null
+}
+
+export interface BuildAttendanceScheduleConflictDiagnosticsInput {
+  assignments?: AttendanceScheduleAssignmentLike[]
+  rotationAssignments?: AttendanceScheduleRotationAssignmentLike[]
+  assignmentDraft?: AttendanceScheduleAssignmentDraft | null
+  rotationAssignmentDraft?: AttendanceScheduleAssignmentDraft | null
+}
+
+interface NormalizedScheduleInterval {
+  id: string
+  kind: 'shift' | 'rotation'
+  userId: string
+  refLabel: string
+  startDate: string
+  endDate: string | null
+}
+
+function dateKey(value: unknown): string {
+  const text = typeof value === 'string' ? value.trim() : ''
+  return /^\d{4}-\d{2}-\d{2}$/.test(text) ? text : ''
+}
+
+function normalizeOpenEnd(value: unknown): string | null {
+  const endDate = dateKey(value)
+  return endDate || null
+}
+
+function overlaps(left: NormalizedScheduleInterval, right: NormalizedScheduleInterval): boolean {
+  const leftEnd = left.endDate ?? '9999-12-31'
+  const rightEnd = right.endDate ?? '9999-12-31'
+  return left.startDate <= rightEnd && right.startDate <= leftEnd
+}
+
+function overlapStart(left: NormalizedScheduleInterval, right: NormalizedScheduleInterval): string {
+  return left.startDate > right.startDate ? left.startDate : right.startDate
+}
+
+function overlapEnd(left: NormalizedScheduleInterval, right: NormalizedScheduleInterval): string | null {
+  const leftEnd = left.endDate ?? '9999-12-31'
+  const rightEnd = right.endDate ?? '9999-12-31'
+  const endDate = leftEnd < rightEnd ? leftEnd : rightEnd
+  return endDate === '9999-12-31' ? null : endDate
+}
+
+function normalizeInterval(input: {
+  id?: string | null
+  kind: 'shift' | 'rotation'
+  userId?: string
+  refId?: string
+  refLabel?: string
+  startDate?: string
+  endDate?: string | null
+  isActive?: boolean
+}): NormalizedScheduleInterval | null {
+  if (input.isActive === false) return null
+  const userId = typeof input.userId === 'string' ? input.userId.trim() : ''
+  const refId = typeof input.refId === 'string' ? input.refId.trim() : ''
+  const startDate = dateKey(input.startDate)
+  if (!userId || !refId || !startDate) return null
+  const endDate = normalizeOpenEnd(input.endDate)
+  if (endDate && endDate < startDate) return null
+  return {
+    id: input.id?.trim() || `draft:${input.kind}`,
+    kind: input.kind,
+    userId,
+    refLabel: input.refLabel?.trim() || refId,
+    startDate,
+    endDate,
+  }
+}
+
+function normalizeShiftIntervals(
+  assignments: AttendanceScheduleAssignmentLike[] | undefined,
+  draft: AttendanceScheduleAssignmentDraft | null | undefined,
+): NormalizedScheduleInterval[] {
+  const draftInterval = draft
+    ? normalizeInterval({ ...draft, kind: 'shift' })
+    : null
+  const draftId = draftInterval?.id ?? null
+  const intervals = (Array.isArray(assignments) ? assignments : [])
+    .map((item) => normalizeInterval({
+      id: item.assignment.id,
+      kind: 'shift',
+      userId: item.assignment.userId,
+      refId: item.assignment.shiftId,
+      refLabel: item.shift?.name || item.assignment.shiftId,
+      startDate: item.assignment.startDate,
+      endDate: item.assignment.endDate,
+      isActive: item.assignment.isActive,
+    }))
+    .filter((item): item is NormalizedScheduleInterval => Boolean(item))
+    .filter((item) => item.id !== draftId)
+  if (draftInterval) intervals.push(draftInterval)
+  return intervals
+}
+
+function normalizeRotationIntervals(
+  assignments: AttendanceScheduleRotationAssignmentLike[] | undefined,
+  draft: AttendanceScheduleAssignmentDraft | null | undefined,
+): NormalizedScheduleInterval[] {
+  const draftInterval = draft
+    ? normalizeInterval({ ...draft, kind: 'rotation' })
+    : null
+  const draftId = draftInterval?.id ?? null
+  const intervals = (Array.isArray(assignments) ? assignments : [])
+    .map((item) => normalizeInterval({
+      id: item.assignment.id,
+      kind: 'rotation',
+      userId: item.assignment.userId,
+      refId: item.assignment.rotationRuleId,
+      refLabel: item.rotation?.name || item.assignment.rotationRuleId,
+      startDate: item.assignment.startDate,
+      endDate: item.assignment.endDate,
+      isActive: item.assignment.isActive,
+    }))
+    .filter((item): item is NormalizedScheduleInterval => Boolean(item))
+    .filter((item) => item.id !== draftId)
+  if (draftInterval) intervals.push(draftInterval)
+  return intervals
+}
+
+function diagnosticKey(
+  code: AttendanceScheduleConflictDiagnosticCode,
+  left: NormalizedScheduleInterval,
+  right: NormalizedScheduleInterval,
+): string {
+  return `${code}:${left.userId}:${left.id}:${right.id}:${overlapStart(left, right)}`
+}
+
+function pushOverlapDiagnostic(
+  diagnostics: AttendanceScheduleConflictDiagnostic[],
+  code: AttendanceScheduleConflictDiagnosticCode,
+  left: NormalizedScheduleInterval,
+  right: NormalizedScheduleInterval,
+): void {
+  diagnostics.push({
+    key: diagnosticKey(code, left, right),
+    code,
+    severity: 'warning',
+    userId: left.userId,
+    primaryLabel: left.refLabel,
+    secondaryLabel: right.refLabel,
+    overlapStart: overlapStart(left, right),
+    overlapEnd: overlapEnd(left, right),
+  })
+}
+
+function collectSameKindOverlaps(
+  diagnostics: AttendanceScheduleConflictDiagnostic[],
+  code: 'shift_assignment_overlap' | 'rotation_assignment_overlap',
+  intervals: NormalizedScheduleInterval[],
+): void {
+  for (let leftIndex = 0; leftIndex < intervals.length; leftIndex += 1) {
+    const left = intervals[leftIndex]
+    if (!left) continue
+    for (let rightIndex = leftIndex + 1; rightIndex < intervals.length; rightIndex += 1) {
+      const right = intervals[rightIndex]
+      if (!right) continue
+      if (left.userId !== right.userId) continue
+      if (!overlaps(left, right)) continue
+      pushOverlapDiagnostic(diagnostics, code, left, right)
+    }
+  }
+}
+
+export function buildAttendanceScheduleConflictDiagnostics({
+  assignments,
+  rotationAssignments,
+  assignmentDraft,
+  rotationAssignmentDraft,
+}: BuildAttendanceScheduleConflictDiagnosticsInput): AttendanceScheduleConflictDiagnostic[] {
+  const shiftIntervals = normalizeShiftIntervals(assignments, assignmentDraft)
+  const rotationIntervals = normalizeRotationIntervals(rotationAssignments, rotationAssignmentDraft)
+  const diagnostics: AttendanceScheduleConflictDiagnostic[] = []
+
+  collectSameKindOverlaps(diagnostics, 'shift_assignment_overlap', shiftIntervals)
+  collectSameKindOverlaps(diagnostics, 'rotation_assignment_overlap', rotationIntervals)
+
+  for (const rotation of rotationIntervals) {
+    for (const shift of shiftIntervals) {
+      if (rotation.userId !== shift.userId) continue
+      if (!overlaps(rotation, shift)) continue
+      pushOverlapDiagnostic(diagnostics, 'rotation_overrides_shift', shift, rotation)
+    }
+  }
+
+  return diagnostics
+}
+
+export function formatAttendanceScheduleConflictDiagnostic(
+  diagnostic: AttendanceScheduleConflictDiagnostic,
+  tr: Translate,
+): string {
+  const range = diagnostic.overlapEnd
+    ? `${diagnostic.overlapStart} - ${diagnostic.overlapEnd}`
+    : `${diagnostic.overlapStart}+`
+  if (diagnostic.code === 'rotation_overrides_shift') {
+    return tr(
+      `User ${diagnostic.userId}: rotation ${diagnostic.secondaryLabel} overlaps shift assignment ${diagnostic.primaryLabel} (${range}); rotation wins at runtime.`,
+      `用户 ${diagnostic.userId}：轮班 ${diagnostic.secondaryLabel} 与固定排班 ${diagnostic.primaryLabel} 在 ${range} 重叠；运行时以轮班为准。`,
+    )
+  }
+  if (diagnostic.code === 'rotation_assignment_overlap') {
+    return tr(
+      `User ${diagnostic.userId}: rotation assignments ${diagnostic.primaryLabel} and ${diagnostic.secondaryLabel} overlap (${range}); the backend picks the latest matching assignment.`,
+      `用户 ${diagnostic.userId}：轮班分配 ${diagnostic.primaryLabel} 与 ${diagnostic.secondaryLabel} 在 ${range} 重叠；后端会选择最新命中的分配。`,
+    )
+  }
+  return tr(
+    `User ${diagnostic.userId}: shift assignments ${diagnostic.primaryLabel} and ${diagnostic.secondaryLabel} overlap (${range}); the backend picks the latest matching assignment.`,
+    `用户 ${diagnostic.userId}：固定排班 ${diagnostic.primaryLabel} 与 ${diagnostic.secondaryLabel} 在 ${range} 重叠；后端会选择最新命中的分配。`,
+  )
+}

--- a/apps/web/tests/AttendanceSchedulingAdminSection.spec.ts
+++ b/apps/web/tests/AttendanceSchedulingAdminSection.spec.ts
@@ -296,6 +296,107 @@ describe('AttendanceSchedulingAdminSection', () => {
     expect(container!.textContent).toContain('Editing shift assignment: user-9 → shift-a')
   })
 
+  it('shows schedule conflict diagnostics for overlapping assignments', async () => {
+    const scheduling = createSchedulingBindings({
+      rotationAssignments: ref<AttendanceRotationAssignmentItem[]>([
+        {
+          assignment: {
+            id: 'rotation-assignment-1',
+            userId: 'user-9',
+            rotationRuleId: 'rot-1',
+            startDate: '2026-03-05',
+            endDate: null,
+            isActive: true,
+          },
+          rotation: {
+            id: 'rot-1',
+            name: 'Two shift',
+            timezone: 'UTC',
+            shiftSequence: ['shift-a', 'shift-b'],
+            isActive: true,
+          },
+        },
+      ]),
+      assignments: ref<AttendanceAssignmentItem[]>([
+        {
+          assignment: {
+            id: 'assignment-1',
+            userId: 'user-9',
+            shiftId: 'shift-a',
+            startDate: '2026-03-01',
+            endDate: null,
+            isActive: true,
+          },
+          shift: {
+            id: 'shift-a',
+            name: 'Day shift',
+            timezone: 'UTC',
+            workStartTime: '09:00',
+            workEndTime: '18:00',
+            isOvernight: false,
+            lateGraceMinutes: 10,
+            earlyGraceMinutes: 10,
+            roundingMinutes: 5,
+            workingDays: [1, 2, 3, 4, 5],
+          },
+        },
+        {
+          assignment: {
+            id: 'assignment-2',
+            userId: 'user-9',
+            shiftId: 'shift-b',
+            startDate: '2026-03-10',
+            endDate: null,
+            isActive: true,
+          },
+          shift: {
+            id: 'shift-b',
+            name: 'Night shift',
+            timezone: 'UTC',
+            workStartTime: '22:00',
+            workEndTime: '06:00',
+            isOvernight: true,
+            lateGraceMinutes: 10,
+            earlyGraceMinutes: 10,
+            roundingMinutes: 5,
+            workingDays: [1, 2, 3, 4, 5],
+          },
+        },
+      ]),
+      assignmentEditingId: ref(null),
+      assignmentForm: reactive<AssignmentFormState>({
+        userId: '',
+        shiftId: '',
+        startDate: '2026-03-01',
+        endDate: '',
+        isActive: true,
+      }),
+      rotationAssignmentEditingId: ref(null),
+      rotationAssignmentForm: reactive<RotationAssignmentFormState>({
+        userId: '',
+        rotationRuleId: '',
+        startDate: '2026-03-01',
+        endDate: '',
+        isActive: true,
+      }),
+    })
+
+    app = createApp(AttendanceSchedulingAdminSection, {
+      tr,
+      scheduling,
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const diagnostics = container!.querySelector('[data-attendance-schedule-conflict-diagnostics]')
+    expect(diagnostics).toBeTruthy()
+    expect(diagnostics?.textContent).toContain('Schedule conflict checks')
+    expect(diagnostics?.textContent).toContain('User user-9')
+    expect(diagnostics?.textContent).toContain('rotation wins')
+    expect(container!.querySelector('[data-schedule-conflict-diagnostic="shift_assignment_overlap"]')).toBeTruthy()
+    expect(container!.querySelector('[data-schedule-conflict-diagnostic="rotation_overrides_shift"]')).toBeTruthy()
+  })
+
   it('falls back to plain counts when nothing is being edited', async () => {
     const scheduling = createSchedulingBindings({
       rotationRuleEditingId: ref(null),

--- a/apps/web/tests/attendanceScheduleConflictDiagnostics.spec.ts
+++ b/apps/web/tests/attendanceScheduleConflictDiagnostics.spec.ts
@@ -1,0 +1,182 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildAttendanceScheduleConflictDiagnostics,
+  formatAttendanceScheduleConflictDiagnostic,
+} from '../src/views/attendance/attendanceScheduleConflictDiagnostics'
+
+describe('attendance schedule conflict diagnostics', () => {
+  it('detects overlapping shift assignments for the same user', () => {
+    const diagnostics = buildAttendanceScheduleConflictDiagnostics({
+      assignments: [
+        {
+          assignment: {
+            id: 'assignment-1',
+            userId: 'user-1',
+            shiftId: 'shift-day',
+            startDate: '2026-06-01',
+            endDate: '2026-06-10',
+            isActive: true,
+          },
+          shift: { id: 'shift-day', name: 'Day shift' },
+        },
+        {
+          assignment: {
+            id: 'assignment-2',
+            userId: 'user-1',
+            shiftId: 'shift-night',
+            startDate: '2026-06-05',
+            endDate: null,
+            isActive: true,
+          },
+          shift: { id: 'shift-night', name: 'Night shift' },
+        },
+      ],
+    })
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'shift_assignment_overlap',
+        userId: 'user-1',
+        primaryLabel: 'Day shift',
+        secondaryLabel: 'Night shift',
+        overlapStart: '2026-06-05',
+        overlapEnd: '2026-06-10',
+      }),
+    ])
+  })
+
+  it('detects overlapping rotation assignments for the same user', () => {
+    const diagnostics = buildAttendanceScheduleConflictDiagnostics({
+      rotationAssignments: [
+        {
+          assignment: {
+            id: 'rotation-assignment-1',
+            userId: 'user-1',
+            rotationRuleId: 'rot-a',
+            startDate: '2026-06-01',
+            endDate: null,
+            isActive: true,
+          },
+          rotation: { id: 'rot-a', name: 'Two shift' },
+        },
+        {
+          assignment: {
+            id: 'rotation-assignment-2',
+            userId: 'user-1',
+            rotationRuleId: 'rot-b',
+            startDate: '2026-06-03',
+            endDate: '2026-06-12',
+            isActive: true,
+          },
+          rotation: { id: 'rot-b', name: 'Weekend rotation' },
+        },
+      ],
+    })
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'rotation_assignment_overlap',
+        primaryLabel: 'Two shift',
+        secondaryLabel: 'Weekend rotation',
+        overlapStart: '2026-06-03',
+        overlapEnd: '2026-06-12',
+      }),
+    ])
+  })
+
+  it('reports that rotation assignments override overlapping fixed shift assignments', () => {
+    const diagnostics = buildAttendanceScheduleConflictDiagnostics({
+      assignments: [
+        {
+          assignment: {
+            id: 'assignment-1',
+            userId: 'user-1',
+            shiftId: 'shift-day',
+            startDate: '2026-06-01',
+            endDate: null,
+            isActive: true,
+          },
+          shift: { id: 'shift-day', name: 'Day shift' },
+        },
+      ],
+      rotationAssignments: [
+        {
+          assignment: {
+            id: 'rotation-assignment-1',
+            userId: 'user-1',
+            rotationRuleId: 'rot-a',
+            startDate: '2026-06-05',
+            endDate: null,
+            isActive: true,
+          },
+          rotation: { id: 'rot-a', name: 'Two shift' },
+        },
+      ],
+    })
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'rotation_overrides_shift',
+        primaryLabel: 'Day shift',
+        secondaryLabel: 'Two shift',
+        overlapStart: '2026-06-05',
+        overlapEnd: null,
+      }),
+    ])
+    expect(formatAttendanceScheduleConflictDiagnostic(diagnostics[0]!, (en) => en)).toContain('rotation wins')
+  })
+
+  it('includes valid drafts and ignores inactive or invalid rows', () => {
+    const diagnostics = buildAttendanceScheduleConflictDiagnostics({
+      assignments: [
+        {
+          assignment: {
+            id: 'assignment-1',
+            userId: 'user-1',
+            shiftId: 'shift-day',
+            startDate: '2026-06-01',
+            endDate: '2026-06-10',
+            isActive: true,
+          },
+          shift: { id: 'shift-day', name: 'Day shift' },
+        },
+        {
+          assignment: {
+            id: 'assignment-inactive',
+            userId: 'user-1',
+            shiftId: 'shift-off',
+            startDate: '2026-06-01',
+            endDate: '2026-06-10',
+            isActive: false,
+          },
+          shift: { id: 'shift-off', name: 'Inactive shift' },
+        },
+      ],
+      assignmentDraft: {
+        id: null,
+        userId: 'user-1',
+        refId: 'shift-draft',
+        refLabel: 'Draft shift',
+        startDate: '2026-06-03',
+        endDate: '',
+        isActive: true,
+      },
+      rotationAssignmentDraft: {
+        id: null,
+        userId: 'user-1',
+        refId: 'rot-invalid',
+        refLabel: 'Invalid rotation',
+        startDate: '2026-06-12',
+        endDate: '2026-06-01',
+        isActive: true,
+      },
+    })
+
+    expect(diagnostics).toHaveLength(1)
+    expect(diagnostics[0]).toMatchObject({
+      code: 'shift_assignment_overlap',
+      primaryLabel: 'Day shift',
+      secondaryLabel: 'Draft shift',
+    })
+  })
+})

--- a/docs/development/attendance-schedule-conflict-preview-development-20260521.md
+++ b/docs/development/attendance-schedule-conflict-preview-development-20260521.md
@@ -1,0 +1,92 @@
+# Attendance Schedule Conflict Preview Development
+
+Date: 2026-05-21
+Branch: `codex/attendance-schedule-conflict-preview-20260521`
+Base: `origin/main@9af961d70`
+
+## Summary
+
+This slice adds admin-side conflict hints for the attendance scheduling surfaces.
+It explains existing runtime behavior before admins have to discover it through
+calculation results:
+
+- overlapping fixed shift assignments for the same user;
+- overlapping rotation assignments for the same user;
+- fixed shift assignments overlapped by rotation assignments, where runtime
+  resolution already gives rotation priority.
+
+The attendance fact source remains `attendance_*`. This is a frontend advisory
+slice only; no resolver, route, migration, or persistence behavior changes.
+
+## Scope
+
+Delivered:
+
+- A shared pure helper,
+  `buildAttendanceScheduleConflictDiagnostics()`, in
+  `attendanceScheduleConflictDiagnostics.ts`.
+- Diagnostic rendering in the production `AttendanceView.vue` scheduling
+  sections.
+- Diagnostic rendering in the extracted
+  `AttendanceSchedulingAdminSection.vue` component to keep the refactor surface
+  in parity.
+- Focused helper and component tests.
+- Development and verification notes.
+
+Not delivered:
+
+- No backend conflict-blocking validator.
+- No auto-fix, dedupe, delete, reorder, or split-assignment action.
+- No effective-calendar preview integration. Calendar policy diagnostics remain
+  a separate slice.
+
+## Runtime Semantics Mirrored
+
+The helper mirrors the current backend resolver posture:
+
+- `resolveWorkContext()` chooses `rotationInfo?.shift` before
+  `assignmentInfo?.shift`, so rotation assignments override overlapping fixed
+  shift assignments for the same user.
+- `loadShiftAssignment()` and `loadRotationAssignment()` both order by
+  `start_date DESC, created_at DESC` and select one row. When same-kind rows
+  overlap, admins should know the backend will pick the latest matching row
+  rather than combine both.
+- Inactive assignments are ignored.
+- Rows or drafts with missing user/reference/start date are ignored until they
+  are specific enough to reason about.
+- Invalid draft date ranges are ignored by this advisory helper because existing
+  save validation already blocks them.
+
+## UI Placement
+
+The production monolith still owns the active admin page, while
+`AttendanceSchedulingAdminSection.vue` carries the extracted/refactor surface.
+The warning block is therefore rendered in both:
+
+- `AttendanceView.vue`
+  - Rotation assignment section.
+  - Shift assignment section.
+- `AttendanceSchedulingAdminSection.vue`
+  - Scheduling conflict block before assignment editors/tables.
+
+## Changed Files
+
+- `apps/web/src/views/attendance/attendanceScheduleConflictDiagnostics.ts`
+  - New helper, diagnostic types, and formatter.
+- `apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue`
+  - Uses the helper and displays schedule conflict warnings.
+- `apps/web/src/views/AttendanceView.vue`
+  - Displays the same warnings in the production scheduling sections.
+- `apps/web/tests/attendanceScheduleConflictDiagnostics.spec.ts`
+  - Helper unit coverage.
+- `apps/web/tests/AttendanceSchedulingAdminSection.spec.ts`
+  - Component rendering coverage.
+
+## Boundaries
+
+- No `attendance_*` migration.
+- No direct `meta_*` writes.
+- No plugin/backend route changes.
+- No new client-side resolver for attendance calculation; the helper only
+  explains existing backend precedence.
+- No staging/prod write operation.

--- a/docs/development/attendance-schedule-conflict-preview-verification-20260521.md
+++ b/docs/development/attendance-schedule-conflict-preview-verification-20260521.md
@@ -1,0 +1,43 @@
+# Attendance Schedule Conflict Preview Verification
+
+Date: 2026-05-21
+Branch: `codex/attendance-schedule-conflict-preview-20260521`
+Base: `origin/main@9af961d70`
+
+## Verification Matrix
+
+| Layer | Command | Result |
+| --- | --- | --- |
+| Frontend focused specs | `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceScheduleConflictDiagnostics.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts --watch=false` | PASS, 9 tests |
+| Frontend type-check | `pnpm --filter @metasheet/web type-check` | PASS |
+| Frontend scheduling regression | `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceScheduleConflictDiagnostics.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts tests/useAttendanceAdminScheduling.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` | PASS, 43 tests |
+| Frontend build | `pnpm --filter @metasheet/web build` | PASS |
+| Whitespace | `git diff --check` | PASS |
+
+## Acceptance Criteria
+
+- Overlapping active fixed shift assignments for the same user emit a warning.
+- Overlapping active rotation assignments for the same user emit a warning.
+- Rotation assignment overlap with a fixed shift assignment for the same user
+  emits a warning that rotation wins at runtime.
+- Inactive rows do not emit warnings.
+- Incomplete drafts do not emit warnings until user/reference/start date exist.
+- The extracted scheduling component displays diagnostics.
+- The production `AttendanceView.vue` displays diagnostics in scheduling admin
+  sections.
+
+## Boundary Checks
+
+- No backend file changed.
+- No `plugins/plugin-attendance/index.cjs` change.
+- No migration file added or changed.
+- No direct `meta_*` SQL write.
+- No staging/prod write operation.
+
+## Notes
+
+This is an advisory UI slice. It does not block save and does not alter runtime
+selection. Existing backend behavior remains the source of truth.
+
+The frontend build still emits the existing Vite warning about large chunks and
+the mixed static/dynamic import of `WorkflowDesigner.vue`; the command exits 0.


### PR DESCRIPTION
## Summary

Adds an advisory schedule-conflict preview for attendance admin scheduling surfaces. It warns when active fixed shift assignments overlap, active rotation assignments overlap, and when a rotation assignment overlaps a fixed shift assignment that it will override at runtime.

Implementation:
- shared pure helper `buildAttendanceScheduleConflictDiagnostics()` + formatter
- warning blocks in production `AttendanceView.vue` and extracted `AttendanceSchedulingAdminSection.vue`
- focused helper/component tests
- development and verification markdown under `docs/development/`

Boundaries:
- frontend advisory only; no backend resolver or route changes
- no `attendance_*` migration
- no direct `meta_*` writes
- no staging/prod writes

## Test plan

- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceScheduleConflictDiagnostics.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts --watch=false` — 9 tests pass
- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceScheduleConflictDiagnostics.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts tests/useAttendanceAdminScheduling.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` — 43 tests pass
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `pnpm --filter @metasheet/web build`
- [x] `git diff --check`
- [x] staged whitespace / node_modules-dist / secret scan clean

## Notes

The build still emits the existing Vite warning about large chunks and mixed static/dynamic import of `WorkflowDesigner.vue`; the command exits 0.