### PR TITLE
fix(attendance): flag truncated advanced scheduling workbench snapshots

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -4375,6 +4375,16 @@
                 </span>
               </div>
 
+              <div
+                v-if="advancedSchedulingWorkbenchTruncationWarning"
+                class="attendance__schedule-conflict-diagnostics"
+                data-attendance-advanced-scheduling-truncation
+                role="alert"
+              >
+                <strong>{{ tr('Snapshot truncated', '快照已截断') }}</strong>
+                <p>{{ advancedSchedulingWorkbenchTruncationWarning }}</p>
+              </div>
+
               <div class="attendance__summary attendance__summary--workbench" data-attendance-advanced-scheduling-metrics>
                 <div
                   v-for="item in advancedSchedulingWorkbenchMetricItems"
@@ -5961,6 +5971,12 @@ interface AttendanceAdvancedSchedulingWorkbench {
   metadata?: {
     readOnly?: boolean
     source?: string
+    truncation?: {
+      assignmentLimit?: number
+      shiftAssignments?: boolean
+      rotationAssignments?: boolean
+      truncated?: boolean
+    }
   }
 }
 
@@ -6362,6 +6378,34 @@ const advancedSchedulingWorkbenchReadOnlyLabel = computed(() =>
     ? tr('Read-only snapshot', '只读快照')
     : tr('Not loaded', '未加载')
 )
