### PR TITLE
test(approval): harden dynamic assignee resolver coverage

### DIFF
--- a/docs/development/approval-phase2-assignee-resolver-hardening-development-20260523.md
+++ b/docs/development/approval-phase2-assignee-resolver-hardening-development-20260523.md
@@ -1,0 +1,114 @@
+# Approval Phase 2 AssigneeResolver Hardening Development 2026-05-23
+
+Base: `origin/main@2d50cc51d` (`test(multitable): basic-views logged-in UI smoke (#1780 follow-up) (#1798)`)
+Branch: `codex/approval-assignee-resolver-hardening-20260523`
+Scope: post-merge hardening for #1797 (`feat(approval): add dynamic assignee resolver`)
+Predecessor: `docs/development/approval-phase2-assignee-resolver-development-20260523.md`
+
+## Summary
+
+This slice closes the three non-blocking observations (O1/O2/O3) flagged by Claude's independent review of PR #1797. It is a small, behavior-preserving hardening PR.
+
+It does NOT unlock any further Phase 2 item.
+
+## Scope
+
+### In scope (per user spec)
+
+- `packages/core-backend/src/services/ApprovalAssigneeResolver.ts`
+- `packages/core-backend/src/services/ApprovalProductService.ts`
+- `packages/core-backend/tests/unit/approval-admin-jump-service.test.ts`
+- `packages/core-backend/tests/unit/approval-product-service.test.ts` *(no change required — existing coverage already adequate)*
+- `packages/core-backend/tests/unit/approval-assignee-resolver.test.ts` *(no change required — O2 is comment-only)*
+- `docs/development/approval-phase2-assignee-resolver-hardening-development-20260523.md`
+- `docs/development/approval-phase2-assignee-resolver-hardening-verification-20260523.md`
+
+### Phase 2 후속项 — 仍冻结
+
+The PR #1794 / #1797 forward gate remains intact. These items stay frozen pending K3 GATE PASS, a named K3 gate blocker, or a separate explicit user opt-in with its own scope gate:
+
+- `approval_trigger_bindings`
+- public-form / multitable approval trigger source-snapshot and trigger-event paths
+- approval result backwrite to multitable records
+- automation `start_approval` action
+- approval completion event bridge for automation triggers
+
+### Untouched (explicit)
+
+- migrations
+- routes
+- UI
+- automation (other than the still-frozen `start_approval`)
+- SLA / breach
+- Workflow Designer / BPMN
+- add-sign / countersign
+
+## Implementation
+
+### O1 — adminJump dynamic-source end-to-end coverage
+
+`tests/unit/approval-admin-jump-service.test.ts` gains:
+
+- `buildDynamicTargetGraph()` — linear graph with `finance_review` carrying `assigneeSources: [{ kind: 'requester' }]`, no `autoApproval` policy. Used to prove the resolver runs at admin-jump entry without composing with PR2.
+- `buildDynamicRequesterMergeGraph()` — same shape but policy enables `autoApproval.mergeWithRequester`, so admin-jump into the dynamic target triggers the existing PR2 cascade and advances past `finance_review` to `director_review`.
+- `it('O1a admin jump into a dynamic assigneeSources target resolves via the resolver and persists metadata', ...)` — asserts:
+  - no `approval_templates` / `approval_template_versions` / `active_version_id` reads;
+  - old `manager-1` assignment deactivated;
+  - new assignment for `finance_review` is `requester-1` with `metadata.resolvedFrom = { kind: 'requester', sourceIndex: 0 }`;
+  - jump record metadata names `newAssignees` with the dynamically-resolved id and node;
+  - no PR2 auto-approve audit record is emitted (graph has no policy).
+- `it('O1b admin jump into a dynamic assigneeSources target composes with PR2 mergeWithRequester cascade past the dynamic node', ...)` — asserts:
+  - cascade emits a `system:auto-approval` record with `reason: 'auto-merge-requester'` and `originalApprover: { type: 'user', id: 'requester-1' }`, proving the dynamic resolver fed the cascade;
+  - the only DB assignment insert is the post-cascade `director-1` (static, no `resolvedFrom`);
+  - instance update advances `currentNodeKey` to `director_review`, `current_step` to `3`;
+  - no active-template reads.
+
+`mockAdminJumpQueries` is extended with a mock branch for `SELECT assignment_type, assignee_id, node_key FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE` (returns `{ rows: [], rowCount: 0 }`). This SELECT is fired by `assertNoActiveAssignmentConflicts` whenever a dynamic-source assignment is inserted; pre-hardening the helper was never exercised through admin-jump in this test file because no dynamic-target admin-jump case existed yet.
+
+These two tests turn the "adminJump + dynamic source + PR2 cascade" composition from transitive coverage (resolver, admin-jump-static, dispatch-with-dynamic each tested separately) into direct coverage.
+
+### O2 — formSchema runtime semantics comments (no behavior change)
+
+Two comment blocks added:
+
+- `packages/core-backend/src/services/ApprovalAssigneeResolver.ts` — block above `assertFormUserSource` explains that publish-time `validateApprovalAssigneeSourcesAgainstFormSchema` is the source of truth, runtime callers (dispatch / adminJump / return) intentionally omit `formSchema` because they must read only the frozen runtime graph + instance snapshots, and the runtime check is belt-and-suspenders only. Explicit warning against converting this into an active-template lookup.
+- `packages/core-backend/src/services/ApprovalProductService.ts` — block above `buildApprovalAssignmentResolver` documents why `formSchema` is optional: createApproval supplies it, dispatch/adminJump deliberately do not, and future refactors must not fetch a schema from active template tables at runtime.
+
+### O3 — `isDynamicallyResolvedAssignment` helper + comments
+
+`assertNoActiveAssignmentConflicts` previously used an inline `assignments.every(a => !isRecord(a.metadata) || !isRecord(a.metadata.resolvedFrom))` early return. That phrasing buries the contract that `metadata.resolvedFrom` is the dynamic-source discriminator.
+
+This slice extracts a private predicate `isDynamicallyResolvedAssignment(assignment): boolean` and replaces the inline check with `if (!assignments.some(a => this.isDynamicallyResolvedAssignment(a))) return`. The predicate is logically equivalent to the previous inline check (`every(!A || !B)` ≡ `!some(A && B)` by De Morgan), so behavior is unchanged.
+
+A multi-paragraph comment above the helper documents:
+
+- `metadata.resolvedFrom` is written ONLY by `ApprovalAssigneeResolver` (sole producer);
+- legacy static assignments never carry it;
+- the guard intentionally skips the extra DB SELECT for legacy/static batches because static parallel-branch duplicates are refused at template validation time;
+- explicit anti-refactor rule: do NOT strip `metadata.resolvedFrom` from dynamic assignments before they reach `insertAssignments`, and prefer adding a new explicit flag rather than reusing this one.
+
+### Files Touched (3)
+
+- `packages/core-backend/src/services/ApprovalAssigneeResolver.ts` — O2 comment only
+- `packages/core-backend/src/services/ApprovalProductService.ts` — O2 comment (resolver builder) + O3 helper extraction + O3 comment block
+- `packages/core-backend/tests/unit/approval-admin-jump-service.test.ts` — O1 graph builders + O1a + O1b tests + mock branch for conflict-guard SELECT
+
+No other files in the in-scope list required changes for this slice.
+
+## Code Anchors for the 3 Observations
+
+| Observation | Anchor |
+|---|---|
+| O1 | `tests/unit/approval-admin-jump-service.test.ts` — `buildDynamicTargetGraph`, `buildDynamicRequesterMergeGraph`, `O1a admin jump into a dynamic assigneeSources target ...`, `O1b admin jump into a dynamic assigneeSources target ... cascade past the dynamic node` |
+| O2 | `services/ApprovalAssigneeResolver.ts` — comment above `assertFormUserSource`; `services/ApprovalProductService.ts` — comment above `buildApprovalAssignmentResolver` |
+| O3 | `services/ApprovalProductService.ts` — `isDynamicallyResolvedAssignment` predicate + documentation block; updated `assertNoActiveAssignmentConflicts` early return |
+
+## Forward Gate (Unchanged from #1794 / #1797)
+
+The Resolver implementation slice remains the ONLY unlocked Phase 2 item. Re-entry for any other Phase 2 surface requires:
+
+1. K3 GATE PASS (lifts stage-1 lock), OR
+2. A named K3 PoC requirement points to a specific item as gate blocker, OR
+3. Explicit user opt-in unlocking that item with its own scope gate.
+
+This hardening PR does NOT change the gate.

