### PR TITLE
feat(attendance): block conflicting schedule assignments

### DIFF
--- a/docs/development/attendance-scheduling-conflict-save-development-20260521.md
+++ b/docs/development/attendance-scheduling-conflict-save-development-20260521.md
@@ -1,0 +1,97 @@
+# Attendance Scheduling Conflict Save Guard Development (2026-05-21)
+
+## Summary
+
+This slice hardens attendance scheduling writes so advisory conflict diagnostics are enforced at the backend save boundary.
+
+Before this change, the admin UI could warn about overlapping fixed-shift and rotation assignments, but API clients could still persist those overlaps. The runtime resolver would then pick one winner (`rotation` before `shift`, latest assignment within the same kind), leaving ambiguity in saved scheduling state.
+
+This slice keeps the existing frontend warning UX and adds an API-level conflict guard for assignment create/update.
+
+## Scope
+
+- Fixed shift assignments:
+  - `POST /api/attendance/assignments`
+  - `PUT /api/attendance/assignments/:id`
+- Rotation assignments:
+  - `POST /api/attendance/rotation-assignments`
+  - `PUT /api/attendance/rotation-assignments/:id`
+- No `attendance_*` migration.
+- No direct `meta_*` write.
+- No frontend validator rewrite.
+- No change to runtime resolver precedence.
+
+## Conflict Contract
+
+Only active drafts are checked. `isActive: false` assignments remain saveable and do not block.
+
+Date overlap is inclusive and matches the existing frontend diagnostic helper:
+
+```text
+left.startDate <= rightEnd && right.startDate <= leftEnd
+```
+
+Open-ended `endDate` is treated as `9999-12-31`.
+
+| Draft kind | Existing kind | Result |
+| --- | --- | --- |
+| shift | shift | `409 ATTENDANCE_SCHEDULE_ASSIGNMENT_CONFLICT`, `shift_assignment_overlap` |
+| rotation | rotation | `409 ATTENDANCE_SCHEDULE_ASSIGNMENT_CONFLICT`, `rotation_assignment_overlap` |
+| shift | rotation | `409 ATTENDANCE_SCHEDULE_ASSIGNMENT_CONFLICT`, `rotation_overrides_shift` |
+| rotation | shift | `409 ATTENDANCE_SCHEDULE_ASSIGNMENT_CONFLICT`, `rotation_overrides_shift` |
+| inactive draft | any | allowed |
+| different user | any | allowed |
+
+## Implementation Notes
+
+- Added `findAttendanceScheduleAssignmentConflict(db, draft)` in `plugins/plugin-attendance/index.cjs`.
+- The helper checks same-kind conflicts first, then cross-kind conflicts.
+- Update paths pass `excludeId` so an assignment does not conflict with itself.
+- Create/update paths now run the conflict check and write inside one `db.transaction()`.
+- Each transactional write takes a per-org/user `pg_advisory_xact_lock` before conflict detection, narrowing concurrent save races for the same user's schedule.
+- Explicit update payloads with `endDate: null` now clear the stored end date instead of falling back to the existing date.
+- The API response uses:
+
+```json
+{
+  "ok": false,
+  "error": {
+    "code": "ATTENDANCE_SCHEDULE_ASSIGNMENT_CONFLICT",
+    "message": "...",
+    "details": {
+      "conflictType": "rotation_overrides_shift",
+      "draftKind": "shift",
+      "existingKind": "rotation"
+    }
+  }
+}
+```
+
+- Rotation assignment create/update now also rejects `endDate < startDate`, matching fixed assignment behavior.
+- Existing broad integration tests that intentionally created a fixed assignment and a rotation assignment for the same user/date were adjusted to use non-overlapping dates or a distinct user. Those tests no longer rely on ambiguous saved state.
+
+## Review Patch
+
+After the initial PR opened, automated review flagged two high-priority save-boundary concerns:
+
+- the check/write sequence was not serialized for concurrent requests;
+- `PUT` with `endDate: null` could not clear a previously bounded assignment.
+
+The follow-up patch addressed both without adding migrations or changing runtime resolution:
+
+- `acquireAttendanceScheduleAssignmentLock(trx, orgId, userId)` serializes schedule saves for the same org/user inside the transaction;
+- `resolveAttendanceScheduleAssignmentUpdateEndDate(payload, existingEndDate)` distinguishes omitted `endDate` from explicit `null`/empty string.
+
+## Frontend Boundary
+
+No frontend code changed.
+
+`useAttendanceAdminScheduling.ts` already reads backend `error.message` for save failures, so the new 409 message is surfaced by the existing path. The existing conflict preview remains advisory before save; the backend is now the final enforcement point.
+
+## Files
+
+- `plugins/plugin-attendance/index.cjs`
+- `packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts`
+- `packages/core-backend/tests/integration/attendance-plugin.test.ts`
+- `docs/development/attendance-scheduling-conflict-save-development-20260521.md`
+- `docs/development/attendance-scheduling-conflict-save-verification-20260521.md`

