### PR TITLE
feat(attendance): add calendar policy holiday-length quick add

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1425,6 +1425,11 @@
                     <p class="attendance__field-hint attendance__field-hint--warn">
                       {{ tr('Role matching uses the platform user role plus assigned RBAC role IDs/names; role tags use the same resolver aliases until a dedicated role-tag catalog exists.', '角色匹配使用用户平台角色及已分配 RBAC 角色 ID/名称；在独立角色标签目录落地前，角色标签使用同一解析别名。') }}
                     </p>
+                    <AttendanceCalendarPolicyQuickAdd
+                      :attendance-group-options="attendanceGroupOptions"
+                      :tr="tr"
+                      @append="appendCalendarPolicyQuickAdd"
+                    />
                     <AttendanceCalendarPolicyPreviewPanel
                       :tr="tr"
                       :draft-overrides="calendarPolicyPreviewDraftOverrides"
@@ -1505,7 +1510,7 @@
                                 <div class="attendance__override-filters">
                                   <label class="attendance__override-field">
                                     <span>{{ tr('Attendance groups', '考勤组') }}</span>
-                                    <input v-model="override.attendanceGroups" type="text" placeholder="单休办公,白班" />
+                                    <input v-model="override.attendanceGroups" type="text" placeholder="单休办公,白班" data-calendar-policy-override-attendance-groups />
                                     <small v-if="attendanceGroupOptions.length" class="attendance__field-hint">
                                       {{ tr('Known groups', '已知分组') }}: {{ attendanceGroupOptions.join(', ') }}
                                     </small>
@@ -1536,11 +1541,11 @@
                                   </label>
                                   <label class="attendance__override-field">
                                     <span>{{ tr('Day index start', '节假日序号起始') }}</span>
-                                    <input v-model.number="override.dayIndexStart" type="number" min="1" />
+                                    <input v-model.number="override.dayIndexStart" type="number" min="1" data-calendar-policy-override-day-index-start />
                                   </label>
                                   <label class="attendance__override-field">
                                     <span>{{ tr('Day index end', '节假日序号结束') }}</span>
-                                    <input v-model.number="override.dayIndexEnd" type="number" min="1" />
+                                    <input v-model.number="override.dayIndexEnd" type="number" min="1" data-calendar-policy-override-day-index-end />
                                   </label>
                                   <label class="attendance__override-field">
                                     <span>{{ tr('Day index list', '节假日序号列表') }}</span>
@@ -5412,6 +5417,7 @@
 <script setup lang="ts">
 import { computed, nextTick, onMounted, reactive, ref, watch } from 'vue'
 import AttendanceAdminRail from './attendance/AttendanceAdminRail.vue'
+import AttendanceCalendarPolicyQuickAdd from './attendance/AttendanceCalendarPolicyQuickAdd.vue'
 import AttendanceCalendarPolicyPreviewPanel from './attendance/AttendanceCalendarPolicyPreviewPanel.vue'
 import AttendanceImportBatchesSection from './attendance/AttendanceImportBatchesSection.vue'
 import AttendanceHolidayDataSection from './attendance/AttendanceHolidayDataSection.vue'
