### PR TITLE
fix(ops): keep Bridge Agent smoke PS5.1-safe

### DIFF
--- a/docs/development/bridge-agent-driver-smoke-ps51-encoding-development-20260522.md
+++ b/docs/development/bridge-agent-driver-smoke-ps51-encoding-development-20260522.md
@@ -1,0 +1,82 @@
+# Bridge Agent Driver Smoke PowerShell 5.1 Encoding Fix - development - 2026-05-22
+
+## Context
+
+The on-prem entity-machine follow-up for release
+`multitable-onprem-bridge-agent-20260521-575261f43` proved that BA-M1 readonly
+Bridge Agent can run against the PLM source through the discovered allowlist.
+
+The same follow-up also exposed one operator-side packaging issue:
+
+- packaged `scripts/ops/bridge-agent-driver-smoke.ps1` was UTF-8 without BOM;
+- Windows PowerShell 5.1 can decode such scripts through the system code page;
+- the script contained localized-login redaction regex literals with CJK text;
+- running the script directly from the package hit a parse/decoding issue;
+- an operator-created UTF-8 BOM execution copy worked around the issue.
+
+This is a package/operator ergonomics bug, not a SQL connectivity or Bridge
+Agent runtime failure.
+
+## Change
+
+The BA-M0.5 driver-smoke script now keeps the localized-login redaction regex
+ASCII-safe by using .NET regex Unicode escape sequences:
+
+```text
+\u7528\u6237
+\u4f7f\u7528\u8005
+\u767b\u5165\u540d
+\u767b\u5f55\u540d
+\u767b\u5f55\u5931\u8d25
+\u767b\u5165\u5931\u6557
+```
+
+The redaction behavior remains the same: English `Login failed for user ...`,
+common Chinese localized login-failure forms, and exact quoted occurrences of
+the supplied username are still masked to `<redacted-login>`.
+
+The script source itself no longer depends on UTF-8 BOM decoding to preserve
+those regex literals.
+
+## Guardrails
+
+Two gates were added:
+
+1. `scripts/ops/bridge-agent-driver-smoke-contract.test.mjs`
+   - asserts `bridge-agent-driver-smoke.ps1` contains only ASCII-safe bytes;
+   - asserts the Unicode escape markers are present;
+   - asserts literal CJK characters do not reappear in the script.
+
+2. `scripts/ops/multitable-onprem-package-verify.sh`
+   - rejects packaged `bridge-agent-driver-smoke.ps1` if it contains
+     non-ASCII bytes.
+
+This makes the Windows PowerShell 5.1 compatibility rule part of both local
+verification and official on-prem package verification.
+
+## Scope
+
+- BA-M0.5 driver-smoke script redaction regex encoding only.
+- Driver-smoke contract test.
+- On-prem package verifier marker.
+- Development and verification documentation.
+
+No SQL query behavior changed. The smoke still executes only
+`SELECT @@VERSION`.
+
+## Out of scope
+
+- BA-M1 readonly Bridge Agent HTTP behavior.
+- MetaSheet/Data Factory BA-M2 integration.
+- plugin-integration-core runtime.
+- K3 Save / Submit / Audit.
+- Any customer SQL writes or business table mutation.
+
+## Deployment impact
+
+Next Windows on-prem packages should run the packaged
+`bridge-agent-driver-smoke.ps1` directly under Windows PowerShell 5.1 without
+requiring an operator-created UTF-8 BOM copy.
+
+Existing entity-machine BA-M1 PASS evidence remains valid; this change removes
+the packaging/encoding workaround for future runs.

