### PR TITLE
feat(attendance): add comprehensive hours calculator helpers

### DIFF
--- a/docs/development/attendance-comprehensive-hours-control-pr1-development-20260522.md
+++ b/docs/development/attendance-comprehensive-hours-control-pr1-development-20260522.md
@@ -1,0 +1,69 @@
+# Attendance Comprehensive Working Hours Control PR1 Development
+
+Date: 2026-05-22
+Branch: `codex/attendance-comprehensive-hours-pr1-20260522`
+
+## Summary
+
+This slice implements PR1 from `attendance-comprehensive-hours-control-rfc-20260522.md`: pure calculator helpers for comprehensive working-hours control (`综合工时制`). It deliberately does not add a route, UI, policy storage, migration, save warning, or save block.
+
+The helpers define the semantics that later preview and enforcement PRs will reuse:
+
+- deterministic period resolution
+- planned scheduled minutes from effective-calendar / schedule-day inputs
+- actual attendance minutes from summary payloads
+- cap comparison for warn vs block policy modes
+- stable per-user preview rows
+
+## Changed Files
+
+| File | Change |
+| --- | --- |
+| `plugins/plugin-attendance/index.cjs` | Adds pure comprehensive-hours helper functions and exports them through the existing test surface. |
+| `packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts` | Adds unit coverage for period resolution, invalid input, planned-vs-actual separation, cap comparison, and stable preview rows. |
+| `docs/development/attendance-comprehensive-hours-control-pr1-development-20260522.md` | This development note. |
+| `docs/development/attendance-comprehensive-hours-control-pr1-verification-20260522.md` | Verification evidence. |
+
+## Helper Contract
+
+| Helper | Contract |
+| --- | --- |
+| `resolveAttendanceComprehensiveHoursPeriod(input, options?)` | Resolves `month`, `quarter`, `year`, `custom_range`, and `payroll_cycle` to `{ type, key, from, to, label }`; returns `{ ok:false,error }` instead of throwing for invalid input. |
+| `calculateAttendanceComprehensiveShiftPlannedMinutes(profile)` | Computes shift duration from `workStartTime` / `workEndTime` and `isOvernight`; returns 0 for invalid times. |
+| `buildAttendanceComprehensivePlannedMinutesFromDays(days, options?)` | Aggregates planned minutes from effective-calendar-style day rows without reading actual attendance summaries. |
+| `buildAttendanceComprehensiveActualMinutesFromSummary(summary)` | Extracts actual minutes from existing summary payload fields such as `total_minutes` / `work_duration`. |
+| `buildAttendanceComprehensiveHoursComparison(input)` | Computes `remainingMinutes`, `excessMinutes`, and `status: ok | warning | violation`. |
+| `buildAttendanceComprehensiveHoursPreviewRows(input)` | Produces stable user-sorted comparison rows and switches planned vs actual source by `metric`. |
+
+## Boundary
+
+| Boundary | Decision |
+| --- | --- |
+| HTTP route | Not added. |
+| Frontend UI | Not added. |
+| Policy persistence | Not added. |
+| New migration | Not added. |
+| `attendance_*` fact writes | Not added. |
+| Direct `meta_*` writes | Not added. |
+| Multitable writes | Not added. |
+| Advanced scheduling write path | Not touched. |
+| Save warning / save block | Not added. |
+| Data Factory / Bridge Agent | Not touched. |
+
+## Design Notes
+
+### Planned and Actual Stay Separate
+
+`buildAttendanceComprehensivePlannedMinutesFromDays()` consumes schedule/effective-calendar day rows. `buildAttendanceComprehensiveActualMinutesFromSummary()` consumes existing attendance summary payloads. They are intentionally separate helpers so a future preview route cannot accidentally use actual attendance data to block future schedule saves.
+
+### Invalid Input Does Not Throw
+
+The period resolver returns structured errors. This makes the future PR2 route able to map validation failures to 400 responses without adding another parser shape.
+
+### Strong Control Is Only a Status
+
+This PR can compute `status='violation'` when `enforcement='block'`, but it does not enforce or block anything. Enforcement belongs to a later explicit opt-in PR.
+
+## Follow-Up
+
+Next slice should be PR2: a read-only `POST /api/attendance/comprehensive-hours/preview` route that wires these helpers to database producers. That PR should request independent review before merge.

