### PR TITLE
feat(attendance): preview fixed shift assignment impact

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -4835,6 +4835,58 @@
                   </li>
                 </ul>
               </div>
+              <div
+                v-if="shiftAssignmentPreview.items.length"
+                class="attendance__shift-assignment-preview"
+                data-attendance-shift-assignment-preview
+              >
+                <div class="attendance__preview-header">
+                  <strong>{{ tr('Assignment impact preview', '班次分配影响预览') }}</strong>
+                  <span>
+                    {{ shiftAssignmentPreview.shiftName }}
+                    <template v-if="shiftAssignmentPreview.isTruncated">
+                      · {{ tr(`First ${shiftAssignmentPreview.items.length} of ${shiftAssignmentPreview.projectedDays} days`, `前 ${shiftAssignmentPreview.items.length} / 共 ${shiftAssignmentPreview.projectedDays} 天`) }}
+                    </template>
+                  </span>
+                </div>
+                <ol>
+                  <li
+                    v-for="item in shiftAssignmentPreview.items"
+                    :key="`${item.date}:${item.dayIndex}:${item.shiftId}`"
+                    :data-shift-assignment-known="item.isKnown ? 'true' : 'false'"
+                  >
+                    <span>{{ item.date }}</span>
+                    <span>{{ tr(`Day ${item.dayIndex}`, `第 ${item.dayIndex} 天`) }}</span>
+                    <span>{{ item.label }}</span>
+                    <span v-if="item.isKnown">
+                      {{ item.schedule }}<template v-if="item.isOvernight"> · {{ tr('Overnight', '跨夜') }}</template>
+                    </span>
+                    <span v-else>{{ tr('Unresolved shift', '未解析班次') }}</span>
+                    <span
+                      v-if="item.calendar"
+                      class="attendance__assignment-calendar-chip"
+                      :class="item.calendar.sourceClass"
+                      :title="item.calendar.tooltip"
+                      :data-calendar-working-day="item.calendar.isWorkingDay === true ? 'true' : item.calendar.isWorkingDay === false ? 'false' : 'unknown'"
+                      :data-calendar-source="item.calendar.source || ''"
+                      :data-calendar-override="item.calendar.hasOverride ? 'true' : 'false'"
+                    >
+                      {{ item.calendar.label || (item.calendar.isWorkingDay === false ? tr('Rest day', '休息日') : tr('Working day', '工作日')) }}
+                    </span>
+                  </li>
+                </ol>
+                <small
+                  v-if="shiftAssignmentPreview.missingShiftId"
+                  class="attendance__field-hint attendance__field-hint--warning"
+                  data-attendance-shift-assignment-missing
+                >
+                  {{ tr('This assignment references a shift ID that is not in the loaded shift catalog', '该分配引用了当前已加载班次中不存在的 ID') }}:
+                  {{ shiftAssignmentPreview.missingShiftId }}
+                </small>
+                <small class="attendance__field-hint">
+                  {{ tr('Preview is advisory and uses the selected shift, dates, and effective-calendar context for the selected user/date.', '预览仅作提示，基于所选班次、日期以及所选用户/日期的生效日历上下文计算。') }}
+                </small>
+              </div>
               <div class="attendance__admin-grid">
                 <label class="attendance__field" for="attendance-assignment-user-id">
                   <span>{{ tr('User ID', '用户 ID') }}</span>
@@ -5021,6 +5073,8 @@ import {
   buildAttendanceRotationAssignmentCalendarMap,
   buildAttendanceRotationAssignmentPreview,
   buildAttendanceRotationSequencePreview,
+  buildAttendanceShiftAssignmentCalendarMap,
+  buildAttendanceShiftAssignmentPreview,
   parseAttendanceRotationSequenceInput,
 } from './attendance/attendanceRotationSequencePreview'
 import { usePlugins } from '../composables/usePlugins'
@@ -7732,6 +7786,40 @@ async function loadEffectiveCalendarForRotationAssignment(
   }
 }
 
