### PR TITLE
fix(attendance): aggregate advanced scheduling workbench metrics

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -5977,6 +5977,20 @@ interface AttendanceAdvancedSchedulingWorkbench {
       rotationAssignments?: boolean
       truncated?: boolean
     }
+    sampling?: {
+      assignmentLimit?: number
+      sampled?: boolean
+      shiftAssignments?: {
+        visible?: number
+        total?: number
+        truncated?: boolean
+      }
+      rotationAssignments?: {
+        visible?: number
+        total?: number
+        truncated?: boolean
+      }
+    }
   }
 }
 
@@ -6380,30 +6394,34 @@ const advancedSchedulingWorkbenchReadOnlyLabel = computed(() =>
 )
 
 const advancedSchedulingWorkbenchTruncationWarning = computed(() => {
+  const sampling = advancedSchedulingWorkbench.value?.metadata?.sampling
   const truncation = advancedSchedulingWorkbench.value?.metadata?.truncation
-  if (!truncation?.truncated) return ''
-  const limit = Number(truncation.assignmentLimit) || 500
-  if (truncation.shiftAssignments && truncation.rotationAssignments) {
+  const sampled = sampling?.sampled ?? truncation?.truncated
+  if (!sampled) return ''
+  const limit = Number(sampling?.assignmentLimit ?? truncation?.assignmentLimit) || 500
+  const shiftSampled = sampling?.shiftAssignments?.truncated ?? truncation?.shiftAssignments
+  const rotationSampled = sampling?.rotationAssignments?.truncated ?? truncation?.rotationAssignments
+  if (shiftSampled && rotationSampled) {
     return tr(
-      `Shift and rotation assignment snapshots are capped at ${limit} rows each; coverage counts may be lower than actual.`,
-      `固定班与轮班分配快照分别最多显示 ${limit} 行，覆盖统计可能低于实际。`,
+      `Shift and rotation assignment detail rows are capped at ${limit} each; top metrics use full aggregate counts.`,
+      `固定班与轮班分配明细分别最多显示 ${limit} 行，顶部指标使用完整聚合统计。`,
     )
   }
-  if (truncation.shiftAssignments) {
+  if (shiftSampled) {
     return tr(
-      `Shift assignment snapshot is capped at ${limit} rows; coverage counts may be lower than actual.`,
-      `固定班分配快照最多显示 ${limit} 行，覆盖统计可能低于实际。`,
+      `Shift assignment detail rows are capped at ${limit}; top metrics use full aggregate counts.`,
+      `固定班分配明细最多显示 ${limit} 行，顶部指标使用完整聚合统计。`,
     )
   }
-  if (truncation.rotationAssignments) {
+  if (rotationSampled) {
     return tr(
-      `Rotation assignment snapshot is capped at ${limit} rows; coverage counts may be lower than actual.`,
-      `轮班分配快照最多显示 ${limit} 行，覆盖统计可能低于实际。`,
+      `Rotation assignment detail rows are capped at ${limit}; top metrics use full aggregate counts.`,
+      `轮班分配明细最多显示 ${limit} 行，顶部指标使用完整聚合统计。`,
     )
   }
   return tr(
-    `Assignment snapshot is capped at ${limit} rows; coverage counts may be lower than actual.`,
-    `分配快照最多显示 ${limit} 行，覆盖统计可能低于实际。`,
+    `Assignment detail rows are capped at ${limit}; top metrics use full aggregate counts.`,
+    `分配明细最多显示 ${limit} 行，顶部指标使用完整聚合统计。`,
   )
 })
 

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -209,8 +209,8 @@ describe('Attendance admin regressions', () => {
               shifts: 2,
               rotationRules: 1,
               shiftAssignments: 1,
-              rotationAssignments: 1,
-              assignedUsers: 2,
+              rotationAssignments: 9,
+              assignedUsers: 10,
               diagnostics: 1,
               groupsWithoutMembers: 0,
               assignmentUsersWithoutScheduleGroup: 1,
@@ -251,6 +251,20 @@ describe('Attendance admin regressions', () => {
                 shiftAssignments: true,
                 rotationAssignments: false,
                 truncated: true,
+              },
+              sampling: {
+                assignmentLimit: 500,
+                sampled: true,
+                shiftAssignments: {
+                  visible: 1,
+                  total: 1,
+                  truncated: true,
+                },
+                rotationAssignments: {
+                  visible: 1,
+                  total: 9,
+                  truncated: false,
+                },
               },
             },
           },
@@ -788,9 +802,10 @@ describe('Attendance admin regressions', () => {
     expect(section).toBeTruthy()
     expect(window.getComputedStyle(section!).display).not.toBe('none')
     expect(section!.textContent).toContain('Read-only snapshot')
-    expect(section!.querySelector('[data-attendance-advanced-scheduling-truncation]')?.textContent).toContain('Shift assignment snapshot is capped at 500 rows')
+    expect(section!.querySelector('[data-attendance-advanced-scheduling-truncation]')?.textContent).toContain('Shift assignment detail rows are capped at 500')
+    expect(section!.querySelector('[data-attendance-advanced-scheduling-truncation]')?.textContent).toContain('top metrics use full aggregate counts')
     expect(section!.querySelector('[data-attendance-advanced-scheduling-metric="schedule-groups"]')?.textContent).toContain('1')
-    expect(section!.querySelector('[data-attendance-advanced-scheduling-metric="assignments"]')?.textContent).toContain('2')
+    expect(section!.querySelector('[data-attendance-advanced-scheduling-metric="assignments"]')?.textContent).toContain('10')
     expect(section!.querySelector('[data-attendance-advanced-scheduling-diagnostic="assignment_without_schedule_group"]')?.textContent).toContain('1')
     expect(section!.querySelector('[data-attendance-advanced-scheduling-groups]')?.textContent).toContain('Line A')
     const buttons = Array.from(section!.querySelectorAll<HTMLButtonElement>('button')).map(button => button.textContent || '')

--- a/docs/development/attendance-advanced-scheduling-workbench-aggregate-accuracy-development-20260522.md
+++ b/docs/development/attendance-advanced-scheduling-workbench-aggregate-accuracy-development-20260522.md
@@ -1,0 +1,105 @@
+# Attendance Advanced Scheduling Workbench Aggregate Accuracy Development
+
+Date: 2026-05-22
+Branch: `codex/attendance-advanced-scheduling-aggregate-20260522`
+
+## Summary
+
+This slice extends the read-only workbench truncation hardening from `#1762`.
+The previous behavior correctly warned when assignment detail rows were capped,
+but the top-level assignment metrics still came from the capped row sample. This
+slice keeps the 500-row detail sample for UI detail and diagnostics, then adds
+read-only aggregate SQL so top metrics and schedule-group coverage counts are
+complete.
+
+## Changed Files
+
+| File | Change |
+| --- | --- |
+| `plugins/plugin-attendance/index.cjs` | Adds read-only aggregate queries for assignment totals, assigned users, mixed-assignment users, users without schedule groups, and per-schedule-group assignment coverage. |
+| `apps/web/src/views/AttendanceView.vue` | Adds `metadata.sampling` typing and updates the warning copy to state that detail rows are capped while top metrics use full aggregate counts. |
+| `packages/core-backend/tests/unit/attendance-advanced-scheduling-workbench.test.ts` | Locks aggregate summary overrides, aggregate group coverage, and source-level aggregate query hooks. |
+| `apps/web/tests/attendance-admin-regressions.spec.ts` | Verifies the warning copy and that the assignment metric renders aggregate totals rather than sample row counts. |
+| `docs/development/attendance-advanced-scheduling-workbench-aggregate-accuracy-development-20260522.md` | This note. |
+| `docs/development/attendance-advanced-scheduling-workbench-aggregate-accuracy-verification-20260522.md` | Verification evidence. |
+
+## Backend Contract
+
+The route remains unchanged:
+
+```text
+GET /api/attendance/advanced-scheduling/workbench
+```
+
+It remains `attendance:admin`, GET-only, and read-only.
+
+The route now returns two distinct surfaces:
+
+1. Full aggregate metrics:
+   - `summary.shiftAssignments`
+   - `summary.rotationAssignments`
+   - `summary.assignedUsers`
+   - `summary.assignmentUsersWithoutScheduleGroup`
+   - `summary.usersWithBothAssignmentKinds`
+   - per-group `assignedUserCount`, `shiftAssignmentCount`, and
+     `rotationAssignmentCount`
+2. Detail samples:
+   - `assignments.shiftItems`
+   - `assignments.rotationItems`
+   - diagnostic sample `userIds`
+
+The sample remains capped by
+`ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT`.
+
+New response metadata:
+
+```json
+{
+  "metadata": {
+    "readOnly": true,
+    "source": "attendance_advanced_scheduling_workbench",
+    "truncation": {
+      "assignmentLimit": 500,
+      "shiftAssignments": true,
+      "rotationAssignments": false,
+      "truncated": true
+    },
+    "sampling": {
+      "assignmentLimit": 500,
+      "sampled": true,
+      "shiftAssignments": {
+        "visible": 500,
+        "total": 650,
+        "truncated": true
+      },
+      "rotationAssignments": {
+        "visible": 0,
+        "total": 3,
+        "truncated": false
+      }
+    }
+  }
+}
+```
+
+`metadata.truncation` is retained for backward compatibility with `#1762`;
+`metadata.sampling` is the clearer operator-facing contract.
+
+## Boundary
+
+| Boundary | Decision |
+| --- | --- |
+| Write path | Not added. |
+| Grid edit / import / copy-paste | Not added. |
+| Migration | Not added. |
+| `attendance_*` writes | Not added. |
+| Direct `meta_*` writes | Not added. |
+| Multitable | Not touched. |
+| Data Factory / Bridge Agent | Not touched. |
+
+## Follow-Up
+
+If the detail samples themselves become insufficient, the next allowed
+read-only hardening slice is pagination or aggregate-only drilldown. That is
+still separate from advanced scheduling write paths, which remain locked until
+explicit customer opt-in or K3 PoC stage-1 GATE PASS.

--- a/docs/development/attendance-advanced-scheduling-workbench-aggregate-accuracy-verification-20260522.md
+++ b/docs/development/attendance-advanced-scheduling-workbench-aggregate-accuracy-verification-20260522.md
@@ -1,0 +1,68 @@
+# Attendance Advanced Scheduling Workbench Aggregate Accuracy Verification
+
+Date: 2026-05-22
+Branch: `codex/attendance-advanced-scheduling-aggregate-20260522`
+
+## Scope Verification
+
+| Area | Result |
+| --- | --- |
+| Runtime domain | Attendance only |
+| Data Factory / Bridge Agent | Not touched |
+| New migration | None |
+| Schedule write path | None added |
+| Direct `meta_*` writes | None |
+| Multitable writes | None |
+| Secrets / tokens | None |
+
+## Acceptance Criteria
+
+| Criterion | Evidence |
+| --- | --- |
+| Top workbench metrics use full aggregate counts | Backend helper accepts aggregate counts and tests assert aggregate totals override capped detail samples. |
+| Detail rows remain capped samples | `metadata.sampling` reports visible vs total counts and keeps the existing sample limit. |
+| Per-group coverage uses aggregate counts | Backend helper accepts schedule-group aggregate coverage rows and tests assert group table values no longer depend on sample rows. |
+| UI warning is not misleading | Frontend copy says detail rows are capped while top metrics use full aggregate counts. |
+| Existing read-only boundary remains intact | No write route, migration, grid edit, import, copy-paste, or multitable behavior added. |
+
+## Verification Commands
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/attendance-advanced-scheduling-workbench.test.ts \
+  tests/unit/attendance-advanced-scheduling-scope.test.ts \
+  tests/unit/attendance-scheduling-assignment-conflict.test.ts \
+  --reporter=dot
+
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/attendance-admin-anchor-nav.spec.ts \
+  tests/attendance-admin-regressions.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web type-check
+
+pnpm --filter @metasheet/core-backend build
+
+git diff --check
+```
+
+## Results
+
+| Check | Result |
+| --- | --- |
+| Plugin syntax | PASS |
+| Backend advanced scheduling tests | PASS, 15 tests |
+| Frontend admin nav + regression tests | PASS, 34 tests |
+| Web type-check | PASS |
+| Core backend build | PASS |
+| `git diff --check` | PASS |
+
+## Notes
+
+- No live staging/prod operation is required for this slice. It is a local,
+  read-only response-shape and aggregate-query hardening.
+- If frontend Vitest emits `WebSocket server error: Port is already in use` but
+  the targeted specs pass, record it as an environment warning rather than a
+  product regression.

--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-workbench.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-workbench.test.ts
@@ -55,6 +55,20 @@ describe('attendance advanced scheduling read-only workbench', () => {
         rotationAssignments: false,
         truncated: false,
       },
+      sampling: {
+        assignmentLimit: 500,
+        sampled: false,
+        shiftAssignments: {
+          visible: 2,
+          total: 2,
+          truncated: false,
+        },
+        rotationAssignments: {
+          visible: 1,
+          total: 1,
+          truncated: false,
+        },
+      },
     })
     expect(workbench.summary).toMatchObject({
       scheduleGroups: 2,
@@ -85,7 +99,7 @@ describe('attendance advanced scheduling read-only workbench', () => {
     ])
   })
 
-  it('reports assignment snapshot truncation metadata without changing the read-only summary shape', () => {
+  it('uses aggregate assignment counts while keeping capped detail rows as a sample', () => {
     const shiftAssignments = Array.from({ length: 500 }, (_, index) => ({
       assignment: {
         id: `sa-${index}`,
@@ -103,18 +117,73 @@ describe('attendance advanced scheduling read-only workbench', () => {
       to: '2026-06-30',
       scheduleGroups: [],
       shiftAssignments,
+      assignmentAggregates: {
+        shiftAssignments: 650,
+        rotationAssignments: 3,
+        assignedUsers: 640,
+        assignmentUsersWithoutScheduleGroup: 639,
+        usersWithBothAssignmentKinds: 2,
+      },
       assignmentLimit: 500,
       shiftAssignmentsTruncated: true,
       rotationAssignmentsTruncated: false,
     })
 
-    expect(workbench.summary.shiftAssignments).toBe(500)
+    expect(workbench.summary).toMatchObject({
+      shiftAssignments: 650,
+      rotationAssignments: 3,
+      assignedUsers: 640,
+      assignmentUsersWithoutScheduleGroup: 639,
+      usersWithBothAssignmentKinds: 2,
+    })
     expect(workbench.assignments.shiftItems).toHaveLength(500)
+    expect(workbench.diagnostics.find((item: any) => item.code === 'assignment_without_schedule_group')).toMatchObject({
+      count: 639,
+    })
     expect(workbench.metadata.truncation).toEqual({
       assignmentLimit: 500,
       shiftAssignments: true,
       rotationAssignments: false,
       truncated: true,
+    })
+    expect(workbench.metadata.sampling).toEqual({
+      assignmentLimit: 500,
+      sampled: true,
+      shiftAssignments: {
+        visible: 500,
+        total: 650,
+        truncated: true,
+      },
+      rotationAssignments: {
+        visible: 0,
+        total: 3,
+        truncated: false,
+      },
+    })
+  })
+
+  it('uses aggregate group coverage counts when detail samples are capped', () => {
+    const workbench = helpers.buildAttendanceAdvancedSchedulingWorkbench({
+      scheduleGroups: [{ id: 'group-a', name: 'Line A', code: 'line-a', source: 'manual', isActive: true }],
+      scheduleGroupMembers: [
+        { id: 'm-1', scheduleGroupId: 'group-a', userId: 'user-1', effectiveFrom: '2026-06-01', effectiveTo: null },
+      ],
+      shiftAssignments: [],
+      scheduleGroupAssignmentAggregates: [
+        {
+          scheduleGroupId: 'group-a',
+          assignedUserCount: 25,
+          shiftAssignmentCount: 31,
+          rotationAssignmentCount: 7,
+        },
+      ],
+    })
+
+    expect(workbench.scheduleGroups.items[0]).toMatchObject({
+      memberCount: 1,
+      assignedUserCount: 25,
+      shiftAssignmentCount: 31,
+      rotationAssignmentCount: 7,
     })
   })
 
@@ -128,5 +197,7 @@ describe('attendance advanced scheduling read-only workbench', () => {
     expect(pluginSource).toContain('LIMIT ${ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT + 1}')
     expect(pluginSource).toContain('visibleShiftAssignmentRows = shiftAssignmentRows.slice(0, ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT)')
     expect(pluginSource).toContain('visibleRotationAssignmentRows = rotationAssignmentRows.slice(0, ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT)')
+    expect(pluginSource).toContain('assignmentAggregateRows')
+    expect(pluginSource).toContain('scheduleGroupAssignmentAggregateRows')
   })
 })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -7480,6 +7480,12 @@ function buildAttendanceAdvancedSchedulingDiagnostic({ code, severity = 'info', 
 
 const ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT = 500
 
+function normalizeAttendanceWorkbenchCount(value, fallback = 0) {
+  const numeric = Number(value)
+  if (!Number.isFinite(numeric) || numeric < 0) return fallback
+  return Math.floor(numeric)
+}
+
 function buildAttendanceAdvancedSchedulingWorkbench(input = {}) {
   const from = normalizeDateOnly(input.from) ?? null
   const to = normalizeDateOnly(input.to) ?? null
@@ -7499,6 +7505,18 @@ function buildAttendanceAdvancedSchedulingWorkbench(input = {}) {
     rotationAssignments: Boolean(input.rotationAssignmentsTruncated),
     truncated: Boolean(input.shiftAssignmentsTruncated || input.rotationAssignmentsTruncated),
   }
+  const assignmentAggregates = input.assignmentAggregates && typeof input.assignmentAggregates === 'object'
+    ? input.assignmentAggregates
+    : {}
+  const scheduleGroupAssignmentAggregates = new Map(
+    (Array.isArray(input.scheduleGroupAssignmentAggregates) ? input.scheduleGroupAssignmentAggregates : [])
+      .map((item) => {
+        const scheduleGroupId = String(item?.scheduleGroupId || '').trim()
+        if (!scheduleGroupId) return null
+        return [scheduleGroupId, item]
+      })
+      .filter(Boolean)
+  )
 
   const membersByGroupId = new Map()
   const groupIdsByUserId = new Map()
@@ -7518,18 +7536,29 @@ function buildAttendanceAdvancedSchedulingWorkbench(input = {}) {
   const shiftAssignmentCountByUser = countBy(shiftAssignments, item => item?.assignment?.userId)
   const rotationAssignmentCountByUser = countBy(rotationAssignments, item => item?.assignment?.userId)
   const assignedUserIds = new Set([...shiftAssignmentCountByUser.keys(), ...rotationAssignmentCountByUser.keys()])
+  const summaryShiftAssignments = normalizeAttendanceWorkbenchCount(assignmentAggregates.shiftAssignments, shiftAssignments.length)
+  const summaryRotationAssignments = normalizeAttendanceWorkbenchCount(assignmentAggregates.rotationAssignments, rotationAssignments.length)
+  const summaryAssignedUsers = normalizeAttendanceWorkbenchCount(assignmentAggregates.assignedUsers, assignedUserIds.size)
 
   const scheduleGroupIds = new Set(scheduleGroups.map(group => group.id).filter(Boolean))
   const groupItems = scheduleGroups.map((group) => {
     const members = membersByGroupId.get(group.id) ?? []
     const memberUserIds = new Set(members.map(member => member.userId).filter(Boolean))
     const assignedMemberUserIds = [...memberUserIds].filter(userId => assignedUserIds.has(userId))
-    const shiftAssignmentCount = [...memberUserIds].reduce((sum, userId) => sum + (shiftAssignmentCountByUser.get(userId) ?? 0), 0)
-    const rotationAssignmentCount = [...memberUserIds].reduce((sum, userId) => sum + (rotationAssignmentCountByUser.get(userId) ?? 0), 0)
+    const aggregate = scheduleGroupAssignmentAggregates.get(group.id)
+    const shiftAssignmentCount = normalizeAttendanceWorkbenchCount(
+      aggregate?.shiftAssignmentCount,
+      [...memberUserIds].reduce((sum, userId) => sum + (shiftAssignmentCountByUser.get(userId) ?? 0), 0)
+    )
+    const rotationAssignmentCount = normalizeAttendanceWorkbenchCount(
+      aggregate?.rotationAssignmentCount,
+      [...memberUserIds].reduce((sum, userId) => sum + (rotationAssignmentCountByUser.get(userId) ?? 0), 0)
+    )
+    const assignedUserCount = normalizeAttendanceWorkbenchCount(aggregate?.assignedUserCount, assignedMemberUserIds.length)
     return {
       ...group,
       memberCount: members.length,
-      assignedUserCount: assignedMemberUserIds.length,
+      assignedUserCount,
       shiftAssignmentCount,
       rotationAssignmentCount,
     }
@@ -7543,6 +7572,14 @@ function buildAttendanceAdvancedSchedulingWorkbench(input = {}) {
     .filter(userId => !groupIdsByUserId.has(userId))
   const usersWithBothAssignmentKinds = [...shiftAssignmentCountByUser.keys()]
     .filter(userId => rotationAssignmentCountByUser.has(userId))
+  const assignmentUsersWithoutScheduleGroupCount = normalizeAttendanceWorkbenchCount(
+    assignmentAggregates.assignmentUsersWithoutScheduleGroup,
+    assignmentUsersWithoutScheduleGroup.length
+  )
+  const usersWithBothAssignmentKindsCount = normalizeAttendanceWorkbenchCount(
+    assignmentAggregates.usersWithBothAssignmentKinds,
+    usersWithBothAssignmentKinds.length
+  )
   const schedulerScopesWithUnknownGroups = schedulerScopes
     .filter(scope => Array.isArray(scope?.scope?.scheduleGroupIds) && scope.scope.scheduleGroupIds.some(groupId => !scheduleGroupIds.has(groupId)))
   const schedulerScopeUnknownGroupIds = schedulerScopesWithUnknownGroups
@@ -7558,12 +7595,12 @@ function buildAttendanceAdvancedSchedulingWorkbench(input = {}) {
         scheduleGroupIds: groupsWithoutMembers.map(group => group.id),
       })
       : null,
-    assignmentUsersWithoutScheduleGroup.length
+    assignmentUsersWithoutScheduleGroupCount
       ? buildAttendanceAdvancedSchedulingDiagnostic({
         code: 'assignment_without_schedule_group',
         severity: 'warning',
         message: 'Active shift or rotation assignments reference users without an effective schedule-group membership in this range.',
-        count: assignmentUsersWithoutScheduleGroup.length,
+        count: assignmentUsersWithoutScheduleGroupCount,
         userIds: assignmentUsersWithoutScheduleGroup,
       })
       : null,
@@ -7576,12 +7613,12 @@ function buildAttendanceAdvancedSchedulingWorkbench(input = {}) {
         userIds: usersWithMultipleScheduleGroups,
       })
       : null,
-    usersWithBothAssignmentKinds.length
+    usersWithBothAssignmentKindsCount
       ? buildAttendanceAdvancedSchedulingDiagnostic({
         code: 'user_mixed_assignment_kinds',
         severity: 'info',
         message: 'Users have both shift and rotation assignment rows in this range; effective-calendar resolution still owns day-level precedence.',
-        count: usersWithBothAssignmentKinds.length,
+        count: usersWithBothAssignmentKindsCount,
         userIds: usersWithBothAssignmentKinds,
       })
       : null,
@@ -7604,14 +7641,14 @@ function buildAttendanceAdvancedSchedulingWorkbench(input = {}) {
       schedulerScopes: schedulerScopes.length,
       shifts: shifts.length,
       rotationRules: rotationRules.length,
-      shiftAssignments: shiftAssignments.length,
-      rotationAssignments: rotationAssignments.length,
-      assignedUsers: assignedUserIds.size,
+      shiftAssignments: summaryShiftAssignments,
+      rotationAssignments: summaryRotationAssignments,
+      assignedUsers: summaryAssignedUsers,
       diagnostics: diagnostics.length,
       groupsWithoutMembers: groupsWithoutMembers.length,
-      assignmentUsersWithoutScheduleGroup: assignmentUsersWithoutScheduleGroup.length,
+      assignmentUsersWithoutScheduleGroup: assignmentUsersWithoutScheduleGroupCount,
       usersWithMultipleScheduleGroups: usersWithMultipleScheduleGroups.length,
-      usersWithBothAssignmentKinds: usersWithBothAssignmentKinds.length,
+      usersWithBothAssignmentKinds: usersWithBothAssignmentKindsCount,
     },
     scheduleGroups: {
       items: groupItems,
@@ -7639,6 +7676,20 @@ function buildAttendanceAdvancedSchedulingWorkbench(input = {}) {
       readOnly: true,
       source: 'attendance_advanced_scheduling_workbench',
       truncation,
+      sampling: {
+        assignmentLimit,
+        sampled: truncation.truncated,
+        shiftAssignments: {
+          visible: shiftAssignments.length,
+          total: summaryShiftAssignments,
+          truncated: truncation.shiftAssignments,
+        },
+        rotationAssignments: {
+          visible: rotationAssignments.length,
+          total: summaryRotationAssignments,
+          truncated: truncation.rotationAssignments,
+        },
+      },
     },
   }
 }
@@ -25181,6 +25232,8 @@ module.exports = {
             rotationRuleRows,
             shiftAssignmentRows,
             rotationAssignmentRows,
+            assignmentAggregateRows,
+            scheduleGroupAssignmentAggregateRows,
           ] = await Promise.all([
             db.query(
               `SELECT *
@@ -25252,6 +25305,99 @@ module.exports = {
                LIMIT ${ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT + 1}`,
               [orgId, rangeStart, rangeEnd]
             ),
+            db.query(
+              `WITH active_shift AS (
+                 SELECT a.id, a.user_id
+                 FROM attendance_shift_assignments a
+                 JOIN attendance_shifts s ON s.id = a.shift_id
+                 WHERE a.org_id = $1
+                   AND COALESCE(a.is_active, true) = true
+                   AND a.start_date <= $3::date
+                   AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
+               ),
+               active_rotation AS (
+                 SELECT a.id, a.user_id
+                 FROM attendance_rotation_assignments a
+                 JOIN attendance_rotation_rules r ON r.id = a.rotation_rule_id
+                 WHERE a.org_id = $1
+                   AND COALESCE(a.is_active, true) = true
+                   AND a.start_date <= $3::date
+                   AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
+               ),
+               assigned_users AS (
+                 SELECT user_id FROM active_shift WHERE user_id IS NOT NULL
+                 UNION
+                 SELECT user_id FROM active_rotation WHERE user_id IS NOT NULL
+               ),
+               active_members AS (
+                 SELECT DISTINCT user_id
+                 FROM attendance_schedule_group_members
+                 WHERE org_id = $1
+                   AND user_id IS NOT NULL
+                   AND COALESCE(effective_from, DATE '0001-01-01') <= $3::date
+                   AND COALESCE(effective_to, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
+               ),
+               mixed_users AS (
+                 SELECT s.user_id
+                 FROM active_shift s
+                 JOIN active_rotation r ON r.user_id = s.user_id
+                 WHERE s.user_id IS NOT NULL
+                 GROUP BY s.user_id
+               )
+               SELECT
+                 (SELECT COUNT(*) FROM active_shift)::int AS shift_assignments,
+                 (SELECT COUNT(*) FROM active_rotation)::int AS rotation_assignments,
+                 (SELECT COUNT(*) FROM assigned_users)::int AS assigned_users,
+                 (SELECT COUNT(*) FROM assigned_users au WHERE NOT EXISTS (
+                   SELECT 1 FROM active_members m WHERE m.user_id = au.user_id
+                 ))::int AS assignment_users_without_schedule_group,
+                 (SELECT COUNT(*) FROM mixed_users)::int AS users_with_both_assignment_kinds`,
+              [orgId, rangeStart, rangeEnd]
+            ),
+            db.query(
+              `WITH active_members AS (
+                 SELECT schedule_group_id, user_id
+                 FROM attendance_schedule_group_members
+                 WHERE org_id = $1
+                   AND user_id IS NOT NULL
+                   AND schedule_group_id IS NOT NULL
+                   AND COALESCE(effective_from, DATE '0001-01-01') <= $3::date
+                   AND COALESCE(effective_to, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
+               ),
+               shift_counts AS (
+                 SELECT a.user_id, COUNT(*)::int AS assignment_count
+                 FROM attendance_shift_assignments a
+                 JOIN attendance_shifts s ON s.id = a.shift_id
+                 WHERE a.org_id = $1
+                   AND COALESCE(a.is_active, true) = true
+                   AND a.start_date <= $3::date
+                   AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
+                 GROUP BY a.user_id
+               ),
+               rotation_counts AS (
+                 SELECT a.user_id, COUNT(*)::int AS assignment_count
+                 FROM attendance_rotation_assignments a
+                 JOIN attendance_rotation_rules r ON r.id = a.rotation_rule_id
+                 WHERE a.org_id = $1
+                   AND COALESCE(a.is_active, true) = true
+                   AND a.start_date <= $3::date
+                   AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
+                 GROUP BY a.user_id
+               )
+               SELECT
+                 m.schedule_group_id,
+                 COUNT(DISTINCT CASE
+                   WHEN COALESCE(s.assignment_count, 0) + COALESCE(r.assignment_count, 0) > 0 THEN m.user_id
+                   ELSE NULL
+                 END)::int AS assigned_user_count,
+                 COALESCE(SUM(COALESCE(s.assignment_count, 0)), 0)::int AS shift_assignment_count,
+                 COALESCE(SUM(COALESCE(r.assignment_count, 0)), 0)::int AS rotation_assignment_count
+               FROM active_members m
+               LEFT JOIN shift_counts s ON s.user_id = m.user_id
+               LEFT JOIN rotation_counts r ON r.user_id = m.user_id
+               GROUP BY m.schedule_group_id`,
+              [orgId, rangeStart, rangeEnd]
+            ),
           ])
 
           const shiftAssignmentsTruncated = shiftAssignmentRows.length > ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT
@@ -25274,6 +25420,19 @@ module.exports = {
             rotationAssignments: visibleRotationAssignmentRows.map(row => ({
               assignment: mapRotationAssignmentRow(row),
               rotation: mapRotationRuleFromAssignmentRow(row),
+            })),
+            assignmentAggregates: {
+              shiftAssignments: assignmentAggregateRows[0]?.shift_assignments,
+              rotationAssignments: assignmentAggregateRows[0]?.rotation_assignments,
+              assignedUsers: assignmentAggregateRows[0]?.assigned_users,
+              assignmentUsersWithoutScheduleGroup: assignmentAggregateRows[0]?.assignment_users_without_schedule_group,
+              usersWithBothAssignmentKinds: assignmentAggregateRows[0]?.users_with_both_assignment_kinds,
+            },
+            scheduleGroupAssignmentAggregates: scheduleGroupAssignmentAggregateRows.map(row => ({
+              scheduleGroupId: row.schedule_group_id,
+              assignedUserCount: row.assigned_user_count,
+              shiftAssignmentCount: row.shift_assignment_count,
+              rotationAssignmentCount: row.rotation_assignment_count,
             })),
             assignmentLimit: ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT,
             shiftAssignmentsTruncated,


### PR DESCRIPTION
## Summary

Continues the read-only advanced scheduling workbench hardening after #1762.

- keeps assignment detail rows capped at the existing 500-row sample limit
- adds read-only aggregate SQL for top assignment metrics and per-schedule-group coverage counts
- returns metadata.sampling so operators can distinguish visible sample rows from full totals
- updates the truncation warning copy to say detail rows are capped while top metrics use full aggregate counts

## Verification

- [x] node --check plugins/plugin-attendance/index.cjs
- [x] backend advanced scheduling tests: 15 pass
- [x] frontend admin nav + regression tests: 34 pass
- [x] pnpm --filter @metasheet/web type-check
- [x] pnpm --filter @metasheet/core-backend build
- [x] git diff --check

Note: frontend Vitest emitted the known nonfatal WebSocket port-in-use warning while both targeted specs passed.

## Boundary

Read-only hardening only. No migration, no attendance_* write, no direct meta_* write, no multitable behavior, no grid edit/copy/import/temporary-shift write path.