### PR TITLE
feat(integration): K3 WISE M1 Material Save-only fix — runtime impl (#1903/#1904)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -19,6 +19,11 @@ const {
   __internals: sqlExecutorInternals,
   createK3WiseSqlServerReadOnlyExecutor,
 } = require(path.join(__dirname, '..', 'lib', 'adapters', 'k3-wise-sqlserver-executor.cjs'))
+const {
+  getK3WiseDocumentObjectDefaults,
+  getK3WiseDocumentTemplate,
+  listK3WiseDocumentTemplates,
+} = require(path.join(__dirname, '..', 'lib', 'adapters', 'k3-wise-document-templates.cjs'))
 const materialDetailFixture = require(path.join(__dirname, 'fixtures', 'k3-wise-material-detail-redacted.json'))
 
 function cloneJson(value) {
@@ -92,6 +97,20 @@ function createK3FetchMock() {
           StatusCode: 200,
           Message: 'Successful',
           Data: [{ FStatus: true, FItemID: 1001, FNumber: record.FNumber }],
+        })
+      }
+      if (record.FNumber === 'NESTOK') {
+        return jsonResponse(200, {
+          StatusCode: 200,
+          Message: 'Successful',
+          Data: [{ Data: { FStatus: true, FNumber: record.FNumber, FItemID: 123 } }],
+        })
+      }
+      if (record.FNumber === 'NESTFAIL') {
+        return jsonResponse(200, {
+          StatusCode: 200,
+          Message: 'Successful',
+          Data: [{ Data: { FStatus: false, FMessage: 'nested unit group invalid' } }],
         })
       }
       if (parsed.searchParams.get('Token')) {
@@ -1113,15 +1132,423 @@ async function testK3WebApiAutoFlagCoercion() {
   }
 }
 