--- a/docs/development/attendance-comprehensive-hours-control-pr1-verification-20260522.md
+++ b/docs/development/attendance-comprehensive-hours-control-pr1-verification-20260522.md
@@ -1,0 +1,65 @@
+# Attendance Comprehensive Working Hours Control PR1 Verification
+
+Date: 2026-05-22
+Branch: `codex/attendance-comprehensive-hours-pr1-20260522`
+
+## Scope Verification
+
+| Area | Result |
+| --- | --- |
+| Runtime code | Limited to pure helpers in `plugins/plugin-attendance/index.cjs`. |
+| Route / API | None added. |
+| Frontend | None changed. |
+| Migration | None added. |
+| `attendance_*` fact writes | None added. |
+| Direct `meta_*` writes | None added. |
+| Multitable writes | None added. |
+| Save warning / save block | None added. |
+| Data Factory / Bridge Agent | Not touched. |
+
+## Test Coverage
+
+| Test | Coverage |
+| --- | --- |
+| `resolves month, quarter, year, custom range, and payroll-cycle periods deterministically` | Locks period key/from/to/label semantics. |
+| `rejects invalid period input without throwing` | Locks structured error behavior. |
+| `aggregates planned minutes from effective calendar-style days without using actual attendance summary` | Locks planned scheduled minutes, holiday/off day 0, overnight shift, explicit planned-minute override, and source retention. |
+| `keeps actual minutes sourced from summary payloads separate from planned minutes` | Locks actual summary extraction and null fallback. |
+| `builds warning vs violation comparisons from the same cap math` | Locks warn/block status semantics and cap math. |
+| `sorts preview rows by userId and switches metric source by mode` | Locks stable row ordering and planned/actual source selection. |
+
+## Commands
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/attendance-comprehensive-hours-control.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/attendance-advanced-scheduling-workbench.test.ts \
+  tests/unit/attendance-scheduling-assignment-conflict.test.ts \
+  tests/unit/attendance-effective-calendar-role-context.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend build
+
+git diff --check
+```
+
+## Results
+
+| Check | Result |
+| --- | --- |
+| Plugin syntax | PASS |
+| New comprehensive-hours helper test | PASS, 6 tests |
+| Existing scheduling/effective-calendar focused regressions | PASS, 15 tests |
+| Core backend build | PASS |
+| `git diff --check` | PASS |
+
+## Notes
+
+No live staging evidence is applicable for this PR because it exposes no route and performs no write. PR2 will be the first slice where runtime preview evidence can be added.
+
+The isolated worktree required `pnpm install --ignore-scripts` before Vitest. That produced unrelated tracked `node_modules` symlink noise in plugin/tool folders; commit staging must explicitly list only the four slice files and must not use `git add -A`.

--- a/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
+++ b/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
@@ -1,0 +1,214 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceReportFieldCatalogForTests
+
+describe('attendance comprehensive working-hours control helpers', () => {
+  it('resolves month, quarter, year, custom range, and payroll-cycle periods deterministically', () => {
+    expect(helpers.resolveAttendanceComprehensiveHoursPeriod({ type: 'month', year: 2026, month: 2 })).toEqual({
+      ok: true,
+      period: {
+        type: 'month',
+        key: '2026-02',
+        from: '2026-02-01',
+        to: '2026-02-28',
+        label: '2026-02',
+      },
+    })
+
+    expect(helpers.resolveAttendanceComprehensiveHoursPeriod({ type: 'quarter', year: '2026', quarter: '4' })).toEqual({
+      ok: true,
+      period: {
+        type: 'quarter',
+        key: '2026-Q4',
+        from: '2026-10-01',
+        to: '2026-12-31',
+        label: '2026 Q4',
+      },
+    })
+
+    expect(helpers.resolveAttendanceComprehensiveHoursPeriod({ type: 'year', year: 2028 })).toEqual({
+      ok: true,
+      period: {
+        type: 'year',
+        key: '2028',
+        from: '2028-01-01',
+        to: '2028-12-31',
+        label: '2028',
+      },
+    })
+
+    expect(helpers.resolveAttendanceComprehensiveHoursPeriod({
+      type: 'custom_range',
+      from: '2026-05-01',
+      to: '2026-05-31',
+    })).toEqual({
+      ok: true,
+      period: {
+        type: 'custom_range',
+        key: 'range:2026-05-01:2026-05-31',
+        from: '2026-05-01',
+        to: '2026-05-31',
+        label: '2026-05-01..2026-05-31',
+      },
+    })
+
+    expect(helpers.resolveAttendanceComprehensiveHoursPeriod({
+      type: 'payroll_cycle',
+      cycleId: 'cycle-a',
+      cycle: {
+        id: 'cycle-ignored',
+        name: 'April payroll',
+        startDate: '2026-04-01',
+        endDate: '2026-04-30',
+      },
+    })).toEqual({
+      ok: true,
+      period: {
+        type: 'payroll_cycle',
+        key: 'cycle:cycle-a',
+        cycleId: 'cycle-a',
+        from: '2026-04-01',
+        to: '2026-04-30',
+        label: 'April payroll',
+      },
+    })
+  })
+
+  it('rejects invalid period input without throwing', () => {
+    expect(helpers.resolveAttendanceComprehensiveHoursPeriod({ type: 'week', year: 2026 }).error.code).toBe('INVALID_PERIOD_TYPE')
+    expect(helpers.resolveAttendanceComprehensiveHoursPeriod({ type: 'month', year: 2026, month: 13 }).error.code).toBe('INVALID_PERIOD_MONTH')
+    expect(helpers.resolveAttendanceComprehensiveHoursPeriod({ type: 'quarter', year: 2026, quarter: 5 }).error.code).toBe('INVALID_PERIOD_QUARTER')
+    expect(helpers.resolveAttendanceComprehensiveHoursPeriod({ type: 'year', year: 10000 }).error.code).toBe('INVALID_PERIOD_YEAR')
+    expect(helpers.resolveAttendanceComprehensiveHoursPeriod({ type: 'custom_range', from: '2026-02-02', to: '2026-02-01' }).error.code).toBe('INVALID_PERIOD_RANGE')
+    expect(helpers.resolveAttendanceComprehensiveHoursPeriod({ type: 'payroll_cycle', cycleId: 'cycle-a' }).error.code).toBe('INVALID_PAYROLL_CYCLE')
+  })
+
+  it('aggregates planned minutes from effective calendar-style days without using actual attendance summary', () => {
+    const planned = helpers.buildAttendanceComprehensivePlannedMinutesFromDays([
+      {
+        date: '2026-05-01',
+        effective: { isWorkingDay: true, source: 'shift' },
+        shift: { workStartTime: '09:00', workEndTime: '18:00', isOvernight: false },
+      },
+      {
+        date: '2026-05-02',
+        effective: { isWorkingDay: false, source: 'national' },
+        shift: { workStartTime: '09:00', workEndTime: '18:00' },
+      },
+      {
+        date: '2026-05-03',
+        effective: { isWorkingDay: true, source: 'rotation' },
+        shift: { workStartTime: '22:00', workEndTime: '06:00', isOvernight: true },
+      },
+      {
+        date: '2026-05-04',
+        effective: { isWorkingDay: true, source: 'manual' },
+        plannedMinutes: 300,
+      },
+    ])
+
+    expect(planned).toMatchObject({
+      plannedMinutes: 540 + 0 + 480 + 300,
+      days: 4,
+      workingDays: 3,
+    })
+    expect(planned.items.map((item: any) => item.plannedMinutes)).toEqual([540, 0, 480, 300])
+    expect(planned.items.map((item: any) => item.source)).toEqual(['shift', 'national', 'rotation', 'manual'])
+  })
+
+  it('keeps actual minutes sourced from summary payloads separate from planned minutes', () => {
+    expect(helpers.buildAttendanceComprehensiveActualMinutesFromSummary({ total_minutes: 1234 })).toEqual({
+      actualMinutes: 1234,
+      source: 'summary',
+    })
+    expect(helpers.buildAttendanceComprehensiveActualMinutesFromSummary({ work_duration: 456 })).toEqual({
+      actualMinutes: 456,
+      source: 'summary',
+    })
+    expect(helpers.buildAttendanceComprehensiveActualMinutesFromSummary(null)).toEqual({
+      actualMinutes: 0,
+      source: 'summary',
+    })
+  })
+
+  it('builds warning vs violation comparisons from the same cap math', () => {
+    expect(helpers.buildAttendanceComprehensiveHoursComparison({
+      userId: 'user-a',
+      metric: 'planned',
+      enforcement: 'warn',
+      capMinutes: 1000,
+      plannedMinutes: 1105,
+    })).toMatchObject({
+      userId: 'user-a',
+      metric: 'planned',
+      enforcement: 'warn',
+      capMinutes: 1000,
+      minutes: 1105,
+      plannedMinutes: 1105,
+      remainingMinutes: 0,
+      excessMinutes: 105,
+      status: 'warning',
+    })
+
+    expect(helpers.buildAttendanceComprehensiveHoursComparison({
+      userId: 'user-a',
+      metric: 'actual',
+      enforcement: 'block',
+      capMinutes: 1000,
+      actualMinutes: 1105,
+    })).toMatchObject({
+      metric: 'actual',
+      enforcement: 'block',
+      actualMinutes: 1105,
+      excessMinutes: 105,
+      status: 'violation',
+    })
+
+    expect(helpers.buildAttendanceComprehensiveHoursComparison({
+      metric: 'planned',
+      capMinutes: 1000,
+      plannedMinutes: 960,
+    })).toMatchObject({
+      remainingMinutes: 40,
+      excessMinutes: 0,
+      status: 'ok',
+    })
+  })
+
+  it('sorts preview rows by userId and switches metric source by mode', () => {
+    const users = [{ id: 'user-b' }, { id: 'user-a' }]
+    const plannedRows = helpers.buildAttendanceComprehensiveHoursPreviewRows({
+      users,
+      metric: 'planned',
+      capMinutes: 500,
+      plannedMinutesByUser: new Map([
+        ['user-b', 400],
+        ['user-a', 600],
+      ]),
+    })
+
+    expect(plannedRows.map((row: any) => [row.userId, row.minutes, row.status])).toEqual([
+      ['user-a', 600, 'warning'],
+      ['user-b', 400, 'ok'],
+    ])
+
+    const actualRows = helpers.buildAttendanceComprehensiveHoursPreviewRows({
+      users,
+      metric: 'actual',
+      enforcement: 'block',
+      capMinutes: 500,
+      actualMinutesByUser: new Map([
+        ['user-b', 700],
+        ['user-a', 300],
+      ]),
+    })
+
+    expect(actualRows.map((row: any) => [row.userId, row.minutes, row.status])).toEqual([
+      ['user-a', 300, 'ok'],
+      ['user-b', 700, 'violation'],
+    ])
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -11672,6 +11672,262 @@ async function buildWorkContextPrefetch(db, options) {
   }
 }
 
+const ATTENDANCE_COMPREHENSIVE_HOURS_PERIOD_TYPES = new Set([
+  'month',
+  'quarter',
+  'year',
+  'payroll_cycle',
+  'custom_range',
+])
+const ATTENDANCE_COMPREHENSIVE_HOURS_METRICS = new Set(['planned', 'actual'])
+const ATTENDANCE_COMPREHENSIVE_HOURS_ENFORCEMENT = new Set(['warn', 'block'])
+
+function buildAttendanceComprehensiveHoursError(code, message) {
+  return { ok: false, error: { code, message } }
+}
+
+function normalizeAttendanceComprehensiveInteger(value, fallback = null) {
+  if (typeof value === 'number' && Number.isInteger(value)) return value
+  if (typeof value === 'string' && /^-?\d+$/.test(value.trim())) return Number(value.trim())
+  return fallback
+}
+
+function attendanceComprehensiveMonthEndDate(year, month) {
+  const date = new Date(Date.UTC(year, month, 0))
+  return date.toISOString().slice(0, 10)
+}
+
+function resolveAttendanceComprehensiveHoursPeriod(input = {}, options = {}) {
+  const type = typeof input.type === 'string' ? input.type.trim() : ''
+  if (!ATTENDANCE_COMPREHENSIVE_HOURS_PERIOD_TYPES.has(type)) {
+    return buildAttendanceComprehensiveHoursError(
+      'INVALID_PERIOD_TYPE',
+      'Comprehensive hours period type must be month, quarter, year, payroll_cycle, or custom_range',
+    )
+  }
+
+  if (type === 'custom_range') {
+    const from = normalizeDateOnlyStrict(input.from)
+    const to = normalizeDateOnlyStrict(input.to)
+    if (!from || !to || from > to) {
+      return buildAttendanceComprehensiveHoursError('INVALID_PERIOD_RANGE', 'Custom range requires valid from/to dates')
+    }
+    return { ok: true, period: { type, key: `range:${from}:${to}`, from, to, label: `${from}..${to}` } }
+  }
+
+  if (type === 'month') {
+    const year = normalizeAttendanceComprehensiveInteger(input.year)
+    const month = normalizeAttendanceComprehensiveInteger(input.month)
+    if (!Number.isInteger(year) || year < 1970 || year > 9999 || !Number.isInteger(month) || month < 1 || month > 12) {
+      return buildAttendanceComprehensiveHoursError('INVALID_PERIOD_MONTH', 'Month period requires valid year and month')
+    }
+    const mm = String(month).padStart(2, '0')
+    const from = `${String(year).padStart(4, '0')}-${mm}-01`
+    const to = attendanceComprehensiveMonthEndDate(year, month)
+    return { ok: true, period: { type, key: `${year}-${mm}`, from, to, label: `${year}-${mm}` } }
+  }
+
+  if (type === 'quarter') {
+    const year = normalizeAttendanceComprehensiveInteger(input.year)
+    const quarter = normalizeAttendanceComprehensiveInteger(input.quarter)
+    if (!Number.isInteger(year) || year < 1970 || year > 9999 || !Number.isInteger(quarter) || quarter < 1 || quarter > 4) {
+      return buildAttendanceComprehensiveHoursError('INVALID_PERIOD_QUARTER', 'Quarter period requires valid year and quarter')
+    }
+    const startMonth = (quarter - 1) * 3 + 1
+    const endMonth = startMonth + 2
+    const from = `${String(year).padStart(4, '0')}-${String(startMonth).padStart(2, '0')}-01`
+    const to = attendanceComprehensiveMonthEndDate(year, endMonth)
+    return { ok: true, period: { type, key: `${year}-Q${quarter}`, from, to, label: `${year} Q${quarter}` } }
+  }
+
+  if (type === 'year') {
+    const year = normalizeAttendanceComprehensiveInteger(input.year)
+    if (!Number.isInteger(year) || year < 1970 || year > 9999) {
+      return buildAttendanceComprehensiveHoursError('INVALID_PERIOD_YEAR', 'Year period requires a valid year')
+    }
+    return {
+      ok: true,
+      period: {
+        type,
+        key: String(year),
+        from: `${String(year).padStart(4, '0')}-01-01`,
+        to: `${String(year).padStart(4, '0')}-12-31`,
+        label: String(year),
+      },
+    }
+  }
+
+  const cycle = input.cycle && typeof input.cycle === 'object'
+    ? input.cycle
+    : options.payrollCycle && typeof options.payrollCycle === 'object'
+      ? options.payrollCycle
+      : input
+  const cycleId = typeof (input.cycleId ?? cycle.id) === 'string' ? String(input.cycleId ?? cycle.id).trim() : ''
+  const from = normalizeDateOnlyStrict(cycle.startDate ?? cycle.start_date)
+  const to = normalizeDateOnlyStrict(cycle.endDate ?? cycle.end_date)
+  if (!cycleId || !from || !to || from > to) {
+    return buildAttendanceComprehensiveHoursError('INVALID_PAYROLL_CYCLE', 'Payroll-cycle period requires cycleId, startDate, and endDate')
+  }
+  return {
+    ok: true,
+    period: {
+      type,
+      key: `cycle:${cycleId}`,
+      cycleId,
+      from,
+      to,
+      label: typeof cycle.name === 'string' && cycle.name.trim() ? cycle.name.trim() : `Payroll cycle ${cycleId}`,
+    },
+  }
+}
+
+function resolveAttendanceComprehensiveHoursMetric(value) {
+  return typeof value === 'string' && ATTENDANCE_COMPREHENSIVE_HOURS_METRICS.has(value)
+    ? value
+    : 'planned'
+}
+
+function resolveAttendanceComprehensiveHoursEnforcement(value) {
+  return typeof value === 'string' && ATTENDANCE_COMPREHENSIVE_HOURS_ENFORCEMENT.has(value)
+    ? value
+    : 'warn'
+}
+
+function calculateAttendanceComprehensiveShiftPlannedMinutes(profile) {
+  const startTime = normalizeTimeString(profile?.workStartTime ?? profile?.work_start_time ?? DEFAULT_RULE.workStartTime)
+  const endTime = normalizeTimeString(profile?.workEndTime ?? profile?.work_end_time ?? DEFAULT_RULE.workEndTime)
+  if (!startTime || !endTime) return 0
+  const startMinutes = parseTimeToMinutes(startTime, null)
+  const endMinutes = parseTimeToMinutes(endTime, null)
+  if (!Number.isFinite(startMinutes) || !Number.isFinite(endMinutes)) return 0
+  const isOvernight = resolveOvernightFlag(profile?.isOvernight ?? profile?.is_overnight, startTime, endTime)
+  let duration = endMinutes - startMinutes
+  if (isOvernight && duration <= 0) duration += 24 * 60
+  if (!isOvernight && duration < 0) return 0
+  return Math.max(0, Math.floor(duration))
+}
+
+function resolveAttendanceComprehensiveDayProfile(day, fallbackProfile) {
+  if (day?.profile && typeof day.profile === 'object') return day.profile
+  if (day?.shift && typeof day.shift === 'object') return day.shift
+  if (day?.rule && typeof day.rule === 'object') return day.rule
+  if (day?.resolvedContext?.rule && typeof day.resolvedContext.rule === 'object') return day.resolvedContext.rule
+  return fallbackProfile ?? DEFAULT_RULE
+}
+
+function isAttendanceComprehensiveDayWorking(day, profile) {
+  if (day?.effective && typeof day.effective.isWorkingDay === 'boolean') return day.effective.isWorkingDay
+  if (typeof day?.isWorkingDay === 'boolean') return day.isWorkingDay
+  if (typeof day?.resolvedContext?.isWorkingDay === 'boolean') return day.resolvedContext.isWorkingDay
+  const date = normalizeDateOnly(day?.date ?? day?.workDate ?? day?.work_date)
+  const weekday = date ? getWeekdayFromDateKey(date) : null
+  return weekday != null && Array.isArray(profile?.workingDays) && profile.workingDays.includes(weekday)
+}
+
+function buildAttendanceComprehensivePlannedMinutesFromDays(days, options = {}) {
+  const fallbackProfile = options.defaultRule ?? options.fallbackProfile ?? DEFAULT_RULE
+  const items = []
+  let plannedMinutes = 0
+  for (const day of Array.isArray(days) ? days : []) {
+    const date = normalizeDateOnly(day?.date ?? day?.workDate ?? day?.work_date)
+    const profile = resolveAttendanceComprehensiveDayProfile(day, fallbackProfile)
+    const isWorkingDay = isAttendanceComprehensiveDayWorking(day, profile)
+    const explicitMinutes = Number(day?.plannedMinutes ?? day?.planned_minutes)
+    const minutes = isWorkingDay
+      ? Number.isFinite(explicitMinutes)
+        ? Math.max(0, Math.floor(explicitMinutes))
+        : calculateAttendanceComprehensiveShiftPlannedMinutes(profile)
+      : 0
+    plannedMinutes += minutes
+    items.push({
+      date,
+      isWorkingDay,
+      plannedMinutes: minutes,
+      source: day?.effective?.source ?? day?.source ?? day?.resolvedContext?.policySource ?? day?.resolvedContext?.source ?? null,
+    })
+  }
+  return {
+    plannedMinutes,
+    days: items.length,
+    workingDays: items.filter(item => item.isWorkingDay).length,
+    items,
+  }
+}
+
+function buildAttendanceComprehensiveActualMinutesFromSummary(summary) {
+  if (!summary || typeof summary !== 'object') return { actualMinutes: 0, source: 'summary' }
+  const candidates = [
+    summary.total_minutes,
+    summary.work_duration,
+    summary.workMinutes,
+    summary.work_minutes,
+  ]
+  for (const value of candidates) {
+    const minutes = Number(value)
+    if (Number.isFinite(minutes)) {
+      return { actualMinutes: Math.max(0, Math.floor(minutes)), source: 'summary' }
+    }
+  }
+  return { actualMinutes: 0, source: 'summary' }
+}
+
+function buildAttendanceComprehensiveHoursComparison(input = {}) {
+  const metric = resolveAttendanceComprehensiveHoursMetric(input.metric)
+  const enforcement = resolveAttendanceComprehensiveHoursEnforcement(input.enforcement)
+  const capMinutesRaw = Number(input.capMinutes ?? input.cap_minutes)
+  const capMinutes = Number.isFinite(capMinutesRaw) ? Math.max(0, Math.floor(capMinutesRaw)) : 0
+  const minutesRaw = Number(
+    input.minutes
+      ?? (metric === 'actual'
+        ? input.actualMinutes ?? input.actual_minutes
+        : input.plannedMinutes ?? input.planned_minutes)
+  )
+  const minutes = Number.isFinite(minutesRaw) ? Math.max(0, Math.floor(minutesRaw)) : 0
+  const excessMinutes = Math.max(0, minutes - capMinutes)
+  const remainingMinutes = Math.max(0, capMinutes - minutes)
+  const status = excessMinutes > 0
+    ? enforcement === 'block' ? 'violation' : 'warning'
+    : 'ok'
+  return {
+    userId: input.userId ?? input.user_id ?? null,
+    period: input.period ?? null,
+    metric,
+    enforcement,
+    capMinutes,
+    minutes,
+    plannedMinutes: metric === 'planned' ? minutes : undefined,
+    actualMinutes: metric === 'actual' ? minutes : undefined,
+    remainingMinutes,
+    excessMinutes,
+    status,
+  }
+}
+
+function buildAttendanceComprehensiveHoursPreviewRows(input = {}) {
+  const users = Array.isArray(input.users) ? input.users : []
+  const metric = resolveAttendanceComprehensiveHoursMetric(input.metric)
+  const enforcement = resolveAttendanceComprehensiveHoursEnforcement(input.enforcement)
+  const capMinutes = Number(input.capMinutes ?? input.cap_minutes ?? 0)
+  const plannedByUser = input.plannedMinutesByUser instanceof Map ? input.plannedMinutesByUser : new Map()
+  const actualByUser = input.actualMinutesByUser instanceof Map ? input.actualMinutesByUser : new Map()
+  return users
+    .map((user) => {
+      const userId = String(user?.id ?? user?.userId ?? user?.user_id ?? '').trim()
+      const minutes = metric === 'actual'
+        ? Number(actualByUser.get(userId) ?? user?.actualMinutes ?? user?.actual_minutes ?? 0)
+        : Number(plannedByUser.get(userId) ?? user?.plannedMinutes ?? user?.planned_minutes ?? 0)
+      return buildAttendanceComprehensiveHoursComparison({
+        userId,
+        period: input.period ?? null,
+        metric,
+        enforcement,
+        capMinutes,
+        minutes,
+      })
+    })
+    .sort((a, b) => String(a.userId ?? '').localeCompare(String(b.userId ?? '')))
+}
+
 function buildWorkdayContextSummary(options) {
   const { workDate, storedIsWorkday, resolvedContext } = options
   if (!resolvedContext || !workDate) return null
@@ -13361,6 +13617,12 @@ module.exports = {
     getAttendancePayrollSummaryFieldValue,
     normalizeCalendarPolicyOverrides,
     resolveEffectiveCalendar,
+    resolveAttendanceComprehensiveHoursPeriod,
+    calculateAttendanceComprehensiveShiftPlannedMinutes,
+    buildAttendanceComprehensivePlannedMinutesFromDays,
+    buildAttendanceComprehensiveActualMinutesFromSummary,
+    buildAttendanceComprehensiveHoursComparison,
+    buildAttendanceComprehensiveHoursPreviewRows,
     findAttendanceScheduleAssignmentConflict,
     acquireAttendanceScheduleAssignmentLock,
     getAttendanceScheduleAssignmentConflictMessage,


### PR DESCRIPTION
## Summary

Implements PR1 from the comprehensive working-hours control RFC: pure calculator helpers only.

This adds backend helper semantics for:
- deterministic period resolution (`month`, `quarter`, `year`, `custom_range`, `payroll_cycle`)
- planned scheduled minutes from effective-calendar / schedule-day inputs
- actual attendance minutes extracted from existing summary payloads
- cap comparison (`ok` / `warning` / `violation`) for warn vs block modes
- stable per-user preview rows for the future read-only preview route

No route, UI, policy persistence, migration, multitable writer, or save warning/blocking is added in this PR.

## Verification

- [x] `node --check plugins/plugin-attendance/index.cjs`
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-comprehensive-hours-control.test.ts --reporter=dot` — 6 pass
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-advanced-scheduling-workbench.test.ts tests/unit/attendance-scheduling-assignment-conflict.test.ts tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` — 15 pass
- [x] `pnpm --filter @metasheet/core-backend build`
- [x] `git diff --check`
- [x] staged secret / local-path scan returned 0 matches

Note: isolated worktree needed `pnpm install --ignore-scripts`; the resulting tracked `node_modules` symlink noise remains unstaged and is not part of this PR.

## Boundary

- No `attendance_*` migration
- No direct `meta_*` writes
- No multitable writes
- No route or frontend surface
- No advanced scheduling write path
- No save warning or save block
- Data Factory / Bridge Agent untouched