+
+const advancedSchedulingWorkbenchTruncationWarning = computed(() => {
+  const truncation = advancedSchedulingWorkbench.value?.metadata?.truncation
+  if (!truncation?.truncated) return ''
+  const limit = Number(truncation.assignmentLimit) || 500
+  if (truncation.shiftAssignments && truncation.rotationAssignments) {
+    return tr(
+      `Shift and rotation assignment snapshots are capped at ${limit} rows each; coverage counts may be lower than actual.`,
+      `固定班与轮班分配快照分别最多显示 ${limit} 行，覆盖统计可能低于实际。`,
+    )
+  }
+  if (truncation.shiftAssignments) {
+    return tr(
+      `Shift assignment snapshot is capped at ${limit} rows; coverage counts may be lower than actual.`,
+      `固定班分配快照最多显示 ${limit} 行，覆盖统计可能低于实际。`,
+    )
+  }
+  if (truncation.rotationAssignments) {
+    return tr(
+      `Rotation assignment snapshot is capped at ${limit} rows; coverage counts may be lower than actual.`,
+      `轮班分配快照最多显示 ${limit} 行，覆盖统计可能低于实际。`,
+    )
+  }
+  return tr(
+    `Assignment snapshot is capped at ${limit} rows; coverage counts may be lower than actual.`,
+    `分配快照最多显示 ${limit} 行，覆盖统计可能低于实际。`,
+  )
+})
 
 const reportRangeLabel = computed(() => {
   if (!fromDate.value || !toDate.value) return tr('Range not set', '区间未设置')

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -246,6 +246,12 @@ describe('Attendance admin regressions', () => {
             metadata: {
               readOnly: true,
               source: 'attendance_advanced_scheduling_workbench',
+              truncation: {
+                assignmentLimit: 500,
+                shiftAssignments: true,
+                rotationAssignments: false,
+                truncated: true,
+              },
             },
           },
         })
@@ -782,6 +788,7 @@ describe('Attendance admin regressions', () => {
     expect(section).toBeTruthy()
     expect(window.getComputedStyle(section!).display).not.toBe('none')
     expect(section!.textContent).toContain('Read-only snapshot')
+    expect(section!.querySelector('[data-attendance-advanced-scheduling-truncation]')?.textContent).toContain('Shift assignment snapshot is capped at 500 rows')
     expect(section!.querySelector('[data-attendance-advanced-scheduling-metric="schedule-groups"]')?.textContent).toContain('1')
     expect(section!.querySelector('[data-attendance-advanced-scheduling-metric="assignments"]')?.textContent).toContain('2')
     expect(section!.querySelector('[data-attendance-advanced-scheduling-diagnostic="assignment_without_schedule_group"]')?.textContent).toContain('1')

--- a/docs/development/attendance-advanced-scheduling-workbench-truncation-development-20260522.md
+++ b/docs/development/attendance-advanced-scheduling-workbench-truncation-development-20260522.md
@@ -1,0 +1,84 @@
+# Attendance Advanced Scheduling Workbench Truncation Development
+
+Date: 2026-05-22
+Branch: `codex/attendance-advanced-scheduling-truncation-20260522`
+
+## Summary
+
+This slice hardens the read-only advanced scheduling workbench shipped in
+`#1755`. The workbench assignment queries previously used `LIMIT 500`; large
+tenants could therefore see lower-than-actual assignment coverage counts without
+an explicit UI signal. This change keeps the route read-only and adds honest
+truncation metadata plus a frontend warning.
+
+## Changed Files
+
+| File | Change |
+| --- | --- |
+| `plugins/plugin-attendance/index.cjs` | Adds `ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT`, queries assignment rows with `limit + 1`, slices visible rows back to the limit, and returns `metadata.truncation`. |
+| `apps/web/src/views/AttendanceView.vue` | Adds `metadata.truncation` typing, computes a read-only truncation warning, and renders it in the workbench panel. |
+| `packages/core-backend/tests/unit/attendance-advanced-scheduling-workbench.test.ts` | Locks truncation metadata and verifies the route keeps limit+1 read behavior with visible-row slicing. |
+| `apps/web/tests/attendance-admin-regressions.spec.ts` | Verifies the frontend warning renders while the panel remains read-only. |
+| `docs/development/attendance-advanced-scheduling-workbench-truncation-development-20260522.md` | This note. |
+| `docs/development/attendance-advanced-scheduling-workbench-truncation-verification-20260522.md` | Verification evidence. |
+
+## Backend Contract
+
+The route remains:
+
+```text
+GET /api/attendance/advanced-scheduling/workbench
+```
+
+It still writes nothing and still requires `attendance:admin`.
+
+Assignment query behavior:
+
+- Query up to `ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT + 1`
+  rows for shift assignments.
+- Query up to the same `limit + 1` rows for rotation assignments.
+- If either query returns more than the configured limit, set the matching
+  truncation flag.
+- Slice rows back to the configured limit before building the visible snapshot.
+
+Returned metadata:
+
+```json
+{
+  "metadata": {
+    "readOnly": true,
+    "source": "attendance_advanced_scheduling_workbench",
+    "truncation": {
+      "assignmentLimit": 500,
+      "shiftAssignments": false,
+      "rotationAssignments": false,
+      "truncated": false
+    }
+  }
+}
+```
+
+## Frontend Contract
+
+When `metadata.truncation.truncated` is true, the workbench renders a warning
+banner that names the truncated assignment type and the row cap. The warning is
+purely informational; it does not add edit, export, sync, or retry behavior.
+
+## Boundary
+
+| Boundary | Decision |
+| --- | --- |
+| Write path | Not added. |
+| Grid edit / import / copy-paste | Not added. |
+| Migration | Not added. |
+| `attendance_*` writes | Not added. |
+| Direct `meta_*` writes | Not added. |
+| Multitable | Not touched. |
+| Data Factory / Bridge Agent | Not touched. |
+
+## Follow-Up
+
+If real tenants hit truncation often, a future read-only slice can replace the
+row fetch with aggregate SQL or paginated diagnostics. That remains separate
+from any advanced scheduling write-path work, which is still locked until
+explicit customer opt-in or K3 PoC stage-1 GATE PASS.

--- a/docs/development/attendance-advanced-scheduling-workbench-truncation-verification-20260522.md
+++ b/docs/development/attendance-advanced-scheduling-workbench-truncation-verification-20260522.md
@@ -1,0 +1,67 @@
+# Attendance Advanced Scheduling Workbench Truncation Verification
+
+Date: 2026-05-22
+Branch: `codex/attendance-advanced-scheduling-truncation-20260522`
+
+## Scope Verification
+
+| Area | Result |
+| --- | --- |
+| Runtime domain | Attendance only |
+| Data Factory / Bridge Agent | Not touched |
+| New migration | None |
+| Schedule write path | None added |
+| Direct `meta_*` writes | None |
+| Multitable writes | None |
+| Secrets / tokens | None |
+
+## Acceptance Criteria
+
+| Criterion | Evidence |
+| --- | --- |
+| Workbench no longer silently truncates assignment snapshots | Backend route queries `limit + 1`, slices visible rows to the limit, and returns `metadata.truncation`. |
+| UI shows a reviewer/operator-visible warning | Frontend renders `data-attendance-advanced-scheduling-truncation` when truncation is true. |
+| Existing read-only boundary remains intact | No write route, migration, grid edit, import, copy-paste, or multitable behavior added. |
+| Tests lock both backend and frontend behavior | Backend helper/source test and frontend regression test updated. |
+
+## Verification Commands
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/attendance-advanced-scheduling-workbench.test.ts \
+  tests/unit/attendance-advanced-scheduling-scope.test.ts \
+  tests/unit/attendance-scheduling-assignment-conflict.test.ts \
+  --reporter=dot
+
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/attendance-admin-anchor-nav.spec.ts \
+  tests/attendance-admin-regressions.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web type-check
+
+pnpm --filter @metasheet/core-backend build
+
+git diff --check
+```
+
+## Results
+
+| Check | Result |
+| --- | --- |
+| Plugin syntax | PASS |
+| Backend advanced scheduling tests | PASS, 14 tests |
+| Frontend admin nav + regression tests | PASS, 34 tests |
+| Web type-check | PASS |
+| Core backend build | PASS |
+| `git diff --check` | PASS |
+
+## Notes
+
+- No live staging/prod operation is required for this slice. It is a local,
+  read-only response-shape hardening.
+- If frontend Vitest emits `WebSocket server error: Port is already in use` but
+  the targeted specs pass, record it as an environment warning rather than a
+  product regression.

--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-workbench.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-workbench.test.ts
@@ -49,6 +49,12 @@ describe('attendance advanced scheduling read-only workbench', () => {
     expect(workbench.metadata).toEqual({
       readOnly: true,
       source: 'attendance_advanced_scheduling_workbench',
+      truncation: {
+        assignmentLimit: 500,
+        shiftAssignments: false,
+        rotationAssignments: false,
+        truncated: false,
+      },
     })
     expect(workbench.summary).toMatchObject({
       scheduleGroups: 2,
@@ -79,6 +85,39 @@ describe('attendance advanced scheduling read-only workbench', () => {
     ])
   })
 
+  it('reports assignment snapshot truncation metadata without changing the read-only summary shape', () => {
+    const shiftAssignments = Array.from({ length: 500 }, (_, index) => ({
+      assignment: {
+        id: `sa-${index}`,
+        userId: `user-${index}`,
+        shiftId: 'shift-a',
+        startDate: '2026-06-01',
+        endDate: null,
+        isActive: true,
+      },
+      shift: { id: 'shift-a', name: 'Day' },
+    }))
+
+    const workbench = helpers.buildAttendanceAdvancedSchedulingWorkbench({
+      from: '2026-06-01',
+      to: '2026-06-30',
+      scheduleGroups: [],
+      shiftAssignments,
+      assignmentLimit: 500,
+      shiftAssignmentsTruncated: true,
+      rotationAssignmentsTruncated: false,
+    })
+
+    expect(workbench.summary.shiftAssignments).toBe(500)
+    expect(workbench.assignments.shiftItems).toHaveLength(500)
+    expect(workbench.metadata.truncation).toEqual({
+      assignmentLimit: 500,
+      shiftAssignments: true,
+      rotationAssignments: false,
+      truncated: true,
+    })
+  })
+
   it('registers a read-only attendance-admin GET route and no sibling write route', () => {
     expect(pluginSource).toMatch(
       /'GET',\s*\n\s*'\/api\/attendance\/advanced-scheduling\/workbench',\s*\n\s*withPermission\('attendance:admin'/,
@@ -86,5 +125,8 @@ describe('attendance advanced scheduling read-only workbench', () => {
     expect(pluginSource).not.toContain("'POST',\n      '/api/attendance/advanced-scheduling/workbench'")
     expect(pluginSource).not.toContain("'PUT',\n      '/api/attendance/advanced-scheduling/workbench'")
     expect(pluginSource).not.toContain("'DELETE',\n      '/api/attendance/advanced-scheduling/workbench'")
+    expect(pluginSource).toContain('LIMIT ${ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT + 1}')
+    expect(pluginSource).toContain('visibleShiftAssignmentRows = shiftAssignmentRows.slice(0, ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT)')
+    expect(pluginSource).toContain('visibleRotationAssignmentRows = rotationAssignmentRows.slice(0, ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT)')
   })
 })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -7478,6 +7478,8 @@ function buildAttendanceAdvancedSchedulingDiagnostic({ code, severity = 'info', 
   }
 }
 
+const ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT = 500
+
 function buildAttendanceAdvancedSchedulingWorkbench(input = {}) {
   const from = normalizeDateOnly(input.from) ?? null
   const to = normalizeDateOnly(input.to) ?? null
@@ -7488,6 +7490,15 @@ function buildAttendanceAdvancedSchedulingWorkbench(input = {}) {
   const rotationRules = Array.isArray(input.rotationRules) ? input.rotationRules : []
   const shiftAssignments = Array.isArray(input.shiftAssignments) ? input.shiftAssignments : []
   const rotationAssignments = Array.isArray(input.rotationAssignments) ? input.rotationAssignments : []
+  const assignmentLimit = Number.isFinite(Number(input.assignmentLimit))
+    ? Math.max(0, Math.floor(Number(input.assignmentLimit)))
+    : ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT
+  const truncation = {
+    assignmentLimit,
+    shiftAssignments: Boolean(input.shiftAssignmentsTruncated),
+    rotationAssignments: Boolean(input.rotationAssignmentsTruncated),
+    truncated: Boolean(input.shiftAssignmentsTruncated || input.rotationAssignmentsTruncated),
+  }
 
   const membersByGroupId = new Map()
   const groupIdsByUserId = new Map()
@@ -7627,6 +7638,7 @@ function buildAttendanceAdvancedSchedulingWorkbench(input = {}) {
     metadata: {
       readOnly: true,
       source: 'attendance_advanced_scheduling_workbench',
+      truncation,
     },
   }
 }
@@ -25222,7 +25234,7 @@ module.exports = {
                  AND a.start_date <= $3::date
                  AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
                ORDER BY a.start_date DESC, a.created_at DESC
-               LIMIT 500`,
+               LIMIT ${ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT + 1}`,
               [orgId, rangeStart, rangeEnd]
             ),
             db.query(
@@ -25237,10 +25249,15 @@ module.exports = {
                  AND a.start_date <= $3::date
                  AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
                ORDER BY a.start_date DESC, a.created_at DESC
-               LIMIT 500`,
+               LIMIT ${ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT + 1}`,
               [orgId, rangeStart, rangeEnd]
             ),
           ])
+
+          const shiftAssignmentsTruncated = shiftAssignmentRows.length > ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT
+          const rotationAssignmentsTruncated = rotationAssignmentRows.length > ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT
+          const visibleShiftAssignmentRows = shiftAssignmentRows.slice(0, ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT)
+          const visibleRotationAssignmentRows = rotationAssignmentRows.slice(0, ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT)
 
           const data = buildAttendanceAdvancedSchedulingWorkbench({
             from,
@@ -25250,14 +25267,17 @@ module.exports = {
             schedulerScopes: schedulerScopeRows.map(mapAttendanceSchedulerScopeRow),
             shifts: shiftRows.map(mapShiftRow),
             rotationRules: rotationRuleRows.map(mapRotationRuleRow),
-            shiftAssignments: shiftAssignmentRows.map(row => ({
+            shiftAssignments: visibleShiftAssignmentRows.map(row => ({
               assignment: mapAssignmentRow(row),
               shift: mapShiftFromAssignmentRow(row),
             })),
-            rotationAssignments: rotationAssignmentRows.map(row => ({
+            rotationAssignments: visibleRotationAssignmentRows.map(row => ({
               assignment: mapRotationAssignmentRow(row),
               rotation: mapRotationRuleFromAssignmentRow(row),
             })),
+            assignmentLimit: ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT,
+            shiftAssignmentsTruncated,
+            rotationAssignmentsTruncated,
           })
           res.json({ ok: true, data })
         } catch (error) {


### PR DESCRIPTION
## Summary

Hardens the read-only advanced scheduling workbench from #1755 so large tenants do not get silently under-counted assignment coverage.

- queries shift/rotation assignment snapshots with limit+1 and slices visible rows back to 500
- returns metadata.truncation with per-assignment-type flags
- renders a read-only frontend warning when a snapshot is capped
- keeps the route GET-only/admin-only and adds no scheduling write path

## Verification

- [x] node --check plugins/plugin-attendance/index.cjs
- [x] backend advanced scheduling tests: 14 pass
- [x] frontend admin nav + regression tests: 34 pass
- [x] pnpm --filter @metasheet/web type-check
- [x] pnpm --filter @metasheet/core-backend build
- [x] git diff --check

Note: frontend Vitest emitted the known nonfatal WebSocket port-in-use warning while both targeted specs passed.

## Boundary

Read-only hardening only. No migration, no attendance_* write, no direct meta_* write, no multitable behavior, no grid edit/copy/import/temporary-shift write path.