### PR TITLE
feat(attendance): add comprehensive hours preview route

### DIFF
--- a/docs/development/attendance-comprehensive-hours-control-pr2-development-20260522.md
+++ b/docs/development/attendance-comprehensive-hours-control-pr2-development-20260522.md
@@ -1,0 +1,122 @@
+# Attendance Comprehensive Working Hours Control PR2 Development
+
+Date: 2026-05-22
+Branch: `codex/attendance-comprehensive-hours-preview-20260522`
+
+## Summary
+
+This slice implements PR2 from `attendance-comprehensive-hours-control-rfc-20260522.md`: a read-only backend preview route for comprehensive working-hours control (`综合工时制`).
+
+It wires the PR1 pure helpers to existing attendance producers:
+
+- planned minutes from effective-calendar / schedule context resolution
+- actual minutes from `loadAttendanceSummary()`
+- cap comparison with stable user ordering
+- explicit validation and schema-gap errors
+
+The route does not persist policy, does not add UI, and does not touch any schedule save path.
+
+## Public API
+
+```text
+POST /api/attendance/comprehensive-hours/preview
+```
+
+Permission: `attendance:admin`
+
+Request shape:
+
+```json
+{
+  "policyDraft": {
+    "capMinutes": 960,
+    "enforcement": "warn"
+  },
+  "scope": {
+    "userIds": ["user-a", "user-b"]
+  },
+  "period": {
+    "type": "custom_range",
+    "from": "2026-05-01",
+    "to": "2026-05-31"
+  },
+  "metric": "planned"
+}
+```
+
+Supported period types match PR1:
+
+- `month`
+- `quarter`
+- `year`
+- `custom_range`
+- `payroll_cycle`
+
+For `payroll_cycle`, the route accepts `cycleId` and loads `attendance_payroll_cycles` to resolve the date range.
+
+## Response Shape
+
+```json
+{
+  "ok": true,
+  "data": {
+    "readOnly": true,
+    "period": {
+      "type": "custom_range",
+      "key": "range:2026-05-01:2026-05-31",
+      "from": "2026-05-01",
+      "to": "2026-05-31",
+      "label": "2026-05-01..2026-05-31"
+    },
+    "metric": "planned",
+    "enforcement": "warn",
+    "capMinutes": 960,
+    "scope": {
+      "userIds": ["user-a", "user-b"]
+    },
+    "rows": [],
+    "aggregate": {
+      "users": 0,
+      "ok": 0,
+      "warning": 0,
+      "violation": 0,
+      "totalMinutes": 0,
+      "totalExcessMinutes": 0,
+      "totalRemainingMinutes": 0,
+      "status": "ok"
+    },
+    "degraded": false
+  }
+}
+```
+
+## Implementation Notes
+
+| Area | Decision |
+| --- | --- |
+| Scope | v1 requires explicit `userId` / `userIds`; `allUsers` is rejected to avoid turning preview into a batch scan. |
+| Cap input | Accepts `capMinutes` or `capHours` at top level or under `policyDraft`; value must be positive. |
+| Planned metric | Uses `buildWorkContextPrefetch()` + `resolveWorkContextFromPrefetch()` over the resolved date range, then feeds PR1's planned-minutes helper. |
+| Actual metric | Uses `loadAttendanceSummary()` and PR1's actual-minutes helper. |
+| Payroll cycle | Loads `attendance_payroll_cycles` by `cycleId` and passes the mapped cycle into PR1 period resolution. |
+| Schema gaps | Runs narrow read-only schema probes for the producer tables; missing table/column returns `503 DB_NOT_READY` instead of silent zeroes. |
+| Sorting | User IDs are normalized, de-duplicated, and sorted; rows are also sorted by `userId`. |
+
+## Boundary
+
+| Boundary | Result |
+| --- | --- |
+| HTTP route | Adds only `POST /api/attendance/comprehensive-hours/preview`. |
+| Frontend UI | Not added. |
+| Policy persistence | Not added. |
+| New migration | Not added. |
+| `attendance_*` fact writes | Not added. |
+| Direct `meta_*` writes | Not added. |
+| Multitable writes | Not added. |
+| Advanced scheduling write path | Not touched. |
+| Save warning / save block | Not added. |
+| Data Factory / Bridge Agent | Not touched. |
+
+## Follow-Up
+
+PR3 should add an admin read-only preview UI. It must still avoid save warnings, save blocking, policy persistence, and schedule write-path changes unless the user explicitly opens those later stages.

