### PR TITLE
docs(attendance): benchmark advanced scheduling scope

### DIFF
--- a/docs/development/attendance-advanced-scheduling-benchmark-todo-20260521.md
+++ b/docs/development/attendance-advanced-scheduling-benchmark-todo-20260521.md
@@ -1,0 +1,239 @@
+# Attendance Advanced Scheduling Benchmark TODO
+
+Date: 2026-05-21
+Scope: planning / benchmark only. No runtime code, migration, route, API, or UI change in this slice.
+Source focus: DingTalk handbook advanced scheduling pages under
+`https://alidocs.dingtalk.com/i/p/Y7kmbokZp3pgGLq2/docs/...`, read from the
+left-hand "考勤高级版" menu and the visible right-hand detail pages.
+
+## Reading Coverage
+
+The DingTalk handbook body is rendered through an embedded preview frame, so the
+benchmark was read through visible page content and screenshots rather than a
+full text export. Covered pages:
+
+| Page | URL observed | Details read |
+| --- | --- | --- |
+| `管理员设置固定班制考勤` | `pq7N1kjGYznWyLOOOwxm8O43vrPX95oA` | fixed workday setup, multiple attendance time rules, shift selection, legal-holiday auto rest, special dates |
+| `电脑端排班` | `OBld...` / advanced menu detail | schedule export, day/cycle scheduling, copy/paste, copy previous week/month, batch schedule, Excel import, clear schedule, line-draw temporary shift, fullscreen, statistics, comprehensive-hours check |
+| `排班报表` | `Z0LYK27vwxp80YeBXABOWo5Olb4md9eP` | report homepage, department/person/time-dimensional visual reports |
+| `小组织管理` | `6wPdlBDrQk4JYPj2ynx2VXKx72oEGeL5` | associate attendance group/class with organization tree; create/edit/delete small org groups |
+| `排班规则` | `qXomz1wAyjKVXPMpQ7bEV3Y9pRBx5OrE` | custom schedule rules per attendance group; multi-shift day, temporary line scheduling, daily/weekly/monthly working-hour caps |
+| `排班人` | `B6L5QAmawMPJMaOKXZ4zJq1z09lnK3kb` | assign schedulers by role/position/member and restrict scheduling scope |
+| `如何新增排班班组` | `bxgzX5wq4YoJPb597wK5WRy2OB79ALPD` | group employees by work nature, shift plan, or responsibility; Excel batch import/update; role-scoped view/edit; recurring export for payroll/performance decisions |
+| `调度` | `lo1YvX0prG98kexQpv2KVPw7xzbmLdEZ` | batch staff transfer through OA approval; AI/optimized scheduling plan; production-line support scenarios |
+| `排班权限设置` | `k2wz1jPpZ30Woa5Bj49EJNnvrL4A6dxE` | assign scheduling permissions by actual role/need and control who can operate schedules |
+| `操作日志` | `65ALkBedOKwVBzXyrnOZVZq43Nxzop2P` | keep schedule operation records for audit/compliance, leave dispute handling, permission-abuse or mistake investigation |
+
+Left-hand advanced scheduling menu also includes `手机端排班`,
+`排班周期`, `高级排班调度设置`, and `插件中心`; these remain follow-up pages for
+full visual capture before implementation PRs.
+
+## DingTalk Capability Map
+
+| Domain | DingTalk capability | Product implication |
+| --- | --- | --- |
+| Shift catalog | Named shifts, time windows, multiple attendance time rules | A reusable shift catalog is the scheduling primitive. |
+| Fixed schedule | Standard workday + selected weekdays + special dates | Fixed schedules are the easy mode but still interact with holidays. |
+| Schedule workbench | Day scheduling, cycle scheduling, copy/paste, copy previous week/month | Real scheduling work needs a dense grid, not only CRUD forms. |
+| Bulk operations | Batch by group, shift, day, person; Excel import; clear by person/date | High-volume operators need bulk fill and rollback-like clearing. |
+| Temporary scheduling | Line-draw scheduling creates a temporary shift without pre-creating a catalog item | One-off staffing changes need lightweight overlays. |
+| Schedule group | Group employees by work nature, shift plan, org responsibility; Excel update | Scheduling groups are not identical to org departments. |
+| Scheduler role | Assign scheduling responsibility by role/position/member and scope | Scheduling authority is delegated and scoped. |
+| Rules | Multi-shift day, temporary line schedule, daily/weekly/monthly hour caps | The rule layer constrains both manual and automated scheduling. |
+| Cycle | Repeating cycle scheduling | Rotation sequence needs a calendar-aware cycle surface. |
+| Dispatch | OA-approved staff transfer and AI/optimized scheduling plans | Advanced scheduling includes planning/optimization, not just saved rows. |
+| Reports | Department/person/time visual reports and export | The schedule itself needs analytics before attendance is even calculated. |
+| Governance | Permission settings and operation logs | Every schedule change must be attributable and reviewable. |
+| Plugins | Comprehensive-hours plugin validates hour caps at save time | Extensibility points matter for vertical labor models. |
+
+## Current MetaSheet Attendance State
+
+| Existing MetaSheet capability | Status | Evidence anchor |
+| --- | --- | --- |
+| Shift catalog and fixed shift assignments | Covered | `AttendanceView.vue` scheduling admin + assignment routes |
+| Rotation rules and rotation assignments | Covered | `attendance-rotation-sequence-preview-*`, `attendance-rotation-assignment-preview-*` |
+| Effective calendar resolver | Covered | `attendance-effective-calendar-*`, calendar policy resolver/admin UI |
+| Group rule-set preview | Partial | `attendance-effective-calendar-group-ruleset-*`; intentionally only `groupId` preview, not full `userId` calc-chain |
+| Conflict preview and save guard | Covered | `attendance-schedule-conflict-preview-*`, `attendance-scheduling-conflict-save-*` |
+| Daily and period report sync to multitable | Covered | `attendance-report-records-*`, `attendance-report-period-rollup-*`, report sync jobs |
+| Formula / period formulas | Covered | formula hardening and period-summary formula docs |
+| Schedule dense grid | Missing | Current admin form is CRUD-oriented, not spreadsheet-like scheduling. |
+| Copy/paste and copy week/month | Missing | No scheduling grid clipboard model yet. |
+| Schedule Excel import/export | Missing | Report export exists; schedule import/export is separate. |
+| Schedule groups distinct from org departments | Partial | Attendance groups exist, but DingTalk-style scheduling groups with batch import/edit scope are not first-class. |
+| Scheduler scoped permissions | Partial | Admin roles exist, but scheduling-person scope is not first-class. |
+| Operation log for schedule changes | Partial | Audit infrastructure exists, but advanced scheduling operation log surface is not complete. |
+| Temporary line-draw shifts | Missing | No one-off shift overlay model yet. |
+| Dispatch optimization | Missing | No OA transfer / optimized scheduling planner. |
+| Mobile scheduling | Missing | Existing attendance page is responsive, but no dedicated mobile scheduling flow. |
+
+## Benchmark Verdict
+
+We can match DingTalk's advanced scheduling only if the next work moves beyond
+CRUD forms. The differentiator should not be a DingTalk clone; it should combine
+DingTalk-like operator speed with MetaSheet strengths:
+
+1. Explainable schedule chain:
+   every cell explains whether it came from fixed assignment, rotation, temporary
+   overlay, calendar policy, group rule set, or manual edit.
+2. What-if preview before save:
+   batch schedule changes show affected people/dates, conflicts, working-day
+   changes, report sync impact, and payroll-period impact before persistence.
+3. Multitable-native reporting:
+   schedule snapshots, daily records, and period summaries can be viewed,
+   filtered, formula-extended, and audited in private multitable objects.
+4. Strong governance:
+   permissions, operation logs, and backend conflict guards are first-class, not
+   just frontend warnings.
+
+## Proposed PR Roadmap
+
+### PR0 - Benchmark closeout (this document)
+
+Deliver a product/technical benchmark and lock the sequence below. No code.
+
+### PR1 - Scheduling group and scheduler-scope design lock
+
+Goal: decide the data boundary for DingTalk-like `排班班组` and `排班人`.
+
+Must answer:
+
+- Are scheduling groups separate from `attendance_groups`, or a typed extension?
+- How are scheduler scopes represented: departments, attendance groups,
+  scheduling groups, users, roles, role tags?
+- Which write paths need operation-log events?
+- What is the no-migration minimal slice, and where is migration unavoidable?
+
+Deliverables:
+
+- design MD
+- verification MD
+- no runtime change unless a tiny read-only descriptor is needed
+
+### PR2 - Read-only advanced scheduling workbench
+
+Goal: dense grid over date x user/group, reading current effective schedule.
+
+Scope:
+
+- user/group/date filters
+- fixed assignment + rotation + effective calendar explanation per cell
+- conflict badges from existing diagnostics
+- no editing yet
+
+This is the safest bridge from current CRUD forms to DingTalk-style scheduling.
+
+### PR3 - Grid edit draft and preview
+
+Goal: edit grid cells in draft mode and preview impact before save.
+
+Scope:
+
+- assign existing shift to selected cells
+- clear selected cells
+- preview affected rows and conflict diagnostics
+- save through existing assignment APIs or a new narrow batch endpoint
+
+Boundary:
+
+- no temporary shift creation yet
+- no Excel import yet
+
+### PR4 - Copy/paste and copy previous period
+
+Goal: match high-frequency DingTalk operator workflows.
+
+Scope:
+
+- copy/paste selected cells
+- copy previous week
+- copy previous month
+- deterministic preview before save
+- undo-like clear for just-created draft changes before persistence
+
+### PR5 - Schedule import/export
+
+Goal: Excel-style bulk handoff.
+
+Scope:
+
+- export schedule grid template
+- import into draft grid
+- row-level validation and error report
+- no direct write on import until preview passes
+
+### PR6 - Temporary line-draw shift overlay
+
+Goal: support one-off line scheduling without pre-creating a shift.
+
+Design boundary:
+
+- temporary shift overlay must explain itself in effective calendar.
+- overlay must not pollute the reusable shift catalog.
+- export/report must show both the temporary label and normalized work minutes.
+
+### PR7 - Scheduler permissions and operation log
+
+Goal: match governance capabilities.
+
+Scope:
+
+- scheduler role/scope assignment
+- scoped read/write enforcement on scheduling endpoints
+- operation log for create/update/delete/batch/import/copy/clear
+- audit surface in admin UI
+
+### PR8 - Schedule analytics and multitable snapshots
+
+Goal: exceed DingTalk report usefulness.
+
+Scope:
+
+- schedule-plan snapshot object, distinct from attendance facts and report records
+- department/person/time pivots
+- shift coverage, hour totals, conflict counts
+- private multitable views and formulas
+
+### PR9 - Dispatch optimization preview
+
+Goal: exceed manual scheduling with explainable suggestions.
+
+Scope:
+
+- optimization inputs: required coverage, user availability, hour caps, skills/tags
+- generated plan stays draft until approved
+- every suggestion includes an explanation and constraint score
+- OA approval / transfer workflow is a separate integration slice
+
+## Hard Boundaries
+
+- Stay focused on attendance; Data Factory / Bridge Agent work is out of this
+  window.
+- Do not let multitable objects become the attendance fact source.
+- Do not write directly to `meta_*`.
+- Do not bypass existing scheduling conflict save guards.
+- Do not add client-only validators that drift from backend schedule truth.
+- Staging/live evidence must be explicitly authorized and must not fabricate
+  pass results if credentials or seed data are missing.
+
+## Near-Term Recommendation
+
+Start with PR1, not PR2. The DingTalk pages show that `排班班组` and `排班人`
+are load-bearing concepts, not cosmetic UI labels. If we build a grid before
+deciding scheduler scope and scheduling-group ownership, later permission and
+audit fixes will be expensive.
+
+Recommended PR1 title:
+
+```text
+docs(attendance): lock advanced scheduling group and scheduler scope
+```
+
+Recommended Claude review focus for PR1:
+
+- Whether scheduling group is safely separated from org department and
+  attendance group.
+- Whether scheduler scope can enforce both read and write operations.
+- Whether operation-log requirements cover batch/import/copy/clear.
+- Whether the roadmap avoids hidden fact-source or multitable-boundary drift.

