### PR TITLE
feat(multitable): localize automation rule editor chrome (T3D-2)

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -2,7 +2,7 @@
   <div v-if="visible" class="meta-rule-editor__overlay" @click.self="$emit('close')">
     <div class="meta-rule-editor">
       <div class="meta-rule-editor__header">
-        <h4 class="meta-rule-editor__title">{{ rule ? 'Edit Automation Rule' : 'New Automation Rule' }}</h4>
+        <h4 class="meta-rule-editor__title">{{ rule ? automationLabel('editor.titleEdit', isZh) : automationLabel('editor.titleNew', isZh) }}</h4>
         <button class="meta-rule-editor__close" type="button" @click="$emit('close')">&times;</button>
       </div>
 
@@ -10,60 +10,60 @@
         <div v-if="error" class="meta-rule-editor__error" role="alert">{{ error }}</div>
 
         <!-- Name -->
-        <label class="meta-rule-editor__label">Name</label>
-        <input v-model="draft.name" class="meta-rule-editor__input" type="text" placeholder="Automation name" data-field="name" />
+        <label class="meta-rule-editor__label">{{ automationLabel('editor.name', isZh) }}</label>
+        <input v-model="draft.name" class="meta-rule-editor__input" type="text" :placeholder="automationLabel('editor.namePlaceholder', isZh)" data-field="name" />
 
         <!-- 1. Trigger selector -->
         <section class="meta-rule-editor__section">
-          <div class="meta-rule-editor__section-title">Trigger</div>
+          <div class="meta-rule-editor__section-title">{{ automationLabel('trigger.title', isZh) }}</div>
           <select v-model="draft.triggerType" class="meta-rule-editor__select" data-field="triggerType">
-            <option value="record.created">When record created</option>
-            <option value="record.updated">When record updated</option>
-            <option value="record.deleted">When record deleted</option>
-            <option value="field.value_changed">When field value changed</option>
-            <option value="schedule.cron">Schedule (cron)</option>
-            <option value="schedule.interval">Schedule (interval)</option>
-            <option value="webhook.received">Webhook received</option>
+            <option value="record.created">{{ automationTriggerTypeLabel('record.created', isZh) }}</option>
+            <option value="record.updated">{{ automationTriggerTypeLabel('record.updated', isZh) }}</option>
+            <option value="record.deleted">{{ automationTriggerTypeLabel('record.deleted', isZh) }}</option>
+            <option value="field.value_changed">{{ automationTriggerTypeLabel('field.value_changed', isZh) }}</option>
+            <option value="schedule.cron">{{ automationTriggerTypeLabel('schedule.cron', isZh) }}</option>
+            <option value="schedule.interval">{{ automationTriggerTypeLabel('schedule.interval', isZh) }}</option>
+            <option value="webhook.received">{{ automationTriggerTypeLabel('webhook.received', isZh) }}</option>
           </select>
 
           <!-- field.value_changed config -->
           <template v-if="draft.triggerType === 'field.value_changed'">
-            <label class="meta-rule-editor__label">Watch field</label>
+            <label class="meta-rule-editor__label">{{ automationLabel('trigger.watchField', isZh) }}</label>
             <select v-model="draft.triggerConfig.fieldId" class="meta-rule-editor__select" data-field="triggerFieldId">
-              <option value="">-- select field --</option>
+              <option value="">{{ automationLabel('trigger.selectField', isZh) }}</option>
               <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
             </select>
-            <label class="meta-rule-editor__label">Condition</label>
+            <label class="meta-rule-editor__label">{{ automationLabel('trigger.condition', isZh) }}</label>
             <select v-model="draft.triggerConfig.condition" class="meta-rule-editor__select" data-field="triggerCondition">
-              <option value="any">Any change</option>
-              <option value="equals">Equals</option>
-              <option value="changed_to">Changed to</option>
+              <option value="any">{{ automationTriggerConditionLabel('any', isZh) }}</option>
+              <option value="equals">{{ automationTriggerConditionLabel('equals', isZh) }}</option>
+              <option value="changed_to">{{ automationTriggerConditionLabel('changed_to', isZh) }}</option>
             </select>
             <template v-if="draft.triggerConfig.condition !== 'any'">
-              <label class="meta-rule-editor__label">Value</label>
-              <input v-model="draft.triggerConfig.value" class="meta-rule-editor__input" type="text" placeholder="Value" data-field="triggerValue" />
+              <label class="meta-rule-editor__label">{{ automationLabel('editor.value', isZh) }}</label>
+              <input v-model="draft.triggerConfig.value" class="meta-rule-editor__input" type="text" :placeholder="automationLabel('editor.value', isZh)" data-field="triggerValue" />
             </template>
           </template>
 
           <!-- schedule.cron config -->
           <template v-if="draft.triggerType === 'schedule.cron'">
-            <label class="meta-rule-editor__label">Preset</label>
+            <label class="meta-rule-editor__label">{{ automationLabel('trigger.preset', isZh) }}</label>
             <select v-model="cronPreset" class="meta-rule-editor__select" data-field="cronPreset">
-              <option value="*/5 * * * *">Every 5 minutes</option>
-              <option value="0 * * * *">Every hour</option>
-              <option value="0 0 * * *">Daily at midnight</option>
-              <option value="0 0 * * 1">Weekly (Monday)</option>
-              <option value="custom">Custom</option>
+              <option value="*/5 * * * *">{{ automationCronPresetLabel('*/5 * * * *', isZh) }}</option>
+              <option value="0 * * * *">{{ automationCronPresetLabel('0 * * * *', isZh) }}</option>
+              <option value="0 0 * * *">{{ automationCronPresetLabel('0 0 * * *', isZh) }}</option>
+              <option value="0 0 * * 1">{{ automationCronPresetLabel('0 0 * * 1', isZh) }}</option>
+              <option value="custom">{{ automationCronPresetLabel('custom', isZh) }}</option>
             </select>
             <template v-if="cronPreset === 'custom'">
-              <label class="meta-rule-editor__label">Cron expression</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('trigger.cronExpression', isZh) }}</label>
               <input v-model="draft.triggerConfig.cron" class="meta-rule-editor__input" type="text" placeholder="* * * * *" data-field="cronExpression" />
             </template>
           </template>
 
           <!-- schedule.interval config -->
           <template v-if="draft.triggerType === 'schedule.interval'">
-            <label class="meta-rule-editor__label">Interval (minutes)</label>
+            <label class="meta-rule-editor__label">{{ automationLabel('trigger.intervalMinutes', isZh) }}</label>
             <input v-model.number="draft.triggerConfig.intervalMinutes" class="meta-rule-editor__input" type="number" min="1" placeholder="5" data-field="intervalMinutes" />
           </template>
         </section>
@@ -71,8 +71,8 @@
         <!-- 2. Conditions -->
         <section class="meta-rule-editor__section">
           <div class="meta-rule-editor__section-title">
-            Conditions
-            <span class="meta-rule-editor__hint">(optional)</span>
+            {{ automationLabel('condition.title', isZh) }}
+            <span class="meta-rule-editor__hint">{{ automationLabel('condition.optional', isZh) }}</span>
           </div>
           <div v-if="draft.conditions.conditions.length > 1" class="meta-rule-editor__conjunction">
             <button
@@ -80,13 +80,13 @@
               class="meta-rule-editor__toggle-btn"
               :class="{ 'meta-rule-editor__toggle-btn--active': draft.conditions.conjunction === 'AND' }"
               @click="draft.conditions.conjunction = 'AND'"
-            >AND</button>
+            >{{ automationLabel('condition.and', isZh) }}</button>
             <button
               type="button"
               class="meta-rule-editor__toggle-btn"
               :class="{ 'meta-rule-editor__toggle-btn--active': draft.conditions.conjunction === 'OR' }"
               @click="draft.conditions.conjunction = 'OR'"
-            >OR</button>
+            >{{ automationLabel('condition.or', isZh) }}</button>
           </div>
           <div class="meta-rule-editor__condition-list">
             <template v-for="entry in conditionEditorEntries" :key="entry.pathKey">
@@ -96,31 +96,31 @@
                 :style="conditionIndentStyle(entry.depth)"
                 :data-condition-group-path="entry.pathKey"
               >
-                <span class="meta-rule-editor__group-label">Group</span>
+                <span class="meta-rule-editor__group-label">{{ automationLabel('condition.group', isZh) }}</span>
                 <div class="meta-rule-editor__conjunction">
                   <button
                     type="button"
                     class="meta-rule-editor__toggle-btn"
                     :class="{ 'meta-rule-editor__toggle-btn--active': normalizeConditionConjunction(entry.group) === 'AND' }"
                     @click="setGroupConjunction(entry.group, 'AND')"
-                  >AND</button>
+                  >{{ automationLabel('condition.and', isZh) }}</button>
                   <button
                     type="button"
                     class="meta-rule-editor__toggle-btn"
                     :class="{ 'meta-rule-editor__toggle-btn--active': normalizeConditionConjunction(entry.group) === 'OR' }"
                     @click="setGroupConjunction(entry.group, 'OR')"
-                  >OR</button>
+                  >{{ automationLabel('condition.or', isZh) }}</button>
                 </div>
                 <div class="meta-rule-editor__condition-actions">
-                  <button class="meta-rule-editor__btn" type="button" data-action="add-nested-condition" @click="addConditionToGroup(entry.path)">+ Condition</button>
+                  <button class="meta-rule-editor__btn" type="button" data-action="add-nested-condition" @click="addConditionToGroup(entry.path)">{{ automationLabel('condition.addNestedCondition', isZh) }}</button>
                   <button
                     class="meta-rule-editor__btn"
                     type="button"
                     data-action="add-condition-group"
                     :disabled="!entry.canAddGroup"
                     @click="addGroupToGroup(entry.path)"
-                  >+ Group</button>
-                  <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeConditionNode(entry.path)" title="Remove group">&times;</button>
+                  >{{ automationLabel('condition.addNestedGroup', isZh) }}</button>
+                  <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeConditionNode(entry.path)" :title="automationLabel('condition.removeGroupTitle', isZh)">&times;</button>
                 </div>
               </div>
               <div
@@ -135,7 +135,7 @@
                   class="meta-rule-editor__select meta-rule-editor__select--sm"
                   @change="onConditionFieldChange(entry.condition, ($event.target as HTMLSelectElement).value)"
                 >
-                  <option value="">-- field --</option>
+                  <option value="">{{ automationLabel('condition.selectField', isZh) }}</option>
                   <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
                 </select>
                 <select
@@ -143,7 +143,7 @@
                   class="meta-rule-editor__select meta-rule-editor__select--sm"
                   @change="onConditionOperatorChange(entry.condition, ($event.target as HTMLSelectElement).value as ConditionOperator)"
                 >
-                  <option v-for="op in conditionOperatorsForField(entry.condition.fieldId)" :key="op.value" :value="op.value">{{ op.label }}</option>
+                  <option v-for="op in conditionOperatorsForField(entry.condition.fieldId)" :key="op.value" :value="op.value">{{ automationConditionOperatorLabel(op.value, isZh) }}</option>
                 </select>
                 <template v-if="!isUnaryOperator(entry.condition.operator)">
                   <select
