### PR TITLE
fix(multitable): export-xlsx applies field permissions and view hidden fields

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -5673,11 +5673,13 @@ export function univerMetaRouter(): Router {
       if (!sheet) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
       }
+      let viewHiddenFieldIds: string[] = []
       if (viewId) {
         const view = await tryResolveViewShared(pool.query.bind(pool), viewId)
         if (!view || view.sheetId !== sheetId) {
           return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `View not found: ${viewId}` } })
         }
+        viewHiddenFieldIds = view.hiddenFieldIds ?? []
       }
 
       const { access, capabilities } = await resolveSheetReadableCapabilities(req, pool.query.bind(pool), sheetId)
@@ -5686,7 +5688,15 @@ export function univerMetaRouter(): Router {
       }
       if (!capabilities.canRead || !capabilities.canExport) return sendForbidden(res)
 
-      const fields = filterVisiblePropertyFields(await loadFieldsForSheetShared(pool.query.bind(pool), sheetId))
+      // D3c: export must mirror the view path's field masking — apply subject-scoped
+      // field_permissions + view.hidden_field_ids, not only static property.hidden.
+      const visibleFields = filterVisiblePropertyFields(await loadFieldsForSheetShared(pool.query.bind(pool), sheetId))
+      const fieldScopeMap = await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, access.userId)
+      const fieldPermissions = deriveFieldPermissions(visibleFields, capabilities, {
+        hiddenFieldIds: viewHiddenFieldIds,
+        fieldScopeMap,
+      })
+      const fields = visibleFields.filter((field) => fieldPermissions[field.id]?.visible !== false)
       const fieldIds = new Set(fields.map((field) => field.id))
       const rows: Array<Array<string | number | boolean | null | undefined>> = []
       let cursor: string | undefined

