### PR TITLE
fix(auth): clear local session on logout

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -77,7 +77,7 @@ import { usePlugins } from './composables/usePlugins'
 import { setMultitableApiErrorLocaleResolver } from './multitable/api/client'
 import { resolveRouteDocumentTitle } from './router/routeTitles'
 import { useFeatureFlags } from './stores/featureFlags'
-import { getApiBase } from './utils/api'
+import { clearStoredAuthState, getApiBase } from './utils/api'
 
 const route = useRoute()
 const { navItems: pluginNavItems, fetchPlugins } = usePlugins()
@@ -186,12 +186,9 @@ async function logout(): Promise<void> {
   }
   clearToken()
   try {
-    if (typeof localStorage !== 'undefined') {
-      localStorage.removeItem('metasheet_features')
-      localStorage.removeItem('metasheet_product_mode')
-    }
+    clearStoredAuthState()
   } catch {
-    // Ignore feature cache cleanup failures.
+    // Ignore local session cleanup failures; logout should still leave the view.
   }
   window.location.assign('/login')
 }

--- a/apps/web/tests/App.spec.ts
+++ b/apps/web/tests/App.spec.ts
@@ -1,32 +1,39 @@
-import { afterEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick, ref, type App as VueApp, type Component } from 'vue'
 import App from '../src/App.vue'
 import { setMultitableApiErrorLocaleResolver } from '../src/multitable/api/client'
 
-const loadProductFeatures = vi.fn().mockResolvedValue(undefined)
-const fetchPlugins = vi.fn().mockResolvedValue(undefined)
-
-vi.mock('vue-router', () => ({
-  useRoute: () => ({
+const mocks = vi.hoisted(() => ({
+  route: {
     path: '/login',
+    fullPath: '/login',
     meta: {
       hideNavbar: true,
       requiresGuest: true,
-    },
-  }),
+    } as Record<string, unknown>,
+  },
+  loadProductFeatures: vi.fn().mockResolvedValue(undefined),
+  fetchPlugins: vi.fn().mockResolvedValue(undefined),
+  getApiBase: vi.fn(() => 'https://api.example.com'),
+  clearStoredAuthState: vi.fn(),
+}))
+
+vi.mock('vue-router', () => ({
+  useRoute: () => mocks.route,
 }))
 
 vi.mock('../src/composables/usePlugins', () => ({
   usePlugins: () => ({
     navItems: ref([]),
-    fetchPlugins,
+    fetchPlugins: mocks.fetchPlugins,
   }),
 }))
 
 vi.mock('../src/stores/featureFlags', () => ({
   useFeatureFlags: () => ({
-    loadProductFeatures,
+    loadProductFeatures: mocks.loadProductFeatures,
     isAttendanceFocused: () => false,
+    isPlmWorkbenchFocused: () => false,
     hasFeature: () => false,
   }),
 }))
@@ -39,11 +46,14 @@ vi.mock('../src/composables/useLocale', () => ({
   }),
 }))
 
