### PR TITLE
feat(attendance): add comprehensive hours weak save warnings

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -5033,6 +5033,17 @@
                   />
                 </label>
               </div>
+              <p
+                v-if="comprehensiveHoursAssignmentAdvisory.rotation.message"
+                class="attendance__status"
+                :class="{
+                  'attendance__status--warn': comprehensiveHoursAssignmentAdvisory.rotation.kind === 'warn',
+                  'attendance__status--error': comprehensiveHoursAssignmentAdvisory.rotation.kind === 'error'
+                }"
+                data-attendance-comprehensive-hours-assignment-advisory="rotation"
+              >
+                {{ comprehensiveHoursAssignmentAdvisory.rotation.message }}
+              </p>
               <div class="attendance__admin-actions">
                 <button
                   class="attendance__btn attendance__btn--primary"
@@ -5345,6 +5356,17 @@
                   />
                 </label>
               </div>
+              <p
+                v-if="comprehensiveHoursAssignmentAdvisory.shift.message"
+                class="attendance__status"
+                :class="{
+                  'attendance__status--warn': comprehensiveHoursAssignmentAdvisory.shift.kind === 'warn',
+                  'attendance__status--error': comprehensiveHoursAssignmentAdvisory.shift.kind === 'error'
+                }"
+                data-attendance-comprehensive-hours-assignment-advisory="shift"
+              >
+                {{ comprehensiveHoursAssignmentAdvisory.shift.message }}
+              </p>
               <div class="attendance__admin-actions">
                 <button class="attendance__btn attendance__btn--primary" :disabled="assignmentSaving" @click="saveAssignment">
                   {{ assignmentSaving ? tr('Saving...', '保存中...') : assignmentEditingId ? tr('Update assignment', '更新分配') : tr('Create assignment', '创建分配') }}
@@ -6346,6 +6368,13 @@ interface AttendanceComprehensiveHoursPreviewResult {
   rows: AttendanceComprehensiveHoursPreviewRow[]
   aggregate: AttendanceComprehensiveHoursPreviewAggregate
   degraded?: boolean
+}
+
+type AttendanceComprehensiveHoursAssignmentKind = 'shift' | 'rotation'
+
+interface AttendanceComprehensiveHoursAssignmentAdvisory {
+  kind: 'info' | 'warn' | 'error'
+  message: string
 }
 
 interface CalendarDay {
@@ -7606,6 +7635,10 @@ const comprehensiveHoursPreviewLoading = ref(false)
 const comprehensiveHoursPreviewStatus = ref<{ kind: 'info' | 'warn' | 'error'; message: string }>({
   kind: 'info',
   message: '',
+})
+const comprehensiveHoursAssignmentAdvisory = reactive<Record<AttendanceComprehensiveHoursAssignmentKind, AttendanceComprehensiveHoursAssignmentAdvisory>>({
+  shift: { kind: 'info', message: '' },
+  rotation: { kind: 'info', message: '' },
 })
 const holidayEditingId = ref<string | null>(null)
 const leaveTypeEditingId = ref<string | null>(null)
@@ -14411,6 +14444,104 @@ async function previewComprehensiveHours() {
   }
 }
 
