### PR TITLE
feat(integration): DF-N1.5 dead-letter replay — single manual confirm-gated replay (front-end)

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -490,6 +490,41 @@ export async function listIntegrationDeadLetters(
   return Array.isArray(data) ? data : []
 }
 
+export interface IntegrationDeadLetterReplayPayload extends IntegrationScope {
+  mode?: IntegrationPipelineMode
+}
+
+// Backend returns 202 with { deadLetter, replay, warning? }. `replay` is the
+// re-run result; on full success the deadLetter is marked 'replayed'.
+export interface IntegrationDeadLetterReplayResult {
+  deadLetter?: IntegrationDeadLetter
+  replay?: IntegrationPipelineRunResult
+  warning?: { code?: string; message?: string }
+  [key: string]: unknown
+}
+
+// Only 'open' letters are replayable — the server enforces the same, but the UI
+// must not even offer replay for replayed/discarded letters (a second live ERP
+// write). Keep this in lock-step with the backend guard in pipeline-runner.cjs.
+export function isDeadLetterReplayable(deadLetter: Pick<IntegrationDeadLetter, 'status'>): boolean {
+  return deadLetter.status === 'open'
+}
+
+// Surfaces the existing dead-letter replay route (POST .../:id/replay). This is
+// a single manual one-record re-enqueue (DF-N1) — NOT bounded retry/back-pressure
+// orchestration (DF-N3). Replay re-runs the pipeline with the stored payload,
+// i.e. a real target write; callers must gate it behind an explicit confirm.
+export async function replayIntegrationDeadLetter(
+  deadLetterId: string,
+  payload: IntegrationDeadLetterReplayPayload,
+): Promise<IntegrationDeadLetterReplayResult> {
+  const response = await apiFetch(`/api/integration/dead-letters/${encodeURIComponent(deadLetterId)}/replay`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+  return parseIntegrationResponse<IntegrationDeadLetterReplayResult>(response)
+}
+
 export async function listIntegrationStagingDescriptors(): Promise<IntegrationStagingDescriptor[]> {
   const response = await apiFetch('/api/integration/staging/descriptors')
   const data = await parseIntegrationResponse<IntegrationStagingDescriptor[]>(response)

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -689,7 +689,7 @@
       <div class="integration-workbench__panel-head">
         <div>
           <h2>运行监控</h2>
-          <p>{{ observationSummary }}。展示最近 5 条 run（状态 / 写入 / 失败 + 行级结果）与 open dead letters，便于清洗后回看失败原因。</p>
+          <p>{{ observationSummary }}。展示最近 5 条 run（状态 / 写入 / 失败 + 行级结果）与 open dead letters（可重放），便于清洗后回看失败原因。</p>
         </div>
         <button type="button" class="integration-workbench__button" data-testid="refresh-observation" :disabled="observingPipeline" @click="refreshPipelineObservation(false)">
           {{ observingPipeline ? '刷新中' : '刷新监控' }}
@@ -735,6 +735,38 @@
               <small>
                 {{ deadLetter.status }} · {{ deadLetter.createdAt || deadLetter.id }}<template v-if="deadLetter.retryCount"> · retries {{ deadLetter.retryCount }}</template><template v-if="deadLetter.idempotencyKey"> · key {{ deadLetter.idempotencyKey }}</template>
               </small>
+              <div class="integration-workbench__dead-letter-actions">
+                <span
+                  :class="['integration-workbench__badge', isDeadLetterReplayable(deadLetter) ? 'integration-workbench__badge--retryable' : '']"
+                  :data-testid="`dead-letter-retryable-${deadLetter.id}`"
+                >{{ isDeadLetterReplayable(deadLetter) ? '可重放' : '不可重放' }}</span>
+                <template v-if="isDeadLetterReplayable(deadLetter)">
+                  <button
+                    v-if="confirmReplayDeadLetterId !== deadLetter.id"
+                    type="button"
+                    class="integration-workbench__button integration-workbench__button--ghost"
+                    :data-testid="`replay-dead-letter-${deadLetter.id}`"
+                    :disabled="replayingDeadLetterId === deadLetter.id"
+                    @click="requestReplay(deadLetter.id)"
+                  >准备 Replay</button>
+                  <template v-else>
+                    <button
+                      type="button"
+                      class="integration-workbench__button integration-workbench__button--danger"
+                      :data-testid="`confirm-replay-dead-letter-${deadLetter.id}`"
+                      :disabled="replayingDeadLetterId === deadLetter.id"
+                      @click="replayDeadLetter(deadLetter)"
+                    >{{ replayingDeadLetterId === deadLetter.id ? 'Replay 中…' : '确认 Replay（会真实写入）' }}</button>
+                    <button
+                      type="button"
+                      class="integration-workbench__link-button"
+                      :data-testid="`cancel-replay-dead-letter-${deadLetter.id}`"
+                      :disabled="replayingDeadLetterId === deadLetter.id"
+                      @click="cancelReplay"
+                    >取消</button>
+                  </template>
+                </template>
+              </div>
             </li>
           </ol>
         </div>
@@ -774,6 +806,7 @@ import {
   normalizeIntegrationProjectId,
   getExternalSystemSchema,
   installIntegrationStaging,
+  isDeadLetterReplayable,
   listIntegrationDeadLetters,
   listIntegrationPipelineRuns,
   listIntegrationStagingDescriptors,
@@ -781,6 +814,7 @@ import {
   listIntegrationAdapters,
   listWorkbenchExternalSystems,
   previewIntegrationTemplate,
+  replayIntegrationDeadLetter,
   runIntegrationPipeline,
   testExternalSystemConnection,
   upsertWorkbenchExternalSystem,
@@ -934,6 +968,8 @@ const lastDryRunResult = ref<IntegrationPipelineRunResult | null>(null)
 const pipelineRuns = ref<IntegrationPipelineRun[]>([])
 const deadLetters = ref<IntegrationDeadLetter[]>([])
 const expandedRunIds = ref<Set<string>>(new Set())
+const confirmReplayDeadLetterId = ref('')
+const replayingDeadLetterId = ref('')
 const statusMessage = ref('')
 const statusKind = ref<'idle' | 'success' | 'error'>('idle')
 const pipelineName = ref('')
@@ -2344,6 +2380,48 @@ function toggleRunSummaries(runId: string): void {
   expandedRunIds.value = next
 }
 
+// Two-step confirm before any live replay. Replay re-runs the pipeline with the
+// stored payload (a real target/ERP write), so it mirrors the deliberate
+// allowSaveOnlyRun opt-in used for Save-only runs in this view.
+function requestReplay(deadLetterId: string): void {
+  confirmReplayDeadLetterId.value = deadLetterId
+}
+
+function cancelReplay(): void {
+  confirmReplayDeadLetterId.value = ''
+}
+
+async function replayDeadLetter(deadLetter: IntegrationDeadLetter): Promise<void> {
+  if (!isDeadLetterReplayable(deadLetter)) {
+    setStatus('仅可重放 open 状态的 dead letter', 'error')
+    return
+  }
+  replayingDeadLetterId.value = deadLetter.id
+  try {
+    const result = await replayIntegrationDeadLetter(deadLetter.id, {
+      ...currentScope(),
+      mode: pipelineRunMode.value,
+    })
+    // Verdict is the ERP write outcome (rowsFailed) alone. A write that
+    // SUCCEEDED but whose markReplayed bookkeeping failed comes back with the
+    // letter still 'open' + a warning (pipeline-runner.cjs:732-756); that is
+    // still a success — prompting a retry there would risk a duplicate write.
+    const rowsFailed = Number(result.replay?.metrics?.rowsFailed ?? 0)
+    if (rowsFailed > 0) {
+      setStatus(`Replay 未完全成功：dead letter ${deadLetter.id} 仍未解决`, 'error')
+    } else {
+      const warning = result.warning?.message ? `（${result.warning.message}）` : ''
+      setStatus(`Replay 成功：dead letter ${deadLetter.id} 已重放${warning}`, 'success')
+    }
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  } finally {
+    replayingDeadLetterId.value = ''
+    confirmReplayDeadLetterId.value = ''
+    await refreshPipelineObservation(true)
+  }
+}
+
 async function savePipeline(): Promise<void> {
   savingPipeline.value = true
   try {
@@ -3287,6 +3365,22 @@ watch(showAdvancedConnectors, () => {
   min-height: 0;
   max-height: 200px;
   margin: 4px 0 0;
+}
+
+.integration-workbench__dead-letter-actions {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.integration-workbench__badge--retryable {
+  background: #e3f3e8;
+  color: #1f6f43;
+}
+
+.integration-workbench__button--ghost {
+  background: transparent;
 }
 
 .integration-workbench__link-button {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -1199,8 +1199,10 @@ describe('IntegrationWorkbenchView', () => {
     expect(scopeStatus.textContent).toContain('default:integration-core')
   })
 
-  it('renders run monitoring with row-level results and read-only dead-letter display', async () => {
-    apiFetchMock.mockImplementation(async (url: string) => {
+  it('renders run monitoring with row-level results and confirm-gated dead-letter replay', async () => {
+    const replayBodies: Array<Record<string, unknown>> = []
+    let deadLetterFetches = 0
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
       // onMounted bootstrap (refreshBootstrap)
       if (url === '/api/integration/adapters') return jsonResponse([])
       if (url.startsWith('/api/integration/external-systems')) return jsonResponse([])
@@ -1235,6 +1237,9 @@ describe('IntegrationWorkbenchView', () => {
         ])
       }
       if (url === '/api/integration/dead-letters?tenantId=default&pipelineId=pipe_mon&status=open&limit=5') {
+        deadLetterFetches += 1
+        // After replay, the letter leaves the open list.
+        if (deadLetterFetches >= 2) return jsonResponse([])
         return jsonResponse([
           {
             id: 'dl_mon_1',
@@ -1249,6 +1254,14 @@ describe('IntegrationWorkbenchView', () => {
             status: 'open',
           },
         ])
+      }
+      if (url === '/api/integration/dead-letters/dl_mon_1/replay') {
+        expect(init?.method).toBe('POST')
+        replayBodies.push(JSON.parse(String(init?.body)))
+        return jsonResponse({
+          deadLetter: { id: 'dl_mon_1', status: 'replayed' },
+          replay: { run: { id: 'run_mon_2' }, metrics: { rowsWritten: 1, rowsFailed: 0 } },
+        })
       }
       throw new Error(`unexpected URL ${url}`)
     })
@@ -1293,14 +1306,243 @@ describe('IntegrationWorkbenchView', () => {
     expect(summaries.textContent).toContain('K3-9001')
     expect(summaries.textContent).toContain('MAT-002')
 
-    // Dead-letter is read-only (error code / message / status). DF-N1 surfaces
-    // no replay action — replay is deferred to its own PR — so neither the
-    // replay button nor the retryability badge is rendered.
-    const dlRow = container.querySelector('[data-testid="dead-letter-dl_mon_1"]') as HTMLElement
-    expect(dlRow).not.toBeNull()
-    expect(dlRow.textContent).toContain('VALIDATION_FAILED')
-    expect(dlRow.textContent).toContain('open')
-    expect(container.querySelector('[data-testid="replay-dead-letter-dl_mon_1"]')).toBeNull()
-    expect(container.querySelector('[data-testid="dead-letter-retryable-dl_mon_1"]')).toBeNull()
+    // Open dead-letter shows as retryable.
+    expect(container.querySelector('[data-testid="dead-letter-dl_mon_1"]')).not.toBeNull()
+    expect((container.querySelector('[data-testid="dead-letter-retryable-dl_mon_1"]') as HTMLElement).textContent).toContain('可重放')
+
+    // Replay requires a two-step confirm: prepare click does NOT POST.
+    const prepareBtn = container.querySelector('[data-testid="replay-dead-letter-dl_mon_1"]') as HTMLButtonElement
+    expect(prepareBtn).not.toBeNull()
+    expect(container.querySelector('[data-testid="confirm-replay-dead-letter-dl_mon_1"]')).toBeNull()
+    prepareBtn.click()
+    await flushUi()
+    expect(replayBodies).toHaveLength(0)
+
+    // Confirm click POSTs to the existing replay route with the scoped body.
+    const confirmBtn = container.querySelector('[data-testid="confirm-replay-dead-letter-dl_mon_1"]') as HTMLButtonElement
+    expect(confirmBtn).not.toBeNull()
+    confirmBtn.click()
+    // Replay → success status → finally awaits refreshPipelineObservation (two
+    // parallel fetches + re-render); drain the full async chain.
+    await flushUi(15)
+    expect(replayBodies).toEqual([{ tenantId: 'default', workspaceId: null, mode: 'manual' }])
+
+    // Observation reloaded after replay; the replayed letter left the open list.
+    expect(deadLetterFetches).toBeGreaterThanOrEqual(2)
+    expect(container.querySelector('[data-testid="dead-letter-dl_mon_1"]')).toBeNull()
+    expect(container.textContent).toContain('Replay 成功')
+  })
+
+  it('treats a successful replay carrying a markReplayed warning as success (no false retry prompt)', async () => {
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems')) return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/runs?tenantId=default&pipelineId=pipe_warn&limit=5') return jsonResponse([])
+      if (url === '/api/integration/dead-letters?tenantId=default&pipelineId=pipe_warn&status=open&limit=5') {
+        return jsonResponse([
+          { id: 'dl_warn_1', tenantId: 'default', workspaceId: null, pipelineId: 'pipe_warn', runId: 'run_x', errorCode: 'TARGET_5XX', errorMessage: 'gateway timeout', status: 'open' },
+        ])
+      }
+      if (url === '/api/integration/dead-letters/dl_warn_1/replay') {
+        expect(init?.method).toBe('POST')
+        // ERP write SUCCEEDED (rowsFailed 0), but markReplayed bookkeeping failed:
+        // backend returns success + warning with the letter still 'open'
+        // (pipeline-runner.cjs:732-756).
+        return jsonResponse({
+          deadLetter: { id: 'dl_warn_1', status: 'open' },
+          replay: { run: { id: 'run_y' }, metrics: { rowsWritten: 1, rowsFailed: 0 } },
+          warning: { code: 'MARK_REPLAYED_FAILED', message: 'bookkeeping failed' },
+        })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    const pipelineIdInput = container.querySelector('[data-testid="pipeline-id"]') as HTMLInputElement
+    pipelineIdInput.value = 'pipe_warn'
+    pipelineIdInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="refresh-observation"]') as HTMLButtonElement).click()
+    await flushUi()
+    ;(container.querySelector('[data-testid="replay-dead-letter-dl_warn_1"]') as HTMLButtonElement).click()
+    await flushUi()
+    ;(container.querySelector('[data-testid="confirm-replay-dead-letter-dl_warn_1"]') as HTMLButtonElement).click()
+    await flushUi(15)
+
+    // A successful write must read as success even though the letter stayed
+    // 'open' and a warning came back — and must NOT show the retry prompt
+    // (which would invite a duplicate ERP write). The warning is surfaced.
+    expect(container.textContent).toContain('Replay 成功')
+    expect(container.textContent).toContain('bookkeeping failed')
+    expect(container.textContent).not.toContain('未完全成功')
+  })
+
+  it('does not offer replay for a non-open (replayed/discarded) dead-letter', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems')) return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/runs?tenantId=default&pipelineId=pipe_np&limit=5') return jsonResponse([])
+      if (url === '/api/integration/dead-letters?tenantId=default&pipelineId=pipe_np&status=open&limit=5') {
+        // A letter already 'replayed' must NOT be replayable again (a second
+        // live ERP write); the only-open guard must hide the replay button.
+        return jsonResponse([
+          { id: 'dl_np_1', tenantId: 'default', workspaceId: null, pipelineId: 'pipe_np', runId: 'run_z', errorCode: 'VALIDATION_FAILED', errorMessage: 'missing code', status: 'replayed' },
+        ])
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    const pipelineIdInput = container.querySelector('[data-testid="pipeline-id"]') as HTMLInputElement
+    pipelineIdInput.value = 'pipe_np'
+    pipelineIdInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="refresh-observation"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="dead-letter-dl_np_1"]')).not.toBeNull()
+    expect((container.querySelector('[data-testid="dead-letter-retryable-dl_np_1"]') as HTMLElement).textContent).toContain('不可重放')
+    expect(container.querySelector('[data-testid="replay-dead-letter-dl_np_1"]')).toBeNull()
+  })
+
+  it('surfaces a 403 permission error on replay without removing the dead-letter', async () => {
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems')) return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/runs?tenantId=default&pipelineId=pipe_perm&limit=5') return jsonResponse([])
+      if (url === '/api/integration/dead-letters?tenantId=default&pipelineId=pipe_perm&status=open&limit=5') {
+        return jsonResponse([
+          { id: 'dl_perm_1', tenantId: 'default', workspaceId: null, pipelineId: 'pipe_perm', runId: 'run_p', errorCode: 'VALIDATION_FAILED', errorMessage: 'missing code', status: 'open' },
+        ])
+      }
+      if (url === '/api/integration/dead-letters/dl_perm_1/replay') {
+        expect(init?.method).toBe('POST')
+        // Backend route enforces requireAccess(req, 'write').
+        return new Response(
+          JSON.stringify({ ok: false, error: { code: 'FORBIDDEN', message: 'write permission required' } }),
+          { status: 403, headers: { 'Content-Type': 'application/json' } },
+        )
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    const pipelineIdInput = container.querySelector('[data-testid="pipeline-id"]') as HTMLInputElement
+    pipelineIdInput.value = 'pipe_perm'
+    pipelineIdInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="refresh-observation"]') as HTMLButtonElement).click()
+    await flushUi()
+    ;(container.querySelector('[data-testid="replay-dead-letter-dl_perm_1"]') as HTMLButtonElement).click()
+    await flushUi()
+    ;(container.querySelector('[data-testid="confirm-replay-dead-letter-dl_perm_1"]') as HTMLButtonElement).click()
+    await flushUi(15)
+
+    // Permission failure is surfaced and the dead-letter stays put (the panel
+    // reflects server truth on refresh — there is no optimistic removal).
+    expect(container.textContent).toContain('write permission required')
+    expect(container.querySelector('[data-testid="dead-letter-dl_perm_1"]')).not.toBeNull()
+  })
+
+  it('locks the confirm button while a replay is in flight (no double-submit window)', async () => {
+    let resolveReplay!: (v: Response) => void
+    let replayCalls = 0
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems')) return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/runs?tenantId=default&pipelineId=pipe_if&limit=5') return jsonResponse([])
+      if (url === '/api/integration/dead-letters?tenantId=default&pipelineId=pipe_if&status=open&limit=5') {
+        return jsonResponse([
+          { id: 'dl_if_1', tenantId: 'default', workspaceId: null, pipelineId: 'pipe_if', runId: 'run_if', errorCode: 'VALIDATION_FAILED', errorMessage: 'missing code', status: 'open' },
+        ])
+      }
+      if (url === '/api/integration/dead-letters/dl_if_1/replay') {
+        replayCalls += 1
+        // Hold the request open so the in-flight UI state is observable.
+        return new Promise<Response>((resolve) => { resolveReplay = resolve })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    const pipelineIdInput = container.querySelector('[data-testid="pipeline-id"]') as HTMLInputElement
+    pipelineIdInput.value = 'pipe_if'
+    pipelineIdInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="refresh-observation"]') as HTMLButtonElement).click()
+    await flushUi()
+    ;(container.querySelector('[data-testid="replay-dead-letter-dl_if_1"]') as HTMLButtonElement).click()
+    await flushUi()
+    const confirmBtn = container.querySelector('[data-testid="confirm-replay-dead-letter-dl_if_1"]') as HTMLButtonElement
+    expect(confirmBtn).not.toBeNull()
+    confirmBtn.click()
+    await flushUi()
+
+    // Request held open: the confirm button is disabled and shows the busy label,
+    // so a second click cannot fire another POST.
+    expect(confirmBtn.disabled).toBe(true)
+    expect(confirmBtn.textContent).toContain('Replay 中…')
+    expect(replayCalls).toBe(1)
+
+    // Resolve and let the flow complete.
+    resolveReplay(new Response(
+      JSON.stringify({ ok: true, data: { deadLetter: { id: 'dl_if_1', status: 'replayed' }, replay: { run: { id: 'run_if2' }, metrics: { rowsFailed: 0 } } } }),
+      { status: 200, headers: { 'Content-Type': 'application/json' } },
+    ))
+    await flushUi(15)
+    expect(replayCalls).toBe(1)
+    expect(container.textContent).toContain('Replay 成功')
   })
 })

--- a/apps/web/tests/integrationWorkbench.spec.ts
+++ b/apps/web/tests/integrationWorkbench.spec.ts
@@ -14,7 +14,9 @@ import {
   upsertWorkbenchExternalSystem,
   upsertIntegrationPipeline,
   isIntegrationScopedProjectId,
+  isDeadLetterReplayable,
   normalizeIntegrationProjectId,
+  replayIntegrationDeadLetter,
 } from '../src/services/integration/workbench'
 
 const apiFetchMock = vi.fn()
@@ -302,5 +304,68 @@ describe('integration workbench service', () => {
       status: 'open',
       limit: 5,
     })).resolves.toHaveLength(1)
+  })
+})
+
+describe('integration dead-letter replay service', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    if (typeof localStorage?.clear === 'function') localStorage.clear()
+  })
+
+  it.each([
+    ['open', true],
+    ['replayed', false],
+    ['discarded', false],
+    ['unknown', false],
+  ])('isDeadLetterReplayable(status=%s) -> %s', (status, expected) => {
+    expect(isDeadLetterReplayable({ status })).toBe(expected)
+  })
+
+  it('replays a dead letter via the existing :id/replay route and returns the envelope data', async () => {
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/dead-letters/dl%201/replay') {
+        expect(init?.method).toBe('POST')
+        expect(JSON.parse(String(init?.body))).toEqual({
+          tenantId: 'default',
+          workspaceId: null,
+          mode: 'manual',
+        })
+        return jsonResponse({
+          deadLetter: { id: 'dl 1', status: 'replayed' },
+          replay: { run: { id: 'run_9' }, metrics: { rowsWritten: 1, rowsFailed: 0 } },
+        })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    await expect(replayIntegrationDeadLetter('dl 1', {
+      tenantId: 'default',
+      workspaceId: null,
+      mode: 'manual',
+    })).resolves.toMatchObject({
+      deadLetter: { id: 'dl 1', status: 'replayed' },
+      replay: { metrics: { rowsFailed: 0 } },
+    })
+  })
+
+  it('surfaces a backend replay error (e.g. 501 REPLAY_NOT_IMPLEMENTED)', async () => {
+    apiFetchMock.mockImplementation(async () => new Response(
+      JSON.stringify({ ok: false, error: { code: 'REPLAY_NOT_IMPLEMENTED', message: 'Dead-letter replay is not implemented' } }),
+      { status: 501, headers: { 'Content-Type': 'application/json' } },
+    ))
+    await expect(replayIntegrationDeadLetter('dl 1', { tenantId: 'default' }))
+      .rejects.toThrow('Dead-letter replay is not implemented')
+  })
+
+  it('surfaces a 403 when the caller lacks write permission on the replay route', async () => {
+    // Replay is a write — the backend route enforces requireAccess(req, 'write').
+    // A forbidden caller must see the error, not a silent success.
+    apiFetchMock.mockImplementation(async () => new Response(
+      JSON.stringify({ ok: false, error: { code: 'FORBIDDEN', message: 'write permission required' } }),
+      { status: 403, headers: { 'Content-Type': 'application/json' } },
+    ))
+    await expect(replayIntegrationDeadLetter('dl 1', { tenantId: 'default' }))
+      .rejects.toThrow('write permission required')
   })
 })

