### PR TITLE
fix(attendance): adapt strict smoke to current overview

### DIFF
--- a/docs/development/attendance-strict-smoke-current-overview-development-20260523.md
+++ b/docs/development/attendance-strict-smoke-current-overview-development-20260523.md
@@ -1,0 +1,83 @@
+# Attendance Strict Smoke Current Overview Adaptation - Development Notes
+
+Date: 2026-05-23
+
+## Summary
+
+The production deployment moved to the newer Attendance information architecture:
+
+- `Records` now lives under the `Reports` tab instead of the default `Overview` tab.
+- Admin Center uses a focused section rail. Only the active `data-admin-section` is visible.
+- Import payload templates can still contain display-only `columns` hints, while the current import API accepts either no `columns` for CSV imports or structured column objects.
+- Mobile Admin Center can show the real admin console instead of the older `Desktop recommended` gate.
+
+The strict production gates were still using older Playwright assumptions, so the deployment itself passed API smoke and provisioning but timed out in UI checks. This change adapts the verification scripts to the current UI without changing product runtime code.
+
+## Scope
+
+Changed scripts:
+
+- `scripts/verify-attendance-production-flow.mjs`
+- `scripts/verify-attendance-full-flow.mjs`
+
+No runtime product code, migrations, API handlers, workflow files, K3/Data Factory/Bridge Agent code, or package build scripts are changed.
+
+## Design
+
+### 1. Records Discovery
+
+Both scripts now treat `Records` as a tab-scoped surface:
+
+1. Look for a visible `Records` card/section.
+2. If it is not visible, click the `Reports` tab.
+3. Wait for the `Records` card/section inside Reports.
+
+The full-flow script switches back to `Overview` after Records assertions, because the `Anomalies` card remains an overview surface.
+
+### 2. Admin Section Selection
+
+Admin Center checks now use the product's stable rail attributes:
+
+- `data-admin-quick-jump="true"`
+- `data-admin-section="<section-id>"`
+
+This avoids waiting for hidden headings. The scripts explicitly select:
+
+- `attendance-admin-user-access`
+- `attendance-admin-import`
+- `attendance-admin-settings`
+- `attendance-admin-default-rule`
+- `attendance-admin-payroll-cycles`
+
+The production flow also attempts `attendance-admin-import-batches`, but treats it as optional UI evidence because the current DOM nests that section under the import section; API batch-item verification remains the hard assertion.
+
+### 3. Import Payload Compatibility
+
+The production flow removes display-only string `columns` arrays before calling import preview/commit. Current import schema expects structured column objects if `columns` is supplied; the CSV path does not need `columns`, so deleting legacy template hints is the least invasive compatibility fix.
+
+The full-flow recovery path applies the same sanitization before building upload-based import payloads.
+
+### 4. Status Message Matching
+
+The invalid JSON retry assertion now matches the start of the localized message instead of an exact full string. The current UI appends timezone context to the error message, so exact matching was brittle while the user-visible error itself was correct.
+
+### 5. Mobile Admin Center
+
+The mobile full-flow accepts either:
+
+- the old `Desktop recommended` gate, or
+- the current `Admin Console` surface.
+
+This keeps the gate compatible with both deployed UI shapes.
+
+## Deployment Impact
+
+None. This is an ops/test-script adaptation only.
+
+## Security
+
+No secrets are stored in repo files. Live verification used a local `0600` token file and passed the token only through `AUTH_TOKEN`.
+
+## Known Follow-Up
+
+`attendance-admin-import-batches` is currently nested under the import admin section, so selecting it through the focused rail can make its parent hidden. This PR does not change product UI; it records the issue by warning and preserves API-level batch validation in the smoke path.

--- a/docs/development/attendance-strict-smoke-current-overview-verification-20260523.md
+++ b/docs/development/attendance-strict-smoke-current-overview-verification-20260523.md
@@ -36,6 +36,15 @@ git diff --check
 
 Result: PASS.
 
+Follow-up review fixes:
+
+- Removed a redundant second `selectAdminSection()` call in
+  `verify-attendance-full-flow.mjs` so the import-section fallback can continue
+  to skip optional assertions when the first admin-section lookup is caught.
+- Reused the first `User Access` section handle in
+  `verify-attendance-production-flow.mjs` so the screenshot and role
+  provisioning checks share one quick-jump selection.
+
 ## Live Verification Target
 
 Target:

