### PR TITLE
feat(approval): add dynamic assignee resolver

### DIFF
--- a/docs/development/approval-phase2-assignee-resolver-development-20260523.md
+++ b/docs/development/approval-phase2-assignee-resolver-development-20260523.md
@@ -1,0 +1,149 @@
+# Approval Phase 2 AssigneeResolver Development 2026-05-23
+
+Base: `origin/main@675afd560` (`docs(approval): scope phase2 assignee resolver (#1794)`)
+Branch: `codex/approval-assignee-resolver-impl-20260523`
+Scope gate: `docs/development/approval-phase2-assignee-resolver-scope-gate-20260523.md`
+
+## Summary
+
+This slice implements the first unlocked Phase 2 item: a pure approval assignee resolver for dynamic approval-node assignment sources.
+
+It keeps the executor graph-local, stores source configuration in the frozen runtime graph, preserves legacy static assignment behavior, and does not unlock trigger bindings, start-approval automation, result backwrite, event bridge, UI, SLA, or add-sign/countersign work.
+
+## Implemented Files
+
+| File | Purpose |
+|---|---|
+| `packages/core-backend/src/types/approval-product.ts` | Adds `ApprovalAssigneeSource`, `ApprovalAssigneeResolutionMetadata`, and optional `ApprovalNodeConfig.assigneeSources`. Legacy `assigneeType` / `assigneeIds` remain optional for backward compatibility. |
+| `packages/core-backend/src/services/ApprovalAssigneeResolver.ts` | New synchronous, DB-free resolver for `static_user`, `static_role`, `requester`, and `form_field_user`. |
+| `packages/core-backend/src/services/ApprovalGraphExecutor.ts` | Accepts an injected pure assignment resolver and applies existing empty-assignee policy when dynamic resolution returns no assignment. |
+| `packages/core-backend/src/services/ApprovalProductService.ts` | Normalizes and validates `assigneeSources`, wires resolver inputs from frozen runtime graph state, persists assignment metadata, and refuses dynamic parallel collisions before insertion. |
+| `packages/core-backend/tests/unit/approval-assignee-resolver.test.ts` | Unit coverage for resolver source semantics, schema validation, empty dynamic values, and dedupe. |
+| `packages/core-backend/tests/unit/approval-graph-executor.test.ts` | Executor coverage for injected resolver, empty-assignee `error`, and empty-assignee `auto-approve`. |
+| `packages/core-backend/tests/unit/approval-product-service.test.ts` | Product-service coverage for normalization, schema validation, metadata persistence, version-freeze reads, and dynamic parallel collisions. |
+| `packages/core-backend/tests/unit/approval-admin-jump-service.test.ts` | Existing admin-jump expectations updated for assignment metadata parameter. |
+
+No route, migration, UI, automation, Workflow Designer, SLA, breach, trigger-binding, backwrite, event-bridge, or add-sign files changed.
+
+## Resolver Contract
+
+The resolver input is intentionally narrow:
+
+- frozen approval node config;
+- frozen form schema when available;
+- current instance `form_snapshot`;
+- current instance `requester_snapshot`;
+- node key and source step.
+
+The resolver is synchronous and does not query the database. It returns runtime assignments shaped as:
+
+```ts
+{
+  assignmentType: 'user' | 'role',
+  assigneeId: string,
+  nodeKey: string,
+  sourceStep: number,
+  metadata?: {
+    resolvedFrom: {
+      kind: 'static_user' | 'static_role' | 'requester' | 'form_field_user',
+      sourceIndex: number,
+      fieldId?: string,
+    },
+  },
+}
+```
+
+Legacy `assigneeType` / `assigneeIds` runtime graphs remain metadata-free.
+
+## Source Semantics
+
+| Source | Behavior |
+|---|---|
+| `static_user` | Resolves each configured user id into a `user` assignment. |
+| `static_role` | Resolves each configured role id into a `role` assignment. It does not expand role membership. |
+| `requester` | Resolves to `requester_snapshot.id` when present. Missing requester id produces no assignments and lets the node `emptyAssigneePolicy` decide. |
+| `form_field_user` | Resolves a string value or object `{ id }` from `form_snapshot[fieldId]`. Missing, empty, or unsupported values produce no assignments and let `emptyAssigneePolicy` decide. |
+
+When `formSchema` is available, `form_field_user` must reference an existing field whose type is `user`; otherwise the service throws `APPROVAL_ASSIGNEE_INVALID_SOURCE`.
+
+Within one node, duplicate resolved `(assignmentType, assigneeId)` pairs are deduped and the first source metadata wins.
+
+## Normalization and Validation
+
+`assigneeSources` is authoritative when present. Legacy fields may coexist only if they are valid legacy fields; this keeps display/backward compatibility while avoiding ambiguous partial legacy config.
+
+Validation rules added in `ApprovalProductService`:
+
+- `assigneeSources` must be an array if present.
+- `assigneeSources: []` is invalid at normalization time.
+- `static_user.userIds` and `static_role.roleIds` must be non-empty string arrays.
+- `form_field_user.fieldId` must be a non-empty string.
+- create, update-version, and publish paths validate `form_field_user` against the form schema.
+
+## Runtime Wiring
+
+`ApprovalProductService` builds a pure resolver callback from:
+
+- instance form snapshot;
+- requester snapshot;
+- form schema at instance creation time.
+
+The resolver callback is injected into `ApprovalGraphExecutor` for:
+
+- `createApproval`;
+- `dispatchAction` advance/return path;
+- `adminJump`.
+
+`dispatchAction` and `adminJump` continue to load the instance-bound `runtime_graph` through `published_definition_id`. They do not read active template JSON or `approval_template_versions` for source configuration.
+
+## Dynamic Parallel Collision Guard
+
+The existing database invariant allows only one active assignment per `(instance_id, assignment_type, assignee_id)`. Static cross-branch duplicates are already prevented before runtime; dynamic sources can collide only after resolving against a specific instance.
+
+This slice adds a pre-insert guard:
+
+- detects duplicate dynamic assignments in the pending batch;
+- detects dynamic assignments colliding with existing active assignments;
+- throws `APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT`;
+- rolls back before inserting assignments, audit rows, or committing the transaction.
+
+The guard is metadata-sensitive. Legacy/static metadata-free paths avoid the extra active-assignment SELECT, preserving old-path behavior and performance.
+
+## Scope Gate Mapping
+
+| Gate | Result |
+|---|---|
+| G1 runtime graph snapshot | `assigneeSources` lives in `ApprovalNodeConfig` and is captured by the published runtime graph. |
+| G2 sync DB-free resolver | `ApprovalAssigneeResolver` is pure and synchronous. |
+| G3 v1 sources only | Only `static_user`, `static_role`, `requester`, and `form_field_user` are accepted. |
+| G4 empty-assignee semantics | Empty dynamic resolution flows through existing `error` / `auto-approve` policy only. |
+| G5 role assignment semantics | `static_role` remains `assignment_type='role'`; no role expansion. |
+| G6 dynamic parallel conflict | `APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT` is thrown before assignment insert. |
+| G7 no boundary crossing | No migrations, routes, UI, automation, Workflow Designer, SLA, breach, trigger, backwrite, event bridge, or add-sign files changed. |
+| G8 frozen graph reads | dispatch/admin-jump paths use instance-bound `published_definition_id` runtime graph. |
+
+## Review NIT Handling
+
+| NIT | Handling |
+|---|---|
+| NIT-1 split T14 | Dynamic parallel conflict is covered at creation time and advance time. |
+| NIT-2 empty `assigneeSources` | Empty source arrays are invalid during graph normalization and publish validation. |
+| NIT-3 active-template negative read | Dispatch test asserts the advance path does not read active template tables for dynamic sources. |
+
+## Forward Gate
+
+This implementation keeps the PR #1794 forward gate intact.
+
+The resolver slice is unlocked as approval-kernel hardening only. These items remain frozen and require K3 GATE PASS, a named K3 gate blocker, or separate explicit opt-in with a new scope gate:
+
+- `approval_trigger_bindings`;
+- multitable/public-form approval trigger source-snapshot and trigger-event paths;
+- approval result backwrite to multitable records;
+- automation `start_approval`;
+- approval completion event bridge for automation triggers.
+
+## Deployment Notes
+
+No migration is included. Existing published runtime graphs without `assigneeSources` continue through the legacy static assignment path.
+
+New dynamic-source templates can only be authored by API/internal config until a future UI slice is explicitly scoped. This PR intentionally does not add UI controls.

