### PR TITLE
feat(multitable): frozen columns (left-prefix sticky stack)

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldHeader.vue
+++ b/apps/web/src/multitable/components/MetaFieldHeader.vue
@@ -15,6 +15,15 @@
     <span v-if="sortDirection" class="meta-field-header__sort">
       {{ sortDirection === 'asc' ? '\u25B2' : '\u25BC' }}
     </span>
+    <button
+      type="button"
+      class="meta-field-header__pin"
+      :class="{ 'meta-field-header__pin--on': frozen }"
+      :aria-label="pinLabel"
+      :title="pinLabel"
+      @click.stop="emit('toggle-freeze')"
+      @mousedown.stop
+    >&#x1F4CC;</button>
     <div
       class="meta-field-header__resize"
       @mousedown.stop.prevent="onResizeStart"
@@ -25,6 +34,8 @@
 <script setup lang="ts">
 import { ref, computed } from 'vue'
 import type { MetaField } from '../types'
+import { useLocale } from '../../composables/useLocale'
+import { metaCoreLabel } from '../utils/meta-core-labels'
 
 const FIELD_ICONS: Record<string, string> = {
   string: 'Aa', longText: '\u00B6', number: '#', boolean: '\u2611', date: '\u{1F4C5}', dateTime: '\u{1F552}', select: '\u25CF', multiSelect: '\u25C9',
@@ -38,13 +49,19 @@ const props = defineProps<{
   sortDirection?: 'asc' | 'desc' | null
   sortable?: boolean
   width?: number
+  frozen?: boolean
+  frozenLeft?: number | null
 }>()
 
 const emit = defineEmits<{
   (e: 'toggle-sort'): void
   (e: 'resize', fieldId: string, width: number): void
   (e: 'reorder', fromFieldId: string, toFieldId: string): void
+  (e: 'toggle-freeze'): void
 }>()
+
+const { isZh } = useLocale()
+const pinLabel = computed(() => metaCoreLabel(props.frozen ? 'grid.unfreezeColumns' : 'grid.freezeUpToColumn', isZh.value))
 
 const isDragOver = ref(false)
 
@@ -68,8 +85,21 @@ function onDrop(e: DragEvent) {
 const fieldTypeIcon = computed(() => FIELD_ICONS[props.field.type] ?? '?')
 
 const headerStyle = computed(() => {
-  if (!props.width) return undefined
-  return { width: `${props.width}px`, minWidth: `${props.width}px`, maxWidth: `${props.width}px` }
+  const style: Record<string, string> = {}
+  if (props.width) {
+    style.width = `${props.width}px`
+    style.minWidth = `${props.width}px`
+    style.maxWidth = `${props.width}px`
+  }
+  // frozen header: inline position:sticky overrides the CSS `position: relative`, giving horizontal
+  // stickiness; the absolute resize handle still anchors to this th (sticky is a containing block).
+  if (props.frozenLeft != null) {
+    style.position = 'sticky'
+    style.left = `${props.frozenLeft}px`
+    style.zIndex = '4'
+    style.background = '#f9fafb'
+  }
+  return Object.keys(style).length ? style : undefined
 })
 
 function onResizeStart(e: MouseEvent) {
@@ -99,6 +129,10 @@ function onResizeStart(e: MouseEvent) {
 .meta-field-header__icon { display: inline-block; width: 22px; text-align: center; color: #999; font-size: 12px; margin-right: 4px; }
 .meta-field-header__name { overflow: hidden; text-overflow: ellipsis; }
 .meta-field-header__sort { margin-left: 4px; font-size: 10px; color: #409eff; }
+.meta-field-header__pin { border: none; background: none; cursor: pointer; padding: 0 2px; margin-left: 4px; font-size: 11px; line-height: 1; opacity: 0; transition: opacity 0.12s; vertical-align: middle; }
+.meta-field-header:hover .meta-field-header__pin { opacity: 0.4; }
+.meta-field-header__pin:hover { opacity: 0.85; }
+.meta-field-header__pin--on { opacity: 0.9; }
 .meta-field-header__resize { position: absolute; top: 0; right: -4px; width: 9px; height: 100%; cursor: col-resize; z-index: 2; }
 .meta-field-header__resize:hover { background: #409eff; opacity: 0.5; }
 .meta-field-header__resize::after { content: ''; position: absolute; top: 25%; left: 3px; width: 3px; height: 50%; border-left: 1px solid transparent; border-right: 1px solid transparent; }

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -505,10 +505,12 @@ function cellStyle(rid: string, fid: string, ci?: number) {
   const formatStyle = formatting
     ? composeStyleObject(undefined, formatting.cellStyles[fid])
     : undefined
-  // frozen body cell: sticky-left + opaque bg (occludes scrolled-under content). The solid bg means
-  // frozen cells don't show row hover/selection tint — accepted MVP limitation (see design §3).
+  // frozen body cell: sticky-left + an OPAQUE bg (occludes scrolled-under content). Preserve any
+  // conditional-formatting backgroundColor — only fall back to #fff when formatting set none. (Row
+  // hover/selection tint is still not shown on frozen cells — accepted MVP limitation; conditional
+  // formatting is NOT lost.)
   const frozenStyle: Record<string, string> | undefined = frozen
-    ? { position: 'sticky', left: `${frozenLeft(ci!)}px`, zIndex: '2', background: '#fff' }
+    ? { position: 'sticky', left: `${frozenLeft(ci!)}px`, zIndex: '2', backgroundColor: formatStyle?.backgroundColor ?? '#fff' }
     : undefined
   if (!widthStyle && !formatStyle && !frozenStyle) return undefined
   return { ...(widthStyle ?? {}), ...(formatStyle ?? {}), ...(frozenStyle ?? {}) }

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -14,17 +14,20 @@
             <th v-if="enableMultiSelect" class="meta-grid__check-col">
               <input type="checkbox" :checked="allSelected" @change="toggleSelectAll" />
             </th>
-            <th class="meta-grid__row-num">#</th>
+            <th class="meta-grid__row-num" :style="{ left: `${rowNumLeft}px` }">#</th>
             <MetaFieldHeader
-              v-for="field in visibleFields"
+              v-for="(field, fi) in visibleFields"
               :key="field.id"
               :field="field"
               :sort-direction="getSortDir(field.id)"
               :sortable="isSortable(field)"
               :width="columnWidths?.[field.id]"
+              :frozen="isFrozen(fi)"
+              :frozen-left="isFrozen(fi) ? frozenLeft(fi) : null"
               @toggle-sort="emit('toggle-sort', field.id)"
               @resize="(fid, w) => emit('resize-column', fid, w)"
               @reorder="(from, to) => emit('reorder-field', from, to)"
+              @toggle-freeze="onToggleFreeze(fi)"
             />
           </tr>
         </thead>
@@ -51,7 +54,7 @@
                 <td v-if="enableMultiSelect" class="meta-grid__check-col" @click.stop>
                   <input type="checkbox" :checked="selectedIds.has(row.id)" :disabled="!rowAllowsAnyBulkAction(row.id)" @change="toggleSelectRow(row.id)" />
                 </td>
-                <td class="meta-grid__row-num">
+                <td class="meta-grid__row-num" :style="{ left: `${rowNumLeft}px` }">
                   <span>{{ startIndex + flatIndex(group, ri) + 1 }}</span>
                   <button
                     v-if="resolveRowActions(row.id).canComment"
@@ -70,7 +73,7 @@
                   :key="field.id"
                   class="meta-grid__cell"
                   :class="{ 'meta-grid__cell--editing': isEditing(row.id, field.id), 'meta-grid__cell--readonly': !isEditable(row.id, field), 'meta-grid__cell--focused': focusRow === flatIndex(group, ri) && focusCol === ci }"
-                  :style="cellStyle(row.id, field.id)"
+                  :style="cellStyle(row.id, field.id, ci)"
                   @dblclick="startEdit(row, field)"
                   @click.stop="onCellClick(flatIndex(group, ri), ci, row.id)"
                 >
@@ -137,7 +140,7 @@
               <td v-if="enableMultiSelect" class="meta-grid__check-col" @click.stop>
                 <input type="checkbox" :checked="selectedIds.has(row.id)" :disabled="!rowAllowsAnyBulkAction(row.id)" @change="toggleSelectRow(row.id)" />
               </td>
-              <td class="meta-grid__row-num">
+              <td class="meta-grid__row-num" :style="{ left: `${rowNumLeft}px` }">
                 <button class="meta-grid__expand-btn" :class="{ 'meta-grid__expand-btn--open': expandedRowIds.has(row.id) }" :aria-label="expandedRowIds.has(row.id) ? l('grid.collapseRow') : l('grid.expandRow')" @click.stop="toggleRowExpand(row.id)">&#x25B6;</button>
                 <span>{{ startIndex + ri + 1 }}</span>
                 <button
@@ -159,7 +162,7 @@
                 :aria-label="field.name"
                 class="meta-grid__cell"
                 :class="{ 'meta-grid__cell--editing': isEditing(row.id, field.id), 'meta-grid__cell--readonly': !isEditable(row.id, field), 'meta-grid__cell--focused': focusRow === ri && focusCol === ci }"
-                :style="cellStyle(row.id, field.id)"
+                :style="cellStyle(row.id, field.id, ci)"
                 @dblclick="startEdit(row, field)"
                 @click.stop="onCellClick(ri, ci, row.id)"
               >
@@ -285,6 +288,7 @@ import {
 } from '../utils/comment-affordance'
 import { isSystemField } from '../utils/system-fields'
 import { useLocale } from '../../composables/useLocale'
+import { frozenPrefixCount } from '../utils/frozen-columns'
 import {
   metaCoreLabel,
   selectedCount,
@@ -311,6 +315,7 @@ const props = defineProps<{
   canDelete?: boolean
   canBulkEdit?: boolean
   canCreate?: boolean
+  frozenLeftColumnIds?: string[]
   rowActionOverrides?: Record<string, MetaRowActions>
   fieldReadOnlyIds?: string[]
   columnWidths?: Record<string, number>
@@ -341,6 +346,7 @@ const emit = defineEmits<{
   (e: 'bulk-edit', payload: { mode: 'set' | 'clear'; recordIds: string[] }): void
   (e: 'reorder-field', fromFieldId: string, toFieldId: string): void
   (e: 'create-record'): void
+  (e: 'set-frozen', frozenLeftColumnIds: string[]): void
 }>()
 
 const { isZh } = useLocale()
@@ -488,8 +494,10 @@ const isEditable = (recordId: string, f: MetaField) =>
   resolveRowActions(recordId).canEdit && EDITABLE.has(f.type) && !isSystemField(f) && !props.fieldReadOnlyIds?.includes(f.id)
 const isEditing = (rid: string, fid: string) => editCell.value?.recordId === rid && editCell.value?.fieldId === fid
 
-function cellStyle(rid: string, fid: string) {
-  const w = props.columnWidths?.[fid]
+function cellStyle(rid: string, fid: string, ci?: number) {
+  const frozen = typeof ci === 'number' && isFrozen(ci)
+  // frozen cells need a definite width so the sticky-offset math is exact
+  const w = frozen ? colWidth(fid) : props.columnWidths?.[fid]
   const widthStyle: Record<string, string> | undefined = w
     ? { width: `${w}px`, minWidth: `${w}px`, maxWidth: `${w}px` }
     : undefined
@@ -497,8 +505,33 @@ function cellStyle(rid: string, fid: string) {
   const formatStyle = formatting
     ? composeStyleObject(undefined, formatting.cellStyles[fid])
     : undefined
-  if (!widthStyle && !formatStyle) return undefined
-  return { ...(widthStyle ?? {}), ...(formatStyle ?? {}) }
+  // frozen body cell: sticky-left + opaque bg (occludes scrolled-under content). The solid bg means
+  // frozen cells don't show row hover/selection tint — accepted MVP limitation (see design §3).
+  const frozenStyle: Record<string, string> | undefined = frozen
+    ? { position: 'sticky', left: `${frozenLeft(ci!)}px`, zIndex: '2', background: '#fff' }
+    : undefined
+  if (!widthStyle && !formatStyle && !frozenStyle) return undefined
+  return { ...(widthStyle ?? {}), ...(formatStyle ?? {}), ...(frozenStyle ?? {}) }
+}
+
+// ── frozen columns (left-prefix) ──────────────────────────────────────────
+const FROZEN_DEFAULT_WIDTH = 160
+const CHECK_COL_W = 36
+const ROW_NUM_W = 56
+const frozenCount = computed(() => frozenPrefixCount(props.visibleFields.map((f) => f.id), props.frozenLeftColumnIds ?? []))
+function isFrozen(i: number) { return i < frozenCount.value }
+function colWidth(fid: string) { return props.columnWidths?.[fid] ?? FROZEN_DEFAULT_WIDTH }
+const stickyBaseLeft = computed(() => (props.enableMultiSelect ? CHECK_COL_W : 0) + ROW_NUM_W)
+function frozenLeft(i: number) {
+  let left = stickyBaseLeft.value
+  for (let j = 0; j < i; j++) left += colWidth(props.visibleFields[j].id)
+  return left
+}
+// base-fix (global): row-num sits AFTER check-col, not overlapping at left:0
+const rowNumLeft = computed(() => (props.enableMultiSelect ? CHECK_COL_W : 0))
+function onToggleFreeze(i: number) {
+  if (i === frozenCount.value - 1) emit('set-frozen', [])
+  else emit('set-frozen', props.visibleFields.slice(0, i + 1).map((f) => f.id))
 }
 
 function rowStyle(rid: string): Record<string, string> | undefined {

--- a/apps/web/src/multitable/utils/frozen-columns.ts
+++ b/apps/web/src/multitable/utils/frozen-columns.ts
@@ -1,0 +1,27 @@
+/**
+ * Frozen-columns view.config helpers (benchmark v2 #4 sub-slice 2).
+ *
+ * `view.config` is freeform JSON (`Record<string, unknown>`); `frozenLeftColumnIds` is read with a
+ * NARROW helper so dirty/invalid config can never reach the sticky-offset math. Strict: only an array
+ * whose every element is a string passes; anything else → []. (Design §1/§7.)
+ */
+export function parseFrozenIds(config: Record<string, unknown> | null | undefined): string[] {
+  const value = config?.frozenLeftColumnIds
+  if (!Array.isArray(value)) return []
+  if (!value.every((x) => typeof x === 'string')) return []
+  return value as string[]
+}
+
+/**
+ * Length of the longest contiguous LEFT prefix of `orderedFieldIds` whose ids are all in the frozen
+ * set. Reorder-robust: only a contiguous left prefix is ever frozen; non-prefix frozen ids are ignored.
+ */
+export function frozenPrefixCount(orderedFieldIds: string[], frozenIds: string[]): number {
+  const set = new Set(frozenIds)
+  let n = 0
+  for (const id of orderedFieldIds) {
+    if (set.has(id)) n++
+    else break
+  }
+  return n
+}

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -53,6 +53,7 @@ export type MetaCoreLabelKey =
   | 'grid.noRecordsTitle'
   | 'grid.noRecordsHintPrefix' | 'grid.noRecordsHintAction' | 'grid.noRecordsHintSuffix'
   | 'grid.addRecordInline'
+  | 'grid.freezeUpToColumn' | 'grid.unfreezeColumns'
   | 'grid.noMatchingTitle' | 'grid.noMatchingHint'
   | 'grid.collapseRow' | 'grid.expandRow'
   | 'grid.prev' | 'grid.next' | 'grid.loading'
@@ -149,6 +150,8 @@ const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
   'grid.noRecordsHintAction': { en: '+ New Record', zh: '+ 新建记录' },
   'grid.noRecordsHintSuffix': { en: 'to add your first row', zh: '添加第一行' },
   'grid.addRecordInline': { en: 'New record', zh: '新建记录' },
+  'grid.freezeUpToColumn': { en: 'Freeze up to this column', zh: '冻结到此列' },
+  'grid.unfreezeColumns': { en: 'Unfreeze columns', zh: '取消冻结' },
   'grid.noMatchingTitle': { en: 'No matching records', zh: '没有匹配的记录' },
   'grid.noMatchingHint': { en: 'Try a different search term', zh: '试试其他搜索词' },
   'grid.collapseRow': { en: 'Collapse row', zh: '收起行' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -246,7 +246,7 @@
           :rows="grid.rows.value" :visible-fields="scopedGridFields" :sort-rules="grid.sortRules.value"
           :loading="grid.loading.value" :current-page="grid.currentPage.value" :total-pages="grid.totalPages.value"
           :start-index="pageStartIndex" :selected-record-id="selectedRecordId" :can-edit="effectiveRowActions.canEdit"
-          :can-delete="gridAllowsAnyDelete" :can-bulk-edit="effectiveRowActions.canEdit" :can-create="caps.canCreateRecord.value" :field-read-only-ids="readOnlyFieldIds" :column-widths="grid.columnWidths.value"
+          :can-delete="gridAllowsAnyDelete" :can-bulk-edit="effectiveRowActions.canEdit" :can-create="caps.canCreateRecord.value" :frozen-left-column-ids="activeFrozenLeftColumnIds" :field-read-only-ids="readOnlyFieldIds" :column-widths="grid.columnWidths.value"
           :row-action-overrides="grid.rowActionOverrides.value"
           :link-summaries="grid.linkSummaries.value" :attachment-summaries="grid.attachmentSummaries.value"
           :enable-multi-select="gridAllowsAnyDelete || effectiveRowActions.canEdit"
@@ -261,6 +261,7 @@
           @go-to-page="grid.goToPage" @open-link-picker="onGridLinkPicker" @resize-column="grid.setColumnWidth"
           @bulk-delete="onBulkDelete" @bulk-edit="onBulkEditRequest" @reorder-field="onReorderField"
           @create-record="onAddRecord"
+          @set-frozen="onSetFrozen"
           @open-comments="onOpenRecordComments"
           @open-field-comments="onOpenGridFieldComments"
         />
@@ -508,6 +509,7 @@ import {
   type CalendarHolidayFetchState,
 } from '../utils/calendar-holiday-notice'
 import { addPeopleLookupToken, inferPeopleLookupKind, resolvePeopleImportValue } from '../utils/people-import'
+import { parseFrozenIds } from '../utils/frozen-columns'
 import { buildRecordFormattingMap, extractRulesFromConfig } from '../utils/conditional-formatting'
 import {
   decorateAndSortBases,
@@ -1738,6 +1740,14 @@ async function onPersistActiveViewConfig(input: {
   const viewId = workbench.activeViewId.value
   if (!viewId) return
   await updateViewInternal(viewId, input, false)
+}
+
+// frozen columns (left-prefix) — read via narrow helper; persist merges into view.config
+const activeFrozenLeftColumnIds = computed(() => parseFrozenIds(workbench.activeView.value?.config))
+function onSetFrozen(frozenLeftColumnIds: string[]) {
+  void onPersistActiveViewConfig({
+    config: { ...(workbench.activeView.value?.config ?? {}), frozenLeftColumnIds },
+  })
 }
 
 async function updateViewInternal(

--- a/apps/web/tests/multitable-frozen-columns-grid.spec.ts
+++ b/apps/web/tests/multitable-frozen-columns-grid.spec.ts
@@ -79,6 +79,33 @@ describe('MetaGridTable frozen columns — offsets', () => {
     const root = mountGrid({ frozenLeftColumnIds: [], enableMultiSelect: false })
     expect(headers(root)[0].style.position).not.toBe('sticky')
   })
+
+  it('frozen cell PRESERVES conditional-formatting background (not clobbered by the opaque #fff)', () => {
+    const root = mountGrid({
+      rows: [{ id: 'r1', version: 1, data: { f1: 'A' } }],
+      frozenLeftColumnIds: ['f1'],
+      columnWidths: { f1: 100 },
+      enableMultiSelect: false,
+      conditionalFormatting: {
+        rules: [],
+        byRecordId: new Map([['r1', { rowStyle: undefined, cellStyles: { f1: { backgroundColor: '#ffeeee' } }, matchedRuleIds: [] }]]),
+      },
+    })
+    const cell = root.querySelector('.meta-grid__cell') as HTMLElement // r1/f1, frozen
+    expect(cell.style.position).toBe('sticky')
+    expect(cell.style.backgroundColor).toBe('rgb(255, 238, 238)') // #ffeeee preserved, NOT #fff
+  })
+
+  it('frozen cell WITHOUT conditional formatting falls back to opaque #fff', () => {
+    const root = mountGrid({
+      rows: [{ id: 'r1', version: 1, data: { f1: 'A' } }],
+      frozenLeftColumnIds: ['f1'],
+      columnWidths: { f1: 100 },
+      enableMultiSelect: false,
+    })
+    const cell = root.querySelector('.meta-grid__cell') as HTMLElement
+    expect(cell.style.backgroundColor).toBe('rgb(255, 255, 255)') // #fff
+  })
 })
 
 describe('MetaGridTable frozen columns — pin interaction', () => {

--- a/apps/web/tests/multitable-frozen-columns-grid.spec.ts
+++ b/apps/web/tests/multitable-frozen-columns-grid.spec.ts
@@ -1,0 +1,107 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, type App } from 'vue'
+import MetaGridTable from '../src/multitable/components/MetaGridTable.vue'
+import type { MetaField } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+let app: App<Element> | null = null
+let container: HTMLDivElement | null = null
+
+afterEach(() => {
+  app?.unmount(); app = null
+  container?.remove(); container = null
+  useLocale().setLocale('en')
+})
+
+const FIELDS: MetaField[] = [
+  { id: 'f1', name: 'F1', type: 'string' },
+  { id: 'f2', name: 'F2', type: 'string' },
+  { id: 'f3', name: 'F3', type: 'string' },
+]
+
+function mountGrid(props: Record<string, unknown>) {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp({
+    setup() {
+      return () => h(MetaGridTable, {
+        rows: [], visibleFields: FIELDS, sortRules: [], loading: false,
+        currentPage: 1, totalPages: 1, startIndex: 0, canEdit: true,
+        searchText: '', rowDensity: 'normal',
+        ...props,
+      })
+    },
+  })
+  app.mount(container)
+  return container
+}
+
+const headers = (root: HTMLElement) => Array.from(root.querySelectorAll('.meta-field-header')) as HTMLElement[]
+const pins = (root: HTMLElement) => Array.from(root.querySelectorAll('.meta-field-header__pin')) as HTMLButtonElement[]
+
+describe('MetaGridTable frozen columns — offsets', () => {
+  it('applies cumulative sticky left to the frozen prefix (no multi-select)', () => {
+    const root = mountGrid({
+      frozenLeftColumnIds: ['f1', 'f2'],
+      columnWidths: { f1: 100, f2: 120 },
+      enableMultiSelect: false,
+    })
+    const h = headers(root)
+    // base = 0 (no check-col) + 56 (row-num)
+    expect(h[0].style.left).toBe('56px') // f1 at base
+    expect(h[0].style.position).toBe('sticky')
+    expect(h[1].style.left).toBe('156px') // f2 at base + f1 width(100)
+    expect(h[2].style.left).toBe('') // f3 not frozen
+  })
+
+  it('adds check-col width (36) to the base + fixes row-num offset when multi-select on', () => {
+    const root = mountGrid({
+      frozenLeftColumnIds: ['f1'],
+      columnWidths: { f1: 100 },
+      enableMultiSelect: true,
+    })
+    // row-num base-fix: sits after the 36px check-col
+    expect((root.querySelector('.meta-grid__row-num') as HTMLElement).style.left).toBe('36px')
+    // f1 frozen at base = 36 (check) + 56 (row-num) = 92
+    expect(headers(root)[0].style.left).toBe('92px')
+  })
+
+  it('uses FROZEN_DEFAULT_WIDTH (160) for a frozen column without an explicit width', () => {
+    const root = mountGrid({
+      frozenLeftColumnIds: ['f1', 'f2'],
+      columnWidths: {}, // f1 has no explicit width → default 160
+      enableMultiSelect: false,
+    })
+    expect(headers(root)[1].style.left).toBe('216px') // 56 + 160
+  })
+
+  it('freezes nothing when frozenLeftColumnIds is empty', () => {
+    const root = mountGrid({ frozenLeftColumnIds: [], enableMultiSelect: false })
+    expect(headers(root)[0].style.position).not.toBe('sticky')
+  })
+})
+
+describe('MetaGridTable frozen columns — pin interaction', () => {
+  it('clicking a non-boundary pin emits set-frozen with the left prefix', () => {
+    const onSetFrozen = vi.fn()
+    const root = mountGrid({ frozenLeftColumnIds: [], enableMultiSelect: false, onSetFrozen })
+    pins(root)[1].click() // freeze up to f2
+    expect(onSetFrozen).toHaveBeenCalledWith(['f1', 'f2'])
+  })
+
+  it('clicking the current boundary pin unfreezes ([])', () => {
+    const onSetFrozen = vi.fn()
+    const root = mountGrid({ frozenLeftColumnIds: ['f1', 'f2'], enableMultiSelect: false, onSetFrozen })
+    pins(root)[1].click() // f2 is the boundary → unfreeze
+    expect(onSetFrozen).toHaveBeenCalledWith([])
+  })
+
+  it('pin click does NOT bubble into sort (@click.stop)', () => {
+    const onSetFrozen = vi.fn()
+    const onToggleSort = vi.fn()
+    const root = mountGrid({ frozenLeftColumnIds: [], enableMultiSelect: false, onSetFrozen, onToggleSort })
+    pins(root)[0].click()
+    expect(onSetFrozen).toHaveBeenCalledTimes(1)
+    expect(onToggleSort).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/tests/multitable-frozen-columns-util.spec.ts
+++ b/apps/web/tests/multitable-frozen-columns-util.spec.ts
@@ -1,0 +1,47 @@
+import { describe, expect, it } from 'vitest'
+import { parseFrozenIds, frozenPrefixCount } from '../src/multitable/utils/frozen-columns'
+
+describe('parseFrozenIds (narrow helper — dirty config never reaches offset math)', () => {
+  it('passes a valid string[]', () => {
+    expect(parseFrozenIds({ frozenLeftColumnIds: ['a', 'b'] })).toEqual(['a', 'b'])
+  })
+  it('→ [] for missing field', () => {
+    expect(parseFrozenIds({})).toEqual([])
+    expect(parseFrozenIds({ other: 1 })).toEqual([])
+  })
+  it('→ [] for non-array', () => {
+    expect(parseFrozenIds({ frozenLeftColumnIds: 'a' })).toEqual([])
+    expect(parseFrozenIds({ frozenLeftColumnIds: 3 })).toEqual([])
+    expect(parseFrozenIds({ frozenLeftColumnIds: { 0: 'a' } })).toEqual([])
+  })
+  it('→ [] for array with any non-string element (strict)', () => {
+    expect(parseFrozenIds({ frozenLeftColumnIds: ['a', 2] })).toEqual([])
+    expect(parseFrozenIds({ frozenLeftColumnIds: [null] })).toEqual([])
+    expect(parseFrozenIds({ frozenLeftColumnIds: ['a', { x: 1 }] })).toEqual([])
+  })
+  it('→ [] for null / undefined config', () => {
+    expect(parseFrozenIds(null)).toEqual([])
+    expect(parseFrozenIds(undefined)).toEqual([])
+  })
+  it('→ [] for empty array (no frozen)', () => {
+    expect(parseFrozenIds({ frozenLeftColumnIds: [] })).toEqual([])
+  })
+})
+
+describe('frozenPrefixCount (reorder-robust left-prefix)', () => {
+  const order = ['f1', 'f2', 'f3', 'f4']
+  it('counts a contiguous left prefix', () => {
+    expect(frozenPrefixCount(order, ['f1', 'f2'])).toBe(2)
+    expect(frozenPrefixCount(order, ['f1'])).toBe(1)
+    expect(frozenPrefixCount(order, [])).toBe(0)
+  })
+  it('ignores non-prefix frozen ids (after reorder)', () => {
+    // f3 frozen but f1/f2 not → no contiguous left prefix
+    expect(frozenPrefixCount(order, ['f3'])).toBe(0)
+    // f1 + f3 frozen but f2 breaks contiguity → only f1
+    expect(frozenPrefixCount(order, ['f1', 'f3'])).toBe(1)
+  })
+  it('clamps to all columns', () => {
+    expect(frozenPrefixCount(order, ['f1', 'f2', 'f3', 'f4', 'gone'])).toBe(4)
+  })
+})

--- a/docs/development/multitable-frozen-columns-design-20260525.md
+++ b/docs/development/multitable-frozen-columns-design-20260525.md
@@ -1,0 +1,106 @@
+# Multitable Frozen Columns — Design (2026-05-25)
+
+benchmark v2 §9 #4 (Grid BI polish), second sub-slice: user-configurable **left-frozen** columns
+(sticky during horizontal scroll). Predecessor: inline create row (#1834). Frontend-only.
+
+Model decision (signed off): **left-prefix** — freeze the leftmost contiguous N columns
+("Freeze up to this column" / "Unfreeze"), like Feishu/Airtable. Keeps sticky offsets sane and
+reorder semantics simple.
+
+---
+
+## 0. Scope + boundary
+
+- **Frontend-only.** `view.config` is freeform `jsonb` (backend zod `config: z.record(z.unknown())`,
+  `univer-meta.ts:4979`) → `frozenLeftColumnIds` needs **no backend/contract/migration change**.
+- Files: `MetaGridTable.vue` (sticky stack), `MetaFieldHeader.vue` (freeze affordance),
+  `useMultitableGrid.ts` (read config), `MultitableWorkbench.vue` (wire + persist). No backend.
+- Multitable kernel-polish (allowed under K3 lock); no rbac/contract.
+
+## 1. Persistence
+
+- Stored at `view.config.frozenLeftColumnIds: string[]` — the ordered field ids of the frozen prefix.
+- Read: `workbench.activeView.value?.config?.frozenLeftColumnIds` → prop into `MetaGridTable`.
+- Write: existing `onPersistActiveViewConfig({ config: { ...currentConfig, frozenLeftColumnIds } })`
+  → `client.updateView` (PATCH) → reload. (No new API.)
+
+## 2. Prefix derivation (reorder-robust)
+
+`MetaGridTable` derives, at render, the **frozen count** = length of the longest prefix of
+`visibleFields` whose ids are ALL in `frozenLeftColumnIds`:
+
+```
+frozenCount = while visibleFields[n].id ∈ frozenSet: n++
+isFrozen(i) = i < frozenCount
+```
+
+So only a contiguous left prefix is ever sticky. After a column **reorder**, if the frozen set is no
+longer a left prefix, the non-prefix ids are simply ignored (graceful; no broken sticky). Persisted
+ids are normalized to the prefix on the next freeze action.
+
+## 3. Sticky stack offsets (the core)
+
+**Existing quirk to fix:** `.meta-grid__check-col` (36px) and `.meta-grid__row-num` (56px) are BOTH
+`position: sticky; left: 0` → they overlap when multi-select is on. Frozen columns require an
+**offset-driven** stack. When `frozenCount > 0`, set inline `left` on the whole prefix:
+
+| element | inline `left` (only when `frozenCount>0`) | width |
+|---|---|---|
+| check-col (if multiSelect) | `0` | 36 |
+| row-num | `multiSelect ? 36 : 0` | 56 |
+| frozen data col `i` (`i<frozenCount`) | `base + Σ_{j<i} width(j)` | width(i) |
+
+`base = (multiSelect ? 36 : 0) + 56`. `width(id) = columnWidths[id] ?? FROZEN_DEFAULT_WIDTH` (160).
+**Reactive to `columnWidths`** → resizing a frozen column recomputes downstream offsets automatically.
+
+- When `frozenCount === 0`: **no inline left** → existing CSS unchanged (no behavior change; the
+  pre-existing overlap stays as-is, out of this slice's scope to "fix" globally).
+- The base-fix (inline left on check-col/row-num) applies **only in frozen mode** — documented as an
+  incidental correctness improvement, not a separate refactor.
+
+**z-index layers:** normal cells (0) < frozen body cells (2) < sticky header row (3) < frozen header
+cells (4). Frozen cells get an opaque `background` (so scrolled content doesn't show through).
+
+**Width-determinism:** a frozen column with no explicit `columnWidths` entry is rendered at
+`FROZEN_DEFAULT_WIDTH` (also pinned as its `min/maxWidth`) so the offset math is exact.
+
+## 4. Grouped vs flat tbody
+
+Both `<tbody>` branches render data cells via `v-for (field, ci) in visibleFields` → apply the frozen
+style by index in both. The **group-header row** is a single `colspan` cell — NOT frozen (it spans the
+full width; freezing it is meaningless). Only data cells + headers stick.
+
+## 5. Freeze UI (minimal, greenfield)
+
+`MetaFieldHeader` has no menu today. MVP affordance: a small **pin toggle** in each header cell:
+
+- click on column `i` (not currently the boundary) → freeze up to `i`: emit `set-frozen` with
+  `visibleFields[0..i].map(id)`.
+- click when `i` is the current boundary → unfreeze: emit `set-frozen` with `[]`.
+- visual: pin icon filled when the column is within the frozen prefix.
+
+`MetaGridTable` re-emits to the workbench → `onPersistActiveViewConfig`. (A richer dropdown menu —
+"freeze 1/2/3 columns", per-column context menu — is a later polish; MVP is the pin toggle.)
+
+## 6. Edge cases
+
+- **Frozen wider than viewport:** allowed (user's choice); horizontal scroll still works, frozen prefix
+  just occupies most width. No cap in MVP (note for later).
+- **Reorder:** §2 graceful derivation.
+- **Resize:** §3 reactive offsets.
+- **All columns frozen / 0 columns:** frozenCount clamps to visibleFields.length / 0; harmless.
+- **hiddenFieldIds interaction:** `visibleFields` is already post-hidden; prefix derived over visible set.
+
+## 7. Verification plan
+
+- **Component test** (`MetaGridTable`): asserts `isFrozen` prefix derivation + computed `left` offset
+  values (the offset math) for a few width configs + multiselect on/off; asserts non-prefix-after-
+  reorder is not sticky. Asserts `MetaFieldHeader` pin emits `set-frozen` with the right prefix.
+- **Caveat:** actual CSS `position: sticky` rendering is browser-native and NOT unit-testable headless;
+  the test covers the **offset math + gating + emit**, which is the logic. Visual confirmation is manual.
+- vue-tsc clean; `src/multitable/**` not in eslint allowlist (gated by type-check + tests).
+
+## 8. Slicing
+
+Single slice (rendering + minimal pin UI + persistence) — all three needed for a usable feature.
+Richer freeze menu + right-edge freeze = deferred polish.

--- a/docs/development/multitable-frozen-columns-design-20260525.md
+++ b/docs/development/multitable-frozen-columns-design-20260525.md
@@ -20,7 +20,10 @@ reorder semantics simple.
 ## 1. Persistence
 
 - Stored at `view.config.frozenLeftColumnIds: string[]` — the ordered field ids of the frozen prefix.
-- Read: `workbench.activeView.value?.config?.frozenLeftColumnIds` → prop into `MetaGridTable`.
+- **Read via a narrow helper** (should-fix): `config` is `Record<string, unknown>`, so
+  `parseFrozenIds(config)` returns `string[]` **only** when the field is an array of strings; any
+  other shape (missing / non-array / non-string elements / dirty config) → `[]`. Dirty config must
+  never reach the sticky-offset math. Then → prop into `MetaGridTable`.
 - Write: existing `onPersistActiveViewConfig({ config: { ...currentConfig, frozenLeftColumnIds } })`
   → `client.updateView` (PATCH) → reload. (No new API.)
 
@@ -40,11 +43,14 @@ ids are normalized to the prefix on the next freeze action.
 
 ## 3. Sticky stack offsets (the core)
 
-**Existing quirk to fix:** `.meta-grid__check-col` (36px) and `.meta-grid__row-num` (56px) are BOTH
-`position: sticky; left: 0` → they overlap when multi-select is on. Frozen columns require an
-**offset-driven** stack. When `frozenCount > 0`, set inline `left` on the whole prefix:
+**Base-fix (GLOBAL, per review):** `.meta-grid__check-col` (36px) and `.meta-grid__row-num` (56px) are
+BOTH `position: sticky; left: 0` today → they overlap when multi-select is on. Fix it **globally, not
+just in frozen mode**: check-col `left:0`, row-num `left: multiSelect ? 36 : 0` — always. Small + correct;
+removes the overlap even when nothing is frozen, and avoids the meta columns "jumping" the instant
+freeze is toggled on. (Not "absorbing the overlap into the frozen base" — that would be adapting to a
+known layout bug.) The offset stack:
 
-| element | inline `left` (only when `frozenCount>0`) | width |
+| element | inline `left` (always) | width |
 |---|---|---|
 | check-col (if multiSelect) | `0` | 36 |
 | row-num | `multiSelect ? 36 : 0` | 56 |
@@ -52,11 +58,14 @@ ids are normalized to the prefix on the next freeze action.
 
 `base = (multiSelect ? 36 : 0) + 56`. `width(id) = columnWidths[id] ?? FROZEN_DEFAULT_WIDTH` (160).
 **Reactive to `columnWidths`** → resizing a frozen column recomputes downstream offsets automatically.
+Frozen data columns get sticky styling only when `i < frozenCount`; the check-col/row-num base-fix is
+unconditional.
 
-- When `frozenCount === 0`: **no inline left** → existing CSS unchanged (no behavior change; the
-  pre-existing overlap stays as-is, out of this slice's scope to "fix" globally).
-- The base-fix (inline left on check-col/row-num) applies **only in frozen mode** — documented as an
-  incidental correctness improvement, not a separate refactor.
+**Header positioning fix (should-fix):** `MetaFieldHeader`'s `<th>` currently has `position: sticky`
+*then* `position: relative` (`MetaFieldHeader.vue:92`) — the `relative` overrides, so the header is NOT
+actually sticky. Frozen-header implementation must **fix the header positioning** (don't rely on the
+broken current sticky semantics) while **preserving the `absolute` resize handle** (give the handle its
+own stacking context / keep it positioned within the th). Frozen header cells then layer per below.
 
 **z-index layers:** normal cells (0) < frozen body cells (2) < sticky header row (3) < frozen header
 cells (4). Frozen cells get an opaque `background` (so scrolled content doesn't show through).
@@ -78,6 +87,10 @@ full width; freezing it is meaningless). Only data cells + headers stick.
   `visibleFields[0..i].map(id)`.
 - click when `i` is the current boundary → unfreeze: emit `set-frozen` with `[]`.
 - visual: pin icon filled when the column is within the frozen prefix.
+- **MUST `@click.stop` AND `@mousedown.stop`** (should-fix): the header cell's own click triggers
+  **sort** (`MetaFieldHeader.vue:7`) and mousedown can start resize/reorder — the pin button must not
+  bubble into either (no accidental sort/reorder on freeze toggle). Pin button gets an `aria-label` +
+  `title` ("Freeze up to this column" / "Unfreeze"), localized via `meta-core-labels`.
 
 `MetaGridTable` re-emits to the workbench → `onPersistActiveViewConfig`. (A richer dropdown menu —
 "freeze 1/2/3 columns", per-column context menu — is a later polish; MVP is the pin toggle.)
@@ -96,8 +109,14 @@ full width; freezing it is meaningless). Only data cells + headers stick.
 - **Component test** (`MetaGridTable`): asserts `isFrozen` prefix derivation + computed `left` offset
   values (the offset math) for a few width configs + multiselect on/off; asserts non-prefix-after-
   reorder is not sticky. Asserts `MetaFieldHeader` pin emits `set-frozen` with the right prefix.
+- **`parseFrozenIds` unit test (should-fix):** dirty/invalid `config` → `[]`. Cases: missing field,
+  `frozenLeftColumnIds` not an array, array with non-string elements, `null`, nested object — each
+  must yield `[]` (never reaches the offset math). Valid `string[]` passes through.
+- **Pin no-side-effect test:** clicking the pin emits `set-frozen` and does **not** emit `toggle-sort`
+  / `reorder` (verifies `.stop` handlers).
 - **Caveat:** actual CSS `position: sticky` rendering is browser-native and NOT unit-testable headless;
-  the test covers the **offset math + gating + emit**, which is the logic. Visual confirmation is manual.
+  the test covers the **offset math + gating + emit + parse + no-bubble**, which is the logic. Visual
+  confirmation is manual.
 - vue-tsc clean; `src/multitable/**` not in eslint allowlist (gated by type-check + tests).
 
 ## 8. Slicing

--- a/docs/development/multitable-frozen-columns-verification-20260525.md
+++ b/docs/development/multitable-frozen-columns-verification-20260525.md
@@ -55,8 +55,9 @@ freeform `jsonb`; `frozenLeftColumnIds` rides existing `updateView` PATCH.
 
 ## 5. Known MVP limitations / deferred
 
-- Frozen cells use a **solid bg** (occlude scrolled content) → they don't show row hover/selection tint
-  on the frozen prefix (common grid behavior; documented).
+- Frozen cells use an **opaque bg** (occlude scrolled content) that **preserves conditional-formatting
+  `backgroundColor`** (falls back to `#fff` only when no formatting) — verified by spec. They still
+  don't show row **hover/selection** tint on the frozen prefix (common grid behavior; documented).
 - No cap if the frozen prefix exceeds viewport width (allowed; user's choice).
 - Deferred polish (separate opt-ins): richer freeze dropdown menu, right-edge freeze, frozen-cell
   row-state tint. Next #4 sub-slice: aggregation footer / group rollup.

--- a/docs/development/multitable-frozen-columns-verification-20260525.md
+++ b/docs/development/multitable-frozen-columns-verification-20260525.md
@@ -1,0 +1,62 @@
+# Multitable Frozen Columns — Verification (2026-05-25)
+
+Implements the design (`docs/development/multitable-frozen-columns-design-20260525.md`).
+benchmark v2 §9 #4 sub-slice 2. Frontend-only.
+
+---
+
+## 1. What shipped
+
+- **`utils/frozen-columns.ts`** — `parseFrozenIds` (narrow: only `string[]` passes, dirty config → `[]`)
+  + `frozenPrefixCount` (reorder-robust longest-left-prefix).
+- **`MetaGridTable.vue`** — `frozenLeftColumnIds` prop; `frozenCount`/`frozenLeft(i)`/`isFrozen(i)`
+  computeds; offset-driven sticky on frozen header (via `MetaFieldHeader`) + body cells; **global
+  base-fix** (row-num inline `left = multiSelect?36:0`, fixing the row-num/check-col `left:0` overlap);
+  `FROZEN_DEFAULT_WIDTH=160`; `set-frozen` emit + `onToggleFreeze`.
+- **`MetaFieldHeader.vue`** — pin toggle (`@click.stop @mousedown.stop`, localized aria/title); `frozen`
+  + `frozenLeft` props; inline `position:sticky` (overrides the broken CSS `relative`, keeps the
+  absolute resize handle); `toggle-freeze` emit.
+- **`MultitableWorkbench.vue`** — `activeFrozenLeftColumnIds = parseFrozenIds(activeView.config)` prop;
+  `@set-frozen → onSetFrozen` merges `frozenLeftColumnIds` into `view.config` via the existing persist.
+- **`meta-core-labels.ts`** — `grid.freezeUpToColumn` / `grid.unfreezeColumns` (en/zh).
+
+## 2. Design adherence
+
+| design point | done |
+|---|---|
+| left-prefix model | ✅ `frozenPrefixCount` (contiguous left prefix; reorder-robust) |
+| frontend-only (freeform `view.config`) | ✅ no backend/contract/migration |
+| offset-driven stack (check 0 → row-num 36 → frozen base+Σ) | ✅ `frozenLeft(i)` reactive to `columnWidths` |
+| global base-fix (not frozen-mode-only) | ✅ row-num inline left always |
+| header positioning fix + keep resize handle | ✅ inline `position:sticky` on frozen th |
+| `parseFrozenIds` narrow + invalid fallback | ✅ + unit tests |
+| pin `@click.stop`/`@mousedown.stop` + aria | ✅ + no-bubble test |
+| width-determinism (`FROZEN_DEFAULT_WIDTH`) | ✅ tested |
+| minimal pin UI (no dropdown) | ✅ |
+
+## 3. Boundary
+
+`apps/web/src/multitable/` only — **no backend / api-client / contract / rbac**. `view.config` is
+freeform `jsonb`; `frozenLeftColumnIds` rides existing `updateView` PATCH.
+
+## 4. Verification
+
+- **27 tests passed** across 4 files:
+  - `multitable-frozen-columns-util.spec.ts` — `parseFrozenIds` (valid / missing / non-array /
+    non-string element / null / empty) + `frozenPrefixCount` (prefix / reorder-ignored / clamp).
+  - `multitable-frozen-columns-grid.spec.ts` — cumulative sticky `left` offsets (no-multiselect base 56;
+    multiselect base 92 + row-num fix 36; `FROZEN_DEFAULT_WIDTH` 216; empty = not sticky); pin emits
+    left prefix; boundary pin unfreezes `[]`; pin does NOT bubble into sort.
+  - regressions: `meta-grid-table-i18n.spec.ts`, `multitable-grid-inline-create-row.spec.ts` — green.
+- **vue-tsc**: clean.
+- **Caveat (design §7):** actual CSS `position: sticky` rendering is browser-native and NOT
+  unit-testable headless; the tests cover the **offset math + gating + emit + parse + no-bubble** (the
+  logic). Visual sticky behavior is manual.
+
+## 5. Known MVP limitations / deferred
+
+- Frozen cells use a **solid bg** (occlude scrolled content) → they don't show row hover/selection tint
+  on the frozen prefix (common grid behavior; documented).
+- No cap if the frozen prefix exceeds viewport width (allowed; user's choice).
+- Deferred polish (separate opt-ins): richer freeze dropdown menu, right-edge freeze, frozen-cell
+  row-state tint. Next #4 sub-slice: aggregation footer / group rollup.


### PR DESCRIPTION
## What

benchmark v2 §9 #4 (Grid BI polish), sub-slice 2. User-configurable **left-frozen** columns (sticky during horizontal scroll), left-prefix model.

- **Frontend-only**: `view.config.frozenLeftColumnIds` (freeform `jsonb` — no backend/contract/migration).
- **Offset-driven sticky stack**: check-col `0` → row-num `36` → frozen col `i` = `base + Σ preceding widths`, reactive to resize. **Globally fixes** the prior row-num/check-col both-`left:0` overlap.
- **Reorder-robust** prefix derivation; `FROZEN_DEFAULT_WIDTH` for width-determinism; `parseFrozenIds` narrow helper (dirty config → `[]`).
- **UI**: minimal pin toggle in `MetaFieldHeader` (`@click.stop @mousedown.stop` + localized aria — no accidental sort/reorder). Freeze-up-to / unfreeze.
- Frozen cell bg **preserves conditional-formatting `backgroundColor`** (opaque `#fff` only as fallback).

## Boundary

`apps/web/src/multitable/` only — no backend / api / contract / rbac.

## Verification

- **vue-tsc** clean.
- **Tests** (component + util): `parseFrozenIds` invalid-config fallback; cumulative offset math (base/multiselect/default-width/empty); pin emit + boundary-unfreeze + **no sort-bubble**; **frozen cell keeps conditional-formatting bg** + `#fff` fallback; i18n & inline-create regressions green.
- **Caveat:** my env is headless — tests cover the **offset math + gating + emit + parse** (the logic); actual CSS `position: sticky` visual is browser-native (manual confirmation recommended).

## Design

`docs/development/multitable-frozen-columns-design-20260525.md` (left-prefix, offset stack, base-fix, parse helper, pin UI — reviewed + revised).

🤖 Generated with [Claude Code](https://claude.com/claude-code)