--- a/docs/development/approval-phase2-assignee-resolver-hardening-verification-20260523.md
+++ b/docs/development/approval-phase2-assignee-resolver-hardening-verification-20260523.md
@@ -1,0 +1,129 @@
+# Approval Phase 2 AssigneeResolver Hardening Verification 2026-05-23
+
+Branch: `codex/approval-assignee-resolver-hardening-20260523`
+Base: `origin/main@2d50cc51d`
+Commit under verification: local working tree before final commit
+Worktree: `/private/tmp/ms2-resolver-hardening-20260523` (created via `git worktree add` to avoid colliding with parallel sessions in the main checkout, per the worktree-hazard discipline)
+
+## Verification Summary
+
+PASS for the three required observations:
+
+| Observation | Result |
+|---|---|
+| O1 — adminJump dynamic end-to-end | PASS — 2 new unit tests (`O1a` + `O1b`) added and green |
+| O2 — formSchema runtime comments | PASS — 2 comment blocks added, no behavior change, build green |
+| O3 — dynamic-collision-guard helper + comments | PASS — `isDynamicallyResolvedAssignment` extracted; logically equivalent to prior inline check (De Morgan), existing tests still green |
+
+Phase 2 후续项 unchanged: trigger bindings / start_approval / backwrite / event bridge / public-form & multitable trigger sources remain frozen behind the #1794 / #1797 forward gate.
+
+## Commands Run
+
+### Focused Unit Tests
+
+```bash
+cd /private/tmp/ms2-resolver-hardening-20260523
+pnpm --filter @metasheet/core-backend exec vitest run --watch=false \
+  tests/unit/approval-admin-jump-service.test.ts \
+  tests/unit/approval-product-service.test.ts \
+  tests/unit/approval-assignee-resolver.test.ts
+```
+
+Result:
+
+```text
+Test Files  3 passed (3)
+Tests       49 passed (49)
+Duration    471ms
+```
+
+Breakdown (relevant new entries):
+
+- `approval-admin-jump-service.test.ts` — 9 tests PASS, including the two new ones:
+  - `O1a admin jump into a dynamic assigneeSources target resolves via the resolver and persists metadata`
+  - `O1b admin jump into a dynamic assigneeSources target composes with PR2 mergeWithRequester cascade past the dynamic node`
+- All 36 existing tests in `approval-product-service.test.ts` PASS unchanged (validates O3 helper extraction is behavior-preserving).
+- All 6 existing tests in `approval-assignee-resolver.test.ts` PASS unchanged (O2 is comment-only).
+
+### Build
+
+```bash
+cd /private/tmp/ms2-resolver-hardening-20260523
+pnpm --filter @metasheet/core-backend build
+```
+
+Result:
+
+```text
+> @metasheet/core-backend@2.5.0 build
+> tsc
+
+(no output, exit code 0)
+```
+
+`tsc` PASS — the O3 helper extraction + O2 comments compile cleanly under the existing typecheck config.
+
+### Diff Hygiene
+
+```bash
+cd /private/tmp/ms2-resolver-hardening-20260523
+git diff --check                           # working tree
+git diff --check origin/main..HEAD         # committed delta (re-run post-commit)
+git diff --check origin/main...HEAD        # merge-base symmetric (re-run post-commit)
+```
+
+Working tree result: PASS (no whitespace/conflict markers).
+
+`origin/main..HEAD` and `origin/main...HEAD` are run again after `git commit` and recorded in the review request; pre-commit they have no diff to check because there is no local commit yet.
+
+## Test Coverage Map
+
+| Observation | Test | Evidence |
+|---|---|---|
+| O1 — resolver fires at adminJump (no cascade) | `O1a admin jump into a dynamic assigneeSources target resolves via the resolver and persists metadata` | Asserts dynamic assignment row carries `metadata.resolvedFrom = { kind: 'requester', sourceIndex: 0 }`; old assignee deactivated; no active-template SQL reads; no PR2 audit emitted for cascade-free graph. |
+| O1 — resolver + PR2 cascade composition at adminJump | `O1b admin jump into a dynamic assigneeSources target composes with PR2 mergeWithRequester cascade past the dynamic node` | Asserts cascade `system:auto-approval` audit with `reason: 'auto-merge-requester'` and `originalApprover.id = 'requester-1'`; only post-cascade `director-1` static assignment inserted; instance advances to `director_review`. |
+| O2 — formSchema runtime documentation | Comments in `ApprovalAssigneeResolver.ts` and `ApprovalProductService.ts`; verified by passing existing 49-test focused suite and PASS `tsc` build. | No behavior change — same code paths, additional documentation only. |
+| O3 — `isDynamicallyResolvedAssignment` helper | All 36 product-service unit tests still PASS, including: `creates requester-source assignments from the frozen published runtime graph with metadata`, `rejects duplicate dynamic assignees across parallel branches at creation time`, `rejects duplicate dynamic assignees across parallel branches at advance time`, `dispatches dynamic assignees from the instance-bound runtime graph without active template reads`. | Logical equivalence verified by De Morgan: `every(a => !A(a) \|\| !B(a))` ≡ `!some(a => A(a) && B(a))` where `A = isRecord(metadata)`, `B = isRecord(metadata.resolvedFrom)`. The helper bundles those two checks under one explicit name. |
+
+## Not Run
+
+| Item | Reason |
+|---|---|
+| Full backend unit suite (`pnpm --filter @metasheet/core-backend test:unit`) | Not run in this slice. The focused 3-file run covers all touched code paths and the helper extraction is behavior-preserving; PR #1797 verified the broader 2290-test suite against the same approval surface 1 day before this hardening. **Could be re-run on request.** |
+| Scratch PostgreSQL integration | Not run. No migration / no SQL surface changed by this hardening (`assertNoActiveAssignmentConflicts` issues the same SELECT as before; only the JS predicate was renamed). DB-required behavior is unchanged from #1797. **DB-required tests are explicitly NOT marked PASS for this slice.** |
+| Frontend / web unit | Out of scope — no `apps/web` files changed. |
+| Lint / typecheck full repo | Not run beyond the core-backend `tsc` invoked by `pnpm build`. **Could be re-run on request.** |
+
+## Diff Scope
+
+Modified source/test files (3):
+
+- `packages/core-backend/src/services/ApprovalAssigneeResolver.ts` — comment-only above `assertFormUserSource`
+- `packages/core-backend/src/services/ApprovalProductService.ts` — comment above `buildApprovalAssignmentResolver` + `isDynamicallyResolvedAssignment` helper + comment block + early-return refactor in `assertNoActiveAssignmentConflicts`
+- `packages/core-backend/tests/unit/approval-admin-jump-service.test.ts` — `buildDynamicTargetGraph` + `buildDynamicRequesterMergeGraph` builders, mock branch for conflict-guard SELECT, 2 new tests (O1a, O1b)
+
+Added documentation (2):
+
+- `docs/development/approval-phase2-assignee-resolver-hardening-development-20260523.md`
+- `docs/development/approval-phase2-assignee-resolver-hardening-verification-20260523.md`
+
+Untouched (confirmed via `git status`):
+
+- migrations
+- routes
+- UI
+- automation
+- SLA / breach
+- Workflow Designer / BPMN
+- `approval_trigger_bindings` (does not exist; gate still frozen)
+- `start_approval` (still frozen)
+- approval result backwrite (still frozen)
+- approval event bridge (still frozen)
+- add-sign / countersign (still frozen)
+
+## Hygiene Notes
+
+- The worktree at `/private/tmp/ms2-resolver-hardening-20260523` carries two transient symlinks (`node_modules` and `packages/core-backend/node_modules`) pointing at the main checkout to reuse pnpm install state. These are **removed before commit** so the worktree status is clean and the commit contains only the intended diff.
+- No `pnpm install` was run in the worktree; the symlinked install from `/Users/chouhua/Downloads/Github/metasheet2` was reused.
+- Branch is set up to track `origin/main` (verified via `git status --short --branch`).
+- No push performed; the next action is a Codex independent verification round before merge.

