### PR TITLE
feat(attendance): apply group rule set in effective calendar

### DIFF
--- a/docs/development/attendance-effective-calendar-group-ruleset-development-20260521.md
+++ b/docs/development/attendance-effective-calendar-group-ruleset-development-20260521.md
@@ -1,0 +1,79 @@
+# Attendance Effective Calendar Group Rule Set Development
+
+Date: 2026-05-21
+Branch: `codex/attendance-effective-calendar-group-ruleset-20260521`
+Base: `origin/main@3a03b7cf6`
+
+## Summary
+
+This slice closes the effective-calendar `groupId` mode limitation where the
+base profile always used the organization default attendance rule. When an
+attendance group has `attendance_groups.rule_set_id`, `GET/POST
+/api/attendance/effective-calendar` now uses that rule set's `config.rule` as
+the group-mode base profile.
+
+The change is intentionally read-only and resolver-scoped. It does not change
+`userId` calculation-chain behavior, import commit behavior, punch writeback,
+or any `attendance_*` schema.
+
+## Delivered
+
+- `loadAttendanceGroupByIdOrCode()` now loads `rule_set_id` and maps it to
+  `ruleSetId`.
+- Older environments that lack `attendance_groups.rule_set_id` fall back to the
+  pre-existing group lookup shape instead of returning a false `Group not
+  found`.
+- The group-mode resolver treats missing rule-set schema as `null`, matching
+  the resolver's read-only posture without changing other rule-set callers.
+- `resolveEffectiveCalendar()` applies `normalizeRuleOverride(config.rule)` to
+  the default rule when the current mode is `groupId` and the group has a rule
+  set.
+- `groupId` timezone output now follows the same chain with the derived group
+  rule profile before the group fallback timezone.
+
+## Boundary
+
+- No migration.
+- No direct `meta_*` writes.
+- No settings storage shape change.
+- No frontend change.
+- No `userId` calc-chain cutover for group rule sets. That is a separate
+  product decision because it would affect punch/import/payroll materialized
+  facts, not just read-only group preview.
+
+## Behavior
+
+Before:
+
+| Mode | Group has rule set? | Saturday with default Mon-Fri rule | Output |
+| --- | --- | --- | --- |
+| `groupId` | yes, `workingDays: [6]` | default says rest | rest day |
+
+After:
+
+| Mode | Group has rule set? | Saturday with group `workingDays: [6]` | Output |
+| --- | --- | --- | --- |
+| `groupId` | yes | group rule says work | working day |
+| `groupId` | no | default Mon-Fri says rest | rest day |
+
+Calendar-policy layering is unchanged: group-source `calendarPolicy` overrides
+still apply on top of the base profile and can override the final effective
+workday.
+
+## Tests Added
+
+- `uses a group rule-set rule as groupId effective-calendar base profile`
+  - proves `attendance_rule_sets.config.rule.workingDays` drives the group-mode
+    base/effective value;
+  - proves rule-set timezone is used before group timezone;
+  - proves the resolver actually queries the referenced rule set.
+- `keeps groupId mode on the default rule when the group has no rule set`
+  - proves no rule-set lookup runs;
+  - preserves pre-existing default-rule behavior.
+
+## Follow-Up
+
+If the product wants an employee's group-bound rule set to become the default
+`userId` rule for punch/import/payroll, that should be a separate calc-chain
+slice with integration coverage. This slice only fixes the read-only group
+preview surface documented as a v1 limitation.

