### PR TITLE
fix(attendance): reject invalid comprehensive preview enums

### DIFF
--- a/docs/development/attendance-comprehensive-hours-preview-input-validation-development-20260523.md
+++ b/docs/development/attendance-comprehensive-hours-preview-input-validation-development-20260523.md
@@ -38,6 +38,10 @@ Implementation details:
 - Existing internal helpers such as `buildAttendanceComprehensiveHoursComparison()`
   keep their defensive fallback behavior, so this is scoped to the route-facing
   preview contract.
+- The older `resolveAttendanceComprehensiveHoursMetric()` and
+  `resolveAttendanceComprehensiveHoursEnforcement()` helpers intentionally remain
+  for internal derived paths that need a defensive fallback. The new
+  `normalize*Input()` helpers are the strict route-boundary validators.
 
 ## Boundary
 

--- a/docs/development/attendance-comprehensive-hours-preview-input-validation-development-20260523.md
+++ b/docs/development/attendance-comprehensive-hours-preview-input-validation-development-20260523.md
@@ -1,0 +1,59 @@
+# Attendance Comprehensive Hours Preview Input Validation Development
+
+Date: 2026-05-23
+Branch: `codex/attendance-comprehensive-hours-preview-postmerge-review-20260523`
+
+## Context
+
+PR #1774 added the read-only backend preview route:
+
+```text
+POST /api/attendance/comprehensive-hours/preview
+```
+
+The post-merge review confirmed the route is admin-gated and does not add write
+paths, but found one input-contract gap: invalid `metric` or `enforcement`
+values silently fell back to `planned` / `warn`. That is acceptable for low-level
+comparison helpers, but it is too ambiguous for the HTTP preview boundary because
+planned and actual comprehensive-hours metrics intentionally use different data
+producers.
+
+## Change
+
+This slice adds explicit route-input normalization for the two enum fields:
+
+| Field | Default when omitted | Accepted values | Invalid result |
+| --- | --- | --- | --- |
+| `metric` | `planned` | `planned`, `actual` | `INVALID_METRIC` |
+| `enforcement` | `warn` | `warn`, `block` | `INVALID_ENFORCEMENT` |
+
+Implementation details:
+
+- `normalizeAttendanceComprehensiveHoursMetricInput()` validates a supplied
+  metric and trims surrounding whitespace.
+- `normalizeAttendanceComprehensiveHoursEnforcementInput()` validates a supplied
+  enforcement mode and trims surrounding whitespace.
+- `normalizeAttendanceComprehensiveHoursPreviewInput()` now returns a validation
+  error before any DB reads when either supplied enum is invalid.
+- Existing internal helpers such as `buildAttendanceComprehensiveHoursComparison()`
+  keep their defensive fallback behavior, so this is scoped to the route-facing
+  preview contract.
+
+## Boundary
+
+| Area | Result |
+| --- | --- |
+| HTTP route surface | Unchanged: still only `POST /api/attendance/comprehensive-hours/preview`. |
+| Permission | Unchanged: still `attendance:admin`. |
+| DB writes | None added. |
+| Schedule save warning/block | None added. |
+| Policy persistence | None added. |
+| Frontend UI | None added. |
+| Data Factory / Bridge Agent / K3 | Not touched. |
+
+## Why This Matters
+
+`metric='actuals'` previously meant "use planned minutes" because the helper
+fell back to `planned`. That can make a preview look valid while using the wrong
+producer. The new behavior keeps operator mistakes visible and preserves the RFC
+rule that planned and actual producers must not be conflated.

