### PR TITLE
feat(multitable): close final i18n audit small residuals (Slice A)

### DIFF
--- a/apps/web/src/multitable/components/MetaCalendarView.vue
+++ b/apps/web/src/multitable/components/MetaCalendarView.vue
@@ -450,6 +450,7 @@ const eventsByDate = computed(() => {
         value: row.data[titleField.value.id],
         linkSummaries: props.linkSummaries?.[row.id]?.[titleField.value.id],
         attachmentSummaries: props.attachmentSummaries?.[row.id]?.[titleField.value.id],
+        isZh: isZh.value,
       })
       : row.id
     const title = titleDisplay === '—' ? row.id : titleDisplay

--- a/apps/web/src/multitable/components/MetaFormView.vue
+++ b/apps/web/src/multitable/components/MetaFormView.vue
@@ -479,6 +479,7 @@ function readonlyFieldDisplay(field: MetaField): string {
     value: formData[field.id] ?? props.record?.data[field.id],
     linkSummaries: props.linkSummariesByField?.[field.id],
     attachmentSummaries: props.attachmentSummariesByField?.[field.id],
+    isZh: isZh.value,
   })
 }
 
@@ -536,7 +537,7 @@ async function onFormFileSelect(fieldId: string, e: Event) {
   clearAttachmentOperationError(fieldId)
   const field = props.fields.find((item) => item.id === fieldId)
   if (field) {
-    const validationError = validateAttachmentSelection(field, files, attachmentList(fieldId).length)
+    const validationError = validateAttachmentSelection(field, files, attachmentList(fieldId).length, isZh.value)
     if (validationError) {
       setAttachmentOperationError(fieldId, validationError)
       input.value = ''

--- a/apps/web/src/multitable/components/MetaGalleryView.vue
+++ b/apps/web/src/multitable/components/MetaGalleryView.vue
@@ -258,6 +258,7 @@ function formatValue(row: MetaRecord, field: MetaField): string {
     value: row.data[field.id],
     linkSummaries: props.linkSummaries?.[row.id]?.[field.id],
     attachmentSummaries: props.attachmentSummaries?.[row.id]?.[field.id],
+    isZh: isZh.value,
   })
 }
 

--- a/apps/web/src/multitable/components/MetaGanttView.vue
+++ b/apps/web/src/multitable/components/MetaGanttView.vue
@@ -146,6 +146,7 @@
 <script setup lang="ts">
 import { computed, onBeforeUnmount, ref, watch } from 'vue'
 import type { LinkedRecordSummary, MetaAttachment, MetaField, MetaGanttViewConfig, MetaRecord } from '../types'
+import { useLocale } from '../../composables/useLocale'
 import { formatFieldDisplay } from '../utils/field-display'
 import { isSelfTableLinkField, resolveGanttViewConfig } from '../utils/view-config'
 
@@ -186,6 +187,7 @@ const zoom = ref<'day' | 'week' | 'month'>('week')
 const selectedRecordId = ref<string | null>(null)
 const pendingConfigKey = ref<string | null>(null)
 const resizingRecordId = ref<string | null>(null)
+const { isZh } = useLocale()
 
 type ResizeEdge = 'start' | 'end'
 
@@ -246,6 +248,7 @@ function displayTitle(record: MetaRecord): string {
     value: record.data[field.id],
     linkSummaries: props.linkSummaries?.[record.id]?.[field.id],
     attachmentSummaries: props.attachmentSummaries?.[record.id]?.[field.id],
+    isZh: isZh.value,
   })
   return value === '-' || value === '\u2014' ? record.id : value
 }

--- a/apps/web/src/multitable/components/MetaHierarchyView.vue
+++ b/apps/web/src/multitable/components/MetaHierarchyView.vue
@@ -225,7 +225,7 @@ function onPickOrphanMode(event: Event) {
 
 function titleForRow(row: MetaRecord): string {
   if (!titleField.value) return row.id
-  const display = formatFieldDisplay({ field: titleField.value, value: row.data[titleField.value.id] })
+  const display = formatFieldDisplay({ field: titleField.value, value: row.data[titleField.value.id], isZh: isZh.value })
   return display === '-' || display === '—' ? row.id : display
 }
 

--- a/apps/web/src/multitable/components/MetaKanbanView.vue
+++ b/apps/web/src/multitable/components/MetaKanbanView.vue
@@ -290,6 +290,7 @@ function formatValue(row: MetaRecord, field: MetaField): string {
     value: row.data[field.id],
     linkSummaries: props.linkSummaries?.[row.id]?.[field.id],
     attachmentSummaries: props.attachmentSummaries?.[row.id]?.[field.id],
+    isZh: isZh.value,
   })
 }
 

--- a/apps/web/src/multitable/components/MetaMentionPopover.vue
+++ b/apps/web/src/multitable/components/MetaMentionPopover.vue
@@ -1,9 +1,9 @@
 <template>
   <div v-if="visible" class="meta-mention-popover" @click.self="emit('close')">
-    <div class="meta-mention-popover__panel" role="dialog" aria-label="Mentions">
+    <div class="meta-mention-popover__panel" role="dialog" :aria-label="l('comment.mentions')">
       <div class="meta-mention-popover__header">
-        <strong>Mentions</strong>
-        <button class="meta-mention-popover__close" aria-label="Close mentions" @click="emit('close')">&times;</button>
+        <strong>{{ l('comment.mentions') }}</strong>
+        <button class="meta-mention-popover__close" :aria-label="l('comment.closeMentions')" @click="emit('close')">&times;</button>
       </div>
       <div class="meta-mention-popover__list">
         <button
@@ -13,7 +13,7 @@
           :class="{ 'meta-mention-popover__item--unread': item.unreadCount > 0 }"
           @click="emit('select-record', { rowId: item.rowId, fieldId: item.mentionedFieldIds[0] ?? null, mentionedFieldIds: item.mentionedFieldIds })"
         >
-          <span v-if="item.unreadCount > 0" class="meta-mention-popover__unread-dot" aria-label="Unread"></span>
+          <span v-if="item.unreadCount > 0" class="meta-mention-popover__unread-dot" :aria-label="l('comment.unread')"></span>
           <span class="meta-mention-popover__label">{{ resolveLabel(item.rowId) }}</span>
           <span class="meta-mention-popover__count">{{ item.mentionedCount }}</span>
           <span
@@ -31,6 +31,8 @@
 
 <script setup lang="ts">
 import type { CommentMentionSummaryItem, MetaField, MetaRecord } from '../types'
+import { useLocale } from '../../composables/useLocale'
+import { commentLabel, mentionFieldScope, type MetaCommentLabelKey } from '../utils/meta-comment-labels'
 
 const props = defineProps<{
   visible: boolean
@@ -51,6 +53,9 @@ const emit = defineEmits<{
   (e: 'select-record', payload: MentionPopoverSelectPayload): void
 }>()
 
+const { isZh } = useLocale()
+const l = (key: MetaCommentLabelKey) => commentLabel(key, isZh.value)
+
 function resolveLabel(rowId: string): string {
   if (!props.displayFieldId) return rowId
   const row = props.rows.find((record) => record.id === rowId)
@@ -68,8 +73,7 @@ function resolveFieldName(fieldId: string): string {
 function fieldScopeLabel(mentionedFieldIds: string[]): string {
   if (mentionedFieldIds.length === 0) return ''
   const primary = resolveFieldName(mentionedFieldIds[0])
-  if (mentionedFieldIds.length === 1) return primary
-  return `${primary} +${mentionedFieldIds.length - 1} more`
+  return mentionFieldScope(primary, mentionedFieldIds.length - 1, isZh.value)
 }
 </script>
 

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -504,6 +504,7 @@ function formatValue(field: MetaField, v: unknown): string {
     value: v,
     linkSummaries: props.linkSummariesByField?.[field.id],
     attachmentSummaries: props.attachmentSummariesByField?.[field.id],
+    isZh: isZh.value,
   })
 }
 
@@ -589,7 +590,7 @@ async function onDrawerFileSelect(fieldId: string, e: Event) {
   clearAttachmentError(fieldId)
   const field = props.fields.find((item) => item.id === fieldId)
   if (field) {
-    const validationError = validateAttachmentSelection(field, files, attachmentList(fieldId).length)
+    const validationError = validateAttachmentSelection(field, files, attachmentList(fieldId).length, isZh.value)
     if (validationError) {
       setAttachmentError(fieldId, validationError)
       input.value = ''

--- a/apps/web/src/multitable/components/MetaTimelineView.vue
+++ b/apps/web/src/multitable/components/MetaTimelineView.vue
@@ -330,6 +330,7 @@ function displayLabel(record: MetaRecord): string {
     value: record.data[displayField.value.id],
     linkSummaries: props.linkSummaries?.[record.id]?.[displayField.value.id],
     attachmentSummaries: props.attachmentSummaries?.[record.id]?.[displayField.value.id],
+    isZh: isZh.value,
   })
   return label === '—' ? record.id : label
 }

--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -344,6 +344,7 @@ const readonlyDisplayValue = computed(() =>
     field: props.field,
     value: props.modelValue,
     attachmentSummaries: props.attachmentSummaries,
+    isZh: isZh.value,
   }),
 )
 
