### PR TITLE
fix(attendance): preserve shift fallback for blank planned minutes

### DIFF
--- a/docs/development/attendance-comprehensive-hours-null-fallback-design-20260522.md
+++ b/docs/development/attendance-comprehensive-hours-null-fallback-design-20260522.md
@@ -1,0 +1,46 @@
+# Attendance Comprehensive Hours Null Fallback Design
+
+Date: 2026-05-22
+Branch: `codex/attendance-comprehensive-hours-null-fallback-20260522`
+
+## Summary
+
+This follow-up hardens the pure comprehensive-hours PR1 helpers after review of
+`#1770`. The planned-minutes helper accepted explicit per-day overrides, but
+`null` and empty-string values were normalized with `Number(...)`, which turned
+them into `0`. That made a missing/blank override suppress normal shift-duration
+calculation.
+
+The fix keeps the same public helper surface and changes only the optional
+override normalization:
+
+- `undefined`, `null`, and blank strings mean "no explicit override"
+- finite numeric values still become non-negative integer minutes
+- invalid non-numeric values also fall back to shift-derived planned minutes
+
+## Why This Matters
+
+Future preview routes will likely read day-like rows from DB/query producers
+where nullable columns are common. A `plannedMinutes: null` value should not make
+a working day appear to have 0 planned minutes. Only a real explicit `0` should
+mean zero planned minutes.
+
+## Scope
+
+| Area | Decision |
+| --- | --- |
+| Runtime route | Not added. |
+| UI | Not changed. |
+| DB migration | Not added. |
+| Attendance writes | Not added. |
+| Save warning / blocking | Not added. |
+| Helper API | Preserved. |
+
+## Implementation
+
+Added `normalizeAttendanceComprehensiveOptionalMinutes(...)` and routed day-level
+`plannedMinutes` / `planned_minutes` through it before falling back to
+`calculateAttendanceComprehensiveShiftPlannedMinutes(profile)`.
+
+The helper deliberately treats explicit numeric `0` as an override, while
+`null` and `''` are absence signals.