--- a/docs/development/attendance-advanced-scheduling-benchmark-verification-20260521.md
+++ b/docs/development/attendance-advanced-scheduling-benchmark-verification-20260521.md
@@ -1,0 +1,111 @@
+# Attendance Advanced Scheduling Benchmark Verification
+
+Date: 2026-05-21
+Branch: `codex/attendance-advanced-scheduling-benchmark-20260521`
+
+## Scope Verification
+
+This slice is docs-only.
+
+| Check | Result |
+| --- | --- |
+| Runtime code changed | No |
+| `plugins/plugin-attendance/index.cjs` changed | No |
+| Frontend code changed | No |
+| Migration changed | No |
+| `attendance_*` fact write changed | No |
+| Direct `meta_*` write | No |
+| Data Factory / Bridge Agent touched | No |
+
+## Source Reading Evidence
+
+The DingTalk advanced scheduling handbook was read through the in-app browser.
+The body is rendered in an embedded preview frame, so evidence came from visible
+right-hand page content rather than a full text export.
+
+Observed advanced scheduling menu entries:
+
+- `高级排班视频介绍`
+- `新手入门`
+- `客户案例`
+- `产品介绍`
+- `高级排班产品操作界面介绍`
+- `电脑端排班`
+- `手机端排班`
+- `排班报表`
+- `小组织管理`
+- `排班规则`
+- `排班人`
+- `如何新增排班班组`
+- `排班周期`
+- `调度`
+- `高级排班调度设置`
+- `排班权限设置`
+- `操作日志`
+- `插件中心`
+
+Right-hand detail pages visually read in this slice:
+
+| Page | Evidence captured |
+| --- | --- |
+| `管理员设置固定班制考勤` | Fixed workday setup, selected weekdays, shift selection, multiple attendance time rules, legal-holiday auto rest, special dates. |
+| `电脑端排班` | Export schedule, day/cycle scheduling, copy/paste, copy previous week/month, batch scheduling by group/shift/day/person, Excel import, clear schedule, line-draw temporary shift, fullscreen, statistics, comprehensive-hours validation. |
+| `排班报表` | Department/person/time-dimensional visual schedule reports. |
+| `小组织管理` | Scheduling group / attendance group / class organization association, create/edit/delete small org groups. |
+| `排班规则` | Multi-shift per day, temporary line scheduling, daily/weekly/monthly scheduling-hour caps. |
+| `排班人` | Scheduler assignment by role/position/member and scheduling scope. |
+| `如何新增排班班组` | Grouping by work nature, shift plan, or responsibility; Excel batch import/update; role-scoped view/edit; recurring export for payroll/performance decisions. |
+| `调度` | OA approval based staff transfer, AI/optimized scheduling plan, production-line support scenarios. |
+| `排班权限设置` | Permission assignment by role and business need, controlling who can perform scheduling operations. |
+| `操作日志` | Schedule operation audit for compliance, leave disputes, permission abuse, and mistake investigation. |
+
+Follow-up reading still recommended before implementation:
+
+- Full `手机端排班` detail.
+- Full `排班周期` detail.
+- Full `高级排班调度设置` detail.
+- Full `插件中心` detail.
+
+These follow-ups do not block the benchmark verdict because the current roadmap
+starts with the load-bearing `排班班组` / `排班人` scope decision.
+
+## Repo Cross-Check
+
+The benchmark was cross-checked against current `origin/main` docs and code
+anchors:
+
+| MetaSheet area | Local evidence |
+| --- | --- |
+| Effective calendar | `attendance-effective-calendar-rfc-20260520.md`, `attendance-effective-calendar-group-ruleset-*` |
+| Calendar policy | `attendance-calendar-policy-*` docs |
+| Rotation rules and assignments | `attendance-rotation-sequence-preview-*`, `attendance-rotation-assignment-preview-*` |
+| Conflict diagnostics and backend save guard | `attendance-schedule-conflict-preview-*`, `attendance-scheduling-conflict-save-*` |
+| Daily and period report sync | `attendance-report-records-*`, `attendance-report-period-rollup-*`, `attendance-report-sync-jobs-*` |
+| Frontend scheduling surfaces | `apps/web/src/views/AttendanceView.vue` rotation/fixed assignment sections |
+
+## Verification Commands
+
+```bash
+git status --short
+git diff --no-index --check /dev/null docs/development/attendance-advanced-scheduling-benchmark-todo-20260521.md
+git diff --no-index --check /dev/null docs/development/attendance-advanced-scheduling-benchmark-verification-20260521.md
+```
+
+Expected:
+
+- `git status --short`: only the two benchmark markdown files are untracked.
+- `git diff --no-index --check`: no whitespace diagnostics. Exit code `1`
+  is expected because `/dev/null` differs from each new file.
+
+## Acceptance Criteria
+
+- DingTalk advanced scheduling menu is recorded.
+- Right-hand details read are mapped into product capabilities.
+- Current MetaSheet coverage is separated into covered / partial / missing.
+- "Exceed DingTalk" strategy is explicit:
+  - explainable schedule chain
+  - save-before-impact preview
+  - multitable-native reporting
+  - governance and operation logs
+- Next PR is scoped to scheduling group and scheduler permission design before
+  dense-grid implementation.

