### PR TITLE
feat(attendance): add comprehensive hours strong save control

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -4584,7 +4584,27 @@
                     <option value="block">{{ tr('Strict preview', '严格预览') }}</option>
                   </select>
                   <small class="attendance__field-hint">
-                    {{ tr('Mode only changes preview status. It is not persisted and does not enforce saves.', '模式只影响预览状态，不会持久化，也不会拦截保存。') }}
+                    {{ tr(
+                      'Mode only changes preview status. It is not persisted. See \'Save-time strong control\' below to enable save blocking.',
+                      '模式只影响预览状态，不会持久化。如需保存时拦截，请使用下方“保存时强管控”。'
+                    ) }}
+                  </small>
+                </label>
+                <label
+                  class="attendance__field attendance__field--checkbox"
+                  data-attendance-comprehensive-hours-save-block-mode
+                >
+                  <input
+                    type="checkbox"
+                    id="attendance-comprehensive-hours-save-block-mode"
+                    v-model="comprehensiveHoursSaveBlockMode"
+                  />
+                  <span>{{ tr('Save-time strong control', '保存时强管控') }}</span>
+                  <small class="attendance__field-hint">
+                    {{ tr(
+                      'When enabled, shift and rotation assignment saves are blocked if the comprehensive-hours preview returns a violation. Preview errors and degraded data never block saves.',
+                      '启用后，若综合工时预览返回违规，将拦截班次和轮班分配保存；预览失败或降级数据不会拦截保存。'
+                    ) }}
                   </small>
                 </label>
                 <label class="attendance__field" for="attendance-comprehensive-hours-period-type">
@@ -5038,9 +5058,11 @@
                 class="attendance__status"
                 :class="{
                   'attendance__status--warn': comprehensiveHoursAssignmentAdvisory.rotation.kind === 'warn',
-                  'attendance__status--error': comprehensiveHoursAssignmentAdvisory.rotation.kind === 'error'
+                  'attendance__status--error': comprehensiveHoursAssignmentAdvisory.rotation.kind === 'error',
+                  'attendance__status--error attendance__status--block': comprehensiveHoursAssignmentAdvisory.rotation.kind === 'block'
                 }"
                 data-attendance-comprehensive-hours-assignment-advisory="rotation"
+                :data-attendance-comprehensive-hours-assignment-advisory-kind="comprehensiveHoursAssignmentAdvisory.rotation.kind"
               >
                 {{ comprehensiveHoursAssignmentAdvisory.rotation.message }}
               </p>
@@ -5361,9 +5383,11 @@
                 class="attendance__status"
                 :class="{
                   'attendance__status--warn': comprehensiveHoursAssignmentAdvisory.shift.kind === 'warn',
-                  'attendance__status--error': comprehensiveHoursAssignmentAdvisory.shift.kind === 'error'
+                  'attendance__status--error': comprehensiveHoursAssignmentAdvisory.shift.kind === 'error',
+                  'attendance__status--error attendance__status--block': comprehensiveHoursAssignmentAdvisory.shift.kind === 'block'
                 }"
                 data-attendance-comprehensive-hours-assignment-advisory="shift"
+                :data-attendance-comprehensive-hours-assignment-advisory-kind="comprehensiveHoursAssignmentAdvisory.shift.kind"
               >
                 {{ comprehensiveHoursAssignmentAdvisory.shift.message }}
               </p>
@@ -6373,7 +6397,7 @@ interface AttendanceComprehensiveHoursPreviewResult {
 type AttendanceComprehensiveHoursAssignmentKind = 'shift' | 'rotation'
 
 interface AttendanceComprehensiveHoursAssignmentAdvisory {
-  kind: 'info' | 'warn' | 'error'
+  kind: 'info' | 'warn' | 'error' | 'block'
   message: string
 }
 
@@ -7640,6 +7664,7 @@ const comprehensiveHoursAssignmentAdvisory = reactive<Record<AttendanceComprehen
   shift: { kind: 'info', message: '' },
   rotation: { kind: 'info', message: '' },
 })
+const comprehensiveHoursSaveBlockMode = ref(false)
 const holidayEditingId = ref<string | null>(null)
 const leaveTypeEditingId = ref<string | null>(null)
 const overtimeRuleEditingId = ref<string | null>(null)
