### PR TITLE
feat(attendance): validate payroll_cycle cap mapping against template window (§7)

### DIFF
--- a/docs/development/attendance-comprehensive-hours-payroll-cycle-cap-precise-window-verification-20260526.md
+++ b/docs/development/attendance-comprehensive-hours-payroll-cycle-cap-precise-window-verification-20260526.md
@@ -1,0 +1,89 @@
+# Comprehensive-Hours `payroll_cycle` Cap-Mapping — §7 Precise Template-Window Validation — 2026-05-26
+
+Implements the deferred **§7 precise upgrade** from
+`attendance-comprehensive-hours-payroll-cycle-cap-mapping-design-20260526.md` (#1887), replacing
+the V1 **coarse** heuristic (templateId present + span≤62) shipped in the prior slice (#1894). A
+`payroll_cycle` now maps to the `month` cap **only when its own dates match the window its
+template would generate** — a templateId-bearing cycle with hand-entered, mismatched dates no
+longer receives a cap. Runtime slice only: `plugins/plugin-attendance/index.cjs` + its unit suite
++ this doc. **No migration / route / UI / write path.**
+
+## What changed vs V1 (#1894)
+
+| | V1 coarse (#1894) | §7 precise (this slice) |
+| --- | --- | --- |
+| Gate | `templateId` present **and** span≤62 | `templateId` **and** `templateWindowMatches===true` **and** span≤62 |
+| Date-mismatched, in-span, template-bound cycle | resolved `month` (documented imprecision) | **`null`** (no cap) |
+| Template read | none (no JOIN) | reads `attendance_payroll_templates`, recomputes window |
+
+## Implementation
+
+1. **`verifyAttendancePayrollCycleTemplateWindow(db, orgId, cycle)`** (new, near `resolvePayrollWindow`):
+   reads the cycle's template, recomputes the expected window via
+   `resolvePayrollWindow(mapPayrollTemplateRow(row), parseDateInput(cycle.startDate))` (the same
+   call the cycle-generation routes use), and returns `expected.startDate === cycle.startDate &&
+   expected.endDate === cycle.endDate`. **Fail-closed**: no templateId, missing template row,
+   unparseable dates, or any read/compute error → `false` (wrapped in `try/catch`), so an
+   old/partial schema degrades to "unverified → no cap" instead of 503-ing the period sync.
+2. **Producer** `resolveAttendanceReportPeriodSyncPeriod` calls the verifier and stamps
+   `period.templateWindowMatches` (a boolean) alongside the existing `period.templateId`.
+3. **Builder** `buildAttendanceComprehensiveHoursPeriodSummaryValues` payroll branch now requires
+   `period.templateWindowMatches === true` (strict) in addition to `templateId` and the span
+   guard. `templateWindowMatches` subsumes the coarse heuristic; the span guard is retained as
+   cheap defense-in-depth (a matching monthly window is inherently ≤62d). `source` stays
+   `payroll_cycle_template_monthly`; the `date_range` path is untouched.
+
+## Anchor convention
+
+The verifier anchors `resolvePayrollWindow` on the **cycle's start date** — identical to how the
+create/generate routes (`index.cjs` ~:24678 / :24806 / :24917) derive a window. For a
+template-generated cycle the start date sits on the template `start_day`, so the recomputed window
+round-trips to the cycle's own dates → match. A hand-entered start that isn't on a template
+boundary recomputes a different canonical window → no match.
+
+## Tests — `attendance-comprehensive-hours-control.test.ts` (44 passed, +5 over #1894)
+
+| # | Case | Expected |
+| --- | --- | --- |
+| P1 | template-verified (`templateWindowMatches:true`), in-span, month cap set | excess vs month cap, payroll source |
+| P2 | cross-month 26th→25th, verified | bridge → custom_range/null (asserted); payroll branch → month |
+| P3 | month cap unset | null |
+| P4 | `templateId` null | null |
+| P5 | span > 62d | null (span guard, even if verified) |
+| **P5b** | **in-span but `templateWindowMatches:false`** | **null** (flipped from V1's `month` — the imprecision §7 removes) |
+| **§7 gate** | `templateWindowMatches` false / undefined / truthy-non-true | null (strict `=== true`) |
+| span guard | ≤62 / 63 / reversed / invalid | true/false/false/false |
+| source lock | literal `payroll_cycle_template_monthly` ≠ default | locked |
+| P8 | date_range path | unchanged, default source |
+| **producer (match)** | real producer, template window matches | `templateWindowMatches === true` |
+| **producer (mismatch)** | hand-entered dates ≠ template window | `false` |
+| **producer (no template)** | `templateId` null | `templateId` null, `false` |
+| **producer (template row gone)** | template missing | `false` (fail-closed) |
+| **verify helper** | match / mismatch / no-template / **throwing db** | true / false / false / **false (catch)** |
+| P7 | cap edit re-syncs a verified payroll_cycle row (real sync) | created → patched w/ new cap |
+
+The producer + verify-helper tests are the wire-vs-fixture guard: the builder fixtures set
+`templateWindowMatches` directly and cannot catch a producer that mis-computes or drops it.
+
+## Production data effect (intentional)
+
+Existing snapshot rows for templateId-bearing cycles whose dates do **not** match the template
+window currently carry `comprehensive_hours_cap_minutes = <month value>` /
+`cap_source = payroll_cycle_template_monthly` (granted by the V1 coarse rule). After this lands,
+the next period sync flips those rows to **all-null**: `templateWindowMatches` becomes `false`, the
+cap value/source change, the row `source_fingerprint` changes, and the existing fingerprint
+re-sync mechanism patches the row (the same mechanism the date-range P7 / payroll P7 tests
+exercise). This is the intended correction of the V1 imprecision, not a regression — no manual
+backfill needed; rows self-correct on their next sync.
+
+## Boundaries
+
+Adds one `SELECT` on `attendance_payroll_templates` in the producer (read-only, fail-closed). No
+migration, no new settings/route/UI, no raw `attendance_*`/`meta_*` write. Still deferred:
+quarterly/yearly payroll cadence (design §6), per-cycle cap override.
+
+## Cross-references
+
+- `attendance-comprehensive-hours-payroll-cycle-cap-mapping-design-20260526.md` (#1887) — §7 is the upgrade this implements.
+- `attendance-comprehensive-hours-payroll-cycle-cap-mapping-impl-verification-20260526.md` (#1894) — the V1 coarse slice this supersedes.
+- `[[attendance-multitable-report-boundary]]`, `[[staged-opt-in-lineage]]`, `[[k3-poc-stage1-lock-no-new-fronts]]`.

--- a/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
+++ b/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
@@ -754,7 +754,7 @@ describe('comprehensive-hours period value-plumbing (PR6)', () => {
 
 // Coarse payroll_cycle → month cap mapping (V1) — design-lock:
 // docs/development/attendance-comprehensive-hours-payroll-cycle-cap-mapping-design-20260526.md
-describe('comprehensive-hours payroll_cycle cap-mapping (V1 coarse)', () => {
+describe('comprehensive-hours payroll_cycle cap-mapping (§7 precise template-window)', () => {
   const orgId = 'org-1'
   const userId = 'u-1'
   const logger = { warn() {}, error() {}, info() {} }
@@ -766,14 +766,16 @@ describe('comprehensive-hours payroll_cycle cap-mapping (V1 coarse)', () => {
     comprehensive_hours_cap_source: null,
     comprehensive_hours_cap_effective_key: null,
   }
-  // A template-bound payroll cycle: in-span (≤62d), templateId present. Dates here are a
-  // cross-month pay window (26th→25th) — deliberately NOT a natural calendar month, so the
+  // A template-verified payroll cycle: in-span (≤62d), templateId present, and (§7) its dates
+  // MATCH the template window — the producer sets templateWindowMatches:true. Dates here are a
+  // cross-month pay window (26th→25th), deliberately NOT a natural calendar month, so the
   // date_range bridge would yield custom_range; the payroll branch maps it to month.
   const payrollCycle = (overrides: Record<string, unknown> = {}) => ({
     periodType: 'payroll_cycle',
     periodKey: 'cycle:c-1',
     cycleId: 'c-1',
     templateId: 'tpl-1',
+    templateWindowMatches: true,
     from: '2026-02-26',
     to: '2026-03-25',
     periodStart: '2026-02-26',
@@ -820,16 +822,23 @@ describe('comprehensive-hours payroll_cycle cap-mapping (V1 coarse)', () => {
     expect(build(monthCap(10560), payrollCycle({ from: '2026-01-01', to: '2026-03-31' }))).toEqual(allNull)
   })
 
-  // P5b — DOCUMENTED IMPRECISION: templateId present, span≤62, but the dates do NOT match the
-  // template window (hand-entered, not a real monthly period). V1 has no JOIN/template read, so
-  // it STILL resolves month. The precise §7 upgrade would resolve null. Locking the coarse
-  // behavior here so the trade-off is explicit and a future change is a conscious one.
-  it('P5b: in-span but date-mismatched cycle still resolves month (coarse-heuristic limit)', () => {
-    const offWindow = payrollCycle({ from: '2026-03-10', to: '2026-04-08' }) // 30d, not a monthly window
-    expect(helpers.bridgeAttendanceDateRangeToComprehensiveHoursPeriod('2026-03-10', '2026-04-08').type).toBe('custom_range')
-    const values = build(monthCap(10560), offWindow)
-    expect(values.comprehensive_hours_cap_minutes).toBe(10560)
-    expect(values.comprehensive_hours_cap_source).toBe(PAYROLL_SOURCE)
+  // P5b — §7 PRECISE BEHAVIOR (flipped from the V1 coarse heuristic): templateId present,
+  // span≤62, but the cycle dates do NOT match the template window, so the producer sets
+  // templateWindowMatches:false. The builder now stale-nulls (under V1 this case resolved month).
+  // This is the imprecision the §7 upgrade removes.
+  it('P5b: in-span but date-mismatched cycle (templateWindowMatches:false) → null (§7)', () => {
+    const offWindow = payrollCycle({ from: '2026-03-10', to: '2026-04-08', templateWindowMatches: false })
+    expect(build(monthCap(10560), offWindow)).toEqual(allNull)
+  })
+
+  // §7 gate — templateWindowMatches is REQUIRED (not just templateId). Absent/false → null even
+  // for an in-span, template-bound cycle. Guards the builder against a producer that fails or
+  // skips verification (fail-closed).
+  it('§7 gate: templateWindowMatches must be exactly true (false/undefined → null)', () => {
+    expect(build(monthCap(10560), payrollCycle({ templateWindowMatches: false }))).toEqual(allNull)
+    expect(build(monthCap(10560), payrollCycle({ templateWindowMatches: undefined }))).toEqual(allNull)
+    // Truthy-but-not-true must not satisfy the strict === true check.
+    expect(build(monthCap(10560), payrollCycle({ templateWindowMatches: 1 as unknown as boolean }))).toEqual(allNull)
   })
 
   // Span guard — direct unit coverage of the ≤62 (inclusive) boundary.
@@ -856,27 +865,71 @@ describe('comprehensive-hours payroll_cycle cap-mapping (V1 coarse)', () => {
     expect(values.comprehensive_hours_cap_source).toBe('org_default_by_cycle_type')
   })
 
-  // WIRE-VS-FIXTURE (mandatory): the producer must EMIT templateId onto the payroll_cycle
-  // period — the builder tests above use synthetic periods and cannot catch a producer that
-  // forgets it (cf. the #1781 dayIndex serialization drift). Exercise the real producer.
-  it('producer carries templateId from the loaded payroll cycle row (and null when absent)', async () => {
-    const cycleId = '11111111-1111-4111-8111-111111111111'
-    const cycleDb = (templateId: string | null) => ({
-      async query(sql: string) {
-        if (/FROM attendance_payroll_cycles/i.test(String(sql))) {
-          return [{ id: cycleId, org_id: orgId, template_id: templateId, name: 'Feb cycle', start_date: '2026-02-26', end_date: '2026-03-25', status: 'open', metadata: null }]
-        }
-        throw new Error('unmocked query: ' + sql)
-      },
-    })
-    const withTpl = await helpers.resolveAttendanceReportPeriodSyncPeriod(cycleDb('tpl-9'), orgId, { cycleId })
-    expect(withTpl.ok).toBe(true)
-    expect(withTpl.period.periodType).toBe('payroll_cycle')
-    expect(withTpl.period.templateId).toBe('tpl-9')
-    expect(withTpl.period.from).toBe('2026-02-26')
+  // A 26th→25th monthly template: start_day 26, end_day 25, end_month_offset 1. Anchored on a
+  // cycle start of 2026-02-26 it generates the window 2026-02-26 .. 2026-03-25.
+  const monthlyTemplate26 = { id: 'tpl-9', org_id: orgId, name: 'monthly 26', timezone: 'UTC', start_day: 26, end_day: 25, end_month_offset: 1, auto_generate: true, config: null, is_default: true }
+  const cycleId = '11111111-1111-4111-8111-111111111111'
+  // db mock for the producer: serves the cycle row + (optionally) the template row.
+  const producerDb = (opts: { templateId: string | null, start?: string, end?: string, template?: Record<string, unknown> | null }) => ({
+    async query(sql: string, params: unknown[] = []) {
+      const s = String(sql)
+      if (/FROM attendance_payroll_cycles/i.test(s)) {
+        return [{ id: cycleId, org_id: orgId, template_id: opts.templateId, name: 'cycle', start_date: opts.start ?? '2026-02-26', end_date: opts.end ?? '2026-03-25', status: 'open', metadata: null }]
+      }
+      if (/FROM attendance_payroll_templates/i.test(s)) {
+        return opts.template === null ? [] : [opts.template ?? monthlyTemplate26]
+      }
+      throw new Error('unmocked query: ' + s + ' :: ' + JSON.stringify(params))
+    },
+  })
 
-    const noTpl = await helpers.resolveAttendanceReportPeriodSyncPeriod(cycleDb(null), orgId, { cycleId })
+  // WIRE-VS-FIXTURE (mandatory): the producer must EMIT templateId AND compute templateWindowMatches
+  // onto the payroll_cycle period — the builder tests above use synthetic periods and cannot catch a
+  // producer that forgets either (cf. the #1781 dayIndex serialization drift). Exercise the real producer.
+  it('producer carries templateId + templateWindowMatches (true when dates match the template window)', async () => {
+    const matched = await helpers.resolveAttendanceReportPeriodSyncPeriod(producerDb({ templateId: 'tpl-9' }), orgId, { cycleId })
+    expect(matched.ok).toBe(true)
+    expect(matched.period.periodType).toBe('payroll_cycle')
+    expect(matched.period.templateId).toBe('tpl-9')
+    expect(matched.period.from).toBe('2026-02-26')
+    expect(matched.period.templateWindowMatches).toBe(true)
+  })
+
+  it('producer sets templateWindowMatches false when the cycle dates do NOT match the template window', async () => {
+    // Hand-entered window 2026-03-10..2026-04-08 — the template would generate 2026-02-26..2026-03-25.
+    const mismatch = await helpers.resolveAttendanceReportPeriodSyncPeriod(producerDb({ templateId: 'tpl-9', start: '2026-03-10', end: '2026-04-08' }), orgId, { cycleId })
+    expect(mismatch.period.templateId).toBe('tpl-9')
+    expect(mismatch.period.templateWindowMatches).toBe(false)
+  })
+
+  it('producer sets templateId null + templateWindowMatches false when the cycle has no template', async () => {
+    const noTpl = await helpers.resolveAttendanceReportPeriodSyncPeriod(producerDb({ templateId: null }), orgId, { cycleId })
     expect(noTpl.period.templateId).toBeNull()
+    expect(noTpl.period.templateWindowMatches).toBe(false)
+  })
+
+  it('producer fails closed (templateWindowMatches false) when the template row is missing', async () => {
+    const gone = await helpers.resolveAttendanceReportPeriodSyncPeriod(producerDb({ templateId: 'tpl-9', template: null }), orgId, { cycleId })
+    expect(gone.period.templateWindowMatches).toBe(false)
+  })
+
+  // Direct unit coverage of the §7 verify helper — incl. the fail-closed catch on a throwing db
+  // (an old/partial schema must NOT 503 the period sync; it degrades to "unverified" → no cap).
+  it('verify helper: matches / mismatches / no-template / db-error all behave fail-closed', async () => {
+    const ok = await helpers.verifyAttendancePayrollCycleTemplateWindow(producerDb({ templateId: 'tpl-9' }), orgId, { templateId: 'tpl-9', startDate: '2026-02-26', endDate: '2026-03-25' })
+    expect(ok).toBe(true)
+    const bad = await helpers.verifyAttendancePayrollCycleTemplateWindow(producerDb({ templateId: 'tpl-9' }), orgId, { templateId: 'tpl-9', startDate: '2026-03-10', endDate: '2026-04-08' })
+    expect(bad).toBe(false)
+    const none = await helpers.verifyAttendancePayrollCycleTemplateWindow(producerDb({ templateId: 'tpl-9' }), orgId, { templateId: null, startDate: '2026-02-26', endDate: '2026-03-25' })
+    expect(none).toBe(false)
+    // Calendar-month template shape (start_day 1, end_day 31, offset 0) must also verify true —
+    // proves the helper handles same-month windows, not only the cross-month 26th→25th shape.
+    const calTemplate = { id: 'tpl-cal', org_id: orgId, name: 'cal', timezone: 'UTC', start_day: 1, end_day: 31, end_month_offset: 0, auto_generate: true, config: null, is_default: false }
+    const cal = await helpers.verifyAttendancePayrollCycleTemplateWindow(producerDb({ templateId: 'tpl-cal', template: calTemplate }), orgId, { templateId: 'tpl-cal', startDate: '2026-03-01', endDate: '2026-03-31' })
+    expect(cal).toBe(true)
+    const throwingDb = { async query() { throw new Error('relation "attendance_payroll_templates" does not exist') } }
+    const errored = await helpers.verifyAttendancePayrollCycleTemplateWindow(throwingDb, orgId, { templateId: 'tpl-9', startDate: '2026-02-26', endDate: '2026-03-25' })
+    expect(errored).toBe(false)
   })
 
   // P7 — cap edit changes effective_key → a payroll_cycle row re-syncs (run on the PAYROLL

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -3466,18 +3466,23 @@ async function resolveAttendanceReportPeriodSyncPeriod(db, orgId, params = {}) {
       return { ok: false, status: 404, code: 'NOT_FOUND', message: 'Payroll cycle not found' }
     }
     const cycle = mapPayrollCycleRow(rows[0])
+    // §7 precise window verification (replaces the V1 coarse heuristic): only a cycle whose
+    // dates match its template's generated window maps to the month cap downstream.
+    const templateWindowMatches = await verifyAttendancePayrollCycleTemplateWindow(db, orgId, cycle)
     return {
       ok: true,
       period: {
         periodType: 'payroll_cycle',
         periodKey: `cycle:${cycle.id}`,
         cycleId: cycle.id,
-        // Carried for the comprehensive-hours cap mapping (coarse V1, see
+        // Carried for the comprehensive-hours cap mapping (see
         // docs/development/attendance-comprehensive-hours-payroll-cycle-cap-mapping-design-20260526.md
-        // §4). Presence of a templateId is a (coarse) monthly-cadence signal; absence → no cap.
-        // Mirrored top-level (alongside the nested `cycle`) on purpose so the builder stays
-        // agnostic of the cycle row shape — consistent with how `cycleId` is surfaced.
+        // §4/§7). Mirrored top-level (alongside the nested `cycle`) so the builder stays agnostic
+        // of the cycle row shape — consistent with how `cycleId` is surfaced.
         templateId: cycle.templateId || null,
+        // §7: true only when the cycle's dates equal the window its template would generate. The
+        // builder requires this (not just templateId presence) before mapping the month cap.
+        templateWindowMatches,
         periodName: cycle.name || cycle.id,
         from: cycle.startDate,
         to: cycle.endDate,
@@ -7152,6 +7157,32 @@ function addMonthsToDate(anchorDate, delta) {
   const { year, month, day } = getUtcParts(anchorDate)
   const next = addMonthsUtc(year, month, delta)
   return buildUtcDate(next.year, next.month, day)
+}
+
+// §7 precise cap-mapping check (see
+// docs/development/attendance-comprehensive-hours-payroll-cycle-cap-mapping-design-20260526.md §7):
+// does a payroll cycle's own dates actually match the window its template would generate? Read the
+// template, recompute its expected window anchored on the cycle's start date, and compare. This
+// replaces the V1 coarse "templateId present + span≤62" heuristic — a templateId-bearing cycle with
+// hand-entered dates that do NOT match the template window now fails verification (→ no cap).
+// Fail-closed: no templateId, missing template row, unparseable dates, or any read/compute error
+// all return false (the caller then stale-nulls the cap), so an old/partial schema never 503s the
+// period sync.
+async function verifyAttendancePayrollCycleTemplateWindow(db, orgId, cycle) {
+  try {
+    if (!cycle?.templateId || !cycle.startDate || !cycle.endDate) return false
+    const anchor = parseDateInput(cycle.startDate)
+    if (!anchor) return false
+    const rows = await db.query(
+      'SELECT * FROM attendance_payroll_templates WHERE id = $1 AND org_id = $2',
+      [cycle.templateId, orgId],
+    )
+    if (!Array.isArray(rows) || rows.length === 0) return false
+    const expected = resolvePayrollWindow(mapPayrollTemplateRow(rows[0]), anchor)
+    return expected.startDate === cycle.startDate && expected.endDate === cycle.endDate
+  } catch {
+    return false
+  }
 }
 
 function normalizeRuleOverride(value) {
@@ -12161,11 +12192,11 @@ function attendancePayrollCycleWithinMonthlySpan(from, to) {
 // Compute the four comprehensive-hours period values for one row. Fail-closed: a cap is
 // resolved only when one of the explicitly-supported period shapes matches —
 //   • date_range that bridges to an aligned month/quarter/year with a configured org default, or
-//   • payroll_cycle carrying a templateId whose span ≤62d (coarse monthly mapping → month cap,
-//     source=payroll_cycle_template_monthly).
-// custom_range / templateId-less or oversized payroll cycles / missing/unknown periodType /
-// unset cap all stale-null. Reuses the cap resolver (#1829) and the shared excess math — no
-// parallel computation.
+//   • payroll_cycle whose dates MATCH its template's generated window (§7: producer sets
+//     period.templateWindowMatches), span ≤62d → month cap, source=payroll_cycle_template_monthly.
+// custom_range / templateId-less / date-mismatched / oversized payroll cycles / missing/unknown
+// periodType / unset cap all stale-null. Reuses the cap resolver (#1829) and the shared excess
+// math — no parallel computation.
 function buildAttendanceComprehensiveHoursPeriodSummaryValues(settings, orgId, userId, period, actualMinutes) {
   const nullValues = {
     comprehensive_hours_excess_minutes: null,
@@ -12183,10 +12214,14 @@ function buildAttendanceComprehensiveHoursPeriodSummaryValues(settings, orgId, u
   } else if (
     period?.periodType === 'payroll_cycle'
     && period.templateId
+    && period.templateWindowMatches === true
     && attendancePayrollCycleWithinMonthlySpan(period.from, period.to)
   ) {
-    // Coarse monthly mapping: a template-bound, in-span payroll cycle resolves the month
-    // org default, stamped with the distinct payroll source label.
+    // §7 precise mapping: a payroll cycle whose dates MATCH its template's generated window
+    // (verified in the producer) resolves the month org default, stamped with the distinct
+    // payroll source label. templateWindowMatches subsumes the old coarse heuristic — a
+    // date-mismatched cycle now fails this branch and stale-nulls. The span guard is retained
+    // as cheap defense-in-depth (a matching monthly window is inherently ≤62d).
     cap = resolveAttendanceComprehensiveHoursCap(
       settings,
       orgId,
@@ -14241,6 +14276,7 @@ module.exports = {
     buildAttendanceComprehensiveHoursCapEffectiveKey,
     buildAttendanceComprehensiveHoursPeriodSummaryValues,
     attendancePayrollCycleWithinMonthlySpan,
+    verifyAttendancePayrollCycleTemplateWindow,
     ATTENDANCE_COMPREHENSIVE_HOURS_CAP_SOURCE_DEFAULT,
     ATTENDANCE_COMPREHENSIVE_HOURS_CAP_SOURCE_PAYROLL_MONTHLY,
     ATTENDANCE_COMPREHENSIVE_HOURS_PERIOD_VALUE_COLUMNS,


### PR DESCRIPTION
Implements the deferred **§7 precise template-window validation** from #1887, replacing the V1 **coarse** heuristic shipped in #1894. A `payroll_cycle` now maps to the `month` comprehensive-hours cap **only when its own dates match the window its template would generate** — a templateId-bearing cycle with hand-entered, mismatched dates no longer gets a cap. Runtime slice only: `plugins/plugin-attendance/index.cjs` + unit suite + verification doc. **No migration / route / UI / write path.**

## What changed vs V1 (#1894)
| | V1 coarse (#1894) | §7 precise (this) |
|---|---|---|
| Gate | `templateId` + span≤62 | `templateId` + `templateWindowMatches===true` + span≤62 |
| Date-mismatched in-span template-bound cycle | resolved `month` (documented imprecision) | **`null`** |
| Template read | none | reads `attendance_payroll_templates`, recomputes window |

## Implementation
- **`verifyAttendancePayrollCycleTemplateWindow(db, orgId, cycle)`** (new): reads the template, recomputes the expected window via `resolvePayrollWindow(mapPayrollTemplateRow(row), parseDateInput(cycle.startDate))` (same call the cycle-generation routes use), compares to the cycle's dates. **Fail-closed** (`try/catch → false`): no templateId / missing template / unparseable dates / any read error → `false`, so an old/partial schema degrades to "unverified → no cap" instead of 503-ing the period sync.
- **Producer** stamps `period.templateWindowMatches` alongside `period.templateId`.
- **Builder** payroll branch requires `templateWindowMatches === true` (strict) + `templateId` + span guard (retained as cheap defense-in-depth). `source=payroll_cycle_template_monthly` and the `date_range` path unchanged.

## Anchor convention
Anchors `resolvePayrollWindow` on the **cycle start date** — identical to the create/generate routes. A template-generated cycle round-trips to its own dates → match; a hand-entered start off the template boundary recomputes a different window → no match.

## Tests — `attendance-comprehensive-hours-control.test.ts` (44 passed, +5 over #1894)
**P5b flipped** from "still month" → **null** (the imprecision §7 removes). New: §7 gate (false/undefined/truthy-non-true → null, strict `===true`); **producer** match / mismatch / no-template / template-row-gone; **verify helper** match/mismatch/no-template/**throwing-db fail-closed**. Producer + verify-helper tests are the wire-vs-fixture guard (builder fixtures set the flag directly and can't catch a producer that mis-computes it). Adjacent `attendance-report-field-catalog` 32/32; `git diff --check` clean.

## Boundaries
One read-only `SELECT` on `attendance_payroll_templates` (fail-closed). No migration/route/UI/raw write. Still deferred: quarterly/yearly cadence (§6), per-cycle override.

Verification doc: `docs/development/attendance-comprehensive-hours-payroll-cycle-cap-precise-window-verification-20260526.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

## Production data effect (intentional)
Existing snapshot rows for date-mismatched templateId-bearing cycles (granted a cap by the V1 coarse rule) flip to **all-null** on their next sync: `templateWindowMatches` becomes false → cap/source change → `source_fingerprint` changes → the existing re-sync mechanism patches the row (same path the P7 tests exercise). Intended correction, not a regression; rows self-correct, no backfill.

## Producer uniqueness verified
The only path reaching the snapshot builder with a `payroll_cycle` period is `resolveAttendanceReportPeriodSyncPeriod` (both sync entrypoints use its `resolvedPeriod.period`). The job descriptor (`:2704`) stores only `{cycleId}` and re-resolves for dates; the preview path (`:12385`) uses a caller-supplied cap, not the payroll→month mapping. No inline payroll-period constructor bypasses the strict `templateWindowMatches` gate.