### PR TITLE
fix(multitable): reject writes to formula fields (readonly, like lookup/rollup)

### DIFF
--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -401,7 +401,11 @@ export class RecordWriteService {
           throw new RecordFieldForbiddenError(`Field is readonly: ${change.fieldId}`, change.fieldId)
         }
 
-        if (field.type === 'lookup' || field.type === 'rollup') {
+        // formula/lookup/rollup are computed (readonly) fields — their values are
+        // derived server-side, never written by clients. `deriveFieldPermissions`
+        // already marks them readonly for the UI; reject here too as the backend
+        // backstop so a non-UI client can't pollute record data with a written value.
+        if (field.type === 'formula' || field.type === 'lookup' || field.type === 'rollup') {
           throw new RecordFieldForbiddenError(`Field is readonly: ${change.fieldId}`, change.fieldId)
         }
 
@@ -571,11 +575,8 @@ export class RecordWriteService {
         for (const change of changes) {
           const field = fieldById.get(change.fieldId)
           if (!field) continue
-
-          if (field.type === 'formula') {
-            if (typeof change.value !== 'string') continue
-            if (change.value !== '' && !change.value.startsWith('=')) continue
-          }
+          // Note: formula/lookup/rollup are rejected up-front in validateChanges
+          // (Step 0), so no computed-field change reaches this write loop.
 
           if (field.type === 'link' && field.link) {
             const ids = h.normalizeLinkIds(change.value)

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -597,15 +597,14 @@ describe('RecordWriteService', () => {
   })
 
   it('should not emit events when no records are updated', async () => {
-    // Pass a formula field change with invalid value (not starting with =), so applied === 0
-    const changesByRecord = new Map([
-      ['rec1', [{ fieldId: 'fld_formula', value: 123 }]],
+    // A record whose change list is empty applies nothing (applied === 0), so no
+    // update is recorded and neither realtime nor eventBus fire. (Previously this
+    // leaned on the formula write-loop skip; formula is now rejected up-front in
+    // validateChanges, so an empty change list is the clean "no-op" scenario.)
+    const changesByRecord = new Map<string, Array<{ fieldId: string; value: unknown }>>([
+      ['rec1', []],
     ])
-    // Add formula field to fieldById so validation passes
-    const fieldByIdWithFormula = new Map([
-      ['fld_formula', { type: 'formula' as const, readOnly: false, hidden: false }],
-    ])
-    const input = buildTestInput({ changesByRecord, fieldById: fieldByIdWithFormula })
+    const input = buildTestInput({ changesByRecord })
     const service = new RecordWriteService(pool, eventBus as any, helpers)
     const result = await service.patchRecords(input)
 
@@ -688,9 +687,9 @@ describe('RecordWriteService', () => {
         .rejects.toThrow(RecordFieldForbiddenError)
     })
 
-    it('rejects lookup/rollup fields', async () => {
+    it('rejects computed fields (formula/lookup/rollup)', async () => {
       const service = new RecordWriteService(pool, eventBus as any, helpers)
-      for (const type of ['lookup', 'rollup'] as const) {
+      for (const type of ['formula', 'lookup', 'rollup'] as const) {
         const changesByRecord = new Map([
           ['rec1', [{ fieldId: 'fld1', value: 'x' }]],
         ])


### PR DESCRIPTION
Follow-up to **A1 (#1883)** — closes the write-policy gap A1 left open.

## Why
Formula fields are computed/readonly. `deriveFieldPermissions` (`permission-derivation.ts:58`) already marks `formula`/`lookup`/`rollup` readonly, so the web grid treats formula cells as readonly and **never PATCHes them**. But `validateChanges` only rejected `lookup`/`rollup` — it let a non-UI client write `''` or `=…` into a formula field's value, polluting `record.data`.

## Change
- `validateChanges`: reject `formula` in the same `RecordFieldForbiddenError` (FIELD_READONLY) branch as `lookup`/`rollup` — backend backstop matching the existing readonly intent.
- Drop the now-dead `formula` skip in the patch write loop (`validateChanges` runs first in Step 0, so no computed-field change reaches the loop).
- Repurpose the "no events when no records updated" test to an empty-change no-op (it previously leaned on the formula skip).

## Safety (pre-check done)
- Frontend already treats formula readonly (perm-derivation → `readOnlyFieldIds`) → no UI flow sends formula in a PATCH.
- Create / form-submit paths use a **separate** validation (`record-service`), not `validateChanges` — unaffected.
- The recalc's own materialization write (A1) goes via a direct DB UPDATE in `recalculateRecord`, not `validateChanges` — unaffected.
- No test PATCHes a formula value expecting success; the one no-op test is updated.

## Verify
- `pnpm --filter @metasheet/core-backend test:unit` → **2340 pass**; `build` (tsc) → green.
- New coverage: `validateChanges > rejects computed fields (formula/lookup/rollup)`.

Scope: multitable kernel only — no integration-core / K3 / RBAC / auth / storage; no OSS.

🤖 Generated with [Claude Code](https://claude.com/claude-code)