### PR TITLE
feat(attendance): add advanced scheduling scope foundation

### DIFF
--- a/docs/development/attendance-advanced-scheduling-scope-foundation-development-20260522.md
+++ b/docs/development/attendance-advanced-scheduling-scope-foundation-development-20260522.md
@@ -1,0 +1,132 @@
+# Attendance Advanced Scheduling Scope Foundation Development
+
+Date: 2026-05-22
+Branch: `codex/attendance-schedule-groups-scope-20260522`
+
+## Summary
+
+This slice turns the advanced-scheduling design lock into the first backend
+foundation: DingTalk-like `排班班组` and `排班人` now have explicit SQL models,
+admin-only API surfaces, and pure helper contracts for date-aware membership
+windows and scoped scheduler actions.
+
+It intentionally does not build the dense schedule grid, Excel import/export,
+temporary shift drawing, dispatch optimizer, frontend UI, or multitable snapshot
+sync. Those remain follow-up slices after this ownership model is stable.
+
+## Changed Files
+
+| File | Change |
+| --- | --- |
+| `packages/core-backend/src/db/migrations/zzzz20260522100000_create_attendance_schedule_groups.ts` | Adds `attendance_schedule_groups`, `attendance_schedule_group_members`, and `attendance_scheduler_scopes` with idempotent indexes and date-window guardrails. |
+| `plugins/plugin-attendance/index.cjs` | Adds mappers/normalizers/scope helpers and admin-only CRUD/list routes for schedule groups, date-aware members, and scheduler scopes. |
+| `packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts` | Locks the migration boundary, route guard wiring, schedule-group normalization, membership window semantics, and scheduler-scope matching. |
+| `docs/development/attendance-advanced-scheduling-scope-foundation-development-20260522.md` | This development note. |
+| `docs/development/attendance-advanced-scheduling-scope-foundation-verification-20260522.md` | Verification evidence for this slice. |
+
+## Data Model
+
+### `attendance_schedule_groups`
+
+Operational scheduling groups are separate from `attendance_groups`.
+
+Key fields:
+
+- `name`, `code`, `description`
+- optional `attendance_group_id` reference
+- optional `parent_id` for small-organization nesting
+- `department_ref` as a string reference
+- `source`: `manual | import | integration`
+- `is_active` for soft-delete semantics
+- `created_by`, `updated_by`, timestamps
+
+Important contract:
+
+- The table references `attendance_groups` when useful, but does not mutate or
+  replace it.
+- Active `(org_id, name)` and non-null `(org_id, code)` are unique.
+- Delete route soft-deactivates instead of cascading schedule history away.
+
+### `attendance_schedule_group_members`
+
+Membership is date-aware.
+
+Key fields:
+
+- `schedule_group_id`
+- `user_id`
+- `effective_from`, `effective_to`
+- `role`: `member | lead | backup`
+- `source`: `manual | import | integration`
+
+Important contract:
+
+- A check constraint rejects `effective_to < effective_from`.
+- API write path rejects overlapping windows for the same org/group/user.
+- The member-create route serializes writes with a transaction-scoped advisory
+  lock keyed by `orgId:scheduleGroupId:userId` before running the overlap query,
+  so concurrent requests for the same member cannot both pass the pre-insert
+  check. Exact duplicate-window unique violations are also mapped to
+  `409 MEMBERSHIP_OVERLAP`.
+- This does not change `attendance_group_members`.
+
+### `attendance_scheduler_scopes`
+
+Scheduler delegation is explicit and action-scoped.
+
+Key fields:
+
+- `subject_type`: `user | role | role_tag`
+- `subject_ref`
+- `actions`: `view | edit | import | export | clear | approve | dispatch`
+- `scope` JSON object with `scheduleGroupIds`, `attendanceGroupIds`, `userIds`,
+  `departments`, `roles`, `roleTags`
+- `is_active`
+
+Important contract:
+
+- Empty scope is invalid. Only `attendance:admin` remains global.
+- `view` does not imply `edit`; every action is explicit.
+- CRUD routes are admin-only in this foundation slice. Scoped non-admin
+  enforcement is reserved for future grid/write endpoints.
+
+## API Surface
+
+All routes are guarded by `attendance:admin`.
+
+| Method | Path | Behavior |
+| --- | --- | --- |
+| `GET` | `/api/attendance/schedule-groups` | List active schedule groups, `includeInactive=true` opt-in. |
+| `GET` | `/api/attendance/schedule-groups/:id` | Read one schedule group. |
+| `POST` | `/api/attendance/schedule-groups` | Create schedule group. |
+| `PUT` | `/api/attendance/schedule-groups/:id` | Update schedule group. |
+| `DELETE` | `/api/attendance/schedule-groups/:id` | Soft-delete by setting `is_active=false`. |
+| `GET` | `/api/attendance/schedule-groups/:id/members` | List date-aware members. |
+| `POST` | `/api/attendance/schedule-groups/:id/members` | Add one or more members, rejecting overlaps. |
+| `DELETE` | `/api/attendance/schedule-groups/:id/members/:memberId` | Delete one membership row by id. |
+| `GET` | `/api/attendance/scheduler-scopes` | List active scheduler scopes, `includeInactive=true` opt-in. |
+| `POST` | `/api/attendance/scheduler-scopes` | Create explicit scheduler scope. |
+| `PUT` | `/api/attendance/scheduler-scopes/:id` | Update explicit scheduler scope. |
+| `DELETE` | `/api/attendance/scheduler-scopes/:id` | Soft-delete by setting `is_active=false`. |
+
+## Boundary Decisions
+
+| Boundary | Decision |
+| --- | --- |
+| Existing `attendance_groups` | Not overloaded. Only optional FK reference from schedule group to attendance group. |
+| Existing `attendance_group_members` | Not modified. New date-aware table is separate. |
+| Scheduling grid | Deferred. The grid must use this scope model later. |
+| Scoped non-admin writes | Deferred. This slice defines scope rows and pure matching helper; future write endpoints must enforce it. |
+| Operation log | Contract remains documented; no audit write was added here because this slice only creates admin setup surfaces and no grid/bulk schedule mutation. |
+| Multitable | Not touched. Future schedule snapshots remain rebuildable outputs, not facts. |
+| Data Factory / Bridge Agent | Not touched. |
+
+## Follow-Up Slices
+
+1. Read-only advanced scheduling workbench that consumes schedule groups and
+   current assignments.
+2. Backend scoped permission enforcement helper for non-admin scheduling writes.
+3. Dense grid draft/preview flow that routes every write through conflict guards.
+4. Copy/paste and copy previous week/month.
+5. Excel import/export with out-of-scope row rejection.
+6. Operation-log integration for grid/import/clear/copy actions.