+// ---------------------------------------------------------------------------
+// M1 Material Save-only failure fix (#1903/#1904 impl) — anchored tests
+// ---------------------------------------------------------------------------
+
+const PROFILE_ID = 'material-k3wise-customer-profile-v1'
+
+function createProfiledSystem(objectOverrides = {}, configOverrides = {}) {
+  return createK3WebApiSystem({
+    config: {
+      baseUrl: 'https://k3.example.test',
+      autoSubmit: false,
+      autoAudit: false,
+      objects: {
+        material: { profile: PROFILE_ID, ...objectOverrides },
+      },
+      ...configOverrides,
+    },
+  })
+}
+
+// Anchor 1 — opt-in customer profile + generic byte-stability.
+function testM1ProfileOptIn() {
+  // Generic material template is byte-stable (no profile fields leak in).
+  const genericTemplate = getK3WiseDocumentTemplate('material')
+  assert.equal(genericTemplate.id, 'k3wise.material.v1', 'generic material id unchanged')
+  const genericNames = genericTemplate.schema.map((field) => field.name)
+  assert.ok(genericNames.includes('FBaseUnitID'), 'generic material keeps FBaseUnitID')
+  assert.ok(!genericNames.includes('FErpClsID'), 'generic material has no profile enum field FErpClsID')
+  assert.ok(!genericNames.includes('FUseState'), 'generic material has no profile enum field FUseState')
+  assert.ok(!genericNames.some((name) => /ChkMde$/.test(name)), 'generic material has no quality-mode fields')
+
+  // getK3WiseDocumentObjectDefaults() must NOT contain the profile.
+  const defaults = getK3WiseDocumentObjectDefaults()
+  assert.deepEqual(Object.keys(defaults).sort(), ['bom', 'material'], 'defaults loop iterates only material + bom')
+  assert.equal(defaults.material.id, 'k3wise.material.v1', 'defaults.material is the generic template')
+  assert.equal(
+    JSON.stringify(defaults).includes(PROFILE_ID),
+    false,
+    'profile id never appears in getK3WiseDocumentObjectDefaults()',
+  )
+
+  // Profile IS discoverable via getK3WiseDocumentTemplate / listK3WiseDocumentTemplates.
+  const profile = getK3WiseDocumentTemplate('materialCustomerProfile')
+  assert.ok(profile, 'profile discoverable via getK3WiseDocumentTemplate')
+  assert.equal(profile.id, PROFILE_ID)
+  assert.equal(profile.lifecycle, 'save-only')
+  const listedIds = listK3WiseDocumentTemplates().map((tpl) => tpl.id)
+  assert.ok(listedIds.includes(PROFILE_ID), 'profile listed by listK3WiseDocumentTemplates')
+  assert.ok(listedIds.includes('k3wise.material.v1'), 'generic still listed')
+
+  // Synthetic-only sample values — no real dictionary value baked in.
+  assert.equal(profile.sampleSource.FNumber, 'MAT-001', 'sample uses synthetic code')
+
+  // Selection hook: WITHOUT profile the normalized material equals today's generic.
+  const plainObjects = webApiInternals.normalizeObjects({})
+  assert.equal(plainObjects.material.id, 'k3wise.material.v1', 'no-profile normalized material is generic')
+  assert.equal(plainObjects.material.lifecycle, undefined, 'no-profile material has no save-only lifecycle')
+
+  // WITH profile the normalized material is the profile (id + FID-shaped enum fields).
+  const profiledObjects = webApiInternals.normalizeObjects({
+    objects: { material: { profile: PROFILE_ID } },
+  })
+  assert.equal(profiledObjects.material.id, PROFILE_ID, 'profile selection swaps the base template')
+  assert.equal(profiledObjects.material.lifecycle, 'save-only', 'profile selection re-pins save-only lifecycle')
+  const profiledNames = profiledObjects.material.schema.map((field) => field.name)
+  assert.ok(profiledNames.includes('FErpClsID'), 'profiled material includes FID-shaped enum field FErpClsID')
+  const erpCls = profiledObjects.material.schema.find((field) => field.name === 'FErpClsID')
+  assert.equal(erpCls.reference.identifier, 'FID', 'FErpClsID declares FID identifier')
+  const unitGroup = profiledObjects.material.schema.find((field) => field.name === 'FUnitGroupID')
+  assert.equal(unitGroup.reference.identifier, 'FNumber', 'FUnitGroupID declares FNumber identifier')
+
+  // Negative control: a non-matching profile value does NOT swap (generic untouched,
+  // byte-for-byte equal to the no-profile normalization).
+  const otherProfile = webApiInternals.normalizeObjects({
+    objects: { material: { profile: 'some-other-id' } },
+  })
+  assert.equal(otherProfile.material.id, 'k3wise.material.v1', 'unknown profile value leaves generic in place')
+  assert.deepEqual(
+    otherProfile.material.schema,
+    plainObjects.material.schema,
+    'unknown profile value yields byte-stable generic schema',
+  )
+}
+
+// Anchor 2 — per-field base-data shaping via the profile's reference.identifier.
+async function testM1BaseDataObjectShaping() {
+  const { fetchImpl } = createK3FetchMock()
+  const adapter = createK3WiseWebApiAdapter({
+    system: createProfiledSystem(),
+    fetchImpl,
+  })
+  const preview = await adapter.previewUpsert({
+    object: 'material',
+    records: [
+      {
+        FNumber: 'MAT-SHAPE-001',
+        FName: 'Shape material',
+        FUnitGroupID: 'UG-PCS', // numbered scalar → { FNumber }
+        FErpClsID: 1001, // enum scalar → { FID }
+        FUnitID: { FNumber: 'PCS', FName: 'Pieces' }, // pre-built object passes through
+      },
+    ],
+    keyFields: ['FNumber'],
+  })
+  assert.deepEqual(
+    preview.records[0].body.Data.FUnitGroupID,
+    { FNumber: 'UG-PCS' },
+    'numbered field scalar → { FNumber: value }',
+  )
+  assert.deepEqual(
+    preview.records[0].body.Data.FErpClsID,
+    { FID: 1001 },
+    'enum field scalar → { FID: value }',
+  )
+  assert.deepEqual(
+    preview.records[0].body.Data.FUnitID,
+    { FNumber: 'PCS', FName: 'Pieces' },
+    'pre-built object value passes through unchanged',
+  )
+}
+
+// Anchor 3 — fail-closed placeholder guard before the HTTP Save.
+async function testM1FailClosedPlaceholder() {
+  const fullyConfiguredRecord = {
+    FNumber: 'MAT-FC-001',
+    FName: 'Fail-closed material',
+    FUnitGroupID: 'UG-PCS',
+    FUnitID: 'PCS',
+    FErpClsID: 1001,
+  }
+
+  // (a) Placeholder in a REQUIRED field → upsert rejects, ZERO save calls.
+  {
+    const { calls, fetchImpl } = createK3FetchMock()
+    const adapter = createK3WiseWebApiAdapter({ system: createProfiledSystem(), fetchImpl })
+    const upsert = await adapter.upsert({
+      object: 'material',
+      records: [{ ...fullyConfiguredRecord, FUnitGroupID: '<fill-outside-git>' }],
+      keyFields: ['FNumber'],
+    })
+    assert.equal(upsert.written, 0, 'placeholder in required field is not written')
+    assert.equal(upsert.failed, 1, 'placeholder in required field is recorded as failed')
+    assert.match(upsert.errors[0].message, /unreplaced placeholder in required field FUnitGroupID/)
+    const saveCalls = calls.filter((call) => call.pathname === '/K3API/Material/Save')
+    assert.equal(saveCalls.length, 0, 'fail-closed: ZERO Save HTTP calls reach the transport')
+  }
+
+  // (b) Negative control — fully-substituted record proceeds (Save call happens).
+  {
+    const { calls, fetchImpl } = createK3FetchMock()
+    const adapter = createK3WiseWebApiAdapter({ system: createProfiledSystem(), fetchImpl })
+    const upsert = await adapter.upsert({
+      object: 'material',
+      records: [{ ...fullyConfiguredRecord, FNumber: 'ROWOK' }],
+      keyFields: ['FNumber'],
+    })
+    assert.equal(upsert.written, 1, 'fully-substituted record proceeds and is written')
+    const saveCalls = calls.filter((call) => call.pathname === '/K3API/Material/Save')
+    assert.equal(saveCalls.length, 1, 'fully-substituted record issues exactly one Save call')
+  }
+
+  // (c) Guard is the blocker — a placeholder in a NON-required field does NOT block.
+  {
+    const { calls, fetchImpl } = createK3FetchMock()
+    const adapter = createK3WiseWebApiAdapter({ system: createProfiledSystem(), fetchImpl })
+    const upsert = await adapter.upsert({
+      object: 'material',
+      records: [{ ...fullyConfiguredRecord, FNumber: 'ROWOK', FUseState: '<fill-outside-git>' }],
+      keyFields: ['FNumber'],
+    })
+    assert.equal(upsert.written, 1, 'placeholder in NON-required field does not block the Save')
+    const saveCalls = calls.filter((call) => call.pathname === '/K3API/Material/Save')
+    assert.equal(saveCalls.length, 1, 'non-required placeholder still issues the Save call')
+    // The non-required placeholder is dropped (not shaped/sent) since the guard
+    // only fires on required fields; confirm it never reached the body.
+    assert.equal(
+      Object.prototype.hasOwnProperty.call(saveCalls[0].body.Data, 'FUseState'),
+      true,
+      'non-required placeholder is still projected (proves required === true is the discriminator)',
+    )
+  }
+}
+
+// Anchor 4 — Save-response Data[0].Data parse (unwrap + helper probes).
+async function testM1ReadbackData0Data() {
+  const profiledSystem = () => createProfiledSystem({}, {})
+
+  // Full upsert path: nested success → judged succeeded.
+  {
+    const { fetchImpl } = createK3FetchMock()
+    const adapter = createK3WiseWebApiAdapter({ system: profiledSystem(), fetchImpl })
+    const upsert = await adapter.upsert({
+      object: 'material',
+      records: [{
+        FNumber: 'NESTOK', FName: 'Nested ok', FUnitGroupID: 'UG', FUnitID: 'PCS', FErpClsID: 1,
+      }],
+      keyFields: ['FNumber'],
+    })
+    assert.equal(upsert.written, 1, 'Data[0].Data nested success is judged succeeded')
+    assert.equal(upsert.results[0].externalId, 123, 'nested FItemID surfaced as external id')
+  }
+
+  // Full upsert path: nested failure → message/code resolved + judged failed.
+  {
+    const { fetchImpl } = createK3FetchMock()
+    const adapter = createK3WiseWebApiAdapter({ system: profiledSystem(), fetchImpl })
+    const upsert = await adapter.upsert({
+      object: 'material',
+      records: [{
+        FNumber: 'NESTFAIL', FName: 'Nested fail', FUnitGroupID: 'UG', FUnitID: 'PCS', FErpClsID: 1,
+      }],
+      keyFields: ['FNumber'],
+    })
+    assert.equal(upsert.written, 0, 'Data[0].Data nested failure is judged failed')
+    assert.equal(upsert.failed, 1)
+    assert.match(upsert.errors[0].message, /nested unit group invalid/, 'nested FMessage resolved')
+  }
+
+  // Regression: flat Data[0].X still works on the original generic adapter.
+  {
+    const { fetchImpl } = createK3FetchMock()
+    const adapter = createK3WiseWebApiAdapter({
+      system: createK3WebApiSystem({
+        config: { baseUrl: 'https://k3.example.test', autoSubmit: false, autoAudit: false },
+      }),
+      fetchImpl,
+    })
+    const upsert = await adapter.upsert({
+      object: 'material',
+      records: [{ FNumber: 'ROWOK', FName: 'Flat ok' }],
+      keyFields: ['FNumber'],
+    })
+    assert.equal(upsert.written, 1, 'flat Data[0].FStatus regression preserved')
+    assert.equal(upsert.results[0].externalId, 1001, 'flat FItemID still surfaced')
+  }
+
+  // Negative-control (unit level) — proves the extractBusinessRows unwrap is load-bearing.
+  const nestedSuccess = { StatusCode: 200, Message: 'Successful', Data: [{ Data: { FStatus: true, FItemID: 123, FNumber: 'MAT-NEST' } }] }
+  const rows = webApiInternals.extractBusinessRows(nestedSuccess)
+  assert.equal(rows.length, 1, 'extractBusinessRows yields one canonical row (no double-add)')
+  assert.deepEqual(rows[0], { FStatus: true, FItemID: 123, FNumber: 'MAT-NEST' }, 'row is the unwrapped inner object')
+  assert.equal(webApiInternals.saveBusinessSuccess(nestedSuccess, {}), true, 'nested success judged succeeded (unwrap required)')
+
+  // Negative-control (unit level) — proves the Data.0.Data.* helper probes are load-bearing.
+  const nestedFailure = { StatusCode: 200, Message: 'Successful', Data: [{ Data: { FStatus: false, FMessage: 'nested missing unit', Code: 'N' } }] }
+  assert.equal(webApiInternals.responseMessage(nestedFailure, {}, null), 'nested missing unit', 'Data.0.Data.FMessage probe resolves')
+  assert.equal(webApiInternals.responseCode(nestedFailure, {}, null), 'N', 'Data.0.Data.Code probe resolves')
+
+  // Flat shape unchanged at the helper level (regression).
+  const flat = { StatusCode: 200, Data: [{ FStatus: false, FMessage: 'flat message', Code: 'E1' }] }
+  assert.equal(webApiInternals.responseMessage(flat, {}, null), 'flat message', 'flat Data.0.FMessage unchanged')
+  assert.equal(webApiInternals.responseCode(flat, {}, null), 'E1', 'flat Data.0.Code unchanged')
+}
+
+// Anchor 5 — sanitized row diagnostics (mask identifiers, scrub message).
+function testM1DiagnosticsRedaction() {
+  // Envelope-200 / row-fail carrying a raw FNumber identifier and a secret-shaped message.
+  const data = {
+    StatusCode: 200,
+    Message: 'Successful',
+    Data: [{
+      FStatus: false,
+      FNumber: 'MAT-SECRET-123',
+      FItemID: 0,
+      FMessage: 'save rejected for pwd=topsecret123 missing unit group',
+    }],
+  }
+  const summary = webApiInternals.createBusinessResponseSummary(data, {}, { operation: 'save', success: false })
+  const serialized = JSON.stringify(summary)
+
+  // Raw record identifier must NOT appear; a masked form MUST appear.
+  assert.equal(serialized.includes('MAT-SECRET-123'), false, 'raw FNumber is never in the summary')
+  assert.equal(summary.billNoMasked, '****123', 'billNo is masked to a 3-char tail')
+  assert.equal(summary.externalIdMasked, null, 'no meaningful external id (FItemID 0) → null masked id')
+
+  // Redacted message: secret-shaped substring scrubbed, surrounding context kept.
+  assert.equal(serialized.includes('topsecret123'), false, 'secret-shaped value scrubbed from message')
+  assert.match(summary.responseMessageRedacted, /missing unit group/, 'diagnostic context preserved')
+  assert.match(summary.responseMessageRedacted, /\[redacted\]/, 'pwd=… replaced with [redacted]')
+
+  // Booleans / counts retained (existing consumers depend on them).
+  assert.equal(summary.success, false)
+  assert.equal(summary.failedRowCount, 1)
+  assert.equal(summary.envelopeStatusCode, 200)
+  assert.equal(summary.billNoPresent, true)
+
+  // maskRowKey edge cases.
+  assert.equal(webApiInternals.maskRowKey(''), null, 'empty string → null')
+  assert.equal(webApiInternals.maskRowKey(null), null, 'null → null')
+  assert.equal(webApiInternals.maskRowKey('AB'), '****AB', 'short value masked, tail kept')
+
+  // Negative control: an UN-masked summary (raw FNumber spread in) DOES leak — proving
+  // the assertion above discriminates rather than being trivially true.
+  const unmaskedSummary = { ...summary, billNoRaw: data.Data[0].FNumber }
+  assert.equal(
+    JSON.stringify(unmaskedSummary).includes('MAT-SECRET-123'),
+    true,
+    'control: a summary that emits the raw FNumber would leak it',
+  )
+}
+
+// Anchor 5 (wire) — the new masked/redacted summary fields must round-trip through
+// the real upsert wire (responseSummary on results AND errors), not just the direct
+// helper call. Guards the wire-vs-fixture drift trap if the `...saveSummary` spread
+// is ever refactored to a pick/whitelist that drops the new fields.
+async function testM1DiagnosticsRedactionWire() {
+  const { fetchImpl } = createK3FetchMock()
+  const adapter = createK3WiseWebApiAdapter({
+    system: createK3WebApiSystem({
+      config: { baseUrl: 'https://k3.example.test', autoSubmit: false, autoAudit: false },
+    }),
+    fetchImpl,
+  })
+  const upsert = await adapter.upsert({
+    object: 'material',
+    records: [
+      { FNumber: 'ROWOK', FName: 'Positive row' }, // FItemID 1001 → ****001
+      { FNumber: 'ROWFAIL', FName: 'Business row fail' }, // FStatus false + message
+    ],
+    keyFields: ['FNumber'],
+  })
+  // Success row: masked external id present on the wire; raw never present.
+  const okSummary = upsert.results[0].responseSummary
+  assert.equal(okSummary.externalIdMasked, '****001', 'masked external id round-trips on results[].responseSummary')
+  assert.equal(Object.prototype.hasOwnProperty.call(okSummary, 'externalIdMasked'), true)
+  // Fail row: redacted message present on the wire (errors[].responseSummary).
+  const failSummary = upsert.errors[0].responseSummary
+  assert.ok(failSummary, 'error carries a responseSummary on the wire')
+  assert.match(failSummary.responseMessageRedacted, /unit group parameter invalid/, 'redacted message round-trips on errors[].responseSummary')
+  assert.equal(Object.prototype.hasOwnProperty.call(failSummary, 'responseMessageRedacted'), true)
+}
+
+// Anchor 6 — autoSubmit/autoAudit hard guard for save-only profiles.
+async function testM1SaveOnlyLocks() {
+  const profiledOkRecord = {
+    FNumber: 'ROWOK', FName: 'Save-only material',
+    FUnitGroupID: 'UG', FUnitID: 'PCS', FErpClsID: 1,
+  }
+
+  // Profile selected + autoSubmit/autoAudit forced true via BOTH request + config:
+  // the guard must still prevent any Submit/Audit HTTP call.
+  {
+    const { calls, fetchImpl } = createK3FetchMock()
+    const adapter = createK3WiseWebApiAdapter({
+      // config.autoSubmit/autoAudit true AND request.options true → still locked.
+      system: createProfiledSystem({}, { autoSubmit: true, autoAudit: true }),
+      fetchImpl,
+    })
+    const upsert = await adapter.upsert({
+      object: 'material',
+      records: [profiledOkRecord],
+      keyFields: ['FNumber'],
+      options: { autoSubmit: true, autoAudit: true },
+    })
+    assert.equal(upsert.written, 1, 'save-only profile still writes via Save')
+    assert.equal(upsert.metadata.autoSubmit, false, 'save-only profile forces autoSubmit=false')
+    assert.equal(upsert.metadata.autoAudit, false, 'save-only profile forces autoAudit=false')
+    const submitCalls = calls.filter((call) => call.pathname === '/K3API/Material/Submit')
+    const auditCalls = calls.filter((call) => call.pathname === '/K3API/Material/Audit')
+    assert.equal(submitCalls.length, 0, 'save-only profile makes NO Submit HTTP call')
+    assert.equal(auditCalls.length, 0, 'save-only profile makes NO Audit HTTP call')
+  }
+
+  // Negative control: a non-save-only object (generic material) with autoSubmit=true
+  // DOES fire Submit — proving the guard (not something else) is what blocks above.
+  {
+    const { calls, fetchImpl } = createK3FetchMock()
+    const adapter = createK3WiseWebApiAdapter({
+      system: createK3WebApiSystem({
+        config: { baseUrl: 'https://k3.example.test', autoSubmit: true, autoAudit: true },
+      }),
+      fetchImpl,
+    })
+    const upsert = await adapter.upsert({
+      object: 'material',
+      records: [{ FNumber: 'MAT-CTRL-001', FName: 'Control bolt' }],
+      keyFields: ['FNumber'],
+      options: { autoSubmit: true, autoAudit: true },
+    })
+    assert.equal(upsert.written, 1)
+    assert.equal(upsert.metadata.autoSubmit, true, 'non-save-only object keeps autoSubmit=true')
+    const submitCalls = calls.filter((call) => call.pathname === '/K3API/Material/Submit')
+    const auditCalls = calls.filter((call) => call.pathname === '/K3API/Material/Audit')
+    assert.equal(submitCalls.length, 1, 'control: Submit DOES fire for a non-save-only object')
+    assert.equal(auditCalls.length, 1, 'control: Audit DOES fire for a non-save-only object')
+  }
+
+  // Boundaries: the profile keeps operations:['upsert'] — Submit/Audit/BOM/list/read rejected.
+  {
+    const { fetchImpl } = createK3FetchMock()
+    const adapter = createK3WiseWebApiAdapter({ system: createProfiledSystem(), fetchImpl })
+    const profiledObjects = webApiInternals.normalizeObjects({ objects: { material: { profile: PROFILE_ID } } })
+    assert.deepEqual(profiledObjects.material.operations, ['upsert'], 'profile exposes only upsert')
+    // read is not in operations → ensureOperation rejects.
+    const readAttempt = await adapter.read({ object: 'material', filters: { FNumber: 'MAT-X' } }).catch((error) => error)
+    assert.ok(readAttempt instanceof UnsupportedAdapterOperationError, 'save-only profile rejects read/list')
+    // bom is unaffected and unchanged.
+    assert.equal(profiledObjects.bom.id, 'k3wise.bom.v1', 'BOM object unchanged by profile selection')
+  }
+}
+
 async function main() {
   await testK3WebApiAdapter()
+  testM1ProfileOptIn()
+  await testM1BaseDataObjectShaping()
+  await testM1FailClosedPlaceholder()
+  await testM1ReadbackData0Data()
+  testM1DiagnosticsRedaction()
+  await testM1DiagnosticsRedactionWire()
+  await testM1SaveOnlyLocks()
   await testK3WebApiMaterialDetailReadSmoke()
   await testK3WebApiAuthorityCodeToken()
   await testK3WebApiSaveBusinessEvidence()
   testSqlServerConnectionConfigNormalization()
   await testK3SqlServerChannel()
   await testK3WebApiAutoFlagCoercion()
-  console.log('✓ k3-wise-adapters: WebAPI, SQL Server channel, and auto-flag coercion tests passed')
+  console.log('✓ k3-wise-adapters: WebAPI, SQL Server channel, auto-flag coercion, and M1 Material Save-only profile tests passed')
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs
@@ -3,6 +3,7 @@
 const K3_WISE_DOCUMENT_TEMPLATE_VERSION = '2026.05.v1'
 
 const K3_REFERENCE_BY_NUMBER = { identifier: 'FNumber' }
+const K3_REFERENCE_BY_ID = { identifier: 'FID' }
 
 const MATERIAL_FIELD_MAPPINGS = [
   {
@@ -165,6 +166,63 @@ const K3_WISE_DOCUMENT_TEMPLATES = {
   },
 }
 
+// Opt-in customer-profiled Material preset. Stored SEPARATELY from
+// K3_WISE_DOCUMENT_TEMPLATES so it is never iterated by
+// getK3WiseDocumentObjectDefaults() (the generic default set must stay
+// material + bom only). Discoverable solely via getK3WiseDocumentTemplate /
+// listK3WiseDocumentTemplates and selected at runtime by its profile id.
+// Declares the customer field SET and per-field SHAPE only — every sampleSource
+// value is synthetic (never a real customer dictionary value).
+const K3_WISE_DOCUMENT_PROFILES = {
+  materialCustomerProfile: {
+    id: 'material-k3wise-customer-profile-v1',
+    version: K3_WISE_DOCUMENT_TEMPLATE_VERSION,
+    documentType: 'material',
+    targetObject: 'material',
+    label: 'K3 WISE Material (customer profile)',
+    lifecycle: 'save-only',
+    operations: ['upsert'],
+    savePath: '/K3API/Material/Save',
+    submitPath: '/K3API/Material/Submit',
+    auditPath: '/K3API/Material/Audit',
+    bodyKey: 'Data',
+    keyField: 'FNumber',
+    keyParam: 'Number',
+    schema: [
+      { name: 'FNumber', label: 'Material code', type: 'string', required: true },
+      { name: 'FName', label: 'Material name', type: 'string', required: true },
+      { name: 'FModel', label: 'Specification', type: 'string' },
+      // Numbered base-data references → { FNumber: value }
+      { name: 'FUnitGroupID', label: 'Unit group', type: 'reference', reference: K3_REFERENCE_BY_NUMBER, required: true },
+      { name: 'FUnitID', label: 'Base unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER, required: true },
+      { name: 'FOrderUnitID', label: 'Order unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FSaleUnitID', label: 'Sales unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FProductUnitID', label: 'Production unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FStoreUnitID', label: 'Inventory unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FAcctID', label: 'Inventory account', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FSaleAcctID', label: 'Sales account', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      { name: 'FCostAcctID', label: 'Cost account', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+      // Enum / category references → { FID: value }
+      { name: 'FErpClsID', label: 'ERP classification', type: 'reference', reference: K3_REFERENCE_BY_ID, required: true },
+      { name: 'FUseState', label: 'Use state', type: 'reference', reference: K3_REFERENCE_BY_ID },
+      { name: 'FProChkMde', label: 'Production inspection mode', type: 'reference', reference: K3_REFERENCE_BY_ID },
+      { name: 'FWWChkMde', label: 'Subcontract inspection mode', type: 'reference', reference: K3_REFERENCE_BY_ID },
+      { name: 'FSOChkMde', label: 'Sales inspection mode', type: 'reference', reference: K3_REFERENCE_BY_ID },
+      { name: 'FWthDrwChkMde', label: 'Issue inspection mode', type: 'reference', reference: K3_REFERENCE_BY_ID },
+      { name: 'FStkChkMde', label: 'Receipt inspection mode', type: 'reference', reference: K3_REFERENCE_BY_ID },
+      { name: 'FOtherChkMde', label: 'Other inspection mode', type: 'reference', reference: K3_REFERENCE_BY_ID },
+    ],
+    sampleSource: {
+      FNumber: 'MAT-001',
+      FName: 'Bolt',
+      FModel: 'M6 x 20',
+      FUnitGroupID: '<fill-outside-git>',
+      FUnitID: '<fill-outside-git>',
+      FErpClsID: '<fill-outside-git>',
+    },
+  },
+}
+
 function cloneJson(value) {
   return value === undefined ? undefined : JSON.parse(JSON.stringify(value))
 }
@@ -223,12 +281,15 @@ function normalizeTemplate(template, field) {
 }
 
 function getK3WiseDocumentTemplate(name) {
-  const template = K3_WISE_DOCUMENT_TEMPLATES[name]
+  const template = K3_WISE_DOCUMENT_TEMPLATES[name] || K3_WISE_DOCUMENT_PROFILES[name]
   return template ? cloneJson(template) : null
 }
 
 function listK3WiseDocumentTemplates() {
-  return Object.values(K3_WISE_DOCUMENT_TEMPLATES).map((template) => cloneJson(template))
+  return [
+    ...Object.values(K3_WISE_DOCUMENT_TEMPLATES),
+    ...Object.values(K3_WISE_DOCUMENT_PROFILES),
+  ].map((template) => cloneJson(template))
 }
 
 function getK3WiseDocumentObjectDefaults() {
@@ -256,6 +317,7 @@ function mergeK3WiseDocumentObject(templateObject, configuredObject, field) {
 module.exports = {
   K3_WISE_DOCUMENT_TEMPLATE_VERSION,
   K3_WISE_DOCUMENT_TEMPLATES,
+  K3_WISE_DOCUMENT_PROFILES,
   getK3WiseDocumentObjectDefaults,
   getK3WiseDocumentTemplate,
   listK3WiseDocumentTemplates,

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -20,10 +20,14 @@ const {
 } = require('../contracts.cjs')
 const {
   getK3WiseDocumentObjectDefaults,
+  getK3WiseDocumentTemplate,
   listK3WiseDocumentTemplates,
   mergeK3WiseDocumentObject,
   normalizeTemplate,
 } = require('./k3-wise-document-templates.cjs')
+const { scrubSecretStringValue } = require('../payload-redaction.cjs')
+
+const MATERIAL_CUSTOMER_PROFILE_ID = 'material-k3wise-customer-profile-v1'
 
 class K3WiseWebApiAdapterError extends Error {
   constructor(message, details = {}) {
@@ -146,6 +150,27 @@ function applyReferenceShape(value, field) {
   return { [identifier]: value }
 }
 
+// An unreplaced authoring placeholder: a string that (trimmed) is wrapped in
+// angle brackets, e.g. <fill-outside-git> / <placeholder> / <…>. Used by the
+// fail-closed guard so a half-configured customer profile errors cleanly before
+// the HTTP Save instead of writing corrupt data to K3.
+function isPlaceholderString(value) {
+  return typeof value === 'string' && /^<.*>$/.test(value.trim())
+}
+
+// Detect a placeholder in a field value, recursing ONE level into object keys
+// and values (covers a pre-shaped reference object such as { FNumber: '<...>' }).
+function containsPlaceholder(value) {
+  if (isPlaceholderString(value)) return true
+  if (isPlainObject(value)) {
+    for (const [key, child] of Object.entries(value)) {
+      if (isPlaceholderString(key)) return true
+      if (isPlaceholderString(child)) return true
+    }
+  }
+  return false
+}
+
 function normalizeBusinessBoolean(value) {
   if (value === undefined || value === null || value === '') return null
   if (typeof value === 'boolean') return value
@@ -255,7 +280,24 @@ function extractBusinessRows(data) {
       rows.add(candidate)
     }
   }
-  return Array.from(rows)
+  // One unwrap pass for the Data[0].Data nesting shape (mirrors the read path's
+  // `element.Data` unwrap): if a row carries its business signal under row.Data
+  // and the OUTER row carries none, use the inner object as the canonical row.
+  // Flat rows (outer has signal) are left untouched — one representation per row.
+  return Array.from(rows).map((row) => {
+    if (!isPlainObject(row.Data)) return row
+    const innerHasSignal = (
+      businessRowStatus(row.Data) !== null ||
+      businessRowMessage(row.Data) !== undefined ||
+      businessRowHasIdentifier(row.Data)
+    )
+    const outerHasSignal = (
+      businessRowStatus(row) !== null ||
+      businessRowMessage(row) !== undefined ||
+      businessRowHasIdentifier(row)
+    )
+    return innerHasSignal && !outerHasSignal ? row.Data : row
+  })
 }
 
 function hasExplicitBusinessFailure(data) {
@@ -350,12 +392,26 @@ function normalizeObjects(config) {
   const configured = toPlainObject(config.objects, 'config.objects')
   const normalized = {}
   for (const [name, defaults] of Object.entries(DEFAULT_OBJECTS)) {
+    const configuredObject = isPlainObject(configured[name]) ? configured[name] : {}
+    // Opt-in customer profile: ONLY when config explicitly selects it by id, and
+    // ONLY for the material object slot (it is a Material profile — never apply it to
+    // bom or any other object, even on a misconfigured `profile`). Any other / absent
+    // value leaves the generic default template untouched.
+    let baseTemplate = defaults
+    const usesCustomerProfile = name === 'material' && configuredObject.profile === MATERIAL_CUSTOMER_PROFILE_ID
+    if (usesCustomerProfile) {
+      const profileTemplate = getK3WiseDocumentTemplate('materialCustomerProfile')
+      if (profileTemplate) baseTemplate = normalizeTemplate(profileTemplate, `config.objects.${name}`)
+    }
     try {
       normalized[name] = mergeK3WiseDocumentObject(
-        defaults,
-        isPlainObject(configured[name]) ? configured[name] : {},
+        baseTemplate,
+        configuredObject,
         `config.objects.${name}`,
       )
+      // Re-pin save-only lifecycle after merge so a config override cannot
+      // clobber it — the autoSubmit/autoAudit hard guard is the last-line defense.
+      if (usesCustomerProfile) normalized[name].lifecycle = 'save-only'
     } catch (error) {
       throw new AdapterValidationError(error.message, {
         field: `config.objects.${name}`,
@@ -434,6 +490,15 @@ function projectRecordForBody(record, objectConfig) {
     const fieldName = field && field.name
     if (typeof fieldName !== 'string' || fieldName.trim().length === 0) continue
     if (Object.prototype.hasOwnProperty.call(record, fieldName)) {
+      // Fail-closed: an unreplaced placeholder in a REQUIRED field must never
+      // reach the Save body / the K3 wire. Throws out of projectRecordForBody
+      // before buildSaveBody → no HTTP Save for this record.
+      if (field.required === true && containsPlaceholder(record[fieldName])) {
+        throw new AdapterValidationError(
+          `K3 WISE Save refused: unreplaced placeholder in required field ${fieldName}`,
+          { field: fieldName },
+        )
+      }
       const value = applyReferenceShape(record[fieldName], field)
       if (!isBlankValue(value)) projected[fieldName] = value
     }
@@ -616,6 +681,10 @@ function responseMessage(data, config, fallback = 'K3 WISE WebAPI business respo
     getPath(data, 'Data.0.Message'),
     getPath(data, 'Data.0.ErrorMessage'),
     getPath(data, 'Data.0.FErrMessage'),
+    getPath(data, 'Data.0.Data.FMessage'),
+    getPath(data, 'Data.0.Data.Message'),
+    getPath(data, 'Data.0.Data.ErrorMessage'),
+    getPath(data, 'Data.0.Data.FErrMessage'),
     getPath(data, 'message'),
     getPath(data, 'Message'),
     getPath(data, 'error'),
@@ -634,6 +703,8 @@ function responseCode(data, config, fallback = 'OK') {
     getPath(data, 'ErrorCode'),
     getPath(data, 'Data.0.Code'),
     getPath(data, 'Data.0.ErrorCode'),
+    getPath(data, 'Data.0.Data.Code'),
+    getPath(data, 'Data.0.Data.ErrorCode'),
     getPath(data, 'StatusCode'),
     getPath(data, 'Data.Code'),
     getPath(data, 'Result.ResponseStatus.ErrorCode'),
@@ -650,6 +721,8 @@ function responseFailureCode(data, config, fallback) {
     getPath(data, 'ErrorCode'),
     getPath(data, 'Data.0.Code'),
     getPath(data, 'Data.0.ErrorCode'),
+    getPath(data, 'Data.0.Data.Code'),
+    getPath(data, 'Data.0.Data.ErrorCode'),
     getPath(data, 'Data.Code'),
     getPath(data, 'Result.ResponseStatus.ErrorCode'),
   )
@@ -668,8 +741,10 @@ function responseBillNo(data, config) {
     getPath(data, 'Number'),
     getPath(data, 'Data.FBillNo'),
     getPath(data, 'Data.0.FBillNo'),
+    getPath(data, 'Data.0.Data.FBillNo'),
     getPath(data, 'Data.FNumber'),
     getPath(data, 'Data.0.FNumber'),
+    getPath(data, 'Data.0.Data.FNumber'),
     getPath(data, 'Result.Number'),
     getPath(data, 'Result.ResponseStatus.SuccessEntitys.0.Number'),
   )
@@ -684,12 +759,24 @@ function responseExternalId(data, config) {
     getPath(data, 'FItemID'),
     getPath(data, 'Data.FItemID'),
     getPath(data, 'Data.0.FItemID'),
+    getPath(data, 'Data.0.Data.FItemID'),
     getPath(data, 'Data.Id'),
     getPath(data, 'Data.0.Id'),
+    getPath(data, 'Data.0.Data.Id'),
     getPath(data, 'Result.Id'),
     getPath(data, 'Result.ResponseStatus.SuccessEntitys.0.Id'),
   ]
   return candidates.find(isMeaningfulIdentifier)
+}
+
+// Conservative row-key masking for sanitized diagnostics: never the raw value.
+// Keeps a 3-char tail so an operator can correlate without the record identifier
+// leaking. Returns null for empty/blank inputs so a missing id stays absent.
+function maskRowKey(value) {
+  if (value === undefined || value === null) return null
+  const text = String(value)
+  if (text.trim().length === 0) return null
+  return `****${text.slice(-3)}`
 }
 
 function createBusinessResponseSummary(data, config, { operation, success }) {
@@ -708,6 +795,11 @@ function createBusinessResponseSummary(data, config, { operation, success }) {
     dataCode: firstDefined(getPath(data, 'Data.Code'), getPath(data, 'data.code'), null),
     responseCode: responseCode(data, config, null),
     responseMessagePresent: message !== undefined && message !== null && message !== '',
+    // Sanitized diagnostics: NEVER raw record identifiers or raw message text.
+    // Mask the identifiers; run the message through the shared secret scrubber.
+    responseMessageRedacted: typeof message === 'string' ? scrubSecretStringValue(message) : null,
+    externalIdMasked: isMeaningfulIdentifier(externalId) ? maskRowKey(externalId) : null,
+    billNoMasked: isMeaningfulIdentifier(billNo) ? maskRowKey(billNo) : null,
     rowCount: rows.length,
     successfulRowCount: successfulRows,
     failedRowCount: failedRows,
@@ -1060,8 +1152,15 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
     const savePath = assertRelativePath(objectConfig.savePath || objectConfig.path, 'object.savePath')
     const submitPath = objectConfig.submitPath ? assertRelativePath(objectConfig.submitPath, 'object.submitPath') : null
     const auditPath = objectConfig.auditPath ? assertRelativePath(objectConfig.auditPath, 'object.auditPath') : null
-    const autoSubmit = resolveAutoFlag(request.options.autoSubmit, config.autoSubmit, 'autoSubmit')
-    const autoAudit = resolveAutoFlag(request.options.autoAudit, config.autoAudit, 'autoAudit')
+    let autoSubmit = resolveAutoFlag(request.options.autoSubmit, config.autoSubmit, 'autoSubmit')
+    let autoAudit = resolveAutoFlag(request.options.autoAudit, config.autoAudit, 'autoAudit')
+    // Save-only profile hard guard: force both lifecycle steps off, overriding
+    // request AND config. A save-only customer profile must never Submit/Audit —
+    // the if (autoSubmit) / if (autoAudit) blocks below can never fire for it.
+    if (objectConfig.lifecycle === 'save-only') {
+      autoSubmit = false
+      autoAudit = false
+    }
     const authContext = await login()
     const results = []
     const errors = []
@@ -1224,15 +1323,19 @@ module.exports = {
   __internals: {
     DEFAULT_OBJECTS,
     businessSuccess,
+    createBusinessResponseSummary,
+    extractBusinessRows,
     extractRecordKey,
     extractMaterialDetailRecord,
     buildMaterialReadRecord,
     listK3WiseDocumentTemplates,
+    maskRowKey,
     normalizeObjects,
     projectRecordForBody,
     responseBillNo,
     responseCode,
     responseExternalId,
+    responseMessage,
     saveBusinessSuccess,
   },
 }


### PR DESCRIPTION
> **DO NOT MERGE** — runtime implementation of the merged #1903/#1904 design; opened for review. This is a write-path to a customer K3 WISE ERP — please review before merge. After merge: patched package, then a fresh explicit #1792 approval before any 2nd Save-only attempt.

## Scope (strictly design §4/§5; backend only)

Two backend adapter files + their test. **No frontend, no scope expansion.** Closes the M1 Material Save-only failure cause from #1792.

**`k3-wise-document-templates.cjs` — opt-in customer profile**
- New `material-k3wise-customer-profile-v1` in a **separate** `K3_WISE_DOCUMENT_PROFILES` const — **not** iterated by `getK3WiseDocumentObjectDefaults()`, so the generic `k3wise.material.v1` is byte-stable. Per-field shape: `FNumber` for numbered base-data (`FUnitGroupID`/`FUnit*`/`FAcct*`), `FID` for enum/category (`FErpClsID`, `FUseState`, the six `F*ChkMde` quality modes). Synthetic sample values only.

**`k3-wise-webapi-adapter.cjs`**
- **Opt-in selection** (`normalizeObjects`): profile applied **only** when `config.objects.material.profile === 'material-k3wise-customer-profile-v1'` (material slot only); default untouched. `lifecycle: 'save-only'` re-pinned post-merge.
- **R-FAILCLOSED** (`projectRecordForBody`): unreplaced `<…>` placeholder in a **required** field → `AdapterValidationError` **before** the HTTP Save (recurses one level into objects).
- **Save-response `Data[0].Data`**: one `row.Data` unwrap in `extractBusinessRows` (no double-add) + appended `Data.0.Data.*` probes on the five response helpers (flat shape unchanged).
- **R-REDACT** (`createBusinessResponseSummary`): `externalIdMasked`/`billNoMasked` (`maskRowKey`) + `responseMessageRedacted` (`scrubSecretStringValue`); **no raw record identifiers or raw message** emitted.
- **Auto-flag hard guard** (`upsert`): `autoSubmit`/`autoAudit` forced `false` for the save-only profile, overriding request **and** config.

## Tests — six anchors, each with a negative control
`preset-opt-in` (+ unknown-profile control, generic byte-stable) · `base-data-object-shaping` · `fail-closed-placeholder` (ZERO save calls + substituted control) · `readback-data0-data` (nested success/fail + flat regression + revert controls) · `diagnostics-redaction` (raw-`FNumber` absent + **wire round-trip** + masking-off control) · `save-only-locks` (no submit/audit + non-save-only control). **23/23** plugin `.cjs` tests pass; downstream consumers (`e2e-plm-k3wise-writeback`, `pipeline-runner`, `http-routes-plm-k3wise-poc`) unaffected.

## NOT in scope / still locked
- **Frontend G4** (FBaseUnitID-centric default UI / shape selector) — deferred to a follow-up.
- Submit / Audit / BOM Save / list-search / pagination / broad read / server-side reference resolver / production / multi-record / direct K3 SQL — unchanged; `operations` stays `['upsert']`.

## After this merges
Patched package → fresh explicit #1792 approval → only then a 2nd 1–3 record Save-only attempt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)