### PR TITLE
fix(attendance): validate UUID route inputs

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -3836,6 +3836,111 @@ describe('Attendance Plugin Integration', () => {
     expect((requestGetAfterDeleteRes.body as { data?: { request?: { status?: string } } } | undefined)?.data?.request?.status).toBe('cancelled')
   })
 
+  it('returns validation errors for malformed attendance UUID route params', async () => {
+    if (!baseUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const testUserId = `attendance-invalid-id-${runSuffix}`
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(testUserId)}&roles=user&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const cases = [
+      { method: 'GET', path: '/api/attendance/requests/not-a-uuid' },
+      { method: 'PUT', path: '/api/attendance/requests/not-a-uuid', body: {} },
+      { method: 'POST', path: '/api/attendance/requests/not-a-uuid/cancel', body: {} },
+      { method: 'DELETE', path: '/api/attendance/requests/not-a-uuid' },
+      { method: 'GET', path: '/api/attendance/payroll-cycles/not-a-uuid/summary' },
+      { method: 'GET', path: '/api/attendance/payroll-cycles/not-a-uuid/summary/export' },
+      { method: 'GET', path: '/api/attendance/payroll-cycles/not-a-uuid/export' },
+      { method: 'GET', path: '/api/attendance/holidays/not-a-uuid' },
+    ]
+
+    for (const testCase of cases) {
+      const res = await requestJson(`${baseUrl}${testCase.path}`, {
+        method: testCase.method,
+        headers: {
+          Authorization: `Bearer ${token}`,
+          ...(testCase.body ? { 'Content-Type': 'application/json' } : {}),
+        },
+        body: testCase.body ? JSON.stringify(testCase.body) : undefined,
+      })
+      expect(res.status, `${testCase.method} ${testCase.path}`).toBe(400)
+      const body = (res.body as { ok?: boolean; error?: { code?: string; message?: string } } | undefined) ?? {}
+      expect(body.ok, `${testCase.method} ${testCase.path}`).toBe(false)
+      expect(body.error?.code, `${testCase.method} ${testCase.path}`).toBe('VALIDATION_ERROR')
+      expect(body.error?.message, `${testCase.method} ${testCase.path}`).toBe('id must be a UUID')
+    }
+  })
+
+  it('returns validation errors for malformed attendance request reference UUIDs', async () => {
+    if (!baseUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const testUserId = `attendance-invalid-ref-${runSuffix}`
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(testUserId)}&roles=user&perms=attendance:read,attendance:write`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const workDate = new Date().toISOString().slice(0, 10)
+    const requestedInAt = new Date().toISOString()
+    const cases = [
+      {
+        field: 'leaveTypeId',
+        payload: {
+          workDate,
+          requestType: 'leave',
+          leaveTypeId: 'not-a-uuid',
+          minutes: 60,
+        },
+      },
+      {
+        field: 'overtimeRuleId',
+        payload: {
+          workDate,
+          requestType: 'overtime',
+          overtimeRuleId: 'not-a-uuid',
+          minutes: 60,
+        },
+      },
+      {
+        field: 'approvalFlowId',
+        payload: {
+          workDate,
+          requestType: 'time_correction',
+          requestedInAt,
+          approvalFlowId: 'not-a-uuid',
+        },
+      },
+    ]
+
+    for (const testCase of cases) {
+      const res = await requestJson(`${baseUrl}/api/attendance/requests`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(testCase.payload),
+      })
+      expect(res.status, testCase.field).toBe(400)
+      const body = (res.body as {
+        ok?: boolean
+        error?: { code?: string; message?: string; details?: Array<{ field?: string; message?: string }> }
+      } | undefined) ?? {}
+      expect(body.ok, testCase.field).toBe(false)
+      expect(body.error?.code, testCase.field).toBe('VALIDATION_ERROR')
+      expect(body.error?.message, testCase.field).toBe(`${testCase.field} must be a UUID`)
+      expect(body.error?.details?.[0]?.field, testCase.field).toBe(testCase.field)
+    }
+  })
+
   it('writes an adjusted attendance record after final approval for a missed check-in request', async () => {
     if (!baseUrl) return
 

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -1,0 +1,243 @@
+import { createRequire } from 'node:module'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+
+type RouteHandler = (req: any, res: any, next: any) => Promise<void>
+
+const originalRbacBypass = process.env.RBAC_BYPASS
+const originalAsyncEnabled = process.env.ATTENDANCE_IMPORT_ASYNC_ENABLED
+
+function restoreEnv(name: string, value: string | undefined) {
+  if (value === undefined) {
+    delete process.env[name]
+    return
+  }
+  process.env[name] = value
+}
+
+function createResponse() {
+  return {
+    statusCode: 200,
+    body: undefined as unknown,
+    headersSent: false,
+    headers: {} as Record<string, string>,
+    status(code: number) {
+      this.statusCode = code
+      return this
+    },
+    json(body: unknown) {
+      this.body = body
+      this.headersSent = true
+      return this
+    },
+    send(body: unknown) {
+      this.body = body
+      this.headersSent = true
+      return this
+    },
+    setHeader(name: string, value: string) {
+      this.headers[name] = value
+      return this
+    },
+  }
+}
+
+async function createHarness(rbacBypass = 'true') {
+  process.env.RBAC_BYPASS = rbacBypass
+  process.env.ATTENDANCE_IMPORT_ASYNC_ENABLED = 'false'
+
+  const routes = new Map<string, RouteHandler>()
+  const db = {
+    query: vi.fn(async () => {
+      throw new Error('db disabled in unit harness')
+    }),
+    transaction: vi.fn(async (callback: (client: unknown) => unknown) => callback(db)),
+  }
+  const logger = {
+    debug: vi.fn(),
+    info: vi.fn(),
+    warn: vi.fn(),
+    error: vi.fn(),
+  }
+
+  await attendancePlugin.activate({
+    api: {
+      database: db,
+      events: { emit: vi.fn() },
+      http: {
+        addRoute(method: string, path: string, handler: RouteHandler) {
+          routes.set(`${method.toUpperCase()} ${path}`, handler)
+        },
+      },
+    },
+    logger,
+  })
+
+  db.query.mockClear()
+  db.transaction.mockClear()
+
+  return { db, logger, routes }
+}
+
+async function invokeRoute(
+  routes: Map<string, RouteHandler>,
+  key: string,
+  options: { params?: Record<string, string>; body?: unknown; query?: Record<string, unknown> } = {},
+) {
+  const handler = routes.get(key)
+  expect(handler, key).toBeTypeOf('function')
+  const res = createResponse()
+  await handler?.(
+    {
+      params: options.params ?? {},
+      body: options.body ?? {},
+      query: options.query ?? {},
+      headers: {},
+      user: { id: 'attendance-user-1', orgId: 'default' },
+      ip: '127.0.0.1',
+      get: vi.fn(() => undefined),
+    },
+    res,
+    vi.fn(),
+  )
+  return res
+}
+
+afterEach(async () => {
+  restoreEnv('RBAC_BYPASS', originalRbacBypass)
+  restoreEnv('ATTENDANCE_IMPORT_ASYNC_ENABLED', originalAsyncEnabled)
+  await attendancePlugin.deactivate()
+  vi.restoreAllMocks()
+})
+
+describe('attendance UUID route validation', () => {
+  it('rejects malformed route UUID params before hitting the database', async () => {
+    const { db, routes } = await createHarness()
+    const cases = [
+      { key: 'GET /api/attendance/requests/:id' },
+      { key: 'PUT /api/attendance/requests/:id' },
+      { key: 'POST /api/attendance/requests/:id/approve' },
+      { key: 'POST /api/attendance/requests/:id/reject' },
+      { key: 'POST /api/attendance/requests/:id/cancel' },
+      { key: 'DELETE /api/attendance/requests/:id' },
+      { key: 'PUT /api/attendance/integrations/:id' },
+      { key: 'DELETE /api/attendance/integrations/:id' },
+      { key: 'GET /api/attendance/integrations/:id/runs' },
+      { key: 'POST /api/attendance/integrations/:id/sync' },
+      { key: 'GET /api/attendance/import/batches/:id' },
+      { key: 'GET /api/attendance/import/batches/:id/items' },
+      { key: 'GET /api/attendance/import/batches/:id/export.csv' },
+      { key: 'POST /api/attendance/import/rollback/:id' },
+      { key: 'DELETE /api/attendance/payroll-cycles/:id' },
+      { key: 'GET /api/attendance/payroll-cycles/:id/summary' },
+      { key: 'GET /api/attendance/payroll-cycles/:id/summary/export' },
+      { key: 'GET /api/attendance/payroll-cycles/:id/export' },
+      { key: 'GET /api/attendance/holidays/:id' },
+      { key: 'PUT /api/attendance/holidays/:id' },
+      { key: 'DELETE /api/attendance/holidays/:id' },
+    ]
+
+    for (const testCase of cases) {
+      const res = await invokeRoute(routes, testCase.key, { params: { id: 'not-a-uuid' } })
+      expect(res.statusCode, testCase.key).toBe(400)
+      expect(res.body, testCase.key).toMatchObject({
+        ok: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'id must be a UUID',
+        },
+      })
+    }
+
+    expect(db.query).not.toHaveBeenCalled()
+    expect(db.transaction).not.toHaveBeenCalled()
+  })
+
+  it('rejects malformed attendance request reference UUIDs as validation errors', async () => {
+    const { db, routes } = await createHarness()
+    const workDate = '2026-05-26'
+    const cases = [
+      {
+        field: 'leaveTypeId',
+        body: {
+          workDate,
+          requestType: 'leave',
+          leaveTypeId: 'not-a-uuid',
+          minutes: 60,
+        },
+      },
+      {
+        field: 'overtimeRuleId',
+        body: {
+          workDate,
+          requestType: 'overtime',
+          overtimeRuleId: 'not-a-uuid',
+          minutes: 60,
+        },
+      },
+      {
+        field: 'approvalFlowId',
+        body: {
+          workDate,
+          requestType: 'time_correction',
+          requestedInAt: '2026-05-26T09:00:00.000Z',
+          approvalFlowId: 'not-a-uuid',
+        },
+      },
+    ]
+
+    for (const testCase of cases) {
+      const res = await invokeRoute(routes, 'POST /api/attendance/requests', { body: testCase.body })
+      expect(res.statusCode, testCase.field).toBe(400)
+      expect(res.body, testCase.field).toMatchObject({
+        ok: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: `${testCase.field} must be a UUID`,
+          details: [{ field: testCase.field, message: 'Must be a UUID' }],
+        },
+      })
+    }
+
+    expect(db.query).not.toHaveBeenCalled()
+    expect(db.transaction).not.toHaveBeenCalled()
+  })
+
+  it('does not relabel handler failures as permission check failures', async () => {
+    const { db, routes } = await createHarness('false')
+    const dbFailure = new Error('request lookup failed')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[]) => {
+      if (sql.includes('FROM user_roles') && params?.[1] === 'admin') return []
+      if (sql.includes('FROM user_permissions') && params?.[1] === 'attendance:write') return [{ ok: 1 }]
+      if (sql.includes('FROM attendance_leave_types')) throw dbFailure
+      return []
+    })
+
+    const handler = routes.get('POST /api/attendance/requests')
+    expect(handler).toBeTypeOf('function')
+    const res = createResponse()
+
+    await expect(handler?.(
+      {
+        params: {},
+        body: {
+          workDate: '2026-05-26',
+          requestType: 'leave',
+          leaveTypeId: '00000000-0000-4000-8000-000000000000',
+          minutes: 60,
+        },
+        query: {},
+        headers: {},
+        user: { id: 'attendance-user-1', orgId: 'default' },
+        ip: '127.0.0.1',
+        get: vi.fn(() => undefined),
+      },
+      res,
+      vi.fn(),
+    )).rejects.toThrow('request lookup failed')
+    expect((res.body as { error?: { message?: string } } | undefined)?.error?.message).not.toBe('Permission check failed')
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -13951,6 +13951,25 @@ function createRbacHelpers(db, logger) {
 
   function withAnyPermission(permissions, handler) {
     return async (req, res, next) => {
+      const invokeHandler = async () => {
+        try {
+          await handler(req, res, next)
+        } catch (error) {
+          if (error instanceof HttpError && !res.headersSent) {
+            res.status(error.status).json({
+              ok: false,
+              error: {
+                code: error.code,
+                message: error.message,
+                ...(Array.isArray(error.details) && error.details.length > 0 ? { details: error.details } : {}),
+              },
+            })
+            return
+          }
+          throw error
+        }
+      }
+
       const userId = getUserId(req)
       if (!userId) {
         res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
@@ -13958,7 +13977,7 @@ function createRbacHelpers(db, logger) {
       }
 
       if (process.env.RBAC_BYPASS === 'true') {
-        await handler(req, res, next)
+        await invokeHandler()
         return
       }
 
@@ -13984,11 +14003,13 @@ function createRbacHelpers(db, logger) {
             return
           }
         }
-        await handler(req, res, next)
       } catch (error) {
         logger.error('RBAC guard error', error)
         res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Permission check failed' } })
+        return
       }
+
+      await invokeHandler()
     }
   }
 
@@ -17473,6 +17494,21 @@ module.exports = {
       return normalizeOptionalText(value)
     }
 
+    function normalizeRequestUuidReferenceInput(value, fallback = null, fieldName = 'id') {
+      const candidate = normalizeRequestReferenceInput(value, fallback)
+      if (!candidate) return candidate
+      const uuid = normalizeUuidString(candidate)
+      if (!uuid) {
+        throw new HttpError(
+          400,
+          'VALIDATION_ERROR',
+          `${fieldName} must be a UUID`,
+          singleValidationDetail(fieldName, 'Must be a UUID')
+        )
+      }
+      return uuid
+    }
+
     async function ensureAttendanceRequestAccess(requestRow, requesterId, actionLabel) {
       if (requestRow.user_id === requesterId) return
       const allowed = await canAccessOtherUsers(requesterId)
@@ -17577,7 +17613,11 @@ module.exports = {
       let overtimeRule = null
       if (requestType === 'leave') {
         leaveType = await loadLeaveType(db, orgId, {
-          id: normalizeRequestReferenceInput(firstDefinedValue(parsedData.leaveTypeId, parsedData.leave_type_id), existingLeaveType.id),
+          id: normalizeRequestUuidReferenceInput(
+            firstDefinedValue(parsedData.leaveTypeId, parsedData.leave_type_id),
+            existingLeaveType.id,
+            'leaveTypeId'
+          ),
           code: normalizeRequestReferenceInput(firstDefinedValue(parsedData.leaveTypeCode, parsedData.leave_type_code), existingLeaveType.code),
         })
         if (!leaveType) {
@@ -17596,7 +17636,11 @@ module.exports = {
         }
       } else if (requestType === 'overtime') {
         overtimeRule = await loadOvertimeRule(db, orgId, {
-          id: normalizeRequestReferenceInput(firstDefinedValue(parsedData.overtimeRuleId, parsedData.overtime_rule_id), existingOvertimeRule.id),
+          id: normalizeRequestUuidReferenceInput(
+            firstDefinedValue(parsedData.overtimeRuleId, parsedData.overtime_rule_id),
+            existingOvertimeRule.id,
+            'overtimeRuleId'
+          ),
           name: normalizeRequestReferenceInput(firstDefinedValue(parsedData.overtimeRuleName, parsedData.overtime_rule_name), existingOvertimeRule.name),
         })
         if (!overtimeRule) {
@@ -17632,7 +17676,11 @@ module.exports = {
 
       const approvalFlow = await loadApprovalFlow(db, orgId, {
         requestType,
-        flowId: normalizeRequestReferenceInput(firstDefinedValue(parsedData.approvalFlowId, parsedData.approval_flow_id), existingApprovalFlow.id),
+        flowId: normalizeRequestUuidReferenceInput(
+          firstDefinedValue(parsedData.approvalFlowId, parsedData.approval_flow_id),
+          existingApprovalFlow.id,
+          'approvalFlowId'
+        ),
       })
 
       const reason = parsedData.reason === undefined
@@ -17886,10 +17934,16 @@ module.exports = {
           return
         }
 
+        const requestId = normalizeUuidString(req.params.id)
+        if (!requestId) {
+          respondInvalidUuid(res)
+          return
+        }
+
         try {
           const rows = await db.query(
             'SELECT * FROM attendance_requests WHERE id = $1',
-            [req.params.id]
+            [requestId]
           )
           if (rows.length === 0) {
             res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Request not found' } })
@@ -17933,11 +17987,17 @@ module.exports = {
           return
         }
 
+        const requestId = normalizeUuidString(req.params.id)
+        if (!requestId) {
+          respondInvalidUuid(res)
+          return
+        }
+
         try {
           const request = await db.transaction(async (trx) => {
             const requestRows = await trx.query(
               'SELECT * FROM attendance_requests WHERE id = $1 FOR UPDATE',
-              [req.params.id]
+              [requestId]
             )
             if (requestRows.length === 0) {
               throw new HttpError(404, 'NOT_FOUND', 'Request not found')
@@ -17961,7 +18021,7 @@ module.exports = {
                  AND status IN ('pending', 'approved')
                  AND id <> $5
                LIMIT 1`,
-              [existingRequest.org_id, existingRequest.user_id, draft.workDate, draft.requestType, req.params.id]
+              [existingRequest.org_id, existingRequest.user_id, draft.workDate, draft.requestType, requestId]
             )
             if (duplicateRows.length > 0) {
               throw new HttpError(409, 'DUPLICATE_REQUEST', 'Duplicate attendance request already exists for this date')
@@ -17979,7 +18039,7 @@ module.exports = {
                WHERE id = $1
                RETURNING *`,
               [
-                req.params.id,
+                requestId,
                 draft.workDate,
                 draft.requestType,
                 draft.requestedInAt,
@@ -18043,7 +18103,11 @@ module.exports = {
         return
       }
 
-      const requestId = req.params.id
+      const requestId = normalizeUuidString(req.params.id)
+      if (!requestId) {
+        respondInvalidUuid(res)
+        return
+      }
 
       try {
         const result = await db.transaction(async (trx) => {
@@ -18287,7 +18351,11 @@ module.exports = {
         return
       }
 
-      const requestId = req.params.id
+      const requestId = normalizeUuidString(req.params.id)
+      if (!requestId) {
+        respondInvalidUuid(res)
+        return
+      }
 
       try {
         const result = await db.transaction(async (trx) => {
@@ -23177,7 +23245,11 @@ module.exports = {
           return
         }
         const orgId = getOrgId(req)
-        const integrationId = req.params.id
+        const integrationId = normalizeUuidString(req.params.id)
+        if (!integrationId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const existing = await db.query(
@@ -23230,7 +23302,11 @@ module.exports = {
       '/api/attendance/integrations/:id',
       withPermission('attendance:admin', async (req, res) => {
         const orgId = getOrgId(req)
-        const integrationId = req.params.id
+        const integrationId = normalizeUuidString(req.params.id)
+        if (!integrationId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const rows = await db.query(
@@ -23258,7 +23334,11 @@ module.exports = {
       '/api/attendance/integrations/:id/runs',
       withAttendanceImportPermission(async (req, res) => {
         const orgId = getOrgId(req)
-        const integrationId = req.params.id
+        const integrationId = normalizeUuidString(req.params.id)
+        if (!integrationId) {
+          respondInvalidUuid(res)
+          return
+        }
         const { page, pageSize, offset } = parsePagination(req.query)
 
         try {
@@ -23308,7 +23388,11 @@ module.exports = {
           res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
           return
         }
-        const integrationId = req.params.id
+        const integrationId = normalizeUuidString(req.params.id)
+        if (!integrationId) {
+          respondInvalidUuid(res)
+          return
+        }
         let run = null
         let imported = 0
         let skipped = []
@@ -23857,7 +23941,11 @@ module.exports = {
       '/api/attendance/import/batches/:id',
       withAttendanceImportPermission(async (req, res) => {
         const orgId = getOrgId(req)
-        const batchId = req.params.id
+        const batchId = normalizeUuidString(req.params.id)
+        if (!batchId) {
+          respondInvalidUuid(res)
+          return
+        }
         try {
           const rows = await db.query(
             'SELECT * FROM attendance_import_batches WHERE id = $1 AND org_id = $2',
@@ -23884,7 +23972,11 @@ module.exports = {
 	      '/api/attendance/import/batches/:id/items',
 	      withAttendanceImportPermission(async (req, res) => {
         const orgId = getOrgId(req)
-        const batchId = req.params.id
+        const batchId = normalizeUuidString(req.params.id)
+        if (!batchId) {
+          respondInvalidUuid(res)
+          return
+        }
         const { page, pageSize, offset } = parsePagination(req.query)
         try {
           const countRows = await db.query(
@@ -23924,7 +24016,11 @@ module.exports = {
 	      '/api/attendance/import/batches/:id/export.csv',
 	      withAttendanceImportPermission(async (req, res) => {
 	        const orgId = getOrgId(req)
-	        const batchId = req.params.id
+	        const batchId = normalizeUuidString(req.params.id)
+	        if (!batchId) {
+	          respondInvalidUuid(res)
+	          return
+	        }
 	        const rawType = String(req.query?.type ?? req.query?.kind ?? '').toLowerCase()
 	        const type = ['all', 'imported', 'skipped', 'anomalies'].includes(rawType) ? rawType : 'all'
 
@@ -24064,7 +24160,11 @@ module.exports = {
 	      '/api/attendance/import/rollback/:id',
       withAttendanceImportPermission(async (req, res) => {
         const orgId = getOrgId(req)
-        const batchId = req.params.id
+        const batchId = normalizeUuidString(req.params.id)
+        if (!batchId) {
+          respondInvalidUuid(res)
+          return
+        }
         try {
           const batchRows = await db.query(
             'SELECT * FROM attendance_import_batches WHERE id = $1 AND org_id = $2',
@@ -24815,7 +24915,11 @@ module.exports = {
       '/api/attendance/payroll-cycles/:id',
       withPermission('attendance:admin', async (req, res) => {
         const orgId = getOrgId(req)
-        const payrollCycleId = req.params.id
+        const payrollCycleId = normalizeUuidString(req.params.id)
+        if (!payrollCycleId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const rows = await db.query(
@@ -24874,7 +24978,11 @@ module.exports = {
         }
 
         const orgId = getOrgId(req)
-        const cycleId = req.params.id
+        const cycleId = normalizeUuidString(req.params.id)
+        if (!cycleId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const cycleRows = await db.query(
@@ -24948,7 +25056,11 @@ module.exports = {
         }
 
         const orgId = getOrgId(req)
-        const cycleId = req.params.id
+        const cycleId = normalizeUuidString(req.params.id)
+        if (!cycleId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const cycleRows = await db.query(
@@ -27211,7 +27323,11 @@ module.exports = {
       '/api/attendance/holidays/:id',
       withPermission('attendance:read', async (req, res) => {
         const orgId = getOrgId(req)
-        const holidayId = req.params.id
+        const holidayId = normalizeUuidString(req.params.id)
+        if (!holidayId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const rows = await db.query(
@@ -27424,7 +27540,11 @@ module.exports = {
         }
 
         const orgId = getOrgId(req)
-        const holidayId = req.params.id
+        const holidayId = normalizeUuidString(req.params.id)
+        if (!holidayId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const existingRows = await db.query(
@@ -27477,7 +27597,11 @@ module.exports = {
       '/api/attendance/holidays/:id',
       withPermission('attendance:admin', async (req, res) => {
         const orgId = getOrgId(req)
-        const holidayId = req.params.id
+        const holidayId = normalizeUuidString(req.params.id)
+        if (!holidayId) {
+          respondInvalidUuid(res)
+          return
+        }
 
         try {
           const rows = await db.query(


### PR DESCRIPTION
## Summary
- Split the attendance RBAC wrapper so permission lookup failures still return `Permission check failed`, while handler `HttpError` responses keep their business/validation code.
- Validate malformed UUID route params before DB access for attendance request, integration, import batch, payroll cycle, and holiday routes.
- Validate request body UUID references for `leaveTypeId`, `overtimeRuleId`, and `approvalFlowId`.

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "malformed attendance" --reporter=dot` (current local env has no attendance test DB, so the wider fixture-guarded integration suite remains skipped)
- `git diff --check -- plugins/plugin-attendance/index.cjs packages/core-backend/tests/integration/attendance-plugin.test.ts packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts`

Fixes #1853
Fixes #1854
Fixes #1856
Fixes #1858