--- a/docs/development/attendance-comprehensive-hours-preview-input-validation-verification-20260523.md
+++ b/docs/development/attendance-comprehensive-hours-preview-input-validation-verification-20260523.md
@@ -1,0 +1,80 @@
+# Attendance Comprehensive Hours Preview Input Validation Verification
+
+Date: 2026-05-23
+Branch: `codex/attendance-comprehensive-hours-preview-postmerge-review-20260523`
+
+## Review Scope
+
+Post-merge review target:
+
+- `353d01dcd feat(attendance): add comprehensive hours preview route (#1774)`
+- `plugins/plugin-attendance/index.cjs`
+- `packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts`
+
+Reviewed boundaries:
+
+| Check | Evidence |
+| --- | --- |
+| Admin gate | Route registration uses `withPermission('attendance:admin')`. |
+| Read-only route | Only `POST /api/attendance/comprehensive-hours/preview` was added for this feature. |
+| No writes in preview helper | Existing planned preview test asserts all recorded SQL starts with `SELECT` and has no `INSERT`, `UPDATE`, `DELETE`, or `PATCH`. |
+| Planned/actual separation | Planned preview uses effective-calendar/schedule context producers; actual preview uses `loadAttendanceSummary()`. |
+| Schema gaps | Missing table/column errors return `503 DB_NOT_READY`. |
+
+## Added Coverage
+
+The existing invalid-preview test now also covers:
+
+| Case | Expected result |
+| --- | --- |
+| `metric: 'actuals'` | `INVALID_METRIC` |
+| `policyDraft.enforcement: 'deny'` | `INVALID_ENFORCEMENT` |
+| `metric: ' actual '`, `enforcement: ' block '` | Valid, normalized to `actual` / `block` |
+
+This proves supplied invalid enum values fail before DB reads instead of silently
+falling back to `planned` / `warn`.
+
+## Commands
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+```
+
+Result: PASS.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/attendance-comprehensive-hours-control.test.ts \
+  --reporter=dot
+```
+
+Result: PASS, 11 tests.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/attendance-advanced-scheduling-workbench.test.ts \
+  tests/unit/attendance-scheduling-assignment-conflict.test.ts \
+  tests/unit/attendance-effective-calendar-role-context.test.ts \
+  --reporter=dot
+```
+
+Result: PASS, 15 tests.
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result: PASS.
+
+```bash
+git diff --check
+```
+
+Result: PASS.
+
+## Dependency Note
+
+The isolated worktree did not have its own `node_modules`. The verification used
+temporary symlinks to the existing workspace dependencies and then removed them
+before staging. No dependency directories or build outputs are part of this
+slice.

--- a/docs/development/attendance-comprehensive-hours-preview-input-validation-verification-20260523.md
+++ b/docs/development/attendance-comprehensive-hours-preview-input-validation-verification-20260523.md
@@ -28,6 +28,8 @@ The existing invalid-preview test now also covers:
 | Case | Expected result |
 | --- | --- |
 | `metric: 'actuals'` | `INVALID_METRIC` |
+| `policyDraft.metric: 'actuals'` | `INVALID_METRIC` |
+| `enforcement: 'deny'` | `INVALID_ENFORCEMENT` |
 | `policyDraft.enforcement: 'deny'` | `INVALID_ENFORCEMENT` |
 | `metric: ' actual '`, `enforcement: ' block '` | Valid, normalized to `actual` / `block` |
 

--- a/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
+++ b/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
@@ -410,6 +410,24 @@ describe('attendance comprehensive working-hours control helpers', () => {
       userId: 'user-a',
       period: { type: 'month', year: 2026, month: 5 },
       capMinutes: 600,
+      policyDraft: { metric: 'actuals' },
+    })).toMatchObject({
+      ok: false,
+      error: { code: 'INVALID_METRIC' },
+    })
+    expect(helpers.normalizeAttendanceComprehensiveHoursPreviewInput({
+      userId: 'user-a',
+      period: { type: 'month', year: 2026, month: 5 },
+      capMinutes: 600,
+      enforcement: 'deny',
+    })).toMatchObject({
+      ok: false,
+      error: { code: 'INVALID_ENFORCEMENT' },
+    })
+    expect(helpers.normalizeAttendanceComprehensiveHoursPreviewInput({
+      userId: 'user-a',
+      period: { type: 'month', year: 2026, month: 5 },
+      capMinutes: 600,
       policyDraft: { enforcement: 'deny' },
     })).toMatchObject({
       ok: false,

--- a/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
+++ b/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
@@ -397,6 +397,37 @@ describe('attendance comprehensive working-hours control helpers', () => {
       ok: false,
       error: { code: 'INVALID_CAP' },
     })
+    expect(helpers.normalizeAttendanceComprehensiveHoursPreviewInput({
+      userId: 'user-a',
+      period: { type: 'month', year: 2026, month: 5 },
+      capMinutes: 600,
+      metric: 'actuals',
+    })).toMatchObject({
+      ok: false,
+      error: { code: 'INVALID_METRIC' },
+    })
+    expect(helpers.normalizeAttendanceComprehensiveHoursPreviewInput({
+      userId: 'user-a',
+      period: { type: 'month', year: 2026, month: 5 },
+      capMinutes: 600,
+      policyDraft: { enforcement: 'deny' },
+    })).toMatchObject({
+      ok: false,
+      error: { code: 'INVALID_ENFORCEMENT' },
+    })
+    expect(helpers.normalizeAttendanceComprehensiveHoursPreviewInput({
+      userId: 'user-a',
+      period: { type: 'month', year: 2026, month: 5 },
+      capMinutes: 600,
+      metric: ' actual ',
+      enforcement: ' block ',
+    })).toMatchObject({
+      ok: true,
+      input: {
+        metric: 'actual',
+        enforcement: 'block',
+      },
+    })
     await expect(helpers.previewAttendanceComprehensiveHours(db, 'org-1', {
       userId: 'user-a',
       period: { type: 'week' },

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -11794,6 +11794,30 @@ function resolveAttendanceComprehensiveHoursEnforcement(value) {
     : 'warn'
 }
 
+function normalizeAttendanceComprehensiveHoursMetricInput(value) {
+  if (value === undefined || value === null || value === '') return { ok: true, metric: 'planned' }
+  if (typeof value === 'string') {
+    const metric = value.trim()
+    if (ATTENDANCE_COMPREHENSIVE_HOURS_METRICS.has(metric)) return { ok: true, metric }
+  }
+  return buildAttendanceComprehensiveHoursError(
+    'INVALID_METRIC',
+    'Comprehensive hours preview metric must be planned or actual.',
+  )
+}
+
+function normalizeAttendanceComprehensiveHoursEnforcementInput(value) {
+  if (value === undefined || value === null || value === '') return { ok: true, enforcement: 'warn' }
+  if (typeof value === 'string') {
+    const enforcement = value.trim()
+    if (ATTENDANCE_COMPREHENSIVE_HOURS_ENFORCEMENT.has(enforcement)) return { ok: true, enforcement }
+  }
+  return buildAttendanceComprehensiveHoursError(
+    'INVALID_ENFORCEMENT',
+    'Comprehensive hours preview enforcement must be warn or block.',
+  )
+}
+
 function calculateAttendanceComprehensiveShiftPlannedMinutes(profile) {
   const startTime = normalizeTimeString(profile?.workStartTime ?? profile?.work_start_time ?? DEFAULT_RULE.workStartTime)
   const endTime = normalizeTimeString(profile?.workEndTime ?? profile?.work_end_time ?? DEFAULT_RULE.workEndTime)
@@ -12007,8 +12031,10 @@ function normalizeAttendanceComprehensiveHoursCapMinutes(input = {}) {
 
 function normalizeAttendanceComprehensiveHoursPreviewInput(input = {}) {
   const policyDraft = input.policyDraft && typeof input.policyDraft === 'object' ? input.policyDraft : {}
-  const metric = resolveAttendanceComprehensiveHoursMetric(input.metric ?? policyDraft.metric)
-  const enforcement = resolveAttendanceComprehensiveHoursEnforcement(input.enforcement ?? policyDraft.enforcement)
+  const metric = normalizeAttendanceComprehensiveHoursMetricInput(input.metric ?? policyDraft.metric)
+  if (!metric.ok) return metric
+  const enforcement = normalizeAttendanceComprehensiveHoursEnforcementInput(input.enforcement ?? policyDraft.enforcement)
+  if (!enforcement.ok) return enforcement
   const scope = normalizeAttendanceComprehensiveHoursUserIds(input)
   if (!scope.ok) return scope
   const cap = normalizeAttendanceComprehensiveHoursCapMinutes(input)
@@ -12028,8 +12054,8 @@ function normalizeAttendanceComprehensiveHoursPreviewInput(input = {}) {
   return {
     ok: true,
     input: {
-      metric,
-      enforcement,
+      metric: metric.metric,
+      enforcement: enforcement.enforcement,
       capMinutes: cap.capMinutes,
       userIds: scope.userIds,
       periodInput,
@@ -13915,6 +13941,8 @@ module.exports = {
     buildAttendanceComprehensiveActualMinutesFromSummary,
     buildAttendanceComprehensiveHoursComparison,
     buildAttendanceComprehensiveHoursPreviewRows,
+    normalizeAttendanceComprehensiveHoursMetricInput,
+    normalizeAttendanceComprehensiveHoursEnforcementInput,
     normalizeAttendanceComprehensiveHoursPreviewInput,
     resolveAttendanceComprehensiveHoursPreviewPeriod,
     previewAttendanceComprehensiveHours,


### PR DESCRIPTION
## Summary

Post-merge review of #1774 found that the new comprehensive-hours preview route silently fell back to `planned` / `warn` when callers supplied invalid `metric` or `enforcement` values.

This PR keeps the omitted-field defaults, but rejects supplied invalid enum values before DB reads:

- invalid `metric` -> `INVALID_METRIC`
- invalid `enforcement` -> `INVALID_ENFORCEMENT`
- surrounding whitespace on valid enum strings is normalized

## Scope

- Small backend validation hardening for `POST /api/attendance/comprehensive-hours/preview`
- Focused unit coverage in `attendance-comprehensive-hours-control.test.ts`
- Development + verification MDs

## Boundaries

- No frontend UI
- No migration
- No policy persistence
- No schedule save warning/block
- No Data Factory / Bridge Agent / K3 changes
- Internal comparison helpers keep their defensive fallback behavior; this only tightens the route-facing preview contract

## Verification

- `node --check plugins/plugin-attendance/index.cjs` PASS
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-comprehensive-hours-control.test.ts --reporter=dot` PASS, 11 tests
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-advanced-scheduling-workbench.test.ts tests/unit/attendance-scheduling-assignment-conflict.test.ts tests/unit/attendance-effective-calendar-role-context.test.ts --reporter=dot` PASS, 15 tests
- `pnpm --filter @metasheet/core-backend build` PASS
- `git diff --check` PASS
