### PR TITLE
fix(multitable): hint when calendar holidays are unsynced

### DIFF
--- a/apps/web/src/multitable/components/MetaCalendarView.vue
+++ b/apps/web/src/multitable/components/MetaCalendarView.vue
@@ -29,6 +29,9 @@
           <button v-if="dateField" class="meta-calendar__change-btn" @click="onResetDateField">{{ viewRenderLabel('calendar.change', isZh) }}</button>
         </span>
       </div>
+      <div v-if="calendarHolidayNotice" class="meta-calendar__notice" role="status">
+        {{ calendarHolidayNotice }}
+      </div>
 
       <template v-if="viewMode === 'month'">
         <div class="meta-calendar__weekdays">
@@ -353,6 +356,7 @@ const props = defineProps<{
   // marker. PR1 wires this in MultitableWorkbench; existing CalendarHoliday
   // payloads remain compatible since the new fields are optional.
   calendarHolidays?: CalendarEffectiveChip[]
+  calendarHolidayNotice?: string | null
   commentPresence?: Record<string, MultitableCommentPresenceSummary | undefined>
 }>()
 
@@ -765,6 +769,7 @@ function onCellKeydown(e: KeyboardEvent, cellIdx: number, cells: CalendarCell[])
 .meta-calendar__mode-select { padding: 4px 8px; border: 1px solid #ddd; border-radius: 4px; font-size: 12px; }
 .meta-calendar__field-label { margin-left: auto; font-size: 12px; color: #999; }
 .meta-calendar__change-btn { padding: 1px 6px; border: 1px solid #ddd; border-radius: 3px; background: #fff; cursor: pointer; font-size: 11px; color: #409eff; margin-left: 4px; }
+.meta-calendar__notice { margin: 8px 16px 0; padding: 6px 10px; border: 1px solid #fde68a; border-radius: 6px; background: #fffbeb; color: #92400e; font-size: 12px; line-height: 1.45; }
 .meta-calendar__weekdays { display: grid; grid-template-columns: repeat(7, 1fr); border-bottom: 1px solid #eee; }
 .meta-calendar__weekday { padding: 6px 0; text-align: center; font-size: 12px; font-weight: 600; color: #999; }
 .meta-calendar__grid { display: grid; grid-template-columns: repeat(7, 1fr); flex: 1; overflow-y: auto; }

--- a/apps/web/src/multitable/utils/calendar-holiday-notice.ts
+++ b/apps/web/src/multitable/utils/calendar-holiday-notice.ts
@@ -1,0 +1,42 @@
+import type { CalendarVisibleRange } from '../../composables/useCalendarDays'
+import { viewRenderLabel } from './meta-view-render-labels'
+
+export type CalendarHolidayFetchState = 'idle' | 'waiting-for-user' | 'loading' | 'ready' | 'empty' | 'error'
+
+// The hint should not appear for naturally quiet months such as July/August.
+// These month anchors cover the common China public-holiday windows used by
+// the attendance holiday-cn sync path, while keeping the UI quiet elsewhere.
+const HOLIDAY_EXPECTATION_MONTHS = new Set([1, 2, 4, 5, 6, 9, 10])
+
+function parseDateKey(value: string | null | undefined): Date | null {
+  const raw = String(value || '').trim()
+  const match = raw.match(/^(\d{4})-(\d{2})-(\d{2})$/)
+  if (!match) return null
+  const [, y, m, d] = match
+  const date = new Date(Number(y), Number(m) - 1, Number(d))
+  return Number.isNaN(date.getTime()) ? null : date
+}
+
+export function visibleRangeHasHolidayExpectation(range: CalendarVisibleRange | null | undefined): boolean {
+  const from = parseDateKey(range?.from)
+  const to = parseDateKey(range?.to)
+  if (!from || !to || from.getTime() > to.getTime()) return false
+
+  const cursor = new Date(from.getFullYear(), from.getMonth(), 1)
+  const end = new Date(to.getFullYear(), to.getMonth(), 1)
+  while (cursor.getTime() <= end.getTime()) {
+    if (HOLIDAY_EXPECTATION_MONTHS.has(cursor.getMonth() + 1)) return true
+    cursor.setMonth(cursor.getMonth() + 1)
+  }
+  return false
+}
+
+export function calendarHolidaySyncNotice(options: {
+  state: CalendarHolidayFetchState
+  range: CalendarVisibleRange | null | undefined
+  isZh: boolean
+}): string | null {
+  if (options.state !== 'empty') return null
+  if (!visibleRangeHasHolidayExpectation(options.range)) return null
+  return viewRenderLabel('calendar.holidayDataMissingHint', options.isZh)
+}

--- a/apps/web/src/multitable/utils/meta-view-render-labels.ts
+++ b/apps/web/src/multitable/utils/meta-view-render-labels.ts
@@ -28,6 +28,7 @@ export type MetaViewRenderLabelKey =
   | 'calendar.newRecord'
   | 'calendar.selectDateField'
   | 'calendar.noRecordsOnDay'
+  | 'calendar.holidayDataMissingHint'
   | 'gallery.title'
   | 'gallery.cover'
   | 'gallery.columns'
@@ -108,6 +109,7 @@ export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'calendar.newRecord',
   'calendar.selectDateField',
   'calendar.noRecordsOnDay',
+  'calendar.holidayDataMissingHint',
   'gallery.title',
   'gallery.cover',
   'gallery.columns',
@@ -189,6 +191,10 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
   'calendar.newRecord': { en: '+ New record', zh: '+ 新建记录' },
   'calendar.selectDateField': { en: 'Select a date field to use for the calendar:', zh: '选择一个日期字段用于日历：' },
   'calendar.noRecordsOnDay': { en: 'No records on this day', zh: '这一天没有记录' },
+  'calendar.holidayDataMissingHint': {
+    en: 'No public holiday data is synced for this range. Sync holidays in Attendance settings if holiday or makeup-workday chips are expected.',
+    zh: '当前范围没有已同步的节假日数据；如应显示节假日或调休班标记，请先在考勤设置中同步节假日。',
+  },
   'gallery.title': { en: 'Title', zh: '标题' },
   'gallery.cover': { en: 'Cover', zh: '封面' },
   'gallery.columns': { en: 'Columns', zh: '列数' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -186,6 +186,7 @@
           :view-config="workbench.activeView.value?.config"
           :link-summaries="grid.linkSummaries.value" :attachment-summaries="grid.attachmentSummaries.value"
           :calendar-holidays="calendarHolidays"
+          :calendar-holiday-notice="calendarHolidayNotice"
           :can-create="caps.canCreateRecord.value"
           :can-comment="effectiveRowActions.canComment"
           :comment-presence="commentPresenceState.presenceByRecordId.value"
@@ -501,6 +502,10 @@ import { extractImportTokens, type ImportBuildFailure, type ImportBuildResult, t
 import { buildXlsxBuffer } from '../import/xlsx-mapping'
 import { filterPropertyVisibleFields } from '../utils/field-permissions'
 import { isLinkField, isPersonField } from '../utils/link-fields'
+import {
+  calendarHolidaySyncNotice,
+  type CalendarHolidayFetchState,
+} from '../utils/calendar-holiday-notice'
 import { addPeopleLookupToken, inferPeopleLookupKind, resolvePeopleImportValue } from '../utils/people-import'
 import { buildRecordFormattingMap, extractRulesFromConfig } from '../utils/conditional-formatting'
 import {
@@ -585,6 +590,7 @@ const templates = ref<MetaTemplate[]>([])
 const templateLibraryLoading = ref(false)
 const templateLibraryError = ref<string | null>(null)
 const calendarHolidays = ref<CalendarEffectiveChip[]>([])
+const calendarHolidayFetchState = ref<CalendarHolidayFetchState>('idle')
 // Composite cache key `${from}|${to}|${userId}` — when userId arrives later
 // (auth resolving after MetaCalendarView's first visible-range emit) the new
 // key forces a refetch instead of skipping on stale (range-only) match.
@@ -593,6 +599,11 @@ let calendarHolidayLoadVersion = 0
 // Last range emitted by MetaCalendarView — replayed once currentUserId
 // resolves so the user does not see an empty calendar for the gap window.
 const lastCalendarVisibleRange = ref<CalendarVisibleRange | null>(null)
+const calendarHolidayNotice = computed(() => calendarHolidaySyncNotice({
+  state: calendarHolidayFetchState.value,
+  range: lastCalendarVisibleRange.value,
+  isZh: isZh.value,
+}))
 const installingTemplateId = ref<string | null>(null)
 const showShortcuts = ref(false)
 const showImportModal = ref(false)
@@ -2824,11 +2835,15 @@ async function loadCalendarHolidays(range: CalendarVisibleRange) {
   // range can fire before currentUserId resolves; we must not silently skip).
   lastCalendarVisibleRange.value = range
   const userId = currentUserId.value
-  if (!userId) return
+  if (!userId) {
+    calendarHolidayFetchState.value = 'waiting-for-user'
+    return
+  }
   const cacheKey = `${from}|${to}|${userId}`
   if (calendarEffectiveCacheKey === cacheKey) return
   calendarEffectiveCacheKey = cacheKey
   const loadVersion = ++calendarHolidayLoadVersion
+  calendarHolidayFetchState.value = 'loading'
   try {
     const result = await fetchEffectiveCalendar({
       from,
@@ -2841,12 +2856,14 @@ async function loadCalendarHolidays(range: CalendarVisibleRange) {
     calendarHolidays.value = items
       .filter(isCalendarEffectiveItemNoteworthy)
       .map(effectiveCalendarItemToChip)
+    calendarHolidayFetchState.value = calendarHolidays.value.length ? 'ready' : 'empty'
   } catch (error) {
     // Failure (network, 401/403 suppressed, server) must not block calendar
     // rendering — clear chips but leave the cell grid intact. Bust the cache
     // key so a later auth/retry can succeed.
     if (loadVersion === calendarHolidayLoadVersion) {
       calendarHolidays.value = []
+      calendarHolidayFetchState.value = 'error'
       calendarEffectiveCacheKey = null
     }
     if (error instanceof EffectiveCalendarFetchError) {

--- a/apps/web/tests/calendar-holiday-notice.spec.ts
+++ b/apps/web/tests/calendar-holiday-notice.spec.ts
@@ -1,0 +1,32 @@
+import { describe, expect, it } from 'vitest'
+import {
+  calendarHolidaySyncNotice,
+  visibleRangeHasHolidayExpectation,
+} from '../src/multitable/utils/calendar-holiday-notice'
+
+describe('calendar holiday sync notice', () => {
+  it('detects visible ranges that commonly contain synced public-holiday data', () => {
+    expect(visibleRangeHasHolidayExpectation({ from: '2026-04-27', to: '2026-06-07' })).toBe(true)
+    expect(visibleRangeHasHolidayExpectation({ from: '2026-07-01', to: '2026-08-31' })).toBe(false)
+  })
+
+  it('only shows the sync hint after a loaded range has no noteworthy holidays', () => {
+    expect(calendarHolidaySyncNotice({
+      state: 'empty',
+      range: { from: '2026-04-27', to: '2026-06-07' },
+      isZh: true,
+    })).toContain('节假日')
+
+    expect(calendarHolidaySyncNotice({
+      state: 'ready',
+      range: { from: '2026-04-27', to: '2026-06-07' },
+      isZh: true,
+    })).toBeNull()
+
+    expect(calendarHolidaySyncNotice({
+      state: 'empty',
+      range: { from: '2026-07-01', to: '2026-08-31' },
+      isZh: false,
+    })).toBeNull()
+  })
+})

--- a/apps/web/tests/multitable-calendar-view.spec.ts
+++ b/apps/web/tests/multitable-calendar-view.spec.ts
@@ -179,6 +179,45 @@ describe('MetaCalendarView', () => {
     container.remove()
   })
 
+  it('renders a calendar holiday sync notice when the workbench passes one', async () => {
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-05-01T12:00:00Z'))
+
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaCalendarView, {
+          rows: [],
+          fields: [
+            { id: 'fld_title', name: 'Title', type: 'string' },
+            { id: 'fld_start', name: 'Start', type: 'date' },
+          ],
+          loading: false,
+          calendarHolidayNotice: 'No public holiday data is synced for this range.',
+          viewConfig: {
+            dateFieldId: 'fld_start',
+            titleFieldId: 'fld_title',
+            defaultView: 'month',
+            weekStartsOn: 0,
+          },
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    const notice = container.querySelector('.meta-calendar__notice')
+    expect(notice).not.toBeNull()
+    expect(notice?.getAttribute('role')).toBe('status')
+    expect(notice?.textContent).toContain('No public holiday data')
+
+    app.unmount()
+    container.remove()
+  })
+
   // ===== Step 4 PR1: effective-calendar chip rendering =====
   // The 6 cases below pin the contract between Workbench (which maps API
   // items to CalendarEffectiveChip) and MetaCalendarView (which renders the

--- a/docs/development/multitable-calendar-holiday-sync-hint-design-20260522.md
+++ b/docs/development/multitable-calendar-holiday-sync-hint-design-20260522.md
@@ -1,0 +1,62 @@
+# Multitable Calendar Holiday Sync Hint Design - 2026-05-22
+
+## Context
+
+Issue #1763 showed that Multitable Calendar could render lunar labels while
+showing no holiday / makeup-workday chips. The entity-machine retest later
+confirmed the root cause was unsynced 2026 attendance holiday data, not a
+Calendar rendering regression.
+
+The remaining product gap is discoverability: when holiday data is missing for
+a range where public-holiday chips are likely expected, the Calendar view looked
+silently incomplete.
+
+## Scope
+
+This slice adds a small frontend-only hint. It does not change attendance
+holiday sync, the effective-calendar backend, database schema, K3 runtime, or
+Bridge Agent behavior.
+
+## Design
+
+The implementation keeps responsibility split:
+
+- `MultitableWorkbench.vue` owns data loading state for
+  `fetchEffectiveCalendar()`.
+- `calendar-holiday-notice.ts` decides whether an empty loaded range should
+  surface a hint.
+- `MetaCalendarView.vue` only renders the notice passed by the workbench.
+- `meta-view-render-labels.ts` owns the bilingual static string.
+
+The hint appears only when all of these are true:
+
+1. an effective-calendar request completed successfully;
+2. no noteworthy chips were produced after `isCalendarEffectiveItemNoteworthy`;
+3. the visible range intersects common China public-holiday months used by the
+   existing `holiday-cn` sync path: January, February, April, May, June,
+   September, or October.
+
+This avoids prompting on naturally quiet months such as July and August.
+
+## User Experience
+
+Chinese:
+
+> 当前范围没有已同步的节假日数据；如应显示节假日或调休班标记，请先在考勤设置中同步节假日。
+
+English:
+
+> No public holiday data is synced for this range. Sync holidays in Attendance
+> settings if holiday or makeup-workday chips are expected.
+
+The notice uses `role="status"` so it is available to assistive technology
+without being a blocking toast.
+
+## Non-Goals
+
+- No automatic holiday sync.
+- No new backend endpoint.
+- No inferred holiday generation in the Calendar view.
+- No K3 Save / Submit / Audit.
+- No Bridge Agent or Data Factory runtime change.
+

--- a/docs/development/multitable-calendar-holiday-sync-hint-verification-20260522.md
+++ b/docs/development/multitable-calendar-holiday-sync-hint-verification-20260522.md
@@ -1,0 +1,59 @@
+# Multitable Calendar Holiday Sync Hint Verification - 2026-05-22
+
+## Local Checks
+
+```bash
+pnpm --filter @metasheet/web exec vitest run \
+  tests/calendar-holiday-notice.spec.ts \
+  tests/multitable-calendar-view.spec.ts \
+  tests/meta-view-render-labels.spec.ts \
+  --watch=false
+```
+
+Result: PASS. `3` files, `21` tests.
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Result: PASS. Vite completed with the existing large-chunk warning only.
+
+```bash
+git diff --check origin/main...HEAD
+```
+
+Result: PASS.
+
+## Test Matrix
+
+| Case | Coverage |
+| --- | --- |
+| Empty holiday data in a likely public-holiday range | `calendar-holiday-notice.spec.ts` returns a localized hint |
+| Empty holiday data in July/August | `calendar-holiday-notice.spec.ts` returns `null` |
+| Non-empty/ready holiday data | `calendar-holiday-notice.spec.ts` returns `null` |
+| Calendar component notice rendering | `multitable-calendar-view.spec.ts` asserts `.meta-calendar__notice` and `role=status` |
+| Bilingual label table completeness | `meta-view-render-labels.spec.ts` covers all label keys |
+
+## Manual Entity-Machine Expectation
+
+With 2026 holiday data synced, no notice should appear in May/June because
+holiday chips are present.
+
+If an operator clears or has not synced attendance holidays, May/June calendar
+ranges should show the hint instead of silently displaying only lunar labels.
+
+## Deployment Impact
+
+Frontend-only. No migration, no package script change, no backend route change,
+no integration-core change.
+
+## Gate Impact
+
+This does not affect #1709 / #1711. Customer GATE remains unchanged, and no K3
+Save / Submit / Audit path is touched.


### PR DESCRIPTION
## Summary
- add a small Multitable Calendar notice for loaded ranges where public-holiday chips are likely expected but effective-calendar returns no noteworthy holidays
- keep the notice quiet for naturally empty ranges such as July/August
- localize the notice and render it as role=status

Follow-up to #1763 after the entity-machine retest showed the root cause was unsynced holiday data, not calendar rendering.

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/calendar-holiday-notice.spec.ts tests/multitable-calendar-view.spec.ts tests/meta-view-render-labels.spec.ts --watch=false -> 21/21 PASS
- pnpm --filter @metasheet/web exec vue-tsc --noEmit -> PASS
- pnpm --filter @metasheet/web build -> PASS, existing large-chunk warning only
- git diff --check origin/main...HEAD -> PASS

## Scope
Frontend-only. No backend route, DB migration, integration-core, Bridge Agent, or K3 Save/Submit/Audit change.