### PR TITLE
feat(integration): DF-N1 run monitoring UI — runs + row-level + dead-letter display (read-only, front-end)

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -173,6 +173,21 @@ export interface IntegrationPipelineObservationQuery extends IntegrationScope {
   offset?: number
 }
 
+// One per-record target-write business response (sanitized + capped at 50
+// server-side). This is the concrete present-day grain of #1839's RowResult.
+export interface IntegrationTargetWriteSummary {
+  [key: string]: unknown
+}
+
+// Forward-compatible: the runner records `targetWriteSummaries` (row-level write
+// results, #1813) and `watermarkAdvanced` inside `run.details` today; unknown
+// keys are preserved so new detail fields don't require a type bump.
+export interface IntegrationPipelineRunDetails {
+  targetWriteSummaries?: IntegrationTargetWriteSummary[]
+  watermarkAdvanced?: boolean
+  [key: string]: unknown
+}
+
 export interface IntegrationPipelineRun {
   id: string
   tenantId: string
@@ -189,7 +204,7 @@ export interface IntegrationPipelineRun {
   finishedAt?: string | null
   durationMs?: number | null
   errorSummary?: string | null
-  details?: Record<string, unknown>
+  details?: IntegrationPipelineRunDetails
   createdAt?: string | null
 }
 

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -688,11 +688,11 @@
     <section class="integration-workbench__panel">
       <div class="integration-workbench__panel-head">
         <div>
-          <h2>运行观察</h2>
-          <p>{{ observationSummary }}。这里显示最近 5 条 run 和 open dead letters，便于清洗后回看失败原因。</p>
+          <h2>运行监控</h2>
+          <p>{{ observationSummary }}。展示最近 5 条 run（状态 / 写入 / 失败 + 行级结果）与 open dead letters，便于清洗后回看失败原因。</p>
         </div>
         <button type="button" class="integration-workbench__button" data-testid="refresh-observation" :disabled="observingPipeline" @click="refreshPipelineObservation(false)">
-          {{ observingPipeline ? '刷新中' : '刷新观察' }}
+          {{ observingPipeline ? '刷新中' : '刷新监控' }}
         </button>
       </div>
 
@@ -701,11 +701,27 @@
           <h3>最近运行</h3>
           <div v-if="pipelineRuns.length === 0" class="integration-workbench__empty">暂无运行记录。</div>
           <ol v-else class="integration-workbench__record-list" data-testid="pipeline-runs">
-            <li v-for="run in pipelineRuns" :key="run.id">
-              <strong>{{ run.status }}</strong>
-              <span>{{ run.mode }}</span>
-              <span>read {{ run.rowsRead }} / clean {{ run.rowsCleaned }} / write {{ run.rowsWritten }} / fail {{ run.rowsFailed }}</span>
-              <small>{{ run.startedAt || run.createdAt || run.id }}</small>
+            <li v-for="run in pipelineRuns" :key="run.id" :data-testid="`pipeline-run-${run.id}`">
+              <div class="integration-workbench__run-head">
+                <strong :class="`integration-workbench__run-status integration-workbench__run-status--${run.status}`" :data-testid="`run-status-${run.id}`">{{ run.status }}</strong>
+                <span>{{ run.mode }}</span>
+                <span v-if="run.triggeredBy">by {{ run.triggeredBy }}</span>
+              </div>
+              <div class="integration-workbench__run-metrics">
+                <span>read {{ run.rowsRead }}</span>
+                <span>clean {{ run.rowsCleaned }}</span>
+                <span class="integration-workbench__run-metric--write">write {{ run.rowsWritten }}</span>
+                <span class="integration-workbench__run-metric--fail">fail {{ run.rowsFailed }}</span>
+                <span v-if="run.durationMs != null">{{ run.durationMs }}ms</span>
+              </div>
+              <small>{{ run.startedAt || run.createdAt || run.id }}<template v-if="run.finishedAt"> → {{ run.finishedAt }}</template></small>
+              <p v-if="run.errorSummary" class="integration-workbench__run-error" :data-testid="`run-error-${run.id}`">{{ run.errorSummary }}</p>
+              <div v-if="runRowSummaries(run).length > 0" class="integration-workbench__run-summaries">
+                <button type="button" class="integration-workbench__link-button" :data-testid="`toggle-run-summaries-${run.id}`" @click="toggleRunSummaries(run.id)">
+                  {{ isRunExpanded(run.id) ? '收起行级结果' : `展开行级结果（${runRowSummaries(run).length}）` }}
+                </button>
+                <pre v-if="isRunExpanded(run.id)" :data-testid="`run-row-summaries-${run.id}`">{{ JSON.stringify(runRowSummaries(run), null, 2) }}</pre>
+              </div>
             </li>
           </ol>
         </div>
@@ -713,10 +729,12 @@
           <h3>Open Dead Letters</h3>
           <div v-if="deadLetters.length === 0" class="integration-workbench__empty">暂无 open dead letters。</div>
           <ol v-else class="integration-workbench__record-list" data-testid="dead-letters">
-            <li v-for="deadLetter in deadLetters" :key="deadLetter.id">
+            <li v-for="deadLetter in deadLetters" :key="deadLetter.id" :data-testid="`dead-letter-${deadLetter.id}`">
               <strong>{{ deadLetter.errorCode }}</strong>
               <span>{{ deadLetter.errorMessage }}</span>
-              <small>{{ deadLetter.status }} · {{ deadLetter.createdAt || deadLetter.id }}</small>
+              <small>
+                {{ deadLetter.status }} · {{ deadLetter.createdAt || deadLetter.id }}<template v-if="deadLetter.retryCount"> · retries {{ deadLetter.retryCount }}</template><template v-if="deadLetter.idempotencyKey"> · key {{ deadLetter.idempotencyKey }}</template>
+              </small>
             </li>
           </ol>
         </div>
@@ -775,6 +793,7 @@ import {
   type IntegrationPipelineMode,
   type IntegrationPipelineRun,
   type IntegrationPipelineRunResult,
+  type IntegrationTargetWriteSummary,
   type IntegrationStagingDescriptor,
   type IntegrationStagingInstallResult,
   type IntegrationStagingOpenTarget,
@@ -914,6 +933,7 @@ const pipelineResultText = ref('尚未执行')
 const lastDryRunResult = ref<IntegrationPipelineRunResult | null>(null)
 const pipelineRuns = ref<IntegrationPipelineRun[]>([])
 const deadLetters = ref<IntegrationDeadLetter[]>([])
+const expandedRunIds = ref<Set<string>>(new Set())
 const statusMessage = ref('')
 const statusKind = ref<'idle' | 'success' | 'error'>('idle')
 const pipelineName = ref('')
@@ -2308,6 +2328,22 @@ async function refreshPipelineObservation(silent = false): Promise<void> {
   }
 }
 
+function runRowSummaries(run: IntegrationPipelineRun): IntegrationTargetWriteSummary[] {
+  const summaries = run.details?.targetWriteSummaries
+  return Array.isArray(summaries) ? summaries : []
+}
+
+function isRunExpanded(runId: string): boolean {
+  return expandedRunIds.value.has(runId)
+}
+
+function toggleRunSummaries(runId: string): void {
+  const next = new Set(expandedRunIds.value)
+  if (next.has(runId)) next.delete(runId)
+  else next.add(runId)
+  expandedRunIds.value = next
+}
+
 async function savePipeline(): Promise<void> {
   savingPipeline.value = true
   try {
@@ -3181,6 +3217,91 @@ watch(showAdvancedConnectors, () => {
 
 .integration-workbench__record-list small {
   color: #5c6878;
+}
+
+.integration-workbench__run-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.integration-workbench__run-metrics {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  font-size: 12px;
+  color: #5c6878;
+}
+
+.integration-workbench__run-metric--write {
+  color: #1f6f43;
+  font-weight: 600;
+}
+
+.integration-workbench__run-metric--fail {
+  color: #8f1d1d;
+  font-weight: 600;
+}
+
+.integration-workbench__run-status {
+  text-transform: uppercase;
+  font-size: 11px;
+  letter-spacing: 0.04em;
+  padding: 1px 6px;
+  border-radius: 4px;
+  background: #e7eef6;
+  color: #24476b;
+}
+
+.integration-workbench__run-status--succeeded {
+  background: #e3f3e8;
+  color: #1f6f43;
+}
+
+.integration-workbench__run-status--partial {
+  background: #fdf3e0;
+  color: #8a5a12;
+}
+
+.integration-workbench__run-status--failed,
+.integration-workbench__run-status--cancelled {
+  background: #fbe7e7;
+  color: #8f1d1d;
+}
+
+.integration-workbench__run-error {
+  margin: 0;
+  font-size: 12px;
+  color: #8f1d1d;
+}
+
+.integration-workbench__run-summaries {
+  display: grid;
+  gap: 4px;
+}
+
+/* Inline row-level results: override the global tall/dark `pre` so each
+   expanded run stays compact within the record list. */
+.integration-workbench__run-summaries pre {
+  min-height: 0;
+  max-height: 200px;
+  margin: 4px 0 0;
+}
+
+.integration-workbench__link-button {
+  border: none;
+  background: none;
+  padding: 0;
+  color: #357abd;
+  cursor: pointer;
+  font: inherit;
+  text-decoration: underline;
+}
+
+.integration-workbench__link-button:disabled {
+  cursor: not-allowed;
+  opacity: 0.55;
 }
 
 .integration-workbench__preview {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -1198,4 +1198,109 @@ describe('IntegrationWorkbenchView', () => {
     expect(container.querySelector('[data-testid="staging-project-id-scope-warning"]')).toBeNull()
     expect(scopeStatus.textContent).toContain('default:integration-core')
   })
+
+  it('renders run monitoring with row-level results and read-only dead-letter display', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      // onMounted bootstrap (refreshBootstrap)
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems')) return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      // monitoring reads
+      if (url === '/api/integration/runs?tenantId=default&pipelineId=pipe_mon&limit=5') {
+        return jsonResponse([
+          {
+            id: 'run_mon_1',
+            tenantId: 'default',
+            workspaceId: null,
+            pipelineId: 'pipe_mon',
+            mode: 'manual',
+            triggeredBy: 'api',
+            status: 'partial',
+            rowsRead: 3,
+            rowsCleaned: 3,
+            rowsWritten: 2,
+            rowsFailed: 1,
+            durationMs: 1200,
+            startedAt: '2026-05-26T01:00:00.000Z',
+            finishedAt: '2026-05-26T01:00:01.200Z',
+            errorSummary: '1 row failed validation',
+            details: {
+              watermarkAdvanced: false,
+              targetWriteSummaries: [
+                { code: 'MAT-001', result: 'ok', targetId: 'K3-9001' },
+                { code: 'MAT-002', result: 'ok', targetId: 'K3-9002' },
+              ],
+            },
+          },
+        ])
+      }
+      if (url === '/api/integration/dead-letters?tenantId=default&pipelineId=pipe_mon&status=open&limit=5') {
+        return jsonResponse([
+          {
+            id: 'dl_mon_1',
+            tenantId: 'default',
+            workspaceId: null,
+            pipelineId: 'pipe_mon',
+            runId: 'run_mon_1',
+            idempotencyKey: 'MAT-003',
+            errorCode: 'VALIDATION_FAILED',
+            errorMessage: 'missing name',
+            retryCount: 0,
+            status: 'open',
+          },
+        ])
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    // Stage-5 term (renamed from 运行观察).
+    expect(container.textContent).toContain('运行监控')
+
+    // Point monitoring at an existing pipeline, then refresh.
+    const pipelineIdInput = container.querySelector('[data-testid="pipeline-id"]') as HTMLInputElement
+    pipelineIdInput.value = 'pipe_mon'
+    pipelineIdInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="refresh-observation"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    // Run row surfaces status + emphasized write/fail counts.
+    const runRow = container.querySelector('[data-testid="pipeline-run-run_mon_1"]') as HTMLElement
+    expect(runRow).not.toBeNull()
+    expect(runRow.textContent).toContain('partial')
+    expect(runRow.textContent).toContain('write 2')
+    expect(runRow.textContent).toContain('fail 1')
+
+    // Row-level results are collapsed by default, then expandable.
+    expect(container.querySelector('[data-testid="run-row-summaries-run_mon_1"]')).toBeNull()
+    ;(container.querySelector('[data-testid="toggle-run-summaries-run_mon_1"]') as HTMLButtonElement).click()
+    await flushUi()
+    const summaries = container.querySelector('[data-testid="run-row-summaries-run_mon_1"]') as HTMLElement
+    expect(summaries).not.toBeNull()
+    expect(summaries.textContent).toContain('K3-9001')
+    expect(summaries.textContent).toContain('MAT-002')
+
+    // Dead-letter is read-only (error code / message / status). DF-N1 surfaces
+    // no replay action — replay is deferred to its own PR — so neither the
+    // replay button nor the retryability badge is rendered.
+    const dlRow = container.querySelector('[data-testid="dead-letter-dl_mon_1"]') as HTMLElement
+    expect(dlRow).not.toBeNull()
+    expect(dlRow.textContent).toContain('VALIDATION_FAILED')
+    expect(dlRow.textContent).toContain('open')
+    expect(container.querySelector('[data-testid="replay-dead-letter-dl_mon_1"]')).toBeNull()
+    expect(container.querySelector('[data-testid="dead-letter-retryable-dl_mon_1"]')).toBeNull()
+  })
 })

--- a/docs/development/data-factory-df-n1-run-monitoring-ui-design-20260526.md
+++ b/docs/development/data-factory-df-n1-run-monitoring-ui-design-20260526.md
@@ -1,0 +1,65 @@
+# Data Factory — DF-N1 Run Monitoring UI Design - 2026-05-26
+
+## Status / purpose
+
+**Front-end-only implementation of DF-N1 (the first slice of Data Factory Stage 5 "运行监控").** Surfaces the run / row-level / dead-letter state that the integration-core runtime **already records**, in the existing IntegrationWorkbench view. **Read-only**: read-existing-state only; **zero backend, zero migration, zero new connector behavior, no write action.** Implementation PR — held for review, not auto-merged.
+
+**Replay is intentionally NOT in this slice** — see the scope decision below.
+
+## Relationship to the 阶段二 design seed set (references, does NOT re-derive)
+
+- `data-factory-hub-direction-20260525.md` / **#1838** — direction & gating (umbrella). Confirms: *"success/fail today = pipeline run status + targetWriteSummaries (row-level, #1813) + dead-letters (replayable)."* This slice surfaces the run-status + targetWriteSummaries + dead-letter **state** (it does not act on the "replayable" part).
+- `data-factory-nifi-inspired-run-provenance-design-20260526.md` / **#1839** — run/provenance + core object data model, and the **DF-N0..N4 phasing**. This slice is **DF-N1**: *"Run result UI on existing surfaces … Prefer existing `integration_run_log` and `integration_exceptions` … Expected lock profile: front-end / read-existing-state first. Any API or persistence change must be split into its own gated PR."* `targetWriteSummaries` is the concrete present-day form of #1839's design-model **RowResult**.
+- `data-factory-user-flow-ia-design-20260526.md` / **#1844** — UX/IA. **Stage 5 "运行监控"** = *"Run history + row-level results + provenance/lineage + dead-letters + retry of selected failed rows"*, and explicitly: *"stage 5 monitoring surfaces existing run/exception data first (#1839 DF-N1)"* and *"each screen/feature is its own gated PR."* This PR is that gated opt-in for Stage 5's first, read-only slice; the "retry of selected failed rows" part of Stage 5 is deferred.
+
+K3 WISE stays a **preset**, not the product center.
+
+## What this slice adds (concrete)
+
+All changes are in `apps/web` (Vue frontend) + its tests + these docs.
+
+1. **Panel rename `运行观察 → 运行监控`** to match #1844's Stage-5 term. (No test asserts on the old literal — verified by grep; existing `data-testid`s preserved.)
+2. **Run list — structured columns.** Per run: `status` (state badge), `mode`, `triggeredBy`, read/clean/**write**/**fail** counts (write & fail emphasized per the user goal), `durationMs`, `startedAt`/`finishedAt`, and `errorSummary` when present.
+3. **Row-level results (`targetWriteSummaries`).** Each run can expand to show `run.details.targetWriteSummaries` — the per-record target-write business responses the runner already records (sanitized, capped at 50 server-side). Rendered read-only as compact JSON. This is #1839's RowResult at today's grain.
+4. **Open dead-letter / exception entry — read-only.** Per dead-letter: `errorCode`, `errorMessage`, `status` (open/replayed/discarded — which itself conveys retryability), `retryCount`, `idempotencyKey`, `createdAt`. **No action buttons.**
+
+## Scope decision (NAMED): DF-N1 is read-only; replay deferred to its own PR
+
+Replay sits in the genuine gap between DF-N1 and DF-N3, so it is called out explicitly rather than buried — and, per review, **kept out of this slice**.
+
+- **DF-N1 strict text** emphasizes *links* and *read-existing-state first*. A slice literally named "运行监控" should be **read-only**.
+- The existing `POST /api/integration/dead-letters/:id/replay` route **re-runs the pipeline** — a real target/ERP write. Even gated (two-step confirm, open-only, backend write-perm), surfacing a write here muddies the monitoring boundary and deserves a focused review of its own (idempotency / duplicate-write semantics as the subject, not a footnote).
+- **Decision:** ship pure read-only monitoring now; replay returns as a **separate gated PR** ("DF-N1.5 single manual replay" or a DF-N3 precursor). The replay implementation is preserved on branch `frontend/data-factory-df-n1_5-deadletter-replay-20260526` for that PR.
+
+| Concern | This slice (DF-N1, read-only) | Deferred |
+|---|---|---|
+| Run / row-level / dead-letter **display** | ✅ | — |
+| Single manual replay (existing route, confirm-gated) | ❌ | **DF-N1.5 / own PR** |
+| Bulk "retry selected failed rows" + stop rules + run policy + back-pressure | ❌ | **DF-N3** (frozen) |
+
+## Lock profile / boundaries
+
+- **Pure front-end, read-only.** Touches only `apps/web/src/views/IntegrationWorkbenchView.vue`, `apps/web/src/services/integration/workbench.ts` (read-only types over existing read routes), their specs, and these docs.
+- **No** backend / plugin / migration / connector / API-contract / RBAC change, and **no write action** of any kind. (Stage-1 K3 lock respected.)
+- **No** K3 Submit/Audit, no BOM, no multi-record push, no read/list unlock, no server-side reference auto-composition.
+- **DF-N2 (provenance event), DF-N3 (retry/back-pressure), DF-N4 (connector catalog), and dead-letter replay remain separate gated opt-ins.**
+- Scope stays single-pipeline (tied to the view's existing `savedPipelineId`); cross-pipeline monitoring is not required by #1844 for DF-N1.
+
+## Existing data sources reused (no new endpoints)
+
+| Surface | Existing route | Existing client |
+|---|---|---|
+| Runs | `GET /api/integration/runs` | `listIntegrationPipelineRuns()` |
+| Row-level results | `run.details.targetWriteSummaries` (runner-recorded) | (read off the run object; typed via `IntegrationPipelineRunDetails`) |
+| Open dead-letters | `GET /api/integration/dead-letters?status=open` | `listIntegrationDeadLetters()` |
+
+## Test plan
+
+- **Service spec** (`integrationWorkbench.spec.ts`): existing run/dead-letter list coverage; `IntegrationPipelineRunDetails` typing of `targetWriteSummaries`.
+- **Component spec** (`IntegrationWorkbenchView.spec.ts`): run row renders status/write/fail; `targetWriteSummaries` collapsed→expandable; dead-letter renders read-only (code/message/status); and **no replay button / no retryability badge** is rendered (locks the read-only scope). Stable `data-testid`s: `pipeline-run-<id>`, `toggle-run-summaries-<id>`, `run-row-summaries-<id>`, `dead-letter-<id>`.
+
+## See also
+
+- #1838 (direction/gating) · #1839 (run/provenance + DF-N phasing) · #1844 (IA Stage 5) · #1813 (targetWriteSummaries / row-level) · #1828 (completeness preview) · #1709/#1835 (read decision/track) · #1792 (GATE).
+- Verification: `data-factory-df-n1-run-monitoring-ui-verification-20260526.md`.
+- Deferred replay work: branch `frontend/data-factory-df-n1_5-deadletter-replay-20260526`.

--- a/docs/development/data-factory-df-n1-run-monitoring-ui-verification-20260526.md
+++ b/docs/development/data-factory-df-n1-run-monitoring-ui-verification-20260526.md
@@ -1,0 +1,43 @@
+# Data Factory — DF-N1 Run Monitoring UI Verification - 2026-05-26
+
+Verification for `data-factory-df-n1-run-monitoring-ui-design-20260526.md` (DF-N1 = first, **read-only** slice of #1844 Stage 5 "运行监控"). Branch: `frontend/data-factory-df-n1-run-monitoring-20260526` (off `origin/main` @ 8d792a948). **Not merged — held for review.** Replay deliberately excluded (see design doc scope decision); replay impl preserved on `frontend/data-factory-df-n1_5-deadletter-replay-20260526`.
+
+## What was implemented (front-end only, read-only)
+
+| File | Change |
+|---|---|
+| `apps/web/src/services/integration/workbench.ts` | `IntegrationTargetWriteSummary` + forward-compatible `IntegrationPipelineRunDetails` types (narrows `run.details.targetWriteSummaries`). No write/replay client. |
+| `apps/web/src/views/IntegrationWorkbenchView.vue` | Panel `运行观察 → 运行监控`; structured run rows (status badge, mode, triggeredBy, read/clean/**write**/**fail**, duration, timestamps, errorSummary); expandable per-run **row-level results** from `targetWriteSummaries`; read-only dead-letter rows (errorCode/message/status/retryCount/idempotencyKey); scoped CSS. No action buttons. |
+| `apps/web/tests/integrationWorkbench.spec.ts` | Service run/dead-letter list coverage (unchanged from baseline). |
+| `apps/web/tests/IntegrationWorkbenchView.spec.ts` | New mount test: rename, run metrics, collapsed→expandable row-level results, read-only dead-letter display, and **assert no replay button / no retryability badge** (locks the read-only scope). |
+| `docs/development/data-factory-df-n1-run-monitoring-ui-{design,verification}-20260526.md` | This design + verification. |
+
+## Commands run (all from the worktree)
+
+```
+pnpm --filter @metasheet/web exec vitest run tests/integrationWorkbench.spec.ts tests/IntegrationWorkbenchView.spec.ts
+  → Test Files 2 passed (2) · Tests 29 passed (29)
+pnpm --filter @metasheet/web type-check          → exit 0 (vue-tsc -b, no errors)
+pnpm --filter @metasheet/web exec eslint <4 changed files>
+  → 0 errors, warnings = pre-existing `router-link` test-stub pattern only
+```
+
+This satisfies #1839's verification-strategy item *"front-end test Data Factory run status and dead-letter links"* (extended to row-level results), within a read-only scope.
+
+## Regression check — full web suite (no DF-N1 regressions)
+
+`pnpm --filter @metasheet/web exec vitest run` → 16 test failures, all proven **pre-existing on clean `origin/main`**, not caused by this slice:
+- The 9 failing files (`approval-center`, `attendance-*` ×2, `featureFlags`, `multitable-*` ×4, `useAttendanceAdminRail`) are unrelated domains; **none import** `integration/workbench` or `IntegrationWorkbenchView`.
+- Baseline run with this slice **stashed** reproduced the **identical** `9 files / 16 tests` failures.
+- The two integration-workbench specs pass before and after stash-pop.
+
+(This baseline was established on the replay-inclusive revision; removing replay only shrinks the changed surface, so the conclusion holds.)
+
+## Lock-profile confirmation (matches design)
+
+- **Pure front-end, read-only.** Diff touches only `apps/web/**` (view + service + specs) and these two docs. **No** change to `plugins/plugin-integration-core/**`, `packages/core-backend/**`, migrations, OpenAPI, RBAC, or any connector. **No write action** of any kind — the view only calls the existing read routes (`/runs`, `/dead-letters`). (The `node_modules/.bin` churn from `pnpm install` in the fresh worktree is **not** staged.)
+- **Read-only scope verified** — the component test asserts that neither a replay button (`replay-dead-letter-*`) nor a retryability badge (`dead-letter-retryable-*`) is rendered.
+
+## Not done (remain separate gated opt-ins)
+
+Dead-letter **replay** (single manual; impl preserved on the df-n1_5 branch) · DF-N2 provenance events · DF-N3 bounded retry / stop rules / back-pressure · DF-N4 connector catalog · cross-pipeline monitoring · K3 Submit/Audit/BOM/multi-record/read-unlock.


### PR DESCRIPTION
## DF-N1 — Run Monitoring UI (read-only, front-end only)

First slice of Data Factory **Stage 5 "运行监控"** (#1844), implementing **DF-N1** from the run/provenance phasing (#1839): *"Run result UI on existing surfaces … front-end / read-existing-state first."* Surfaces the run / row-level / dead-letter state the integration-core runtime **already records**, in `IntegrationWorkbenchView`.

> **Updated per review:** replay removed — this PR is now **read-only monitoring**. See "Scope decision" below.

### What it adds
- Panel `运行观察 → 运行监控` (Stage-5 term).
- **Run rows**: status badge, mode, triggeredBy, read/clean/**write**/**fail**, duration, timestamps, errorSummary.
- **Row-level results**: expandable per-run `run.details.targetWriteSummaries` (#1813 / #1839 RowResult).
- **Dead-letters**: read-only display (errorCode / message / status / retryCount / idempotencyKey). No action buttons.

### Scope decision — replay deferred (your call applied)
The existing `POST .../:id/replay` route **re-runs the pipeline = a real target/ERP write**, which doesn't belong in a slice named "运行监控". Replay is deferred to its **own gated PR** ("DF-N1.5 single manual replay" / DF-N3 precursor) where the duplicate-write/idempotency semantics get a focused review. The replay implementation (confirm-gated button + service wrapper + tests) is **preserved** on `frontend/data-factory-df-n1_5-deadletter-replay-20260526`.

### Lock profile
**Pure front-end, read-only** — touches only `apps/web/**` + 2 docs. No backend / migration / connector / OpenAPI / RBAC change, and **no write action** (only the existing `/runs` + `/dead-letters` read routes). K3 Stage-1 lock respected.

### Verification
- `29/29` integration-workbench tests pass; `type-check` clean; `0` lint errors.
- Component test asserts **no replay button / no retryability badge** renders (locks the read-only scope).
- Full-suite 16 failures are pre-existing on clean `origin/main` (stash-baseline reproduced identical `9 files / 16 tests`; none of the failing specs import the changed files).

Docs: `docs/development/data-factory-df-n1-run-monitoring-ui-{design,verification}-20260526.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)