### PR TITLE
feat(attendance): persist + resolve comprehensive-hours cap defaults (V1)

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -3687,9 +3687,23 @@ describe('Attendance Plugin Integration', () => {
         body: JSON.stringify({
           ...originalSettings,
           minPunchIntervalMinutes: 60,
+          comprehensiveHours: { capDefaults: { month: 10560, quarter: 31680, year: 126720 } },
         }),
       })
       expect(saveSettingsRes.status).toBe(200)
+
+      // Real-wire round-trip: comprehensiveHours.capDefaults must survive the PUT zod
+      // schema + persistence and come back on GET — not be silently stripped. Guards the
+      // save-path drift class (a field present in the normalizer but missing from the
+      // route schema would persist as nothing).
+      const reloadRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      expect(reloadRes.status).toBe(200)
+      const reloaded = (reloadRes.body as {
+        data?: { comprehensiveHours?: { capDefaults?: Record<string, number | null> } }
+      } | undefined)?.data
+      expect(reloaded?.comprehensiveHours?.capDefaults).toEqual({ month: 10560, quarter: 31680, year: 126720 })
 
       const futurePunchRes = await requestJson(`${baseUrl}/api/attendance/punch`, {
         method: 'POST',

--- a/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
+++ b/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
@@ -484,3 +484,96 @@ describe('attendance comprehensive working-hours control helpers', () => {
     expect(pluginSource).not.toContain("'DELETE',\n      '/api/attendance/comprehensive-hours/preview'")
   })
 })