+async function loadEffectiveCalendarForShiftAssignment(
+  range: { userId: string; from: string; to: string },
+): Promise<void> {
+  const userId = range.userId.trim()
+  const from = range.from.trim()
+  const to = range.to.trim()
+  if (!userId || !from || !to) return
+  const cacheKey = `${userId}|${from}|${to}`
+  if (shiftAssignmentEffectiveCalendarCacheKey === cacheKey) return
+  shiftAssignmentEffectiveCalendarCacheKey = cacheKey
+  const loadVersion = ++shiftAssignmentEffectiveCalendarLoadVersion
+  try {
+    const result = await fetchEffectiveCalendar({
+      from,
+      to,
+      userId,
+      suppressUnauthorizedRedirect: true,
+    })
+    if (loadVersion !== shiftAssignmentEffectiveCalendarLoadVersion) return
+    const items = Array.isArray(result?.items) ? result.items : []
+    shiftAssignmentEffectiveCalendarChips.value = items
+      .filter(isCalendarEffectiveItemNoteworthy)
+      .map(effectiveCalendarItemToChip)
+  } catch (error) {
+    if (loadVersion === shiftAssignmentEffectiveCalendarLoadVersion) {
+      shiftAssignmentEffectiveCalendarChips.value = []
+      shiftAssignmentEffectiveCalendarCacheKey = null
+    }
+    if (error instanceof EffectiveCalendarFetchError) {
+      console.debug('[AttendanceView] shift assignment effective-calendar load failed', error.status, error.message)
+    }
+  }
+}
+
 watch(
   calendarMonth,
   (month) => {
@@ -7908,6 +7996,57 @@ const assignmentForm = reactive({
   endDate: '',
   isActive: true,
 })
+
+const shiftAssignmentEffectiveCalendarChips = ref<CalendarEffectiveChip[]>([])
+let shiftAssignmentEffectiveCalendarCacheKey: string | null = null
+let shiftAssignmentEffectiveCalendarLoadVersion = 0
+
+const shiftAssignmentPreviewBase = computed(() => buildAttendanceShiftAssignmentPreview({
+  shiftId: assignmentForm.shiftId,
+  shifts: shifts.value,
+  startDate: assignmentForm.startDate,
+  endDate: assignmentForm.endDate || null,
+  maxDays: 14,
+}))
+
+const shiftAssignmentCalendarByDate = computed(() => buildAttendanceShiftAssignmentCalendarMap(
+  shiftAssignmentEffectiveCalendarChips.value.map((chip) => ({
+    date: chip.date,
+    isWorkingDay: chip.effective?.isWorkingDay ?? chip.isWorkingDay,
+    label: chip.name || fallbackChipName(chip),
+    source: chip.effective?.source,
+    sourceClass: calendarChipSourceClassName(chip.effective?.source),
+    tooltip: buildCalendarChipTooltip(chip),
+    hasOverride: hasCalendarChipOverrideMarker(chip),
+  })),
+))
+
+const shiftAssignmentPreview = computed(() => buildAttendanceShiftAssignmentPreview({
+  shiftId: assignmentForm.shiftId,
+  shifts: shifts.value,
+  startDate: assignmentForm.startDate,
+  endDate: assignmentForm.endDate || null,
+  maxDays: 14,
+  calendarByDate: shiftAssignmentCalendarByDate.value,
+}))
+
+const shiftAssignmentEffectiveCalendarRange = computed(() => {
+  const userId = assignmentForm.userId.trim()
+  const items = shiftAssignmentPreviewBase.value.items
+  const first = items[0]
+  const last = items[items.length - 1]
+  if (!userId || !first || !last) return null
+  return { userId, from: first.date, to: last.date }
+})
+
+watch(shiftAssignmentEffectiveCalendarRange, (range) => {
+  if (!range) {
+    shiftAssignmentEffectiveCalendarChips.value = []
+    shiftAssignmentEffectiveCalendarCacheKey = null
+    return
+  }
+  void loadEffectiveCalendarForShiftAssignment(range)
+}, { immediate: true })
 
 const holidayForm = reactive({
   date: toDateInput(today),
@@ -15196,7 +15335,8 @@ const holidaySectionBindings = {
   font-size: 12px;
 }
 
-.attendance__rotation-assignment-preview {
+.attendance__rotation-assignment-preview,
+.attendance__shift-assignment-preview {
   border: 1px solid #bfdbfe;
   background: #eff6ff;
   border-radius: 6px;
@@ -15212,7 +15352,8 @@ const holidaySectionBindings = {
 }
 
 .attendance__rotation-sequence-preview ol,
-.attendance__rotation-assignment-preview ol {
+.attendance__rotation-assignment-preview ol,
+.attendance__shift-assignment-preview ol {
   display: grid;
   gap: 6px;
   margin: 8px 0 0;
@@ -15226,7 +15367,8 @@ const holidaySectionBindings = {
   align-items: center;
 }
 
-.attendance__rotation-assignment-preview li {
+.attendance__rotation-assignment-preview li,
+.attendance__shift-assignment-preview li {
   display: grid;
   grid-template-columns: minmax(96px, max-content) minmax(56px, max-content) minmax(120px, 1fr) minmax(120px, max-content) minmax(92px, max-content);
   gap: 8px;
@@ -15241,7 +15383,12 @@ const holidaySectionBindings = {
   color: #92400e;
 }
 
-.attendance__rotation-assignment-calendar-chip {
+.attendance__shift-assignment-preview li[data-shift-assignment-known="false"] {
+  color: #92400e;
+}
+
+.attendance__rotation-assignment-calendar-chip,
+.attendance__assignment-calendar-chip {
   border: 1px solid var(--calendar-source-accent, #bfdbfe);
   border-left-width: 3px;
   border-radius: 999px;
@@ -15251,11 +15398,13 @@ const holidaySectionBindings = {
   white-space: nowrap;
 }
 
-.attendance__rotation-assignment-calendar-chip[data-calendar-working-day="false"] {
+.attendance__rotation-assignment-calendar-chip[data-calendar-working-day="false"],
+.attendance__assignment-calendar-chip[data-calendar-working-day="false"] {
   background: #fef3c7;
 }
 
-.attendance__rotation-assignment-calendar-chip[data-calendar-override="true"] {
+.attendance__rotation-assignment-calendar-chip[data-calendar-override="true"],
+.attendance__assignment-calendar-chip[data-calendar-override="true"] {
   border-style: dashed;
 }
 

--- a/apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue
+++ b/apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue
@@ -532,6 +532,58 @@
       {{ tr('Shift assignments', '排班分配') }}: {{ assignments.length }}
       <span v-if="assignmentEditingId"> · {{ assignmentEditingLabel }}</span>
     </div>
+    <div
+      v-if="shiftAssignmentPreview.items.length"
+      class="attendance__shift-assignment-preview"
+      data-attendance-shift-assignment-preview
+    >
+      <div class="attendance__preview-header">
+        <strong>{{ tr('Assignment impact preview', '班次分配影响预览') }}</strong>
+        <span>
+          {{ shiftAssignmentPreview.shiftName }}
+          <template v-if="shiftAssignmentPreview.isTruncated">
+            · {{ tr(`First ${shiftAssignmentPreview.items.length} of ${shiftAssignmentPreview.projectedDays} days`, `前 ${shiftAssignmentPreview.items.length} / 共 ${shiftAssignmentPreview.projectedDays} 天`) }}
+          </template>
+        </span>
+      </div>
+      <ol>
+        <li
+          v-for="item in shiftAssignmentPreview.items"
+          :key="`${item.date}:${item.dayIndex}:${item.shiftId}`"
+          :data-shift-assignment-known="item.isKnown ? 'true' : 'false'"
+        >
+          <span>{{ item.date }}</span>
+          <span>{{ tr(`Day ${item.dayIndex}`, `第 ${item.dayIndex} 天`) }}</span>
+          <span>{{ item.label }}</span>
+          <span v-if="item.isKnown">
+            {{ item.schedule }}<template v-if="item.isOvernight"> · {{ tr('Overnight', '跨夜') }}</template>
+          </span>
+          <span v-else>{{ tr('Unresolved shift', '未解析班次') }}</span>
+          <span
+            v-if="item.calendar"
+            class="attendance__assignment-calendar-chip"
+            :class="item.calendar.sourceClass"
+            :title="item.calendar.tooltip"
+            :data-calendar-working-day="item.calendar.isWorkingDay === true ? 'true' : item.calendar.isWorkingDay === false ? 'false' : 'unknown'"
+            :data-calendar-source="item.calendar.source || ''"
+            :data-calendar-override="item.calendar.hasOverride ? 'true' : 'false'"
+          >
+            {{ item.calendar.label || (item.calendar.isWorkingDay === false ? tr('Rest day', '休息日') : tr('Working day', '工作日')) }}
+          </span>
+        </li>
+      </ol>
+      <small
+        v-if="shiftAssignmentPreview.missingShiftId"
+        class="attendance__field-hint attendance__field-hint--warning"
+        data-attendance-shift-assignment-missing
+      >
+        {{ tr('This assignment references a shift ID that is not in the loaded shift catalog', '该分配引用了当前已加载班次中不存在的 ID') }}:
+        {{ shiftAssignmentPreview.missingShiftId }}
+      </small>
+      <small class="attendance__field-hint">
+        {{ tr('Preview is advisory and uses the selected shift, dates, and optional effective-calendar context.', '预览仅作提示，基于所选班次、日期和可选生效日历上下文计算。') }}
+      </small>
+    </div>
     <div class="attendance__admin-grid">
       <AttendanceUserPickerField
         v-model="assignmentForm.userId"
@@ -649,8 +701,10 @@ import {
   buildAttendanceRotationAssignmentCalendarMap,
   buildAttendanceRotationAssignmentPreview,
   buildAttendanceRotationSequencePreview,
+  buildAttendanceShiftAssignmentCalendarMap,
+  buildAttendanceShiftAssignmentPreview,
   parseAttendanceRotationSequenceInput,
-  type AttendanceRotationAssignmentCalendarLike,
+  type AttendanceShiftAssignmentCalendarLike,
 } from './attendanceRotationSequencePreview'
 import {
   buildCalendarChipTooltip,
@@ -759,6 +813,7 @@ interface SchedulingBindings {
 const props = defineProps<{
   tr: Translate
   scheduling: SchedulingBindings
+  shiftAssignmentCalendarChips?: CalendarEffectiveChip[]
   rotationAssignmentCalendarChips?: CalendarEffectiveChip[]
 }>()
 
@@ -869,6 +924,18 @@ const rotationAssignmentCalendarByDate = computed(() => buildAttendanceRotationA
   })),
 ))
 
+const shiftAssignmentCalendarByDate = computed(() => buildAttendanceShiftAssignmentCalendarMap(
+  (props.shiftAssignmentCalendarChips ?? []).map((chip): AttendanceShiftAssignmentCalendarLike => ({
+    date: chip.date,
+    isWorkingDay: chip.effective?.isWorkingDay ?? chip.isWorkingDay,
+    label: chip.name || fallbackChipName(chip),
+    source: chip.effective?.source,
+    sourceClass: calendarChipSourceClassName(chip.effective?.source),
+    tooltip: buildCalendarChipTooltip(chip),
+    hasOverride: hasCalendarChipOverrideMarker(chip),
+  })),
+))
+
 const rotationAssignmentPreview = computed(() => buildAttendanceRotationAssignmentPreview({
   rotationRuleId: rotationAssignmentForm.rotationRuleId,
   rotationRules: rotationRules.value,
@@ -877,6 +944,15 @@ const rotationAssignmentPreview = computed(() => buildAttendanceRotationAssignme
   endDate: rotationAssignmentForm.endDate || null,
   maxDays: 14,
   calendarByDate: rotationAssignmentCalendarByDate.value,
+}))
+
+const shiftAssignmentPreview = computed(() => buildAttendanceShiftAssignmentPreview({
+  shiftId: assignmentForm.shiftId,
+  shifts: shifts.value,
+  startDate: assignmentForm.startDate,
+  endDate: assignmentForm.endDate || null,
+  maxDays: 14,
+  calendarByDate: shiftAssignmentCalendarByDate.value,
 }))
 
 const rotationRuleEditingLabel = computed(() => {
@@ -1036,7 +1112,8 @@ const assignmentEditingLabel = computed(() => {
   font-size: 12px;
 }
 
-.attendance__rotation-assignment-preview {
+.attendance__rotation-assignment-preview,
+.attendance__shift-assignment-preview {
   border: 1px solid #bfdbfe;
   background: #eff6ff;
   border-radius: 6px;
@@ -1052,7 +1129,8 @@ const assignmentEditingLabel = computed(() => {
 }
 
 .attendance__rotation-sequence-preview ol,
-.attendance__rotation-assignment-preview ol {
+.attendance__rotation-assignment-preview ol,
+.attendance__shift-assignment-preview ol {
   display: grid;
   gap: 6px;
   margin: 8px 0 0;
@@ -1066,7 +1144,8 @@ const assignmentEditingLabel = computed(() => {
   align-items: center;
 }
 
-.attendance__rotation-assignment-preview li {
+.attendance__rotation-assignment-preview li,
+.attendance__shift-assignment-preview li {
   display: grid;
   grid-template-columns: minmax(96px, max-content) minmax(56px, max-content) minmax(120px, 1fr) minmax(120px, max-content) minmax(92px, max-content);
   gap: 8px;
@@ -1081,7 +1160,12 @@ const assignmentEditingLabel = computed(() => {
   color: #92400e;
 }
 
-.attendance__rotation-assignment-calendar-chip {
+.attendance__shift-assignment-preview li[data-shift-assignment-known="false"] {
+  color: #92400e;
+}
+
+.attendance__rotation-assignment-calendar-chip,
+.attendance__assignment-calendar-chip {
   border: 1px solid var(--calendar-source-accent, #bfdbfe);
   border-left-width: 3px;
   border-radius: 999px;
@@ -1091,11 +1175,13 @@ const assignmentEditingLabel = computed(() => {
   white-space: nowrap;
 }
 
-.attendance__rotation-assignment-calendar-chip[data-calendar-working-day="false"] {
+.attendance__rotation-assignment-calendar-chip[data-calendar-working-day="false"],
+.attendance__assignment-calendar-chip[data-calendar-working-day="false"] {
   background: #fef3c7;
 }
 
-.attendance__rotation-assignment-calendar-chip[data-calendar-override="true"] {
+.attendance__rotation-assignment-calendar-chip[data-calendar-override="true"],
+.attendance__assignment-calendar-chip[data-calendar-override="true"] {
   border-style: dashed;
 }
 

--- a/apps/web/src/views/attendance/attendanceRotationSequencePreview.ts
+++ b/apps/web/src/views/attendance/attendanceRotationSequencePreview.ts
@@ -51,6 +51,8 @@ export interface AttendanceRotationAssignmentCalendarLike {
   hasOverride?: boolean
 }
 
+export type AttendanceShiftAssignmentCalendarLike = AttendanceRotationAssignmentCalendarLike
+
 export interface BuildAttendanceRotationAssignmentPreviewInput {
   rotationRuleId: string | null | undefined
   rotationRules: AttendanceRotationAssignmentRuleLike[] | null | undefined
@@ -59,6 +61,35 @@ export interface BuildAttendanceRotationAssignmentPreviewInput {
   endDate?: string | null
   maxDays?: number
   calendarByDate?: Map<string, AttendanceRotationAssignmentCalendarLike>
+}
+
+export interface BuildAttendanceShiftAssignmentPreviewInput {
+  shiftId: string | null | undefined
+  shifts: AttendanceRotationSequenceShiftLike[] | null | undefined
+  startDate: string | null | undefined
+  endDate?: string | null
+  maxDays?: number
+  calendarByDate?: Map<string, AttendanceShiftAssignmentCalendarLike>
+}
+
+export interface AttendanceShiftAssignmentPreviewItem {
+  date: string
+  dayIndex: number
+  shiftId: string
+  label: string
+  schedule: string
+  isKnown: boolean
+  isOvernight: boolean
+  calendar?: AttendanceShiftAssignmentCalendarLike
+}
+
+export interface AttendanceShiftAssignmentPreview {
+  shiftId: string
+  shiftName: string
+  items: AttendanceShiftAssignmentPreviewItem[]
+  missingShiftId: string | null
+  isTruncated: boolean
+  projectedDays: number
 }
 
 const DATE_KEY_PATTERN = /^\d{4}-\d{2}-\d{2}$/
@@ -100,6 +131,12 @@ export function buildAttendanceRotationAssignmentCalendarMap(
     map.set(date, { ...item, date })
   }
   return map
+}
+
+export function buildAttendanceShiftAssignmentCalendarMap(
+  items: AttendanceShiftAssignmentCalendarLike[] | null | undefined,
+): Map<string, AttendanceShiftAssignmentCalendarLike> {
+  return buildAttendanceRotationAssignmentCalendarMap(items)
 }
 
 export function parseAttendanceRotationSequenceInput(value: string | string[] | null | undefined): string[] {
@@ -202,6 +239,64 @@ export function buildAttendanceRotationAssignmentPreview({
     ruleName: rule.name,
     items,
     missingRefs,
+    isTruncated: projectedDays > visibleDays,
+    projectedDays,
+  }
+}
+
+export function buildAttendanceShiftAssignmentPreview({
+  shiftId,
+  shifts,
+  startDate,
+  endDate,
+  maxDays,
+  calendarByDate,
+}: BuildAttendanceShiftAssignmentPreviewInput): AttendanceShiftAssignmentPreview {
+  const selectedShiftId = typeof shiftId === 'string' ? shiftId.trim() : ''
+  const shiftList = Array.isArray(shifts) ? shifts : []
+  const shift = shiftList.find(item => item.id === selectedShiftId)
+  const start = parseDateKey(startDate)
+  const end = parseDateKey(endDate)
+  const previewLimit = normalizeMaxDays(maxDays)
+  const empty = {
+    shiftId: selectedShiftId,
+    shiftName: shift?.name ?? '',
+    items: [],
+    missingShiftId: null,
+    isTruncated: false,
+    projectedDays: 0,
+  }
+
+  if (!selectedShiftId || !start) return empty
+  if (end && end < start) return empty
+
+  const projectedDays = end ? inclusiveDayCount(start, end) : previewLimit
+  const visibleDays = Math.min(projectedDays, previewLimit)
+  const label = shift ? `${shift.name} (${shift.id})` : selectedShiftId
+  const schedule = shift ? `${shift.workStartTime} -> ${shift.workEndTime}` : ''
+  const isKnown = Boolean(shift)
+  const isOvernight = Boolean(shift?.isOvernight)
+  const missingShiftId = !shift && shiftList.length > 0 ? selectedShiftId : null
+
+  const items = Array.from({ length: visibleDays }, (_, index): AttendanceShiftAssignmentPreviewItem => {
+    const date = formatDateKey(addDays(start, index))
+    return {
+      date,
+      dayIndex: index + 1,
+      shiftId: selectedShiftId,
+      label,
+      schedule,
+      isKnown,
+      isOvernight,
+      calendar: calendarByDate?.get(date),
+    }
+  })
+
+  return {
+    shiftId: selectedShiftId,
+    shiftName: shift?.name ?? selectedShiftId,
+    items,
+    missingShiftId,
     isTruncated: projectedDays > visibleDays,
     projectedDays,
   }

--- a/apps/web/tests/AttendanceSchedulingAdminSection.spec.ts
+++ b/apps/web/tests/AttendanceSchedulingAdminSection.spec.ts
@@ -532,6 +532,55 @@ describe('AttendanceSchedulingAdminSection', () => {
     expect(container!.querySelector('[data-attendance-rotation-assignment-missing]')).toBeFalsy()
   })
 
+  it('renders shift assignment date impact preview from the selected shift', async () => {
+    const scheduling = createSchedulingBindings({
+      assignmentForm: reactive<AssignmentFormState>({
+        userId: 'user-9',
+        shiftId: 'shift-a',
+        startDate: '2026-03-01',
+        endDate: '2026-03-03',
+        isActive: true,
+      }),
+    })
+
+    app = createApp(AttendanceSchedulingAdminSection, {
+      tr,
+      scheduling,
+      shiftAssignmentCalendarChips: [
+        {
+          id: 'calendar-2',
+          date: '2026-03-02',
+          name: 'Org rest override',
+          isWorkingDay: false,
+          effective: { isWorkingDay: false, source: 'org', label: 'Org rest override', policyId: 'policy-2' },
+          base: { isWorkingDay: true, source: 'shift' },
+          layers: [
+            { kind: 'base_rule', source: 'shift', isWorkingDay: true, label: 'Shift workday' },
+            { kind: 'calendar_policy', source: 'org', isWorkingDay: false, label: 'Org rest override', refId: 'policy-2' },
+          ],
+          overlays: [],
+        } satisfies CalendarEffectiveChip,
+      ],
+    })
+    app.mount(container!)
+    await flushUi()
+
+    const preview = container!.querySelector('[data-attendance-shift-assignment-preview]')
+    expect(preview).toBeTruthy()
+    expect(preview?.textContent).toContain('Assignment impact preview')
+    expect(preview?.textContent).toContain('Day shift')
+    expect(preview?.textContent).toContain('2026-03-01')
+    expect(preview?.textContent).toContain('Day 1')
+    expect(preview?.textContent).toContain('09:00 -> 18:00')
+    expect(preview?.textContent).toContain('2026-03-02')
+    expect(preview?.textContent).toContain('Org rest override')
+    const calendarChip = preview!.querySelector('[data-calendar-source="org"]')
+    expect(calendarChip).toBeTruthy()
+    expect(calendarChip?.getAttribute('data-calendar-working-day')).toBe('false')
+    expect(calendarChip?.getAttribute('data-calendar-override')).toBe('true')
+    expect(container!.querySelector('[data-attendance-shift-assignment-missing]')).toBeFalsy()
+  })
+
   it('falls back to plain counts when nothing is being edited', async () => {
     const scheduling = createSchedulingBindings({
       rotationRuleEditingId: ref(null),

--- a/apps/web/tests/attendanceRotationSequencePreview.spec.ts
+++ b/apps/web/tests/attendanceRotationSequencePreview.spec.ts
@@ -3,6 +3,8 @@ import {
   buildAttendanceRotationAssignmentCalendarMap,
   buildAttendanceRotationAssignmentPreview,
   buildAttendanceRotationSequencePreview,
+  buildAttendanceShiftAssignmentCalendarMap,
+  buildAttendanceShiftAssignmentPreview,
   parseAttendanceRotationSequenceInput,
 } from '../src/views/attendance/attendanceRotationSequencePreview'
 
@@ -237,6 +239,95 @@ describe('attendance rotation sequence preview', () => {
       label: 'Org rest override',
       source: 'org',
       sourceClass: 'calendar-source--org',
+      hasOverride: true,
+    })
+  })
+
+  it('projects a fixed shift assignment across the assignment date window', () => {
+    const preview = buildAttendanceShiftAssignmentPreview({
+      shiftId: 'shift-a',
+      shifts: [
+        {
+          id: 'shift-a',
+          name: 'Day shift',
+          workStartTime: '09:00',
+          workEndTime: '18:00',
+        },
+      ],
+      startDate: '2026-03-01',
+      endDate: '2026-03-03',
+    })
+
+    expect(preview.shiftName).toBe('Day shift')
+    expect(preview.projectedDays).toBe(3)
+    expect(preview.isTruncated).toBe(false)
+    expect(preview.missingShiftId).toBeNull()
+    expect(preview.items.map(item => [item.date, item.dayIndex, item.shiftId, item.label, item.schedule])).toEqual([
+      ['2026-03-01', 1, 'shift-a', 'Day shift (shift-a)', '09:00 -> 18:00'],
+      ['2026-03-02', 2, 'shift-a', 'Day shift (shift-a)', '09:00 -> 18:00'],
+      ['2026-03-03', 3, 'shift-a', 'Day shift (shift-a)', '09:00 -> 18:00'],
+    ])
+  })
+
+  it('caps fixed shift assignment previews and reports missing loaded shift refs', () => {
+    const preview = buildAttendanceShiftAssignmentPreview({
+      shiftId: 'legacy-shift',
+      shifts: [
+        {
+          id: 'shift-a',
+          name: 'Day shift',
+          workStartTime: '09:00',
+          workEndTime: '18:00',
+        },
+      ],
+      startDate: '2026-03-01',
+      endDate: '2026-03-10',
+      maxDays: 2,
+    })
+
+    expect(preview.projectedDays).toBe(10)
+    expect(preview.items).toHaveLength(2)
+    expect(preview.isTruncated).toBe(true)
+    expect(preview.missingShiftId).toBe('legacy-shift')
+    expect(preview.items.map(item => [item.date, item.isKnown, item.label])).toEqual([
+      ['2026-03-01', false, 'legacy-shift'],
+      ['2026-03-02', false, 'legacy-shift'],
+    ])
+  })
+
+  it('attaches effective-calendar context to fixed shift assignment rows', () => {
+    const calendarByDate = buildAttendanceShiftAssignmentCalendarMap([
+      {
+        date: '2026-03-02',
+        isWorkingDay: false,
+        label: 'Manual rest day',
+        source: 'manual',
+        sourceClass: 'calendar-source--manual',
+        tooltip: '2026-03-02 — Rest day · manual',
+        hasOverride: true,
+      },
+    ])
+    const preview = buildAttendanceShiftAssignmentPreview({
+      shiftId: 'shift-a',
+      shifts: [
+        {
+          id: 'shift-a',
+          name: 'Day shift',
+          workStartTime: '09:00',
+          workEndTime: '18:00',
+        },
+      ],
+      startDate: '2026-03-01',
+      endDate: '2026-03-03',
+      calendarByDate,
+    })
+
+    expect(preview.items.map(item => item.date)).toEqual(['2026-03-01', '2026-03-02', '2026-03-03'])
+    expect(preview.items[0]?.calendar).toBeUndefined()
+    expect(preview.items[1]?.calendar).toMatchObject({
+      label: 'Manual rest day',
+      source: 'manual',
+      sourceClass: 'calendar-source--manual',
       hasOverride: true,
     })
   })

--- a/docs/development/attendance-shift-assignment-preview-development-20260521.md
+++ b/docs/development/attendance-shift-assignment-preview-development-20260521.md
@@ -1,0 +1,98 @@
+# Attendance Shift Assignment Preview Development 2026-05-21
+
+## Summary
+
+This slice adds a frontend-only advisory preview for fixed shift assignments.
+It mirrors the rotation assignment impact preview, but for the simpler
+`assignmentForm.shiftId + startDate/endDate` path.
+
+The preview shows the selected shift across the visible assignment date window
+and can attach effective-calendar context for the selected user/date when the
+backend resolver returns notable holiday, policy, or overlay chips.
+
+The wording is intentional: this is an operator preview of the current draft
+inputs and calendar context, not the final backend scheduling result of an
+unsaved assignment. Runtime scheduling truth and save validation remain in the
+backend.
+
+## Scope
+
+- Extend the existing rotation preview helper module with fixed shift
+  assignment preview helpers.
+- Render the preview in the extracted `AttendanceSchedulingAdminSection.vue`.
+- Render the same preview in production `AttendanceView.vue`.
+- Reuse the existing `/api/attendance/effective-calendar` frontend client.
+- Reuse existing calendar chip helpers and noteworthy-item filtering.
+- Keep the preview bounded to the same 14 visible rows as rotation assignment
+  previews.
+
+## Boundaries
+
+- No backend route changes.
+- No database migration.
+- No direct `attendance_*` fact-source changes.
+- No direct `meta_*` reads or writes.
+- No save-blocking frontend validator.
+- No attempt to simulate final backend resolution for an unsaved assignment.
+
+## Behavior
+
+The fixed shift assignment preview uses:
+
+- `assignmentForm.userId`
+- `assignmentForm.shiftId`
+- `assignmentForm.startDate`
+- `assignmentForm.endDate`
+- the currently loaded shift catalog
+
+For closed ranges, it projects each date from `startDate` through `endDate`,
+capped at 14 visible rows. For open-ended ranges, it projects the first 14
+days.
+
+Known shift IDs display shift name, ID, schedule, and overnight marker.
+Unknown shift IDs remain visible and are reported only when a shift catalog is
+loaded. This avoids hiding legacy or not-yet-loaded references.
+
+In production `AttendanceView.vue`, when the fixed assignment draft has a
+selected user and visible preview rows:
+
+1. The UI computes the visible preview date range from the base preview without
+   calendar context.
+2. It fetches effective-calendar data for `{ userId, from, to }`.
+3. It filters to noteworthy items only.
+4. It converts those effective-calendar items into chips.
+5. It indexes chips by date and attaches matching chip context to preview rows.
+
+Fetch failures only clear the context chips and reset the cache key. The shift
+preview and save behavior remain unchanged.
+
+## Files Changed
+
+- `apps/web/src/views/attendance/attendanceRotationSequencePreview.ts`
+  - Added `buildAttendanceShiftAssignmentPreview()`.
+  - Added `buildAttendanceShiftAssignmentCalendarMap()`.
+  - Added fixed shift assignment preview types.
+- `apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue`
+  - Added optional fixed assignment calendar chips prop.
+  - Added fixed shift assignment impact preview rendering.
+- `apps/web/src/views/AttendanceView.vue`
+  - Added fixed assignment preview rendering in the production admin surface.
+  - Added visible-range effective-calendar fetch for the fixed assignment
+    draft.
+- `apps/web/tests/attendanceRotationSequencePreview.spec.ts`
+  - Added helper coverage for date projection, truncation, missing shift refs,
+    and calendar context attachment.
+- `apps/web/tests/AttendanceSchedulingAdminSection.spec.ts`
+  - Added component coverage for rendered fixed assignment preview rows and
+    effective-calendar chip metadata.
+
+## Design Notes
+
+The effective-calendar cache key intentionally excludes `shiftId`. The backend
+endpoint resolves saved user/date context and does not evaluate the unsaved
+draft shift assignment. Re-fetching on shift changes would suggest a stronger
+truth than the API can provide.
+
+The preview remains a small ergonomic safety surface: it helps admins see the
+dates and selected shift they are about to save, while conflict diagnostics and
+backend validation remain authoritative for overlap and persistence semantics.

--- a/docs/development/attendance-shift-assignment-preview-verification-20260521.md
+++ b/docs/development/attendance-shift-assignment-preview-verification-20260521.md
@@ -1,0 +1,77 @@
+# Attendance Shift Assignment Preview Verification 2026-05-21
+
+## Local Verification
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/attendanceRotationSequencePreview.spec.ts \
+  tests/AttendanceSchedulingAdminSection.spec.ts \
+  --watch=false
+```
+
+Result: PASS, 2 files / 19 tests.
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/attendanceRotationSequencePreview.spec.ts \
+  tests/AttendanceSchedulingAdminSection.spec.ts \
+  tests/useAttendanceAdminScheduling.spec.ts \
+  tests/effectiveCalendar.spec.ts \
+  tests/calendarChipDisplay.spec.ts \
+  tests/attendance-admin-regressions.spec.ts \
+  --watch=false
+```
+
+Result: PASS, 6 files / 80 tests.
+
+## Build And Static Verification
+
+```bash
+pnpm --filter @metasheet/web type-check
+```
+
+Result: PASS (`vue-tsc -b`).
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: PASS (`vue-tsc -b && vite build`, with existing Vite chunk-size / mixed static+dynamic import warnings).
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+## Coverage
+
+- Fixed shift assignment preview projects a selected shift across a closed date
+  window.
+- Open-ended and long closed previews are capped to the visible row limit.
+- Missing selected shift IDs remain visible and are reported when the loaded
+  shift catalog cannot resolve them.
+- Effective-calendar context attaches by exact preview date without changing
+  row order.
+- Extracted scheduling UI renders fixed assignment preview date, day index,
+  shift label, schedule, calendar source, working/rest state, override marker,
+  and tooltip metadata.
+- Existing rotation preview, effective-calendar client, calendar chip display,
+  scheduling composable, and admin regression suites remain green.
+
+## Boundary Check
+
+- No backend route changes.
+- No database migrations.
+- No `attendance_*` fact-source changes.
+- No direct `meta_*` reads or writes.
+- No save-blocking client validator.
+- Effective-calendar fetch failure only clears fixed assignment calendar chips;
+  fixed assignment preview and save behavior remain unchanged.
+
+## Notes
+
+`pnpm install` was required in the isolated worktree to restore local test and
+build binaries. It rewrote tracked `node_modules` symlink entries under
+plugin/tool folders; those generated changes were restored before validation
+and are not part of this slice.


### PR DESCRIPTION
## Summary

Adds a frontend-only fixed shift assignment impact preview beside the scheduling assignment form. It mirrors the rotation assignment preview: selected shift + date range projects visible preview rows, and notable effective-calendar context for the selected user/date appears beside matching rows.

The preview is advisory. It does not simulate final backend scheduling for an unsaved assignment, and it does not change save validation or persistence.

## Boundaries

- Frontend-only slice
- No backend route changes
- No database migrations
- No `attendance_*` fact-source changes
- No direct `meta_*` reads or writes
- No save-blocking client validator

## Test plan

- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceRotationSequencePreview.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts --watch=false`
- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceRotationSequencePreview.spec.ts tests/AttendanceSchedulingAdminSection.spec.ts tests/useAttendanceAdminScheduling.spec.ts tests/effectiveCalendar.spec.ts tests/calendarChipDisplay.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false`
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `pnpm --filter @metasheet/web build`
- [x] `git diff --check`

Docs: `docs/development/attendance-shift-assignment-preview-development-20260521.md` and `docs/development/attendance-shift-assignment-preview-verification-20260521.md`.
