### PR TITLE
fix(onprem): harden Windows SYSTEM deploy path

### DIFF
--- a/scripts/ops/attendance-onprem-start-pm2.ps1
+++ b/scripts/ops/attendance-onprem-start-pm2.ps1
@@ -68,6 +68,122 @@ function Import-AppEnvFile {
   }
 }
 
+function Add-PathEntryIfExists {
+  param([string]$PathEntry)
+
+  if ([string]::IsNullOrWhiteSpace($PathEntry) -or -not (Test-Path -LiteralPath $PathEntry)) {
+    return
+  }
+
+  $currentPath = [Environment]::GetEnvironmentVariable('PATH', 'Process')
+  $entries = @()
+  if (-not [string]::IsNullOrWhiteSpace($currentPath)) {
+    $entries = @($currentPath -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+  }
+
+  $alreadyPresent = $false
+  foreach ($entry in $entries) {
+    if ($entry.TrimEnd('\') -ieq $PathEntry.TrimEnd('\')) {
+      $alreadyPresent = $true
+      break
+    }
+  }
+
+  if (-not $alreadyPresent) {
+    $env:PATH = if ([string]::IsNullOrWhiteSpace($currentPath)) { $PathEntry } else { "$PathEntry;$currentPath" }
+  }
+}
+
+function Get-WindowsToolPathCandidates {
+  $candidates = @()
+  $programFiles = [Environment]::GetEnvironmentVariable('ProgramFiles')
+  $programFilesX86 = [Environment]::GetEnvironmentVariable('ProgramFiles(x86)')
+
+  foreach ($base in @($programFiles, $programFilesX86, 'C:\Program Files', 'C:\Program Files (x86)')) {
+    if (-not [string]::IsNullOrWhiteSpace($base)) {
+      $candidates += (Join-Path $base 'nodejs')
+    }
+  }
+
+  $npmBases = @($env:APPDATA, 'C:\Users\Administrator\AppData\Roaming')
+  if (-not [string]::IsNullOrWhiteSpace($env:USERPROFILE)) {
+    $npmBases += (Join-Path $env:USERPROFILE 'AppData\Roaming')
+  }
+
+  foreach ($base in $npmBases) {
+    if (-not [string]::IsNullOrWhiteSpace($base)) {
+      $candidates += (Join-Path $base 'npm')
+    }
+  }
+
+  $systemRoot = if ([string]::IsNullOrWhiteSpace($env:SystemRoot)) { 'C:\Windows' } else { $env:SystemRoot }
+  $candidates += @(
+    (Join-Path $systemRoot 'System32'),
+    $systemRoot
+  )
+
+  return $candidates | Select-Object -Unique
+}
+
+function Initialize-WindowsSystemToolPath {
+  if ([System.Environment]::OSVersion.Platform -ne [System.PlatformID]::Win32NT) {
+    return
+  }
+
+  foreach ($candidate in Get-WindowsToolPathCandidates) {
+    Add-PathEntryIfExists -PathEntry $candidate
+  }
+}
+
+function Set-EnvIfMissing {
+  param(
+    [string]$Name,
+    [string]$Value
+  )
+
+  if ([string]::IsNullOrWhiteSpace($Value)) {
+    return
+  }
+
+  $current = [Environment]::GetEnvironmentVariable($Name, 'Process')
+  if ([string]::IsNullOrWhiteSpace($current)) {
+    Set-Item -Path ("Env:{0}" -f $Name) -Value $Value
+  }
+}
+
+function Initialize-WindowsSystemProfileEnv {
+  if ([System.Environment]::OSVersion.Platform -ne [System.PlatformID]::Win32NT) {
+    return
+  }
+
+  $systemRoot = if ([string]::IsNullOrWhiteSpace($env:SystemRoot)) { 'C:\Windows' } else { $env:SystemRoot }
+  $systemProfile = Join-Path $systemRoot 'System32\config\systemprofile'
+  $profileRoot = if ([string]::IsNullOrWhiteSpace($env:USERPROFILE)) { $systemProfile } else { $env:USERPROFILE }
+  New-Item -ItemType Directory -Force -Path $profileRoot | Out-Null
+
+  Set-EnvIfMissing -Name 'USERPROFILE' -Value $profileRoot
+  Set-EnvIfMissing -Name 'HOME' -Value $profileRoot
+
+  $pathRoot = [System.IO.Path]::GetPathRoot($profileRoot)
+  if (-not [string]::IsNullOrWhiteSpace($pathRoot)) {
+    $homeDrive = $pathRoot.TrimEnd('\')
+    $homePath = $profileRoot.Substring($homeDrive.Length)
+    if (-not $homePath.StartsWith('\')) {
+      $homePath = '\' + $homePath
+    }
+    Set-EnvIfMissing -Name 'HOMEDRIVE' -Value $homeDrive
+    Set-EnvIfMissing -Name 'HOMEPATH' -Value $homePath
+  }
+
+  $pm2Home = if ([string]::IsNullOrWhiteSpace($env:PM2_HOME)) {
+    Join-Path $profileRoot '.pm2'
+  } else {
+    $env:PM2_HOME
+  }
+  New-Item -ItemType Directory -Force -Path $pm2Home | Out-Null
+  Set-EnvIfMissing -Name 'PM2_HOME' -Value $pm2Home
+}
+
 function Resolve-Pm2Command {
   param([string]$BaseDir)
 
@@ -79,8 +195,83 @@ function Resolve-Pm2Command {
   return 'pm2'
 }
 
+function ConvertTo-ComparablePath {
+  param([string]$Candidate)
+
+  if ([string]::IsNullOrWhiteSpace($Candidate)) {
+    return ''
+  }
+
+  try {
+    return ([System.IO.Path]::GetFullPath($Candidate).TrimEnd('\')).ToLowerInvariant()
+  }
+  catch {
+    return $Candidate.Trim().TrimEnd('\').ToLowerInvariant()
+  }
+}
+
+function Get-Pm2AppProcess {
+  param(
+    [string]$Pm2Command,
+    [string]$AppName
+  )
+
+  $jsonLines = & $Pm2Command jlist 2>$null
+  if ($LASTEXITCODE -ne 0) {
+    return $null
+  }
+
+  $json = ($jsonLines | Out-String).Trim()
+  if ([string]::IsNullOrWhiteSpace($json)) {
+    return $null
+  }
+
+  try {
+    $apps = $json | ConvertFrom-Json
+    return @($apps) | Where-Object { $_.name -eq $AppName } | Select-Object -First 1
+  }
+  catch {
+    return $null
+  }
+}
+
+function Test-Pm2AppMatchesTarget {
+  param(
+    [object]$App,
+    [string]$ExpectedScriptPath,
+    [string]$ExpectedCwd
+  )
+
+  if ($null -eq $App -or $null -eq $App.pm2_env) {
+    return $false
+  }
+
+  $actualScriptPath = ConvertTo-ComparablePath -Candidate ([string]$App.pm2_env.pm_exec_path)
+  $actualCwd = ConvertTo-ComparablePath -Candidate ([string]$App.pm2_env.pm_cwd)
+  $expectedScript = ConvertTo-ComparablePath -Candidate $ExpectedScriptPath
+  $expectedRoot = ConvertTo-ComparablePath -Candidate $ExpectedCwd
+
+  return $actualScriptPath -eq $expectedScript -and $actualCwd -eq $expectedRoot
+}
+
+function Start-Pm2App {
+  param(
+    [string]$Pm2Command,
+    [string]$ConfigPath,
+    [string]$AppName,
+    [string]$EnvName
+  )
+
+  & $Pm2Command start $ConfigPath --only $AppName --env $EnvName --update-env
+  if ($LASTEXITCODE -ne 0) {
+    throw "pm2 start failed for $AppName"
+  }
+}
+
 $envFile = Resolve-AppEnvFile -BaseDir $resolvedRoot
 Import-AppEnvFile -EnvFile $envFile
+Initialize-WindowsSystemToolPath
+Initialize-WindowsSystemProfileEnv
 
 $ecosystemConfig = Join-Path $resolvedRoot 'ecosystem.config.cjs'
 if (-not (Test-Path $ecosystemConfig)) {
@@ -90,18 +281,36 @@ if (-not (Test-Path $ecosystemConfig)) {
 New-Item -ItemType Directory -Force -Path (Join-Path $resolvedRoot 'output\logs') | Out-Null
 
 $pm2Command = Resolve-Pm2Command -BaseDir $resolvedRoot
+$expectedScriptPath = Join-Path $resolvedRoot 'packages\core-backend\dist\src\index.js'
+$existingApp = Get-Pm2AppProcess -Pm2Command $pm2Command -AppName $Pm2AppName
 
-& $pm2Command describe $Pm2AppName *> $null
-if ($LASTEXITCODE -eq 0) {
-  & $pm2Command restart $Pm2AppName --update-env
-  if ($LASTEXITCODE -ne 0) {
-    throw "pm2 restart failed for $Pm2AppName"
+if ($null -ne $existingApp) {
+  if (Test-Pm2AppMatchesTarget -App $existingApp -ExpectedScriptPath $expectedScriptPath -ExpectedCwd $resolvedRoot) {
+    & $pm2Command restart $Pm2AppName --update-env
+    if ($LASTEXITCODE -ne 0) {
+      throw "pm2 restart failed for $Pm2AppName"
+    }
+  }
+  else {
+    Write-Host "[attendance-onprem-start-pm2] deleting stale pm2 app definition for $Pm2AppName before start"
+    & $pm2Command delete $Pm2AppName
+    if ($LASTEXITCODE -ne 0) {
+      throw "pm2 delete failed for stale $Pm2AppName"
+    }
+    Start-Pm2App -Pm2Command $pm2Command -ConfigPath $ecosystemConfig -AppName $Pm2AppName -EnvName $Pm2Env
   }
 }
 else {
-  & $pm2Command start $ecosystemConfig --only $Pm2AppName --env $Pm2Env --update-env
+  & $pm2Command describe $Pm2AppName *> $null
   if ($LASTEXITCODE -ne 0) {
-    throw "pm2 start failed for $Pm2AppName"
+    Start-Pm2App -Pm2Command $pm2Command -ConfigPath $ecosystemConfig -AppName $Pm2AppName -EnvName $Pm2Env
+  }
+  else {
+    Write-Host "[attendance-onprem-start-pm2] pm2 jlist did not return $Pm2AppName; falling back to restart"
+    & $pm2Command restart $Pm2AppName --update-env
+    if ($LASTEXITCODE -ne 0) {
+      throw "pm2 restart failed for $Pm2AppName"
+    }
   }
 }
 

--- a/scripts/ops/multitable-onprem-apply-package.ps1
+++ b/scripts/ops/multitable-onprem-apply-package.ps1
@@ -105,6 +105,73 @@ function Require-Command {
   }
 }
 
+function Add-PathEntryIfExists {
+  param([string]$PathEntry)
+
+  if ([string]::IsNullOrWhiteSpace($PathEntry) -or -not (Test-Path -LiteralPath $PathEntry)) {
+    return
+  }
+
+  $currentPath = [Environment]::GetEnvironmentVariable('PATH', 'Process')
+  $entries = @()
+  if (-not [string]::IsNullOrWhiteSpace($currentPath)) {
+    $entries = @($currentPath -split ';' | Where-Object { -not [string]::IsNullOrWhiteSpace($_) })
+  }
+
+  $alreadyPresent = $false
+  foreach ($entry in $entries) {
+    if ($entry.TrimEnd('\') -ieq $PathEntry.TrimEnd('\')) {
+      $alreadyPresent = $true
+      break
+    }
+  }
+
+  if (-not $alreadyPresent) {
+    $env:PATH = if ([string]::IsNullOrWhiteSpace($currentPath)) { $PathEntry } else { "$PathEntry;$currentPath" }
+  }
+}
+
+function Get-WindowsToolPathCandidates {
+  $candidates = @()
+  $programFiles = [Environment]::GetEnvironmentVariable('ProgramFiles')
+  $programFilesX86 = [Environment]::GetEnvironmentVariable('ProgramFiles(x86)')
+
+  foreach ($base in @($programFiles, $programFilesX86, 'C:\Program Files', 'C:\Program Files (x86)')) {
+    if (-not [string]::IsNullOrWhiteSpace($base)) {
+      $candidates += (Join-Path $base 'nodejs')
+    }
+  }
+
+  $npmBases = @($env:APPDATA, 'C:\Users\Administrator\AppData\Roaming')
+  if (-not [string]::IsNullOrWhiteSpace($env:USERPROFILE)) {
+    $npmBases += (Join-Path $env:USERPROFILE 'AppData\Roaming')
+  }
+
+  foreach ($base in $npmBases) {
+    if (-not [string]::IsNullOrWhiteSpace($base)) {
+      $candidates += (Join-Path $base 'npm')
+    }
+  }
+
+  $systemRoot = if ([string]::IsNullOrWhiteSpace($env:SystemRoot)) { 'C:\Windows' } else { $env:SystemRoot }
+  $candidates += @(
+    (Join-Path $systemRoot 'System32'),
+    $systemRoot
+  )
+
+  return $candidates | Select-Object -Unique
+}
+
+function Initialize-WindowsSystemToolPath {
+  if ([System.Environment]::OSVersion.Platform -ne [System.PlatformID]::Win32NT) {
+    return
+  }
+
+  foreach ($candidate in Get-WindowsToolPathCandidates) {
+    Add-PathEntryIfExists -PathEntry $candidate
+  }
+}
+
 function Resolve-CommandPath {
   param([string]$Name)
 
@@ -117,6 +184,15 @@ function Resolve-CommandPath {
 }
 
 function Resolve-PnpmInstallCommand {
+  foreach ($dir in Get-WindowsToolPathCandidates) {
+    foreach ($leaf in @('pnpm.exe', 'pnpm.cmd', 'pnpm.ps1')) {
+      $candidate = Join-Path $dir $leaf
+      if (Test-Path -LiteralPath $candidate) {
+        return $candidate
+      }
+    }
+  }
+
   $cmdCommand = Get-Command 'pnpm.cmd' -ErrorAction SilentlyContinue | Select-Object -First 1
   if ($cmdCommand -and -not [string]::IsNullOrWhiteSpace($cmdCommand.Source)) {
     return $cmdCommand.Source
@@ -447,6 +523,8 @@ if (-not (Test-Path -LiteralPath $resolvedEnvFile)) {
 $importedEnvCount = Import-AppEnvFile -EnvFile $resolvedEnvFile
 Write-Info ("Loaded env from {0} ({1} variables); migration / restart / healthcheck will inherit DATABASE_URL and JWT_SECRET when present in that file" -f $resolvedEnvFile, $importedEnvCount)
 
+Initialize-WindowsSystemToolPath
+
 $outputLogs = Join-Path $resolvedRoot 'output\logs'
 New-Item -ItemType Directory -Force -Path $outputLogs | Out-Null
 $extractRoot = New-ShortTempDirectory -Prefix 'mspa'
@@ -470,8 +548,8 @@ try {
   Set-Location $resolvedRoot
 
   Require-Command -Name 'node'
-  $pnpmPath = Resolve-CommandPath -Name 'pnpm'
   $pnpmInstallPath = Resolve-PnpmInstallCommand
+  $pnpmPath = $pnpmInstallPath
 
   if ($InstallDeps -ne '0') {
     $dependencyTimeoutSec = Convert-PositiveInt -Value $DependencyRefreshTimeoutSec -Label 'DependencyRefreshTimeoutSec'

--- a/scripts/ops/onprem-windows-system-hardening.test.mjs
+++ b/scripts/ops/onprem-windows-system-hardening.test.mjs
@@ -1,0 +1,52 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(fileURLToPath(new URL('../..', import.meta.url)))
+
+function readScript(relativePath) {
+  return fs.readFileSync(path.join(repoRoot, relativePath), 'utf8')
+}
+
+test('Windows apply helper bootstraps SYSTEM-safe tool PATH and resolves pnpm from common locations', () => {
+  const script = readScript('scripts/ops/multitable-onprem-apply-package.ps1')
+
+  assert.match(script, /function Initialize-WindowsSystemToolPath/)
+  assert.match(script, /C:\\Users\\Administrator\\AppData\\Roaming/)
+  assert.match(script, /Join-Path \$base 'nodejs'/)
+  assert.match(script, /foreach \(\$leaf in @\('pnpm\.exe', 'pnpm\.cmd', 'pnpm\.ps1'\)\)/)
+  assert.match(script, /Initialize-WindowsSystemToolPath/)
+  assert.match(script, /\$pnpmInstallPath = Resolve-PnpmInstallCommand/)
+  assert.match(script, /\$pnpmPath = \$pnpmInstallPath/)
+})
+
+test('PM2 startup helper initializes SYSTEM profile env before invoking PM2', () => {
+  const script = readScript('scripts/ops/attendance-onprem-start-pm2.ps1')
+
+  assert.match(script, /function Initialize-WindowsSystemProfileEnv/)
+  assert.match(script, /Set-EnvIfMissing -Name 'USERPROFILE'/)
+  assert.match(script, /Set-EnvIfMissing -Name 'HOME'/)
+  assert.match(script, /Set-EnvIfMissing -Name 'HOMEPATH'/)
+  assert.match(script, /Set-EnvIfMissing -Name 'PM2_HOME'/)
+  assert.match(script, /\$homeDrive = \$pathRoot\.TrimEnd\('\\'\)/)
+  assert.match(script, /\$homePath = \$profileRoot\.Substring\(\$homeDrive\.Length\)/)
+  assert.match(script, /-not \$homePath\.StartsWith\('\\'\)/)
+  assert.doesNotMatch(script, /\$profileRoot\.Substring\(\$pathRoot\.Length - 1\)/)
+  assert.match(script, /Initialize-WindowsSystemToolPath/)
+  assert.match(script, /Initialize-WindowsSystemProfileEnv/)
+})
+
+test('PM2 startup helper replaces stale app definitions instead of restart-only reuse', () => {
+  const script = readScript('scripts/ops/attendance-onprem-start-pm2.ps1')
+
+  assert.match(script, /function Get-Pm2AppProcess/)
+  assert.match(script, /function Test-Pm2AppMatchesTarget/)
+  assert.match(script, /pm_exec_path/)
+  assert.match(script, /pm_cwd/)
+  assert.match(script, /packages\\core-backend\\dist\\src\\index\.js/)
+  assert.match(script, /deleting stale pm2 app definition/)
+  assert.match(script, /delete \$Pm2AppName/)
+  assert.match(script, /--update-env/)
+})


### PR DESCRIPTION
## Summary
- bootstrap common Windows SYSTEM PATH entries before resolving node/pnpm/tar/cmd helpers
- resolve pnpm from common node/npm install locations, including Administrator npm paths
- initialize HOME/HOMEPATH/USERPROFILE/PM2_HOME before PM2 startup
- replace stale PM2 app definitions when existing pm_exec_path or pm_cwd points at an older package root

Fixes #1916.

## Verification
- node --test scripts/ops/onprem-windows-system-hardening.test.mjs scripts/ops/attendance-onprem-package-verify-migrations.test.mjs
- git diff --check

Note: PowerShell runtime execution was not available on this macOS worker, so verification is static contract coverage plus existing package verifier coverage.
