### PR TITLE
fix(integration): extend secret value-scrub to token/secret/api_key/JWT shapes

### DIFF
--- a/plugins/plugin-integration-core/__tests__/payload-redaction.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/payload-redaction.test.cjs
@@ -173,6 +173,25 @@ function main() {
     assert.equal(scrubSecretStringValue(s), s, `benign string must not be over-redacted: ${s}`)
   }
 
+  // DSN userinfo where the PASSWORD ITSELF contains '@' — must mask to the LAST '@'
+  // before the host, not stop at the first one (regression for the inherited bug).
+  assert.equal(
+    scrubSecretStringValue('jdbc:sqlserver://user:P@ssw0rd@host;databaseName=db'),
+    'jdbc:sqlserver://user:[redacted]@host;databaseName=db',
+  )
+  assert.equal(
+    scrubSecretStringValue('postgres://user:p@ss@host/db'),
+    'postgres://user:[redacted]@host/db',
+  )
+  // no secret tail must survive
+  assert.equal(scrubSecretStringValue('mongodb://u:p@ss@w0rd@cluster').includes('ss@w0rd'), false)
+  // through the live sanitizer under a benign key (the F1 conn-string leak case)
+  const dsnLeak = sanitizeIntegrationPayload({ detail: 'jdbc:sqlserver://user:P@ssw0rd@host;databaseName=db' })
+  assert.equal(dsnLeak.detail, 'jdbc:sqlserver://user:[redacted]@host;databaseName=db')
+  assert.equal(dsnLeak.detail.includes('ssw0rd'), false, 'password @-tail must not leak')
+  // host:port with NO credentials (no userinfo '@') must survive
+  assert.equal(scrubSecretStringValue('redis://localhost:6379/0'), 'redis://localhost:6379/0')
+
   console.log('✓ payload-redaction: sensitive key + value-scrub + false-positive matrix tests passed')
 }
 

--- a/plugins/plugin-integration-core/__tests__/payload-redaction.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/payload-redaction.test.cjs
@@ -127,6 +127,52 @@ function main() {
   assert.equal(longSecret.blob.includes('u:p@'), false, 'raw password not exposed in truncated head')
   assert.equal(longSecret.blob.endsWith('...[truncated]'), true)
 
+  // value-scrub coverage extension: secret-shaped key=value beyond password/pwd,
+  // and standalone JWTs — all must redact even under a benign key.
+  const moreSecretValues = [
+    ['token=ABC123DEF456GHI789', 'token=[redacted]'],
+    ['api_key=sk_live_0123456789abcdef', 'api_key=[redacted]'],
+    ['apikey=0123456789abcdef', 'apikey=[redacted]'],
+    ['secret=topSecretValue123', 'secret=[redacted]'],
+    ['access_token=xyz987abc654', 'access_token=[redacted]'],
+    ['client_secret=cs_abc123def', 'client_secret=[redacted]'],
+    ['refresh_token=rt_998877', 'refresh_token=[redacted]'],
+    // standalone JWT with no Bearer/token= prefix
+    ['auth eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiIxMjM0NSJ9.SflKxwRJSMeKKF2QT4fwpM', 'auth [redacted-jwt]'],
+  ]
+  for (const [input, expected] of moreSecretValues) {
+    assert.equal(scrubSecretStringValue(input), expected, `secret value must be scrubbed: ${input}`)
+  }
+
+  // benign-key leak path through the live sanitizer (the F1 the value-scrub closes)
+  const leakObj = sanitizeIntegrationPayload({
+    detail: 'callback rejected: token=ABC123DEF456 expired',
+    note: 'use api_key=sk_test_abcdef when calling',
+    trace: 'id token eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.aGVsbG8td29ybGQtc2ln',
+  })
+  assert.equal(leakObj.detail, 'callback rejected: token=[redacted] expired')
+  assert.equal(leakObj.note, 'use api_key=[redacted] when calling')
+  assert.equal(leakObj.trace.includes('[redacted-jwt]'), true)
+  assert.equal(leakObj.trace.includes('eyJhbGci'), false, 'raw JWT head must not survive')
+
+  // Bearer-prefixed JWT still redacted (regression on the existing Bearer rule)
+  assert.equal(
+    scrubSecretStringValue('Authorization: Bearer eyJhbGciOiJIUzI1NiJ9.eyJzdWIiOiJ4In0.aGVsbG8td29ybGQ'),
+    'Authorization: Bearer [redacted]',
+  )
+
+  // extended false-positive matrix — these MUST survive (no `=`, or not JWT-shaped)
+  const benignExtended = [
+    'keep it secret, keep it safe',
+    'tokens of appreciation were handed out',
+    'the client secret handshake is documented here',
+    'order qty=2 price=100 status=open',
+    'base64 thumbnail starts eyJonly-one-segment-no-dots here',
+  ]
+  for (const s of benignExtended) {
+    assert.equal(scrubSecretStringValue(s), s, `benign string must not be over-redacted: ${s}`)
+  }
+
   console.log('✓ payload-redaction: sensitive key + value-scrub + false-positive matrix tests passed')
 }
 

