### PR TITLE
fix(integration): clarify K3 row-level save failures

### DIFF
--- a/docs/development/integration-k3wise-m1-save-row-diagnostic-design-20260527.md
+++ b/docs/development/integration-k3wise-m1-save-row-diagnostic-design-20260527.md
@@ -1,0 +1,40 @@
+# K3 WISE M1 Save Row Diagnostic Design - 2026-05-27
+
+## Purpose
+
+After the second M1 Material Save-only attempt, the live K3 response still failed the row-level success gate while surfacing only the envelope-level message `Successful`. That wording is misleading for the operator: the write did not pass, but the dead letter reads like a success.
+
+This change improves diagnostics only. It does not approve another Save-only attempt and does not change the Save success criteria.
+
+## Scope
+
+- Keep the existing row-level success gate unchanged.
+- When a Save response fails row-level success but the only response message is success-like, replace the dead-letter message with a structural failure summary.
+- Preserve useful K3 validation messages when they exist, such as row-level `FMessage`.
+- Keep diagnostics redacted and structural: row count, successful row count, failed row count, success entity count, envelope status, and envelope message presence.
+
+## Non-goals
+
+- No third M1 Save-only approval.
+- No Submit, Audit, BOM, list/search, pagination, multi-record, production, or direct K3 SQL work.
+- No raw K3 payload persistence.
+- No customer dictionary/default population. The missing `bodyTemplate` / field-mapping configuration remains an operator/customer configuration track.
+
+## Behavior
+
+For a failing Save response:
+
+1. Prefer explicit row-level or configured failure messages.
+2. If the message is success-like, for example `Successful`, synthesize:
+
+```text
+K3 WISE save failed row-level success gate
+```
+
+with bounded structural counts.
+
+This keeps dead letters actionable without exposing raw material identifiers, K3 codes, tokens, endpoint details, or connection strings.
+
+## Boundary
+
+This PR is allowed to touch only the K3 WebAPI adapter diagnostics and its tests. It is not a product-level K3 standardization step. The next live write still requires a separate fresh approval after the entity machine preview proves the customer-profile Material fields are present.

--- a/docs/development/integration-k3wise-m1-save-row-diagnostic-verification-20260527.md
+++ b/docs/development/integration-k3wise-m1-save-row-diagnostic-verification-20260527.md
@@ -1,0 +1,42 @@
+# K3 WISE M1 Save Row Diagnostic Verification - 2026-05-27
+
+## Verification Matrix
+
+| Check | Expected |
+| --- | --- |
+| Existing row-level validation message | Preserved in the dead-letter message |
+| Nested `Data[0].Data` row failure message | Preserved in the dead-letter message |
+| Envelope `Successful` with row failure and no row message | Replaced with row-level success-gate failure summary |
+| Diagnostic redaction boundary | No raw material identifiers, K3 codes, tokens, host, authorityCode, or connection strings added |
+| Save success criteria | Unchanged |
+| Submit/Audit/BOM/list boundaries | Unchanged |
+
+## Local Commands
+
+```bash
+node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+pnpm -F plugin-integration-core test
+```
+
+## Current Result
+
+- `node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`: PASS.
+- `pnpm -F plugin-integration-core test`: PASS.
+
+## Negative Control
+
+The new regression case uses a K3-like response with:
+
+```json
+{
+  "StatusCode": 200,
+  "Message": "Successful",
+  "Data": [{ "FStatus": false, "FItemID": 0 }]
+}
+```
+
+Before the diagnostic change, that path surfaces `Successful` as the row failure message. After the change, the message is a structural row-level success-gate failure summary.
+
+## #1792 Boundary
+
+This verification does not authorize another Save-only attempt. The third M1 attempt remains blocked until customer/operator configuration preview proves the actual Save body includes the reviewed customer-profile fields.

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -87,6 +87,13 @@ function createK3FetchMock() {
           Data: [{ FStatus: false, FItemID: 0, FMessage: 'required unit missing' }],
         })
       }
