### PR TITLE
docs(attendance): lock comprehensive hours warning-only PR4 design

### DIFF
--- a/docs/development/attendance-comprehensive-hours-control-pr3-postmerge-verification-20260522.md
+++ b/docs/development/attendance-comprehensive-hours-control-pr3-postmerge-verification-20260522.md
@@ -1,0 +1,48 @@
+# Attendance Comprehensive Working Hours Control PR3 Post-Merge Verification
+
+Date: 2026-05-22
+Branch checked: `origin/main`
+Merge commit: `29d01e65f477b5d876b9672ac5d85ee4b6febce4`
+
+## Summary
+
+PR3 (`#1777`, admin read-only comprehensive-hours preview UI) is merged to `main`.
+The code and image-build portions are verified, but remote runtime deployment and
+live UI smoke are **not** closed because the deploy host SSH path is currently
+unavailable.
+
+## Verified
+
+| Check | Result |
+| --- | --- |
+| `#1777` PR state | `MERGED` |
+| Merge commit in `origin/main` | PASS: `29d01e65f...` is `origin/main` HEAD at verification time. |
+| PR checks before merge | PASS: Node 18, Node 20, coverage, e2e, contracts, after-sales, DingTalk P4, K3 WISE all green; Strict E2E skipped by rule. |
+| Docker image build/push | PASS inside run `26319033603`: backend and frontend build/push steps both succeeded. |
+| `Deploy to Production` workflow | PASS for run `26319033530`, but this workflow is a minimal/stub deployment gate and is not sufficient as runtime deployment evidence. |
+
+## Not Verified
+
+| Check | Result |
+| --- | --- |
+| Real remote deploy through `Build and Push Docker Images` | FAIL/BLOCKED: run `26319033603` failed in deploy job before remote deploy. |
+| Failure point | `Sync deploy host files` failed: `ssh: connect to host *** port 22: Connection timed out` in GitHub Actions. |
+| Direct health probe | Inconclusive: `http://142.171.239.56:8081/api/health` and `:8082` returned `Empty reply from server`; HTTPS timed out. |
+| Local SSH probe | Failed: `Connection closed by 142.171.239.56 port 22`. |
+| Live admin UI smoke | Not run; no verified running host containing `29d01e65f...` was reachable. |
+
+## Operational Follow-Up
+
+Before claiming production runtime evidence for PR3:
+
+1. Restore/confirm deploy-host SSH reachability from GitHub Actions or rerun the deploy from an allowed network path.
+2. Rerun the `Build and Push Docker Images` workflow for a commit that includes `29d01e65f...`.
+3. Confirm remote runtime image/tag includes the PR3 merge commit.
+4. Run an admin UI smoke:
+   - open Attendance admin
+   - navigate to `Scheduling -> Comprehensive hours`
+   - enter one known sample `userId`
+   - preview both `planned` and `actual`
+   - confirm read-only result rendering and no Save/Apply/Enforce write controls
+
+This is a deployment/connectivity gap, not a PR3 code regression.

