### PR TITLE
feat(multitable): agg-footer #4-3b-2a group subtotals (in-memory)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -737,9 +737,18 @@ function normalizeCommentsParams(params: { containerId: string; targetId: string
   }
 }
 
+export interface ViewAggregateGroup {
+  key: string | number | boolean | null
+  count: number
+  aggregates: Record<string, { fn: string; value: number }>
+}
 export interface ViewAggregateResult {
   total: number
   aggregates: Record<string, { fn: string; value: number }>
+  // #4-3b-2a: present only when the view groups (view.groupInfo.fieldId resolves to an allowed,
+  // non-computed field); otherwise absent (response is byte-identical to the grand-total-only shape).
+  groupFieldId?: string
+  groups?: ViewAggregateGroup[]
 }
 
 export class MultitableApiClient {

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -110,6 +110,18 @@
                   </button>
                 </td>
               </tr>
+              <tr v-if="hasGroupSubtotals" class="meta-grid__group-subtotal">
+                <td v-if="enableMultiSelect" class="meta-grid__check-col" :style="{ left: '0px' }"></td>
+                <td class="meta-grid__row-num" :style="{ left: `${rowNumLeft}px` }">Σ</td>
+                <td
+                  v-for="(field, fi) in visibleFields"
+                  :key="field.id"
+                  class="meta-grid__foot-cell meta-grid__group-subtotal-cell"
+                  :style="isFrozen(fi) ? { position: 'sticky', left: `${frozenLeft(fi)}px`, zIndex: '1', background: '#fcfcfd' } : undefined"
+                >
+                  <span class="meta-grid__foot-value">{{ groupAggValueDisplay(group.key, field.id) }}</span>
+                </td>
+              </tr>
             </template>
           </template>
           <tr v-if="!rows.length && !loading">
@@ -359,6 +371,9 @@ const props = defineProps<{
   aggregationConfig?: Record<string, string>
   aggregates?: Record<string, { fn: string; value: number }>
   aggregateTooLarge?: boolean
+  // #4-3b-2a: server-computed per-group subtotals (full filtered set, NOT page). Matched to the
+  // client's rendered groups by key. Value rendered from this prop only — no local group aggregation.
+  aggregateGroups?: Array<{ key: string | number | boolean | null; count: number; aggregates: Record<string, { fn: string; value: number }> }>
 }>()
 
 const emit = defineEmits<{
@@ -574,11 +589,26 @@ function aggFnOptions(field: MetaField): string[] {
   return AGG_NUMERIC_TYPES.has(field.type) ? AGG_FNS_NUMERIC : AGG_FNS_OTHER
 }
 const hasAnyAggregation = computed(() => Object.keys(props.aggregationConfig ?? {}).length > 0 || !!props.aggregateTooLarge)
+function formatAggValue(value: number): string {
+  return Number.isInteger(value) ? String(value) : String(Math.round(value * 100) / 100)
+}
 // value comes ONLY from the server response (props.aggregates) — never computed from local rows
 function aggValueDisplay(fieldId: string): string {
   const a = props.aggregates?.[fieldId]
-  if (!a) return ''
-  return Number.isInteger(a.value) ? String(a.value) : String(Math.round(a.value * 100) / 100)
+  return a ? formatAggValue(a.value) : ''
+}
+// #4-3b-2a: server per-group subtotals, keyed by the client group-key form ('__ungrouped__' for null)
+const serverGroupAggByKey = computed(() => {
+  const m = new Map<string, Record<string, { fn: string; value: number }>>()
+  for (const g of props.aggregateGroups ?? []) {
+    m.set(g.key === null ? '__ungrouped__' : String(g.key), g.aggregates)
+  }
+  return m
+})
+const hasGroupSubtotals = computed(() => hasAnyAggregation.value && !props.aggregateTooLarge && (props.aggregateGroups?.length ?? 0) > 0)
+function groupAggValueDisplay(groupKey: string, fieldId: string): string {
+  const a = serverGroupAggByKey.value.get(groupKey)?.[fieldId]
+  return a ? formatAggValue(a.value) : ''
 }
 function onAggChange(fieldId: string, e: Event) {
   const v = (e.target as HTMLSelectElement).value
@@ -743,6 +773,9 @@ function onKeydown(e: KeyboardEvent) {
 .meta-grid__foot-fn { font-size: 11px; color: #999; border: none; background: transparent; cursor: pointer; opacity: 0.5; }
 .meta-grid__foot-fn:hover { opacity: 1; }
 .meta-grid__foot-toolarge td { color: #c0392b; font-weight: 500; }
+.meta-grid__group-subtotal { background: #fcfcfd; }
+.meta-grid__group-subtotal-cell { border-top: 1px solid #ececec; }
+.meta-grid__group-subtotal .meta-grid__foot-value { font-weight: 600; color: #555; }
 .meta-grid__add-row-btn {
   display: flex; align-items: center; gap: 6px; width: 100%;
   padding: 8px 12px; background: transparent; border: none; cursor: pointer;

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -246,7 +246,7 @@
           :rows="grid.rows.value" :visible-fields="scopedGridFields" :sort-rules="grid.sortRules.value"
           :loading="grid.loading.value" :current-page="grid.currentPage.value" :total-pages="grid.totalPages.value"
           :start-index="pageStartIndex" :selected-record-id="selectedRecordId" :can-edit="effectiveRowActions.canEdit"
-          :can-delete="gridAllowsAnyDelete" :can-bulk-edit="effectiveRowActions.canEdit" :can-create="caps.canCreateRecord.value" :frozen-left-column-ids="activeFrozenLeftColumnIds" :aggregation-config="activeAggregationConfig" :aggregates="aggregateValues" :aggregate-too-large="aggregateTooLarge" :field-read-only-ids="readOnlyFieldIds" :column-widths="grid.columnWidths.value"
+          :can-delete="gridAllowsAnyDelete" :can-bulk-edit="effectiveRowActions.canEdit" :can-create="caps.canCreateRecord.value" :frozen-left-column-ids="activeFrozenLeftColumnIds" :aggregation-config="activeAggregationConfig" :aggregates="aggregateValues" :aggregate-too-large="aggregateTooLarge" :aggregate-groups="aggregateGroups" :field-read-only-ids="readOnlyFieldIds" :column-widths="grid.columnWidths.value"
           :row-action-overrides="grid.rowActionOverrides.value"
           :link-summaries="grid.linkSummaries.value" :attachment-summaries="grid.attachmentSummaries.value"
           :enable-multi-select="gridAllowsAnyDelete || effectiveRowActions.canEdit"
@@ -1754,6 +1754,7 @@ function onSetFrozen(frozenLeftColumnIds: string[]) {
 // aggregation footer (#4-3b-1): SERVER-RESPONSE ONLY — never compute aggregates from local rows
 const aggregateValues = ref<Record<string, { fn: string; value: number }>>({})
 const aggregateTooLarge = ref(false)
+const aggregateGroups = ref<import('../api/client').ViewAggregateGroup[]>([]) // #4-3b-2a server per-group subtotals
 const activeAggregationConfig = computed<Record<string, string>>(() => {
   const raw = workbench.activeView.value?.config?.aggregations
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {}
@@ -1769,16 +1770,19 @@ async function loadAggregates() {
   if (!sheetId || Object.keys(activeAggregationConfig.value).length === 0) {
     aggregateValues.value = {}
     aggregateTooLarge.value = false
+    aggregateGroups.value = []
     return
   }
   try {
     const r = await workbench.client.aggregateView({ sheetId, viewId: viewId || undefined, search: searchText.value || undefined })
     if (seq !== aggregateReqSeq) return // a newer request superseded this one
     aggregateValues.value = r.aggregates ?? {}
+    aggregateGroups.value = r.groups ?? []
     aggregateTooLarge.value = false
   } catch (e) {
     if (seq !== aggregateReqSeq) return
     aggregateValues.value = {} // NO local fallback — keeps the "filtered set, not page rows" contract
+    aggregateGroups.value = []
     aggregateTooLarge.value = (e as { code?: string })?.code === 'AGGREGATE_TOO_LARGE'
   }
 }

--- a/apps/web/tests/multitable-agg-footer-grid.spec.ts
+++ b/apps/web/tests/multitable-agg-footer-grid.spec.ts
@@ -70,4 +70,66 @@ describe('MetaGridTable aggregation footer', () => {
     expect(optsOf(selects[1])).not.toContain('sum') // fld_name (string) — no sum
     expect(optsOf(selects[1])).toContain('count')
   })
+
+  // ---- #4-3b-2a group subtotals ----
+  const GROUP_FIELDS: MetaField[] = [
+    { id: 'fld_qty', name: 'Qty', type: 'number' },
+    { id: 'fld_cat', name: 'Cat', type: 'string' },
+  ]
+
+  it('renders SERVER per-group subtotal rows — never computes group sums from local rows', () => {
+    const root = mountGrid({
+      rows: [
+        { id: 'r1', version: 1, data: { fld_qty: 1, fld_cat: 'A' } },
+        { id: 'r2', version: 1, data: { fld_qty: 2, fld_cat: 'B' } },
+      ],
+      visibleFields: GROUP_FIELDS,
+      groupField: { id: 'fld_cat', name: 'Cat', type: 'string' },
+      aggregationConfig: { fld_qty: 'sum' },
+      aggregates: { fld_qty: { fn: 'sum', value: 1100 } }, // grand total (server)
+      aggregateGroups: [
+        { key: 'A', count: 10, aggregates: { fld_qty: { fn: 'sum', value: 500 } } },
+        { key: 'B', count: 20, aggregates: { fld_qty: { fn: 'sum', value: 600 } } },
+      ],
+    })
+    const subtotalRows = Array.from(root.querySelectorAll('.meta-grid__group-subtotal'))
+    expect(subtotalRows.length).toBe(2) // one per rendered group
+    const vals = subtotalRows.flatMap((r) => Array.from(r.querySelectorAll('.meta-grid__foot-value')).map((e) => e.textContent?.trim()))
+    expect(vals).toContain('500') // server group A subtotal
+    expect(vals).toContain('600') // server group B subtotal
+    expect(vals).not.toContain('1') // never the local row qty
+    expect(vals).not.toContain('2')
+  })
+
+  it('maps the server null-key group onto the client "(empty)" group', () => {
+    const root = mountGrid({
+      rows: [
+        { id: 'r1', version: 1, data: { fld_qty: 1, fld_cat: '' } }, // empty → client "__ungrouped__"
+        { id: 'r2', version: 1, data: { fld_qty: 2, fld_cat: 'A' } },
+      ],
+      visibleFields: GROUP_FIELDS,
+      groupField: { id: 'fld_cat', name: 'Cat', type: 'string' },
+      aggregationConfig: { fld_qty: 'sum' },
+      aggregates: { fld_qty: { fn: 'sum', value: 3 } },
+      aggregateGroups: [
+        { key: 'A', count: 1, aggregates: { fld_qty: { fn: 'sum', value: 222 } } },
+        { key: null, count: 1, aggregates: { fld_qty: { fn: 'sum', value: 111 } } }, // null-key → "(empty)"
+      ],
+    })
+    const vals = Array.from(root.querySelectorAll('.meta-grid__group-subtotal .meta-grid__foot-value')).map((e) => e.textContent?.trim())
+    expect(vals).toContain('111') // server null-group value rendered under the empty client group
+    expect(vals).toContain('222')
+  })
+
+  it('no subtotal rows when the server returned no groups', () => {
+    const root = mountGrid({
+      rows: [{ id: 'r1', version: 1, data: { fld_qty: 1, fld_cat: 'A' } }],
+      visibleFields: GROUP_FIELDS,
+      groupField: { id: 'fld_cat', name: 'Cat', type: 'string' },
+      aggregationConfig: { fld_qty: 'sum' },
+      aggregates: { fld_qty: { fn: 'sum', value: 1 } },
+      aggregateGroups: [],
+    })
+    expect(root.querySelector('.meta-grid__group-subtotal')).toBeNull()
+  })
 })

--- a/docs/development/multitable-agg-footer-2a-groupsubtotals-verification-20260526.md
+++ b/docs/development/multitable-agg-footer-2a-groupsubtotals-verification-20260526.md
@@ -1,0 +1,57 @@
+# Multitable Aggregation Footer #4-3b-2a — Group Subtotals (in-memory) Verification (2026-05-26)
+
+Implements the locked design `docs/development/multitable-agg-footer-2b-design-20260526.md` (#1849).
+benchmark v2 §9 #4-3b-2a. Backend-first (real-DB + unit green) then frontend. **No SQL-agg, no computed parity** (those stay #4-3b-2b / 2c).
+
+---
+
+## 1. What shipped
+
+**Backend** (multitable-internal kernel-polish):
+- `multitable/aggregation-helpers.ts` — new pure `groupRowsByField(rows, groupFieldId)`: partitions rows into ordered buckets (empty/`null` key LAST; others numeric-aware string sort), total-preserving (`Σ buckets === input`). Single group field (matches grid). `key` emit = primitive as-is / JSON string for complex / `null` for empty; map key namespaced so `1` and `"1"` never collide.
+- `GET /sheets/:sheetId/view-aggregate` (univer-meta.ts) — extended:
+  - group field resolved from **`view.groupInfo.fieldId`** (the grid source of truth; NOT `view.config.groupFieldId`).
+  - **computed group field → `422 AGGREGATE_COMPUTED_GROUP_UNSUPPORTED`** (no `applyLookupRollup` here).
+  - **group field not in D3c-allowed set → `422 AGGREGATE_GROUP_FIELD_DENIED`** (group keys = the field's distinct values → would leak; hard-fail, no silent grand-total fallback).
+  - per-group `aggregates` computed by the SAME `computeAggregates` closure as the grand total → identical fn set + D3c omission (hidden field omitted in every group).
+  - response adds `groupFieldId` + `groups:[{key,count,aggregates}]` **only when grouped**; non-grouped requests are byte-identical to #4-3b-1.
+
+**Frontend** (`apps/web/src/multitable/`):
+- `client.ts` — `ViewAggregateResult` + new `ViewAggregateGroup` (`groupFieldId?`, `groups?`).
+- `MetaGridTable.vue` — per-group subtotal `<tr class="meta-grid__group-subtotal">` rendered after each group's rows (inside the collapse guard), matched to the server group by key (`null` → client `__ungrouped__`). Value rendered **only** from the server `aggregateGroups` prop (`groupAggValueDisplay`) — no local group aggregation. Frozen columns sticky-left like the grand-total `<tfoot>`.
+- `MultitableWorkbench.vue` — `aggregateGroups` ref set from `r.groups ?? []` (under the same monotonic `aggregateReqSeq` guard); cleared on empty/error; passed as `:aggregate-groups`.
+
+## 2. Locked constraints honored (design #1849)
+
+| constraint | done |
+|---|---|
+| group source = `view.groupInfo.fieldId` (not config.groupFieldId) | endpoint reads `view.groupInfo.fieldId` |
+| group shape extends #4-3b-1; non-grouped byte-identical | `groups`/`groupFieldId` only when grouped |
+| `Σ groups.count === total` (partition) | `groupRowsByField` total-preserving; integration test asserts |
+| `key: null` for empty (response contract) → "(empty)" | helper emits `null`; frontend maps to `__ungrouped__`; FE + unit tests |
+| group-by denied field → 422 `AGGREGATE_GROUP_FIELD_DENIED` (no silent fallback) | hard-fail; integration test |
+| computed group field → 422 `AGGREGATE_COMPUTED_GROUP_UNSUPPORTED` | hard-fail; integration test |
+| hidden aggregate field omitted **per group** | shared `computeAggregates`; integration test |
+| 413 unchanged (whole-sheet scan-input cap) | untouched |
+| frontend renders server response only (no local fallback) | `groupAggValueDisplay` reads prop; FE test asserts server 500/600 win, never local 1/2 |
+
+## 3. Boundary
+
+Backend = `core-backend/src/multitable` + the existing route (multitable-internal kernel-polish; **no** SQL-agg, **no** `applyLookupRollup`/computed parity, **no** integration-core/k3-wise/attendance/rbac-core). Frontend = `apps/web/src/multitable`. No schema/migration change (`group_info` column already exists).
+
+## 4. Verification
+
+- **Backend unit (no DB, runs in default `test` step): `tests/unit/aggregation-helpers.test.ts` 7/7** — `aggregateField` fns + `groupRowsByField` partition / null-key-last / numeric ordering / no `1`-vs-`"1"` collision. (Run locally, green.)
+- **Backend real-DB (CI `plugin-tests.yml` step): `multitable-view-aggregate.test.ts` 15/15** — 10 from #4-3b-1 + 5 new: group partition + per-group sums (Σcount===total, grand total still present), per-group hidden-field omission, empty/`null`-key group (count 20), group-denied 422, computed-group 422.
+- **Frontend: `multitable-agg-footer-grid.spec.ts` 8/8** — 5 from #4-3b-1 + 3 new: server per-group values win over local rows, server `null`-key → client "(empty)", no subtotal rows when server returned none.
+- Backend `tsc` clean; frontend `vue-tsc` clean.
+- Pre-existing unrelated local spec flakiness (attendance / approval-center / featureFlags / some multitable-workbench specs) reproduces on clean `origin/main` with this branch stashed → **not introduced here**; CI is the gate.
+- **Caveat (header count):** group header count is still page-based (existing behavior); the subtotal *value* is the full filtered-set server value. Reconciling the header count is out of scope (not a subtotal concern).
+- **Caveat (complex-type group key, display-only):** the server emits `key = JSON.stringify(val)` for array/object group values (multi-select/link), while the grid's existing `groupedRows` keys by `String(val)` (e.g. `['a','b']` → `"a,b"`). So grouping by a complex-type field renders no subtotal for those buckets — **server data is still correct** (`Σ groups.count === total` holds), the client just can't match the key. Realistic group fields (string/number/single-select) work. Follow-up if needed: client `JSON.stringify` for non-primitive group values, or store both forms in `serverGroupAggByKey`.
+- **Caveat (422 refusal UX):** on `AGGREGATE_GROUP_FIELD_DENIED` / `AGGREGATE_COMPUTED_GROUP_UNSUPPORTED` the workbench clears values but `aggregationConfig` stays set, so the `<tfoot>` renders with blank value cells (no number) rather than a "this view can't be aggregated" message. This is the locked hard-fail (no silent grand-total fallback), but the refusal UX is unspecified — follow-up: add a third footer label alongside `aggregateTooLarge`.
+
+## 5. Deferred (unchanged)
+
+- **#4-3b-2b** SQL-side aggregation — evidence-gated (a real sheet hits the raw-count 413).
+- **#4-3b-2c** computed-filter/group parity — demand-gated; default keep 422.
+- Value-based group ordering, multi-level grouping, collapsible-group server state — not planned.

--- a/packages/core-backend/src/multitable/aggregation-helpers.ts
+++ b/packages/core-backend/src/multitable/aggregation-helpers.ts
@@ -3,7 +3,8 @@
  *
  * Dedicated helper (NOT the private `ChartAggregationService.aggregate`) so the footer's locked fn set
  * + config naming can't drift. `toNumber` replicated from chart-aggregation-service.ts (it's private).
- * Design: docs/development/multitable-agg-footer-design-20260525.md.
+ * Design: docs/development/multitable-agg-footer-design-20260525.md
+ *       + docs/development/multitable-agg-footer-2b-design-20260526.md (#4-3b-2a group subtotals).
  */
 export type AggregationFn = 'sum' | 'avg' | 'min' | 'max' | 'count' | 'countNonEmpty' | 'countDistinct'
 
@@ -86,4 +87,51 @@ export function aggregateField(values: unknown[], fn: AggregationFn, fieldType: 
     }
   }
   return null
+}
+
+/** One group bucket: the emitted (JSON-serializable) key + the data rows that fell into it. */
+export interface AggregateGroupBucket {
+  key: string | number | boolean | null
+  rows: Array<Record<string, unknown>>
+}
+
+const GROUP_NULL_SENTINEL = '__empty__' // internal map key for the empty-value group
+
+// LOCKED (#4-3b-2a, design §3.1): empty cell → group key `null`; primitive → itself; complex (array/
+// object, e.g. multi-select/link) → its JSON string. The map key is namespaced so a primitive value
+// and its JSON form can't collide.
+function groupKeyOf(raw: unknown): { mapKey: string; emit: AggregateGroupBucket['key'] } {
+  if (isEmptyCell(raw)) return { mapKey: GROUP_NULL_SENTINEL, emit: null }
+  if (typeof raw === 'string' || typeof raw === 'number' || typeof raw === 'boolean') {
+    return { mapKey: `v:${typeof raw}:${String(raw)}`, emit: raw }
+  }
+  const json = JSON.stringify(raw)
+  return { mapKey: `j:${json}`, emit: json }
+}
+
+/**
+ * Partition `rows` by `groupFieldId` into buckets, ordered by key (empty/null group LAST; others by
+ * numeric-aware string compare). Pure + total-preserving: `Σ buckets[].rows.length === rows.length`.
+ * The route computes per-bucket aggregates with `aggregateField` under the same omission rules as the
+ * grand total. Single group field only (matches grid `view.groupInfo.fieldId`); no multi-level.
+ */
+export function groupRowsByField(
+  rows: Array<Record<string, unknown>>,
+  groupFieldId: string,
+): AggregateGroupBucket[] {
+  const buckets = new Map<string, AggregateGroupBucket>()
+  for (const data of rows) {
+    const { mapKey, emit } = groupKeyOf(data[groupFieldId])
+    let bucket = buckets.get(mapKey)
+    if (!bucket) {
+      bucket = { key: emit, rows: [] }
+      buckets.set(mapKey, bucket)
+    }
+    bucket.rows.push(data)
+  }
+  return [...buckets.values()].sort((a, b) => {
+    if (a.key === null) return b.key === null ? 0 : 1
+    if (b.key === null) return -1
+    return String(a.key).localeCompare(String(b.key), undefined, { numeric: true })
+  })
 }

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -65,7 +65,7 @@ import {
   tryResolveView as tryResolveViewShared,
   type MultitableViewConfig as SharedMultitableViewConfig,
 } from '../multitable/loaders'
-import { parseAggregations, aggregateField, type AggregationFn } from '../multitable/aggregation-helpers'
+import { parseAggregations, aggregateField, groupRowsByField, type AggregationFn } from '../multitable/aggregation-helpers'
 import { ensureLegacyBase as ensureLegacyBaseShared } from '../multitable/provisioning'
 import {
   MultitableTemplateConflictError,
@@ -5822,14 +5822,46 @@ export function univerMetaRouter(): Router {
 
       // aggregate ONLY configured + D3c-allowed fields; disallowed (hidden) field aggregates are OMITTED
       const aggConfig = parseAggregations(view?.config ?? null)
-      const aggregates: Record<string, { fn: AggregationFn; value: number }> = {}
-      for (const [fieldId, fn] of Object.entries(aggConfig)) {
-        const fieldType = aggregateFieldTypeById.get(fieldId)
-        if (!fieldType) continue // hidden / permission-denied / unknown → omit (no leak)
-        const value = aggregateField(rows.map((rec) => rec.data[fieldId]), fn, fieldType)
-        if (value !== null) aggregates[fieldId] = { fn, value }
+      const computeAggregates = (dataRows: Array<Record<string, unknown>>) => {
+        const out: Record<string, { fn: AggregationFn; value: number }> = {}
+        for (const [fieldId, fn] of Object.entries(aggConfig)) {
+          const fieldType = aggregateFieldTypeById.get(fieldId)
+          if (!fieldType) continue // hidden / permission-denied / unknown → omit (no leak)
+          const value = aggregateField(dataRows.map((d) => d[fieldId]), fn, fieldType)
+          if (value !== null) out[fieldId] = { fn, value }
+        }
+        return out
       }
-      return res.json({ ok: true, data: { total: rows.length, aggregates } })
+      // group subtotals (#4-3b-2a): grid group field is view.groupInfo.fieldId (NOT view.config.groupFieldId).
+      // Resolve + run the 422 gates BEFORE the grand total → no wasted aggregation on a refused request.
+      const groupFieldId =
+        typeof (view?.groupInfo as { fieldId?: unknown } | undefined)?.fieldId === 'string'
+          ? ((view!.groupInfo as { fieldId?: string }).fieldId as string).trim()
+          : ''
+      if (groupFieldId) {
+        // group field computed → can't materialize here (same posture as computed filter)
+        const groupFieldType = filterFieldTypeById.get(groupFieldId)
+        if (groupFieldType && COMPUTED_FILTER_TYPES.has(groupFieldType)) {
+          return res.status(422).json({ ok: false, error: { code: 'AGGREGATE_COMPUTED_GROUP_UNSUPPORTED', message: 'Grouping a view by a computed (lookup/rollup/formula) field is not yet supported' } })
+        }
+        // group field hidden/denied (or not a visible property field) → REFUSE: the group keys are that
+        // field's distinct values, so emitting them would leak data the user can't see.
+        if (!aggregateFieldTypeById.has(groupFieldId)) {
+          return res.status(422).json({ ok: false, error: { code: 'AGGREGATE_GROUP_FIELD_DENIED', message: 'Cannot group by a field that is not visible to this user' } })
+        }
+      }
+
+      const aggregates = computeAggregates(rows.map((rec) => rec.data))
+      if (!groupFieldId) {
+        // not grouped → response byte-identical to #4-3b-1
+        return res.json({ ok: true, data: { total: rows.length, aggregates } })
+      }
+      const groups = groupRowsByField(rows.map((rec) => rec.data), groupFieldId).map((bucket) => ({
+        key: bucket.key,
+        count: bucket.rows.length,
+        aggregates: computeAggregates(bucket.rows),
+      }))
+      return res.json({ ok: true, data: { total: rows.length, aggregates, groupFieldId, groups } })
     } catch (err) {
       const hint = getDbNotReadyMessage(err)
       if (hint) return res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: hint } })

--- a/packages/core-backend/tests/integration/multitable-view-aggregate.test.ts
+++ b/packages/core-backend/tests/integration/multitable-view-aggregate.test.ts
@@ -30,6 +30,11 @@ const V_SECRET = `v_secret_${TS}`
 const V_BADFN = `v_badfn_${TS}`
 const V_HIDFILTER = `v_hidfilter_${TS}` // hides + filters on the same field
 const V_COMPUTED = `v_computed_${TS}` // filters on a computed (formula) field → must 422
+const V_GROUP = `v_group_${TS}` // groups by cat (A/B)
+const V_GROUP_SECRET = `v_group_secret_${TS}` // groups by cat, aggregates a hidden field → omitted per group
+const V_GROUP_NOTE = `v_group_note_${TS}` // groups by note (has empty '' → null-key group)
+const V_GROUP_DENIED = `v_group_denied_${TS}` // groups by a hidden field → 422
+const V_GROUP_COMPUTED = `v_group_computed_${TS}` // groups by a computed (formula) field → 422
 const N = 60 // > default page size (50) → proves full-set, not page
 
 let app: Express
@@ -81,6 +86,16 @@ describeIfDatabase('multitable view-aggregate (real DB)', () => {
       [V_COMPUTED, SHEET_ID, V_COMPUTED, 'grid', '[]',
         JSON.stringify({ conjunction: 'and', conditions: [{ fieldId: FLD_FORMULA, operator: 'isnotempty' }] }),
         JSON.stringify({ aggregations: { [FLD_QTY]: 'sum' } })])
+    // grouped views (#4-3b-2a): grid group field = view.groupInfo.fieldId
+    const groupedView = (id: string, aggregations: Record<string, string>, groupFieldId: string) =>
+      q('INSERT INTO meta_views (id, sheet_id, name, type, hidden_field_ids, filter_info, config, group_info) VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7::jsonb,$8::jsonb)',
+        [id, SHEET_ID, id, 'grid', '[]', JSON.stringify({ conjunction: 'and', conditions: [] }),
+          JSON.stringify({ aggregations }), JSON.stringify({ fieldId: groupFieldId })])
+    await groupedView(V_GROUP, { [FLD_QTY]: 'sum' }, FLD_CAT) // A/B, 30 each
+    await groupedView(V_GROUP_SECRET, { [FLD_QTY]: 'sum', [FLD_SECRET]: 'sum' }, FLD_CAT) // secret omitted per group
+    await groupedView(V_GROUP_NOTE, { [FLD_QTY]: 'sum' }, FLD_NOTE) // '' → null-key group
+    await groupedView(V_GROUP_DENIED, { [FLD_QTY]: 'sum' }, FLD_SECRET) // hidden group field → 422
+    await groupedView(V_GROUP_COMPUTED, { [FLD_QTY]: 'sum' }, FLD_FORMULA) // computed group field → 422
     // hide fld_secret from this user (subject-scoped) — its aggregate must be OMITTED
     await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER, false, false])
   })
@@ -162,5 +177,56 @@ describeIfDatabase('multitable view-aggregate (real DB)', () => {
     const res = await aggregate(V_COMPUTED)
     expect(res.status).toBe(422)
     expect(res.body.error.code).toBe('AGGREGATE_COMPUTED_FILTER_UNSUPPORTED')
+  })
+
+  // ---- #4-3b-2a group subtotals ----
+
+  test('GROUP: groups partition the full set (Σ count === total) with per-group sums', async () => {
+    const res = await aggregate(V_GROUP) // group by cat A/B
+    expect(res.status).toBe(200)
+    expect(res.body.data.total).toBe(N)
+    expect(res.body.data.groupFieldId).toBe(FLD_CAT)
+    const groups = res.body.data.groups as Array<{ key: unknown; count: number; aggregates: Record<string, { fn: string; value: number }> }>
+    expect(groups.map((g) => g.key)).toEqual(['A', 'B']) // server key order
+    expect(groups.reduce((s, g) => s + g.count, 0)).toBe(N) // partition
+    const byKey = Object.fromEntries(groups.map((g) => [g.key, g]))
+    expect(byKey.A.count).toBe(30)
+    expect(byKey.A.aggregates[FLD_QTY]).toEqual({ fn: 'sum', value: 900 }) // odd i 1..59
+    expect(byKey.B.aggregates[FLD_QTY]).toEqual({ fn: 'sum', value: 930 }) // even i 2..60
+    // grand total unchanged + still present alongside groups
+    expect(res.body.data.aggregates[FLD_QTY]).toEqual({ fn: 'sum', value: 1830 })
+  })
+
+  test('GROUP SECURITY: a hidden aggregate field is OMITTED in every group (not just the grand total)', async () => {
+    const res = await aggregate(V_GROUP_SECRET) // groups by cat, config aggregates FLD_SECRET (hidden) + FLD_QTY
+    expect(res.status).toBe(200)
+    for (const g of res.body.data.groups as Array<{ aggregates: Record<string, unknown> }>) {
+      expect(g.aggregates[FLD_QTY]).toBeDefined()
+      expect(g.aggregates[FLD_SECRET]).toBeUndefined() // hidden → omitted per group, NOT null/0
+    }
+    expect(res.body.data.aggregates[FLD_SECRET]).toBeUndefined() // and in the grand total
+  })
+
+  test('GROUP empty/NULL key: empty cell values form one group with key:null', async () => {
+    const res = await aggregate(V_GROUP_NOTE) // note = '' when i%3==0 (20 rows) else 'x' (40 rows)
+    expect(res.status).toBe(200)
+    const groups = res.body.data.groups as Array<{ key: unknown; count: number }>
+    expect(groups.reduce((s, g) => s + g.count, 0)).toBe(N)
+    const nullGroup = groups.find((g) => g.key === null)
+    expect(nullGroup).toBeDefined()
+    expect(nullGroup!.count).toBe(20) // the '' rows
+    expect(groups.find((g) => g.key === 'x')!.count).toBe(40)
+  })
+
+  test('GROUP DENIED: grouping by a hidden field HARD-FAILS 422 (group keys would leak its data)', async () => {
+    const res = await aggregate(V_GROUP_DENIED) // groups by FLD_SECRET (field_permissions.visible=false)
+    expect(res.status).toBe(422)
+    expect(res.body.error.code).toBe('AGGREGATE_GROUP_FIELD_DENIED')
+  })
+
+  test('GROUP COMPUTED: grouping by a formula field HARD-FAILS 422', async () => {
+    const res = await aggregate(V_GROUP_COMPUTED)
+    expect(res.status).toBe(422)
+    expect(res.body.error.code).toBe('AGGREGATE_COMPUTED_GROUP_UNSUPPORTED')
   })
 })

--- a/packages/core-backend/tests/unit/aggregation-helpers.test.ts
+++ b/packages/core-backend/tests/unit/aggregation-helpers.test.ts
@@ -1,0 +1,58 @@
+/**
+ * Unit tests for the pure footer aggregation helpers (no DB).
+ * Focus: groupRowsByField partition/ordering/null-key contract (#4-3b-2a) + aggregateField basics.
+ */
+import { describe, expect, it } from 'vitest'
+
+import { aggregateField, groupRowsByField } from '../../src/multitable/aggregation-helpers'
+
+describe('aggregateField (locked fns)', () => {
+  it('sum/avg/min/max over numeric, skipping non-numeric', () => {
+    const vals = [1, 2, '3', 'x', null]
+    expect(aggregateField(vals, 'sum', 'number')).toBe(6)
+    expect(aggregateField(vals, 'avg', 'number')).toBe(2)
+    expect(aggregateField(vals, 'min', 'number')).toBe(1)
+    expect(aggregateField(vals, 'max', 'number')).toBe(3)
+  })
+  it('sum on a non-numeric field type is not applicable → null (caller omits)', () => {
+    expect(aggregateField(['a', 'b'], 'sum', 'string')).toBeNull()
+  })
+  it('countNonEmpty treats null/undefined/""/[] as empty', () => {
+    expect(aggregateField(['x', '', null, undefined, [], 'y'], 'countNonEmpty', 'string')).toBe(2)
+  })
+})
+
+describe('groupRowsByField (#4-3b-2a)', () => {
+  const rows = [
+    { cat: 'A', qty: 1 },
+    { cat: 'B', qty: 2 },
+    { cat: 'A', qty: 3 },
+    { cat: '', qty: 4 }, // empty → null-key group
+    { cat: null, qty: 5 }, // also empty → same null-key group
+  ]
+
+  it('partitions all rows (Σ buckets === input length)', () => {
+    const buckets = groupRowsByField(rows, 'cat')
+    expect(buckets.reduce((s, b) => s + b.rows.length, 0)).toBe(rows.length)
+  })
+
+  it('empty/null values collapse into a single key:null group, ordered LAST', () => {
+    const buckets = groupRowsByField(rows, 'cat')
+    expect(buckets.map((b) => b.key)).toEqual(['A', 'B', null]) // non-null first (sorted), null last
+    const nullBucket = buckets.find((b) => b.key === null)!
+    expect(nullBucket.rows.length).toBe(2) // '' and null
+  })
+
+  it('numeric-aware key ordering (2 before 10)', () => {
+    const buckets = groupRowsByField(
+      [{ g: 10 }, { g: 2 }, { g: 1 }],
+      'g',
+    )
+    expect(buckets.map((b) => b.key)).toEqual([1, 2, 10])
+  })
+
+  it('a primitive value and its JSON form do not collide', () => {
+    const buckets = groupRowsByField([{ g: 1 }, { g: '1' }], 'g')
+    expect(buckets.length).toBe(2) // number 1 and string "1" are distinct groups
+  })
+})


### PR DESCRIPTION
Implements the locked design #1849 (`docs/development/multitable-agg-footer-2b-design-20260526.md`). benchmark v2 §9 **#4-3b-2a**. Backend-first. **No SQL-agg, no computed parity** (those stay #4-3b-2b / 2c).

## Backend (multitable-internal kernel-polish)
- `aggregation-helpers.ts`: pure **`groupRowsByField`** — partitions rows into ordered buckets (empty/`null` key LAST; others numeric-aware), total-preserving (`Σ buckets === input`); namespaced map keys so `1` and `"1"` don't collide; `key:null` for empty.
- `view-aggregate` route:
  - group field from **`view.groupInfo.fieldId`** (grid source of truth).
  - **computed group field → `422 AGGREGATE_COMPUTED_GROUP_UNSUPPORTED`**; **denied group field → `422 AGGREGATE_GROUP_FIELD_DENIED`** (hard-fail, no silent grand-total fallback — group keys would leak). 422 gates run **before** the grand-total computation (no wasted work on refusal).
  - per-group aggregates via the same D3c-omission closure as the grand total (hidden field omitted in every group).
  - response adds `groupFieldId` + `groups:[{key,count,aggregates}]` **only when grouped**; non-grouped requests **byte-identical** to #4-3b-1.

## Frontend (`apps/web/src/multitable`)
- `client` `ViewAggregateGroup`/`groups`.
- `MetaGridTable` per-group subtotal `<tr>` after each group's rows, matched to the server group by key (`null` → client `(empty)`), value from the server prop **only** (no local group aggregation), frozen-sticky like the grand-total `<tfoot>`.
- `MultitableWorkbench` `aggregateGroups` ref under the existing monotonic `aggregateReqSeq` guard.

## Tests
- **unit 7/7** `groupRowsByField` (partition / null-key-last / numeric order / `1`≠`"1"`) — runs in default `test` step.
- **integration +5** (→15 total) real-DB: partition + per-group sums (Σcount===total, grand total present), per-group hidden-field omit, empty/`null`-key group, group-denied 422, computed-group 422.
- **frontend +3** (→8): server per-group values win over local rows, server `null`→client "(empty)", no subtotal when server returned none.
- Backend `tsc` + frontend `vue-tsc` clean.

## Known caveats (verification §4; none block — downstream of correct server behavior)
- group **header** count still page-based (subtotal *value* is full-set); complex-type (multi-select/link) group key won't match client `String(val)` form (server data still correct); 422 renders a blank footer rather than a refusal message. All flagged as follow-ups.

## Scope discipline
Multitable kernel-polish; no SQL-agg / `applyLookupRollup` / rbac / integration-core. No schema change (`group_info` exists). **K3 yields.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)