### PR TITLE
feat(attendance): support extra-rest calendar policy quick add

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1471,9 +1471,9 @@
                             <tr>
                               <td>
                                 <div class="attendance__inline-fields">
-                                  <input v-model="override.date" class="attendance__table-input" type="date" :aria-label="tr('Single date', '单日')" />
-                                  <input v-model="override.from" class="attendance__table-input" type="date" :aria-label="tr('From date', '开始日期')" />
-                                  <input v-model="override.to" class="attendance__table-input" type="date" :aria-label="tr('To date', '结束日期')" />
+                                  <input v-model="override.date" class="attendance__table-input" type="date" :aria-label="tr('Single date', '单日')" data-calendar-policy-override-date />
+                                  <input v-model="override.from" class="attendance__table-input" type="date" :aria-label="tr('From date', '开始日期')" data-calendar-policy-override-from />
+                                  <input v-model="override.to" class="attendance__table-input" type="date" :aria-label="tr('To date', '结束日期')" data-calendar-policy-override-to />
                                 </div>
                               </td>
                               <td>

--- a/apps/web/src/views/attendance/AttendanceCalendarPolicyQuickAdd.vue
+++ b/apps/web/src/views/attendance/AttendanceCalendarPolicyQuickAdd.vue
@@ -6,8 +6,8 @@
         <p class="attendance__field-hint">
           {{
             tr(
-              'Use this for "Group A rests 3 days while the base holiday is 5 days." The helper creates a group-scoped workday exception for the remaining holiday day indexes.',
-              '用于“某个考勤组在 5 天假期里只休 3 天”这类场景。系统会为剩余节假日序号生成班组级调班规则。',
+              'Use this for "Group A rests 3 days while the base holiday is 5 days" or "Group B rests 5 days while the base holiday is 3 days." The helper creates a group-scoped calendar policy row.',
+              '用于“某个考勤组在 5 天假期里只休 3 天”或“某个考勤组在 3 天基础假期上多休到 5 天”这类场景。系统会生成班组级日历规则。',
             )
           }}
         </p>
@@ -60,6 +60,18 @@
           min="1"
           data-calendar-policy-quick-target-days
         />
+      </label>
+      <label class="attendance__field" :for="baseStartDateInputId">
+        <span>{{ tr('Base rest start date', '基础休息起始日期') }}</span>
+        <input
+          :id="baseStartDateInputId"
+          v-model="form.baseRestStartDate"
+          type="date"
+          data-calendar-policy-quick-base-start-date
+        />
+        <small class="attendance__field-hint">
+          {{ tr('Required only when target rest days is greater than base rest days. Use the first date in the base rest range, not necessarily the festival date.', '仅当目标休息天数大于基础休息天数时必填。请填写基础休息范围的第一天，不一定是节日本身日期。') }}
+        </small>
       </label>
       <label class="attendance__field" :for="labelInputId">
         <span>{{ tr('Label', '标签') }}</span>
@@ -118,6 +130,7 @@ const groupInputId = `${quickAddId}-group`
 const groupListId = `${quickAddId}-groups`
 const baseDaysInputId = `${quickAddId}-base-days`
 const targetDaysInputId = `${quickAddId}-target-days`
