### PR TITLE
feat(integration): add K3 Material read-only smoke

### DIFF
--- a/docs/development/integration-k3wise-material-detail-read-smoke-design-20260526.md
+++ b/docs/development/integration-k3wise-material-detail-read-smoke-design-20260526.md
@@ -1,0 +1,113 @@
+# K3 WISE Material/GetDetail Read-Only Smoke Design - 2026-05-26
+
+## Purpose
+
+This slice implements the smallest runtime unlock for #1709: a read-only smoke
+that calls K3 WISE `Material/GetDetail` for one known material number and
+harvests the reference objects already present in that detail payload.
+
+It is not a general source connector. It exists to prove that MetaSheet can read
+one customer-approved material detail without crossing into Save, Submit, Audit,
+BOM, pagination, list reads, broad filters, or server-side pipeline composition.
+
+## Decision
+
+The unlocked runtime surface is:
+
+- Adapter: `erp:k3-wise-webapi`
+- Object: `material`
+- Operation: `read`, only when the material object is explicitly configured with
+  `operations` including `read`
+- Endpoint: `POST /K3API/Material/GetDetail`
+- Request body:
+
+```json
+{
+  "Data": {
+    "FNumber": "<material-number>"
+  },
+  "GetProperty": false
+}
+```
+
+- Response shape: K3 envelope with `Data[0].Data` as the material detail record
+- Output: one `createReadResult()` record plus `_k3ReferenceObjects`
+
+The default K3 WISE material template still advertises only `upsert`. This keeps
+existing target-only deployments unchanged. Operators must explicitly enable
+`read` on the material object before this smoke path runs.
+
+## Runtime Shape
+
+The adapter accepts the material key from either:
+
+- `options.templateMaterialNumber`
+- `options.materialNumber`
+- `options.number`
+- `options.FNumber`
+- `filters.templateMaterialNumber`
+- `filters.materialNumber`
+- `filters.number`
+- `filters.FNumber`
+
+The adapter rejects missing or blank keys with `K3_WISE_READ_KEY_REQUIRED`.
+
+The adapter calls `Material/GetDetail` with the same authenticated transport used
+by existing WebAPI calls. Login/session handling and authority-code token mode
+are reused unchanged.
+
+## Reference Harvesting
+
+The smoke reads the material detail and harvests reference-like objects from the
+record into `_k3ReferenceObjects`.
+
+Reference fields are selected by:
+
+- `options.referenceFields` or `filters.referenceFields`, when provided
+- otherwise all material template schema fields whose type is `reference`
+
+A value is treated as a reference object when it is an object containing at least
+one non-empty reference identifier/name key such as `FNumber`, `FID`, `FId`, or
+`FName`.
+
+The customer sample proved that `FUnitGroupID` can return `{ "FName": ... }`
+without `FNumber`/`FID`. This implementation accepts that special real-world
+shape instead of rejecting it.
+
+## Explicit Non-Goals
+
+This slice does not implement:
+
+- K3 Save, Submit, Audit, or Delete
+- BOM reads
+- list/search APIs
+- pagination or cursor handling
+- broad filters or watermark reads
+- master-code resolution
+- automatic lookup-to-object composition
+- server-side pipeline transforms
+- Data Factory run orchestration changes
+
+Those remain separately gated. The read-only smoke can feed operator preview and
+future one-record regression work, but it does not unlock productionized pipeline
+Save composition by itself.
+
+## Error Taxonomy
+
+- `K3_WISE_READ_KEY_REQUIRED`: no concrete material number was supplied
+- `K3_WISE_READ_FILTER_UNSUPPORTED`: a broad/list-style filter was supplied
+- `K3_WISE_READ_LIST_UNSUPPORTED`: cursor or watermark read was requested
+- `K3_WISE_READ_NOT_CONFIGURED`: material read endpoint is absent
+- `K3_WISE_READ_FAILED`: transport or non-2xx HTTP failure
+- `K3_WISE_READ_BUSINESS_ERROR`: K3 returned a business-negative envelope or no
+  material detail row
+
+Errors intentionally identify the failure class without echoing credentials,
+tokens, raw connection strings, or request secrets.
+
+## Files
+
+- `plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs`
+- `plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs`
+- `plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`
+- `plugins/plugin-integration-core/__tests__/fixtures/k3-wise-material-detail-redacted.json`

