### PR TITLE
fix(attendance): avoid admin preload on employee surface

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -16031,6 +16031,7 @@ async function exportPayrollCycleSummary() {
 }
 
 async function loadAdminData() {
+  if (!showAdmin.value) return
   try {
     await Promise.all([
       loadSettings(),
@@ -16083,7 +16084,9 @@ onMounted(() => {
       pluginsLoaded.value = true
       if (attendancePluginActive.value) {
         refreshAll()
-        loadAdminData()
+        if (showAdmin.value) {
+          loadAdminData()
+        }
       }
     })
     .catch(() => {
@@ -16094,7 +16097,9 @@ onMounted(() => {
 watch(orgId, () => {
   if (attendancePluginActive.value) {
     refreshAll()
-    loadAdminData()
+    if (showAdmin.value) {
+      loadAdminData()
+    }
   }
 })
 

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -516,6 +516,38 @@ describe('Attendance admin regressions', () => {
     container = null
   })
 
+  it('does not preload admin-only attendance data on the employee overview surface', async () => {
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    const requestedUrls = vi.mocked(apiFetch).mock.calls.map(call => String(call[0]))
+    const forbiddenAdminLoads = [
+      '/api/attendance-admin/',
+      '/api/attendance/settings',
+      '/api/attendance/rule-templates',
+      '/api/attendance/rule-sets',
+      '/api/attendance/groups',
+      '/api/attendance/import/batches',
+      '/api/attendance/report-fields',
+      '/api/attendance/overtime-rules',
+      '/api/attendance/payroll-templates',
+      '/api/attendance/leave-types',
+      '/api/attendance/approval-flows',
+      '/api/attendance/payroll-cycles',
+      '/api/attendance/advanced-scheduling/workbench',
+      '/api/attendance/shifts',
+      '/api/attendance/rotation-assignments',
+      '/api/attendance/assignments',
+      '/api/attendance/rotation-rules',
+    ]
+
+    expect(requestedUrls.length).toBeGreaterThan(0)
+    expect(
+      requestedUrls.filter(url => forbiddenAdminLoads.some(prefix => url.startsWith(prefix))),
+    ).toEqual([])
+  })
+
   it('keeps the clicked admin section focused and retires the show-all toggle', async () => {
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)


### PR DESCRIPTION
## Summary
- gate `loadAdminData()` so it only runs on the admin attendance surface
- stop the employee overview/reports shells from preloading admin-only attendance endpoints on mount or org changes
- add a regression test that the overview surface does not request `attendance-admin/*` or admin-only configuration endpoints

Fixes #1855

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vitest run tests/attendance-experience-entrypoints.spec.ts tests/attendance-selfservice-dashboard.spec.ts tests/attendance-reports-analytics.spec.ts --watch=false`
- `pnpm --filter @metasheet/web type-check`
- `git diff --check`
