### PR TITLE
fix(attendance-onprem): verify packaged migration set

### DIFF
--- a/docs/deployment/attendance-onprem-package-layout-20260306.md
+++ b/docs/deployment/attendance-onprem-package-layout-20260306.md
@@ -69,6 +69,8 @@ metasheet/
     core-backend/
       package.json
       dist/
+      src/db/migrations/
+      migrations/
   scripts/ops/
     attendance-onprem-package-install.sh
     attendance-onprem-package-upgrade.sh
@@ -95,6 +97,8 @@ metasheet/
 说明：
 
 - `apps/web/dist` 与 `packages/core-backend/dist` 现在是交付包必选项（非可选）。
+- `packages/core-backend/src/db/migrations` 与 `packages/core-backend/migrations` 也必须随包交付：运行时从 `dist/src/db/migrations` 加载编译后的 TS 迁移，从 `src/db/migrations` 加载源 SQL 迁移，从 `migrations` 加载 legacy SQL bridge 迁移。
+- 发包校验会确认源 TS 迁移均存在对应的 `dist` JS 产物，并显式覆盖已升级数据库常见的 `zzzz20260318123000_formalize_meta_comments` 与 `zzzz20260320150000_add_spreadsheet_permissions_and_cell_versions`，避免迁移历史中存在的名称在包内不可见。
 - `plugins/` 下只允许包含 `plugin-attendance`，确保交付包是“考勤专用”。
 - 安装/升级会把包内 `apps/web/dist` 发布到 nginx root。默认 root 为当前部署目录的 `apps/web/dist`；如果包先解压在 `packages/<package>/<package>` 下，脚本会自动发布到上层部署根的 `apps/web/dist`。特殊 nginx root 可用 `WEB_DIST_TARGET` 覆盖。
 