+      if (record.FNumber === 'AMBIGUOUSFAIL') {
+        return jsonResponse(200, {
+          StatusCode: 200,
+          Message: 'Successful',
+          Data: [{ FStatus: false, FItemID: 0 }],
+        })
+      }
       if (record.FNumber === 'ROWOK') {
         return jsonResponse(200, {
           StatusCode: 200,
@@ -773,12 +780,13 @@ async function testK3WebApiSaveBusinessEvidence() {
       { FNumber: 'ROWOK', FName: 'Positive row' },
       { FNumber: 'ROWFAIL', FName: 'Business row fail' },
       { FNumber: 'STATUS201', FName: 'Envelope fail' },
+      { FNumber: 'AMBIGUOUSFAIL', FName: 'Envelope-success row fail' },
     ],
     keyFields: ['FNumber'],
   })
 
   assert.equal(upsert.written, 1, 'only K3 business-positive row counts as written')
-  assert.equal(upsert.failed, 2, 'K3 row-level failures are counted as failed')
+  assert.equal(upsert.failed, 3, 'K3 row-level failures are counted as failed')
   assert.equal(upsert.results[0].externalId, 1001, 'positive FItemID is surfaced as external id')
   assert.equal(upsert.results[0].responseSummary.success, true)
   assert.equal(upsert.results[0].responseSummary.externalIdPresent, true)
@@ -788,10 +796,15 @@ async function testK3WebApiSaveBusinessEvidence() {
   assert.equal(upsert.errors[0].responseSummary.failedRowCount, 1)
   assert.equal(upsert.errors[1].code, 'K3_WISE_SAVE_FAILED')
   assert.match(upsert.errors[1].message, /required unit/i)
-  assert.equal(upsert.metadata.businessResponses.length, 3)
+  assert.equal(upsert.errors[2].code, 'K3_WISE_SAVE_FAILED')
+  assert.notEqual(upsert.errors[2].message, 'Successful')
+  assert.match(upsert.errors[2].message, /row-level success gate/i)
+  assert.match(upsert.errors[2].message, /failedRowCount=1/)
+  assert.equal(upsert.errors[2].diagnostic.validationMessage, upsert.errors[2].message)
+  assert.equal(upsert.metadata.businessResponses.length, 4)
   assert.deepEqual(
     upsert.metadata.businessResponses.map((summary) => summary.success),
-    [true, false, false],
+    [true, false, false, false],
     'business response summaries preserve one entry per attempted save',
   )
 }

--- a/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs
@@ -94,6 +94,13 @@ function createK3FetchMock() {
           Data: [{ FStatus: false, FItemID: 0 }],
         })
       }
