### PR TITLE
docs(multitable): align #1780 closure doc with spec .serial

### DIFF
--- a/docs/development/multitable-issue-1780-closure-verification-20260523.md
+++ b/docs/development/multitable-issue-1780-closure-verification-20260523.md
@@ -32,9 +32,10 @@ deferred item (see §6).
 
 `packages/core-backend/tests/e2e/multitable-basic-views-smoke.spec.ts` — five
 Playwright tests, one per view type (grid / calendar / kanban / gallery / form),
-sharing a single base/sheet fixture created in `beforeAll`. Tests run under
-plain `test.describe` so per-view failures report independently; the wrapper
-pins `--workers=1` for serial execution. Each test:
+sharing a single base/sheet fixture created in `beforeAll` and run via
+`test.describe.serial` (since the tests share the fixture, a fixture-stage
+failure short-circuits the remaining tests instead of cascading misleading
+per-view failures; the wrapper additionally pins `--workers=1`). Each test:
 
 - asserts `.mt-workbench` (the workbench root, defined at
   `apps/web/src/multitable/views/MultitableWorkbench.vue:2`) is visible


### PR DESCRIPTION
## Summary

Followup nit from PR #1798 review.

The closure verification doc described the spec as running under plain `test.describe`, but the spec actually uses `test.describe.serial`:

- `packages/core-backend/tests/e2e/multitable-basic-views-smoke.spec.ts:112` — `test.describe.serial('Multitable basic views smoke', () => {`
- spec header comment at `:13` — "Tests run serial because they share that fixture; …"

This PR brings the doc onto the spec's actual semantics. Rationale captured: because all 5 tests share one base/sheet fixture built in `beforeAll`, a fixture-stage failure should short-circuit rather than cascade misleading per-view failures; `--workers=1` in the wrapper is the additional belt-and-suspenders.

## Scope

Docs-only — single file changed (4 insertions, 3 deletions). No test, wrapper, or business-code touches.

## Test plan

- [x] `grep -n "test.describe" packages/core-backend/tests/e2e/multitable-basic-views-smoke.spec.ts` confirms `.serial` is the checked-in state on main
- [x] Doc now reads "run via `test.describe.serial`" matching the spec

🤖 Generated with [Claude Code](https://claude.com/claude-code)