### PR TITLE
feat(multitable): localize automation DingTalk chrome (T3D-4)

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationManager.vue
+++ b/apps/web/src/multitable/components/MetaAutomationManager.vue
@@ -74,32 +74,32 @@
 
           <template v-if="draft.actionType === 'send_dingtalk_group_message'">
             <div class="meta-automation__preset-row">
-              <span class="meta-automation__preset-label">Message preset</span>
-              <button class="meta-automation__btn" type="button" data-automation-preset="group-form" @click="applyGroupPreset('form_request')">Form request</button>
-              <button class="meta-automation__btn" type="button" data-automation-preset="group-internal" @click="applyGroupPreset('internal_process')">Internal processing</button>
-              <button class="meta-automation__btn" type="button" data-automation-preset="group-both" @click="applyGroupPreset('form_and_process')">Form + processing</button>
+              <span class="meta-automation__preset-label">{{ l('dingtalk.preset') }}</span>
+              <button class="meta-automation__btn" type="button" data-automation-preset="group-form" @click="applyGroupPreset('form_request')">{{ automationDingTalkPresetLabel('form_request', isZh) }}</button>
+              <button class="meta-automation__btn" type="button" data-automation-preset="group-internal" @click="applyGroupPreset('internal_process')">{{ automationDingTalkPresetLabel('internal_process', isZh) }}</button>
+              <button class="meta-automation__btn" type="button" data-automation-preset="group-both" @click="applyGroupPreset('form_and_process')">{{ automationDingTalkPresetLabel('form_and_process', isZh) }}</button>
             </div>
-            <label class="meta-automation__label">Add DingTalk groups</label>
+            <label class="meta-automation__label">{{ l('dingtalk.addGroups') }}</label>
             <select
               v-model="draft.dingtalkDestinationPickerId"
               class="meta-automation__select"
               data-automation-field="dingtalkDestinationPickerId"
               @change="appendDingTalkGroupDestination($event.target as HTMLSelectElement)"
             >
-              <option value="">-- add DingTalk group --</option>
+              <option value="">{{ l('dingtalk.addGroupOption') }}</option>
               <option v-for="destination in availableDingTalkGroupDestinations" :key="destination.id" :value="destination.id">
                 {{ destination.name }} · {{ dingTalkDestinationScopeLabel(destination) }}
               </option>
             </select>
             <div class="meta-automation__hint" data-automation-field="dingtalkDestinationPickerHint">
-              DingTalk groups registered for this table or shared from the organization catalog are listed here.
+              {{ l('dingtalk.groupsRegisteredHint') }}
             </div>
             <div
               v-if="!dingTalkDestinations.length"
               class="meta-automation__hint"
               data-automation-field="dingtalkDestinationEmpty"
             >
-              No DingTalk groups are available for this table yet. Add one in API Tokens &amp; Webhooks &gt; DingTalk Groups, ask an admin to share an organization catalog group, or use a record group field path below.
+              {{ l('dingtalk.noGroupsAvailable') }}
             </div>
             <div
               v-if="selectedDingTalkGroupDestinations.length"
@@ -115,10 +115,10 @@
               >
                 <strong>{{ destination.label }}</strong>
                 <span>{{ destination.subtitle || destination.id }}</span>
-                <em>Remove</em>
+                <em>{{ l('dingtalk.remove') }}</em>
               </button>
             </div>
-            <label class="meta-automation__label">Record group field paths (optional)</label>
+            <label class="meta-automation__label">{{ l('dingtalk.recordGroupFieldPaths') }}</label>
             <input
               v-model="draft.dingtalkDestinationFieldPath"
               class="meta-automation__input"
@@ -126,13 +126,13 @@
               placeholder="record.opsDestinationId, record.escalationDestinationIds"
               data-automation-field="dingtalkDestinationFieldPath"
             />
-            <label class="meta-automation__label">Pick group field</label>
+            <label class="meta-automation__label">{{ l('dingtalk.pickGroupField') }}</label>
             <select
               class="meta-automation__select"
               data-automation-field="dingtalkDestinationFieldSelect"
               @change="appendDingTalkGroupDestinationField($event.target as HTMLSelectElement)"
             >
-              <option value="">-- pick field --</option>
+              <option value="">{{ l('dingtalk.pickFieldOption') }}</option>
               <option v-for="field in dingTalkGroupDestinationCandidateFields" :key="field.id" :value="field.id">
                 {{ field.name }}
               </option>
@@ -151,7 +151,7 @@
               >
                 <strong>{{ field.label }}</strong>
                 <span>{{ field.id }}</span>
-                <em>Remove</em>
+                <em>{{ l('dingtalk.remove') }}</em>
               </button>
             </div>
             <div
@@ -161,12 +161,12 @@
             >
               {{ warning }}
             </div>
-            <label class="meta-automation__label">Title template</label>
+            <label class="meta-automation__label">{{ l('dingtalk.titleTemplate') }}</label>
             <input
               v-model="draft.dingtalkTitleTemplate"
               class="meta-automation__input"
               type="text"
-              placeholder="例如：{{record.title}} 待处理"
+              :placeholder="l('dingtalk.titleTemplatePlaceholder')"
               data-automation-field="dingtalkTitleTemplate"
             />
             <div
@@ -177,7 +177,7 @@
               {{ warning }}
             </div>
             <div class="meta-automation__preset-row">
-              <span class="meta-automation__preset-label">Template tokens</span>
+              <span class="meta-automation__preset-label">{{ l('dingtalk.templateTokens') }}</span>
               <button
                 v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
                 :key="token.key"
@@ -186,15 +186,15 @@
                 :data-automation-token="`group-title-${token.key}`"
                 @click="appendGroupTemplateToken('title', token.value)"
               >
-                {{ token.label }}
+                {{ dingTalkTemplateTokenLabel(token, isZh) }}
               </button>
             </div>
-            <label class="meta-automation__label">Body template</label>
+            <label class="meta-automation__label">{{ l('dingtalk.bodyTemplate') }}</label>
             <textarea
               v-model="draft.dingtalkBodyTemplate"
               class="meta-automation__input"
               rows="4"
-              placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
+              :placeholder="l('dingtalk.bodyTemplatePlaceholder')"
               data-automation-field="dingtalkBodyTemplate"
             ></textarea>
             <div
@@ -205,7 +205,7 @@
               {{ warning }}
             </div>
             <div class="meta-automation__preset-row">
-              <span class="meta-automation__preset-label">Template tokens</span>
+              <span class="meta-automation__preset-label">{{ l('dingtalk.templateTokens') }}</span>
               <button
                 v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
                 :key="token.key"
@@ -214,12 +214,12 @@
                 :data-automation-token="`group-body-${token.key}`"
                 @click="appendGroupTemplateToken('body', token.value)"
               >
-                {{ token.label }}
+                {{ dingTalkTemplateTokenLabel(token, isZh) }}
               </button>
             </div>
-            <label class="meta-automation__label">Public form view (optional)</label>
+            <label class="meta-automation__label">{{ l('dingtalk.publicFormView') }}</label>
             <select v-model="draft.publicFormViewId" class="meta-automation__select" data-automation-field="publicFormViewId">
-              <option value="">-- no public form link --</option>
+              <option value="">{{ l('dingtalk.noPublicFormLinkOption') }}</option>
               <option v-for="view in formViews" :key="view.id" :value="view.id">{{ view.name }}</option>
             </select>
             <div
@@ -229,9 +229,9 @@
             >
               {{ warning }}
             </div>
-            <label class="meta-automation__label">Internal processing view (optional)</label>
+            <label class="meta-automation__label">{{ l('dingtalk.internalProcessingView') }}</label>
             <select v-model="draft.internalViewId" class="meta-automation__select" data-automation-field="internalViewId">
-              <option value="">-- no internal link --</option>
+              <option value="">{{ l('dingtalk.noInternalLinkOption') }}</option>
               <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
             </select>
             <div
@@ -242,66 +242,66 @@
               {{ warning }}
             </div>
             <div class="meta-automation__preview" data-automation-summary="group">
-              <div class="meta-automation__preview-title">Message summary</div>
-              <div><strong>Groups:</strong> {{ dingTalkGroupSummary }}</div>
-              <div><strong>Record groups:</strong> {{ dingTalkGroupFieldSummary }}</div>
-              <div><strong>Title template:</strong> {{ templatePreviewText(draft.dingtalkTitleTemplate, 'No title template') }}</div>
-              <div class="meta-automation__preview-body"><strong>Body template:</strong> {{ templatePreviewText(draft.dingtalkBodyTemplate, 'No body template') }}</div>
+              <div class="meta-automation__preview-title">{{ l('dingtalk.messageSummary') }}</div>
+              <div><strong>{{ l('dingtalk.groups') }}:</strong> {{ dingTalkGroupSummary }}</div>
+              <div><strong>{{ l('dingtalk.recordGroups') }}:</strong> {{ dingTalkGroupFieldSummary }}</div>
+              <div><strong>{{ l('dingtalk.titleTemplate') }}:</strong> {{ templatePreviewText(draft.dingtalkTitleTemplate, l('dingtalk.noTitleTemplate')) }}</div>
+              <div class="meta-automation__preview-body"><strong>{{ l('dingtalk.bodyTemplate') }}:</strong> {{ templatePreviewText(draft.dingtalkBodyTemplate, l('dingtalk.noBodyTemplate')) }}</div>
               <div class="meta-automation__preview-line">
-                <span><strong>Rendered title:</strong> {{ renderedTemplateExample(draft.dingtalkTitleTemplate, 'No rendered title') }}</span>
+                <span><strong>{{ l('dingtalk.renderedTitle') }}:</strong> {{ renderedTemplateExample(draft.dingtalkTitleTemplate, l('dingtalk.noRenderedTitle')) }}</span>
                 <button
                   class="meta-automation__copy-btn"
                   type="button"
                   data-automation-copy="group-rendered-title"
                   @click="copyPreviewText('group-title', renderedTemplateExample(draft.dingtalkTitleTemplate, ''))"
                 >
-                  {{ copiedPreviewKey === 'group-title' ? 'Copied' : 'Copy' }}
+                  {{ copiedPreviewKey === 'group-title' ? l('dingtalk.copied') : l('dingtalk.copy') }}
                 </button>
               </div>
               <div class="meta-automation__preview-line meta-automation__preview-body">
-                <span><strong>Rendered body:</strong> {{ renderedTemplateExample(draft.dingtalkBodyTemplate, 'No rendered body') }}</span>
+                <span><strong>{{ l('dingtalk.renderedBody') }}:</strong> {{ renderedTemplateExample(draft.dingtalkBodyTemplate, l('dingtalk.noRenderedBody')) }}</span>
                 <button
                   class="meta-automation__copy-btn"
                   type="button"
                   data-automation-copy="group-rendered-body"
                   @click="copyPreviewText('group-body', renderedTemplateExample(draft.dingtalkBodyTemplate, ''))"
                 >
-                  {{ copiedPreviewKey === 'group-body' ? 'Copied' : 'Copy' }}
+                  {{ copiedPreviewKey === 'group-body' ? l('dingtalk.copied') : l('dingtalk.copy') }}
                 </button>
               </div>
-              <div><strong>Public form:</strong> {{ viewSummaryName(draft.publicFormViewId, 'No public form link') }}</div>
+              <div><strong>{{ l('dingtalk.publicForm') }}:</strong> {{ viewSummaryName(draft.publicFormViewId, l('dingtalk.noPublicFormLink')) }}</div>
               <div
                 class="meta-automation__public-form-access"
                 :class="`meta-automation__public-form-access--${draftGroupPublicFormAccessState.level}`"
                 data-automation-public-form-access="group"
                 :data-access-level="draftGroupPublicFormAccessState.level"
               >
-                <strong>Public form access:</strong> {{ draftGroupPublicFormAccessState.summary }}
+                <strong>{{ l('dingtalk.publicFormAccess') }}:</strong> {{ draftGroupPublicFormAccessState.summary }}
               </div>
               <div data-automation-public-form-audience="group">
-                <strong>Allowed audience:</strong> {{ draftGroupPublicFormAccessState.audienceSummary }}
+                <strong>{{ l('dingtalk.allowedAudience') }}:</strong> {{ draftGroupPublicFormAccessState.audienceSummary }}
               </div>
-              <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.internalViewId, 'No internal link') }}</div>
+              <div><strong>{{ l('dingtalk.internalProcessing') }}:</strong> {{ viewSummaryName(draft.internalViewId, l('dingtalk.noInternalLink')) }}</div>
             </div>
           </template>
 
           <template v-if="draft.actionType === 'send_dingtalk_person_message'">
             <div class="meta-automation__preset-row">
-              <span class="meta-automation__preset-label">Message preset</span>
-              <button class="meta-automation__btn" type="button" data-automation-preset="person-form" @click="applyPersonPreset('form_request')">Form request</button>
-              <button class="meta-automation__btn" type="button" data-automation-preset="person-internal" @click="applyPersonPreset('internal_process')">Internal processing</button>
-              <button class="meta-automation__btn" type="button" data-automation-preset="person-both" @click="applyPersonPreset('form_and_process')">Form + processing</button>
+              <span class="meta-automation__preset-label">{{ l('dingtalk.preset') }}</span>
+              <button class="meta-automation__btn" type="button" data-automation-preset="person-form" @click="applyPersonPreset('form_request')">{{ automationDingTalkPresetLabel('form_request', isZh) }}</button>
+              <button class="meta-automation__btn" type="button" data-automation-preset="person-internal" @click="applyPersonPreset('internal_process')">{{ automationDingTalkPresetLabel('internal_process', isZh) }}</button>
+              <button class="meta-automation__btn" type="button" data-automation-preset="person-both" @click="applyPersonPreset('form_and_process')">{{ automationDingTalkPresetLabel('form_and_process', isZh) }}</button>
             </div>
-            <label class="meta-automation__label">Search and add users or member groups</label>
+            <label class="meta-automation__label">{{ l('dingtalk.searchUsersOrGroups') }}</label>
             <input
               v-model="dingtalkPersonUserSearch"
               class="meta-automation__input"
               type="text"
-              placeholder="Search by user, member group, email, or subject ID"
+              :placeholder="l('dingtalk.searchUsersOrGroupsPlaceholder')"
               data-automation-field="dingtalkPersonUserSearch"
               @input="void loadDingTalkPersonSuggestions()"
             />
-            <div v-if="dingtalkPersonUserSearchLoading" class="meta-automation__hint">Searching users and member groups…</div>
+            <div v-if="dingtalkPersonUserSearchLoading" class="meta-automation__hint">{{ l('dingtalk.searchingUsersOrGroups') }}</div>
             <div v-else-if="dingtalkPersonUserSearchError" class="meta-automation__hint meta-automation__hint--error">{{ dingtalkPersonUserSearchError }}</div>
             <div v-else-if="availableDingTalkPersonSuggestions.length" class="meta-automation__recipient-list">
               <button
@@ -318,10 +318,10 @@
                 <span>{{ personRecipientSubjectLabel(candidate) }}</span>
                 <span v-if="candidate.accessLevel">{{ personRecipientAccessLabel(candidate.accessLevel) }}</span>
                 <span v-if="personRecipientDingTalkStatusLabel(candidate.subjectType, candidate)">{{ personRecipientDingTalkStatusLabel(candidate.subjectType, candidate) }}</span>
-                <span v-if="isInactivePersonRecipientCandidate(candidate)">Inactive users cannot be added</span>
+                <span v-if="isInactivePersonRecipientCandidate(candidate)">{{ l('dingtalk.inactiveUsersCannotBeAdded') }}</span>
               </button>
             </div>
-            <div v-else-if="dingtalkPersonUserSearch.trim()" class="meta-automation__hint">No matching users or member groups</div>
+            <div v-else-if="dingtalkPersonUserSearch.trim()" class="meta-automation__hint">{{ l('dingtalk.noMatchingUsersOrGroups') }}</div>
             <div v-if="selectedDingTalkPersonRecipients.length" class="meta-automation__recipient-list meta-automation__recipient-list--selected">
               <button
                 v-for="recipient in selectedDingTalkPersonRecipients"
@@ -334,7 +334,7 @@
                 <strong>{{ recipient.label }}</strong>
                 <span>{{ recipient.subtitle || recipient.id }}</span>
                 <span v-if="personRecipientDingTalkStatusLabel('user', recipient)">{{ personRecipientDingTalkStatusLabel('user', recipient) }}</span>
-                <em>Remove</em>
+                <em>{{ l('dingtalk.remove') }}</em>
               </button>
             </div>
             <div v-if="selectedDingTalkPersonMemberGroups.length" class="meta-automation__recipient-list meta-automation__recipient-list--selected">
@@ -349,40 +349,40 @@
                 <strong>{{ group.label }}</strong>
                 <span>{{ group.subtitle || group.id }}</span>
                 <span v-if="personRecipientDingTalkStatusLabel('member-group', group)">{{ personRecipientDingTalkStatusLabel('member-group', group) }}</span>
-                <em>Remove</em>
+                <em>{{ l('dingtalk.remove') }}</em>
               </button>
             </div>
-            <label class="meta-automation__label">Local user IDs</label>
+            <label class="meta-automation__label">{{ l('dingtalk.localUserIds') }}</label>
             <textarea
               v-model="draft.dingtalkPersonUserIds"
               class="meta-automation__input"
               rows="3"
-              placeholder="使用逗号或换行分隔本地 userId"
+              :placeholder="l('dingtalk.localUserIdsPlaceholder')"
               data-automation-field="dingtalkPersonUserIds"
             ></textarea>
-            <label class="meta-automation__label">Member group IDs (optional)</label>
+            <label class="meta-automation__label">{{ l('dingtalk.memberGroupIds') }}</label>
             <textarea
               v-model="draft.dingtalkPersonMemberGroupIds"
               class="meta-automation__input"
               rows="2"
-              placeholder="使用逗号或换行分隔成员组 ID"
+              :placeholder="l('dingtalk.memberGroupIdsPlaceholder')"
               data-automation-field="dingtalkPersonMemberGroupIds"
             ></textarea>
-            <label class="meta-automation__label">Record recipient field paths (optional)</label>
+            <label class="meta-automation__label">{{ l('dingtalk.recordRecipientFieldPaths') }}</label>
             <input
               v-model="draft.dingtalkPersonRecipientFieldPath"
               class="meta-automation__input"
               type="text"
-              placeholder="例如：record.assigneeUserIds, record.reviewerUserId"
+              :placeholder="l('dingtalk.recordRecipientFieldPathPlaceholder')"
               data-automation-field="dingtalkPersonRecipientFieldPath"
             />
-            <label class="meta-automation__label">Pick recipient field</label>
+            <label class="meta-automation__label">{{ l('dingtalk.pickRecipientField') }}</label>
             <select
               class="meta-automation__select"
               data-automation-field="dingtalkPersonRecipientFieldSelect"
               @change="appendDingTalkPersonRecipientField($event.target as HTMLSelectElement)"
             >
-              <option value="">-- choose a user field --</option>
+              <option value="">{{ l('dingtalk.chooseUserFieldOption') }}</option>
               <option v-for="field in dingTalkPersonRecipientCandidateFields" :key="field.id" :value="field.id">
                 {{ field.name }} (record.{{ field.id }})
               </option>
@@ -400,7 +400,7 @@
                 @click="removeDingTalkPersonRecipientField(field.id)"
               >
                 <strong>{{ field.label }}</strong>
-                <em>Remove</em>
+                <em>{{ l('dingtalk.remove') }}</em>
               </button>
             </div>
             <div
@@ -411,23 +411,23 @@
               {{ warning }}
             </div>
             <div class="meta-automation__hint">
-              Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths. The picker only lists user fields.
+              {{ l('dingtalk.recordRecipientFieldPathHint') }}
             </div>
-            <label class="meta-automation__label">Record member group field paths (optional)</label>
+            <label class="meta-automation__label">{{ l('dingtalk.recordMemberGroupFieldPaths') }}</label>
             <input
               v-model="draft.dingtalkPersonMemberGroupRecipientFieldPath"
               class="meta-automation__input"
               type="text"
-              placeholder="例如：record.watcherGroupIds, record.escalationGroupId"
+              :placeholder="l('dingtalk.recordMemberGroupFieldPathPlaceholder')"
               data-automation-field="dingtalkPersonMemberGroupRecipientFieldPath"
             />
-            <label class="meta-automation__label">Pick member group field</label>
+            <label class="meta-automation__label">{{ l('dingtalk.pickMemberGroupField') }}</label>
             <select
               class="meta-automation__select"
               data-automation-field="dingtalkPersonMemberGroupRecipientFieldSelect"
               @change="appendDingTalkPersonMemberGroupRecipientField($event.target as HTMLSelectElement)"
             >
-              <option value="">-- choose a member group field --</option>
+              <option value="">{{ l('dingtalk.chooseMemberGroupFieldOption') }}</option>
               <option v-for="field in dingTalkPersonMemberGroupRecipientCandidateFields" :key="field.id" :value="field.id">
                 {{ field.name }} (record.{{ field.id }})
               </option>
@@ -445,7 +445,7 @@
                 @click="removeDingTalkPersonMemberGroupRecipientField(field.id)"
               >
                 <strong>{{ field.label }}</strong>
-                <em>Remove</em>
+                <em>{{ l('dingtalk.remove') }}</em>
               </button>
             </div>
             <div
@@ -456,14 +456,14 @@
               {{ warning }}
             </div>
             <div class="meta-automation__hint">
-              Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths whose values resolve to member group IDs. The picker only lists explicit member group fields.
+              {{ l('dingtalk.recordMemberGroupFieldPathHint') }}
             </div>
-            <label class="meta-automation__label">Title template</label>
+            <label class="meta-automation__label">{{ l('dingtalk.titleTemplate') }}</label>
             <input
               v-model="draft.dingtalkPersonTitleTemplate"
               class="meta-automation__input"
               type="text"
-              placeholder="例如：{{record.title}} 待处理"
+              :placeholder="l('dingtalk.titleTemplatePlaceholder')"
               data-automation-field="dingtalkPersonTitleTemplate"
             />
             <div
@@ -474,7 +474,7 @@
               {{ warning }}
             </div>
             <div class="meta-automation__preset-row">
-              <span class="meta-automation__preset-label">Template tokens</span>
+              <span class="meta-automation__preset-label">{{ l('dingtalk.templateTokens') }}</span>
               <button
                 v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
                 :key="token.key"
@@ -483,15 +483,15 @@
                 :data-automation-token="`person-title-${token.key}`"
                 @click="appendPersonTemplateToken('title', token.value)"
               >
-                {{ token.label }}
+                {{ dingTalkTemplateTokenLabel(token, isZh) }}
               </button>
             </div>
-            <label class="meta-automation__label">Body template</label>
+            <label class="meta-automation__label">{{ l('dingtalk.bodyTemplate') }}</label>
             <textarea
               v-model="draft.dingtalkPersonBodyTemplate"
               class="meta-automation__input"
               rows="4"
-              placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
+              :placeholder="l('dingtalk.bodyTemplatePlaceholder')"
               data-automation-field="dingtalkPersonBodyTemplate"
             ></textarea>
             <div
@@ -502,7 +502,7 @@
               {{ warning }}
             </div>
             <div class="meta-automation__preset-row">
-              <span class="meta-automation__preset-label">Template tokens</span>
+              <span class="meta-automation__preset-label">{{ l('dingtalk.templateTokens') }}</span>
               <button
                 v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
                 :key="token.key"
@@ -511,12 +511,12 @@
                 :data-automation-token="`person-body-${token.key}`"
                 @click="appendPersonTemplateToken('body', token.value)"
               >
-                {{ token.label }}
+                {{ dingTalkTemplateTokenLabel(token, isZh) }}
               </button>
             </div>
-            <label class="meta-automation__label">Public form view (optional)</label>
+            <label class="meta-automation__label">{{ l('dingtalk.publicFormView') }}</label>
             <select v-model="draft.dingtalkPersonPublicFormViewId" class="meta-automation__select" data-automation-field="dingtalkPersonPublicFormViewId">
-              <option value="">-- no public form link --</option>
+              <option value="">{{ l('dingtalk.noPublicFormLinkOption') }}</option>
               <option v-for="view in formViews" :key="view.id" :value="view.id">{{ view.name }}</option>
             </select>
             <div
@@ -526,9 +526,9 @@
             >
               {{ warning }}
             </div>
-            <label class="meta-automation__label">Internal processing view (optional)</label>
+            <label class="meta-automation__label">{{ l('dingtalk.internalProcessingView') }}</label>
             <select v-model="draft.dingtalkPersonInternalViewId" class="meta-automation__select" data-automation-field="dingtalkPersonInternalViewId">
-              <option value="">-- no internal link --</option>
+              <option value="">{{ l('dingtalk.noInternalLinkOption') }}</option>
               <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
             </select>
             <div
@@ -539,47 +539,47 @@
               {{ warning }}
             </div>
             <div class="meta-automation__preview" data-automation-summary="person">