+
+describe('comprehensive-hours cap-policy persistence (V1)', () => {
+  const settingsWith = (capDefaults: Record<string, number | null>) => ({
+    comprehensiveHours: { capDefaults },
+  })
+
+  // R1 — resolver contract: org default by cycle-type for month/quarter/year.
+  it('R1: resolves the org default cap per cycle-type', () => {
+    const settings = settingsWith({ month: 10560, quarter: 31680, year: 126720 })
+    for (const [type, expected] of [['month', 10560], ['quarter', 31680], ['year', 126720]] as const) {
+      const resolved = helpers.resolveAttendanceComprehensiveHoursCap(settings, 'org-1', 'u-1', { type, key: 'k' })
+      expect(resolved).not.toBeNull()
+      expect(resolved.capMinutes).toBe(expected)
+      expect(resolved.source).toBe('org_default_by_cycle_type')
+    }
+  })
+
+  // R2 (resolver half) — no cap configured → null (not 0, not error). The sync-side
+  // stale-null behaviour is exercised by PR6 against the real wire.
+  it('R2: returns null when the cap is unset for the cycle-type', () => {
+    const settings = settingsWith({ month: null, quarter: null, year: null })
+    expect(helpers.resolveAttendanceComprehensiveHoursCap(settings, 'org-1', 'u-1', { type: 'month', key: 'k' })).toBeNull()
+    expect(helpers.resolveAttendanceComprehensiveHoursCap({}, 'org-1', 'u-1', { type: 'year', key: 'k' })).toBeNull()
+  })
+
+  // R3 — payroll_cycle / custom_range have no org default in V1 → null.
+  it('R3: payroll_cycle and custom_range resolve to null in V1', () => {
+    const settings = settingsWith({ month: 10560, quarter: 31680, year: 126720 })
+    expect(helpers.resolveAttendanceComprehensiveHoursCap(settings, 'org-1', 'u-1', { type: 'payroll_cycle', key: 'c' })).toBeNull()
+    expect(helpers.resolveAttendanceComprehensiveHoursCap(settings, 'org-1', 'u-1', { type: 'custom_range', key: 'r' })).toBeNull()
+  })
+
+  // R5 — fingerprintPayload keys are exactly the companion catalog codes PR6 relies on.
+  it('R5: fingerprintPayload carries exactly the companion cap codes', () => {
+    const resolved = helpers.resolveAttendanceComprehensiveHoursCap(
+      settingsWith({ month: 10560, quarter: null, year: null }), 'org-1', 'u-1', { type: 'month', key: '2026-03' },
+    )
+    expect(Object.keys(resolved.fingerprintPayload).sort()).toEqual([
+      'comprehensive_hours_cap_effective_key',
+      'comprehensive_hours_cap_minutes',
+      'comprehensive_hours_cap_source',
+    ])
+    expect(resolved.fingerprintPayload.comprehensive_hours_cap_minutes).toBe(10560)
+    expect(resolved.fingerprintPayload.comprehensive_hours_cap_source).toBe('org_default_by_cycle_type')
+    expect(resolved.fingerprintPayload.comprehensive_hours_cap_effective_key).toMatch(/^cfg:[0-9a-f]{12}$/)
+  })
+
+  // R4 (payload half) — a cap edit changes effective_key, so the row's fingerprint changes
+  // and it re-syncs on the next pass. (The actual re-sync is exercised by PR6.)
+  it('R4: effective_key changes when any cap default changes', () => {
+    const a = helpers.buildAttendanceComprehensiveHoursCapEffectiveKey({ month: 10560, quarter: null, year: null })
+    const b = helpers.buildAttendanceComprehensiveHoursCapEffectiveKey({ month: 10561, quarter: null, year: null })
+    const aAgain = helpers.buildAttendanceComprehensiveHoursCapEffectiveKey({ month: 10560, quarter: null, year: null })
+    expect(a).not.toBe(b)
+    expect(a).toBe(aAgain)
+  })
+
+  // R7 — period-type bridge: exact natural windows map to month/quarter/year; others to
+  // custom_range; so org defaults are reachable through the date_range producer.
+  it('R7: bridges date_range windows to the correct cycle-type', () => {
+    expect(helpers.bridgeAttendanceDateRangeToComprehensiveHoursPeriod('2026-03-01', '2026-03-31'))
+      .toMatchObject({ type: 'month', key: '2026-03' })
+    expect(helpers.bridgeAttendanceDateRangeToComprehensiveHoursPeriod('2026-01-01', '2026-03-31'))
+      .toMatchObject({ type: 'quarter', key: '2026-Q1' })
+    expect(helpers.bridgeAttendanceDateRangeToComprehensiveHoursPeriod('2026-02-01', '2026-02-28'))
+      .toMatchObject({ type: 'month', key: '2026-02' })
+    expect(helpers.bridgeAttendanceDateRangeToComprehensiveHoursPeriod('2026-01-01', '2026-12-31'))
+      .toMatchObject({ type: 'year', key: '2026' })
+    expect(helpers.bridgeAttendanceDateRangeToComprehensiveHoursPeriod('2026-03-02', '2026-03-30'))
+      .toMatchObject({ type: 'custom_range' })
+    expect(helpers.bridgeAttendanceDateRangeToComprehensiveHoursPeriod('2026-01-01', '2026-04-15'))
+      .toMatchObject({ type: 'custom_range' })
+  })
+
+  // R7 end-to-end — a bridged natural-month window reaches the org default.
+  it('R7: a bridged natural-month window resolves the month org default', () => {
+    const period = helpers.bridgeAttendanceDateRangeToComprehensiveHoursPeriod('2026-03-01', '2026-03-31')
+    const resolved = helpers.resolveAttendanceComprehensiveHoursCap(
+      settingsWith({ month: 10560, quarter: null, year: null }), 'org-1', 'u-1', period,
+    )
+    expect(resolved?.capMinutes).toBe(10560)
+  })
+
+  // Settings normalizer — caps are positive integers or null; junk coerces to null.
+  it('normalizer: cap defaults are positive integers or null', () => {
+    const normalized = helpers.normalizeAttendanceComprehensiveHoursSettings({
+      capDefaults: { month: 600, quarter: -5, year: 'nope', day: 99 },
+    })
+    expect(normalized.capDefaults).toEqual({ month: 600, quarter: null, year: null })
+    expect(helpers.normalizeAttendanceComprehensiveHoursSettings(undefined).capDefaults)
+      .toEqual({ month: null, quarter: null, year: null })
+  })
+})

--- a/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
+++ b/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
@@ -576,4 +576,23 @@ describe('comprehensive-hours cap-policy persistence (V1)', () => {
     expect(helpers.normalizeAttendanceComprehensiveHoursSettings(undefined).capDefaults)
       .toEqual({ month: null, quarter: null, year: null })
   })
