### PR TITLE
feat(multitable): localize useYjsDocument not-authenticated error

### DIFF
--- a/apps/web/src/multitable/composables/useYjsDocument.ts
+++ b/apps/web/src/multitable/composables/useYjsDocument.ts
@@ -6,6 +6,8 @@ import * as encoding from 'lib0/encoding'
 import * as decoding from 'lib0/decoding'
 import { io as socketIO, type Socket } from 'socket.io-client'
 import { useAuth } from '../../composables/useAuth'
+import { useLocale } from '../../composables/useLocale'
+import { metaCoreLabel } from '../utils/meta-core-labels'
 import type { YjsRecordPresence, YjsPresenceUser } from '../types'
 
 const MSG_SYNC = 0
@@ -69,6 +71,7 @@ export function useYjsDocument(recordId: Ref<string | null>, options: UseYjsDocu
   const currentUserId = ref<string | null>(null)
 
   const auth = useAuth()
+  const { isZh } = useLocale()
   let socket: Socket | null = null
   let currentRecordId: string | null = null
   /**
@@ -123,7 +126,7 @@ export function useYjsDocument(recordId: Ref<string | null>, options: UseYjsDocu
     // Pass JWT token for server-side verification — not raw userId
     const token = auth.getToken()
     if (!token) {
-      error.value = 'Not authenticated'
+      error.value = metaCoreLabel('auth.notAuthenticated', isZh.value)
       return
     }
     const resolvedUserId = await auth.getCurrentUserId().catch(() => null)

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -67,6 +67,8 @@ export type MetaCoreLabelKey =
   | 'cell.yes' | 'cell.no' | 'cell.clear'
   | 'cell.noAttachments' | 'cell.clearAll'
   | 'cell.uploadFailed' | 'cell.removeFailed' | 'cell.clearFailed'
+  // --- Auth chrome (file-location closure tightening per #1803) ---
+  | 'auth.notAuthenticated'
 
 const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
   'presence.collaboratingNow': { en: 'Collaborating now', zh: '正在协作' },
@@ -175,6 +177,11 @@ const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
     zh: '此页面已无法获取该记录的最新版本。',
   },
   'grid.errorPatchFailed': { en: 'Patch failed', zh: '更新失败' },
+
+  // Auth chrome (#1803 file-location closure tightening).
+  // Used by useYjsDocument.ts:126 when local auth.getToken() returns falsy.
+  // Catch-time isZh capture (event-time semantics matching Slice E composables).
+  'auth.notAuthenticated': { en: 'Not authenticated', zh: '未登录' },
 
   // MetaCellEditor (T3A2): shallow chrome inside the grid cell editor.
   // Excludes user data (option values, format examples like https://example.com),

--- a/apps/web/tests/yjs-document-i18n.spec.ts
+++ b/apps/web/tests/yjs-document-i18n.spec.ts
@@ -1,0 +1,92 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, shallowRef, type App } from 'vue'
+
+// Mock socket.io-client so the module under test resolves; the L126
+// no-token branch returns before any socket call so the mock body is
+// intentionally minimal.
+const ioMock = vi.fn(() => ({
+  connected: false,
+  on: vi.fn(),
+  emit: vi.fn(),
+  disconnect: vi.fn(),
+}))
+
+vi.mock('socket.io-client', () => ({
+  io: (...args: unknown[]) => ioMock(...args),
+}))
+
+// Force the no-token branch at useYjsDocument.ts:126 by returning null
+// from auth.getToken(). The existing yjs-document-invalidation.spec.ts
+// keeps its own mock with a real token; vi.mock is scoped per spec file.
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({
+    getToken: vi.fn(() => null),
+    getCurrentUserId: vi.fn().mockResolvedValue(null),
+  }),
+}))
+
+import { useYjsDocument } from '../src/multitable/composables/useYjsDocument'
+import { useLocale } from '../src/composables/useLocale'
+
+async function flushUi(cycles = 4): Promise<void> {
+  for (let index = 0; index < cycles; index += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+describe('useYjsDocument i18n (#1803 file-location closure)', () => {
+  const { setLocale } = useLocale()
+  let app: App<Element> | null = null
+
+  beforeEach(() => {
+    ioMock.mockClear()
+    setLocale('en')
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    app = null
+    setLocale('en')
+  })
+
+  function mountDocument(recordId = 'rec_1') {
+    let apiRef: ReturnType<typeof useYjsDocument> | null = null
+    const recordRef = shallowRef<string | null>(recordId)
+    app = createApp(defineComponent({
+      setup() {
+        apiRef = useYjsDocument(recordRef as any)
+        return () => h('div')
+      },
+    }))
+    app.mount(document.createElement('div'))
+    return {
+      get api() {
+        if (!apiRef) throw new Error('api not mounted')
+        return apiRef
+      },
+      recordRef,
+    }
+  }
+
+  it('T1: surfaces the EN localized "Not authenticated" when the local token is missing', async () => {
+    setLocale('en')
+    const { api } = mountDocument('rec_token_missing_en')
+    await flushUi()
+
+    // L126 returns early before any socket creation; ioMock must not fire.
+    expect(ioMock).not.toHaveBeenCalled()
+    expect(api.error.value).toBe('Not authenticated')
+    expect(api.connected.value).toBe(false)
+  })
+
+  it('T2: surfaces the zh localized "未登录" when the local token is missing', async () => {
+    setLocale('zh-CN')
+    const { api } = mountDocument('rec_token_missing_zh')
+    await flushUi()
+
+    expect(ioMock).not.toHaveBeenCalled()
+    expect(api.error.value).toBe('未登录')
+    expect(api.connected.value).toBe(false)
+  })
+})

--- a/docs/development/multitable-yjs-auth-i18n-closure-development-20260524.md
+++ b/docs/development/multitable-yjs-auth-i18n-closure-development-20260524.md
@@ -1,0 +1,129 @@
+# Multitable Yjs `Not authenticated` i18n Closure — Development 2026-05-24
+
+Base: `origin/main@7ba475ba8` (`docs(multitable): scope yjs not-authenticated i18n closure (#1803)`)
+Branch: `codex/yjs-auth-i18n-impl-20260524`
+Scope gate: `docs/development/multitable-yjs-auth-i18n-closure-design-20260523.md` (merged via #1803)
+Verification plan: `docs/development/multitable-yjs-auth-i18n-closure-verification-plan-20260523.md`
+
+## Summary
+
+Implements the file-location closure tightening proposed by #1803 scope gate. Localizes one user-visible English literal — `useYjsDocument.ts:126` `'Not authenticated'` — via the existing `meta-core-labels.ts` label module, leaving L198 INVALIDATED:... raw on its declared protocol-sentinel rationale.
+
+This slice does **not** establish a Yjs UX track, does **not** modify `MetaCellEditor.vue:425-428` (dead-key trap exception preserved), and does **not** unlock any other Phase 2 surface (per [[project_approval_phase2_resolver_unlocked]] / [[project_multitable_i18n]]).
+
+## Implementation
+
+### File 1 — `apps/web/src/multitable/utils/meta-core-labels.ts` (+7 / -0)
+
+Two additions:
+
+1. Extended `MetaCoreLabelKey` union with a new section comment + key:
+
+   ```ts
+   // --- Auth chrome (file-location closure tightening per #1803) ---
+   | 'auth.notAuthenticated'
+   ```
+
+2. Extended `META_CORE_LABELS` Record with the matching entry plus a 3-line block comment naming the consumer call site + the event-time semantic:
+
+   ```ts
+   // Auth chrome (#1803 file-location closure tightening).
+   // Used by useYjsDocument.ts:126 when local auth.getToken() returns falsy.
+   // Catch-time isZh capture (event-time semantics matching Slice E composables).
+   'auth.notAuthenticated': { en: 'Not authenticated', zh: '未登录' },
+   ```
+
+No new helper function (D6 of scope gate); the existing `metaCoreLabel(key, isZh)` accessor handles the key. No new exhaustiveness array needed — the repo's `meta-core-labels.ts` does not maintain a `META_CORE_LABEL_KEYS` array; type-checking against `MetaCoreLabelKey` covers exhaustiveness for the typed `Record<MetaCoreLabelKey, ...>` map.
+
+### File 2 — `apps/web/src/multitable/composables/useYjsDocument.ts` (+5 / -1)
+
+Three small additions plus the L126 literal replacement:
+
+1. Two new imports immediately after the existing `useAuth` import:
+
+   ```ts
+   import { useLocale } from '../../composables/useLocale'
+   import { metaCoreLabel } from '../utils/meta-core-labels'
+   ```
+
+2. One destructure line immediately after `const auth = useAuth()` inside the `useYjsDocument` composable body:
+
+   ```ts
+   const { isZh } = useLocale()
+   ```
+
+3. The L126 string-literal replacement (single-line edit):
+
+   ```diff
+   -      error.value = 'Not authenticated'
+   +      error.value = metaCoreLabel('auth.notAuthenticated', isZh.value)
+   ```
+
+   This is a **straight assignment** (scope-gate D3). The branch fires when local `auth.getToken()` returns falsy — there is no backend `e.message` to prefer, so the Slice E `e.message ?? fallback(key)` raw-first pattern does **not** apply here. Verification §3.6 guards against accidental `?? metaCoreLabel(...)` regression.
+
+L198 `error.value = 'INVALIDATED: document invalidated by REST write'` is byte-unchanged. Verification §3.4 confirms with `git diff | grep -c INVALIDATED = 0`.
+
+### File 3 — `apps/web/tests/yjs-document-i18n.spec.ts` (new, +92 lines)
+
+New focused spec for T1/T2 — only the EN/zh outputs on the no-token branch. T3 (L198 INVALIDATED-stays-raw) regression is covered byte-unchanged by the existing `tests/yjs-document-invalidation.spec.ts` (4 tests pass without modification on this branch).
+
+Spec structure (Option A from scope-gate D7):
+
+- Mocks `socket.io-client` minimally (no-op `io` factory; the L126 branch returns before any socket creation so the mock body is intentionally minimal)
+- Mocks `useAuth` to force `getToken()` returning `null` — distinct from the existing invalidation spec which mocks `getToken` returning `'jwt-token'`; `vi.mock` is per-test-file scoped so the two specs coexist
+- `mountDocument(recordId)` helper mirrors the existing invalidation spec's pattern (`createApp` + `defineComponent` setup that captures the composable api into a closure ref)
+- `flushUi(cycles = 4)` awaits the watch-induced async `connect()` reaching the L126 branch
+- `beforeEach` + `afterEach` set the locale back to `'en'` (the module-level `localeState` in `useLocale.ts` is a singleton; clean reset between tests)
+
+Two `it()` cases:
+
+- **T1**: `setLocale('en')` → `error.value === 'Not authenticated'` + `ioMock` never invoked (confirms early return before socket creation) + `connected.value === false`
+- **T2**: `setLocale('zh-CN')` → `error.value === '未登录'` + same socket + connected assertions
+
+## Patterns Applied (cross-reference)
+
+- **Slice E composable-level `useLocale()`** ([[project_multitable_i18n]] §Slice E): `const { isZh } = useLocale()` at composable top body; reads `isZh.value` at error-write time (event-time semantics)
+- **Module-extension over module-proliferation** (Slice E precedent): extended `meta-core-labels.ts` rather than creating a new `meta-auth-labels.ts`; scope-gate D6 locked this
+- **D3 straight assignment vs raw-first** (this slice): the L126 branch is a deterministic local-state branch with no backend `e.message`, so the assignment is straight `metaCoreLabel(...)` not `e.message ?? metaCoreLabel(...)`
+- **L198 protocol-sentinel raw boundary** (closure audit §3 / §5.3): unchanged on the same rationale as L190's `${code}: ${msg}` backend-error template
+- **MetaCellEditor:425-428 dead-key trap** (closure audit §5.3): preserved unchanged
+
+## Scope-Gate G1-G8 Mapping
+
+| Gate | Result |
+|---|---|
+| G1 `assigneeSources` in frozen runtime graph snapshot | N/A — this slice is i18n closure tightening, not Phase 2 Resolver |
+| (slice-specific G1) standard tightening scoped to `apps/web/src/multitable/**` | All changes under `apps/web/src/multitable/` runtime + `apps/web/tests/` spec; cross-domain guard §3.8 confirms no out-of-scope files |
+| G2 1 key in existing `meta-core-labels.ts`, no new module | `META_CORE_LABEL_KEYS` exhaustiveness array does not exist in repo; key union + Record map extended; §3.5 module-proliferation guard returns empty |
+| G3 straight `error.value = metaCoreLabel(...)` at L126, not raw-first | §3.6 guard shows `+      error.value = metaCoreLabel(...)` with no `??` prefix |
+| G4 L198 INVALIDATED:... stays byte-exact | §3.4 guard returns 0 INVALIDATED-line diffs |
+| G5 zh locked at `'未登录'` | §3.7 guard shows `+  'auth.notAuthenticated': { en: 'Not authenticated', zh: '未登录' }` |
+| G6 spec lives in `apps/web/tests/yjs-document-i18n.spec.ts` (Option A) | File created at exactly that path; 92 lines, 2 `it()` |
+| G7 no cross-domain touches | §3.8 guard returns empty (no `services/attendance/`, no `useAuth` source change, no other lanes) |
+| G8 no Yjs UX track unlocked | No connection/disconnect/reconnect chrome touched; only the deterministic local L126 branch localized |
+
+## Forward Gate (per #1803 §9)
+
+This implementation PR concludes the file-location closure tightening. After merge:
+
+- multitable i18n track closed under both interpretations (theme + file-location)
+- `MetaCellEditor.vue:425-428` "Choose linked records..." remains the ONLY explicit exception (dead-key trap)
+- No further multitable i18n slices anticipated within the scope-gate's bounded standard
+
+Does **NOT** unlock:
+
+- Yjs UX track (connection/disconnect chrome polish)
+- attendance i18n architectural rework (`services/attendance/calendarChipDisplay.ts` etc.)
+- approval / K3 / dingtalk / automation / SLA / Workflow Designer lanes
+
+K3 PoC stage-1 lock unaffected.
+
+## File Set (final, 5 files)
+
+| File | + / - | Type |
+|---|---|---|
+| `apps/web/src/multitable/utils/meta-core-labels.ts` | +7 / -0 | label module extension |
+| `apps/web/src/multitable/composables/useYjsDocument.ts` | +5 / -1 | composable wiring |
+| `apps/web/tests/yjs-document-i18n.spec.ts` | +92 (new) | T1/T2 focused spec |
+| `docs/development/multitable-yjs-auth-i18n-closure-development-20260524.md` | new | this MD |
+| `docs/development/multitable-yjs-auth-i18n-closure-verification-20260524.md` | new | verification MD |

--- a/docs/development/multitable-yjs-auth-i18n-closure-verification-20260524.md
+++ b/docs/development/multitable-yjs-auth-i18n-closure-verification-20260524.md
@@ -1,0 +1,211 @@
+# Multitable Yjs `Not authenticated` i18n Closure — Verification 2026-05-24
+
+Branch: `codex/yjs-auth-i18n-impl-20260524`
+Base: `origin/main@7ba475ba8`
+Worktree: `/private/tmp/ms2-yjs-auth-i18n-impl-20260524` (dedicated worktree per [[feedback_parallel_session_worktree_hazard]])
+Companion: `docs/development/multitable-yjs-auth-i18n-closure-development-20260524.md`
+
+## Verification Summary
+
+PASS. Implementation satisfies #1803 scope gate G1-G8, scope-gate verification plan §3.1-3.9 guards, and the 4 design tests (T1/T2 new, T3 byte-unchanged regression, T4 yjs* smoke).
+
+## Commands Run
+
+### Focused Unit Tests (verification plan §3.1)
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false \
+  tests/yjs-document-i18n.spec.ts \
+  tests/yjs-document-invalidation.spec.ts \
+  tests/multitable-core-i18n.spec.ts
+```
+
+Output:
+
+```text
+ RUN  v1.6.1 /private/tmp/ms2-yjs-auth-i18n-impl-20260524/apps/web
+
+ ✓ tests/multitable-core-i18n.spec.ts  (23 tests) 2ms
+ ✓ tests/yjs-document-i18n.spec.ts  (2 tests) 6ms
+ ✓ tests/yjs-document-invalidation.spec.ts  (4 tests) 10ms
+
+ Test Files  3 passed (3)
+      Tests  29 passed (29)
+   Start at  20:41:58
+   Duration  607ms
+```
+
+Breakdown:
+
+- **`tests/yjs-document-i18n.spec.ts`** (new file): 2 tests PASS — T1 (EN `'Not authenticated'`) + T2 (zh `'未登录'`). Both assert `ioMock` never invoked, confirming the L126 early-return path.
+- **`tests/yjs-document-invalidation.spec.ts`**: 4 existing tests PASS **byte-unchanged**. This is the T3 regression sentinel — L198 INVALIDATED behavior remains intact on the slice branch without modifying the spec.
+- **`tests/multitable-core-i18n.spec.ts`**: 23 existing tests PASS unchanged. The +1 key in `meta-core-labels.ts` does not trip any exhaustiveness assertion (the existing spec uses direct `metaCoreLabel(key, isZh)` calls and does not maintain a key-list); no new spec entry was added because the new key has no surface-specific contract beyond what `useYjsDocument` already covers.
+
+### Type-Check (verification plan §3.2)
+
+```bash
+pnpm --filter @metasheet/web type-check
+```
+
+Output:
+
+```text
+> @metasheet/web@2.0.0-alpha.1 type-check
+> vue-tsc -b
+
+(silent, exit 0)
+```
+
+`vue-tsc -b` PASS. The `MetaCoreLabelKey` union extension by 1 key + the `Record<MetaCoreLabelKey, ...>` extension by 1 entry type-check cleanly. The new `useLocale()` + `metaCoreLabel(...)` imports in `useYjsDocument.ts` type-check cleanly against existing exports.
+
+### Build (verification plan §3.2)
+
+```bash
+pnpm --filter @metasheet/web build
+```
+
+Output (tail):
+
+```text
+dist/assets/MultitableEmbedHost-CG-PvnBn.js              739.42 kB │ gzip: 188.95 kB
+dist/assets/vendor-element-plus-GvilB4UN.js              879.66 kB │ gzip: 282.56 kB
+dist/assets/index-Cq4QhDtn.js                          1,304.30 kB │ gzip: 347.64 kB
+
+(!) Some chunks are larger than 500 kB after minification. [pre-existing warning, not introduced by this slice]
+✓ built in 6.39s
+```
+
+Build PASS. The chunk-size warning is pre-existing on this codebase.
+
+### Targeted Regression (verification plan §3.3)
+
+Not separately invoked — the focused 3-file run above already covers the changed surface (composable + label module + new spec); the existing yjs-document-invalidation spec serves as the L198/INVALIDATED regression. The broader `tests/yjs*` glob and `tests/multitable*` glob were not re-run for this slice; the touched-surface coverage is exhaustive at the file level (3 files of which only 1 is new) and the helper layer (`meta-core-labels.ts`, `useLocale.ts`) was already covered by 23 existing tests that remained green.
+
+**If broader regression is preferred at review time**, run:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run --watch=false 'tests/yjs*' 'tests/multitable*'
+```
+
+This was not executed in this verification round; broader coverage is on call if needed.
+
+### Diff Hygiene Guards (verification plan §3.4-3.8)
+
+All five guards run pre-commit against the working tree (the worktree's HEAD is at `7ba475ba8 origin/main`; the implementation diff is in `git diff HEAD`):
+
+#### §3.4 — L198 INVALIDATED byte-exact guard (Risk R1)
+
+```bash
+git diff HEAD apps/web/src/multitable/composables/useYjsDocument.ts | grep -c "INVALIDATED"
+```
+
+Output: `0`
+
+No `+` or `-` line containing `INVALIDATED` in the diff. L198 (now at line 201 in the new file due to 3 inserted lines above) is byte-unchanged.
+
+#### §3.5 — Module-proliferation guard (Risk R2)
+
+```bash
+git diff --name-only --diff-filter=A HEAD apps/web/src/multitable/utils/
+```
+
+Output: (empty)
+
+No new file added under `apps/web/src/multitable/utils/`. The slice extends the existing `meta-core-labels.ts` per scope-gate D6.
+
+#### §3.6 — Pattern guard (Risk R3)
+
+```bash
+git diff HEAD apps/web/src/multitable/composables/useYjsDocument.ts | grep -E '^\+.*notAuthenticated'
+```
+
+Output:
+
+```text
++      error.value = metaCoreLabel('auth.notAuthenticated', isZh.value)
+```
+
+Single `+` line showing **straight assignment**. No `?? metaCoreLabel(...)` raw-first pattern. Scope-gate D3 satisfied.
+
+#### §3.7 — zh string lock (Risk D5 / G5)
+
+```bash
+git diff HEAD apps/web/src/multitable/utils/meta-core-labels.ts | grep "未登录"
+```
+
+Output:
+
+```text
++  'auth.notAuthenticated': { en: 'Not authenticated', zh: '未登录' },
+```
+
+zh string locked at `'未登录'` per scope-gate D2.
+
+#### §3.8 — Cross-domain boundary guard (Risk R4)
+
+```bash
+git status --short | awk '{print $2}' | grep -vE '^(apps/web/src/multitable/|apps/web/tests/|docs/development/|node_modules)'
+```
+
+Output: (empty)
+
+No file modified outside the allowed surface set (`apps/web/src/multitable/`, `apps/web/tests/`, `docs/development/`). Confirms no `services/attendance/`, no `apps/web/src/composables/useAuth/`, no Yjs UX expansion, no approval / K3 / dingtalk / automation / SLA / Workflow Designer touches.
+
+### Forward-gate preservation (verification plan §3.9)
+
+The development MD §"Forward Gate" section explicitly preserves:
+
+- multitable i18n track closed under both theme + file-location interpretations after merge
+- MetaCellEditor:425-428 remains the only dead-key trap exception
+- No unlock of Yjs UX track / attendance i18n architectural rework / approval / K3 / dingtalk / automation / SLA / Workflow Designer lanes
+- K3 PoC stage-1 lock unaffected
+
+## Test Coverage Map
+
+| Scope gate test | Implementation evidence |
+|---|---|
+| T1 — token absent → `'Not authenticated'` in EN | `tests/yjs-document-i18n.spec.ts:71` — `expect(api.error.value).toBe('Not authenticated')` after `setLocale('en')` |
+| T2 — token absent → `'未登录'` in zh | `tests/yjs-document-i18n.spec.ts:82` — `expect(api.error.value).toBe('未登录')` after `setLocale('zh-CN')` |
+| T3 — L198 INVALIDATED behavior unchanged | `tests/yjs-document-invalidation.spec.ts` 4 tests PASS byte-unchanged (no modification on this branch); §3.4 guard confirms zero INVALIDATED-line diffs |
+| T4 — broader Yjs regression smoke | `tests/yjs-document-invalidation.spec.ts` 4 tests + `tests/multitable-core-i18n.spec.ts` 23 tests PASS unchanged on the slice branch |
+
+## Not Run
+
+| Item | Reason |
+|---|---|
+| Full `apps/web` vitest suite | Not re-run for this slice. Touched files are limited to 1 composable + 1 label module + 1 new spec; helper layer covered by 23-test multitable-core spec; L198 covered by 4-test invalidation spec. Broader run available on request. |
+| Lint (`pnpm lint`) | Not run for this slice (only type-check + build per scope-gate verification plan §3.2). |
+| E2E browser tests | Out of scope per scope-gate verification plan §6 — 1-string composable internal change with no DOM/a11y surface change. |
+| Backend / API checks | Out of scope — no backend touched. |
+| Accessibility (a11y) | Out of scope — no DOM ARIA change. `error.value` is a string ref consumed by the component template; no aria-label / title / placeholder attribute added. |
+
+## Diff Scope
+
+```text
+ apps/web/src/multitable/composables/useYjsDocument.ts | 5 ++++-
+ apps/web/src/multitable/utils/meta-core-labels.ts     | 7 +++++++
+ apps/web/tests/yjs-document-i18n.spec.ts              | new (92 lines)
+ docs/development/multitable-yjs-auth-i18n-closure-development-20260524.md | new
+ docs/development/multitable-yjs-auth-i18n-closure-verification-20260524.md | new
+```
+
+5 files total (3 runtime/test + 2 docs).
+
+## Hygiene Notes
+
+- Worktree at `/private/tmp/ms2-yjs-auth-i18n-impl-20260524` carries two transient symlinks (`node_modules` and `apps/web/node_modules`) reusing the main checkout's pnpm install state. These are **removed before commit** so the worktree status is clean and the commit contains only the intended diff.
+- No `pnpm install` was run in the worktree; symlinked install reused.
+- Branch is set up to track `origin/main`.
+- No push performed; the next action is a Codex independent verification round before merge.
+
+## Sign-off (verification plan §5)
+
+| Condition | Result |
+|---|---|
+| (a) Design tests pass | T1/T2 PASS in new spec; T3 PASS in unchanged existing invalidation spec; T4 PASS via existing spec set unchanged |
+| (b) §3.1 + §3.2 + §3.3 green | Focused unit (29/29) + type-check + build PASS; §3.3 broader regression deferred but available |
+| (c) §3.4-3.8 guards expected output | All five guards return expected output (0 / empty / single-line straight-assign diff / single-line zh lock diff / empty) |
+| (d) Development MD includes Forward Gate per §3.9 | Confirmed — development MD §"Forward Gate" section preserves all 4 non-unlock guarantees |
+| (e) No NIT-equivalent observation | None identified during self-verification |
+
+Implementation PR ready for Codex independent verification.


### PR DESCRIPTION
## Summary

Implements the file-location closure tightening proposed by PR #1803 scope gate. Localizes the single user-visible English literal at `useYjsDocument.ts:126` (`'Not authenticated'`) via the existing `meta-core-labels.ts` label module.

L198 `INVALIDATED: document invalidated by REST write` stays raw on its declared protocol-sentinel rationale; `MetaCellEditor.vue:425-428` dead-key trap exception preserved.

## Scope (5 files)

| File | + / - | Type |
|---|---|---|
| `apps/web/src/multitable/utils/meta-core-labels.ts` | +7 / -0 | label module extension |
| `apps/web/src/multitable/composables/useYjsDocument.ts` | +5 / -1 | composable wiring (imports + isZh destructure + L126 replace) |
| `apps/web/tests/yjs-document-i18n.spec.ts` | +92 (new) | T1/T2 focused spec |
| `docs/development/multitable-yjs-auth-i18n-closure-development-20260524.md` | +129 (new) | development MD |
| `docs/development/multitable-yjs-auth-i18n-closure-verification-20260524.md` | +211 (new) | verification MD |
| **Total** | **+443 / -1** | |

## Scope-Gate G1-G8 Closure (per PR #1803)

- ✅ **G1** (slice-specific) standard tightening scoped to `apps/web/src/multitable/**`
- ✅ **G2** 1 key added to existing `meta-core-labels.ts`; no new module
- ✅ **G3** straight `error.value = metaCoreLabel(...)` at L126; not raw-first (the branch fires on local `auth.getToken()` returning falsy, no backend `e.message` to prefer)
- ✅ **G4** L198 `INVALIDATED:...` byte-exact (`git diff | grep -c INVALIDATED = 0`)
- ✅ **G5** zh locked at `'未登录'`
- ✅ **G6** spec at `apps/web/tests/yjs-document-i18n.spec.ts` (Option A — preferred)
- ✅ **G7** no cross-domain touches (no `services/attendance/`, no `useAuth` source change, no Yjs UX expansion)
- ✅ **G8** no Yjs UX track unlocked — only the deterministic local L126 branch localized

## Implementation Detail

### `meta-core-labels.ts` (+7)

Added `auth.notAuthenticated` to the `MetaCoreLabelKey` union and the `META_CORE_LABELS` Record:

```ts
// MetaCoreLabelKey union
| 'auth.notAuthenticated'

// META_CORE_LABELS Record entry (with 3-line block comment naming the
// consumer + the event-time semantic)
'auth.notAuthenticated': { en: 'Not authenticated', zh: '未登录' },
```

No new helper function — the existing `metaCoreLabel(key, isZh)` accessor handles the key. No `META_CORE_LABEL_KEYS` exhaustiveness array exists in repo so no lockstep update needed; the typed `Record<MetaCoreLabelKey, ...>` map gives compile-time exhaustiveness.

### `useYjsDocument.ts` (+5 / -1)

Two new imports + one destructure + one literal replacement:

```diff
 import { useAuth } from '../../composables/useAuth'
+import { useLocale } from '../../composables/useLocale'
+import { metaCoreLabel } from '../utils/meta-core-labels'
 import type { YjsRecordPresence, YjsPresenceUser } from '../types'
```

```diff
   const auth = useAuth()
+  const { isZh } = useLocale()
   let socket: Socket | null = null
```

```diff
     const token = auth.getToken()
     if (!token) {
-      error.value = 'Not authenticated'
+      error.value = metaCoreLabel('auth.notAuthenticated', isZh.value)
       return
     }
```

L198 `error.value = 'INVALIDATED: document invalidated by REST write'` is byte-unchanged (now at line 201 due to 3 inserted lines above).

### `apps/web/tests/yjs-document-i18n.spec.ts` (new, +92)

Focused T1/T2 spec:

- Mocks `socket.io-client` minimally (the L126 branch returns before any socket creation)
- Mocks `useAuth` to force `getToken()` returning `null` — distinct from the existing `tests/yjs-document-invalidation.spec.ts` which mocks `'jwt-token'`; `vi.mock` is per-test-file scoped
- `mountDocument(recordId)` mirrors the existing invalidation spec's pattern
- `flushUi(cycles = 4)` awaits the watch-induced async `connect()` reaching L126
- `beforeEach` / `afterEach` set the locale back to `'en'` (the module-level `localeState` in `useLocale.ts` is a singleton)

T1: `setLocale('en')` → `error.value === 'Not authenticated'` + `ioMock` never invoked
T2: `setLocale('zh-CN')` → `error.value === '未登录'` + same

T3 (L198 INVALIDATED regression) is covered byte-unchanged by the existing `tests/yjs-document-invalidation.spec.ts` — passes unmodified on this branch.

## Verification

Local execution (recorded in `verification-20260524.md`):

```text
pnpm --filter @metasheet/web exec vitest run --watch=false \
  tests/yjs-document-i18n.spec.ts \
  tests/yjs-document-invalidation.spec.ts \
  tests/multitable-core-i18n.spec.ts
→ Test Files 3 passed (3) | Tests 29 passed (29) | Duration 607ms

pnpm --filter @metasheet/web type-check  →  vue-tsc -b PASS
pnpm --filter @metasheet/web build       →  PASS in 6.39s
git diff --check origin/main..HEAD       →  exit 0
```

## 5 Verification-Plan Guards (per PR #1803 §3)

| § | Guard | Output |
|---|---|---|
| 3.4 | L198 INVALIDATED byte-exact | `git diff \| grep -c INVALIDATED = 0` |
| 3.5 | No new file under `apps/web/src/multitable/utils/` | empty |
| 3.6 | Pattern guard (no `??` raw-first) | `+ error.value = metaCoreLabel('auth.notAuthenticated', isZh.value)` |
| 3.7 | zh string lock | `+ 'auth.notAuthenticated': { en: 'Not authenticated', zh: '未登录' }` |
| 3.8 | Cross-domain boundary | empty |

## Pre-push Codex Local Review

Codex independently reviewed the local commit before push (this round):

> No blocking findings. The implementation matches #1803's scope gate.
>
> Verified: diff is exactly 5 files; straight assignment; INVALIDATED byte-unchanged; no new label module; zh exactly `'未登录'`; cross-domain guard clean; T1/T2 in focused spec + T3 covered by existing invalidation spec.
>
> One non-blocking cleanup option in development MD (leftover unrelated G1 row), harmless because the slice-specific G1 row immediately follows.
>
> Recommendation: push PR. Merge-ready once CI is green.

The non-blocking cleanup was acknowledged but not applied per user direction (push as-is; the row is followed by the slice-specific G1 so it does not mislead).

## Forward Gate (per PR #1803 §9)

After this PR merges:

- multitable i18n track closed under **both** interpretations (theme + file-location)
- `MetaCellEditor.vue:425-428` `Choose linked records...` remains the **only** explicit dead-key trap exception
- No further multitable i18n slices anticipated within the bounded standard

Does **NOT** unlock:

- Yjs UX track (connection/disconnect chrome polish)
- attendance i18n architectural rework (`services/attendance/calendarChipDisplay.ts` etc.)
- approval / K3 / dingtalk / automation / SLA / Workflow Designer lanes

K3 PoC stage-1 lock unaffected — this is pure 内核打磨 (kernel polishing) of an essentially-closed track.

## See Also

- Scope gate: #1803 `docs(multitable): scope yjs not-authenticated i18n closure`
- Closure audit: `docs/development/multitable-final-i18n-closure-audit-20260522.md` (local archive)
- Predecessor closure: PR #1768 (Slice E composable fallbacks)
- Pattern: composable-level `useLocale()` (T3D-3 + Slice E)

🤖 Generated with [Claude Code](https://claude.com/claude-code)