### PR TITLE
feat(attendance): preview draft calendar policies

### DIFF
--- a/apps/web/src/services/attendance/effectiveCalendar.ts
+++ b/apps/web/src/services/attendance/effectiveCalendar.ts
@@ -98,6 +98,32 @@ export interface CalendarEffectiveResponse {
   items: CalendarEffectiveItem[]
 }
 
+export interface CalendarEffectiveDraftOverride {
+  id?: string
+  name?: string
+  match?: 'contains' | 'regex' | 'equals'
+  date?: string
+  from?: string
+  to?: string
+  dayIndexStart?: number
+  dayIndexEnd?: number
+  dayIndexList?: number[]
+  filters?: {
+    userIds?: string[]
+    userNames?: string[]
+    excludeUserIds?: string[]
+    excludeUserNames?: string[]
+    attendanceGroups?: string[]
+    roles?: string[]
+    roleTags?: string[]
+  }
+  effective: {
+    isWorkingDay: boolean
+    label?: string
+    source: 'org' | 'group' | 'role' | 'user'
+  }
+}
+
 // UI-facing chip shape: lets calendar components keep treating items as the
 // legacy CalendarHoliday tuple (id/date/name/isWorkingDay drives the badge
 // text + working/rest class) while also carrying the richer effective fields
@@ -170,6 +196,7 @@ export interface FetchEffectiveCalendarOptions {
   userId?: string
   groupId?: string
   orgOnly?: boolean
+  draftOverrides?: CalendarEffectiveDraftOverride[]
   suppressUnauthorizedRedirect?: boolean
   signal?: AbortSignal
 }