--- a/docs/development/approval-phase2-assignee-resolver-verification-20260523.md
+++ b/docs/development/approval-phase2-assignee-resolver-verification-20260523.md
@@ -1,0 +1,168 @@
+# Approval Phase 2 AssigneeResolver Verification 2026-05-23
+
+Branch: `codex/approval-assignee-resolver-impl-20260523`
+Base: `origin/main@675afd560`
+Commit under verification: local working tree before final commit
+
+## Verification Summary
+
+PASS. The implementation satisfies the resolver scope gate and the review NITs with unit, build, diff, and scratch PostgreSQL coverage.
+
+## Commands Run
+
+### Focused Unit Tests
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run --watch=false \
+  tests/unit/approval-assignee-resolver.test.ts \
+  tests/unit/approval-graph-executor.test.ts \
+  tests/unit/approval-product-service.test.ts
+```
+
+Result:
+
+```text
+Test Files  3 passed (3)
+Tests       56 passed (56)
+```
+
+After updating admin-jump metadata expectations:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run --watch=false \
+  tests/unit/approval-admin-jump-service.test.ts \
+  tests/unit/approval-assignee-resolver.test.ts \
+  tests/unit/approval-graph-executor.test.ts \
+  tests/unit/approval-product-service.test.ts
+```
+
+Result:
+
+```text
+Test Files  4 passed (4)
+Tests       63 passed (63)
+```
+
+### Full Backend Unit Suite
+
+```bash
+pnpm --filter @metasheet/core-backend test:unit
+```
+
+Result:
+
+```text
+Test Files  176 passed (176)
+Tests       2290 passed (2290)
+```
+
+### Build
+
+```bash
+pnpm --filter @metasheet/core-backend build
+```
+
+Result:
+
+```text
+PASS
+```
+
+### Scratch PostgreSQL Integration
+
+Scratch database:
+
+```text
+ms2_approval_resolver_1779544135
+```
+
+Command:
+
+```bash
+DATABASE_URL=postgres://localhost/ms2_approval_resolver_1779544135 \
+  pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts \
+  run tests/integration/approval-pack1a-lifecycle.api.test.ts \
+      tests/integration/approval-wp1-parallel-gateway.api.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+```text
+Test Files  2 passed (2)
+Tests       7 passed (7)
+```
+
+The scratch database was dropped after the run.
+
+### Diff Hygiene
+
+```bash
+git diff --check origin/main..HEAD
+git diff --check origin/main...HEAD
+git diff --check
+```
+
+Result:
+
+```text
+PASS
+```
+
+## Test Coverage Map
+
+| Scope test | Coverage |
+|---|---|
+| T1 legacy static assignments | Resolver unit test keeps legacy static user/role assignments metadata-free. Existing approval unit and integration tests remain green. |
+| T2 old runtime graph compatibility | Full unit and scratch approval integration pass with legacy graphs. |
+| T3 requester source | Product-service unit test persists requester-source metadata on created assignments. |
+| T4 empty requester with `error` | Graph executor unit test returns `APPROVAL_ASSIGNEE_EMPTY`. |
+| T5 empty requester with `auto-approve` | Graph executor unit test emits empty-assignee auto path. |
+| T6 string `form_field_user` | Resolver unit test resolves string user id. |
+| T7 object `form_field_user` | Resolver unit test resolves object `{ id }`. |
+| T8 invalid form field source | Resolver and product-service validation tests reject non-user/missing fields with `APPROVAL_ASSIGNEE_INVALID_SOURCE`. |
+| T9 hidden/pruned/missing form value | Resolver unit test returns empty assignments for missing dynamic values, leaving policy decision to executor. |
+| T10 dedupe | Resolver unit test dedupes duplicate resolved assignments and keeps first source metadata. |
+| T11 static role semantics | Resolver unit test keeps `static_role` as `assignment_type='role'`; no role expansion is implemented. |
+| T12 PR2 requester auto-merge composition | Existing PR2 unit and integration coverage remains green; requester assignments are normal `user` assignments and flow through existing auto-approval logic. |
+| T13 PR2 historical dedupe composition | Existing PR2 historical dedupe coverage remains green; dynamic user assignments share the same runtime shape. |
+| T14 dynamic parallel duplicate | Product-service tests cover create-time and advance-time duplicate requester collisions with rollback. |
+| T15 version freeze | Dispatch unit test asserts dynamic-source advance reads the instance-bound runtime graph and does not query active template tables. |
+| T16 admin jump composition | Admin-jump unit tests remain green with resolver wiring and metadata parameter. |
+| T17 metadata | Resolver and product-service tests assert `metadata.resolvedFrom` for dynamic sources and no metadata for legacy static path. |
+| T18 no schema change | File diff contains no migrations or bootstrap changes. |
+
+## Review NIT Evidence
+
+| NIT | Evidence |
+|---|---|
+| NIT-1 | `approval-product-service.test.ts` includes both create-time and advance-time dynamic parallel conflict tests. |
+| NIT-2 | `normalizeApprovalAssigneeSources()` rejects `assigneeSources: []`; product-service unit tests pin the validation. |
+| NIT-3 | Dispatch version-freeze test asserts no `approval_templates`, `approval_template_versions`, or `active_version_id` query is made while advancing a dynamic-source instance. |
+
+## Scope Control
+
+Changed runtime/test files are limited to:
+
+- `packages/core-backend/src/types/approval-product.ts`
+- `packages/core-backend/src/services/ApprovalAssigneeResolver.ts`
+- `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+- `packages/core-backend/tests/unit/approval-assignee-resolver.test.ts`
+- `packages/core-backend/tests/unit/approval-graph-executor.test.ts`
+- `packages/core-backend/tests/unit/approval-product-service.test.ts`
+- `packages/core-backend/tests/unit/approval-admin-jump-service.test.ts`
+
+No migrations, routes, UI, automation, Workflow Designer, SLA, breach, trigger-binding, backwrite, event-bridge, or add-sign/countersign files changed.
+
+## Known Notes
+
+The first ad hoc integration attempt was not counted because it did not use the integration Vitest config. The recorded DB signal above is the later `vitest.integration.config.ts` run against scratch PostgreSQL.
+
+Two local dependency symlinks were created only so this isolated worktree could reuse the main checkout dependencies:
+
+- `node_modules`
+- `packages/core-backend/node_modules`
+
+They are not part of the PR and must remain unstaged/removed before commit.

