### PR TITLE
feat(attendance): render effective-calendar day and overlay badges

### DIFF
--- a/apps/web/src/multitable/components/MetaCalendarView.vue
+++ b/apps/web/src/multitable/components/MetaCalendarView.vue
@@ -60,18 +60,29 @@
             </div>
             <div v-if="cell.holidays.length" class="meta-calendar__holidays">
               <span
-                v-for="holiday in cell.holidays.slice(0, 2)"
-                :key="`${cell.dateStr}-${holiday.id}`"
+                v-for="entry in calendarHolidayDisplays(cell.holidays, 2)"
+                :key="`${cell.dateStr}-${entry.holiday.id}`"
                 class="meta-calendar__holiday"
                 :class="[
-                  holiday.isWorkingDay ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest',
-                  hasOverrideMarker(holiday) ? 'meta-calendar__holiday--overridden' : null,
-                  holiday.overlays && holiday.overlays.length ? 'meta-calendar__holiday--with-overlay' : null,
-                  calendarChipSourceClassName(holiday.effective?.source),
+                  entry.display.dayBadge?.kind === 'work' ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest',
+                  entry.display.hasOverride ? 'meta-calendar__holiday--overridden' : null,
+                  entry.display.hasOverlay ? 'meta-calendar__holiday--with-overlay' : null,
+                  entry.display.sourceClass,
                 ]"
-                :title="buildHolidayTooltip(holiday)"
+                :title="entry.display.tooltip"
               >
-                {{ holiday.name || fallbackHolidayName(holiday) }}
+                <span v-if="entry.display.title" class="meta-calendar__holiday-title">{{ entry.display.title }}</span>
+                <span
+                  v-if="entry.display.dayBadge"
+                  class="meta-calendar__holiday-day-badge"
+                  :class="`meta-calendar__holiday-day-badge--${entry.display.dayBadge.kind}`"
+                >{{ entry.display.dayBadge.text }}</span>
+                <span
+                  v-for="overlay in entry.display.overlayBadges.slice(0, 2)"
+                  :key="`${entry.holiday.id}-${overlay.kind}`"
+                  class="meta-calendar__holiday-overlay-badge"
+                  :class="overlay.className"
+                >{{ overlay.text }}</span>
               </span>
             </div>
             <div class="meta-calendar__events">
@@ -147,18 +158,29 @@
             </div>
             <div v-if="cell.holidays.length" class="meta-calendar__holidays">
               <span
-                v-for="holiday in cell.holidays.slice(0, 2)"
-                :key="`${cell.dateStr}-${holiday.id}`"
+                v-for="entry in calendarHolidayDisplays(cell.holidays, 2)"
+                :key="`${cell.dateStr}-${entry.holiday.id}`"
                 class="meta-calendar__holiday"
                 :class="[
-                  holiday.isWorkingDay ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest',
-                  hasOverrideMarker(holiday) ? 'meta-calendar__holiday--overridden' : null,
-                  holiday.overlays && holiday.overlays.length ? 'meta-calendar__holiday--with-overlay' : null,
-                  calendarChipSourceClassName(holiday.effective?.source),
+                  entry.display.dayBadge?.kind === 'work' ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest',
+                  entry.display.hasOverride ? 'meta-calendar__holiday--overridden' : null,
+                  entry.display.hasOverlay ? 'meta-calendar__holiday--with-overlay' : null,
+                  entry.display.sourceClass,
                 ]"
-                :title="buildHolidayTooltip(holiday)"
+                :title="entry.display.tooltip"
               >
-                {{ holiday.name || fallbackHolidayName(holiday) }}
+                <span v-if="entry.display.title" class="meta-calendar__holiday-title">{{ entry.display.title }}</span>
+                <span
+                  v-if="entry.display.dayBadge"
+                  class="meta-calendar__holiday-day-badge"
+                  :class="`meta-calendar__holiday-day-badge--${entry.display.dayBadge.kind}`"
+                >{{ entry.display.dayBadge.text }}</span>
+                <span
+                  v-for="overlay in entry.display.overlayBadges.slice(0, 2)"
+                  :key="`${entry.holiday.id}-${overlay.kind}`"
+                  class="meta-calendar__holiday-overlay-badge"
+                  :class="overlay.className"
+                >{{ overlay.text }}</span>
               </span>
             </div>
             <div class="meta-calendar__events">
@@ -216,18 +238,29 @@
             <div v-if="activeDayCell.lunarLabel || activeDayCell.holidays.length" class="meta-calendar__day-calendar-meta">
               <span v-if="activeDayCell.lunarLabel" class="meta-calendar__lunar">{{ activeDayCell.lunarLabel }}</span>
               <span
-                v-for="holiday in activeDayCell.holidays"
-                :key="`${activeDayCell.dateStr}-${holiday.id}`"
+                v-for="entry in calendarHolidayDisplays(activeDayCell.holidays)"
+                :key="`${activeDayCell.dateStr}-${entry.holiday.id}`"
                 class="meta-calendar__holiday"
                 :class="[
-                  holiday.isWorkingDay ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest',
-                  hasOverrideMarker(holiday) ? 'meta-calendar__holiday--overridden' : null,
-                  holiday.overlays && holiday.overlays.length ? 'meta-calendar__holiday--with-overlay' : null,
-                  calendarChipSourceClassName(holiday.effective?.source),
+                  entry.display.dayBadge?.kind === 'work' ? 'meta-calendar__holiday--working' : 'meta-calendar__holiday--rest',
+                  entry.display.hasOverride ? 'meta-calendar__holiday--overridden' : null,
+                  entry.display.hasOverlay ? 'meta-calendar__holiday--with-overlay' : null,
+                  entry.display.sourceClass,
                 ]"
-                :title="buildHolidayTooltip(holiday)"
+                :title="entry.display.tooltip"
               >
-                {{ holiday.name || fallbackHolidayName(holiday) }}
+                <span v-if="entry.display.title" class="meta-calendar__holiday-title">{{ entry.display.title }}</span>
+                <span
+                  v-if="entry.display.dayBadge"
+                  class="meta-calendar__holiday-day-badge"
+                  :class="`meta-calendar__holiday-day-badge--${entry.display.dayBadge.kind}`"
+                >{{ entry.display.dayBadge.text }}</span>
+                <span
+                  v-for="overlay in entry.display.overlayBadges.slice(0, 2)"
+                  :key="`${entry.holiday.id}-${overlay.kind}`"
+                  class="meta-calendar__holiday-overlay-badge"
+                  :class="overlay.className"
+                >{{ overlay.text }}</span>
               </span>
             </div>
             <div class="meta-calendar__day-meta">{{ calendarEventCount(currentDayEvents.length, isZh) }}</div>
@@ -311,10 +344,8 @@ import type {
   CalendarEffectiveChip,
 } from '../../services/attendance/effectiveCalendar'
 import {
-  buildCalendarChipTooltip,
-  calendarChipSourceClassName,
-  fallbackChipName,
-  hasCalendarChipOverrideMarker,
+  buildCalendarChipDisplay,
+  type CalendarChipDisplayModel,
 } from '../../services/attendance/calendarChipDisplay'
 import MetaAttachmentList from './MetaAttachmentList.vue'
 import MetaCommentActionChip from './MetaCommentActionChip.vue'
@@ -633,16 +664,21 @@ function rangeFromCells(cells: CalendarCell[]): CalendarVisibleRange | null {
   }
 }
 
-// PR2: chip-display helpers (fallback name, override marker, tooltip,
-// source class) are extracted to apps/web/src/services/attendance/calendarChipDisplay.ts
-// so the multitable Calendar view and attendance personal calendar share one
-// implementation. The PR1 visual contract (red/green base + dotted override
-// + overlay dot) is preserved; PR2 adds the source border-left accent via
-// the shared `calendar-source--{source}` class.
+interface CalendarHolidayDisplayEntry {
+  holiday: CalendarEffectiveChip
+  display: CalendarChipDisplayModel
+}
 
