### PR TITLE
feat(integration): K3 Material reference shape-selector persistence (A4)

### DIFF
--- a/apps/web/src/services/integration/k3WiseSetup.ts
+++ b/apps/web/src/services/integration/k3WiseSetup.ts
@@ -6,6 +6,8 @@ export type K3SqlServerMode = 'readonly' | 'middle-table' | 'stored-procedure'
 export type K3WiseWebApiAuthMode = 'authority-code' | 'login'
 export type IntegrationPipelineRunMode = 'manual' | 'incremental' | 'full'
 export type K3WisePipelineTarget = 'material' | 'bom'
+// A4: per-reference-field K3 Save shape — {FNumber} / {FID} single-key, or object-passthrough.
+export type K3WiseReferenceShape = 'FNumber' | 'FID' | 'object'
 export type IntegrationPipelineRunStatus = 'pending' | 'running' | 'succeeded' | 'partial' | 'failed' | 'cancelled'
 export type IntegrationDeadLetterStatus = 'open' | 'replayed' | 'discarded'
 export type PlmReadMethod = 'api' | 'database' | 'table' | 'file' | 'manual'
@@ -164,6 +166,8 @@ export interface K3WiseSetupForm {
   materialSavePath: string
   materialSubmitPath: string
   materialAuditPath: string
+  // A4: per-reference-field Save shape for Material (field name → shape); empty/unset ⇒ {FNumber}.
+  materialReferenceShapes: Record<string, K3WiseReferenceShape>
   bomSavePath: string
   bomSubmitPath: string
   bomAuditPath: string
@@ -239,6 +243,10 @@ export interface K3WiseDocumentTemplate {
       identifier?: string
       identifierField?: string
       key?: string
+      // A4: declared object-passthrough intent for this reference field. The shipped
+      // #1817 adapter already passes object values through regardless; this flag records
+      // the operator's choice for the downstream composition/Save work to consume.
+      passthrough?: boolean
     }
   }>
   sampleSource: Record<string, unknown>
@@ -967,6 +975,7 @@ export function createDefaultK3WiseSetupForm(): K3WiseSetupForm {
     materialSavePath: '/K3API/Material/Save',
     materialSubmitPath: '/K3API/Material/Submit',
     materialAuditPath: '/K3API/Material/Audit',
+    materialReferenceShapes: defaultMaterialReferenceShapes(),
     bomSavePath: '/K3API/BOM/Save',
     bomSubmitPath: '/K3API/BOM/Submit',
     bomAuditPath: '/K3API/BOM/Audit',
@@ -1875,6 +1884,54 @@ export function buildK3WisePipelineObservationQuery(
   }
 }
 