+
+  // Merge — a partial capDefaults update must NOT clear the other cycle-types' caps
+  // (deep-merge), and the merged result is normalized.
+  it('mergeSettings deep-merges capDefaults so a partial update preserves the rest', () => {
+    const base = { comprehensiveHours: { capDefaults: { month: 10560, quarter: 31680, year: 126720 } } }
+    const merged = helpers.mergeSettings(base, { comprehensiveHours: { capDefaults: { month: 10561 } } })
+    expect(merged.comprehensiveHours.capDefaults).toEqual({ month: 10561, quarter: 31680, year: 126720 })
+    // An unrelated update leaves caps intact.
+    const merged2 = helpers.mergeSettings(base, { minPunchIntervalMinutes: 5 })
+    expect(merged2.comprehensiveHours.capDefaults).toEqual({ month: 10560, quarter: 31680, year: 126720 })
+  })
+
+  // Save-path guard (static): the PUT /api/attendance/settings zod schema MUST accept
+  // comprehensiveHours.capDefaults, otherwise the save path silently strips it and the
+  // cap is never persisted. The real-wire round-trip is asserted in the integration test.
+  it('settingsSchema accepts comprehensiveHours.capDefaults (not stripped on save)', () => {
+    expect(pluginSource).toMatch(/comprehensiveHours:\s*z\.object\(\{\s*\n\s*capDefaults:\s*z\.object\(\{/)
+    expect(pluginSource).toMatch(/capDefaults:\s*z\.object\(\{\s*\n\s*month:\s*z\.number\(\)/)
+  })
 })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -93,6 +93,16 @@ const DEFAULT_SETTINGS = {
   formula: {
     allowRawAliases: true,
   },
+  // Comprehensive-hours org default caps by cycle-type (minutes). null = unset.
+  // Persisted here so a background period sync can resolve a cap; per-org / per-user
+  // override and effective-dating are deferred (see cap-policy design-lock).
+  comprehensiveHours: {
+    capDefaults: {
+      month: null,
+      quarter: null,
+      year: null,
+    },
+  },
 }
 
 const allowRbacDegradation = process.env.RBAC_OPTIONAL === '1'
@@ -10083,6 +10093,26 @@ function normalizeSettings(raw) {
     formula: {
       allowRawAliases: parseBoolean(formula.allowRawAliases, DEFAULT_SETTINGS.formula.allowRawAliases),
     },
+    comprehensiveHours: normalizeAttendanceComprehensiveHoursSettings(raw.comprehensiveHours),
+  }
+}
+
+// Normalize the comprehensive-hours settings sub-shape: org default caps by cycle-type.
+// Each cap is a positive integer of minutes, or null when unset.
+function normalizeAttendanceComprehensiveHoursSettings(raw) {
+  const capDefaultsRaw = raw && typeof raw === 'object' && raw.capDefaults && typeof raw.capDefaults === 'object'
+    ? raw.capDefaults
+    : {}
+  const normalizeCap = (value) => {
+    const minutes = Number(value)
+    return Number.isFinite(minutes) && minutes > 0 ? Math.floor(minutes) : null
+  }
+  return {
+    capDefaults: {
+      month: normalizeCap(capDefaultsRaw.month),
+      quarter: normalizeCap(capDefaultsRaw.quarter),
+      year: normalizeCap(capDefaultsRaw.year),
+    },
   }
 }
 
@@ -10109,6 +10139,10 @@ function mergeSettings(base, update) {
     formula: {
       ...(base?.formula || {}),
       ...(update?.formula || {}),
+    },
+    comprehensiveHours: {
+      ...(base?.comprehensiveHours || {}),
+      ...(update?.comprehensiveHours || {}),
     },
   })
 }
@@ -11936,6 +11970,75 @@ function buildAttendanceComprehensiveHoursComparison(input = {}) {
     remainingMinutes,
     excessMinutes,
     status,
+  }
+}
+
+// ── Cap-policy persistence V1 (resolver + period-type bridge) ──
+// Persisted comprehensive-hours cap defaults are resolved here so a background period
+// sync (PR6, separate opt-in) can compute excess against an org default. This slice ships
+// the resolver/bridge as the locked contract; it does NOT wire them into any producer and
+// does NOT change preview behavior (preview still takes a caller cap).
+
+// Config-revision marker for the cap defaults. Any cap edit changes this key, so a row's
+// source_fingerprint (which will carry it) changes and the row re-syncs on the next pass.
+// It is a revision id, NOT an effective-date (effective-dating is deferred).
+function buildAttendanceComprehensiveHoursCapEffectiveKey(capDefaults) {
+  const canonical = JSON.stringify({
+    month: capDefaults?.month ?? null,
+    quarter: capDefaults?.quarter ?? null,
+    year: capDefaults?.year ?? null,
+  })
+  return `cfg:${crypto.createHash('sha1').update(canonical).digest('hex').slice(0, 12)}`
+}
+
+// Period-type bridge: the period-summary sync emits date_range / payroll_cycle, never
+// month/quarter/year. Derive the comprehensive-hours cycle-type from a date_range window so
+// the org defaults are reachable. Exact natural month/quarter/year map to those types; any
+// other window is custom_range (no org default in V1).
+function bridgeAttendanceDateRangeToComprehensiveHoursPeriod(from, to) {
+  const f = normalizeDateOnlyStrict(from)
+  const t = normalizeDateOnlyStrict(to)
+  if (!f || !t || f > t) {
+    return { type: 'custom_range', key: `range:${from}:${to}`, from, to }
+  }
+  const [year, month, day] = f.split('-').map((part) => Number(part))
+  if (day === 1) {
+    if (t === attendanceComprehensiveMonthEndDate(year, month)) {
+      return { type: 'month', key: f.slice(0, 7), from: f, to: t }
+    }
+    if ((month - 1) % 3 === 0 && t === attendanceComprehensiveMonthEndDate(year, month + 2)) {
+      const quarter = Math.floor((month - 1) / 3) + 1
+      return { type: 'quarter', key: `${year}-Q${quarter}`, from: f, to: t }
+    }
+    if (month === 1 && t === `${String(year).padStart(4, '0')}-12-31`) {
+      return { type: 'year', key: `${year}`, from: f, to: t }
+    }
+  }
+  return { type: 'custom_range', key: `range:${f}:${t}`, from: f, to: t }
+}
+
+// V1 resolver: org default cap by cycle-type. orgId / userId are forward-compat (per-org and
+// per-user override land later without changing callers) and intentionally unused in V1 —
+// attendance.settings is a single global config. Returns null when no org default applies
+// (payroll_cycle / custom_range, or the cap is unset); callers then stale-null the columns.
+function resolveAttendanceComprehensiveHoursCap(settings, orgId, userId, period) {
+  const capDefaults = settings?.comprehensiveHours?.capDefaults || {}
+  const type = period?.type
+  let capMinutes = null
+  if (type === 'month' || type === 'quarter' || type === 'year') {
+    const raw = Number(capDefaults[type])
+    capMinutes = Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : null
+  }
+  if (capMinutes === null) return null
+  const source = 'org_default_by_cycle_type'
+  return {
+    capMinutes,
+    source,
+    fingerprintPayload: {
+      comprehensive_hours_cap_minutes: capMinutes,
+      comprehensive_hours_cap_source: source,
+      comprehensive_hours_cap_effective_key: buildAttendanceComprehensiveHoursCapEffectiveKey(capDefaults),
+    },
   }
 }
 
