### PR TITLE
fix(integration): require K3 business success evidence

### DIFF
--- a/docs/development/integration-k3wise-business-success-evidence-design-20260525.md
+++ b/docs/development/integration-k3wise-business-success-evidence-design-20260525.md
@@ -1,0 +1,90 @@
+# K3 WISE business success evidence design - 2026-05-25
+
+## Context
+
+Issue #1792 exposed a real K3 WISE write-confirmation gap during the Material
+GATE. MetaSheet reported a one-record Save-only run as `rowsWritten=1`, but K3
+readback could not confirm that the material existed. Direct K3 WebAPI probes
+then showed the important shape:
+
+- HTTP transport can succeed.
+- K3 outer envelope can return `StatusCode=200` and `Message=Successful`.
+- The row-level business payload can still return `FStatus=false`,
+  `FItemID=0`, and field-level validation text.
+
+That means outer HTTP/envelope success is not enough evidence for a K3 write.
+
+## Scope
+
+This slice fixes the runtime interpretation of K3 WISE business responses. It
+does not implement the full customer material template, K3 reference resolution,
+post-save readback templates, BOM write, Submit, or Audit.
+
+Touched runtime surfaces:
+
+- `plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs`
+- `plugins/plugin-integration-core/lib/pipeline-runner.cjs`
+
+## Design
+
+### Save-specific success rule
+
+Generic `businessSuccess()` still exists for login, token, health, submit, and
+audit style calls. It now rejects explicit negative business signals before it
+falls back to the envelope status.
+
+K3 Save uses the stricter `saveBusinessSuccess()` path:
+
+1. Any explicit failure wins:
+   - negative `Data.Code`;
+   - `Result.ResponseStatus.IsSuccess=false`;
+   - row `FStatus=false`;
+   - row or envelope text that clearly indicates failure such as `Faild`,
+     `failed`, `invalid`, `not found`, `no access`, `失败`, `错误`, `不存在`, or
+     `无权限`.
+2. Save success requires business evidence:
+   - configured `saveSuccessPath` / `successPath`; or
+   - positive `Data.Code`; or
+   - explicit success boolean; or
+   - success entity count; or
+   - row `FStatus=true` plus a meaningful id / number.
+3. K3 envelope `StatusCode=200` by itself is insufficient for Save.
+
+### Sanitized business summaries
+
+The adapter now builds one small business-response summary per attempted K3
+operation. The summary records evidence shape, not raw payload values:
+
+- operation;
+- envelope status and message presence;
+- response code and message presence;
+- row count;
+- successful/failed row counts;
+- success entity count;
+- whether an external id or bill number was present.
+
+The persisted summary records only message presence, not raw K3 message text,
+because K3 field-level errors may echo material codes or other customer row
+values.
+
+Pipeline runner persists those summaries to run details under
+`targetWriteSummaries`, after `sanitizeIntegrationPayload()` and size/depth
+limits. This gives operators a run-level explanation for "outer 200, business
+row failed" without storing tokens or full K3 payloads.
+
+### Compatibility
+
+Existing adapter error code compatibility is preserved for Save failures:
+`K3_WISE_SAVE_FAILED` remains the emitted code. The difference is that row-level
+K3 failures now go to the failed path instead of being counted as written.
+
+## Out Of Scope
+
+- No K3 Submit / Audit.
+- No BOM write.
+- No K3 WebAPI read/list runtime.
+- No SQL direct K3 table writes.
+- No DB migration.
+- No frontend UI changes.
+- No full Material template/reference-resolution implementation.
+- No post-save readback implementation in this slice.

--- a/docs/development/integration-k3wise-business-success-evidence-design-20260525.md
+++ b/docs/development/integration-k3wise-business-success-evidence-design-20260525.md
@@ -72,6 +72,10 @@ Pipeline runner persists those summaries to run details under
 limits. This gives operators a run-level explanation for "outer 200, business
 row failed" without storing tokens or full K3 payloads.
 
+The runner caps collected summaries at 50 during the write loop, not only at
+final serialization time, so large runs do not keep sanitizing summaries that
+will be discarded.
+
 ### Compatibility
 
 Existing adapter error code compatibility is preserved for Save failures:

--- a/docs/development/integration-k3wise-business-success-evidence-verification-20260525.md
+++ b/docs/development/integration-k3wise-business-success-evidence-verification-20260525.md
@@ -1,0 +1,128 @@
+# K3 WISE business success evidence verification - 2026-05-25
+
+## Local Verification
+
+All commands were run from `/tmp/ms2-k3-business-success`.
+
+```bash
+node --check plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+node --check plugins/plugin-integration-core/lib/pipeline-runner.cjs
+node --check plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+node --check plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+```
+
+Result: all syntax checks passed.
+
+```bash
+pnpm --dir plugins/plugin-integration-core test:k3-wise-adapters
+```
+
+Result:
+
+```text
+✓ k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed
+```
+
+```bash
+pnpm --dir plugins/plugin-integration-core test:pipeline-runner
+```
+
+Result:
+
+```text
+✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed
+```
+
+## Regression Cases Added
+
+### K3 Save row-level failure is not written
+
+Added adapter coverage for a K3 response with:
+
+```json
+{
+  "StatusCode": 200,
+  "Message": "Successful",
+  "Data": [
+    {
+      "FStatus": false,
+      "FItemID": 0,
+      "FMessage": "unit group parameter invalid"
+    }
+  ]
+}
+```
+
+Expected result:
+
+- `written=0` for that row;
+- `failed=1`;
+- error code remains `K3_WISE_SAVE_FAILED`;
+- response summary reports `success=false` and `failedRowCount=1`.
+
+### K3 `StatusCode=201` + `Message=Faild` is not written
+
+Added adapter coverage for the observed K3 failure spelling:
+
+```json
+{
+  "StatusCode": 201,
+  "Message": "Faild",
+  "Data": [
+    {
+      "FStatus": false,
+      "FItemID": 0,
+      "FMessage": "required unit missing"
+    }
+  ]
+}
+```
+
+Expected result:
+
+- not counted as written;
+- failure is surfaced through the target error path;
+- business summary reports `success=false`.
+
+### K3 Save requires stronger evidence than envelope 200
+
+Added internal assertions:
+
+- generic `businessSuccess()` rejects explicit row-level failure;
+- `saveBusinessSuccess({ StatusCode: 200, Message: "Successful" })` returns
+  false;
+- `saveBusinessSuccess()` returns true only when a row has `FStatus=true` and a
+  meaningful id.
+
+### Run details persist sanitized response summaries
+
+Added pipeline-runner coverage proving adapter `metadata.businessResponses[]`
+is persisted to run details as `targetWriteSummaries[]` after payload
+sanitization.
+
+The test intentionally injects a fake `token` key into the adapter summary and
+asserts the stored run detail contains:
+
+```text
+token = [redacted]
+```
+
+## Deployment Impact
+
+- No migration.
+- No config change.
+- No frontend change.
+- Existing Save failure code stays compatible as `K3_WISE_SAVE_FAILED`.
+- Runs that previously treated K3 outer envelope success as a write may now
+  correctly become `partial` / failed when K3 row-level business status is
+  negative.
+
+## Remaining Work
+
+This PR intentionally does not solve the complete K3 Material reference-field
+write shape. Follow-up work should add a customer-confirmed full Material Save
+template and reference-resolution mapping for fields such as unit group, units,
+accounts, stock, and valuation defaults.
+
+Post-save readback should also be added as a separate optional evidence gate
+after the Save response parser is fixed.