--- a/docs/development/bridge-agent-driver-smoke-ps51-encoding-verification-20260522.md
+++ b/docs/development/bridge-agent-driver-smoke-ps51-encoding-verification-20260522.md
@@ -1,0 +1,143 @@
+# Bridge Agent Driver Smoke PowerShell 5.1 Encoding Fix - verification - 2026-05-22
+
+## Trigger
+
+Issue follow-up reported that the packaged
+`scripts/ops/bridge-agent-driver-smoke.ps1` from release
+`multitable-onprem-bridge-agent-20260521-575261f43` hit a Windows PowerShell
+5.1 UTF-8 parsing issue when executed directly from the package.
+
+The operator worked around it with a UTF-8 BOM execution copy. This
+verification records the code-side fix that removes the need for that
+workaround in future packages.
+
+## Static source checks
+
+Command:
+
+```bash
+LC_ALL=C grep -n '[^ -~]' scripts/ops/bridge-agent-driver-smoke.ps1 || true
+```
+
+Result:
+
+```text
+0 matches
+```
+
+The script starts without a BOM and contains only ASCII-safe bytes:
+
+```text
+00000000: 2372 6571 7569 7265  #require
+```
+
+## Contract tests
+
+Command:
+
+```bash
+node --test \
+  scripts/ops/bridge-agent-driver-smoke-contract.test.mjs \
+  scripts/ops/bridge-agent-readonly-contract.test.mjs
+```
+
+Result:
+
+```text
+tests 7
+pass 7
+fail 0
+```
+
+Covered assertions:
+
+- driver-smoke script is ASCII-safe for Windows PowerShell 5.1;
+- localized SQL login redaction uses `\uXXXX` regex escapes;
+- literal CJK regex characters do not reappear in the script;
+- package verifier contains the non-ASCII rejection marker;
+- existing BA-M1 readonly contract tests still pass.
+
+## Package verifier syntax / diff checks
+
+Commands:
+
+```bash
+bash -n scripts/ops/multitable-onprem-package-verify.sh
+git diff --check origin/main...HEAD
+```
+
+Result:
+
+```text
+PASS
+PASS
+```
+
+## Package-level check
+
+The isolated worktree did not install dependencies, so the package build reused
+the already-built local `apps/web/dist` and `packages/core-backend/dist`
+artifacts from the main checkout to exercise package assembly and verification.
+The changed Bridge Agent files and package verifier came from this branch.
+
+Expected command shape:
+
+```bash
+INSTALL_DEPS=0 BUILD_WEB=0 BUILD_BACKEND=0 \
+  PACKAGE_TAG=bridge-agent-ps51-local \
+  scripts/ops/multitable-onprem-package-build.sh
+
+VERIFY_REPORT_JSON=/tmp/ms2-bridge-agent-ps51-zip.verify.json \
+VERIFY_REPORT_MD=/tmp/ms2-bridge-agent-ps51-zip.verify.md \
+  scripts/ops/multitable-onprem-package-verify.sh \
+  output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-bridge-agent-ps51-local.zip
+
+VERIFY_REPORT_JSON=/tmp/ms2-bridge-agent-ps51-tgz.verify.json \
+VERIFY_REPORT_MD=/tmp/ms2-bridge-agent-ps51-tgz.verify.md \
+  scripts/ops/multitable-onprem-package-verify.sh \
+  output/releases/multitable-onprem/metasheet-multitable-onprem-v2.5.0-bridge-agent-ps51-local.tgz
+```
+
+Result:
+
+```text
+zip: Package verify OK
+tgz: Package verify OK
+```
+
+## Secret hygiene
+
+Touched files were scanned for common secret shapes:
+
+- JWT-like values;
+- authorization headers;
+- raw password assignments;
+- raw PostgreSQL userinfo URLs;
+- raw access-token URL query values.
+
+Result:
+
+```text
+0 matches
+```
+
+## Remaining live validation
+
+Because this development host is macOS and does not provide Windows
+PowerShell 5.1, the final live check remains an operator-side rerun on the
+on-prem Windows bridge host:
+
+```powershell
+.\scripts\ops\bridge-agent-driver-smoke.ps1 `
+  -Provider SqlClient `
+  -Server '<host>' `
+  -Database '<db>' `
+  -Username '<readonly_user>' `
+  -PasswordEnvVar BRIDGE_SMOKE_DB_PASSWORD `
+  -OutDir 'C:\metasheet\bridge-evidence'
+```
+
+Expected: the packaged script runs directly, without creating a BOM copy, and
+still emits redacted JSON/Markdown evidence.
+
+No K3 Save / Submit / Audit should be run for this validation.