@@ -164,7 +164,7 @@
                     data-condition-value="boolean"
                     @change="onBooleanConditionValueChange(entry.condition, ($event.target as HTMLSelectElement).value)"
                   >
-                    <option value="">-- value --</option>
+                    <option value="">{{ automationLabel('condition.selectValue', isZh) }}</option>
                     <option value="true">true</option>
                     <option value="false">false</option>
                   </select>
@@ -175,7 +175,7 @@
                     data-condition-value="select"
                     @change="entry.condition.value = ($event.target as HTMLSelectElement).value"
                   >
-                    <option value="">-- value --</option>
+                    <option value="">{{ automationLabel('condition.selectValue', isZh) }}</option>
                     <option v-for="option in conditionFieldOptions(entry.condition)" :key="option.value" :value="option.value">
                       {{ optionLabel(option) }}
                     </option>
@@ -201,19 +201,19 @@
                     :placeholder="conditionValuePlaceholder(entry.condition)"
                   />
                 </template>
-                <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeConditionNode(entry.path)" title="Remove condition">&times;</button>
+                <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeConditionNode(entry.path)" :title="automationLabel('condition.removeConditionTitle', isZh)">&times;</button>
               </div>
             </template>
           </div>
           <div class="meta-rule-editor__condition-actions">
-            <button class="meta-rule-editor__btn" type="button" data-action="add-condition" @click="addCondition">+ Add condition</button>
-            <button class="meta-rule-editor__btn" type="button" data-action="add-condition-group" @click="addGroupToGroup([])">+ Add group</button>
+            <button class="meta-rule-editor__btn" type="button" data-action="add-condition" @click="addCondition">{{ automationLabel('condition.addCondition', isZh) }}</button>
+            <button class="meta-rule-editor__btn" type="button" data-action="add-condition-group" @click="addGroupToGroup([])">{{ automationLabel('condition.addGroup', isZh) }}</button>
           </div>
         </section>
 
         <!-- 3. Actions -->
         <section class="meta-rule-editor__section">
-          <div class="meta-rule-editor__section-title">Actions <span class="meta-rule-editor__hint">(1-3 steps)</span></div>
+          <div class="meta-rule-editor__section-title">{{ automationLabel('editor.actions', isZh) }} <span class="meta-rule-editor__hint">{{ automationLabel('editor.actionStepHint', isZh) }}</span></div>
           <div
             v-for="(action, idx) in draft.actions"
             :key="idx"
@@ -223,19 +223,19 @@
             <div class="meta-rule-editor__action-header">
               <span class="meta-rule-editor__action-num">{{ idx + 1 }}.</span>
               <select v-model="action.type" class="meta-rule-editor__select" @change="onDraftActionTypeChange(action)">
-                <option value="update_record">Update record</option>
-                <option value="create_record">Create record</option>
-                <option value="send_webhook">Send webhook</option>
-                <option value="send_notification">Send notification</option>
-                <option value="send_email">Send email</option>
-                <option value="send_dingtalk_group_message">Send DingTalk group message</option>
-                <option value="send_dingtalk_person_message">Send DingTalk person message</option>
-                <option value="lock_record">Lock record</option>
+                <option value="update_record">{{ automationActionTypeLabel('update_record', isZh) }}</option>
+                <option value="create_record">{{ automationActionTypeLabel('create_record', isZh) }}</option>
+                <option value="send_webhook">{{ automationActionTypeLabel('send_webhook', isZh) }}</option>
+                <option value="send_notification">{{ automationActionTypeLabel('send_notification', isZh) }}</option>
+                <option value="send_email">{{ automationActionTypeLabel('send_email', isZh) }}</option>
+                <option value="send_dingtalk_group_message">{{ automationActionTypeLabel('send_dingtalk_group_message', isZh) }}</option>
+                <option value="send_dingtalk_person_message">{{ automationActionTypeLabel('send_dingtalk_person_message', isZh) }}</option>
+                <option value="lock_record">{{ automationActionTypeLabel('lock_record', isZh) }}</option>
               </select>
               <div class="meta-rule-editor__action-btns">
-                <button v-if="idx > 0" class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="moveAction(idx, -1)" title="Move up">&#x2191;</button>
-                <button v-if="idx < draft.actions.length - 1" class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="moveAction(idx, 1)" title="Move down">&#x2193;</button>
-                <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeAction(idx)" title="Remove action">&times;</button>
+                <button v-if="idx > 0" class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="moveAction(idx, -1)" :title="automationLabel('editor.moveUpTitle', isZh)">&#x2191;</button>
+                <button v-if="idx < draft.actions.length - 1" class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="moveAction(idx, 1)" :title="automationLabel('editor.moveDownTitle', isZh)">&#x2193;</button>
+                <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeAction(idx)" :title="automationLabel('editor.removeActionTitle', isZh)">&times;</button>
               </div>
             </div>
 
@@ -243,32 +243,32 @@
             <div v-if="action.type === 'update_record'" class="meta-rule-editor__action-config">
               <div v-for="(pair, pidx) in (action.config.fieldUpdates as FieldPair[] || [])" :key="pidx" class="meta-rule-editor__field-pair">
                 <select v-model="pair.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm">
-                  <option value="">-- field --</option>
+                  <option value="">{{ automationLabel('condition.selectField', isZh) }}</option>
                   <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
                 </select>
-                <input v-model="pair.value" class="meta-rule-editor__input meta-rule-editor__input--sm" type="text" placeholder="Value" />
+                <input v-model="pair.value" class="meta-rule-editor__input meta-rule-editor__input--sm" type="text" :placeholder="automationLabel('editor.value', isZh)" />
                 <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeFieldUpdate(action, pidx)">&times;</button>
               </div>
-              <button class="meta-rule-editor__btn" type="button" @click="addFieldUpdate(action)">+ Field</button>
+              <button class="meta-rule-editor__btn" type="button" @click="addFieldUpdate(action)">{{ automationLabel('editor.addField', isZh) }}</button>
             </div>
 
             <!-- create_record config -->
             <div v-if="action.type === 'create_record'" class="meta-rule-editor__action-config">
-              <label class="meta-rule-editor__label">Target sheet ID</label>
-              <input v-model="action.config.targetSheetId" class="meta-rule-editor__input" type="text" placeholder="Sheet ID" />
+              <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.targetSheetId', isZh) }}</label>
+              <input v-model="action.config.targetSheetId" class="meta-rule-editor__input" type="text" :placeholder="automationLabel('actionConfig.sheetIdPlaceholder', isZh)" />
               <div v-for="(pair, pidx) in (action.config.fieldValues as FieldPair[] || [])" :key="pidx" class="meta-rule-editor__field-pair">
-                <input v-model="pair.fieldId" class="meta-rule-editor__input meta-rule-editor__input--sm" type="text" placeholder="Field ID" />
-                <input v-model="pair.value" class="meta-rule-editor__input meta-rule-editor__input--sm" type="text" placeholder="Value" />
+                <input v-model="pair.fieldId" class="meta-rule-editor__input meta-rule-editor__input--sm" type="text" :placeholder="automationLabel('actionConfig.fieldIdPlaceholder', isZh)" />
+                <input v-model="pair.value" class="meta-rule-editor__input meta-rule-editor__input--sm" type="text" :placeholder="automationLabel('editor.value', isZh)" />
                 <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeCreateFieldValue(action, pidx)">&times;</button>
               </div>
-              <button class="meta-rule-editor__btn" type="button" @click="addCreateFieldValue(action)">+ Field</button>
+              <button class="meta-rule-editor__btn" type="button" @click="addCreateFieldValue(action)">{{ automationLabel('editor.addField', isZh) }}</button>
             </div>
 
             <!-- send_webhook config -->
             <div v-if="action.type === 'send_webhook'" class="meta-rule-editor__action-config">
-              <label class="meta-rule-editor__label">URL</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.url', isZh) }}</label>
               <input v-model="action.config.url" class="meta-rule-editor__input" type="url" placeholder="https://..." />
-              <label class="meta-rule-editor__label">Method</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.method', isZh) }}</label>
               <select v-model="action.config.method" class="meta-rule-editor__select">
                 <option value="POST">POST</option>
                 <option value="PUT">PUT</option>
@@ -278,15 +278,15 @@
 
             <!-- send_notification config -->
             <div v-if="action.type === 'send_notification'" class="meta-rule-editor__action-config">
-              <label class="meta-rule-editor__label">User ID</label>
-              <input v-model="action.config.userId" class="meta-rule-editor__input" type="text" placeholder="User ID" />
-              <label class="meta-rule-editor__label">Message</label>
-              <textarea v-model="action.config.message" class="meta-rule-editor__textarea" placeholder="Notification message" rows="3"></textarea>
+              <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.userId', isZh) }}</label>
+              <input v-model="action.config.userId" class="meta-rule-editor__input" type="text" :placeholder="automationLabel('actionConfig.userId', isZh)" />
+              <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.message', isZh) }}</label>
+              <textarea v-model="action.config.message" class="meta-rule-editor__textarea" :placeholder="automationLabel('actionConfig.notificationMessagePlaceholder', isZh)" rows="3"></textarea>
             </div>
 
             <!-- send_email config -->
             <div v-if="action.type === 'send_email'" class="meta-rule-editor__action-config">
-              <label class="meta-rule-editor__label">Recipients</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.recipients', isZh) }}</label>
               <textarea
                 v-model="action.config.recipientsText"
                 class="meta-rule-editor__textarea"
@@ -294,21 +294,21 @@
                 placeholder="ops@example.com, owner@example.com"
                 data-field="emailRecipients"
               ></textarea>
-              <div class="meta-rule-editor__hint">Use comma or newline separated email addresses. Delivery uses the NotificationService email channel.</div>
-              <label class="meta-rule-editor__label">Subject template</label>
+              <div class="meta-rule-editor__hint">{{ automationLabel('actionConfig.emailRecipientsHint', isZh) }}</div>
+              <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.subjectTemplate', isZh) }}</label>
               <input
                 v-model="action.config.subjectTemplate"
                 class="meta-rule-editor__input"
                 type="text"
-                placeholder="{{record.title}} needs attention"
+                :placeholder="automationLabel('actionConfig.emailSubjectPlaceholder', isZh)"
                 data-field="emailSubjectTemplate"
               />
-              <label class="meta-rule-editor__label">Body template</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('actionConfig.bodyTemplate', isZh) }}</label>
               <textarea
                 v-model="action.config.bodyTemplate"
                 class="meta-rule-editor__textarea"
                 rows="4"
-                placeholder="Record {{recordId}} changed. Status: {{record.status}}"
+                :placeholder="automationLabel('actionConfig.emailBodyPlaceholder', isZh)"
                 data-field="emailBodyTemplate"
               ></textarea>
             </div>
@@ -874,7 +874,7 @@
             <div v-if="action.type === 'lock_record'" class="meta-rule-editor__action-config">
               <label class="meta-rule-editor__toggle-label">
                 <input type="checkbox" v-model="action.config.locked" />
