### PR TITLE
chore(attendance): add admin smoke checklist

### DIFF
--- a/docs/operations/attendance-admin-smoke-checklist.md
+++ b/docs/operations/attendance-admin-smoke-checklist.md
@@ -1,0 +1,139 @@
+# Attendance Admin Smoke Checklist
+
+This runbook covers the post-deploy acceptance check for attendance admin
+permissions. It is intentionally narrow: separate employee attendance access
+from attendance admin access, and prove the expected boundary with read-only
+GET requests.
+
+Related issues: #1846 and #1847.
+
+## Permission boundary
+
+Attendance has two different runtime surfaces:
+
+- Employee/self-service attendance: `/attendance` plus read or write actions
+  backed by `features.attendance=true` and normal attendance permissions.
+- Attendance admin: settings, rule sets, calendars, payroll configuration,
+  scheduling, import history, role templates, user search, and audit logs. This
+  requires `features.attendanceAdmin=true` or the explicit `attendance:admin`
+  permission.
+
+A global-looking user role is not enough for this checklist. The source of
+truth is `/api/auth/me` from the exact JWT used by the smoke run.
+
+## Secret hygiene
+
+Prefer a token file over a literal token in the shell:
+
+```bash
+AUTH_TOKEN_FILE="/tmp/$(whoami)-metasheet-attendance-admin.jwt"
+chmod 0600 "$AUTH_TOKEN_FILE"
+```
+
+The script refuses group or world-readable token files unless
+`ALLOW_INSECURE_TOKEN_FILE=1` is explicitly set for a local throwaway test.
+Never commit token files or paste JWT values into GitHub issues.
+
+If an operator grants attendance admin permissions after a user has already
+logged in, re-login and use a fresh JWT. Older JWTs can still report
+`features.attendanceAdmin=false`.
+
+## Employee boundary check
+
+Use this when validating that employee accounts can open attendance without
+being treated as admins. Admin-only endpoints should return `403`; the default
+attendance rule should still be readable.
+
+```bash
+API_BASE="http://<host>:<port>/api" \
+AUTH_TOKEN_FILE="/tmp/<employee-jwt>.jwt" \
+EXPECTED_ADMIN=false \
+node scripts/verify-attendance-admin-smoke.mjs
+```
+
+Pass criteria:
+
+- `/api/auth/me` returns 200.
+- The report shows `features.attendance=true`.
+- The report shows `features.attendanceAdmin=false`.
+- `GET /api/attendance/rules/default` returns 2xx.
+- Admin endpoints return `403` and are recorded as `forbidden as expected`.
+
+This is the expected outcome for an employee account. It is not a product
+defect by itself.
+
+## Admin acceptance check
+
+Use this when validating the attendance admin account after deployment or after
+role changes.
+
+```bash
+API_BASE="http://<host>:<port>/api" \
+AUTH_TOKEN_FILE="/tmp/<attendance-admin-jwt>.jwt" \
+REQUIRE_ADMIN=true \
+EXPECTED_ADMIN=true \
+node scripts/verify-attendance-admin-smoke.mjs
+```
+
+Pass criteria:
+
+- `/api/auth/me` returns 200.
+- The report shows `features.attendanceAdmin=true` or
+  `attendance:admin` in the effective permissions signal.
+- Every endpoint in the script returns 2xx.
+- The script exits 0 and writes a JSON report under
+  `output/attendance-admin-smoke/`.
+
+## Login fallback
+
+Token files are preferred. If a short-lived local session is acceptable, the
+script can also log in without printing the password:
+
+```bash
+API_BASE="http://<host>:<port>/api" \
+LOGIN_EMAIL="<attendance-admin-email>" \
+LOGIN_PASSWORD="<attendance-admin-password>" \
+REQUIRE_ADMIN=true \
+EXPECTED_ADMIN=true \
+node scripts/verify-attendance-admin-smoke.mjs
+```
+
+Unset those environment variables after the run.
+
+## Endpoint coverage
+
+The script performs GET-only probes for:
+
+- `/api/auth/me`
+- `/api/attendance/rules/default`
+- `/api/attendance/settings`
+- `/api/attendance/rule-sets`
+- `/api/attendance/rule-templates`
+- `/api/attendance/groups`
+- `/api/attendance/import/batches`
+- `/api/attendance/report-fields`
+- `/api/attendance/payroll-templates`
+- `/api/attendance/payroll-cycles`
+- `/api/attendance/leave-types`
+- `/api/attendance/overtime-rules`
+- `/api/attendance/approval-flows`
+- `/api/attendance/advanced-scheduling/workbench`
+- `/api/attendance/rotation-rules`
+- `/api/attendance/rotation-assignments`
+- `/api/attendance/shifts`
+- `/api/attendance/assignments`
+- `/api/attendance-admin/role-templates`
+- `/api/attendance-admin/users/search`
+- `/api/attendance-admin/audit-logs`
+
+## Troubleshooting
+
+- `AUTH_NOT_ATTENDANCE_ADMIN`: the JWT is valid but does not expose
+  attendance admin. Re-login after granting the role, then rerun.
+- Employee run fails because admin endpoints return 2xx: the boundary is too
+  loose or the wrong token was used.
+- Admin run fails with `403`: the account lacks attendance admin or attendance
+  import/admin-linked permissions for that route.
+- Admin run fails with `503 DB_NOT_READY`: deploy or migration state must be
+  checked before treating this as an RBAC failure.
+- `AUTH_TOKEN_FILE_INSECURE`: chmod the token file to `0600` or stricter.

