### PR TITLE
feat(multitable): localize automation manager chrome (T3D-3)

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -2,7 +2,7 @@
   <div v-if="visible" class="meta-automation__overlay" @click.self="$emit('close')">
     <div class="meta-automation">
       <div class="meta-automation__header">
-        <h4 class="meta-automation__title">Automations</h4>
+        <h4 class="meta-automation__title">{{ l('manager.title') }}</h4>
         <button class="meta-automation__close" type="button" @click="$emit('close')">&times;</button>
       </div>
 
@@ -11,63 +11,63 @@
 
         <!-- Create / Edit form -->
         <section v-if="showForm" class="meta-automation__form">
-          <div class="meta-automation__form-title">{{ editingRuleId ? 'Edit Automation' : 'New Automation' }}</div>
+          <div class="meta-automation__form-title">{{ editingRuleId ? l('manager.quickEditTitle') : l('manager.quickNewTitle') }}</div>
 
-          <label class="meta-automation__label">Name</label>
+          <label class="meta-automation__label">{{ l('editor.name') }}</label>
           <input
             v-model="draft.name"
             class="meta-automation__input"
             type="text"
-            placeholder="Automation name"
+            :placeholder="l('editor.namePlaceholder')"
             data-automation-field="name"
           />
 
-          <label class="meta-automation__label">Trigger</label>
+          <label class="meta-automation__label">{{ l('trigger.title') }}</label>
           <select v-model="draft.triggerType" class="meta-automation__select" data-automation-field="triggerType">
-            <option value="record.created">When record created</option>
-            <option value="record.updated">When record updated</option>
-            <option value="field.changed">When field changes</option>
+            <option value="record.created">{{ automationTriggerTypeLabel('record.created', isZh) }}</option>
+            <option value="record.updated">{{ automationTriggerTypeLabel('record.updated', isZh) }}</option>
+            <option value="field.changed">{{ automationTriggerTypeLabel('field.changed', isZh) }}</option>
           </select>
 
           <template v-if="draft.triggerType === 'field.changed'">
-            <label class="meta-automation__label">Watch field</label>
+            <label class="meta-automation__label">{{ l('trigger.watchField') }}</label>
             <select v-model="draft.triggerFieldId" class="meta-automation__select" data-automation-field="triggerFieldId">
-              <option value="">-- select field --</option>
+              <option value="">{{ l('trigger.selectField') }}</option>
               <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
             </select>
           </template>
 
-          <label class="meta-automation__label">Action</label>
+          <label class="meta-automation__label">{{ l('manager.action') }}</label>
           <select v-model="draft.actionType" class="meta-automation__select" data-automation-field="actionType">
-            <option value="notify">Send notification</option>
-            <option value="update_field">Update field value</option>
-            <option value="send_dingtalk_group_message">Send DingTalk group message</option>
-            <option value="send_dingtalk_person_message">Send DingTalk person message</option>
+            <option value="notify">{{ automationActionTypeLabel('notify', isZh) }}</option>
+            <option value="update_field">{{ automationActionTypeLabel('update_field', isZh) }}</option>
+            <option value="send_dingtalk_group_message">{{ automationActionTypeLabel('send_dingtalk_group_message', isZh) }}</option>
+            <option value="send_dingtalk_person_message">{{ automationActionTypeLabel('send_dingtalk_person_message', isZh) }}</option>
           </select>
 
           <template v-if="draft.actionType === 'notify'">
-            <label class="meta-automation__label">Message</label>
+            <label class="meta-automation__label">{{ l('actionConfig.message') }}</label>
             <input
               v-model="draft.notifyMessage"
               class="meta-automation__input"
               type="text"
-              placeholder="Notification message"
+              :placeholder="l('actionConfig.notificationMessagePlaceholder')"
               data-automation-field="notifyMessage"
             />
           </template>
 
           <template v-if="draft.actionType === 'update_field'">
-            <label class="meta-automation__label">Target field</label>
+            <label class="meta-automation__label">{{ l('manager.targetField') }}</label>
             <select v-model="draft.targetFieldId" class="meta-automation__select" data-automation-field="targetFieldId">
-              <option value="">-- select field --</option>
+              <option value="">{{ l('trigger.selectField') }}</option>
               <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
             </select>
-            <label class="meta-automation__label">Value</label>
+            <label class="meta-automation__label">{{ l('editor.value') }}</label>
             <input
               v-model="draft.targetValue"
               class="meta-automation__input"
               type="text"
-              placeholder="New value"
+              :placeholder="l('manager.newValuePlaceholder')"
               data-automation-field="targetValue"
             />
           </template>
@@ -585,9 +585,9 @@
 
           <div class="meta-automation__form-actions">
             <button class="meta-automation__btn meta-automation__btn--primary" type="button" :disabled="!canSave" @click="onSave">
-              {{ editingRuleId ? 'Update' : 'Create' }}
+              {{ editingRuleId ? l('manager.update') : l('manager.create') }}
             </button>
-            <button class="meta-automation__btn" type="button" @click="cancelForm">Cancel</button>
+            <button class="meta-automation__btn" type="button" @click="cancelForm">{{ l('editor.cancel') }}</button>
           </div>
         </section>
 
@@ -599,7 +599,7 @@
             data-automation-new-rule="advanced"
             @click="openRuleEditor()"
           >
-            + New Automation
+            {{ l('manager.newAutomation') }}
           </button>
           <button
             class="meta-automation__btn meta-automation__btn-add"
@@ -607,14 +607,14 @@
             data-automation-new-rule="quick"
             @click="openCreateForm"
           >
-            Quick legacy form
+            {{ l('manager.quickLegacyForm') }}
           </button>
         </div>
 
         <!-- Rule list -->
-        <div v-if="loading" class="meta-automation__empty">Loading automations&#x2026;</div>
+        <div v-if="loading" class="meta-automation__empty">{{ l('manager.loading') }}</div>
         <div v-else-if="!rules.length && !showForm" class="meta-automation__empty" data-automation-empty="true">
-          No automations yet. Create your first automation rule.
+          {{ l('manager.empty') }}
         </div>
         <div
           v-for="rule in rules"
@@ -631,7 +631,7 @@
                 data-automation-toggle="true"
                 @change="onToggle(rule)"
               />
-              <span>{{ rule.enabled ? 'Enabled' : 'Disabled' }}</span>
+              <span>{{ rule.enabled ? l('manager.enabled') : l('manager.disabled') }}</span>
             </label>
           </div>
           <div class="meta-automation__card-desc">
@@ -676,13 +676,13 @@
                 class="meta-automation__card-link-audience"
                 :data-automation-card-link-audience="link.key"
               >
-                Allowed audience: {{ link.audienceSummary }}
+                {{ allowedAudienceText(link.audienceSummary) }}
               </span>
             </div>
           </div>
           <div v-if="ruleStats[rule.id]" class="meta-automation__card-stats">
-            <span class="meta-automation__stat meta-automation__stat--success">{{ ruleStats[rule.id].success }} ok</span>
-            <span class="meta-automation__stat meta-automation__stat--failed">{{ ruleStats[rule.id].failed }} fail</span>
+            <span class="meta-automation__stat meta-automation__stat--success">{{ automationCardStats(ruleStats[rule.id].success, 'ok', isZh) }}</span>
+            <span class="meta-automation__stat meta-automation__stat--failed">{{ automationCardStats(ruleStats[rule.id].failed, 'fail', isZh) }}</span>
           </div>
           <div
             v-if="ruleTestRunStates[rule.id]"
@@ -694,8 +694,8 @@
             {{ ruleTestRunStates[rule.id].message }}
           </div>
           <div class="meta-automation__card-actions">
-            <button class="meta-automation__btn" type="button" data-automation-edit="true" @click="openRuleEditor(rule)">Edit</button>
-            <button class="meta-automation__btn" type="button" data-automation-logs="true" @click="openLogViewer(rule)">View Logs</button>
+            <button class="meta-automation__btn" type="button" data-automation-edit="true" @click="openRuleEditor(rule)">{{ l('manager.edit') }}</button>
+            <button class="meta-automation__btn" type="button" data-automation-logs="true" @click="openLogViewer(rule)">{{ l('manager.viewLogs') }}</button>
             <button
               v-if="ruleHasActionType(rule, 'send_dingtalk_group_message')"
               class="meta-automation__btn"
@@ -703,7 +703,7 @@
               :data-automation-group-deliveries="rule.id"
               @click="openGroupDeliveryViewer(rule)"
             >
-              View Deliveries
+              {{ l('manager.viewDeliveries') }}
             </button>
             <button
               v-if="ruleHasActionType(rule, 'send_dingtalk_person_message')"
@@ -712,9 +712,9 @@
               :data-automation-person-deliveries="rule.id"
               @click="openPersonDeliveryViewer(rule)"
             >
-              View Deliveries
+              {{ l('manager.viewDeliveries') }}
             </button>
-            <button class="meta-automation__btn meta-automation__btn--danger" type="button" data-automation-delete="true" @click="onDelete(rule)">Delete</button>
+            <button class="meta-automation__btn meta-automation__btn--danger" type="button" data-automation-delete="true" @click="onDelete(rule)">{{ l('manager.delete') }}</button>
           </div>
         </div>
       </div>
@@ -769,6 +769,7 @@ import type {
   MetaView,
 } from '../types'
 import { AppRouteNames } from '../../router/types'
+import { useLocale } from '../../composables/useLocale'
 import { useMultitableAutomations } from '../composables/useMultitableAutomations'
 import type { MultitableApiClient } from '../api/client'
 import MetaAutomationRuleEditor from './MetaAutomationRuleEditor.vue'
@@ -799,6 +800,21 @@ import {
   listDingTalkInternalViewLinkBlockingErrors,
   listDingTalkInternalViewLinkWarnings,
 } from '../utils/dingtalkInternalViewLinkWarnings'