+      if (record.FNumber === 'CHINESENEGFAIL') {
+        return jsonResponse(200, {
+          StatusCode: 200,
+          Message: 'Successful',
+          Data: [{ FStatus: false, FItemID: 0, FMessage: '操作不成功' }],
+        })
+      }
       if (record.FNumber === 'ROWOK') {
         return jsonResponse(200, {
           StatusCode: 200,
@@ -518,6 +525,24 @@ async function testK3WebApiAdapter() {
     Message: 'Successful',
     Data: [{ FStatus: true, FItemID: 1001 }],
   }, {}), true)
+  assert.equal(
+    webApiInternals.responseFailureMessage(
+      { StatusCode: 200, Message: '操作成功', Data: [{ FStatus: false, FItemID: 0 }] },
+      {},
+      { failedRowCount: 1 },
+    ),
+    'K3 WISE save failed row-level success gate (failedRowCount=1)',
+    'Chinese success-like envelope message is synthesized when row-level success fails',
+  )
+  assert.equal(
+    webApiInternals.responseFailureMessage(
+      { StatusCode: 200, Message: '未成功', Data: [{ FStatus: false, FItemID: 0 }] },
+      {},
+      { failedRowCount: 1 },
+    ),
+    '未成功',
+    'Chinese negated-success message is preserved as a real failure message',
+  )
 
   const invalidBaseUrl = (() => {
     try {
@@ -781,12 +806,13 @@ async function testK3WebApiSaveBusinessEvidence() {
       { FNumber: 'ROWFAIL', FName: 'Business row fail' },
       { FNumber: 'STATUS201', FName: 'Envelope fail' },
       { FNumber: 'AMBIGUOUSFAIL', FName: 'Envelope-success row fail' },
+      { FNumber: 'CHINESENEGFAIL', FName: 'Chinese negated success row fail' },
     ],
     keyFields: ['FNumber'],
   })
 
   assert.equal(upsert.written, 1, 'only K3 business-positive row counts as written')
-  assert.equal(upsert.failed, 3, 'K3 row-level failures are counted as failed')
+  assert.equal(upsert.failed, 4, 'K3 row-level failures are counted as failed')
   assert.equal(upsert.results[0].externalId, 1001, 'positive FItemID is surfaced as external id')
   assert.equal(upsert.results[0].responseSummary.success, true)
   assert.equal(upsert.results[0].responseSummary.externalIdPresent, true)
@@ -801,10 +827,13 @@ async function testK3WebApiSaveBusinessEvidence() {
   assert.match(upsert.errors[2].message, /row-level success gate/i)
   assert.match(upsert.errors[2].message, /failedRowCount=1/)
   assert.equal(upsert.errors[2].diagnostic.validationMessage, upsert.errors[2].message)
-  assert.equal(upsert.metadata.businessResponses.length, 4)
+  assert.equal(upsert.errors[3].code, 'K3_WISE_SAVE_FAILED')
+  assert.equal(upsert.errors[3].message, '操作不成功')
+  assert.equal(upsert.errors[3].diagnostic.validationMessage, '操作不成功')
+  assert.equal(upsert.metadata.businessResponses.length, 5)
   assert.deepEqual(
     upsert.metadata.businessResponses.map((summary) => summary.success),
-    [true, false, false, false],
+    [true, false, false, false, false],
     'business response summaries preserve one entry per attempted save',
   )
 }

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -714,8 +714,9 @@ function isSuccessLikeResponseMessage(value) {
   if (typeof value !== 'string') return false
   const normalized = value.trim().toLowerCase()
   if (!normalized) return false
+  const hasChineseSuccess = /成功/.test(normalized) && !/[不未没]\s*成功/.test(normalized)
   return ['success', 'successful', 'succeeded', 'ok'].includes(normalized) ||
-    /成功/.test(normalized)
+    hasChineseSuccess
 }
 
 function responseFailureMessage(data, config, summary, fallback = 'K3 WISE save failed row-level success gate') {

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -710,6 +710,36 @@ function responseMessage(data, config, fallback = 'K3 WISE WebAPI business respo
   )
 }
 
+function isSuccessLikeResponseMessage(value) {
+  if (typeof value !== 'string') return false
+  const normalized = value.trim().toLowerCase()
+  if (!normalized) return false
+  return ['success', 'successful', 'succeeded', 'ok'].includes(normalized) ||
+    /成功/.test(normalized)
+}
+
+function responseFailureMessage(data, config, summary, fallback = 'K3 WISE save failed row-level success gate') {
+  const message = responseMessage(data, config, null)
+  if (message && !isSuccessLikeResponseMessage(message)) return message
+
+  const fields = []
+  if (summary && typeof summary === 'object') {
+    for (const field of [
+      'rowCount',
+      'successfulRowCount',
+      'failedRowCount',
+      'successEntityCount',
+      'envelopeStatusCode',
+      'envelopeMessagePresent',
+    ]) {
+      if (summary[field] !== undefined && summary[field] !== null) {
+        fields.push(`${field}=${summary[field]}`)
+      }
+    }
+  }
+  return fields.length > 0 ? `${fallback} (${fields.join(', ')})` : fallback
+}
+
 function responseCode(data, config, fallback = 'OK') {
   return firstDefined(
     config.responseCodePath ? getPath(data, config.responseCodePath) : undefined,
@@ -1193,7 +1223,7 @@ function createK3WiseWebApiAdapter({ system, fetchImpl = globalThis.fetch, logge
         raw.push({ index, operation: 'save', body: save.data, summary: saveSummary })
         businessResponses.push({ index, object: request.object, ...saveSummary })
         if (!saveSucceeded) {
-          throw new K3WiseWebApiAdapterError(String(responseMessage(save.data, config)), {
+          throw new K3WiseWebApiAdapterError(String(responseFailureMessage(save.data, config, saveSummary)), {
             code: responseFailureCode(save.data, config, 'K3_WISE_SAVE_FAILED'),
             body: save.data,
             responseSummary: saveSummary,
@@ -1348,6 +1378,7 @@ module.exports = {
     responseBillNo,
     responseCode,
     responseExternalId,
+    responseFailureMessage,
     saveBusinessSuccess,
   },
 }


### PR DESCRIPTION
## Summary

Follow-up from #1792 after the second M1 Material Save-only attempt on `d5026a04f` failed safely. The live response surfaced only the envelope-level `Successful` message even though the row-level success gate failed, which makes the dead letter misleading.

This PR changes diagnostics only:

- preserves explicit K3 row-level validation messages when present;
- when a Save response fails row-level success but only has a success-like envelope message, synthesizes a structural row-level failure summary instead of surfacing `Successful`;
- keeps the summary redacted and bounded: row count, successful row count, failed row count, success entity count, envelope status, and envelope message presence;
- leaves Save success criteria unchanged.

## Boundaries

- No third M1 Save-only approval.
- No Submit / Audit / BOM / list/search / pagination / multi-record / production.
- No customer dictionary/default population.
- No raw K3 payload, raw material code, token, authorityCode, host, or connection string exposure.

The #1792 write path remains blocked until the actual Save body preview includes the reviewed customer-profile fields.

## Verification

- `node plugins/plugin-integration-core/__tests__/k3-wise-adapters.test.cjs`
- `pnpm -F plugin-integration-core test`
- `git diff --check`
- Added-line secret-shape sweep: clean

## Notes

The full plugin test in the isolated worktree reused the main checkout dependency symlinks for local execution only; those symlinks were removed before commit.