+function setComprehensiveHoursAssignmentAdvisory(
+  kind: AttendanceComprehensiveHoursAssignmentKind,
+  advisory: AttendanceComprehensiveHoursAssignmentAdvisory,
+): void {
+  comprehensiveHoursAssignmentAdvisory[kind] = advisory
+}
+
+function clearComprehensiveHoursAssignmentAdvisory(kind: AttendanceComprehensiveHoursAssignmentKind): void {
+  setComprehensiveHoursAssignmentAdvisory(kind, { kind: 'info', message: '' })
+}
+
+function resolveComprehensiveHoursAssignmentStatus(
+  result: AttendanceComprehensiveHoursPreviewResult | null | undefined,
+): AttendanceComprehensiveHoursStatus {
+  const aggregateStatus = result?.aggregate?.status
+  if (aggregateStatus === 'violation' || aggregateStatus === 'warning' || aggregateStatus === 'ok') {
+    return aggregateStatus
+  }
+  if (result?.rows?.some(row => row.status === 'violation')) return 'violation'
+  if (result?.rows?.some(row => row.status === 'warning')) return 'warning'
+  return 'ok'
+}
+
+function comprehensiveHoursAssignmentAdvisoryMessage(
+  result: AttendanceComprehensiveHoursPreviewResult | null | undefined,
+): string {
+  if (result?.degraded) {
+    return tr(
+      'Comprehensive-hours advisory preview returned degraded data; saving is still allowed in this stage.',
+      '综合工时提示预览返回降级数据；当前阶段仍允许保存。',
+    )
+  }
+  const status = resolveComprehensiveHoursAssignmentStatus(result)
+  if (status === 'violation') {
+    return tr(
+      'Comprehensive-hours advisory before save: planned minutes exceed the draft cap. Saving is still allowed in this stage.',
+      '保存前综合工时提示：计划工时已超过草稿上限；当前阶段仍允许保存。',
+    )
+  }
+  if (status === 'warning') {
+    return tr(
+      'Comprehensive-hours advisory before save: planned minutes are close to the draft cap. Saving is still allowed in this stage.',
+      '保存前综合工时提示：计划工时接近草稿上限；当前阶段仍允许保存。',
+    )
+  }
+  return ''
+}
+
+async function previewComprehensiveHoursAssignmentAdvisory(
+  kind: AttendanceComprehensiveHoursAssignmentKind,
+  draft: { userId: string; startDate: string; endDate: string | null; isActive: boolean },
+): Promise<void> {
+  clearComprehensiveHoursAssignmentAdvisory(kind)
+  if (!draft.isActive) return
+  const userId = draft.userId.trim()
+  const from = draft.startDate.trim()
+  if (!userId || !from) return
+  const capHours = Number(comprehensiveHoursPreviewForm.capHours)
+  const body = {
+    policyDraft: {
+      capHours: Number.isFinite(capHours) && capHours > 0 ? capHours : 160,
+      enforcement: 'warn',
+    },
+    scope: { userId },
+    period: {
+      type: 'custom_range',
+      from,
+      to: draft.endDate || from,
+    },
+    metric: 'planned',
+  }
+  try {
+    const query = buildQuery({ orgId: normalizedOrgId() })
+    const response = await apiFetch(`/api/attendance/comprehensive-hours/preview?${query.toString()}`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(body),
+    })
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to preview comprehensive hours', '综合工时预览失败')))
+    }
+    const result = data.data as AttendanceComprehensiveHoursPreviewResult | null | undefined
+    const message = comprehensiveHoursAssignmentAdvisoryMessage(result)
+    if (message) {
+      setComprehensiveHoursAssignmentAdvisory(kind, { kind: 'warn', message })
+    }
+  } catch (error: any) {
+    setComprehensiveHoursAssignmentAdvisory(kind, {
+      kind: 'error',
+      message: tr(
+        'Comprehensive-hours advisory preview is unavailable; saving is still allowed in this stage.',
+        '综合工时提示预览暂不可用；当前阶段仍允许保存。',
+      ) + ` ${readErrorMessage(error, '')}`.trimEnd(),
+    })
+  }
+}
+
 function resetRotationRuleForm() {
   rotationRuleEditingId.value = null
   rotationRuleForm.name = ''
@@ -14576,6 +14707,12 @@ async function saveRotationAssignment() {
       isActive: rotationAssignmentForm.isActive,
       orgId: normalizedOrgId(),
     }
+    await previewComprehensiveHoursAssignmentAdvisory('rotation', {
+      userId: payload.userId,
+      startDate: payload.startDate,
+      endDate: payload.endDate,
+      isActive: payload.isActive,
+    })
     const endpoint = isEditing
       ? `/api/attendance/rotation-assignments/${rotationAssignmentEditingId.value}`
       : '/api/attendance/rotation-assignments'
@@ -14796,6 +14933,12 @@ async function saveAssignment() {
       isActive: assignmentForm.isActive,
       orgId: normalizedOrgId(),
     }
+    await previewComprehensiveHoursAssignmentAdvisory('shift', {
+      userId: payload.userId,
+      startDate: payload.startDate,
+      endDate: payload.endDate,
+      isActive: payload.isActive,
+    })
     const endpoint = isEditing
       ? `/api/attendance/assignments/${assignmentEditingId.value}`
       : '/api/attendance/assignments'
@@ -16254,6 +16397,10 @@ const holidaySectionBindings = {
 
 .attendance__status--error {
   color: #c62828;
+}
+
+.attendance__status--warn {
+  color: #9a6700;
 }
 
 .attendance__grid {

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -989,6 +989,288 @@ describe('Attendance admin regressions', () => {
     expect(buttons.join(' ')).not.toContain('Delete')
   })
 
+  it('runs a weak comprehensive-hours advisory before saving shift assignments without blocking save', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/shifts')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'shift-a',
+                name: 'Day shift',
+                timezone: 'UTC',
+                workStartTime: '09:00',
+                workEndTime: '18:00',
+                isOvernight: false,
+                lateGraceMinutes: 10,
+                earlyGraceMinutes: 10,
+                roundingMinutes: 5,
+                workingDays: [1, 2, 3, 4, 5],
+              },
+            ],
+          },
+        })
+      }
+      if (url.includes('/api/attendance/comprehensive-hours/preview')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            readOnly: true,
+            period: { type: 'custom_range', from: '2026-05-01', to: '2026-05-10' },
+            metric: 'planned',
+            enforcement: 'warn',
+            capMinutes: 9600,
+            scope: { userIds: ['user-9'] },
+            aggregate: {
+              users: 1,
+              ok: 0,
+              warning: 0,
+              violation: 1,
+              totalMinutes: 10200,
+              totalExcessMinutes: 600,
+              totalRemainingMinutes: 0,
+              status: 'violation',
+            },
+            rows: [
+              {
+                userId: 'user-9',
+                minutes: 10200,
+                plannedMinutes: 10200,
+                capMinutes: 9600,
+                remainingMinutes: 0,
+                excessMinutes: 600,
+                status: 'violation',
+                source: 'effective_calendar',
+              },
+            ],
+            degraded: false,
+          },
+        })
+      }
+      if (url === '/api/attendance/assignments' && init?.method === 'POST') {
+        return jsonResponse(200, { ok: true })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const assignmentsNav = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-assignments"]')
+    expect(assignmentsNav).toBeTruthy()
+    assignmentsNav!.click()
+    await flushUi(2)
+
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
+    expect(section).toBeTruthy()
+    setInput(section!, '#attendance-assignment-user-id', 'user-9')
+    const shiftSelect = section!.querySelector<HTMLSelectElement>('#attendance-assignment-shift-id')
+    expect(shiftSelect).toBeTruthy()
+    shiftSelect!.value = 'shift-a'
+    shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(section!, '#attendance-assignment-start-date', '2026-05-01')
+    setInput(section!, '#attendance-assignment-end-date', '2026-05-10')
+    await flushUi(2)
+
+    const createButton = Array.from(section!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Create assignment'))
+    expect(createButton).toBeTruthy()
+    expect(createButton!.disabled).toBe(false)
+    createButton!.click()
+    await flushUi(8)
+
+    const previewCallIndex = vi.mocked(apiFetch).mock.calls.findIndex(([input]) =>
+      String(input).includes('/api/attendance/comprehensive-hours/preview')
+    )
+    const saveCallIndex = vi.mocked(apiFetch).mock.calls.findIndex(([input, init]) =>
+      String(input) === '/api/attendance/assignments' && init?.method === 'POST'
+    )
+    expect(previewCallIndex).toBeGreaterThanOrEqual(0)
+    expect(saveCallIndex).toBeGreaterThan(previewCallIndex)
+    const previewBody = JSON.parse(String(vi.mocked(apiFetch).mock.calls[previewCallIndex]![1]!.body))
+    expect(previewBody).toMatchObject({
+      policyDraft: { capHours: 160, enforcement: 'warn' },
+      scope: { userId: 'user-9' },
+      period: { type: 'custom_range', from: '2026-05-01', to: '2026-05-10' },
+      metric: 'planned',
+    })
+    expect(previewBody).not.toHaveProperty('allUsers')
+    expect(section!.querySelector('[data-attendance-comprehensive-hours-assignment-advisory="shift"]')?.textContent)
+      .toContain('Saving is still allowed')
+    expect(container!.textContent).toContain('Assignment created.')
+  })
+
+  it('runs a weak comprehensive-hours advisory before saving rotation assignments without blocking save', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/rotation-rules')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'rot-1',
+                name: 'Two shift',
+                timezone: 'UTC',
+                shiftSequence: ['shift-a', 'shift-b'],
+                isActive: true,
+              },
+            ],
+          },
+        })
+      }
+      if (url.includes('/api/attendance/comprehensive-hours/preview')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            readOnly: true,
+            period: { type: 'custom_range', from: '2026-05-01', to: '2026-05-10' },
+            metric: 'planned',
+            enforcement: 'warn',
+            capMinutes: 9600,
+            scope: { userIds: ['user-7'] },
+            aggregate: {
+              users: 1,
+              ok: 0,
+              warning: 1,
+              violation: 0,
+              totalMinutes: 9500,
+              totalExcessMinutes: 0,
+              totalRemainingMinutes: 100,
+              status: 'warning',
+            },
+            rows: [
+              {
+                userId: 'user-7',
+                minutes: 9500,
+                plannedMinutes: 9500,
+                capMinutes: 9600,
+                remainingMinutes: 100,
+                excessMinutes: 0,
+                status: 'warning',
+                source: 'effective_calendar',
+              },
+            ],
+            degraded: false,
+          },
+        })
+      }
+      if (url === '/api/attendance/rotation-assignments' && init?.method === 'POST') {
+        return jsonResponse(200, { ok: true })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-rotation-assignments')
+    expect(section).toBeTruthy()
+    setInput(section!, '#attendance-rotation-user', 'user-7')
+    const rotationSelect = section!.querySelector<HTMLSelectElement>('#attendance-rotation-rule')
+    expect(rotationSelect).toBeTruthy()
+    rotationSelect!.value = 'rot-1'
+    rotationSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(section!, '#attendance-rotation-start', '2026-05-01')
+    setInput(section!, '#attendance-rotation-end', '2026-05-10')
+    await flushUi(2)
+
+    const createButton = Array.from(section!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Create assignment'))
+    expect(createButton).toBeTruthy()
+    createButton!.click()
+    await flushUi(8)
+
+    const previewCallIndex = vi.mocked(apiFetch).mock.calls.findIndex(([input]) =>
+      String(input).includes('/api/attendance/comprehensive-hours/preview')
+    )
+    const saveCallIndex = vi.mocked(apiFetch).mock.calls.findIndex(([input, init]) =>
+      String(input) === '/api/attendance/rotation-assignments' && init?.method === 'POST'
+    )
+    expect(previewCallIndex).toBeGreaterThanOrEqual(0)
+    expect(saveCallIndex).toBeGreaterThan(previewCallIndex)
+    const previewBody = JSON.parse(String(vi.mocked(apiFetch).mock.calls[previewCallIndex]![1]!.body))
+    expect(previewBody).toMatchObject({
+      policyDraft: { capHours: 160, enforcement: 'warn' },
+      scope: { userId: 'user-7' },
+      period: { type: 'custom_range', from: '2026-05-01', to: '2026-05-10' },
+      metric: 'planned',
+    })
+    expect(previewBody).not.toHaveProperty('allUsers')
+    expect(section!.querySelector('[data-attendance-comprehensive-hours-assignment-advisory="rotation"]')?.textContent)
+      .toContain('Saving is still allowed')
+    expect(container!.textContent).toContain('Rotation assignment created.')
+  })
+
+  it('keeps shift assignment save available when the weak comprehensive-hours advisory preview fails', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/shifts')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'shift-a',
+                name: 'Day shift',
+                timezone: 'UTC',
+                workStartTime: '09:00',
+                workEndTime: '18:00',
+                isOvernight: false,
+                lateGraceMinutes: 10,
+                earlyGraceMinutes: 10,
+                roundingMinutes: 5,
+                workingDays: [1, 2, 3, 4, 5],
+              },
+            ],
+          },
+        })
+      }
+      if (url.includes('/api/attendance/comprehensive-hours/preview')) {
+        return jsonResponse(503, {
+          ok: false,
+          error: { code: 'DB_NOT_READY', message: 'schema not ready' },
+        })
+      }
+      if (url === '/api/attendance/assignments' && init?.method === 'POST') {
+        return jsonResponse(200, { ok: true })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
+    expect(section).toBeTruthy()
+    setInput(section!, '#attendance-assignment-user-id', 'user-9')
+    const shiftSelect = section!.querySelector<HTMLSelectElement>('#attendance-assignment-shift-id')
+    expect(shiftSelect).toBeTruthy()
+    shiftSelect!.value = 'shift-a'
+    shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(section!, '#attendance-assignment-start-date', '2026-05-01')
+    setInput(section!, '#attendance-assignment-end-date', '2026-05-10')
+    await flushUi(2)
+
+    const createButton = Array.from(section!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Create assignment'))
+    expect(createButton).toBeTruthy()
+    createButton!.click()
+    await flushUi(8)
+
+    expect(vi.mocked(apiFetch).mock.calls.some(([input, init]) =>
+      String(input) === '/api/attendance/assignments' && init?.method === 'POST'
+    )).toBe(true)
+    expect(section!.querySelector('[data-attendance-comprehensive-hours-assignment-advisory="shift"]')?.textContent)
+      .toContain('saving is still allowed')
+    expect(container!.textContent).toContain('Assignment created.')
+  })
+
   it('restores the run21 holiday calendar, rule builder, and import template guidance', async () => {
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)

--- a/docs/development/attendance-comprehensive-hours-control-pr4-warning-development-20260523.md
+++ b/docs/development/attendance-comprehensive-hours-control-pr4-warning-development-20260523.md
@@ -1,0 +1,93 @@
+# Attendance comprehensive-hours PR4 weak warning development - 2026-05-23
+
+## Summary
+
+This slice implements the runtime part of PR4 from
+`attendance-comprehensive-hours-control-pr4-warning-design-20260522.md`.
+
+The change is intentionally weak-control only: shift-assignment and
+rotation-assignment saves run a read-only comprehensive-hours advisory preview
+before calling the existing save endpoint, but preview status never blocks the
+original save.
+
+## Files Changed
+
+| File | Change |
+| --- | --- |
+| `apps/web/src/views/AttendanceView.vue` | Adds assignment-save advisory state, reuses `POST /api/attendance/comprehensive-hours/preview`, renders warning/error text near shift and rotation assignment save buttons, then always continues the original save path. |
+| `apps/web/tests/attendance-admin-regressions.spec.ts` | Adds weak-control regression tests for violation and preview-error paths. |
+| `docs/development/attendance-comprehensive-hours-preview-runtime-smoke-verification-20260523.md` | Records production runtime smoke for the #1777 read-only preview UI and route on `23.254.236.11`. |
+| `docs/development/attendance-comprehensive-hours-control-pr4-warning-development-20260523.md` | This development note. |
+| `docs/development/attendance-comprehensive-hours-control-pr4-warning-verification-20260523.md` | Runtime verification note for this slice. |
+
+## Save-Time Advisory Contract
+
+The assignment save flow now performs this sequence:
+
+1. Validate the existing assignment form exactly as before.
+2. Build a read-only comprehensive-hours preview body from the validated draft.
+3. Call the existing backend preview route.
+4. Render a local advisory if the preview returns `warning`, `violation`,
+   degraded data, or an unavailable/error response.
+5. Continue the original assignment save request.
+
+The preview request body is deliberately narrow:
+
+```json
+{
+  "policyDraft": {
+    "capHours": 160,
+    "enforcement": "warn"
+  },
+  "scope": {
+    "userId": "<assignment-user-id>"
+  },
+  "period": {
+    "type": "custom_range",
+    "from": "<assignment-start-date>",
+    "to": "<assignment-end-date-or-start-date>"
+  },
+  "metric": "planned"
+}
+```
+
+Key details:
+
+- `metric` is always `planned`.
+- `enforcement` is always `warn` for save-time advisory previews.
+- `scope` is always a single explicit `userId`.
+- `allUsers` is never emitted.
+- Open-ended assignments use the start date as the conservative one-day preview
+  end date.
+
+## Behavior Matrix
+
+| Preview result | UI message | Save behavior |
+| --- | --- | --- |
+| `ok` | No advisory message. | Original save continues. |
+| `warning` | Advisory copy says planned minutes are close to the draft cap. | Original save continues. |
+| `violation` | Advisory copy says planned minutes exceed the draft cap. | Original save continues. |
+| `degraded` | Advisory copy says preview returned degraded data. | Original save continues. |
+| `400` / `503` / network error | Advisory copy says preview is unavailable. | Original save continues. |
+
+All copy avoids PR5 language such as blocked, cannot save, policy enforced, or
+violation prevented.
+
+## Boundaries
+
+| Boundary | Status |
+| --- | --- |
+| Backend route changes | None. Reuses `POST /api/attendance/comprehensive-hours/preview`. |
+| `attendance_*` migrations | None. |
+| `meta_*` writes | None. |
+| Policy persistence | None. |
+| Strong block-save guard | Deferred to PR5. |
+| Actual-minute enforcement | Not used. Save-time warning uses planned minutes only. |
+| All-users save preview | Not used. |
+
+## Runtime Evidence Link
+
+The production runtime smoke for the existing PR3 preview UI/route is recorded in
+`attendance-comprehensive-hours-preview-runtime-smoke-verification-20260523.md`.
+It confirms that the reused preview route is deployed and responds on
+`23.254.236.11:8081` before this weak-warning slice adds a caller.

--- a/docs/development/attendance-comprehensive-hours-control-pr4-warning-verification-20260523.md
+++ b/docs/development/attendance-comprehensive-hours-control-pr4-warning-verification-20260523.md
@@ -1,0 +1,55 @@
+# Attendance comprehensive-hours PR4 weak warning verification - 2026-05-23
+
+## Scope Verified
+
+This runtime slice adds weak comprehensive-hours advisory warnings to shift and
+rotation assignment saves. It does not add backend routes, persistence, or
+block-save behavior.
+
+## Contract Coverage
+
+| Contract | Evidence |
+| --- | --- |
+| Reuses existing preview route | Tests assert `POST /api/attendance/comprehensive-hours/preview` is called before save. |
+| Planned metric only | Tests assert request body `metric: "planned"`. |
+| Weak warning only | Tests assert assignment save still calls `/api/attendance/assignments` after preview violation. |
+| Preview error does not block save | Tests assert a `503 DB_NOT_READY` preview response still allows assignment save. |
+| No all-users body | Tests assert preview body has no `allUsers` property. |
+| No new backend/migration/persistence | Changed files are frontend test/view docs only; plugin syntax check is clean. |
+
+## Test Results
+
+| Command | Result |
+| --- | --- |
+| `node --check plugins/plugin-attendance/index.cjs` | PASS |
+| `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts tests/attendance-admin-anchor-nav.spec.ts --watch=false` | PASS, 41 tests |
+| `pnpm --filter @metasheet/web type-check` | PASS |
+| `pnpm --filter @metasheet/web build` | PASS |
+| `git diff --check` | PASS |
+| Secret/home-path scan over changed 2026-05-23 docs + frontend files | PASS, 0 matches |
+
+## Runtime Smoke Dependency
+
+The reused backend route and PR3 read-only UI were smoke-tested on production
+before this slice:
+
+- API base: `http://23.254.236.11:8081`
+- admin JWT read from local `0600` file, token value not printed
+- `GET /api/auth/me`: PASS
+- unauthenticated preview route: HTTP 401 rather than 404
+- authenticated planned preview: HTTP 200
+- UI route `/attendance?tab=admin#attendance-admin-comprehensive-hours-preview`:
+  PASS with one row and aggregate OK
+
+Full evidence is in
+`attendance-comprehensive-hours-preview-runtime-smoke-verification-20260523.md`.
+
+## Remaining Explicitly Deferred
+
+| Follow-up | Status |
+| --- | --- |
+| PR5 strong-control block-save guard | Deferred; requires separate explicit opt-in. |
+| Stored comprehensive-hours policies | Deferred. |
+| Actual-minute enforcement on save | Deferred. |
+| All-users save preview | Deferred. |
+| Reporting / multitable snapshot | Deferred. |

--- a/docs/development/attendance-comprehensive-hours-preview-runtime-smoke-verification-20260523.md
+++ b/docs/development/attendance-comprehensive-hours-preview-runtime-smoke-verification-20260523.md
@@ -1,0 +1,126 @@
+# Attendance comprehensive-hours preview runtime smoke - 2026-05-23
+
+## Scope
+
+This verification records a production runtime smoke for the comprehensive-hours
+preview UI and backend route after the deploy host moved from the legacy
+`142.171.239.56` address to `23.254.236.11`.
+
+The smoke is read-only:
+
+- no attendance fact table writes;
+- no settings or policy persistence;
+- no schedule save / block-save path;
+- no token value recorded in this file.
+
+## Environment
+
+| Item | Value |
+| --- | --- |
+| API base | `http://23.254.236.11:8081` |
+| Token source | local file, `0600`, value not printed |
+| Production repo HEAD | `dc24a793d` |
+| Production backend image | `ghcr.io/zensgit/metasheet2-backend:dc24a793d42e914f437860cabb3f17eae69f4777` |
+| Production web image | `ghcr.io/zensgit/metasheet2-web:dc24a793d42e914f437860cabb3f17eae69f4777` |
+| Confirmed ancestry | includes `#1777` comprehensive-hours preview UI and `#1779` effective-calendar badge slice |
+
+## Runtime health
+
+| Check | Result |
+| --- | --- |
+| SSH to `23.254.236.11` as `mainuser` | PASS |
+| `http://23.254.236.11:8081/api/health` | PASS, HTTP 200 |
+| `http://23.254.236.11:8082/api/health` | PASS, HTTP 200 |
+| main web `/` | PASS, HTTP 200 |
+| staging web `/` | PASS, HTTP 200 |
+| main backend `/health` from host side | PASS |
+| staging backend `/health` from host side | PASS |
+
+## Auth and backend route smoke
+
+The admin JWT was read from a local restricted-permission file. The token value
+was not printed.
+
+| Check | Result |
+| --- | --- |
+| `GET /api/auth/me` | PASS, user `zhouhua@china-yaguang.com`, role `admin` |
+| unauthenticated `POST /api/attendance/comprehensive-hours/preview` | PASS, HTTP 401 `Missing Bearer token` rather than 404 |
+| authenticated planned preview | PASS, HTTP 200 |
+
+Authenticated preview payload shape:
+
+```json
+{
+  "metric": "planned",
+  "enforcement": "warn",
+  "capMinutes": 480,
+  "userIds": ["<sample-user-id>"],
+  "period": {
+    "type": "custom_range",
+    "from": "2026-05-01",
+    "to": "2026-05-01"
+  }
+}
+```
+
+Authenticated preview response summary:
+
+| Field | Value |
+| --- | --- |
+| `ok` | `true` |
+| `data.readOnly` | `true` |
+| `data.metric` | `planned` |
+| `data.enforcement` | `warn` |
+| `data.rows.length` | `1` |
+| `data.aggregate.status` | `ok` |
+| `data.period.key` | `range:2026-05-01:2026-05-01` |
+
+## UI smoke
+
+The browser smoke used a normal Playwright browser context with the same local
+admin JWT injected into browser storage. The in-app Browser plugin could not be
+used for authenticated navigation because its page context had no
+`localStorage`, `sessionStorage`, or `cookie` storage available.
+
+Flow:
+
+1. Open `http://23.254.236.11:8081/attendance`.
+2. Authenticate with the local admin JWT.
+3. Open `Admin Center`.
+4. Jump to `Comprehensive hours`.
+5. Enter one explicit user id.
+6. Select `custom_range`, `2026-05-01` to `2026-05-01`.
+7. Select `planned`, `warn`, `8` cap hours.
+8. Click `Preview comprehensive hours`.
+
+Observed UI result:
+
+| UI assertion | Result |
+| --- | --- |
+| URL | `http://23.254.236.11:8081/attendance?tab=admin#attendance-admin-comprehensive-hours-preview` |
+| `GET /api/auth/me` | HTTP 200 |
+| `POST /api/attendance/comprehensive-hours/preview` | HTTP 200 |
+| Status text | `Read-only preview refreshed. No policy was saved.` |
+| Read-only chip | `Read-only preview` |
+| Result rows | `1` |
+| Aggregate users | `1` |
+| Aggregate OK | `1` |
+| Aggregate warnings | `0` |
+| Aggregate violations | `0` |
+
+Screenshot artifact was written outside the repo at:
+
+```text
+/tmp/attendance-comprehensive-hours-ui-smoke-20260523.png
+```
+
+## Conclusion
+
+PASS. The comprehensive-hours preview backend route and admin UI are deployed on
+the production runtime behind `23.254.236.11:8081`. The smoke confirms the
+intended PR3 boundary: read-only preview works, returns a backend 200, renders
+rows and aggregate status, and explicitly reports that no policy was saved.
+
+This closes the runtime evidence gap left by the previous legacy-IP deploy-host
+SSH timeout. Future PR4 work should remain warning-only until the separately
+scoped strong-control PR is explicitly approved.


### PR DESCRIPTION
## Summary

Adds PR4 weak-control comprehensive-hours advisories to scheduling saves.

- Shift and rotation assignment saves call the existing `POST /api/attendance/comprehensive-hours/preview` route before the original save request.
- Preview body is explicit and narrow: single `userId`, `metric: planned`, `enforcement: warn`, custom assignment date range, and no `allUsers`.
- Warning/violation/degraded/error states render advisory copy near the save controls; save remains allowed and the original save request still runs.
- Includes runtime smoke evidence for the deployed PR3 read-only preview route/UI on `23.254.236.11:8081`.

## Boundaries

- No backend route changes.
- No `attendance_*` migration.
- No `meta_*` writes.
- No policy persistence.
- No strong block-save behavior; PR5 remains deferred.

## Test plan

- [x] `node --check plugins/plugin-attendance/index.cjs`
- [x] `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts tests/attendance-admin-anchor-nav.spec.ts --watch=false` (41 tests)
- [x] `pnpm --filter @metasheet/web type-check`
- [x] `pnpm --filter @metasheet/web build`
- [x] `git diff --cached --check`
- [x] Staged secret/home-path scan (0 matches)