### PR TITLE
chore(integration): add readonly bridge scheduled task helper

### DIFF
--- a/docs/development/bridge-agent-readonly-scheduled-task-design-20260522.md
+++ b/docs/development/bridge-agent-readonly-scheduled-task-design-20260522.md
@@ -1,0 +1,106 @@
+# Bridge Agent Readonly Scheduled Task Design
+
+Date: 2026-05-22
+
+## Purpose
+
+BA-M2 proved that MetaSheet Data Factory can read `material`, `bom`, and
+`bom_child` through the localhost readonly Bridge Agent. The entity-machine
+smoke also exposed an operational gap: a Bridge Agent process launched as an
+SSH child process can disappear when the SSH session ends, leaving Data Factory
+with `fetch failed`.
+
+This slice makes the durable startup path explicit and package-verified by
+adding a Windows Scheduled Task helper for the existing readonly Bridge Agent.
+
+## Scope
+
+In scope:
+
+- install/start/stop/status/uninstall helper for Windows Task Scheduler;
+- run the existing `scripts/ops/bridge-agent-readonly.ps1` as `SYSTEM`;
+- at-startup trigger;
+- stable task name `MetaSheetReadonlyBridgeAgent`;
+- secret-free `Status` output with Task Scheduler state, `LastTaskResult`, and
+  a local TCP listener probe;
+- runbook instructions for machine-level environment variables;
+- package-build and package-verify gates so the helper ships in the on-prem
+  zip/tgz.
+
+Out of scope:
+
+- changing Bridge Agent SQL query behavior;
+- adding writes, filters, watermarks, relationship expansion, or raw SQL;
+- changing `plugin-integration-core`;
+- changing Data Factory UI;
+- K3 Save / Submit / Audit;
+- Windows Service packaging.
+
+## Design
+
+The helper is `scripts/ops/bridge-agent-readonly-scheduled-task.ps1`.
+
+It registers a task with:
+
+- action: Windows PowerShell 5.1;
+- arguments: `-NoProfile -ExecutionPolicy Bypass -File <root>\scripts\ops\bridge-agent-readonly.ps1 -ConfigPath <config>`;
+- trigger: `AtStartup`;
+- principal: `SYSTEM`, service account logon, highest run level;
+- restart policy: up to three restarts at one-minute intervals.
+
+The helper keeps all Bridge Agent protocol and SQL safety rules in the existing
+agent script. This is intentionally an operational wrapper, not a second agent.
+
+## Secret Handling
+
+The Scheduled Task runs as `SYSTEM`, so user-scoped environment variables from
+SSH/RDP are not visible. The runbook now directs operators to use machine-level
+environment variables or an approved host secret mechanism for:
+
+- `METASHEET_BRIDGE_SQL_USERNAME`
+- `METASHEET_BRIDGE_SQL_PASSWORD`
+- `METASHEET_BRIDGE_SHARED_SECRET`
+
+The helper does not print those values and does not call authenticated Bridge
+Agent endpoints. The `Status` action uses `Get-ScheduledTaskInfo` and a
+`System.Net.Sockets.TcpClient` probe against `127.0.0.1:<port>` only.
+
+## Package Contract
+
+`multitable-onprem-package-build.sh` now includes the helper in
+`REQUIRED_PATHS` and mentions it in `INSTALL.txt`.
+
+`multitable-onprem-package-verify.sh` now fails if the package lacks:
+
+- `scripts/ops/bridge-agent-readonly-scheduled-task.ps1`;
+- install/start/stop/status/uninstall action markers;
+- `Register-ScheduledTask`;
+- `SYSTEM` principal;
+- `Get-ScheduledTaskInfo`;
+- secret-free local TCP listener check;
+- runbook documentation for persistent Scheduled Task startup and
+  machine-level environment variables.
+
+## Expected Operator Flow
+
+1. Configure `C:\ProgramData\MetaSheet\BridgeAgent\config.json`.
+2. Store Bridge Agent secrets in machine-level environment variables.
+3. Run `bridge-agent-readonly.ps1 -ValidateConfigOnly`.
+4. Install and start the task:
+
+   ```powershell
+   powershell -ExecutionPolicy Bypass -File C:\metasheet\scripts\ops\bridge-agent-readonly-scheduled-task.ps1 `
+     -Action Install `
+     -RootDir C:\metasheet `
+     -ConfigPath C:\ProgramData\MetaSheet\BridgeAgent\config.json `
+     -StartAfterInstall
+   ```
+
+5. Run the authenticated `/health`, `/objects`, `/schema/*`, and `/query/*`
+   smoke commands from the existing runbook.
+
+## Compatibility
+
+The helper targets Windows PowerShell 5.1 and stays ASCII-only. It does not
+require PowerShell 7, NSSM, WinSW, .NET SDK, Visual Studio, Docker, or a new
+database migration.

