### PR TITLE
feat(attendance): show calendar context in rotation preview

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -4550,6 +4550,17 @@
                       {{ item.schedule }}<template v-if="item.isOvernight"> · {{ tr('Overnight', '跨夜') }}</template>
                     </span>
                     <span v-else>{{ tr('Unresolved shift', '未解析班次') }}</span>
+                    <span
+                      v-if="item.calendar"
+                      class="attendance__rotation-assignment-calendar-chip"
+                      :class="item.calendar.sourceClass"
+                      :title="item.calendar.tooltip"
+                      :data-calendar-working-day="item.calendar.isWorkingDay === true ? 'true' : item.calendar.isWorkingDay === false ? 'false' : 'unknown'"
+                      :data-calendar-source="item.calendar.source || ''"
+                      :data-calendar-override="item.calendar.hasOverride ? 'true' : 'false'"
+                    >
+                      {{ item.calendar.label || (item.calendar.isWorkingDay === false ? tr('Rest day', '休息日') : tr('Working day', '工作日')) }}
+                    </span>
                   </li>
                 </ol>
                 <small
@@ -4561,7 +4572,7 @@
                   {{ rotationAssignmentPreview.missingRefs.join(', ') }}
                 </small>
                 <small class="attendance__field-hint">
-                  {{ tr('Preview is advisory and uses the current loaded rule, dates, and shift catalog.', '预览仅作提示，基于当前已加载的规则、日期和班次目录计算。') }}
+                  {{ tr('Preview is advisory and uses the current loaded rule, dates, shift catalog, and effective-calendar context for the selected user/date.', '预览仅作提示，基于当前已加载的规则、日期、班次目录以及所选用户/日期的生效日历上下文计算。') }}
                 </small>
               </div>
               <div class="attendance__admin-grid">
