### PR TITLE
feat(integration): add K3 WISE Material-only gate check

### DIFF
--- a/docs/development/k3wise-material-only-gate-check-design-20260527.md
+++ b/docs/development/k3wise-material-only-gate-check-design-20260527.md
@@ -1,0 +1,76 @@
+# K3 WISE Material-Only Gate Check Design - 2026-05-27
+
+## Purpose
+
+Issue #1792 is the umbrella customer GATE for the K3 WISE live PoC. It must not
+act as a global stop sign for lock-safe Data Factory work, but it must still
+block K3 write expansion, BOM, Submit/Audit, and production signoff.
+
+The immediate need is a smaller machine-checkable sub-gate for the current
+Material-first path:
+
+- verify that Material read/detail evidence is present and sanitized;
+- verify that the first dry-run scope stays `FNumber` / `FName`;
+- verify that BOM and Save-only are still separately gated;
+- avoid requiring deferred BOM, relationship, pagination, list, or broad read
+  evidence for this Material-only readiness check.
+
+## Change
+
+`scripts/ops/integration-k3wise-gate-contract-check.mjs` now supports:
+
+```bash
+--scope full
+--scope material-only
+```
+
+`full` remains the default and preserves the existing O/R full GATE behavior.
+
+`material-only` validates only:
+
+- `webapiReadList.answers.O1-MAT`
+- `webapiReadList.answers.O1-MAT-M`
+- `webapiReadList.answers.O6`
+- `webapiReadList.samples.materialDetail`
+- `materialOnlySafety.answers.M0-SCOPE`
+- `materialOnlySafety.answers.M0-PREVIEW-FIELDS`
+- `materialOnlySafety.answers.M0-BOM-DEFERRED`
+- `materialOnlySafety.answers.M0-SAVE-ONLY-SEPARATE-APPROVAL`
+- `materialOnlySafety.answers.M0-AUTOSUBMIT-FALSE`
+- `materialOnlySafety.answers.M0-AUTOAUDIT-FALSE`
+
+The successful material-only decision is `PASS_MATERIAL_ONLY`, not `PASS`.
+This makes the artifact usable for #1792 Material dry-run readiness without
+being mistaken for the full customer GATE.
+
+The `M0-PREVIEW-FIELDS` answer must explicitly mention `FNumber` and `FName`
+so the sub-gate matches the current #1792 decision: first Material dry-run is
+minimal and does not enable `FModel` or unit mapping.
+
+## Boundaries
+
+This change does not contact MetaSheet or K3 WISE.
+
+It does not approve:
+
+- K3 Save-only;
+- K3 Submit;
+- K3 Audit;
+- BOM Save;
+- relationship runtime;
+- broad read/list, pagination, or filters;
+- master-code resolver;
+- server-side reference-object composition;
+- production signoff.
+
+Save-only remains behind separate explicit approval after Material dry-run
+evidence and rollback ownership are confirmed.
+
+## Compatibility
+
+Existing callers do not need to change. If `--scope` is omitted, the checker
+uses `full` and still requires the full O1-O6/R1-R7 evidence set.
+
+The `material-only` report is intentionally not accepted as the existing full
+delivery-readiness gate, because that readiness compiler checks for
+`decision === "PASS"`.