--- a/scripts/verify-attendance-admin-smoke.mjs
+++ b/scripts/verify-attendance-admin-smoke.mjs
@@ -1,0 +1,489 @@
+#!/usr/bin/env node
+import fs from 'node:fs'
+import path from 'node:path'
+import { fileURLToPath, pathToFileURL } from 'node:url'
+
+const DEFAULT_TIMEOUT_MS = 15_000
+const DEFAULT_RETRY_ATTEMPTS = 3
+const DEFAULT_RETRY_DELAY_MS = 500
+
+export const ADMIN_ENDPOINTS = Object.freeze([
+  { key: 'attendance.settings', path: '/attendance/settings' },
+  { key: 'attendance.ruleSets', path: '/attendance/rule-sets?pageSize=5' },
+  { key: 'attendance.ruleTemplates', path: '/attendance/rule-templates' },
+  { key: 'attendance.groups', path: '/attendance/groups?pageSize=5' },
+  { key: 'attendance.importBatches', path: '/attendance/import/batches?pageSize=5' },
+  { key: 'attendance.reportFields', path: '/attendance/report-fields' },
+  { key: 'attendance.payrollTemplates', path: '/attendance/payroll-templates?pageSize=5' },
+  { key: 'attendance.payrollCycles', path: '/attendance/payroll-cycles?pageSize=5' },
+  { key: 'attendance.leaveTypes', path: '/attendance/leave-types?pageSize=5' },
+  { key: 'attendance.overtimeRules', path: '/attendance/overtime-rules?pageSize=5' },
+  { key: 'attendance.approvalFlows', path: '/attendance/approval-flows?pageSize=5' },
+  { key: 'attendance.rotationRules', path: '/attendance/rotation-rules?pageSize=5' },
+  { key: 'attendance.rotationAssignments', path: '/attendance/rotation-assignments?pageSize=5' },
+  { key: 'attendance.shifts', path: '/attendance/shifts?pageSize=5' },
+  { key: 'attendance.assignments', path: '/attendance/assignments?pageSize=5' },
+  { key: 'attendanceAdmin.roleTemplates', path: '/attendance-admin/role-templates' },
+  { key: 'attendanceAdmin.usersSearch', path: '/attendance-admin/users/search?q=&pageSize=5' },
+  { key: 'attendanceAdmin.auditLogs', path: '/attendance-admin/audit-logs?page=1&pageSize=5' },
+])
+
+const READ_ENDPOINTS = Object.freeze([
+  { key: 'attendance.rulesDefault', path: '/attendance/rules/default' },
+])
+
+function timestampSlug(date = new Date()) {
+  return date.toISOString().replace(/[:.]/g, '-')
+}
+
+function parseBoolean(value) {
+  if (value === true) return true
+  const normalized = String(value || '').trim().toLowerCase()
+  return normalized === '1' || normalized === 'true' || normalized === 'yes' || normalized === 'y'
+}
+
+function parseOptionalBoolean(value) {
+  if (value === undefined || value === null || String(value).trim() === '') return null
+  return parseBoolean(value)
+}
+
+function parsePositiveInteger(value, fallback) {
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed) || parsed <= 0) return fallback
+  return Math.floor(parsed)
+}
+
+function toDateOnly(date) {
+  return date.toISOString().slice(0, 10)
+}
+
+function defaultDateRange(now = new Date()) {
+  const to = new Date(Date.UTC(now.getUTCFullYear(), now.getUTCMonth(), now.getUTCDate()))
+  const from = new Date(to)
+  from.setUTCDate(from.getUTCDate() - 30)
+  return { from: toDateOnly(from), to: toDateOnly(to) }
+}
+
+function buildDefaultOutputFile(now = new Date()) {
+  return `output/attendance-admin-smoke/${timestampSlug(now)}.json`
+}
+
+export function normalizeApiBase(value) {
+  const raw = String(value || '').trim()
+  if (!raw) return ''
+  const url = new URL(raw)
+  url.hash = ''
+  url.search = ''
+  url.pathname = url.pathname.replace(/\/+$/, '')
+  if (!url.pathname || url.pathname === '/') {
+    url.pathname = '/api'
+  } else if (!url.pathname.endsWith('/api')) {
+    url.pathname = `${url.pathname}/api`
+  }
+  return url.toString().replace(/\/+$/, '')
+}
+
+function joinApiPath(apiBase, endpointPath) {
+  const normalizedPath = String(endpointPath || '').startsWith('/')
+    ? String(endpointPath)
+    : `/${endpointPath}`
+  return `${apiBase}${normalizedPath}`
+}
+
+export function parseConfig(env = process.env, now = new Date()) {
+  const range = defaultDateRange(now)
+  const from = String(env.FROM_DATE || env.FROM || range.from).trim()
+  const to = String(env.TO_DATE || env.TO || range.to).trim()
+  return {
+    apiBase: normalizeApiBase(env.API_BASE || env.BASE_URL),
+    authToken: String(env.AUTH_TOKEN || env.TOKEN || '').trim(),
+    authTokenFile: String(env.AUTH_TOKEN_FILE || env.TOKEN_FILE || '').trim(),
+    loginEmail: String(env.LOGIN_EMAIL || env.AUTH_EMAIL || '').trim(),
+    loginPassword: String(env.LOGIN_PASSWORD || env.AUTH_PASSWORD || '').trim(),
+    allowInsecureTokenFile: parseBoolean(env.ALLOW_INSECURE_TOKEN_FILE),
+    expectedAdmin: parseOptionalBoolean(env.EXPECTED_ADMIN),
+    requireAdmin: parseBoolean(env.REQUIRE_ADMIN),
+    outputFile: String(env.OUTPUT_FILE || env.REPORT_JSON || buildDefaultOutputFile(now)).trim(),
+    writeOutput: env.WRITE_OUTPUT === undefined ? true : parseBoolean(env.WRITE_OUTPUT),
+    timeoutMs: parsePositiveInteger(env.TIMEOUT_MS || env.API_TIMEOUT_MS, DEFAULT_TIMEOUT_MS),
+    retryAttempts: parsePositiveInteger(env.API_RETRY_ATTEMPTS, DEFAULT_RETRY_ATTEMPTS),
+    retryDelayMs: parsePositiveInteger(env.API_RETRY_DELAY_MS, DEFAULT_RETRY_DELAY_MS),
+    from,
+    to,
+  }
+}
+
+export function validateConfig(config) {
+  const errors = []
+  if (!config.apiBase) errors.push('API_BASE or BASE_URL is required')
+  if (!config.authToken && !config.authTokenFile && !(config.loginEmail && config.loginPassword)) {
+    errors.push('AUTH_TOKEN, AUTH_TOKEN_FILE, or LOGIN_EMAIL + LOGIN_PASSWORD is required')
+  }
+  if (config.loginEmail && !config.loginPassword) errors.push('LOGIN_PASSWORD is required when LOGIN_EMAIL is set')
+  if (config.loginPassword && !config.loginEmail) errors.push('LOGIN_EMAIL is required when LOGIN_PASSWORD is set')
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(config.from)) errors.push('FROM_DATE must use YYYY-MM-DD')
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(config.to)) errors.push('TO_DATE must use YYYY-MM-DD')
+  if (config.from > config.to) errors.push('FROM_DATE must be on or before TO_DATE')
+  return errors
+}
+
+function assertTokenFileMode(stat, displayPath, allowInsecure) {
+  if (allowInsecure) return
+  if ((stat.mode & 0o077) !== 0) {
+    const modeText = (stat.mode & 0o777).toString(8).padStart(4, '0')
+    throw new Error(`AUTH_TOKEN_FILE_INSECURE: ${displayPath}: mode ${modeText}, expected 0600 or stricter`)
+  }
+}
+
+function readTokenFile(filePath, allowInsecure) {
+  const displayPath = filePath
+  const stat = fs.statSync(filePath)
+  if (!stat.isFile()) throw new Error(`AUTH_TOKEN_FILE_NOT_FILE: ${displayPath}`)
+  assertTokenFileMode(stat, displayPath, allowInsecure)
+  const token = fs.readFileSync(filePath, 'utf8').trim()
+  if (!token) throw new Error(`AUTH_TOKEN_FILE_EMPTY: ${displayPath}`)
+  return token
+}
+
+function envelopeFailed(json) {
+  if (!json || typeof json !== 'object') return false
+  return json.ok === false || json.success === false
+}
+
+function unwrapData(json) {
+  if (json && typeof json === 'object' && Object.prototype.hasOwnProperty.call(json, 'data')) {
+    return json.data
+  }
+  return json
+}
+
+function safePreview(raw) {
+  return String(raw || '').replace(/\s+/g, ' ').slice(0, 220)
+}
+
+function sleep(ms) {
+  return new Promise(resolve => setTimeout(resolve, ms))
+}
+
+function isRetriableStatus(status) {
+  return status === 408 || status === 429 || (status >= 500 && status <= 504)
+}
+
+async function fetchWithTimeout(fetchImpl, url, init, timeoutMs) {
+  if (typeof AbortSignal !== 'undefined' && typeof AbortSignal.timeout === 'function') {
+    return fetchImpl(url, { ...init, signal: AbortSignal.timeout(timeoutMs) })
+  }
+
+  const controller = new AbortController()
+  const timer = setTimeout(() => controller.abort(), timeoutMs)
+  try {
+    return await fetchImpl(url, { ...init, signal: controller.signal })
+  } finally {
+    clearTimeout(timer)
+  }
+}
+
+async function requestJson(config, token, endpointPath, options = {}) {
+  const fetchImpl = options.fetchImpl || fetch
+  const method = options.method || 'GET'
+  const label = options.label || `${method} ${endpointPath}`
+  const url = endpointPath.startsWith('http') ? endpointPath : joinApiPath(config.apiBase, endpointPath)
+  const headers = {
+    Accept: 'application/json',
+    ...(token ? { Authorization: `Bearer ${token}` } : {}),
+    ...(options.body === undefined ? {} : { 'Content-Type': 'application/json' }),
+    ...(options.headers || {}),
+  }
+  const init = {
+    method,
+    headers,
+    ...(options.body === undefined ? {} : { body: JSON.stringify(options.body) }),
+  }
+  let lastError = null
+
+  for (let attempt = 1; attempt <= config.retryAttempts; attempt += 1) {
+    try {
+      const res = await fetchWithTimeout(fetchImpl, url, init, config.timeoutMs)
+      const raw = await res.text()
+      let json = null
+      try {
+        json = raw ? JSON.parse(raw) : null
+      } catch {
+        json = null
+      }
+
+      if (isRetriableStatus(res.status) && attempt < config.retryAttempts) {
+        await sleep(Math.min(config.retryDelayMs * attempt, 5_000))
+        continue
+      }
+
+      return {
+        label,
+        path: endpointPath,
+        status: res.status,
+        ok: res.ok && !envelopeFailed(json),
+        json,
+        errorCode: json?.error?.code || '',
+        message: json?.error?.message || json?.error || '',
+        rawPreview: safePreview(raw),
+      }
+    } catch (error) {
+      lastError = error
+      if (attempt >= config.retryAttempts) break
+      await sleep(Math.min(config.retryDelayMs * attempt, 5_000))
+    }
+  }
+
+  return {
+    label,
+    path: endpointPath,
+    status: 0,
+    ok: false,
+    json: null,
+    errorCode: 'NETWORK_ERROR',
+    message: lastError instanceof Error ? lastError.message : String(lastError),
+    rawPreview: '',
+  }
+}
+
+async function resolveToken(config, fetchImpl) {
+  if (config.authToken) return { token: config.authToken, source: 'AUTH_TOKEN' }
+  if (config.authTokenFile) {
+    return {
+      token: readTokenFile(config.authTokenFile, config.allowInsecureTokenFile),
+      source: 'AUTH_TOKEN_FILE',
+    }
+  }
+
+  const login = await requestJson(config, '', '/auth/login', {
+    fetchImpl,
+    method: 'POST',
+    label: 'POST /auth/login',
+    body: {
+      email: config.loginEmail,
+      identifier: config.loginEmail,
+      password: config.loginPassword,
+    },
+  })
+  const data = unwrapData(login.json)
+  const token = String(data?.token || login.json?.token || '').trim()
+  if (!login.ok || !token) {
+    throw new Error(`LOGIN_FAILED: HTTP ${login.status} ${login.rawPreview || login.message}`)
+  }
+  return { token, source: 'LOGIN_EMAIL_PASSWORD' }
+}
+
+function collectPermissions(user, data) {
+  const candidates = [
+    user?.permissions,
+    data?.permissions,
+    user?.effectivePermissions,
+    data?.effectivePermissions,
+  ]
+  return candidates
+    .flatMap(value => Array.isArray(value) ? value : [])
+    .map(value => String(value || '').trim())
+    .filter(Boolean)
+}
+
+function isAttendanceAdmin({ features, permissions }) {
+  return features?.attendanceAdmin === true || permissions.includes('attendance:admin')
+}
+
+function redactUser(user) {
+  return {
+    id: user?.id || user?.userId || user?.user_id || '',
+    email: user?.email || '',
+    role: user?.role || '',
+  }
+}
+
+function endpointExpectation(endpoint, expectedAdmin) {
+  if (endpoint.kind === 'read') return 'allow'
+  return expectedAdmin ? 'allow' : 'forbid'
+}
+
+function evaluateEndpoint(endpoint, result, expectedAdmin) {
+  const expectation = endpointExpectation(endpoint, expectedAdmin)
+  if (expectation === 'allow') {
+    const passed = result.status >= 200 && result.status < 300 && !envelopeFailed(result.json)
+    return {
+      ...result,
+      expectation,
+      passed,
+      reason: passed ? 'allowed' : `expected 2xx, got ${result.status || 'network error'}`,
+    }
+  }
+
+  const passed = result.status === 403
+  return {
+    ...result,
+    expectation,
+    passed,
+    reason: passed ? 'forbidden as expected' : `expected 403, got ${result.status || 'network error'}`,
+  }
+}
+
+function buildEndpoints(config) {
+  const workbenchPath = `/attendance/advanced-scheduling/workbench?from=${encodeURIComponent(config.from)}&to=${encodeURIComponent(config.to)}`
+  return [
+    ...READ_ENDPOINTS.map(endpoint => ({ ...endpoint, kind: 'read' })),
+    ...ADMIN_ENDPOINTS.map(endpoint => ({ ...endpoint, kind: 'admin' })),
+    { key: 'attendance.advancedSchedulingWorkbench', path: workbenchPath, kind: 'admin' },
+  ]
+}
+
+function summarizeEndpoint(endpoint) {
+  return {
+    key: endpoint.key,
+    path: endpoint.path,
+    status: endpoint.status,
+    expectation: endpoint.expectation,
+    passed: endpoint.passed,
+    reason: endpoint.reason,
+    errorCode: endpoint.errorCode || '',
+    message: endpoint.message || '',
+  }
+}
+
+function ensureOutputDir(outputFile) {
+  const dir = path.dirname(outputFile)
+  if (dir && dir !== '.') fs.mkdirSync(dir, { recursive: true })
+}
+
+export async function runAttendanceAdminSmoke(config, options = {}) {
+  const errors = validateConfig(config)
+  if (errors.length > 0) {
+    throw new Error(`CONFIG_INVALID: ${errors.join('; ')}`)
+  }
+
+  const fetchImpl = options.fetchImpl || fetch
+  const logger = options.logger || console
+  const now = options.now || new Date()
+  const auth = await resolveToken(config, fetchImpl)
+  logger.log(`[attendance-admin-smoke] auth source: ${auth.source}`)
+
+  const me = await requestJson(config, auth.token, '/auth/me', {
+    fetchImpl,
+    label: 'GET /auth/me',
+  })
+  if (!me.ok) {
+    throw new Error(`AUTH_ME_FAILED: HTTP ${me.status} ${me.rawPreview || me.message}`)
+  }
+
+  const data = unwrapData(me.json)
+  const user = data?.user || {}
+  const features = data?.features || {}
+  const permissions = collectPermissions(user, data)
+  const actualAdmin = isAttendanceAdmin({ features, permissions })
+  const expectedAdmin = config.expectedAdmin === null ? actualAdmin : config.expectedAdmin
+
+  logger.log(
+    `[attendance-admin-smoke] /auth/me ok: email=${user?.email || '(unknown)'} role=${user?.role || '(unknown)'} attendanceAdmin=${actualAdmin}`,
+  )
+
+  if (config.requireAdmin && !actualAdmin) {
+    throw new Error('AUTH_NOT_ATTENDANCE_ADMIN: /auth/me did not expose features.attendanceAdmin=true or attendance:admin')
+  }
+
+  const endpoints = buildEndpoints(config)
+  const results = []
+  for (const endpoint of endpoints) {
+    const result = await requestJson(config, auth.token, endpoint.path, {
+      fetchImpl,
+      label: `GET ${endpoint.path}`,
+    })
+    const evaluated = evaluateEndpoint(endpoint, result, expectedAdmin)
+    results.push(evaluated)
+    const marker = evaluated.passed ? 'PASS' : 'FAIL'
+    logger.log(`[attendance-admin-smoke] ${marker} ${endpoint.key}: HTTP ${evaluated.status} (${evaluated.reason})`)
+  }
+
+  const failed = results.filter(result => !result.passed)
+  const report = {
+    generatedAt: now.toISOString(),
+    apiBase: config.apiBase,
+    auth: {
+      tokenSource: auth.source,
+      user: redactUser(user),
+      features: {
+        attendance: features?.attendance === true,
+        attendanceAdmin: features?.attendanceAdmin === true,
+        attendanceImport: features?.attendanceImport === true,
+        mode: features?.mode || '',
+      },
+      permissionSignals: {
+        attendanceAdminFeature: features?.attendanceAdmin === true,
+        attendanceAdminPermission: permissions.includes('attendance:admin'),
+      },
+    },
+    expectation: {
+      expectedAdmin,
+      requireAdmin: config.requireAdmin,
+      from: config.from,
+      to: config.to,
+    },
+    summary: {
+      total: results.length,
+      passed: results.length - failed.length,
+      failed: failed.length,
+      adminEndpoints: results.filter(result => result.expectation === 'allow' && result.key !== 'attendance.rulesDefault').length,
+      forbiddenAsExpected: results.filter(result => result.expectation === 'forbid' && result.passed).length,
+    },
+    endpoints: results.map(summarizeEndpoint),
+  }
+
+  if (config.writeOutput && config.outputFile) {
+    ensureOutputDir(config.outputFile)
+    fs.writeFileSync(config.outputFile, `${JSON.stringify(report, null, 2)}\n`)
+    logger.log(`[attendance-admin-smoke] wrote ${config.outputFile}`)
+  }
+
+  if (failed.length > 0) {
+    const error = new Error(`ATTENDANCE_ADMIN_SMOKE_FAILED: ${failed.length}/${results.length} endpoints failed`)
+    error.report = report
+    throw error
+  }
+
+  return report
+}
+
+export function renderHelp() {
+  return [
+    'Usage:',
+    '  API_BASE=http://<host>:<port>/api AUTH_TOKEN_FILE=/secure/admin.jwt REQUIRE_ADMIN=true node scripts/verify-attendance-admin-smoke.mjs',
+    '',
+    'Auth inputs:',
+    '  AUTH_TOKEN or AUTH_TOKEN_FILE',
+    '  LOGIN_EMAIL + LOGIN_PASSWORD',
+    '',
+    'Expectation controls:',
+    '  EXPECTED_ADMIN=true|false  Override /auth/me-derived expectation',
+    '  REQUIRE_ADMIN=true         Fail immediately if token is not attendance admin',
+    '',
+    'Optional:',
+    '  FROM_DATE=YYYY-MM-DD TO_DATE=YYYY-MM-DD OUTPUT_FILE=path WRITE_OUTPUT=0',
+  ].join('\n')
+}
+
+async function main() {
+  if (process.argv.includes('--help') || process.argv.includes('-h')) {
+    console.log(renderHelp())
+    return
+  }
+
+  let config = null
+  try {
+    config = parseConfig()
+    await runAttendanceAdminSmoke(config)
+  } catch (error) {
+    console.error(`[attendance-admin-smoke] ERROR: ${error instanceof Error ? error.message : String(error)}`)
+    process.exitCode = 1
+  }
+}
+
+const currentFile = pathToFileURL(fileURLToPath(import.meta.url)).href
+const invokedFile = process.argv[1] ? pathToFileURL(path.resolve(process.argv[1])).href : ''
+if (currentFile === invokedFile) {
+  await main()
+}

