### PR TITLE
refactor(integration): consolidate http-routes secret-text redaction into shared scrubber

### DIFF
--- a/plugins/plugin-integration-core/__tests__/payload-redaction.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/payload-redaction.test.cjs
@@ -209,6 +209,9 @@ function main() {
   assert.equal(scrubSecretStringValue('Authorization: Basic dXNlcjpwYXNzd29yZA=='), 'Authorization: Basic [redacted]')
   assert.equal(scrubSecretStringValue('use Basic authentication for the proxy'), 'use Basic authentication for the proxy')
   assert.equal(scrubSecretStringValue('Basic auth required'), 'Basic auth required')
+  // non-ASCII (CJK) Basic credential must STILL redact (decode contains ':' + no control chars)
+  const cjkBasic = `Basic ${Buffer.from('用户:密码').toString('base64')}`
+  assert.equal(scrubSecretStringValue(`Authorization: ${cjkBasic}`), 'Authorization: Basic [redacted]')
 
   // SEC-prefixed opaque secret id (12+, requires a digit) → redacted; plain prose kept
   assert.equal(scrubSecretStringValue('id SEC1a2b3c4d5e6f7g'), 'id [redacted-secret-id]')

--- a/plugins/plugin-integration-core/__tests__/payload-redaction.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/payload-redaction.test.cjs
@@ -192,6 +192,37 @@ function main() {
   // host:port with NO credentials (no userinfo '@') must survive
   assert.equal(scrubSecretStringValue('redis://localhost:6379/0'), 'redis://localhost:6379/0')
 
+  // consolidation: shapes folded in from the former http-routes redactor must scrub here
+  const consolidated = [
+    ['id_token=eyJhdr.body.sig', 'id_token=[redacted]'],
+    ['session_id=abc123sessionvalue', 'session_id=[redacted]'],
+    ['signature=9f8e7d6c5b4a', 'signature=[redacted]'],
+    ['sig=deadbeefcafe', 'sig=[redacted]'],
+    ['sign=abc123def', 'sign=[redacted]'],
+  ]
+  for (const [input, expected] of consolidated) {
+    assert.equal(scrubSecretStringValue(input), expected, `consolidated shape must scrub: ${input}`)
+  }
+
+  // Basic auth — HIGH-CONFIDENCE: base64 decodes to printable "user:pass" → redact;
+  // benign "Basic authentication"/"Basic auth" must NOT be redacted.
+  assert.equal(scrubSecretStringValue('Authorization: Basic dXNlcjpwYXNzd29yZA=='), 'Authorization: Basic [redacted]')
+  assert.equal(scrubSecretStringValue('use Basic authentication for the proxy'), 'use Basic authentication for the proxy')
+  assert.equal(scrubSecretStringValue('Basic auth required'), 'Basic auth required')
+
+  // SEC-prefixed opaque secret id (12+, requires a digit) → redacted; plain prose kept
+  assert.equal(scrubSecretStringValue('id SEC1a2b3c4d5e6f7g'), 'id [redacted-secret-id]')
+  assert.equal(scrubSecretStringValue('see the SECTIONHEADING below'), 'see the SECTIONHEADING below')
+
+  // Bearer now 8+ (folds the former http-routes 8+ coverage); benign phrase still safe
+  assert.equal(scrubSecretStringValue('Bearer abcd1234efgh5678'), 'Bearer [redacted]')
+  assert.equal(scrubSecretStringValue('Bearer of bad news arrived'), 'Bearer of bad news arrived')
+
+  // left word-boundary on sig/sign — must NOT over-redact design=/assign=
+  for (const s of ['the design=modern was chosen', 'please assign=alice to triage', 'redesign=v2 shipped']) {
+    assert.equal(scrubSecretStringValue(s), s, `word-boundary must protect: ${s}`)
+  }
+
   console.log('✓ payload-redaction: sensitive key + value-scrub + false-positive matrix tests passed')
 }
 

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -30,7 +30,7 @@ const ROUTES = [
   ['GET', '/api/integration/dead-letters', 'deadLettersList'],
   ['POST', '/api/integration/dead-letters/:id/replay', 'deadLettersReplay'],
 ]
-const { sanitizeIntegrationPayload } = require('./payload-redaction.cjs')
+const { sanitizeIntegrationPayload, scrubSecretStringValue } = require('./payload-redaction.cjs')
 const { getPath, setPath, transformRecord } = require('./transform-engine.cjs')
 const { validateRecord } = require('./validator.cjs')
 
@@ -274,10 +274,8 @@ const TEST_CONNECTION_RESULT_KEYS = new Set([
   'authenticated',
   'connected',
 ])
-const SECRET_TEXT_PATTERN = /(?:access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?id|api[_-]?key|secret|signature|sig|sign|password)=([^&#\s]+)/ig
-const AUTH_TEXT_PATTERN = /\b(Bearer|Basic)\s+[A-Za-z0-9._~+/=-]{8,}/ig
-const JWT_TEXT_PATTERN = /\beyJ[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\.[A-Za-z0-9_-]+\b/g
-const SECRET_ID_PATTERN = /\bSEC[A-Za-z0-9_-]{12,}\b/g
+// Secret-text shapes are no longer maintained here — consolidated into the shared
+// scrubber (payload-redaction.cjs `scrubSecretStringValue`). See redactSecretText below.
 const DEFAULT_ADAPTER_SUPPORTS = ['testConnection', 'listObjects', 'getSchema', 'read', 'upsert']
 const DEFAULT_ADAPTER_ROLES = ['source', 'target', 'bidirectional']
 const DANGEROUS_JSON_KEYS = new Set(['__proto__', 'prototype', 'constructor'])
@@ -381,18 +379,11 @@ const ADAPTER_METADATA = {
   },
 }
 
-function redactSecretText(value) {
-  if (typeof value !== 'string') return value
-  return value
-    .replace(/:\/\/([^:/?#\s]+):([^@/?#\s]+)@/g, '://[redacted]@')
-    .replace(SECRET_TEXT_PATTERN, (match) => {
-      const equals = match.indexOf('=')
-      return equals === -1 ? '[redacted]' : `${match.slice(0, equals + 1)}[redacted]`
-    })
-    .replace(AUTH_TEXT_PATTERN, '$1 [redacted]')
-    .replace(JWT_TEXT_PATTERN, '[redacted-jwt]')
-    .replace(SECRET_ID_PATTERN, '[redacted-secret-id]')
-}
+// Route-level secret-text redaction delegates to the shared scrubber
+// (payload-redaction.cjs) — single secret-shape source, no second regex set here.
+// DSN userinfo now preserves the username and masks only the password
+// (scheme://user:[redacted]@host), matching the shared diagnostic-preserving behavior.
+const redactSecretText = scrubSecretStringValue
 
 function isPlainObject(value) {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))

--- a/plugins/plugin-integration-core/lib/payload-redaction.cjs
+++ b/plugins/plugin-integration-core/lib/payload-redaction.cjs
@@ -40,6 +40,20 @@ function isSensitivePayloadKey(key) {
   return SENSITIVE_PAYLOAD_KEYS.has(normalizeKey(key))
 }
 
+// Basic-auth credential heuristic: a real `Basic <base64>` decodes to a printable
+// "user:pass" (contains ':'). Used so benign phrases like "Basic authentication"
+// (whose word does NOT base64-decode to printable user:pass) are NOT redacted.
+function looksLikeBasicCredential(token) {
+  if (typeof token !== 'string' || token.length < 8) return false
+  let decoded
+  try {
+    decoded = Buffer.from(token, 'base64').toString('utf8')
+  } catch {
+    return false
+  }
+  return decoded.includes(':') && /^[\x20-\x7e]+$/.test(decoded)
+}
+
 // Value-based secret scrubbing. Key-based redaction only fires when the KEY is
 // sensitive; a secret riding inside a benign string value (error messages,
 // `details`, free text) would otherwise leak. These patterns mask the secret
@@ -54,16 +68,22 @@ const SECRET_VALUE_PATTERNS = Object.freeze([
   // authority via [^\s/?#]+), so passwords that themselves contain `@`
   // (e.g. user:P@ssw0rd@host) are fully masked, not just up to the first `@`.
   { re: /\b([a-z][a-z0-9+.-]*:\/\/[^\s:/@]+):[^\s/?#]+@([^\s/@:;?#]+)/gi, replace: '$1:[redacted]@$2' },
-  // key=value credential params (ODBC / SQL Server / JDBC query, URL query, free text):
-  // password / pwd / passwd / secret / client_secret / token / access_token /
-  // refresh_token / api_key / apikey. Anchored on `key=` so benign prose like the
-  // word "secret" or "token" (no `=`) is never matched.
-  { re: /\b(password|pwd|passwd|secret|client[_-]?secret|token|access[_-]?token|refresh[_-]?token|api[_-]?key|apikey)=([^;&\s"']+)/gi, replace: '$1=[redacted]' },
-  // Bearer token — require a long token-shaped value so "Bearer of bad news" is safe.
-  { re: /\b(Bearer)\s+([A-Za-z0-9._~+/-]{20,}=*)/g, replace: '$1 [redacted]' },
+  // key=value credential params (ODBC / SQL Server / JDBC query, URL query, free text).
+  // Union of the shared set and the former http-routes set (consolidated here so there
+  // is ONE secret-shape source). LEFT word-boundary anchored so benign prose never
+  // matches — e.g. "design=x" / "assign=y" do NOT match sign=/sig=.
+  { re: /\b(password|pwd|passwd|secret|client[_-]?secret|token|access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?id|signature|sig|sign|api[_-]?key|apikey)=([^;&\s"']+)/gi, replace: '$1=[redacted]' },
+  // Bearer token — token-shaped value (8+, incl '=' padding); "Bearer of bad news" is safe.
+  { re: /\b(Bearer)\s+([A-Za-z0-9._~+/=-]{8,})/g, replace: '$1 [redacted]' },
+  // Basic auth — HIGH-CONFIDENCE ONLY: the base64 token must decode to a printable
+  // "user:pass" (contains ':'), so "Basic authentication" / "Basic auth" are kept.
+  { re: /\b(Basic)\s+([A-Za-z0-9+/]+={0,2})/g, replace: (m, _kw, tok) => (looksLikeBasicCredential(tok) ? 'Basic [redacted]' : m) },
   // Standalone JWT (eyJ… three base64url segments) even without a Bearer/token= prefix.
   // The `eyJ` header + dotted-triple shape is JWT-specific; benign text won't match.
   { re: /\beyJ[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}\.[A-Za-z0-9_-]{8,}/g, replace: '[redacted-jwt]' },
+  // Opaque secret id: SEC-prefixed, 12+ chars, REQUIRING at least one digit so plain
+  // uppercase prose ("SECTIONHEADING") is not scrubbed.
+  { re: /\bSEC(?=[A-Za-z0-9_-]*[0-9])[A-Za-z0-9_-]{12,}\b/g, replace: '[redacted-secret-id]' },
 ])
 
 function scrubSecretStringValue(value) {

--- a/plugins/plugin-integration-core/lib/payload-redaction.cjs
+++ b/plugins/plugin-integration-core/lib/payload-redaction.cjs
@@ -51,7 +51,17 @@ function looksLikeBasicCredential(token) {
   } catch {
     return false
   }
-  return decoded.includes(':') && /^[\x20-\x7e]+$/.test(decoded)
+  // A real `Basic <base64>` decodes to a "user:pass" string: contains ':' and is
+  // valid printable text. Non-ASCII (e.g. CJK) user/pass is allowed; only control
+  // chars (C0/DEL/C1) and U+FFFD (invalid-UTF-8 garbage, i.e. a benign word that
+  // happened to base64-decode) are rejected -- so "Basic authentication" is kept
+  // while a base64 of a CJK user:pass is redacted.
+  if (!decoded.includes(':')) return false
+  for (let i = 0; i < decoded.length; i++) {
+    const c = decoded.charCodeAt(i)
+    if (c <= 0x1f || (c >= 0x7f && c <= 0x9f) || c === 0xfffd) return false
+  }
+  return true
 }
 
 // Value-based secret scrubbing. Key-based redaction only fires when the KEY is


### PR DESCRIPTION
## What

Eliminates the **second secret-shape regex set**. `http-routes.cjs` no longer maintains `SECRET_TEXT_PATTERN` / `AUTH_TEXT_PATTERN` / `JWT_TEXT_PATTERN` / `SECRET_ID_PATTERN` + its own `redactSecretText` body — `redactSecretText` now **delegates to the shared `scrubSecretStringValue`** (`payload-redaction.cjs`). One secret-shape source → no drift risk.

## Coverage folded into the shared scrubber (so nothing is lost; all consumers get it, stricter)

- **key=value union** adds `id_token` / `session_id` / `signature` / `sig` / `sign` — **left word-boundary anchored**, so `design=x` / `assign=y` are NOT matched (fixes the no-`\b` false positive the old http-routes set had).
- **Bearer** lowered to `8+` (incl `=` padding) to preserve the former coverage; "Bearer of bad news" still safe.
- **Basic auth** added **high-confidence only**: the base64 token must decode to a printable `user:pass` (contains `:`), so `Basic authentication` / `Basic auth` are NOT redacted (fixes the old `Basic\s+{8,}` false positive).
- **SEC-prefixed** opaque secret id (`12+`) now **requires a digit**, so prose like `SECTIONHEADING` is not scrubbed.

## Behavior change (owner-decided)

The http-routes DSN redaction now **preserves the username** and masks only the password (`scheme://user:[redacted]@host`), matching the shared diagnostic-preserving behavior locked in #1895 — rather than masking the whole userinfo. Username is not the secret; a separate policy PR can revisit treating it as sensitive. Also inherits #1895's fix for passwords containing `@`.

## Constraints honored (as specified)

- `sig`/`sign` have a left boundary (no `design=`/`assign=` over-redaction).
- Basic auth is high-confidence (base64-decodes to `user:pass`), not loose `Basic\s+\S+`.
- SEC pattern has a digit/length constraint, not plain English.
- http-routes.cjs maintains no independent secret-shape set.
- No K3 write / resolver / broad read-list touched.

## Verification

All pass: `payload-redaction` (new union shapes + FP matrix: `design=`/`assign=`/`Basic authentication`/`SECTIONHEADING`/`Bearer of bad news` all preserved) + `http-routes` + `runner-support` + `pipeline-runner` + `external-systems` + `bridge-agent-readonly-adapter` + `http-routes-plm-k3wise-poc`.

## Scope (narrow, as requested)

Only the http-routes duplicate is consolidated. Bridge Agent / SQL executor adapters were not touched (they were out of scope; no evidence they maintain a separate text-redaction set on the same risk surface).

🤖 Generated with [Claude Code](https://claude.com/claude-code)