### PR TITLE
fix(attendance-import): normalize CSV template columns

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -5479,6 +5479,7 @@ import {
   type CalendarPolicyOverrideWire,
 } from './attendance/attendanceCalendarPolicyOverrides'
 import { useAttendanceAdminImportBatches } from './attendance/useAttendanceAdminImportBatches'
+import { normalizeImportPayloadColumns } from './attendance/attendanceImportPayload'
 import {
   buildRuleSetPreviewRecommendations,
   summarizeRuleSetPreviewResult,
@@ -10746,6 +10747,7 @@ function buildImportPayload(): Record<string, any> | null {
   }
   payload.mode = importMode.value || payload.mode || 'override'
   if (payload.mappingProfileId === '') delete payload.mappingProfileId
+  normalizeImportPayloadColumns(payload)
   return payload
 }
 

--- a/apps/web/src/views/attendance/attendanceImportPayload.ts
+++ b/apps/web/src/views/attendance/attendanceImportPayload.ts
@@ -1,0 +1,69 @@
+export type AttendanceImportPayload = Record<string, any>
+export type AttendanceImportPayloadColumn = Record<string, unknown>
+
+const IMPORT_COLUMN_ID_KEYS = [
+  'id',
+  'column_id',
+  'columnId',
+  'key',
+  'name',
+  'header',
+  'sourceField',
+  'source',
+  'field',
+  'label',
+]
+
+const IMPORT_COLUMN_NAME_KEYS = [
+  'name',
+  'header',
+  'sourceField',
+  'source',
+  'field',
+  'key',
+  'label',
+]
+
+function firstNonEmptyField(
+  source: Record<string, unknown>,
+  keys: string[],
+): unknown {
+  for (const key of keys) {
+    const value = source[key]
+    if (String(value ?? '').trim()) return value
+  }
+  return undefined
+}
+
+export function normalizeImportPayloadColumn(column: unknown): AttendanceImportPayloadColumn | null {
+  if (typeof column === 'string' || typeof column === 'number') {
+    const text = String(column).trim()
+    if (!text) return null
+    return {
+      id: column,
+      name: text,
+    }
+  }
+
+  if (!column || typeof column !== 'object' || Array.isArray(column)) return null
+  const source = column as Record<string, unknown>
+  const id = firstNonEmptyField(source, IMPORT_COLUMN_ID_KEYS)
+  if (id === undefined) return null
+
+  const normalized: AttendanceImportPayloadColumn = {
+    ...source,
+    id,
+  }
+  if (typeof normalized.name !== 'string' || !normalized.name.trim()) {
+    const name = firstNonEmptyField(source, IMPORT_COLUMN_NAME_KEYS)
+    if (name !== undefined) normalized.name = String(name).trim()
+  }
+  return normalized
+}
+
+export function normalizeImportPayloadColumns(payload: AttendanceImportPayload) {
+  if (!Array.isArray(payload.columns)) return
+  payload.columns = payload.columns
+    .map(normalizeImportPayloadColumn)
+    .filter((column): column is AttendanceImportPayloadColumn => Boolean(column))
+}

--- a/apps/web/src/views/attendance/useAttendanceAdminImportWorkflow.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminImportWorkflow.ts
@@ -1,5 +1,6 @@
 import { computed, reactive, ref, watch, type Ref } from 'vue'
 import { apiFetch as baseApiFetch } from '../../utils/api'
+import { normalizeImportPayloadColumns } from './attendanceImportPayload'
 
 type ApiFetchFn = typeof baseApiFetch
 type Translate = (en: string, zh: string) => string
@@ -1174,6 +1175,7 @@ export function useAttendanceAdminImportWorkflow({
     }
     payload.mode = importMode.value || payload.mode || 'override'
     if (payload.mappingProfileId === '') delete payload.mappingProfileId
+    normalizeImportPayloadColumns(payload)
     return payload
   }
 

--- a/apps/web/tests/attendance-import-preview-regression.spec.ts
+++ b/apps/web/tests/attendance-import-preview-regression.spec.ts
@@ -181,4 +181,72 @@ describe('Attendance import preview regression', () => {
     expect(unwrapRef<string[]>(setupState.importCsvWarnings)).toEqual([])
     expect(unwrapRef<Record<string, unknown> | null>(setupState.statusMeta)?.action).toBe('retry-preview-import')
   })
