### PR TITLE
ci(attendance): run integration gate against postgres

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -148,7 +148,7 @@ jobs:
       - name: Run DB migrations
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts
         run: |
           pnpm --filter @metasheet/core-backend db:migrate
 
@@ -217,9 +217,13 @@ jobs:
         run: |
           pnpm --filter @metasheet/web build
 
-      - name: Run integration tests
+      - name: Run attendance integration tests
+        env:
+          DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
+          ATTENDANCE_TEST_DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
         run: |
-          pnpm --filter @metasheet/core-backend test:integration || true # Non-blocking
+          : "${DATABASE_URL:?DATABASE_URL is required for attendance integration}"
+          pnpm --filter @metasheet/core-backend test:integration:attendance
 
       - name: Upload test results
         if: always()
@@ -293,7 +297,7 @@ jobs:
       - name: Run DB migrations
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
-          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts,zzzz20260114110000_create_user_orgs_table.ts
+          MIGRATION_EXCLUDE: 008_plugin_infrastructure.sql,048_create_event_bus_tables.sql,049_create_bpmn_workflow_tables.sql,042a_core_model_views.sql,20250924120000_create_views_view_states.ts,20250924140000_create_gantt_tables.ts,20250925_create_view_tables.sql,20251117000001_add_snapshot_labels.ts,20251117000002_create_protection_rules.ts,20251201000001_create_change_management_tables.ts
         run: |
           pnpm --filter @metasheet/core-backend db:migrate
 


### PR DESCRIPTION
## Summary
- replace the non-blocking `plugin-tests.yml` integration step with a strict attendance integration gate
- pass `DATABASE_URL` / `ATTENDANCE_TEST_DATABASE_URL` into that gate so `attendance-plugin.test.ts` starts the real Express app instead of skipping
- stop excluding `zzzz20260114110000_create_user_orgs_table.ts` from the plugin test migrations because the attendance auto-absence test now needs `user_orgs`

## Notes
This intentionally targets the attendance suite instead of making the whole `tests/integration` directory blocking. A local full-directory real run still exposes unrelated historical failures outside attendance, so turning that entire command red would expand #1866 beyond the CI blind spot it was tracking.

Follow-up to #1866 and #1870.

## Verification
- `git diff --check`
- fresh PostgreSQL scratch DB + workflow migration exclude: `pnpm --filter @metasheet/core-backend test:integration:attendance` -> `78 passed`
- fresh PostgreSQL scratch DB + workflow migration exclude: `pnpm --filter @metasheet/core-backend test:integration:after-sales` -> `25 passed`
- diagnostic only: full `pnpm --filter @metasheet/core-backend test:integration` still has unrelated historical failures outside attendance, so it is not made blocking in this PR