@@ -195,6 +222,37 @@ export async function fetchEffectiveCalendar(
   const modeCount = (userId ? 1 : 0) + (groupId ? 1 : 0) + (orgOnly ? 1 : 0)
   if (modeCount !== 1) {
     throw new Error('fetchEffectiveCalendar: provide exactly one of userId, groupId, or orgOnly=true.')
+  }
+
+  const useDraftPreview = Array.isArray(options.draftOverrides)
+  if (useDraftPreview) {
+    const body: Record<string, unknown> = {
+      from,
+      to,
+      calendarPolicy: { overrides: options.draftOverrides ?? [] },
+    }
+    if (userId) body.userId = userId
+    if (groupId) body.groupId = groupId
+    if (orgOnly) body.orgOnly = true
+
+    const response = await apiFetch('/api/attendance/effective-calendar/preview', {
+      method: 'POST',
+      body: JSON.stringify(body),
+      suppressUnauthorizedRedirect: suppressUnauthorizedRedirect ?? true,
+      signal,
+    })
+    let data: any = null
+    try {
+      data = await response.json()
+    } catch {
+      data = null
+    }
+    if (!response.ok || data?.ok === false) {
+      const message = data?.error?.message
+        ?? `Failed to load effective calendar (HTTP ${response.status}).`
+      throw new EffectiveCalendarFetchError(message, response.status, data?.error?.code)
+    }
+    return data?.data as CalendarEffectiveResponse
   }
 
   const query = new URLSearchParams({ from, to })

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1407,7 +1407,10 @@
                     <p class="attendance__field-hint attendance__field-hint--warn">
                       {{ tr('Role matching uses the platform user role plus assigned RBAC role IDs/names; role tags use the same resolver aliases until a dedicated role-tag catalog exists.', '角色匹配使用用户平台角色及已分配 RBAC 角色 ID/名称；在独立角色标签目录落地前，角色标签使用同一解析别名。') }}
                     </p>
-                    <AttendanceCalendarPolicyPreviewPanel :tr="tr" />
+                    <AttendanceCalendarPolicyPreviewPanel
+                      :tr="tr"
+                      :draft-overrides="calendarPolicyPreviewDraftOverrides"
+                    />
                     <div
                       v-if="calendarPolicyOverrideDiagnostics.length"
                       class="attendance__calendar-policy-diagnostics"
@@ -7932,6 +7935,7 @@ const settingsForm = reactive({
 })
 
 const calendarPolicyOverrideDiagnostics = computed(() => buildCalendarPolicyOverrideDiagnostics(settingsForm.calendarPolicyOverrides))
+const calendarPolicyPreviewDraftOverrides = computed(() => calendarPolicyOverridesFromForm(settingsForm.calendarPolicyOverrides))
 
 function calendarPolicySourceRequirement(source: CalendarPolicyOverrideFormState['source']): string {
   if (source === 'group') return tr('attendance groups', '考勤组')

--- a/apps/web/src/views/attendance/AttendanceCalendarPolicyPreviewPanel.vue
+++ b/apps/web/src/views/attendance/AttendanceCalendarPolicyPreviewPanel.vue
@@ -4,7 +4,9 @@
       <div>
         <h5>{{ tr('Preview effective calendar', '预览有效日历') }}</h5>
         <p class="attendance__field-hint">
-          {{ tr('Uses the saved effective-calendar resolver. Unsaved edits must be saved first.', '使用已保存的有效日历解析器；未保存的修改需先保存。') }}
+          {{ hasDraftOverrides
+            ? tr('Can preview the current editor draft without saving. Runtime still uses saved settings until Save settings succeeds.', '可在不保存的情况下预览当前编辑草稿；运行时仍以保存成功后的设置为准。')
+            : tr('Uses the saved effective-calendar resolver. Unsaved edits must be saved first.', '使用已保存的有效日历解析器；未保存的修改需先保存。') }}
         </p>
       </div>
       <button
@@ -42,6 +44,14 @@
       <label v-if="previewMode === 'userId'" class="attendance__field">
         <span>{{ tr('User ID', '用户 ID') }}</span>
         <input v-model="previewUserId" type="text" placeholder="user_1" data-attendance-calendar-policy-preview-user />
+      </label>
+      <label v-if="hasDraftOverrides" class="attendance__field attendance__field--checkbox">
+        <span>{{ tr(`Include unsaved editor rules (${draftOverrideCount})`, `包含未保存的编辑规则（${draftOverrideCount} 条）`) }}</span>
+        <input
+          v-model="includeDraftOverrides"
+          type="checkbox"
+          data-attendance-calendar-policy-preview-draft
+        />
       </label>
     </div>
 
@@ -98,10 +108,11 @@
 </template>
 
 <script setup lang="ts">
-import { ref } from 'vue'
+import { computed, ref } from 'vue'
 import {
   EffectiveCalendarFetchError,
   fetchEffectiveCalendar,
+  type CalendarEffectiveDraftOverride,
   type CalendarEffectiveItem,
   type CalendarEffectiveMode,
   type CalendarEffectiveSource,
@@ -114,6 +125,7 @@ type PreviewMode = CalendarEffectiveMode
 
 const props = defineProps<{
   tr: Translate
+  draftOverrides?: CalendarEffectiveDraftOverride[]
 }>()
 
 const tr = props.tr
@@ -124,9 +136,12 @@ const previewTo = ref(today())
 const previewMode = ref<PreviewMode>('orgOnly')
 const previewGroupId = ref('')
 const previewUserId = ref('')
+const includeDraftOverrides = ref(true)
 const previewLoading = ref(false)
 const previewError = ref('')
 const previewResult = ref<CalendarEffectiveResponse | null>(null)
+const hasDraftOverrides = computed(() => Array.isArray(props.draftOverrides))
+const draftOverrideCount = computed(() => props.draftOverrides?.length ?? 0)
 
 const SOURCE_LABELS: Record<CalendarEffectiveSource, [string, string]> = {
   rule: ['Rule', '规则'],
@@ -197,7 +212,7 @@ function buildPreviewOptions(): FetchEffectiveCalendarOptions | null {
   }
   if (previewMode.value === 'orgOnly') {
     options.orgOnly = true
-    return options
+    return withDraftOverrides(options)
   }
   if (previewMode.value === 'groupId') {
     const groupId = previewGroupId.value.trim()
@@ -206,7 +221,7 @@ function buildPreviewOptions(): FetchEffectiveCalendarOptions | null {
       return null
     }
     options.groupId = groupId
-    return options
+    return withDraftOverrides(options)
   }
   const userId = previewUserId.value.trim()
   if (!userId) {
@@ -214,6 +229,16 @@ function buildPreviewOptions(): FetchEffectiveCalendarOptions | null {
     return null
   }
   options.userId = userId
+  return withDraftOverrides(options)
+}
+
+function withDraftOverrides(options: FetchEffectiveCalendarOptions): FetchEffectiveCalendarOptions {
+  if (hasDraftOverrides.value && includeDraftOverrides.value) {
+    return {
+      ...options,
+      draftOverrides: props.draftOverrides ?? [],
+    }
+  }
   return options
 }
 

--- a/apps/web/tests/AttendanceCalendarPolicyPreviewPanel.spec.ts
+++ b/apps/web/tests/AttendanceCalendarPolicyPreviewPanel.spec.ts
@@ -96,8 +96,8 @@ describe('AttendanceCalendarPolicyPreviewPanel', () => {
     vi.clearAllMocks()
   })
 
-  function mountPanel(): HTMLElement {
-    app = createApp(AttendanceCalendarPolicyPreviewPanel, { tr })
+  function mountPanel(extraProps: Record<string, unknown> = {}): HTMLElement {
+    app = createApp(AttendanceCalendarPolicyPreviewPanel, { tr, ...extraProps })
     app.mount(container!)
     return container!
   }
@@ -167,5 +167,46 @@ describe('AttendanceCalendarPolicyPreviewPanel', () => {
     const error = root.querySelector('[data-attendance-calendar-policy-preview-error]')
     expect(error?.textContent).toContain('No access to this user. (FORBIDDEN)')
     expect(root.querySelector('[data-attendance-calendar-policy-preview-result]')).toBeNull()
+  })
+
+  it('can include or exclude unsaved editor overrides from preview calls', async () => {
+    const draftOverrides = [
+      {
+        date: '2026-10-06',
+        effective: { isWorkingDay: true, source: 'org' as const, label: 'Draft workday' },
+      },
+    ]
+    fetchEffectiveCalendarMock.mockResolvedValue(buildResult())
+    const root = mountPanel({ draftOverrides })
+    await flushUi()
+
+    expect(root.textContent).toContain('包含未保存的编辑规则（1 条）')
+    setInput(root, '[data-attendance-calendar-policy-preview-from]', '2026-10-01')
+    setInput(root, '[data-attendance-calendar-policy-preview-to]', '2026-10-07')
+    clickPreview(root)
+    await flushUi(8)
+
+    expect(fetchEffectiveCalendarMock).toHaveBeenLastCalledWith({
+      from: '2026-10-01',
+      to: '2026-10-07',
+      orgOnly: true,
+      suppressUnauthorizedRedirect: true,
+      draftOverrides,
+    })
+
+    const checkbox = root.querySelector<HTMLInputElement>('[data-attendance-calendar-policy-preview-draft]')
+    expect(checkbox).toBeTruthy()
+    checkbox!.checked = false
+    checkbox!.dispatchEvent(new Event('change'))
+    await flushUi()
+    clickPreview(root)
+    await flushUi(8)
+
+    expect(fetchEffectiveCalendarMock).toHaveBeenLastCalledWith({
+      from: '2026-10-01',
+      to: '2026-10-07',
+      orgOnly: true,
+      suppressUnauthorizedRedirect: true,
+    })
   })
 })

--- a/apps/web/tests/effectiveCalendar.spec.ts
+++ b/apps/web/tests/effectiveCalendar.spec.ts
@@ -82,6 +82,40 @@ describe('fetchEffectiveCalendar', () => {
     expect((apiFetchMock.mock.calls[0]?.[1] as any)?.suppressUnauthorizedRedirect).toBe(false)
   })
 
+  it('posts draft calendar policy overrides to the admin preview endpoint', async () => {
+    apiFetchMock.mockResolvedValueOnce(jsonResponse(200, buildOkPayload()))
+    await fetchEffectiveCalendar({
+      from: '2026-10-01',
+      to: '2026-10-07',
+      orgOnly: true,
+      draftOverrides: [
+        {
+          date: '2026-10-04',
+          effective: { isWorkingDay: true, source: 'org', label: 'Draft workday' },
+        },
+      ],
+    })
+
+    expect(apiFetchMock).toHaveBeenCalledTimes(1)
+    const [path, options] = apiFetchMock.mock.calls[0]
+    expect(path).toBe('/api/attendance/effective-calendar/preview')
+    expect((options as any)?.method).toBe('POST')
+    expect((options as any)?.suppressUnauthorizedRedirect).toBe(true)
+    expect(JSON.parse(String((options as any)?.body || '{}'))).toEqual({
+      from: '2026-10-01',
+      to: '2026-10-07',
+      orgOnly: true,
+      calendarPolicy: {
+        overrides: [
+          {
+            date: '2026-10-04',
+            effective: { isWorkingDay: true, source: 'org', label: 'Draft workday' },
+          },
+        ],
+      },
+    })
+  })
+
   it('rejects when no mode is provided (mirrors route validation)', async () => {
     await expect(fetchEffectiveCalendar({ from: '2026-01-01', to: '2026-01-02' } as any)).rejects.toThrow(/exactly one of/)
     expect(apiFetchMock).not.toHaveBeenCalled()

--- a/docs/development/attendance-calendar-policy-draft-preview-development-20260521.md
+++ b/docs/development/attendance-calendar-policy-draft-preview-development-20260521.md
@@ -1,0 +1,79 @@
+# Attendance Calendar Policy Draft Preview Development
+
+Date: 2026-05-21
+Branch: `codex/attendance-calendar-draft-preview-20260521`
+Base: `origin/main@46800a8ef`
+
+## Summary
+
+This slice lets attendance admins preview effective-calendar policy rows while
+they are still editing them. Before this change the preview panel always called
+the saved `GET /api/attendance/effective-calendar` resolver, so a user had to
+save settings before verifying a draft override. The new path is read-only:
+it simulates the current editor payload through the same backend resolver and
+does not persist anything.
+
+## Scope
+
+Delivered:
+
+- `POST /api/attendance/effective-calendar/preview` for admin-only draft
+  simulation.
+- Existing `resolveEffectiveCalendar()` can accept caller-provided
+  `calendarPolicyOverrides`; if absent, it keeps loading saved settings.
+- `settingsSchema` and the draft preview route share one
+  `calendarPolicyOverrideSchema`, so save and preview accept the same wire
+  shape.
+- The preview panel now shows an opt-in checkbox for "Include unsaved editor
+  rules" when the parent provides draft overrides.
+- `AttendanceView.vue` passes the current editor rows through
+  `calendarPolicyOverridesFromForm()`, reusing the same normalization that
+  save uses.
+
+Not delivered:
+
+- No save-blocking validator.
+- No unsaved shift/rotation assignment simulation.
+- No new `attendance_*` migration or fact-source write.
+- No direct `meta_*` write.
+
+## Design Notes
+
+The frontend still does not implement a calendar-policy resolver. It only
+serializes the editor state with the existing save codec and asks the backend
+to resolve the preview. This avoids a second source of truth for source
+priority, day-index filters, role filters, and same-priority tie order.
+
+The preview endpoint uses `attendance:admin` because it can simulate arbitrary
+calendar-policy settings for org/group/user modes. The saved GET endpoint is
+unchanged and remains the shared read path for user-facing calendar widgets.
+
+The draft preview intentionally normalizes the provided overrides via
+`normalizeCalendarPolicyOverrides()` before resolution. Incomplete rows are
+dropped in the same way they would be dropped on save; the existing diagnostics
+surface incomplete scoped rows before the admin runs preview.
+
+## Files Changed
+
+- `plugins/plugin-attendance/index.cjs`
+  - Added shared zod schema for calendar-policy override payloads.
+  - Added the draft preview route.
+  - Exported `resolveEffectiveCalendar()` and
+    `normalizeCalendarPolicyOverrides()` for focused tests.
+- `apps/web/src/services/attendance/effectiveCalendar.ts`
+  - Added `draftOverrides` option and POST preview transport.
+- `apps/web/src/views/attendance/AttendanceCalendarPolicyPreviewPanel.vue`
+  - Added draft checkbox and copy.
+- `apps/web/src/views/AttendanceView.vue`
+  - Wires current editor overrides into the preview panel.
+- Tests:
+  - `packages/core-backend/tests/unit/attendance-effective-calendar-role-context.test.ts`
+  - `apps/web/tests/effectiveCalendar.spec.ts`
+  - `apps/web/tests/AttendanceCalendarPolicyPreviewPanel.spec.ts`
+
+## Follow-Up Candidate
+
+The next higher-risk slice is backend save-time conflict validation for fixed
+shift assignments and rotation assignments. That would change persistence
+semantics and should be scoped separately from this read-only draft-preview
+slice.

--- a/docs/development/attendance-calendar-policy-draft-preview-verification-20260521.md
+++ b/docs/development/attendance-calendar-policy-draft-preview-verification-20260521.md
@@ -1,0 +1,48 @@
+# Attendance Calendar Policy Draft Preview Verification
+
+Date: 2026-05-21
+Branch: `codex/attendance-calendar-draft-preview-20260521`
+
+## Test Matrix
+
+| Check | Command | Result |
+| --- | --- | --- |
+| Plugin syntax | `node --check plugins/plugin-attendance/index.cjs` | PASS |
+| Backend draft resolver unit | `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` | PASS, 3 tests |
+| Frontend focused specs | `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/effectiveCalendar.spec.ts tests/AttendanceCalendarPolicyPreviewPanel.spec.ts --watch=false` | PASS, 21 tests |
+| Backend attendance regression | `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` | PASS, 59 tests |
+| Frontend admin regression | `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/effectiveCalendar.spec.ts tests/AttendanceCalendarPolicyPreviewPanel.spec.ts tests/useAttendanceAdminConfig.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` | PASS, 36 tests |
+| Web type-check | `pnpm --filter @metasheet/web type-check` | PASS |
+| Core backend build | `pnpm --filter @metasheet/core-backend build` | PASS |
+| Web build | `pnpm --filter @metasheet/web build` | PASS |
+| Whitespace | `git diff --check` | PASS |
+
+## Acceptance Criteria
+
+- Draft preview can resolve a supplied calendar-policy override without reading
+  saved `system_configs` settings.
+- Existing saved-preview behavior is preserved when no draft overrides are
+  provided.
+- The frontend POSTs draft overrides to
+  `/api/attendance/effective-calendar/preview` only when the draft checkbox is
+  enabled.
+- The preview panel can exclude draft rows and fall back to the saved GET path.
+- Save payload and preview payload use the same editor-to-wire codec.
+
+## Boundary Checks
+
+- No `attendance_*` migration.
+- No direct `meta_*` SQL write.
+- No persistence through the new preview route.
+- No frontend resolver or save-blocking validator.
+- Existing GET `/api/attendance/effective-calendar` behavior remains unchanged.
+
+## Notes
+
+`pnpm install` was required in the isolated worktree to restore local test
+binaries. The generated tracked `node_modules` symlink noise was restored before
+verification and is not part of the slice.
+
+The web build still emits the existing Vite warning about
+`WorkflowDesigner.vue` being both dynamically and statically imported, plus
+large chunk warnings. The build exits successfully.

--- a/packages/core-backend/tests/unit/attendance-effective-calendar-role-context.test.ts
+++ b/packages/core-backend/tests/unit/attendance-effective-calendar-role-context.test.ts
@@ -6,6 +6,47 @@ const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cj
 const helpers = attendancePlugin.__attendanceReportFieldCatalogForTests
 
 describe('attendance effective calendar role context', () => {
+  it('resolves effective-calendar preview rows from draft overrides without loading saved settings', async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('system_configs')) {
+        throw new Error('saved settings should not be loaded for draft preview')
+      }
+      if (sql.includes('FROM attendance_rules')) return []
+      if (sql.includes('FROM attendance_holidays')) return []
+      return []
+    })
+
+    const result = await helpers.resolveEffectiveCalendar({ query }, {
+      orgId: 'default',
+      from: '2026-10-06',
+      to: '2026-10-06',
+      orgOnly: true,
+      calendarPolicyOverrides: [
+        {
+          date: '2026-10-06',
+          effective: { isWorkingDay: false, source: 'org', label: 'Draft rest day' },
+        },
+      ],
+    })
+
+    expect(result).toMatchObject({
+      mode: 'orgOnly',
+      from: '2026-10-06',
+      to: '2026-10-06',
+      items: [
+        {
+          date: '2026-10-06',
+          effective: {
+            isWorkingDay: false,
+            source: 'org',
+            label: 'Draft rest day',
+          },
+        },
+      ],
+    })
+    expect(result.items[0]?.layers.some((layer: any) => layer.kind === 'calendar_policy')).toBe(true)
+  })
+
   it('loads role aliases from users.role and assigned RBAC roles for single-user matching', async () => {
     const query = vi.fn(async (sql: string) => {
       if (sql.includes('SELECT name, role FROM users')) {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -10709,10 +10709,15 @@ async function resolveEffectiveCalendar(db, args) {
   else if (args.groupId) mode = 'groupId'
   else mode = 'orgOnly'
 
-  const settings = await getSettings(db)
-  const calendarOverrides = Array.isArray(settings?.calendarPolicy?.overrides)
-    ? settings.calendarPolicy.overrides
-    : []
+  let calendarPolicyOverrides
+  if (Array.isArray(args.calendarPolicyOverrides)) {
+    calendarPolicyOverrides = normalizeCalendarPolicyOverrides(args.calendarPolicyOverrides)
+  } else {
+    const settings = await getSettings(db)
+    calendarPolicyOverrides = Array.isArray(settings?.calendarPolicy?.overrides)
+      ? settings.calendarPolicy.overrides
+      : []
+  }
   const defaultRule = await loadDefaultRule(db, orgId)
   const dates = enumerateAttendanceCalendarDateRange(from, to)
   const holidaysByDate = await loadHolidayMapByDates(db, orgId, dates)
@@ -10840,7 +10845,7 @@ async function resolveEffectiveCalendar(db, args) {
     // effective.* fields are chosen by the shared selector so the calc
     // chain (resolveWorkContext) reaches the same verdict by the same
     // priority + tie-order rule.
-    for (const override of calendarOverrides) {
+    for (const override of calendarPolicyOverrides) {
       if (!matchCalendarOverride(override, dayContext, mode)) continue
       pushCalendarLayer(layers, {
         kind: 'calendar_policy',
@@ -10850,7 +10855,7 @@ async function resolveEffectiveCalendar(db, args) {
         refId: override.id,
       })
     }
-    const policyWinner = selectHighestPriorityCalendarOverride(calendarOverrides, dayContext, mode)
+    const policyWinner = selectHighestPriorityCalendarOverride(calendarPolicyOverrides, dayContext, mode)
     if (policyWinner) {
       effective = {
         isWorkingDay: policyWinner.isWorkingDay,
@@ -12719,6 +12724,8 @@ module.exports = {
     normalizeAttendancePayrollSummaryFieldTemplateConfig,
     buildAttendancePayrollSummaryFieldTemplate,
     getAttendancePayrollSummaryFieldValue,
+    normalizeCalendarPolicyOverrides,
+    resolveEffectiveCalendar,
     buildAttendanceRecordReportExportItem,
     buildAttendanceRecordReportExportItemAsync,
     buildAttendanceRecordReportCsv,
@@ -12741,6 +12748,43 @@ module.exports = {
         context.api.events.emit(type, data)
       }
     }
+
+    const calendarPolicyOverrideSchema = z.object({
+      id: z.string().optional(),
+      name: z.string().optional(),
+      match: z.enum(['contains', 'regex', 'equals']).optional(),
+      date: z.string().optional(),
+      from: z.string().optional(),
+      to: z.string().optional(),
+      dayIndexStart: z.number().int().min(1).optional(),
+      dayIndexEnd: z.number().int().min(1).optional(),
+      dayIndexList: z.array(z.number().int().min(1)).optional(),
+      filters: z.object({
+        userIds: z.array(z.string()).optional(),
+        userNames: z.array(z.string()).optional(),
+        excludeUserIds: z.array(z.string()).optional(),
+        excludeUserNames: z.array(z.string()).optional(),
+        attendanceGroups: z.array(z.string()).optional(),
+        roles: z.array(z.string()).optional(),
+        roleTags: z.array(z.string()).optional(),
+      }).optional(),
+      effective: z.object({
+        isWorkingDay: z.boolean(),
+        label: z.string().optional(),
+        source: z.enum(['org', 'group', 'role', 'user']),
+      }),
+    })
+
+    const effectiveCalendarPreviewSchema = z.object({
+      from: z.string().optional(),
+      to: z.string().optional(),
+      userId: z.string().optional(),
+      groupId: z.string().optional(),
+      orgOnly: z.boolean().optional(),
+      calendarPolicy: z.object({
+        overrides: z.array(calendarPolicyOverrideSchema).optional(),
+      }).optional(),
+    })
 
     const settingsSchema = z.object({
       autoAbsence: z.object({
@@ -12775,33 +12819,7 @@ module.exports = {
         ).optional(),
       }).optional(),
       calendarPolicy: z.object({
-        overrides: z.array(
-          z.object({
-            id: z.string().optional(),
-            name: z.string().optional(),
-            match: z.enum(['contains', 'regex', 'equals']).optional(),
-            date: z.string().optional(),
-            from: z.string().optional(),
-            to: z.string().optional(),
-            dayIndexStart: z.number().int().min(1).optional(),
-            dayIndexEnd: z.number().int().min(1).optional(),
-            dayIndexList: z.array(z.number().int().min(1)).optional(),
-            filters: z.object({
-              userIds: z.array(z.string()).optional(),
-              userNames: z.array(z.string()).optional(),
-              excludeUserIds: z.array(z.string()).optional(),
-              excludeUserNames: z.array(z.string()).optional(),
-              attendanceGroups: z.array(z.string()).optional(),
-              roles: z.array(z.string()).optional(),
-              roleTags: z.array(z.string()).optional(),
-            }).optional(),
-            effective: z.object({
-              isWorkingDay: z.boolean(),
-              label: z.string().optional(),
-              source: z.enum(['org', 'group', 'role', 'user']),
-            }),
-          })
-        ).optional(),
+        overrides: z.array(calendarPolicyOverrideSchema).optional(),
       }).optional(),
       holidaySync: z.object({
         source: z.enum(['holiday-cn']).optional(),
@@ -24572,6 +24590,80 @@ module.exports = {
           }
           logger.error('Attendance effective-calendar resolve failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to resolve effective calendar.' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/effective-calendar/preview',
+      withPermission('attendance:admin', async (req, res) => {
+        const parsed = effectiveCalendarPreviewSchema.safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+
+        const fromRaw = typeof parsed.data.from === 'string' ? parsed.data.from.trim() : ''
+        const toRaw = typeof parsed.data.to === 'string' ? parsed.data.to.trim() : ''
+        if (!fromRaw || !toRaw) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: '"from" and "to" are required (YYYY-MM-DD).' } })
+          return
+        }
+        const from = normalizeDateOnlyStrict(fromRaw)
+        const to = normalizeDateOnlyStrict(toRaw)
+        if (!from) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid "from" date. Use YYYY-MM-DD.' } })
+          return
+        }
+        if (!to) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid "to" date. Use YYYY-MM-DD.' } })
+          return
+        }
+        if (from > to) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: '"from" must be on or before "to".' } })
+          return
+        }
+        const rangeDays = diffDays(from, to) + 1
+        if (rangeDays > 366) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Range must be <= 366 days.' } })
+          return
+        }
+
+        const userIdRaw = typeof parsed.data.userId === 'string' ? parsed.data.userId.trim() : ''
+        const groupIdRaw = typeof parsed.data.groupId === 'string' ? parsed.data.groupId.trim() : ''
+        const orgOnly = parsed.data.orgOnly === true
+        const modeCount = (userIdRaw ? 1 : 0) + (groupIdRaw ? 1 : 0) + (orgOnly ? 1 : 0)
+        if (modeCount !== 1) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Provide exactly one of userId, groupId, or orgOnly=true.' } })
+          return
+        }
+
+        try {
+          const orgId = getOrgId(req)
+          const result = await resolveEffectiveCalendar(db, {
+            orgId,
+            from,
+            to,
+            userId: userIdRaw || undefined,
+            groupId: groupIdRaw || undefined,
+            orgOnly: orgOnly === true ? true : undefined,
+            calendarPolicyOverrides: parsed.data.calendarPolicy?.overrides ?? [],
+            logger,
+          })
+          res.json({ ok: true, data: result })
+        } catch (error) {
+          const message = error instanceof Error ? error.message : String(error)
+          if (message === 'NOT_FOUND:group') {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Group not found.' } })
+            return
+          }
+          if (message.startsWith('VALIDATION:')) {
+            res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message } })
+            return
+          }
+          logger.error('Attendance effective-calendar draft preview failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to preview effective calendar.' } })
         }
       })
     )


### PR DESCRIPTION
## Summary

Adds read-only draft preview for effective-calendar policy rows so admins can verify the current editor state before saving settings. The saved `GET /api/attendance/effective-calendar` path stays unchanged; draft preview uses a new admin-only `POST /api/attendance/effective-calendar/preview` route and the same backend resolver/normalizer as the saved settings path.

## Changes

- `resolveEffectiveCalendar()` accepts caller-provided `calendarPolicyOverrides` for simulation and otherwise keeps loading saved settings.
- Save and preview share one calendar-policy override zod schema.
- The shared frontend `fetchEffectiveCalendar()` client POSTs to the draft endpoint only when `draftOverrides` is provided.
- The admin preview panel can include/exclude unsaved editor rules and `AttendanceView` passes the current editor payload via the existing save codec.
- Added development and verification docs under `docs/development/`.

## Test plan

- [x] `node --check plugins/plugin-attendance/index.cjs`
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` (3 tests)
- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/effectiveCalendar.spec.ts tests/AttendanceCalendarPolicyPreviewPanel.spec.ts --watch=false` (21 tests)
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` (59 tests)
- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/effectiveCalendar.spec.ts tests/AttendanceCalendarPolicyPreviewPanel.spec.ts tests/useAttendanceAdminConfig.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` (36 tests)
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `pnpm --filter @metasheet/core-backend build`
- [x] `pnpm --filter @metasheet/web build`
- [x] `git diff --check`

## Boundaries

No `attendance_*` migration, no direct `meta_*` write, no persistence through the preview route, no frontend calendar-policy resolver, and no save-blocking validator.