--- a/docs/development/attendance-comprehensive-hours-control-pr4-warning-design-20260522.md
+++ b/docs/development/attendance-comprehensive-hours-control-pr4-warning-design-20260522.md
@@ -1,0 +1,125 @@
+# Attendance Comprehensive Working Hours Control PR4 Warning Design
+
+Date: 2026-05-22
+Branch: `codex/attendance-comprehensive-hours-pr4-design-lock-20260522`
+
+## Summary
+
+PR4 is the first comprehensive-hours slice that may touch schedule-save UX. It
+must remain a **weak-control warning** only. It may surface planned
+comprehensive-hours over-cap warnings before or during schedule save, but it
+must not block persistence, alter schedule write semantics, or persist a
+comprehensive-hours policy.
+
+This document is a design lock. Runtime implementation requires a separate
+explicit go after review.
+
+## Current Foundation
+
+| Slice | Status | Role |
+| --- | --- | --- |
+| PR0 RFC | Merged | Product/technical roadmap. |
+| PR1 helpers `#1770` | Merged | Pure comprehensive-hours calculators. |
+| PR2 preview route `#1774` | Merged | Read-only backend preview route. |
+| PR2.5 enum strictness `#1776` | Merged | Backend rejects invalid enum values instead of defaulting. |
+| PR3 admin UI `#1777` | Merged | Read-only admin preview panel. |
+
+## PR4 Objective
+
+When an admin is editing or saving schedule data, show a warning if the planned
+minutes for affected users exceed a draft comprehensive-hours cap for the
+selected period.
+
+The warning should answer:
+
+- who is affected
+- which period was checked
+- planned minutes vs cap
+- warning or violation status
+- that saving is still allowed in PR4
+
+## Hard Boundaries
+
+| Boundary | Requirement |
+| --- | --- |
+| Weak control only | Save must remain allowed even when preview status is `warning` or `violation`. |
+| No policy persistence | Do not add settings storage, catalog rows, migrations, or localStorage-backed policy persistence. |
+| No backend block | Do not reject schedule save based on comprehensive-hours status. |
+| No route multiplication | Reuse `POST /api/attendance/comprehensive-hours/preview`; do not add another comprehensive-hours calculation endpoint. |
+| No actual-minute enforcement | PR4 warning uses planned metric only. Actual metric remains reporting/read-only. |
+| Explicit scope | No all-users batch in save flow. Scope should be derived from the edited assignment user(s), capped by backend preview limits. |
+| Existing write semantics | Existing schedule save success/failure behavior must remain unchanged. |
+| PR5 deferred | Strong block-save guard remains a separate explicit opt-in slice. |
+
+## Candidate Touch Points
+
+PR4 should inspect the smallest save surfaces that create or update planned
+schedule minutes:
+
+| Surface | Existing shape | PR4 behavior |
+| --- | --- | --- |
+| Shift assignment save | single assignment user + date range | Preview the assignment user's planned period, show warning banner if over cap, still save. |
+| Rotation assignment save | single assignment user + date range | Same as shift assignment. |
+| Advanced scheduling workbench | read-only | No PR4 write behavior. May link operators back to preview UI only. |
+
+Do not start with batch import, Excel-like grid edit, temporary line-draw shifts,
+or all-users scheduler actions. Those are separate advanced-scheduling write
+surfaces and remain outside PR4.
+
+## Warning Flow
+
+1. User edits a shift or rotation assignment.
+2. UI derives a draft preview request:
+   - `metric: 'planned'`
+   - `scope: { userId }`
+   - `period`: selected period from UI, or a conservative period inferred from
+     assignment range only if product copy clearly labels it as inferred
+   - `policyDraft`: cap/enforcement from in-memory form state only
+3. UI calls `POST /api/attendance/comprehensive-hours/preview`.
+4. If preview returns `warning` or `violation`, show a warning panel near the save
+   button.
+5. Save button remains enabled and still calls the original save function.
+6. Optional: save completion may include a non-blocking toast that warnings were
+   advisory.
+
+## UX Copy Requirements
+
+Warning text must avoid implying enforcement:
+
+- Good: `Comprehensive-hours warning: planned minutes exceed the draft cap. Saving is still allowed in this stage.`
+- Bad: `Blocked`, `Cannot save`, `Policy enforced`, `Violation prevented`.
+
+The panel must include a clear read-only/advisory marker and, where possible,
+link to the PR3 comprehensive-hours preview section for deeper inspection.
+
+## Error Handling
+
+| Preview result | PR4 behavior |
+| --- | --- |
+| `ok` | Show no warning, or show a compact OK status if preview was user-triggered. |
+| `warning` / `violation` | Show advisory warning. Save remains allowed. |
+| `400` validation | Show local preview error; save remains governed by existing save validation only. |
+| `503 DB_NOT_READY` | Show schema-readiness warning; save remains allowed. |
+| network/error | Show preview unavailable warning; save remains allowed. |
+
+## Test Requirements For Runtime PR
+
+The implementation PR must include tests that prove:
+
+- warning preview calls the existing `/comprehensive-hours/preview` route
+- request body uses `metric: 'planned'`
+- warning/violation renders advisory copy
+- save remains enabled after warning/violation
+- original save function still runs after warning/violation
+- preview errors do not block save
+- no `allUsers` request body is emitted
+- no new backend route, migration, or policy persistence is added
+
+## Out Of Scope
+
+- PR5 strong-control block-save guard
+- stored comprehensive-hours policies
+- scheduler role permissions
+- all-users batch preview in save flows
+- period summary/multitable snapshots
+- advanced scheduling grid edit, copy/paste, import, temporary shift drawing