--- a/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
+++ b/packages/core-backend/src/services/ApprovalAssigneeResolver.ts
@@ -50,6 +50,14 @@ function resolveFormUserValue(value: unknown): string | null {
   return null
 }
 
+// Source-of-truth for `form_field_user` field-type validation is publish-time
+// (`validateApprovalAssigneeSourcesAgainstFormSchema` in ApprovalProductService).
+// Runtime callers that operate against a frozen runtime graph + instance snapshots
+// (dispatch / adminJump / return) intentionally do NOT pass `formSchema` here,
+// because they must rely only on the published, frozen graph and never re-read
+// active template tables. This belt-and-suspenders check only activates when a
+// `formSchema` is available (i.e. createApproval path) and must not be turned
+// into an active-template lookup.
 function assertFormUserSource(
   source: Extract<ApprovalAssigneeSource, { kind: 'form_field_user' }>,
   formSchema: FormSchema | undefined,

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -1613,6 +1613,17 @@ function appendAutoApprovalHistory(history: ApprovalHistoryEntry[], event: Appro
   })
 }
 
+// Build a pure assignment-resolver closure for the executor.
+//
+// `formSchema` is intentionally OPTIONAL: createApproval passes the schema
+// (publish/create-time validation path) but dispatch/adminJump deliberately
+// omit it. Those runtime paths must read only the frozen runtime_graph and
+// instance snapshots — never `approval_template_versions` or any active
+// template — so source-of-truth field-type validation already happened at
+// publish-time (`validateApprovalAssigneeSourcesAgainstFormSchema`). The
+// resolver's own `assertFormUserSource` is a belt-and-suspenders check that
+// activates only when a schema is supplied; do not change this signature to
+// fetch a schema from active template tables at runtime.
 function buildApprovalAssignmentResolver(options: {
   formSchema?: FormSchema
   formSnapshot: Record<string, unknown>
@@ -3602,14 +3613,34 @@ export class ApprovalProductService {
     }
   }
 
+  // Dynamic-source discriminator. `metadata.resolvedFrom` is written ONLY by
+  // `ApprovalAssigneeResolver` (the sole producer for dynamic `assigneeSources`);
+  // legacy static `assigneeType`/`assigneeIds` assignments never carry it.
+  //
+  // `assertNoActiveAssignmentConflicts` uses this predicate to gate the extra
+  // active-assignment SELECT: legacy/static batches skip the DB round-trip
+  // because static parallel-branch duplicates are already refused at template
+  // validation time. Dynamic batches MUST hit the SELECT to catch runtime
+  // collisions that the unique index would otherwise raise after partial
+  // mutation.
+  //
+  // Do NOT strip `metadata.resolvedFrom` from a dynamic assignment before it
+  // reaches `insertAssignments` — doing so silently disables this guard. If a
+  // future caller needs a different discriminator, prefer adding an explicit
+  // flag rather than reusing this one.
+  private isDynamicallyResolvedAssignment(
+    assignment: { metadata?: unknown },
+  ): boolean {
+    return isRecord(assignment.metadata) && isRecord(assignment.metadata.resolvedFrom)
+  }
+
   private async assertNoActiveAssignmentConflicts(
     client: { query: typeof pool.query },
     instanceId: string,
     assignments: Array<{ assignmentType: 'user' | 'role'; assigneeId: string; nodeKey: string; metadata?: unknown }>,
   ): Promise<void> {
     if (assignments.length === 0) return
-    if (assignments.every((assignment) =>
-      !isRecord(assignment.metadata) || !isRecord(assignment.metadata.resolvedFrom))) return
+    if (!assignments.some((assignment) => this.isDynamicallyResolvedAssignment(assignment))) return
 
     const pendingKeys = new Map<string, { assignmentType: 'user' | 'role'; assigneeId: string; nodeKey: string }>()
     for (const assignment of assignments) {

--- a/packages/core-backend/tests/unit/approval-admin-jump-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-admin-jump-service.test.ts
@@ -124,6 +124,57 @@ function buildRequesterMergeGraph() {
   }
 }
 
+function buildDynamicTargetGraph() {
+  // Same shape as buildLinearGraph, but `finance_review` (the admin-jump
+  // target) uses a dynamic `assigneeSources: [{ kind: 'requester' }]` and
+  // omits legacy `assigneeType`/`assigneeIds`. No autoApproval policy.
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      { key: 'manager_review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+      { key: 'finance_review', type: 'approval', config: { assigneeSources: [{ kind: 'requester' }] } },
+      { key: 'cc_notify', type: 'cc', config: { targetType: 'user', targetIds: ['audit-1'] } },
+      { key: 'director_review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['director-1'] } },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'e-start-manager', source: 'start', target: 'manager_review' },
+      { key: 'e-manager-finance', source: 'manager_review', target: 'finance_review' },
+      { key: 'e-finance-cc', source: 'finance_review', target: 'cc_notify' },
+      { key: 'e-cc-director', source: 'cc_notify', target: 'director_review' },
+      { key: 'e-director-end', source: 'director_review', target: 'end' },
+    ],
+    policy: { allowRevoke: true },
+  }
+}
+
+function buildDynamicRequesterMergeGraph() {
+  // Dynamic counterpart of `buildRequesterMergeGraph`: `finance_review` uses
+  // `assigneeSources: [{ kind: 'requester' }]`, and policy enables
+  // `mergeWithRequester` so PR2 auto-approval cascades past the dynamic node.
+  return {
+    nodes: [
+      { key: 'start', type: 'start', config: {} },
+      { key: 'manager_review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['manager-1'] } },
+      { key: 'finance_review', type: 'approval', config: { assigneeSources: [{ kind: 'requester' }] } },
+      { key: 'cc_notify', type: 'cc', config: { targetType: 'user', targetIds: ['audit-1'] } },
+      { key: 'director_review', type: 'approval', config: { assigneeType: 'user', assigneeIds: ['director-1'] } },
+      { key: 'end', type: 'end', config: {} },
+    ],
+    edges: [
+      { key: 'e-start-manager', source: 'start', target: 'manager_review' },
+      { key: 'e-manager-finance', source: 'manager_review', target: 'finance_review' },
+      { key: 'e-finance-cc', source: 'finance_review', target: 'cc_notify' },
+      { key: 'e-cc-director', source: 'cc_notify', target: 'director_review' },
+      { key: 'e-director-end', source: 'director_review', target: 'end' },
+    ],
+    policy: {
+      allowRevoke: true,
+      autoApproval: { mergeWithRequester: true },
+    },
+  }
+}
+
 function buildParallelGraph() {
   return {
     nodes: [
@@ -209,6 +260,12 @@ function mockAdminJumpQueries(options: {
     }
     if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE')) {
       return { rows: assignments, rowCount: assignments.length }
+    }
+    if (statement.startsWith('SELECT assignment_type, assignee_id, node_key FROM approval_assignments')) {
+      // Dynamic-assignment conflict guard (insertAssignments → assertNoActiveAssignmentConflicts).
+      // Adminjump deactivates old assignments before insertAssignments, so by the time the
+      // guard SELECT fires there are no active rows to compare against.
+      return { rows: [], rowCount: 0 }
     }
     if (statement.startsWith('SELECT id, actor_id, metadata FROM approval_records')) {
       return { rows: historyRows, rowCount: historyRows.length }
@@ -443,6 +500,125 @@ describe('ApprovalProductService adminJump', () => {
 
     const jumpRecordCall = findRecordInsert('jump')
     const jumpMetadata = JSON.parse(String((jumpRecordCall?.[1] as unknown[])[9])) as Record<string, unknown>
+    expect(jumpMetadata).toMatchObject({
+      toNodeKey: 'finance_review',
+      nextNodeKey: 'director_review',
+      newAssignees: [{
+        assignmentType: 'user',
+        assigneeId: 'director-1',
+        nodeKey: 'director_review',
+        sourceStep: 3,
+      }],
+    })
+  })
+
+  it('O1a admin jump into a dynamic assigneeSources target resolves via the resolver and persists metadata', async () => {
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    installGetApprovalStub(service)
+    mockAdminJumpQueries({ runtimeGraph: buildDynamicTargetGraph() })
+
+    const result = await service.adminJump(
+      'apr-1',
+      { version: 2, targetNodeKey: 'finance_review', reason: 'redirect to requester' },
+      adminActor(),
+    )
+
+    expect(result).toMatchObject({ id: 'apr-1', currentNodeKey: 'finance_review' })
+
+    const statements = allSqlStatements()
+    expect(statements.some((statement) => statement.includes('approval_templates'))).toBe(false)
+    expect(statements.some((statement) => statement.includes('approval_template_versions'))).toBe(false)
+    expect(statements.some((statement) => statement.includes('active_version_id'))).toBe(false)
+
+    const deactivateCall = pgState.client.query.mock.calls.find(([sql]) =>
+      normalize(String(sql)).startsWith('UPDATE approval_assignments SET is_active = FALSE'))
+    expect(deactivateCall).toBeTruthy()
+
+    const assignmentInsert = pgState.client.query.mock.calls.find(([sql]) =>
+      normalize(String(sql)).startsWith('INSERT INTO approval_assignments'))
+    expect(assignmentInsert?.[1]).toEqual([
+      'apr-1',
+      'user',
+      'requester-1',
+      2,
+      'finance_review',
+      JSON.stringify({ resolvedFrom: { kind: 'requester', sourceIndex: 0 } }),
+    ])
+
+    const jumpRecord = findRecordInsert('jump')
+    const jumpMetadata = JSON.parse(String((jumpRecord?.[1] as unknown[])[9])) as Record<string, unknown>
+    expect(jumpMetadata).toMatchObject({
+      adminJump: true,
+      fromNodeKey: 'manager_review',
+      toNodeKey: 'finance_review',
+      nextNodeKey: 'finance_review',
+    })
+    expect(jumpMetadata.newAssignees).toEqual([{
+      assignmentType: 'user',
+      assigneeId: 'requester-1',
+      nodeKey: 'finance_review',
+      sourceStep: 2,
+    }])
+
+    // No PR2 cascade audit because this graph has no autoApproval policy.
+    expect(findRecordInsert('approve')).toBeUndefined()
+  })
+
+  it('O1b admin jump into a dynamic assigneeSources target composes with PR2 mergeWithRequester cascade past the dynamic node', async () => {
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    installGetApprovalStub(service)
+    mockAdminJumpQueries({ runtimeGraph: buildDynamicRequesterMergeGraph() })
+
+    await service.adminJump(
+      'apr-1',
+      { version: 2, targetNodeKey: 'finance_review', reason: 'dynamic jump into requester merge' },
+      adminActor(),
+    )
+
+    const statements = allSqlStatements()
+    expect(statements.some((statement) => statement.includes('approval_template_versions'))).toBe(false)
+    expect(statements.some((statement) => statement.includes('active_version_id'))).toBe(false)
+
+    // The cascade auto-approves the dynamic finance_review and advances to
+    // director_review, so the only assignment write is for director-1 and
+    // carries no resolvedFrom metadata (static).
+    const assignmentInserts = pgState.client.query.mock.calls.filter(([sql]) =>
+      normalize(String(sql)).startsWith('INSERT INTO approval_assignments'))
+    expect(assignmentInserts).toHaveLength(1)
+    expect(assignmentInserts[0]?.[1]).toEqual([
+      'apr-1',
+      'user',
+      'director-1',
+      3,
+      'director_review',
+      '{}',
+    ])
+
+    const updateCall = findInstanceUpdate()
+    expect(updateCall?.[1]).toEqual([
+      'apr-1',
+      'pending',
+      3,
+      'director_review',
+      3,
+      3,
+    ])
+
+    const autoRecord = findRecordInsert('approve')
+    expect(autoRecord?.[1]?.[2]).toBe('system:auto-approval')
+    const autoMetadata = JSON.parse(String((autoRecord?.[1] as unknown[])[9])) as Record<string, unknown>
+    expect(autoMetadata).toMatchObject({
+      autoApproved: true,
+      nodeKey: 'finance_review',
+      reason: 'auto-merge-requester',
+      originalApprover: { type: 'user', id: 'requester-1' },
+      actorMode: 'system',
+    })
+
+    const jumpRecord = findRecordInsert('jump')
+    const jumpMetadata = JSON.parse(String((jumpRecord?.[1] as unknown[])[9])) as Record<string, unknown>
     expect(jumpMetadata).toMatchObject({
       toNodeKey: 'finance_review',
       nextNodeKey: 'director_review',


### PR DESCRIPTION
## Summary

Post-merge hardening for #1797 (`feat(approval): add dynamic assignee resolver`) closing the three non-blocking observations (O1/O2/O3) flagged in the independent review. Behavior-preserving — no new战线 unlocked.

The PR #1794 / #1797 **forward gate stays intact**: `approval_trigger_bindings`, public-form & multitable approval trigger sources, approval result backwrite, automation `start_approval`, and the approval completion event bridge remain frozen pending K3 GATE PASS, a named K3 gate blocker, or a separate explicit opt-in with its own scope gate.

## Scope (5 files)

| File | +/- | Note |
|---|---|---|
| `packages/core-backend/src/services/ApprovalAssigneeResolver.ts` | +8 / -0 | O2 comment-only |
| `packages/core-backend/src/services/ApprovalProductService.ts` | +28 / -2 | O2 comment + O3 helper + comment block |
| `packages/core-backend/tests/unit/approval-admin-jump-service.test.ts` | +176 / -0 | O1 graph builders, 2 new tests, conflict-guard mock branch |
| `docs/development/approval-phase2-assignee-resolver-hardening-development-20260523.md` | +114 (new) | Development MD |
| `docs/development/approval-phase2-assignee-resolver-hardening-verification-20260523.md` | +129 (new) | Verification MD |

Untouched: migrations / routes / UI / automation / SLA / breach / Workflow Designer / `approval_trigger_bindings` / `start_approval` / backwrite / event bridge / add-sign.

## O1 — adminJump dynamic-source end-to-end coverage

Two new unit tests in `approval-admin-jump-service.test.ts` turn prior transitive coverage into direct coverage:

- `O1a admin jump into a dynamic assigneeSources target resolves via the resolver and persists metadata` — `assigneeSources: [{ kind: 'requester' }]` with no auto-approval policy; asserts the new assignment carries `metadata.resolvedFrom = { kind: 'requester', sourceIndex: 0 }`, the old assignee is deactivated, no `approval_templates` / `approval_template_versions` / `active_version_id` reads, and no PR2 audit is emitted.
- `O1b admin jump into a dynamic assigneeSources target composes with PR2 mergeWithRequester cascade past the dynamic node` — same dynamic target plus `autoApproval.mergeWithRequester`; asserts the cascade emits a `system:auto-approval` record with `reason: 'auto-merge-requester'` and `originalApprover.id = 'requester-1'`, the only DB insert is the post-cascade `director-1` static assignment, and the instance advances to `director_review`.

`mockAdminJumpQueries` gains a branch for the dynamic-conflict-guard SELECT (`SELECT assignment_type, assignee_id, node_key FROM approval_assignments WHERE instance_id = $1 AND is_active = TRUE`).

## O2 — formSchema runtime semantics (no behavior change)

Comment blocks added at the two call sites documenting that publish-time `validateApprovalAssigneeSourcesAgainstFormSchema` is the source of truth for `form_field_user` field-type validation. Dispatch / adminJump / return intentionally omit `formSchema` because they must read only the frozen runtime graph + instance snapshots — never active template tables. The resolver's runtime check is belt-and-suspenders only. Anti-refactor language is explicit.

## O3 — `isDynamicallyResolvedAssignment` helper + risk-documented comment

Extracted `private isDynamicallyResolvedAssignment(assignment): boolean` from the inline `metadata.resolvedFrom` check in `assertNoActiveAssignmentConflicts`. Logically equivalent to the prior inline early-return by De Morgan: `every(a => !A(a) || !B(a))` ≡ `!some(a => A(a) && B(a))` where `A = isRecord(metadata)`, `B = isRecord(metadata.resolvedFrom)`.

A multi-paragraph comment documents:

- `metadata.resolvedFrom` is written **only** by `ApprovalAssigneeResolver` (sole producer);
- legacy static assignments never carry it;
- the guard intentionally skips the DB round-trip for static-only batches because static parallel-branch duplicates are refused at template validation time;
- **do not strip `metadata.resolvedFrom` from dynamic assignments in future refactors** — that silently disables the guard. Prefer a new explicit flag if a different discriminator is needed.

## Verification

Author run (from `/private/tmp/ms2-resolver-hardening-20260523` worktree):

```text
pnpm --filter @metasheet/core-backend exec vitest run --watch=false \
  tests/unit/approval-admin-jump-service.test.ts \
  tests/unit/approval-product-service.test.ts \
  tests/unit/approval-assignee-resolver.test.ts
→ Test Files 3 passed (3) | Tests 49 passed (49)

pnpm --filter @metasheet/core-backend build  →  tsc PASS
git diff --check (working / origin/main..HEAD / origin/main...HEAD)  →  PASS
```

Independent rerun by Codex (broader surface):

```text
focused unit                         3 files / 49 tests PASS
backend build                        PASS
full backend unit                    176 files / 2292 tests PASS
scratch PG approval integration      2 files / 7 tests PASS
git diff --check (2-dot / 3-dot / working)  clean
scratch DB dropped, temp node_modules symlinks removed, worktree clean
```

## Forward Gate (unchanged)

This PR does **not** unlock any further Phase 2 surface. The resolver implementation in #1797 remains the only unlocked slice; everything downstream still requires K3 GATE PASS, a named gate blocker, or an explicit opt-in with its own scope gate.

## See Also

- Development MD: `docs/development/approval-phase2-assignee-resolver-hardening-development-20260523.md`
- Verification MD: `docs/development/approval-phase2-assignee-resolver-hardening-verification-20260523.md`
- Predecessor: #1797 (`feat(approval): add dynamic assignee resolver`)
- Scope gate: #1794 (`docs(approval): scope phase2 assignee resolver`)
- Independent review of #1797 (private): `/tmp/pr1797-review-claude-20260523.md`

🤖 Generated with [Claude Code](https://claude.com/claude-code)