### PR TITLE
chore(integration): add customer README to K3 GATE template

### DIFF
--- a/docs/development/k3wise-gate-contract-customer-handoff-readme-design-20260522.md
+++ b/docs/development/k3wise-gate-contract-customer-handoff-readme-design-20260522.md
@@ -1,0 +1,79 @@
+# K3 WISE GATE Contract Customer Handoff README Design - 2026-05-22
+
+## Purpose
+
+The first local GATE contract packet after #1710 closed needed a Chinese
+operator/customer README next to the generated JSON files. That README was
+useful, but it was only added manually to `/tmp`, so the next operator could
+regenerate the packet with `--init-template` and still miss the handoff guide.
+
+This slice makes the README part of the canonical initializer:
+
+```bash
+node scripts/ops/integration-k3wise-gate-contract-check.mjs \
+  --init-template /path/outside-git/k3wise-gate-contract
+```
+
+The generated directory now includes `README-CUSTOMER-HANDOFF.zh.md` in
+addition to the packet JSON and eight redacted sample skeletons.
+
+## Scope
+
+Changed:
+
+- `scripts/ops/integration-k3wise-gate-contract-check.mjs`
+- `scripts/ops/integration-k3wise-gate-contract-check.test.mjs`
+- `scripts/ops/multitable-onprem-package-verify.sh`
+- this design note
+- companion verification note
+
+Not changed:
+
+- no `plugins/plugin-integration-core` runtime
+- no K3 WebAPI read/list implementation
+- no relationship resolver implementation
+- no SQL executor implementation
+- no DB migration
+- no API route
+- no frontend route
+- no K3 Save, Submit, or Audit call
+
+Customer GATE remains blocked until the filled packet passes validation.
+
+## README Contents
+
+The README is Chinese-facing and intentionally operational. It explains:
+
+- which files in the packet must be filled;
+- the WebAPI read/list answer IDs `O1-MAT`, `O1-MAT-M`, `O1-BOM`,
+  `O1-BOM-M`, `O2-P`, `O2-T`, `O2-C`, `O3-F`, `O3-M`, `O4-MAT`,
+  `O4-BOM`, and `O6`;
+- the relationship answer IDs `R1` through `R7`;
+- redaction expectations for tokens, cookies, passwords, SQL connection
+  strings, URL query secrets, and real business data;
+- the checker command to run after filling the packet;
+- the current boundary: the packet never triggers K3 Save, Submit, or Audit.
+
+The README deliberately does not contain real hostnames, tokens, passwords,
+authority codes, database URLs, or customer business values.
+
+## Package Verification
+
+`scripts/ops/multitable-onprem-package-verify.sh` now asserts that the packaged
+GATE contract checker contains the `README-CUSTOMER-HANDOFF.zh.md` marker.
+
+This catches stale on-prem packages that still generate the JSON packet but do
+not generate the customer handoff README.
+
+## Operator Impact
+
+Operators can still generate the packet outside Git with one command. The only
+visible difference is that the target directory now contains a human-readable
+Chinese checklist for the customer-facing GATE handoff.
+
+The runtime unlock condition is unchanged:
+
+1. Customer fills O1-O6 and R1-R7 evidence outside Git.
+2. The checker returns `PASS`.
+3. Maintainer reviews the evidence and explicitly starts the post-GATE runtime
+   work.

