### PR TITLE
feat(attendance): add advanced scheduling read-only workbench

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -4349,6 +4349,98 @@
             </div>
 
             <div
+              v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.advancedSchedulingWorkbench)"
+              class="attendance__admin-section"
+              v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.advancedSchedulingWorkbench)"
+              data-attendance-advanced-scheduling-workbench
+            >
+              <div class="attendance__admin-section-header">
+                <div>
+                  <h4>{{ tr('Advanced scheduling workbench', '高级排班工作台') }}</h4>
+                  <small class="attendance__field-hint">
+                    {{ tr('Read-only scope, coverage, and conflict signals across groups, shifts, rotations, and effective calendars.', '只读汇总排班组、班次、轮班、生效日历的覆盖与冲突信号。') }}
+                  </small>
+                </div>
+                <button class="attendance__btn" :disabled="advancedSchedulingWorkbenchLoading" @click="loadAdvancedSchedulingWorkbench">
+                  {{ advancedSchedulingWorkbenchLoading ? tr('Loading...', '加载中...') : tr('Reload workbench', '重载工作台') }}
+                </button>
+              </div>
+
+              <div class="attendance__admin-meta">
+                <span class="attendance__status-chip" data-attendance-advanced-scheduling-readonly>
+                  {{ advancedSchedulingWorkbenchReadOnlyLabel }}
+                </span>
+                <span class="attendance__status-chip">
+                  {{ reportRangeLabel }}
+                </span>
+              </div>
+
+              <div class="attendance__summary attendance__summary--workbench" data-attendance-advanced-scheduling-metrics>
+                <div
+                  v-for="item in advancedSchedulingWorkbenchMetricItems"
+                  :key="item.key"
+                  class="attendance__summary-item"
+                  :data-attendance-advanced-scheduling-metric="item.key"
+                >
+                  <span>{{ item.label }}</span>
+                  <strong>{{ item.value }}</strong>
+                </div>
+              </div>
+
+              <div
+                v-if="advancedSchedulingWorkbenchDiagnostics.length"
+                class="attendance__schedule-conflict-diagnostics"
+                data-attendance-advanced-scheduling-diagnostics
+                role="alert"
+              >
+                <strong>{{ tr('Planning signals', '排班信号') }}</strong>
+                <ul>
+                  <li
+                    v-for="diagnostic in advancedSchedulingWorkbenchDiagnostics"
+                    :key="diagnostic.code"
+                    :data-attendance-advanced-scheduling-diagnostic="diagnostic.code"
+                  >
+                    {{ diagnostic.message }} · {{ diagnostic.count }}
+                  </li>
+                </ul>
+              </div>
+              <div v-else class="attendance__empty" data-attendance-advanced-scheduling-no-diagnostics>
+                {{ tr('No planning signals in the current range.', '当前区间暂无排班信号。') }}
+              </div>
+
+              <div v-if="advancedSchedulingWorkbenchGroups.length === 0" class="attendance__empty">
+                {{ tr('No active schedule groups yet.', '暂无启用的排班组。') }}
+              </div>
+              <div v-else class="attendance__table-wrapper">
+                <table class="attendance__table" data-attendance-advanced-scheduling-groups>
+                  <thead>
+                    <tr>
+                      <th>{{ tr('Schedule group', '排班组') }}</th>
+                      <th>{{ tr('Members', '成员') }}</th>
+                      <th>{{ tr('Assigned users', '已分配成员') }}</th>
+                      <th>{{ tr('Shift assignments', '班次分配') }}</th>
+                      <th>{{ tr('Rotation assignments', '轮班分配') }}</th>
+                      <th>{{ tr('Source', '来源') }}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="group in advancedSchedulingWorkbenchGroups" :key="group.id">
+                      <td>
+                        <strong>{{ group.name }}</strong>
+                        <div class="attendance__field-hint">{{ group.code || group.id }}</div>
+                      </td>
+                      <td>{{ group.memberCount }}</td>
+                      <td>{{ group.assignedUserCount }}</td>
+                      <td>{{ group.shiftAssignmentCount }}</td>
+                      <td>{{ group.rotationAssignmentCount }}</td>
+                      <td>{{ group.source || 'manual' }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <div
               v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.rotationRules)"
               class="attendance__admin-section"
               v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.rotationRules)"
@@ -5820,6 +5912,58 @@ interface AttendanceRotationAssignmentItem {
   rotation: AttendanceRotationRule
 }
 
+interface AttendanceAdvancedSchedulingDiagnostic {
+  code: string
+  severity: 'info' | 'warning' | 'error'
+  message: string
+  count: number
+  userIds?: string[]
+  scheduleGroupIds?: string[]
+}
+
+interface AttendanceAdvancedSchedulingGroupItem {
+  id: string
+  name: string
+  code?: string
+  source?: string
+  memberCount: number
+  assignedUserCount: number
+  shiftAssignmentCount: number
+  rotationAssignmentCount: number
+  isActive?: boolean
+}
+
+interface AttendanceAdvancedSchedulingWorkbench {
+  range?: {
+    from: string | null
+    to: string | null
+  }
+  summary: {
+    scheduleGroups: number
+    scheduleGroupMembers: number
+    schedulerScopes: number
+    shifts: number
+    rotationRules: number
+    shiftAssignments: number
+    rotationAssignments: number
+    assignedUsers: number
+    diagnostics: number
+    groupsWithoutMembers: number
+    assignmentUsersWithoutScheduleGroup: number
+    usersWithMultipleScheduleGroups: number
+    usersWithBothAssignmentKinds: number
+  }
+  scheduleGroups: {
+    items: AttendanceAdvancedSchedulingGroupItem[]
+    total: number
+  }
+  diagnostics: AttendanceAdvancedSchedulingDiagnostic[]
+  metadata?: {
+    readOnly?: boolean
+    source?: string
+  }
+}
+
 // PR2 adds `sourceClass` carrying `calendar-source--{national|manual|org|group|role|user}`
 // (or undefined for plain rule/shift days). The shared palette in
 // apps/web/src/styles/calendar-source-palette.css resolves it to a 4px
