### PR TITLE
refactor(formula): remove dead dependency-graph code from grid A1 engine (F1)

### DIFF
--- a/docs/development/formula-engine-deadcode-cleanup-f1-verification-20260526.md
+++ b/docs/development/formula-engine-deadcode-cleanup-f1-verification-20260526.md
@@ -1,0 +1,41 @@
+# 网格 A1 引擎死依赖图代码清理（F1）—— 验证
+
+> Date: 2026-05-26 · Branch: `runtime/formula-engine-deadcode-f1-20260526`（切自 `origin/main` 516176619）
+> 关联: Track F / `docs/development/multitable-derived-field-borrow-plan-20260526.md` F1
+> 范围: **仅删 `formula/engine.ts` 零生产调用的死代码**；不动 `MultitableFormulaEngine`；不做 AST 缓存/环检测/函数重构。K3 PoC Stage-1 锁内允许的内核打磨。
+
+## 1. 为什么
+
+OSS 对标（`multitable-vs-teable-hyperformula-comparison-20260526.md` §"HyperFormula"）确认：网格 A1 引擎 `formula/engine.ts` 的依赖图机器是**死代码**——`buildDependencyGraph()`/`topologicalSort()`/`calculationOrder`/`dependencyGraph` 没有任何生产调用方，唯一命中是一条只测内部状态的单测。把它留在代码里会让人误以为这套依赖图在生产链路生效（实际不然——网格公式按 `calculate()` 即时求值，依赖图从不参与）。
+
+## 2. 死代码核实（删前全仓 grep）
+
+| 符号 | 调用情况 | 结论 |
+|---|---|---|
+| `buildDependencyGraph(sheetId)` (`engine.ts`) | **唯一调用方 = `tests/unit/formula-engine.test.ts` 的 `'Build dependency graph'` 测试**；`src/` 内零调用 | 死 |
+| `topologicalSort()` | 仅被 `buildDependencyGraph` 内部调用 | 死 |
+| `calculationOrder` 字段 | 仅在 `buildDependencyGraph` 内被**写**（`= this.topologicalSort()`），**无任何读取** | 死（write-only） |
+| `dependencyGraph: Map` 字段（`engine.ts`） | 仅在上述两方法内用 | 死 |
+
+**明确不相关、未触碰**（同名但不同物）：
+- `PluginRegistry.ts` 的 `dependencyGraph` / `rebuildDependencyGraph()` —— 插件依赖图，另一个类，生产在用。
+- `packages/openapi/dist-sdk` 的 `MultitableDependencyGraph` —— 生成的 SDK schema，与网格引擎无关。
+
+## 3. 改动
+
+- `packages/core-backend/src/formula/engine.ts`：删 `calculationOrder` + `dependencyGraph` 两个私有字段；删 `buildDependencyGraph()` + `topologicalSort()` 两个方法（含其 doc 注释）。其余（`db`/`functions`/`calculate()`/内置函数等）不动。
+- `packages/core-backend/tests/unit/formula-engine.test.ts`：删只覆盖死代码的 `describe('Dependency Graph')` 块（其内仅一条 `'Build dependency graph'` 测试，注释自承"tests internal state… in a real implementation you'd expose methods"）。`TEST_IDS.SHEET_1` 仍被其它用例使用，保留。
+
+净 **−82 行，纯删除**，无行为变化。
+
+## 4. 验证
+
+- `tsc --noEmit`：绿。
+- `pnpm build`（core-backend `tsc`）：绿。
+- `eslint src/formula/engine.ts`：0 error。
+- 指定单测 `formula-engine.test.ts` + `multitable-formula-engine.test.ts`：**129 passed (2 files)**。
+- 全后端单元套件：**3229 passed / 86 skipped**（= A2-defense 后 3230 − 删掉的 1 条死代码测试），零回归。
+
+## 5. K3 / OSS 合规
+- 仅删网格 A1 引擎死代码；不动 `MultitableFormulaEngine`、不动 integration-core/K3/RBAC/auth/存储。
+- 未引入任何 OSS 代码。无 migration。

--- a/docs/development/multitable-derived-field-borrow-plan-20260526.md
+++ b/docs/development/multitable-derived-field-borrow-plan-20260526.md
@@ -129,11 +129,11 @@
 
 ## 6. Track F — 网格 A1 引擎清理（内核打磨，低优先）
 
