### PR TITLE
feat(attendance): payroll_cycle comprehensive-hours cap mapping (V1 coarse)

### DIFF
--- a/docs/development/attendance-comprehensive-hours-payroll-cycle-cap-mapping-impl-verification-20260526.md
+++ b/docs/development/attendance-comprehensive-hours-payroll-cycle-cap-mapping-impl-verification-20260526.md
@@ -1,0 +1,70 @@
+# Comprehensive-Hours `payroll_cycle` Cap-Mapping — V1 Coarse Impl Verification — 2026-05-26
+
+Implements the V1 **coarse** mapping locked in
+`attendance-comprehensive-hours-payroll-cycle-cap-mapping-design-20260526.md` (#1887). Runtime
+slice only: no JOIN, no template-config read, **no migration / route / UI / write path**, and the
+precise template-window validation (design §7) is **deliberately not** implemented (deferred
+opt-in). All edits are in `plugins/plugin-attendance/index.cjs` + one unit-test file.
+
+## What landed (matches design §3/§4)
+
+1. **Producer carries `templateId`.** `resolveAttendanceReportPeriodSyncPeriod` now emits
+   `templateId: cycle.templateId || null` on the `payroll_cycle` period (mirrors `cycleId`).
+   Presence of a templateId is the (coarse) monthly-cadence signal; absence → no cap.
+2. **Span guard.** `attendancePayrollCycleWithinMonthlySpan(from, to)` — valid dates, `from ≤ to`,
+   inclusive span `≤ 62` days (`ATTENDANCE_PAYROLL_CYCLE_MONTHLY_MAX_SPAN_DAYS`). 62 is the
+   conservative ceiling for a structurally-monthly template (`end_month_offset ∈ {0,1}`).
+3. **Builder branch** (`buildAttendanceComprehensiveHoursPeriodSummaryValues`):
+   - `date_range` → existing bridge → resolver (unchanged, `org_default_by_cycle_type`).
+   - `payroll_cycle` **and** `templateId` **and** span ≤ 62 → resolve the **`month`** org default,
+     stamped `source = payroll_cycle_template_monthly`.
+   - everything else (missing/unknown type, templateId-less, oversized) → `nullValues`
+     (fail-closed unchanged).
+4. **Resolver source label.** `resolveAttendanceComprehensiveHoursCap` gained an optional
+   `sourceLabel` (default `org_default_by_cycle_type`); cap minutes + `effective_key`
+   (= `hash(capDefaults)`) are unchanged, so a cap edit re-syncs payroll rows exactly like
+   date-range rows. Source literals locked as exported consts.
+
+## Accepted imprecision (design §3, locked by test P5b)
+
+The cycle create route (`index.cjs` POST `/api/attendance/payroll-cycles`) uses body
+`startDate`/`endDate` as-is and validates only `start ≤ end`; it does **not** verify the dates
+match the template window. So a templateId-bearing cycle with hand-entered, ≤62d dates that are
+**not** a real monthly period **still** receives the `month` cap. This is a conscious coarse-
+heuristic trade-off — blast radius is one reporting metric (`comprehensive_hours_excess_minutes`
+in the snapshot), never a calc-chain or enforcement decision. The precise upgrade (read template +
+verify via `resolvePayrollWindow`) is design §7, a separate opt-in.
+
+## Tests — `attendance-comprehensive-hours-control.test.ts` (39 passed, 11 new)
+
+| # | Case | Expected | Result |
+| --- | --- | --- | --- |
+| P1 | template + span≤62 + month cap set | excess vs month cap, `source=payroll_cycle_template_monthly` | ✅ |
+| P2 | cross-month 26th→25th | bridge → `custom_range`/null (asserted), payroll branch → month | ✅ |
+| P3 | month cap unset | null | ✅ |
+| P4 | `templateId` null/undefined | null (+ PR6-block anchor at line ~673) | ✅ |
+| P5 | span > 62d | null | ✅ |
+| P5b | in-span but date-mismatched cycle | **still month** (documented imprecision) | ✅ |
+| span guard | ≤62 inclusive / 63 / reversed / invalid | true / false / false / false | ✅ |
+| source lock | literal `payroll_cycle_template_monthly` ≠ default | locked | ✅ |
+| P8 | `date_range` path | unchanged, default source | ✅ |
+| **wire** | **producer emits `templateId`** (real `resolveAttendanceReportPeriodSyncPeriod`, mocked db) | `tpl-9` carried; `null` when row null | ✅ |
+| P7 | cap edit re-syncs a `payroll_cycle` row (real sync) | `created` then `patched` w/ new cap | ✅ |
+
+The **wire** test is mandatory per the wire-vs-fixture rule: P1–P8/P5b use synthetic periods and
+cannot catch a producer that forgets to emit `templateId` (cf. the #1781 `dayIndex` drift).
+
+Adjacent suites unaffected: `attendance-report-field-catalog.test.ts` 32/32.
+
+## Boundaries (unchanged from design)
+
+No migration, no new settings/config (reuses the `month` cap), no template `config` read, no new
+route, no UI, no `attendance_*`/`meta_*` raw write (snapshot writes go through the multitable
+records API only — re-asserted by the existing PR6 "no raw INSERT/UPDATE/DELETE" test). Deferred:
+precise template-window validation (§7), quarterly/yearly cadence (§6), per-cycle override.
+
+## Cross-references
+
+- `attendance-comprehensive-hours-payroll-cycle-cap-mapping-design-20260526.md` (#1887) — design-lock.
+- `attendance-comprehensive-hours-pr6-value-plumbing-verification-20260525.md` (#1833) — the value-plumbing this extends.
+- `[[attendance-multitable-report-boundary]]`, `[[staged-opt-in-lineage]]`, `[[k3-poc-stage1-lock-no-new-fronts]]`.

--- a/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
+++ b/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
@@ -669,7 +669,9 @@ describe('comprehensive-hours period value-plumbing (PR6)', () => {
       comprehensive_hours_cap_effective_key: null,
     }
     expect(helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues({}, orgId, userId, naturalMonth, 13000)).toEqual(allNull)
-    // Fail-closed periodType whitelist: only date_range proceeds.
+    // Fail-closed periodType whitelist: a date_range proceeds; a payroll_cycle WITHOUT a
+    // templateId stale-nulls (this is the P4 anchor for the payroll-cycle mapping block below —
+    // do NOT "fix" it by adding a templateId; templateId-less must remain null).
     expect(helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues(monthCap(10560), orgId, userId, { ...naturalMonth, periodType: 'payroll_cycle' }, 13000)).toEqual(allNull)
     expect(helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues(monthCap(10560), orgId, userId, { ...naturalMonth, periodType: 'custom_range' }, 13000)).toEqual(allNull)
     expect(helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues(monthCap(10560), orgId, userId, { ...naturalMonth, periodType: 'some_future_type' }, 13000)).toEqual(allNull)
@@ -747,5 +749,168 @@ describe('comprehensive-hours period value-plumbing (PR6)', () => {
     expect(pluginSource).toMatch(
       /for \(const column of valueColumns\)[\s\S]*?Object\.assign\(logical, comprehensiveHoursValues\)[\s\S]*?buildAttendanceReportPeriodSummarySourceFingerprint\(logical\)/,
     )
+  })
+})
+
+// Coarse payroll_cycle → month cap mapping (V1) — design-lock:
+// docs/development/attendance-comprehensive-hours-payroll-cycle-cap-mapping-design-20260526.md
+describe('comprehensive-hours payroll_cycle cap-mapping (V1 coarse)', () => {
+  const orgId = 'org-1'
+  const userId = 'u-1'
+  const logger = { warn() {}, error() {}, info() {} }
+  const monthCap = (minutes: number | null) => ({ comprehensiveHours: { capDefaults: { month: minutes, quarter: null, year: null } } })
+  const PAYROLL_SOURCE = helpers.ATTENDANCE_COMPREHENSIVE_HOURS_CAP_SOURCE_PAYROLL_MONTHLY
+  const allNull = {
+    comprehensive_hours_excess_minutes: null,
+    comprehensive_hours_cap_minutes: null,
+    comprehensive_hours_cap_source: null,
+    comprehensive_hours_cap_effective_key: null,
+  }
+  // A template-bound payroll cycle: in-span (≤62d), templateId present. Dates here are a
+  // cross-month pay window (26th→25th) — deliberately NOT a natural calendar month, so the
+  // date_range bridge would yield custom_range; the payroll branch maps it to month.
+  const payrollCycle = (overrides: Record<string, unknown> = {}) => ({
+    periodType: 'payroll_cycle',
+    periodKey: 'cycle:c-1',
+    cycleId: 'c-1',
+    templateId: 'tpl-1',
+    from: '2026-02-26',
+    to: '2026-03-25',
+    periodStart: '2026-02-26',
+    periodEnd: '2026-03-25',
+    ...overrides,
+  })
+  const build = (settings: unknown, period: Record<string, unknown>, minutes = 13000) =>
+    helpers.buildAttendanceComprehensiveHoursPeriodSummaryValues(settings, orgId, userId, period, minutes)
+
+  // P1 — template + span≤62 + month cap set → excess against month cap; payroll source label.
+  it('P1: template-bound, in-span, month cap set → month cap with payroll source', () => {
+    expect(build(monthCap(10560), payrollCycle())).toEqual({
+      comprehensive_hours_excess_minutes: 2440,
+      comprehensive_hours_cap_minutes: 10560,
+      comprehensive_hours_cap_source: PAYROLL_SOURCE,
+      comprehensive_hours_cap_effective_key: expect.stringMatching(/^cfg:[0-9a-f]{12}$/),
+    })
+  })
+
+  // P2 — cross-month window the date_range bridge canNOT map (→ custom_range → null), but the
+  // payroll branch maps to month. This proves the new path CHANGES behavior, not just "no regression".
+  it('P2: cross-month (26th→25th) — bridge would null, payroll branch resolves month', () => {
+    const bridged = helpers.bridgeAttendanceDateRangeToComprehensiveHoursPeriod('2026-02-26', '2026-03-25')
+    expect(bridged.type).toBe('custom_range')
+    expect(helpers.resolveAttendanceComprehensiveHoursCap(monthCap(10560), orgId, userId, bridged)).toBeNull()
+    const values = build(monthCap(10560), payrollCycle())
+    expect(values.comprehensive_hours_cap_minutes).toBe(10560)
+    expect(values.comprehensive_hours_cap_source).toBe(PAYROLL_SOURCE)
+  })
+
+  // P3 — month cap unset → stale-null.
+  it('P3: month cap unset → null', () => {
+    expect(build(monthCap(null), payrollCycle())).toEqual(allNull)
+  })
+
+  // P4 — templateId null → null. (See also the anchor assertion in the PR6 block above.)
+  it('P4: templateId null → null (no monthly-cadence signal)', () => {
+    expect(build(monthCap(10560), payrollCycle({ templateId: null }))).toEqual(allNull)
+    expect(build(monthCap(10560), payrollCycle({ templateId: undefined }))).toEqual(allNull)
+  })
+
+  // P5 — span > 62d (anomaly / multi-month) → null even with a templateId.
+  it('P5: span > 62d → null', () => {
+    expect(build(monthCap(10560), payrollCycle({ from: '2026-01-01', to: '2026-03-31' }))).toEqual(allNull)
+  })
+
+  // P5b — DOCUMENTED IMPRECISION: templateId present, span≤62, but the dates do NOT match the
+  // template window (hand-entered, not a real monthly period). V1 has no JOIN/template read, so
+  // it STILL resolves month. The precise §7 upgrade would resolve null. Locking the coarse
+  // behavior here so the trade-off is explicit and a future change is a conscious one.
+  it('P5b: in-span but date-mismatched cycle still resolves month (coarse-heuristic limit)', () => {
+    const offWindow = payrollCycle({ from: '2026-03-10', to: '2026-04-08' }) // 30d, not a monthly window
+    expect(helpers.bridgeAttendanceDateRangeToComprehensiveHoursPeriod('2026-03-10', '2026-04-08').type).toBe('custom_range')
+    const values = build(monthCap(10560), offWindow)
+    expect(values.comprehensive_hours_cap_minutes).toBe(10560)
+    expect(values.comprehensive_hours_cap_source).toBe(PAYROLL_SOURCE)
+  })
+
+  // Span guard — direct unit coverage of the ≤62 (inclusive) boundary.
+  it('span guard: ≤62 inclusive passes, 63 fails, invalid/reversed fails', () => {
+    expect(helpers.attendancePayrollCycleWithinMonthlySpan('2026-02-26', '2026-03-25')).toBe(true)
+    expect(helpers.attendancePayrollCycleWithinMonthlySpan('2026-01-01', '2026-03-03')).toBe(true) // 62 inclusive
+    expect(helpers.attendancePayrollCycleWithinMonthlySpan('2026-01-01', '2026-03-04')).toBe(false) // 63
+    expect(helpers.attendancePayrollCycleWithinMonthlySpan('2026-03-25', '2026-02-26')).toBe(false) // reversed
+    expect(helpers.attendancePayrollCycleWithinMonthlySpan('not-a-date', '2026-03-25')).toBe(false)
+  })
+
+  // Source-label contract lock — the literal is a snapshot column value; pin it.
+  it('source label is the locked payroll literal, distinct from the calendar default', () => {
+    expect(PAYROLL_SOURCE).toBe('payroll_cycle_template_monthly')
+    expect(helpers.ATTENDANCE_COMPREHENSIVE_HOURS_CAP_SOURCE_DEFAULT).toBe('org_default_by_cycle_type')
+    expect(PAYROLL_SOURCE).not.toBe(helpers.ATTENDANCE_COMPREHENSIVE_HOURS_CAP_SOURCE_DEFAULT)
+  })
+
+  // P8 — date_range path is untouched (still the calendar default source).
+  it('P8: date_range path unchanged (calendar default source)', () => {
+    const naturalMonth = { periodType: 'date_range', from: '2026-03-01', to: '2026-03-31' }
+    const values = build(monthCap(10560), naturalMonth)
+    expect(values.comprehensive_hours_cap_minutes).toBe(10560)
+    expect(values.comprehensive_hours_cap_source).toBe('org_default_by_cycle_type')
+  })
+
+  // WIRE-VS-FIXTURE (mandatory): the producer must EMIT templateId onto the payroll_cycle
+  // period — the builder tests above use synthetic periods and cannot catch a producer that
+  // forgets it (cf. the #1781 dayIndex serialization drift). Exercise the real producer.
+  it('producer carries templateId from the loaded payroll cycle row (and null when absent)', async () => {
+    const cycleId = '11111111-1111-4111-8111-111111111111'
+    const cycleDb = (templateId: string | null) => ({
+      async query(sql: string) {
+        if (/FROM attendance_payroll_cycles/i.test(String(sql))) {
+          return [{ id: cycleId, org_id: orgId, template_id: templateId, name: 'Feb cycle', start_date: '2026-02-26', end_date: '2026-03-25', status: 'open', metadata: null }]
+        }
+        throw new Error('unmocked query: ' + sql)
+      },
+    })
+    const withTpl = await helpers.resolveAttendanceReportPeriodSyncPeriod(cycleDb('tpl-9'), orgId, { cycleId })
+    expect(withTpl.ok).toBe(true)
+    expect(withTpl.period.periodType).toBe('payroll_cycle')
+    expect(withTpl.period.templateId).toBe('tpl-9')
+    expect(withTpl.period.from).toBe('2026-02-26')
+
+    const noTpl = await helpers.resolveAttendanceReportPeriodSyncPeriod(cycleDb(null), orgId, { cycleId })
+    expect(noTpl.period.templateId).toBeNull()
+  })
+
+  // P7 — cap edit changes effective_key → a payroll_cycle row re-syncs (run on the PAYROLL
+  // branch explicitly; same fingerprint mechanism as date_range but assert it here).
+  it('P7: cap edit re-syncs a payroll_cycle row through the real sync', async () => {
+    helpers.resetAttendanceSettingsCacheForTests()
+    const createRecord = vi.fn().mockResolvedValue({ id: 'rec-new' })
+    const patchRecord = vi.fn().mockResolvedValue({})
+    const queryRecords = vi.fn().mockResolvedValue([])
+    const ensureObject = vi.fn().mockResolvedValue({ baseId: 'base-1', sheet: { id: 'sheet-1' } })
+    const context = { api: { multitable: { provisioning: { ensureObject }, records: { queryRecords, createRecord, patchRecord } } } }
+    const syncDb = (settings: unknown) => ({
+      async query(sql: string) {
+        const s = String(sql)
+        if (/FROM system_configs/i.test(s)) return [{ value: JSON.stringify(settings) }]
+        if (/is_workday THEN work_minutes/i.test(s)) return [{ total_days: 22, total_minutes: 13000, total_late_minutes: 0, total_early_leave_minutes: 0, normal_days: 22, late_days: 0, early_leave_days: 0, late_early_days: 0, partial_days: 0, absent_days: 0, adjusted_days: 0, off_days: 9 }]
+        if (/FROM attendance_requests/i.test(s)) return []
+        if (/FROM users u/i.test(s)) return [{ user_name: 'U One', username: 'u1', meta: null }]
+        if (/FROM attendance_leave_types/i.test(s)) return []
+        if (/FROM attendance_overtime_rules/i.test(s)) return []
+        throw new Error('unmocked query: ' + s.replace(/\s+/g, ' ').slice(0, 90))
+      },
+    })
+    const period = payrollCycle()
+    const r1 = await helpers.syncAttendanceReportPeriodSummary(context, syncDb(monthCap(10560)), orgId, logger, { userId, period })
+    expect(r1.created).toBe(1)
+    const stored = createRecord.mock.calls[0][0].data
+    expect(stored.comprehensive_hours_cap_source).toBe(PAYROLL_SOURCE)
+    expect(stored.comprehensive_hours_cap_minutes).toBe(10560)
+    queryRecords.mockResolvedValue([{ id: 'rec-1', data: stored }])
+
+    helpers.resetAttendanceSettingsCacheForTests()
+    const r2 = await helpers.syncAttendanceReportPeriodSummary(context, syncDb(monthCap(9000)), orgId, logger, { userId, period })
+    expect(r2.patched).toBe(1)
+    expect(patchRecord.mock.calls[0][0].changes.comprehensive_hours_cap_minutes).toBe(9000)
   })
 })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -3472,6 +3472,12 @@ async function resolveAttendanceReportPeriodSyncPeriod(db, orgId, params = {}) {
         periodType: 'payroll_cycle',
         periodKey: `cycle:${cycle.id}`,
         cycleId: cycle.id,
+        // Carried for the comprehensive-hours cap mapping (coarse V1, see
+        // docs/development/attendance-comprehensive-hours-payroll-cycle-cap-mapping-design-20260526.md
+        // §4). Presence of a templateId is a (coarse) monthly-cadence signal; absence → no cap.
+        // Mirrored top-level (alongside the nested `cycle`) on purpose so the builder stays
+        // agnostic of the cycle row shape — consistent with how `cycleId` is surfaced.
+        templateId: cycle.templateId || null,
         periodName: cycle.name || cycle.id,
         from: cycle.startDate,
         to: cycle.endDate,
@@ -12086,11 +12092,25 @@ function bridgeAttendanceDateRangeToComprehensiveHoursPeriod(from, to) {
   return { type: 'custom_range', key: `range:${f}:${t}`, from: f, to: t }
 }
 
+// Cap source labels (snapshot column contract — distinct labels let later analysis tell a
+// payroll-mapped cap from a calendar-cycle-mapped one even when the minute value is identical).
+const ATTENDANCE_COMPREHENSIVE_HOURS_CAP_SOURCE_DEFAULT = 'org_default_by_cycle_type'
+const ATTENDANCE_COMPREHENSIVE_HOURS_CAP_SOURCE_PAYROLL_MONTHLY = 'payroll_cycle_template_monthly'
+
 // V1 resolver: org default cap by cycle-type. orgId / userId are forward-compat (per-org and
 // per-user override land later without changing callers) and intentionally unused in V1 —
-// attendance.settings is a single global config. Returns null when no org default applies
-// (payroll_cycle / custom_range, or the cap is unset); callers then stale-null the columns.
-function resolveAttendanceComprehensiveHoursCap(settings, orgId, userId, period) {
+// attendance.settings is a single global config. `sourceLabel` lets a caller stamp a distinct
+// cap-source on the same org-default value (the payroll_cycle → month coarse mapping uses
+// PAYROLL_MONTHLY); the cap minutes + effective_key are unchanged. Returns null when no org
+// default applies (custom_range / a type with no cap, or the cap is unset); callers then
+// stale-null the columns.
+function resolveAttendanceComprehensiveHoursCap(
+  settings,
+  orgId,
+  userId,
+  period,
+  sourceLabel = ATTENDANCE_COMPREHENSIVE_HOURS_CAP_SOURCE_DEFAULT,
+) {
   const capDefaults = settings?.comprehensiveHours?.capDefaults || {}
   const type = period?.type
   let capMinutes = null
@@ -12099,7 +12119,7 @@ function resolveAttendanceComprehensiveHoursCap(settings, orgId, userId, period)
     capMinutes = Number.isFinite(raw) && raw > 0 ? Math.floor(raw) : null
   }
   if (capMinutes === null) return null
-  const source = 'org_default_by_cycle_type'
+  const source = sourceLabel
   return {
     capMinutes,
     source,
@@ -12123,11 +12143,29 @@ const ATTENDANCE_COMPREHENSIVE_HOURS_PERIOD_VALUE_COLUMNS = Object.freeze([
   { id: 'comprehensive_hours_cap_effective_key', name: '综合工时上限版本', type: 'string', order: 4003 },
 ])
 
-// Compute the four comprehensive-hours period values for one row. Fail-closed: only an
-// explicit date_range that bridges to an aligned month/quarter/year with a configured org
-// default yields a cap; payroll_cycle / custom_range / missing type / unset cap all
-// stale-null. Reuses the cap resolver (#1829) and the shared excess math — no parallel
-// computation.
+// Coarse monthly-cadence guard for a payroll_cycle window (see the payroll-cycle cap-mapping
+// design-lock). A payroll template is structurally monthly (end_month_offset ∈ {0,1}), so its
+// max legitimate span is ~58–59 days; 62 (inclusive) is the conservative ceiling. This guard
+// is necessary-but-not-sufficient: it does NOT read the template or verify the cycle's dates
+// match the template window (the create route allows hand-entered dates), so a templateId-
+// bearing cycle with mismatched ≤62d dates still passes — an accepted V1 imprecision; the
+// precise template-window validation is a deferred opt-in.
+const ATTENDANCE_PAYROLL_CYCLE_MONTHLY_MAX_SPAN_DAYS = 62
+function attendancePayrollCycleWithinMonthlySpan(from, to) {
+  const f = normalizeDateOnlyStrict(from)
+  const t = normalizeDateOnlyStrict(to)
+  if (!f || !t || f > t) return false
+  return diffDays(f, t) + 1 <= ATTENDANCE_PAYROLL_CYCLE_MONTHLY_MAX_SPAN_DAYS
+}
+
+// Compute the four comprehensive-hours period values for one row. Fail-closed: a cap is
+// resolved only when one of the explicitly-supported period shapes matches —
+//   • date_range that bridges to an aligned month/quarter/year with a configured org default, or
+//   • payroll_cycle carrying a templateId whose span ≤62d (coarse monthly mapping → month cap,
+//     source=payroll_cycle_template_monthly).
+// custom_range / templateId-less or oversized payroll cycles / missing/unknown periodType /
+// unset cap all stale-null. Reuses the cap resolver (#1829) and the shared excess math — no
+// parallel computation.
 function buildAttendanceComprehensiveHoursPeriodSummaryValues(settings, orgId, userId, period, actualMinutes) {
   const nullValues = {
     comprehensive_hours_excess_minutes: null,
@@ -12135,15 +12173,36 @@ function buildAttendanceComprehensiveHoursPeriodSummaryValues(settings, orgId, u
     comprehensive_hours_cap_source: null,
     comprehensive_hours_cap_effective_key: null,
   }
-  // Whitelist date_range (fail-closed): only a date_range window bridges to a cycle-type.
-  // payroll_cycle, missing, and any future periodType stale-null until explicitly supported.
-  if (!period || period.periodType !== 'date_range') return nullValues
-  const bridged = bridgeAttendanceDateRangeToComprehensiveHoursPeriod(period.from, period.to)
-  const cap = resolveAttendanceComprehensiveHoursCap(settings, orgId, userId, bridged)
+  let cap = null
+  let comparisonKey = null
+  if (period?.periodType === 'date_range') {
+    // Only a date_range window bridges to a cycle-type (month/quarter/year/custom_range).
+    const bridged = bridgeAttendanceDateRangeToComprehensiveHoursPeriod(period.from, period.to)
+    cap = resolveAttendanceComprehensiveHoursCap(settings, orgId, userId, bridged)
+    comparisonKey = bridged.key
+  } else if (
+    period?.periodType === 'payroll_cycle'
+    && period.templateId
+    && attendancePayrollCycleWithinMonthlySpan(period.from, period.to)
+  ) {
+    // Coarse monthly mapping: a template-bound, in-span payroll cycle resolves the month
+    // org default, stamped with the distinct payroll source label.
+    cap = resolveAttendanceComprehensiveHoursCap(
+      settings,
+      orgId,
+      userId,
+      { type: 'month', key: period.periodKey || `cycle:${period.cycleId}` },
+      ATTENDANCE_COMPREHENSIVE_HOURS_CAP_SOURCE_PAYROLL_MONTHLY,
+    )
+    comparisonKey = period.periodKey || (period.cycleId ? `cycle:${period.cycleId}` : null)
+  } else {
+    // Fail-closed: missing/unknown periodType, templateId-less or oversized payroll cycle.
+    return nullValues
+  }
   if (!cap) return nullValues
   const comparison = buildAttendanceComprehensiveHoursComparison({
     userId,
-    period: bridged.key,
+    period: comparisonKey,
     metric: 'actual',
     enforcement: 'warn',
     capMinutes: cap.capMinutes,
@@ -14181,6 +14240,9 @@ module.exports = {
     resolveAttendanceComprehensiveHoursCap,
     buildAttendanceComprehensiveHoursCapEffectiveKey,
     buildAttendanceComprehensiveHoursPeriodSummaryValues,
+    attendancePayrollCycleWithinMonthlySpan,
+    ATTENDANCE_COMPREHENSIVE_HOURS_CAP_SOURCE_DEFAULT,
+    ATTENDANCE_COMPREHENSIVE_HOURS_CAP_SOURCE_PAYROLL_MONTHLY,
     ATTENDANCE_COMPREHENSIVE_HOURS_PERIOD_VALUE_COLUMNS,
     resetAttendanceSettingsCacheForTests,
     mergeSettings,


### PR DESCRIPTION
Implements the **V1 coarse** `payroll_cycle → month` cap mapping locked in #1887 (design-lock). Runtime slice only — **no migration / route / UI / write path**; the precise template-window validation (design §7) is **deliberately deferred**.

## What it does (design §3/§4)
- **Producer** `resolveAttendanceReportPeriodSyncPeriod` emits `period.templateId` (mirrors `cycleId`) — presence is the coarse monthly-cadence signal.
- **Span guard** `attendancePayrollCycleWithinMonthlySpan` — valid dates, `from ≤ to`, inclusive span `≤ 62` (the conservative ceiling for a structurally-monthly `end_month_offset ∈ {0,1}` template).
- **Builder branch**: `date_range` (unchanged) · `payroll_cycle` + `templateId` + span≤62 → **`month`** org default, `source=payroll_cycle_template_monthly` · everything else → fail-closed `null`.
- **Resolver** gains an optional `sourceLabel` (default `org_default_by_cycle_type`); cap minutes + `effective_key` (=`hash(capDefaults)`) unchanged → a cap edit re-syncs payroll rows exactly like date-range rows. Source literals locked as exported consts.

## Accepted imprecision (locked by P5b)
The cycle create route uses body `startDate`/`endDate` as-is (only `start ≤ end`), so a templateId-bearing cycle with hand-entered ≤62d dates that are **not** a real monthly window **still** gets the `month` cap. Conscious coarse-heuristic trade-off — blast radius is one reporting metric, never calc/enforcement. Precise fix = §7 deferred opt-in.

## Tests — `attendance-comprehensive-hours-control.test.ts` (39 passed, 11 new)
P1 (excess+payroll source) · P2 (cross-month: bridge nulls, payroll branch resolves — proves behavior *change*) · P3 (cap unset→null) · P4 (templateId null→null) · P5 (span>62→null) · **P5b** (date-mismatched → still month, documented imprecision) · span-guard boundary · source-literal lock · P8 (date_range unchanged) · **mandatory producer wire test** (real `resolveAttendanceReportPeriodSyncPeriod`, mocked db — catches a producer dropping `templateId`, cf. #1781 `dayIndex` drift) · P7 (cap-edit re-sync on the **payroll** branch via real sync). Adjacent: `attendance-report-field-catalog` 32/32.

## Boundaries
No JOIN, no template-config read, no migration/route/UI, no raw `attendance_*`/`meta_*` write (snapshot writes go through the multitable records API only). Deferred: precise template-window validation (§7), quarterly/yearly cadence (§6), per-cycle override.

Verification doc: `docs/development/attendance-comprehensive-hours-payroll-cycle-cap-mapping-impl-verification-20260526.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)