@@ -6192,6 +6336,32 @@ const activeReportRangePreset = computed<AttendanceReportRangePreset | ''>(() =>
   }
   return ''
 })
+
+const advancedSchedulingWorkbenchMetricItems = computed(() => {
+  const summary = advancedSchedulingWorkbench.value?.summary
+  return [
+    { key: 'schedule-groups', label: tr('Schedule groups', '排班组'), value: summary?.scheduleGroups ?? 0 },
+    { key: 'members', label: tr('Effective members', '生效成员'), value: summary?.scheduleGroupMembers ?? 0 },
+    { key: 'shifts', label: tr('Shifts', '班次'), value: summary?.shifts ?? 0 },
+    { key: 'rotation-rules', label: tr('Rotation rules', '轮班规则'), value: summary?.rotationRules ?? 0 },
+    { key: 'assignments', label: tr('Assignments', '分配'), value: (summary?.shiftAssignments ?? 0) + (summary?.rotationAssignments ?? 0) },
+    { key: 'scheduler-scopes', label: tr('Scheduler scopes', '调度权限'), value: summary?.schedulerScopes ?? 0 },
+  ]
+})
+
+const advancedSchedulingWorkbenchGroups = computed(() =>
+  advancedSchedulingWorkbench.value?.scheduleGroups?.items ?? []
+)
+
+const advancedSchedulingWorkbenchDiagnostics = computed(() =>
+  advancedSchedulingWorkbench.value?.diagnostics ?? []
+)
+
+const advancedSchedulingWorkbenchReadOnlyLabel = computed(() =>
+  advancedSchedulingWorkbench.value?.metadata?.readOnly
+    ? tr('Read-only snapshot', '只读快照')
+    : tr('Not loaded', '未加载')
+)
 
 const reportRangeLabel = computed(() => {
   if (!fromDate.value || !toDate.value) return tr('Range not set', '区间未设置')
@@ -6954,6 +7124,7 @@ const overtimeRules = ref<AttendanceOvertimeRule[]>([])
 const approvalFlows = ref<AttendanceApprovalFlow[]>([])
 const rotationRules = ref<AttendanceRotationRule[]>([])
 const rotationAssignments = ref<AttendanceRotationAssignmentItem[]>([])
+const advancedSchedulingWorkbench = ref<AttendanceAdvancedSchedulingWorkbench | null>(null)
 const ruleSets = ref<AttendanceRuleSet[]>([])
 const ruleTemplateSystemText = ref('[]')
 const ruleTemplateLibraryText = ref('[]')
@@ -7018,6 +7189,7 @@ const importAsyncJobTelemetryText = computed(() => {
 
 const shiftEditingId = ref<string | null>(null)
 const assignmentEditingId = ref<string | null>(null)
+const advancedSchedulingWorkbenchLoading = ref(false)
 const holidayEditingId = ref<string | null>(null)
 const leaveTypeEditingId = ref<string | null>(null)
 const overtimeRuleEditingId = ref<string | null>(null)
@@ -13626,6 +13798,32 @@ async function deleteApprovalFlow(id: string) {
   }
 }
 
+async function loadAdvancedSchedulingWorkbench() {
+  advancedSchedulingWorkbenchLoading.value = true
+  try {
+    const query = buildQuery({
+      orgId: normalizedOrgId(),
+      from: fromDate.value,
+      to: toDate.value,
+    })
+    const response = await apiFetch(`/api/attendance/advanced-scheduling/workbench?${query.toString()}`)
+    if (response.status === 403) {
+      adminForbidden.value = true
+      return
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to load advanced scheduling workbench', '加载高级排班工作台失败')))
+    }
+    adminForbidden.value = false
+    advancedSchedulingWorkbench.value = data.data ?? null
+  } catch (error: any) {
+    setStatus(readErrorMessage(error, tr('Failed to load advanced scheduling workbench', '加载高级排班工作台失败')), 'error')
+  } finally {
+    advancedSchedulingWorkbenchLoading.value = false
+  }
+}
+
 function resetRotationRuleForm() {
   rotationRuleEditingId.value = null
   rotationRuleForm.name = ''
@@ -15074,6 +15272,7 @@ async function loadAdminData() {
       loadLeaveTypes(),
       loadOvertimeRules(),
       loadApprovalFlows(),
+      loadAdvancedSchedulingWorkbench(),
       loadRotationRules(),
       loadShifts(),
       loadAssignments(),

--- a/apps/web/src/views/attendance/useAttendanceAdminRail.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminRail.ts
@@ -28,6 +28,7 @@ export const ATTENDANCE_ADMIN_SECTION_IDS = {
   leaveTypes: 'attendance-admin-leave-types',
   overtimeRules: 'attendance-admin-overtime-rules',
   approvalFlows: 'attendance-admin-approval-flows',
+  advancedSchedulingWorkbench: 'attendance-admin-advanced-scheduling-workbench',
   rotationRules: 'attendance-admin-rotation-rules',
   rotationAssignments: 'attendance-admin-rotation-assignments',
   shifts: 'attendance-admin-shifts',
@@ -174,6 +175,7 @@ export function useAttendanceAdminRail({
     { id: ATTENDANCE_ADMIN_SECTION_IDS.leaveTypes, label: tr('Leave Types', '请假类型') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.overtimeRules, label: tr('Overtime Rules', '加班规则') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.approvalFlows, label: tr('Approval Flows', '审批流') },
+    { id: ATTENDANCE_ADMIN_SECTION_IDS.advancedSchedulingWorkbench, label: tr('Advanced scheduling', '高级排班') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.rotationRules, label: tr('Rotation Rules', '轮班规则') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.rotationAssignments, label: tr('Rotation Assignments', '轮班分配') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.shifts, label: tr('Shifts', '班次') },
@@ -196,6 +198,7 @@ export function useAttendanceAdminRail({
       id: 'scheduling',
       label: tr('Scheduling', '排班执行'),
       itemIds: [
+        ATTENDANCE_ADMIN_SECTION_IDS.advancedSchedulingWorkbench,
         ATTENDANCE_ADMIN_SECTION_IDS.rotationRules,
         ATTENDANCE_ADMIN_SECTION_IDS.rotationAssignments,
         ATTENDANCE_ADMIN_SECTION_IDS.shifts,

--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -124,11 +124,12 @@ describe('Attendance admin anchor navigation', () => {
     )
 
     expect(groupLabels).toEqual(['Workspace', 'Scheduling', 'Organization', 'Policies', 'Data & Payroll'])
-    expect(labels).toHaveLength(23)
+    expect(labels).toHaveLength(24)
     expect(labels).toEqual(
       expect.arrayContaining([
         'Settings',
         'User Access',
+        'Advanced scheduling',
         'Import',
         'Import batches',
         'Report fields',
@@ -280,14 +281,15 @@ describe('Attendance admin anchor navigation', () => {
 
     const jumpSelect = container!.querySelector<HTMLSelectElement>('[data-admin-quick-jump="true"]')
     expect(jumpSelect).toBeTruthy()
-    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(23)
+    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(24)
 
-    jumpSelect!.value = 'attendance-admin-shifts'
+    jumpSelect!.value = 'attendance-admin-advanced-scheduling-workbench'
     jumpSelect!.dispatchEvent(new Event('change', { bubbles: true }))
     await flushUi(2)
 
-    expect(window.location.hash).toBe('#attendance-admin-shifts')
-    expect(container!.querySelector('[data-admin-current-section="true"]')?.textContent).toContain('Scheduling · Shifts')
+    expect(window.location.hash).toBe('#attendance-admin-advanced-scheduling-workbench')
+    expect(container!.querySelector('[data-admin-current-section="true"]')?.textContent).toContain('Scheduling · Advanced scheduling')
+    expect(container!.querySelector('[data-attendance-advanced-scheduling-workbench]')).toBeTruthy()
   })
 
   it('normalizes legacy show-all storage back to focused mode across remounts', async () => {
@@ -655,6 +657,7 @@ describe('Attendance admin anchor navigation', () => {
       item => item.textContent?.trim() || '',
     )
     expect(groupLabels[0]).toBe('Scheduling')
+    expect(container!.querySelector('[data-admin-anchor="attendance-admin-advanced-scheduling-workbench"]')).toBeTruthy()
     expect(container!.querySelector('[data-admin-anchor="attendance-admin-shifts"]')).toBeTruthy()
     expect(container!.querySelector('[data-admin-anchor="attendance-admin-user-access"]')).toBeNull()
     expect(container!.querySelector('[data-admin-shortcut="attendance-admin-shifts"]')?.textContent).toContain('Scheduling · Shifts')

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -197,6 +197,59 @@ describe('Attendance admin regressions', () => {
           },
         })
       }
+      if (url.includes('/api/attendance/advanced-scheduling/workbench')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            range: { from: '2026-05-01', to: '2026-05-31' },
+            summary: {
+              scheduleGroups: 1,
+              scheduleGroupMembers: 2,
+              schedulerScopes: 1,
+              shifts: 2,
+              rotationRules: 1,
+              shiftAssignments: 1,
+              rotationAssignments: 1,
+              assignedUsers: 2,
+              diagnostics: 1,
+              groupsWithoutMembers: 0,
+              assignmentUsersWithoutScheduleGroup: 1,
+              usersWithMultipleScheduleGroups: 0,
+              usersWithBothAssignmentKinds: 0,
+            },
+            scheduleGroups: {
+              total: 1,
+              items: [
+                {
+                  id: 'sg-1',
+                  name: 'Line A',
+                  code: 'line-a',
+                  source: 'manual',
+                  memberCount: 2,
+                  assignedUserCount: 1,
+                  shiftAssignmentCount: 1,
+                  rotationAssignmentCount: 1,
+                  isActive: true,
+                },
+              ],
+            },
+            diagnostics: [
+              {
+                code: 'assignment_without_schedule_group',
+                severity: 'warning',
+                message: 'Active shift or rotation assignments reference users without an effective schedule-group membership in this range.',
+                count: 1,
+                userIds: ['user-3'],
+                scheduleGroupIds: [],
+              },
+            ],
+            metadata: {
+              readOnly: true,
+              source: 'attendance_advanced_scheduling_workbench',
+            },
+          },
+        })
+      }
       if (url.includes('/api/attendance/leave-types')) {
         return jsonResponse(200, {
           ok: true,
@@ -713,6 +766,31 @@ describe('Attendance admin regressions', () => {
     expect(actionCell).toBeTruthy()
     expect(actionCell?.classList.contains('attendance__table-actions')).toBe(true)
     expect(window.getComputedStyle(actionCell!).display).toBe('table-cell')
+  })
+
+  it('renders the read-only advanced scheduling workbench without write controls', async () => {
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const workbenchNav = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-advanced-scheduling-workbench"]')
+    expect(workbenchNav).toBeTruthy()
+    workbenchNav!.click()
+    await flushUi(2)
+
+    const section = container!.querySelector<HTMLElement>('[data-attendance-advanced-scheduling-workbench]')
+    expect(section).toBeTruthy()
+    expect(window.getComputedStyle(section!).display).not.toBe('none')
+    expect(section!.textContent).toContain('Read-only snapshot')
+    expect(section!.querySelector('[data-attendance-advanced-scheduling-metric="schedule-groups"]')?.textContent).toContain('1')
+    expect(section!.querySelector('[data-attendance-advanced-scheduling-metric="assignments"]')?.textContent).toContain('2')
+    expect(section!.querySelector('[data-attendance-advanced-scheduling-diagnostic="assignment_without_schedule_group"]')?.textContent).toContain('1')
+    expect(section!.querySelector('[data-attendance-advanced-scheduling-groups]')?.textContent).toContain('Line A')
+    const buttons = Array.from(section!.querySelectorAll<HTMLButtonElement>('button')).map(button => button.textContent || '')
+    expect(buttons.join(' ')).toContain('Reload workbench')
+    expect(buttons.join(' ')).not.toContain('Create')
+    expect(buttons.join(' ')).not.toContain('Edit')
+    expect(buttons.join(' ')).not.toContain('Delete')
   })
 
   it('restores the run21 holiday calendar, rule builder, and import template guidance', async () => {

--- a/docs/development/attendance-advanced-scheduling-readonly-workbench-development-20260522.md
+++ b/docs/development/attendance-advanced-scheduling-readonly-workbench-development-20260522.md
@@ -1,0 +1,114 @@
+# Attendance Advanced Scheduling Read-Only Workbench Development
+
+Date: 2026-05-22
+Branch: `codex/attendance-advanced-scheduling-readonly-workbench-20260522`
+
+## Summary
+
+This slice adds the first DingTalk-style advanced scheduling workbench surface
+on top of the PR1 schedule-group foundation. It is intentionally read-only:
+operators can see coverage and planning signals across schedule groups, shifts,
+rotation rules, active assignments, scheduler scopes, and effective-calendar
+boundaries, but this slice does not create or edit schedule data.
+
+## Changed Files
+
+| File | Change |
+| --- | --- |
+| `plugins/plugin-attendance/index.cjs` | Adds a pure `buildAttendanceAdvancedSchedulingWorkbench()` summarizer and `GET /api/attendance/advanced-scheduling/workbench`. |
+| `apps/web/src/views/AttendanceView.vue` | Adds the admin workbench panel under Scheduling with metrics, diagnostics, and schedule-group coverage table. |
+| `apps/web/src/views/attendance/useAttendanceAdminRail.ts` | Adds `Advanced scheduling` as the first Scheduling nav item. |
+| `packages/core-backend/tests/unit/attendance-advanced-scheduling-workbench.test.ts` | Locks summarizer semantics and route read-only/admin contract. |
+| `apps/web/tests/attendance-admin-anchor-nav.spec.ts` | Updates nav and quick-jump coverage for the new section. |
+| `apps/web/tests/attendance-admin-regressions.spec.ts` | Verifies the workbench renders read-only data and no Create/Edit/Delete controls. |
+| `docs/development/attendance-advanced-scheduling-readonly-workbench-development-20260522.md` | This development note. |
+| `docs/development/attendance-advanced-scheduling-readonly-workbench-verification-20260522.md` | Verification evidence for this slice. |
+
+## Backend Contract
+
+New route:
+
+```text
+GET /api/attendance/advanced-scheduling/workbench?from=YYYY-MM-DD&to=YYYY-MM-DD
+```
+
+Guard:
+
+```text
+attendance:admin
+```
+
+The route reads:
+
+- `attendance_schedule_groups`
+- `attendance_schedule_group_members`
+- `attendance_scheduler_scopes`
+- `attendance_shifts`
+- `attendance_rotation_rules`
+- `attendance_shift_assignments`
+- `attendance_rotation_assignments`
+
+It writes nothing. There is no sibling `POST`, `PUT`, or `DELETE` route for the
+workbench path.
+
+## Workbench Payload
+
+The response is a snapshot:
+
+- `summary`: counts for groups, members, scheduler scopes, shifts, rotation
+  rules, assignments, assigned users, and diagnostics.
+- `scheduleGroups.items`: active schedule groups enriched with member count,
+  assigned-user count, shift-assignment count, and rotation-assignment count.
+- `diagnostics`: planning signals for empty groups, assigned users without
+  schedule-group membership, multi-group users, mixed shift/rotation assignment
+  users, and scheduler scopes pointing at inactive or missing groups.
+- `metadata.readOnly=true`: explicit frontend and reviewer signal.
+
+## Read-Only Boundary
+
+| Boundary | Decision |
+| --- | --- |
+| Schedule writes | Not added. Existing shift/rotation/assignment forms remain the only write UI. |
+| Grid editing | Not added. Draft grid/edit preview remains the next product slice. |
+| Migration | Not added. This consumes PR1 tables. |
+| `attendance_*` facts | No new fact table writes. Reads stay inside attendance plugin routes. |
+| `meta_*` | Not touched. |
+| Multitable | Not touched. |
+| Data Factory / Bridge Agent | Not touched. |
+
+## Frontend Placement
+
+The panel is placed as the first item in the existing admin `Scheduling` rail
+group. This makes it the overview for the existing lower-level Scheduling
+sections:
+
+1. Advanced scheduling
+2. Rotation Rules
+3. Rotation Assignments
+4. Shifts
+5. Assignments
+6. Holidays
+
+The UI is deliberately operational rather than decorative: compact metrics,
+warning diagnostics, and a table of schedule-group coverage. The only button in
+the panel reloads the snapshot.
+
+## Diagnostics Semantics
+
+| Diagnostic | Meaning |
+| --- | --- |
+| `schedule_group_without_members` | An active schedule group has no effective members in the selected range. |
+| `assignment_without_schedule_group` | A user has an active shift or rotation assignment but no effective schedule-group membership. |
+| `user_multiple_schedule_groups` | A user belongs to more than one schedule group in the selected range. |
+| `user_mixed_assignment_kinds` | A user has both shift and rotation assignment rows; effective-calendar resolution still decides day-level precedence. |
+| `scheduler_scope_unknown_schedule_group` | A scheduler scope references a schedule group not present in the active snapshot. |
+
+## Follow-Up
+
+Next slice should build draft/grid preview on top of this read-only overview:
+
+- dense date x user/group grid
+- draft cell edits against existing shifts
+- clear selected cells
+- preview conflicts and effective-calendar changes
+- save through existing guarded assignment APIs or a narrow batch endpoint

--- a/docs/development/attendance-advanced-scheduling-readonly-workbench-verification-20260522.md
+++ b/docs/development/attendance-advanced-scheduling-readonly-workbench-verification-20260522.md
@@ -1,0 +1,74 @@
+# Attendance Advanced Scheduling Read-Only Workbench Verification
+
+Date: 2026-05-22
+Branch: `codex/attendance-advanced-scheduling-readonly-workbench-20260522`
+
+## Scope Verification
+
+| Area | Result |
+| --- | --- |
+| Runtime domain | Attendance only |
+| Data Factory / Bridge Agent | Not touched |
+| New migration | None |
+| Schedule write path | None added |
+| Direct `meta_*` writes | None |
+| Multitable writes | None |
+| Secrets / tokens | None |
+
+## Boundary Evidence
+
+| Boundary | Evidence |
+| --- | --- |
+| Workbench is read-only | Backend adds only `GET /api/attendance/advanced-scheduling/workbench`; tests assert no sibling `POST` / `PUT` / `DELETE` route. |
+| Admin-only | Backend route is wired through `withPermission('attendance:admin', ...)`; tests assert the route guard. |
+| Existing write guards untouched | Existing shift/rotation/assignment write routes and conflict guards are not changed. |
+| Scheduling group foundation consumed, not redefined | The workbench reads PR1 schedule group/member/scheduler-scope tables and does not add new schema. |
+| Frontend has no write controls | Regression test asserts the workbench section contains Reload but no Create/Edit/Delete controls. |
+| Existing admin navigation preserved | Anchor-nav tests verify the new section joins the existing Scheduling rail and quick jump. |
+
+## Test Commands
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/attendance-advanced-scheduling-workbench.test.ts \
+  tests/unit/attendance-advanced-scheduling-scope.test.ts \
+  tests/unit/attendance-scheduling-assignment-conflict.test.ts \
+  --reporter=dot
+
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/attendance-admin-anchor-nav.spec.ts \
+  tests/attendance-admin-regressions.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web type-check
+
+pnpm --filter @metasheet/core-backend build
+
+git diff --check
+```
+
+## Results
+
+| Check | Result |
+| --- | --- |
+| Plugin syntax | PASS |
+| Backend advanced scheduling tests | PASS, 13 tests |
+| Frontend admin nav + regression tests | PASS, 34 tests |
+| Web type-check | PASS |
+| Core backend build | PASS |
+| `git diff --check` | PASS |
+
+## Notes
+
+- The isolated worktree needed `pnpm install --ignore-scripts` before package
+  tests. That produced unrelated tracked `node_modules` symlink noise under
+  plugin/tool directories. Commit staging must explicitly list only this slice's
+  files and must not use `git add -A`.
+- The frontend Vitest run printed `WebSocket server error: Port is already in
+  use`, but both targeted spec files completed successfully. This is recorded
+  as a test-environment warning, not a product regression.
+- No live staging/prod operation was run for this slice. The route is read-only,
+  and live evidence can be added later once staging has schedule groups,
+  assignments, and scheduler scopes seeded.

--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-workbench.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-workbench.test.ts
@@ -1,0 +1,90 @@
+import { readFileSync } from 'node:fs'
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceReportFieldCatalogForTests
+
+const pluginSource = readFileSync(
+  new URL('../../../../plugins/plugin-attendance/index.cjs', import.meta.url),
+  'utf8',
+)
+
+describe('attendance advanced scheduling read-only workbench', () => {
+  it('summarizes schedule groups, assignments, scheduler scopes, and diagnostics without writes', () => {
+    const workbench = helpers.buildAttendanceAdvancedSchedulingWorkbench({
+      from: '2026-06-01',
+      to: '2026-06-30',
+      scheduleGroups: [
+        { id: 'group-a', name: 'Line A', code: 'line-a', source: 'manual', isActive: true },
+        { id: 'group-empty', name: 'Empty group', code: 'empty', source: 'manual', isActive: true },
+      ],
+      scheduleGroupMembers: [
+        { id: 'm-1', scheduleGroupId: 'group-a', userId: 'user-1', effectiveFrom: '2026-06-01', effectiveTo: null },
+        { id: 'm-2', scheduleGroupId: 'group-a', userId: 'user-2', effectiveFrom: '2026-06-01', effectiveTo: null },
+        { id: 'm-3', scheduleGroupId: 'group-b', userId: 'user-2', effectiveFrom: '2026-06-01', effectiveTo: null },
+      ],
+      schedulerScopes: [
+        {
+          id: 'scope-1',
+          subjectType: 'role_tag',
+          subjectRef: 'scheduler',
+          actions: ['view'],
+          scope: { scheduleGroupIds: ['group-missing'], userIds: [], attendanceGroupIds: [], departments: [], roles: [], roleTags: [] },
+          isActive: true,
+        },
+      ],
+      shifts: [{ id: 'shift-a', name: 'Day' }],
+      rotationRules: [{ id: 'rot-a', name: 'Two shift', shiftSequence: ['shift-a'] }],
+      shiftAssignments: [
+        { assignment: { id: 'sa-1', userId: 'user-1', shiftId: 'shift-a', startDate: '2026-06-01', endDate: null, isActive: true }, shift: { id: 'shift-a', name: 'Day' } },
+        { assignment: { id: 'sa-2', userId: 'user-3', shiftId: 'shift-a', startDate: '2026-06-01', endDate: null, isActive: true }, shift: { id: 'shift-a', name: 'Day' } },
+      ],
+      rotationAssignments: [
+        { assignment: { id: 'ra-1', userId: 'user-1', rotationRuleId: 'rot-a', startDate: '2026-06-01', endDate: null, isActive: true }, rotation: { id: 'rot-a', name: 'Two shift' } },
+      ],
+    })
+
+    expect(workbench.metadata).toEqual({
+      readOnly: true,
+      source: 'attendance_advanced_scheduling_workbench',
+    })
+    expect(workbench.summary).toMatchObject({
+      scheduleGroups: 2,
+      scheduleGroupMembers: 3,
+      schedulerScopes: 1,
+      shifts: 1,
+      rotationRules: 1,
+      shiftAssignments: 2,
+      rotationAssignments: 1,
+      assignedUsers: 2,
+      groupsWithoutMembers: 1,
+      assignmentUsersWithoutScheduleGroup: 1,
+      usersWithMultipleScheduleGroups: 1,
+      usersWithBothAssignmentKinds: 1,
+    })
+    expect(workbench.scheduleGroups.items.find((group: any) => group.id === 'group-a')).toMatchObject({
+      memberCount: 2,
+      assignedUserCount: 1,
+      shiftAssignmentCount: 1,
+      rotationAssignmentCount: 1,
+    })
+    expect(workbench.diagnostics.map((item: any) => item.code)).toEqual([
+      'schedule_group_without_members',
+      'assignment_without_schedule_group',
+      'user_multiple_schedule_groups',
+      'user_mixed_assignment_kinds',
+      'scheduler_scope_unknown_schedule_group',
+    ])
+  })
+
+  it('registers a read-only attendance-admin GET route and no sibling write route', () => {
+    expect(pluginSource).toMatch(
+      /'GET',\s*\n\s*'\/api\/attendance\/advanced-scheduling\/workbench',\s*\n\s*withPermission\('attendance:admin'/,
+    )
+    expect(pluginSource).not.toContain("'POST',\n      '/api/attendance/advanced-scheduling/workbench'")
+    expect(pluginSource).not.toContain("'PUT',\n      '/api/attendance/advanced-scheduling/workbench'")
+    expect(pluginSource).not.toContain("'DELETE',\n      '/api/attendance/advanced-scheduling/workbench'")
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -7453,6 +7453,184 @@ function attendanceSchedulerScopeMatchesTarget(scopeRow, target) {
   return true
 }
 
+function countBy(items, resolveKey) {
+  const counts = new Map()
+  for (const item of Array.isArray(items) ? items : []) {
+    const key = resolveKey(item)
+    if (!key) continue
+    counts.set(key, (counts.get(key) ?? 0) + 1)
+  }
+  return counts
+}
+
+function sortedUnique(values) {
+  return Array.from(new Set((Array.isArray(values) ? values : []).map(value => String(value || '').trim()).filter(Boolean))).sort()
+}
+
+function buildAttendanceAdvancedSchedulingDiagnostic({ code, severity = 'info', message, count, userIds, scheduleGroupIds }) {
+  return {
+    code,
+    severity,
+    message,
+    count: Number(count) || 0,
+    userIds: sortedUnique(userIds),
+    scheduleGroupIds: sortedUnique(scheduleGroupIds),
+  }
+}
+
+function buildAttendanceAdvancedSchedulingWorkbench(input = {}) {
+  const from = normalizeDateOnly(input.from) ?? null
+  const to = normalizeDateOnly(input.to) ?? null
+  const scheduleGroups = Array.isArray(input.scheduleGroups) ? input.scheduleGroups : []
+  const scheduleGroupMembers = Array.isArray(input.scheduleGroupMembers) ? input.scheduleGroupMembers : []
+  const schedulerScopes = Array.isArray(input.schedulerScopes) ? input.schedulerScopes : []
+  const shifts = Array.isArray(input.shifts) ? input.shifts : []
+  const rotationRules = Array.isArray(input.rotationRules) ? input.rotationRules : []
+  const shiftAssignments = Array.isArray(input.shiftAssignments) ? input.shiftAssignments : []
+  const rotationAssignments = Array.isArray(input.rotationAssignments) ? input.rotationAssignments : []
+
+  const membersByGroupId = new Map()
+  const groupIdsByUserId = new Map()
+  for (const member of scheduleGroupMembers) {
+    const groupId = member.scheduleGroupId
+    const userId = member.userId
+    if (groupId) {
+      if (!membersByGroupId.has(groupId)) membersByGroupId.set(groupId, [])
+      membersByGroupId.get(groupId).push(member)
+    }
+    if (userId && groupId) {
+      if (!groupIdsByUserId.has(userId)) groupIdsByUserId.set(userId, new Set())
+      groupIdsByUserId.get(userId).add(groupId)
+    }
+  }
+
+  const shiftAssignmentCountByUser = countBy(shiftAssignments, item => item?.assignment?.userId)
+  const rotationAssignmentCountByUser = countBy(rotationAssignments, item => item?.assignment?.userId)
+  const assignedUserIds = new Set([...shiftAssignmentCountByUser.keys(), ...rotationAssignmentCountByUser.keys()])
+
+  const scheduleGroupIds = new Set(scheduleGroups.map(group => group.id).filter(Boolean))
+  const groupItems = scheduleGroups.map((group) => {
+    const members = membersByGroupId.get(group.id) ?? []
+    const memberUserIds = new Set(members.map(member => member.userId).filter(Boolean))
+    const assignedMemberUserIds = [...memberUserIds].filter(userId => assignedUserIds.has(userId))
+    const shiftAssignmentCount = [...memberUserIds].reduce((sum, userId) => sum + (shiftAssignmentCountByUser.get(userId) ?? 0), 0)
+    const rotationAssignmentCount = [...memberUserIds].reduce((sum, userId) => sum + (rotationAssignmentCountByUser.get(userId) ?? 0), 0)
+    return {
+      ...group,
+      memberCount: members.length,
+      assignedUserCount: assignedMemberUserIds.length,
+      shiftAssignmentCount,
+      rotationAssignmentCount,
+    }
+  })
+
+  const groupsWithoutMembers = groupItems.filter(group => group.isActive !== false && group.memberCount === 0)
+  const usersWithMultipleScheduleGroups = [...groupIdsByUserId.entries()]
+    .filter(([, groupIds]) => groupIds.size > 1)
+    .map(([userId]) => userId)
+  const assignmentUsersWithoutScheduleGroup = [...assignedUserIds]
+    .filter(userId => !groupIdsByUserId.has(userId))
+  const usersWithBothAssignmentKinds = [...shiftAssignmentCountByUser.keys()]
+    .filter(userId => rotationAssignmentCountByUser.has(userId))
+  const schedulerScopesWithUnknownGroups = schedulerScopes
+    .filter(scope => Array.isArray(scope?.scope?.scheduleGroupIds) && scope.scope.scheduleGroupIds.some(groupId => !scheduleGroupIds.has(groupId)))
+  const schedulerScopeUnknownGroupIds = schedulerScopesWithUnknownGroups
+    .flatMap(scope => normalizeStringArray(scope?.scope?.scheduleGroupIds).filter(groupId => !scheduleGroupIds.has(groupId)))
+
+  const diagnostics = [
+    groupsWithoutMembers.length
+      ? buildAttendanceAdvancedSchedulingDiagnostic({
+        code: 'schedule_group_without_members',
+        severity: 'warning',
+        message: 'Active schedule groups have no effective members in this range.',
+        count: groupsWithoutMembers.length,
+        scheduleGroupIds: groupsWithoutMembers.map(group => group.id),
+      })
+      : null,
+    assignmentUsersWithoutScheduleGroup.length
+      ? buildAttendanceAdvancedSchedulingDiagnostic({
+        code: 'assignment_without_schedule_group',
+        severity: 'warning',
+        message: 'Active shift or rotation assignments reference users without an effective schedule-group membership in this range.',
+        count: assignmentUsersWithoutScheduleGroup.length,
+        userIds: assignmentUsersWithoutScheduleGroup,
+      })
+      : null,
+    usersWithMultipleScheduleGroups.length
+      ? buildAttendanceAdvancedSchedulingDiagnostic({
+        code: 'user_multiple_schedule_groups',
+        severity: 'warning',
+        message: 'Users belong to multiple schedule groups in this range.',
+        count: usersWithMultipleScheduleGroups.length,
+        userIds: usersWithMultipleScheduleGroups,
+      })
+      : null,
+    usersWithBothAssignmentKinds.length
+      ? buildAttendanceAdvancedSchedulingDiagnostic({
+        code: 'user_mixed_assignment_kinds',
+        severity: 'info',
+        message: 'Users have both shift and rotation assignment rows in this range; effective-calendar resolution still owns day-level precedence.',
+        count: usersWithBothAssignmentKinds.length,
+        userIds: usersWithBothAssignmentKinds,
+      })
+      : null,
+    schedulerScopesWithUnknownGroups.length
+      ? buildAttendanceAdvancedSchedulingDiagnostic({
+        code: 'scheduler_scope_unknown_schedule_group',
+        severity: 'warning',
+        message: 'Scheduler scopes reference schedule groups that are not active in this workbench snapshot.',
+        count: schedulerScopesWithUnknownGroups.length,
+        scheduleGroupIds: schedulerScopeUnknownGroupIds,
+      })
+      : null,
+  ].filter(Boolean)
+
+  return {
+    range: { from, to },
+    summary: {
+      scheduleGroups: scheduleGroups.length,
+      scheduleGroupMembers: scheduleGroupMembers.length,
+      schedulerScopes: schedulerScopes.length,
+      shifts: shifts.length,
+      rotationRules: rotationRules.length,
+      shiftAssignments: shiftAssignments.length,
+      rotationAssignments: rotationAssignments.length,
+      assignedUsers: assignedUserIds.size,
+      diagnostics: diagnostics.length,
+      groupsWithoutMembers: groupsWithoutMembers.length,
+      assignmentUsersWithoutScheduleGroup: assignmentUsersWithoutScheduleGroup.length,
+      usersWithMultipleScheduleGroups: usersWithMultipleScheduleGroups.length,
+      usersWithBothAssignmentKinds: usersWithBothAssignmentKinds.length,
+    },
+    scheduleGroups: {
+      items: groupItems,
+      total: groupItems.length,
+    },
+    shifts: {
+      items: shifts,
+      total: shifts.length,
+    },
+    rotationRules: {
+      items: rotationRules,
+      total: rotationRules.length,
+    },
+    assignments: {
+      shiftItems: shiftAssignments,
+      rotationItems: rotationAssignments,
+      total: shiftAssignments.length + rotationAssignments.length,
+    },
+    schedulerScopes: {
+      items: schedulerScopes,
+      total: schedulerScopes.length,
+    },
+    diagnostics,
+    metadata: {
+      readOnly: true,
+      source: 'attendance_advanced_scheduling_workbench',
+    },
+  }
+}
+
 function normalizeAttendanceGroupValue(value) {
   if (value === undefined || value === null) return null
   const text = String(value).trim()
@@ -13143,6 +13321,7 @@ module.exports = {
     doAttendanceScheduleMembershipWindowsOverlap,
     buildAttendanceScheduleGroupMemberLockKey,
     acquireAttendanceScheduleGroupMemberLock,
+    buildAttendanceAdvancedSchedulingWorkbench,
     normalizeAttendanceSchedulerScopeBody,
     normalizeAttendanceSchedulerScopeInput,
     mapAttendanceSchedulerScopeRow,
@@ -24953,6 +25132,141 @@ module.exports = {
           }
           logger.error('Attendance scheduler scope delete failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete scheduler scope' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/advanced-scheduling/workbench',
+      withPermission('attendance:admin', async (req, res) => {
+        const fromRaw = typeof req.query.from === 'string' ? req.query.from.trim() : ''
+        const toRaw = typeof req.query.to === 'string' ? req.query.to.trim() : ''
+        const from = fromRaw ? normalizeDateOnlyStrict(fromRaw) : null
+        const to = toRaw ? normalizeDateOnlyStrict(toRaw) : null
+        if (fromRaw && !from) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid "from" date. Use YYYY-MM-DD.' } })
+          return
+        }
+        if (toRaw && !to) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid "to" date. Use YYYY-MM-DD.' } })
+          return
+        }
+        if (from && to && from > to) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: '"from" must be on or before "to".' } })
+          return
+        }
+        const orgId = getOrgId(req)
+        const rangeStart = from ?? '0001-01-01'
+        const rangeEnd = to ?? ATTENDANCE_SCHEDULE_OPEN_END_DATE
+
+        try {
+          const [
+            scheduleGroupRows,
+            scheduleGroupMemberRows,
+            schedulerScopeRows,
+            shiftRows,
+            rotationRuleRows,
+            shiftAssignmentRows,
+            rotationAssignmentRows,
+          ] = await Promise.all([
+            db.query(
+              `SELECT *
+               FROM attendance_schedule_groups
+               WHERE org_id = $1 AND is_active = true
+               ORDER BY name ASC, created_at DESC`,
+              [orgId]
+            ),
+            db.query(
+              `SELECT *
+               FROM attendance_schedule_group_members
+               WHERE org_id = $1
+                 AND COALESCE(effective_from, DATE '0001-01-01') <= $3::date
+                 AND COALESCE(effective_to, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
+               ORDER BY schedule_group_id ASC, effective_from ASC NULLS FIRST, user_id ASC`,
+              [orgId, rangeStart, rangeEnd]
+            ),
+            db.query(
+              `SELECT *
+               FROM attendance_scheduler_scopes
+               WHERE org_id = $1 AND is_active = true
+               ORDER BY subject_type ASC, subject_ref ASC, created_at DESC`,
+              [orgId]
+            ),
+            db.query(
+              `SELECT *
+               FROM attendance_shifts
+               WHERE org_id = $1
+               ORDER BY name ASC, created_at DESC`,
+              [orgId]
+            ),
+            db.query(
+              `SELECT *
+               FROM attendance_rotation_rules
+               WHERE org_id = $1
+               ORDER BY is_active DESC, name ASC, created_at DESC`,
+              [orgId]
+            ),
+            db.query(
+              `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.start_date, a.end_date, a.is_active,
+                      s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
+                      s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight,
+                      s.late_grace_minutes AS shift_late_grace_minutes,
+                      s.early_grace_minutes AS shift_early_grace_minutes,
+                      s.rounding_minutes AS shift_rounding_minutes,
+                      s.working_days AS shift_working_days
+               FROM attendance_shift_assignments a
+               JOIN attendance_shifts s ON s.id = a.shift_id
+               WHERE a.org_id = $1
+                 AND COALESCE(a.is_active, true) = true
+                 AND a.start_date <= $3::date
+                 AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
+               ORDER BY a.start_date DESC, a.created_at DESC
+               LIMIT 500`,
+              [orgId, rangeStart, rangeEnd]
+            ),
+            db.query(
+              `SELECT a.id, a.org_id, a.user_id, a.rotation_rule_id, a.start_date, a.end_date, a.is_active,
+                      r.name AS rotation_name, r.timezone AS rotation_timezone,
+                      r.shift_sequence AS rotation_shift_sequence,
+                      r.is_active AS rotation_is_active
+               FROM attendance_rotation_assignments a
+               JOIN attendance_rotation_rules r ON r.id = a.rotation_rule_id
+               WHERE a.org_id = $1
+                 AND COALESCE(a.is_active, true) = true
+                 AND a.start_date <= $3::date
+                 AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
+               ORDER BY a.start_date DESC, a.created_at DESC
+               LIMIT 500`,
+              [orgId, rangeStart, rangeEnd]
+            ),
+          ])
+
+          const data = buildAttendanceAdvancedSchedulingWorkbench({
+            from,
+            to,
+            scheduleGroups: scheduleGroupRows.map(mapAttendanceScheduleGroupRow),
+            scheduleGroupMembers: scheduleGroupMemberRows.map(mapAttendanceScheduleGroupMemberRow),
+            schedulerScopes: schedulerScopeRows.map(mapAttendanceSchedulerScopeRow),
+            shifts: shiftRows.map(mapShiftRow),
+            rotationRules: rotationRuleRows.map(mapRotationRuleRow),
+            shiftAssignments: shiftAssignmentRows.map(row => ({
+              assignment: mapAssignmentRow(row),
+              shift: mapShiftFromAssignmentRow(row),
+            })),
+            rotationAssignments: rotationAssignmentRows.map(row => ({
+              assignment: mapRotationAssignmentRow(row),
+              rotation: mapRotationRuleFromAssignmentRow(row),
+            })),
+          })
+          res.json({ ok: true, data })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+            return
+          }
+          logger.error('Attendance advanced scheduling workbench query failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load advanced scheduling workbench' } })
         }
       })
     )


### PR DESCRIPTION
## Summary

Adds a read-only advanced scheduling workbench as the first Scheduling admin section.

- Backend: `GET /api/attendance/advanced-scheduling/workbench` aggregates schedule groups, date-aware members, scheduler scopes, shifts, rotation rules, active shift assignments, and active rotation assignments.
- Frontend: adds an `Advanced scheduling` admin rail entry with compact metrics, planning diagnostics, and schedule-group coverage table.
- Boundary: read-only only. No schedule writes, no new migration, no multitable writes, no `meta_*` writes, and existing shift/rotation/assignment save guards are untouched.

## Test plan

- [x] `node --check plugins/plugin-attendance/index.cjs`
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-advanced-scheduling-workbench.test.ts tests/unit/attendance-advanced-scheduling-scope.test.ts tests/unit/attendance-scheduling-assignment-conflict.test.ts --reporter=dot` (13 pass)
- [x] `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-anchor-nav.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` (34 pass; Vitest printed a non-fatal WebSocket port-in-use warning)
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `pnpm --filter @metasheet/core-backend build`
- [x] `git diff --check`

## Docs

- `docs/development/attendance-advanced-scheduling-readonly-workbench-development-20260522.md`
- `docs/development/attendance-advanced-scheduling-readonly-workbench-verification-20260522.md`