--- a/docs/development/k3wise-material-only-gate-check-verification-20260527.md
+++ b/docs/development/k3wise-material-only-gate-check-verification-20260527.md
@@ -1,0 +1,52 @@
+# K3 WISE Material-Only Gate Check Verification - 2026-05-27
+
+## Scope
+
+This verifies the `--scope material-only` sub-gate added to
+`scripts/ops/integration-k3wise-gate-contract-check.mjs`.
+
+It is a tooling-only change. No plugin runtime, DB migration, API route,
+frontend, K3 write, Submit/Audit, BOM, or broad read/list behavior is added.
+
+## Commands
+
+```bash
+node --check scripts/ops/integration-k3wise-gate-contract-check.mjs
+node --check scripts/ops/integration-k3wise-gate-contract-check.test.mjs
+node scripts/ops/integration-k3wise-gate-contract-check.test.mjs
+node scripts/ops/integration-k3wise-gate-contract-check.mjs --help
+CHECK_DIR="$(mktemp -d /tmp/k3wise-material-only-template-check-XXXXXX)"
+node scripts/ops/integration-k3wise-gate-contract-check.mjs --init-template "$CHECK_DIR"
+node scripts/ops/integration-k3wise-gate-contract-check.mjs --scope material-only --input "$CHECK_DIR/k3wise-gate-contract-packet.template.json" --out-dir "$CHECK_DIR/check-material-only"
+git diff --check
+```
+
+## Results
+
+| Check | Result |
+| --- | --- |
+| Script syntax | PASS |
+| Test syntax | PASS |
+| Gate checker test suite | PASS, 11/11 |
+| Help output includes `--scope` | PASS |
+| Template contains `materialOnlySafety.answers` | PASS |
+| Unfilled template remains blocked in material-only mode | PASS, `decision=GATE_BLOCKED` |
+| Package verifier marker | PASS, verifier now checks packaged checker contains `PASS_MATERIAL_ONLY` |
+| Whitespace check | PASS |
+
+## Acceptance Matrix
+
+| Requirement | Evidence |
+| --- | --- |
+| Default full behavior remains unchanged | Existing full PASS and full blocked tests still pass with no `--scope` argument. |
+| Material-only can pass without BOM/relationship/list/pagination evidence | `material-only scope passes without BOM, pagination, list, or relationship evidence`. |
+| Material-only missing O1/O6/sample/safety inputs blocks | `material-only scope blocks missing material answers, safety answers, or material sample`. |
+| Material-only rejects absolute URLs and secret query parameters | `material-only scope still rejects unsafe endpoints and query secrets`. |
+| Material-only sample secret scan remains active | `material-only scope still scans material samples for secrets`. |
+| Successful material-only decision cannot be confused with full PASS | Decision is `PASS_MATERIAL_ONLY`, and Markdown states this is not full customer GATE pass and does not approve K3 Save-only. |
+
+## Boundary Confirmation
+
+`PASS_MATERIAL_ONLY` means Material dry-run readiness only. It does not approve
+K3 Save-only, Submit, Audit, BOM, broad read/list, server-side composition, or
+production use.

--- a/scripts/ops/integration-k3wise-gate-contract-check.mjs
+++ b/scripts/ops/integration-k3wise-gate-contract-check.mjs
@@ -5,6 +5,7 @@ import path from 'node:path'
 import { fileURLToPath } from 'node:url'
 
 const DEFAULT_OUTPUT_ROOT = 'output/integration-k3wise-gate-contract-check'