--- a/docs/development/integration-k3wise-business-success-evidence-verification-20260525.md
+++ b/docs/development/integration-k3wise-business-success-evidence-verification-20260525.md
@@ -107,6 +107,13 @@ asserts the stored run detail contains:
 token = [redacted]
 ```
 
+Review follow-up:
+
+- `extractBusinessRows()` now de-duplicates candidate row objects by reference
+  before computing summary counts.
+- `targetWriteSummaries` is capped during the write loop at 50 summaries before
+  sanitization work is performed for discarded entries.
+
 ## Deployment Impact
 
 - No migration.

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -68,6 +68,27 @@ function createK3FetchMock() {
       if (record.FNumber === 'BAD') {
         return jsonResponse(200, { success: false, message: 'invalid material' })
       }
+      if (record.FNumber === 'ROWFAIL') {
+        return jsonResponse(200, {
+          StatusCode: 200,
+          Message: 'Successful',
+          Data: [{ FStatus: false, FItemID: 0, FMessage: 'unit group parameter invalid' }],
+        })
+      }
+      if (record.FNumber === 'STATUS201') {
+        return jsonResponse(200, {
+          StatusCode: 201,
+          Message: 'Faild',
+          Data: [{ FStatus: false, FItemID: 0, FMessage: 'required unit missing' }],
+        })
+      }
+      if (record.FNumber === 'ROWOK') {
+        return jsonResponse(200, {
+          StatusCode: 200,
+          Message: 'Successful',
+          Data: [{ FStatus: true, FItemID: 1001, FNumber: record.FNumber }],
+        })
+      }
       if (parsed.searchParams.get('Token')) {
         return jsonResponse(200, {
           StatusCode: 200,
@@ -390,9 +411,21 @@ async function testK3WebApiAdapter() {
   assert.equal(webApiInternals.businessSuccess({ success: true }, {}), true)
   assert.equal(webApiInternals.businessSuccess({ StatusCode: 200, Data: { Code: 'Y' } }, {}), true)
   assert.equal(webApiInternals.businessSuccess({ StatusCode: 500, Data: { Code: 'N' } }, {}), false)
+  assert.equal(webApiInternals.businessSuccess({
+    StatusCode: 200,
+    Message: 'Successful',
+    Data: [{ FStatus: false, FItemID: 0, FMessage: 'unit group parameter invalid' }],
+  }, {}), false)
+  assert.equal(webApiInternals.businessSuccess({ StatusCode: 201, Message: 'Faild' }, {}), false)
   assert.equal(webApiInternals.businessSuccess({ Result: { ResponseStatus: { IsSuccess: true } } }, {}), true)
   assert.equal(webApiInternals.businessSuccess({ Result: { ResponseStatus: { IsSuccess: false } } }, {}), false)
   assert.equal(webApiInternals.businessSuccess({ id: 'silent-success' }, {}), false)
+  assert.equal(webApiInternals.saveBusinessSuccess({ StatusCode: 200, Message: 'Successful' }, {}), false)
+  assert.equal(webApiInternals.saveBusinessSuccess({
+    StatusCode: 200,
+    Message: 'Successful',
+    Data: [{ FStatus: true, FItemID: 1001 }],
+  }, {}), true)
 
   const invalidBaseUrl = (() => {
     try {
@@ -506,6 +539,48 @@ async function testK3WebApiAuthorityCodeToken() {
   assert.equal(upsert.written, 1)
   assert.equal(upsert.results[0].externalId, 'item-MAT-TOKEN-001')
   assert.equal(upsert.results[0].billNo, 'MAT-TOKEN-001')
+}
+
+async function testK3WebApiSaveBusinessEvidence() {
+  const { fetchImpl } = createK3FetchMock()
+  const adapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      config: {
+        baseUrl: 'https://k3.example.test',
+        autoSubmit: false,
+        autoAudit: false,
+      },
+    }),
+    fetchImpl,
+  })
+
+  const upsert = await adapter.upsert({
+    object: 'material',
+    records: [
+      { FNumber: 'ROWOK', FName: 'Positive row' },
+      { FNumber: 'ROWFAIL', FName: 'Business row fail' },
+      { FNumber: 'STATUS201', FName: 'Envelope fail' },
+    ],
+    keyFields: ['FNumber'],
+  })
+
+  assert.equal(upsert.written, 1, 'only K3 business-positive row counts as written')
+  assert.equal(upsert.failed, 2, 'K3 row-level failures are counted as failed')
+  assert.equal(upsert.results[0].externalId, 1001, 'positive FItemID is surfaced as external id')
+  assert.equal(upsert.results[0].responseSummary.success, true)
+  assert.equal(upsert.results[0].responseSummary.externalIdPresent, true)
+  assert.equal(upsert.errors[0].code, 'K3_WISE_SAVE_FAILED')
+  assert.match(upsert.errors[0].message, /unit group/i)
+  assert.equal(upsert.errors[0].responseSummary.success, false)
+  assert.equal(upsert.errors[0].responseSummary.failedRowCount, 1)
+  assert.equal(upsert.errors[1].code, 'K3_WISE_SAVE_FAILED')
+  assert.match(upsert.errors[1].message, /required unit/i)
+  assert.equal(upsert.metadata.businessResponses.length, 3)
+  assert.deepEqual(
+    upsert.metadata.businessResponses.map((summary) => summary.success),
+    [true, false, false],
+    'business response summaries preserve one entry per attempted save',
+  )
 }
 
 async function testK3SqlServerChannel() {
@@ -850,6 +925,7 @@ async function testK3WebApiAutoFlagCoercion() {
 async function main() {
   await testK3WebApiAdapter()
   await testK3WebApiAuthorityCodeToken()
+  await testK3WebApiSaveBusinessEvidence()
   testSqlServerConnectionConfigNormalization()
   await testK3SqlServerChannel()
   await testK3WebApiAutoFlagCoercion()

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -510,6 +510,50 @@ async function main() {
   assert.equal(errorOnly.db.tables.get('integration_dead_letters')[0].error_code, 'ERP_REJECTED')
   assert.equal(await errorOnly.db.selectOne('integration_watermarks', { pipeline_id: 'pipe_1' }), null, 'error-only target result does not advance watermark')
 
+  // --- 4c.1b. Adapter business summaries are persisted on run details ---
+  const targetSummary = createRunnerHarness({
+    sourceRecords: [
+      { code: 'sum-01', revision: 'r1', qty: '3', name: 'Bolt', updatedAt: '2026-04-24T01:00:00.000Z' },
+    ],
+    targetUpsert: async (input) => createUpsertResult({
+      written: 0,
+      failed: 1,
+      errors: [
+        {
+          key: input.records[0]._integration_idempotency_key,
+          code: 'K3_WISE_SAVE_BUSINESS_FAILED',
+          message: 'unit group parameter invalid',
+          responseSummary: {
+            operation: 'save',
+            success: false,
+            envelopeStatusCode: 200,
+            responseMessagePresent: true,
+            failedRowCount: 1,
+            externalIdPresent: false,
+            token: 'must-redact',
+          },
+        },
+      ],
+      metadata: {
+        businessResponses: [
+          {
+            operation: 'save',
+            success: false,
+            envelopeStatusCode: 200,
+            responseMessagePresent: true,
+            failedRowCount: 1,
+            token: 'must-redact',
+          },
+        ],
+      },
+    }),
+  })
+  const targetSummaryRun = await targetSummary.runner.runPipeline({ tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'incremental', triggeredBy: 'manual' })
+  assert.equal(targetSummaryRun.run.status, 'partial')
+  assert.equal(targetSummaryRun.run.details.targetWriteSummaries.length, 1)
+  assert.equal(targetSummaryRun.run.details.targetWriteSummaries[0].success, false)
+  assert.equal(targetSummaryRun.run.details.targetWriteSummaries[0].token, '[redacted]')
+
   // --- 4c.2. Itemized plus aggregate failures preserve replay evidence ---
   const mixedFailure = createRunnerHarness({
     sourceRecords: [

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -121,6 +121,145 @@ function firstDefined(...values) {
   return undefined
 }
 
+function normalizeBusinessBoolean(value) {
+  if (value === undefined || value === null || value === '') return null
+  if (typeof value === 'boolean') return value
+  if (typeof value === 'number') {
+    if (value === 1) return true
+    if (value === 0) return false
+    return null
+  }
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    if (normalized.length === 0) return null
+    if (['true', '1', 'yes', 'y', 'success', 'successful', 'ok', '是', '成功'].includes(normalized)) return true
+    if (['false', '0', 'no', 'n', 'fail', 'failed', 'faild', 'failure', 'error', '否', '失败', '错误'].includes(normalized)) return false
+  }
+  return null
+}
+
+function businessTextIndicatesFailure(value) {
+  if (typeof value !== 'string' || value.trim().length === 0) return false
+  return /\b(faild|failed|failure|error|invalid|denied|not\s+exist|not\s+found|no\s+access)\b/i.test(value) ||
+    /失败|错误|不存在|无权限|无权|非法|无效/.test(value)
+}
+
+function getStatusCode(data) {
+  return toPositiveNumber(firstDefined(getPath(data, 'StatusCode'), getPath(data, 'statusCode')))
+}
+
+function getDataCode(data) {
+  return firstDefined(getPath(data, 'Data.Code'), getPath(data, 'data.code'))
+}
+
+function getSuccessEntityCount(data) {
+  const successEntities = firstDefined(
+    getPath(data, 'Result.ResponseStatus.SuccessEntitys'),
+    getPath(data, 'Result.ResponseStatus.SuccessEntities'),
+    getPath(data, 'Data.SuccessEntitys'),
+    getPath(data, 'Data.SuccessEntities'),
+  )
+  return Array.isArray(successEntities) ? successEntities.length : 0
+}
+
+function businessRowMessage(row) {
+  return firstDefined(
+    getPath(row, 'FMessage'),
+    getPath(row, 'Message'),
+    getPath(row, 'message'),
+    getPath(row, 'ErrorMessage'),
+    getPath(row, 'errorMessage'),
+    getPath(row, 'FErrMessage'),
+    getPath(row, 'ErrMessage'),
+  )
+}
+
+function businessRowStatus(row) {
+  return normalizeBusinessBoolean(firstDefined(
+    getPath(row, 'FStatus'),
+    getPath(row, 'fStatus'),
+    getPath(row, 'status'),
+    getPath(row, 'Status'),
+    getPath(row, 'success'),
+    getPath(row, 'Success'),
+    getPath(row, 'IsSuccess'),
+    getPath(row, 'isSuccess'),
+  ))
+}
+
+function isMeaningfulIdentifier(value) {
+  if (value === undefined || value === null || value === '') return false
+  if (typeof value === 'number') return Number.isFinite(value) && value > 0
+  if (typeof value === 'string') {
+    const normalized = value.trim().toLowerCase()
+    return normalized.length > 0 && !['0', 'null', 'undefined', 'none'].includes(normalized)
+  }
+  return true
+}
+
+function businessRowHasIdentifier(row) {
+  return isMeaningfulIdentifier(firstDefined(
+    getPath(row, 'FItemID'),
+    getPath(row, 'FItemId'),
+    getPath(row, 'FId'),
+    getPath(row, 'FID'),
+    getPath(row, 'Id'),
+    getPath(row, 'id'),
+    getPath(row, 'Number'),
+    getPath(row, 'FNumber'),
+  ))
+}
+
+function extractBusinessRows(data) {
+  const rows = []
+  const candidates = [
+    getPath(data, 'Data'),
+    getPath(data, 'data'),
+    getPath(data, 'Result.Data'),
+    getPath(data, 'Result.ResponseStatus.SuccessEntitys'),
+    getPath(data, 'Result.ResponseStatus.SuccessEntities'),
+  ]
+  for (const candidate of candidates) {
+    if (Array.isArray(candidate)) {
+      rows.push(...candidate.filter(isPlainObject))
+    } else if (isPlainObject(candidate) && (
+      businessRowStatus(candidate) !== null ||
+      businessRowMessage(candidate) !== undefined ||
+      businessRowHasIdentifier(candidate)
+    )) {
+      rows.push(candidate)
+    }
+  }
+  return rows
+}
+
+function hasExplicitBusinessFailure(data) {
+  const dataCode = getDataCode(data)
+  if (typeof dataCode === 'string' && ['N', 'NO', 'FALSE', 'FAILED', 'FAILD', 'ERROR'].includes(dataCode.trim().toUpperCase())) return true
+  const responseSuccess = normalizeBusinessBoolean(getPath(data, 'Result.ResponseStatus.IsSuccess'))
+  if (responseSuccess === false) return true
+  for (const row of extractBusinessRows(data)) {
+    if (businessRowStatus(row) === false) return true
+    if (businessTextIndicatesFailure(businessRowMessage(row))) return true
+  }
+  return businessTextIndicatesFailure(firstDefined(getPath(data, 'Message'), getPath(data, 'message')))
+}
+
+function hasExplicitBusinessSuccess(data) {
+  const dataCode = getDataCode(data)
+  if (typeof dataCode === 'string' && ['Y', 'YES', 'TRUE', 'SUCCESS', 'OK'].includes(dataCode.trim().toUpperCase())) return true
+  const candidates = [
+    getPath(data, 'success'),
+    getPath(data, 'ok'),
+    getPath(data, 'Success'),
+    getPath(data, 'IsSuccess'),
+    getPath(data, 'Result.ResponseStatus.IsSuccess'),
+  ]
+  if (candidates.some((candidate) => normalizeBusinessBoolean(candidate) === true)) return true
+  if (getSuccessEntityCount(data) > 0) return true
+  return extractBusinessRows(data).some((row) => businessRowStatus(row) === true && businessRowHasIdentifier(row))
+}
+
 // Tri-state coercion for autoSubmit / autoAudit decision logic.
 // Returns true / false for any boolean-like input, or null when the field is
 // truly unset (undefined / null / ""). The decision logic at upsert-time uses
@@ -281,29 +420,30 @@ function buildLifecycleBody(record, request, objectConfig, operation) {
 }
 
 function businessSuccess(data, config) {
+  if (hasExplicitBusinessFailure(data)) return false
   if (config.successPath) return Boolean(getPath(data, config.successPath))
-  const statusCode = toPositiveNumber(firstDefined(getPath(data, 'StatusCode'), getPath(data, 'statusCode')))
-  const dataCode = firstDefined(getPath(data, 'Data.Code'), getPath(data, 'data.code'))
-  if (typeof dataCode === 'string' && ['N', 'NO', 'FALSE', 'FAILED', 'ERROR'].includes(dataCode.trim().toUpperCase())) return false
+  const statusCode = getStatusCode(data)
+  const dataCode = getDataCode(data)
   if (typeof dataCode === 'string' && ['Y', 'YES', 'TRUE', 'SUCCESS', 'OK'].includes(dataCode.trim().toUpperCase())) return true
   if (statusCode !== null) return statusCode >= 200 && statusCode < 300
-  const candidates = [
-    getPath(data, 'success'),
-    getPath(data, 'ok'),
-    getPath(data, 'Success'),
-    getPath(data, 'IsSuccess'),
-    getPath(data, 'Result.ResponseStatus.IsSuccess'),
-  ]
-  for (const candidate of candidates) {
-    if (candidate === true || candidate === 'true' || candidate === 1 || candidate === '1') return true
-    if (candidate === false || candidate === 'false' || candidate === 0 || candidate === '0') return false
-  }
+  if (hasExplicitBusinessSuccess(data)) return true
   return false
+}
+
+function saveBusinessSuccess(data, config) {
+  if (hasExplicitBusinessFailure(data)) return false
+  if (config.saveSuccessPath) return Boolean(getPath(data, config.saveSuccessPath))
+  if (config.successPath) return Boolean(getPath(data, config.successPath))
+  return hasExplicitBusinessSuccess(data)
 }
 
 function responseMessage(data, config, fallback = 'K3 WISE WebAPI business response failed') {
   return firstDefined(
     config.messagePath ? getPath(data, config.messagePath) : undefined,
+    getPath(data, 'Data.0.FMessage'),
+    getPath(data, 'Data.0.Message'),
+    getPath(data, 'Data.0.ErrorMessage'),
+    getPath(data, 'Data.0.FErrMessage'),
     getPath(data, 'message'),
     getPath(data, 'Message'),
     getPath(data, 'error'),
@@ -320,11 +460,31 @@ function responseCode(data, config, fallback = 'OK') {
     getPath(data, 'Code'),
     getPath(data, 'errorCode'),
     getPath(data, 'ErrorCode'),
+    getPath(data, 'Data.0.Code'),
+    getPath(data, 'Data.0.ErrorCode'),
     getPath(data, 'StatusCode'),
     getPath(data, 'Data.Code'),
     getPath(data, 'Result.ResponseStatus.ErrorCode'),
     fallback,
   )
+}
+
+function responseFailureCode(data, config, fallback) {
+  const explicit = firstDefined(
+    config.responseCodePath ? getPath(data, config.responseCodePath) : undefined,
+    getPath(data, 'code'),
+    getPath(data, 'Code'),
+    getPath(data, 'errorCode'),
+    getPath(data, 'ErrorCode'),
+    getPath(data, 'Data.0.Code'),
+    getPath(data, 'Data.0.ErrorCode'),
+    getPath(data, 'Data.Code'),
+    getPath(data, 'Result.ResponseStatus.ErrorCode'),
+  )
+  if (explicit !== undefined && explicit !== null && explicit !== '') return explicit
+  const statusCode = getStatusCode(data)
+  if (statusCode !== null && (statusCode < 200 || statusCode >= 300)) return statusCode
+  return fallback
 }
 
 function responseBillNo(data, config) {
@@ -335,24 +495,54 @@ function responseBillNo(data, config) {
     getPath(data, 'number'),
     getPath(data, 'Number'),
     getPath(data, 'Data.FBillNo'),
+    getPath(data, 'Data.0.FBillNo'),
     getPath(data, 'Data.FNumber'),
+    getPath(data, 'Data.0.FNumber'),
     getPath(data, 'Result.Number'),
     getPath(data, 'Result.ResponseStatus.SuccessEntitys.0.Number'),
   )
 }
 
 function responseExternalId(data, config) {
-  return firstDefined(
+  const candidates = [
     config.externalIdPath ? getPath(data, config.externalIdPath) : undefined,
     getPath(data, 'externalId'),
     getPath(data, 'id'),
     getPath(data, 'Id'),
     getPath(data, 'FItemID'),
     getPath(data, 'Data.FItemID'),
+    getPath(data, 'Data.0.FItemID'),
     getPath(data, 'Data.Id'),
+    getPath(data, 'Data.0.Id'),
     getPath(data, 'Result.Id'),
     getPath(data, 'Result.ResponseStatus.SuccessEntitys.0.Id'),
-  )
+  ]
+  return candidates.find(isMeaningfulIdentifier)
+}
+
+function createBusinessResponseSummary(data, config, { operation, success }) {
+  const rows = extractBusinessRows(data)
+  const rowStatuses = rows.map((row) => businessRowStatus(row)).filter((value) => value !== null)
+  const failedRows = rowStatuses.filter((value) => value === false).length
+  const successfulRows = rowStatuses.filter((value) => value === true).length
+  const externalId = responseExternalId(data, config)
+  const billNo = responseBillNo(data, config)
+  const message = responseMessage(data, config, null)
+  return {
+    operation,
+    success: Boolean(success),
+    envelopeStatusCode: firstDefined(getPath(data, 'StatusCode'), getPath(data, 'statusCode'), null),
+    envelopeMessagePresent: firstDefined(getPath(data, 'Message'), getPath(data, 'message')) !== undefined,
+    dataCode: firstDefined(getPath(data, 'Data.Code'), getPath(data, 'data.code'), null),
+    responseCode: responseCode(data, config, null),
+    responseMessagePresent: message !== undefined && message !== null && message !== '',
+    rowCount: rows.length,
+    successfulRowCount: successfulRows,
+    failedRowCount: failedRows,
+    successEntityCount: getSuccessEntityCount(data),
+    externalIdPresent: isMeaningfulIdentifier(externalId),
+    billNoPresent: isMeaningfulIdentifier(billNo),
+  }
 }
 
 function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logger } = {}) {
@@ -635,6 +825,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
     const results = []
     const errors = []
     const raw = []
+    const businessResponses = []
 
     for (let index = 0; index < request.records.length; index += 1) {
       const record = request.records[index]
@@ -646,11 +837,18 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
           headers: authContext.headers,
           body: buildSaveBody(record, request, objectConfig),
         })
-        raw.push({ index, operation: 'save', body: save.data })
-        if (!businessSuccess(save.data, config)) {
+        const saveSucceeded = saveBusinessSuccess(save.data, config)
+        const saveSummary = createBusinessResponseSummary(save.data, config, {
+          operation: 'save',
+          success: saveSucceeded,
+        })
+        raw.push({ index, operation: 'save', body: save.data, summary: saveSummary })
+        businessResponses.push({ index, object: request.object, ...saveSummary })
+        if (!saveSucceeded) {
           throw new K3WiseWebApiAdapterError(String(responseMessage(save.data, config)), {
-            code: responseCode(save.data, config, 'K3_WISE_SAVE_FAILED'),
+            code: responseFailureCode(save.data, config, 'K3_WISE_SAVE_FAILED'),
             body: save.data,
+            responseSummary: saveSummary,
             object: request.object,
             key,
           })
@@ -670,11 +868,18 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
             headers: authContext.headers,
             body: buildLifecycleBody(record, request, objectConfig, 'submit'),
           })
-          raw.push({ index, operation: 'submit', body: submit.data })
-          if (!businessSuccess(submit.data, config)) {
+          const submitSucceeded = businessSuccess(submit.data, config)
+          const submitSummary = createBusinessResponseSummary(submit.data, config, {
+            operation: 'submit',
+            success: submitSucceeded,
+          })
+          raw.push({ index, operation: 'submit', body: submit.data, summary: submitSummary })
+          businessResponses.push({ index, object: request.object, ...submitSummary })
+          if (!submitSucceeded) {
             throw new K3WiseWebApiAdapterError(String(responseMessage(submit.data, config)), {
               code: responseCode(submit.data, config, 'K3_WISE_SUBMIT_FAILED'),
               body: submit.data,
+              responseSummary: submitSummary,
               object: request.object,
               key,
             })
@@ -695,11 +900,18 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
             headers: authContext.headers,
             body: buildLifecycleBody(record, request, objectConfig, 'audit'),
           })
-          raw.push({ index, operation: 'audit', body: audit.data })
-          if (!businessSuccess(audit.data, config)) {
+          const auditSucceeded = businessSuccess(audit.data, config)
+          const auditSummary = createBusinessResponseSummary(audit.data, config, {
+            operation: 'audit',
+            success: auditSucceeded,
+          })
+          raw.push({ index, operation: 'audit', body: audit.data, summary: auditSummary })
+          businessResponses.push({ index, object: request.object, ...auditSummary })
+          if (!auditSucceeded) {
             throw new K3WiseWebApiAdapterError(String(responseMessage(audit.data, config)), {
               code: responseCode(audit.data, config, 'K3_WISE_AUDIT_FAILED'),
               body: audit.data,
+              responseSummary: auditSummary,
               object: request.object,
               key,
             })
@@ -715,6 +927,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
           billNo: responseBillNo(save.data, config),
           responseCode: responseCode(save.data, config, 'OK'),
           responseMessage: responseMessage(save.data, config, 'K3 WISE save succeeded'),
+          responseSummary: saveSummary,
           raw: save.data,
         })
       } catch (error) {
@@ -724,6 +937,9 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
           object: request.object,
           code: error && error.details && error.details.code ? error.details.code : 'K3_WISE_UPSERT_FAILED',
           message: error && error.message ? error.message : String(error),
+          responseSummary: error && error.details && error.details.responseSummary
+            ? error.details.responseSummary
+            : undefined,
         })
       }
     }
@@ -739,6 +955,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
         autoSubmit,
         autoAudit,
         k3Template: objectConfig.k3Template ? { ...objectConfig.k3Template } : undefined,
+        businessResponses,
       },
     })
   }
@@ -773,5 +990,6 @@ module.exports = {
     responseBillNo,
     responseCode,
     responseExternalId,
+    saveBusinessSuccess,
   },
 }

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -211,7 +211,7 @@ function businessRowHasIdentifier(row) {
 }
 
 function extractBusinessRows(data) {
-  const rows = []
+  const rows = new Set()
   const candidates = [
     getPath(data, 'Data'),
     getPath(data, 'data'),
@@ -221,16 +221,16 @@ function extractBusinessRows(data) {
   ]
   for (const candidate of candidates) {
     if (Array.isArray(candidate)) {
-      rows.push(...candidate.filter(isPlainObject))
+      candidate.filter(isPlainObject).forEach((row) => rows.add(row))
     } else if (isPlainObject(candidate) && (
       businessRowStatus(candidate) !== null ||
       businessRowMessage(candidate) !== undefined ||
       businessRowHasIdentifier(candidate)
     )) {
-      rows.push(candidate)
+      rows.add(candidate)
     }
   }
-  return rows
+  return Array.from(rows)
 }
 
 function hasExplicitBusinessFailure(data) {

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -558,8 +558,9 @@ function createPipelineRunner(deps = {}) {
             keyFields: ['_integration_idempotency_key'],
             options: resolveTargetOptions(context.pipeline),
           }), cleanRecords)
-          if (writeResult.metadata && Array.isArray(writeResult.metadata.businessResponses)) {
-            targetWriteSummaries.push(...writeResult.metadata.businessResponses.map((summary) => sanitizeIntegrationPayload(summary, {
+          if (writeResult.metadata && Array.isArray(writeResult.metadata.businessResponses) && targetWriteSummaries.length < 50) {
+            const remainingTargetWriteSummarySlots = 50 - targetWriteSummaries.length
+            targetWriteSummaries.push(...writeResult.metadata.businessResponses.slice(0, remainingTargetWriteSummarySlots).map((summary) => sanitizeIntegrationPayload(summary, {
               maxDepth: 4,
               maxArrayItems: 20,
               maxStringLength: 500,
@@ -645,7 +646,7 @@ function createPipelineRunner(deps = {}) {
             nextCursor: cursor,
             erpFeedback,
             ...(targetWriteSummaries.length > 0 && {
-              targetWriteSummaries: targetWriteSummaries.slice(0, 50),
+              targetWriteSummaries,
             }),
             maxPagesReached,
             pagesProcessed: page,

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -182,6 +182,7 @@ function buildUnmatchedTargetErrorPayload(error = {}) {
     key: errorKey(error) || null,
     code: error.code || null,
     message: error.message || null,
+    responseSummary: error.responseSummary || null,
   }
 }
 
@@ -515,6 +516,7 @@ function createPipelineRunner(deps = {}) {
       let lastSuccessfulWatermark = null
       let exitedNormally = false
       const erpFeedback = []
+      const targetWriteSummaries = []
       let remainingDryRunSamples = dryRun && Number.isInteger(input.sampleLimit) && input.sampleLimit > 0
         ? input.sampleLimit
         : null
@@ -556,6 +558,14 @@ function createPipelineRunner(deps = {}) {
             keyFields: ['_integration_idempotency_key'],
             options: resolveTargetOptions(context.pipeline),
           }), cleanRecords)
+          if (writeResult.metadata && Array.isArray(writeResult.metadata.businessResponses)) {
+            targetWriteSummaries.push(...writeResult.metadata.businessResponses.map((summary) => sanitizeIntegrationPayload(summary, {
+              maxDepth: 4,
+              maxArrayItems: 20,
+              maxStringLength: 500,
+              maxBytes: 12000,
+            })))
+          }
           metrics.rowsWritten += writeResult.written || 0
           metrics.rowsFailed += writeResult.failed || 0
           const targetErrors = writeResult.errors || []
@@ -634,6 +644,9 @@ function createPipelineRunner(deps = {}) {
             watermarkAdvanced: !dryRun && metrics.rowsFailed === 0 && Boolean(lastSuccessfulWatermark),
             nextCursor: cursor,
             erpFeedback,
+            ...(targetWriteSummaries.length > 0 && {
+              targetWriteSummaries: targetWriteSummaries.slice(0, 50),
+            }),
             maxPagesReached,
             pagesProcessed: page,
           },


### PR DESCRIPTION
## Summary

Fixes the K3 WISE Save-only evidence gap exposed in #1792: MetaSheet must not count a K3 write as `rowsWritten=1` when only HTTP / outer K3 envelope succeeded but the business row returned failure, such as `FStatus=false` / `FItemID=0`.

## Changes

- Adds stricter K3 Save success evaluation:
  - explicit business failures win over HTTP/envelope success;
  - `StatusCode=200` / `Message=Successful` alone is not enough for Save;
  - Save requires business-positive evidence such as success entity count or row `FStatus=true` plus meaningful id/number.
- Preserves existing Save failure code compatibility as `K3_WISE_SAVE_FAILED`.
- Adds sanitized `targetWriteSummaries` to run details via adapter `metadata.businessResponses`:
  - status/code/count/id-presence evidence only;
  - no raw K3 payload;
  - message text is not persisted, only message presence.
- Adds regression tests for:
  - outer 200 + row `FStatus=false` -> failed, not written;
  - `StatusCode=201` + `Message=Faild` -> failed;
  - positive row status + id -> written;
  - run details summary sanitizes sensitive keys.

## Verification

- `node --check plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs`
- `node --check plugins/plugin-integration-core/lib/pipeline-runner.cjs`
- `node --check plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`
- `node --check plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs`
- `pnpm --dir plugins/plugin-integration-core test:k3-wise-adapters`
- `pnpm --dir plugins/plugin-integration-core test:pipeline-runner`
- `pnpm --dir plugins/plugin-integration-core test`
- `git diff --cached --check`

## Out of scope

- No K3 Submit / Audit.
- No BOM write.
- No K3 read/list runtime.
- No DB migration.
- No frontend change.
- No full Material reference-field template or post-save readback implementation in this PR.