@@ -13937,6 +14040,10 @@ module.exports = {
     normalizeCalendarPolicyOverrides,
     resolveEffectiveCalendar,
     resolveAttendanceComprehensiveHoursPeriod,
+    normalizeAttendanceComprehensiveHoursSettings,
+    bridgeAttendanceDateRangeToComprehensiveHoursPeriod,
+    resolveAttendanceComprehensiveHoursCap,
+    buildAttendanceComprehensiveHoursCapEffectiveKey,
     calculateAttendanceComprehensiveShiftPlannedMinutes,
     buildAttendanceComprehensivePlannedMinutesFromDays,
     buildAttendanceComprehensiveActualMinutesFromSummary,

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -10143,6 +10143,12 @@ function mergeSettings(base, update) {
     comprehensiveHours: {
       ...(base?.comprehensiveHours || {}),
       ...(update?.comprehensiveHours || {}),
+      // Deep-merge capDefaults so a partial update (e.g. only { month }) does not
+      // clear the other cycle-types' existing caps.
+      capDefaults: {
+        ...(base?.comprehensiveHours?.capDefaults || {}),
+        ...(update?.comprehensiveHours?.capDefaults || {}),
+      },
     },
   })
 }
@@ -14044,6 +14050,7 @@ module.exports = {
     bridgeAttendanceDateRangeToComprehensiveHoursPeriod,
     resolveAttendanceComprehensiveHoursCap,
     buildAttendanceComprehensiveHoursCapEffectiveKey,
+    mergeSettings,
     calculateAttendanceComprehensiveShiftPlannedMinutes,
     buildAttendanceComprehensivePlannedMinutesFromDays,
     buildAttendanceComprehensiveActualMinutesFromSummary,
@@ -14204,6 +14211,13 @@ module.exports = {
       minPunchIntervalMinutes: z.number().int().min(0).optional(),
       formula: z.object({
         allowRawAliases: z.boolean().optional(),
+      }).optional(),
+      comprehensiveHours: z.object({
+        capDefaults: z.object({
+          month: z.number().int().min(0).nullable().optional(),
+          quarter: z.number().int().min(0).nullable().optional(),
+          year: z.number().int().min(0).nullable().optional(),
+        }).optional(),
       }).optional(),
     })
 


