### PR TITLE
fix(auth): tune RC logout and login limits

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -94,6 +94,10 @@ ATTENDANCE_IMPORT_REQUIRE_TOKEN=0
 # =============================================================================
 RATE_LIMIT_WINDOW_MS=900000
 RATE_LIMIT_MAX_REQUESTS=100
+AUTH_RATE_LIMIT_WINDOW_MS=900000
+AUTH_LOGIN_MAX_ATTEMPTS=5
+AUTH_LOGIN_BLOCK_DURATION_MS=1800000
+AUTH_REGISTER_MAX_PER_IP=3
 
 # =============================================================================
 # CORS CONFIGURATION

--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -172,23 +172,24 @@ const accountEmail = computed(() => {
 
 async function logout(): Promise<void> {
   const token = getToken()
-  if (token) {
-    try {
-      await fetch(`${getApiBase()}/api/auth/logout`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${token}`,
-        },
-      })
-    } catch {
-      // Ignore logout network failures and still clear local session.
-    }
-  }
   clearToken()
   try {
     clearStoredAuthState()
   } catch {
     // Ignore local session cleanup failures; logout should still leave the view.
+  }
+  if (token) {
+    try {
+      void fetch(`${getApiBase()}/api/auth/logout`, {
+        method: 'POST',
+        keepalive: true,
+        headers: {
+          Authorization: `Bearer ${token}`,
+        },
+      }).catch(() => null)
+    } catch {
+      // Ignore logout network failures and still clear local session.
+    }
   }
   window.location.assign('/login')
 }

--- a/apps/web/tests/App.spec.ts
+++ b/apps/web/tests/App.spec.ts
@@ -164,6 +164,11 @@ describe('App guest bootstrap', () => {
     window.localStorage.setItem('metasheet_product_mode', 'attendance')
     window.localStorage.setItem('user_permissions', '["attendance:admin"]')
     window.localStorage.setItem('user_roles', '["admin"]')
+    const authTokensSeenByLogoutFetch: Array<string | null> = []
+    vi.mocked(globalThis.fetch).mockImplementation(async () => {
+      authTokensSeenByLogoutFetch.push(window.localStorage.getItem('auth_token'))
+      return new Response('{}', { status: 200 })
+    })
 
     container = document.createElement('div')
     document.body.appendChild(container)
@@ -189,11 +194,13 @@ describe('App guest bootstrap', () => {
 
     expect(globalThis.fetch).toHaveBeenCalledWith('https://api.example.com/api/auth/logout', {
       method: 'POST',
+      keepalive: true,
       headers: {
         Authorization: 'Bearer session-token',
       },
     })
     expect(mocks.clearStoredAuthState).toHaveBeenCalledTimes(1)
+    expect(authTokensSeenByLogoutFetch).toEqual([null])
     for (const key of [
       'auth_token',
       'jwt',

--- a/packages/core-backend/src/routes/auth.ts
+++ b/packages/core-backend/src/routes/auth.ts
@@ -105,10 +105,39 @@ interface RateLimitEntry {
 const rateLimitStore = new Map<string, RateLimitEntry>()
 
 // Configuration
-const RATE_LIMIT_WINDOW_MS = 15 * 60 * 1000  // 15 minutes
-const MAX_LOGIN_ATTEMPTS = 5                   // Max failed attempts
-const BLOCK_DURATION_MS = 30 * 60 * 1000      // 30 minutes block
-const MAX_REGISTER_PER_IP = 3                  // Max registrations per IP per window
+const DEFAULT_AUTH_RATE_LIMIT_CONFIG = {
+  windowMs: 15 * 60 * 1000,          // 15 minutes
+  maxLoginAttempts: 5,               // Max failed attempts
+  blockDurationMs: 30 * 60 * 1000,   // 30 minutes block
+  maxRegisterPerIp: 3,               // Max registrations per IP per window
+} as const
+
+interface AuthRateLimitConfig {
+  windowMs: number
+  maxLoginAttempts: number
+  blockDurationMs: number
+  maxRegisterPerIp: number
+}
+
+function parsePositiveIntegerEnv(name: string, fallback: number): number {
+  const raw = process.env[name]
+  if (typeof raw !== 'string' || raw.trim().length === 0) return fallback
+  const parsed = Number(raw.trim())
+  if (!Number.isInteger(parsed) || parsed < 1) {
+    logger.warn(`Ignoring invalid ${name}; expected a positive integer`)
+    return fallback
+  }
+  return parsed
+}
+
+function getAuthRateLimitConfig(): AuthRateLimitConfig {
+  return {
+    windowMs: parsePositiveIntegerEnv('AUTH_RATE_LIMIT_WINDOW_MS', DEFAULT_AUTH_RATE_LIMIT_CONFIG.windowMs),
+    maxLoginAttempts: parsePositiveIntegerEnv('AUTH_LOGIN_MAX_ATTEMPTS', DEFAULT_AUTH_RATE_LIMIT_CONFIG.maxLoginAttempts),
+    blockDurationMs: parsePositiveIntegerEnv('AUTH_LOGIN_BLOCK_DURATION_MS', DEFAULT_AUTH_RATE_LIMIT_CONFIG.blockDurationMs),
+    maxRegisterPerIp: parsePositiveIntegerEnv('AUTH_REGISTER_MAX_PER_IP', DEFAULT_AUTH_RATE_LIMIT_CONFIG.maxRegisterPerIp),
+  }
+}
 
 function getClientIP(req: Request): string {
   const forwarded = req.headers['x-forwarded-for']
@@ -138,7 +167,11 @@ function resolveRequestTenantId(req: Request): string | undefined {
   )
 }
 
-function checkRateLimit(key: string, maxAttempts: number): { allowed: boolean; retryAfter?: number } {
+function checkRateLimit(
+  key: string,
+  maxAttempts: number,
+  config: Pick<AuthRateLimitConfig, 'windowMs' | 'blockDurationMs'>,
+): { allowed: boolean; retryAfter?: number } {
   const now = Date.now()
   const entry = rateLimitStore.get(key)
 
@@ -151,7 +184,7 @@ function checkRateLimit(key: string, maxAttempts: number): { allowed: boolean; r
   if (!entry || entry.resetTime < now) {
     rateLimitStore.set(key, {
       count: 1,
-      resetTime: now + RATE_LIMIT_WINDOW_MS,
+      resetTime: now + config.windowMs,
       blocked: false
     })
     return { allowed: true }
@@ -161,9 +194,9 @@ function checkRateLimit(key: string, maxAttempts: number): { allowed: boolean; r
   entry.count++
   if (entry.count > maxAttempts) {
     entry.blocked = true
-    entry.blockExpires = now + BLOCK_DURATION_MS
-    logger.warn(`Blocking ${key} for ${BLOCK_DURATION_MS / 1000}s after ${entry.count} attempts`)
-    return { allowed: false, retryAfter: Math.ceil(BLOCK_DURATION_MS / 1000) }
+    entry.blockExpires = now + config.blockDurationMs
+    logger.warn(`Blocking ${key} for ${config.blockDurationMs / 1000}s after ${entry.count} attempts`)
+    return { allowed: false, retryAfter: Math.ceil(config.blockDurationMs / 1000) }
   }
 
   return { allowed: true }
@@ -185,7 +218,8 @@ const loginRateLimiter = (req: Request, res: Response, next: NextFunction) => {
   ).toLowerCase()
   const key = `login:${ip}:${identifier}`
 
-  const result = checkRateLimit(key, MAX_LOGIN_ATTEMPTS)
+  const config = getAuthRateLimitConfig()
+  const result = checkRateLimit(key, config.maxLoginAttempts, config)
   if (!result.allowed) {
     logger.warn(`Rate limit exceeded for login: ${ip} / ${identifier}`)
     return res.status(429).json({
@@ -202,7 +236,8 @@ const registerRateLimiter = (req: Request, res: Response, next: NextFunction) =>
   const ip = getClientIP(req)
   const key = `register:${ip}`
 
-  const result = checkRateLimit(key, MAX_REGISTER_PER_IP)
+  const config = getAuthRateLimitConfig()
+  const result = checkRateLimit(key, config.maxRegisterPerIp, config)
   if (!result.allowed) {
     logger.warn(`Rate limit exceeded for registration: ${ip}`)
     return res.status(429).json({
@@ -445,7 +480,7 @@ function requiresPasswordChange(user: User | null | undefined): boolean {
 
 /**
  * 用户登录
- * Protected by rate limiting: 5 attempts per 15 minutes
+ * Protected by configurable rate limiting: default 5 attempts per 15 minutes
  */
 authRouter.post('/login', loginRateLimiter, async (req: Request, res: Response) => {
   const ip = getClientIP(req)
@@ -504,7 +539,7 @@ authRouter.post('/login', loginRateLimiter, async (req: Request, res: Response) 
 
 /**
  * 用户注册
- * Protected by rate limiting: 3 registrations per IP per 15 minutes
+ * Protected by configurable rate limiting: default 3 registrations per IP per 15 minutes
  */
 authRouter.post('/register', registerRateLimiter, async (req: Request, res: Response) => {
   const ip = getClientIP(req)

--- a/packages/core-backend/tests/unit/auth-login-routes.test.ts
+++ b/packages/core-backend/tests/unit/auth-login-routes.test.ts
@@ -180,13 +180,14 @@ async function invokeRoute(
         })
         if (maybePromise && typeof maybePromise.then === 'function') {
           Promise.resolve(maybePromise).then(() => resolve()).catch(reject)
-        } else if (routeLayer.handle.length < 3) {
+        } else if (res.headersSent || routeLayer.handle.length < 3) {
           resolve()
         }
       } catch (error) {
         reject(error)
       }
     })
+    if (res.headersSent) break
   }
 
   return res
@@ -293,6 +294,25 @@ describe('auth login routes', () => {
         ipAddress: '127.0.0.1',
       }),
     )
+  })
+
+  it('honors env-tuned login rate limit thresholds', async () => {
+    vi.stubEnv('AUTH_LOGIN_MAX_ATTEMPTS', '1')
+    vi.stubEnv('AUTH_LOGIN_BLOCK_DURATION_MS', '2500')
+    authServiceMocks.login.mockResolvedValue(null)
+
+    const body = {
+      email: 'rate-limit-env@example.com',
+      password: 'WrongPass9A',
+    }
+
+    const firstResponse = await invokeRoute('post', '/login', { body })
+    const secondResponse = await invokeRoute('post', '/login', { body })
+
+    expect(firstResponse.statusCode).toBe(401)
+    expect(secondResponse.statusCode).toBe(429)
+    expect((secondResponse.body as Record<string, any>).retryAfter).toBe(3)
+    expect(authServiceMocks.login).toHaveBeenCalledTimes(1)
   })
 
   it('forwards x-tenant-id into the normal login flow', async () => {


### PR DESCRIPTION
## Summary
- Clear local auth/token state before firing the logout revoke request, then send the backend revoke as a keepalive fire-and-forget request to shrink the stale-token 403 window.
- Make auth login/register rate limit thresholds env-tunable while preserving current production defaults.
- Cover the auth 429 middleware short-circuit path in unit tests.

## #649 coverage
- Handles the remaining code deltas for logout/request cleanup and env-tunable login rate limits.
- Current main already covers the zero-data attendance guidance and narrow desktop/headless attendance viewport hinting with focused frontend tests.
- Current routing already redirects the legacy plugin attendance path to `/attendance`; the approval inbox empty state renders via the table empty slot without introducing console.error logging.

Closes #649

## Verification
- `git diff --check HEAD~1..HEAD`
- `pnpm --filter @metasheet/web exec vitest run tests/App.spec.ts tests/attendance-selfservice-dashboard.spec.ts tests/attendance-experience-entrypoints.spec.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/auth-login-routes.test.ts --watch=false`
- `pnpm --filter @metasheet/web lint`
- `pnpm --filter @metasheet/core-backend build`