### PR TITLE
fix(integration): support K3 Material reference payload shapes

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -235,6 +235,11 @@ export interface K3WiseDocumentTemplate {
     label: string
     type: string
     required?: boolean
+    reference?: {
+      identifier?: string
+      identifierField?: string
+      key?: string
+    }
   }>
   sampleSource: Record<string, unknown>
 }
@@ -307,6 +312,7 @@ const SQLSERVER_KIND = 'erp:k3-wise-sqlserver'
 const K3_WISE_POC_MIN_SAMPLE_LIMIT = 1
 const K3_WISE_POC_MAX_SAMPLE_LIMIT = 3
 const K3_WISE_DOCUMENT_TEMPLATE_VERSION = '2026.05.v1'
+const K3_REFERENCE_BY_NUMBER = { identifier: 'FNumber' }
 const IMPORT_SECRET_KEY_PATTERN =
   /(password|passwd|pwd|secret|sessionid|session_id|cookie|accesskey|access_key|privatekey|private_key|clientsecret|client_secret|authoritycode|authority_code|^token$|access[_-]?token|bearer[_-]?token)/i
 
@@ -323,7 +329,20 @@ const K3_WISE_DOCUMENT_TEMPLATES: Record<K3WisePipelineTarget, K3WiseDocumentTem
       { name: 'FNumber', label: '物料编码', type: 'string', required: true },
       { name: 'FName', label: '物料名称', type: 'string', required: true },
       { name: 'FModel', label: '规格型号', type: 'string' },
-      { name: 'FBaseUnitID', label: '基本单位', type: 'string' },
+      { name: 'FUnitGroupID', label: '单位组', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FBaseUnitID', label: '基本单位', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FOrderUnitID', label: '订货单位', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FSaleUnitID', label: '销售单位', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FProductUnitID', label: '生产单位', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FStoreUnitID', label: '库存单位', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FAcctID', label: '存货科目', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FSaleAcctID', label: '销售科目', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FCostAcctID', label: '成本科目', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FCheckCycle', label: '检验周期', type: 'number' },
+      { name: 'FTrack', label: '跟踪策略', type: 'string' },
+      { name: 'FBatChangeEconomy', label: '批量变动经济量', type: 'number' },
+      { name: 'FStdBatchQty', label: '标准批量', type: 'number' },
+      { name: 'FKanBanCapability', label: '看板能力', type: 'number' },
     ],
     sampleSource: {
       code: 'MAT-001',
@@ -735,11 +754,25 @@ function buildTargetRecordFromTemplate(template: K3WiseDocumentTemplate): Record
   return target
 }
 