--- a/docs/development/attendance-comprehensive-hours-null-fallback-verification-20260522.md
+++ b/docs/development/attendance-comprehensive-hours-null-fallback-verification-20260522.md
@@ -1,0 +1,60 @@
+# Attendance Comprehensive Hours Null Fallback Verification
+
+Date: 2026-05-22
+Branch: `codex/attendance-comprehensive-hours-null-fallback-20260522`
+
+## Scope Verification
+
+| Area | Result |
+| --- | --- |
+| Changed helper | `buildAttendanceComprehensivePlannedMinutesFromDays()` only. |
+| Route / API | None added. |
+| Frontend | None changed. |
+| Migration | None added. |
+| Attendance writes | None added. |
+| Save warning / block | None added. |
+| Data Factory / Bridge Agent | Not touched. |
+
+## Regression Case
+
+The existing planned-minutes test now includes two working days with nullable or
+blank explicit override values:
+
+| Input | Expected |
+| --- | --- |
+| `plannedMinutes: null`, shift `10:00..17:30` | fallback to `450` minutes |
+| `planned_minutes: ''`, shift `08:00..12:00` | fallback to `240` minutes |
+
+This locks the desired distinction between a true explicit `0` override and an
+absent override value.
+
+## Commands
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+
+NODE_PATH=/Users/chouhua/Downloads/Github/metasheet2/node_modules \
+  /Users/chouhua/Downloads/Github/metasheet2/node_modules/.bin/vitest run \
+  packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend build
+
+git diff --check origin/main...HEAD
+```
+
+## Results
+
+| Check | Result |
+| --- | --- |
+| Plugin syntax | PASS |
+| Comprehensive-hours helper test | PASS, 6 tests |
+| Core backend build | PASS |
+| `git diff --check origin/main...HEAD` | PASS |
+
+## Note
+
+The isolated worktree does not have its own `node_modules`, so the local Vitest
+run used the already-installed root workspace dependency path. The core-backend
+build used temporary local dependency links, then removed generated ignored
+outputs before commit. CI should still use the normal workspace `pnpm` commands.

--- a/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
+++ b/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
@@ -108,15 +108,27 @@ describe('attendance comprehensive working-hours control helpers', () => {
         effective: { isWorkingDay: true, source: 'manual' },
         plannedMinutes: 300,
       },
+      {
+        date: '2026-05-05',
+        effective: { isWorkingDay: true, source: 'null-fallback' },
+        shift: { workStartTime: '10:00', workEndTime: '17:30' },
+        plannedMinutes: null,
+      },
+      {
+        date: '2026-05-06',
+        effective: { isWorkingDay: true, source: 'empty-fallback' },
+        shift: { workStartTime: '08:00', workEndTime: '12:00' },
+        planned_minutes: '',
+      },
     ])
 
     expect(planned).toMatchObject({
-      plannedMinutes: 540 + 0 + 480 + 300,
-      days: 4,
-      workingDays: 3,
+      plannedMinutes: 540 + 0 + 480 + 300 + 450 + 240,
+      days: 6,
+      workingDays: 5,
     })
-    expect(planned.items.map((item: any) => item.plannedMinutes)).toEqual([540, 0, 480, 300])
-    expect(planned.items.map((item: any) => item.source)).toEqual(['shift', 'national', 'rotation', 'manual'])
+    expect(planned.items.map((item: any) => item.plannedMinutes)).toEqual([540, 0, 480, 300, 450, 240])
+    expect(planned.items.map((item: any) => item.source)).toEqual(['shift', 'national', 'rotation', 'manual', 'null-fallback', 'empty-fallback'])
   })
 
   it('keeps actual minutes sourced from summary payloads separate from planned minutes', () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -11807,6 +11807,16 @@ function calculateAttendanceComprehensiveShiftPlannedMinutes(profile) {
   return Math.max(0, Math.floor(duration))
 }
 
+function normalizeAttendanceComprehensiveOptionalMinutes(...values) {
+  for (const value of values) {
+    if (value === undefined || value === null) continue
+    if (typeof value === 'string' && value.trim() === '') continue
+    const minutes = Number(value)
+    if (Number.isFinite(minutes)) return Math.max(0, Math.floor(minutes))
+  }
+  return null
+}
+
 function resolveAttendanceComprehensiveDayProfile(day, fallbackProfile) {
   if (day?.profile && typeof day.profile === 'object') return day.profile
   if (day?.shift && typeof day.shift === 'object') return day.shift
@@ -11832,10 +11842,10 @@ function buildAttendanceComprehensivePlannedMinutesFromDays(days, options = {}) 
     const date = normalizeDateOnly(day?.date ?? day?.workDate ?? day?.work_date)
     const profile = resolveAttendanceComprehensiveDayProfile(day, fallbackProfile)
     const isWorkingDay = isAttendanceComprehensiveDayWorking(day, profile)
-    const explicitMinutes = Number(day?.plannedMinutes ?? day?.planned_minutes)
+    const explicitMinutes = normalizeAttendanceComprehensiveOptionalMinutes(day?.plannedMinutes, day?.planned_minutes)
     const minutes = isWorkingDay
-      ? Number.isFinite(explicitMinutes)
-        ? Math.max(0, Math.floor(explicitMinutes))
+      ? explicitMinutes !== null
+        ? explicitMinutes
         : calculateAttendanceComprehensiveShiftPlannedMinutes(profile)
       : 0
     plannedMinutes += minutes


### PR DESCRIPTION
## Summary

Follow-up to #1770 after post-merge review. `buildAttendanceComprehensivePlannedMinutesFromDays()` treated `plannedMinutes: null` and `planned_minutes: ""` as explicit zero because `Number(null)` / `Number("")` are `0`. Nullable producer rows should mean "no explicit override", so working days should fall back to shift-derived planned minutes unless the override is a real numeric value.

## Scope

- Runtime route/API: none
- UI: none
- DB migration: none
- Attendance writes / save blocking: none
- Data Factory / Bridge Agent: untouched

## Verification

- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-comprehensive-hours-control.test.ts --reporter=dot` -> 6/6 PASS
- `pnpm --filter @metasheet/core-backend build` -> PASS
- `git diff --cached --check` -> PASS before commit

## Notes

The local isolated worktree reused already-installed workspace dependencies for verification because it did not carry its own `node_modules`. CI should run the normal workspace install/test path.