--- a/docs/development/k3wise-gate-contract-customer-handoff-readme-verification-20260522.md
+++ b/docs/development/k3wise-gate-contract-customer-handoff-readme-verification-20260522.md
@@ -1,0 +1,61 @@
+# K3 WISE GATE Contract Customer Handoff README Verification - 2026-05-22
+
+## Scope
+
+This verification covers the `--init-template` addition that writes
+`README-CUSTOMER-HANDOFF.zh.md` next to the GATE contract packet.
+
+Stage 1 Lock status: held. The change is ops/test/docs only and does not touch
+integration-core runtime, migrations, API routes, frontend routes, K3 calls, or
+pipeline execution.
+
+## Local Verification
+
+| Command | Result |
+| --- | --- |
+| `pnpm verify:integration-k3wise:gate-contract` | PASS: 5/5 tests |
+| `node scripts/ops/integration-k3wise-gate-contract-check.mjs --init-template /tmp/k3wise-gate-contract-readme-test-20260522` | PASS: `decision=TEMPLATE_CREATED`, `sampleCount=8`, `readmePath` present |
+| `node scripts/ops/integration-k3wise-gate-contract-check.mjs --input /tmp/k3wise-gate-contract-readme-test-20260522/k3wise-gate-contract-packet.template.json --out-dir /tmp/k3wise-gate-contract-readme-test-20260522/check-initial` | PASS: exit `2`, `decision=GATE_BLOCKED`, summary `0 pass / 23 blocked / 0 fail` |
+| secret-shape scan over generated packet directory | PASS: 0/5 patterns matched |
+| `bash -n scripts/ops/multitable-onprem-package-verify.sh` | PASS |
+| `git diff --check origin/main...HEAD` | PASS |
+
+## Regression Coverage
+
+The focused gate-contract test now verifies:
+
+- `--init-template` stdout lists `README-CUSTOMER-HANDOFF.zh.md`;
+- the README file exists in the generated directory;
+- the README contains the expected customer-facing markers:
+  - `K3 WISE GATE`;
+  - `O1-MAT`;
+  - `O1-BOM`;
+  - `R1`;
+  - `R7`;
+  - the no Save/Submit/Audit boundary;
+- the README does not contain JWT-shaped values, Bearer headers, credentialed
+  database URLs, or secret-looking URL query parameters.
+
+## Manual Template Smoke
+
+The generated packet must still be blocked before the customer fills it:
+
+```bash
+node scripts/ops/integration-k3wise-gate-contract-check.mjs \
+  --input /tmp/k3wise-gate-contract-readme-test-20260522/k3wise-gate-contract-packet.template.json \
+  --out-dir /tmp/k3wise-gate-contract-readme-test-20260522/check-initial
+```
+
+Expected result:
+
+- exit code `2`;
+- decision `GATE_BLOCKED`;
+- no `FAIL`;
+- no secret-shape findings.
+
+## Residual Risk
+
+This README improves handoff repeatability only. It does not validate customer
+business semantics and does not replace maintainer review of the filled packet.
+The post-GATE runtime work for #1709 and #1711 still requires a filled packet
+that returns `PASS`.

--- a/scripts/ops/integration-k3wise-gate-contract-check.mjs
+++ b/scripts/ops/integration-k3wise-gate-contract-check.mjs
@@ -57,6 +57,7 @@ const RELATIONSHIP_SAMPLES = {
   },
 }
 const TEMPLATE_PACKET_FILE = 'k3wise-gate-contract-packet.template.json'
+const TEMPLATE_HANDOFF_README_FILE = 'README-CUSTOMER-HANDOFF.zh.md'
 const TEMPLATE_SAMPLE_FILES = {
   materialList: 'sample-material-list.redacted.json',
   materialDetail: 'sample-material-detail.redacted.json',
@@ -630,6 +631,79 @@ function buildTemplateSamples() {
   }
 }
 