--- a/docs/development/data-factory-df-n1_5-deadletter-replay-design-20260526.md
+++ b/docs/development/data-factory-df-n1_5-deadletter-replay-design-20260526.md
@@ -1,0 +1,68 @@
+# Data Factory — DF-N1.5 Dead-Letter Replay Design - 2026-05-26
+
+## Status / purpose
+
+**Front-end-only slice adding a single, manual dead-letter replay action** to the Data Factory 运行监控 panel, surfacing the **already-implemented** `POST /api/integration/dead-letters/:id/replay` route. Split out of DF-N1 (read-only monitoring, **merged as #1848**) per review, because replay **re-runs the pipeline — a real target/ERP write** — and its safety semantics deserve to be the *primary* review subject rather than a footnote in a "monitoring" slice.
+
+**This is NOT DF-N3.** It adds one manual, confirm-gated, one-record re-enqueue. It adds **no** bulk retry, stop rules, run policy, back-pressure, or auto-re-enqueue — all of which remain DF-N3 (frozen).
+
+## Relationship to the family
+
+- Builds directly on **#1848** (DF-N1 read-only 运行监控, merged) — reuses its run/dead-letter surfaces.
+- **#1844** Stage 5 lists *"retry of selected failed rows"*; this delivers the **single-manual** grain of that, deferring "selected rows"/bulk to DF-N3.
+- **#1839** DF-N3 ("Retry and back pressure") owns the orchestration; this slice deliberately stays on the DF-N1 side (surface an existing capability, no new runtime).
+- Backend route + `runner.replayDeadLetter` already exist and are tested in `plugins/plugin-integration-core` — **no backend change here.**
+
+## What this slice adds (front-end only)
+
+- `apps/web/src/services/integration/workbench.ts`: `replayIntegrationDeadLetter()` (wraps the existing `POST …/:id/replay`), `isDeadLetterReplayable()` (`status === 'open'`), and the `IntegrationDeadLetterReplayPayload` / `IntegrationDeadLetterReplayResult` types.
+- `apps/web/src/views/IntegrationWorkbenchView.vue`: a **retryability badge** + a **two-step confirm** replay control (`准备 Replay → 确认 Replay（会真实写入）`, `取消`) on each **open** dead-letter; on completion it refreshes the monitoring panel.
+
+## PRIMARY REVIEW SUBJECTS (threat model)
+
+Per maintainer direction, these four are the focus of this PR. Each row = the risk, the defense, where it is enforced, and the locking test.
+
+### 1. Idempotency
+- **Risk:** replaying re-sends the same source record to the target → a duplicate business object.
+- **Defense:** replay re-runs the pipeline with the **stored source payload**, so it carries the same `idempotencyKeyFields` → the pipeline/target dedupes on the idempotency key. This is a **backend invariant** (the pipeline runner + adapter), relied upon here — not re-implemented in the UI.
+- **Enforced:** backend (pipeline idempotency key). **UI role:** none beyond not mangling the payload (it sends only `{tenantId, workspaceId, mode}` + the `:id`; the payload is server-held).
+- **Note for reviewer:** the strength of this guarantee == the target adapter's idempotency honoring. For K3 this is the idempotency-key contract; confirm it holds for any future target before enabling replay there.
+
+### 2. Duplicate-write risk (UI-side defenses, layered)
+- **Risk:** a second live write from accidental / repeated / stale triggering.
+- **Defenses:**
+  - **Only-open** — `isDeadLetterReplayable` renders the action only for `status === 'open'`; the backend independently throws if status ≠ open (`pipeline-runner.cjs:699`). A letter marked `replayed` after a successful write **cannot be replayed again**.
+  - **Two-step confirm** — see §4.
+  - **In-flight lock** — `replayingDeadLetterId` disables the confirm button while the request is outstanding (no double-submit).
+  - **Success verdict = `rowsFailed` only** — a write that succeeded but whose `markReplayed` bookkeeping failed (letter stays `open` + `warning`, `pipeline-runner.cjs:732-756`) reads as **success**, so the user is **not** prompted to retry a write that already landed.
+- **Enforced:** UI (only-open render, confirm, in-flight lock, verdict) + backend (open-only throw, idempotency).
+- **Tests:** `does not offer replay for a non-open … dead-letter`; the warning-case verdict test; the two-step-confirm test.
+
+### 3. Permission
+- **Risk:** a read-only user triggering a write.
+- **Defense:** the route enforces `requireAccess(req, 'write')` server-side → `403` for unauthorized callers. The UI surfaces the error via the status banner; the letter remains visible because the panel is **refresh-driven (server truth)** with no optimistic mutation.
+- **Enforced:** backend (authoritative). UI surfaces, does not gate (a client-side hide would be advisory only and could drift from the real grant).
+- **Tests:** service `surfaces a 403 when the caller lacks write permission`; component `surfaces a 403 permission error on replay without removing the dead-letter`.
+
+### 4. Two-step confirm
+- **Risk:** a single stray click firing a live write.
+- **Defense:** `准备 Replay` only arms the confirm; the **first click issues no network call**; only `确认 Replay（会真实写入）` POSTs. Mirrors the existing Save-only `allowSaveOnlyRun` posture.
+- **Enforced:** UI.
+- **Test:** the two-step-confirm test asserts the prepare click issues **zero** `apiFetch` to `/replay`.
+
+## Boundaries / non-goals
+
+- **Front-end only.** Touches `apps/web/**` + these docs. No backend / migration / connector / OpenAPI / RBAC change (the route already exists). K3 Stage-1 lock respected.
+- **Single manual** replay only — **no** bulk "retry selected rows", stop rules, run policy, back-pressure, auto-re-enqueue (DF-N3, frozen).
+- No change to DF-N1's read-only surfaces; this strictly *adds* the action.
+
+## Test plan
+
+- **Service** (`integrationWorkbench.spec.ts`): replay route/body/encoding; `isDeadLetterReplayable` truth table; **501** and **403** error surfacing.
+- **Component** (`IntegrationWorkbenchView.spec.ts`): two-step confirm (prepare ⇒ no POST); confirm POSTs scoped body ⇒ observation reload; markReplayed-warning ⇒ success (no false retry); non-open ⇒ no replay button; **403 ⇒ error surfaced, letter retained**.
+
+## See also
+
+- #1848 (DF-N1 read-only monitoring, merged) · #1839 (DF-N phasing; DF-N3 = bulk retry/back-pressure) · #1844 (IA Stage 5) · #1838 (direction/gating).
+- Backend: `plugins/plugin-integration-core/lib/pipeline-runner.cjs` (`replayDeadLetter`, lines ~688–757) · `lib/http-routes.cjs` (`deadLettersReplay`).
+- Verification: `data-factory-df-n1_5-deadletter-replay-verification-20260526.md`.

--- a/docs/development/data-factory-df-n1_5-deadletter-replay-verification-20260526.md
+++ b/docs/development/data-factory-df-n1_5-deadletter-replay-verification-20260526.md
@@ -1,0 +1,42 @@
+# Data Factory — DF-N1.5 Dead-Letter Replay Verification - 2026-05-26
+
+Verification for `data-factory-df-n1_5-deadletter-replay-design-20260526.md`. Branch `frontend/data-factory-df-n1_5-deadletter-replay-impl-20260526` (off `origin/main` @ `be87b4d96`, i.e. on top of merged DF-N1 #1848). **Front-end only; not merged — held for review** (the four threat-model subjects below are the intended review focus).
+
+## What was implemented
+
+| File | Change |
+|---|---|
+| `apps/web/src/services/integration/workbench.ts` | `replayIntegrationDeadLetter()` over the existing `POST /api/integration/dead-letters/:id/replay`; `isDeadLetterReplayable()` (`status==='open'`); `IntegrationDeadLetterReplay{Payload,Result}` types. |
+| `apps/web/src/views/IntegrationWorkbenchView.vue` | Per open dead-letter: retryability badge + **two-step confirm** replay (`准备 → 确认（会真实写入）`, `取消`), in-flight lock, success verdict = `rowsFailed` only; refresh on completion. |
+| `apps/web/tests/integrationWorkbench.spec.ts` | Replay route/body/encoding; `isDeadLetterReplayable` truth table; **501** + **403** surfacing. |
+| `apps/web/tests/IntegrationWorkbenchView.spec.ts` | Two-step confirm (prepare⇒no POST); confirm⇒POST⇒reload; markReplayed-warning⇒success; non-open⇒no button; 403⇒error surfaced + letter retained; in-flight⇒confirm disabled + busy label (no double-submit window). |
+| `docs/development/data-factory-df-n1_5-deadletter-replay-{design,verification}-20260526.md` | This design + verification. |
+
+## Threat-model subjects → evidence
+
+| Subject | Where enforced | Locking test |
+|---|---|---|
+| **Idempotency** | backend (pipeline idempotency key on replay re-run) | n/a in FE — documented invariant; UI sends only id+scope, not payload |
+| **Duplicate-write** | UI (only-open render, two-step confirm, in-flight lock, `rowsFailed` verdict) + backend (open-only throw, idempotency) | `does not offer replay for a non-open … dead-letter`; markReplayed-warning⇒success; two-step confirm; `locks the confirm button while a replay is in flight` |
+| **Permission** | backend `requireAccess(req,'write')` ⇒ 403 | service `surfaces a 403 …`; component `surfaces a 403 … without removing the dead-letter` |
+| **Two-step confirm** | UI | prepare click issues **zero** `/replay` POST; only confirm POSTs |
+
+## Commands run (from the worktree)
+
+```
+pnpm --filter @metasheet/web exec vitest run tests/integrationWorkbench.spec.ts tests/IntegrationWorkbenchView.spec.ts
+  → Test Files 2 passed (2) · Tests 40 passed (40)   (service 28, component 12)
+pnpm --filter @metasheet/web type-check          → exit 0 (vue-tsc -b, no errors)
+pnpm --filter @metasheet/web exec eslint <4 changed files>
+  → 0 errors, warnings = pre-existing `router-link` test-stub pattern only
+```
+
+## Lock-profile confirmation
+
+- **Pure front-end.** Diff is `apps/web/**` (view + service + specs) + these two docs only. **No** change to `plugins/plugin-integration-core/**`, `packages/core-backend/**`, migrations, OpenAPI, RBAC, or any connector — the replay **route already exists**; this only surfaces it. K3 Stage-1 lock respected. (The `node_modules/.bin` churn from the worktree `pnpm install` is **not** staged.)
+- **Single manual** replay only; no bulk/stop-rules/back-pressure/auto-re-enqueue (DF-N3 stays frozen).
+- Construction note: the replay delta was reconstructed as `diff(merged-main, the preserved df-n1_5 commit d39c6f934)` restricted to source+test files (verified to be purely the replay additions), then re-applied on top of `be87b4d96`; DF-N1.5 docs are written fresh (not carried from the old DF-N1 draft).
+
+## Not done (still separate gated opt-ins)
+
+DF-N2 provenance events · DF-N3 bulk retry / stop rules / run policy / back-pressure · DF-N4 connector catalog · cross-pipeline monitoring · K3 Submit/Audit/BOM/multi-record/read-unlock.


### PR DESCRIPTION
## DF-N1.5 — Dead-letter replay (single manual, front-end only)

Adds a **single, manual, confirm-gated** dead-letter replay to the 运行监控 panel, surfacing the **existing** `POST /api/integration/dead-letters/:id/replay` route. Split out of DF-N1 (#1848, read-only) per review — replay **re-runs the pipeline = a real target/ERP write**, so its safety semantics are the *primary* review subject here.

> **NOT DF-N3.** One manual one-record re-enqueue. No bulk "retry selected rows", stop rules, run policy, back-pressure, or auto-re-enqueue.

### 🔑 Primary review subjects (threat model)

| Subject | Where enforced | Locking test(s) |
|---|---|---|
| **Idempotency** | backend — pipeline idempotency-key dedupe on the replay re-run (UI sends only `{id, scope, mode}`, never the payload) | documented invariant (FE can't unit-test backend dedupe) |
| **Duplicate-write** | UI: only-open render · two-step confirm · in-flight lock · `rowsFailed`-only verdict — *+* backend: open-only throw, idempotency | non-open⇒no button · markReplayed-warning⇒success · prepare⇒no POST · in-flight⇒confirm disabled |
| **Permission** | backend `requireAccess(req,'write')` ⇒ 403 | service 403 surfacing · component 403⇒error shown, letter retained |
| **Two-step confirm** | UI (`准备 → 确认（会真实写入）`) | prepare click issues **zero** `/replay` POST |

Note on the markReplayed-warning path (`pipeline-runner.cjs:732-756`): a write that **succeeded** but whose bookkeeping failed returns the letter still `open` + a warning — the UI reads this as **success**, not a retry prompt, to avoid inviting a duplicate write.

### Lock profile
**Front-end only** — `apps/web/**` + 2 docs. No backend / migration / connector / OpenAPI / RBAC change (route already exists). K3 Stage-1 lock respected.

### Verification
- **40/40** integration-workbench tests (service 28, component 12); `type-check` clean; `0` lint errors.
- Construction: replay delta reconstructed as `diff(merged-main, preserved df-n1_5 commit)` for source+tests (verified purely additive), re-applied on `be87b4d96`; DF-N1.5 docs written fresh.

Docs: `docs/development/data-factory-df-n1_5-deadletter-replay-{design,verification}-20260526.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)