### PR TITLE
feat(multitable): localize final audit composable fallbacks

### DIFF
--- a/apps/web/src/multitable/components/MetaImportModal.vue
+++ b/apps/web/src/multitable/components/MetaImportModal.vue
@@ -634,6 +634,7 @@ async function buildRecords(): Promise<ImportBuildResult> {
     fields: props.fields,
     fieldResolvers: props.fieldResolvers,
     fieldOverrides: manualFieldOverrides.value,
+    isZh: isZh.value,
   })
 }
 
@@ -762,6 +763,7 @@ async function applyFixesAndRetry() {
     fields: props.fields,
     fieldResolvers: props.fieldResolvers,
     fieldOverrides: subsetOverrides,
+    isZh: isZh.value,
   })
 
   const retryableFailures = result.failures.filter((failure) => !failure.skipped && failure.retryable !== false)

--- a/apps/web/src/multitable/composables/useMultitableCommentInbox.ts
+++ b/apps/web/src/multitable/composables/useMultitableCommentInbox.ts
@@ -1,9 +1,13 @@
 import { computed, ref } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type { MultitableCommentInboxItem, MultitableCommentInboxPage } from '../types'
 import { MultitableApiClient, multitableClient } from '../api/client'
+import { commentLabel } from '../utils/meta-comment-labels'
 
 export function useMultitableCommentInbox(client?: MultitableApiClient) {
   const api = client ?? multitableClient
+  const { isZh } = useLocale()
+  const fallback = (key: Parameters<typeof commentLabel>[0]) => commentLabel(key, isZh.value)
   const inbox = ref<MultitableCommentInboxItem[]>([])
   const total = ref(0)
   const unreadCount = ref(0)
@@ -22,7 +26,7 @@ export function useMultitableCommentInbox(client?: MultitableApiClient) {
       total.value = page.total
       return page
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to load comment inbox'
+      error.value = e.message ?? fallback('comment.errorLoadInbox')
       throw e
     } finally {
       loading.value = false
@@ -34,7 +38,7 @@ export function useMultitableCommentInbox(client?: MultitableApiClient) {
       unreadCount.value = await api.getCommentUnreadCount()
       return unreadCount.value
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to load unread comment count'
+      error.value = e.message ?? fallback('comment.errorLoadUnreadCount')
       throw e
     }
   }
@@ -60,7 +64,7 @@ export function useMultitableCommentInbox(client?: MultitableApiClient) {
       inbox.value = nextItems
       if (wasUnread) unreadCount.value = Math.max(0, unreadCount.value - 1)
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to mark comment as read'
+      error.value = e.message ?? fallback('comment.errorMarkRead')
       throw e
     } finally {
       busyIds.value = busyIds.value.filter((id) => id !== commentId)

--- a/apps/web/src/multitable/composables/useMultitableCommentInboxSummary.ts
+++ b/apps/web/src/multitable/composables/useMultitableCommentInboxSummary.ts
@@ -1,7 +1,9 @@
 import { computed, ref } from 'vue'
 import { useAuth } from '../../composables/useAuth'
+import { useLocale } from '../../composables/useLocale'
 import type { CommentMentionSummary } from '../types'
 import { MultitableApiClient, multitableClient } from '../api/client'
+import { commentLabel } from '../utils/meta-comment-labels'
 import {
   normalizeMultitableCommentMutationEvent,
   normalizeMultitableCommentRealtimeEvent,
@@ -16,6 +18,8 @@ export function useMultitableCommentInboxSummary(opts?: {
 }) {
   const auth = useAuth()
   const client = opts?.client ?? multitableClient
+  const { isZh } = useLocale()
+  const fallback = (key: Parameters<typeof commentLabel>[0]) => commentLabel(key, isZh.value)
 
   const summary = ref<CommentMentionSummary | null>(null)
   const loading = ref(false)
@@ -56,7 +60,7 @@ export function useMultitableCommentInboxSummary(opts?: {
       summary.value = await client.loadMentionSummary({ spreadsheetId: params.spreadsheetId })
       lastMarkedReadAt = null
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to load mention summary'
+      error.value = e.message ?? fallback('comment.errorLoadMentionSummary')
       summary.value = null
     } finally {
       loading.value = false

--- a/apps/web/src/multitable/composables/useMultitableCommentPresence.ts
+++ b/apps/web/src/multitable/composables/useMultitableCommentPresence.ts
@@ -1,6 +1,8 @@
 import { onScopeDispose, ref } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type { MultitableCommentPresenceSummary } from '../types'
 import { MultitableApiClient, multitableClient } from '../api/client'
+import { commentLabel } from '../utils/meta-comment-labels'
 import {
   normalizeMultitableCommentMutationEvent,
   normalizeMultitableCommentRealtimeEvent,
@@ -60,6 +62,8 @@ function buildEmptyPresenceSummary(containerId: string, targetId: string): Multi
 
 export function useMultitableCommentPresence(client?: MultitableApiClient, options?: UseMultitableCommentPresenceOptions) {
   const api = client ?? multitableClient
+  const { isZh } = useLocale()
+  const fallback = (key: Parameters<typeof commentLabel>[0]) => commentLabel(key, isZh.value)
   const subscribeRealtime = options?.subscribeRealtime ?? subscribeToMultitableCommentsRealtime
   const presenceByRecordId = ref<Record<string, MultitableCommentPresenceSummary>>({})
   const loading = ref(false)
@@ -216,7 +220,7 @@ export function useMultitableCommentPresence(client?: MultitableApiClient, optio
       replacePresence(data.items ?? [])
     } catch (e: any) {
       if (loadVersion !== activeLoadVersion || !sameScope(activeScope, scope)) return
-      error.value = e.message ?? 'Failed to load comment presence'
+      error.value = e.message ?? fallback('comment.errorLoadPresence')
     } finally {
       if (loadVersion === activeLoadVersion) {
         loading.value = false

--- a/apps/web/src/multitable/composables/useMultitableComments.ts
+++ b/apps/web/src/multitable/composables/useMultitableComments.ts
@@ -1,11 +1,15 @@
 import { ref } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type { MetaCommentsScope, MultitableComment } from '../types'
 import { MultitableApiClient, multitableClient } from '../api/client'
+import { commentLabel } from '../utils/meta-comment-labels'
 
 type CommentsTarget = { containerId: string; targetId: string; targetFieldId?: string | null } | MetaCommentsScope
 
 export function useMultitableComments(client?: MultitableApiClient) {
   const api = client ?? multitableClient
+  const { isZh } = useLocale()
+  const fallback = (key: Parameters<typeof commentLabel>[0]) => commentLabel(key, isZh.value)
   const comments = ref<MultitableComment[]>([])
   const loading = ref(false)
   const error = ref<string | null>(null)
@@ -21,7 +25,7 @@ export function useMultitableComments(client?: MultitableApiClient) {
       const data = await api.listComments(params)
       comments.value = data.comments ?? []
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to load comments'
+      error.value = e.message ?? fallback('comment.errorLoad')
     } finally {
       loading.value = false
     }
@@ -35,7 +39,7 @@ export function useMultitableComments(client?: MultitableApiClient) {
       if (data.comment) comments.value.unshift(data.comment)
       return data.comment ?? null
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to add comment'
+      error.value = e.message ?? fallback('comment.errorAdd')
       throw e
     } finally {
       submitting.value = false
@@ -52,7 +56,7 @@ export function useMultitableComments(client?: MultitableApiClient) {
       const idx = comments.value.findIndex((c) => c.id === commentId)
       if (idx >= 0) comments.value[idx] = { ...comments.value[idx], resolved: true }
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to resolve comment'
+      error.value = e.message ?? fallback('comment.errorResolve')
       throw e
     } finally {
       resolvingIds.value = resolvingIds.value.filter((id) => id !== commentId)
@@ -69,7 +73,7 @@ export function useMultitableComments(client?: MultitableApiClient) {
       if (data.comment) upsertComment(data.comment)
       return data.comment ?? null
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to update comment'
+      error.value = e.message ?? fallback('comment.errorUpdate')
       throw e
     } finally {
       updatingIds.value = updatingIds.value.filter((id) => id !== commentId)
@@ -85,7 +89,7 @@ export function useMultitableComments(client?: MultitableApiClient) {
       await api.deleteComment(commentId)
       applyDeletedComment(commentId)
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to delete comment'
+      error.value = e.message ?? fallback('comment.errorDelete')
       throw e
     } finally {
       deletingIds.value = deletingIds.value.filter((id) => id !== commentId)

--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -1,4 +1,5 @@
 import { ref, computed, watch, type Ref, type ComputedRef, type WatchStopHandle } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type {
   MetaCapabilityOrigin,
   LinkedRecordSummary,
@@ -13,6 +14,7 @@ import type {
 } from '../types'
 import { MultitableApiClient, multitableClient } from '../api/client'
 import { isPropertyHiddenField } from '../utils/field-permissions'
+import { metaCoreLabel } from '../utils/meta-core-labels'
 
 // --- Sort / Filter types ---
 
@@ -340,6 +342,8 @@ export function useMultitableGrid(opts: {
 }) {
   const client = opts.client ?? multitableClient
   const pageSize = opts.pageSize ?? DEFAULT_PAGE_SIZE
+  const { isZh } = useLocale()
+  const fallback = (key: Parameters<typeof metaCoreLabel>[0]) => metaCoreLabel(key, isZh.value)
 
   // Core state
   const fields = ref<MetaField[]>([])
@@ -468,7 +472,7 @@ export function useMultitableGrid(opts: {
       if (data.view) syncFromView(data.view)
     } catch (e: any) {
       if (requestId !== latestLoadRequestId) return
-      error.value = e.message ?? 'Failed to load view data'
+      error.value = e.message ?? fallback('grid.errorLoadViewData')
     } finally {
       if (requestId === latestLoadRequestId) loading.value = false
     }
@@ -592,12 +596,12 @@ export function useMultitableGrid(opts: {
   // --- Record CRUD ---
 
   function rejectRowEdit(): false {
-    error.value = 'Record editing is not allowed for this row.'
+    error.value = fallback('grid.errorEditRowBlocked')
     return false
   }
 
   function rejectRowDelete(): false {
-    error.value = 'Record deletion is not allowed for this row.'
+    error.value = fallback('grid.errorDeleteRowBlocked')
     return false
   }
 
@@ -615,7 +619,7 @@ export function useMultitableGrid(opts: {
       viewId: opts.viewId.value,
     })
     if (!context.sheetId && !context.viewId) {
-      error.value = 'sheetId or viewId is required'
+      error.value = fallback('grid.errorContextRequired')
       return
     }
     if (!opts.sheetId.value && context.sheetId) opts.sheetId.value = context.sheetId
@@ -628,7 +632,7 @@ export function useMultitableGrid(opts: {
       })
       await loadViewData(page.value.offset)
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to create record'
+      error.value = e.message ?? fallback('grid.errorCreateRecord')
     }
   }
 
@@ -641,7 +645,7 @@ export function useMultitableGrid(opts: {
       await loadViewData(page.value.offset)
       return true
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to delete record'
+      error.value = e.message ?? fallback('grid.errorDeleteRecord')
       return false
     }
   }
@@ -695,13 +699,13 @@ export function useMultitableGrid(opts: {
           recordId,
           fieldId,
           attemptedValue: value,
-          message: e.message ?? 'This cell was updated elsewhere. Reload and retry.',
+          message: e.message ?? fallback('grid.errorCellUpdatedElsewhere'),
           serverVersion: typeof e.serverVersion === 'number' ? e.serverVersion : undefined,
           previousLinkSummaries: oldLinkSummaries,
           nextLinkSummaries,
         }
       }
-      error.value = e.message ?? 'Failed to patch cell'
+      error.value = e.message ?? fallback('grid.errorPatchCell')
     }
   }
 
@@ -776,7 +780,7 @@ export function useMultitableGrid(opts: {
     const updated = (result.updated ?? []).map((u) => u.recordId)
     const failed = (result.failed ?? []).map((failure) => ({
       recordId: failure.recordId,
-      reason: failure.message || failure.code || 'Patch failed',
+      reason: failure.message || failure.code || fallback('grid.errorPatchFailed'),
     }))
     return { updated, failed }
   }
@@ -827,7 +831,7 @@ export function useMultitableGrid(opts: {
       row = rows.value.find((record) => record.id === pending.recordId)
     }
     if (!row) {
-      error.value = 'The latest record version is not available on this page anymore.'
+      error.value = fallback('grid.errorRecordVersionUnavailable')
       return false
     }
 

--- a/apps/web/src/multitable/composables/useMultitableRecordPermissions.ts
+++ b/apps/web/src/multitable/composables/useMultitableRecordPermissions.ts
@@ -1,9 +1,13 @@
 import { ref } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type { RecordPermissionEntry } from '../types'
 import { MultitableApiClient, multitableClient } from '../api/client'
+import { permissionLabel } from '../utils/meta-permission-labels'
 
 export function useMultitableRecordPermissions(client?: MultitableApiClient) {
   const api = client ?? multitableClient
+  const { isZh } = useLocale()
+  const fallback = (key: Parameters<typeof permissionLabel>[0]) => permissionLabel(key, isZh.value)
   const entries = ref<RecordPermissionEntry[]>([])
   const loading = ref(false)
   const error = ref<string | null>(null)
@@ -14,7 +18,7 @@ export function useMultitableRecordPermissions(client?: MultitableApiClient) {
     try {
       entries.value = await api.listRecordPermissions(sheetId, recordId)
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to load record permissions'
+      error.value = e.message ?? fallback('record.error.loadPermissions')
     } finally {
       loading.value = false
     }
@@ -32,7 +36,7 @@ export function useMultitableRecordPermissions(client?: MultitableApiClient) {
       await api.updateRecordPermission(sheetId, recordId, subjectType, subjectId, accessLevel)
       await loadPermissions(sheetId, recordId)
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to grant record permission'
+      error.value = e.message ?? fallback('record.error.grant')
       throw e
     }
   }
@@ -47,7 +51,7 @@ export function useMultitableRecordPermissions(client?: MultitableApiClient) {
       await api.deleteRecordPermission(sheetId, recordId, permissionId)
       entries.value = entries.value.filter((entry) => entry.id !== permissionId)
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to revoke record permission'
+      error.value = e.message ?? fallback('record.error.remove')
       throw e
     }
   }

--- a/apps/web/src/multitable/composables/useMultitableWorkbench.ts
+++ b/apps/web/src/multitable/composables/useMultitableWorkbench.ts
@@ -1,4 +1,5 @@
 import { ref, computed, watch } from 'vue'
+import { useLocale } from '../../composables/useLocale'
 import type {
   MetaCapabilityOrigin,
   MetaCapabilities,
@@ -9,6 +10,7 @@ import type {
   MetaViewPermission,
 } from '../types'
 import { MultitableApiClient, multitableClient } from '../api/client'
+import { workbenchLabel } from '../utils/workbench-labels'
 
 const SYSTEM_PEOPLE_SHEET_DESCRIPTION = '__metasheet_system:people__'
 const EMPTY_CAPABILITIES: MetaCapabilities = {
@@ -35,6 +37,8 @@ export function useMultitableWorkbench(opts?: {
   client?: MultitableApiClient
 }) {
   const client = opts?.client ?? multitableClient
+  const { isZh } = useLocale()
+  const fallback = (key: Parameters<typeof workbenchLabel>[0]) => workbenchLabel(key, isZh.value)
 
   const sheets = ref<MetaSheet[]>([])
   const fields = ref<MetaField[]>([])
@@ -159,7 +163,7 @@ export function useMultitableWorkbench(opts?: {
         await loadSheetMeta(activeSheetId.value)
       }
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to load sheets'
+      error.value = e.message ?? fallback('error.loadSheets')
     } finally {
       loading.value = false
     }
@@ -183,7 +187,7 @@ export function useMultitableWorkbench(opts?: {
       syncContextState(ctx, requestedViewId)
       return true
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to load sheet metadata'
+      error.value = e.message ?? fallback('error.loadSheetMetadata')
       return false
     }
   }
@@ -207,7 +211,7 @@ export function useMultitableWorkbench(opts?: {
       }
       return true
     } catch (e: any) {
-      error.value = e.message ?? 'Failed to load base metadata'
+      error.value = e.message ?? fallback('error.loadBaseMetadata')
       return false
     } finally {
       loading.value = false
@@ -234,7 +238,7 @@ export function useMultitableWorkbench(opts?: {
     if (ok) return true
     const failureMessage = error.value
     restoreSnapshot(snapshot)
-    error.value = failureMessage ?? 'Failed to load base metadata'
+    error.value = failureMessage ?? fallback('error.loadBaseMetadata')
     return false
   }
 
@@ -266,7 +270,7 @@ export function useMultitableWorkbench(opts?: {
       if (ok) return true
       const failureMessage = error.value
       restoreSnapshot(snapshot)
-      error.value = failureMessage ?? 'Failed to load sheet metadata'
+      error.value = failureMessage ?? fallback('error.loadSheetMetadata')
       return false
     }
 
@@ -276,7 +280,7 @@ export function useMultitableWorkbench(opts?: {
       if (ok) return true
       const failureMessage = error.value
       restoreSnapshot(snapshot)
-      error.value = failureMessage ?? 'Failed to load sheet metadata'
+      error.value = failureMessage ?? fallback('error.loadSheetMetadata')
       return false
     }
 

--- a/apps/web/src/multitable/import/bulk-import.ts
+++ b/apps/web/src/multitable/import/bulk-import.ts
@@ -1,4 +1,5 @@
 import type { MultitableApiClient } from '../api/client'
+import { duplicateRowSkipped, importCancelled } from '../utils/meta-import-labels'
 
 export type BulkImportFailure = {
   index: number
@@ -37,22 +38,22 @@ const DEFAULT_MAX_RETRY_ATTEMPTS = 1
 const DEFAULT_RETRY_BASE_DELAY_MS = 500
 const DEFAULT_MAX_RETRY_DELAY_MS = 30_000
 
-function createAbortError() {
-  const error = new Error('Import cancelled') as Error & { name: string }
+function createAbortError(isZh = false) {
+  const error = new Error(importCancelled(isZh)) as Error & { name: string }
   error.name = 'AbortError'
   return error
 }
 
-function ensureNotAborted(signal?: AbortSignal) {
-  if (signal?.aborted) throw createAbortError()
+function ensureNotAborted(signal?: AbortSignal, isZh = false) {
+  if (signal?.aborted) throw createAbortError(isZh)
 }
 
-function sleep(ms: number, signal?: AbortSignal): Promise<void> {
+function sleep(ms: number, signal?: AbortSignal, isZh = false): Promise<void> {
   if (!signal) {
     return new Promise((resolve) => globalThis.setTimeout(resolve, ms))
   }
   if (signal.aborted) {
-    return Promise.reject(createAbortError())
+    return Promise.reject(createAbortError(isZh))
   }
   return new Promise((resolve, reject) => {
     const timer = globalThis.setTimeout(() => {
@@ -62,7 +63,7 @@ function sleep(ms: number, signal?: AbortSignal): Promise<void> {
     const onAbort = () => {
       globalThis.clearTimeout(timer)
       signal.removeEventListener('abort', onAbort)
-      reject(createAbortError())
+      reject(createAbortError(isZh))
     }
     signal.addEventListener('abort', onAbort, { once: true })
   })
@@ -124,20 +125,21 @@ async function createRecordWithRetry(params: {
   sleepFn: (ms: number) => Promise<void>
   jitterFn: (delayMs: number) => number
   signal?: AbortSignal
+  isZh?: boolean
 }) {
-  const { client, sheetId, viewId, data, maxRetryAttempts, retryBaseDelayMs, maxRetryDelayMs, sleepFn, jitterFn, signal } = params
+  const { client, sheetId, viewId, data, maxRetryAttempts, retryBaseDelayMs, maxRetryDelayMs, sleepFn, jitterFn, signal, isZh = false } = params
   let attempt = 0
   while (true) {
     try {
-      ensureNotAborted(signal)
+      ensureNotAborted(signal, isZh)
       return await client.createRecord({ sheetId, viewId, data }, { signal })
     } catch (error) {
       if (!isRetryableError(error) || attempt >= maxRetryAttempts) {
         throw error
       }
-      ensureNotAborted(signal)
+      ensureNotAborted(signal, isZh)
       await sleepFn(retryDelayMs({ error, attempt, retryBaseDelayMs, maxRetryDelayMs, jitterFn }))
-      ensureNotAborted(signal)
+      ensureNotAborted(signal, isZh)
       attempt += 1
     }
   }
@@ -149,6 +151,7 @@ export function skipDuplicateImportRows(params: {
   primaryFieldId: string
   primaryFieldName?: string
   existingKeys?: Iterable<string>
+  isZh?: boolean
 }) {
   const {
     records,
@@ -156,6 +159,7 @@ export function skipDuplicateImportRows(params: {
     primaryFieldId,
     primaryFieldName = primaryFieldId,
     existingKeys = [],
+    isZh = false,
   } = params
 
   const keptRecords: Array<Record<string, unknown>> = []
@@ -184,7 +188,7 @@ export function skipDuplicateImportRows(params: {
         fieldId: primaryFieldId,
         key: normalizedKey,
         skipped: true,
-        message: `Skipped duplicate row because ${primaryFieldName} already exists: ${String(rawKey).trim()}`,
+        message: duplicateRowSkipped(primaryFieldName, rawKey, isZh),
       })
       return
     }
@@ -212,6 +216,7 @@ export async function bulkImportRecords(params: {
   sleepFn?: (ms: number) => Promise<void>
   jitterFn?: (delayMs: number) => number
   signal?: AbortSignal
+  isZh?: boolean
 }): Promise<BulkImportResult> {
   const {
     client,
@@ -222,14 +227,15 @@ export async function bulkImportRecords(params: {
     maxRetryAttempts = DEFAULT_MAX_RETRY_ATTEMPTS,
     retryBaseDelayMs = DEFAULT_RETRY_BASE_DELAY_MS,
     maxRetryDelayMs = DEFAULT_MAX_RETRY_DELAY_MS,
-    sleepFn = (ms) => sleep(ms, params.signal),
+    sleepFn = (ms) => sleep(ms, params.signal, params.isZh ?? false),
     jitterFn = applyRetryJitter,
     signal,
+    isZh = false,
   } = params
   const settled: PromiseSettledResult<unknown>[] = []
   const chunkSize = Math.max(1, Math.floor(concurrency))
   for (let offset = 0; offset < records.length; offset += chunkSize) {
-    ensureNotAborted(signal)
+    ensureNotAborted(signal, isZh)
     const chunk = records.slice(offset, offset + chunkSize)
     const chunkSettled = await Promise.allSettled(
       chunk.map((data) => createRecordWithRetry({
@@ -243,10 +249,11 @@ export async function bulkImportRecords(params: {
         sleepFn,
         jitterFn,
         signal,
+        isZh,
       })),
     )
     if (signal?.aborted || chunkSettled.some((item) => item.status === 'rejected' && isAbortError(item.reason))) {
-      throw createAbortError()
+      throw createAbortError(isZh)
     }
     settled.push(...chunkSettled)
   }

--- a/apps/web/src/multitable/import/delimited.ts
+++ b/apps/web/src/multitable/import/delimited.ts
@@ -1,4 +1,5 @@
 import type { MetaField } from '../types'
+import { importResolverMissing, importValueResolveFailed } from '../utils/meta-import-labels'
 import { isLinkField, isPersonField } from '../utils/link-fields'
 
 export type DelimitedParseResult = {
@@ -125,8 +126,9 @@ export async function buildImportedRecords(params: {
   fields: MetaField[]
   fieldResolvers?: Record<string, ImportValueResolver>
   fieldOverrides?: ImportFieldOverrides
+  isZh?: boolean
 }): Promise<ImportBuildResult> {
-  const { parsedRows, fieldMapping, fields, fieldResolvers = {}, fieldOverrides = {} } = params
+  const { parsedRows, fieldMapping, fields, fieldResolvers = {}, fieldOverrides = {}, isZh = false } = params
   const records: Array<Record<string, unknown>> = []
   const rowIndexes: number[] = []
   const failures: ImportBuildFailure[] = []
@@ -157,9 +159,7 @@ export async function buildImportedRecords(params: {
         }
         const resolver = fieldResolvers[fieldId]
         if (!resolver) {
-          rowFailure = isPersonField(field)
-            ? `No import resolver is configured for people field ${field.name}`
-            : `No import resolver is configured for linked field ${field.name}`
+          rowFailure = importResolverMissing(field.name, isPersonField(field) ? 'person' : 'link', isZh)
           failingField = field
           break
         }
@@ -167,16 +167,12 @@ export async function buildImportedRecords(params: {
         try {
           resolved = await resolver(rawValue, field)
         } catch (error: any) {
-          rowFailure = error?.message ?? (isPersonField(field)
-            ? `Unable to resolve people value for ${field.name}: ${rawValue}`
-            : `Unable to resolve linked value for ${field.name}: ${rawValue}`)
+          rowFailure = error?.message ?? importValueResolveFailed(field.name, rawValue, isPersonField(field) ? 'person' : 'link', isZh)
           failingField = field
           break
         }
         if (resolved === null || resolved === undefined) {
-          rowFailure = isPersonField(field)
-            ? `Unable to resolve people value for ${field.name}: ${rawValue}`
-            : `Unable to resolve linked value for ${field.name}: ${rawValue}`
+          rowFailure = importValueResolveFailed(field.name, rawValue, isPersonField(field) ? 'person' : 'link', isZh)
           failingField = field
           break
         }

--- a/apps/web/src/multitable/utils/meta-comment-labels.ts
+++ b/apps/web/src/multitable/utils/meta-comment-labels.ts
@@ -3,6 +3,8 @@
 // Scope: comment drawer/composer chrome plus row-comment action chip labels in
 // alternative views. User content, author names, record labels, field names, and
 // backend/composable error bodies stay raw and are never translated here.
+// Frontend-owned composable fallback strings live here once no raw backend
+// message is available.
 
 export type MetaCommentLabelKey =
   | 'comment.title'
@@ -32,6 +34,16 @@ export type MetaCommentLabelKey =
   | 'comment.hintBase'
   | 'comment.hintWithMention'
   | 'comment.discardDraftConfirm'
+  | 'comment.errorLoad'
+  | 'comment.errorAdd'
+  | 'comment.errorResolve'
+  | 'comment.errorUpdate'
+  | 'comment.errorDelete'
+  | 'comment.errorLoadInbox'
+  | 'comment.errorLoadUnreadCount'
+  | 'comment.errorMarkRead'
+  | 'comment.errorLoadMentionSummary'
+  | 'comment.errorLoadPresence'
 
 const META_COMMENT_LABELS: Record<MetaCommentLabelKey, { en: string; zh: string }> = {
   'comment.title': { en: 'Comments', zh: '评论' },
@@ -67,6 +79,16 @@ const META_COMMENT_LABELS: Record<MetaCommentLabelKey, { en: string; zh: string 
     en: 'Discard unsaved comment draft?',
     zh: '放弃未保存的评论草稿吗？',
   },
+  'comment.errorLoad': { en: 'Failed to load comments', zh: '加载评论失败' },
+  'comment.errorAdd': { en: 'Failed to add comment', zh: '添加评论失败' },
+  'comment.errorResolve': { en: 'Failed to resolve comment', zh: '解决评论失败' },
+  'comment.errorUpdate': { en: 'Failed to update comment', zh: '更新评论失败' },
+  'comment.errorDelete': { en: 'Failed to delete comment', zh: '删除评论失败' },
+  'comment.errorLoadInbox': { en: 'Failed to load comment inbox', zh: '加载评论收件箱失败' },
+  'comment.errorLoadUnreadCount': { en: 'Failed to load unread comment count', zh: '加载未读评论数失败' },
+  'comment.errorMarkRead': { en: 'Failed to mark comment as read', zh: '标记评论已读失败' },
+  'comment.errorLoadMentionSummary': { en: 'Failed to load mention summary', zh: '加载提及摘要失败' },
+  'comment.errorLoadPresence': { en: 'Failed to load comment presence', zh: '加载评论状态失败' },
 }
 
 export function commentLabel(key: MetaCommentLabelKey, isZh: boolean): string {

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -55,6 +55,12 @@ export type MetaCoreLabelKey =
   | 'grid.noMatchingTitle' | 'grid.noMatchingHint'
   | 'grid.collapseRow' | 'grid.expandRow'
   | 'grid.prev' | 'grid.next' | 'grid.loading'
+  | 'grid.errorLoadViewData'
+  | 'grid.errorEditRowBlocked' | 'grid.errorDeleteRowBlocked'
+  | 'grid.errorContextRequired'
+  | 'grid.errorCreateRecord' | 'grid.errorDeleteRecord'
+  | 'grid.errorCellUpdatedElsewhere' | 'grid.errorPatchCell'
+  | 'grid.errorRecordVersionUnavailable' | 'grid.errorPatchFailed'
   // --- MetaCellEditor static (T3A2) ---
   | 'cell.editing'
   | 'cell.barcodePlaceholder' | 'cell.locationPlaceholder'
@@ -146,6 +152,29 @@ const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
   'grid.prev': { en: 'Prev', zh: '上一页' },
   'grid.next': { en: 'Next', zh: '下一页' },
   'grid.loading': { en: 'Loading data', zh: '正在加载数据' },
+  // Frontend-owned composable fallbacks. Backend/user messages still win via `e.message ?? fallback`.
+  'grid.errorLoadViewData': { en: 'Failed to load view data', zh: '加载视图数据失败' },
+  'grid.errorEditRowBlocked': {
+    en: 'Record editing is not allowed for this row.',
+    zh: '该行不允许编辑记录。',
+  },
+  'grid.errorDeleteRowBlocked': {
+    en: 'Record deletion is not allowed for this row.',
+    zh: '该行不允许删除记录。',
+  },
+  'grid.errorContextRequired': { en: 'sheetId or viewId is required', zh: '需要 sheetId 或 viewId' },
+  'grid.errorCreateRecord': { en: 'Failed to create record', zh: '创建记录失败' },
+  'grid.errorDeleteRecord': { en: 'Failed to delete record', zh: '删除记录失败' },
+  'grid.errorCellUpdatedElsewhere': {
+    en: 'This cell was updated elsewhere. Reload and retry.',
+    zh: '该单元格已在别处更新。请重新加载后重试。',
+  },
+  'grid.errorPatchCell': { en: 'Failed to patch cell', zh: '更新单元格失败' },
+  'grid.errorRecordVersionUnavailable': {
+    en: 'The latest record version is not available on this page anymore.',
+    zh: '此页面已无法获取该记录的最新版本。',
+  },
+  'grid.errorPatchFailed': { en: 'Patch failed', zh: '更新失败' },
 
   // MetaCellEditor (T3A2): shallow chrome inside the grid cell editor.
   // Excludes user data (option values, format examples like https://example.com),

--- a/apps/web/src/multitable/utils/meta-import-labels.ts
+++ b/apps/web/src/multitable/utils/meta-import-labels.ts
@@ -193,3 +193,41 @@ export function xlsxTruncated(importedRows: number, maxRows: number, isZh: boole
     ? `已导入前 ${importedRows} 行；其余行已跳过（上限 ${maxRows}）。`
     : `Imported the first ${importedRows} rows; remaining rows were skipped (limit ${maxRows}).`
 }
+
+export function importResolverMissing(fieldName: string, kind: 'person' | 'link', isZh: boolean): string {
+  if (kind === 'person') {
+    return isZh
+      ? `人员字段 ${fieldName} 未配置导入解析器`
+      : `No import resolver is configured for people field ${fieldName}`
+  }
+  return isZh
+    ? `关联字段 ${fieldName} 未配置导入解析器`
+    : `No import resolver is configured for linked field ${fieldName}`
+}
+
+export function importValueResolveFailed(
+  fieldName: string,
+  rawValue: string,
+  kind: 'person' | 'link',
+  isZh: boolean,
+): string {
+  if (kind === 'person') {
+    return isZh
+      ? `无法解析 ${fieldName} 的人员值：${rawValue}`
+      : `Unable to resolve people value for ${fieldName}: ${rawValue}`
+  }
+  return isZh
+    ? `无法解析 ${fieldName} 的关联值：${rawValue}`
+    : `Unable to resolve linked value for ${fieldName}: ${rawValue}`
+}
+
+export function importCancelled(isZh: boolean): string {
+  return isZh ? '导入已取消' : 'Import cancelled'
+}
+
+export function duplicateRowSkipped(primaryFieldName: string, rawValue: unknown, isZh: boolean): string {
+  const normalizedRaw = String(rawValue).trim()
+  return isZh
+    ? `已跳过重复行，因为 ${primaryFieldName} 已存在：${normalizedRaw}`
+    : `Skipped duplicate row because ${primaryFieldName} already exists: ${normalizedRaw}`
+}

--- a/apps/web/src/multitable/utils/workbench-labels.ts
+++ b/apps/web/src/multitable/utils/workbench-labels.ts
@@ -56,6 +56,8 @@ export type WorkbenchLabelKey =
   | 'confirm.pageLeaveBusy' | 'confirm.pageLeaveDirty'
   // §3.6 MetaTemplateCard button (counts use the card* helpers below)
   | 'card.install' | 'card.installing'
+  // final audit closure follow-up: composable fallback messages (backend e.message remains raw)
+  | 'error.loadSheets' | 'error.loadSheetMetadata' | 'error.loadBaseMetadata'
 
 const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = {
   'conflict.fieldFallback': { en: 'cell', zh: '单元格' },
@@ -197,6 +199,10 @@ const WORKBENCH_LABELS: Record<WorkbenchLabelKey, { en: string; zh: string }> = 
 
   'card.install': { en: 'Use template', zh: '使用模板' },
   'card.installing': { en: 'Installing...', zh: '创建中...' },
+
+  'error.loadSheets': { en: 'Failed to load sheets', zh: '加载 Sheet 失败' },
+  'error.loadSheetMetadata': { en: 'Failed to load sheet metadata', zh: '加载 Sheet 元数据失败' },
+  'error.loadBaseMetadata': { en: 'Failed to load base metadata', zh: '加载 Base 元数据失败' },
 }
 
 export function workbenchLabel(key: WorkbenchLabelKey, isZh: boolean): string {

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -2265,6 +2265,7 @@ async function onBulkImport(payload: ImportBuildResult) {
         viewId: workbench.activeViewId.value || undefined,
         records: recordsToImport,
         signal: controller.signal,
+        isZh: isZh.value,
       })
       : { attempted: 0, succeeded: 0, failed: 0, firstError: null, failures: [] }
 

--- a/apps/web/tests/meta-comment-labels.spec.ts
+++ b/apps/web/tests/meta-comment-labels.spec.ts
@@ -39,6 +39,16 @@ describe('meta-comment-labels static keys', () => {
       ['comment.hintBase', 'Ctrl/Cmd + Enter to send', 'Ctrl/Cmd + Enter 发送'],
       ['comment.hintWithMention', 'Tab to mention, Ctrl/Cmd + Enter to send', 'Tab 提及，Ctrl/Cmd + Enter 发送'],
       ['comment.discardDraftConfirm', 'Discard unsaved comment draft?', '放弃未保存的评论草稿吗？'],
+      ['comment.errorLoad', 'Failed to load comments', '加载评论失败'],
+      ['comment.errorAdd', 'Failed to add comment', '添加评论失败'],
+      ['comment.errorResolve', 'Failed to resolve comment', '解决评论失败'],
+      ['comment.errorUpdate', 'Failed to update comment', '更新评论失败'],
+      ['comment.errorDelete', 'Failed to delete comment', '删除评论失败'],
+      ['comment.errorLoadInbox', 'Failed to load comment inbox', '加载评论收件箱失败'],
+      ['comment.errorLoadUnreadCount', 'Failed to load unread comment count', '加载未读评论数失败'],
+      ['comment.errorMarkRead', 'Failed to mark comment as read', '标记评论已读失败'],
+      ['comment.errorLoadMentionSummary', 'Failed to load mention summary', '加载提及摘要失败'],
+      ['comment.errorLoadPresence', 'Failed to load comment presence', '加载评论状态失败'],
     ]
 
     for (const [key, en, zh] of expectations) {

--- a/apps/web/tests/multitable-comment-inbox.spec.ts
+++ b/apps/web/tests/multitable-comment-inbox.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useLocale } from '../src/composables/useLocale'
 import { useMultitableCommentInbox } from '../src/multitable/composables/useMultitableCommentInbox'
 import { MultitableApiClient } from '../src/multitable/api/client'
 
@@ -12,6 +13,7 @@ describe('useMultitableCommentInbox', () => {
   let client: MultitableApiClient
 
   beforeEach(() => {
+    useLocale().setLocale('en')
     client = createMockClient()
   })
 
@@ -112,5 +114,30 @@ describe('useMultitableCommentInbox', () => {
 
     expect(state.items.value[0].unread).toBe(false)
     expect(state.unreadCount.value).toBe(2)
+  })
+
+  it('localizes mark-read fallback when backend message is absent', async () => {
+    useLocale().setLocale('zh-CN')
+    const state = useMultitableCommentInbox({
+      markCommentRead: vi.fn().mockRejectedValue({}),
+    } as any)
+    state.items.value = [{
+      id: 'c1',
+      containerId: 'sheet_ops',
+      targetId: 'rec_1',
+      fieldId: null,
+      parentId: undefined,
+      mentions: [],
+      authorId: 'user_2',
+      content: 'hello',
+      resolved: false,
+      createdAt: '2026-04-04T00:00:00.000Z',
+      unread: true,
+      mentioned: false,
+    }]
+
+    await expect(state.markRead('c1')).rejects.toThrow()
+
+    expect(state.error.value).toBe('标记评论已读失败')
   })
 })

--- a/apps/web/tests/multitable-comment-presence.spec.ts
+++ b/apps/web/tests/multitable-comment-presence.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useLocale } from '../src/composables/useLocale'
 import { MultitableApiClient } from '../src/multitable/api/client'
 import { useMultitableCommentPresence } from '../src/multitable/composables/useMultitableCommentPresence'
 
@@ -50,6 +51,7 @@ describe('useMultitableCommentPresence', () => {
   let client: MultitableApiClient
 
   beforeEach(() => {
+    useLocale().setLocale('en')
     client = createMockClient()
   })
 
@@ -201,5 +203,16 @@ describe('useMultitableCommentPresence', () => {
 
     expect(state.presenceByRecordId.value).toEqual({})
     expect(realtime.unsubscribe).toHaveBeenCalled()
+  })
+
+  it('localizes load fallback when backend message is absent', async () => {
+    useLocale().setLocale('zh-CN')
+    const state = useMultitableCommentPresence({
+      listCommentPresence: vi.fn().mockRejectedValue({}),
+    } as any)
+
+    await state.loadPresence({ containerId: 'sheet_orders', targetIds: ['rec_1'] })
+
+    expect(state.error.value).toBe('加载评论状态失败')
   })
 })

--- a/apps/web/tests/multitable-comments.spec.ts
+++ b/apps/web/tests/multitable-comments.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useLocale } from '../src/composables/useLocale'
 import { useMultitableComments } from '../src/multitable/composables/useMultitableComments'
 import { MultitableApiClient } from '../src/multitable/api/client'
 
@@ -11,7 +12,10 @@ function createMockClient() {
 describe('useMultitableComments', () => {
   let client: MultitableApiClient
 
-  beforeEach(() => { client = createMockClient() })
+  beforeEach(() => {
+    useLocale().setLocale('en')
+    client = createMockClient()
+  })
 
   it('loads comments', async () => {
     const comments = [{ id: 'c1', spreadsheetId: 's1', rowId: 'r1', fieldId: null, mentions: [], authorId: 'u1', content: 'hello', resolved: false, createdAt: '2026-01-01' }]
@@ -192,5 +196,27 @@ describe('useMultitableComments', () => {
     const state = useMultitableComments(client)
     await state.loadComments({ containerId: 's1', targetId: 'r1' })
     expect(state.error.value).toBeTruthy()
+  })
+
+  it('localizes frontend load fallback when backend message is absent', async () => {
+    useLocale().setLocale('zh-CN')
+    const state = useMultitableComments({
+      listComments: vi.fn().mockRejectedValue({}),
+    } as any)
+
+    await state.loadComments({ containerId: 's1', targetId: 'r1' })
+
+    expect(state.error.value).toBe('加载评论失败')
+  })
+
+  it('keeps backend error messages raw ahead of localized fallbacks', async () => {
+    useLocale().setLocale('zh-CN')
+    const state = useMultitableComments({
+      listComments: vi.fn().mockRejectedValue(new Error('backend raw')),
+    } as any)
+
+    await state.loadComments({ containerId: 's1', targetId: 'r1' })
+
+    expect(state.error.value).toBe('backend raw')
   })
 })

--- a/apps/web/tests/multitable-core-i18n.spec.ts
+++ b/apps/web/tests/multitable-core-i18n.spec.ts
@@ -21,6 +21,9 @@ describe('meta-core-labels static keys', () => {
     expect(metaCoreLabel('grid.aria', true)).toBe('数据表格')
     expect(metaCoreLabel('grid.aria', false)).toBe('Data grid')
     expect(metaCoreLabel('toolbar.aria', true)).toBe('表格工具栏')
+    expect(metaCoreLabel('grid.errorLoadViewData', true)).toBe('加载视图数据失败')
+    expect(metaCoreLabel('grid.errorPatchCell', false)).toBe('Failed to patch cell')
+    expect(metaCoreLabel('grid.errorPatchFailed', true)).toBe('更新失败')
   })
 
   it('F1: sort-direction options — en keeps alphabet arrows, zh is 升序/降序', () => {

--- a/apps/web/tests/multitable-grid.spec.ts
+++ b/apps/web/tests/multitable-grid.spec.ts
@@ -1,5 +1,6 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
 import { ref, nextTick } from 'vue'
+import { useLocale } from '../src/composables/useLocale'
 import {
   useMultitableGrid,
   buildSortInfo,
@@ -30,7 +31,10 @@ function createMockClient() {
 describe('useMultitableGrid', () => {
   let client: MultitableApiClient
 
-  beforeEach(() => { client = createMockClient() })
+  beforeEach(() => {
+    useLocale().setLocale('en')
+    client = createMockClient()
+  })
 
   it('initializes with empty state', () => {
     const grid = useMultitableGrid({ sheetId: ref(''), viewId: ref(''), client })
@@ -293,6 +297,21 @@ describe('useMultitableGrid', () => {
 
     expect(fetchFn).not.toHaveBeenCalled()
     expect(grid.error.value).toBe('sheetId or viewId is required')
+  })
+
+  it('localizes local record-create context fallback in zh-CN', async () => {
+    useLocale().setLocale('zh-CN')
+    const fetchFn = vi.fn()
+    const grid = useMultitableGrid({
+      sheetId: ref(''),
+      viewId: ref(''),
+      client: new MultitableApiClient({ fetchFn }),
+    })
+
+    await grid.createRecord({})
+
+    expect(fetchFn).not.toHaveBeenCalled()
+    expect(grid.error.value).toBe('需要 sheetId 或 viewId')
   })
 
   it('falls back to the last non-empty page when a load lands beyond the new total', async () => {
@@ -559,6 +578,29 @@ describe('useMultitableGrid', () => {
     expect(fetchFn).not.toHaveBeenCalled()
     expect(grid.rows.value[0].data.f1).toBe('before')
     expect(grid.error.value).toBe('Record editing is not allowed for this row.')
+  })
+
+  it('localizes local row-action edit blocks in zh-CN', async () => {
+    useLocale().setLocale('zh-CN')
+    const fetchFn = vi.fn()
+    const grid = useMultitableGrid({
+      sheetId: ref(''),
+      viewId: ref(''),
+      client: new MultitableApiClient({ fetchFn }),
+    })
+
+    grid.fields.value = [{ id: 'f1', name: 'Title', type: 'string' }]
+    grid.rows.value = [{ id: 'r1', version: 1, data: { f1: 'before' } }]
+    grid.rowActions.value = {
+      canEdit: false,
+      canDelete: true,
+      canComment: true,
+    }
+
+    await grid.patchCell('r1', 'f1', 'patched', 1)
+
+    expect(fetchFn).not.toHaveBeenCalled()
+    expect(grid.error.value).toBe('该行不允许编辑记录。')
   })
 
   it('allows patchCell when a record-scoped rowActionOverride grants edit access', async () => {

--- a/apps/web/tests/multitable-import.spec.ts
+++ b/apps/web/tests/multitable-import.spec.ts
@@ -100,6 +100,33 @@ describe('multitable import parsing', () => {
     ])
   })
 
+  it('localizes unresolved people values when isZh is requested and preserves raw value', async () => {
+    const records = await buildImportedRecords({
+      parsedRows: [['Unknown Person']],
+      fieldMapping: { 0: 'fld_people' },
+      fields: [
+        {
+          id: 'fld_people',
+          name: '负责人',
+          type: 'link',
+          property: { refKind: 'user', foreignSheetId: 'sheet_people' },
+        },
+      ],
+      fieldResolvers: {
+        fld_people: async () => null,
+      },
+      isZh: true,
+    })
+
+    expect(records.failures).toEqual([
+      expect.objectContaining({
+        rowIndex: 0,
+        retryable: false,
+        message: '无法解析 负责人 的人员值：Unknown Person',
+      }),
+    ])
+  })
+
   it('prefers field overrides over people resolution failures', async () => {
     const resolver = vi.fn(async () => {
       throw new Error('Multiple people match "Owner". Use email for an exact match.')
@@ -185,6 +212,31 @@ describe('multitable import parsing', () => {
     ])
   })
 
+  it('localizes missing link resolver fallback and keeps the field name raw', async () => {
+    const records = await buildImportedRecords({
+      parsedRows: [['Vendor']],
+      fieldMapping: { 0: 'fld_vendor' },
+      fields: [
+        {
+          id: 'fld_vendor',
+          name: '供应商',
+          type: 'link',
+          property: { foreignSheetId: 'sheet_vendors', limitSingleRecord: true },
+        },
+      ],
+      fieldResolvers: {},
+      isZh: true,
+    })
+
+    expect(records.failures).toEqual([
+      expect.objectContaining({
+        fieldId: 'fld_vendor',
+        fieldName: '供应商',
+        message: '关联字段 供应商 未配置导入解析器',
+      }),
+    ])
+  })
+
   it('skips duplicate rows using the primary import field against existing and in-batch values', () => {
     const result = skipDuplicateImportRows({
       records: [
@@ -212,6 +264,26 @@ describe('multitable import parsing', () => {
         fieldId: 'fld_name',
         skipped: true,
         message: 'Skipped duplicate row because Name already exists: Beta',
+      }),
+    ])
+  })
+
+  it('localizes duplicate-row skipped messages and keeps raw field/value text', () => {
+    const result = skipDuplicateImportRows({
+      records: [
+        { fld_name: 'Alpha' },
+        { fld_name: 'alpha' },
+      ],
+      rowIndexes: [0, 1],
+      primaryFieldId: 'fld_name',
+      primaryFieldName: '名称',
+      isZh: true,
+    })
+
+    expect(result.skippedRows).toEqual([
+      expect.objectContaining({
+        rowIndex: 1,
+        message: '已跳过重复行，因为 名称 已存在：alpha',
       }),
     ])
   })
@@ -437,5 +509,18 @@ describe('multitable bulk import', () => {
 
     await expect(importPromise).rejects.toMatchObject({ name: 'AbortError', message: 'Import cancelled' })
     expect(fetchFn).toHaveBeenCalledTimes(1)
+  })
+
+  it('localizes generated abort errors when isZh is requested', async () => {
+    const controller = new AbortController()
+    controller.abort()
+    const client = new MultitableApiClient({ fetchFn: vi.fn() })
+
+    await expect(bulkImportRecords({
+      client,
+      records: [{ fld_name: 'A' }],
+      signal: controller.signal,
+      isZh: true,
+    })).rejects.toMatchObject({ name: 'AbortError', message: '导入已取消' })
   })
 })

--- a/apps/web/tests/multitable-mention-inbox.spec.ts
+++ b/apps/web/tests/multitable-mention-inbox.spec.ts
@@ -1,4 +1,5 @@
 import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useLocale } from '../src/composables/useLocale'
 import { MultitableApiClient } from '../src/multitable/api/client'
 import { useMultitableCommentInboxSummary } from '../src/multitable/composables/useMultitableCommentInboxSummary'
 import type { CommentMentionSummary } from '../src/multitable/types'
@@ -67,6 +68,7 @@ describe('useMultitableCommentInboxSummary', () => {
   let client: MultitableApiClient
 
   beforeEach(() => {
+    useLocale().setLocale('en')
     client = makeMockClient()
   })
 
@@ -101,6 +103,19 @@ describe('useMultitableCommentInboxSummary', () => {
 
     expect(inbox.summary.value).toBeNull()
     expect(inbox.error.value).toContain('DB error')
+  })
+
+  it('localizes summary fallback when backend message is absent', async () => {
+    useLocale().setLocale('zh-CN')
+    const failClient = {
+      loadMentionSummary: vi.fn().mockRejectedValue({}),
+    } as any
+    const inbox = useMultitableCommentInboxSummary({ client: failClient })
+
+    await inbox.loadSummary({ spreadsheetId: 'sheet_1' })
+
+    expect(inbox.summary.value).toBeNull()
+    expect(inbox.error.value).toBe('加载提及摘要失败')
   })
 
   it('skips load for empty spreadsheetId', async () => {

--- a/apps/web/tests/multitable-record-permissions-composable.spec.ts
+++ b/apps/web/tests/multitable-record-permissions-composable.spec.ts
@@ -1,0 +1,31 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { useLocale } from '../src/composables/useLocale'
+import { useMultitableRecordPermissions } from '../src/multitable/composables/useMultitableRecordPermissions'
+
+describe('useMultitableRecordPermissions i18n fallbacks', () => {
+  beforeEach(() => {
+    useLocale().setLocale('en')
+  })
+
+  it('localizes frontend load fallback when backend message is absent', async () => {
+    useLocale().setLocale('zh-CN')
+    const state = useMultitableRecordPermissions({
+      listRecordPermissions: vi.fn().mockRejectedValue({}),
+    } as any)
+
+    await state.loadPermissions('sheet_1', 'record_1')
+
+    expect(state.error.value).toBe('加载记录权限失败')
+  })
+
+  it('keeps backend grant errors raw ahead of localized fallbacks', async () => {
+    useLocale().setLocale('zh-CN')
+    const state = useMultitableRecordPermissions({
+      updateRecordPermission: vi.fn().mockRejectedValue(new Error('backend grant raw')),
+    } as any)
+
+    await expect(state.grantPermission('sheet_1', 'record_1', 'user', 'user_1', 'read')).rejects.toThrow('backend grant raw')
+
+    expect(state.error.value).toBe('backend grant raw')
+  })
+})

--- a/apps/web/tests/multitable-workbench-i18n.spec.ts
+++ b/apps/web/tests/multitable-workbench-i18n.spec.ts
@@ -58,6 +58,7 @@ const ALL_KEYS: WorkbenchLabelKey[] = [
   'confirm.discardContextChanges', 'confirm.discardRecordChanges',
   'confirm.pageLeaveBusy', 'confirm.pageLeaveDirty',
   'card.install', 'card.installing',
+  'error.loadSheets', 'error.loadSheetMetadata', 'error.loadBaseMetadata',
 ]
 
 describe('workbench-labels static table', () => {
@@ -85,6 +86,8 @@ describe('workbench-labels static table', () => {
     expect(workbenchLabel('conflict.fieldFallback', false)).toBe('cell')
     expect(workbenchLabel('card.install', true)).toBe('使用模板')
     expect(workbenchLabel('card.installing', false)).toBe('Installing...')
+    expect(workbenchLabel('error.loadSheets', true)).toBe('加载 Sheet 失败')
+    expect(workbenchLabel('error.loadSheetMetadata', false)).toBe('Failed to load sheet metadata')
   })
 })
 

--- a/apps/web/tests/multitable-workbench.spec.ts
+++ b/apps/web/tests/multitable-workbench.spec.ts
@@ -1,4 +1,5 @@
 import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { useLocale } from '../src/composables/useLocale'
 import { useMultitableWorkbench } from '../src/multitable/composables/useMultitableWorkbench'
 import { MultitableApiClient } from '../src/multitable/api/client'
 
@@ -9,6 +10,10 @@ function mockClient(data: any = {}) {
 }
 
 describe('useMultitableWorkbench', () => {
+  beforeEach(() => {
+    useLocale().setLocale('en')
+  })
+
   it('loads sheets and auto-selects first', async () => {
     const client = mockClient({ sheets: [{ id: 's1', name: 'Sheet1' }, { id: 's2', name: 'Sheet2' }] })
     const wb = useMultitableWorkbench({ client })
@@ -348,5 +353,25 @@ describe('useMultitableWorkbench', () => {
     const wb = useMultitableWorkbench({ client })
     await wb.loadSheets()
     expect(wb.error.value).toBeTruthy()
+  })
+
+  it('localizes sheet-load fallback when backend message is absent', async () => {
+    useLocale().setLocale('zh-CN')
+    const client = { listSheets: vi.fn().mockRejectedValue({}) } as any
+    const wb = useMultitableWorkbench({ client })
+
+    await wb.loadSheets()
+
+    expect(wb.error.value).toBe('加载 Sheet 失败')
+  })
+
+  it('keeps backend load errors raw ahead of localized fallbacks', async () => {
+    useLocale().setLocale('zh-CN')
+    const client = { listSheets: vi.fn().mockRejectedValue(new Error('backend raw')) } as any
+    const wb = useMultitableWorkbench({ client })
+
+    await wb.loadSheets()
+
+    expect(wb.error.value).toBe('backend raw')
   })
 })

--- a/docs/development/multitable-final-audit-composable-fallbacks-design-20260522.md
+++ b/docs/development/multitable-final-audit-composable-fallbacks-design-20260522.md
@@ -1,0 +1,82 @@
+# Multitable final audit composable fallbacks design (2026-05-22)
+
+## 1. Decision summary
+
+This slice closes the final-audit residual frontend-owned fallback strings in multitable composables and import helpers.
+
+- Reuse existing label modules instead of adding a broad catch-all module.
+- Preserve raw backend and user-data messages: `e.message` and import resolver errors always win.
+- Keep pure import helpers locale-optional with `isZh = false`; Vue-bound callers pass `isZh.value`.
+- Leave `useYjsDocument.ts` technical diagnostics and the unreachable MetaCellEditor linked-record fallback out of scope.
+
+## 2. Files in scope
+
+- `apps/web/src/multitable/composables/useMultitableWorkbench.ts`
+- `apps/web/src/multitable/composables/useMultitableGrid.ts`
+- `apps/web/src/multitable/composables/useMultitableComments.ts`
+- `apps/web/src/multitable/composables/useMultitableCommentInbox.ts`
+- `apps/web/src/multitable/composables/useMultitableCommentInboxSummary.ts`
+- `apps/web/src/multitable/composables/useMultitableCommentPresence.ts`
+- `apps/web/src/multitable/composables/useMultitableRecordPermissions.ts`
+- `apps/web/src/multitable/import/delimited.ts`
+- `apps/web/src/multitable/import/bulk-import.ts`
+- Existing label modules: `workbench-labels.ts`, `meta-core-labels.ts`, `meta-comment-labels.ts`, `meta-import-labels.ts`
+- Caller wiring: `MetaImportModal.vue`, `MultitableWorkbench.vue`
+
+Out of scope:
+
+- `useYjsDocument.ts` auth/invalidation diagnostics.
+- `MetaCellEditor.vue` unreachable `Choose linked records...` defensive branch.
+- Backend/API contract changes.
+
+## 3. Label ownership
+
+| Surface | Module | Notes |
+| --- | --- | --- |
+| Workbench context loads | `workbench-labels.ts` | Adds `error.loadSheets`, `error.loadSheetMetadata`, `error.loadBaseMetadata`. |
+| Grid composable | `meta-core-labels.ts` | Grid-state fallbacks stay with core grid chrome. |
+| Comment composables | `meta-comment-labels.ts` | Comment/inbox/mention/presence fallbacks share the comment domain. |
+| Record permission composable | `meta-permission-labels.ts` | Reuses existing `record.error.*` keys; no new permission keys. |
+| Import helpers | `meta-import-labels.ts` | Adds import resolver/abort/duplicate dynamic helpers. |
+
+## 4. Raw boundary
+
+Raw values stay raw:
+
+- Backend `e.message`.
+- Import resolver thrown `error.message`.
+- Field names in import failures.
+- Raw imported cell values.
+- Duplicate primary field values.
+- Record/field IDs and technical codes.
+
+Only frontend-owned fallback text is localized.
+
+## 5. Implementation notes
+
+Vue composables call `useLocale()` inside the composable function and read `isZh.value` at catch time. This matches earlier composable-level i18n precedent while keeping error messages event-time: once written into `error.value`, they do not retranslate after a locale toggle.
+
+Pure import helpers accept optional `isZh = false` because they are not Vue-bound. Existing direct unit tests and old call sites remain English by default.
+
+## 6. Test plan
+
+- Label helper coverage:
+  - `multitable-workbench-i18n.spec.ts`
+  - `multitable-core-i18n.spec.ts`
+  - `meta-comment-labels.spec.ts`
+  - `multitable-import.spec.ts`
+- Composable fallback coverage:
+  - `multitable-workbench.spec.ts`
+  - `multitable-grid.spec.ts`
+  - `multitable-comments.spec.ts`
+  - `multitable-comment-inbox.spec.ts`
+  - `multitable-mention-inbox.spec.ts`
+  - `multitable-comment-presence.spec.ts`
+  - `multitable-record-permissions-composable.spec.ts`
+
+## 7. Acceptance
+
+- Targeted specs pass.
+- `vue-tsc`, frontend build, and diff-check pass.
+- Grep confirms scoped hardcoded fallback strings only remain inside label modules or intentionally out-of-scope diagnostics.
+- No backend/contract/migration/attendance/K3 changes.

--- a/docs/development/multitable-final-audit-composable-fallbacks-verification-20260522.md
+++ b/docs/development/multitable-final-audit-composable-fallbacks-verification-20260522.md
@@ -1,0 +1,101 @@
+# Multitable final audit composable fallbacks verification (2026-05-22)
+
+## 1. Scope
+
+Final-audit residual fallback slice for multitable composables and import helpers.
+
+Changed surfaces:
+
+- `useMultitableWorkbench.ts`
+- `useMultitableGrid.ts`
+- `useMultitableComments.ts`
+- `useMultitableCommentInbox.ts`
+- `useMultitableCommentInboxSummary.ts`
+- `useMultitableCommentPresence.ts`
+- `useMultitableRecordPermissions.ts`
+- `import/delimited.ts`
+- `import/bulk-import.ts`
+- Existing multitable label modules and targeted specs.
+
+No backend, contract, migration, attendance, or K3 files are in scope.
+
+## 2. Preflight grep
+
+Command used:
+
+```bash
+grep -R -n "Failed to load sheets\|Failed to load sheet metadata\|Failed to load base metadata\|Failed to load view data\|Record editing is not allowed for this row\.\|Record deletion is not allowed for this row\.\|sheetId or viewId is required\|Failed to create record\|Failed to delete record\|This cell was updated elsewhere\|Failed to patch cell\|Patch failed\|latest record version\|Failed to load comments\|Failed to add comment\|Failed to resolve comment\|Failed to update comment\|Failed to delete comment\|Failed to load comment inbox\|Failed to load unread comment count\|Failed to mark comment as read\|Failed to load mention summary\|Failed to load comment presence\|Failed to load record permissions\|Failed to grant record permission\|Failed to revoke record permission\|No import resolver is configured\|Unable to resolve people value\|Unable to resolve linked value\|Import cancelled\|Skipped duplicate row because" apps/web/src/multitable --include='*.ts' --include='*.vue'
+```
+
+Post-implementation result: matches are contained in label modules or pre-existing Workbench toast labels. No composable/import helper call-site keeps these fallback literals inline.
+
+Permission reuse reachability:
+
+```bash
+grep -n "'record\\.error" apps/web/src/multitable/utils/meta-permission-labels.ts
+```
+
+Result:
+
+```text
+39:  | 'record.error.grant'
+40:  | 'record.error.loadCandidates'
+41:  | 'record.error.loadPermissions'
+42:  | 'record.error.remove'
+43:  | 'record.error.update'
+143:  'record.error.grant': { en: 'Failed to grant permission', zh: '授予权限失败' },
+145:  'record.error.loadPermissions': { en: 'Failed to load record permissions', zh: '加载记录权限失败' },
+146:  'record.error.remove': { en: 'Failed to remove permission', zh: '移除权限失败' },
+```
+
+## 3. Raw boundary evidence
+
+Tests assert:
+
+- Backend comment error message `backend raw` wins over zh fallback.
+- Workbench backend error message `backend raw` wins over zh fallback.
+- Record permission backend grant error `backend grant raw` wins over zh fallback.
+- Import field names and raw values pass through localized helper text unchanged.
+- Duplicate row value `alpha` passes through localized helper text unchanged.
+
+## 4. Targeted test pass
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false tests/multitable-workbench.spec.ts tests/multitable-grid.spec.ts tests/multitable-comments.spec.ts tests/multitable-comment-inbox.spec.ts tests/multitable-mention-inbox.spec.ts tests/multitable-comment-presence.spec.ts tests/multitable-import.spec.ts tests/multitable-record-permissions-composable.spec.ts tests/multitable-workbench-i18n.spec.ts tests/multitable-core-i18n.spec.ts tests/meta-comment-labels.spec.ts
+```
+
+Result:
+
+```text
+Test Files  11 passed (11)
+Tests       155 passed (155)
+```
+
+## 5. Worktree dependency note
+
+This clean `/private/tmp` worktree did not have local dependency links, so verification used temporary untracked symlinks:
+
+- `node_modules -> /Users/chouhua/Downloads/Github/metasheet2/node_modules`
+- `apps/web/node_modules -> /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules`
+
+These symlinks are not intended PR files and must not be staged.
+
+## 6. Type/build/diff gates
+
+Commands:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web build
+git diff --check origin/main..HEAD
+```
+
+Result:
+
+```text
+vue-tsc --noEmit: PASS
+frontend build: PASS (vite built in 5.95s)
+git diff --check origin/main..HEAD: PASS
+```


### PR DESCRIPTION
## Summary
- Closure audit follow-up: localize residual frontend-owned multitable composable/import fallback strings.
- Reuse existing label modules: workbench-labels, meta-core-labels, meta-comment-labels, meta-import-labels; record permissions reuse existing record.error.* keys.
- Preserve raw precedence for backend e.message, import resolver errors, field names, imported values, duplicate keys, and technical IDs.

## Verification
- Targeted Vitest: 155/155 passed across 11 files.
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` passed.
- `pnpm --filter @metasheet/web build` passed, built in 6.46s.
- `git diff --check origin/main..HEAD` clean.

## Docs
- `docs/development/multitable-final-audit-composable-fallbacks-design-20260522.md`
- `docs/development/multitable-final-audit-composable-fallbacks-verification-20260522.md`

## Notes
- No backend, contract, migration, attendance, or K3 changes.
- `useYjsDocument.ts` technical diagnostics and the unreachable MetaCellEditor linked-record fallback remain intentionally out of scope.