-              <div class="meta-automation__preview-title">Message summary</div>
-              <div><strong>Recipients:</strong> {{ dingTalkPersonRecipientSummary }}</div>
-              <div><strong>Record recipients:</strong> {{ dingTalkPersonRecipientFieldSummary }}</div>
-              <div><strong>Record member groups:</strong> {{ dingTalkPersonMemberGroupFieldSummary }}</div>
-              <div><strong>Title template:</strong> {{ templatePreviewText(draft.dingtalkPersonTitleTemplate, 'No title template') }}</div>
-              <div class="meta-automation__preview-body"><strong>Body template:</strong> {{ templatePreviewText(draft.dingtalkPersonBodyTemplate, 'No body template') }}</div>
+              <div class="meta-automation__preview-title">{{ l('dingtalk.messageSummary') }}</div>
+              <div><strong>{{ l('dingtalk.recipients') }}:</strong> {{ dingTalkPersonRecipientSummary }}</div>
+              <div><strong>{{ l('dingtalk.recordRecipients') }}:</strong> {{ dingTalkPersonRecipientFieldSummary }}</div>
+              <div><strong>{{ l('dingtalk.recordMemberGroups') }}:</strong> {{ dingTalkPersonMemberGroupFieldSummary }}</div>
+              <div><strong>{{ l('dingtalk.titleTemplate') }}:</strong> {{ templatePreviewText(draft.dingtalkPersonTitleTemplate, l('dingtalk.noTitleTemplate')) }}</div>
+              <div class="meta-automation__preview-body"><strong>{{ l('dingtalk.bodyTemplate') }}:</strong> {{ templatePreviewText(draft.dingtalkPersonBodyTemplate, l('dingtalk.noBodyTemplate')) }}</div>
               <div class="meta-automation__preview-line">
-                <span><strong>Rendered title:</strong> {{ renderedTemplateExample(draft.dingtalkPersonTitleTemplate, 'No rendered title') }}</span>
+                <span><strong>{{ l('dingtalk.renderedTitle') }}:</strong> {{ renderedTemplateExample(draft.dingtalkPersonTitleTemplate, l('dingtalk.noRenderedTitle')) }}</span>
                 <button
                   class="meta-automation__copy-btn"
                   type="button"
                   data-automation-copy="person-rendered-title"
                   @click="copyPreviewText('person-title', renderedTemplateExample(draft.dingtalkPersonTitleTemplate, ''))"
                 >
-                  {{ copiedPreviewKey === 'person-title' ? 'Copied' : 'Copy' }}
+                  {{ copiedPreviewKey === 'person-title' ? l('dingtalk.copied') : l('dingtalk.copy') }}
                 </button>
               </div>
               <div class="meta-automation__preview-line meta-automation__preview-body">
-                <span><strong>Rendered body:</strong> {{ renderedTemplateExample(draft.dingtalkPersonBodyTemplate, 'No rendered body') }}</span>
+                <span><strong>{{ l('dingtalk.renderedBody') }}:</strong> {{ renderedTemplateExample(draft.dingtalkPersonBodyTemplate, l('dingtalk.noRenderedBody')) }}</span>
                 <button
                   class="meta-automation__copy-btn"
                   type="button"
                   data-automation-copy="person-rendered-body"
                   @click="copyPreviewText('person-body', renderedTemplateExample(draft.dingtalkPersonBodyTemplate, ''))"
                 >
-                  {{ copiedPreviewKey === 'person-body' ? 'Copied' : 'Copy' }}
+                  {{ copiedPreviewKey === 'person-body' ? l('dingtalk.copied') : l('dingtalk.copy') }}
                 </button>
               </div>
-              <div><strong>Public form:</strong> {{ viewSummaryName(draft.dingtalkPersonPublicFormViewId, 'No public form link') }}</div>
+              <div><strong>{{ l('dingtalk.publicForm') }}:</strong> {{ viewSummaryName(draft.dingtalkPersonPublicFormViewId, l('dingtalk.noPublicFormLink')) }}</div>
               <div
                 class="meta-automation__public-form-access"
                 :class="`meta-automation__public-form-access--${draftPersonPublicFormAccessState.level}`"
                 data-automation-public-form-access="person"
                 :data-access-level="draftPersonPublicFormAccessState.level"
               >
-                <strong>Public form access:</strong> {{ draftPersonPublicFormAccessState.summary }}
+                <strong>{{ l('dingtalk.publicFormAccess') }}:</strong> {{ draftPersonPublicFormAccessState.summary }}
               </div>
               <div data-automation-public-form-audience="person">
-                <strong>Allowed audience:</strong> {{ draftPersonPublicFormAccessState.audienceSummary }}
+                <strong>{{ l('dingtalk.allowedAudience') }}:</strong> {{ draftPersonPublicFormAccessState.audienceSummary }}
               </div>
-              <div><strong>Internal processing:</strong> {{ viewSummaryName(draft.dingtalkPersonInternalViewId, 'No internal link') }}</div>
+              <div><strong>{{ l('dingtalk.internalProcessing') }}:</strong> {{ viewSummaryName(draft.dingtalkPersonInternalViewId, l('dingtalk.noInternalLink')) }}</div>
             </div>
           </template>
 
@@ -781,6 +781,7 @@ import {
   appendTemplateToken,
   DINGTALK_BODY_TEMPLATE_TOKENS,
   DINGTALK_TITLE_TEMPLATE_TOKENS,
+  dingTalkTemplateTokenLabel,
 } from '../utils/dingtalkNotificationTemplateTokens'
 import { listDingTalkTemplateSyntaxWarnings } from '../utils/dingtalkNotificationTemplateLint'
 import { renderDingTalkTemplateExample } from '../utils/dingtalkNotificationTemplateExample'
@@ -807,6 +808,12 @@ import {
   automationCardLinkSummary,
   automationCardStats,
   automationCardTriggerSummary,
+  automationDingTalkDestinationScopeLabel,
+  automationDingTalkDestinationSubtitle,
+  automationDingTalkPersonAccessLabel,
+  automationDingTalkPersonStatusLabel,
+  automationDingTalkPersonSubjectLabel,
+  automationDingTalkPresetLabel,
   automationLabel,
   automationTestRunFailed,
   automationTestRunRequestFailed,
@@ -920,10 +927,10 @@ const formViews = computed(() => (props.views ?? []).filter((view) =>
 ))
 const internalViews = computed(() => (props.views ?? []).filter((view) => !view.sheetId || view.sheetId === props.sheetId))
 const draftGroupPublicFormAccessState = computed(() =>
-  getDingTalkPublicFormLinkAccessState(draft.value.publicFormViewId, formViews.value),
+  getDingTalkPublicFormLinkAccessState(draft.value.publicFormViewId, formViews.value, { isZh: isZh.value }),
 )
 const draftPersonPublicFormAccessState = computed(() =>
-  getDingTalkPublicFormLinkAccessState(draft.value.dingtalkPersonPublicFormViewId, formViews.value),
+  getDingTalkPublicFormLinkAccessState(draft.value.dingtalkPersonPublicFormViewId, formViews.value, { isZh: isZh.value }),
 )
 
 interface DingTalkCardLink {
@@ -967,25 +974,25 @@ function isInactivePersonRecipientCandidate(candidate: MetaSheetPermissionCandid
 }
 
 function personRecipientSubjectLabel(candidate: MetaSheetPermissionCandidate): string {
-  return candidate.subjectType === 'member-group' ? 'Member group' : 'User'
+  return automationDingTalkPersonSubjectLabel(candidate.subjectType === 'member-group' ? 'member-group' : 'user', isZh.value)
 }
 
 function personRecipientAccessLabel(accessLevel: MetaSheetPermissionCandidate['accessLevel']): string {
-  return accessLevel ? `Access: ${accessLevel}` : ''
+  return accessLevel ? automationDingTalkPersonAccessLabel(accessLevel, isZh.value) : ''
 }
 
 function personRecipientDingTalkStatusLabel(
   subjectType: MetaSheetPermissionCandidate['subjectType'],
   status: Pick<MetaSheetPermissionCandidate, 'dingtalkBound' | 'dingtalkGrantEnabled' | 'dingtalkPersonDeliveryAvailable'>,
 ): string {
-  if (subjectType === 'member-group') return 'Member group members are checked individually for DingTalk delivery'
+  if (subjectType === 'member-group') return automationDingTalkPersonStatusLabel('memberGroupCheckedIndividually', isZh.value)
   if (subjectType !== 'user') return ''
-  if (status.dingtalkPersonDeliveryAvailable === false) return 'No DingTalk delivery link; person message will skip until linked'
-  if (status.dingtalkPersonDeliveryAvailable === true && status.dingtalkGrantEnabled === true) return 'DingTalk direct message ready; form authorization enabled'
-  if (status.dingtalkPersonDeliveryAvailable === true && status.dingtalkGrantEnabled === false) return 'DingTalk direct message ready; form authorization not enabled'
-  if (status.dingtalkBound === false) return 'Not bound to DingTalk; person message may skip until linked'
-  if (status.dingtalkBound === true && status.dingtalkGrantEnabled === true) return 'DingTalk bound; form authorization enabled'
-  if (status.dingtalkBound === true && status.dingtalkGrantEnabled === false) return 'DingTalk bound; form authorization not enabled'
+  if (status.dingtalkPersonDeliveryAvailable === false) return automationDingTalkPersonStatusLabel('noDeliveryLink', isZh.value)
+  if (status.dingtalkPersonDeliveryAvailable === true && status.dingtalkGrantEnabled === true) return automationDingTalkPersonStatusLabel('deliveryReadyGrantEnabled', isZh.value)
+  if (status.dingtalkPersonDeliveryAvailable === true && status.dingtalkGrantEnabled === false) return automationDingTalkPersonStatusLabel('deliveryReadyGrantDisabled', isZh.value)
+  if (status.dingtalkBound === false) return automationDingTalkPersonStatusLabel('notBound', isZh.value)
+  if (status.dingtalkBound === true && status.dingtalkGrantEnabled === true) return automationDingTalkPersonStatusLabel('boundGrantEnabled', isZh.value)
+  if (status.dingtalkBound === true && status.dingtalkGrantEnabled === false) return automationDingTalkPersonStatusLabel('boundGrantDisabled', isZh.value)
   return ''
 }
 
@@ -1132,16 +1139,12 @@ function dingTalkDestinationScope(destination?: DingTalkGroupDestination): 'priv
 
 function dingTalkDestinationScopeLabel(destination?: DingTalkGroupDestination): string {
   const scope = dingTalkDestinationScope(destination)
-  if (scope === 'org') return 'Organization catalog'
-  if (scope === 'sheet') return 'This table'
-  return 'Private'
+  return automationDingTalkDestinationScopeLabel(scope, isZh.value)
 }
 
 function dingTalkDestinationSubtitle(destination?: DingTalkGroupDestination): string | undefined {
   const scope = dingTalkDestinationScope(destination)
-  if (scope === 'org') return destination?.orgId ? `organization catalog: ${destination.orgId}` : 'organization catalog'
-  if (scope === 'sheet') return destination?.sheetId ? `sheet: ${destination.sheetId}` : 'this table'
-  return 'private'
+  return automationDingTalkDestinationSubtitle(scope, scope === 'org' ? destination?.orgId ?? '' : destination?.sheetId ?? '', isZh.value)
 }
 
 const selectedDingTalkGroupDestinations = computed(() =>
@@ -1175,7 +1178,7 @@ function removeDingTalkGroupDestination(destinationId: string) {
 }
 
 const dingTalkGroupSummary = computed(() => {
-  if (!selectedDingTalkGroupDestinations.value.length) return 'No groups selected'
+  if (!selectedDingTalkGroupDestinations.value.length) return l('dingtalk.noGroupsSelected')
   return selectedDingTalkGroupDestinations.value.map((item) => item.label).join(', ')
 })
 
@@ -1192,27 +1195,28 @@ function templatePreviewText(value: string, fallback: string) {
 function renderedTemplateExample(value: string, fallback: string) {
   const trimmed = value.trim()
   if (!trimmed) return fallback
-  const rendered = renderDingTalkTemplateExample(trimmed).trim()
+  const rendered = renderDingTalkTemplateExample(trimmed, isZh.value).trim()
   return rendered || fallback
 }
 
 function publicFormLinkWarnings(value: unknown, warnWhenDingTalkAccessRisk = false) {
   return listDingTalkPublicFormLinkWarnings(value, formViews.value, {
+    isZh: isZh.value,
     warnWhenFullyPublic: warnWhenDingTalkAccessRisk,
     warnWhenProtectedWithoutAllowlist: warnWhenDingTalkAccessRisk,
   })
 }
 
 function publicFormLinkBlockingErrors(value: unknown) {
-  return listDingTalkPublicFormLinkBlockingErrors(value, formViews.value)
+  return listDingTalkPublicFormLinkBlockingErrors(value, formViews.value, { isZh: isZh.value })
 }
 
 function internalViewLinkWarnings(value: unknown) {
-  return listDingTalkInternalViewLinkWarnings(value, internalViews.value)
+  return listDingTalkInternalViewLinkWarnings(value, internalViews.value, isZh.value)
 }
 
 function internalViewLinkBlockingErrors(value: unknown) {
-  return listDingTalkInternalViewLinkBlockingErrors(value, internalViews.value)
+  return listDingTalkInternalViewLinkBlockingErrors(value, internalViews.value, isZh.value)
 }
 
 function readPublicFormToken(view: MetaView): string {
@@ -1309,10 +1313,10 @@ const dingTalkPersonRecipientSummary = computed(() => {
   const userLabels = selectedDingTalkPersonRecipients.value.map((item) => item.label)
   const groupLabels = selectedDingTalkPersonMemberGroups.value.map((item) => item.label)
   const parts = [
-    userLabels.length ? `Users: ${userLabels.join(', ')}` : '',
-    groupLabels.length ? `Groups: ${groupLabels.join(', ')}` : '',
+    userLabels.length ? `${isZh.value ? '用户' : 'Users'}: ${userLabels.join(', ')}` : '',
+    groupLabels.length ? `${isZh.value ? '成员组' : 'Groups'}: ${groupLabels.join(', ')}` : '',
   ].filter(Boolean)
-  if (!parts.length) return 'No recipients selected'
+  if (!parts.length) return l('dingtalk.noRecipientsSelected')
   return parts.join(' | ')
 })
 
@@ -1340,7 +1344,7 @@ function recipientFieldSummaryLabel(path: string) {
 }
 
 function groupDestinationFieldPathWarnings(value: string) {
-  return listDingTalkGroupDestinationFieldPathWarnings(value, props.fields)
+  return listDingTalkGroupDestinationFieldPathWarnings(value, props.fields, isZh.value)
 }
 
 const dingTalkPersonRecipientCandidateFields = computed(() => props.fields.filter((field) => field.type === 'user'))
@@ -1361,16 +1365,16 @@ const selectedDingTalkPersonMemberGroupRecipientFields = computed(() => parseRec
   .filter((item) => item.label))
 
 function recipientFieldPathWarnings(value: string) {
-  return listDingTalkPersonRecipientFieldPathWarnings(value, props.fields)
+  return listDingTalkPersonRecipientFieldPathWarnings(value, props.fields, isZh.value)
 }
 
 function memberGroupRecipientFieldPathWarnings(value: string) {
-  return listDingTalkPersonMemberGroupRecipientFieldPathWarnings(value, props.fields)
+  return listDingTalkPersonMemberGroupRecipientFieldPathWarnings(value, props.fields, isZh.value)
 }
 
 const dingTalkPersonRecipientFieldSummary = computed(() => {
   const labels = selectedDingTalkPersonRecipientFields.value.map((item) => item.label)
-  if (!labels.length) return 'No dynamic recipient field'
+  if (!labels.length) return l('dingtalk.noDynamicRecipientField')
   return labels.join(', ')
 })
 
@@ -1378,13 +1382,13 @@ const dingTalkPersonMemberGroupFieldSummary = computed(() => {
   const labels = parseRecipientFieldPathsText(draft.value.dingtalkPersonMemberGroupRecipientFieldPath)
     .map((path) => recipientFieldSummaryLabel(path))
     .filter(Boolean)
-  if (!labels.length) return 'No dynamic member group field'
+  if (!labels.length) return l('dingtalk.noDynamicMemberGroupField')
   return labels.join(', ')
 })
 
 const dingTalkGroupFieldSummary = computed(() => {
   const labels = selectedDingTalkGroupDestinationFields.value.map((item) => item.label)
-  if (!labels.length) return 'No dynamic group field'
+  if (!labels.length) return l('dingtalk.noDynamicGroupField')
   return labels.join(', ')
 })
 
@@ -1443,7 +1447,7 @@ function removeDingTalkPersonMemberGroupRecipientField(path: string) {
 }
 
 function templateSyntaxWarnings(value: string) {
-  return listDingTalkTemplateSyntaxWarnings(value)
+  return listDingTalkTemplateSyntaxWarnings(value, isZh.value)
 }
 
 onBeforeUnmount(() => {
@@ -1460,6 +1464,7 @@ function applyGroupPreset(preset: DingTalkNotificationPreset) {
     },
     preset,
     props.views ?? [],
+    isZh.value,
   )
   draft.value.dingtalkTitleTemplate = next.titleTemplate ?? ''
   draft.value.dingtalkBodyTemplate = next.bodyTemplate ?? ''
@@ -1477,6 +1482,7 @@ function applyPersonPreset(preset: DingTalkNotificationPreset) {
     },
     preset,
     props.views ?? [],
+    isZh.value,
   )
   draft.value.dingtalkPersonTitleTemplate = next.titleTemplate ?? ''
   draft.value.dingtalkPersonBodyTemplate = next.bodyTemplate ?? ''

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -316,32 +316,32 @@
             <!-- send_dingtalk_group_message config -->
             <div v-if="action.type === 'send_dingtalk_group_message'" class="meta-rule-editor__action-config">
               <div class="meta-rule-editor__preset-row">
-                <span class="meta-rule-editor__preset-label">Message preset</span>
-                <button class="meta-rule-editor__btn" type="button" data-field="groupPresetForm" @click="applyGroupPreset(action, 'form_request')">Form request</button>
-                <button class="meta-rule-editor__btn" type="button" data-field="groupPresetInternal" @click="applyGroupPreset(action, 'internal_process')">Internal processing</button>
-                <button class="meta-rule-editor__btn" type="button" data-field="groupPresetBoth" @click="applyGroupPreset(action, 'form_and_process')">Form + processing</button>
+                <span class="meta-rule-editor__preset-label">{{ automationLabel('dingtalk.preset', isZh) }}</span>
+                <button class="meta-rule-editor__btn" type="button" data-field="groupPresetForm" @click="applyGroupPreset(action, 'form_request')">{{ automationDingTalkPresetLabel('form_request', isZh) }}</button>
+                <button class="meta-rule-editor__btn" type="button" data-field="groupPresetInternal" @click="applyGroupPreset(action, 'internal_process')">{{ automationDingTalkPresetLabel('internal_process', isZh) }}</button>
+                <button class="meta-rule-editor__btn" type="button" data-field="groupPresetBoth" @click="applyGroupPreset(action, 'form_and_process')">{{ automationDingTalkPresetLabel('form_and_process', isZh) }}</button>
               </div>
-              <label class="meta-rule-editor__label">Add DingTalk groups</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.addGroups', isZh) }}</label>
               <select
                 v-model="action.config.destinationPickerId"
                 class="meta-rule-editor__select"
                 data-field="dingtalkDestinationPickerId"
                 @change="appendGroupDestination(action, $event.target as HTMLSelectElement)"
               >
-                <option value="">-- add DingTalk group --</option>
+                <option value="">{{ automationLabel('dingtalk.addGroupOption', isZh) }}</option>
                 <option v-for="destination in availableGroupDestinations(action)" :key="destination.id" :value="destination.id">
                   {{ destination.name }} · {{ groupDestinationScopeLabel(destination) }}
                 </option>
               </select>
               <div class="meta-rule-editor__hint" data-field="dingtalkDestinationPickerHint">
-                DingTalk group destinations registered for this table or shared from the organization catalog are listed here.
+                {{ automationLabel('dingtalk.groupsRegisteredHint', isZh) }}
               </div>
               <div
                 v-if="!dingTalkDestinationsError && dingTalkDestinations.length === 0"
                 class="meta-rule-editor__hint"
                 data-field="dingtalkDestinationEmpty"
               >
-                No DingTalk groups are available for this table yet. Add one in API Tokens &amp; Webhooks &gt; DingTalk Groups, ask an admin to share an organization catalog group, or use a record group field path below.
+                {{ automationLabel('dingtalk.noGroupsAvailable', isZh) }}
               </div>
               <div
                 v-if="selectedGroupDestinations(action).length"
@@ -357,11 +357,11 @@
                 >
                   <strong>{{ destination.label }}</strong>
                   <span>{{ destination.subtitle || destination.id }}</span>
-                  <em>Remove</em>
+                  <em>{{ automationLabel('dingtalk.remove', isZh) }}</em>
                 </button>
               </div>
               <div v-if="dingTalkDestinationsError" class="meta-rule-editor__hint">{{ dingTalkDestinationsError }}</div>
-              <label class="meta-rule-editor__label">Record group field paths (optional)</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.recordGroupFieldPaths', isZh) }}</label>
               <input
                 v-model="action.config.destinationFieldPath"
                 class="meta-rule-editor__input"
@@ -370,15 +370,15 @@
                 data-field="dingtalkDestinationFieldPath"
               />
               <div class="meta-rule-editor__hint" data-field="dingtalkDestinationFieldPathHint">
-                Use record fields whose value is a DingTalk group destination ID, not a local user, member group, or DingTalk group name.
+                {{ automationLabel('dingtalk.recordGroupFieldPathHint', isZh) }}
               </div>
-              <label class="meta-rule-editor__label">Pick group field</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.pickGroupField', isZh) }}</label>
               <select
                 class="meta-rule-editor__select"
                 data-field="dingtalkDestinationFieldSelect"
                 @change="appendGroupDestinationFieldPath(action, $event.target as HTMLSelectElement)"
               >
-                <option value="">-- pick field --</option>
+                <option value="">{{ automationLabel('dingtalk.pickFieldOption', isZh) }}</option>
                 <option v-for="field in groupDestinationCandidateFields" :key="field.id" :value="field.id">
                   {{ field.name }}
                 </option>
@@ -397,7 +397,7 @@
                 >
                   <strong>{{ field.label }}</strong>
                   <span>{{ field.id }}</span>
-                  <em>Remove</em>
+                  <em>{{ automationLabel('dingtalk.remove', isZh) }}</em>
                 </button>
               </div>
               <div
@@ -407,12 +407,12 @@
               >
                 {{ warning }}
               </div>
-              <label class="meta-rule-editor__label">Title template</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.titleTemplate', isZh) }}</label>
               <input
                 v-model="action.config.titleTemplate"
                 class="meta-rule-editor__input"
                 type="text"
-                placeholder="例如：{{record.title}} 待处理"
+                :placeholder="automationLabel('dingtalk.titleTemplatePlaceholder', isZh)"
                 data-field="dingtalkTitleTemplate"
               />
               <div
@@ -423,7 +423,7 @@
                 {{ warning }}
               </div>
               <div class="meta-rule-editor__token-row">
-                <span class="meta-rule-editor__preset-label">Template tokens</span>
+                <span class="meta-rule-editor__preset-label">{{ automationLabel('dingtalk.templateTokens', isZh) }}</span>
                 <button
                   v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
                   :key="token.key"
@@ -432,15 +432,15 @@
                   :data-field="`groupTitleToken-${token.key}`"
                   @click="appendGroupTemplateToken(action, 'titleTemplate', token.value)"
                 >
-                  {{ token.label }}
+                  {{ dingTalkTemplateTokenLabel(token, isZh) }}
                 </button>
               </div>
-              <label class="meta-rule-editor__label">Body template</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.bodyTemplate', isZh) }}</label>
               <textarea
                 v-model="action.config.bodyTemplate"
                 class="meta-rule-editor__textarea"
                 rows="4"
-                placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
+                :placeholder="automationLabel('dingtalk.bodyTemplatePlaceholder', isZh)"
                 data-field="dingtalkBodyTemplate"
               ></textarea>
               <div
@@ -451,7 +451,7 @@
                 {{ warning }}
               </div>
               <div class="meta-rule-editor__token-row">
-                <span class="meta-rule-editor__preset-label">Template tokens</span>
+                <span class="meta-rule-editor__preset-label">{{ automationLabel('dingtalk.templateTokens', isZh) }}</span>
                 <button
                   v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
                   :key="token.key"
@@ -460,16 +460,16 @@
                   :data-field="`groupBodyToken-${token.key}`"
                   @click="appendGroupTemplateToken(action, 'bodyTemplate', token.value, true)"
                 >
-                  {{ token.label }}
+                  {{ dingTalkTemplateTokenLabel(token, isZh) }}
                 </button>
               </div>
-              <label class="meta-rule-editor__label">Public form view (optional)</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.publicFormView', isZh) }}</label>
               <select
                 v-model="action.config.publicFormViewId"
                 class="meta-rule-editor__select"
                 data-field="publicFormViewId"
               >
-                <option value="">-- no public form link --</option>
+                  <option value="">{{ automationLabel('dingtalk.noPublicFormLinkOption', isZh) }}</option>
                 <option v-for="view in formViews" :key="view.id" :value="view.id">{{ view.name }}</option>
               </select>
               <div
@@ -490,23 +490,23 @@
                   :data-field="`groupPublicFormAccessSummary-${idx}`"
                   :data-access-level="accessState.level"
                 >
-                  <strong>Access:</strong> {{ accessState.summary }}
+                  <strong>{{ automationLabel('dingtalk.publicFormAccess', isZh) }}:</strong> {{ accessState.summary }}
                 </div>
                 <div
                   v-if="accessState.hasSelection"
                   class="meta-rule-editor__hint meta-rule-editor__access-audience"
                   :data-field="`groupPublicFormAudienceSummary-${idx}`"
                 >
-                  <strong>Allowed audience:</strong> {{ accessState.audienceSummary }}
+                  <strong>{{ automationLabel('dingtalk.allowedAudience', isZh) }}:</strong> {{ accessState.audienceSummary }}
                 </div>
               </template>
-              <label class="meta-rule-editor__label">Internal processing view (optional)</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.internalProcessingView', isZh) }}</label>
               <select
                 v-model="action.config.internalViewId"
                 class="meta-rule-editor__select"
                 data-field="internalViewId"
               >
-                <option value="">-- no internal link --</option>
+                <option value="">{{ automationLabel('dingtalk.noInternalLinkOption', isZh) }}</option>
                 <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
               </select>
               <div
@@ -517,58 +517,58 @@
                 {{ warning }}
               </div>
               <div class="meta-rule-editor__preview" data-field="groupMessageSummary">
-                <div class="meta-rule-editor__preview-title">Message summary</div>
-                <div><strong>Groups:</strong> {{ dingTalkGroupSummary(action) }}</div>
-                <div><strong>Record groups:</strong> {{ groupDestinationFieldPathSummary(action.config.destinationFieldPath) }}</div>
-                <div><strong>Title template:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
-                <div class="meta-rule-editor__preview-body"><strong>Body template:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
+                <div class="meta-rule-editor__preview-title">{{ automationLabel('dingtalk.messageSummary', isZh) }}</div>
+                <div><strong>{{ automationLabel('dingtalk.groups', isZh) }}:</strong> {{ dingTalkGroupSummary(action) }}</div>
+                <div><strong>{{ automationLabel('dingtalk.recordGroups', isZh) }}:</strong> {{ groupDestinationFieldPathSummary(action.config.destinationFieldPath) }}</div>
+                <div><strong>{{ automationLabel('dingtalk.titleTemplate', isZh) }}:</strong> {{ templatePreviewText(action.config.titleTemplate, automationLabel('dingtalk.noTitleTemplate', isZh)) }}</div>
+                <div class="meta-rule-editor__preview-body"><strong>{{ automationLabel('dingtalk.bodyTemplate', isZh) }}:</strong> {{ templatePreviewText(action.config.bodyTemplate, automationLabel('dingtalk.noBodyTemplate', isZh)) }}</div>
                 <div class="meta-rule-editor__preview-line">
-                  <span><strong>Rendered title:</strong> {{ renderedTemplateExample(action.config.titleTemplate, 'No rendered title') }}</span>
+                  <span><strong>{{ automationLabel('dingtalk.renderedTitle', isZh) }}:</strong> {{ renderedTemplateExample(action.config.titleTemplate, automationLabel('dingtalk.noRenderedTitle', isZh)) }}</span>
                   <button
                     class="meta-rule-editor__copy-btn"
                     type="button"
                     :data-field="`groupRenderedTitleCopy-${idx}`"
                     @click="copyPreviewText(`group-title-${idx}`, renderedTemplateExample(action.config.titleTemplate, ''))"
                   >
-                    {{ copiedPreviewKey === `group-title-${idx}` ? 'Copied' : 'Copy' }}
+                    {{ copiedPreviewKey === `group-title-${idx}` ? automationLabel('dingtalk.copied', isZh) : automationLabel('dingtalk.copy', isZh) }}
                   </button>
                 </div>
                 <div class="meta-rule-editor__preview-line meta-rule-editor__preview-body">
-                  <span><strong>Rendered body:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, 'No rendered body') }}</span>
+                  <span><strong>{{ automationLabel('dingtalk.renderedBody', isZh) }}:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, automationLabel('dingtalk.noRenderedBody', isZh)) }}</span>
                   <button
                     class="meta-rule-editor__copy-btn"
                     type="button"
                     :data-field="`groupRenderedBodyCopy-${idx}`"
                     @click="copyPreviewText(`group-body-${idx}`, renderedTemplateExample(action.config.bodyTemplate, ''))"
                   >
