### PR TITLE
fix(attendance): link approval center to attendance queue

### DIFF
--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -103,6 +103,20 @@
             全部标记已读
           </el-button>
         </div>
+        <div
+          class="approval-center__attendance-entry"
+          data-testid="attendance-approval-queue-entry"
+        >
+          <div class="approval-center__attendance-entry-copy">
+            <strong>考勤审批</strong>
+            <p>
+              补卡、请假、加班审批当前在考勤模块处理，不计入平台/PLM 待办列表。
+            </p>
+          </div>
+          <el-button type="primary" plain @click="openAttendanceApprovalQueue">
+            待处理考勤审批
+          </el-button>
+        </div>
         <el-table
           v-loading="store.loading"
           :data="store.pendingApprovals"
@@ -445,6 +459,13 @@ function handleRowClick(row: UnifiedApprovalDTO) {
   router.push({ name: 'approval-detail', params: { id: row.id } })
 }
 
+function openAttendanceApprovalQueue() {
+  router.push({
+    name: 'attendance',
+    query: { section: 'attendance-overview-requests' },
+  })
+}
+
 onMounted(() => {
   loadCurrentTab()
   void refreshPendingBadgeCount()
@@ -504,5 +525,41 @@ onMounted(() => {
   display: flex;
   justify-content: flex-end;
   margin-bottom: 12px;
+}
+
+.approval-center__attendance-entry {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  padding: 14px 16px;
+  margin-bottom: 12px;
+  border: 1px solid #dbeafe;
+  border-radius: 8px;
+  background: #eff6ff;
+}
+
+.approval-center__attendance-entry-copy {
+  display: grid;
+  gap: 4px;
+}
+
+.approval-center__attendance-entry-copy strong {
+  color: #1f2937;
+  font-size: 14px;
+}
+
+.approval-center__attendance-entry-copy p {
+  margin: 0;
+  color: #4b5563;
+  font-size: 13px;
+  line-height: 1.5;
+}
+
+@media (max-width: 720px) {
+  .approval-center__attendance-entry {
+    align-items: flex-start;
+    flex-direction: column;
+  }
 }
 </style>

--- a/apps/web/src/views/attendance/AttendanceExperienceView.vue
+++ b/apps/web/src/views/attendance/AttendanceExperienceView.vue
@@ -121,6 +121,11 @@ const desktopOnlyMessage = computed(() => {
   return t.value.adminDesktopHint
 })
 
+const overviewInitialSectionId = computed(() => {
+  const section = Array.isArray(route.query.section) ? route.query.section[0] : route.query.section
+  return section === 'attendance-overview-requests' ? section : ''
+})
+
 function matchesMediaQuery(query: string): boolean {
   try {
     return Boolean(window.matchMedia?.(query)?.matches)
@@ -149,7 +154,7 @@ const activeView = computed(() => {
       return {
         component: AttendanceOverview,
         key: 'attendance-overview',
-        props: {},
+        props: { initialSectionId: overviewInitialSectionId.value },
       }
     case 'reports':
       return {

--- a/apps/web/tests/approval-center.spec.ts
+++ b/apps/web/tests/approval-center.spec.ts
@@ -74,7 +74,10 @@ const ElTabPane = defineComponent({
   name: 'ElTabPane',
   props: { label: String, name: String },
   render() {
-    return h('div', { 'data-tab-pane': this.name, 'data-tab-label': this.label }, this.$slots.default?.())
+    return h('div', { 'data-tab-pane': this.name, 'data-tab-label': this.label }, [
+      this.$slots.label?.(),
+      this.$slots.default?.(),
+    ])
   },
 })
 
@@ -233,10 +236,10 @@ describe('ApprovalCenterView', () => {
     expect(panes.length).toBe(4)
 
     const labels = Array.from(panes).map((p) => p.getAttribute('data-tab-label'))
-    expect(labels).toContain('待我处理')
     expect(labels).toContain('我发起的')
     expect(labels).toContain('抄送我的')
     expect(labels).toContain('已完成')
+    expect(container!.textContent).toContain('待我处理')
   })
 
   it('calls loadPending on mount', async () => {
@@ -281,5 +284,26 @@ describe('ApprovalCenterView', () => {
     await mountView()
     expect(container!.querySelector('[data-el-input]')).toBeTruthy()
     expect(container!.querySelector('[data-el-select]')).toBeTruthy()
+  })
+
+  it('shows the attendance approval queue entry and routes to the attendance requests section', async () => {
+    await mountView()
+
+    const entry = container!.querySelector('[data-testid="attendance-approval-queue-entry"]')
+    expect(entry?.textContent).toContain('考勤审批')
+    expect(entry?.textContent).toContain('待处理考勤审批')
+
+    const button = Array.from(container!.querySelectorAll('button')).find(candidate =>
+      candidate.textContent?.includes('待处理考勤审批'),
+    )
+    expect(button).toBeTruthy()
+
+    button!.click()
+    await flushUi()
+
+    expect(pushSpy).toHaveBeenCalledWith({
+      name: 'attendance',
+      query: { section: 'attendance-overview-requests' },
+    })
   })
 })

--- a/apps/web/tests/attendance-experience-entrypoints.spec.ts
+++ b/apps/web/tests/attendance-experience-entrypoints.spec.ts
@@ -133,6 +133,18 @@ describe('Attendance experience entrypoints', () => {
     expect(adminView?.dataset.section).toBe('attendance-admin-import')
   })
 
+  it('routes the attendance approval queue shortcut into the overview requests section', async () => {
+    routeState.query = { section: 'attendance-overview-requests' }
+
+    app = createApp(AttendanceExperienceView)
+    app.mount(container!)
+    await flushUi()
+
+    const overviewView = container!.querySelector<HTMLElement>('[data-view="overview"]')
+    expect(overviewView).toBeTruthy()
+    expect(overviewView?.dataset.section).toBe('attendance-overview-requests')
+  })
+
   it('routes the reports entrypoint into a dedicated reports view', async () => {
     routeState.query = { tab: 'reports' }
 


### PR DESCRIPTION
## Summary
- add a visible attendance approval queue entry to the Approval Center pending tab
- clarify that missing-punch, leave, and overtime attendance approvals are handled inside the attendance module instead of the platform/PLM approval list
- route the CTA directly to the attendance overview requests section via `section=attendance-overview-requests`

Fixes #1919

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/approval-center.spec.ts tests/attendance-experience-entrypoints.spec.ts --watch=false`
- `pnpm --filter @metasheet/web type-check`
- `git diff --check`

Note: the targeted ApprovalCenterView spec still prints pre-existing Element Plus stub warnings for el-icon/el-badge/el-tooltip; assertions pass.