--- a/scripts/ops/attendance-onprem-package-build.sh
+++ b/scripts/ops/attendance-onprem-package-build.sh
@@ -22,6 +22,11 @@ REQUIRED_PATHS=(
   "apps/web/package.json"
   "packages/core-backend/dist"
   "packages/core-backend/package.json"
+  # The packaged migration runner resolves compiled TS migrations from dist,
+  # source SQL migrations from src/db/migrations, and legacy SQL bridge
+  # migrations from packages/core-backend/migrations.
+  "packages/core-backend/src/db/migrations"
+  "packages/core-backend/migrations"
   "plugins/plugin-attendance"
   "scripts/ops/attendance-onprem-package-install.sh"
   "scripts/ops/attendance-onprem-package-upgrade.sh"

--- a/scripts/ops/attendance-onprem-package-verify-migrations.test.mjs
+++ b/scripts/ops/attendance-onprem-package-verify-migrations.test.mjs
@@ -1,0 +1,224 @@
+import assert from 'node:assert/strict'
+import { spawnSync } from 'node:child_process'
+import { createHash } from 'node:crypto'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(fileURLToPath(new URL('../..', import.meta.url)))
+const verifyScriptPath = path.join(repoRoot, 'scripts/ops/attendance-onprem-package-verify.sh')
+
+const upgradeMigrationNames = [
+  'zzzz20260318123000_formalize_meta_comments',
+  'zzzz20260320150000_add_spreadsheet_permissions_and_cell_versions',
+]
+
+function writeFile(root, rel, contents = '') {
+  const abs = path.join(root, rel)
+  fs.mkdirSync(path.dirname(abs), { recursive: true })
+  fs.writeFileSync(abs, contents)
+}
+
+function sha256(filePath) {
+  return createHash('sha256').update(fs.readFileSync(filePath)).digest('hex')
+}
+
+function writeMinimumPackage(pkgRoot, options = {}) {
+  const {
+    omitDistMigration,
+    extraSourceMigration,
+  } = options
+
+  const placeholderFiles = [
+    'apps/web/package.json',
+    'packages/core-backend/package.json',
+    'plugins/plugin-attendance/plugin.json',
+    'plugins/plugin-attendance/index.cjs',
+    'scripts/ops/attendance-onprem-start-pm2.ps1',
+    'scripts/ops/attendance-onprem-package-install.sh',
+    'scripts/ops/attendance-onprem-package-upgrade.sh',
+    'scripts/ops/attendance-onprem-publish-web-dist.sh',
+    'scripts/ops/attendance-onprem-publish-web-dist.ps1',
+    'run-migrate.bat',
+    'scripts/ops/attendance-wsl-portproxy-refresh.ps1',
+    'scripts/ops/attendance-wsl-portproxy-task.ps1',
+    'docker/app.env.example',
+    'ops/nginx/attendance-onprem.conf.example',
+    'docs/deployment/attendance-windows-onprem-easy-start-20260306.md',
+    'docs/deployment/attendance-windows-wsl-onprem-20260306.md',
+    'docs/deployment/attendance-windows-wsl-direct-commands-20260306.md',
+    'docs/deployment/attendance-windows-wsl-customer-profiled-commands-20260306.md',
+  ]
+
+  for (const rel of placeholderFiles) {
+    writeFile(pkgRoot, rel, `${rel}\n`)
+  }
+
+  writeFile(pkgRoot, 'apps/web/dist/index.html', '<html>attendance</html>\n')
+  writeFile(pkgRoot, 'packages/core-backend/dist/src/index.js', 'module.exports = {}\n')
+  writeFile(pkgRoot, 'packages/core-backend/dist/src/db/migrate.js', 'module.exports = {}\n')
+  writeFile(
+    pkgRoot,
+    'packages/core-backend/dist/src/db/migration-provider.js',
+    [
+      'const marker = "MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL";',
+      'const legacy = "032_create_approval_records";',
+      'module.exports = { marker, legacy };',
+      '',
+    ].join('\n')
+  )
+
+  writeFile(
+    pkgRoot,
+    'docker/app.env.attendance-onprem.template',
+    'JWT_SECRET=change-me\nBCRYPT_SALT_ROUNDS=12\n'
+  )
+  writeFile(
+    pkgRoot,
+    'docker/app.env.attendance-onprem.ready.env',
+    'JWT_SECRET=change-me\nBCRYPT_SALT_ROUNDS=12\n'
+  )
+  writeFile(
+    pkgRoot,
+    'pnpm-workspace.yaml',
+    "packages:\n  - 'packages/*'\n  - 'plugins/*'\n"
+  )
+
+  writeFile(
+    pkgRoot,
+    'start-pm2.bat',
+    'powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\\ops\\attendance-onprem-start-pm2.ps1" -RootDir "%~dp0."\n'
+  )
+  writeFile(pkgRoot, 'start-pm2-remote.bat', 'call "%~dp0start-pm2.bat"\n')
+  writeFile(
+    pkgRoot,
+    'deploy-run34.bat',
+    'powershell -NoProfile -ExecutionPolicy Bypass -File "%~dp0scripts\\ops\\attendance-onprem-deploy-run.ps1" -RootDir "%~dp0."\n'
+  )
+  writeFile(
+    pkgRoot,
+    'scripts/ops/attendance-onprem-deploy-run.ps1',
+    'scripts\\ops\\attendance-onprem-publish-web-dist.ps1\n'
+  )
+  writeFile(
+    pkgRoot,
+    'scripts/ops/attendance-onprem-bootstrap.sh',
+    'bash scripts/ops/attendance-onprem-publish-web-dist.sh\n'
+  )
+  writeFile(
+    pkgRoot,
+    'scripts/ops/attendance-onprem-update.sh',
+    'bash scripts/ops/attendance-onprem-publish-web-dist.sh\n'
+  )
+
+  writeFile(
+    pkgRoot,
+    'packages/core-backend/src/db/migrations/20250925_create_view_tables.sql',
+    'select 1;\n'
+  )
+  writeFile(
+    pkgRoot,
+    'packages/core-backend/src/db/migrations/20250926_create_audit_tables.sql',
+    'select 1;\n'
+  )
+  writeFile(
+    pkgRoot,
+    'packages/core-backend/migrations/056_add_users_must_change_password.sql',
+    'alter table users add column if not exists must_change_password boolean;\n'
+  )
+
+  for (const migrationName of upgradeMigrationNames) {
+    writeFile(
+      pkgRoot,
+      `packages/core-backend/src/db/migrations/${migrationName}.ts`,
+      'export async function up() {}\n'
+    )
+
+    if (migrationName !== omitDistMigration) {
+      writeFile(
+        pkgRoot,
+        `packages/core-backend/dist/src/db/migrations/${migrationName}.js`,
+        'exports.up = async function up() {};\n'
+      )
+    }
+  }
+
+  if (extraSourceMigration) {
+    writeFile(
+      pkgRoot,
+      `packages/core-backend/src/db/migrations/${extraSourceMigration}.ts`,
+      'export async function up() {}\n'
+    )
+  }
+}
+
+function makeArchive(options = {}) {
+  const tempRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'attendance-package-verify-'))
+  const packageName = 'metasheet-attendance-onprem-v2.7.2-run34'
+  const stagingRoot = path.join(tempRoot, 'staging')
+  const pkgRoot = path.join(stagingRoot, packageName)
+  const archivePath = path.join(tempRoot, `${packageName}.tgz`)
+
+  writeMinimumPackage(pkgRoot, options)
+
+  const tar = spawnSync('tar', ['-czf', archivePath, '-C', stagingRoot, packageName], {
+    encoding: 'utf8',
+  })
+  assert.equal(tar.status, 0, tar.stderr || tar.stdout)
+
+  writeFile(tempRoot, 'SHA256SUMS', `${sha256(archivePath)}  ${path.basename(archivePath)}\n`)
+  return { archivePath, tempRoot }
+}
+
+function withArchive(options, assertion) {
+  const { archivePath, tempRoot } = makeArchive(options)
+
+  try {
+    assertion(archivePath)
+  } finally {
+    fs.rmSync(tempRoot, { recursive: true, force: true })
+  }
+}
+
+function runVerify(archivePath) {
+  return spawnSync('bash', [verifyScriptPath, archivePath], {
+    cwd: repoRoot,
+    env: { ...process.env, VERIFY_SHA: '1', VERIFY_NO_GITHUB_LINKS: '1' },
+    encoding: 'utf8',
+  })
+}
+
+test('accepts a package with compiled migration coverage for upgraded databases', () => {
+  withArchive({}, (archivePath) => {
+    const result = runVerify(archivePath)
+
+    assert.equal(result.status, 0, result.stderr || result.stdout)
+    assert.match(result.stderr, /Package verify OK/)
+  })
+})
+
+test('rejects a package missing an issue 1907 upgraded-database migration in dist', () => {
+  const missingMigration = 'zzzz20260320150000_add_spreadsheet_permissions_and_cell_versions'
+  withArchive({ omitDistMigration: missingMigration }, (archivePath) => {
+    const result = runVerify(archivePath)
+
+    assert.notEqual(result.status, 0)
+    assert.match(
+      result.stderr,
+      new RegExp(`Required package content missing: packages/core-backend/dist/src/db/migrations/${missingMigration}\\.js`)
+    )
+  })
+})
+
+test('rejects a package when a source TS migration lacks compiled JS', () => {
+  const extraSourceMigration = 'zzzz20260601000000_future_attendance_package_guard'
+  withArchive({ extraSourceMigration }, (archivePath) => {
+    const result = runVerify(archivePath)
+
+    assert.notEqual(result.status, 0)
+    assert.match(result.stderr, new RegExp(extraSourceMigration))
+    assert.match(result.stderr, /Package missing compiled JS for one or more core backend TS migrations/)
+  })
+})

