### PR TITLE
feat(attendance): add comprehensive hours preview UI

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -4451,6 +4451,284 @@
             </div>
 
             <div
+              v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.comprehensiveHoursPreview)"
+              class="attendance__admin-section"
+              v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.comprehensiveHoursPreview)"
+              data-attendance-comprehensive-hours-preview
+            >
+              <div class="attendance__admin-section-header">
+                <div>
+                  <h4>{{ tr('Comprehensive hours preview', '综合工时预览') }}</h4>
+                  <small class="attendance__field-hint">
+                    {{ tr('Read-only cap comparison for explicit users. It does not save policies or block schedule changes.', '面向指定员工的只读工时上限对比，不保存策略，也不会阻断排班变更。') }}
+                  </small>
+                </div>
+                <button
+                  class="attendance__btn"
+                  :disabled="comprehensiveHoursPreviewLoading || !comprehensiveHoursCanPreview"
+                  @click="previewComprehensiveHours"
+                  data-attendance-comprehensive-hours-preview-run
+                >
+                  {{ comprehensiveHoursPreviewLoading ? tr('Previewing...', '预览中...') : tr('Preview comprehensive hours', '预览综合工时') }}
+                </button>
+              </div>
+
+              <div class="attendance__admin-meta">
+                <span class="attendance__status-chip" data-attendance-comprehensive-hours-readonly>
+                  {{ comprehensiveHoursPreviewReadOnlyLabel }}
+                </span>
+                <span class="attendance__status-chip">
+                  {{ comprehensiveHoursPreviewPeriodLabel }}
+                </span>
+              </div>
+
+              <div class="attendance__admin-grid">
+                <label class="attendance__field" for="attendance-comprehensive-hours-user-mode">
+                  <span>{{ tr('Scope', '范围') }}</span>
+                  <select
+                    id="attendance-comprehensive-hours-user-mode"
+                    v-model="comprehensiveHoursPreviewForm.userMode"
+                    data-attendance-comprehensive-hours-user-mode
+                  >
+                    <option value="single">{{ tr('Single user', '单个员工') }}</option>
+                    <option value="multiple">{{ tr('User IDs', '多个员工 ID') }}</option>
+                  </select>
+                  <small class="attendance__field-hint">
+                    {{ tr('Preview v1 intentionally requires explicit users; all-users batch remains out of scope.', '预览 v1 必须显式指定员工；全员批量仍不在本次范围。') }}
+                  </small>
+                </label>
+                <label
+                  v-if="comprehensiveHoursPreviewForm.userMode === 'single'"
+                  class="attendance__field"
+                  for="attendance-comprehensive-hours-user-id"
+                >
+                  <span>{{ tr('User ID', '员工 ID') }}</span>
+                  <input
+                    id="attendance-comprehensive-hours-user-id"
+                    v-model="comprehensiveHoursPreviewForm.userId"
+                    type="text"
+                    placeholder="user-1"
+                    data-attendance-comprehensive-hours-user-id
+                  />
+                </label>
+                <label
+                  v-else
+                  class="attendance__field"
+                  for="attendance-comprehensive-hours-user-ids"
+                >
+                  <span>{{ tr('User IDs', '员工 ID 列表') }}</span>
+                  <textarea
+                    id="attendance-comprehensive-hours-user-ids"
+                    v-model="comprehensiveHoursPreviewForm.userIds"
+                    rows="3"
+                    placeholder="user-1, user-2"
+                    data-attendance-comprehensive-hours-user-ids
+                  />
+                  <small class="attendance__field-hint">
+                    {{ tr('Comma, space, or newline separated. The backend caps preview scope at 100 users.', '可用逗号、空格或换行分隔；后端最多预览 100 人。') }}
+                  </small>
+                </label>
+                <label class="attendance__field" for="attendance-comprehensive-hours-metric">
+                  <span>{{ tr('Metric', '指标') }}</span>
+                  <select
+                    id="attendance-comprehensive-hours-metric"
+                    v-model="comprehensiveHoursPreviewForm.metric"
+                    data-attendance-comprehensive-hours-metric
+                  >
+                    <option value="planned">{{ tr('Planned minutes', '计划工时') }}</option>
+                    <option value="actual">{{ tr('Actual minutes', '实际工时') }}</option>
+                  </select>
+                </label>
+                <label class="attendance__field" for="attendance-comprehensive-hours-cap-hours">
+                  <span>{{ tr('Cap hours', '上限小时') }}</span>
+                  <input
+                    id="attendance-comprehensive-hours-cap-hours"
+                    v-model.number="comprehensiveHoursPreviewForm.capHours"
+                    type="number"
+                    min="0.1"
+                    step="0.5"
+                    data-attendance-comprehensive-hours-cap-hours
+                  />
+                </label>
+                <label class="attendance__field" for="attendance-comprehensive-hours-enforcement">
+                  <span>{{ tr('Policy mode', '策略模式') }}</span>
+                  <select
+                    id="attendance-comprehensive-hours-enforcement"
+                    v-model="comprehensiveHoursPreviewForm.enforcement"
+                    data-attendance-comprehensive-hours-enforcement
+                  >
+                    <option value="warn">{{ tr('Warn preview', '预警预览') }}</option>
+                    <option value="block">{{ tr('Strict preview', '严格预览') }}</option>
+                  </select>
+                  <small class="attendance__field-hint">
+                    {{ tr('Mode only changes preview status. It is not persisted and does not enforce saves.', '模式只影响预览状态，不会持久化，也不会拦截保存。') }}
+                  </small>
+                </label>
+                <label class="attendance__field" for="attendance-comprehensive-hours-period-type">
+                  <span>{{ tr('Period', '周期') }}</span>
+                  <select
+                    id="attendance-comprehensive-hours-period-type"
+                    v-model="comprehensiveHoursPreviewForm.periodType"
+                    data-attendance-comprehensive-hours-period-type
+                  >
+                    <option value="month">{{ tr('Month', '月') }}</option>
+                    <option value="quarter">{{ tr('Quarter', '季度') }}</option>
+                    <option value="year">{{ tr('Year', '年') }}</option>
+                    <option value="custom_range">{{ tr('Custom range', '自定义区间') }}</option>
+                    <option value="payroll_cycle">{{ tr('Payroll cycle', '计薪周期') }}</option>
+                  </select>
+                </label>
+                <label
+                  v-if="['month', 'quarter', 'year'].includes(comprehensiveHoursPreviewForm.periodType)"
+                  class="attendance__field"
+                  for="attendance-comprehensive-hours-year"
+                >
+                  <span>{{ tr('Year', '年份') }}</span>
+                  <input
+                    id="attendance-comprehensive-hours-year"
+                    v-model.number="comprehensiveHoursPreviewForm.year"
+                    type="number"
+                    min="2000"
+                    max="9999"
+                    data-attendance-comprehensive-hours-year
+                  />
+                </label>
+                <label
+                  v-if="comprehensiveHoursPreviewForm.periodType === 'month'"
+                  class="attendance__field"
+                  for="attendance-comprehensive-hours-month"
+                >
+                  <span>{{ tr('Month', '月份') }}</span>
+                  <input
+                    id="attendance-comprehensive-hours-month"
+                    v-model.number="comprehensiveHoursPreviewForm.month"
+                    type="number"
+                    min="1"
+                    max="12"
+                    data-attendance-comprehensive-hours-month
+                  />
+                </label>
+                <label
+                  v-if="comprehensiveHoursPreviewForm.periodType === 'quarter'"
+                  class="attendance__field"
+                  for="attendance-comprehensive-hours-quarter"
+                >
+                  <span>{{ tr('Quarter', '季度') }}</span>
+                  <select
+                    id="attendance-comprehensive-hours-quarter"
+                    v-model.number="comprehensiveHoursPreviewForm.quarter"
+                    data-attendance-comprehensive-hours-quarter
+                  >
+                    <option :value="1">Q1</option>
+                    <option :value="2">Q2</option>
+                    <option :value="3">Q3</option>
+                    <option :value="4">Q4</option>
+                  </select>
+                </label>
+                <label
+                  v-if="comprehensiveHoursPreviewForm.periodType === 'custom_range'"
+                  class="attendance__field"
+                  for="attendance-comprehensive-hours-from"
+                >
+                  <span>{{ tr('From', '开始日期') }}</span>
+                  <input
+                    id="attendance-comprehensive-hours-from"
+                    v-model="comprehensiveHoursPreviewForm.from"
+                    type="date"
+                    data-attendance-comprehensive-hours-from
+                  />
+                </label>
+                <label
+                  v-if="comprehensiveHoursPreviewForm.periodType === 'custom_range'"
+                  class="attendance__field"
+                  for="attendance-comprehensive-hours-to"
+                >
+                  <span>{{ tr('To', '结束日期') }}</span>
+                  <input
+                    id="attendance-comprehensive-hours-to"
+                    v-model="comprehensiveHoursPreviewForm.to"
+                    type="date"
+                    data-attendance-comprehensive-hours-to
+                  />
+                </label>
+                <label
+                  v-if="comprehensiveHoursPreviewForm.periodType === 'payroll_cycle'"
+                  class="attendance__field"
+                  for="attendance-comprehensive-hours-cycle-id"
+                >
+                  <span>{{ tr('Cycle ID', '计薪周期 ID') }}</span>
+                  <input
+                    id="attendance-comprehensive-hours-cycle-id"
+                    v-model="comprehensiveHoursPreviewForm.cycleId"
+                    type="text"
+                    placeholder="cycle-2026-05"
+                    data-attendance-comprehensive-hours-cycle-id
+                  />
+                </label>
+              </div>
+
+              <p
+                v-if="comprehensiveHoursPreviewStatus.message"
+                class="attendance__status"
+                :class="{ 'attendance__status--error': comprehensiveHoursPreviewStatus.kind === 'error' }"
+                data-attendance-comprehensive-hours-status
+              >
+                {{ comprehensiveHoursPreviewStatus.message }}
+              </p>
+
+              <div class="attendance__summary attendance__summary--workbench" data-attendance-comprehensive-hours-aggregate>
+                <div
+                  v-for="item in comprehensiveHoursPreviewAggregateItems"
+                  :key="item.key"
+                  class="attendance__summary-item"
+                  :data-attendance-comprehensive-hours-aggregate-item="item.key"
+                >
+                  <span>{{ item.label }}</span>
+                  <strong>{{ item.value }}</strong>
+                </div>
+              </div>
+
+              <div v-if="comprehensiveHoursPreviewRows.length === 0" class="attendance__empty" data-attendance-comprehensive-hours-empty>
+                {{ tr('Run a read-only preview to compare comprehensive-hours caps.', '运行只读预览以对比综合工时上限。') }}
+              </div>
+              <div v-else class="attendance__table-wrapper">
+                <table class="attendance__table" data-attendance-comprehensive-hours-rows>
+                  <thead>
+                    <tr>
+                      <th>{{ tr('User', '员工') }}</th>
+                      <th>{{ tr('Metric minutes', '指标分钟') }}</th>
+                      <th>{{ tr('Cap', '上限') }}</th>
+                      <th>{{ tr('Remaining', '剩余') }}</th>
+                      <th>{{ tr('Excess', '超出') }}</th>
+                      <th>{{ tr('Status', '状态') }}</th>
+                      <th>{{ tr('Source', '来源') }}</th>
+                    </tr>
+                  </thead>
+                  <tbody>
+                    <tr v-for="row in comprehensiveHoursPreviewRows" :key="row.userId">
+                      <td>
+                        <strong>{{ row.userId }}</strong>
+                        <div v-if="row.days !== undefined" class="attendance__field-hint">
+                          {{ tr(`${row.workingDays ?? 0}/${row.days ?? 0} working days`, `${row.workingDays ?? 0}/${row.days ?? 0} 个工作日`) }}
+                        </div>
+                      </td>
+                      <td>{{ formatComprehensiveHoursMinutes(row.minutes ?? row.plannedMinutes ?? row.actualMinutes) }}</td>
+                      <td>{{ formatComprehensiveHoursMinutes(row.capMinutes) }}</td>
+                      <td>{{ formatComprehensiveHoursMinutes(row.remainingMinutes) }}</td>
+                      <td>{{ formatComprehensiveHoursMinutes(row.excessMinutes) }}</td>
+                      <td>
+                        <span class="attendance__status-chip" :class="comprehensiveHoursStatusClass(row.status)">
+                          {{ formatComprehensiveHoursStatus(row.status) }}
+                        </span>
+                      </td>
+                      <td>{{ row.source || (comprehensiveHoursPreview?.metric === 'actual' ? 'summary' : 'effective_calendar') }}</td>
+                    </tr>
+                  </tbody>
+                </table>
+              </div>
+            </div>
+
+            <div
               v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.rotationRules)"
               class="attendance__admin-section"
               v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.rotationRules)"
