### PR TITLE
docs(integration): K3 reference-mapping UI contract (design + verification)

### DIFF
--- a/docs/development/integration-k3wise-reference-mapping-ui-contract-design-20260525.md
+++ b/docs/development/integration-k3wise-reference-mapping-ui-contract-design-20260525.md
@@ -1,0 +1,59 @@
+# K3 WISE Reference Mapping — UI Contract Design - 2026-05-25
+
+## Scope
+
+- Turn the #1821 authoring design + #1824 probe findings into a **product contract** for the Data Factory / K3 reference-mapping UI and its completeness preview.
+- **Docs-only.** No K3 Save runtime; no Submit/Audit/BOM; no read/list runtime; no new K3 object; nothing implemented.
+- Step 1 of the agreed sequence: **UI-contract (here) → frontend-only preview → [decide read/list runtime] → 1 Material Save-only regression**.
+
+## Background — what is already settled (evidence)
+
+- **#1792 GATE `PASS_SAVE_AND_READBACK`** — the deployment requires **full reference objects** (`{FName, FNumber}` / `{FID, FName}`), proven via clone-preservation of an existing Material detail.
+- **#1824 O4** — `config.objects.material.schema` (incl. each field's `reference.identifier`) round-trips `upsert` → store → `get`; the public projection rebuilds null-proto objects (JSON content identical).
+- **#1824 lookup analysis** (`univer-meta.ts:1636-1674`) — a multitable `lookup` yields an **array** of **one** target field's raw value, **skipping** null/undefined targets and unreadable linked records. ⇒ a single lookup **cannot** compose a reference object.
+
+## Contract
+
+### C1 — ③ 基础资料对照表 is multi-column components, NOT single-lookup-to-object
+- One row = one full K3 reference object, expressed as **separate columns**: `sourceCode` / `k3FNumber` / `k3FName` / `k3FID` / `enabled` / `description`.
+- Component rule: at least one of `k3FNumber` | `k3FID`; any `{FName, …}` shape additionally requires `k3FName`.
+- The UI **MUST NOT** present a "single lookup → reference object" path (proven impossible, #1824). Each component is surfaced by its **own** lookup (or carried as its own staging column) and composed (see C3).
+
+### C2 — lookup output is an array with null-skip semantics
+- Any consumer of a lookup-sourced reference column **MUST** treat the value as `unknown[]`, never a scalar.
+- The array length **may be less than** the number of linked records (null/undefined targets and unreadable links are skipped — `univer-meta.ts:1648-1650`).
+- Consumer rule: **an empty array ⇒ "unresolved"**. Never assume "1 linked record ⇒ 1 entry"; `[0]` is valid **only after** asserting the array is non-empty.
+
+### C3 — composition location (the core constraint)
+Composing `{FName, FNumber}` / `{FID, FName}` from C1 components has four possible homes. **This contract authorizes exactly one and explicitly does not enable the others.** Any consumer that composes a reference object **MUST declare** its composition home.
+
+| composition home | lock status | this contract |
+|---|---|---|
+| **preview** (client-side) | lock-safe | ✅ **AUTHORIZED** (the step-2 preview) |
+| operator/client-driven Save | lock-safe | ❌ NOT authorized here |
+| server / pipeline transform | **FROZEN** | ❌ NOT enabled |
+| staging pre-populated (objects already in the row) | needs read/list to source | ❌ deferred (separate track) |
+
+**Only preview composition is in scope.** Productionized (pipeline) Save composition is a **separate decision in step 3** (read/list runtime) and is **NOT pre-committed** by this contract. This clause exists to stop a later PR from quietly composing server-side "because the contract didn't say not to."
+
+### C4 — ② shape selector persists to runtime config
+- Persist per-field shape into `config.objects.material.schema[*]` (#1824 O4: this round-trips). The frontend **MUST write the COMPLETE schema array** — the config merge replaces the whole array (shallow-merge), so a partial write would drop sibling fields.
+- The get/public projection returns **null-prototype** objects; consumers compare JSON-normalized content, not by prototype/`instanceof`.
+
+### C5 — preview completeness + Save guard
+- ⑤ preview reads the staging reference columns + the user's ③ mapping (a **bounded sample scan**, not full-table), composes **client-side** (C3), and lists each reference value as resolved or **"unresolved"** (no ③ row OR missing a required component OR empty lookup array per C2).
+- The preview **MAY disable the Save action client-side** as a UX guard. This is **not** a hard server gate — a hard block would be runtime, out of scope here.
+
+## Boundary / non-goals
+
+- Docs-only; nothing implemented; no behavior changed.
+- **No** K3 Save runtime; **no** Submit/Audit/BOM; **no** read/list runtime (deferred by capability; the docs-front read/list contract is #1593); **no** new K3 object.
+- **Rollback procedure is not in scope** (separate track). The eventual 1-record Save regression's manual rollback belongs to that test's customer approval, per the #1792 GATE thread.
+- Productionized (pipeline/server) Save composition is deferred to step 3.
+
+## See also
+
+- #1821 — reference-mapping authoring design (the surfaces ①–⑤ this contract formalizes).
+- #1824 — O4 round-trip test + lookup code-path analysis (merge `996bf3c73`).
+- #1792 — Customer GATE; `PASS_SAVE_AND_READBACK` proved full reference objects are required.
+- #1593 — read/list docs-front GATE contract (the runtime is deferred; not started here).

--- a/docs/development/integration-k3wise-reference-mapping-ui-contract-verification-20260525.md
+++ b/docs/development/integration-k3wise-reference-mapping-ui-contract-verification-20260525.md
@@ -1,0 +1,36 @@
+# K3 WISE Reference Mapping — UI Contract Verification - 2026-05-25
+
+## Scope
+
+Verifies the **contract** in `integration-k3wise-reference-mapping-ui-contract-design-20260525.md`. This is a docs-only contract; **no implementation exists yet**, so this document confirms lock conformance and records the **acceptance matrix** the step-2 frontend impl must satisfy. Behavioral verification of the impl is the step-2 PR's own verification doc.
+
+## Lock conformance
+
+- **Files:** 2 docs under `docs/development/`. No runtime, no contract-code, no migration, no `plugins/`, no `apps/` source.
+- **Banned-term note:** the terms `Save` / `Submit` / `Audit` / `BOM` / `read/list` / `plugin-integration-core` appear **only as boundary / deferred / scope-exclusion statements**, never as changes. Actual changes to any of those surfaces: **0**.
+- **Stage 1 Lock:** unchanged. This contract enables a future frontend + client-side preview only; the frozen surfaces (server/pipeline composition, read/list runtime, Save expansion) are explicitly kept frozen by C3 and the Boundary section.
+
+## Acceptance matrix (what the step-2 frontend impl MUST satisfy)
+
+| # | Requirement | Source |
+|---|---|---|
+| A1 | ③ uses **multi-column components** (`sourceCode`/`k3FNumber`/`k3FName`/`k3FID`/`enabled`/`description`); **no** "single lookup → object" UI | C1 / #1824 |
+| A2 | Lookup consumers treat the value as an **array**; **empty ⇒ unresolved**; `[0]` only after non-empty assertion; never assume 1 link ⇒ 1 entry | C2 / #1824 |
+| A3 | Composition runs **client-side preview only**; consumer **declares** its composition home; **no** server/pipeline composition; productionized Save composition deferred to step 3 | C3 |
+| A4 | ② persists the **complete** `config.objects.material.schema` array; treats the null-proto public projection as JSON (no prototype/`instanceof` reliance) | C4 / #1824 O4 |
+| A5 | Preview lists **unresolved** (no ③ row / missing required component / empty array); the Save guard is **client-side UX only**, not a hard server gate | C5 |
+| A6 | **No** K3 write, **no** Submit/Audit/BOM, **no** read/list runtime, **no** new K3 object | Boundary |
+| A7 | Preview uses a **bounded sample scan** (sample cap), not a full-table scan | C5 |
+
+## Evidence references
+
+- **#1824 O4 test** — `external-systems.test.cjs §7e` (merge `996bf3c73`): `config.objects.material.schema` (incl. per-field `reference.identifier`) round-trips upsert→store→get; sanitize active but spares the schema.
+- **#1824 lookup analysis** — `packages/core-backend/src/routes/univer-meta.ts:1636-1674` (`resolveLookupValues`): array of one target field's value, null/undefined + unreadable skipped.
+- **#1792 `PASS_SAVE_AND_READBACK`** — full reference objects required (clone-preservation).
+- **#1821** — authoring design (surfaces ①–⑤).
+
+## Boundary
+
+- Verifies contract **intent and lock conformance** only; no behavior exists to test yet.
+- The step-2 frontend PR's verification doc will cover impl conformance against A1–A7.
+- Rollback procedure and read/list runtime are separate tracks, out of scope here.


### PR DESCRIPTION
## Summary
**Step 1** of the agreed sequence. Docs-only UI contract turning the #1821 authoring design + #1824 probe findings into a **product contract** for the Data Factory / K3 reference-mapping UI and completeness preview.

## What it pins
- **C1** — ③ 基础资料对照表 = **multi-column components** (`sourceCode`/`k3FNumber`/`k3FName`/`k3FID`/`enabled`/`description`); **no** "single lookup → object" (proven impossible, #1824).
- **C2** — lookup output is an **array** with null-skip semantics → **empty ⇒ unresolved**; `[0]` only after non-empty assertion; never assume 1 link ⇒ 1 entry.
- **C3** — composition location is a **contract requirement**: **preview (client-side) AUTHORIZED**; operator-client / server-pipeline (**frozen**) / staging-pre-populated (needs read/list) **NOT enabled**; productionized Save composition **deferred to step 3**. Stops a later PR from quietly composing server-side.
- **C4** — ② persists the **complete** `config.objects.material.schema` (#1824 O4 proved round-trip); treat the null-proto public projection as JSON.
- **C5** — preview lists **unresolved** (bounded sample scan); the Save guard is **client-side UX only**, not a hard server gate.
- **Verification** — lock conformance + acceptance matrix **A1–A7** (verifies the *contract*; no impl exists yet).

## Scope / boundary
- Docs-only (2 MDs under `docs/development/`). **No** K3 Save runtime, Submit/Audit/BOM, read/list runtime, or new K3 object.
- Rollback procedure and read/list runtime are **separate tracks**, not in scope.

## Verification
- Secret-shape sweep: clean. `git diff --cached --check`: clean. 2 files.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