--- a/docs/development/attendance-advanced-scheduling-group-scope-design-20260521.md
+++ b/docs/development/attendance-advanced-scheduling-group-scope-design-20260521.md
@@ -1,0 +1,324 @@
+# Attendance Advanced Scheduling Group / Scheduler Scope Design
+
+Date: 2026-05-21
+Scope: PR1 design lock only. No runtime code, route, migration, frontend, or
+staging operation in this slice.
+
+## Summary
+
+DingTalk advanced scheduling treats `排班班组` and `排班人` as load-bearing
+concepts:
+
+- `排班班组`: an operator-facing grouping used to batch schedule employees by
+  work nature, shift plan, project, or responsibility. It supports Excel batch
+  maintenance and recurring report/export decisions.
+- `排班人`: delegated scheduler users who may only operate within assigned
+  scheduling scope.
+
+MetaSheet currently has `attendance_groups`, `attendance_group_members`, RBAC,
+fixed assignments, rotation assignments, conflict save guards, effective
+calendar, and audit tables. Those pieces are necessary but not sufficient:
+`attendance_groups` represent attendance policy/rule-set ownership, while
+advanced scheduling needs an additional operational grouping and scoped
+delegation layer.
+
+## Decisions
+
+| Topic | Decision |
+| --- | --- |
+| Scheduling group ownership | Add a separate `attendance_schedule_groups` model. Do not reuse or overload `attendance_groups`. |
+| Relationship to attendance groups | Optional reference from schedule group to `attendance_groups.id`; schedule groups may also exist without an attendance group. |
+| Membership | Add date-aware schedule-group membership, separate from `attendance_group_members`. |
+| Scheduler scope | Add an attendance scheduling scope table that grants scheduler actions over schedule groups, attendance groups, users, departments, roles, or role tags. |
+| RBAC layering | Existing `attendance:admin` remains superuser. New scoped scheduler permissions are checked after coarse RBAC and before scheduling writes. |
+| Operation log | Reuse `operation_audit_logs` with attendance-specific `resource_type` / `action` values. Do not create a parallel audit fact table in v1. |
+| Multitable boundary | Advanced scheduling can later sync schedule snapshots to private multitable objects, but multitable never becomes the schedule fact source. |
+| Dense grid timing | Build read-only grid only after this scope model is locked. |
+
+## Why Not Reuse `attendance_groups`
+
+Existing `attendance_groups` already carries:
+
+- `rule_set_id`
+- timezone
+- group membership
+- effective-calendar group preview behavior
+- import/sync mapping through DingTalk group names and codes
+
+Overloading it for `排班班组` would create semantic coupling:
+
+| Need | Why `attendance_groups` is wrong |
+| --- | --- |
+| Project- or production-line based scheduling group | Not necessarily an attendance policy group. |
+| Temporary staffing group for a date range | Attendance group membership may remain stable. |
+| Multiple scheduler scopes within one attendance group | `attendance_groups` has no delegated scheduler semantics. |
+| Batch import/update of scheduling groups | Existing group import/update semantics are tied to attendance group membership. |
+| Per-schedule operation log | Existing group CRUD does not represent schedule edit actions. |
+
+Therefore `attendance_schedule_groups` is a new operational model.
+
+## Proposed Data Model
+
+This is a design contract for future implementation PRs; this PR does not add
+migrations.
+
+### `attendance_schedule_groups`
+
+```text
+id uuid primary key
+org_id text not null default 'default'
+name text not null
+code text null
+description text null
+attendance_group_id uuid null references attendance_groups(id)
+parent_id uuid null references attendance_schedule_groups(id)
+department_ref text null
+source text not null default 'manual' -- manual | import | integration
+is_active boolean not null default true
+created_by text null
+updated_by text null
+created_at timestamptz default now()
+updated_at timestamptz default now()
+```
+
+Indexes:
+
+- unique `(org_id, name)` for active names.
+- unique `(org_id, code)` where code is not null.
+- `(org_id, attendance_group_id)`.
+- `(org_id, parent_id)`.
+
+Notes:
+
+- `department_ref` is a string reference in v1 because the repo has multiple
+  department/org sources. It must not become a hard foreign key until the
+  canonical org-directory model is confirmed.
+- `parent_id` supports DingTalk-like small-organization nesting.
+- `source` supports Excel import and future integration without conflating
+  imported rows with manual rows.
+
+### `attendance_schedule_group_members`
+
+```text
+id uuid primary key
+org_id text not null default 'default'
+schedule_group_id uuid not null references attendance_schedule_groups(id)
+user_id text not null
+effective_from date null
+effective_to date null
+role text null -- member | lead | backup
+source text not null default 'manual'
+created_by text null
+updated_by text null
+created_at timestamptz default now()
+updated_at timestamptz default now()
+```
+
+Indexes:
+
+- `(org_id, schedule_group_id)`.
+- `(org_id, user_id)`.
+- `(org_id, schedule_group_id, user_id, effective_from, effective_to)`.
+
+Contract:
+
+- Membership is date-aware so a future schedule grid can answer "who belonged
+  to this scheduling group on this day?"
+- Overlap policy for one user in the same schedule group is strict: overlapping
+  active membership windows should be rejected or merged by an explicit import
+  preview. Do not silently create duplicates.
+- Membership does not change `attendance_group_members`.
+
+### `attendance_scheduler_scopes`
+
+```text
+id uuid primary key
+org_id text not null default 'default'
+subject_type text not null -- user | role | role_tag
+subject_ref text not null
+actions text[] not null -- view | edit | import | export | clear | approve | dispatch
+scope jsonb not null
+is_active boolean not null default true
+created_by text null
+updated_by text null
+created_at timestamptz default now()
+updated_at timestamptz default now()
+```
+
+Recommended `scope` shape:
+
+```json
+{
+  "scheduleGroupIds": [],
+  "attendanceGroupIds": [],
+  "userIds": [],
+  "departments": [],
+  "roles": [],
+  "roleTags": []
+}
+```
+
+Contract:
+
+- Empty scope is invalid for scoped schedulers. Only `attendance:admin` may act
+  globally.
+- `actions` must be explicit; `view` does not imply `edit`, and `edit` does not
+  imply `import` or `clear`.
+- Role and role-tag subjects use existing RBAC/role context; this table is not
+  a replacement for `user_roles`.
+- If RBAC tables are degraded, scoped scheduler checks fail closed.
+
+## Permission Model
+
+Future scheduling endpoints should apply two layers:
+
+1. Coarse access:
+   - `attendance:admin` or a new broad `attendance:schedule` permission enters
+     the scheduling module.
+   - `attendance:admin` bypasses scoped checks.
+2. Scoped scheduling access:
+   - Non-admin users must match an active `attendance_scheduler_scopes` row for
+     the requested action and target people/dates/groups.
+
+Target context for scope checks:
+
+```ts
+interface ScheduleTargetContext {
+  orgId: string
+  action: 'view' | 'edit' | 'import' | 'export' | 'clear' | 'approve' | 'dispatch'
+  userIds: string[]
+  scheduleGroupIds?: string[]
+  attendanceGroupIds?: string[]
+  departments?: string[]
+  roles?: string[]
+  roleTags?: string[]
+  from?: string
+  to?: string
+}
+```
+
+Rules:
+
+- `view`: all returned rows must be within scope or filtered out.
+- `edit` / `clear`: all targeted rows must be within scope; partial writes are
+  rejected unless the endpoint explicitly supports per-row results.
+- `import`: preview may show out-of-scope rows as rejected; commit must not write
+  them.
+- `export`: export body must be scoped, not just the UI query.
+- `dispatch`: reserved for future optimizer / OA-transfer flow.
+
+## Operation Log Contract
+
+Reuse `operation_audit_logs`.
+
+Recommended values:
+
+| Operation | action | resource_type |
+| --- | --- | --- |
+| schedule group create/update/delete | `attendance.schedule_group.create/update/delete` | `attendance_schedule_group` |
+| schedule group membership import/update | `attendance.schedule_group_members.import/update` | `attendance_schedule_group` |
+| scheduler scope create/update/delete | `attendance.scheduler_scope.create/update/delete` | `attendance_scheduler_scope` |
+| grid cell edit | `attendance.schedule_grid.edit` | `attendance_schedule_assignment` |
+| grid clear | `attendance.schedule_grid.clear` | `attendance_schedule_assignment` |
+| copy previous week/month | `attendance.schedule_grid.copy_period` | `attendance_schedule_assignment` |
+| Excel import preview/commit | `attendance.schedule_import.preview/commit` | `attendance_schedule_import` |
+| temporary line-draw shift | `attendance.temporary_shift.create/update/delete` | `attendance_temporary_shift` |
+| dispatch plan preview/commit | `attendance.dispatch.preview/commit` | `attendance_dispatch_plan` |
+
+Minimum metadata:
+
+```json
+{
+  "orgId": "default",
+  "actorId": "user-1",
+  "source": "ui|import|api|job",
+  "from": "2026-05-01",
+  "to": "2026-05-31",
+  "targetCounts": {
+    "users": 12,
+    "dates": 31,
+    "cells": 372
+  },
+  "scope": {
+    "scheduleGroupIds": [],
+    "attendanceGroupIds": []
+  },
+  "fingerprintBefore": "...",
+  "fingerprintAfter": "...",
+  "requestId": "..."
+}
+```
+
+Do not log raw Excel file contents or secrets.
+
+## API Roadmap
+
+### PR2 read-only descriptors
+
+Before a grid exists, add read-only endpoints:
+
+- `GET /api/attendance/schedule-groups`
+- `GET /api/attendance/schedule-groups/:id/members`
+- `GET /api/attendance/scheduler-scopes`
+
+All require `attendance:admin` in PR2. Scoped non-admin access comes only after
+the scope checker is implemented.
+
+### PR3 scope checker
+
+Add helper:
+
+```ts
+canScheduleForScope(db, actorId, targetContext, options)
+```
+
+Test:
+
+- admin global pass
+- user subject pass
+- role subject pass
+- role tag pass
+- out-of-scope read filters or rejects
+- out-of-scope write rejects
+- RBAC schema degraded fails closed for scoped scheduler
+
+### PR4 read-only dense workbench
+
+Uses:
+
+- `attendance_schedule_groups`
+- current fixed and rotation assignment readers
+- effective calendar explanation
+- existing conflict diagnostics
+
+No editing yet.
+
+### PR5 write paths and logs
+
+Only after PR4 proves the read model:
+
+- batch grid edit
+- clear
+- copy previous week/month
+- operation-log writes
+- backend conflict guard remains authoritative
+
+## Out of Scope
+
+- Excel import/export implementation.
+- Temporary line-draw shift implementation.
+- Dispatch optimizer.
+- Mobile scheduling UI.
+- Multitable schedule snapshot object.
+- Any Data Factory / Bridge Agent work.
+
+## Review Checklist
+
+Claude / reviewer should check:
+
+- `attendance_schedule_groups` is separate from `attendance_groups`.
+- `attendance_group_members` remains unchanged by schedule-group membership.
+- scoped scheduler checks fail closed when RBAC is unavailable.
+- every future write operation has a named operation-log action.
+- no multitable object is proposed as schedule fact source.
+- no client-only validator becomes scheduling truth.