@@ -5994,6 +6272,56 @@ interface AttendanceAdvancedSchedulingWorkbench {
   }
 }
 
+type AttendanceComprehensiveHoursMetric = 'planned' | 'actual'
+type AttendanceComprehensiveHoursEnforcement = 'warn' | 'block'
+type AttendanceComprehensiveHoursPeriodType = 'month' | 'quarter' | 'year' | 'custom_range' | 'payroll_cycle'
+type AttendanceComprehensiveHoursStatus = 'ok' | 'warning' | 'violation'
+
+interface AttendanceComprehensiveHoursPreviewRow {
+  userId: string
+  minutes?: number
+  plannedMinutes?: number
+  actualMinutes?: number
+  capMinutes: number
+  remainingMinutes: number
+  excessMinutes: number
+  status: AttendanceComprehensiveHoursStatus
+  source?: string
+  days?: number
+  workingDays?: number
+}
+
+interface AttendanceComprehensiveHoursPreviewAggregate {
+  users: number
+  ok: number
+  warning: number
+  violation: number
+  totalMinutes: number
+  totalExcessMinutes: number
+  totalRemainingMinutes: number
+  status: AttendanceComprehensiveHoursStatus
+}
+
+interface AttendanceComprehensiveHoursPreviewResult {
+  readOnly?: boolean
+  period?: {
+    type?: string
+    key?: string
+    from?: string
+    to?: string
+    label?: string
+  }
+  metric: AttendanceComprehensiveHoursMetric
+  enforcement: AttendanceComprehensiveHoursEnforcement
+  capMinutes: number
+  scope?: {
+    userIds?: string[]
+  }
+  rows: AttendanceComprehensiveHoursPreviewRow[]
+  aggregate: AttendanceComprehensiveHoursPreviewAggregate
+  degraded?: boolean
+}
+
 // PR2 adds `sourceClass` carrying `calendar-source--{national|manual|org|group|role|user}`
 // (or undefined for plain rule/shift days). The shared palette in
 // apps/web/src/styles/calendar-source-palette.css resolves it to a 4px
