### PR TITLE
feat(spreadsheets): add server-side cell search (#529)

### DIFF
--- a/packages/core-backend/src/routes/spreadsheets.ts
+++ b/packages/core-backend/src/routes/spreadsheets.ts
@@ -27,6 +27,15 @@ interface CellReadQuery {
   endRow?: number
 }
 
+interface CellSearchQuery {
+  q: string
+  limit: number
+  offset: number
+}
+
+const DEFAULT_CELL_SEARCH_LIMIT = 50
+const MAX_CELL_SEARCH_LIMIT = 200
+
 function getActorId(req: Request): string | undefined {
   const user = req.user
   if (!user) return undefined
@@ -75,6 +84,39 @@ function parseCellReadQuery(query: Request['query']): { value?: CellReadQuery; e
   }
 
   return { value: parsed }
+}
+
+function parseCellSearchQuery(query: Request['query']): { value?: CellSearchQuery; error?: string } {
+  const rawSearch = query.q ?? query.query
+  if (Array.isArray(rawSearch)) {
+    return { error: 'q must be a single non-empty string' }
+  }
+
+  const q = typeof rawSearch === 'string' ? rawSearch.trim() : ''
+  if (!q) {
+    return { error: 'q must be a non-empty string' }
+  }
+
+  const parsedLimit = parseOptionalNonNegativeInteger(query.limit, 'limit')
+  if (parsedLimit.error) return { error: parsedLimit.error }
+  if (parsedLimit.value !== undefined && parsedLimit.value > MAX_CELL_SEARCH_LIMIT) {
+    return { error: `limit must be less than or equal to ${MAX_CELL_SEARCH_LIMIT}` }
+  }
+
+  const parsedOffset = parseOptionalNonNegativeInteger(query.offset, 'offset')
+  if (parsedOffset.error) return { error: parsedOffset.error }
+
+  return {
+    value: {
+      q,
+      limit: parsedLimit.value ?? DEFAULT_CELL_SEARCH_LIMIT,
+      offset: parsedOffset.value ?? 0,
+    },
+  }
+}
+
+function escapeSqlLikePattern(value: string): string {
+  return value.replace(/[\\%_]/g, '\\$&')
 }
 
 /**
@@ -223,6 +265,66 @@ export function spreadsheetsRouter(_injector?: Injector, options: SpreadsheetRou
     } catch (error) {
       logger.error('Failed to load spreadsheet', error as Error)
       return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load spreadsheet' } })
+    }
+  })
+
+  r.get('/api/spreadsheets/:id/search', rbacGuard('spreadsheets', 'read'), async (req: Request, res: Response) => {
+    const id = req.params.id
+    const parsed = parseCellSearchQuery(req.query)
+    if (parsed.error) {
+      return res.status(400).json({ ok: false, error: { code: 'INVALID_QUERY', message: parsed.error } })
+    }
+    const { q, limit, offset } = parsed.value
+    const pattern = `%${escapeSqlLikePattern(q)}%`
+
+    try {
+      const spreadsheet = await db
+        .selectFrom('spreadsheets')
+        .select(['id'])
+        .where('id', '=', id)
+        .where('deleted_at', 'is', null)
+        .executeTakeFirst()
+
+      if (!spreadsheet) {
+        return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Spreadsheet not found' } })
+      }
+
+      const items = await db
+        .selectFrom('cells')
+        .innerJoin('sheets', 'sheets.id', 'cells.sheet_id')
+        .select([
+          'cells.id',
+          'cells.sheet_id',
+          'cells.row_index',
+          'cells.column_index',
+          'cells.value',
+          'cells.data_type',
+          'cells.formula',
+          'cells.computed_value',
+          'cells.version',
+          'cells.created_at',
+          'cells.updated_at',
+          'sheets.name as sheet_name',
+          'sheets.order_index as sheet_order_index',
+        ])
+        .where('sheets.spreadsheet_id', '=', id)
+        .where(sql<boolean>`(
+          COALESCE(cells.value::text, '') ILIKE ${pattern} ESCAPE '\\'
+          OR COALESCE(cells.computed_value::text, '') ILIKE ${pattern} ESCAPE '\\'
+          OR COALESCE(cells.formula, '') ILIKE ${pattern} ESCAPE '\\'
+          OR COALESCE(cells.data_type, '') ILIKE ${pattern} ESCAPE '\\'
+        )`)
+        .orderBy('sheets.order_index', 'asc')
+        .orderBy('cells.row_index', 'asc')
+        .orderBy('cells.column_index', 'asc')
+        .limit(limit)
+        .offset(offset)
+        .execute()
+
+      return res.json({ ok: true, data: { q, limit, offset, items } })
+    } catch (error) {
+      logger.error('Failed to search spreadsheet cells', error as Error)
+      return res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to search spreadsheet cells' } })
     }
   })
 

--- a/packages/core-backend/tests/unit/spreadsheets-cells-search.test.ts
+++ b/packages/core-backend/tests/unit/spreadsheets-cells-search.test.ts
@@ -1,0 +1,197 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+import type { Request, Response } from 'express'
+
+vi.mock('../../src/rbac/rbac', () => ({
+  rbacGuard: () => (_req: Request, _res: Response, next: () => void) => next(),
+}))
+vi.mock('../../src/audit/audit', () => ({
+  auditLog: vi.fn().mockResolvedValue(undefined),
+}))
+vi.mock('../../src/db/db', () => ({
+  db: {},
+}))
+vi.mock('../../src/core/logger', () => ({
+  Logger: class {
+    // eslint-disable-next-line @typescript-eslint/no-unused-vars
+    constructor(_context: string) {}
+    info() {}
+    warn() {}
+    error() {}
+    debug() {}
+  },
+}))
+
+const spreadsheetId = 'spreadsheet_1'
+
+function createMockRes() {
+  const res: any = {
+    statusCode: 200,
+    jsonPayload: null,
+    status(code: number) { res.statusCode = code; return res },
+    json(payload: unknown) { res.jsonPayload = payload; return res },
+  }
+  return res as Response & { statusCode: number; jsonPayload: any }
+}
+
+function makeSelectQuery(result: { takeFirst?: unknown; execute?: unknown[] }) {
+  const state = {
+    select: [] as unknown[],
+    where: [] as unknown[][],
+    innerJoin: [] as Array<[unknown, unknown, unknown]>,
+    orderBy: [] as Array<[unknown, unknown]>,
+    limit: undefined as number | undefined,
+    offset: undefined as number | undefined,
+  }
+  const chain: any = {
+    select: vi.fn((fields: unknown) => {
+      state.select.push(fields)
+      return chain
+    }),
+    selectAll: vi.fn(() => chain),
+    innerJoin: vi.fn((table: unknown, left: unknown, right: unknown) => {
+      state.innerJoin.push([table, left, right])
+      return chain
+    }),
+    where: vi.fn((...args: unknown[]) => {
+      state.where.push(args)
+      return chain
+    }),
+    orderBy: vi.fn((field: unknown, direction: unknown) => {
+      state.orderBy.push([field, direction])
+      return chain
+    }),
+    limit: vi.fn((value: number) => {
+      state.limit = value
+      return chain
+    }),
+    offset: vi.fn((value: number) => {
+      state.offset = value
+      return chain
+    }),
+    executeTakeFirst: vi.fn().mockResolvedValue(result.takeFirst),
+    execute: vi.fn().mockResolvedValue(result.execute ?? []),
+  }
+  return { chain, state }
+}
+
+function makeDb(options: { spreadsheet?: unknown; items?: unknown[] } = {}) {
+  const spreadsheetQuery = makeSelectQuery({
+    takeFirst: options.spreadsheet === undefined ? { id: spreadsheetId } : options.spreadsheet,
+  })
+  const cellsQuery = makeSelectQuery({ execute: options.items ?? [] })
+  const db = {
+    selectFrom: vi.fn((table: string) => {
+      if (table === 'spreadsheets') return spreadsheetQuery.chain
+      if (table === 'cells') return cellsQuery.chain
+      throw new Error(`unexpected table ${table}`)
+    }),
+  }
+  return { db, spreadsheetQuery, cellsQuery }
+}
+
+async function loadRouter(db: unknown) {
+  const mod = await import('../../src/routes/spreadsheets')
+  return mod.spreadsheetsRouter(undefined, { db: db as any })
+}
+
+async function callSearch(router: any, query: Request['query'] = {}) {
+  const req = {
+    params: { id: spreadsheetId },
+    query,
+    user: { id: 'user_1' },
+  } as unknown as Request
+  const res = createMockRes()
+  const layer = router.stack.find((l: any) => l?.route?.path === '/api/spreadsheets/:id/search' && l.route.methods?.get)
+  if (!layer) throw new Error('GET spreadsheet search route not registered')
+  const handlers = layer.route.stack.map((s: any) => s.handle)
+  const realHandler = handlers[handlers.length - 1]
+  await realHandler(req, res, () => {})
+  return res
+}
+
+describe('GET /api/spreadsheets/:id/search (#529)', () => {
+  beforeEach(() => {
+    vi.resetModules()
+  })
+
+  it('searches cells with default paging and stable ordering', async () => {
+    const items = [
+      {
+        id: 'cell_1',
+        sheet_id: 'sheet_1',
+        row_index: 2,
+        column_index: 1,
+        value: { value: 'Alpha' },
+        sheet_name: 'Sheet1',
+        sheet_order_index: 0,
+      },
+    ]
+    const { db, cellsQuery } = makeDb({ items })
+    const router = await loadRouter(db)
+
+    const res = await callSearch(router, { q: 'Alpha' })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.jsonPayload).toEqual({ ok: true, data: { q: 'Alpha', limit: 50, offset: 0, items } })
+    expect(db.selectFrom).toHaveBeenNthCalledWith(1, 'spreadsheets')
+    expect(db.selectFrom).toHaveBeenNthCalledWith(2, 'cells')
+    expect(cellsQuery.state.innerJoin).toEqual([['sheets', 'sheets.id', 'cells.sheet_id']])
+    expect(cellsQuery.state.where[0]).toEqual(['sheets.spreadsheet_id', '=', spreadsheetId])
+    expect(cellsQuery.state.where).toHaveLength(2)
+    expect(cellsQuery.state.orderBy).toEqual([
+      ['sheets.order_index', 'asc'],
+      ['cells.row_index', 'asc'],
+      ['cells.column_index', 'asc'],
+    ])
+    expect(cellsQuery.state.limit).toBe(50)
+    expect(cellsQuery.state.offset).toBe(0)
+  })
+
+  it('accepts query alias plus explicit limit and offset', async () => {
+    const { db, cellsQuery } = makeDb()
+    const router = await loadRouter(db)
+
+    const res = await callSearch(router, { query: 'Beta', limit: '2', offset: '3' })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.jsonPayload.data.q).toBe('Beta')
+    expect(res.jsonPayload.data.limit).toBe(2)
+    expect(res.jsonPayload.data.offset).toBe(3)
+    expect(cellsQuery.state.limit).toBe(2)
+    expect(cellsQuery.state.offset).toBe(3)
+  })
+
+  it('rejects an empty search term before hitting the database', async () => {
+    const { db } = makeDb()
+    const router = await loadRouter(db)
+
+    const res = await callSearch(router, { q: '   ' })
+
+    expect(res.statusCode).toBe(400)
+    expect(res.jsonPayload.ok).toBe(false)
+    expect(res.jsonPayload.error.code).toBe('INVALID_QUERY')
+    expect(db.selectFrom).not.toHaveBeenCalled()
+  })
+
+  it('rejects an oversized limit before hitting the database', async () => {
+    const { db } = makeDb()
+    const router = await loadRouter(db)
+
+    const res = await callSearch(router, { q: 'Alpha', limit: '201' })
+
+    expect(res.statusCode).toBe(400)
+    expect(res.jsonPayload.error.message).toBe('limit must be less than or equal to 200')
+    expect(db.selectFrom).not.toHaveBeenCalled()
+  })
+
+  it('returns 404 when the spreadsheet does not exist', async () => {
+    const { db, cellsQuery } = makeDb({ spreadsheet: null })
+    const router = await loadRouter(db)
+
+    const res = await callSearch(router, { q: 'Alpha' })
+
+    expect(res.statusCode).toBe(404)
+    expect(res.jsonPayload.error.code).toBe('NOT_FOUND')
+    expect(cellsQuery.chain.execute).not.toHaveBeenCalled()
+  })
+})


### PR DESCRIPTION
## Summary
- add `GET /api/spreadsheets/:id/search` for legacy spreadsheet cells
- support `q` / `query`, default `limit=50`, explicit `offset`, and a hard `limit<=200` guard
- search server-side across `value`, `computed_value`, `formula`, and `data_type`, ordered by sheet/row/column
- keep this scoped to the API backlog item; no frontend search UI or PostgreSQL full-text index added here

Closes #529.

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/spreadsheets-cells-search.test.ts tests/unit/spreadsheets-cells-read-pagination.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend test:unit`
- `git diff --check`