### PR TITLE
feat(attendance): PR6 value-plumbing — surface comprehensive_hours_excess_minutes (V1)

### DIFF
--- a/docs/development/attendance-comprehensive-hours-pr6-value-plumbing-verification-20260525.md
+++ b/docs/development/attendance-comprehensive-hours-pr6-value-plumbing-verification-20260525.md
@@ -1,0 +1,88 @@
+# Comprehensive-Hours PR6 — Value-Plumbing (V1) Design + Verification — 2026-05-25
+
+Minimal runtime slice that wires the #1829 cap resolver into the
+`attendance_report_period_summaries` period sync, surfacing **one** period-level metric
+(`comprehensive_hours_excess_minutes`) plus the three cap companion fields. Verified
+against `plugins/plugin-attendance/index.cjs` at the PR head.
+
+## Scope (and explicit non-scope)
+
+**In:** compute and write, per period-summary row, the comprehensive-hours excess against
+a persisted org-default cap (resolved via #1829), with cap provenance carried so a cap edit
+re-syncs the row.
+
+**Out (unchanged):** no new route, no UI, no migration, no new writer/producer, daily
+`attendance_report_records` untouched, preview behavior unchanged, no attendance-group /
+per-user override, no effective-dating, no `payroll_cycle` cap derivation.
+
+## Design
+
+System-managed value columns, not catalog-authored (so no catalog seed / migration):
+
+- `ATTENDANCE_COMPREHENSIVE_HOURS_PERIOD_VALUE_COLUMNS` (`index.cjs:12080`) — 4 columns: `comprehensive_hours_excess_minutes` (number), `comprehensive_hours_cap_minutes` (number), `comprehensive_hours_cap_source` (string), `comprehensive_hours_cap_effective_key` (string).
+- `buildAttendanceComprehensiveHoursPeriodSummaryValues(settings, orgId, userId, period, actualMinutes)` (`:12092`) — fail-closed: only an explicit `date_range` that bridges (`bridgeAttendanceDateRangeToComprehensiveHoursPeriod` `:12028`) to an aligned `month`/`quarter`/`year` with a configured org default (`resolveAttendanceComprehensiveHoursCap` `:12054`) yields a cap; `payroll_cycle`, `custom_range`, missing `periodType`, and unset cap all **stale-null** all four columns. Excess uses the shared `buildAttendanceComprehensiveHoursComparison` math (no parallel computation).
+
+Sync wiring in `syncAttendanceReportPeriodSummary` (`:3519`):
+
+- The 4 columns are appended to the provisioned set (`allValueColumns` `:3550`) so `ensureObject` creates them and `resolveFieldIds`/`logicalIds` map them — they ride the **existing** provisioning + record-write path. They are **not** added to `valueFields`, so the field-config fingerprint is unaffected (these are system columns, not catalog config).
+- The computed values are set into `logical` via `Object.assign(logical, comprehensiveHoursValues)` (`:3625`) **after** the catalog value loop and **before** `buildAttendanceReportPeriodSummarySourceFingerprint(logical)`. So the cap value / source / effective_key are hashed into `source_fingerprint` → a cap edit changes the fingerprint → the row patches on the next sync (passive re-sync). Existing pre-PR6 rows re-sync once automatically because `logical` now carries four extra keys.
+
+## Boundaries held
+
+| Boundary (#1819 / #1825) | How |
+| --- | --- |
+| No new writer / parallel producer | Reuses `syncAttendanceReportPeriodSummary`; source guard asserts no `sync*Comprehensive*` producer. |
+| No migration | Columns are provisioned via the existing multitable `ensureObject`, not SQL; no `migrations/` change. |
+| No raw `meta_*` write | All snapshot writes go through `records.createRecord`/`patchRecord`; test asserts zero `INSERT/UPDATE/DELETE` and no `meta_` / snapshot-table SQL. |
+| No route / UI | None added. |
+| Daily records untouched | Only the period sync changed. |
+| `payroll_cycle` deferred | Fail-closed to null in V1 (cycle-template mapping is a future opt-in). |
+
+## Test coverage
+
+`packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts`, 28/28
+(7 new under "comprehensive-hours period value-plumbing (PR6)"):
+
+| Requirement | Test |
+| --- | --- |
+| Value logic incl. stale-null | value helper: aligned cap → excess; no-cap / payroll_cycle / non-aligned / missing-type → all-null |
+| **stale-null through the real sync** | no org default → `createRecord` data has all 4 columns null |
+| Computed write | cap configured → `createRecord` data has excess + companion fields |
+| **cap fingerprint re-sync** | capture-and-replay: sync#1 create → feed stored data back → unchanged cap = skipped → changed cap = `patchRecord` with new excess/cap |
+| Existing-row migration | pre-PR6 record (no comp-hours keys, stale fingerprint) → patched on first new sync |
+| **no parallel producer / no raw meta** | zero `INSERT/UPDATE/DELETE`; no `meta_`/snapshot-table SQL; writes only via records API; source guard for `sync*Comprehensive*`; wiring + ordering source guard |
+
+### Test-level honesty (what the mock does and does not cover)
+
+The real producer `syncAttendanceReportPeriodSummary` is exercised via **mock-multitable +
+mock-db** (the mock captures the actual write payload the producer emits). The integration
+harness (`attendance-plugin.test.ts`) does not currently wire the multitable plugin, so an
+HTTP-level test against real `provisioning.ensureObject` / `records.createRecord` is **not**
+added in this slice — that path would only ever hit the `degraded` branch there. This is the
+producer-level wire (field assembly + fingerprint + create/patch/skip decision), which is
+the right level for this change; drift between the producer and the multitable record API is
+out of scope here and is covered by the multitable plugin's own tests. This is **not** the
+same as the #1829 cap-policy integration test, which hit real Postgres + real HTTP — that
+was a settings round-trip; this slice's writes target multitable provisioning, which the
+harness lacks.
+
+## Verification run
+
+- `attendance-comprehensive-hours-control.test.ts`: 28/28.
+- Full core-backend unit suite: 2309/2309.
+- `tsc` (build:cache): clean.
+- Mock-db uses a hard-fail default (`throw` on unmocked query) so a missing mock surfaces as a failure, not a silent `[]`.
+
+## Cross-references
+
+- `docs/development/attendance-comprehensive-hours-pr6-snapshot-boundary-20260525.md` (#1819) — boundary contract.
+- `docs/development/attendance-comprehensive-hours-pr6-runtime-orientation-20260525.md` (#1823) — established this as the post-cap-policy slice.
+- `docs/development/attendance-comprehensive-hours-cap-policy-persistence-design-20260525.md` (#1825) — resolver contract + period-type bridge + fingerprint-via-companion-fields.
+- cap-policy impl V1 (#1829) — the resolver/bridge this slice consumes.
+- `[[attendance-multitable-report-boundary]]`, `[[staged-opt-in-lineage]]`, `[[feedback_metasheet2_skip_when_unreachable_blind_spot]]`.
+
+## Not done (future opt-ins)
+
+Per-org / attendance-group / per-user cap override; effective-dating + retroactive recompute;
+`payroll_cycle` cap derivation (cycle-template mapping); additional comprehensive-hours
+metrics beyond `excess_minutes`; any UI surfacing of these columns.

--- a/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
+++ b/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
@@ -1,6 +1,6 @@
 import { readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
-import { describe, expect, it } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 
 const require = createRequire(import.meta.url)
 const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
@@ -594,5 +594,154 @@ describe('comprehensive-hours cap-policy persistence (V1)', () => {
   it('settingsSchema accepts comprehensiveHours.capDefaults (not stripped on save)', () => {
     expect(pluginSource).toMatch(/comprehensiveHours:\s*z\.object\(\{\s*\n\s*capDefaults:\s*z\.object\(\{/)
     expect(pluginSource).toMatch(/capDefaults:\s*z\.object\(\{\s*\n\s*month:\s*z\.number\(\)/)
+  })
+})
+
+describe('comprehensive-hours period value-plumbing (PR6)', () => {
+  const orgId = 'org-1'
+  const userId = 'u-1'
+  // Exact natural March → bridges to cycle-type 'month'.
+  const naturalMonth = {
+    periodType: 'date_range',
+    from: '2026-03-01',
+    to: '2026-03-31',
+    periodKey: '2026-03',
+    periodName: 'Mar 2026',
+    periodStart: '2026-03-01',
+    periodEnd: '2026-03-31',
+  }
+  const logger = { warn() {}, error() {}, info() {} }
+  const monthCap = (minutes: number | null) => ({ comprehensiveHours: { capDefaults: { month: minutes, quarter: null, year: null } } })
+
+  beforeEach(() => helpers.resetAttendanceSettingsCacheForTests())
+  afterEach(() => helpers.resetAttendanceSettingsCacheForTests())
+
+  function createMultitableContext() {
+    const createRecord = vi.fn().mockResolvedValue({ id: 'rec-new' })
+    const patchRecord = vi.fn().mockResolvedValue({})
+    const queryRecords = vi.fn().mockResolvedValue([])
+    const ensureObject = vi.fn().mockResolvedValue({ baseId: 'base-1', sheet: { id: 'sheet-1' } })
+    return {
+      createRecord,
+      patchRecord,
+      queryRecords,
+      // No resolveFieldIds → the sync uses identity field mapping, so logical id === physical id.
+      context: { api: { multitable: { provisioning: { ensureObject }, records: { queryRecords, createRecord, patchRecord } } } },
+    }
+  }
+
+  function createSyncDb(settings: unknown, totalMinutes = 13000) {
+    const queries: Array<{ sql: string, params: unknown[] }> = []
+    const summaryRow = {
+      total_days: 22, total_minutes: totalMinutes, total_late_minutes: 0, total_early_leave_minutes: 0,
+      normal_days: 22, late_days: 0, early_leave_days: 0, late_early_days: 0, partial_days: 0,
+      absent_days: 0, adjusted_days: 0, off_days: 9,
+    }
+    return {
+      queries,
+      async query(sql: string, params: unknown[] = []) {
+        const s = String(sql)
+        queries.push({ sql: s, params })
+        if (/FROM system_configs/i.test(s)) return [{ value: JSON.stringify(settings) }]
+        if (/is_workday THEN work_minutes/i.test(s)) return [summaryRow]
+        if (/FROM attendance_requests/i.test(s)) return []
+        if (/FROM users u/i.test(s)) return [{ user_name: 'U One', username: 'u1', meta: null }]
+        if (/FROM attendance_leave_types/i.test(s)) return []
+        if (/FROM attendance_overtime_rules/i.test(s)) return []
+        throw new Error('unmocked query: ' + s.replace(/\s+/g, ' ').slice(0, 90))
+      },
+    }
+  }
+
+  // --- value helper: stale-null + cap (no DB) ---
+  it('value helper: aligned date_range with cap → excess; others → null', () => {
+    const withCap = helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues(monthCap(10560), orgId, userId, naturalMonth, 13000)
+    expect(withCap).toEqual({
+      comprehensive_hours_excess_minutes: 2440,
+      comprehensive_hours_cap_minutes: 10560,
+      comprehensive_hours_cap_source: 'org_default_by_cycle_type',
+      comprehensive_hours_cap_effective_key: expect.stringMatching(/^cfg:[0-9a-f]{12}$/),
+    })
+    const allNull = {
+      comprehensive_hours_excess_minutes: null,
+      comprehensive_hours_cap_minutes: null,
+      comprehensive_hours_cap_source: null,
+      comprehensive_hours_cap_effective_key: null,
+    }
+    expect(helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues({}, orgId, userId, naturalMonth, 13000)).toEqual(allNull)
+    expect(helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues(monthCap(10560), orgId, userId, { ...naturalMonth, periodType: 'payroll_cycle' }, 13000)).toEqual(allNull)
+    expect(helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues(monthCap(10560), orgId, userId, { periodType: 'date_range', from: '2026-03-02', to: '2026-03-30' }, 13000)).toEqual(allNull)
+    expect(helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues(monthCap(10560), orgId, userId, { from: '2026-03-01', to: '2026-03-31' }, 13000)).toEqual(allNull)
+  })
+
+  // --- stale-null through the real sync ---
+  it('sync stale-nulls the comprehensive-hours columns when no org default applies', async () => {
+    const mt = createMultitableContext()
+    const result = await helpers.syncAttendanceReportPeriodSummary(mt.context, createSyncDb(monthCap(null)), orgId, logger, { userId, period: naturalMonth })
+    expect(result.created).toBe(1)
+    const data = mt.createRecord.mock.calls[0][0].data
+    expect(data.comprehensive_hours_excess_minutes).toBeNull()
+    expect(data.comprehensive_hours_cap_minutes).toBeNull()
+    expect(data.comprehensive_hours_cap_source).toBeNull()
+    expect(data.comprehensive_hours_cap_effective_key).toBeNull()
+  })
+
+  it('sync writes the computed excess + cap companion fields when a cap is configured', async () => {
+    const mt = createMultitableContext()
+    await helpers.syncAttendanceReportPeriodSummary(mt.context, createSyncDb(monthCap(10560)), orgId, logger, { userId, period: naturalMonth })
+    const data = mt.createRecord.mock.calls[0][0].data
+    expect(data.comprehensive_hours_excess_minutes).toBe(2440)
+    expect(data.comprehensive_hours_cap_minutes).toBe(10560)
+    expect(data.comprehensive_hours_cap_source).toBe('org_default_by_cycle_type')
+    expect(data.comprehensive_hours_cap_effective_key).toMatch(/^cfg:/)
+  })
+
+  // --- cap-fingerprint re-sync (capture-and-replay through the real fingerprint mechanism) ---
+  it('re-syncs on cap change and skips when unchanged', async () => {
+    const mt = createMultitableContext()
+    const r1 = await helpers.syncAttendanceReportPeriodSummary(mt.context, createSyncDb(monthCap(10560)), orgId, logger, { userId, period: naturalMonth })
+    expect(r1.created).toBe(1)
+    const stored = mt.createRecord.mock.calls[0][0].data
+    mt.queryRecords.mockResolvedValue([{ id: 'rec-1', data: stored }])
+
+    helpers.resetAttendanceSettingsCacheForTests()
+    const r2 = await helpers.syncAttendanceReportPeriodSummary(mt.context, createSyncDb(monthCap(10560)), orgId, logger, { userId, period: naturalMonth })
+    expect(r2.skipped).toBe(1)
+    expect(mt.patchRecord).not.toHaveBeenCalled()
+
+    helpers.resetAttendanceSettingsCacheForTests()
+    const r3 = await helpers.syncAttendanceReportPeriodSummary(mt.context, createSyncDb(monthCap(9000)), orgId, logger, { userId, period: naturalMonth })
+    expect(r3.patched).toBe(1)
+    const changes = mt.patchRecord.mock.calls[0][0].changes
+    expect(changes.comprehensive_hours_cap_minutes).toBe(9000)
+    expect(changes.comprehensive_hours_excess_minutes).toBe(4000)
+  })
+
+  it('re-syncs a pre-PR6 row whose fingerprint predates the comprehensive-hours columns', async () => {
+    const mt = createMultitableContext()
+    mt.queryRecords.mockResolvedValue([{ id: 'rec-old', data: { source_fingerprint: 'stale-old-fp', field_fingerprint: 'stale-old-ff' } }])
+    const result = await helpers.syncAttendanceReportPeriodSummary(mt.context, createSyncDb(monthCap(10560)), orgId, logger, { userId, period: naturalMonth })
+    expect(result.patched).toBe(1)
+    expect(mt.patchRecord).toHaveBeenCalledTimes(1)
+  })
+
+  // --- no raw meta / snapshot-table write: snapshot writes go through the multitable records API only ---
+  it('performs no raw INSERT/UPDATE/DELETE and never touches meta_ or the snapshot table directly', async () => {
+    const mt = createMultitableContext()
+    const db = createSyncDb(monthCap(10560))
+    await helpers.syncAttendanceReportPeriodSummary(mt.context, db, orgId, logger, { userId, period: naturalMonth })
+    expect(db.queries.filter((q) => /\b(INSERT|UPDATE|DELETE)\b/i.test(q.sql))).toEqual([])
+    expect(db.queries.some((q) => /attendance_report_period_summaries|\bmeta_/i.test(q.sql))).toBe(false)
+    // The only snapshot writes are through the records API.
+    expect(mt.createRecord).toHaveBeenCalledTimes(1)
+  })
+
+  // --- no parallel producer + wiring + ordering (source-level guards) ---
+  it('no parallel comprehensive-hours producer; helper wired into the sync after the loop and before the fingerprint', () => {
+    expect(pluginSource).not.toMatch(/async function sync[A-Za-z]*Comprehensive[A-Za-z]*\b/)
+    expect(pluginSource).toMatch(/buildAttendanceComprehensiveHoursPeriodSummaryValues\(/)
+    expect(pluginSource).toMatch(
+      /for \(const column of valueColumns\)[\s\S]*?Object\.assign\(logical, comprehensiveHoursValues\)[\s\S]*?buildAttendanceReportPeriodSummarySourceFingerprint\(logical\)/,
+    )
   })
 })

--- a/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
+++ b/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
@@ -669,9 +669,13 @@ describe('comprehensive-hours period value-plumbing (PR6)', () => {
       comprehensive_hours_cap_effective_key: null,
     }
     expect(helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues({}, orgId, userId, naturalMonth, 13000)).toEqual(allNull)
+    // Fail-closed periodType whitelist: only date_range proceeds.
     expect(helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues(monthCap(10560), orgId, userId, { ...naturalMonth, periodType: 'payroll_cycle' }, 13000)).toEqual(allNull)
-    expect(helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues(monthCap(10560), orgId, userId, { periodType: 'date_range', from: '2026-03-02', to: '2026-03-30' }, 13000)).toEqual(allNull)
+    expect(helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues(monthCap(10560), orgId, userId, { ...naturalMonth, periodType: 'custom_range' }, 13000)).toEqual(allNull)
+    expect(helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues(monthCap(10560), orgId, userId, { ...naturalMonth, periodType: 'some_future_type' }, 13000)).toEqual(allNull)
     expect(helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues(monthCap(10560), orgId, userId, { from: '2026-03-01', to: '2026-03-31' }, 13000)).toEqual(allNull)
+    // A non-aligned date_range still proceeds to the bridge, which yields custom_range → null.
+    expect(helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues(monthCap(10560), orgId, userId, { periodType: 'date_range', from: '2026-03-02', to: '2026-03-30' }, 13000)).toEqual(allNull)
   })
 
   // --- stale-null through the real sync ---

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -12096,7 +12096,9 @@ function buildAttendanceComprehensiveHoursPeriodSummaryValues(settings, orgId, u
     comprehensive_hours_cap_source: null,
     comprehensive_hours_cap_effective_key: null,
   }
-  if (!period || !period.periodType || period.periodType === 'payroll_cycle') return nullValues
+  // Whitelist date_range (fail-closed): only a date_range window bridges to a cycle-type.
+  // payroll_cycle, missing, and any future periodType stale-null until explicitly supported.
+  if (!period || period.periodType !== 'date_range') return nullValues
   const bridged = bridgeAttendanceDateRangeToComprehensiveHoursPeriod(period.from, period.to)
   const cap = resolveAttendanceComprehensiveHoursCap(settings, orgId, userId, bridged)
   if (!cap) return nullValues

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -3544,17 +3544,21 @@ async function syncAttendanceReportPeriodSummary(context, db, orgId, logger, par
   const dynamicSubtype = await loadAttendanceReportDynamicSubtypeContext(db, orgId, logger)
   const valueFields = buildAttendanceReportPeriodSummaryValueFields(managedSummaryFormulaFields, dynamicSubtype.definitions)
   const valueColumns = buildAttendanceReportPeriodSummaryValueColumns(valueFields)
+  // Comprehensive-hours system columns are provisioned alongside the catalog value columns
+  // but filled separately (not from the catalog value loop). fieldFingerprint stays keyed
+  // on valueFields only — these are system columns, not catalog config.
+  const allValueColumns = [...valueColumns, ...ATTENDANCE_COMPREHENSIVE_HOURS_PERIOD_VALUE_COLUMNS]
   const activeValueCodes = buildAttendanceReportPeriodSummaryActiveValueCodes(summaryFormulaFields, dynamicSubtype.definitions)
   const fieldFingerprint = buildAttendanceReportFieldConfigFingerprint(valueFields).value
 
   const baseDescriptor = getAttendanceReportPeriodSummariesDescriptor()
   await provisioning.ensureObject({
     projectId: ensured.projectId,
-    descriptor: { ...baseDescriptor, fields: [...baseDescriptor.fields, ...valueColumns] },
+    descriptor: { ...baseDescriptor, fields: [...baseDescriptor.fields, ...allValueColumns] },
   })
   const logicalIds = [
     ...Object.values(ATTENDANCE_REPORT_PERIOD_SUMMARIES_FIELDS),
-    ...valueColumns.map(column => column.id),
+    ...allValueColumns.map(column => column.id),
   ]
   const fieldIds = typeof provisioning.resolveFieldIds === 'function'
     ? await provisioning.resolveFieldIds({
@@ -3605,6 +3609,20 @@ async function syncAttendanceReportPeriodSummary(context, db, orgId, logger, par
       const value = getAttendancePeriodSummaryFieldValue(summaryWithFormulas, column.id)
       logical[column.id] = value === '' && isAttendanceDynamicSubtypeCode(column.id) ? 0 : value
     }
+    // Comprehensive-hours metric + cap companion fields. Set AFTER the catalog value loop
+    // and BEFORE the source fingerprint so the cap value/source/effective_key are hashed
+    // into source_fingerprint (a cap edit → fingerprint change → re-sync). Stale-nulls when
+    // no org default applies.
+    const settings = await getSettings(db)
+    const { actualMinutes } = buildAttendanceComprehensiveActualMinutesFromSummary(summary)
+    const comprehensiveHoursValues = buildAttendanceComprehensiveHoursPeriodSummaryValues(
+      settings,
+      orgId,
+      userId,
+      period,
+      actualMinutes,
+    )
+    Object.assign(logical, comprehensiveHoursValues)
     const sourceFingerprint = buildAttendanceReportPeriodSummarySourceFingerprint(logical)
 
     const data = {}
@@ -10165,6 +10183,12 @@ async function loadSettings(db) {
   }
 }
 
+// Test-only: clear the module-level settings cache so a test can control the persisted
+// settings per case (the 60s TTL would otherwise leak settings across tests).
+function resetAttendanceSettingsCacheForTests() {
+  settingsCache = { value: DEFAULT_SETTINGS, loadedAt: 0 }
+}
+
 async function getSettings(db) {
   if (Date.now() - settingsCache.loadedAt < SETTINGS_CACHE_TTL_MS) {
     return settingsCache.value
@@ -12045,6 +12069,50 @@ function resolveAttendanceComprehensiveHoursCap(settings, orgId, userId, period)
       comprehensive_hours_cap_source: source,
       comprehensive_hours_cap_effective_key: buildAttendanceComprehensiveHoursCapEffectiveKey(capDefaults),
     },
+  }
+}
+
+// ── PR6 value-plumbing: one period-level comprehensive-hours metric + cap companion fields ──
+// System-managed value columns (not catalog-authored) injected into the period-summary
+// snapshot. They ride the existing provisioning + record-write path; no new producer, no
+// route, no UI, no migration. The cap companion fields carry the resolver's fingerprintPayload
+// so a cap edit changes the row source_fingerprint and the row re-syncs.
+const ATTENDANCE_COMPREHENSIVE_HOURS_PERIOD_VALUE_COLUMNS = Object.freeze([
+  { id: 'comprehensive_hours_excess_minutes', name: '综合工时超额（分钟）', type: 'number', order: 4000 },
+  { id: 'comprehensive_hours_cap_minutes', name: '综合工时上限（分钟）', type: 'number', order: 4001 },
+  { id: 'comprehensive_hours_cap_source', name: '综合工时上限来源', type: 'string', order: 4002 },
+  { id: 'comprehensive_hours_cap_effective_key', name: '综合工时上限版本', type: 'string', order: 4003 },
+])
+
+// Compute the four comprehensive-hours period values for one row. Fail-closed: only an
+// explicit date_range that bridges to an aligned month/quarter/year with a configured org
+// default yields a cap; payroll_cycle / custom_range / missing type / unset cap all
+// stale-null. Reuses the cap resolver (#1829) and the shared excess math — no parallel
+// computation.
+function buildAttendanceComprehensiveHoursPeriodSummaryValues(settings, orgId, userId, period, actualMinutes) {
+  const nullValues = {
+    comprehensive_hours_excess_minutes: null,
+    comprehensive_hours_cap_minutes: null,
+    comprehensive_hours_cap_source: null,
+    comprehensive_hours_cap_effective_key: null,
+  }
+  if (!period || !period.periodType || period.periodType === 'payroll_cycle') return nullValues
+  const bridged = bridgeAttendanceDateRangeToComprehensiveHoursPeriod(period.from, period.to)
+  const cap = resolveAttendanceComprehensiveHoursCap(settings, orgId, userId, bridged)
+  if (!cap) return nullValues
+  const comparison = buildAttendanceComprehensiveHoursComparison({
+    userId,
+    period: bridged.key,
+    metric: 'actual',
+    enforcement: 'warn',
+    capMinutes: cap.capMinutes,
+    minutes: actualMinutes,
+  })
+  return {
+    comprehensive_hours_excess_minutes: comparison.excessMinutes,
+    comprehensive_hours_cap_minutes: cap.fingerprintPayload.comprehensive_hours_cap_minutes,
+    comprehensive_hours_cap_source: cap.fingerprintPayload.comprehensive_hours_cap_source,
+    comprehensive_hours_cap_effective_key: cap.fingerprintPayload.comprehensive_hours_cap_effective_key,
   }
 }
 
@@ -14050,6 +14118,9 @@ module.exports = {
     bridgeAttendanceDateRangeToComprehensiveHoursPeriod,
     resolveAttendanceComprehensiveHoursCap,
     buildAttendanceComprehensiveHoursCapEffectiveKey,
+    buildAttendanceComprehensiveHoursPeriodSummaryValues,
+    ATTENDANCE_COMPREHENSIVE_HOURS_PERIOD_VALUE_COLUMNS,
+    resetAttendanceSettingsCacheForTests,
     mergeSettings,
     calculateAttendanceComprehensiveShiftPlannedMinutes,
     buildAttendanceComprehensivePlannedMinutesFromDays,


### PR DESCRIPTION
## What

Minimal PR6 runtime slice: wires the #1829 cap resolver into `syncAttendanceReportPeriodSummary`, surfacing **one** period-level metric `comprehensive_hours_excess_minutes` + 3 cap companion fields into the `attendance_report_period_summaries` snapshot. 3 files, +311/-3.

**Out of scope (unchanged):** no route, no UI, **no migration**, no new writer/producer, daily `attendance_report_records` untouched, preview behavior unchanged, no group/per-user override, no effective-dating, no `payroll_cycle` cap derivation.

## Design

- 4 **system-managed** value columns (`ATTENDANCE_COMPREHENSIVE_HOURS_PERIOD_VALUE_COLUMNS`) appended to the provisioned set (`allValueColumns`) — they ride the existing `ensureObject` + `records.createRecord/patchRecord` path. **Not** added to `valueFields`, so the field-config fingerprint is unaffected (these are system columns, not catalog config — no catalog seed, no migration).
- `buildAttendanceComprehensiveHoursPeriodSummaryValues`: **fail-closed** — only an explicit `date_range` bridging to an aligned month/quarter/year with a configured org default yields a cap; `payroll_cycle` / `custom_range` / missing `periodType` / unset cap all **stale-null** all four columns. Excess reuses `buildAttendanceComprehensiveHoursComparison` (no parallel computation).
- Values set into `logical` **after** the catalog value loop and **before** `buildAttendanceReportPeriodSummarySourceFingerprint(logical)`, so cap value/source/effective_key are hashed into `source_fingerprint` → a cap edit re-syncs the row; existing pre-PR6 rows re-sync once automatically (extra keys diverge the fingerprint).

## Tests (28/28, 7 new)

value/stale-null logic · **real-sync stale-null** · computed write · **cap-fingerprint re-sync** (capture-and-replay through the real fingerprint mechanism) + skip-when-unchanged · **pre-PR6 row migration** · **no raw INSERT/UPDATE + no `meta_`/snapshot-table SQL** (writes only via records API) · no-parallel-producer + wiring/ordering source guards. Full core-backend unit suite **2309/2309**; `tsc` clean.

### Test-level disclosure

The real producer `syncAttendanceReportPeriodSummary` is exercised via **mock-multitable + mock-db** (captures the actual write payload the producer emits, with a hard-fail default on unmocked queries). The integration harness does **not** wire the multitable plugin, so an HTTP-level test against real `provisioning`/`records` is **not** added in this slice (that path only hits `degraded` there). This is the producer-level wire — the right level for this change; producer↔multitable-API drift is covered by the multitable plugin's own tests. Not claiming a real-Postgres round-trip like the #1829 settings test, which was a different (settings) path. See the verification MD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)