--- a/docs/development/integration-k3wise-material-detail-read-smoke-verification-20260526.md
+++ b/docs/development/integration-k3wise-material-detail-read-smoke-verification-20260526.md
@@ -1,0 +1,85 @@
+# K3 WISE Material/GetDetail Read-Only Smoke Verification - 2026-05-26
+
+## Scope
+
+This verification covers the #1709 read-only runtime slice for one K3 WISE
+Material/GetDetail record.
+
+It verifies only the runtime and fixture contract. It does not claim customer
+environment live success, does not unlock broad K3 reads, and does not exercise
+Save, Submit, Audit, BOM, list, pagination, or server-side Data Factory
+composition.
+
+## Acceptance Matrix
+
+| ID | Requirement | Evidence |
+| --- | --- | --- |
+| A1 | Default K3 WebAPI target remains read-disabled | Adapter tests expect the default `adapter.read({ object: 'material' })` call and a fully keyed `adapter.read({ object: 'material', filters: { FNumber } })` call to throw `UnsupportedAdapterOperationError`. |
+| A2 | Material read is opt-in | New test enables `config.objects.material.operations = ['upsert', 'read']` before calling read. |
+| A3 | Endpoint is exactly Material/GetDetail | New test asserts one `POST /K3API/Material/GetDetail` call. |
+| A4 | Body is the customer-approved single-key shape | New test asserts `{ Data: { FNumber }, GetProperty: false }`. |
+| A5 | No write operation is fired | New test asserts no `/Material/Save`, `/Material/Submit`, or `/Material/Audit` call during read. |
+| A6 | Response harvesting preserves reference object shapes | Fixture includes `{FName}`, `{FNumber,FName}`, and `{FID,FName}` examples; test asserts all are harvested into `_k3ReferenceObjects`. |
+| A7 | `FUnitGroupID` with only `FName` is accepted | Test asserts the FName-only object is retained because the customer sample exposed that shape. |
+| A8 | Missing key is rejected | Test asserts `K3_WISE_READ_KEY_REQUIRED`. |
+| A9 | Broad/list filters are rejected | Test asserts `K3_WISE_READ_FILTER_UNSUPPORTED` for `modifiedSince`. |
+| A10 | Cursor/watermark reads are rejected | Test asserts `K3_WISE_READ_LIST_UNSUPPORTED` for cursor and watermark inputs. |
+| A11 | BOM remains locked | Test configures BOM with `read` and still asserts `UnsupportedAdapterOperationError`. |
+| A12 | K3 business-negative read is surfaced | Test asserts `K3_WISE_READ_BUSINESS_ERROR`. |
+| A13 | HTTP/transport read failure is surfaced | Test asserts `K3_WISE_READ_FAILED`. |
+
+## Commands Run
+
+```bash
+pnpm -F plugin-integration-core test:k3-wise-adapters
+```
+
+Result:
+
+```text
+plugin-integration-core@0.1.0 test:k3-wise-adapters
+node __tests__/k3-wise-adapters.test.cjs
+
+✓ k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed
+```
+
+Broader validation:
+
+```bash
+git diff --check
+pnpm -F plugin-integration-core test
+pnpm -F plugin-integration-core test:k3-wise-adapters
+pnpm verify:integration-k3wise:poc
+```
+
+Results:
+
+- `git diff --check`: pass
+- `pnpm -F plugin-integration-core test`: pass
+- `pnpm -F plugin-integration-core test:k3-wise-adapters`: pass
+- `pnpm verify:integration-k3wise:poc`: pass
+
+## Secret Hygiene
+
+The committed fixture is redacted:
+
+- No real K3 host
+- No token
+- No password
+- No authority code
+- No raw material code or account value
+- Placeholder values only, such as `<template-material-number>` and
+  `<base-unit-number>`
+
+The tests assert request shape and operation paths without logging credentials or
+session token values.
+
+## Residual Risk
+
+This slice proves runtime mechanics against a redacted fixture and local adapter
+tests. It still requires a separate entity-machine smoke with a customer-approved
+template material number before any S4 one-record Save regression can use the
+harvested reference objects.
+
+The slice does not resolve master data by code. It only harvests reference
+objects already present in the detail record.

