### PR TITLE
feat(multitable): inline create row — trailing "+ New record" in the grid

### DIFF
--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -116,6 +116,13 @@
               <div class="meta-grid__empty-hint">{{ l('grid.noRecordsHintPrefix') }} <strong>{{ l('grid.noRecordsHintAction') }}</strong> {{ l('grid.noRecordsHintSuffix') }}</div>
             </td>
           </tr>
+          <tr v-if="canCreate && filteredRows.length && !loading" class="meta-grid__add-row">
+            <td :colspan="colSpan">
+              <button type="button" class="meta-grid__add-row-btn" @click="emit('create-record')">
+                <span class="meta-grid__add-row-plus" aria-hidden="true">+</span> {{ l('grid.addRecordInline') }}
+              </button>
+            </td>
+          </tr>
         </tbody>
         <tbody v-else>
           <template v-for="(row, ri) in filteredRows" :key="row.id">
@@ -223,6 +230,13 @@
               </template>
             </td>
           </tr>
+          <tr v-if="canCreate && filteredRows.length && !loading" class="meta-grid__add-row">
+            <td :colspan="colSpan">
+              <button type="button" class="meta-grid__add-row-btn" @click="emit('create-record')">
+                <span class="meta-grid__add-row-plus" aria-hidden="true">+</span> {{ l('grid.addRecordInline') }}
+              </button>
+            </td>
+          </tr>
         </tbody>
       </table>
     </div>