--- a/docs/development/attendance-comprehensive-hours-control-pr2-verification-20260522.md
+++ b/docs/development/attendance-comprehensive-hours-control-pr2-verification-20260522.md
@@ -1,0 +1,65 @@
+# Attendance Comprehensive Working Hours Control PR2 Verification
+
+Date: 2026-05-22
+Branch: `codex/attendance-comprehensive-hours-preview-20260522`
+
+## Scope Verification
+
+| Area | Result |
+| --- | --- |
+| Runtime route | Adds only `POST /api/attendance/comprehensive-hours/preview`. |
+| Permission | `attendance:admin`. |
+| Frontend | None changed. |
+| Migration | None added. |
+| `attendance_*` fact writes | None added. |
+| Direct `meta_*` writes | None added. |
+| Multitable writes | None added. |
+| Save warning / save block | None added. |
+| Data Factory / Bridge Agent | Not touched. |
+
+## Test Coverage
+
+| Test | Coverage |
+| --- | --- |
+| Existing PR1 helper tests | Period resolution, invalid input, planned-vs-actual separation, cap comparison, stable rows. |
+| `previews planned comprehensive hours from effective-calendar producers without writes` | Locks planned producer path, explicit users, stable de-dup/sort, aggregate violation status, and SELECT-only behavior. |
+| `previews actual comprehensive hours from attendance summary without planned producers` | Locks actual summary path and proves planned schedule tables are not queried in actual mode. |
+| `resolves payroll-cycle preview periods from the database when only cycleId is provided` | Locks payroll-cycle date-range resolution by `cycleId`. |
+| `rejects invalid preview requests and reports schema gaps explicitly` | Locks empty scope, invalid cap, invalid period 400, and schema gap 503 `DB_NOT_READY`. |
+| `registers only an admin-gated read-only comprehensive-hours preview route` | Locks route method/path/permission and absence of PUT/PATCH/DELETE preview routes. |
+
+## Commands
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/attendance-comprehensive-hours-control.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/attendance-advanced-scheduling-workbench.test.ts \
+  tests/unit/attendance-scheduling-assignment-conflict.test.ts \
+  tests/unit/attendance-effective-calendar-role-context.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend build
+
+git diff --check
+```
+
+## Results
+
+| Check | Result |
+| --- | --- |
+| Plugin syntax | PASS |
+| Comprehensive-hours helper + preview test | PASS, 11 tests |
+| Existing scheduling/effective-calendar focused regressions | PASS, 15 tests |
+| Core backend build | PASS |
+| `git diff --check` | PASS |
+
+## Notes
+
+This PR does not run live staging evidence because it is a read-only backend preview endpoint and does not add a UI entry. Runtime evidence can be added with PR3 when the admin preview panel exists.
+
+The isolated worktree required `pnpm install --ignore-scripts` before Vitest. That produced unrelated tracked `node_modules` symlink noise in plugin/tool folders; commit staging must explicitly list only the four slice files and must not use `git add -A`.

--- a/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
+++ b/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
@@ -1,9 +1,38 @@
+import { readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { describe, expect, it } from 'vitest'
 
 const require = createRequire(import.meta.url)
 const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
 const helpers = attendancePlugin.__attendanceReportFieldCatalogForTests
+const pluginSource = readFileSync(new URL('../../../../plugins/plugin-attendance/index.cjs', import.meta.url), 'utf8')
+
+function createPreviewDb(handler: (sql: string, params: unknown[]) => unknown[] | Promise<unknown[]>) {
+  const queries: Array<{ sql: string, params: unknown[] }> = []
+  return {
+    queries,
+    async query(sql: string, params: unknown[] = []) {
+      queries.push({ sql, params })
+      return handler(sql, params)
+    },
+  }
+}
+
+function defaultRuleRow() {
+  return {
+    id: 'rule-default',
+    name: 'Default',
+    timezone: 'Asia/Shanghai',
+    work_start_time: '09:00',
+    work_end_time: '17:00',
+    late_grace_minutes: 0,
+    early_grace_minutes: 0,
+    rounding_minutes: 0,
+    working_days: [1, 2, 3, 4, 5],
+    is_default: true,
+    org_id: 'org-1',
+  }
+}
 
 describe('attendance comprehensive working-hours control helpers', () => {
   it('resolves month, quarter, year, custom range, and payroll-cycle periods deterministically', () => {
@@ -222,5 +251,187 @@ describe('attendance comprehensive working-hours control helpers', () => {
       ['user-a', 300, 'ok'],
       ['user-b', 700, 'violation'],
     ])
+  })
+
+  it('previews planned comprehensive hours from effective-calendar producers without writes', async () => {
+    const db = createPreviewDb((sql) => {
+      if (sql.includes('SELECT 1 FROM')) return [{ ok: 1 }]
+      if (sql.includes('FROM attendance_rules') && sql.includes('is_default')) return [defaultRuleRow()]
+      return []
+    })
+
+    const result = await helpers.previewAttendanceComprehensiveHours(db, 'org-1', {
+      scope: { userIds: ['user-b', 'user-a', 'user-a'] },
+      period: { type: 'custom_range', from: '2026-05-04', to: '2026-05-05' },
+      policyDraft: { capHours: 12, enforcement: 'block' },
+      metric: 'planned',
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        readOnly: true,
+        metric: 'planned',
+        enforcement: 'block',
+        capMinutes: 720,
+        period: {
+          type: 'custom_range',
+          key: 'range:2026-05-04:2026-05-05',
+        },
+        aggregate: {
+          users: 2,
+          violation: 2,
+          status: 'violation',
+        },
+      },
+    })
+    expect(result.data.scope.userIds).toEqual(['user-a', 'user-b'])
+    expect(result.data.rows.map((row: any) => [row.userId, row.minutes, row.days, row.workingDays, row.status, row.source])).toEqual([
+      ['user-a', 960, 2, 2, 'violation', 'effective_calendar'],
+      ['user-b', 960, 2, 2, 'violation', 'effective_calendar'],
+    ])
+    expect(db.queries.every(({ sql }) => sql.trim().startsWith('SELECT'))).toBe(true)
+    expect(db.queries.map(({ sql }) => sql).join('\n')).not.toMatch(/\b(INSERT|UPDATE|DELETE|PATCH)\b/i)
+  })
+
+  it('previews actual comprehensive hours from attendance summary without planned producers', async () => {
+    const db = createPreviewDb((sql) => {
+      if (sql.includes('SELECT 1 FROM')) return [{ ok: 1 }]
+      if (sql.includes('FROM attendance_records')) {
+        return [{
+          total_days: 3,
+          total_minutes: 620,
+          total_late_minutes: 0,
+          total_early_leave_minutes: 0,
+          normal_days: 3,
+          late_days: 0,
+          early_leave_days: 0,
+          late_early_days: 0,
+          partial_days: 0,
+          absent_days: 0,
+          adjusted_days: 0,
+          off_days: 0,
+        }]
+      }
+      if (sql.includes('FROM attendance_requests')) return []
+      throw new Error(`Unexpected query: ${sql}`)
+    })
+
+    const result = await helpers.previewAttendanceComprehensiveHours(db, 'org-1', {
+      userId: 'user-a',
+      period: { type: 'month', year: 2026, month: 5 },
+      capMinutes: 600,
+      metric: 'actual',
+      enforcement: 'warn',
+    })
+
+    expect(result).toMatchObject({
+      ok: true,
+      data: {
+        metric: 'actual',
+        aggregate: {
+          users: 1,
+          warning: 1,
+          status: 'warning',
+          totalMinutes: 620,
+          totalExcessMinutes: 20,
+        },
+      },
+    })
+    expect(result.data.rows).toEqual([
+      expect.objectContaining({
+        userId: 'user-a',
+        actualMinutes: 620,
+        plannedMinutes: undefined,
+        source: 'summary',
+        status: 'warning',
+      }),
+    ])
+    expect(db.queries.map(({ sql }) => sql).join('\n')).not.toContain('attendance_shift_assignments')
+  })
+
+  it('resolves payroll-cycle preview periods from the database when only cycleId is provided', async () => {
+    const cycleId = '11111111-1111-4111-8111-111111111111'
+    const db = createPreviewDb((sql) => {
+      if (sql.includes('FROM attendance_payroll_cycles')) {
+        return [{
+          id: cycleId,
+          org_id: 'org-1',
+          name: 'May payroll',
+          start_date: '2026-05-01',
+          end_date: '2026-05-31',
+          status: 'open',
+        }]
+      }
+      return []
+    })
+
+    await expect(helpers.resolveAttendanceComprehensiveHoursPreviewPeriod(db, 'org-1', {
+      type: 'payroll_cycle',
+      cycleId,
+    })).resolves.toMatchObject({
+      ok: true,
+      period: {
+        type: 'payroll_cycle',
+        key: `cycle:${cycleId}`,
+        cycleId,
+        from: '2026-05-01',
+        to: '2026-05-31',
+        label: 'May payroll',
+      },
+    })
+  })
+
+  it('rejects invalid preview requests and reports schema gaps explicitly', async () => {
+    const db = createPreviewDb(() => [])
+
+    expect(helpers.normalizeAttendanceComprehensiveHoursPreviewInput({})).toMatchObject({
+      ok: false,
+      error: { code: 'EMPTY_SCOPE' },
+    })
+    expect(helpers.normalizeAttendanceComprehensiveHoursPreviewInput({
+      userId: 'user-a',
+      period: { type: 'month', year: 2026, month: 5 },
+      capMinutes: 0,
+    })).toMatchObject({
+      ok: false,
+      error: { code: 'INVALID_CAP' },
+    })
+    await expect(helpers.previewAttendanceComprehensiveHours(db, 'org-1', {
+      userId: 'user-a',
+      period: { type: 'week' },
+      capMinutes: 600,
+    })).resolves.toMatchObject({
+      ok: false,
+      status: 400,
+      error: { code: 'INVALID_PERIOD_TYPE' },
+    })
+
+    const schemaDb = createPreviewDb((sql) => {
+      if (sql.includes('SELECT 1 FROM attendance_rules')) {
+        const error = new Error('relation "attendance_rules" does not exist') as Error & { code?: string }
+        error.code = '42P01'
+        throw error
+      }
+      return []
+    })
+    await expect(helpers.previewAttendanceComprehensiveHours(schemaDb, 'org-1', {
+      userId: 'user-a',
+      period: { type: 'custom_range', from: '2026-05-04', to: '2026-05-05' },
+      capMinutes: 600,
+    })).resolves.toMatchObject({
+      ok: false,
+      status: 503,
+      error: { code: 'DB_NOT_READY' },
+    })
+  })
+
+  it('registers only an admin-gated read-only comprehensive-hours preview route', () => {
+    expect(pluginSource).toMatch(
+      /'POST',\s*\n\s*'\/api\/attendance\/comprehensive-hours\/preview',\s*\n\s*withPermission\('attendance:admin'/,
+    )
+    expect(pluginSource).not.toContain("'PUT',\n      '/api/attendance/comprehensive-hours/preview'")
+    expect(pluginSource).not.toContain("'PATCH',\n      '/api/attendance/comprehensive-hours/preview'")
+    expect(pluginSource).not.toContain("'DELETE',\n      '/api/attendance/comprehensive-hours/preview'")
   })
 })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -11681,6 +11681,7 @@ const ATTENDANCE_COMPREHENSIVE_HOURS_PERIOD_TYPES = new Set([
 ])
 const ATTENDANCE_COMPREHENSIVE_HOURS_METRICS = new Set(['planned', 'actual'])
 const ATTENDANCE_COMPREHENSIVE_HOURS_ENFORCEMENT = new Set(['warn', 'block'])
+const ATTENDANCE_COMPREHENSIVE_HOURS_PREVIEW_MAX_USERS = 100
 
 function buildAttendanceComprehensiveHoursError(code, message) {
   return { ok: false, error: { code, message } }
@@ -11936,6 +11937,287 @@ function buildAttendanceComprehensiveHoursPreviewRows(input = {}) {
       })
     })
     .sort((a, b) => String(a.userId ?? '').localeCompare(String(b.userId ?? '')))
+}
+
+function normalizeAttendanceComprehensiveHoursUserIds(input = {}) {
+  const scope = input.scope && typeof input.scope === 'object' ? input.scope : {}
+  if (input.allUsers === true || scope.allUsers === true) {
+    return buildAttendanceComprehensiveHoursError(
+      'ALL_USERS_NOT_SUPPORTED',
+      'Comprehensive hours preview v1 requires explicit userId/userIds; allUsers belongs to a later batch slice.',
+    )
+  }
+  const values = []
+  for (const value of [input.userId, scope.userId]) {
+    if (typeof value === 'string' && value.trim()) values.push(value.trim())
+  }
+  for (const list of [input.userIds, scope.userIds]) {
+    if (!Array.isArray(list)) continue
+    for (const value of list) {
+      if (typeof value === 'string' && value.trim()) values.push(value.trim())
+    }
+  }
+  const userIds = Array.from(new Set(values)).sort()
+  if (userIds.length === 0) {
+    return buildAttendanceComprehensiveHoursError(
+      'EMPTY_SCOPE',
+      'Comprehensive hours preview requires userId or userIds.',
+    )
+  }
+  if (userIds.length > ATTENDANCE_COMPREHENSIVE_HOURS_PREVIEW_MAX_USERS) {
+    return buildAttendanceComprehensiveHoursError(
+      'SCOPE_TOO_LARGE',
+      `Comprehensive hours preview supports at most ${ATTENDANCE_COMPREHENSIVE_HOURS_PREVIEW_MAX_USERS} userIds per request.`,
+    )
+  }
+  return { ok: true, userIds }
+}
+
+function normalizeAttendanceComprehensiveHoursCapMinutes(input = {}) {
+  const policyDraft = input.policyDraft && typeof input.policyDraft === 'object' ? input.policyDraft : {}
+  const minuteCandidates = [
+    policyDraft.capMinutes,
+    policyDraft.cap_minutes,
+    input.capMinutes,
+    input.cap_minutes,
+  ]
+  for (const value of minuteCandidates) {
+    const minutes = Number(value)
+    if (Number.isFinite(minutes) && minutes > 0) {
+      return { ok: true, capMinutes: Math.floor(minutes) }
+    }
+  }
+  const hourCandidates = [
+    policyDraft.capHours,
+    policyDraft.cap_hours,
+    input.capHours,
+    input.cap_hours,
+  ]
+  for (const value of hourCandidates) {
+    const hours = Number(value)
+    if (Number.isFinite(hours) && hours > 0) {
+      return { ok: true, capMinutes: Math.floor(hours * 60) }
+    }
+  }
+  return buildAttendanceComprehensiveHoursError(
+    'INVALID_CAP',
+    'Comprehensive hours preview requires a positive capMinutes or capHours value.',
+  )
+}
+
+function normalizeAttendanceComprehensiveHoursPreviewInput(input = {}) {
+  const policyDraft = input.policyDraft && typeof input.policyDraft === 'object' ? input.policyDraft : {}
+  const metric = resolveAttendanceComprehensiveHoursMetric(input.metric ?? policyDraft.metric)
+  const enforcement = resolveAttendanceComprehensiveHoursEnforcement(input.enforcement ?? policyDraft.enforcement)
+  const scope = normalizeAttendanceComprehensiveHoursUserIds(input)
+  if (!scope.ok) return scope
+  const cap = normalizeAttendanceComprehensiveHoursCapMinutes(input)
+  if (!cap.ok) return cap
+  const periodInput = input.period && typeof input.period === 'object'
+    ? input.period
+    : {
+      type: input.type,
+      from: input.from,
+      to: input.to,
+      year: input.year,
+      month: input.month,
+      quarter: input.quarter,
+      cycleId: input.cycleId,
+      cycle: input.cycle,
+    }
+  return {
+    ok: true,
+    input: {
+      metric,
+      enforcement,
+      capMinutes: cap.capMinutes,
+      userIds: scope.userIds,
+      periodInput,
+    },
+  }
+}
+
+async function resolveAttendanceComprehensiveHoursPreviewPeriod(db, orgId, periodInput = {}) {
+  const raw = periodInput && typeof periodInput === 'object' ? { ...periodInput } : {}
+  if (!raw.type) {
+    if (raw.cycleId) raw.type = 'payroll_cycle'
+    else if (raw.from !== undefined || raw.to !== undefined) raw.type = 'custom_range'
+  }
+  if (raw.type === 'payroll_cycle' && raw.cycleId && !(raw.cycle || raw.startDate || raw.start_date)) {
+    const cycleId = normalizeUuidString(raw.cycleId)
+    if (!cycleId) {
+      return buildAttendanceComprehensiveHoursError('INVALID_PAYROLL_CYCLE', 'Payroll-cycle period requires a valid cycleId.')
+    }
+    const rows = await db.query(
+      'SELECT * FROM attendance_payroll_cycles WHERE id = $1 AND org_id = $2',
+      [cycleId, orgId],
+    )
+    if (!rows.length) {
+      return {
+        ok: false,
+        error: {
+          code: 'NOT_FOUND',
+          message: 'Payroll cycle not found.',
+        },
+        status: 404,
+      }
+    }
+    raw.cycle = mapPayrollCycleRow(rows[0])
+  }
+  const resolved = resolveAttendanceComprehensiveHoursPeriod(raw)
+  if (!resolved.ok) return resolved
+  const rangeDays = diffDays(resolved.period.from, resolved.period.to) + 1
+  if (rangeDays > 366) {
+    return buildAttendanceComprehensiveHoursError('INVALID_PERIOD_RANGE', 'Comprehensive hours preview range must be <= 366 days.')
+  }
+  return resolved
+}
+
+async function assertAttendanceComprehensiveHoursPreviewSchemaReady(db, orgId, metric) {
+  const tables = metric === 'actual'
+    ? ['attendance_records', 'attendance_requests']
+    : [
+      'attendance_rules',
+      'attendance_holidays',
+      'attendance_shifts',
+      'attendance_shift_assignments',
+      'attendance_rotation_assignments',
+    ]
+  for (const table of tables) {
+    await db.query(`SELECT 1 FROM ${table} WHERE org_id = $1 LIMIT 1`, [orgId])
+  }
+}
+
+async function loadAttendanceComprehensivePlannedMinutesByUser(db, orgId, userIds, period) {
+  const workDates = enumerateAttendanceCalendarDateRange(period.from, period.to)
+  const defaultRule = await loadDefaultRule(db, orgId)
+  const { prefetched } = await buildWorkContextPrefetch(db, {
+    orgId,
+    userIds,
+    workDates,
+    defaultRule,
+  })
+  const plannedMinutesByUser = new Map()
+  const plannedDetailsByUser = new Map()
+  for (const userId of userIds) {
+    const days = workDates.map((date) => ({
+      date,
+      resolvedContext: resolveWorkContextFromPrefetch({
+        orgId,
+        userId,
+        workDate: date,
+        defaultRule,
+        prefetched,
+      }),
+    }))
+    const planned = buildAttendanceComprehensivePlannedMinutesFromDays(days, { defaultRule })
+    plannedMinutesByUser.set(userId, planned.plannedMinutes)
+    plannedDetailsByUser.set(userId, planned)
+  }
+  return { plannedMinutesByUser, plannedDetailsByUser }
+}
+
+async function loadAttendanceComprehensiveActualMinutesByUser(db, orgId, userIds, period) {
+  const actualMinutesByUser = new Map()
+  const actualDetailsByUser = new Map()
+  for (const userId of userIds) {
+    const summary = await loadAttendanceSummary(db, orgId, userId, period.from, period.to)
+    const actual = buildAttendanceComprehensiveActualMinutesFromSummary(summary)
+    actualMinutesByUser.set(userId, actual.actualMinutes)
+    actualDetailsByUser.set(userId, { ...actual, summary })
+  }
+  return { actualMinutesByUser, actualDetailsByUser }
+}
+
+function buildAttendanceComprehensiveHoursPreviewAggregate(rows) {
+  const aggregate = {
+    users: rows.length,
+    ok: 0,
+    warning: 0,
+    violation: 0,
+    totalMinutes: 0,
+    totalExcessMinutes: 0,
+    totalRemainingMinutes: 0,
+    status: 'ok',
+  }
+  for (const row of rows) {
+    if (row.status === 'violation') aggregate.violation += 1
+    else if (row.status === 'warning') aggregate.warning += 1
+    else aggregate.ok += 1
+    aggregate.totalMinutes += Number(row.minutes ?? 0)
+    aggregate.totalExcessMinutes += Number(row.excessMinutes ?? 0)
+    aggregate.totalRemainingMinutes += Number(row.remainingMinutes ?? 0)
+  }
+  aggregate.status = aggregate.violation > 0 ? 'violation' : aggregate.warning > 0 ? 'warning' : 'ok'
+  return aggregate
+}
+
+async function previewAttendanceComprehensiveHours(db, orgId, body = {}) {
+  const normalized = normalizeAttendanceComprehensiveHoursPreviewInput(body)
+  if (!normalized.ok) return { ...normalized, status: 400 }
+  try {
+    const resolved = await resolveAttendanceComprehensiveHoursPreviewPeriod(db, orgId, normalized.input.periodInput)
+    if (!resolved.ok) {
+      return { ...resolved, status: resolved.status ?? 400 }
+    }
+    await assertAttendanceComprehensiveHoursPreviewSchemaReady(db, orgId, normalized.input.metric)
+    const users = normalized.input.userIds.map(id => ({ id }))
+    let plannedResult = { plannedMinutesByUser: new Map(), plannedDetailsByUser: new Map() }
+    let actualResult = { actualMinutesByUser: new Map(), actualDetailsByUser: new Map() }
+    if (normalized.input.metric === 'actual') {
+      actualResult = await loadAttendanceComprehensiveActualMinutesByUser(db, orgId, normalized.input.userIds, resolved.period)
+    } else {
+      plannedResult = await loadAttendanceComprehensivePlannedMinutesByUser(db, orgId, normalized.input.userIds, resolved.period)
+    }
+    const rows = buildAttendanceComprehensiveHoursPreviewRows({
+      users,
+      metric: normalized.input.metric,
+      enforcement: normalized.input.enforcement,
+      capMinutes: normalized.input.capMinutes,
+      period: resolved.period,
+      plannedMinutesByUser: plannedResult.plannedMinutesByUser,
+      actualMinutesByUser: actualResult.actualMinutesByUser,
+    }).map((row) => {
+      const detail = normalized.input.metric === 'actual'
+        ? actualResult.actualDetailsByUser.get(row.userId)
+        : plannedResult.plannedDetailsByUser.get(row.userId)
+      return {
+        ...row,
+        source: normalized.input.metric === 'actual' ? 'summary' : 'effective_calendar',
+        ...(normalized.input.metric === 'planned' && detail
+          ? { days: detail.days, workingDays: detail.workingDays }
+          : {}),
+      }
+    })
+    return {
+      ok: true,
+      data: {
+        readOnly: true,
+        period: resolved.period,
+        metric: normalized.input.metric,
+        enforcement: normalized.input.enforcement,
+        capMinutes: normalized.input.capMinutes,
+        scope: {
+          userIds: normalized.input.userIds,
+        },
+        rows,
+        aggregate: buildAttendanceComprehensiveHoursPreviewAggregate(rows),
+        degraded: false,
+      },
+    }
+  } catch (error) {
+    if (isDatabaseSchemaError(error)) {
+      return {
+        ok: false,
+        status: 503,
+        error: {
+          code: 'DB_NOT_READY',
+          message: 'Attendance tables missing',
+        },
+      }
+    }
+    throw error
+  }
 }
 
 function buildWorkdayContextSummary(options) {
@@ -13633,6 +13915,9 @@ module.exports = {
     buildAttendanceComprehensiveActualMinutesFromSummary,
     buildAttendanceComprehensiveHoursComparison,
     buildAttendanceComprehensiveHoursPreviewRows,
+    normalizeAttendanceComprehensiveHoursPreviewInput,
+    resolveAttendanceComprehensiveHoursPreviewPeriod,
+    previewAttendanceComprehensiveHours,
     findAttendanceScheduleAssignmentConflict,
     acquireAttendanceScheduleAssignmentLock,
     getAttendanceScheduleAssignmentConflictMessage,
@@ -26366,6 +26651,31 @@ module.exports = {
           }
           logger.error('Attendance assignment delete failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete assignment' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/comprehensive-hours/preview',
+      withPermission('attendance:admin', async (req, res) => {
+        try {
+          const result = await previewAttendanceComprehensiveHours(db, getOrgId(req), req.body ?? {})
+          if (!result.ok) {
+            res.status(result.status || 400).json({
+              ok: false,
+              error: result.error || { code: 'VALIDATION_ERROR', message: 'Invalid comprehensive hours preview request' },
+            })
+            return
+          }
+          res.json({ ok: true, data: result.data })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance comprehensive-hours preview failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to preview comprehensive hours.' } })
         }
       })
     )


### PR DESCRIPTION
## Summary

Adds PR2 for comprehensive working-hours control: a read-only backend preview route at `POST /api/attendance/comprehensive-hours/preview`.

- Supports explicit `userId` / `userIds` scope, month/quarter/year/custom-range/payroll-cycle periods, `planned` vs `actual` metrics, and warn/block cap comparison.
- Wires planned previews to existing effective-calendar/schedule context producers and actual previews to `loadAttendanceSummary()`.
- Returns explicit validation errors and `503 DB_NOT_READY` for producer schema gaps instead of silently returning zeroes.

Boundaries: no frontend, no migration, no policy persistence, no multitable writes, no direct `meta_*` writes, no schedule save warning/block, no Data Factory / Bridge Agent changes.

## Test plan

- [x] `node --check plugins/plugin-attendance/index.cjs`
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-comprehensive-hours-control.test.ts --reporter=dot` — 11 pass
- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-advanced-scheduling-workbench.test.ts tests/unit/attendance-scheduling-assignment-conflict.test.ts tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` — 15 pass
- [x] `pnpm --filter @metasheet/core-backend build`
- [x] `git diff --check`

## Review ask

Please review as an attendance-only read-only route slice. The key risks to check are: no writes, admin-only route, schema-gap handling, planned/actual source separation, and no accidental schedule save-path coupling.