--- a/scripts/ops/bridge-agent-driver-smoke-contract.test.mjs
+++ b/scripts/ops/bridge-agent-driver-smoke-contract.test.mjs
@@ -1,0 +1,43 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+
+const scriptPath = new URL('./bridge-agent-driver-smoke.ps1', import.meta.url);
+const verifyScriptPath = new URL('./multitable-onprem-package-verify.sh', import.meta.url);
+
+async function readSmokeScript() {
+  return readFile(scriptPath, 'utf8');
+}
+
+test('driver smoke script remains ASCII-safe for Windows PowerShell 5.1', async () => {
+  const bytes = await readFile(scriptPath);
+  const nonAscii = [...bytes.entries()].filter(([, byte]) => {
+    return byte !== 0x09 && byte !== 0x0a && byte !== 0x0d && (byte < 0x20 || byte > 0x7e);
+  });
+
+  assert.deepEqual(nonAscii, []);
+});
+
+test('localized SQL login redaction uses Unicode escapes instead of literal CJK', async () => {
+  const script = await readSmokeScript();
+
+  for (const marker of [
+    '\\u7528\\u6237',
+    '\\u4f7f\\u7528\\u8005',
+    '\\u767b\\u5165\\u540d',
+    '\\u767b\\u5f55\\u540d',
+    '\\u767b\\u5f55\\u5931\\u8d25',
+    '\\u767b\\u5165\\u5931\\u6557',
+  ]) {
+    assert.match(script, new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')));
+  }
+
+  assert.doesNotMatch(script, /[\u3400-\u9fff]/);
+});
+
+test('package verifier rejects non-ASCII driver smoke scripts', async () => {
+  const verifyScript = await readFile(verifyScriptPath, 'utf8');
+
+  assert.match(verifyScript, /Bridge Agent driver smoke must remain ASCII-safe for Windows PowerShell 5\.1/);
+  assert.match(verifyScript, /LC_ALL=C grep -n '\[\^ -~\]'/);
+});

--- a/scripts/ops/bridge-agent-driver-smoke.ps1
+++ b/scripts/ops/bridge-agent-driver-smoke.ps1
@@ -141,7 +141,7 @@ function ConvertTo-RedactedText {
   )
   $redacted = [System.Text.RegularExpressions.Regex]::Replace(
     $redacted,
-    "((?:用户|使用者|登入名|登录名)\s*$quotePattern)([^`"']+)($quotePattern\s*(?:登录失败|登入失敗|login failed))",
+    "((?:\u7528\u6237|\u4f7f\u7528\u8005|\u767b\u5165\u540d|\u767b\u5f55\u540d)\s*$quotePattern)([^`"']+)($quotePattern\s*(?:\u767b\u5f55\u5931\u8d25|\u767b\u5165\u5931\u6557|login failed))",
     '${1}' + $redactedLogin + '${3}'
   )
   if (-not [string]::IsNullOrEmpty($Username)) {
@@ -459,7 +459,7 @@ $mdPath   = Join-Path $OutDir 'ba-m0_5-driver-smoke.md'
 # JSON evidence
 $evidence | ConvertTo-Json -Depth 8 | Out-File -LiteralPath $jsonPath -Encoding utf8 -Force
 
-# Human-readable Markdown evidence (no secrets — mirrors JSON content)
+# Human-readable Markdown evidence (no secrets - mirrors JSON content)
 $mdLines = @()
 $mdLines += '# BA-M0.5 Driver Smoke Evidence'
 $mdLines += ''

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -328,6 +328,9 @@ function verify_bridge_agent_tooling_contract() {
   local readonly_runbook="${root}/docs/operations/bridge-agent-readonly-runbook-20260521.md"
   local install_txt="${root}/INSTALL.txt"
 
+  if LC_ALL=C grep -n '[^ -~]' "$smoke_script" >/dev/null 2>&1; then
+    die "Bridge Agent driver smoke must remain ASCII-safe for Windows PowerShell 5.1"
+  fi
   search_fixed_string 'SELECT @@VERSION' "$smoke_script" || die "Bridge Agent driver smoke must run SELECT @@VERSION only"
   search_fixed_string "[ValidateSet('SqlClient', 'Odbc', 'OleDb')]" "$smoke_script" || die "Bridge Agent driver smoke must support SqlClient/Odbc/OleDb provider modes"
   search_fixed_string 'OdbcDriverName' "$smoke_script" || die "Bridge Agent driver smoke must allow BA-M0 approved ODBC driver names"


### PR DESCRIPTION
## Summary

Fixes the Windows PowerShell 5.1 encoding issue reported from the entity-machine run of release `multitable-onprem-bridge-agent-20260521-575261f43`.

The packaged `bridge-agent-driver-smoke.ps1` contained localized-login redaction regex literals with CJK text. Windows PowerShell 5.1 can decode UTF-8-without-BOM scripts through the system code page, so the operator needed a UTF-8 BOM execution copy. This PR removes that workaround requirement by keeping the script ASCII-safe.

## Changes

- Replaces localized-login regex literals in `bridge-agent-driver-smoke.ps1` with .NET regex `\uXXXX` escapes.
- Replaces one non-ASCII comment dash in the same script.
- Adds a driver-smoke contract test that asserts the script stays ASCII-safe and retains the Unicode escape markers.
- Adds a package verifier gate that rejects packaged driver-smoke scripts with non-ASCII bytes.
- Adds development and verification MDs.

## Verification

- `LC_ALL=C grep -n '[^ -~]' scripts/ops/bridge-agent-driver-smoke.ps1 || true` -> 0 matches
- `node --test scripts/ops/bridge-agent-driver-smoke-contract.test.mjs scripts/ops/bridge-agent-readonly-contract.test.mjs` -> 7/7 PASS
- `bash -n scripts/ops/multitable-onprem-package-verify.sh`
- `git diff --check origin/main...HEAD`
- secret-shape scan across touched files -> 0 hits
- local package build using existing local dist artifacts:
  - `.tgz` package verify: PASS
  - `.zip` package verify: PASS

## Scope

Ops/docs/tests only. No SQL behavior change, no BA-M1 HTTP contract change, no plugin-integration-core, no DB/API/frontend, no K3 Save/Submit/Audit.