@@ -296,6 +310,7 @@ const props = defineProps<{
   canEdit: boolean
   canDelete?: boolean
   canBulkEdit?: boolean
+  canCreate?: boolean
   rowActionOverrides?: Record<string, MetaRowActions>
   fieldReadOnlyIds?: string[]
   columnWidths?: Record<string, number>
@@ -325,6 +340,7 @@ const emit = defineEmits<{
   (e: 'bulk-delete', recordIds: string[]): void
   (e: 'bulk-edit', payload: { mode: 'set' | 'clear'; recordIds: string[] }): void
   (e: 'reorder-field', fromFieldId: string, toFieldId: string): void
+  (e: 'create-record'): void
 }>()
 
 const { isZh } = useLocale()
@@ -637,6 +653,14 @@ function onKeydown(e: KeyboardEvent) {
 .meta-grid__field-comment-action--idle {
   color: #94a3b8;
 }
+.meta-grid__add-row td { padding: 0; border-top: 1px solid #eef0f2; }
+.meta-grid__add-row-btn {
+  display: flex; align-items: center; gap: 6px; width: 100%;
+  padding: 8px 12px; background: transparent; border: none; cursor: pointer;
+  font-size: 13px; color: #4a5568; text-align: left; position: sticky; left: 0;
+}
+.meta-grid__add-row-btn:hover { background: #f5f7fa; color: #2563eb; }
+.meta-grid__add-row-plus { font-weight: 700; font-size: 15px; line-height: 1; }
 .meta-grid__empty { text-align: center; padding: 48px 32px; color: #999; }
 .meta-grid__empty-icon { font-size: 36px; margin-bottom: 8px; opacity: 0.5; }
 .meta-grid__empty-title { font-size: 15px; font-weight: 600; color: #666; margin-bottom: 4px; }

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -52,6 +52,7 @@ export type MetaCoreLabelKey =
   | 'grid.clear' | 'grid.clearSelection'
   | 'grid.noRecordsTitle'
   | 'grid.noRecordsHintPrefix' | 'grid.noRecordsHintAction' | 'grid.noRecordsHintSuffix'
+  | 'grid.addRecordInline'
   | 'grid.noMatchingTitle' | 'grid.noMatchingHint'
   | 'grid.collapseRow' | 'grid.expandRow'
   | 'grid.prev' | 'grid.next' | 'grid.loading'
@@ -147,6 +148,7 @@ const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
   'grid.noRecordsHintPrefix': { en: 'Click', zh: '点击' },
   'grid.noRecordsHintAction': { en: '+ New Record', zh: '+ 新建记录' },
   'grid.noRecordsHintSuffix': { en: 'to add your first row', zh: '添加第一行' },
+  'grid.addRecordInline': { en: '+ New record', zh: '+ 新建记录' },
   'grid.noMatchingTitle': { en: 'No matching records', zh: '没有匹配的记录' },
   'grid.noMatchingHint': { en: 'Try a different search term', zh: '试试其他搜索词' },
   'grid.collapseRow': { en: 'Collapse row', zh: '收起行' },

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -148,7 +148,7 @@ const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
   'grid.noRecordsHintPrefix': { en: 'Click', zh: '点击' },
   'grid.noRecordsHintAction': { en: '+ New Record', zh: '+ 新建记录' },
   'grid.noRecordsHintSuffix': { en: 'to add your first row', zh: '添加第一行' },
-  'grid.addRecordInline': { en: '+ New record', zh: '+ 新建记录' },
+  'grid.addRecordInline': { en: 'New record', zh: '新建记录' },
   'grid.noMatchingTitle': { en: 'No matching records', zh: '没有匹配的记录' },
   'grid.noMatchingHint': { en: 'Try a different search term', zh: '试试其他搜索词' },
   'grid.collapseRow': { en: 'Collapse row', zh: '收起行' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -246,7 +246,7 @@
           :rows="grid.rows.value" :visible-fields="scopedGridFields" :sort-rules="grid.sortRules.value"
           :loading="grid.loading.value" :current-page="grid.currentPage.value" :total-pages="grid.totalPages.value"
           :start-index="pageStartIndex" :selected-record-id="selectedRecordId" :can-edit="effectiveRowActions.canEdit"
-          :can-delete="gridAllowsAnyDelete" :can-bulk-edit="effectiveRowActions.canEdit" :field-read-only-ids="readOnlyFieldIds" :column-widths="grid.columnWidths.value"
+          :can-delete="gridAllowsAnyDelete" :can-bulk-edit="effectiveRowActions.canEdit" :can-create="caps.canCreateRecord.value" :field-read-only-ids="readOnlyFieldIds" :column-widths="grid.columnWidths.value"
           :row-action-overrides="grid.rowActionOverrides.value"
           :link-summaries="grid.linkSummaries.value" :attachment-summaries="grid.attachmentSummaries.value"
           :enable-multi-select="gridAllowsAnyDelete || effectiveRowActions.canEdit"
@@ -260,6 +260,7 @@
           @select-record="onSelectRecord" @toggle-sort="onToggleSort" @patch-cell="onPatchCell"
           @go-to-page="grid.goToPage" @open-link-picker="onGridLinkPicker" @resize-column="grid.setColumnWidth"
           @bulk-delete="onBulkDelete" @bulk-edit="onBulkEditRequest" @reorder-field="onReorderField"
+          @create-record="onAddRecord"
           @open-comments="onOpenRecordComments"
           @open-field-comments="onOpenGridFieldComments"
         />

--- a/apps/web/tests/multitable-grid-inline-create-row.spec.ts
+++ b/apps/web/tests/multitable-grid-inline-create-row.spec.ts
@@ -1,0 +1,78 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaGridTable from '../src/multitable/components/MetaGridTable.vue'
+import type { MetaField, MetaRecord } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  app?.unmount()
+  app = null
+  container?.remove()
+  container = null
+  useLocale().setLocale('en')
+})
+
+const TITLE_FIELD: MetaField = { id: 'title', name: 'Title', type: 'string' }
+const ONE_ROW: MetaRecord[] = [{ id: 'r1', version: 1, data: { title: 'Alpha' } }]
+
+function mountGrid(props: Record<string, unknown>) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp({
+    setup() {
+      return () => h(MetaGridTable, {
+        rows: ONE_ROW,
+        visibleFields: [TITLE_FIELD],
+        sortRules: [],
+        loading: false,
+        currentPage: 1,
+        totalPages: 1,
+        startIndex: 0,
+        canEdit: true,
+        searchText: '',
+        rowDensity: 'normal',
+        ...props,
+      })
+    },
+  })
+  app.mount(container)
+  return container
+}
+
+describe('MetaGridTable inline create row', () => {
+  it('renders the "+" add-row when canCreate and rows exist', () => {
+    const root = mountGrid({ canCreate: true, rows: ONE_ROW })
+    const btn = root.querySelector('.meta-grid__add-row-btn')
+    expect(btn).not.toBeNull()
+    expect(btn?.textContent).toContain('+ New record')
+  })
+
+  it('localizes the add-row label in zh-CN', () => {
+    useLocale().setLocale('zh-CN')
+    const root = mountGrid({ canCreate: true, rows: ONE_ROW })
+    expect(root.querySelector('.meta-grid__add-row-btn')?.textContent).toContain('+ 新建记录')
+  })
+
+  it('hides the add-row when canCreate is false (capability gate)', () => {
+    const root = mountGrid({ canCreate: false, rows: ONE_ROW })
+    expect(root.querySelector('.meta-grid__add-row-btn')).toBeNull()
+  })
+
+  it('hides the add-row when there are no rows (empty-state CTA owns that case)', () => {
+    const root = mountGrid({ canCreate: true, rows: [] })
+    expect(root.querySelector('.meta-grid__add-row-btn')).toBeNull()
+    // empty state still shown
+    expect(root.textContent ?? '').toContain('No records yet')
+  })
+
+  it('emits create-record on click (wired to the gated create path)', async () => {
+    const onCreateRecord = vi.fn()
+    const root = mountGrid({ canCreate: true, rows: ONE_ROW, onCreateRecord })
+    const btn = root.querySelector('.meta-grid__add-row-btn') as HTMLButtonElement
+    btn.click()
+    expect(onCreateRecord).toHaveBeenCalledTimes(1)
+  })
+})

--- a/apps/web/tests/multitable-grid-inline-create-row.spec.ts
+++ b/apps/web/tests/multitable-grid-inline-create-row.spec.ts
@@ -43,17 +43,20 @@ function mountGrid(props: Record<string, unknown>) {
 }
 
 describe('MetaGridTable inline create row', () => {
-  it('renders the "+" add-row when canCreate and rows exist', () => {
+  const btnText = (root: HTMLElement) =>
+    (root.querySelector('.meta-grid__add-row-btn')?.textContent ?? '').replace(/\s+/g, ' ').trim()
+
+  it('renders the "+" add-row when canCreate and rows exist (single + glyph, no duplicate)', () => {
     const root = mountGrid({ canCreate: true, rows: ONE_ROW })
-    const btn = root.querySelector('.meta-grid__add-row-btn')
-    expect(btn).not.toBeNull()
-    expect(btn?.textContent).toContain('+ New record')
+    expect(root.querySelector('.meta-grid__add-row-btn')).not.toBeNull()
+    // exact normalized text — guards against the "+ +" glyph/label duplication
+    expect(btnText(root)).toBe('+ New record')
   })
 
-  it('localizes the add-row label in zh-CN', () => {
+  it('localizes the add-row label in zh-CN (single + glyph)', () => {
     useLocale().setLocale('zh-CN')
     const root = mountGrid({ canCreate: true, rows: ONE_ROW })
-    expect(root.querySelector('.meta-grid__add-row-btn')?.textContent).toContain('+ 新建记录')
+    expect(btnText(root)).toBe('+ 新建记录')
   })
 
   it('hides the add-row when canCreate is false (capability gate)', () => {

--- a/docs/development/multitable-inline-create-row-verification-20260525.md
+++ b/docs/development/multitable-inline-create-row-verification-20260525.md
@@ -1,0 +1,59 @@
+# Multitable Inline Create Row — Verification (2026-05-25)
+
+Benchmark v2 §9 #4 (Grid BI polish), first sub-slice: a trailing "+ New record" row in the grid
+that creates a record directly, instead of only the toolbar / empty-state CTA.
+
+Predecessor: D3 permission matrix complete (#1831). Successor sub-slices of #4 (frozen columns,
+agg footer / group rollup) are separate opt-ins.
+
+---
+
+## 1. What shipped
+
+- **`MetaGridTable.vue`**: a trailing `"+ New record"` row (`.meta-grid__add-row`) in **both** the
+  grouped and flat `<tbody>` branches. Gated `v-if="canCreate && filteredRows.length && !loading"`,
+  emits **`create-record`** on click. New prop `canCreate?: boolean`, new emit `create-record`.
+- **`MultitableWorkbench.vue`**: passes `:can-create="caps.canCreateRecord.value"` and wires
+  `@create-record="onAddRecord"` — the **existing gated empty-create path** (`grid.createRecord()` →
+  `loadViewData` reload). Same handler the toolbar "+ New Record" button uses.
+- **`meta-core-labels.ts`**: `grid.addRecordInline` (`+ New record` / `+ 新建记录`), via the typed
+  `MetaCoreLabelKey` module (i18n discipline).
+- **CSS**: `.meta-grid__add-row-btn` — full-width, sticky-left (visible during horizontal scroll),
+  hover affordance, `+` glyph `aria-hidden`.
+
+## 2. Design (quick-add, confirmed scope)
+
+Reuses the existing create semantics verbatim — clicking the row fires the **same** gated
+`onAddRecord` (empty `createRecord()`), and the existing post-create reload surfaces the new blank
+row (then the user edits inline / opens the drawer). No editable phantom-row, no new create path.
+
+- **Capability gate:** identical to the toolbar button (`canCreateRecord` → `canCreate` prop). Hidden
+  for viewer/commenter.
+- **Empty state:** the "+" row shows only when rows exist; the 0-rows empty-state keeps its own
+  "+ New Record" CTA (no duplicate affordance).
+- **a11y:** real `<button>`, gated, localized label.
+
+## 3. Boundary
+
+- **`apps/web/src/multitable/` only** (multitable kernel-polish, allowed under the K3 lock). No
+  backend / api-client / contract / rbac change — reuses `createRecord` as-is.
+
+## 4. Verification
+
+- **Tests** — `apps/web/tests/multitable-grid-inline-create-row.spec.ts` (5 cases) + existing
+  `meta-grid-table-i18n.spec.ts` (6, regression): **11 passed**.
+  - renders when `canCreate` + rows; zh-CN label localized; hidden when `!canCreate`; hidden when
+    0 rows (empty-state owns it); emits `create-record` on click.
+- **Type-check** — `pnpm --filter @metasheet/web type-check` (vue-tsc -b): clean.
+- **Lint** — my changed lines are clean. Note: the web `lint` script scopes to a PLM/workflow/auth
+  allowlist and does **not** cover `src/multitable/**`, so this surface is gated by type-check + tests,
+  not eslint. (A targeted `eslint` run surfaced 2 **pre-existing** issues in `MultitableWorkbench.vue`
+  — an unused `apiFetch` import + an attribute-linebreak warning, both on lines I did not touch and
+  out of CI lint scope; left as-is, not this slice's debt.)
+
+## 5. Deferred (other #4 sub-slices, separate opt-ins)
+
+- Frozen columns (`view.config.frozenLeftColumnIds[]` + CSS sticky stack).
+- Aggregation footer / group rollup (BI core).
+- Inline-edit on the created blank row (current flow surfaces the row via reload; inline cell-edit
+  on a phantom row was explicitly out of scope — quick-add chosen).

--- a/docs/development/multitable-inline-create-row-verification-20260525.md
+++ b/docs/development/multitable-inline-create-row-verification-20260525.md
@@ -16,8 +16,9 @@ agg footer / group rollup) are separate opt-ins.
 - **`MultitableWorkbench.vue`**: passes `:can-create="caps.canCreateRecord.value"` and wires
   `@create-record="onAddRecord"` — the **existing gated empty-create path** (`grid.createRecord()` →
   `loadViewData` reload). Same handler the toolbar "+ New Record" button uses.
-- **`meta-core-labels.ts`**: `grid.addRecordInline` (`+ New record` / `+ 新建记录`), via the typed
-  `MetaCoreLabelKey` module (i18n discipline).
+- **`meta-core-labels.ts`**: `grid.addRecordInline` (`New record` / `新建记录`) via the typed
+  `MetaCoreLabelKey` module; the `+` is a separate `aria-hidden` glyph span → renders `+ New record`
+  (label intentionally has **no** leading `+` to avoid a doubled glyph).
 - **CSS**: `.meta-grid__add-row-btn` — full-width, sticky-left (visible during horizontal scroll),
   hover affordance, `+` glyph `aria-hidden`.
 


### PR DESCRIPTION
## What

benchmark v2 §9 #4 (Grid BI polish), first sub-slice. A gated trailing **"+ New record"** row in the grid (both grouped + flat `<tbody>`) that creates a record directly — instead of only the toolbar / empty-state CTA.

- **Quick-add** (confirmed scope): click → emits `create-record` → wired in the workbench to the **existing gated `onAddRecord`** path (`grid.createRecord()` → reload surfaces the blank row). No editable phantom row, no new create path.
- **Capability gate:** `canCreate ← caps.canCreateRecord` — identical to the toolbar button (hidden for viewer/commenter). Mirrors the Kanban sibling's `can-create`/`create-record` pattern.
- **Edge:** shows only when rows exist (0-rows empty-state keeps its own CTA); real `<button>` + `aria-hidden` `+` glyph; sticky-left; i18n `grid.addRecordInline`.

## Boundary

`apps/web/src/multitable/` only — **no backend / api-client / contract / rbac** change (reuses `createRecord` as-is). Multitable kernel-polish.

## Verification

- **vue-tsc** clean.
- **11 tests green** — 5 new (`multitable-grid-inline-create-row.spec.ts`: render/gate/empty/emit + zh-CN, exact-text assertion catches the `+`-glyph dedup) + 6 grid-i18n regression.
- `src/multitable/**` isn't in the web eslint allowlist → this surface is gated by type-check + tests.

🤖 Generated with [Claude Code](https://claude.com/claude-code)