--- a/plugins/plugin-integration-core/__tests__/fixtures/k3-wise-material-detail-redacted.json
+++ b/plugins/plugin-integration-core/__tests__/fixtures/k3-wise-material-detail-redacted.json
@@ -1,0 +1,37 @@
+{
+  "StatusCode": 200,
+  "Message": "Successful",
+  "Data": [
+    {
+      "FNumber": "<template-material-number>",
+      "Data": {
+        "FNumber": "<template-material-number>",
+        "FName": "<redacted-material-name>",
+        "FModel": "<redacted-model>",
+        "FUnitGroupID": {
+          "FName": "<unit-group-name>"
+        },
+        "FBaseUnitID": {
+          "FNumber": "<base-unit-number>",
+          "FName": "<base-unit-name>"
+        },
+        "FOrderUnitID": {
+          "FNumber": "<order-unit-number>",
+          "FName": "<order-unit-name>"
+        },
+        "FAcctID": {
+          "FID": "<inventory-account-id>",
+          "FName": "<inventory-account-name>"
+        },
+        "FSaleAcctID": {
+          "FID": "<sales-account-id>",
+          "FName": "<sales-account-name>"
+        },
+        "FCostAcctID": {
+          "FID": "<cost-account-id>",
+          "FName": "<cost-account-name>"
+        }
+      }
+    }
+  ]
+}

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -19,6 +19,11 @@ const {
   __internals: sqlExecutorInternals,
   createK3WiseSqlServerReadOnlyExecutor,
 } = require(path.join(__dirname, '..', 'lib', 'adapters', 'k3-wise-sqlserver-executor.cjs'))
+const materialDetailFixture = require(path.join(__dirname, 'fixtures', 'k3-wise-material-detail-redacted.json'))
+
+function cloneJson(value) {
+  return JSON.parse(JSON.stringify(value))
+}
 
 function jsonResponse(status, body, headers = {}) {
   return {
@@ -97,6 +102,33 @@ function createK3FetchMock() {
         })
       }
       return jsonResponse(200, { success: true, externalId: `item-${record.FNumber}`, billNo: record.FNumber })