--- a/docs/development/attendance-effective-calendar-group-ruleset-verification-20260521.md
+++ b/docs/development/attendance-effective-calendar-group-ruleset-verification-20260521.md
@@ -1,0 +1,46 @@
+# Attendance Effective Calendar Group Rule Set Verification
+
+Date: 2026-05-21
+Branch: `codex/attendance-effective-calendar-group-ruleset-20260521`
+
+## Verification Matrix
+
+| Layer | Command | Result |
+| --- | --- | --- |
+| Plugin syntax | `node --check plugins/plugin-attendance/index.cjs` | PASS |
+| Focused backend unit | `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` | PASS, 5 tests |
+| Backend catalog/formula/effective-calendar regression | `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` | PASS, 61 tests |
+| Backend build | `pnpm --filter @metasheet/core-backend build` | PASS |
+| Frontend type-check | `pnpm --filter @metasheet/web type-check` | PASS |
+| Whitespace | `git diff --check` | PASS |
+
+## Focused Evidence
+
+- `groupId` with `attendance_groups.rule_set_id` and rule-set
+  `workingDays: [6]` returns Saturday as `base.isWorkingDay=true` and
+  `effective.isWorkingDay=true`.
+- The same response reports `timezone=Asia/Shanghai` from the rule set before
+  falling back to the group timezone.
+- A group without `rule_set_id` does not query `attendance_rule_sets` and
+  retains the default-rule Saturday rest-day result.
+
+## Boundary Checks
+
+- No migration file added or edited.
+- No `attendance_*` fact-source write path changed.
+- No direct `meta_*` SQL write.
+- No frontend or client-side validator change.
+- `userId` calculation-chain behavior is intentionally unchanged.
+
+## Commands Run
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/attendance-report-field-catalog.test.ts \
+  tests/unit/attendance-report-field-formula-engine.test.ts \
+  tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot
+pnpm --filter @metasheet/core-backend build
+pnpm --filter @metasheet/web type-check
+git diff --check
+```

--- a/docs/development/attendance-effective-calendar-group-ruleset-verification-20260521.md
+++ b/docs/development/attendance-effective-calendar-group-ruleset-verification-20260521.md
@@ -8,8 +8,8 @@ Branch: `codex/attendance-effective-calendar-group-ruleset-20260521`
 | Layer | Command | Result |
 | --- | --- | --- |
 | Plugin syntax | `node --check plugins/plugin-attendance/index.cjs` | PASS |
-| Focused backend unit | `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` | PASS, 5 tests |
-| Backend catalog/formula/effective-calendar regression | `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` | PASS, 61 tests |
+| Focused backend unit | `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` | PASS, 6 tests |
+| Backend catalog/formula/effective-calendar regression | `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` | PASS, 62 tests |
 | Backend build | `pnpm --filter @metasheet/core-backend build` | PASS |
 | Frontend type-check | `pnpm --filter @metasheet/web type-check` | PASS |
 | Whitespace | `git diff --check` | PASS |
@@ -23,6 +23,10 @@ Branch: `codex/attendance-effective-calendar-group-ruleset-20260521`
   falling back to the group timezone.
 - A group without `rule_set_id` does not query `attendance_rule_sets` and
   retains the default-rule Saturday rest-day result.
+- Legacy schema fallback is covered: if the new group lookup sees PostgreSQL
+  `42703` for missing `rule_set_id`, the resolver retries the exact pre-slice
+  group lookup shape, keeps default-rule behavior, and does not query
+  `attendance_rule_sets`.
 
 Semantic note: User belonging to a group with `rule_set_id` will see different
 calendars between `groupId`-mode preview and `userId`-mode preview; this is the

--- a/docs/development/attendance-effective-calendar-group-ruleset-verification-20260521.md
+++ b/docs/development/attendance-effective-calendar-group-ruleset-verification-20260521.md
@@ -24,6 +24,21 @@ Branch: `codex/attendance-effective-calendar-group-ruleset-20260521`
 - A group without `rule_set_id` does not query `attendance_rule_sets` and
   retains the default-rule Saturday rest-day result.
 
+Semantic note: User belonging to a group with `rule_set_id` will see different
+calendars between `groupId`-mode preview and `userId`-mode preview; this is the
+intended boundary in this slice, deferred to a separate product decision.
+
+## Schema-Degrade Gate
+
+The fallback is intentionally narrow: it only catches errors classified by
+`isDatabaseSchemaError()` while loading group `rule_set_id` / rule-set config
+for the read-only `groupId` resolver path. The classifier recognizes:
+
+- PostgreSQL code `42P01` (`undefined_table`).
+- PostgreSQL code `42703` (`undefined_column`).
+- Message text containing `relation` or `table` plus `does not exist`.
+- Message text containing `column` plus `does not exist`.
+
 ## Boundary Checks
 
 - No migration file added or edited.

--- a/packages/core-backend/tests/unit/attendance-effective-calendar-role-context.test.ts
+++ b/packages/core-backend/tests/unit/attendance-effective-calendar-role-context.test.ts
@@ -243,4 +243,68 @@ describe('attendance effective calendar role context', () => {
       source: 'rule',
     })
   })
+
+  it('falls back to the pre-rule-set group lookup when rule_set_id schema is missing', async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM attendance_rules')) {
+        return [
+          {
+            id: 'default-rule',
+            name: 'Default rule',
+            timezone: 'UTC',
+            work_start_time: '09:00',
+            work_end_time: '18:00',
+            late_grace_minutes: 10,
+            early_grace_minutes: 10,
+            rounding_minutes: 5,
+            working_days: [1, 2, 3, 4, 5],
+            is_default: true,
+            org_id: 'default',
+          },
+        ]
+      }
+      if (sql.includes('FROM attendance_holidays')) return []
+      if (sql.includes('FROM attendance_groups') && sql.includes('rule_set_id')) {
+        const error = new Error('column "rule_set_id" does not exist') as Error & { code?: string }
+        error.code = '42703'
+        throw error
+      }
+      if (sql.includes('FROM attendance_groups')) {
+        return [
+          {
+            id: 'group-legacy',
+            name: 'Legacy Ops',
+            code: 'legacy_ops',
+            timezone: 'Asia/Tokyo',
+          },
+        ]
+      }
+      if (sql.includes('FROM attendance_rule_sets')) {
+        throw new Error('rule-set lookup should not run after schema fallback')
+      }
+      return []
+    })
+
+    const result = await helpers.resolveEffectiveCalendar({ query }, {
+      orgId: 'default',
+      from: '2026-10-10',
+      to: '2026-10-10',
+      groupId: 'legacy_ops',
+      calendarPolicyOverrides: [],
+    })
+
+    expect(result.timezone).toBe('UTC')
+    expect(result.items[0]?.base).toMatchObject({
+      isWorkingDay: false,
+      source: 'rule',
+    })
+    expect(query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT id, name, code, timezone, rule_set_id'),
+      ['default', 'legacy_ops'],
+    )
+    expect(query).toHaveBeenCalledWith(
+      expect.not.stringContaining('rule_set_id'),
+      ['default', 'legacy_ops'],
+    )
+  })
 })

--- a/packages/core-backend/tests/unit/attendance-effective-calendar-role-context.test.ts
+++ b/packages/core-backend/tests/unit/attendance-effective-calendar-role-context.test.ts
@@ -108,4 +108,139 @@ describe('attendance effective calendar role context', () => {
     expect(helpers.matchScopeFilters({ roles: ['attendance employee'] }, user2)).toBe(true)
     expect(helpers.matchScopeFilters({ roleTags: ['operator'] }, user2)).toBe(true)
   })
+
+  it('uses a group rule-set rule as groupId effective-calendar base profile', async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM attendance_rules')) {
+        return [
+          {
+            id: 'default-rule',
+            name: 'Default rule',
+            timezone: 'UTC',
+            work_start_time: '09:00',
+            work_end_time: '18:00',
+            late_grace_minutes: 10,
+            early_grace_minutes: 10,
+            rounding_minutes: 5,
+            working_days: [1, 2, 3, 4, 5],
+            is_default: true,
+            org_id: 'default',
+          },
+        ]
+      }
+      if (sql.includes('FROM attendance_holidays')) return []
+      if (sql.includes('FROM attendance_groups')) {
+        return [
+          {
+            id: 'group-1',
+            name: 'Weekend Ops',
+            code: 'weekend_ops',
+            timezone: 'Asia/Tokyo',
+            rule_set_id: 'rule-set-1',
+          },
+        ]
+      }
+      if (sql.includes('FROM attendance_rule_sets')) {
+        return [
+          {
+            config: {
+              rule: {
+                timezone: 'Asia/Shanghai',
+                workingDays: [6],
+              },
+            },
+          },
+        ]
+      }
+      return []
+    })
+
+    const result = await helpers.resolveEffectiveCalendar({ query }, {
+      orgId: 'default',
+      from: '2026-10-10',
+      to: '2026-10-10',
+      groupId: 'group-1',
+      calendarPolicyOverrides: [],
+    })
+
+    expect(result.timezone).toBe('Asia/Shanghai')
+    expect(result.items[0]).toMatchObject({
+      date: '2026-10-10',
+      base: {
+        isWorkingDay: true,
+        source: 'rule',
+      },
+      effective: {
+        isWorkingDay: true,
+        source: 'rule',
+      },
+    })
+    expect(result.items[0]?.layers).toEqual([
+      {
+        kind: 'base_rule',
+        source: 'rule',
+        isWorkingDay: true,
+      },
+    ])
+    expect(query).toHaveBeenCalledWith(
+      'SELECT config FROM attendance_rule_sets WHERE id = $1 AND org_id = $2',
+      ['rule-set-1', 'default'],
+    )
+  })
+
+  it('keeps groupId mode on the default rule when the group has no rule set', async () => {
+    const query = vi.fn(async (sql: string) => {
+      if (sql.includes('FROM attendance_rules')) {
+        return [
+          {
+            id: 'default-rule',
+            name: 'Default rule',
+            timezone: 'UTC',
+            work_start_time: '09:00',
+            work_end_time: '18:00',
+            late_grace_minutes: 10,
+            early_grace_minutes: 10,
+            rounding_minutes: 5,
+            working_days: [1, 2, 3, 4, 5],
+            is_default: true,
+            org_id: 'default',
+          },
+        ]
+      }
+      if (sql.includes('FROM attendance_holidays')) return []
+      if (sql.includes('FROM attendance_groups')) {
+        return [
+          {
+            id: 'group-2',
+            name: 'Weekday Ops',
+            code: 'weekday_ops',
+            timezone: 'Asia/Tokyo',
+            rule_set_id: null,
+          },
+        ]
+      }
+      if (sql.includes('FROM attendance_rule_sets')) {
+        throw new Error('rule-set lookup should not run without group rule_set_id')
+      }
+      return []
+    })
+
+    const result = await helpers.resolveEffectiveCalendar({ query }, {
+      orgId: 'default',
+      from: '2026-10-10',
+      to: '2026-10-10',
+      groupId: 'group-2',
+      calendarPolicyOverrides: [],
+    })
+
+    expect(result.timezone).toBe('UTC')
+    expect(result.items[0]?.base).toMatchObject({
+      isWorkingDay: false,
+      source: 'rule',
+    })
+    expect(result.items[0]?.effective).toMatchObject({
+      isWorkingDay: false,
+      source: 'rule',
+    })
+  })
 })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -10746,16 +10746,44 @@ async function loadAttendanceGroupByIdOrCode(db, orgId, identifier) {
   const targetOrg = orgId || DEFAULT_ORG_ID
   try {
     const rows = await db.query(
-      `SELECT id, name, code, timezone
+      `SELECT id, name, code, timezone, rule_set_id
        FROM attendance_groups
        WHERE org_id = $1 AND (id::text = $2 OR code = $2)
        LIMIT 1`,
       [targetOrg, String(identifier)]
     )
