### PR TITLE
chore(integration): package Bridge Agent operator tools

### DIFF
--- a/docs/development/bridge-agent-package-verify-development-20260521.md
+++ b/docs/development/bridge-agent-package-verify-development-20260521.md
@@ -1,0 +1,62 @@
+# Bridge Agent Package Verify Development Notes
+
+Date: 2026-05-21
+
+## Purpose
+
+PR #1731 added the BA-M1 readonly Bridge Agent runtime skeleton. This follow-up
+makes the Windows on-prem delivery package accountable for shipping the Bridge
+Agent operator tools, not just the K3/Data Factory runtime.
+
+Without this gate, the source tree could contain the BA-M0.5/BA-M1 scripts while
+the official on-prem zip quietly omits them. That would leave the operator with
+a merged runbook but no script on the Windows bridge host.
+
+## Files Changed
+
+- `scripts/ops/multitable-onprem-package-build.sh`
+- `scripts/ops/multitable-onprem-package-verify.sh`
+- `docs/development/bridge-agent-package-verify-development-20260521.md`
+- `docs/development/bridge-agent-package-verify-verification-20260521.md`
+
+## Build Inclusion
+
+The package builder now includes:
+
+- `scripts/ops/bridge-agent-driver-smoke.ps1`
+- `scripts/ops/fixtures/bridge-agent-driver-smoke`
+- `scripts/ops/bridge-agent-readonly.ps1`
+- `scripts/ops/fixtures/bridge-agent-readonly`
+- `docs/operations/bridge-agent-driver-smoke-runbook-20260520.md`
+- `docs/operations/bridge-agent-readonly-runbook-20260521.md`
+
+`INSTALL.txt` gains a short "Legacy SQL readonly Bridge Agent tools" section so
+operators can find BA-M0.5 and BA-M1 from the package root.
+
+## Verify Gate
+
+`multitable-onprem-package-verify.sh` now requires the package to contain the
+Bridge Agent files and checks contract markers:
+
+- BA-M0.5 smoke still runs only `SELECT @@VERSION`;
+- BA-M0.5 provider names stay configurable for approved legacy drivers;
+- BA-M0.5 evidence templates are present;
+- BA-M1 uses `System.Data.SqlClient`;
+- BA-M1 rejects non-localhost bindings;
+- BA-M1 rejects raw SQL and filters;
+- BA-M1 builds bounded `SELECT TOP` queries from allowlisted identifiers;
+- BA-M1 config keeps credentials/secrets in environment variable names;
+- BA-M1 runbook documents localhost, validation, URL ACL, and negative checks.
+
+## Boundaries
+
+This PR does not change the Bridge Agent runtime behavior. It only changes the
+delivery package and package verifier.
+
+Still out of scope:
+
+- `plugin-integration-core` integration;
+- Data Factory UI wiring;
+- SQL writes;
+- K3 Save / Submit / Audit;
+- customer-GATE changes.

