### PR TITLE
feat(attendance): preview rotation shift sequence

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -4388,6 +4388,55 @@
                     type="text"
                     :placeholder="tr('shiftId1, shiftId2', '班次ID1, 班次ID2')"
                   />
+                  <small class="attendance__field-hint">
+                    {{ tr('Separate shift IDs with commas. Use the quick append buttons below to build the sequence in order, and repeat a shift if the cycle needs duplicates.', '请用英文逗号分隔班次 ID。可用下方快捷按钮按顺序拼接，如需重复班次可重复点击。') }}
+                  </small>
+                  <div v-if="shifts.length > 0" class="attendance__sequence-builder">
+                    <span class="attendance__field-hint">{{ tr('Quick append from existing shifts', '从已有班次快捷拼接') }}</span>
+                    <div class="attendance__sequence-builder-actions">
+                      <button
+                        v-for="shift in shifts"
+                        :key="shift.id"
+                        class="attendance__btn attendance__btn--inline"
+                        type="button"
+                        @click="appendShiftToRotationSequence(shift.id)"
+                      >
+                        {{ shift.name }} · {{ shift.id }}
+                      </button>
+                    </div>
+                  </div>
+                  <small v-if="rotationSequencePreviewText" class="attendance__field-hint">
+                    {{ tr('Current sequence', '当前序列') }}: {{ rotationSequencePreviewText }}
+                  </small>
+                  <div
+                    v-if="rotationSequencePreview.items.length"
+                    class="attendance__rotation-sequence-preview"
+                    data-attendance-rotation-sequence-preview
+                  >
+                    <strong>{{ tr('Cycle preview', '轮班周期预览') }}</strong>
+                    <ol>
+                      <li
+                        v-for="item in rotationSequencePreview.items"
+                        :key="`${item.dayIndex}:${item.shiftRef}`"
+                        :data-rotation-sequence-known="item.isKnown ? 'true' : 'false'"
+                      >
+                        <span>{{ tr(`Day ${item.dayIndex}`, `第 ${item.dayIndex} 天`) }}</span>
+                        <span>{{ item.label }}</span>
+                        <span v-if="item.isKnown">
+                          {{ item.schedule }}<template v-if="item.isOvernight"> · {{ tr('Overnight', '跨夜') }}</template>
+                        </span>
+                        <span v-else>{{ tr('Unresolved shift', '未解析班次') }}</span>
+                      </li>
+                    </ol>
+                    <small
+                      v-if="rotationSequencePreview.missingRefs.length"
+                      class="attendance__field-hint attendance__field-hint--warning"
+                      data-attendance-rotation-sequence-missing
+                    >
+                      {{ tr('Missing loaded shift IDs', '当前已加载班次中不存在这些 ID') }}:
+                      {{ rotationSequencePreview.missingRefs.join(', ') }}
+                    </small>
+                  </div>
                 </label>
                 <label class="attendance__field attendance__field--checkbox" for="attendance-rotation-active">
                   <span>{{ tr('Active', '启用') }}</span>
@@ -4914,6 +4963,10 @@ import {
   formatAttendanceScheduleConflictDiagnostic,
   type AttendanceScheduleConflictDiagnostic,
 } from './attendance/attendanceScheduleConflictDiagnostics'
+import {
+  buildAttendanceRotationSequencePreview,
+  parseAttendanceRotationSequenceInput,
+} from './attendance/attendanceRotationSequencePreview'
 import { usePlugins } from '../composables/usePlugins'
 import { apiFetch } from '../utils/api'
 import { readErrorMessage } from '../utils/error'
@@ -7804,6 +7857,20 @@ const rotationRuleForm = reactive({
   isActive: true,
 })
 