+function normalizeReferenceIdentifier(field: K3WiseDocumentTemplate['schema'][number]): string | null {
+  const reference = field.reference
+  if (!reference || typeof reference !== 'object') return null
+  const identifier = reference.identifier || reference.identifierField || reference.key
+  return typeof identifier === 'string' && identifier.trim() ? identifier.trim() : null
+}
+
+function applyReferenceShape(value: unknown, field: K3WiseDocumentTemplate['schema'][number]): unknown {
+  const identifier = normalizeReferenceIdentifier(field)
+  if (!identifier || isBlank(value) || (value && typeof value === 'object' && !Array.isArray(value))) return value
+  return { [identifier]: value }
+}
+
 function projectTargetRecordForTemplate(template: K3WiseDocumentTemplate, record: Record<string, unknown>): Record<string, unknown> {
   const projected: Record<string, unknown> = {}
   template.schema.forEach((field) => {
     if (Object.prototype.hasOwnProperty.call(record, field.name)) {
-      projected[field.name] = record[field.name]
+      const value = applyReferenceShape(record[field.name], field)
+      if (!isBlank(value)) projected[field.name] = value
     }
   })
   return projected

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -610,7 +610,7 @@ describe('K3 WISE setup helpers', () => {
         FNumber: 'MAT-001',
         FName: 'Bolt',
         FModel: 'M6 x 20',
-        FBaseUnitID: 'Pcs',
+        FBaseUnitID: { FNumber: 'Pcs' },
       },
     })
     expect(bomPreview).toEqual({

--- a/docs/development/integration-k3wise-material-reference-template-design-20260525.md
+++ b/docs/development/integration-k3wise-material-reference-template-design-20260525.md
@@ -1,0 +1,91 @@
+# K3 WISE Material reference template design - 2026-05-25
+
+## Context
+
+Customer GATE #1792 proved that the K3 WISE service and token path are reachable,
+but a minimal Material payload with only `FNumber` / `FName` is not enough for a
+positive Save in the tested K3 WISE 15.1 environment.
+
+Direct K3 probes showed two important facts:
+
+- `Material/GetTemplate` models unit, account, and similar master-data fields as
+  reference objects.
+- `Material/GetList` can return numeric ids for the same conceptual fields, but
+  writing those numeric ids back as flat scalars failed with row-level K3
+  business errors.
+
+So the next runtime slice is not "write more records". It is to make Material
+Save payload construction capable of preserving K3 reference object shape.
+
+## Scope
+
+This PR keeps the scope narrow:
+
+- Material Save payload construction and preview only.
+- No BOM write.
+- No Submit or Audit.
+- No K3 WebAPI read/list runtime.
+- No DB migration.
+- No real K3 credentials or customer payload examples.
+
+## Design
+
+K3 document schema fields may now declare a reference shape:
+
+```json
+{
+  "name": "FBaseUnitID",
+  "type": "reference",
+  "reference": { "identifier": "FNumber" }
+}
+```
+
+When a target record contains that field:
+
+- a scalar value such as `"PCS"` is rendered as `{ "FNumber": "PCS" }`;
+- an object value such as `{ "FID": 1, "FName": "Pcs" }` is preserved as-is;
+- blank values are omitted.
+
+This allows customer-confirmed mappings to choose the correct K3 reference
+identifier shape without forcing every deployment into the same format.
+
+## Built-in Material Fields
+
+The built-in Material template now exposes the reference/scalar fields that were
+surfaced by the customer GATE failure analysis:
+
+- `FUnitGroupID`
+- `FBaseUnitID`
+- `FOrderUnitID`
+- `FSaleUnitID`
+- `FProductUnitID`
+- `FStoreUnitID`
+- `FAcctID`
+- `FSaleAcctID`
+- `FCostAcctID`
+- `FCheckCycle`
+- `FTrack`
+- `FBatChangeEconomy`
+- `FStdBatchQty`
+- `FKanBanCapability`
+
+These fields are optional. They only appear in the outbound payload when the
+Data Factory mapping or customer-specific configuration supplies values.
+
+## Preview Consistency
+
+The same reference wrapping is applied in three places:
+
+- K3 WebAPI adapter `previewUpsert()`;
+- K3 WebAPI adapter `upsert()`;
+- template preview helpers used by the K3 setup/Data Factory UI.
+
+This keeps dry-run output aligned with the actual Save request body.
+
+## Safety Boundary
+
+This PR does not make a positive Save possible by itself. It only enables the
+correct payload shape once the customer/K3 admin provides valid unit/account
+reference values or a known-good redacted Save JSON.
+
+Save-only expansion, BOM, Submit, and Audit remain blocked by the customer GATE.

--- a/docs/development/integration-k3wise-material-reference-template-verification-20260525.md
+++ b/docs/development/integration-k3wise-material-reference-template-verification-20260525.md
@@ -1,0 +1,69 @@
+# K3 WISE Material reference template verification - 2026-05-25
+
+## Local Verification Plan
+
+Commands:
+
+```bash
+node --check plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+node --check plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs
+node --check plugins/plugin-integration-core/lib/http-routes.cjs
+node --check plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+pnpm --dir plugins/plugin-integration-core test:k3-wise-adapters
+pnpm --dir plugins/plugin-integration-core test:http-routes
+pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+git diff --check
+```
+
+Result:
+
+- syntax checks: PASS;
+- `pnpm --dir plugins/plugin-integration-core test:k3-wise-adapters`: PASS;
+- `pnpm --dir plugins/plugin-integration-core test:http-routes`: PASS;
+- `pnpm --dir plugins/plugin-integration-core test`: PASS;
+- `pnpm verify:integration-k3wise:poc`: PASS;
+- `vitest run tests/k3WiseSetup.spec.ts --watch=false`: 43/43 PASS;
+- `vue-tsc --noEmit`: PASS;
+- `git diff --check`: PASS.
+
+Note: the isolated worktree did not have its own installed frontend
+`node_modules`, so the frontend commands were run using the already-installed
+workspace binaries from the main checkout. Temporary symlinks were removed
+before staging.
+
+## Expected Assertions
+
+Backend adapter:
+
+- Material schema still exposes required `FNumber` and `FName`.
+- Optional K3 reference fields are available in schema.
+- Preview/upsert preserves a full object reference value.
+- Preview/upsert wraps scalar reference values using the configured identifier
+  field, for example `FBaseUnitID: "PCS"` becomes
+  `FBaseUnitID: { FNumber: "PCS" }`.
+- Existing minimal `FNumber` / `FName` Material calls remain valid.
+- #1813 business-success evidence behavior remains unchanged.
+
+Frontend/K3 setup:
+
+- Material JSON preview no longer shows unit reference fields as flat strings.
+- The generated preview remains secret-free and does not include internal
+  `sourceId`, `revision`, token, authorityCode, or password fields.
+
+## Deployment Impact
+
+- No migration.
+- No configuration change required for existing minimal pipelines.
+- Existing mappings keep working; reference wrapping only changes fields that are
+  declared as K3 reference fields and actually present in the target record.
+- The change is packaged in plugin runtime and web preview code.
+
+## GATE Status
+
+This PR does not unblock full customer GATE by itself. Positive Material Save
+still requires customer-confirmed reference values or a known-good redacted
+Material Save JSON for the target K3 WISE account.
+
+Do not expand to more Save-only records, BOM, Submit, or Audit based solely on
+this PR.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -1122,7 +1122,7 @@ async function testTemplatePreviewRoute() {
         schema: [
           { name: 'FNumber', label: 'Material code', type: 'string', required: true },
           { name: 'FName', label: 'Material name', type: 'string', required: true },
-          { name: 'FBaseUnitID', label: 'Base unit', type: 'string' },
+          { name: 'FBaseUnitID', label: 'Base unit', type: 'reference', reference: { identifier: 'FNumber' } },
           { name: 'FQty', label: 'Quantity', type: 'number' },
         ],
       },
@@ -1134,7 +1134,7 @@ async function testTemplatePreviewRoute() {
     Data: {
       FNumber: 'MAT-001',
       FName: 'Bolt',
-      FBaseUnitID: 'Pcs',
+      FBaseUnitID: { FNumber: 'Pcs' },
       FQty: 2,
     },
   })

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -288,6 +288,29 @@ async function testK3WebApiAdapter() {
   assert.equal(preview.metadata.autoSubmit, true)
   assert.equal(preview.metadata.autoAudit, true)
 
+  const referencePreview = await adapter.previewUpsert({
+    object: 'material',
+    records: [
+      {
+        FNumber: 'MAT-REF-001',
+        FName: 'Reference material',
+        FUnitGroupID: { FNumber: 'UG-PCS', FName: 'Pieces' },
+        FBaseUnitID: 'PCS',
+        FAcctID: '1405',
+      },
+    ],
+    keyFields: ['FNumber'],
+  })
+  assert.deepEqual(referencePreview.records[0].body, {
+    Data: {
+      FNumber: 'MAT-REF-001',
+      FName: 'Reference material',
+      FUnitGroupID: { FNumber: 'UG-PCS', FName: 'Pieces' },
+      FBaseUnitID: { FNumber: 'PCS' },
+      FAcctID: { FNumber: '1405' },
+    },
+  }, 'material reference fields preserve object values and wrap scalar values')
+
   const upsert = await adapter.upsert({
     object: 'material',
     records: [

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs
@@ -2,6 +2,8 @@
 
 const K3_WISE_DOCUMENT_TEMPLATE_VERSION = '2026.05.v1'
 
+const K3_REFERENCE_BY_NUMBER = { identifier: 'FNumber' }
+
 const MATERIAL_FIELD_MAPPINGS = [
   {
     sourceField: 'code',
@@ -103,7 +105,20 @@ const K3_WISE_DOCUMENT_TEMPLATES = {
       { name: 'FNumber', label: 'Material code', type: 'string', required: true },
       { name: 'FName', label: 'Material name', type: 'string', required: true },
       { name: 'FModel', label: 'Specification', type: 'string' },
-      { name: 'FBaseUnitID', label: 'Base unit', type: 'string' },
+      { name: 'FUnitGroupID', label: 'Unit group', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FBaseUnitID', label: 'Base unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FOrderUnitID', label: 'Order unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FSaleUnitID', label: 'Sales unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FProductUnitID', label: 'Production unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FStoreUnitID', label: 'Inventory unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FAcctID', label: 'Inventory account', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FSaleAcctID', label: 'Sales account', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FCostAcctID', label: 'Cost account', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FCheckCycle', label: 'Check cycle', type: 'number' },
+      { name: 'FTrack', label: 'Track policy', type: 'string' },
+      { name: 'FBatChangeEconomy', label: 'Batch change economy', type: 'number' },
+      { name: 'FStdBatchQty', label: 'Standard batch quantity', type: 'number' },
+      { name: 'FKanBanCapability', label: 'Kanban capability', type: 'number' },
     ],
     sampleSource: {
       code: 'MAT-001',

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -121,6 +121,30 @@ function firstDefined(...values) {
   return undefined
 }
 
+function cloneJson(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value))
+}
+
+function isBlankValue(value) {
+  return value === undefined || value === null || (typeof value === 'string' && value.trim() === '')
+}
+
+function normalizeReferenceIdentifier(field) {
+  const reference = field && isPlainObject(field.reference) ? field.reference : null
+  const identifier = firstDefined(
+    reference && reference.identifier,
+    reference && reference.identifierField,
+    reference && reference.key,
+  )
+  return typeof identifier === 'string' && identifier.trim() ? identifier.trim() : null
+}
+
+function applyReferenceShape(value, field) {
+  const identifier = normalizeReferenceIdentifier(field)
+  if (!identifier || isBlankValue(value) || isPlainObject(value)) return value
+  return { [identifier]: value }
+}
+
 function normalizeBusinessBoolean(value) {
   if (value === undefined || value === null || value === '') return null
   if (typeof value === 'boolean') return value
@@ -387,8 +411,11 @@ function buildSaveBody(record, request, objectConfig) {
     return objectConfig.buildBody(record, request)
   }
   const bodyKey = objectConfig.bodyKey || 'Data'
-  const base = isPlainObject(objectConfig.bodyTemplate) ? { ...objectConfig.bodyTemplate } : {}
-  base[bodyKey] = projectRecordForBody(record, objectConfig)
+  const base = isPlainObject(objectConfig.bodyTemplate) ? cloneJson(objectConfig.bodyTemplate) : {}
+  const projected = projectRecordForBody(record, objectConfig)
+  base[bodyKey] = isPlainObject(base[bodyKey]) && isPlainObject(projected)
+    ? { ...base[bodyKey], ...projected }
+    : projected
   return base
 }
 
@@ -402,9 +429,12 @@ function projectRecordForBody(record, objectConfig) {
     : []
   if (schemaFields.length === 0) return record
   const projected = {}
-  for (const field of schemaFields) {
-    if (Object.prototype.hasOwnProperty.call(record, field)) {
-      projected[field] = record[field]
+  for (const field of objectConfig.schema) {
+    const fieldName = field && field.name
+    if (typeof fieldName !== 'string' || fieldName.trim().length === 0) continue
+    if (Object.prototype.hasOwnProperty.call(record, fieldName)) {
+      const value = applyReferenceShape(record[fieldName], field)
+      if (!isBlankValue(value)) projected[fieldName] = value
     }
   }
   return projected

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -587,9 +587,25 @@ function projectRecordForTemplate(record, schema) {
   const projected = {}
   for (const field of schema) {
     const value = getPath(record, field.name)
-    if (value !== undefined) setPath(projected, field.name, value)
+    if (value !== undefined) setPath(projected, field.name, applyPreviewReferenceShape(value, field))
   }
   return projected
+}
+
+function normalizePreviewReferenceIdentifier(field) {
+  const reference = field && isPlainObject(field.reference) ? field.reference : null
+  const identifier = firstString(
+    reference && reference.identifier,
+    reference && reference.identifierField,
+    reference && reference.key,
+  )
+  return identifier || null
+}
+
+function applyPreviewReferenceShape(value, field) {
+  const identifier = normalizePreviewReferenceIdentifier(field)
+  if (!identifier || value === undefined || value === null || value === '' || isPlainObject(value)) return value
+  return { [identifier]: value }
 }
 
 function buildTemplatePreview(input) {


### PR DESCRIPTION
## Summary
- Adds K3 Material reference-field shaping for Save payloads and preview output.
- Preserves existing object reference values and wraps scalar reference values as `{ FNumber: value }` for configured reference fields.
- Extends the built-in Material template with optional unit/account/reference fields surfaced by the customer GATE failure analysis.

## Scope
- Material Save payload construction and template preview only.
- No DB migration.
- No BOM write expansion.
- No Submit/Audit enablement.
- No K3 WebAPI read/list runtime.
- No customer credentials or live payload examples.

## Verification
- `node --check` on modified plugin files and tests: PASS.
- `pnpm --dir plugins/plugin-integration-core test:k3-wise-adapters`: PASS.
- `pnpm --dir plugins/plugin-integration-core test:http-routes`: PASS.
- `pnpm --dir plugins/plugin-integration-core test`: PASS.
- `pnpm --filter @metasheet/web exec vitest run tests/k3WiseSetup.spec.ts --watch=false`: 43/43 PASS.
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`: PASS.
- `pnpm verify:integration-k3wise:poc`: PASS.
- `git diff --check origin/main...HEAD`: PASS.

## GATE Impact
This does not unblock the full customer GATE by itself. It only makes Material payload shaping capable of using customer-confirmed K3 reference values or a known-good redacted Save JSON. BOM, Submit, Audit, and wider Save-only expansion remain blocked until customer evidence confirms them.