--- a/docs/development/bridge-agent-readonly-scheduled-task-verification-20260522.md
+++ b/docs/development/bridge-agent-readonly-scheduled-task-verification-20260522.md
@@ -1,0 +1,137 @@
+# Bridge Agent Readonly Scheduled Task Verification
+
+Date: 2026-05-22
+
+## Local Commands
+
+Commands run from repo root:
+
+```bash
+node --test \
+  scripts/ops/bridge-agent-readonly-contract.test.mjs \
+  scripts/ops/bridge-agent-readonly-task-contract.test.mjs
+
+bash -n \
+  scripts/ops/multitable-onprem-package-build.sh \
+  scripts/ops/multitable-onprem-package-verify.sh
+
+git diff --check origin/main...HEAD
+```
+
+Package build and verify:
+
+```bash
+OUTPUT_DIR=/tmp/ms2-bridge-agent-task-package \
+PACKAGE_TAG=bridge-task-local \
+BUILD_WEB=1 \
+BUILD_BACKEND=1 \
+  scripts/ops/multitable-onprem-package-build.sh
+
+VERIFY_REPORT_JSON=/tmp/ms2-bridge-agent-task-package/verify-zip.json \
+VERIFY_REPORT_MD=/tmp/ms2-bridge-agent-task-package/verify-zip.md \
+  scripts/ops/multitable-onprem-package-verify.sh \
+  /tmp/ms2-bridge-agent-task-package/metasheet-multitable-onprem-v2.5.0-bridge-task-local.zip
+
+VERIFY_REPORT_JSON=/tmp/ms2-bridge-agent-task-package/verify-tgz.json \
+VERIFY_REPORT_MD=/tmp/ms2-bridge-agent-task-package/verify-tgz.md \
+  scripts/ops/multitable-onprem-package-verify.sh \
+  /tmp/ms2-bridge-agent-task-package/metasheet-multitable-onprem-v2.5.0-bridge-task-local.tgz
+
+zipinfo -1 /tmp/ms2-bridge-agent-task-package/metasheet-multitable-onprem-v2.5.0-bridge-task-local.zip |
+  rg 'bridge-agent-readonly-scheduled-task.ps1|bridge-agent-readonly-runbook-20260521.md'
+
+tar -tzf /tmp/ms2-bridge-agent-task-package/metasheet-multitable-onprem-v2.5.0-bridge-task-local.tgz |
+  rg 'bridge-agent-readonly-scheduled-task.ps1|bridge-agent-readonly-runbook-20260521.md'
+```
+
+Secret-shape scan over the changed files:
+
+```bash
+node <<'NODE'
+const fs = require('node:fs');
+const files = [
+  'scripts/ops/bridge-agent-readonly-scheduled-task.ps1',
+  'scripts/ops/bridge-agent-readonly-task-contract.test.mjs',
+  'scripts/ops/multitable-onprem-package-build.sh',
+  'scripts/ops/multitable-onprem-package-verify.sh',
+  'docs/operations/bridge-agent-readonly-runbook-20260521.md',
+  'docs/development/bridge-agent-readonly-scheduled-task-design-20260522.md',
+  'docs/development/bridge-agent-readonly-scheduled-task-verification-20260522.md',
+];
+const patterns = [
+  new RegExp('Bearer ' + '[A-Za-z0-9]'),
+  new RegExp('ey' + 'J[A-Za-z0-9_-]{6,}\\.'),
+  new RegExp('postgres' + '://[^<\\s]+'),
+  new RegExp('METASHEET_BRIDGE_SQL_' + 'PASSWORD=.'),
+  new RegExp('Pass' + 'word=.*;'),
+];
+let hits = 0;
+for (const file of files) {
+  const text = fs.readFileSync(file, 'utf8');
+  for (const pattern of patterns) {
+    if (pattern.test(text)) {
+      console.error(`${file}: ${pattern}`);
+      hits++;
+    }
+  }
+}
+process.exit(hits === 0 ? 0 : 1);
+NODE
+```
+
+## Contract Matrix
+
+| Check | Evidence |
+| --- | --- |
+| Persistent startup helper exists | Package build `REQUIRED_PATHS` includes `bridge-agent-readonly-scheduled-task.ps1`. |
+| Runs existing agent, not a fork | Contract test asserts `bridge-agent-readonly.ps1` and `-ConfigPath` markers. |
+| Windows Scheduled Task | Contract test and package verify assert `Register-ScheduledTask` and startup trigger markers. |
+| Runs as SYSTEM | Contract test and package verify assert `New-ScheduledTaskPrincipal -UserId 'SYSTEM'`. |
+| Secret-free status | Contract test asserts `Get-ScheduledTaskInfo`, `LastTaskResult`, and `TcpClient`; no `/health` secret header call. |
+| Package regression guard | Package verify asserts helper markers, runbook section, and `INSTALL.txt` mention. |
+| Operator docs | Runbook adds `Persistent Scheduled Task Start` and `Machine-level environment variables`. |
+
+## Local Result
+
+| Command | Result |
+| --- | --- |
+| `node --test scripts/ops/bridge-agent-readonly-contract.test.mjs scripts/ops/bridge-agent-readonly-task-contract.test.mjs` | PASS, 7/7 |
+| `bash -n scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh` | PASS, rc=0 |
+| `git diff --check origin/main...HEAD` | PASS, rc=0 |
+| secret-shape scan | PASS, 0 hits |
+| local package build with `BUILD_WEB=1 BUILD_BACKEND=1` | PASS, zip/tgz generated under `/tmp/ms2-bridge-agent-task-package` |
+| package verify on generated zip | PASS, `Package verify OK` |
+| package verify on generated tgz | PASS, `Package verify OK` |
+| zip/tgz content probe | PASS, both contain `bridge-agent-readonly-scheduled-task.ps1` and updated readonly runbook |
+
+Note: `pnpm install --frozen-lockfile` was run in the isolated worktree to
+restore missing local dependencies before the package build. It changed tracked
+plugin/tool `node_modules` shim files as a local install side effect; those
+generated dependency changes were restored and are not part of this PR.
+
+## Windows Host Validation
+
+This PR is verified statically on macOS. The behavioral validation must happen
+on the Windows bridge host after a package containing this helper is deployed:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File C:\metasheet\scripts\ops\bridge-agent-readonly-scheduled-task.ps1 `
+  -Action Install `
+  -RootDir C:\metasheet `
+  -ConfigPath C:\ProgramData\MetaSheet\BridgeAgent\config.json `
+  -StartAfterInstall
+```
+
+Expected operator evidence:
+
+- `State: Running`;
+- `LastTaskResult: 0` after successful start;
+- `Local TCP listener: 127.0.0.1:19091 reachable`;
+- authenticated `/health` returns `ok=true` and `databaseReachable=true`;
+- Data Factory `bridge:legacy-sql-readonly` test connection passes;
+- dry-run still reads capped rows from allowlisted objects only.
+
+## Stage Boundaries
+
+This slice does not change Data Factory runtime behavior, SQL read semantics, or
+K3 write behavior. Customer GATE and K3 Save / Submit / Audit remain blocked.

--- a/docs/operations/bridge-agent-readonly-runbook-20260521.md
+++ b/docs/operations/bridge-agent-readonly-runbook-20260521.md
@@ -66,6 +66,25 @@ For a persistent operator setup, store them using the chosen Windows secret
 mechanism and inject them into the process environment before start. BA-M1 MVP
 does not prescribe the final service secret store.
 
+### Machine-level environment variables for Scheduled Task mode
+
+When the agent runs as `SYSTEM` through Windows Task Scheduler, user-scoped
+PowerShell variables from an SSH/RDP session are not visible. Store the three
+runtime values in the machine environment or another approved host secret
+mechanism before installing the task.
+
+Example shape, with values filled only on the customer host:
+
+```powershell
+[Environment]::SetEnvironmentVariable('METASHEET_BRIDGE_SQL_USERNAME', '<readonly-sql-login>', 'Machine')
+[Environment]::SetEnvironmentVariable('METASHEET_BRIDGE_SQL_PASSWORD', '<readonly-sql-password>', 'Machine')
+[Environment]::SetEnvironmentVariable('METASHEET_BRIDGE_SHARED_SECRET', '<local-shared-secret>', 'Machine')
+```
+
+Do not paste the real values into chat, issue comments, screenshots, or
+artifacts. Restart the Scheduled Task after changing machine-level environment
+variables.
+
 ## Config Setup
 
 Copy the example config to the private host path:
@@ -125,6 +144,47 @@ run the equivalent command as Administrator:
 ```powershell
 netsh http add urlacl url=http://127.0.0.1:19091/ user=<service-account>
 ```
+
+## Persistent Scheduled Task Start
+
+Do not rely on a background process launched from an SSH session. Windows may
+tear down child processes when the remote session exits, which makes Data
+Factory see `fetch failed` even though the foreground command worked during the
+session.
+
+After config validation passes, install the persistent task from an elevated
+PowerShell window:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File C:\metasheet\scripts\ops\bridge-agent-readonly-scheduled-task.ps1 `
+  -Action Install `
+  -RootDir C:\metasheet `
+  -ConfigPath C:\ProgramData\MetaSheet\BridgeAgent\config.json `
+  -StartAfterInstall
+```
+
+Expected markers:
+
+```text
+[bridge-agent-readonly-task] Task installed.
+[bridge-agent-readonly-task] Task start requested.
+[bridge-agent-readonly-task] State: Running
+[bridge-agent-readonly-task] Local TCP listener: 127.0.0.1:19091 reachable
+```
+
+Useful management commands:
+
+```powershell
+powershell -ExecutionPolicy Bypass -File C:\metasheet\scripts\ops\bridge-agent-readonly-scheduled-task.ps1 -Action Status
+powershell -ExecutionPolicy Bypass -File C:\metasheet\scripts\ops\bridge-agent-readonly-scheduled-task.ps1 -Action Stop
+powershell -ExecutionPolicy Bypass -File C:\metasheet\scripts\ops\bridge-agent-readonly-scheduled-task.ps1 -Action Start
+powershell -ExecutionPolicy Bypass -File C:\metasheet\scripts\ops\bridge-agent-readonly-scheduled-task.ps1 -Action Uninstall
+```
+
+`Status` deliberately checks only the Scheduled Task state, `LastTaskResult`,
+and the local TCP listener. It does not call `/health`, because `/health`
+requires `X-MetaSheet-Bridge-Secret` and the helper must not read or print the
+shared secret. Use the smoke commands below for authenticated protocol checks.
 
 ## Smoke Commands
 