@@ -422,10 +423,10 @@ const linkButtonLabel = computed(() => {
   // unreachable in the current render flow. We intentionally do NOT localize this
   // static English string in T3A2 (would be a dead key per the merged dev MD §7.6).
   // If a future refactor exposes this branch to the DOM, localize it together with
-  // `formatLinkActionLabel` (queued for T3B with the link picker/drawer slice).
+  // a real render assertion; the reachable link branch below now receives locale.
   if (props.field.type !== 'link') return 'Choose linked records...'
   const count = Array.isArray(props.modelValue) ? props.modelValue.length : props.modelValue ? 1 : 0
-  return formatLinkActionLabel(props.field, count)
+  return formatLinkActionLabel(props.field, count, isZh.value)
 })
 
 const uploading = ref(false)
@@ -483,7 +484,7 @@ function setAttachmentValue(nextIds: string[], confirm = true) {
 
 async function uploadFiles(files: FileList) {
   attachmentError.value = ''
-  const validationError = validateAttachmentSelection(props.field, files, attachmentIds.value.length)
+  const validationError = validateAttachmentSelection(props.field, files, attachmentIds.value.length, isZh.value)
   if (validationError) {
     attachmentError.value = validationError
     return

--- a/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellRenderer.vue
@@ -120,11 +120,13 @@
 import { computed } from 'vue'
 import type { MetaAttachment, MetaField, LinkedRecordSummary } from '../../types'
 import MetaAttachmentList from '../MetaAttachmentList.vue'
+import { useLocale } from '../../../composables/useLocale'
 import { isPersonField } from '../../utils/link-fields'
 import { formatFieldDisplay } from '../../utils/field-display'
 import { isSystemFieldType } from '../../utils/system-fields'
 
 const props = defineProps<{ field: MetaField; value: unknown; linkSummaries?: LinkedRecordSummary[]; attachmentSummaries?: MetaAttachment[] }>()
+const { isZh } = useLocale()
 
 const displayValue = computed(() => {
   return formatFieldDisplay({
@@ -132,6 +134,7 @@ const displayValue = computed(() => {
     value: props.value,
     linkSummaries: props.linkSummaries,
     attachmentSummaries: props.attachmentSummaries,
+    isZh: isZh.value,
   })
 })
 const isSystemField = computed(() => isSystemFieldType(props.field.type))
@@ -175,6 +178,7 @@ const linkItems = computed(() => {
     value: props.value,
     linkSummaries: props.linkSummaries,
     attachmentSummaries: props.attachmentSummaries,
+    isZh: isZh.value,
   })
   if (!linkIds.value.length) return []
   return [{ id: '__link_summary__', display: fallbackLabel }]
@@ -198,6 +202,7 @@ const attachmentItems = computed<MetaAttachment[]>(() => {
       value: props.value,
       linkSummaries: props.linkSummaries,
       attachmentSummaries: props.attachmentSummaries,
+      isZh: isZh.value,
     }),
     mimeType: 'application/octet-stream',
     size: 0,

--- a/apps/web/src/multitable/utils/field-config.ts
+++ b/apps/web/src/multitable/utils/field-config.ts
@@ -287,19 +287,25 @@ export function isValidPhoneValue(value: unknown): boolean {
   return typeof value === 'string' && PHONE_REGEX.test(value.trim())
 }
 
-export function validateAttachmentSelection(field: MetaField, files: FileList | File[], existingCount: number): string | null {
+export function validateAttachmentSelection(field: MetaField, files: FileList | File[], existingCount: number, isZh = false): string | null {
   if (field.type !== 'attachment') return null
   const { maxFiles, acceptedMimeTypes } = resolveAttachmentFieldProperty(field.property)
   const fileList = Array.from(files)
   if (maxFiles && existingCount + fileList.length > maxFiles && !shouldReplaceAttachmentSelection(field, fileList, existingCount)) {
-    return maxFiles === 1
-      ? 'This field only allows one attachment. Clear the current file before adding another.'
+    if (maxFiles === 1) {
+      return isZh
+        ? '该字段只允许一个附件。添加新文件前请先清除当前文件。'
+        : 'This field only allows one attachment. Clear the current file before adding another.'
+    }
+    return isZh
+      ? `该字段最多允许 ${maxFiles} 个附件。`
       : `This field allows up to ${maxFiles} attachments.`
   }
   if (acceptedMimeTypes.length > 0) {
     const disallowed = fileList.find((file) => file.type && !acceptedMimeTypes.includes(file.type))
     if (disallowed) {
-      return `File type not allowed: ${disallowed.type || disallowed.name}`
+      const rejectedType = disallowed.type || disallowed.name
+      return isZh ? `不允许的文件类型：${rejectedType}` : `File type not allowed: ${rejectedType}`
     }
   }
   return null

--- a/apps/web/src/multitable/utils/field-display.ts
+++ b/apps/web/src/multitable/utils/field-display.ts
@@ -65,14 +65,16 @@ function formatAutoNumber(value: unknown, property: Record<string, unknown> | un
   return `${prefix}${String(Math.trunc(num)).padStart(digits, '0')}`
 }
 
-function summarizeLinkCount(field: MetaField, count: number): string {
+function summarizeLinkCount(field: MetaField, count: number, isZh = false): string {
   if (count <= 0) return '—'
+  if (isZh) return field.property?.refKind === 'user' ? `${count} 个人员` : `${count} 条关联记录`
   if (field.property?.refKind === 'user') return count === 1 ? '1 person' : `${count} people`
   return count === 1 ? '1 linked record' : `${count} linked records`
 }
 
-function summarizeAttachmentCount(count: number): string {
+function summarizeAttachmentCount(count: number, isZh = false): string {
   if (count <= 0) return '—'
+  if (isZh) return `${count} 个附件`
   return count === 1 ? '1 attachment' : `${count} attachments`
 }
 
@@ -104,8 +106,9 @@ export function formatFieldDisplay(params: {
   value: unknown
   linkSummaries?: LinkedRecordSummary[] | null
   attachmentSummaries?: MetaAttachment[] | null
+  isZh?: boolean
 }): string {
-  const { field, value, linkSummaries, attachmentSummaries } = params
+  const { field, value, linkSummaries, attachmentSummaries, isZh = false } = params
   if (value === null || value === undefined || value === '') return '—'
 
   if (field.type === 'date') return formatDate(value)
@@ -113,7 +116,7 @@ export function formatFieldDisplay(params: {
   if (field.type === 'createdTime' || field.type === 'modifiedTime') return formatDateTime(value)
   if (field.type === 'autoNumber') return formatAutoNumber(value, field.property)
   if (isSystemFieldType(field.type)) return String(value)
-  if (field.type === 'boolean') return value ? 'Yes' : 'No'
+  if (field.type === 'boolean') return isZh ? (value ? '是' : '否') : (value ? 'Yes' : 'No')
 
   if (field.type === 'number') {
     const num = typeof value === 'number' ? value : Number(value)
@@ -164,7 +167,7 @@ export function formatFieldDisplay(params: {
         .join(', ')
     }
     const count = Array.isArray(value) ? value.length : value ? 1 : 0
-    return summarizeLinkCount(field, count)
+    return summarizeLinkCount(field, count, isZh)
   }
 
   if (field.type === 'attachment') {
@@ -175,7 +178,7 @@ export function formatFieldDisplay(params: {
         .join(', ')
     }
     const count = Array.isArray(value) ? value.length : value ? 1 : 0
-    return summarizeAttachmentCount(count)
+    return summarizeAttachmentCount(count, isZh)
   }
 
   if (Array.isArray(value)) {

--- a/apps/web/src/multitable/utils/meta-comment-labels.ts
+++ b/apps/web/src/multitable/utils/meta-comment-labels.ts
@@ -1,7 +1,7 @@
 // Comments drawer + composer chrome string table (T3B2).
 //
 // Scope: comment drawer/composer chrome plus row-comment action chip labels in
-// alternative views. User content, author names, mention labels, and
+// alternative views. User content, author names, record labels, field names, and
 // backend/composable error bodies stay raw and are never translated here.
 
 export type MetaCommentLabelKey =
@@ -18,6 +18,9 @@ export type MetaCommentLabelKey =
   | 'comment.resolve'
   | 'comment.resolving'
   | 'comment.resolved'
+  | 'comment.mentions'
+  | 'comment.closeMentions'
+  | 'comment.unread'
   | 'comment.placeholderAdd'
   | 'comment.placeholderEdit'
   | 'comment.placeholderReply'
@@ -44,6 +47,9 @@ const META_COMMENT_LABELS: Record<MetaCommentLabelKey, { en: string; zh: string 
   'comment.resolve': { en: 'Resolve', zh: '解决' },
   'comment.resolving': { en: 'Resolving...', zh: '正在解决...' },
   'comment.resolved': { en: 'Resolved', zh: '已解决' },
+  'comment.mentions': { en: 'Mentions', zh: '提及' },
+  'comment.closeMentions': { en: 'Close mentions', zh: '关闭提及' },
+  'comment.unread': { en: 'Unread', zh: '未读' },
   'comment.placeholderAdd': { en: 'Add a comment...', zh: '添加评论...' },
   'comment.placeholderEdit': { en: 'Edit comment…', zh: '编辑评论…' },
   'comment.placeholderReply': { en: 'Reply to thread…', zh: '回复线程…' },
@@ -93,4 +99,9 @@ export function editingBanner(actorLabel: string, isZh: boolean): string {
 
 export function replyingBanner(actorLabel: string, isZh: boolean): string {
   return isZh ? `正在回复 ${actorLabel}` : `Replying to ${actorLabel}`
+}
+
+export function mentionFieldScope(primaryFieldName: string, extraCount: number, isZh: boolean): string {
+  if (extraCount <= 0) return primaryFieldName
+  return isZh ? `${primaryFieldName} +${extraCount} 个字段` : `${primaryFieldName} +${extraCount} more`
 }

--- a/apps/web/src/multitable/utils/people-import.ts
+++ b/apps/web/src/multitable/utils/people-import.ts
@@ -41,6 +41,10 @@ function ambiguousMatchMessage(token: string, kind: LookupKind) {
   return `Multiple people match "${token}". Use email for an exact match.`
 }
 
+function singlePersonLimitMessage(rawValue: string, isZh: boolean) {
+  return isZh ? `人员字段只允许一个人员：${rawValue}` : `People field only allows one person: ${rawValue}`
+}
+
 function collectMatchesForLookup(token: string, kind: LookupKind, lookup?: Map<string, string | null>) {
   if (!lookup) return []
   const normalized = normalizePeopleImportKey(token)
@@ -60,8 +64,9 @@ export function resolvePeopleImportValue(params: {
   rawValue: string
   currentField?: MetaField
   lookups: PeopleImportLookupMaps
+  isZh?: boolean
 }): string[] | null {
-  const { rawValue, currentField, lookups } = params
+  const { rawValue, currentField, lookups, isZh = false } = params
   const tokens = extractImportTokens(rawValue)
   if (!tokens.length) return null
 
@@ -71,7 +76,7 @@ export function resolvePeopleImportValue(params: {
   }
   if (matchesFromIds.length) {
     if (currentField?.property?.limitSingleRecord === true && matchesFromIds.length > 1) {
-      throw new Error(`People field only allows one person: ${rawValue}`)
+      throw new Error(singlePersonLimitMessage(rawValue, isZh))
     }
     return matchesFromIds
   }
@@ -84,7 +89,7 @@ export function resolvePeopleImportValue(params: {
     }
     if (!bucketMatches.length) continue
     if (currentField?.property?.limitSingleRecord === true && bucketMatches.length > 1) {
-      throw new Error(`People field only allows one person: ${rawValue}`)
+      throw new Error(singlePersonLimitMessage(rawValue, isZh))
     }
     return bucketMatches
   }

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -1128,6 +1128,7 @@ async function getPeopleResolver(field: MetaField): Promise<ImportValueResolver 
           name: nameLookup,
           alias: aliasLookup,
         },
+        isZh: isZh.value,
       })
   })().catch((error) => {
     peopleResolverCache.delete(targetSheetId)

--- a/apps/web/tests/meta-cell-editor-i18n.spec.ts
+++ b/apps/web/tests/meta-cell-editor-i18n.spec.ts
@@ -165,6 +165,28 @@ describe('MetaCellEditor i18n — attachment chrome', () => {
   })
 })
 
+describe('MetaCellEditor i18n — link action chrome', () => {
+  it('localizes the reachable link action button while preserving field metadata raw', () => {
+    const field: MetaField = {
+      id: 'owner',
+      name: 'Owner',
+      type: 'link',
+      property: { refKind: 'user' } as unknown as MetaField['property'],
+    }
+
+    useLocale().setLocale('zh-CN')
+    let root = mountEditor(field, [])
+    expect(root.querySelector('.meta-cell-editor__link-btn')?.textContent?.trim()).toBe('选择人员...')
+    expect(root.textContent).not.toContain('Choose people')
+
+    app?.unmount(); app = null; container?.remove(); container = null
+
+    useLocale().setLocale('zh-CN')
+    root = mountEditor(field, ['rec_1'])
+    expect(root.querySelector('.meta-cell-editor__link-btn')?.textContent?.trim()).toBe('编辑人员 (1)')
+  })
+})
+
 describe('MetaCellEditor i18n — user-data preservation', () => {
   it('select option values stay exactly as authored (user data)', () => {
     useLocale().setLocale('zh-CN')

--- a/apps/web/tests/meta-comment-labels.spec.ts
+++ b/apps/web/tests/meta-comment-labels.spec.ts
@@ -3,6 +3,7 @@ import {
   commentLabel,
   editingBanner,
   emptyMessage,
+  mentionFieldScope,
   replyingBanner,
   replyCount,
   type MetaCommentLabelKey,
@@ -24,6 +25,9 @@ describe('meta-comment-labels static keys', () => {
       ['comment.resolve', 'Resolve', '解决'],
       ['comment.resolving', 'Resolving...', '正在解决...'],
       ['comment.resolved', 'Resolved', '已解决'],
+      ['comment.mentions', 'Mentions', '提及'],
+      ['comment.closeMentions', 'Close mentions', '关闭提及'],
+      ['comment.unread', 'Unread', '未读'],
       ['comment.placeholderAdd', 'Add a comment...', '添加评论...'],
       ['comment.placeholderEdit', 'Edit comment…', '编辑评论…'],
       ['comment.placeholderReply', 'Reply to thread…', '回复线程…'],
@@ -67,5 +71,11 @@ describe('meta-comment-labels helpers', () => {
     expect(editingBanner('张三', true)).toBe('正在编辑 张三')
     expect(replyingBanner('Amy Wong', false)).toBe('Replying to Amy Wong')
     expect(replyingBanner('张三', true)).toBe('正在回复 张三')
+  })
+
+  it('formats mention field scopes while preserving field names raw', () => {
+    expect(mentionFieldScope('Title', 0, false)).toBe('Title')
+    expect(mentionFieldScope('Title', 1, false)).toBe('Title +1 more')
+    expect(mentionFieldScope('标题', 1, true)).toBe('标题 +1 个字段')
   })
 })

--- a/apps/web/tests/multitable-field-config-i18n.spec.ts
+++ b/apps/web/tests/multitable-field-config-i18n.spec.ts
@@ -1,0 +1,48 @@
+import { describe, expect, it } from 'vitest'
+import { validateAttachmentSelection } from '../src/multitable/utils/field-config'
+import type { MetaField } from '../src/multitable/types'
+
+function file(name: string, type: string): File {
+  return new File(['x'], name, { type })
+}
+
+describe('validateAttachmentSelection i18n fallbacks', () => {
+  it('keeps attachment validation fallbacks in English by default', () => {
+    const field: MetaField = {
+      id: 'avatar',
+      name: 'Avatar',
+      type: 'attachment',
+      property: { maxFiles: 1 } as unknown as MetaField['property'],
+    }
+
+    expect(validateAttachmentSelection(field, [file('b.png', 'image/png'), file('c.png', 'image/png')], 1)).toBe(
+      'This field only allows one attachment. Clear the current file before adding another.',
+    )
+  })
+
+  it('localizes attachment max-file validation fallbacks when requested', () => {
+    const field: MetaField = {
+      id: 'files',
+      name: 'Files',
+      type: 'attachment',
+      property: { maxFiles: 2 } as unknown as MetaField['property'],
+    }
+
+    expect(validateAttachmentSelection(field, [file('a.png', 'image/png'), file('b.png', 'image/png')], 1, true)).toBe(
+      '该字段最多允许 2 个附件。',
+    )
+  })
+
+  it('localizes rejected MIME fallbacks while preserving MIME values raw', () => {
+    const field: MetaField = {
+      id: 'files',
+      name: 'Files',
+      type: 'attachment',
+      property: { acceptedMimeTypes: ['image/png'] } as unknown as MetaField['property'],
+    }
+
+    expect(validateAttachmentSelection(field, [file('brief.pdf', 'application/pdf')], 0, true)).toBe(
+      '不允许的文件类型：application/pdf',
+    )
+  })
+})

--- a/apps/web/tests/multitable-field-display-i18n.spec.ts
+++ b/apps/web/tests/multitable-field-display-i18n.spec.ts
@@ -1,0 +1,45 @@
+import { describe, expect, it } from 'vitest'
+import { formatFieldDisplay } from '../src/multitable/utils/field-display'
+import type { MetaField } from '../src/multitable/types'
+
+describe('formatFieldDisplay i18n fallbacks', () => {
+  it('keeps English boolean labels by default and localizes them when requested', () => {
+    const field: MetaField = { id: 'done', name: 'Done', type: 'boolean' }
+
+    expect(formatFieldDisplay({ field, value: true })).toBe('Yes')
+    expect(formatFieldDisplay({ field, value: false })).toBe('No')
+    expect(formatFieldDisplay({ field, value: true, isZh: true })).toBe('是')
+    expect(formatFieldDisplay({ field, value: false, isZh: true })).toBe('否')
+  })
+
+  it('localizes link count summaries without translating linked record display names', () => {
+    const personField: MetaField = {
+      id: 'owner',
+      name: 'Owner',
+      type: 'link',
+      property: { refKind: 'user' } as unknown as MetaField['property'],
+    }
+    const recordField: MetaField = { id: 'task', name: 'Task', type: 'link' }
+
+    expect(formatFieldDisplay({ field: personField, value: ['u1', 'u2'], isZh: true })).toBe('2 个人员')
+    expect(formatFieldDisplay({ field: recordField, value: ['r1'], isZh: true })).toBe('1 条关联记录')
+    expect(formatFieldDisplay({
+      field: personField,
+      value: ['u1'],
+      linkSummaries: [{ id: 'u1', display: 'Amy Wong' }],
+      isZh: true,
+    })).toBe('Amy Wong')
+  })
+
+  it('localizes attachment count summaries without translating file names', () => {
+    const field: MetaField = { id: 'files', name: 'Files', type: 'attachment' }
+
+    expect(formatFieldDisplay({ field, value: ['a1', 'a2'], isZh: true })).toBe('2 个附件')
+    expect(formatFieldDisplay({
+      field,
+      value: ['a1'],
+      attachmentSummaries: [{ id: 'a1', filename: 'Design Brief.pdf', mimeType: 'application/pdf', size: 1, url: '', thumbnailUrl: null, uploadedAt: '' }],
+      isZh: true,
+    })).toBe('Design Brief.pdf')
+  })
+})

--- a/apps/web/tests/multitable-mention-popover.spec.ts
+++ b/apps/web/tests/multitable-mention-popover.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, nextTick, type App as VueApp } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
 import MetaMentionPopover from '../src/multitable/components/MetaMentionPopover.vue'
 import type { CommentMentionSummaryItem, MetaField, MetaRecord } from '../src/multitable/types'
 
@@ -28,6 +29,7 @@ afterEach(() => {
   container?.remove()
   app = null
   container = null
+  useLocale().setLocale('en')
 })
 
 const ROWS: MetaRecord[] = [
@@ -47,15 +49,34 @@ const ITEMS: CommentMentionSummaryItem[] = [
 
 describe('MetaMentionPopover', () => {
   it('renders unread affordances and record labels', async () => {
+    useLocale().setLocale('en')
     mountPopover({ visible: true, items: ITEMS, rows: ROWS, fields: FIELDS, displayFieldId: 'title' })
     await nextTick()
 
+    expect(container!.querySelector('.meta-mention-popover__panel')?.getAttribute('aria-label')).toBe('Mentions')
+    expect(container!.querySelector('.meta-mention-popover__header strong')?.textContent).toBe('Mentions')
+    expect(container!.querySelector('.meta-mention-popover__close')?.getAttribute('aria-label')).toBe('Close mentions')
     const itemEls = container!.querySelectorAll('.meta-mention-popover__item')
     expect(itemEls).toHaveLength(2)
     expect(itemEls[0].classList.contains('meta-mention-popover__item--unread')).toBe(true)
-    expect(itemEls[0].querySelector('.meta-mention-popover__unread-dot')).not.toBeNull()
+    expect(itemEls[0].querySelector('.meta-mention-popover__unread-dot')?.getAttribute('aria-label')).toBe('Unread')
     expect(itemEls[0].querySelector('.meta-mention-popover__label')!.textContent).toBe('Alpha')
     expect(itemEls[1].querySelector('.meta-mention-popover__fields')!.textContent!.trim()).toBe('Title +1 more')
+  })
+
+  it('localizes mention popover chrome while preserving record and field names raw', async () => {
+    useLocale().setLocale('zh-CN')
+    mountPopover({ visible: true, items: ITEMS, rows: ROWS, fields: FIELDS, displayFieldId: 'title' })
+    await nextTick()
+
+    expect(container!.querySelector('.meta-mention-popover__panel')?.getAttribute('aria-label')).toBe('提及')
+    expect(container!.querySelector('.meta-mention-popover__header strong')?.textContent).toBe('提及')
+    expect(container!.querySelector('.meta-mention-popover__close')?.getAttribute('aria-label')).toBe('关闭提及')
+    const itemEls = container!.querySelectorAll('.meta-mention-popover__item')
+    expect(itemEls[0].querySelector('.meta-mention-popover__unread-dot')?.getAttribute('aria-label')).toBe('未读')
+    expect(itemEls[0].querySelector('.meta-mention-popover__label')!.textContent).toBe('Alpha')
+    expect(itemEls[1].querySelector('.meta-mention-popover__label')!.textContent).toBe('Beta')
+    expect(itemEls[1].querySelector('.meta-mention-popover__fields')!.textContent!.trim()).toBe('Title +1 个字段')
   })
 
   it('emits the selected row and field scope', async () => {

--- a/apps/web/tests/multitable-people-import.spec.ts
+++ b/apps/web/tests/multitable-people-import.spec.ts
@@ -44,6 +44,24 @@ describe('people import lookup priorities', () => {
     })).toThrow('People field only allows one person')
   })
 
+  it('localizes single-select people field lookup fallbacks when requested', () => {
+    const emailLookup = new Map<string, string | null>()
+    addPeopleLookupToken(emailLookup, 'amy@example.com', 'rec_amy')
+    addPeopleLookupToken(emailLookup, 'jamie@example.com', 'rec_jamie')
+
+    expect(() => resolvePeopleImportValue({
+      rawValue: 'amy@example.com, jamie@example.com',
+      currentField: {
+        id: 'fld_owner',
+        name: 'Owner',
+        type: 'link',
+        property: { refKind: 'user', limitSingleRecord: true },
+      },
+      lookups: { email: emailLookup },
+      isZh: true,
+    })).toThrow('人员字段只允许一个人员：amy@example.com, jamie@example.com')
+  })
+
   it('classifies email, name and alias fields consistently', () => {
     expect(inferPeopleLookupKind('Email')).toBe('email')
     expect(inferPeopleLookupKind('Display Name')).toBe('name')

--- a/docs/development/multitable-final-audit-small-residuals-design-20260522.md
+++ b/docs/development/multitable-final-audit-small-residuals-design-20260522.md
@@ -1,0 +1,166 @@
+# Multitable Final Audit Slice A — Small Residuals Design (2026-05-22)
+
+## 1. Scope
+
+This slice closes the smallest true-positive residuals found by
+`multitable-final-i18n-audit-20260522.md`.
+
+In scope:
+
+- `MetaMentionPopover.vue` mention popover chrome.
+- `MetaCellEditor.vue` link action button caller now that `linkActionLabel()` is locale-aware.
+- `validateAttachmentSelection()` frontend fallback messages.
+- `people-import.ts` single-person import fallback message.
+- `formatFieldDisplay()` boolean / link-count / attachment-count summaries.
+
+Out of scope:
+
+- Visual/alternative view render chrome (`MetaCalendarView`, `MetaGalleryView`, `MetaTimelineView`, `MetaGanttView`, `MetaHierarchyView`, `MetaKanbanView`, `MetaDashboardView`).
+- Formula docs and diagnostics.
+- `api/client.ts` static fallback architecture.
+- Backend contracts, migrations, attendance, K3, and non-multitable app chrome.
+
+## 2. Decisions
+
+### 2.1 Mention Popover
+
+Owner: `meta-comment-labels.ts`.
+
+Rationale: the popover is comment/mention chrome; it should not create a new
+module or depend on workbench labels.
+
+New labels/helpers:
+
+- `comment.mentions`
+- `comment.closeMentions`
+- `comment.unread`
+- `mentionFieldScope(primaryFieldName, extraCount, isZh)`
+
+Raw boundary:
+
+- Record labels stay raw.
+- Field names stay raw.
+- Counts stay numeric.
+
+### 2.2 Cell Editor Link Action
+
+`linkActionLabel(field, count, isZh = false)` is already localized. The remaining
+cell editor caller should pass `isZh.value`.
+
+The old unreachable fallback branch stays English and documented as unreachable:
+
+```ts
+if (props.field.type !== 'link') return 'Choose linked records...'
+```
+
+Reason: the surrounding `v-else-if="field.type === 'link'"` means this branch is
+not currently rendered. Creating a key for it would reintroduce the T3A2
+dead-key problem.
+
+### 2.3 Attachment Validation
+
+`validateAttachmentSelection(field, files, existingCount, isZh = false)` keeps
+English as default for compatibility and supports zh at call-sites that already
+have `useLocale()`.
+
+Raw boundary:
+
+- MIME types stay raw.
+- File names stay raw.
+- `maxFiles` stays numeric.
+
+### 2.4 People Import
+
+`resolvePeopleImportValue()` receives optional `isZh?: boolean` while preserving
+English default behavior.
+
+Only the single-person limit fallback is in scope. Ambiguous lookup guidance
+remains English for this slice because it is tied to import matching workflow
+copy and should be handled with import-modal/API fallback surfaces if needed.
+
+### 2.5 Field Display Summaries
+
+`formatFieldDisplay()` receives optional `isZh?: boolean`.
+
+Localized outputs:
+
+- boolean: `Yes` / `No` -> `是` / `否`
+- people summary: `1 person`, `N people` -> `1 个人员`, `N 个人员`
+- linked record summary: `1 linked record`, `N linked records` -> `1 条关联记录`, `N 条关联记录`
+- attachment summary: `1 attachment`, `N attachments` -> `1 个附件`, `N 个附件`
+
+Raw boundary:
+
+- Link summary display values stay raw.
+- Attachment filenames stay raw.
+- User-authored select/multi-select option values stay raw.
+- Dates/times use the existing browser locale behavior and are not changed here.
+
+## 3. Preflight Evidence
+
+Cells directory audit:
+
+```bash
+rg --files apps/web/src/multitable/components/cells
+rg -n "Choose linked records|validateAttachmentSelection|placeholder=\"[A-Za-z]|aria-label=\"[A-Za-z]" apps/web/src/multitable/components/cells
+```
+
+Result: only `MetaCellEditor.vue` has in-scope link/attachment residuals.
+There are no separate `MetaSelectCellEditor` / `MetaDateCellEditor` /
+`MetaLinkCellEditor` variants in this checkout.
+
+Primary grep:
+
+```bash
+rg -n "Choose linked records|linkActionLabel|validateAttachmentSelection|People field only allows|Yes' : 'No|Mentions|Unread|more" apps/web/src/multitable apps/web/tests
+```
+
+## 4. Implementation Order
+
+1. Extend `meta-comment-labels.ts` with mention popover labels/helper.
+2. Wire `MetaMentionPopover.vue` with `useLocale()` and new labels.
+3. Pass `isZh.value` from `MetaCellEditor.vue` to `linkActionLabel()` and `validateAttachmentSelection()`.
+4. Add optional `isZh` parameter to `validateAttachmentSelection()` and update record/form/cell callers.
+5. Add optional `isZh` parameter to `resolvePeopleImportValue()` and single-person message helper.
+6. Add optional `isZh` parameter to `formatFieldDisplay()` and update visible component call-sites that already render field values.
+7. Add/extend focused tests.
+8. Write verification MD and stop before push.
+
+## 5. Test Plan
+
+Focused tests:
+
+- `multitable-mention-popover.spec.ts`: en baseline, zh chrome, raw field/record labels.
+- `meta-cell-editor-i18n.spec.ts`: zh link action.
+- `multitable-people-import.spec.ts`: en default and zh single-person limit fallback.
+- field display unit spec: en default, zh boolean/link/attachment summaries, raw user display preservation.
+- field config unit spec: en default and zh attachment validation fallback, raw MIME value preservation.
+
+Validation:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/multitable-mention-popover.spec.ts \
+  tests/meta-cell-editor-i18n.spec.ts \
+  tests/multitable-people-import.spec.ts \
+  tests/multitable-field-display-i18n.spec.ts \
+  tests/multitable-field-config-i18n.spec.ts \
+  tests/multitable-number-format.spec.ts \
+  tests/multitable-system-fields.spec.ts \
+  tests/multitable-location-field.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web run type-check
+pnpm --filter @metasheet/web build
+git diff --check origin/main..HEAD
+```
+
+## 6. Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Accidentally localizing user data | Tests keep field names, record labels, option values, raw IDs, MIME types, and filenames unchanged |
+| Broad call-site churn from `formatFieldDisplay()` | Keep `isZh` optional with English default; only pass it from visible multitable components |
+| Dead-key regression in cell link fallback | Do not add a key for the unreachable non-link branch |
+| People import ambiguity guidance remains English | Explicitly deferred; only single-person limit fallback is in this small slice |
+| Visual view residuals remain | Tracked in final audit Slice B, not mixed into Slice A |

--- a/docs/development/multitable-final-audit-small-residuals-verification-20260522.md
+++ b/docs/development/multitable-final-audit-small-residuals-verification-20260522.md
@@ -1,0 +1,141 @@
+# Multitable Final Audit Slice A Verification — Small Residuals
+
+Date: 2026-05-22
+Branch: `frontend/multitable-final-i18n-audit-20260522`
+Base: `origin/main@a235a5c1e`
+
+## DoD
+
+- Final audit inventory exists: `docs/development/multitable-final-i18n-audit-20260522.md`.
+- Slice A design exists: `docs/development/multitable-final-audit-small-residuals-design-20260522.md`.
+- Five scoped residual groups are wired:
+  - `MetaMentionPopover.vue` static chrome and extra-field suffix.
+  - `MetaCellEditor.vue` reachable link action label.
+  - `validateAttachmentSelection()` frontend fallback errors.
+  - `resolvePeopleImportValue()` single-person limit fallback.
+  - `formatFieldDisplay()` boolean/link/attachment summary fallbacks.
+- Raw data remains raw: record labels, field names, file names, MIME types, person names, record IDs, and existing backend/composable errors are not translated.
+- Deferred surfaces remain explicitly out of scope: visual/alt-view chrome, formula docs, API client fallbacks, backend/contract/migration/attendance/K3.
+
+## Files Changed
+
+Implementation:
+
+- `apps/web/src/multitable/components/MetaMentionPopover.vue`
+- `apps/web/src/multitable/components/cells/MetaCellEditor.vue`
+- `apps/web/src/multitable/components/cells/MetaCellRenderer.vue`
+- `apps/web/src/multitable/components/MetaFormView.vue`
+- `apps/web/src/multitable/components/MetaRecordDrawer.vue`
+- `apps/web/src/multitable/components/MetaCalendarView.vue`
+- `apps/web/src/multitable/components/MetaGalleryView.vue`
+- `apps/web/src/multitable/components/MetaTimelineView.vue`
+- `apps/web/src/multitable/components/MetaKanbanView.vue`
+- `apps/web/src/multitable/components/MetaHierarchyView.vue`
+- `apps/web/src/multitable/components/MetaGanttView.vue`
+- `apps/web/src/multitable/views/MultitableWorkbench.vue`
+- `apps/web/src/multitable/utils/meta-comment-labels.ts`
+- `apps/web/src/multitable/utils/field-display.ts`
+- `apps/web/src/multitable/utils/field-config.ts`
+- `apps/web/src/multitable/utils/people-import.ts`
+
+Tests:
+
+- `apps/web/tests/meta-comment-labels.spec.ts`
+- `apps/web/tests/multitable-mention-popover.spec.ts`
+- `apps/web/tests/meta-cell-editor-i18n.spec.ts`
+- `apps/web/tests/multitable-people-import.spec.ts`
+- `apps/web/tests/multitable-field-display-i18n.spec.ts`
+- `apps/web/tests/multitable-field-config-i18n.spec.ts`
+
+Docs:
+
+- `docs/development/multitable-final-i18n-audit-20260522.md`
+- `docs/development/multitable-final-audit-small-residuals-design-20260522.md`
+- `docs/development/multitable-final-audit-small-residuals-verification-20260522.md`
+
+## Test Evidence
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/meta-comment-labels.spec.ts \
+  tests/multitable-mention-popover.spec.ts \
+  tests/meta-cell-editor-i18n.spec.ts \
+  tests/multitable-people-import.spec.ts \
+  tests/multitable-field-display-i18n.spec.ts \
+  tests/multitable-field-config-i18n.spec.ts \
+  tests/multitable-location-field.spec.ts \
+  tests/multitable-number-format.spec.ts \
+  tests/multitable-system-fields.spec.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+Test Files  9 passed (9)
+Tests       49 passed (49)
+```
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web run type-check
+```
+
+Result:
+
+```text
+> @metasheet/web@2.0.0-alpha.1 type-check
+> vue-tsc -b
+```
+
+Exit code: 0.
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result:
+
+```text
+✓ 2420 modules transformed.
+✓ built in 6.75s
+```
+
+Build warnings:
+
+- Existing Vite warning: `WorkflowDesigner.vue` is both dynamically and statically imported.
+- Existing Vite chunk-size warning for large bundles.
+
+## Raw Boundary Checks
+
+- `MetaMentionPopover`: record labels `Alpha` / `Beta` and field name `Title` remain raw in zh-CN render; only `Mentions`, `Close mentions`, `Unread`, and `+1 more` chrome localize.
+- `MetaCellEditor`: link action uses `formatLinkActionLabel(field, count, isZh.value)`; field metadata remains raw.
+- `validateAttachmentSelection`: MIME value such as `application/pdf` is interpolated raw.
+- `resolvePeopleImportValue`: raw import value is interpolated raw after the localized prefix.
+- `formatFieldDisplay`: linked record display names and attachment filenames remain raw when summaries exist.
+- Existing backend/composable errors remain raw because Slice A only localizes frontend static fallbacks.
+
+## Preflight / Deferred Confirmation
+
+Preflight confirmed `apps/web/src/multitable/components/cells/` contains only:
+
+- `MetaCellEditor.vue`
+- `MetaCellRenderer.vue`
+
+There are no separate `MetaSelectCellEditor.vue`, `MetaDateCellEditor.vue`, or `MetaLinkCellEditor.vue` variants to wire in Slice A.
+
+Remaining visible residuals are intentionally deferred:
+
+- Visual/alt-view chrome in Calendar/Gallery/Timeline/Gantt/Hierarchy/Kanban/Dashboard/Chart.
+- Formula help/example strings.
+- API client fallback messages.
+- `formatLinkActionLabel` unreachable fallback branch in `MetaCellEditor.vue` remains English by design until a future refactor makes it reachable.
+
+## Worktree Notes
+
+This clean worktree initially had no `node_modules`, so `vitest` was not resolvable. To avoid `pnpm install` tracked symlink noise, `apps/web/node_modules` was linked to the main worktree dependency tree. The path is ignored and not part of the PR diff.

--- a/docs/development/multitable-final-i18n-audit-20260522.md
+++ b/docs/development/multitable-final-i18n-audit-20260522.md
@@ -1,0 +1,336 @@
+# Multitable Final I18n Audit (2026-05-22)
+
+## 1. Purpose
+
+This document is the post-T3D final audit plan and scout result for
+`apps/web/src/multitable/**`.
+
+Baseline:
+
+- Branch: `frontend/multitable-final-i18n-audit-20260522`
+- Base: `origin/main@a235a5c1e` (`chore(integration): add bridge source refresh staging smoke`)
+- T3D-4 is already on `origin/main` through PR `#1750`
+- Scope: frontend multitable i18n only
+- Out of scope: backend contracts, migrations, attendance, K3 integration, non-multitable app chrome
+
+This pass does not assume that every English token is a defect. It classifies
+each finding into one of three buckets:
+
+| Bucket | Meaning | Action |
+| --- | --- | --- |
+| True-positive chrome | User-visible UI or fallback text that should follow locale | Fix in follow-up slices |
+| Raw-data / technical literal | User data, IDs, enum values, examples, protocol tokens, backend messages | Keep raw; add tests only if risky |
+| Deferred / non-goal | Larger feature domain or intentionally English technical reference | Keep documented; revisit only by explicit scope |
+
+## 2. Audit Commands
+
+Commands run from the clean audit worktree:
+
+```bash
+git fetch origin
+git log --oneline -1 origin/main
+find apps/web/src/multitable -maxdepth 3 -type f | wc -l
+rg --files apps/web/src/multitable | rg 'labels|Label|i18n|locale'
+rg -n --glob '*.vue' ">\\s*[A-Z][A-Za-z0-9 ,.'’:/()&+\\-]*\\s*<" apps/web/src/multitable
+rg -n --glob '*.vue' "(placeholder|aria-label|title)=\\\"[^\\\"]*[A-Za-z][^\\\"]*\\\"" apps/web/src/multitable
+rg -n "validateAttachmentSelection|formatLinkActionLabel|linkActionLabel|Choose linked records|Open comments|Mentions|Unread|Timeline view|Gantt view|Hierarchy view|Loading\\.\\.\\.|No records|Create first record|Select a date field|Formula|Unexpected closing|People field only allows|This field only allows" apps/web/src/multitable
+rg -n "Validation failed|Insufficient permissions|Please sign in|Please check|This field only allows|File type not allowed|People field only allows|Import cancelled|Yes' : 'No|Unexpected closing|Formula expression is empty|not balanced|cannot end" apps/web/src/multitable/{api,utils,import,composables} apps/web/src/multitable/components
+```
+
+Scout size:
+
+- `apps/web/src/multitable`: 103 source files at depth <= 3
+- Label/helper modules found: 15
+
+Current label/helper modules:
+
+```text
+meta-automation-labels.ts
+meta-core-labels.ts
+meta-manager-labels.ts
+meta-record-labels.ts
+meta-comment-labels.ts
+meta-link-picker-labels.ts
+meta-import-labels.ts
+meta-attachment-labels.ts
+meta-bulk-edit-labels.ts
+meta-api-token-labels.ts
+meta-permission-labels.ts
+meta-form-share-labels.ts
+meta-base-picker-labels.ts
+workbench-labels.ts
+category-labels.ts
+```
+
+## 3. True-Positive Findings
+
+### 3.1 High: Visual / Alternative View Chrome
+
+The largest remaining user-visible English surface is the visual view family.
+These components already import `useLocale()` in several places, but their own
+view chrome is still mostly hard-coded English.
+
+| File | Representative findings | Notes |
+| --- | --- | --- |
+| `MetaCalendarView.vue` | `Select a date field to use for the calendar:`, `Today`, `View`, `Month`, `Week`, `Day`, `Change`, `No records on this day`, `Loading...`, `Open comments for ...`, `No attachments` | Also owns effective-calendar tooltip/chip display from Step 4 |
+| `MetaGalleryView.vue` | `Title`, `Auto`, `Cover`, `None`, `Columns`, `Card size`, `Small/Medium/Large`, `Card fields`, `+ Add record`, `No records to display`, `Create first record`, `Prev/Next`, `Loading...`, `Open comments for ...`, `No attachments` | View-manager labels already include many config labels but component template is not wired |
+| `MetaTimelineView.vue` | `Timeline view`, `Start date`, `End date`, `Label field`, `Zoom`, `Day/Week/Month`, `Axis spacing...`, `Select start and end date fields...`, `Record`, `Unscheduled`, `No records found`, `Create first record`, `Open comments for ...`, `No attachments` | Also includes scheduling/drag wording |
+| `MetaGanttView.vue` | `Gantt view`, `Loading...`, `Start`, `End`, `Title`, `Progress`, `Group`, `Dependencies`, `Zoom`, `+ Add task`, `Select start and end date fields to display Gantt tasks.`, `Task`, `No records found.` | Gantt-specific labels should likely be a view label group, not manager-only labels |
+| `MetaHierarchyView.vue` | `Hierarchy view`, `Parent field`, `Title field`, `Expand depth`, `Orphans`, `No parent link field configured.`, `No records match this hierarchy view.`, `Loading...`, `Open comments for ...` | Some config labels exist in `meta-manager-labels.ts`; render chrome still unwired |
+| `MetaKanbanView.vue` | `Select a select-type field to group by:`, `No select-type fields found...`, `+ Add record`, `Group`, `Grouped by:`, `Card fields`, `Clear`, `Uncategorized`, `Drop a card here...`, `No cards in this column`, `+ Add`, `Loading...`, `Open comments for ...` | Kanban has the densest true-positive template strings after timeline/gallery |
+| `MetaDashboardView.vue` | `Rename`, `+ Add Panel`, `+ New Dashboard`, `Loading dashboard...`, `No dashboards yet...`, `Small/Medium/Large`, `Loading chart...`, `Add Chart Panel`, `No charts available...` | Dashboard surface was not covered by earlier T2/T3 slices |
+| `MetaChartRenderer.vue` | table headers `Label` / `Value` | Small but visible; chart labels/data remain raw |
+
+Recommended slice: `final-audit-visual-views`.
+
+Implementation notes:
+
+- Prefer a new `meta-view-render-labels.ts` or extend `meta-manager-labels.ts`
+  only if the label is truly shared with manager config.
+- Reuse `commentLabel('comment.title', isZh)` for action-chip labels, but add
+  dedicated helpers for `Open comments for ${record}` and
+  `Open comments for ${field} on ${record}`.
+- Preserve record titles, field names, option values, chart labels, attachment
+  filenames, and date strings as raw user data.
+
+### 3.2 Medium: Mention Popover
+
+`MetaMentionPopover.vue` remains fully English:
+
+| Line | String |
+| --- | --- |
+| 3 | `aria-label="Mentions"` |
+| 5 | `Mentions` |
+| 6 | `aria-label="Close mentions"` |
+| 16 | `aria-label="Unread"` |
+| 72 | `${primary} +${n} more` |
+
+Recommended slice: include with `final-audit-small-residuals`.
+
+Suggested owner: `meta-comment-labels.ts`, because it is comment/mention chrome.
+
+### 3.3 Medium: Link Cell Editor Button
+
+`linkActionLabel(field, count, isZh = false)` is localized, but one remaining
+caller still uses the English default:
+
+| File | Line | Finding |
+| --- | --- | --- |
+| `components/cells/MetaCellEditor.vue` | 428 | `return formatLinkActionLabel(props.field, count)` |
+
+The earlier T3A2 comment at lines 425-426 still references a deferred
+`formatLinkActionLabel` path. This is now stale after T3B1/T3B3 localized the
+helper. The cell editor should pass `isZh.value` and add a regression test in
+`meta-cell-editor-i18n.spec.ts`.
+
+Recommended slice: include with `final-audit-small-residuals`.
+
+### 3.4 Medium: Attachment / People / Display Utility Fallbacks
+
+Utility-level frontend fallback messages still return English:
+
+| File | Lines | Finding |
+| --- | --- | --- |
+| `utils/field-config.ts` | 296, 302 | `This field only allows one attachment...`, `File type not allowed: ...` from `validateAttachmentSelection()` |
+| `utils/people-import.ts` | 74, 87 | `People field only allows one person: ...` |
+| `utils/field-display.ts` | 116 | boolean display `Yes` / `No` |
+
+These strings are user-visible through record drawer/form/cell/editor/import
+flows, not backend raw messages.
+
+Recommended slice: include with `final-audit-small-residuals` if kept narrow;
+otherwise make a small `final-audit-utils` PR.
+
+Design rule:
+
+- Do not translate raw `rawValue`, MIME types, filenames, user IDs, or field IDs.
+- Add optional `isZh = false` arguments to helpers rather than forcing all
+  existing callers to change at once.
+
+### 3.5 Medium: API Client Static Fallbacks
+
+`apps/web/src/multitable/api/client.ts` still emits English fallback messages:
+
+| Lines | String |
+| --- | --- |
+| 174, 186 | `Validation failed` |
+| 198 | `Insufficient permissions` |
+| 200 | `Please sign in to continue.` |
+| 202 | `Please check the submitted data and try again.` |
+| 109 | `API ${status}` |
+
+These are frontend-generated fallback strings when backend payloads do not
+provide messages. They are likely user-visible because many components surface
+`e.message` raw first.
+
+Recommended slice: `final-audit-api-fallbacks`.
+
+Risk:
+
+- This client is not a Vue component and currently does not consume
+  `useLocale()`. Avoid a broad composable dependency if possible.
+- Options: pass a formatter/context at call sites, or centralize a multitable
+  API error label helper with a default English fallback.
+
+### 3.6 Medium: Formula Reference Docs and Diagnostics
+
+`utils/formula-docs.ts` remains intentionally documented as raw in
+`meta-manager-labels.ts`, but final audit confirms it is user-visible in the
+field manager formula reference panel.
+
+Findings:
+
+- Category labels/descriptions: `Aggregate`, `Math`, `Operators`, etc.
+- Function descriptions: `Adds numeric values together.`, `Returns the arithmetic mean...`, etc.
+- Formula diagnostics: `Unexpected closing parenthesis.`, `Formula expression is empty.`, `Unknown field reference {...}.`, etc.
+
+Recommended slice: `final-audit-formula-docs`.
+
+Design rule:
+
+- Function names, signatures, examples, insert text, formula tokens, and field
+  refs stay raw.
+- Category labels, descriptions, and diagnostics should be localized.
+- This slice is larger than the small residuals and should not be mixed with
+  visual view chrome.
+
+### 3.7 Low: Dashboard / Chart Renderer If Not Folded Into Visual Views
+
+If `MetaDashboardView.vue` is not included in the visual-view slice, it should
+be a separate low-risk PR with `MetaChartRenderer.vue`:
+
+- Dashboard chrome: `Rename`, `+ Add Panel`, `+ New Dashboard`, `Loading dashboard...`
+- Chart table headers: `Label`, `Value`
+
+Chart data labels and `displayConfig.title/prefix/suffix` stay raw/user-owned.
+
+## 4. Raw / Keep As-Is Findings
+
+These were seen by grep but should not be localized by default:
+
+| Pattern | Reason |
+| --- | --- |
+| Field names, view names, record titles, chart labels, option values | User-authored data |
+| IDs such as `recordId`, `sheetId`, `actorId`, `fld_target`, `fld_xxx` | Technical identifiers |
+| URLs/emails/MIME placeholders such as `https://example.com`, `name@example.com`, `image/png,application/pdf` | Format examples, not chrome |
+| HTTP methods `GET`, `POST`, `PUT` | Protocol values |
+| Formula function names/signatures/examples/insert text | Formula language tokens |
+| Currency codes and symbols (`CNY`, `USD`, `HK$`) | ISO/code data |
+| Timezone `UTC` | Technical value |
+| `data-*` enum values and CSS suffixes | Selector/persistence raw values |
+| Backend/API `e.message`, `payload.message`, field error values | Backend/user-visible raw message source |
+| Template tokens `{{recordId}}`, `{{record.xxx}}` | Template syntax |
+| Attachment filenames and MIME types | User/file metadata |
+
+## 5. Deferred / Review-Later Findings
+
+| Surface | Reason |
+| --- | --- |
+| Formula docs if product wants English formula reference | Current code comment explicitly listed formula docs as raw in T3C; final audit recommends revisiting, but this is a product decision |
+| API client fallback strategy | Needs a deliberate architecture choice because it is outside component scope |
+| Full alt-view visual polish | Many visual views have UI/UX debt beyond string localization; keep i18n fix narrow |
+| Tests with English expectations | Only update tests that assert changed user-facing copy; do not bulk-localize test fixture names |
+
+## 6. Recommended Follow-Up Slices
+
+### Slice A: `final-audit-small-residuals`
+
+Scope:
+
+- `MetaMentionPopover.vue`
+- `MetaCellEditor.vue` link action caller
+- `validateAttachmentSelection()`
+- `people-import.ts`
+- `field-display.ts` boolean display
+
+Why first:
+
+- Smallest real closure.
+- Directly addresses earlier deferred `validateAttachmentSelection` and
+  `formatLinkActionLabel` markers.
+- Low UI risk and focused tests exist.
+
+Expected tests:
+
+- `meta-cell-editor-i18n.spec.ts`
+- `multitable-mention-popover.spec.ts` or new i18n spec
+- focused unit tests for `field-config`, `people-import`, `field-display`
+
+### Slice B: `final-audit-visual-views`
+
+Scope:
+
+- `MetaCalendarView.vue`
+- `MetaGalleryView.vue`
+- `MetaTimelineView.vue`
+- `MetaGanttView.vue`
+- `MetaHierarchyView.vue`
+- `MetaKanbanView.vue`
+- optionally `MetaDashboardView.vue` / `MetaChartRenderer.vue`
+
+Why second:
+
+- Biggest remaining visible EN surface.
+- Needs a coherent label module strategy and render-spec coverage.
+
+Expected tests:
+
+- Extend existing `multitable-*-view.spec.ts` files.
+- Add zh-CN render assertions for each view.
+- Add a11y sentinel counts for `[aria-label]`, `[title]`, `[placeholder]`.
+
+### Slice C: `final-audit-formula-docs`
+
+Scope:
+
+- `utils/formula-docs.ts`
+- `MetaFieldManager.vue` formula reference rendering
+
+Why third:
+
+- Larger data table and diagnostic path.
+- Needs careful raw boundary for formula syntax, function names, examples, and field refs.
+
+Expected tests:
+
+- formula docs unit tests for category/diagnostic localization
+- FieldManager render spec for zh category/description/diagnostic display
+
+### Slice D: `final-audit-api-fallbacks`
+
+Scope:
+
+- `api/client.ts`
+- any call-site needing locale-aware fallback formatting
+
+Why last:
+
+- Requires architectural decision on how non-component API code accesses locale.
+- Many existing flows intentionally preserve backend `e.message` raw first.
+
+## 7. Acceptance Gate for Each Fix Slice
+
+Each follow-up PR must include:
+
+- Narrow design note or verification MD section with true-positive list.
+- No backend/contract/migration/attendance/K3 changes.
+- No `node_modules` or unrelated worktree noise.
+- `git diff --check origin/main..HEAD` clean.
+- Focused Vitest specs for changed surfaces.
+- `pnpm --filter @metasheet/web run type-check`.
+- `pnpm --filter @metasheet/web build` unless the slice is docs-only.
+- CI `test (18.x)` and `test (20.x)` green before merge.
+
+## 8. Current Recommendation
+
+Proceed with Slice A first: `final-audit-small-residuals`.
+
+This gives the highest closure per line changed and explicitly closes the two
+known early deferred markers:
+
+- `validateAttachmentSelection()`
+- `MetaCellEditor` / `formatLinkActionLabel` caller path
+
+After Slice A, decide whether to take visual views as one PR or split
+Calendar/Gallery/Timeline/Gantt/Kanban/Hierarchy/Dashboard into two smaller PRs
+based on implementation size.


### PR DESCRIPTION
## Summary

First slice of the post-T3 final multitable i18n audit. This closes small residual chrome/fallback strings and commits the audit plan for the remaining follow-up slices.

- Add final audit planning doc covering Slice A small residuals, Slice B visual views, Slice C formula docs, and Slice D API fallbacks.
- Extend `meta-comment-labels.ts` with mention popover chrome and `mentionFieldScope()`.
- Pass locale into existing helpers for link action, attachment validation, people import single-person limits, and field display summaries.
- Keep the unreachable `Choose linked records...` branch in `MetaCellEditor` English by design to avoid a dead key.
- Touch 8 visual view components only for `isZh.value` plumbing; no visual-view chrome is changed in this slice.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/meta-comment-labels.spec.ts tests/multitable-mention-popover.spec.ts tests/meta-cell-editor-i18n.spec.ts tests/multitable-people-import.spec.ts tests/multitable-field-display-i18n.spec.ts tests/multitable-field-config-i18n.spec.ts tests/multitable-location-field.spec.ts tests/multitable-number-format.spec.ts tests/multitable-system-fields.spec.ts --watch=false`
  - `Test Files 9 passed (9)`
  - `Tests 49 passed (49)`
- `pnpm --filter @metasheet/web run type-check`
- `pnpm --filter @metasheet/web build`
- `git diff --check origin/main..HEAD`

Docs:

- `docs/development/multitable-final-i18n-audit-20260522.md`
- `docs/development/multitable-final-audit-small-residuals-design-20260522.md`
- `docs/development/multitable-final-audit-small-residuals-verification-20260522.md`

## Next

Slice B: visual/alternative view render chrome (`MetaCalendarView`, `MetaGalleryView`, `MetaTimelineView`, `MetaGanttView`, `MetaHierarchyView`, `MetaKanbanView`, `MetaDashboardView`, `MetaChartRenderer`).