--- a/docs/development/attendance-advanced-scheduling-group-scope-verification-20260521.md
+++ b/docs/development/attendance-advanced-scheduling-group-scope-verification-20260521.md
@@ -1,0 +1,72 @@
+# Attendance Advanced Scheduling Group / Scheduler Scope Verification
+
+Date: 2026-05-21
+Branch: `codex/attendance-advanced-scheduling-benchmark-20260521`
+
+## Scope
+
+PR1 is design-only. It locks the next implementation boundaries for DingTalk-like
+`排班班组` and `排班人` without changing runtime behavior.
+
+| Area | Result |
+| --- | --- |
+| Runtime code | Not changed |
+| Frontend code | Not changed |
+| Migration | Not changed |
+| `plugins/plugin-attendance/index.cjs` | Not changed |
+| `attendance_*` fact writes | Not changed |
+| Direct `meta_*` writes | Not changed |
+| Data Factory / Bridge Agent | Not touched |
+
+## Code Orientation Evidence
+
+The design was checked against current `origin/main` implementation:
+
+| Existing surface | Evidence | Design implication |
+| --- | --- | --- |
+| Attendance groups | `zzzz20260204123000_create_attendance_groups.ts` creates `attendance_groups` with `rule_set_id`, timezone, description, plus `attendance_group_members`. | Do not overload this model for scheduling groups; it already owns attendance policy semantics. |
+| Attendance group routes | `plugins/plugin-attendance/index.cjs` exposes `/api/attendance/groups` CRUD with `attendance:admin`. | Scheduling groups need a separate route family and should not mutate attendance group membership. |
+| RBAC | `createRbacHelpers()` checks `user_permissions`, `user_roles`, and `role_permissions`. | Scoped scheduler access should layer on top of RBAC; `attendance:admin` remains global. |
+| Role context | Existing role/role-tag extraction supports calendar policy filters. | Scheduler scopes can reuse users/roles/roleTags, but must still fail closed on writes. |
+| Conflict save guard | `attendance-scheduling-conflict-save-*` documents backend 409 conflict enforcement. | Future grid/bulk writes must not bypass the guard. |
+| Operation audit | `operation_audit_logs` exists and is schema-hardened with `occurred_at` and `meta`. | v1 should reuse this audit table instead of introducing a parallel operation-log fact store. |
+| Report multitable sync | report-records / period-summaries docs lock multitable as rebuildable report layer. | Future schedule snapshots may be multitable, but schedule truth remains SQL attendance models. |
+
+## Design Decisions Verified
+
+| Decision | Verification |
+| --- | --- |
+| `attendance_schedule_groups` separate from `attendance_groups` | Avoids mixing rule-set/timezone policy groups with operational scheduling groups. |
+| Date-aware schedule group membership | Supports "who belonged to this schedule group on this day" for future grid and import previews. |
+| Scoped scheduler table | Covers DingTalk `排班人` semantics: scheduler by user/role/role tag with explicit scope and action list. |
+| `attendance:admin` bypass + scoped non-admin fail-closed | Preserves current admin behavior while preventing degraded RBAC from granting scheduling power. |
+| `operation_audit_logs` reuse | Matches existing audit schema and avoids new fact-source drift. |
+| Dense grid deferred | Prevents building UI before permission/scope ownership is known. |
+
+## Verification Commands
+
+```bash
+git status --short
+git diff --no-index --check /dev/null docs/development/attendance-advanced-scheduling-benchmark-todo-20260521.md
+git diff --no-index --check /dev/null docs/development/attendance-advanced-scheduling-benchmark-verification-20260521.md
+git diff --no-index --check /dev/null docs/development/attendance-advanced-scheduling-group-scope-design-20260521.md
+git diff --no-index --check /dev/null docs/development/attendance-advanced-scheduling-group-scope-verification-20260521.md
+```
+
+Expected:
+
+- `git status --short`: only four new markdown files.
+- `git diff --no-index --check`: no whitespace diagnostics. Exit code `1`
+  is expected because `/dev/null` differs from each new file.
+
+## Acceptance Criteria
+
+- Scheduling group is explicitly separate from attendance group.
+- Scheduler scope model is explicit and action-scoped.
+- Existing RBAC and `attendance:admin` behavior are preserved.
+- Future writes have an operation-log contract.
+- Future grid/bulk/import paths must go through backend conflict guards.
+- The next coding PR can be either:
+  - read-only `attendance_schedule_groups` descriptor/routes; or
+  - schema migration + focused unit tests for schedule groups and scheduler
+    scopes.


### PR DESCRIPTION
## Summary

- Records the DingTalk advanced scheduling benchmark reading and maps it against the current MetaSheet attendance implementation.
- Adds the proposed advanced-scheduling roadmap and locks the first design slice for schedule groups, scheduler scopes, and audit boundaries.
- Adds verification notes for the docs-only scope and repo orientation.

## Boundaries

- Docs only: no runtime code, frontend, backend route, migration, staging/prod write, or Data Factory change.
- Attendance remains the only domain in scope.
- Future implementation keeps multitable outputs rebuildable and does not make them attendance facts.

## Verification

- `git diff --no-index --check /dev/null <new-md>` for each new markdown file
- `git diff --cached --check` before commit
- staged boundary checked: exactly 4 docs files