+const baseStartDateInputId = `${quickAddId}-base-start-date`
 const labelInputId = `${quickAddId}-label`
 
 const form = reactive({
@@ -125,17 +138,28 @@ const form = reactive({
   attendanceGroup: '',
   baseRestDays: 5,
   targetRestDays: 3,
+  baseRestStartDate: '',
   label: '',
 })
 
-const defaultLabel = computed(() => {
+const isLongerRestTarget = computed(() => Number(form.targetRestDays) > Number(form.baseRestDays))
+
+const defaultWorkdayLabel = computed(() => {
   const holidayName = form.holidayName.trim() || tr('Holiday', '节假日')
   return tr(`${holidayName} make-up workday`, `${holidayName}调班`)
 })
 
+const defaultExtraRestLabel = computed(() => {
+  const holidayName = form.holidayName.trim() || tr('Holiday', '节假日')
+  return tr(`${holidayName} extra rest`, `${holidayName}延休`)
+})
+
+const defaultLabel = computed(() => (isLongerRestTarget.value ? defaultExtraRestLabel.value : defaultWorkdayLabel.value))
+
 const quickAddResult = computed(() => buildHolidayLengthCalendarPolicyOverride({
   ...form,
-  localizedDefaultLabel: defaultLabel.value,
+  localizedDefaultLabel: defaultWorkdayLabel.value,
+  localizedExtraRestLabel: defaultExtraRestLabel.value,
 }))
 
 function appendQuickOverride() {
@@ -152,6 +176,12 @@ const statusKind = computed<'info' | 'warn'>(() => {
 const statusMessage = computed(() => {
   const result = quickAddResult.value
   if (result.kind === 'append') {
+    if (result.form.isWorkingDay === false && result.form.from && result.form.to) {
+      return tr(
+        `Will add a group rest exception from ${result.form.from} to ${result.form.to}.`,
+        `将新增班组延休规则：${result.form.from} 至 ${result.form.to} 改为休息日。`,
+      )
+    }
     return tr(
       `Will add a group workday exception for holiday day ${result.form.dayIndexStart}-${result.form.dayIndexEnd}.`,
       `将新增班组调班规则：节假日第 ${result.form.dayIndexStart}-${result.form.dayIndexEnd} 天改为工作日。`,
@@ -160,9 +190,11 @@ const statusMessage = computed(() => {
   if (result.reason === 'same_length') {
     return tr('No rule is needed because the target rest length equals the base holiday length.', '目标休息天数与基础假期一致，无需新增规则。')
   }
-  if (result.reason === 'target_longer_than_base') {
-    return tr('Longer-than-base rest spans are not generated automatically in v1; extend the base holiday range or use the advanced table.', 'v1 不自动生成长于基础假期的休息规则；请先延长基础假期范围，或使用高级表格手动配置。')
+  if (result.reason === 'missing_base_rest_start_date') {
+    return tr('Enter the base rest start date to generate extra rest days.', '请填写基础休息起始日期，才能生成额外休息日规则。')
   }
-  return tr('Fill a holiday name, attendance group, and valid day counts before adding a rule.', '请先填写节假日名称、考勤组和有效天数。')
+  return isLongerRestTarget.value
+    ? tr('Fill a holiday name, attendance group, valid day counts, and a valid base rest start date before adding a rule.', '请先填写节假日名称、考勤组、有效天数和有效的基础休息起始日期。')
+    : tr('Fill a holiday name, attendance group, and valid day counts before adding a rule.', '请先填写节假日名称、考勤组和有效天数。')
 })
 </script>

--- a/apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue
+++ b/apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue
@@ -161,9 +161,9 @@
                     <tr>
                       <td>
                         <div class="attendance__inline-fields">
-                          <input v-model="override.date" class="attendance__table-input" type="date" :aria-label="tr('Single date', '单日')" />
-                          <input v-model="override.from" class="attendance__table-input" type="date" :aria-label="tr('From date', '开始日期')" />
-                          <input v-model="override.to" class="attendance__table-input" type="date" :aria-label="tr('To date', '结束日期')" />
+                          <input v-model="override.date" class="attendance__table-input" type="date" :aria-label="tr('Single date', '单日')" data-calendar-policy-override-date />
+                          <input v-model="override.from" class="attendance__table-input" type="date" :aria-label="tr('From date', '开始日期')" data-calendar-policy-override-from />
+                          <input v-model="override.to" class="attendance__table-input" type="date" :aria-label="tr('To date', '结束日期')" data-calendar-policy-override-to />
                         </div>
                       </td>
                       <td>

--- a/apps/web/src/views/attendance/attendanceCalendarPolicyOverrides.ts
+++ b/apps/web/src/views/attendance/attendanceCalendarPolicyOverrides.ts
@@ -68,14 +68,16 @@ export interface CalendarPolicyHolidayLengthQuickAddInput {
   attendanceGroup: string
   baseRestDays: number
   targetRestDays: number
+  baseRestStartDate?: string
   label?: string
   localizedDefaultLabel?: string
+  localizedExtraRestLabel?: string
 }
 
 export type CalendarPolicyHolidayLengthQuickAddResult =
   | { kind: 'append'; form: CalendarPolicyOverrideFormState }
   | { kind: 'noop'; reason: 'same_length' }
-  | { kind: 'unsupported'; reason: 'target_longer_than_base' | 'invalid_input' }
+  | { kind: 'unsupported'; reason: 'invalid_input' | 'missing_base_rest_start_date' }
 
 function listToText(list?: Array<string | number>): string {
   return Array.isArray(list) ? list.join(',') : ''
@@ -206,6 +208,32 @@ function normalizeQuickAddDayCount(value: unknown): number | null {
   return count
 }
 
+function parseDateOnly(value: unknown): Date | null {
+  if (typeof value !== 'string') return null
+  const match = /^(\d{4})-(\d{2})-(\d{2})$/.exec(value.trim())
+  if (!match) return null
+  const year = Number(match[1])
+  const month = Number(match[2])
+  const day = Number(match[3])
+  const date = new Date(Date.UTC(year, month - 1, day))
+  if (
+    date.getUTCFullYear() !== year
+    || date.getUTCMonth() !== month - 1
+    || date.getUTCDate() !== day
+  ) {
+    return null
+  }
+  return date
+}
+
+function addCalendarDays(date: Date, days: number): string {
+  const next = new Date(date.getTime() + days * 86_400_000)
+  const year = String(next.getUTCFullYear()).padStart(4, '0')
+  const month = String(next.getUTCMonth() + 1).padStart(2, '0')
+  const day = String(next.getUTCDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
 export function buildHolidayLengthCalendarPolicyOverride(
   input: CalendarPolicyHolidayLengthQuickAddInput,
 ): CalendarPolicyHolidayLengthQuickAddResult {
@@ -220,7 +248,26 @@ export function buildHolidayLengthCalendarPolicyOverride(
     return { kind: 'noop', reason: 'same_length' }
   }
   if (targetRestDays > baseRestDays) {
-    return { kind: 'unsupported', reason: 'target_longer_than_base' }
+    const baseRestStartDate = input.baseRestStartDate?.trim() ?? ''
+    if (!baseRestStartDate) {
+      return { kind: 'unsupported', reason: 'missing_base_rest_start_date' }
+    }
+    const baseRestStart = parseDateOnly(baseRestStartDate)
+    if (!baseRestStart) {
+      return { kind: 'unsupported', reason: 'invalid_input' }
+    }
+    return {
+      kind: 'append',
+      form: {
+        ...createDefaultCalendarPolicyOverrideForm(),
+        from: addCalendarDays(baseRestStart, baseRestDays),
+        to: addCalendarDays(baseRestStart, targetRestDays - 1),
+        source: 'group',
+        isWorkingDay: false,
+        label: input.label?.trim() || input.localizedExtraRestLabel?.trim() || `${holidayName}延休`,
+        attendanceGroups: attendanceGroup,
+      },
+    }
   }
 
   return {

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -572,6 +572,42 @@ describe('Attendance admin regressions', () => {
     expect(dayIndexEndInputs.some(input => input.value === '5')).toBe(true)
   })
 
+  it('renders the production quick-add panel and appends a longer-rest date range row', async () => {
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const settings = container!.querySelector<HTMLElement>('#attendance-admin-settings')
+    expect(settings).toBeTruthy()
+    expect(window.getComputedStyle(settings!).display).not.toBe('none')
+    expect(settings!.querySelector('[data-attendance-calendar-policy-quick-add]')).toBeTruthy()
+
+    setInput(settings!, '[data-calendar-policy-quick-holiday]', 'National Day')
+    setInput(settings!, '[data-calendar-policy-quick-group]', 'long-rest-shift')
+    setInput(settings!, '[data-calendar-policy-quick-base-days]', '3')
+    setInput(settings!, '[data-calendar-policy-quick-target-days]', '5')
+    setInput(settings!, '[data-calendar-policy-quick-base-start-date]', '2026-10-01')
+    await flushUi(2)
+
+    const quickAddButton = settings!.querySelector<HTMLButtonElement>('button[data-calendar-policy-quick-add]')
+    expect(quickAddButton).toBeTruthy()
+    expect(quickAddButton!.disabled).toBe(false)
+    quickAddButton!.click()
+    await flushUi(4)
+
+    expect(settings!.textContent).toContain('Will add a group rest exception from 2026-10-04 to 2026-10-05.')
+    const groupInputs = Array.from(settings!.querySelectorAll<HTMLInputElement>('[data-calendar-policy-override-attendance-groups]'))
+    expect(groupInputs.some(input => input.value === 'long-rest-shift')).toBe(true)
+    const fromInputs = Array.from(settings!.querySelectorAll<HTMLInputElement>('[data-calendar-policy-override-from]'))
+    const toInputs = Array.from(settings!.querySelectorAll<HTMLInputElement>('[data-calendar-policy-override-to]'))
+    expect(fromInputs.some(input => input.value === '2026-10-04')).toBe(true)
+    expect(toInputs.some(input => input.value === '2026-10-05')).toBe(true)
+    const dayIndexStartInputs = Array.from(settings!.querySelectorAll<HTMLInputElement>('[data-calendar-policy-override-day-index-start]'))
+    const dayIndexEndInputs = Array.from(settings!.querySelectorAll<HTMLInputElement>('[data-calendar-policy-override-day-index-end]'))
+    expect(dayIndexStartInputs.some(input => input.value === '4')).toBe(false)
+    expect(dayIndexEndInputs.some(input => input.value === '5')).toBe(false)
+  })
+
   it('passes the selected CSV header mode when exporting report records', async () => {
     const originalCreateObjectURL = URL.createObjectURL
     const originalRevokeObjectURL = URL.revokeObjectURL

--- a/apps/web/tests/attendanceCalendarPolicyOverrides.spec.ts
+++ b/apps/web/tests/attendanceCalendarPolicyOverrides.spec.ts
@@ -178,13 +178,59 @@ describe('attendance calendar policy holiday length quick add', () => {
     })).toEqual({ kind: 'noop', reason: 'same_length' })
   })
 
-  it('does not generate longer-than-base holiday spans automatically', () => {
+  it('requires a base rest start date before generating longer group holiday length', () => {
     expect(buildHolidayLengthCalendarPolicyOverride({
       holidayName: '国庆',
       attendanceGroup: '长假班组',
       baseRestDays: 3,
       targetRestDays: 5,
-    })).toEqual({ kind: 'unsupported', reason: 'target_longer_than_base' })
+    })).toEqual({ kind: 'unsupported', reason: 'missing_base_rest_start_date' })
+  })
+
+  it('creates a date-range rest exception for longer group holiday length', () => {
+    const result = buildHolidayLengthCalendarPolicyOverride({
+      holidayName: '国庆',
+      attendanceGroup: '长假班组',
+      baseRestDays: 3,
+      targetRestDays: 5,
+      baseRestStartDate: '2026-10-01',
+      localizedExtraRestLabel: '国庆延休',
+    })
+
+    expect(result).toEqual({
+      kind: 'append',
+      form: expect.objectContaining({
+        name: '',
+        match: 'contains',
+        date: '',
+        from: '2026-10-04',
+        to: '2026-10-05',
+        dayIndexStart: null,
+        dayIndexEnd: null,
+        dayIndexList: '',
+        source: 'group',
+        isWorkingDay: false,
+        attendanceGroups: '长假班组',
+        label: '国庆延休',
+      }),
+    })
+    if (result.kind !== 'append') throw new Error('expected append result')
+    const [wire] = calendarPolicyOverridesFromForm([result.form])
+    expect(wire).toMatchObject({
+      from: '2026-10-04',
+      to: '2026-10-05',
+      filters: { attendanceGroups: ['长假班组'] },
+      effective: {
+        isWorkingDay: false,
+        label: '国庆延休',
+        source: 'group',
+      },
+    })
+    expect(wire?.name).toBeUndefined()
+    expect(wire?.match).toBeUndefined()
+    expect(wire?.dayIndexStart).toBeUndefined()
+    expect(wire?.dayIndexEnd).toBeUndefined()
+    expect(wire?.dayIndexList).toEqual([])
   })
 
   it('rejects invalid quick-add inputs', () => {
@@ -208,19 +254,36 @@ describe('attendance calendar policy holiday length quick add', () => {
       baseRestDays: 5.5,
       targetRestDays: 3,
     })).toEqual({ kind: 'unsupported', reason: 'invalid_input' })
+
+    expect(buildHolidayLengthCalendarPolicyOverride({
+      holidayName: '国庆',
+      attendanceGroup: '长假班组',
+      baseRestDays: 3,
+      targetRestDays: 5,
+      baseRestStartDate: '2026-02-30',
+    })).toEqual({ kind: 'unsupported', reason: 'invalid_input' })
   })
 
   it('keeps diagnostics behavior for generated and manually incomplete group rows', () => {
-    const result = buildHolidayLengthCalendarPolicyOverride({
+    const shorterResult = buildHolidayLengthCalendarPolicyOverride({
       holidayName: '国庆',
       attendanceGroup: '短假班组',
       baseRestDays: 5,
       targetRestDays: 3,
     })
-    if (result.kind !== 'append') throw new Error('expected append result')
+    if (shorterResult.kind !== 'append') throw new Error('expected append result')
+    const longerResult = buildHolidayLengthCalendarPolicyOverride({
+      holidayName: '国庆',
+      attendanceGroup: '长假班组',
+      baseRestDays: 3,
+      targetRestDays: 5,
+      baseRestStartDate: '2026-10-01',
+    })
+    if (longerResult.kind !== 'append') throw new Error('expected append result')
 
     const diagnostics = buildCalendarPolicyOverrideDiagnostics([
-      result.form,
+      shorterResult.form,
+      longerResult.form,
       overrideForm({
         source: 'group',
         attendanceGroups: '',
@@ -234,7 +297,7 @@ describe('attendance calendar policy holiday length quick add', () => {
     expect(diagnostics).toEqual([
       expect.objectContaining({
         code: 'missing_scope',
-        primaryIndex: 1,
+        primaryIndex: 2,
         source: 'group',
       }),
     ])

--- a/apps/web/tests/useAttendanceHolidayRuleSection.spec.ts
+++ b/apps/web/tests/useAttendanceHolidayRuleSection.spec.ts
@@ -383,6 +383,66 @@ describe('AttendanceHolidayRuleSection', () => {
     expect(container!.querySelector('.attendance__override-field input[placeholder="单休办公,白班"]')).toBeTruthy()
   })
 
+  it('quick-adds a longer group holiday length as a concrete rest date range', async () => {
+    const settingsForm = reactive<HolidaySettingsState>(createDefaultSettings())
+
+    const config = {
+      addCalendarPolicyOverride: vi.fn(),
+      addHolidayOverride: vi.fn(),
+      holidaySyncLastRun: { value: null },
+      holidaySyncLoading: { value: false },
+      removeCalendarPolicyOverride: vi.fn(),
+      removeHolidayOverride: vi.fn(),
+      saveSettings: vi.fn(),
+      settingsForm,
+      settingsLoading: { value: false },
+      syncHolidays: vi.fn(),
+      syncHolidaysForYears: vi.fn(),
+    } as HolidayConfig
+
+    app = createApp(AttendanceHolidayRuleSection, {
+      attendanceGroupOptions: ['长假班组'],
+      config,
+      formatDateTime,
+      tr,
+    })
+    app.mount(container!)
+    await flushUi()
+
+    setInput(container!, '[data-calendar-policy-quick-group]', '长假班组')
+    setInput(container!, '[data-calendar-policy-quick-base-days]', '3')
+    setInput(container!, '[data-calendar-policy-quick-target-days]', '5')
+    setInput(container!, '[data-calendar-policy-quick-base-start-date]', '2026-10-01')
+    await flushUi(2)
+
+    const quickAddButton = container!.querySelector<HTMLButtonElement>('button[data-calendar-policy-quick-add]')
+    expect(quickAddButton).toBeTruthy()
+    expect(quickAddButton!.disabled).toBe(false)
+    quickAddButton!.click()
+    await flushUi(6)
+
+    expect(config.addCalendarPolicyOverride).not.toHaveBeenCalled()
+    expect(settingsForm.calendarPolicyOverrides).toHaveLength(1)
+    expect(settingsForm.calendarPolicyOverrides[0]).toMatchObject({
+      name: '',
+      match: 'contains',
+      date: '',
+      from: '2026-10-04',
+      to: '2026-10-05',
+      dayIndexStart: null,
+      dayIndexEnd: null,
+      dayIndexList: '',
+      source: 'group',
+      isWorkingDay: false,
+      attendanceGroups: '长假班组',
+      label: '国庆延休',
+    })
+    const accordions = container!.querySelectorAll<HTMLButtonElement>('.attendance__accordion')
+    expect(accordions[1]?.getAttribute('aria-expanded')).toBe('true')
+    expect(container!.textContent).toContain('2026-10-04 至 2026-10-05 改为休息日')
+    expect(container!.querySelector('.attendance__override-field input[placeholder="单休办公,白班"]')).toBeTruthy()
+  })
+
   it('shows effective calendar override diagnostics for unsaved and shadowed rules', async () => {
     const settingsForm = reactive<HolidaySettingsState>(createDefaultSettings())
     settingsForm.calendarPolicyOverrides.push(

--- a/docs/development/attendance-calendar-policy-extra-rest-admin-verification-20260523.md
+++ b/docs/development/attendance-calendar-policy-extra-rest-admin-verification-20260523.md
@@ -1,0 +1,186 @@
+# Attendance Calendar Policy Extra-Rest Admin Verification
+
+Date: 2026-05-23
+Branch: `frontend/attendance-calendar-extra-rest-quick-add-20260523`
+Base: `origin/main@dc24a793d` (`#1786` design)
+
+## 1. DoD
+
+- Existing shorter-rest quick-add path remains unchanged: base 5 / target 3
+  still emits a group-scoped workday override for holiday day indexes 4-5.
+- New longer-rest path works: base 3 / target 5 plus base rest start date
+  emits a group-scoped rest override for `from=2026-10-04` to
+  `to=2026-10-05`.
+- Longer-rest generated rows do not set `name`, `dayIndexStart`, or
+  `dayIndexEnd`; `dayIndexList` stays empty so backend normalization treats it
+  as no day-index filter.
+- Production `AttendanceView.vue` and extracted
+  `AttendanceHolidayRuleSection.vue` both consume the shared quick-add
+  component and can append the longer-rest row.
+- No backend route, migration, resolver, effective-calendar API contract,
+  payroll, employee badge rendering, pending-leave, or team-availability code
+  changed.
+
+## 2. Changed Files
+
+Implementation:
+
+- `apps/web/src/views/attendance/attendanceCalendarPolicyOverrides.ts`
+- `apps/web/src/views/attendance/AttendanceCalendarPolicyQuickAdd.vue`
+- `apps/web/src/views/attendance/AttendanceHolidayRuleSection.vue`
+- `apps/web/src/views/AttendanceView.vue`
+
+Tests:
+
+- `apps/web/tests/attendanceCalendarPolicyOverrides.spec.ts`
+- `apps/web/tests/useAttendanceHolidayRuleSection.spec.ts`
+- `apps/web/tests/attendance-admin-regressions.spec.ts`
+
+Docs:
+
+- `docs/development/attendance-calendar-policy-extra-rest-admin-verification-20260523.md`
+
+## 3. Implementation Evidence
+
+Helper contract:
+
+- `CalendarPolicyHolidayLengthQuickAddInput` now accepts
+  `baseRestStartDate?: string` and `localizedExtraRestLabel?: string`.
+- `target_longer_than_base` was retired from the active result union. The no-date
+  longer-rest path returns `missing_base_rest_start_date`.
+- `parseDateOnly()` validates strict `YYYY-MM-DD` calendar dates using UTC
+  component round-trip checks. `2026-02-30` is rejected.
+- `addCalendarDays()` uses UTC date-only arithmetic and formats back to
+  `YYYY-MM-DD`.
+
+Generated longer-rest row:
+
+```ts
+{
+  name: '',
+  match: 'contains',
+  date: '',
+  from: '2026-10-04',
+  to: '2026-10-05',
+  dayIndexStart: null,
+  dayIndexEnd: null,
+  dayIndexList: '',
+  source: 'group',
+  isWorkingDay: false,
+  label: '国庆延休',
+  attendanceGroups: '长假班组',
+}
+```
+
+Wire shape after `calendarPolicyOverridesFromForm()`:
+
+- `from='2026-10-04'`
+- `to='2026-10-05'`
+- `filters.attendanceGroups=['长假班组']`
+- `effective.source='group'`
+- `effective.isWorkingDay=false`
+- `name === undefined`
+- `match === undefined`
+- `dayIndexStart === undefined`
+- `dayIndexEnd === undefined`
+- `dayIndexList === []`
+
+The empty `dayIndexList` is intentional with the current serializer. Backend
+normalization drops empty arrays and `matchDayIndexFilter()` treats empty lists
+as no filter, so this is not an effective day-index filter.
+
+UI evidence:
+
+- `AttendanceCalendarPolicyQuickAdd.vue` adds
+  `data-calendar-policy-quick-base-start-date`.
+- The base rest start date field is always visible, with copy saying it is only
+  required when target rest days exceed base rest days.
+- Status copy now distinguishes:
+  - shorter path: `Will add a group workday exception for holiday day X-Y.`
+  - longer path: `Will add a group rest exception from YYYY-MM-DD to YYYY-MM-DD.`
+  - missing date: `Enter the base rest start date to generate extra rest days.`
+- `AttendanceView.vue` and `AttendanceHolidayRuleSection.vue` now expose stable
+  date-range selectors:
+  - `data-calendar-policy-override-date`
+  - `data-calendar-policy-override-from`
+  - `data-calendar-policy-override-to`
+
+## 4. Test Evidence
+
+Focused vitest:
+
+```text
+NODE_OPTIONS=--no-experimental-webstorage pnpm --filter @metasheet/web exec vitest run tests/attendanceCalendarPolicyOverrides.spec.ts tests/useAttendanceHolidayRuleSection.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false
+
+✓ tests/attendanceCalendarPolicyOverrides.spec.ts  (10 tests)
+✓ tests/useAttendanceHolidayRuleSection.spec.ts  (8 tests)
+✓ tests/attendance-admin-regressions.spec.ts  (15 tests)
+
+Test Files  3 passed (3)
+Tests       33 passed (33)
+```
+
+Type-check:
+
+```text
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+EXIT 0
+```
+
+Build:
+
+```text
+pnpm --filter @metasheet/web build
+
+✓ 2426 modules transformed.
+✓ built in 6.09s
+EXIT 0
+```
+
+Diff check:
+
+```text
+git diff --check origin/main..HEAD
+EXIT 0
+```
+
+## 5. Regression Matrix
+
+| Surface | Assertion |
+| --- | --- |
+| Helper shorter path | Base 5 / target 3 still emits `name='国庆'`, `dayIndexStart=4`, `dayIndexEnd=5`, `isWorkingDay=true`. |
+| Helper same-length path | Base 5 / target 5 remains `noop: same_length`. |
+| Helper longer path without date | Base 3 / target 5 returns `unsupported: missing_base_rest_start_date`. |
+| Helper longer path with date | Base 3 / target 5 / `2026-10-01` emits `from=2026-10-04`, `to=2026-10-05`, `isWorkingDay=false`. |
+| Helper invalid date | `2026-02-30` returns `unsupported: invalid_input`. |
+| Serializer | Longer-rest wire row has no `name`, no `match`, no start/end day-index filters, and an empty `dayIndexList`. |
+| Diagnostics | Generated shorter and longer rows do not trigger missing-scope; manually bare group rows still do. |
+| Extracted section | `AttendanceHolidayRuleSection.vue` appends the longer-rest row and expands the advanced accordion. |
+| Production admin | `AttendanceView.vue` appends the longer-rest row through stable `data-calendar-policy-*` selectors. |
+
+## 6. Scope Boundaries
+
+Not changed:
+
+- `plugins/plugin-attendance/index.cjs`
+- backend migrations
+- backend route validation
+- effective-calendar resolver matching
+- employee calendar badge rendering
+- payroll/comprehensive-hours logic
+- pending leave or team availability surfaces
+
+Optional backend smoke from the design was not run in this implementation pass
+because no backend/schema/resolver code changed. Existing real-route coverage for
+group-specific holiday lengths remains the backend confidence anchor.
+
+## 7. Worktree Notes
+
+The implementation worktree uses dependency symlinks:
+
+- `node_modules -> /Users/chouhua/Downloads/Github/metasheet2/node_modules`
+- `apps/web/node_modules -> /Users/chouhua/Downloads/Github/metasheet2/apps/web/node_modules`
+- `packages/core-backend/node_modules -> /Users/chouhua/Downloads/Github/metasheet2/packages/core-backend/node_modules`
+
+`apps/web/dist/` was generated by the build. These paths are not part of the PR
+diff and must not be staged.


### PR DESCRIPTION
## Summary

Implements the longer-than-base extension to the PR-D #1785 Admin/HR Quick-Add, per #1786 design. Admins can now configure "Group rests 5 days when base holiday is 3 days" by providing `baseRestStartDate` in addition to base/target rest days. The helper generates a pure `from`/`to` + `attendanceGroups` + `source=group` + `isWorkingDay=false` calendar-policy row with empty `name` and no day-index filters — required because extra rest dates usually have no holiday row (matched against `matchCalendarOverride` constraints).

Shorter-rest path unchanged. Both production `AttendanceView` and extracted `AttendanceHolidayRuleSection` continue to mount the same shared `AttendanceCalendarPolicyQuickAdd.vue` (D6 anti-drift preserved).

## Test plan

- [x] 33/33 focused vitest PASS (helper + extracted component + production-mount regression)
- [x] `vue-tsc --noEmit` PASS
- [x] `pnpm --filter @metasheet/web build` PASS
- [x] `git diff --check origin/main..HEAD` clean
- [x] Helper unit test explicitly asserts `wire?.name === undefined`, `wire?.dayIndexStart === undefined`, `wire?.dayIndexEnd === undefined`, `wire?.dayIndexList === []` — locks #1786 §3 critical constraint as machine-verifiable invariant
- [x] `parseDateOnly` round-trip rejects calendar-invalid dates (`2026-02-30`)
- [x] No backend / migration / employee-rendering / payroll / pending-leave / team-availability changes

Refs #1786 (PR-E design), #1785 (PR-D shorter-rest impl).