--- a/packages/core-backend/tests/integration/multitable-export-permission-canary.test.ts
+++ b/packages/core-backend/tests/integration/multitable-export-permission-canary.test.ts
@@ -1,0 +1,163 @@
+/**
+ * Export permission projection regression tests (benchmark v2 #3 / Gap 7, D3c).
+ *
+ * These guard the D3c fix to the export-xlsx route (univer-meta.ts GET
+ * /sheets/:sheetId/export-xlsx): exported fields must mirror the view path's masking
+ * — subject-scoped `field_permissions` AND `view.hidden_field_ids`, not only static
+ * `property.hidden`. Authored as RED canaries against pre-fix main (the field leaked
+ * in header + cells); now GREEN regression guards that ship WITH the fix.
+ * See docs/development/multitable-d3-permission-matrix-design-20260525.md §3.
+ *
+ * Record-scope is intentionally NOT covered here: tracing the view-path filter
+ * (univer-meta.ts record-permission filtering) shows it is a no-op for hiding —
+ * deriveRecordPermissions defaults to allow and treats access_level ∈
+ * {read,write,admin} all as canRead, so no per-record read-deny exists anywhere.
+ * An export-projection-only fix cannot enforce a record-read restriction that the
+ * product model doesn't have; that is a separate model question (out of D3c scope).
+ *
+ * Harness note: route-level integration with a mocked pool (the gap is in route
+ * LOGIC, exercised for real). The full 5-class golden matrix (D3d) will use a real
+ * DB with real seeded permission rows.
+ */
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, test, vi } from 'vitest'
+
+import type { XlsxModule } from '../../src/multitable/xlsx-service'
+
+type QueryResult = { rows: any[]; rowCount?: number }
+type QueryHandler = (sql: string, params?: unknown[]) => QueryResult | Promise<QueryResult>
+
+const SHEET_ID = 'sheet_canary'
+// fld_secret has property {} — NOT statically hidden, so filterVisiblePropertyFields
+// keeps it. It is hidden ONLY via subject-scoped field_permissions / view hidden list.
+const FIELD_ROWS = [
+  { id: 'fld_name', name: 'Name', type: 'string', property: {}, order: 1 },
+  { id: 'fld_amount', name: 'Amount', type: 'number', property: {}, order: 2 },
+  { id: 'fld_secret', name: 'Secret', type: 'string', property: {}, order: 3 },
+]
+const RECORD_ROWS = [
+  { id: 'rec_1', sheet_id: SHEET_ID, version: 1, data: { fld_name: 'Alpha', fld_amount: 12, fld_secret: 'topsecret' } },
+]
+
+const xlsx = await import('xlsx') as unknown as XlsxModule
+
+function createMockPool(opts: {
+  fieldPermissionRows?: Array<{ field_id: string; visible: boolean; read_only: boolean }>
+  viewRow?: Record<string, unknown> | null
+}) {
+  const handler: QueryHandler = (sql, params) => {
+    // --- seeded permission/view data (the shapes a D3c fix would consume) ---
+    if (sql.includes('FROM field_permissions')) {
+      return { rows: opts.fieldPermissionRows ?? [], rowCount: (opts.fieldPermissionRows ?? []).length }
+    }
+    if (sql.includes('FROM meta_views WHERE id = $1')) {
+      return { rows: opts.viewRow ? [opts.viewRow] : [], rowCount: opts.viewRow ? 1 : 0 }
+    }
+    // --- other permission tables: empty (no extra restriction) ---
+    if (sql.includes('FROM spreadsheet_permissions')) return { rows: [], rowCount: 0 }
+    if (sql.includes('FROM view_permissions')) return { rows: [], rowCount: 0 }
+    if (sql.includes('FROM meta_view_permissions')) return { rows: [], rowCount: 0 }
+    if (sql.includes('FROM record_permissions')) return { rows: [], rowCount: 0 }
+    if (sql.includes('FROM formula_dependencies')) return { rows: [], rowCount: 0 }
+    // --- sheet / fields / records ---
+    if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
+      return { rows: [{ id: SHEET_ID, base_id: 'base_canary', name: 'Canary Sheet', description: null }] }
+    }
+    if (sql.includes('SELECT id FROM meta_sheets WHERE id = $1 AND deleted_at IS NULL')) {
+      return { rows: [{ id: SHEET_ID }] }
+    }
+    if (sql.includes('FROM meta_fields WHERE sheet_id = $1')) {
+      return { rows: FIELD_ROWS }
+    }
+    if (sql.includes('FROM meta_records') && sql.includes('SELECT id, sheet_id, version, data')) {
+      expect(params?.[0]).toBe(SHEET_ID)
+      return { rows: RECORD_ROWS }
+    }
+    return { rows: [], rowCount: 0 }
+  }
+  const query = vi.fn(async (sql: string, params?: unknown[]) => handler(sql, params))
+  const transaction = vi.fn(async (fn: (c: { query: typeof query }) => Promise<unknown>) => fn({ query }))
+  return { query, transaction }
+}
+
+async function createApp(mockArgs: Parameters<typeof createMockPool>[0]) {
+  vi.resetModules()
+  vi.doMock('../../src/rbac/service', () => ({
+    isAdmin: vi.fn().mockResolvedValue(false),
+    userHasPermission: vi.fn().mockResolvedValue(false),
+    listUserPermissions: vi.fn().mockResolvedValue([]),
+    invalidateUserPerms: vi.fn(),
+    getPermCacheStatus: vi.fn(),
+  }))
+  const { poolManager } = await import('../../src/integration/db/connection-pool')
+  const { univerMetaRouter } = await import('../../src/routes/univer-meta')
+  const mockPool = createMockPool(mockArgs)
+  vi.spyOn(poolManager, 'get').mockReturnValue(mockPool as any)
+
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    req.user = { id: 'user_canary', roles: [], perms: ['multitable:read'], permissions: ['multitable:read'] } as any
+    next()
+  })
+  app.use('/api/multitable', univerMetaRouter())
+  return app
+}
+
+async function exportRows(app: express.Express, viewId?: string): Promise<string[][]> {
+  const url = `/api/multitable/sheets/${SHEET_ID}/export-xlsx${viewId ? `?viewId=${viewId}` : ''}`
+  const response = await request(app)
+    .get(url)
+    .buffer(true)
+    .parse((res, callback) => {
+      const chunks: Buffer[] = []
+      res.on('data', (chunk) => chunks.push(Buffer.from(chunk)))
+      res.on('end', () => callback(null, Buffer.concat(chunks)))
+    })
+    .expect(200)
+  const parsed = xlsx.read(response.body, { type: 'buffer' })
+  return xlsx.utils.sheet_to_json(parsed.Sheets[parsed.SheetNames[0]], { header: 1, raw: false, defval: '' }) as string[][]
+}
+
+describe('multitable export permission projection (D3c regression)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  test('CANARY field-scope: field hidden via field_permissions.visible=false must NOT appear in export header or cells', async () => {
+    // user has sheet read+export; field_permissions hides fld_secret for this user.
+    const app = await createApp({
+      fieldPermissionRows: [{ field_id: 'fld_secret', visible: false, read_only: false }],
+    })
+    const rows = await exportRows(app)
+    const header = rows[0] ?? []
+    const flat = rows.flat()
+    // export must apply field_permissions (D3c): 'Secret' + 'topsecret' masked.
+    expect(header).not.toContain('Secret')
+    expect(flat).not.toContain('topsecret')
+  })
+
+  test('CANARY view-scope: field in view.hidden_field_ids must NOT appear in export header or cells', async () => {
+    const app = await createApp({
+      viewRow: {
+        id: 'view_secret',
+        sheet_id: SHEET_ID,
+        name: 'Secret View',
+        type: 'grid',
+        filter_info: null,
+        sort_info: null,
+        group_info: null,
+        hidden_field_ids: ['fld_secret'],
+        config: null,
+      },
+    })
+    const rows = await exportRows(app, 'view_secret')
+    const header = rows[0] ?? []
+    const flat = rows.flat()
+    // export must apply view.hidden_field_ids (D3c), not just validate viewId existence.
+    expect(header).not.toContain('Secret')
+    expect(flat).not.toContain('topsecret')
+  })
+})