--- a/plugins/plugin-integration-core/lib/payload-redaction.cjs
+++ b/plugins/plugin-integration-core/lib/payload-redaction.cjs
@@ -50,7 +50,10 @@ function isSensitivePayloadKey(key) {
 const SECRET_VALUE_PATTERNS = Object.freeze([
   // URL/DSN userinfo: scheme://user:password@host  → mask the password only.
   // Covers postgres/mysql/redis/amqp/http(s)/jdbc:... DSNs carrying credentials.
-  { re: /\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):([^\s/@]+)@/gi, replace: '$1:[redacted]@' },
+  // Password is matched greedily up to the LAST `@` before the host (bounded to the
+  // authority via [^\s/?#]+), so passwords that themselves contain `@`
+  // (e.g. user:P@ssw0rd@host) are fully masked, not just up to the first `@`.
+  { re: /\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):[^\s/?#]+@([^\s/@:;?#]+)/gi, replace: '$1:[redacted]@$2' },
   // key=value credential params (ODBC / SQL Server / JDBC query, URL query, free text):
   // password / pwd / passwd / secret / client_secret / token / access_token /
   // refresh_token / api_key / apikey. Anchored on `key=` so benign prose like the

--- a/plugins/plugin-integration-core/lib/payload-redaction.cjs
+++ b/plugins/plugin-integration-core/lib/payload-redaction.cjs
@@ -51,10 +51,16 @@ const SECRET_VALUE_PATTERNS = Object.freeze([
   // URL/DSN userinfo: scheme://user:password@host  → mask the password only.
   // Covers postgres/mysql/redis/amqp/http(s)/jdbc:... DSNs carrying credentials.
   { re: /\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):([^\s/@]+)@/gi, replace: '$1:[redacted]@' },
-  // key=value credential params (ODBC / SQL Server / JDBC query): password= / pwd=
-  { re: /\b(password|pwd)=([^;&\s"']+)/gi, replace: '$1=[redacted]' },
+  // key=value credential params (ODBC / SQL Server / JDBC query, URL query, free text):
+  // password / pwd / passwd / secret / client_secret / token / access_token /
+  // refresh_token / api_key / apikey. Anchored on `key=` so benign prose like the
+  // word "secret" or "token" (no `=`) is never matched.
+  { re: /\b(password|pwd|passwd|secret|client[_-]?secret|token|access[_-]?token|refresh[_-]?token|api[_-]?key|apikey)=([^;&\s"']+)/gi, replace: '$1=[redacted]' },
   // Bearer token — require a long token-shaped value so "Bearer of bad news" is safe.
   { re: /\b(Bearer)\s+([A-Za-z0-9._~+/-]{20,}=*)/g, replace: '$1 [redacted]' },
+  // Standalone JWT (eyJ… three base64url segments) even without a Bearer/token= prefix.
+  // The `eyJ` header + dotted-triple shape is JWT-specific; benign text won't match.
+  { re: /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g, replace: '[redacted-jwt]' },
 ])
 
 function scrubSecretStringValue(value) {


### PR DESCRIPTION
## What

Extends the shared payload-redaction value-scrub (`scrubSecretStringValue` in `plugins/plugin-integration-core/lib/payload-redaction.cjs`) to cover secret-shaped **values** that still leaked under **benign keys** — confirmed live on origin/main.

The existing scrubber (already merged) masked: DB/DSN credentials, `password=`/`pwd=`, and `Bearer <token>`. It did **not** mask: `token=` / `secret=` / `api_key=` / `access_token=` / `client_secret=` / `refresh_token=`, nor a **standalone JWT** (`eyJ…` without a `Bearer`/`token=` prefix). Empirically confirmed those were KEPT (leaked).

## Change (additive — only redacts more)

- Widen the `key=value` credential rule to `password|pwd|passwd|secret|client_secret|token|access_token|refresh_token|api_key|apikey` — anchored on `key=`, so benign prose (the word "secret"/"token" with no `=`) is never matched.
- Add a standalone-JWT pattern (`eyJ` + dotted-triple base64url) — JWT-specific shape; benign text won't match.
- Still mask the secret **substring only** (preserve diagnostic context: scheme/host/db); scrub runs **before** truncation.

## Constraints honored (as specified)

- High-confidence shapes only (JDBC/ODBC/DSN, Bearer/JWT, token=/password=/secret=/api_key=/…).
- Redacts even under a benign key.
- Does **not** over-redact: normal error text, plain URLs, `qty=/price=/status=`, "client secret" (space, no `=`), non-JWT `eyJ`-prefixed text all preserved (covered by the extended false-positive matrix).
- Fail-safe substring masking; no K3 Save/BOM/Submit/Audit, no resolver/composition, no read/list touched.

## Verification

- `node __tests__/payload-redaction.test.cjs` passes (new adversarial cases: each new `key=value` shape + standalone JWT scrubbed, direct + via the live sanitizer under a benign key; Bearer-JWT regression; extended false-positive matrix).
- All redaction consumers pass with the change: `runner-support`, `pipeline-runner`, `external-systems`, `http-routes`, `bridge-agent-readonly-adapter` (shared-helper change → verified across consumers).

## Lock posture

Redaction hardening — **allowed before #1792 PASS** per the GATE boundary. Touches no K3 write / reference resolver / read-list path.

## Out of scope (noted)

`http-routes.cjs` carries its own `redactSecretText`; a future consolidation so all paths share one secret-shape set would remove the duplication. Not done here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)