+
+  it('normalizes string CSV template columns before preview submit', async () => {
+    const apiFetchMock = vi.mocked(apiFetch)
+    let previewPayload: Record<string, any> | null = null
+
+    apiFetchMock.mockImplementation(async (path: string, init?: RequestInit) => {
+      const url = String(path)
+      if (url.startsWith('/api/attendance/import/prepare')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            commitToken: 'token-columns',
+            expiresAt: '2099-01-01T00:00:00.000Z',
+          },
+        })
+      }
+
+      if (url.startsWith('/api/attendance/import/preview')) {
+        previewPayload = JSON.parse(String(init?.body ?? '{}'))
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [],
+            csvWarnings: [],
+            groupWarnings: [],
+            rowCount: 1,
+          },
+        })
+      }
+
+      return jsonResponse(200, {
+        ok: true,
+        data: {
+          items: [],
+          summary: null,
+        },
+      })
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    const vm = app.mount(container!)
+    await flushUi(6)
+
+    const setupState = (vm as any).$?.setupState as Record<string, any>
+    setupState.importForm.payload = JSON.stringify({
+      source: 'dingtalk_csv',
+      columns: ['日期', 'UserId', '考勤组'],
+      csvText: '日期,UserId,考勤组\n2026-03-12,u-1,白班\n',
+    }, null, 2)
+    await flushUi(2)
+
+    const importSection = findImportSection(container!)
+    findButton(importSection, 'Preview').click()
+    await flushUi(6)
+
+    expect(previewPayload?.columns).toEqual([
+      { id: '日期', name: '日期' },
+      { id: 'UserId', name: 'UserId' },
+      { id: '考勤组', name: '考勤组' },
+    ])
+    expect(previewPayload?.csvText).toBe('日期,UserId,考勤组\n2026-03-12,u-1,白班\n')
+    expect(apiFetchMock).toHaveBeenCalledWith(
+      '/api/attendance/import/preview',
+      expect.objectContaining({
+        method: 'POST',
+      }),
+    )
+  })
 })

--- a/apps/web/tests/useAttendanceAdminImportWorkflow.spec.ts
+++ b/apps/web/tests/useAttendanceAdminImportWorkflow.spec.ts
@@ -391,7 +391,10 @@ describe('useAttendanceAdminImportWorkflow', () => {
     const { workflow, apiFetch, setStatus } = createWorkflow({ readFileText })
     const file = new File(['userId,workDate\nu-1,2026-03-12\n'], 'attendance.csv', { type: 'text/csv' })
 
-    workflow.importForm.payload = JSON.stringify({ source: 'manual' }, null, 2)
+    workflow.importForm.payload = JSON.stringify({
+      source: 'manual',
+      columns: ['userId', { id: '', name: 'workDate' }],
+    }, null, 2)
     workflow.importMode.value = 'override'
     workflow.setImportCsvFile(file)
 
@@ -405,6 +408,10 @@ describe('useAttendanceAdminImportWorkflow', () => {
     expect(payload.source).toBe('manual')
     expect(payload.mode).toBe('override')
     expect(payload.csvFileId).toBeUndefined()
+    expect(workflow.buildImportPayload()?.columns).toEqual([
+      { id: 'userId', name: 'userId' },
+      { id: 'workDate', name: 'workDate' },
+    ])
     expect(workflow.importPayloadRowCountHint.value).toBe(1)
     expect(workflow.importPreviewLane.value).toBe('sync')
     expect(workflow.importCommitLane.value).toBe('sync')


### PR DESCRIPTION
## Summary
- normalize string/number `columns` entries into `{ id, name }` objects before attendance import preview/commit payloads are submitted
- apply the same guard to the legacy AttendanceView path and the extracted admin import workflow
- add regression coverage for `/attendance?tab=import` preview payloads generated from CSV template columns

Closes #1918

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/useAttendanceAdminImportWorkflow.spec.ts tests/attendance-import-preview-regression.spec.ts --watch=false
- git diff --check