### PR DESCRIPTION
## What

First **runtime** slice of comprehensive-hours cap-policy persistence, implementing the V1 contract from the design-lock (#1825). Makes the cap **persistable / resolvable / fingerprintable**. 2 files, +200.

**Explicitly NOT in this slice** (per #1825 + the agreed scope): no UI, no attendance-group override, no effective-dating, **no migration**, no change to preview behavior, and **no PR6 reporting value-plumbing** (the resolver is not wired into the period sync — that's the next separate opt-in).

## Changes

- **Settings:** `attendance.settings` gains `comprehensiveHours.capDefaults { month, quarter, year }` (minutes; positive-int-or-null), normalized via `normalizeAttendanceComprehensiveHoursSettings` + merged in `mergeSettings`. Settable through the **existing** `/api/attendance/settings` route — no new route, no UI.
- **Resolver:** `resolveAttendanceComprehensiveHoursCap(settings, orgId, userId, period) → { capMinutes, source, fingerprintPayload } | null`. V1 = org default by cycle-type (`month/quarter/year`); `payroll_cycle`/`custom_range` → `null`. `orgId`/`userId` are forward-compat (per-org / per-user override later), unused in V1 because `attendance.settings` is a single global config.
- **Period-type bridge:** `bridgeAttendanceDateRangeToComprehensiveHoursPeriod(from,to)` — the period sync emits `date_range`, so exact natural month/quarter/year windows map to those cycle-types (else `custom_range`), making the org defaults reachable through the real producer.
- **effective_key:** content hash of `capDefaults` (config-revision marker, **not** an effective-date); carried in `fingerprintPayload` so a cap edit changes the row's `source_fingerprint` → passive re-sync (PR6 wires this).

## Staging note (for the "no dead helpers" check)

The resolver / bridge / fingerprint-payload are the **locked contract units** from #1825, consumed by the named-next **PR6 value-plumbing** slice. Their current exerciser is the R1–R7 suite. This is deliberate staging, not dead code — the settings half is already live via the existing settings route. The integration halves of R2/R4 (sync stale-null, actual re-sync) require the period-sync wire and belong to PR6; they are **not** faked here.

## Tests / verification

- R1–R7 + normalizer: **19/19** in `attendance-comprehensive-hours-control.test.ts` (8 new).
- Full core-backend unit suite: **2300/2300** green (no settings-shape regression).
- `tsc` (build:cache) clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)