### PR TITLE
feat(attendance): preview rotation assignment impact

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -4523,6 +4523,47 @@
                   </li>
                 </ul>
               </div>
+              <div
+                v-if="rotationAssignmentPreview.items.length"
+                class="attendance__rotation-assignment-preview"
+                data-attendance-rotation-assignment-preview
+              >
+                <div class="attendance__preview-header">
+                  <strong>{{ tr('Assignment impact preview', '轮班分配影响预览') }}</strong>
+                  <span>
+                    {{ rotationAssignmentPreview.ruleName }}
+                    <template v-if="rotationAssignmentPreview.isTruncated">
+                      · {{ tr(`First ${rotationAssignmentPreview.items.length} of ${rotationAssignmentPreview.projectedDays} days`, `前 ${rotationAssignmentPreview.items.length} / 共 ${rotationAssignmentPreview.projectedDays} 天`) }}
+                    </template>
+                  </span>
+                </div>
+                <ol>
+                  <li
+                    v-for="item in rotationAssignmentPreview.items"
+                    :key="`${item.date}:${item.dayIndex}:${item.shiftRef}`"
+                    :data-rotation-assignment-known="item.isKnown ? 'true' : 'false'"
+                  >
+                    <span>{{ item.date }}</span>
+                    <span>{{ tr(`Day ${item.dayIndex}`, `第 ${item.dayIndex} 天`) }}</span>
+                    <span>{{ item.label }}</span>
+                    <span v-if="item.isKnown">
+                      {{ item.schedule }}<template v-if="item.isOvernight"> · {{ tr('Overnight', '跨夜') }}</template>
+                    </span>
+                    <span v-else>{{ tr('Unresolved shift', '未解析班次') }}</span>
+                  </li>
+                </ol>
+                <small
+                  v-if="rotationAssignmentPreview.missingRefs.length"
+                  class="attendance__field-hint attendance__field-hint--warning"
+                  data-attendance-rotation-assignment-missing
+                >
+                  {{ tr('This assignment references shift IDs that are not in the loaded shift catalog', '该分配引用了当前已加载班次中不存在的 ID') }}:
+                  {{ rotationAssignmentPreview.missingRefs.join(', ') }}
+                </small>
+                <small class="attendance__field-hint">
+                  {{ tr('Preview is advisory and uses the current loaded rule, dates, and shift catalog.', '预览仅作提示，基于当前已加载的规则、日期和班次目录计算。') }}
+                </small>
+              </div>
               <div class="attendance__admin-grid">
                 <label class="attendance__field" for="attendance-rotation-user">
                   <span>{{ tr('User ID', '用户 ID') }}</span>
@@ -4964,6 +5005,7 @@ import {
   type AttendanceScheduleConflictDiagnostic,
 } from './attendance/attendanceScheduleConflictDiagnostics'
 import {
+  buildAttendanceRotationAssignmentPreview,
   buildAttendanceRotationSequencePreview,
   parseAttendanceRotationSequenceInput,
 } from './attendance/attendanceRotationSequencePreview'
@@ -7878,6 +7920,15 @@ const rotationAssignmentForm = reactive({
   endDate: '',
   isActive: true,
 })
