### PR TITLE
fix(multitable): reject formula→formula references at field write (A2-defense)

### DIFF
--- a/docs/development/multitable-derived-field-borrow-plan-20260526.md
+++ b/docs/development/multitable-derived-field-borrow-plan-20260526.md
@@ -41,12 +41,19 @@
   - **如建（as-built）**：`validateChanges` 把 `formula` 并入 `lookup`/`rollup` 的 `RecordFieldForbiddenError`(FIELD_READONLY) 只读分支；并删掉写循环里现已 dead 的 formula skip（validateChanges 先行）。
   - **pre-check 结论（已做）**：formula 经 `deriveFieldPermissions`(`permission-derivation.ts:58`)→`readOnlyFieldIds` **已是 UI 只读** → 网格从不 PATCH formula；create/form-submit 走**独立** `record-service` 校验、不受影响；recalc 物化写是直连 DB UPDATE、不过 validateChanges。无生产写入方被破坏；唯一一个依赖旧"静默跳过"的测试已改成 empty-change no-op。2340 后端单测通过、tsc 绿。
 
-- [ ] ⬜ **A2 记录内 formula 链拓扑排序**
-  - **现状缺陷**：`recalculateRecord` 循环读**原始** `data`、写 `updates`，所以 `B={fld_A}` 且 A 也是 formula 时，B 读到 A 的旧值/公式串 —— 无序。
-  - **做什么**：对记录内 formula 字段按依赖做局部拓扑序求值。注意：`formula_dependencies` 记的是**表级 field→field 边**，不是单记录内的求值链；这里**复用它的边数据**（过滤出当前记录的 formula 字段子图来定序），不是直接复用一套现成机制 —— 需新写记录内的局部定序。
-  - **验收**：单测 —— B 引用 A（皆 formula），单次重算后 B = 基于 A 新值的结果。
-  - **工作量**: S · **风险**: 低 · **依赖**: 与 A1 同改更省事
-  - **K3**: 允许
+- [x] ✅ **A2-defense (PR #1896 OPEN — `runtime/multitable-formula-defense-20260526`) 后端拒绝 formula→formula 引用**
+  - **A2 pre-check 结论**（落地前取证）：链式 formula 在产品引导路径被**前端三层硬禁**（token 选择器排除 `type==='formula'` + 表达式校验 error + 保存禁用），但经 **raw API**（create/update 对 formula 表达式零校验）+ **类型转换**（建 string X→建 formula B 引用 X→把 X 转成 formula）**可达**，且 `recalculateRecord` 无 topo → 链式静默算错。详见 `multitable-formula-reference-guard-verification-20260526.md` §1。
+  - **判定**：不为"产品未暴露的功能"建 topo 机器；改做最小、锁安全的 defense，与前端立场一致。
+  - **如建（as-built）**：`univer-meta.ts` 新增 `validateFormulaReferences`（抽 refs，含自身 / 凡 `mapFieldType==='formula'` 的 ref → 拒；**只拒 formula 类型**，lookup/rollup 作输入放行，未知 ref 仍容忍）+ `findFormulaReferrers`（反向，`formula_dependencies JOIN meta_fields` 复检存活 formula 引用方，**JOIN+类型过滤忽略陈旧边**——删字段/转走 formula 都不清边）；三处强制点：create + update 校验本字段表达式、update `nextType==='formula' && currentType!=='formula'` 时反向拒转换。
+  - **测试**：新增 route-level `multitable-formula-reference-guard.test.ts`（真实路由 + 内存 pool，9 例含判别 lookup/nonexistent 放行 + 承重 stale-edge 转换放行 + 存量链式纯改名 on-edit 不触发）；全后端单元 3230 passed/86 skipped 零回归 + tsc 绿。
+  - **soft-migration**：存量含 formula 引用的 formula 字段，下次编辑表达式/转换时才校验失败（lazy/on-edit，不加迁移；存量链式误算属既有问题）。
+  - **K3 / OSS**：仅多维表内核字段校验；未碰 integration-core/K3/RBAC/auth/存储；无 OSS 代码；无 migration。
+
+- [ ] 🔒 **A2-full（记录内 formula 链拓扑排序）—— 降级为 gated/future**
+  - **为什么降级**：A2-defense 已使 formula→formula 在后端不可达（与前端一致），产品**不暴露**链式 formula → 没有正确性需求要支持它。topo 求值只在"决定把链式 formula 作为产品特性"时才有意义。
+  - **若启用做什么**：`recalculateRecord` 循环改读"边算边回灌"的工作副本，按 `formula_dependencies` 当前记录子图局部拓扑定序；同时放宽 A2-defense 的拒绝。
+  - **门**：需显式 opt-in（先回答"链式 formula 是否成为产品特性"），且与 B/C 的引擎/依赖图工作面协同最佳。
+  - **K3**: 允许（但默认 defer）
 
 - [ ] ⬜ **A2b 宏展开转义/注入加固**
   - **现状缺陷**：`evaluateField` 把字段值字面替换进表达式字符串；值含引号 / `{fld_` / 运算符时会污染表达式。
@@ -139,7 +146,8 @@
 
 ```
 优先级（非自动推进）:
-  ✅ A1（#1883）· ✅ A1.1（#1890） →  A2 · F1（顺手清理）   ← 内核打磨，下一顺位 A2
+  ✅ A1（#1883）· ✅ A1.1（#1890）· ✅ A2-defense  →  F1（顺手清理）   ← 内核打磨，下一顺位 F1
+        ├─ A2-full（链式 topo）：🔒 降级 gated/future（产品不暴露链式 formula；先答"是否做成特性"）
         └─ 若决定投资真引擎 ─→ scope-gate: B1 ⊕ C1（打包一份 RFC）→ B2 · C2a · C3 ·（C2b 另议）
   D（outbox）        ：保持冻结，等 DF-N2
   E（存储）          ：永不
@@ -147,7 +155,7 @@
 ```
 
 - **重要**：箭头是优先级顺序，**不代表做完一条自动开下一条**。每条各需独立 opt-in；我一条一条来。
-- **A1 已合并**（#1883）、**A1.1 已合并**（#1890）。下一顺位 = **A2**（记录内 formula 链拓扑排序），其后视情况 F1；或走 B1⊕C1 的 RFC。各自独立 opt-in。
+- **A1 已合并**（#1883）、**A1.1 已合并**（#1890）、**A2-defense 已完成**（formula→formula 后端拒绝）。下一顺位 = **F1**（删网格死代码，顺手）；**A2-full（链式 topo）已降级为 gated/future**（产品不暴露链式 formula）；或走 B1⊕C1 的 RFC。各自独立 opt-in。
 - **想把多维表派生字段做"扎实"** → 额外 opt-in **B1⊕C1 的 RFC**，再逐条决定 B2/C2a/C3；**C2b（物化）是最重、最靠近存储模型的独立 gate，单独拍板**。
 - **阶段二相关（D）** 一律等 GATE/解锁，不在本轮。
 

--- a/docs/development/multitable-formula-reference-guard-verification-20260526.md
+++ b/docs/development/multitable-formula-reference-guard-verification-20260526.md
@@ -1,0 +1,68 @@
+# 多维表 formula→formula 引用防御（A2-defense）—— 验证
+
+> Date: 2026-05-26 · Branch: `runtime/multitable-formula-defense-20260526`（切自 `origin/main` 466635ad1）
+> 关联: Track A / `docs/development/multitable-derived-field-borrow-plan-20260526.md` 的 A2 ·
+> 上游基线: A1 #1883 (`9e3fcf549`) + A1.1 #1890 (`3dae1ed3`)
+> 范围: **仅多维表内核字段校验**；未触碰 `integration-core`/K3/RBAC/auth/存储；未引入 OSS 代码。K3 PoC Stage-1 锁内允许的内核打磨。
+
+## 1. A2 pre-check（先取证，再决定做不做 topo）
+
+A2 原计划是"记录内 formula 链拓扑排序"（让 `B={fld_A}` 且 A 也是 formula 时算对）。落地前先做了可达性 pre-check，回答三问：
+
+1. **前端是否禁止 formula→formula？** —— **是，三层硬阻止**：
+   - token 插入器 `formulaSourceFields`（`apps/web/src/multitable/components/MetaFieldManager.vue:631`）`filter(field.type !== 'formula')`：候选里根本不出现 formula 字段，且排除自引用。
+   - 表达式是 freeform `<textarea>`，但 `validateFormulaExpression` 用的就是这个**已过滤**列表 → 手打 `{fld_某formula}` 被判 "unknown field reference"，`severity: 'error'`（`apps/web/src/multitable/utils/formula-docs.ts:960`）。
+   - 保存被硬禁用：error 级诊断 → 配置序列化返回 `undefined` → `fieldConfigBlockingReason` 置位 → 保存按钮 `:disabled`（`MetaFieldManager.vue:342` / `:1048`）。
+2. **后端是否记录 formula→formula 边？** —— **是，无类型过滤**。`router.post('/fields')`（`univer-meta.ts`）/ `router.patch('/fields/:fieldId')` 两处都 `extractFieldReferences(expression)` → `syncFormulaDependencies`；`extractFieldReferences`（`formula-engine.ts:28`，正则 `/\{(fld_[a-zA-Z0-9_]+)\}/g`）不校验被引用字段的类型/存在性。照实写入 `formula_dependencies`。
+3. **真实 API 能否绕过前端？** —— **能，完全无防护**。create/update 的 zod schema 只有 `type` enum + `property: z.record(z.unknown())`；`validateLookupRollupConfig` 只管 lookup/rollup，formula 不校验。raw API 发 `{expression:"{fld_otherFormula}"}` 会被接受并记边。
+
+**额外（纯 UI 可达）路径**：先建 string 字段 X，建 formula B 引用 X（合法），再把 X **转成 formula**。update 路径转换 X 时只同步 X 自己的依赖、不回查引用 X 的 B → B→X 静默变成 formula→formula 边，全程没碰 raw API。
+
+**当前 recalc 对链式的真实行为**（`formula-engine.ts` `recalculateRecord`，origin/main 版）：循环里每个 `evaluateField(expression, data, …)` 都读**同一份原始 `data`**，结果只累积到独立的 `updates`、迭代间不回灌 → B 引用 formula A 时 B 读 A 旧值。**无拓扑序 → 链式公式静默算错。**
+
+**判定**：链式 formula 在产品引导路径上被**明确禁掉**，但可经 API + 类型转换**可达**且当前**静默算错**。因此不为"产品未暴露的功能"建 topo 机器（A2-full 降级为 future/gated），改做最小、锁安全的 **A2-defense**：后端拒绝 formula→formula（含自引用），与前端立场一致，关掉 API/转换绕道。
+
+## 2. 改动（A2-defense，as-built）
+
+文件：`packages/core-backend/src/routes/univer-meta.ts`
+
+- 新增 `validateFormulaReferences(query, sheetId, fieldId, expression) → string | null`（模仿 `validateLookupRollupConfig` 风格，中文+字段 id 报错）：抽 refs；含 `fieldId` 自身 → 报错；查 `meta_fields` 这些 ref 的**当前**类型，凡 `mapFieldType === 'formula'` → 报错。
+  - **精确匹配前端立场**：只拒 `formula` 类型 ref。lookup/rollup 作为 formula 输入是**允许**的（前端 `formulaSourceFields` 只排除 `type !== 'formula'`），不误伤。
+  - **未知/缺失 ref 仍容忍**（后端现状：`evaluateField` 把缺失 ref 替成 `0`）——超出本次范围，单列为未来决策。
+- 新增 `findFormulaReferrers(query, sheetId, fieldId) → string[]`（反向）：`formula_dependencies fd JOIN meta_fields mf` 查引用 `fieldId` 的**存活 formula 字段**。`JOIN + mapFieldType` 复检是**承重**的：`formula_dependencies` 在字段删除（`univer-meta.ts` `DELETE FROM meta_fields` 不清边）/ formula→非formula 转换（`syncFormulaDependencies` 仅在 `nextType==='formula'` 调用）时**都不清理**，会留陈旧边、指向已非 formula 的字段 —— 这些**不得**阻断转换。
+- **三处强制点**（均抛 `ValidationError` → 400 `VALIDATION_ERROR`，在事务内抛 → 回滚）：
+  1. create：`validateLookupRollupConfig` 之后，`type === 'formula' && property?.expression` → `validateFormulaReferences`。
+  2. update：同上，`nextType === 'formula' && nextProperty?.expression`。
+  3. update 转换防御：`nextType === 'formula' && currentType !== 'formula'` → `findFormulaReferrers`，非空则拒（报出引用方字段 id）。
+
+**不做**（确认范围边界）：不动 recalc topo（那是 A2-full，单独 gate）；不加 `formula_dependencies` 清理迁移（lazy/on-edit）；不改前端（三层守卫已在）；不拒未知 ref。
+
+## 3. soft-migration 语义（需知会）
+
+本改动落地后，**任何已存在的、表达式含 formula 引用的 formula 字段**（此前经 raw API 或转换路径造出）会在**下次有人编辑其表达式 / 把某字段转成 formula 时**校验失败。这是**正确行为**，但对这一类记录是一次行为变化。**不加迁移**——lazy / on-edit 是恰当范围；存量链式 formula 的 recalc 误算是既有问题，不在本 PR 范围。
+
+**严格的 on-edit（非每次写）**：update 强制点①的 `nextProperty` 会回退到存量 `row.property`，因此**仅当 PATCH payload 显式带 `property.expression` 时才校验**（`expressionInPayload` 守卫）。对存量链式 formula 做**纯改名 PATCH（不带 property）不会触发校验、不会 400**——已由单测锁定。
+
+## 4. 测试
+
+新增 `packages/core-backend/tests/unit/multitable-formula-reference-guard.test.ts`（**route-level**：挂真实 `univerMetaRouter()` + 内存 mock pool，打真实 `POST/PATCH /api/multitable/fields`，非手搭 helper 调用 —— 遵循 wire-vs-fixture 纪律），9 例全绿：
+
+| 用例 | 期望 |
+|---|---|
+| create formula 引用另一 formula | 400，报出被引用 formula id，事务回滚（B 未落库） |
+| create formula 引用自身 | 400，"引用自身" |
+| create formula 引用 **lookup**（判别：不过度拒绝） | 201 放行 |
+| create formula 引用**不存在**字段（保留现容忍） | 201 放行 |
+| update formula 表达式改为引用另一 formula | 400 |
+| 对存量链式 formula 做**纯改名 PATCH**（不带 property）| 200，表达式不变（lazy/on-edit，不过度急切）|
+| 转换 string→formula 而有**存活** formula 引用它 | 400，报出引用方 id，"转换为公式" |
+| 转换 string→formula 而无引用 | 200 放行 |
+| 转换 string→formula 而仅有**陈旧边**（引用方已转走非 formula）| 200 放行（承重：JOIN+类型复检忽略陈旧边）|
+
+- 全后端单元套件：**3229 passed / 86 skipped**（含本 8 例），零回归。
+- `tsc --noEmit`：绿。
+
+## 5. K3 / OSS 合规
+- 仅多维表内核字段校验；未触碰 `integration-core`/K3/RBAC/auth/存储模型。
+- 未引入 Teable/HyperFormula 任何代码。
+- 无 migration（不新增表/列；`formula_dependencies` 已存在，沿用其 schema）。

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1005,6 +1005,70 @@ async function validateLookupRollupConfig(
   return null
 }
 
+/**
+ * A2-defense (formula→formula guard). The product does NOT support a formula field
+ * referencing another formula field: the frontend hard-blocks it (the token picker
+ * `formulaSourceFields` excludes `type === 'formula'`, and the expression validator
+ * flags a hand-typed formula ref as an error that disables save), and
+ * `recalculateRecord` has no intra-record topological order — so a formula→formula
+ * chain would silently compute against stale intermediate values. This closes the
+ * raw-API path the frontend can't. lookup/rollup fields ARE permitted as formula
+ * inputs (the frontend offers them — only `type !== 'formula'` is filtered), so only
+ * `formula`-typed references and self-references are rejected. Unknown / missing
+ * references stay tolerated (current behavior; a separate decision). Returns an
+ * error message (matching `validateLookupRollupConfig`'s Chinese-with-field-id style)
+ * or null when the expression is clean.
+ */
+async function validateFormulaReferences(
+  query: QueryFn,
+  sheetId: string,
+  fieldId: string,
+  expression: string,
+): Promise<string | null> {
+  const refs = multitableFormulaEngine.extractFieldReferences(expression)
+  if (refs.length === 0) return null
+  if (refs.includes(fieldId)) {
+    return `公式字段不能引用自身：{${fieldId}}`
+  }
+  const res = await query(
+    'SELECT id, type FROM meta_fields WHERE sheet_id = $1 AND id = ANY($2::text[])',
+    [sheetId, refs],
+  )
+  const formulaRefs = (res.rows as Array<{ id: unknown; type: unknown }>)
+    .filter((row) => mapFieldType(String(row.type ?? '')) === 'formula')
+    .map((row) => String(row.id))
+  if (formulaRefs.length > 0) {
+    return `公式字段不能引用其它公式字段：${formulaRefs.map((id) => `{${id}}`).join('、')}`
+  }
+  return null
+}
+
+/**
+ * A2-defense reverse guard. Lists the *live* formula fields whose expression
+ * references `fieldId`, used to reject converting `fieldId` INTO a formula when a
+ * formula already depends on it (a path the forward guard never sees: A is created
+ * as a non-formula, formula B references A, then A is converted to formula). The
+ * JOIN + `mapFieldType` re-check is load-bearing: `formula_dependencies` is NOT
+ * cleaned up on field delete or on a formula→non-formula conversion, so it can hold
+ * stale edges pointing at fields that are no longer formulas — those must NOT block.
+ */
+async function findFormulaReferrers(
+  query: QueryFn,
+  sheetId: string,
+  fieldId: string,
+): Promise<string[]> {
+  const res = await query(
+    `SELECT DISTINCT fd.field_id AS field_id, mf.type AS type
+       FROM formula_dependencies fd
+       JOIN meta_fields mf ON mf.id = fd.field_id AND mf.sheet_id = fd.sheet_id
+      WHERE fd.sheet_id = $1 AND fd.depends_on_field_id = $2`,
+    [sheetId, fieldId],
+  )
+  return (res.rows as Array<{ field_id: unknown; type: unknown }>)
+    .filter((row) => mapFieldType(String(row.type ?? '')) === 'formula')
+    .map((row) => String(row.field_id))
+}
+
 function normalizeLinkIds(value: unknown): string[] {
   if (value === null || value === undefined) return []
 
@@ -4430,6 +4494,10 @@ export function univerMetaRouter(): Router {
         if (configError) {
           throw new ValidationError(configError)
         }
+        if (type === 'formula' && property?.expression) {
+          const formulaError = await validateFormulaReferences(query, sheetId, fieldId, String(property.expression))
+          if (formulaError) throw new ValidationError(formulaError)
+        }
 
         let order = desiredOrder
         if (typeof order !== 'number') {
@@ -4709,6 +4777,27 @@ export function univerMetaRouter(): Router {
         const configError = await validateLookupRollupConfig(req, query, sheetId, nextType, nextProperty)
         if (configError) {
           throw new ValidationError(configError)
+        }
+        // Only re-validate the expression when the caller is actually writing it
+        // (lazy/on-edit): `nextProperty` falls back to the stored `row.property`, so a
+        // rename-only PATCH on a pre-existing chained formula must NOT re-validate and
+        // 400. Gate on the payload explicitly carrying `property.expression`.
+        const expressionInPayload =
+          typeof parsed.data.property !== 'undefined'
+          && Object.prototype.hasOwnProperty.call(parsed.data.property ?? {}, 'expression')
+        if (nextType === 'formula' && expressionInPayload && nextProperty?.expression) {
+          const formulaError = await validateFormulaReferences(query, sheetId, fieldId, String(nextProperty.expression))
+          if (formulaError) throw new ValidationError(formulaError)
+        }
+        // Reverse guard: converting a non-formula field INTO a formula must not create
+        // a formula→formula edge that a formula already depends on (see findFormulaReferrers).
+        if (nextType === 'formula' && currentType !== 'formula') {
+          const referrers = await findFormulaReferrers(query, sheetId, fieldId)
+          if (referrers.length > 0) {
+            throw new ValidationError(
+              `无法将该字段转换为公式：已有公式字段引用它：${referrers.map((id) => `{${id}}`).join('、')}`,
+            )
+          }
         }
 
         if (typeof desiredOrder === 'number' && desiredOrder !== currentOrder) {

--- a/packages/core-backend/tests/unit/multitable-formula-reference-guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-formula-reference-guard.test.ts
@@ -1,0 +1,360 @@
+/**
+ * A2-defense — formula→formula reference guard (route-level).
+ *
+ * The product does NOT support a formula field referencing another formula
+ * field: the frontend hard-blocks it (the token picker excludes `type ===
+ * 'formula'` and the expression validator flags a hand-typed formula ref as an
+ * error that disables save), and `recalculateRecord` has no intra-record
+ * topological order — so a formula→formula chain would silently compute against
+ * stale intermediate values. Two paths can still introduce such an edge past the
+ * frontend, and these tests lock both at the real route binding (not a hand-built
+ * helper call — see the wire-vs-fixture rule):
+ *
+ *   1. Forward: creating / updating a formula whose expression references a
+ *      formula field (or itself). Rejected with 400.
+ *   2. Reverse (conversion): converting a non-formula field INTO a formula while a
+ *      live formula already references it. Rejected with 400.
+ *
+ * Discriminating cases prove we did NOT over-reject:
+ *   - formula→lookup / formula→rollup are ALLOWED (the frontend offers them; only
+ *     `type === 'formula'` is filtered).
+ *   - formula→nonexistent stays ALLOWED (current tolerance; a separate decision).
+ *   - the conversion guard must IGNORE stale `formula_dependencies` edges left by a
+ *     formula→non-formula conversion (cleanup does not run on that path), because
+ *     those edges no longer point at a live formula consumer.
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+
+const SHEET_ID = 'sheet_fg'
+
+type StoredField = {
+  id: string
+  sheet_id: string
+  name: string
+  type: string
+  property: Record<string, unknown>
+  order: number
+}
+type Edge = { fieldId: string; dependsOn: string }
+type QueryResult = { rows: any[]; rowCount?: number }
+
+/**
+ * In-memory store mirroring the subset of DB interactions the field POST/PATCH
+ * paths perform, plus a real `formula_dependencies` edge set so the conversion
+ * guard (and the stale-edge case) can be exercised end-to-end. Edge cleanup
+ * deliberately matches production: edges for a field are removed ONLY when that
+ * field is (re)written as a formula — never on a conversion away from formula.
+ */
+function createStore(initial: StoredField[]) {
+  const fields = new Map<string, StoredField>()
+  for (const f of initial) fields.set(f.id, { ...f, property: { ...f.property } })
+  const edges: Edge[] = []
+
+  const handler = (sql: string, params?: unknown[]): QueryResult => {
+    if (sql.includes('FROM meta_sheets WHERE id = $1')) {
+      return { rows: [{ id: SHEET_ID }] }
+    }
+    if (sql.includes('MAX("order")')) {
+      const max = Math.max(-1, ...[...fields.values()].map((f) => f.order))
+      return { rows: [{ max_order: max }] }
+    }
+    // A2-defense forward guard.
+    if (sql.includes('SELECT id, type FROM meta_fields WHERE sheet_id = $1 AND id = ANY')) {
+      const ids = (params?.[1] as string[]) ?? []
+      const rows = ids
+        .map((id) => fields.get(id))
+        .filter((f): f is StoredField => Boolean(f))
+        .map((f) => ({ id: f.id, type: f.type }))
+      return { rows }
+    }
+    // A2-defense reverse guard (conversion): formula_dependencies JOIN meta_fields.
+    if (sql.includes('FROM formula_dependencies fd') && sql.includes('JOIN meta_fields mf')) {
+      const target = params?.[1] as string
+      const seen = new Set<string>()
+      const rows: Array<{ field_id: string; type: string }> = []
+      for (const e of edges) {
+        if (e.dependsOn !== target || seen.has(e.fieldId)) continue
+        const f = fields.get(e.fieldId)
+        if (!f) continue // JOIN drops edges whose referencing field was deleted
+        seen.add(e.fieldId)
+        rows.push({ field_id: f.id, type: f.type })
+      }
+      return { rows }
+    }
+    if (sql.includes('DELETE FROM formula_dependencies')) {
+      const fieldId = params?.[1] as string
+      for (let i = edges.length - 1; i >= 0; i--) {
+        if (edges[i].fieldId === fieldId) edges.splice(i, 1)
+      }
+      return { rows: [] }
+    }
+    if (sql.includes('INSERT INTO formula_dependencies')) {
+      edges.push({ fieldId: params?.[1] as string, dependsOn: params?.[2] as string })
+      return { rows: [] }
+    }
+    if (sql.includes('SELECT id, sheet_id, name, type, property, "order" FROM meta_fields WHERE id = $1')) {
+      const f = fields.get(params?.[0] as string)
+      return { rows: f ? [{ ...f }] : [] }
+    }
+    if (sql.includes('SELECT id, sheet_id FROM meta_fields WHERE id = $1')) {
+      const f = fields.get(params?.[0] as string)
+      return { rows: f ? [{ id: f.id, sheet_id: f.sheet_id }] : [] }
+    }
+    if (sql.includes('INSERT INTO meta_fields')) {
+      const [id, sheet_id, name, type, propertyJson, order] = params as [string, string, string, string, string, number]
+      const f: StoredField = { id, sheet_id, name, type, property: JSON.parse(propertyJson), order }
+      fields.set(id, f)
+      return { rows: [{ id, name, type, property: f.property, order }] }
+    }
+    if (sql.startsWith('UPDATE meta_fields') && sql.includes('SET name = $2')) {
+      const [id, name, type, propertyJson, order] = params as [string, string, string, string, number]
+      const f = fields.get(id)
+      if (!f) return { rows: [] }
+      f.name = name
+      f.type = type
+      f.property = JSON.parse(propertyJson)
+      f.order = order
+      return { rows: [{ id: f.id, name: f.name, type: f.type, property: f.property, order: f.order }] }
+    }
+    if (sql.startsWith('UPDATE meta_fields')) return { rows: [] } // order-shuffle no-op
+    if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE id = $1')) {
+      const f = fields.get(params?.[0] as string)
+      return { rows: f ? [{ id: f.id, name: f.name, type: f.type, property: f.property, order: f.order }] : [] }
+    }
+    return { rows: [], rowCount: 0 }
+  }
+
+  return { fields, edges, handler }
+}
+
+function createMockPool(handler: (sql: string, params?: unknown[]) => QueryResult) {
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    if (
+      sql.includes('FROM spreadsheet_permissions')
+      || sql.includes('FROM field_permissions')
+      || sql.includes('FROM view_permissions')
+      || sql.includes('FROM meta_view_permissions')
+      || sql.includes('FROM record_permissions')
+    ) {
+      return { rows: [], rowCount: 0 }
+    }
+    return handler(sql, params)
+  })
+  const transaction = vi.fn(async (fn: (client: { query: typeof query }) => Promise<unknown>) => fn({ query }))
+  return { query, transaction }
+}
+
+async function createApp(handler: (sql: string, params?: unknown[]) => QueryResult) {
+  vi.resetModules()
+  vi.doMock('../../src/rbac/service', () => ({
+    isAdmin: vi.fn().mockResolvedValue(false),
+    userHasPermission: vi.fn().mockResolvedValue(false),
+    listUserPermissions: vi.fn().mockResolvedValue(['multitable:write']),
+    invalidateUserPerms: vi.fn(),
+    getPermCacheStatus: vi.fn(),
+  }))
+
+  const { poolManager } = await import('../../src/integration/db/connection-pool')
+  const { univerMetaRouter } = await import('../../src/routes/univer-meta')
+  const mockPool = createMockPool(handler)
+  vi.spyOn(poolManager, 'get').mockReturnValue(mockPool as any)
+
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    req.user = { id: 'user_fg', roles: [], perms: ['multitable:read', 'multitable:write'] }
+    next()
+  })
+  app.use('/api/multitable', univerMetaRouter())
+  return app
+}
+
+function field(over: Partial<StoredField> & { id: string; type: string }): StoredField {
+  return { sheet_id: SHEET_ID, name: over.id, property: {}, order: 0, ...over }
+}
+
+describe('A2-defense — formula reference guard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('rejects creating a formula that references another formula field', async () => {
+    const { fields, handler } = createStore([
+      field({ id: 'fld_a', type: 'formula', property: { expression: '=1+1' } }),
+    ])
+    const app = await createApp(handler)
+
+    const res = await request(app).post('/api/multitable/fields').send({
+      sheetId: SHEET_ID,
+      id: 'fld_b',
+      name: 'B',
+      type: 'formula',
+      property: { expression: '=SUM({fld_a}, 1)' },
+    })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toContain('fld_a')
+    expect(fields.has('fld_b')).toBe(false) // transaction rolled back
+  })
+
+  it('rejects a formula that references itself', async () => {
+    const { handler } = createStore([])
+    const app = await createApp(handler)
+
+    const res = await request(app).post('/api/multitable/fields').send({
+      sheetId: SHEET_ID,
+      id: 'fld_self',
+      name: 'Self',
+      type: 'formula',
+      property: { expression: '={fld_self}' },
+    })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.message).toContain('引用自身')
+    expect(res.body.error.message).toContain('fld_self')
+  })
+
+  it('ALLOWS a formula that references a lookup field (not over-rejecting computed inputs)', async () => {
+    const { fields, handler } = createStore([
+      field({ id: 'fld_look', type: 'lookup', property: {} }),
+    ])
+    const app = await createApp(handler)
+
+    const res = await request(app).post('/api/multitable/fields').send({
+      sheetId: SHEET_ID,
+      id: 'fld_f',
+      name: 'F',
+      type: 'formula',
+      property: { expression: '={fld_look} * 2' },
+    })
+
+    expect(res.status).toBe(201)
+    expect(fields.has('fld_f')).toBe(true)
+  })
+
+  it('ALLOWS a formula that references a nonexistent field (preserves current tolerance)', async () => {
+    const { fields, handler } = createStore([])
+    const app = await createApp(handler)
+
+    const res = await request(app).post('/api/multitable/fields').send({
+      sheetId: SHEET_ID,
+      id: 'fld_g',
+      name: 'G',
+      type: 'formula',
+      property: { expression: '={fld_ghost} + 1' },
+    })
+
+    expect(res.status).toBe(201)
+    expect(fields.has('fld_g')).toBe(true)
+  })
+
+  it('rejects updating a formula expression to reference another formula field', async () => {
+    const { handler } = createStore([
+      field({ id: 'fld_a', type: 'formula', property: { expression: '=2' } }),
+      field({ id: 'fld_b', type: 'formula', property: { expression: '=1' } }),
+    ])
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .patch('/api/multitable/fields/fld_b')
+      .send({ property: { expression: '={fld_a} + 1' } })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.message).toContain('fld_a')
+  })
+
+  it('does NOT re-validate a pre-existing chained formula on a rename-only PATCH (lazy/on-edit)', async () => {
+    // Legacy state: B is already stored as a formula referencing formula A (created
+    // pre-defense via API/conversion). A rename that does not touch the expression
+    // must pass — validation is lazy/on-edit, not on every write. `nextProperty`
+    // falls back to the stored expression, so this guards against an over-eager 400.
+    const { fields, handler } = createStore([
+      field({ id: 'fld_a', type: 'formula', property: { expression: '=2' } }),
+      field({ id: 'fld_b', type: 'formula', property: { expression: '={fld_a} + 1' } }),
+    ])
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .patch('/api/multitable/fields/fld_b')
+      .send({ name: 'Renamed B' })
+
+    expect(res.status).toBe(200)
+    expect(fields.get('fld_b')?.name).toBe('Renamed B')
+    expect((fields.get('fld_b')?.property as any).expression).toBe('={fld_a} + 1') // unchanged
+  })
+
+  it('rejects converting a field INTO a formula when a live formula already references it', async () => {
+    const { handler } = createStore([
+      field({ id: 'fld_x', type: 'string', property: {} }),
+    ])
+    const app = await createApp(handler)
+
+    // B (formula) references X (string) — allowed, records the B→X edge.
+    await request(app).post('/api/multitable/fields').send({
+      sheetId: SHEET_ID,
+      id: 'fld_b',
+      name: 'B',
+      type: 'formula',
+      property: { expression: '={fld_x} + 1' },
+    }).expect(201)
+
+    // Now converting X to a formula would make B→X a formula→formula edge.
+    const res = await request(app)
+      .patch('/api/multitable/fields/fld_x')
+      .send({ type: 'formula', property: { expression: '=5' } })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.message).toContain('fld_b')
+    expect(res.body.error.message).toContain('转换为公式')
+  })
+
+  it('ALLOWS converting a field into a formula when nothing references it', async () => {
+    const { fields, handler } = createStore([
+      field({ id: 'fld_x', type: 'string', property: {} }),
+    ])
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .patch('/api/multitable/fields/fld_x')
+      .send({ type: 'formula', property: { expression: '=5' } })
+
+    expect(res.status).toBe(200)
+    expect(fields.get('fld_x')?.type).toBe('formula')
+  })
+
+  it('ALLOWS conversion despite a stale formula_dependencies edge from a since-converted referrer', async () => {
+    const { fields, edges, handler } = createStore([
+      field({ id: 'fld_x', type: 'string', property: {} }),
+    ])
+    const app = await createApp(handler)
+
+    // B (formula) references X — records B→X edge.
+    await request(app).post('/api/multitable/fields').send({
+      sheetId: SHEET_ID,
+      id: 'fld_b',
+      name: 'B',
+      type: 'formula',
+      property: { expression: '={fld_x} + 1' },
+    }).expect(201)
+
+    // Convert B away from formula → its B→X edge is NOT cleaned up (matches prod).
+    await request(app)
+      .patch('/api/multitable/fields/fld_b')
+      .send({ type: 'string' })
+      .expect(200)
+    expect(edges.some((e) => e.fieldId === 'fld_b' && e.dependsOn === 'fld_x')).toBe(true) // stale edge lingers
+
+    // Converting X to a formula must SUCCEED: the lingering edge points at B,
+    // which is no longer a formula, so it must not block.
+    const res = await request(app)
+      .patch('/api/multitable/fields/fld_x')
+      .send({ type: 'formula', property: { expression: '=9' } })
+
+    expect(res.status).toBe(200)
+    expect(fields.get('fld_x')?.type).toBe('formula')
+  })
+})