--- a/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
+++ b/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
@@ -1,0 +1,134 @@
+import type {
+  ApprovalAssigneeResolutionMetadata,
+  ApprovalAssigneeSource,
+  ApprovalNodeConfig,
+  FormSchema,
+} from '../types/approval-product'
+import { ServiceError } from './ApprovalBridgeService'
+
+export type ResolvedApprovalAssignment = {
+  assignmentType: 'user' | 'role'
+  assigneeId: string
+  nodeKey: string
+  sourceStep: number
+  metadata?: ApprovalAssigneeResolutionMetadata
+}
+
+export interface ResolveApprovalAssigneesOptions {
+  nodeKey: string
+  sourceStep: number
+  config: ApprovalNodeConfig
+  formSchema?: FormSchema
+  formSnapshot: Record<string, unknown>
+  requesterSnapshot: Record<string, unknown> | null
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeId(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : null
+}
+
+function metadataFor(source: ApprovalAssigneeSource, sourceIndex: number): ApprovalAssigneeResolutionMetadata {
+  return {
+    resolvedFrom: {
+      kind: source.kind,
+      sourceIndex,
+      ...(source.kind === 'form_field_user' ? { fieldId: source.fieldId } : {}),
+    },
+  }
+}
+
+function resolveFormUserValue(value: unknown): string | null {
+  const stringId = normalizeId(value)
+  if (stringId) return stringId
+  if (isRecord(value)) {
+    return normalizeId(value.id)
+  }
+  return null
+}
+
+function assertFormUserSource(
+  source: Extract<ApprovalAssigneeSource, { kind: 'form_field_user' }>,
+  formSchema: FormSchema | undefined,
+  nodeKey: string,
+): void {
+  if (!formSchema) return
+  const field = formSchema.fields.find((entry) => entry.id === source.fieldId)
+  if (!field || field.type !== 'user') {
+    throw new ServiceError(
+      `Approval node ${nodeKey} references a non-user assignee field`,
+      400,
+      'APPROVAL_ASSIGNEE_INVALID_SOURCE',
+      { nodeKey, fieldId: source.fieldId },
+    )
+  }
+}
+
+export function resolveApprovalAssignees(
+  options: ResolveApprovalAssigneesOptions,
+): ResolvedApprovalAssignment[] {
+  const sources = options.config.assigneeSources
+  if (!sources) {
+    return (options.config.assigneeIds ?? []).map((assigneeId) => ({
+      assignmentType: options.config.assigneeType === 'role' ? 'role' : 'user',
+      assigneeId,
+      nodeKey: options.nodeKey,
+      sourceStep: options.sourceStep,
+    }))
+  }
+
+  const resolved: ResolvedApprovalAssignment[] = []
+  const seen = new Set<string>()
+
+  const pushResolved = (
+    assignmentType: 'user' | 'role',
+    assigneeId: string,
+    source: ApprovalAssigneeSource,
+    sourceIndex: number,
+  ): void => {
+    const key = `${assignmentType}:${assigneeId}`
+    if (seen.has(key)) return
+    seen.add(key)
+    resolved.push({
+      assignmentType,
+      assigneeId,
+      nodeKey: options.nodeKey,
+      sourceStep: options.sourceStep,
+      metadata: metadataFor(source, sourceIndex),
+    })
+  }
+
+  sources.forEach((source, sourceIndex) => {
+    switch (source.kind) {
+      case 'static_user':
+        source.userIds.forEach((userId) => pushResolved('user', userId, source, sourceIndex))
+        break
+      case 'static_role':
+        source.roleIds.forEach((roleId) => pushResolved('role', roleId, source, sourceIndex))
+        break
+      case 'requester': {
+        const requesterId = normalizeId(options.requesterSnapshot?.id)
+        if (requesterId) pushResolved('user', requesterId, source, sourceIndex)
+        break
+      }
+      case 'form_field_user': {
+        assertFormUserSource(source, options.formSchema, options.nodeKey)
+        const assigneeId = resolveFormUserValue(options.formSnapshot[source.fieldId])
+        if (assigneeId) pushResolved('user', assigneeId, source, sourceIndex)
+        break
+      }
+      default:
+        throw new ServiceError(
+          `Approval node ${options.nodeKey} has an unsupported assignee source`,
+          400,
+          'APPROVAL_ASSIGNEE_INVALID_SOURCE',
+          { nodeKey: options.nodeKey },
+        )
+    }
+  })
+
+  return resolved
+}

--- a/packages/core-backend/src/services/ApprovalGraphExecutor.ts
+++ b/packages/core-backend/src/services/ApprovalGraphExecutor.ts
@@ -1,4 +1,5 @@
 import type {
+  ApprovalAssigneeResolutionMetadata,
   ApprovalAutoApprovalReason,
   ApprovalEdge,
   ApprovalMode,
@@ -12,13 +13,23 @@ import type {
   ParallelNodeConfig,
   RuntimeGraph,
 } from '../types/approval-product'
+import { ServiceError } from './ApprovalBridgeService'
 
 export interface ApprovalGraphAssignment {
   assignmentType: 'user' | 'role'
   assigneeId: string
   nodeKey: string
   sourceStep: number
+  metadata?: ApprovalAssigneeResolutionMetadata
 }
+
+export interface ApprovalGraphAssignmentResolverInput {
+  nodeKey: string
+  sourceStep: number
+  config: ApprovalNodeConfig
+}
+
+export type ApprovalGraphAssignmentResolver = (input: ApprovalGraphAssignmentResolverInput) => ApprovalGraphAssignment[]
 
 export interface ApprovalCcEvent {
   nodeKey: string
@@ -112,9 +123,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 }
 
 function isApprovalNodeConfig(config: unknown): config is ApprovalNodeConfig {
-  return isRecord(config)
-    && (config.assigneeType === 'user' || config.assigneeType === 'role')
+  if (!isRecord(config)) return false
+  const hasLegacyAssignees = (config.assigneeType === 'user' || config.assigneeType === 'role')
     && Array.isArray(config.assigneeIds)
+  return hasLegacyAssignees || Array.isArray(config.assigneeSources)
 }
 
 function isConditionBranch(value: unknown): value is ConditionBranch {
@@ -452,6 +464,7 @@ export class ApprovalGraphExecutor {
   constructor(
     private readonly runtimeGraph: RuntimeGraph,
     private readonly formData: Record<string, unknown>,
+    private readonly options: { assignmentResolver?: ApprovalGraphAssignmentResolver } = {},
   ) {
     for (const node of runtimeGraph.nodes) {
       this.nodeMap.set(node.key, node)
@@ -615,7 +628,7 @@ export class ApprovalGraphExecutor {
   }
 
   getApprovalNodeAssigneeIds(nodeKey: string): string[] {
-    return [...this.getApprovalNodeConfig(nodeKey).assigneeIds]
+    return [...(this.getApprovalNodeConfig(nodeKey).assigneeIds ?? [])]
   }
 
   resolveReturnToNode(targetNodeKey: string): ApprovalGraphResolution {
@@ -750,7 +763,8 @@ export class ApprovalGraphExecutor {
         }
         const sourceStep = this.stepIndexForNode(node.key)
         const approvalMode = normalizeApprovalMode(approvalConfig.approvalMode)
-        if (approvalConfig.assigneeIds.length === 0) {
+        const assignments = this.resolveAssignmentsForApprovalNode(node.key, approvalConfig, sourceStep)
+        if (assignments.length === 0) {
           if (approvalConfig.emptyAssigneePolicy === 'auto-approve') {
             autoApprovalEvents.push({
               nodeKey: node.key,
@@ -761,19 +775,19 @@ export class ApprovalGraphExecutor {
             currentKey = this.firstTargetForNode(node.key)
             continue
           }
-          throw new Error(`Approval node ${node.key} has no assignees`)
+          throw new ServiceError(
+            `Approval node ${node.key} has no assignees`,
+            400,
+            'APPROVAL_ASSIGNEE_EMPTY',
+            { nodeKey: node.key },
+          )
         }
         return {
           status: 'pending',
           currentNodeKey: node.key,
           currentStep: sourceStep,
           totalSteps: this.totalSteps,
-          assignments: approvalConfig.assigneeIds.map((assigneeId) => ({
-            assignmentType: approvalConfig.assigneeType,
-            assigneeId,
-            nodeKey: node.key,
-            sourceStep,
-          })),
+          assignments,
           ccEvents,
           autoApprovalEvents,
           aggregateMode: context.aggregateMode,
@@ -1014,7 +1028,8 @@ export class ApprovalGraphExecutor {
         }
         const sourceStep = this.stepIndexForNode(node.key)
         const approvalMode = normalizeApprovalMode(approvalConfig.approvalMode)
-        if (approvalConfig.assigneeIds.length === 0) {
+        const assignments = this.resolveAssignmentsForApprovalNode(node.key, approvalConfig, sourceStep)
+        if (assignments.length === 0) {
           if (approvalConfig.emptyAssigneePolicy === 'auto-approve') {
             autoApprovalEvents.push({
               nodeKey: node.key,
@@ -1025,17 +1040,17 @@ export class ApprovalGraphExecutor {
             currentKey = this.firstTargetForNode(node.key)
             continue
           }
-          throw new Error(`Approval node ${node.key} has no assignees`)
+          throw new ServiceError(
+            `Approval node ${node.key} has no assignees`,
+            400,
+            'APPROVAL_ASSIGNEE_EMPTY',
+            { nodeKey: node.key },
+          )
         }
         return {
           kind: 'pending-approval',
           approvalNodeKey: node.key,
-          assignments: approvalConfig.assigneeIds.map((assigneeId) => ({
-            assignmentType: approvalConfig.assigneeType,
-            assigneeId,
-            nodeKey: node.key,
-            sourceStep,
-          })),
+          assignments,
           ccEvents,
           autoApprovalEvents,
         }
@@ -1079,5 +1094,21 @@ export class ApprovalGraphExecutor {
       throw new Error(`Approval node ${node.key} has invalid config`)
     }
     return approvalConfig
+  }
+
+  private resolveAssignmentsForApprovalNode(
+    nodeKey: string,
+    approvalConfig: ApprovalNodeConfig,
+    sourceStep: number,
+  ): ApprovalGraphAssignment[] {
+    if (this.options.assignmentResolver) {
+      return this.options.assignmentResolver({ nodeKey, sourceStep, config: approvalConfig })
+    }
+    return (approvalConfig.assigneeIds ?? []).map((assigneeId) => ({
+      assignmentType: approvalConfig.assigneeType === 'role' ? 'role' : 'user',
+      assigneeId,
+      nodeKey,
+      sourceStep,
+    }))
   }
 }

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -2,6 +2,7 @@ import crypto from 'crypto'
 import { pool } from '../db/pg'
 import type {
   ApprovalActionRequest,
+  ApprovalAssigneeSource,
   ApprovalAutoApprovalReason,
   AutoApprovalActorMode,
   AutoApprovalMergeReason,
@@ -28,12 +29,14 @@ import { APPROVAL_TERMINAL_STATUSES } from '../types/approval-product'
 import {
   ApprovalGraphExecutor,
   type ApprovalGraphAssignment,
+  type ApprovalGraphAssignmentResolver,
   type ApprovalGraphAutoApprovalEvent,
   type ApprovalGraphResolution,
   type ParallelInstanceState,
   pruneHiddenFormData,
   validateApprovalFormData,
 } from './ApprovalGraphExecutor'
+import { resolveApprovalAssignees } from './ApprovalAssigneeResolver'
 import type {
   ApprovalAssignmentDTO,
   ApprovalAssignmentRow,
@@ -353,6 +356,84 @@ function normalizeAutoApprovalPolicy(
   }
 }
 
+function normalizeStringArray(
+  value: unknown,
+  context: ValidationContext,
+  path: string,
+): string[] {
+  if (!Array.isArray(value) || value.length === 0 || value.some((entry) => !isNonEmptyString(entry))) {
+    failValidation(context, `${path} must be a non-empty string array`)
+  }
+  return value.map((entry) => entry.trim())
+}
+
+function normalizeApprovalAssigneeSources(
+  value: unknown,
+  context: ValidationContext,
+  path: string,
+): ApprovalAssigneeSource[] | undefined {
+  if (value === undefined) return undefined
+  if (!Array.isArray(value)) {
+    failValidation(context, `${path} must be an array`)
+  }
+  if (value.length === 0) {
+    failValidation(context, `${path} must not be empty`)
+  }
+
+  return value.map((source, index): ApprovalAssigneeSource => {
+    const sourcePath = `${path}[${index}]`
+    if (!isRecord(source) || !isNonEmptyString(source.kind)) {
+      failValidation(context, `${sourcePath}.kind is required`)
+    }
+    switch (source.kind) {
+      case 'static_user':
+        return {
+          kind: 'static_user',
+          userIds: normalizeStringArray(source.userIds, context, `${sourcePath}.userIds`),
+        }
+      case 'static_role':
+        return {
+          kind: 'static_role',
+          roleIds: normalizeStringArray(source.roleIds, context, `${sourcePath}.roleIds`),
+        }
+      case 'requester':
+        return { kind: 'requester' }
+      case 'form_field_user':
+        if (!isNonEmptyString(source.fieldId)) {
+          failValidation(context, `${sourcePath}.fieldId is required`)
+        }
+        return {
+          kind: 'form_field_user',
+          fieldId: source.fieldId.trim(),
+        }
+      default:
+        failValidation(context, `${sourcePath}.kind is invalid`)
+    }
+  })
+}
+
+function validateApprovalAssigneeSourcesAgainstFormSchema(
+  approvalGraph: ApprovalGraph,
+  formSchema: FormSchema,
+  context: ValidationContext,
+): void {
+  const fieldById = new Map(formSchema.fields.map((field) => [field.id, field]))
+  approvalGraph.nodes.forEach((node) => {
+    if (node.type !== 'approval') return
+    const config = node.config as { assigneeSources?: ApprovalAssigneeSource[] }
+    for (const source of config.assigneeSources ?? []) {
+      if (source.kind !== 'form_field_user') continue
+      const field = fieldById.get(source.fieldId)
+      if (!field || field.type !== 'user') {
+        failValidation(
+          context,
+          `approvalGraph node ${node.key} assigneeSources form_field_user must reference a user field`,
+        )
+      }
+    }
+  })
+}
+
 function failValidation(context: ValidationContext, message: string): never {
   throw new ServiceError(message, context.status, context.code)
 }
@@ -583,12 +664,21 @@ function normalizeApprovalGraph(
 
     switch (node.type) {
       case 'approval':
-        if ((node.config.assigneeType !== 'user' && node.config.assigneeType !== 'role')
-          || !Array.isArray(node.config.assigneeIds)
-          || node.config.assigneeIds.some((entry) => !isNonEmptyString(entry))) {
-          failValidation(context, `approvalGraph.nodes[${index}].config must define assigneeType and assigneeIds`)
-        }
         {
+          const assigneeSources = normalizeApprovalAssigneeSources(
+            node.config.assigneeSources,
+            context,
+            `approvalGraph.nodes[${index}].config.assigneeSources`,
+          )
+          const hasLegacyAssignees = (node.config.assigneeType === 'user' || node.config.assigneeType === 'role')
+            && Array.isArray(node.config.assigneeIds)
+            && node.config.assigneeIds.every((entry) => isNonEmptyString(entry))
+          if (!assigneeSources && !hasLegacyAssignees) {
+            failValidation(context, `approvalGraph.nodes[${index}].config must define assigneeType and assigneeIds or assigneeSources`)
+          }
+          if (assigneeSources && (node.config.assigneeType !== undefined || node.config.assigneeIds !== undefined) && !hasLegacyAssignees) {
+            failValidation(context, `approvalGraph.nodes[${index}].config legacy assigneeType/assigneeIds must be valid when provided`)
+          }
           const approvalMode = normalizeApprovalMode(
             node.config.approvalMode,
             context,
@@ -605,8 +695,13 @@ function normalizeApprovalGraph(
             `approvalGraph.nodes[${index}].config.autoApprovalPolicy`,
           )
           normalizedNode.config = {
-            assigneeType: node.config.assigneeType,
-            assigneeIds: node.config.assigneeIds.map((entry) => entry.trim()),
+            ...(hasLegacyAssignees
+              ? {
+                  assigneeType: node.config.assigneeType as 'user' | 'role',
+                  assigneeIds: (node.config.assigneeIds as string[]).map((entry) => entry.trim()),
+                }
+              : {}),
+            ...(assigneeSources ? { assigneeSources } : {}),
             ...(approvalMode ? { approvalMode } : {}),
             ...(emptyAssigneePolicy ? { emptyAssigneePolicy } : {}),
             ...(autoApprovalPolicy ? { autoApprovalPolicy } : {}),
@@ -816,9 +911,17 @@ function collectBranchAssignees(
       )
     }
     if (node.type === 'approval') {
-      const approvalConfig = node.config as { assigneeIds?: string[] }
+      const approvalConfig = node.config as { assigneeIds?: string[]; assigneeSources?: ApprovalAssigneeSource[] }
       for (const assignee of approvalConfig.assigneeIds ?? []) {
         assignees.add(assignee)
+      }
+      for (const source of approvalConfig.assigneeSources ?? []) {
+        if (source.kind === 'static_user') {
+          source.userIds.forEach((assignee) => assignees.add(assignee))
+        }
+        if (source.kind === 'static_role') {
+          source.roleIds.forEach((assignee) => assignees.add(assignee))
+        }
       }
     }
     // Walk the first outgoing edge — condition nodes aren't explored for every
@@ -1510,6 +1613,21 @@ function appendAutoApprovalHistory(history: ApprovalHistoryEntry[], event: Appro
   })
 }
 
+function buildApprovalAssignmentResolver(options: {
+  formSchema?: FormSchema
+  formSnapshot: Record<string, unknown>
+  requesterSnapshot: Record<string, unknown> | null
+}): ApprovalGraphAssignmentResolver {
+  return ({ nodeKey, sourceStep, config }) => resolveApprovalAssignees({
+    nodeKey,
+    sourceStep,
+    config,
+    formSchema: options.formSchema,
+    formSnapshot: options.formSnapshot,
+    requesterSnapshot: options.requesterSnapshot,
+  })
+}
+
 export class ApprovalProductService {
   /**
    * Wave 2 WP5 slice 1 — optional metrics service injection so tests can
@@ -1866,6 +1984,7 @@ export class ApprovalProductService {
     const slaHours = slaHoursNormalized === undefined ? null : slaHoursNormalized
     const formSchema = assertFormSchema(request.formSchema)
     const approvalGraph = assertApprovalGraph(request.approvalGraph)
+    validateApprovalAssigneeSourcesAgainstFormSchema(approvalGraph, formSchema, REQUEST_VALIDATION_CONTEXT)
 
     let client: ApprovalDbClient | null = null
     try {
@@ -2016,6 +2135,10 @@ export class ApprovalProductService {
         )
         const nextVersion = Number.parseInt(maxVersionResult.rows[0]?.max_version || '0', 10) + 1
 
+        const nextFormSchema = formSchema ?? asFormSchema(latestVersion.form_schema)
+        const nextApprovalGraph = approvalGraph ?? asApprovalGraph(latestVersion.approval_graph)
+        validateApprovalAssigneeSourcesAgainstFormSchema(nextApprovalGraph, nextFormSchema, REQUEST_VALIDATION_CONTEXT)
+
         const versionResult = await client.query<TemplateVersionRow>(
           `INSERT INTO approval_template_versions (template_id, version, status, form_schema, approval_graph)
            VALUES ($1, $2, 'draft', $3, $4)
@@ -2023,8 +2146,8 @@ export class ApprovalProductService {
           [
             id,
             nextVersion,
-            JSON.stringify(formSchema ?? latestVersion.form_schema),
-            JSON.stringify(approvalGraph ?? latestVersion.approval_graph),
+            JSON.stringify(nextFormSchema),
+            JSON.stringify(nextApprovalGraph),
           ],
         )
         version = versionResult.rows[0]
@@ -2098,7 +2221,10 @@ export class ApprovalProductService {
         [id],
       )
 
-      const runtimeGraph = buildRuntimeGraph(asApprovalGraph(version.approval_graph), policy)
+      const formSchema = asFormSchema(version.form_schema)
+      const approvalGraph = asApprovalGraph(version.approval_graph)
+      validateApprovalAssigneeSourcesAgainstFormSchema(approvalGraph, formSchema, STORED_GRAPH_CONTEXT)
+      const runtimeGraph = buildRuntimeGraph(approvalGraph, policy)
 
       const publishedDefinitionResult = await client.query<PublishedDefinitionRow>(
         `INSERT INTO approval_published_definitions (template_id, template_version_id, runtime_graph, is_active, published_at)
@@ -2348,15 +2474,6 @@ export class ApprovalProductService {
       )
     }
 
-    const runtimeGraph = asRuntimeGraph(bundle.publishedDefinition.runtime_graph)
-    const executor = new ApprovalGraphExecutor(runtimeGraph, normalizedFormData)
-    const instanceId = crypto.randomUUID()
-    const initialResolution = executor.resolveInitialState()
-    const initial = runtimeGraphHasAutoApprovalPolicy(runtimeGraph)
-      ? this.applyAutoApprovalCascade(instanceId, runtimeGraph, executor, initialResolution, actor.userId, [])
-      : initialResolution
-    const requestNo = await this.allocateRequestNo()
-
     const requesterSnapshot = {
       id: actor.userId,
       name: actor.userName || actor.userId,
@@ -2365,6 +2482,20 @@ export class ApprovalProductService {
       roles: actor.roles || [],
       permissions: actor.permissions || [],
     }
+    const runtimeGraph = asRuntimeGraph(bundle.publishedDefinition.runtime_graph)
+    const executor = new ApprovalGraphExecutor(runtimeGraph, normalizedFormData, {
+      assignmentResolver: buildApprovalAssignmentResolver({
+        formSchema,
+        formSnapshot: normalizedFormData,
+        requesterSnapshot,
+      }),
+    })
+    const instanceId = crypto.randomUUID()
+    const initialResolution = executor.resolveInitialState()
+    const initial = runtimeGraphHasAutoApprovalPolicy(runtimeGraph)
+      ? this.applyAutoApprovalCascade(instanceId, runtimeGraph, executor, initialResolution, actor.userId, [])
+      : initialResolution
+    const requestNo = await this.allocateRequestNo()
 
     const instanceMetadata: Record<string, unknown> = { templateKey: bundle.template.key }
     if (initial.parallelState) {
@@ -2559,9 +2690,16 @@ export class ApprovalProductService {
         [id],
       )
       const oldAssignees = assignmentRowsForAudit(activeAssignments.rows)
-      const executor = new ApprovalGraphExecutor(runtimeGraph, toNullableRecord(instance.form_snapshot) || {})
+      const formSnapshot = toNullableRecord(instance.form_snapshot) || {}
+      const requesterSnapshot = toNullableRecord(instance.requester_snapshot)
+      const executor = new ApprovalGraphExecutor(runtimeGraph, formSnapshot, {
+        assignmentResolver: buildApprovalAssignmentResolver({
+          formSnapshot,
+          requesterSnapshot,
+        }),
+      })
       const jumpResolution = executor.resolveReturnToNode(targetNodeKey)
-      const requesterId = toNullableRecord(instance.requester_snapshot)?.id
+      const requesterId = requesterSnapshot?.id
       // Admin jump enters the target through the same node-entry path as create/advance,
       // so PR2 auto-approval policies intentionally compose after the jump.
       const resolution = runtimeGraphHasAutoApprovalPolicy(runtimeGraph)
@@ -2699,7 +2837,14 @@ export class ApprovalProductService {
       )
 
       const runtimeGraph = asRuntimeGraph(runtime.runtime_graph)
-      const executor = new ApprovalGraphExecutor(runtimeGraph, toNullableRecord(instance.form_snapshot) || {})
+      const formSnapshot = toNullableRecord(instance.form_snapshot) || {}
+      const requesterSnapshot = toNullableRecord(instance.requester_snapshot)
+      const executor = new ApprovalGraphExecutor(runtimeGraph, formSnapshot, {
+        assignmentResolver: buildApprovalAssignmentResolver({
+          formSnapshot,
+          requesterSnapshot,
+        }),
+      })
       const storedCurrentNodeKey = instance.current_node_key
       const actorRoles = actor.roles || []
       const actorName = actor.userName || actor.userId
@@ -2786,7 +2931,7 @@ export class ApprovalProductService {
         if (!runtimeGraph.policy.allowRevoke) {
           throw new ServiceError('Approval cannot be revoked for this template', 409, 'APPROVAL_REVOKE_DISABLED')
         }
-        const requesterId = toNullableRecord(instance.requester_snapshot)?.id
+        const requesterId = requesterSnapshot?.id
         if (requesterId !== actor.userId) {
           throw new ServiceError('Only the requester can revoke this approval', 403, 'APPROVAL_REVOKE_FORBIDDEN')
         }
@@ -2884,7 +3029,7 @@ export class ApprovalProductService {
 
         await this.deactivateAllActiveAssignments(client, id)
         const returnResolution = executor.resolveReturnToNode(targetNodeKey)
-        const requesterId = toNullableRecord(instance.requester_snapshot)?.id
+        const requesterId = requesterSnapshot?.id
         const resolution = runtimeGraphHasAutoApprovalPolicy(runtimeGraph)
           ? this.applyAutoApprovalCascade(
               id,
@@ -3055,7 +3200,7 @@ export class ApprovalProductService {
           nodeKey: currentNodeKey,
           actorId: actor.userId,
         })
-        const requesterId = toNullableRecord(instance.requester_snapshot)?.id
+        const requesterId = requesterSnapshot?.id
         resolution = this.applyAutoApprovalCascade(
           id,
           runtimeGraph,
@@ -3437,20 +3582,78 @@ export class ApprovalProductService {
   private async insertAssignments(
     client: { query: typeof pool.query },
     instanceId: string,
-    assignments: Array<{ assignmentType: 'user' | 'role'; assigneeId: string; nodeKey: string; sourceStep: number }>,
+    assignments: Array<{ assignmentType: 'user' | 'role'; assigneeId: string; nodeKey: string; sourceStep: number; metadata?: unknown }>,
   ): Promise<void> {
+    await this.assertNoActiveAssignmentConflicts(client, instanceId, assignments)
     for (const assignment of assignments) {
       await client.query(
         `INSERT INTO approval_assignments
          (instance_id, assignment_type, assignee_id, source_step, node_key, is_active, metadata, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, TRUE, '{}'::jsonb, now(), now())`,
+         VALUES ($1, $2, $3, $4, $5, TRUE, $6::jsonb, now(), now())`,
         [
           instanceId,
           assignment.assignmentType,
           assignment.assigneeId,
           assignment.sourceStep,
           assignment.nodeKey,
+          JSON.stringify(assignment.metadata ?? {}),
         ],
+      )
+    }
+  }
+
+  private async assertNoActiveAssignmentConflicts(
+    client: { query: typeof pool.query },
+    instanceId: string,
+    assignments: Array<{ assignmentType: 'user' | 'role'; assigneeId: string; nodeKey: string; metadata?: unknown }>,
+  ): Promise<void> {
+    if (assignments.length === 0) return
+    if (assignments.every((assignment) =>
+      !isRecord(assignment.metadata) || !isRecord(assignment.metadata.resolvedFrom))) return
+
+    const pendingKeys = new Map<string, { assignmentType: 'user' | 'role'; assigneeId: string; nodeKey: string }>()
+    for (const assignment of assignments) {
+      const key = `${assignment.assignmentType}:${assignment.assigneeId}`
+      const existing = pendingKeys.get(key)
+      if (existing) {
+        throw new ServiceError(
+          'Approval assignee resolves to multiple active parallel assignments',
+          409,
+          'APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT',
+          {
+            instanceId,
+            assignmentType: assignment.assignmentType,
+            assigneeId: assignment.assigneeId,
+            nodeKeys: [existing.nodeKey, assignment.nodeKey],
+          },
+        )
+      }
+      pendingKeys.set(key, assignment)
+    }
+
+    const activeResult = await client.query<{
+      assignment_type: 'user' | 'role'
+      assignee_id: string
+      node_key: string | null
+    }>(
+      `SELECT assignment_type, assignee_id, node_key
+       FROM approval_assignments
+       WHERE instance_id = $1 AND is_active = TRUE`,
+      [instanceId],
+    )
+    for (const active of activeResult.rows) {
+      const pending = pendingKeys.get(`${active.assignment_type}:${active.assignee_id}`)
+      if (!pending) continue
+      throw new ServiceError(
+        'Approval assignee resolves to multiple active parallel assignments',
+        409,
+        'APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT',
+        {
+          instanceId,
+          assignmentType: pending.assignmentType,
+          assigneeId: pending.assigneeId,
+          nodeKeys: [active.node_key, pending.nodeKey].filter((entry): entry is string => Boolean(entry)),
+        },
       )
     }
   }

--- a/packages/core-backend/src/types/approval-product.ts
+++ b/packages/core-backend/src/types/approval-product.ts
@@ -9,6 +9,7 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user'
 export type ApprovalMode = 'single' | 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
@@ -43,11 +44,26 @@ export interface ApprovalNode {
 }
 
 export interface ApprovalNodeConfig {
-  assigneeType: ApprovalAssigneeType
-  assigneeIds: string[]
+  assigneeType?: ApprovalAssigneeType
+  assigneeIds?: string[]
+  assigneeSources?: ApprovalAssigneeSource[]
   approvalMode?: ApprovalMode
   emptyAssigneePolicy?: EmptyAssigneePolicy
   autoApprovalPolicy?: AutoApprovalPolicy
+}
+
+export type ApprovalAssigneeSource =
+  | { kind: 'static_user'; userIds: string[] }
+  | { kind: 'static_role'; roleIds: string[] }
+  | { kind: 'requester' }
+  | { kind: 'form_field_user'; fieldId: string }
+
+export interface ApprovalAssigneeResolutionMetadata {
+  resolvedFrom: {
+    kind: ApprovalAssigneeSourceKind
+    sourceIndex: number
+    fieldId?: string
+  }
 }
 
 export interface ConditionNodeConfig {

--- a/packages/core-backend/tests/unit/approval-admin-jump-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-admin-jump-service.test.ts
@@ -360,6 +360,7 @@ describe('ApprovalProductService adminJump', () => {
       'finance-1',
       2,
       'finance_review',
+      '{}',
     ])
 
     const recordCall = findRecordInsert('jump')
@@ -425,6 +426,7 @@ describe('ApprovalProductService adminJump', () => {
       'director-1',
       3,
       'director_review',
+      '{}',
     ])
 
     const autoRecordCall = findRecordInsert('approve')

--- a/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
+++ b/packages/core-backend/tests/unit/approval-assignee-resolver.test.ts
@@ -1,0 +1,149 @@
+import { describe, expect, it } from 'vitest'
+import { resolveApprovalAssignees } from '../../src/services/ApprovalAssigneeResolver'
+import type { ApprovalNodeConfig, FormSchema } from '../../src/types/approval-product'
+
+const userFieldSchema: FormSchema = {
+  fields: [
+    { id: 'approver', type: 'user', label: 'Approver' },
+    { id: 'notes', type: 'text', label: 'Notes' },
+  ],
+}
+
+function resolve(config: ApprovalNodeConfig, formSnapshot: Record<string, unknown> = {}) {
+  return resolveApprovalAssignees({
+    nodeKey: 'review',
+    sourceStep: 2,
+    config,
+    formSchema: userFieldSchema,
+    formSnapshot,
+    requesterSnapshot: { id: 'requester-1', name: 'Requester One' },
+  })
+}
+
+describe('ApprovalAssigneeResolver', () => {
+  it('keeps legacy static user and role assignments metadata-free', () => {
+    expect(resolve({ assigneeType: 'user', assigneeIds: ['user-1', 'user-2'] })).toEqual([
+      { assignmentType: 'user', assigneeId: 'user-1', nodeKey: 'review', sourceStep: 2 },
+      { assignmentType: 'user', assigneeId: 'user-2', nodeKey: 'review', sourceStep: 2 },
+    ])
+
+    expect(resolve({ assigneeType: 'role', assigneeIds: ['finance'] })).toEqual([
+      { assignmentType: 'role', assigneeId: 'finance', nodeKey: 'review', sourceStep: 2 },
+    ])
+  })
+
+  it('resolves requester and static sources with source metadata', () => {
+    expect(resolve({
+      assigneeSources: [
+        { kind: 'requester' },
+        { kind: 'static_user', userIds: ['manager-1'] },
+        { kind: 'static_role', roleIds: ['finance'] },
+      ],
+    })).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'requester-1',
+        nodeKey: 'review',
+        sourceStep: 2,
+        metadata: { resolvedFrom: { kind: 'requester', sourceIndex: 0 } },
+      },
+      {
+        assignmentType: 'user',
+        assigneeId: 'manager-1',
+        nodeKey: 'review',
+        sourceStep: 2,
+        metadata: { resolvedFrom: { kind: 'static_user', sourceIndex: 1 } },
+      },
+      {
+        assignmentType: 'role',
+        assigneeId: 'finance',
+        nodeKey: 'review',
+        sourceStep: 2,
+        metadata: { resolvedFrom: { kind: 'static_role', sourceIndex: 2 } },
+      },
+    ])
+  })
+
+  it('resolves user form fields from string and object values', () => {
+    expect(resolve({
+      assigneeSources: [{ kind: 'form_field_user', fieldId: 'approver' }],
+    }, { approver: 'form-user-1' })).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'form-user-1',
+        nodeKey: 'review',
+        sourceStep: 2,
+        metadata: { resolvedFrom: { kind: 'form_field_user', sourceIndex: 0, fieldId: 'approver' } },
+      },
+    ])
+
+    expect(resolve({
+      assigneeSources: [{ kind: 'form_field_user', fieldId: 'approver' }],
+    }, { approver: { id: 'form-user-2', name: 'Form User' } })).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'form-user-2',
+        nodeKey: 'review',
+        sourceStep: 2,
+        metadata: { resolvedFrom: { kind: 'form_field_user', sourceIndex: 0, fieldId: 'approver' } },
+      },
+    ])
+  })
+
+  it('returns no assignments for missing dynamic values so the node policy decides', () => {
+    expect(resolve({
+      assigneeSources: [
+        { kind: 'form_field_user', fieldId: 'approver' },
+      ],
+    }, { approver: null })).toEqual([])
+
+    expect(resolveApprovalAssignees({
+      nodeKey: 'review',
+      sourceStep: 2,
+      config: { assigneeSources: [{ kind: 'requester' }] },
+      formSchema: userFieldSchema,
+      formSnapshot: {},
+      requesterSnapshot: null,
+    })).toEqual([])
+  })
+
+  it('rejects form_field_user sources that do not point at user fields when schema is available', () => {
+    expect(() => resolve({
+      assigneeSources: [{ kind: 'form_field_user', fieldId: 'notes' }],
+    }, { notes: 'user-1' })).toThrowError(expect.objectContaining({
+      code: 'APPROVAL_ASSIGNEE_INVALID_SOURCE',
+      statusCode: 400,
+    }))
+
+    expect(() => resolve({
+      assigneeSources: [{ kind: 'form_field_user', fieldId: 'missing' }],
+    })).toThrowError(expect.objectContaining({
+      code: 'APPROVAL_ASSIGNEE_INVALID_SOURCE',
+      statusCode: 400,
+    }))
+  })
+
+  it('dedupes duplicate resolved assignees and keeps the first source metadata', () => {
+    expect(resolve({
+      assigneeSources: [
+        { kind: 'requester' },
+        { kind: 'static_user', userIds: ['requester-1', 'manager-1'] },
+      ],
+    })).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'requester-1',
+        nodeKey: 'review',
+        sourceStep: 2,
+        metadata: { resolvedFrom: { kind: 'requester', sourceIndex: 0 } },
+      },
+      {
+        assignmentType: 'user',
+        assigneeId: 'manager-1',
+        nodeKey: 'review',
+        sourceStep: 2,
+        metadata: { resolvedFrom: { kind: 'static_user', sourceIndex: 1 } },
+      },
+    ])
+  })
+})

--- a/packages/core-backend/tests/unit/approval-graph-executor.test.ts
+++ b/packages/core-backend/tests/unit/approval-graph-executor.test.ts
@@ -184,6 +184,96 @@ describe('ApprovalGraphExecutor', () => {
     ])
   })
 
+  it('uses an injected resolver for assigneeSources nodes', () => {
+    const runtimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'dynamic-review', type: 'approval', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-dynamic', source: 'start', target: 'dynamic-review' },
+        { key: 'edge-dynamic-end', source: 'dynamic-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    const executor = new ApprovalGraphExecutor(runtimeGraph, {}, {
+      assignmentResolver: ({ nodeKey, sourceStep, config }) => [{
+        assignmentType: 'user',
+        assigneeId: `resolved-${config.assigneeSources?.[0]?.kind}`,
+        nodeKey,
+        sourceStep,
+        metadata: { resolvedFrom: { kind: 'requester', sourceIndex: 0 } },
+      }],
+    })
+
+    expect(executor.resolveInitialState().assignments).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'resolved-requester',
+        nodeKey: 'dynamic-review',
+        sourceStep: 1,
+        metadata: { resolvedFrom: { kind: 'requester', sourceIndex: 0 } },
+      },
+    ])
+  })
+
+  it('lets empty dynamic resolution follow the existing empty-assignee policies', () => {
+    const autoRuntimeGraph: RuntimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'dynamic-gap',
+          type: 'approval',
+          config: {
+            assigneeSources: [{ kind: 'requester' }],
+            emptyAssigneePolicy: 'auto-approve',
+          },
+        },
+        { key: 'final-review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['user-9'] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-gap', source: 'start', target: 'dynamic-gap' },
+        { key: 'edge-gap-final', source: 'dynamic-gap', target: 'final-review' },
+        { key: 'edge-final-end', source: 'final-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    const resolver = ({ nodeKey, sourceStep }: { nodeKey: string; sourceStep: number }) =>
+      nodeKey === 'dynamic-gap'
+        ? []
+        : [{ assignmentType: 'user' as const, assigneeId: 'user-9', nodeKey, sourceStep }]
+    const autoExecutor = new ApprovalGraphExecutor(autoRuntimeGraph, {}, { assignmentResolver: resolver })
+    const initial = autoExecutor.resolveInitialState()
+
+    expect(initial.currentNodeKey).toBe('final-review')
+    expect(initial.autoApprovalEvents).toEqual([
+      {
+        nodeKey: 'dynamic-gap',
+        sourceStep: 1,
+        approvalMode: 'single',
+        reason: 'empty-assignee',
+      },
+    ])
+
+    const errorRuntimeGraph: RuntimeGraph = {
+      ...autoRuntimeGraph,
+      nodes: autoRuntimeGraph.nodes.map((node) =>
+        node.key === 'dynamic-gap'
+          ? { ...node, config: { assigneeSources: [{ kind: 'requester' }] } }
+          : node),
+    }
+    const errorExecutor = new ApprovalGraphExecutor(errorRuntimeGraph, {}, { assignmentResolver: resolver })
+
+    expect(() => errorExecutor.resolveInitialState()).toThrowError(expect.objectContaining({
+      code: 'APPROVAL_ASSIGNEE_EMPTY',
+      statusCode: 400,
+    }))
+  })
+
   it('tags resolveAfterApprove resolutions with the resolved-away node aggregate mode', () => {
     const runtimeGraph: RuntimeGraph = {
       nodes: [

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -978,6 +978,63 @@ describe('ApprovalProductService', () => {
     expect(pgState.pool.connect).not.toHaveBeenCalled()
   })
 
+  it('rejects empty assigneeSources and invalid form field sources before hitting the database', async () => {
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService()
+
+    await expect(service.createTemplate({
+      key: 'empty-sources',
+      name: 'Empty Sources',
+      formSchema: { fields: [] },
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          { key: 'approval_1', type: 'approval', config: { assigneeSources: [] } },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-approval', source: 'start', target: 'approval_1' },
+          { key: 'edge-approval-end', source: 'approval_1', target: 'end' },
+        ],
+      },
+    } as never)).rejects.toMatchObject({
+      message: 'approvalGraph.nodes[1].config.assigneeSources must not be empty',
+      statusCode: 400,
+      code: 'VALIDATION_ERROR',
+    })
+
+    await expect(service.createTemplate({
+      key: 'bad-field-source',
+      name: 'Bad Field Source',
+      formSchema: {
+        fields: [
+          { id: 'notes', type: 'text', label: 'Notes' },
+        ],
+      },
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', config: {} },
+          {
+            key: 'approval_1',
+            type: 'approval',
+            config: { assigneeSources: [{ kind: 'form_field_user', fieldId: 'notes' }] },
+          },
+          { key: 'end', type: 'end', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-approval', source: 'start', target: 'approval_1' },
+          { key: 'edge-approval-end', source: 'approval_1', target: 'end' },
+        ],
+      },
+    } as never)).rejects.toMatchObject({
+      message: 'approvalGraph node approval_1 assigneeSources form_field_user must reference a user field',
+      statusCode: 400,
+      code: 'VALIDATION_ERROR',
+    })
+
+    expect(pgState.pool.connect).not.toHaveBeenCalled()
+  })
+
   it('records terminal metrics for approvals auto-approved at creation', async () => {
     const metrics = {
       recordInstanceStart: vi.fn().mockResolvedValue(undefined),
@@ -1676,6 +1733,134 @@ describe('ApprovalProductService', () => {
       JSON.parse(String(params?.[9])).autoApproved === true)).toBe(false)
   })
 
+  it('creates requester-source assignments from the frozen published runtime graph with metadata', async () => {
+    const runtimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'approval_1', type: 'approval', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval-end', source: 'approval_1', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+    mockPublishedTemplatePool(runtimeGraph, 'AP-101008')
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('INSERT INTO approval_instances')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('SELECT assignment_type, assignee_id, node_key FROM approval_assignments')) {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('INSERT INTO approval_assignments')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled client query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      currentNodeKey: 'approval_1',
+      assignments: [{
+        id: 'asg-requester',
+        type: 'user',
+        assigneeId: 'requester-1',
+        sourceStep: 1,
+        nodeKey: 'approval_1',
+        isActive: true,
+        metadata: { resolvedFrom: { kind: 'requester', sourceIndex: 0 } },
+      }],
+    }))
+
+    await service.createApproval(
+      { templateId: 'tpl-1', formData: {} },
+      { userId: 'requester-1', userName: 'Requester One' },
+    )
+
+    const assignmentInsert = pgState.client.query.mock.calls.find(([sql]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_assignments'))
+    expect(assignmentInsert?.[1]).toEqual([
+      expect.any(String),
+      'user',
+      'requester-1',
+      1,
+      'approval_1',
+      JSON.stringify({ resolvedFrom: { kind: 'requester', sourceIndex: 0 } }),
+    ])
+  })
+
+  it('rejects duplicate dynamic assignees across parallel branches at creation time', async () => {
+    const runtimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        {
+          key: 'parallel_fork',
+          type: 'parallel',
+          config: {
+            branches: ['edge-fork-legal', 'edge-fork-compliance'],
+            joinMode: 'all',
+            joinNodeKey: 'end',
+          },
+        },
+        { key: 'legal-review', type: 'approval', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'compliance-review', type: 'approval', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-fork', source: 'start', target: 'parallel_fork' },
+        { key: 'edge-fork-legal', source: 'parallel_fork', target: 'legal-review' },
+        { key: 'edge-fork-compliance', source: 'parallel_fork', target: 'compliance-review' },
+        { key: 'edge-legal-end', source: 'legal-review', target: 'end' },
+        { key: 'edge-compliance-end', source: 'compliance-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+    mockPublishedTemplatePool(runtimeGraph, 'AP-101009')
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('INSERT INTO approval_instances')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled client query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+
+    await expect(service.createApproval(
+      { templateId: 'tpl-1', formData: {} },
+      { userId: 'requester-1' },
+    )).rejects.toMatchObject({
+      code: 'APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT',
+      statusCode: 409,
+      details: {
+        assignmentType: 'user',
+        assigneeId: 'requester-1',
+        nodeKeys: ['legal-review', 'compliance-review'],
+      },
+    })
+
+    const statements = pgState.client.query.mock.calls.map(([sql]) => normalize(sql as string))
+    expect(statements).toContain('ROLLBACK')
+    expect(statements).not.toContain('COMMIT')
+    expect(statements.some((statement) => statement.startsWith('INSERT INTO approval_assignments'))).toBe(false)
+  })
+
   it('keeps all-mode approvals pending when requester auto-merge leaves human assignees', async () => {
     const runtimeGraph = {
       nodes: [
@@ -1728,7 +1913,7 @@ describe('ApprovalProductService', () => {
     const assignmentInserts = pgState.client.query.mock.calls.filter(([sql]) =>
       normalize(sql as string).startsWith('INSERT INTO approval_assignments'))
     expect(assignmentInserts).toHaveLength(1)
-    expect(assignmentInserts[0]?.[1]).toEqual([expect.any(String), 'user', 'manager-2', 1, 'approval_1'])
+    expect(assignmentInserts[0]?.[1]).toEqual([expect.any(String), 'user', 'manager-2', 1, 'approval_1', '{}'])
 
     const autoRecordCall = pgState.client.query.mock.calls.find(([sql, params]) =>
       normalize(sql as string).startsWith('INSERT INTO approval_records') &&
@@ -2248,6 +2433,236 @@ describe('ApprovalProductService', () => {
     expect(autoRecords.map((entry) => entry.matchedAgainst.nodeKey)).toEqual(['prior-legal', 'prior-compliance'])
   })
 
+  it('dispatches dynamic assignees from the instance-bound runtime graph without active template reads', async () => {
+    const runtimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'approval_gate', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['lead-1'] } },
+        { key: 'requester-review', type: 'approval', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-gate', source: 'start', target: 'approval_gate' },
+        { key: 'edge-gate-requester', source: 'approval_gate', target: 'requester-review' },
+        { key: 'edge-requester-end', source: 'requester-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return {
+          rows: [buildInstanceRow({
+            current_node_key: 'approval_gate',
+            current_step: 1,
+            total_steps: 2,
+            requester_snapshot: { id: 'requester-1', name: 'Requester One' },
+          })],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return {
+          rows: [{
+            id: 'asg-gate',
+            instance_id: 'apr-1',
+            assignment_type: 'user',
+            assignee_id: 'lead-1',
+            source_step: 1,
+            node_key: 'approval_gate',
+            is_active: true,
+            metadata: {},
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('UPDATE approval_instances SET status = $2')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('SELECT assignment_type, assignee_id, node_key FROM approval_assignments')) {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('INSERT INTO approval_assignments')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      currentStep: 2,
+      totalSteps: 2,
+      currentNodeKey: 'requester-review',
+      assignments: [{
+        id: 'asg-requester',
+        type: 'user',
+        assigneeId: 'requester-1',
+        sourceStep: 2,
+        nodeKey: 'requester-review',
+        isActive: true,
+        metadata: { resolvedFrom: { kind: 'requester', sourceIndex: 0 } },
+      }],
+    }))
+
+    await service.dispatchAction(
+      'apr-1',
+      { action: 'approve' },
+      { userId: 'lead-1' },
+    )
+
+    const statements = pgState.client.query.mock.calls.map(([sql]) => normalize(sql as string))
+    expect(statements.some((statement) => statement.includes('approval_template_versions'))).toBe(false)
+    expect(statements.some((statement) => statement.includes('approval_templates'))).toBe(false)
+
+    const assignmentInsert = pgState.client.query.mock.calls.find(([sql]) =>
+      normalize(sql as string).startsWith('INSERT INTO approval_assignments'))
+    expect(assignmentInsert?.[1]).toEqual([
+      'apr-1',
+      'user',
+      'requester-1',
+      2,
+      'requester-review',
+      JSON.stringify({ resolvedFrom: { kind: 'requester', sourceIndex: 0 } }),
+    ])
+  })
+
+  it('rejects duplicate dynamic assignees across parallel branches at advance time', async () => {
+    const runtimeGraph = {
+      nodes: [
+        { key: 'start', type: 'start', config: {} },
+        { key: 'approval_gate', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['lead-1'] } },
+        {
+          key: 'parallel_fork',
+          type: 'parallel',
+          config: {
+            branches: ['edge-fork-legal', 'edge-fork-compliance'],
+            joinMode: 'all',
+            joinNodeKey: 'end',
+          },
+        },
+        { key: 'legal-review', type: 'approval', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'compliance-review', type: 'approval', config: { assigneeSources: [{ kind: 'requester' }] } },
+        { key: 'end', type: 'end', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-gate', source: 'start', target: 'approval_gate' },
+        { key: 'edge-gate-fork', source: 'approval_gate', target: 'parallel_fork' },
+        { key: 'edge-fork-legal', source: 'parallel_fork', target: 'legal-review' },
+        { key: 'edge-fork-compliance', source: 'parallel_fork', target: 'compliance-review' },
+        { key: 'edge-legal-end', source: 'legal-review', target: 'end' },
+        { key: 'edge-compliance-end', source: 'compliance-review', target: 'end' },
+      ],
+      policy: { allowRevoke: true },
+    }
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return {
+          rows: [buildInstanceRow({
+            current_node_key: 'approval_gate',
+            current_step: 1,
+            total_steps: 3,
+            requester_snapshot: { id: 'requester-1', name: 'Requester One' },
+          })],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return {
+          rows: [{
+            id: 'asg-gate',
+            instance_id: 'apr-1',
+            assignment_type: 'user',
+            assignee_id: 'lead-1',
+            source_step: 1,
+            node_key: 'approval_gate',
+            is_active: true,
+            metadata: {},
+            created_at: new Date(),
+            updated_at: new Date(),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('UPDATE approval_instances SET metadata = COALESCE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('UPDATE approval_instances SET status = $2')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+
+    await expect(service.dispatchAction(
+      'apr-1',
+      { action: 'approve' },
+      { userId: 'lead-1' },
+    )).rejects.toMatchObject({
+      code: 'APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT',
+      statusCode: 409,
+      details: {
+        assignmentType: 'user',
+        assigneeId: 'requester-1',
+        nodeKeys: ['legal-review', 'compliance-review'],
+      },
+    })
+
+    const statements = pgState.client.query.mock.calls.map(([sql]) => normalize(sql as string))
+    expect(statements).toContain('ROLLBACK')
+    expect(statements).not.toContain('COMMIT')
+    expect(statements.some((statement) => statement.startsWith('INSERT INTO approval_assignments'))).toBe(false)
+    expect(statements.some((statement) => statement.startsWith('INSERT INTO approval_records'))).toBe(false)
+  })
+
   it('refuses and warns when adjacent merge would auto-approve duplicate parallel assignees', async () => {
     const runtimeGraph = {
       nodes: [
@@ -2375,7 +2790,7 @@ describe('ApprovalProductService', () => {
     const assignmentInserts = pgState.client.query.mock.calls.filter(([sql]) =>
       normalize(sql as string).startsWith('INSERT INTO approval_assignments'))
     expect(assignmentInserts).toHaveLength(1)
-    expect(assignmentInserts[0]?.[1]).toEqual(['apr-1', 'user', 'manager-1', 3, 'compliance-review'])
+    expect(assignmentInserts[0]?.[1]).toEqual(['apr-1', 'user', 'manager-1', 3, 'compliance-review', '{}'])
 
     const skippedRecord = pgState.client.query.mock.calls.find(([sql, params]) =>
       normalize(sql as string).startsWith('INSERT INTO approval_records') &&
@@ -2491,7 +2906,7 @@ describe('ApprovalProductService', () => {
         return { rows: [], rowCount: 1 }
       }
       if (statement.startsWith('INSERT INTO approval_assignments')) {
-        expect(params).toEqual(['apr-1', 'user', 'legacy-manager', 2, 'approval_old_high'])
+        expect(params).toEqual(['apr-1', 'user', 'legacy-manager', 2, 'approval_old_high', '{}'])
         return { rows: [], rowCount: 1 }
       }
       if (statement.startsWith('INSERT INTO approval_records')) {


### PR DESCRIPTION
## Summary

Implements the first unlocked Approval Phase 2 slice: a pure, synchronous `ApprovalAssigneeResolver` for dynamic approval-node assignee sources.

This PR adds support for:

- legacy static `assigneeType` / `assigneeIds` compatibility;
- `assigneeSources` in the frozen runtime graph;
- v1 sources: `static_user`, `static_role`, `requester`, `form_field_user`;
- dynamic assignment metadata via `approval_assignments.metadata.resolvedFrom`;
- resolver wiring through create, dispatch advance/return, and admin jump;
- pre-insert dynamic parallel collision refusal with `APPROVAL_ASSIGNEE_PARALLEL_DYNAMIC_CONFLICT`.

## Scope Control

No migrations, routes, UI, automation, Workflow Designer, SLA, breach, trigger-binding, backwrite, event-bridge, or add-sign/countersign files changed.

The PR #1794 forward gate remains intact: `approval_trigger_bindings`, public-form/multitable trigger paths, result backwrite, automation `start_approval`, and approval completion event bridge are still frozen pending K3 GATE PASS, named gate blocker, or separate explicit opt-in.

## Files

- `packages/core-backend/src/types/approval-product.ts`
- `packages/core-backend/src/services/ApprovalAssigneeResolver.ts`
- `packages/core-backend/src/services/ApprovalGraphExecutor.ts`
- `packages/core-backend/src/services/ApprovalProductService.ts`
- `packages/core-backend/tests/unit/approval-assignee-resolver.test.ts`
- `packages/core-backend/tests/unit/approval-graph-executor.test.ts`
- `packages/core-backend/tests/unit/approval-product-service.test.ts`
- `packages/core-backend/tests/unit/approval-admin-jump-service.test.ts`
- `docs/development/approval-phase2-assignee-resolver-development-20260523.md`
- `docs/development/approval-phase2-assignee-resolver-verification-20260523.md`

## Verification

- Focused unit: `3 files / 56 tests PASS`
- Focused after admin-jump metadata expectation update: `4 files / 63 tests PASS`
- Full backend unit: `176 files / 2290 tests PASS`
- Backend build: `PASS`
- Scratch PostgreSQL approval integration: `2 files / 7 tests PASS`
- Diff hygiene: `git diff --check origin/main..HEAD`, `origin/main...HEAD`, and working diff all clean

See:

- `docs/development/approval-phase2-assignee-resolver-development-20260523.md`
- `docs/development/approval-phase2-assignee-resolver-verification-20260523.md`
