### PR TITLE
fix(attendance): prevent shell nav label wrapping

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -243,6 +243,7 @@ html, body {
   display: flex;
   align-items: center;
   justify-content: space-between;
+  gap: 12px;
   padding: 0 20px;
   height: 50px;
   background: #fff;
@@ -253,6 +254,7 @@ html, body {
 .nav-brand {
   display: flex;
   align-items: center;
+  flex: 0 0 auto;
   gap: 10px;
 }
 
@@ -260,28 +262,47 @@ html, body {
   font-size: 18px;
   font-weight: 600;
   color: #1976d2;
+  white-space: nowrap;
 }
 
 .nav-links {
   display: flex;
+  flex: 1 1 auto;
   gap: 8px;
+  min-width: 0;
+  overflow-x: auto;
+  overscroll-behavior-x: contain;
+  scrollbar-width: none;
+}
+
+.nav-links::-webkit-scrollbar {
+  display: none;
 }
 
 .nav-actions {
   display: flex;
   align-items: center;
+  flex: 0 1 auto;
   gap: 12px;
+  min-width: 0;
 }
 
 .nav-user {
   color: #6b7280;
   font-size: 13px;
+  max-width: clamp(120px, 18vw, 260px);
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
 }
 
 .nav-locale {
   display: inline-flex;
   align-items: center;
+  flex: 0 0 auto;
   gap: 6px;
+  white-space: nowrap;
 }
 
 .nav-locale__label {
@@ -298,11 +319,16 @@ html, body {
 }
 
 .nav-link {
+  display: inline-flex;
+  align-items: center;
+  flex: 0 0 auto;
+  line-height: 1.2;
   padding: 8px 16px;
   text-decoration: none;
   color: #666;
   border-radius: 4px;
   transition: all 0.2s;
+  white-space: nowrap;
 }
 
 .nav-link--button {
@@ -352,6 +378,7 @@ html, body {
 
   .nav-user {
     width: 100%;
+    max-width: 100%;
   }
 
   .nav-link {

--- a/apps/web/tests/platform-shell-nav.spec.ts
+++ b/apps/web/tests/platform-shell-nav.spec.ts
@@ -1,5 +1,6 @@
 import { afterEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick, ref, type App as VueApp, type Component } from 'vue'
+import { existsSync } from 'node:fs'
 import { readFile } from 'node:fs/promises'
 import { resolve } from 'node:path'
 
@@ -8,6 +9,14 @@ async function flushUi(cycles = 4): Promise<void> {
     await Promise.resolve()
     await nextTick()
   }
+}
+
+function resolveWebFile(relativePath: string): string {
+  const candidates = [
+    resolve(process.cwd(), relativePath),
+    resolve(process.cwd(), 'apps/web', relativePath),
+  ]
+  return candidates.find((candidate) => existsSync(candidate)) ?? candidates[0]
 }
 
 describe('platform shell navigation', () => {
@@ -207,8 +216,24 @@ describe('platform shell navigation', () => {
     expect(links.some((link) => link.href === '/admin/users')).toBe(false)
   })
 
+  it('keeps platform shell nav labels from wrapping vertically on desktop', async () => {
+    const source = await readFile(resolveWebFile('src/App.vue'), 'utf8')
+    const style = source.match(/<style>([\s\S]*?)<\/style>/)?.[1] ?? ''
+    const navLinksRule = style.match(/\.nav-links\s*\{([^}]+)\}/)?.[1] ?? ''
+    const navLinkRule = style.match(/\.nav-link\s*\{([^}]+)\}/)?.[1] ?? ''
+    const navUserRule = style.match(/\.nav-user\s*\{([^}]+)\}/)?.[1] ?? ''
+
+    expect(navLinksRule).toMatch(/flex:\s*1 1 auto/)
+    expect(navLinksRule).toMatch(/min-width:\s*0/)
+    expect(navLinksRule).toMatch(/overflow-x:\s*auto/)
+    expect(navLinkRule).toMatch(/flex:\s*0 0 auto/)
+    expect(navLinkRule).toMatch(/white-space:\s*nowrap/)
+    expect(navUserRule).toMatch(/text-overflow:\s*ellipsis/)
+    expect(navUserRule).toMatch(/white-space:\s*nowrap/)
+  })
+
   it('marks legacy table/view routes as deprecated while keeping deep links registered', async () => {
-    const source = await readFile(resolve(process.cwd(), 'src/router/appRoutes.ts'), 'utf8')
+    const source = await readFile(resolveWebFile('src/router/appRoutes.ts'), 'utf8')
     const deprecatedPaths = ['/kanban', '/calendar', '/gallery', '/form']
 
     for (const path of deprecatedPaths) {
@@ -220,7 +245,7 @@ describe('platform shell navigation', () => {
   })
 
   it('redirects /grid to /multitable as part of Grid retirement (Phase B)', async () => {
-    const source = await readFile(resolve(process.cwd(), 'src/router/appRoutes.ts'), 'utf8')
+    const source = await readFile(resolveWebFile('src/router/appRoutes.ts'), 'utf8')
     const gridRedirectPattern = /path:\s*'\/grid'[\s\S]*?redirect:\s*'\/multitable'[\s\S]*?deprecated:\s*true/
     expect(source, 'Expected /grid to redirect to /multitable with deprecated meta').toMatch(gridRedirectPattern)
     // GridView.vue and its formula engine have been removed; the route must not import them
@@ -228,7 +253,7 @@ describe('platform shell navigation', () => {
   })
 
   it('keeps a dedicated approvals route in the platform shell', async () => {
-    const source = await readFile(resolve(process.cwd(), 'src/router/appRoutes.ts'), 'utf8')
+    const source = await readFile(resolveWebFile('src/router/appRoutes.ts'), 'utf8')
 
     expect(source).toContain("path: '/approvals'")
     expect(source).toContain("import('../views/approval/ApprovalCenterView.vue')")


### PR DESCRIPTION
## Summary
- keep platform shell nav labels and the signed-in email on one line
- let the primary nav strip scroll horizontally when the desktop shell is crowded
- add a regression test so the nav CSS keeps nowrap/overflow behavior

Fixes #1920.

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/platform-shell-nav.spec.ts --watch=false
- git diff --check
- Browser computed-layout check at local 127.0.0.1 fixture: wrappedItems=[]; nav height=50px; nav link strip overflow-x=auto at 1280px viewport
