### PR TITLE
feat(multitable): formula dry-run frontend panel + structured diagnostics (#5b)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -751,6 +751,26 @@ export interface ViewAggregateResult {
   groups?: ViewAggregateGroup[]
 }
 
+// Formula dry-run (#5b, design #1869). Diagnostics carry structured context; the client localizes by
+// kind/code and NEVER renders `message` in the UI (message is debug/EN-only).
+export type DryRunDiagnosticKind = 'unknown_field' | 'unsupported' | 'runtime' | 'type_mismatch' | 'missing_sample'
+export interface DryRunDiagnostic {
+  severity: 'error' | 'warning' | 'info'
+  kind: DryRunDiagnosticKind
+  message: string
+  code?: string
+  fieldId?: string
+  expectedType?: string
+  actualType?: string
+}
+export interface DryRunResult {
+  success: boolean
+  result?: string | number | boolean | null
+  resultType?: 'number' | 'string' | 'boolean' | 'date' | 'null'
+  referencedFields: string[]
+  diagnostics: DryRunDiagnostic[]
+}
+
 export class MultitableApiClient {
   private fetch: FetchFn
   private readonly isZhOption?: ApiErrorLocaleOption
@@ -1037,6 +1057,18 @@ export class MultitableApiClient {
   async aggregateView(params: { sheetId: string; viewId?: string; search?: string }): Promise<ViewAggregateResult> {
     const { sheetId, ...rest } = params
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/view-aggregate${qs(rest as Record<string, string | undefined>)}`)
+    return this.parseJson(res)
+  }
+
+  // Formula dry-run (#5b): evaluate an UNSAVED expression against caller-supplied sample values.
+  // 200 (even on success:false runtime errors) → DryRunResult; 403/413/422 → MultitableApiError.
+  async dryRunFormula(params: { sheetId: string; expression: string; sampleValues: Record<string, unknown> }): Promise<DryRunResult> {
+    const { sheetId, expression, sampleValues } = params
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/formula/dry-run`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ expression, sampleValues }),
+    })
     return this.parseJson(res)
   }
 

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -173,6 +173,37 @@
               {{ diagnostic.message }}
             </div>
           </div>
+          <!-- #5b dry-run: evaluate the UNSAVED expression against sample data (server response only) -->
+          <div v-if="dryRunFn" class="meta-field-mgr__field meta-field-mgr__dryrun">
+            <div v-if="dryRunReferencedFields.length" class="meta-field-mgr__dryrun-samples">
+              <span>{{ ml('field.formulaDryRun.sampleHeading') }}</span>
+              <label v-for="f in dryRunReferencedFields" :key="f.id" class="meta-field-mgr__dryrun-sample">
+                <span class="meta-field-mgr__dryrun-sample-name">{{ f.name }}</span>
+                <input v-model="dryRunSamples[f.id]" :type="f.numeric ? 'number' : 'text'" class="meta-field-mgr__input" :placeholder="f.type" />
+              </label>
+              <div v-if="dryRunInvalidNumeric" class="meta-field-mgr__formula-diagnostic meta-field-mgr__formula-diagnostic--error">
+                {{ ml('field.formulaDryRun.invalidNumber') }}
+              </div>
+            </div>
+            <button type="button" class="meta-field-mgr__dryrun-btn" :disabled="!dryRunCanEvaluate" @click="runDryRun">
+              {{ dryRunRunning ? ml('field.formulaDryRun.evaluating') : ml('field.formulaDryRun.test') }}
+            </button>
+            <div v-if="dryRunTransportError" class="meta-field-mgr__dryrun-result meta-field-mgr__dryrun-result--error">{{ dryRunTransportError }}</div>
+            <div v-else-if="dryRunResult" class="meta-field-mgr__dryrun-result">
+              <div class="meta-field-mgr__dryrun-result-head">
+                <strong>{{ dryRunResult.success ? ml('field.formulaDryRun.resultHeading') : ml('field.formulaDryRun.errorHeading') }}</strong>
+                <code v-if="dryRunResult.success" class="meta-field-mgr__dryrun-value">{{ dryRunResultText }}</code>
+              </div>
+              <div
+                v-for="(d, i) in dryRunSortedDiagnostics"
+                :key="`${d.kind}-${d.code ?? ''}-${i}`"
+                class="meta-field-mgr__formula-diagnostic"
+                :class="`meta-field-mgr__formula-diagnostic--${d.severity}`"
+              >
+                <code v-if="d.code" class="meta-field-mgr__dryrun-tag">{{ d.code }}</code>{{ localizeDryRunDiag(d) }}
+              </div>
+            </div>
+          </div>
           <div class="meta-field-mgr__field">
             <span>{{ ml('field.insertFieldToken') }}</span>
             <div class="meta-field-mgr__chips">
@@ -396,10 +427,13 @@ import {
   getFormulaFunctionCategories,
   getFormulaFunctionCatalog,
   validateFormulaExpression,
+  extractFormulaFieldRefs,
   type FormulaFunctionCategory,
   type FormulaFunctionDoc,
   type FormulaDiagnostic,
 } from '../utils/formula-docs'
