### PR TITLE
feat(attendance): read-only rule_set preview-divergence diagnostic on scheduling workbench

### DIFF
--- a/docs/development/attendance-advanced-scheduling-rule-set-diagnostic-verification-20260526.md
+++ b/docs/development/attendance-advanced-scheduling-rule-set-diagnostic-verification-20260526.md
@@ -25,7 +25,7 @@ by group than the actual per-user effective-calendar resolves. The diagnostic su
 ## Data signal (read-only)
 
 - `attendance_schedule_groups.attendance_group_id` → `attendance_groups.rule_set_id` (both columns already exist; no migration).
-- Route adds: `SELECT id FROM attendance_groups WHERE org_id = $1 AND rule_set_id IS NOT NULL` (query form A — simplest; `attendance_groups` is small and the builder intersects against the active schedule groups anyway). Org-scoped, read-only.
+- Route adds a **schema-safe** read-only lookup, `loadAttendanceRuleSetAttendanceGroupIds(db, orgId)` → `SELECT id FROM attendance_groups WHERE org_id = $1 AND rule_set_id IS NOT NULL` (query form A — simplest; `attendance_groups` is small and the builder intersects against the active schedule groups anyway). Org-scoped, read-only. **Because this is an optional visibility signal, the helper catches `isDatabaseSchemaError` and returns `[]`** (diagnostic absent) on an older schema lacking `attendance_groups.rule_set_id` or the table — so it never fails the whole workbench with `503 DB_NOT_READY`. Non-schema errors still propagate.
 - Builder (`buildAttendanceAdvancedSchedulingWorkbench`): new optional input `ruleSetAttendanceGroupIds` (defaults to `[]` → backward compatible). `scheduleGroupsWithRuleSetOverride` (`:7626`) = active schedule groups whose `attendanceGroupId` is in that set. If any, emit the diagnostic (`:7677`), appended **last** in the diagnostics array (preserves the existing order assertion).
 
 ## The diagnostic