+function buildCustomerHandoffReadme() {
+  return `# K3 WISE GATE 信息填写说明
+
+这份包用于确认 MetaSheet 下一阶段是否可以开发 K3 WISE WebAPI 读取和关系映射功能。请只填写脱敏后的接口路径、字段说明、样例结构和业务规则，不要填写任何真实密码、Token、Cookie、authorityCode、SQL 连接串或生产数据原文。
+
+## 文件清单
+
+- \`${TEMPLATE_PACKET_FILE}\`：主填写文件。
+- \`${TEMPLATE_SAMPLE_FILES.materialList}\`：物料列表接口脱敏样例。
+- \`${TEMPLATE_SAMPLE_FILES.materialDetail}\`：物料详情接口脱敏样例。
+- \`${TEMPLATE_SAMPLE_FILES.bomList}\`：BOM 列表接口脱敏样例。
+- \`${TEMPLATE_SAMPLE_FILES.bomDetail}\`：BOM 详情接口脱敏样例。
+- \`${TEMPLATE_SAMPLE_FILES.flatBomLines}\`：平铺 BOM 行样例。
+- \`${TEMPLATE_SAMPLE_FILES.treeBom}\`：树形 BOM 样例。
+- \`${TEMPLATE_SAMPLE_FILES.unresolvedChild}\`：子件无法匹配时的样例。
+- \`${TEMPLATE_SAMPLE_FILES.k3BomSaveShape}\`：K3 BOM Save 请求体结构样例。
+
+## WebAPI read/list 必填项
+
+请在 \`webapiReadList.answers\` 中填写：
+
+- \`O1-MAT\`：物料读取接口相对路径，例如 \`/K3API/...\`。不要填完整域名、Token 或查询密钥。
+- \`O1-MAT-M\`：物料读取接口方法，只能是 \`GET\` 或 \`POST\`。
+- \`O1-BOM\`：BOM 读取接口相对路径。
+- \`O1-BOM-M\`：BOM 读取接口方法，只能是 \`GET\` 或 \`POST\`。
+- \`O2-P\`：分页规则，例如页码参数、每页数量参数、最大页数限制。
+- \`O2-T\`：总数或下一页判断规则。
+- \`O2-C\`：游标或下一页 token 规则；如果没有请写“无，按页码”。
+- \`O3-F\`：过滤条件规则，例如物料编码、修改时间、组织范围。
+- \`O3-M\`：最小可接受过滤条件；用于避免全量扫生产数据。
+- \`O4-MAT\`：物料响应中关键字段含义和路径。
+- \`O4-BOM\`：BOM 响应中关键字段含义和路径。
+- \`O6\`：错误响应格式，例如认证失败、无数据、参数错误。
+
+## relationship 必填项
+
+请在 \`relationshipMapping.answers\` 中填写：
+
+- \`R1\`：BOM 来源形态，是平铺行、树形结构，还是二者都有。
+- \`R2\`：父件、子件、数量、单位分别由哪些字段表示。
+- \`R3\`：单位映射规则，例如 PCS/EA/KG 对应 K3 中哪个字段或编码。
+- \`R4\`：物料分类映射规则。
+- \`R5\`：子件找不到时的期望行为。
+- \`R6\`：重复、冲突或多版本 BOM 的处理规则。
+- \`R7\`：首轮 PoC 必须支持哪些关系，哪些可以暂缓。
+
+## 脱敏要求
+
+可以保留字段名和结构，但请替换所有敏感值：
+
+- Token / Cookie / session / authorityCode：写成 \`<redacted>\`。
+- 密码、密钥、连接串：写成 \`<redacted>\`。
+- 真实客户物料编码、名称、供应商、人员等业务数据：用示例值替换，例如 \`MAT-001\`、\`Demo Parent\`。
+- URL 里不要包含 \`access_token\`、\`api_key\`、\`password\`、\`secret\`、\`sign\`、\`session_id\` 等查询参数。
+
+## 校验方式
+
+填写完成后，在 MetaSheet 仓库根目录运行：
+
+\`\`\`bash
+node scripts/ops/integration-k3wise-gate-contract-check.mjs \\
+  --input /path/outside-git/k3wise-gate-contract/k3wise-gate-contract-packet.template.json \\
+  --out-dir /path/outside-git/k3wise-gate-contract/check-filled
+\`\`\`
+
+只有校验结果为 \`PASS\` 后，MetaSheet 才会开始 #1709 / #1711 的 runtime 开发。若结果是 \`GATE_BLOCKED\`，说明仍有必填项未完成。若结果是 \`FAIL\`，说明存在格式或脱敏问题。
+
+## 明确边界
+
+这份包不会触发 K3 写入。当前阶段不执行 K3 Save、Submit、Audit，也不会修改生产 K3 数据。
+`
+}
+
 async function writeTemplateJson(filePath, value) {
   await writeFile(filePath, `${JSON.stringify(value, null, 2)}\n`, { flag: 'wx' })
 }