+import { localizeDryRunDiagnostic } from '../utils/meta-formula-labels'
+import type { DryRunResult, DryRunDiagnostic } from '../api/client'
 import {
   normalizeStringArray,
   resolveAutoNumberFieldProperty,
@@ -538,6 +572,9 @@ const props = defineProps<{
   fields: MetaField[]
   sheets: MetaSheet[]
   sheetId: string
+  // #5b: formula dry-run callback (the workbench wires it to client.dryRunFormula). Optional so the
+  // panel degrades gracefully (button hidden) where no fn is provided.
+  dryRunFn?: (params: { sheetId: string; expression: string; sampleValues: Record<string, unknown> }) => Promise<DryRunResult>
 }>()
 
 const emit = defineEmits<{
@@ -644,6 +681,104 @@ const configTargetType = computed(() => {
   if (configTarget.value) return configDraftType.value
   return newFieldConfigVisible.value && requiresConfig(newFieldType.value) ? newFieldType.value : null
 })
+
+// ---- #5b formula dry-run (C1–C4 per design #1869) ----
+const DRY_RUN_NUMERIC_TYPES = new Set(['number', 'currency', 'percent', 'rating', 'autoNumber'])
+const dryRunSamples = reactive<Record<string, string>>({})
+const dryRunResult = ref<DryRunResult | null>(null)
+const dryRunRunning = ref(false)
+const dryRunTransportError = ref<string | null>(null)
+let dryRunSeq = 0
+// C1: dry-run state is EPHEMERAL — cleared whenever the field config resets (close/reopen), so a
+// reopened formula field never pre-fills last time's sample values (and missing_sample still fires).
+function resetDryRunState() {
+  for (const key of Object.keys(dryRunSamples)) delete dryRunSamples[key]
+  dryRunResult.value = null
+  dryRunTransportError.value = null
+  dryRunRunning.value = false
+  dryRunSeq++
+}
+// C1: referenced fields come from the EXISTING extractFormulaFieldRefs (no mirror helper → no drift)
+const dryRunReferencedFields = computed(() => {
+  if (configTargetType.value !== 'formula') return []
+  // INTERSECT with formulaSourceFields — unknown {fld} refs are owned by the static diagnostics
+  // (which error and disable Evaluate), so they don't get confusing sample rows here.
+  return extractFormulaFieldRefs(formulaDraft.expression)
+    .map((id) => formulaSourceFields.value.find((f) => f.id === id))
+    .filter((field): field is NonNullable<typeof field> => Boolean(field))
+    .map((field) => ({ id: field.id, name: field.name, type: field.type, numeric: DRY_RUN_NUMERIC_TYPES.has(field.type) }))
+})
+const dryRunInvalidNumeric = computed(() =>
+  dryRunReferencedFields.value.some((f) => {
+    const raw = dryRunSamples[f.id]
+    const s = raw == null ? '' : String(raw) // type="number" v-model can yield a number, not a string
+    return f.numeric && s.trim() !== '' && Number.isNaN(Number(s))
+  }),
+)
+const dryRunHasStaticError = computed(() => formulaDiagnostics.value.some((d) => d.severity === 'error'))
+// C2: Evaluate enabled iff non-empty + no static error + no invalid numeric input + not running + fn wired
+const dryRunCanEvaluate = computed(() =>
+  Boolean(props.dryRunFn) &&
+  formulaDraft.expression.trim().length > 0 &&
+  !dryRunHasStaticError.value &&
+  !dryRunInvalidNumeric.value &&
+  !dryRunRunning.value,
+)
+// C3: diagnostics sorted error > warning > info
+const dryRunSortedDiagnostics = computed<DryRunDiagnostic[]>(() => {
+  const order: Record<string, number> = { error: 0, warning: 1, info: 2 }
+  return [...(dryRunResult.value?.diagnostics ?? [])].sort((a, b) => order[a.severity] - order[b.severity])
+})
+const dryRunResultText = computed(() => {
+  const r = dryRunResult.value
+  if (!r || !r.success || r.result === null || r.result === undefined) return ''
+  return String(r.result)
+})
+function localizeDryRunDiag(diagnostic: DryRunDiagnostic): string {
+  return localizeDryRunDiagnostic(diagnostic, isZh.value) // NEVER renders diagnostic.message
+}
+// C1 serialization: omit empty (→ server missing_sample), Number() for numeric, boolean for checkbox, else string
+function buildDryRunSampleValues(): Record<string, unknown> {
+  const out: Record<string, unknown> = {}
+  for (const f of dryRunReferencedFields.value) {
+    const raw = dryRunSamples[f.id]
+    const s = raw == null ? '' : String(raw)
+    if (s.trim() === '') continue // omit empty → server missing_sample
+    if (f.numeric) out[f.id] = Number(s)
+    else if (f.type === 'boolean') out[f.id] = s === 'true'
+    else out[f.id] = s
+  }
+  return out
+}
+async function runDryRun() {
+  if (!props.dryRunFn || !dryRunCanEvaluate.value) return
+  const seq = ++dryRunSeq
+  dryRunRunning.value = true
+  dryRunTransportError.value = null
+  try {
+    const res = await props.dryRunFn({ sheetId: props.sheetId, expression: formulaDraft.expression, sampleValues: buildDryRunSampleValues() })
+    if (seq !== dryRunSeq) return // stale response superseded
+    dryRunResult.value = res
+  } catch (err) {
+    if (seq !== dryRunSeq) return
+    dryRunResult.value = null
+    const status = (err as { status?: number }).status
+    if (status === 403) dryRunTransportError.value = ml('field.formulaDryRun.forbidden')
+    else if (status === 413 || status === 422) dryRunTransportError.value = ml('field.formulaDryRun.tooLarge')
+    else dryRunTransportError.value = ml('field.formulaDryRun.requestFailed')
+  } finally {
+    if (seq === dryRunSeq) dryRunRunning.value = false
+  }
+}
+// C2: result describes the current expression; any edit clears it + invalidates an in-flight response.
+// Also clear `running` — otherwise a superseded request's `finally` skips the reset (seq !== dryRunSeq)
+// and the Evaluate button would stay disabled for the new expression.
+watch(() => formulaDraft.expression, () => {
+  dryRunResult.value = null
+  dryRunTransportError.value = null
+  dryRunRunning.value = false
+  dryRunSeq++
+})
 const fieldConfigSchemaChanged = computed(() =>
   Boolean(configTarget.value && configDraftType.value && displayFieldType(configTarget.value) !== configDraftType.value),
 )
@@ -739,6 +874,7 @@ function resetDrafts() {
   formulaDraft.expression = ''
   formulaFunctionSearch.value = ''
   formulaFunctionCategory.value = 'all'
+  resetDryRunState()
   attachmentDraft.maxFiles = 1
   attachmentDraft.acceptedMimeTypesText = ''
   currencyDraft.code = 'CNY'

--- a/apps/web/src/multitable/utils/meta-formula-labels.ts
+++ b/apps/web/src/multitable/utils/meta-formula-labels.ts
@@ -155,6 +155,36 @@ export function formulaDiagnosticLabel(key: FormulaDiagnosticLabelKey, isZh: boo
   return pick(DIAGNOSTIC_LABELS[key], isZh)
 }
 
+// Dry-run (#5b) diagnostics: localized by `kind`, interpolating structured context (fieldId / types /
+// Excel-sentinel `code`, all language-neutral). The server `message` is NEVER rendered here.
+export type DryRunDiagnosticInput = {
+  kind: string
+  code?: string
+  fieldId?: string
+  expectedType?: string
+  actualType?: string
+}
+
+const DRY_RUN_DIAGNOSTIC_LABELS: Record<string, LocaleText> = {
+  unknown_field: { en: 'Unknown field reference: {fieldId}', zh: '未知字段引用：{fieldId}' },
+  unsupported: { en: 'Cell/range references (e.g. A1, A1:B3) are not supported in dry-run.', zh: '试算暂不支持单元格/区域引用（如 A1、A1:B3）。' },
+  runtime: { en: 'Formula evaluated to an error: {code}', zh: '公式计算出错：{code}' },
+  type_mismatch: { en: 'Sample for {fieldId} is {actualType}, but the field type is {expectedType}.', zh: '{fieldId} 的示例值类型为 {actualType}，但字段类型为 {expectedType}。' },
+  missing_sample: { en: 'No sample value for {fieldId}; treated as empty.', zh: '{fieldId} 未提供示例值，按空值处理。' },
+}
+
+export function localizeDryRunDiagnostic(diagnostic: DryRunDiagnosticInput, isZh: boolean): string {
+  const tpl = DRY_RUN_DIAGNOSTIC_LABELS[diagnostic.kind]
+  // Unknown future kind → localized generic fallback showing only the raw kind token (language-neutral).
+  // NEVER fall back to the server `message` (would leak English into the localized UI — strict-zero).
+  if (!tpl) return isZh ? `诊断：${diagnostic.kind}` : `Diagnostic: ${diagnostic.kind}`
+  return pick(tpl, isZh)
+    .replace('{fieldId}', diagnostic.fieldId ?? '')
+    .replace('{code}', diagnostic.code ?? '')
+    .replace('{actualType}', diagnostic.actualType ?? '')
+    .replace('{expectedType}', diagnostic.expectedType ?? '')
+}
+
 export function formulaEmptyArgument(functionName: string, isZh: boolean): string {
   return isZh
     ? `${functionName} 存在空参数。`

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -28,6 +28,9 @@ export type MetaManagerLabelKey =
   | 'field.optionalOverride' | 'field.aggregation'
   | 'field.expression' | 'field.insertFieldToken'
   | 'field.formulaReference' | 'field.formulaSearchPlaceholder'
+  | 'field.formulaDryRun.test' | 'field.formulaDryRun.sampleHeading' | 'field.formulaDryRun.evaluating'
+  | 'field.formulaDryRun.resultHeading' | 'field.formulaDryRun.errorHeading' | 'field.formulaDryRun.invalidNumber'
+  | 'field.formulaDryRun.forbidden' | 'field.formulaDryRun.tooLarge' | 'field.formulaDryRun.requestFailed'
   | 'field.allCategories' | 'field.noMatchingFunctions'
   | 'field.maxFiles' | 'field.acceptedMimeTypes'
   | 'field.decimals' | 'field.preserve' | 'field.unit'
@@ -155,6 +158,15 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'field.expression': { en: 'Expression', zh: '表达式' },
   'field.insertFieldToken': { en: 'Insert field token', zh: '插入字段令牌' },
   'field.formulaReference': { en: 'Formula reference', zh: '公式参考' },
+  'field.formulaDryRun.test': { en: 'Test with sample data', zh: '用示例数据试算' },
+  'field.formulaDryRun.sampleHeading': { en: 'Sample values', zh: '示例值' },
+  'field.formulaDryRun.evaluating': { en: 'Evaluating…', zh: '试算中…' },
+  'field.formulaDryRun.resultHeading': { en: 'Result', zh: '结果' },
+  'field.formulaDryRun.errorHeading': { en: 'Could not evaluate', zh: '无法计算' },
+  'field.formulaDryRun.invalidNumber': { en: 'Enter a valid number', zh: '请输入有效数字' },
+  'field.formulaDryRun.forbidden': { en: 'You cannot manage fields on this sheet', zh: '你没有管理该表字段的权限' },
+  'field.formulaDryRun.tooLarge': { en: 'Expression is too large or complex to test', zh: '表达式过大或过于复杂，无法试算' },
+  'field.formulaDryRun.requestFailed': { en: 'Dry-run request failed', zh: '试算请求失败' },
   'field.formulaSearchPlaceholder': { en: 'Search SUM, IF, %, ^, &...', zh: '搜索 SUM、IF、%、^、&...' },
   'field.allCategories': { en: 'All categories', zh: '全部分类' },
   'field.noMatchingFunctions': { en: 'No matching functions.', zh: '没有匹配的函数。' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -351,6 +351,7 @@
     />
     <MetaFieldManager
       :visible="showFieldManager" :fields="propertyVisibleWorkbenchFields" :sheets="workbench.sheets.value" :sheet-id="workbench.activeSheetId.value"
+      :dry-run-fn="dryRunFormulaFn"
       @update:dirty="fieldManagerDirty = $event"
       @close="showFieldManager = false" @create-field="onCreateField" @update-field="onUpdateField" @delete-field="onDeleteField"
     />
@@ -1755,6 +1756,9 @@ function onSetFrozen(frozenLeftColumnIds: string[]) {
 const aggregateValues = ref<Record<string, { fn: string; value: number }>>({})
 const aggregateTooLarge = ref(false)
 const aggregateGroups = ref<import('../api/client').ViewAggregateGroup[]>([]) // #4-3b-2a server per-group subtotals
+// #5b: formula dry-run passthrough to the API client (MetaFieldManager is emit-based, so it takes a fn prop)
+const dryRunFormulaFn = (params: { sheetId: string; expression: string; sampleValues: Record<string, unknown> }) =>
+  workbench.client.dryRunFormula(params)
 const activeAggregationConfig = computed<Record<string, string>>(() => {
   const raw = workbench.activeView.value?.config?.aggregations
   if (!raw || typeof raw !== 'object' || Array.isArray(raw)) return {}

--- a/apps/web/tests/multitable-formula-dryrun-panel.spec.ts
+++ b/apps/web/tests/multitable-formula-dryrun-panel.spec.ts
@@ -1,0 +1,156 @@
+import { createApp, h, nextTick } from 'vue'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { useLocale } from '../src/composables/useLocale'
+import MetaFieldManager from '../src/multitable/components/MetaFieldManager.vue'
+import type { DryRunResult } from '../src/multitable/api/client'
+import { localizeDryRunDiagnostic } from '../src/multitable/utils/meta-formula-labels'
+
+// Drives MetaFieldManager into formula-config state and exposes the dry-run panel (#5b).
+async function mountFormulaConfig(
+  dryRunFn: (p: { sheetId: string; expression: string; sampleValues: Record<string, unknown> }) => Promise<DryRunResult>,
+  extraFields: Array<{ id: string; name: string; type: string }> = [],
+) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({
+    render() {
+      return h(MetaFieldManager, {
+        visible: true,
+        sheetId: 'sheet_1',
+        sheets: [],
+        // formula field kept LAST so the last Configure button always targets it
+        fields: [
+          { id: 'fld_price', name: 'Price', type: 'number' },
+          ...extraFields,
+          { id: 'fld_total', name: 'Total', type: 'formula', property: { expression: '' } },
+        ],
+        dryRunFn,
+      })
+    },
+  })
+  app.mount(container)
+  await nextTick()
+  const configs = Array.from(container.querySelectorAll('.meta-field-mgr__action[title="Configure"]')) as HTMLButtonElement[]
+  configs[configs.length - 1]?.click() // the formula field
+  await nextTick()
+  return { container, app }
+}
+
+async function setExpression(container: HTMLElement, expr: string) {
+  const ta = container.querySelector('.meta-field-mgr__textarea') as HTMLTextAreaElement
+  ta.value = expr
+  ta.dispatchEvent(new Event('input'))
+  await nextTick()
+}
+async function setSample(container: HTMLElement, value: string) {
+  const input = container.querySelector('.meta-field-mgr__dryrun-sample input') as HTMLInputElement
+  input.value = value
+  input.dispatchEvent(new Event('input'))
+  await nextTick()
+}
+const clickEvaluate = (c: HTMLElement) => (c.querySelector('.meta-field-mgr__dryrun-btn') as HTMLButtonElement).click()
+async function flush() { for (let i = 0; i < 6; i++) { await Promise.resolve(); await nextTick() } }
+
+afterEach(() => { useLocale().setLocale('en'); document.body.innerHTML = '' ; vi.restoreAllMocks() })
+
+describe('MetaFieldManager formula dry-run panel (#5b)', () => {
+  it('renders LOCALIZED diagnostics, never the raw server message (strict-zero)', async () => {
+    const fn = vi.fn().mockResolvedValue({
+      success: true, result: 43, resultType: 'number', referencedFields: ['fld_price'],
+      diagnostics: [{ severity: 'warning', kind: 'type_mismatch', fieldId: 'fld_price', expectedType: 'number', actualType: 'string', message: 'RAW_SERVER_MESSAGE_DO_NOT_SHOW' }],
+    } satisfies DryRunResult)
+    const { container } = await mountFormulaConfig(fn)
+    await setExpression(container, '={fld_price}+1')
+    clickEvaluate(container)
+    await flush()
+    const zone = container.querySelector('.meta-field-mgr__dryrun-result') as HTMLElement
+    expect(zone).not.toBeNull()
+    expect(zone.textContent).toContain('43') // success value
+    expect(zone.textContent).toContain('fld_price') // localized template interpolates structured context
+    expect(zone.textContent).not.toContain('RAW_SERVER_MESSAGE_DO_NOT_SHOW') // never the server message
+  })
+
+  it('serializes a numeric sample as a NUMBER and a text sample as a STRING (both branches)', async () => {
+    const fn = vi.fn().mockResolvedValue({ success: true, result: 0, resultType: 'number', referencedFields: ['fld_name', 'fld_price'], diagnostics: [] } satisfies DryRunResult)
+    const { container } = await mountFormulaConfig(fn, [{ id: 'fld_name', name: 'Name', type: 'string' }])
+    await setExpression(container, '=CONCAT({fld_name}, {fld_price})') // refs both; input order = name, price
+    const inputs = Array.from(container.querySelectorAll('.meta-field-mgr__dryrun-sample input')) as HTMLInputElement[]
+    inputs[0].value = 'hello'; inputs[0].dispatchEvent(new Event('input')) // fld_name (string)
+    inputs[1].value = '3.5'; inputs[1].dispatchEvent(new Event('input')) // fld_price (number)
+    await nextTick()
+    clickEvaluate(container)
+    await nextTick()
+    const payload = fn.mock.calls[0][0].sampleValues
+    expect(payload.fld_price).toBe(3.5) // number (not "3.5")
+    expect(payload.fld_name).toBe('hello') // string (not coerced)
+    expect(typeof payload.fld_name).toBe('string')
+  })
+
+  it('drops a STALE response when the expression changed mid-flight', async () => {
+    let resolveFn!: (r: DryRunResult) => void
+    const fn = vi.fn().mockReturnValue(new Promise<DryRunResult>((r) => { resolveFn = r }))
+    const { container } = await mountFormulaConfig(fn)
+    await setExpression(container, '={fld_price}+1')
+    clickEvaluate(container) // seq 1, pending
+    await nextTick()
+    await setExpression(container, '={fld_price}+2') // expression edit → clears result + bumps seq + clears running
+    resolveFn({ success: true, result: 1, resultType: 'number', referencedFields: ['fld_price'], diagnostics: [] }) // stale resolve
+    await flush()
+    expect(container.querySelector('.meta-field-mgr__dryrun-result')).toBeNull() // stale response NOT shown
+    // and the panel must RECOVER: button re-enabled, a second Evaluate fires
+    const btn = container.querySelector('.meta-field-mgr__dryrun-btn') as HTMLButtonElement
+    expect(btn.disabled).toBe(false)
+    clickEvaluate(container)
+    await nextTick()
+    expect(fn).toHaveBeenCalledTimes(2)
+  })
+
+  it('serializes a boolean sample as true/false, not "true"', async () => {
+    const fn = vi.fn().mockResolvedValue({ success: true, result: 1, resultType: 'number', referencedFields: ['fld_flag'], diagnostics: [] } satisfies DryRunResult)
+    const { container } = await mountFormulaConfig(fn, [{ id: 'fld_flag', name: 'Flag', type: 'boolean' }])
+    await setExpression(container, '=IF({fld_flag}, 1, 0)')
+    await setSample(container, 'true') // single referenced field → first input
+    clickEvaluate(container)
+    await nextTick()
+    expect(fn.mock.calls[0][0].sampleValues).toEqual({ fld_flag: true }) // boolean, not the string "true"
+  })
+
+  it('a dry-run runtime error does NOT disable Save (dry-run is informational only)', async () => {
+    const fn = vi.fn().mockResolvedValue({
+      success: false, result: '#DIV/0!', referencedFields: ['fld_price'],
+      diagnostics: [{ severity: 'error', kind: 'runtime', code: '#DIV/0!', message: 'x' }],
+    } satisfies DryRunResult)
+    const { container } = await mountFormulaConfig(fn)
+    await setExpression(container, '={fld_price}/0') // syntactically valid
+    clickEvaluate(container)
+    await flush()
+    const saveBtn = (Array.from(container.querySelectorAll('.meta-field-mgr__btn-add')) as HTMLButtonElement[])
+      .find((b) => b.textContent?.includes('Save field settings'))
+    expect(saveBtn).toBeTruthy()
+    expect(saveBtn!.disabled).toBe(false) // dry-run error must not gate save
+  })
+
+  it('clears sample values on reopen — they are ephemeral (C1)', async () => {
+    const fn = vi.fn().mockResolvedValue({ success: true, result: 0, resultType: 'number', referencedFields: ['fld_price'], diagnostics: [] } satisfies DryRunResult)
+    const { container } = await mountFormulaConfig(fn)
+    await setExpression(container, '={fld_price}+1')
+    await setSample(container, '99')
+    expect((container.querySelector('.meta-field-mgr__dryrun-sample input') as HTMLInputElement).value).toBe('99')
+    // reopen the formula field's config → resetDrafts() clears the ephemeral dry-run state
+    const configs = Array.from(container.querySelectorAll('.meta-field-mgr__action[title="Configure"]')) as HTMLButtonElement[]
+    configs[configs.length - 1].click()
+    await nextTick()
+    await setExpression(container, '={fld_price}+1') // expression reloads empty on reopen; re-enter it
+    const input = container.querySelector('.meta-field-mgr__dryrun-sample input') as HTMLInputElement
+    expect(input.value).toBe('') // NOT the stale '99'
+  })
+
+  it('localizer never returns the server message, even for an unknown future kind', () => {
+    const known = localizeDryRunDiagnostic({ kind: 'unknown_field', fieldId: 'fld_x' }, false)
+    expect(known).toContain('fld_x')
+    // a kind the client doesn't know → localized generic fallback (raw kind token), NEVER the message
+    const future = localizeDryRunDiagnostic({ kind: 'some_future_kind' }, true)
+    expect(future).toContain('some_future_kind')
+    expect(future).toBe('诊断：some_future_kind')
+  })
+})

--- a/docs/development/multitable-formula-dryrun-5b-verification-20260526.md
+++ b/docs/development/multitable-formula-dryrun-5b-verification-20260526.md
@@ -1,0 +1,39 @@
+# Multitable Formula Dry-Run #5b — Frontend Panel Verification (2026-05-26)
+
+Implements the locked design `docs/development/multitable-formula-dryrun-5b-design-20260526.md` (#1869), i18n decision **(a) structured context** (user-confirmed). benchmark v2 §9 #5b. Backend step-0 (structured context) → frontend panel.
+
+> K3: multitable kernel-polish (the multitable wrapper + `apps/web/multitable` + 2 existing label modules). Shared formula core untouched. K3 yields.
+
+---
+
+## 1. What shipped
+
+**Backend step-0** (`multitable/formula-engine.ts`, additive — shared core untouched):
+- `DryRunDiagnostic` gains structured context: `fieldId?`, `expectedType?`, `actualType?`. Populated for `unknown_field` (fieldId), `missing_sample` (fieldId), `type_mismatch` (fieldId/expectedType/actualType). `message` is now explicitly English-for-logs-only.
+
+**Frontend** (`apps/web/src/multitable`):
+- `client.dryRunFormula({ sheetId, expression, sampleValues })` → `DryRunResult` (mirrors `aggregateView`; `DryRunResult`/`DryRunDiagnostic` types).
+- `meta-formula-labels.ts` — `localizeDryRunDiagnostic(diagnostic, isZh)`: localized templates per `kind` (+ `code` sentinel passthrough), interpolating structured context; **NEVER renders `message`**; unknown `kind` → localized generic fallback (raw `kind` token).
+- `meta-manager-labels.ts` — `field.formulaDryRun.*` panel chrome (button/headings/error labels), EN+ZH.
+- `MetaFieldManager.vue` — the dry-run panel in the formula config block (gated on a `dryRunFn` prop, wired by the workbench to `client.dryRunFormula`).
+
+## 2. The 4 contracts (design #1869) — as built
+
+| contract | implementation |
+|---|---|
+| **C1** sample defaults + serialization | inputs from the **existing `extractFormulaFieldRefs`, INTERSECTED with `formulaSourceFields`** (unknown refs are owned by the static diagnostics, no confusing sample rows); one type-appropriate input per ref, empty + type-hint placeholder; payload **omits empty** (→ `missing_sample`), `Number(value)` for numeric (string-coercion-safe; `type="number"` v-model can yield a number), **`boolean`→true/false**, else string; **invalid numeric input disables Evaluate** with a local hint. **Ephemeral:** `resetDryRunState()` (in `resetDrafts`) clears samples + result on close/reopen, so a reopened field never pre-fills last time's values. |
+| **C2** trigger | explicit **Evaluate button only**; enabled iff non-empty + no static error + no invalid-numeric + not running + fn wired; `dryRunSeq` monotonic guard; **expression edit clears the result, invalidates in-flight, AND clears `running`** (so a superseded request can't leave the button stuck disabled). |
+| **C3** diagnostic priority | **separate dry-run result zone** (distinct from the static-diagnostics list); success → value + diagnostics, failure → error heading + sentinel `code` tag; Zone B sorted **error > warning > info**. |
+| **C4** layering | dry-run is **purely informational**; `fieldConfigBlockingReason` / save untouched — a `runtime`/`type_mismatch` does **not** block save. |
+| i18n | localize by `kind`/`code`; client **never** renders the server `message` (strict-zero). |
+
+## 3. Verification
+
+- **Backend unit (no DB): `tests/unit/formula-dryrun.test.ts` 9/9** — incl. **structured-field assertions** (`unknown_field.fieldId`, `missing_sample.fieldId`, `type_mismatch.fieldId/.expectedType/.actualType`) + the no-DB spy = 0.
+- **Backend integration (CI real-DB): `multitable-formula-dryrun.test.ts`** — +1 case asserting `type_mismatch` carries `fieldId/expectedType/actualType` over the wire; unknown-field asserts `fieldId`. (Mechanizes the i18n contract per design §5.)
+- **Frontend: `tests/multitable-formula-dryrun-panel.spec.ts` 7/7** — (1) localized diagnostics, **never the raw server message**; (2) **both serialization branches** — numeric `3.5`→Number, text `'hello'`→string; (3) **stale response dropped AND the button recovers** (re-enabled + second Evaluate fires); (4) **dry-run error does NOT disable Save**; (5) **boolean sample → `true`/`false`, not `"true"`**; (6) **sample values cleared on reopen** (ephemeral, C1); (7) localizer unknown-kind fallback never returns `message`.
+- Backend `tsc` + frontend `vue-tsc` clean; existing formula-editor + field-manager specs green (no regression).
+
+## 4. Deferred (unchanged)
+- **#5c** evaluate against a real record — demand-gated (D3c surface).
+- Sample-value persistence — deferred (data-shape question, no signal).

--- a/packages/core-backend/src/multitable/formula-engine.ts
+++ b/packages/core-backend/src/multitable/formula-engine.ts
@@ -19,8 +19,12 @@ export type DryRunDiagnosticKind = 'unknown_field' | 'unsupported' | 'runtime' |
 export interface DryRunDiagnostic {
   severity: 'error' | 'warning' | 'info'
   kind: DryRunDiagnosticKind
-  message: string
+  message: string // English; for logs/debug only — the client localizes by kind/code (design #1869 §3a)
   code?: string
+  // Structured context so the client can render fully-localized templates without parsing `message`.
+  fieldId?: string
+  expectedType?: string
+  actualType?: string
 }
 export interface DryRunResult {
   success: boolean
@@ -137,7 +141,7 @@ export class MultitableFormulaEngine {
     const fieldById = new Map(fields.map((f) => [f.id, f.type]))
     for (const ref of referencedFields) {
       if (!fieldById.has(ref)) {
-        diagnostics.push({ severity: 'error', kind: 'unknown_field', message: `Unknown field reference: {${ref}}` })
+        diagnostics.push({ severity: 'error', kind: 'unknown_field', fieldId: ref, message: `Unknown field reference: {${ref}}` })
       }
     }
     // Gate (b): A1/cell/range references are unsupported (would reach the DB).
@@ -152,13 +156,13 @@ export class MultitableFormulaEngine {
     // Non-blocking advisories: type mismatch + missing sample (no silent coercion).
     for (const ref of referencedFields) {
       if (!(ref in sampleValues)) {
-        diagnostics.push({ severity: 'info', kind: 'missing_sample', message: `No sample value for {${ref}}; treated as empty` })
+        diagnostics.push({ severity: 'info', kind: 'missing_sample', fieldId: ref, message: `No sample value for {${ref}}; treated as empty` })
         continue
       }
       const declared = fieldById.get(ref)!
       const v = sampleValues[ref]
       if (NUMERIC_FIELD_TYPES.has(declared) && v !== null && v !== undefined && typeof v !== 'number') {
-        diagnostics.push({ severity: 'warning', kind: 'type_mismatch', message: `Sample for {${ref}} is ${typeof v}, but the field type is ${declared}` })
+        diagnostics.push({ severity: 'warning', kind: 'type_mismatch', fieldId: ref, expectedType: declared, actualType: typeof v, message: `Sample for {${ref}} is ${typeof v}, but the field type is ${declared}` })
       }
     }
 

--- a/packages/core-backend/tests/integration/multitable-formula-dryrun.test.ts
+++ b/packages/core-backend/tests/integration/multitable-formula-dryrun.test.ts
@@ -59,7 +59,17 @@ describeIfDatabase('multitable formula dry-run (real DB)', () => {
     expect(res.status).toBe(200)
     expect(res.body.data.success).toBe(false)
     expect(res.body.data.result).toBeUndefined()
-    expect(res.body.data.diagnostics.some((d: { kind: string }) => d.kind === 'unknown_field')).toBe(true)
+    const unknown = res.body.data.diagnostics.find((d: { kind: string }) => d.kind === 'unknown_field')
+    expect(unknown).toBeDefined()
+    expect(unknown.fieldId).toBe(`fld_missing_${TS}`) // structured context survives the wire (i18n contract)
+  })
+
+  test('type mismatch carries structured context over the wire', async () => {
+    testPerms = ['multitable:write']
+    const res = await post({ expression: `={${FLD_A}}+1`, sampleValues: { [FLD_A]: 'x' } }) // string for a number field
+    expect(res.status).toBe(200)
+    const mismatch = res.body.data.diagnostics.find((d: { kind: string }) => d.kind === 'type_mismatch')
+    expect(mismatch).toMatchObject({ fieldId: FLD_A, expectedType: 'number', actualType: 'string' })
   })
 
   test('capability gate: read-only user (no multitable:write) → 403', async () => {

--- a/packages/core-backend/tests/unit/formula-dryrun.test.ts
+++ b/packages/core-backend/tests/unit/formula-dryrun.test.ts
@@ -58,7 +58,7 @@ describe('MultitableFormulaEngine.dryRun', () => {
     const r = await noDb.dryRun('={fld_missing}+1', { fld_missing: 9 }, FIELDS)
     expect(r.success).toBe(false)
     expect(r.result).toBeUndefined() // never evaluated → no false-green
-    expect(r.diagnostics).toContainEqual(expect.objectContaining({ kind: 'unknown_field', severity: 'error' }))
+    expect(r.diagnostics).toContainEqual(expect.objectContaining({ kind: 'unknown_field', severity: 'error', fieldId: 'fld_missing' }))
   })
 
   it('GATE: A1/range reference → unsupported error, NOT evaluated', async () => {
@@ -70,13 +70,13 @@ describe('MultitableFormulaEngine.dryRun', () => {
 
   it('type mismatch → warning, but still evaluates (no silent coercion)', async () => {
     const r = await noDb.dryRun('={fld_a}+1', { fld_a: '3' }, FIELDS) // string for a number field
-    expect(r.diagnostics).toContainEqual(expect.objectContaining({ kind: 'type_mismatch', severity: 'warning' }))
+    expect(r.diagnostics).toContainEqual(expect.objectContaining({ kind: 'type_mismatch', severity: 'warning', fieldId: 'fld_a', expectedType: 'number', actualType: 'string' }))
     expect(r.success).toBeDefined() // evaluation still proceeds
   })
 
   it('missing sample value → info diagnostic, treated as empty', async () => {
     const r = await noDb.dryRun('={fld_a}+{fld_b}', { fld_a: 1 }, FIELDS) // fld_b missing
-    expect(r.diagnostics).toContainEqual(expect.objectContaining({ kind: 'missing_sample', severity: 'info' }))
+    expect(r.diagnostics).toContainEqual(expect.objectContaining({ kind: 'missing_sample', severity: 'info', fieldId: 'fld_b' }))
     expect(r.success).toBe(true)
     expect(r.result).toBe(1) // fld_b → 0
   })


### PR DESCRIPTION
Implements the locked design #1869 (i18n decision **(a) structured context**, user-confirmed). benchmark v2 §9 **#5b** — backend step-0 (structured diagnostic context) + the dry-run panel in the formula field editor.

## Backend step-0 (additive — shared `formula/engine.ts` untouched)
- `DryRunDiagnostic` gains `fieldId?`/`expectedType?`/`actualType?` (populated for `unknown_field`/`missing_sample`/`type_mismatch`); `message` is now English-for-logs-only. Unit + real-DB tests **assert the structured fields** (mechanizes the i18n contract).

## Frontend (the 4 contracts)
- **C1** — sample inputs from the existing `extractFormulaFieldRefs` **intersected with `formulaSourceFields`** (unknown refs owned by static diagnostics); typed serialization (omit empty→`missing_sample`, `Number()` numeric, **`boolean`→true/false**, else string; invalid-numeric disables Evaluate). **Ephemeral:** `resetDryRunState()` clears samples + result on close/reopen.
- **C2** — explicit Evaluate button only; `reqSeq` guard; **expression edit clears result + invalidates in-flight + clears `running`** (no stuck-disabled button).
- **C3** — separate result zone, sorted error>warning>info, sentinel `code` tag.
- **C4** — dry-run **never touches the save gate** (informational only).
- **i18n** — `localizeDryRunDiagnostic` localizes by `kind`/`code`; **never renders the server `message`**; unknown kind → localized generic fallback. Labels in the 2 existing modules.
- `client.dryRunFormula` mirrors `aggregateView`; wired into `MetaFieldManager` via a `dryRunFn` prop (emit-based component).

## Tests
- backend unit **9/9** (structured fields + no-DB spy=0) + real-DB (structured-wire assertions; added to `plugin-tests.yml` step in #5a).
- frontend **7/7**: no-message-render, both serialization branches (number+string), boolean→true, **stale-drop + button recovery**, **save-gate unaffected**, **ephemeral reset on reopen**, unknown-kind fallback.
- `tsc` + `vue-tsc` clean; existing formula-editor + field-manager specs green.

Reviewer findings across rounds (DB-access framing earlier in #5a; here: stale-running, boolean type, intersect, sample reset) all folded.

## Scope
Multitable kernel-polish; shared formula core / attendance / rbac / integration-core untouched. **K3 yields.** #5c (real-record) demand-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)