-vi.mock('../src/utils/api', () => ({
-  apiFetch: vi.fn(),
-  clearStoredAuthState: vi.fn(),
-  getStoredAuthToken: vi.fn(() => ''),
-}))
+vi.mock('../src/utils/api', async () => {
+  const actual = await vi.importActual<typeof import('../src/utils/api')>('../src/utils/api')
+  return {
+    ...actual,
+    clearStoredAuthState: mocks.clearStoredAuthState,
+    getApiBase: mocks.getApiBase,
+  }
+})
 
 async function flushUi(cycles = 4): Promise<void> {
   for (let i = 0; i < cycles; i += 1) {
@@ -55,6 +65,42 @@ async function flushUi(cycles = 4): Promise<void> {
 describe('App guest bootstrap', () => {
   let app: VueApp<Element> | null = null
   let container: HTMLDivElement | null = null
+  const originalFetch = globalThis.fetch
+  const originalLocation = window.location
+
+  beforeEach(() => {
+    mocks.route.path = '/login'
+    mocks.route.fullPath = '/login'
+    mocks.route.meta = {
+      hideNavbar: true,
+      requiresGuest: true,
+    }
+    mocks.loadProductFeatures.mockResolvedValue(undefined)
+    mocks.fetchPlugins.mockResolvedValue(undefined)
+    mocks.getApiBase.mockReturnValue('https://api.example.com')
+    mocks.clearStoredAuthState.mockImplementation(() => {
+      for (const key of [
+        'auth_token',
+        'jwt',
+        'devToken',
+        'tenantId',
+        'workspaceId',
+        'metasheet_features',
+        'metasheet_product_mode',
+        'user_permissions',
+        'user_roles',
+      ]) {
+        window.localStorage.removeItem(key)
+      }
+    })
+    window.localStorage.clear()
+    globalThis.fetch = vi.fn(async () => new Response('{}', { status: 200 })) as typeof fetch
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    })
+  })
 
   afterEach(() => {
     if (app) app.unmount()
@@ -62,6 +108,12 @@ describe('App guest bootstrap', () => {
     app = null
     container = null
     setMultitableApiErrorLocaleResolver(undefined)
+    globalThis.fetch = originalFetch
+    Object.defineProperty(window, 'location', {
+      value: originalLocation,
+      writable: true,
+      configurable: true,
+    })
     vi.clearAllMocks()
   })
 
@@ -81,8 +133,78 @@ describe('App guest bootstrap', () => {
     app.mount(container)
     await flushUi()
 
-    expect(loadProductFeatures).toHaveBeenCalledTimes(1)
-    expect(loadProductFeatures).toHaveBeenCalledWith(false, { skipSessionProbe: true })
-    expect(fetchPlugins).not.toHaveBeenCalled()
+    expect(mocks.loadProductFeatures).toHaveBeenCalledTimes(1)
+    expect(mocks.loadProductFeatures).toHaveBeenCalledWith(false, { skipSessionProbe: true })
+    expect(mocks.fetchPlugins).not.toHaveBeenCalled()
+  })
+
+  it('clears local auth state and redirects after sign out', async () => {
+    const assign = vi.fn()
+    Object.defineProperty(window, 'location', {
+      value: {
+        ...originalLocation,
+        assign,
+        href: 'https://app.example.com/attendance?tab=admin',
+        origin: 'https://app.example.com',
+        pathname: '/attendance',
+        search: '?tab=admin',
+        hash: '',
+      },
+      writable: true,
+      configurable: true,
+    })
+
+    mocks.route.path = '/attendance'
+    mocks.route.fullPath = '/attendance?tab=admin'
+    mocks.route.meta = {}
+    window.localStorage.setItem('auth_token', 'session-token')
+    window.localStorage.setItem('jwt', 'session-token')
+    window.localStorage.setItem('devToken', 'dev-token')
+    window.localStorage.setItem('metasheet_features', '{"attendance":true}')
+    window.localStorage.setItem('metasheet_product_mode', 'attendance')
+    window.localStorage.setItem('user_permissions', '["attendance:admin"]')
+    window.localStorage.setItem('user_roles', '["admin"]')
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+
+    app = createApp(App as Component)
+    app.component('router-view', { render: () => h('div') })
+    app.component('router-link', {
+      props: ['to'],
+      render() {
+        return h('a', { href: this.$props.to }, this.$slots.default ? this.$slots.default() : [])
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const signOutButton = Array.from(container.querySelectorAll('button'))
+      .find((button) => button.textContent?.includes('退出登录')) as HTMLButtonElement | undefined
+    expect(signOutButton).toBeTruthy()
+
+    signOutButton?.click()
+    await flushUi()
+
+    expect(globalThis.fetch).toHaveBeenCalledWith('https://api.example.com/api/auth/logout', {
+      method: 'POST',
+      headers: {
+        Authorization: 'Bearer session-token',
+      },
+    })
+    expect(mocks.clearStoredAuthState).toHaveBeenCalledTimes(1)
+    for (const key of [
+      'auth_token',
+      'jwt',
+      'devToken',
+      'metasheet_features',
+      'metasheet_product_mode',
+      'user_permissions',
+      'user_roles',
+    ]) {
+      expect(window.localStorage.getItem(key)).toBeNull()
+    }
+    expect(assign).toHaveBeenCalledWith('/login')
   })
 })

--- a/docs/development/auth-logout-local-session-cleanup-verification-20260525.md
+++ b/docs/development/auth-logout-local-session-cleanup-verification-20260525.md
@@ -1,0 +1,58 @@
+# Auth Logout Local Session Cleanup Verification — 2026-05-25
+
+## Summary
+
+Production logout diagnosis showed that the visible `Sign out` button called `POST /api/auth/logout` successfully and a follow-up `/api/auth/me` returned `401`, but the frontend stayed on `/attendance?tab=admin`, retained local auth keys, and rendered a blank page instead of the login screen.
+
+This slice hardens the shell logout path so a successful or failed network logout always clears local auth/session state and redirects to `/login`.
+
+## Change
+
+- `apps/web/src/App.vue`
+  - Continue calling `POST /api/auth/logout` when a token is present.
+  - Keep `clearToken()` to reset the `useAuth()` in-memory session cache.
+  - Call shared `clearStoredAuthState()` so all local auth context keys are cleared in one place:
+    - `auth_token`
+    - `jwt`
+    - `devToken`
+    - tenant hints
+    - user role/permission snapshots
+    - feature/product-mode cache
+  - Keep the final redirect to `/login`.
+
+- `apps/web/tests/App.spec.ts`
+  - Added a regression test that mounts the authenticated shell, clicks `Sign out`, verifies the logout API call, confirms auth/user/feature localStorage keys are cleared, and asserts redirect to `/login`.
+
+## Boundaries
+
+- Frontend shell only.
+- No backend route changes.
+- No database or migration changes.
+- No attendance business logic changes.
+- No production write operations.
+
+## Verification
+
+Commands run from the isolated worktree:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/App.spec.ts --watch=false
+pnpm --filter @metasheet/web type-check
+git diff --check
+```
+
+Results:
+
+- `tests/App.spec.ts`: 2/2 pass.
+- `vue-tsc -b`: pass.
+- `git diff --check`: pass.
+
+## Live Diagnosis Artifact
+
+The production diagnosis evidence for the original behavior is stored outside the repository:
+
+- `/tmp/attendance-logout-only-diagnosis-20260525.md`
+- `/tmp/attendance-logout-before-20260525.png`
+- `/tmp/attendance-logout-after-20260525.png`
+
+The diagnosis did not print tokens, did not use the password login form, and did not perform any production data writes.


### PR DESCRIPTION
## Summary
- harden shell logout to clear the shared local auth/session state after calling /api/auth/logout
- keep the redirect to /login even if cleanup fails
- add a regression spec for clicking Sign out and clearing auth/user/feature localStorage keys
- record the production diagnosis and verification in docs/development/auth-logout-local-session-cleanup-verification-20260525.md

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/App.spec.ts --watch=false
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web build
- git diff --check

## Boundaries
- frontend shell only
- no backend route changes
- no database or migration changes
- no production data writes