### PR TITLE
fix(integration): lock Material-only scope out of full K3 delivery-readiness

### DIFF
--- a/scripts/ops/integration-k3wise-delivery-readiness.mjs
+++ b/scripts/ops/integration-k3wise-delivery-readiness.mjs
@@ -248,6 +248,7 @@ function compactGateContractDetails(report, details = {}) {
   const relationshipMapping = isPlainObject(sections.relationshipMapping) ? sections.relationshipMapping : {}
   return {
     ...details,
+    scope: typeof report?.scope === 'string' && report.scope ? report.scope : 'full',
     summary: {
       pass: Number.isFinite(Number(summary.pass)) ? Number(summary.pass) : 0,
       blocked: Number.isFinite(Number(summary.blocked)) ? Number(summary.blocked) : 0,
@@ -285,7 +286,15 @@ function evaluateGateContractCheck(report) {
     }))
   }
 
-  if (report.ok === true && report.decision === 'PASS') {
+  const scope = typeof report.scope === 'string' && report.scope ? report.scope : 'full'
+  if (scope !== 'full') {
+    return gate('gate-contract-check', 'K3 read/list and relationship GATE contract', 'fail', compactGateContractDetails(report, {
+      reason: `GATE contract check scope is "${scope}" (e.g. Material-only dry-run readiness); a non-full scope cannot satisfy the full K3 read/list + relationship GATE`,
+      decision: report.decision || null,
+    }))
+  }
+
+  if (report.ok === true && report.decision === 'PASS' && scope === 'full') {
     return gate('gate-contract-check', 'K3 read/list and relationship GATE contract', 'pass', compactGateContractDetails(report, {
       reason: 'O1-O6 and R1-R7 customer evidence passed the machine check',
       decision: 'PASS',

--- a/scripts/ops/integration-k3wise-delivery-readiness.test.mjs
+++ b/scripts/ops/integration-k3wise-delivery-readiness.test.mjs
@@ -289,6 +289,48 @@ test('blocks readiness when GATE contract check is blocked or failed', () => {
   assert.match(failed.gates.find((gate) => gate.id === 'gate-contract-check').reason, /FAIL/)
 })
 
+test('does not treat a Material-only scope GATE contract check as full GATE readiness', () => {
+  const report = buildReadinessReport({
+    postdeploySmoke: postdeployPass(),
+    packageVerify: packageVerifyPass(),
+    gateContractCheck: gateContractPass({
+      decision: 'PASS_MATERIAL_DRY_RUN_READY',
+      scope: 'material-only',
+      sections: {
+        webapiReadList: { answered: 9, requiredAnswers: 9 },
+        relationshipMapping: { answered: 0, requiredAnswers: 0 },
+      },
+    }),
+    preflightPacket: preflightReadyPacket(),
+  }, { generatedAt: '2026-05-06T00:00:00.000Z' })
+
+  assert.equal(report.decision, BLOCKED_DECISION)
+  const gateContract = report.gates.find((gate) => gate.id === 'gate-contract-check')
+  assert.equal(gateContract.status, 'fail')
+  assert.equal(gateContract.scope, 'material-only')
+  assert.match(gateContract.reason, /non-full scope cannot satisfy the full K3 read\/list \+ relationship GATE/)
+})
+
+test('rejects a non-full scope even when the decision string is bare PASS (future-leak guard)', () => {
+  // Locks the regression: under the previous logic an ok:true/decision:'PASS' report
+  // would satisfy the pass branch. A non-full scope must never count as full GATE
+  // readiness, even if a future change sets the decision back to 'PASS' or loosens the
+  // exact decision match.
+  const report = buildReadinessReport({
+    postdeploySmoke: postdeployPass(),
+    packageVerify: packageVerifyPass(),
+    gateContractCheck: gateContractPass({
+      scope: 'material-only',
+    }),
+    preflightPacket: preflightReadyPacket(),
+  }, { generatedAt: '2026-05-06T00:00:00.000Z' })
+
+  assert.equal(report.decision, BLOCKED_DECISION)
+  const gateContract = report.gates.find((gate) => gate.id === 'gate-contract-check')
+  assert.equal(gateContract.status, 'fail')
+  assert.equal(gateContract.scope, 'material-only')
+})
+
 test('blocks readiness when GATE contract check does not hold the Stage 1 Lock', () => {
   const report = buildReadinessReport({
     postdeploySmoke: postdeployPass(),


### PR DESCRIPTION
## What

`delivery-readiness` accepted a GATE contract report as full read/list+relationship readiness via an exact `decision === 'PASS'` match.

**Containment was *not* broken on main today.** The Material-only check (#1893) emits `decision: 'PASS_MATERIAL_DRY_RUN_READY'`, so the exact `=== 'PASS'` match happened to reject it. But that held **implicitly and untested** — a future change that sets the decision back to `'PASS'`, or loosens the exact match (e.g. `startsWith('PASS')`), would silently treat a Material-only dry-run as a full GATE pass and could unblock #1709 / #1711 read/list + relationship runtime under the K3 Stage-1 lock.

## Change

- Add an explicit `scope !== 'full'` guard **before** the pass branch in `evaluateGateContractCheck`, keyed on the report's `scope`. Reports without a `scope` field (full-GATE reports and pre-#1893 evidence) are treated as `'full'`, so they still pass — backward compatible.
- Surface `scope` in the gate detail (`compactGateContractDetails`) for observability.
- Lock both shapes with tests:
  - **realistic-today**: `PASS_MATERIAL_DRY_RUN_READY` + `scope: material-only` → gate `fail`, overall `BLOCKED`.
  - **future-leak guard**: bare `PASS` + `scope: material-only` → still `fail`. This is the shape that *would have leaked* under the previous logic.
- **Negative control:** both new tests were confirmed to FAIL against the pre-guard code (14 pass / 2 fail), proving they exercise the new branch and are not vacuous.

## Scope / lock-safety

ops-tooling + tests only. No `plugin-integration-core` runtime, no route, no migration, no DB schema, no frontend, no K3 contact. Respects the K3 PoC Stage-1 lock.

## Verification

- `node --test integration-k3wise-delivery-readiness.test.mjs` → 16 pass / 0 fail (14 base + 2 new)
- `node --test integration-k3wise-gate-contract-check.test.mjs` → 17 pass / 0 fail (unchanged)
- `node --check` both `.mjs` → OK

Related: #1893 (introduced the Material-only scope), #1709 / #1711 (the read/list + relationship runtime this gate guards).

🤖 Generated with [Claude Code](https://claude.com/claude-code)