-                    {{ copiedPreviewKey === `group-body-${idx}` ? 'Copied' : 'Copy' }}
+                    {{ copiedPreviewKey === `group-body-${idx}` ? automationLabel('dingtalk.copied', isZh) : automationLabel('dingtalk.copy', isZh) }}
                   </button>
                 </div>
-                <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
-                <div><strong>Public form access:</strong> {{ publicFormAccessState(action.config.publicFormViewId).summary }}</div>
-                <div><strong>Allowed audience:</strong> {{ publicFormAccessState(action.config.publicFormViewId).audienceSummary }}</div>
-                <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
+                <div><strong>{{ automationLabel('dingtalk.publicForm', isZh) }}:</strong> {{ viewSummaryName(action.config.publicFormViewId, automationLabel('dingtalk.noPublicFormLink', isZh)) }}</div>
+                <div><strong>{{ automationLabel('dingtalk.publicFormAccess', isZh) }}:</strong> {{ publicFormAccessState(action.config.publicFormViewId).summary }}</div>
+                <div><strong>{{ automationLabel('dingtalk.allowedAudience', isZh) }}:</strong> {{ publicFormAccessState(action.config.publicFormViewId).audienceSummary }}</div>
+                <div><strong>{{ automationLabel('dingtalk.internalProcessing', isZh) }}:</strong> {{ viewSummaryName(action.config.internalViewId, automationLabel('dingtalk.noInternalLink', isZh)) }}</div>
               </div>
             </div>
 
             <!-- send_dingtalk_person_message config -->
             <div v-if="action.type === 'send_dingtalk_person_message'" class="meta-rule-editor__action-config">
               <div class="meta-rule-editor__preset-row">
-                <span class="meta-rule-editor__preset-label">Message preset</span>
-                <button class="meta-rule-editor__btn" type="button" data-field="personPresetForm" @click="applyPersonPreset(action, 'form_request')">Form request</button>
-                <button class="meta-rule-editor__btn" type="button" data-field="personPresetInternal" @click="applyPersonPreset(action, 'internal_process')">Internal processing</button>
-                <button class="meta-rule-editor__btn" type="button" data-field="personPresetBoth" @click="applyPersonPreset(action, 'form_and_process')">Form + processing</button>
+                <span class="meta-rule-editor__preset-label">{{ automationLabel('dingtalk.preset', isZh) }}</span>
+                <button class="meta-rule-editor__btn" type="button" data-field="personPresetForm" @click="applyPersonPreset(action, 'form_request')">{{ automationDingTalkPresetLabel('form_request', isZh) }}</button>
+                <button class="meta-rule-editor__btn" type="button" data-field="personPresetInternal" @click="applyPersonPreset(action, 'internal_process')">{{ automationDingTalkPresetLabel('internal_process', isZh) }}</button>
+                <button class="meta-rule-editor__btn" type="button" data-field="personPresetBoth" @click="applyPersonPreset(action, 'form_and_process')">{{ automationDingTalkPresetLabel('form_and_process', isZh) }}</button>
               </div>
-              <label class="meta-rule-editor__label">Search and add users or member groups</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.searchUsersOrGroups', isZh) }}</label>
               <input
                 v-model="action.config.userIdsSearch"
                 class="meta-rule-editor__input"
                 type="text"
-                placeholder="Search by user, member group, email, or subject ID"
+                :placeholder="automationLabel('dingtalk.searchUsersOrGroupsPlaceholder', isZh)"
                 data-field="dingtalkPersonUserSearch"
                 @input="void loadPersonRecipientSuggestions(idx, action)"
               />
-              <div v-if="personRecipientLoading[idx]" class="meta-rule-editor__hint">Searching users and member groups…</div>
+              <div v-if="personRecipientLoading[idx]" class="meta-rule-editor__hint">{{ automationLabel('dingtalk.searchingUsersOrGroups', isZh) }}</div>
               <div v-else-if="personRecipientErrors[idx]" class="meta-rule-editor__hint meta-rule-editor__hint--error">{{ personRecipientErrors[idx] }}</div>
               <div v-else-if="availablePersonRecipientSuggestions(idx, action).length" class="meta-rule-editor__recipient-list">
                 <button
@@ -585,10 +585,10 @@
                   <span>{{ personRecipientSubjectLabel(candidate) }}</span>
                   <span v-if="candidate.accessLevel">{{ personRecipientAccessLabel(candidate.accessLevel) }}</span>
                   <span v-if="personRecipientDingTalkStatusLabel(candidate.subjectType, candidate)">{{ personRecipientDingTalkStatusLabel(candidate.subjectType, candidate) }}</span>
-                  <span v-if="isInactivePersonRecipientCandidate(candidate)">Inactive users cannot be added</span>
+                  <span v-if="isInactivePersonRecipientCandidate(candidate)">{{ automationLabel('dingtalk.inactiveUsersCannotBeAdded', isZh) }}</span>
                 </button>
               </div>
-              <div v-else-if="typeof action.config.userIdsSearch === 'string' && action.config.userIdsSearch.trim()" class="meta-rule-editor__hint">No matching users or member groups</div>
+              <div v-else-if="typeof action.config.userIdsSearch === 'string' && action.config.userIdsSearch.trim()" class="meta-rule-editor__hint">{{ automationLabel('dingtalk.noMatchingUsersOrGroups', isZh) }}</div>
               <div v-if="selectedPersonRecipients(action).length" class="meta-rule-editor__recipient-list meta-rule-editor__recipient-list--selected">
                 <button
                   v-for="recipient in selectedPersonRecipients(action)"
@@ -601,7 +601,7 @@
                   <strong>{{ recipient.label }}</strong>
                   <span>{{ recipient.subtitle || recipient.id }}</span>
                   <span v-if="personRecipientDingTalkStatusLabel('user', recipient)">{{ personRecipientDingTalkStatusLabel('user', recipient) }}</span>
-                  <em>Remove</em>
+                  <em>{{ automationLabel('dingtalk.remove', isZh) }}</em>
                 </button>
               </div>
               <div v-if="selectedPersonRecipientGroups(action).length" class="meta-rule-editor__recipient-list meta-rule-editor__recipient-list--selected">
@@ -616,40 +616,40 @@
                   <strong>{{ group.label }}</strong>
                   <span>{{ group.subtitle || group.id }}</span>
                   <span v-if="personRecipientDingTalkStatusLabel('member-group', group)">{{ personRecipientDingTalkStatusLabel('member-group', group) }}</span>
-                  <em>Remove</em>
+                  <em>{{ automationLabel('dingtalk.remove', isZh) }}</em>
                 </button>
               </div>
-              <label class="meta-rule-editor__label">Local user IDs</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.localUserIds', isZh) }}</label>
               <textarea
                 v-model="action.config.userIdsText"
                 class="meta-rule-editor__textarea"
                 rows="3"
-                placeholder="使用逗号或换行分隔本地 userId"
+                :placeholder="automationLabel('dingtalk.localUserIdsPlaceholder', isZh)"
                 data-field="dingtalkPersonUserIds"
               ></textarea>
-              <label class="meta-rule-editor__label">Member group IDs (optional)</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.memberGroupIds', isZh) }}</label>
               <textarea
                 v-model="action.config.memberGroupIdsText"
                 class="meta-rule-editor__textarea"
                 rows="2"
-                placeholder="使用逗号或换行分隔成员组 ID"
+                :placeholder="automationLabel('dingtalk.memberGroupIdsPlaceholder', isZh)"
                 data-field="dingtalkPersonMemberGroupIds"
               ></textarea>
-              <label class="meta-rule-editor__label">Record recipient field paths (optional)</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.recordRecipientFieldPaths', isZh) }}</label>
               <input
                 v-model="action.config.recipientFieldPath"
                 class="meta-rule-editor__input"
                 type="text"
-                placeholder="例如：record.assigneeUserIds, record.reviewerUserId"
+                :placeholder="automationLabel('dingtalk.recordRecipientFieldPathPlaceholder', isZh)"
                 data-field="dingtalkPersonRecipientFieldPath"
               />
-              <label class="meta-rule-editor__label">Pick recipient field</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.pickRecipientField', isZh) }}</label>
               <select
                 class="meta-rule-editor__select"
                 data-field="dingtalkPersonRecipientFieldSelect"
                 @change="appendRecipientFieldPath(action, ($event.target as HTMLSelectElement))"
               >
-                <option value="">-- choose a user field --</option>
+                <option value="">{{ automationLabel('dingtalk.chooseUserFieldOption', isZh) }}</option>
                 <option v-for="field in recipientCandidateFields" :key="field.id" :value="field.id">
                   {{ field.name }} (record.{{ field.id }})
                 </option>
@@ -667,7 +667,7 @@
                   @click="removeRecipientFieldPath(action, field.id)"
                 >
                   <strong>{{ field.label }}</strong>
-                  <em>Remove</em>
+                  <em>{{ automationLabel('dingtalk.remove', isZh) }}</em>
                 </button>
               </div>
               <div
@@ -678,23 +678,23 @@
                 {{ warning }}
               </div>
               <div class="meta-rule-editor__hint">
-                Record data is keyed by field ID. Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths. The picker only lists user fields.
+                {{ automationLabel('dingtalk.recordRecipientFieldPathHint', isZh) }}
               </div>
-              <label class="meta-rule-editor__label">Record member group field paths (optional)</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.recordMemberGroupFieldPaths', isZh) }}</label>
               <input
                 v-model="action.config.memberGroupRecipientFieldPath"
                 class="meta-rule-editor__input"
                 type="text"
-                placeholder="例如：record.watcherGroupIds, record.escalationGroupId"
+                :placeholder="automationLabel('dingtalk.recordMemberGroupFieldPathPlaceholder', isZh)"
                 data-field="dingtalkPersonMemberGroupRecipientFieldPath"
               />
-              <label class="meta-rule-editor__label">Pick member group field</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.pickMemberGroupField', isZh) }}</label>
               <select
                 class="meta-rule-editor__select"
                 data-field="dingtalkPersonMemberGroupRecipientFieldSelect"
                 @change="appendMemberGroupRecipientFieldPath(action, $event.target as HTMLSelectElement)"
               >
-                <option value="">-- choose a member group field --</option>
+                <option value="">{{ automationLabel('dingtalk.chooseMemberGroupFieldOption', isZh) }}</option>
                 <option v-for="field in memberGroupRecipientCandidateFields" :key="field.id" :value="field.id">
                   {{ field.name }} (record.{{ field.id }})
                 </option>
@@ -712,7 +712,7 @@
                   @click="removeMemberGroupRecipientFieldPath(action, field.id)"
                 >
                   <strong>{{ field.label }}</strong>
-                  <em>Remove</em>
+                  <em>{{ automationLabel('dingtalk.remove', isZh) }}</em>
                 </button>
               </div>
               <div
@@ -723,14 +723,14 @@
                 {{ warning }}
               </div>
               <div class="meta-rule-editor__hint">
-                Use comma or newline separated <code>record.&lt;fieldId&gt;</code> paths whose values resolve to member group IDs. The picker only lists explicit member group fields.
+                {{ automationLabel('dingtalk.recordMemberGroupFieldPathHint', isZh) }}
               </div>
-              <label class="meta-rule-editor__label">Title template</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.titleTemplate', isZh) }}</label>
               <input
                 v-model="action.config.titleTemplate"
                 class="meta-rule-editor__input"
                 type="text"
-                placeholder="例如：{{record.title}} 待处理"
+                :placeholder="automationLabel('dingtalk.titleTemplatePlaceholder', isZh)"
                 data-field="dingtalkPersonTitleTemplate"
               />
               <div
@@ -741,7 +741,7 @@
                 {{ warning }}
               </div>
               <div class="meta-rule-editor__token-row">
-                <span class="meta-rule-editor__preset-label">Template tokens</span>
+                <span class="meta-rule-editor__preset-label">{{ automationLabel('dingtalk.templateTokens', isZh) }}</span>
                 <button
                   v-for="token in DINGTALK_TITLE_TEMPLATE_TOKENS"
                   :key="token.key"
@@ -750,15 +750,15 @@
                   :data-field="`personTitleToken-${token.key}`"
                   @click="appendPersonTemplateToken(action, 'titleTemplate', token.value)"
                 >
-                  {{ token.label }}
+                  {{ dingTalkTemplateTokenLabel(token, isZh) }}
                 </button>
               </div>
-              <label class="meta-rule-editor__label">Body template</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.bodyTemplate', isZh) }}</label>
               <textarea
                 v-model="action.config.bodyTemplate"
                 class="meta-rule-editor__textarea"
                 rows="4"
-                placeholder="支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}"
+                :placeholder="automationLabel('dingtalk.bodyTemplatePlaceholder', isZh)"
                 data-field="dingtalkPersonBodyTemplate"
               ></textarea>
               <div
@@ -769,7 +769,7 @@
                 {{ warning }}
               </div>
               <div class="meta-rule-editor__token-row">
-                <span class="meta-rule-editor__preset-label">Template tokens</span>
+                <span class="meta-rule-editor__preset-label">{{ automationLabel('dingtalk.templateTokens', isZh) }}</span>
                 <button
                   v-for="token in DINGTALK_BODY_TEMPLATE_TOKENS"
                   :key="token.key"
@@ -778,16 +778,16 @@
                   :data-field="`personBodyToken-${token.key}`"
                   @click="appendPersonTemplateToken(action, 'bodyTemplate', token.value, true)"
                 >
-                  {{ token.label }}
+                  {{ dingTalkTemplateTokenLabel(token, isZh) }}
                 </button>
               </div>
-              <label class="meta-rule-editor__label">Public form view (optional)</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.publicFormView', isZh) }}</label>
               <select
                 v-model="action.config.publicFormViewId"
                 class="meta-rule-editor__select"
                 data-field="dingtalkPersonPublicFormViewId"
               >
-                <option value="">-- no public form link --</option>
+                <option value="">{{ automationLabel('dingtalk.noPublicFormLinkOption', isZh) }}</option>
                 <option v-for="view in formViews" :key="view.id" :value="view.id">{{ view.name }}</option>
               </select>
               <div
@@ -808,23 +808,23 @@
                   :data-field="`personPublicFormAccessSummary-${idx}`"
                   :data-access-level="accessState.level"
                 >
-                  <strong>Access:</strong> {{ accessState.summary }}
+                  <strong>{{ automationLabel('dingtalk.publicFormAccess', isZh) }}:</strong> {{ accessState.summary }}
                 </div>
                 <div
                   v-if="accessState.hasSelection"
                   class="meta-rule-editor__hint meta-rule-editor__access-audience"
                   :data-field="`personPublicFormAudienceSummary-${idx}`"
                 >
-                  <strong>Allowed audience:</strong> {{ accessState.audienceSummary }}
+                  <strong>{{ automationLabel('dingtalk.allowedAudience', isZh) }}:</strong> {{ accessState.audienceSummary }}
                 </div>
               </template>
-              <label class="meta-rule-editor__label">Internal processing view (optional)</label>
+              <label class="meta-rule-editor__label">{{ automationLabel('dingtalk.internalProcessingView', isZh) }}</label>
               <select
                 v-model="action.config.internalViewId"
                 class="meta-rule-editor__select"
                 data-field="dingtalkPersonInternalViewId"
               >
-                <option value="">-- no internal link --</option>
+                <option value="">{{ automationLabel('dingtalk.noInternalLinkOption', isZh) }}</option>
                 <option v-for="view in internalViews" :key="view.id" :value="view.id">{{ view.name }}</option>
               </select>
               <div
@@ -835,38 +835,38 @@
                 {{ warning }}
               </div>
               <div class="meta-rule-editor__preview" data-field="personMessageSummary">
-                <div class="meta-rule-editor__preview-title">Message summary</div>
-                <div><strong>Recipients:</strong> {{ personRecipientSummary(action) }}</div>
-                <div><strong>Record recipients:</strong> {{ recipientFieldPathSummary(action.config.recipientFieldPath) }}</div>
-                <div><strong>Record member groups:</strong> {{ recipientFieldPathSummary(action.config.memberGroupRecipientFieldPath) }}</div>
-                <div><strong>Title template:</strong> {{ templatePreviewText(action.config.titleTemplate, 'No title template') }}</div>
-                <div class="meta-rule-editor__preview-body"><strong>Body template:</strong> {{ templatePreviewText(action.config.bodyTemplate, 'No body template') }}</div>
+                <div class="meta-rule-editor__preview-title">{{ automationLabel('dingtalk.messageSummary', isZh) }}</div>
+                <div><strong>{{ automationLabel('dingtalk.recipients', isZh) }}:</strong> {{ personRecipientSummary(action) }}</div>
+                <div><strong>{{ automationLabel('dingtalk.recordRecipients', isZh) }}:</strong> {{ recipientFieldPathSummary(action.config.recipientFieldPath) }}</div>
+                <div><strong>{{ automationLabel('dingtalk.recordMemberGroups', isZh) }}:</strong> {{ memberGroupRecipientFieldPathSummary(action.config.memberGroupRecipientFieldPath) }}</div>
+                <div><strong>{{ automationLabel('dingtalk.titleTemplate', isZh) }}:</strong> {{ templatePreviewText(action.config.titleTemplate, automationLabel('dingtalk.noTitleTemplate', isZh)) }}</div>
+                <div class="meta-rule-editor__preview-body"><strong>{{ automationLabel('dingtalk.bodyTemplate', isZh) }}:</strong> {{ templatePreviewText(action.config.bodyTemplate, automationLabel('dingtalk.noBodyTemplate', isZh)) }}</div>
                 <div class="meta-rule-editor__preview-line">
-                  <span><strong>Rendered title:</strong> {{ renderedTemplateExample(action.config.titleTemplate, 'No rendered title') }}</span>
+                  <span><strong>{{ automationLabel('dingtalk.renderedTitle', isZh) }}:</strong> {{ renderedTemplateExample(action.config.titleTemplate, automationLabel('dingtalk.noRenderedTitle', isZh)) }}</span>
                   <button
                     class="meta-rule-editor__copy-btn"
                     type="button"
                     :data-field="`personRenderedTitleCopy-${idx}`"
                     @click="copyPreviewText(`person-title-${idx}`, renderedTemplateExample(action.config.titleTemplate, ''))"
                   >
-                    {{ copiedPreviewKey === `person-title-${idx}` ? 'Copied' : 'Copy' }}
+                    {{ copiedPreviewKey === `person-title-${idx}` ? automationLabel('dingtalk.copied', isZh) : automationLabel('dingtalk.copy', isZh) }}
                   </button>
                 </div>
                 <div class="meta-rule-editor__preview-line meta-rule-editor__preview-body">
-                  <span><strong>Rendered body:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, 'No rendered body') }}</span>
+                  <span><strong>{{ automationLabel('dingtalk.renderedBody', isZh) }}:</strong> {{ renderedTemplateExample(action.config.bodyTemplate, automationLabel('dingtalk.noRenderedBody', isZh)) }}</span>
                   <button
                     class="meta-rule-editor__copy-btn"
                     type="button"
                     :data-field="`personRenderedBodyCopy-${idx}`"
                     @click="copyPreviewText(`person-body-${idx}`, renderedTemplateExample(action.config.bodyTemplate, ''))"
                   >
-                    {{ copiedPreviewKey === `person-body-${idx}` ? 'Copied' : 'Copy' }}
+                    {{ copiedPreviewKey === `person-body-${idx}` ? automationLabel('dingtalk.copied', isZh) : automationLabel('dingtalk.copy', isZh) }}
                   </button>
                 </div>
-                <div><strong>Public form:</strong> {{ viewSummaryName(action.config.publicFormViewId, 'No public form link') }}</div>
-                <div><strong>Public form access:</strong> {{ publicFormAccessState(action.config.publicFormViewId).summary }}</div>
-                <div><strong>Allowed audience:</strong> {{ publicFormAccessState(action.config.publicFormViewId).audienceSummary }}</div>
-                <div><strong>Internal processing:</strong> {{ viewSummaryName(action.config.internalViewId, 'No internal link') }}</div>
+                <div><strong>{{ automationLabel('dingtalk.publicForm', isZh) }}:</strong> {{ viewSummaryName(action.config.publicFormViewId, automationLabel('dingtalk.noPublicFormLink', isZh)) }}</div>
+                <div><strong>{{ automationLabel('dingtalk.publicFormAccess', isZh) }}:</strong> {{ publicFormAccessState(action.config.publicFormViewId).summary }}</div>
+                <div><strong>{{ automationLabel('dingtalk.allowedAudience', isZh) }}:</strong> {{ publicFormAccessState(action.config.publicFormViewId).audienceSummary }}</div>
+                <div><strong>{{ automationLabel('dingtalk.internalProcessing', isZh) }}:</strong> {{ viewSummaryName(action.config.internalViewId, automationLabel('dingtalk.noInternalLink', isZh)) }}</div>
               </div>
             </div>
 
@@ -947,6 +947,7 @@ import {
   appendTemplateToken,
   DINGTALK_BODY_TEMPLATE_TOKENS,
   DINGTALK_TITLE_TEMPLATE_TOKENS,
+  dingTalkTemplateTokenLabel,
 } from '../utils/dingtalkNotificationTemplateTokens'
 import { listDingTalkTemplateSyntaxWarnings } from '../utils/dingtalkNotificationTemplateLint'
 import { renderDingTalkTemplateExample } from '../utils/dingtalkNotificationTemplateExample'