+const VALID_SCOPES = new Set(['full', 'material-only'])
 const READ_ANSWER_IDS = [
   'O1-MAT',
   'O1-MAT-M',
@@ -21,6 +22,9 @@ const READ_ANSWER_IDS = [
 ]
 const READ_METHOD_IDS = ['O1-MAT-M', 'O1-BOM-M']
 const READ_PATH_IDS = ['O1-MAT', 'O1-BOM']
+const MATERIAL_ONLY_READ_ANSWER_IDS = ['O1-MAT', 'O1-MAT-M', 'O6']
+const MATERIAL_ONLY_READ_METHOD_IDS = ['O1-MAT-M']
+const MATERIAL_ONLY_READ_PATH_IDS = ['O1-MAT']
 const READ_SAMPLES = {
   materialList: {
     label: 'Material list sample',
@@ -37,6 +41,12 @@ const READ_SAMPLES = {
   bomDetail: {
     label: 'BOM detail sample',
     validator: assertBomSample,
+  },
+}
+const MATERIAL_ONLY_READ_SAMPLES = {
+  materialDetail: {
+    label: 'Material detail sample',
+    validator: assertMaterialSample,
   },
 }
 const RELATIONSHIP_ANSWER_IDS = ['R1', 'R2', 'R3', 'R4', 'R5', 'R6', 'R7']
@@ -58,6 +68,14 @@ const RELATIONSHIP_SAMPLES = {
     validator: assertK3BomSaveShape,
   },
 }
+const MATERIAL_ONLY_SAFETY_ANSWER_IDS = [
+  'M0-SCOPE',
+  'M0-PREVIEW-FIELDS',
+  'M0-BOM-DEFERRED',
+  'M0-SAVE-ONLY-SEPARATE-APPROVAL',
+  'M0-AUTOSUBMIT-FALSE',
+  'M0-AUTOAUDIT-FALSE',
+]
 const TEMPLATE_PACKET_FILE = 'k3wise-gate-contract-packet.template.json'
 const TEMPLATE_HANDOFF_README_FILE = 'README-CUSTOMER-HANDOFF.zh.md'
 const TEMPLATE_SAMPLE_FILES = {
@@ -88,7 +106,7 @@ class GateContractCheckError extends Error {
 
 function printHelp() {
   console.log(`Usage:
-  node scripts/ops/integration-k3wise-gate-contract-check.mjs --input <packet.json> [options]
+  node scripts/ops/integration-k3wise-gate-contract-check.mjs --input <packet.json> [--scope full|material-only] [options]
   node scripts/ops/integration-k3wise-gate-contract-check.mjs --init-template <dir>
 
 Validates the customer GATE-front packet for #1526 before any K3 WISE read/list,
@@ -97,6 +115,7 @@ does not contact MetaSheet or K3.
 
 Options:
   --input <path>      JSON packet with WebAPI read/list and relationship answers
+  --scope <scope>     Validation scope: full (default) or material-only
   --init-template <dir>
                       Create a fillable packet + redacted sample skeleton outside Git
   --out-dir <dir>    Evidence output directory, default ${DEFAULT_OUTPUT_ROOT}/<timestamp>
@@ -121,6 +140,16 @@ Packet shape:
       "unresolvedChild": "relationship-unresolved-child.redacted.json",
       "k3BomSaveShape": "relationship-k3-bom-save-shape.redacted.json"
     }
+  },
+  "materialOnlySafety": {
+    "answers": {
+      "M0-SCOPE": "Material only first",
+      "M0-PREVIEW-FIELDS": "First dry-run preview only includes FNumber and FName",
+      "M0-BOM-DEFERRED": "BOM deferred until Material passes",
+      "M0-SAVE-ONLY-SEPARATE-APPROVAL": "Save-only requires separate approval after dry-run",
+      "M0-AUTOSUBMIT-FALSE": "autoSubmit=false",
+      "M0-AUTOAUDIT-FALSE": "autoAudit=false"
+    }
   }
 }`)
 }
@@ -138,6 +167,7 @@ function parseArgs(argv = process.argv.slice(2)) {
     input: '',
     initTemplate: '',
     outDir: '',
+    scope: 'full',
     help: false,
   }
   for (let i = 0; i < argv.length; i += 1) {
@@ -155,6 +185,10 @@ function parseArgs(argv = process.argv.slice(2)) {
         opts.outDir = readRequiredValue(argv, i, arg)
         i += 1
         break
+      case '--scope':
+        opts.scope = readRequiredValue(argv, i, arg)
+        i += 1
+        break
       case '--help':
       case '-h':
         opts.help = true
@@ -168,6 +202,9 @@ function parseArgs(argv = process.argv.slice(2)) {
   }
   if (opts.input && opts.initTemplate) {
     throw new GateContractCheckError('--input and --init-template cannot be used together')
+  }
+  if (!VALID_SCOPES.has(opts.scope)) {
+    throw new GateContractCheckError('--scope must be full or material-only', { scope: opts.scope })
   }
   return opts
 }
@@ -183,9 +220,10 @@ function isFilled(value) {
   return !PLACEHOLDER_PATTERN.test(String(value).trim())
 }
 
-function decisionFromIssues(issues) {
+function decisionFromIssues(issues, scope = 'full') {
   if (issues.some((issue) => issue.status === 'fail')) return { decision: 'FAIL', exitCode: 1 }
   if (issues.some((issue) => issue.status === 'blocked')) return { decision: 'GATE_BLOCKED', exitCode: 2 }
+  if (scope === 'material-only') return { decision: 'PASS_MATERIAL_ONLY', exitCode: 0 }
   return { decision: 'PASS', exitCode: 0 }
 }
 
@@ -213,15 +251,15 @@ function validateRequiredAnswers({ answers, ids, sectionId, issues }) {
   }
 }
 
-function validateReadAnswerSemantics(answers, issues) {
-  for (const id of READ_METHOD_IDS) {
+function validateReadAnswerSemantics(answers, issues, { methodIds = READ_METHOD_IDS, pathIds = READ_PATH_IDS } = {}) {
+  for (const id of methodIds) {
     const method = String(answers[id] || '').trim().toUpperCase()
     if (!method) continue
     if (method !== 'GET' && method !== 'POST') {
       addIssue(issues, 'blocked', `webapiReadList.${id}`, `${id} must be GET or POST`, { value: method })
     }
   }
-  for (const id of READ_PATH_IDS) {
+  for (const id of pathIds) {
     const endpoint = String(answers[id] || '').trim()
     if (!endpoint) continue
     if (/^https?:\/\//i.test(endpoint)) {
@@ -232,6 +270,27 @@ function validateReadAnswerSemantics(answers, issues) {
     if (SECRET_QUERY_PATTERN.test(endpoint)) {
       addIssue(issues, 'fail', `webapiReadList.${id}`, `${id} contains a secret-looking query parameter`)
     }
+  }
+}
+
+function validateMaterialOnlySafetyAnswers(answers, issues) {
+  validateRequiredAnswers({
+    answers,
+    ids: MATERIAL_ONLY_SAFETY_ANSWER_IDS,
+    sectionId: 'materialOnlySafety',
+    issues,
+  })
+  const autoSubmit = String(answers['M0-AUTOSUBMIT-FALSE'] || '').trim()
+  const autoAudit = String(answers['M0-AUTOAUDIT-FALSE'] || '').trim()
+  const previewFields = String(answers['M0-PREVIEW-FIELDS'] || '').trim()
+  if (previewFields && (!/\bFNumber\b/i.test(previewFields) || !/\bFName\b/i.test(previewFields))) {
+    addIssue(issues, 'blocked', 'materialOnlySafety.M0-PREVIEW-FIELDS', 'first Material dry-run preview must explicitly include FNumber and FName')
+  }
+  if (autoSubmit && !/autoSubmit\s*=\s*false|^false$|disabled|off|no|禁用|关闭|不启用/i.test(autoSubmit)) {
+    addIssue(issues, 'blocked', 'materialOnlySafety.M0-AUTOSUBMIT-FALSE', 'autoSubmit must be explicitly confirmed false')
+  }
+  if (autoAudit && !/autoAudit\s*=\s*false|^false$|disabled|off|no|禁用|关闭|不启用/i.test(autoAudit)) {
+    addIssue(issues, 'blocked', 'materialOnlySafety.M0-AUTOAUDIT-FALSE', 'autoAudit must be explicitly confirmed false')
   }
 }
 
@@ -384,52 +443,69 @@ async function validateSamples({ samples, sampleSpecs, baseDir, sectionId, issue
   return sampleResults
 }
 
-export async function buildGateContractReport(packet, { inputPath = '', generatedAt = new Date().toISOString() } = {}) {
+export async function buildGateContractReport(packet, { inputPath = '', generatedAt = new Date().toISOString(), scope = 'full' } = {}) {
+  if (!VALID_SCOPES.has(scope)) {
+    throw new GateContractCheckError('scope must be full or material-only', { scope })
+  }
   const issues = []
   const baseDir = inputPath ? path.dirname(path.resolve(inputPath)) : process.cwd()
   const webapiReadList = getObject(packet, 'webapiReadList')
   const relationshipMapping = getObject(packet, 'relationshipMapping')
+  const materialOnlySafety = getObject(packet, 'materialOnlySafety')
   const readAnswers = getObject(webapiReadList, 'answers')
   const relationshipAnswers = getObject(relationshipMapping, 'answers')
+  const materialOnlySafetyAnswers = getObject(materialOnlySafety, 'answers')
 
-  validateRequiredAnswers({
-    answers: readAnswers,
-    ids: READ_ANSWER_IDS,
-    sectionId: 'webapiReadList',
-    issues,
-  })
-  validateReadAnswerSemantics(readAnswers, issues)
+  const readAnswerIds = scope === 'material-only' ? MATERIAL_ONLY_READ_ANSWER_IDS : READ_ANSWER_IDS
+  const readSampleSpecs = scope === 'material-only' ? MATERIAL_ONLY_READ_SAMPLES : READ_SAMPLES
 
-  validateRequiredAnswers({
-    answers: relationshipAnswers,
-    ids: RELATIONSHIP_ANSWER_IDS,
-    sectionId: 'relationshipMapping',
-    issues,
+  validateRequiredAnswers({ answers: readAnswers, ids: readAnswerIds, sectionId: 'webapiReadList', issues })
+  validateReadAnswerSemantics(readAnswers, issues, {
+    methodIds: scope === 'material-only' ? MATERIAL_ONLY_READ_METHOD_IDS : READ_METHOD_IDS,
+    pathIds: scope === 'material-only' ? MATERIAL_ONLY_READ_PATH_IDS : READ_PATH_IDS,
   })
+
+  if (scope === 'material-only') {
+    validateMaterialOnlySafetyAnswers(materialOnlySafetyAnswers, issues)
+  } else {
+    validateRequiredAnswers({
+      answers: relationshipAnswers,
+      ids: RELATIONSHIP_ANSWER_IDS,
+      sectionId: 'relationshipMapping',
+      issues,
+    })
+  }
 
   scanSecrets(readAnswers, issues, 'webapiReadList.answers')
-  scanSecrets(relationshipAnswers, issues, 'relationshipMapping.answers')
+  if (scope === 'material-only') {
+    scanSecrets(materialOnlySafetyAnswers, issues, 'materialOnlySafety.answers')
+  } else {
+    scanSecrets(relationshipAnswers, issues, 'relationshipMapping.answers')
+  }
 
   const readSamples = await validateSamples({
     samples: getObject(webapiReadList, 'samples'),
-    sampleSpecs: READ_SAMPLES,
+    sampleSpecs: readSampleSpecs,
     baseDir,
     sectionId: 'webapiReadList',
     issues,
   })
-  const relationshipSamples = await validateSamples({
-    samples: getObject(relationshipMapping, 'samples'),
-    sampleSpecs: RELATIONSHIP_SAMPLES,
-    baseDir,
-    sectionId: 'relationshipMapping',
-    issues,
-  })
+  const relationshipSamples = scope === 'material-only'
+    ? []
+    : await validateSamples({
+      samples: getObject(relationshipMapping, 'samples'),
+      sampleSpecs: RELATIONSHIP_SAMPLES,
+      baseDir,
+      sectionId: 'relationshipMapping',
+      issues,
+    })
 
-  const decision = decisionFromIssues(issues)
+  const decision = decisionFromIssues(issues, scope)
   return {
     ok: decision.exitCode === 0,
     generatedAt,
     inputPath: inputPath ? path.resolve(inputPath) : '',
+    scope,
     decision: decision.decision,
     exitCode: decision.exitCode,
     stage1Lock: {
@@ -438,13 +514,22 @@ export async function buildGateContractReport(packet, { inputPath = '', generate
     },
     sections: {
       webapiReadList: {
-        requiredAnswers: READ_ANSWER_IDS.length,
-        answered: READ_ANSWER_IDS.filter((id) => isFilled(readAnswers[id])).length,
+        requiredAnswers: readAnswerIds.length,
+        answered: readAnswerIds.filter((id) => isFilled(readAnswers[id])).length,
         samples: readSamples,
       },
+      ...(scope === 'material-only'
+        ? {
+          materialOnlySafety: {
+            requiredAnswers: MATERIAL_ONLY_SAFETY_ANSWER_IDS.length,
+            answered: MATERIAL_ONLY_SAFETY_ANSWER_IDS.filter((id) => isFilled(materialOnlySafetyAnswers[id])).length,
+            samples: [],
+          },
+        }
+        : {}),
       relationshipMapping: {
-        requiredAnswers: RELATIONSHIP_ANSWER_IDS.length,
-        answered: RELATIONSHIP_ANSWER_IDS.filter((id) => isFilled(relationshipAnswers[id])).length,
+        requiredAnswers: scope === 'material-only' ? 0 : RELATIONSHIP_ANSWER_IDS.length,
+        answered: scope === 'material-only' ? 0 : RELATIONSHIP_ANSWER_IDS.filter((id) => isFilled(relationshipAnswers[id])).length,
         samples: relationshipSamples,
       },
     },
@@ -462,6 +547,7 @@ function renderMarkdown(report) {
     '# K3 WISE GATE Contract Check',
     '',
     `- Generated at: \`${report.generatedAt}\``,
+    `- Scope: \`${report.scope || 'full'}\``,
     `- Decision: \`${report.decision}\``,
     `- Exit code: \`${report.exitCode}\``,
     `- Stage 1 Lock: \`${report.stage1Lock.status}\``,
@@ -478,7 +564,11 @@ function renderMarkdown(report) {
   }
   lines.push('', '## Issues', '')
   if (report.issues.length === 0) {
-    lines.push('No issues. Runtime work can start only if the broader customer GATE is also PASS.')
+    if (report.scope === 'material-only') {
+      lines.push('No issues for Material-only dry-run readiness. This is not a full customer GATE pass and does not approve K3 Save-only, Submit, Audit, BOM, broad read/list, or production use.')
+    } else {
+      lines.push('No issues. Runtime work can start only if the broader customer GATE is also PASS.')
+    }
   } else {
     lines.push('| Status | ID | Message |', '| --- | --- | --- |')
     for (const issue of report.issues) {
@@ -489,6 +579,9 @@ function renderMarkdown(report) {
   lines.push('- This check does not contact K3 WISE or MetaSheet.')
   lines.push('- This check does not enable WebAPI read/list, SQL sampling, or relationship runtime.')
   lines.push('- This check does not lift the customer GATE.')
+  if (report.scope === 'material-only') {
+    lines.push('- Material-only PASS only means FNumber/FName dry-run readiness; Save-only still requires separate explicit approval.')
+  }
   return `${lines.join('\n')}\n`
 }
 
@@ -526,6 +619,9 @@ function buildTemplatePacket() {
         unresolvedChild: TEMPLATE_SAMPLE_FILES.unresolvedChild,
         k3BomSaveShape: TEMPLATE_SAMPLE_FILES.k3BomSaveShape,
       },
+    },
+    materialOnlySafety: {
+      answers: Object.fromEntries(MATERIAL_ONLY_SAFETY_ANSWER_IDS.map((id) => [id, '<fill-outside-git>'])),
     },
   }
 }
@@ -650,6 +746,19 @@ function buildCustomerHandoffReadme() {
 - \`${TEMPLATE_SAMPLE_FILES.unresolvedChild}\`：子件无法匹配时的样例。
 - \`${TEMPLATE_SAMPLE_FILES.k3BomSaveShape}\`：K3 BOM Save 请求体结构样例。
 
+## Material-only 快线
+
+如当前只需要推进 #1792 的 Material-only dry-run readiness，可使用：
+
+\`\`\`bash
+node scripts/ops/integration-k3wise-gate-contract-check.mjs \\
+  --scope material-only \\
+  --input /path/outside-git/k3wise-gate-contract/k3wise-gate-contract-packet.template.json \\
+  --out-dir /path/outside-git/k3wise-gate-contract/check-material-only
+\`\`\`
+
+Material-only 模式只验证物料详情读取路径、物料详情脱敏样例和 \`materialOnlySafety.answers\`。它不会要求 BOM、relationship、pagination 或 full read/list 项，也不会批准 Save、Submit、Audit 或 BOM。
+
 ## WebAPI read/list 必填项
 
 请在 \`webapiReadList.answers\` 中填写：
@@ -745,7 +854,7 @@ async function main() {
     return 0
   }
   const packet = await readJsonFile(opts.input)
-  const report = await buildGateContractReport(packet, { inputPath: opts.input })
+  const report = await buildGateContractReport(packet, { inputPath: opts.input, scope: opts.scope })
   const outDir = opts.outDir || path.join(DEFAULT_OUTPUT_ROOT, nowStamp())
   const outputs = await writeOutputs(report, outDir)
   console.log(JSON.stringify({

--- a/scripts/ops/integration-k3wise-gate-contract-check.test.mjs
+++ b/scripts/ops/integration-k3wise-gate-contract-check.test.mjs
@@ -65,6 +65,31 @@ function completePacket() {
   }
 }
 
+function materialOnlyPacket() {
+  return {
+    webapiReadList: {
+      answers: {
+        'O1-MAT': '/K3API/Material/GetDetail',
+        'O1-MAT-M': 'POST',
+        O6: 'same token scope as Save',
+      },
+      samples: {
+        materialDetail: 'sample-material-detail.redacted.json',
+      },
+    },
+    materialOnlySafety: {
+      answers: {
+        'M0-SCOPE': 'Material only first',
+        'M0-PREVIEW-FIELDS': 'First dry-run preview only includes FNumber and FName',
+        'M0-BOM-DEFERRED': 'BOM deferred until Material passes',
+        'M0-SAVE-ONLY-SEPARATE-APPROVAL': 'Save-only requires separate approval after dry-run',
+        'M0-AUTOSUBMIT-FALSE': 'autoSubmit=false',
+        'M0-AUTOAUDIT-FALSE': 'autoAudit=false',
+      },
+    },
+  }
+}
+
 async function writeCompleteSamples(dir, overrides = {}) {
   const samples = {
     'sample-material-list.redacted.json': {
@@ -101,6 +126,25 @@ async function writeCompleteSamples(dir, overrides = {}) {
         FParentItemNumber: 'FG-001',
         FChildItems: [{ FItemNumber: 'MAT-001', FQty: 2, FUnitID: 'PCS', FEntryID: 1 }],
       },
+    },
+    ...overrides,
+  }
+  await Promise.all(Object.entries(samples).map(([fileName, value]) => writeJson(path.join(dir, fileName), value)))
+}
+
+async function writeMaterialOnlySamples(dir, overrides = {}) {
+  const samples = {
+    'sample-material-detail.redacted.json': {
+      StatusCode: 200,
+      Message: 'Successful',
+      Data: [
+        {
+          Data: {
+            FNumber: '<redacted:FNumber>',
+            FName: '<redacted:FName>',
+          },
+        },
+      ],
     },
     ...overrides,
   }
@@ -151,6 +195,107 @@ test('missing answers or sample files block runtime work with exit 2', async () 
   assert.equal(report.exitCode, 2)
   assert(report.issues.some((issue) => issue.id === 'webapiReadList.O1-BOM'))
   assert(report.issues.some((issue) => issue.id === 'relationshipMapping.sample.treeBom'))
+})
+
+test('material-only scope passes without BOM, pagination, list, or relationship evidence', async () => {
+  const dir = await makeDir()
+  await writeMaterialOnlySamples(dir)
+  const packetPath = path.join(dir, 'packet.json')
+  const outDir = path.join(dir, 'out')
+  await writeJson(packetPath, materialOnlyPacket())
+
+  const result = runCli(['--scope', 'material-only', '--input', packetPath, '--out-dir', outDir])
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stdout, /"decision": "PASS_MATERIAL_ONLY"/)
+
+  const evidence = JSON.parse(await readFile(path.join(outDir, 'integration-k3wise-gate-contract-check.json'), 'utf8'))
+  assert.equal(evidence.scope, 'material-only')
+  assert.equal(evidence.decision, 'PASS_MATERIAL_ONLY')
+  assert.equal(evidence.sections.webapiReadList.answered, 3)
+  assert.equal(evidence.sections.webapiReadList.requiredAnswers, 3)
+  assert.equal(evidence.sections.webapiReadList.samples.length, 1)
+  assert.equal(evidence.sections.materialOnlySafety.answered, 6)
+  assert.equal(evidence.sections.relationshipMapping.requiredAnswers, 0)
+  assert.equal(evidence.issues.length, 0)
+
+  const markdown = await readFile(path.join(outDir, 'integration-k3wise-gate-contract-check.md'), 'utf8')
+  assert.match(markdown, /Scope: `material-only`/)
+  assert.match(markdown, /not a full customer GATE pass/)
+  assert.match(markdown, /does not approve K3 Save-only/)
+})
+
+test('material-only scope blocks missing material answers, safety answers, or material sample', async () => {
+  const dir = await makeDir()
+  const packet = materialOnlyPacket()
+  packet.webapiReadList.answers.O6 = '<fill>'
+  packet.webapiReadList.samples.materialDetail = 'missing-material.redacted.json'
+  packet.materialOnlySafety.answers['M0-AUTOAUDIT-FALSE'] = '<fill>'
+  packet.materialOnlySafety.answers['M0-PREVIEW-FIELDS'] = 'Material preview only'
+
+  const report = await buildGateContractReport(packet, {
+    inputPath: path.join(dir, 'packet.json'),
+    generatedAt: '2026-05-27T00:00:00.000Z',
+    scope: 'material-only',
+  })
+
+  assert.equal(report.decision, 'GATE_BLOCKED')
+  assert.equal(report.exitCode, 2)
+  assert(report.issues.some((issue) => issue.id === 'webapiReadList.O6'))
+  assert(report.issues.some((issue) => issue.id === 'webapiReadList.sample.materialDetail'))
+  assert(report.issues.some((issue) => issue.id === 'materialOnlySafety.M0-AUTOAUDIT-FALSE'))
+  assert(report.issues.some((issue) => issue.id === 'materialOnlySafety.M0-PREVIEW-FIELDS'))
+})
+
+test('material-only scope still rejects unsafe endpoints and query secrets', async () => {
+  const dir = await makeDir()
+  await writeMaterialOnlySamples(dir)
+
+  const absolutePacket = materialOnlyPacket()
+  absolutePacket.webapiReadList.answers['O1-MAT'] = 'https://k3.example.test/K3API/Material/GetDetail'
+  const absoluteReport = await buildGateContractReport(absolutePacket, {
+    inputPath: path.join(dir, 'packet.json'),
+    generatedAt: '2026-05-27T00:00:00.000Z',
+    scope: 'material-only',
+  })
+  assert.equal(absoluteReport.decision, 'FAIL')
+  assert(absoluteReport.issues.some((issue) => issue.id === 'webapiReadList.O1-MAT' && issue.status === 'fail'))
+
+  const secretQueryPacket = materialOnlyPacket()
+  secretQueryPacket.webapiReadList.answers['O1-MAT'] = '/K3API/Material/GetDetail?token=RAW-TOKEN'
+  const secretQueryReport = await buildGateContractReport(secretQueryPacket, {
+    inputPath: path.join(dir, 'packet.json'),
+    generatedAt: '2026-05-27T00:00:00.000Z',
+    scope: 'material-only',
+  })
+  assert.equal(secretQueryReport.decision, 'FAIL')
+  assert(secretQueryReport.issues.some((issue) => issue.id === 'webapiReadList.O1-MAT' && issue.status === 'fail'))
+})
+
+test('material-only scope still scans material samples for secrets', async () => {
+  const dir = await makeDir()
+  await writeMaterialOnlySamples(dir, {
+    'sample-material-detail.redacted.json': {
+      StatusCode: 200,
+      Data: [
+        {
+          Data: {
+            FNumber: '<redacted:FNumber>',
+            FName: '<redacted:FName>',
+            callback: 'https://k3.example.test/K3API?access_token=RAW-TOKEN-SHOULD-NOT-LEAK',
+          },
+        },
+      ],
+    },
+  })
+  const packetPath = path.join(dir, 'packet.json')
+  const outDir = path.join(dir, 'out')
+  await writeJson(packetPath, materialOnlyPacket())
+
+  const result = runCli(['--scope', 'material-only', '--input', packetPath, '--out-dir', outDir])
+  assert.equal(result.status, 1)
+  const evidenceText = await readFile(path.join(outDir, 'integration-k3wise-gate-contract-check.json'), 'utf8')
+  assert.match(evidenceText, /URL query secret/)
+  assert.equal(evidenceText.includes('RAW-TOKEN-SHOULD-NOT-LEAK'), false)
 })
 
 test('absolute read endpoints are rejected before runtime work', async () => {

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -300,6 +300,7 @@ function verify_generic_integration_workbench_contract() {
   search_fixed_string 'READ_ANSWER_IDS' "$gate_contract_checker" || die "GATE contract checker must validate WebAPI read/list answer IDs"
   search_fixed_string 'RELATIONSHIP_ANSWER_IDS' "$gate_contract_checker" || die "GATE contract checker must validate relationship answer IDs"
   search_fixed_string 'GATE_BLOCKED' "$gate_contract_checker" || die "GATE contract checker must distinguish incomplete customer evidence"
+  search_fixed_string 'PASS_MATERIAL_ONLY' "$gate_contract_checker" || die "GATE contract checker must include the Material-only dry-run readiness decision"
   search_fixed_string 'SECRET_QUERY_PATTERN' "$gate_contract_checker" || die "GATE contract checker must reject secret-looking query parameters"
   search_fixed_string '--init-template' "$gate_contract_checker" || die "GATE contract checker must initialize a fillable packet template"
   search_fixed_string 'k3wise-gate-contract-packet.template.json' "$gate_contract_checker" || die "GATE contract checker must write the canonical packet template file"


### PR DESCRIPTION
## Summary

Adds a `--scope material-only` mode to the K3 WISE GATE contract checker so #1792 can advance the Material-first dry-run readiness path without being blocked by deferred BOM / relationship / pagination / list evidence.

This keeps the existing full GATE behavior as the default.

## What changed

- `scripts/ops/integration-k3wise-gate-contract-check.mjs`
  - adds `--scope full|material-only`, defaulting to `full`;
  - material-only requires `O1-MAT`, `O1-MAT-M`, `O6`, one Material detail sample, and explicit `materialOnlySafety.answers`;
  - successful material-only decision is `PASS_MATERIAL_ONLY`, not `PASS`;
  - generated handoff template now includes `materialOnlySafety.answers` and documents the Material-only fast path.
- `scripts/ops/integration-k3wise-gate-contract-check.test.mjs`
  - covers full default behavior, material-only pass, missing material/safety inputs, unsafe endpoint/query secret failures, and sample secret scanning.
- `scripts/ops/multitable-onprem-package-verify.sh`
  - adds a package marker for `PASS_MATERIAL_ONLY`.
- Adds design and verification MDs.

## Boundaries

This PR does not approve or implement K3 Save-only, Submit, Audit, BOM, relationship runtime, broad read/list, pagination, filters, server-side reference composition, or production signoff.

`PASS_MATERIAL_ONLY` only means Material dry-run readiness for the current #1792 Material-first slice. Save-only still requires separate explicit approval after dry-run review and rollback confirmation.

## Verification

- `pnpm verify:integration-k3wise:gate-contract`
- `pnpm verify:integration-k3wise:poc`
- `node scripts/ops/integration-k3wise-gate-contract-check.mjs --help`
- `node scripts/ops/integration-k3wise-gate-contract-check.mjs --init-template /tmp/k3wise-material-only-template-check-9917`
- `node scripts/ops/integration-k3wise-gate-contract-check.mjs --scope material-only --input /tmp/k3wise-material-only-template-check-9917/k3wise-gate-contract-packet.template.json --out-dir /tmp/k3wise-material-only-template-check-9917/check-material-only` (expected `GATE_BLOCKED` for unfilled template)
- `bash -n scripts/ops/multitable-onprem-package-verify.sh`
- `git diff --check`

## Related

- #1792 umbrella/sub-gate clarification: https://github.com/zensgit/metasheet2/issues/1792#issuecomment-4550451939