-const fallbackHolidayName = fallbackChipName
-const hasOverrideMarker = hasCalendarChipOverrideMarker
-const buildHolidayTooltip = buildCalendarChipTooltip
+function calendarHolidayDisplays(
+  holidays: CalendarEffectiveChip[],
+  limit?: number,
+): CalendarHolidayDisplayEntry[] {
+  const items = typeof limit === 'number' ? holidays.slice(0, limit) : holidays
+  return items.map((holiday) => ({
+    holiday,
+    display: buildCalendarChipDisplay(holiday, { isZh: isZh.value }),
+  }))
+}
 
 function onPickDateField(e: Event) {
   const val = (e.target as HTMLSelectElement).value
@@ -722,7 +758,7 @@ function cellAriaLabel(cell: CalendarCell): string {
   const total = cell.events.length + cell.overflow
   const annotations = [
     cell.lunarLabel,
-    ...cell.holidays.map((holiday) => holiday.name || fallbackHolidayName(holiday)),
+    ...cell.holidays.map((holiday) => buildCalendarChipDisplay(holiday, { isZh: isZh.value }).ariaLabel),
   ].filter((item): item is string => Boolean(item))
   return calendarCellAriaLabel(dateLabel, annotations, total, isZh.value)
 }
@@ -787,14 +823,24 @@ function onCellKeydown(e: KeyboardEvent, cellIdx: number, cells: CalendarCell[])
 .meta-calendar__lunar { color: #8a5c2e; font-size: 10px; line-height: 1.25; white-space: nowrap; }
 .meta-calendar__holidays,
 .meta-calendar__day-calendar-meta { display: flex; align-items: center; gap: 4px; flex-wrap: wrap; margin-bottom: 3px; }
-.meta-calendar__holiday { display: inline-flex; align-items: center; max-width: 100%; padding: 1px 5px; border-radius: 999px; font-size: 10px; line-height: 1.35; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
+.meta-calendar__holiday { display: inline-flex; align-items: center; gap: 3px; max-width: 100%; padding: 1px 5px; border-radius: 999px; font-size: 10px; line-height: 1.35; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; }
 .meta-calendar__holiday--rest { background: #ffe8e8; color: #9a1a1a; }
 .meta-calendar__holiday--working { background: #e5f7ec; color: #15693a; }
-/* Minimal override marker (PR1 scope C): dotted bottom-border + cursor:help so
- * the user notices a layered policy and the native title tooltip discloses the
- * full chain. Source coloring palette is intentionally deferred to PR2. */
+.meta-calendar__holiday-title { min-width: 0; overflow: hidden; text-overflow: ellipsis; }
+.meta-calendar__holiday-day-badge,
+.meta-calendar__holiday-overlay-badge { display: inline-flex; align-items: center; justify-content: center; min-width: 1.2em; padding: 0 3px; border-radius: 999px; font-weight: 700; line-height: 1.2; flex-shrink: 0; }
+.meta-calendar__holiday-day-badge--rest { background: rgba(215, 58, 74, 0.16); color: #9a1a1a; }
+.meta-calendar__holiday-day-badge--work { background: rgba(34, 197, 94, 0.16); color: #15693a; }
+.meta-calendar__holiday-overlay-badge { color: #fff; }
+.meta-calendar__holiday-overlay-badge.calendar-overlay--leave { background: #2563eb; }
+.meta-calendar__holiday-overlay-badge.calendar-overlay--overtime { background: #f97316; }
+.meta-calendar__holiday-overlay-badge.calendar-overlay--correction { background: #6b7280; }
+.meta-calendar__holiday-overlay-badge.calendar-overlay--business-trip { background: #7c3aed; }
+.meta-calendar__holiday-overlay-badge.calendar-overlay--training { background: #0891b2; }
+/* Minimal override marker: dotted bottom-border + cursor:help so the user
+ * notices a layered policy and the native title tooltip discloses the chain. */
 .meta-calendar__holiday--overridden { border-bottom: 1px dotted currentColor; cursor: help; }
-.meta-calendar__holiday--with-overlay::after { content: '·'; margin-left: 3px; opacity: 0.55; }
+.meta-calendar__holiday--with-overlay::after { content: none; }
 .meta-calendar__events { display: flex; flex-direction: column; gap: 2px; }
 .meta-calendar__event { padding: 2px 4px; background: #409eff; color: #fff; border-radius: 3px; font-size: 11px; overflow: hidden; text-overflow: ellipsis; white-space: nowrap; cursor: pointer; display: flex; align-items: center; gap: 6px; }
 .meta-calendar__event:hover { background: #337ecc; }

--- a/apps/web/src/services/attendance/calendarChipDisplay.ts
+++ b/apps/web/src/services/attendance/calendarChipDisplay.ts
@@ -5,14 +5,14 @@
 // Extracted from MetaCalendarView's PR1 inline helpers so the attendance
 // consumers do not duplicate "same logic" (Codex Should-Fix #1 on PR2 plan).
 // Pure functions — no DOM, no Vue, no i18n state. Both UIs accept the same
-// string outputs and decide for themselves how to localize labels later if
-// needed; matching PR1's English fallback convention keeps the contract
-// stable until PR3 introduces i18n.
+// string outputs and provide the current locale explicitly so we do not bind
+// calendar rendering to a Vue composable from this service module.
 
 import type {
   CalendarEffectiveChip,
   CalendarEffectiveLayer,
   CalendarEffectiveOverlay,
+  CalendarEffectiveOverlayKind,
   CalendarEffectiveSource,
 } from './effectiveCalendar'
 
@@ -40,6 +40,316 @@ export function calendarChipSourceClassName(
     // working/rest class only.
     default:
       return undefined
+  }
+}
+
+export type CalendarChipEmployeeSourceCategory = 'national' | 'company-policy'
+export type CalendarChipDayBadgeKind = 'work' | 'rest'
+export type CalendarChipOverlayBadgeKind =
+  | 'leave'
+  | 'overtime'
+  | 'correction'
+  | 'business-trip'
+  | 'training'
+
+export interface BuildCalendarChipDisplayOptions {
+  isZh?: boolean
+  fullDayMinutes?: number
+}
+
+export interface CalendarChipDayBadge {
+  kind: CalendarChipDayBadgeKind
+  text: string
+  label: string
+}
+
+export interface CalendarChipOverlayBadge {
+  kind: CalendarChipOverlayBadgeKind
+  className: string
+  text: string
+  label: string
+  minutes?: number
+  fullDay: boolean
+}
+
+export interface CalendarChipDisplayModel {
+  title?: string
+  dayBadge?: CalendarChipDayBadge
+  overlayBadges: CalendarChipOverlayBadge[]
+  sourceClass?: string
+  tooltip?: string
+  ariaLabel: string
+  visibleText: string
+  hasOverlay: boolean
+  hasOverride: boolean
+}
+
+const GENERATED_DAY_INDEX_NAME_RE = /^(.*?)(?:\s*-\s*|第|\s+DAY\s*)(\d+)(?:天)?$/i
+
+const OVERLAY_DISPLAY: Record<
+  CalendarEffectiveOverlayKind,
+  {
+    kind: CalendarChipOverlayBadgeKind
+    zhShort: string
+    zhLabel: string
+    enLabel: string
+  }
+> = {
+  personal_leave: {
+    kind: 'leave',
+    zhShort: '假',
+    zhLabel: '请假',
+    enLabel: 'Leave',
+  },
+  overtime: {
+    kind: 'overtime',
+    zhShort: '加',
+    zhLabel: '加班',
+    enLabel: 'Overtime',
+  },
+  attendance_correction: {
+    kind: 'correction',
+    zhShort: '补',
+    zhLabel: '补卡',
+    enLabel: 'Correction',
+  },
+  business_trip: {
+    kind: 'business-trip',
+    zhShort: '出',
+    zhLabel: '出差',
+    enLabel: 'Business trip',
+  },
+  training: {
+    kind: 'training',
+    zhShort: '训',
+    zhLabel: '培训',
+    enLabel: 'Training',
+  },
+}
+
+function normalizedText(value: string | null | undefined): string | undefined {
+  if (typeof value !== 'string') return undefined
+  const trimmed = value.trim()
+  return trimmed || undefined
+}
+
+function parseGeneratedDayIndexName(name: string | undefined): { title: string; dayIndex: number } | undefined {
+  if (!name) return undefined
+  const match = name.match(GENERATED_DAY_INDEX_NAME_RE)
+  if (!match) return undefined
+  const dayIndex = Number.parseInt(match[2] ?? '', 10)
+  const title = (match[1] ?? '').trim()
+  if (!Number.isFinite(dayIndex) || dayIndex <= 0 || !title) return undefined
+  return { title, dayIndex }
+}
+
+function hasGeneratedContinuationName(chip: CalendarEffectiveChip): boolean {
+  const baseName = normalizedText(chip.base?.name)
+  const parsed = parseGeneratedDayIndexName(baseName)
+  const dayIndex = chip.base?.dayIndex
+  return Boolean(parsed && typeof dayIndex === 'number' && parsed.dayIndex === dayIndex && dayIndex > 1)
+}
+
+function resolveBaseTitle(chip: CalendarEffectiveChip): string | undefined {
+  const baseName = normalizedText(chip.base?.name)
+  if (!baseName) return undefined
+  const parsed = parseGeneratedDayIndexName(baseName)
+  const dayIndex = chip.base?.dayIndex
+  if (typeof dayIndex === 'number' && parsed?.dayIndex === dayIndex) {
+    if (dayIndex === 1) return parsed.title
+    return undefined
+  }
+  return baseName
+}
+
+function hasCalendarPolicyLayer(chip: CalendarEffectiveChip): boolean {
+  return Array.isArray(chip.layers) && chip.layers.some((layer) => layer.kind === 'calendar_policy')
+}
+
+function resolveTitleLabel(chip: CalendarEffectiveChip): string | undefined {
+  if (!chip.effective && !chip.base && !chip.layers?.length && !chip.overlays?.length) {
+    return normalizedText(chip.name) ?? fallbackChipName(chip)
+  }
+
+  const effectiveLabel = normalizedText(chip.effective?.label)
+  if (hasCalendarPolicyLayer(chip) && effectiveLabel) return effectiveLabel
+
+  const baseTitle = resolveBaseTitle(chip)
+  if (baseTitle) return baseTitle
+
+  if (chip.overlays?.length || hasGeneratedContinuationName(chip)) return undefined
+  return effectiveLabel ?? normalizedText(chip.name)
+}
+
+function resolveEffectiveWorkingDay(chip: CalendarEffectiveChip): boolean | undefined {
+  if (typeof chip.effective?.isWorkingDay === 'boolean') return chip.effective.isWorkingDay
+  if (typeof chip.isWorkingDay === 'boolean') return chip.isWorkingDay
+  if (typeof chip.base?.isWorkingDay === 'boolean') return chip.base.isWorkingDay
+  return undefined
+}
+
+function sourceCategory(source: CalendarEffectiveSource | undefined): CalendarChipEmployeeSourceCategory | undefined {
+  if (source === 'national') return 'national'
+  if (source === 'manual' || source === 'org' || source === 'group' || source === 'role' || source === 'user') {
+    return 'company-policy'
+  }
+  return undefined
+}
+
+export function calendarChipEmployeeSourceClassName(
+  source: CalendarEffectiveSource | undefined,
+): string | undefined {
+  const category = sourceCategory(source)
+  if (category === 'national') return 'calendar-source--national'
+  if (category === 'company-policy') return 'calendar-source--company-policy'
+  return undefined
+}
+
+function dayBadgeLabel(kind: CalendarChipDayBadgeKind, isZh: boolean): string {
+  if (kind === 'work') return isZh ? '工作日' : 'Working day'
+  return isZh ? '休息日' : 'Rest day'
+}
+
+function buildDayBadge(chip: CalendarEffectiveChip, isZh: boolean): CalendarChipDayBadge | undefined {
+  const isWorkingDay = resolveEffectiveWorkingDay(chip)
+  if (typeof isWorkingDay !== 'boolean') return undefined
+  const kind: CalendarChipDayBadgeKind = isWorkingDay ? 'work' : 'rest'
+  return {
+    kind,
+    text: isZh ? (kind === 'work' ? '班' : '休') : '',
+    label: dayBadgeLabel(kind, isZh),
+  }
+}
+
+function normalizeFullDayMinutes(value: number | undefined): number {
+  return typeof value === 'number' && Number.isFinite(value) && value > 0 ? value : 480
+}
+
+function formatDuration(minutes: number): string {
+  if (minutes % 60 === 0) return `${minutes / 60}h`
+  return `${minutes}m`
+}
+
+function buildOverlayBadge(
+  overlay: CalendarEffectiveOverlay,
+  isZh: boolean,
+  fullDayMinutes: number,
+): CalendarChipOverlayBadge {
+  const display = OVERLAY_DISPLAY[overlay.kind]
+  const minutes = typeof overlay.minutes === 'number' && Number.isFinite(overlay.minutes)
+    ? overlay.minutes
+    : undefined
+  const fullDay = typeof minutes === 'number' && minutes === fullDayMinutes
+  const label = normalizedText(overlay.label) ?? (isZh ? display.zhLabel : display.enLabel)
+  const durationText = typeof minutes === 'number' && !fullDay ? ` ${formatDuration(minutes)}` : ''
+  return {
+    kind: display.kind,
+    className: `calendar-overlay--${display.kind}`,
+    text: isZh ? `${display.zhShort}${durationText}` : '',
+    label,
+    minutes,
+    fullDay,
+  }
+}
+
+function describeEmployeeSource(source: CalendarEffectiveSource | undefined, isZh: boolean): string | undefined {
+  switch (source) {
+    case 'national':
+      return isZh ? '法定节假日' : 'Statutory holiday'
+    case 'manual':
+      return isZh ? '公司节假日 · 手动设置' : 'Company calendar · manual'
+    case 'org':
+      return isZh ? '公司节假日 · 组织级日历政策' : 'Company calendar · org policy'
+    case 'group':
+      return isZh ? '公司节假日 · 班组日历政策' : 'Company calendar · group policy'
+    case 'role':
+      return isZh ? '公司节假日 · 角色日历政策' : 'Company calendar · role policy'
+    case 'user':
+      return isZh ? '公司节假日 · 个人日历政策' : 'Company calendar · user policy'
+    default:
+      return undefined
+  }
+}
+
+function describeLayerForLocalizedTooltip(layer: CalendarEffectiveLayer, isZh: boolean): string {
+  const verdict = layer.isWorkingDay ? (isZh ? '班' : 'work') : (isZh ? '休' : 'rest')
+  const label = layer.label ? ` ${layer.label}` : ''
+  return `${layer.source}:${label} (${verdict})`
+}
+
+function buildDisplayTooltip(
+  chip: CalendarEffectiveChip,
+  display: {
+    title?: string
+    dayBadge?: CalendarChipDayBadge
+    overlayBadges: CalendarChipOverlayBadge[]
+  },
+  isZh: boolean,
+): string | undefined {
+  if (!chip.effective && !chip.base && !chip.layers?.length && !chip.overlays?.length) {
+    return undefined
+  }
+  const lines: string[] = []
+  const sourceLabel = describeEmployeeSource(chip.effective?.source ?? chip.base?.source, isZh)
+  const verdictLabel = display.dayBadge?.label
+  const headlineParts = [display.title, verdictLabel, sourceLabel].filter(Boolean)
+  lines.push(`${chip.date}${headlineParts.length ? ` — ${headlineParts.join(' · ')}` : ''}`)
+  const rawBaseName = normalizedText(chip.base?.name)
+  if (!display.title && rawBaseName) {
+    lines.push(`${isZh ? '节日' : 'Holiday'}: ${rawBaseName}`)
+  }
+  if (chip.layers?.length) {
+    lines.push(`${isZh ? '层级' : 'Layers'}: ${chip.layers.map((layer) => describeLayerForLocalizedTooltip(layer, isZh)).join(' → ')}`)
+  }
+  if (display.overlayBadges.length) {
+    const overlayText = display.overlayBadges.map((badge) => {
+      const minutes = typeof badge.minutes === 'number' ? ` · ${badge.minutes}m` : ''
+      return `${badge.label}${minutes}`
+    }).join('; ')
+    lines.push(`${isZh ? '个人状态' : 'Overlays'}: ${overlayText}`)
+  }
+  return lines.join('\n')
+}
+
+function buildAriaLabel(display: {
+  title?: string
+  dayBadge?: CalendarChipDayBadge
+  overlayBadges: CalendarChipOverlayBadge[]
+}, chip: CalendarEffectiveChip): string {
+  const parts = [
+    chip.date,
+    display.title,
+    display.dayBadge?.label,
+    ...display.overlayBadges.map((badge) => badge.label),
+  ].filter(Boolean)
+  return parts.join(' · ')
+}
+
+export function buildCalendarChipDisplay(
+  chip: CalendarEffectiveChip,
+  options: BuildCalendarChipDisplayOptions = {},
+): CalendarChipDisplayModel {
+  const isZh = options.isZh === true
+  const fullDayMinutes = normalizeFullDayMinutes(options.fullDayMinutes)
+  const title = resolveTitleLabel(chip)
+  const dayBadge = buildDayBadge(chip, isZh)
+  const overlayBadges = (chip.overlays ?? []).map((overlay) => buildOverlayBadge(overlay, isZh, fullDayMinutes))
+  const partialDisplay = { title, dayBadge, overlayBadges }
+  const visibleText = [
+    title,
+    dayBadge?.text,
+    ...overlayBadges.map((badge) => badge.text),
+  ].filter(Boolean).join(' ')
+  return {
+    title,
+    dayBadge,
+    overlayBadges,
+    sourceClass: calendarChipEmployeeSourceClassName(chip.effective?.source ?? chip.base?.source),
+    tooltip: buildDisplayTooltip(chip, partialDisplay, isZh),
+    ariaLabel: buildAriaLabel(partialDisplay, chip),
+    visibleText,
+    hasOverlay: overlayBadges.length > 0,
+    hasOverride: hasCalendarChipOverrideMarker(chip),
   }
 }
 

--- a/apps/web/src/services/attendance/effectiveCalendar.ts
+++ b/apps/web/src/services/attendance/effectiveCalendar.ts
@@ -33,6 +33,7 @@ export interface CalendarEffectiveBase {
   isWorkingDay: boolean
   source: CalendarEffectiveSource
   holidayId?: string
+  dayIndex?: number
   name?: string | null
 }
 

--- a/apps/web/src/styles/calendar-source-palette.css
+++ b/apps/web/src/styles/calendar-source-palette.css
@@ -17,6 +17,7 @@
 .calendar-source--group    { --calendar-source-accent: #3a86ff; }
 .calendar-source--role     { --calendar-source-accent: #9b5de5; }
 .calendar-source--user     { --calendar-source-accent: #063070; }
+.calendar-source--company-policy { --calendar-source-accent: #3a86ff; }
 
 /* Generic consume: any element carrying a calendar-source--<kind> class gets
  * a 4px left border accent in the resolved color. Surfaces opt in by adding
@@ -28,6 +29,7 @@
 .calendar-source--org,
 .calendar-source--group,
 .calendar-source--role,
-.calendar-source--user {
+.calendar-source--user,
+.calendar-source--company-policy {
   border-left: 4px solid var(--calendar-source-accent, transparent);
 }

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -644,7 +644,25 @@
               <span v-if="day.statusLabel" class="attendance__calendar-status">{{ day.statusLabel }}</span>
               <span v-else class="attendance__calendar-status attendance__calendar-status--empty">--</span>
               <span v-if="showLunarLabel && day.lunarLabel" class="attendance__calendar-lunar">{{ day.lunarLabel }}</span>
-              <span v-if="showHolidayBadge && day.holidayName" class="attendance__calendar-holiday" :class="day.sourceClass">{{ day.holidayName }}</span>
+              <span
+                v-if="showHolidayBadge && day.calendarDisplay"
+                class="attendance__calendar-holiday"
+                :class="day.calendarDisplay.sourceClass"
+                :title="day.calendarDisplay.tooltip"
+              >
+                <span v-if="day.calendarDisplay.title" class="attendance__calendar-holiday-title">{{ day.calendarDisplay.title }}</span>
+                <span
+                  v-if="day.calendarDisplay.dayBadge"
+                  class="attendance__calendar-holiday-day-badge"
+                  :class="`attendance__calendar-holiday-day-badge--${day.calendarDisplay.dayBadge.kind}`"
+                >{{ day.calendarDisplay.dayBadge.text }}</span>
+                <span
+                  v-for="overlay in day.calendarDisplay.overlayBadges.slice(0, 2)"
+                  :key="overlay.kind"
+                  class="attendance__calendar-holiday-overlay-badge"
+                  :class="overlay.className"
+                >{{ overlay.text }}</span>
+              </span>
             </div>
           </div>
         </div>
@@ -5442,10 +5460,12 @@ import {
   type CalendarEffectiveChip,
 } from '../services/attendance/effectiveCalendar'
 import {
+  buildCalendarChipDisplay,
   buildCalendarChipTooltip,
   calendarChipSourceClassName,
   fallbackChipName,
   hasCalendarChipOverrideMarker,
+  type CalendarChipDisplayModel,
 } from '../services/attendance/calendarChipDisplay'
 import {
   buildAttendanceScheduleConflictDiagnostics,
@@ -6322,10 +6342,6 @@ interface AttendanceComprehensiveHoursPreviewResult {
   degraded?: boolean
 }
 
-// PR2 adds `sourceClass` carrying `calendar-source--{national|manual|org|group|role|user}`
-// (or undefined for plain rule/shift days). The shared palette in
-// apps/web/src/styles/calendar-source-palette.css resolves it to a 4px
-// border-left accent; UI surfaces apply the class without per-component CSS.
 interface CalendarDay {
   key: string
   day: number
@@ -6334,9 +6350,8 @@ interface CalendarDay {
   status?: string
   statusLabel?: string
   tooltip: string
-  holidayName?: string
+  calendarDisplay?: CalendarChipDisplayModel
   lunarLabel?: string
-  sourceClass?: string
 }
 
 interface AttendanceApiError extends Error {
@@ -8421,12 +8436,8 @@ const calendarDays = computed<CalendarDay[]>(() => {
     const chip = calendarEffectiveChipMap.value.get(key)
     let status = record?.status
     let statusLabel = status ? formatStatus(status) : undefined
-    const holidayName = typeof chip?.name === 'string' && chip.name.trim().length > 0
-      ? chip.name.trim()
-      : undefined
+    const calendarDisplay = chip ? buildCalendarChipDisplay(chip, { isZh: isZh.value }) : undefined
     const lunarLabel = formatLunarDayLabel(date)
-    const chipTooltip = chip ? buildCalendarChipTooltip(chip) : undefined
-    const sourceClass = calendarChipSourceClassName(chip?.effective?.source)
     let tooltip = record
       ? `${key} · ${statusLabel} · ${record.work_minutes} min`
       : key
@@ -8436,13 +8447,13 @@ const calendarDays = computed<CalendarDay[]>(() => {
       // Prefer the layer-chain tooltip when the chip exposes effective fields
       // so users can see "national rest → org override" without leaving the
       // cell; fall back to the legacy text otherwise.
-      tooltip = chipTooltip
-        ?? (holidayName ? `${key} · ${holidayName}` : `${key} · ${tr('Holiday', '休息日')}`)
-    } else if (record && status === 'off' && holidayName) {
-      tooltip = chipTooltip
-        ?? `${key} · ${holidayName} · ${record.work_minutes} min`
-    } else if (chipTooltip) {
-      tooltip = chipTooltip
+      tooltip = calendarDisplay?.tooltip
+        ?? (calendarDisplay?.visibleText ? `${key} · ${calendarDisplay.visibleText}` : `${key} · ${tr('Holiday', '休息日')}`)
+    } else if (record && status === 'off' && calendarDisplay?.visibleText) {
+      tooltip = calendarDisplay.tooltip
+        ?? `${key} · ${calendarDisplay.visibleText} · ${record.work_minutes} min`
+    } else if (calendarDisplay?.tooltip) {
+      tooltip = calendarDisplay.tooltip
     }
     return {
       key,
@@ -8452,9 +8463,8 @@ const calendarDays = computed<CalendarDay[]>(() => {
       status,
       statusLabel,
       tooltip,
-      holidayName,
+      calendarDisplay,
       lunarLabel,
-      sourceClass,
     }
   })
 })
@@ -16535,6 +16545,9 @@ const holidaySectionBindings = {
 }
 
 .attendance__calendar-holiday {
+  display: inline-flex;
+  align-items: center;
+  gap: 3px;
   margin-top: auto;
   font-size: 10px;
   color: #b45309;
@@ -16554,6 +16567,59 @@ const holidaySectionBindings = {
   white-space: nowrap;
   overflow: hidden;
   text-overflow: ellipsis;
+}
+
+.attendance__calendar-holiday-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+
+.attendance__calendar-holiday-day-badge,
+.attendance__calendar-holiday-overlay-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 1.2em;
+  padding: 0 3px;
+  border-radius: 999px;
+  font-weight: 700;
+  line-height: 1.2;
+  flex-shrink: 0;
+}
+
+.attendance__calendar-holiday-day-badge--rest {
+  background: rgba(215, 58, 74, 0.16);
+  color: #9a1a1a;
+}
+
+.attendance__calendar-holiday-day-badge--work {
+  background: rgba(34, 197, 94, 0.16);
+  color: #15693a;
+}
+
+.attendance__calendar-holiday-overlay-badge {
+  color: #fff;
+}
+
+.attendance__calendar-holiday-overlay-badge.calendar-overlay--leave {
+  background: #2563eb;
+}
+
+.attendance__calendar-holiday-overlay-badge.calendar-overlay--overtime {
+  background: #f97316;
+}
+
+.attendance__calendar-holiday-overlay-badge.calendar-overlay--correction {
+  background: #6b7280;
+}
+
+.attendance__calendar-holiday-overlay-badge.calendar-overlay--business-trip {
+  background: #7c3aed;
+}
+
+.attendance__calendar-holiday-overlay-badge.calendar-overlay--training {
+  background: #0891b2;
 }
 
 .attendance__calendar-cell--muted {

--- a/apps/web/tests/attendance-selfservice-dashboard.spec.ts
+++ b/apps/web/tests/attendance-selfservice-dashboard.spec.ts
@@ -1,6 +1,7 @@
 import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, nextTick, ref, type App } from 'vue'
 import AttendanceView from '../src/views/AttendanceView.vue'
+import { useLocale } from '../src/composables/useLocale'
 import { apiFetch } from '../src/utils/api'
 
 vi.mock('../src/composables/usePlugins', () => ({
@@ -168,6 +169,35 @@ function installOverviewMock(): void {
     if (url.includes('/api/attendance/reports/requests?')) {
       return jsonResponse(200, { ok: true, data: { items: [] } })
     }
+    if (url.includes('/api/attendance/effective-calendar?')) {
+      return jsonResponse(200, {
+        ok: true,
+        data: {
+          mode: 'userId',
+          from: '2026-03-30',
+          to: '2026-05-03',
+          timezone: 'Asia/Shanghai',
+          items: [
+            {
+              date: '2026-04-05',
+              base: { isWorkingDay: false, source: 'national', name: '清明节-1', holidayId: 'h_qm', dayIndex: 1 },
+              effective: { isWorkingDay: false, source: 'national', label: '清明节-1' },
+              layers: [{ kind: 'holiday', source: 'national', isWorkingDay: false, label: '清明节-1' }],
+              overlays: [],
+            },
+            {
+              date: '2026-04-10',
+              base: { isWorkingDay: true, source: 'rule' },
+              effective: { isWorkingDay: true, source: 'rule' },
+              layers: [{ kind: 'base_rule', source: 'rule', isWorkingDay: true }],
+              overlays: [
+                { kind: 'overtime', source: 'attendance_requests', requestType: 'overtime', minutes: 180, status: 'approved', refId: 'request-approved' },
+              ],
+            },
+          ],
+        },
+      })
+    }
     if (url.includes('/api/attendance/holidays?')) {
       return jsonResponse(200, { ok: true, data: { items: [] } })
     }
@@ -244,6 +274,18 @@ function installZeroStateMock(): void {
     if (url.includes('/api/attendance/reports/requests?')) {
       return jsonResponse(200, { ok: true, data: { items: [] } })
     }
+    if (url.includes('/api/attendance/effective-calendar?')) {
+      return jsonResponse(200, {
+        ok: true,
+        data: {
+          mode: 'userId',
+          from: '2026-03-30',
+          to: '2026-05-03',
+          timezone: 'Asia/Shanghai',
+          items: [],
+        },
+      })
+    }
     if (url.includes('/api/attendance/holidays?')) {
       return jsonResponse(200, { ok: true, data: { items: [] } })
     }
@@ -289,6 +331,7 @@ describe('Attendance self-service dashboard', () => {
     if (app) app.unmount()
     if (container) container.remove()
     HTMLElement.prototype.scrollIntoView = originalScrollIntoView
+    useLocale().setLocale('en')
     vi.useRealTimers()
     app = null
     container = null
@@ -310,6 +353,32 @@ describe('Attendance self-service dashboard', () => {
     expect(container?.querySelector('[data-selfservice-primary-action]')?.textContent).toContain('Resolve anomaly reminders')
     expect(container?.querySelector('[data-selfservice-card="guide"]')?.textContent).toContain('Adjusted')
     expect(container?.querySelector('[data-selfservice-card="guide"]')?.textContent).toContain('manual correction')
+  })
+
+  it('renders effective-calendar holiday anchors and approved overlays in the personal calendar', async () => {
+    useLocale().setLocale('zh-CN')
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi(12)
+
+    const targetInput = container?.querySelector('input[name="targetUserId"]') as HTMLInputElement | null
+    expect(targetInput).toBeTruthy()
+    targetInput!.value = 'user-self'
+    targetInput!.dispatchEvent(new Event('input', { bubbles: true }))
+    findButton(container!, '刷新').click()
+    await flushUi(12)
+
+    const chips = Array.from(container!.querySelectorAll('.attendance__calendar-holiday')) as HTMLElement[]
+    const statutoryChip = chips.find((chip) => chip.textContent?.includes('清明节'))
+    expect(statutoryChip).toBeTruthy()
+    expect(statutoryChip!.textContent).toContain('休')
+    expect(statutoryChip!.textContent?.includes('清明节-1')).toBe(false)
+    expect(statutoryChip!.classList.contains('calendar-source--national')).toBe(true)
+
+    const overtimeChip = chips.find((chip) => chip.textContent?.includes('加 3h'))
+    expect(overtimeChip).toBeTruthy()
+    expect(overtimeChip!.textContent).toContain('班')
+    expect(overtimeChip!.getAttribute('title') ?? '').toContain('加班 · 180m')
   })
 
   it('surfaces anomaly-driven follow-up guidance and request backlog detail', async () => {

--- a/apps/web/tests/calendarChipDisplay.spec.ts
+++ b/apps/web/tests/calendarChipDisplay.spec.ts
@@ -9,7 +9,9 @@
 
 import { describe, expect, it } from 'vitest'
 import {
+  buildCalendarChipDisplay,
   buildCalendarChipTooltip,
+  calendarChipEmployeeSourceClassName,
   calendarChipOriginBadge,
   calendarChipOriginClassName,
   calendarChipSourceClassName,
@@ -34,6 +36,109 @@ describe('calendarChipSourceClassName', () => {
     expect(calendarChipSourceClassName('shift')).toBeUndefined()
     expect(calendarChipSourceClassName('rotation')).toBeUndefined()
     expect(calendarChipSourceClassName(undefined)).toBeUndefined()
+  })
+})
+
+describe('employee calendar chip display', () => {
+  it('collapses non-national sources into the employee company-policy accent', () => {
+    expect(calendarChipEmployeeSourceClassName('national')).toBe('calendar-source--national')
+    for (const source of ['manual', 'org', 'group', 'role', 'user'] as const) {
+      expect(calendarChipEmployeeSourceClassName(source)).toBe('calendar-source--company-policy')
+    }
+    expect(calendarChipEmployeeSourceClassName('rule')).toBeUndefined()
+  })
+
+  it('shows the stripped festival anchor on dayIndex=1 across backend suffix formats', () => {
+    for (const name of ['国庆节-1', '国庆节第1天', '国庆节 DAY1']) {
+      const display = buildCalendarChipDisplay({
+        id: name,
+        date: '2026-10-01',
+        name,
+        isWorkingDay: false,
+        base: { isWorkingDay: false, source: 'national', name, dayIndex: 1 },
+        effective: { isWorkingDay: false, source: 'national', label: name },
+      } as CalendarEffectiveChip, { isZh: true })
+      expect(display.title).toBe('国庆节')
+      expect(display.dayBadge?.text).toBe('休')
+      expect(display.visibleText).toBe('国庆节 休')
+      expect(display.sourceClass).toBe('calendar-source--national')
+    }
+  })
+
+  it('uses only the rest badge for generated holiday continuation days', () => {
+    const display = buildCalendarChipDisplay({
+      id: 'national-2',
+      date: '2026-10-02',
+      name: '国庆节-2',
+      isWorkingDay: false,
+      base: { isWorkingDay: false, source: 'national', name: '国庆节-2', dayIndex: 2 },
+      effective: { isWorkingDay: false, source: 'national', label: '国庆节-2' },
+    } as CalendarEffectiveChip, { isZh: true })
+    expect(display.title).toBeUndefined()
+    expect(display.dayBadge?.text).toBe('休')
+    expect(display.visibleText).toBe('休')
+    expect(display.tooltip).toContain('国庆节-2')
+  })
+
+  it('renders overlay as a secondary badge without reading overlay-derived chip.name', () => {
+    const display = buildCalendarChipDisplay({
+      id: 'leave-1',
+      date: '2026-10-06',
+      name: 'Leave',
+      isWorkingDay: true,
+      base: { isWorkingDay: true, source: 'rule' },
+      effective: { isWorkingDay: true, source: 'rule' },
+      overlays: [{ kind: 'personal_leave', source: 'attendance_requests', minutes: 240, status: 'approved' }],
+    } as CalendarEffectiveChip, { isZh: true })
+    expect(display.title).toBeUndefined()
+    expect(display.dayBadge?.text).toBe('班')
+    expect(display.overlayBadges[0]).toMatchObject({
+      kind: 'leave',
+      text: '假 4h',
+      label: '请假',
+      fullDay: false,
+    })
+    expect(display.visibleText).toBe('班 假 4h')
+    expect(display.tooltip).toContain('个人状态: 请假 · 240m')
+  })
+
+  it('hides overlay duration when minutes equals the configured full-day threshold', () => {
+    const display = buildCalendarChipDisplay({
+      id: 'leave-2',
+      date: '2026-10-07',
+      isWorkingDay: true,
+      base: { isWorkingDay: true, source: 'rule' },
+      effective: { isWorkingDay: true, source: 'rule' },
+      overlays: [{ kind: 'personal_leave', source: 'attendance_requests', minutes: 480 }],
+    } as CalendarEffectiveChip, { isZh: true, fullDayMinutes: 480 })
+    expect(display.overlayBadges[0]?.text).toBe('假')
+    expect(display.overlayBadges[0]?.fullDay).toBe(true)
+  })
+
+  it('keeps English short badges empty while preserving tooltip detail', () => {
+    const display = buildCalendarChipDisplay({
+      id: 'ot-1',
+      date: '2026-10-08',
+      name: 'Overtime',
+      isWorkingDay: true,
+      base: { isWorkingDay: true, source: 'rule' },
+      effective: { isWorkingDay: true, source: 'rule' },
+      overlays: [{ kind: 'overtime', source: 'attendance_requests', minutes: 120 }],
+    } as CalendarEffectiveChip, { isZh: false })
+    expect(display.dayBadge?.text).toBe('')
+    expect(display.overlayBadges[0]?.text).toBe('')
+    expect(display.visibleText).toBe('')
+    expect(display.tooltip).toContain('Overlays: Overtime · 120m')
+  })
+
+  it('falls back to legacy chip name when no effective-calendar fields are present', () => {
+    const display = buildCalendarChipDisplay({
+      id: 'legacy',
+      date: '2026-01-01',
+      isWorkingDay: false,
+    } as CalendarEffectiveChip, { isZh: false })
+    expect(display.title).toBe('Holiday')
+    expect(display.visibleText).toBe('Holiday')
   })
 })
 

--- a/apps/web/tests/effectiveCalendar.spec.ts
+++ b/apps/web/tests/effectiveCalendar.spec.ts
@@ -178,6 +178,18 @@ describe('effectiveCalendarItemToChip + isCalendarEffectiveItemNoteworthy', () =
     expect(chip.layers?.length).toBe(1)
   })
 
+  it('preserves base.dayIndex exposed by the backend wire contract', () => {
+    const item: CalendarEffectiveItem = {
+      date: '2026-10-01',
+      base: { isWorkingDay: false, source: 'national', name: '国庆节-1', holidayId: 'h_1', dayIndex: 1 },
+      effective: { isWorkingDay: false, source: 'national', label: '国庆节-1' },
+      layers: [{ kind: 'holiday', source: 'national', isWorkingDay: false, label: '国庆节-1' }],
+      overlays: [],
+    }
+    const chip = effectiveCalendarItemToChip(item)
+    expect(chip.base?.dayIndex).toBe(1)
+  })
+
   it('prefers effective.label when both base.name and effective.label exist', () => {
     const item: CalendarEffectiveItem = {
       date: '2026-10-05',

--- a/apps/web/tests/multitable-calendar-view.spec.ts
+++ b/apps/web/tests/multitable-calendar-view.spec.ts
@@ -257,6 +257,11 @@ describe('MetaCalendarView', () => {
       (el) => el.textContent?.trim() === text,
     ) as HTMLElement | null
   }
+  function findChipContainingText(container: HTMLElement, text: string): HTMLElement | null {
+    return Array.from(container.querySelectorAll('.meta-calendar__holiday')).find(
+      (el) => el.textContent?.includes(text),
+    ) as HTMLElement | null
+  }
 
   it('§4-PR1 case 1: national base chip renders with tooltip naming effective.source=national, no override marker', async () => {
     vi.useFakeTimers()
@@ -281,10 +286,67 @@ describe('MetaCalendarView', () => {
     expect(chip!.classList.contains('meta-calendar__holiday--rest')).toBe(true)
     expect(chip!.classList.contains('meta-calendar__holiday--overridden')).toBe(false)
     expect(chip!.classList.contains('meta-calendar__holiday--with-overlay')).toBe(false)
+    expect(chip!.classList.contains('calendar-source--national')).toBe(true)
     const title = chip!.getAttribute('title') ?? ''
     expect(title).toContain('2026-10-01')
-    expect(title).toContain('national')
+    expect(title).toContain('Statutory holiday')
     expect(title).toContain('Rest day')
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('PR-B: generated holiday dayIndex=1 keeps the festival anchor visible plus the rest badge', async () => {
+    useLocale().setLocale('zh-CN')
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-10-02T00:00:00Z'))
+
+    const { app, container } = mountChipCalendar([
+      {
+        id: 'h_nat_cn',
+        date: '2026-10-01',
+        name: '国庆节-1',
+        isWorkingDay: false,
+        base: { isWorkingDay: false, source: 'national', name: '国庆节-1', holidayId: 'h_nat_cn', dayIndex: 1 },
+        effective: { isWorkingDay: false, source: 'national', label: '国庆节-1' },
+        layers: [{ kind: 'holiday', source: 'national', isWorkingDay: false, label: '国庆节-1' }],
+        overlays: [],
+      },
+    ])
+    await nextTick()
+
+    const chip = findChipContainingText(container, '国庆节')
+    expect(chip).not.toBeNull()
+    expect(chip!.textContent).toContain('休')
+    expect(chip!.textContent?.includes('国庆节-1')).toBe(false)
+    expect(chip!.classList.contains('calendar-source--national')).toBe(true)
+
+    app.unmount()
+    container.remove()
+  })
+
+  it('PR-B: generated holiday continuation days show only the rest badge and keep raw holiday name in tooltip', async () => {
+    useLocale().setLocale('zh-CN')
+    vi.useFakeTimers()
+    vi.setSystemTime(new Date('2026-10-03T00:00:00Z'))
+
+    const { app, container } = mountChipCalendar([
+      {
+        id: 'h_nat_cn_2',
+        date: '2026-10-02',
+        name: '国庆节 DAY2',
+        isWorkingDay: false,
+        base: { isWorkingDay: false, source: 'national', name: '国庆节 DAY2', holidayId: 'h_nat_cn_2', dayIndex: 2 },
+        effective: { isWorkingDay: false, source: 'national', label: '国庆节 DAY2' },
+        layers: [{ kind: 'holiday', source: 'national', isWorkingDay: false, label: '国庆节 DAY2' }],
+        overlays: [],
+      },
+    ])
+    await nextTick()
+
+    const chip = findChipByText(container, '休')
+    expect(chip).not.toBeNull()
+    expect(chip!.getAttribute('title') ?? '').toContain('国庆节 DAY2')
 
     app.unmount()
     container.remove()
@@ -315,6 +377,7 @@ describe('MetaCalendarView', () => {
     expect(chip).not.toBeNull()
     expect(chip!.classList.contains('meta-calendar__holiday--working')).toBe(true)
     expect(chip!.classList.contains('meta-calendar__holiday--overridden')).toBe(true)
+    expect(chip!.classList.contains('calendar-source--company-policy')).toBe(true)
     const title = chip!.getAttribute('title') ?? ''
     expect(title).toContain('national:')
     expect(title).toContain('National Day')
@@ -350,6 +413,7 @@ describe('MetaCalendarView', () => {
     expect(chip).not.toBeNull()
     expect(chip!.classList.contains('meta-calendar__holiday--rest')).toBe(true)
     expect(chip!.classList.contains('meta-calendar__holiday--overridden')).toBe(true)
+    expect(chip!.classList.contains('calendar-source--company-policy')).toBe(true)
     const title = chip!.getAttribute('title') ?? ''
     expect(title).toContain('group:')
 
@@ -380,6 +444,7 @@ describe('MetaCalendarView', () => {
 
     const chip = findChipByText(container, 'User confirm')
     expect(chip!.classList.contains('meta-calendar__holiday--overridden')).toBe(true)
+    expect(chip!.classList.contains('calendar-source--company-policy')).toBe(true)
     const title = chip!.getAttribute('title') ?? ''
     expect(title).toContain('user:')
     expect(title).toContain('User confirm')
@@ -409,13 +474,14 @@ describe('MetaCalendarView', () => {
     ])
     await nextTick()
 
-    const chip = findChipByText(container, 'Leave + OT')
+    const chip = findChipByText(container, 'Manual rest')
     expect(chip!.classList.contains('meta-calendar__holiday--with-overlay')).toBe(true)
+    expect(chip!.classList.contains('calendar-source--company-policy')).toBe(true)
     const title = chip!.getAttribute('title') ?? ''
     expect(title).toContain('Overlays:')
-    expect(title).toContain('personal_leave')
+    expect(title).toContain('Leave')
     expect(title).toContain('240m')
-    expect(title).toContain('overtime')
+    expect(title).toContain('Overtime')
     expect(title).toContain('180m')
 
     app.unmount()
@@ -423,6 +489,7 @@ describe('MetaCalendarView', () => {
   })
 
   it('§4-PR1 case 5b: overlay-only rule day renders the overlay label (not generic "Working day") and keeps --with-overlay', async () => {
+    useLocale().setLocale('zh-CN')
     vi.useFakeTimers()
     vi.setSystemTime(new Date('2026-08-16T00:00:00Z'))
 
@@ -446,15 +513,17 @@ describe('MetaCalendarView', () => {
     ])
     await nextTick()
 
-    const chip = findChipByText(container, 'Leave')
+    const chip = findChipContainingText(container, '假 4h')
     expect(chip).not.toBeNull()
     expect(chip!.classList.contains('meta-calendar__holiday--working')).toBe(true)
     expect(chip!.classList.contains('meta-calendar__holiday--overridden')).toBe(false)
     expect(chip!.classList.contains('meta-calendar__holiday--with-overlay')).toBe(true)
-    // No generic "Working day" fallback should be shown
+    expect(chip!.textContent).toContain('班')
+    // No legacy overlay-derived chip.name or generic fallback should be shown.
+    expect(chip!.textContent?.includes('Leave')).toBe(false)
     expect(chip!.textContent?.includes('Working day')).toBe(false)
     const title = chip!.getAttribute('title') ?? ''
-    expect(title).toContain('personal_leave')
+    expect(title).toContain('请假')
     expect(title).toContain('240m')
 
     app.unmount()

--- a/docs/development/attendance-calendar-double-badge-design-20260522.md
+++ b/docs/development/attendance-calendar-double-badge-design-20260522.md
@@ -1,0 +1,458 @@
+# Attendance Calendar Double-Badge Design (PR-B)
+
+Date: 2026-05-22
+Branch: `frontend/attendance-calendar-double-badge-design-20260522`
+Base: `origin/main@2d939402d`
+Status: design draft; no implementation yet
+
+## 1. Goal
+
+Make attendance calendar chips communicate three separate facts without mixing them:
+
+1. Day-level calendar verdict: whether this date is effectively a working day.
+2. Holiday/source provenance: whether the verdict came from statutory holiday data or company policy.
+3. Personal overlays: approved leave, overtime, attendance correction, business trip, or training on that date.
+
+The target user-facing examples:
+
+- National Day anchor: `10-01` can show `国庆节` and `休`.
+- Holiday rest period: `09-29` through `10-05` can show a red `休` even when only some dates are the named festival anchor.
+- Makeup workday: `10-08` can show a green `班`.
+- Company Saturday workday override can also show `班`, but with company provenance in tooltip/accent.
+- Approved leave on a normal workday should show `班` plus a secondary `假`, not replace the calendar verdict.
+
+## 2. Current Code Anchors
+
+| Area | Current state | Anchor |
+| --- | --- | --- |
+| Backend effective calendar | `GET /api/attendance/effective-calendar` composes base holiday/rule, calendar policy layers, and approved request overlays. | `plugins/plugin-attendance/index.cjs:10907`, `:11320` |
+| Approved overlays | Only approved `attendance_requests` are loaded; request types map to `personal_leave`, `overtime`, and `attendance_correction`. | `plugins/plugin-attendance/index.cjs:10927`, `:11019`, `:11407` |
+| User-specific groups | `userId` mode loads `attendanceGroups` from `attendance_group_members`, so different groups can resolve different holiday lengths. | `plugins/plugin-attendance/index.cjs:11048`, `:11359` |
+| Calendar policy scope | `userId` mode allows `org`, `group`, `role`, `user`; `groupId` mode allows `group`; `orgOnly` allows `org`. | `plugins/plugin-attendance/index.cjs:10921` |
+| Frontend effective item type | `CalendarEffectiveItem` carries `base`, `effective`, `layers`, and `overlays`. `CalendarEffectiveBase` does not yet declare `dayIndex`; PR-B must extend the TS type to expose the field already returned on the wire by `buildCalendarBaseFromHoliday()`. | `apps/web/src/services/attendance/effectiveCalendar.ts:32`, `plugins/plugin-attendance/index.cjs:11290` |
+| Current overlay chip issue | `effectiveCalendarItemToChip()` can set `chip.name` from the first overlay label when no base/effective label exists. That makes overlay the primary visible message. | `apps/web/src/services/attendance/effectiveCalendar.ts:154`, `:177` |
+| Current chip tooltip | Tooltip already lists layer chain and overlays, but text is English/raw and not employee-friendly. | `apps/web/src/services/attendance/calendarChipDisplay.ts:93` |
+| Multitable Calendar render | `MetaCalendarView` renders one text node per chip and only adds `--with-overlay` as a small dot. | `apps/web/src/multitable/components/MetaCalendarView.vue:61`, `:790` |
+| Attendance personal calendar | `AttendanceView` uses effective-calendar chips, but only exposes one `holidayName` string. | `apps/web/src/views/AttendanceView.vue:8069`, `:8090` |
+| Source palette | 6 fine-grained source colors already exist: `national`, `manual`, `org`, `group`, `role`, `user`. | `apps/web/src/styles/calendar-source-palette.css:14` |
+
+## 3. Scope
+
+In scope:
+
+- Shared display helper(s) for day badge, overlay badges, employee source category, and tooltip text.
+- `MetaCalendarView.vue` double-badge rendering.
+- `AttendanceView.vue` personal calendar double-badge rendering.
+- Optional reuse in assignment preview chips only if it remains mechanical and low churn.
+- Unit/render tests for helpers and both visible consumers.
+- Documentation and verification MD.
+
+Out of scope:
+
+- Backend schema/API changes.
+- Pending/unapproved request visibility.
+- Team availability calendar or cross-user viewer.
+- Admin holiday CRUD source-color semantics; admin surfaces keep 6 fine-grained source colors.
+- Exact statutory festival-anchor data modeling such as `festivalAnchorDate`. See §7.
+
+## 4. Core Decisions
+
+### D1. Preserve API semantics
+
+Do not merge or rewrite `effective.source`.
+
+The API still returns:
+
+```ts
+type CalendarEffectiveSource =
+  | 'rule'
+  | 'shift'
+  | 'rotation'
+  | 'national'
+  | 'manual'
+  | 'org'
+  | 'group'
+  | 'role'
+  | 'user'
+```
+
+The UI can derive a coarser employee-facing category, but raw source remains available for tooltip, admin, tests, and debugging.
+
+### D2. Two visual layers
+
+Primary day badge answers: "Is this date a workday or rest day?"
+
+Secondary overlay badges answer: "Does this person have approved leave/overtime/correction/etc. on this date?"
+
+Do not let overlay replace day verdict.
+
+| Scenario | Primary | Secondary | Rationale |
+| --- | --- | --- | --- |
+| Normal workday + approved leave | `班` | `假` or `假 4h` | Workday fact remains visible. |
+| Rest day + approved overtime | `休` | `加 8h` | Rest-day fact remains visible. |
+| National Day rest | `国庆节` + `休` | none | `dayIndex === 1` anchor/festival label plus rest verdict. |
+| Company Saturday work override | `班` | none | Company policy changed verdict. |
+| Correction on workday | `班` | `补` | Attendance correction is personal overlay. |
+
+### D3. Employee source category is two-state
+
+Employee-facing calendar surfaces should show source provenance as:
+
+- statutory: `national`
+- company-policy: everything else that is noteworthy (`manual`, `org`, `group`, `role`, `user`)
+
+Admin surfaces keep the existing 6-source palette.
+
+Implementation rule:
+
+- Keep `calendarChipSourceClassName(source)` unchanged for admin/fine-grained consumers.
+- Add a new helper for employee surfaces, for example:
+
+```ts
+export type CalendarChipEmployeeSourceCategory = 'national' | 'company-policy'
+
+export function calendarChipEmployeeSourceClassName(
+  source: CalendarEffectiveSource | undefined,
+): string | undefined
+```
+
+`national` returns `calendar-source--national`; non-national noteworthy company sources return `calendar-source--company-policy`; `rule/shift/rotation/undefined` return `undefined`.
+
+CSS:
+
+```css
+.calendar-source--company-policy { --calendar-source-accent: #3a86ff; }
+```
+
+### D4. Approved overlays only
+
+V1 displays only overlays returned by effective-calendar. Backend currently loads `status = 'approved'` requests only.
+
+Pending requests are deferred. If product later wants pending visibility, it should use a different visual contract, such as dashed/grey secondary badges, because pending is workflow state rather than effective fact.
+
+### D5. Overlay labels are localized and compact
+
+Add localized labels for overlay short badges:
+
+| Overlay kind | EN full | EN short badge | ZH full | ZH short badge |
+| --- | --- | --- | --- | --- |
+| `personal_leave` | Leave | empty | 请假 | `假` |
+| `overtime` | Overtime | empty | 加班 | `加` |
+| `attendance_correction` | Correction | empty | 补卡 | `补` |
+| `business_trip` | Business trip | empty | 出差 | `出` |
+| `training` | Training | empty | 培训 | `训` |
+
+The ZH badge uses the short form; tooltip uses the full localized form. In EN locale, the visible short overlay badge text is empty and the tooltip carries the full English label. This follows the product decision that PR-B's compact single-character badges are a Chinese UI affordance; EN users rely on color/outline plus tooltip instead of invented abbreviations such as `L` or `OT`.
+
+### D6. Duration display
+
+Overlay badges show duration only when useful:
+
+- `minutes` missing or invalid: show badge only, e.g. `假`.
+- Full-day threshold: use `rule.workMinutes` if available in the consumer; otherwise fallback to `480`.
+- `minutes >= fullDayMinutes`: show badge only, e.g. `假`.
+- `minutes < fullDayMinutes`: show rounded hours when divisible or sensible, e.g. `假 4h`; tooltip always shows raw minutes.
+
+If PR-B cannot reliably pass `rule.workMinutes` into the shared helper without broad churn, use fallback `480` in v1 and document it in verification MD.
+
+### D7. Day badge text
+
+Day badge is derived from `effective.isWorkingDay`:
+
+- ZH: `true` -> `班`; `false` -> `休`
+- EN: empty visible text; tooltip carries `Working day` / `Rest day`
+
+Do not infer work/rest from source.
+
+Holiday/festival label is separate:
+
+- If a non-generated anchor label is available, show it before the day badge.
+- Generated holiday-period labels such as `国庆-2` should not become the only visible text.
+- When `base.dayIndex === 1`, strip the generated suffix and show the festival anchor label before the day badge, e.g. `国庆节-1` -> `国庆节` + `休`.
+- When `base.dayIndex > 1`, prefer the short day badge in the chip and keep the full raw holiday name in tooltip.
+- Suffix stripping for v1 is deliberately narrow: `/^(.*?)(?:-|第)(\d+)(?:天)?$/` and only when the parsed numeric suffix matches `base.dayIndex`.
+
+## 5. Proposed Display Model
+
+Add a pure display model in `apps/web/src/services/attendance/calendarChipDisplay.ts`:
+
+```ts
+export type CalendarChipDayBadgeKind = 'work' | 'rest'
+export type CalendarChipOverlayBadgeKind =
+  | 'leave'
+  | 'overtime'
+  | 'correction'
+  | 'business_trip'
+  | 'training'
+
+export interface CalendarChipOverlayBadge {
+  kind: CalendarChipOverlayBadgeKind
+  text: string
+  fullLabel: string
+  minutes?: number
+  requestType?: string
+  status?: string
+}
+
+export interface CalendarChipDisplayModel {
+  titleLabel?: string
+  dayBadge: {
+    kind: CalendarChipDayBadgeKind
+    text: string
+    fullLabel: string
+  }
+  overlayBadges: CalendarChipOverlayBadge[]
+  sourceClass?: string
+  fineSourceClass?: string
+  tooltip?: string
+  hasOverride: boolean
+  hasOverlay: boolean
+}
+
+export function buildCalendarChipDisplay(
+  chip: CalendarEffectiveChip,
+  options: {
+    isZh: boolean
+    audience?: 'employee' | 'admin'
+    fullDayMinutes?: number
+  },
+): CalendarChipDisplayModel
+```
+
+Notes:
+
+- `sourceClass` is audience-aware; employee surfaces get national/company two-state.
+- `fineSourceClass` preserves 6-source class for admin surfaces if needed.
+- `titleLabel` is raw user/source data and must not be translated.
+- `overlayBadges` is derived from `chip.overlays` and is not written back into `chip.name`.
+- When `chip.overlays.length > 0`, the display helper must not trust `chip.name` as a title by default, because current `effectiveCalendarItemToChip()` may derive `chip.name` from the first overlay fallback. The display helper should derive title from `chip.base.name`, `chip.effective.label`, and `base.dayIndex` rules instead. Changing `effectiveCalendarItemToChip()` semantics is deferred to a separate cleanup PR.
+
+## 6. DOM Contract
+
+`MetaCalendarView.vue` should change from one visible text node:
+
+```vue
+{{ holiday.name || fallbackHolidayName(holiday) }}
+```
+
+to structured but compact segments:
+
+```vue
+<span class="meta-calendar__holiday-title" v-if="display.titleLabel">
+  {{ display.titleLabel }}
+</span>
+<span
+  class="meta-calendar__holiday-day-badge"
+  :class="`meta-calendar__holiday-day-badge--${display.dayBadge.kind}`"
+>
+  {{ display.dayBadge.text }}
+</span>
+<span
+  v-for="overlay in display.overlayBadges.slice(0, 2)"
+  :key="overlay.kind"
+  class="meta-calendar__holiday-overlay-badge"
+  :class="`meta-calendar__holiday-overlay-badge--${overlay.kind}`"
+>
+  {{ overlay.text }}
+</span>
+```
+
+The exact code can be optimized to avoid repeated helper calls, but tests must assert the rendered text, classes, and tooltip.
+
+Do not add `data-*` with localized text. Any data attributes must stay raw enum values.
+
+## 7. Festival Anchor Limitation
+
+The current backend holiday row shape is:
+
+```ts
+{ date, name, isWorkingDay, origin }
+```
+
+It does not carry a canonical `festivalAnchorDate`.
+
+The sync path can generate day-index names, e.g. `name-1`, via `normalizeHolidayCnDays()` and `formatHolidayDayIndex()`. PR-B should improve display clarity, but should not pretend it can always infer "10-01 is the true National Day anchor" from date/name alone.
+
+V1 behavior:
+
+- Preserve raw `base.name` in tooltip.
+- Show clean short `休` / `班` day badge everywhere.
+- Show `titleLabel` only when the name is suitable for a compact chip.
+- If a generated day-index suffix is detected and `base.dayIndex === 1`, strip the suffix for the visible title and show the festival anchor, e.g. `国庆节-1` -> `国庆节`.
+- If a generated day-index suffix is detected and `base.dayIndex > 1`, prefer `休`/`班` in the chip and keep the full name in tooltip.
+
+Future backend enhancement, if exact statutory anchors are required:
+
+```ts
+base: {
+  name?: string
+  festivalName?: string
+  festivalAnchorDate?: string
+  holidayPeriodName?: string
+}
+```
+
+That should be a separate backend/API PR, not hidden inside this frontend display slice.
+
+## 8. Surface-Specific Behavior
+
+### Multitable Calendar
+
+Files:
+
+- `apps/web/src/multitable/components/MetaCalendarView.vue`
+- `apps/web/src/multitable/views/MultitableWorkbench.vue`
+
+Behavior:
+
+- Use `buildCalendarChipDisplay(chip, { isZh: isZh.value, audience: 'employee' })`.
+- Employee source class is national/company two-state.
+- Existing `cell.holidays.slice(0, 2)` remains unchanged.
+- Overlay badges are inside the same chip, not additional holiday entries.
+
+### Attendance Personal Calendar
+
+Files:
+
+- `apps/web/src/views/AttendanceView.vue`
+
+Behavior:
+
+- Use the same display model for `day.holidayName` replacement or extend `CalendarDay` to carry `calendarDisplay`.
+- Show primary day badge and secondary overlay badges in the cell.
+- Keep existing status label for attendance record status; do not regress record status rendering.
+
+### Attendance Admin Holiday CRUD
+
+Files:
+
+- `apps/web/src/views/attendance/AttendanceHolidayDataSection.vue`
+
+Behavior:
+
+- Out of PR-B scope unless a small type/test update is required.
+- Continue using 6-source/fine-grained origin semantics.
+- Future improvement: replace the current `N/M` single-letter admin origin badges (`N = national`, `M = manual`) with `国家同步` / `公司手工`; not required for PR-B.
+
+### Assignment Preview Chips
+
+Files:
+
+- `apps/web/src/views/attendance/AttendanceSchedulingAdminSection.vue`
+- `apps/web/src/views/AttendanceView.vue`
+
+Behavior:
+
+- Only update if the shared helper change forces a type adjustment.
+- Admin preview can keep fine source class and existing text in PR-B to avoid scope creep.
+
+## 9. I18n Placement
+
+Do not put employee calendar labels into multitable i18n modules unless they are multitable-specific.
+
+Preferred location:
+
+- Extend `apps/web/src/services/attendance/calendarChipDisplay.ts` with localized pure helpers taking `isZh`.
+
+Rationale:
+
+- This is attendance calendar semantics shared by multitable Calendar and AttendanceView.
+- Existing service file already owns calendar chip display helpers.
+- Avoid a Vue composable dependency in service code.
+
+If the implementation grows beyond compact helper labels, create:
+
+- `apps/web/src/services/attendance/calendarChipLabels.ts`
+
+but keep it under `services/attendance`, not `apps/web/src/multitable/utils`.
+
+## 10. Tests
+
+### Unit tests
+
+Extend:
+
+- `apps/web/tests/calendarChipDisplay.spec.ts`
+- `apps/web/tests/effectiveCalendar.spec.ts`
+
+Cases:
+
+1. Workday with approved leave: display model returns day `班` plus overlay `假`.
+2. Rest day with overtime: day `休` plus overlay `加 8h`.
+3. National rest day: employee source class is `calendar-source--national`.
+4. Manual/org/group/user source: employee source class is `calendar-source--company-policy`; fine source remains available.
+5. Overlay i18n: zh returns `假/加/补/出/训`; en returns empty short badge text and full English tooltip labels.
+6. Full-day threshold: `minutes=480` -> `假`; `minutes=240` -> `假 4h`.
+7. Invalid/missing minutes: badge text has no duration; tooltip preserves available raw fields.
+8. Generated day-index label: `dayIndex=1` chip displays stripped festival title + day badge; `dayIndex=2` chip keeps full raw name in tooltip and visible chip can be day badge only.
+9. Legacy chip compatibility:
+   - Old `CalendarHoliday` shape with only `id/date/name/isWorkingDay` renders `name` plus work/rest class.
+   - Missing `overlays` behaves as no overlays.
+   - Missing `effective/base/layers` returns a backward-compatible tooltip/fallback rather than throwing.
+
+### Render tests
+
+Extend:
+
+- `apps/web/tests/multitable-calendar-view.spec.ts`
+- Attendance personal calendar spec if an existing focused harness is available; otherwise add a narrow render/helper test around the calendar day builder.
+
+Required render cases:
+
+1. `班 + 假` appears for overlay-only workday; no generic `Working day` text.
+2. `休 + 加` appears for rest day with overtime.
+3. National source renders national accent class; company source renders company-policy class on employee surfaces.
+4. Tooltip includes layer chain and overlay details.
+5. No localized display string is used in a CSS selector or `data-*`.
+
+### Backend tests
+
+No backend changes expected.
+
+Do not add integration tests unless implementation discovers a backend gap. Existing integration coverage already asserts approved overlays are returned additively.
+
+## 11. Implementation Order
+
+1. Rebase/branch from latest `origin/main`; confirm clean worktree.
+2. Preflight grep:
+   - `rg -n "OVERLAY_FALLBACK_LABEL|with-overlay|calendarChipSourceClassName|fallbackChipName|buildCalendarChipTooltip" apps/web/src apps/web/tests`
+   - `rg -n "effective-calendar|loadApprovedRequestsForOverlay|calendarOverlayKindFromRequestType" plugins/plugin-attendance/index.cjs packages/core-backend/tests`
+3. Extend `CalendarEffectiveBase` in `effectiveCalendar.ts` with `dayIndex?: number`.
+4. Add/extend display model helpers in `calendarChipDisplay.ts`. The helper must ignore overlay-derived `chip.name` when overlays exist; it should not change `effectiveCalendarItemToChip()` in this PR.
+5. Add `.calendar-source--company-policy` to `apps/web/src/styles/calendar-source-palette.css`.
+6. Wire `MetaCalendarView.vue` to structured chip segments.
+7. Wire `AttendanceView.vue` personal calendar to structured chip segments.
+8. Update/extend unit tests.
+9. Update/extend render tests.
+10. Write verification MD.
+11. Run validation commands:
+    - `pnpm --filter @metasheet/web exec vitest run apps/web/tests/calendarChipDisplay.spec.ts apps/web/tests/effectiveCalendar.spec.ts apps/web/tests/multitable-calendar-view.spec.ts`
+    - Add the focused AttendanceView/calendar spec command chosen during implementation.
+    - `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
+    - `pnpm --filter @metasheet/web build`
+    - `git diff --check origin/main..HEAD`
+12. Commit and stop before push for review.
+
+## 12. Risk Register
+
+| Risk | Mitigation |
+| --- | --- |
+| Overlay hides work/rest fact | Two-layer DOM contract; tests assert `班 + 假` and `休 + 加`. |
+| Employee source category loses admin detail | Preserve raw `effective.source`; tooltip shows exact source; admin surfaces keep 6-source helper. |
+| `chip.name` remains overlay fallback and fights display helper | Display helper must derive from `chip.effective/base/layers/overlays`, not blindly trust `chip.name`. Unit test overlay-only workday. |
+| Festival anchor is over-inferred | PR-B explicitly does not invent `festivalAnchorDate`; raw name stays in tooltip. |
+| Full-day duration threshold wrong for non-480 rules | Use consumer-provided `fullDayMinutes` when available; fallback 480 documented and tooltip shows raw minutes. |
+| Visual overcrowding in month cells | Compact one-character badges; overlay badges capped to first two in render with tooltip for full details. |
+| Pending leave confusion | Pending requests not included; defer separate workflow-state design. |
+| i18n drift between Multitable and AttendanceView | Shared service helper takes `isZh`; both surfaces use it. |
+
+## 13. Acceptance Gate
+
+PR-B is implementation-ready only when design review confirms:
+
+- `休/班` remains tied to `effective.isWorkingDay`.
+- Approved overlays render as secondary badges, never as the sole primary day verdict.
+- Employee surfaces use national/company source category while preserving exact source in tooltip.
+- Admin/source fine-grained semantics are not regressed.
+- Pending requests remain out of v1.
+- Tests cover `班 + 假`, `休 + 加`, national/company source category, duration display, and raw tooltip preservation.

--- a/docs/development/attendance-calendar-double-badge-verification-20260522.md
+++ b/docs/development/attendance-calendar-double-badge-verification-20260522.md
@@ -1,0 +1,128 @@
+# Attendance Calendar Double-Badge Verification (PR-B)
+
+Date: 2026-05-22
+Branch: `frontend/attendance-calendar-double-badge-design-20260522`
+Base after rebase: `origin/main@29d01e65f`
+
+## 1. DoD
+
+PASS if all are true:
+
+- `CalendarEffectiveBase.dayIndex?: number` is declared on the frontend type and preserved through `effectiveCalendarItemToChip()`.
+- Employee calendar chips render day verdict and personal overlays as separate visual segments.
+- Employee surfaces collapse source accent to national vs company-policy while admin/fine-grained consumers still use the existing 6-source helper.
+- Overlay-present days do not read overlay-derived `chip.name` as the primary title.
+- Existing legacy chips without effective-calendar fields still render safely.
+- Target unit/render tests, `vue-tsc`, frontend build, and diff check pass.
+
+## 2. Preflight
+
+Commands:
+
+```bash
+rg -n "OVERLAY_FALLBACK_LABEL|with-overlay|calendarChipSourceClassName|fallbackChipName|buildCalendarChipTooltip" apps/web/src apps/web/tests
+rg -n "effective-calendar|loadApprovedRequestsForOverlay|calendarOverlayKindFromRequestType|buildCalendarBaseFromHoliday|dayIndex: meta.dayIndex" plugins/plugin-attendance/index.cjs packages/core-backend/tests
+```
+
+Key findings:
+
+- `effectiveCalendarItemToChip()` still owns overlay-derived legacy `chip.name`; PR-B keeps it unchanged.
+- Employee rendering uses new `buildCalendarChipDisplay()` and ignores overlay-derived `chip.name` when overlays exist.
+- Admin/assignment preview consumers still use `calendarChipSourceClassName()` / `fallbackChipName()` / `buildCalendarChipTooltip()` unchanged.
+- Backend wire already exposes `base.dayIndex` in `buildCalendarBaseFromHoliday()` via `dayIndex: meta.dayIndex`.
+
+## 3. Implementation Evidence
+
+Changed files:
+
+```text
+apps/web/src/services/attendance/effectiveCalendar.ts
+apps/web/src/services/attendance/calendarChipDisplay.ts
+apps/web/src/styles/calendar-source-palette.css
+apps/web/src/multitable/components/MetaCalendarView.vue
+apps/web/src/views/AttendanceView.vue
+apps/web/tests/calendarChipDisplay.spec.ts
+apps/web/tests/effectiveCalendar.spec.ts
+apps/web/tests/multitable-calendar-view.spec.ts
+apps/web/tests/attendance-selfservice-dashboard.spec.ts
+docs/development/attendance-calendar-double-badge-design-20260522.md
+docs/development/attendance-calendar-double-badge-verification-20260522.md
+```
+
+Design fidelity:
+
+- A1 closed: generated holiday suffix stripping supports `name-1`, `name第1天`, and `name DAY1`; only `dayIndex === 1` shows the stripped anchor title.
+- A2 closed: EN short day/overlay badges are empty; tooltip carries full English labels.
+- A3 closed: display helper ignores overlay-derived `chip.name` for overlay-primary decisions; `effectiveCalendarItemToChip()` remains backward-compatible.
+- A4 closed: `CalendarEffectiveBase.dayIndex?: number` is declared before display helper usage.
+- Employee source class: `national -> calendar-source--national`; `manual/org/group/role/user -> calendar-source--company-policy`; `rule/shift/rotation -> undefined`.
+- Personal calendar: `AttendanceView` now renders the same structured display model as `MetaCalendarView`.
+
+## 4. Test Evidence
+
+Command:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/calendarChipDisplay.spec.ts tests/effectiveCalendar.spec.ts tests/multitable-calendar-view.spec.ts tests/attendance-selfservice-dashboard.spec.ts --watch=false
+```
+
+Output:
+
+```text
+✓ tests/calendarChipDisplay.spec.ts  (18 tests)
+✓ tests/effectiveCalendar.spec.ts  (18 tests)
+✓ tests/multitable-calendar-view.spec.ts  (14 tests)
+✓ tests/attendance-selfservice-dashboard.spec.ts  (7 tests)
+
+Test Files  4 passed (4)
+Tests       57 passed (57)
+```
+
+Coverage points:
+
+- Helper unit: national/company source category, dayIndex suffix stripping, dayIndex continuation, overlay-only workday, full-day threshold, EN empty short badges, legacy fallback.
+- Effective-calendar client: `base.dayIndex` preserved by `effectiveCalendarItemToChip()`.
+- Multitable Calendar: national anchor `国庆节 + 休`, continuation `休` with raw name in tooltip, company-policy accent, overlay badges, legacy chip compatibility.
+- Attendance personal calendar: `清明节 + 休` and approved overtime `班 + 加 3h` render from effective-calendar response.
+
+## 5. Type / Build Evidence
+
+Commands:
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+pnpm --filter @metasheet/web run type-check
+pnpm --filter @metasheet/web build
+```
+
+Output:
+
+```text
+vue-tsc --noEmit: exit 0
+type-check: vue-tsc -b exit 0
+build: ✓ built in 6.03s
+```
+
+Build warning observed:
+
+- Existing Vite warning: `WorkflowDesigner.vue` is both dynamically and statically imported. This is unrelated to PR-B and did not fail the build.
+
+Rebase note:
+
+- The branch was rebased after `origin/main` advanced. The only conflict was in `AttendanceView.vue` near new comprehensive-hours types; the resolution kept the upstream types and applied PR-B's `CalendarDay.calendarDisplay` change. Post-rebase diff is 11 PR-B files only.
+
+## 6. Raw Boundary
+
+Preserved raw data:
+
+- `effective.source` remains the API source token; display only derives an employee category.
+- `layers[].source`, `layers[].label`, and `overlays[].minutes` remain visible in tooltip.
+- `base.name` raw generated continuation labels such as `国庆节 DAY2` stay in tooltip.
+- Overlay backend `label` remains raw when provided; compact badge text uses locale-specific short labels.
+- `AttendanceView` admin/assignment preview chip behavior remains on the fine-grained helper.
+
+## 7. Worktree Notes
+
+- Local `node_modules` symlinks were used only to run the web toolchain in the temporary worktree.
+- `apps/web/dist/` is ignored build output and is not part of the PR diff.
+- No backend, migration, contract, K3, or attendance plugin runtime code changed.


### PR DESCRIPTION
## DoD

- Adds frontend `CalendarEffectiveBase.dayIndex?: number` to consume the backend wire field.
- Renders employee calendar chips with separate day verdict and personal overlay badges.
- Collapses employee source accents to `national` vs `company-policy` while preserving exact API source in tooltip/raw data.
- Keeps `effectiveCalendarItemToChip()` semantics unchanged; display helper ignores overlay-derived `chip.name` when overlays exist.
- Preserves legacy chip compatibility.

## Implementation Evidence

- New shared display model in `apps/web/src/services/attendance/calendarChipDisplay.ts`.
- `MetaCalendarView.vue` and `AttendanceView.vue` render structured title/day/overlay segments from the same helper.
- `dayIndex === 1` strips generated suffixes (`name-1`, `name第1天`, `name DAY1`) so festival anchors can show the holiday name plus `休`. Continuation days show compact `休` and keep the raw holiday name in tooltip.
- Overlay badges support approved leave/overtime/correction/business trip/training with compact ZH labels and EN tooltip-only short-badge behavior.

## Raw Boundary

- `effective.source` remains unchanged.
- Admin/assignment preview consumers keep the existing fine-grained source helper.
- Layer chain, exact source, raw base names, backend overlay labels, and overlay minutes remain visible in tooltip.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/calendarChipDisplay.spec.ts tests/effectiveCalendar.spec.ts tests/multitable-calendar-view.spec.ts tests/attendance-selfservice-dashboard.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/web build`
- `git diff --check origin/main..HEAD`

See:
- `docs/development/attendance-calendar-double-badge-design-20260522.md`
- `docs/development/attendance-calendar-double-badge-verification-20260522.md`