-    return rows.length ? { id: rows[0].id, name: rows[0].name, code: rows[0].code, timezone: rows[0].timezone } : null
+    return rows.length
+      ? {
+        id: rows[0].id,
+        name: rows[0].name,
+        code: rows[0].code,
+        timezone: rows[0].timezone,
+        ruleSetId: rows[0].rule_set_id ?? null,
+      }
+      : null
   } catch (error) {
-    if (isDatabaseSchemaError(error)) return null
-    throw error
+    if (!isDatabaseSchemaError(error)) throw error
+    try {
+      const rows = await db.query(
+        `SELECT id, name, code, timezone
+         FROM attendance_groups
+         WHERE org_id = $1 AND (id::text = $2 OR code = $2)
+         LIMIT 1`,
+        [targetOrg, String(identifier)]
+      )
+      return rows.length
+        ? {
+          id: rows[0].id,
+          name: rows[0].name,
+          code: rows[0].code,
+          timezone: rows[0].timezone,
+          ruleSetId: null,
+        }
+        : null
+    } catch (fallbackError) {
+      if (isDatabaseSchemaError(fallbackError)) return null
+      throw fallbackError
+    }
   }
 }
 
@@ -10779,6 +10807,17 @@ function buildCalendarBaseFromProfile(profile, weekday, source) {
     isWorkingDay,
     source: source ?? 'rule',
   }