--- a/docs/development/attendance-scheduling-conflict-save-verification-20260521.md
+++ b/docs/development/attendance-scheduling-conflict-save-verification-20260521.md
@@ -1,0 +1,109 @@
+# Attendance Scheduling Conflict Save Guard Verification (2026-05-21)
+
+## Verification Matrix
+
+| Check | Result |
+| --- | --- |
+| `node --check plugins/plugin-attendance/index.cjs` | PASS |
+| Backend unit: scheduling conflict guard + catalog + formula | PASS, 61 tests |
+| Backend integration targeted scheduling routes | PASS command completed, 3 selected tests entered, local DB-backed server path guarded by existing `baseUrl` checks |
+| Frontend scheduling specs | PASS, 35 tests |
+| `pnpm --filter @metasheet/core-backend build` | PASS |
+| `pnpm --filter @metasheet/web type-check` | PASS |
+| `git diff --check` | PASS |
+
+## Commands
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+```
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/attendance-scheduling-assignment-conflict.test.ts \
+  tests/unit/attendance-report-field-catalog.test.ts \
+  tests/unit/attendance-report-field-formula-engine.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+3 files passed
+61 tests passed
+```
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/attendance-plugin.test.ts \
+  -t "rejects overlapping active shift and rotation assignments at save time|registers attendance routes and lists plugin|accepts legacy snake_case payload aliases" \
+  --reporter=dot
+```
+
+Result:
+
+```text
+1 file passed
+3 tests passed, 72 skipped/filtered
+```
+
+Note: the local integration harness keeps its existing `baseUrl`/database guard. This command verifies collection and targeted test wiring in the current worktree; the pure conflict logic is covered by the new unit test without requiring a live integration database.
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/attendanceScheduleConflictDiagnostics.spec.ts \
+  tests/useAttendanceAdminScheduling.spec.ts \
+  tests/AttendanceSchedulingAdminSection.spec.ts \
+  --watch=false \
+  --reporter=dot
+```
+
+Result:
+
+```text
+3 files passed
+35 tests passed
+```
+
+```bash
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web type-check
+git diff --check
+```
+
+Result:
+
+```text
+PASS
+```
+
+## Unit Coverage Added
+
+`attendance-scheduling-assignment-conflict.test.ts` covers:
+
+- same-kind shift overlap returns `shift_assignment_overlap`;
+- cross-kind shift/rotation overlap returns `rotation_overrides_shift`;
+- update paths use `excludeId`;
+- inactive drafts short-circuit before querying;
+- explicit `endDate: null` clears an existing end date instead of falling back;
+- transactional save helper takes the expected per-org/user advisory lock;
+- conflict type names stay aligned with frontend diagnostics.
+
+## Integration Coverage Added
+
+`attendance-plugin.test.ts` now includes a route-level scenario for:
+
+- fixed shift assignment overlap -> 409;
+- different user overlap -> allowed;
+- rotation over fixed shift -> 409;
+- inactive rotation overlap -> allowed;
+- rotation over rotation -> 409;
+- fixed shift update into rotation range -> 409;
+- rotation `endDate < startDate` -> 400.
+
+## Boundary Checks
+
+- No `attendance_*` migration added.
+- No direct `meta_*` write added.
+- No frontend validator added.
+- Existing frontend conflict preview remains advisory; backend save routes now enforce the same conflict names.

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -484,6 +484,7 @@ describe('Attendance Plugin Integration', () => {
         userId: testUserId,
         shiftId,
         startDate: workDate,
+        endDate: workDate,
         isActive: true,
       }),
     })
