### PR TITLE
fix(multitable): recalculate formula fields on record patch

### DIFF
--- a/docs/development/multitable-formula-patch-recalc-verification-20260526.md
+++ b/docs/development/multitable-formula-patch-recalc-verification-20260526.md
@@ -1,0 +1,83 @@
+# A1 — Formula recalc on record PATCH: verification
+
+> Date: 2026-05-26 · Branch: `codex/multitable-formula-patch-recalc-20260526` (off `origin/main` c0707b21e)
+> Scope: multitable kernel only. **No** integration-core / K3 / RBAC / auth / storage-model / OSS code.
+> Plan ref: `docs/development/multitable-derived-field-borrow-plan-20260526.md` Track A / item A1.
+
+## 1. 缺陷
+
+多维表 `formula` 字段在**网格 PATCH 编辑**后不刷新：用户在网格里改了 formula 引用的源字段，formula 值保持陈旧。
+
+## 2. 根因（两层，都已验证）
+
+1. **表达式取错了源**：formula 表达式存在 `meta_fields.property.expression`（前端 `MetaFieldManager.vue` 的编辑器、以及 `formula_dependencies` 的依赖抽取都用它）。但 `MultitableFormulaEngine.recalculateRecord` 从 `record.data[fieldId]` 取表达式并要求 `startsWith('=')` —— 而 `record.data[formulaFieldId]` 存的是**计算值/空**，不是 `=…` 串。所以对"字段定义式 formula"该过滤基本 no-op，**光接线也算不出值**。
+2. **recalc 只接了一条写路径**：`recalculateRecord` 全后端唯一调用点是 `/views/:viewId/submit`（公开表单提交）。网格 PATCH 走 `RecordWriteService.patchRecords`，只做 lookup/rollup，**从不触发 formula recalc**。
+
+> 因此 A1 必须"先修表达式语义，再接 PATCH 写路径"——不能只接线。
+
+## 3. 实现（4 处改动，全部在多维表内核）
+
+1. **`multitable/formula-engine.ts` `recalculateRecord`**：表达式取 `field.property.expression` 为准；**仅当该字段完全没有 `property.expression`（undefined，老记录）时**才回退到 record.data 里的遗留 `=…` 串 —— `property.expression` 为空串视为"无公式"、不回退到 data 串（避免把客户端早先写进 data 的脏 `=…` 当公式算）。写回改为 **JSONB 合并仅 formula 键** (`data = data || $1::jsonb`)，避免 SELECT→UPDATE 间并发写被整块覆盖；**不 bump version**（派生值非用户编辑）。
+2. **`multitable/record-write-service.ts`**：`RecordWriteHelpers` 新增**必填** `recalculateFormulaFields`；`patchRecords` 加 Step 4c —— 用真实变更字段调该 helper，把重算出的 formula 值并入响应 `records`，并注入实时广播 `recordPatches[].patch` + 把 formula 字段 id 加进 `fieldIds`。
+3. **`routes/univer-meta.ts`**：新增 `recalculateFormulaFields` helper（先按 `formula_dependencies` 门控，命中才逐记录调 `recalculateRecord`），注入 `/patch` 路由的 writeHelpers；表单提交路径改为用 recalc 返回值**叠加**可见 formula 值进响应（不覆盖已合并的 link 值）。
+4. **`index.ts`（Yjs 协同桥）**：`recalculateFormulaFields` 在此**置为 no-op stub**，与该桥既有的 `applyLookupRollup`/`computeDependentLookupRollupRecords` stub 一致（Yjs 协同写路径本就不做派生字段重算；formula 在协同路径的支持是单独议题，非本 PR）。
+
+## 4. 实时陈旧问题的处理（已验证无需前端改动）
+
+`apps/web/src/multitable/composables/useMultitableGrid.ts:applyRemoteRecordPatch` 对远端 patch 做 `data: { ...current.data, ...options.patch }` 并恒返回 true。因此把重算后的 formula 值放进广播 `recordPatches[].patch`，其它客户端会**直接合并出新值**——无需任何前端改动。`fieldIds` 里加 formula id 仅在该字段正被排序/筛选时触发整页刷新（`structuralRealtimeFieldIds` = 活动 sort/filter 字段），那种情况下整页刷新本就是正确行为。
+
+## 5. 实现边界（本 PR 明确不做）
+
+- A2 记录内 formula 链拓扑排序 / A2b 宏展开转义重写 —— 不做。
+- B（ANTLR 解析器）/ C（统一依赖图、多跳、物化）/ D（异步 outbox）/ E（存储迁移）/ F（网格引擎）—— 不做。
+- 不引入 Teable / HyperFormula 源码或依赖。
+- 不改 version 语义；formula 物化不额外 bump version。
+- 不改 migration / 存储模型。
+- Yjs 协同写路径的 formula recalc —— stub（与 lookup/rollup 一致），非本 PR。
+- 不为"顺手"把 `recalculateRecord` 改成批量形态（per-record N+1 在本 scope 可接受）。
+- **`validateChanges` 对 formula 字段的写校验保持不变**（执行单验收要求"readonly 语义不变"）。现状：`validateChanges` 允许客户端把 `''` 或 `=…` 串写进 formula 字段值（不像 lookup/rollup 直接拒）。本 PR 不动它。**已知留待决策的后续项**：是否把 formula 也并入 `lookup`/`rollup` 的 `RecordFieldForbiddenError` 只读分支（彻底禁止直接写 formula 值）。本 PR 通过上面的"回退仅在 property.expression 缺失时生效"已消除该写入对计算正确性的影响（脏 `=…` 串在 property.expression 存在时被忽略），故此项是收口/防污染，不是正确性阻塞 —— 单独 opt-in 决定。
+
+## 6. 测试
+
+命令与结果（在 worktree `metasheet2-formula-a1` 执行）：
+
+```
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/multitable-formula-engine.test.ts tests/unit/record-write-service.test.ts
+→ 2 files / 81 tests PASS
+
+pnpm --filter @metasheet/core-backend test:unit
+→ 179 files / 2338 tests PASS（无回归）
+
+pnpm --filter @metasheet/core-backend build   # tsc 类型检查
+→ PASS（必填 helper 在编译期抓出了 index.ts Yjs 桥的漏接线，已补 stub）
+
+cd packages/core-backend && npx playwright test --config tests/e2e/playwright.config.ts \
+  multitable-formula-smoke.spec.ts
+→ 5 tests SKIPPED（本地未起 backend:7778 / frontend:8899；runner 已识别新增 case 4 @:150）
+```
+
+新增/改动测试：
+- `multitable-formula-engine.test.ts`：property.expression 取源 + 仅合并 formula 键写回（断言 `data || ` 且参数只含 formula 键）；遗留 `=…` 串回退；表达式失败写 `#ERROR!`；无 formula 字段不发 UPDATE。
+- `record-write-service.test.ts`：依赖命中→formula 值进响应 `records` **且**进实时 `recordPatches[].patch` + `fieldIds`（锁住"其它客户端不陈旧"）；无依赖→响应/实时不含 formula。
+- `multitable-formula-smoke.spec.ts` case 4（真 wire）：建 A/B/formula(`={A}+{B}`) + 记录 → 经真实 `POST /api/multitable/patch` 改 A=20 → 断言 PATCH 响应 `records` 与独立 `GET /records/:id` 的 DB 值均为 25。
+
+## 7. 未覆盖 / 待补
+
+- **e2e 在本地被 skip**（无 :7778/:8899）。需在起了 backend+frontend 的环境（CI e2e step / staging）跑一次 case 4 拿到真绿。当前它已被 runner 识别、断言已写死，但未实跑通过。
+- formula 在 Yjs 协同写路径不重算（与 lookup/rollup 一致，已 stub）—— 如需协同实时 formula，另开 issue。
+
+## 8. K3 / OSS 声明
+
+- 不触碰 `plugin-integration-core` / K3 / 中央 RBAC / auth / 存储模型。
+- 未引入任何 OSS（Teable / HyperFormula）代码或依赖；本次借鉴仅为"先修语义再接线"的思路。
+
+## 9. 验收对照（对应执行单 §6）
+
+| 验收项 | 状态 |
+|---|---|
+| PATCH 源字段后同记录 formula 在 DB 与 API response 更新 | ✅ 单测锁定；e2e 断言已写（待真跑） |
+| 发起端能看到 formula 刷新 | ✅ 响应 `records` 携带 |
+| 其它实时客户端不因只本地 patch 源字段而陈旧 | ✅ 实时 `recordPatches[].patch` 携带 formula 值（applyRemoteRecordPatch 合并） |
+| formula readonly 写语义不变 | ✅ 未改 validateChanges |
+| 不实现多跳/跨表/链/物化策略/ANTLR | ✅ |

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -2051,6 +2051,10 @@ export class MetaSheetServer {
           serializeAttachmentSummaryMap: () => ({}),
           applyLookupRollup: async () => {},
           computeDependentLookupRollupRecords: async () => [],
+          // Yjs-bridge writes intentionally skip computed-field recompute (lookup/
+          // rollup are stubbed above); formula recalc stays scoped to the REST PATCH
+          // path for now and is stubbed here for the same reason.
+          recalculateFormulaFields: async () => [],
           loadLinkValuesByRecord: async () => new Map(),
           buildLinkSummaries: async () => new Map(),
           buildAttachmentSummaries: async () => new Map(),

--- a/packages/core-backend/src/multitable/formula-engine.ts
+++ b/packages/core-backend/src/multitable/formula-engine.ts
@@ -242,38 +242,51 @@ export class MultitableFormulaEngine {
       const data: Record<string, unknown> =
         typeof row.data === 'string' ? JSON.parse(row.data) : (row.data ?? {})
 
-      const formulaFields = fields.filter(
-        (f) => f.type === 'formula' && typeof data[f.id] === 'string' && (data[f.id] as string).startsWith('='),
-      )
+      // Resolve each formula field's expression. Field-defined formulas store the
+      // expression in `field.property.expression` (the authoring surface + the
+      // source `formula_dependencies` is built from). Fall back to a legacy `=…`
+      // string persisted directly in the record data so older records / direct
+      // writes still compute.
+      const formulaTargets = fields.flatMap((field) => {
+        if (field.type !== 'formula') return []
+        const property = field.property as Record<string, unknown> | undefined
+        // The legacy data-string fallback applies ONLY when the field has no
+        // `expression` property key at all (older records). If the key is present
+        // — even as null / a number / an empty string — the field "defines" an
+        // expression and that is the source of truth: a non-empty string is the
+        // formula; anything else means "no formula" and must NOT fall through to a
+        // possibly-stale `=…` string sitting in record data.
+        const hasExpressionKey = !!property && Object.prototype.hasOwnProperty.call(property, 'expression')
+        let expression: string | null = null
+        if (hasExpressionKey) {
+          const fromProperty = property!.expression
+          expression = typeof fromProperty === 'string' && fromProperty.trim().length > 0 ? fromProperty : null
+        } else if (typeof data[field.id] === 'string' && (data[field.id] as string).startsWith('=')) {
+          expression = data[field.id] as string
+        }
+        return expression ? [{ field, expression }] : []
+      })
 
-      if (formulaFields.length === 0) return data
+      if (formulaTargets.length === 0) return data
 
       const updates: Record<string, unknown> = {}
-      let changed = false
-
-      for (const field of formulaFields) {
-        const expression = data[field.id] as string
+      for (const { field, expression } of formulaTargets) {
         try {
-          const result = await this.evaluateField(expression, data, fields)
-          updates[field.id] = result
-          changed = true
+          updates[field.id] = await this.evaluateField(expression, data, fields)
         } catch (error) {
           logger.error(`Failed to evaluate formula for field ${field.id}:`, error as Error)
           updates[field.id] = '#ERROR!'
-          changed = true
         }
       }
 
-      if (changed) {
-        const nextData = { ...data, ...updates }
-        await query(
-          `UPDATE meta_records SET data = $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3`,
-          [JSON.stringify(nextData), recordId, sheetId],
-        )
-        return nextData
-      }
-
-      return data
+      // Merge only the computed formula keys (`data || $patch`) so a concurrent
+      // write to other fields between this SELECT and UPDATE is not clobbered. No
+      // version bump: formula values are derived, not an authoritative user edit.
+      await query(
+        `UPDATE meta_records SET data = data || $1::jsonb, updated_at = now() WHERE id = $2 AND sheet_id = $3`,
+        [JSON.stringify(updates), recordId, sheetId],
+      )
+      return { ...data, ...updates }
     } catch (error) {
       logger.error('recalculateRecord failed:', error as Error)
       return null

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -283,6 +283,20 @@ export interface RecordWriteHelpers {
     query: QueryFn,
     updatedRecordIds: string[],
   ) => Promise<Array<{ sheetId: string; recordId: string; data: Record<string, unknown> }>>
+  /**
+   * Recalculate `formula` fields for the given just-updated records when a
+   * changed field has a dependent formula (per `formula_dependencies`). Returns
+   * the recomputed formula values per record so the caller can surface them in
+   * the response + realtime patch. Returns `[]` when nothing depends on the
+   * change. Intra-sheet / intra-record only (no cross-sheet read → no perm gate).
+   */
+  recalculateFormulaFields: (
+    query: QueryFn,
+    sheetId: string,
+    fields: UniverMetaField[],
+    updatedRecordIds: string[],
+    changedFieldIds: string[],
+  ) => Promise<Array<{ recordId: string; data: Record<string, unknown> }>>
   loadLinkValuesByRecord: (
     query: QueryFn,
     recordIds: string[],
@@ -839,7 +853,40 @@ export class RecordWriteService {
         data: h.filterRecordDataByFieldIds(record.data, visiblePropertyFieldIds),
       }))
     const crossSheetRelated = relatedRecords.filter((record) => record.sheetId !== sheetId)
-    const mergedRecords = h.mergeComputedRecords(computedRecords, sameSheetRelated)
+
+    // -----------------------------------------------------------------------
+    // Step 4c: Formula field recalculation (field.property.expression-based).
+    // Unlike lookup/rollup (computed-on-read), formula values are materialized
+    // back to the record by the helper; here we collect the recomputed values to
+    // surface in the response + realtime patch so the editing client AND other
+    // clients refresh after a source field changes via this write path.
+    // -----------------------------------------------------------------------
+    const changedFieldIds = [
+      ...new Set(
+        Array.from(changesByRecord.values()).flatMap((changes) => changes.map((change) => change.fieldId)),
+      ),
+    ]
+    const formulaRecords =
+      updates.length > 0
+        ? (
+            await h.recalculateFormulaFields(
+              this.pool.query.bind(this.pool),
+              sheetId,
+              fields,
+              updates.map((update) => update.recordId),
+              changedFieldIds,
+            )
+          ).map((record) => ({
+            recordId: record.recordId,
+            data: h.filterRecordDataByFieldIds(record.data, visiblePropertyFieldIds),
+          }))
+        : []
+    const formulaByRecord = new Map(formulaRecords.map((record) => [record.recordId, record.data]))
+
+    const mergedRecords = h.mergeComputedRecords(
+      h.mergeComputedRecords(computedRecords, sameSheetRelated),
+      formulaRecords,
+    )
 
     // -----------------------------------------------------------------------
     // Step 5: Link / attachment summary rebuild
@@ -893,16 +940,23 @@ export class RecordWriteService {
         kind: 'record-updated',
         recordIds: updates.map((update) => update.recordId),
         fieldIds: [
-          ...new Set(
-            Array.from(changesByRecord.values()).flatMap((changes) => changes.map((change) => change.fieldId)),
-          ),
+          ...new Set([
+            ...changedFieldIds,
+            ...formulaRecords.flatMap((record) => Object.keys(record.data)),
+          ]),
         ],
         recordPatches: updates.map((update) => ({
           recordId: update.recordId,
           version: update.version,
-          patch: Object.fromEntries(
-            (changesByRecord.get(update.recordId) ?? []).map((change) => [change.fieldId, change.value]),
-          ),
+          patch: {
+            ...Object.fromEntries(
+              (changesByRecord.get(update.recordId) ?? []).map((change) => [change.fieldId, change.value]),
+            ),
+            // Materialized formula values so other clients merge the fresh value
+            // (applyRemoteRecordPatch does `{ ...data, ...patch }`) rather than
+            // keeping a stale formula after only the source field is patched.
+            ...(formulaByRecord.get(update.recordId) ?? {}),
+          },
         })),
       })
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1565,6 +1565,49 @@ async function loadLinkValuesByRecord(
   return linkValuesByRecord
 }
 
+/**
+ * Recalculate `formula` fields for just-updated records when a changed field has
+ * a dependent formula in this sheet (per `formula_dependencies`). Delegates the
+ * per-record evaluate + materialize to MultitableFormulaEngine.recalculateRecord
+ * (which sources the expression from `field.property.expression`) and returns the
+ * recomputed formula-field values per record so the write path can surface them
+ * in the response + realtime patch. Returns `[]` when no formula depends on the
+ * change. Intra-sheet / intra-record only — no cross-sheet read, no perm gate.
+ */
+async function recalculateFormulaFields(
+  query: QueryFn,
+  sheetId: string,
+  fields: UniverMetaField[],
+  updatedRecordIds: string[],
+  changedFieldIds: string[],
+): Promise<Array<{ recordId: string; data: Record<string, unknown> }>> {
+  if (updatedRecordIds.length === 0 || changedFieldIds.length === 0) return []
+  const formulaFieldIds = fields.filter((f) => f.type === 'formula').map((f) => f.id)
+  if (formulaFieldIds.length === 0) return []
+
+  // Gate: only recompute when a changed field actually feeds a formula here.
+  const depRes = await query(
+    `SELECT DISTINCT field_id FROM formula_dependencies
+     WHERE depends_on_field_id = ANY($1::text[])
+       AND (depends_on_sheet_id IS NULL OR depends_on_sheet_id = $2)
+       AND sheet_id = $2`,
+    [changedFieldIds, sheetId],
+  )
+  if (depRes.rows.length === 0) return []
+
+  const results: Array<{ recordId: string; data: Record<string, unknown> }> = []
+  for (const recordId of updatedRecordIds) {
+    const nextData = await multitableFormulaEngine.recalculateRecord(query, sheetId, recordId, fields)
+    if (!nextData) continue
+    const formulaData: Record<string, unknown> = {}
+    for (const fieldId of formulaFieldIds) {
+      if (fieldId in nextData) formulaData[fieldId] = nextData[fieldId]
+    }
+    results.push({ recordId, data: formulaData })
+  }
+  return results
+}
+
 async function applyLookupRollup(
   req: Request,
   query: QueryFn,
@@ -6855,12 +6898,23 @@ export function univerMetaRouter(): Router {
             [changedFieldIds, view.sheetId],
           )
           if (depRes.rows.length > 0) {
-            await multitableFormulaEngine.recalculateRecord(
+            const recalculated = await multitableFormulaEngine.recalculateRecord(
               pool.query.bind(pool),
               view.sheetId,
               record.id,
               fields,
             )
+            if (recalculated) {
+              // Surface freshly materialized formula values in the response/broadcast.
+              // record.data was already filtered + link-merged above, so overlay only
+              // visible formula fields rather than replacing it (avoids clobbering the
+              // normalized link values).
+              for (const field of fields) {
+                if (field.type === 'formula' && field.id in recalculated && visibleFormFieldIds.has(field.id)) {
+                  record.data[field.id] = recalculated[field.id]
+                }
+              }
+            }
           }
         }
       } catch (recalcErr) {
@@ -7929,6 +7983,7 @@ export function univerMetaRouter(): Router {
         serializeAttachmentSummaryMap,
         applyLookupRollup: (q, f, rows, rl, lv) => applyLookupRollup(req, q, f, rows, rl, lv),
         computeDependentLookupRollupRecords: (q, ids) => computeDependentLookupRollupRecords(req, q, ids),
+        recalculateFormulaFields,
         loadLinkValuesByRecord,
         buildLinkSummaries: (q, rows, rl, lv) => buildLinkSummaries(req, q, rows, rl, lv),
         buildAttachmentSummaries: (q, sid, rows, af) => buildAttachmentSummaries(q, req, sid, rows, af),

--- a/packages/core-backend/tests/e2e/multitable-formula-smoke.spec.ts
+++ b/packages/core-backend/tests/e2e/multitable-formula-smoke.spec.ts
@@ -147,6 +147,43 @@ test.describe('Multitable formula smoke', () => {
     expect(updatedField?.property?.expression).toBe('')
   })
 
+  test('recalculates a formula field after a source field changes via grid PATCH (A1 fix)', async ({ request }) => {
+    const client = makeAuthClient(request, token)
+    const label = uniqueLabel('f-recalc')
+
+    const base = await createBase(client, `${label}-base`)
+    const sheet = await createSheet(client, base.id, `${label}-sheet`)
+    const numA = await createField(client, sheet.id, 'A', 'number')
+    const numB = await createField(client, sheet.id, 'B', 'number')
+    // Creating the formula field populates formula_dependencies (A→Sum, B→Sum).
+    const expression = `={${numA.id}} + {${numB.id}}`
+    const formula = await createField(client, sheet.id, 'Sum', 'formula', { expression })
+
+    const record = await createRecord(client, sheet.id, { [numA.id]: 10, [numB.id]: 5 })
+
+    // Change source field A 10 → 20 through the REAL grid PATCH write path
+    // (POST /api/multitable/patch → RecordWriteService.patchRecords), the path
+    // that previously left the formula stale (recalc only fired on form-submit).
+    const patchEnv = await client.post<{
+      updated: Array<{ recordId: string; version: number }>
+      records?: Array<{ recordId: string; data: Record<string, unknown> }>
+    }>('/api/multitable/patch', {
+      sheetId: sheet.id,
+      changes: [{ recordId: record.id, fieldId: numA.id, value: 20 }],
+    })
+
+    // (a) API response surfaces the recomputed formula (20 + 5 = 25).
+    const responseRecords = patchEnv.data?.records ?? []
+    const responseFormula = responseRecords.find((entry) => entry.recordId === record.id)
+    expect(responseFormula?.data?.[formula.id]).toBe(25)
+
+    // (b) DB is materialized: an independent GET returns the fresh formula value.
+    const getEnv = await client.get<{ record: { data: Record<string, unknown> } }>(
+      `/api/multitable/records/${record.id}?sheetId=${sheet.id}`,
+    )
+    expect(getEnv.data?.record?.data?.[formula.id]).toBe(25)
+  })
+
   test('persisted ApiEnvelope shape on field list is well-formed (helpers contract)', async ({ request }) => {
     // Tiny smoke that doubles as a sanity guard for the shared helper
     // module: if the response envelope contract changes upstream and

--- a/packages/core-backend/tests/unit/multitable-formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/multitable-formula-engine.test.ts
@@ -308,35 +308,103 @@ describe('MultitableFormulaEngine', () => {
   })
 
   describe('recalculateRecord', () => {
-    it('evaluates formula fields and writes back', async () => {
-      const recordData = {
-        fld_price: 10,
-        fld_qty: 3,
-        fld_total: '={fld_price}*{fld_qty}',
-        fld_name: 'Item',
-      }
-
-      const selectMock = vi.fn().mockResolvedValue({
-        rows: [{ id: 'rec_1', data: recordData }],
-        rowCount: 1,
+    function makeQuery(recordData: Record<string, unknown>) {
+      const updateCalls: Array<{ sql: string; params: unknown[] }> = []
+      const mockQuery = vi.fn().mockImplementation((sql: string, params: unknown[]) => {
+        if (sql.startsWith('SELECT')) {
+          return Promise.resolve({ rows: [{ id: 'rec_1', data: recordData }], rowCount: 1 })
+        }
+        updateCalls.push({ sql, params })
+        return Promise.resolve({ rows: [], rowCount: 1 })
       })
-      const updateMock = vi.fn().mockResolvedValue({ rows: [], rowCount: 1 })
+      return { mockQuery, updateCalls }
+    }
 
-      const mockQuery = vi.fn().mockImplementation((sql: string) => {
-        if (sql.startsWith('SELECT')) return selectMock(sql)
-        return updateMock(sql)
-      })
+    it('sources the expression from field.property.expression (record data holds no formula string)', async () => {
+      // Production shape: the formula expression lives in field.property.expression,
+      // NOT in record.data[formulaId] (which holds the computed value or nothing).
+      const { mockQuery, updateCalls } = makeQuery({ fld_price: 10, fld_qty: 3, fld_name: 'Item' })
 
-      const result = await mtEngine.recalculateRecord(
-        mockQuery,
-        'sheet_1',
-        'rec_1',
-        sampleFields,
-      )
+      const result = await mtEngine.recalculateRecord(mockQuery, 'sheet_1', 'rec_1', sampleFields)
 
       expect(result).not.toBeNull()
       expect(result!.fld_total).toBe(30)
-      expect(mockQuery).toHaveBeenCalledTimes(2) // SELECT + UPDATE
+      // Writes back via a JSONB merge of ONLY the formula key (not a full-blob replace),
+      // so a concurrent write to other fields between SELECT and UPDATE is not clobbered.
+      expect(updateCalls).toHaveLength(1)
+      expect(updateCalls[0].sql).toContain('data || ')
+      expect(JSON.parse(updateCalls[0].params[0] as string)).toEqual({ fld_total: 30 })
+    })
+
+    it('falls back to a legacy "=..." string in record data when no property.expression', async () => {
+      const legacyFields: MultitableField[] = [
+        { id: 'fld_a', name: 'A', type: 'number' },
+        { id: 'fld_b', name: 'B', type: 'number' },
+        { id: 'fld_legacy', name: 'Legacy', type: 'formula' }, // no property.expression
+      ]
+      const { mockQuery } = makeQuery({ fld_a: 4, fld_b: 6, fld_legacy: '={fld_a}+{fld_b}' })
+
+      const result = await mtEngine.recalculateRecord(mockQuery, 'sheet_1', 'rec_1', legacyFields)
+
+      expect(result).not.toBeNull()
+      expect(result!.fld_legacy).toBe(10)
+    })
+
+    it('treats an empty property.expression as "no formula" and ignores a stale data string', async () => {
+      const emptyExprFields: MultitableField[] = [
+        { id: 'fld_a', name: 'A', type: 'number' },
+        { id: 'fld_empty', name: 'Empty', type: 'formula', property: { expression: '' } },
+      ]
+      // Record data holds a stale "=..." string for the formula field (e.g. a prior
+      // client write). With an empty property.expression the field has no formula,
+      // so it must NOT be recomputed from the stale string.
+      const { mockQuery, updateCalls } = makeQuery({ fld_a: 7, fld_empty: '={fld_a}' })
+
+      const result = await mtEngine.recalculateRecord(mockQuery, 'sheet_1', 'rec_1', emptyExprFields)
+
+      expect(updateCalls).toHaveLength(0)
+      expect(result!.fld_empty).toBe('={fld_a}') // unchanged — not recomputed
+    })
+
+    it('does not fall back to a stale data string when property.expression is present but non-string', async () => {
+      // Sanitization / bad input can leave property.expression as null or a number.
+      // The `expression` KEY is present, so the field "defines" an expression — a
+      // malformed one means "no formula", NOT a license to recompute from a stale
+      // "=..." string sitting in record data.
+      for (const badExpression of [null, 123] as const) {
+        const fields: MultitableField[] = [
+          { id: 'fld_a', name: 'A', type: 'number' },
+          { id: 'fld_x', name: 'X', type: 'formula', property: { expression: badExpression as unknown as string } },
+        ]
+        const { mockQuery, updateCalls } = makeQuery({ fld_a: 9, fld_x: '={fld_a}' })
+
+        const result = await mtEngine.recalculateRecord(mockQuery, 'sheet_1', 'rec_1', fields)
+
+        expect(updateCalls).toHaveLength(0)
+        expect(result!.fld_x).toBe('={fld_a}') // unchanged — stale string NOT recomputed
+      }
+    })
+
+    it('writes #ERROR! when the expression fails to evaluate', async () => {
+      const errFields: MultitableField[] = [
+        { id: 'fld_bad', name: 'Bad', type: 'formula', property: { expression: '=NOPE_FUNC()' } },
+      ]
+      const { mockQuery } = makeQuery({})
+
+      const result = await mtEngine.recalculateRecord(mockQuery, 'sheet_1', 'rec_1', errFields)
+
+      expect(result).not.toBeNull()
+      expect(result!.fld_bad).toBe('#ERROR!')
+    })
+
+    it('returns the record unchanged and issues no UPDATE when there are no formula fields', async () => {
+      const noFormulaFields: MultitableField[] = [{ id: 'fld_a', name: 'A', type: 'number' }]
+      const { mockQuery, updateCalls } = makeQuery({ fld_a: 1 })
+
+      const result = await mtEngine.recalculateRecord(mockQuery, 'sheet_1', 'rec_1', noFormulaFields)
+
+      expect(result).toEqual({ fld_a: 1 })
+      expect(updateCalls).toHaveLength(0)
     })
 
     it('returns null when record not found', async () => {

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -49,6 +49,7 @@ function createMockHelpers(overrides: Partial<RecordWriteHelpers> = {}): RecordW
     serializeAttachmentSummaryMap: () => ({}),
     applyLookupRollup: vi.fn().mockResolvedValue(undefined),
     computeDependentLookupRollupRecords: vi.fn().mockResolvedValue([]),
+    recalculateFormulaFields: vi.fn().mockResolvedValue([]),
     loadLinkValuesByRecord: vi.fn().mockResolvedValue(new Map()),
     buildLinkSummaries: vi.fn().mockResolvedValue(new Map()),
     buildAttachmentSummaries: vi.fn().mockResolvedValue(new Map()),
@@ -220,6 +221,67 @@ describe('RecordWriteService', () => {
         recordIds: ['rec1'],
       }),
     )
+  })
+
+  it('recomputes dependent formula fields and surfaces them in the response + realtime patch', async () => {
+    const recalculateFormulaFields = vi
+      .fn()
+      .mockResolvedValue([{ recordId: 'rec1', data: { fld_total: 42 } }])
+    helpers = createMockHelpers({ recalculateFormulaFields })
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+
+    const fields: UniverMetaField[] = [
+      { id: 'fld_name', name: 'Name', type: 'string', order: 0 },
+      { id: 'fld_total', name: 'Total', type: 'formula', order: 1, property: { expression: '={fld_name}' } },
+    ]
+    const input = buildTestInput({
+      fields,
+      visiblePropertyFields: fields,
+      visiblePropertyFieldIds: new Set(fields.map((f) => f.id)),
+      fieldById: new Map(fields.map((f) => [f.id, { type: f.type, readOnly: false, hidden: false }])) as any,
+    })
+
+    const result = await service.patchRecords(input)
+
+    // Helper is invoked with the changed field ids so it can gate on formula_dependencies.
+    expect(recalculateFormulaFields).toHaveBeenCalledWith(
+      expect.any(Function),
+      'sheet1',
+      fields,
+      ['rec1'],
+      ['fld_name'],
+    )
+    // Editing client: the computed formula value rides back in the response records.
+    expect(result.records).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ recordId: 'rec1', data: expect.objectContaining({ fld_total: 42 }) }),
+      ]),
+    )
+    // Other clients: the formula field id is in fieldIds AND its value is in the
+    // realtime record patch, so applyRemoteRecordPatch merges fresh (no stale formula).
+    const realtimePayload = mockPublish.mock.calls[0][0] as {
+      fieldIds: string[]
+      recordPatches: Array<{ recordId: string; patch: Record<string, unknown> }>
+    }
+    expect(realtimePayload.fieldIds).toEqual(expect.arrayContaining(['fld_name', 'fld_total']))
+    const patchForRec1 = realtimePayload.recordPatches.find((p) => p.recordId === 'rec1')
+    expect(patchForRec1?.patch).toMatchObject({ fld_name: 'Alice', fld_total: 42 })
+  })
+
+  it('adds no formula values to the response or realtime when nothing depends on the change', async () => {
+    // Default mock helper reports no dependents (returns []).
+    const service = new RecordWriteService(pool, eventBus as any, helpers)
+
+    const result = await service.patchRecords(buildTestInput())
+
+    expect(helpers.recalculateFormulaFields).toHaveBeenCalled()
+    expect(result.records).toBeUndefined()
+    const realtimePayload = mockPublish.mock.calls[0][0] as {
+      fieldIds: string[]
+      recordPatches: Array<{ recordId: string; patch: Record<string, unknown> }>
+    }
+    expect(realtimePayload.fieldIds).toEqual(['fld_name'])
+    expect(realtimePayload.recordPatches[0].patch).toEqual({ fld_name: 'Alice' })
   })
 
   it('creates subscriber notifications for each updated record and skips the actor', async () => {


### PR DESCRIPTION
## 缺陷
多维表 `formula` 字段在**网格 PATCH 编辑**后不刷新 —— 改了 formula 引用的源字段，formula 值保持陈旧。

## 根因（两层，均已验证）
1. **取错表达式源**：表达式存在 `meta_fields.property.expression`，但 `recalculateRecord` 从 `record.data[fieldId]`（计算值/空）取并要求 `startsWith('=')` → 对字段定义式 formula 基本 no-op。
2. **只接了一条写路径**：`recalculateRecord` 唯一调用点是 `/views/:viewId/submit`（表单提交）；网格 PATCH 走 `RecordWriteService.patchRecords`，只做 lookup/rollup，从不触发 formula recalc。

> 所以"先修表达式语义，再接 PATCH"——不能只接线。

## 实现（多维表内核，4 处）
- `recalculateRecord`：表达式以 `property.expression` 为准（仅 `property.expression` 完全缺失的老记录回退到 data 里的 `=…` 串；空表达式视为"无公式"不回退）；写回改 JSONB 合并仅 formula 键；不 bump version。
- `RecordWriteService.patchRecords`：新增**必填** `recalculateFormulaFields` helper（按 `formula_dependencies` 门控）；重算值并入响应 `records` + 实时 `recordPatches[].patch` + `fieldIds`（其它客户端经 `applyRemoteRecordPatch` 直接合并新值，**无需前端改动**）。
- 表单提交路径：用 recalc 返回值叠加可见 formula 值进响应。
- Yjs 协同桥：helper 置 no-op stub（与其 lookup/rollup stub 一致）。

## 测试
- `pnpm --filter @metasheet/core-backend test:unit` → **179 files / 2338 tests PASS**（含新增 engine 语义 + 接线断言）。
- `pnpm --filter @metasheet/core-backend build`（tsc）→ **PASS**（必填 helper 在编译期抓出 Yjs 桥漏接线，已补 stub）。
- e2e `multitable-formula-smoke.spec.ts` 新增 case 4（真 `POST /api/multitable/patch` → formula=25 + 独立 GET 验 DB）→ **本地无 :7778/:8899 被 SKIP**（runner 已识别）；需在起了前后端的环境跑一次拿真绿。

## 范围围栏
- **不触碰** K3 / `plugin-integration-core` / 中央 RBAC / auth / 存储模型 / migration。
- **未引入** Teable / HyperFormula 代码或依赖（借鉴仅为思路）。
- A2（记录内拓扑）/ A2b（宏展开加固）/ B / C / D / E / F **本 PR 不做**。

## 留待决策的后续项（未在本 PR 动）
`validateChanges` 仍允许客户端把 `''`/`=…` 写进 formula 字段值（执行单要求"readonly 语义不变"，故本 PR 不改）。是否把 formula 并入 lookup/rollup 的只读拒写分支 = 单独 opt-in 决定。本 PR 的"回退仅在 property.expression 缺失时生效"已消除该写入对计算正确性的影响。

## 文档
`docs/development/multitable-formula-patch-recalc-verification-20260526.md`（缺陷/实现/边界/测试/验收对照）。源起：`docs/research/multitable-vs-teable-hyperformula-comparison-20260526.md` + 计划 Track A / A1。

> 单维护者仓：开 PR 供 review，**不自动 merge**。

🤖 Generated with [Claude Code](https://claude.com/claude-code)