@@ -7187,6 +7515,7 @@ const approvalFlows = ref<AttendanceApprovalFlow[]>([])
 const rotationRules = ref<AttendanceRotationRule[]>([])
 const rotationAssignments = ref<AttendanceRotationAssignmentItem[]>([])
 const advancedSchedulingWorkbench = ref<AttendanceAdvancedSchedulingWorkbench | null>(null)
+const comprehensiveHoursPreview = ref<AttendanceComprehensiveHoursPreviewResult | null>(null)
 const ruleSets = ref<AttendanceRuleSet[]>([])
 const ruleTemplateSystemText = ref('[]')
 const ruleTemplateLibraryText = ref('[]')
@@ -7252,6 +7581,11 @@ const importAsyncJobTelemetryText = computed(() => {
 const shiftEditingId = ref<string | null>(null)
 const assignmentEditingId = ref<string | null>(null)
 const advancedSchedulingWorkbenchLoading = ref(false)
+const comprehensiveHoursPreviewLoading = ref(false)
+const comprehensiveHoursPreviewStatus = ref<{ kind: 'info' | 'warn' | 'error'; message: string }>({
+  kind: 'info',
+  message: '',
+})
 const holidayEditingId = ref<string | null>(null)
 const leaveTypeEditingId = ref<string | null>(null)
 const overtimeRuleEditingId = ref<string | null>(null)
@@ -8508,6 +8842,104 @@ const adminHolidayRange = reactive({
   to: toDateInput(lastDayOfMonth(today)),
 })
 
+const comprehensiveHoursPreviewForm = reactive({
+  userMode: 'single' as 'single' | 'multiple',
+  userId: '',
+  userIds: '',
+  periodType: 'month' as AttendanceComprehensiveHoursPeriodType,
+  year: today.getFullYear(),
+  month: today.getMonth() + 1,
+  quarter: Math.floor(today.getMonth() / 3) + 1,
+  from: toDateInput(firstDayOfMonth(today)),
+  to: toDateInput(lastDayOfMonth(today)),
+  cycleId: '',
+  metric: 'planned' as AttendanceComprehensiveHoursMetric,
+  capHours: 160,
+  enforcement: 'warn' as AttendanceComprehensiveHoursEnforcement,
+})
+
+function comprehensiveHoursUserIds(): string[] {
+  if (comprehensiveHoursPreviewForm.userMode === 'multiple') {
+    return parseUserIdList(comprehensiveHoursPreviewForm.userIds)
+  }
+  return parseUserIdList(comprehensiveHoursPreviewForm.userId).slice(0, 1)
+}
+
+function comprehensiveHoursPreviewPeriodPayload(): Record<string, unknown> {
+  const type = comprehensiveHoursPreviewForm.periodType
+  if (type === 'custom_range') {
+    return {
+      type,
+      from: comprehensiveHoursPreviewForm.from,
+      to: comprehensiveHoursPreviewForm.to,
+    }
+  }
+  if (type === 'payroll_cycle') {
+    return {
+      type,
+      cycleId: comprehensiveHoursPreviewForm.cycleId.trim(),
+    }
+  }
+  if (type === 'quarter') {
+    return {
+      type,
+      year: Number(comprehensiveHoursPreviewForm.year),
+      quarter: Number(comprehensiveHoursPreviewForm.quarter),
+    }
+  }
+  if (type === 'year') {
+    return {
+      type,
+      year: Number(comprehensiveHoursPreviewForm.year),
+    }
+  }
+  return {
+    type,
+    year: Number(comprehensiveHoursPreviewForm.year),
+    month: Number(comprehensiveHoursPreviewForm.month),
+  }
+}
+
+const comprehensiveHoursCanPreview = computed(() => {
+  if (comprehensiveHoursUserIds().length === 0) return false
+  if (!Number.isFinite(Number(comprehensiveHoursPreviewForm.capHours)) || Number(comprehensiveHoursPreviewForm.capHours) <= 0) return false
+  if (comprehensiveHoursPreviewForm.periodType === 'custom_range') {
+    return Boolean(comprehensiveHoursPreviewForm.from && comprehensiveHoursPreviewForm.to)
+  }
+  if (comprehensiveHoursPreviewForm.periodType === 'payroll_cycle') {
+    return comprehensiveHoursPreviewForm.cycleId.trim().length > 0
+  }
+  return Number.isFinite(Number(comprehensiveHoursPreviewForm.year))
+})
+
+const comprehensiveHoursPreviewRows = computed(() => comprehensiveHoursPreview.value?.rows ?? [])
+
+const comprehensiveHoursPreviewReadOnlyLabel = computed(() =>
+  comprehensiveHoursPreview.value?.readOnly
+    ? tr('Read-only preview', '只读预览')
+    : tr('Not previewed', '未预览')
+)
+
+const comprehensiveHoursPreviewPeriodLabel = computed(() => {
+  const period = comprehensiveHoursPreview.value?.period
+  if (!period) return tr('Period not previewed', '周期未预览')
+  if (period.label) return period.label
+  if (period.from && period.to) return `${period.from} - ${period.to}`
+  return period.key || period.type || tr('Period', '周期')
+})
+
+const comprehensiveHoursPreviewAggregateItems = computed(() => {
+  const aggregate = comprehensiveHoursPreview.value?.aggregate
+  return [
+    { key: 'users', label: tr('Users', '员工'), value: aggregate?.users ?? 0 },
+    { key: 'ok', label: tr('OK', '正常'), value: aggregate?.ok ?? 0 },
+    { key: 'warning', label: tr('Warnings', '预警'), value: aggregate?.warning ?? 0 },
+    { key: 'violation', label: tr('Violations', '超限'), value: aggregate?.violation ?? 0 },
+    { key: 'minutes', label: tr('Total minutes', '总分钟'), value: aggregate?.totalMinutes ?? 0 },
+    { key: 'excess', label: tr('Excess minutes', '超出分钟'), value: aggregate?.totalExcessMinutes ?? 0 },
+  ]
+})
+
 function toDateKey(date: Date): string {
   const year = date.getFullYear()
   const month = String(date.getMonth() + 1).padStart(2, '0')
@@ -8956,6 +9388,24 @@ function parseUserIdList(value: string): string[] {
       .map(item => item.trim())
       .filter(Boolean)
   ))
+}
+
+function formatComprehensiveHoursMinutes(value: unknown): string {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) return '--'
+  return String(Math.round(parsed))
+}
+
+function formatComprehensiveHoursStatus(status: AttendanceComprehensiveHoursStatus | string | undefined): string {
+  if (status === 'violation') return tr('Violation', '超限')
+  if (status === 'warning') return tr('Warning', '预警')
+  return tr('OK', '正常')
+}
+
+function comprehensiveHoursStatusClass(status: AttendanceComprehensiveHoursStatus | string | undefined): string {
+  if (status === 'violation') return 'attendance__status-chip--late_early'
+  if (status === 'warning') return 'attendance__status-chip--late'
+  return 'attendance__status-chip--normal'
 }
 
 function formatApprovalSteps(steps: AttendanceApprovalStep[]): string {
@@ -13883,6 +14333,61 @@ async function loadAdvancedSchedulingWorkbench() {
     setStatus(readErrorMessage(error, tr('Failed to load advanced scheduling workbench', '加载高级排班工作台失败')), 'error')
   } finally {
     advancedSchedulingWorkbenchLoading.value = false
+  }
+}
+
+async function previewComprehensiveHours() {
+  const userIds = comprehensiveHoursUserIds()
+  if (userIds.length === 0) {
+    comprehensiveHoursPreviewStatus.value = {
+      kind: 'error',
+      message: tr('Enter at least one user ID before previewing.', '请先填写至少一个员工 ID。'),
+    }
+    return
+  }
+  comprehensiveHoursPreviewLoading.value = true
+  comprehensiveHoursPreviewStatus.value = { kind: 'info', message: '' }
+  try {
+    const query = buildQuery({ orgId: normalizedOrgId() })
+    const body = {
+      policyDraft: {
+        capHours: Number(comprehensiveHoursPreviewForm.capHours),
+        enforcement: comprehensiveHoursPreviewForm.enforcement,
+      },
+      scope: userIds.length === 1
+        ? { userId: userIds[0] }
+        : { userIds },
+      period: comprehensiveHoursPreviewPeriodPayload(),
+      metric: comprehensiveHoursPreviewForm.metric,
+    }
+    const response = await apiFetch(`/api/attendance/comprehensive-hours/preview?${query.toString()}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    if (response.status === 403) {
+      adminForbidden.value = true
+      return
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to preview comprehensive hours', '综合工时预览失败')))
+    }
+    adminForbidden.value = false
+    comprehensiveHoursPreview.value = data.data ?? null
+    comprehensiveHoursPreviewStatus.value = {
+      kind: data.data?.degraded ? 'warn' : 'info',
+      message: data.data?.degraded
+        ? tr('Preview returned degraded data; check attendance schema readiness.', '预览返回降级数据，请检查考勤表结构是否就绪。')
+        : tr('Read-only preview refreshed. No policy was saved.', '只读预览已刷新，未保存任何策略。'),
+    }
+  } catch (error: any) {
+    comprehensiveHoursPreviewStatus.value = {
+      kind: 'error',
+      message: readErrorMessage(error, tr('Failed to preview comprehensive hours', '综合工时预览失败')),
+    }
+  } finally {
+    comprehensiveHoursPreviewLoading.value = false
   }
 }
 

--- a/apps/web/src/views/attendance/useAttendanceAdminRail.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminRail.ts
@@ -29,6 +29,7 @@ export const ATTENDANCE_ADMIN_SECTION_IDS = {
   overtimeRules: 'attendance-admin-overtime-rules',
   approvalFlows: 'attendance-admin-approval-flows',
   advancedSchedulingWorkbench: 'attendance-admin-advanced-scheduling-workbench',
+  comprehensiveHoursPreview: 'attendance-admin-comprehensive-hours-preview',
   rotationRules: 'attendance-admin-rotation-rules',
   rotationAssignments: 'attendance-admin-rotation-assignments',
   shifts: 'attendance-admin-shifts',
@@ -176,6 +177,7 @@ export function useAttendanceAdminRail({
     { id: ATTENDANCE_ADMIN_SECTION_IDS.overtimeRules, label: tr('Overtime Rules', '加班规则') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.approvalFlows, label: tr('Approval Flows', '审批流') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.advancedSchedulingWorkbench, label: tr('Advanced scheduling', '高级排班') },
+    { id: ATTENDANCE_ADMIN_SECTION_IDS.comprehensiveHoursPreview, label: tr('Comprehensive hours', '综合工时') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.rotationRules, label: tr('Rotation Rules', '轮班规则') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.rotationAssignments, label: tr('Rotation Assignments', '轮班分配') },
     { id: ATTENDANCE_ADMIN_SECTION_IDS.shifts, label: tr('Shifts', '班次') },
@@ -199,6 +201,7 @@ export function useAttendanceAdminRail({
       label: tr('Scheduling', '排班执行'),
       itemIds: [
         ATTENDANCE_ADMIN_SECTION_IDS.advancedSchedulingWorkbench,
+        ATTENDANCE_ADMIN_SECTION_IDS.comprehensiveHoursPreview,
         ATTENDANCE_ADMIN_SECTION_IDS.rotationRules,
         ATTENDANCE_ADMIN_SECTION_IDS.rotationAssignments,
         ATTENDANCE_ADMIN_SECTION_IDS.shifts,

--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -124,12 +124,13 @@ describe('Attendance admin anchor navigation', () => {
     )
 
     expect(groupLabels).toEqual(['Workspace', 'Scheduling', 'Organization', 'Policies', 'Data & Payroll'])
-    expect(labels).toHaveLength(24)
+    expect(labels).toHaveLength(25)
     expect(labels).toEqual(
       expect.arrayContaining([
         'Settings',
         'User Access',
         'Advanced scheduling',
+        'Comprehensive hours',
         'Import',
         'Import batches',
         'Report fields',
@@ -281,7 +282,7 @@ describe('Attendance admin anchor navigation', () => {
 
     const jumpSelect = container!.querySelector<HTMLSelectElement>('[data-admin-quick-jump="true"]')
     expect(jumpSelect).toBeTruthy()
-    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(24)
+    expect(Array.from(jumpSelect!.querySelectorAll('option')).length).toBe(25)
 
     jumpSelect!.value = 'attendance-admin-advanced-scheduling-workbench'
     jumpSelect!.dispatchEvent(new Event('change', { bubbles: true }))
@@ -290,6 +291,23 @@ describe('Attendance admin anchor navigation', () => {
     expect(window.location.hash).toBe('#attendance-admin-advanced-scheduling-workbench')
     expect(container!.querySelector('[data-admin-current-section="true"]')?.textContent).toContain('Scheduling · Advanced scheduling')
     expect(container!.querySelector('[data-attendance-advanced-scheduling-workbench]')).toBeTruthy()
+  })
+
+  it('jumps to the comprehensive hours preview from the quick selector', async () => {
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const jumpSelect = container!.querySelector<HTMLSelectElement>('[data-admin-quick-jump="true"]')
+    expect(jumpSelect).toBeTruthy()
+
+    jumpSelect!.value = 'attendance-admin-comprehensive-hours-preview'
+    jumpSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    expect(window.location.hash).toBe('#attendance-admin-comprehensive-hours-preview')
+    expect(container!.querySelector('[data-admin-current-section="true"]')?.textContent).toContain('Scheduling · Comprehensive hours')
+    expect(container!.querySelector('[data-attendance-comprehensive-hours-preview]')).toBeTruthy()
   })
 
   it('normalizes legacy show-all storage back to focused mode across remounts', async () => {

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -270,6 +270,52 @@ describe('Attendance admin regressions', () => {
           },
         })
       }
+      if (url.includes('/api/attendance/comprehensive-hours/preview')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            readOnly: true,
+            period: {
+              type: 'month',
+              key: '2026-05',
+              from: '2026-05-01',
+              to: '2026-05-31',
+              label: 'May 2026',
+            },
+            metric: 'planned',
+            enforcement: 'warn',
+            capMinutes: 9600,
+            scope: {
+              userIds: ['user-1'],
+            },
+            aggregate: {
+              users: 1,
+              ok: 0,
+              warning: 0,
+              violation: 1,
+              totalMinutes: 10200,
+              totalExcessMinutes: 600,
+              totalRemainingMinutes: 0,
+              status: 'violation',
+            },
+            rows: [
+              {
+                userId: 'user-1',
+                minutes: 10200,
+                plannedMinutes: 10200,
+                capMinutes: 9600,
+                remainingMinutes: 0,
+                excessMinutes: 600,
+                status: 'violation',
+                source: 'effective_calendar',
+                days: 31,
+                workingDays: 22,
+              },
+            ],
+            degraded: false,
+          },
+        })
+      }
       if (url.includes('/api/attendance/leave-types')) {
         return jsonResponse(200, {
           ok: true,
@@ -810,6 +856,60 @@ describe('Attendance admin regressions', () => {
     expect(section!.querySelector('[data-attendance-advanced-scheduling-groups]')?.textContent).toContain('Line A')
     const buttons = Array.from(section!.querySelectorAll<HTMLButtonElement>('button')).map(button => button.textContent || '')
     expect(buttons.join(' ')).toContain('Reload workbench')
+    expect(buttons.join(' ')).not.toContain('Create')
+    expect(buttons.join(' ')).not.toContain('Edit')
+    expect(buttons.join(' ')).not.toContain('Delete')
+  })
+
+  it('runs the read-only comprehensive hours preview without write controls', async () => {
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const previewNav = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-comprehensive-hours-preview"]')
+    expect(previewNav).toBeTruthy()
+    previewNav!.click()
+    await flushUi(2)
+
+    const section = container!.querySelector<HTMLElement>('[data-attendance-comprehensive-hours-preview]')
+    expect(section).toBeTruthy()
+    expect(window.getComputedStyle(section!).display).not.toBe('none')
+
+    const userInput = section!.querySelector<HTMLInputElement>('[data-attendance-comprehensive-hours-user-id]')
+    expect(userInput).toBeTruthy()
+    userInput!.value = 'user-1'
+    userInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi(2)
+
+    const runButton = section!.querySelector<HTMLButtonElement>('[data-attendance-comprehensive-hours-preview-run]')
+    expect(runButton).toBeTruthy()
+    expect(runButton!.disabled).toBe(false)
+    runButton!.click()
+    await flushUi(4)
+
+    const previewCall = vi.mocked(apiFetch).mock.calls.find(([input]) =>
+      String(input).includes('/api/attendance/comprehensive-hours/preview')
+    )
+    expect(previewCall).toBeTruthy()
+    const requestBody = JSON.parse(String((previewCall![1] as RequestInit).body))
+    expect(requestBody).toMatchObject({
+      policyDraft: { capHours: 160, enforcement: 'warn' },
+      scope: { userId: 'user-1' },
+      period: { type: 'month' },
+      metric: 'planned',
+    })
+
+    expect(section!.textContent).toContain('Read-only preview')
+    expect(section!.querySelector('[data-attendance-comprehensive-hours-status]')?.textContent).toContain('No policy was saved')
+    expect(section!.querySelector('[data-attendance-comprehensive-hours-aggregate-item="violation"]')?.textContent).toContain('1')
+    expect(section!.querySelector('[data-attendance-comprehensive-hours-rows]')?.textContent).toContain('user-1')
+    expect(section!.querySelector('[data-attendance-comprehensive-hours-rows]')?.textContent).toContain('Violation')
+
+    const buttons = Array.from(section!.querySelectorAll<HTMLButtonElement>('button')).map(button => button.textContent || '')
+    expect(buttons.join(' ')).toContain('Preview comprehensive hours')
+    expect(buttons.join(' ')).not.toContain('Save')
+    expect(buttons.join(' ')).not.toContain('Apply')
+    expect(buttons.join(' ')).not.toContain('Enforce')
     expect(buttons.join(' ')).not.toContain('Create')
     expect(buttons.join(' ')).not.toContain('Edit')
     expect(buttons.join(' ')).not.toContain('Delete')

--- a/docs/development/attendance-comprehensive-hours-control-pr3-development-20260522.md
+++ b/docs/development/attendance-comprehensive-hours-control-pr3-development-20260522.md
@@ -1,0 +1,77 @@
+# Attendance Comprehensive Working Hours Control PR3 Development
+
+Date: 2026-05-22
+Branch: `codex/attendance-comprehensive-hours-preview-ui-20260522`
+
+## Summary
+
+This slice implements PR3 from `attendance-comprehensive-hours-control-rfc-20260522.md`: an admin read-only preview panel for comprehensive working-hours control (`综合工时制`).
+
+It consumes the already-merged PR2 backend route:
+
+```text
+POST /api/attendance/comprehensive-hours/preview
+```
+
+The panel helps admins compare an explicit user or explicit user list against a draft cap for month, quarter, year, custom range, or payroll-cycle periods. It does not persist policy, does not enforce schedule saves, and does not add any backend route.
+
+## Files
+
+| File | Change |
+| --- | --- |
+| `apps/web/src/views/AttendanceView.vue` | Adds the read-only comprehensive-hours preview section, request builder, preview status, aggregate cards, and row table. |
+| `apps/web/src/views/attendance/useAttendanceAdminRail.ts` | Adds `Comprehensive hours` to the Scheduling admin rail. |
+| `apps/web/tests/attendance-admin-regressions.spec.ts` | Locks preview body shape, result rendering, and absence of write buttons. |
+| `apps/web/tests/attendance-admin-anchor-nav.spec.ts` | Updates admin anchor counts and adds a quick-jump regression for the new section. |
+
+## Boundary
+
+- Frontend-only runtime change.
+- No `plugins/plugin-attendance/index.cjs` edits.
+- No `attendance_*` migration.
+- No `meta_*` writes.
+- No all-users batch preview.
+- No policy persistence, schedule-save warning, or schedule-save blocking.
+- No client-side validator beyond disabling preview when required form inputs are empty.
+
+## UI Contract
+
+The panel is mounted under the Scheduling admin group, next to the Advanced scheduling workbench.
+
+Inputs:
+
+- Scope: single `userId` or comma/space/newline-separated `userIds`
+- Metric: `planned` or `actual`
+- Cap: draft hours, converted by the backend to minutes
+- Policy mode: `warn` or strict preview (`block` in the backend contract)
+- Period: month, quarter, year, custom date range, or payroll cycle ID
+
+Output:
+
+- Read-only status chip
+- Period label
+- Aggregate cards for users, OK, warning, violation, total minutes, and excess minutes
+- Per-user comparison table with metric minutes, cap, remaining, excess, status, and source
+- Local error/degraded status without clearing the admin page
+
+## Request Shape
+
+```json
+{
+  "policyDraft": {
+    "capHours": 160,
+    "enforcement": "warn"
+  },
+  "scope": {
+    "userId": "user-1"
+  },
+  "period": {
+    "type": "month",
+    "year": 2026,
+    "month": 5
+  },
+  "metric": "planned"
+}
+```
+
+The backend remains authoritative for validation, cap normalization, period resolution, schema readiness, and planned-vs-actual producer separation.

--- a/docs/development/attendance-comprehensive-hours-control-pr3-verification-20260522.md
+++ b/docs/development/attendance-comprehensive-hours-control-pr3-verification-20260522.md
@@ -1,0 +1,42 @@
+# Attendance Comprehensive Working Hours Control PR3 Verification
+
+Date: 2026-05-22
+Branch: `codex/attendance-comprehensive-hours-preview-ui-20260522`
+
+## Verification Focus
+
+| Focus | Evidence |
+| --- | --- |
+| Read-only UI | The section only calls `POST /api/attendance/comprehensive-hours/preview`; it has no Save, Apply, Enforce, Create, Edit, or Delete button. |
+| Backend authority | The frontend does not duplicate formula or comprehensive-hours validation. Backend preview remains the active validator and period resolver. |
+| Explicit scope | UI exposes only single user and explicit user-list modes. All-users batch is not present. |
+| Admin navigation | Admin rail count and quick-jump behavior include the new Scheduling section. |
+| No backend scope creep | No plugin, migration, or persistence file is touched in this slice. |
+
+## Test Coverage
+
+| Test | Coverage |
+| --- | --- |
+| `runs the read-only comprehensive hours preview without write controls` | Mounts admin page, opens the new section, fills `userId`, runs preview, asserts request body, read-only result rendering, violation row, and absence of write buttons. |
+| `jumps to the comprehensive hours preview from the quick selector` | Locks the new section id, quick-jump selection, current-section label, and mounted panel. |
+| Existing admin anchor count tests | Updated from 24 to 25 to prevent accidental nav deletion while adding this section. |
+
+## Commands
+
+```bash
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run \
+  tests/attendance-admin-regressions.spec.ts \
+  tests/attendance-admin-anchor-nav.spec.ts \
+  --watch=false
+
+pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/web build
+git diff --check
+```
+
+## Deferred
+
+- PR4 weak-control warning on schedule save.
+- PR5 strong-control block-save guard.
+- PR6 reporting or multitable snapshot.
+- Staging live UI evidence, after explicit staging credentials and sample users are provided.


### PR DESCRIPTION
## Summary

- Adds a Scheduling admin section for read-only comprehensive-hours preview.
- Calls the existing POST /api/attendance/comprehensive-hours/preview route with explicit user scope, draft cap, period, metric, and policy mode.
- Displays read-only status, aggregate cards, and per-user comparison rows without policy persistence or schedule enforcement.

## Boundaries

- Frontend-only runtime change; no plugin/backend route edits.
- No attendance_* migration and no meta_* writes.
- No all-users batch scope, save warning, save block, or multitable snapshot.

## Test plan

- [x] NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts tests/attendance-admin-anchor-nav.spec.ts --watch=false
- [x] pnpm --filter @metasheet/web type-check
- [x] pnpm --filter @metasheet/web build
- [x] git diff --check

## Review request

Please ask Claude for independent review focused on: read-only UI boundary, request body compatibility with #1774 preview route, admin rail regression, and absence of save/apply/enforce controls.