### PR TITLE
fix(spreadsheets): paginate legacy cells reads

### DIFF
--- a/packages/core-backend/src/routes/spreadsheets.ts
+++ b/packages/core-backend/src/routes/spreadsheets.ts
@@ -20,6 +20,13 @@ interface SpreadsheetRouterOptions {
   db?: SpreadsheetDb
 }
 
+interface CellReadQuery {
+  limit?: number
+  offset?: number
+  startRow?: number
+  endRow?: number
+}
+
 function getActorId(req: Request): string | undefined {
   const user = req.user
   if (!user) return undefined
@@ -34,6 +41,40 @@ function toCellValue(value: unknown): Record<string, unknown> | null {
   if (value === null) return null
   if (typeof value === 'object') return value as Record<string, unknown>
   return { value }
+}
+
+function parseOptionalNonNegativeInteger(raw: unknown, field: string): { value?: number; error?: string } {
+  if (raw === undefined) return {}
+  if (Array.isArray(raw)) {
+    return { error: `${field} must be a single non-negative integer` }
+  }
+
+  const text = String(raw).trim()
+  if (!/^\d+$/.test(text)) {
+    return { error: `${field} must be a non-negative integer` }
+  }
+
+  const value = Number(text)
+  if (!Number.isSafeInteger(value)) {
+    return { error: `${field} must be a safe non-negative integer` }
+  }
+
+  return { value }
+}
+
+function parseCellReadQuery(query: Request['query']): { value?: CellReadQuery; error?: string } {
+  const parsed: CellReadQuery = {}
+  for (const field of ['limit', 'offset', 'startRow', 'endRow'] as const) {
+    const result = parseOptionalNonNegativeInteger(query[field], field)
+    if (result.error) return { error: result.error }
+    if (result.value !== undefined) parsed[field] = result.value
+  }
+
+  if (parsed.startRow !== undefined && parsed.endRow !== undefined && parsed.endRow < parsed.startRow) {
+    return { error: 'endRow must be greater than or equal to startRow' }
+  }
+
+  return { value: parsed }
 }
 
 /**
@@ -327,6 +368,11 @@ export function spreadsheetsRouter(_injector?: Injector, options: SpreadsheetRou
 
   r.get('/api/spreadsheets/:id/sheets/:sheetId/cells', rbacGuard('spreadsheets', 'read'), async (req: Request, res: Response) => {
     const { id, sheetId } = req.params
+    const cellQuery = parseCellReadQuery(req.query)
+    if (cellQuery.error) {
+      return res.status(400).json({ ok: false, error: { code: 'INVALID_QUERY', message: cellQuery.error } })
+    }
+    const { limit, offset, startRow, endRow } = cellQuery.value ?? {}
 
     try {
       const sheet = await db
@@ -340,13 +386,27 @@ export function spreadsheetsRouter(_injector?: Injector, options: SpreadsheetRou
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Sheet not found' } })
       }
 
-      const cells = await db
+      let cellsQuery = db
         .selectFrom('cells')
         .selectAll()
         .where('sheet_id', '=', sheetId)
         .orderBy('row_index', 'asc')
         .orderBy('column_index', 'asc')
-        .execute()
+
+      if (startRow !== undefined) {
+        cellsQuery = cellsQuery.where('row_index', '>=', startRow)
+      }
+      if (endRow !== undefined) {
+        cellsQuery = cellsQuery.where('row_index', '<=', endRow)
+      }
+      if (limit !== undefined) {
+        cellsQuery = cellsQuery.limit(limit)
+      }
+      if (offset !== undefined) {
+        cellsQuery = cellsQuery.offset(offset)
+      }
+
+      const cells = await cellsQuery.execute()
 
       return res.json({ ok: true, data: { sheet, cells } })
     } catch (error) {

--- a/packages/core-backend/tests/unit/spreadsheets-cells-read-pagination.test.ts
+++ b/packages/core-backend/tests/unit/spreadsheets-cells-read-pagination.test.ts
@@ -1,0 +1,159 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Request, Response } from 'express'
+
+vi.mock('../../src/rbac/rbac', () => ({
+  rbacGuard: () => (_req: Request, _res: Response, next: () => void) => next(),
+}))
+vi.mock('../../src/audit/audit', () => ({
+  auditLog: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../../src/db/db', () => ({
+  db: {},
+}))
+vi.mock('../../src/core/logger', () => ({
+  Logger: class {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    constructor(_context: string) {}
+    info() {}
+    warn() {}
+    error() {}
+    debug() {}
+  },
+}))
+
+const spreadsheetId = 'spreadsheet_1'
+const sheetId = 'sheet_1'
+
+function createMockRes() {
+  const res: any = {
+    statusCode: 200,
+    jsonPayload: null,
+    status(code: number) { res.statusCode = code; return res },
+    json(payload: unknown) { res.jsonPayload = payload; return res },
+  }
+  return res as Response & { statusCode: number; jsonPayload: any }
+}
+
+function makeSelectQuery(result: { takeFirst?: unknown; execute?: unknown[] }) {
+  const state = {
+    where: [] as Array<[unknown, unknown, unknown]>,
+    orderBy: [] as Array<[unknown, unknown]>,
+    limit: undefined as number | undefined,
+    offset: undefined as number | undefined,
+  }
+  const chain: any = {
+    selectAll: vi.fn(() => chain),
+    where: vi.fn((field: unknown, op: unknown, value: unknown) => {
+      state.where.push([field, op, value])
+      return chain
+    }),
+    orderBy: vi.fn((field: unknown, direction: unknown) => {
+      state.orderBy.push([field, direction])
+      return chain
+    }),
+    limit: vi.fn((value: number) => {
+      state.limit = value
+      return chain
+    }),
+    offset: vi.fn((value: number) => {
+      state.offset = value
+      return chain
+    }),
+    executeTakeFirst: vi.fn().mockResolvedValue(result.takeFirst),
+    execute: vi.fn().mockResolvedValue(result.execute ?? []),
+  }
+  return { chain, state }
+}
+
+function makeDb(cells: unknown[] = []) {
+  const sheetQuery = makeSelectQuery({
+    takeFirst: { id: sheetId, spreadsheet_id: spreadsheetId, name: 'Sheet1' },
+  })
+  const cellsQuery = makeSelectQuery({ execute: cells })
+  const db = {
+    selectFrom: vi.fn((table: string) => {
+      if (table === 'sheets') return sheetQuery.chain
+      if (table === 'cells') return cellsQuery.chain
+      throw new Error(`unexpected table ${table}`)
+    }),
+  }
+  return { db, sheetQuery, cellsQuery }
+}
+
+async function loadRouter(db: unknown) {
+  const mod = await import('../../src/routes/spreadsheets')
+  return mod.spreadsheetsRouter(undefined, { db: db as any })
+}
+
+async function callGetCells(router: any, query: Request['query'] = {}) {
+  const req = {
+    params: { id: spreadsheetId, sheetId },
+    query,
+    user: { id: 'user_1' },
+  } as unknown as Request
+  const res = createMockRes()
+  const layer = router.stack.find((l: any) => l?.route?.path === '/api/spreadsheets/:id/sheets/:sheetId/cells' && l.route.methods?.get)
+  if (!layer) throw new Error('GET cells route not registered')
+  const handlers = layer.route.stack.map((s: any) => s.handle)
+  const realHandler = handlers[handlers.length - 1]
+  await realHandler(req, res, () => {})
+  return res
+}
+
+describe('GET /api/spreadsheets/:id/sheets/:sheetId/cells pagination (#530)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('preserves full cell reads when pagination params are absent', async () => {
+    const cells = [
+      { id: 'cell_1', sheet_id: sheetId, row_index: 0, column_index: 0 },
+      { id: 'cell_2', sheet_id: sheetId, row_index: 1, column_index: 0 },
+    ]
+    const { db, cellsQuery } = makeDb(cells)
+    const router = await loadRouter(db)
+
+    const res = await callGetCells(router)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.jsonPayload.ok).toBe(true)
+    expect(res.jsonPayload.data.cells).toEqual(cells)
+    expect(cellsQuery.state.where).toEqual([['sheet_id', '=', sheetId]])
+    expect(cellsQuery.state.orderBy).toEqual([['row_index', 'asc'], ['column_index', 'asc']])
+    expect(cellsQuery.chain.limit).not.toHaveBeenCalled()
+    expect(cellsQuery.chain.offset).not.toHaveBeenCalled()
+  })
+
+  it('applies row range and limit/offset query params to the cells query', async () => {
+    const cells = [
+      { id: 'cell_3', sheet_id: sheetId, row_index: 2, column_index: 0 },
+      { id: 'cell_4', sheet_id: sheetId, row_index: 3, column_index: 0 },
+    ]
+    const { db, cellsQuery } = makeDb(cells)
+    const router = await loadRouter(db)
+
+    const res = await callGetCells(router, { startRow: '2', endRow: '5', limit: '2', offset: '1' })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.jsonPayload.data.cells).toEqual(cells)
+    expect(cellsQuery.state.where).toEqual([
+      ['sheet_id', '=', sheetId],
+      ['row_index', '>=', 2],
+      ['row_index', '<=', 5],
+    ])
+    expect(cellsQuery.state.limit).toBe(2)
+    expect(cellsQuery.state.offset).toBe(1)
+  })
+
+  it('rejects an inverted row range before hitting the database', async () => {
+    const { db } = makeDb()
+    const router = await loadRouter(db)
+
+    const res = await callGetCells(router, { startRow: '5', endRow: '2' })
+
+    expect(res.statusCode).toBe(400)
+    expect(res.jsonPayload.ok).toBe(false)
+    expect(res.jsonPayload.error.code).toBe('INVALID_QUERY')
+    expect(db.selectFrom).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- Add `limit`, `offset`, `startRow`, and `endRow` support to legacy `GET /api/spreadsheets/:id/sheets/:sheetId/cells`.
- Preserve existing full-read behavior when pagination params are absent.
- Reject invalid query params with `INVALID_QUERY` before hitting the database.

Closes #530

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/spreadsheets-cell-version.test.ts tests/unit/spreadsheets-cells-read-pagination.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check origin/main...HEAD`