+
+const rotationAssignmentPreview = computed(() => buildAttendanceRotationAssignmentPreview({
+  rotationRuleId: rotationAssignmentForm.rotationRuleId,
+  rotationRules: rotationRules.value,
+  shifts: shifts.value,
+  startDate: rotationAssignmentForm.startDate,
+  endDate: rotationAssignmentForm.endDate || null,
+  maxDays: 14,
+}))
 
 const scheduleConflictDiagnostics = computed(() => buildAttendanceScheduleConflictDiagnostics({
   assignments: assignments.value,
@@ -15053,7 +15104,23 @@ const holidaySectionBindings = {
   font-size: 12px;
 }
 
-.attendance__rotation-sequence-preview ol {
+.attendance__rotation-assignment-preview {
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 12px;
+}
+
+.attendance__preview-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.attendance__rotation-sequence-preview ol,
+.attendance__rotation-assignment-preview ol {
   display: grid;
   gap: 6px;
   margin: 8px 0 0;
@@ -15067,7 +15134,18 @@ const holidaySectionBindings = {
   align-items: center;
 }
 
+.attendance__rotation-assignment-preview li {
+  display: grid;
+  grid-template-columns: minmax(96px, max-content) minmax(56px, max-content) minmax(120px, 1fr) minmax(120px, max-content);
+  gap: 8px;
+  align-items: center;
+}
+
 .attendance__rotation-sequence-preview li[data-rotation-sequence-known="false"] {
+  color: #92400e;
+}
+
+.attendance__rotation-assignment-preview li[data-rotation-assignment-known="false"] {
   color: #92400e;
 }
 

--- a/apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue
+++ b/apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue
@@ -229,6 +229,47 @@
         </li>
       </ul>
     </div>
+    <div
+      v-if="rotationAssignmentPreview.items.length"
+      class="attendance__rotation-assignment-preview"
+      data-attendance-rotation-assignment-preview
+    >
+      <div class="attendance__preview-header">
+        <strong>{{ tr('Assignment impact preview', '轮班分配影响预览') }}</strong>
+        <span>
+          {{ rotationAssignmentPreview.ruleName }}
+          <template v-if="rotationAssignmentPreview.isTruncated">
+            · {{ tr(`First ${rotationAssignmentPreview.items.length} of ${rotationAssignmentPreview.projectedDays} days`, `前 ${rotationAssignmentPreview.items.length} / 共 ${rotationAssignmentPreview.projectedDays} 天`) }}
+          </template>
+        </span>
+      </div>
+      <ol>
+        <li
+          v-for="item in rotationAssignmentPreview.items"
+          :key="`${item.date}:${item.dayIndex}:${item.shiftRef}`"
+          :data-rotation-assignment-known="item.isKnown ? 'true' : 'false'"
+        >
+          <span>{{ item.date }}</span>
+          <span>{{ tr(`Day ${item.dayIndex}`, `第 ${item.dayIndex} 天`) }}</span>
+          <span>{{ item.label }}</span>
+          <span v-if="item.isKnown">
+            {{ item.schedule }}<template v-if="item.isOvernight"> · {{ tr('Overnight', '跨夜') }}</template>
+          </span>
+          <span v-else>{{ tr('Unresolved shift', '未解析班次') }}</span>
+        </li>
+      </ol>
+      <small
+        v-if="rotationAssignmentPreview.missingRefs.length"
+        class="attendance__field-hint attendance__field-hint--warning"
+        data-attendance-rotation-assignment-missing
+      >
+        {{ tr('This assignment references shift IDs that are not in the loaded shift catalog', '该分配引用了当前已加载班次中不存在的 ID') }}:
+        {{ rotationAssignmentPreview.missingRefs.join(', ') }}
+      </small>
+      <small class="attendance__field-hint">
+        {{ tr('Preview is advisory and uses the current loaded rule, dates, and shift catalog.', '预览仅作提示，基于当前已加载的规则、日期和班次目录计算。') }}
+      </small>
+    </div>
     <div class="attendance__admin-grid">
       <AttendanceUserPickerField
         v-model="rotationAssignmentForm.userId"
@@ -594,6 +635,7 @@ import {
   type AttendanceScheduleConflictDiagnostic,
 } from './attendanceScheduleConflictDiagnostics'
 import {
+  buildAttendanceRotationAssignmentPreview,
   buildAttendanceRotationSequencePreview,
   parseAttendanceRotationSequenceInput,
 } from './attendanceRotationSequencePreview'
@@ -794,6 +836,15 @@ const rotationSequencePreviewText = computed(() => {
     .join(' -> ')
 })
 
+const rotationAssignmentPreview = computed(() => buildAttendanceRotationAssignmentPreview({
+  rotationRuleId: rotationAssignmentForm.rotationRuleId,
+  rotationRules: rotationRules.value,
+  shifts: shifts.value,
+  startDate: rotationAssignmentForm.startDate,
+  endDate: rotationAssignmentForm.endDate || null,
+  maxDays: 14,
+}))
+
 const rotationRuleEditingLabel = computed(() => {
   const name = rotationRuleForm.name.trim()
   return tr(
@@ -951,7 +1002,23 @@ const assignmentEditingLabel = computed(() => {
   font-size: 12px;
 }
 
-.attendance__rotation-sequence-preview ol {
+.attendance__rotation-assignment-preview {
+  border: 1px solid #bfdbfe;
+  background: #eff6ff;
+  border-radius: 6px;
+  padding: 10px 12px;
+  font-size: 12px;
+}
+
+.attendance__preview-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 12px;
+  flex-wrap: wrap;
+}
+
+.attendance__rotation-sequence-preview ol,
+.attendance__rotation-assignment-preview ol {
   display: grid;
   gap: 6px;
   margin: 8px 0 0;
@@ -965,7 +1032,18 @@ const assignmentEditingLabel = computed(() => {
   align-items: center;
 }
 
+.attendance__rotation-assignment-preview li {
+  display: grid;
+  grid-template-columns: minmax(96px, max-content) minmax(56px, max-content) minmax(120px, 1fr) minmax(120px, max-content);
+  gap: 8px;
+  align-items: center;
+}
+
 .attendance__rotation-sequence-preview li[data-rotation-sequence-known="false"] {
+  color: #92400e;
+}
+
+.attendance__rotation-assignment-preview li[data-rotation-assignment-known="false"] {
   color: #92400e;
 }
 

--- a/apps/web/src/views/attendance/attendanceRotationSequencePreview.ts
+++ b/apps/web/src/views/attendance/attendanceRotationSequencePreview.ts
@@ -20,6 +20,63 @@ export interface AttendanceRotationSequencePreview {
   missingRefs: string[]
 }
 
+export interface AttendanceRotationAssignmentRuleLike {
+  id: string
+  name: string
+  shiftSequence: string[]
+}
+
+export interface AttendanceRotationAssignmentPreviewItem extends AttendanceRotationSequencePreviewItem {
+  date: string
+  sequenceIndex: number
+}
+
+export interface AttendanceRotationAssignmentPreview {
+  ruleId: string
+  ruleName: string
+  items: AttendanceRotationAssignmentPreviewItem[]
+  missingRefs: string[]
+  isTruncated: boolean
+  projectedDays: number
+}
+
+export interface BuildAttendanceRotationAssignmentPreviewInput {
+  rotationRuleId: string | null | undefined
+  rotationRules: AttendanceRotationAssignmentRuleLike[] | null | undefined
+  shifts: AttendanceRotationSequenceShiftLike[] | null | undefined
+  startDate: string | null | undefined
+  endDate?: string | null
+  maxDays?: number
+}
+
+const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
+
+function parseDateKey(value: string | null | undefined): Date | null {
+  const text = typeof value === 'string' ? value.trim() : ''
+  if (!DATE_KEY_PATTERN.test(text)) return null
+  const date = new Date(`${text}T00:00:00.000Z`)
+  return Number.isNaN(date.getTime()) || formatDateKey(date) !== text ? null : date
+}
+
+function formatDateKey(date: Date): string {
+  return date.toISOString().slice(0, 10)
+}
+
+function addDays(date: Date, days: number): Date {
+  const next = new Date(date.getTime())
+  next.setUTCDate(next.getUTCDate() + days)
+  return next
+}
+
+function inclusiveDayCount(startDate: Date, endDate: Date): number {
+  return Math.floor((endDate.getTime() - startDate.getTime()) / 86_400_000) + 1
+}
+
+function normalizeMaxDays(value: number | null | undefined): number {
+  if (typeof value !== 'number' || !Number.isFinite(value)) return 14
+  return Math.min(Math.max(Math.floor(value), 1), 60)
+}
+
 export function parseAttendanceRotationSequenceInput(value: string | string[] | null | undefined): string[] {
   const source = Array.isArray(value) ? value.join(',') : value ?? ''
   return source
@@ -56,4 +113,68 @@ export function buildAttendanceRotationSequencePreview(
   })
 
   return { items, missingRefs }
+}
+
+export function buildAttendanceRotationAssignmentPreview({
+  rotationRuleId,
+  rotationRules,
+  shifts,
+  startDate,
+  endDate,
+  maxDays,
+}: BuildAttendanceRotationAssignmentPreviewInput): AttendanceRotationAssignmentPreview {
+  const selectedRuleId = typeof rotationRuleId === 'string' ? rotationRuleId.trim() : ''
+  const ruleList = Array.isArray(rotationRules) ? rotationRules : []
+  const rule = ruleList.find(item => item.id === selectedRuleId)
+  const start = parseDateKey(startDate)
+  const end = parseDateKey(endDate)
+  const previewLimit = normalizeMaxDays(maxDays)
+  const empty = {
+    ruleId: selectedRuleId,
+    ruleName: rule?.name ?? '',
+    items: [],
+    missingRefs: [],
+    isTruncated: false,
+    projectedDays: 0,
+  }
+
+  if (!rule || !start) return empty
+  if (end && end < start) return empty
+
+  const sequence = parseAttendanceRotationSequenceInput(rule.shiftSequence)
+  if (sequence.length === 0) return empty
+
+  const projectedDays = end ? inclusiveDayCount(start, end) : previewLimit
+  const visibleDays = Math.min(projectedDays, previewLimit)
+  const shiftList = Array.isArray(shifts) ? shifts : []
+  const hasShiftCatalog = shiftList.length > 0
+  const shiftById = new Map(shiftList.map(shift => [shift.id, shift]))
+  const missingRefs: string[] = []
+
+  const items = Array.from({ length: visibleDays }, (_, index): AttendanceRotationAssignmentPreviewItem => {
+    const shiftRef = sequence[index % sequence.length] ?? ''
+    const shift = shiftById.get(shiftRef)
+    if (!shift && hasShiftCatalog && shiftRef && !missingRefs.includes(shiftRef)) {
+      missingRefs.push(shiftRef)
+    }
+    return {
+      date: formatDateKey(addDays(start, index)),
+      dayIndex: index + 1,
+      sequenceIndex: index % sequence.length,
+      shiftRef,
+      label: shift ? `${shift.name} (${shift.id})` : shiftRef,
+      schedule: shift ? `${shift.workStartTime} -> ${shift.workEndTime}` : '',
+      isKnown: Boolean(shift),
+      isOvernight: Boolean(shift?.isOvernight),
+    }
+  })
+
+  return {
+    ruleId: rule.id,
+    ruleName: rule.name,
+    items,
+    missingRefs,
+    isTruncated: projectedDays > visibleDays,
+    projectedDays,
+  }
 }

--- a/apps/web/tests/AttendanceSchedulingAdminSection.spec.ts
+++ b/apps/web/tests/AttendanceSchedulingAdminSection.spec.ts
@@ -452,6 +452,64 @@ describe('AttendanceSchedulingAdminSection', () => {
     expect(container!.querySelector('[data-attendance-rotation-sequence-missing]')?.textContent).toContain('missing-shift')
   })
 
+  it('renders rotation assignment date impact preview from the selected rule', async () => {
+    const scheduling = createSchedulingBindings({
+      shifts: ref<AttendanceShift[]>([
+        {
+          id: 'shift-a',
+          name: 'Day shift',
+          timezone: 'UTC',
+          workStartTime: '09:00',
+          workEndTime: '18:00',
+          isOvernight: false,
+          lateGraceMinutes: 10,
+          earlyGraceMinutes: 10,
+          roundingMinutes: 5,
+          workingDays: [1, 2, 3, 4, 5],
+        },
+        {
+          id: 'shift-b',
+          name: 'Night shift',
+          timezone: 'UTC',
+          workStartTime: '22:00',
+          workEndTime: '06:00',
+          isOvernight: true,
+          lateGraceMinutes: 10,
+          earlyGraceMinutes: 10,
+          roundingMinutes: 5,
+          workingDays: [1, 2, 3, 4, 5],
+        },
+      ]),
+      rotationAssignmentForm: reactive<RotationAssignmentFormState>({
+        userId: 'user-7',
+        rotationRuleId: 'rot-1',
+        startDate: '2026-03-01',
+        endDate: '2026-03-03',
+        isActive: true,
+      }),
+    })
+
+    app = createApp(AttendanceSchedulingAdminSection, {
+      tr,
+      scheduling,
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const preview = container!.querySelector('[data-attendance-rotation-assignment-preview]')
+    expect(preview).toBeTruthy()
+    expect(preview?.textContent).toContain('Assignment impact preview')
+    expect(preview?.textContent).toContain('Two shift')
+    expect(preview?.textContent).toContain('2026-03-01')
+    expect(preview?.textContent).toContain('Day 1')
+    expect(preview?.textContent).toContain('Day shift (shift-a)')
+    expect(preview?.textContent).toContain('2026-03-02')
+    expect(preview?.textContent).toContain('Night shift (shift-b)')
+    expect(preview?.textContent).toContain('22:00 -> 06:00')
+    expect(preview?.textContent).toContain('Overnight')
+    expect(container!.querySelector('[data-attendance-rotation-assignment-missing]')).toBeFalsy()
+  })
+
   it('falls back to plain counts when nothing is being edited', async () => {
     const scheduling = createSchedulingBindings({
       rotationRuleEditingId: ref(null),

--- a/apps/web/tests/attendanceRotationSequencePreview.spec.ts
+++ b/apps/web/tests/attendanceRotationSequencePreview.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildAttendanceRotationAssignmentPreview,
   buildAttendanceRotationSequencePreview,
   parseAttendanceRotationSequenceInput,
 } from '../src/views/attendance/attendanceRotationSequencePreview'
@@ -88,5 +89,100 @@ describe('attendance rotation sequence preview', () => {
         isKnown: false,
       }),
     ])
+  })
+
+  it('projects a selected rotation rule across the assignment date window', () => {
+    const preview = buildAttendanceRotationAssignmentPreview({
+      rotationRuleId: 'rot-1',
+      rotationRules: [
+        {
+          id: 'rot-1',
+          name: 'Two shift',
+          shiftSequence: ['shift-a', 'shift-b'],
+        },
+      ],
+      shifts: [
+        {
+          id: 'shift-a',
+          name: 'Day shift',
+          workStartTime: '09:00',
+          workEndTime: '18:00',
+        },
+        {
+          id: 'shift-b',
+          name: 'Night shift',
+          workStartTime: '22:00',
+          workEndTime: '06:00',
+          isOvernight: true,
+        },
+      ],
+      startDate: '2026-03-01',
+      endDate: '2026-03-04',
+    })
+
+    expect(preview.ruleName).toBe('Two shift')
+    expect(preview.projectedDays).toBe(4)
+    expect(preview.isTruncated).toBe(false)
+    expect(preview.items.map(item => [item.date, item.dayIndex, item.shiftRef, item.label])).toEqual([
+      ['2026-03-01', 1, 'shift-a', 'Day shift (shift-a)'],
+      ['2026-03-02', 2, 'shift-b', 'Night shift (shift-b)'],
+      ['2026-03-03', 3, 'shift-a', 'Day shift (shift-a)'],
+      ['2026-03-04', 4, 'shift-b', 'Night shift (shift-b)'],
+    ])
+    expect(preview.items[1]?.isOvernight).toBe(true)
+  })
+
+  it('caps open-ended rotation assignment previews and reports missing shift refs once', () => {
+    const preview = buildAttendanceRotationAssignmentPreview({
+      rotationRuleId: 'rot-1',
+      rotationRules: [
+        {
+          id: 'rot-1',
+          name: 'Legacy rotation',
+          shiftSequence: ['shift-a', 'missing-shift'],
+        },
+      ],
+      shifts: [
+        {
+          id: 'shift-a',
+          name: 'Day shift',
+          workStartTime: '09:00',
+          workEndTime: '18:00',
+        },
+      ],
+      startDate: '2026-03-01',
+      endDate: null,
+      maxDays: 3,
+    })
+
+    expect(preview.projectedDays).toBe(3)
+    expect(preview.isTruncated).toBe(false)
+    expect(preview.missingRefs).toEqual(['missing-shift'])
+    expect(preview.items.map(item => [item.date, item.shiftRef, item.isKnown])).toEqual([
+      ['2026-03-01', 'shift-a', true],
+      ['2026-03-02', 'missing-shift', false],
+      ['2026-03-03', 'shift-a', true],
+    ])
+  })
+
+  it('marks long closed assignment previews as truncated', () => {
+    const preview = buildAttendanceRotationAssignmentPreview({
+      rotationRuleId: 'rot-1',
+      rotationRules: [
+        {
+          id: 'rot-1',
+          name: 'Long rotation',
+          shiftSequence: ['shift-a'],
+        },
+      ],
+      shifts: [],
+      startDate: '2026-03-01',
+      endDate: '2026-03-10',
+      maxDays: 4,
+    })
+
+    expect(preview.projectedDays).toBe(10)
+    expect(preview.items).toHaveLength(4)
+    expect(preview.isTruncated).toBe(true)
   })
 })

--- a/docs/development/attendance-rotation-assignment-preview-development-20260521.md
+++ b/docs/development/attendance-rotation-assignment-preview-development-20260521.md
@@ -1,0 +1,59 @@
+# Attendance Rotation Assignment Preview Development 2026-05-21
+
+## Summary
+
+This slice adds a frontend-only advisory preview for rotation assignments. When an admin selects a rotation rule and date window, the UI now projects the first scheduled days for that user assignment from the rule sequence and the loaded shift catalog.
+
+The change builds on the earlier conflict diagnostics and rotation sequence preview work:
+
+- Conflict diagnostics still explain overlap risk between fixed shift assignments and rotation assignments.
+- Rotation rule sequence preview still explains the rule cycle itself.
+- This slice bridges those two surfaces by showing what the selected rotation assignment will do on concrete dates before the admin saves it.
+
+## Scope
+
+- Add `buildAttendanceRotationAssignmentPreview()` to the existing rotation sequence preview helper.
+- Render assignment impact preview in `AttendanceSchedulingAdminSection.vue`.
+- Keep production `AttendanceView.vue` in parity with the extracted scheduling section.
+- Add focused unit and component coverage.
+- Add this development note and a verification note.
+
+## Boundaries
+
+- No backend routes.
+- No database migration.
+- No `attendance_*` fact-source change.
+- No direct `meta_*` reads or writes.
+- No new save-blocking validator.
+- Preview remains advisory; backend save behavior is unchanged.
+
+## Behavior
+
+The preview uses:
+
+- `rotationAssignmentForm.rotationRuleId`
+- `rotationAssignmentForm.startDate`
+- `rotationAssignmentForm.endDate`
+- loaded `rotationRules`
+- loaded `shifts`
+
+For closed ranges, it projects each date from `startDate` through `endDate`, capped at 14 visible rows. For open-ended ranges, it projects 14 days. The sequence repeats by modulo over `rotationRule.shiftSequence`.
+
+Known shift IDs display shift name, ID, schedule, and overnight marker. Unknown shift IDs remain visible and are reported once in a warning. This mirrors the prior sequence preview behavior and avoids silently hiding legacy or not-yet-loaded references.
+
+## Files Changed
+
+- `apps/web/src/views/attendance/attendanceRotationSequencePreview.ts`
+  - Added assignment preview types and `buildAttendanceRotationAssignmentPreview()`.
+- `apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue`
+  - Added the advisory assignment impact preview panel near rotation assignment conflict diagnostics.
+- `apps/web/src/views/AttendanceView.vue`
+  - Added the same production monolith preview to keep parity until the extracted section fully replaces it.
+- `apps/web/tests/attendanceRotationSequencePreview.spec.ts`
+  - Added date-window, open-ended cap, missing-ref, and truncation coverage.
+- `apps/web/tests/AttendanceSchedulingAdminSection.spec.ts`
+  - Added component coverage for rendered assignment impact preview rows.
+
+## Notes
+
+This is intentionally not a full calendar renderer and does not apply holidays, effective working-day overrides, or runtime attendance calculation. It is an operator-facing preview of the selected rotation rule sequence over dates. Runtime truth remains in backend scheduling evaluation.

--- a/docs/development/attendance-rotation-assignment-preview-verification-20260521.md
+++ b/docs/development/attendance-rotation-assignment-preview-verification-20260521.md
@@ -1,0 +1,62 @@
+# Attendance Rotation Assignment Preview Verification 2026-05-21
+
+## Local Verification
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/attendanceRotationSequencePreview.spec.ts \
+  tests/AttendanceSchedulingAdminSection.spec.ts \
+  --watch=false
+```
+
+Result: PASS, 2 files / 14 tests.
+
+## Regression Verification
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/attendanceRotationSequencePreview.spec.ts \
+  tests/AttendanceSchedulingAdminSection.spec.ts \
+  tests/useAttendanceAdminScheduling.spec.ts \
+  tests/attendance-admin-regressions.spec.ts \
+  --watch=false
+```
+
+Result: PASS, 4 files / 48 tests.
+
+```bash
+pnpm --filter @metasheet/web type-check
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: PASS. Vite emitted the existing `WorkflowDesigner.vue` mixed static/dynamic import warning and large chunk warnings; no new build failure.
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+## Coverage
+
+- Parses and reuses rotation rule shift sequences.
+- Projects closed date windows into date-by-date preview rows.
+- Repeats shift sequences across assignment dates.
+- Displays overnight shift metadata.
+- Caps open-ended previews to a bounded row count.
+- Marks long closed ranges as truncated.
+- Reports missing shift references once while keeping rows visible.
+- Renders the assignment impact preview in the extracted scheduling admin section.
+
+## Boundary Check
+
+- No backend route changes.
+- No database migrations.
+- No `attendance_*` fact-source changes.
+- No direct `meta_*` reads or writes.
+- No save-blocking client validator.


### PR DESCRIPTION
## Summary

Adds an advisory **rotation assignment impact preview** to attendance scheduling.

- Projects the selected rotation rule over the assignment start/end date window.
- Reuses the loaded shift catalog to show shift name, ID, schedule, and overnight markers.
- Keeps unresolved shift references visible and reports missing loaded shift IDs once.
- Renders the same preview in the extracted scheduling section and the current production `AttendanceView.vue` monolith.

This is frontend-only: no backend routes, no migration, no `attendance_*` fact-source change, no `meta_*` writes, and no save-blocking client validator.

## Test plan

- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceRotationSequencePreview.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts --watch=false`
- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceRotationSequencePreview.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts tests/useAttendanceAdminScheduling.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false`
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `pnpm --filter @metasheet/web build`
- [x] `git diff --check`

## Docs

- `docs/development/attendance-rotation-assignment-preview-development-20260521.md`
- `docs/development/attendance-rotation-assignment-preview-verification-20260521.md`
