### PR TITLE
feat(integration): K3 M1 Save-only failure fix — backend (parse/preset/fail-closed/diagnostics)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -94,6 +94,21 @@ function createK3FetchMock() {
           Data: [{ FStatus: true, FItemID: 1001, FNumber: record.FNumber }],
         })
       }
+      if (record.FNumber === 'NESTEDOK') {
+        // Customer K3 that nests the per-row payload under Data[0].Data
+        return jsonResponse(200, {
+          StatusCode: 200,
+          Message: 'Successful',
+          Data: [{ FNumber: record.FNumber, Data: { FStatus: true, FItemID: 2002, FNumber: record.FNumber } }],
+        })
+      }
+      if (record.FNumber === 'NESTEDFAIL') {
+        return jsonResponse(200, {
+          StatusCode: 200,
+          Message: 'Successful',
+          Data: [{ FNumber: record.FNumber, Data: { FStatus: false, FItemID: 0, FMessage: 'nested unit group parameter invalid' } }],
+        })
+      }
       if (parsed.searchParams.get('Token')) {
         return jsonResponse(200, {
           StatusCode: 200,
@@ -774,6 +789,50 @@ async function testK3WebApiSaveBusinessEvidence() {
   )
 }
 
+// Keystone (M1 fix): a customer K3 that nests the per-row payload under Data[0].Data
+// must have its success/message/id parsed from the nested object, not the bare wrapper.
+// Pre-fix this was a parse-induced false-negative (a real success read as failed).
+async function testK3WebApiNestedDataSaveParse() {
+  const { fetchImpl } = createK3FetchMock()
+  const adapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      config: { baseUrl: 'https://k3.example.test', autoSubmit: false, autoAudit: false },
+    }),
+    fetchImpl,
+  })
+
+  const upsert = await adapter.upsert({
+    object: 'material',
+    records: [
+      { FNumber: 'NESTEDOK', FName: 'Nested success row' },
+      { FNumber: 'NESTEDFAIL', FName: 'Nested failure row' },
+    ],
+    keyFields: ['FNumber'],
+  })
+
+  // Nested Data[0].Data success is recognized (pre-fix: false-negative → written 0).
+  assert.equal(upsert.written, 1, 'nested Data[0].Data success row counts as written')
+  assert.equal(upsert.failed, 1, 'nested Data[0].Data failure row counts as failed')
+  assert.equal(upsert.results[0].key, 'NESTEDOK')
+  assert.equal(upsert.results[0].externalId, 2002, 'externalId resolved from Data[0].Data.FItemID')
+  assert.equal(upsert.results[0].responseSummary.success, true)
+  assert.equal(upsert.results[0].responseSummary.externalIdPresent, true)
+  // Nested failure: message resolved from Data[0].Data.FMessage, not the envelope fallback.
+  assert.equal(upsert.errors[0].code, 'K3_WISE_SAVE_FAILED')
+  assert.match(upsert.errors[0].message, /nested unit group/i)
+  assert.equal(upsert.errors[0].responseSummary.success, false)
+  assert.equal(upsert.errors[0].responseSummary.failedRowCount, 1)
+
+  // Regression: flat Data[0].X rows are unchanged by the unwrap.
+  const flat = await adapter.upsert({
+    object: 'material',
+    records: [{ FNumber: 'ROWOK', FName: 'Flat success row' }],
+    keyFields: ['FNumber'],
+  })
+  assert.equal(flat.written, 1, 'flat Data[0].X success still recognized')
+  assert.equal(flat.results[0].externalId, 1001, 'flat externalId unchanged')
+}
+
 async function testK3SqlServerChannel() {
   const executorCalls = []
   const queryExecutor = {
@@ -1118,6 +1177,7 @@ async function main() {
   await testK3WebApiMaterialDetailReadSmoke()
   await testK3WebApiAuthorityCodeToken()
   await testK3WebApiSaveBusinessEvidence()
+  await testK3WebApiNestedDataSaveParse()
   testSqlServerConnectionConfigNormalization()
   await testK3SqlServerChannel()
   await testK3WebApiAutoFlagCoercion()

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -109,6 +109,13 @@ function createK3FetchMock() {
           Data: [{ FNumber: record.FNumber, Data: { FStatus: false, FItemID: 0, FMessage: 'nested unit group parameter invalid' } }],
         })
       }
+      if (record.FNumber === 'SECRETFAIL') {
+        return jsonResponse(200, {
+          StatusCode: 200,
+          Message: 'Successful',
+          Data: [{ FStatus: false, FItemID: 0, FMessage: 'save failed: postgres://k3user:s3cretpw@db.internal/erp rejected the request' }],
+        })
+      }
       if (parsed.searchParams.get('Token')) {
         return jsonResponse(200, {
           StatusCode: 200,
@@ -833,6 +840,98 @@ async function testK3WebApiNestedDataSaveParse() {
   assert.equal(flat.results[0].externalId, 1001, 'flat externalId unchanged')
 }
 
+// Customer-profiled Material Save: base-data shaping (G3), fail-closed placeholder guard,
+// save-only locks, and conservative redacted row diagnostics (M1 fix §4/§5).
+function profileSystem() {
+  return createK3WebApiSystem({
+    config: {
+      baseUrl: 'https://k3.example.test',
+      autoSubmit: false,
+      autoAudit: false,
+      objects: { material: { profile: 'material-k3wise-customer-profile-v1' } },
+    },
+  })
+}
+
+async function testK3WebApiCustomerProfile() {
+  // ----- base-data object shaping (G3): numbered -> {FNumber}, enum/category -> {FID} -----
+  {
+    const { calls, fetchImpl } = createK3FetchMock()
+    const adapter = createK3WiseWebApiAdapter({ system: profileSystem(), fetchImpl })
+    const upsert = await adapter.upsert({
+      object: 'material',
+      records: [{ FNumber: 'SHAPE01', FName: 'Shaped', FUnitGroupID: '10', FErpClsID: '1001' }],
+      keyFields: ['FNumber'],
+    })
+    assert.equal(upsert.written, 1, 'profile save succeeds')
+    const saveCall = calls.find((call) => call.pathname === '/K3API/Material/Save')
+    assert.deepEqual(saveCall.body.Data.FUnitGroupID, { FNumber: '10' }, 'numbered base data wrapped {FNumber}')
+    assert.deepEqual(saveCall.body.Data.FErpClsID, { FID: '1001' }, 'enum/category wrapped {FID}')
+  }
+
+  // ----- fail-closed placeholder: unreplaced <fill-outside-git> never reaches K3 -----
+  {
+    const { calls, fetchImpl } = createK3FetchMock()
+    const adapter = createK3WiseWebApiAdapter({ system: profileSystem(), fetchImpl })
+    const upsert = await adapter.upsert({
+      object: 'material',
+      records: [{ FNumber: 'PH01', FName: 'Has placeholder', FUnitGroupID: '<fill-outside-git>' }],
+      keyFields: ['FNumber'],
+    })
+    assert.equal(upsert.written, 0, 'placeholder row is not written')
+    assert.equal(upsert.failed, 1)
+    assert.equal(upsert.errors[0].code, 'K3_WISE_PRESET_PLACEHOLDER_UNFILLED')
+    assert.equal(
+      calls.some((call) => call.pathname === '/K3API/Material/Save'),
+      false,
+      'fail-closed: NO Material/Save HTTP call was made for the placeholder row',
+    )
+  }
+
+  // ----- save-only locks: profile (no submit/audit path) + auto flags false -> no Submit/Audit -----
+  {
+    const { calls, fetchImpl } = createK3FetchMock()
+    const adapter = createK3WiseWebApiAdapter({ system: profileSystem(), fetchImpl })
+    await adapter.upsert({
+      object: 'material',
+      records: [{ FNumber: 'NESTEDOK', FName: 'Save only' }],
+      keyFields: ['FNumber'],
+    })
+    assert.ok(calls.some((call) => call.pathname === '/K3API/Material/Save'), 'save attempted')
+    assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Submit'), false, 'no Submit call')
+    assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Audit'), false, 'no Audit call')
+  }
+
+  // ----- conservative redacted row diagnostics (G5 / R-REDACT) -----
+  {
+    const { fetchImpl } = createK3FetchMock()
+    const adapter = createK3WiseWebApiAdapter({ system: profileSystem(), fetchImpl })
+    const upsert = await adapter.upsert({
+      object: 'material',
+      records: [
+        { FNumber: 'SECRETFAIL', FName: 'a', sourceId: 'plm-code-9' },
+        { FNumber: 'SECRETFAIL', FName: 'b', sourceId: '550e8400-e29b-41d4-a716-446655440000' },
+      ],
+      keyFields: ['FNumber'],
+    })
+    assert.equal(upsert.failed, 2)
+    const diag = upsert.errors[0].diagnostic
+    assert.deepEqual(Object.keys(diag).sort(), ['responseCode', 'rowKeys', 'rowStatus', 'validationMessage'])
+    assert.equal(diag.rowStatus, 'failed')
+    assert.match(diag.rowKeys.k3Key, /^sha12:[0-9a-f]{12}$/, 'K3 key is hashed, never raw')
+    assert.match(diag.rowKeys.sourceId, /^sha12:/, 'non-UUID sourceId is hashed')
+    // Second row: a confirmed internal UUID sourceId is kept in full.
+    assert.equal(upsert.errors[1].diagnostic.rowKeys.sourceId, '550e8400-e29b-41d4-a716-446655440000')
+    // Secret-shaped value in the K3 message is scrubbed; benign text survives.
+    const serialized = JSON.stringify(diag)
+    assert.equal(serialized.includes('SECRETFAIL'), false, 'raw FNumber absent from diagnostic')
+    assert.equal(serialized.includes('s3cretpw'), false, 'secret scrubbed from validation message')
+    assert.match(diag.validationMessage, /save failed/i, 'benign diagnostic text survives')
+    // The surfaced error.message is also scrubbed.
+    assert.equal(upsert.errors[0].message.includes('s3cretpw'), false, 'error.message scrubbed too')
+  }
+}
+
 async function testK3SqlServerChannel() {
   const executorCalls = []
   const queryExecutor = {
@@ -1178,6 +1277,7 @@ async function main() {
   await testK3WebApiAuthorityCodeToken()
   await testK3WebApiSaveBusinessEvidence()
   await testK3WebApiNestedDataSaveParse()
+  await testK3WebApiCustomerProfile()
   testSqlServerConnectionConfigNormalization()
   await testK3SqlServerChannel()
   await testK3WebApiAutoFlagCoercion()

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -929,6 +929,91 @@ async function testK3WebApiCustomerProfile() {
     assert.match(diag.validationMessage, /save failed/i, 'benign diagnostic text survives')
     // The surfaced error.message is also scrubbed.
     assert.equal(upsert.errors[0].message.includes('s3cretpw'), false, 'error.message scrubbed too')
+    assert.ok(diag.validationMessage, 'validationMessage is populated when the error has a message')
+  }
+
+  // ----- HARD save-only lock: config + request + overlay paths cannot enable Submit/Audit -----
+  {
+    const { calls, fetchImpl } = createK3FetchMock()
+    const adapter = createK3WiseWebApiAdapter({
+      system: createK3WebApiSystem({
+        config: {
+          baseUrl: 'https://k3.example.test',
+          autoSubmit: true, // operator tries to enable via config
+          autoAudit: true,
+          objects: {
+            material: {
+              profile: 'material-k3wise-customer-profile-v1',
+              submitPath: '/K3API/Material/Submit', // overlay tries to re-inject the endpoints
+              auditPath: '/K3API/Material/Audit',
+            },
+          },
+        },
+      }),
+      fetchImpl,
+    })
+    const upsert = await adapter.upsert({
+      object: 'material',
+      records: [{ FNumber: 'NESTEDOK', FName: 'Hard lock' }],
+      keyFields: ['FNumber'],
+      options: { autoSubmit: true, autoAudit: true }, // request tries too
+    })
+    assert.equal(upsert.written, 1, 'save still succeeds under the hard lock')
+    assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Submit'), false, 'Submit refused (config+request+overlay)')
+    assert.equal(calls.some((call) => call.pathname === '/K3API/Material/Audit'), false, 'Audit refused (config+request+overlay)')
+    assert.equal(upsert.metadata.saveOnly, true)
+    assert.equal(upsert.metadata.autoSubmit, false, 'autoSubmit forced false in metadata')
+    assert.equal(upsert.metadata.autoAudit, false, 'autoAudit forced false in metadata')
+    assert.equal(upsert.metadata.autoFlagsRefused, true, 'refusal is observable in metadata')
+  }
+
+  // ----- object-value passthrough fidelity: two-field {FNumber,FName}/{FID,FName} preserved -----
+  {
+    const { calls, fetchImpl } = createK3FetchMock()
+    const adapter = createK3WiseWebApiAdapter({ system: profileSystem(), fetchImpl })
+    await adapter.upsert({
+      object: 'material',
+      records: [{
+        FNumber: 'OBJ01',
+        FName: 'Object passthrough',
+        FUnitGroupID: { FNumber: '10', FName: 'Each' },
+        FErpClsID: { FID: '1001', FName: 'Raw materials' },
+      }],
+      keyFields: ['FNumber'],
+    })
+    const saveCall = calls.find((call) => call.pathname === '/K3API/Material/Save')
+    assert.deepEqual(saveCall.body.Data.FUnitGroupID, { FNumber: '10', FName: 'Each' }, 'two-field {FNumber,FName} preserved verbatim')
+    assert.deepEqual(saveCall.body.Data.FErpClsID, { FID: '1001', FName: 'Raw materials' }, 'two-field {FID,FName} preserved verbatim')
+  }
+
+  // ----- fail-closed: a present-but-empty / non-string profile must throw, not fall back -----
+  {
+    const { fetchImpl } = createK3FetchMock()
+    for (const bad of ['', '   ', 123]) {
+      assert.throws(
+        () => createK3WiseWebApiAdapter({
+          system: createK3WebApiSystem({
+            config: { baseUrl: 'https://k3.example.test', objects: { material: { profile: bad } } },
+          }),
+          fetchImpl,
+        }),
+        /profile must be a non-empty string/,
+        `profile=${JSON.stringify(bad)} fails closed`,
+      )
+    }
+  }
+
+  // ----- diagnostic message fallback: an error without .message still yields a message -----
+  {
+    const diag = webApiInternals.buildRowSaveDiagnostic({
+      status: 'failed',
+      record: { sourceId: 'plm-9' },
+      key: 'MAT-X',
+      rawMessage: String({ toString: () => 'opaque adapter failure' }),
+      code: 'K3_WISE_UPSERT_FAILED',
+    })
+    assert.equal(diag.validationMessage, 'opaque adapter failure', 'falls back to String(error), not null')
+    assert.match(diag.rowKeys.k3Key, /^sha12:/)
   }
 }
 

--- a/plugins/plugin-integration-core/__tests__/k3-wise-material-presets.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-material-presets.test.cjs
@@ -1,0 +1,97 @@
+'use strict'
+
+// K3 WISE customer-profiled Material Save preset (M1 fix) — preset-level guards.
+// Adapter-flow checks (shaping / fail-closed / diagnostics / save-only locks) live in
+// k3-wise-adapters.test.cjs which already has the K3 fetch mock.
+
+const assert = require('node:assert')
+const {
+  getK3WiseDocumentObjectDefaults,
+  getK3WiseMaterialProfile,
+  listK3WiseMaterialProfiles,
+  MATERIAL_CUSTOMER_PROFILE_ID,
+} = require('../lib/adapters/k3-wise-document-templates.cjs')
+
+const ALLOWED_FIELD_KEYS = new Set(['name', 'label', 'type', 'required', 'reference'])
+const ALLOWED_REFERENCE_KEYS = new Set(['identifier'])
+const ALLOWED_IDENTIFIERS = new Set(['FNumber', 'FID'])
+
+// R-OPTIN: the customer profile is a DISTINCT id; the generic default is never the preset.
+function testPresetIsDistinctAndOptIn() {
+  const generic = getK3WiseDocumentObjectDefaults().material
+  const genericFields = new Set(generic.schema.map((field) => field.name))
+  assert.equal(generic.id, 'k3wise.material.v1', 'generic default is the minimal template')
+  assert.equal(genericFields.has('FErpClsID'), false, 'generic template lacks the customer G2 fields')
+
+  const profile = getK3WiseMaterialProfile(MATERIAL_CUSTOMER_PROFILE_ID)
+  assert.ok(profile, 'customer profile resolves by id')
+  assert.equal(profile.id, MATERIAL_CUSTOMER_PROFILE_ID)
+  const profileFields = new Set(profile.schema.map((field) => field.name))
+  // G2 fields the customer env requires (verbatim from the frozen design §1).
+  for (const required of [
+    'FErpClsID', 'FUseState', 'FTrack', 'FDefaultLoc', 'FDSManagerID', 'FPlanPrice',
+    'FPlanTrategy', 'FOrderTrategy',
+    'FInspectionLevel', 'FProChkMde', 'FWWChkMde', 'FSOChkMde', 'FWthDrwChkMde', 'FStkChkMde', 'FOtherChkMde',
+    'FUnitGroupID', 'FUnitID',
+  ]) {
+    assert.ok(profileFields.has(required), `customer profile declares ${required}`)
+  }
+}
+
+// G3: numbered base data → {FNumber}; enum/category → {FID}.
+function testPerFieldShapeDeclared() {
+  const profile = getK3WiseMaterialProfile(MATERIAL_CUSTOMER_PROFILE_ID)
+  const byName = new Map(profile.schema.map((field) => [field.name, field]))
+  const byNumber = ['FUnitGroupID', 'FUnitID', 'FBaseUnitID', 'FAcctID', 'FDefaultLoc']
+  const byId = ['FErpClsID', 'FUseState', 'FInspectionLevel', 'FProChkMde', 'FPlanTrategy']
+  for (const name of byNumber) {
+    assert.equal(byName.get(name).reference.identifier, 'FNumber', `${name} is by-FNumber`)
+  }
+  for (const name of byId) {
+    assert.equal(byName.get(name).reference.identifier, 'FID', `${name} is by-FID (enum/category)`)
+  }
+}
+
+// Scope-creep guard: the preset must not grow operations beyond upsert.
+function testOperationsStayUpsertOnly() {
+  const profile = getK3WiseMaterialProfile(MATERIAL_CUSTOMER_PROFILE_ID)
+  assert.deepEqual(profile.operations, ['upsert'], 'preset operations stay [upsert]')
+  // Save-only by construction: no submit/audit endpoints on the profile.
+  assert.equal(profile.submitPath, undefined, 'preset has no submitPath')
+  assert.equal(profile.auditPath, undefined, 'preset has no auditPath')
+}
+
+// no-hardcoded-values: the preset declares STRUCTURE only — field name/label/type/shape.
+// No concrete dictionary value (defaultValue / value / sample code) is baked into any
+// reference field, and reference identifiers are restricted to FNumber/FID.
+function testNoHardcodedCustomerValues() {
+  const profile = getK3WiseMaterialProfile(MATERIAL_CUSTOMER_PROFILE_ID)
+  for (const field of profile.schema) {
+    for (const key of Object.keys(field)) {
+      assert.ok(ALLOWED_FIELD_KEYS.has(key), `field ${field.name} carries only structural keys (got "${key}")`)
+    }
+    if (field.reference) {
+      for (const key of Object.keys(field.reference)) {
+        assert.ok(ALLOWED_REFERENCE_KEYS.has(key), `${field.name}.reference is structural only (got "${key}")`)
+      }
+      assert.ok(ALLOWED_IDENTIFIERS.has(field.reference.identifier), `${field.name} identifier is FNumber/FID`)
+    }
+  }
+}
+
+function testUnknownProfileResolvesNull() {
+  assert.equal(getK3WiseMaterialProfile('material-does-not-exist'), null, 'unknown profile id → null')
+  assert.equal(getK3WiseMaterialProfile(''), null, 'empty profile id → null')
+  assert.ok(listK3WiseMaterialProfiles().includes(MATERIAL_CUSTOMER_PROFILE_ID), 'profile is registered')
+}
+
+function main() {
+  testPresetIsDistinctAndOptIn()
+  testPerFieldShapeDeclared()
+  testOperationsStayUpsertOnly()
+  testNoHardcodedCustomerValues()
+  testUnknownProfileResolvesNull()
+  console.log('✓ k3-wise-material-presets: preset opt-in, per-field shape, operations, no-hardcoded-values, unknown-profile passed')
+}
+
+main()

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs
@@ -182,6 +182,9 @@ const MATERIAL_CUSTOMER_PROFILE = {
   targetObject: 'material',
   label: 'K3 WISE Material (customer profile)',
   operations: ['upsert'],
+  // Hard Save-only lock (M1): the adapter forces autoSubmit/autoAudit off and strips any
+  // submit/audit endpoint when this profile is selected — non-overridable by config/request.
+  lifecycle: 'save-only',
   savePath: '/K3API/Material/Save',
   readPath: '/K3API/Material/GetDetail',
   readMethod: 'POST',

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs
@@ -3,6 +3,7 @@
 const K3_WISE_DOCUMENT_TEMPLATE_VERSION = '2026.05.v1'
 
 const K3_REFERENCE_BY_NUMBER = { identifier: 'FNumber' }
+const K3_REFERENCE_BY_ID = { identifier: 'FID' }
 
 const MATERIAL_FIELD_MAPPINGS = [
   {
@@ -165,6 +166,67 @@ const K3_WISE_DOCUMENT_TEMPLATES = {
   },
 }
 
+// Customer-profiled Material Save preset (M1 Save-only fix). Distinct from the generic
+// minimal template `k3wise.material.v1`. Applied ONLY when config selects it by id
+// (`config.objects.material.profile`); the default template is NEVER silently swapped
+// (R-OPTIN). Declares the FULLER field set the customer K3 WISE env requires (G2) with
+// per-field reference shape (G3: numbered base data -> {FNumber,FName}; enum/category ->
+// {FID,FName}). STRUCTURE ONLY — no customer dictionary values are baked in; operators
+// supply values at runtime (no-hardcoded-values rule). Save-only by construction: no
+// submitPath/auditPath, so submit/audit cannot fire from this profile.
+const MATERIAL_CUSTOMER_PROFILE_ID = 'material-k3wise-customer-profile-v1'
+const MATERIAL_CUSTOMER_PROFILE = {
+  id: MATERIAL_CUSTOMER_PROFILE_ID,
+  version: K3_WISE_DOCUMENT_TEMPLATE_VERSION,
+  documentType: 'material',
+  targetObject: 'material',
+  label: 'K3 WISE Material (customer profile)',
+  operations: ['upsert'],
+  savePath: '/K3API/Material/Save',
+  readPath: '/K3API/Material/GetDetail',
+  readMethod: 'POST',
+  bodyKey: 'Data',
+  keyField: 'FNumber',
+  keyParam: 'Number',
+  schema: [
+    { name: 'FNumber', label: 'Material code', type: 'string', required: true },
+    { name: 'FName', label: 'Material name', type: 'string', required: true },
+    { name: 'FModel', label: 'Specification', type: 'string' },
+    // Unit family + accounts + warehouse + manager — numbered base data ({FNumber,FName})
+    { name: 'FUnitGroupID', label: 'Unit group', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+    { name: 'FUnitID', label: 'Unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+    { name: 'FBaseUnitID', label: 'Base unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+    { name: 'FOrderUnitID', label: 'Order unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+    { name: 'FSaleUnitID', label: 'Sales unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+    { name: 'FProductUnitID', label: 'Production unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+    { name: 'FStoreUnitID', label: 'Inventory unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+    { name: 'FAcctID', label: 'Inventory account', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+    { name: 'FSaleAcctID', label: 'Sales account', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+    { name: 'FCostAcctID', label: 'Cost account', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+    { name: 'FDefaultLoc', label: 'Default warehouse', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+    { name: 'FDSManagerID', label: 'Default stock manager', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+    // Enum / category — by FID ({FID,FName})
+    { name: 'FErpClsID', label: 'ERP material category', type: 'reference', reference: K3_REFERENCE_BY_ID },
+    { name: 'FUseState', label: 'Use state', type: 'reference', reference: K3_REFERENCE_BY_ID },
+    { name: 'FTrack', label: 'Track policy', type: 'reference', reference: K3_REFERENCE_BY_ID },
+    { name: 'FPlanTrategy', label: 'Planning strategy', type: 'reference', reference: K3_REFERENCE_BY_ID },
+    { name: 'FOrderTrategy', label: 'Order strategy', type: 'reference', reference: K3_REFERENCE_BY_ID },
+    { name: 'FInspectionLevel', label: 'Inspection level', type: 'reference', reference: K3_REFERENCE_BY_ID },
+    { name: 'FProChkMde', label: 'Production inspection mode', type: 'reference', reference: K3_REFERENCE_BY_ID },
+    { name: 'FWWChkMde', label: 'Outsourcing inspection mode', type: 'reference', reference: K3_REFERENCE_BY_ID },
+    { name: 'FSOChkMde', label: 'Sales inspection mode', type: 'reference', reference: K3_REFERENCE_BY_ID },
+    { name: 'FWthDrwChkMde', label: 'Receipt inspection mode', type: 'reference', reference: K3_REFERENCE_BY_ID },
+    { name: 'FStkChkMde', label: 'Stock inspection mode', type: 'reference', reference: K3_REFERENCE_BY_ID },
+    { name: 'FOtherChkMde', label: 'Other inspection mode', type: 'reference', reference: K3_REFERENCE_BY_ID },
+    { name: 'FPlanPrice', label: 'Plan price', type: 'number' },
+  ],
+  fieldMappings: MATERIAL_FIELD_MAPPINGS,
+}
+
+const K3_WISE_MATERIAL_PROFILES = {
+  [MATERIAL_CUSTOMER_PROFILE_ID]: MATERIAL_CUSTOMER_PROFILE,
+}
+
 function cloneJson(value) {
   return value === undefined ? undefined : JSON.parse(JSON.stringify(value))
 }
@@ -231,6 +293,16 @@ function listK3WiseDocumentTemplates() {
   return Object.values(K3_WISE_DOCUMENT_TEMPLATES).map((template) => cloneJson(template))
 }
 
+function getK3WiseMaterialProfile(id) {
+  const key = typeof id === 'string' ? id.trim() : ''
+  const profile = key ? K3_WISE_MATERIAL_PROFILES[key] : null
+  return profile ? normalizeTemplate(profile, `materialProfile.${key}`) : null
+}
+
+function listK3WiseMaterialProfiles() {
+  return Object.keys(K3_WISE_MATERIAL_PROFILES)
+}
+
 function getK3WiseDocumentObjectDefaults() {
   const defaults = {}
   for (const [name, template] of Object.entries(K3_WISE_DOCUMENT_TEMPLATES)) {
@@ -256,9 +328,13 @@ function mergeK3WiseDocumentObject(templateObject, configuredObject, field) {
 module.exports = {
   K3_WISE_DOCUMENT_TEMPLATE_VERSION,
   K3_WISE_DOCUMENT_TEMPLATES,
+  K3_WISE_MATERIAL_PROFILES,
+  MATERIAL_CUSTOMER_PROFILE_ID,
   getK3WiseDocumentObjectDefaults,
   getK3WiseDocumentTemplate,
+  getK3WiseMaterialProfile,
   listK3WiseDocumentTemplates,
+  listK3WiseMaterialProfiles,
   mergeK3WiseDocumentObject,
   normalizeTemplate,
 }

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -20,10 +20,13 @@ const {
 } = require('../contracts.cjs')
 const {
   getK3WiseDocumentObjectDefaults,
+  getK3WiseMaterialProfile,
   listK3WiseDocumentTemplates,
   mergeK3WiseDocumentObject,
   normalizeTemplate,
 } = require('./k3-wise-document-templates.cjs')
+const crypto = require('node:crypto')
+const { scrubSecretStringValue } = require('../payload-redaction.cjs')
 
 class K3WiseWebApiAdapterError extends Error {
   constructor(message, details = {}) {
@@ -370,12 +373,26 @@ function normalizeObjects(config) {
   const configured = toPlainObject(config.objects, 'config.objects')
   const normalized = {}
   for (const [name, defaults] of Object.entries(DEFAULT_OBJECTS)) {
+    const configuredObject = isPlainObject(configured[name]) ? configured[name] : {}
+    let base = defaults
+    let overlay = configuredObject
+    // R-OPTIN: a config may select a named profile by id (the customer Material Save
+    // preset). When selected, the profile REPLACES the generic template as the merge base
+    // (the default template is never silently swapped — only on explicit opt-in). Operator
+    // config still overlays on top; the `profile` key itself is metadata, not a template field.
+    if (name === 'material' && typeof configuredObject.profile === 'string' && configuredObject.profile.trim()) {
+      const profile = getK3WiseMaterialProfile(configuredObject.profile)
+      if (!profile) {
+        throw new AdapterValidationError(`Unknown K3 WISE material profile: ${configuredObject.profile}`, {
+          field: `config.objects.${name}.profile`,
+        })
+      }
+      base = profile
+      overlay = { ...configuredObject }
+      delete overlay.profile
+    }
     try {
-      normalized[name] = mergeK3WiseDocumentObject(
-        defaults,
-        isPlainObject(configured[name]) ? configured[name] : {},
-        `config.objects.${name}`,
-      )
+      normalized[name] = mergeK3WiseDocumentObject(base, overlay, `config.objects.${name}`)
     } catch (error) {
       throw new AdapterValidationError(error.message, {
         field: `config.objects.${name}`,
@@ -440,6 +457,80 @@ function buildSaveBody(record, request, objectConfig) {
   return base
 }
 
+// A value that IS exactly a `<…>` token (template placeholder), not one that merely
+// contains angle brackets. Anchored so real values like "<M6>" specs are not over-matched
+// unless the whole value is a bare sentinel.
+const PLACEHOLDER_SENTINEL = /^<[^>]+>$/
+
+// Fail-closed: an unreplaced preset placeholder must never reach a K3 Save. Scan the
+// projected body recursively (reference shapes nest the placeholder one level down) and
+// reject BEFORE the HTTP call so a half-configured profile errors cleanly instead of
+// writing corrupt data to K3.
+function assertNoUnfilledPlaceholders(value, fieldPath) {
+  if (typeof value === 'string') {
+    if (PLACEHOLDER_SENTINEL.test(value.trim())) {
+      throw new AdapterValidationError(
+        `K3 WISE Save body has an unfilled placeholder at ${fieldPath}; supply the customer value before saving`,
+        { code: 'K3_WISE_PRESET_PLACEHOLDER_UNFILLED', field: fieldPath },
+      )
+    }
+    return
+  }
+  if (Array.isArray(value)) {
+    value.forEach((item, index) => assertNoUnfilledPlaceholders(item, `${fieldPath}[${index}]`))
+    return
+  }
+  if (isPlainObject(value)) {
+    for (const [key, child] of Object.entries(value)) {
+      assertNoUnfilledPlaceholders(child, `${fieldPath}.${key}`)
+    }
+  }
+}
+
+const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
+const DIAGNOSTIC_MESSAGE_MAX = 500
+
+function hashToken(value) {
+  return `sha12:${crypto.createHash('sha256').update(String(value)).digest('hex').slice(0, 12)}`
+}
+
+// Conservative row-key disposition (M1 R-REDACT): K3 identifiers (FNumber / ref codes) are
+// never persisted in full — only a stable hash token for correlation.
+function maskRowKey(value) {
+  return isBlankValue(value) ? null : hashToken(value)
+}
+
+// A sourceId is kept in full ONLY when it is a confirmed MetaSheet internal UUID; any other
+// shape (PLM / customer business code) is hashed too — default to masking when in doubt.
+function dispositionSourceId(value) {
+  if (isBlankValue(value)) return undefined
+  const str = String(value).trim()
+  return UUID_RE.test(str) ? str : hashToken(str)
+}
+
+function truncateDiagnosticMessage(value) {
+  const str = String(value)
+  return str.length > DIAGNOSTIC_MESSAGE_MAX ? `${str.slice(0, DIAGNOSTIC_MESSAGE_MAX)}…` : str
+}
+
+// Build a sanitized, conservative per-row Save diagnostic (G5 / R-REDACT). Persists ONLY:
+// rowStatus, masked/hashed row keys, response code, and a redacted + truncated validation
+// message. Never the raw FNumber, K3 ref values, token, host, authorityCode, password, or
+// connection string — the message is scrubbed via scrubSecretStringValue.
+function buildRowSaveDiagnostic({ status, record, key, error }) {
+  const rawMessage = error && error.message ? String(error.message) : ''
+  const code = error && error.details && error.details.code ? error.details.code : undefined
+  return {
+    rowStatus: status,
+    rowKeys: {
+      k3Key: maskRowKey(key),
+      sourceId: dispositionSourceId(isPlainObject(record) ? record.sourceId : undefined),
+    },
+    responseCode: code !== undefined && code !== null ? String(code) : null,
+    validationMessage: rawMessage ? truncateDiagnosticMessage(scrubSecretStringValue(rawMessage)) : null,
+  }
+}
+
 function projectRecordForBody(record, objectConfig) {
   if (objectConfig.passThroughBody === true) return record
   if (!isPlainObject(record)) return record
@@ -458,6 +549,7 @@ function projectRecordForBody(record, objectConfig) {
       if (!isBlankValue(value)) projected[fieldName] = value
     }
   }
+  assertNoUnfilledPlaceholders(projected, 'Data')
   return projected
 }
 
@@ -1212,15 +1304,19 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
           raw: save.data,
         })
       } catch (error) {
+        const rawMessage = error && error.message ? error.message : String(error)
         errors.push({
           index,
           key,
           object: request.object,
           code: error && error.details && error.details.code ? error.details.code : 'K3_WISE_UPSERT_FAILED',
-          message: error && error.message ? error.message : String(error),
+          message: scrubSecretStringValue(rawMessage),
           responseSummary: error && error.details && error.details.responseSummary
             ? error.details.responseSummary
             : undefined,
+          // Conservative sanitized row diagnostic (G5 / R-REDACT) — masked keys, scrubbed
+          // message; intended as the persisted artifact for explaining the row failure.
+          diagnostic: buildRowSaveDiagnostic({ status: 'failed', record, key, error }),
         })
       }
     }

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -376,11 +376,20 @@ function normalizeObjects(config) {
     const configuredObject = isPlainObject(configured[name]) ? configured[name] : {}
     let base = defaults
     let overlay = configuredObject
+    let saveOnlyProfile = false
     // R-OPTIN: a config may select a named profile by id (the customer Material Save
     // preset). When selected, the profile REPLACES the generic template as the merge base
     // (the default template is never silently swapped — only on explicit opt-in). Operator
     // config still overlays on top; the `profile` key itself is metadata, not a template field.
-    if (name === 'material' && typeof configuredObject.profile === 'string' && configuredObject.profile.trim()) {
+    if (name === 'material' && configuredObject.profile !== undefined) {
+      // Fail-closed: a `profile` that is present but empty / non-string is a misconfiguration.
+      // Do NOT silently fall back to the generic minimal template — the operator believes a
+      // customer profile is active.
+      if (typeof configuredObject.profile !== 'string' || !configuredObject.profile.trim()) {
+        throw new AdapterValidationError('config.objects.material.profile must be a non-empty string when present', {
+          field: `config.objects.${name}.profile`,
+        })
+      }
       const profile = getK3WiseMaterialProfile(configuredObject.profile)
       if (!profile) {
         throw new AdapterValidationError(`Unknown K3 WISE material profile: ${configuredObject.profile}`, {
@@ -390,6 +399,7 @@ function normalizeObjects(config) {
       base = profile
       overlay = { ...configuredObject }
       delete overlay.profile
+      saveOnlyProfile = profile.lifecycle === 'save-only'
     }
     try {
       normalized[name] = mergeK3WiseDocumentObject(base, overlay, `config.objects.${name}`)
@@ -397,6 +407,15 @@ function normalizeObjects(config) {
       throw new AdapterValidationError(error.message, {
         field: `config.objects.${name}`,
       })
+    }
+    // HARD LOCK (M1): a save-only profile cannot be downgraded by the operator overlay.
+    // Strip any submit/audit endpoints the overlay may have re-injected and pin the
+    // lifecycle marker AFTER the merge so it is non-overridable. upsert() reads
+    // `lifecycle === 'save-only'` to force autoSubmit/autoAudit off regardless of request/config.
+    if (saveOnlyProfile) {
+      normalized[name].lifecycle = 'save-only'
+      delete normalized[name].submitPath
+      delete normalized[name].auditPath
     }
   }
   for (const [name, value] of Object.entries(configured)) {
@@ -517,9 +536,11 @@ function truncateDiagnosticMessage(value) {
 // rowStatus, masked/hashed row keys, response code, and a redacted + truncated validation
 // message. Never the raw FNumber, K3 ref values, token, host, authorityCode, password, or
 // connection string — the message is scrubbed via scrubSecretStringValue.
-function buildRowSaveDiagnostic({ status, record, key, error }) {
-  const rawMessage = error && error.message ? String(error.message) : ''
-  const code = error && error.details && error.details.code ? error.details.code : undefined
+function buildRowSaveDiagnostic({ status, record, key, rawMessage, code }) {
+  // rawMessage is resolved by the caller with the same `String(error)` fallback the outer
+  // error.message uses, so the diagnostic message can never be null while the surfaced
+  // message is populated (and vice-versa).
+  const message = typeof rawMessage === 'string' ? rawMessage : (rawMessage == null ? '' : String(rawMessage))
   return {
     rowStatus: status,
     rowKeys: {
@@ -527,7 +548,7 @@ function buildRowSaveDiagnostic({ status, record, key, error }) {
       sourceId: dispositionSourceId(isPlainObject(record) ? record.sourceId : undefined),
     },
     responseCode: code !== undefined && code !== null ? String(code) : null,
-    validationMessage: rawMessage ? truncateDiagnosticMessage(scrubSecretStringValue(rawMessage)) : null,
+    validationMessage: message ? truncateDiagnosticMessage(scrubSecretStringValue(message)) : null,
   }
 }
 
@@ -1189,11 +1210,19 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
     }
     ensureOperation(normalizedSystem.kind, request.object, objectConfig, 'upsert')
 
+    // HARD LOCK (M1): a save-only profile forces autoSubmit/autoAudit OFF and drops any
+    // submit/audit endpoint, regardless of what request or config set. This is the lock the
+    // M1 design requires (not merely a default false). `autoFlagsRefused` records that a
+    // caller asked for submit/audit and was denied, so it is observable in metadata.
+    const saveOnly = objectConfig.lifecycle === 'save-only'
     const savePath = assertRelativePath(objectConfig.savePath || objectConfig.path, 'object.savePath')
-    const submitPath = objectConfig.submitPath ? assertRelativePath(objectConfig.submitPath, 'object.submitPath') : null
-    const auditPath = objectConfig.auditPath ? assertRelativePath(objectConfig.auditPath, 'object.auditPath') : null
-    const autoSubmit = resolveAutoFlag(request.options.autoSubmit, config.autoSubmit, 'autoSubmit')
-    const autoAudit = resolveAutoFlag(request.options.autoAudit, config.autoAudit, 'autoAudit')
+    const submitPath = saveOnly ? null : (objectConfig.submitPath ? assertRelativePath(objectConfig.submitPath, 'object.submitPath') : null)
+    const auditPath = saveOnly ? null : (objectConfig.auditPath ? assertRelativePath(objectConfig.auditPath, 'object.auditPath') : null)
+    const requestedAutoSubmit = resolveAutoFlag(request.options.autoSubmit, config.autoSubmit, 'autoSubmit')
+    const requestedAutoAudit = resolveAutoFlag(request.options.autoAudit, config.autoAudit, 'autoAudit')
+    const autoSubmit = saveOnly ? false : requestedAutoSubmit
+    const autoAudit = saveOnly ? false : requestedAutoAudit
+    const autoFlagsRefused = saveOnly && (requestedAutoSubmit === true || requestedAutoAudit === true)
     const authContext = await login()
     const results = []
     const errors = []
@@ -1305,18 +1334,19 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
         })
       } catch (error) {
         const rawMessage = error && error.message ? error.message : String(error)
+        const code = error && error.details && error.details.code ? error.details.code : 'K3_WISE_UPSERT_FAILED'
         errors.push({
           index,
           key,
           object: request.object,
-          code: error && error.details && error.details.code ? error.details.code : 'K3_WISE_UPSERT_FAILED',
+          code,
           message: scrubSecretStringValue(rawMessage),
           responseSummary: error && error.details && error.details.responseSummary
             ? error.details.responseSummary
             : undefined,
           // Conservative sanitized row diagnostic (G5 / R-REDACT) — masked keys, scrubbed
-          // message; intended as the persisted artifact for explaining the row failure.
-          diagnostic: buildRowSaveDiagnostic({ status: 'failed', record, key, error }),
+          // message (same rawMessage source as above); the persisted artifact for the failure.
+          diagnostic: buildRowSaveDiagnostic({ status: 'failed', record, key, rawMessage, code }),
         })
       }
     }
@@ -1329,8 +1359,10 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
       raw,
       metadata: {
         object: request.object,
+        saveOnly,
         autoSubmit,
         autoAudit,
+        autoFlagsRefused,
         k3Template: objectConfig.k3Template ? { ...objectConfig.k3Template } : undefined,
         businessResponses,
       },
@@ -1360,6 +1392,7 @@ module.exports = {
   __internals: {
     DEFAULT_OBJECTS,
     businessSuccess,
+    buildRowSaveDiagnostic,
     extractRecordKey,
     extractMaterialDetailRecord,
     buildMaterialReadRecord,

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -235,6 +235,23 @@ function businessRowHasIdentifier(row) {
   ))
 }
 
+function unwrapBusinessRow(row) {
+  // Some K3 WISE envelopes nest the per-row payload under `row.Data`
+  // (e.g. `Data[0].Data.{FNumber,FMessage,Code,FItemID,...}`). Mirror the read-path
+  // unwrap (extractMaterialDetailRecord) so business success / message / code / id
+  // parsing sees the nested content instead of the bare wrapper. Preserve the outer key
+  // (FNumber) as a fallback when the inner record lacks one. Only unwraps when `.Data` is
+  // itself a plain object — flat rows (`Data[0].X`) are returned untouched.
+  if (isPlainObject(row) && isPlainObject(row.Data)) {
+    const inner = row.Data
+    if (isBlankValue(inner.FNumber) && !isBlankValue(row.FNumber)) {
+      return { ...inner, FNumber: row.FNumber }
+    }
+    return inner
+  }
+  return row
+}
+
 function extractBusinessRows(data) {
   const rows = new Set()
   const candidates = [
@@ -246,13 +263,16 @@ function extractBusinessRows(data) {
   ]
   for (const candidate of candidates) {
     if (Array.isArray(candidate)) {
-      candidate.filter(isPlainObject).forEach((row) => rows.add(row))
-    } else if (isPlainObject(candidate) && (
-      businessRowStatus(candidate) !== null ||
-      businessRowMessage(candidate) !== undefined ||
-      businessRowHasIdentifier(candidate)
-    )) {
-      rows.add(candidate)
+      candidate.filter(isPlainObject).forEach((row) => rows.add(unwrapBusinessRow(row)))
+    } else if (isPlainObject(candidate)) {
+      const row = unwrapBusinessRow(candidate)
+      if (
+        businessRowStatus(row) !== null ||
+        businessRowMessage(row) !== undefined ||
+        businessRowHasIdentifier(row)
+      ) {
+        rows.add(row)
+      }
     }
   }
   return Array.from(rows)
@@ -616,6 +636,12 @@ function responseMessage(data, config, fallback = 'K3 WISE WebAPI business respo
     getPath(data, 'Data.0.Message'),
     getPath(data, 'Data.0.ErrorMessage'),
     getPath(data, 'Data.0.FErrMessage'),
+    getPath(data, 'Data.0.Data.FMessage'),
+    getPath(data, 'Data.0.Data.Message'),
+    getPath(data, 'Data.0.Data.ErrorMessage'),
+    getPath(data, 'Data.0.Data.FErrMessage'),
+    getPath(data, 'Data.Data.FMessage'),
+    getPath(data, 'Data.Data.Message'),
     getPath(data, 'message'),
     getPath(data, 'Message'),
     getPath(data, 'error'),
@@ -634,6 +660,9 @@ function responseCode(data, config, fallback = 'OK') {
     getPath(data, 'ErrorCode'),
     getPath(data, 'Data.0.Code'),
     getPath(data, 'Data.0.ErrorCode'),
+    getPath(data, 'Data.0.Data.Code'),
+    getPath(data, 'Data.0.Data.ErrorCode'),
+    getPath(data, 'Data.Data.Code'),
     getPath(data, 'StatusCode'),
     getPath(data, 'Data.Code'),
     getPath(data, 'Result.ResponseStatus.ErrorCode'),
@@ -650,6 +679,9 @@ function responseFailureCode(data, config, fallback) {
     getPath(data, 'ErrorCode'),
     getPath(data, 'Data.0.Code'),
     getPath(data, 'Data.0.ErrorCode'),
+    getPath(data, 'Data.0.Data.Code'),
+    getPath(data, 'Data.0.Data.ErrorCode'),
+    getPath(data, 'Data.Data.Code'),
     getPath(data, 'Data.Code'),
     getPath(data, 'Result.ResponseStatus.ErrorCode'),
   )
@@ -668,8 +700,12 @@ function responseBillNo(data, config) {
     getPath(data, 'Number'),
     getPath(data, 'Data.FBillNo'),
     getPath(data, 'Data.0.FBillNo'),
+    getPath(data, 'Data.0.Data.FBillNo'),
+    getPath(data, 'Data.Data.FBillNo'),
     getPath(data, 'Data.FNumber'),
     getPath(data, 'Data.0.FNumber'),
+    getPath(data, 'Data.0.Data.FNumber'),
+    getPath(data, 'Data.Data.FNumber'),
     getPath(data, 'Result.Number'),
     getPath(data, 'Result.ResponseStatus.SuccessEntitys.0.Number'),
   )
@@ -684,8 +720,12 @@ function responseExternalId(data, config) {
     getPath(data, 'FItemID'),
     getPath(data, 'Data.FItemID'),
     getPath(data, 'Data.0.FItemID'),
+    getPath(data, 'Data.0.Data.FItemID'),
+    getPath(data, 'Data.Data.FItemID'),
     getPath(data, 'Data.Id'),
     getPath(data, 'Data.0.Id'),
+    getPath(data, 'Data.0.Data.Id'),
+    getPath(data, 'Data.Data.Id'),
     getPath(data, 'Result.Id'),
     getPath(data, 'Result.ResponseStatus.SuccessEntitys.0.Id'),
   ]

--- a/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.mjs
@@ -44,6 +44,10 @@ function sanitizeMockBody(value) {
 export function createMockK3WebApiServer({
   logger = () => {},
   knownBadFNumbers = new Set(['BAD']),
+  // Envelope-200-but-row-level-fail: K3 returns StatusCode 200 / "Successful" yet the
+  // row did not save. Lets the live PoC demo exercise the M1 row-level diagnostic path
+  // offline. Default empty → no behavior change for existing callers.
+  rowFailFNumbers = new Set(),
   includeSessionCookie = true,
   includeSessionId = true,
 } = {}) {
@@ -110,6 +114,14 @@ export function createMockK3WebApiServer({
       const fNumber = (body?.Model || body?.Data)?.FNumber
       if (knownBadFNumbers.has(fNumber)) {
         jsonResponse(res, 200, { success: false, message: `mock K3 rejects ${fNumber}: invalid material code` })
+        return
+      }
+      if (rowFailFNumbers.has(fNumber)) {
+        jsonResponse(res, 200, {
+          StatusCode: 200,
+          Message: 'Successful',
+          Data: [{ FStatus: false, FItemID: 0, FMessage: `mock K3 row-level fail for ${fNumber}: required base-data object missing` }],
+        })
         return
       }
       jsonResponse(res, 200, { success: true, externalId: `mock-${fNumber}`, billNo: fNumber })

--- a/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs
+++ b/scripts/ops/fixtures/integration-k3wise/mock-k3-webapi-server.test.mjs
@@ -93,6 +93,30 @@ test('mock K3 still evaluates material payloads with the raw request body', asyn
   }
 })
 
+test('mock K3 can return envelope-200-but-row-level-fail for the M1 diagnostic path', async () => {
+  const mock = createMockK3WebApiServer({
+    rowFailFNumbers: new Set(['ROWFAIL']),
+  })
+  const baseUrl = await mock.start()
+  try {
+    const result = await postJson(baseUrl, '/K3API/Material/Save', {
+      Data: { FNumber: 'ROWFAIL', FName: 'Row level fail' },
+    })
+
+    // Envelope reports success, but the row did not save — the shape the M1 fix detects.
+    assert.equal(result.status, 200)
+    assert.equal(result.body.StatusCode, 200)
+    assert.equal(result.body.Message, 'Successful')
+    assert.equal(result.body.Data[0].FStatus, false)
+    assert.match(result.body.Data[0].FMessage, /row-level fail/)
+    // A non-listed FNumber still saves cleanly (default behavior unchanged).
+    const ok = await postJson(baseUrl, '/K3API/Material/Save', { Data: { FNumber: 'OK1', FName: 'ok' } })
+    assert.equal(ok.body.success, true)
+  } finally {
+    await mock.stop()
+  }
+})
+
 test('mock K3 WebAPI rejects methods that real K3 endpoints would not accept', async () => {
   const mock = createMockK3WebApiServer()
   const baseUrl = await mock.start()


### PR DESCRIPTION
## What

Backend runtime implementation of the **K3 WISE M1 Material Save-only failure fix**, per the frozen design `integration-k3wise-m1-material-save-failure-fix-{design,verification}-20260527.md` (#1903 + #1904). Range-limited M1 unlock; **no Submit/Audit/BOM/list/search/pagination/production/multi-record** touched.

**Scope split (owner-directed):** this PR is the **backend** fix. The **frontend operator UX** (preset selection, unit-family default migration, per-field shape selector — design §4 `k3WiseSetup.ts` / `IntegrationWorkbenchView.vue`) is a **separate gated follow-up PR**; it only affects configuration experience and is not a hard gate for the next Save-only attempt.

## Changes (design §4 backend rows)

- **Keystone — `Data[0].Data` Save-response parse** (`k3-wise-webapi-adapter.cjs`): the read path already unwrapped `element.Data`, but the Save-response layer did not. `extractBusinessRows` now unwraps `row.Data` (mirrors `:546`); the five path helpers (`responseMessage`/`Code`/`FailureCode`/`BillNo`/`ExternalId`) gain `Data.0.Data.*` probes appended after the existing `Data.0.*` (flat-shape customers unaffected). A customer nesting under `Data[0].Data` no longer has a genuine success misread as failed.
- **Customer preset `material-k3wise-customer-profile-v1`** (`k3-wise-document-templates.cjs`): a **distinct, opt-in** template with the fuller field set the customer env requires (G2) and per-field shape (G3: numbered base data by-`FNumber`, enum/category by-`FID`). **Structure only — no customer values.** R-OPTIN: applied only via `config.objects.material.profile` (replace-base); the generic `k3wise.material.v1` is never silently swapped. Save-only by construction (no submit/audit path).
- **Fail-closed placeholder guard**: `projectRecordForBody` scans the projected body recursively for `/^<[^>]+>$/` sentinels and throws `K3_WISE_PRESET_PLACEHOLDER_UNFILLED` **before** the HTTP Save — an unreplaced placeholder never reaches K3.
- **Conservative redacted row diagnostics** (G5 / R-REDACT): each failed row carries `diagnostic { rowStatus, rowKeys (k3Key hashed; sourceId full only if internal UUID else hashed), responseCode, validationMessage (`scrubSecretStringValue` + truncate) }`; `error.message` is scrubbed too. Never the raw `FNumber`/ref value/token/host/DSN.
- **Live-PoC mock**: opt-in `rowFailFNumbers` for the envelope-200-row-fail shape (offline diagnostic-path demo).

## Tests (design §5) — all green, 2 negative controls

- New `k3-wise-material-presets.test.cjs`: opt-in/distinct, per-field shape, `operations` stays `['upsert']`, no-hardcoded-values structural scan, unknown-profile.
- `k3-wise-adapters.test.cjs`: nested `Data[0].Data` success/failure (+ flat regression), base-data shaping, fail-closed, save-only locks, diagnostics-redaction (hashed keys, UUID passthrough, secret scrub).
- **Negative controls**: reverting the `extractBusinessRows` unwrap fails the nested-success assertion; neutralizing the fail-closed scan lets the placeholder reach the save body.
- No regressions: `e2e-plm-k3wise-writeback` / `pipeline-runner` / `http-routes-plm-k3wise-poc` / `payload-redaction` / mock-server all pass.

## Boundaries

`operations` stays `['upsert']`; no route/migration/DB/RBAC/auth; no frontend. Submit/Audit/BOM/list/search/pagination/multi-record stay locked. Next gated steps after merge: frontend follow-up PR, then a patched package, then a fresh #1792 approval before any 2nd Save-only attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)