### PR TITLE
docs(attendance): acceptance smoke-harness consolidation + CI-flake classifier (P3 v1)

### DIFF
--- a/docs/operations/attendance-acceptance-harness.md
+++ b/docs/operations/attendance-acceptance-harness.md
@@ -36,7 +36,7 @@ command line.**
 
 ### R3 — GitHub-infra flake vs genuine failure
 - Many checks failing in **2–4 s** across **unrelated** suites = a shared pre-code step failure (Set up job / Checkout), almost always GitHub infra, not your change.
-- Infra signatures: `pnpm/action-setup` / `codeload.github.com` / "could not be found at the URI" / "Failed to download archive" (action-CDN); `HTTP 403` / "unable to access … github" / "RPC failed" / "expected 'packfile'" / git exit 128 (checkout/throttle).
+- Infra signatures are **context-bound** (a bare `HTTP 403` / `exit code 128` is *not* a signature — genuine auth/permission tests print those): action-CDN — `pnpm/action-setup` / `codeload.github.com` / "Download action repository" / "could not be found at the URI" / "Failed to download archive"; git checkout — "unable to access 'https://…github" (URL-bound 403) / "RPC failed; HTTP" / "/usr/bin/git' failed with exit code 128" / "fatal: expected 'packfile'".
 - Tool: `scripts/ci/ci-flake-classify.sh <PR#> [--rerun]` — classify-only by default; exit `0` clear / `2` all-infra / `3` genuine. Re-run **only** when classified all-infra; bound retries (≤3 rounds) and **never merge red CI**.
 - Fail-safe: a failure matching no infra signature is treated as **genuine** (never silently rerun).
 

