### PR TITLE
feat(integration): K3 reference completeness preview (frontend-only)

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -778,6 +778,149 @@ function projectTargetRecordForTemplate(template: K3WiseDocumentTemplate, record
   return projected
 }
 
+// ---- Reference completeness preview (S2) --------------------------------------
+// Implements the K3 reference-mapping UI contract
+// (integration-k3wise-reference-mapping-ui-contract-design-20260525.md):
+//   C2 — a reference cell is treated as an array with null-skip semantics.
+//   C3 — compose {FNumber} / {FName,FNumber} / {FID,FName} client-side (preview ONLY).
+//   C5 — bounded sample scan + unresolved detection.
+// This is a client-side preview/validation helper, NOT a server gate. It deliberately
+// does NOT reuse applyReferenceShape (single-key wrap, a different concern) — it
+// preserves EVERY present component so two-field shapes are not flattened.
+
+export type K3WiseReferenceCompletenessReason = 'empty' | 'missing-identifier' | 'invalid-row'
+
+export interface K3WiseReferenceCompletenessEntry {
+  field: string
+  label: string
+  rowIndex: number
+  status: 'resolved' | 'unresolved'
+  reason?: K3WiseReferenceCompletenessReason
+  composed?: Record<string, unknown>
+}
+
+export interface K3WiseReferenceCompletenessPreview {
+  scannedRowCount: number
+  truncated: boolean
+  entries: K3WiseReferenceCompletenessEntry[]
+  resolvedCount: number
+  unresolvedCount: number
+  canSave: boolean
+}
+
+const K3_REFERENCE_COMPONENT_KEYS = ['FNumber', 'FName', 'FID'] as const
+const K3_REFERENCE_IDENTIFIER_KEYS = ['FNumber', 'FID'] as const
+const DEFAULT_REFERENCE_COMPLETENESS_SAMPLE_LIMIT = 3
+
+// Normalize a reference cell to candidate values, dropping null/undefined/'' (C2 null-skip).
+function normalizeReferenceCellValues(raw: unknown): unknown[] {
+  const list = Array.isArray(raw)
+    ? raw
+    : raw === null || raw === undefined || raw === ''
+      ? []
+      : [raw]
+  return list.filter((value) => value !== null && value !== undefined && value !== '')
+}
+
+// Compose a K3 reference object from one candidate, PRESERVING every present component
+// ({FName,FNumber} / {FID,FName} stay multi-field). Returns null when no identifier
+// component (FNumber|FID) is present. A scalar composes to the degenerate {FNumber}.
+function composeK3ReferenceObject(candidate: unknown): Record<string, unknown> | null {
+  if (typeof candidate === 'object' && candidate !== null && !Array.isArray(candidate)) {
+    const source = candidate as Record<string, unknown>
+    const composed: Record<string, unknown> = {}
+    for (const key of K3_REFERENCE_COMPONENT_KEYS) {
+      const value = source[key]
+      if (value !== null && value !== undefined && value !== '') composed[key] = value
+    }
+    const hasIdentifier = K3_REFERENCE_IDENTIFIER_KEYS.some((key) => composed[key] !== undefined)
+    return hasIdentifier ? composed : null
+  }
+  return { FNumber: candidate }
+}
+
+export function buildK3WiseReferenceCompletenessPreview(
+  target: K3WisePipelineTarget,
+  rows: unknown,
+  options?: { sampleLimit?: number },
+): K3WiseReferenceCompletenessPreview {
+  const template = K3_WISE_DOCUMENT_TEMPLATES[target]
+  const referenceFields = (template ? template.schema : []).filter((field) => Boolean(field.reference))
+  const sampleLimit = Math.max(1, Math.floor(options?.sampleLimit ?? DEFAULT_REFERENCE_COMPLETENESS_SAMPLE_LIMIT))
+
+  // Defensive: garbage in (textarea-parsed JSON) must not throw. Non-array ⇒ nothing
+  // validated ⇒ canSave stays false.
+  if (!Array.isArray(rows)) {
+    return { scannedRowCount: 0, truncated: false, entries: [], resolvedCount: 0, unresolvedCount: 0, canSave: false }
+  }
+
+  const scannedRowCount = Math.min(rows.length, sampleLimit)
+  const truncated = rows.length > sampleLimit
+  const entries: K3WiseReferenceCompletenessEntry[] = []
+
+  for (let rowIndex = 0; rowIndex < scannedRowCount; rowIndex += 1) {
+    const row = rows[rowIndex]
+    const isObjectRow = typeof row === 'object' && row !== null && !Array.isArray(row)
+    for (const field of referenceFields) {
+      const base = { field: field.name, label: field.label, rowIndex }
+      if (!isObjectRow) {
+        entries.push({ ...base, status: 'unresolved', reason: 'invalid-row' })
+        continue
+      }
+      const candidates = normalizeReferenceCellValues((row as Record<string, unknown>)[field.name])
+      if (candidates.length === 0) {
+        entries.push({ ...base, status: 'unresolved', reason: 'empty' })
+        continue
+      }
+      let composed: Record<string, unknown> | null = null
+      for (const candidate of candidates) {
+        composed = composeK3ReferenceObject(candidate)
+        if (composed) break
+      }
+      entries.push(
+        composed
+          ? { ...base, status: 'resolved', composed }
+          : { ...base, status: 'unresolved', reason: 'missing-identifier' },
+      )
+    }
+  }
+
+  const resolvedCount = entries.filter((entry) => entry.status === 'resolved').length
+  const unresolvedCount = entries.length - resolvedCount
+  // UX-only signal (contract C5): true only when at least one row was actually scanned
+  // AND no unresolved reference was found. An empty/zero-row sample must NOT report
+  // "resolvable" (nothing was checked). This NEVER enforces on the server.
+  return {
+    scannedRowCount,
+    truncated,
+    entries,
+    resolvedCount,
+    unresolvedCount,
+    canSave: scannedRowCount > 0 && unresolvedCount === 0,
+  }
+}
+
+// Illustrative rows for the preview panel: row 0 fully resolves (mixed {FName,FNumber}
+// and {FID,FName} shapes); row 1 shows both unresolved reasons (empty array, and an
+// object missing an identifier component).
+export const K3_WISE_REFERENCE_COMPLETENESS_SAMPLE_ROWS: ReadonlyArray<Record<string, unknown>> = [
+  {
+    FUnitGroupID: [{ FName: '基本单位组', FNumber: 'UG01' }],
+    FBaseUnitID: [{ FName: '个', FNumber: 'Pcs' }],
+    FOrderUnitID: [{ FName: '个', FNumber: 'Pcs' }],
+    FSaleUnitID: [{ FName: '个', FNumber: 'Pcs' }],
+    FProductUnitID: [{ FName: '个', FNumber: 'Pcs' }],
+    FStoreUnitID: [{ FName: '个', FNumber: 'Pcs' }],
+    FAcctID: [{ FID: '1001', FName: '库存商品' }],
+    FSaleAcctID: [{ FID: '6001', FName: '主营业务收入' }],
+    FCostAcctID: [{ FID: '6401', FName: '主营业务成本' }],
+  },
+  {
+    FBaseUnitID: [],
+    FAcctID: [{ FName: '缺编码科目' }],
+  },
+]
+
 function validateHttpUrl(value: string, field: keyof K3WiseSetupForm, issues: K3WiseSetupValidationIssue[]): void {
   const normalized = trim(value)
   if (!normalized) {

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -797,6 +797,61 @@
           <pre class="k3-setup__json-preview">{{ templatePreviewJson }}</pre>
         </section>
 
+        <section class="k3-setup__section" data-testid="reference-completeness-panel">
+          <div class="k3-setup__preview-head">
+            <strong>引用字段完整性预览</strong>
+            <span>仅前端校验 · 不写 K3 · 非服务端门</span>
+          </div>
+          <p class="k3-setup__hint">
+            粘贴一行或多行 staging/preview 样本(JSON 数组),客户端组合 K3 引用对象并标出未解析项。
+            引用列按数组处理(lookup 输出),保留 {FName,FNumber}/{FID,FName} 全部组件;空数组或缺少标识符(FNumber/FID)显示“未解析”。仅扫描前 3 行样本。
+          </p>
+          <textarea
+            v-model="referenceCompletenessInput"
+            rows="10"
+            spellcheck="false"
+            data-testid="reference-completeness-input"
+          ></textarea>
+          <p
+            v-if="referenceCompletenessPreview.error"
+            class="k3-setup__hint"
+            data-testid="reference-completeness-error"
+          >
+            {{ referenceCompletenessPreview.error }}
+          </p>
+          <template v-else>
+            <div class="k3-setup__preview-head" data-testid="reference-completeness-summary">
+              <span>扫描 {{ referenceCompletenessPreview.preview.scannedRowCount }} 行{{ referenceCompletenessPreview.preview.truncated ? '(已截断,仅前 3 行)' : '' }}</span>
+              <span>已解析 {{ referenceCompletenessPreview.preview.resolvedCount }} · 未解析 {{ referenceCompletenessPreview.preview.unresolvedCount }}</span>
+            </div>
+            <p
+              class="k3-setup__hint"
+              :data-can-save="referenceCompletenessPreview.preview.canSave ? 'true' : 'false'"
+              data-testid="reference-completeness-cansave"
+            >
+              <template v-if="referenceCompletenessPreview.preview.scannedRowCount === 0">
+                ℹ️ 尚无样本行可校验(canSave=false,仅前端提示)。请粘贴至少一行 staging/preview 样本。
+              </template>
+              <template v-else-if="referenceCompletenessPreview.preview.canSave">
+                ✅ 样本内引用均可解析(仅前端提示,非服务端门 —— 服务端不据此放行)。
+              </template>
+              <template v-else>
+                ⛔ 存在未解析引用:Save 在前端禁用/提示(仅 UX,非服务端门)。请补全 staging 引用数据后再 Save。
+              </template>
+            </p>
+            <ul class="k3-setup__issues k3-setup__issues--compact" data-testid="reference-completeness-entries">
+              <li
+                v-for="entry in referenceCompletenessPreview.preview.entries"
+                :key="`${entry.rowIndex}:${entry.field}`"
+              >
+                行 {{ entry.rowIndex }} · {{ entry.label }}（{{ entry.field }}）：
+                <template v-if="entry.status === 'resolved'">已解析 → {{ formatComposed(entry.composed) }}</template>
+                <template v-else>未解析（{{ entry.reason }}）</template>
+              </li>
+            </ul>
+          </template>
+        </section>
+
         <details class="k3-setup__section k3-setup__details">
           <summary class="k3-setup__section-summary">
             <span>Pipeline 执行参数</span>
@@ -882,6 +937,8 @@ import {
   validateK3WisePipelineRunForm,
   validateK3WiseSetupForm,
   validateK3WiseStagingInstallForm,
+  buildK3WiseReferenceCompletenessPreview,
+  K3_WISE_REFERENCE_COMPLETENESS_SAMPLE_ROWS,
   type IntegrationDeadLetter,
   type IntegrationExternalSystem,
   type IntegrationPipelineRun,
@@ -889,6 +946,7 @@ import {
   type IntegrationStagingInstallResult,
   type K3WiseDocumentTemplateMapping,
   type K3WisePipelineTarget,
+  type K3WiseReferenceCompletenessPreview,
 } from '../services/integration/k3WiseSetup'
 import {
   isIntegrationScopedProjectId,
@@ -960,6 +1018,25 @@ const gateDraftText = computed(() => {
 const observationSummary = computed(() => `${pipelineRuns.value.length} runs / ${deadLetters.value.length} open`)
 const stagingDescriptorLabel = computed(() => stagingDescriptors.value.length > 0 ? `${stagingDescriptors.value.length} descriptors` : 'not loaded')
 const templatePreviewJson = computed(() => JSON.stringify(buildK3WiseDocumentPayloadPreview(templatePreviewTarget.value), null, 2))
+
+// Reference completeness preview (S2). Client-side validation pad only — never a server gate.
+const referenceCompletenessInput = ref(JSON.stringify(K3_WISE_REFERENCE_COMPLETENESS_SAMPLE_ROWS, null, 2))
+const referenceCompletenessPreview = computed<{ error: string; preview: K3WiseReferenceCompletenessPreview }>(() => {
+  const empty: K3WiseReferenceCompletenessPreview = {
+    scannedRowCount: 0, truncated: false, entries: [], resolvedCount: 0, unresolvedCount: 0, canSave: false,
+  }
+  const raw = referenceCompletenessInput.value.trim()
+  if (!raw) return { error: '请粘贴 staging/preview 样本行(JSON 数组)。', preview: empty }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    return { error: 'JSON 解析失败:请粘贴合法的 JSON 数组。', preview: empty }
+  }
+  if (!Array.isArray(parsed)) return { error: '样本必须是 JSON 数组(每个元素是一行 staging 记录)。', preview: empty }
+  return { error: '', preview: buildK3WiseReferenceCompletenessPreview(templatePreviewTarget.value, parsed, { sampleLimit: 3 }) }
+})
+const formatComposed = (value: unknown): string => JSON.stringify(value)
 const stagingOpenTargets = computed(() => buildStagingOpenTargets(stagingInstallResult.value, form.baseId))
 const selectedWebApiSystem = computed(() => webApiSystems.value.find((system) => system.id === form.webApiSystemId) || null)
 const selectedSqlSystem = computed(() => sqlSystems.value.find((system) => system.id === form.sqlSystemId) || null)

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -34,6 +34,8 @@ import {
   validateK3WisePipelineRunForm,
   validateK3WiseSetupForm,
   validateK3WiseStagingInstallForm,
+  buildK3WiseReferenceCompletenessPreview,
+  K3_WISE_REFERENCE_COMPLETENESS_SAMPLE_ROWS,
   type IntegrationExternalSystem,
 } from '../src/services/integration/k3WiseSetup'
 
@@ -1193,5 +1195,96 @@ describe('K3 WISE setup helpers', () => {
       field: 'allowLivePipelineRun',
     })
     expect(summary.canRunLive).toBe(true)
+  })
+})
+
+describe('buildK3WiseReferenceCompletenessPreview', () => {
+  const entryFor = (preview: ReturnType<typeof buildK3WiseReferenceCompletenessPreview>, field: string, rowIndex = 0) =>
+    preview.entries.find((entry) => entry.field === field && entry.rowIndex === rowIndex)
+
+  it('preserves ALL present components — {FName,FNumber} stays two-field, not flattened to {FNumber}', () => {
+    const preview = buildK3WiseReferenceCompletenessPreview('material', [{ FBaseUnitID: [{ FName: '个', FNumber: 'Pcs' }] }])
+    const entry = entryFor(preview, 'FBaseUnitID')
+    expect(entry?.status).toBe('resolved')
+    expect(entry?.composed).toEqual({ FName: '个', FNumber: 'Pcs' })
+  })
+
+  it('composes {FID,FName} preserving both components', () => {
+    const preview = buildK3WiseReferenceCompletenessPreview('material', [{ FAcctID: [{ FID: '1001', FName: '库存商品' }] }])
+    expect(entryFor(preview, 'FAcctID')?.composed).toEqual({ FID: '1001', FName: '库存商品' })
+  })
+
+  it('wraps a scalar reference value as the degenerate single-key {FNumber}', () => {
+    const preview = buildK3WiseReferenceCompletenessPreview('material', [{ FBaseUnitID: 'Pcs' }])
+    expect(entryFor(preview, 'FBaseUnitID')?.composed).toEqual({ FNumber: 'Pcs' })
+  })
+
+  it('flags an empty array as unresolved (empty)', () => {
+    const preview = buildK3WiseReferenceCompletenessPreview('material', [{ FBaseUnitID: [] }])
+    const entry = entryFor(preview, 'FBaseUnitID')
+    expect(entry?.status).toBe('unresolved')
+    expect(entry?.reason).toBe('empty')
+  })
+
+  it('skips null entries and flags a missing identifier as unresolved', () => {
+    const preview = buildK3WiseReferenceCompletenessPreview('material', [{ FBaseUnitID: [null, { FName: 'only-name' }] }])
+    const entry = entryFor(preview, 'FBaseUnitID')
+    expect(entry?.status).toBe('unresolved')
+    expect(entry?.reason).toBe('missing-identifier')
+  })
+
+  it('resolves when a valid object follows skipped null entries (array null-skip)', () => {
+    const preview = buildK3WiseReferenceCompletenessPreview('material', [{ FBaseUnitID: [null, { FNumber: 'Pcs' }] }])
+    expect(entryFor(preview, 'FBaseUnitID')?.status).toBe('resolved')
+  })
+
+  it('bounds the scan to sampleLimit and reports truncation', () => {
+    const rows = Array.from({ length: 10 }, () => ({ FBaseUnitID: [{ FNumber: 'Pcs' }] }))
+    const preview = buildK3WiseReferenceCompletenessPreview('material', rows, { sampleLimit: 2 })
+    expect(preview.scannedRowCount).toBe(2)
+    expect(preview.truncated).toBe(true)
+    expect(preview.entries.every((entry) => entry.rowIndex < 2)).toBe(true)
+  })
+
+  it('returns no entries and canSave=false for invalid (non-array) rows', () => {
+    const preview = buildK3WiseReferenceCompletenessPreview('material', null)
+    expect(preview.entries).toEqual([])
+    expect(preview.canSave).toBe(false)
+  })
+
+  it('flags a non-object row entry as invalid-row', () => {
+    const preview = buildK3WiseReferenceCompletenessPreview('material', ['not-an-object'])
+    expect(preview.entries.length).toBeGreaterThan(0)
+    expect(preview.entries.every((entry) => entry.reason === 'invalid-row')).toBe(true)
+    expect(preview.canSave).toBe(false)
+  })
+
+  it('sample rows: row 0 fully resolves, row 1 surfaces both unresolved reasons → canSave=false', () => {
+    const preview = buildK3WiseReferenceCompletenessPreview(
+      'material',
+      K3_WISE_REFERENCE_COMPLETENESS_SAMPLE_ROWS as Array<Record<string, unknown>>,
+    )
+    expect(preview.canSave).toBe(false)
+    const row0 = preview.entries.filter((entry) => entry.rowIndex === 0)
+    expect(row0.length).toBeGreaterThan(0)
+    expect(row0.every((entry) => entry.status === 'resolved')).toBe(true)
+    const row1 = preview.entries.filter((entry) => entry.rowIndex === 1)
+    expect(row1.some((entry) => entry.reason === 'empty')).toBe(true)
+    expect(row1.some((entry) => entry.reason === 'missing-identifier')).toBe(true)
+  })
+
+  it('does NOT report canSave for an empty sample (nothing was checked)', () => {
+    const preview = buildK3WiseReferenceCompletenessPreview('material', [])
+    expect(preview.scannedRowCount).toBe(0)
+    expect(preview.entries).toEqual([])
+    expect(preview.canSave).toBe(false)
+  })
+
+  it('reports canSave only when at least one row scanned and all references resolve', () => {
+    const fullRow = K3_WISE_REFERENCE_COMPLETENESS_SAMPLE_ROWS[0]
+    const preview = buildK3WiseReferenceCompletenessPreview('material', [fullRow] as Array<Record<string, unknown>>)
+    expect(preview.scannedRowCount).toBe(1)
+    expect(preview.unresolvedCount).toBe(0)
+    expect(preview.canSave).toBe(true)
   })
 })

--- a/docs/development/integration-k3wise-reference-completeness-preview-design-20260525.md
+++ b/docs/development/integration-k3wise-reference-completeness-preview-design-20260525.md
@@ -1,0 +1,37 @@
+# K3 WISE Reference Completeness Preview — Design (S2) - 2026-05-25
+
+## Scope
+
+- **Step 2** of the agreed sequence: a **frontend-only** "reference field completeness preview" on the Data Factory / K3 setup page, implementing the #1826 UI contract.
+- Small implementation PR: **impl + tests + this design + verification**. Frontend + tests + docs only.
+- **No** K3 Save/Submit/Audit/BOM/read-list runtime; **no** `plugin-integration-core`; **no** server gate.
+
+## Design
+
+### Pure helper — `k3WiseSetup.ts`
+`buildK3WiseReferenceCompletenessPreview(target, rows, { sampleLimit })`:
+- Reference fields = `template.schema` entries that carry `reference`.
+- **Bounded scan** (C5/A7): first `sampleLimit` rows (default **3**); `truncated` flags more.
+- Per reference field × scanned row:
+  - Normalize the cell to an array with **null-skip** (C2/A2): scalar → `[v]`; `null`/`''`/`undefined` → `[]`; array → filtered of `null`/`undefined`/`''`.
+  - Empty array → unresolved `empty`. Non-object row → unresolved `invalid-row`.
+  - Compose the first candidate that yields an identifier, **preserving every present component** (`FNumber`/`FName`/`FID`) so `{FName,FNumber}` / `{FID,FName}` stay multi-field (C3/A1); a scalar composes to the degenerate `{FNumber}`. No identifier in any candidate → unresolved `missing-identifier`.
+- Returns `scannedRowCount` / `truncated` / `entries` / `resolvedCount` / `unresolvedCount` / `canSave = unresolvedCount === 0` (**UX-only**, C5).
+- **Defensive** (advisor): non-array `rows` → empty result + `canSave:false`; non-object entries handled.
+- Deliberately does **not** reuse `applyReferenceShape` (the #1817 single-key wrap) — it composes from possibly-multiple components and preserves them all.
+- `K3_WISE_REFERENCE_COMPLETENESS_SAMPLE_ROWS`: illustrative rows — row 0 fully resolves (mixed two-field shapes); row 1 shows both unresolved reasons (empty array, missing identifier). Keeps the view's script lean.
+
+### Panel — `IntegrationK3WiseSetupView.vue`
+- A **validation pad**: a textarea prefilled with the sample rows; a computed parses the JSON (defensive: parse error / non-array → inline error) and runs the helper against the selected `templatePreviewTarget`.
+- Renders scanned/truncated, resolved/unresolved counts, a per-entry list (composed object when resolved, reason when not), and a **Save-guard line that explicitly states "仅前端提示,非服务端门"** (C5) — the guard is a client-side UX disable/hint, never a server gate.
+
+## Lock conformance / boundary
+
+- Files: `k3WiseSetup.ts` (+helper), `IntegrationK3WiseSetupView.vue` (+panel), `k3WiseSetup.spec.ts` (+tests), 2 docs — all under `apps/web/` + `docs/`.
+- No K3 write, Submit/Audit/BOM, read/list runtime, `plugin-integration-core`, or server gate. The helper has no I/O; the panel adds no `apiFetch`.
+- The ② shape-selector persistence (contract C4/A4) is a **separate** future piece — not in this preview PR.
+
+## See also
+- #1826 — UI contract (C1–C5, A1–A7).
+- #1824 — lookup array / null-skip semantics + O4 (merge `996bf3c73`).
+- #1792 — Customer GATE; full reference objects required.

--- a/docs/development/integration-k3wise-reference-completeness-preview-verification-20260525.md
+++ b/docs/development/integration-k3wise-reference-completeness-preview-verification-20260525.md
@@ -1,0 +1,37 @@
+# K3 WISE Reference Completeness Preview — Verification (S2) - 2026-05-25
+
+## Scope
+
+Verifies the **S2 implementation** against the #1826 contract acceptance matrix, with file:line evidence and local test results. (Unlike #1826's verification, which verified contract intent, this verifies real behavior.)
+
+## Acceptance matrix mapping (contract A# → artifact + evidence)
+
+| A# | Requirement | Artifact / evidence | In S2? |
+|---|---|---|---|
+| A1 | Multi-column components; no single-lookup→object | `composeK3ReferenceObject` composes from `FNumber`/`FName`/`FID` component keys (`k3WiseSetup.ts`); panel consumes component-bearing rows; no "single lookup → object" UI | ✅ |
+| A2 | Lookup-array + null-skip; empty ⇒ unresolved; no blind `[0]` | `normalizeReferenceCellValues` (array + filter `null`/`undefined`/`''`); empty → `empty`; composes first valid candidate. Tests: empty / null-skip / missing-identifier / resolve-after-null | ✅ |
+| A3 | Composition client-side preview only; declared home; no server | Helper is pure client TS; panel runs in-browser; **no `apiFetch`/runtime call added**. Composition home = preview (only) | ✅ |
+| A4 | ② persists complete `config.objects.material.schema` (null-proto-safe) | **Out of scope for S2** — A4 is the ② shape-selector persistence, a separate future piece. This preview composes for display, not persistence | ⏸ deferred |
+| A5 | Preview lists unresolved; Save guard is client-side UX only | Panel renders unresolved list + a 3-way `canSave` line ("尚无样本行" / "可解析" / "存在未解析"), all stating "仅前端提示,非服务端门". `canSave = scannedRowCount > 0 && unresolvedCount === 0` (UX-only; an empty/zero-row sample is NOT reported resolvable). Tests cover `canSave` incl. empty-sample and happy-path | ✅ |
+| A6 | No K3 write/Submit/Audit/BOM/read-list/new object | Boundary scan: only `apps/web` + docs; helper has no I/O; no new endpoint | ✅ |
+| A7 | Bounded sample scan (not full-table) | `sampleLimit` default **3**; `truncated` flag. Test: bounds scan to 2, asserts truncation + only scanned rows present | ✅ |
+
+S2 satisfies **A1, A2, A3, A5, A6, A7**. **A4** (② shape persistence) is explicitly deferred to a later piece and is not part of this preview.
+
+## Local verification
+
+- `vitest run tests/k3WiseSetup.spec.ts` → **55 passed** (43 existing + 12 new for `buildK3WiseReferenceCompletenessPreview`).
+- `vue-tsc --noEmit` → **exit 0, 0 errors** (0 in changed files).
+- Secret-shape sweep on changed files: clean.
+
+## Test coverage (new)
+
+- Preserves all present components (`{FName,FNumber}` stays two-field, not flattened).
+- Composes `{FID,FName}` preserving both; scalar → degenerate `{FNumber}`.
+- Empty array → `empty`; missing identifier → `missing-identifier`; null entries skipped; resolves after skipped nulls.
+- Bounded scan + truncation; non-array rows → no entries + `canSave:false`; non-object row → `invalid-row`.
+- Sample rows: row 0 fully resolved, row 1 surfaces both reasons → `canSave:false`.
+- Empty sample (`[]`) → `scannedRowCount:0`, no entries, `canSave:false` (nothing checked); a single fully-resolved row → `canSave:true` (happy path locked).
+
+## Boundary
+- Frontend + tests + docs only; no runtime, no server gate; A4 (② persistence) deferred to a later PR.


### PR DESCRIPTION
## Summary
**S2** — a frontend-only **"reference field completeness preview"** implementing the #1826 UI contract. Small impl PR: impl + tests + design/verification MD.

## What it adds
- **Pure helper** `buildK3WiseReferenceCompletenessPreview(target, rows, { sampleLimit })` (`k3WiseSetup.ts`): composes `{FNumber}` / `{FName,FNumber}` / `{FID,FName}` **preserving every present component** (two-field never flattened); treats the reference cell as an **array with null-skip**; flags `empty` / `missing-identifier` / `invalid-row`; **bounded scan** (default 3 rows); `canSave` is **UX-only**. Defensive against garbage (non-array / non-object) input. Does **not** reuse the single-key `applyReferenceShape`.
- **Validation-pad panel** in `IntegrationK3WiseSetupView.vue`: textarea (prefilled with an illustrative sample) → client-side compose → resolved/unresolved list + a Save-guard line that **explicitly says it is a front-end hint, not a server gate** (C5).
- **10 new tests** + an exported illustrative sample.

## Contract conformance (#1826)
Satisfies **A1 / A2 / A3 / A5 / A6 / A7**. **A4** (② shape-selector persistence into `config.objects.material.schema`) is a separate future piece, deferred.

## Scope / boundary
- **Frontend + tests + docs only.** No K3 Save/Submit/Audit/BOM/read-list runtime, no `plugin-integration-core`, no server gate, no new endpoint. The helper has no I/O; the panel adds no `apiFetch`.

## Verification
- `vitest run tests/k3WiseSetup.spec.ts` → **53 passed** (43 existing + 10 new).
- `vue-tsc --noEmit` → **exit 0, 0 errors**.
- Secret-shape sweep on added lines: clean. `git diff --cached --check`: clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