-- [ ] ⬜ **F1 删 `formula/engine.ts` 的死依赖图代码**
-  - **现状**：`buildDependencyGraph`/`topologicalSort`/`calculationOrder` **零调用方**（唯一 `rebuildDependencyGraph` 命中是无关的 `PluginRegistry`）。
-  - **验收**：删除后 build/类型/测试全绿，行为无变化。
-  - **工作量**: XS · **风险**: 极低 · **依赖**: 无
-  - **K3**: 允许
+- [x] ✅ **F1 (PR #1897 OPEN, `runtime/formula-engine-deadcode-f1-20260526`) 删 `formula/engine.ts` 的死依赖图代码**
+  - **现状**：`buildDependencyGraph`/`topologicalSort`/`calculationOrder`/`dependencyGraph` **零生产调用方**（唯一调用是一条只测内部状态的单测；`PluginRegistry`/openapi-sdk 的同名物不相关、未触碰）。
+  - **如建（as-built）**：删 `engine.ts` 两字段(`calculationOrder`/`dependencyGraph`) + 两方法(`buildDependencyGraph`/`topologicalSort`)；删只覆盖它的 `describe('Dependency Graph')` 测试块。净 −82 行纯删除、无行为变化。不动 `MultitableFormulaEngine`，不做 AST 缓存/环检测/重构。
+  - **验证**：tsc + `pnpm build` + eslint(0 error) + `formula-engine.test.ts`/`multitable-formula-engine.test.ts`(129 pass) + 全后端单元 3229 pass/86 skip 零回归。详见 `formula-engine-deadcode-cleanup-f1-verification-20260526.md`。
+  - **工作量**: XS · **风险**: 极低 · **依赖**: 无 · **K3**: 允许
 
 - [ ] 🔒 **F2 网格引擎 AST 缓存 + 环检测 —— 仅当网格公式被产品化**
   - **思想来源**：HyperFormula（GPL，仅思想）：AST 按归一化引用 hash 缓存、Tarjan SCC 环检测、脏子图局部重算。
@@ -146,7 +146,7 @@
 
 ```
 优先级（非自动推进）:
-  ✅ A1（#1883）· ✅ A1.1（#1890）· ✅ A2-defense  →  F1（顺手清理）   ← 内核打磨，下一顺位 F1
+  ✅ A1（#1883）· ✅ A1.1（#1890）· ✅ A2-defense · ✅ F1（死代码清理）   ← 内核打磨链已落
         ├─ A2-full（链式 topo）：🔒 降级 gated/future（产品不暴露链式 formula；先答"是否做成特性"）
         └─ 若决定投资真引擎 ─→ scope-gate: B1 ⊕ C1（打包一份 RFC）→ B2 · C2a · C3 ·（C2b 另议）
   D（outbox）        ：保持冻结，等 DF-N2
@@ -155,7 +155,7 @@
 ```
 
 - **重要**：箭头是优先级顺序，**不代表做完一条自动开下一条**。每条各需独立 opt-in；我一条一条来。
-- **A1 已合并**（#1883）、**A1.1 已合并**（#1890）、**A2-defense 已完成**（formula→formula 后端拒绝）。下一顺位 = **F1**（删网格死代码，顺手）；**A2-full（链式 topo）已降级为 gated/future**（产品不暴露链式 formula）；或走 B1⊕C1 的 RFC。各自独立 opt-in。
+- **A1**（#1883）、**A1.1**（#1890）、**A2-defense**、**F1**（删网格死代码）均已落。剩余均为独立 opt-in：**A2-full（链式 topo）已降级 gated/future**（产品不暴露链式 formula，先答"是否做成特性"）；或走 **B1⊕C1 的 RFC**（设计工作，不与清理混做）。
 - **想把多维表派生字段做"扎实"** → 额外 opt-in **B1⊕C1 的 RFC**，再逐条决定 B2/C2a/C3；**C2b（物化）是最重、最靠近存储模型的独立 gate，单独拍板**。
 - **阶段二相关（D）** 一律等 GATE/解锁，不在本轮。
 

--- a/packages/core-backend/src/formula/engine.ts
+++ b/packages/core-backend/src/formula/engine.ts
@@ -130,8 +130,6 @@ type SpreadsheetFunction = (...args: unknown[]) => unknown
 export class FormulaEngine {
   private db: Pick<Kysely<Database>, 'selectFrom'> | null
   private functions: Map<string, SpreadsheetFunction> = new Map()
-  private calculationOrder: string[] = []
-  private dependencyGraph: Map<string, Set<string>> = new Map()
 
   constructor(options: { db?: Pick<Kysely<Database>, 'selectFrom'> } = {}) {
     this.db = options.db ?? defaultDb
@@ -1025,57 +1023,6 @@ export class FormulaEngine {
         result.push(arg)
       }
     }
-    return result
-  }
-
-  /**
-   * Build dependency graph for a sheet
-   */
-  async buildDependencyGraph(sheetId: string): Promise<void> {
-    if (!this.db) return
-
-    const formulas = await this.db
-      .selectFrom('formulas')
-      .select(['cell_id', 'dependencies', 'dependents'])
-      .where('sheet_id', '=', sheetId)
-      .execute()
-
-    this.dependencyGraph.clear()
-
-    for (const formula of formulas) {
-      const deps = formula.dependencies as string[]
-      this.dependencyGraph.set(formula.cell_id, new Set(deps))
-    }
-
-    // Calculate topological order for calculation
-    this.calculationOrder = this.topologicalSort()
-  }
-
-  /**
-   * Topological sort for calculation order
-   */
-  private topologicalSort(): string[] {
-    const visited = new Set<string>()
-    const result: string[] = []
-
-    const visit = (node: string) => {
-      if (visited.has(node)) return
-      visited.add(node)
-
-      const deps = this.dependencyGraph.get(node)
-      if (deps) {
-        for (const dep of deps) {
-          visit(dep)
-        }
-      }
-
-      result.push(node)
-    }
-
-    for (const node of this.dependencyGraph.keys()) {
-      visit(node)
-    }
-
     return result
   }
 }