@@ -4998,6 +5009,8 @@ import {
 import {
   buildCalendarChipTooltip,
   calendarChipSourceClassName,
+  fallbackChipName,
+  hasCalendarChipOverrideMarker,
 } from '../services/attendance/calendarChipDisplay'
 import {
   buildAttendanceScheduleConflictDiagnostics,
@@ -5005,6 +5018,7 @@ import {
   type AttendanceScheduleConflictDiagnostic,
 } from './attendance/attendanceScheduleConflictDiagnostics'
 import {
+  buildAttendanceRotationAssignmentCalendarMap,
   buildAttendanceRotationAssignmentPreview,
   buildAttendanceRotationSequencePreview,
   parseAttendanceRotationSequenceInput,
@@ -7684,6 +7698,40 @@ watch(committedCalendarUserId, (next) => {
   }
 })
 
+async function loadEffectiveCalendarForRotationAssignment(
+  range: { userId: string; from: string; to: string },
+): Promise<void> {
+  const userId = range.userId.trim()
+  const from = range.from.trim()
+  const to = range.to.trim()
+  if (!userId || !from || !to) return
+  const cacheKey = `${userId}|${from}|${to}`
+  if (rotationAssignmentEffectiveCalendarCacheKey === cacheKey) return
+  rotationAssignmentEffectiveCalendarCacheKey = cacheKey
+  const loadVersion = ++rotationAssignmentEffectiveCalendarLoadVersion
+  try {
+    const result = await fetchEffectiveCalendar({
+      from,
+      to,
+      userId,
+      suppressUnauthorizedRedirect: true,
+    })
+    if (loadVersion !== rotationAssignmentEffectiveCalendarLoadVersion) return
+    const items = Array.isArray(result?.items) ? result.items : []
+    rotationAssignmentEffectiveCalendarChips.value = items
+      .filter(isCalendarEffectiveItemNoteworthy)
+      .map(effectiveCalendarItemToChip)
+  } catch (error) {
+    if (loadVersion === rotationAssignmentEffectiveCalendarLoadVersion) {
+      rotationAssignmentEffectiveCalendarChips.value = []
+      rotationAssignmentEffectiveCalendarCacheKey = null
+    }
+    if (error instanceof EffectiveCalendarFetchError) {
+      console.debug('[AttendanceView] rotation assignment effective-calendar load failed', error.status, error.message)
+    }
+  }
+}
+
 watch(
   calendarMonth,
   (month) => {
@@ -7921,7 +7969,11 @@ const rotationAssignmentForm = reactive({
   isActive: true,
 })
 
-const rotationAssignmentPreview = computed(() => buildAttendanceRotationAssignmentPreview({
+const rotationAssignmentEffectiveCalendarChips = ref<CalendarEffectiveChip[]>([])
+let rotationAssignmentEffectiveCalendarCacheKey: string | null = null
+let rotationAssignmentEffectiveCalendarLoadVersion = 0
+
+const rotationAssignmentPreviewBase = computed(() => buildAttendanceRotationAssignmentPreview({
   rotationRuleId: rotationAssignmentForm.rotationRuleId,
   rotationRules: rotationRules.value,
   shifts: shifts.value,
@@ -7929,6 +7981,46 @@ const rotationAssignmentPreview = computed(() => buildAttendanceRotationAssignme
   endDate: rotationAssignmentForm.endDate || null,
   maxDays: 14,
 }))
+
+const rotationAssignmentCalendarByDate = computed(() => buildAttendanceRotationAssignmentCalendarMap(
+  rotationAssignmentEffectiveCalendarChips.value.map((chip) => ({
+    date: chip.date,
+    isWorkingDay: chip.effective?.isWorkingDay ?? chip.isWorkingDay,
+    label: chip.name || fallbackChipName(chip),
+    source: chip.effective?.source,
+    sourceClass: calendarChipSourceClassName(chip.effective?.source),
+    tooltip: buildCalendarChipTooltip(chip),
+    hasOverride: hasCalendarChipOverrideMarker(chip),
+  })),
+))
+
+const rotationAssignmentPreview = computed(() => buildAttendanceRotationAssignmentPreview({
+  rotationRuleId: rotationAssignmentForm.rotationRuleId,
+  rotationRules: rotationRules.value,
+  shifts: shifts.value,
+  startDate: rotationAssignmentForm.startDate,
+  endDate: rotationAssignmentForm.endDate || null,
+  maxDays: 14,
+  calendarByDate: rotationAssignmentCalendarByDate.value,
+}))
+
+const rotationAssignmentEffectiveCalendarRange = computed(() => {
+  const userId = rotationAssignmentForm.userId.trim()
+  const items = rotationAssignmentPreviewBase.value.items
+  const first = items[0]
+  const last = items[items.length - 1]
+  if (!userId || !first || !last) return null
+  return { userId, from: first.date, to: last.date }
+})
+
+watch(rotationAssignmentEffectiveCalendarRange, (range) => {
+  if (!range) {
+    rotationAssignmentEffectiveCalendarChips.value = []
+    rotationAssignmentEffectiveCalendarCacheKey = null
+    return
+  }
+  void loadEffectiveCalendarForRotationAssignment(range)
+}, { immediate: true })
 
 const scheduleConflictDiagnostics = computed(() => buildAttendanceScheduleConflictDiagnostics({
   assignments: assignments.value,
@@ -15136,7 +15228,7 @@ const holidaySectionBindings = {
 
 .attendance__rotation-assignment-preview li {
   display: grid;
-  grid-template-columns: minmax(96px, max-content) minmax(56px, max-content) minmax(120px, 1fr) minmax(120px, max-content);
+  grid-template-columns: minmax(96px, max-content) minmax(56px, max-content) minmax(120px, 1fr) minmax(120px, max-content) minmax(92px, max-content);
   gap: 8px;
   align-items: center;
 }
@@ -15147,6 +15239,24 @@ const holidaySectionBindings = {
 
 .attendance__rotation-assignment-preview li[data-rotation-assignment-known="false"] {
   color: #92400e;
+}
+
+.attendance__rotation-assignment-calendar-chip {
+  border: 1px solid var(--calendar-source-accent, #bfdbfe);
+  border-left-width: 3px;
+  border-radius: 999px;
+  padding: 2px 8px;
+  color: #1f2937;
+  background: #fff;
+  white-space: nowrap;
+}
+
+.attendance__rotation-assignment-calendar-chip[data-calendar-working-day="false"] {
+  background: #fef3c7;
+}
+
+.attendance__rotation-assignment-calendar-chip[data-calendar-override="true"] {
+  border-style: dashed;
 }
 
 .attendance__field-hint--warning {

--- a/apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue
+++ b/apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue
@@ -256,6 +256,17 @@
             {{ item.schedule }}<template v-if="item.isOvernight"> · {{ tr('Overnight', '跨夜') }}</template>
           </span>
           <span v-else>{{ tr('Unresolved shift', '未解析班次') }}</span>
+          <span
+            v-if="item.calendar"
+            class="attendance__rotation-assignment-calendar-chip"
+            :class="item.calendar.sourceClass"
+            :title="item.calendar.tooltip"
+            :data-calendar-working-day="item.calendar.isWorkingDay === true ? 'true' : item.calendar.isWorkingDay === false ? 'false' : 'unknown'"
+            :data-calendar-source="item.calendar.source || ''"
+            :data-calendar-override="item.calendar.hasOverride ? 'true' : 'false'"
+          >
+            {{ item.calendar.label || (item.calendar.isWorkingDay === false ? tr('Rest day', '休息日') : tr('Working day', '工作日')) }}
+          </span>
         </li>
       </ol>
       <small
@@ -267,7 +278,7 @@
         {{ rotationAssignmentPreview.missingRefs.join(', ') }}
       </small>
       <small class="attendance__field-hint">
-        {{ tr('Preview is advisory and uses the current loaded rule, dates, and shift catalog.', '预览仅作提示，基于当前已加载的规则、日期和班次目录计算。') }}
+        {{ tr('Preview is advisory and uses the current loaded rule, dates, shift catalog, and optional effective-calendar context.', '预览仅作提示，基于当前已加载的规则、日期、班次目录和可选生效日历上下文计算。') }}
       </small>
     </div>
     <div class="attendance__admin-grid">
@@ -635,10 +646,19 @@ import {
   type AttendanceScheduleConflictDiagnostic,
 } from './attendanceScheduleConflictDiagnostics'
 import {
+  buildAttendanceRotationAssignmentCalendarMap,
   buildAttendanceRotationAssignmentPreview,
   buildAttendanceRotationSequencePreview,
   parseAttendanceRotationSequenceInput,
+  type AttendanceRotationAssignmentCalendarLike,
 } from './attendanceRotationSequencePreview'
+import {
+  buildCalendarChipTooltip,
+  calendarChipSourceClassName,
+  fallbackChipName,
+  hasCalendarChipOverrideMarker,
+} from '../../services/attendance/calendarChipDisplay'
+import type { CalendarEffectiveChip } from '../../services/attendance/effectiveCalendar'
 
 type Translate = (en: string, zh: string) => string
 type MaybePromise<T> = T | Promise<T>
@@ -739,6 +759,7 @@ interface SchedulingBindings {
 const props = defineProps<{
   tr: Translate
   scheduling: SchedulingBindings
+  rotationAssignmentCalendarChips?: CalendarEffectiveChip[]
 }>()
 
 const tr = props.tr
@@ -836,6 +857,18 @@ const rotationSequencePreviewText = computed(() => {
     .join(' -> ')
 })
 
+const rotationAssignmentCalendarByDate = computed(() => buildAttendanceRotationAssignmentCalendarMap(
+  (props.rotationAssignmentCalendarChips ?? []).map((chip) => ({
+    date: chip.date,
+    isWorkingDay: chip.effective?.isWorkingDay ?? chip.isWorkingDay,
+    label: chip.name || fallbackChipName(chip),
+    source: chip.effective?.source,
+    sourceClass: calendarChipSourceClassName(chip.effective?.source),
+    tooltip: buildCalendarChipTooltip(chip),
+    hasOverride: hasCalendarChipOverrideMarker(chip),
+  })),
+))
+
 const rotationAssignmentPreview = computed(() => buildAttendanceRotationAssignmentPreview({
   rotationRuleId: rotationAssignmentForm.rotationRuleId,
   rotationRules: rotationRules.value,
@@ -843,6 +876,7 @@ const rotationAssignmentPreview = computed(() => buildAttendanceRotationAssignme
   startDate: rotationAssignmentForm.startDate,
   endDate: rotationAssignmentForm.endDate || null,
   maxDays: 14,
+  calendarByDate: rotationAssignmentCalendarByDate.value,
 }))
 
 const rotationRuleEditingLabel = computed(() => {
@@ -1034,7 +1068,7 @@ const assignmentEditingLabel = computed(() => {
 
 .attendance__rotation-assignment-preview li {
   display: grid;
-  grid-template-columns: minmax(96px, max-content) minmax(56px, max-content) minmax(120px, 1fr) minmax(120px, max-content);
+  grid-template-columns: minmax(96px, max-content) minmax(56px, max-content) minmax(120px, 1fr) minmax(120px, max-content) minmax(92px, max-content);
   gap: 8px;
   align-items: center;
 }
@@ -1045,6 +1079,24 @@ const assignmentEditingLabel = computed(() => {
 
 .attendance__rotation-assignment-preview li[data-rotation-assignment-known="false"] {
   color: #92400e;
+}
+
+.attendance__rotation-assignment-calendar-chip {
+  border: 1px solid var(--calendar-source-accent, #bfdbfe);
+  border-left-width: 3px;
+  border-radius: 999px;
+  padding: 2px 8px;
+  color: #1f2937;
+  background: #fff;
+  white-space: nowrap;
+}
+
+.attendance__rotation-assignment-calendar-chip[data-calendar-working-day="false"] {
+  background: #fef3c7;
+}
+
+.attendance__rotation-assignment-calendar-chip[data-calendar-override="true"] {
+  border-style: dashed;
 }
 
 .attendance__field-hint--warning {

--- a/apps/web/src/views/attendance/attendanceRotationSequencePreview.ts
+++ b/apps/web/src/views/attendance/attendanceRotationSequencePreview.ts
@@ -29,6 +29,7 @@ export interface AttendanceRotationAssignmentRuleLike {
 export interface AttendanceRotationAssignmentPreviewItem extends AttendanceRotationSequencePreviewItem {
   date: string
   sequenceIndex: number
+  calendar?: AttendanceRotationAssignmentCalendarLike
 }
 
 export interface AttendanceRotationAssignmentPreview {
@@ -40,6 +41,16 @@ export interface AttendanceRotationAssignmentPreview {
   projectedDays: number
 }
 
+export interface AttendanceRotationAssignmentCalendarLike {
+  date: string
+  isWorkingDay?: boolean
+  label?: string | null
+  source?: string
+  sourceClass?: string
+  tooltip?: string
+  hasOverride?: boolean
+}
+
 export interface BuildAttendanceRotationAssignmentPreviewInput {
   rotationRuleId: string | null | undefined
   rotationRules: AttendanceRotationAssignmentRuleLike[] | null | undefined
@@ -47,6 +58,7 @@ export interface BuildAttendanceRotationAssignmentPreviewInput {
   startDate: string | null | undefined
   endDate?: string | null
   maxDays?: number
+  calendarByDate?: Map<string, AttendanceRotationAssignmentCalendarLike>
 }
 
 const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
@@ -75,6 +87,19 @@ function inclusiveDayCount(startDate: Date, endDate: Date): number {
 function normalizeMaxDays(value: number | null | undefined): number {
   if (typeof value !== 'number' || !Number.isFinite(value)) return 14
   return Math.min(Math.max(Math.floor(value), 1), 60)
+}
+
+export function buildAttendanceRotationAssignmentCalendarMap(
+  items: AttendanceRotationAssignmentCalendarLike[] | null | undefined,
+): Map<string, AttendanceRotationAssignmentCalendarLike> {
+  const map = new Map<string, AttendanceRotationAssignmentCalendarLike>()
+  if (!Array.isArray(items)) return map
+  for (const item of items) {
+    const date = typeof item.date === 'string' ? item.date.trim() : ''
+    if (!DATE_KEY_PATTERN.test(date)) continue
+    map.set(date, { ...item, date })
+  }
+  return map
 }
 
 export function parseAttendanceRotationSequenceInput(value: string | string[] | null | undefined): string[] {
@@ -122,6 +147,7 @@ export function buildAttendanceRotationAssignmentPreview({
   startDate,
   endDate,
   maxDays,
+  calendarByDate,
 }: BuildAttendanceRotationAssignmentPreviewInput): AttendanceRotationAssignmentPreview {
   const selectedRuleId = typeof rotationRuleId === 'string' ? rotationRuleId.trim() : ''
   const ruleList = Array.isArray(rotationRules) ? rotationRules : []
@@ -154,11 +180,12 @@ export function buildAttendanceRotationAssignmentPreview({
   const items = Array.from({ length: visibleDays }, (_, index): AttendanceRotationAssignmentPreviewItem => {
     const shiftRef = sequence[index % sequence.length] ?? ''
     const shift = shiftById.get(shiftRef)
+    const date = formatDateKey(addDays(start, index))
     if (!shift && hasShiftCatalog && shiftRef && !missingRefs.includes(shiftRef)) {
       missingRefs.push(shiftRef)
     }
     return {
-      date: formatDateKey(addDays(start, index)),
+      date,
       dayIndex: index + 1,
       sequenceIndex: index % sequence.length,
       shiftRef,
@@ -166,6 +193,7 @@ export function buildAttendanceRotationAssignmentPreview({
       schedule: shift ? `${shift.workStartTime} -> ${shift.workEndTime}` : '',
       isKnown: Boolean(shift),
       isOvernight: Boolean(shift?.isOvernight),
+      calendar: calendarByDate?.get(date),
     }
   })
 

--- a/apps/web/tests/AttendanceSchedulingAdminSection.spec.ts
+++ b/apps/web/tests/AttendanceSchedulingAdminSection.spec.ts
@@ -7,6 +7,7 @@ import type {
   AttendanceRotationRule,
   AttendanceShift,
 } from '../src/views/attendance/useAttendanceAdminScheduling'
+import type { CalendarEffectiveChip } from '../src/services/attendance/effectiveCalendar'
 
 type Translate = (en: string, zh: string) => string
 
@@ -492,6 +493,21 @@ describe('AttendanceSchedulingAdminSection', () => {
     app = createApp(AttendanceSchedulingAdminSection, {
       tr,
       scheduling,
+      rotationAssignmentCalendarChips: [
+        {
+          id: 'calendar-1',
+          date: '2026-03-02',
+          name: 'Org rest override',
+          isWorkingDay: false,
+          effective: { isWorkingDay: false, source: 'org', label: 'Org rest override', policyId: 'policy-1' },
+          base: { isWorkingDay: true, source: 'rotation' },
+          layers: [
+            { kind: 'base_rule', source: 'rotation', isWorkingDay: true, label: 'Rotation workday' },
+            { kind: 'calendar_policy', source: 'org', isWorkingDay: false, label: 'Org rest override', refId: 'policy-1' },
+          ],
+          overlays: [],
+        } satisfies CalendarEffectiveChip,
+      ],
     })
     app.mount(container!)
     await flushUi()
@@ -507,6 +523,12 @@ describe('AttendanceSchedulingAdminSection', () => {
     expect(preview?.textContent).toContain('Night shift (shift-b)')
     expect(preview?.textContent).toContain('22:00 -> 06:00')
     expect(preview?.textContent).toContain('Overnight')
+    expect(preview?.textContent).toContain('Org rest override')
+    const calendarChip = container!.querySelector('[data-calendar-source="org"]')
+    expect(calendarChip).toBeTruthy()
+    expect(calendarChip?.getAttribute('data-calendar-working-day')).toBe('false')
+    expect(calendarChip?.getAttribute('data-calendar-override')).toBe('true')
+    expect(calendarChip?.getAttribute('title')).toContain('Layers:')
     expect(container!.querySelector('[data-attendance-rotation-assignment-missing]')).toBeFalsy()
   })
 

--- a/apps/web/tests/attendanceRotationSequencePreview.spec.ts
+++ b/apps/web/tests/attendanceRotationSequencePreview.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildAttendanceRotationAssignmentCalendarMap,
   buildAttendanceRotationAssignmentPreview,
   buildAttendanceRotationSequencePreview,
   parseAttendanceRotationSequenceInput,
@@ -184,5 +185,59 @@ describe('attendance rotation sequence preview', () => {
     expect(preview.projectedDays).toBe(10)
     expect(preview.items).toHaveLength(4)
     expect(preview.isTruncated).toBe(true)
+  })
+
+  it('attaches effective-calendar context by preview date without changing row order', () => {
+    const calendarByDate = buildAttendanceRotationAssignmentCalendarMap([
+      {
+        date: '2026-03-02',
+        isWorkingDay: false,
+        label: 'Org rest override',
+        source: 'org',
+        sourceClass: 'calendar-source--org',
+        tooltip: '2026-03-02 — Rest day · org',
+        hasOverride: true,
+      },
+      {
+        date: 'invalid-date',
+        label: 'ignored',
+      },
+    ])
+    const preview = buildAttendanceRotationAssignmentPreview({
+      rotationRuleId: 'rot-1',
+      rotationRules: [
+        {
+          id: 'rot-1',
+          name: 'Two shift',
+          shiftSequence: ['shift-a', 'shift-b'],
+        },
+      ],
+      shifts: [
+        {
+          id: 'shift-a',
+          name: 'Day shift',
+          workStartTime: '09:00',
+          workEndTime: '18:00',
+        },
+        {
+          id: 'shift-b',
+          name: 'Night shift',
+          workStartTime: '22:00',
+          workEndTime: '06:00',
+        },
+      ],
+      startDate: '2026-03-01',
+      endDate: '2026-03-03',
+      calendarByDate,
+    })
+
+    expect(preview.items.map(item => item.date)).toEqual(['2026-03-01', '2026-03-02', '2026-03-03'])
+    expect(preview.items[0]?.calendar).toBeUndefined()
+    expect(preview.items[1]?.calendar).toMatchObject({
+      label: 'Org rest override',
+      source: 'org',
+      sourceClass: 'calendar-source--org',
+      hasOverride: true,
+    })
   })
 })

--- a/docs/development/attendance-rotation-calendar-context-preview-development-20260521.md
+++ b/docs/development/attendance-rotation-calendar-context-preview-development-20260521.md
@@ -1,0 +1,60 @@
+# Attendance Rotation Calendar Context Preview Development 2026-05-21
+
+## Summary
+
+This slice extends the rotation assignment impact preview with effective-calendar context. The assignment preview still projects the selected rotation rule over the draft date window, and now each preview row can show a compact calendar chip for notable user/date context such as a holiday, calendar policy override, or approved overlay.
+
+The key wording is intentional: this is calendar context for the selected user/date, not the final computed result of an unsaved draft rotation assignment. Runtime scheduling truth remains in the backend.
+
+## Scope
+
+- Reuse the existing `/api/attendance/effective-calendar` frontend client.
+- Reuse existing calendar display helpers:
+  - `effectiveCalendarItemToChip`
+  - `isCalendarEffectiveItemNoteworthy`
+  - `calendarChipSourceClassName`
+  - `hasCalendarChipOverrideMarker`
+  - `buildCalendarChipTooltip`
+  - `fallbackChipName`
+- Enrich rotation assignment preview rows by date when effective-calendar chips are available.
+- Keep `AttendanceSchedulingAdminSection.vue` parity through an optional `rotationAssignmentCalendarChips` prop.
+- Let production `AttendanceView.vue` fetch effective-calendar chips for the draft `userId` and visible preview date range.
+
+## Boundaries
+
+- No backend route changes.
+- No database migration.
+- No direct `attendance_*` fact-source changes.
+- No direct `meta_*` reads or writes.
+- No save-blocking frontend validator.
+- No attempt to make the backend evaluate unsaved rotation assignment drafts.
+
+## Behavior
+
+In production `AttendanceView.vue`, when the rotation assignment draft has a selected user, selected rotation rule, valid start date, and visible preview rows:
+
+1. The UI computes the visible preview date range.
+2. It fetches effective-calendar data for `{ userId, from, to }`.
+3. It filters to noteworthy items only, matching the personal calendar behavior.
+4. It converts effective-calendar items into chips.
+5. It indexes chips by date and attaches matching chip context to the existing preview rows.
+
+Fetch failures clear only the context chips. The assignment preview remains visible, and save behavior is unchanged.
+
+## Files Changed
+
+- `apps/web/src/views/attendance/attendanceRotationSequencePreview.ts`
+  - Added optional calendar context on assignment preview rows.
+  - Added `buildAttendanceRotationAssignmentCalendarMap()`.
+- `apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue`
+  - Added optional effective-calendar chip rendering for extracted scheduling UI parity.
+- `apps/web/src/views/AttendanceView.vue`
+  - Added draft-range effective-calendar fetch and chip rendering in the production admin surface.
+- `apps/web/tests/attendanceRotationSequencePreview.spec.ts`
+  - Added date-based calendar context attachment coverage.
+- `apps/web/tests/AttendanceSchedulingAdminSection.spec.ts`
+  - Added calendar chip rendering assertions on the assignment preview.
+
+## Design Notes
+
+The preview is deliberately scoped to the already visible rows, currently capped at 14 days. Long assignments still show a bounded sample, and the calendar fetch uses the same visible sample range. This keeps the surface responsive and avoids introducing a background scheduling simulator.

--- a/docs/development/attendance-rotation-calendar-context-preview-verification-20260521.md
+++ b/docs/development/attendance-rotation-calendar-context-preview-verification-20260521.md
@@ -1,0 +1,63 @@
+# Attendance Rotation Calendar Context Preview Verification 2026-05-21
+
+## Local Verification
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/attendanceRotationSequencePreview.spec.ts \
+  tests/AttendanceSchedulingAdminSection.spec.ts \
+  --watch=false
+```
+
+Result: PASS, 2 files / 15 tests.
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/attendanceRotationSequencePreview.spec.ts \
+  tests/AttendanceSchedulingAdminSection.spec.ts \
+  tests/useAttendanceAdminScheduling.spec.ts \
+  tests/effectiveCalendar.spec.ts \
+  tests/calendarChipDisplay.spec.ts \
+  tests/attendance-admin-regressions.spec.ts \
+  --watch=false
+```
+
+Result: PASS, 6 files / 76 tests.
+
+## Coverage
+
+- Rotation assignment preview still projects rule sequences by date.
+- Calendar context attaches by exact preview date without changing row order.
+- Invalid calendar dates are ignored by the map helper.
+- Extracted scheduling UI renders effective-calendar chip label, source, working/rest state, override marker, and tooltip.
+- Existing effective-calendar client and chip display tests remain green.
+- Existing attendance admin regression suite remains green, including `AttendanceView.vue` setup.
+
+## Build And Static Verification
+
+```bash
+pnpm --filter @metasheet/web type-check
+```
+
+Result: PASS (`vue-tsc -b`).
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: PASS (`vue-tsc -b && vite build`, with existing Vite chunk-size / mixed static+dynamic import warnings).
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+## Boundary Check
+
+- No backend route changes.
+- No database migrations.
+- No `attendance_*` fact-source changes.
+- No direct `meta_*` reads or writes.
+- No save-blocking client validator.
+- Effective-calendar fetch failure only clears calendar chips; preview/save behavior remains unchanged.


### PR DESCRIPTION
## Summary

Adds effective-calendar context chips to the rotation assignment impact preview. The preview still projects the selected rotation rule over the draft date window, and now notable calendar/holiday/policy context for the selected user/date appears beside matching preview rows.

This is intentionally advisory context, not a backend evaluation of the unsaved draft assignment. Save behavior and backend scheduling truth are unchanged.

## Boundaries

- Frontend-only slice
- No backend route changes
- No database migrations
- No `attendance_*` fact-source changes
- No direct `meta_*` reads or writes
- No save-blocking client validator

## Test plan

- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceRotationSequencePreview.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts --watch=false`
- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceRotationSequencePreview.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts tests/useAttendanceAdminScheduling.spec.ts tests/effectiveCalendar.spec.ts tests/calendarChipDisplay.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false`
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `pnpm --filter @metasheet/web build`
- [x] `git diff --check`

Docs: `docs/development/attendance-rotation-calendar-context-preview-development-20260521.md` and `docs/development/attendance-rotation-calendar-context-preview-verification-20260521.md`.
