### PR TITLE
docs(data-factory): 阶段二 execution plan + TODO checklist (gated; DF-N0..N4 + FaaS)

### DIFF
--- a/docs/development/data-factory-df-n2-task-checklist-20260526.md
+++ b/docs/development/data-factory-df-n2-task-checklist-20260526.md
@@ -1,0 +1,40 @@
+# Data Factory DF-N2 (Provenance) — task-level checklist (gated) - 2026-05-26
+
+> **图例:** 🔒 blocked-by-gate · ⬜ ready-when-unlocked · ✅ done
+> **Gated:** the whole chain touches `plugin-integration-core` → blocked behind **Gate 0** (K3 PoC GATE PASS + 阶段二 unlock) + a **separate per-PR opt-in**. Not passed today.
+> **Scope:** task/sub-PR-level expansion of the **DF-N2** row in `data-factory-stage2-execution-plan-20260526.md` (and its TODO). **Execution-planning only — NOT new design, NOT a build authorization.** ProvenanceEvent is already designed in #1839; this only breaks the phase into tasks. Preference (#1874): **JSONB on existing tables + a by-`rowId` view, NOT a new event table.**
+
+DF-N2 is the **recommended first move** on unlock day (lowest risk, zero new connector behavior, deepens the "对接成功/失败记录" goal to per-record-across-runs lineage).
+
+## DF-N2-1 — contracts 〔lane: contracts〕
+- [ ] 🔒 Define `ProvenanceEvent` TS type `{ runId, rowId, eventType, at, attrs }` (attrs = safe fields / presence flags only)
+- [ ] 🔒 11 event-type enum: `source_read` / `row_imported` / `row_edited` / `mapping_applied` / `validation_failed` / `dry_run_previewed` / `target_write_attempted` / `target_write_succeeded` / `target_write_failed` / `row_retried` / `row_exported`
+- [ ] 🔒 Redaction contract: allow presence flags + safe ids; forbid token / password / connection-string / customer secret
+- [ ] 🔒 OpenAPI component: `ProvenanceEvent` + the by-`rowId` query response schema
+- [ ] 🔒 Tests: OpenAPI↔TS parity · invalid `eventType` rejected · redaction unit (attrs carrying a token → stripped)
+- ▸ Exit: contract frozen, zero runtime change
+
+## DF-N2-2 — runtime + migration 〔lane: runtime〕
+- [ ] 🔒 Pick storage: a JSONB lineage column on the existing run / `integration_run_log` surface, events tagged by `rowId` — **no new write-path table**
+- [ ] 🔒 Plugin SQL migration (integration-core's own SQL, guarded by `migration-sql.test.cjs`): add the JSONB column + an `integration_provenance_by_row` **view** (unnest across runs, join `integration_dead_letters` / `integration_exceptions`)
+- [ ] 🔒 Wire `lib/pipeline-runner.cjs` to append a **redacted** event at each lifecycle point (reuse `sanitizeIntegrationPayload`)
+- [ ] 🔒 Capacity guard: per-row event count / size cap (mirror the `targetWriteSummaries` cap-50 discipline)
+- [ ] 🔒 Back-compat: existing runs have no events → the view tolerates empty/null
+- [ ] 🔒 Tests: redaction (stored events carry no sensitive field) · correct event appended per step · **by-`rowId` cross-run timeline** (seed 2 runs for the same rowId, assert ordered) · **real-wire round-trip** (the lineage field survives real API serialization — wire-vs-fixture guard) · `migration-sql.test.cjs` green · replay does not wrongly duplicate events
+- ▸ Exit: per-record events queryable across runs, redacted
+
+## DF-N2-3 — frontend 〔lane: frontend〕
+- [ ] 🔒 `apps/web/src/services/integration/workbench.ts`: read-only types + by-`rowId` provenance read (client over the new GET route)
+- [ ] 🔒 `IntegrationWorkbenchView`: per-row **lineage timeline** expandable (reuse the DF-N1 expand pattern + stable `data-testid`)
+- [ ] 🔒 Render the event timeline (eventType + timestamp + safe summary), read-only, no secret
+- [ ] 🔒 Tests: timeline renders · **no replay / no write affordance** (read-only lock, mirrors DF-N1) · no secret shown · empty state (row with no lineage)
+- ▸ Exit: per-row end-to-end history visible read-only in 运行监控
+
+## Chain discipline (DF-N2 as a 3-lane mini-chain)
+- [ ] 🔒 Order: N2-1 contracts → N2-2 runtime (depends on the contract) → N2-3 frontend (depends on the read route); **each a separate opt-in**
+- [ ] 🔒 New GET by-`rowId` route: OpenAPI parity + RBAC read permission
+- [ ] 🔒 Whole chain touches integration-core → stays behind **Gate 0** (K3 unlock)
+
+## See also
+- `data-factory-stage2-execution-plan-20260526.md` (this expands its DF-N2 row) · `data-factory-stage2-todo-20260526.md`.
+- #1839 (ProvenanceEvent design + DF-N0..N4 phasing) · #1838 + addendum #1874 (JSONB-on-existing-tables preference) · #1848 (DF-N1 read-only monitoring this builds on) · #1857 (DF-N1.5 replay).

--- a/docs/development/data-factory-stage2-execution-plan-20260526.md
+++ b/docs/development/data-factory-stage2-execution-plan-20260526.md
@@ -1,0 +1,124 @@
+# Data Factory 阶段二 — Execution Plan (gated PR-level view) - 2026-05-26
+
+## Status / purpose
+
+**Execution-planning view, NOT new design, NOT a build authorization.** This doc
+expands the already-merged `DF-N0..N4` phasing (#1839) plus the implementation-path
+preferences recorded in #1874 into **concrete PR-level steps** — scope, lane, test
+strategy, and the gate that unlocks each. It introduces **no new contracts or
+architecture**; per #1838's "PAUSE 阶段二 design", further *design* detail still
+waits for K3 PoC evidence. Everything here is gated behind **K3 PoC GATE PASS +
+an explicit 阶段二 unlock + a separate per-PR opt-in**.
+
+K3 WISE stays a **preset**, not the product center.
+
+## 0. Reading rules (read first)
+
+- **Gate 0 (precondition for everything):** K3 PoC **GATE PASS** + 阶段二 unlock + per-PR opt-in.
+- **Current gate status (2026-05-26):** positive K3 Material Save proven 2026-05-25, but the **S3 read/list runtime decision + S4 single-record positive-Save regression are NOT closed**, and Submit/Audit/BOM/multi-record remain blocked → **Gate 0 is NOT passed → zero PRs below start now.**
+- **The whole 阶段二 touches `plugin-integration-core`** (plugin-managed SQL + the pipeline runner + routes) — which is exactly what the K3 Stage-1 lock freezes. Each step is therefore explicitly gated behind unlock; none is implied by this doc.
+- **Hard locks that persist through every phase:** K3 stays Save-only / one-record; no Submit/Audit/BOM/multi-record K3 push without a separate owner decision; payload redaction mandatory; **never expose an arbitrary-JS / raw-SQL editor to business users**; OpenAPI parity gate; wire-vs-fixture round-trip test for any new serialized field; real-DB golden gate for anything touching permissions.
+- ⚠️ **The PoC may reshape DF-N4 / FaaS** (read model, write-back semantics, reference resolution — the open #1838 gating questions). Do **not** pre-build those.
+
+## 1. Current baseline (what already exists — this plan extends, not reinvents)
+
+- **Plugin-managed tables (integration-core's own SQL, guarded by `migration-sql.test.cjs` — NOT core kysely `zzzz` migrations):** `integration_external_systems`, `integration_pipelines`, `integration_field_mappings`, `integration_runs` / `integration_run_log`, `integration_dead_letters`, `integration_exceptions`, `integration_idempotency_key`, `integration_watermarks`.
+- **Adapters** (contract = `plugins/plugin-integration-core/lib/contracts.cjs`, 5 methods `testConnection / listObjects / getSchema / read / upsert`): `k3-wise-webapi`, `sqlserver`, `bridge-agent-readonly`, `http`, `metasheet-multitable-target`, `metasheet-staging-source`, `plm-yuantus`.
+- `lib/transform-engine.cjs` (clean DSL, whitelisted transforms). `lib/pipeline-runner.cjs` (run + `targetWriteSummaries` capped 50 + sanitized; dead-letter create/replay at ~688–757). Routes via the `ROUTES` table in `lib/http-routes.cjs`.
+- **Already shipped (Stage-5 "运行监控"):** DF-N1 read-only monitoring UI (#1848) + DF-N1.5 single manual dead-letter replay (#1857), front-end only.
+- **#1839 config objects map onto existing tables:** `ConnectorProfile` ≈ `integration_external_systems`; `MappingRule` ≈ `integration_field_mappings`; `DatasetDefinition` (schema + identity + direction) is the newest piece (partially served today by adapter `getSchema`/`listObjects` + `integration_watermarks`).
+
+## 2. Dependency graph & sequencing
+
+```
+Gate 0: K3 GATE PASS + 阶段二 unlock
+   │
+   ├─▶ DF-N2 provenance ───┐   (nearest, lowest-risk, extends existing tables)
+   │                       │
+   └─▶ Config layer C ─────┤   (back-end for the operator 5-stage flow #1844; parallel-safe with N2)
+                           ▼
+                    DF-N3 retry + back-pressure   (changes runtime semantics, heaviest; back-pressure only meaningful once multi-record export unlocks)
+                           ▼
+                    DF-N4 connector catalog + 2nd ERP   ("通用" proven here by real reuse; needs a 2nd vendor + PoC evidence)
+                           ▼
+                    FaaS escape-hatch   (阶段二+/阶段三, last; dedicated security review)
+```
+
+**Rationale:** N2 follows the just-shipped DF-N1/N1.5 and is lowest-risk; the config layer is the back-end that makes the 5-stage flow usable and is resource-disjoint from N2 (parallel-safe); N3 depends on N2's per-row results to know *what* to retry and carries the highest runtime risk; N4 is the real test of "通用" and requires a 2nd-vendor adapter reusing the same contract; FaaS is heaviest / largest security surface and must wait until the config tier proves "most systems = config only," then only covers the long tail.
+
+## 3. Phase-by-phase PR breakdown
+
+### Phase DF-N2 — Provenance (per-record lineage)
+**Unlock:** 阶段二 unlock. **Preference (#1874):** JSONB on existing tables + a by-`rowId` view — **not** a new event table.
+
+| PR | Scope | Lane | Key tests | Lock / gate |
+|---|---|---|---|---|
+| N2-1 | Freeze `ProvenanceEvent` shape + 11 event-type enum + redaction contract; land OpenAPI component | contracts | schema parity; invalid-enum rejection | docs/contract, no runtime |
+| N2-2 | Plugin SQL migration: add a JSONB lineage field on the existing run/exception surface + a by-`rowId` **view**; runner appends a (redacted) event per step | runtime | redaction unit test (no token/password/conn-string); append-per-step; by-`rowId` query returns **cross-run** lineage; **new field round-trips through real wire** (wire-vs-fixture guard) | plugin-local SQL, `migration-sql.test.cjs` guard; zero new connector behavior; inside K3 lock |
+| N2-3 | Run-monitoring panel (`IntegrationWorkbenchView`) gains a **per-row lineage timeline** (read-only): expand a row → source_read→…→target_write across runs | frontend | renders timeline; shows no secret | reuses DF-N1 surfaces; read-only |
+
+**Exit:** a record's end-to-end history is queryable by `rowId` across runs, redacted, surfaced read-only — directly deepening the original 阶段二 motivation "对接成功/失败记录".
+
+### Phase Config layer C — formalization (operator 5-stage back-end; parallel-safe with N2)
+**Unlock:** 阶段二 unlock. **Note:** extends existing `external_systems` / `field_mappings`, does not rebuild.
+
+| PR | Scope | Lane | Key tests | Lock / gate |
+|---|---|---|---|---|
+| C-1 | Formalize `ConnectorProfile` / `DatasetDefinition` / `MappingRule` typed contracts + OpenAPI; map onto existing tables, add `DatasetDefinition` (schema/identity/direction) | contracts | parity; contract validation | docs/contract |
+| C-2 | `DatasetDefinition` persistence (new `integration_datasets` or table extension); explicit read/write capability (a read-only source cannot silently write) | runtime | **read-only source rejects upsert**; invalid enum rejects (no silent default); capability round-trips | K3 stays Save-only; reference auto-composition stays frozen |
+| C-3 | 5-stage stepper UI (数据源→数据集→数据准备→测试发布→运行监控) wiring existing import/clean/dry-run/monitor; stage availability reflects capability | frontend | stepper gating; dry-run-before-write enforced | guided linear flow, **not** a flow canvas |
+| C-4 | Mandatory dry-run-before-write guard (client-side, mirrors #1826 C5) | frontend | write disabled until dry-run passes | — |
+
+### Phase DF-N3 — Retry + back-pressure
+**Unlock:** N2 done + (multi-record relevance, itself K3-gated) + separate opt-in. **This changes pipeline runtime semantics — highest risk.**
+
+| PR | Scope | Lane | Key tests | Lock / gate |
+|---|---|---|---|---|
+| N3-1 | `RunPolicy` contract: max rows/run, max/batch, consecutive-failures→pause, 5xx backoff, auth-fail hard stop, validation→dead_letter; per-connector defaults | contracts | parity; policy defaults | docs/contract |
+| N3-2 | Bounded retry of **selected** failed rows; new run linked to the original | runtime | **retry excludes prior successes** (#1839 hard lock); idempotency key prevents duplicate writes | changes runtime, own gate review |
+| N3-3 | Back-pressure / stop rules in the runner (threshold pause, exponential backoff, auth-fail hard stop) | runtime | each stop rule unit-tested; pause is visible | back-pressure is real only **after multi-record export unlocks** (separate K3 gate) |
+| N3-4 | Bulk "retry selected failed rows" UI + run-policy editor + visible pause state | frontend | bulk-select retry; two-step write confirm; policy persists | — |
+
+### Phase DF-N4 — Connector template catalog (+ 2nd ERP)
+**Unlock:** N3 done + the 阶段二 roadmap's "2nd ERP" decision (金蝶云星空 / 用友 U8) + opt-in. **"通用" is proven here by real reuse.**
+
+| PR | Scope | Lane | Key tests | Lock / gate |
+|---|---|---|---|---|
+| N4-1 | Standardize source/target dataset **templates**; make K3 WISE a **preset template** (not a special lane); catalog schema | contracts | parity; template contract | — |
+| N4-2 | HTTP JSON / SQL read-only (with allowlist/view guidance) / CSV/Excel templates | runtime | each template passes the same `adapter-contracts.test` conformance | SQL stays an advanced path |
+| N4-3 | **2nd-vendor adapter** (the real "通用" proof) — reuse the same contract, do not fork | runtime | the same golden adapter-contract suite passes for vendor 2 | do not pre-build templates the PoC has not validated |
+| N4-4 | Connector catalog UI (pick template → configure → use) | frontend | catalog render; template→profile flow | — |
+
+### Phase FaaS escape-hatch (阶段二+ / spans 阶段三, last)
+**Unlock:** N4 config tier proven to cover most systems + a real long-tail system config can't express + **a dedicated security review** + opt-in. **Preference (#1874):** host on our own sandbox, **not** Aliyun FC; config tier first, code tier for the long tail only.
+
+| PR | Scope | Lane | Key tests | Lock / gate |
+|---|---|---|---|---|
+| F-1 | **Security-model RFC:** sandbox boundary, resource limits (CPU/mem/time), secret isolation (author never sees secrets = platform-injected context), allowed SDK surface (HTTP / other connectors / platform read APIs only), threat model | design | — (design PR) | separate gated design |
+| F-2 | function-adapter host: load a user module via `plugin-sandbox.ts` / `PluginIsolationManager.ts`, implement `contracts.cjs`'s 5 methods, inject context + managed credentials; worker/process isolation; **long/async timeout (NOT Yida's 10s)** | runtime | sandbox-escape blocked; resource-limit kill; secret not leaked; async timeout | heaviest security surface, multiple separate gates |
+| F-3 | Credential / parameter-context management (author references a managed secret, never embeds it) | runtime | secret never enters event payload (ties to N2 redaction) or logs | — |
+| F-4 | Connector-authoring surface (upload/edit function, test-connection, deploy) — **integrator/admin only, RBAC-gated, NOT a business-user surface** | frontend | RBAC gate; test-connection runs in sandbox | the business-user surface stays **config-only, always** |
+| F-5 | Connector-level logging / quota / governance (the #1838 borrowable) | runtime | quota enforcement; audit trail | — |
+
+## 4. Cross-cutting discipline (every PR)
+
+- **4-lane branches** (contracts → runtime → frontend → integration), baseline-first for hot files; Conventional Commits; single-maintainer self-review + admin-merge.
+- **OpenAPI parity gate**, **wire-vs-fixture round-trip** (any new serialized field needs a real-wire integration test), **enum strictness** (invalid value rejects, never silent-defaults), **redaction mandatory** on every provenance/log path, **real-DB golden gate** (`describeIfDatabase`) for anything touching permissions.
+- **Migration discipline:** integration-core is **plugin-local SQL** (not the core `zzzz` kysely chain), guarded by `migration-sql.test.cjs`; deploys follow the pending-migration + auth round-trip check (deploy SOP).
+
+## 5. Out of scope / risks
+
+- The **PoC may reshape DF-N4's read model / write-back semantics / reference resolution** (the open #1838 gating questions) — do not pre-build.
+- Multi-record / BOM / Submit/Audit = separate owner decisions, not in this plan.
+- **FaaS effectively spans roadmap 阶段三** (vendor registry / schema catalog / adapter builder) and 阶段四 (marketplace) — it is not "阶段二 wrap-up"; it sits last and may slip into 阶段三.
+
+## 6. Recommended minimal first move (if only one thing on unlock day)
+
+**Start with N2-2 (the JSONB lineage) as a single PR** — lowest risk, zero new connector behavior, and the most direct payoff for the original 阶段二 motivation (per-record success/fail). Then the config layer C-1/C-2. **Explicitly do not** start with FaaS or DF-N4 (heaviest, furthest, most PoC-dependent).
+
+## See also
+
+- #1838 (direction / gating, incl. the NiFi + Yida-FaaS takeaways) + its 2026-05-26 addendum #1874 (DF-N2 JSONB + FaaS-on-own-sandbox preferences).
+- #1839 (run/provenance + core data model + DF-N0..N4 phasing). #1844 (UX/IA 5-stage flow). #1826 (K3 ref-mapping UI contract). #1835/#1709 (read-only unlock decision / read-list track). #1792 (GATE).
+- Shipped: #1848 (DF-N1 read-only monitoring) · #1857 (DF-N1.5 single manual replay).
+- Locks: K3 PoC Stage-1 lock; K3 GATE Save-path progression (S3 read/list + S4 regression still open).

--- a/docs/development/data-factory-stage2-execution-plan-20260526.md
+++ b/docs/development/data-factory-stage2-execution-plan-20260526.md
@@ -112,9 +112,9 @@ Gate 0: K3 GATE PASS + 阶段二 unlock
 - Multi-record / BOM / Submit/Audit = separate owner decisions, not in this plan.
 - **FaaS effectively spans roadmap 阶段三** (vendor registry / schema catalog / adapter builder) and 阶段四 (marketplace) — it is not "阶段二 wrap-up"; it sits last and may slip into 阶段三.
 
-## 6. Recommended minimal first move (if only one thing on unlock day)
+## 6. Recommended first move on unlock day (the DF-N2 mini-chain, contracts-first)
 
-**Start with N2-2 (the JSONB lineage) as a single PR** — lowest risk, zero new connector behavior, and the most direct payoff for the original 阶段二 motivation (per-record success/fail). Then the config layer C-1/C-2. **Explicitly do not** start with FaaS or DF-N4 (heaviest, furthest, most PoC-dependent).
+**Start the DF-N2 mini-chain — the first PR is N2-1 (contracts): freeze the `ProvenanceEvent` shape / event-type enum / redaction contract + OpenAPI before any runtime.** **N2-2 (the JSONB lineage) is the first *runtime* PR, immediately after N2-1** — it is the highest-value / lowest-risk runtime slice and the most direct payoff for the original 阶段二 motivation (per-record success/fail). Then N2-3, then the config layer C-1/C-2. **Explicitly do not** start with FaaS or DF-N4 (heaviest, furthest, most PoC-dependent), and **do not begin N2-2 runtime/migration before the N2-1 contract is frozen** (contracts-first — see the DF-N2 chain discipline in `data-factory-df-n2-task-checklist-20260526.md`).
 
 ## See also
 

--- a/docs/development/data-factory-stage2-todo-20260526.md
+++ b/docs/development/data-factory-stage2-todo-20260526.md
@@ -1,0 +1,56 @@
+# Data Factory 阶段二 — TODO (gated checklist) - 2026-05-26
+
+> **图例:** 🔒 blocked-by-gate · ⬜ ready-when-unlocked · ✅ done · ⏸ deferred
+> **全部 gated:** K3 PoC GATE PASS + 阶段二 unlock + 每个 PR 单独 opt-in。**Gate 0 今天未过 → 下面一项都不启动。**
+> 这是 #1839 DF-N0..N4 phasing + #1874 偏好的执行清单，**非新设计、非开建授权**。
+
+## Gate 0 — 前置门（未过）
+- [ ] 🔒 K3 PoC **GATE PASS**（S3 read/list 决定 + S4 单记录 Save 回归仍未闭）
+- [ ] 🔒 阶段二 **unlock** 决定（owner）
+
+## 已完成（Stage-5 监控）
+- [x] ✅ DF-N1 只读运行监控 UI（#1848）
+- [x] ✅ DF-N1.5 单条手动 dead-letter 重放（#1857）
+- [x] ✅ #1838 addendum：DF-N2 JSONB + FaaS-自有沙箱偏好（#1874，OPEN）
+
+## DF-N2 — Provenance 逐记录血缘 〔最近 · 最低风险〕
+- [ ] 🔒 **N2-1** contracts：`ProvenanceEvent` 形状 + 11 event-type 枚举 + 脱敏契约 + OpenAPI　·　测试：schema parity / 非法枚举拒绝
+- [ ] 🔒 **N2-2** runtime：现有 run/exception 上加 JSONB lineage + by-`rowId` 视图；runner 每步追加脱敏事件　·　测试：脱敏 / 每步追加 / **跨 run** by-rowId / **新字段真 wire round-trip**　·　plugin-local SQL（`migration-sql.test.cjs` 守门）
+- [ ] 🔒 **N2-3** frontend：`IntegrationWorkbenchView` 逐行血缘时间线（只读）　·　测试：时间线渲染 / 不显示 secret
+
+## 配置层 C — operator 5 段式后端 〔可与 N2 并行〕
+- [ ] 🔒 **C-1** contracts：`ConnectorProfile`/`DatasetDefinition`/`MappingRule` 类型 + OpenAPI（映射现有表，Dataset 是新增）
+- [ ] 🔒 **C-2** runtime：`DatasetDefinition` 持久化 + read/write capability 显式化　·　测试：**只读源拒绝 upsert** / 非法枚举拒绝
+- [ ] 🔒 **C-3** frontend：5 段式 stepper（数据源→数据集→数据准备→测试发布→运行监控）
+- [ ] 🔒 **C-4** frontend：dry-run **写前强制**守卫（对齐 #1826 C5）
+
+## DF-N3 — Retry + Back-pressure 〔改 runtime 语义 · 最高风险 · 需 N2 + 多记录相关性〕
+- [ ] 🔒 **N3-1** contracts：`RunPolicy`（max rows、连续失败→暂停、5xx 退避、auth-fail 硬停、validation→dead_letter）
+- [ ] 🔒 **N3-2** runtime：选定失败行有界 retry　·　测试：**不含此前成功行** / idempotency 防重复写
+- [ ] 🔒 **N3-3** runtime：back-pressure / 停止规则　·　测试：每条规则 / 暂停可见（多记录解锁后才真正生效）
+- [ ] 🔒 **N3-4** frontend：bulk retry UI + run-policy 编辑器
+
+## DF-N4 — 连接器目录 + 第 2 家 ERP 〔证明「通用」· 需 2nd vendor + PoC 证据〕
+- [ ] 🔒 **N4-1** contracts：dataset 模板标准化；K3 WISE 变**预设模板**
+- [ ] 🔒 **N4-2** runtime：HTTP / SQL 只读 / CSV·Excel 模板　·　测试：各过 `adapter-contracts.test`
+- [ ] 🔒 **N4-3** runtime：**第 2 家 vendor adapter**（同契约、不 fork）　·　测试：golden 契约套件对 vendor2 通过
+- [ ] 🔒 **N4-4** frontend：连接器目录 UI
+
+## FaaS 逃生舱 〔阶段二+/阶段三 · 最后 · 独立安全评审〕
+- [ ] 🔒 **F-1** design：安全模型 RFC（沙箱/资源上限/密钥隔离/SDK 面/威胁模型）
+- [ ] 🔒 **F-2** runtime：function-adapter 宿主，长在 `plugin-sandbox.ts`/`PluginIsolationManager.ts`（**非 Aliyun FC**；长/异步超时）　·　测试：逃逸被挡 / 资源超限被杀 / secret 不泄漏
+- [ ] 🔒 **F-3** runtime：托管凭据 / parameter-context（作者不见 secret）
+- [ ] 🔒 **F-4** frontend：连接器编写面（**仅集成者/admin，RBAC 门控**）
+- [ ] 🔒 **F-5** runtime：连接器级 logging/quota/governance
+
+## 贯穿全程（每个 PR 都要）
+- [ ] 4-lane 分支（contracts/runtime/frontend/integration）· conventional commit · self-review + admin-merge
+- [ ] OpenAPI parity 门 · wire-vs-fixture round-trip · enum 严格 · 脱敏强制 · 触权限走 real-DB golden 门
+- [ ] integration-core = plugin-local SQL（`migration-sql.test.cjs` 守门）· 部署查 pending-migration + auth round-trip
+
+## 解冻当天的最小起点
+- [ ] ⬜ **先做 N2-2（JSONB 血缘）单 PR**，再 C-1/C-2。**不要**从 FaaS / DF-N4 起步。
+
+## 永不违反的硬锁
+- K3 Save-only / 单记录；无 Submit/Audit/BOM/多记录（除非 owner 决定）
+- 业务用户面**永远只配置**，绝不开任意 JS/SQL 编辑器

--- a/docs/development/data-factory-stage2-todo-20260526.md
+++ b/docs/development/data-factory-stage2-todo-20260526.md
@@ -11,7 +11,7 @@
 ## 已完成（Stage-5 监控）
 - [x] ✅ DF-N1 只读运行监控 UI（#1848）
 - [x] ✅ DF-N1.5 单条手动 dead-letter 重放（#1857）
-- [x] ✅ #1838 addendum：DF-N2 JSONB + FaaS-自有沙箱偏好（#1874，OPEN）
+- [x] ✅ #1838 addendum：DF-N2 JSONB + FaaS-自有沙箱偏好（#1874）
 
 ## DF-N2 — Provenance 逐记录血缘 〔最近 · 最低风险〕
 - [ ] 🔒 **N2-1** contracts：`ProvenanceEvent` 形状 + 11 event-type 枚举 + 脱敏契约 + OpenAPI　·　测试：schema parity / 非法枚举拒绝
@@ -48,8 +48,10 @@
 - [ ] OpenAPI parity 门 · wire-vs-fixture round-trip · enum 严格 · 脱敏强制 · 触权限走 real-DB golden 门
 - [ ] integration-core = plugin-local SQL（`migration-sql.test.cjs` 守门）· 部署查 pending-migration + auth round-trip
 
-## 解冻当天的最小起点
-- [ ] ⬜ **先做 N2-2（JSONB 血缘）单 PR**，再 C-1/C-2。**不要**从 FaaS / DF-N4 起步。
+## 解冻当天的起点（DF-N2 mini-chain，契约优先）
+- [ ] ⬜ **首个 PR = N2-1 契约**（先冻结 ProvenanceEvent / 枚举 / 脱敏 + OpenAPI，再动 runtime）
+- [ ] ⬜ **N2-2（JSONB 血缘）= N2-1 之后的首个 runtime PR**（最高价值 / 最低风险的 runtime 切片），再 N2-3，再 C-1/C-2
+- [ ] ⬜ **不要**从 FaaS / DF-N4 起步；**不要**在 N2-1 契约冻结前先做 N2-2 runtime（契约优先）
 
 ## 永不违反的硬锁
 - K3 Save-only / 单记录；无 Submit/Audit/BOM/多记录（除非 owner 决定）


### PR DESCRIPTION
## What

Two **docs-only** planning artifacts in `docs/development/`, expanding the already-merged `DF-N0..N4` phasing (#1839) + the #1874 implementation-path preferences into actionable form:

- **`data-factory-stage2-execution-plan-20260526.md`** — PR-level execution view: dependency graph, per-phase PR breakdown (scope / lane / key tests / unlock gate), cross-cutting discipline, risks, recommended minimal first move.
- **`data-factory-stage2-todo-20260526.md`** — a trackable, gated **checklist** mirroring the same phases (🔒 blocked-by-gate / ⬜ ready-when-unlocked / ✅ done).

## Framing (important)

- **Execution-planning only — NOT new design, NOT a build authorization.** No new contracts or architecture; this only sequences the existing #1839 phasing into PR-level steps. Consistent with #1838's "PAUSE 阶段二 design".
- **Everything gated** behind K3 PoC **GATE PASS** + 阶段二 unlock + a separate **per-PR opt-in**. **Gate 0 is not passed today** (S3 read/list decision + S4 single-record Save regression still open) → nothing here starts now.
- Hard locks preserved throughout: K3 stays preset / Save-only / one-record; no Submit/Audit/BOM/multi-record; redaction mandatory; **no arbitrary JS/SQL editor for business users**.

## Boundary

- **Docs-only**, +180 lines, 2 new files. No runtime / migration / connector / RBAC / OpenAPI change.
- Branched off `origin/main`; independent of #1874 (references it, no hard dependency). Single-maintainer repo → ready for admin-merge.

## Sequencing captured

`Gate 0 → DF-N2 provenance ∥ Config layer C → DF-N3 retry/back-pressure → DF-N4 catalog + 2nd ERP → FaaS escape-hatch (阶段二+)`. Recommended first move on unlock day: **N2-2 (JSONB lineage)**, not FaaS/N4.

🤖 Generated with [Claude Code](https://claude.com/claude-code)