--- a/docs/operations/attendance-acceptance-harness.md
+++ b/docs/operations/attendance-acceptance-harness.md
@@ -1,0 +1,66 @@
+# Attendance Acceptance Smoke Harness — Consolidation & Decision Rules
+
+One entry point for attendance acceptance/verification. It is **mostly decision rules and
+disambiguators**, not procedures — the step-by-step lives in the existing runbooks (linked
+below); this doc encodes the judgment that was learned the hard way so future acceptances need
+less manual reasoning and avoid the specific mistakes that bit us.
+
+**Auth surface:** the tools referenced here use only the local `gh` CLI or a JWT read from a
+`0600` file. **No script in this harness reads a JWT/service token or puts a secret on a
+command line.**
+
+## Consolidation map (link, don't copy — these are the source of truth for procedure)
+
+| Concern | Runbook / evidence (procedure) |
+| --- | --- |
+| Staging acceptance gate (JWT/auth/deploy gates → PUT cap → sync → verify → restore) | `docs/operations/attendance-comprehensive-hours-reporting-staging-acceptance-runbook.md` |
+| Advanced-scheduling workbench (read-only, diagnostics, truncation §2.5) | `docs/operations/attendance-advanced-scheduling-workbench-runbook.md` |
+| Bundle-fingerprint heartbeat (prod, read-only) | `docs/development/attendance-pr5-prod-heartbeat-closeout-20260524.md` |
+| Login/logout smoke (real-stack evidence) | `docs/development/attendance-comprehensive-hours-pr6-staging-acceptance-20260526.md` |
+| Reporting V1 capability + limits | `docs/development/attendance-comprehensive-hours-reporting-closeout-20260525.md` |
+
+## Decision rules (the actual increment)
+
+### R1 — Token hygiene
+- Keep the token in a `0600` file; never paste it into chat/tickets (the transcript persists — deleting the local file does **not** invalidate it; only **server-side rotation** does).
+- Pass it via `curl -H @<header-file>`, built without the token touching `argv`:
+  `{ printf 'Authorization: Bearer '; cat "$JWT"; } > /tmp/hdr && chmod 600 /tmp/hdr`
+- Staging and prod use **distinct `JWT_SECRET`s** — a prod token returns `401 Invalid token` on staging (and vice-versa).
+- After any exposure: rotate server-side, then confirm with the **old** token → `GET /api/auth/me` → expect `401`.
+
+### R2 — Settings save/restore (restore from the SAVED ORIGINAL, never a hardcoded value)
+- **Save the original settings first; that saved value is the source of truth for restore.** Do **not** assume the original is null/empty.
+- A partial `PUT` deep-merges, so only assert what you changed (e.g. `month==600`) while confirming the other keys are **unchanged from the original**.
+- Restore by `PUT`-ing the saved original back, then GET-compare equals the saved original.
+- *Why:* a hardcoded `{month:null,…}` restore (the #1850 Codex BLOCK) silently wipes pre-existing caps while claiming "fully reversible."
+
+### R3 — GitHub-infra flake vs genuine failure
+- Many checks failing in **2–4 s** across **unrelated** suites = a shared pre-code step failure (Set up job / Checkout), almost always GitHub infra, not your change.
+- Infra signatures: `pnpm/action-setup` / `codeload.github.com` / "could not be found at the URI" / "Failed to download archive" (action-CDN); `HTTP 403` / "unable to access … github" / "RPC failed" / "expected 'packfile'" / git exit 128 (checkout/throttle).
+- Tool: `scripts/ci/ci-flake-classify.sh <PR#> [--rerun]` — classify-only by default; exit `0` clear / `2` all-infra / `3` genuine. Re-run **only** when classified all-infra; bound retries (≤3 rounds) and **never merge red CI**.
+- Fail-safe: a failure matching no infra signature is treated as **genuine** (never silently rerun).
+
+### R4 — "Green-by-skip" detection (a green check can mean the suite never ran)
+Before citing a green integration check as pass evidence, run this **3-point check** (any one true ⇒ the suite may be green by *skipping*, not passing):
+1. Does the workflow step set `DATABASE_URL` / `ATTENDANCE_TEST_DATABASE_URL` in its env?
+2. Is the command guarded by `|| true` (non-blocking)?
+3. Does the test file early-return on `!baseUrl` / `!dbUrl` (a silent-skip shape, not a guard)?
+- *Why:* #1861 found `plugin-tests.yml`'s integration step ran `test:integration || true` with no DB, so the attendance suite was green by skipping. #1867 made the skip **honest** (`describe.skip`, throw-not-return); #1872 wired a real postgres + `DATABASE_URL` + `test:integration:attendance` (no `|| true`) so it actually runs. The fixed end-state is the bar.
+
+### R5 — Wire-vs-fixture / save-path drift
+- A field added to a normalizer/object isn't "settable/persistable" until proven by a **route round-trip** (write via the real endpoint → read back), not a unit test on the normalizer. Check both the **request** validator (zod schema) and the **response** projection — either can silently strip a new field (#1829 zod-strip; #1781 `dayIndex` serialization-strip). See `[[skip-when-unreachable-blind-spot]]`.
+
+## Reusable tooling
+
+- `scripts/ci/ci-flake-classify.sh` — CI-flake classifier (R3). `gh`-only, read-only by default.
+  - Matcher unit test: `scripts/ci/__tests__/ci-flake-classify.test.sh` (feeds recorded incident excerpts in `scripts/ci/__fixtures__/`; no live-CI dependency).
+
+## Boundaries
+
+Read-only / diagnostic. No prod or staging writes from this harness. No new route, no migration, no `attendance_*` / `meta_*` write. Scripts use only local `gh` auth or a `0600` JWT file (R1).
+
+## Cross-references
+
+- `[[skip-when-unreachable-blind-spot]]` — the coverage blind-spot lessons R4/R5 distill.
+- `[[staging-8082-jwt-and-deploy-lane]]` — staging preflight (distinct secret; deploy lane doesn't auto-mirror main).
+- `[[review-auto-md]]`, `[[staged-opt-in-lineage]]`.

--- a/scripts/ci/__fixtures__/genuine-app-403.txt
+++ b/scripts/ci/__fixtures__/genuine-app-403.txt
@@ -1,0 +1,4 @@
+test (20.x)	Run integration tests	FAIL tests/integration/attendance-plugin.test.ts > admin route rejects non-admin
+test (20.x)	Run integration tests	AssertionError: expected response status 200 to be 403
+test (20.x)	Run integration tests	  POST /api/attendance/settings → HTTP 403 Forbidden (permission denied)
+test (20.x)	Run integration tests	 Tests  1 failed | 77 passed (78)

--- a/scripts/ci/__fixtures__/genuine-test-failure.txt
+++ b/scripts/ci/__fixtures__/genuine-test-failure.txt
@@ -1,0 +1,5 @@
+test (20.x)	Run unit tests	FAIL tests/unit/attendance-advanced-scheduling-workbench.test.ts
+test (20.x)	Run unit tests	AssertionError: expected 500 to be 499
+test (20.x)	Run unit tests	  - Expected: 499
+test (20.x)	Run unit tests	  + Received: 500
+test (20.x)	Run unit tests	 Tests  1 failed | 8 passed (9)

--- a/scripts/ci/__fixtures__/infra-action-setup.txt
+++ b/scripts/ci/__fixtures__/infra-action-setup.txt
@@ -1,0 +1,3 @@
+contracts (openapi)	Set up job	Download action repository 'pnpm/action-setup@v4' (SHA:b906affcce14559ad1aafd4ab0e942779e9f58b1)
+contracts (openapi)	Set up job	##[error]An action could not be found at the URI 'https://codeload.github.com/pnpm/action-setup/tar.gz/b906affcce14559ad1aafd4ab0e942779e9f58b1'
+contracts (openapi)	Set up job	##[error]Failed to download archive 'https://codeload.github.com/pnpm/action-setup/tar.gz/...' after 1 attempts.

--- a/scripts/ci/__fixtures__/infra-checkout-403.txt
+++ b/scripts/ci/__fixtures__/infra-checkout-403.txt
@@ -1,0 +1,4 @@
+DingTalk P4 ops regression gate	Checkout repository	##[error]fatal: unable to access 'https://github.com/zensgit/metasheet2/': The requested URL returned error: 403
+DingTalk P4 ops regression gate	Checkout repository	##[error]error: RPC failed; HTTP 403 curl 22 The requested URL returned error: 403
+DingTalk P4 ops regression gate	Checkout repository	##[error]fatal: expected 'packfile'
+DingTalk P4 ops regression gate	Checkout repository	The process '/usr/bin/git' failed with exit code 128

--- a/scripts/ci/__tests__/ci-flake-classify.test.sh
+++ b/scripts/ci/__tests__/ci-flake-classify.test.sh
@@ -12,4 +12,5 @@ assert_genuine()  { if is_infra_log "$(cat "$1")"; then echo "FAIL genuine: $(ba
 assert_infra   "$FIX/infra-action-setup.txt"
 assert_infra   "$FIX/infra-checkout-403.txt"
 assert_genuine "$FIX/genuine-test-failure.txt"
+assert_genuine "$FIX/genuine-app-403.txt"
 [[ "$fail" == "0" ]] && { echo "ci-flake-classify matcher: PASS"; exit 0; } || { echo "ci-flake-classify matcher: FAIL"; exit 1; }

--- a/scripts/ci/__tests__/ci-flake-classify.test.sh
+++ b/scripts/ci/__tests__/ci-flake-classify.test.sh
@@ -1,0 +1,15 @@
+#!/usr/bin/env bash
+# Unit test for ci-flake-classify.sh's infra-signature matcher (the testable core).
+# Does NOT hit real CI (that would be flaky); feeds recorded incident excerpts to is_infra_log.
+set -uo pipefail
+HERE="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+# shellcheck source=../ci-flake-classify.sh
+source "$HERE/../ci-flake-classify.sh"
+FIX="$HERE/../__fixtures__"
+fail=0
+assert_infra()    { if is_infra_log "$(cat "$1")"; then echo "ok   infra:   $(basename "$1")"; else echo "FAIL infra:   $(basename "$1") (expected match)"; fail=1; fi; }
+assert_genuine()  { if is_infra_log "$(cat "$1")"; then echo "FAIL genuine: $(basename "$1") (matched infra, expected genuine)"; fail=1; else echo "ok   genuine: $(basename "$1")"; fi; }
+assert_infra   "$FIX/infra-action-setup.txt"
+assert_infra   "$FIX/infra-checkout-403.txt"
+assert_genuine "$FIX/genuine-test-failure.txt"
+[[ "$fail" == "0" ]] && { echo "ci-flake-classify matcher: PASS"; exit 0; } || { echo "ci-flake-classify matcher: FAIL"; exit 1; }

--- a/scripts/ci/ci-flake-classify.sh
+++ b/scripts/ci/ci-flake-classify.sh
@@ -19,14 +19,18 @@ set -euo pipefail
 #   3  at least one genuine failure (do NOT rerun blindly — investigate)
 #   1  script/usage error (bad args, gh unavailable)
 #
-# Infra-flake signatures — observed in real GitHub Actions incidents (2026-05-26, PR #1876):
-#   pnpm/action-setup, codeload.github.com, "could not be found at the URI",
-#   "Failed to download archive"            → action-CDN download flake (Set up job)
-#   "HTTP 403", "unable to access", "RPC failed", "expected 'packfile'", git exit 128
-#                                           → repo checkout / git throttle (Checkout repository)
-# A failure whose log matches none of these is classified GENUINE (fail-safe direction:
-# unknown → treat as real, never silently rerun).
-INFRA_SIGNATURES='pnpm/action-setup|codeload\.github\.com|could not be found at the URI|Failed to download archive|HTTP 403|unable to access .https://github|RPC failed|expected .packfile|failed with exit code 128'
+# Infra-flake signatures — observed in real GitHub Actions incidents (2026-05-26, PR #1876).
+# EVERY signature is CONTEXT-BOUND: a bare token like "HTTP 403" or "exit code 128" is NOT a
+# signature, because genuine app/auth/permission tests legitimately print those. Each pattern
+# ties the failure to a GitHub-infra context (action download or git checkout):
+#   action-CDN download (Set up job): pnpm/action-setup, codeload.github.com,
+#     "Download action repository", "could not be found at the URI", "Failed to download archive"
+#   repo checkout / git transport (Checkout repository): "unable to access 'https://…github"
+#     (URL-bound 403/auth), "RPC failed; HTTP" (git RPC), "/usr/bin/git' failed with exit code 128"
+#     (git-bound 128), "fatal: expected 'packfile'" (git clone)
+# A failure whose log matches none of these is classified GENUINE (fail-safe: unknown → real,
+# never silently rerun). In particular a bare app-level "HTTP 403" stays GENUINE.
+INFRA_SIGNATURES='pnpm/action-setup|codeload\.github\.com|Download action repository|could not be found at the URI|Failed to download archive|unable to access .https?://[^ ]*github|RPC failed; HTTP|/usr/bin/git. failed with exit code 128|fatal: expected .packfile'
 
 # is_infra_log <text> | echo <text> | is_infra_log
 # Returns 0 if the log text matches a known infra signature, 1 otherwise.

--- a/scripts/ci/ci-flake-classify.sh
+++ b/scripts/ci/ci-flake-classify.sh
@@ -1,0 +1,103 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+# ci-flake-classify.sh — classify a PR's failing CI checks as GitHub-infra flake vs genuine.
+#
+# Usage:
+#   scripts/ci/ci-flake-classify.sh <PR-number> [--rerun]
+#
+# Default is classify-only (read-only): prints a verdict and which jobs are infra vs genuine.
+# --rerun is opt-in and ONLY re-runs failed jobs when EVERY failure is an infra flake (never
+# when a genuine failure is present). Re-running CI is idempotent and touches no prod/staging.
+#
+# Auth surface: the local `gh` CLI only. This script never reads JWTs or service tokens, and
+# never puts a secret on a command line.
+#
+# Exit codes (chainable into a bounded-retry loop):
+#   0  no failing checks (all clear)
+#   2  all failures are infra flakes (safe to rerun)
+#   3  at least one genuine failure (do NOT rerun blindly — investigate)
+#   1  script/usage error (bad args, gh unavailable)
+#
+# Infra-flake signatures — observed in real GitHub Actions incidents (2026-05-26, PR #1876):
+#   pnpm/action-setup, codeload.github.com, "could not be found at the URI",
+#   "Failed to download archive"            → action-CDN download flake (Set up job)
+#   "HTTP 403", "unable to access", "RPC failed", "expected 'packfile'", git exit 128
+#                                           → repo checkout / git throttle (Checkout repository)
+# A failure whose log matches none of these is classified GENUINE (fail-safe direction:
+# unknown → treat as real, never silently rerun).
+INFRA_SIGNATURES='pnpm/action-setup|codeload\.github\.com|could not be found at the URI|Failed to download archive|HTTP 403|unable to access .https://github|RPC failed|expected .packfile|failed with exit code 128'
+
+# is_infra_log <text> | echo <text> | is_infra_log
+# Returns 0 if the log text matches a known infra signature, 1 otherwise.
+is_infra_log() {
+  local text="${1:-$(cat)}"
+  grep -qiE "$INFRA_SIGNATURES" <<<"$text"
+}
+
+_die() { echo "ci-flake-classify: $*" >&2; exit 1; }
+
+classify_pr() {
+  local pr="$1" do_rerun="$2"
+  command -v gh >/dev/null 2>&1 || _die "gh CLI not found"
+  [[ "$pr" =~ ^[0-9]+$ ]] || _die "PR number must be numeric, got: $pr"
+
+  # tab-separated: name<TAB>state<TAB>elapsed<TAB>url
+  local checks; checks="$(gh pr checks "$pr" 2>/dev/null)" || _die "could not read checks for PR #$pr"
+  local failing; failing="$(awk -F'\t' '$2=="fail"{print $1"\t"$NF}' <<<"$checks")"
+
+  if [[ -z "$failing" ]]; then
+    echo "VERDICT: CLEAR — no failing checks on PR #$pr"
+    return 0
+  fi
+
+  local genuine="" infra="" run_ids=""
+  while IFS=$'\t' read -r name url; do
+    [[ -z "$name" ]] && continue
+    local job_id run_id log
+    job_id="$(grep -oE 'job/[0-9]+' <<<"$url" | grep -oE '[0-9]+' || true)"
+    run_id="$(grep -oE 'runs/[0-9]+' <<<"$url" | grep -oE '[0-9]+' || true)"
+    [[ -n "$run_id" ]] && run_ids+="$run_id"$'\n'
+    log=""
+    [[ -n "$job_id" ]] && log="$(gh run view --job "$job_id" --log-failed 2>/dev/null | tail -50 || true)"
+    if [[ -n "$log" ]] && is_infra_log "$log"; then
+      infra+="  [infra]   $name"$'\n'
+    else
+      genuine+="  [genuine] $name"$'\n'
+    fi
+  done <<<"$failing"
+
+  echo "Failing checks on PR #$pr:"
+  [[ -n "$infra" ]]   && printf '%s' "$infra"
+  [[ -n "$genuine" ]] && printf '%s' "$genuine"
+
+  if [[ -n "$genuine" ]]; then
+    echo "VERDICT: GENUINE — at least one failure is not an infra flake; do NOT rerun blindly."
+    return 3
+  fi
+
+  echo "VERDICT: INFRA — all failures match known GitHub-infra signatures (safe to rerun)."
+  if [[ "$do_rerun" == "true" ]]; then
+    local uniq_runs; uniq_runs="$(printf '%s' "$run_ids" | sort -u | grep -E '^[0-9]+$' || true)"
+    for r in $uniq_runs; do
+      echo "  rerunning failed jobs in run $r"
+      gh run rerun "$r" --failed >/dev/null 2>&1 || echo "  (rerun $r failed to dispatch)" >&2
+    done
+  else
+    echo "  (re-run with: $0 $pr --rerun)"
+  fi
+  return 2
+}
+
+main() {
+  local pr="${1:-}" flag="${2:-}"
+  [[ -z "$pr" || "$pr" == "-h" || "$pr" == "--help" ]] && _die "usage: $0 <PR-number> [--rerun]"
+  local do_rerun="false"
+  [[ "$flag" == "--rerun" ]] && do_rerun="true"
+  classify_pr "$pr" "$do_rerun"
+}
+
+# Allow sourcing (for tests) without executing main.
+if [[ "${BASH_SOURCE[0]:-$0}" == "${0}" ]]; then
+  main "$@"
+fi


### PR DESCRIPTION
## What

P3 consolidation: one ops doc + one reusable read-only tool that **encode the judgment** from this session's acceptance work (so future verifications need less manual reasoning and avoid the specific mistakes that bit us). 6 files; mostly decision rules, cross-referencing existing runbooks rather than copying them.

## Contents

- **`docs/operations/attendance-acceptance-harness.md`** — consolidation map (links #1850 staging-acceptance runbook, workbench runbook, #1810 heartbeat, #1843 login/logout evidence, #1836 closeout) + decision rules:
  - **R1 token hygiene** — 0600 file, `curl -H @header-file` (never argv), delete ≠ invalidate (rotate server-side), staging/prod distinct `JWT_SECRET`.
  - **R2 settings save/restore** — restore from the **saved original**, never a hardcoded value (the #1850 BLOCK: hardcoded nulls wipe pre-existing caps).
  - **R3 infra-flake vs genuine** — the 2–4s-across-unrelated-suites signature + signatures table + the classifier.
  - **R4 green-by-skip 3-point check** — `DATABASE_URL` in step env? `|| true`? test-level `!baseUrl` early-return? (the #1861→#1867→#1872 arc).
  - **R5 wire/save-path drift** — a field isn't "persistable" until a route round-trip proves it (#1829 zod-strip, #1781 serialization-strip).
- **`scripts/ci/ci-flake-classify.sh`** — classify a PR's failing checks as GitHub-infra flake vs genuine using recorded incident signatures. **`gh`-only auth, no token, no prod/staging writes.** Classify-only by default; `--rerun` opt-in **only** when every failure is infra. Exit codes `0` clear / `2` all-infra / `3` genuine / `1` error (chainable into a bounded-retry loop).
- **`scripts/ci/__tests__` + `__fixtures__`** — matcher unit test over recorded incident excerpts (no live-CI dependency). PASS locally.

## Boundaries

Read-only / diagnostic. No new route, no migration, no `attendance_*`/`meta_*` write, no prod/staging mutation, no auto-anything. Scripts use only local `gh` auth.

## Deliberately excluded

The #1810 §3.6 "logout doesn't clear session" finding stays **unverified** in its closeout — not promoted into this runbook.

🤖 Generated with [Claude Code](https://claude.com/claude-code)