+}
+
+function buildAttendanceRuleWithRuleSetOverride(baseRule, ruleSetConfig) {
+  const override = normalizeRuleOverride(ruleSetConfig?.rule)
+  return override
+    ? {
+      ...baseRule,
+      ...override,
+      workingDays: override.workingDays ?? baseRule.workingDays,
+    }
+    : baseRule
 }
 
 function buildCalendarBaseFromHoliday(holiday) {
@@ -10848,6 +10887,7 @@ async function resolveEffectiveCalendar(db, args) {
   let rotationShiftsById = new Map()
   let overlays = []
   let groupContext = null
+  let groupRule = null
 
   if (mode === 'userId') {
     scopeContext = await loadAttendanceScopeContextForUser(db, orgId, args.userId)
@@ -10859,6 +10899,15 @@ async function resolveEffectiveCalendar(db, args) {
   } else if (mode === 'groupId') {
     groupContext = await loadAttendanceGroupByIdOrCode(db, orgId, args.groupId)
     if (!groupContext) throw new Error('NOT_FOUND:group')
+    if (groupContext.ruleSetId) {
+      let ruleSetConfig = null
+      try {
+        ruleSetConfig = await loadRuleSetConfigById(db, orgId, groupContext.ruleSetId)
+      } catch (error) {
+        if (!isDatabaseSchemaError(error)) throw error
+      }
+      groupRule = buildAttendanceRuleWithRuleSetOverride(defaultRule, ruleSetConfig)
+    }
     const groupRefs = []
     if (groupContext.name) groupRefs.push(groupContext.name)
     if (groupContext.code) groupRefs.push(groupContext.code)
@@ -10883,7 +10932,7 @@ async function resolveEffectiveCalendar(db, args) {
   const timezone = resolveCalendarTimezone({
     rotation: firstDateRotation,
     shift: firstDateShift,
-    defaultRule,
+    defaultRule: groupRule ?? defaultRule,
     group: groupContext,
     defaultTimezone: undefined,
   })
@@ -10911,7 +10960,7 @@ async function resolveEffectiveCalendar(db, args) {
   const items = dates.map((date) => {
     const weekday = getWeekdayFromDateKey(date)
     let profileSource = 'rule'
-    let profile = defaultRule
+    let profile = groupRule ?? defaultRule
 
     if (mode === 'userId') {
       const rotationInfo = resolveRotationInfoFromPrefetch(rotationByUser.get(args.userId), date, rotationShiftsById)


### PR DESCRIPTION
## Summary

Closes the effective-calendar `groupId` limitation where the base profile always used the org default rule. When an attendance group has `attendance_groups.rule_set_id`, group-mode effective-calendar preview now applies that rule set's `config.rule` before evaluating holidays and calendar policy layers.

Boundaries:
- no migration / no direct `meta_*` writes
- no frontend change
- no `userId` calc-chain cutover for group rule sets; this remains a separate product decision
- old schemas without `attendance_groups.rule_set_id` fall back to the previous group lookup shape instead of false 404

## Test plan

- [x] `node --check plugins/plugin-attendance/index.cjs`
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts tests/unit/attendance-report-field-formula-engine.test.ts tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` (61 tests)
- [x] `pnpm --filter @metasheet/core-backend build`
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `git diff --check`

## Docs

- `docs/development/attendance-effective-calendar-group-ruleset-development-20260521.md`
- `docs/development/attendance-effective-calendar-group-ruleset-verification-20260521.md`