--- a/docs/development/attendance-advanced-scheduling-scope-foundation-verification-20260522.md
+++ b/docs/development/attendance-advanced-scheduling-scope-foundation-verification-20260522.md
@@ -1,0 +1,72 @@
+# Attendance Advanced Scheduling Scope Foundation Verification
+
+Date: 2026-05-22
+Branch: `codex/attendance-schedule-groups-scope-20260522`
+
+## Scope Verification
+
+| Area | Result |
+| --- | --- |
+| Runtime domain | Attendance only |
+| Data Factory / Bridge Agent | Not touched |
+| Frontend UI | Not touched |
+| Multitable | Not touched |
+| Existing `attendance_groups` | Not altered |
+| Existing `attendance_group_members` | Not altered |
+| New migration | Adds only advanced scheduling foundation tables |
+| Direct `meta_*` writes | None |
+| Secrets / tokens | None |
+
+## Boundary Evidence
+
+| Boundary | Evidence |
+| --- | --- |
+| Separate schedule group model | Migration creates `attendance_schedule_groups` instead of altering `attendance_groups`. |
+| Date-aware membership | Migration creates `attendance_schedule_group_members` with `effective_from` / `effective_to` and a date-window check constraint. |
+| `attendance_group_members` untouched | Tests assert the migration does not contain `ALTER TABLE attendance_group_members` or a drop of that table. |
+| Admin-only setup routes | Tests assert every new route path is wired through `withPermission('attendance:admin', ...)`. |
+| Empty scheduler scopes fail closed | Tests assert `normalizeAttendanceSchedulerScopeInput(... scope: {})` throws instead of creating a global non-admin scope. |
+| Scope matching is all-targets | Tests assert a scope covering `sg-1` + `u-1/u-2` allows `sg-1/u-1` but rejects `sg-2` or `u-3`. |
+| Membership overlap is not silent | Tests assert inclusive overlapping windows are detected and adjacent non-overlap is allowed. |
+| Membership overlap is concurrency-guarded | Tests assert the member-create path takes `pg_advisory_xact_lock` before querying existing membership windows and maps exact duplicate `23505` to `409 MEMBERSHIP_OVERLAP`. |
+
+## Test Commands
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/attendance-advanced-scheduling-scope.test.ts \
+  tests/unit/attendance-effective-calendar-role-context.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/attendance-import-permission.test.ts \
+  tests/unit/attendance-scheduling-assignment-conflict.test.ts \
+  tests/unit/attendance-advanced-scheduling-scope.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend build
+
+git diff --check
+```
+
+## Results
+
+| Check | Result |
+| --- | --- |
+| Plugin syntax | PASS |
+| Advanced scheduling + effective-calendar unit tests | PASS, 12 tests |
+| Import permission + conflict + advanced scheduling unit tests | PASS, 13 tests |
+| Core backend build | PASS |
+| Secret scan on changed code/docs | PASS, no token/private key/JWT literal matches |
+
+## Notes
+
+- The isolated worktree needed `pnpm install --ignore-scripts` to restore local
+  `node_modules` links before running the package build. This produced unrelated
+  node_modules symlink noise in the worktree; commit staging must explicitly list
+  the slice files and must not use `git add -A`.
+- This slice does not prove live staging behavior because it does not operate on
+  staging/prod. Runtime evidence should start with the next read-only workbench
+  or API smoke slice.

--- a/packages/core-backend/src/db/migrations/zzzz20260522100000_create_attendance_schedule_groups.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260522100000_create_attendance_schedule_groups.ts
@@ -1,0 +1,119 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists, createIndexIfNotExists } from './_patterns'
+
+const DEFAULT_ORG_ID = 'default'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  const scheduleGroupsExists = await checkTableExists(db, 'attendance_schedule_groups')
+  if (!scheduleGroupsExists) {
+    await db.schema
+      .createTable('attendance_schedule_groups')
+      .ifNotExists()
+      .addColumn('id', 'uuid', col => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('org_id', 'text', col => col.notNull().defaultTo(DEFAULT_ORG_ID))
+      .addColumn('name', 'text', col => col.notNull())
+      .addColumn('code', 'text')
+      .addColumn('description', 'text')
+      .addColumn('attendance_group_id', 'uuid', col => col.references('attendance_groups.id').onDelete('set null'))
+      .addColumn('parent_id', 'uuid', col => col.references('attendance_schedule_groups.id').onDelete('set null'))
+      .addColumn('department_ref', 'text')
+      .addColumn('source', 'text', col => col.notNull().defaultTo('manual'))
+      .addColumn('is_active', 'boolean', col => col.notNull().defaultTo(true))
+      .addColumn('created_by', 'text')
+      .addColumn('updated_by', 'text')
+      .addColumn('created_at', 'timestamptz', col => col.defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', col => col.defaultTo(sql`now()`))
+      .execute()
+  }
+
+  await createIndexIfNotExists(db, 'idx_attendance_schedule_groups_org', 'attendance_schedule_groups', 'org_id')
+  await createIndexIfNotExists(db, 'idx_attendance_schedule_groups_attendance_group', 'attendance_schedule_groups', 'attendance_group_id')
+  await createIndexIfNotExists(db, 'idx_attendance_schedule_groups_parent', 'attendance_schedule_groups', 'parent_id')
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_attendance_schedule_groups_org_name_active
+    ON attendance_schedule_groups(org_id, name)
+    WHERE is_active = true
+  `.execute(db)
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_attendance_schedule_groups_org_code
+    ON attendance_schedule_groups(org_id, code)
+    WHERE code IS NOT NULL
+  `.execute(db)
+
+  const membersExists = await checkTableExists(db, 'attendance_schedule_group_members')
+  if (!membersExists) {
+    await db.schema
+      .createTable('attendance_schedule_group_members')
+      .ifNotExists()
+      .addColumn('id', 'uuid', col => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('org_id', 'text', col => col.notNull().defaultTo(DEFAULT_ORG_ID))
+      .addColumn('schedule_group_id', 'uuid', col => col.notNull().references('attendance_schedule_groups.id').onDelete('cascade'))
+      .addColumn('user_id', 'text', col => col.notNull())
+      .addColumn('effective_from', 'date')
+      .addColumn('effective_to', 'date')
+      .addColumn('role', 'text')
+      .addColumn('source', 'text', col => col.notNull().defaultTo('manual'))
+      .addColumn('created_by', 'text')
+      .addColumn('updated_by', 'text')
+      .addColumn('created_at', 'timestamptz', col => col.defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', col => col.defaultTo(sql`now()`))
+      .execute()
+  }
+
+  await createIndexIfNotExists(db, 'idx_attendance_schedule_group_members_org', 'attendance_schedule_group_members', 'org_id')
+  await createIndexIfNotExists(db, 'idx_attendance_schedule_group_members_group', 'attendance_schedule_group_members', 'schedule_group_id')
+  await createIndexIfNotExists(db, 'idx_attendance_schedule_group_members_user', 'attendance_schedule_group_members', 'user_id')
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_attendance_schedule_group_members_exact_window
+    ON attendance_schedule_group_members(
+      org_id,
+      schedule_group_id,
+      user_id,
+      COALESCE(effective_from, DATE '0001-01-01'),
+      COALESCE(effective_to, DATE '9999-12-31')
+    )
+  `.execute(db)
+  await sql`
+    ALTER TABLE attendance_schedule_group_members
+    ADD CONSTRAINT attendance_schedule_group_members_window_check
+    CHECK (effective_from IS NULL OR effective_to IS NULL OR effective_to >= effective_from)
+  `.execute(db).catch((error) => {
+    if (error?.code !== '42710') throw error
+  })
+
+  const scopesExists = await checkTableExists(db, 'attendance_scheduler_scopes')
+  if (!scopesExists) {
+    await db.schema
+      .createTable('attendance_scheduler_scopes')
+      .ifNotExists()
+      .addColumn('id', 'uuid', col => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('org_id', 'text', col => col.notNull().defaultTo(DEFAULT_ORG_ID))
+      .addColumn('subject_type', 'text', col => col.notNull())
+      .addColumn('subject_ref', 'text', col => col.notNull())
+      .addColumn('actions', sql`text[]`, col => col.notNull())
+      .addColumn('scope', 'jsonb', col => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('is_active', 'boolean', col => col.notNull().defaultTo(true))
+      .addColumn('created_by', 'text')
+      .addColumn('updated_by', 'text')
+      .addColumn('created_at', 'timestamptz', col => col.defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', col => col.defaultTo(sql`now()`))
+      .execute()
+  }
+
+  await createIndexIfNotExists(db, 'idx_attendance_scheduler_scopes_org', 'attendance_scheduler_scopes', 'org_id')
+  await createIndexIfNotExists(db, 'idx_attendance_scheduler_scopes_subject', 'attendance_scheduler_scopes', 'subject_ref')
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_attendance_scheduler_scopes_active_subject
+    ON attendance_scheduler_scopes(org_id, subject_type, subject_ref)
+    WHERE is_active = true
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('attendance_scheduler_scopes').ifExists().cascade().execute()
+  await db.schema.dropTable('attendance_schedule_group_members').ifExists().cascade().execute()
+  await db.schema.dropTable('attendance_schedule_groups').ifExists().cascade().execute()
+}

--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
@@ -1,0 +1,170 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceReportFieldCatalogForTests
+
+const pluginSource = readFileSync(
+  new URL('../../../../plugins/plugin-attendance/index.cjs', import.meta.url),
+  'utf8',
+)
+
+const migrationSource = readFileSync(
+  new URL('../../src/db/migrations/zzzz20260522100000_create_attendance_schedule_groups.ts', import.meta.url),
+  'utf8',
+)
+
+function expectAdminRoute(path: string) {
+  const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const pattern = new RegExp(`['"]${escaped}['"],\\s*\\n\\s*withPermission\\(['"]attendance:admin['"]`)
+  expect(pluginSource).toMatch(pattern)
+}
+
+describe('attendance advanced scheduling scope foundation', () => {
+  it('creates separate scheduling tables without mutating existing attendance group membership tables', () => {
+    expect(migrationSource).toContain("createTable('attendance_schedule_groups')")
+    expect(migrationSource).toContain("createTable('attendance_schedule_group_members')")
+    expect(migrationSource).toContain("createTable('attendance_scheduler_scopes')")
+    expect(migrationSource).toContain("references('attendance_groups.id')")
+    expect(migrationSource).not.toContain('ALTER TABLE attendance_groups')
+    expect(migrationSource).not.toContain('ALTER TABLE attendance_group_members')
+    expect(migrationSource).not.toContain("dropTable('attendance_groups')")
+    expect(migrationSource).not.toContain("dropTable('attendance_group_members')")
+  })
+
+  it('guards the new scheduling group and scheduler-scope routes behind attendance admin', () => {
+    [
+      '/api/attendance/schedule-groups',
+      '/api/attendance/schedule-groups/:id',
+      '/api/attendance/schedule-groups/:id/members',
+      '/api/attendance/schedule-groups/:id/members/:memberId',
+      '/api/attendance/scheduler-scopes',
+      '/api/attendance/scheduler-scopes/:id',
+    ].forEach(expectAdminRoute)
+  })
+
+  it('normalizes schedule groups without overloading attendance_groups semantics', () => {
+    const input = helpers.normalizeAttendanceScheduleGroupInput({
+      name: '  Line A Team  ',
+      code: 'line-a',
+      description: '  Day production line  ',
+      attendanceGroupId: '11111111-1111-4111-8111-111111111111',
+      parentId: null,
+      departmentRef: '  factory-1  ',
+      source: 'import',
+      isActive: true,
+    })
+
+    expect(input).toEqual({
+      name: 'Line A Team',
+      code: 'line-a',
+      description: 'Day production line',
+      attendanceGroupId: '11111111-1111-4111-8111-111111111111',
+      parentId: null,
+      departmentRef: 'factory-1',
+      source: 'import',
+      isActive: true,
+    })
+    expect(() => helpers.normalizeAttendanceScheduleGroupInput({
+      name: '<script>alert(1)</script>',
+    })).toThrow(/unsafe characters/)
+    expect(() => helpers.normalizeAttendanceScheduleGroupInput({
+      name: 'Line A',
+      attendanceGroupId: 'not-a-uuid',
+    })).toThrow(/attendanceGroupId must be a UUID/)
+  })
+
+  it('requires date-aware membership windows to be valid and non-overlap-ready', () => {
+    const input = helpers.normalizeAttendanceScheduleGroupMemberInput({
+      userIds: ['u-1', 'u-2'],
+      effectiveFrom: '2026-06-01',
+      effectiveTo: '2026-06-30',
+      role: 'lead',
+      source: 'manual',
+    })
+
+    expect(input).toEqual({
+      userIds: ['u-1', 'u-2'],
+      effectiveFrom: '2026-06-01',
+      effectiveTo: '2026-06-30',
+      role: 'lead',
+      source: 'manual',
+    })
+    expect(helpers.doAttendanceScheduleMembershipWindowsOverlap(
+      { effectiveFrom: '2026-06-01', effectiveTo: '2026-06-30' },
+      { effectiveFrom: '2026-06-30', effectiveTo: '2026-07-10' },
+    )).toBe(true)
+    expect(helpers.doAttendanceScheduleMembershipWindowsOverlap(
+      { effectiveFrom: '2026-06-01', effectiveTo: '2026-06-29' },
+      { effectiveFrom: '2026-06-30', effectiveTo: '2026-07-10' },
+    )).toBe(false)
+    expect(() => helpers.normalizeAttendanceScheduleGroupMemberInput({
+      userId: 'u-1',
+      effectiveFrom: '2026-07-01',
+      effectiveTo: '2026-06-30',
+    })).toThrow(/effectiveTo/)
+  })
+
+  it('serializes membership writes by org/group/user before overlap insert checks', () => {
+    expect(helpers.buildAttendanceScheduleGroupMemberLockKey(
+      'default',
+      '11111111-1111-4111-8111-111111111111',
+      'user-1',
+    )).toBe('default:11111111-1111-4111-8111-111111111111:user-1')
+    expect(pluginSource).toContain('function acquireAttendanceScheduleGroupMemberLock')
+    expect(pluginSource).toContain('SELECT pg_advisory_xact_lock(hashtext($1::text), hashtext($2::text))')
+    expect(pluginSource).toMatch(
+      /await acquireAttendanceScheduleGroupMemberLock\(trx, orgId, groupId, userId\)[\s\S]+FROM attendance_schedule_group_members/,
+    )
+    expect(pluginSource).toMatch(
+      /error\?\.code === '23505'[\s\S]+code: 'MEMBERSHIP_OVERLAP'/,
+    )
+  })
+
+  it('normalizes explicit scheduler actions and fails closed on empty scope', () => {
+    const scope = helpers.normalizeAttendanceSchedulerScopeInput({
+      subjectType: 'role_tag',
+      subjectRef: 'line_scheduler',
+      actions: ['view', 'edit'],
+      scope: {
+        scheduleGroupIds: ['sg-1'],
+        userIds: ['u-1', 'u-2'],
+      },
+    })
+
+    expect(scope).toEqual({
+      subjectType: 'role_tag',
+      subjectRef: 'line_scheduler',
+      actions: ['view', 'edit'],
+      scope: {
+        scheduleGroupIds: ['sg-1'],
+        attendanceGroupIds: [],
+        userIds: ['u-1', 'u-2'],
+        departments: [],
+        roles: [],
+        roleTags: [],
+      },
+      isActive: true,
+    })
+    expect(helpers.attendanceSchedulerScopeMatchesTarget(scope, {
+      scheduleGroupIds: ['sg-1'],
+      userIds: ['u-1'],
+    })).toBe(true)
+    expect(helpers.attendanceSchedulerScopeMatchesTarget(scope, {
+      scheduleGroupIds: ['sg-2'],
+      userIds: ['u-1'],
+    })).toBe(false)
+    expect(helpers.attendanceSchedulerScopeMatchesTarget(scope, {
+      scheduleGroupIds: ['sg-1'],
+      userIds: ['u-3'],
+    })).toBe(false)
+    expect(() => helpers.normalizeAttendanceSchedulerScopeInput({
+      subjectType: 'user',
+      subjectRef: 'scheduler-1',
+      actions: ['view'],
+      scope: {},
+    })).toThrow(/scope must include at least one target/)
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -43,6 +43,10 @@ const REQUEST_TYPES = [
   'leave',
   'overtime',
 ]
+const ATTENDANCE_SCHEDULE_GROUP_SOURCES = new Set(['manual', 'import', 'integration'])
+const ATTENDANCE_SCHEDULE_GROUP_MEMBER_ROLES = new Set(['member', 'lead', 'backup'])
+const ATTENDANCE_SCHEDULER_SCOPE_SUBJECT_TYPES = new Set(['user', 'role', 'role_tag'])
+const ATTENDANCE_SCHEDULER_SCOPE_ACTIONS = new Set(['view', 'edit', 'import', 'export', 'clear', 'approve', 'dispatch'])
 
 const SETTINGS_KEY = 'attendance.settings'
 const SETTINGS_CACHE_TTL_MS = 60000
@@ -7227,6 +7231,228 @@ function mapAttendanceGroupMemberRow(row) {
   }
 }
 
+function normalizeNullableText(value) {
+  if (value === undefined || value === null) return null
+  const text = String(value).trim()
+  return text.length ? text : null
+}
+
+function normalizeOptionalUuidField(fieldName, value) {
+  if (value === undefined || value === null || value === '') return null
+  const uuid = normalizeUuidString(String(value))
+  if (!uuid) {
+    throw new HttpError(400, 'VALIDATION_ERROR', `${fieldName} must be a UUID`)
+  }
+  return uuid
+}
+
+function normalizeEnumValue(fieldName, value, allowed, fallback) {
+  const raw = value === undefined || value === null || value === '' ? fallback : String(value).trim()
+  if (!allowed.has(raw)) {
+    throw new HttpError(400, 'VALIDATION_ERROR', `${fieldName} is invalid`)
+  }
+  return raw
+}
+
+function mapAttendanceScheduleGroupRow(row) {
+  return {
+    id: row.id,
+    orgId: row.org_id ?? DEFAULT_ORG_ID,
+    name: row.name,
+    code: row.code ?? '',
+    description: row.description ?? null,
+    attendanceGroupId: row.attendance_group_id ?? null,
+    parentId: row.parent_id ?? null,
+    departmentRef: row.department_ref ?? null,
+    source: row.source ?? 'manual',
+    isActive: row.is_active !== false,
+    createdBy: row.created_by ?? null,
+    updatedBy: row.updated_by ?? null,
+    createdAt: row.created_at ? new Date(row.created_at).toISOString() : undefined,
+    updatedAt: row.updated_at ? new Date(row.updated_at).toISOString() : undefined,
+  }
+}
+
+function mapAttendanceScheduleGroupMemberRow(row) {
+  return {
+    id: row.id,
+    orgId: row.org_id ?? DEFAULT_ORG_ID,
+    scheduleGroupId: row.schedule_group_id,
+    userId: row.user_id,
+    effectiveFrom: normalizeDateOnly(row.effective_from),
+    effectiveTo: normalizeDateOnly(row.effective_to),
+    role: row.role ?? null,
+    source: row.source ?? 'manual',
+    createdBy: row.created_by ?? null,
+    updatedBy: row.updated_by ?? null,
+    createdAt: row.created_at ? new Date(row.created_at).toISOString() : undefined,
+    updatedAt: row.updated_at ? new Date(row.updated_at).toISOString() : undefined,
+  }
+}
+
+function normalizeAttendanceScheduleGroupInput(value, existing = null) {
+  const name = value.name !== undefined
+    ? normalizeSafeDisplayName('name', value.name)
+    : normalizeSafeDisplayName('name', existing?.name)
+  const code = resolveAttendanceCode({
+    explicitCode: value.code,
+    existingCode: existing?.code,
+    prefix: 'schedule-group',
+    name,
+  })
+  const attendanceGroupId = value.attendanceGroupId !== undefined
+    ? normalizeOptionalUuidField('attendanceGroupId', value.attendanceGroupId)
+    : existing?.attendance_group_id ?? existing?.attendanceGroupId ?? null
+  const parentId = value.parentId !== undefined
+    ? normalizeOptionalUuidField('parentId', value.parentId)
+    : existing?.parent_id ?? existing?.parentId ?? null
+  if (parentId && existing?.id && parentId === existing.id) {
+    throw new HttpError(400, 'VALIDATION_ERROR', 'parentId cannot reference the same schedule group')
+  }
+  return {
+    name,
+    code,
+    description: value.description !== undefined ? normalizeNullableText(value.description) : existing?.description ?? null,
+    attendanceGroupId,
+    parentId,
+    departmentRef: value.departmentRef !== undefined ? normalizeNullableText(value.departmentRef) : existing?.department_ref ?? existing?.departmentRef ?? null,
+    source: normalizeEnumValue('source', value.source, ATTENDANCE_SCHEDULE_GROUP_SOURCES, existing?.source ?? 'manual'),
+    isActive: value.isActive !== undefined ? value.isActive !== false : existing?.is_active !== false,
+  }
+}
+
+function normalizeAttendanceScheduleGroupMemberInput(value) {
+  const userIds = normalizeStringArray([
+    ...(Array.isArray(value.userIds) ? value.userIds : []),
+    value.userId,
+  ].filter((item) => item !== undefined && item !== null))
+  const effectiveFrom = value.effectiveFrom === undefined || value.effectiveFrom === null || value.effectiveFrom === ''
+    ? null
+    : normalizeDateOnlyStrict(String(value.effectiveFrom))
+  const effectiveTo = value.effectiveTo === undefined || value.effectiveTo === null || value.effectiveTo === ''
+    ? null
+    : normalizeDateOnlyStrict(String(value.effectiveTo))
+  if (!userIds.length) {
+    throw new HttpError(400, 'VALIDATION_ERROR', 'userId is required')
+  }
+  if ((value.effectiveFrom && !effectiveFrom) || (value.effectiveTo && !effectiveTo)) {
+    throw new HttpError(400, 'VALIDATION_ERROR', 'effective date must use YYYY-MM-DD')
+  }
+  if (effectiveFrom && effectiveTo && effectiveTo < effectiveFrom) {
+    throw new HttpError(400, 'VALIDATION_ERROR', 'effectiveTo must be on or after effectiveFrom')
+  }
+  return {
+    userIds,
+    effectiveFrom,
+    effectiveTo,
+    role: value.role === undefined || value.role === null || value.role === ''
+      ? null
+      : normalizeEnumValue('role', value.role, ATTENDANCE_SCHEDULE_GROUP_MEMBER_ROLES, 'member'),
+    source: normalizeEnumValue('source', value.source, ATTENDANCE_SCHEDULE_GROUP_SOURCES, 'manual'),
+  }
+}
+
+function doAttendanceScheduleMembershipWindowsOverlap(a, b) {
+  const aStart = a?.effectiveFrom ?? '0001-01-01'
+  const aEnd = a?.effectiveTo ?? '9999-12-31'
+  const bStart = b?.effectiveFrom ?? '0001-01-01'
+  const bEnd = b?.effectiveTo ?? '9999-12-31'
+  return aStart <= bEnd && bStart <= aEnd
+}
+
+function buildAttendanceScheduleGroupMemberLockKey(orgId, scheduleGroupId, userId) {
+  return [
+    String(orgId ?? ''),
+    String(scheduleGroupId ?? ''),
+    String(userId ?? ''),
+  ].join(':')
+}
+
+async function acquireAttendanceScheduleGroupMemberLock(client, orgId, scheduleGroupId, userId) {
+  await client.query(
+    'SELECT pg_advisory_xact_lock(hashtext($1::text), hashtext($2::text))',
+    ['attendance-schedule-group-member', buildAttendanceScheduleGroupMemberLockKey(orgId, scheduleGroupId, userId)]
+  )
+}
+
+function normalizeAttendanceSchedulerScopeBody(value) {
+  const source = value && typeof value === 'object' ? value : {}
+  const result = {}
+  for (const key of ['scheduleGroupIds', 'attendanceGroupIds', 'userIds', 'departments', 'roles', 'roleTags']) {
+    result[key] = normalizeStringArray(source[key])
+  }
+  return result
+}
+
+function attendanceSchedulerScopeHasTargets(scope) {
+  if (!scope || typeof scope !== 'object') return false
+  return ['scheduleGroupIds', 'attendanceGroupIds', 'userIds', 'departments', 'roles', 'roleTags']
+    .some((key) => Array.isArray(scope[key]) && scope[key].length > 0)
+}
+
+function normalizeAttendanceSchedulerScopeInput(value, existing = null) {
+  const subjectType = normalizeEnumValue(
+    'subjectType',
+    value.subjectType,
+    ATTENDANCE_SCHEDULER_SCOPE_SUBJECT_TYPES,
+    existing?.subject_type ?? existing?.subjectType
+  )
+  const subjectRef = value.subjectRef !== undefined
+    ? normalizeSafeDisplayName('subjectRef', value.subjectRef)
+    : normalizeSafeDisplayName('subjectRef', existing?.subject_ref ?? existing?.subjectRef)
+  const actions = normalizeStringArray(value.actions !== undefined ? value.actions : existing?.actions)
+  const invalidActions = actions.filter((action) => !ATTENDANCE_SCHEDULER_SCOPE_ACTIONS.has(action))
+  if (!actions.length || invalidActions.length > 0) {
+    throw new HttpError(400, 'VALIDATION_ERROR', 'actions must contain valid scheduler actions')
+  }
+  const scope = normalizeAttendanceSchedulerScopeBody(value.scope !== undefined ? value.scope : existing?.scope)
+  if (!attendanceSchedulerScopeHasTargets(scope)) {
+    throw new HttpError(400, 'VALIDATION_ERROR', 'scope must include at least one target')
+  }
+  return {
+    subjectType,
+    subjectRef,
+    actions,
+    scope,
+    isActive: value.isActive !== undefined ? value.isActive !== false : existing?.is_active !== false,
+  }
+}
+
+function mapAttendanceSchedulerScopeRow(row) {
+  return {
+    id: row.id,
+    orgId: row.org_id ?? DEFAULT_ORG_ID,
+    subjectType: row.subject_type,
+    subjectRef: row.subject_ref,
+    actions: normalizeStringArray(row.actions),
+    scope: normalizeAttendanceSchedulerScopeBody(normalizeMetadata(row.scope)),
+    isActive: row.is_active !== false,
+    createdBy: row.created_by ?? null,
+    updatedBy: row.updated_by ?? null,
+    createdAt: row.created_at ? new Date(row.created_at).toISOString() : undefined,
+    updatedAt: row.updated_at ? new Date(row.updated_at).toISOString() : undefined,
+  }
+}
+
+function scopeListCoversTarget(scopeList, targetList) {
+  const allowed = new Set(normalizeStringArray(scopeList))
+  const targets = normalizeStringArray(targetList)
+  if (targets.length === 0) return true
+  if (allowed.size === 0) return false
+  return targets.every((target) => allowed.has(target))
+}
+
+function attendanceSchedulerScopeMatchesTarget(scopeRow, target) {
+  const scope = normalizeAttendanceSchedulerScopeBody(scopeRow?.scope ?? scopeRow)
+  if (!scopeListCoversTarget(scope.scheduleGroupIds, target?.scheduleGroupIds)) return false
+  if (!scopeListCoversTarget(scope.attendanceGroupIds, target?.attendanceGroupIds)) return false
+  if (!scopeListCoversTarget(scope.userIds, target?.userIds)) return false
+  if (!scopeListCoversTarget(scope.departments, target?.departments)) return false
+  if (!scopeListCoversTarget(scope.roles, target?.roles)) return false
+  if (!scopeListCoversTarget(scope.roleTags, target?.roleTags)) return false
+  return true
+}
+
 function normalizeAttendanceGroupValue(value) {
   if (value === undefined || value === null) return null
   const text = String(value).trim()
@@ -12906,6 +13132,21 @@ module.exports = {
     buildAttendanceReportFieldConfig,
     buildAttendanceReportFieldConfigHeaders,
     buildAttendanceReportFieldConfigFingerprint,
+    ATTENDANCE_SCHEDULE_GROUP_SOURCES,
+    ATTENDANCE_SCHEDULE_GROUP_MEMBER_ROLES,
+    ATTENDANCE_SCHEDULER_SCOPE_SUBJECT_TYPES,
+    ATTENDANCE_SCHEDULER_SCOPE_ACTIONS,
+    mapAttendanceScheduleGroupRow,
+    mapAttendanceScheduleGroupMemberRow,
+    normalizeAttendanceScheduleGroupInput,
+    normalizeAttendanceScheduleGroupMemberInput,
+    doAttendanceScheduleMembershipWindowsOverlap,
+    buildAttendanceScheduleGroupMemberLockKey,
+    acquireAttendanceScheduleGroupMemberLock,
+    normalizeAttendanceSchedulerScopeBody,
+    normalizeAttendanceSchedulerScopeInput,
+    mapAttendanceSchedulerScopeRow,
+    attendanceSchedulerScopeMatchesTarget,
     matchScopeFilters,
     loadAttendanceScopeContextForUser,
     loadAttendanceScopeContextMapForUsers,
@@ -24098,6 +24339,620 @@ module.exports = {
           }
           logger.error('Attendance group member delete failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to remove group member' } })
+        }
+      })
+    )
+
+    const scheduleGroupSchema = z.object({
+      name: z.string().min(1).optional(),
+      code: z.string().trim().optional().nullable(),
+      description: z.string().optional().nullable(),
+      attendanceGroupId: z.string().optional().nullable(),
+      parentId: z.string().optional().nullable(),
+      departmentRef: z.string().optional().nullable(),
+      source: z.enum(['manual', 'import', 'integration']).optional(),
+      isActive: z.boolean().optional(),
+    }).strict()
+
+    const scheduleGroupCreateSchema = scheduleGroupSchema.extend({
+      name: z.string().min(1),
+    })
+
+    const scheduleGroupMemberSchema = z.object({
+      userId: z.string().optional(),
+      userIds: z.array(z.string()).optional(),
+      effectiveFrom: z.string().optional().nullable(),
+      effectiveTo: z.string().optional().nullable(),
+      role: z.enum(['member', 'lead', 'backup']).optional().nullable(),
+      source: z.enum(['manual', 'import', 'integration']).optional(),
+    }).strict()
+
+    const schedulerScopeSchema = z.object({
+      subjectType: z.enum(['user', 'role', 'role_tag']).optional(),
+      subjectRef: z.string().min(1).optional(),
+      actions: z.array(z.enum(['view', 'edit', 'import', 'export', 'clear', 'approve', 'dispatch'])).optional(),
+      scope: z.record(z.unknown()).optional(),
+      isActive: z.boolean().optional(),
+    }).strict()
+
+    const schedulerScopeCreateSchema = schedulerScopeSchema.extend({
+      subjectType: z.enum(['user', 'role', 'role_tag']),
+      subjectRef: z.string().min(1),
+      actions: z.array(z.enum(['view', 'edit', 'import', 'export', 'clear', 'approve', 'dispatch'])).min(1),
+      scope: z.record(z.unknown()),
+    })
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/schedule-groups',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const { page, pageSize, offset } = parsePagination(req.query)
+        const includeInactive = parseBoolean(req.query.includeInactive, false)
+        try {
+          const activeClause = includeInactive ? '' : 'AND is_active = true'
+          const countRows = await db.query(
+            `SELECT COUNT(*)::int AS total
+             FROM attendance_schedule_groups
+             WHERE org_id = $1 ${activeClause}`,
+            [orgId]
+          )
+          const total = Number(countRows[0]?.total ?? 0)
+          const rows = await db.query(
+            `SELECT *
+             FROM attendance_schedule_groups
+             WHERE org_id = $1 ${activeClause}
+             ORDER BY is_active DESC, name ASC, created_at DESC
+             LIMIT $2 OFFSET $3`,
+            [orgId, pageSize, offset]
+          )
+          res.json({ ok: true, data: { items: rows.map(mapAttendanceScheduleGroupRow), total, page, pageSize } })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+            return
+          }
+          logger.error('Attendance schedule groups fetch failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load schedule groups' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/schedule-groups/:id',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const groupId = normalizeUuidString(req.params.id)
+        if (!groupId) {
+          respondInvalidUuid(res)
+          return
+        }
+        try {
+          const rows = await db.query(
+            'SELECT * FROM attendance_schedule_groups WHERE id = $1 AND org_id = $2',
+            [groupId, orgId]
+          )
+          if (!rows.length) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Schedule group not found' } })
+            return
+          }
+          res.json({ ok: true, data: mapAttendanceScheduleGroupRow(rows[0]) })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+            return
+          }
+          logger.error('Attendance schedule group lookup failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load schedule group' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/schedule-groups',
+      withPermission('attendance:admin', async (req, res) => {
+        const parsed = scheduleGroupCreateSchema.safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+        const orgId = getOrgId(req)
+        const actorId = getUserId(req)
+        let input
+        try {
+          input = normalizeAttendanceScheduleGroupInput(parsed.data)
+        } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+            return
+          }
+          throw error
+        }
+        try {
+          const rows = await db.query(
+            `INSERT INTO attendance_schedule_groups (
+               org_id, name, code, description, attendance_group_id, parent_id, department_ref,
+               source, is_active, created_by, updated_by, created_at, updated_at
+             )
+             VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $10, now(), now())
+             RETURNING *`,
+            [
+              orgId,
+              input.name,
+              input.code,
+              input.description,
+              input.attendanceGroupId,
+              input.parentId,
+              input.departmentRef,
+              input.source,
+              input.isActive,
+              actorId,
+            ]
+          )
+          res.json({ ok: true, data: mapAttendanceScheduleGroupRow(rows[0]) })
+        } catch (error) {
+          if (error?.code === '23505') {
+            res.status(409).json({ ok: false, error: { code: 'ALREADY_EXISTS', message: 'Schedule group name or code already exists' } })
+            return
+          }
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+            return
+          }
+          logger.error('Attendance schedule group create failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create schedule group' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'PUT',
+      '/api/attendance/schedule-groups/:id',
+      withPermission('attendance:admin', async (req, res) => {
+        const parsed = scheduleGroupSchema.safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+        const orgId = getOrgId(req)
+        const actorId = getUserId(req)
+        const groupId = normalizeUuidString(req.params.id)
+        if (!groupId) {
+          respondInvalidUuid(res)
+          return
+        }
+        try {
+          const existingRows = await db.query(
+            'SELECT * FROM attendance_schedule_groups WHERE id = $1 AND org_id = $2',
+            [groupId, orgId]
+          )
+          if (!existingRows.length) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Schedule group not found' } })
+            return
+          }
+          const input = normalizeAttendanceScheduleGroupInput(parsed.data, existingRows[0])
+          const rows = await db.query(
+            `UPDATE attendance_schedule_groups
+             SET name = $3,
+                 code = $4,
+                 description = $5,
+                 attendance_group_id = $6,
+                 parent_id = $7,
+                 department_ref = $8,
+                 source = $9,
+                 is_active = $10,
+                 updated_by = $11,
+                 updated_at = now()
+             WHERE id = $1 AND org_id = $2
+             RETURNING *`,
+            [
+              groupId,
+              orgId,
+              input.name,
+              input.code,
+              input.description,
+              input.attendanceGroupId,
+              input.parentId,
+              input.departmentRef,
+              input.source,
+              input.isActive,
+              actorId,
+            ]
+          )
+          res.json({ ok: true, data: mapAttendanceScheduleGroupRow(rows[0]) })
+        } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+            return
+          }
+          if (error?.code === '23505') {
+            res.status(409).json({ ok: false, error: { code: 'ALREADY_EXISTS', message: 'Schedule group name or code already exists' } })
+            return
+          }
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+            return
+          }
+          logger.error('Attendance schedule group update failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to update schedule group' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'DELETE',
+      '/api/attendance/schedule-groups/:id',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const actorId = getUserId(req)
+        const groupId = normalizeUuidString(req.params.id)
+        if (!groupId) {
+          respondInvalidUuid(res)
+          return
+        }
+        try {
+          const rows = await db.query(
+            `UPDATE attendance_schedule_groups
+             SET is_active = false, updated_by = $3, updated_at = now()
+             WHERE id = $1 AND org_id = $2
+             RETURNING *`,
+            [groupId, orgId, actorId]
+          )
+          if (!rows.length) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Schedule group not found' } })
+            return
+          }
+          res.json({ ok: true, data: mapAttendanceScheduleGroupRow(rows[0]) })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+            return
+          }
+          logger.error('Attendance schedule group delete failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete schedule group' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/schedule-groups/:id/members',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const groupId = normalizeUuidString(req.params.id)
+        if (!groupId) {
+          respondInvalidUuid(res)
+          return
+        }
+        const { page, pageSize, offset } = parsePagination(req.query)
+        try {
+          const countRows = await db.query(
+            `SELECT COUNT(*)::int AS total
+             FROM attendance_schedule_group_members
+             WHERE org_id = $1 AND schedule_group_id = $2`,
+            [orgId, groupId]
+          )
+          const rows = await db.query(
+            `SELECT *
+             FROM attendance_schedule_group_members
+             WHERE org_id = $1 AND schedule_group_id = $2
+             ORDER BY effective_from ASC NULLS FIRST, user_id ASC, created_at DESC
+             LIMIT $3 OFFSET $4`,
+            [orgId, groupId, pageSize, offset]
+          )
+          res.json({
+            ok: true,
+            data: { items: rows.map(mapAttendanceScheduleGroupMemberRow), total: Number(countRows[0]?.total ?? 0), page, pageSize },
+          })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+            return
+          }
+          logger.error('Attendance schedule group members fetch failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load schedule group members' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/schedule-groups/:id/members',
+      withPermission('attendance:admin', async (req, res) => {
+        const parsed = scheduleGroupMemberSchema.safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+        const orgId = getOrgId(req)
+        const actorId = getUserId(req)
+        const groupId = normalizeUuidString(req.params.id)
+        if (!groupId) {
+          respondInvalidUuid(res)
+          return
+        }
+        let input
+        try {
+          input = normalizeAttendanceScheduleGroupMemberInput(parsed.data)
+        } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+            return
+          }
+          throw error
+        }
+        try {
+          const created = []
+          await db.transaction(async (trx) => {
+            for (const userId of input.userIds) {
+              await acquireAttendanceScheduleGroupMemberLock(trx, orgId, groupId, userId)
+              const overlapRows = await trx.query(
+                `SELECT 1
+                 FROM attendance_schedule_group_members
+                 WHERE org_id = $1
+                   AND schedule_group_id = $2
+                   AND user_id = $3
+                   AND COALESCE(effective_from, DATE '0001-01-01') <= COALESCE($5::date, DATE '9999-12-31')
+                   AND COALESCE(effective_to, DATE '9999-12-31') >= COALESCE($4::date, DATE '0001-01-01')
+                 LIMIT 1`,
+                [orgId, groupId, userId, input.effectiveFrom, input.effectiveTo]
+              )
+              if (overlapRows.length) {
+                throw new HttpError(409, 'MEMBERSHIP_OVERLAP', `Schedule group membership overlaps for ${userId}`)
+              }
+              const rows = await trx.query(
+                `INSERT INTO attendance_schedule_group_members (
+                   org_id, schedule_group_id, user_id, effective_from, effective_to, role,
+                   source, created_by, updated_by, created_at, updated_at
+                 )
+                 VALUES ($1, $2, $3, $4::date, $5::date, $6, $7, $8, $8, now(), now())
+                 RETURNING *`,
+                [orgId, groupId, userId, input.effectiveFrom, input.effectiveTo, input.role, input.source, actorId]
+              )
+              if (rows.length) created.push(mapAttendanceScheduleGroupMemberRow(rows[0]))
+            }
+          })
+          res.json({ ok: true, data: { items: created } })
+        } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+            return
+          }
+          if (error?.code === '23505') {
+            res.status(409).json({ ok: false, error: { code: 'MEMBERSHIP_OVERLAP', message: 'Schedule group membership overlaps or already exists' } })
+            return
+          }
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+            return
+          }
+          logger.error('Attendance schedule group member create failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to add schedule group members' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'DELETE',
+      '/api/attendance/schedule-groups/:id/members/:memberId',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const groupId = normalizeUuidString(req.params.id)
+        const memberId = normalizeUuidString(req.params.memberId)
+        if (!groupId) {
+          respondInvalidUuid(res)
+          return
+        }
+        if (!memberId) {
+          respondInvalidUuid(res, 'memberId')
+          return
+        }
+        try {
+          const rows = await db.query(
+            `DELETE FROM attendance_schedule_group_members
+             WHERE id = $1 AND org_id = $2 AND schedule_group_id = $3
+             RETURNING id`,
+            [memberId, orgId, groupId]
+          )
+          if (!rows.length) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Schedule group member not found' } })
+            return
+          }
+          res.json({ ok: true, data: { id: memberId } })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+            return
+          }
+          logger.error('Attendance schedule group member delete failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to remove schedule group member' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/scheduler-scopes',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const { page, pageSize, offset } = parsePagination(req.query)
+        const includeInactive = parseBoolean(req.query.includeInactive, false)
+        try {
+          const activeClause = includeInactive ? '' : 'AND is_active = true'
+          const countRows = await db.query(
+            `SELECT COUNT(*)::int AS total
+             FROM attendance_scheduler_scopes
+             WHERE org_id = $1 ${activeClause}`,
+            [orgId]
+          )
+          const rows = await db.query(
+            `SELECT *
+             FROM attendance_scheduler_scopes
+             WHERE org_id = $1 ${activeClause}
+             ORDER BY is_active DESC, subject_type ASC, subject_ref ASC, created_at DESC
+             LIMIT $2 OFFSET $3`,
+            [orgId, pageSize, offset]
+          )
+          res.json({ ok: true, data: { items: rows.map(mapAttendanceSchedulerScopeRow), total: Number(countRows[0]?.total ?? 0), page, pageSize } })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+            return
+          }
+          logger.error('Attendance scheduler scopes fetch failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load scheduler scopes' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/scheduler-scopes',
+      withPermission('attendance:admin', async (req, res) => {
+        const parsed = schedulerScopeCreateSchema.safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+        const orgId = getOrgId(req)
+        const actorId = getUserId(req)
+        let input
+        try {
+          input = normalizeAttendanceSchedulerScopeInput(parsed.data)
+        } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+            return
+          }
+          throw error
+        }
+        try {
+          const rows = await db.query(
+            `INSERT INTO attendance_scheduler_scopes (
+               org_id, subject_type, subject_ref, actions, scope, is_active,
+               created_by, updated_by, created_at, updated_at
+             )
+             VALUES ($1, $2, $3, $4::text[], $5::jsonb, $6, $7, $7, now(), now())
+             RETURNING *`,
+            [
+              orgId,
+              input.subjectType,
+              input.subjectRef,
+              input.actions,
+              JSON.stringify(input.scope),
+              input.isActive,
+              actorId,
+            ]
+          )
+          res.json({ ok: true, data: mapAttendanceSchedulerScopeRow(rows[0]) })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+            return
+          }
+          logger.error('Attendance scheduler scope create failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create scheduler scope' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'PUT',
+      '/api/attendance/scheduler-scopes/:id',
+      withPermission('attendance:admin', async (req, res) => {
+        const parsed = schedulerScopeSchema.safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+        const orgId = getOrgId(req)
+        const actorId = getUserId(req)
+        const scopeId = normalizeUuidString(req.params.id)
+        if (!scopeId) {
+          respondInvalidUuid(res)
+          return
+        }
+        try {
+          const existingRows = await db.query(
+            'SELECT * FROM attendance_scheduler_scopes WHERE id = $1 AND org_id = $2',
+            [scopeId, orgId]
+          )
+          if (!existingRows.length) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Scheduler scope not found' } })
+            return
+          }
+          const input = normalizeAttendanceSchedulerScopeInput(parsed.data, existingRows[0])
+          const rows = await db.query(
+            `UPDATE attendance_scheduler_scopes
+             SET subject_type = $3,
+                 subject_ref = $4,
+                 actions = $5::text[],
+                 scope = $6::jsonb,
+                 is_active = $7,
+                 updated_by = $8,
+                 updated_at = now()
+             WHERE id = $1 AND org_id = $2
+             RETURNING *`,
+            [
+              scopeId,
+              orgId,
+              input.subjectType,
+              input.subjectRef,
+              input.actions,
+              JSON.stringify(input.scope),
+              input.isActive,
+              actorId,
+            ]
+          )
+          res.json({ ok: true, data: mapAttendanceSchedulerScopeRow(rows[0]) })
+        } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+            return
+          }
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+            return
+          }
+          logger.error('Attendance scheduler scope update failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to update scheduler scope' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'DELETE',
+      '/api/attendance/scheduler-scopes/:id',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const actorId = getUserId(req)
+        const scopeId = normalizeUuidString(req.params.id)
+        if (!scopeId) {
+          respondInvalidUuid(res)
+          return
+        }
+        try {
+          const rows = await db.query(
+            `UPDATE attendance_scheduler_scopes
+             SET is_active = false, updated_by = $3, updated_at = now()
+             WHERE id = $1 AND org_id = $2
+             RETURNING *`,
+            [scopeId, orgId, actorId]
+          )
+          if (!rows.length) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Scheduler scope not found' } })
+            return
+          }
+          res.json({ ok: true, data: mapAttendanceSchedulerScopeRow(rows[0]) })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+            return
+          }
+          logger.error('Attendance scheduler scope delete failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete scheduler scope' } })
         }
       })
     )