+function appendShiftToRotationSequence(shiftId: string) {
+  const current = parseShiftSequenceInput(rotationRuleForm.shiftSequence)
+  rotationRuleForm.shiftSequence = [...current, shiftId].join(', ')
+}
+
+const rotationSequencePreview = computed(() => buildAttendanceRotationSequencePreview(
+  rotationRuleForm.shiftSequence,
+  shifts.value,
+))
+
+const rotationSequencePreviewText = computed(() => rotationSequencePreview.value.items
+  .map(item => item.label)
+  .join(' -> '))
+
 const rotationAssignmentForm = reactive({
   userId: '',
   rotationRuleId: '',
@@ -8347,10 +8414,7 @@ function parseWorkingDaysInput(value: string): number[] {
 }
 
 function parseShiftSequenceInput(value: string): string[] {
-  return value
-    .split(/[\n,]/)
-    .map(item => item.trim())
-    .filter(Boolean)
+  return parseAttendanceRotationSequenceInput(value)
 }
 
 function parseApprovalStepsInput(value: string): AttendanceApprovalStep[] | null {
@@ -14967,6 +15031,48 @@ const holidaySectionBindings = {
 .attendance__schedule-conflict-diagnostics ul {
   margin: 6px 0 0;
   padding-left: 18px;
+}
+
+.attendance__sequence-builder {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.attendance__sequence-builder-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.attendance__rotation-sequence-preview {
+  border: 1px solid #d1d5db;
+  background: #f9fafb;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 12px;
+}
+
+.attendance__rotation-sequence-preview ol {
+  display: grid;
+  gap: 6px;
+  margin: 8px 0 0;
+  padding-left: 18px;
+}
+
+.attendance__rotation-sequence-preview li {
+  display: grid;
+  grid-template-columns: minmax(56px, max-content) minmax(120px, 1fr) minmax(120px, max-content);
+  gap: 8px;
+  align-items: center;
+}
+
+.attendance__rotation-sequence-preview li[data-rotation-sequence-known="false"] {
+  color: #92400e;
+}
+
+.attendance__field-hint--warning {
+  color: #92400e;
 }
 
 .attendance__btn {

--- a/apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue
+++ b/apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue
@@ -118,6 +118,35 @@
         <small v-if="rotationSequencePreviewText" class="attendance__field-hint">
           {{ tr('Current sequence', '当前序列') }}: {{ rotationSequencePreviewText }}
         </small>
+        <div
+          v-if="rotationSequencePreview.items.length"
+          class="attendance__rotation-sequence-preview"
+          data-attendance-rotation-sequence-preview
+        >
+          <strong>{{ tr('Cycle preview', '轮班周期预览') }}</strong>
+          <ol>
+            <li
+              v-for="item in rotationSequencePreview.items"
+              :key="`${item.dayIndex}:${item.shiftRef}`"
+              :data-rotation-sequence-known="item.isKnown ? 'true' : 'false'"
+            >
+              <span>{{ tr(`Day ${item.dayIndex}`, `第 ${item.dayIndex} 天`) }}</span>
+              <span>{{ item.label }}</span>
+              <span v-if="item.isKnown">
+                {{ item.schedule }}<template v-if="item.isOvernight"> · {{ tr('Overnight', '跨夜') }}</template>
+              </span>
+              <span v-else>{{ tr('Unresolved shift', '未解析班次') }}</span>
+            </li>
+          </ol>
+          <small
+            v-if="rotationSequencePreview.missingRefs.length"
+            class="attendance__field-hint attendance__field-hint--warning"
+            data-attendance-rotation-sequence-missing
+          >
+            {{ tr('Missing loaded shift IDs', '当前已加载班次中不存在这些 ID') }}:
+            {{ rotationSequencePreview.missingRefs.join(', ') }}
+          </small>
+        </div>
       </label>
       <label class="attendance__field attendance__field--checkbox" for="attendance-rotation-rule-active">
         <span>{{ tr('Active', '启用') }}</span>
@@ -564,6 +593,10 @@ import {
   formatAttendanceScheduleConflictDiagnostic,
   type AttendanceScheduleConflictDiagnostic,
 } from './attendanceScheduleConflictDiagnostics'
+import {
+  buildAttendanceRotationSequencePreview,
+  parseAttendanceRotationSequenceInput,
+} from './attendanceRotationSequencePreview'
 
 type Translate = (en: string, zh: string) => string
 type MaybePromise<T> = T | Promise<T>
@@ -742,10 +775,7 @@ function formatScheduleConflictDiagnostic(diagnostic: AttendanceScheduleConflict
 }
 
 function parseShiftSequence(value: string): string[] {
-  return value
-    .split(',')
-    .map(item => item.trim())
-    .filter(Boolean)
+  return parseAttendanceRotationSequenceInput(value)
 }
 
 function appendShiftToRotationSequence(shiftId: string) {
@@ -753,13 +783,15 @@ function appendShiftToRotationSequence(shiftId: string) {
   rotationRuleForm.shiftSequence = [...current, shiftId].join(', ')
 }
 
+const rotationSequencePreview = computed(() => buildAttendanceRotationSequencePreview(
+  rotationRuleForm.shiftSequence,
+  shifts.value,
+))
+
 const rotationSequencePreviewText = computed(() => {
-  const sequence = parseShiftSequence(rotationRuleForm.shiftSequence)
-  if (sequence.length === 0) return ''
-  return sequence.map((shiftId) => {
-    const shift = shifts.value.find(item => item.id === shiftId)
-    return shift ? `${shift.name} (${shiftId})` : shiftId
-  }).join(' → ')
+  return rotationSequencePreview.value.items
+    .map(item => item.label)
+    .join(' -> ')
 })
 
 const rotationRuleEditingLabel = computed(() => {
@@ -909,6 +941,36 @@ const assignmentEditingLabel = computed(() => {
   display: flex;
   gap: 8px;
   flex-wrap: wrap;
+}
+
+.attendance__rotation-sequence-preview {
+  border: 1px solid #d1d5db;
+  background: #f9fafb;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 12px;
+}
+
+.attendance__rotation-sequence-preview ol {
+  display: grid;
+  gap: 6px;
+  margin: 8px 0 0;
+  padding-left: 18px;
+}
+
+.attendance__rotation-sequence-preview li {
+  display: grid;
+  grid-template-columns: minmax(56px, max-content) minmax(120px, 1fr) minmax(120px, max-content);
+  gap: 8px;
+  align-items: center;
+}
+
+.attendance__rotation-sequence-preview li[data-rotation-sequence-known="false"] {
+  color: #92400e;
+}
+
+.attendance__field-hint--warning {
+  color: #92400e;
 }
 
 .attendance__table-wrapper {

--- a/apps/web/src/views/attendance/attendanceRotationSequencePreview.ts
+++ b/apps/web/src/views/attendance/attendanceRotationSequencePreview.ts
@@ -1,0 +1,59 @@
+export interface AttendanceRotationSequenceShiftLike {
+  id: string
+  name: string
+  workStartTime: string
+  workEndTime: string
+  isOvernight?: boolean
+}
+
+export interface AttendanceRotationSequencePreviewItem {
+  dayIndex: number
+  shiftRef: string
+  label: string
+  schedule: string
+  isKnown: boolean
+  isOvernight: boolean
+}
+
+export interface AttendanceRotationSequencePreview {
+  items: AttendanceRotationSequencePreviewItem[]
+  missingRefs: string[]
+}
+
+export function parseAttendanceRotationSequenceInput(value: string | string[] | null | undefined): string[] {
+  const source = Array.isArray(value) ? value.join(',') : value ?? ''
+  return source
+    .split(/[\n,]/)
+    .map(item => item.trim())
+    .filter(Boolean)
+}
+
+export function buildAttendanceRotationSequencePreview(
+  value: string | string[] | null | undefined,
+  shifts: AttendanceRotationSequenceShiftLike[] | null | undefined,
+): AttendanceRotationSequencePreview {
+  const sequence = parseAttendanceRotationSequenceInput(value)
+  const shiftList = Array.isArray(shifts) ? shifts : []
+  const hasShiftCatalog = shiftList.length > 0
+  const shiftById = new Map(shiftList.map(shift => [shift.id, shift]))
+  const missingRefs: string[] = []
+
+  const items = sequence.map((shiftRef, index): AttendanceRotationSequencePreviewItem => {
+    const shift = shiftById.get(shiftRef)
+    if (!shift && hasShiftCatalog && !missingRefs.includes(shiftRef)) {
+      missingRefs.push(shiftRef)
+    }
+    const label = shift ? `${shift.name} (${shift.id})` : shiftRef
+    const schedule = shift ? `${shift.workStartTime} -> ${shift.workEndTime}` : ''
+    return {
+      dayIndex: index + 1,
+      shiftRef,
+      label,
+      schedule,
+      isKnown: Boolean(shift),
+      isOvernight: Boolean(shift?.isOvernight),
+    }
+  })
+
+  return { items, missingRefs }
+}

--- a/apps/web/tests/AttendanceSchedulingAdminSection.spec.ts
+++ b/apps/web/tests/AttendanceSchedulingAdminSection.spec.ts
@@ -397,6 +397,61 @@ describe('AttendanceSchedulingAdminSection', () => {
     expect(container!.querySelector('[data-schedule-conflict-diagnostic="rotation_overrides_shift"]')).toBeTruthy()
   })
 
+  it('renders rotation sequence preview and missing-shift diagnostics', async () => {
+    const scheduling = createSchedulingBindings({
+      shifts: ref<AttendanceShift[]>([
+        {
+          id: 'shift-a',
+          name: 'Day shift',
+          timezone: 'UTC',
+          workStartTime: '09:00',
+          workEndTime: '18:00',
+          isOvernight: false,
+          lateGraceMinutes: 10,
+          earlyGraceMinutes: 10,
+          roundingMinutes: 5,
+          workingDays: [1, 2, 3, 4, 5],
+        },
+        {
+          id: 'shift-b',
+          name: 'Night shift',
+          timezone: 'UTC',
+          workStartTime: '22:00',
+          workEndTime: '06:00',
+          isOvernight: true,
+          lateGraceMinutes: 10,
+          earlyGraceMinutes: 10,
+          roundingMinutes: 5,
+          workingDays: [1, 2, 3, 4, 5],
+        },
+      ]),
+      rotationRuleForm: reactive<RotationRuleFormState>({
+        name: 'Three day cycle',
+        timezone: 'UTC',
+        shiftSequence: 'shift-a, shift-b, missing-shift',
+        isActive: true,
+      }),
+    })
+
+    app = createApp(AttendanceSchedulingAdminSection, {
+      tr,
+      scheduling,
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const preview = container!.querySelector('[data-attendance-rotation-sequence-preview]')
+    expect(preview).toBeTruthy()
+    expect(preview?.textContent).toContain('Cycle preview')
+    expect(preview?.textContent).toContain('Day 1')
+    expect(preview?.textContent).toContain('Day shift (shift-a)')
+    expect(preview?.textContent).toContain('Night shift (shift-b)')
+    expect(preview?.textContent).toContain('22:00 -> 06:00')
+    expect(preview?.textContent).toContain('Overnight')
+    expect(preview?.textContent).toContain('Unresolved shift')
+    expect(container!.querySelector('[data-attendance-rotation-sequence-missing]')?.textContent).toContain('missing-shift')
+  })
+
   it('falls back to plain counts when nothing is being edited', async () => {
     const scheduling = createSchedulingBindings({
       rotationRuleEditingId: ref(null),

--- a/apps/web/tests/attendanceRotationSequencePreview.spec.ts
+++ b/apps/web/tests/attendanceRotationSequencePreview.spec.ts
@@ -1,0 +1,92 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildAttendanceRotationSequencePreview,
+  parseAttendanceRotationSequenceInput,
+} from '../src/views/attendance/attendanceRotationSequencePreview'
+
+describe('attendance rotation sequence preview', () => {
+  it('parses comma and newline separated shift references', () => {
+    expect(parseAttendanceRotationSequenceInput(' shift-a,shift-b\nshift-c ,, ')).toEqual([
+      'shift-a',
+      'shift-b',
+      'shift-c',
+    ])
+  })
+
+  it('maps known shifts to ordered day preview rows', () => {
+    const preview = buildAttendanceRotationSequencePreview('shift-a, shift-b, shift-a', [
+      {
+        id: 'shift-a',
+        name: 'Day shift',
+        workStartTime: '09:00',
+        workEndTime: '18:00',
+        isOvernight: false,
+      },
+      {
+        id: 'shift-b',
+        name: 'Night shift',
+        workStartTime: '22:00',
+        workEndTime: '06:00',
+        isOvernight: true,
+      },
+    ])
+
+    expect(preview.missingRefs).toEqual([])
+    expect(preview.items).toEqual([
+      expect.objectContaining({
+        dayIndex: 1,
+        shiftRef: 'shift-a',
+        label: 'Day shift (shift-a)',
+        schedule: '09:00 -> 18:00',
+        isKnown: true,
+        isOvernight: false,
+      }),
+      expect.objectContaining({
+        dayIndex: 2,
+        shiftRef: 'shift-b',
+        label: 'Night shift (shift-b)',
+        schedule: '22:00 -> 06:00',
+        isKnown: true,
+        isOvernight: true,
+      }),
+      expect.objectContaining({
+        dayIndex: 3,
+        shiftRef: 'shift-a',
+      }),
+    ])
+  })
+
+  it('reports missing references once when the shift catalog is loaded', () => {
+    const preview = buildAttendanceRotationSequencePreview('shift-a, missing-shift, missing-shift', [
+      {
+        id: 'shift-a',
+        name: 'Day shift',
+        workStartTime: '09:00',
+        workEndTime: '18:00',
+      },
+    ])
+
+    expect(preview.missingRefs).toEqual(['missing-shift'])
+    expect(preview.items[1]).toMatchObject({
+      dayIndex: 2,
+      shiftRef: 'missing-shift',
+      label: 'missing-shift',
+      schedule: '',
+      isKnown: false,
+      isOvernight: false,
+    })
+  })
+
+  it('does not call refs missing until a shift catalog is available', () => {
+    const preview = buildAttendanceRotationSequencePreview('legacy-shift-name', [])
+
+    expect(preview.missingRefs).toEqual([])
+    expect(preview.items).toEqual([
+      expect.objectContaining({
+        dayIndex: 1,
+        shiftRef: 'legacy-shift-name',
+        isKnown: false,
+      }),
+    ])
+  })
+})

--- a/docs/development/attendance-rotation-sequence-preview-development-20260521.md
+++ b/docs/development/attendance-rotation-sequence-preview-development-20260521.md
@@ -1,0 +1,76 @@
+# Attendance Rotation Sequence Preview Development
+
+Date: 2026-05-21
+Branch: `codex/attendance-rotation-sequence-preview-20260521`
+Base: `origin/main@663e7646e`
+
+## Summary
+
+This slice adds a small admin-side preview for rotation rule shift sequences.
+Admins can see the resolved day-by-day cycle before saving a rotation rule:
+
+- `Day 1 / Day 2 / ...` rows show the loaded shift name, id, schedule, and
+  overnight marker.
+- Missing shift references are called out when the shift catalog is loaded.
+- The quick-append buttons in the extracted scheduling section and production
+  `AttendanceView.vue` both build the same comma-separated sequence.
+
+This is a frontend advisory slice only. Backend rotation-rule validation remains
+the source of truth for whether a sequence can be saved.
+
+## Scope
+
+Delivered:
+
+- A shared pure helper in
+  `apps/web/src/views/attendance/attendanceRotationSequencePreview.ts`.
+- Rotation sequence preview rendering in
+  `apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue`.
+- Rotation sequence quick append and preview rendering in the production
+  `apps/web/src/views/AttendanceView.vue` scheduling surface.
+- Focused helper and component tests.
+- Development and verification notes.
+
+Not delivered:
+
+- No backend rotation-rule validator change.
+- No migration or schema change.
+- No auto-repair of legacy name-based `shiftSequence` entries.
+- No save blocking beyond the existing backend validation path.
+
+## Design Notes
+
+`attendance_rotation_rules.shift_sequence` is persisted as an ordered array of
+string references. Current backend create/update validation requires shift IDs,
+while older docs and delete-guard history acknowledge legacy deployments may
+have name-like entries. The preview therefore stays advisory:
+
+- it resolves references against the currently loaded shift catalog by `id`;
+- it reports missing references only when at least one shift is loaded;
+- it still displays unresolved references so admins can inspect legacy values;
+- it does not decide whether the backend will accept the save.
+
+The parser accepts comma or newline separators, matching the existing
+`parseShiftSequenceInput()` behavior in the production monolith.
+
+## Changed Files
+
+- `apps/web/src/views/attendance/attendanceRotationSequencePreview.ts`
+  - New parser and preview builder.
+- `apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue`
+  - Renders cycle preview and missing-reference warning.
+- `apps/web/src/views/AttendanceView.vue`
+  - Adds quick append parity and renders the same preview in the active admin
+    page.
+- `apps/web/tests/attendanceRotationSequencePreview.spec.ts`
+  - Pure helper coverage.
+- `apps/web/tests/AttendanceSchedulingAdminSection.spec.ts`
+  - Component rendering coverage.
+
+## Boundaries
+
+- No `attendance_*` migration.
+- No direct `meta_*` write.
+- No plugin/backend route change.
+- No new client-side save validator.
+- No staging/prod write operation.

--- a/docs/development/attendance-rotation-sequence-preview-verification-20260521.md
+++ b/docs/development/attendance-rotation-sequence-preview-verification-20260521.md
@@ -1,0 +1,43 @@
+# Attendance Rotation Sequence Preview Verification
+
+Date: 2026-05-21
+Branch: `codex/attendance-rotation-sequence-preview-20260521`
+Base: `origin/main@663e7646e`
+
+## Verification Matrix
+
+| Layer | Command | Result |
+| --- | --- | --- |
+| Frontend focused specs | `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceRotationSequencePreview.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts --watch=false` | PASS, 10 tests |
+| Frontend type-check | `pnpm --filter @metasheet/web type-check` | PASS |
+| Frontend scheduling regression | `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceRotationSequencePreview.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts tests/useAttendanceAdminScheduling.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` | PASS, 44 tests |
+| Frontend build | `pnpm --filter @metasheet/web build` | PASS |
+| Whitespace | `git diff --check` | PASS |
+
+## Acceptance Criteria
+
+- Comma and newline separated shift sequences parse consistently.
+- Known shift references render ordered preview rows with shift name, id,
+  schedule, and overnight marker.
+- Missing shift references are reported once when the shift catalog is loaded.
+- Legacy/unresolved references remain visible instead of being hidden.
+- The extracted scheduling component displays the preview.
+- The production `AttendanceView.vue` displays the preview and supports quick
+  append from loaded shifts.
+
+## Boundary Checks
+
+- No backend file changed.
+- No `plugins/plugin-attendance/index.cjs` change.
+- No migration file added or changed.
+- No direct `meta_*` SQL write.
+- No staging/prod write operation.
+
+## Notes
+
+`pnpm install` was required in the isolated worktree to restore local test
+binaries. It rewrote tracked `node_modules` symlink entries under plugin/tool
+folders; those generated changes were restored before staging.
+
+The frontend build still emits the existing Vite warning about large chunks and
+the mixed static/dynamic import of `WorkflowDesigner.vue`; the command exits 0.


### PR DESCRIPTION
## Summary

Adds a frontend-only rotation shift sequence preview for attendance scheduling admins. The preview resolves loaded shift IDs into day-by-day cycle rows, shows schedule and overnight markers, and calls out missing shift references when the shift catalog is available.

Implementation:
- shared pure helper `attendanceRotationSequencePreview.ts`
- preview in the active `AttendanceView.vue` scheduling surface
- preview in the extracted `AttendanceSchedulingAdminSection.vue` surface
- focused helper/component tests
- development and verification markdown under `docs/development/`

Boundaries:
- frontend advisory only; backend rotation-rule validation remains authoritative
- no `attendance_*` migration
- no direct `meta_*` writes
- no backend route/plugin changes
- no staging/prod writes

## Test plan

- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceRotationSequencePreview.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts --watch=false` — 10 tests pass
- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceRotationSequencePreview.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts tests/useAttendanceAdminScheduling.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` — 44 tests pass
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `pnpm --filter @metasheet/web build`
- [x] `git diff --check`
- [x] staged whitespace / node_modules-dist / secret scan clean

## Notes

The isolated worktree needed `pnpm install`; generated tracked node_modules symlink noise was restored before staging. The web build still emits the existing Vite warning about large chunks and mixed static/dynamic import of `WorkflowDesigner.vue`; the command exits 0.