-                Lock record
+                {{ automationLabel('actionConfig.lockRecord', isZh) }}
               </label>
             </div>
           </div>
@@ -884,7 +884,7 @@
             type="button"
             data-action="add-action"
             @click="addAction"
-          >+ Add action</button>
+          >{{ automationLabel('editor.addAction', isZh) }}</button>
         </section>
       </div>
 
@@ -892,10 +892,10 @@
       <div class="meta-rule-editor__footer">
         <div class="meta-rule-editor__test-run-feedback">
           <div v-if="savedRuleHasDingTalkActions" class="meta-rule-editor__hint meta-rule-editor__hint--warning" data-field="dingtalkTestRunWarning">
-            Test Run executes the saved rule and can send real DingTalk messages to configured groups or users.
+            {{ automationLabel('testRun.warning', isZh) }}
           </div>
           <div v-if="!props.rule?.id" class="meta-rule-editor__hint" data-field="testRunUnsavedHint">
-            Save this automation before running a test.
+            {{ automationLabel('testRun.unsavedHint', isZh) }}
           </div>
           <div
             v-if="props.testRunState"
@@ -908,7 +908,7 @@
           </div>
         </div>
         <button class="meta-rule-editor__btn meta-rule-editor__btn--primary" type="button" :disabled="!canSave || saving" data-action="save" @click="onSave">
-          {{ saving ? 'Saving...' : 'Save' }}
+          {{ saving ? automationLabel('editor.saving', isZh) : automationLabel('editor.save', isZh) }}
         </button>
         <button
           class="meta-rule-editor__btn"
@@ -917,9 +917,9 @@
           @click="onTestRun"
           data-action="test"
         >
-          {{ props.testRunState?.status === 'running' ? 'Running...' : 'Test Run' }}
+          {{ props.testRunState?.status === 'running' ? automationLabel('testRun.running', isZh) : automationLabel('testRun.button', isZh) }}
         </button>
-        <button class="meta-rule-editor__btn" type="button" @click="$emit('close')">Cancel</button>
+        <button class="meta-rule-editor__btn" type="button" @click="$emit('close')">{{ automationLabel('editor.cancel', isZh) }}</button>
       </div>
     </div>
   </div>