### PR DESCRIPTION
## Summary

Adds the first backend foundation for DingTalk-like advanced scheduling:

- new SQL models for `attendance_schedule_groups`, date-aware `attendance_schedule_group_members`, and explicit `attendance_scheduler_scopes`
- admin-only CRUD/list APIs for schedule groups, members, and scheduler scopes
- helper contracts for membership window overlap and all-target scheduler-scope matching
- focused unit coverage plus development/verification MD

## Boundaries

- Attendance only; no Data Factory / Bridge Agent work
- No frontend UI in this slice
- Does not overload existing `attendance_groups` or mutate `attendance_group_members`
- No multitable writes; future schedule snapshots remain rebuildable outputs
- Dense grid, Excel import/export, temporary shifts, scoped non-admin write enforcement, and operation-log writes are follow-up slices

## Verification

- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-advanced-scheduling-scope.test.ts tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` → 11 pass
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-import-permission.test.ts tests/unit/attendance-scheduling-assignment-conflict.test.ts tests/unit/attendance-advanced-scheduling-scope.test.ts --reporter=dot` → 12 pass
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`

## Worktree note

The isolated worktree required `pnpm install --ignore-scripts` to restore local dependency links for build/test. That produced unrelated node_modules symlink noise in the worktree; staging was explicit and the PR contains only the 5 slice files.