--- a/docs/development/attendance-strict-smoke-current-overview-verification-20260523.md
+++ b/docs/development/attendance-strict-smoke-current-overview-verification-20260523.md
@@ -1,0 +1,164 @@
+# Attendance Strict Smoke Current Overview Adaptation - Verification
+
+Date: 2026-05-23
+
+## Context
+
+After the deploy host IP was updated to `23.254.236.11`, the production deploy workflow recovered:
+
+- `Build and Push Docker Images` run `26327831118`: success
+- `Attendance Locale zh Smoke (Prod)` run `26327830919`: success
+- `Attendance Remote Preflight (Prod)` run `26327913495`: success
+- `Attendance Remote Metrics (Prod)` run `26327914080`: success
+- `Attendance Remote Storage Health (Prod)` run `26327913654`: success
+
+`Attendance Strict Gates (Prod)` run `26328283120` was then triggered with `expect_product_mode=platform`.
+
+Result:
+
+- `apiSmoke`: PASS
+- `provisioning`: PASS
+- `playwrightProd`: FAIL, reason `TIMEOUT`
+- `playwrightDesktop`: FAIL, reason `TIMEOUT`
+- `playwrightMobile`: FAIL, reason `TIMEOUT`
+
+The artifact screenshot showed the current Attendance overview and confirmed that `Records` is no longer on the default overview screen.
+
+## Static Checks
+
+Commands:
+
+```bash
+node --check scripts/verify-attendance-production-flow.mjs
+node --check scripts/verify-attendance-full-flow.mjs
+git diff --check
+```
+
+Result: PASS.
+
+## Live Verification Target
+
+Target:
+
+- Web URL: `http://23.254.236.11:8081/attendance`
+- API base: `http://23.254.236.11:8081/api`
+- Expected product mode: `platform`
+
+Auth:
+
+- Used local token file `/tmp/metasheet-23-main-admin-72h-20260523T082748Z.jwt`.
+- Token value was not printed.
+- `/api/auth/me` reported admin user and enabled attendance features.
+
+## Production Flow
+
+Command shape:
+
+```bash
+AUTH_TOKEN="$(cat /tmp/metasheet-23-main-admin-72h-20260523T082748Z.jwt)" \
+WEB_URL=http://23.254.236.11:8081/attendance \
+API_BASE=http://23.254.236.11:8081/api \
+EXPECT_PRODUCT_MODE=platform \
+HEADLESS=true \
+OUTPUT_DIR=/tmp/attendance-production-flow-current-overview-6 \
+node scripts/verify-attendance-production-flow.mjs
+```
+
+Result: PASS.
+
+Observed evidence:
+
+- Features: `attendance=true`, `attendanceAdmin=true`, `attendanceImport=true`, `mode=platform`.
+- Records was not visible on Overview, so the script switched to Reports.
+- Punch API returned ok.
+- Adjustment request returned `DUPLICATE_REQUEST`; this is an accepted best-effort warning because the script had already created today's request in earlier retries.
+- User Access admin section loaded through `data-admin-quick-jump`.
+- Import template loaded.
+- CSV payload loaded.
+- Mapping profile applied.
+- Import preview returned `items=1`.
+- Import commit returned `imported=1`.
+- Import batches UI was not reachable through the focused rail; the script continued to API batch-item verification.
+- Group and membership API verification passed.
+- Final Records refresh passed after switching to Reports.
+- Final log: `Production flow verification complete`.
+
+Output screenshots:
+
+- `/tmp/attendance-production-flow-current-overview-6/01-overview-loaded.png`
+- `/tmp/attendance-production-flow-current-overview-6/02-overview-after-request.png`
+- `/tmp/attendance-production-flow-current-overview-6/03-admin-loaded.png`
+- `/tmp/attendance-production-flow-current-overview-6/03a-admin-user-access.png`
+- `/tmp/attendance-production-flow-current-overview-6/04-import-preview.png`
+- `/tmp/attendance-production-flow-current-overview-6/05-import-batches.png`
+- `/tmp/attendance-production-flow-current-overview-6/06-overview-after-import.png`
+
+## Full Flow - Desktop
+
+Command shape:
+
+```bash
+AUTH_TOKEN="$(cat /tmp/metasheet-23-main-admin-72h-20260523T082748Z.jwt)" \
+WEB_URL=http://23.254.236.11:8081/attendance \
+API_BASE=http://23.254.236.11:8081/api \
+EXPECT_PRODUCT_MODE=platform \
+HEADLESS=true \
+OUTPUT_DIR=/tmp/attendance-full-flow-current-overview-3 \
+node scripts/verify-attendance-full-flow.mjs
+```
+
+Result: PASS.
+
+Observed evidence:
+
+- Loaded features from `/api/auth/me`.
+- Records was not visible on Overview, so the script switched to Reports.
+- The script returned to Overview and verified the Anomalies card.
+- Invalid JSON import retry feedback was verified with the current message shape.
+- Admin settings save cycle passed.
+- Default rule save cycle passed.
+- Payroll batch UI passed.
+- Final log: `Full flow verification complete`.
+
+Output screenshots:
+
+- `/tmp/attendance-full-flow-current-overview-3/01-overview.png`
+- `/tmp/attendance-full-flow-current-overview-3/02-admin.png`
+
+## Full Flow - Mobile
+
+Command shape:
+
+```bash
+AUTH_TOKEN="$(cat /tmp/metasheet-23-main-admin-72h-20260523T082748Z.jwt)" \
+WEB_URL=http://23.254.236.11:8081/attendance \
+API_BASE=http://23.254.236.11:8081/api \
+EXPECT_PRODUCT_MODE=platform \
+HEADLESS=true \
+UI_MOBILE=true \
+OUTPUT_DIR=/tmp/attendance-full-flow-current-overview-mobile-2 \
+node scripts/verify-attendance-full-flow.mjs
+```
+
+Result: PASS.
+
+Observed evidence:
+
+- Loaded features from `/api/auth/me`.
+- Records was not visible on Overview, so the script switched to Reports.
+- The script returned to Overview and verified the Anomalies card.
+- Mobile Admin Center accepted the current Admin Console surface.
+- Final log: `Full flow verification complete`.
+
+Output screenshots:
+
+- `/tmp/attendance-full-flow-current-overview-mobile-2/01-overview.png`
+- `/tmp/attendance-full-flow-current-overview-mobile-2/02-admin.png`
+
+## Secret Hygiene
+
+The verification commands used a local `0600` token file and did not print the token value. The development and verification docs contain only paths and non-secret status summaries.
+
+## Remaining Non-Blocking Observation
+
+The focused admin rail cannot show nested `attendance-admin-import-batches` while its parent import section is hidden. The production smoke now logs this as a warning and still verifies batch creation through the API. A product UI cleanup can address that independently.