@@ -970,6 +971,12 @@ import {
   automationConditionOperatorLabel,
   automationConditionValuePlaceholder,
   automationCronPresetLabel,
+  automationDingTalkDestinationScopeLabel,
+  automationDingTalkDestinationSubtitle,
+  automationDingTalkPersonAccessLabel,
+  automationDingTalkPersonStatusLabel,
+  automationDingTalkPersonSubjectLabel,
+  automationDingTalkPresetLabel,
   automationLabel,
   automationTriggerConditionLabel,
   automationTriggerTypeLabel,
@@ -1767,25 +1774,25 @@ function isInactivePersonRecipientCandidate(candidate: MetaSheetPermissionCandid
 }
 
 function personRecipientSubjectLabel(candidate: MetaSheetPermissionCandidate): string {
-  return candidate.subjectType === 'member-group' ? 'Member group' : 'User'
+  return automationDingTalkPersonSubjectLabel(candidate.subjectType === 'member-group' ? 'member-group' : 'user', isZh.value)
 }
 
 function personRecipientAccessLabel(accessLevel: MetaSheetPermissionCandidate['accessLevel']): string {
-  return accessLevel ? `Access: ${accessLevel}` : ''
+  return accessLevel ? automationDingTalkPersonAccessLabel(accessLevel, isZh.value) : ''
 }
 
 function personRecipientDingTalkStatusLabel(
   subjectType: MetaSheetPermissionCandidate['subjectType'],
   status: Pick<MetaSheetPermissionCandidate, 'dingtalkBound' | 'dingtalkGrantEnabled' | 'dingtalkPersonDeliveryAvailable'>,
 ): string {
-  if (subjectType === 'member-group') return 'Member group members are checked individually for DingTalk delivery'
+  if (subjectType === 'member-group') return automationDingTalkPersonStatusLabel('memberGroupCheckedIndividually', isZh.value)
   if (subjectType !== 'user') return ''
-  if (status.dingtalkPersonDeliveryAvailable === false) return 'No DingTalk delivery link; person message will skip until linked'
-  if (status.dingtalkPersonDeliveryAvailable === true && status.dingtalkGrantEnabled === true) return 'DingTalk direct message ready; form authorization enabled'
-  if (status.dingtalkPersonDeliveryAvailable === true && status.dingtalkGrantEnabled === false) return 'DingTalk direct message ready; form authorization not enabled'
-  if (status.dingtalkBound === false) return 'Not bound to DingTalk; person message may skip until linked'
-  if (status.dingtalkBound === true && status.dingtalkGrantEnabled === true) return 'DingTalk bound; form authorization enabled'
-  if (status.dingtalkBound === true && status.dingtalkGrantEnabled === false) return 'DingTalk bound; form authorization not enabled'
+  if (status.dingtalkPersonDeliveryAvailable === false) return automationDingTalkPersonStatusLabel('noDeliveryLink', isZh.value)
+  if (status.dingtalkPersonDeliveryAvailable === true && status.dingtalkGrantEnabled === true) return automationDingTalkPersonStatusLabel('deliveryReadyGrantEnabled', isZh.value)
+  if (status.dingtalkPersonDeliveryAvailable === true && status.dingtalkGrantEnabled === false) return automationDingTalkPersonStatusLabel('deliveryReadyGrantDisabled', isZh.value)
+  if (status.dingtalkBound === false) return automationDingTalkPersonStatusLabel('notBound', isZh.value)
+  if (status.dingtalkBound === true && status.dingtalkGrantEnabled === true) return automationDingTalkPersonStatusLabel('boundGrantEnabled', isZh.value)
+  if (status.dingtalkBound === true && status.dingtalkGrantEnabled === false) return automationDingTalkPersonStatusLabel('boundGrantDisabled', isZh.value)
   return ''
 }
 
@@ -1909,16 +1916,12 @@ function groupDestinationScope(destination?: DingTalkGroupDestination): 'private
 
 function groupDestinationScopeLabel(destination?: DingTalkGroupDestination): string {
   const scope = groupDestinationScope(destination)
-  if (scope === 'org') return 'Organization catalog'
-  if (scope === 'sheet') return 'This table'
-  return 'Private'
+  return automationDingTalkDestinationScopeLabel(scope, isZh.value)
 }
 
 function groupDestinationSubtitle(destination?: DingTalkGroupDestination): string | undefined {
   const scope = groupDestinationScope(destination)
-  if (scope === 'org') return destination?.orgId ? `organization catalog: ${destination.orgId}` : 'organization catalog'
-  if (scope === 'sheet') return destination?.sheetId ? `sheet: ${destination.sheetId}` : 'this table'
-  return 'private'
+  return automationDingTalkDestinationSubtitle(scope, scope === 'org' ? destination?.orgId ?? '' : destination?.sheetId ?? '', isZh.value)
 }
 
 function selectedGroupDestinations(action: DraftAction) {
@@ -1965,19 +1968,19 @@ function removeGroupDestination(action: DraftAction, destinationId: string) {
 
 function dingTalkGroupSummary(action: DraftAction) {
   const selected = selectedGroupDestinations(action)
-  if (!selected.length) return 'No groups selected'
+  if (!selected.length) return automationLabel('dingtalk.noGroupsSelected', isZh.value)
   return selected.map((item) => item.label).join(', ')
 }
 
 function groupDestinationFieldPathWarnings(value: unknown) {
-  return listDingTalkGroupDestinationFieldPathWarnings(value, props.fields)
+  return listDingTalkGroupDestinationFieldPathWarnings(value, props.fields, isZh.value)
 }
 
 function groupDestinationFieldPathSummary(value: unknown) {
   const labels = parseRecipientFieldPathsText(value)
     .map((path) => recipientFieldSummaryLabel(path))
     .filter(Boolean)
-  if (!labels.length) return 'No dynamic group field'
+  if (!labels.length) return automationLabel('dingtalk.noDynamicGroupField', isZh.value)
   return labels.join(', ')
 }
 
@@ -2017,31 +2020,32 @@ function templatePreviewText(value: unknown, fallback: string) {
 
 function renderedTemplateExample(value: unknown, fallback: string) {
   if (typeof value !== 'string' || !value.trim()) return fallback
-  const rendered = renderDingTalkTemplateExample(value).trim()
+  const rendered = renderDingTalkTemplateExample(value, isZh.value).trim()
   return rendered || fallback
 }
 
 function publicFormLinkWarnings(value: unknown, warnWhenDingTalkAccessRisk = false) {
   return listDingTalkPublicFormLinkWarnings(value, formViews.value, {
+    isZh: isZh.value,
     warnWhenFullyPublic: warnWhenDingTalkAccessRisk,
     warnWhenProtectedWithoutAllowlist: warnWhenDingTalkAccessRisk,
   })
 }
 
 function publicFormLinkBlockingErrors(value: unknown) {
-  return listDingTalkPublicFormLinkBlockingErrors(value, formViews.value)
+  return listDingTalkPublicFormLinkBlockingErrors(value, formViews.value, { isZh: isZh.value })
 }
 
 function internalViewLinkWarnings(value: unknown) {
-  return listDingTalkInternalViewLinkWarnings(value, internalViews.value)
+  return listDingTalkInternalViewLinkWarnings(value, internalViews.value, isZh.value)
 }
 
 function internalViewLinkBlockingErrors(value: unknown) {
-  return listDingTalkInternalViewLinkBlockingErrors(value, internalViews.value)
+  return listDingTalkInternalViewLinkBlockingErrors(value, internalViews.value, isZh.value)
 }
 
 function publicFormAccessState(value: unknown) {
-  return getDingTalkPublicFormLinkAccessState(value, formViews.value)
+  return getDingTalkPublicFormLinkAccessState(value, formViews.value, { isZh: isZh.value })
 }
 
 function isDingTalkActionType(value: unknown): boolean {
@@ -2070,10 +2074,10 @@ function personRecipientSummary(action: DraftAction) {
   const selectedUsers = selectedPersonRecipients(action).map((item) => item.label)
   const selectedGroups = selectedPersonRecipientGroups(action).map((item) => item.label)
   const parts = [
-    selectedUsers.length ? `Users: ${selectedUsers.join(', ')}` : '',
-    selectedGroups.length ? `Groups: ${selectedGroups.join(', ')}` : '',
+    selectedUsers.length ? `${isZh.value ? '用户' : 'Users'}: ${selectedUsers.join(', ')}` : '',
+    selectedGroups.length ? `${isZh.value ? '成员组' : 'Groups'}: ${selectedGroups.join(', ')}` : '',
   ].filter(Boolean)
-  if (!parts.length) return 'No recipients selected'
+  if (!parts.length) return automationLabel('dingtalk.noRecipientsSelected', isZh.value)
   return parts.join(' | ')
 }
 
@@ -2113,18 +2117,26 @@ function selectedMemberGroupRecipientFields(action: DraftAction) {
 }
 
 function recipientFieldPathWarnings(value: unknown) {
-  return listDingTalkPersonRecipientFieldPathWarnings(value, props.fields)
+  return listDingTalkPersonRecipientFieldPathWarnings(value, props.fields, isZh.value)
 }
 
 function memberGroupRecipientFieldPathWarnings(value: unknown) {
-  return listDingTalkPersonMemberGroupRecipientFieldPathWarnings(value, props.fields)
+  return listDingTalkPersonMemberGroupRecipientFieldPathWarnings(value, props.fields, isZh.value)
 }
 
 function recipientFieldPathSummary(value: unknown) {
   const labels = parseRecipientFieldPathsText(value)
     .map((path) => recipientFieldSummaryLabel(path))
     .filter(Boolean)
-  if (!labels.length) return 'No dynamic recipient field'
+  if (!labels.length) return automationLabel('dingtalk.noDynamicRecipientField', isZh.value)
+  return labels.join(', ')
+}
+
+function memberGroupRecipientFieldPathSummary(value: unknown) {
+  const labels = parseRecipientFieldPathsText(value)
+    .map((path) => recipientFieldSummaryLabel(path))
+    .filter(Boolean)
+  if (!labels.length) return automationLabel('dingtalk.noDynamicMemberGroupField', isZh.value)
   return labels.join(', ')
 }
 
@@ -2165,7 +2177,7 @@ function removeMemberGroupRecipientFieldPath(action: DraftAction, path: string) 
 }
 
 function templateSyntaxWarnings(value: unknown) {
-  return typeof value === 'string' ? listDingTalkTemplateSyntaxWarnings(value) : []
+  return typeof value === 'string' ? listDingTalkTemplateSyntaxWarnings(value, isZh.value) : []
 }
 
 onBeforeUnmount(() => {
@@ -2184,6 +2196,7 @@ function applyGroupPreset(action: DraftAction, preset: DingTalkNotificationPrese
       },
       preset,
       props.views ?? [],
+      isZh.value,
     ),
   }
 }
@@ -2200,6 +2213,7 @@ function applyPersonPreset(action: DraftAction, preset: DingTalkNotificationPres
       },
       preset,
       props.views ?? [],
+      isZh.value,
     ),
   }
 }

