### PR TITLE
fix(attendance): expose day index in effective calendar response

### DIFF
--- a/apps/web/tests/calendarChipDisplay.spec.ts
+++ b/apps/web/tests/calendarChipDisplay.spec.ts
@@ -140,6 +140,36 @@ describe('employee calendar chip display', () => {
     expect(display.title).toBe('Holiday')
     expect(display.visibleText).toBe('Holiday')
   })
+
+  it('renders group-specific holiday length results as the same employee company-policy accent', () => {
+    const shortGroupDisplays = [1, 2, 3, 4, 5].map((dayIndex) => buildCalendarChipDisplay({
+      id: `short-${dayIndex}`,
+      date: `2026-10-${String(dayIndex).padStart(2, '0')}`,
+      isWorkingDay: dayIndex >= 4,
+      base: {
+        isWorkingDay: false,
+        source: 'national',
+        name: `国庆节-${dayIndex}`,
+        dayIndex,
+      },
+      effective: dayIndex >= 4
+        ? { isWorkingDay: true, source: 'group', label: 'Short group makeup work' }
+        : { isWorkingDay: false, source: 'national', label: `国庆节-${dayIndex}` },
+      layers: dayIndex >= 4
+        ? [
+            { kind: 'holiday', source: 'national', isWorkingDay: false, label: `国庆节-${dayIndex}` },
+            { kind: 'calendar_policy', source: 'group', isWorkingDay: true, label: 'Short group makeup work' },
+          ]
+        : [{ kind: 'holiday', source: 'national', isWorkingDay: false, label: `国庆节-${dayIndex}` }],
+      overlays: [],
+    } as CalendarEffectiveChip, { isZh: true }))
+
+    expect(shortGroupDisplays.map(display => display.dayBadge?.text)).toEqual(['休', '休', '休', '班', '班'])
+    expect(shortGroupDisplays[0]?.visibleText).toBe('国庆节 休')
+    expect(shortGroupDisplays[3]?.visibleText).toBe('Short group makeup work 班')
+    expect(shortGroupDisplays[3]?.sourceClass).toBe('calendar-source--company-policy')
+    expect(shortGroupDisplays[3]?.tooltip).toContain('公司节假日 · 班组日历政策')
+  })
 })
 
 describe('hasCalendarChipOverrideMarker', () => {

--- a/docs/development/attendance-effective-calendar-acceptance-development-20260523.md
+++ b/docs/development/attendance-effective-calendar-acceptance-development-20260523.md
@@ -1,0 +1,118 @@
+# Attendance Effective Calendar Acceptance Development (PR-C)
+
+Date: 2026-05-23
+Branch: `frontend/attendance-calendar-effective-acceptance-20260523`
+Base: `origin/main@92c753172` (`#1779` merged)
+
+## 1. Goal
+
+Close the product-level acceptance gap after PR-B double-badge rendering:
+
+- statutory holiday anchor and rest/work verdicts are already rendered by PR-B;
+- approved overlays are already rendered by PR-B;
+- this slice adds an explicit acceptance proof that different attendance groups can see different holiday lengths through the real `userId` effective-calendar API.
+
+The motivating scenario is National Day-style scheduling:
+
+- one group rests 3 days;
+- another group rests 5 days;
+- the employee calendar should show each employee's own effective rest/work days.
+
+## 2. Scope
+
+In scope:
+
+- Backend integration acceptance for `GET /api/attendance/effective-calendar` in `userId` mode with two group memberships.
+- Minimal backend response fix if the acceptance test finds a real serialization gap.
+- Frontend display-helper fixture proving the resulting day sequence renders as compact employee chips.
+- Development and verification MD.
+
+Out of scope:
+
+- Backend resolver behavior changes.
+- Pending/unapproved leave visibility.
+- Team availability or cross-user calendar UI.
+- Admin calendar-policy editor changes.
+- Overlay color/design token adjustments.
+
+## 3. Existing Coverage Before PR-C
+
+Already covered before this slice:
+
+- `effective-calendar §6.1`: baseline rule + holiday rows.
+- `effective-calendar §6.2`: calendarPolicy mode gates, priority, normalization, and one group-policy case.
+- `effective-calendar §6.3`: approved request overlays are additive and do not change effective workday.
+- PR-B frontend tests: dayIndex anchor, generated continuation days, overlay secondary badges, employee national/company source category.
+
+Missing acceptance:
+
+- two users in different attendance groups over the same holiday range receiving different effective rest lengths from the real API.
+
+## 4. Implementation
+
+### Runtime fix
+
+The real route acceptance initially exposed a backend gap: `buildCalendarBaseFromHoliday()` already computed `base.dayIndex`, but `resolveEffectiveCalendar()` omitted it when serializing `baseOut`.
+
+Fix:
+
+- Add `baseOut.dayIndex = base.dayIndex` when present.
+- No resolver matching semantics changed.
+- No database schema, route validation, policy priority, or frontend runtime code changed.
+
+### Backend integration
+
+Add a focused integration test:
+
+`effective-calendar accepts group-specific holiday lengths for different users in userId mode`
+
+Setup:
+
+- Insert 5 national rest days: `National Day-1` through `National Day-5`.
+- Create two attendance groups:
+  - short holiday group
+  - long holiday group
+- Assign one user to each group.
+- Save one `calendarPolicy.overrides[]` group policy:
+  - `dayIndexStart: 4`
+  - `dayIndexEnd: 5`
+  - `filters.attendanceGroups: [shortGroupName]`
+  - `effective.source: 'group'`
+  - `effective.isWorkingDay: true`
+
+Assertions:
+
+- short-group user sees rest dates only on day 1-3 and work dates on day 4-5.
+- long-group user sees rest dates on all day 1-5.
+- short-group day 4 has `effective.source === 'group'`.
+- long-group items remain `effective.source === 'national'` and have no `calendar_policy` layers.
+- `base.dayIndex` is present, proving the PR-B display anchor can consume the API response.
+
+### Frontend helper fixture
+
+Extend `calendarChipDisplay.spec.ts` with a compact fixture for the same 5-day scenario:
+
+- day badges render `休, 休, 休, 班, 班`.
+- day 1 renders stripped anchor `国庆节 休`.
+- group override day renders `Short group makeup work 班`.
+- group override day uses `calendar-source--company-policy`.
+
+## 5. Risk Notes
+
+| Risk | Mitigation |
+| --- | --- |
+| Integration test mutates shared attendance settings | Preserve current `calendarPolicy`, restore it in `finally`. |
+| Group policy accidentally affects all users | Assert long-group user has no `calendar_policy` layers. |
+| UI claims support but API lacks group-specific result | Backend test hits the real route with `userId` mode. |
+| Product scope expands into team availability | Deferred; this slice only proves self-calendar correctness. |
+
+## 6. Acceptance Gate
+
+PR-C is complete when:
+
+- targeted frontend helper test passes;
+- targeted backend integration test passes against a migrated scratch PostgreSQL database;
+- `vue-tsc` passes;
+- frontend build passes;
+- diff check is clean;
+- runtime source changes are limited to the `base.dayIndex` response serialization fix.

--- a/docs/development/attendance-effective-calendar-acceptance-verification-20260523.md
+++ b/docs/development/attendance-effective-calendar-acceptance-verification-20260523.md
@@ -1,0 +1,139 @@
+# Attendance Effective Calendar Acceptance Verification (PR-C)
+
+Date: 2026-05-23
+Branch: `frontend/attendance-calendar-effective-acceptance-20260523`
+Base: `origin/main@92c753172`
+
+## 1. DoD
+
+PASS if all are true:
+
+- Backend route acceptance proves two group-scoped users can receive different holiday lengths in `userId` mode.
+- API response includes `base.dayIndex` for generated holiday rows, so PR-B's employee chip anchor logic can consume real wire data.
+- Frontend display helper renders that result as the expected employee chip sequence.
+- Runtime code changes are limited to serializing the already-computed `base.dayIndex`.
+- Targeted tests, type-check, build, and diff-check pass.
+
+## 2. Implementation Summary
+
+Files changed:
+
+```text
+packages/core-backend/tests/integration/attendance-plugin.test.ts
+plugins/plugin-attendance/index.cjs
+apps/web/tests/calendarChipDisplay.spec.ts
+docs/development/attendance-effective-calendar-acceptance-development-20260523.md
+docs/development/attendance-effective-calendar-acceptance-verification-20260523.md
+```
+
+Runtime files changed:
+
+```text
+plugins/plugin-attendance/index.cjs
+```
+
+Runtime change:
+
+- `resolveEffectiveCalendar()` now includes `base.dayIndex` in the serialized `base` object when `buildCalendarBaseFromHoliday()` derived it from the holiday name.
+- No resolver matching, policy priority, route validation, schema, or frontend runtime code changed.
+
+## 3. Backend Acceptance
+
+Added integration test:
+
+```text
+effective-calendar accepts group-specific holiday lengths for different users in userId mode
+```
+
+Acceptance matrix:
+
+| User | Group policy | Expected rest dates | Expected work dates |
+| --- | --- | --- | --- |
+| short-group user | group override flips dayIndex 4-5 to work | day 1-3 | day 4-5 |
+| long-group user | no matching override | day 1-5 | none |
+
+Key assertions:
+
+- `shortItems[0].base.dayIndex === 1`
+- day 4 for short-group user has `effective.source === 'group'`
+- long-group user has all `effective.source === 'national'`
+- long-group user has no `calendar_policy` layers
+
+Real DB gate:
+
+- Scratch PostgreSQL database created from local `.env` connection and migrated before test.
+- Initial real-route run failed on `base.dayIndex === undefined`, proving the test catches the serialization gap.
+- After the one-line response fix, the same test passed against the migrated scratch DB.
+- Scratch DB was dropped after validation.
+
+## 4. Frontend Acceptance
+
+Extended `calendarChipDisplay.spec.ts`:
+
+```text
+renders group-specific holiday length results as the same employee company-policy accent
+```
+
+Key assertions:
+
+- day badge sequence: `['休', '休', '休', '班', '班']`
+- day 1 visible text: `国庆节 休`
+- short-group override day visible text: `Short group makeup work 班`
+- short-group override day source class: `calendar-source--company-policy`
+
+## 5. Commands
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/calendarChipDisplay.spec.ts --watch=false
+```
+
+```text
+✓ tests/calendarChipDisplay.spec.ts  (19 tests)
+Test Files  1 passed (1)
+Tests       19 passed (19)
+```
+
+```bash
+DATABASE_URL=<scratch> ATTENDANCE_TEST_DATABASE_URL=<scratch> \
+  pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run \
+  tests/integration/attendance-plugin.test.ts -t "group-specific holiday lengths" --run
+```
+
+```text
+✓ tests/integration/attendance-plugin.test.ts > Attendance Plugin Integration > effective-calendar accepts group-specific holiday lengths for different users in userId mode
+Test Files  1 passed (1)
+Tests       1 passed | 75 skipped (76)
+```
+
+```bash
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+```text
+PASS (exit 0)
+```
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+```text
+✓ built in 6.42s
+```
+
+```bash
+git diff --check
+```
+
+```text
+PASS (exit 0)
+```
+
+## 6. Worktree Notes
+
+- Worktree path: `/private/tmp/metasheet2-prc-effective-calendar-acceptance-20260523`
+- Backend runtime change is limited to `plugins/plugin-attendance/index.cjs` response serialization.
+- No migration, contract, K3, or frontend runtime code changed.
+- Temporary dependency symlinks and `apps/web/dist/` were local validation artifacts and are not part of the intended PR diff.

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -7803,6 +7803,152 @@ describe('Attendance Plugin Integration', () => {
     }
   })
 
+  it('effective-calendar accepts group-specific holiday lengths for different users in userId mode', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const year = 3030 + (Number.parseInt(runSuffix.slice(-3), 36) % 500)
+    const orgId = 'default'
+    const rangeFrom = `${year}-10-01`
+    const rangeTo = `${year}-10-05`
+    const shortUserId = `attendance-effcal-short-${runSuffix}`
+    const longUserId = `attendance-effcal-long-${runSuffix}`
+    const adminUserId = `attendance-effcal-group-length-admin-${runSuffix}`
+    const shortGroupName = `effcal-short-holiday-${runSuffix}`
+    const longGroupName = `effcal-long-holiday-${runSuffix}`
+    let shortGroupId: string | null = null
+    let longGroupId: string | null = null
+    let originalCalendarPolicy: any = null
+
+    const pool = new Pool({ connectionString: dbUrl })
+    try {
+      await pool.query(
+        'DELETE FROM attendance_holidays WHERE org_id = $1 AND holiday_date BETWEEN $2 AND $3',
+        [orgId, rangeFrom, rangeTo]
+      )
+      for (let day = 1; day <= 5; day += 1) {
+        await pool.query(
+          `INSERT INTO attendance_holidays (id, org_id, holiday_date, name, is_working_day, origin)
+           VALUES ($1, 'default', $2, $3, false, 'national')`,
+          [randomUuidV4(), `${year}-10-${String(day).padStart(2, '0')}`, `National Day-${day}`]
+        )
+      }
+
+      const shortGroupRows = await pool.query(
+        `INSERT INTO attendance_groups (org_id, name, code, timezone)
+         VALUES ('default', $1, $2, 'UTC')
+         RETURNING id`,
+        [shortGroupName, shortGroupName]
+      )
+      shortGroupId = String(shortGroupRows.rows[0].id)
+      const longGroupRows = await pool.query(
+        `INSERT INTO attendance_groups (org_id, name, code, timezone)
+         VALUES ('default', $1, $2, 'UTC')
+         RETURNING id`,
+        [longGroupName, longGroupName]
+      )
+      longGroupId = String(longGroupRows.rows[0].id)
+      await pool.query(
+        `INSERT INTO attendance_group_members (org_id, group_id, user_id)
+         VALUES ('default', $1, $2), ('default', $3, $4)`,
+        [shortGroupId, shortUserId, longGroupId, longUserId]
+      )
+
+      const adminTokenRes = await requestJson(
+        `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin,attendance:approve`
+      )
+      const adminToken = (adminTokenRes.body as { token?: string } | undefined)?.token
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+
+      const settingsRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        headers: { Authorization: `Bearer ${adminToken}` },
+      })
+      originalCalendarPolicy = (settingsRes.body as any)?.data?.calendarPolicy ?? { overrides: [] }
+
+      const putRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          calendarPolicy: {
+            overrides: [
+              {
+                dayIndexStart: 4,
+                dayIndexEnd: 5,
+                filters: { attendanceGroups: [shortGroupName] },
+                effective: {
+                  isWorkingDay: true,
+                  label: 'Short group makeup work',
+                  source: 'group',
+                },
+              },
+            ],
+          },
+        }),
+      })
+      expect(putRes.status).toBe(200)
+
+      const fetchForUser = async (userId: string) => {
+        const res = await requestJson(
+          `${baseUrl}/api/attendance/effective-calendar?from=${rangeFrom}&to=${rangeTo}&userId=${encodeURIComponent(userId)}`,
+          { headers: { Authorization: `Bearer ${adminToken}` } }
+        )
+        expect(res.status).toBe(200)
+        return ((res.body as any)?.data?.items ?? []) as any[]
+      }
+
+      const shortItems = await fetchForUser(shortUserId)
+      const longItems = await fetchForUser(longUserId)
+      expect(shortItems).toHaveLength(5)
+      expect(longItems).toHaveLength(5)
+
+      const shortRestDates = shortItems.filter(item => item.effective.isWorkingDay === false).map(item => item.date)
+      const shortWorkDates = shortItems.filter(item => item.effective.isWorkingDay === true).map(item => item.date)
+      const longRestDates = longItems.filter(item => item.effective.isWorkingDay === false).map(item => item.date)
+      expect(shortRestDates).toEqual([`${year}-10-01`, `${year}-10-02`, `${year}-10-03`])
+      expect(shortWorkDates).toEqual([`${year}-10-04`, `${year}-10-05`])
+      expect(longRestDates).toEqual([`${year}-10-01`, `${year}-10-02`, `${year}-10-03`, `${year}-10-04`, `${year}-10-05`])
+
+      const shortByDate = new Map<string, any>(shortItems.map(item => [item.date, item]))
+      expect(shortByDate.get(`${year}-10-01`)?.base.dayIndex).toBe(1)
+      expect(shortByDate.get(`${year}-10-01`)?.effective.source).toBe('national')
+      expect(shortByDate.get(`${year}-10-04`)?.base.dayIndex).toBe(4)
+      expect(shortByDate.get(`${year}-10-04`)?.effective.source).toBe('group')
+      expect(shortByDate.get(`${year}-10-04`)?.layers.map((layer: any) => layer.source)).toContain('group')
+      expect(longItems.every(item => item.effective.source === 'national')).toBe(true)
+      expect(longItems.flatMap(item => item.layers).some((layer: any) => layer.kind === 'calendar_policy')).toBe(false)
+    } finally {
+      const cleanupTokenRes = await requestJson(
+        `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(`${adminUserId}-cleanup`)}&roles=admin&perms=attendance:admin`
+      ).catch(() => null)
+      const cleanupToken = (cleanupTokenRes?.body as { token?: string } | undefined)?.token
+      if (cleanupToken) {
+        await requestJson(`${baseUrl}/api/attendance/settings`, {
+          method: 'PUT',
+          headers: { Authorization: `Bearer ${cleanupToken}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ calendarPolicy: originalCalendarPolicy ?? { overrides: [] } }),
+        }).catch(() => undefined)
+      }
+      if (shortGroupId || longGroupId) {
+        await pool.query(
+          'DELETE FROM attendance_group_members WHERE group_id = ANY($1::uuid[])',
+          [[shortGroupId, longGroupId].filter(Boolean)]
+        ).catch(() => undefined)
+        await pool.query(
+          'DELETE FROM attendance_groups WHERE id = ANY($1::uuid[])',
+          [[shortGroupId, longGroupId].filter(Boolean)]
+        ).catch(() => undefined)
+      }
+      await pool.query(
+        'DELETE FROM attendance_holidays WHERE org_id = $1 AND holiday_date BETWEEN $2 AND $3',
+        [orgId, rangeFrom, rangeTo]
+      ).catch(() => undefined)
+      await pool.end()
+    }
+  })
+
   it('effective-calendar §6.3 returns approved request overlays additively without merging', async () => {
     if (!baseUrl) return
     const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -11507,6 +11507,7 @@ async function resolveEffectiveCalendar(db, args) {
     }
     if (base.holidayId) baseOut.holidayId = base.holidayId
     if (base.name) baseOut.name = base.name
+    if (base.dayIndex) baseOut.dayIndex = base.dayIndex
 
     const effectiveOut = {
       isWorkingDay: effective.isWorkingDay,


### PR DESCRIPTION
## Summary

- Exposes the already-derived `base.dayIndex` field in `GET /api/attendance/effective-calendar` responses so PR-B employee holiday chips can consume real wire data.
- Adds backend acceptance proving two users in different attendance groups can see different effective holiday lengths in `userId` mode.
- Adds frontend display-helper coverage for the resulting 5-day sequence (`休, 休, 休, 班, 班`) and company-policy accent.

## Evidence

- RED→GREEN: the new real-route integration test initially failed with `base.dayIndex === undefined`; the one-line response serialization fix made the same test pass against a migrated scratch PostgreSQL DB.
- Scratch DB was dropped after validation.
- Runtime source change is limited to `plugins/plugin-attendance/index.cjs`; no migration, contract, K3, or frontend runtime code changed.

## Verification

```text
✓ tests/calendarChipDisplay.spec.ts  (19 tests)
✓ tests/integration/attendance-plugin.test.ts > Attendance Plugin Integration > effective-calendar accepts group-specific holiday lengths for different users in userId mode
Test Files  1 passed (1)
Tests       1 passed | 75 skipped (76)
pnpm --filter @metasheet/web exec vue-tsc --noEmit: PASS
pnpm --filter @metasheet/web build: PASS (✓ built in 6.42s)
git diff --check: PASS
```

Docs:

- `docs/development/attendance-effective-calendar-acceptance-development-20260523.md`
- `docs/development/attendance-effective-calendar-acceptance-verification-20260523.md`