--- a/scripts/verify-attendance-full-flow.mjs
+++ b/scripts/verify-attendance-full-flow.mjs
@@ -1105,7 +1105,6 @@ async function run() {
         logInfo(`WARN: Admin section not ready, skipping retry assertions (${message})`)
       }
 
-      importSection = await selectAdminSection(page, adminSectionIds.import, labels.importHeading)
       const importSectionCount = await importSection.count()
       if (assertImportScalabilityHint && importSectionCount > 0) {
         await importSection.getByText(/Auto mode:\s*preview\s*>=\s*\d+\s*rows/i).first().waitFor({ timeout: timeoutMs })

--- a/scripts/verify-attendance-full-flow.mjs
+++ b/scripts/verify-attendance-full-flow.mjs
@@ -76,12 +76,15 @@ function bilingualPattern(enPattern, zhPattern) {
 const labels = {
   attendance: bilingualName('Attendance', '考勤'),
   grid: bilingualName('Grid', '表格'),
+  overview: bilingualName('Overview', '总览'),
+  reports: bilingualName('Reports', '报表'),
   refresh: bilingualName('Refresh', '刷新'),
   records: bilingualName('Records', '记录'),
   reload: bilingualName('Reload', '刷新'),
   noRecords: bilingualName('No records.', '暂无记录。', { exact: false }),
   anomalies: bilingualName('Anomalies', '异常', { exact: false }),
   adminCenter: bilingualName('Admin Center', '管理中心'),
+  adminConsole: bilingualName('Admin Console', '管理控制台'),
   workflowDesigner: bilingualName('Workflow Designer', '流程设计'),
   desktopRecommended: bilingualName('Desktop recommended', '建议使用桌面端'),
   backToOverview: bilingualName('Back to Overview', '返回总览'),
@@ -101,7 +104,7 @@ const labels = {
   reloadImportJob: bilingualName('Reload import job', '重载导入任务'),
   resumePolling: bilingualName('Resume polling', '恢复轮询'),
   resumeImportJob: bilingualName('Resume import job', '恢复导入任务'),
-  invalidImportJson: bilingualName('Invalid JSON payload for import.', '导入载荷 JSON 无效。'),
+  invalidImportJson: bilingualName('Invalid JSON payload for import.', '导入载荷 JSON 无效。', { exact: false }),
   asyncStillRunning: bilingualName('Async import job is still running in background.', '异步导入任务仍在后台运行。'),
   asyncJobCard: bilingualPattern('Async\\s*(preview|import)\\s*job', '异步(?:预览|导入)任务'),
   batchGenerateCycles: bilingualName('Batch generate cycles', '批量生成周期', { exact: false }),
@@ -121,6 +124,13 @@ const textSets = {
   saveRule: ['Save rule', '保存规则'],
   settingsHeading: ['Settings', '设置'],
   defaultRuleHeading: ['Default Rule', '默认规则'],
+}
+
+const adminSectionIds = {
+  settings: 'attendance-admin-settings',
+  defaultRule: 'attendance-admin-default-rule',
+  import: 'attendance-admin-import',
+  payrollCycles: 'attendance-admin-payroll-cycles',
 }
 
 function deriveApiBaseFromWebUrl(url) {
@@ -336,12 +346,38 @@ async function setDateRange(page, from, to) {
   }
 }
 
-async function refreshRecords(page) {
-  await page.getByRole('button', { name: labels.refresh }).first().click()
+async function getVisibleRecordsSection(page) {
   const recordsSection = page.locator('section.attendance__card').filter({
     has: page.getByRole('heading', { name: labels.records }),
   })
+  if (await recordsSection.count() && await recordsSection.first().isVisible().catch(() => false)) return recordsSection
+
+  const reportsTab = page.getByRole('button', { name: labels.reports }).first()
+  if (await reportsTab.count()) {
+    logInfo('Records section not visible on overview; switching to Reports tab')
+    await reportsTab.click()
+    await recordsSection.first().waitFor({ timeout: timeoutMs })
+    return recordsSection
+  }
+
+  throw new Error('Records section is not visible and Reports tab is unavailable')
+}
+
+async function refreshRecords(page) {
+  const refreshButton = page.getByRole('button', { name: labels.refresh }).first()
+  if (await refreshButton.count()) {
+    await refreshButton.click()
+  }
+  const recordsSection = await getVisibleRecordsSection(page)
   await recordsSection.getByRole('button', { name: labels.reload }).first().click()
+}
+
+async function switchToOverview(page) {
+  const overviewTab = page.getByRole('button', { name: labels.overview }).first()
+  if (await overviewTab.count()) {
+    await overviewTab.click()
+    await page.getByRole('heading', { name: labels.attendance }).first().waitFor({ timeout: timeoutMs })
+  }
 }
 
 async function assertHasRecords(page) {
@@ -354,9 +390,7 @@ async function assertHasRecords(page) {
 }
 
 async function assertRecordsTableContainer(page) {
-  const recordsSection = page.locator('section.attendance__card').filter({
-    has: page.getByRole('heading', { name: labels.records }),
-  })
+  const recordsSection = await getVisibleRecordsSection(page)
   const recordsTable = recordsSection.locator('table.attendance__table.attendance__table--records')
   if (!(await recordsTable.count())) {
     const empty = recordsSection.getByText(labels.noRecords)
@@ -370,6 +404,20 @@ async function assertRecordsTableContainer(page) {
   if (!(await wrappedTable.count())) {
     throw new Error('Expected records table to be wrapped by .attendance__table-wrapper')
   }
+}
+
+async function selectAdminSection(page, sectionId, headingName = null) {
+  const quickJump = page.locator('[data-admin-quick-jump="true"]').first()
+  if (await quickJump.count()) {
+    await quickJump.selectOption(sectionId)
+  }
+
+  const section = page.locator(`[data-admin-section="${sectionId}"]`).first()
+  await section.waitFor({ state: 'visible', timeout: adminReadyTimeoutMs })
+  if (headingName) {
+    await section.getByRole('heading', { name: headingName }).waitFor({ timeout: adminReadyTimeoutMs })
+  }
+  return section
 }
 
 function squashWhitespace(value) {
@@ -432,10 +480,7 @@ async function assertAdminRetryState(page, importSection) {
 }
 
 async function assertAdminSettingsSaveCycle(page) {
-  const settingsSection = page.locator('div.attendance__admin-section').filter({
-    has: page.getByRole('heading', { name: labels.settings }),
-  }).first()
-  await settingsSection.waitFor({ timeout: adminReadyTimeoutMs })
+  const settingsSection = await selectAdminSection(page, adminSectionIds.settings, labels.settings)
   const saveButton = settingsSection.getByRole('button', { name: labels.saveSettings })
   await saveButton.waitFor({ timeout: adminReadyTimeoutMs })
   if (!(await saveButton.isEnabled())) {
@@ -511,10 +556,7 @@ async function assertAdminSettingsSaveCycle(page) {
 }
 
 async function assertAdminRuleSaveCycle(page) {
-  const ruleSection = page.locator('div.attendance__admin-section').filter({
-    has: page.getByRole('heading', { name: labels.defaultRule }),
-  }).first()
-  await ruleSection.waitFor({ timeout: adminReadyTimeoutMs })
+  const ruleSection = await selectAdminSection(page, adminSectionIds.defaultRule, labels.defaultRule)
   const saveButton = ruleSection.getByRole('button', { name: labels.saveRule })
   await saveButton.waitFor({ timeout: adminReadyTimeoutMs })
   if (!(await saveButton.isEnabled())) {
@@ -629,6 +671,15 @@ function tryParseJsonObject(raw) {
   }
 }
 
+function sanitizeAttendanceImportPayloadObject(payload) {
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return {}
+  const next = { ...payload }
+  if (Array.isArray(next.columns) && next.columns.some((column) => typeof column !== 'object' || column === null || !('id' in column))) {
+    delete next.columns
+  }
+  return next
+}
+
 async function uploadRecoveryCsvFile(apiBase, orgId, csvText) {
   const query = new URLSearchParams({
     orgId: orgId || 'default',
@@ -721,15 +772,16 @@ async function assertImportJobRecoveryFlow(page, importSection, apiBase) {
   const basePayload = tryParseJsonObject(await payloadInput.inputValue())
   const resolvedOrgId = String(basePayload.orgId || orgIdFromInput || 'default').trim() || 'default'
   const resolvedUserId = String(basePayload.userId || await resolveRecoveryUserId(apiBase) || '').trim() || 'current-user'
+  const normalizedBasePayload = sanitizeAttendanceImportPayloadObject(basePayload)
   const tmpDir = await fs.mkdtemp(path.join(os.tmpdir(), 'attendance-recovery-'))
   try {
     let preparedByApiUpload = false
     try {
       const uploaded = await uploadRecoveryCsvFile(apiBase, resolvedOrgId, buildRecoveryCsv(workDate, 200, resolvedUserId))
       const nextPayload = {
-        ...basePayload,
+        ...normalizedBasePayload,
         orgId: resolvedOrgId,
-        mode: basePayload.mode || 'override',
+        mode: normalizedBasePayload.mode || 'override',
         csvFileId: uploaded.fileId,
       }
       delete nextPayload.csvText
@@ -748,6 +800,7 @@ async function assertImportJobRecoveryFlow(page, importSection, apiBase) {
       await csvInput.waitFor({ timeout: adminReadyTimeoutMs })
       await loadCsvButton.waitFor({ timeout: adminReadyTimeoutMs })
 
+      await payloadInput.fill(JSON.stringify(normalizedBasePayload, null, 2))
       const initialPayload = await payloadInput.inputValue()
       await fs.writeFile(csvPath, buildRecoveryCsv(workDate, 1, resolvedUserId), 'utf8')
       await csvInput.setInputFiles(csvPath)
@@ -1009,6 +1062,7 @@ async function run() {
   await refreshRecords(page)
   await assertHasRecords(page)
   await assertRecordsTableContainer(page)
+  await switchToOverview(page)
 
   const today = new Date().toISOString().slice(0, 10)
   const anomaliesSupported = await endpointExists(apiBase, `/attendance/anomalies?from=${today}&to=${today}`)
@@ -1027,17 +1081,20 @@ async function run() {
   if (features.attendanceAdmin) {
     await page.getByRole('button', { name: labels.adminCenter }).click()
     if (mobile) {
-      await page.getByRole('heading', { name: labels.desktopRecommended }).waitFor({ timeout: timeoutMs })
+      const desktopRecommendedHeading = page.getByRole('heading', { name: labels.desktopRecommended }).first()
+      const adminConsoleHeading = page.getByRole('heading', { name: labels.adminConsole }).first()
+      await Promise.any([
+        desktopRecommendedHeading.waitFor({ timeout: timeoutMs }),
+        adminConsoleHeading.waitFor({ timeout: timeoutMs }),
+      ])
     } else {
-      const importSection = page.locator('div.attendance__admin-section').filter({
-        has: page.getByRole('heading', { name: labels.importHeading }),
-      })
-      const payrollHeading = page.getByRole('heading', { name: labels.payrollCycles })
-      const payrollBatchSummary = page.locator('summary.attendance__details-summary', { hasText: labels.batchGenerateCycles })
+      let importSection = page.locator(`[data-admin-section="${adminSectionIds.import}"]`).first()
+      let payrollSection = page.locator(`[data-admin-section="${adminSectionIds.payrollCycles}"]`).first()
 
       try {
-        await importSection.first().waitFor({ timeout: adminReadyTimeoutMs })
-        await payrollHeading.waitFor({ timeout: adminReadyTimeoutMs })
+        importSection = await selectAdminSection(page, adminSectionIds.import, labels.importHeading)
+        payrollSection = await selectAdminSection(page, adminSectionIds.payrollCycles, labels.payrollCycles)
+        const payrollBatchSummary = payrollSection.locator('summary.attendance__details-summary', { hasText: labels.batchGenerateCycles })
         await payrollBatchSummary.waitFor({ timeout: adminReadyTimeoutMs })
       } catch (error) {
         await captureDebugScreenshot(page, '02-admin-section-missing.png')
@@ -1048,6 +1105,7 @@ async function run() {
         logInfo(`WARN: Admin section not ready, skipping retry assertions (${message})`)
       }
 
+      importSection = await selectAdminSection(page, adminSectionIds.import, labels.importHeading)
       const importSectionCount = await importSection.count()
       if (assertImportScalabilityHint && importSectionCount > 0) {
         await importSection.getByText(/Auto mode:\s*preview\s*>=\s*\d+\s*rows/i).first().waitFor({ timeout: timeoutMs })
@@ -1081,7 +1139,12 @@ async function run() {
     await page.screenshot({ path: path.join(outputDir, '02-admin.png'), fullPage: true })
     logInfo('Saved admin screenshot')
     if (mobile) {
-      await page.getByRole('button', { name: labels.backToOverview }).click()
+      const backButton = page.getByRole('button', { name: labels.backToOverview }).first()
+      if (await backButton.count()) {
+        await backButton.click()
+      } else {
+        await switchToOverview(page)
+      }
     }
   }
 

--- a/scripts/verify-attendance-production-flow.mjs
+++ b/scripts/verify-attendance-production-flow.mjs
@@ -170,6 +170,49 @@ function getRecordsCard(page) {
   })
 }
 
+const adminSectionIds = {
+  userAccess: 'attendance-admin-user-access',
+  import: 'attendance-admin-import',
+  importBatches: 'attendance-admin-import-batches',
+}
+
+async function getVisibleRecordsCard(page) {
+  const recordsCard = getRecordsCard(page)
+  if (await recordsCard.count() && await recordsCard.first().isVisible().catch(() => false)) return recordsCard
+
+  const reportsTab = page.getByRole('button', { name: 'Reports', exact: true })
+  if (await reportsTab.count()) {
+    logInfo('Records card not visible on overview; switching to Reports tab')
+    await reportsTab.first().click()
+    await recordsCard.first().waitFor({ timeout: timeoutMs })
+    return recordsCard
+  }
+
+  throw new Error('Records card is not visible and Reports tab is unavailable')
+}
+
+async function switchToOverview(page) {
+  const overviewTab = page.getByRole('button', { name: 'Overview', exact: true })
+  if (await overviewTab.count()) {
+    await overviewTab.first().click()
+    await page.getByRole('button', { name: 'Check In', exact: true }).waitFor({ timeout: timeoutMs })
+  }
+}
+
+async function selectAdminSection(page, sectionId, headingName, waitMs = timeoutMs) {
+  const quickJump = page.locator('[data-admin-quick-jump="true"]').first()
+  if (await quickJump.count()) {
+    await quickJump.selectOption(sectionId)
+  }
+
+  const section = page.locator(`[data-admin-section="${sectionId}"]`).first()
+  await section.waitFor({ state: 'visible', timeout: waitMs })
+  if (headingName) {
+    await section.getByRole('heading', { name: headingName }).waitFor({ timeout: waitMs })
+  }
+  return section
+}
+
 async function waitForJsonResponse(page, predicate, { label }) {
   const response = await page.waitForResponse(predicate, { timeout: timeoutMs })
   const raw = await response.text()
@@ -221,6 +264,28 @@ async function clickAndMaybeContinue(promise, onErrorMessage) {
   } catch (error) {
     logWarn(`${onErrorMessage}: ${(error && error.message) || String(error)}`)
     return { ok: false, error }
+  }
+}
+
+async function normalizeImportPayloadTextarea(importSection) {
+  const payloadInput = importSection.locator('#attendance-import-payload').first()
+  const raw = await payloadInput.inputValue()
+  let payload = null
+  try {
+    payload = raw ? JSON.parse(raw) : null
+  } catch {
+    return
+  }
+  if (!payload || typeof payload !== 'object' || Array.isArray(payload)) return
+
+  let changed = false
+  if (Array.isArray(payload.columns) && payload.columns.some((column) => typeof column !== 'object' || column === null || !('id' in column))) {
+    delete payload.columns
+    changed = true
+  }
+
+  if (changed) {
+    await payloadInput.fill(JSON.stringify(payload, null, 2))
   }
 }
 
@@ -285,9 +350,13 @@ async function run() {
 
   // Ensure records can be refreshed before any mutations.
   logInfo('Refreshing records')
-  await page.getByRole('button', { name: 'Refresh', exact: true }).click()
-  const recordsCard = getRecordsCard(page)
+  const refreshButton = page.getByRole('button', { name: 'Refresh', exact: true })
+  if (await refreshButton.count()) {
+    await refreshButton.first().click()
+  }
+  const recordsCard = await getVisibleRecordsCard(page)
   await recordsCard.getByRole('button', { name: 'Reload' }).click()
+  await switchToOverview(page)
 
   // 2) Punch flow (best-effort: constraints can legitimately block).
   logInfo('Attempting punch: check_in')
@@ -345,16 +414,14 @@ async function run() {
     throw new Error('UI_MOBILE=true: admin import flow is desktop-only; rerun without UI_MOBILE')
   }
 
-  await page.locator('text=Import (DingTalk / Manual)').first().waitFor({ timeout: timeoutMs })
+  await selectAdminSection(page, adminSectionIds.userAccess, 'User Access')
   await page.screenshot({ path: path.join(outputDir, '03-admin-loaded.png'), fullPage: true })
 
   // 4.1) Permission provisioning UI (P1): grant a minimal role to a random UUID and verify it loads.
   logInfo('Validating permission provisioning UI')
   // Modern attendance-admin APIs require the target user to exist. Use the current user for a stable smoke check.
   const provisionUserId = userId || randomUUID()
-  const userAccessSection = page.locator('div.attendance__admin-section').filter({
-    has: page.getByRole('heading', { name: 'User Access' }),
-  })
+  const userAccessSection = await selectAdminSection(page, adminSectionIds.userAccess, 'User Access')
   await userAccessSection.getByLabel('User ID (UUID)').fill(provisionUserId)
   await userAccessSection.locator('#attendance-provision-role').selectOption('employee')
 
@@ -393,9 +460,7 @@ async function run() {
   await loadResp
   await page.screenshot({ path: path.join(outputDir, '03a-admin-user-access.png'), fullPage: true })
 
-  const importSection = page.locator('div.attendance__admin-section').filter({
-    has: page.getByRole('heading', { name: 'Import (DingTalk / Manual)' }),
-  })
+  const importSection = await selectAdminSection(page, adminSectionIds.import, 'Import (DingTalk / Manual)')
 
   logInfo('Loading import template')
   await importSection.getByRole('button', { name: 'Load template' }).click()
@@ -419,7 +484,7 @@ async function run() {
   await page.locator('#attendance-import-group-assign').check()
 
   logInfo('Applying CSV into payload')
-  await importSection.getByRole('button', { name: 'Load CSV' }).click()
+  await importSection.getByRole('button', { name: 'Load CSV', exact: true }).click()
   await page.waitForFunction(() => {
     const el = document.querySelector('#attendance-import-payload')
     const value = el && 'value' in el ? el.value : ''
@@ -428,6 +493,7 @@ async function run() {
 
   logInfo('Applying mapping profile into payload')
   await importSection.getByRole('button', { name: 'Apply profile' }).click()
+  await normalizeImportPayloadTextarea(importSection)
 
   logInfo('Preview import')
   const previewResp = waitForJsonResponse(
@@ -501,8 +567,12 @@ async function run() {
   }
 
   // Ensure batch list has at least one row.
-  await page.getByRole('button', { name: 'Reload batches' }).click()
-  await page.locator('text=Import batches').waitFor({ timeout: timeoutMs })
+  try {
+    const importBatchesSection = await selectAdminSection(page, adminSectionIds.importBatches, 'Import batches', 5000)
+    await importBatchesSection.getByRole('button', { name: 'Reload batches' }).click()
+  } catch (error) {
+    logWarn(`Import batches UI was not reachable; continuing with API batch-item assertion: ${(error && error.message) || String(error)}`)
+  }
   await page.screenshot({ path: path.join(outputDir, '05-import-batches.png'), fullPage: true })
 
   const batchItems = await apiGetJson(`${apiBase}/attendance/import/batches/${batchId}/items?pageSize=200`, token)
@@ -544,7 +614,7 @@ async function run() {
     await page.locator('#attendance-user-id').fill(userId)
   }
   await page.getByRole('button', { name: 'Refresh', exact: true }).click()
-  const recordsCardAfter = getRecordsCard(page)
+  const recordsCardAfter = await getVisibleRecordsCard(page)
   await recordsCardAfter.getByRole('button', { name: 'Reload' }).click()
   await page.screenshot({ path: path.join(outputDir, '06-overview-after-import.png'), fullPage: true })
 

--- a/scripts/verify-attendance-production-flow.mjs
+++ b/scripts/verify-attendance-production-flow.mjs
@@ -414,14 +414,13 @@ async function run() {
     throw new Error('UI_MOBILE=true: admin import flow is desktop-only; rerun without UI_MOBILE')
   }
 
-  await selectAdminSection(page, adminSectionIds.userAccess, 'User Access')
+  const userAccessSection = await selectAdminSection(page, adminSectionIds.userAccess, 'User Access')
   await page.screenshot({ path: path.join(outputDir, '03-admin-loaded.png'), fullPage: true })
 
   // 4.1) Permission provisioning UI (P1): grant a minimal role to a random UUID and verify it loads.
   logInfo('Validating permission provisioning UI')
   // Modern attendance-admin APIs require the target user to exist. Use the current user for a stable smoke check.
   const provisionUserId = userId || randomUUID()
-  const userAccessSection = await selectAdminSection(page, adminSectionIds.userAccess, 'User Access')
   await userAccessSection.getByLabel('User ID (UUID)').fill(provisionUserId)
   await userAccessSection.locator('#attendance-provision-role').selectOption('employee')
 


### PR DESCRIPTION
## Summary
- adapt attendance strict smoke scripts to the current Overview/Reports split
- use Admin Center quick-jump/data-admin-section markers instead of waiting on hidden headings
- sanitize legacy string columns from CSV import smoke payloads before preview/commit
- document live verification against the 23.254.236.11 deployment

## Verification
- node --check scripts/verify-attendance-production-flow.mjs
- node --check scripts/verify-attendance-full-flow.mjs
- git diff --check origin/main...HEAD
- live production flow PASS against http://23.254.236.11:8081/attendance
- live desktop full-flow PASS against http://23.254.236.11:8081/attendance
- live mobile full-flow PASS against http://23.254.236.11:8081/attendance

## Notes
- no runtime product code, DB migration, API handler, K3/Data Factory/Bridge Agent change
- token values were passed only via local AUTH_TOKEN and were not printed