+// A4: build the COMPLETE Material schema array with each reference field's chosen shape.
+// Non-reference fields are preserved unchanged (the array must be complete — the config
+// merge replaces the whole schema array, not a deep-merge). FNumber/FID set reference.identifier;
+// 'object' keeps a sane scalar-fallback identifier and records passthrough intent.
+export function buildK3WiseMaterialReferenceSchema(
+  shapeByField: Record<string, K3WiseReferenceShape> = {},
+): K3WiseDocumentTemplate['schema'] {
+  const template = K3_WISE_DOCUMENT_TEMPLATES.material
+  return template.schema.map((field) => {
+    const base = cloneJson(field)
+    if (!base.reference) return base
+    const shape = shapeByField[field.name] ?? 'FNumber'
+    base.reference = shape === 'object'
+      ? { identifier: 'FNumber', passthrough: true }
+      : { identifier: shape }
+    return base
+  })
+}
+
+// A4: default per-field shapes — every Material reference field starts at {FNumber}.
+export function defaultMaterialReferenceShapes(): Record<string, K3WiseReferenceShape> {
+  return Object.fromEntries(
+    K3_WISE_DOCUMENT_TEMPLATES.material.schema
+      .filter((field) => field.reference)
+      .map((field) => [field.name, 'FNumber' as K3WiseReferenceShape]),
+  )
+}
+
+// A4: restore per-field shapes from a SAVED material schema, merged OVER the defaults — so every
+// reference field stays present (fields absent from the saved schema remain {FNumber}) and the
+// reload round-trip does not silently downgrade an operator's earlier FID / object choices.
+export function parseMaterialReferenceShapesFromSchema(schema: unknown): Record<string, K3WiseReferenceShape> {
+  const shapes = defaultMaterialReferenceShapes()
+  if (!Array.isArray(schema)) return shapes
+  for (const field of schema) {
+    if (!field || typeof field !== 'object') continue
+    const name = (field as { name?: unknown }).name
+    if (typeof name !== 'string' || !(name in shapes)) continue
+    const reference = (field as { reference?: unknown }).reference
+    if (!reference || typeof reference !== 'object') continue
+    const ref = reference as { identifier?: unknown; passthrough?: unknown }
+    if (ref.passthrough === true) shapes[name] = 'object'
+    else if (ref.identifier === 'FID') shapes[name] = 'FID'
+    else shapes[name] = 'FNumber'
+  }
+  return shapes
+}
+
 export function buildK3WiseSetupPayloads(form: K3WiseSetupForm): K3WiseSetupPayloads {
   const workspaceId = optionalString(form.workspaceId) ?? null
   const baseSystem = {
@@ -1914,6 +1971,9 @@ export function buildK3WiseSetupPayloads(form: K3WiseSetupForm): K3WiseSetupPayl
           ...(optionalString(form.materialSubmitPath) ? { submitPath: trim(form.materialSubmitPath) } : {}),
           ...(optionalString(form.materialAuditPath) ? { auditPath: trim(form.materialAuditPath) } : {}),
           keyField: 'FNumber',
+          // A4: persist the COMPLETE material schema (shallow-merge replaces the whole array,
+          // so a partial would drop sibling fields) with the operator's per-field reference shape.
+          schema: buildK3WiseMaterialReferenceSchema(form.materialReferenceShapes),
           k3Template: getK3WiseDocumentTemplateMeta('material'),
         },
         bom: {
@@ -2121,6 +2181,9 @@ export function applyExternalSystemToForm(form: K3WiseSetupForm, system: Integra
     next.bomSavePath = typeof bom.savePath === 'string' ? bom.savePath : next.bomSavePath
     next.bomSubmitPath = typeof bom.submitPath === 'string' ? bom.submitPath : next.bomSubmitPath
     next.bomAuditPath = typeof bom.auditPath === 'string' ? bom.auditPath : next.bomAuditPath
+    // A4: restore per-field shape selections from the saved schema so a reload + re-save does not
+    // silently downgrade them to the default {FNumber} (merged over defaults; missing fields stay FNumber).
+    next.materialReferenceShapes = parseMaterialReferenceShapesFromSchema(material.schema)
   }
   if (system.kind === SQLSERVER_KIND) {
     const config = system.config || {}

--- a/apps/web/src/views/IntegrationK3WiseSetupView.vue
+++ b/apps/web/src/views/IntegrationK3WiseSetupView.vue
@@ -852,6 +852,35 @@
           </template>
         </section>
 
+        <section class="k3-setup__section" data-testid="reference-shape-selector">
+          <div class="k3-setup__preview-head">
+            <strong>Material 引用字段 Save Shape</strong>
+            <span>保存时写入 config.objects.material.schema(完整 schema)</span>
+          </div>
+          <p class="k3-setup__hint">
+            为每个 Material 引用字段选择 K3 Save 形态:<code>{FNumber}</code> / <code>{FID}</code> 单键,或 object-passthrough(由源提供完整对象)。
+            保存时写入<strong>完整</strong> material schema —— 浅合并会整体替换 schema 数组,partial 会丢字段。
+          </p>
+          <div class="k3-setup__grid">
+            <label
+              v-for="field in materialReferenceFields"
+              :key="`shape:${field.name}`"
+              class="k3-setup__field"
+            >
+              <span>{{ field.label }}（{{ field.name }}）</span>
+              <select
+                :value="form.materialReferenceShapes[field.name]"
+                :data-testid="`reference-shape-${field.name}`"
+                @change="setMaterialReferenceShape(field.name, ($event.target as HTMLSelectElement).value)"
+              >
+                <option value="FNumber">{FNumber}</option>
+                <option value="FID">{FID}</option>
+                <option value="object">object-passthrough</option>
+              </select>
+            </label>
+          </div>
+        </section>
+
         <details class="k3-setup__section k3-setup__details">
           <summary class="k3-setup__section-summary">
             <span>Pipeline 执行参数</span>
@@ -989,6 +1018,16 @@ const templatePreviewTarget = ref<K3WisePipelineTarget>('material')
 
 const savedSystems = computed(() => [...webApiSystems.value, ...sqlSystems.value])
 const documentTemplates = listK3WiseDocumentTemplates()
+// A4: Material reference fields offered in the per-field shape selector.
+const materialReferenceFields = computed(() =>
+  (documentTemplates.find((template) => template.targetObject === 'material')?.schema ?? [])
+    .filter((field) => Boolean(field.reference)),
+)
+const setMaterialReferenceShape = (fieldName: string, value: string) => {
+  if (value === 'FNumber' || value === 'FID' || value === 'object') {
+    form.materialReferenceShapes[fieldName] = value
+  }
+}
 const validationIssues = computed(() => validateK3WiseSetupForm(form))
 const stagingIssues = computed(() => validateK3WiseStagingInstallForm(form))
 const pipelineIssues = computed(() => validateK3WisePipelineTemplateForm(form, stagingDescriptors.value))

--- a/apps/web/tests/k3WiseSetup.spec.ts
+++ b/apps/web/tests/k3WiseSetup.spec.ts
@@ -35,6 +35,9 @@ import {
   validateK3WiseSetupForm,
   validateK3WiseStagingInstallForm,
   buildK3WiseReferenceCompletenessPreview,
+  buildK3WiseMaterialReferenceSchema,
+  parseMaterialReferenceShapesFromSchema,
+  K3_WISE_WEBAPI_KIND,
   K3_WISE_REFERENCE_COMPLETENESS_SAMPLE_ROWS,
   type IntegrationExternalSystem,
 } from '../src/services/integration/k3WiseSetup'
@@ -1286,5 +1289,79 @@ describe('buildK3WiseReferenceCompletenessPreview', () => {
     expect(preview.scannedRowCount).toBe(1)
     expect(preview.unresolvedCount).toBe(0)
     expect(preview.canSave).toBe(true)
+  })
+})
+
+describe('buildK3WiseMaterialReferenceSchema (A4 shape persistence)', () => {
+  it('returns the COMPLETE material schema array (non-reference fields preserved)', () => {
+    const full = buildK3WiseMaterialReferenceSchema({})
+    const template = listK3WiseDocumentTemplates().find((t) => t.targetObject === 'material')
+    expect(full.length).toBe(template?.schema.length)
+    // a non-reference field (FNumber identity column) is preserved unchanged
+    const fnumber = full.find((f) => f.name === 'FNumber')
+    expect(fnumber?.reference).toBeUndefined()
+  })
+
+  it('defaults unset reference fields to {FNumber}', () => {
+    const full = buildK3WiseMaterialReferenceSchema({})
+    expect(full.find((f) => f.name === 'FBaseUnitID')?.reference).toEqual({ identifier: 'FNumber' })
+  })
+
+  it('applies per-field identifier choices (FID)', () => {
+    const full = buildK3WiseMaterialReferenceSchema({ FAcctID: 'FID' })
+    expect(full.find((f) => f.name === 'FAcctID')?.reference).toEqual({ identifier: 'FID' })
+    // other reference fields keep the default
+    expect(full.find((f) => f.name === 'FBaseUnitID')?.reference).toEqual({ identifier: 'FNumber' })
+  })
+
+  it('records object-passthrough as a scalar-fallback identifier plus passthrough flag', () => {
+    const full = buildK3WiseMaterialReferenceSchema({ FBaseUnitID: 'object' })
+    expect(full.find((f) => f.name === 'FBaseUnitID')?.reference).toEqual({ identifier: 'FNumber', passthrough: true })
+  })
+
+  it('is JSON-serializable identity (plain objects, no null-proto / class instances)', () => {
+    const full = buildK3WiseMaterialReferenceSchema({ FAcctID: 'FID', FBaseUnitID: 'object' })
+    expect(JSON.parse(JSON.stringify(full))).toEqual(full)
+  })
+
+  it('buildK3WiseSetupPayloads persists the complete schema into config.objects.material.schema', () => {
+    const form = createDefaultK3WiseSetupForm()
+    form.materialReferenceShapes = { ...form.materialReferenceShapes, FAcctID: 'FID' }
+    const payloads = buildK3WiseSetupPayloads(form)
+    const schema = (payloads.webApi.config as any).objects.material.schema as Array<Record<string, any>>
+    expect(Array.isArray(schema)).toBe(true)
+    // complete array (all material template fields), with the chosen identifier present
+    expect(schema.length).toBe(listK3WiseDocumentTemplates().find((t) => t.targetObject === 'material')?.schema.length)
+    expect(schema.find((f) => f.name === 'FAcctID')?.reference?.identifier).toBe('FID')
+    expect(schema.find((f) => f.name === 'FBaseUnitID')?.reference?.identifier).toBe('FNumber')
+  })
+
+  it('parseMaterialReferenceShapesFromSchema merges over defaults (garbage-safe)', () => {
+    expect(parseMaterialReferenceShapesFromSchema(undefined).FBaseUnitID).toBe('FNumber')
+    const parsed = parseMaterialReferenceShapesFromSchema([{ name: 'FAcctID', reference: { identifier: 'FID' } }])
+    expect(parsed.FAcctID).toBe('FID')
+    expect(parsed.FUnitGroupID).toBe('FNumber') // present-by-default, absent from the schema
+  })
+
+  it('restores materialReferenceShapes from a saved config on reload (persistence closure)', () => {
+    const saved = {
+      id: 'sys_saved',
+      name: 'K3 saved',
+      kind: K3_WISE_WEBAPI_KIND,
+      tenantId: 'default',
+      workspaceId: '',
+      config: { objects: { material: { schema: [
+        { name: 'FAcctID', type: 'reference', reference: { identifier: 'FID' } },
+        { name: 'FBaseUnitID', type: 'reference', reference: { identifier: 'FNumber', passthrough: true } },
+      ] } } },
+    } as unknown as IntegrationExternalSystem
+    const form = applyExternalSystemToForm(createDefaultK3WiseSetupForm(), saved)
+    expect(form.materialReferenceShapes.FAcctID).toBe('FID')
+    expect(form.materialReferenceShapes.FBaseUnitID).toBe('object')
+    expect(form.materialReferenceShapes.FUnitGroupID).toBe('FNumber') // not in saved schema → stays default
+    // re-save still emits the COMPLETE schema with the restored shapes (no silent downgrade)
+    const schema = (buildK3WiseSetupPayloads(form).webApi.config as any).objects.material.schema as Array<Record<string, any>>
+    expect(schema.find((f) => f.name === 'FAcctID')?.reference).toEqual({ identifier: 'FID' })
+    expect(schema.find((f) => f.name === 'FBaseUnitID')?.reference).toEqual({ identifier: 'FNumber', passthrough: true })
   })
 })

--- a/docs/development/integration-k3wise-shape-selector-persistence-design-20260525.md
+++ b/docs/development/integration-k3wise-shape-selector-persistence-design-20260525.md
@@ -1,0 +1,35 @@
+# K3 WISE Material Reference Shape-Selector Persistence (A4) — Design - 2026-05-25
+
+## Scope
+
+- **A4** from the #1826 UI contract: a per-Material-reference-field **Save shape selector** that persists into `config.objects.material.schema`. Frontend impl + tests + this MD.
+- **No** integration-core runtime change, K3 write, Submit/Audit/BOM, read/list, or server gate.
+- Two-step (user-mandated): **(1) route-fidelity probe FIRST; (2) frontend selector only if the route preserves the schema.**
+
+## Step 1 — route-fidelity probe (RESULT: PASS)
+
+**Concern:** does the real HTTP upsert route preserve `config.objects.material.schema[*].reference.identifier`, or strip it via route / requestBody / sanitizer / validator? (#1824's O4 covered only the *registry* layer.)
+
+**Finding (code):** `externalSystemsUpsert` → `externalSystems.upsertExternalSystem(scopedInput(req, requestBody(req)))`; `requestBody` returns raw `req.body`; `scopedInput` does `{ ...input, tenantId, workspaceId }` (spread — no field pick/strip); no plugin-level body schema. `config.objects` is already an established persisted shape (the staging adapters read `config.objects`).
+
+**Proof:** `http-routes.test.cjs` → `testExternalSystemUpsertPreservesObjectSchema` (isolated harness) asserts the route forwards `config.objects.material.schema` (incl. each field's `reference.identifier`) **verbatim** to the store AND in the response. PASS ⇒ route is faithful ⇒ **pure-frontend** (no backend widening needed).
+
+## Step 2 — frontend shape selector
+
+- `K3WiseReferenceShape = 'FNumber' | 'FID' | 'object'`.
+- Form: `materialReferenceShapes: Record<string, K3WiseReferenceShape>` (default: every material reference field → `'FNumber'`).
+- `buildK3WiseMaterialReferenceSchema(shapeByField)`: returns the **COMPLETE** material schema array (all fields; non-reference fields preserved unchanged), each reference field's `reference` set per shape — `FNumber`/`FID` → `{ identifier }`; `'object'` → `{ identifier: 'FNumber', passthrough: true }` (scalar-fallback identifier + declared object intent).
+- `buildK3WiseSetupPayloads`: writes `config.objects.material.schema = buildK3WiseMaterialReferenceSchema(form.materialReferenceShapes)` — the **whole** array (the config merge replaces the schema array, so a partial would drop sibling fields — contract **C4**).
+- View: a selector section over `materialReferenceFields`; each is a `<select>` (`{FNumber}` / `{FID}` / object-passthrough) wired via `:value` + a typed `@change` setter that narrows the value to the union before assigning (avoids the v-model `string`→union friction and validates the input).
+- **Restore-on-load (persistence closure):** `applyExternalSystemToForm` calls `parseMaterialReferenceShapesFromSchema(material.schema)` — restoring each field's shape (`passthrough → object`, `identifier 'FID' → FID`, else `FNumber`) **merged over the defaults** (every reference field stays present; fields absent from the saved schema remain `FNumber`). Without this, a reload + re-save would silently downgrade earlier choices to `FNumber`. `createDefaultK3WiseSetupForm` and the restore both use the shared `defaultMaterialReferenceShapes()`.
+
+## Note on `object` passthrough
+
+`'object'` records the operator's **intent** that the field will carry a full reference object. The shipped #1817 adapter already passes object values through regardless of identifier, so the `passthrough` flag changes **no** adapter behavior today — it is forward-intent that the downstream composition / S3 work will consume. A4 does **not** itself produce two-field `{FName,FNumber}`/`{FID,FName}` objects.
+
+## Lock / boundary
+
+- Frontend + **one** integration-core **test** (the route probe) + docs. **No** integration-core runtime change; no K3 write / Submit/Audit/BOM / read/list; no server gate.
+
+## See also
+- #1826 — UI contract (A4 / C4); #1824 — O4 registry round-trip + lookup analysis; #1828 — S2 preview; #1817 — adapter reads `reference.identifier`.

--- a/docs/development/integration-k3wise-shape-selector-persistence-verification-20260525.md
+++ b/docs/development/integration-k3wise-shape-selector-persistence-verification-20260525.md
@@ -1,0 +1,35 @@
+# K3 WISE Material Reference Shape-Selector Persistence (A4) — Verification - 2026-05-25
+
+## Scope
+
+Verifies the A4 implementation against contract **A4** and the user-mandated two-step gate.
+
+## Step 1 — route-fidelity gate (PASS)
+
+- `testExternalSystemUpsertPreservesObjectSchema` (`plugins/plugin-integration-core/__tests__/http-routes.test.cjs`, isolated harness): the HTTP upsert route forwards `config.objects.material.schema[*].reference.identifier` **verbatim** to the store call AND in the response. **PASS** ⇒ the route does not strip the schema ⇒ A4 stays **pure-frontend** (no backend widening). Had it stripped, the procedure was to STOP and report (front+back contract change) — not triggered.
+
+## Contract mapping (A# / C# → artifact + evidence)
+
+| Item | Artifact / evidence | Status |
+|---|---|---|
+| **A4** ② persists complete `config.objects.material.schema` | `buildK3WiseMaterialReferenceSchema` (complete array) + `buildK3WiseSetupPayloads` injects it under `config.objects.material.schema`; test asserts complete array + per-field `reference.identifier` | ✅ |
+| **C4** complete-schema (shallow-merge replaces whole array) | helper returns the WHOLE material schema (non-reference fields preserved); payload writes it whole; test asserts `schema.length === material template schema length` | ✅ |
+| null-proto / JSON safety | schema is plain objects; test `JSON.parse(JSON.stringify(full)).toEqual(full)` | ✅ |
+| selector options `{FNumber}` / `{FID}` / object-passthrough | `<select>` over `materialReferenceFields` via `:value` + typed `@change` setter; `'object'` → `{identifier:'FNumber', passthrough:true}` | ✅ |
+| **persistence CLOSURE** — reload restores shapes (no silent downgrade) | `applyExternalSystemToForm` calls `parseMaterialReferenceShapesFromSchema(material.schema)`, merged over defaults; round-trip test: saved `{FAcctID:{identifier:FID}}` + `{FBaseUnitID:{identifier:FNumber,passthrough:true}}` → form shapes restored (`FID`/`object`), absent field stays `FNumber`, and re-save re-emits the COMPLETE schema unchanged | ✅ |
+
+## Local verification
+
+- `pnpm --dir plugins/plugin-integration-core test:http-routes` (incl. the route-fidelity probe) → **PASS**.
+- `vitest run tests/k3WiseSetup.spec.ts` → **63 passed** (55 prior + 8 new: `buildK3WiseMaterialReferenceSchema` / payload persistence / **reload-restore closure** / garbage-safe parse).
+- `vue-tsc --noEmit` → **exit 0, 0 errors**.
+- Secret-shape sweep on added lines: clean.
+
+## Boundary
+
+- Frontend + **one** integration-core test (route probe) + docs. **No** integration-core runtime change, K3 write, Submit/Audit/BOM, read/list runtime, or server gate.
+- `'object'` is declared intent only; it does **not** itself produce two-field reference objects (composition / S3 still required).
+
+## See also
+- design: `integration-k3wise-shape-selector-persistence-design-20260525.md`
+- #1826 (contract), #1824 (O4), #1828 (S2 preview).

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -476,6 +476,39 @@ async function testExternalSystemRoutes() {
   assert.equal(conflict.body.error.details.referencedPipelineCount, 2)
 }
 
+async function testExternalSystemUpsertPreservesObjectSchema() {
+  // A4 route-fidelity probe (isolated harness): the HTTP upsert route MUST forward
+  // config.objects.material.schema (incl. each field's reference.identifier) verbatim —
+  // not strip it via route / requestBody / scopedInput / response path. The store + get +
+  // sanitize round-trip is covered separately by external-systems.test.cjs §7e (O4).
+  const { calls, services } = createMockServices()
+  const { routes } = mountRoutes(services)
+  const refSchema = [
+    { name: 'FBaseUnitID', type: 'reference', reference: { identifier: 'FNumber' } },
+    { name: 'FAcctID', type: 'reference', reference: { identifier: 'FID' } },
+  ]
+  const res = await invoke(routes, 'POST', '/api/integration/external-systems', {
+    user: WRITE_USER,
+    body: {
+      id: 'sys_ref_schema',
+      tenantId: 'tenant_1',
+      workspaceId: 'workspace_1',
+      name: 'K3 WISE ref-schema',
+      kind: 'erp:k3-wise-webapi',
+      role: 'target',
+      status: 'active',
+      config: { objects: { material: { schema: refSchema } } },
+    },
+  })
+  assertOkResponse(res, 201)
+  const forwarded = findCall(calls, 'upsertExternalSystem')
+  assert.ok(forwarded, 'route forwarded the upsert to the store')
+  assert.deepEqual(forwarded[1].config.objects.material.schema, refSchema,
+    'A4 route fidelity: config.objects.material.schema (incl. per-field reference.identifier) forwarded verbatim, not stripped')
+  assert.equal(res.body.data.config.objects.material.schema[1].reference.identifier, 'FID',
+    'A4 route fidelity: response path preserves nested reference.identifier')
+}
+
 async function testExternalSystemTestPersistsFailureAndPreservesInactive() {
   const { calls, services } = createMockServices({
     externalSystemRegistry: {
@@ -1807,6 +1840,7 @@ async function testListOffsetCap() {
 async function main() {
   await testUnauthenticatedWriteRequestIsRejected()
   await testExternalSystemRoutes()
+  await testExternalSystemUpsertPreservesObjectSchema()
   await testExternalSystemTestPersistsFailureAndPreservesInactive()
   await testExternalSystemTestRequiresSavedSystem()
   await testExternalSystemTestRedactsAdapterResultSecrets()


### PR DESCRIPTION
## Summary
**A4** — a per-Material-reference-field **Save shape selector** persisted into `config.objects.material.schema`. Built **two-step as mandated**.

## Step 1 — route-fidelity probe (PASS · hard gate)
`testExternalSystemUpsertPreservesObjectSchema` (`http-routes.test.cjs`, isolated harness) proves the **real HTTP upsert route forwards `config.objects.material.schema[*].reference.identifier` verbatim** (store call + response). ⇒ A4 stays **pure-frontend** — no backend widening. (Had the route stripped it → STOP + report a front+back contract change; not triggered.)

## Step 2 — frontend shape selector
- `K3WiseReferenceShape = 'FNumber' | 'FID' | 'object'`; `materialReferenceShapes` form field (default each material reference field → `FNumber`).
- `buildK3WiseMaterialReferenceSchema` → the **COMPLETE** material schema (non-reference fields preserved; `FNumber`/`FID` → `{identifier}`; `object` → `{identifier:'FNumber', passthrough:true}`).
- `buildK3WiseSetupPayloads` persists the **whole** array into `config.objects.material.schema` (contract **C4** shallow-merge — partial would drop sibling fields).
- View: per-field `<select>` (`{FNumber}` / `{FID}` / object-passthrough) via `:value` + a typed `@change` setter (no v-model `string`→union friction; validates input).

## Tests
6 new + the route probe: complete-array, per-field identifier, object-passthrough flag, JSON-serializable identity, payload persistence.

## Scope / boundary
- Frontend + **one integration-core TEST** (route probe) + docs. **No** integration-core runtime, K3 write, Submit/Audit/BOM, read/list, or server gate.
- `'object'` is declared intent — it does **not** itself produce two-field objects (composition / S3).

## Verification
- `test:http-routes` (incl. route probe) → PASS · `vitest tests/k3WiseSetup.spec.ts` → **61 passed** · `vue-tsc --noEmit` → exit 0, 0 errors · secret sweep on added lines clean · `git diff --cached --check` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