+import {
+  automationActionTypeLabel,
+  automationCardActionSummary,
+  automationCardLinkLabel,
+  automationCardLinkSummary,
+  automationCardStats,
+  automationCardTriggerSummary,
+  automationLabel,
+  automationTestRunFailed,
+  automationTestRunRequestFailed,
+  automationTestRunSkipped,
+  automationTestRunSucceeded,
+  automationTriggerTypeLabel,
+  type AutomationLabelKey,
+} from '../utils/meta-automation-labels'
 
 const props = defineProps<{
   visible: boolean
@@ -814,6 +830,8 @@ const emit = defineEmits<{
 }>()
 
 const router = useRouter()
+const { isZh } = useLocale()
+const l = (key: AutomationLabelKey) => automationLabel(key, isZh.value)
 
 type AutomationTestRunState = {
   status: 'running' | 'success' | 'failed' | 'skipped'
@@ -1236,7 +1254,7 @@ function dingTalkCardLinks(rule: AutomationRule): DingTalkCardLink[] {
         seen.add(key)
         links.push({
           key,
-          label: `Open public form: ${viewSummaryName(publicFormViewId, publicFormViewId)}`,
+          label: automationCardLinkLabel('publicForm', viewSummaryName(publicFormViewId, publicFormViewId), isZh.value),
           href: buildPublicFormHref(publicFormViewId, publicToken),
           accessSummary: accessState.summary,
           audienceSummary: accessState.audienceSummary,
@@ -1254,7 +1272,7 @@ function dingTalkCardLinks(rule: AutomationRule): DingTalkCardLink[] {
         seen.add(key)
         links.push({
           key,
-          label: `Open internal view: ${viewSummaryName(internalViewId, internalViewId)}`,
+          label: automationCardLinkLabel('internalView', viewSummaryName(internalViewId, internalViewId), isZh.value),
           viewId: internalViewId,
         })
       }
@@ -1548,7 +1566,7 @@ async function onTestRule(ruleId: string) {
   } catch (err: unknown) {
     setRuleTestRunState(ruleId, {
       status: 'failed',
-      message: `Test run request failed: ${readErrorMessage(err)}`,
+      message: automationTestRunRequestFailed(readErrorMessage(err), isZh.value),
     })
   }
 }
@@ -1558,13 +1576,13 @@ function setRuleTestRunState(ruleId: string, state: AutomationTestRunState) {
 }
 
 function readErrorMessage(err: unknown): string {
-  return err instanceof Error && err.message.trim() ? err.message : 'Unknown error'
+  return err instanceof Error && err.message.trim() ? err.message : ''
 }
 
 function testRunPendingMessage(ruleId: string): string {
   return hasDingTalkRuleActions(rules.value.find((rule) => rule.id === ruleId))
-    ? 'Running test. DingTalk actions may send real messages.'
-    : 'Running test.'
+    ? l('manager.testRunningDingTalkWarning')
+    : l('manager.testRunning')
 }
 
 function hasDingTalkRuleActions(rule: AutomationRule | undefined): boolean {
@@ -1583,18 +1601,18 @@ function describeTestRunExecution(execution: AutomationExecution): AutomationTes
   if (execution.status === 'failed' || failedStep) {
     return {
       status: 'failed',
-      message: `Test run failed: ${execution.error || failedStep?.error || 'At least one action failed.'}`,
+      message: automationTestRunFailed(execution.error || failedStep?.error || '', isZh.value),
     }
   }
   if (execution.status === 'skipped') {
     return {
       status: 'skipped',
-      message: `Test run skipped${duration}.`,
+      message: automationTestRunSkipped(duration, isZh.value),
     }
   }
   return {
     status: 'success',
-    message: `Test run succeeded${duration}.`,
+    message: automationTestRunSucceeded(duration, isZh.value),
   }
 }
 
@@ -1808,12 +1826,12 @@ function fieldNameById(fieldId: string): string {
 function describeTrigger(rule: AutomationRule): string {
   switch (rule.triggerType) {
     case 'record.created':
-      return 'When a record is created'
+      return automationCardTriggerSummary(rule.triggerType, '', isZh.value)
     case 'record.updated':
-      return 'When a record is updated'
+      return automationCardTriggerSummary(rule.triggerType, '', isZh.value)
     case 'field.changed': {
       const fid = rule.triggerConfig?.fieldId as string | undefined
-      return fid ? `When "${fieldNameById(fid)}" changes` : 'When a field changes'
+      return automationCardTriggerSummary(rule.triggerType, fid ? fieldNameById(fid) : '', isZh.value)
     }
     default:
       return String(rule.triggerType)
@@ -1831,23 +1849,19 @@ function describeActionType(actionType: AutomationActionType, actionConfig: Reco
   switch (actionType) {
     case 'notify':
     case 'send_notification':
-      return 'Send notification'
+      return automationCardActionSummary(actionType, '', isZh.value)
     case 'update_field': {
       const fid = actionConfig?.fieldId as string | undefined
-      return fid ? `Update "${fieldNameById(fid)}"` : 'Update field value'
+      return automationCardActionSummary(actionType, fid ? fieldNameById(fid) : '', isZh.value)
     }
     case 'update_record':
-      return 'Update record'
     case 'create_record':
-      return 'Create record'
     case 'send_webhook':
-      return 'Send webhook'
-    case 'send_dingtalk_group_message':
-      return `Send DingTalk group message${describeDingTalkActionLinks(actionConfig)}`
-    case 'send_dingtalk_person_message':
-      return `Send DingTalk person message${describeDingTalkActionLinks(actionConfig)}`
     case 'lock_record':
-      return 'Lock record'
+      return automationCardActionSummary(actionType, '', isZh.value)
+    case 'send_dingtalk_group_message':
+    case 'send_dingtalk_person_message':
+      return `${automationCardActionSummary(actionType, '', isZh.value)}${describeDingTalkActionLinks(actionConfig)}`
     default:
       return String(actionType)
   }
@@ -1861,10 +1875,14 @@ function describeDingTalkActionLinks(actionConfig: Record<string, unknown>): str
     ? actionConfig.internalViewId.trim()
     : ''
   const parts = [
-    publicFormViewId ? `Public form: ${viewSummaryName(publicFormViewId, publicFormViewId)}` : '',
-    internalViewId ? `Internal processing: ${viewSummaryName(internalViewId, internalViewId)}` : '',
+    publicFormViewId ? automationCardLinkSummary('publicForm', viewSummaryName(publicFormViewId, publicFormViewId), isZh.value) : '',
+    internalViewId ? automationCardLinkSummary('internalView', viewSummaryName(internalViewId, internalViewId), isZh.value) : '',
   ].filter(Boolean)
   return parts.length ? ` · ${parts.join(' · ')}` : ''
+}
+
+function allowedAudienceText(summary: string): string {
+  return `${l('manager.allowedAudiencePrefix')}${isZh.value ? '' : ' '}${summary}`
 }
 
 function ruleHasActionType(rule: AutomationRule, actionType: AutomationActionType): boolean {

--- a/apps/web/src/multitable/composables/useMultitableAutomations.ts
+++ b/apps/web/src/multitable/composables/useMultitableAutomations.ts
@@ -1,12 +1,19 @@
 import { ref } from 'vue'
 import type { AutomationRule } from '../types'
 import { MultitableApiClient, multitableClient } from '../api/client'
+import { useLocale } from '../../composables/useLocale'
+import { automationLabel } from '../utils/meta-automation-labels'
 
 export function useMultitableAutomations(client?: MultitableApiClient) {
   const api = client ?? multitableClient
+  const { isZh } = useLocale()
   const rules = ref<AutomationRule[]>([])
   const loading = ref(false)
   const error = ref<string | null>(null)
+
+  function errorMessage(e: any, fallbackKey: Parameters<typeof automationLabel>[0]): string {
+    return e?.message ?? automationLabel(fallbackKey, isZh.value)
+  }
 
   async function loadRules(sheetId: string): Promise<void> {
     loading.value = true
@@ -14,7 +21,7 @@ export function useMultitableAutomations(client?: MultitableApiClient) {
     try {
       rules.value = await api.listAutomationRules(sheetId)
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to load automation rules'
+      error.value = errorMessage(e, 'error.loadRules')
     } finally {
       loading.value = false
     }
@@ -29,7 +36,7 @@ export function useMultitableAutomations(client?: MultitableApiClient) {
       const created = await api.createAutomationRule(sheetId, rule)
       rules.value = [created, ...rules.value]
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to create automation rule'
+      error.value = errorMessage(e, 'error.createRule')
       throw e
     }
   }
@@ -43,7 +50,7 @@ export function useMultitableAutomations(client?: MultitableApiClient) {
         rules.value[idx] = { ...rules.value[idx], ...updates }
       }
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to update automation rule'
+      error.value = errorMessage(e, 'error.updateRule')
       throw e
     }
   }
@@ -54,7 +61,7 @@ export function useMultitableAutomations(client?: MultitableApiClient) {
       await api.deleteAutomationRule(sheetId, ruleId)
       rules.value = rules.value.filter((r) => r.id !== ruleId)
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to delete automation rule'
+      error.value = errorMessage(e, 'error.deleteRule')
       throw e
     }
   }

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -33,6 +33,9 @@ export type AutomationCronPresetValue =
   | '0 0 * * 1'
   | 'custom'
 
+export type AutomationCardLinkVariant = 'publicForm' | 'internalView'
+export type AutomationCardStatType = 'ok' | 'fail'
+
 export type AutomationLabelKey =
   | 'log.title'
   | 'log.total'
@@ -113,8 +116,40 @@ export type AutomationLabelKey =
   | 'testRun.unsavedHint'
   | 'testRun.button'
   | 'testRun.running'
+  | 'manager.title'
+  | 'manager.quickEditTitle'
+  | 'manager.quickNewTitle'
+  | 'manager.action'
+  | 'manager.targetField'
+  | 'manager.newValuePlaceholder'
+  | 'manager.update'
+  | 'manager.create'
+  | 'manager.newAutomation'
+  | 'manager.quickLegacyForm'
+  | 'manager.loading'
+  | 'manager.empty'
+  | 'manager.enabled'
+  | 'manager.disabled'
+  | 'manager.allowedAudiencePrefix'
+  | 'manager.statOk'
+  | 'manager.statFail'
+  | 'manager.edit'
+  | 'manager.viewLogs'
+  | 'manager.viewDeliveries'
+  | 'manager.delete'
+  | 'manager.cardPublicForm'
+  | 'manager.cardInternalProcessing'
+  | 'manager.cardOpenPublicForm'
+  | 'manager.cardOpenInternalView'
+  | 'manager.testRunning'
+  | 'manager.testRunningDingTalkWarning'
+  | 'manager.testRunAtLeastOneActionFailed'
   | 'error.loadGroupDeliveries'
   | 'error.loadPersonDeliveries'
+  | 'error.loadRules'
+  | 'error.createRule'
+  | 'error.updateRule'
+  | 'error.deleteRule'
   | 'error.saveFailed'
   | 'error.unknown'
   | 'status.all'
@@ -203,8 +238,40 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'testRun.unsavedHint',
   'testRun.button',
   'testRun.running',
+  'manager.title',
+  'manager.quickEditTitle',
+  'manager.quickNewTitle',
+  'manager.action',
+  'manager.targetField',
+  'manager.newValuePlaceholder',
+  'manager.update',
+  'manager.create',
+  'manager.newAutomation',
+  'manager.quickLegacyForm',
+  'manager.loading',
+  'manager.empty',
+  'manager.enabled',
+  'manager.disabled',
+  'manager.allowedAudiencePrefix',
+  'manager.statOk',
+  'manager.statFail',
+  'manager.edit',
+  'manager.viewLogs',
+  'manager.viewDeliveries',
+  'manager.delete',
+  'manager.cardPublicForm',
+  'manager.cardInternalProcessing',
+  'manager.cardOpenPublicForm',
+  'manager.cardOpenInternalView',
+  'manager.testRunning',
+  'manager.testRunningDingTalkWarning',
+  'manager.testRunAtLeastOneActionFailed',
   'error.loadGroupDeliveries',
   'error.loadPersonDeliveries',
+  'error.loadRules',
+  'error.createRule',
+  'error.updateRule',
+  'error.deleteRule',
   'error.saveFailed',
   'error.unknown',
   'status.all',
@@ -294,8 +361,40 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'testRun.unsavedHint': { en: 'Save this automation before running a test.', zh: '请先保存此自动化，再运行测试。' },
   'testRun.button': { en: 'Test Run', zh: '测试运行' },
   'testRun.running': { en: 'Running...', zh: '正在运行...' },
+  'manager.title': { en: 'Automations', zh: '自动化' },
+  'manager.quickEditTitle': { en: 'Edit Automation', zh: '编辑自动化' },
+  'manager.quickNewTitle': { en: 'New Automation', zh: '新建自动化' },
+  'manager.action': { en: 'Action', zh: '动作' },
+  'manager.targetField': { en: 'Target field', zh: '目标字段' },
+  'manager.newValuePlaceholder': { en: 'New value', zh: '新值' },
+  'manager.update': { en: 'Update', zh: '更新' },
+  'manager.create': { en: 'Create', zh: '创建' },
+  'manager.newAutomation': { en: '+ New Automation', zh: '+ 新建自动化' },
+  'manager.quickLegacyForm': { en: 'Quick legacy form', zh: '快速旧版表单' },
+  'manager.loading': { en: 'Loading automations...', zh: '正在加载自动化...' },
+  'manager.empty': { en: 'No automations yet. Create your first automation rule.', zh: '暂无自动化。创建第一条自动化规则。' },
+  'manager.enabled': { en: 'Enabled', zh: '已启用' },
+  'manager.disabled': { en: 'Disabled', zh: '已停用' },
+  'manager.allowedAudiencePrefix': { en: 'Allowed audience:', zh: '允许范围：' },
+  'manager.statOk': { en: 'ok', zh: '成功' },
+  'manager.statFail': { en: 'fail', zh: '失败' },
+  'manager.edit': { en: 'Edit', zh: '编辑' },
+  'manager.viewLogs': { en: 'View Logs', zh: '查看日志' },
+  'manager.viewDeliveries': { en: 'View Deliveries', zh: '查看投递记录' },
+  'manager.delete': { en: 'Delete', zh: '删除' },
+  'manager.cardPublicForm': { en: 'Public form', zh: '公开表单' },
+  'manager.cardInternalProcessing': { en: 'Internal processing', zh: '内部处理' },
+  'manager.cardOpenPublicForm': { en: 'Open public form', zh: '打开公开表单' },
+  'manager.cardOpenInternalView': { en: 'Open internal view', zh: '打开内部处理视图' },
+  'manager.testRunning': { en: 'Running test.', zh: '正在运行测试。' },
+  'manager.testRunningDingTalkWarning': { en: 'Running test. DingTalk actions may send real messages.', zh: '正在运行测试。钉钉动作可能发送真实消息。' },
+  'manager.testRunAtLeastOneActionFailed': { en: 'At least one action failed.', zh: '至少一个动作失败。' },
   'error.loadGroupDeliveries': { en: 'Failed to load DingTalk group deliveries.', zh: '加载钉钉群投递记录失败。' },
   'error.loadPersonDeliveries': { en: 'Failed to load DingTalk person deliveries.', zh: '加载钉钉个人投递记录失败。' },
+  'error.loadRules': { en: 'Failed to load automation rules', zh: '加载自动化规则失败' },
+  'error.createRule': { en: 'Failed to create automation rule', zh: '创建自动化规则失败' },
+  'error.updateRule': { en: 'Failed to update automation rule', zh: '更新自动化规则失败' },
+  'error.deleteRule': { en: 'Failed to delete automation rule', zh: '删除自动化规则失败' },
   'error.saveFailed': { en: 'Save failed', zh: '保存失败' },
   'error.unknown': { en: 'Unknown error', zh: '未知错误' },
   'status.all': { en: 'All statuses', zh: '全部状态' },
@@ -434,6 +533,67 @@ export function automationConditionValuePlaceholder(widget: AutomationConditionV
   if (widget === 'date') return 'YYYY-MM-DD'
   if (widget === 'dateTime') return isZh ? '日期和时间' : 'Date and time'
   return isZh ? '值' : 'Value'
+}
+
+export function automationCardTriggerSummary(
+  triggerType: AutomationTriggerType | (string & {}),
+  fieldName: string,
+  isZh: boolean,
+): string {
+  if (triggerType === 'field.changed' || triggerType === 'field.value_changed') {
+    const rawField = fieldName.trim()
+    if (!rawField) return isZh ? '当字段变化时' : 'When a field changes'
+    return isZh ? `当“${rawField}”变化时` : `When "${rawField}" changes`
+  }
+  if (triggerType === 'record.created') return isZh ? '当记录创建时' : 'When a record is created'
+  if (triggerType === 'record.updated') return isZh ? '当记录更新时' : 'When a record is updated'
+  return automationTriggerTypeLabel(triggerType, isZh)
+}
+
+export function automationCardActionSummary(
+  actionType: AutomationActionType | (string & {}),
+  fieldName: string,
+  isZh: boolean,
+): string {
+  if (actionType === 'update_field') {
+    const rawField = fieldName.trim()
+    if (!rawField) return automationActionTypeLabel(actionType, isZh)
+    return isZh ? `更新“${rawField}”` : `Update "${rawField}"`
+  }
+  return automationActionTypeLabel(actionType, isZh)
+}
+
+export function automationCardLinkLabel(variant: AutomationCardLinkVariant, viewName: string, isZh: boolean): string {
+  const key = variant === 'publicForm' ? 'manager.cardOpenPublicForm' : 'manager.cardOpenInternalView'
+  return `${automationLabel(key, isZh)}${isZh ? '：' : ': '}${viewName}`
+}
+
+export function automationCardLinkSummary(variant: AutomationCardLinkVariant, viewName: string, isZh: boolean): string {
+  const key = variant === 'publicForm' ? 'manager.cardPublicForm' : 'manager.cardInternalProcessing'
+  return `${automationLabel(key, isZh)}${isZh ? '：' : ': '}${viewName}`
+}
+
+export function automationCardStats(count: number, status: AutomationCardStatType, isZh: boolean): string {
+  const key = status === 'ok' ? 'manager.statOk' : 'manager.statFail'
+  return `${count} ${automationLabel(key, isZh)}`
+}
+
+export function automationTestRunRequestFailed(message: string, isZh: boolean): string {
+  const detail = message.trim() || automationLabel('error.unknown', isZh)
+  return isZh ? `测试运行请求失败：${detail}` : `Test run request failed: ${detail}`
+}
+
+export function automationTestRunFailed(raw: string, isZh: boolean): string {
+  const detail = raw.trim() || automationLabel('manager.testRunAtLeastOneActionFailed', isZh)
+  return isZh ? `测试运行失败：${detail}` : `Test run failed: ${detail}`
+}
+
+export function automationTestRunSkipped(duration: string, isZh: boolean): string {
+  return isZh ? `测试运行已跳过${duration}。` : `Test run skipped${duration}.`
+}
+
+export function automationTestRunSucceeded(duration: string, isZh: boolean): string {
+  return isZh ? `测试运行成功${duration}。` : `Test run succeeded${duration}.`
 }
 
 export function supportCopyFailed(message: string, isZh: boolean): string {

--- a/apps/web/tests/meta-automation-labels.spec.ts
+++ b/apps/web/tests/meta-automation-labels.spec.ts
@@ -3,11 +3,20 @@ import { describe, expect, it } from 'vitest'
 import {
   AUTOMATION_LABEL_KEYS,
   automationActionTypeLabel,
+  automationCardActionSummary,
+  automationCardLinkLabel,
+  automationCardLinkSummary,
+  automationCardStats,
+  automationCardTriggerSummary,
   automationConditionOperatorLabel,
   automationConditionValuePlaceholder,
   automationCronPresetLabel,
   automationLabel,
   automationStatusLabel,
+  automationTestRunFailed,
+  automationTestRunRequestFailed,
+  automationTestRunSkipped,
+  automationTestRunSucceeded,
   automationTriggerConditionLabel,
   automationTriggerTypeLabel,
   supportCopyFailed,
@@ -93,5 +102,43 @@ describe('meta-automation-labels', () => {
     expect(supportCopyFailed('Network down', true)).toBe('复制失败：Network down')
     expect(supportDownloadFailed('Disk full', false)).toBe('Download failed: Disk full')
     expect(supportDownloadFailed('Disk full', true)).toBe('下载失败：Disk full')
+  })
+
+  it('localizes manager card summaries while preserving raw field and view names', () => {
+    expect(automationCardTriggerSummary('record.created', '', false)).toBe('When a record is created')
+    expect(automationCardTriggerSummary('record.updated', '', true)).toBe('当记录更新时')
+    expect(automationCardTriggerSummary('field.changed', '状态', false)).toBe('When "状态" changes')
+    expect(automationCardTriggerSummary('field.changed', 'Status', true)).toBe('当“Status”变化时')
+    expect(automationCardTriggerSummary('future.trigger', '', true)).toBe('future.trigger')
+
+    expect(automationCardActionSummary('notify', '', true)).toBe('发送通知')
+    expect(automationCardActionSummary('update_field', '状态', false)).toBe('Update "状态"')
+    expect(automationCardActionSummary('update_field', 'Status', true)).toBe('更新“Status”')
+    expect(automationCardActionSummary('future_action', '', true)).toBe('future_action')
+
+    expect(automationCardLinkLabel('publicForm', '我的视图', false)).toBe('Open public form: 我的视图')
+    expect(automationCardLinkLabel('internalView', 'Grid', true)).toBe('打开内部处理视图：Grid')
+    expect(automationCardLinkSummary('publicForm', '我的视图', false)).toBe('Public form: 我的视图')
+    expect(automationCardLinkSummary('internalView', 'Grid', true)).toBe('内部处理：Grid')
+
+    expect(automationCardStats(1, 'ok', false)).toBe('1 ok')
+    expect(automationCardStats(3, 'fail', true)).toBe('3 失败')
+  })
+
+  it('localizes manager test-run messages with raw details and empty fallbacks', () => {
+    expect(automationTestRunRequestFailed('Automation service unavailable', false)).toBe('Test run request failed: Automation service unavailable')
+    expect(automationTestRunRequestFailed('', false)).toBe('Test run request failed: Unknown error')
+    expect(automationTestRunRequestFailed('服务异常', true)).toBe('测试运行请求失败：服务异常')
+    expect(automationTestRunRequestFailed('', true)).toBe('测试运行请求失败：未知错误')
+
+    expect(automationTestRunFailed('DingTalk robot keyword blocked', false)).toBe('Test run failed: DingTalk robot keyword blocked')
+    expect(automationTestRunFailed('', false)).toBe('Test run failed: At least one action failed.')
+    expect(automationTestRunFailed('钉钉机器人关键字拦截', true)).toBe('测试运行失败：钉钉机器人关键字拦截')
+    expect(automationTestRunFailed('', true)).toBe('测试运行失败：至少一个动作失败。')
+
+    expect(automationTestRunSucceeded(' (32 ms)', false)).toBe('Test run succeeded (32 ms).')
+    expect(automationTestRunSucceeded('', true)).toBe('测试运行成功。')
+    expect(automationTestRunSkipped(' (4 ms)', false)).toBe('Test run skipped (4 ms).')
+    expect(automationTestRunSkipped('', true)).toBe('测试运行已跳过。')
   })
 })

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -14,6 +14,7 @@ function flushPromises() {
 }
 import MetaAutomationManager from '../src/multitable/components/MetaAutomationManager.vue'
 import { MultitableApiClient } from '../src/multitable/api/client'
+import { useLocale } from '../src/composables/useLocale'
 import { AppRouteNames } from '../src/router/types'
 import type { AutomationRule, DingTalkGroupDelivery, DingTalkPersonDelivery } from '../src/multitable/types'
 
@@ -38,6 +39,7 @@ function mockClient(
     testErrorMessage?: string
     groupDeliveryErrorMessage?: string
     personDeliveryErrorMessage?: string
+    rulesErrorMessage?: string | null
     stats?: Record<string, unknown>
     dingTalkGroups?: Array<Record<string, unknown>>
   } = {},
@@ -144,6 +146,12 @@ function mockClient(
       }
       if (url.endsWith('/stats')) {
         return ok(options.stats ?? { total: 1, success: 1, failed: 0, skipped: 0, avgDuration: 32 })
+      }
+      if (options.rulesErrorMessage !== undefined) {
+        if (options.rulesErrorMessage === null) {
+          return new Response(JSON.stringify({}), { status: 500, headers: { 'Content-Type': 'application/json' } })
+        }
+        return apiError(options.rulesErrorMessage)
       }
       return ok({ rules })
     }
@@ -287,6 +295,7 @@ describe('MetaAutomationManager', () => {
   const originalClipboard = navigator.clipboard
 
   beforeEach(() => {
+    useLocale().setLocale('en')
     routerPushMock.mockClear()
     Object.defineProperty(navigator, 'clipboard', {
       configurable: true,
@@ -297,6 +306,7 @@ describe('MetaAutomationManager', () => {
   })
 
   afterEach(() => {
+    useLocale().setLocale('en')
     document.body.innerHTML = ''
     vi.restoreAllMocks()
     Object.defineProperty(navigator, 'clipboard', {
@@ -314,6 +324,127 @@ describe('MetaAutomationManager', () => {
     expect(cards.length).toBe(1)
     expect(container.querySelector('.meta-automation__card-name')?.textContent).toBe('Notify on create')
     expect(container.querySelector('.meta-automation__card-desc')?.textContent).toContain('Send notification')
+  })
+
+  it('localizes zh-CN manager card chrome while preserving raw rule data and selectors', async () => {
+    useLocale().setLocale('zh-CN')
+    const { client } = mockClient([
+      fakeRule({
+        name: 'Raw 规则名',
+        triggerType: 'field.changed',
+        triggerConfig: { fieldId: 'fld_1' },
+        actionType: 'update_field',
+        actionConfig: { fieldId: 'fld_2', value: 'Done' },
+        enabled: false,
+      }),
+    ], { stats: { total: 4, success: 1, failed: 3, skipped: 0, avgDuration: 32 } })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+    await flushPromises()
+
+    const card = container.querySelector('[data-automation-rule="rule_1"]') as HTMLElement
+    expect(container.querySelector('.meta-automation__title')?.textContent).toBe('自动化')
+    expect(card).not.toBeNull()
+    expect(card.getAttribute('data-automation-rule')).toBe('rule_1')
+    expect(card.querySelector('.meta-automation__card-name')?.textContent).toBe('Raw 规则名')
+    expect(card.querySelector('.meta-automation__card-desc')?.textContent).toContain('当“Status”变化时 → 更新“Name”')
+    expect(card.querySelector('.meta-automation__toggle')?.textContent).toContain('已停用')
+    expect(card.querySelector('.meta-automation__stat--success')?.textContent).toBe('1 成功')
+    expect(card.querySelector('.meta-automation__stat--failed')?.textContent).toBe('3 失败')
+    expect(card.querySelector('[data-automation-edit="true"]')?.textContent).toContain('编辑')
+    expect(card.querySelector('[data-automation-delete="true"]')?.textContent).toContain('删除')
+  })
+
+  it('localizes zh-CN quick legacy form chrome without translating raw data attributes', async () => {
+    useLocale().setLocale('zh-CN')
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('[data-automation-new-rule="quick"]') as HTMLButtonElement
+    expect(addBtn.textContent).toContain('快速旧版表单')
+    addBtn.click()
+    await nextTick()
+
+    const nameInput = container.querySelector('[data-automation-field="name"]') as HTMLInputElement
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    expect(container.querySelector('.meta-automation__form-title')?.textContent).toContain('新建自动化')
+    expect(nameInput.placeholder).toBe('自动化名称')
+    expect(actionSelect.value).toBe('notify')
+    expect(Array.from(actionSelect.options).map((option) => option.value)).toEqual([
+      'notify',
+      'update_field',
+      'send_dingtalk_group_message',
+      'send_dingtalk_person_message',
+    ])
+    expect(actionSelect.textContent).toContain('发送通知')
+    expect((container.querySelector('[data-automation-field="notifyMessage"]') as HTMLInputElement).placeholder).toBe('通知内容')
+    expect(container.querySelectorAll('[aria-label]')).toHaveLength(0)
+    expect(container.querySelectorAll('[title]')).toHaveLength(0)
+    expect(container.querySelectorAll('[placeholder]')).toHaveLength(2)
+
+    actionSelect.value = 'update_field'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    const targetField = container.querySelector('[data-automation-field="targetFieldId"]') as HTMLSelectElement
+    const targetValue = container.querySelector('[data-automation-field="targetValue"]') as HTMLInputElement
+    expect(targetField.value).toBe('')
+    expect(targetValue.placeholder).toBe('新值')
+    expect(container.querySelector('.meta-automation__btn--primary')?.textContent).toContain('创建')
+    expect(container.querySelectorAll('[placeholder]')).toHaveLength(2)
+  })
+
+  it('localizes zh-CN card-level DingTalk links and preserves raw access summaries', async () => {
+    useLocale().setLocale('zh-CN')
+    const zhViews = [
+      { id: 'view_grid', sheetId: 'sheet_1', name: '内部视图', type: 'grid' },
+      {
+        id: 'view_form',
+        sheetId: 'sheet_1',
+        name: '我的视图',
+        type: 'form',
+        config: { publicForm: { enabled: true, publicToken: 'pub_view_form' } },
+      },
+    ]
+    const { client } = mockClient([
+      fakeRule({
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationId: 'dt_1',
+          publicFormViewId: 'view_form',
+          internalViewId: 'view_grid',
+        },
+      }),
+    ])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views: zhViews, client })
+    await flushPromises()
+
+    const desc = container.querySelector('[data-automation-rule="rule_1"] .meta-automation__card-desc')
+    expect(desc?.textContent).toContain('公开表单：我的视图')
+    expect(desc?.textContent).toContain('内部处理：内部视图')
+    expect(container.querySelector('[data-automation-card-link="public-form:view_form"]')?.textContent)
+      .toContain('打开公开表单：我的视图')
+    expect(container.querySelector('[data-automation-card-link="internal-view:view_grid"]')?.textContent)
+      .toContain('打开内部处理视图：内部视图')
+    expect(container.querySelector('[data-automation-card-link-audience="public-form:view_form"]')?.textContent)
+      .toContain('允许范围：Anyone with the link can submit')
+    expect(container.querySelector('[data-automation-card-link-access="public-form:view_form"]')?.getAttribute('data-access-level'))
+      .toBe('public')
+  })
+
+  it('localizes zh-CN frontend fallback errors from the automation composable at event time', async () => {
+    useLocale().setLocale('zh-CN')
+    const client = {
+      listDingTalkGroups: vi.fn(async () => []),
+      listAutomationRules: vi.fn(async () => {
+        throw {}
+      }),
+    } as unknown as MultitableApiClient
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    expect(container.querySelector('.meta-automation__error')?.textContent).toBe('加载自动化规则失败')
   })
 
   it('describes V1 multi-action DingTalk group rules in the list', async () => {
@@ -2350,6 +2481,83 @@ describe('MetaAutomationManager', () => {
     expect(container.querySelector('[data-field="testRunStatus"]')?.textContent).toContain('Test run succeeded (32 ms)')
     expect(container.querySelector('[data-automation-test-status="rule_1"]')?.textContent).toContain('Test run succeeded (32 ms)')
     expect(fetchFn.mock.calls.filter(([url]) => String(url).endsWith('/stats')).length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('localizes zh-CN automation test run messages while preserving raw durations and backend errors', async () => {
+    useLocale().setLocale('zh-CN')
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    let resolveExecution!: (value: Record<string, unknown>) => void
+    const testExecution = new Promise<Record<string, unknown>>((resolve) => {
+      resolveExecution = resolve
+    })
+    const { client } = mockClient([
+      fakeRule({
+        name: 'DingTalk group notify',
+        actionType: 'send_dingtalk_group_message',
+        actionConfig: {
+          destinationId: 'dt_1',
+          titleTemplate: 'Ticket {{recordId}}',
+          bodyTemplate: 'Please fill {{record.status}}',
+        },
+        actions: [{
+          type: 'send_dingtalk_group_message',
+          config: { destinationId: 'dt_1', titleTemplate: 'Ticket {{recordId}}', bodyTemplate: 'Please fill' },
+        }],
+      }),
+    ], { testExecution })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    ;(container.querySelector('[data-automation-edit="true"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const testBtn = container.querySelector('[data-action="test"]') as HTMLButtonElement
+    expect(testBtn.disabled).toBe(false)
+    expect(container.textContent).toContain('可能向已配置的钉钉群或用户发送真实消息')
+
+    testBtn.click()
+    await nextTick()
+
+    expect(container.querySelector('[data-field="testRunStatus"]')?.textContent)
+      .toContain('正在运行测试。钉钉动作可能发送真实消息。')
+
+    resolveExecution({
+      id: 'exec_1',
+      ruleId: 'rule_1',
+      status: 'success',
+      triggeredBy: 'test',
+      triggeredAt: '2026-04-21T00:00:00.000Z',
+      duration: 32,
+      steps: [],
+    })
+    await flushPromises()
+
+    expect(container.querySelector('[data-field="testRunStatus"]')?.textContent).toContain('测试运行成功 (32 ms)。')
+    expect(container.querySelector('[data-automation-test-status="rule_1"]')?.textContent).toContain('测试运行成功 (32 ms)。')
+  })
+
+  it('localizes zh-CN automation test run request failures with raw backend messages', async () => {
+    useLocale().setLocale('zh-CN')
+    vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const { client } = mockClient([
+      fakeRule({
+        name: 'DingTalk person notify',
+        actionType: 'send_dingtalk_person_message',
+        actionConfig: { userIds: ['user_1'], titleTemplate: 'Ticket {{recordId}}', bodyTemplate: 'Please fill' },
+        actions: [{ type: 'send_dingtalk_person_message', config: { userIds: ['user_1'] } }],
+      }),
+    ], { testErrorMessage: 'Automation service unavailable' })
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    ;(container.querySelector('[data-automation-edit="true"]') as HTMLButtonElement).click()
+    await flushPromises()
+    ;(container.querySelector('[data-action="test"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(container.querySelector('[data-field="testRunStatus"]')?.textContent)
+      .toContain('测试运行请求失败：Automation service unavailable')
+    expect(container.querySelector('[data-field="testRunStatus"]')?.getAttribute('data-status')).toBe('failed')
   })
 
   it('uses a generic running message for non-DingTalk automation tests', async () => {

--- a/docs/development/multitable-t3d3-automation-manager-i18n-design-20260521.md
+++ b/docs/development/multitable-t3d3-automation-manager-i18n-design-20260521.md
@@ -1,0 +1,414 @@
+# T3D-3 Automation Manager i18n Design
+
+Date: 2026-05-21
+
+Branch: `docs/multitable-t3d3-automation-manager-i18n-design-20260521`
+
+Base: `origin/main@71e8eef1b`
+
+## 1. Decision Summary
+
+T3D-3 is the third PR in the 4-PR T3D automation i18n chain.
+
+| Decision | Outcome |
+| --- | --- |
+| Module | Continue extending `apps/web/src/multitable/utils/meta-automation-labels.ts`; no new module. |
+| Primary component | `apps/web/src/multitable/components/MetaAutomationManager.vue` only. |
+| Composable | `apps/web/src/multitable/composables/useMultitableAutomations.ts` static frontend fallback errors are in scope. |
+| Scope | Manager shell, rule cards, card-level DingTalk summaries/links, legacy quick form core chrome, test-run card messages, and manager-owned fallback errors. |
+| Defer | Deep DingTalk configuration panels, token/preset/warning helpers, preview labels, shared DingTalk link access-summary helpers, and zh-only placeholders stay T3D-4. |
+| Tests | Extend `meta-automation-labels.spec.ts` and `multitable-automation-manager.spec.ts`; do not create a new manager harness. |
+
+This preserves the parent T3D split:
+
+- T3D-1: log + delivery viewers shipped.
+- T3D-2: rule editor core shipped.
+- T3D-3: manager shell/cards/quick form.
+- T3D-4: DingTalk automation shared chrome across manager + rule editor.
+
+## 2. Scout Snapshot
+
+Real source:
+
+| File | Lines | Role |
+| --- | ---: | --- |
+| `MetaAutomationManager.vue` | 2,283 | Manager dialog, legacy quick form, rule cards, DingTalk card links, test-run card status. |
+| `useMultitableAutomations.ts` | 67 | Manager-only CRUD composable with static frontend fallbacks. |
+| `multitable-automation-manager.spec.ts` | 2,841 | Existing heavy manager behavior spec; extend this rather than add a new mount harness. |
+| `meta-automation-labels.ts` | 445 | T3D shared label module after T3D-1/T3D-2. |
+
+Source attribute counts in `MetaAutomationManager.vue`:
+
+| Attribute | Source count | T3D-3 rule |
+| --- | ---: | --- |
+| `aria-label=` | 0 | Spec sentinel must keep fixture count at 0. |
+| `title=` | 0 | Spec sentinel must keep fixture count at 0. |
+| `placeholder=` | 13 | T3D-3 localizes only in-scope quick-form placeholders; T3D-4 owns DingTalk placeholder cleanup. |
+| `data-*` / `:data-*` | 96 | Values are raw selectors and must not bind localized display text. |
+| `:class` | 4 | Raw enum/state suffixes stay raw. |
+
+## 3. Files In Scope
+
+Implementation files:
+
+| File | Change |
+| --- | --- |
+| `apps/web/src/multitable/utils/meta-automation-labels.ts` | Add manager keys and helpers; reuse T3D-1/T3D-2 helpers. |
+| `apps/web/src/multitable/components/MetaAutomationManager.vue` | Wire manager shell/card/quick-form/test-run chrome. |
+| `apps/web/src/multitable/composables/useMultitableAutomations.ts` | Localize static frontend fallback errors; keep backend `e.message` raw. |
+
+Test files:
+
+| File | Change |
+| --- | --- |
+| `apps/web/tests/meta-automation-labels.spec.ts` | Add manager helper coverage, ALL_KEYS lockstep, raw fallback checks. |
+| `apps/web/tests/multitable-automation-manager.spec.ts` | Add zh/en manager render assertions, raw selector checks, a11y sentinels. |
+
+Docs:
+
+| File | Change |
+| --- | --- |
+| `docs/development/multitable-t3d3-automation-manager-i18n-design-20260521.md` | This design. |
+| `docs/development/multitable-t3d3-automation-manager-i18n-verification-20260521.md` | Implementation evidence. |
+
+Out of scope:
+
+| Surface | Reason |
+| --- | --- |
+| `MetaAutomationRuleEditor.vue` | T3D-2 core shipped; DingTalk panels remain T3D-4. |
+| `dingtalk*.ts` helper utilities | T3D-4 owns shared token/warning/access copy. |
+| Deep DingTalk config branches inside `MetaAutomationManager.vue` | T3D-4 spans manager + rule editor and will handle shared DingTalk copy consistently. |
+| Existing zh-only DingTalk placeholders | T3D-4 converts them to bilingual helpers. |
+| Backend, contracts, migrations, attendance, K3 | K3 PoC stage-1 lock; this is frontend i18n only. |
+
+## 4. Exact Chrome Targets
+
+### 4.1 Manager Shell And Legacy Quick Form Core
+
+These are in scope and should be wired through `automationLabel(...)` or existing T3D-2 helpers.
+
+| Source | Current EN | Target zh | Key/helper |
+| --- | --- | --- | --- |
+| L5 | `Automations` | `自动化` | `manager.title` |
+| L14 | `Edit Automation` | `编辑自动化` | `manager.quickEditTitle` |
+| L14 | `New Automation` | `新建自动化` | `manager.quickNewTitle` |
+| L16 | `Name` | `名称` | reuse `editor.name` |
+| L21 | `Automation name` | `自动化名称` | reuse `editor.namePlaceholder` |
+| L25 | `Trigger` | `触发器` | reuse `trigger.title` |
+| L27-L29 | trigger options | existing zh trigger labels | reuse `automationTriggerTypeLabel(...)` |
+| L33 | `Watch field` | `监听字段` | reuse `trigger.watchField` |
+| L35/L62 | `-- select field --` | `-- 选择字段 --` | reuse `trigger.selectField` |
+| L40 | `Action` | `动作` | `manager.action` |
+| L42-L45 | action options | existing zh action labels | reuse `automationActionTypeLabel(...)` |
+| L49 | `Message` | `消息` | reuse `actionConfig.message` |
+| L54 | `Notification message` | `通知内容` | reuse `actionConfig.notificationMessagePlaceholder` |
+| L60 | `Target field` | `目标字段` | `manager.targetField` |
+| L65 | `Value` | `值` | reuse `editor.value` |
+| L70 | `New value` | `新值` | `manager.newValuePlaceholder` |
+| L587-L590 | `Update` / `Create` / `Cancel` | `更新` / `创建` / `取消` | `manager.update`, `manager.create`, reuse `editor.cancel` |
+| L602 | `+ New Automation` | `+ 新建自动化` | `manager.newAutomation` |
+| L610 | `Quick legacy form` | `快速旧版表单` | `manager.quickLegacyForm` |
+| L615 | `Loading automations...` | `正在加载自动化...` | `manager.loading` |
+| L617 | `No automations yet. Create your first automation rule.` | `暂无自动化。创建第一条自动化规则。` | `manager.empty` |
+
+Deep DingTalk quick-form blocks under the same legacy form are not fully localized here. T3D-3 may localize shared action select labels because `automationActionTypeLabel(...)` already owns them, but labels such as `Message preset`, `Template tokens`, `Public form view`, preview labels, token buttons, warnings, and DingTalk-specific placeholders remain T3D-4.
+
+### 4.2 Rule Cards And Card Actions
+
+| Source | Current EN | Target zh | Key/helper |
+| --- | --- | --- | --- |
+| L634 | `Enabled` / `Disabled` | `已启用` / `已停用` | `manager.enabled`, `manager.disabled` |
+| L638 | `describeTrigger(rule) -> describeAction(rule)` | localized card summary | new dynamic helpers below |
+| L679 | `Allowed audience:` | `允许范围：` | `manager.allowedAudiencePrefix` |
+| L684-L685 | `${n} ok` / `${n} fail` | `${n} 成功` / `${n} 失败` | `automationCardStats(count, status, isZh)` or `manager.statOk/Fail` |
+| L697 | `Edit` | `编辑` | `manager.edit` |
+| L698 | `View Logs` | `查看日志` | `manager.viewLogs` |
+| L706/L715 | `View Deliveries` | `查看投递记录` | `manager.viewDeliveries` |
+| L717 | `Delete` | `删除` | `manager.delete` |
+
+Card-level DingTalk display is in scope:
+
+| Source | Current EN | Target zh | Key/helper |
+| --- | --- | --- | --- |
+| L1239 | `Open public form: ${view}` | `打开公开表单：${view}` | `automationCardLinkLabel('publicForm', viewName, isZh)` |
+| L1257 | `Open internal view: ${view}` | `打开内部处理视图：${view}` | `automationCardLinkLabel('internalView', viewName, isZh)` |
+| L1864 | `Public form: ${view}` | `公开表单：${view}` | `automationCardLinkSummary('publicForm', viewName, isZh)` |
+| L1865 | `Internal processing: ${view}` | `内部处理：${view}` | `automationCardLinkSummary('internalView', viewName, isZh)` |
+| L679 | `Allowed audience: ${summary}` | `允许范围：${summary}` | prefix only; `summary` stays as returned by helper until T3D-4 |
+
+Card-level vs panel-level DingTalk boundary:
+
+- In scope: manager card labels and summaries owned directly by `MetaAutomationManager.vue`, such as `Public form:`, `Open public form:`, `Internal processing:`, `Allowed audience:`, `ok`, and `fail`.
+- Deferred: access-summary text returned by shared DingTalk helpers, warning copy, template token labels, preview labels, and the deep config panel copy. Those require shared helper changes across manager + rule editor and belong to T3D-4.
+- Link label vs summary helpers are intentionally separate: label helpers include the `Open` / `打开` action prefix for clickable controls; summary helpers use bare `X:` / `X：` text inside card descriptions.
+
+### 4.3 Dynamic Card Summary Helpers
+
+Add these helpers to `meta-automation-labels.ts`:
+
+```ts
+export function automationCardTriggerSummary(
+  triggerType: AutomationTriggerType | (string & {}),
+  fieldName: string,
+  isZh: boolean,
+): string
+
+export function automationCardActionSummary(
+  actionType: AutomationActionType | (string & {}),
+  fieldName: string,
+  isZh: boolean,
+): string
+```
+
+Additional card and test-run helper signatures:
+
+```ts
+export type AutomationCardLinkVariant = 'publicForm' | 'internalView'
+export type AutomationCardStatType = 'ok' | 'fail'
+
+export function automationCardLinkLabel(
+  variant: AutomationCardLinkVariant,
+  viewName: string,
+  isZh: boolean,
+): string
+
+export function automationCardLinkSummary(
+  variant: AutomationCardLinkVariant,
+  viewName: string,
+  isZh: boolean,
+): string
+
+export function automationCardStats(
+  count: number,
+  status: AutomationCardStatType,
+  isZh: boolean,
+): string
+
+export function automationTestRunRequestFailed(message: string, isZh: boolean): string
+export function automationTestRunFailed(raw: string, isZh: boolean): string
+export function automationTestRunSkipped(duration: string, isZh: boolean): string
+export function automationTestRunSucceeded(duration: string, isZh: boolean): string
+```
+
+`AutomationCardStatType` is deliberately not `AutomationStatus`: card stats are a 2-state delivery count (`ok` / `fail`), while execution status is `success` / `failed` / `skipped` / `running`.
+
+`automationCardLinkLabel(...)` adds the clickable-action prefix (`Open public form: ${view}` / `打开公开表单：${view}`), while `automationCardLinkSummary(...)` returns the bare description form (`Public form: ${view}` / `公开表单：${view}`).
+
+Behavior:
+
+| Current EN | Target zh | Notes |
+| --- | --- | --- |
+| `When a record is created` | `当记录创建时` | Can delegate to `automationTriggerTypeLabel('record.created', isZh)`. |
+| `When a record is updated` | `当记录更新时` | Delegate to existing trigger helper. |
+| `When "${field}" changes` | `当“${field}”变化时` | Field name is raw; do not translate. |
+| `When a field changes` | `当字段变化时` | No field ID fallback. |
+| `Send notification` | `发送通知` | Delegate to `automationActionTypeLabel('notify', isZh)`. |
+| `Update "${field}"` | `更新“${field}”` | Field name is raw; do not translate. |
+| `Update field value` | `更新字段值` | Delegate to existing action helper for `update_field`. |
+| `Update record` / `Create record` / `Send webhook` / `Lock record` | Existing zh labels | Delegate to `automationActionTypeLabel(...)`. |
+| `Send DingTalk group/person message` | Existing zh labels | Card-level label in scope; DingTalk link suffix handled separately. |
+
+Raw boundary: `fieldName` is user-defined data and must be passed through unmodified.
+
+### 4.4 Test-Run Card Messages
+
+Reuse T3D-1/T3D-2 status helpers where possible.
+
+| Source | Current EN | Target zh | Key/helper |
+| --- | --- | --- | --- |
+| L1566-L1567 | `Running test.` | `正在运行测试。` | `manager.testRunning`; may embed `automationLabel('status.running', isZh)` but should have sentence-level copy. |
+| L1566 | `Running test. DingTalk actions may send real messages.` | `正在运行测试。钉钉动作可能发送真实消息。` | `manager.testRunningDingTalkWarning` |
+| L1551 | `Test run request failed: ${message}` | `测试运行请求失败：${message}` | `automationTestRunRequestFailed(message, isZh)` |
+| L1586 | `Test run failed: ${raw}` | `测试运行失败：${raw}` | `automationTestRunFailed(raw, isZh)` |
+| L1586 fallback | `At least one action failed.` | `至少一个动作失败。` | `manager.testRunAtLeastOneActionFailed` |
+| L1592 | `Test run skipped${duration}.` | `测试运行已跳过${duration}。` | `automationTestRunSkipped(duration, isZh)` |
+| L1597 | `Test run succeeded${duration}.` | `测试运行成功${duration}。` | `automationTestRunSucceeded(duration, isZh)` |
+
+`duration` is a formatted technical value such as ` (32 ms)` and remains raw except for spacing/punctuation required by the surrounding sentence. Runtime/backend error messages remain raw.
+
+Empty raw-boundary behavior:
+
+- `automationTestRunRequestFailed(message, isZh)`: if `message.trim()` is empty, interpolate `automationLabel('error.unknown', isZh)`.
+- `automationTestRunFailed(raw, isZh)`: if `raw.trim()` is empty, return `Test run failed: At least one action failed.` / `测试运行失败：至少一个动作失败。`; otherwise interpolate raw as-is.
+- Helper spec must cover en raw, en empty, zh raw, and zh empty cases for both failure helpers.
+
+### 4.5 useMultitableAutomations Fallbacks
+
+`useMultitableAutomations.ts` is manager-domain because the manager is its only consumer.
+
+| Source | Current fallback | Target zh | Key |
+| --- | --- | --- | --- |
+| L17 | `Failed to load automation rules` | `加载自动化规则失败` | `error.loadRules` |
+| L32 | `Failed to create automation rule` | `创建自动化规则失败` | `error.createRule` |
+| L46 | `Failed to update automation rule` | `更新自动化规则失败` | `error.updateRule` |
+| L57 | `Failed to delete automation rule` | `删除自动化规则失败` | `error.deleteRule` |
+
+Implementation rule:
+
+```ts
+error.value = e instanceof Error && e.message ? e.message : automationLabel('error.loadRules', isZh.value)
+```
+
+Backend/API `e.message` wins and stays raw. The localized string is only the frontend static fallback.
+
+Locale wiring option: import `useLocale()` in the composable and read `isZh.value` at catch time. This keeps the call site stable and matches T3E-2 event-time toast semantics: already-stored errors do not retranslate after a locale toggle.
+
+Composable-level `useLocale()` is preferred over passing `isZh` through each CRUD call because the composable owns the static fallback strings and the manager is its only consumer. This is an event-time error message, not a reactive render label; stored errors do not retranslate after a later locale toggle.
+
+## 5. T3D-4 Deferred DingTalk Inventory
+
+T3D-4 owns DingTalk-specific panel/helper copy shared across manager + rule editor:
+
+- `Message preset`, `Form request`, `Internal processing`, `Form + processing`.
+- `Add DingTalk groups`, `-- add DingTalk group --`, `Record group field paths`, `Pick group field`.
+- `Search and add users or member groups`, person recipient states, inactive-user text.
+- `Template tokens`, token button labels, preview labels, copy/copied states.
+- `Public form view`, `Internal processing view`, access summary text from shared helpers.
+- Warning helpers from `dingtalk*.ts`.
+- Existing zh-only placeholders.
+
+Scout-locked Manager zh-only placeholders for T3D-4:
+
+| Source | Literal | Notes |
+| --- | --- | --- |
+| `MetaAutomationManager.vue:169` | `例如：{{record.title}} 待处理` | group title template placeholder |
+| `MetaAutomationManager.vue:197` | `支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}` | group body template placeholder; extra scout finding beyond the earlier 6-line reminder |
+| `MetaAutomationManager.vue:360` | `使用逗号或换行分隔本地 userId` | person local user IDs |
+| `MetaAutomationManager.vue:368` | `使用逗号或换行分隔成员组 ID` | person member group IDs |
+| `MetaAutomationManager.vue:376` | `例如：record.assigneeUserIds, record.reviewerUserId` | person recipient field path |
+| `MetaAutomationManager.vue:421` | `例如：record.watcherGroupIds, record.escalationGroupId` | person member-group field path |
+| `MetaAutomationManager.vue:466` | `例如：{{record.title}} 待处理` | person title template placeholder |
+| `MetaAutomationManager.vue:494` | `支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}` | person body template placeholder; extra scout finding beyond the earlier 6-line reminder |
+
+T3D-3 should not "fix" these opportunistically; doing so would force T3D-4 to rebase through the same DingTalk panel.
+
+## 6. Raw Boundary
+
+These remain raw:
+
+- Rule names (`rule.name`), field names, view names, sheet IDs, view IDs, rule IDs.
+- `data-*` attributes, `:data-*` values, and CSS suffix values.
+- Persisted automation enum values in form controls.
+- DingTalk group/user/member-group labels, subject IDs, subtitles, and status payloads.
+- Public form access summaries returned by shared DingTalk helper utilities until T3D-4.
+- Backend/API error messages from `e.message`.
+- Runtime test-run error payloads from `execution.error`, `failedStep.error`, and `props.testRunState.message`.
+- Template tokens and user-entered template strings.
+
+M1 selector-binding trap:
+
+- Do not bind localized labels into `data-automation-*`, `data-status`, `data-access-level`, or CSS suffix classes.
+- Existing `:class="\`meta-automation__test-run-status--${status}\`"` and `:data-status="status"` stay raw.
+
+## 7. A11y Boundary
+
+T3D-3 localizes visible text and existing placeholders only. It must not add new a11y attributes.
+
+Source counts before T3D-3:
+
+- `aria-label=`: 0
+- `title=`: 0
+- `placeholder=`: 13
+
+Test requirement:
+
+- Add a fixture-render sentinel in `multitable-automation-manager.spec.ts` that records `[aria-label]`, `[title]`, and `[placeholder]` counts.
+- Because T3D-3 may localize in-scope placeholder text without adding/removing attributes, the count should stay fixture-computed and explicitly asserted.
+- Verification MD must record both source count and rendered fixture count.
+
+## 8. Test Plan
+
+### 8.1 Helper Spec
+
+Extend `apps/web/tests/meta-automation-labels.spec.ts`:
+
+- ALL_KEYS lockstep for new manager/error/testRun keys.
+- `automationCardTriggerSummary(...)`: record created, record updated, field changed with raw field name, no-field fallback, unknown trigger raw fallback.
+- `automationCardActionSummary(...)`: notify, update field with raw field name, update/create/webhook/lock, DingTalk action labels, unknown action raw fallback.
+- Card link helpers for public form/internal view with raw view names.
+- Test-run helpers: running, DingTalk warning, request failed with raw message, failed with raw message/fallback, skipped/succeeded with raw duration.
+- Failure helpers must cover en raw, en empty, zh raw, and zh empty cases.
+- Static CRUD fallback keys: `error.loadRules`, `error.createRule`, `error.updateRule`, `error.deleteRule`.
+- Direct reuse proof: `automationLabel('status.running', false) === 'running'` and zh remains `运行中`.
+
+### 8.2 Manager Render Spec
+
+Extend `apps/web/tests/multitable-automation-manager.spec.ts`:
+
+- en baseline for manager shell/card still renders expected English.
+- zh-CN manager shell/list/card test: `自动化`, `+ 新建自动化`, `快速旧版表单`, `已启用` / `已停用`, `查看日志`, `查看投递记录`, `删除`.
+- zh-CN quick legacy core test: `新建自动化`, `名称`, `触发器`, `动作`, `发送通知`, `更新字段值`, `通知内容`, `新值`, `创建`, `取消`.
+- zh-CN card dynamic summary test: field name remains raw inside localized text.
+- zh-CN DingTalk card-level test: `公开表单：Public Form`, `内部处理：Grid`, `打开公开表单：Public Form`, `允许范围：...`; shared access summary text remains raw/deferred if still English.
+- zh-CN test-run status test: generic running, DingTalk warning, success/skipped/failed/request-failed strings; raw backend/test error messages remain raw.
+- `useMultitableAutomations` fallback test: when API throws no message, localized frontend fallback appears; when API throws a message, raw message wins.
+- Raw selector tests: `data-automation-rule`, `data-automation-toggle`, `data-status`, `data-access-level`, and option `value` attributes remain raw.
+- A11y sentinel test: fixture `[aria-label]`, `[title]`, `[placeholder]` counts.
+
+### 8.3 Validation Commands
+
+Package-relative paths because `pnpm --filter @metasheet/web exec` runs with `apps/web` as cwd:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/meta-automation-labels.spec.ts tests/multitable-automation-manager.spec.ts --reporter=dot
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web build
+git diff --check origin/main..HEAD
+git diff --check
+```
+
+## 9. Preflight Grep
+
+Before implementation, run:
+
+```bash
+rg -n "Automations|Edit Automation|New Automation|Automation name|When record created|When record updated|When field changes|-- select field --|Send notification|Update field value|Notification message|New value|Quick legacy form|Loading automations|No automations yet|Enabled|Disabled|Allowed audience| ok| fail|View Logs|View Deliveries|Running test|Test run succeeded|Test run failed|Test run skipped|Failed to load automation rules|Failed to create automation rule|Failed to update automation rule|Failed to delete automation rule" apps/web/src/multitable/components/MetaAutomationManager.vue apps/web/src/multitable/composables/useMultitableAutomations.ts
+```
+
+Classify every hit:
+
+- Localize in T3D-3.
+- Raw runtime/user data; leave untouched.
+- DingTalk deep panel/helper; explicitly defer to T3D-4.
+
+Verification MD must include the grep command and a concise classification.
+
+## 10. Implementation Order
+
+1. Rebase first: `git fetch origin && git rebase origin/main`.
+2. Run the T3D-3 preflight grep from §9.
+3. Extend `meta-automation-labels.ts` with manager keys and dynamic helpers.
+4. Extend `meta-automation-labels.spec.ts`.
+5. Wire `useMultitableAutomations.ts` static frontend fallback errors.
+6. Wire `MetaAutomationManager.vue` shell/card/legacy quick-form core chrome.
+7. Wire card-level DingTalk labels only; do not enter deep config panel copy.
+8. Wire test-run card messages.
+9. Extend `multitable-automation-manager.spec.ts`.
+10. Write verification MD with grep, test output, a11y counts, raw-boundary evidence, intra-module reuse grep, and proof that the 8 T3D-4 zh-only placeholders from §5 remain untouched in T3D-3.
+11. Run validation commands.
+12. Commit locally and stop before push.
+
+## 11. Risk Register
+
+| Risk | Mitigation |
+| --- | --- |
+| T3D-3 accidentally localizes deep DingTalk panel copy and collides with T3D-4. | Keep DingTalk config/token/warning/preview copy deferred except card-level labels explicitly listed in §4.2. |
+| Card dynamic helpers translate user field/view names. | Helper signatures accept raw names and interpolate without mutation; specs assert raw field/view names. |
+| `useMultitableAutomations` replaces backend `e.message` with localized fallback. | Raw `e.message` wins; only static no-message fallback localizes. |
+| `data-*` or CSS suffix binds localized text. | Spec asserts raw `data-status`, `data-access-level`, option values, and selector attributes. |
+| A11y boundary drifts. | Fixture sentinel locks `[aria-label]` / `[title]` / `[placeholder]` counts. |
+| 4-PR chain modifies `meta-automation-labels.ts` across multiple slices; mid-flight rebase can conflict in union/map/ALL_KEYS. | Before push run `git fetch origin && git rebase origin/main`; if pushed PR becomes BEHIND and overlap is zero, Path A admin squash is acceptable; if automation label/module overlap exists, rebase + `--force-with-lease`. |
+| T3D-3 consumes T3D-1/T3D-2 helpers that later drift. | Verification MD includes intra-module reuse grep for `automationStatusLabel`, `automationActionTypeLabel`, `automationTriggerTypeLabel`, and `automationLabel('status.running', ...)`. |
+
+## 12. Approval Gate
+
+Implementation is ready only if:
+
+- `meta-automation-labels.ts` remains the single T3D module.
+- Manager shell/card/legacy quick-form core chrome is localized.
+- Deep DingTalk panel/helper copy remains T3D-4.
+- `useMultitableAutomations` frontend fallback errors are localized while backend messages stay raw.
+- Dynamic card helpers preserve raw field/view names.
+- A11y count sentinel is present.
+- `multitable-automation-manager.spec.ts` remains the only manager render harness.
+- Validation commands pass and diff scope is limited to T3D-3 files.

--- a/docs/development/multitable-t3d3-automation-manager-i18n-verification-20260521.md
+++ b/docs/development/multitable-t3d3-automation-manager-i18n-verification-20260521.md
@@ -1,0 +1,164 @@
+# T3D-3 Automation Manager I18n Verification - 2026-05-21
+
+## DoD
+
+T3D-3 localizes the automation manager shell, card summaries, card-level DingTalk links, test-run card messages, and `useMultitableAutomations` static frontend fallback errors without touching backend contracts, migrations, K3, attendance, RuleEditor deep DingTalk panel copy, or T3D-4 placeholder scope.
+
+Result: PASS.
+
+## Scope
+
+Changed production surfaces:
+
+- `apps/web/src/multitable/utils/meta-automation-labels.ts`
+- `apps/web/src/multitable/components/MetaAutomationManager.vue`
+- `apps/web/src/multitable/composables/useMultitableAutomations.ts`
+
+Changed tests:
+
+- `apps/web/tests/meta-automation-labels.spec.ts`
+- `apps/web/tests/multitable-automation-manager.spec.ts`
+
+Docs:
+
+- `docs/development/multitable-t3d3-automation-manager-i18n-design-20260521.md`
+- `docs/development/multitable-t3d3-automation-manager-i18n-verification-20260521.md`
+
+Out of scope and unchanged: RuleEditor deep DingTalk panel copy, `dingtalk*.ts` warning/token helpers, automation backend/API contracts, migrations, attendance, K3, and final global audit.
+
+## Preflight And Reuse Grep
+
+Preflight source grep confirmed the T3D-3 chrome strings came from `MetaAutomationManager.vue` and `useMultitableAutomations.ts`, while deep DingTalk panel strings remained intentionally deferred to T3D-4.
+
+Intra-module reuse evidence:
+
+```text
+apps/web/src/multitable/utils/meta-automation-labels.ts:412:export function automationStatusLabel(...)
+apps/web/src/multitable/utils/meta-automation-labels.ts:420:export function automationActionTypeLabel(...)
+apps/web/src/multitable/utils/meta-automation-labels.ts:446:export function automationTriggerTypeLabel(...)
+apps/web/src/multitable/utils/meta-automation-labels.ts:389:'manager.testRunning'
+apps/web/src/multitable/utils/meta-automation-labels.ts:390:'manager.testRunningDingTalkWarning'
+apps/web/src/multitable/components/MetaAutomationManager.vue:1829:automationCardTriggerSummary(...)
+apps/web/src/multitable/components/MetaAutomationManager.vue:1852:automationCardActionSummary(...)
+apps/web/src/multitable/components/MetaAutomationManager.vue:1257:automationCardLinkLabel(...)
+apps/web/src/multitable/components/MetaAutomationManager.vue:1878:automationCardLinkSummary(...)
+```
+
+New T3D-3 helpers are covered by `meta-automation-labels.spec.ts` and wired in `MetaAutomationManager.vue`:
+
+- `automationCardTriggerSummary`
+- `automationCardActionSummary`
+- `automationCardLinkLabel`
+- `automationCardLinkSummary`
+- `automationCardStats`
+- `automationTestRunRequestFailed`
+- `automationTestRunFailed`
+- `automationTestRunSkipped`
+- `automationTestRunSucceeded`
+
+## Deferred Placeholder Check
+
+The 8 zh-only DingTalk placeholders discovered during T3D-3 scout remain untouched for T3D-4:
+
+```text
+MetaAutomationManager.vue:169 placeholder="例如：{{record.title}} 待处理"
+MetaAutomationManager.vue:197 placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
+MetaAutomationManager.vue:360 placeholder="使用逗号或换行分隔本地 userId"
+MetaAutomationManager.vue:368 placeholder="使用逗号或换行分隔成员组 ID"
+MetaAutomationManager.vue:376 placeholder="例如：record.assigneeUserIds, record.reviewerUserId"
+MetaAutomationManager.vue:421 placeholder="例如：record.watcherGroupIds, record.escalationGroupId"
+MetaAutomationManager.vue:466 placeholder="例如：{{record.title}} 待处理"
+MetaAutomationManager.vue:494 placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
+```
+
+Source a11y count for `MetaAutomationManager.vue` after T3D-3:
+
+- `aria-label`: 0
+- `title`: 0
+- `placeholder`: 13
+
+Fixture-render sentinel in `multitable-automation-manager.spec.ts` locks:
+
+- quick-form zh fixture `[aria-label] = 0`
+- quick-form zh fixture `[title] = 0`
+- quick-form zh fixture `[placeholder] = 2`
+
+The source count is higher than fixture count because DingTalk panel placeholders are conditional and deferred to T3D-4.
+
+## Raw Boundary
+
+Raw values preserved:
+
+- Rule name (`Raw 规则名`)
+- Field/view names (`Status`, `Name`, `我的视图`, `内部视图`)
+- `data-automation-rule`, `data-automation-field`, `data-access-level`, and other raw selectors
+- DingTalk public-form access summary text from lower-level helpers
+- Backend/API error messages when present
+- `duration` string such as ` (32 ms)` without trimming
+- Test-run raw failed step error text
+- Unknown enum fallbacks via `String(value)`
+
+New fallback-only frontend errors localize through `useMultitableAutomations`:
+
+- `error.loadRules`
+- `error.createRule`
+- `error.updateRule`
+- `error.deleteRule`
+
+This is the first metasheet2 multitable i18n slice that consumes `useLocale()` inside a composable. It is called once at composable creation time (`const { isZh } = useLocale()`), and catch blocks read `isZh.value` at event time. Stored `error.value` is an event-time string and does not retranslate after a later locale toggle.
+
+## Test Evidence
+
+Targeted T3D suite:
+
+```text
+pnpm --filter @metasheet/web exec vitest run \
+  tests/meta-automation-labels.spec.ts \
+  tests/multitable-automation-manager.spec.ts \
+  tests/multitable-automation-rule-editor.spec.ts \
+  tests/MetaAutomationLogViewer.spec.ts \
+  tests/meta-automation-delivery-viewers-i18n.spec.ts \
+  --watch=false
+
+✓ tests/meta-automation-labels.spec.ts (8 tests)
+✓ tests/meta-automation-delivery-viewers-i18n.spec.ts (4 tests)
+✓ tests/MetaAutomationLogViewer.spec.ts (17 tests)
+✓ tests/multitable-automation-manager.spec.ts (78 tests)
+✓ tests/multitable-automation-rule-editor.spec.ts (84 tests)
+
+Test Files 5 passed (5)
+Tests 191 passed (191)
+```
+
+Type-check:
+
+```text
+pnpm --filter @metasheet/web type-check
+
+> vue-tsc -b
+exit=0
+```
+
+Build:
+
+```text
+pnpm --filter @metasheet/web build
+
+> vue-tsc -b && vite build
+✓ built in 5.87s
+```
+
+The Vite build emitted the existing chunk-size/dynamic-import warnings; no T3D-3-specific build error occurred.
+
+Diff whitespace check for intended source/docs files:
+
+```text
+git diff --check -- apps/web/src/multitable apps/web/tests docs/development
+exit=0
+```
+
+## Node Modules Note
+
+This separate worktree initially had no `vitest` executable, so `pnpm install --ignore-scripts` was run to create local workspace executables before validation. It modified tracked `node_modules` symlinks under plugin/tool folders in the worktree. These paths are not staged and are not part of the intended PR diff.
+
+Before commit/push, use targeted `git add` for the seven T3D-3 files only.


### PR DESCRIPTION
## Summary

- Extend the T3D automation label module with 27 manager/static keys, 9 manager helpers, and 2 typed unions (`AutomationCardLinkVariant`, `AutomationCardStatType`).
- Localize `MetaAutomationManager.vue` manager shell/card/quick-form/test-run chrome while preserving raw rule names, field/view names, selectors, IDs, backend errors, and duration strings.
- Localize `useMultitableAutomations.ts` static frontend fallback errors using the first composable-level `useLocale()` consumption in metasheet2 multitable i18n; stored errors remain event-time strings and do not retranslate after a later locale toggle.
- Keep card-level DingTalk display in T3D-3 scope (`Open public form:`, `Internal processing:`); deep DingTalk panel chrome and 8 zh-only placeholders remain deferred to T3D-4.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/meta-automation-labels.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts tests/MetaAutomationLogViewer.spec.ts tests/meta-automation-delivery-viewers-i18n.spec.ts --watch=false` -> 191/191 passed
- `pnpm --filter @metasheet/web type-check` -> passed
- `pnpm --filter @metasheet/web build` -> passed (`✓ built in 5.87s`; existing Vite chunk warnings only)
- `git diff --check origin/main..HEAD` -> clean

## Notes

- Aria sentinel: fixture `[aria-label]/[title]/[placeholder] = 0/0/2`; source count is `0/0/13` because conditional DingTalk panel placeholders are deferred to T3D-4.
- Design: `docs/development/multitable-t3d3-automation-manager-i18n-design-20260521.md`
- Verification: `docs/development/multitable-t3d3-automation-manager-i18n-verification-20260521.md`
- Next slice: T3D-4 DingTalk shared chrome, final slice in the T3D 4-PR chain.
