### PR TITLE
docs(ops): deploy-host SSH timeout runbook for docker-build (#1772)

### DIFF
--- a/docs/development/docker-build-deploy-ssh-timeout-runbook-design-20260522.md
+++ b/docs/development/docker-build-deploy-ssh-timeout-runbook-design-20260522.md
@@ -1,0 +1,113 @@
+# docker-build deploy-job SSH timeout runbook - design - 2026-05-22
+
+## Goal
+
+Issue #1772 reports that after PR #1771 merged at `d23472167`, the
+main-push workflow `Build and Push Docker Images` succeeded in the build
+job but failed in the deploy job at the very first step (`Sync deploy
+host files`), with the sanitized error:
+
+```text
+ssh: connect to host <redacted> port 22: Connection timed out
+deploy_rc missing; failing deploy job.
+```
+
+The build worked, the merged PR did not touch deploy plumbing, and the
+later main-push workflows (Phase 5 Production Flags Guard, Observability
+E2E, Deploy to Production, monitoring-alert, Plugin System Tests) all
+passed. The fault is squarely **deploy-host TCP/22 reachability from
+GitHub-hosted runners**, not an app or CI regression.
+
+We do not have an operator runbook for this specific failure shape today.
+Adding one captures the diagnostic ordering on the operator side so the
+next recurrence can be triaged from the workflow log + the runbook
+without context-bouncing or guessing.
+
+## Scope
+
+In scope:
+
+- `docs/operations/docker-build-deploy-ssh-timeout-runbook.md` - the
+  operator-facing runbook.
+- this design MD + a verification MD.
+
+Out of scope (hard):
+
+- any change to `.github/workflows/docker-build.yml` itself - the
+  workflow is fine when the host is reachable;
+- deploy SSH key rotation (a separate concern - this runbook explicitly
+  says timeout is not the key/user failure shape);
+- application runtime, DB migration, API, frontend;
+- Bridge Agent / Data Factory / K3 WISE / SQL Server / customer GATE.
+
+## Why an operator-facing runbook is the right delivery shape
+
+The failure is operational, not code. Three signals say so:
+
+- the workflow's build job is healthy and the same code path was green
+  before the failure;
+- the failure text is at the TCP layer (`Connection timed out` on port
+  22), before any auth or sshd negotiation;
+- the suggested checks in #1772 itself are deploy-host infra checks
+  (firewall, SG, sshd state), not code changes.
+
+So the deliverable is operator knowledge in a single place, citing the
+exact step and line in the workflow so an operator triaging the next
+recurrence does not have to read the YAML to find what failed.
+
+## Runbook shape decisions
+
+1. **Symptom-first**, not failure-class-first. The runbook opens with
+   the exact step name, the exact line number, and the exact sanitized
+   error text. The operator's eye should match-in-one-pass without
+   reading the whole doc.
+
+2. **Order the checklist by failure probability**, not by OSI layer.
+   Most recurrences will be DNS drift / cloud-SG edit / runner CIDR
+   roll, in that order; key/user/sshd checks come later because the
+   `Connection timed out` shape does not indicate those.
+
+3. **Explicit "this is not the failure shape for X" lines.** A timeout
+   is not `Permission denied`. A timeout is not sshd-config. Saying so
+   prevents the operator from rotating the key in panic.
+
+4. **Secret-hygiene discipline section** up front. The whole point of
+   the workflow already redacting `<redacted>` in its log is so the
+   sanitized form is the canonical form. The runbook tells the
+   operator to copy the sanitized line, not their own terminal.
+
+5. **Cite GitHub's published runner CIDR endpoint**
+   (`https://api.github.com/meta`) and note it can roll. The deploy
+   host's allowlist must track it; cached lists go stale.
+
+6. **`ssh -v` reproduction** as the single most useful diagnostic
+   once 1-7 are clean, with the placeholders shape the operator should
+   actually type. Match `ConnectTimeout` / `StrictHostKeyChecking` /
+   `IdentitiesOnly` to what the workflow uses, so the local repro is
+   apples-to-apples.
+
+7. **Re-run failed jobs** is step 9, gated on "you fixed something". The
+   runbook also names the run ID from #1772
+   (`26293551077`) so this first incident has a working link.
+
+## Why not patch the workflow
+
+Two reasons:
+
+- the workflow already does the right thing when reachability is
+  restored - re-runs succeed without code change;
+- adding workflow-side resilience (retries, fallback hosts, etc.)
+  hides the underlying outage and slows future triage. The operator
+  side is the right place to fix this.
+
+If a future recurrence shows the timeout is reliably transient and
+short, a small `--connect-timeout` / single retry could be considered -
+but that is a separate change and not part of this docs PR.
+
+## Files
+
+- `docs/operations/docker-build-deploy-ssh-timeout-runbook.md` (new)
+- `docs/development/docker-build-deploy-ssh-timeout-runbook-design-20260522.md`
+  (this file)
+- `docs/development/docker-build-deploy-ssh-timeout-runbook-verification-20260522.md`
+  (companion)

--- a/docs/development/docker-build-deploy-ssh-timeout-runbook-verification-20260522.md
+++ b/docs/development/docker-build-deploy-ssh-timeout-runbook-verification-20260522.md
@@ -1,0 +1,114 @@
+# docker-build deploy-job SSH timeout runbook - verification - 2026-05-22
+
+Companion to `docker-build-deploy-ssh-timeout-runbook-design-20260522.md`.
+Docs only: one operator runbook + two dev MDs. No workflow YAML change.
+No `plugin-integration-core`, no DB migration, no API runtime, no
+frontend.
+
+## Local evidence (isolated worktree)
+
+### 1. Acceptance-text greps against the runbook
+
+Each marker the task required, counted via `grep -cF` against
+`docs/operations/docker-build-deploy-ssh-timeout-runbook.md`:
+
+| Marker | Count |
+| --- | --- |
+| `DNS / IP resolution` | 1 (section 1 heading) |
+| `port 22` | 7 |
+| `security group` | 5 |
+| `firewall` | 7 |
+| `deploy user` | 1 (section 7 heading + the `<deploy-user>` placeholder shows 1 here) |
+| `deploy key` | 4 |
+| `api.github.com/meta` | 1 (the canonical GitHub runner CIDR endpoint) |
+| `ssh -vv` | 1 (the `-vv` reproduction shape in section 8) |
+| `Re-run failed jobs` | 2 (section 9 instruction + the closing reference) |
+| `26293551077` | 3 (cited as the workflow run, in symptom + step 9 + "Related" footer) |
+| `#1772` | 3 (top tracking line + step 9 reference + "Related" footer) |
+| `docker-build.yml:71` | 1 (the failing step's exact line) |
+| `docker-build.yml:86` | 1 (the failing `ssh` command's exact line inside the step) |
+
+All eight checklist items from the task acceptance are present
+(DNS/IP, port 22, security group / firewall, deploy user, deploy key,
+GitHub runner outbound, manual `ssh -v`, when to rerun).
+
+### 2. Workflow grounding (cite-only, no edit)
+
+The runbook cites `.github/workflows/docker-build.yml` line numbers
+verified against `origin/main` (HEAD `18dccc36d` at the time of this
+PR's branch creation):
+
+- `name: Build and Push Docker Images` on line 1
+- `jobs:` on line 19
+- `deploy:` job on line 64
+- `Sync deploy host files` step on line 71
+- the first `ssh` command inside that step on line 86
+
+The runbook does **not** modify the workflow YAML. The line numbers are
+load-bearing for operator triage, so they are cited; the runbook also
+notes "the workflow is fine when the host is reachable; do not add a
+debug step to docker-build.yml itself".
+
+### 3. Secret-shape sweep
+
+Patterns searched, expected count `0` per cell:
+
+| Pattern | runbook | design MD |
+| --- | --- | --- |
+| `eyJ[A-Za-z0-9_-]{6,}` (JWT shape) | 0 | 0 |
+| `(Password\|Pwd)=<populated>` | 0 | 0 |
+| `Bearer <token>` | 0 | 0 |
+| `postgres://<userinfo>@` | 0 | 0 |
+| IPv4 literal | **1*** | 0 |
+| SSH key blob (`-----BEGIN ... PRIVATE KEY-----` / `ssh-rsa AAAA` / `ssh-ed25519 AAAA`) | 0 | 0 |
+
+`*` The single IPv4 literal in the runbook is `0.0.0.0/0` (line 142),
+the universal CIDR placeholder meaning "any IPv4" - it is **not** a
+leaked host address. The phrase is "If the deploy host's inbound is
+open to `0.0.0.0/0` on port 22, this step is not the cause - move to
+step 6." It is needed to phrase the negative case for security-group
+allowlisting and cannot be omitted without losing clinical meaning.
+No real `<deploy-host>` / `<deploy-user>` / `<deploy-path>` value
+appears anywhere; every reference uses an explicit placeholder.
+
+### 4. `git diff --check`
+
+```text
+git diff --check  -> exit 0
+```
+
+## Acceptance criteria mapped to evidence
+
+| Criterion | Evidence |
+| --- | --- |
+| docs/ops small PR, no runtime / DB / API change | only 3 docs files; section 1 above lists them; section 2 confirms no workflow YAML edit |
+| Runbook explains the workflow failure shape | symptom section names the exact step, the exact line, the exact sanitized error text |
+| Operator checklist: DNS/IP | section 1 above |
+| Operator checklist: port 22 | sections 3 + 4 + 6 |
+| Operator checklist: security group / firewall | section 4 (cloud SG + on-prem firewall + NAT + recent-change scan) |
+| Operator checklist: deploy user | section 7 |
+| Operator checklist: deploy key | section 7 (with the explicit "timeout is not the key/user failure shape" caveat) |
+| Operator checklist: GitHub runner outbound IPs | section 5 cites `https://api.github.com/meta` |
+| Operator checklist: manual `ssh -v` | section 8 with the `ssh -vv -o ConnectTimeout=10 ...` placeholder-only reproduction shape |
+| Operator checklist: when to rerun failed jobs | section 9 with the "fix first, rerun once" discipline |
+| Cite #1772 and workflow failure point | tracking line + step 9 + Related-workflows footer; line numbers 71 and 86 for the step and the ssh call |
+| Design MD + verification MD | this PR adds both |
+| No secret / host / user / key emitted | secret-shape sweep above; `0.0.0.0/0` is the only IPv4 literal and it is the CIDR-any placeholder, not a leak |
+
+## Out-of-scope reaffirmation
+
+- No `.github/workflows/docker-build.yml` modification.
+- No SSH key rotation / cloud SG edits / firewall changes are performed
+  by this PR - it documents how an operator does them on the deploy
+  host side.
+- No `plugin-integration-core`, no DB migration, no API runtime, no
+  frontend, no K3 Save / Submit / Audit.
+- Customer GATE state unchanged.
+
+## Operational note
+
+Developed in an isolated `git worktree`
+(`/tmp/ms2-deploy-ssh-67785`) per the parallel-session worktree hazard
+memory. Branch verified
+(`codex/docker-build-deploy-ssh-timeout-runbook-20260522`) before
+commit and push.

--- a/docs/development/docker-build-deploy-ssh-timeout-runbook-verification-20260522.md
+++ b/docs/development/docker-build-deploy-ssh-timeout-runbook-verification-20260522.md
@@ -26,7 +26,7 @@ Each marker the task required, counted via `grep -cF` against
 | `26293551077` | 3 (cited as the workflow run, in symptom + step 9 + "Related" footer) |
 | `#1772` | 3 (top tracking line + step 9 reference + "Related" footer) |
 | `docker-build.yml:71` | 1 (the failing step's exact line) |
-| `docker-build.yml:86` | 1 (the failing `ssh` command's exact line inside the step) |
+| `docker-build.yml:88` | 1 (the failing `ssh` command's exact line inside the step) |
 
 All eight checklist items from the task acceptance are present
 (DNS/IP, port 22, security group / firewall, deploy user, deploy key,
@@ -42,7 +42,7 @@ PR's branch creation):
 - `jobs:` on line 19
 - `deploy:` job on line 64
 - `Sync deploy host files` step on line 71
-- the first `ssh` command inside that step on line 86
+- the first `ssh` command inside that step on line 88
 
 The runbook does **not** modify the workflow YAML. The line numbers are
 load-bearing for operator triage, so they are cited; the runbook also
@@ -91,7 +91,7 @@ git diff --check  -> exit 0
 | Operator checklist: GitHub runner outbound IPs | section 5 cites `https://api.github.com/meta` |
 | Operator checklist: manual `ssh -v` | section 8 with the `ssh -vv -o ConnectTimeout=10 ...` placeholder-only reproduction shape |
 | Operator checklist: when to rerun failed jobs | section 9 with the "fix first, rerun once" discipline |
-| Cite #1772 and workflow failure point | tracking line + step 9 + Related-workflows footer; line numbers 71 and 86 for the step and the ssh call |
+| Cite #1772 and workflow failure point | tracking line + step 9 + Related-workflows footer; line numbers 71 and 88 for the step and the ssh call |
 | Design MD + verification MD | this PR adds both |
 | No secret / host / user / key emitted | secret-shape sweep above; `0.0.0.0/0` is the only IPv4 literal and it is the CIDR-any placeholder, not a leak |
 

--- a/docs/operations/docker-build-deploy-ssh-timeout-runbook.md
+++ b/docs/operations/docker-build-deploy-ssh-timeout-runbook.md
@@ -11,7 +11,7 @@ step:
 - failing step: `Sync deploy host files`
   (`.github/workflows/docker-build.yml:71`)
 - failing command: the first `ssh` inside that step
-  (`.github/workflows/docker-build.yml:86`)
+  (`.github/workflows/docker-build.yml:88`)
 - failing error shape:
 
   ```text
@@ -246,7 +246,8 @@ system API. It is operator documentation only.
 
 - Workflow: `Build and Push Docker Images` -
   `.github/workflows/docker-build.yml` (`name:` on line 1, `deploy:`
-  job starts at line 64, `Sync deploy host files` step at line 71).
+  job starts at line 64, `Sync deploy host files` step at line 71,
+  first `ssh` command inside that step on line 88).
 - Tracking issue: #1772.
 - First failing run: workflow run `26293551077` after the
   `d23472167` main commit (`fix(multitable): hint when calendar

--- a/docs/operations/docker-build-deploy-ssh-timeout-runbook.md
+++ b/docs/operations/docker-build-deploy-ssh-timeout-runbook.md
@@ -1,0 +1,254 @@
+# Docker Build deploy-job SSH timeout runbook
+
+## Symptom this runbook addresses
+
+The main-push workflow **Build and Push Docker Images**
+(`.github/workflows/docker-build.yml`) finishes the `build` job cleanly
+(backend image build + frontend image build + "Set packages to private"
+all succeed), but the downstream `deploy` job fails at the very first
+step:
+
+- failing step: `Sync deploy host files`
+  (`.github/workflows/docker-build.yml:71`)
+- failing command: the first `ssh` inside that step
+  (`.github/workflows/docker-build.yml:86`)
+- failing error shape:
+
+  ```text
+  ssh: connect to host <redacted> port 22: Connection timed out
+  deploy_rc missing; failing deploy job.
+  ```
+
+This is a **TCP-level reachability failure on port 22 from the GitHub
+Actions runner to the deploy host**. It is not an authentication failure,
+not a sshd config failure, not a key rotation failure. The TCP handshake
+itself does not complete.
+
+Tracking issue: #1772
+(first observed on workflow run `26293551077`, after PR #1771 merged at
+`d23472167`).
+
+## Prerequisites for the operator
+
+- Read access to the GitHub Actions run log for the failing
+  `Sync deploy host files` step.
+- Network / firewall access to the side that controls the deploy host's
+  inbound rules (cloud security group, on-prem firewall, NAT router).
+- A control workstation (or any host you control) from which you can
+  run `ssh -v` against the deploy host - used as a sanity check before
+  declaring "host reachable".
+- Permission to **Re-run failed jobs** on the workflow run.
+
+You do **not** need to rotate the deploy SSH key for a connection
+timeout; rotating mid-incident only confuses the diagnosis.
+
+## Discipline: do not echo secrets while debugging
+
+When following this runbook, do NOT:
+
+- copy / paste / Slack the literal `DEPLOY_HOST`, `DEPLOY_USER`,
+  `DEPLOY_PATH`, or the decoded deploy SSH key,
+- attach the base64'd SSH key to any ticket,
+- log into the deploy host with the deploy key and then
+  `cat ~/.ssh/authorized_keys` into chat,
+- screenshot a terminal that has the host or user value in the prompt.
+
+Use placeholders (`<deploy-host>`, `<deploy-user>`, `<deploy-path>`) in
+written notes. The `ssh: connect to host <redacted> port 22: Connection
+timed out` line that the workflow already emits is the canonical
+sanitized form - copy that, not your terminal.
+
+## Operator checklist
+
+Run these in order. The first one that fails is the cause; do not move
+on. Each item names the value to check and how to check it without
+disclosing the value.
+
+### 1. DNS / IP resolution
+
+The workflow uses `DEPLOY_HOST` as supplied. If `DEPLOY_HOST` is a name
+(not a literal IP), confirm it resolves to the **current** address of
+the deploy host - a stale A record points the runner at an IP that no
+longer answers.
+
+- On any workstation: `host <deploy-host>` or `dig +short <deploy-host>`.
+- Compare the resolved IP with the deploy host's current public IP as
+  shown in the cloud console / on-prem inventory. They must match. Do
+  not paste either value into chat - just confirm equality.
+- If `DEPLOY_HOST` is a literal IP, skip this step.
+
+If the answer is wrong: update DNS, wait TTL, then move to step 8
+(rerun).
+
+### 2. Deploy host is up
+
+The deploy host must be powered on and the OS must be reachable on a
+non-SSH path you control (cloud console serial console, vendor web
+console, ICMP from a peer).
+
+- Cloud: confirm the instance state is `running` and the boot has
+  completed.
+- On-prem: confirm the box is on, NIC is up.
+- If the host is down: bring it up, then go to step 6.
+
+### 3. TCP/22 reachability from outside the deploy host's network
+
+The GitHub-hosted runner reaches the host from a public address.
+Confirm port 22 is reachable from outside the deploy host's own LAN
+**before** doing any auth check.
+
+- From a workstation that is on the **public Internet**
+  (not the same LAN, not the same VPN): run
+  `nc -vz -w 5 <deploy-host> 22`. Expect `succeeded` / `connected`.
+  Do not print the host value in chat.
+- `timed out` here means the port is firewalled or the host's NIC
+  drops the SYN. Move to step 4.
+- `refused` here means SSHd is not listening on 22. Move to step 6.
+
+### 4. Cloud security group / on-prem firewall / NAT
+
+Port 22/TCP from the runner to the host must be allowed end to end.
+This is the most common cause of the timeout shape this runbook
+addresses.
+
+- Cloud security group / network ACL: confirm an inbound rule allows
+  TCP/22 from the runner-side address space (see step 5).
+- On-prem firewall (router / pf / iptables): confirm a corresponding
+  allow rule on the WAN-facing interface and that connection tracking
+  is healthy.
+- NAT / port-forward: confirm port 22 still forwards to the deploy
+  host's private IP, and the deploy host's private IP has not changed.
+- Recent change: scan the deploy host's security group / firewall
+  change log for any change in the last 24h. A timeout right after a
+  group/policy edit is almost always the edit.
+
+### 5. GitHub runner outbound IP ranges
+
+GitHub-hosted runners egress from a published CIDR set. If the deploy
+host's inbound is **allowlisted to specific source IPs**, the runner's
+current outbound range must be in the allowlist.
+
+- Pull the current CIDR set:
+
+  ```bash
+  curl -s https://api.github.com/meta | jq -r '.actions[]' | head
+  ```
+
+- Confirm the deploy host's security group / firewall allowlists at
+  least the CIDRs the workflow's runners egress from (the published
+  `actions` list).
+- The published list changes; do not cache it. Re-pull whenever the
+  workflow starts failing right after a GitHub Actions IP roll.
+- If the deploy host's inbound is open to `0.0.0.0/0` on port 22,
+  this step is not the cause - move to step 6.
+
+### 6. SSH service on the deploy host
+
+If TCP/22 reaches the host but the deploy job still times out, sshd may
+be reachable but not responsive. (`refused` is sshd-not-listening;
+`timed out` is sshd-blocked or sshd-hung.)
+
+- From a console session on the deploy host (cloud console / serial /
+  out-of-band - **not** SSH): `systemctl status sshd` (or `ssh` on
+  systems using that unit name). Expect `active (running)` and a
+  recent successful start.
+- Confirm sshd is bound to the expected port (`grep -E '^Port' /etc/ssh/sshd_config`).
+  If `Port 22` is commented and a different port is configured, the
+  workflow times out because it dials `:22`.
+- If sshd is hung: restart it (`systemctl restart sshd`).
+
+### 7. Deploy user / deploy key (only if steps 1-6 are clean)
+
+A timeout shape **does not** indicate a key or user problem - those
+return `Permission denied (publickey)` or `Permission denied (publickey,password)`
+instead. If you have already verified 1-6 and the timeout persists,
+spot-check these anyway:
+
+- Deploy user account exists on the host and has not been locked
+  (`getent passwd <deploy-user>` on the host - run inside an out-of-band
+  console; do not paste the username back).
+- The deploy user's `~/.ssh/authorized_keys` has not been truncated or
+  rewritten. Compare its size / mtime against your last known-good
+  snapshot. Do not paste the file content.
+- The deploy key in the GitHub secret has not been rotated without
+  updating `authorized_keys`. If the workflow log shows `Permission
+  denied` instead of `Connection timed out`, that is the case - use a
+  different runbook for key rotation.
+
+### 8. Manual `ssh -v` verification
+
+This is the single most useful step once you believe steps 1-7 are
+green. Reproduce the workflow's connection shape from a workstation
+that egresses from approximately the same address space as a
+GitHub-hosted runner, or from a runner-local sanity workflow.
+
+From a control workstation (placeholders only - do not paste real
+values):
+
+```bash
+ssh -vv -o ConnectTimeout=10 \
+    -o StrictHostKeyChecking=no \
+    -o IdentitiesOnly=yes \
+    -i ~/.ssh/<deploy-key-file> \
+    <deploy-user>@<deploy-host> 'echo ok'
+```
+
+Read the `-vv` lines:
+
+- `OpenSSH ...` / `Reading configuration data ...` - sanity, ignore.
+- `Connecting to <deploy-host> port 22.` then nothing for ~30s
+  followed by `Connection timed out` - this matches the workflow
+  failure shape. Network is the cause; loop back to steps 3-5.
+- `Connection established. ... Server signature` - host reachable;
+  the workflow's earlier timeout was transient. Move to step 9.
+- `Permission denied (publickey)` - host reachable, key/user wrong;
+  not this runbook's failure mode.
+
+If you need to reproduce from a GitHub-hosted runner exactly (because
+your workstation has different egress), use a small sanity workflow
+that runs the same `ssh -o ConnectTimeout=10 ...` against the host
+**after** decoding the same deploy key, and inspect its log. Do not
+add a debug step to `docker-build.yml` itself.
+
+### 9. When to rerun failed jobs
+
+Only rerun after you have **identified the cause** (one of steps 1-8
+returned a definitive answer) and the cause is fixed.
+
+- In the GitHub UI for the failing run, click **Re-run failed jobs**.
+  This re-uses the `build` job's already-pushed images (no rebuild) and
+  only re-runs the `deploy` job - cheap.
+- For the run cited in #1772: `26293551077`.
+- If the rerun fails at the same `Sync deploy host files` step with
+  the same `Connection timed out` text, the cause was **not** fixed -
+  loop back to step 3.
+
+Do not rerun more than twice for the same root cause; further reruns
+add noise without information.
+
+## Out of scope
+
+This runbook covers **TCP/22 reachability from the runner to the
+deploy host**. Out of scope:
+
+- workflow file changes (the workflow itself is fine when the host is
+  reachable),
+- deploy SSH key rotation (a separate runbook),
+- application runtime / DB / API behavior,
+- Bridge Agent / Data Factory / K3 WISE / SQL Server work,
+- customer GATE state.
+
+This runbook does not touch `plugins/plugin-integration-core`,
+`packages/core-backend`, `apps/web`, any DB migration, or any external
+system API. It is operator documentation only.
+
+## Related workflows and runs
+
+- Workflow: `Build and Push Docker Images` -
+  `.github/workflows/docker-build.yml` (`name:` on line 1, `deploy:`
+  job starts at line 64, `Sync deploy host files` step at line 71).
+- Tracking issue: #1772.
+- First failing run: workflow run `26293551077` after the
+  `d23472167` main commit (`fix(multitable): hint when calendar
+  holidays are unsynced`, PR #1771). The PR itself did not change
+  deploy-host infrastructure.


### PR DESCRIPTION
## 这是什么
按 #1772 + workflow `Build and Push Docker Images` 在 `Sync deploy host files` 步首个 `ssh` TCP/22 超时这一**实证**失败语境,新增**operator-facing runbook**。**仅 docs/ops**——不动 workflow YAML、不动 runtime/DB/API/frontend。

## 实证定位(不靠猜)
- workflow: `.github/workflows/docker-build.yml`(line 1: `name: Build and Push Docker Images`)
- 失败 job: `deploy:`(line 64)
- 失败 step: `Sync deploy host files`(line 71)
- 失败命令: 该 step 内首个 `ssh ... $DEPLOY_USER@$DEPLOY_HOST ...`(line 88)
- 失败 run: workflow run `26293551077`,触发 PR #1771 / 合并 SHA `d23472167`(该 PR **不**触 deploy 基础设施)
- 错误文案(脱敏): `ssh: connect to host <redacted> port 22: Connection timed out` + `deploy_rc missing; failing deploy job.`

## 产物(3 文件,+482/-0)
| 文件 | 作用 |
|---|---|
| `docs/operations/docker-build-deploy-ssh-timeout-runbook.md` | 9 步 operator checklist + secret 卫生 + 失败 shape 误判防护 |
| `docs/development/docker-build-deploy-ssh-timeout-runbook-design-20260522.md` | 范围、为什么是 operator-facing 不是 workflow 改动、checklist 排序依据(按发生概率非 OSI 层)|
| `docs/development/docker-build-deploy-ssh-timeout-runbook-verification-20260522.md` | 实证 acceptance 表 + secret-shape sweep + diff-check |

## Runbook 设计要点(reviewer 重点)
1. **症状先行**:开头直接给 step name + 行号 + 脱敏错误原文,operator 眼对就行
2. **按失败概率排序**(DNS 漂移 / 云 SG 改动 / runner CIDR 滚 → sshd / key/user 在后),不按 OSI 层。因为 timeout shape 不是 auth 类失败
3. **显式"这不是 X 的失败 shape"** 反向 caveat 防 operator 拿到 timeout 就去轮 key
4. **secret 卫生 section** 前置——workflow log 已 redacted,告诉 operator 引用脱敏行而非终端;**不**贴真值
5. **GitHub runner CIDR**:`https://api.github.com/meta` 是 canonical endpoint,会滚动,不要缓存
6. **`ssh -vv` 复现段** 给 placeholder-only 的精确命令形态(`ConnectTimeout=10 -StrictHostKeyChecking=no -IdentitiesOnly=yes -i ...`),与 workflow 内同形,apples-to-apples
7. **Re-run failed jobs** 是 step 9,门控"先修后跑";run id `26293551077` 给本次 incident 一个可点的链接

## 为什么**不**改 workflow
- workflow 本身在 host 可达时工作正常;
- 加 workflow 侧 retry/fallback 会掩盖底层中断,拖慢未来 triage;
- 真有"经常短抖"的证据再单开 PR 加 `--connect-timeout` / 单次重试,本 PR 不混入。

## 本地证据(全在隔离 worktree)
| 检查 | 结果 |
|---|---|
| acceptance markers 13 项 grep | 全部 ≥1 命中(DNS/port 22/security group/firewall/deploy user/deploy key/api.github.com/meta/ssh -vv/Re-run failed jobs/26293551077/#1772/docker-build.yml:71/docker-build.yml:88)|
| 工作流文件行号引用准确 | `.github/workflows/docker-build.yml` 在 `origin/main` HEAD `18dccc36d`,line 1 `name:`,line 64 `deploy:`,line 71 `Sync deploy host files`,line 88 `ssh ...` ✓ |
| Secret-shape sweep 6 模式 × 2 文件 | **IPv4 唯一 1 命中 = `0.0.0.0/0`**(CIDR-any 占位符,非 host 泄露,已在 verification MD 显式声明);其他 11 cells 全 0 |
| `git diff --check` | exit 0 |
| 分支 self-check | `codex/docker-build-deploy-ssh-timeout-runbook-20260522` ✓ |

## 范围与红线
- docs only,3 文件 +482/-0。
- **未触** `.github/workflows/docker-build.yml`、`plugins/plugin-integration-core`、`packages/*`、`apps/*`、任何 migration、frontend、K3 Save/Submit/Audit。
- customer GATE 不解除。本 PR 不替 operator 改云 SG / 防火墙 / SSH key——只教他们怎么改。

## 操作纪律
按 *Parallel-session worktree hazard* memory 隔离 worktree 全程开发 + commit + push;commit 前 `git branch --show-current` 核对通过。

## Test plan
- [ ] CI pr-validate(docs only,预期通过)
- [ ] Codex / maintainer review:确认 checklist 9 步顺序符合"按概率"、secret 卫生段够强、line 引用与 workflow 一致、`0.0.0.0/0` 占位符可接受

## Root-cause caveat

Refs #1772. This PR documents the operator runbook for the observed SSH timeout.
It does not restore runner-to-host TCP/22 reachability by itself. The actual
network/firewall/host-side root cause is tracked separately and may recur until
addressed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