--- a/packages/core-backend/tests/unit/formula-engine.test.ts
+++ b/packages/core-backend/tests/unit/formula-engine.test.ts
@@ -761,35 +761,6 @@ describe('Formula Engine', () => {
     })
   })
 
-  describe('Dependency Graph', () => {
-    test('Build dependency graph', async () => {
-      const formulas = [
-        {
-          cell_id: 'cell1',
-          dependencies: ['A1', 'B1'],
-          dependents: []
-        },
-        {
-          cell_id: 'cell2',
-          dependencies: ['A1'],
-          dependents: []
-        }
-      ]
-
-      mockDb.selectFrom.mockReturnValue({
-        select: vi.fn().mockReturnThis(),
-        where: vi.fn().mockReturnThis(),
-        execute: vi.fn().mockResolvedValue(formulas)
-      })
-
-      await engine.buildDependencyGraph(TEST_IDS.SHEET_1)
-
-      // This tests internal state - in a real implementation,
-      // you'd expose methods to verify the dependency graph
-      expect(mockDb.selectFrom).toHaveBeenCalledWith('formulas')
-    })
-  })
-
   describe('Edge Cases', () => {
     test('Empty string formula', async () => {
       const result = await engine.calculate('', context)


### PR DESCRIPTION
## What

Pure dead-code removal from the grid A1 engine `packages/core-backend/src/formula/engine.ts`. Removes `buildDependencyGraph()`, `topologicalSort()`, and the `calculationOrder` / `dependencyGraph` private fields — **zero production call-sites**.

## Why

OSS comparison confirmed this dependency-graph machine never participates in any runtime path: grid formulas evaluate eagerly via `calculate()`. The only caller of `buildDependencyGraph` was a single unit test asserting internal state (its own comment: *"in a real implementation you'd expose methods…"*), and `calculationOrder` was **write-only** (set, never read). Leaving it in invited the false belief that the graph is live in production.

## Verified dead repo-wide before removal

| Symbol | Callers | Verdict |
|---|---|---|
| `buildDependencyGraph(sheetId)` | only `formula-engine.test.ts` (`'Build dependency graph'`); zero in `src/` | dead |
| `topologicalSort()` | only inside `buildDependencyGraph` | dead |
| `calculationOrder` field | written in `buildDependencyGraph`, never read | dead (write-only) |
| `dependencyGraph` field | only those two methods | dead |

**Untouched (same name, unrelated):** `PluginRegistry.ts`'s `dependencyGraph` / `rebuildDependencyGraph` (a different, live class) and the generated `MultitableDependencyGraph` in the openapi SDK. `MultitableFormulaEngine` is untouched.

## Scope

No AST cache, cycle detection, or refactor — **pure deletion (−82 lines, no behavior change)**. Removed the dead-code-only `describe('Dependency Graph')` test block (`TEST_IDS.SHEET_1` stays — used by other cases).

## Verify

- `tsc --noEmit` + `pnpm build`: green.
- `eslint src/formula/engine.ts`: 0 errors.
- `formula-engine.test.ts` + `multitable-formula-engine.test.ts`: **129 passed**.
- Full backend unit suite: **3229 passed / 86 skipped** (= prior 3230 − the one deleted dead-code test), zero regressions.

## Compliance

Multitable kernel polish only. No `integration-core`/K3/RBAC/auth/storage. No OSS code. No migration.

Verification doc: `docs/development/formula-engine-deadcode-cleanup-f1-verification-20260526.md`. Plan: Track F / `docs/development/multitable-derived-field-borrow-plan-20260526.md` (F1). Follows A1 #1883 + A1.1 #1890 + A2-defense #1896.

🤖 Generated with [Claude Code](https://claude.com/claude-code)