### PR TITLE
fix(integration): canonicalize K3 GATE checker entry path

### DIFF
--- a/docs/development/k3wise-gate-contract-check-windows-entry-design-20260522.md
+++ b/docs/development/k3wise-gate-contract-check-windows-entry-design-20260522.md
@@ -13,7 +13,7 @@ node scripts/ops/integration-k3wise-gate-contract-check.mjs --init-template <dir
 The same package could generate the handoff packet only through a temporary
 wrapper that forced `main()` to run.
 
-## Root Cause
+## Root Causes
 
 The checker used this direct-run guard:
 
@@ -28,6 +28,12 @@ does not match Windows paths such as `C:\metasheet\scripts\ops\script.mjs`.
 Node exits successfully after importing the module, but `main()` is never
 called, so no output directory is created.
 
+Local package verification also surfaced the same class of issue on POSIX when
+the package is executed through a symlinked path. On macOS, `/tmp` resolves to
+`/private/tmp`; Node may report the module URL with the real path while
+`process.argv[1]` keeps the symlink path. A pure normalized string comparison is
+therefore still too weak.
+
 ## Change
 
 The checker now resolves `import.meta.url` with `fileURLToPath()` and compares
@@ -35,6 +41,9 @@ that filesystem path with `process.argv[1]` after platform-aware normalization:
 
 - POSIX paths are compared exactly after `path.resolve()` / `path.normalize()`.
 - Windows paths use `path.win32` normalization and case-insensitive comparison.
+- When the compared paths exist on the current platform, `realpathSync.native()`
+  is applied before comparison so `/tmp` and `/private/tmp` resolve to the same
+  entrypoint.
 
 This keeps the command behavior unchanged on macOS/Linux while making Windows
 direct execution invoke `main()` correctly.
@@ -64,7 +73,7 @@ node scripts/ops/integration-k3wise-gate-contract-check.mjs --input <packet.json
 ```
 
 The helper `isDirectCliRun()` is exported only to make the Windows path behavior
-unit-testable on non-Windows development machines.
+and symlink realpath behavior unit-testable.
 
 ## Deployment Impact
 

--- a/docs/development/k3wise-gate-contract-check-windows-entry-verification-20260522.md
+++ b/docs/development/k3wise-gate-contract-check-windows-entry-verification-20260522.md
@@ -23,6 +23,8 @@ Expected:
   - case-insensitive Windows paths;
   - negative non-matching script path;
   - POSIX direct-run path.
+- New symlink/realpath direct-run guard test passes for equivalent physical
+  paths, covering the macOS `/tmp` to `/private/tmp` package-verification case.
 
 ### 2. CLI Template Smoke
 
@@ -86,6 +88,22 @@ PASS criteria:
 - Directory contains 8 redacted sample skeletons.
 - Running the checker against the empty template returns expected
   `GATE_BLOCKED`, not silent success.
+
+## Package Extraction Smoke
+
+The Release verification should also extract the Windows zip to a temporary
+directory and run the packaged checker directly from that extracted path:
+
+```bash
+node <extracted-package>/scripts/ops/integration-k3wise-gate-contract-check.mjs --init-template <tmp-output-dir>
+```
+
+PASS criteria:
+
+- stdout contains `TEMPLATE_CREATED`;
+- the target directory is created;
+- README, packet JSON, and 8 redacted sample skeletons exist;
+- checking the empty template returns exit `2` with `GATE_BLOCKED`.
 
 ## Security Check
 

--- a/scripts/ops/integration-k3wise-gate-contract-check.mjs
+++ b/scripts/ops/integration-k3wise-gate-contract-check.mjs
@@ -1,4 +1,5 @@
 #!/usr/bin/env node
+import { realpathSync } from 'node:fs'
 import { mkdir, readFile, writeFile } from 'node:fs/promises'
 import path from 'node:path'
 import { fileURLToPath } from 'node:url'
@@ -761,8 +762,17 @@ async function main() {
 export function isDirectCliRun(moduleFilePath, entryFilePath, platform = process.platform) {
   if (!entryFilePath) return false
   const pathModule = platform === 'win32' ? path.win32 : path
-  const modulePath = pathModule.normalize(moduleFilePath)
-  const entryPath = pathModule.resolve(entryFilePath)
+  const normalizePath = (value) => {
+    const resolved = pathModule.resolve(value)
+    if (platform !== process.platform) return pathModule.normalize(resolved)
+    try {
+      return pathModule.normalize(realpathSync.native(resolved))
+    } catch {
+      return pathModule.normalize(resolved)
+    }
+  }
+  const modulePath = normalizePath(moduleFilePath)
+  const entryPath = normalizePath(entryFilePath)
   if (platform === 'win32') {
     return modulePath.toLowerCase() === entryPath.toLowerCase()
   }

--- a/scripts/ops/integration-k3wise-gate-contract-check.test.mjs
+++ b/scripts/ops/integration-k3wise-gate-contract-check.test.mjs
@@ -1,5 +1,5 @@
 import assert from 'node:assert/strict'
-import { mkdir, mkdtemp, readFile, writeFile } from 'node:fs/promises'
+import { mkdir, mkdtemp, readFile, symlink, writeFile } from 'node:fs/promises'
 import os from 'node:os'
 import path from 'node:path'
 import { spawnSync } from 'node:child_process'
@@ -264,4 +264,18 @@ test('direct-run guard accepts Windows script paths', () => {
     ),
     true,
   )
+})
+
+test('direct-run guard accepts equivalent real paths through symlinks', async () => {
+  const dir = await makeDir()
+  const realDir = path.join(dir, 'real')
+  const linkDir = path.join(dir, 'link')
+  await mkdir(realDir)
+  await symlink(realDir, linkDir, 'dir')
+
+  const realScript = path.join(realDir, 'integration-k3wise-gate-contract-check.mjs')
+  const linkScript = path.join(linkDir, 'integration-k3wise-gate-contract-check.mjs')
+  await writeFile(realScript, '')
+
+  assert.equal(isDirectCliRun(realScript, linkScript), true)
 })


### PR DESCRIPTION
## Summary

Follow-up to #1765 discovered during downloaded package verification.

#1765 fixed the Windows path form, but package extraction on macOS exposed the
same direct-run class through symlinked paths: `/tmp` resolves to
`/private/tmp`, so `fileURLToPath(import.meta.url)` and `process.argv[1]` can
still refer to the same file with different path spellings. In that case the
checker imports and exits 0 without invoking `main()`.

This PR canonicalizes existing entry paths with `realpathSync.native()` before
comparison, while keeping the Windows case-insensitive path behavior from #1765.

## Scope

- K3 GATE checker CLI direct-run guard only.
- Adds a symlink/realpath regression test.
- Updates the design/verification MD from #1765 with the realpath finding and
  package-extraction smoke.

No K3 Save / Submit / Audit, no SQL Bridge runtime change, no Data Factory
pipeline change, no DB migration.

## Verification

- `pnpm verify:integration-k3wise:gate-contract` -> 7/7 PASS
- `node --check scripts/ops/integration-k3wise-gate-contract-check.mjs` -> PASS
- `git diff --check origin/main...HEAD` -> PASS
- CLI smoke: `--init-template` creates README + packet JSON + 8 redacted samples;
  checking empty template returns exit 2 / `GATE_BLOCKED` / 23 blocked

## Follow-up after merge

Build/publish a fresh on-prem package and re-run downloaded-package extraction
smoke before sending the Windows retest request.