@@ -14495,17 +14520,18 @@ function comprehensiveHoursAssignmentAdvisoryMessage(
 async function previewComprehensiveHoursAssignmentAdvisory(
   kind: AttendanceComprehensiveHoursAssignmentKind,
   draft: { userId: string; startDate: string; endDate: string | null; isActive: boolean },
-): Promise<void> {
+): Promise<{ blocked: boolean }> {
   clearComprehensiveHoursAssignmentAdvisory(kind)
-  if (!draft.isActive) return
+  if (!draft.isActive) return { blocked: false }
   const userId = draft.userId.trim()
   const from = draft.startDate.trim()
-  if (!userId || !from) return
+  if (!userId || !from) return { blocked: false }
+  const strongMode = comprehensiveHoursSaveBlockMode.value === true
   const capHours = Number(comprehensiveHoursPreviewForm.capHours)
   const body = {
     policyDraft: {
       capHours: Number.isFinite(capHours) && capHours > 0 ? capHours : 160,
-      enforcement: 'warn',
+      enforcement: strongMode ? 'block' : 'warn',
     },
     scope: { userId },
     period: {
@@ -14527,10 +14553,21 @@ async function previewComprehensiveHoursAssignmentAdvisory(
       throw new Error(readErrorMessage(data, tr('Failed to preview comprehensive hours', '综合工时预览失败')))
     }
     const result = data.data as AttendanceComprehensiveHoursPreviewResult | null | undefined
+    if (strongMode && !result?.degraded && resolveComprehensiveHoursAssignmentStatus(result) === 'violation') {
+      setComprehensiveHoursAssignmentAdvisory(kind, {
+        kind: 'block',
+        message: tr(
+          'Comprehensive-hours strong-control: save blocked because planned minutes exceed the cap. Disable strong-control to override.',
+          '综合工时强管控：计划工时已超过上限，保存已被拦截；关闭强管控可临时放行。',
+        ),
+      })
+      return { blocked: true }
+    }
     const message = comprehensiveHoursAssignmentAdvisoryMessage(result)
     if (message) {
       setComprehensiveHoursAssignmentAdvisory(kind, { kind: 'warn', message })
     }
+    return { blocked: false }
   } catch (error: any) {
     setComprehensiveHoursAssignmentAdvisory(kind, {
       kind: 'error',
@@ -14539,6 +14576,7 @@ async function previewComprehensiveHoursAssignmentAdvisory(
         '综合工时提示预览暂不可用；当前阶段仍允许保存。',
       ) + ` ${readErrorMessage(error, '')}`.trimEnd(),
     })
+    return { blocked: false }
   }
 }
 
@@ -14707,12 +14745,16 @@ async function saveRotationAssignment() {
       isActive: rotationAssignmentForm.isActive,
       orgId: normalizedOrgId(),
     }
-    await previewComprehensiveHoursAssignmentAdvisory('rotation', {
+    const rotationAdvisory = await previewComprehensiveHoursAssignmentAdvisory('rotation', {
       userId: payload.userId,
       startDate: payload.startDate,
       endDate: payload.endDate,
       isActive: payload.isActive,
     })
+    if (rotationAdvisory.blocked) {
+      setStatus(comprehensiveHoursAssignmentAdvisory.rotation.message, 'error')
+      return
+    }
     const endpoint = isEditing
       ? `/api/attendance/rotation-assignments/${rotationAssignmentEditingId.value}`
       : '/api/attendance/rotation-assignments'
@@ -14933,12 +14975,16 @@ async function saveAssignment() {
       isActive: assignmentForm.isActive,
       orgId: normalizedOrgId(),
     }
-    await previewComprehensiveHoursAssignmentAdvisory('shift', {
+    const shiftAdvisory = await previewComprehensiveHoursAssignmentAdvisory('shift', {
       userId: payload.userId,
       startDate: payload.startDate,
       endDate: payload.endDate,
       isActive: payload.isActive,
     })
+    if (shiftAdvisory.blocked) {
+      setStatus(comprehensiveHoursAssignmentAdvisory.shift.message, 'error')
+      return
+    }
     const endpoint = isEditing
       ? `/api/attendance/assignments/${assignmentEditingId.value}`
       : '/api/attendance/assignments'

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -1271,6 +1271,584 @@ describe('Attendance admin regressions', () => {
     expect(container!.textContent).toContain('Assignment created.')
   })
 
+  it('PR5 strong-control blocks shift assignment save when preview returns violation', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/shifts')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'shift-a',
+                name: 'Day shift',
+                timezone: 'UTC',
+                workStartTime: '09:00',
+                workEndTime: '18:00',
+                isOvernight: false,
+                lateGraceMinutes: 10,
+                earlyGraceMinutes: 10,
+                roundingMinutes: 5,
+                workingDays: [1, 2, 3, 4, 5],
+              },
+            ],
+          },
+        })
+      }
+      if (url.includes('/api/attendance/comprehensive-hours/preview')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            readOnly: true,
+            period: { type: 'custom_range', from: '2026-05-01', to: '2026-05-10' },
+            metric: 'planned',
+            enforcement: 'block',
+            capMinutes: 9600,
+            scope: { userIds: ['user-9'] },
+            aggregate: {
+              users: 1,
+              ok: 0,
+              warning: 0,
+              violation: 1,
+              totalMinutes: 10200,
+              totalExcessMinutes: 600,
+              totalRemainingMinutes: 0,
+              status: 'violation',
+            },
+            rows: [
+              {
+                userId: 'user-9',
+                minutes: 10200,
+                plannedMinutes: 10200,
+                capMinutes: 9600,
+                remainingMinutes: 0,
+                excessMinutes: 600,
+                status: 'violation',
+                source: 'effective_calendar',
+              },
+            ],
+            degraded: false,
+          },
+        })
+      }
+      if (url === '/api/attendance/assignments' && init?.method === 'POST') {
+        return jsonResponse(200, { ok: true })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const strongModeCheckbox = container!.querySelector<HTMLInputElement>('#attendance-comprehensive-hours-save-block-mode')
+    expect(strongModeCheckbox).toBeTruthy()
+    strongModeCheckbox!.checked = true
+    strongModeCheckbox!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
+    expect(section).toBeTruthy()
+    setInput(section!, '#attendance-assignment-user-id', 'user-9')
+    const shiftSelect = section!.querySelector<HTMLSelectElement>('#attendance-assignment-shift-id')
+    expect(shiftSelect).toBeTruthy()
+    shiftSelect!.value = 'shift-a'
+    shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(section!, '#attendance-assignment-start-date', '2026-05-01')
+    setInput(section!, '#attendance-assignment-end-date', '2026-05-10')
+    await flushUi(2)
+
+    const createButton = Array.from(section!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Create assignment'))
+    expect(createButton).toBeTruthy()
+    createButton!.click()
+    await flushUi(8)
+
+    const previewBody = JSON.parse(String(vi.mocked(apiFetch).mock.calls.find(([input]) =>
+      String(input).includes('/api/attendance/comprehensive-hours/preview')
+    )![1]!.body))
+    expect(previewBody).toMatchObject({
+      policyDraft: { capHours: 160, enforcement: 'block' },
+      scope: { userId: 'user-9' },
+      period: { type: 'custom_range', from: '2026-05-01', to: '2026-05-10' },
+      metric: 'planned',
+    })
+    expect(previewBody).not.toHaveProperty('allUsers')
+
+    const savePosted = vi.mocked(apiFetch).mock.calls.some(([input, init]) =>
+      String(input) === '/api/attendance/assignments' && init?.method === 'POST'
+    )
+    expect(savePosted).toBe(false)
+    expect(container!.textContent).not.toContain('Assignment created.')
+
+    const advisory = section!.querySelector<HTMLElement>('[data-attendance-comprehensive-hours-assignment-advisory="shift"]')
+    expect(advisory).toBeTruthy()
+    expect(advisory!.dataset.attendanceComprehensiveHoursAssignmentAdvisoryKind).toBe('block')
+    const advisoryText = advisory!.textContent || ''
+    expect(advisoryText).toContain('strong-control')
+    expect(advisoryText).toContain('save blocked')
+    expect(advisoryText).not.toContain('cannot save')
+    expect(advisoryText).not.toContain('policy enforced')
+    expect(advisoryText).not.toContain('violation prevented')
+    expect(advisoryText).not.toContain('禁止保存')
+    expect(advisoryText).not.toContain('已强制策略')
+    expect(advisoryText).not.toContain('已阻止违规')
+  })
+
+  it('PR5 strong-control allows shift assignment save when preview returns warning', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/shifts')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'shift-a',
+                name: 'Day shift',
+                timezone: 'UTC',
+                workStartTime: '09:00',
+                workEndTime: '18:00',
+                isOvernight: false,
+                lateGraceMinutes: 10,
+                earlyGraceMinutes: 10,
+                roundingMinutes: 5,
+                workingDays: [1, 2, 3, 4, 5],
+              },
+            ],
+          },
+        })
+      }
+      if (url.includes('/api/attendance/comprehensive-hours/preview')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            readOnly: true,
+            period: { type: 'custom_range', from: '2026-05-01', to: '2026-05-10' },
+            metric: 'planned',
+            enforcement: 'block',
+            capMinutes: 9600,
+            scope: { userIds: ['user-9'] },
+            aggregate: {
+              users: 1,
+              ok: 0,
+              warning: 1,
+              violation: 0,
+              totalMinutes: 9500,
+              totalExcessMinutes: 0,
+              totalRemainingMinutes: 100,
+              status: 'warning',
+            },
+            rows: [
+              {
+                userId: 'user-9',
+                minutes: 9500,
+                plannedMinutes: 9500,
+                capMinutes: 9600,
+                remainingMinutes: 100,
+                excessMinutes: 0,
+                status: 'warning',
+                source: 'effective_calendar',
+              },
+            ],
+            degraded: false,
+          },
+        })
+      }
+      if (url === '/api/attendance/assignments' && init?.method === 'POST') {
+        return jsonResponse(200, { ok: true })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const strongModeCheckbox = container!.querySelector<HTMLInputElement>('#attendance-comprehensive-hours-save-block-mode')
+    expect(strongModeCheckbox).toBeTruthy()
+    strongModeCheckbox!.checked = true
+    strongModeCheckbox!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
+    expect(section).toBeTruthy()
+    setInput(section!, '#attendance-assignment-user-id', 'user-9')
+    const shiftSelect = section!.querySelector<HTMLSelectElement>('#attendance-assignment-shift-id')
+    shiftSelect!.value = 'shift-a'
+    shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(section!, '#attendance-assignment-start-date', '2026-05-01')
+    setInput(section!, '#attendance-assignment-end-date', '2026-05-10')
+    await flushUi(2)
+
+    const createButton = Array.from(section!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Create assignment'))
+    expect(createButton).toBeTruthy()
+    createButton!.click()
+    await flushUi(8)
+
+    const previewBody = JSON.parse(String(vi.mocked(apiFetch).mock.calls.find(([input]) =>
+      String(input).includes('/api/attendance/comprehensive-hours/preview')
+    )![1]!.body))
+    expect(previewBody.policyDraft.enforcement).toBe('block')
+
+    const savePosted = vi.mocked(apiFetch).mock.calls.some(([input, init]) =>
+      String(input) === '/api/attendance/assignments' && init?.method === 'POST'
+    )
+    expect(savePosted).toBe(true)
+    expect(container!.textContent).toContain('Assignment created.')
+
+    const advisory = section!.querySelector<HTMLElement>('[data-attendance-comprehensive-hours-assignment-advisory="shift"]')
+    expect(advisory?.dataset.attendanceComprehensiveHoursAssignmentAdvisoryKind).toBe('warn')
+    expect(advisory?.textContent).toContain('Saving is still allowed')
+  })
+
+  it('PR5 strong-control allows shift assignment save when preview returns ok', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/shifts')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'shift-a',
+                name: 'Day shift',
+                timezone: 'UTC',
+                workStartTime: '09:00',
+                workEndTime: '18:00',
+                isOvernight: false,
+                lateGraceMinutes: 10,
+                earlyGraceMinutes: 10,
+                roundingMinutes: 5,
+                workingDays: [1, 2, 3, 4, 5],
+              },
+            ],
+          },
+        })
+      }
+      if (url.includes('/api/attendance/comprehensive-hours/preview')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            readOnly: true,
+            period: { type: 'custom_range', from: '2026-05-01', to: '2026-05-10' },
+            metric: 'planned',
+            enforcement: 'block',
+            capMinutes: 9600,
+            scope: { userIds: ['user-9'] },
+            aggregate: {
+              users: 1,
+              ok: 1,
+              warning: 0,
+              violation: 0,
+              totalMinutes: 5000,
+              totalExcessMinutes: 0,
+              totalRemainingMinutes: 4600,
+              status: 'ok',
+            },
+            rows: [
+              {
+                userId: 'user-9',
+                minutes: 5000,
+                plannedMinutes: 5000,
+                capMinutes: 9600,
+                remainingMinutes: 4600,
+                excessMinutes: 0,
+                status: 'ok',
+                source: 'effective_calendar',
+              },
+            ],
+            degraded: false,
+          },
+        })
+      }
+      if (url === '/api/attendance/assignments' && init?.method === 'POST') {
+        return jsonResponse(200, { ok: true })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const strongModeCheckbox = container!.querySelector<HTMLInputElement>('#attendance-comprehensive-hours-save-block-mode')
+    strongModeCheckbox!.checked = true
+    strongModeCheckbox!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
+    setInput(section!, '#attendance-assignment-user-id', 'user-9')
+    const shiftSelect = section!.querySelector<HTMLSelectElement>('#attendance-assignment-shift-id')
+    shiftSelect!.value = 'shift-a'
+    shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(section!, '#attendance-assignment-start-date', '2026-05-01')
+    setInput(section!, '#attendance-assignment-end-date', '2026-05-10')
+    await flushUi(2)
+
+    const createButton = Array.from(section!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Create assignment'))
+    createButton!.click()
+    await flushUi(8)
+
+    expect(vi.mocked(apiFetch).mock.calls.some(([input, init]) =>
+      String(input) === '/api/attendance/assignments' && init?.method === 'POST'
+    )).toBe(true)
+    expect(container!.textContent).toContain('Assignment created.')
+
+    const advisory = section!.querySelector<HTMLElement>('[data-attendance-comprehensive-hours-assignment-advisory="shift"]')
+    expect(advisory?.textContent || '').toBe('')
+  })
+
+  it('PR5 strong-control allows shift assignment save when preview fails with 503', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/shifts')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'shift-a',
+                name: 'Day shift',
+                timezone: 'UTC',
+                workStartTime: '09:00',
+                workEndTime: '18:00',
+                isOvernight: false,
+                lateGraceMinutes: 10,
+                earlyGraceMinutes: 10,
+                roundingMinutes: 5,
+                workingDays: [1, 2, 3, 4, 5],
+              },
+            ],
+          },
+        })
+      }
+      if (url.includes('/api/attendance/comprehensive-hours/preview')) {
+        return jsonResponse(503, {
+          ok: false,
+          error: { code: 'DB_NOT_READY', message: 'schema not ready' },
+        })
+      }
+      if (url === '/api/attendance/assignments' && init?.method === 'POST') {
+        return jsonResponse(200, { ok: true })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const strongModeCheckbox = container!.querySelector<HTMLInputElement>('#attendance-comprehensive-hours-save-block-mode')
+    strongModeCheckbox!.checked = true
+    strongModeCheckbox!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
+    setInput(section!, '#attendance-assignment-user-id', 'user-9')
+    const shiftSelect = section!.querySelector<HTMLSelectElement>('#attendance-assignment-shift-id')
+    shiftSelect!.value = 'shift-a'
+    shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(section!, '#attendance-assignment-start-date', '2026-05-01')
+    setInput(section!, '#attendance-assignment-end-date', '2026-05-10')
+    await flushUi(2)
+
+    const createButton = Array.from(section!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Create assignment'))
+    createButton!.click()
+    await flushUi(8)
+
+    expect(vi.mocked(apiFetch).mock.calls.some(([input, init]) =>
+      String(input) === '/api/attendance/assignments' && init?.method === 'POST'
+    )).toBe(true)
+    expect(container!.textContent).toContain('Assignment created.')
+
+    const advisory = section!.querySelector<HTMLElement>('[data-attendance-comprehensive-hours-assignment-advisory="shift"]')
+    expect(advisory?.dataset.attendanceComprehensiveHoursAssignmentAdvisoryKind).toBe('error')
+    expect(advisory?.textContent).toContain('saving is still allowed')
+  })
+
+  it('PR5 strong-control blocks rotation assignment save when preview returns violation', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/rotation-rules')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'rot-1',
+                name: 'Two shift',
+                timezone: 'UTC',
+                shiftSequence: ['shift-a', 'shift-b'],
+                isActive: true,
+              },
+            ],
+          },
+        })
+      }
+      if (url.includes('/api/attendance/comprehensive-hours/preview')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            readOnly: true,
+            period: { type: 'custom_range', from: '2026-05-01', to: '2026-05-10' },
+            metric: 'planned',
+            enforcement: 'block',
+            capMinutes: 9600,
+            scope: { userIds: ['user-7'] },
+            aggregate: {
+              users: 1,
+              ok: 0,
+              warning: 0,
+              violation: 1,
+              totalMinutes: 10500,
+              totalExcessMinutes: 900,
+              totalRemainingMinutes: 0,
+              status: 'violation',
+            },
+            rows: [
+              {
+                userId: 'user-7',
+                minutes: 10500,
+                plannedMinutes: 10500,
+                capMinutes: 9600,
+                remainingMinutes: 0,
+                excessMinutes: 900,
+                status: 'violation',
+                source: 'effective_calendar',
+              },
+            ],
+            degraded: false,
+          },
+        })
+      }
+      if (url === '/api/attendance/rotation-assignments' && init?.method === 'POST') {
+        return jsonResponse(200, { ok: true })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const strongModeCheckbox = container!.querySelector<HTMLInputElement>('#attendance-comprehensive-hours-save-block-mode')
+    strongModeCheckbox!.checked = true
+    strongModeCheckbox!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-rotation-assignments')
+    expect(section).toBeTruthy()
+    setInput(section!, '#attendance-rotation-user', 'user-7')
+    const rotationSelect = section!.querySelector<HTMLSelectElement>('#attendance-rotation-rule')
+    rotationSelect!.value = 'rot-1'
+    rotationSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(section!, '#attendance-rotation-start', '2026-05-01')
+    setInput(section!, '#attendance-rotation-end', '2026-05-10')
+    await flushUi(2)
+
+    const createButton = Array.from(section!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Create assignment'))
+    createButton!.click()
+    await flushUi(8)
+
+    const previewBody = JSON.parse(String(vi.mocked(apiFetch).mock.calls.find(([input]) =>
+      String(input).includes('/api/attendance/comprehensive-hours/preview')
+    )![1]!.body))
+    expect(previewBody).toMatchObject({
+      policyDraft: { capHours: 160, enforcement: 'block' },
+      scope: { userId: 'user-7' },
+      period: { type: 'custom_range', from: '2026-05-01', to: '2026-05-10' },
+      metric: 'planned',
+    })
+    expect(previewBody).not.toHaveProperty('allUsers')
+
+    expect(vi.mocked(apiFetch).mock.calls.some(([input, init]) =>
+      String(input) === '/api/attendance/rotation-assignments' && init?.method === 'POST'
+    )).toBe(false)
+    expect(container!.textContent).not.toContain('Rotation assignment created.')
+
+    const advisory = section!.querySelector<HTMLElement>('[data-attendance-comprehensive-hours-assignment-advisory="rotation"]')
+    expect(advisory?.dataset.attendanceComprehensiveHoursAssignmentAdvisoryKind).toBe('block')
+    expect(advisory?.textContent).toContain('strong-control')
+    expect(advisory?.textContent).toContain('save blocked')
+  })
+
+  it('PR5 inactive shift assignment skips the preview call in both modes', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/shifts')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'shift-a',
+                name: 'Day shift',
+                timezone: 'UTC',
+                workStartTime: '09:00',
+                workEndTime: '18:00',
+                isOvernight: false,
+                lateGraceMinutes: 10,
+                earlyGraceMinutes: 10,
+                roundingMinutes: 5,
+                workingDays: [1, 2, 3, 4, 5],
+              },
+            ],
+          },
+        })
+      }
+      if (url === '/api/attendance/assignments' && init?.method === 'POST') {
+        return jsonResponse(200, { ok: true })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const strongModeCheckbox = container!.querySelector<HTMLInputElement>('#attendance-comprehensive-hours-save-block-mode')
+    strongModeCheckbox!.checked = true
+    strongModeCheckbox!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
+    setInput(section!, '#attendance-assignment-user-id', 'user-9')
+    const shiftSelect = section!.querySelector<HTMLSelectElement>('#attendance-assignment-shift-id')
+    shiftSelect!.value = 'shift-a'
+    shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(section!, '#attendance-assignment-start-date', '2026-05-01')
+    setInput(section!, '#attendance-assignment-end-date', '2026-05-10')
+
+    const activeCheckbox = section!.querySelector<HTMLInputElement>('#attendance-assignment-active')
+    expect(activeCheckbox).toBeTruthy()
+    activeCheckbox!.checked = false
+    activeCheckbox!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const createButton = Array.from(section!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Create assignment'))
+    createButton!.click()
+    await flushUi(8)
+
+    const previewCalled = vi.mocked(apiFetch).mock.calls.some(([input]) =>
+      String(input).includes('/api/attendance/comprehensive-hours/preview')
+    )
+    expect(previewCalled).toBe(false)
+
+    expect(vi.mocked(apiFetch).mock.calls.some(([input, init]) =>
+      String(input) === '/api/attendance/assignments' && init?.method === 'POST'
+    )).toBe(true)
+    expect(container!.textContent).toContain('Assignment created.')
+
+    const advisory = section!.querySelector<HTMLElement>('[data-attendance-comprehensive-hours-assignment-advisory="shift"]')
+    expect(advisory?.textContent || '').toBe('')
+  })
+
   it('restores the run21 holiday calendar, rule builder, and import template guidance', async () => {
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -1777,6 +1777,108 @@ describe('Attendance admin regressions', () => {
     expect(advisory?.textContent).toContain('save blocked')
   })
 
+  it('PR5 strong-control does NOT block shift assignment save when preview is degraded even if status is violation', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/shifts')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'shift-a',
+                name: 'Day shift',
+                timezone: 'UTC',
+                workStartTime: '09:00',
+                workEndTime: '18:00',
+                isOvernight: false,
+                lateGraceMinutes: 10,
+                earlyGraceMinutes: 10,
+                roundingMinutes: 5,
+                workingDays: [1, 2, 3, 4, 5],
+              },
+            ],
+          },
+        })
+      }
+      if (url.includes('/api/attendance/comprehensive-hours/preview')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            readOnly: true,
+            period: { type: 'custom_range', from: '2026-05-01', to: '2026-05-10' },
+            metric: 'planned',
+            enforcement: 'block',
+            capMinutes: 9600,
+            scope: { userIds: ['user-9'] },
+            aggregate: {
+              users: 1,
+              ok: 0,
+              warning: 0,
+              violation: 1,
+              totalMinutes: 10200,
+              totalExcessMinutes: 600,
+              totalRemainingMinutes: 0,
+              status: 'violation',
+            },
+            rows: [
+              {
+                userId: 'user-9',
+                minutes: 10200,
+                plannedMinutes: 10200,
+                capMinutes: 9600,
+                remainingMinutes: 0,
+                excessMinutes: 600,
+                status: 'violation',
+                source: 'effective_calendar',
+              },
+            ],
+            degraded: true,
+          },
+        })
+      }
+      if (url === '/api/attendance/assignments' && init?.method === 'POST') {
+        return jsonResponse(200, { ok: true })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const strongModeCheckbox = container!.querySelector<HTMLInputElement>('#attendance-comprehensive-hours-save-block-mode')
+    strongModeCheckbox!.checked = true
+    strongModeCheckbox!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
+    setInput(section!, '#attendance-assignment-user-id', 'user-9')
+    const shiftSelect = section!.querySelector<HTMLSelectElement>('#attendance-assignment-shift-id')
+    shiftSelect!.value = 'shift-a'
+    shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(section!, '#attendance-assignment-start-date', '2026-05-01')
+    setInput(section!, '#attendance-assignment-end-date', '2026-05-10')
+    await flushUi(2)
+
+    const createButton = Array.from(section!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Create assignment'))
+    createButton!.click()
+    await flushUi(8)
+
+    expect(vi.mocked(apiFetch).mock.calls.some(([input, init]) =>
+      String(input) === '/api/attendance/assignments' && init?.method === 'POST'
+    )).toBe(true)
+    expect(container!.textContent).toContain('Assignment created.')
+
+    const advisory = section!.querySelector<HTMLElement>('[data-attendance-comprehensive-hours-assignment-advisory="shift"]')
+    expect(advisory?.dataset.attendanceComprehensiveHoursAssignmentAdvisoryKind).toBe('warn')
+    const advisoryText = advisory?.textContent || ''
+    expect(advisoryText).toContain('degraded')
+    expect(advisoryText).toContain('saving is still allowed')
+    expect(advisoryText).not.toContain('save blocked')
+  })
+
   it('PR5 inactive shift assignment skips the preview call in both modes', async () => {
     vi.mocked(apiFetch).mockImplementation(async (input, init) => {
       const url = typeof input === 'string' ? input : input.url

--- a/docs/development/attendance-comprehensive-hours-pr5-strong-control-design-20260523.md
+++ b/docs/development/attendance-comprehensive-hours-pr5-strong-control-design-20260523.md
@@ -1,0 +1,267 @@
+# Attendance comprehensive-hours PR5 strong-control design lock - 2026-05-23
+
+## Lineage
+
+| Step | PR | State |
+| --- | --- | --- |
+| PR0 RFC | `attendance-comprehensive-hours-control-rfc-20260522.md` | merged |
+| PR1 helpers | #1770 | merged |
+| PR2 preview route | #1774 | merged |
+| PR2.5 invalid enum reject | #1776 | merged |
+| PR3 admin preview UI | #1777 | merged |
+| PR4 design lock | #1778 | merged |
+| PR4 runtime weak-control | #1790 | merged + production smoke PASS + staging E2E PASS (#1795) |
+| **PR5 design lock** | **this MD** | **in progress** |
+| PR5 runtime strong-control | (paired implementation PR) | in progress |
+| PR6 reporting | (out of scope) | deferred |
+
+PR5 is the **explicit opt-in** strong-control slice deferred by the #1778 PR4
+design lock. The user opted in at 2026-05-23 after PR4 production smoke and
+staging E2E both PASS. Scope was bounded by the user as "frontend save-chain
+strong-control only; no new backend route; no preview compute change; no
+migration; no `meta_*` write".
+
+## Goal
+
+Add a deliberately-toggled strong-control mode that **blocks the assignment
+save call** when the existing read-only comprehensive-hours preview returns
+`aggregate.status === 'violation'`. Default behavior remains the PR4
+weak-control advisory. The mode is per-session, not persisted.
+
+## Hard Boundaries
+
+| Boundary | Requirement |
+| --- | --- |
+| **Default off** | The strong-control mode must default to off so that PR4 weak-control remains the out-of-box behavior. |
+| **Frontend only** | All save-chain enforcement happens in the frontend. No backend route, no plugin route, no middleware change, no migration. |
+| **Reuse existing preview route** | The preview call must continue to use `POST /api/attendance/comprehensive-hours/preview`. No new endpoint. |
+| **Reuse existing payload contract** | `metric: 'planned'`, single `userId`, `period.type: 'custom_range'`, no `allUsers`. The only payload change is `enforcement` becoming `'block'` when strong-control mode is on; that value is already accepted by the existing route per #1776. |
+| **No policy persistence** | Mode is held in a Vue ref. No localStorage, no DB write, no settings/catalog row. Reloading the page resets to default off. |
+| **No preview compute change** | The backend preview classification logic is not modified. The frontend interprets `aggregate.status` exactly as today; only the consequence of `violation` changes. |
+| **Preview failure never blocks** | If the preview returns 4xx/5xx, network error, or degraded data, the save MUST proceed. Strong-control only fires on a successful preview that classifies as `violation`. |
+| **PR4 weak behavior preserved** | When mode is off, the existing PR4 weak-control flow is byte-for-byte identical (same advisory copy, same payload, same call ordering, same save-always semantics). |
+| **No reuse of preview-form enforcement field** | The existing `comprehensiveHoursPreviewForm.enforcement` field (added in #1777) explicitly documents "Mode only changes preview status. It is not persisted and does not enforce saves." PR5 MUST NOT silently change that contract. PR5 adds a separate, clearly-labeled toggle. |
+| **Inactive assignment skip preserved** | When the assignment form has `isActive: false`, the preview call is skipped entirely (same as PR4). Strong-control therefore does not block inactive draft saves. |
+| **No allUsers** | The save-time preview payload never carries an `allUsers` field. |
+| **Both surfaces** | Shift assignment save and rotation assignment save are both governed by the same mode. |
+| **Banned UX copy** | Block-state advisory copy must not use PR5-style language verbatim — wait, this is **PR5** so block-state copy is now allowed, but only for the block-state. Other states (warn/violation in weak mode, degraded, error) must keep the PR4 "Saving is still allowed in this stage" wording unchanged. |
+
+## State design
+
+Add a new top-level ref and extend the existing advisory discriminator.
+
+| Identifier | Type | Default | Purpose |
+| --- | --- | --- | --- |
+| `comprehensiveHoursSaveBlockMode` | `Ref<boolean>` | `false` | When `true`, save-time advisory uses `enforcement: 'block'` and blocks save on `violation`. When `false`, PR4 weak behavior. |
+| `AttendanceComprehensiveHoursAssignmentAdvisory['kind']` | `'info' \| 'warn' \| 'error' \| 'block'` | (n/a) | Adds `'block'` discriminator so the UI can render the block-state advisory distinctly. |
+
+Per-kind block flag is not stored — the save handler reads the current
+advisory's `kind` to decide whether to abort. This avoids state-doubling
+between the advisory object and a separate boolean.
+
+## API contract changes
+
+None on the backend.
+
+On the frontend, the advisory function's return type changes from `Promise<void>`
+to `Promise<{ blocked: boolean }>`:
+
+```ts
+async function previewComprehensiveHoursAssignmentAdvisory(
+  kind: AttendanceComprehensiveHoursAssignmentKind,
+  draft: { userId: string; startDate: string; endDate: string | null; isActive: boolean },
+): Promise<{ blocked: boolean }>
+```
+
+Callers (`saveAssignment`, `saveRotationAssignment`) check the `blocked`
+field and `return` early without calling the save endpoint when `blocked === true`.
+
+## Behavior matrix
+
+Mode = `weak` (PR4, default off). The first 5 rows are unchanged from #1790.
+
+| Mode | Preview result | Advisory kind | Save call | Status text after |
+| --- | --- | --- | --- | --- |
+| weak | `ok` | none | runs | `Assignment created.` / `Rotation assignment created.` |
+| weak | `warning` | `warn` | runs | success text |
+| weak | `violation` | `warn` | runs | success text |
+| weak | `degraded` | `warn` | runs | success text |
+| weak | HTTP 400/503/network/parse error | `error` | runs | success text |
+| strong | `ok` | none | runs | success text |
+| strong | `warning` | `warn` | runs | success text |
+| strong | `violation` | **`block`** | **does NOT run** | error-style text: `Comprehensive-hours strong-control: save blocked because planned minutes exceed the cap. Disable strong-control to override.` |
+| strong | `degraded` | `warn` | runs | success text (preview-failure-never-blocks holds) |
+| strong | HTTP 400/503/network/parse error | `error` | runs | success text |
+
+Inactive assignment (any mode): preview call skipped, no advisory, save runs.
+
+## Payload contract
+
+The preview request body is constructed identically to PR4 except for the
+`enforcement` value:
+
+```json
+{
+  "policyDraft": {
+    "capHours": <admin-form value or 160>,
+    "enforcement": "<warn (weak) | block (strong)>"
+  },
+  "scope": { "userId": "<assignment-user-id>" },
+  "period": {
+    "type": "custom_range",
+    "from": "<assignment-start-date>",
+    "to": "<assignment-end-date-or-start-date>"
+  },
+  "metric": "planned"
+}
+```
+
+All other invariants from PR4 hold:
+
+- `metric` is hardcoded `planned`.
+- `scope` is a single explicit `userId`.
+- `allUsers` is never present.
+- Period is `custom_range` from the assignment dates (open-ended uses
+  `from` for both `from` and `to`).
+
+## UX copy
+
+### New strong-control block-state copy
+
+| Language | Copy |
+| --- | --- |
+| EN | `Comprehensive-hours strong-control: save blocked because planned minutes exceed the cap. Disable strong-control to override.` |
+| ZH | `综合工时强管控：计划工时已超过上限，保存已被拦截；关闭强管控可临时放行。` |
+
+The block-state copy explicitly tells the admin how to override (toggle off),
+so the gate is never a dead-end. This is intentional — PR5 is admin-facing
+strong control, not employee-facing hard wall.
+
+### Preserved PR4 copy (must not regress)
+
+The other advisory messages keep the exact PR4 wording. Specifically the
+sentinel phrase `Saving is still allowed in this stage` / `当前阶段仍允许保存`
+remains on:
+
+- weak-mode warning advisory
+- weak-mode violation advisory
+- both modes' degraded advisory
+- both modes' preview-error advisory
+
+### Banned copy (anti-regression)
+
+The block-state copy may use the word `blocked` because that is the literal
+state, but the other advisory states MUST NOT introduce any of:
+
+| Banned in non-block states | EN | ZH |
+| --- | --- | --- |
+| | `cannot save` | `禁止保存` |
+| | `policy enforced` | `已强制策略` |
+| | `violation prevented` | `已阻止违规` |
+
+This list is verified by the test suite via bundle/test-output grep with
+status-kind ≠ `block`.
+
+## UI surface
+
+A new control is added to the existing `attendance-admin-comprehensive-hours-preview`
+admin section, **below** the existing read-only preview controls so admins
+encounter it as an explicit extension rather than a silent override.
+
+```html
+<label
+  class="attendance__field attendance__field--checkbox"
+  data-attendance-comprehensive-hours-save-block-mode
+>
+  <input
+    type="checkbox"
+    id="attendance-comprehensive-hours-save-block-mode"
+    v-model="comprehensiveHoursSaveBlockMode"
+  />
+  <span>{{ tr('Save-time strong control', '保存时强管控') }}</span>
+  <small class="attendance__field-hint">
+    {{ tr(
+      'When enabled, shift and rotation assignment saves are blocked if the comprehensive-hours preview returns a violation. Preview errors never block saves.',
+      '启用后，若综合工时预览返回违规，将拦截班次和轮班分配保存；预览失败不会拦截保存。'
+    ) }}
+  </small>
+</label>
+```
+
+Additionally, the existing `comprehensiveHoursPreviewForm.enforcement` field's
+hint copy is **lightly updated** to disambiguate the two enforcement concepts:
+
+| Field | Before | After |
+| --- | --- | --- |
+| `Policy mode` (preview-form enforcement) hint | "Mode only changes preview status. It is not persisted and does not enforce saves." | "Mode only changes preview status. It is not persisted. See 'Save-time strong control' below to enable save blocking." |
+
+Same hint update in Chinese.
+
+This is a docs-style tweak inside the same section; not a behavior change.
+
+## Test requirements
+
+The vitest test suite must cover the 9 user-listed assertions plus one
+regression. Each row is a separate `it(...)` or a clear assertion block within
+a shared one.
+
+| # | Assertion | Mode | Preview result | Save endpoint called? | Advisory kind |
+| --- | --- | --- | --- | --- | --- |
+| T1 | weak mode after warning | weak | `warning` | yes | `warn` |
+| T2 | weak mode after violation | weak | `violation` | yes | `warn` |
+| T3 | strong mode blocks on violation | strong | `violation` | **no** | `block` |
+| T4 | strong mode allows on warning | strong | `warning` | yes | `warn` |
+| T5 | strong mode allows on ok | strong | `ok` | yes | none |
+| T6 | weak mode preview 503 → save runs | weak | HTTP 503 | yes | `error` |
+| T7 | strong mode preview 503 → save runs | strong | HTTP 503 | yes | `error` |
+| T8 | inactive assignment skips preview | weak or strong | n/a (not called) | yes | none |
+| T9 | payload contract across modes | both | n/a (asserts body shape) | n/a | n/a |
+| T10 (regression) | strong mode banned-language scan | strong | various | n/a | n/a |
+
+T8 covers both `weak` and `strong` paths to confirm `isActive: false` shorts
+out the preview before mode is consulted.
+
+T9 explicitly asserts in both modes:
+
+- `body.metric === 'planned'`
+- `typeof body.scope.userId === 'string'`
+- `!('allUsers' in body)`
+- `body.period.type === 'custom_range'`
+- `body.policyDraft.enforcement` is `'warn'` in weak mode and `'block'` in strong mode
+
+T10 scans the rendered assignment-section DOM after strong-mode violation for
+the absence of `cannot save`, `policy enforced`, `violation prevented`,
+`禁止保存`, `已强制策略`, `已阻止违规` — but allows the word `blocked` in
+the block-state advisory text (it is the legitimate state name).
+
+Both shift and rotation save surfaces must be covered for at least T1, T2,
+T3, T4, T6, T7.
+
+## Out-of-scope reaffirmation
+
+- ❌ No backend route changes (verify with `grep "addRoute(" -r plugins/plugin-attendance`).
+- ❌ No `attendance_*` migrations.
+- ❌ No `meta_*` writes.
+- ❌ No policy persistence (no localStorage, no settings row).
+- ❌ No change to preview compute logic on the backend.
+- ❌ No new endpoint.
+- ❌ No K3 / Data Factory / Bridge Agent touch.
+- ❌ No `allUsers` mode.
+- ❌ No PR6 reporting work.
+
+## Deferred to PR6 or later
+
+- Per-org / per-tenant default for the strong-control toggle.
+- Persistence of the toggle across sessions.
+- Time-bound or role-bound auto-enforcement (e.g. "strong-control auto-on for HR director").
+- Block-state escalation hook (e.g. require approval to override).
+- Strong-control on bulk / multi-user save flows (not present today).
+- Block-state metrics / audit trail.
+
+## References
+
+- #1778 — PR4 design lock (`docs/development/attendance-comprehensive-hours-control-pr4-warning-design-20260522.md`).
+- #1790 — PR4 runtime weak-control.
+- #1795 — PR4 staging E2E PASS evidence.
+- `[[k3-poc-stage1-lock-no-new-fronts]]` — internal kernel-polish; this PR sits in the authorized 内核打磨 lane.
+- `[[staged-optin-lineage]]` — each PR in this chain is a separate explicit user opt-in.

--- a/docs/development/attendance-comprehensive-hours-pr5-strong-control-verification-20260523.md
+++ b/docs/development/attendance-comprehensive-hours-pr5-strong-control-verification-20260523.md
@@ -1,0 +1,154 @@
+# Attendance comprehensive-hours PR5 strong-control verification - 2026-05-23
+
+## Scope verified
+
+Runtime PR5 implementation against the design lock in
+`docs/development/attendance-comprehensive-hours-pr5-strong-control-design-20260523.md`.
+
+This slice adds a deliberately-opt-in strong-control toggle that blocks
+shift/rotation assignment save when the read-only comprehensive-hours preview
+returns `aggregate.status === 'violation'`. PR4 weak-control behavior is the
+default and is preserved byte-for-byte when the toggle is off.
+
+## Files changed
+
+| File | Delta |
+| --- | --- |
+| `apps/web/src/views/AttendanceView.vue` | +49 lines, -5 lines: add `comprehensiveHoursSaveBlockMode` ref, extend advisory `kind` discriminator with `'block'`, plumb mode + violation gate through `previewComprehensiveHoursAssignmentAdvisory`, add early-return in `saveAssignment` + `saveRotationAssignment`, add admin checkbox UI + hint update on preview-form enforcement field, add `--block` CSS modifier class and `data-attendance-comprehensive-hours-assignment-advisory-kind` data attribute |
+| `apps/web/tests/attendance-admin-regressions.spec.ts` | +6 PR5 tests covering all 9 design-required assertions plus the rotation surface |
+| `docs/development/attendance-comprehensive-hours-pr5-strong-control-design-20260523.md` | +new design lock MD |
+| `docs/development/attendance-comprehensive-hours-pr5-strong-control-verification-20260523.md` | +this verification MD |
+
+No new files outside the above four. No `plugins/`, `packages/`, `migrations/`,
+`scripts/`, or `.github/workflows/` touches.
+
+## Contract coverage
+
+| Contract from design MD | Test(s) | Result |
+| --- | --- | --- |
+| Default off → PR4 weak behavior preserved | 3 PR4 tests `runs a weak comprehensive-hours advisory ...` (shift + rotation) + `keeps shift assignment save available when the weak ... preview fails` | PASS — 3/3 green |
+| Strong mode + `violation` blocks save (shift) | `PR5 strong-control blocks shift assignment save when preview returns violation` | PASS |
+| Strong mode + `violation` blocks save (rotation) | `PR5 strong-control blocks rotation assignment save when preview returns violation` | PASS |
+| Strong mode + `warning` allows save | `PR5 strong-control allows shift assignment save when preview returns warning` | PASS |
+| Strong mode + `ok` allows save | `PR5 strong-control allows shift assignment save when preview returns ok` | PASS |
+| Strong mode + preview 503 allows save | `PR5 strong-control allows shift assignment save when preview fails with 503` | PASS |
+| Inactive assignment skips preview entirely | `PR5 inactive shift assignment skips the preview call in both modes` | PASS |
+| Payload contract: `metric: planned`, single `userId`, `custom_range`, no `allUsers`, `enforcement` mirrors mode (`warn`/`block`) | Asserted in all 6 PR5 tests (positive enforcement assertion in shift+rotation block tests; preserved in PR4 weak tests for `warn` mode) | PASS |
+| Block-state advisory copy banned-language scan | In the shift-violation block test: `advisoryText` must NOT contain `cannot save`, `policy enforced`, `violation prevented`, `禁止保存`, `已强制策略`, `已阻止违规` | PASS |
+| Preview reuses existing `/api/attendance/comprehensive-hours/preview` route | URL match in every test mock | PASS |
+
+## Bundle fingerprint (against built `dist/assets/index-CA82mKPV.js`)
+
+| Fingerprint (PR5 new) | Count |
+| --- | ---: |
+| `Save-time strong control` | 1 |
+| `保存时强管控` | 1 |
+| `strong-control: save blocked` | 1 |
+| `综合工时强管控` | 1 |
+| `attendance-comprehensive-hours-save-block-mode` (id + data attr) | 2 |
+
+PR4 fingerprints preserved in the same built bundle:
+
+| Fingerprint (PR4 must remain) | Count |
+| --- | ---: |
+| `data-attendance-comprehensive-hours-assignment-advisory` | 2 |
+| `Saving is still allowed in this stage` | 1 |
+| `当前阶段仍允许保存` | 1 |
+| `Comprehensive-hours advisory` | 1 |
+| `comprehensive-hours/preview` | 1 |
+
+PR5 banned-language scan in the built bundle:
+
+| Pattern | Count |
+| --- | ---: |
+| `cannot save` | 0 |
+| `policy enforced` | 0 |
+| `violation prevented` | 0 |
+| `禁止保存` | 0 |
+| `已强制策略` | 0 |
+| `已阻止违规` | 0 |
+
+The block-state advisory uses the word `blocked` as the legitimate state
+descriptor; that is the only block/strong-control terminology allowed by the
+design MD.
+
+## Test commands and results
+
+| Command | Result |
+| --- | --- |
+| `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts tests/attendance-admin-anchor-nav.spec.ts --watch=false` | **47/47 PASS** (24 admin-regressions + 23 anchor-nav), 6.26 s |
+| `pnpm --filter @metasheet/web type-check` | PASS |
+| `pnpm --filter @metasheet/web build` | PASS, 6.63 s |
+| `node --check plugins/plugin-attendance/index.cjs` | PASS |
+| `git diff --check` | PASS |
+
+## Boundary reaffirmation
+
+| Constraint | Check |
+| --- | --- |
+| No new backend route | Diff confines to `apps/web/` and `docs/development/`. `grep "addRoute(" plugins/ packages/` Δ = 0. |
+| No `attendance_*` migration | No `migrations/` change. |
+| No `meta_*` write | No `multitable*` / `meta_*` code reference added. |
+| No policy persistence | Strong-mode toggle is a Vue ref. No `localStorage`, no settings/catalog row, no API write. Page reload resets the toggle. |
+| No preview compute change | Backend `comprehensive-hours/preview` route unchanged. The frontend reuses the existing payload contract; `enforcement: 'block'` was already accepted by the route per #1776. |
+| No `allUsers` | Test asserts `not.toHaveProperty('allUsers')` in both shift and rotation PR5 tests. |
+| PR4 weak behavior preserved | 3 PR4 tests still pass; default `comprehensiveHoursSaveBlockMode = false` keeps `enforcement: 'warn'` and the unconditional save path. |
+| Inactive assignment skip preserved | `PR5 inactive ... skips the preview call in both modes` test asserts `previewCalled === false`. |
+| Codex review only model | PR will be opened OPEN without auto-merge per user direction. |
+
+## Secret / home-path scan
+
+```
+$ grep -rE "eyJ[A-Za-z0-9_-]{20,}|Bearer\s+[A-Za-z0-9_.-]{20,}|/Users/[a-z]|/home/[a-z]" \
+    apps/web/src/views/AttendanceView.vue \
+    apps/web/tests/attendance-admin-regressions.spec.ts \
+    docs/development/attendance-comprehensive-hours-pr5-*.md
+(no matches)
+```
+
+No JWT, no `Bearer` token, no user home path in any PR5 file.
+
+## Items intentionally NOT done
+
+- No production smoke for PR5. The bundle fingerprint is in the local build
+  only; deploy and rerun a smoke against `:8081` after this PR is merged and
+  the build/push pipeline lands the image.
+- No staging E2E for PR5 — same reason as above. Per `[[staging-8082-jwt-and-deploy-lane]]`
+  memory, staging requires a separate deploy lane trigger and its own JWT.
+- No backend integration test for `enforcement: 'block'` on the preview route
+  (the existing #1776 tests already lock `INVALID_*` rejection for invalid
+  enums; `'block'` is a valid enum already accepted by the route).
+- No persistence of the strong-mode toggle. Intentional per design MD §
+  Hard Boundaries "No policy persistence".
+- No telemetry / audit trail when a save is blocked. Deferred to PR6 reporting.
+- No bulk / multi-user save flow change. There is no such flow today.
+
+## Production runtime check after merge (recommended SOP)
+
+After admin-merge + `Build and Push Docker Images` on the merge SHA, run the
+following anonymous bundle fingerprint check against production:
+
+```
+curl -s http://<prod-host>:8081/attendance \
+  | grep -oE '/assets/index-[^"]+\.js' \
+  | xargs -I{} curl -s "http://<prod-host>:8081{}" \
+  | grep -E "Save-time strong control|保存时强管控|strong-control: save blocked|attendance-comprehensive-hours-save-block-mode"
+```
+
+Expect 5 matches (one per fingerprint above) before declaring PR5 live.
+
+## References
+
+- Design MD: `docs/development/attendance-comprehensive-hours-pr5-strong-control-design-20260523.md`
+- PR4 runtime: #1790
+- PR4 design lock: #1778 (defines PR5 as the deferred strong-control slice)
+- Preview route hardening: #1776 (already accepts `enforcement: 'block'`)
+- Admin preview UI: #1777 (defines the section that hosts the new toggle)
+- PR4 staging E2E PASS: #1795
+- Memory: `[[k3-poc-stage1-lock-no-new-fronts]]` (this PR sits in the
+  authorized 内核打磨 lane).
+- Memory: `[[staged-optin-lineage]]` (user opt-in at 2026-05-23 unlocks PR5).
+- Memory: `[[skip-when-unreachable]]` (no early-return-on-unmocked, all tests
+  assert real ordered behavior).
+- Memory: `[[staging-8082-jwt-and-deploy-lane]]` (explains why staging E2E is
+  deferred until staging deploy + staging JWT are both ready).

--- a/docs/development/attendance-comprehensive-hours-pr5-strong-control-verification-20260523.md
+++ b/docs/development/attendance-comprehensive-hours-pr5-strong-control-verification-20260523.md
@@ -33,6 +33,7 @@ No new files outside the above four. No `plugins/`, `packages/`, `migrations/`,
 | Strong mode + `ok` allows save | `PR5 strong-control allows shift assignment save when preview returns ok` | PASS |
 | Strong mode + preview 503 allows save | `PR5 strong-control allows shift assignment save when preview fails with 503` | PASS |
 | Inactive assignment skips preview entirely | `PR5 inactive shift assignment skips the preview call in both modes` | PASS |
+| Strong mode + `degraded: true` still allows save even on `violation` status (locks `!result?.degraded` guard) | `PR5 strong-control does NOT block shift assignment save when preview is degraded even if status is violation` | PASS |
 | Payload contract: `metric: planned`, single `userId`, `custom_range`, no `allUsers`, `enforcement` mirrors mode (`warn`/`block`) | Asserted in all 6 PR5 tests (positive enforcement assertion in shift+rotation block tests; preserved in PR4 weak tests for `warn` mode) | PASS |
 | Block-state advisory copy banned-language scan | In the shift-violation block test: `advisoryText` must NOT contain `cannot save`, `policy enforced`, `violation prevented`, `禁止保存`, `已强制策略`, `已阻止违规` | PASS |
 | Preview reuses existing `/api/attendance/comprehensive-hours/preview` route | URL match in every test mock | PASS |
@@ -76,7 +77,7 @@ design MD.
 
 | Command | Result |
 | --- | --- |
-| `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts tests/attendance-admin-anchor-nav.spec.ts --watch=false` | **47/47 PASS** (24 admin-regressions + 23 anchor-nav), 6.26 s |
+| `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts tests/attendance-admin-anchor-nav.spec.ts --watch=false` | **48/48 PASS** (25 admin-regressions + 23 anchor-nav), 5.91 s |
 | `pnpm --filter @metasheet/web type-check` | PASS |
 | `pnpm --filter @metasheet/web build` | PASS, 6.63 s |
 | `node --check plugins/plugin-attendance/index.cjs` | PASS |


### PR DESCRIPTION
## Summary

Adds an opt-in `Save-time strong control` toggle to the comprehensive-hours admin preview section. When enabled, shift and rotation assignment saves are blocked if the existing read-only preview returns `aggregate.status === 'violation'`. PR4 weak-control behavior is the default and is preserved byte-for-byte when the toggle is off.

- Reuses `POST /api/attendance/comprehensive-hours/preview` — no new endpoint.
- Sends `policyDraft.enforcement: 'block'` in strong mode (already accepted by the route since #1776).
- Blocks save only on `aggregate.status === 'violation'`. Preview errors, degraded data, warnings, and `ok` results never block.
- Block-state advisory says: "Comprehensive-hours strong-control: save blocked because planned minutes exceed the cap. Disable strong-control to override." — never a dead-end.
- Inactive assignment still skips the preview call entirely.

Toggle is a Vue ref. No localStorage, no settings row, no DB write. Page reload resets to default off.

## Hard boundaries (match docs/development/attendance-comprehensive-hours-pr5-strong-control-design-20260523.md)

- ❌ No backend route changes.
- ❌ No `attendance_*` migration.
- ❌ No `meta_*` writes.
- ❌ No policy persistence.
- ❌ No PR4 weak-control behavior regression (3 PR4 tests still green).
- ❌ No `allUsers` mode.
- ❌ No K3 / Data Factory / Bridge Agent touch.
- ✅ Only `apps/web/src/views/AttendanceView.vue`, `apps/web/tests/attendance-admin-regressions.spec.ts`, and 2 docs MDs.

## Test plan

- [x] `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts tests/attendance-admin-anchor-nav.spec.ts --watch=false` — **47/47 PASS** (3 PR4 weak + 6 new PR5 + 38 unrelated)
- [x] `pnpm --filter @metasheet/web type-check` — PASS
- [x] `pnpm --filter @metasheet/web build` — PASS
- [x] `node --check plugins/plugin-attendance/index.cjs` — PASS
- [x] `git diff --check` — PASS
- [x] Built bundle PR5 fingerprint scan — 5/5 present
- [x] Built bundle PR4 fingerprint scan — 5/5 preserved
- [x] Built bundle PR5 banned-language scan — 0/6 hits
- [x] Secret / home-path scan over changed files — 0 matches

## Test coverage (6 new vitest cases)

| # | Behavior | Result |
| --- | --- | --- |
| 1 | Strong-mode + violation blocks shift save + block-advisory copy passes banned-language scan | PASS |
| 2 | Strong-mode + violation blocks rotation save | PASS |
| 3 | Strong-mode + warning allows shift save | PASS |
| 4 | Strong-mode + ok allows shift save | PASS |
| 5 | Strong-mode + preview 503 allows shift save (preview failure never blocks) | PASS |
| 6 | Inactive shift assignment skips preview call entirely (in either mode) | PASS |

Plus PR4's existing 3 weak-control tests assert PR4 byte-for-byte preserved (warn-mode warning/violation/503 all still save).

## Review note

Per discipline `[[staged-optin-lineage]]`: not auto-merging. Leaving open for Codex independent review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)