### PR TITLE
fix(attendance-onprem): publish packaged web dist (#1908)

### DIFF
--- a/docs/deployment/attendance-onprem-package-layout-20260306.md
+++ b/docs/deployment/attendance-onprem-package-layout-20260306.md
@@ -78,6 +78,8 @@ metasheet/
     attendance-onprem-env-check.sh
     attendance-onprem-healthcheck.sh
     attendance-onprem-update.sh
+    attendance-onprem-publish-web-dist.sh
+    attendance-onprem-publish-web-dist.ps1
     attendance-wsl-portproxy-refresh.ps1
     attendance-wsl-portproxy-task.ps1
   docker/app.env.example
@@ -94,6 +96,7 @@ metasheet/
 
 - `apps/web/dist` 与 `packages/core-backend/dist` 现在是交付包必选项（非可选）。
 - `plugins/` 下只允许包含 `plugin-attendance`，确保交付包是“考勤专用”。
+- 安装/升级会把包内 `apps/web/dist` 发布到 nginx root。默认 root 为当前部署目录的 `apps/web/dist`；如果包先解压在 `packages/<package>/<package>` 下，脚本会自动发布到上层部署根的 `apps/web/dist`。特殊 nginx root 可用 `WEB_DIST_TARGET` 覆盖。
 
 ## 2. 首次安装（照抄）
 

--- a/scripts/ops/attendance-onprem-bootstrap.sh
+++ b/scripts/ops/attendance-onprem-bootstrap.sh
@@ -55,6 +55,8 @@ if [[ "$RUN_MIGRATIONS" == "1" ]]; then
   run node "${ROOT_DIR}/packages/core-backend/dist/src/db/migrate.js"
 fi
 
+run "${ROOT_DIR}/scripts/ops/attendance-onprem-publish-web-dist.sh"
+
 if [[ "$START_SERVICE" == "1" ]]; then
   if [[ "$SERVICE_MANAGER" == "pm2" ]]; then
     run mkdir -p "${ROOT_DIR}/output/logs"

--- a/scripts/ops/attendance-onprem-deploy-run.ps1
+++ b/scripts/ops/attendance-onprem-deploy-run.ps1
@@ -46,9 +46,19 @@ if (-not (Test-Path $migratePath)) {
   throw "Missing backend migration entrypoint: $migratePath"
 }
 
+$publishWebDistScript = Join-Path $resolvedRoot 'scripts\ops\attendance-onprem-publish-web-dist.ps1'
+if (-not (Test-Path $publishWebDistScript)) {
+  throw "Missing web dist publish script: $publishWebDistScript"
+}
+
 & node $migratePath
 if ($LASTEXITCODE -ne 0) {
   throw 'database migration failed'
+}
+
+& $publishWebDistScript -RootDir $resolvedRoot
+if ($LASTEXITCODE -ne 0) {
+  throw 'web dist publish failed'
 }
 
 $startScript = Join-Path $resolvedRoot 'scripts\ops\attendance-onprem-start-pm2.ps1'

--- a/scripts/ops/attendance-onprem-package-build.sh
+++ b/scripts/ops/attendance-onprem-package-build.sh
@@ -33,6 +33,8 @@ REQUIRED_PATHS=(
   "scripts/ops/attendance-onprem-env-check.sh"
   "scripts/ops/attendance-onprem-healthcheck.sh"
   "scripts/ops/attendance-onprem-update.sh"
+  "scripts/ops/attendance-onprem-publish-web-dist.sh"
+  "scripts/ops/attendance-onprem-publish-web-dist.ps1"
   "run-migrate.bat"
   "scripts/ops/attendance-wsl-portproxy-refresh.ps1"
   "scripts/ops/attendance-wsl-portproxy-task.ps1"

--- a/scripts/ops/attendance-onprem-package-verify.sh
+++ b/scripts/ops/attendance-onprem-package-verify.sh
@@ -87,6 +87,17 @@ function verify_onprem_env_templates() {
   done
 }
 
+function verify_web_dist_publish_entrypoints() {
+  local root="$1"
+
+  search_fixed_string 'attendance-onprem-publish-web-dist.sh' "${root}/scripts/ops/attendance-onprem-bootstrap.sh" \
+    || die "attendance-onprem-bootstrap.sh must publish apps/web/dist to the nginx root"
+  search_fixed_string 'attendance-onprem-publish-web-dist.sh' "${root}/scripts/ops/attendance-onprem-update.sh" \
+    || die "attendance-onprem-update.sh must publish apps/web/dist to the nginx root"
+  search_fixed_string 'attendance-onprem-publish-web-dist.ps1' "${root}/scripts/ops/attendance-onprem-deploy-run.ps1" \
+    || die "attendance-onprem-deploy-run.ps1 must publish apps/web/dist to the nginx root"
+}
+
 function verify_no_github_links() {
   local root="$1"
   local patterns='github\.com|githubusercontent\.com|github\.io'
@@ -201,6 +212,8 @@ required=(
   "scripts/ops/attendance-onprem-deploy-run.ps1"
   "scripts/ops/attendance-onprem-package-install.sh"
   "scripts/ops/attendance-onprem-package-upgrade.sh"
+  "scripts/ops/attendance-onprem-publish-web-dist.sh"
+  "scripts/ops/attendance-onprem-publish-web-dist.ps1"
   "run-migrate.bat"
   "scripts/ops/attendance-wsl-portproxy-refresh.ps1"
   "scripts/ops/attendance-wsl-portproxy-task.ps1"
@@ -240,6 +253,7 @@ fi
 
 verify_onprem_env_templates "$pkg_root"
 verify_workspace_manifest "$pkg_root"
+verify_web_dist_publish_entrypoints "$pkg_root"
 
 if search_extended_regex 'VITE_API_(URL|BASE):"http://(127\.0\.0\.1|localhost)' "${pkg_root}/apps/web/dist"; then
   die "Frontend bundle embeds loopback VITE_API_* config; rebuild package with isolated web env"

--- a/scripts/ops/attendance-onprem-publish-web-dist.ps1
+++ b/scripts/ops/attendance-onprem-publish-web-dist.ps1
@@ -1,0 +1,121 @@
+param(
+  [string]$RootDir = (Resolve-Path (Join-Path $PSScriptRoot '..\..')).Path,
+  [string]$SourceDir = '',
+  [string]$TargetDir = ''
+)
+
+$ErrorActionPreference = 'Stop'
+
+function Resolve-ExistingDirectory {
+  param(
+    [string]$Candidate,
+    [string]$Label
+  )
+
+  $trimmed = $Candidate.Trim().Trim('"')
+  if ([string]::IsNullOrWhiteSpace($trimmed)) {
+    throw "$Label is empty after normalization"
+  }
+
+  if (-not (Test-Path -LiteralPath $trimmed -PathType Container)) {
+    throw "$Label does not exist: $trimmed"
+  }
+
+  return [System.IO.Path]::GetFullPath($trimmed)
+}
+
+function Resolve-WebDistSource {
+  param([string]$BaseDir)
+
+  if (-not [string]::IsNullOrWhiteSpace($SourceDir)) {
+    return Resolve-ExistingDirectory -Candidate $SourceDir -Label 'SourceDir'
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($env:WEB_DIST_SOURCE)) {
+    return Resolve-ExistingDirectory -Candidate $env:WEB_DIST_SOURCE -Label 'WEB_DIST_SOURCE'
+  }
+
+  return Resolve-ExistingDirectory -Candidate (Join-Path $BaseDir 'apps\web\dist') -Label 'web dist source'
+}
+
+function Resolve-WebDistTarget {
+  param([string]$BaseDir)
+
+  if (-not [string]::IsNullOrWhiteSpace($TargetDir)) {
+    return [System.IO.Path]::GetFullPath($TargetDir.Trim().Trim('"'))
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($env:WEB_DIST_TARGET)) {
+    return [System.IO.Path]::GetFullPath($env:WEB_DIST_TARGET.Trim().Trim('"'))
+  }
+
+  $rootInfo = Get-Item -LiteralPath $BaseDir
+  $parent = $rootInfo.Parent
+  if ($parent -and $parent.Name -eq 'packages') {
+    $deployRoot = $parent.Parent.FullName
+    return [System.IO.Path]::GetFullPath((Join-Path $deployRoot 'apps\web\dist'))
+  }
+
+  if ($parent -and $parent.Parent -and $parent.Parent.Name -eq 'packages') {
+    $deployRoot = $parent.Parent.Parent.FullName
+    return [System.IO.Path]::GetFullPath((Join-Path $deployRoot 'apps\web\dist'))
+  }
+
+  return [System.IO.Path]::GetFullPath((Join-Path $BaseDir 'apps\web\dist'))
+}
+
+function Test-SamePath {
+  param(
+    [string]$Left,
+    [string]$Right
+  )
+
+  if (-not (Test-Path -LiteralPath $Left -PathType Container)) {
+    return $false
+  }
+  if (-not (Test-Path -LiteralPath $Right -PathType Container)) {
+    return $false
+  }
+
+  $leftFull = [System.IO.Path]::GetFullPath((Resolve-Path -LiteralPath $Left).Path).TrimEnd('\', '/')
+  $rightFull = [System.IO.Path]::GetFullPath((Resolve-Path -LiteralPath $Right).Path).TrimEnd('\', '/')
+  return $leftFull.Equals($rightFull, [System.StringComparison]::OrdinalIgnoreCase)
+}
+
+$resolvedRoot = Resolve-ExistingDirectory -Candidate $RootDir -Label 'RootDir'
+$source = Resolve-WebDistSource -BaseDir $resolvedRoot
+$target = Resolve-WebDistTarget -BaseDir $resolvedRoot
+
+$sourceIndex = Join-Path $source 'index.html'
+if (-not (Test-Path -LiteralPath $sourceIndex -PathType Leaf)) {
+  throw "Missing web dist source index.html: $sourceIndex"
+}
+
+if (Test-SamePath -Left $source -Right $target) {
+  Write-Host "[attendance-onprem-publish-web-dist] Web dist already at nginx root: $target"
+  exit 0
+}
+
+$targetParent = Split-Path -Parent $target
+New-Item -ItemType Directory -Force -Path $targetParent | Out-Null
+
+$tmpTarget = Join-Path $targetParent ('.web-dist.tmp.' + [System.Guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $tmpTarget | Out-Null
+
+try {
+  Get-ChildItem -LiteralPath $source -Force | Copy-Item -Destination $tmpTarget -Recurse -Force
+  if (Test-Path -LiteralPath $target) {
+    Remove-Item -LiteralPath $target -Recurse -Force
+  }
+  Move-Item -LiteralPath $tmpTarget -Destination $target
+}
+catch {
+  if (Test-Path -LiteralPath $tmpTarget) {
+    Remove-Item -LiteralPath $tmpTarget -Recurse -Force -ErrorAction SilentlyContinue
+  }
+  throw
+}
+
+Write-Host '[attendance-onprem-publish-web-dist] Published web dist'
+Write-Host "  source: $source"
+Write-Host "  target: $target"

--- a/scripts/ops/attendance-onprem-publish-web-dist.sh
+++ b/scripts/ops/attendance-onprem-publish-web-dist.sh
@@ -1,0 +1,80 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+ROOT_DIR="${ROOT_DIR_OVERRIDE:-$(cd "$(dirname "${BASH_SOURCE[0]}")/../.." && pwd)}"
+WEB_DIST_SOURCE="${WEB_DIST_SOURCE:-${ROOT_DIR}/apps/web/dist}"
+WEB_DIST_TARGET="${WEB_DIST_TARGET:-}"
+
+function info() {
+  echo "[attendance-onprem-publish-web-dist] $*" >&2
+}
+
+function die() {
+  echo "[attendance-onprem-publish-web-dist] ERROR: $*" >&2
+  exit 1
+}
+
+function resolve_web_dist_target() {
+  if [[ -n "$WEB_DIST_TARGET" ]]; then
+    printf '%s\n' "$WEB_DIST_TARGET"
+    return
+  fi
+
+  local normalized="${ROOT_DIR%/}"
+  case "$normalized" in
+    */packages/*/*)
+      local deploy_root="${normalized%%/packages/*}"
+      if [[ -n "$deploy_root" && "$deploy_root" != "$normalized" ]]; then
+        printf '%s/apps/web/dist\n' "$deploy_root"
+        return
+      fi
+      ;;
+    */packages/*)
+      local deploy_root="${normalized%%/packages/*}"
+      if [[ -n "$deploy_root" && "$deploy_root" != "$normalized" ]]; then
+        printf '%s/apps/web/dist\n' "$deploy_root"
+        return
+      fi
+      ;;
+  esac
+
+  printf '%s/apps/web/dist\n' "$ROOT_DIR"
+}
+
+function same_existing_dir() {
+  local left="$1"
+  local right="$2"
+  [[ -d "$left" && -d "$right" ]] || return 1
+
+  local left_real
+  local right_real
+  left_real="$(cd "$left" && pwd -P)"
+  right_real="$(cd "$right" && pwd -P)"
+  [[ "$left_real" == "$right_real" ]]
+}
+
+[[ -f "${WEB_DIST_SOURCE}/index.html" ]] || die "Missing web dist source index.html: ${WEB_DIST_SOURCE}/index.html"
+
+target="$(resolve_web_dist_target)"
+if same_existing_dir "$WEB_DIST_SOURCE" "$target"; then
+  info "Web dist already at nginx root: ${target}"
+  exit 0
+fi
+
+target_parent="$(dirname "$target")"
+mkdir -p "$target_parent"
+tmp_target="$(mktemp -d "${target_parent}/.web-dist.tmp.XXXXXX")"
+
+cleanup() {
+  rm -rf "$tmp_target" || true
+}
+trap cleanup EXIT
+
+cp -R "${WEB_DIST_SOURCE}/." "$tmp_target/"
+rm -rf "$target"
+mv "$tmp_target" "$target"
+trap - EXIT
+
+info "Published web dist"
+info "  source: ${WEB_DIST_SOURCE}"
+info "  target: ${target}"

--- a/scripts/ops/attendance-onprem-publish-web-dist.test.mjs
+++ b/scripts/ops/attendance-onprem-publish-web-dist.test.mjs
@@ -1,0 +1,73 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(fileURLToPath(new URL('../..', import.meta.url)))
+const scriptPath = path.join(repoRoot, 'scripts/ops/attendance-onprem-publish-web-dist.sh')
+
+function makeDist(root, label) {
+  const dist = path.join(root, 'apps/web/dist')
+  fs.mkdirSync(dist, { recursive: true })
+  fs.writeFileSync(path.join(dist, 'index.html'), `<html>${label}</html>`)
+  fs.mkdirSync(path.join(dist, 'assets'), { recursive: true })
+  fs.writeFileSync(path.join(dist, 'assets/app.js'), `console.log(${JSON.stringify(label)})`)
+  return dist
+}
+
+function runPublish(env) {
+  const result = spawnSync('bash', [scriptPath], {
+    cwd: repoRoot,
+    env: { ...process.env, ...env },
+    encoding: 'utf8',
+  })
+  assert.equal(result.status, 0, result.stderr || result.stdout)
+  return result
+}
+
+test('publishes web dist to explicit WEB_DIST_TARGET', () => {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'attendance-web-dist-explicit-'))
+  const source = makeDist(path.join(tempRoot, 'release'), 'explicit')
+  const target = path.join(tempRoot, 'nginx/apps/web/dist')
+
+  runPublish({
+    WEB_DIST_SOURCE: source,
+    WEB_DIST_TARGET: target,
+  })
+
+  assert.equal(fs.readFileSync(path.join(target, 'index.html'), 'utf8'), '<html>explicit</html>')
+  assert.equal(fs.readFileSync(path.join(target, 'assets/app.js'), 'utf8'), 'console.log("explicit")')
+})
+
+test('derives deploy root when package is extracted under packages/package/package', () => {
+  const deployRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'attendance-web-dist-derived-'))
+  const packageRoot = path.join(deployRoot, 'packages/metasheet-attendance-onprem-v2.7.2-run34/metasheet-attendance-onprem-v2.7.2-run34')
+  const source = makeDist(packageRoot, 'derived')
+  const target = path.join(deployRoot, 'apps/web/dist')
+
+  runPublish({
+    ROOT_DIR_OVERRIDE: packageRoot,
+    WEB_DIST_SOURCE: source,
+  })
+
+  assert.equal(fs.readFileSync(path.join(target, 'index.html'), 'utf8'), '<html>derived</html>')
+  assert.equal(fs.readFileSync(path.join(target, 'assets/app.js'), 'utf8'), 'console.log("derived")')
+})
+
+test('derives deploy root when package is extracted directly under packages/package', () => {
+  const deployRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'attendance-web-dist-direct-'))
+  const packageRoot = path.join(deployRoot, 'packages/metasheet-attendance-onprem-v2.7.2-run34')
+  const source = makeDist(packageRoot, 'direct')
+  const target = path.join(deployRoot, 'apps/web/dist')
+
+  runPublish({
+    ROOT_DIR_OVERRIDE: packageRoot,
+    WEB_DIST_SOURCE: source,
+  })
+
+  assert.equal(fs.readFileSync(path.join(target, 'index.html'), 'utf8'), '<html>direct</html>')
+  assert.equal(fs.readFileSync(path.join(target, 'assets/app.js'), 'utf8'), 'console.log("direct")')
+})

--- a/scripts/ops/attendance-onprem-update.sh
+++ b/scripts/ops/attendance-onprem-update.sh
@@ -63,6 +63,8 @@ if [[ "$RUN_MIGRATIONS" == "1" ]]; then
   run node "${ROOT_DIR}/packages/core-backend/dist/src/db/migrate.js"
 fi
 
+run "${ROOT_DIR}/scripts/ops/attendance-onprem-publish-web-dist.sh"
+
 if [[ "$RESTART_SERVICE" == "1" ]]; then
   if [[ "$SERVICE_MANAGER" == "pm2" ]]; then
     run mkdir -p "${ROOT_DIR}/output/logs"


### PR DESCRIPTION
## Summary
- add bash + PowerShell helpers that publish packaged `apps/web/dist` to the nginx root
- call the publish step from attendance on-prem bootstrap/update and Windows `deploy-run.ps1` after build/migration and before service restart
- derive the deploy root automatically for `packages/<package>` and `packages/<package>/<package>` extraction layouts; allow `WEB_DIST_TARGET` override
- include the helper in package build/verify and document the contract

Closes #1908.

## Verification
- `bash -n scripts/ops/attendance-onprem-publish-web-dist.sh scripts/ops/attendance-onprem-bootstrap.sh scripts/ops/attendance-onprem-update.sh scripts/ops/attendance-onprem-package-build.sh scripts/ops/attendance-onprem-package-verify.sh`
- `node --test scripts/ops/attendance-onprem-publish-web-dist.test.mjs`
- synthetic `attendance-onprem-package-verify.sh` package check: PASS
- `git diff --check HEAD~1..HEAD`

PowerShell syntax was not executed locally because `pwsh`/`powershell` is not installed in this environment.