### PR TITLE
feat(multitable): localize formula docs and diagnostics (final audit Slice C)

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -391,9 +391,9 @@ import { computed, onBeforeUnmount, reactive, ref, watch } from 'vue'
 import { useLocale } from '../../composables/useLocale'
 import type { FieldValidationRule, MetaField, MetaFieldCreateType, MetaSheet } from '../types'
 import {
-  FORMULA_FUNCTION_CATEGORIES,
   buildFormulaFieldTokenInsertion,
   buildFormulaFunctionInsertion,
+  getFormulaFunctionCategories,
   getFormulaFunctionCatalog,
   validateFormulaExpression,
   type FormulaFunctionCategory,
@@ -588,7 +588,7 @@ const formulaDraft = reactive<{ expression: string }>({
 })
 const formulaFunctionSearch = ref('')
 const formulaFunctionCategory = ref<FormulaFunctionCategory | 'all'>('all')
-const formulaFunctionCategories = FORMULA_FUNCTION_CATEGORIES
+const formulaFunctionCategories = computed(() => getFormulaFunctionCategories(isZh.value))
 const attachmentDraft = reactive<{ maxFiles: number; acceptedMimeTypesText: string }>({
   maxFiles: 1,
   acceptedMimeTypesText: '',
@@ -632,12 +632,12 @@ const formulaSourceFields = computed(() =>
   props.fields.filter((field) => field.id !== configTarget.value?.id && field.type !== 'formula'),
 )
 const formulaCatalogSections = computed(() =>
-  getFormulaFunctionCatalog(formulaFunctionSearch.value, formulaFunctionCategory.value)
+  getFormulaFunctionCatalog(formulaFunctionSearch.value, formulaFunctionCategory.value, isZh.value)
     .map((section) => ({ ...section, functions: section.functions.slice(0, 6) })),
 )
 const formulaDiagnostics = computed<FormulaDiagnostic[]>(() =>
   configTargetType.value === 'formula'
-    ? validateFormulaExpression(formulaDraft.expression, formulaSourceFields.value)
+    ? validateFormulaExpression(formulaDraft.expression, formulaSourceFields.value, isZh.value)
     : [],
 )
 const configTargetType = computed(() => {

--- a/apps/web/src/multitable/utils/formula-docs.ts
+++ b/apps/web/src/multitable/utils/formula-docs.ts
@@ -1,4 +1,15 @@
 import type { MetaField } from '../types'
+import {
+  formulaCategoryLabel,
+  formulaDiagnosticLabel,
+  formulaEmptyArgument,
+  formulaFieldNameReference,
+  formulaFunctionDescription,
+  formulaMaxArgs,
+  formulaMinArgs,
+  formulaUndocumentedFunction,
+  formulaUnknownFieldReference,
+} from './meta-formula-labels'
 
 export type FormulaFunctionCategory =
   | 'aggregate'
@@ -540,22 +551,34 @@ const FORMULA_FUNCTION_ARITY: Record<string, Pick<FormulaFunctionDoc, 'minArgs' 
   YEAR: { minArgs: 1, maxArgs: 1 },
 }
 
-export function searchFormulaFunctionDocs(query: string): FormulaFunctionDoc[] {
-  const normalized = query.trim().toUpperCase()
-  if (!normalized) return FORMULA_FUNCTION_DOCS
+function localizeFormulaFunctionDoc(doc: FormulaFunctionDoc, isZh: boolean): FormulaFunctionDoc {
+  const description = formulaFunctionDescription(doc.name, isZh) || doc.description
+  return description === doc.description ? doc : { ...doc, description }
+}
+
+export function getFormulaFunctionCategories(isZh = false): FormulaFunctionCategoryDoc[] {
+  return FORMULA_FUNCTION_CATEGORIES.map((category) => formulaCategoryLabel(category.id, isZh))
+}
+
+export function searchFormulaFunctionDocs(query: string, isZh = false): FormulaFunctionDoc[] {
+  const trimmed = query.trim()
+  const normalized = trimmed.toUpperCase()
+  if (!normalized) return FORMULA_FUNCTION_DOCS.map((doc) => localizeFormulaFunctionDoc(doc, isZh))
   return FORMULA_FUNCTION_DOCS.filter((doc) =>
     doc.name.includes(normalized)
     || doc.signature.toUpperCase().includes(normalized)
-    || doc.description.toUpperCase().includes(normalized),
-  )
+    || doc.description.toUpperCase().includes(normalized)
+    || (isZh && formulaFunctionDescription(doc.name, true).includes(trimmed)),
+  ).map((doc) => localizeFormulaFunctionDoc(doc, isZh))
 }
 
 export function getFormulaFunctionCatalog(
   query = '',
   category: FormulaFunctionCategory | 'all' = 'all',
+  isZh = false,
 ): FormulaFunctionCatalogSection[] {
-  const docs = searchFormulaFunctionDocs(query).filter((doc) => category === 'all' || doc.category === category)
-  return FORMULA_FUNCTION_CATEGORIES
+  const docs = searchFormulaFunctionDocs(query, isZh).filter((doc) => category === 'all' || doc.category === category)
+  return getFormulaFunctionCategories(isZh)
     .map((categoryDoc) => ({
       category: categoryDoc.id,
       label: categoryDoc.label,
@@ -601,7 +624,7 @@ export function extractFormulaFieldRefs(expression: string): string[] {
   return refs
 }
 
-function getFormulaSyntaxDiagnostics(expression: string): FormulaDiagnostic[] {
+function getFormulaSyntaxDiagnostics(expression: string, isZh: boolean): FormulaDiagnostic[] {
   const diagnostics: FormulaDiagnostic[] = []
   let parenthesesDepth = 0
   let bracketDepth = 0
@@ -638,7 +661,7 @@ function getFormulaSyntaxDiagnostics(expression: string): FormulaDiagnostic[] {
     }
     if (char === ')') {
       if (parenthesesDepth === 0) {
-        diagnostics.push({ severity: 'error', message: 'Unexpected closing parenthesis.' })
+        diagnostics.push({ severity: 'error', message: formulaDiagnosticLabel('diagnostic.unexpectedClosingParenthesis', isZh) })
       } else {
         parenthesesDepth--
       }
@@ -651,7 +674,7 @@ function getFormulaSyntaxDiagnostics(expression: string): FormulaDiagnostic[] {
     }
     if (char === ']') {
       if (bracketDepth === 0) {
-        diagnostics.push({ severity: 'error', message: 'Unexpected closing array bracket.' })
+        diagnostics.push({ severity: 'error', message: formulaDiagnosticLabel('diagnostic.unexpectedClosingArrayBracket', isZh) })
       } else {
         bracketDepth--
       }
@@ -664,7 +687,7 @@ function getFormulaSyntaxDiagnostics(expression: string): FormulaDiagnostic[] {
     }
     if (char === '}') {
       if (braceDepth === 0) {
-        diagnostics.push({ severity: 'error', message: 'Unexpected closing field-reference brace.' })
+        diagnostics.push({ severity: 'error', message: formulaDiagnosticLabel('diagnostic.unexpectedClosingFieldReferenceBrace', isZh) })
       } else {
         braceDepth--
       }
@@ -672,21 +695,21 @@ function getFormulaSyntaxDiagnostics(expression: string): FormulaDiagnostic[] {
   }
 
   if (inQuotes) {
-    diagnostics.push({ severity: 'error', message: 'Quoted string is not closed.' })
+    diagnostics.push({ severity: 'error', message: formulaDiagnosticLabel('diagnostic.quotedStringNotClosed', isZh) })
   }
   if (parenthesesDepth > 0) {
-    diagnostics.push({ severity: 'error', message: 'Parentheses are not balanced.' })
+    diagnostics.push({ severity: 'error', message: formulaDiagnosticLabel('diagnostic.parenthesesNotBalanced', isZh) })
   }
   if (bracketDepth > 0) {
-    diagnostics.push({ severity: 'error', message: 'Array brackets are not balanced.' })
+    diagnostics.push({ severity: 'error', message: formulaDiagnosticLabel('diagnostic.arrayBracketsNotBalanced', isZh) })
   }
   if (braceDepth > 0) {
-    diagnostics.push({ severity: 'error', message: 'Field reference braces are not balanced.' })
+    diagnostics.push({ severity: 'error', message: formulaDiagnosticLabel('diagnostic.fieldReferenceBracesNotBalanced', isZh) })
   }
 
   const withoutWhitespace = expression.trimEnd()
   if (TRAILING_BINARY_OPERATOR_PATTERN.test(withoutWhitespace)) {
-    diagnostics.push({ severity: 'error', message: 'Formula cannot end with a binary operator.' })
+    diagnostics.push({ severity: 'error', message: formulaDiagnosticLabel('diagnostic.trailingBinaryOperator', isZh) })
   }
 
   return diagnostics
@@ -878,7 +901,7 @@ function collectFormulaFunctionCalls(expression: string): ParsedFormulaFunctionC
   return calls
 }
 
-function getFormulaFunctionArgumentDiagnostics(expression: string): FormulaDiagnostic[] {
+function getFormulaFunctionArgumentDiagnostics(expression: string, isZh: boolean): FormulaDiagnostic[] {
   const diagnostics: FormulaDiagnostic[] = []
   const knownFunctions = new Set(FORMULA_FUNCTION_DOCS.map((doc) => doc.name))
   for (const call of collectFormulaFunctionCalls(expression)) {
@@ -886,7 +909,7 @@ function getFormulaFunctionArgumentDiagnostics(expression: string): FormulaDiagn
 
     const emptyArgument = call.args.some((arg) => !arg)
     if (emptyArgument) {
-      diagnostics.push({ severity: 'error', message: `${call.name} has an empty argument.` })
+      diagnostics.push({ severity: 'error', message: formulaEmptyArgument(call.name, isZh) })
       continue
     }
 
@@ -896,7 +919,7 @@ function getFormulaFunctionArgumentDiagnostics(expression: string): FormulaDiagn
     if (typeof arity.minArgs === 'number' && call.args.length < arity.minArgs) {
       diagnostics.push({
         severity: 'error',
-        message: `${call.name} expects at least ${arity.minArgs} argument${arity.minArgs === 1 ? '' : 's'}.`,
+        message: formulaMinArgs(call.name, arity.minArgs, isZh),
       })
       continue
     }
@@ -904,7 +927,7 @@ function getFormulaFunctionArgumentDiagnostics(expression: string): FormulaDiagn
     if (typeof arity.maxArgs === 'number' && call.args.length > arity.maxArgs) {
       diagnostics.push({
         severity: 'error',
-        message: `${call.name} expects at most ${arity.maxArgs} argument${arity.maxArgs === 1 ? '' : 's'}.`,
+        message: formulaMaxArgs(call.name, arity.maxArgs, isZh),
       })
     }
   }
@@ -912,16 +935,16 @@ function getFormulaFunctionArgumentDiagnostics(expression: string): FormulaDiagn
   return diagnostics
 }
 
-export function validateFormulaExpression(expression: string, fields: MetaField[]): FormulaDiagnostic[] {
+export function validateFormulaExpression(expression: string, fields: MetaField[], isZh = false): FormulaDiagnostic[] {
   const diagnostics: FormulaDiagnostic[] = []
   const trimmed = expression.trim()
   if (!trimmed) {
-    diagnostics.push({ severity: 'warning', message: 'Formula expression is empty.' })
+    diagnostics.push({ severity: 'warning', message: formulaDiagnosticLabel('diagnostic.emptyExpression', isZh) })
     return diagnostics
   }
 
-  diagnostics.push(...getFormulaSyntaxDiagnostics(trimmed))
-  diagnostics.push(...getFormulaFunctionArgumentDiagnostics(trimmed))
+  diagnostics.push(...getFormulaSyntaxDiagnostics(trimmed, isZh))
+  diagnostics.push(...getFormulaFunctionArgumentDiagnostics(trimmed, isZh))
 
   const fieldIds = new Set(fields.map((field) => field.id))
   const fieldNames = new Set(fields.map((field) => field.name))
@@ -930,11 +953,11 @@ export function validateFormulaExpression(expression: string, fields: MetaField[
     if (fieldNames.has(ref)) {
       diagnostics.push({
         severity: 'warning',
-        message: `Field reference {${ref}} uses a name. Use the field chip to insert a stable {fld_xxx} token.`,
+        message: formulaFieldNameReference(ref, isZh),
       })
       continue
     }
-    diagnostics.push({ severity: 'error', message: `Unknown field reference {${ref}}.` })
+    diagnostics.push({ severity: 'error', message: formulaUnknownFieldReference(ref, isZh) })
   }
 
   const knownFunctions = new Set(FORMULA_FUNCTION_DOCS.map((doc) => doc.name))
@@ -943,7 +966,7 @@ export function validateFormulaExpression(expression: string, fields: MetaField[
   while ((match = FUNCTION_CALL_PATTERN.exec(trimmed.toUpperCase())) !== null) {
     const fn = match[1]
     if (fn && !knownFunctions.has(fn)) {
-      diagnostics.push({ severity: 'warning', message: `${fn} is not documented in this editor yet.` })
+      diagnostics.push({ severity: 'warning', message: formulaUndocumentedFunction(fn, isZh) })
     }
   }
 

--- a/apps/web/src/multitable/utils/meta-formula-labels.ts
+++ b/apps/web/src/multitable/utils/meta-formula-labels.ts
@@ -1,0 +1,192 @@
+// Formula reference and validation chrome.
+//
+// Scope: formula catalog category names/descriptions, formula function
+// descriptions, and frontend formula diagnostics. Formula names, signatures,
+// examples, insertion snippets, field refs, and unknown formula tokens stay raw.
+
+import type {
+  FormulaFunctionCategory,
+  FormulaFunctionCategoryDoc,
+  FormulaFunctionDoc,
+} from './formula-docs'
+
+type LocaleText = { en: string; zh: string }
+type FormulaFunctionName = FormulaFunctionDoc['name']
+
+export type FormulaDiagnosticLabelKey =
+  | 'diagnostic.unexpectedClosingParenthesis'
+  | 'diagnostic.unexpectedClosingArrayBracket'
+  | 'diagnostic.unexpectedClosingFieldReferenceBrace'
+  | 'diagnostic.quotedStringNotClosed'
+  | 'diagnostic.parenthesesNotBalanced'
+  | 'diagnostic.arrayBracketsNotBalanced'
+  | 'diagnostic.fieldReferenceBracesNotBalanced'
+  | 'diagnostic.trailingBinaryOperator'
+  | 'diagnostic.emptyExpression'
+
+const CATEGORY_LABELS: Record<FormulaFunctionCategory, { label: LocaleText; description: LocaleText }> = {
+  aggregate: {
+    label: { en: 'Aggregate', zh: '聚合' },
+    description: { en: 'Summarize numeric or non-empty values.', zh: '汇总数字或非空值。' },
+  },
+  math: {
+    label: { en: 'Math', zh: '数学' },
+    description: { en: 'Round, transform, and compare numbers.', zh: '对数字进行舍入、转换和比较。' },
+  },
+  operator: {
+    label: { en: 'Operators', zh: '运算符' },
+    description: { en: 'Combine values with spreadsheet operators.', zh: '使用表格运算符合并值。' },
+  },
+  logic: {
+    label: { en: 'Logic', zh: '逻辑' },
+    description: { en: 'Branch and combine conditions.', zh: '分支处理并组合条件。' },
+  },
+  text: {
+    label: { en: 'Text', zh: '文本' },
+    description: { en: 'Join, slice, and normalize text.', zh: '拼接、截取并规范化文本。' },
+  },
+  date: {
+    label: { en: 'Date', zh: '日期' },
+    description: { en: 'Create or extract date values.', zh: '创建或提取日期值。' },
+  },
+  lookup: {
+    label: { en: 'Lookup', zh: '查找' },
+    description: { en: 'Find values from arrays or ranges.', zh: '从数组或范围中查找值。' },
+  },
+  statistical: {
+    label: { en: 'Statistical', zh: '统计' },
+    description: { en: 'Calculate distribution helpers.', zh: '计算分布类辅助值。' },
+  },
+}
+
+const FUNCTION_DESCRIPTIONS: Record<FormulaFunctionName, LocaleText> = {
+  SUM: { en: 'Adds numeric values together.', zh: '将数字值相加。' },
+  AVERAGE: { en: 'Returns the arithmetic mean of numeric values.', zh: '返回数字值的算术平均值。' },
+  COUNT: { en: 'Counts numeric values.', zh: '统计数字值。' },
+  COUNTA: { en: 'Counts values that are not empty.', zh: '统计非空值。' },
+  MIN: { en: 'Returns the smallest numeric value.', zh: '返回最小的数字值。' },
+  MAX: { en: 'Returns the largest numeric value.', zh: '返回最大的数字值。' },
+  ROUND: { en: 'Rounds a number to the requested decimal places.', zh: '将数字舍入到指定小数位。' },
+  CEILING: { en: 'Rounds a number up to the nearest integer.', zh: '将数字向上舍入到最接近的整数。' },
+  FLOOR: { en: 'Rounds a number down to the nearest integer.', zh: '将数字向下舍入到最接近的整数。' },
+  POWER: { en: 'Raises a number to a power.', zh: '返回数字的乘方结果。' },
+  SQRT: { en: 'Returns the square root of a number.', zh: '返回数字的平方根。' },
+  MOD: { en: 'Returns the remainder after division.', zh: '返回除法后的余数。' },
+  ABS: { en: 'Returns the absolute value of a number.', zh: '返回数字的绝对值。' },
+  ADD: { en: 'Adds two numeric values. Text numbers are coerced to numbers.', zh: '将两个数字值相加。文本数字会被转换为数字。' },
+  SUBTRACT: { en: 'Subtracts the right numeric value from the left value.', zh: '从左侧值中减去右侧数字值。' },
+  MULTIPLY: { en: 'Multiplies two numeric values.', zh: '将两个数字值相乘。' },
+  DIVIDE: { en: 'Divides the left numeric value by the right value.', zh: '将左侧数字值除以右侧值。' },
+  POWER_OPERATOR: { en: 'Raises the left numeric value to the power of the right value.', zh: '将左侧数字值提升到右侧值指定的幂。' },
+  PERCENT_OPERATOR: { en: 'Converts a number to a percentage value, for example 50% becomes 0.5.', zh: '将数字转换为百分比值，例如 50% 会变为 0.5。' },
+  CONCAT_OPERATOR: { en: 'Concatenates values as text.', zh: '将值按文本拼接。' },
+  COMPARISON: { en: 'Compares two values and returns TRUE or FALSE.', zh: '比较两个值并返回 TRUE 或 FALSE。' },
+  IF: { en: 'Chooses one of two values based on a condition.', zh: '根据条件在两个值中选择一个。' },
+  AND: { en: 'Returns true only when all conditions are true.', zh: '仅当所有条件都为 true 时返回 true。' },
+  OR: { en: 'Returns true when any condition is true.', zh: '任一条件为 true 时返回 true。' },
+  NOT: { en: 'Reverses a boolean value.', zh: '反转布尔值。' },
+  TRUE: { en: 'Returns the boolean value TRUE.', zh: '返回布尔值 TRUE。' },
+  FALSE: { en: 'Returns the boolean value FALSE.', zh: '返回布尔值 FALSE。' },
+  SWITCH: { en: 'Returns the result for the first matching value, with an optional default.', zh: '返回第一个匹配值对应的结果，可包含默认值。' },
+  CONCAT: { en: 'Joins text values together.', zh: '将文本值拼接在一起。' },
+  CONCATENATE: { en: 'Joins text values together.', zh: '将文本值拼接在一起。' },
+  LEFT: { en: 'Returns characters from the start of a text value.', zh: '返回文本值开头的字符。' },
+  RIGHT: { en: 'Returns characters from the end of a text value.', zh: '返回文本值末尾的字符。' },
+  MID: { en: 'Returns characters from the middle of a text value.', zh: '返回文本值中间位置的字符。' },
+  LEN: { en: 'Returns the length of a text value.', zh: '返回文本值的长度。' },
+  UPPER: { en: 'Converts text to uppercase.', zh: '将文本转换为大写。' },
+  LOWER: { en: 'Converts text to lowercase.', zh: '将文本转换为小写。' },
+  TRIM: { en: 'Removes leading and trailing whitespace from text.', zh: '移除文本开头和结尾的空白。' },
+  SUBSTITUTE: { en: 'Replaces all occurrences of old text with new text.', zh: '将旧文本的所有出现位置替换为新文本。' },
+  NOW: { en: 'Returns the current date and time.', zh: '返回当前日期和时间。' },
+  TODAY: { en: 'Returns the current date.', zh: '返回当前日期。' },
+  DATE: { en: 'Creates a date from year, month, and day numbers.', zh: '根据年、月、日数字创建日期。' },
+  DATEDIF: { en: 'Returns the difference between two dates using unit D, M, or Y.', zh: '使用 D、M 或 Y 单位返回两个日期之间的差值。' },
+  DATEDIFF: { en: 'Returns the number of days between two dates.', zh: '返回两个日期之间的天数。' },
+  YEAR: { en: 'Returns the year from a date value.', zh: '返回日期值中的年份。' },
+  MONTH: { en: 'Returns the month from a date value.', zh: '返回日期值中的月份。' },
+  DAY: { en: 'Returns the day of month from a date value.', zh: '返回日期值中的日。' },
+  VLOOKUP: { en: 'Looks up a value in the first column of a table-like range.', zh: '在类似表格的范围第一列中查找值。' },
+  HLOOKUP: { en: 'Looks up a value in the first row of a table-like range.', zh: '在类似表格的范围第一行中查找值。' },
+  INDEX: { en: 'Returns a value from a range by row and column position.', zh: '按行列位置从范围中返回值。' },
+  MATCH: { en: 'Returns the position of a value in a range.', zh: '返回值在范围中的位置。' },
+  STDEV: { en: 'Returns the sample standard deviation of numeric values.', zh: '返回数字值的样本标准差。' },
+  VAR: { en: 'Returns the sample variance of numeric values.', zh: '返回数字值的样本方差。' },
+  MEDIAN: { en: 'Returns the median of numeric values.', zh: '返回数字值的中位数。' },
+  MODE: { en: 'Returns the most common numeric value.', zh: '返回最常见的数字值。' },
+}
+
+const DIAGNOSTIC_LABELS: Record<FormulaDiagnosticLabelKey, LocaleText> = {
+  'diagnostic.unexpectedClosingParenthesis': { en: 'Unexpected closing parenthesis.', zh: '意外的右括号。' },
+  'diagnostic.unexpectedClosingArrayBracket': { en: 'Unexpected closing array bracket.', zh: '意外的右方括号。' },
+  'diagnostic.unexpectedClosingFieldReferenceBrace': { en: 'Unexpected closing field-reference brace.', zh: '意外的字段引用右花括号。' },
+  'diagnostic.quotedStringNotClosed': { en: 'Quoted string is not closed.', zh: '引号字符串未闭合。' },
+  'diagnostic.parenthesesNotBalanced': { en: 'Parentheses are not balanced.', zh: '圆括号不匹配。' },
+  'diagnostic.arrayBracketsNotBalanced': { en: 'Array brackets are not balanced.', zh: '方括号不匹配。' },
+  'diagnostic.fieldReferenceBracesNotBalanced': { en: 'Field reference braces are not balanced.', zh: '字段引用花括号不匹配。' },
+  'diagnostic.trailingBinaryOperator': { en: 'Formula cannot end with a binary operator.', zh: '公式不能以二元运算符结尾。' },
+  'diagnostic.emptyExpression': { en: 'Formula expression is empty.', zh: '公式表达式为空。' },
+}
+
+function pick(text: LocaleText, isZh: boolean): string {
+  return isZh ? text.zh : text.en
+}
+
+export function formulaCategoryLabel(category: FormulaFunctionCategory, isZh: boolean): FormulaFunctionCategoryDoc {
+  const entry = CATEGORY_LABELS[category]
+  if (!entry) {
+    const raw = String(category)
+    return { id: category, label: raw, description: raw }
+  }
+  return {
+    id: category,
+    label: pick(entry.label, isZh),
+    description: pick(entry.description, isZh),
+  }
+}
+
+export function formulaFunctionDescription(name: string, isZh: boolean): string {
+  const entry = FUNCTION_DESCRIPTIONS[name]
+  if (!entry) return ''
+  return pick(entry, isZh)
+}
+
+export function formulaDiagnosticLabel(key: FormulaDiagnosticLabelKey, isZh: boolean): string {
+  return pick(DIAGNOSTIC_LABELS[key], isZh)
+}
+
+export function formulaEmptyArgument(functionName: string, isZh: boolean): string {
+  return isZh
+    ? `${functionName} 存在空参数。`
+    : `${functionName} has an empty argument.`
+}
+
+export function formulaMinArgs(functionName: string, count: number, isZh: boolean): string {
+  return isZh
+    ? `${functionName} 至少需要 ${count} 个参数。`
+    : `${functionName} expects at least ${count} argument${count === 1 ? '' : 's'}.`
+}
+
+export function formulaMaxArgs(functionName: string, count: number, isZh: boolean): string {
+  return isZh
+    ? `${functionName} 最多接受 ${count} 个参数。`
+    : `${functionName} expects at most ${count} argument${count === 1 ? '' : 's'}.`
+}
+
+export function formulaFieldNameReference(ref: string, isZh: boolean): string {
+  return isZh
+    ? `字段引用 {${ref}} 使用了名称。请使用字段标签插入稳定的 {fld_xxx} 令牌。`
+    : `Field reference {${ref}} uses a name. Use the field chip to insert a stable {fld_xxx} token.`
+}
+
+export function formulaUnknownFieldReference(ref: string, isZh: boolean): string {
+  return isZh
+    ? `未知字段引用 {${ref}}。`
+    : `Unknown field reference {${ref}}.`
+}
+
+export function formulaUndocumentedFunction(functionName: string, isZh: boolean): string {
+  return isZh
+    ? `${functionName} 尚未在此编辑器中记录。`
+    : `${functionName} is not documented in this editor yet.`
+}

--- a/apps/web/tests/meta-formula-labels.spec.ts
+++ b/apps/web/tests/meta-formula-labels.spec.ts
@@ -1,0 +1,62 @@
+import { describe, expect, it } from 'vitest'
+import {
+  formulaCategoryLabel,
+  formulaDiagnosticLabel,
+  formulaEmptyArgument,
+  formulaFieldNameReference,
+  formulaFunctionDescription,
+  formulaMaxArgs,
+  formulaMinArgs,
+  formulaUndocumentedFunction,
+  formulaUnknownFieldReference,
+} from '../src/multitable/utils/meta-formula-labels'
+
+describe('meta formula labels', () => {
+  it('localizes formula categories', () => {
+    expect(formulaCategoryLabel('aggregate', false)).toEqual({
+      id: 'aggregate',
+      label: 'Aggregate',
+      description: 'Summarize numeric or non-empty values.',
+    })
+    expect(formulaCategoryLabel('aggregate', true)).toEqual({
+      id: 'aggregate',
+      label: '聚合',
+      description: '汇总数字或非空值。',
+    })
+    expect(formulaCategoryLabel('operator', true).label).toBe('运算符')
+    expect(formulaCategoryLabel('statistical', true).description).toBe('计算分布类辅助值。')
+  })
+
+  it('localizes formula function descriptions and returns empty for unknown functions', () => {
+    expect(formulaFunctionDescription('SUM', false)).toBe('Adds numeric values together.')
+    expect(formulaFunctionDescription('SUM', true)).toBe('将数字值相加。')
+    expect(formulaFunctionDescription('PERCENT_OPERATOR', true)).toBe('将数字转换为百分比值，例如 50% 会变为 0.5。')
+    expect(formulaFunctionDescription('FOO', true)).toBe('')
+  })
+
+  it('localizes every static diagnostic label', () => {
+    expect(formulaDiagnosticLabel('diagnostic.unexpectedClosingParenthesis', false)).toBe('Unexpected closing parenthesis.')
+    expect(formulaDiagnosticLabel('diagnostic.unexpectedClosingParenthesis', true)).toBe('意外的右括号。')
+    expect(formulaDiagnosticLabel('diagnostic.unexpectedClosingArrayBracket', true)).toBe('意外的右方括号。')
+    expect(formulaDiagnosticLabel('diagnostic.unexpectedClosingFieldReferenceBrace', true)).toBe('意外的字段引用右花括号。')
+    expect(formulaDiagnosticLabel('diagnostic.quotedStringNotClosed', true)).toBe('引号字符串未闭合。')
+    expect(formulaDiagnosticLabel('diagnostic.parenthesesNotBalanced', true)).toBe('圆括号不匹配。')
+    expect(formulaDiagnosticLabel('diagnostic.arrayBracketsNotBalanced', true)).toBe('方括号不匹配。')
+    expect(formulaDiagnosticLabel('diagnostic.fieldReferenceBracesNotBalanced', true)).toBe('字段引用花括号不匹配。')
+    expect(formulaDiagnosticLabel('diagnostic.trailingBinaryOperator', true)).toBe('公式不能以二元运算符结尾。')
+    expect(formulaDiagnosticLabel('diagnostic.emptyExpression', true)).toBe('公式表达式为空。')
+  })
+
+  it('preserves raw values in dynamic diagnostics', () => {
+    expect(formulaEmptyArgument('ROUND', false)).toBe('ROUND has an empty argument.')
+    expect(formulaEmptyArgument('ROUND', true)).toBe('ROUND 存在空参数。')
+    expect(formulaMinArgs('IF', 3, false)).toBe('IF expects at least 3 arguments.')
+    expect(formulaMinArgs('IF', 1, false)).toBe('IF expects at least 1 argument.')
+    expect(formulaMinArgs('IF', 3, true)).toBe('IF 至少需要 3 个参数。')
+    expect(formulaMaxArgs('TODAY', 0, false)).toBe('TODAY expects at most 0 arguments.')
+    expect(formulaMaxArgs('ROUND', 2, true)).toBe('ROUND 最多接受 2 个参数。')
+    expect(formulaFieldNameReference('Price', true)).toBe('字段引用 {Price} 使用了名称。请使用字段标签插入稳定的 {fld_xxx} 令牌。')
+    expect(formulaUnknownFieldReference('fld_missing', true)).toBe('未知字段引用 {fld_missing}。')
+    expect(formulaUndocumentedFunction('FOO', true)).toBe('FOO 尚未在此编辑器中记录。')
+  })
+})

--- a/apps/web/tests/multitable-formula-editor.spec.ts
+++ b/apps/web/tests/multitable-formula-editor.spec.ts
@@ -1,11 +1,13 @@
 import { createApp, h, nextTick } from 'vue'
 import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useLocale } from '../src/composables/useLocale'
 import MetaFieldManager from '../src/multitable/components/MetaFieldManager.vue'
 import {
   FORMULA_FUNCTION_DOCS,
   buildFormulaFieldTokenInsertion,
   buildFormulaFunctionInsertion,
   extractFormulaFieldRefs,
+  getFormulaFunctionCategories,
   getFormulaFunctionCatalog,
   searchFormulaFunctionDocs,
   validateFormulaExpression,
@@ -13,6 +15,7 @@ import {
 
 describe('multitable formula editor', () => {
   afterEach(() => {
+    useLocale().setLocale('en')
     document.body.innerHTML = ''
     vi.restoreAllMocks()
   })
@@ -106,6 +109,41 @@ describe('multitable formula editor', () => {
     expect(buildFormulaFunctionInsertion('', ifDoc!)).toBe('=IF(, , )')
     expect(buildFormulaFunctionInsertion('=SUM({fld_price})', 'today')).toBe('=SUM({fld_price}) TODAY()')
     expect(buildFormulaFieldTokenInsertion('=SUM()', 'fld_tax')).toBe('=SUM() {fld_tax}')
+  })
+
+  it('localizes formula catalogs and diagnostics when requested', () => {
+    expect(getFormulaFunctionCategories(true).find((category) => category.id === 'math')).toMatchObject({
+      label: '数学',
+      description: '对数字进行舍入、转换和比较。',
+    })
+
+    expect(searchFormulaFunctionDocs('SUM', true)[0]).toMatchObject({
+      name: 'SUM',
+      signature: 'SUM(number, ...)',
+      description: '将数字值相加。',
+      example: '=SUM({fld_price}, {fld_tax})',
+      insertText: 'SUM()',
+    })
+    expect(searchFormulaFunctionDocs('Adds', true).map((doc) => doc.name)).toContain('SUM')
+    expect(searchFormulaFunctionDocs('相加', true).map((doc) => doc.name)).toEqual(expect.arrayContaining(['SUM', 'ADD']))
+
+    const fields = [{ id: 'fld_price', name: 'Price', type: 'number' }]
+    expect(validateFormulaExpression('', fields, true)).toContainEqual({
+      severity: 'warning',
+      message: '公式表达式为空。',
+    })
+    expect(validateFormulaExpression('=ROUND(, 2)', fields, true)).toContainEqual({
+      severity: 'error',
+      message: 'ROUND 存在空参数。',
+    })
+    expect(validateFormulaExpression('=SUM({Price})', fields, true)).toContainEqual({
+      severity: 'warning',
+      message: '字段引用 {Price} 使用了名称。请使用字段标签插入稳定的 {fld_xxx} 令牌。',
+    })
+    expect(validateFormulaExpression('=FOO({fld_price})', fields, true)).toContainEqual({
+      severity: 'warning',
+      message: 'FOO 尚未在此编辑器中记录。',
+    })
   })
 
   it('documents every backend registered formula function', () => {
@@ -305,6 +343,53 @@ describe('multitable formula editor', () => {
     expect(container.textContent).toContain('Operators')
     expect(container.textContent).toContain('value%')
     expect(container.textContent).toContain('left ^ right')
+
+    app.unmount()
+  })
+
+  it('renders localized formula reference chrome while preserving raw formula syntax', async () => {
+    useLocale().setLocale('zh-CN')
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaFieldManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          sheets: [],
+          fields: [
+            { id: 'fld_price', name: 'Price', type: 'number' },
+            { id: 'fld_total', name: 'Total', type: 'formula', property: { expression: '=SUM({fld_missing})' } },
+          ],
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const configureButtons = Array.from(container.querySelectorAll('.meta-field-mgr__action[title="配置"]')) as HTMLButtonElement[]
+    configureButtons[1]?.click()
+    await nextTick()
+
+    const categorySelect = container.querySelector('.meta-field-mgr__formula-toolbar .meta-field-mgr__select') as HTMLSelectElement
+    expect(categorySelect.querySelector('option[value="math"]')?.textContent).toBe('数学')
+    categorySelect.value = 'math'
+    categorySelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    expect(container.textContent).toContain('数学')
+    expect(container.textContent).toContain('将数字舍入到指定小数位。')
+    expect(container.textContent).toContain('ROUND(number, digits)')
+    expect(container.textContent).toContain('=ROUND({fld_amount}, 2)')
+    expect(container.textContent).toContain('未知字段引用 {fld_missing}。')
+    expect(container.textContent).not.toContain('Unknown field reference {fld_missing}.')
+    expect(container.querySelector('.meta-field-mgr__formula-diagnostic--error')).toBeTruthy()
+    expect(container.querySelectorAll('[aria-label]')).toHaveLength(0)
+    expect(container.querySelectorAll('[title]')).toHaveLength(13)
+    expect(container.querySelectorAll('[placeholder]')).toHaveLength(3)
 
     app.unmount()
   })

--- a/docs/development/multitable-final-audit-formula-docs-design-20260522.md
+++ b/docs/development/multitable-final-audit-formula-docs-design-20260522.md
@@ -1,0 +1,408 @@
+# Multitable Final Audit Slice C Design — Formula Docs and Diagnostics
+
+Date: 2026-05-22
+Branch: `frontend/multitable-final-audit-formula-docs-design-20260522`
+Base: `origin/main@149ec98e6` (`docs(attendance): close advanced scheduling read-only boundary (#1759)`)
+
+## 1. Decision Summary
+
+Slice C localizes the formula reference catalog and formula validation diagnostics that were intentionally deferred by final audit Slice A and Slice B.
+
+Scope:
+
+| Surface | File | Decision |
+| --- | --- | --- |
+| Formula catalog categories | `apps/web/src/multitable/utils/formula-docs.ts` | Localize the 8 category labels/descriptions used by the formula reference selector and section headers. |
+| Formula function descriptions | `apps/web/src/multitable/utils/formula-docs.ts` | Localize descriptions for all 54 formula docs; keep function names, signatures, examples, and insertion snippets raw. |
+| Formula diagnostics | `apps/web/src/multitable/utils/formula-docs.ts` | Localize static and dynamic frontend diagnostics emitted by `validateFormulaExpression(...)`; preserve raw function names, field refs, and token examples. |
+| Formula panel rendering | `apps/web/src/multitable/components/MetaFieldManager.vue` | Pass `isZh.value` into formula catalog and diagnostic helpers; no template structure change beyond localized text. |
+| Tests | `apps/web/tests/multitable-formula-editor.spec.ts` plus new formula label helper spec | Preserve English default contract and add zh render/helper coverage. |
+
+Architecture:
+
+| Decision | Outcome |
+| --- | --- |
+| New formula module | Add `apps/web/src/multitable/utils/meta-formula-labels.ts`. Formula catalog copy is large and formula-specific; it should not overload `meta-manager-labels.ts`. |
+| Existing manager module | Keep existing manager keys (`field.formulaReference`, `field.formulaSearchPlaceholder`, `field.allCategories`, `field.noMatchingFunctions`, `field.expression`, `field.insertFieldToken`) in `meta-manager-labels.ts`; do not duplicate them. |
+| Optional locale parameters | `searchFormulaFunctionDocs`, `getFormulaFunctionCatalog`, `getFormulaFunctionCategories`, and `validateFormulaExpression` receive optional `isZh = false` to preserve current English default tests and callers. |
+| Search behavior | Formula search should match raw function name/signature, English description, and localized description. This preserves EN search terms in zh mode and enables zh description search. |
+| Raw boundary | Formula names, signatures, examples, insert snippets, field IDs, field names, `{fld_xxx}`, formulas, backend-compatible tokens, and unknown enum/function values stay raw. |
+
+Out of scope:
+
+| Deferred Surface | Reason |
+| --- | --- |
+| API client static fallback errors | Final audit Slice D; separate architecture needed for client-level i18n. |
+| Field manager non-formula chrome | Already handled by `meta-manager-labels.ts` and earlier T3C/T3E slices. |
+| Formula runtime/backend contract | Slice C changes frontend docs/diagnostics only; no backend, contract, migration, attendance, K3. |
+| Formula expression placeholder `=SUM({fld_price}, {fld_tax})` | Raw formula syntax example; not user-facing prose and should remain unchanged. |
+
+## 2. Files In Scope
+
+Implementation files:
+
+```text
+apps/web/src/multitable/utils/meta-formula-labels.ts
+apps/web/src/multitable/utils/formula-docs.ts
+apps/web/src/multitable/components/MetaFieldManager.vue
+```
+
+Tests:
+
+```text
+apps/web/tests/meta-formula-labels.spec.ts
+apps/web/tests/multitable-formula-editor.spec.ts
+```
+
+Docs:
+
+```text
+docs/development/multitable-final-audit-formula-docs-design-20260522.md
+docs/development/multitable-final-audit-formula-docs-verification-20260522.md
+```
+
+Out-of-scope examples that must remain untouched:
+
+```text
+apps/web/src/multitable/api/client.ts
+apps/web/src/multitable/utils/workbench-labels.ts
+apps/web/src/multitable/utils/meta-view-render-labels.ts
+packages/core-backend/**
+packages/openapi/**
+plugins/**
+```
+
+## 3. Scout Evidence
+
+Formula source:
+
+| Source | Evidence |
+| --- | --- |
+| Category labels/descriptions | `formula-docs.ts:42-51`, 8 `FORMULA_FUNCTION_CATEGORIES` entries. |
+| Formula function docs | `formula-docs.ts:53-487`, 54 `FORMULA_FUNCTION_DOCS` entries. |
+| Catalog search and sections | `formula-docs.ts:543-566`, `searchFormulaFunctionDocs` and `getFormulaFunctionCatalog`. |
+| Syntax diagnostics | `formula-docs.ts:604-692`, static syntax messages. |
+| Argument diagnostics | `formula-docs.ts:881-912`, dynamic function arity / empty-argument messages. |
+| Validation diagnostics | `formula-docs.ts:915-950`, empty expression, field-reference, undocumented-function messages. |
+| Formula panel rendering | `MetaFieldManager.vue:161-229`, diagnostics, category select, section headers, doc descriptions/examples. |
+| Formula panel data plumbing | `MetaFieldManager.vue:591-640`, categories, catalog sections, diagnostics. |
+
+Existing localized manager chrome to reuse:
+
+| Existing key/helper | Owner | Use |
+| --- | --- | --- |
+| `field.expression` | `meta-manager-labels.ts` | Formula expression label. |
+| `field.insertFieldToken` | `meta-manager-labels.ts` | Field-token chip section. |
+| `field.formulaReference` | `meta-manager-labels.ts` | Formula reference label. |
+| `field.formulaSearchPlaceholder` | `meta-manager-labels.ts` | Search input placeholder. |
+| `field.allCategories` | `meta-manager-labels.ts` | Category select all-option. |
+| `field.noMatchingFunctions` | `meta-manager-labels.ts` | Empty catalog state. |
+| `insertFieldTokenTitle(fieldId, isZh)` | `meta-manager-labels.ts` | Field-token chip title; field ID raw. |
+
+No separate cell editor variants were found during Slice A; formula docs are owned by `formula-docs.ts` and consumed from `MetaFieldManager.vue`.
+
+## 4. Label Module Contract
+
+Add a formula-specific label module:
+
+```ts
+export type FormulaCategoryLabelKey =
+  | 'category.aggregate'
+  | 'category.math'
+  | 'category.operator'
+  | 'category.logic'
+  | 'category.text'
+  | 'category.date'
+  | 'category.lookup'
+  | 'category.statistical'
+
+export type FormulaDiagnosticLabelKey =
+  | 'diagnostic.unexpectedClosingParenthesis'
+  | 'diagnostic.unexpectedClosingArrayBracket'
+  | 'diagnostic.unexpectedClosingFieldReferenceBrace'
+  | 'diagnostic.quotedStringNotClosed'
+  | 'diagnostic.parenthesesNotBalanced'
+  | 'diagnostic.arrayBracketsNotBalanced'
+  | 'diagnostic.fieldReferenceBracesNotBalanced'
+  | 'diagnostic.trailingBinaryOperator'
+  | 'diagnostic.emptyExpression'
+
+export function formulaCategoryLabel(category: FormulaFunctionCategory, isZh: boolean): FormulaFunctionCategoryDoc
+export function formulaFunctionDescription(name: string, isZh: boolean): string
+export function formulaDiagnosticLabel(key: FormulaDiagnosticLabelKey, isZh: boolean): string
+export function formulaEmptyArgument(functionName: string, isZh: boolean): string
+export function formulaMinArgs(functionName: string, count: number, isZh: boolean): string
+export function formulaMaxArgs(functionName: string, count: number, isZh: boolean): string
+export function formulaFieldNameReference(ref: string, isZh: boolean): string
+export function formulaUnknownFieldReference(ref: string, isZh: boolean): string
+export function formulaUndocumentedFunction(functionName: string, isZh: boolean): string
+```
+
+Notes:
+
+- `FormulaFunctionCategory` / `FormulaFunctionCategoryDoc` can be imported as type-only imports to avoid a runtime cycle.
+- Unknown categories must fall back to `String(value)`, not throw.
+- `formulaFunctionDescription(name, isZh)` returns an empty string for unknown function names. Empty means "no description"; callers may decide whether to render a placeholder, but the helper must not invent a description by echoing the function name.
+- Dynamic helpers must preserve raw function names (`ROUND`, `TODAY`, unknown `FOO`) and raw field refs (`Price`, `fld_missing`) exactly.
+- `formulaFieldNameReference()` must keep `{fld_xxx}` literal raw inside the guidance text.
+
+## 5. Exact Chrome Targets
+
+### 5.1 Category Labels and Descriptions
+
+| Category | EN label | zh label | EN description | zh description |
+| --- | --- | --- | --- | --- |
+| aggregate | Aggregate | 聚合 | Summarize numeric or non-empty values. | 汇总数字或非空值。 |
+| math | Math | 数学 | Round, transform, and compare numbers. | 对数字进行舍入、转换和比较。 |
+| operator | Operators | 运算符 | Combine values with spreadsheet operators. | 使用表格运算符合并值。 |
+| logic | Logic | 逻辑 | Branch and combine conditions. | 分支处理并组合条件。 |
+| text | Text | 文本 | Join, slice, and normalize text. | 拼接、截取并规范化文本。 |
+| date | Date | 日期 | Create or extract date values. | 创建或提取日期值。 |
+| lookup | Lookup | 查找 | Find values from arrays or ranges. | 从数组或范围中查找值。 |
+| statistical | Statistical | 统计 | Calculate distribution helpers. | 计算分布类辅助值。 |
+
+### 5.2 Formula Function Descriptions
+
+All 54 function docs keep `name`, `signature`, `example`, and `insertText` raw. Only `description` is localized.
+
+| Function | zh description |
+| --- | --- |
+| SUM | 将数字值相加。 |
+| AVERAGE | 返回数字值的算术平均值。 |
+| COUNT | 统计数字值。 |
+| COUNTA | 统计非空值。 |
+| MIN | 返回最小的数字值。 |
+| MAX | 返回最大的数字值。 |
+| ROUND | 将数字舍入到指定小数位。 |
+| CEILING | 将数字向上舍入到最接近的整数。 |
+| FLOOR | 将数字向下舍入到最接近的整数。 |
+| POWER | 返回数字的乘方结果。 |
+| SQRT | 返回数字的平方根。 |
+| MOD | 返回除法后的余数。 |
+| ABS | 返回数字的绝对值。 |
+| ADD | 将两个数字值相加。文本数字会被转换为数字。 |
+| SUBTRACT | 从左侧值中减去右侧数字值。 |
+| MULTIPLY | 将两个数字值相乘。 |
+| DIVIDE | 将左侧数字值除以右侧值。 |
+| POWER_OPERATOR | 将左侧数字值提升到右侧值指定的幂。 |
+| PERCENT_OPERATOR | 将数字转换为百分比值，例如 50% 会变为 0.5。 |
+| CONCAT_OPERATOR | 将值按文本拼接。 |
+| COMPARISON | 比较两个值并返回 TRUE 或 FALSE。 |
+| IF | 根据条件在两个值中选择一个。 |
+| AND | 仅当所有条件都为 true 时返回 true。 |
+| OR | 任一条件为 true 时返回 true。 |
+| NOT | 反转布尔值。 |
+| TRUE | 返回布尔值 TRUE。 |
+| FALSE | 返回布尔值 FALSE。 |
+| SWITCH | 返回第一个匹配值对应的结果，可包含默认值。 |
+| CONCAT | 将文本值拼接在一起。 |
+| CONCATENATE | 将文本值拼接在一起。 |
+| LEFT | 返回文本值开头的字符。 |
+| RIGHT | 返回文本值末尾的字符。 |
+| MID | 返回文本值中间位置的字符。 |
+| LEN | 返回文本值的长度。 |
+| UPPER | 将文本转换为大写。 |
+| LOWER | 将文本转换为小写。 |
+| TRIM | 移除文本开头和结尾的空白。 |
+| SUBSTITUTE | 将旧文本的所有出现位置替换为新文本。 |
+| NOW | 返回当前日期和时间。 |
+| TODAY | 返回当前日期。 |
+| DATE | 根据年、月、日数字创建日期。 |
+| DATEDIF | 使用 D、M 或 Y 单位返回两个日期之间的差值。 |
+| DATEDIFF | 返回两个日期之间的天数。 |
+| YEAR | 返回日期值中的年份。 |
+| MONTH | 返回日期值中的月份。 |
+| DAY | 返回日期值中的日。 |
+| VLOOKUP | 在类似表格的范围第一列中查找值。 |
+| HLOOKUP | 在类似表格的范围第一行中查找值。 |
+| INDEX | 按行列位置从范围中返回值。 |
+| MATCH | 返回值在范围中的位置。 |
+| STDEV | 返回数字值的样本标准差。 |
+| VAR | 返回数字值的样本方差。 |
+| MEDIAN | 返回数字值的中位数。 |
+| MODE | 返回最常见的数字值。 |
+
+### 5.3 Diagnostics
+
+Static diagnostics:
+
+| Source line | EN | zh |
+| --- | --- | --- |
+| `formula-docs.ts:641` | Unexpected closing parenthesis. | 意外的右括号。 |
+| `formula-docs.ts:654` | Unexpected closing array bracket. | 意外的右方括号。 |
+| `formula-docs.ts:667` | Unexpected closing field-reference brace. | 意外的字段引用右花括号。 |
+| `formula-docs.ts:675` | Quoted string is not closed. | 引号字符串未闭合。 |
+| `formula-docs.ts:678` | Parentheses are not balanced. | 圆括号不匹配。 |
+| `formula-docs.ts:681` | Array brackets are not balanced. | 方括号不匹配。 |
+| `formula-docs.ts:684` | Field reference braces are not balanced. | 字段引用花括号不匹配。 |
+| `formula-docs.ts:689` | Formula cannot end with a binary operator. | 公式不能以二元运算符结尾。 |
+| `formula-docs.ts:919` | Formula expression is empty. | 公式表达式为空。 |
+
+Dynamic diagnostics:
+
+| Source line | EN shape | zh shape | Raw values |
+| --- | --- | --- | --- |
+| `formula-docs.ts:889` | `${fn} has an empty argument.` | `${fn} 存在空参数。` | `fn` raw uppercase |
+| `formula-docs.ts:899` | `${fn} expects at least ${n} argument(s).` | `${fn} 至少需要 ${n} 个参数。` | `fn`, `n` raw |
+| `formula-docs.ts:907` | `${fn} expects at most ${n} argument(s).` | `${fn} 最多接受 ${n} 个参数。` | `fn`, `n` raw |
+| `formula-docs.ts:933` | `Field reference {${ref}} uses a name. Use the field chip to insert a stable {fld_xxx} token.` | `字段引用 {${ref}} 使用了名称。请使用字段标签插入稳定的 {fld_xxx} 令牌。` | `ref`, `{fld_xxx}` raw |
+| `formula-docs.ts:937` | `Unknown field reference {${ref}}.` | `未知字段引用 {${ref}}。` | `ref` raw |
+| `formula-docs.ts:946` | `${fn} is not documented in this editor yet.` | `${fn} 尚未在此编辑器中记录。` | `fn` raw uppercase |
+
+English pluralization stays byte-compatible for default callers: `argument` when `n === 1`, otherwise `arguments`. Chinese uses `个参数` for both.
+
+## 6. API Shape Changes
+
+Keep English default behavior for all existing callers:
+
+```ts
+export function getFormulaFunctionCategories(isZh = false): FormulaFunctionCategoryDoc[]
+export function searchFormulaFunctionDocs(query: string, isZh = false): FormulaFunctionDoc[]
+export function getFormulaFunctionCatalog(
+  query = '',
+  category: FormulaFunctionCategory | 'all' = 'all',
+  isZh = false,
+): FormulaFunctionCatalogSection[]
+export function validateFormulaExpression(expression: string, fields: MetaField[], isZh = false): FormulaDiagnostic[]
+```
+
+Implementation notes:
+
+- `FORMULA_FUNCTION_CATEGORIES` and `FORMULA_FUNCTION_DOCS` may remain the English default source of truth for backward compatibility.
+- Locale-aware functions should return cloned/localized objects, not mutate exported static arrays.
+- `searchFormulaFunctionDocs(query, true)` should search against `name`, `signature`, English description, and zh description.
+- `MetaFieldManager.vue` should switch `formulaFunctionCategories` from a raw constant to a computed locale-aware list.
+- `formulaCatalogSections` and `formulaDiagnostics` should pass `isZh.value`.
+
+## 7. Raw Boundary
+
+Do not translate:
+
+| Raw item | Reason |
+| --- | --- |
+| Function names (`SUM`, `IF`, `ROUND`) | Formula language tokens; backend/runtime-compatible. |
+| Function signatures (`SUM(number, ...)`) | Technical API syntax. |
+| Insert snippets (`ROUND(, 2)`, `10%`, `>=`) | Inserted into formula expression; must remain runtime-compatible. |
+| Formula examples (`=SUM({fld_price}, {fld_tax})`) | Copy-pastable formula syntax. |
+| Field IDs and refs (`fld_price`, `{fld_missing}`, `{Price}`) | User/schema tokens. |
+| Field names in chips (`Price`) | User-authored data. |
+| Unknown function names (`FOO`) | User formula token; raw in diagnostics. |
+| `diagnostic.severity` (`warning` / `error`) | CSS modifier state and persisted UI enum; never localize. |
+| Formula expression textarea placeholder | Raw syntax example, not prose. |
+
+M1 trap guard:
+
+- `:class="\`meta-field-mgr__formula-diagnostic--${diagnostic.severity}\`"` must keep `diagnostic.severity` raw.
+- Category `<option :value="category.id">` must keep category ID raw while display text localizes.
+
+## 8. A11y and Attribute Boundary
+
+Slice C localizes existing visible text and diagnostics only.
+
+Source count in `MetaFieldManager.vue` before implementation:
+
+```text
+aria-label=0
+title=9
+placeholder=13
+```
+
+Rules:
+
+- Do not add new `aria-label`, `title`, or `placeholder` attributes.
+- Do not localize formula syntax placeholders such as `=SUM({fld_price}, {fld_tax})`.
+- Existing `title` usage for field token insertion remains owned by `insertFieldTokenTitle(field.id, isZh)`.
+- Render specs should lock a formula-panel fixture sentinel for `[aria-label]`, `[title]`, and `[placeholder]` counts.
+
+## 9. Preflight Grep
+
+Before implementation, run source and reuse scans:
+
+```bash
+grep -R -n -E "Aggregate|Summarize numeric|Adds numeric|Formula expression is empty|Unexpected closing|not balanced|has an empty argument|expects at least|expects at most|Unknown field reference|not documented in this editor yet" \
+  apps/web/src/multitable/utils/formula-docs.ts \
+  apps/web/src/multitable/components/MetaFieldManager.vue \
+  apps/web/tests/multitable-formula-editor.spec.ts
+
+grep -R -n -E "field\\.formulaReference|field\\.formulaSearchPlaceholder|field\\.allCategories|field\\.noMatchingFunctions|insertFieldTokenTitle" \
+  apps/web/src/multitable/utils/meta-manager-labels.ts \
+  apps/web/src/multitable/components/MetaFieldManager.vue \
+  apps/web/tests
+```
+
+Verification MD must include:
+
+- The post-implementation grep result showing formula prose now flows through `meta-formula-labels.ts` or localized helper calls.
+- Reuse-key reachability evidence for existing `meta-manager-labels.ts` formula panel chrome.
+- A raw-boundary grep snippet for `diagnostic.severity`, formula examples, and insert snippets.
+
+## 10. Test Plan
+
+Unit tests:
+
+| Spec | Coverage |
+| --- | --- |
+| `meta-formula-labels.spec.ts` | 8 categories, representative function descriptions, all diagnostic helpers, EN default/zh output, unknown fallback, raw interpolation. |
+| `multitable-formula-editor.spec.ts` | Existing formula utility behavior remains EN by default; localized catalog and diagnostics with `isZh=true`; search matches both EN function names and zh descriptions. |
+
+Render tests:
+
+Extend `multitable-formula-editor.spec.ts`:
+
+- zh-CN formula panel renders `数学` / `运算符` category labels and zh descriptions while preserving `ROUND(number, digits)` and formula examples raw.
+- zh-CN unknown field reference renders `未知字段引用 {fld_missing}。` and does not call `update-field`.
+- zh-CN field-name warning preserves `{Price}` and `{fld_xxx}` raw.
+- Category `<option>` values remain raw (`math`, `operator`, etc.) while text localizes.
+- Formula-panel a11y sentinel counts stay unchanged for `[aria-label]`, `[title]`, `[placeholder]`.
+
+Validation commands:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/meta-formula-labels.spec.ts \
+  tests/multitable-formula-editor.spec.ts \
+  tests/multitable-field-manager.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web run type-check
+pnpm --filter @metasheet/web build
+git diff --check origin/main..HEAD
+```
+
+## 11. Implementation Order
+
+1. Rebase to latest `origin/main` and verify the branch is clean.
+2. Run the preflight grep commands in Section 9.
+3. Add `meta-formula-labels.ts` with category, function-description, and diagnostic helpers.
+4. Extend `formula-docs.ts` optional `isZh = false` APIs; keep exported default arrays English and immutable.
+5. Wire `MetaFieldManager.vue` formula category/catalog/diagnostic computed values to `isZh.value`.
+6. Add `meta-formula-labels.spec.ts`.
+7. Extend `multitable-formula-editor.spec.ts` for EN default, zh catalog/diagnostics, raw boundary, and a11y sentinels.
+8. Write verification MD with preflight/reuse/raw/a11y evidence.
+9. Run validation commands.
+10. Commit only Slice C files and stop before push.
+
+## 12. Risks
+
+| Risk | Mitigation |
+| --- | --- |
+| Mutating exported catalog arrays breaks EN default callers | Return localized clones; keep `FORMULA_FUNCTION_DOCS` and `FORMULA_FUNCTION_CATEGORIES` English. |
+| Search becomes worse in zh mode | Search name/signature plus both EN and localized descriptions. |
+| Unknown formula descriptions render misleading text | `formulaFunctionDescription()` returns `''` for unknown names; spec covers the empty fallback. |
+| Function signatures/examples accidentally translated | Helper spec and render spec assert signatures/examples remain raw. |
+| CSS class state localized by accident | `diagnostic.severity` remains raw; spec checks class modifier. |
+| Dynamic diagnostic raw values get localized | Helper tests cover raw `ROUND`, `{Price}`, `{fld_missing}`, and unknown `FOO`. |
+| Label-module cycle | Use type-only imports from `formula-docs.ts` in `meta-formula-labels.ts`, or keep formula label helpers type-light. |
+| Slice C grows into manager rewrite | Reuse existing manager keys and only touch formula panel data. |
+| Slice D API fallbacks get mixed in | API client fallback architecture remains explicitly deferred. |
+
+## 13. Approval Gate
+
+Implementation is ready for review when:
+
+- `meta-formula-labels.ts` owns formula-only copy and no formula description/diagnostic key is duplicated in `meta-manager-labels.ts`.
+- English default API behavior remains compatible with existing tests.
+- zh-CN catalog and diagnostics render through `MetaFieldManager.vue`.
+- Raw formula syntax, function signatures, examples, insert snippets, field refs, field names, and severity enums are preserved.
+- A11y/title/placeholder counts do not increase.
+- Verification MD includes preflight grep, reuse-key reachability, raw-boundary, and validation evidence.

--- a/docs/development/multitable-final-audit-formula-docs-verification-20260522.md
+++ b/docs/development/multitable-final-audit-formula-docs-verification-20260522.md
@@ -1,0 +1,180 @@
+# Multitable Final Audit Slice C Verification — Formula Docs and Diagnostics
+
+Date: 2026-05-22
+Branch: `frontend/multitable-final-audit-formula-docs-design-20260522`
+Base: `origin/main@149ec98e6` (`docs(attendance): close advanced scheduling read-only boundary (#1759)`)
+
+## 1. DoD
+
+Slice C is complete when formula catalog copy and formula diagnostics are locale-aware without changing formula syntax or runtime contracts.
+
+Result: PASS.
+
+| Gate | Result |
+| --- | --- |
+| Formula label module added | PASS: `meta-formula-labels.ts` owns formula category/function/diagnostic chrome. |
+| English default compatibility | PASS: existing formula editor tests still assert EN default strings. |
+| zh-CN catalog render | PASS: render spec asserts `数学` and zh description while keeping `ROUND(number, digits)` raw. |
+| zh-CN diagnostics render | PASS: render spec asserts `未知字段引用 {fld_missing}。` and preserves `--error` class state. |
+| Raw syntax preserved | PASS: signatures, examples, insert snippets, field refs, and function names remain raw. |
+| A11y boundary | PASS: formula-panel fixture locks `[aria-label]/[title]/[placeholder] = 0/13/3`; no new attributes added. |
+| Type-only import guard | PASS: `meta-formula-labels.ts` imports `formula-docs.ts` types only, avoiding a runtime cycle. |
+
+## 2. Files Changed
+
+```text
+apps/web/src/multitable/utils/meta-formula-labels.ts          NEW
+apps/web/src/multitable/utils/formula-docs.ts                 MOD
+apps/web/src/multitable/components/MetaFieldManager.vue       MOD
+apps/web/tests/meta-formula-labels.spec.ts                    NEW
+apps/web/tests/multitable-formula-editor.spec.ts              MOD
+docs/development/multitable-final-audit-formula-docs-design-20260522.md        NEW
+docs/development/multitable-final-audit-formula-docs-verification-20260522.md  NEW
+```
+
+Out of scope and untouched: backend, contracts, migrations, attendance runtime code, K3 scripts, API client fallback architecture, visual view render module, manager non-formula chrome.
+
+## 3. Preflight and Reachability Evidence
+
+Formula source grep after implementation:
+
+```text
+apps/web/src/multitable/utils/formula-docs.ts:54:  { id: 'aggregate', label: 'Aggregate', description: 'Summarize numeric or non-empty values.' },
+apps/web/src/multitable/utils/formula-docs.ts:69:    description: 'Adds numeric values together.',
+apps/web/tests/multitable-formula-editor.spec.ts:37:    ])).toContainEqual({ severity: 'error', message: 'Unknown field reference {fld_missing}.' })
+apps/web/tests/multitable-formula-editor.spec.ts:49:      message: 'Array brackets are not balanced.',
+apps/web/tests/multitable-formula-editor.spec.ts:53:      message: 'Field reference braces are not balanced.',
+apps/web/tests/multitable-formula-editor.spec.ts:61:      message: 'Parentheses are not balanced.',
+apps/web/tests/multitable-formula-editor.spec.ts:74:      message: 'IF expects at least 3 arguments.',
+apps/web/tests/multitable-formula-editor.spec.ts:78:      message: 'ROUND expects at most 2 arguments.',
+apps/web/tests/multitable-formula-editor.spec.ts:82:      message: 'ROUND has an empty argument.',
+apps/web/tests/multitable-formula-editor.spec.ts:86:      message: 'DATEDIF expects at least 3 arguments.',
+apps/web/tests/multitable-formula-editor.spec.ts:90:      message: 'TODAY expects at most 0 arguments.',
+apps/web/src/multitable/utils/meta-formula-labels.ts:29:    label: { en: 'Aggregate', zh: '聚合' },
+apps/web/src/multitable/utils/meta-formula-labels.ts:30:    description: { en: 'Summarize numeric or non-empty values.', zh: '汇总数字或非空值。' },
+apps/web/src/multitable/utils/meta-formula-labels.ts:63:  SUM: { en: 'Adds numeric values together.', zh: '将数字值相加。' },
+apps/web/src/multitable/utils/meta-formula-labels.ts:120:  'diagnostic.unexpectedClosingParenthesis': { en: 'Unexpected closing parenthesis.', zh: '意外的右括号。' },
+apps/web/src/multitable/utils/meta-formula-labels.ts:128:  'diagnostic.emptyExpression': { en: 'Formula expression is empty.', zh: '公式表达式为空。' },
+apps/web/src/multitable/utils/meta-formula-labels.ts:161:    : `${functionName} has an empty argument.`
+apps/web/src/multitable/utils/meta-formula-labels.ts:167:    : `${functionName} expects at least ${count} argument${count === 1 ? '' : 's'}.`
+apps/web/src/multitable/utils/meta-formula-labels.ts:173:    : `${functionName} expects at most ${count} argument${count === 1 ? '' : 's'}.`
+apps/web/src/multitable/utils/meta-formula-labels.ts:185:    : `Unknown field reference {${ref}}.`
+apps/web/src/multitable/utils/meta-formula-labels.ts:191:    : `${functionName} is not documented in this editor yet.`
+```
+
+Interpretation: remaining EN literals in `formula-docs.ts` are the immutable default English catalog arrays. Remaining EN literals in tests are EN-baseline assertions. Runtime localized prose now lives in `meta-formula-labels.ts` or flows through helper calls.
+
+Existing manager formula panel reuse grep:
+
+```text
+apps/web/src/multitable/utils/meta-manager-labels.ts:30:  | 'field.formulaReference' | 'field.formulaSearchPlaceholder'
+apps/web/src/multitable/utils/meta-manager-labels.ts:31:  | 'field.allCategories' | 'field.noMatchingFunctions'
+apps/web/src/multitable/utils/meta-manager-labels.ts:157:  'field.formulaReference': { en: 'Formula reference', zh: '公式参考' },
+apps/web/src/multitable/utils/meta-manager-labels.ts:158:  'field.formulaSearchPlaceholder': { en: 'Search SUM, IF, %, ^, &...', zh: '搜索 SUM、IF、%、^、&...' },
+apps/web/src/multitable/utils/meta-manager-labels.ts:159:  'field.allCategories': { en: 'All categories', zh: '全部分类' },
+apps/web/src/multitable/utils/meta-manager-labels.ts:160:  'field.noMatchingFunctions': { en: 'No matching functions.', zh: '没有匹配的函数。' },
+apps/web/src/multitable/utils/meta-manager-labels.ts:310:export function insertFieldTokenTitle(fieldId: string, isZh: boolean): string {
+apps/web/src/multitable/components/MetaFieldManager.vue:184:                :title="insertFieldTokenTitle(field.id, isZh)"
+apps/web/src/multitable/components/MetaFieldManager.vue:190:            <span>{{ ml('field.formulaReference') }}</span>
+apps/web/src/multitable/components/MetaFieldManager.vue:195:                :placeholder="ml('field.formulaSearchPlaceholder')"
+apps/web/src/multitable/components/MetaFieldManager.vue:198:                <option value="all">{{ ml('field.allCategories') }}</option>
+apps/web/src/multitable/components/MetaFieldManager.vue:229:            <div v-else class="meta-field-mgr__formula-empty">{{ ml('field.noMatchingFunctions') }}</div>
+```
+
+Type-only import cycle guard:
+
+```text
+apps/web/src/multitable/utils/meta-formula-labels.ts:7:import type {
+```
+
+The new formula label module imports only types from `formula-docs.ts`; `formula-docs.ts` imports runtime helpers from `meta-formula-labels.ts`.
+
+## 4. Raw Boundary Evidence
+
+Raw syntax and selector state grep:
+
+```text
+apps/web/src/multitable/utils/formula-docs.ts:70:    example: '=SUM({fld_price}, {fld_tax})',
+apps/web/src/multitable/utils/formula-docs.ts:115:    signature: 'ROUND(number, digits)',
+apps/web/src/multitable/utils/formula-docs.ts:119:    insertText: 'ROUND(, 2)',
+apps/web/src/multitable/components/MetaFieldManager.vue:164:            <textarea v-model="formulaDraft.expression" class="meta-field-mgr__textarea" placeholder="=SUM({fld_price}, {fld_tax})"></textarea>
+apps/web/src/multitable/components/MetaFieldManager.vue:171:              :class="`meta-field-mgr__formula-diagnostic--${diagnostic.severity}`"
+apps/web/src/multitable/components/MetaFieldManager.vue:1048:    const blockingDiagnostic = formulaDiagnostics.value.find((diagnostic) => diagnostic.severity === 'error')
+apps/web/src/multitable/components/MetaFieldManager.vue:1357:.meta-field-mgr__formula-diagnostic--warning { background: #fff7e6; color: #8a5a00; border: 1px solid #f3d19e; }
+apps/web/src/multitable/components/MetaFieldManager.vue:1358:.meta-field-mgr__formula-diagnostic--error { background: #fef0f0; color: #c0392b; border: 1px solid #fbc4c4; }
+apps/web/tests/multitable-formula-editor.spec.ts:385:    expect(container.textContent).toContain('ROUND(number, digits)')
+apps/web/tests/multitable-formula-editor.spec.ts:387:    expect(container.textContent).toContain('未知字段引用 {fld_missing}。')
+apps/web/tests/multitable-formula-editor.spec.ts:389:    expect(container.querySelector('.meta-field-mgr__formula-diagnostic--error')).toBeTruthy()
+```
+
+Raw values covered by tests:
+
+| Raw value | Evidence |
+| --- | --- |
+| Function names | `ROUND`, `IF`, `TODAY`, `FOO` asserted raw in helper/spec diagnostics. |
+| Function signatures | `ROUND(number, digits)` asserted visible in zh render. |
+| Examples and insert snippets | `=ROUND({fld_amount}, 2)` and `ROUND(, 2)` remain raw. |
+| Field refs | `{Price}`, `{fld_missing}`, `{fld_xxx}` asserted raw inside zh diagnostics. |
+| Category option value | `option[value="math"]` remains raw while option text is `数学`. |
+| Severity enum | `.meta-field-mgr__formula-diagnostic--error` asserted raw. |
+
+## 5. A11y Boundary
+
+Source-level before implementation:
+
+```text
+MetaFieldManager.vue aria-label=0
+MetaFieldManager.vue title=9
+MetaFieldManager.vue placeholder=13
+```
+
+Formula-panel fixture after implementation:
+
+```text
+[aria-label] = 0
+[title] = 13
+[placeholder] = 3
+```
+
+The fixture count differs from source count because only a subset of conditional UI is rendered in the formula panel, while repeated field rows and field-token chip titles are present. The spec locks the fixture count to prevent adding new a11y attributes in this slice.
+
+## 6. Validation
+
+Post-ff base rerun on `origin/main@149ec98e6`:
+
+```text
+pnpm --filter @metasheet/web exec vitest run tests/meta-formula-labels.spec.ts tests/multitable-formula-editor.spec.ts tests/multitable-field-manager.spec.ts --watch=false
+
+Test Files  3 passed (3)
+Tests       34 passed (34)
+```
+
+```text
+pnpm --filter @metasheet/web run type-check
+
+> vue-tsc -b
+exit 0
+```
+
+```text
+pnpm --filter @metasheet/web build
+
+✓ 2422 modules transformed.
+✓ built in 6.31s
+```
+
+Build warning observed and unchanged in character:
+
+```text
+WorkflowDesigner.vue is dynamically imported by appRoutes.ts but also statically imported by viewRegistry.ts and AttendanceWorkflowDesigner.vue.
+```
+
+This is a pre-existing bundling warning unrelated to formula docs.
+
+## 7. Notes
+
+- `formulaFunctionDescription('FOO', true)` returns `''` by design. Empty means "unknown function has no description"; the helper does not invent description text by echoing the function name.
+- `FORMULA_FUNCTION_CATEGORIES` and `FORMULA_FUNCTION_DOCS` remain English default arrays. Locale-aware APIs return cloned localized objects.
+- `searchFormulaFunctionDocs(query, true)` searches raw function names/signatures, English descriptions, and zh descriptions. Specs cover `SUM`, `Adds`, and `相加`.
+- `MetaFieldManager.vue` formula catalog and diagnostics now read `isZh.value` at render/computed time; locale toggles re-render the formula docs/diagnostics rather than storing event-time strings.
+- `apps/web/dist/` and `apps/web/node_modules` may be present from local build/install state; they are ignored and not part of the intended PR diff.


### PR DESCRIPTION
## Summary

Third final-audit slice. Localizes formula reference catalog and formula diagnostics:

- Adds `meta-formula-labels.ts` for formula-only copy: 8 categories, 54 function descriptions, 9 static diagnostics, and 6 dynamic diagnostic helpers.
- Extends `formula-docs.ts` APIs with optional `isZh = false` while preserving EN default compatibility.
- Wires `MetaFieldManager.vue` formula category/catalog/diagnostic computeds to `isZh.value` for reactive locale rendering.
- Preserves raw formula syntax: function names, signatures, examples, insert snippets, field refs, category option values, and diagnostic severity CSS modifiers.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/meta-formula-labels.spec.ts tests/multitable-formula-editor.spec.ts tests/multitable-field-manager.spec.ts --watch=false`
- `pnpm --filter @metasheet/web run type-check`
- `pnpm --filter @metasheet/web build`
- `git diff --check origin/main..HEAD`

## Notes

- Design: `docs/development/multitable-final-audit-formula-docs-design-20260522.md`
- Verification: `docs/development/multitable-final-audit-formula-docs-verification-20260522.md`
- Next: Slice D API/client fallback errors.