@@ -13699,6 +13705,10 @@ function removeHolidayOverride(index: number) {
 
 function addCalendarPolicyOverride() {
   settingsForm.calendarPolicyOverrides.push(createDefaultCalendarPolicyOverrideForm())
+}
+
+function appendCalendarPolicyQuickAdd(form: CalendarPolicyOverrideFormState) {
+  settingsForm.calendarPolicyOverrides.push(form)
 }
 
 function removeCalendarPolicyOverride(index: number) {

--- a/apps/web/src/views/attendance/AttendanceCalendarPolicyQuickAdd.vue
+++ b/apps/web/src/views/attendance/AttendanceCalendarPolicyQuickAdd.vue
@@ -1,0 +1,168 @@
+<template>
+  <div class="attendance__admin-subsection" data-attendance-calendar-policy-quick-add>
+    <div class="attendance__admin-subsection-header">
+      <div>
+        <h5>{{ tr('Group holiday length quick add', '班组节假日时长快捷配置') }}</h5>
+        <p class="attendance__field-hint">
+          {{
+            tr(
+              'Use this for "Group A rests 3 days while the base holiday is 5 days." The helper creates a group-scoped workday exception for the remaining holiday day indexes.',
+              '用于“某个考勤组在 5 天假期里只休 3 天”这类场景。系统会为剩余节假日序号生成班组级调班规则。',
+            )
+          }}
+        </p>
+      </div>
+    </div>
+    <div class="attendance__admin-grid">
+      <label class="attendance__field" :for="holidayInputId">
+        <span>{{ tr('Holiday name', '节假日名称') }}</span>
+        <input
+          :id="holidayInputId"
+          v-model="form.holidayName"
+          type="text"
+          data-calendar-policy-quick-holiday
+          placeholder="国庆"
+        />
+      </label>
+      <label class="attendance__field" :for="groupInputId">
+        <span>{{ tr('Attendance group', '考勤组') }}</span>
+        <input
+          :id="groupInputId"
+          v-model="form.attendanceGroup"
+          type="text"
+          :list="groupListId"
+          data-calendar-policy-quick-group
+          placeholder="单休办公"
+        />
+        <datalist :id="groupListId">
+          <option v-for="group in attendanceGroupOptions" :key="group" :value="group" />
+        </datalist>
+        <small v-if="attendanceGroupOptions.length" class="attendance__field-hint">
+          {{ tr('Known groups', '已知分组') }}: {{ attendanceGroupOptions.join(', ') }}
+        </small>
+      </label>
+      <label class="attendance__field" :for="baseDaysInputId">
+        <span>{{ tr('Base rest days', '基础休息天数') }}</span>
+        <input
+          :id="baseDaysInputId"
+          v-model.number="form.baseRestDays"
+          type="number"
+          min="1"
+          data-calendar-policy-quick-base-days
+        />
+      </label>
+      <label class="attendance__field" :for="targetDaysInputId">
+        <span>{{ tr('Target rest days', '目标休息天数') }}</span>
+        <input
+          :id="targetDaysInputId"
+          v-model.number="form.targetRestDays"
+          type="number"
+          min="1"
+          data-calendar-policy-quick-target-days
+        />
+      </label>
+      <label class="attendance__field" :for="labelInputId">
+        <span>{{ tr('Label', '标签') }}</span>
+        <input
+          :id="labelInputId"
+          v-model="form.label"
+          type="text"
+          data-calendar-policy-quick-label
+          :placeholder="defaultLabel"
+        />
+      </label>
+    </div>
+    <p class="attendance__field-hint">
+      {{ tr('After adding a quick row, run preview in group or user mode before saving.', '添加快捷规则后，请先用班组或用户模式预览，再保存。') }}
+    </p>
+    <p v-if="statusMessage" class="attendance__field-hint" :class="{ 'attendance__field-hint--warn': statusKind === 'warn' }" data-calendar-policy-quick-status>
+      {{ statusMessage }}
+    </p>
+    <div class="attendance__admin-actions">
+      <button
+        class="attendance__btn"
+        type="button"
+        data-calendar-policy-quick-add
+        :disabled="quickAddResult.kind !== 'append'"
+        @click="appendQuickOverride"
+      >
+        {{ tr('Add group holiday rule', '添加班组节假日规则') }}
+      </button>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+import { computed, reactive, useId } from 'vue'
+import {
+  buildHolidayLengthCalendarPolicyOverride,
+  type CalendarPolicyOverrideFormState,
+} from './attendanceCalendarPolicyOverrides'
+
+type Translate = (en: string, zh: string) => string
+
+const props = defineProps<{
+  attendanceGroupOptions: string[]
+  tr: Translate
+}>()
+
+const emit = defineEmits<{
+  append: [form: CalendarPolicyOverrideFormState]
+}>()
+
+const tr = (en: string, zh: string) => props.tr(en, zh)
+const attendanceGroupOptions = computed(() => props.attendanceGroupOptions)
+const quickAddId = useId()
+const holidayInputId = `${quickAddId}-holiday`
+const groupInputId = `${quickAddId}-group`
+const groupListId = `${quickAddId}-groups`
+const baseDaysInputId = `${quickAddId}-base-days`
+const targetDaysInputId = `${quickAddId}-target-days`
+const labelInputId = `${quickAddId}-label`
+
+const form = reactive({
+  holidayName: tr('National Day', '国庆'),
+  attendanceGroup: '',
+  baseRestDays: 5,
+  targetRestDays: 3,
+  label: '',
+})
+
+const defaultLabel = computed(() => {
+  const holidayName = form.holidayName.trim() || tr('Holiday', '节假日')
+  return tr(`${holidayName} make-up workday`, `${holidayName}调班`)
+})
+
+const quickAddResult = computed(() => buildHolidayLengthCalendarPolicyOverride({
+  ...form,
+  localizedDefaultLabel: defaultLabel.value,
+}))
+
+function appendQuickOverride() {
+  const result = quickAddResult.value
+  if (result.kind !== 'append') return
+  emit('append', result.form)
+}
+
+const statusKind = computed<'info' | 'warn'>(() => {
+  const result = quickAddResult.value
+  return result.kind === 'append' || result.kind === 'noop' ? 'info' : 'warn'
+})
+
+const statusMessage = computed(() => {
+  const result = quickAddResult.value
+  if (result.kind === 'append') {
+    return tr(
+      `Will add a group workday exception for holiday day ${result.form.dayIndexStart}-${result.form.dayIndexEnd}.`,
+      `将新增班组调班规则：节假日第 ${result.form.dayIndexStart}-${result.form.dayIndexEnd} 天改为工作日。`,
+    )
+  }
+  if (result.reason === 'same_length') {
+    return tr('No rule is needed because the target rest length equals the base holiday length.', '目标休息天数与基础假期一致，无需新增规则。')
+  }
+  if (result.reason === 'target_longer_than_base') {
+    return tr('Longer-than-base rest spans are not generated automatically in v1; extend the base holiday range or use the advanced table.', 'v1 不自动生成长于基础假期的休息规则；请先延长基础假期范围，或使用高级表格手动配置。')
+  }
+  return tr('Fill a holiday name, attendance group, and valid day counts before adding a rule.', '请先填写节假日名称、考勤组和有效天数。')
+})
+</script>

--- a/apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue
+++ b/apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue
@@ -119,6 +119,11 @@
           <p class="attendance__field-hint attendance__field-hint--warn">
             {{ tr('Role matching uses the platform user role plus assigned RBAC role IDs/names; role tags use the same resolver aliases until a dedicated role-tag catalog exists.', '角色匹配使用用户平台角色及已分配 RBAC 角色 ID/名称；在独立角色标签目录落地前，角色标签使用同一解析别名。') }}
           </p>
+          <AttendanceCalendarPolicyQuickAdd
+            :attendance-group-options="attendanceGroupOptions"
+            :tr="tr"
+            @append="appendCalendarPolicyQuickAdd"
+          />
           <AttendanceCalendarPolicyPreviewPanel :tr="tr" />
           <div
             v-if="calendarPolicyOverrideDiagnostics.length"
@@ -191,7 +196,7 @@
                         <div class="attendance__override-filters">
                           <label class="attendance__override-field">
                             <span>{{ tr('Attendance groups', '考勤组') }}</span>
-                            <input v-model="override.attendanceGroups" type="text" placeholder="单休办公,白班" />
+                            <input v-model="override.attendanceGroups" type="text" placeholder="单休办公,白班" data-calendar-policy-override-attendance-groups />
                             <small v-if="attendanceGroupOptions.length" class="attendance__field-hint">{{ tr('Known groups', '已知分组') }}: {{ attendanceGroupOptions.join(', ') }}</small>
                           </label>
                           <label class="attendance__override-field"><span>{{ tr('Roles', '角色') }}</span><input v-model="override.roles" type="text" placeholder="attendance_admin,班组长" /></label>
@@ -200,8 +205,8 @@
                           <label class="attendance__override-field"><span>{{ tr('User names', '用户名') }}</span><input v-model="override.userNames" type="text" placeholder="张三,李四" /></label>
                           <label class="attendance__override-field"><span>{{ tr('Exclude user IDs', '排除用户ID') }}</span><input v-model="override.excludeUserIds" type="text" placeholder="uuid3" /></label>
                           <label class="attendance__override-field"><span>{{ tr('Exclude user names', '排除用户名') }}</span><input v-model="override.excludeUserNames" type="text" placeholder="王五" /></label>
-                          <label class="attendance__override-field"><span>{{ tr('Day index start', '节假日序号起始') }}</span><input v-model.number="override.dayIndexStart" type="number" min="1" /></label>
-                          <label class="attendance__override-field"><span>{{ tr('Day index end', '节假日序号结束') }}</span><input v-model.number="override.dayIndexEnd" type="number" min="1" /></label>
+                          <label class="attendance__override-field"><span>{{ tr('Day index start', '节假日序号起始') }}</span><input v-model.number="override.dayIndexStart" type="number" min="1" data-calendar-policy-override-day-index-start /></label>
+                          <label class="attendance__override-field"><span>{{ tr('Day index end', '节假日序号结束') }}</span><input v-model.number="override.dayIndexEnd" type="number" min="1" data-calendar-policy-override-day-index-end /></label>
                           <label class="attendance__override-field"><span>{{ tr('Day index list', '节假日序号列表') }}</span><input v-model="override.dayIndexList" type="text" placeholder="1,2,3" /></label>
                         </div>
                       </td>
@@ -300,6 +305,7 @@
 
 <script setup lang="ts">
 import { computed, ref, watch, type Ref } from 'vue'
+import AttendanceCalendarPolicyQuickAdd from './AttendanceCalendarPolicyQuickAdd.vue'
 import AttendanceCalendarPolicyPreviewPanel from './AttendanceCalendarPolicyPreviewPanel.vue'
 import {
   buildCalendarPolicyOverrideDiagnostics,
@@ -458,6 +464,11 @@ const addHolidayOverrideAndExpand = () => {
 const addCalendarPolicyOverrideAndExpand = () => {
   calendarPolicyOverridesExpanded.value = true
   props.config.addCalendarPolicyOverride()
+}
+
+const appendCalendarPolicyQuickAdd = (form: CalendarPolicyOverrideFormState) => {
+  calendarPolicyOverridesExpanded.value = true
+  settingsForm.calendarPolicyOverrides.push(form)
 }
 
 const removeHolidayOverride = (index: number) => props.config.removeHolidayOverride(index)

--- a/apps/web/src/views/attendance/attendanceCalendarPolicyOverrides.ts
+++ b/apps/web/src/views/attendance/attendanceCalendarPolicyOverrides.ts
@@ -63,6 +63,20 @@ export interface CalendarPolicyOverrideDiagnostic {
   source: CalendarPolicySource
 }
 
+export interface CalendarPolicyHolidayLengthQuickAddInput {
+  holidayName: string
+  attendanceGroup: string
+  baseRestDays: number
+  targetRestDays: number
+  label?: string
+  localizedDefaultLabel?: string
+}
+
+export type CalendarPolicyHolidayLengthQuickAddResult =
+  | { kind: 'append'; form: CalendarPolicyOverrideFormState }
+  | { kind: 'noop'; reason: 'same_length' }
+  | { kind: 'unsupported'; reason: 'target_longer_than_base' | 'invalid_input' }
+
 function listToText(list?: Array<string | number>): string {
   return Array.isArray(list) ? list.join(',') : ''
 }
@@ -183,6 +197,45 @@ export function createDefaultCalendarPolicyOverrideForm(): CalendarPolicyOverrid
     userNames: '',
     excludeUserIds: '',
     excludeUserNames: '',
+  }
+}
+
+function normalizeQuickAddDayCount(value: unknown): number | null {
+  const count = typeof value === 'number' ? value : Number(value)
+  if (!Number.isInteger(count) || count < 1) return null
+  return count
+}
+
+export function buildHolidayLengthCalendarPolicyOverride(
+  input: CalendarPolicyHolidayLengthQuickAddInput,
+): CalendarPolicyHolidayLengthQuickAddResult {
+  const holidayName = input.holidayName.trim()
+  const attendanceGroup = input.attendanceGroup.trim()
+  const baseRestDays = normalizeQuickAddDayCount(input.baseRestDays)
+  const targetRestDays = normalizeQuickAddDayCount(input.targetRestDays)
+  if (!holidayName || !attendanceGroup || !baseRestDays || !targetRestDays) {
+    return { kind: 'unsupported', reason: 'invalid_input' }
+  }
+  if (targetRestDays === baseRestDays) {
+    return { kind: 'noop', reason: 'same_length' }
+  }
+  if (targetRestDays > baseRestDays) {
+    return { kind: 'unsupported', reason: 'target_longer_than_base' }
+  }
+
+  return {
+    kind: 'append',
+    form: {
+      ...createDefaultCalendarPolicyOverrideForm(),
+      name: holidayName,
+      match: 'contains',
+      dayIndexStart: targetRestDays + 1,
+      dayIndexEnd: baseRestDays,
+      source: 'group',
+      isWorkingDay: true,
+      label: input.label?.trim() || input.localizedDefaultLabel?.trim() || `${holidayName}调班`,
+      attendanceGroups: attendanceGroup,
+    },
   }
 }
 

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -51,6 +51,13 @@ async function flushUi(cycles = 6): Promise<void> {
   }
 }
 
+function setInput(container: HTMLElement, selector: string, value: string): void {
+  const input = container.querySelector<HTMLInputElement>(selector)
+  expect(input, `expected input ${selector}`).toBeTruthy()
+  input!.value = value
+  input!.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
 function setViewportWidth(width: number): void {
   Object.defineProperty(window, 'innerWidth', {
     configurable: true,
@@ -532,6 +539,37 @@ describe('Attendance admin regressions', () => {
     expect(container!.querySelector('[data-admin-shortcut="attendance-admin-group-members"]')?.textContent).toContain('Organization · Group members')
     expect(container!.textContent).toContain('User picker')
     expect(container!.textContent).toContain('Append selected user')
+  })
+
+  it('renders the production calendar-policy quick-add panel and appends a group day-index row', async () => {
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const settings = container!.querySelector<HTMLElement>('#attendance-admin-settings')
+    expect(settings).toBeTruthy()
+    expect(window.getComputedStyle(settings!).display).not.toBe('none')
+    expect(settings!.querySelector('[data-attendance-calendar-policy-quick-add]')).toBeTruthy()
+
+    setInput(settings!, '[data-calendar-policy-quick-holiday]', 'National Day')
+    setInput(settings!, '[data-calendar-policy-quick-group]', 'day-shift')
+    await flushUi(2)
+
+    const quickAddButton = settings!.querySelector<HTMLButtonElement>('button[data-calendar-policy-quick-add]')
+    expect(quickAddButton).toBeTruthy()
+    expect(quickAddButton!.disabled).toBe(false)
+    quickAddButton!.click()
+    await flushUi(4)
+
+    expect(settings!.textContent).toContain('Will add a group workday exception for holiday day 4-5.')
+    const policyRows = settings!.querySelectorAll('template, tbody tr')
+    expect(policyRows.length).toBeGreaterThan(0)
+    const groupInputs = Array.from(settings!.querySelectorAll<HTMLInputElement>('[data-calendar-policy-override-attendance-groups]'))
+    expect(groupInputs.some(input => input.value === 'day-shift')).toBe(true)
+    const dayIndexStartInputs = Array.from(settings!.querySelectorAll<HTMLInputElement>('[data-calendar-policy-override-day-index-start]'))
+    const dayIndexEndInputs = Array.from(settings!.querySelectorAll<HTMLInputElement>('[data-calendar-policy-override-day-index-end]'))
+    expect(dayIndexStartInputs.some(input => input.value === '4')).toBe(true)
+    expect(dayIndexEndInputs.some(input => input.value === '5')).toBe(true)
   })
 
   it('passes the selected CSV header mode when exporting report records', async () => {

--- a/apps/web/tests/attendanceCalendarPolicyOverrides.spec.ts
+++ b/apps/web/tests/attendanceCalendarPolicyOverrides.spec.ts
@@ -1,5 +1,6 @@
 import { describe, expect, it } from 'vitest'
 import {
+  buildHolidayLengthCalendarPolicyOverride,
   buildCalendarPolicyOverrideDiagnostics,
   calendarPolicyOverridesFromForm,
   type CalendarPolicyOverrideFormState,
@@ -125,5 +126,117 @@ describe('attendance calendar policy override diagnostics', () => {
     ])
 
     expect(diagnostics).toEqual([])
+  })
+})
+
+describe('attendance calendar policy holiday length quick add', () => {
+  it('creates a group-scoped workday exception for shorter group holiday length', () => {
+    const result = buildHolidayLengthCalendarPolicyOverride({
+      holidayName: '国庆',
+      attendanceGroup: '短假班组',
+      baseRestDays: 5,
+      targetRestDays: 3,
+      localizedDefaultLabel: '国庆调班',
+    })
+
+    expect(result).toEqual({
+      kind: 'append',
+      form: expect.objectContaining({
+        name: '国庆',
+        match: 'contains',
+        dayIndexStart: 4,
+        dayIndexEnd: 5,
+        source: 'group',
+        isWorkingDay: true,
+        attendanceGroups: '短假班组',
+        label: '国庆调班',
+      }),
+    })
+    if (result.kind !== 'append') throw new Error('expected append result')
+    expect(calendarPolicyOverridesFromForm([result.form])).toEqual([
+      expect.objectContaining({
+        name: '国庆',
+        match: 'contains',
+        dayIndexStart: 4,
+        dayIndexEnd: 5,
+        filters: { attendanceGroups: ['短假班组'] },
+        effective: {
+          isWorkingDay: true,
+          label: '国庆调班',
+          source: 'group',
+        },
+      }),
+    ])
+  })
+
+  it('returns a no-op when target rest length equals the base length', () => {
+    expect(buildHolidayLengthCalendarPolicyOverride({
+      holidayName: '国庆',
+      attendanceGroup: '常规班组',
+      baseRestDays: 5,
+      targetRestDays: 5,
+    })).toEqual({ kind: 'noop', reason: 'same_length' })
+  })
+
+  it('does not generate longer-than-base holiday spans automatically', () => {
+    expect(buildHolidayLengthCalendarPolicyOverride({
+      holidayName: '国庆',
+      attendanceGroup: '长假班组',
+      baseRestDays: 3,
+      targetRestDays: 5,
+    })).toEqual({ kind: 'unsupported', reason: 'target_longer_than_base' })
+  })
+
+  it('rejects invalid quick-add inputs', () => {
+    expect(buildHolidayLengthCalendarPolicyOverride({
+      holidayName: '',
+      attendanceGroup: '短假班组',
+      baseRestDays: 5,
+      targetRestDays: 3,
+    })).toEqual({ kind: 'unsupported', reason: 'invalid_input' })
+
+    expect(buildHolidayLengthCalendarPolicyOverride({
+      holidayName: '国庆',
+      attendanceGroup: '',
+      baseRestDays: 5,
+      targetRestDays: 3,
+    })).toEqual({ kind: 'unsupported', reason: 'invalid_input' })
+
+    expect(buildHolidayLengthCalendarPolicyOverride({
+      holidayName: '国庆',
+      attendanceGroup: '短假班组',
+      baseRestDays: 5.5,
+      targetRestDays: 3,
+    })).toEqual({ kind: 'unsupported', reason: 'invalid_input' })
+  })
+
+  it('keeps diagnostics behavior for generated and manually incomplete group rows', () => {
+    const result = buildHolidayLengthCalendarPolicyOverride({
+      holidayName: '国庆',
+      attendanceGroup: '短假班组',
+      baseRestDays: 5,
+      targetRestDays: 3,
+    })
+    if (result.kind !== 'append') throw new Error('expected append result')
+
+    const diagnostics = buildCalendarPolicyOverrideDiagnostics([
+      result.form,
+      overrideForm({
+        source: 'group',
+        attendanceGroups: '',
+        dayIndexStart: 4,
+        dayIndexEnd: 5,
+        isWorkingDay: true,
+        label: 'Bare group row',
+      }),
+    ])
+
+    expect(diagnostics).toEqual([
+      expect.objectContaining({
+        code: 'missing_scope',
+        primaryIndex: 1,
+        source: 'group',
+      }),
+    ])
   })
 })

--- a/apps/web/tests/useAttendanceHolidayRuleSection.spec.ts
+++ b/apps/web/tests/useAttendanceHolidayRuleSection.spec.ts
@@ -90,6 +90,13 @@ function findButton(container: HTMLElement, label: string): HTMLButtonElement {
   return button as HTMLButtonElement
 }
 
+function setInput(container: HTMLElement, selector: string, value: string): void {
+  const input = container.querySelector<HTMLInputElement>(selector)
+  expect(input, `expected input ${selector}`).toBeTruthy()
+  input!.value = value
+  input!.dispatchEvent(new Event('input'))
+}
+
 function createDefaultSettings(): HolidaySettingsState {
   return {
     holidayFirstDayEnabled: true,
@@ -320,6 +327,60 @@ describe('AttendanceHolidayRuleSection', () => {
     expect(container!.querySelector('.attendance__override-field input[placeholder="单休办公,白班"]')).toBeTruthy()
     const roleInputs = container!.querySelectorAll('.attendance__override-field input[placeholder="attendance_admin,班组长"]')
     expect(roleInputs.length).toBeGreaterThanOrEqual(2)
+  })
+
+  it('quick-adds a group holiday-length calendar policy row', async () => {
+    const settingsForm = reactive<HolidaySettingsState>(createDefaultSettings())
+
+    const config = {
+      addCalendarPolicyOverride: vi.fn(),
+      addHolidayOverride: vi.fn(),
+      holidaySyncLastRun: { value: null },
+      holidaySyncLoading: { value: false },
+      removeCalendarPolicyOverride: vi.fn(),
+      removeHolidayOverride: vi.fn(),
+      saveSettings: vi.fn(),
+      settingsForm,
+      settingsLoading: { value: false },
+      syncHolidays: vi.fn(),
+      syncHolidaysForYears: vi.fn(),
+    } as HolidayConfig
+
+    app = createApp(AttendanceHolidayRuleSection, {
+      attendanceGroupOptions: ['短假班组'],
+      config,
+      formatDateTime,
+      tr,
+    })
+    app.mount(container!)
+    await flushUi()
+
+    expect(container!.querySelector('[data-attendance-calendar-policy-quick-add]')).toBeTruthy()
+    setInput(container!, '[data-calendar-policy-quick-group]', '短假班组')
+    await flushUi(2)
+
+    const quickAddButton = container!.querySelector<HTMLButtonElement>('button[data-calendar-policy-quick-add]')
+    expect(quickAddButton).toBeTruthy()
+    expect(quickAddButton!.disabled).toBe(false)
+    quickAddButton!.click()
+    await flushUi(6)
+
+    expect(config.addCalendarPolicyOverride).not.toHaveBeenCalled()
+    expect(settingsForm.calendarPolicyOverrides).toHaveLength(1)
+    expect(settingsForm.calendarPolicyOverrides[0]).toMatchObject({
+      name: '国庆',
+      match: 'contains',
+      dayIndexStart: 4,
+      dayIndexEnd: 5,
+      source: 'group',
+      isWorkingDay: true,
+      attendanceGroups: '短假班组',
+      label: '国庆调班',
+    })
+    const accordions = container!.querySelectorAll<HTMLButtonElement>('.attendance__accordion')
+    expect(accordions[1]?.getAttribute('aria-expanded')).toBe('true')
+    expect(container!.textContent).toContain('节假日第 4-5 天改为工作日')
+    expect(container!.querySelector('.attendance__override-field input[placeholder="单休办公,白班"]')).toBeTruthy()
   })
 
   it('shows effective calendar override diagnostics for unsaved and shadowed rules', async () => {

--- a/docs/development/attendance-calendar-policy-admin-quick-add-verification-20260523.md
+++ b/docs/development/attendance-calendar-policy-admin-quick-add-verification-20260523.md
@@ -1,0 +1,110 @@
+# Attendance Calendar Policy Admin Quick-Add Verification
+
+Date: 2026-05-23
+Branch: `frontend/attendance-calendar-policy-admin-quick-add-20260523`
+Base: `origin/main@2ef7f8046` (`#1783` design merged)
+
+## 1. Scope
+
+This slice implements the Admin/HR quick-add flow designed in
+`docs/development/attendance-calendar-policy-admin-ux-design-20260523.md`.
+It helps admins generate a group-scoped `calendarPolicy.overrides[]` row for
+the common "base holiday is 5 days, this group rests 3 days" case.
+
+No backend route, plugin resolver, migration, employee badge rendering, payroll
+calculation, pending-leave, or team-availability behavior changed.
+
+## 2. Changed Files
+
+| File | Purpose |
+| --- | --- |
+| `apps/web/src/views/attendance/attendanceCalendarPolicyOverrides.ts` | Adds pure quick-add input/result types and `buildHolidayLengthCalendarPolicyOverride()`. |
+| `apps/web/src/views/attendance/AttendanceCalendarPolicyQuickAdd.vue` | New shared quick-add panel used by both admin surfaces. |
+| `apps/web/src/views/AttendanceView.vue` | Production admin settings surface mounts the shared quick-add panel. |
+| `apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue` | Extracted holiday-rule section mounts the same shared panel to prevent further drift. |
+| `apps/web/tests/attendanceCalendarPolicyOverrides.spec.ts` | Helper and diagnostics regression coverage. |
+| `apps/web/tests/useAttendanceHolidayRuleSection.spec.ts` | Extracted component render/append coverage. |
+| `apps/web/tests/attendance-admin-regressions.spec.ts` | Production `AttendanceView.vue` render/append coverage. |
+
+## 3. Implementation Evidence
+
+- `baseRestDays=5`, `targetRestDays=3` generates one group-scoped workday
+  exception:
+  - `name = holidayName`
+  - `match = contains`
+  - `dayIndexStart = 4`
+  - `dayIndexEnd = 5`
+  - `source = group`
+  - `isWorkingDay = true`
+  - `attendanceGroups = <group>`
+- `targetRestDays === baseRestDays` returns a no-op and does not append a row.
+- `targetRestDays > baseRestDays` returns unsupported; v1 does not infer
+  longer-than-base rest spans.
+- Invalid holiday/group/day-count inputs return unsupported.
+- Generated rows round-trip through `calendarPolicyOverridesFromForm()`.
+- Existing diagnostics still catch incomplete manual group rows while accepting
+  quick-add rows with a required group filter.
+- The production surface and extracted component both mount the same
+  `AttendanceCalendarPolicyQuickAdd.vue` component.
+
+## 4. Test Evidence
+
+Focused tests:
+
+```text
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceCalendarPolicyOverrides.spec.ts tests/useAttendanceHolidayRuleSection.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false
+
+✓ tests/attendanceCalendarPolicyOverrides.spec.ts  (9 tests)
+✓ tests/useAttendanceHolidayRuleSection.spec.ts  (7 tests)
+✓ tests/attendance-admin-regressions.spec.ts  (14 tests)
+
+Test Files  3 passed (3)
+Tests       30 passed (30)
+```
+
+Type check:
+
+```text
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+
+PASS
+```
+
+Build:
+
+```text
+pnpm --filter @metasheet/web build
+
+✓ built in 6.03s
+```
+
+Build emitted the existing Vite chunk-size and mixed dynamic/static import
+warnings around `WorkflowDesigner.vue`; no new failure.
+
+Diff check:
+
+```text
+git diff --check
+
+PASS
+```
+
+## 5. Boundary Checks
+
+- No files under `plugins/`, `packages/`, `migrations/`, or backend routes were
+  changed.
+- No employee-facing calendar badge logic changed.
+- No `attendance_*` schema, payroll, auto-absence, or facts behavior changed.
+- No role/roleTag quick-add was added; the helper only emits `source='group'`.
+- `node_modules` symlinks were created only to reuse the main checkout test
+  dependencies in the isolated worktree and are not part of the intended diff.
+
+## 6. Follow-Up
+
+Potential later work remains intentionally separate:
+
+- longer-than-base holiday quick-add generation;
+- role/roleTag quick-add after resolver context exists;
+- refactoring the monolithic admin settings section to exclusively use extracted
+  subsection components;
+- team availability and pending leave calendar product designs.


### PR DESCRIPTION
## Summary

Implements the Admin/HR quick-add flow from `docs/development/attendance-calendar-policy-admin-ux-design-20260523.md`.

- Adds a shared `AttendanceCalendarPolicyQuickAdd.vue` panel for group holiday-length adjustments.
- Generates group-scoped `calendarPolicy.overrides[]` rows for cases like base holiday 5 days, target group rests 3 days.
- Mounts the shared panel in both the production `AttendanceView.vue` admin settings surface and the extracted `AttendanceHolidayRuleSection.vue` to avoid drift.
- Keeps persisted calendar policy shape unchanged; no backend, migration, payroll, employee calendar badge, pending-leave, or team-availability behavior changes.

## Verification

- `NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceCalendarPolicyOverrides.spec.ts tests/useAttendanceHolidayRuleSection.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false` → 30 passed
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit` → pass
- `pnpm --filter @metasheet/web build` → pass; existing Vite WorkflowDesigner/chunk-size warnings only
- `git diff --check origin/main..HEAD` → clean

Verification doc: `docs/development/attendance-calendar-policy-admin-quick-add-verification-20260523.md`