### PR TITLE
feat(multitable): localize visual view render chrome (final audit Slice B)

### DIFF
--- a/apps/web/src/multitable/components/MetaCalendarView.vue
+++ b/apps/web/src/multitable/components/MetaCalendarView.vue
@@ -2,9 +2,9 @@
   <div class="meta-calendar">
     <div v-if="!dateField" class="meta-calendar__picker">
       <div class="meta-calendar__picker-icon">&#x1F4C5;</div>
-      <p>Select a date field to use for the calendar:</p>
+      <p>{{ viewRenderLabel('calendar.selectDateField', isZh) }}</p>
       <select class="meta-calendar__field-select" @change="onPickDateField($event)">
-        <option value="">— Choose field —</option>
+        <option value="">{{ viewRenderLabel('common.chooseField', isZh) }}</option>
         <option v-for="f in dateFields" :key="f.id" :value="f.id">{{ f.name }}</option>
       </select>
     </div>
@@ -14,19 +14,19 @@
         <button class="meta-calendar__nav-btn" @click="goPrevious">&lsaquo;</button>
         <span class="meta-calendar__title">{{ periodLabel }}</span>
         <button class="meta-calendar__nav-btn" @click="goNext">&rsaquo;</button>
-        <button class="meta-calendar__today-btn" @click="goToday">Today</button>
-        <button v-if="canCreate" class="meta-calendar__create-btn" @click="onQuickCreate">+ Add record</button>
+        <button class="meta-calendar__today-btn" @click="goToday">{{ viewRenderLabel('calendar.today', isZh) }}</button>
+        <button v-if="canCreate" class="meta-calendar__create-btn" @click="onQuickCreate">{{ viewRenderLabel('common.addRecord', isZh) }}</button>
         <label class="meta-calendar__mode-label">
-          View
+          {{ viewRenderLabel('calendar.view', isZh) }}
           <select class="meta-calendar__mode-select" :value="viewMode" @change="onViewModeChange">
-            <option value="month">Month</option>
-            <option value="week">Week</option>
-            <option value="day">Day</option>
+            <option value="month">{{ calendarViewModeLabel('month', isZh) }}</option>
+            <option value="week">{{ calendarViewModeLabel('week', isZh) }}</option>
+            <option value="day">{{ calendarViewModeLabel('day', isZh) }}</option>
           </select>
         </label>
         <span class="meta-calendar__field-label">
-          Field: <strong>{{ dateField.name }}</strong>
-          <button v-if="dateField" class="meta-calendar__change-btn" @click="onResetDateField">Change</button>
+          {{ isZh ? '字段：' : 'Field:' }} <strong>{{ dateField.name }}</strong>
+          <button v-if="dateField" class="meta-calendar__change-btn" @click="onResetDateField">{{ viewRenderLabel('calendar.change', isZh) }}</button>
         </span>
       </div>
 
@@ -85,7 +85,7 @@
                     class="meta-calendar__event-attachments"
                     :attachments="ev.attachments"
                     variant="compact"
-                    empty-label="No attachments"
+                    :empty-label="metaCoreLabel('cell.noAttachments', isZh)"
                   />
                   <template v-else>{{ ev.title }}</template>
                 </div>
@@ -94,7 +94,7 @@
                     type="button"
                     class="meta-calendar__comment-btn"
                     :class="rowCommentButtonClass(ev.id)"
-                    :aria-label="`Open comments for ${ev.title}`"
+                    :aria-label="openRecordCommentsAria(ev.title, isZh)"
                     @click.stop="emit('open-comments', ev.id)"
                     @keydown="onRowCommentKeydown($event, ev.id)"
                   >
@@ -105,7 +105,7 @@
                     type="button"
                     class="meta-calendar__field-comment-btn"
                     :class="fieldCommentButtonClass(ev.id)"
-                    :aria-label="`Open comments for ${dateField.name}`"
+                    :aria-label="openFieldCommentsAria(dateField.name, isZh)"
                     @click.stop="emit('open-field-comments', { recordId: ev.id, fieldId: dateField.id })"
                     @keydown="onFieldCommentKeydown($event, ev.id, dateField.id)"
                   >
@@ -113,7 +113,7 @@
                   </button>
                 </div>
               </div>
-              <div v-if="cell.overflow > 0" class="meta-calendar__overflow">+{{ cell.overflow }} more</div>
+              <div v-if="cell.overflow > 0" class="meta-calendar__overflow">{{ calendarMoreEvents(cell.overflow, isZh) }}</div>
             </div>
           </div>
         </div>
@@ -172,7 +172,7 @@
                     class="meta-calendar__event-attachments"
                     :attachments="ev.attachments"
                     variant="compact"
-                    empty-label="No attachments"
+                    :empty-label="metaCoreLabel('cell.noAttachments', isZh)"
                   />
                   <template v-else>{{ ev.title }}</template>
                 </div>
@@ -181,7 +181,7 @@
                     type="button"
                     class="meta-calendar__comment-btn"
                     :class="rowCommentButtonClass(ev.id)"
-                    :aria-label="`Open comments for ${ev.title}`"
+                    :aria-label="openRecordCommentsAria(ev.title, isZh)"
                     @click.stop="emit('open-comments', ev.id)"
                     @keydown="onRowCommentKeydown($event, ev.id)"
                   >
@@ -192,7 +192,7 @@
                     type="button"
                     class="meta-calendar__field-comment-btn"
                     :class="fieldCommentButtonClass(ev.id)"
-                    :aria-label="`Open comments for ${dateField.name}`"
+                    :aria-label="openFieldCommentsAria(dateField.name, isZh)"
                     @click.stop="emit('open-field-comments', { recordId: ev.id, fieldId: dateField.id })"
                     @keydown="onFieldCommentKeydown($event, ev.id, dateField.id)"
                   >
@@ -200,7 +200,7 @@
                   </button>
                 </div>
               </div>
-              <div v-if="cell.overflow > 0" class="meta-calendar__overflow">+{{ cell.overflow }} more</div>
+              <div v-if="cell.overflow > 0" class="meta-calendar__overflow">{{ calendarMoreEvents(cell.overflow, isZh) }}</div>
             </div>
           </div>
         </div>
@@ -227,13 +227,13 @@
                 {{ holiday.name || fallbackHolidayName(holiday) }}
               </span>
             </div>
-            <div class="meta-calendar__day-meta">{{ currentDayEvents.length }} event{{ currentDayEvents.length === 1 ? '' : 's' }}</div>
+            <div class="meta-calendar__day-meta">{{ calendarEventCount(currentDayEvents.length, isZh) }}</div>
             <button
               v-if="canCreate"
               class="meta-calendar__day-create"
               @click="emit('create-record', buildCreateRecordData(activeDayStr))"
             >
-              + New record
+              {{ viewRenderLabel('calendar.newRecord', isZh) }}
             </button>
           </div>
           <div class="meta-calendar__day-list">
@@ -253,7 +253,7 @@
                   class="meta-calendar__day-event-attachments"
                   :attachments="ev.attachments"
                   variant="compact"
-                  empty-label="No attachments"
+                  :empty-label="metaCoreLabel('cell.noAttachments', isZh)"
                 />
                 <template v-else>{{ ev.title }}</template>
               </div>
@@ -262,7 +262,7 @@
                   type="button"
                   class="meta-calendar__comment-btn"
                   :class="rowCommentButtonClass(ev.id)"
-                  :aria-label="`Open comments for ${ev.title}`"
+                  :aria-label="openRecordCommentsAria(ev.title, isZh)"
                   @click.stop="emit('open-comments', ev.id)"
                   @keydown="onRowCommentKeydown($event, ev.id)"
                 >
@@ -273,7 +273,7 @@
                   type="button"
                   class="meta-calendar__field-comment-btn"
                   :class="fieldCommentButtonClass(ev.id)"
-                  :aria-label="`Open comments for ${dateField.name}`"
+                  :aria-label="openFieldCommentsAria(dateField.name, isZh)"
                   @click.stop="emit('open-field-comments', { recordId: ev.id, fieldId: dateField.id })"
                   @keydown="onFieldCommentKeydown($event, ev.id, dateField.id)"
                 >
@@ -281,13 +281,13 @@
                 </button>
               </div>
             </div>
-            <div v-if="!currentDayEvents.length" class="meta-calendar__empty-hint">No records on this day</div>
+            <div v-if="!currentDayEvents.length" class="meta-calendar__empty-hint">{{ viewRenderLabel('calendar.noRecordsOnDay', isZh) }}</div>
           </div>
         </div>
       </template>
     </template>
 
-    <div v-if="loading" class="meta-calendar__loading">Loading...</div>
+    <div v-if="loading" class="meta-calendar__loading">{{ viewRenderLabel('common.loading', isZh) }}</div>
   </div>
 </template>
 
@@ -324,6 +324,17 @@ import {
   resolveRecordCommentAffordance,
 } from '../utils/comment-affordance'
 import { commentLabel } from '../utils/meta-comment-labels'
+import { metaCoreLabel } from '../utils/meta-core-labels'
+import {
+  calendarCellAriaLabel,
+  calendarEventCount,
+  calendarMoreEvents,
+  calendarViewModeLabel,
+  calendarWeekdayShort,
+  openFieldCommentsAria,
+  openRecordCommentsAria,
+  viewRenderLabel,
+} from '../utils/meta-view-render-labels'
 
 const MAX_EVENTS_PER_CELL = 3
 
@@ -361,7 +372,6 @@ const pendingConfigKey = ref<string | null>(null)
 const { isZh } = useLocale()
 const commentsChipLabel = computed(() => commentLabel('comment.title', isZh.value))
 
-const baseWeekdays = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
 const calendarConfig = computed<Required<MetaCalendarViewConfig>>(() =>
   resolveCalendarViewConfig(props.fields, props.viewConfig),
 )