--- a/docs/development/attendance-comprehensive-hours-control-pr4-warning-verification-20260522.md
+++ b/docs/development/attendance-comprehensive-hours-control-pr4-warning-verification-20260522.md
@@ -1,0 +1,54 @@
+# Attendance Comprehensive Working Hours Control PR4 Warning Verification
+
+Date: 2026-05-22
+Branch: `codex/attendance-comprehensive-hours-pr4-design-lock-20260522`
+
+## Scope Verified
+
+This is a docs-only design-lock slice. It does not implement runtime PR4.
+
+| Check | Result |
+| --- | --- |
+| Runtime code | Not changed. |
+| Backend/plugin files | Not changed. |
+| Frontend files | Not changed. |
+| Migrations | None. |
+| `meta_*` writes | None. |
+| Tests | Not required for docs-only slice. |
+
+## Added Artifacts
+
+| File | Purpose |
+| --- | --- |
+| `attendance-comprehensive-hours-control-pr3-postmerge-verification-20260522.md` | Records #1777 merge/deploy evidence and the current remote-deploy blocker. |
+| `attendance-comprehensive-hours-control-pr4-warning-design-20260522.md` | Locks PR4 as weak-control warning only, with explicit boundaries and runtime test requirements. |
+| `attendance-comprehensive-hours-control-pr4-warning-verification-20260522.md` | This verification note. |
+
+## Verification Commands
+
+```bash
+git diff --check
+git diff --name-only
+```
+
+Expected changed files are docs under `docs/development/` only.
+
+## Runtime Preconditions Before PR4 Implementation
+
+Before runtime PR4 begins:
+
+1. Claude or another independent reviewer should approve the warning-only design
+   boundary.
+2. The implementation PR must re-check the current save surfaces in
+   `AttendanceView.vue` before editing.
+3. The implementation PR must include tests proving preview warnings do not block
+   save.
+4. PR5 block-save behavior must remain deferred unless the user explicitly
+   authorizes it.
+
+## Deployment Note
+
+The preceding PR3 post-merge check found that #1777 is merged and image build/push
+succeeded, but the real remote deploy workflow failed at deploy-host SSH timeout.
+That blocker should be resolved before claiming production runtime evidence for
+the PR3 UI.


### PR DESCRIPTION
## Summary

- Records #1777 post-merge verification: merged to main, PR checks green, image build/push succeeded, but real remote deploy is blocked by deploy-host SSH timeout.
- Adds PR4 design-lock docs for comprehensive-hours weak-control warning only.
- Adds verification docs for this docs-only slice.

## Boundaries

- Docs only.
- No runtime code, plugin/backend/frontend changes, migrations, or meta_* writes.
- PR4 runtime implementation is not started here.
- PR5 block-save behavior remains deferred pending explicit opt-in.

## Verification

- [x] git diff --check
- [x] Staged files are docs/development only
- [x] Secret scan over staged diff: no JWT/token/private key/home-path literals

## Review request

Please ask Claude to review that PR4 remains warning-only: save must remain allowed, no policy persistence, no new route, planned metric only, explicit user scope only, and PR5 strong block remains deferred.