### PR DESCRIPTION
## Summary

D3c scoped security fix for the export-xlsx route.

Before this change, `GET /api/multitable/sheets/:sheetId/export-xlsx` masked only static `property.hidden` fields. It did not apply subject-scoped `field_permissions.visible=false` and did not apply `view.hidden_field_ids` when exporting with `viewId`, so fields hidden in the grid could still appear in exported XLSX headers and cells.

This mirrors the view path's field masking inside the export route:

- resolve `view.hiddenFieldIds` when `viewId` is provided
- load `field_permissions` via `loadFieldPermissionScopeMap`
- derive field visibility with `deriveFieldPermissions(... { hiddenFieldIds, fieldScopeMap })`
- export only fields whose derived permission is visible

## Scope

- `packages/core-backend/src/routes/univer-meta.ts`: export-xlsx field projection only
- Adds the two D3b canaries as green regression tests
- No `rbac/service.ts`, auth, central permission model, record-scope, frontend, migration, K3, integration-core, or attendance changes

Record-scope is intentionally out of scope: the current record permission model is grant-only (`read|write|admin`) and has no per-record read-deny that an export-projection-only fix could enforce. Full 5-class real-DB golden matrix remains D3d.

## Test plan

- [x] `pnpm --filter @metasheet/core-backend exec vitest run tests/integration/multitable-export-permission-canary.test.ts tests/integration/multitable-xlsx-routes.test.ts --pool=forks --poolOptions.forks.singleFork=true`
- [x] `pnpm --filter @metasheet/core-backend exec tsc --noEmit -p tsconfig.json`
- [x] `git diff --check origin/main..HEAD`

Refs D3a design: `docs/development/multitable-d3-permission-matrix-design-20260525.md`.