--- a/scripts/verify-attendance-admin-smoke.test.mjs
+++ b/scripts/verify-attendance-admin-smoke.test.mjs
@@ -1,0 +1,146 @@
+import assert from 'node:assert/strict'
+import http from 'node:http'
+import test from 'node:test'
+
+import {
+  ADMIN_ENDPOINTS,
+  normalizeApiBase,
+  parseConfig,
+  runAttendanceAdminSmoke,
+} from './verify-attendance-admin-smoke.mjs'
+
+function send(res, status, json) {
+  res.writeHead(status, { 'Content-Type': 'application/json' })
+  res.end(JSON.stringify(json))
+}
+
+function createSilentLogger() {
+  return {
+    log() {},
+    error() {},
+    warn() {},
+  }
+}
+
+async function startMockServer({ admin }) {
+  const calls = []
+  const server = http.createServer((req, res) => {
+    const url = new URL(req.url || '/', 'http://127.0.0.1')
+    calls.push(`${req.method} ${url.pathname}${url.search}`)
+
+    if (req.method === 'GET' && url.pathname === '/api/auth/me') {
+      send(res, 200, {
+        success: true,
+        data: {
+          user: { id: admin ? 'admin-user' : 'employee-user', email: admin ? 'admin@example.com' : 'employee@example.com', role: 'user' },
+          features: {
+            attendance: true,
+            attendanceAdmin: admin,
+            attendanceImport: admin,
+            mode: 'attendance',
+          },
+        },
+      })
+      return
+    }
+
+    if (req.method === 'GET' && url.pathname === '/api/attendance/rules/default') {
+      send(res, 200, { ok: true, data: { id: 'default-rule' } })
+      return
+    }
+
+    const expectedAdminPaths = new Set([
+      ...ADMIN_ENDPOINTS.map(endpoint => `/api${endpoint.path.split('?')[0]}`),
+      '/api/attendance/advanced-scheduling/workbench',
+    ])
+    if (req.method === 'GET' && expectedAdminPaths.has(url.pathname)) {
+      if (admin) {
+        send(res, 200, { ok: true, data: { items: [], templates: [] } })
+      } else {
+        send(res, 403, { ok: false, error: { code: 'FORBIDDEN', message: 'Forbidden' } })
+      }
+      return
+    }
+
+    send(res, 404, { ok: false, error: { code: 'NOT_FOUND' } })
+  })
+
+  await new Promise(resolve => server.listen(0, '127.0.0.1', resolve))
+  const address = server.address()
+  return {
+    apiBase: `http://127.0.0.1:${address.port}`,
+    calls,
+    close: () => new Promise(resolve => server.close(resolve)),
+  }
+}
+
+test('normalizeApiBase accepts deployment origin or /api base', () => {
+  assert.equal(normalizeApiBase('http://example.test:8081'), 'http://example.test:8081/api')
+  assert.equal(normalizeApiBase('http://example.test:8081/api/'), 'http://example.test:8081/api')
+})
+
+test('passes an attendance admin token when admin endpoints return 2xx', async () => {
+  const server = await startMockServer({ admin: true })
+  try {
+    const report = await runAttendanceAdminSmoke(
+      parseConfig({
+        API_BASE: server.apiBase,
+        AUTH_TOKEN: 'admin-token',
+        REQUIRE_ADMIN: 'true',
+        WRITE_OUTPUT: '0',
+      }, new Date('2026-05-26T12:00:00.000Z')),
+      { logger: createSilentLogger() },
+    )
+
+    assert.equal(report.auth.features.attendanceAdmin, true)
+    assert.equal(report.expectation.expectedAdmin, true)
+    assert.equal(report.summary.failed, 0)
+    assert.equal(report.summary.passed, report.summary.total)
+  } finally {
+    await server.close()
+  }
+})
+
+test('passes an employee token when admin endpoints are forbidden as expected', async () => {
+  const server = await startMockServer({ admin: false })
+  try {
+    const report = await runAttendanceAdminSmoke(
+      parseConfig({
+        API_BASE: server.apiBase,
+        AUTH_TOKEN: 'employee-token',
+        EXPECTED_ADMIN: 'false',
+        WRITE_OUTPUT: '0',
+      }, new Date('2026-05-26T12:00:00.000Z')),
+      { logger: createSilentLogger() },
+    )
+
+    assert.equal(report.auth.features.attendanceAdmin, false)
+    assert.equal(report.expectation.expectedAdmin, false)
+    assert.equal(report.summary.failed, 0)
+    assert.equal(report.summary.forbiddenAsExpected, ADMIN_ENDPOINTS.length + 1)
+    assert.ok(server.calls.includes('GET /api/attendance/rules/default'))
+  } finally {
+    await server.close()
+  }
+})
+
+test('REQUIRE_ADMIN fails before endpoint probing for an employee token', async () => {
+  const server = await startMockServer({ admin: false })
+  try {
+    await assert.rejects(
+      () => runAttendanceAdminSmoke(
+        parseConfig({
+          API_BASE: server.apiBase,
+          AUTH_TOKEN: 'employee-token',
+          REQUIRE_ADMIN: 'true',
+          WRITE_OUTPUT: '0',
+        }, new Date('2026-05-26T12:00:00.000Z')),
+        { logger: createSilentLogger() },
+      ),
+      /AUTH_NOT_ATTENDANCE_ADMIN/,
+    )
+    assert.deepEqual(server.calls, ['GET /api/auth/me'])
+  } finally {
+    await server.close()
+  }
+})


### PR DESCRIPTION
## Summary
- add a GET-only attendance admin smoke script that reads `AUTH_TOKEN_FILE`, `AUTH_TOKEN`, or login credentials without printing token values
- classify `/auth/me` into attendance admin vs employee boundary mode, then validate the expected 2xx or 403 behavior for the admin surface
- document the post-deploy checklist and token hygiene for #1846 and #1847

Fixes #1846
Fixes #1847

## Verification
- `node --check scripts/verify-attendance-admin-smoke.mjs`
- `node --test scripts/verify-attendance-admin-smoke.test.mjs`
- `git diff --cached --check` before commit

## Note
- `pnpm exec eslint scripts/verify-attendance-admin-smoke.mjs scripts/verify-attendance-admin-smoke.test.mjs` was attempted, but this checkout does not have an ESLint config discoverable from the repo root for these script files.
