### PR TITLE
docs(attendance): fix PR5 closeout admin-assertion snippet object level

### DIFF
--- a/docs/development/attendance-pr5-prod-heartbeat-closeout-20260524.md
+++ b/docs/development/attendance-pr5-prod-heartbeat-closeout-20260524.md
@@ -134,10 +134,14 @@ Step 6 directly proved the gating activates: both admin-only sections rendered.
 **Recorded for any future reuse of the /tmp login script** (NOT being changed now — script is in /tmp only, not in repo): the admin assertion should be a disjunction such as
 
 ```js
+const body = await meResponse.json()
+const user = body.data?.user ?? {}
+const features = body.data?.features ?? {}
+
 const isAttendanceAdmin =
-  meResp.role === 'admin' ||
-  (Array.isArray(meResp.permissions) && meResp.permissions.includes('attendance:admin')) ||
-  meResp.attendanceAdmin === true
+  user.role === 'admin' ||
+  (Array.isArray(user.permissions) && user.permissions.includes('attendance:admin')) ||
+  features.attendanceAdmin === true
 ```
 
 so that any of the three signal channels is sufficient. Not blocking; not patched in this window.


### PR DESCRIPTION
## What

Follow-up P2 docs-accuracy fix on the merged #1810 closeout doc.

The §3.5 admin-assertion snippet (`docs/development/attendance-pr5-prod-heartbeat-closeout-20260524.md`) read the wrong object level:

```js
meResp.role === 'admin' ||
meResp.permissions.includes('attendance:admin') ||
meResp.attendanceAdmin === true
```

But the table directly above it documents the real `/api/auth/me` shape, and the endpoint returns the envelope `{ success: true, data: { user, features } }`:

| Documented signal | Snippet read (old, wrong) |
| --- | --- |
| `data.user.role` | `meResp.role` |
| `data.features.attendanceAdmin` | `meResp.attendanceAdmin` |
| `data.user.permissions[]` | `meResp.permissions` |

Anyone copying the old snippet would read `undefined` at every channel.

## Fix

Destructure the envelope first, then assert against the correct levels:

```js
const body = await meResponse.json()
const user = body.data?.user ?? {}
const features = body.data?.features ?? {}

const isAttendanceAdmin =
  user.role === 'admin' ||
  (Array.isArray(user.permissions) && user.permissions.includes('attendance:admin')) ||
  features.attendanceAdmin === true
```

## Scope

- Docs-only, single file, +7/-3 lines.
- No code, no runtime, no test impact.
- The /tmp login script itself is not in the repo and is unchanged (matching the doc's own "NOT being changed now" note).

🤖 Generated with [Claude Code](https://claude.com/claude-code)