@@ -639,6 +713,8 @@ async function initTemplateDirectory(targetDir) {
   await mkdir(resolvedDir, { recursive: true })
   const packetPath = path.join(resolvedDir, TEMPLATE_PACKET_FILE)
   await writeTemplateJson(packetPath, buildTemplatePacket())
+  const readmePath = path.join(resolvedDir, TEMPLATE_HANDOFF_README_FILE)
+  await writeFile(readmePath, buildCustomerHandoffReadme(), { flag: 'wx' })
   const samples = buildTemplateSamples()
   for (const [fileName, value] of Object.entries(samples)) {
     await writeTemplateJson(path.join(resolvedDir, fileName), value)
@@ -646,6 +722,7 @@ async function initTemplateDirectory(targetDir) {
   return {
     templateDir: resolvedDir,
     packetPath,
+    readmePath,
     sampleCount: Object.keys(samples).length,
   }
 }

--- a/scripts/ops/integration-k3wise-gate-contract-check.test.mjs
+++ b/scripts/ops/integration-k3wise-gate-contract-check.test.mjs
@@ -200,11 +200,24 @@ test('init-template writes a safe fillable packet that is blocked until customer
   assert.equal(initResult.status, 0, initResult.stderr)
   assert.match(initResult.stdout, /"decision": "TEMPLATE_CREATED"/)
   assert.match(initResult.stdout, /"sampleCount": 8/)
+  assert.match(initResult.stdout, /README-CUSTOMER-HANDOFF\.zh\.md/)
 
   const packetPath = path.join(dir, 'k3wise-gate-contract-packet.template.json')
   const packet = JSON.parse(await readFile(packetPath, 'utf8'))
   assert.equal(packet.webapiReadList.answers['O1-MAT'], '<fill-outside-git>')
   assert.equal(packet.relationshipMapping.answers.R1, '<fill-outside-git>')
+
+  const readmeText = await readFile(path.join(dir, 'README-CUSTOMER-HANDOFF.zh.md'), 'utf8')
+  assert.match(readmeText, /K3 WISE GATE 信息填写说明/)
+  assert.match(readmeText, /O1-MAT/)
+  assert.match(readmeText, /O1-BOM/)
+  assert.match(readmeText, /R1/)
+  assert.match(readmeText, /R7/)
+  assert.match(readmeText, /不执行 K3 Save、Submit、Audit/)
+  assert.doesNotMatch(readmeText, /Bearer\s+[A-Za-z0-9._-]{16,}/i)
+  assert.doesNotMatch(readmeText, /[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}\.[A-Za-z0-9_-]{16,}/)
+  assert.doesNotMatch(readmeText, /\b(postgres|postgresql|mysql|mssql|sqlserver|jdbc):\/\/[^/\s:]+:[^@\s]+@/i)
+  assert.doesNotMatch(readmeText, /[?&](access[_-]?token|api[_-]?key|auth|authorization|credential|jwt|password|secret|session[_-]?id|sign|signature|token)=([^&#\s]+)/i)
 
   for (const samplePath of [
     ...Object.values(packet.webapiReadList.samples),

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -303,6 +303,7 @@ function verify_generic_integration_workbench_contract() {
   search_fixed_string 'SECRET_QUERY_PATTERN' "$gate_contract_checker" || die "GATE contract checker must reject secret-looking query parameters"
   search_fixed_string '--init-template' "$gate_contract_checker" || die "GATE contract checker must initialize a fillable packet template"
   search_fixed_string 'k3wise-gate-contract-packet.template.json' "$gate_contract_checker" || die "GATE contract checker must write the canonical packet template file"
+  search_fixed_string 'README-CUSTOMER-HANDOFF.zh.md' "$gate_contract_checker" || die "GATE contract checker must write the customer handoff README"
   search_fixed_string '--init-template' "$install_txt" || die "INSTALL.txt must document the GATE contract template initializer"
   search_fixed_string '8 redacted' "$install_txt" || die "INSTALL.txt must explain the generated sample skeleton count"
   search_fixed_string 'integration-k3wise-gate-contract-check.mjs' "$webapi_read_manifest" || die "WebAPI read/list manifest must point operators at the packaged GATE checker"


### PR DESCRIPTION
## Summary

Adds a Chinese customer/operator handoff README to the K3 WISE GATE contract `--init-template` output.

Generated packet directories now include:

- `k3wise-gate-contract-packet.template.json`
- `README-CUSTOMER-HANDOFF.zh.md`
- the existing 8 redacted sample skeleton files

The README explains O1-O6 WebAPI read/list answers, R1-R7 relationship answers, redaction rules, the checker command, and the current no Save/Submit/Audit boundary.

## Scope

- Ops/test/docs only.
- No `plugins/plugin-integration-core` runtime changes.
- No DB migration, API route, frontend route, K3 network call, SQL executor, or relationship resolver implementation.
- Customer GATE remains blocked until the filled packet returns `PASS`.

## Verification

- `pnpm verify:integration-k3wise:gate-contract` -> 5/5 PASS
- `node scripts/ops/integration-k3wise-gate-contract-check.mjs --init-template /tmp/k3wise-gate-contract-readme-test-20260522` -> `TEMPLATE_CREATED`, `sampleCount=8`, README path present
- Generated template checker smoke -> exit `2`, `GATE_BLOCKED`, `0 pass / 23 blocked / 0 fail`
- Generated packet secret scan -> 0/5 patterns matched
- `bash -n scripts/ops/multitable-onprem-package-verify.sh` -> PASS
- `git diff --check origin/main...HEAD` -> PASS

## Deployment impact

Future on-prem packages that include this checker will generate the customer handoff README automatically. Package verify now fails if the packaged checker loses the README marker.
