### PR TITLE
fix(integration): scrub secret-shaped values from dead-letter errorMessage

### DIFF
--- a/plugins/plugin-integration-core/__tests__/runner-support.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/runner-support.test.cjs
@@ -282,6 +282,23 @@ async function main() {
   assert.equal(replayed.lastReplayRunId, 'run_2')
   assert.equal(replayed.retryCount, 1)
 
+  // provenance hardening: a secret-shaped value in the free-text errorMessage must be
+  // scrubbed before persistence (it rides into the run-monitoring UI and survives replay).
+  const secretDl = await deadLetters.create({
+    id: 'dl_secret',
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    runId: 'run_1',
+    pipelineId: 'pipe_1',
+    sourcePayload: { code: 'S-01' },
+    errorCode: 'TARGET_WRITE_FAILED',
+    errorMessage: 'K3 connect failed: jdbc:sqlserver://user:P@ssw0rd@host;databaseName=db token=ABC123DEF456',
+  })
+  assert.ok(!secretDl.errorMessage.includes('P@ssw0rd'), 'dead-letter errorMessage must not leak DSN password')
+  assert.ok(!secretDl.errorMessage.includes('ABC123DEF456'), 'dead-letter errorMessage must not leak token value')
+  assert.match(secretDl.errorMessage, /\[redacted\]/)
+  assert.match(secretDl.errorMessage, /K3 connect failed/) // non-secret diagnostic context preserved
+
   await deadLetters.create({
     id: 'dl_discarded_store',
     tenantId: 'tenant_1',

--- a/plugins/plugin-integration-core/lib/dead-letter.cjs
+++ b/plugins/plugin-integration-core/lib/dead-letter.cjs
@@ -1,7 +1,7 @@
 'use strict'
 
 const crypto = require('node:crypto')
-const { sanitizeIntegrationPayload } = require('./payload-redaction.cjs')
+const { sanitizeIntegrationPayload, scrubSecretStringValue } = require('./payload-redaction.cjs')
 
 const TABLE = 'integration_dead_letters'
 const VALID_STATUSES = new Set(['open', 'replayed', 'discarded'])
@@ -105,7 +105,11 @@ function createDeadLetterStore({ db, idGenerator = crypto.randomUUID } = {}) {
       source_payload: normalizeJsonPayload(input.sourcePayload, 'sourcePayload'),
       transformed_payload: normalizeJsonPayload(input.transformedPayload, 'transformedPayload', { nullable: true }),
       error_code: requiredString(input.errorCode || 'VALIDATION_FAILED', 'errorCode'),
-      error_message: requiredString(input.errorMessage, 'errorMessage'),
+      // Scrub secret-shaped values out of the free-text error message before it is
+      // persisted (it rides into the run-monitoring UI and survives replay). Source/
+      // transformed payloads are already sanitized; the error message was the one
+      // un-scrubbed channel (a conn-string / token in an adapter error would leak).
+      error_message: scrubSecretStringValue(requiredString(input.errorMessage, 'errorMessage')),
       retry_count: normalizeNonNegativeInteger(input.retryCount, 'retryCount'),
       status: normalizeStatus(input.status),
       last_replay_run_id: optionalString(input.lastReplayRunId, 'lastReplayRunId'),

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -247,12 +247,16 @@ function redactDeadLetter(deadLetter, fullPayload = false) {
       ...deadLetter,
       sourcePayload: sanitizeIntegrationPayload(deadLetter.sourcePayload),
       transformedPayload: sanitizeIntegrationPayload(deadLetter.transformedPayload),
+      // Scrub secret-shaped values from the free-text error message at display time too,
+      // so pre-fix dead-letters (stored before write-time scrubbing) cannot leak on read.
+      errorMessage: scrubSecretStringValue(deadLetter.errorMessage),
       payloadRedacted: true,
     }
   }
   const { sourcePayload: _sourcePayload, transformedPayload: _transformedPayload, ...safe } = deadLetter
   return {
     ...safe,
+    errorMessage: scrubSecretStringValue(deadLetter.errorMessage),
     payloadRedacted: true,
   }
 }


### PR DESCRIPTION
## What

DF run-provenance inventory + the one real hardening gap it surfaced.

**Inventory (current `origin/main`):** dead-letter records already carry stable `runId` / `pipelineId` / `errorCode` (error class) / `retryCount` / `lastReplayRunId` (replay source) / `status`, and **write-time-sanitized** `sourcePayload` + `transformedPayload`. Replay preserves provenance (`markReplayed` keeps the original row + links the replay run). The **one un-sanitized channel** was the free-text `errorMessage`.

**Gap (confirmed, output-reaching):** a secret-shaped value in an adapter/transform/validation error — e.g. a JDBC conn-string with an embedded password, or `token=…` — was:
- stored **raw** (`createDeadLetter` only `requiredString`'d it),
- displayed **raw** (`redactDeadLetter` sanitized only the payloads, spread `errorMessage` through),
- carried through **replay**.

→ a real leak into the run-monitoring UI / API response.

## Fix (reuses the shared, already-hardened `scrubSecretStringValue`)

- `dead-letter.cjs` `createDeadLetter`: scrub `errorMessage` **at write** (matches the payload-sanitize-at-write pattern; clean storage → clean display + replay for new records).
- `http-routes.cjs` `redactDeadLetter`: scrub `errorMessage` **at display** in both branches (defense-in-depth for pre-fix records already stored raw).

## Test

Focused (`runner-support.test.cjs`): a dead-letter created with a DSN-password + `token=…` errorMessage stores it scrubbed — no `P@ssw0rd` / token value survives, `[redacted]` present, non-secret diagnostic context (`K3 connect failed`) preserved.

## Scope

Provenance/redaction hardening only — **fills the gap, no new process engine**, no `automation-executor`, **no `workflow-job-contract`**, no new runner/report. `systemId` intentionally NOT added (would need a schema migration; derivable from `pipelineId`). Lock-safe; no K3 Save/BOM/Submit/Audit touched. No file overlap with the parallel K3 Save-only runtime PRs.

## Verification

`runner-support` / `pipeline-runner` / `http-routes` / `payload-redaction` / `external-systems` / `bridge-agent-readonly-adapter` all pass (shared-helper change → verified across consumers).

🤖 Generated with [Claude Code](https://claude.com/claude-code)