@@ -41,12 +41,13 @@ No change. `AttendanceView.vue` (`:4432`) renders diagnostics in a generic `v-fo
 the new diagnostic appears automatically with its server message. Verified by reading the
 template; no FE diff and (by requirement) no fix affordance.
 
-## Tests (workbench test file, 8/8; 4 new)
+## Tests (workbench test file, 9/9; 5 new)
 
 - **Positive:** schedule group whose `attendanceGroupId ∈ ruleSetAttendanceGroupIds` → diagnostic present, `severity:info`, `count:1`, correct `scheduleGroupIds`, message contains "by design".
 - **Negative:** linked attendance group not in the rule_set set → diagnostic absent (no false positive).
 - **Backward compat:** no `ruleSetAttendanceGroupIds` input, and group without `attendanceGroupId` → diagnostic absent; the existing diagnostics-order assertion still passes.
 - **Source guard:** the new query matches the read-only `SELECT … rule_set_id IS NOT NULL`; the workbench GET handler **region** contains no `INSERT INTO`/`UPDATE`/`DELETE FROM` (scoped to the handler — the file legitimately writes `attendance_groups` elsewhere via group sync).
+- **Schema-safe degradation:** `loadAttendanceRuleSetAttendanceGroupIds` returns `[]` on an `undefined_column`/`undefined_table` error (so the workbench keeps working without the diagnostic on older schemas) and **rethrows** non-schema errors (e.g. connection failures). 9/9 in the workbench test file.
 
 ## Verification run
 

--- a/docs/development/attendance-advanced-scheduling-rule-set-diagnostic-verification-20260526.md
+++ b/docs/development/attendance-advanced-scheduling-rule-set-diagnostic-verification-20260526.md
@@ -1,0 +1,60 @@
+# Advanced-Scheduling Rule-Set Preview-Divergence Diagnostic — Design + Verification — 2026-05-26
+
+Read-only enhancement to the existing `GET /api/attendance/advanced-scheduling/workbench`:
+a 6th diagnostic that surfaces a known **preview-semantics divergence** — a `groupId`-mode
+preview applies the linked attendance group's `rule_set`, while the per-user
+`effective-calendar` calc-chain intentionally does not. Informational only; it changes no
+calculation. Verified against `plugins/plugin-attendance/index.cjs` at the PR head.
+
+## Scope / non-scope
+
+- **In:** one `info` diagnostic (`schedule_group_rule_set_preview_divergence`) + one read-only `SELECT` in the workbench route.
+- **Out (unchanged):** no new route (the existing GET is enhanced), no UI edit (frontend renders diagnostics generically), no migration, no writer, no POST/PUT/PATCH/DELETE. **The auto-absence / working-hours / comprehensive-hours / effective-calendar calc-chains are untouched.**
+- **This PR takes no position** on whether the userId calc-chain *should* adopt the group rule_set. That is a separate product/compliance decision; this slice only makes the existing divergence visible.
+
+## The divergence (evidence)
+
+In the scheduling preview resolver:
+
+- **`mode === 'groupId'`** (`index.cjs:11452`): when the resolved attendance group has a `ruleSetId`, it loads the rule_set config and applies `groupRule = buildAttendanceRuleWithRuleSetOverride(defaultRule, ruleSetConfig)` (`:11462`) — the **rule_set override is applied**.
+- **`mode === 'userId'`** (`index.cjs:11445`): loads the user's scope context + assignments + overlays; it does **not** apply any group rule_set override — the per-user effective-calendar resolution follows existing boundaries.
+
+So a schedule group whose linked attendance group carries a rule_set will preview differently
+by group than the actual per-user effective-calendar resolves. The diagnostic surfaces that.
+
+## Data signal (read-only)
+
+- `attendance_schedule_groups.attendance_group_id` → `attendance_groups.rule_set_id` (both columns already exist; no migration).
+- Route adds: `SELECT id FROM attendance_groups WHERE org_id = $1 AND rule_set_id IS NOT NULL` (query form A — simplest; `attendance_groups` is small and the builder intersects against the active schedule groups anyway). Org-scoped, read-only.
+- Builder (`buildAttendanceAdvancedSchedulingWorkbench`): new optional input `ruleSetAttendanceGroupIds` (defaults to `[]` → backward compatible). `scheduleGroupsWithRuleSetOverride` (`:7626`) = active schedule groups whose `attendanceGroupId` is in that set. If any, emit the diagnostic (`:7677`), appended **last** in the diagnostics array (preserves the existing order assertion).
+
+## The diagnostic
+
+- `code: schedule_group_rule_set_preview_divergence`, **`severity: info`** (it fires on every well-configured org that uses rule_sets — `warning` would be permanent noise; matches `user_mixed_assignment_kinds` which is `info` for the same by-design reason).
+- `message`: "Schedule groups link to an attendance group with a rule_set override; group-mode preview applies the rule_set, while per-user effective-calendar resolution still follows existing boundaries (by design — calc chain unchanged)."
+- `count` + `scheduleGroupIds` of the affected active schedule groups.
+
+## Frontend
+
+No change. `AttendanceView.vue` (`:4432`) renders diagnostics in a generic `v-for` loop —
+`{{ diagnostic.message }} · {{ diagnostic.count }}`, keyed by `code`, with no fix button — so
+the new diagnostic appears automatically with its server message. Verified by reading the
+template; no FE diff and (by requirement) no fix affordance.
+
+## Tests (workbench test file, 8/8; 4 new)
+
+- **Positive:** schedule group whose `attendanceGroupId ∈ ruleSetAttendanceGroupIds` → diagnostic present, `severity:info`, `count:1`, correct `scheduleGroupIds`, message contains "by design".
+- **Negative:** linked attendance group not in the rule_set set → diagnostic absent (no false positive).
+- **Backward compat:** no `ruleSetAttendanceGroupIds` input, and group without `attendanceGroupId` → diagnostic absent; the existing diagnostics-order assertion still passes.
+- **Source guard:** the new query matches the read-only `SELECT … rule_set_id IS NOT NULL`; the workbench GET handler **region** contains no `INSERT INTO`/`UPDATE`/`DELETE FROM` (scoped to the handler — the file legitimately writes `attendance_groups` elsewhere via group sync).
+
+## Verification run
+
+- `attendance-advanced-scheduling-workbench.test.ts`: 8/8 (existing 4 unchanged + 4 new).
+- Full core-backend unit suite: 2320/2320.
+- `tsc` (build:cache): clean.
+
+## Cross-references
+
+- `docs/operations/attendance-advanced-scheduling-workbench-runbook.md` — the workbench operator runbook (this adds one diagnostic to it).
+- `[[attendance-multitable-report-boundary]]`, `[[skip-when-unreachable-blind-spot]]`.

--- a/docs/development/attendance-advanced-scheduling-rule-set-diagnostic-verification-20260526.md
+++ b/docs/development/attendance-advanced-scheduling-rule-set-diagnostic-verification-20260526.md
@@ -51,8 +51,8 @@ template; no FE diff and (by requirement) no fix affordance.
 
 ## Verification run
 
-- `attendance-advanced-scheduling-workbench.test.ts`: 8/8 (existing 4 unchanged + 4 new).
-- Full core-backend unit suite: 2320/2320.
+- `attendance-advanced-scheduling-workbench.test.ts`: 9/9 (existing 4 unchanged + 5 new).
+- Full core-backend unit suite: 2321/2321.
 - `tsc` (build:cache): clean.
 
 ## Cross-references

--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-workbench.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-workbench.test.ts
@@ -249,7 +249,7 @@ describe('attendance advanced scheduling read-only workbench', () => {
 
     it('source guard: the new query is a SELECT and the workbench route region is read-only', () => {
       expect(pluginSource).toMatch(/SELECT id FROM attendance_groups WHERE org_id = \$1 AND rule_set_id IS NOT NULL/)
-      expect(pluginSource).toContain('ruleSetAttendanceGroupRows')
+      expect(pluginSource).toContain('loadAttendanceRuleSetAttendanceGroupIds(db, orgId)')
       // Scope the write-guard to the workbench GET handler region only (the file legitimately
       // writes attendance_groups elsewhere via group sync). The handler must be SELECT-only.
       const start = pluginSource.indexOf("'/api/attendance/advanced-scheduling/workbench'")
@@ -257,6 +257,18 @@ describe('attendance advanced scheduling read-only workbench', () => {
       const nextRoute = pluginSource.indexOf('context.api.http.addRoute(', start + 1)
       const handler = pluginSource.slice(start, nextRoute > start ? nextRoute : start + 12000)
       expect(handler).not.toMatch(/\b(INSERT\s+INTO|UPDATE\s+\w|DELETE\s+FROM)\b/i)
+    })
+
+    it('schema-safe: rule_set lookup degrades to [] on a missing column/table (no 503), rethrows otherwise', async () => {
+      // Older schema lacking attendance_groups.rule_set_id → undefined_column (42703) → [].
+      const schemaErrDb = { query: async () => { const e: any = new Error('column "rule_set_id" does not exist'); e.code = '42703'; throw e } }
+      await expect(helpers.loadAttendanceRuleSetAttendanceGroupIds(schemaErrDb, 'org-1')).resolves.toEqual([])
+      // Non-schema error must propagate (not be swallowed).
+      const connErrDb = { query: async () => { const e: any = new Error('connection terminated'); e.code = '08006'; throw e } }
+      await expect(helpers.loadAttendanceRuleSetAttendanceGroupIds(connErrDb, 'org-1')).rejects.toThrow('connection terminated')
+      // Happy path returns the ids.
+      const okDb = { query: async () => [{ id: 'ag-1' }, { id: 'ag-2' }] }
+      await expect(helpers.loadAttendanceRuleSetAttendanceGroupIds(okDb, 'org-1')).resolves.toEqual(['ag-1', 'ag-2'])
     })
   })
 })

--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-workbench.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-workbench.test.ts
@@ -200,4 +200,63 @@ describe('attendance advanced scheduling read-only workbench', () => {
     expect(pluginSource).toContain('assignmentAggregateRows')
     expect(pluginSource).toContain('scheduleGroupAssignmentAggregateRows')
   })
+
+  describe('rule_set preview-divergence diagnostic (read-only)', () => {
+    const baseInput = (overrides: Record<string, unknown> = {}) => ({
+      from: '2026-06-01',
+      to: '2026-06-30',
+      scheduleGroups: [
+        { id: 'sg-1', name: 'Group 1', source: 'manual', isActive: true, attendanceGroupId: 'ag-rule' },
+        { id: 'sg-2', name: 'Group 2', source: 'manual', isActive: true, attendanceGroupId: 'ag-plain' },
+      ],
+      scheduleGroupMembers: [
+        { id: 'm-1', scheduleGroupId: 'sg-1', userId: 'u-1', effectiveFrom: '2026-06-01', effectiveTo: null },
+        { id: 'm-2', scheduleGroupId: 'sg-2', userId: 'u-2', effectiveFrom: '2026-06-01', effectiveTo: null },
+      ],
+      ...overrides,
+    })
+
+    it('positive: flags schedule groups whose attendance group carries a rule_set override', () => {
+      const wb = helpers.buildAttendanceAdvancedSchedulingWorkbench(
+        baseInput({ ruleSetAttendanceGroupIds: ['ag-rule'] }),
+      )
+      const diag = wb.diagnostics.find((d: any) => d.code === 'schedule_group_rule_set_preview_divergence')
+      expect(diag).toMatchObject({ severity: 'info', count: 1, scheduleGroupIds: ['sg-1'] })
+      expect(diag.message).toContain('by design')
+    })
+
+    it('negative: no diagnostic when the linked attendance group has no rule_set', () => {
+      // sg-1/sg-2 both link to attendance groups, but neither id is in the rule_set set.
+      const wb = helpers.buildAttendanceAdvancedSchedulingWorkbench(
+        baseInput({ ruleSetAttendanceGroupIds: ['ag-unrelated'] }),
+      )
+      expect(wb.diagnostics.find((d: any) => d.code === 'schedule_group_rule_set_preview_divergence')).toBeUndefined()
+    })
+
+    it('absent input / no attendanceGroupId: diagnostic does not fire (backward compatible)', () => {
+      // No ruleSetAttendanceGroupIds passed at all.
+      const wbNoInput = helpers.buildAttendanceAdvancedSchedulingWorkbench(baseInput())
+      expect(wbNoInput.diagnostics.find((d: any) => d.code === 'schedule_group_rule_set_preview_divergence')).toBeUndefined()
+      // Group without attendanceGroupId is skipped even if some other id is in the set.
+      const wbNoLink = helpers.buildAttendanceAdvancedSchedulingWorkbench({
+        from: '2026-06-01',
+        to: '2026-06-30',
+        scheduleGroups: [{ id: 'sg-x', name: 'No link', source: 'manual', isActive: true }],
+        ruleSetAttendanceGroupIds: ['ag-rule'],
+      })
+      expect(wbNoLink.diagnostics.find((d: any) => d.code === 'schedule_group_rule_set_preview_divergence')).toBeUndefined()
+    })
+
+    it('source guard: the new query is a SELECT and the workbench route region is read-only', () => {
+      expect(pluginSource).toMatch(/SELECT id FROM attendance_groups WHERE org_id = \$1 AND rule_set_id IS NOT NULL/)
+      expect(pluginSource).toContain('ruleSetAttendanceGroupRows')
+      // Scope the write-guard to the workbench GET handler region only (the file legitimately
+      // writes attendance_groups elsewhere via group sync). The handler must be SELECT-only.
+      const start = pluginSource.indexOf("'/api/attendance/advanced-scheduling/workbench'")
+      expect(start).toBeGreaterThan(-1)
+      const nextRoute = pluginSource.indexOf('context.api.http.addRoute(', start + 1)
+      const handler = pluginSource.slice(start, nextRoute > start ? nextRoute : start + 12000)
+      expect(handler).not.toMatch(/\b(INSERT\s+INTO|UPDATE\s+\w|DELETE\s+FROM)\b/i)
+    })
+  })
 })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -7842,6 +7842,23 @@ async function loadRuleSetConfigById(db, orgId, ruleSetId) {
   return normalizeMetadata(rows[0].config)
 }
 
+// Read-only: attendance-group ids carrying a rule_set override, for the workbench
+// preview-divergence diagnostic. This is an OPTIONAL visibility signal — on an older schema
+// without attendance_groups.rule_set_id (or the table), degrade to [] so the diagnostic is
+// simply absent rather than failing the whole workbench with 503. Non-schema errors propagate.
+async function loadAttendanceRuleSetAttendanceGroupIds(db, orgId) {
+  try {
+    const rows = await db.query(
+      'SELECT id FROM attendance_groups WHERE org_id = $1 AND rule_set_id IS NOT NULL',
+      [orgId]
+    )
+    return rows.map(row => row.id).filter(Boolean)
+  } catch (error) {
+    if (isDatabaseSchemaError(error)) return []
+    throw error
+  }
+}
+
 async function loadAttendanceGroupRuleSetMap(db, orgId) {
   const rows = await db.query(
     'SELECT name, code, rule_set_id FROM attendance_groups WHERE org_id = $1 AND rule_set_id IS NOT NULL',
@@ -14180,6 +14197,7 @@ module.exports = {
     buildAttendanceScheduleGroupMemberLockKey,
     acquireAttendanceScheduleGroupMemberLock,
     buildAttendanceAdvancedSchedulingWorkbench,
+    loadAttendanceRuleSetAttendanceGroupIds,
     normalizeAttendanceSchedulerScopeBody,
     normalizeAttendanceSchedulerScopeInput,
     mapAttendanceSchedulerScopeRow,
@@ -26036,7 +26054,7 @@ module.exports = {
             rotationAssignmentRows,
             assignmentAggregateRows,
             scheduleGroupAssignmentAggregateRows,
-            ruleSetAttendanceGroupRows,
+            ruleSetAttendanceGroupIds,
           ] = await Promise.all([
             db.query(
               `SELECT *