+    }
+    if (parsed.pathname === '/K3API/Material/GetDetail') {
+      const materialNumber = body && body.Data && body.Data.FNumber
+      if (!materialNumber) {
+        return jsonResponse(200, {
+          StatusCode: 201,
+          Message: 'FNumber is required',
+          Data: [],
+        })
+      }
+      if (materialNumber === 'READFAIL') {
+        return jsonResponse(200, {
+          StatusCode: 500,
+          Message: 'material detail not found',
+          Data: [],
+        })
+      }
+      if (materialNumber === 'HTTPFAIL') {
+        return jsonResponse(503, {
+          StatusCode: 503,
+          Message: 'temporary upstream failure',
+        })
+      }
+      const response = cloneJson(materialDetailFixture)
+      response.Data[0].FNumber = materialNumber
+      response.Data[0].Data.FNumber = materialNumber
+      return jsonResponse(200, response)
     }
     if (parsed.pathname === '/K3API/Material/Submit') {
       return jsonResponse(200, { success: true, submitted: body.Number })
@@ -341,6 +373,14 @@ async function testK3WebApiAdapter() {
 
   const targetOnlyRead = await adapter.read({ object: 'material' }).catch((error) => error)
   assert.ok(targetOnlyRead instanceof UnsupportedAdapterOperationError, 'K3 WebAPI target rejects read')
+  const targetOnlyReadWithKey = await adapter.read({
+    object: 'material',
+    filters: { FNumber: 'MAT-DEFAULT-OFF' },
+  }).catch((error) => error)
+  assert.ok(
+    targetOnlyReadWithKey instanceof UnsupportedAdapterOperationError,
+    'K3 WebAPI material read stays default-off even when the request contains a valid FNumber',
+  )
 
   const failingLogin = createK3WiseWebApiAdapter({
     system: createK3WebApiSystem({
@@ -522,6 +562,134 @@ async function testK3WebApiAdapter() {
   assert.ok(invalidObjectEndpoint instanceof AdapterValidationError, 'absolute object endpoint is rejected')
 
   assert.equal(K3WiseWebApiAdapterError.name, 'K3WiseWebApiAdapterError')
+}
+
+async function testK3WebApiMaterialDetailReadSmoke() {
+  const { calls, fetchImpl } = createK3FetchMock()
+  const adapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      config: {
+        baseUrl: 'https://k3.example.test',
+        autoSubmit: true,
+        autoAudit: true,
+        objects: {
+          material: {
+            operations: ['upsert', 'read'],
+          },
+        },
+      },
+    }),
+    fetchImpl,
+  })
+
+  const read = await adapter.read({
+    object: 'material',
+    filters: { FNumber: 'MAT-GATE-001' },
+    options: { referenceFields: ['FUnitGroupID', 'FBaseUnitID', 'FAcctID', 'FTrack'] },
+  })
+
+  assert.equal(read.records.length, 1, 'Material/GetDetail smoke returns exactly one record')
+  assert.equal(read.nextCursor, null, 'single-detail smoke never returns a cursor')
+  assert.equal(read.done, true, 'single-detail smoke is terminal')
+  assert.equal(read.metadata.mode, 'material-detail-reference-smoke')
+  assert.equal(read.metadata.readOnly, true)
+  assert.equal(read.metadata.requestedNumber, 'MAT-GATE-001')
+  assert.equal(read.metadata.readPath, '/K3API/Material/GetDetail')
+  assert.deepEqual(read.metadata.referenceFields, ['FUnitGroupID', 'FBaseUnitID', 'FAcctID'])
+  assert.equal(read.metadata.referenceObjectCount, 3)
+
+  const record = read.records[0]
+  assert.equal(record.FNumber, 'MAT-GATE-001', 'requested FNumber is echoed onto the record')
+  assert.deepEqual(
+    record._k3ReferenceObjects.FUnitGroupID,
+    { FName: '<unit-group-name>' },
+    'FUnitGroupID with FName-only shape is accepted because the customer sample exposes it',
+  )
+  assert.deepEqual(record._k3ReferenceObjects.FBaseUnitID, {
+    FNumber: '<base-unit-number>',
+    FName: '<base-unit-name>',
+  })
+  assert.deepEqual(record._k3ReferenceObjects.FAcctID, {
+    FID: '<inventory-account-id>',
+    FName: '<inventory-account-name>',
+  })
+  assert.equal(record._k3ReferenceObjects.FTrack, undefined, 'non-object reference candidates are not harvested')
+
+  const getDetailCalls = calls.filter((call) => call.pathname === '/K3API/Material/GetDetail')
+  assert.equal(getDetailCalls.length, 1, 'read smoke calls Material/GetDetail once')
+  assert.equal(getDetailCalls[0].options.method, 'POST')
+  assert.equal(getDetailCalls[0].options.headers['X-K3-Session'], 'k3-session-1')
+  assert.deepEqual(getDetailCalls[0].body, {
+    Data: { FNumber: 'MAT-GATE-001' },
+    GetProperty: false,
+  })
+  assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Save'), false, 'read smoke must not Save')
+  assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Submit'), false, 'read smoke must not Submit')
+  assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Audit'), false, 'read smoke must not Audit')
+
+  const missingKey = await adapter.read({ object: 'material' }).catch((error) => error)
+  assert.ok(missingKey instanceof AdapterValidationError, 'Material read requires a concrete FNumber/template key')
+  assert.equal(missingKey.details.code, 'K3_WISE_READ_KEY_REQUIRED')
+
+  const broadFilter = await adapter.read({
+    object: 'material',
+    filters: { FNumber: 'MAT-GATE-001', modifiedSince: '2026-05-01T00:00:00Z' },
+  }).catch((error) => error)
+  assert.ok(broadFilter instanceof AdapterValidationError, 'broad list-style filters are blocked')
+  assert.equal(broadFilter.details.code, 'K3_WISE_READ_FILTER_UNSUPPORTED')
+
+  const cursorRead = await adapter.read({
+    object: 'material',
+    filters: { FNumber: 'MAT-GATE-001' },
+    cursor: 'next-page',
+  }).catch((error) => error)
+  assert.ok(cursorRead instanceof AdapterValidationError, 'cursor pagination is blocked')
+  assert.equal(cursorRead.details.code, 'K3_WISE_READ_LIST_UNSUPPORTED')
+
+  const watermarkRead = await adapter.read({
+    object: 'material',
+    filters: { FNumber: 'MAT-GATE-001' },
+    watermark: { FModifyDate: '2026-05-01T00:00:00Z' },
+  }).catch((error) => error)
+  assert.ok(watermarkRead instanceof AdapterValidationError, 'watermark list reads are blocked')
+  assert.equal(watermarkRead.details.code, 'K3_WISE_READ_LIST_UNSUPPORTED')
+
+  const businessFailure = await adapter.read({
+    object: 'material',
+    filters: { FNumber: 'READFAIL' },
+  }).catch((error) => error)
+  assert.ok(businessFailure instanceof K3WiseWebApiAdapterError, 'K3 business failure is surfaced as adapter error')
+  assert.equal(businessFailure.details.code, 'K3_WISE_READ_BUSINESS_ERROR')
+  assert.match(businessFailure.message, /material detail not found/)
+
+  const transportFailure = await adapter.read({
+    object: 'material',
+    filters: { FNumber: 'HTTPFAIL' },
+  }).catch((error) => error)
+  assert.ok(transportFailure instanceof K3WiseWebApiAdapterError, 'HTTP failure is surfaced as read failure')
+  assert.equal(transportFailure.details.code, 'K3_WISE_READ_FAILED')
+  assert.equal(transportFailure.details.path, '/K3API/Material/GetDetail')
+
+  const bomReadAdapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      config: {
+        baseUrl: 'https://k3.example.test',
+        autoSubmit: false,
+        autoAudit: false,
+        objects: {
+          bom: {
+            operations: ['upsert', 'read'],
+          },
+        },
+      },
+    }),
+    fetchImpl,
+  })
+  const bomRead = await bomReadAdapter.read({
+    object: 'bom',
+    filters: { FNumber: 'BOM-001' },
+  }).catch((error) => error)
+  assert.ok(bomRead instanceof UnsupportedAdapterOperationError, 'read-only smoke does not unlock BOM reads')
 }
 
 async function testK3WebApiAuthorityCodeToken() {
@@ -947,6 +1115,7 @@ async function testK3WebApiAutoFlagCoercion() {
 
 async function main() {
   await testK3WebApiAdapter()
+  await testK3WebApiMaterialDetailReadSmoke()
   await testK3WebApiAuthorityCodeToken()
   await testK3WebApiSaveBusinessEvidence()
   testSqlServerConnectionConfigNormalization()

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs
@@ -96,6 +96,8 @@ const K3_WISE_DOCUMENT_TEMPLATES = {
     label: 'K3 WISE Material',
     operations: ['upsert'],
     savePath: '/K3API/Material/Save',
+    readPath: '/K3API/Material/GetDetail',
+    readMethod: 'POST',
     submitPath: '/K3API/Material/Submit',
     auditPath: '/K3API/Material/Audit',
     bodyKey: 'Data',
@@ -211,6 +213,7 @@ function normalizeTemplate(template, field) {
   }
   if (template.submitPath) normalized.submitPath = assertRelativeEndpoint(template.submitPath, `${field}.submitPath`)
   if (template.auditPath) normalized.auditPath = assertRelativeEndpoint(template.auditPath, `${field}.auditPath`)
+  if (template.readPath) normalized.readPath = assertRelativeEndpoint(template.readPath, `${field}.readPath`)
   normalized.k3Template = {
     id: template.id,
     version: template.version,

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -12,10 +12,11 @@
 const {
   AdapterValidationError,
   UnsupportedAdapterOperationError,
+  createReadResult,
   createUpsertResult,
   normalizeExternalSystemForAdapter,
+  normalizeReadRequest,
   normalizeUpsertRequest,
-  unsupportedAdapterOperation,
 } = require('../contracts.cjs')
 const {
   getK3WiseDocumentObjectDefaults,
@@ -440,6 +441,147 @@ function projectRecordForBody(record, objectConfig) {
   return projected
 }
 
+function normalizeStringList(value, field) {
+  if (value === undefined || value === null || value === '') return []
+  const list = Array.isArray(value)
+    ? value
+    : String(value).split(',')
+  const normalized = []
+  for (const item of list) {
+    if (typeof item !== 'string' && typeof item !== 'number') {
+      throw new AdapterValidationError(`${field} must contain only string field names`, { field })
+    }
+    const text = String(item).trim()
+    if (text) normalized.push(text)
+  }
+  return Array.from(new Set(normalized))
+}
+
+function resolveMaterialReadNumber(request) {
+  const number = firstDefined(
+    request.options.templateMaterialNumber,
+    request.options.materialNumber,
+    request.options.number,
+    request.options.FNumber,
+    request.filters.templateMaterialNumber,
+    request.filters.materialNumber,
+    request.filters.number,
+    request.filters.FNumber,
+  )
+  if (typeof number !== 'string' && typeof number !== 'number') {
+    throw new AdapterValidationError('K3 WISE Material read requires templateMaterialNumber or filters.FNumber', {
+      code: 'K3_WISE_READ_KEY_REQUIRED',
+      field: 'templateMaterialNumber',
+      object: request.object,
+    })
+  }
+  const normalized = String(number).trim()
+  if (!normalized) {
+    throw new AdapterValidationError('K3 WISE Material read requires a non-empty templateMaterialNumber', {
+      code: 'K3_WISE_READ_KEY_REQUIRED',
+      field: 'templateMaterialNumber',
+      object: request.object,
+    })
+  }
+  return normalized
+}
+
+function assertMaterialDetailReadOnlyScope(request) {
+  if (request.object !== 'material') {
+    throw new UnsupportedAdapterOperationError('K3 WISE WebAPI read-only smoke supports only material detail reads', {
+      kind: 'erp:k3-wise-webapi',
+      object: request.object,
+      operation: 'read',
+    })
+  }
+  if (request.cursor) {
+    throw new AdapterValidationError('K3 WISE Material read-only smoke does not support cursor/list pagination', {
+      code: 'K3_WISE_READ_LIST_UNSUPPORTED',
+      object: request.object,
+      field: 'cursor',
+    })
+  }
+  if (Object.keys(request.watermark || {}).length > 0) {
+    throw new AdapterValidationError('K3 WISE Material read-only smoke does not support watermark/list reads', {
+      code: 'K3_WISE_READ_LIST_UNSUPPORTED',
+      object: request.object,
+      field: 'watermark',
+    })
+  }
+  const allowedFilterKeys = new Set(['templateMaterialNumber', 'materialNumber', 'number', 'FNumber', 'referenceFields'])
+  const unknownFilters = Object.keys(request.filters).filter((key) => !allowedFilterKeys.has(key))
+  if (unknownFilters.length > 0) {
+    throw new AdapterValidationError('K3 WISE Material read-only smoke supports only a single material-number filter', {
+      code: 'K3_WISE_READ_FILTER_UNSUPPORTED',
+      object: request.object,
+      fields: unknownFilters,
+    })
+  }
+}
+
+function defaultMaterialReferenceFields(objectConfig) {
+  return Array.isArray(objectConfig.schema)
+    ? objectConfig.schema
+      .filter((field) => field && field.type === 'reference' && typeof field.name === 'string' && field.name.trim())
+      .map((field) => field.name.trim())
+    : []
+}
+
+function isReferenceObject(value) {
+  return isPlainObject(value) && Object.keys(value).some((key) => (
+    ['FNumber', 'FID', 'FId', 'FName', 'Name', 'Number', 'Id'].includes(key) &&
+    !isBlankValue(value[key])
+  ))
+}
+
+function materialDetailElement(data) {
+  const rows = getPath(data, 'Data')
+  if (Array.isArray(rows)) return rows.find(isPlainObject) || null
+  return isPlainObject(rows) ? rows : null
+}
+
+function extractMaterialDetailRecord(data, materialNumber) {
+  const element = materialDetailElement(data)
+  if (!element) return null
+  const detail = isPlainObject(element.Data) ? element.Data : element
+  const record = cloneJson(detail)
+  if (isPlainObject(record) && isBlankValue(record.FNumber)) {
+    const number = firstDefined(element.FNumber, materialNumber)
+    if (!isBlankValue(number)) record.FNumber = String(number)
+  }
+  return isPlainObject(record) ? record : null
+}
+
+function buildReadBody(materialNumber, objectConfig) {
+  const template = isPlainObject(objectConfig.readBodyTemplate)
+    ? cloneJson(objectConfig.readBodyTemplate)
+    : {}
+  template.Data = isPlainObject(template.Data)
+    ? { ...template.Data, FNumber: materialNumber }
+    : { FNumber: materialNumber }
+  if (template.GetProperty === undefined) template.GetProperty = false
+  return template
+}
+
+function buildMaterialReadRecord(detail, request, objectConfig) {
+  const requestedFields = [
+    ...normalizeStringList(request.options.referenceFields, 'options.referenceFields'),
+    ...normalizeStringList(request.filters.referenceFields, 'filters.referenceFields'),
+  ]
+  const referenceFields = requestedFields.length > 0
+    ? Array.from(new Set(requestedFields))
+    : defaultMaterialReferenceFields(objectConfig)
+  const referenceObjects = {}
+  for (const fieldName of referenceFields) {
+    const value = detail[fieldName]
+    if (isReferenceObject(value)) referenceObjects[fieldName] = cloneJson(value)
+  }
+  return {
+    ...detail,
+    _k3ReferenceObjects: referenceObjects,
+  }
+}
+
 function buildLifecycleBody(record, request, objectConfig, operation) {
   if (typeof objectConfig.buildLifecycleBody === 'function') {
     return objectConfig.buildLifecycleBody(record, request, operation)
@@ -838,6 +980,75 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
     }
   }
 
+  async function read(input = {}) {
+    const request = normalizeReadRequest(input)
+    const objectConfig = objects[request.object]
+    if (!objectConfig) {
+      throw new AdapterValidationError(`K3 WISE object is not configured: ${request.object}`, { object: request.object })
+    }
+    ensureOperation(normalizedSystem.kind, request.object, objectConfig, 'read')
+    assertMaterialDetailReadOnlyScope(request)
+
+    const readPath = objectConfig.readPath
+      ? assertRelativePath(objectConfig.readPath, 'object.readPath')
+      : null
+    if (!readPath) {
+      throw new K3WiseWebApiAdapterError('K3 WISE read endpoint is not configured for material', {
+        code: 'K3_WISE_READ_NOT_CONFIGURED',
+        object: request.object,
+      })
+    }
+
+    const materialNumber = resolveMaterialReadNumber(request)
+    const authContext = await login()
+    let readResponse
+    try {
+      readResponse = await requestJson(readPath, {
+        method: objectConfig.readMethod || 'POST',
+        query: authContext.query,
+        headers: authContext.headers,
+        body: buildReadBody(materialNumber, objectConfig),
+      })
+    } catch (error) {
+      throw new K3WiseWebApiAdapterError(`K3 WISE WebAPI read failed: ${error && error.message ? error.message : String(error)}`, {
+        code: 'K3_WISE_READ_FAILED',
+        object: request.object,
+        status: error && error.status,
+        path: readPath,
+      })
+    }
+
+    if (!businessSuccess(readResponse.data, config)) {
+      throw new K3WiseWebApiAdapterError(String(responseMessage(readResponse.data, config, 'K3 WISE read business response failed')), {
+        code: 'K3_WISE_READ_BUSINESS_ERROR',
+        object: request.object,
+        responseCode: responseFailureCode(readResponse.data, config, 'K3_WISE_READ_BUSINESS_ERROR'),
+      })
+    }
+
+    const detail = extractMaterialDetailRecord(readResponse.data, materialNumber)
+    if (!detail) {
+      throw new K3WiseWebApiAdapterError('K3 WISE read response did not include a material detail record', {
+        code: 'K3_WISE_READ_BUSINESS_ERROR',
+        object: request.object,
+      })
+    }
+    const record = buildMaterialReadRecord(detail, request, objectConfig)
+    return createReadResult({
+      records: [record],
+      raw: readResponse.data,
+      metadata: {
+        object: request.object,
+        mode: 'material-detail-reference-smoke',
+        requestedNumber: materialNumber,
+        readPath,
+        readOnly: true,
+        referenceFields: Object.keys(record._k3ReferenceObjects || {}),
+        referenceObjectCount: Object.keys(record._k3ReferenceObjects || {}).length,
+      },
+    })
+  }
+
   async function upsert(input = {}) {
     const request = normalizeUpsertRequest(input)
     const objectConfig = objects[request.object]
@@ -997,7 +1208,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
     listObjects,
     getSchema,
     previewUpsert,
-    read: unsupportedAdapterOperation(normalizedSystem.kind, 'read'),
+    read,
     upsert,
   }
 }
@@ -1014,6 +1225,8 @@ module.exports = {
     DEFAULT_OBJECTS,
     businessSuccess,
     extractRecordKey,
+    extractMaterialDetailRecord,
+    buildMaterialReadRecord,
     listK3WiseDocumentTemplates,
     normalizeObjects,
     projectRecordForBody,


### PR DESCRIPTION
## Summary

Implements the narrow #1709 read-only runtime slice for K3 WISE Material/GetDetail:

- opt-in `adapter.read()` support only for `object: material` when material operations explicitly include `read`
- calls `POST /K3API/Material/GetDetail` with `{ Data: { FNumber }, GetProperty: false }`
- harvests reference objects from the returned material detail into `_k3ReferenceObjects`, including the customer-observed `FUnitGroupID: { FName }` shape
- rejects missing keys, broad filters, cursor/watermark reads, and BOM reads
- keeps Save/Submit/Audit untouched and asserts no write endpoint is called during the smoke

## Scope Boundaries

Still not included: BOM read, list/search, pagination, broad filters, master-code resolver, server-side pipeline composition, Save/Submit/Audit, or any migration/API route change.

## Verification

- `git diff --check origin/main...HEAD`
- `pnpm -F plugin-integration-core test:k3-wise-adapters`
- `pnpm -F plugin-integration-core test`
- `pnpm verify:integration-k3wise:poc`

Docs added:

- `docs/development/integration-k3wise-material-detail-read-smoke-design-20260526.md`
- `docs/development/integration-k3wise-material-detail-read-smoke-verification-20260526.md`

Fixture is redacted and contains no real K3 host/token/password/material/account values.