--- a/scripts/ops/attendance-onprem-package-verify.sh
+++ b/scripts/ops/attendance-onprem-package-verify.sh
@@ -98,6 +98,57 @@ function verify_web_dist_publish_entrypoints() {
     || die "attendance-onprem-deploy-run.ps1 must publish apps/web/dist to the nginx root"
 }
 
+function verify_core_backend_migration_set() {
+  local root="$1"
+  local provider="${root}/packages/core-backend/dist/src/db/migration-provider.js"
+  local dist_dir="${root}/packages/core-backend/dist/src/db/migrations"
+  local source_dir="${root}/packages/core-backend/src/db/migrations"
+  local legacy_sql_dir="${root}/packages/core-backend/migrations"
+  local required_upgrade_migrations=(
+    "zzzz20260318123000_formalize_meta_comments"
+    "zzzz20260320150000_add_spreadsheet_permissions_and_cell_versions"
+  )
+
+  [[ -f "$provider" ]] || die "Required package content missing: packages/core-backend/dist/src/db/migration-provider.js"
+  [[ -d "$dist_dir" ]] || die "Required package content missing: packages/core-backend/dist/src/db/migrations"
+  [[ -d "$source_dir" ]] || die "Required package content missing: packages/core-backend/src/db/migrations"
+  [[ -d "$legacy_sql_dir" ]] || die "Required package content missing: packages/core-backend/migrations"
+
+  search_fixed_string 'MIGRATION_INCLUDE_SUPERSEDED_LEGACY_SQL' "$provider" \
+    || die "migration-provider.js must expose the superseded legacy SQL opt-in"
+  search_fixed_string '032_create_approval_records' "$provider" \
+    || die "migration-provider.js must carry the superseded legacy SQL skip list"
+
+  [[ -f "${source_dir}/20250925_create_view_tables.sql" ]] \
+    || die "Source SQL migration missing from package: 20250925_create_view_tables.sql"
+  [[ -f "${source_dir}/20250926_create_audit_tables.sql" ]] \
+    || die "Source SQL migration missing from package: 20250926_create_audit_tables.sql"
+  [[ -f "${legacy_sql_dir}/056_add_users_must_change_password.sql" ]] \
+    || die "Legacy SQL migration missing from package: 056_add_users_must_change_password.sql"
+
+  local migration_name
+  for migration_name in "${required_upgrade_migrations[@]}"; do
+    [[ -f "${source_dir}/${migration_name}.ts" ]] \
+      || die "Required upgraded-database migration missing from source set: ${migration_name}.ts"
+    [[ -f "${dist_dir}/${migration_name}.js" ]] \
+      || die "Required upgraded-database migration missing from dist set: ${migration_name}.js"
+  done
+
+  local missing_compiled=""
+  local source_file
+  while IFS= read -r source_file; do
+    migration_name="$(basename "$source_file" .ts)"
+    if [[ ! -f "${dist_dir}/${migration_name}.js" ]]; then
+      missing_compiled+="${migration_name}"$'\n'
+    fi
+  done < <(find "$source_dir" -maxdepth 1 -type f -name '*.ts' ! -name '_*' | sort)
+
+  if [[ -n "$missing_compiled" ]]; then
+    echo "$missing_compiled" >&2
+    die "Package missing compiled JS for one or more core backend TS migrations"
+  fi
+}
+
 function verify_no_github_links() {
   local root="$1"
   local patterns='github\.com|githubusercontent\.com|github\.io'
@@ -205,7 +256,15 @@ required=(
   "apps/web/package.json"
   "packages/core-backend/dist/src/index.js"
   "packages/core-backend/dist/src/db/migrate.js"
+  "packages/core-backend/dist/src/db/migration-provider.js"
   "packages/core-backend/package.json"
+  "packages/core-backend/src/db/migrations/20250925_create_view_tables.sql"
+  "packages/core-backend/src/db/migrations/20250926_create_audit_tables.sql"
+  "packages/core-backend/src/db/migrations/zzzz20260318123000_formalize_meta_comments.ts"
+  "packages/core-backend/src/db/migrations/zzzz20260320150000_add_spreadsheet_permissions_and_cell_versions.ts"
+  "packages/core-backend/dist/src/db/migrations/zzzz20260318123000_formalize_meta_comments.js"
+  "packages/core-backend/dist/src/db/migrations/zzzz20260320150000_add_spreadsheet_permissions_and_cell_versions.js"
+  "packages/core-backend/migrations/056_add_users_must_change_password.sql"
   "plugins/plugin-attendance/plugin.json"
   "plugins/plugin-attendance/index.cjs"
   "scripts/ops/attendance-onprem-start-pm2.ps1"
@@ -254,6 +313,7 @@ fi
 verify_onprem_env_templates "$pkg_root"
 verify_workspace_manifest "$pkg_root"
 verify_web_dist_publish_entrypoints "$pkg_root"
+verify_core_backend_migration_set "$pkg_root"
 
 if search_extended_regex 'VITE_API_(URL|BASE):"http://(127\.0\.0\.1|localhost)' "${pkg_root}/apps/web/dist"; then
   die "Frontend bundle embeds loopback VITE_API_* config; rebuild package with isolated web env"


### PR DESCRIPTION
## Summary
- include core backend source SQL and legacy migration directories in the attendance on-prem package
- require package verify to prove issue #1907 upgraded-database migrations exist in both source and compiled dist sets
- add synthetic package tests for good, missing required migration, and source/dist parity cases

Closes #1907

## Verification
- bash -n scripts/ops/attendance-onprem-package-build.sh scripts/ops/attendance-onprem-package-verify.sh
- node --test scripts/ops/attendance-onprem-package-verify-migrations.test.mjs
- git diff --check