### PR TITLE
fix(integration): run K3 GATE checker on Windows

### DIFF
--- a/docs/development/k3wise-gate-contract-check-windows-entry-design-20260522.md
+++ b/docs/development/k3wise-gate-contract-check-windows-entry-design-20260522.md
@@ -1,0 +1,75 @@
+# K3 WISE GATE Contract Checker Windows Entrypoint Design - 2026-05-22
+
+## Context
+
+Entity-machine validation of release `multitable-onprem-k3wise-20260522-60f20a186`
+found that the documented Windows command returned exit code `0` but created no
+template directory:
+
+```bash
+node scripts/ops/integration-k3wise-gate-contract-check.mjs --init-template <dir>
+```
+
+The same package could generate the handoff packet only through a temporary
+wrapper that forced `main()` to run.
+
+## Root Cause
+
+The checker used this direct-run guard:
+
+```js
+if (import.meta.url === `file://${process.argv[1]}`) {
+  main()
+}
+```
+
+That happens to work for POSIX absolute paths such as `/repo/script.mjs`, but it
+does not match Windows paths such as `C:\metasheet\scripts\ops\script.mjs`.
+Node exits successfully after importing the module, but `main()` is never
+called, so no output directory is created.
+
+## Change
+
+The checker now resolves `import.meta.url` with `fileURLToPath()` and compares
+that filesystem path with `process.argv[1]` after platform-aware normalization:
+
+- POSIX paths are compared exactly after `path.resolve()` / `path.normalize()`.
+- Windows paths use `path.win32` normalization and case-insensitive comparison.
+
+This keeps the command behavior unchanged on macOS/Linux while making Windows
+direct execution invoke `main()` correctly.
+
+## Scope
+
+Changed:
+
+- `scripts/ops/integration-k3wise-gate-contract-check.mjs`
+- `scripts/ops/integration-k3wise-gate-contract-check.test.mjs`
+
+Not changed:
+
+- K3 WebAPI runtime
+- SQL Bridge Agent runtime
+- Data Factory pipelines
+- DB schema or migrations
+- K3 Save / Submit / Audit
+
+## Compatibility
+
+The script remains an ESM CLI module and keeps the existing public CLI contract:
+
+```bash
+node scripts/ops/integration-k3wise-gate-contract-check.mjs --init-template <dir>
+node scripts/ops/integration-k3wise-gate-contract-check.mjs --input <packet.json> --out-dir <dir>
+```
+
+The helper `isDirectCliRun()` is exported only to make the Windows path behavior
+unit-testable on non-Windows development machines.
+
+## Deployment Impact
+
+No service restart behavior or runtime API changes are introduced. The fix takes
+effect when a new on-prem package includes the updated script.
+
+After packaging, the customer/operator should be able to run the documented
+Windows command directly without a wrapper copy.

--- a/docs/development/k3wise-gate-contract-check-windows-entry-verification-20260522.md
+++ b/docs/development/k3wise-gate-contract-check-windows-entry-verification-20260522.md
@@ -1,0 +1,102 @@
+# K3 WISE GATE Contract Checker Windows Entrypoint Verification - 2026-05-22
+
+## Local Verification
+
+### 1. Focused Checker Tests
+
+Command:
+
+```bash
+node --test scripts/ops/integration-k3wise-gate-contract-check.test.mjs
+```
+
+Expected:
+
+- Existing PASS packet behavior still passes.
+- Existing missing-answer template behavior still returns `GATE_BLOCKED`.
+- Existing secret scan behavior still rejects raw secrets.
+- Existing `--init-template` smoke still creates packet JSON, 8 sample skeletons,
+  and a blocked empty-template report.
+- New Windows direct-run guard test passes for:
+  - backslash Windows paths;
+  - forward-slash Windows paths;
+  - case-insensitive Windows paths;
+  - negative non-matching script path;
+  - POSIX direct-run path.
+
+### 2. CLI Template Smoke
+
+Command:
+
+```bash
+tmp_dir="$(mktemp -d)"
+node scripts/ops/integration-k3wise-gate-contract-check.mjs --init-template "$tmp_dir"
+test -f "$tmp_dir/README-CUSTOMER-HANDOFF.zh.md"
+test -f "$tmp_dir/k3wise-gate-contract-packet.template.json"
+find "$tmp_dir" -maxdepth 1 -name '*.redacted.json' | wc -l
+```
+
+Expected:
+
+- CLI exits `0`.
+- README exists.
+- Packet template exists.
+- Eight redacted sample skeletons exist.
+
+### 3. Existing GATE Contract Verify
+
+Command:
+
+```bash
+pnpm verify:integration-k3wise:gate-contract
+```
+
+Expected:
+
+- Full existing gate-contract verification remains green.
+
+### 4. Syntax / Whitespace
+
+Commands:
+
+```bash
+node --check scripts/ops/integration-k3wise-gate-contract-check.mjs
+git diff --check origin/main...HEAD
+```
+
+Expected:
+
+- Syntax check passes.
+- Diff check reports no whitespace or conflict-marker issues.
+
+## Entity-Machine Retest After Package
+
+After merge and package rebuild, retest the exact failed Windows command:
+
+```powershell
+node scripts\ops\integration-k3wise-gate-contract-check.mjs --init-template C:\metasheet\artifacts\k3wise-gate-contract-<sha>
+```
+
+PASS criteria:
+
+- Command exits `0`.
+- Target directory is created.
+- Directory contains `README-CUSTOMER-HANDOFF.zh.md`.
+- Directory contains `k3wise-gate-contract-packet.template.json`.
+- Directory contains 8 redacted sample skeletons.
+- Running the checker against the empty template returns expected
+  `GATE_BLOCKED`, not silent success.
+
+## Security Check
+
+This change does not alter packet contents or evidence rendering. Existing
+secret checks still cover:
+
+- JWT-shaped values;
+- Bearer tokens;
+- password/secret/token-like keys;
+- DB connection strings with credentials;
+- secret query parameters.
+
+No credentials, SQL connection strings, K3 tokens, session IDs, authority codes,
+or customer row values are introduced by this change.

--- a/scripts/ops/integration-k3wise-gate-contract-check.mjs
+++ b/scripts/ops/integration-k3wise-gate-contract-check.mjs
@@ -1,6 +1,7 @@
 #!/usr/bin/env node
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
+import { fileURLToPath } from 'node:url'
 
 const DEFAULT_OUTPUT_ROOT = 'output/integration-k3wise-gate-contract-check'
 const READ_ANSWER_IDS = [
@@ -757,7 +758,19 @@ async function main() {
   return report.exitCode
 }
 
-if (import.meta.url === `file://${process.argv[1]}`) {
+export function isDirectCliRun(moduleFilePath, entryFilePath, platform = process.platform) {
+  if (!entryFilePath) return false
+  const pathModule = platform === 'win32' ? path.win32 : path
+  const modulePath = pathModule.normalize(moduleFilePath)
+  const entryPath = pathModule.resolve(entryFilePath)
+  if (platform === 'win32') {
+    return modulePath.toLowerCase() === entryPath.toLowerCase()
+  }
+  return modulePath === entryPath
+}
+
+const moduleFilePath = fileURLToPath(import.meta.url)
+if (isDirectCliRun(moduleFilePath, process.argv[1])) {
   main()
     .then((code) => {
       process.exitCode = code

--- a/scripts/ops/integration-k3wise-gate-contract-check.test.mjs
+++ b/scripts/ops/integration-k3wise-gate-contract-check.test.mjs
@@ -6,7 +6,7 @@ import { spawnSync } from 'node:child_process'
 import { fileURLToPath } from 'node:url'
 import test from 'node:test'
 
-import { buildGateContractReport } from './integration-k3wise-gate-contract-check.mjs'
+import { buildGateContractReport, isDirectCliRun } from './integration-k3wise-gate-contract-check.mjs'
 
 const __dirname = path.dirname(fileURLToPath(import.meta.url))
 const repoRoot = path.resolve(__dirname, '..', '..')
@@ -241,4 +241,27 @@ test('init-template writes a safe fillable packet that is blocked until customer
   assert.equal(evidence.sections.relationshipMapping.answered, 0)
   assert.equal(evidence.sections.webapiReadList.samples.filter((sample) => sample.status === 'present').length, 4)
   assert.equal(evidence.sections.relationshipMapping.samples.filter((sample) => sample.status === 'present').length, 4)
+})
+
+test('direct-run guard accepts Windows script paths', () => {
+  const modulePath = 'C:\\metasheet\\scripts\\ops\\integration-k3wise-gate-contract-check.mjs'
+
+  assert.equal(isDirectCliRun(modulePath, modulePath, 'win32'), true)
+  assert.equal(
+    isDirectCliRun(modulePath, 'C:/metasheet/scripts/ops/integration-k3wise-gate-contract-check.mjs', 'win32'),
+    true,
+  )
+  assert.equal(
+    isDirectCliRun(modulePath, 'c:\\METASHEET\\scripts\\ops\\integration-k3wise-gate-contract-check.mjs', 'win32'),
+    true,
+  )
+  assert.equal(isDirectCliRun(modulePath, 'C:\\metasheet\\scripts\\ops\\other-checker.mjs', 'win32'), false)
+  assert.equal(
+    isDirectCliRun(
+      '/repo/scripts/ops/integration-k3wise-gate-contract-check.mjs',
+      '/repo/scripts/ops/integration-k3wise-gate-contract-check.mjs',
+      'linux',
+    ),
+    true,
+  )
 })


### PR DESCRIPTION
## Summary

Fixes the Windows CLI entrypoint bug reported from the entity-machine retest for `integration-k3wise-gate-contract-check.mjs`.

On Windows, the previous guard compared `import.meta.url` to `file://${process.argv[1]}`. With a path like `C:\metasheet\scripts\ops\integration-k3wise-gate-contract-check.mjs`, that comparison fails, so `main()` is never invoked: the command exits 0 but does not create the requested `--init-template` directory.

This PR switches the direct-run check to `fileURLToPath(import.meta.url)` plus platform-aware path normalization, with Windows case-insensitive comparison. The existing CLI contract stays the same.

## Scope

- Fix `scripts/ops/integration-k3wise-gate-contract-check.mjs` direct-run detection.
- Add a Windows path regression test.
- Add design and verification MD.

No K3 runtime, SQL Bridge runtime, API route, DB migration, Data Factory pipeline behavior, Save, Submit, or Audit changes.

## Verification

- `node --test scripts/ops/integration-k3wise-gate-contract-check.test.mjs` -> 6/6 PASS
- `pnpm verify:integration-k3wise:gate-contract` -> 6/6 PASS
- `node --check scripts/ops/integration-k3wise-gate-contract-check.mjs` -> PASS
- CLI smoke: `--init-template` creates README + packet JSON + 8 redacted samples; checking empty template returns exit 2 / `GATE_BLOCKED` / 23 blocked
- `bash -n scripts/ops/multitable-onprem-package-verify.sh` -> PASS
- `git diff --check origin/main...HEAD` -> PASS

## Follow-up after merge

Publish a fresh on-prem package and retest the documented Windows command directly, without the temporary wrapper:

`node scripts\ops\integration-k3wise-gate-contract-check.mjs --init-template C:\metasheet\artifacts\k3wise-gate-contract-<sha>`