--- a/apps/web/src/multitable/utils/dingtalkInternalViewLinkWarnings.ts
+++ b/apps/web/src/multitable/utils/dingtalkInternalViewLinkWarnings.ts
@@ -6,13 +6,16 @@ export interface DingTalkInternalViewLinkView {
 export function listDingTalkInternalViewLinkBlockingErrors(
   viewId: unknown,
   views: readonly DingTalkInternalViewLinkView[],
+  isZh = false,
 ): string[] {
   const id = typeof viewId === 'string' ? viewId.trim() : ''
   if (!id) return []
 
   const view = views.find((item) => item.id === id)
   if (!view) {
-    return [`Internal processing view "${id}" is not available in this sheet; DingTalk messages may not include a working processing link.`]
+    return [isZh
+      ? `内部处理视图 "${id}" 在此表中不可用；钉钉消息可能不包含可用的处理链接。`
+      : `Internal processing view "${id}" is not available in this sheet; DingTalk messages may not include a working processing link.`]
   }
 
   return []
@@ -21,6 +24,7 @@ export function listDingTalkInternalViewLinkBlockingErrors(
 export function listDingTalkInternalViewLinkWarnings(
   viewId: unknown,
   views: readonly DingTalkInternalViewLinkView[],
+  isZh = false,
 ): string[] {
-  return listDingTalkInternalViewLinkBlockingErrors(viewId, views)
+  return listDingTalkInternalViewLinkBlockingErrors(viewId, views, isZh)
 }

--- a/apps/web/src/multitable/utils/dingtalkNotificationPresets.ts
+++ b/apps/web/src/multitable/utils/dingtalkNotificationPresets.ts
@@ -29,6 +29,7 @@ export function applyDingTalkNotificationPreset(
   config: DingTalkNotificationPresetConfig,
   preset: DingTalkNotificationPreset,
   views: MetaView[],
+  isZh = false,
 ): DingTalkNotificationPresetConfig {
   const formViewId = pickDefaultFormViewId(views, config.publicFormViewId)
   const internalViewId = pickDefaultInternalViewId(views, config.internalViewId)
@@ -36,8 +37,10 @@ export function applyDingTalkNotificationPreset(
   if (preset === 'form_request') {
     return {
       ...config,
-      titleTemplate: '{{recordId}} 待填写',
-      bodyTemplate: '请完成本次表单填写。\n记录编号：{{recordId}}\n触发人：{{actorId}}',
+      titleTemplate: isZh ? '{{recordId}} 待填写' : '{{recordId}} needs input',
+      bodyTemplate: isZh
+        ? '请完成本次表单填写。\n记录编号：{{recordId}}\n触发人：{{actorId}}'
+        : 'Please complete this form request.\nRecord ID: {{recordId}}\nActor: {{actorId}}',
       publicFormViewId: formViewId,
       internalViewId: '',
     }
@@ -46,8 +49,10 @@ export function applyDingTalkNotificationPreset(
   if (preset === 'internal_process') {
     return {
       ...config,
-      titleTemplate: '{{recordId}} 待处理',
-      bodyTemplate: '请查看并处理该记录。\n记录编号：{{recordId}}\n触发人：{{actorId}}',
+      titleTemplate: isZh ? '{{recordId}} 待处理' : '{{recordId}} needs processing',
+      bodyTemplate: isZh
+        ? '请查看并处理该记录。\n记录编号：{{recordId}}\n触发人：{{actorId}}'
+        : 'Please review and process this record.\nRecord ID: {{recordId}}\nActor: {{actorId}}',
       publicFormViewId: '',
       internalViewId,
     }
@@ -55,8 +60,10 @@ export function applyDingTalkNotificationPreset(
 
   return {
     ...config,
-    titleTemplate: '{{recordId}} 待填写并处理',
-    bodyTemplate: '请先填写所需信息，并由有权限成员继续处理该记录。\n记录编号：{{recordId}}\n触发人：{{actorId}}',
+    titleTemplate: isZh ? '{{recordId}} 待填写并处理' : '{{recordId}} needs input and processing',
+    bodyTemplate: isZh
+      ? '请先填写所需信息，并由有权限成员继续处理该记录。\n记录编号：{{recordId}}\n触发人：{{actorId}}'
+      : 'Please complete the required form input, then continue processing this record.\nRecord ID: {{recordId}}\nActor: {{actorId}}',
     publicFormViewId: formViewId,
     internalViewId,
   }

--- a/apps/web/src/multitable/utils/dingtalkNotificationTemplateExample.ts
+++ b/apps/web/src/multitable/utils/dingtalkNotificationTemplateExample.ts
@@ -19,7 +19,22 @@ function renderTemplateValue(value: unknown): string {
   }
 }
 
-const EXAMPLE_TEMPLATE_DATA: Record<string, unknown> = {
+const EXAMPLE_TEMPLATE_DATA_EN: Record<string, unknown> = {
+  sheetId: 'sheet_demo_001',
+  recordId: 'record_demo_001',
+  actorId: 'user_demo_001',
+  record: {
+    title: 'Sample request',
+    status: 'Pending',
+    owner: 'Sample owner',
+    name: 'Sample contact',
+    email: 'demo@example.com',
+    mobile: '13900001234',
+    xxx: 'Sample field value',
+  },
+}
+
+const EXAMPLE_TEMPLATE_DATA_ZH: Record<string, unknown> = {
   sheetId: 'sheet_demo_001',
   recordId: 'record_demo_001',
   actorId: 'user_demo_001',
@@ -34,8 +49,9 @@ const EXAMPLE_TEMPLATE_DATA: Record<string, unknown> = {
   },
 }
 
-export function renderDingTalkTemplateExample(template: string): string {
+export function renderDingTalkTemplateExample(template: string, isZh = false): string {
+  const data = isZh ? EXAMPLE_TEMPLATE_DATA_ZH : EXAMPLE_TEMPLATE_DATA_EN
   return template.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (_match, key: string) =>
-    renderTemplateValue(lookupTemplateValue(key, EXAMPLE_TEMPLATE_DATA)),
+    renderTemplateValue(lookupTemplateValue(key, data)),
   )
 }

--- a/apps/web/src/multitable/utils/dingtalkNotificationTemplateLint.ts
+++ b/apps/web/src/multitable/utils/dingtalkNotificationTemplateLint.ts
@@ -10,7 +10,7 @@ function isKnownPlaceholderPath(path: string): boolean {
   return false
 }
 
-export function listDingTalkTemplateSyntaxWarnings(template: string): string[] {
+export function listDingTalkTemplateSyntaxWarnings(template: string, isZh = false): string[] {
   const warnings: string[] = []
   const seen = new Set<string>()
 
@@ -24,21 +24,27 @@ export function listDingTalkTemplateSyntaxWarnings(template: string): string[] {
     const raw = match[0]
     const inner = match[1].trim()
     if (!inner) {
-      push('Empty placeholder {{ }} is not supported.')
+      push(isZh ? '不支持空占位符 {{ }}。' : 'Empty placeholder {{ }} is not supported.')
       continue
     }
     if (!VALID_TEMPLATE_PATH.test(inner)) {
-      push(`Unsupported placeholder syntax ${raw}. Use letters, numbers, "_" and dot paths such as {{recordId}} or {{record.xxx}}.`)
+      push(isZh
+        ? `不支持的占位符语法 ${raw}。请使用字母、数字、"_" 和点路径，例如 {{recordId}} 或 {{record.xxx}}。`
+        : `Unsupported placeholder syntax ${raw}. Use letters, numbers, "_" and dot paths such as {{recordId}} or {{record.xxx}}.`)
       continue
     }
     if (!isKnownPlaceholderPath(inner)) {
-      push(`Unknown placeholder ${raw}. Use {{recordId}}, {{sheetId}}, {{actorId}}, or {{record.fieldName}}.`)
+      push(isZh
+        ? `未知占位符 ${raw}。请使用 {{recordId}}、{{sheetId}}、{{actorId}} 或 {{record.fieldName}}。`
+        : `Unknown placeholder ${raw}. Use {{recordId}}, {{sheetId}}, {{actorId}}, or {{record.fieldName}}.`)
     }
   }
 
   const stripped = template.replace(/\{\{[^{}]*\}\}/g, '')
   if (stripped.includes('{{') || stripped.includes('}}')) {
-    push('Unclosed placeholder braces detected. Use complete forms like {{recordId}}.')
+    push(isZh
+      ? '检测到未闭合的占位符花括号。请使用类似 {{recordId}} 的完整形式。'
+      : 'Unclosed placeholder braces detected. Use complete forms like {{recordId}}.')
   }
 
   return warnings

--- a/apps/web/src/multitable/utils/dingtalkNotificationTemplateTokens.ts
+++ b/apps/web/src/multitable/utils/dingtalkNotificationTemplateTokens.ts
@@ -1,5 +1,10 @@
+import {
+  automationDingTalkTemplateTokenLabel,
+  type AutomationDingTalkTemplateTokenKey,
+} from './meta-automation-labels'
+
 export interface DingTalkNotificationTemplateToken {
-  key: string
+  key: AutomationDingTalkTemplateTokenKey
   label: string
   value: string
 }
@@ -20,4 +25,8 @@ export function appendTemplateToken(currentValue: string, token: string, multili
   if (currentValue.endsWith(token)) return currentValue
   if (/\s$/.test(currentValue)) return `${currentValue}${token}`
   return multiline ? `${currentValue}\n${token}` : `${currentValue} ${token}`
+}
+
+export function dingTalkTemplateTokenLabel(token: DingTalkNotificationTemplateToken, isZh: boolean): string {
+  return automationDingTalkTemplateTokenLabel(token.key, isZh)
 }

--- a/apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts
+++ b/apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts
@@ -1,3 +1,8 @@
+import {
+  automationDingTalkAllowlistSummary,
+  automationLabel,
+} from './meta-automation-labels'
+
 export interface DingTalkPublicFormLinkView {
   id: string
   name?: string
@@ -6,6 +11,7 @@ export interface DingTalkPublicFormLinkView {
 }
 
 export interface DingTalkPublicFormLinkWarningOptions {
+  isZh?: boolean
   nowMs?: number
   warnWhenFullyPublic?: boolean
   warnWhenProtectedWithoutAllowlist?: boolean
@@ -63,15 +69,8 @@ function countAllowlistIds(value: unknown): number {
   ).size
 }
 
-function describeAllowlistCounts(userCount: number, memberGroupCount: number): string {
-  const parts: string[] = []
-  if (userCount > 0) {
-    parts.push(`${userCount} ${userCount === 1 ? 'local user' : 'local users'}`)
-  }
-  if (memberGroupCount > 0) {
-    parts.push(`${memberGroupCount} ${memberGroupCount === 1 ? 'local member group' : 'local member groups'}`)
-  }
-  return parts.join(' and ')
+function label(key: Parameters<typeof automationLabel>[0], isZh: boolean): string {
+  return automationLabel(key, isZh)
 }
 
 export function describeDingTalkPublicFormLinkAudience(
@@ -81,33 +80,36 @@ export function describeDingTalkPublicFormLinkAudience(
 ): string {
   const options = normalizeWarningOptions(optionsOrNowMs)
   const nowMs = options.nowMs ?? Date.now()
+  const isZh = options.isZh === true
   const id = typeof viewId === 'string' ? viewId.trim() : ''
-  if (!id) return 'No public form link'
+  if (!id) return label('dingtalk.noPublicFormLink', isZh)
 
   const view = views.find((item) => item.id === id)
-  if (!view || view.type !== 'form') return 'Allowed audience unavailable'
+  if (!view || view.type !== 'form') return label('dingtalk.allowedAudienceUnavailable', isZh)
 
   const publicForm = isRecord(view.config?.publicForm) ? view.config.publicForm : null
-  if (!publicForm || publicForm.enabled !== true) return 'Allowed audience unavailable'
+  if (!publicForm || publicForm.enabled !== true) return label('dingtalk.allowedAudienceUnavailable', isZh)
 
   const publicToken = typeof publicForm.publicToken === 'string' ? publicForm.publicToken.trim() : ''
-  if (!publicToken) return 'Allowed audience unavailable'
+  if (!publicToken) return label('dingtalk.allowedAudienceUnavailable', isZh)
 
   const expiryMs = parseExpiryMs(publicForm.expiresAt ?? publicForm.expiresOn)
-  if (expiryMs !== null && nowMs >= expiryMs) return 'Allowed audience unavailable'
+  if (expiryMs !== null && nowMs >= expiryMs) return label('dingtalk.allowedAudienceUnavailable', isZh)
 
   const accessMode = normalizeAccessMode(publicForm.accessMode)
-  if (accessMode === 'public') return 'Anyone with the link can submit'
+  if (accessMode === 'public') return isZh ? '任何获得链接的人都可提交' : 'Anyone with the link can submit'
 
   const userCount = countAllowlistIds(publicForm.allowedUserIds)
   const memberGroupCount = countAllowlistIds(publicForm.allowedMemberGroupIds)
   if (userCount === 0 && memberGroupCount === 0) {
     return accessMode === 'dingtalk_granted'
-      ? 'No local allowlist limits are set; all authorized DingTalk users can submit'
-      : 'No local allowlist limits are set; all bound DingTalk users can submit'
+      ? (isZh ? '未设置本地 allowlist 限制；所有已授权钉钉用户都可提交' : 'No local allowlist limits are set; all authorized DingTalk users can submit')
+      : (isZh ? '未设置本地 allowlist 限制；所有已绑定钉钉用户都可提交' : 'No local allowlist limits are set; all bound DingTalk users can submit')
   }
 
-  return `${describeAllowlistCounts(userCount, memberGroupCount)} can submit after DingTalk checks`
+  return isZh
+    ? `${automationDingTalkAllowlistSummary(userCount, memberGroupCount, true)}通过钉钉检查后可提交`
+    : `${automationDingTalkAllowlistSummary(userCount, memberGroupCount, false)} can submit after DingTalk checks`
 }
 
 export function describeDingTalkPublicFormLinkAccess(
@@ -117,22 +119,23 @@ export function describeDingTalkPublicFormLinkAccess(
 ): string {
   const options = normalizeWarningOptions(optionsOrNowMs)
   const nowMs = options.nowMs ?? Date.now()
+  const isZh = options.isZh === true
   const id = typeof viewId === 'string' ? viewId.trim() : ''
-  if (!id) return 'No public form link'
+  if (!id) return label('dingtalk.noPublicFormLink', isZh)
 
   const view = views.find((item) => item.id === id)
-  if (!view) return 'View unavailable in this sheet'
-  if (view.type !== 'form') return 'Selected view is not a form'
+  if (!view) return label('dingtalk.viewUnavailable', isZh)
+  if (view.type !== 'form') return label('dingtalk.selectedViewNotForm', isZh)
 
   const publicForm = isRecord(view.config?.publicForm) ? view.config.publicForm : null
-  if (!publicForm) return 'Public form sharing is not configured'
-  if (publicForm.enabled !== true) return 'Public form sharing is disabled'
+  if (!publicForm) return label('dingtalk.publicFormNotConfigured', isZh)
+  if (publicForm.enabled !== true) return label('dingtalk.publicFormDisabled', isZh)
 
   const publicToken = typeof publicForm.publicToken === 'string' ? publicForm.publicToken.trim() : ''
-  if (!publicToken) return 'Public form sharing is missing a public token'
+  if (!publicToken) return label('dingtalk.publicFormMissingToken', isZh)
 
   const expiryMs = parseExpiryMs(publicForm.expiresAt ?? publicForm.expiresOn)
-  if (expiryMs !== null && nowMs >= expiryMs) return 'Public form sharing has expired'
+  if (expiryMs !== null && nowMs >= expiryMs) return label('dingtalk.publicFormExpired', isZh)
 
   const hasUserAllowlist = hasAllowlistIds(publicForm.allowedUserIds)
   const hasGroupAllowlist = hasAllowlistIds(publicForm.allowedMemberGroupIds)
@@ -140,12 +143,16 @@ export function describeDingTalkPublicFormLinkAccess(
   const accessMode = normalizeAccessMode(publicForm.accessMode)
 
   if (accessMode === 'dingtalk') {
-    return hasAllowlist ? 'DingTalk-bound users in allowlist can submit' : 'All bound DingTalk users can submit'
+    return hasAllowlist
+      ? (isZh ? 'allowlist 中已绑定钉钉的用户可提交' : 'DingTalk-bound users in allowlist can submit')
+      : (isZh ? '所有已绑定钉钉用户都可提交' : 'All bound DingTalk users can submit')
   }
   if (accessMode === 'dingtalk_granted') {
-    return hasAllowlist ? 'Authorized DingTalk users in allowlist can submit' : 'All authorized DingTalk users can submit'
+    return hasAllowlist
+      ? (isZh ? 'allowlist 中已授权的钉钉用户可提交' : 'Authorized DingTalk users in allowlist can submit')
+      : (isZh ? '所有已授权钉钉用户都可提交' : 'All authorized DingTalk users can submit')
   }
-  return 'Fully public; anyone with the link can submit'
+  return isZh ? '完全公开；任何获得链接的人都可提交' : 'Fully public; anyone with the link can submit'
 }
 
 export function getDingTalkPublicFormLinkAccessLevel(
@@ -196,33 +203,46 @@ export function listDingTalkPublicFormLinkBlockingErrors(
 ): string[] {
   const options = normalizeWarningOptions(optionsOrNowMs)
   const nowMs = options.nowMs ?? Date.now()
+  const isZh = options.isZh === true
   const id = typeof viewId === 'string' ? viewId.trim() : ''
   if (!id) return []
 
   const view = views.find((item) => item.id === id)
   if (!view) {
-    return [`Public form view "${id}" is not available in this sheet; DingTalk messages may not include a working fill link.`]
+    return [isZh
+      ? `公开表单视图 "${id}" 在此表中不可用；钉钉消息可能不包含可用的填写链接。`
+      : `Public form view "${id}" is not available in this sheet; DingTalk messages may not include a working fill link.`]
   }
   if (view.type !== 'form') {
-    return [`Selected public form view "${publicFormLabel(view, id)}" is not a form view; choose a form view before sending this DingTalk fill link.`]
+    return [isZh
+      ? `所选公开表单视图 "${publicFormLabel(view, id)}" 不是表单视图；发送此钉钉填写链接前请选择表单视图。`
+      : `Selected public form view "${publicFormLabel(view, id)}" is not a form view; choose a form view before sending this DingTalk fill link.`]
   }
 
   const publicForm = isRecord(view.config?.publicForm) ? view.config.publicForm : null
   if (!publicForm) {
-    return [`Public form sharing is not configured for "${publicFormLabel(view, id)}"; enable sharing before sending this DingTalk fill link.`]
+    return [isZh
+      ? `未为 "${publicFormLabel(view, id)}" 配置公开表单分享；发送此钉钉填写链接前请先启用分享。`
+      : `Public form sharing is not configured for "${publicFormLabel(view, id)}"; enable sharing before sending this DingTalk fill link.`]
   }
   if (publicForm.enabled !== true) {
-    return [`Public form sharing is disabled for "${publicFormLabel(view, id)}"; enable sharing before sending this DingTalk fill link.`]
+    return [isZh
+      ? `"${publicFormLabel(view, id)}" 的公开表单分享已停用；发送此钉钉填写链接前请先启用分享。`
+      : `Public form sharing is disabled for "${publicFormLabel(view, id)}"; enable sharing before sending this DingTalk fill link.`]
   }
 
   const publicToken = typeof publicForm.publicToken === 'string' ? publicForm.publicToken.trim() : ''
   if (!publicToken) {
-    return [`Public form sharing for "${publicFormLabel(view, id)}" is missing a public token; re-enable sharing before sending this DingTalk fill link.`]
+    return [isZh
+      ? `"${publicFormLabel(view, id)}" 的公开表单分享缺少公开令牌；发送此钉钉填写链接前请重新启用分享。`
+      : `Public form sharing for "${publicFormLabel(view, id)}" is missing a public token; re-enable sharing before sending this DingTalk fill link.`]
   }
 
   const expiryMs = parseExpiryMs(publicForm.expiresAt ?? publicForm.expiresOn)
   if (expiryMs !== null && nowMs >= expiryMs) {
-    return [`Public form sharing for "${publicFormLabel(view, id)}" has expired; renew sharing before sending this DingTalk fill link.`]
+    return [isZh
+      ? `"${publicFormLabel(view, id)}" 的公开表单分享已过期；发送此钉钉填写链接前请续期分享。`
+      : `Public form sharing for "${publicFormLabel(view, id)}" has expired; renew sharing before sending this DingTalk fill link.`]
   }
 
   return []
@@ -234,6 +254,7 @@ export function listDingTalkPublicFormLinkWarnings(
   optionsOrNowMs?: number | DingTalkPublicFormLinkWarningOptions,
 ): string[] {
   const options = normalizeWarningOptions(optionsOrNowMs)
+  const isZh = options.isZh === true
   const id = typeof viewId === 'string' ? viewId.trim() : ''
   if (!id) return []
 
@@ -246,7 +267,9 @@ export function listDingTalkPublicFormLinkWarnings(
 
   const accessMode = normalizeAccessMode(publicForm.accessMode)
   if (options.warnWhenFullyPublic && accessMode === 'public') {
-    return [`Public form sharing for "${publicFormLabel(view, id)}" is fully public; everyone who can open the DingTalk message link can submit. Use DingTalk-protected access and an allowlist when only selected users should fill.`]
+    return [isZh
+      ? `"${publicFormLabel(view, id)}" 的公开表单分享完全公开；所有能打开钉钉消息链接的人都可提交。若仅允许指定用户填写，请使用钉钉保护访问和 allowlist。`
+      : `Public form sharing for "${publicFormLabel(view, id)}" is fully public; everyone who can open the DingTalk message link can submit. Use DingTalk-protected access and an allowlist when only selected users should fill.`]
   }
   if (
     options.warnWhenProtectedWithoutAllowlist
@@ -254,8 +277,12 @@ export function listDingTalkPublicFormLinkWarnings(
     && !hasAllowlistIds(publicForm.allowedUserIds)
     && !hasAllowlistIds(publicForm.allowedMemberGroupIds)
   ) {
-    const audience = accessMode === 'dingtalk_granted' ? 'authorized DingTalk users' : 'bound DingTalk users'
-    return [`Public form sharing for "${publicFormLabel(view, id)}" allows all ${audience} to submit; add allowed users or member groups when only selected users should fill.`]
+    const audience = accessMode === 'dingtalk_granted'
+      ? (isZh ? '已授权钉钉用户' : 'authorized DingTalk users')
+      : (isZh ? '已绑定钉钉用户' : 'bound DingTalk users')
+    return [isZh
+      ? `"${publicFormLabel(view, id)}" 的公开表单分享允许所有${audience}提交；若仅允许指定用户填写，请添加允许的用户或成员组。`
+      : `Public form sharing for "${publicFormLabel(view, id)}" allows all ${audience} to submit; add allowed users or member groups when only selected users should fill.`]
   }
 
   return []

--- a/apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts
+++ b/apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts
@@ -26,18 +26,25 @@ function parseRecordFieldPaths(value: unknown): string[] {
 export function listDingTalkGroupDestinationFieldPathWarnings(
   value: unknown,
   fields: readonly DingTalkRecipientWarningField[],
+  isZh = false,
 ): string[] {
   const fieldMap = new Map(fields.map((field) => [field.id, field]))
   return parseRecordFieldPaths(value).flatMap((path) => {
     const field = fieldMap.get(path)
     if (!field) {
-      return [`record.${path} is not a known field in this sheet; DingTalk group messages expect field IDs that resolve to destination IDs.`]
+      return [isZh
+        ? `record.${path} 不是此表中的已知字段；钉钉群消息需要能解析为目标 ID 的字段 ID。`
+        : `record.${path} is not a known field in this sheet; DingTalk group messages expect field IDs that resolve to destination IDs.`]
     }
     if (field.type === 'user') {
-      return [`record.${path} is a user field; use DingTalk person recipient fields instead.`]
+      return [isZh
+        ? `record.${path} 是用户字段；请改用钉钉个人收件人字段。`
+        : `record.${path} is a user field; use DingTalk person recipient fields instead.`]
     }
     if (isDingTalkMemberGroupRecipientField(field)) {
-      return [`record.${path} is a member group field; use DingTalk person member-group recipient fields instead.`]
+      return [isZh
+        ? `record.${path} 是成员组字段；请改用钉钉个人成员组收件人字段。`
+        : `record.${path} is a member group field; use DingTalk person member-group recipient fields instead.`]
     }
     return []
   })
@@ -46,30 +53,40 @@ export function listDingTalkGroupDestinationFieldPathWarnings(
 export function listDingTalkPersonRecipientFieldPathWarnings(
   value: unknown,
   fields: readonly DingTalkRecipientWarningField[],
+  isZh = false,
 ): string[] {
   const userFieldIds = new Set(fields
     .filter((field) => field.type === 'user')
     .map((field) => field.id))
   return parseRecordFieldPaths(value)
     .filter((path) => !userFieldIds.has(path))
-    .map((path) => `record.${path} is not a user field; DingTalk person messages expect local user IDs.`)
+    .map((path) => isZh
+      ? `record.${path} 不是用户字段；钉钉个人消息需要本地用户 ID。`
+      : `record.${path} is not a user field; DingTalk person messages expect local user IDs.`)
 }
 
 export function listDingTalkPersonMemberGroupRecipientFieldPathWarnings(
   value: unknown,
   fields: readonly DingTalkRecipientWarningField[],
+  isZh = false,
 ): string[] {
   const fieldMap = new Map(fields.map((field) => [field.id, field]))
   return parseRecordFieldPaths(value).flatMap((path) => {
     const field = fieldMap.get(path)
     if (!field) {
-      return [`record.${path} is not a known field in this sheet; DingTalk person member-group recipients expect field IDs that resolve to member group IDs.`]
+      return [isZh
+        ? `record.${path} 不是此表中的已知字段；钉钉个人成员组收件人需要能解析为成员组 ID 的字段 ID。`
+        : `record.${path} is not a known field in this sheet; DingTalk person member-group recipients expect field IDs that resolve to member group IDs.`]
     }
     if (field.type === 'user') {
-      return [`record.${path} is a user field; use Record recipient field paths instead.`]
+      return [isZh
+        ? `record.${path} 是用户字段；请改用记录收件人字段路径。`
+        : `record.${path} is a user field; use Record recipient field paths instead.`]
     }
     if (!isDingTalkMemberGroupRecipientField(field)) {
-      return [`record.${path} is not a member group field; DingTalk person member-group recipients expect member group fields.`]
+      return [isZh
+        ? `record.${path} 不是成员组字段；钉钉个人成员组收件人需要成员组字段。`
+        : `record.${path} is not a member group field; DingTalk person member-group recipients expect member group fields.`]
     }
     return []
   })

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -35,6 +35,18 @@ export type AutomationCronPresetValue =
 
 export type AutomationCardLinkVariant = 'publicForm' | 'internalView'
 export type AutomationCardStatType = 'ok' | 'fail'
+export type AutomationDingTalkPreset = 'form_request' | 'internal_process' | 'form_and_process'
+export type AutomationDingTalkTemplateTokenKey = 'recordId' | 'sheetId' | 'actorId' | 'recordField'
+export type AutomationDingTalkDestinationScope = 'private' | 'sheet' | 'org'
+export type AutomationDingTalkPersonSubject = 'user' | 'member-group'
+export type AutomationDingTalkPersonStatus =
+  | 'memberGroupCheckedIndividually'
+  | 'noDeliveryLink'
+  | 'deliveryReadyGrantEnabled'
+  | 'deliveryReadyGrantDisabled'
+  | 'notBound'
+  | 'boundGrantEnabled'
+  | 'boundGrantDisabled'
 
 export type AutomationLabelKey =
   | 'log.title'
@@ -144,6 +156,76 @@ export type AutomationLabelKey =
   | 'manager.testRunning'
   | 'manager.testRunningDingTalkWarning'
   | 'manager.testRunAtLeastOneActionFailed'
+  | 'dingtalk.preset'
+  | 'dingtalk.addGroups'
+  | 'dingtalk.addGroupOption'
+  | 'dingtalk.groupsRegisteredHint'
+  | 'dingtalk.noGroupsAvailable'
+  | 'dingtalk.remove'
+  | 'dingtalk.recordGroupFieldPaths'
+  | 'dingtalk.recordGroupFieldPathHint'
+  | 'dingtalk.pickGroupField'
+  | 'dingtalk.pickFieldOption'
+  | 'dingtalk.searchUsersOrGroups'
+  | 'dingtalk.searchUsersOrGroupsPlaceholder'
+  | 'dingtalk.searchingUsersOrGroups'
+  | 'dingtalk.noMatchingUsersOrGroups'
+  | 'dingtalk.inactiveUsersCannotBeAdded'
+  | 'dingtalk.localUserIds'
+  | 'dingtalk.localUserIdsPlaceholder'
+  | 'dingtalk.memberGroupIds'
+  | 'dingtalk.memberGroupIdsPlaceholder'
+  | 'dingtalk.recordRecipientFieldPaths'
+  | 'dingtalk.recordRecipientFieldPathPlaceholder'
+  | 'dingtalk.pickRecipientField'
+  | 'dingtalk.chooseUserFieldOption'
+  | 'dingtalk.recordRecipientFieldPathHint'
+  | 'dingtalk.recordMemberGroupFieldPaths'
+  | 'dingtalk.recordMemberGroupFieldPathPlaceholder'
+  | 'dingtalk.pickMemberGroupField'
+  | 'dingtalk.chooseMemberGroupFieldOption'
+  | 'dingtalk.recordMemberGroupFieldPathHint'
+  | 'dingtalk.titleTemplate'
+  | 'dingtalk.titleTemplatePlaceholder'
+  | 'dingtalk.bodyTemplate'
+  | 'dingtalk.bodyTemplatePlaceholder'
+  | 'dingtalk.templateTokens'
+  | 'dingtalk.publicFormView'
+  | 'dingtalk.noPublicFormLinkOption'
+  | 'dingtalk.internalProcessingView'
+  | 'dingtalk.noInternalLinkOption'
+  | 'dingtalk.noInternalLink'
+  | 'dingtalk.messageSummary'
+  | 'dingtalk.groups'
+  | 'dingtalk.recordGroups'
+  | 'dingtalk.recipients'
+  | 'dingtalk.recordRecipients'
+  | 'dingtalk.recordMemberGroups'
+  | 'dingtalk.noGroupsSelected'
+  | 'dingtalk.noRecipientsSelected'
+  | 'dingtalk.noDynamicGroupField'
+  | 'dingtalk.noDynamicRecipientField'
+  | 'dingtalk.noDynamicMemberGroupField'
+  | 'dingtalk.renderedTitle'
+  | 'dingtalk.renderedBody'
+  | 'dingtalk.noTitleTemplate'
+  | 'dingtalk.noBodyTemplate'
+  | 'dingtalk.noRenderedTitle'
+  | 'dingtalk.noRenderedBody'
+  | 'dingtalk.copy'
+  | 'dingtalk.copied'
+  | 'dingtalk.publicForm'
+  | 'dingtalk.publicFormAccess'
+  | 'dingtalk.allowedAudience'
+  | 'dingtalk.internalProcessing'
+  | 'dingtalk.noPublicFormLink'
+  | 'dingtalk.allowedAudienceUnavailable'
+  | 'dingtalk.viewUnavailable'
+  | 'dingtalk.selectedViewNotForm'
+  | 'dingtalk.publicFormNotConfigured'
+  | 'dingtalk.publicFormDisabled'
+  | 'dingtalk.publicFormMissingToken'
+  | 'dingtalk.publicFormExpired'
   | 'error.loadGroupDeliveries'
   | 'error.loadPersonDeliveries'
   | 'error.loadRules'
@@ -266,6 +348,76 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'manager.testRunning',
   'manager.testRunningDingTalkWarning',
   'manager.testRunAtLeastOneActionFailed',
+  'dingtalk.preset',
+  'dingtalk.addGroups',
+  'dingtalk.addGroupOption',
+  'dingtalk.groupsRegisteredHint',
+  'dingtalk.noGroupsAvailable',
+  'dingtalk.remove',
+  'dingtalk.recordGroupFieldPaths',
+  'dingtalk.recordGroupFieldPathHint',
+  'dingtalk.pickGroupField',
+  'dingtalk.pickFieldOption',
+  'dingtalk.searchUsersOrGroups',
+  'dingtalk.searchUsersOrGroupsPlaceholder',
+  'dingtalk.searchingUsersOrGroups',
+  'dingtalk.noMatchingUsersOrGroups',
+  'dingtalk.inactiveUsersCannotBeAdded',
+  'dingtalk.localUserIds',
+  'dingtalk.localUserIdsPlaceholder',
+  'dingtalk.memberGroupIds',
+  'dingtalk.memberGroupIdsPlaceholder',
+  'dingtalk.recordRecipientFieldPaths',
+  'dingtalk.recordRecipientFieldPathPlaceholder',
+  'dingtalk.pickRecipientField',
+  'dingtalk.chooseUserFieldOption',
+  'dingtalk.recordRecipientFieldPathHint',
+  'dingtalk.recordMemberGroupFieldPaths',
+  'dingtalk.recordMemberGroupFieldPathPlaceholder',
+  'dingtalk.pickMemberGroupField',
+  'dingtalk.chooseMemberGroupFieldOption',
+  'dingtalk.recordMemberGroupFieldPathHint',
+  'dingtalk.titleTemplate',
+  'dingtalk.titleTemplatePlaceholder',
+  'dingtalk.bodyTemplate',
+  'dingtalk.bodyTemplatePlaceholder',
+  'dingtalk.templateTokens',
+  'dingtalk.publicFormView',
+  'dingtalk.noPublicFormLinkOption',
+  'dingtalk.internalProcessingView',
+  'dingtalk.noInternalLinkOption',
+  'dingtalk.noInternalLink',
+  'dingtalk.messageSummary',
+  'dingtalk.groups',
+  'dingtalk.recordGroups',
+  'dingtalk.recipients',
+  'dingtalk.recordRecipients',
+  'dingtalk.recordMemberGroups',
+  'dingtalk.noGroupsSelected',
+  'dingtalk.noRecipientsSelected',
+  'dingtalk.noDynamicGroupField',
+  'dingtalk.noDynamicRecipientField',
+  'dingtalk.noDynamicMemberGroupField',
+  'dingtalk.renderedTitle',
+  'dingtalk.renderedBody',
+  'dingtalk.noTitleTemplate',
+  'dingtalk.noBodyTemplate',
+  'dingtalk.noRenderedTitle',
+  'dingtalk.noRenderedBody',
+  'dingtalk.copy',
+  'dingtalk.copied',
+  'dingtalk.publicForm',
+  'dingtalk.publicFormAccess',
+  'dingtalk.allowedAudience',
+  'dingtalk.internalProcessing',
+  'dingtalk.noPublicFormLink',
+  'dingtalk.allowedAudienceUnavailable',
+  'dingtalk.viewUnavailable',
+  'dingtalk.selectedViewNotForm',
+  'dingtalk.publicFormNotConfigured',
+  'dingtalk.publicFormDisabled',
+  'dingtalk.publicFormMissingToken',
+  'dingtalk.publicFormExpired',
   'error.loadGroupDeliveries',
   'error.loadPersonDeliveries',
   'error.loadRules',
@@ -389,6 +541,76 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'manager.testRunning': { en: 'Running test.', zh: '正在运行测试。' },
   'manager.testRunningDingTalkWarning': { en: 'Running test. DingTalk actions may send real messages.', zh: '正在运行测试。钉钉动作可能发送真实消息。' },
   'manager.testRunAtLeastOneActionFailed': { en: 'At least one action failed.', zh: '至少一个动作失败。' },
+  'dingtalk.preset': { en: 'Message preset', zh: '消息预设' },
+  'dingtalk.addGroups': { en: 'Add DingTalk groups', zh: '添加钉钉群' },
+  'dingtalk.addGroupOption': { en: '-- add DingTalk group --', zh: '-- 添加钉钉群 --' },
+  'dingtalk.groupsRegisteredHint': { en: 'DingTalk groups registered for this table or shared from the organization catalog are listed here.', zh: '此处列出为本表注册或从组织目录共享的钉钉群。' },
+  'dingtalk.noGroupsAvailable': { en: 'No DingTalk groups are available for this table yet. Add one in API Tokens & Webhooks > DingTalk Groups, ask an admin to share an organization catalog group, or use a record group field path below.', zh: '此表暂无可用钉钉群。请在 API Token 与 Webhook > 钉钉群中添加，或让管理员共享组织目录群，也可使用下方记录群字段路径。' },
+  'dingtalk.remove': { en: 'Remove', zh: '移除' },
+  'dingtalk.recordGroupFieldPaths': { en: 'Record group field paths (optional)', zh: '记录群字段路径（可选）' },
+  'dingtalk.recordGroupFieldPathHint': { en: 'Use record fields whose value is a DingTalk group destination ID, not a local user, member group, or DingTalk group name.', zh: '使用值为钉钉群目标 ID 的记录字段，不要使用本地用户、成员组或钉钉群名称。' },
+  'dingtalk.pickGroupField': { en: 'Pick group field', zh: '选择群字段' },
+  'dingtalk.pickFieldOption': { en: '-- pick field --', zh: '-- 选择字段 --' },
+  'dingtalk.searchUsersOrGroups': { en: 'Search and add users or member groups', zh: '搜索并添加用户或成员组' },
+  'dingtalk.searchUsersOrGroupsPlaceholder': { en: 'Search by user, member group, email, or subject ID', zh: '按用户、成员组、邮箱或主体 ID 搜索' },
+  'dingtalk.searchingUsersOrGroups': { en: 'Searching users and member groups...', zh: '正在搜索用户和成员组...' },
+  'dingtalk.noMatchingUsersOrGroups': { en: 'No matching users or member groups', zh: '没有匹配的用户或成员组' },
+  'dingtalk.inactiveUsersCannotBeAdded': { en: 'Inactive users cannot be added', zh: '不能添加已停用用户' },
+  'dingtalk.localUserIds': { en: 'Local user IDs', zh: '本地用户 ID' },
+  'dingtalk.localUserIdsPlaceholder': { en: 'Use comma or newline separated local user IDs', zh: '使用逗号或换行分隔本地 userId' },
+  'dingtalk.memberGroupIds': { en: 'Member group IDs (optional)', zh: '成员组 ID（可选）' },
+  'dingtalk.memberGroupIdsPlaceholder': { en: 'Use comma or newline separated member group IDs', zh: '使用逗号或换行分隔成员组 ID' },
+  'dingtalk.recordRecipientFieldPaths': { en: 'Record recipient field paths (optional)', zh: '记录收件人字段路径（可选）' },
+  'dingtalk.recordRecipientFieldPathPlaceholder': { en: 'Example: record.assigneeUserIds, record.reviewerUserId', zh: '例如：record.assigneeUserIds, record.reviewerUserId' },
+  'dingtalk.pickRecipientField': { en: 'Pick recipient field', zh: '选择收件人字段' },
+  'dingtalk.chooseUserFieldOption': { en: '-- choose a user field --', zh: '-- 选择用户字段 --' },
+  'dingtalk.recordRecipientFieldPathHint': { en: 'Record data is keyed by field ID. Use comma or newline separated record.<fieldId> paths. The picker only lists user fields.', zh: '记录数据以字段 ID 为键。请使用逗号或换行分隔的 record.<fieldId> 路径。选择器仅列出用户字段。' },
+  'dingtalk.recordMemberGroupFieldPaths': { en: 'Record member group field paths (optional)', zh: '记录成员组字段路径（可选）' },
+  'dingtalk.recordMemberGroupFieldPathPlaceholder': { en: 'Example: record.watcherGroupIds, record.escalationGroupId', zh: '例如：record.watcherGroupIds, record.escalationGroupId' },
+  'dingtalk.pickMemberGroupField': { en: 'Pick member group field', zh: '选择成员组字段' },
+  'dingtalk.chooseMemberGroupFieldOption': { en: '-- choose a member group field --', zh: '-- 选择成员组字段 --' },
+  'dingtalk.recordMemberGroupFieldPathHint': { en: 'Use comma or newline separated record.<fieldId> paths whose values resolve to member group IDs. The picker only lists explicit member group fields.', zh: '使用逗号或换行分隔的 record.<fieldId> 路径，字段值应解析为成员组 ID。选择器仅列出显式成员组字段。' },
+  'dingtalk.titleTemplate': { en: 'Title template', zh: '标题模板' },
+  'dingtalk.titleTemplatePlaceholder': { en: 'Example: {{record.title}} needs attention', zh: '例如：{{record.title}} 待处理' },
+  'dingtalk.bodyTemplate': { en: 'Body template', zh: '正文模板' },
+  'dingtalk.bodyTemplatePlaceholder': { en: 'Supports {{record.xxx}}, {{recordId}}, {{sheetId}}, and {{actorId}}', zh: '支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}' },
+  'dingtalk.templateTokens': { en: 'Template tokens', zh: '模板令牌' },
+  'dingtalk.publicFormView': { en: 'Public form view (optional)', zh: '公开表单视图（可选）' },
+  'dingtalk.noPublicFormLinkOption': { en: '-- no public form link --', zh: '-- 无公开表单链接 --' },
+  'dingtalk.internalProcessingView': { en: 'Internal processing view (optional)', zh: '内部处理视图（可选）' },
+  'dingtalk.noInternalLinkOption': { en: '-- no internal link --', zh: '-- 无内部链接 --' },
+  'dingtalk.noInternalLink': { en: 'No internal link', zh: '无内部链接' },
+  'dingtalk.messageSummary': { en: 'Message summary', zh: '消息摘要' },
+  'dingtalk.groups': { en: 'Groups', zh: '群' },
+  'dingtalk.recordGroups': { en: 'Record groups', zh: '记录群' },
+  'dingtalk.recipients': { en: 'Recipients', zh: '收件人' },
+  'dingtalk.recordRecipients': { en: 'Record recipients', zh: '记录收件人' },
+  'dingtalk.recordMemberGroups': { en: 'Record member groups', zh: '记录成员组' },
+  'dingtalk.noGroupsSelected': { en: 'No groups selected', zh: '未选择群' },
+  'dingtalk.noRecipientsSelected': { en: 'No recipients selected', zh: '未选择收件人' },
+  'dingtalk.noDynamicGroupField': { en: 'No dynamic group field', zh: '无动态群字段' },
+  'dingtalk.noDynamicRecipientField': { en: 'No dynamic recipient field', zh: '无动态收件人字段' },
+  'dingtalk.noDynamicMemberGroupField': { en: 'No dynamic member group field', zh: '无动态成员组字段' },
+  'dingtalk.renderedTitle': { en: 'Rendered title', zh: '渲染标题' },
+  'dingtalk.renderedBody': { en: 'Rendered body', zh: '渲染正文' },
+  'dingtalk.noTitleTemplate': { en: 'No title template', zh: '无标题模板' },
+  'dingtalk.noBodyTemplate': { en: 'No body template', zh: '无正文模板' },
+  'dingtalk.noRenderedTitle': { en: 'No rendered title', zh: '无渲染标题' },
+  'dingtalk.noRenderedBody': { en: 'No rendered body', zh: '无渲染正文' },
+  'dingtalk.copy': { en: 'Copy', zh: '复制' },
+  'dingtalk.copied': { en: 'Copied', zh: '已复制' },
+  'dingtalk.publicForm': { en: 'Public form', zh: '公开表单' },
+  'dingtalk.publicFormAccess': { en: 'Public form access', zh: '公开表单访问' },
+  'dingtalk.allowedAudience': { en: 'Allowed audience', zh: '允许范围' },
+  'dingtalk.internalProcessing': { en: 'Internal processing', zh: '内部处理' },
+  'dingtalk.noPublicFormLink': { en: 'No public form link', zh: '无公开表单链接' },
+  'dingtalk.allowedAudienceUnavailable': { en: 'Allowed audience unavailable', zh: '允许范围不可用' },
+  'dingtalk.viewUnavailable': { en: 'View unavailable in this sheet', zh: '此表中不可用的视图' },
+  'dingtalk.selectedViewNotForm': { en: 'Selected view is not a form', zh: '所选视图不是表单视图' },
+  'dingtalk.publicFormNotConfigured': { en: 'Public form sharing is not configured', zh: '未配置公开表单分享' },
+  'dingtalk.publicFormDisabled': { en: 'Public form sharing is disabled', zh: '公开表单分享已停用' },
+  'dingtalk.publicFormMissingToken': { en: 'Public form sharing is missing a public token', zh: '公开表单分享缺少公开令牌' },
+  'dingtalk.publicFormExpired': { en: 'Public form sharing has expired', zh: '公开表单分享已过期' },
   'error.loadGroupDeliveries': { en: 'Failed to load DingTalk group deliveries.', zh: '加载钉钉群投递记录失败。' },
   'error.loadPersonDeliveries': { en: 'Failed to load DingTalk person deliveries.', zh: '加载钉钉个人投递记录失败。' },
   'error.loadRules': { en: 'Failed to load automation rules', zh: '加载自动化规则失败' },
@@ -576,6 +798,111 @@ export function automationCardLinkSummary(variant: AutomationCardLinkVariant, vi
 export function automationCardStats(count: number, status: AutomationCardStatType, isZh: boolean): string {
   const key = status === 'ok' ? 'manager.statOk' : 'manager.statFail'
   return `${count} ${automationLabel(key, isZh)}`
+}
+
+export function automationDingTalkPresetLabel(preset: AutomationDingTalkPreset | (string & {}), isZh: boolean): string {
+  switch (preset) {
+    case 'form_request':
+      return isZh ? '表单填写' : 'Form request'
+    case 'internal_process':
+      return automationLabel('dingtalk.internalProcessing', isZh)
+    case 'form_and_process':
+      return isZh ? '表单 + 处理' : 'Form + processing'
+    default:
+      return String(preset)
+  }
+}
+
+export function automationDingTalkTemplateTokenLabel(token: AutomationDingTalkTemplateTokenKey | (string & {}), isZh: boolean): string {
+  switch (token) {
+    case 'recordId':
+      return isZh ? '记录 ID' : 'Record ID'
+    case 'sheetId':
+      return isZh ? '表 ID' : 'Sheet ID'
+    case 'actorId':
+      return isZh ? '触发人 ID' : 'Actor ID'
+    case 'recordField':
+      return isZh ? '记录字段' : 'Record field'
+    default:
+      return String(token)
+  }
+}
+
+export function automationDingTalkDestinationScopeLabel(scope: AutomationDingTalkDestinationScope | (string & {}), isZh: boolean): string {
+  switch (scope) {
+    case 'org':
+      return isZh ? '组织目录' : 'Organization catalog'
+    case 'sheet':
+      return isZh ? '本表' : 'This table'
+    case 'private':
+      return isZh ? '私有' : 'Private'
+    default:
+      return String(scope)
+  }
+}
+
+export function automationDingTalkDestinationSubtitle(scope: AutomationDingTalkDestinationScope, id: string, isZh: boolean): string {
+  if (scope === 'org') {
+    if (!id) return isZh ? '组织目录' : 'organization catalog'
+    return isZh ? `组织目录：${id}` : `organization catalog: ${id}`
+  }
+  if (scope === 'sheet') {
+    if (!id) return isZh ? '本表' : 'this table'
+    return isZh ? `表：${id}` : `sheet: ${id}`
+  }
+  return isZh ? '私有' : 'private'
+}
+
+export function automationDingTalkPersonSubjectLabel(subject: AutomationDingTalkPersonSubject | (string & {}), isZh: boolean): string {
+  switch (subject) {
+    case 'member-group':
+      return isZh ? '成员组' : 'Member group'
+    case 'user':
+      return isZh ? '用户' : 'User'
+    default:
+      return String(subject)
+  }
+}
+
+export function automationDingTalkPersonAccessLabel(accessLevel: string, isZh: boolean): string {
+  return accessLevel ? `${isZh ? '权限：' : 'Access: '}${accessLevel}` : ''
+}
+
+export function automationDingTalkPersonStatusLabel(status: AutomationDingTalkPersonStatus | (string & {}), isZh: boolean): string {
+  switch (status) {
+    case 'memberGroupCheckedIndividually':
+      return isZh ? '成员组成员会逐个检查钉钉投递条件' : 'Member group members are checked individually for DingTalk delivery'
+    case 'noDeliveryLink':
+      return isZh ? '无钉钉投递关联；关联前个人消息会跳过' : 'No DingTalk delivery link; person message will skip until linked'
+    case 'deliveryReadyGrantEnabled':
+      return isZh ? '钉钉直接消息已就绪；表单授权已启用' : 'DingTalk direct message ready; form authorization enabled'
+    case 'deliveryReadyGrantDisabled':
+      return isZh ? '钉钉直接消息已就绪；表单授权未启用' : 'DingTalk direct message ready; form authorization not enabled'
+    case 'notBound':
+      return isZh ? '未绑定钉钉；关联前个人消息可能跳过' : 'Not bound to DingTalk; person message may skip until linked'
+    case 'boundGrantEnabled':
+      return isZh ? '已绑定钉钉；表单授权已启用' : 'DingTalk bound; form authorization enabled'
+    case 'boundGrantDisabled':
+      return isZh ? '已绑定钉钉；表单授权未启用' : 'DingTalk bound; form authorization not enabled'
+    default:
+      return String(status)
+  }
+}
+
+export function automationDingTalkAllowlistSummary(userCount: number, memberGroupCount: number, isZh: boolean): string {
+  const users = Math.max(0, userCount)
+  const groups = Math.max(0, memberGroupCount)
+  if (users === 0 && groups === 0) return ''
+  if (isZh) {
+    const parts: string[] = []
+    if (users > 0) parts.push(`${users} 个本地用户`)
+    if (groups > 0) parts.push(`${groups} 个本地成员组`)
+    return parts.join('和 ')
+  }
+  const parts: string[] = []
+  if (users > 0) parts.push(`${users} ${users === 1 ? 'local user' : 'local users'}`)
+  if (groups > 0) parts.push(`${groups} ${groups === 1 ? 'local member group' : 'local member groups'}`)
+  return parts.join(' and ')
 }
 
 export function automationTestRunRequestFailed(message: string, isZh: boolean): string {

--- a/apps/web/tests/dingtalk-internal-view-link-warnings.spec.ts
+++ b/apps/web/tests/dingtalk-internal-view-link-warnings.spec.ts
@@ -25,4 +25,10 @@ describe('dingtalk internal view link warnings', () => {
       'Internal processing view "missing_view" is not available in this sheet; DingTalk messages may not include a working processing link.',
     ])
   })
+
+  it('localizes missing internal processing view warnings while preserving raw ids', () => {
+    expect(listDingTalkInternalViewLinkBlockingErrors('missing_view', views, true)).toEqual([
+      '内部处理视图 "missing_view" 在此表中不可用；钉钉消息可能不包含可用的处理链接。',
+    ])
+  })
 })

--- a/apps/web/tests/dingtalk-public-form-link-warnings.spec.ts
+++ b/apps/web/tests/dingtalk-public-form-link-warnings.spec.ts
@@ -175,6 +175,17 @@ describe('dingtalk public form link warnings', () => {
     expect(describeDingTalkPublicFormLinkAudience('missing_view', views, nowMs)).toBe('Allowed audience unavailable')
   })
 
+  it('localizes selected public form access and audience when requested', () => {
+    expect(describeDingTalkPublicFormLinkAccess('', views, { nowMs, isZh: true })).toBe('无公开表单链接')
+    expect(describeDingTalkPublicFormLinkAccess('view_form_enabled', views, { nowMs, isZh: true }))
+      .toBe('完全公开；任何获得链接的人都可提交')
+    expect(describeDingTalkPublicFormLinkAccess('view_grid', views, { nowMs, isZh: true })).toBe('所选视图不是表单视图')
+    expect(describeDingTalkPublicFormLinkAudience('view_form_protected_allowed_user', views, { nowMs, isZh: true }))
+      .toBe('1 个本地用户通过钉钉检查后可提交')
+    expect(describeDingTalkPublicFormLinkAudience('view_form_granted_allowed_group', views, { nowMs, isZh: true }))
+      .toBe('1 个本地成员组通过钉钉检查后可提交')
+  })
+
   it('returns stable access levels for automation badges', () => {
     expect(getDingTalkPublicFormLinkAccessLevel('', views, nowMs)).toBe('none')
     expect(getDingTalkPublicFormLinkAccessLevel('view_form_enabled', views, nowMs)).toBe('public')
@@ -233,5 +244,14 @@ describe('dingtalk public form link warnings', () => {
     ])
     expect(listDingTalkPublicFormLinkBlockingErrors('view_form_enabled', views, { nowMs, warnWhenFullyPublic: true })).toEqual([])
     expect(listDingTalkPublicFormLinkBlockingErrors('view_form_protected', views, { nowMs, warnWhenProtectedWithoutAllowlist: true })).toEqual([])
+  })
+
+  it('localizes link warnings while preserving raw view labels', () => {
+    expect(listDingTalkPublicFormLinkBlockingErrors('missing_view', views, { nowMs, isZh: true })).toEqual([
+      '公开表单视图 "missing_view" 在此表中不可用；钉钉消息可能不包含可用的填写链接。',
+    ])
+    expect(listDingTalkPublicFormLinkWarnings('view_form_enabled', views, { nowMs, isZh: true, warnWhenFullyPublic: true })).toEqual([
+      '"Enabled Form" 的公开表单分享完全公开；所有能打开钉钉消息链接的人都可提交。若仅允许指定用户填写，请使用钉钉保护访问和 allowlist。',
+    ])
   })
 })

--- a/apps/web/tests/dingtalk-recipient-field-warnings.spec.ts
+++ b/apps/web/tests/dingtalk-recipient-field-warnings.spec.ts
@@ -40,6 +40,17 @@ describe('dingtalk recipient field warnings', () => {
     ])
   })
 
+  it('localizes dynamic group destination warnings while preserving raw field paths', () => {
+    expect(listDingTalkGroupDestinationFieldPathWarnings(
+      ['record.missingDestinationId', 'record.assigneeUserIds'].join(','),
+      fields,
+      true,
+    )).toEqual([
+      'record.missingDestinationId 不是此表中的已知字段；钉钉群消息需要能解析为目标 ID 的字段 ID。',
+      'record.assigneeUserIds 是用户字段；请改用钉钉个人收件人字段。',
+    ])
+  })
+
   it('returns no dynamic group destination warnings for empty or non-string input', () => {
     expect(listDingTalkGroupDestinationFieldPathWarnings('', fields)).toEqual([])
     expect(listDingTalkGroupDestinationFieldPathWarnings(['record.assigneeUserIds'], fields)).toEqual([])
@@ -84,6 +95,15 @@ describe('dingtalk recipient field warnings', () => {
       'record.missingGroupId is not a known field in this sheet; DingTalk person member-group recipients expect field IDs that resolve to member group IDs.',
       'record.assigneeUserIds is a user field; use Record recipient field paths instead.',
       'record.name is not a member group field; DingTalk person member-group recipients expect member group fields.',
+    ])
+  })
+
+  it('localizes dynamic person recipient warnings while preserving raw field paths', () => {
+    expect(listDingTalkPersonRecipientFieldPathWarnings('record.name', fields, true)).toEqual([
+      'record.name 不是用户字段；钉钉个人消息需要本地用户 ID。',
+    ])
+    expect(listDingTalkPersonMemberGroupRecipientFieldPathWarnings('record.name', fields, true)).toEqual([
+      'record.name 不是成员组字段；钉钉个人成员组收件人需要成员组字段。',
     ])
   })
 

--- a/apps/web/tests/meta-automation-labels.spec.ts
+++ b/apps/web/tests/meta-automation-labels.spec.ts
@@ -11,6 +11,14 @@ import {
   automationConditionOperatorLabel,
   automationConditionValuePlaceholder,
   automationCronPresetLabel,
+  automationDingTalkAllowlistSummary,
+  automationDingTalkDestinationScopeLabel,
+  automationDingTalkDestinationSubtitle,
+  automationDingTalkPersonAccessLabel,
+  automationDingTalkPersonStatusLabel,
+  automationDingTalkPersonSubjectLabel,
+  automationDingTalkPresetLabel,
+  automationDingTalkTemplateTokenLabel,
   automationLabel,
   automationStatusLabel,
   automationTestRunFailed,
@@ -140,5 +148,45 @@ describe('meta-automation-labels', () => {
     expect(automationTestRunSucceeded('', true)).toBe('测试运行成功。')
     expect(automationTestRunSkipped(' (4 ms)', false)).toBe('Test run skipped (4 ms).')
     expect(automationTestRunSkipped('', true)).toBe('测试运行已跳过。')
+  })
+
+  it('localizes DingTalk shared chrome helpers with raw fallbacks', () => {
+    expect(automationDingTalkPresetLabel('form_request', false)).toBe('Form request')
+    expect(automationDingTalkPresetLabel('form_request', true)).toBe('表单填写')
+    expect(automationDingTalkPresetLabel('internal_process', true)).toBe('内部处理')
+    expect(automationDingTalkPresetLabel('form_and_process', false)).toBe('Form + processing')
+    expect(automationDingTalkPresetLabel('future_preset', true)).toBe('future_preset')
+
+    expect(automationDingTalkTemplateTokenLabel('recordId', true)).toBe('记录 ID')
+    expect(automationDingTalkTemplateTokenLabel('recordField', false)).toBe('Record field')
+    expect(automationDingTalkTemplateTokenLabel('futureToken', true)).toBe('futureToken')
+
+    expect(automationDingTalkDestinationScopeLabel('org', true)).toBe('组织目录')
+    expect(automationDingTalkDestinationScopeLabel('sheet', false)).toBe('This table')
+    expect(automationDingTalkDestinationSubtitle('org', 'org_catalog', true)).toBe('组织目录：org_catalog')
+    expect(automationDingTalkDestinationSubtitle('sheet', 'sheet_1', false)).toBe('sheet: sheet_1')
+
+    expect(automationDingTalkPersonSubjectLabel('member-group', true)).toBe('成员组')
+    expect(automationDingTalkPersonAccessLabel('read', false)).toBe('Access: read')
+    expect(automationDingTalkPersonAccessLabel('write', true)).toBe('权限：write')
+    expect(automationDingTalkPersonStatusLabel('memberGroupCheckedIndividually', false))
+      .toBe('Member group members are checked individually for DingTalk delivery')
+    expect(automationDingTalkPersonStatusLabel('noDeliveryLink', true))
+      .toBe('无钉钉投递关联；关联前个人消息会跳过')
+    expect(automationDingTalkPersonStatusLabel('deliveryReadyGrantEnabled', false))
+      .toBe('DingTalk direct message ready; form authorization enabled')
+    expect(automationDingTalkPersonStatusLabel('deliveryReadyGrantDisabled', true))
+      .toBe('钉钉直接消息已就绪；表单授权未启用')
+    expect(automationDingTalkPersonStatusLabel('notBound', false))
+      .toBe('Not bound to DingTalk; person message may skip until linked')
+    expect(automationDingTalkPersonStatusLabel('boundGrantEnabled', true))
+      .toBe('已绑定钉钉；表单授权已启用')
+    expect(automationDingTalkPersonStatusLabel('boundGrantDisabled', false))
+      .toBe('DingTalk bound; form authorization not enabled')
+
+    expect(automationDingTalkAllowlistSummary(0, 0, false)).toBe('')
+    expect(automationDingTalkAllowlistSummary(1, 0, false)).toBe('1 local user')
+    expect(automationDingTalkAllowlistSummary(2, 1, false)).toBe('2 local users and 1 local member group')
+    expect(automationDingTalkAllowlistSummary(1, 2, true)).toBe('1 个本地用户和 2 个本地成员组')
   })
 })

--- a/apps/web/tests/multitable-automation-manager.spec.ts
+++ b/apps/web/tests/multitable-automation-manager.spec.ts
@@ -433,6 +433,61 @@ describe('MetaAutomationManager', () => {
       .toBe('public')
   })
 
+  it('localizes zh-CN DingTalk inline form chrome while preserving raw token insertion values', async () => {
+    useLocale().setLocale('zh-CN')
+    const { client } = mockClient([])
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, views, client })
+    await flushPromises()
+
+    const addBtn = container.querySelector('[data-automation-new-rule="quick"]') as HTMLButtonElement
+    addBtn.click()
+    await nextTick()
+
+    const actionSelect = container.querySelector('[data-automation-field="actionType"]') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_person_message'
+    actionSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushPromises()
+
+    expect(container.textContent).toContain('消息预设')
+    expect(container.textContent).toContain('表单填写')
+    expect(container.textContent).toContain('搜索并添加用户或成员组')
+    expect(container.textContent).toContain('模板令牌')
+    expect((container.querySelector('[data-automation-field="dingtalkPersonUserSearch"]') as HTMLInputElement).placeholder)
+      .toBe('按用户、成员组、邮箱或主体 ID 搜索')
+    expect((container.querySelector('[data-automation-field="dingtalkPersonRecipientFieldPath"]') as HTMLInputElement).placeholder)
+      .toBe('例如：record.assigneeUserIds, record.reviewerUserId')
+    expect((container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement).placeholder)
+      .toBe('支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}')
+    expect(container.querySelector('[data-automation-token="person-title-recordId"]')?.textContent).toContain('记录 ID')
+    expect(container.querySelector('[data-automation-token="person-body-recordField"]')?.textContent).toContain('记录字段')
+
+    const titleInput = container.querySelector('[data-automation-field="dingtalkPersonTitleTemplate"]') as HTMLInputElement
+    titleInput.value = '{{record}}'
+    titleInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+    expect(container.textContent).toContain('未知占位符 {{record}}')
+
+    const presetBtn = container.querySelector('[data-automation-preset="person-both"]') as HTMLButtonElement
+    presetBtn.click()
+    await flushPromises()
+
+    const bodyInput = container.querySelector('[data-automation-field="dingtalkPersonBodyTemplate"]') as HTMLTextAreaElement
+    expect(titleInput.value).toBe('{{recordId}} 待填写并处理')
+    expect(bodyInput.value).toContain('请先填写所需信息')
+
+    bodyInput.value = '处理 {{record.xxx}}'
+    bodyInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushPromises()
+
+    const summary = container.querySelector('[data-automation-summary="person"]')
+    expect(summary?.textContent).toContain('消息摘要')
+    expect(summary?.textContent).toContain('渲染正文')
+    expect(summary?.textContent).toContain('处理 示例字段值')
+    expect(container.querySelectorAll('[aria-label]')).toHaveLength(0)
+    expect(container.querySelectorAll('[title]')).toHaveLength(0)
+    expect(container.querySelectorAll('[placeholder]')).toHaveLength(8)
+  })
+
   it('localizes zh-CN frontend fallback errors from the automation composable at event time', async () => {
     useLocale().setLocale('zh-CN')
     const client = {
@@ -2677,8 +2732,8 @@ describe('MetaAutomationManager', () => {
     const publicFormSelect = container.querySelector('[data-automation-field="publicFormViewId"]') as HTMLSelectElement
     const internalViewSelect = container.querySelector('[data-automation-field="internalViewId"]') as HTMLSelectElement
 
-    expect(titleInput.value).toBe('{{recordId}} 待填写')
-    expect(bodyInput.value).toContain('请完成本次表单填写')
+    expect(titleInput.value).toBe('{{recordId}} needs input')
+    expect(bodyInput.value).toContain('Please complete this form request')
     expect(publicFormSelect.value).toBe('view_form')
     expect(internalViewSelect.value).toBe('')
   })
@@ -2711,8 +2766,8 @@ describe('MetaAutomationManager', () => {
     const internalViewSelect = container.querySelector('[data-automation-field="dingtalkPersonInternalViewId"]') as HTMLSelectElement
 
     expect(userIdsInput.value).toBe('user_1')
-    expect(titleInput.value).toBe('{{recordId}} 待填写并处理')
-    expect(bodyInput.value).toContain('请先填写所需信息')
+    expect(titleInput.value).toBe('{{recordId}} needs input and processing')
+    expect(bodyInput.value).toContain('Please complete the required form input')
     expect(publicFormSelect.value).toBe('view_form')
     expect(internalViewSelect.value).toBe('view_grid')
   })
@@ -2781,7 +2836,7 @@ describe('MetaAutomationManager', () => {
     expect(summary?.textContent).toContain('Need action {{recordId}}')
     expect(summary?.textContent).toContain('Handle {{record.xxx}}')
     expect(summary?.textContent).toContain('Need action record_demo_001')
-    expect(summary?.textContent).toContain('Handle 示例字段值')
+    expect(summary?.textContent).toContain('Handle Sample field value')
     expect(summary?.textContent).toContain('Assignees (record.assigneeUserIds)')
     expect(summary?.textContent).toContain('Public Form')
     expect(summary?.textContent).toContain('Fully public; anyone with the link can submit')
@@ -3043,7 +3098,7 @@ describe('MetaAutomationManager', () => {
     await flushPromises()
 
     expect(navigator.clipboard?.writeText).toHaveBeenCalledTimes(1)
-    expect(vi.mocked(navigator.clipboard!.writeText).mock.calls[0]?.[0]).toBe('Handle 示例字段值')
+    expect(vi.mocked(navigator.clipboard!.writeText).mock.calls[0]?.[0]).toBe('Handle Sample field value')
     expect(container.textContent).toContain('Copied')
   })
 })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -346,6 +346,55 @@ describe('MetaAutomationRuleEditor', () => {
     expect(confirmSpy).toHaveBeenCalledWith('测试运行会执行已保存规则，并可能向已配置的钉钉群或用户发送真实消息。未保存的更改不会包含在内。是否继续？')
   })
 
+  it('localizes zh-CN DingTalk group editor chrome while preserving raw template values', async () => {
+    useLocale().setLocale('zh-CN')
+    const client = mockClient()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      views,
+      client,
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    actionSelect.value = 'send_dingtalk_group_message'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('消息预设')
+    expect(container.textContent).toContain('添加钉钉群')
+    expect(container.textContent).toContain('模板令牌')
+    expect(container.querySelector('[data-field="groupTitleToken-recordId"]')?.textContent).toContain('记录 ID')
+    expect(container.querySelector('[data-field="groupBodyToken-recordField"]')?.textContent).toContain('记录字段')
+    expect((container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement).placeholder)
+      .toBe('例如：{{record.title}} 待处理')
+    expect((container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement).placeholder)
+      .toBe('支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}')
+
+    const presetBtn = container.querySelector('[data-field="groupPresetBoth"]') as HTMLButtonElement
+    presetBtn.click()
+    await flushPromises()
+
+    const titleInput = container.querySelector('[data-field="dingtalkTitleTemplate"]') as HTMLInputElement
+    const bodyInput = container.querySelector('[data-field="dingtalkBodyTemplate"]') as HTMLTextAreaElement
+    expect(titleInput.value).toBe('{{recordId}} 待填写并处理')
+    expect(bodyInput.value).toContain('请先填写所需信息')
+
+    bodyInput.value = '处理 {{record.xxx}}'
+    bodyInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const summary = container.querySelector('[data-field="groupMessageSummary"]')
+    expect(summary?.textContent).toContain('消息摘要')
+    expect(summary?.textContent).toContain('渲染正文')
+    expect(summary?.textContent).toContain('处理 示例字段值')
+    expect(container.querySelectorAll('[aria-label]')).toHaveLength(0)
+    expect(container.querySelectorAll('[title]')).toHaveLength(1)
+    expect(container.querySelectorAll('[placeholder]')).toHaveLength(4)
+  })
+
   it('keeps representative a11y attribute counts unchanged after localization wiring', async () => {
     useLocale().setLocale('zh-CN')
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
@@ -3058,8 +3107,8 @@ describe('MetaAutomationRuleEditor', () => {
     const publicFormSelect = container.querySelector('[data-field="publicFormViewId"]') as HTMLSelectElement
     const internalViewSelect = container.querySelector('[data-field="internalViewId"]') as HTMLSelectElement
 
-    expect(titleInput.value).toBe('{{recordId}} 待填写并处理')
-    expect(bodyInput.value).toContain('请先填写所需信息')
+    expect(titleInput.value).toBe('{{recordId}} needs input and processing')
+    expect(bodyInput.value).toContain('Please complete the required form input')
     expect(publicFormSelect.value).toBe('view_form')
     expect(internalViewSelect.value).toBe('view_grid')
   })
@@ -3094,8 +3143,8 @@ describe('MetaAutomationRuleEditor', () => {
     const internalViewSelect = container.querySelector('[data-field="dingtalkPersonInternalViewId"]') as HTMLSelectElement
 
     expect(userIdsInput.value).toBe('user_1')
-    expect(titleInput.value).toBe('{{recordId}} 待处理')
-    expect(bodyInput.value).toContain('请查看并处理该记录')
+    expect(titleInput.value).toBe('{{recordId}} needs processing')
+    expect(bodyInput.value).toContain('Please review and process this record')
     expect(publicFormSelect.value).toBe('')
     expect(internalViewSelect.value).toBe('view_grid')
   })
@@ -3160,7 +3209,7 @@ describe('MetaAutomationRuleEditor', () => {
     expect(summary?.textContent).toContain('Ticket {{recordId}}')
     expect(summary?.textContent).toContain('Please fill {{record.xxx}}')
     expect(summary?.textContent).toContain('Ticket record_demo_001')
-    expect(summary?.textContent).toContain('Please fill 示例字段值')
+    expect(summary?.textContent).toContain('Please fill Sample field value')
     expect(summary?.textContent).toContain('No public form link')
     expect(summary?.textContent).toContain('No internal link')
   })
@@ -3286,7 +3335,7 @@ describe('MetaAutomationRuleEditor', () => {
     await flushPromises()
 
     expect(navigator.clipboard?.writeText).toHaveBeenCalledTimes(1)
-    expect(vi.mocked(navigator.clipboard!.writeText).mock.calls[0]?.[0]).toBe('Please fill 示例字段值')
+    expect(vi.mocked(navigator.clipboard!.writeText).mock.calls[0]?.[0]).toBe('Please fill Sample field value')
     expect(container.textContent).toContain('Copied')
   })
 })

--- a/docs/development/multitable-t3d4-automation-dingtalk-i18n-design-20260522.md
+++ b/docs/development/multitable-t3d4-automation-dingtalk-i18n-design-20260522.md
@@ -1,0 +1,429 @@
+# T3D-4 Automation DingTalk i18n Design
+
+Date: 2026-05-22
+
+Branch: `frontend/multitable-t3d4-automation-dingtalk-i18n-20260522`
+
+Base: `origin/main@b42cd00b6` (`feat(multitable): localize automation manager chrome (T3D-3) (#1744)`)
+
+## 1. Decision Summary
+
+T3D-4 is the final PR in the 4-PR T3D automation i18n chain.
+
+| Decision | Outcome |
+| --- | --- |
+| Module | Continue extending `apps/web/src/multitable/utils/meta-automation-labels.ts`; no new DingTalk-specific module. |
+| Primary surfaces | DingTalk shared chrome across `MetaAutomationManager.vue`, `MetaAutomationRuleEditor.vue`, and `dingtalk*.ts` utilities. |
+| Scope | DingTalk group/person config chrome, template tokens, template warnings, link warnings/access summaries, recipient field warnings, preview labels, copy states, and the 16 zh-only DingTalk placeholders found by latest scout. |
+| Preset templates | Localize generated default preset content at click time. These strings become user-editable template content after insertion and do not retranslate after locale toggle. |
+| Template examples | Localize sample render data via `renderDingTalkTemplateExample(template, isZh)`; user template text and token names stay raw. |
+| Utility signatures | Existing warning/access utilities gain locale options or optional `isZh` parameters while preserving EN as the default for direct utility tests. |
+| A11y boundary | Localize existing placeholder text only; do not add new `aria-label`, `title`, or `placeholder` attributes. Fixture sentinel counts must stay stable. |
+| Defer | Backend/API contract, DingTalk delivery runtime behavior, K3, attendance, non-DingTalk automation chrome, and final global audit. |
+
+This preserves the parent T3D split:
+
+- T3D-1 shipped: log viewer + delivery viewers.
+- T3D-2 shipped: rule editor core.
+- T3D-3 shipped: manager shell/cards/quick form.
+- T3D-4: DingTalk shared chrome across manager + rule editor.
+
+## 2. Scout Snapshot
+
+Real source:
+
+| File | Role |
+| --- | --- |
+| `MetaAutomationManager.vue` | Legacy quick form DingTalk group/person panels, previews, copy controls, card link utilities. |
+| `MetaAutomationRuleEditor.vue` | Full rule editor DingTalk group/person panels, previews, copy controls. |
+| `dingtalkNotificationPresets.ts` | Preset-generated title/body templates, currently zh-only. |
+| `dingtalkNotificationTemplateExample.ts` | Rendered preview sample data, currently zh-only sample fields. |
+| `dingtalkNotificationTemplateLint.ts` | Template syntax warning copy. |
+| `dingtalkNotificationTemplateTokens.ts` | Token button labels and raw token values. |
+| `dingtalkPublicFormLinkWarnings.ts` | Public-form access/audience summaries, blocking errors, and risk warnings. |
+| `dingtalkInternalViewLinkWarnings.ts` | Internal-view link blocking warning. |
+| `dingtalkRecipientFieldWarnings.ts` | Dynamic record-field warning copy for group/person destinations. |
+
+Source attribute counts after T3D-3:
+
+| Component | `aria-label=` | `title=` | `placeholder=` | T3D-4 rule |
+| --- | ---: | ---: | ---: | --- |
+| `MetaAutomationManager.vue` | 0 | 0 | 13 | Localize existing placeholder text only; fixture count stays stable. |
+| `MetaAutomationRuleEditor.vue` | 0 | 5 | 25 | Localize existing DingTalk placeholders only; do not add attributes. |
+
+Existing tests to extend:
+
+| File | Existing role |
+| --- | --- |
+| `meta-automation-labels.spec.ts` | T3D helper unit and ALL_KEYS coverage. |
+| `multitable-automation-manager.spec.ts` | Manager behavior, DingTalk quick-form coverage, card link summaries. |
+| `multitable-automation-rule-editor.spec.ts` | Rule editor DingTalk group/person behavior and warnings. |
+| `dingtalk-public-form-link-warnings.spec.ts` | Public-form access/warning utility tests. |
+| `dingtalk-recipient-field-warnings.spec.ts` | Recipient field warning utility tests. |
+| `dingtalk-internal-view-link-warnings.spec.ts` | Internal-view warning utility tests. |
+
+## 3. Files In Scope
+
+Implementation files:
+
+| File | Change |
+| --- | --- |
+| `apps/web/src/multitable/utils/meta-automation-labels.ts` | Add DingTalk static keys, typed unions, and helper functions. |
+| `apps/web/src/multitable/utils/dingtalkNotificationPresets.ts` | Generate locale-aware default title/body templates. |
+| `apps/web/src/multitable/utils/dingtalkNotificationTemplateExample.ts` | Render preview examples using locale-aware sample data. |
+| `apps/web/src/multitable/utils/dingtalkNotificationTemplateLint.ts` | Localize template syntax warnings. |
+| `apps/web/src/multitable/utils/dingtalkNotificationTemplateTokens.ts` | Keep token values raw and expose localized token labels. |
+| `apps/web/src/multitable/utils/dingtalkPublicFormLinkWarnings.ts` | Localize access summaries, audience summaries, blocking errors, and risk warnings. |
+| `apps/web/src/multitable/utils/dingtalkInternalViewLinkWarnings.ts` | Localize internal-view missing warning. |
+| `apps/web/src/multitable/utils/dingtalkRecipientFieldWarnings.ts` | Localize dynamic recipient field warnings. |
+| `apps/web/src/multitable/components/MetaAutomationManager.vue` | Wire Manager DingTalk panel chrome and pass `isZh.value` into shared utilities. |
+| `apps/web/src/multitable/components/MetaAutomationRuleEditor.vue` | Wire RuleEditor DingTalk panel chrome and pass `isZh.value` into shared utilities. |
+
+Test files:
+
+| File | Change |
+| --- | --- |
+| `apps/web/tests/meta-automation-labels.spec.ts` | Add helper tests, typed discriminator fallbacks, zh/en baseline, ALL_KEYS lockstep. |
+| `apps/web/tests/multitable-automation-manager.spec.ts` | Add zh DingTalk manager render assertions, raw selector checks, a11y sentinels. |
+| `apps/web/tests/multitable-automation-rule-editor.spec.ts` | Add zh DingTalk rule editor render assertions, raw selector checks, a11y sentinels. |
+| `apps/web/tests/dingtalk-public-form-link-warnings.spec.ts` | Add zh cases while preserving EN default behavior. |
+| `apps/web/tests/dingtalk-recipient-field-warnings.spec.ts` | Add zh cases and raw field-path preservation. |
+| `apps/web/tests/dingtalk-internal-view-link-warnings.spec.ts` | Add zh cases and raw view ID preservation. |
+
+Docs:
+
+| File | Change |
+| --- | --- |
+| `docs/development/multitable-t3d4-automation-dingtalk-i18n-design-20260522.md` | This design. |
+| `docs/development/multitable-t3d4-automation-dingtalk-i18n-verification-20260522.md` | Implementation evidence. |
+
+Out of scope:
+
+| Surface | Reason |
+| --- | --- |
+| Automation backend/API/runtime delivery | T3D is frontend i18n only. |
+| Non-DingTalk rule editor/manager chrome | Already covered by T3D-2/T3D-3. |
+| `data-*` selector values and CSS enum suffixes | Raw selectors must remain stable. |
+| User-authored template content after preset insertion | The generated default is localized at click time; later edits are user data. |
+| Final global audit | Runs after T3D-4. |
+
+## 4. Exact Chrome Targets
+
+### 4.1 Shared Presets And Group Destination Chrome
+
+| Source | Current EN | Target zh | Key/helper |
+| --- | --- | --- | --- |
+| Manager L110 / RuleEditor L309 | `Message preset` | `消息预设` | `dingtalk.preset` |
+| Manager L111 / RuleEditor L310 | `Form request` | `表单填写` | `automationDingTalkPresetLabel('form_request', isZh)` |
+| Manager L112 / RuleEditor L311 | `Internal processing` | `内部处理` | `automationDingTalkPresetLabel('internal_process', isZh)` |
+| Manager L113 / RuleEditor L312 | `Form + processing` | `表单 + 处理` | `automationDingTalkPresetLabel('form_and_process', isZh)` |
+| Manager L115 / RuleEditor group branch | `Add DingTalk groups` | `添加钉钉群` | `dingtalk.addGroups` |
+| Manager L126 / RuleEditor L331 | `-- add DingTalk group --` | `-- 添加钉钉群 --` | `dingtalk.addGroupOption` |
+| Manager/RuleEditor scope functions | `Organization catalog` / `This table` / `Private` | `组织目录` / `本表` / `私有` | `automationDingTalkDestinationScopeLabel(...)` |
+| Manager/RuleEditor subtitles | `organization catalog: ${id}` / `sheet: ${id}` / `private` | `组织目录：${id}` / `表：${id}` / `私有` | `automationDingTalkDestinationSubtitle(...)` |
+| Manager/RuleEditor empty state | `No DingTalk groups are available...` | `此表暂无可用钉钉群。请在 API Token 与 Webhook > 钉钉群中添加，或让管理员共享组织目录群，也可使用下方记录群字段路径。` | `dingtalk.noGroupsAvailable` |
+| Chips | `Remove` | `移除` | `dingtalk.remove` |
+| Manager L151 / RuleEditor L357 | `Record group field paths (optional)` | `记录群字段路径（可选）` | `dingtalk.recordGroupFieldPaths` |
+| RuleEditor L375 hint | `Use record fields whose value...` | `使用值为钉钉群目标 ID 的记录字段，不要使用本地用户、成员组或钉钉群名称。` | `dingtalk.recordGroupFieldPathHint` |
+| Manager L159 / RuleEditor L377 | `Pick group field` | `选择群字段` | `dingtalk.pickGroupField` |
+| Manager L164 / RuleEditor L383 | `-- pick field --` | `-- 选择字段 --` | `dingtalk.pickFieldOption` |
+
+### 4.2 Person Recipient Chrome
+
+| Source | Current EN | Target zh | Key/helper |
+| --- | --- | --- | --- |
+| Manager L292 / RuleEditor L562 | `Search and add users or member groups` | `搜索并添加用户或成员组` | `dingtalk.searchUsersOrGroups` |
+| Manager L300 / RuleEditor L567 | `Search by user, member group, email, or subject ID` | `按用户、成员组、邮箱或主体 ID 搜索` | `dingtalk.searchUsersOrGroupsPlaceholder` |
+| Manager/RuleEditor loading | `Searching users and member groups...` | `正在搜索用户和成员组...` | `dingtalk.searchingUsersOrGroups` |
+| Manager/RuleEditor empty | `No matching users or member groups` | `没有匹配的用户或成员组` | `dingtalk.noMatchingUsersOrGroups` |
+| Manager/RuleEditor inactive candidate | `Inactive users cannot be added` | `不能添加已停用用户` | new `dingtalk.inactiveUsersCannotBeAdded` |
+| Manager/RuleEditor subject | `User` / `Member group` | `用户` / `成员组` | `automationDingTalkPersonSubjectLabel(...)` |
+| Manager/RuleEditor access | `Access: ${accessLevel}` | `权限：${accessLevel}` | `automationDingTalkPersonAccessLabel(...)` |
+| Manager/RuleEditor status branches | see status table below | see status table below | `automationDingTalkPersonStatusLabel(...)` |
+| Manager L356 / RuleEditor L623 | `Local user IDs` | `本地用户 ID` | `dingtalk.localUserIds` |
+| Manager L365 / RuleEditor L632 | `Member group IDs (optional)` | `成员组 ID（可选）` | `dingtalk.memberGroupIds` |
+| Manager L374 / RuleEditor L641 | `Record recipient field paths (optional)` | `记录收件人字段路径（可选）` | `dingtalk.recordRecipientFieldPaths` |
+| Manager L380 / RuleEditor L649 | `Pick recipient field` | `选择收件人字段` | `dingtalk.pickRecipientField` |
+| Manager/RuleEditor option | `-- choose a user field --` | `-- 选择用户字段 --` | `dingtalk.chooseUserFieldOption` |
+| Manager/RuleEditor hint | `Record data is keyed by field ID...` | `记录数据以字段 ID 为键。请使用逗号或换行分隔的 record.<fieldId> 路径。选择器仅列出用户字段。` | `dingtalk.recordRecipientFieldPathHint` |
+| Manager L419 / RuleEditor L686 | `Record member group field paths (optional)` | `记录成员组字段路径（可选）` | `dingtalk.recordMemberGroupFieldPaths` |
+| Manager L425 / RuleEditor L694 | `Pick member group field` | `选择成员组字段` | `dingtalk.pickMemberGroupField` |
+| Manager/RuleEditor option | `-- choose a member group field --` | `-- 选择成员组字段 --` | `dingtalk.chooseMemberGroupFieldOption` |
+| Manager/RuleEditor hint | `Use comma or newline separated record.<fieldId> paths...` | `使用逗号或换行分隔的 record.<fieldId> 路径，字段值应解析为成员组 ID。选择器仅列出显式成员组字段。` | `dingtalk.recordMemberGroupFieldPathHint` |
+
+Person delivery status branches are shared by Manager and RuleEditor and must be enumerated, not left as prose:
+
+| Status | Current EN | Target zh |
+| --- | --- | --- |
+| `memberGroupCheckedIndividually` | `Member group members are checked individually for DingTalk delivery` | `成员组成员会逐个检查钉钉投递条件` |
+| `noDeliveryLink` | `No DingTalk delivery link; person message will skip until linked` | `无钉钉投递关联；关联前个人消息会跳过` |
+| `deliveryReadyGrantEnabled` | `DingTalk direct message ready; form authorization enabled` | `钉钉直接消息已就绪；表单授权已启用` |
+| `deliveryReadyGrantDisabled` | `DingTalk direct message ready; form authorization not enabled` | `钉钉直接消息已就绪；表单授权未启用` |
+| `notBound` | `Not bound to DingTalk; person message may skip until linked` | `未绑定钉钉；关联前个人消息可能跳过` |
+| `boundGrantEnabled` | `DingTalk bound; form authorization enabled` | `已绑定钉钉；表单授权已启用` |
+| `boundGrantDisabled` | `DingTalk bound; form authorization not enabled` | `已绑定钉钉；表单授权未启用` |
+
+### 4.3 Template, Token, Preview, And Copy Chrome
+
+| Source | Current EN | Target zh | Key/helper |
+| --- | --- | --- | --- |
+| Manager/RuleEditor | `Title template` | `标题模板` | `dingtalk.titleTemplate` |
+| Manager/RuleEditor | `Body template` | `正文模板` | `dingtalk.bodyTemplate` |
+| Manager/RuleEditor | `Template tokens` | `模板令牌` | `dingtalk.templateTokens` |
+| `DINGTALK_*_TEMPLATE_TOKENS` | `Record ID` / `Sheet ID` / `Actor ID` / `Record field` | `记录 ID` / `表 ID` / `触发人 ID` / `记录字段` | `automationDingTalkTemplateTokenLabel(...)` |
+| Manager/RuleEditor | `Public form view (optional)` | `公开表单视图（可选）` | `dingtalk.publicFormView` |
+| Manager/RuleEditor | `-- no public form link --` | `-- 无公开表单链接 --` | `dingtalk.noPublicFormLinkOption` |
+| Manager/RuleEditor | `Internal processing view (optional)` | `内部处理视图（可选）` | `dingtalk.internalProcessingView` |
+| Manager/RuleEditor | `-- no internal link --` | `-- 无内部链接 --` | `dingtalk.noInternalLinkOption` |
+| Manager/RuleEditor | `Message summary` | `消息摘要` | `dingtalk.messageSummary` |
+| Manager/RuleEditor labels | `Groups`, `Record groups`, `Recipients`, `Record recipients`, `Record member groups` | `群`, `记录群`, `收件人`, `记录收件人`, `记录成员组` | static keys |
+| Manager/RuleEditor labels | `Title template`, `Body template`, `Rendered title`, `Rendered body` | `标题模板`, `正文模板`, `渲染标题`, `渲染正文` | static keys |
+| Manager/RuleEditor fallbacks | `No groups selected`, `No recipients selected`, `No dynamic ...`, `No title template`, `No rendered body` | localized fallback strings | static keys |
+| Manager/RuleEditor buttons | `Copy` / `Copied` | `复制` / `已复制` | `dingtalk.copy`, `dingtalk.copied` |
+| Manager/RuleEditor labels | `Public form`, `Public form access`, `Allowed audience`, `Internal processing` | `公开表单`, `公开表单访问`, `允许范围`, `内部处理` | static keys |
+
+Implementation note: field names, view names, destination names, and rendered template output are raw interpolated values. Only the surrounding chrome is localized.
+
+### 4.4 zh-only Placeholder Targets
+
+Latest grep found 16 zh-only DingTalk placeholders, not the earlier 14-count reminder. T3D-4 owns all 16.
+
+| File:line | Current zh placeholder | Target en placeholder | Key/helper |
+| --- | --- | --- | --- |
+| `MetaAutomationManager.vue:169` | `例如：{{record.title}} 待处理` | `Example: {{record.title}} needs attention` | `dingtalk.titleTemplatePlaceholder` |
+| `MetaAutomationManager.vue:197` | `支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}` | `Supports {{record.xxx}}, {{recordId}}, {{sheetId}}, and {{actorId}}` | `dingtalk.bodyTemplatePlaceholder` |
+| `MetaAutomationManager.vue:360` | `使用逗号或换行分隔本地 userId` | `Use comma or newline separated local user IDs` | `dingtalk.localUserIdsPlaceholder` |
+| `MetaAutomationManager.vue:368` | `使用逗号或换行分隔成员组 ID` | `Use comma or newline separated member group IDs` | `dingtalk.memberGroupIdsPlaceholder` |
+| `MetaAutomationManager.vue:376` | `例如：record.assigneeUserIds, record.reviewerUserId` | `Example: record.assigneeUserIds, record.reviewerUserId` | `dingtalk.recordRecipientFieldPathPlaceholder` |
+| `MetaAutomationManager.vue:421` | `例如：record.watcherGroupIds, record.escalationGroupId` | `Example: record.watcherGroupIds, record.escalationGroupId` | `dingtalk.recordMemberGroupFieldPathPlaceholder` |
+| `MetaAutomationManager.vue:466` | `例如：{{record.title}} 待处理` | `Example: {{record.title}} needs attention` | `dingtalk.titleTemplatePlaceholder` |
+| `MetaAutomationManager.vue:494` | `支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}` | `Supports {{record.xxx}}, {{recordId}}, {{sheetId}}, and {{actorId}}` | `dingtalk.bodyTemplatePlaceholder` |
+| `MetaAutomationRuleEditor.vue:415` | `例如：{{record.title}} 待处理` | `Example: {{record.title}} needs attention` | `dingtalk.titleTemplatePlaceholder` |
+| `MetaAutomationRuleEditor.vue:443` | `支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}` | `Supports {{record.xxx}}, {{recordId}}, {{sheetId}}, and {{actorId}}` | `dingtalk.bodyTemplatePlaceholder` |
+| `MetaAutomationRuleEditor.vue:627` | `使用逗号或换行分隔本地 userId` | `Use comma or newline separated local user IDs` | `dingtalk.localUserIdsPlaceholder` |
+| `MetaAutomationRuleEditor.vue:635` | `使用逗号或换行分隔成员组 ID` | `Use comma or newline separated member group IDs` | `dingtalk.memberGroupIdsPlaceholder` |
+| `MetaAutomationRuleEditor.vue:643` | `例如：record.assigneeUserIds, record.reviewerUserId` | `Example: record.assigneeUserIds, record.reviewerUserId` | `dingtalk.recordRecipientFieldPathPlaceholder` |
+| `MetaAutomationRuleEditor.vue:688` | `例如：record.watcherGroupIds, record.escalationGroupId` | `Example: record.watcherGroupIds, record.escalationGroupId` | `dingtalk.recordMemberGroupFieldPathPlaceholder` |
+| `MetaAutomationRuleEditor.vue:733` | `例如：{{record.title}} 待处理` | `Example: {{record.title}} needs attention` | `dingtalk.titleTemplatePlaceholder` |
+| `MetaAutomationRuleEditor.vue:761` | `支持 {{record.xxx}}、{{recordId}}、{{sheetId}}、{{actorId}}` | `Supports {{record.xxx}}, {{recordId}}, {{sheetId}}, and {{actorId}}` | `dingtalk.bodyTemplatePlaceholder` |
+
+### 4.5 Preset-Generated Template Content
+
+`applyDingTalkNotificationPreset(...)` currently inserts zh-only template content. T3D-4 localizes this generated default content at click time:
+
+| Preset | EN title/body | zh title/body |
+| --- | --- | --- |
+| `form_request` | `{{recordId}} needs input` / `Please complete this form request.\nRecord ID: {{recordId}}\nActor: {{actorId}}` | existing `{{recordId}} 待填写` / `请完成本次表单填写。\n记录编号：{{recordId}}\n触发人：{{actorId}}` |
+| `internal_process` | `{{recordId}} needs processing` / `Please review and process this record.\nRecord ID: {{recordId}}\nActor: {{actorId}}` | existing `{{recordId}} 待处理` / `请查看并处理该记录。\n记录编号：{{recordId}}\n触发人：{{actorId}}` |
+| `form_and_process` | `{{recordId}} needs input and processing` / `Please complete the required form input, then continue processing this record.\nRecord ID: {{recordId}}\nActor: {{actorId}}` | existing `{{recordId}} 待填写并处理` / `请先填写所需信息，并由有权限成员继续处理该记录。\n记录编号：{{recordId}}\n触发人：{{actorId}}` |
+
+This is event-time behavior. Once the preset writes `titleTemplate` / `bodyTemplate` into the draft, that content is user-editable data and does not retranslate if locale changes.
+
+### 4.6 Utility Warning And Access Summary Chrome
+
+These utility functions must become locale-aware and keep raw identifiers interpolated:
+
+| Utility | Current EN class | Target |
+| --- | --- | --- |
+| `listDingTalkTemplateSyntaxWarnings(template, isZh)` | Empty/unsupported/unknown/unclosed placeholder warnings | Localize wrapper text; keep `${raw}` placeholder raw. |
+| `listDingTalkGroupDestinationFieldPathWarnings(value, fields, isZh)` | unknown/user/member-group wrong-type warnings | Localize wrapper text; keep `record.${path}` raw. |
+| `listDingTalkPersonRecipientFieldPathWarnings(value, fields, isZh)` | not user field warnings | Localize wrapper text; keep `record.${path}` raw. |
+| `listDingTalkPersonMemberGroupRecipientFieldPathWarnings(value, fields, isZh)` | unknown/user/not member-group warnings | Localize wrapper text; keep `record.${path}` raw. |
+| `describeDingTalkPublicFormLinkAccess(..., { isZh })` | access state summaries | Localize wrapper text; keep view names raw. |
+| `describeDingTalkPublicFormLinkAudience(..., { isZh })` | audience summaries and allowlist counts | Localize wrapper text and plural/count wording; keep counts raw. |
+| `listDingTalkPublicFormLinkBlockingErrors(..., { isZh })` | missing/disabled/expired form errors | Localize wrapper text; keep view IDs/names raw. |
+| `listDingTalkPublicFormLinkWarnings(..., { isZh })` | fully public / protected-without-allowlist risk warnings | Localize wrapper text; keep view names raw. |
+| `listDingTalkInternalViewLinkWarnings(viewId, views, isZh)` | missing internal-view warning | Localize wrapper text; keep view ID raw. |
+
+For `dingtalkPublicFormLinkWarnings.ts`, prefer extending `DingTalkPublicFormLinkWarningOptions` with `isZh?: boolean` rather than adding positional booleans. This preserves the existing `nowMs` number shorthand in tests and avoids call-site ambiguity.
+
+## 5. Label Module Additions
+
+Continue the T3D single-domain module:
+
+```ts
+export type AutomationDingTalkPreset = 'form_request' | 'internal_process' | 'form_and_process'
+export type AutomationDingTalkTemplateTokenKey = 'recordId' | 'sheetId' | 'actorId' | 'recordField'
+export type AutomationDingTalkDestinationScope = 'private' | 'sheet' | 'org'
+export type AutomationDingTalkPersonSubject = 'user' | 'member-group'
+export type AutomationDingTalkPersonStatus =
+  | 'memberGroupCheckedIndividually'
+  | 'noDeliveryLink'
+  | 'deliveryReadyGrantEnabled'
+  | 'deliveryReadyGrantDisabled'
+  | 'notBound'
+  | 'boundGrantEnabled'
+  | 'boundGrantDisabled'
+
+export function automationDingTalkPresetLabel(preset: AutomationDingTalkPreset | (string & {}), isZh: boolean): string
+export function automationDingTalkTemplateTokenLabel(token: AutomationDingTalkTemplateTokenKey | (string & {}), isZh: boolean): string
+export function automationDingTalkDestinationScopeLabel(scope: AutomationDingTalkDestinationScope | (string & {}), isZh: boolean): string
+export function automationDingTalkDestinationSubtitle(scope: AutomationDingTalkDestinationScope, id: string, isZh: boolean): string
+export function automationDingTalkPersonSubjectLabel(subject: AutomationDingTalkPersonSubject | (string & {}), isZh: boolean): string
+export function automationDingTalkPersonAccessLabel(accessLevel: string, isZh: boolean): string
+export function automationDingTalkPersonStatusLabel(status: AutomationDingTalkPersonStatus | (string & {}), isZh: boolean): string
+export function automationDingTalkAllowlistSummary(userCount: number, memberGroupCount: number, isZh: boolean): string
+```
+
+`automationDingTalkAllowlistSummary(0, 0, isZh)` returns an empty string. Callers must use the existing no-allowlist full-sentence branches for the zero case; the helper only formats non-empty allowlist count summaries.
+
+Static keys should use a `dingtalk.*` namespace inside `AutomationLabelKey`, for example:
+
+| Namespace | Examples |
+| --- | --- |
+| `dingtalk.preset.*` | `dingtalk.preset`, `dingtalk.formRequest`, `dingtalk.internalProcessing`, `dingtalk.formAndProcessing`. |
+| `dingtalk.group.*` | `dingtalk.addGroups`, `dingtalk.recordGroupFieldPaths`, `dingtalk.pickGroupField`. |
+| `dingtalk.person.*` | `dingtalk.searchUsersOrGroups`, `dingtalk.localUserIds`, `dingtalk.recordRecipientFieldPaths`. |
+| `dingtalk.template.*` | `dingtalk.titleTemplate`, `dingtalk.bodyTemplate`, `dingtalk.templateTokens`, placeholders. |
+| `dingtalk.preview.*` | `dingtalk.messageSummary`, `dingtalk.renderedTitle`, `dingtalk.noRenderedBody`, `dingtalk.copy`, `dingtalk.copied`. |
+| `dingtalk.link.*` | `dingtalk.publicFormView`, `dingtalk.publicFormAccess`, `dingtalk.allowedAudience`, `dingtalk.internalProcessingView`. |
+
+Unknown enum/helper values must fall back to `String(value)`.
+
+## 6. Raw Boundary
+
+Keep these raw:
+
+| Raw value | Reason |
+| --- | --- |
+| `data-*` selector values such as `data-field`, `data-automation-token`, `data-access-level` | Test/CSS selectors and persisted enum state. |
+| CSS suffixes from access levels (`public`, `dingtalk`, `dingtalk_granted`, etc.) | Styling contract. |
+| DingTalk destination IDs, user IDs, member group IDs, subject IDs | User/system data. |
+| Field IDs and field paths such as `record.assigneeUserIds` | User schema data and template syntax. |
+| Field names and view names | User-authored data. |
+| Template token values such as `{{recordId}}`, `{{record.xxx}}` | Technical syntax. |
+| User-authored title/body templates after preset insertion | Data, not chrome. |
+| Rendered template output | Derived from user template plus sample/user data. |
+| Backend/API errors and `e.message` | Raw error detail; only frontend fallback wrappers are localized. |
+| Public token / access mode persisted values | Contract data. |
+
+M1 trap guard: localized strings must never be assigned to `data-*` attributes or CSS suffixes. Bind raw values only.
+
+## 7. A11y Boundary
+
+T3D-4 localizes existing placeholder text, but must not add new a11y attributes.
+
+| Component | Source `aria-label` | Source `title` | Source `placeholder` | Expected |
+| --- | ---: | ---: | ---: | --- |
+| `MetaAutomationManager.vue` | 0 | 0 | 13 | Fixture-render count remains stable; placeholder count stays unchanged. |
+| `MetaAutomationRuleEditor.vue` | 0 | 5 | 25 | Fixture-render count remains stable; placeholder count stays unchanged. |
+
+Implementation specs must record fixture-render counts for `[aria-label]`, `[title]`, and `[placeholder]` after wiring. Text changes to existing placeholders are required i18n behavior; adding new attributes is out of scope.
+
+## 8. Test Plan
+
+### 8.1 Helper Unit Tests
+
+Extend `apps/web/tests/meta-automation-labels.spec.ts`:
+
+- All new `dingtalk.*` keys included in `AUTOMATION_LABEL_KEYS`.
+- Preset labels in en/zh plus unknown fallback.
+- Template token labels in en/zh plus unknown fallback.
+- Destination scope labels/subtitles in en/zh, preserving raw IDs.
+- Person subject/access/status labels in en/zh, preserving raw access levels.
+- Allowlist count summaries:
+  - both-zero returns `''`
+  - `1 local user`
+  - `2 local users`
+  - `1 local member group`
+  - mixed user + group
+  - zh count forms with no EN plural suffix.
+
+### 8.2 Utility Tests
+
+Extend existing utility specs:
+
+- `dingtalk-public-form-link-warnings.spec.ts`: keep current EN default expectations; add zh cases using `{ nowMs, isZh: true }`.
+- `dingtalk-recipient-field-warnings.spec.ts`: keep current EN default expectations; add zh cases and assert `record.${path}` remains raw.
+- `dingtalk-internal-view-link-warnings.spec.ts`: keep current EN default expectations; add zh case and assert missing view ID remains raw.
+- Do not add dedicated specs for `dingtalkNotificationTemplateLint.ts`, `dingtalkNotificationTemplateTokens.ts`, `dingtalkNotificationPresets.ts`, or `dingtalkNotificationTemplateExample.ts` in this slice. Their locale behavior is covered through Manager/RuleEditor render specs that exercise the actual call-sites, plus `meta-automation-labels.spec.ts` helper coverage. If implementation later chooses to add a small dedicated spec for debugging, it is additive but not required by this design.
+
+### 8.3 Manager Render Tests
+
+Extend `apps/web/tests/multitable-automation-manager.spec.ts`:
+
+- zh-CN quick-form DingTalk group panel: preset buttons, group picker, template token buttons, preview labels, link labels, copy/copy-state.
+- zh-CN quick-form DingTalk person panel: search labels, recipient labels/statuses, placeholders, field-picker labels, preview labels.
+- Raw selector checks:
+  - `data-automation-token` values stay token keys.
+  - `data-access-level` values stay raw access levels.
+  - field/view/destination IDs remain raw in selectors.
+- A11y sentinel: fixture-render `[aria-label]`, `[title]`, `[placeholder]` counts remain stable.
+
+### 8.4 Rule Editor Render Tests
+
+Extend `apps/web/tests/multitable-automation-rule-editor.spec.ts`:
+
+- zh-CN group action config: preset buttons, dynamic group field chrome, warnings, template tokens, public/internal link labels, preview labels.
+- zh-CN person action config: search and recipient chrome, warnings, template tokens, public/internal link labels, preview labels.
+- Utility warning rendering in zh, with raw field paths and view names preserved.
+- A11y sentinel: fixture-render `[aria-label]`, `[title]`, `[placeholder]` counts remain stable.
+
+### 8.5 Validation Commands
+
+Run package-relative paths because `pnpm --filter @metasheet/web exec` runs with `cwd=apps/web`:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/meta-automation-labels.spec.ts tests/dingtalk-public-form-link-warnings.spec.ts tests/dingtalk-recipient-field-warnings.spec.ts tests/dingtalk-internal-view-link-warnings.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web build
+git diff --check origin/main..HEAD
+```
+
+## 9. Preflight Grep
+
+Before implementation, run:
+
+```bash
+rg -n "Message preset|Form request|Form \\+ processing|Add DingTalk groups|Template tokens|Public form view|Internal processing view|Message summary|Rendered title|Rendered body|No public form link|No internal link|Search by user|No matching users|Inactive users cannot be added|record\\.opsDestinationId|例如：\\{\\{record\\.title\\}\\}|支持 \\{\\{record\\.xxx\\}\\}|使用逗号或换行分隔" apps/web/src/multitable/components/MetaAutomationManager.vue apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+rg -n "Empty placeholder|Unsupported placeholder|Unknown placeholder|Unclosed placeholder|No public form link|Allowed audience unavailable|Public form sharing|Internal processing view|not a user field|not a member group field|member group recipients expect" apps/web/src/multitable/utils/dingtalk*.ts
+```
+
+Classify each hit as:
+
+- `localize`: DingTalk chrome or frontend static fallback.
+- `raw`: user data, token syntax, ID, selector, enum, or backend error.
+- `already shipped`: non-DingTalk automation chrome from T3D-1/T3D-2/T3D-3.
+
+Verification MD must include the grep output or a summarized table with line references.
+
+## 10. Implementation Order
+
+1. Rebase onto current `origin/main` before writing code.
+2. Run the §9 preflight grep and update the implementation checklist if new call-sites appear.
+3. Extend `meta-automation-labels.ts` with `dingtalk.*` keys, typed unions, and helpers.
+4. Update token utilities so token values stay raw and labels render through locale-aware helpers.
+5. Update preset/template-example utilities with locale-aware generated defaults and sample data.
+6. Update template lint, recipient warning, internal-view warning, and public-form warning utilities with locale-aware output.
+7. Wire `MetaAutomationManager.vue` with `isZh.value`; do not touch non-DingTalk chrome.
+8. Wire `MetaAutomationRuleEditor.vue` with `isZh.value`; do not touch non-DingTalk chrome.
+9. Extend helper and utility specs.
+10. Extend manager and rule editor render specs with zh/en/raw/a11y sentinel assertions.
+11. Write verification MD with preflight grep evidence, reuse-grep evidence, test output, a11y counts, raw boundary notes, and known limitations.
+12. Run targeted tests, `vue-tsc`, build, and diff-check.
+13. Commit locally and stop before push.
+
+## 11. Risk Register
+
+| Risk | Mitigation |
+| --- | --- |
+| Locale-aware utility signatures break existing tests | Keep EN default behavior for direct utility calls; call sites pass `isZh.value` explicitly. |
+| Preset-generated templates become user data after insertion | Document event-time semantics; do not try to retranslate edited templates. |
+| Public-form warning options overload becomes ambiguous | Add `isZh?: boolean` to the existing options object; preserve numeric `nowMs` shorthand. |
+| Template token labels accidentally translate token values | Keep `value` raw and localize only labels. |
+| CSS/data selector trap | Assert raw `data-*` and access-level values in render specs. |
+| A11y attribute drift | Lock fixture-render `[aria-label]`, `[title]`, and `[placeholder]` counts. |
+| 4-PR chain mid-flight rebase | For T3D-4, fetch/rebase before push. If PR becomes BEHIND with zero surface overlap, Path A admin squash remains acceptable; otherwise rebase and `--force-with-lease`. |
+| Existing DingTalk specs assert EN strings | Update expectations lockstep and add zh cases; keep EN default utility tests where default behavior remains EN. |
+
+## 12. Approval Gate
+
+Implementation is ready to push only if:
+
+- No backend, contract, migration, attendance, K3, or non-DingTalk automation scope leaks.
+- `meta-automation-labels.ts` is the only label module touched.
+- Every new key/helper has a real call-site or direct utility spec consumer.
+- `data-*`, CSS suffixes, IDs, token values, field paths, view names, destination names, and backend errors stay raw.
+- Manager and RuleEditor specs include zh render checks plus raw selector checks.
+- A11y sentinel counts are recorded and stable.
+- Targeted vitest, `vue-tsc`, build, and `git diff --check` pass.

--- a/docs/development/multitable-t3d4-automation-dingtalk-i18n-verification-20260522.md
+++ b/docs/development/multitable-t3d4-automation-dingtalk-i18n-verification-20260522.md
@@ -1,0 +1,148 @@
+# Multitable T3D-4 Automation DingTalk I18n Verification
+
+Date: 2026-05-22
+Branch: `frontend/multitable-t3d4-automation-dingtalk-i18n-20260522`
+Base: `origin/main@64f77b597`
+
+## DoD
+
+- T3D-4 closes the automation DingTalk shared chrome slice.
+- Scope is frontend i18n only: no backend, contract, migration, attendance, K3, or non-automation manager surfaces.
+- T3D-4 extends the existing `meta-automation-labels.ts` module; no cross-module helper redeclare.
+- DingTalk util functions keep English defaults; Vue consumers pass `isZh.value`.
+- Raw boundaries stay raw: IDs, field/view names, token values, template text after insertion, backend errors, data attributes, and CSS selector values.
+- A11y boundary stays structural: existing text/placeholder localization only, no new `aria-label` or `title` attributes.
+
+## File Scope
+
+Intended PR files: 18.
+
+- Source: `MetaAutomationManager.vue`, `MetaAutomationRuleEditor.vue`, 7 DingTalk utility files, `meta-automation-labels.ts`.
+- Tests: `meta-automation-labels.spec.ts`, 3 DingTalk utility specs, `multitable-automation-manager.spec.ts`, `multitable-automation-rule-editor.spec.ts`.
+- Docs: this verification MD and `multitable-t3d4-automation-dingtalk-i18n-design-20260522.md`.
+
+`pnpm install --frozen-lockfile` was required in this fresh worktree to restore local `node_modules`. It produced tracked `node_modules` symlink noise under plugin/tool folders; those paths are not staged and are not part of the intended PR diff.
+
+## Preflight Grep
+
+Planned DingTalk placeholder call-sites are wired to locale-aware labels:
+
+```text
+MetaAutomationManager.vue:169  dingtalk.titleTemplatePlaceholder
+MetaAutomationManager.vue:197  dingtalk.bodyTemplatePlaceholder
+MetaAutomationManager.vue:300  dingtalk.searchUsersOrGroupsPlaceholder
+MetaAutomationManager.vue:360  dingtalk.localUserIdsPlaceholder
+MetaAutomationManager.vue:368  dingtalk.memberGroupIdsPlaceholder
+MetaAutomationManager.vue:376  dingtalk.recordRecipientFieldPathPlaceholder
+MetaAutomationManager.vue:421  dingtalk.recordMemberGroupFieldPathPlaceholder
+MetaAutomationManager.vue:466  dingtalk.titleTemplatePlaceholder
+MetaAutomationManager.vue:494  dingtalk.bodyTemplatePlaceholder
+MetaAutomationRuleEditor.vue:415  dingtalk.titleTemplatePlaceholder
+MetaAutomationRuleEditor.vue:443  dingtalk.bodyTemplatePlaceholder
+MetaAutomationRuleEditor.vue:567  dingtalk.searchUsersOrGroupsPlaceholder
+MetaAutomationRuleEditor.vue:627  dingtalk.localUserIdsPlaceholder
+MetaAutomationRuleEditor.vue:635  dingtalk.memberGroupIdsPlaceholder
+MetaAutomationRuleEditor.vue:643  dingtalk.recordRecipientFieldPathPlaceholder
+MetaAutomationRuleEditor.vue:688  dingtalk.recordMemberGroupFieldPathPlaceholder
+MetaAutomationRuleEditor.vue:733  dingtalk.titleTemplatePlaceholder
+MetaAutomationRuleEditor.vue:761  dingtalk.bodyTemplatePlaceholder
+```
+
+Static placeholder literals now live in `meta-automation-labels.ts` as paired `en`/`zh` entries. Component templates no longer carry the zh-only placeholder strings directly.
+
+## Reuse / Reachability
+
+Intra-module T3D helper reachability was verified with `rg` over the label module, Manager, RuleEditor, and DingTalk utilities.
+
+- `automationDingTalkPresetLabel`: definition plus Manager and RuleEditor group/person preset buttons.
+- `automationDingTalkTemplateTokenLabel`: definition plus `dingTalkTemplateTokenLabel()`, consumed by Manager and RuleEditor token buttons.
+- `automationDingTalkDestinationScopeLabel` / `automationDingTalkDestinationSubtitle`: definitions plus Manager and RuleEditor group destination labels.
+- `automationDingTalkPersonSubjectLabel` / `automationDingTalkPersonAccessLabel` / `automationDingTalkPersonStatusLabel`: definitions plus Manager and RuleEditor person candidate/chip labels.
+- `automationDingTalkAllowlistSummary`: definition plus `dingtalkPublicFormLinkWarnings.ts`.
+
+`AUTOMATION_LABEL_KEYS` remains unique and exhaustive through `meta-automation-labels.spec.ts`.
+
+## Raw Boundary
+
+Verified by code inspection and tests:
+
+- `data-*` attributes remain raw persisted values (`data-access-level`, `data-automation-*`, selected IDs).
+- DingTalk group destination IDs, local user IDs, member group IDs, field IDs, and view IDs are not translated.
+- Field/view names remain raw user data, including Chinese view names in existing manager-card tests.
+- Template token insertions remain raw: `{{recordId}}`, `{{sheetId}}`, `{{actorId}}`, `{{record.xxx}}`.
+- Rendered example data is locale-specific demo data only; user-authored template text remains raw.
+- Backend/API error messages continue to be surfaced raw; frontend static fallbacks are localized.
+- Public form / internal view warning helpers preserve raw view names and IDs inside localized chrome.
+
+## A11y Boundary
+
+Source attribute count after implementation:
+
+```text
+MetaAutomationManager.vue + MetaAutomationRuleEditor.vue
+[aria-label]  = 0
+[title]       = 5
+[placeholder] = 38
+```
+
+Representative fixture-render sentinel tests:
+
+- `multitable-automation-manager.spec.ts` zh DingTalk person inline form: `[aria-label]/[title]/[placeholder] = 0/0/8`.
+- `multitable-automation-rule-editor.spec.ts` zh DingTalk group editor: `[aria-label]/[title]/[placeholder] = 0/1/4`.
+- Existing RuleEditor base fixture still locks `[aria-label]/[title]/[placeholder] = 0/1/1`.
+
+No new `aria-label` or `title` attributes were added; this slice localizes existing visible text and placeholders.
+
+## Tests
+
+Target specs:
+
+```text
+pnpm --filter @metasheet/web exec vitest run \
+  tests/meta-automation-labels.spec.ts \
+  tests/dingtalk-public-form-link-warnings.spec.ts \
+  tests/dingtalk-recipient-field-warnings.spec.ts \
+  tests/dingtalk-internal-view-link-warnings.spec.ts \
+  tests/multitable-automation-manager.spec.ts \
+  tests/multitable-automation-rule-editor.spec.ts \
+  --watch=false
+
+Test Files  6 passed (6)
+Tests       196 passed (196)
+```
+
+Coverage added:
+
+- DingTalk label helpers: presets, template tokens, destination scopes/subtitles, person subject/access/status, allowlist summary, unknown raw fallbacks.
+- DingTalk utility helpers: EN default and zh requested paths for public form link warnings, recipient field warnings, internal view warnings.
+- Manager render: zh DingTalk inline form chrome, placeholders, token labels, preset output, template syntax warning, rendered example, and a11y sentinel.
+- RuleEditor render: zh DingTalk group editor chrome, placeholders, token labels, preset output, rendered example, and a11y sentinel.
+- Existing EN baseline tests updated to reflect utility EN defaults.
+
+Type/build:
+
+```text
+pnpm --filter @metasheet/web run type-check
+vue-tsc -b
+exit 0
+
+pnpm --filter @metasheet/web build
+vue-tsc -b && vite build
+✓ built in 6.26s
+exit 0
+```
+
+`vite build` retains the existing WorkflowDesigner chunking warning; this slice does not touch workflow routing/chunk configuration.
+
+## Diff Hygiene
+
+```text
+git diff --check -- . ':!**/node_modules/**'
+exit 0
+```
+
+No `TODO`, `FIXME`, `console.log`, or `debugger` was introduced in the touched multitable automation/DingTalk files.
+
+## Result
+
+T3D-4 implementation is ready for implementation review. It completes DingTalk shared chrome localization while keeping T3D-1/2/3 helper/module discipline intact.


### PR DESCRIPTION
## Summary
- Extends `meta-automation-labels.ts` with DingTalk chrome labels/helpers for T3D-4.
- Localizes Automation Manager and Rule Editor DingTalk shared chrome, including 18 placeholder call-sites through 7 shared placeholder keys.
- Adds EN-side defaults for previously zh-only DingTalk presets/template examples while preserving raw template tokens like `{{recordId}}`, `{{sheetId}}`, `{{actorId}}`, and `{{record.xxx}}`.
- Keeps T3D-4 scoped to frontend multitable i18n only; no backend/contract/migration/attendance/K3 changes.

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/meta-automation-labels.spec.ts tests/dingtalk-public-form-link-warnings.spec.ts tests/dingtalk-recipient-field-warnings.spec.ts tests/dingtalk-internal-view-link-warnings.spec.ts tests/multitable-automation-manager.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false` => 6 files / 196 tests passed
- `pnpm --filter @metasheet/web run type-check` => pass
- `pnpm --filter @metasheet/web build` => pass, built in 6.26s
- `git diff --check origin/main..HEAD` => clean

## Notes
- Aria/title/placeholder sentinel coverage is documented in verification MD: source 0/5/38; fixture-render 0/0/8, 0/1/4, and 0/1/1.
- Rebased onto latest `origin/main` before push; PR diff remains the intended 18 T3D-4 files.
- Node_modules symlink noise remains local-only and is not staged or part of this PR.

Docs:
- `docs/development/multitable-t3d4-automation-dingtalk-i18n-design-20260522.md`
- `docs/development/multitable-t3d4-automation-dingtalk-i18n-verification-20260522.md`