@@ -539,6 +540,9 @@ describe('Attendance Plugin Integration', () => {
     expect(rotationRuleRes.status).toBe(201)
     const rotationRuleId = (rotationRuleRes.body as { data?: { id?: string } } | undefined)?.data?.id
     expect(rotationRuleId).toBeTruthy()
+    const rotationStart = new Date(`${workDate}T00:00:00.000Z`)
+    rotationStart.setUTCDate(rotationStart.getUTCDate() + 1)
+    const rotationStartDate = rotationStart.toISOString().slice(0, 10)
 
     const rotationAssignmentRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments`, {
       method: 'POST',
@@ -549,7 +553,7 @@ describe('Attendance Plugin Integration', () => {
       body: JSON.stringify({
         userId: testUserId,
         rotationRuleId,
-        startDate: workDate,
+        startDate: rotationStartDate,
         isActive: true,
       }),
     })
@@ -1912,6 +1916,221 @@ describe('Attendance Plugin Integration', () => {
     expect(lookupRes.status).toBe(200)
   })
 
+  it('rejects overlapping active shift and rotation assignments at save time', async () => {
+    if (!baseUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const testUserId = `attendance-schedule-conflict-${runSuffix}`
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(testUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    async function createShift(name: string): Promise<string> {
+      const shiftRes = await requestJson(`${baseUrl}/api/attendance/shifts`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name,
+          timezone: 'Asia/Shanghai',
+          workStartTime: '09:00',
+          workEndTime: '18:00',
+          workingDays: [1, 2, 3, 4, 5],
+        }),
+      })
+      expect(shiftRes.status).toBe(201)
+      const shiftId = (shiftRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(shiftId).toBeTruthy()
+      if (!shiftId) throw new Error('missing shift id')
+      return shiftId
+    }
+
+    const baseShiftId = await createShift(`Conflict Base Shift ${runSuffix}`)
+    const alternateShiftId = await createShift(`Conflict Alternate Shift ${runSuffix}`)
+
+    const assignmentRes = await requestJson(`${baseUrl}/api/attendance/assignments`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        userId: testUserId,
+        shiftId: baseShiftId,
+        startDate: '2026-06-01',
+        endDate: '2026-06-10',
+        isActive: true,
+      }),
+    })
+    expect(assignmentRes.status).toBe(201)
+    const assignmentId = (assignmentRes.body as { data?: { assignment?: { id?: string } } } | undefined)?.data?.assignment?.id
+    expect(assignmentId).toBeTruthy()
+    if (!assignmentId) return
+
+    const overlappingShiftRes = await requestJson(`${baseUrl}/api/attendance/assignments`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        userId: testUserId,
+        shiftId: alternateShiftId,
+        startDate: '2026-06-10',
+        endDate: '2026-06-12',
+        isActive: true,
+      }),
+    })
+    expect(overlappingShiftRes.status).toBe(409)
+    const overlappingShiftError = (overlappingShiftRes.body as { error?: { code?: string; details?: { conflictType?: string } } } | undefined)?.error
+    expect(overlappingShiftError?.code).toBe('ATTENDANCE_SCHEDULE_ASSIGNMENT_CONFLICT')
+    expect(overlappingShiftError?.details?.conflictType).toBe('shift_assignment_overlap')
+
+    const otherUserShiftRes = await requestJson(`${baseUrl}/api/attendance/assignments`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        userId: `${testUserId}-other`,
+        shiftId: alternateShiftId,
+        startDate: '2026-06-10',
+        endDate: '2026-06-12',
+        isActive: true,
+      }),
+    })
+    expect(otherUserShiftRes.status).toBe(201)
+
+    const rotationRuleRes = await requestJson(`${baseUrl}/api/attendance/rotation-rules`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        name: `Conflict Rotation ${runSuffix}`,
+        timezone: 'Asia/Shanghai',
+        shiftSequence: [alternateShiftId],
+        isActive: true,
+      }),
+    })
+    expect(rotationRuleRes.status).toBe(201)
+    const rotationRuleId = (rotationRuleRes.body as { data?: { id?: string } } | undefined)?.data?.id
+    expect(rotationRuleId).toBeTruthy()
+    if (!rotationRuleId) return
+
+    const overlappingRotationRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        userId: testUserId,
+        rotationRuleId,
+        startDate: '2026-06-05',
+        endDate: '2026-06-08',
+        isActive: true,
+      }),
+    })
+    expect(overlappingRotationRes.status).toBe(409)
+    const overlappingRotationError = (overlappingRotationRes.body as { error?: { details?: { conflictType?: string; draftKind?: string; existingKind?: string } } } | undefined)?.error
+    expect(overlappingRotationError?.details?.conflictType).toBe('rotation_overrides_shift')
+    expect(overlappingRotationError?.details?.draftKind).toBe('rotation')
+    expect(overlappingRotationError?.details?.existingKind).toBe('shift')
+
+    const inactiveRotationRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        userId: testUserId,
+        rotationRuleId,
+        startDate: '2026-06-05',
+        endDate: '2026-06-08',
+        isActive: false,
+      }),
+    })
+    expect(inactiveRotationRes.status).toBe(201)
+
+    const rotationRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        userId: testUserId,
+        rotationRuleId,
+        startDate: '2026-06-11',
+        isActive: true,
+      }),
+    })
+    expect(rotationRes.status).toBe(201)
+    const rotationAssignmentId = (rotationRes.body as { data?: { assignment?: { id?: string } } } | undefined)?.data?.assignment?.id
+    expect(rotationAssignmentId).toBeTruthy()
+    if (!rotationAssignmentId) return
+
+    const overlappingSecondRotationRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        userId: testUserId,
+        rotationRuleId,
+        startDate: '2026-06-12',
+        isActive: true,
+      }),
+    })
+    expect(overlappingSecondRotationRes.status).toBe(409)
+    const overlappingSecondRotationError = (overlappingSecondRotationRes.body as { error?: { details?: { conflictType?: string } } } | undefined)?.error
+    expect(overlappingSecondRotationError?.details?.conflictType).toBe('rotation_assignment_overlap')
+
+    const updateShiftToOverlapRotationRes = await requestJson(`${baseUrl}/api/attendance/assignments/${assignmentId}`, {
+      method: 'PUT',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        endDate: '2026-06-11',
+      }),
+    })
+    expect(updateShiftToOverlapRotationRes.status).toBe(409)
+    const updateShiftError = (updateShiftToOverlapRotationRes.body as { error?: { details?: { conflictType?: string; draftKind?: string; existingKind?: string } } } | undefined)?.error
+    expect(updateShiftError?.details?.conflictType).toBe('rotation_overrides_shift')
+    expect(updateShiftError?.details?.draftKind).toBe('shift')
+    expect(updateShiftError?.details?.existingKind).toBe('rotation')
+
+    const invalidRotationRangeRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        userId: `${testUserId}-invalid-range`,
+        rotationRuleId,
+        startDate: '2026-06-12',
+        endDate: '2026-06-01',
+        isActive: true,
+      }),
+    })
+    expect(invalidRotationRangeRes.status).toBe(400)
+    const invalidRangeError = (invalidRotationRangeRes.body as { error?: { code?: string } } | undefined)?.error
+    expect(invalidRangeError?.code).toBe('VALIDATION_ERROR')
+  })
+
   it('rejects non-UUID shift references for rotation rules, including UUID-like shift names', async () => {
     if (!baseUrl) return
 
@@ -2537,7 +2756,7 @@ describe('Attendance Plugin Integration', () => {
         'Content-Type': 'application/json',
       },
       body: JSON.stringify({
-        user_id: testUserId,
+        user_id: `${testUserId}-rotation`,
         rotation_rule_id: rotationRuleId,
         start_date: '2026-03-20',
         end_date: null,

--- a/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
@@ -1,0 +1,106 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it, vi } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceReportFieldCatalogForTests
+
+describe('attendance scheduling assignment conflict guard', () => {
+  it('detects same-kind and cross-kind active assignment overlaps', async () => {
+    const sameKindDb = {
+      query: vi.fn().mockResolvedValueOnce([
+        {
+          id: 'shift-existing',
+          kind: 'shift',
+          start_date: '2026-06-01',
+          end_date: '2026-06-10',
+        },
+      ]),
+    }
+
+    const sameKindConflict = await helpers.findAttendanceScheduleAssignmentConflict(sameKindDb, {
+      kind: 'shift',
+      orgId: 'org-a',
+      userId: 'user-a',
+      startDate: '2026-06-10',
+      endDate: '2026-06-12',
+      isActive: true,
+    })
+
+    expect(sameKindConflict?.conflictType).toBe('shift_assignment_overlap')
+    expect(sameKindConflict?.existingKind).toBe('shift')
+    expect(helpers.getAttendanceScheduleAssignmentConflictMessage(sameKindConflict)).toMatch(/shift assignment/i)
+    expect(String(sameKindDb.query.mock.calls[0]?.[0] || '')).toContain('attendance_shift_assignments')
+
+    const crossKindDb = {
+      query: vi.fn()
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            id: 'rotation-existing',
+            kind: 'rotation',
+            start_date: '2026-06-11',
+            end_date: null,
+          },
+        ]),
+    }
+
+    const crossKindConflict = await helpers.findAttendanceScheduleAssignmentConflict(crossKindDb, {
+      kind: 'shift',
+      orgId: 'org-a',
+      userId: 'user-a',
+      startDate: '2026-06-10',
+      endDate: null,
+      isActive: true,
+      excludeId: 'shift-current',
+    })
+
+    expect(crossKindConflict?.conflictType).toBe('rotation_overrides_shift')
+    expect(crossKindConflict?.draftKind).toBe('shift')
+    expect(crossKindConflict?.existingKind).toBe('rotation')
+    expect(crossKindConflict?.existingEndDate).toBeNull()
+    expect(String(crossKindDb.query.mock.calls[0]?.[0] || '')).toContain('id <> $5')
+    expect(String(crossKindDb.query.mock.calls[1]?.[0] || '')).toContain('attendance_rotation_assignments')
+  })
+
+  it('skips inactive drafts before querying for conflicts', async () => {
+    const db = { query: vi.fn() }
+
+    const conflict = await helpers.findAttendanceScheduleAssignmentConflict(db, {
+      kind: 'rotation',
+      orgId: 'org-a',
+      userId: 'user-a',
+      startDate: '2026-06-10',
+      endDate: null,
+      isActive: false,
+    })
+
+    expect(conflict).toBeNull()
+    expect(db.query).not.toHaveBeenCalled()
+  })
+
+  it('preserves explicit null endDate on update payloads', () => {
+    expect(helpers.resolveAttendanceScheduleAssignmentUpdateEndDate({}, '2026-06-10')).toBe('2026-06-10')
+    expect(helpers.resolveAttendanceScheduleAssignmentUpdateEndDate({ endDate: null }, '2026-06-10')).toBeNull()
+    expect(helpers.resolveAttendanceScheduleAssignmentUpdateEndDate({ endDate: '' }, '2026-06-10')).toBeNull()
+    expect(helpers.resolveAttendanceScheduleAssignmentUpdateEndDate({ endDate: '2026-06-20' }, '2026-06-10')).toBe('2026-06-20')
+  })
+
+  it('takes a per-org/user advisory lock before transactional writes', async () => {
+    const db = { query: vi.fn().mockResolvedValue([]) }
+
+    await helpers.acquireAttendanceScheduleAssignmentLock(db, 'org-a', 'user-a')
+
+    expect(db.query).toHaveBeenCalledWith(
+      'SELECT pg_advisory_xact_lock(hashtext($1::text), hashtext($2::text))',
+      ['attendance-schedule:org-a', 'user-a'],
+    )
+  })
+
+  it('keeps frontend diagnostic conflict type names stable', () => {
+    expect(helpers.getAttendanceScheduleAssignmentConflictType('shift', 'shift')).toBe('shift_assignment_overlap')
+    expect(helpers.getAttendanceScheduleAssignmentConflictType('rotation', 'rotation')).toBe('rotation_assignment_overlap')
+    expect(helpers.getAttendanceScheduleAssignmentConflictType('rotation', 'shift')).toBe('rotation_overrides_shift')
+    expect(helpers.getAttendanceScheduleAssignmentConflictType('shift', 'rotation')).toBe('rotation_overrides_shift')
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -7980,6 +7980,125 @@ function mapRotationAssignmentRow(row) {
   }
 }
 
+const ATTENDANCE_SCHEDULE_OPEN_END_DATE = '9999-12-31'
+
+function normalizeAttendanceScheduleAssignmentEndDate(value) {
+  const normalized = normalizeDateOnly(value)
+  return normalized || value || null
+}
+
+function resolveAttendanceScheduleAssignmentUpdateEndDate(payload, existingEndDate) {
+  if (!Object.prototype.hasOwnProperty.call(payload, 'endDate')) return existingEndDate
+  return normalizeAttendanceScheduleAssignmentEndDate(payload.endDate)
+}
+
+async function acquireAttendanceScheduleAssignmentLock(client, orgId, userId) {
+  try {
+    await client.query(
+      'SELECT pg_advisory_xact_lock(hashtext($1::text), hashtext($2::text))',
+      [`attendance-schedule:${String(orgId ?? '')}`, String(userId ?? '')]
+    )
+  } catch (_error) {
+    // Best-effort: preserve save behavior if advisory locks are unavailable.
+  }
+}
+
+function getAttendanceScheduleAssignmentConflictType(draftKind, existingKind) {
+  if (draftKind === 'shift' && existingKind === 'shift') return 'shift_assignment_overlap'
+  if (draftKind === 'rotation' && existingKind === 'rotation') return 'rotation_assignment_overlap'
+  return 'rotation_overrides_shift'
+}
+
+function getAttendanceScheduleAssignmentConflictMessage(conflict) {
+  if (conflict.conflictType === 'shift_assignment_overlap') {
+    return 'Shift assignment overlaps an active shift assignment for the same user'
+  }
+  if (conflict.conflictType === 'rotation_assignment_overlap') {
+    return 'Rotation assignment overlaps an active rotation assignment for the same user'
+  }
+  if (conflict.draftKind === 'rotation') {
+    return 'Rotation assignment overlaps an active shift assignment for the same user'
+  }
+  return 'Shift assignment overlaps an active rotation assignment for the same user'
+}
+
+function mapAttendanceScheduleAssignmentConflict(row, draft) {
+  if (!row) return null
+  const existingKind = row.kind === 'rotation' ? 'rotation' : 'shift'
+  const conflictType = getAttendanceScheduleAssignmentConflictType(draft.kind, existingKind)
+  const startDate = normalizeDateOnly(row.start_date) ?? row.start_date
+  const endDate = normalizeAttendanceScheduleAssignmentEndDate(row.end_date)
+  const draftStartDate = normalizeDateOnly(draft.startDate) ?? draft.startDate
+  const draftEndDate = normalizeAttendanceScheduleAssignmentEndDate(draft.endDate)
+  return {
+    conflictType,
+    draftKind: draft.kind,
+    existingKind,
+    assignmentId: row.id,
+    userId: draft.userId,
+    startDate: draftStartDate,
+    endDate: draftEndDate,
+    existingStartDate: startDate,
+    existingEndDate: endDate,
+  }
+}
+
+async function findAttendanceScheduleAssignmentConflict(db, draft) {
+  if (draft.isActive === false) return null
+  const draftStartDate = normalizeDateOnly(draft.startDate) ?? draft.startDate
+  const draftEndDate = normalizeAttendanceScheduleAssignmentEndDate(draft.endDate)
+  const overlapEndDate = draftEndDate || ATTENDANCE_SCHEDULE_OPEN_END_DATE
+  const sameKindTable = draft.kind === 'rotation'
+    ? 'attendance_rotation_assignments'
+    : 'attendance_shift_assignments'
+  const otherKindTable = draft.kind === 'rotation'
+    ? 'attendance_shift_assignments'
+    : 'attendance_rotation_assignments'
+  const sameKindLabel = draft.kind
+  const otherKindLabel = draft.kind === 'rotation' ? 'shift' : 'rotation'
+  const baseParams = [draft.orgId, draft.userId, draftStartDate, overlapEndDate]
+  const excludeClause = draft.excludeId ? 'AND id <> $5' : ''
+  const sameKindRows = await db.query(
+    `SELECT id, start_date, end_date, $${draft.excludeId ? 6 : 5}::text AS kind
+       FROM ${sameKindTable}
+      WHERE org_id = $1
+        AND user_id = $2
+        AND COALESCE(is_active, true) = true
+        AND start_date <= $4::date
+        AND COALESCE(end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
+        ${excludeClause}
+      ORDER BY start_date DESC, created_at DESC
+      LIMIT 1`,
+    draft.excludeId ? [...baseParams, draft.excludeId, sameKindLabel] : [...baseParams, sameKindLabel]
+  )
+  if (sameKindRows.length) return mapAttendanceScheduleAssignmentConflict(sameKindRows[0], draft)
+
+  const otherKindRows = await db.query(
+    `SELECT id, start_date, end_date, $5::text AS kind
+       FROM ${otherKindTable}
+      WHERE org_id = $1
+        AND user_id = $2
+        AND COALESCE(is_active, true) = true
+        AND start_date <= $4::date
+        AND COALESCE(end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
+      ORDER BY start_date DESC, created_at DESC
+      LIMIT 1`,
+    [...baseParams, otherKindLabel]
+  )
+  return mapAttendanceScheduleAssignmentConflict(otherKindRows[0], draft)
+}
+
+function respondAttendanceScheduleAssignmentConflict(res, conflict) {
+  res.status(409).json({
+    ok: false,
+    error: {
+      code: 'ATTENDANCE_SCHEDULE_ASSIGNMENT_CONFLICT',
+      message: getAttendanceScheduleAssignmentConflictMessage(conflict),
+      details: conflict,
+    },
+  })
+}
+
 function mapRotationRuleFromAssignmentRow(row) {
   return mapRotationRuleRow({
     id: row.rotation_rule_id,
@@ -12726,6 +12845,11 @@ module.exports = {
     getAttendancePayrollSummaryFieldValue,
     normalizeCalendarPolicyOverrides,
     resolveEffectiveCalendar,
+    findAttendanceScheduleAssignmentConflict,
+    acquireAttendanceScheduleAssignmentLock,
+    getAttendanceScheduleAssignmentConflictMessage,
+    getAttendanceScheduleAssignmentConflictType,
+    resolveAttendanceScheduleAssignmentUpdateEndDate,
     buildAttendanceRecordReportExportItem,
     buildAttendanceRecordReportExportItemAsync,
     buildAttendanceRecordReportCsv,
@@ -18099,8 +18223,13 @@ module.exports = {
           userId: parsed.data.userId,
           rotationRuleId,
           startDate: parsed.data.startDate,
-          endDate: parsed.data.endDate ?? null,
+          endDate: normalizeAttendanceScheduleAssignmentEndDate(parsed.data.endDate),
           isActive: parsed.data.isActive ?? true,
+        }
+
+        if (payload.endDate && payload.endDate < payload.startDate) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'End date must be after start date' } })
+          return
         }
 
         try {
@@ -18113,23 +18242,42 @@ module.exports = {
             return
           }
 
-          const rows = await db.query(
-            `INSERT INTO attendance_rotation_assignments
-             (id, org_id, user_id, rotation_rule_id, start_date, end_date, is_active)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)
-             RETURNING *`,
-            [
-              randomUUID(),
+          const result = await db.transaction(async (trx) => {
+            await acquireAttendanceScheduleAssignmentLock(trx, orgId, payload.userId)
+            const conflict = await findAttendanceScheduleAssignmentConflict(trx, {
+              kind: 'rotation',
               orgId,
-              payload.userId,
-              payload.rotationRuleId,
-              payload.startDate,
-              payload.endDate,
-              payload.isActive,
-            ]
-          )
+              userId: payload.userId,
+              startDate: payload.startDate,
+              endDate: payload.endDate,
+              isActive: payload.isActive,
+            })
+            if (conflict) return { conflict }
 
-          const assignment = mapRotationAssignmentRow(rows[0])
+            const rows = await trx.query(
+              `INSERT INTO attendance_rotation_assignments
+               (id, org_id, user_id, rotation_rule_id, start_date, end_date, is_active)
+               VALUES ($1, $2, $3, $4, $5, $6, $7)
+               RETURNING *`,
+              [
+                randomUUID(),
+                orgId,
+                payload.userId,
+                payload.rotationRuleId,
+                payload.startDate,
+                payload.endDate,
+                payload.isActive,
+              ]
+            )
+            return { row: rows[0] }
+          })
+
+          if (result.conflict) {
+            respondAttendanceScheduleAssignmentConflict(res, result.conflict)
+            return
+          }
+
+          const assignment = mapRotationAssignmentRow(result.row)
           const rotation = mapRotationRuleRow(ruleRows[0])
           emitEvent('attendance.rotationAssignment.created', { orgId, rotationAssignmentId: assignment.id })
           res.status(201).json({ ok: true, data: { assignment, rotation } })
@@ -18183,8 +18331,13 @@ module.exports = {
             userId: parsed.data.userId ?? existing.user_id,
             rotationRuleId: nextRotationRuleId,
             startDate: parsed.data.startDate ?? existing.start_date,
-            endDate: parsed.data.endDate ?? existing.end_date,
+            endDate: resolveAttendanceScheduleAssignmentUpdateEndDate(parsed.data, existing.end_date),
             isActive: parsed.data.isActive ?? existing.is_active,
+          }
+
+          if (payload.endDate && payload.endDate < payload.startDate) {
+            res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'End date must be after start date' } })
+            return
           }
 
           const ruleRows = await db.query(
@@ -18196,28 +18349,48 @@ module.exports = {
             return
           }
 
-          const rows = await db.query(
-            `UPDATE attendance_rotation_assignments
-             SET user_id = $3,
-                 rotation_rule_id = $4,
-                 start_date = $5,
-                 end_date = $6,
-                 is_active = $7,
-                 updated_at = now()
-             WHERE id = $1 AND org_id = $2
-             RETURNING *`,
-            [
-              assignmentId,
+          const result = await db.transaction(async (trx) => {
+            await acquireAttendanceScheduleAssignmentLock(trx, orgId, payload.userId)
+            const conflict = await findAttendanceScheduleAssignmentConflict(trx, {
+              kind: 'rotation',
               orgId,
-              payload.userId,
-              payload.rotationRuleId,
-              payload.startDate,
-              payload.endDate,
-              payload.isActive,
-            ]
-          )
+              userId: payload.userId,
+              startDate: payload.startDate,
+              endDate: payload.endDate,
+              isActive: payload.isActive,
+              excludeId: assignmentId,
+            })
+            if (conflict) return { conflict }
 
-          const assignment = mapRotationAssignmentRow(rows[0])
+            const rows = await trx.query(
+              `UPDATE attendance_rotation_assignments
+               SET user_id = $3,
+                   rotation_rule_id = $4,
+                   start_date = $5,
+                   end_date = $6,
+                   is_active = $7,
+                   updated_at = now()
+               WHERE id = $1 AND org_id = $2
+               RETURNING *`,
+              [
+                assignmentId,
+                orgId,
+                payload.userId,
+                payload.rotationRuleId,
+                payload.startDate,
+                payload.endDate,
+                payload.isActive,
+              ]
+            )
+            return { row: rows[0] }
+          })
+
+          if (result.conflict) {
+            respondAttendanceScheduleAssignmentConflict(res, result.conflict)
+            return
+          }
+
+          const assignment = mapRotationAssignmentRow(result.row)
           const rotation = mapRotationRuleRow(ruleRows[0])
           emitEvent('attendance.rotationAssignment.updated', { orgId, rotationAssignmentId: assignment.id })
           res.json({ ok: true, data: { assignment, rotation } })
@@ -24309,15 +24482,11 @@ module.exports = {
           respondInvalidUuid(res, 'shiftId')
           return
         }
-        const normalizedEndDate = typeof parsed.data.endDate === 'string' && parsed.data.endDate.trim().length > 0
-          ? parsed.data.endDate
-          : null
-
         const payload = {
           userId: parsed.data.userId,
           shiftId,
           startDate: parsed.data.startDate,
-          endDate: normalizedEndDate,
+          endDate: normalizeAttendanceScheduleAssignmentEndDate(parsed.data.endDate),
           isActive: parsed.data.isActive ?? true,
         }
 
@@ -24336,23 +24505,42 @@ module.exports = {
             return
           }
 
-          const rows = await db.query(
-            `INSERT INTO attendance_shift_assignments
-             (id, org_id, user_id, shift_id, start_date, end_date, is_active)
-             VALUES ($1, $2, $3, $4, $5, $6, $7)
-             RETURNING *`,
-            [
-              randomUUID(),
+          const result = await db.transaction(async (trx) => {
+            await acquireAttendanceScheduleAssignmentLock(trx, orgId, payload.userId)
+            const conflict = await findAttendanceScheduleAssignmentConflict(trx, {
+              kind: 'shift',
               orgId,
-              payload.userId,
-              payload.shiftId,
-              payload.startDate,
-              payload.endDate,
-              payload.isActive,
-            ]
-          )
+              userId: payload.userId,
+              startDate: payload.startDate,
+              endDate: payload.endDate,
+              isActive: payload.isActive,
+            })
+            if (conflict) return { conflict }
 
-          const assignment = mapAssignmentRow(rows[0])
+            const rows = await trx.query(
+              `INSERT INTO attendance_shift_assignments
+               (id, org_id, user_id, shift_id, start_date, end_date, is_active)
+               VALUES ($1, $2, $3, $4, $5, $6, $7)
+               RETURNING *`,
+              [
+                randomUUID(),
+                orgId,
+                payload.userId,
+                payload.shiftId,
+                payload.startDate,
+                payload.endDate,
+                payload.isActive,
+              ]
+            )
+            return { row: rows[0] }
+          })
+
+          if (result.conflict) {
+            respondAttendanceScheduleAssignmentConflict(res, result.conflict)
+            return
+          }
+
+          const assignment = mapAssignmentRow(result.row)
           const shift = mapShiftRow(shiftRows[0])
           emitEvent('attendance.assignment.created', { orgId, assignmentId: assignment.id })
           res.status(201).json({ ok: true, data: { assignment, shift } })
@@ -24402,15 +24590,11 @@ module.exports = {
             respondInvalidUuid(res, 'shiftId')
             return
           }
-          const normalizedEndDate = typeof parsed.data.endDate === 'string'
-            ? (parsed.data.endDate.trim().length > 0 ? parsed.data.endDate : null)
-            : parsed.data.endDate
-
           const payload = {
             userId: parsed.data.userId ?? existing.user_id,
             shiftId: nextShiftId,
             startDate: parsed.data.startDate ?? existing.start_date,
-            endDate: normalizedEndDate ?? existing.end_date,
+            endDate: resolveAttendanceScheduleAssignmentUpdateEndDate(parsed.data, existing.end_date),
             isActive: parsed.data.isActive ?? existing.is_active,
           }
 
@@ -24428,28 +24612,48 @@ module.exports = {
             return
           }
 
-          const rows = await db.query(
-            `UPDATE attendance_shift_assignments
-             SET user_id = $3,
-                 shift_id = $4,
-                 start_date = $5,
-                 end_date = $6,
-                 is_active = $7,
-                 updated_at = now()
-             WHERE id = $1 AND org_id = $2
-             RETURNING *`,
-            [
-              assignmentId,
+          const result = await db.transaction(async (trx) => {
+            await acquireAttendanceScheduleAssignmentLock(trx, orgId, payload.userId)
+            const conflict = await findAttendanceScheduleAssignmentConflict(trx, {
+              kind: 'shift',
               orgId,
-              payload.userId,
-              payload.shiftId,
-              payload.startDate,
-              payload.endDate,
-              payload.isActive,
-            ]
-          )
+              userId: payload.userId,
+              startDate: payload.startDate,
+              endDate: payload.endDate,
+              isActive: payload.isActive,
+              excludeId: assignmentId,
+            })
+            if (conflict) return { conflict }
 
-          const assignment = mapAssignmentRow(rows[0])
+            const rows = await trx.query(
+              `UPDATE attendance_shift_assignments
+               SET user_id = $3,
+                   shift_id = $4,
+                   start_date = $5,
+                   end_date = $6,
+                   is_active = $7,
+                   updated_at = now()
+               WHERE id = $1 AND org_id = $2
+               RETURNING *`,
+              [
+                assignmentId,
+                orgId,
+                payload.userId,
+                payload.shiftId,
+                payload.startDate,
+                payload.endDate,
+                payload.isActive,
+              ]
+            )
+            return { row: rows[0] }
+          })
+
+          if (result.conflict) {
+            respondAttendanceScheduleAssignmentConflict(res, result.conflict)
+            return
+          }
+
+          const assignment = mapAssignmentRow(result.row)
           const shift = mapShiftRow(shiftRows[0])
           emitEvent('attendance.assignment.updated', { orgId, assignmentId: assignment.id })
           res.json({ ok: true, data: { assignment, shift } })


### PR DESCRIPTION
## Summary

Adds backend save-time guards for attendance scheduling assignment conflicts.

- Blocks active fixed-shift assignment overlaps for the same user.
- Blocks active rotation assignment overlaps for the same user.
- Blocks fixed-shift vs rotation overlaps for the same user with the same conflict type used by the frontend diagnostics (`rotation_overrides_shift`).
- Keeps inactive drafts saveable and leaves the existing frontend warning UI unchanged.
- Adds backend validation for rotation assignment `endDate < startDate` to match fixed assignment behavior.

No attendance migrations, no direct `meta_*` writes, and no frontend validator rewrite.

## Test plan

- [x] `node --check plugins/plugin-attendance/index.cjs`
- [x] Backend unit: `attendance-scheduling-assignment-conflict` + catalog + formula, 59 tests PASS
- [x] Backend integration targeted scheduling routes command completed; local DB-backed assertions are guarded by existing `baseUrl` checks
- [x] Frontend scheduling specs, 35 tests PASS
- [x] `pnpm --filter @metasheet/core-backend build`
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `git diff --check`

Docs:

- `docs/development/attendance-scheduling-conflict-save-development-20260521.md`
- `docs/development/attendance-scheduling-conflict-save-verification-20260521.md`