--- a/scripts/ops/bridge-agent-readonly-scheduled-task.ps1
+++ b/scripts/ops/bridge-agent-readonly-scheduled-task.ps1
@@ -1,0 +1,244 @@
+#requires -Version 5.0
+<#
+.SYNOPSIS
+  Install or manage the MetaSheet readonly Bridge Agent as a Windows Scheduled Task.
+
+.DESCRIPTION
+  This helper keeps the BA-M1 readonly Bridge Agent alive after the operator's
+  SSH or RDP session ends. It does not change the Bridge Agent protocol or SQL
+  safety model; it only registers a localhost agent process to run as SYSTEM at
+  startup.
+#>
+
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+  [ValidateSet('Install', 'Start', 'Stop', 'Status', 'Uninstall')]
+  [string]$Action = 'Install',
+
+  [string]$RootDir = '',
+
+  [string]$ConfigPath = 'C:\ProgramData\MetaSheet\BridgeAgent\config.json',
+
+  [string]$TaskName = 'MetaSheetReadonlyBridgeAgent',
+
+  [string]$TaskPath = '\MetaSheet\',
+
+  [string]$PowerShellPath = "$env:SystemRoot\System32\WindowsPowerShell\v1.0\powershell.exe",
+
+  [int]$Port = 19091,
+
+  [switch]$StartAfterInstall
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Write-BridgeTaskInfo {
+  param([string]$Message)
+  Write-Host "[bridge-agent-readonly-task] $Message"
+}
+
+function Throw-BridgeTaskError {
+  param([string]$Message)
+  throw "[bridge-agent-readonly-task] ERROR: $Message"
+}
+
+function Require-Admin {
+  $identity = [Security.Principal.WindowsIdentity]::GetCurrent()
+  $principal = New-Object Security.Principal.WindowsPrincipal($identity)
+  if (-not $principal.IsInRole([Security.Principal.WindowsBuiltInRole]::Administrator)) {
+    Throw-BridgeTaskError 'Run this script in an elevated PowerShell window (Run as Administrator).'
+  }
+}
+
+function Ensure-ScheduledTaskModule {
+  foreach ($command in @('Register-ScheduledTask', 'Get-ScheduledTask', 'Get-ScheduledTaskInfo')) {
+    if (-not (Get-Command $command -ErrorAction SilentlyContinue)) {
+      Throw-BridgeTaskError "ScheduledTasks cmdlet unavailable: $command"
+    }
+  }
+}
+
+function Resolve-RootDirectory {
+  if (-not [string]::IsNullOrWhiteSpace($RootDir)) {
+    return (Resolve-Path -LiteralPath $RootDir).Path
+  }
+
+  $scriptDir = Split-Path -Parent $PSCommandPath
+  return (Resolve-Path -LiteralPath (Join-Path $scriptDir '..\..')).Path
+}
+
+function Resolve-AgentScript {
+  param([string]$ResolvedRootDir)
+  $candidate = Join-Path $ResolvedRootDir 'scripts\ops\bridge-agent-readonly.ps1'
+  if (-not (Test-Path -LiteralPath $candidate -PathType Leaf)) {
+    Throw-BridgeTaskError "Readonly Bridge Agent script not found: $candidate"
+  }
+  return (Resolve-Path -LiteralPath $candidate).Path
+}
+
+function Assert-TaskInputs {
+  param(
+    [string]$ResolvedRootDir,
+    [string]$AgentScript
+  )
+
+  if (-not (Test-Path -LiteralPath $ConfigPath -PathType Leaf)) {
+    Throw-BridgeTaskError "Config file not found: $ConfigPath"
+  }
+  if (-not (Test-Path -LiteralPath $PowerShellPath -PathType Leaf)) {
+    Throw-BridgeTaskError "PowerShell executable not found: $PowerShellPath"
+  }
+  if ($Port -lt 1 -or $Port -gt 65535) {
+    Throw-BridgeTaskError "Port must be between 1 and 65535: $Port"
+  }
+  if ([string]::IsNullOrWhiteSpace($TaskName)) {
+    Throw-BridgeTaskError 'TaskName is required.'
+  }
+  if ([string]::IsNullOrWhiteSpace($TaskPath)) {
+    Throw-BridgeTaskError 'TaskPath is required.'
+  }
+  if (-not $TaskPath.StartsWith('\')) {
+    Throw-BridgeTaskError 'TaskPath must start with a backslash, for example \MetaSheet\.'
+  }
+  if (-not $TaskPath.EndsWith('\')) {
+    Throw-BridgeTaskError 'TaskPath must end with a backslash, for example \MetaSheet\.'
+  }
+
+  Write-BridgeTaskInfo "RootDir: $ResolvedRootDir"
+  Write-BridgeTaskInfo "Agent script: $AgentScript"
+  Write-BridgeTaskInfo "ConfigPath: $ConfigPath"
+  Write-BridgeTaskInfo "Task: $TaskPath$TaskName"
+}
+
+function Build-AgentArguments {
+  param([string]$AgentScript)
+  return @(
+    '-NoProfile',
+    '-ExecutionPolicy Bypass',
+    "-File `"$AgentScript`"",
+    "-ConfigPath `"$ConfigPath`""
+  ) -join ' '
+}
+
+function Test-LocalTcpPort {
+  param([int]$TargetPort)
+  $client = $null
+  try {
+    $client = New-Object System.Net.Sockets.TcpClient
+    $async = $client.BeginConnect('127.0.0.1', $TargetPort, $null, $null)
+    $connected = $async.AsyncWaitHandle.WaitOne(1000, $false)
+    if (-not $connected) { return $false }
+    $client.EndConnect($async)
+    return $client.Connected
+  } catch {
+    return $false
+  } finally {
+    if ($null -ne $client) { $client.Close() }
+  }
+}
+
+function Get-BridgeTask {
+  return Get-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -ErrorAction SilentlyContinue
+}
+
+function Install-BridgeTask {
+  Ensure-ScheduledTaskModule
+  $resolvedRootDir = Resolve-RootDirectory
+  $agentScript = Resolve-AgentScript -ResolvedRootDir $resolvedRootDir
+  Assert-TaskInputs -ResolvedRootDir $resolvedRootDir -AgentScript $agentScript
+
+  $arguments = Build-AgentArguments -AgentScript $agentScript
+  Write-BridgeTaskInfo 'Registering scheduled task as SYSTEM.'
+
+  $taskAction = New-ScheduledTaskAction -Execute $PowerShellPath -Argument $arguments -WorkingDirectory $resolvedRootDir
+  $taskTrigger = New-ScheduledTaskTrigger -AtStartup
+  $taskPrincipal = New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest
+  $taskSettings = New-ScheduledTaskSettingsSet `
+    -AllowStartIfOnBatteries `
+    -DontStopIfGoingOnBatteries `
+    -StartWhenAvailable `
+    -RestartCount 3 `
+    -RestartInterval (New-TimeSpan -Minutes 1)
+  $task = New-ScheduledTask -Action $taskAction -Trigger $taskTrigger -Principal $taskPrincipal -Settings $taskSettings
+
+  if ($PSCmdlet.ShouldProcess("$TaskPath$TaskName", 'Register readonly Bridge Agent scheduled task')) {
+    Register-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -InputObject $task -Force | Out-Null
+    Write-BridgeTaskInfo 'Task installed.'
+    if ($StartAfterInstall) {
+      Start-BridgeTask
+    } else {
+      Show-BridgeTaskStatus
+    }
+  }
+}
+
+function Start-BridgeTask {
+  Ensure-ScheduledTaskModule
+  if (-not (Get-BridgeTask)) {
+    Throw-BridgeTaskError "Task not found: $TaskPath$TaskName"
+  }
+  if ($PSCmdlet.ShouldProcess("$TaskPath$TaskName", 'Start readonly Bridge Agent task')) {
+    Start-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath
+    Write-BridgeTaskInfo 'Task start requested.'
+    Start-Sleep -Seconds 2
+    Show-BridgeTaskStatus
+  }
+}
+
+function Stop-BridgeTask {
+  Ensure-ScheduledTaskModule
+  if (-not (Get-BridgeTask)) {
+    Write-BridgeTaskInfo "Task not found: $TaskPath$TaskName"
+    return
+  }
+  if ($PSCmdlet.ShouldProcess("$TaskPath$TaskName", 'Stop readonly Bridge Agent task')) {
+    Stop-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath
+    Write-BridgeTaskInfo 'Task stop requested.'
+    Show-BridgeTaskStatus
+  }
+}
+
+function Uninstall-BridgeTask {
+  Ensure-ScheduledTaskModule
+  if (-not (Get-BridgeTask)) {
+    Write-BridgeTaskInfo "Task not found: $TaskPath$TaskName"
+    return
+  }
+  if ($PSCmdlet.ShouldProcess("$TaskPath$TaskName", 'Unregister readonly Bridge Agent scheduled task')) {
+    Unregister-ScheduledTask -TaskName $TaskName -TaskPath $TaskPath -Confirm:$false
+    Write-BridgeTaskInfo 'Task removed.'
+  }
+}
+
+function Show-BridgeTaskStatus {
+  Ensure-ScheduledTaskModule
+  $task = Get-BridgeTask
+  if (-not $task) {
+    Write-BridgeTaskInfo "Task not found: $TaskPath$TaskName"
+    return
+  }
+
+  $info = Get-ScheduledTaskInfo -TaskName $TaskName -TaskPath $TaskPath
+  Write-BridgeTaskInfo "Task: $TaskPath$TaskName"
+  Write-BridgeTaskInfo "State: $($task.State)"
+  Write-BridgeTaskInfo "LastRunTime: $($info.LastRunTime)"
+  Write-BridgeTaskInfo "LastTaskResult: $($info.LastTaskResult)"
+  Write-BridgeTaskInfo "NextRunTime: $($info.NextRunTime)"
+
+  if (Test-LocalTcpPort -TargetPort $Port) {
+    Write-BridgeTaskInfo "Local TCP listener: 127.0.0.1:$Port reachable"
+  } else {
+    Write-BridgeTaskInfo "Local TCP listener: 127.0.0.1:$Port not reachable"
+  }
+}
+
+Require-Admin
+
+switch ($Action) {
+  'Install' { Install-BridgeTask }
+  'Start' { Start-BridgeTask }
+  'Stop' { Stop-BridgeTask }
+  'Status' { Show-BridgeTaskStatus }
+  'Uninstall' { Uninstall-BridgeTask }
+  default { Throw-BridgeTaskError "Unknown action: $Action" }
+}

--- a/scripts/ops/bridge-agent-readonly-task-contract.test.mjs
+++ b/scripts/ops/bridge-agent-readonly-task-contract.test.mjs
@@ -1,0 +1,63 @@
+import assert from 'node:assert/strict';
+import { readFile } from 'node:fs/promises';
+import { test } from 'node:test';
+
+const taskScriptPath = new URL('./bridge-agent-readonly-scheduled-task.ps1', import.meta.url);
+
+async function readTaskScript() {
+  return readFile(taskScriptPath, 'utf8');
+}
+
+function escaped(marker) {
+  return new RegExp(marker.replace(/[.*+?^${}()|[\]\\]/g, '\\$&'));
+}
+
+test('scheduled task helper installs the readonly bridge as a SYSTEM startup task', async () => {
+  const script = await readTaskScript();
+
+  for (const marker of [
+    "ValidateSet('Install', 'Start', 'Stop', 'Status', 'Uninstall')",
+    "MetaSheetReadonlyBridgeAgent",
+    "Register-ScheduledTask",
+    "New-ScheduledTaskTrigger -AtStartup",
+    "New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest",
+    "New-ScheduledTaskAction",
+    "-NoProfile",
+    "-ExecutionPolicy Bypass",
+    "bridge-agent-readonly.ps1",
+    "-ConfigPath",
+  ]) {
+    assert.match(script, escaped(marker));
+  }
+});
+
+test('scheduled task helper surfaces status without needing bridge secrets', async () => {
+  const script = await readTaskScript();
+
+  for (const marker of [
+    'Get-ScheduledTaskInfo',
+    'LastTaskResult',
+    'System.Net.Sockets.TcpClient',
+    '127.0.0.1:$Port reachable',
+    '127.0.0.1:$Port not reachable',
+  ]) {
+    assert.match(script, escaped(marker));
+  }
+
+  assert.doesNotMatch(script, /Invoke-RestMethod[\s\S]+X-MetaSheet-Bridge-Secret/i);
+});
+
+test('scheduled task helper does not print or embed Bridge Agent secrets', async () => {
+  const script = await readTaskScript();
+
+  for (const unsafe of [
+    /METASHEET_BRIDGE_SQL_PASSWORD\s*=/i,
+    /Write-(Host|Output|BridgeTaskInfo)[^\n]*METASHEET_BRIDGE_SQL_PASSWORD/i,
+    /Write-(Host|Output|BridgeTaskInfo)[^\n]*METASHEET_BRIDGE_SHARED_SECRET/i,
+    /Bearer\s+[A-Za-z0-9._~+/=-]{8,}/i,
+    /eyJ[A-Za-z0-9_-]{6,}\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+/,
+    new RegExp('Pass' + 'word=.*;', 'i'),
+  ]) {
+    assert.doesNotMatch(script, unsafe);
+  }
+});

--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -80,6 +80,7 @@ REQUIRED_PATHS=(
   "scripts/ops/bridge-agent-driver-smoke.ps1"
   "scripts/ops/fixtures/bridge-agent-driver-smoke"
   "scripts/ops/bridge-agent-readonly.ps1"
+  "scripts/ops/bridge-agent-readonly-scheduled-task.ps1"
   "scripts/ops/fixtures/bridge-agent-readonly"
   "docs/operations/k3-poc-onprem-preflight-runbook.md"
   "docs/operations/integration-k3wise-onprem-operator-handoff-checklist.md"
@@ -476,6 +477,8 @@ Legacy SQL readonly Bridge Agent tools (Windows bridge host only):
     -> BA-M0.5 driver smoke, runs connection.Open() and SELECT @@VERSION only.
   powershell -ExecutionPolicy Bypass -File scripts\ops\bridge-agent-readonly.ps1 -ConfigPath <local-config>
     -> BA-M1 localhost-only readonly bridge for allowlisted SQL views.
+  powershell -ExecutionPolicy Bypass -File scripts\ops\bridge-agent-readonly-scheduled-task.ps1 -Action Install -StartAfterInstall
+    -> persistent Windows Scheduled Task launcher for the readonly bridge.
   Runbooks:
     docs/operations/bridge-agent-driver-smoke-runbook-20260520.md
     docs/operations/bridge-agent-readonly-runbook-20260521.md

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -324,6 +324,7 @@ function verify_bridge_agent_tooling_contract() {
   local smoke_template_md="${root}/scripts/ops/fixtures/bridge-agent-driver-smoke/evidence.template.md"
   local smoke_runbook="${root}/docs/operations/bridge-agent-driver-smoke-runbook-20260520.md"
   local readonly_script="${root}/scripts/ops/bridge-agent-readonly.ps1"
+  local readonly_task_script="${root}/scripts/ops/bridge-agent-readonly-scheduled-task.ps1"
   local readonly_config="${root}/scripts/ops/fixtures/bridge-agent-readonly/config.example.json"
   local readonly_runbook="${root}/docs/operations/bridge-agent-readonly-runbook-20260521.md"
   local install_txt="${root}/INSTALL.txt"
@@ -352,6 +353,17 @@ function verify_bridge_agent_tooling_contract() {
   search_fixed_string 'sharedSecretEnvVar' "$readonly_script" || die "readonly Bridge Agent must read its shared secret from a local environment variable"
   search_fixed_string 'ConvertTo-BridgeError' "$readonly_script" || die "readonly Bridge Agent must redact returned errors"
 
+  if LC_ALL=C grep -n '[^ -~]' "$readonly_task_script" >/dev/null 2>&1; then
+    die "readonly Bridge Agent scheduled task helper must remain ASCII-safe for Windows PowerShell 5.1"
+  fi
+  search_fixed_string "ValidateSet('Install', 'Start', 'Stop', 'Status', 'Uninstall')" "$readonly_task_script" || die "readonly Bridge Agent scheduled task helper must expose install/start/stop/status/uninstall actions"
+  search_fixed_string 'MetaSheetReadonlyBridgeAgent' "$readonly_task_script" || die "readonly Bridge Agent scheduled task helper must use a stable task name"
+  search_fixed_string 'Register-ScheduledTask' "$readonly_task_script" || die "readonly Bridge Agent scheduled task helper must register a Windows Scheduled Task"
+  search_fixed_string "New-ScheduledTaskPrincipal -UserId 'SYSTEM' -LogonType ServiceAccount -RunLevel Highest" "$readonly_task_script" || die "readonly Bridge Agent scheduled task helper must run as SYSTEM"
+  search_fixed_string 'bridge-agent-readonly.ps1' "$readonly_task_script" || die "readonly Bridge Agent scheduled task helper must launch the readonly agent script"
+  search_fixed_string 'Get-ScheduledTaskInfo' "$readonly_task_script" || die "readonly Bridge Agent scheduled task helper must report LastTaskResult"
+  search_fixed_string 'System.Net.Sockets.TcpClient' "$readonly_task_script" || die "readonly Bridge Agent scheduled task helper must include a secret-free local listener check"
+
   search_fixed_string '"host": "127.0.0.1"' "$readonly_config" || die "readonly Bridge Agent example config must bind to localhost"
   search_fixed_string 'METASHEET_BRIDGE_SQL_USERNAME' "$readonly_config" || die "readonly Bridge Agent config must keep SQL username in an env var"
   search_fixed_string 'METASHEET_BRIDGE_SQL_PASSWORD' "$readonly_config" || die "readonly Bridge Agent config must keep SQL password in an env var"
@@ -364,9 +376,13 @@ function verify_bridge_agent_tooling_contract() {
   search_fixed_string 'http://127.0.0.1:19091/' "$readonly_runbook" || die "readonly Bridge Agent runbook must document localhost endpoint"
   search_fixed_string 'Raw SQL must fail' "$readonly_runbook" || die "readonly Bridge Agent runbook must document negative raw-SQL check"
   search_fixed_string 'netsh http add urlacl' "$readonly_runbook" || die "readonly Bridge Agent runbook must document HttpListener URL ACL setup"
+  search_fixed_string 'Persistent Scheduled Task Start' "$readonly_runbook" || die "readonly Bridge Agent runbook must document persistent scheduled task startup"
+  search_fixed_string 'bridge-agent-readonly-scheduled-task.ps1' "$readonly_runbook" || die "readonly Bridge Agent runbook must point operators at the scheduled task helper"
+  search_fixed_string 'Machine-level environment variables' "$readonly_runbook" || die "readonly Bridge Agent runbook must document SYSTEM environment variable handling"
 
   search_fixed_string 'bridge-agent-driver-smoke.ps1' "$install_txt" || die "INSTALL.txt must mention the BA-M0.5 Bridge Agent driver smoke"
   search_fixed_string 'bridge-agent-readonly.ps1' "$install_txt" || die "INSTALL.txt must mention the BA-M1 readonly Bridge Agent"
+  search_fixed_string 'bridge-agent-readonly-scheduled-task.ps1' "$install_txt" || die "INSTALL.txt must mention the readonly Bridge Agent scheduled task helper"
   search_fixed_string 'bridge-agent-readonly-runbook-20260521.md' "$install_txt" || die "INSTALL.txt must point operators at the readonly Bridge Agent runbook"
 }
 
@@ -597,6 +613,7 @@ required=(
   "scripts/ops/fixtures/bridge-agent-driver-smoke/evidence.template.json"
   "scripts/ops/fixtures/bridge-agent-driver-smoke/evidence.template.md"
   "scripts/ops/bridge-agent-readonly.ps1"
+  "scripts/ops/bridge-agent-readonly-scheduled-task.ps1"
   "scripts/ops/fixtures/bridge-agent-readonly/config.example.json"
   "scripts/ops/fixtures/integration-k3wise/gate-intake-template.json"
   "scripts/ops/fixtures/integration-k3wise/evidence-onsite-c4-c9-template.json"


### PR DESCRIPTION
## Summary

Adds a Windows Scheduled Task helper for the readonly Bridge Agent so BA-M2 Data Factory reads do not depend on an SSH child process staying alive. This keeps the existing Bridge Agent protocol and SQL safety model unchanged.

## Scope

- Add `scripts/ops/bridge-agent-readonly-scheduled-task.ps1` with install/start/stop/status/uninstall actions.
- Run the existing `bridge-agent-readonly.ps1` as SYSTEM at startup.
- Add a focused contract test for Scheduled Task markers and secret-free status behavior.
- Update the readonly Bridge Agent runbook with machine-level env handling and persistent task commands.
- Update on-prem package build/verify so the helper is included in zip/tgz and regression-checked.
- Add design and verification MD.

## Verification

- `node --test scripts/ops/bridge-agent-readonly-contract.test.mjs scripts/ops/bridge-agent-readonly-task-contract.test.mjs` — PASS, 7/7
- `bash -n scripts/ops/multitable-onprem-package-build.sh scripts/ops/multitable-onprem-package-verify.sh` — PASS
- `git diff --check origin/main...HEAD` — PASS
- changed-file secret-shape scan — PASS, 0 hits
- local package build with `BUILD_WEB=1 BUILD_BACKEND=1` — PASS
- package verify on generated zip and tgz — PASS
- zip/tgz content probe confirms `bridge-agent-readonly-scheduled-task.ps1` and updated runbook are packaged

## Boundaries

No plugin-integration-core runtime change, no DB migration, no frontend change, no SQL write behavior, no K3 Save/Submit/Audit. Customer GATE remains unchanged.