@@ -26201,12 +26219,9 @@ module.exports = {
                GROUP BY m.schedule_group_id`,
               [orgId, rangeStart, rangeEnd]
             ),
-            db.query(
-              // Read-only: attendance groups carrying a rule_set override (surfaced as a
-              // preview-semantics diagnostic only; no calc-chain effect).
-              `SELECT id FROM attendance_groups WHERE org_id = $1 AND rule_set_id IS NOT NULL`,
-              [orgId]
-            ),
+            // Optional visibility signal — schema-safe: degrades to [] (diagnostic absent)
+            // if attendance_groups.rule_set_id is missing, instead of failing the workbench.
+            loadAttendanceRuleSetAttendanceGroupIds(db, orgId),
           ])
 
           const shiftAssignmentsTruncated = shiftAssignmentRows.length > ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT
@@ -26246,7 +26261,7 @@ module.exports = {
             assignmentLimit: ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT,
             shiftAssignmentsTruncated,
             rotationAssignmentsTruncated,
-            ruleSetAttendanceGroupIds: ruleSetAttendanceGroupRows.map(row => row.id),
+            ruleSetAttendanceGroupIds,
           })
           res.json({ ok: true, data })
         } catch (error) {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -7545,6 +7545,13 @@ function buildAttendanceAdvancedSchedulingWorkbench(input = {}) {
       })
       .filter(Boolean)
   )
+  // Attendance-group ids that carry a rule_set override. Used only to surface a read-only
+  // preview-semantics signal; does not affect any calculation.
+  const ruleSetAttendanceGroupIds = new Set(
+    (Array.isArray(input.ruleSetAttendanceGroupIds) ? input.ruleSetAttendanceGroupIds : [])
+      .map(id => String(id || '').trim())
+      .filter(Boolean)
+  )
 
   const membersByGroupId = new Map()
   const groupIdsByUserId = new Map()
@@ -7612,6 +7619,12 @@ function buildAttendanceAdvancedSchedulingWorkbench(input = {}) {
     .filter(scope => Array.isArray(scope?.scope?.scheduleGroupIds) && scope.scope.scheduleGroupIds.some(groupId => !scheduleGroupIds.has(groupId)))
   const schedulerScopeUnknownGroupIds = schedulerScopesWithUnknownGroups
     .flatMap(scope => normalizeStringArray(scope?.scope?.scheduleGroupIds).filter(groupId => !scheduleGroupIds.has(groupId)))
+  // Active schedule groups whose linked attendance group carries a rule_set override. For
+  // these, a groupId-mode preview applies the rule_set (index.cjs groupId branch), while the
+  // per-user effective-calendar calc-chain (userId branch) intentionally does not — a
+  // by-design boundary surfaced here for visibility only.
+  const scheduleGroupsWithRuleSetOverride = groupItems
+    .filter(group => group.isActive !== false && group.attendanceGroupId && ruleSetAttendanceGroupIds.has(group.attendanceGroupId))
 
   const diagnostics = [
     groupsWithoutMembers.length
@@ -7657,6 +7670,15 @@ function buildAttendanceAdvancedSchedulingWorkbench(input = {}) {
         message: 'Scheduler scopes reference schedule groups that are not active in this workbench snapshot.',
         count: schedulerScopesWithUnknownGroups.length,
         scheduleGroupIds: schedulerScopeUnknownGroupIds,
+      })
+      : null,
+    scheduleGroupsWithRuleSetOverride.length
+      ? buildAttendanceAdvancedSchedulingDiagnostic({
+        code: 'schedule_group_rule_set_preview_divergence',
+        severity: 'info',
+        message: 'Schedule groups link to an attendance group with a rule_set override; group-mode preview applies the rule_set, while per-user effective-calendar resolution still follows existing boundaries (by design — calc chain unchanged).',
+        count: scheduleGroupsWithRuleSetOverride.length,
+        scheduleGroupIds: scheduleGroupsWithRuleSetOverride.map(group => group.id),
       })
       : null,
   ].filter(Boolean)
@@ -26014,6 +26036,7 @@ module.exports = {
             rotationAssignmentRows,
             assignmentAggregateRows,
             scheduleGroupAssignmentAggregateRows,
+            ruleSetAttendanceGroupRows,
           ] = await Promise.all([
             db.query(
               `SELECT *
@@ -26178,6 +26201,12 @@ module.exports = {
                GROUP BY m.schedule_group_id`,
               [orgId, rangeStart, rangeEnd]
             ),
+            db.query(
+              // Read-only: attendance groups carrying a rule_set override (surfaced as a
+              // preview-semantics diagnostic only; no calc-chain effect).
+              `SELECT id FROM attendance_groups WHERE org_id = $1 AND rule_set_id IS NOT NULL`,
+              [orgId]
+            ),
           ])
 
           const shiftAssignmentsTruncated = shiftAssignmentRows.length > ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT
@@ -26217,6 +26246,7 @@ module.exports = {
             assignmentLimit: ATTENDANCE_ADVANCED_SCHEDULING_WORKBENCH_ASSIGNMENT_LIMIT,
             shiftAssignmentsTruncated,
             rotationAssignmentsTruncated,
+            ruleSetAttendanceGroupIds: ruleSetAttendanceGroupRows.map(row => row.id),
           })
           res.json({ ok: true, data })
         } catch (error) {


### PR DESCRIPTION
## What

Enhances the existing `GET /api/attendance/advanced-scheduling/workbench` with **one read-only `info` diagnostic** that surfaces a known preview-semantics divergence. 3 files, +149.

A `groupId`-mode preview applies the linked attendance group's `rule_set` (`index.cjs:11452`/`:11462`), while the per-user `effective-calendar` calc-chain (`userId` branch, `:11445`) intentionally does **not**. This diagnostic flags schedule groups whose linked attendance group carries a `rule_set` so operators can see the gap. **It changes no calculation.**

## Boundaries (all held)

Read-only (one `SELECT`); no write to `attendance_*`/`meta_*`; **no migration**; no new POST/PUT/PATCH/DELETE (existing GET enhanced); auto-absence / working-hours / comprehensive-hours / effective-calendar calc-chains untouched; frontend only displays it (generic `v-for`, **no fix button**). This PR takes **no position** on whether the calc-chain should adopt the rule_set — that's a separate product/compliance decision.

## Changes

- **Builder:** new optional `ruleSetAttendanceGroupIds` input (defaults `[]` → backward compatible); flags active schedule groups whose `attendanceGroupId` is in the set; emits `schedule_group_rule_set_preview_divergence` (`info`), appended **last** (preserves existing order assertions).
- **Route:** one read-only `SELECT id FROM attendance_groups WHERE org_id=$1 AND rule_set_id IS NOT NULL`, passed to the builder.
- **Frontend:** none — renders via the existing generic loop (`AttendanceView.vue:4432`).

## Why `info` severity

It fires on every well-configured org that uses rule_sets; `warning` would be permanent noise. Matches `user_mixed_assignment_kinds` (also `info` for a by-design boundary). Message says "(by design — calc chain unchanged)".

## Tests

Workbench test file **8/8** (4 new): positive · negative (linked group without rule_set → no false positive) · backward-compat (no input / no `attendanceGroupId`) · source-guard (new query is `SELECT`; workbench handler **region** has no write verbs — scoped, since the file legitimately writes `attendance_groups` elsewhere via group sync). Full core-backend unit suite **2320/2320**; `tsc` clean. Includes a development/verification MD.

🤖 Generated with [Claude Code](https://claude.com/claude-code)