@@ -927,6 +927,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, onBeforeUnmount } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type { MultitableApiClient } from '../api/client'
 import type {
   AutomationRule,
@@ -964,6 +965,15 @@ import {
   listDingTalkInternalViewLinkBlockingErrors,
   listDingTalkInternalViewLinkWarnings,
 } from '../utils/dingtalkInternalViewLinkWarnings'
+import {
+  automationActionTypeLabel,
+  automationConditionOperatorLabel,
+  automationConditionValuePlaceholder,
+  automationCronPresetLabel,
+  automationLabel,
+  automationTriggerConditionLabel,
+  automationTriggerTypeLabel,
+} from '../utils/meta-automation-labels'
 
 interface FieldPair {
   fieldId: string
@@ -1059,6 +1069,7 @@ const personRecipientDirectory = ref<Record<string, PersonRecipientDirectoryEntr
 const copiedPreviewKey = ref('')
 let personRecipientSuggestionLoadId = 0
 let copiedPreviewResetTimer: ReturnType<typeof setTimeout> | null = null
+const { isZh } = useLocale()
 
 const formViews = computed(() => (props.views ?? []).filter((view) =>
   view.type === 'form' && (!view.sheetId || view.sheetId === props.sheetId),
@@ -1068,8 +1079,10 @@ const groupDestinationCandidateFields = computed(() => props.fields)
 const recipientCandidateFields = computed(() => props.fields.filter((field) => field.type === 'user'))
 const memberGroupRecipientCandidateFields = computed(() => props.fields.filter(isDingTalkMemberGroupRecipientField))
 const savedRuleHasDingTalkActions = computed(() => ruleHasDingTalkActions(props.rule))
-const DINGTALK_TEST_RUN_CONFIRM_MESSAGE =
-  'Test Run executes the saved rule and can send real DingTalk messages to configured groups or users. Unsaved changes are not included. Continue?'
+function dingTalkTestRunConfirmMessage(): string {
+  const separator = isZh.value ? '' : ' '
+  return `${automationLabel('testRun.warning', isZh.value)}${separator}${automationLabel('testRun.confirmSuffix', isZh.value)}`
+}
 
 type ConditionOperatorOption = { value: ConditionOperator; label: string }
 type ConditionValueWidget = 'text' | 'number' | 'date' | 'dateTime' | 'boolean' | 'booleanMultiSelect' | 'select' | 'multiSelect'
@@ -1308,11 +1321,7 @@ function isArrayOperator(op: ConditionOperator): boolean {
 }
 
 function conditionValuePlaceholder(condition: AutomationCondition): string {
-  if (isArrayOperator(condition.operator)) return 'Comma-separated values'
-  if (conditionValueWidget(condition) === 'number') return 'Number'
-  if (conditionValueWidget(condition) === 'date') return 'YYYY-MM-DD'
-  if (conditionValueWidget(condition) === 'dateTime') return 'Date and time'
-  return 'Value'
+  return automationConditionValuePlaceholder(conditionValueWidget(condition), isArrayOperator(condition.operator), isZh.value)
 }
 
 function isConditionGroupNode(node: AutomationConditionNode): node is ConditionGroup {
@@ -2392,7 +2401,7 @@ async function onSave() {
   try {
     emit('save', buildPayload())
   } catch (e: unknown) {
-    error.value = e instanceof Error ? e.message : 'Save failed'
+    error.value = e instanceof Error ? e.message : automationLabel('error.saveFailed', isZh.value)
   } finally {
     saving.value = false
   }
@@ -2400,7 +2409,7 @@ async function onSave() {
 
 function onTestRun() {
   if (saving.value || props.testRunState?.status === 'running' || !props.rule?.id) return
-  if (savedRuleHasDingTalkActions.value && !window.confirm(DINGTALK_TEST_RUN_CONFIRM_MESSAGE)) return
+  if (savedRuleHasDingTalkActions.value && !window.confirm(dingTalkTestRunConfirmMessage())) return
   emit('test', props.rule.id)
 }
 </script>

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -4,9 +4,34 @@
 // names, IDs, persisted enum values, backend/runtime errors, and redacted
 // support-packet content stay raw.
 
-import type { AutomationActionType, AutomationExecution } from '../types'
+import type {
+  AutomationActionType,
+  AutomationExecution,
+  AutomationTriggerType,
+  ConditionOperator,
+} from '../types'
 
 export type AutomationStatus = AutomationExecution['status'] | 'running'
+
+// Keep in sync with MetaAutomationRuleEditor.vue ConditionValueWidget.
+export type AutomationConditionValueWidget =
+  | 'text'
+  | 'number'
+  | 'date'
+  | 'dateTime'
+  | 'boolean'
+  | 'booleanMultiSelect'
+  | 'select'
+  | 'multiSelect'
+
+export type AutomationTriggerCondition = 'any' | 'equals' | 'changed_to'
+
+export type AutomationCronPresetValue =
+  | '*/5 * * * *'
+  | '0 * * * *'
+  | '0 0 * * *'
+  | '0 0 * * 1'
+  | 'custom'
 
 export type AutomationLabelKey =
   | 'log.title'
@@ -33,13 +58,70 @@ export type AutomationLabelKey =
   | 'delivery.dingtalkPrefix'
   | 'delivery.statusSkippedUnbound'
   | 'delivery.unboundReason'
+  | 'editor.titleEdit'
+  | 'editor.titleNew'
+  | 'editor.name'
+  | 'editor.namePlaceholder'
+  | 'editor.value'
+  | 'editor.save'
+  | 'editor.saving'
+  | 'editor.cancel'
+  | 'editor.actions'
+  | 'editor.actionStepHint'
+  | 'editor.addField'
+  | 'editor.addAction'
+  | 'editor.moveUpTitle'
+  | 'editor.moveDownTitle'
+  | 'editor.removeActionTitle'
+  | 'trigger.title'
+  | 'trigger.watchField'
+  | 'trigger.selectField'
+  | 'trigger.condition'
+  | 'trigger.preset'
+  | 'trigger.cronExpression'
+  | 'trigger.intervalMinutes'
+  | 'condition.title'
+  | 'condition.optional'
+  | 'condition.and'
+  | 'condition.or'
+  | 'condition.group'
+  | 'condition.addNestedCondition'
+  | 'condition.addNestedGroup'
+  | 'condition.removeGroupTitle'
+  | 'condition.selectField'
+  | 'condition.selectValue'
+  | 'condition.addCondition'
+  | 'condition.addGroup'
+  | 'condition.removeConditionTitle'
+  | 'actionConfig.targetSheetId'
+  | 'actionConfig.sheetIdPlaceholder'
+  | 'actionConfig.fieldIdPlaceholder'
+  | 'actionConfig.url'
+  | 'actionConfig.method'
+  | 'actionConfig.userId'
+  | 'actionConfig.message'
+  | 'actionConfig.notificationMessagePlaceholder'
+  | 'actionConfig.recipients'
+  | 'actionConfig.emailRecipientsHint'
+  | 'actionConfig.subjectTemplate'
+  | 'actionConfig.emailSubjectPlaceholder'
+  | 'actionConfig.bodyTemplate'
+  | 'actionConfig.emailBodyPlaceholder'
+  | 'actionConfig.lockRecord'
+  | 'testRun.warning'
+  | 'testRun.confirmSuffix'
+  | 'testRun.unsavedHint'
+  | 'testRun.button'
+  | 'testRun.running'
   | 'error.loadGroupDeliveries'
   | 'error.loadPersonDeliveries'
+  | 'error.saveFailed'
   | 'error.unknown'
   | 'status.all'
   | 'status.success'
   | 'status.failed'
   | 'status.skipped'
+  | 'status.running'
 
 export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'log.title',
@@ -66,13 +148,70 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'delivery.dingtalkPrefix',
   'delivery.statusSkippedUnbound',
   'delivery.unboundReason',
+  'editor.titleEdit',
+  'editor.titleNew',
+  'editor.name',
+  'editor.namePlaceholder',
+  'editor.value',
+  'editor.save',
+  'editor.saving',
+  'editor.cancel',
+  'editor.actions',
+  'editor.actionStepHint',
+  'editor.addField',
+  'editor.addAction',
+  'editor.moveUpTitle',
+  'editor.moveDownTitle',
+  'editor.removeActionTitle',
+  'trigger.title',
+  'trigger.watchField',
+  'trigger.selectField',
+  'trigger.condition',
+  'trigger.preset',
+  'trigger.cronExpression',
+  'trigger.intervalMinutes',
+  'condition.title',
+  'condition.optional',
+  'condition.and',
+  'condition.or',
+  'condition.group',
+  'condition.addNestedCondition',
+  'condition.addNestedGroup',
+  'condition.removeGroupTitle',
+  'condition.selectField',
+  'condition.selectValue',
+  'condition.addCondition',
+  'condition.addGroup',
+  'condition.removeConditionTitle',
+  'actionConfig.targetSheetId',
+  'actionConfig.sheetIdPlaceholder',
+  'actionConfig.fieldIdPlaceholder',
+  'actionConfig.url',
+  'actionConfig.method',
+  'actionConfig.userId',
+  'actionConfig.message',
+  'actionConfig.notificationMessagePlaceholder',
+  'actionConfig.recipients',
+  'actionConfig.emailRecipientsHint',
+  'actionConfig.subjectTemplate',
+  'actionConfig.emailSubjectPlaceholder',
+  'actionConfig.bodyTemplate',
+  'actionConfig.emailBodyPlaceholder',
+  'actionConfig.lockRecord',
+  'testRun.warning',
+  'testRun.confirmSuffix',
+  'testRun.unsavedHint',
+  'testRun.button',
+  'testRun.running',
   'error.loadGroupDeliveries',
   'error.loadPersonDeliveries',
+  'error.saveFailed',
   'error.unknown',
   'status.all',
   'status.success',
   'status.failed',
   'status.skipped',
+  'status.running',
 ]
 
 const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
@@ -100,13 +239,70 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'delivery.dingtalkPrefix': { en: 'DingTalk', zh: '钉钉' },
   'delivery.statusSkippedUnbound': { en: 'Skipped / unbound', zh: '跳过 / 未绑定' },
   'delivery.unboundReason': { en: 'DingTalk account is not linked or user is inactive', zh: '钉钉账号未绑定或用户已停用' },
+  'editor.titleEdit': { en: 'Edit Automation Rule', zh: '编辑自动化规则' },
+  'editor.titleNew': { en: 'New Automation Rule', zh: '新建自动化规则' },
+  'editor.name': { en: 'Name', zh: '名称' },
+  'editor.namePlaceholder': { en: 'Automation name', zh: '自动化名称' },
+  'editor.value': { en: 'Value', zh: '值' },
+  'editor.save': { en: 'Save', zh: '保存' },
+  'editor.saving': { en: 'Saving...', zh: '正在保存...' },
+  'editor.cancel': { en: 'Cancel', zh: '取消' },
+  'editor.actions': { en: 'Actions', zh: '动作' },
+  'editor.actionStepHint': { en: '(1-3 steps)', zh: '（1-3 步）' },
+  'editor.addField': { en: '+ Field', zh: '+ 字段' },
+  'editor.addAction': { en: '+ Add action', zh: '+ 添加动作' },
+  'editor.moveUpTitle': { en: 'Move up', zh: '上移' },
+  'editor.moveDownTitle': { en: 'Move down', zh: '下移' },
+  'editor.removeActionTitle': { en: 'Remove action', zh: '移除动作' },
+  'trigger.title': { en: 'Trigger', zh: '触发器' },
+  'trigger.watchField': { en: 'Watch field', zh: '监听字段' },
+  'trigger.selectField': { en: '-- select field --', zh: '-- 选择字段 --' },
+  'trigger.condition': { en: 'Condition', zh: '条件' },
+  'trigger.preset': { en: 'Preset', zh: '预设' },
+  'trigger.cronExpression': { en: 'Cron expression', zh: 'Cron 表达式' },
+  'trigger.intervalMinutes': { en: 'Interval (minutes)', zh: '间隔（分钟）' },
+  'condition.title': { en: 'Conditions', zh: '条件' },
+  'condition.optional': { en: '(optional)', zh: '（可选）' },
+  'condition.and': { en: 'AND', zh: '且' },
+  'condition.or': { en: 'OR', zh: '或' },
+  'condition.group': { en: 'Group', zh: '条件组' },
+  'condition.addNestedCondition': { en: '+ Condition', zh: '+ 条件' },
+  'condition.addNestedGroup': { en: '+ Group', zh: '+ 条件组' },
+  'condition.removeGroupTitle': { en: 'Remove group', zh: '移除条件组' },
+  'condition.selectField': { en: '-- field --', zh: '-- 字段 --' },
+  'condition.selectValue': { en: '-- value --', zh: '-- 值 --' },
+  'condition.addCondition': { en: '+ Add condition', zh: '+ 添加条件' },
+  'condition.addGroup': { en: '+ Add group', zh: '+ 添加条件组' },
+  'condition.removeConditionTitle': { en: 'Remove condition', zh: '移除条件' },
+  'actionConfig.targetSheetId': { en: 'Target sheet ID', zh: '目标工作表 ID' },
+  'actionConfig.sheetIdPlaceholder': { en: 'Sheet ID', zh: '工作表 ID' },
+  'actionConfig.fieldIdPlaceholder': { en: 'Field ID', zh: '字段 ID' },
+  'actionConfig.url': { en: 'URL', zh: 'URL' },
+  'actionConfig.method': { en: 'Method', zh: '方法' },
+  'actionConfig.userId': { en: 'User ID', zh: '用户 ID' },
+  'actionConfig.message': { en: 'Message', zh: '消息' },
+  'actionConfig.notificationMessagePlaceholder': { en: 'Notification message', zh: '通知内容' },
+  'actionConfig.recipients': { en: 'Recipients', zh: '收件人' },
+  'actionConfig.emailRecipientsHint': { en: 'Use comma or newline separated email addresses. Delivery uses the NotificationService email channel.', zh: '使用逗号或换行分隔邮箱地址。投递使用 NotificationService 邮件通道。' },
+  'actionConfig.subjectTemplate': { en: 'Subject template', zh: '主题模板' },
+  'actionConfig.emailSubjectPlaceholder': { en: '{{record.title}} needs attention', zh: '{{record.title}} 需要处理' },
+  'actionConfig.bodyTemplate': { en: 'Body template', zh: '正文模板' },
+  'actionConfig.emailBodyPlaceholder': { en: 'Record {{recordId}} changed. Status: {{record.status}}', zh: '记录 {{recordId}} 已变更。状态：{{record.status}}' },
+  'actionConfig.lockRecord': { en: 'Lock record', zh: '锁定记录' },
+  'testRun.warning': { en: 'Test Run executes the saved rule and can send real DingTalk messages to configured groups or users.', zh: '测试运行会执行已保存规则，并可能向已配置的钉钉群或用户发送真实消息。' },
+  'testRun.confirmSuffix': { en: 'Unsaved changes are not included. Continue?', zh: '未保存的更改不会包含在内。是否继续？' },
+  'testRun.unsavedHint': { en: 'Save this automation before running a test.', zh: '请先保存此自动化，再运行测试。' },
+  'testRun.button': { en: 'Test Run', zh: '测试运行' },
+  'testRun.running': { en: 'Running...', zh: '正在运行...' },
   'error.loadGroupDeliveries': { en: 'Failed to load DingTalk group deliveries.', zh: '加载钉钉群投递记录失败。' },
   'error.loadPersonDeliveries': { en: 'Failed to load DingTalk person deliveries.', zh: '加载钉钉个人投递记录失败。' },
+  'error.saveFailed': { en: 'Save failed', zh: '保存失败' },
   'error.unknown': { en: 'Unknown error', zh: '未知错误' },
   'status.all': { en: 'All statuses', zh: '全部状态' },
   'status.success': { en: 'success', zh: '成功' },
   'status.failed': { en: 'failed', zh: '失败' },
   'status.skipped': { en: 'skipped', zh: '跳过' },
+  'status.running': { en: 'running', zh: '运行中' },
 }
 
 export function automationLabel(key: AutomationLabelKey, isZh: boolean): string {
@@ -118,7 +314,7 @@ export function automationStatusLabel(status: AutomationStatus | (string & {}), 
   if (status === 'success') return automationLabel('status.success', isZh)
   if (status === 'failed') return automationLabel('status.failed', isZh)
   if (status === 'skipped') return automationLabel('status.skipped', isZh)
-  if (status === 'running') return isZh ? '运行中' : 'running'
+  if (status === 'running') return automationLabel('status.running', isZh)
   return String(status)
 }
 
@@ -146,6 +342,98 @@ export function automationActionTypeLabel(type: AutomationActionType | (string &
     default:
       return String(type)
   }
+}
+
+export function automationTriggerTypeLabel(type: AutomationTriggerType | (string & {}), isZh: boolean): string {
+  switch (type) {
+    case 'record.created':
+      return isZh ? '当记录创建时' : 'When record created'
+    case 'record.updated':
+      return isZh ? '当记录更新时' : 'When record updated'
+    case 'record.deleted':
+      return isZh ? '当记录删除时' : 'When record deleted'
+    case 'field.value_changed':
+      return isZh ? '当字段值变化时' : 'When field value changed'
+    case 'schedule.cron':
+      return isZh ? '定时计划（cron）' : 'Schedule (cron)'
+    case 'schedule.interval':
+      return isZh ? '定时计划（间隔）' : 'Schedule (interval)'
+    case 'webhook.received':
+      return isZh ? '收到 Webhook 时' : 'Webhook received'
+    case 'field.changed':
+      return isZh ? '当字段变化时' : 'When field changed'
+    default:
+      return String(type)
+  }
+}
+
+export function automationTriggerConditionLabel(condition: AutomationTriggerCondition | (string & {}), isZh: boolean): string {
+  switch (condition) {
+    case 'any':
+      return isZh ? '任意变化' : 'Any change'
+    case 'equals':
+      return isZh ? '等于' : 'Equals'
+    case 'changed_to':
+      return isZh ? '变更为' : 'Changed to'
+    default:
+      return String(condition)
+  }
+}
+
+export function automationCronPresetLabel(value: AutomationCronPresetValue | (string & {}), isZh: boolean): string {
+  switch (value) {
+    case '*/5 * * * *':
+      return isZh ? '每 5 分钟' : 'Every 5 minutes'
+    case '0 * * * *':
+      return isZh ? '每小时' : 'Every hour'
+    case '0 0 * * *':
+      return isZh ? '每天午夜' : 'Daily at midnight'
+    case '0 0 * * 1':
+      return isZh ? '每周一' : 'Weekly (Monday)'
+    case 'custom':
+      return isZh ? '自定义' : 'Custom'
+    default:
+      return String(value)
+  }
+}
+
+export function automationConditionOperatorLabel(operator: ConditionOperator | (string & {}), isZh: boolean): string {
+  switch (operator) {
+    case 'equals':
+      return isZh ? '等于' : 'Equals'
+    case 'not_equals':
+      return isZh ? '不等于' : 'Not equals'
+    case 'contains':
+      return isZh ? '包含' : 'Contains'
+    case 'not_contains':
+      return isZh ? '不包含' : 'Not contains'
+    case 'greater_than':
+      return isZh ? '大于' : 'Greater than'
+    case 'less_than':
+      return isZh ? '小于' : 'Less than'
+    case 'greater_or_equal':
+      return isZh ? '大于等于' : 'Greater or equal'
+    case 'less_or_equal':
+      return isZh ? '小于等于' : 'Less or equal'
+    case 'is_empty':
+      return isZh ? '为空' : 'Is empty'
+    case 'is_not_empty':
+      return isZh ? '不为空' : 'Is not empty'
+    case 'in':
+      return isZh ? '在列表中' : 'In list'
+    case 'not_in':
+      return isZh ? '不在列表中' : 'Not in list'
+    default:
+      return String(operator)
+  }
+}
+
+export function automationConditionValuePlaceholder(widget: AutomationConditionValueWidget, isArray: boolean, isZh: boolean): string {
+  if (isArray) return isZh ? '逗号分隔的值' : 'Comma-separated values'
+  if (widget === 'number') return isZh ? '数字' : 'Number'
+  if (widget === 'date') return 'YYYY-MM-DD'
+  if (widget === 'dateTime') return isZh ? '日期和时间' : 'Date and time'
+  return isZh ? '值' : 'Value'
 }
 
 export function supportCopyFailed(message: string, isZh: boolean): string {

--- a/apps/web/tests/meta-automation-labels.spec.ts
+++ b/apps/web/tests/meta-automation-labels.spec.ts
@@ -3,8 +3,13 @@ import { describe, expect, it } from 'vitest'
 import {
   AUTOMATION_LABEL_KEYS,
   automationActionTypeLabel,
+  automationConditionOperatorLabel,
+  automationConditionValuePlaceholder,
+  automationCronPresetLabel,
   automationLabel,
   automationStatusLabel,
+  automationTriggerConditionLabel,
+  automationTriggerTypeLabel,
   supportCopyFailed,
   supportDownloadFailed,
 } from '../src/multitable/utils/meta-automation-labels'
@@ -20,6 +25,8 @@ describe('meta-automation-labels', () => {
   })
 
   it('localizes automation statuses and preserves unknown status values raw', () => {
+    expect(automationLabel('status.running', false)).toBe('running')
+    expect(automationLabel('status.running', true)).toBe('运行中')
     expect(automationStatusLabel('success', false)).toBe('success')
     expect(automationStatusLabel('success', true)).toBe('成功')
     expect(automationStatusLabel('failed', true)).toBe('失败')
@@ -35,6 +42,50 @@ describe('meta-automation-labels', () => {
     expect(automationActionTypeLabel('notify', true)).toBe('发送通知')
     expect(automationActionTypeLabel('update_field', true)).toBe('更新字段值')
     expect(automationActionTypeLabel('future_action', true)).toBe('future_action')
+  })
+
+  it('localizes trigger types, trigger conditions, and cron presets with raw fallbacks', () => {
+    expect(automationTriggerTypeLabel('record.created', false)).toBe('When record created')
+    expect(automationTriggerTypeLabel('record.created', true)).toBe('当记录创建时')
+    expect(automationTriggerTypeLabel('field.changed', true)).toBe('当字段变化时')
+    expect(automationTriggerTypeLabel('future.trigger', true)).toBe('future.trigger')
+
+    expect(automationTriggerConditionLabel('any', true)).toBe('任意变化')
+    expect(automationTriggerConditionLabel('equals', true)).toBe('等于')
+    expect(automationTriggerConditionLabel('changed_to', true)).toBe('变更为')
+    expect(automationTriggerConditionLabel('future_condition', true)).toBe('future_condition')
+
+    expect(automationCronPresetLabel('*/5 * * * *', true)).toBe('每 5 分钟')
+    expect(automationCronPresetLabel('0 0 * * 1', true)).toBe('每周一')
+    expect(automationCronPresetLabel('custom', true)).toBe('自定义')
+    expect(automationCronPresetLabel('0 30 9 * *', true)).toBe('0 30 9 * *')
+  })
+
+  it('localizes condition operators and value placeholders with raw fallbacks', () => {
+    expect(automationConditionOperatorLabel('equals', false)).toBe('Equals')
+    expect(automationConditionOperatorLabel('equals', true)).toBe('等于')
+    expect(automationConditionOperatorLabel('not_equals', true)).toBe('不等于')
+    expect(automationConditionOperatorLabel('contains', true)).toBe('包含')
+    expect(automationConditionOperatorLabel('not_contains', true)).toBe('不包含')
+    expect(automationConditionOperatorLabel('greater_than', true)).toBe('大于')
+    expect(automationConditionOperatorLabel('less_than', true)).toBe('小于')
+    expect(automationConditionOperatorLabel('greater_or_equal', true)).toBe('大于等于')
+    expect(automationConditionOperatorLabel('less_or_equal', true)).toBe('小于等于')
+    expect(automationConditionOperatorLabel('is_empty', true)).toBe('为空')
+    expect(automationConditionOperatorLabel('is_not_empty', true)).toBe('不为空')
+    expect(automationConditionOperatorLabel('in', true)).toBe('在列表中')
+    expect(automationConditionOperatorLabel('not_in', true)).toBe('不在列表中')
+    expect(automationConditionOperatorLabel('future_operator', true)).toBe('future_operator')
+
+    expect(automationConditionValuePlaceholder('text', false, false)).toBe('Value')
+    expect(automationConditionValuePlaceholder('text', false, true)).toBe('值')
+    expect(automationConditionValuePlaceholder('number', false, true)).toBe('数字')
+    expect(automationConditionValuePlaceholder('date', false, true)).toBe('YYYY-MM-DD')
+    expect(automationConditionValuePlaceholder('dateTime', false, true)).toBe('日期和时间')
+    expect(automationConditionValuePlaceholder('boolean', true, true)).toBe('逗号分隔的值')
+    expect(automationConditionValuePlaceholder('booleanMultiSelect', false, true)).toBe('值')
+    expect(automationConditionValuePlaceholder('select', false, true)).toBe('值')
+    expect(automationConditionValuePlaceholder('multiSelect', false, true)).toBe('值')
   })
 
   it('keeps support failure messages as localized chrome plus raw detail', () => {

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -6,6 +6,7 @@ function flushPromises() {
 }
 
 import MetaAutomationRuleEditor from '../src/multitable/components/MetaAutomationRuleEditor.vue'
+import { useLocale } from '../src/composables/useLocale'
 import type { AutomationRule, ConditionGroup } from '../src/multitable/types'
 
 const fields = [
@@ -207,6 +208,7 @@ describe('MetaAutomationRuleEditor', () => {
       configurable: true,
       value: originalClipboard,
     })
+    useLocale().setLocale('en')
   })
 
   it('renders trigger type selector when visible', async () => {
@@ -216,6 +218,142 @@ describe('MetaAutomationRuleEditor', () => {
     const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
     expect(triggerSelect).toBeTruthy()
     expect(triggerSelect.options.length).toBe(7)
+  })
+
+  it('localizes core rule editor chrome in zh-CN while keeping raw select values', async () => {
+    useLocale().setLocale('zh-CN')
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('新建自动化规则')
+    expect(text).toContain('名称')
+    expect(text).toContain('触发器')
+    expect(text).toContain('条件')
+    expect(text).toContain('动作')
+    expect(text).toContain('更新记录')
+    expect(text).toContain('发送钉钉群消息')
+    expect(text).not.toContain('New Automation Rule')
+    expect(text).not.toContain('When record created')
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    expect(nameInput.placeholder).toBe('自动化名称')
+
+    const triggerSelect = container.querySelector('[data-field="triggerType"]') as HTMLSelectElement
+    expect(triggerSelect.options[0]?.value).toBe('record.created')
+    expect(triggerSelect.options[0]?.textContent?.trim()).toBe('当记录创建时')
+    expect(triggerSelect.options[3]?.value).toBe('field.value_changed')
+    expect(triggerSelect.options[3]?.textContent?.trim()).toBe('当字段值变化时')
+
+    triggerSelect.value = 'schedule.cron'
+    triggerSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const cronSelect = container.querySelector('[data-field="cronPreset"]') as HTMLSelectElement
+    expect(cronSelect.options[0]?.value).toBe('*/5 * * * *')
+    expect(cronSelect.options[0]?.textContent?.trim()).toBe('每 5 分钟')
+  })
+
+  it('localizes condition builder labels and placeholders without translating field options', async () => {
+    useLocale().setLocale('zh-CN')
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="add-condition"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const conditionRow = container.querySelector('[data-condition-index="0"]') as HTMLElement
+    const [fieldSelect] = Array.from(conditionRow.querySelectorAll('select')) as HTMLSelectElement[]
+    expect(fieldSelect.options[0]?.textContent?.trim()).toBe('-- 字段 --')
+    expect(fieldSelect.options[1]?.textContent?.trim()).toBe('Status')
+
+    fieldSelect.value = 'fld_score'
+    fieldSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const operatorSelect = Array.from(conditionRow.querySelectorAll('select'))[1] as HTMLSelectElement
+    expect(operatorSelect.options[0]?.value).toBe('equals')
+    expect(operatorSelect.options[0]?.textContent?.trim()).toBe('等于')
+    operatorSelect.value = 'in'
+    operatorSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const valueInput = conditionRow.querySelector('input') as HTMLInputElement
+    expect(valueInput.placeholder).toBe('逗号分隔的值')
+  })
+
+  it('localizes non-DingTalk action config and keeps protocol/example placeholders raw', async () => {
+    useLocale().setLocale('zh-CN')
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    expect(actionSelect.options[0]?.value).toBe('update_record')
+    expect(actionSelect.options[0]?.textContent?.trim()).toBe('更新记录')
+
+    actionSelect.value = 'send_email'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const text = container.textContent ?? ''
+    expect(text).toContain('收件人')
+    expect(text).toContain('主题模板')
+    expect(text).toContain('正文模板')
+    expect(text).toContain('使用逗号或换行分隔邮箱地址。投递使用 NotificationService 邮件通道。')
+    expect((container.querySelector('[data-field="emailRecipients"]') as HTMLTextAreaElement).placeholder)
+      .toBe('ops@example.com, owner@example.com')
+    expect((container.querySelector('[data-field="emailSubjectTemplate"]') as HTMLInputElement).placeholder)
+      .toBe('{{record.title}} 需要处理')
+    expect((container.querySelector('[data-field="emailBodyTemplate"]') as HTMLTextAreaElement).placeholder)
+      .toBe('记录 {{recordId}} 已变更。状态：{{record.status}}')
+  })
+
+  it('localizes test-run warning and confirm text while leaving runtime status messages raw', async () => {
+    useLocale().setLocale('zh-CN')
+    const tested = vi.fn()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      rule: fakeRule({
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Ticket {{recordId}}',
+          bodyTemplate: 'Please fill',
+        },
+        actions: [{
+          type: 'send_dingtalk_group_message',
+          config: { destinationId: 'dt_1', titleTemplate: 'Ticket {{recordId}}', bodyTemplate: 'Please fill' },
+        }],
+      }),
+      testRunState: { status: 'success', message: 'Running test. DingTalk actions may send real messages.' },
+      onTest: tested,
+    })
+    await flushPromises()
+
+    expect(container.querySelector('[data-field="dingtalkTestRunWarning"]')?.textContent)
+      .toContain('测试运行会执行已保存规则')
+    expect(container.querySelector('[data-field="testRunStatus"]')?.textContent)
+      .toContain('Running test. DingTalk actions may send real messages.')
+
+    ;(container.querySelector('[data-action="test"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(tested).toHaveBeenCalledWith('rule_1')
+    expect(confirmSpy).toHaveBeenCalledWith('测试运行会执行已保存规则，并可能向已配置的钉钉群或用户发送真实消息。未保存的更改不会包含在内。是否继续？')
+  })
+
+  it('keeps representative a11y attribute counts unchanged after localization wiring', async () => {
+    useLocale().setLocale('zh-CN')
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+
+    expect(container.querySelectorAll('[aria-label]')).toHaveLength(0)
+    expect(container.querySelectorAll('[title]')).toHaveLength(1)
+    expect(container.querySelectorAll('[placeholder]')).toHaveLength(1)
   })
 
   it('shows field picker for field.value_changed trigger', async () => {

--- a/docs/development/multitable-t3d2-automation-rule-editor-i18n-design-20260521.md
+++ b/docs/development/multitable-t3d2-automation-rule-editor-i18n-design-20260521.md
@@ -1,0 +1,394 @@
+# Multitable T3D-2 Automation Rule Editor I18n Design - 2026-05-21
+
+## 1. Decision Summary
+
+T3D-2 is the second PR in the T3D automation i18n chain. T3D-1 has already landed `meta-automation-labels.ts` and localized the log/delivery viewers. T3D-2 extends that same automation-domain module and wires only the core `MetaAutomationRuleEditor.vue` chrome.
+
+Scope choice:
+- In scope: rule editor shell, trigger selector/config, schedule config, condition builder, non-DingTalk action config, action selector labels, save/test/cancel footer, test-run warning/confirm copy, and save fallback.
+- Out of scope: DingTalk group/person action configuration panels and shared DingTalk helper utilities. Those remain T3D-4 because they span manager + rule editor and include token helpers, recipient warnings, link summaries, and zh-only placeholder cleanup.
+
+This keeps the 2,748-line rule editor reviewable and avoids mixing the core enum-heavy editor with DingTalk-specific copy.
+
+## 2. Scout Facts
+
+Files:
+
+| File | Lines | Notes |
+| --- | ---: | --- |
+| `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue` | 2,748 | Core editor + large DingTalk subpanels in one component. |
+| `apps/web/tests/multitable-automation-rule-editor.spec.ts` | 3,154 | Existing behavior-heavy spec; reuse this instead of creating a new mount harness. |
+| `apps/web/src/multitable/utils/meta-automation-labels.ts` | 157 | T3D-1 module to extend. |
+
+Current a11y attribute counts in `MetaAutomationRuleEditor.vue` source:
+
+| Attribute | Source count | T3D-2 policy |
+| --- | ---: | --- |
+| `aria-label` | 0 | Do not add. |
+| `title=` | 5 | Localize existing title text only. Count remains unchanged. |
+| `placeholder=` | 25 | Localize in-scope core placeholders only. Count remains unchanged. |
+
+Typed source unions:
+
+| Type | Source |
+| --- | --- |
+| `AutomationTriggerType` | `types.ts`: `record.created`, `record.updated`, `record.deleted`, `field.value_changed`, `schedule.cron`, `schedule.interval`, `webhook.received`, legacy `field.changed`. |
+| `AutomationActionType` | `types.ts`: `update_record`, `create_record`, `send_webhook`, `send_notification`, `send_email`, `send_dingtalk_group_message`, `send_dingtalk_person_message`, `lock_record`, legacy `notify`, `update_field`. |
+| `ConditionOperator` | `types.ts`: `equals`, `not_equals`, `contains`, `not_contains`, `greater_than`, `less_than`, `greater_or_equal`, `less_or_equal`, `is_empty`, `is_not_empty`, `in`, `not_in`. |
+| `ConditionValueWidget` | `MetaAutomationRuleEditor.vue`: `text`, `number`, `date`, `dateTime`, `boolean`, `booleanMultiSelect`, `select`, `multiSelect`. |
+
+## 3. Files In Scope
+
+| File | Change |
+| --- | --- |
+| `apps/web/src/multitable/utils/meta-automation-labels.ts` | Extend T3D-1 module with editor/trigger/schedule/condition/action-config/test-run labels and helpers. |
+| `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue` | Wire core editor chrome to `useLocale()` + automation helpers. |
+| `apps/web/tests/meta-automation-labels.spec.ts` | Add helper/key coverage for T3D-2. |
+| `apps/web/tests/multitable-automation-rule-editor.spec.ts` | Add zh/en render assertions, raw-boundary assertions, a11y sentinel counts. |
+| `docs/development/multitable-t3d2-automation-rule-editor-i18n-verification-20260521.md` | Verification report after implementation. |
+
+Out of scope:
+
+| Area | Why |
+| --- | --- |
+| DingTalk group/person action panels, lines ~319-869 | T3D-4 owns shared DingTalk copy, token labels, recipient warnings, link summaries, and zh-only placeholder cleanup. |
+| `MetaAutomationManager.vue` | T3D-3. |
+| `dingtalk*.ts` helper utilities | T3D-4. |
+| Backend/contracts/migrations/attendance/K3 | T3D remains frontend i18n only. |
+
+## 4. Label Module Extension
+
+Extend the existing `apps/web/src/multitable/utils/meta-automation-labels.ts`.
+
+New or extended static key groups:
+
+| Namespace | Examples |
+| --- | --- |
+| `editor.*` | title create/edit, name, automation-name placeholder, save/saving/cancel, add field/action, select field/value. |
+| `trigger.*` | trigger section labels, trigger type labels, watch-field config, schedule labels. |
+| `condition.*` | conditions title, optional, group, add condition/group, remove titles, boolean/value placeholders. |
+| `actionConfig.*` | non-DingTalk action config labels/placeholders/hints for update/create/webhook/notification/email. |
+| `testRun.*` | test run button/running labels, unsaved hint, DingTalk warning, confirm text. |
+| `error.*` | save fallback only. Backend `Error.message` still wins. |
+| `status.running` | Convert T3D-1 inline `running` handling into a real label key. |
+
+Helper additions:
+
+```ts
+export type AutomationConditionValueWidget =
+  | 'text'
+  | 'number'
+  | 'date'
+  | 'dateTime'
+  | 'boolean'
+  | 'booleanMultiSelect'
+  | 'select'
+  | 'multiSelect'
+
+export type AutomationTriggerCondition = 'any' | 'equals' | 'changed_to'
+export type AutomationCronPresetValue =
+  | '*/5 * * * *'
+  | '0 * * * *'
+  | '0 0 * * *'
+  | '0 0 * * 1'
+  | 'custom'
+
+export function automationTriggerTypeLabel(type: AutomationTriggerType | (string & {}), isZh: boolean): string
+export function automationTriggerConditionLabel(condition: AutomationTriggerCondition | (string & {}), isZh: boolean): string
+export function automationCronPresetLabel(value: AutomationCronPresetValue | (string & {}), isZh: boolean): string
+export function automationConditionOperatorLabel(operator: ConditionOperator | (string & {}), isZh: boolean): string
+export function automationConditionValuePlaceholder(widget: AutomationConditionValueWidget, isArray: boolean, isZh: boolean): string
+```
+
+Rules:
+- All discriminator helpers must use explicit literal unions or imported project types. Do not accept plain `string` unless paired with `(string & {})` for unknown fallback.
+- Unknown trigger/action/operator/preset values return `String(value)` raw.
+- `automationActionTypeLabel(...)` already exists from T3D-1 and should be reused for action select labels.
+- `automationStatusLabel('running', ...)` should read `status.running` instead of inline text to keep the key map complete.
+
+## 5. Exact Chrome Targets
+
+### 5.1 Shell
+
+| Source | zh | Key/helper |
+| --- | --- | --- |
+| `Edit Automation Rule` | 编辑自动化规则 | `editor.titleEdit` |
+| `New Automation Rule` | 新建自动化规则 | `editor.titleNew` |
+| `Name` | 名称 | `editor.name` |
+| `Automation name` | 自动化名称 | `editor.namePlaceholder` |
+| `Save` / `Saving...` | 保存 / 正在保存... | `editor.save` / `editor.saving` |
+| `Cancel` | 取消 | `editor.cancel` |
+| `Save failed` | 保存失败 | `error.saveFailed` fallback only; raw `e.message` still wins. |
+
+### 5.2 Trigger + Schedule
+
+| Source | zh | Key/helper |
+| --- | --- | --- |
+| `Trigger` | 触发器 | `trigger.title` |
+| `When record created` | 当记录创建时 | `automationTriggerTypeLabel('record.created')` |
+| `When record updated` | 当记录更新时 | `automationTriggerTypeLabel('record.updated')` |
+| `When record deleted` | 当记录删除时 | `automationTriggerTypeLabel('record.deleted')` |
+| `When field value changed` | 当字段值变化时 | `automationTriggerTypeLabel('field.value_changed')` |
+| `Schedule (cron)` | 定时计划（cron） | `automationTriggerTypeLabel('schedule.cron')` |
+| `Schedule (interval)` | 定时计划（间隔） | `automationTriggerTypeLabel('schedule.interval')` |
+| `Webhook received` | 收到 Webhook 时 | `automationTriggerTypeLabel('webhook.received')` |
+| legacy `field.changed` | 当字段变化时 | `automationTriggerTypeLabel('field.changed')` |
+| `Watch field` | 监听字段 | `trigger.watchField` |
+| `-- select field --` | -- 选择字段 -- | `trigger.selectField` |
+| `Condition` | 条件 | `trigger.condition` |
+| `Any change` / `Equals` / `Changed to` | 任意变化 / 等于 / 变更为 | `automationTriggerConditionLabel(...)` |
+| `Value` | 值 | `editor.value` |
+| `Preset` | 预设 | `trigger.preset` |
+| `Every 5 minutes` | 每 5 分钟 | `automationCronPresetLabel('*/5 * * * *')` |
+| `Every hour` | 每小时 | `automationCronPresetLabel('0 * * * *')` |
+| `Daily at midnight` | 每天午夜 | `automationCronPresetLabel('0 0 * * *')` |
+| `Weekly (Monday)` | 每周一 | `automationCronPresetLabel('0 0 * * 1')` |
+| `Custom` | 自定义 | `automationCronPresetLabel('custom')` |
+| `Cron expression` | Cron 表达式 | `trigger.cronExpression` |
+| `Interval (minutes)` | 间隔（分钟） | `trigger.intervalMinutes` |
+
+Raw:
+- option `value` attributes (`record.created`, cron strings, `custom`) remain raw.
+- field names remain raw.
+- cron placeholder `* * * * *` and numeric placeholder `5` remain raw syntax examples.
+
+### 5.3 Condition Builder
+
+| Source | zh | Key/helper |
+| --- | --- | --- |
+| `Conditions` | 条件 | `condition.title` |
+| `(optional)` | （可选） | `condition.optional` |
+| `AND` / `OR` | 且 / 或 | `condition.and` / `condition.or` visible text only; raw model values stay uppercase. |
+| `Group` | 条件组 | `condition.group` |
+| `+ Condition` | + 条件 | `condition.addNestedCondition` |
+| `+ Group` | + 条件组 | `condition.addNestedGroup` |
+| `Remove group` | 移除条件组 | `condition.removeGroupTitle` |
+| `-- field --` | -- 字段 -- | `condition.selectField` |
+| `-- value --` | -- 值 -- | `condition.selectValue` |
+| `+ Add condition` | + 添加条件 | `condition.addCondition` |
+| `+ Add group` | + 添加条件组 | `condition.addGroup` |
+| `Remove condition` | 移除条件 | `condition.removeConditionTitle` |
+
+Operator labels:
+
+| Operator | zh |
+| --- | --- |
+| `equals` | 等于 |
+| `not_equals` | 不等于 |
+| `contains` | 包含 |
+| `not_contains` | 不包含 |
+| `greater_than` | 大于 |
+| `less_than` | 小于 |
+| `greater_or_equal` | 大于等于 |
+| `less_or_equal` | 小于等于 |
+| `is_empty` | 为空 |
+| `is_not_empty` | 不为空 |
+| `in` | 在列表中 |
+| `not_in` | 不在列表中 |
+
+Condition value placeholders:
+
+| Existing output | zh | Rule |
+| --- | --- | --- |
+| `Comma-separated values` | 逗号分隔的值 | `isArray=true`, regardless of widget. |
+| `Number` | 数字 | widget `number`. |
+| `YYYY-MM-DD` | `YYYY-MM-DD` | date syntax stays raw. |
+| `Date and time` | 日期和时间 | widget `dateTime`. |
+| `Value` | 值 | default. |
+
+Implementation note:
+- Refactor `ConditionOperatorOption` to keep raw `value` as the semantic source. Do not store localized labels in a static module-level array.
+- Template should render `automationConditionOperatorLabel(op.value, isZh)`.
+- `optionLabel(option)` for select/multi-select field options remains raw user/admin data.
+
+### 5.4 Action Selector + Non-DingTalk Action Config
+
+Action select labels use the existing `automationActionTypeLabel(...)`:
+
+| Action type | zh |
+| --- | --- |
+| `update_record` | 更新记录 |
+| `create_record` | 创建记录 |
+| `send_webhook` | 发送 Webhook |
+| `send_notification` / legacy `notify` | 发送通知 |
+| `send_email` | 发送邮件 |
+| `send_dingtalk_group_message` | 发送钉钉群消息 |
+| `send_dingtalk_person_message` | 发送钉钉个人消息 |
+| `lock_record` | 锁定记录 |
+| legacy `update_field` | 更新字段值 |
+
+Non-DingTalk config targets:
+
+| Source | zh | Notes |
+| --- | --- | --- |
+| `Actions` | 动作 | `editor.actions` |
+| `(1-3 steps)` | （1-3 步） | `editor.actionStepHint` |
+| `Move up` / `Move down` / `Remove action` | 上移 / 下移 / 移除动作 | title attrs only; count unchanged. |
+| `+ Field` | + 字段 | used in update/create record config. |
+| `Target sheet ID` | 目标工作表 ID | label. |
+| `Sheet ID` | 工作表 ID | placeholder. |
+| `Field ID` | 字段 ID | placeholder. |
+| `URL` / `Method` | URL / 方法 | URL stays unchanged. |
+| `User ID` / `Message` | 用户 ID / 消息 | notification config. |
+| `Notification message` | 通知内容 | placeholder. |
+| `Recipients` | 收件人 | email config. |
+| `Use comma or newline separated email addresses. Delivery uses the NotificationService email channel.` | 使用逗号或换行分隔邮箱地址。投递使用 NotificationService 邮件通道。 | hint. |
+| `Subject template` | 主题模板 | email config. |
+| `{{record.title}} needs attention` | `{{record.title}} 需要处理` | template placeholder; tokens remain raw. |
+| `Body template` | 正文模板 | email config. |
+| `Record {{recordId}} changed. Status: {{record.status}}` | `记录 {{recordId}} 已变更。状态：{{record.status}}` | template placeholder; tokens remain raw. |
+| `+ Add action` | + 添加动作 | footer of action list. |
+
+Raw:
+- `data-action`, `data-action-index`, and action `value` attributes remain raw.
+- HTTP methods `POST`/`PUT`/`GET` remain raw visible protocol values.
+- URL placeholder `https://...` remains raw.
+- email examples `ops@example.com, owner@example.com` remain raw.
+
+Deferred to T3D-4:
+- Everything inside `send_dingtalk_group_message` and `send_dingtalk_person_message` config panels except the action select visible labels.
+- Existing zh-only placeholders at lines 415/627/635/643/688/733 and related DingTalk helper copy.
+
+### 5.5 Footer + Test Run
+
+| Source | zh | Notes |
+| --- | --- | --- |
+| `Test Run executes the saved rule and can send real DingTalk messages to configured groups or users.` | 测试运行会执行已保存规则，并可能向已配置的钉钉群或用户发送真实消息。 | visible warning. |
+| Confirm string with `Unsaved changes are not included. Continue?` | 测试运行会执行已保存规则，并可能向已配置的钉钉群或用户发送真实消息。未保存的更改不会包含在内。是否继续？ | `window.confirm(...)` text. |
+| `Save this automation before running a test.` | 请先保存此自动化，再运行测试。 | unsaved hint. |
+| `Running...` / `Test Run` | 正在运行... / 测试运行 | button text. |
+| `props.testRunState.message` | raw | Runtime/parent-provided message remains raw for T3D-2. |
+
+## 6. Raw Boundary
+
+Preserve raw:
+- `data-field`, `data-action`, `data-condition-*`, `data-status`, `data-access-level`, CSS suffixes.
+- `<option value="...">` values for triggers, cron presets, trigger conditions, condition operators, booleans, action types, HTTP methods.
+- Field names, option labels, view names, DingTalk group/user names, rule names.
+- Record/template tokens such as `{{recordId}}`, `{{record.status}}`, `record.<fieldId>`.
+- Backend/runtime error text. Only static fallback `Save failed` is localized.
+- `props.testRunState.message`.
+
+Visible labels may be localized through helpers. Unknown enum values must render raw with `String(value)`.
+
+M1 trap guard:
+
+```vue
+<option :value="triggerType">
+  {{ automationTriggerTypeLabel(triggerType, isZh) }}
+</option>
+```
+
+Do not bind localized text to `value`, `data-*`, class suffixes, or model data.
+
+## 7. A11y Boundary
+
+T3D-2 localizes existing title/placeholder text. It must not add new a11y attributes.
+
+Required sentinel assertions in `multitable-automation-rule-editor.spec.ts`:
+- Fixture count for `[aria-label]` remains the same as before implementation.
+- Fixture count for `[title]` remains the same as before implementation.
+- Fixture count for `[placeholder]` remains the same as before implementation.
+
+Source-level scout found:
+- `aria-label`: 0
+- `title=`: 5
+- `placeholder=`: 25
+
+Implementation tests should measure the rendered fixture count after the wiring and assert the expected fixture-computed values. The source counts above are not a replacement for render-level sentinel assertions.
+
+## 8. Test Plan
+
+### 8.1 Label Helper Spec
+
+Extend `apps/web/tests/meta-automation-labels.spec.ts`:
+- `AUTOMATION_LABEL_KEYS` stays unique and readable in both locales.
+- `automationTriggerTypeLabel(...)` covers all current trigger types + legacy `field.changed` + unknown fallback.
+- `automationActionTypeLabel(...)` existing coverage remains; add any missing action aliases if needed.
+- `automationConditionOperatorLabel(...)` covers all 12 operators + unknown fallback.
+- `automationConditionValuePlaceholder(...)` covers `text`, `number`, `date`, `dateTime`, `boolean`, `booleanMultiSelect`, `select`, `multiSelect` and array/non-array paths.
+- `automationTriggerConditionLabel(...)` covers `any`, `equals`, `changed_to`, unknown fallback.
+- `automationCronPresetLabel(...)` covers the 5 current preset values + unknown fallback.
+- `automationStatusLabel('running', true)` reads through the key-backed `status.running` path.
+
+### 8.2 Rule Editor Render Spec
+
+Extend `apps/web/tests/multitable-automation-rule-editor.spec.ts` using the existing mount helper.
+
+Add focused zh-CN tests:
+- Shell + trigger section: titles, trigger option visible labels, field trigger config, cron preset labels; raw option values unchanged.
+- Condition builder: zh condition controls, operator visible labels, raw `ConditionOperator` values, field/option labels remain raw.
+- Placeholder helper: numeric array -> `逗号分隔的值`, number -> `数字`, date -> `YYYY-MM-DD`, dateTime -> `日期和时间`, default -> `值`.
+- Non-DingTalk action config: update/create/webhook/notification/email labels and placeholders; action values and HTTP methods raw.
+- Footer/test-run: unsaved hint, running/test-run button labels, DingTalk warning and confirm text.
+- A11y sentinel: `[aria-label]`, `[title]`, `[placeholder]` fixture counts locked.
+
+Existing behavior tests must remain intact. If existing tests assert English text directly, update them to assert locale-specific text only where the test is about i18n; behavior tests should keep selecting by raw `data-*` selectors.
+
+### 8.3 Validation Commands
+
+Package-relative paths because `pnpm --filter @metasheet/web exec` runs from `apps/web`:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/meta-automation-labels.spec.ts \
+  tests/multitable-automation-rule-editor.spec.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web build
+git diff --check origin/main..HEAD
+git diff --check
+```
+
+## 9. Preflight Grep
+
+Before implementation, run:
+
+```bash
+rg -n "Edit Automation Rule|New Automation Rule|Automation name|When record created|When record updated|When record deleted|When field value changed|Schedule \\(cron\\)|Schedule \\(interval\\)|Webhook received|-- select field --|Any change|Changed to|Every 5 minutes|Every hour|Daily at midnight|Weekly \\(Monday\\)|Conditions|\\+ Condition|\\+ Add condition|Actions|Update record|Create record|Send webhook|Send notification|Send email|Lock record|Target sheet ID|Notification message|Use comma or newline separated email addresses|Save this automation before running a test|Saving\\.\\.\\.|Test Run|Save failed" apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+```
+
+Expected:
+- Hits only in `MetaAutomationRuleEditor.vue`.
+- DingTalk panel hits may appear for action option labels and test-run warning only. Do not wire deeper DingTalk panel strings in T3D-2.
+
+Also run helper reachability after wiring:
+
+```bash
+rg -n "automationTriggerTypeLabel\\(|automationConditionOperatorLabel\\(|automationConditionValuePlaceholder\\(|automationTriggerConditionLabel\\(|automationCronPresetLabel\\(|automationActionTypeLabel\\(" apps/web/src/multitable apps/web/tests
+```
+
+## 10. Implementation Order
+
+1. Run §9 preflight grep and record hit summary for verification MD.
+2. Extend `meta-automation-labels.ts` with T3D-2 keys/types/helpers.
+3. Refactor condition operator options so raw `value` is stored and visible text is rendered via `automationConditionOperatorLabel(...)`.
+4. Wire `MetaAutomationRuleEditor.vue` core shell, trigger/schedule, condition builder, non-DingTalk action config, and footer.
+5. Leave DingTalk group/person config panels unchanged except action select visible labels and test-run warning/confirm text.
+6. Extend `meta-automation-labels.spec.ts`.
+7. Extend `multitable-automation-rule-editor.spec.ts` with zh-CN render tests, raw-boundary tests, and a11y sentinel counts.
+8. Create `docs/development/multitable-t3d2-automation-rule-editor-i18n-verification-20260521.md`.
+9. Run §8.3 validation commands.
+10. Commit locally and stop before push.
+
+## 11. Risk Register
+
+| Risk | Mitigation |
+| --- | --- |
+| Static `conditionOperators` labels become stale on locale toggle. | Store raw `value` only and render via helper in template. |
+| Localized labels accidentally become option `value` or `data-*`. | Tests assert raw values and selectors. |
+| DingTalk panel scope creep. | T3D-2 touches only action select labels and test-run warning/confirm. Deep DingTalk panel strings remain T3D-4. |
+| Existing behavior-heavy RuleEditor spec becomes noisy. | Reuse existing mount helper; add focused i18n tests rather than rewriting baseline tests. |
+| `props.testRunState.message` appears English. | Leave raw in T3D-2; parent/runtime message ownership is outside this slice. |
+| 4-PR chain rebase risk on `meta-automation-labels.ts`. | Before push: `git fetch origin && git rebase origin/main`; if PR becomes BEHIND use `git push --force-with-lease`. After rebase, re-run targeted tests and `git diff --name-status origin/main..HEAD` to confirm only T3D-2 files changed. |
+
+## 12. Approval Gate
+
+T3D-2 implementation is ready only if:
+- `meta-automation-labels.ts` remains the single automation-domain label module.
+- Helper discriminator types are explicit; no free-string widget/operator/action helpers.
+- Raw values stay raw for selectors/config/data attributes.
+- DingTalk deep panel strings are not wired in this PR.
+- A11y sentinel counts are documented and asserted.
+- Targeted rule-editor/helper tests, `vue-tsc`, build, and diff-check pass.

--- a/docs/development/multitable-t3d2-automation-rule-editor-i18n-verification-20260521.md
+++ b/docs/development/multitable-t3d2-automation-rule-editor-i18n-verification-20260521.md
@@ -1,0 +1,174 @@
+# T3D-2 Automation Rule Editor i18n Verification
+
+Date: 2026-05-21
+
+Branch: `docs/multitable-t3d2-rule-editor-i18n-design-20260521`
+
+## 1. Definition Of Done
+
+T3D-2 localizes the core automation rule editor chrome while preserving raw data, persisted enum values, and the deferred DingTalk detail panels.
+
+Acceptance gates:
+
+- `MetaAutomationRuleEditor.vue` core shell, trigger, condition, non-DingTalk action config, and test-run chrome are locale-aware.
+- `meta-automation-labels.ts` owns all T3D automation labels and helpers; no cross-module reuse of `meta-manager-labels.ts` `action.*`.
+- `ConditionOperatorOption` keeps its legacy `{ value, label }` shape, but the template renders labels from `automationConditionOperatorLabel(op.value, isZh)`.
+- Existing behavior specs remain green, with zh-CN render assertions added for core editor chrome.
+- A11y attribute counts are locked by fixture sentinel: no new `aria-label`, `title`, or `placeholder` attributes are introduced.
+- No backend, contract, migration, attendance, K3, or workflow-manager scope is touched.
+
+## 2. Files In Scope
+
+Changed implementation files:
+
+- `apps/web/src/multitable/utils/meta-automation-labels.ts`
+- `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue`
+
+Changed tests:
+
+- `apps/web/tests/meta-automation-labels.spec.ts`
+- `apps/web/tests/multitable-automation-rule-editor.spec.ts`
+
+Documentation:
+
+- `docs/development/multitable-t3d2-automation-rule-editor-i18n-design-20260521.md`
+- `docs/development/multitable-t3d2-automation-rule-editor-i18n-verification-20260521.md`
+
+Out of scope:
+
+- `MetaAutomationManager.vue` list/card manager chrome: T3D-3.
+- DingTalk deep configuration panels and zh-only template placeholders: T3D-4.
+- Automation final global audit: after T3D-2/3/4.
+
+## 3. Preflight And Reachability
+
+Preflight grep command:
+
+```bash
+rg -n "Edit Automation Rule|New Automation Rule|Automation name|When record created|When record updated|When record deleted|When field value changed|Schedule \(cron\)|Schedule \(interval\)|Webhook received|-- select field --|Any change|Changed to|Every 5 minutes|Every hour|Daily at midnight|Weekly \(Monday\)|Conditions|\+ Condition|\+ Add condition|Actions|Update record|Create record|Send webhook|Send notification|Send email|Lock record|Target sheet ID|Notification message|Use comma or newline separated email addresses|Save this automation before running a test|Saving\.\.\.|Test Run|Save failed" apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+```
+
+Post-wiring result:
+
+- Core editor source no longer owns the in-scope static English labels directly.
+- Remaining hits are structural comments, function names, or deferred DingTalk panel chrome.
+- English baseline assertions remain in `apps/web/tests/multitable-automation-rule-editor.spec.ts` and are intentional.
+
+Helper reachability command:
+
+```bash
+rg -n "automationTriggerTypeLabel\(|automationConditionOperatorLabel\(|automationConditionValuePlaceholder\(|automationTriggerConditionLabel\(|automationCronPresetLabel\(|automationActionTypeLabel\(|automationLabel\('status.running'" apps/web/src/multitable apps/web/tests
+```
+
+Reachability result:
+
+- `automationTriggerTypeLabel` is used by trigger select options and covered by helper spec.
+- `automationTriggerConditionLabel` is used by field-trigger condition options and covered by helper spec.
+- `automationCronPresetLabel` is used by cron preset options and covered by helper spec.
+- `automationConditionOperatorLabel` is used by condition operator display labels and covered by helper spec.
+- `automationConditionValuePlaceholder` is used by condition value input placeholders and covered by helper spec.
+- `automationActionTypeLabel` is used by action select options and covered by existing T3D-1 plus T3D-2 specs.
+- `automationLabel('status.running', ...)` is covered directly to lock the key-backed running status branch.
+
+## 4. Reminder Closure
+
+Implementation reminders were handled as follows:
+
+- `AutomationConditionValueWidget` is declared as an explicit 8-value union and has a sync comment pointing at the RuleEditor condition widget source.
+- `ConditionOperatorOption` follows the light refactor path: the `label` field remains for compatibility, while rendering ignores it and uses `automationConditionOperatorLabel(op.value, isZh)`.
+- Full-test-run confirm text uses the DRY two-key strategy: `testRun.warning` plus `testRun.confirmSuffix`.
+- Existing English behavior assertions were preserved where locale defaults to `en`; new zh-CN assertions use `useLocale().setLocale('zh-CN')`.
+- `status.running` is now backed by `automationLabel('status.running', isZh)` and has direct helper spec assertions.
+- Unknown cron presets fall back to raw text, verified with `0 30 9 * *`.
+
+## 5. Test Evidence
+
+Targeted Vitest:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/meta-automation-labels.spec.ts tests/multitable-automation-rule-editor.spec.ts --reporter=dot
+```
+
+PASS:
+
+```text
+✓ tests/meta-automation-labels.spec.ts  (6 tests) 2ms
+✓ tests/multitable-automation-rule-editor.spec.ts  (84 tests) 653ms
+
+Test Files  2 passed (2)
+Tests       90 passed (90)
+```
+
+Type check:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+PASS: exit 0, no output.
+
+Build:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+PASS:
+
+```text
+✓ built in 5.96s
+```
+
+The build still emits the existing Vite warnings for `WorkflowDesigner.vue` mixed dynamic/static import and chunk size. T3D-2 does not touch workflow designer import topology.
+
+Whitespace:
+
+```bash
+git diff --check origin/main..HEAD
+git diff --check
+```
+
+PASS: both clean.
+
+## 6. A11y Sentinel
+
+Representative RuleEditor fixture counts in `multitable-automation-rule-editor.spec.ts`:
+
+- `[aria-label]`: `0`
+- `[title]`: `1`
+- `[placeholder]`: `1`
+
+This locks the T3D-2 boundary: existing text may be localized, but this slice does not add new a11y attributes.
+
+## 7. Raw Boundary
+
+The following remain raw by design:
+
+- Persisted enum values in `<option :value>` for trigger type, condition type, condition operator, cron preset, action type, and boolean options.
+- `data-*` and CSS suffix values used by automation components.
+- Field names, view names, rule names, sheet IDs, record IDs, user IDs, and group IDs.
+- HTTP methods and user-entered URLs.
+- Example template tokens such as `{{record.title}}` and `{{record.assigneeEmail}}`.
+- Backend error messages, including save failures when `e.message` exists.
+- `props.testRunState.message` output from test-run execution.
+- DingTalk deep-panel data, tokens, and warnings deferred to T3D-4.
+
+## 8. Dependency And Noise Notes
+
+The fresh worktree reused the existing frontend dependency install through an ignored symlink:
+
+```text
+apps/web/node_modules -> /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules
+```
+
+No `node_modules` path is staged or part of the PR diff.
+
+## 9. Result
+
+T3D-2 is implementation-ready for review:
+
+- Core RuleEditor chrome localized to zh-CN and en baseline preserved.
+- T3D-1 label module extended instead of adding a second automation module.
+- 90 targeted tests pass.
+- `vue-tsc` and frontend build pass.
+- Diff check is clean.


### PR DESCRIPTION
## Summary

- Extends the T3D-1 `meta-automation-labels.ts` module with RuleEditor chrome labels, typed helper unions, and condition/action/trigger helpers.
- Localizes core `MetaAutomationRuleEditor.vue` chrome: shell, trigger config, condition builder, non-DingTalk action config, save/test-run controls, and save fallback copy.
- Keeps persisted values raw: trigger/action/operator/cron option values, field names, IDs, template tokens, backend errors, and DingTalk deep panel data.

## Design Notes

- `ConditionOperatorOption` uses the light refactor path: the legacy `label` field stays for compatibility, while the template renders `automationConditionOperatorLabel(op.value, isZh)`.
- `status.running` now has a proper `automationLabel('status.running', isZh)` backing key.
- Full test-run confirm copy uses the DRY two-key strategy: `testRun.warning` + `testRun.confirmSuffix` with a locale-aware separator.
- A11y sentinel locks the fixture-rendered boundary at `[aria-label]/[title]/[placeholder] = 0/1/1`; no new a11y attributes are added.
- T3D-3 manager and T3D-4 DingTalk deep panel / zh-only placeholders remain deferred per the 4-PR split.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/meta-automation-labels.spec.ts tests/multitable-automation-rule-editor.spec.ts --reporter=dot`
  - 2 files / 90 tests passed (`6` helper + `84` RuleEditor)
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
  - clean
- `pnpm --filter @metasheet/web build`
  - pass, built in 5.96s
- `git diff --check origin/main..HEAD` and `git diff --check`
  - clean

## Docs

- `docs/development/multitable-t3d2-automation-rule-editor-i18n-design-20260521.md`
- `docs/development/multitable-t3d2-automation-rule-editor-i18n-verification-20260521.md`

## Scope Guard

No backend, contract, migration, attendance, K3, manager, or DingTalk deep-panel scope is changed.