@@ -391,6 +401,7 @@ watch(
 
 const weekdays = computed(() => {
   const weekStartsOn = calendarConfig.value.weekStartsOn
+  const baseWeekdays = [0, 1, 2, 3, 4, 5, 6].map((day) => calendarWeekdayShort(day as 0 | 1 | 2 | 3 | 4 | 5 | 6, isZh.value))
   return [...baseWeekdays.slice(weekStartsOn), ...baseWeekdays.slice(0, weekStartsOn)]
 })
 
@@ -703,15 +714,13 @@ function goToday() {
 
 function cellAriaLabel(cell: CalendarCell): string {
   const d = new Date(cell.dateStr + 'T00:00:00')
-  const dateLabel = d.toLocaleDateString('en-US', { month: 'long', day: 'numeric', year: 'numeric' })
+  const dateLabel = d.toLocaleDateString(isZh.value ? 'zh-CN' : 'en-US', { month: 'long', day: 'numeric', year: 'numeric' })
   const total = cell.events.length + cell.overflow
   const annotations = [
     cell.lunarLabel,
     ...cell.holidays.map((holiday) => holiday.name || fallbackHolidayName(holiday)),
-    total > 0 ? `${total} event${total > 1 ? 's' : ''}` : null,
-  ].filter(Boolean)
-  if (annotations.length) return `${dateLabel}, ${annotations.join(', ')}`
-  return dateLabel
+  ].filter((item): item is string => Boolean(item))
+  return calendarCellAriaLabel(dateLabel, annotations, total, isZh.value)
 }
 
 function onCellKeydown(e: KeyboardEvent, cellIdx: number, cells: CalendarCell[]) {

--- a/apps/web/src/multitable/components/MetaChartRenderer.vue
+++ b/apps/web/src/multitable/components/MetaChartRenderer.vue
@@ -124,8 +124,8 @@
       <table class="meta-chart__table" data-chart="table">
         <thead>
           <tr>
-            <th>Label</th>
-            <th>Value</th>
+            <th>{{ viewRenderLabel('chart.label', isZh) }}</th>
+            <th>{{ viewRenderLabel('chart.value', isZh) }}</th>
           </tr>
         </thead>
         <tbody>
@@ -142,11 +142,14 @@
 <script setup lang="ts">
 import { computed } from 'vue'
 import type { ChartData, ChartDisplayConfig } from '../types'
+import { useLocale } from '../../composables/useLocale'
+import { viewRenderLabel } from '../utils/meta-view-render-labels'
 
 const props = defineProps<{
   chartData: ChartData
   displayConfig?: ChartDisplayConfig
 }>()
+const { isZh } = useLocale()
 
 const COLORS = ['#2563eb', '#16a34a', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4', '#ec4899', '#84cc16']
 

--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -32,20 +32,20 @@
           v-if="activeDashboard && !editingName"
           class="meta-dashboard__btn meta-dashboard__btn--sm"
           type="button"
-          title="Rename"
+          :title="viewRenderLabel('dashboard.rename', isZh)"
           data-action="rename"
           @click="startRename"
-        >Rename</button>
+        >{{ viewRenderLabel('dashboard.rename', isZh) }}</button>
       </div>
       <div class="meta-dashboard__actions">
-        <button class="meta-dashboard__btn" type="button" data-action="add-panel" @click="showAddPanel = true">+ Add Panel</button>
-        <button class="meta-dashboard__btn meta-dashboard__btn--primary" type="button" data-action="create-dashboard" @click="onCreateDashboard">+ New Dashboard</button>
+        <button class="meta-dashboard__btn" type="button" data-action="add-panel" @click="showAddPanel = true">{{ viewRenderLabel('dashboard.addPanel', isZh) }}</button>
+        <button class="meta-dashboard__btn meta-dashboard__btn--primary" type="button" data-action="create-dashboard" @click="onCreateDashboard">{{ viewRenderLabel('dashboard.newDashboard', isZh) }}</button>
       </div>
     </div>
 
-    <div v-if="loading" class="meta-dashboard__empty">Loading dashboard...</div>
+    <div v-if="loading" class="meta-dashboard__empty">{{ viewRenderLabel('dashboard.loadingDashboard', isZh) }}</div>
     <div v-else-if="!activeDashboard" class="meta-dashboard__empty" data-empty="true">
-      No dashboards yet. Create your first dashboard.
+      {{ viewRenderLabel('dashboard.empty', isZh) }}
     </div>
 
     <!-- Grid of panels -->
@@ -66,9 +66,9 @@
               data-field="panel-size"
               @change="onResizePanel(panel.id, ($event.target as HTMLSelectElement).value as 'small' | 'medium' | 'large')"
             >
-              <option value="small">Small</option>
-              <option value="medium">Medium</option>
-              <option value="large">Large</option>
+              <option value="small">{{ viewSizeLabel('small', isZh) }}</option>
+              <option value="medium">{{ viewSizeLabel('medium', isZh) }}</option>
+              <option value="large">{{ viewSizeLabel('large', isZh) }}</option>
             </select>
             <button
               class="meta-dashboard__btn meta-dashboard__btn--icon meta-dashboard__btn--danger"
@@ -84,7 +84,7 @@
             :chart-data="chartDataMap[panel.chartId]"
             :display-config="chartConfigMap[panel.chartId]?.displayConfig"
           />
-          <div v-else class="meta-dashboard__panel-loading">Loading chart...</div>
+          <div v-else class="meta-dashboard__panel-loading">{{ viewRenderLabel('dashboard.loadingChart', isZh) }}</div>
         </div>
       </div>
     </div>
@@ -93,11 +93,11 @@
     <div v-if="showAddPanel" class="meta-dashboard__modal-overlay" @click.self="showAddPanel = false">
       <div class="meta-dashboard__modal">
         <div class="meta-dashboard__modal-header">
-          <h4>Add Chart Panel</h4>
+          <h4>{{ viewRenderLabel('dashboard.addChartPanel', isZh) }}</h4>
           <button class="meta-dashboard__btn meta-dashboard__btn--icon" type="button" @click="showAddPanel = false">&times;</button>
         </div>
         <div class="meta-dashboard__modal-body">
-          <div v-if="!charts.length" class="meta-dashboard__empty">No charts available. Create a chart first.</div>
+          <div v-if="!charts.length" class="meta-dashboard__empty">{{ viewRenderLabel('dashboard.noCharts', isZh) }}</div>
           <div
             v-for="chart in charts"
             :key="chart.id"
@@ -119,6 +119,8 @@ import { ref, computed, watch, nextTick } from 'vue'
 import type { Dashboard, DashboardPanel, ChartConfig, ChartData } from '../types'
 import type { MultitableApiClient } from '../api/client'
 import MetaChartRenderer from './MetaChartRenderer.vue'
+import { useLocale } from '../../composables/useLocale'
+import { dashboardDefaultName, viewRenderLabel, viewSizeLabel } from '../utils/meta-view-render-labels'
 
 const props = defineProps<{
   sheetId: string
@@ -136,6 +138,7 @@ const showAddPanel = ref(false)
 const editingName = ref(false)
 const nameInput = ref('')
 const nameInputRef = ref<HTMLInputElement | null>(null)
+const { isZh } = useLocale()
 
 const activeDashboard = computed(() => dashboards.value.find((d) => d.id === activeDashboardId.value) ?? dashboards.value[0] ?? null)
 
@@ -191,7 +194,7 @@ async function loadPanelData() {
 async function onCreateDashboard() {
   if (!props.client) return
   try {
-    const db = await props.client.createDashboard(props.sheetId, { name: `Dashboard ${dashboards.value.length + 1}` })
+    const db = await props.client.createDashboard(props.sheetId, { name: dashboardDefaultName(dashboards.value.length + 1, isZh.value) })
     dashboards.value.push(db)
     activeDashboardId.value = db.id
   } catch {

--- a/apps/web/src/multitable/components/MetaGalleryView.vue
+++ b/apps/web/src/multitable/components/MetaGalleryView.vue
@@ -2,21 +2,21 @@
   <div class="meta-gallery">
     <div v-if="fields.length" class="meta-gallery__toolbar">
       <label class="meta-gallery__toolbar-field">
-        <span>Title</span>
+        <span>{{ viewRenderLabel('gallery.title', isZh) }}</span>
         <select class="meta-gallery__toolbar-select" :value="galleryDraft.titleFieldId ?? ''" @change="onTitleFieldChange">
-          <option value="">Auto</option>
+          <option value="">{{ viewRenderLabel('common.auto', isZh) }}</option>
           <option v-for="field in titleFieldCandidates" :key="field.id" :value="field.id">{{ field.name }}</option>
         </select>
       </label>
       <label class="meta-gallery__toolbar-field">
-        <span>Cover</span>
+        <span>{{ viewRenderLabel('gallery.cover', isZh) }}</span>
         <select class="meta-gallery__toolbar-select" :value="galleryDraft.coverFieldId ?? ''" @change="onCoverFieldChange">
-          <option value="">None</option>
+          <option value="">{{ viewRenderLabel('common.none', isZh) }}</option>
           <option v-for="field in attachmentFields" :key="field.id" :value="field.id">{{ field.name }}</option>
         </select>
       </label>
       <label class="meta-gallery__toolbar-field">
-        <span>Columns</span>
+        <span>{{ viewRenderLabel('gallery.columns', isZh) }}</span>
         <select class="meta-gallery__toolbar-select" :value="galleryDraft.columns" @change="onColumnsChange">
           <option :value="1">1</option>
           <option :value="2">2</option>
@@ -25,15 +25,15 @@
         </select>
       </label>
       <label class="meta-gallery__toolbar-field">
-        <span>Card size</span>
+        <span>{{ viewRenderLabel('gallery.cardSize', isZh) }}</span>
         <select class="meta-gallery__toolbar-select" :value="galleryDraft.cardSize" @change="onCardSizeChange">
-          <option value="small">Small</option>
-          <option value="medium">Medium</option>
-          <option value="large">Large</option>
+          <option value="small">{{ viewSizeLabel('small', isZh) }}</option>
+          <option value="medium">{{ viewSizeLabel('medium', isZh) }}</option>
+          <option value="large">{{ viewSizeLabel('large', isZh) }}</option>
         </select>
       </label>
       <details class="meta-gallery__field-picker">
-        <summary>Card fields ({{ displayFields.length }})</summary>
+        <summary>{{ cardFieldsSummary(displayFields.length, isZh) }}</summary>
         <div class="meta-gallery__field-picker-list">
           <label v-for="field in configurableFields" :key="field.id" class="meta-gallery__field-picker-item">
             <input
@@ -45,7 +45,7 @@
           </label>
         </div>
       </details>
-      <button v-if="canCreate" class="meta-gallery__create-btn" @click="emit('create-record', {})">+ Add record</button>
+      <button v-if="canCreate" class="meta-gallery__create-btn" @click="emit('create-record', {})">{{ viewRenderLabel('common.addRecord', isZh) }}</button>
     </div>
     <div class="meta-gallery__grid" :style="gridStyle">
       <div
@@ -75,7 +75,7 @@
             class="meta-gallery__comment-btn"
             :class="rowCommentButtonClass(row.id)"
             type="button"
-            :aria-label="`Open comments for ${cardTitle(row)}`"
+            :aria-label="openRecordCommentsAria(cardTitle(row), isZh)"
             @click.stop="emit('open-comments', row.id)"
             @keydown="onRowCommentKeydown($event, row.id)"
           >
@@ -90,7 +90,7 @@
                 <MetaAttachmentList
                   :attachments="attachmentItems(row, field)"
                   variant="compact"
-                  empty-label="No attachments"
+                  :empty-label="metaCoreLabel('cell.noAttachments', isZh)"
                 />
               </div>
               <span v-else class="meta-gallery__field-value">{{ formatValue(row, field) }}</span>
@@ -100,7 +100,7 @@
               type="button"
               class="meta-gallery__field-comment-btn"
               :class="fieldCommentButtonClass(row.id, field.id)"
-              :aria-label="`Open comments for ${field.name} on ${cardTitle(row)}`"
+              :aria-label="openFieldCommentsForRecordAria(field.name, cardTitle(row), isZh)"
               @click.stop="emit('open-field-comments', { recordId: row.id, fieldId: field.id })"
               @keydown="onFieldCommentKeydown($event, row.id, field.id)"
             >
@@ -111,17 +111,17 @@
       </div>
       <div v-if="!rows.length && !loading" class="meta-gallery__empty">
         <div class="meta-gallery__empty-icon">&#x1F5BC;</div>
-        <div class="meta-gallery__empty-title">No records to display</div>
-        <div class="meta-gallery__empty-hint">Add records to see them as cards here</div>
-        <button v-if="canCreate" class="meta-gallery__empty-action" @click="emit('create-record', {})">Create first record</button>
+        <div class="meta-gallery__empty-title">{{ viewRenderLabel('gallery.noRecordsTitle', isZh) }}</div>
+        <div class="meta-gallery__empty-hint">{{ viewRenderLabel('gallery.noRecordsHint', isZh) }}</div>
+        <button v-if="canCreate" class="meta-gallery__empty-action" @click="emit('create-record', {})">{{ viewRenderLabel('common.createFirstRecord', isZh) }}</button>
       </div>
     </div>
     <div v-if="totalPages > 1" class="meta-gallery__pagination">
-      <button class="meta-gallery__page-btn" :disabled="currentPage <= 1" @click="emit('go-to-page', currentPage - 1)">&lsaquo; Prev</button>
+      <button class="meta-gallery__page-btn" :disabled="currentPage <= 1" @click="emit('go-to-page', currentPage - 1)">&lsaquo; {{ viewRenderLabel('gallery.prev', isZh) }}</button>
       <span class="meta-gallery__page-info">{{ currentPage }} / {{ totalPages }}</span>
-      <button class="meta-gallery__page-btn" :disabled="currentPage >= totalPages" @click="emit('go-to-page', currentPage + 1)">Next &rsaquo;</button>
+      <button class="meta-gallery__page-btn" :disabled="currentPage >= totalPages" @click="emit('go-to-page', currentPage + 1)">{{ viewRenderLabel('gallery.next', isZh) }} &rsaquo;</button>
     </div>
-    <div v-if="loading" class="meta-gallery__loading">Loading...</div>
+    <div v-if="loading" class="meta-gallery__loading">{{ viewRenderLabel('common.loading', isZh) }}</div>
   </div>
 </template>
 
@@ -141,6 +141,14 @@ import {
   resolveRecordCommentAffordance,
 } from '../utils/comment-affordance'
 import { commentLabel } from '../utils/meta-comment-labels'
+import { metaCoreLabel } from '../utils/meta-core-labels'
+import {
+  cardFieldsSummary,
+  openFieldCommentsForRecordAria,
+  openRecordCommentsAria,
+  viewRenderLabel,
+  viewSizeLabel,
+} from '../utils/meta-view-render-labels'
 
 const props = defineProps<{
   rows: MetaRecord[]

--- a/apps/web/src/multitable/components/MetaGanttView.vue
+++ b/apps/web/src/multitable/components/MetaGanttView.vue
@@ -1,68 +1,68 @@
 <template>
-  <div class="meta-gantt" role="region" aria-label="Gantt view">
-    <div v-if="loading" class="meta-gantt__loading">Loading...</div>
+  <div class="meta-gantt" role="region" :aria-label="viewRenderLabel('gantt.viewAria', isZh)">
+    <div v-if="loading" class="meta-gantt__loading">{{ viewRenderLabel('common.loading', isZh) }}</div>
     <template v-else>
       <div class="meta-gantt__toolbar">
         <label class="meta-gantt__control">
-          Start
+          {{ viewRenderLabel('gantt.start', isZh) }}
           <select :value="startFieldId" @change="onConfigChange('startFieldId', ($event.target as HTMLSelectElement).value || null)">
-            <option value="">select</option>
+            <option value="">{{ viewRenderLabel('common.select', isZh) }}</option>
             <option v-for="field in dateFields" :key="field.id" :value="field.id">{{ field.name }}</option>
           </select>
         </label>
         <label class="meta-gantt__control">
-          End
+          {{ viewRenderLabel('gantt.end', isZh) }}
           <select :value="endFieldId" @change="onConfigChange('endFieldId', ($event.target as HTMLSelectElement).value || null)">
-            <option value="">select</option>
+            <option value="">{{ viewRenderLabel('common.select', isZh) }}</option>
             <option v-for="field in dateFields" :key="field.id" :value="field.id">{{ field.name }}</option>
           </select>
         </label>
         <label class="meta-gantt__control">
-          Title
+          {{ viewRenderLabel('gantt.title', isZh) }}
           <select :value="titleFieldId" @change="onConfigChange('titleFieldId', ($event.target as HTMLSelectElement).value || null)">
-            <option value="">auto</option>
+            <option value="">{{ viewRenderLabel('common.auto', isZh) }}</option>
             <option v-for="field in titleFields" :key="field.id" :value="field.id">{{ field.name }}</option>
           </select>
         </label>
         <label class="meta-gantt__control">
-          Progress
+          {{ viewRenderLabel('gantt.progress', isZh) }}
           <select :value="progressFieldId" @change="onConfigChange('progressFieldId', ($event.target as HTMLSelectElement).value || null)">
-            <option value="">none</option>
+            <option value="">{{ viewRenderLabel('common.none', isZh) }}</option>
             <option v-for="field in numericFields" :key="field.id" :value="field.id">{{ field.name }}</option>
           </select>
         </label>
         <label class="meta-gantt__control">
-          Group
+          {{ viewRenderLabel('gantt.group', isZh) }}
           <select :value="groupFieldId" @change="onConfigChange('groupFieldId', ($event.target as HTMLSelectElement).value || null)">
-            <option value="">none</option>
+            <option value="">{{ viewRenderLabel('common.none', isZh) }}</option>
             <option v-for="field in groupableFields" :key="field.id" :value="field.id">{{ field.name }}</option>
           </select>
         </label>
         <label class="meta-gantt__control">
-          Dependencies
+          {{ viewRenderLabel('gantt.dependencies', isZh) }}
           <select :value="dependencyFieldId" @change="onConfigChange('dependencyFieldId', ($event.target as HTMLSelectElement).value || null)">
-            <option value="">none</option>
+            <option value="">{{ viewRenderLabel('common.none', isZh) }}</option>
             <option v-for="field in dependencyFields" :key="field.id" :value="field.id">{{ field.name }}</option>
           </select>
         </label>
         <label class="meta-gantt__control">
-          Zoom
+          {{ managerLabel('view.zoom', isZh) }}
           <select :value="zoom" @change="onConfigChange('zoom', ($event.target as HTMLSelectElement).value)">
-            <option value="day">Day</option>
-            <option value="week">Week</option>
-            <option value="month">Month</option>
+            <option value="day">{{ viewZoomLabel('day', isZh) }}</option>
+            <option value="week">{{ viewZoomLabel('week', isZh) }}</option>
+            <option value="month">{{ viewZoomLabel('month', isZh) }}</option>
           </select>
         </label>
-        <button v-if="canCreate" class="meta-gantt__create" @click="onQuickCreate">+ Add task</button>
+        <button v-if="canCreate" class="meta-gantt__create" @click="onQuickCreate">{{ viewRenderLabel('gantt.addTask', isZh) }}</button>
       </div>
 
       <div v-if="!startFieldId || !endFieldId" class="meta-gantt__placeholder">
-        Select start and end date fields to display Gantt tasks.
+        {{ viewRenderLabel('gantt.selectStartEnd', isZh) }}
       </div>
 
       <template v-else>
         <div class="meta-gantt__head">
-          <div class="meta-gantt__task-col">Task</div>
+          <div class="meta-gantt__task-col">{{ viewRenderLabel('gantt.task', isZh) }}</div>
           <div class="meta-gantt__axis">
             <span v-for="tick in axisTicks" :key="tick.key" class="meta-gantt__tick" :style="{ left: tick.left + '%' }">
               {{ tick.label }}
@@ -81,7 +81,7 @@
           >
             <span class="meta-gantt__task-col">
               <strong>{{ displayTitle(task.record) }}</strong>
-              <small>{{ displayStartDate(task) }} to {{ displayEndDate(task) }}</small>
+              <small>{{ displayStartDate(task) }} {{ viewRenderLabel('gantt.to', isZh) }} {{ displayEndDate(task) }}</small>
             </span>
             <span class="meta-gantt__bar-area">
               <span
@@ -104,7 +104,7 @@
                   class="meta-gantt__resize-handle meta-gantt__resize-handle--start"
                   role="separator"
                   aria-orientation="vertical"
-                  :aria-label="`Resize start for ${displayTitle(task.record)}`"
+                  :aria-label="ganttResizeAria('start', displayTitle(task.record), isZh)"
                   @click.stop
                   @mousedown.stop.prevent="onResizeStart(task, 'start', $event)"
                 ></span>
@@ -114,7 +114,7 @@
                   class="meta-gantt__resize-handle meta-gantt__resize-handle--end"
                   role="separator"
                   aria-orientation="vertical"
-                  :aria-label="`Resize end for ${displayTitle(task.record)}`"
+                  :aria-label="ganttResizeAria('end', displayTitle(task.record), isZh)"
                   @click.stop
                   @mousedown.stop.prevent="onResizeStart(task, 'end', $event)"
                 ></span>
@@ -124,7 +124,7 @@
         </div>
 
         <div v-if="unscheduledRows.length" class="meta-gantt__unscheduled">
-          <strong>Unscheduled ({{ unscheduledRows.length }})</strong>
+          <strong>{{ unscheduledCount(unscheduledRows.length, isZh) }}</strong>
           <button
             v-for="row in unscheduledRows"
             :key="row.id"
@@ -136,7 +136,7 @@
         </div>
 
         <div v-if="!scheduledTasks.length && !unscheduledRows.length" class="meta-gantt__placeholder">
-          No records found.
+          {{ viewRenderLabel('common.noRecordsFound', isZh) }}
         </div>
       </template>
     </template>
@@ -149,6 +149,13 @@ import type { LinkedRecordSummary, MetaAttachment, MetaField, MetaGanttViewConfi
 import { useLocale } from '../../composables/useLocale'
 import { formatFieldDisplay } from '../utils/field-display'
 import { isSelfTableLinkField, resolveGanttViewConfig } from '../utils/view-config'
+import { managerLabel } from '../utils/meta-manager-labels'
+import {
+  ganttResizeAria,
+  unscheduledCount,
+  viewRenderLabel,
+  viewZoomLabel,
+} from '../utils/meta-view-render-labels'
 
 const props = defineProps<{
   sheetId?: string
@@ -322,9 +329,9 @@ const unscheduledRows = computed(() => {
 const groupedSections = computed(() => {
   const buckets = new Map<string, { key: string; label: string; items: typeof scheduledTasks.value }>()
   for (const item of scheduledTasks.value) {
-    const raw = groupFieldId.value ? item.record.data[groupFieldId.value] : 'All tasks'
+    const raw = groupFieldId.value ? item.record.data[groupFieldId.value] : viewRenderLabel('gantt.allTasks', isZh.value)
     const key = raw === null || raw === undefined || raw === '' ? 'ungrouped' : String(raw)
-    const label = key === 'ungrouped' ? 'Ungrouped' : key
+    const label = key === 'ungrouped' ? viewRenderLabel('gantt.ungrouped', isZh.value) : key
     if (!buckets.has(key)) buckets.set(key, { key, label, items: [] })
     buckets.get(key)?.items.push(item)
   }

--- a/apps/web/src/multitable/components/MetaHierarchyView.vue
+++ b/apps/web/src/multitable/components/MetaHierarchyView.vue
@@ -1,22 +1,22 @@
 <template>
-  <div class="meta-hierarchy" role="tree" aria-label="Hierarchy view">
+  <div class="meta-hierarchy" role="tree" :aria-label="viewRenderLabel('hierarchy.viewAria', isZh)">
     <div class="meta-hierarchy__toolbar">
       <label class="meta-hierarchy__control">
-        <span>Parent field</span>
+        <span>{{ managerLabel('view.parentField', isZh) }}</span>
         <select :value="hierarchyDraft.parentFieldId ?? ''" @change="onPickParentField">
-          <option value="">(auto link field)</option>
+          <option value="">{{ viewRenderLabel('hierarchy.autoLinkField', isZh) }}</option>
           <option v-for="field in linkFields" :key="field.id" :value="field.id">{{ field.name }}</option>
         </select>
       </label>
       <label class="meta-hierarchy__control">
-        <span>Title field</span>
+        <span>{{ managerLabel('view.titleField', isZh) }}</span>
         <select :value="hierarchyDraft.titleFieldId ?? ''" @change="onPickTitleField">
-          <option value="">(auto)</option>
+          <option value="">{{ viewRenderLabel('common.auto', isZh) }}</option>
           <option v-for="field in fields" :key="field.id" :value="field.id">{{ field.name }}</option>
         </select>
       </label>
       <label class="meta-hierarchy__control">
-        <span>Expand depth</span>
+        <span>{{ managerLabel('view.defaultExpandDepth', isZh) }}</span>
         <input
           :value="hierarchyDraft.defaultExpandDepth"
           type="number"
@@ -26,18 +26,18 @@
         />
       </label>
       <label class="meta-hierarchy__control">
-        <span>Orphans</span>
+        <span>{{ managerLabel('view.orphanRecords', isZh) }}</span>
         <select :value="hierarchyDraft.orphanMode" @change="onPickOrphanMode">
-          <option value="root">show at root</option>
-          <option value="hidden">hide</option>
+          <option value="root">{{ viewRenderLabel('hierarchy.showAtRoot', isZh) }}</option>
+          <option value="hidden">{{ viewRenderLabel('hierarchy.hide', isZh) }}</option>
         </select>
       </label>
-      <button v-if="canCreate" class="meta-hierarchy__create" @click="emit('create-record', {})">+ Add root</button>
+      <button v-if="canCreate" class="meta-hierarchy__create" @click="emit('create-record', {})">{{ viewRenderLabel('hierarchy.addRoot', isZh) }}</button>
     </div>
 
     <div v-if="!parentField" class="meta-hierarchy__placeholder">
-      <strong>No parent link field configured.</strong>
-      <span>Add or choose a link field to render parent-child relationships.</span>
+      <strong>{{ viewRenderLabel('hierarchy.noParentConfigured', isZh) }}</strong>
+      <span>{{ viewRenderLabel('hierarchy.parentHelp', isZh) }}</span>
     </div>
 
     <div v-else class="meta-hierarchy__body">
@@ -52,7 +52,7 @@
         @dragover.prevent
         @drop.prevent="onDropToRoot"
       >
-        Drop here to move to root
+        {{ viewRenderLabel('hierarchy.dropToRoot', isZh) }}
       </div>
       <ul v-if="visibleRoots.length" class="meta-hierarchy__list meta-hierarchy__list--root">
         <HierarchyNode
@@ -65,6 +65,7 @@
           :can-edit="canEdit"
           :can-comment="canComment"
           :comment-label="commentsChipLabel"
+          :is-zh="isZh"
           :dragging-record-id="draggingRecordId"
           :comment-presence="commentPresence"
           @toggle="toggleNode"
@@ -76,10 +77,10 @@
           @drop-record="onDropRecord"
         />
       </ul>
-      <div v-else class="meta-hierarchy__empty">No records match this hierarchy view.</div>
+      <div v-else class="meta-hierarchy__empty">{{ viewRenderLabel('hierarchy.empty', isZh) }}</div>
     </div>
 
-    <div v-if="loading" class="meta-hierarchy__loading">Loading...</div>
+    <div v-if="loading" class="meta-hierarchy__loading">{{ viewRenderLabel('common.loading', isZh) }}</div>
   </div>
 </template>
 
@@ -96,6 +97,11 @@ import {
   resolveRecordCommentAffordance,
 } from '../utils/comment-affordance'
 import { commentLabel } from '../utils/meta-comment-labels'
+import { managerLabel } from '../utils/meta-manager-labels'
+import {
+  openRecordCommentsAria,
+  viewRenderLabel,
+} from '../utils/meta-view-render-labels'
 
 type HierarchyNodeModel = {
   record: MetaRecord
@@ -406,6 +412,7 @@ const HierarchyNode: ReturnType<typeof defineComponent> = defineComponent({
     canEdit: { type: Boolean, default: false },
     canComment: { type: Boolean, default: false },
     commentLabel: { type: String, default: 'Comments' },
+    isZh: { type: Boolean, default: false },
     draggingRecordId: { type: String as PropType<string | null>, default: null },
     commentPresence: { type: Object as PropType<Record<string, MultitableCommentPresenceSummary | undefined> | undefined>, default: undefined },
   },
@@ -469,7 +476,7 @@ const HierarchyNode: ReturnType<typeof defineComponent> = defineComponent({
             ? h('button', {
               class: rowCommentButtonClass(node.record.id),
               type: 'button',
-              'aria-label': `Open comments for ${title}`,
+              'aria-label': openRecordCommentsAria(title, nodeProps.isZh),
               onClick: () => nodeEmit('open-comments', node.record.id),
               onKeydown: (event: KeyboardEvent) => handleCommentAffordanceKeydown(event, () => nodeEmit('open-comments', node.record.id)),
             }, [h(MetaCommentActionChip, { label: nodeProps.commentLabel, state: rowCommentAffordance(node.record.id) })])
@@ -479,7 +486,7 @@ const HierarchyNode: ReturnType<typeof defineComponent> = defineComponent({
               class: 'meta-hierarchy__child-btn',
               type: 'button',
               onClick: () => nodeEmit('create-child', node.record.id),
-            }, '+ Child')
+            }, viewRenderLabel('hierarchy.child', nodeProps.isZh))
             : null,
         ]),
         hasChildren && expanded
@@ -493,6 +500,7 @@ const HierarchyNode: ReturnType<typeof defineComponent> = defineComponent({
               canEdit: nodeProps.canEdit,
               canComment: nodeProps.canComment,
               commentLabel: nodeProps.commentLabel,
+              isZh: nodeProps.isZh,
               draggingRecordId: nodeProps.draggingRecordId,
               commentPresence: nodeProps.commentPresence,
               onToggle: (recordId: string) => nodeEmit('toggle', recordId),

--- a/apps/web/src/multitable/components/MetaKanbanView.vue
+++ b/apps/web/src/multitable/components/MetaKanbanView.vue
@@ -2,27 +2,27 @@
   <div class="meta-kanban">
     <div v-if="!groupField" class="meta-kanban__empty">
       <div class="meta-kanban__empty-icon">&#x1F4CA;</div>
-      <p>Select a <strong>select</strong>-type field to group by:</p>
+      <p>{{ viewRenderLabel('kanban.selectFieldPromptPrefix', isZh) }}<strong>{{ fieldTypeLabel('select', isZh) }}</strong>{{ viewRenderLabel('kanban.selectFieldPromptSuffix', isZh) }}</p>
       <select class="meta-kanban__field-select" :value="kanbanDraft.groupFieldId ?? ''" @change="onPickGroupField($event)">
-        <option value="">— Choose field —</option>
+        <option value="">{{ viewRenderLabel('common.chooseField', isZh) }}</option>
         <option v-for="f in selectFields" :key="f.id" :value="f.id">{{ f.name }}</option>
       </select>
-      <p v-if="!selectFields.length" class="meta-kanban__empty-hint">No select-type fields found. Add a select field first.</p>
-      <button v-if="canCreate" class="meta-kanban__header-add" @click="emit('create-record', {})">+ Add record</button>
+      <p v-if="!selectFields.length" class="meta-kanban__empty-hint">{{ viewRenderLabel('kanban.noSelectFields', isZh) }}</p>
+      <button v-if="canCreate" class="meta-kanban__header-add" @click="emit('create-record', {})">{{ viewRenderLabel('common.addRecord', isZh) }}</button>
     </div>
 
     <template v-else>
       <div class="meta-kanban__header">
         <label class="meta-kanban__header-field">
-          <span>Group</span>
+          <span>{{ viewRenderLabel('gantt.group', isZh) }}</span>
           <select class="meta-kanban__field-select" :value="kanbanDraft.groupFieldId ?? ''" @change="onPickGroupField($event)">
-            <option value="">(none)</option>
+            <option value="">{{ viewRenderLabel('common.none', isZh) }}</option>
             <option v-for="field in selectFields" :key="field.id" :value="field.id">{{ field.name }}</option>
           </select>
         </label>
-        <span class="meta-kanban__group-label">Grouped by: <strong>{{ groupField.name }}</strong></span>
+        <span class="meta-kanban__group-label">{{ viewRenderLabel('kanban.groupedBy', isZh) }} <strong>{{ groupField.name }}</strong></span>
         <details class="meta-kanban__field-picker">
-          <summary>Card fields ({{ previewFields.length }})</summary>
+          <summary>{{ cardFieldsSummary(previewFields.length, isZh) }}</summary>
           <div class="meta-kanban__field-picker-list">
             <label v-for="field in previewFieldCandidates" :key="field.id" class="meta-kanban__field-picker-item">
               <input
@@ -34,14 +34,14 @@
             </label>
           </div>
         </details>
-        <button v-if="canCreate" class="meta-kanban__header-add" @click="emit('create-record', {})">+ Add record</button>
-        <button class="meta-kanban__change-btn" @click="onClearGroupField">Clear</button>
+        <button v-if="canCreate" class="meta-kanban__header-add" @click="emit('create-record', {})">{{ viewRenderLabel('common.addRecord', isZh) }}</button>
+        <button class="meta-kanban__change-btn" @click="onClearGroupField">{{ viewRenderLabel('kanban.clear', isZh) }}</button>
       </div>
 
       <div class="meta-kanban__board">
         <div class="meta-kanban__column">
           <div class="meta-kanban__column-header meta-kanban__column-header--uncategorized">
-            <span>Uncategorized</span>
+            <span>{{ viewRenderLabel('kanban.uncategorized', isZh) }}</span>
             <span class="meta-kanban__count">{{ uncategorized.length }}</span>
           </div>
           <div class="meta-kanban__cards" :class="{ 'meta-kanban__cards--drag-over': dragOverColumn === '__uncategorized__' }" @dragover.prevent="dragOverColumn = '__uncategorized__'" @dragleave="dragOverColumn = null" @drop="dragOverColumn = null; onDrop(null, $event)">
@@ -64,7 +64,7 @@
                   class="meta-kanban__comment-btn"
                   :class="rowCommentButtonClass(row.id)"
                   type="button"
-                  :aria-label="`Open comments for ${cardTitle(row)}`"
+                  :aria-label="openRecordCommentsAria(cardTitle(row), isZh)"
                   @click.stop="emit('open-comments', row.id)"
                   @keydown="onRowCommentKeydown($event, row.id)"
                 >
@@ -82,7 +82,7 @@
                     type="button"
                     class="meta-kanban__field-comment-btn"
                     :class="fieldCommentButtonClass(row.id, f.id)"
-                    :aria-label="`Open comments for ${f.name} on ${cardTitle(row)}`"
+                    :aria-label="openFieldCommentsForRecordAria(f.name, cardTitle(row), isZh)"
                     @click.stop="emit('open-field-comments', { recordId: row.id, fieldId: f.id })"
                     @keydown="onFieldCommentKeydown($event, row.id, f.id)"
                   >
@@ -92,10 +92,10 @@
               </div>
             </div>
             <div v-if="!uncategorized.length" class="meta-kanban__drop-hint">
-              {{ canEdit ? 'Drop a card here or add a new record' : 'No cards in this column' }}
+              {{ canEdit ? viewRenderLabel('kanban.dropOrAdd', isZh) : viewRenderLabel('kanban.noCards', isZh) }}
             </div>
           </div>
-          <button v-if="canCreate" class="meta-kanban__add-btn" @click="emit('create-record', {})">+ Add</button>
+          <button v-if="canCreate" class="meta-kanban__add-btn" @click="emit('create-record', {})">{{ viewRenderLabel('common.add', isZh) }}</button>
         </div>
 
         <div v-for="opt in groupOptions" :key="opt.value" class="meta-kanban__column">
@@ -123,7 +123,7 @@
                   class="meta-kanban__comment-btn"
                   :class="rowCommentButtonClass(row.id)"
                   type="button"
-                  :aria-label="`Open comments for ${cardTitle(row)}`"
+                  :aria-label="openRecordCommentsAria(cardTitle(row), isZh)"
                   @click.stop="emit('open-comments', row.id)"
                   @keydown="onRowCommentKeydown($event, row.id)"
                 >
@@ -141,7 +141,7 @@
                     type="button"
                     class="meta-kanban__field-comment-btn"
                     :class="fieldCommentButtonClass(row.id, f.id)"
-                    :aria-label="`Open comments for ${f.name} on ${cardTitle(row)}`"
+                    :aria-label="openFieldCommentsForRecordAria(f.name, cardTitle(row), isZh)"
                     @click.stop="emit('open-field-comments', { recordId: row.id, fieldId: f.id })"
                     @keydown="onFieldCommentKeydown($event, row.id, f.id)"
                   >
@@ -151,15 +151,15 @@
               </div>
             </div>
             <div v-if="!columnRows(opt.value).length" class="meta-kanban__drop-hint">
-              {{ canEdit ? 'Drop a card here to update its group' : 'No cards in this column' }}
+              {{ canEdit ? viewRenderLabel('kanban.dropToUpdate', isZh) : viewRenderLabel('kanban.noCards', isZh) }}
             </div>
           </div>
-          <button v-if="canCreate" class="meta-kanban__add-btn" @click="emit('create-record', { [groupField!.id]: opt.value })">+ Add</button>
+          <button v-if="canCreate" class="meta-kanban__add-btn" @click="emit('create-record', { [groupField!.id]: opt.value })">{{ viewRenderLabel('common.add', isZh) }}</button>
         </div>
       </div>
     </template>
 
-    <div v-if="loading" class="meta-kanban__loading">Loading...</div>
+    <div v-if="loading" class="meta-kanban__loading">{{ viewRenderLabel('common.loading', isZh) }}</div>
   </div>
 </template>
 
@@ -178,6 +178,13 @@ import {
   resolveRecordCommentAffordance,
 } from '../utils/comment-affordance'
 import { commentLabel } from '../utils/meta-comment-labels'
+import { fieldTypeLabel } from '../utils/meta-core-labels'
+import {
+  cardFieldsSummary,
+  openFieldCommentsForRecordAria,
+  openRecordCommentsAria,
+  viewRenderLabel,
+} from '../utils/meta-view-render-labels'
 
 const props = defineProps<{
   rows: MetaRecord[]

--- a/apps/web/src/multitable/components/MetaTimelineView.vue
+++ b/apps/web/src/multitable/components/MetaTimelineView.vue
@@ -1,26 +1,26 @@
 <template>
-  <div class="meta-timeline" role="region" aria-label="Timeline view">
-    <div v-if="loading" class="meta-timeline__loading">Loading...</div>
+  <div class="meta-timeline" role="region" :aria-label="viewRenderLabel('timeline.viewAria', isZh)">
+    <div v-if="loading" class="meta-timeline__loading">{{ viewRenderLabel('common.loading', isZh) }}</div>
     <template v-else>
       <div class="meta-timeline__config">
         <label class="meta-timeline__config-label">
-          Start date
+          {{ viewRenderLabel('timeline.startDate', isZh) }}
           <select class="meta-timeline__config-select" :value="startFieldId" @change="onStartFieldChange">
-            <option value="">— select —</option>
+            <option value="">{{ viewRenderLabel('common.chooseField', isZh) }}</option>
             <option v-for="f in dateFields" :key="f.id" :value="f.id">{{ f.name }}</option>
           </select>
         </label>
         <label class="meta-timeline__config-label">
-          End date
+          {{ viewRenderLabel('timeline.endDate', isZh) }}
           <select class="meta-timeline__config-select" :value="endFieldId" @change="onEndFieldChange">
-            <option value="">— select —</option>
+            <option value="">{{ viewRenderLabel('common.chooseField', isZh) }}</option>
             <option v-for="f in dateFields" :key="f.id" :value="f.id">{{ f.name }}</option>
           </select>
         </label>
         <label class="meta-timeline__config-label">
-          Label field
+          {{ managerLabel('view.labelField', isZh) }}
           <select class="meta-timeline__config-select" :value="labelFieldId" @change="onLabelFieldChange">
-            <option value="">(auto)</option>
+            <option value="">{{ viewRenderLabel('common.auto', isZh) }}</option>
             <option v-for="f in labelFields" :key="f.id" :value="f.id">{{ f.name }}</option>
           </select>
           <span class="meta-timeline__config-hint">
@@ -28,34 +28,34 @@
           </span>
         </label>
         <label class="meta-timeline__config-label">
-          Zoom
+          {{ managerLabel('view.zoom', isZh) }}
           <select class="meta-timeline__config-select" :value="zoom" @change="onZoomChange">
-            <option value="day">Day</option>
-            <option value="week">Week</option>
-            <option value="month">Month</option>
+            <option value="day">{{ viewZoomLabel('day', isZh) }}</option>
+            <option value="week">{{ viewZoomLabel('week', isZh) }}</option>
+            <option value="month">{{ viewZoomLabel('month', isZh) }}</option>
           </select>
           <span class="meta-timeline__config-hint">
-            Axis spacing follows the selected zoom level.
+            {{ viewRenderLabel('timeline.axisZoomHint', isZh) }}
           </span>
         </label>
-        <button v-if="canCreate" class="meta-timeline__create-btn" @click="onQuickCreate">+ Add record</button>
+        <button v-if="canCreate" class="meta-timeline__create-btn" @click="onQuickCreate">{{ viewRenderLabel('common.addRecord', isZh) }}</button>
       </div>
 
       <div v-if="!startFieldId || !endFieldId" class="meta-timeline__placeholder">
-        Select start and end date fields to display the timeline.
-        <button v-if="canCreate" class="meta-timeline__placeholder-action" @click="onQuickCreate">Create record</button>
+        {{ viewRenderLabel('timeline.selectStartEnd', isZh) }}
+        <button v-if="canCreate" class="meta-timeline__placeholder-action" @click="onQuickCreate">{{ viewRenderLabel('common.createRecord', isZh) }}</button>
       </div>
 
       <template v-else>
         <div class="meta-timeline__header">
           <div class="meta-timeline__label-col">
-            <span>Record</span>
+            <span>{{ viewRenderLabel('timeline.record', isZh) }}</span>
             <span class="meta-timeline__header-meta">
               {{ labelFieldSummary }}
             </span>
           </div>
           <div class="meta-timeline__axis">
-            <span class="meta-timeline__zoom-badge">Zoom: {{ zoomLabel }}</span>
+            <span class="meta-timeline__zoom-badge">{{ managerLabel('view.zoom', isZh) }}: {{ zoomLabel }}</span>
             <span v-for="tick in axisTicks" :key="tick.key" class="meta-timeline__tick" :style="{ left: tick.left + '%' }">
               {{ tick.label }}
             </span>
@@ -79,7 +79,7 @@
                 v-if="isAttachmentLabel && displayField"
                 :attachments="attachmentItems(item.record, displayField)"
                 variant="compact"
-                empty-label="No attachments"
+                :empty-label="metaCoreLabel('cell.noAttachments', isZh)"
               />
               <template v-else>{{ displayLabel(item.record) }}</template>
             </div>
@@ -88,7 +88,7 @@
                 type="button"
                 class="meta-timeline__comment-btn"
                 :class="rowCommentButtonClass(item.record.id)"
-                :aria-label="`Open comments for ${displayLabel(item.record)}`"
+                :aria-label="openRecordCommentsAria(displayLabel(item.record), isZh)"
                 @click.stop="emit('open-comments', item.record.id)"
                 @keydown="onRowCommentKeydown($event, item.record.id)"
               >
@@ -99,7 +99,7 @@
                 type="button"
                 class="meta-timeline__field-comment-btn"
                 :class="fieldCommentButtonClass(item.record.id)"
-                :aria-label="`Open comments for ${displayField.name}`"
+                :aria-label="openFieldCommentsAria(displayField.name, isZh)"
                 @click.stop="emit('open-field-comments', { recordId: item.record.id, fieldId: displayField.id })"
                 @keydown="onFieldCommentKeydown($event, item.record.id, displayField.id)"
               >
@@ -121,7 +121,7 @@
         </div>
 
         <div v-if="unscheduledRows.length" class="meta-timeline__unscheduled">
-          <div class="meta-timeline__unscheduled-header">Unscheduled ({{ unscheduledRows.length }})</div>
+          <div class="meta-timeline__unscheduled-header">{{ unscheduledCount(unscheduledRows.length, isZh) }}</div>
           <div
             v-for="row in unscheduledRows"
             :key="row.id"
@@ -138,7 +138,7 @@
                 v-if="isAttachmentLabel && displayField"
                 :attachments="attachmentItems(row, displayField)"
                 variant="compact"
-                empty-label="No attachments"
+                :empty-label="metaCoreLabel('cell.noAttachments', isZh)"
               />
               <template v-else>{{ displayLabel(row) }}</template>
             </div>
@@ -147,7 +147,7 @@
                 type="button"
                 class="meta-timeline__comment-btn"
                 :class="rowCommentButtonClass(row.id)"
-                :aria-label="`Open comments for ${displayLabel(row)}`"
+                :aria-label="openRecordCommentsAria(displayLabel(row), isZh)"
                 @click.stop="emit('open-comments', row.id)"
                 @keydown="onRowCommentKeydown($event, row.id)"
               >
@@ -158,7 +158,7 @@
                 type="button"
                 class="meta-timeline__field-comment-btn"
                 :class="fieldCommentButtonClass(row.id)"
-                :aria-label="`Open comments for ${displayField.name}`"
+                :aria-label="openFieldCommentsAria(displayField.name, isZh)"
                 @click.stop="emit('open-field-comments', { recordId: row.id, fieldId: displayField.id })"
                 @keydown="onFieldCommentKeydown($event, row.id, displayField.id)"
               >
@@ -169,8 +169,8 @@
         </div>
 
         <div v-if="!scheduledRows.length && !unscheduledRows.length" class="meta-timeline__empty">
-          No records found
-          <button v-if="canCreate" class="meta-timeline__placeholder-action" @click="onQuickCreate">Create first record</button>
+          {{ viewRenderLabel('common.noRecordsFound', isZh) }}
+          <button v-if="canCreate" class="meta-timeline__placeholder-action" @click="onQuickCreate">{{ viewRenderLabel('common.createFirstRecord', isZh) }}</button>
         </div>
       </template>
     </template>
@@ -193,6 +193,17 @@ import {
   resolveRecordCommentAffordance,
 } from '../utils/comment-affordance'
 import { commentLabel } from '../utils/meta-comment-labels'
+import { metaCoreLabel } from '../utils/meta-core-labels'
+import { managerLabel } from '../utils/meta-manager-labels'
+import {
+  openFieldCommentsAria,
+  openRecordCommentsAria,
+  timelineAutoUsesFieldHint,
+  timelineLabelSummary,
+  unscheduledCount,
+  viewRenderLabel,
+  viewZoomLabel,
+} from '../utils/meta-view-render-labels'
 
 const props = defineProps<{
   rows: MetaRecord[]
@@ -279,23 +290,21 @@ const displayField = computed(() =>
 const isAttachmentLabel = computed(() => displayField.value?.type === 'attachment')
 
 const zoomLabel = computed(() => {
-  if (zoom.value === 'day') return 'Day'
-  if (zoom.value === 'month') return 'Month'
-  return 'Week'
+  return viewZoomLabel(zoom.value, isZh.value)
 })
 
 const labelFieldSummary = computed(() => {
-  if (!labelFieldId.value) return 'Label: auto'
+  if (!labelFieldId.value) return timelineLabelSummary('auto', null, isZh.value)
   const field = props.fields.find((item) => item.id === labelFieldId.value)
-  return field ? `Label: ${field.name}` : 'Label: custom'
+  return field ? timelineLabelSummary('field', field.name, isZh.value) : timelineLabelSummary('custom', null, isZh.value)
 })
 
 const labelFieldHint = computed(() => {
   if (!labelFieldId.value) {
     const field = displayField.value
-    return field ? `Auto uses ${field.name} when available.` : 'Auto falls back to record id.'
+    return field ? timelineAutoUsesFieldHint(field.name, isZh.value) : viewRenderLabel('timeline.autoRecordIdHint', isZh.value)
   }
-  return 'Timeline labels use this field across rows and unscheduled items.'
+  return viewRenderLabel('timeline.labelFieldHint', isZh.value)
 })
 
 function rowCommentAffordance(recordId: string) {

--- a/apps/web/src/multitable/utils/meta-view-render-labels.ts
+++ b/apps/web/src/multitable/utils/meta-view-render-labels.ts
@@ -1,0 +1,355 @@
+// Visual view render chrome string table (final audit Slice B).
+//
+// Scope: runtime chrome inside Calendar/Gallery/Timeline/Gantt/Hierarchy/
+// Kanban/Dashboard/ChartRenderer. User-authored values stay raw: field names,
+// record titles, view/dashboard/chart names, option values, attachment
+// filenames, holiday/lunar labels, chart data labels, dates, IDs, and data-*.
+//
+// `common.*` means common inside this view-render module only. It is not an
+// app-wide shared namespace.
+
+export type MetaViewRenderLabelKey =
+  | 'common.loading'
+  | 'common.chooseField'
+  | 'common.select'
+  | 'common.auto'
+  | 'common.none'
+  | 'common.addRecord'
+  | 'common.add'
+  | 'common.createRecord'
+  | 'common.createFirstRecord'
+  | 'common.noRecordsFound'
+  | 'calendar.today'
+  | 'calendar.view'
+  | 'calendar.month'
+  | 'calendar.week'
+  | 'calendar.day'
+  | 'calendar.change'
+  | 'calendar.newRecord'
+  | 'calendar.selectDateField'
+  | 'calendar.noRecordsOnDay'
+  | 'gallery.title'
+  | 'gallery.cover'
+  | 'gallery.columns'
+  | 'gallery.cardSize'
+  | 'gallery.noRecordsTitle'
+  | 'gallery.noRecordsHint'
+  | 'gallery.prev'
+  | 'gallery.next'
+  | 'timeline.viewAria'
+  | 'timeline.startDate'
+  | 'timeline.endDate'
+  | 'timeline.record'
+  | 'timeline.axisZoomHint'
+  | 'timeline.selectStartEnd'
+  | 'timeline.autoRecordIdHint'
+  | 'timeline.labelFieldHint'
+  | 'gantt.viewAria'
+  | 'gantt.start'
+  | 'gantt.end'
+  | 'gantt.title'
+  | 'gantt.progress'
+  | 'gantt.group'
+  | 'gantt.dependencies'
+  | 'gantt.addTask'
+  | 'gantt.selectStartEnd'
+  | 'gantt.task'
+  | 'gantt.to'
+  | 'gantt.allTasks'
+  | 'gantt.ungrouped'
+  | 'hierarchy.viewAria'
+  | 'hierarchy.autoLinkField'
+  | 'hierarchy.showAtRoot'
+  | 'hierarchy.hide'
+  | 'hierarchy.addRoot'
+  | 'hierarchy.noParentConfigured'
+  | 'hierarchy.parentHelp'
+  | 'hierarchy.dropToRoot'
+  | 'hierarchy.empty'
+  | 'hierarchy.child'
+  | 'kanban.selectFieldPromptPrefix'
+  | 'kanban.selectFieldPromptSuffix'
+  | 'kanban.noSelectFields'
+  | 'kanban.groupedBy'
+  | 'kanban.cardFields'
+  | 'kanban.clear'
+  | 'kanban.uncategorized'
+  | 'kanban.dropOrAdd'
+  | 'kanban.dropToUpdate'
+  | 'kanban.noCards'
+  | 'dashboard.rename'
+  | 'dashboard.addPanel'
+  | 'dashboard.newDashboard'
+  | 'dashboard.loadingDashboard'
+  | 'dashboard.empty'
+  | 'dashboard.loadingChart'
+  | 'dashboard.addChartPanel'
+  | 'dashboard.noCharts'
+  | 'chart.label'
+  | 'chart.value'
+
+export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
+  'common.loading',
+  'common.chooseField',
+  'common.select',
+  'common.auto',
+  'common.none',
+  'common.addRecord',
+  'common.add',
+  'common.createRecord',
+  'common.createFirstRecord',
+  'common.noRecordsFound',
+  'calendar.today',
+  'calendar.view',
+  'calendar.month',
+  'calendar.week',
+  'calendar.day',
+  'calendar.change',
+  'calendar.newRecord',
+  'calendar.selectDateField',
+  'calendar.noRecordsOnDay',
+  'gallery.title',
+  'gallery.cover',
+  'gallery.columns',
+  'gallery.cardSize',
+  'gallery.noRecordsTitle',
+  'gallery.noRecordsHint',
+  'gallery.prev',
+  'gallery.next',
+  'timeline.viewAria',
+  'timeline.startDate',
+  'timeline.endDate',
+  'timeline.record',
+  'timeline.axisZoomHint',
+  'timeline.selectStartEnd',
+  'timeline.autoRecordIdHint',
+  'timeline.labelFieldHint',
+  'gantt.viewAria',
+  'gantt.start',
+  'gantt.end',
+  'gantt.title',
+  'gantt.progress',
+  'gantt.group',
+  'gantt.dependencies',
+  'gantt.addTask',
+  'gantt.selectStartEnd',
+  'gantt.task',
+  'gantt.to',
+  'gantt.allTasks',
+  'gantt.ungrouped',
+  'hierarchy.viewAria',
+  'hierarchy.autoLinkField',
+  'hierarchy.showAtRoot',
+  'hierarchy.hide',
+  'hierarchy.addRoot',
+  'hierarchy.noParentConfigured',
+  'hierarchy.parentHelp',
+  'hierarchy.dropToRoot',
+  'hierarchy.empty',
+  'hierarchy.child',
+  'kanban.selectFieldPromptPrefix',
+  'kanban.selectFieldPromptSuffix',
+  'kanban.noSelectFields',
+  'kanban.groupedBy',
+  'kanban.cardFields',
+  'kanban.clear',
+  'kanban.uncategorized',
+  'kanban.dropOrAdd',
+  'kanban.dropToUpdate',
+  'kanban.noCards',
+  'dashboard.rename',
+  'dashboard.addPanel',
+  'dashboard.newDashboard',
+  'dashboard.loadingDashboard',
+  'dashboard.empty',
+  'dashboard.loadingChart',
+  'dashboard.addChartPanel',
+  'dashboard.noCharts',
+  'chart.label',
+  'chart.value',
+]
+
+const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
+  'common.loading': { en: 'Loading...', zh: '正在加载...' },
+  'common.chooseField': { en: '— Choose field —', zh: '— 选择字段 —' },
+  'common.select': { en: 'select', zh: '选择' },
+  'common.auto': { en: 'Auto', zh: '自动' },
+  'common.none': { en: 'None', zh: '无' },
+  'common.addRecord': { en: '+ Add record', zh: '+ 添加记录' },
+  'common.add': { en: '+ Add', zh: '+ 添加' },
+  'common.createRecord': { en: 'Create record', zh: '创建记录' },
+  'common.createFirstRecord': { en: 'Create first record', zh: '创建第一条记录' },
+  'common.noRecordsFound': { en: 'No records found', zh: '未找到记录' },
+  'calendar.today': { en: 'Today', zh: '今天' },
+  'calendar.view': { en: 'View', zh: '视图' },
+  'calendar.month': { en: 'Month', zh: '月' },
+  'calendar.week': { en: 'Week', zh: '周' },
+  'calendar.day': { en: 'Day', zh: '日' },
+  'calendar.change': { en: 'Change', zh: '更改' },
+  'calendar.newRecord': { en: '+ New record', zh: '+ 新建记录' },
+  'calendar.selectDateField': { en: 'Select a date field to use for the calendar:', zh: '选择一个日期字段用于日历：' },
+  'calendar.noRecordsOnDay': { en: 'No records on this day', zh: '这一天没有记录' },
+  'gallery.title': { en: 'Title', zh: '标题' },
+  'gallery.cover': { en: 'Cover', zh: '封面' },
+  'gallery.columns': { en: 'Columns', zh: '列数' },
+  'gallery.cardSize': { en: 'Card size', zh: '卡片尺寸' },
+  'gallery.noRecordsTitle': { en: 'No records to display', zh: '没有可显示的记录' },
+  'gallery.noRecordsHint': { en: 'Add records to see them as cards here', zh: '添加记录后将在此显示为卡片' },
+  'gallery.prev': { en: 'Prev', zh: '上一页' },
+  'gallery.next': { en: 'Next', zh: '下一页' },
+  'timeline.viewAria': { en: 'Timeline view', zh: '时间轴视图' },
+  'timeline.startDate': { en: 'Start date', zh: '开始日期' },
+  'timeline.endDate': { en: 'End date', zh: '结束日期' },
+  'timeline.record': { en: 'Record', zh: '记录' },
+  'timeline.axisZoomHint': { en: 'Axis spacing follows the selected zoom level.', zh: '坐标轴间距跟随所选缩放级别。' },
+  'timeline.selectStartEnd': { en: 'Select start and end date fields to display the timeline.', zh: '选择开始和结束日期字段以显示时间轴。' },
+  'timeline.autoRecordIdHint': { en: 'Auto falls back to record id.', zh: '自动模式会回退到记录 ID。' },
+  'timeline.labelFieldHint': { en: 'Timeline labels use this field across rows and unscheduled items.', zh: '时间轴标签将在行和未排期项目中使用此字段。' },
+  'gantt.viewAria': { en: 'Gantt view', zh: '甘特视图' },
+  'gantt.start': { en: 'Start', zh: '开始' },
+  'gantt.end': { en: 'End', zh: '结束' },
+  'gantt.title': { en: 'Title', zh: '标题' },
+  'gantt.progress': { en: 'Progress', zh: '进度' },
+  'gantt.group': { en: 'Group', zh: '分组' },
+  'gantt.dependencies': { en: 'Dependencies', zh: '依赖' },
+  'gantt.addTask': { en: '+ Add task', zh: '+ 添加任务' },
+  'gantt.selectStartEnd': { en: 'Select start and end date fields to display Gantt tasks.', zh: '选择开始和结束日期字段以显示甘特任务。' },
+  'gantt.task': { en: 'Task', zh: '任务' },
+  'gantt.to': { en: 'to', zh: '至' },
+  'gantt.allTasks': { en: 'All tasks', zh: '全部任务' },
+  'gantt.ungrouped': { en: 'Ungrouped', zh: '未分组' },
+  'hierarchy.viewAria': { en: 'Hierarchy view', zh: '层级视图' },
+  'hierarchy.autoLinkField': { en: '(auto link field)', zh: '自动关联字段' },
+  'hierarchy.showAtRoot': { en: 'show at root', zh: '显示在根级' },
+  'hierarchy.hide': { en: 'hide', zh: '隐藏' },
+  'hierarchy.addRoot': { en: '+ Add root', zh: '+ 添加根记录' },
+  'hierarchy.noParentConfigured': { en: 'No parent link field configured.', zh: '未配置父级关联字段。' },
+  'hierarchy.parentHelp': { en: 'Add or choose a link field to render parent-child relationships.', zh: '添加或选择一个关联字段以渲染父子关系。' },
+  'hierarchy.dropToRoot': { en: 'Drop here to move to root', zh: '拖到此处移动到根级' },
+  'hierarchy.empty': { en: 'No records match this hierarchy view.', zh: '没有匹配此层级视图的记录。' },
+  'hierarchy.child': { en: '+ Child', zh: '+ 子记录' },
+  'kanban.selectFieldPromptPrefix': { en: 'Select a ', zh: '选择一个' },
+  'kanban.selectFieldPromptSuffix': { en: '-type field to group by:', zh: '类型字段进行分组：' },
+  'kanban.noSelectFields': { en: 'No select-type fields found. Add a select field first.', zh: '未找到单选字段。请先添加一个单选字段。' },
+  'kanban.groupedBy': { en: 'Grouped by:', zh: '分组依据：' },
+  'kanban.cardFields': { en: 'Card fields', zh: '卡片字段' },
+  'kanban.clear': { en: 'Clear', zh: '清除' },
+  'kanban.uncategorized': { en: 'Uncategorized', zh: '未分类' },
+  'kanban.dropOrAdd': { en: 'Drop a card here or add a new record', zh: '将卡片拖到此处，或添加新记录' },
+  'kanban.dropToUpdate': { en: 'Drop a card here to update its group', zh: '将卡片拖到此处以更新其分组' },
+  'kanban.noCards': { en: 'No cards in this column', zh: '此列没有卡片' },
+  'dashboard.rename': { en: 'Rename', zh: '重命名' },
+  'dashboard.addPanel': { en: '+ Add Panel', zh: '+ 添加面板' },
+  'dashboard.newDashboard': { en: '+ New Dashboard', zh: '+ 新建仪表板' },
+  'dashboard.loadingDashboard': { en: 'Loading dashboard...', zh: '正在加载仪表板...' },
+  'dashboard.empty': { en: 'No dashboards yet. Create your first dashboard.', zh: '暂无仪表板。创建你的第一个仪表板。' },
+  'dashboard.loadingChart': { en: 'Loading chart...', zh: '正在加载图表...' },
+  'dashboard.addChartPanel': { en: 'Add Chart Panel', zh: '添加图表面板' },
+  'dashboard.noCharts': { en: 'No charts available. Create a chart first.', zh: '暂无可用图表。请先创建一个图表。' },
+  'chart.label': { en: 'Label', zh: '标签' },
+  'chart.value': { en: 'Value', zh: '值' },
+}
+
+export function viewRenderLabel(key: MetaViewRenderLabelKey, isZh: boolean): string {
+  const entry = LABELS[key]
+  return isZh ? entry.zh : entry.en
+}
+
+export type ViewRenderSize = 'small' | 'medium' | 'large'
+export type ViewRenderZoom = 'day' | 'week' | 'month'
+export type CalendarViewMode = 'month' | 'week' | 'day'
+
+export function viewSizeLabel(size: ViewRenderSize | (string & {}), isZh: boolean): string {
+  if (size === 'small') return isZh ? '小' : 'Small'
+  if (size === 'large') return isZh ? '大' : 'Large'
+  if (size === 'medium') return isZh ? '中' : 'Medium'
+  return String(size)
+}
+
+export function viewZoomLabel(zoom: ViewRenderZoom | (string & {}), isZh: boolean): string {
+  if (zoom === 'day') return isZh ? '日' : 'Day'
+  if (zoom === 'month') return isZh ? '月' : 'Month'
+  if (zoom === 'week') return isZh ? '周' : 'Week'
+  return String(zoom)
+}
+
+export function calendarViewModeLabel(mode: CalendarViewMode | (string & {}), isZh: boolean): string {
+  if (mode === 'month') return viewRenderLabel('calendar.month', isZh)
+  if (mode === 'week') return viewRenderLabel('calendar.week', isZh)
+  if (mode === 'day') return viewRenderLabel('calendar.day', isZh)
+  return String(mode)
+}
+
+export function calendarWeekdayShort(index: 0 | 1 | 2 | 3 | 4 | 5 | 6, isZh: boolean): string {
+  const en = ['Sun', 'Mon', 'Tue', 'Wed', 'Thu', 'Fri', 'Sat']
+  const zh = ['周日', '周一', '周二', '周三', '周四', '周五', '周六']
+  return (isZh ? zh : en)[index] ?? String(index)
+}
+
+export function calendarMoreEvents(count: number, isZh: boolean): string {
+  return isZh ? `+${count} 条更多` : `+${count} more`
+}
+
+export function calendarEventCount(count: number, isZh: boolean): string {
+  if (isZh) return `${count} 个事件`
+  return `${count} event${count === 1 ? '' : 's'}`
+}
+
+export function calendarCellAriaLabel(
+  dateLabel: string,
+  annotations: string[],
+  eventCount: number,
+  isZh: boolean,
+): string {
+  const parts = [
+    dateLabel,
+    ...annotations,
+    eventCount > 0 ? calendarEventCount(eventCount, isZh) : null,
+  ].filter((item): item is string => Boolean(item))
+  return parts.join(isZh ? '，' : ', ')
+}
+
+export function openRecordCommentsAria(recordLabel: string, isZh: boolean): string {
+  return isZh ? `打开 ${recordLabel} 的评论` : `Open comments for ${recordLabel}`
+}
+
+export function openFieldCommentsAria(fieldName: string, isZh: boolean): string {
+  return isZh ? `打开 ${fieldName} 的评论` : `Open comments for ${fieldName}`
+}
+
+export function openFieldCommentsForRecordAria(fieldName: string, recordLabel: string, isZh: boolean): string {
+  return isZh ? `打开 ${recordLabel} 中 ${fieldName} 的评论` : `Open comments for ${fieldName} on ${recordLabel}`
+}
+
+export function cardFieldsSummary(count: number, isZh: boolean): string {
+  return isZh ? `卡片字段（${count}）` : `Card fields (${count})`
+}
+
+export function unscheduledCount(count: number, isZh: boolean): string {
+  return isZh ? `未排期（${count}）` : `Unscheduled (${count})`
+}
+
+export function timelineLabelSummary(
+  kind: 'auto' | 'custom' | 'field',
+  fieldName: string | null,
+  isZh: boolean,
+): string {
+  if (kind === 'field' && fieldName) return isZh ? `标签：${fieldName}` : `Label: ${fieldName}`
+  if (kind === 'custom') return isZh ? '标签：自定义' : 'Label: custom'
+  return isZh ? '标签：自动' : 'Label: auto'
+}
+
+export function timelineAutoUsesFieldHint(fieldName: string, isZh: boolean): string {
+  return isZh ? `自动模式会优先使用 ${fieldName}。` : `Auto uses ${fieldName} when available.`
+}
+
+export function ganttResizeAria(edge: 'start' | 'end', taskLabel: string, isZh: boolean): string {
+  if (edge === 'start') return isZh ? `调整 ${taskLabel} 的开始时间` : `Resize start for ${taskLabel}`
+  return isZh ? `调整 ${taskLabel} 的结束时间` : `Resize end for ${taskLabel}`
+}
+
+// Event-time: generated names are persisted as dashboard data and should not
+// retranslate after creation.
+export function dashboardDefaultName(index: number, isZh: boolean): string {
+  return isZh ? `仪表板 ${index}` : `Dashboard ${index}`
+}

--- a/apps/web/tests/meta-view-render-labels.spec.ts
+++ b/apps/web/tests/meta-view-render-labels.spec.ts
@@ -1,0 +1,88 @@
+import { describe, expect, it } from 'vitest'
+import {
+  VIEW_RENDER_LABEL_KEYS,
+  calendarCellAriaLabel,
+  calendarEventCount,
+  calendarMoreEvents,
+  calendarViewModeLabel,
+  calendarWeekdayShort,
+  cardFieldsSummary,
+  dashboardDefaultName,
+  ganttResizeAria,
+  openFieldCommentsAria,
+  openFieldCommentsForRecordAria,
+  openRecordCommentsAria,
+  timelineAutoUsesFieldHint,
+  timelineLabelSummary,
+  unscheduledCount,
+  viewRenderLabel,
+  viewSizeLabel,
+  viewZoomLabel,
+} from '../src/multitable/utils/meta-view-render-labels'
+
+describe('meta-view-render-labels', () => {
+  it('exposes all view-render keys in both locales', () => {
+    expect(VIEW_RENDER_LABEL_KEYS.length).toBeGreaterThan(70)
+    for (const key of VIEW_RENDER_LABEL_KEYS) {
+      expect(viewRenderLabel(key, false)).toBeTruthy()
+      expect(viewRenderLabel(key, true)).toBeTruthy()
+    }
+  })
+
+  it('localizes common static chrome', () => {
+    expect(viewRenderLabel('common.loading', false)).toBe('Loading...')
+    expect(viewRenderLabel('common.loading', true)).toBe('正在加载...')
+    expect(viewRenderLabel('dashboard.addPanel', true)).toBe('+ 添加面板')
+    expect(viewRenderLabel('kanban.uncategorized', true)).toBe('未分类')
+  })
+
+  it('handles size, zoom, view mode, and weekday labels with raw unknown fallbacks', () => {
+    expect(viewSizeLabel('small', false)).toBe('Small')
+    expect(viewSizeLabel('large', true)).toBe('大')
+    expect(viewSizeLabel('giant', true)).toBe('giant')
+    expect(viewZoomLabel('week', false)).toBe('Week')
+    expect(viewZoomLabel('month', true)).toBe('月')
+    expect(viewZoomLabel('quarter', true)).toBe('quarter')
+    expect(calendarViewModeLabel('day', false)).toBe('Day')
+    expect(calendarViewModeLabel('month', true)).toBe('月')
+    expect(calendarViewModeLabel('agenda', true)).toBe('agenda')
+    expect(calendarWeekdayShort(0, false)).toBe('Sun')
+    expect(calendarWeekdayShort(1, true)).toBe('周一')
+  })
+
+  it('formats plural/count labels', () => {
+    expect(calendarMoreEvents(1, false)).toBe('+1 more')
+    expect(calendarMoreEvents(2, true)).toBe('+2 条更多')
+    expect(calendarEventCount(1, false)).toBe('1 event')
+    expect(calendarEventCount(2, false)).toBe('2 events')
+    expect(calendarEventCount(2, true)).toBe('2 个事件')
+    expect(cardFieldsSummary(3, false)).toBe('Card fields (3)')
+    expect(cardFieldsSummary(3, true)).toBe('卡片字段（3）')
+    expect(unscheduledCount(1, false)).toBe('Unscheduled (1)')
+    expect(unscheduledCount(2, true)).toBe('未排期（2）')
+  })
+
+  it('keeps raw field, record, and task labels inside localized chrome', () => {
+    expect(openRecordCommentsAria('客户 A', false)).toBe('Open comments for 客户 A')
+    expect(openRecordCommentsAria('客户 A', true)).toBe('打开 客户 A 的评论')
+    expect(openFieldCommentsAria('状态', true)).toBe('打开 状态 的评论')
+    expect(openFieldCommentsForRecordAria('状态', '客户 A', false)).toBe('Open comments for 状态 on 客户 A')
+    expect(openFieldCommentsForRecordAria('状态', '客户 A', true)).toBe('打开 客户 A 中 状态 的评论')
+    expect(ganttResizeAria('start', '任务 A', false)).toBe('Resize start for 任务 A')
+    expect(ganttResizeAria('end', '任务 A', true)).toBe('调整 任务 A 的结束时间')
+  })
+
+  it('formats timeline and calendar helper text', () => {
+    expect(timelineLabelSummary('auto', null, false)).toBe('Label: auto')
+    expect(timelineLabelSummary('custom', null, true)).toBe('标签：自定义')
+    expect(timelineLabelSummary('field', '状态', false)).toBe('Label: 状态')
+    expect(timelineAutoUsesFieldHint('标题', true)).toBe('自动模式会优先使用 标题。')
+    expect(calendarCellAriaLabel('2026年5月22日', ['春节'], 2, true)).toBe('2026年5月22日，春节，2 个事件')
+    expect(calendarCellAriaLabel('May 22, 2026', ['National Day'], 1, false)).toBe('May 22, 2026, National Day, 1 event')
+  })
+
+  it('generates dashboard default names at event time', () => {
+    expect(dashboardDefaultName(2, false)).toBe('Dashboard 2')
+    expect(dashboardDefaultName(2, true)).toBe('仪表板 2')
+  })
+})

--- a/apps/web/tests/multitable-calendar-view.spec.ts
+++ b/apps/web/tests/multitable-calendar-view.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
 import MetaCalendarView from '../src/multitable/components/MetaCalendarView.vue'
+import { useLocale } from '../src/composables/useLocale'
 
 function isoDate(offsetDays = 0): string {
   const date = new Date()
@@ -11,7 +12,9 @@ function isoDate(offsetDays = 0): string {
 
 describe('MetaCalendarView', () => {
   afterEach(() => {
+    useLocale().setLocale('en')
     vi.useRealTimers()
+    document.body.innerHTML = ''
   })
 
   it('renders persisted default view and emits config changes when switching modes', async () => {
@@ -439,5 +442,62 @@ describe('MetaCalendarView', () => {
 
     app.unmount()
     container.remove()
+  })
+
+  it('localizes calendar view chrome while keeping event and holiday names raw', async () => {
+    useLocale().setLocale('zh-CN')
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-02-03T12:00:00Z'))
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaCalendarView, {
+          rows: [
+            {
+              id: 'rec_1',
+              version: 1,
+              data: {
+                fld_title: 'Contract renewal',
+                fld_start: '2026-02-17',
+              },
+            },
+          ],
+          fields: [
+            { id: 'fld_title', name: 'Title', type: 'string' },
+            { id: 'fld_start', name: 'Start', type: 'date' },
+          ],
+          loading: false,
+          canCreate: true,
+          calendarHolidays: [
+            { id: 'holiday_spring', date: '2026-02-17', name: '春节', isWorkingDay: false },
+          ],
+          viewConfig: {
+            dateFieldId: 'fld_start',
+            titleFieldId: 'fld_title',
+            defaultView: 'month',
+            weekStartsOn: 0,
+          },
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    expect(container.textContent).toContain('今天')
+    expect(container.textContent).toContain('+ 添加记录')
+    expect(container.textContent).toContain('视图')
+    expect(container.textContent).toContain('更改')
+    expect(container.textContent).toContain('春节')
+    expect(container.textContent).toContain('Contract renewal')
+    expect(container.querySelectorAll('[aria-label]')).toHaveLength(42)
+    expect(container.querySelectorAll('[title]')).toHaveLength(0)
+    expect(container.querySelectorAll('[placeholder]')).toHaveLength(0)
+    expect(container.querySelector('.meta-calendar__cell')?.getAttribute('aria-label')).toContain('2026年')
+
+    app.unmount()
   })
 })

--- a/apps/web/tests/multitable-chart-renderer.spec.ts
+++ b/apps/web/tests/multitable-chart-renderer.spec.ts
@@ -7,6 +7,7 @@ function flushPromises() {
 
 import MetaChartRenderer from '../src/multitable/components/MetaChartRenderer.vue'
 import type { ChartData, ChartDisplayConfig } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
 
 function mount(props: Record<string, unknown>) {
   const container = document.createElement('div')
@@ -59,6 +60,7 @@ const tableData: ChartData = {
 
 describe('MetaChartRenderer', () => {
   afterEach(() => {
+    useLocale().setLocale('en')
     document.body.innerHTML = ''
   })
 
@@ -140,5 +142,19 @@ describe('MetaChartRenderer', () => {
 
     const title = container.querySelector('.meta-chart__title')
     expect(title?.textContent).toBe('Sales Overview')
+  })
+
+  it('localizes table headers while keeping chart data labels raw', async () => {
+    useLocale().setLocale('zh-CN')
+    const { container } = mount({ chartData: tableData })
+    await flushPromises()
+
+    expect(container.querySelectorAll('th')[0]?.textContent).toBe('标签')
+    expect(container.querySelectorAll('th')[1]?.textContent).toBe('值')
+    expect(container.textContent).toContain('Row 1')
+    expect(container.textContent).toContain('100')
+    expect(container.querySelectorAll('[aria-label]')).toHaveLength(0)
+    expect(container.querySelectorAll('[title]')).toHaveLength(0)
+    expect(container.querySelectorAll('[placeholder]')).toHaveLength(0)
   })
 })

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -8,6 +8,7 @@ function flushPromises() {
 import MetaDashboardView from '../src/multitable/components/MetaDashboardView.vue'
 import { MultitableApiClient } from '../src/multitable/api/client'
 import type { Dashboard, ChartConfig, ChartData } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
 
 function fakeDashboard(overrides: Partial<Dashboard> = {}): Dashboard {
   return {
@@ -82,6 +83,7 @@ function mount(props: Record<string, unknown>) {
 
 describe('MetaDashboardView', () => {
   afterEach(() => {
+    useLocale().setLocale('en')
     document.body.innerHTML = ''
     vi.restoreAllMocks()
   })
@@ -179,5 +181,37 @@ describe('MetaDashboardView', () => {
     expect(patchCalls.length).toBe(1)
     const body = JSON.parse(patchCalls[0][1].body as string)
     expect(body.panels[0].size).toBe('large')
+  })
+
+  it('localizes dashboard chrome and generated dashboard name while keeping chart names raw', async () => {
+    useLocale().setLocale('zh-CN')
+    const chart = fakeChart({ name: 'Sales Chart' })
+    const { client, fetchFn } = mockClient([fakeDashboard()], [chart])
+    const { container } = mount({ sheetId: 'sheet_1', client })
+    await flushPromises()
+
+    expect(container.textContent).toContain('重命名')
+    expect(container.textContent).toContain('+ 添加面板')
+    expect(container.textContent).toContain('+ 新建仪表板')
+    expect(container.textContent).toContain('Sales Chart')
+    expect(container.textContent).toContain('中')
+
+    const addPanelBtn = container.querySelector('[data-action="add-panel"]') as HTMLButtonElement
+    addPanelBtn.click()
+    await flushPromises()
+    expect(container.textContent).toContain('添加图表面板')
+
+    const createBtn = container.querySelector('[data-action="create-dashboard"]') as HTMLButtonElement
+    createBtn.click()
+    await flushPromises()
+    const postCalls = fetchFn.mock.calls.filter(
+      ([url, init]: [string, RequestInit?]) => url.includes('/dashboards') && init?.method === 'POST',
+    )
+    const body = JSON.parse(postCalls[0][1].body as string)
+    expect(body.name).toBe('仪表板 2')
+    expect(container.querySelector('[data-action="rename"]')?.getAttribute('title')).toBe('重命名')
+    expect(container.querySelectorAll('[aria-label]')).toHaveLength(0)
+    expect(container.querySelectorAll('[title]')).toHaveLength(1)
+    expect(container.querySelectorAll('[placeholder]')).toHaveLength(0)
   })
 })

--- a/apps/web/tests/multitable-gallery-view.spec.ts
+++ b/apps/web/tests/multitable-gallery-view.spec.ts
@@ -1,8 +1,15 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
 import MetaGalleryView from '../src/multitable/components/MetaGalleryView.vue'
+import { useLocale } from '../src/composables/useLocale'
 
 describe('MetaGalleryView', () => {
+  afterEach(() => {
+    useLocale().setLocale('en')
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
   it('renders persisted gallery config including cover image and configured fields', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)
@@ -134,5 +141,55 @@ describe('MetaGalleryView', () => {
 
     app.unmount()
     container.remove()
+  })
+
+  it('localizes gallery chrome while keeping field and card values raw', async () => {
+    useLocale().setLocale('zh-CN')
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaGalleryView, {
+          rows: [],
+          fields: [
+            { id: 'fld_title', name: 'Title', type: 'string' },
+            { id: 'fld_cover', name: 'Cover', type: 'attachment' },
+            { id: 'fld_status', name: 'Status', type: 'string' },
+          ],
+          loading: false,
+          canCreate: true,
+          currentPage: 1,
+          totalPages: 2,
+          viewConfig: {
+            titleFieldId: 'fld_title',
+            coverFieldId: 'fld_cover',
+            fieldIds: ['fld_status'],
+            columns: 2,
+            cardSize: 'large',
+          },
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    expect(container.textContent).toContain('标题')
+    expect(container.textContent).toContain('封面')
+    expect(container.textContent).toContain('列数')
+    expect(container.textContent).toContain('卡片尺寸')
+    expect(container.textContent).toContain('大')
+    expect(container.textContent).toContain('卡片字段（1）')
+    expect(container.textContent).toContain('没有可显示的记录')
+    expect(container.textContent).toContain('创建第一条记录')
+    expect(container.textContent).toContain('上一页')
+    expect(container.textContent).toContain('下一页')
+    expect(container.textContent).toContain('Status')
+    expect(container.querySelectorAll('[aria-label]')).toHaveLength(0)
+    expect(container.querySelectorAll('[title]')).toHaveLength(0)
+    expect(container.querySelectorAll('[placeholder]')).toHaveLength(0)
+
+    app.unmount()
   })
 })

--- a/apps/web/tests/multitable-gantt-view.spec.ts
+++ b/apps/web/tests/multitable-gantt-view.spec.ts
@@ -2,9 +2,11 @@ import { createApp, h, nextTick } from 'vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import MetaGanttView from '../src/multitable/components/MetaGanttView.vue'
 import { resolveGanttViewConfig } from '../src/multitable/utils/view-config'
+import { useLocale } from '../src/composables/useLocale'
 
 describe('MetaGanttView', () => {
   afterEach(() => {
+    useLocale().setLocale('en')
     document.body.innerHTML = ''
     vi.restoreAllMocks()
   })
@@ -843,6 +845,75 @@ describe('MetaGanttView', () => {
     const backwardArrows = arrows.filter((arrow) => arrow.classList.contains('meta-gantt__dependency-arrow--backward'))
     expect(arrows).toHaveLength(2)
     expect(backwardArrows).toHaveLength(1)
+
+    app.unmount()
+  })
+
+  it('localizes Gantt chrome while keeping task and group values raw', async () => {
+    useLocale().setLocale('zh-CN')
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaGanttView, {
+          loading: false,
+          canCreate: true,
+          canEdit: true,
+          fields: [
+            { id: 'fld_name', name: 'Name', type: 'string' },
+            { id: 'fld_start', name: 'Start', type: 'date' },
+            { id: 'fld_end', name: 'End', type: 'date' },
+            { id: 'fld_status', name: 'Status', type: 'select' },
+          ],
+          rows: [
+            {
+              id: 'rec_1',
+              version: 1,
+              data: {
+                fld_name: 'Design',
+                fld_start: '2026-04-01',
+                fld_end: '2026-04-10',
+                fld_status: 'Open',
+              },
+            },
+            {
+              id: 'rec_2',
+              version: 1,
+              data: {
+                fld_name: 'Unplanned',
+                fld_status: 'Open',
+              },
+            },
+          ],
+          viewConfig: {
+            startFieldId: 'fld_start',
+            endFieldId: 'fld_end',
+            titleFieldId: 'fld_name',
+            groupFieldId: 'fld_status',
+          },
+          groupInfo: { fieldId: 'fld_status' },
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    expect(container.querySelector('.meta-gantt')?.getAttribute('aria-label')).toBe('甘特视图')
+    expect(container.textContent).toContain('开始')
+    expect(container.textContent).toContain('结束')
+    expect(container.textContent).toContain('进度')
+    expect(container.textContent).toContain('+ 添加任务')
+    expect(container.textContent).toContain('任务')
+    expect(container.textContent).toContain('至')
+    expect(container.textContent).toContain('未排期（1）')
+    expect(container.textContent).toContain('Design')
+    expect(container.textContent).toContain('Open')
+    expect(container.querySelector('.meta-gantt__resize-handle--start')?.getAttribute('aria-label')).toBe('调整 Design 的开始时间')
+    expect(container.querySelectorAll('[aria-label]')).toHaveLength(3)
+    expect(container.querySelectorAll('[title]')).toHaveLength(1)
+    expect(container.querySelectorAll('[placeholder]')).toHaveLength(0)
 
     app.unmount()
   })

--- a/apps/web/tests/multitable-hierarchy-view.spec.ts
+++ b/apps/web/tests/multitable-hierarchy-view.spec.ts
@@ -1,7 +1,8 @@
 import { createApp, h, nextTick } from 'vue'
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import MetaHierarchyView from '../src/multitable/components/MetaHierarchyView.vue'
 import type { MetaField, MetaRecord } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
 
 const fields: MetaField[] = [
   { id: 'fld_title', name: 'Title', type: 'string' },
@@ -42,6 +43,12 @@ function mountHierarchy(props: {
 }
 
 describe('MetaHierarchyView', () => {
+  afterEach(() => {
+    useLocale().setLocale('en')
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
   it('builds a tree from rows and the first parent link id', async () => {
     const selectSpy = vi.fn()
     const createSpy = vi.fn()
@@ -215,6 +222,36 @@ describe('MetaHierarchyView', () => {
 
     expect(reparentSpy).not.toHaveBeenCalled()
     expect(container.textContent).toContain('Cannot move a record under its own descendant.')
+
+    unmount()
+  })
+
+  it('localizes hierarchy chrome and comment chip label while preserving record titles', async () => {
+    useLocale().setLocale('zh-CN')
+    const { container, unmount } = mountHierarchy({
+      rows: [
+        { id: 'rec_root', version: 1, data: { fld_title: 'Root' } },
+      ],
+      viewConfig: { parentFieldId: 'fld_parent', titleFieldId: 'fld_title', defaultExpandDepth: 2 },
+      canCreate: true,
+      canComment: true,
+    })
+    await nextTick()
+
+    expect(container.querySelector('.meta-hierarchy')?.getAttribute('aria-label')).toBe('层级视图')
+    expect(container.textContent).toContain('父级字段')
+    expect(container.textContent).toContain('标题字段')
+    expect(container.textContent).toContain('默认展开层级')
+    expect(container.textContent).toContain('孤立记录')
+    expect(container.textContent).toContain('+ 添加根记录')
+    expect(container.textContent).toContain('+ 子记录')
+    expect(container.textContent).toContain('Root')
+    expect(container.textContent).toContain('评论')
+    expect(container.textContent).not.toContain('Comments')
+    expect(container.querySelector('button[aria-label="打开 Root 的评论"]')).not.toBeNull()
+    expect(container.querySelectorAll('[aria-label]')).toHaveLength(2)
+    expect(container.querySelectorAll('[title]')).toHaveLength(0)
+    expect(container.querySelectorAll('[placeholder]')).toHaveLength(0)
 
     unmount()
   })

--- a/apps/web/tests/multitable-kanban-view.spec.ts
+++ b/apps/web/tests/multitable-kanban-view.spec.ts
@@ -1,8 +1,15 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
 import MetaKanbanView from '../src/multitable/components/MetaKanbanView.vue'
+import { useLocale } from '../src/composables/useLocale'
 
 describe('MetaKanbanView', () => {
+  afterEach(() => {
+    useLocale().setLocale('en')
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
   it('renders people and attachment summaries with persisted card field config', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)
@@ -116,5 +123,61 @@ describe('MetaKanbanView', () => {
 
     app.unmount()
     container.remove()
+  })
+
+  it('localizes kanban chrome while keeping option values and card titles raw', async () => {
+    useLocale().setLocale('zh-CN')
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaKanbanView, {
+          rows: [
+            {
+              id: 'rec_1',
+              version: 1,
+              data: {
+                fld_title: 'Pilot card',
+                fld_status: 'Doing',
+                fld_note: 'Raw note',
+              },
+            },
+          ],
+          fields: [
+            { id: 'fld_title', name: 'Title', type: 'string' },
+            { id: 'fld_status', name: 'Status', type: 'select', options: [{ value: 'Doing', color: '#409eff' }] },
+            { id: 'fld_note', name: 'Note', type: 'string' },
+          ],
+          loading: false,
+          canCreate: true,
+          canEdit: true,
+          canComment: true,
+          viewConfig: {
+            groupFieldId: 'fld_status',
+            cardFieldIds: ['fld_note'],
+          },
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    expect(container.textContent).toContain('分组')
+    expect(container.textContent).toContain('分组依据：')
+    expect(container.textContent).toContain('卡片字段（1）')
+    expect(container.textContent).toContain('未分类')
+    expect(container.textContent).toContain('+ 添加记录')
+    expect(container.textContent).toContain('+ 添加')
+    expect(container.textContent).toContain('Doing')
+    expect(container.textContent).toContain('Pilot card')
+    expect(container.textContent).toContain('Raw note')
+    expect(container.querySelector('.meta-kanban__comment-btn')?.getAttribute('aria-label')).toBe('打开 Pilot card 的评论')
+    expect(container.querySelectorAll('[aria-label]')).toHaveLength(3)
+    expect(container.querySelectorAll('[title]')).toHaveLength(0)
+    expect(container.querySelectorAll('[placeholder]')).toHaveLength(0)
+
+    app.unmount()
   })
 })

--- a/apps/web/tests/multitable-timeline-view.spec.ts
+++ b/apps/web/tests/multitable-timeline-view.spec.ts
@@ -1,8 +1,15 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick } from 'vue'
 import MetaTimelineView from '../src/multitable/components/MetaTimelineView.vue'
+import { useLocale } from '../src/composables/useLocale'
 
 describe('MetaTimelineView', () => {
+  afterEach(() => {
+    useLocale().setLocale('en')
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
   it('renders persisted label field and zoom state in the timeline header', async () => {
     const container = document.createElement('div')
     document.body.appendChild(container)
@@ -128,5 +135,57 @@ describe('MetaTimelineView', () => {
 
     app.unmount()
     container.remove()
+  })
+
+  it('localizes timeline chrome and preserves raw field and record labels', async () => {
+    useLocale().setLocale('zh-CN')
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaTimelineView, {
+          rows: [
+            {
+              id: 'rec_1',
+              version: 1,
+              data: {
+                fld_name: 'Roadmap',
+                fld_start: '2026-03-01',
+                fld_end: '2026-03-05',
+              },
+            },
+          ],
+          fields: [
+            { id: 'fld_name', name: 'Name', type: 'string' },
+            { id: 'fld_start', name: 'Start', type: 'date' },
+            { id: 'fld_end', name: 'End', type: 'date' },
+          ],
+          loading: false,
+          canCreate: true,
+          viewConfig: {
+            startFieldId: 'fld_start',
+            endFieldId: 'fld_end',
+            labelFieldId: 'fld_name',
+            zoom: 'month',
+          },
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    expect(container.querySelector('.meta-timeline')?.getAttribute('aria-label')).toBe('时间轴视图')
+    expect(container.textContent).toContain('开始日期')
+    expect(container.textContent).toContain('结束日期')
+    expect(container.textContent).toContain('标签：Name')
+    expect(container.textContent).toContain('缩放: 月')
+    expect(container.textContent).toContain('Roadmap')
+    expect(container.querySelectorAll('[aria-label]')).toHaveLength(2)
+    expect(container.querySelectorAll('[title]')).toHaveLength(1)
+    expect(container.querySelectorAll('[placeholder]')).toHaveLength(0)
+
+    app.unmount()
   })
 })

--- a/docs/development/multitable-final-audit-visual-views-design-20260522.md
+++ b/docs/development/multitable-final-audit-visual-views-design-20260522.md
@@ -1,0 +1,509 @@
+# Multitable Final Audit Slice B Design — Visual View Render Chrome
+
+Date: 2026-05-22
+Branch: `frontend/multitable-final-audit-visual-views-design-20260522`
+Base: `origin/main@a60d463c5` (`feat(multitable): close final i18n audit small residuals (#1753)`)
+
+## 1. Decision Summary
+
+Slice B localizes the remaining visual / alternative view render chrome found by
+the final audit. It does not touch backend contracts, migrations, attendance,
+K3, API client fallback errors, formula docs, or manager configuration panels.
+
+Scope:
+
+| Surface | Component | Decision |
+| --- | --- | --- |
+| Calendar | `MetaCalendarView.vue` | Localize picker/header/mode labels/empty states/comment aria/count helpers; keep dates, holiday names, lunar labels, record titles raw |
+| Gallery | `MetaGalleryView.vue` | Localize toolbar controls, pagination, empty states, comment aria; keep field names, card titles, filenames raw |
+| Timeline | `MetaTimelineView.vue` | Localize config labels, zoom labels, label summaries/hints, placeholders, unscheduled/empty states, comment aria |
+| Gantt | `MetaGanttView.vue` | Localize toolbar, placeholder, task column, unscheduled/empty states, resize aria; keep task titles/date ranges/dependency labels raw |
+| Hierarchy | `MetaHierarchyView.vue` | Localize toolbar, orphans options, root drop target, empty states, child action, comment aria |
+| Kanban | `MetaKanbanView.vue` | Localize select-field prompt, header controls, uncategorized/drop hints, add/clear actions, comment aria |
+| Dashboard | `MetaDashboardView.vue` | Localize dashboard shell, add-panel modal, panel-size labels, generated default dashboard name |
+| Chart Renderer | `MetaChartRenderer.vue` | Localize table headers `Label` / `Value`; keep chart data labels and display config raw |
+
+Architecture:
+
+| Decision | Outcome |
+| --- | --- |
+| New render module | Add `apps/web/src/multitable/utils/meta-view-render-labels.ts` for view runtime chrome. |
+| Existing manager module | Do not grow `meta-manager-labels.ts` into a render-surface bucket. Reuse its existing exact config labels/helpers only when the rendered control is the same semantic setting. |
+| Existing core/comment modules | Reuse `metaCoreLabel('cell.noAttachments')` for attachment empty labels and `commentLabel('comment.title')` for chips. Add render helpers for comment button aria because those strings are view-runtime chrome. |
+| Raw data | Preserve record titles, field names, view/dashboard/chart names, option values, attachment filenames, holiday names, lunar labels, dates/times, chart labels, chart values, IDs, and CSS/data enum values. |
+| Slice shape | One Slice B PR is acceptable: 8 components plus one label module, but mostly template text and helper plumbing. |
+
+## 2. Files In Scope
+
+Implementation files:
+
+```text
+apps/web/src/multitable/utils/meta-view-render-labels.ts
+apps/web/src/multitable/components/MetaCalendarView.vue
+apps/web/src/multitable/components/MetaGalleryView.vue
+apps/web/src/multitable/components/MetaTimelineView.vue
+apps/web/src/multitable/components/MetaGanttView.vue
+apps/web/src/multitable/components/MetaHierarchyView.vue
+apps/web/src/multitable/components/MetaKanbanView.vue
+apps/web/src/multitable/components/MetaDashboardView.vue
+apps/web/src/multitable/components/MetaChartRenderer.vue
+```
+
+Tests:
+
+```text
+apps/web/tests/meta-view-render-labels.spec.ts
+apps/web/tests/multitable-calendar-view.spec.ts
+apps/web/tests/multitable-gallery-view.spec.ts
+apps/web/tests/multitable-timeline-view.spec.ts
+apps/web/tests/multitable-gantt-view.spec.ts
+apps/web/tests/multitable-hierarchy-view.spec.ts
+apps/web/tests/multitable-kanban-view.spec.ts
+apps/web/tests/multitable-dashboard-view.spec.ts
+apps/web/tests/multitable-chart-renderer.spec.ts
+apps/web/tests/multitable-alt-view-comment-chip-i18n.spec.ts
+```
+
+Docs:
+
+```text
+docs/development/multitable-final-audit-visual-views-design-20260522.md
+docs/development/multitable-final-audit-visual-views-verification-20260522.md
+```
+
+Out of scope:
+
+| Deferred Surface | Reason |
+| --- | --- |
+| Formula docs / formula diagnostics | Final audit Slice C |
+| API client fallback errors | Final audit Slice D; likely use dedicated API error label helper rather than direct `useLocale()` in client |
+| Manager configuration panels | Already owned by `meta-manager-labels.ts`; only exact existing keys may be reused |
+| Category labels | H2-era `category-labels.ts`; not part of T3/Slice B |
+| Backend, contract, migration, attendance, K3 | K3 stage-1 frontend i18n lock remains in effect |
+
+## 3. Label Module Contract
+
+Add a new render-surface module:
+
+```ts
+export type MetaViewRenderLabelKey =
+  | 'common.loading'
+  | 'common.chooseField'
+  | 'common.select'
+  | 'common.auto'
+  | 'common.none'
+  | 'common.addRecord'
+  | 'common.add'
+  | 'common.createRecord'
+  | 'common.createFirstRecord'
+  | 'common.noRecordsFound'
+  | 'calendar.today'
+  | 'calendar.view'
+  | 'calendar.month'
+  | 'calendar.week'
+  | 'calendar.day'
+  | 'calendar.change'
+  | 'calendar.newRecord'
+  | 'calendar.selectDateField'
+  | 'calendar.noRecordsOnDay'
+  | 'gallery.title'
+  | 'gallery.cover'
+  | 'gallery.columns'
+  | 'gallery.cardSize'
+  | 'gallery.noRecordsTitle'
+  | 'gallery.noRecordsHint'
+  | 'gallery.prev'
+  | 'gallery.next'
+  | 'timeline.viewAria'
+  | 'timeline.startDate'
+  | 'timeline.endDate'
+  | 'timeline.record'
+  | 'timeline.axisZoomHint'
+  | 'timeline.selectStartEnd'
+  | 'timeline.autoRecordIdHint'
+  | 'timeline.labelFieldHint'
+  | 'gantt.viewAria'
+  | 'gantt.start'
+  | 'gantt.end'
+  | 'gantt.title'
+  | 'gantt.progress'
+  | 'gantt.group'
+  | 'gantt.dependencies'
+  | 'gantt.addTask'
+  | 'gantt.selectStartEnd'
+  | 'gantt.task'
+  | 'gantt.to'
+  | 'gantt.allTasks'
+  | 'gantt.ungrouped'
+  | 'hierarchy.viewAria'
+  | 'hierarchy.autoLinkField'
+  | 'hierarchy.showAtRoot'
+  | 'hierarchy.hide'
+  | 'hierarchy.addRoot'
+  | 'hierarchy.noParentConfigured'
+  | 'hierarchy.parentHelp'
+  | 'hierarchy.dropToRoot'
+  | 'hierarchy.empty'
+  | 'hierarchy.child'
+  | 'kanban.selectFieldPromptPrefix'
+  | 'kanban.selectFieldPromptSuffix'
+  | 'kanban.noSelectFields'
+  | 'kanban.groupedBy'
+  | 'kanban.cardFields'
+  | 'kanban.clear'
+  | 'kanban.uncategorized'
+  | 'kanban.dropOrAdd'
+  | 'kanban.dropToUpdate'
+  | 'kanban.noCards'
+  | 'dashboard.rename'
+  | 'dashboard.addPanel'
+  | 'dashboard.newDashboard'
+  | 'dashboard.loadingDashboard'
+  | 'dashboard.empty'
+  | 'dashboard.loadingChart'
+  | 'dashboard.addChartPanel'
+  | 'dashboard.noCharts'
+  | 'chart.label'
+  | 'chart.value'
+
+export function viewRenderLabel(key: MetaViewRenderLabelKey, isZh: boolean): string
+```
+
+Helper contract:
+
+```ts
+export type ViewRenderSize = 'small' | 'medium' | 'large'
+export type ViewRenderZoom = 'day' | 'week' | 'month'
+export type CalendarViewMode = 'month' | 'week' | 'day'
+
+export function viewSizeLabel(size: ViewRenderSize | (string & {}), isZh: boolean): string
+export function viewZoomLabel(zoom: ViewRenderZoom | (string & {}), isZh: boolean): string
+export function calendarViewModeLabel(mode: CalendarViewMode | (string & {}), isZh: boolean): string
+export function calendarWeekdayShort(index: 0 | 1 | 2 | 3 | 4 | 5 | 6, isZh: boolean): string
+export function calendarMoreEvents(count: number, isZh: boolean): string
+export function calendarEventCount(count: number, isZh: boolean): string
+export function calendarCellAriaLabel(dateLabel: string, annotations: string[], eventCount: number, isZh: boolean): string
+export function openRecordCommentsAria(recordLabel: string, isZh: boolean): string
+export function openFieldCommentsAria(fieldName: string, isZh: boolean): string
+export function openFieldCommentsForRecordAria(fieldName: string, recordLabel: string, isZh: boolean): string
+export function cardFieldsSummary(count: number, isZh: boolean): string
+export function unscheduledCount(count: number, isZh: boolean): string
+export function timelineLabelSummary(kind: 'auto' | 'custom' | 'field', fieldName: string | null, isZh: boolean): string
+export function timelineAutoUsesFieldHint(fieldName: string, isZh: boolean): string
+export function ganttResizeAria(edge: 'start' | 'end', taskLabel: string, isZh: boolean): string
+export function dashboardDefaultName(index: number, isZh: boolean): string
+```
+
+Unknown enum fallback rule:
+
+- `viewSizeLabel`, `viewZoomLabel`, and `calendarViewModeLabel` return `String(value)` for unknown values.
+- Raw field/record/task/view names passed into helpers are interpolated unchanged.
+- `common.*` means common only inside `meta-view-render-labels.ts` view-render
+  surfaces. It is not an app-wide shared namespace and must not be imported
+  outside multitable view-render components without a separate ownership review.
+- `dashboardDefaultName(index, isZh)` is event-time. The generated name uses the
+  current locale at create time; once persisted, the dashboard name becomes user
+  data and must not retranslate on later locale switches.
+
+## 4. Reuse Discipline
+
+Reuse existing modules only when the ownership is already correct:
+
+| Existing owner | Reuse in Slice B | Rationale |
+| --- | --- | --- |
+| `meta-core-labels.ts` | `metaCoreLabel('cell.noAttachments', isZh)` for `MetaAttachmentList` empty-label; `fieldTypeLabel('select', isZh)` for Kanban select-field prompt | Cross-surface attachment and field-type chrome already live in the core label module; do not duplicate them. |
+| `meta-comment-labels.ts` | `commentLabel('comment.title', isZh)` for `MetaCommentActionChip` labels | Already proven in alt-view comment chip spec; keep chip title stable. |
+| `meta-manager-labels.ts` | Existing exact config labels/helpers only when a render toolbar exposes the same setting, e.g. `view.groupField`, `view.cardFields`, `view.defaultExpandDepth`, `sizeLabel`, `zoomLabel`, `autoLabel`, `groupNoneLabel`, `orphanModeLabel` | Reuse prevents duplicate manager-config semantics, but Slice B must not extend manager module for runtime empty states or action text. |
+| `workbench-labels.ts` | None | Workbench shell/toast domain; visual view internals should not import it. |
+
+Practical import rule:
+
+- Components may import both `viewRenderLabel` and existing manager/core/comment helpers.
+- `meta-view-render-labels.ts` should not import `meta-manager-labels.ts`; keep modules acyclic and explicit at call sites.
+- If a label is a runtime state or action (`No records`, `Drop here`, `+ Add record`, `Open comments for ...`), it belongs in `meta-view-render-labels.ts`.
+- If a label is the same persisted view setting label (`Title field`, `Card size`, `Zoom`, `Orphans`), reuse existing manager helper/key where exact.
+
+## 5. Exact Chrome Targets
+
+Line numbers are from the current Slice B design branch and may drift after
+implementation; verification must rerun grep.
+
+### 5.1 Calendar
+
+| Line(s) | Current string | Target / helper |
+| --- | --- | --- |
+| 5, 7 | `Select a date field to use for the calendar:`, `— Choose field —` | `calendar.selectDateField`, `common.chooseField` |
+| 17-29 | `Today`, `+ Add record`, `View`, `Month`, `Week`, `Day`, `Field:`, `Change` | `calendar.today`, `common.addRecord`, `calendar.view`, `calendarViewModeLabel`, `calendar.change`; field name raw |
+| 88, 175, 256 | `No attachments` | Reuse `metaCoreLabel('cell.noAttachments')` |
+| 97, 108, 184, 195, 265, 276 | `Open comments for ...` | `openRecordCommentsAria`, `openFieldCommentsAria` |
+| 116, 203 | `+{{ overflow }} more` | `calendarMoreEvents(count)` |
+| 230 | `${n} event(s)` | `calendarEventCount(count)` |
+| 236, 284, 290 | `+ New record`, `No records on this day`, `Loading...` | `calendar.newRecord`, `calendar.noRecordsOnDay`, `common.loading` |
+| 364 | `Sun` ... `Sat` | `calendarWeekdayShort(index)` |
+| 704-714 | `en-US` date aria + `${n} event(s)` | `calendarCellAriaLabel(dateLabel, annotations, count, isZh)`; for zh use `toLocaleDateString('zh-CN', ...)` |
+
+Raw: `dateField.name`, event titles, holiday names, effective-calendar tooltip content, lunar labels, date strings.
+
+### 5.2 Gallery
+
+| Line(s) | Current string | Target / helper |
+| --- | --- | --- |
+| 5-32 | `Title`, `Auto`, `Cover`, `None`, `Columns`, `Card size`, `Small/Medium/Large` | `gallery.title`, `common.auto`, `gallery.cover`, `common.none`, `gallery.columns`, `gallery.cardSize`, `viewSizeLabel` |
+| 36, 48 | `Card fields (${n})`, `+ Add record` | `cardFieldsSummary`, `common.addRecord` |
+| 78, 103 | `Open comments for ...` | `openRecordCommentsAria`, `openFieldCommentsForRecordAria` |
+| 93 | `No attachments` | Reuse `metaCoreLabel('cell.noAttachments')` |
+| 114-116 | `No records to display`, `Add records to see them as cards here`, `Create first record` | `gallery.noRecordsTitle`, `gallery.noRecordsHint`, `common.createFirstRecord` |
+| 120-124 | `Prev`, `Next`, `Loading...` | `gallery.prev`, `gallery.next`, `common.loading` |
+
+Raw: field names, card titles, attachment filenames, field values.
+
+### 5.3 Timeline
+
+| Line(s) | Current string | Target / helper |
+| --- | --- | --- |
+| 2-3 | `Timeline view`, `Loading...` | `timeline.viewAria`, `common.loading` |
+| 7-39 | `Start date`, `End date`, `Label field`, `(auto)`, `Zoom`, `Day/Week/Month`, `Axis spacing...` | `timeline.startDate`, `timeline.endDate`, existing `managerLabel('view.labelField')`, `common.auto`, existing `managerLabel('view.zoom')`, `viewZoomLabel`, `timeline.axisZoomHint` |
+| 41-46 | `+ Add record`, `Select start and end date fields...`, `Create record` | `common.addRecord`, `timeline.selectStartEnd`, `common.createRecord` |
+| 52, 58 | `Record`, `Zoom: ${label}` | `timeline.record`, helper text wrapping raw zoom label |
+| 82, 141 | `No attachments` | Reuse `metaCoreLabel('cell.noAttachments')` |
+| 91, 102, 150, 161 | `Open comments for ...` | comment aria helpers |
+| 124, 172-173 | `Unscheduled (${n})`, `No records found`, `Create first record` | `unscheduledCount`, `common.noRecordsFound`, `common.createFirstRecord` |
+| 281-299 | `Day/Week/Month`, `Label: auto`, `Label: ${field}`, `Label: custom`, auto-label hints | `viewZoomLabel`, `timelineLabelSummary`, `timelineAutoUsesFieldHint`, `timeline.autoRecordIdHint`, `timeline.labelFieldHint` |
+
+Raw: field names, display labels, date ticks, date ranges.
+
+### 5.4 Gantt
+
+| Line(s) | Current string | Target / helper |
+| --- | --- | --- |
+| 2-3 | `Gantt view`, `Loading...` | `gantt.viewAria`, `common.loading` |
+| 7-56 | `Start`, `select`, `End`, `Title`, `auto`, `Progress`, `none`, `Group`, `Dependencies`, `Zoom`, `Day/Week/Month`, `+ Add task` | `gantt.*`, `common.select`, `common.auto`, `common.none`, `viewZoomLabel`, `gantt.addTask` |
+| 60, 65 | `Select start and end date fields...`, `Task` | `gantt.selectStartEnd`, `gantt.task` |
+| 84 | `to` | `gantt.to` |
+| 107, 117 | `Resize start/end for ${title}` | `ganttResizeAria(edge, title, isZh)` |
+| 127, 139 | `Unscheduled (${n})`, `No records found.` | `unscheduledCount`, `common.noRecordsFound` |
+| 325-327 | `All tasks`, `Ungrouped` | `gantt.allTasks`, `gantt.ungrouped` |
+
+Raw: task titles, group option values except empty/ungrouped fallback, dependency labels, date strings.
+
+### 5.5 Hierarchy
+
+| Line(s) | Current string | Target / helper |
+| --- | --- | --- |
+| 2 | `Hierarchy view` | `hierarchy.viewAria` |
+| 5-35 | `Parent field`, `(auto link field)`, `Title field`, `(auto)`, `Expand depth`, `Orphans`, `show at root`, `hide`, `+ Add root` | Reuse exact manager labels for field/depth/orphans where possible; `hierarchy.autoLinkField`, `common.auto`, `hierarchy.showAtRoot`, `hierarchy.hide`, `hierarchy.addRoot` |
+| 39-40 | `No parent link field configured.`, `Add or choose a link field...` | `hierarchy.noParentConfigured`, `hierarchy.parentHelp` |
+| 55 | `Drop here to move to root` | `hierarchy.dropToRoot` |
+| 79, 82 | `No records match this hierarchy view.`, `Loading...` | `hierarchy.empty`, `common.loading` |
+| 408 | default prop `Comments` | Keep as EN fallback; parent passes localized `commentLabel('comment.title')`; hierarchy render spec must assert zh fixture shows `评论`, never fallback `Comments` |
+| 472, 482 | `Open comments for ${title}`, `+ Child` | `openRecordCommentsAria`, `hierarchy.child` |
+
+Raw: record titles, field names, generated diagnostics from tree builder unless they are static frontend strings discovered during implementation.
+
+### 5.6 Kanban
+
+| Line(s) | Current string | Target / helper |
+| --- | --- | --- |
+| 5-10 | `Select a select-type field to group by:`, `— Choose field —`, `No select-type fields found...` | `kanban.selectFieldPromptPrefix` + `fieldTypeLabel('select')` + `kanban.selectFieldPromptSuffix`, `common.chooseField`, `kanban.noSelectFields` |
+| 17-38 | `Group`, `(none)`, `Grouped by:`, `Card fields (${n})`, `+ Add record`, `Clear` | Reuse manager `view.groupField` only if exact; otherwise `gantt.group`/`kanban.groupedBy`, `common.none`, `cardFieldsSummary`, `common.addRecord`, `kanban.clear` |
+| 44, 95, 98, 154, 157, 162 | `Uncategorized`, drop hints, `+ Add`, `Loading...` | `kanban.uncategorized`, `kanban.dropOrAdd`, `kanban.dropToUpdate`, `kanban.noCards`, `common.add`, `common.loading` |
+| 67, 85, 126, 144 | `Open comments for ...` | comment aria helpers |
+
+Raw: select option values, group field names, card titles, preview field names/values.
+
+### 5.7 Dashboard
+
+| Line(s) | Current string | Target / helper |
+| --- | --- | --- |
+| 35-42 | title/text `Rename`, `+ Add Panel`, `+ New Dashboard` | `dashboard.rename`, `dashboard.addPanel`, `dashboard.newDashboard` |
+| 46-48 | `Loading dashboard...`, `No dashboards yet...` | `dashboard.loadingDashboard`, `dashboard.empty` |
+| 69-71 | `Small/Medium/Large` | `viewSizeLabel` |
+| 87, 96, 100 | `Loading chart...`, `Add Chart Panel`, `No charts available...` | `dashboard.loadingChart`, `dashboard.addChartPanel`, `dashboard.noCharts` |
+| 194 | generated `Dashboard ${n}` | `dashboardDefaultName(n, isZh)` |
+
+Raw: dashboard names from server/user input, chart names, chart type enum shown in picker unless a separate chart-type label helper already exists in future scope.
+
+### 5.8 Chart Renderer
+
+| Line(s) | Current string | Target / helper |
+| --- | --- | --- |
+| 127-128 | `Label`, `Value` | `chart.label`, `chart.value` |
+
+Raw: chart title, prefix/suffix, data point labels, data values.
+
+## 6. Raw Boundary
+
+Do not localize these values:
+
+| Raw value | Reason |
+| --- | --- |
+| Field names and view names | User-authored metadata |
+| Record titles / task titles / card titles | User-authored data |
+| Select option values and colors | User-authored option domain |
+| Attachment filenames and URLs | User file metadata |
+| Holiday names, lunar labels, effective-calendar layer labels | Domain data already produced upstream |
+| Chart names, chart data labels, display title/prefix/suffix, numeric values | User/chart configuration and data |
+| Dates, date ranges, axis tick labels | Formatted data; only surrounding chrome localizes |
+| IDs, `data-*` values, CSS suffixes, enum persistence values | Selector/persistence contract |
+| Backend/client errors surfaced through `error.message` | Raw error channel unless explicitly in Slice D |
+
+If implementation discovers additional static frontend fallbacks in these files,
+classify them in the verification MD as localized, raw, or deferred before
+wiring.
+
+## 7. A11y Boundary
+
+Slice B localizes existing visible text and existing a11y text. It must not add
+new a11y attributes unless a real existing control is otherwise inaccessible.
+
+Implementation specs must lock fixture-render counts for:
+
+```ts
+container.querySelectorAll('[aria-label]').length
+container.querySelectorAll('[title]').length
+container.querySelectorAll('[placeholder]').length
+```
+
+Expected behavior:
+
+- Existing `aria-label` values localize where they contain static chrome, e.g. `Timeline view`, `Gantt view`, `Open comments for ...`, `Resize start for ...`.
+- Existing `title` values localize only when they are static chrome, e.g. Dashboard `Rename`; date-range and dependency title strings remain raw data.
+- No placeholder additions are expected in Slice B.
+- `data-*` values stay raw and must never bind localized strings.
+
+## 8. Test Plan
+
+### 8.1 Helper Unit Spec
+
+Create `apps/web/tests/meta-view-render-labels.spec.ts`.
+
+Required coverage:
+
+- `ALL_KEYS` style exhaustive test for every `MetaViewRenderLabelKey`.
+- EN and zh static labels for common keys.
+- Plural/count helpers:
+  - `calendarMoreEvents(1/2)`
+  - `calendarEventCount(1/2)`
+  - `cardFieldsSummary(1/3)`
+  - `unscheduledCount(1/2)`
+- Raw interpolation helpers:
+  - `openRecordCommentsAria('Alpha', true)`
+  - `openFieldCommentsForRecordAria('状态', '客户 A', false)` keeps Chinese field/record names raw inside English chrome.
+  - `ganttResizeAria('start', '任务 A', false)` keeps task label raw.
+  - `dashboardDefaultName(2, true)`.
+- Unknown fallback for `viewSizeLabel`, `viewZoomLabel`, and `calendarViewModeLabel`.
+
+### 8.2 Render Specs
+
+Extend existing specs rather than creating unrelated harnesses:
+
+| Spec | Minimum Slice B assertions |
+| --- | --- |
+| `multitable-calendar-view.spec.ts` | zh picker/header/mode labels; `No records on this day`; localized `No attachments`; `Open comments...` aria; date aria uses zh date/event wording while holiday names remain raw |
+| `multitable-gallery-view.spec.ts` | zh toolbar labels, card size options, empty state, pagination, comment aria; field/card names raw |
+| `multitable-timeline-view.spec.ts` | zh view aria, toolbar, zoom badge, label summary/hints, unscheduled count, empty state, attachment empty label |
+| `multitable-gantt-view.spec.ts` | zh view aria, toolbar, placeholder, task column, `to`, unscheduled count, resize aria, all/ungrouped fallbacks |
+| `multitable-hierarchy-view.spec.ts` | zh tree aria, toolbar/options, parent placeholder, root drop target, empty state, child action, comment aria |
+| `multitable-kanban-view.spec.ts` | zh select-field prompt with localized `select` field type, header controls, drop hints, uncategorized, add/clear actions, comment aria |
+| `multitable-dashboard-view.spec.ts` | zh shell, add-panel modal, generated dashboard name body, panel size options; dashboard/chart names raw |
+| `multitable-chart-renderer.spec.ts` | zh table headers; chart title/data labels/prefix/suffix raw |
+| `multitable-alt-view-comment-chip-i18n.spec.ts` | Existing chip-label coverage stays green; add no redundant mount unless comment-chip regression is not covered elsewhere |
+
+Mount/teardown pattern:
+
+- Use the canonical `createApp` + container cleanup shape from existing visual-view specs.
+- Each render spec touching locale must reset `useLocale().setLocale('en')` in `afterEach`.
+- Prefer behavior/DOM text assertions over implementation-only prop inspection.
+
+### 8.3 Validation Commands
+
+Commands run from repo root:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/meta-view-render-labels.spec.ts \
+  tests/multitable-calendar-view.spec.ts \
+  tests/multitable-gallery-view.spec.ts \
+  tests/multitable-timeline-view.spec.ts \
+  tests/multitable-gantt-view.spec.ts \
+  tests/multitable-hierarchy-view.spec.ts \
+  tests/multitable-kanban-view.spec.ts \
+  tests/multitable-dashboard-view.spec.ts \
+  tests/multitable-chart-renderer.spec.ts \
+  tests/multitable-alt-view-comment-chip-i18n.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web run type-check
+pnpm --filter @metasheet/web build
+git diff --check origin/main..HEAD
+```
+
+Because `pnpm --filter @metasheet/web exec` runs with package context
+available, test paths stay `tests/...`, not `apps/web/tests/...`.
+
+## 9. Preflight Grep
+
+Before implementation, rerun:
+
+```bash
+rg -n "Select a date field|Today|Open comments for|No attachments|No records|Create first record|Timeline view|Gantt view|Hierarchy view|Unscheduled|Drop here to move to root|Select a <strong>select</strong>|Uncategorized|Drop a card here|No cards in this column|Rename|Add Panel|New Dashboard|Loading dashboard|Add Chart Panel|No charts available|<th>Label</th>|<th>Value</th>" \
+  apps/web/src/multitable/components/MetaCalendarView.vue \
+  apps/web/src/multitable/components/MetaGalleryView.vue \
+  apps/web/src/multitable/components/MetaTimelineView.vue \
+  apps/web/src/multitable/components/MetaGanttView.vue \
+  apps/web/src/multitable/components/MetaHierarchyView.vue \
+  apps/web/src/multitable/components/MetaKanbanView.vue \
+  apps/web/src/multitable/components/MetaDashboardView.vue \
+  apps/web/src/multitable/components/MetaChartRenderer.vue
+```
+
+Also verify reuse-key reachability:
+
+```bash
+rg -n "cell.noAttachments|fieldTypeLabel" apps/web/src/multitable/utils/meta-core-labels.ts
+rg -n "comment.title" apps/web/src/multitable/utils/meta-comment-labels.ts
+rg -n "view\\.cardSize|view\\.groupField|view\\.defaultExpandDepth|sizeLabel|zoomLabel|orphanModeLabel|autoLabel|groupNoneLabel" apps/web/src/multitable/utils/meta-manager-labels.ts
+```
+
+Verification MD must include the final grep classification:
+
+- localized by `meta-view-render-labels.ts`
+- reused from existing module
+- raw-data / deferred
+
+## 10. Implementation Order
+
+1. Rebase/fetch latest `origin/main`; confirm `git diff --name-status origin/main..HEAD` is empty before coding.
+2. Run the preflight grep in §9 and update the implementation checklist if line numbers drift.
+3. Add `meta-view-render-labels.ts` with static labels and helpers.
+4. Add `meta-view-render-labels.spec.ts`.
+5. Wire common helpers into Calendar/Gallery/Timeline/Kanban/Hierarchy/Gantt first, because they share comment aria, attachment empty label, loading, add/create, and count helpers.
+6. Wire Dashboard + Chart Renderer.
+7. Extend render specs and a11y count sentinels.
+8. Add verification MD with files changed, grep evidence, raw boundary evidence, and command outputs.
+9. Run validation commands in §8.3.
+10. Commit only Slice B files; do not stage `node_modules`, `dist`, unrelated T3D/audit work, backend, contracts, migrations, attendance, or K3.
+11. Stop before push/PR for implementation review.
+
+## 11. Risk Register
+
+| Risk | Mitigation |
+| --- | --- |
+| `meta-manager-labels.ts` becomes an overloaded render bucket | New `meta-view-render-labels.ts` owns runtime chrome; only exact existing manager config labels/helpers are reused. |
+| Duplicate helper drift | Reuse `fieldTypeLabel`, `commentLabel`, `metaCoreLabel`, and exact manager helpers instead of redeclaring their semantics. |
+| Localized text enters selectors | Keep all `data-*`, CSS suffixes, enum values, and option values raw; add raw selector assertions where tests already depend on them. |
+| A11y count changes silently | Each touched render spec records fixture `[aria-label]` / `[title]` / `[placeholder]` counts. |
+| Raw user data gets translated | Helper tests include Chinese field/record/view names inside English chrome to prove raw interpolation. |
+| Large Slice B PR is hard to review | Verification MD groups diff by module/components/specs and includes per-component target matrix. If implementation reveals excessive churn, split Dashboard/Chart into B2 before push. |
+| Mid-flight `origin/main` advances | Use `git fetch origin && git rebase origin/main` before push; for zero-overlap BEHIND PRs, Path A admin squash remains acceptable but verification must record the behind interval. |
+
+## 12. Approval Gate
+
+Implementation is ready for push only when all are true:
+
+- `meta-view-render-labels.ts` exists and owns render-only chrome.
+- Existing `meta-core-labels.ts`, `meta-comment-labels.ts`, and `meta-manager-labels.ts` are reused only for their established ownership surfaces.
+- All planned true-positive strings in §5 are either localized, reused, or explicitly classified raw/deferred in verification MD.
+- Targeted visual-view specs and helper spec pass.
+- `vue-tsc`, frontend build, and `git diff --check origin/main..HEAD` pass.
+- Diff remains frontend multitable i18n only.

--- a/docs/development/multitable-final-audit-visual-views-verification-20260522.md
+++ b/docs/development/multitable-final-audit-visual-views-verification-20260522.md
@@ -1,0 +1,218 @@
+# Multitable Final Audit Slice B Verification — Visual View Render Chrome
+
+Date: 2026-05-22
+Branch: `frontend/multitable-final-audit-visual-views-design-20260522`
+Base: `origin/main@a60d463c5` after rebase
+
+## DoD
+
+- Slice B design exists:
+  `docs/development/multitable-final-audit-visual-views-design-20260522.md`.
+- New render module exists:
+  `apps/web/src/multitable/utils/meta-view-render-labels.ts`.
+- Visual view render chrome is localized in:
+  Calendar, Gallery, Timeline, Gantt, Hierarchy, Kanban, Dashboard, and Chart
+  table rendering.
+- Existing ownership surfaces are reused rather than redeclared:
+  `meta-core-labels.ts`, `meta-comment-labels.ts`, and
+  `meta-manager-labels.ts`.
+- Raw data remains raw: record titles, field names, option values, dashboard
+  names from the server, chart names, chart labels/data, attachment filenames,
+  holiday names, lunar labels, dates, IDs, and data/CSS enum values.
+- Deferred surfaces remain out of scope: formula docs, API client fallbacks,
+  category labels, backend/contract/migration/attendance/K3.
+
+## Files Changed
+
+Implementation:
+
+- `apps/web/src/multitable/utils/meta-view-render-labels.ts`
+- `apps/web/src/multitable/components/MetaCalendarView.vue`
+- `apps/web/src/multitable/components/MetaGalleryView.vue`
+- `apps/web/src/multitable/components/MetaTimelineView.vue`
+- `apps/web/src/multitable/components/MetaGanttView.vue`
+- `apps/web/src/multitable/components/MetaHierarchyView.vue`
+- `apps/web/src/multitable/components/MetaKanbanView.vue`
+- `apps/web/src/multitable/components/MetaDashboardView.vue`
+- `apps/web/src/multitable/components/MetaChartRenderer.vue`
+
+Tests:
+
+- `apps/web/tests/meta-view-render-labels.spec.ts`
+- `apps/web/tests/multitable-calendar-view.spec.ts`
+- `apps/web/tests/multitable-gallery-view.spec.ts`
+- `apps/web/tests/multitable-timeline-view.spec.ts`
+- `apps/web/tests/multitable-gantt-view.spec.ts`
+- `apps/web/tests/multitable-hierarchy-view.spec.ts`
+- `apps/web/tests/multitable-kanban-view.spec.ts`
+- `apps/web/tests/multitable-dashboard-view.spec.ts`
+- `apps/web/tests/multitable-chart-renderer.spec.ts`
+
+Docs:
+
+- `docs/development/multitable-final-audit-visual-views-design-20260522.md`
+- `docs/development/multitable-final-audit-visual-views-verification-20260522.md`
+
+## Preflight / Reachability Evidence
+
+Source-string grep before implementation found target literals in all 8 visual
+components. After implementation, the same grep only matched identifiers or
+localized key names:
+
+```text
+MetaCalendarView.vue: calendar.today key, cell.isToday class, goToday function
+MetaDashboardView.vue: startRename / finishRename function and event names
+```
+
+No original target UI literals remain for:
+
+```text
+Select a date field
+Open comments for
+No attachments
+No records
+Create first record
+Timeline view
+Gantt view
+Hierarchy view
+Unscheduled
+Drop here to move to root
+Select a <strong>select</strong>
+Uncategorized
+Drop a card here
+No cards in this column
+Add Panel
+New Dashboard
+Loading dashboard
+Add Chart Panel
+No charts available
+<th>Label</th>
+<th>Value</th>
+```
+
+Reuse-key reachability was verified before wiring:
+
+```text
+meta-core-labels.ts: cell.noAttachments
+meta-core-labels.ts: fieldTypeLabel
+meta-comment-labels.ts: comment.title
+meta-manager-labels.ts: view.cardSize / view.groupField / view.defaultExpandDepth
+meta-manager-labels.ts: sizeLabel / zoomLabel / orphanModeLabel / autoLabel / groupNoneLabel
+```
+
+## Test Evidence
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/meta-view-render-labels.spec.ts \
+  tests/multitable-calendar-view.spec.ts \
+  tests/multitable-gallery-view.spec.ts \
+  tests/multitable-timeline-view.spec.ts \
+  tests/multitable-gantt-view.spec.ts \
+  tests/multitable-hierarchy-view.spec.ts \
+  tests/multitable-kanban-view.spec.ts \
+  tests/multitable-dashboard-view.spec.ts \
+  tests/multitable-chart-renderer.spec.ts \
+  tests/multitable-alt-view-comment-chip-i18n.spec.ts \
+  --watch=false
+```
+
+Result:
+
+```text
+Test Files  10 passed (10)
+Tests       69 passed (69)
+```
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web run type-check
+```
+
+Result:
+
+```text
+> @metasheet/web@2.0.0-alpha.1 type-check
+> vue-tsc -b
+```
+
+Exit code: 0.
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result:
+
+```text
+✓ 2421 modules transformed.
+✓ built in 6.34s
+```
+
+Build warnings:
+
+- Existing Vite warning: `WorkflowDesigner.vue` is both dynamically and
+  statically imported.
+- Existing Vite chunk-size warning for large bundles.
+
+Command:
+
+```bash
+git diff --check
+```
+
+Result: clean.
+
+## A11y Sentinel Coverage
+
+Render specs lock fixture-level `[aria-label]`, `[title]`, and `[placeholder]`
+counts on localized fixtures.
+
+| Spec | Sentinel |
+| --- | --- |
+| `multitable-calendar-view.spec.ts` | Calendar zh fixture locks 42 aria labels, 0 title, 0 placeholder |
+| `multitable-gallery-view.spec.ts` | Gallery empty zh fixture locks 0 aria, 0 title, 0 placeholder |
+| `multitable-timeline-view.spec.ts` | Timeline zh fixture locks 2 aria, 1 title, 0 placeholder |
+| `multitable-gantt-view.spec.ts` | Gantt zh fixture locks 3 aria, 1 title, 0 placeholder |
+| `multitable-hierarchy-view.spec.ts` | Hierarchy zh fixture locks 2 aria, 0 title, 0 placeholder |
+| `multitable-kanban-view.spec.ts` | Kanban zh fixture locks 3 aria, 0 title, 0 placeholder |
+| `multitable-dashboard-view.spec.ts` | Dashboard zh fixture locks 0 aria, 1 title, 0 placeholder |
+| `multitable-chart-renderer.spec.ts` | Chart table zh fixture locks 0 aria, 0 title, 0 placeholder |
+
+No Slice B implementation adds new a11y attributes. Existing a11y text is
+localized where it contains chrome; raw data titles/date ranges remain raw.
+
+## Raw Boundary Checks
+
+- Calendar: event title `Contract renewal` and holiday `春节` remain raw while
+  header/picker/date aria chrome localizes.
+- Gallery: field name `Status` remains raw while toolbar/empty/pagination chrome
+  localizes.
+- Timeline: field name `Name` and row label `Roadmap` remain raw while labels,
+  hints, zoom badge, and view aria localize.
+- Gantt: task `Design` and group value `Open` remain raw while toolbar, task
+  column, date-range connector, unscheduled count, and resize aria localize.
+- Hierarchy: record title `Root` remains raw while tree aria, toolbar/options,
+  child action, and comment chip/aria localize.
+- Kanban: option value `Doing`, card title `Pilot card`, and field value
+  `Raw note` remain raw while prompts, headers, drop hints, and comment aria
+  localize.
+- Dashboard: server chart name `Sales Chart` remains raw; generated
+  `dashboardDefaultName()` is event-time and becomes user data after create.
+- Chart Renderer: chart table headers localize; chart data labels and values
+  remain raw.
+
+## Notes
+
+- `common.*` keys are common only inside `meta-view-render-labels.ts`, not a
+  cross-application namespace.
+- `MetaHierarchyView` keeps the internal Options API fallback
+  `commentLabel: 'Comments'`; the zh fixture asserts the parent passes
+  localized `评论` and never exposes fallback `Comments`.
+- `apps/web/dist/` and `apps/web/node_modules` are ignored worktree artifacts
+  from build/test execution and are not part of the intended PR diff.


### PR DESCRIPTION
## Summary
- Localizes all 8 visual/alt-view render components: Calendar, Gallery, Timeline, Gantt, Hierarchy, Kanban, Dashboard, and ChartRenderer.
- Adds new meta-view-render-labels.ts with typed render-surface keys/helpers while reusing existing meta-core, meta-comment, and meta-manager ownership surfaces.
- Preserves raw user/data values: field names, record titles, option values, dashboard/chart names, chart data, holidays, lunar labels, dates, filenames, IDs, and selector enum values.

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/meta-view-render-labels.spec.ts tests/multitable-calendar-view.spec.ts tests/multitable-gallery-view.spec.ts tests/multitable-timeline-view.spec.ts tests/multitable-gantt-view.spec.ts tests/multitable-hierarchy-view.spec.ts tests/multitable-kanban-view.spec.ts tests/multitable-dashboard-view.spec.ts tests/multitable-chart-renderer.spec.ts tests/multitable-alt-view-comment-chip-i18n.spec.ts --watch=false
- pnpm --filter @metasheet/web run type-check
- pnpm --filter @metasheet/web build
- git diff --check origin/main..HEAD

Docs:
- docs/development/multitable-final-audit-visual-views-design-20260522.md
- docs/development/multitable-final-audit-visual-views-verification-20260522.md

Next: Slice C formula docs, then Slice D API fallbacks.