--- a/docs/development/bridge-agent-package-verify-verification-20260521.md
+++ b/docs/development/bridge-agent-package-verify-verification-20260521.md
@@ -1,0 +1,44 @@
+# Bridge Agent Package Verify Verification
+
+Date: 2026-05-21
+
+## Commands
+
+```bash
+bash -n scripts/ops/multitable-onprem-package-build.sh
+bash -n scripts/ops/multitable-onprem-package-verify.sh
+git diff --check origin/main...HEAD
+```
+
+Static marker checks:
+
+```bash
+rg -n "bridge-agent-driver-smoke.ps1|bridge-agent-readonly.ps1|bridge-agent-readonly-runbook-20260521.md" \
+  scripts/ops/multitable-onprem-package-build.sh \
+  scripts/ops/multitable-onprem-package-verify.sh
+
+rg -n "verify_bridge_agent_tooling_contract|RAW_SQL_REJECTED|SELECT TOP \\$Limit|System.Data.SqlClient.SqlConnection|v_MetaSheet_MaterialRead" \
+  scripts/ops/multitable-onprem-package-verify.sh
+```
+
+## Local Result
+
+| Command | Result |
+| --- | --- |
+| `bash -n scripts/ops/multitable-onprem-package-build.sh` | PASS |
+| `bash -n scripts/ops/multitable-onprem-package-verify.sh` | PASS |
+| `git diff --check origin/main...HEAD` | PASS, rc=0 |
+| static marker check for Bridge Agent required paths | PASS, build + verify scripts both reference the BA-M0.5/BA-M1 files |
+| static marker check for `verify_bridge_agent_tooling_contract` | PASS, verifier checks provider, localhost, raw-SQL rejection, bounded SELECT, and readonly-view config markers |
+| secret-shape scan over changed files | PASS, 0 hits |
+
+## Packaging Note
+
+The isolated worktree used for this PR does not have `node_modules`,
+`apps/web/dist`, or `packages/core-backend/dist`, so a full local on-prem package
+build was not executed here. The real zip/tgz inclusion is covered by the
+official GitHub "Multitable On-Prem Package Build" workflow after merge.
+
+This PR still adds deterministic package verifier assertions, so a future
+official package missing the Bridge Agent files or contract markers will fail
+`multitable-onprem-package-verify.sh`.

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -73,11 +73,21 @@ REQUIRED_PATHS=(
   "scripts/ops/integration-k3wise-postdeploy-summary.mjs"
   "scripts/ops/integration-k3wise-gate-contract-check.mjs"
   "scripts/ops/fixtures/integration-k3wise"
+  # Legacy SQL readonly Bridge Agent tooling. BA-M0.5 proves the approved
+  # Windows SQL driver can connect with SELECT @@VERSION only. BA-M1 then
+  # exposes a localhost-only, readonly, allowlisted HTTP bridge for operator
+  # validation before MetaSheet runtime integration begins.
+  "scripts/ops/bridge-agent-driver-smoke.ps1"
+  "scripts/ops/fixtures/bridge-agent-driver-smoke"
+  "scripts/ops/bridge-agent-readonly.ps1"
+  "scripts/ops/fixtures/bridge-agent-readonly"
   "docs/operations/k3-poc-onprem-preflight-runbook.md"
   "docs/operations/integration-k3wise-onprem-operator-handoff-checklist.md"
   "docs/operations/integration-k3wise-internal-trial-runbook.md"
   "docs/operations/integration-k3wise-live-gate-execution-package.md"
   "docs/operations/integration-k3wise-sql-executor-bridge-handoff.md"
+  "docs/operations/bridge-agent-driver-smoke-runbook-20260520.md"
+  "docs/operations/bridge-agent-readonly-runbook-20260521.md"
   "docs/operations/integration-k3wise-webapi-read-list-customer-sample-manifest.md"
   "docs/operations/integration-k3wise-relationship-mapping-customer-sample-manifest.md"
   "docs/development/k3wise-bridge-machine-codex-handoff-20260513.md"
@@ -460,6 +470,15 @@ K3 WISE PoC operator tools (Node only; no Docker needed to run these):
     docs/operations/integration-k3wise-onprem-operator-handoff-checklist.md (deploy-to-live handoff checklist)
     docs/operations/integration-k3wise-internal-trial-runbook.md  (post-deploy auth smoke)
     docs/operations/integration-k3wise-live-gate-execution-package.md (C0-C10 sequence + customer GATE fields)
+
+Legacy SQL readonly Bridge Agent tools (Windows bridge host only):
+  powershell -ExecutionPolicy Bypass -File scripts\ops\bridge-agent-driver-smoke.ps1 ...
+    -> BA-M0.5 driver smoke, runs connection.Open() and SELECT @@VERSION only.
+  powershell -ExecutionPolicy Bypass -File scripts\ops\bridge-agent-readonly.ps1 -ConfigPath <local-config>
+    -> BA-M1 localhost-only readonly bridge for allowlisted SQL views.
+  Runbooks:
+    docs/operations/bridge-agent-driver-smoke-runbook-20260520.md
+    docs/operations/bridge-agent-readonly-runbook-20260521.md
 
 Runtime dependencies:
   node_modules are intentionally not bundled. deploy.bat defaults to

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -317,6 +317,54 @@ function verify_generic_integration_workbench_contract() {
   search_fixed_string '"autoAudit": false' "$onsite_evidence_template" || die "on-site evidence template must default autoAudit=false"
 }
 
+function verify_bridge_agent_tooling_contract() {
+  local root="$1"
+  local smoke_script="${root}/scripts/ops/bridge-agent-driver-smoke.ps1"
+  local smoke_template_json="${root}/scripts/ops/fixtures/bridge-agent-driver-smoke/evidence.template.json"
+  local smoke_template_md="${root}/scripts/ops/fixtures/bridge-agent-driver-smoke/evidence.template.md"
+  local smoke_runbook="${root}/docs/operations/bridge-agent-driver-smoke-runbook-20260520.md"
+  local readonly_script="${root}/scripts/ops/bridge-agent-readonly.ps1"
+  local readonly_config="${root}/scripts/ops/fixtures/bridge-agent-readonly/config.example.json"
+  local readonly_runbook="${root}/docs/operations/bridge-agent-readonly-runbook-20260521.md"
+  local install_txt="${root}/INSTALL.txt"
+
+  search_fixed_string 'SELECT @@VERSION' "$smoke_script" || die "Bridge Agent driver smoke must run SELECT @@VERSION only"
+  search_fixed_string "[ValidateSet('SqlClient', 'Odbc', 'OleDb')]" "$smoke_script" || die "Bridge Agent driver smoke must support SqlClient/Odbc/OleDb provider modes"
+  search_fixed_string 'OdbcDriverName' "$smoke_script" || die "Bridge Agent driver smoke must allow BA-M0 approved ODBC driver names"
+  search_fixed_string 'OleDbProviderName' "$smoke_script" || die "Bridge Agent driver smoke must allow BA-M0 approved OLE DB provider names"
+  search_fixed_string 'data[$kStr]=<redacted>' "$smoke_script" || die "Bridge Agent driver smoke must redact sensitive Exception.Data values"
+  search_fixed_string '"decision": "PASS|FAIL"' "$smoke_template_json" || die "Bridge Agent driver smoke JSON evidence template must be packaged"
+  search_fixed_string 'BA-M1 does not start until BA-M0.5 is signed off green' "$smoke_runbook" || die "Bridge Agent driver smoke runbook must preserve the BA-M1 gate"
+  search_fixed_string 'Do not paste raw evidence into GitHub' "$smoke_runbook" || die "Bridge Agent driver smoke runbook must document evidence hygiene"
+  search_fixed_string 'Driver Smoke Evidence Template' "$smoke_template_md" || die "Bridge Agent driver smoke Markdown evidence template must be packaged"
+
+  search_fixed_string 'System.Data.SqlClient.SqlConnection' "$readonly_script" || die "readonly Bridge Agent must use the approved SqlClient provider"
+  search_fixed_string 'BA-M1 MVP only supports localhost binding' "$readonly_script" || die "readonly Bridge Agent must reject non-localhost bindings"
+  search_fixed_string 'RAW_SQL_REJECTED' "$readonly_script" || die "readonly Bridge Agent must reject raw SQL requests"
+  search_fixed_string 'UNSUPPORTED_FILTERS' "$readonly_script" || die "readonly Bridge Agent must reject filters until BA-M2 designs the query contract"
+  search_fixed_string 'SELECT TOP $Limit' "$readonly_script" || die "readonly Bridge Agent must build bounded SELECT TOP queries"
+  search_fixed_string 'ConvertTo-QuotedIdentifier' "$readonly_script" || die "readonly Bridge Agent must quote allowlisted SQL identifiers"
+  search_fixed_string 'sharedSecretEnvVar' "$readonly_script" || die "readonly Bridge Agent must read its shared secret from a local environment variable"
+  search_fixed_string 'ConvertTo-BridgeError' "$readonly_script" || die "readonly Bridge Agent must redact returned errors"
+
+  search_fixed_string '"host": "127.0.0.1"' "$readonly_config" || die "readonly Bridge Agent example config must bind to localhost"
+  search_fixed_string 'METASHEET_BRIDGE_SQL_USERNAME' "$readonly_config" || die "readonly Bridge Agent config must keep SQL username in an env var"
+  search_fixed_string 'METASHEET_BRIDGE_SQL_PASSWORD' "$readonly_config" || die "readonly Bridge Agent config must keep SQL password in an env var"
+  search_fixed_string 'METASHEET_BRIDGE_SHARED_SECRET' "$readonly_config" || die "readonly Bridge Agent config must keep the shared secret in an env var"
+  search_fixed_string 'v_MetaSheet_MaterialRead' "$readonly_config" || die "readonly Bridge Agent config must prefer material readonly views"
+  search_fixed_string 'v_MetaSheet_BomRead' "$readonly_config" || die "readonly Bridge Agent config must prefer BOM readonly views"
+  search_fixed_string 'v_MetaSheet_BomChildRead' "$readonly_config" || die "readonly Bridge Agent config must prefer BOM child readonly views"
+
+  search_fixed_string 'ValidateConfigOnly' "$readonly_runbook" || die "readonly Bridge Agent runbook must document config validation"
+  search_fixed_string 'http://127.0.0.1:19091/' "$readonly_runbook" || die "readonly Bridge Agent runbook must document localhost endpoint"
+  search_fixed_string 'Raw SQL must fail' "$readonly_runbook" || die "readonly Bridge Agent runbook must document negative raw-SQL check"
+  search_fixed_string 'netsh http add urlacl' "$readonly_runbook" || die "readonly Bridge Agent runbook must document HttpListener URL ACL setup"
+
+  search_fixed_string 'bridge-agent-driver-smoke.ps1' "$install_txt" || die "INSTALL.txt must mention the BA-M0.5 Bridge Agent driver smoke"
+  search_fixed_string 'bridge-agent-readonly.ps1' "$install_txt" || die "INSTALL.txt must mention the BA-M1 readonly Bridge Agent"
+  search_fixed_string 'bridge-agent-readonly-runbook-20260521.md' "$install_txt" || die "INSTALL.txt must point operators at the readonly Bridge Agent runbook"
+}
+
 function write_optional_report() {
   local checksum_status="SKIPPED"
   local link_status="SKIPPED"
@@ -540,6 +588,11 @@ required=(
   "scripts/ops/integration-issue1542-seed-workbench-systems.mjs"
   "scripts/ops/integration-k3wise-postdeploy-summary.mjs"
   "scripts/ops/integration-k3wise-gate-contract-check.mjs"
+  "scripts/ops/bridge-agent-driver-smoke.ps1"
+  "scripts/ops/fixtures/bridge-agent-driver-smoke/evidence.template.json"
+  "scripts/ops/fixtures/bridge-agent-driver-smoke/evidence.template.md"
+  "scripts/ops/bridge-agent-readonly.ps1"
+  "scripts/ops/fixtures/bridge-agent-readonly/config.example.json"
   "scripts/ops/fixtures/integration-k3wise/gate-intake-template.json"
   "scripts/ops/fixtures/integration-k3wise/evidence-onsite-c4-c9-template.json"
   "scripts/ops/fixtures/integration-k3wise/run-mock-poc-demo.mjs"
@@ -561,6 +614,8 @@ required=(
   "docs/operations/integration-k3wise-live-gate-execution-package.md"
   "docs/operations/integration-k3wise-webapi-read-list-customer-sample-manifest.md"
   "docs/operations/integration-k3wise-relationship-mapping-customer-sample-manifest.md"
+  "docs/operations/bridge-agent-driver-smoke-runbook-20260520.md"
+  "docs/operations/bridge-agent-readonly-runbook-20260521.md"
   "docs/development/data-factory-workbench-todo-20260514.md"
   "docs/development/data-factory-workbench-development-20260514.md"
   "docs/development/data-factory-workbench-verification-20260514.md"
@@ -623,6 +678,7 @@ verify_integration_plugin_runtime_dependencies "$pkg_root"
 verify_deployable_artifact_contract "$pkg_root"
 verify_migration_bridge_contract "$pkg_root"
 verify_generic_integration_workbench_contract "$pkg_root"
+verify_bridge_agent_tooling_contract "$pkg_root"
 
 if [[ "$VERIFY_NO_GITHUB_LINKS" == "1" ]]; then
   verify_no_github_links "$pkg_root"


### PR DESCRIPTION
## Summary

Follow-up to #1731. Makes the on-prem package builder and verifier accountable for shipping the BA-M0.5 / BA-M1 Bridge Agent operator tools.

## Scope

- Package builder now includes:
  - `scripts/ops/bridge-agent-driver-smoke.ps1`
  - `scripts/ops/fixtures/bridge-agent-driver-smoke`
  - `scripts/ops/bridge-agent-readonly.ps1`
  - `scripts/ops/fixtures/bridge-agent-readonly`
  - `docs/operations/bridge-agent-driver-smoke-runbook-20260520.md`
  - `docs/operations/bridge-agent-readonly-runbook-20260521.md`
- Package verifier now checks Bridge Agent contract markers: driver smoke SELECT-only behavior, provider configurability, localhost-only BA-M1, raw-SQL rejection, bounded SELECT TOP, env-var secrets, readonly-view config, and runbook pointers.
- INSTALL.txt now points operators at the Bridge Agent tools/runbooks.

## Verification

- `bash -n scripts/ops/multitable-onprem-package-build.sh` -> PASS
- `bash -n scripts/ops/multitable-onprem-package-verify.sh` -> PASS
- `git diff --check origin/main...HEAD` -> PASS
- static Bridge Agent package marker checks -> PASS
- secret-shape scan over changed files -> PASS, 0 hits

## Notes

The isolated worktree used for this PR has no `node_modules`, `apps/web/dist`, or `packages/core-backend/dist`, so I did not run a full local package build. The official Multitable On-Prem Package Build workflow is the real zip/tgz inclusion check after merge.

No plugin-integration-core runtime changes, no DB/API/frontend changes, no SQL writes, no K3 Save/Submit/Audit.