### PR DESCRIPTION
## What

Closes the formula→formula bypass on the multitable field-write path. The product does **not** support a formula field referencing another formula field — the frontend hard-blocks it three ways (token picker excludes `type==='formula'`, expression validator flags a hand-typed formula ref as a save-disabling error), and `recalculateRecord` has no intra-record topological order, so a formula→formula chain would **silently compute against stale values**.

## Why (A2 pre-check)

Before implementing the planned A2 (intra-record formula-chain topo sort), a pre-check established the chained-formula state is still **reachable past the frontend**:
- **raw API** — create/update do zero validation on a formula's expression refs;
- **type conversion** — build string `X`, formula `B` referencing `X` (allowed), then convert `X` to formula → `B→X` becomes a formula→formula edge with no raw-API call.

Since the product deliberately does not expose chained formula, building topo machinery to *support* it (A2-full) is downgraded to gated/future. This PR instead does the minimal, lock-safe **A2-defense**: make the backend reject formula→formula, matching the frontend's stance.

## Changes (`packages/core-backend/src/routes/univer-meta.ts`)

- **`validateFormulaReferences`** — reject a formula whose expression references a `formula`-typed field or itself. **Only formula refs** are rejected; lookup/rollup remain valid inputs (matching the frontend's `type !== 'formula'` filter), and unknown/missing refs stay tolerated (current behavior, separate decision).
- **`findFormulaReferrers`** — reject converting a non-formula field **into** a formula when a *live* formula references it. The `JOIN meta_fields` + `mapFieldType` re-check is load-bearing: `formula_dependencies` is **not** cleaned up on field delete or formula→non-formula conversion, so stale edges must not block.
- **Three enforcement points**: create, update (own expression), update (reverse conversion guard). All throw `ValidationError` → `400`, inside the transaction → rollback.
- **Lazy / on-edit gate** — update point 1's `nextProperty` falls back to the stored `row.property`, so validation is gated on the payload explicitly carrying `property.expression` (`expressionInPayload`). A rename-only PATCH on a pre-existing chained formula does **not** re-validate / 400.

## Tests

New route-level `tests/unit/multitable-formula-reference-guard.test.ts` (real `univerMetaRouter()` + in-memory pool — hits the actual `POST/PATCH /api/multitable/fields`, not a hand-built helper call), 9 cases:

| Case | Expect |
|---|---|
| create formula → formula | 400 + rollback |
| create formula → self | 400 |
| create formula → **lookup** (discriminating: no over-reject) | 201 |
| create formula → **nonexistent** (preserve tolerance) | 201 |
| update formula expr → formula | 400 |
| **rename-only PATCH** on pre-existing chained formula (lazy/on-edit) | 200, expression unchanged |
| convert string→formula with **live** formula referrer | 400 |
| convert string→formula with no referrer | 200 |
| convert string→formula with **stale** edge only (referrer since-converted) | 200 (load-bearing) |

- Full backend unit suite: **3230 passed / 86 skipped**, zero regressions.
- `tsc --noEmit`: green.

## Soft-migration (lazy / on-edit)

Existing formula fields whose stored expression references a formula (created pre-defense via API/conversion) will fail validation on the **next expression edit or conversion** — not on a rename-only write. Correct behavior; **no migration added**; pre-existing chained-formula miscompute is out of scope.

## Scope / compliance

Multitable kernel field-validation only. No `integration-core`/K3/RBAC/auth/storage. No Teable/HyperFormula code. No migration (`formula_dependencies` already exists). K3 PoC Stage-1 lock-safe kernel polish.

Verification doc: `docs/development/multitable-formula-reference-guard-verification-20260526.md`. Plan: Track A / `docs/development/multitable-derived-field-borrow-plan-20260526.md` (A2-defense). Builds on A1 #1883 + A1.1 #1890.

🤖 Generated with [Claude Code](https://claude.com/claude-code)