### PR TITLE
fix(audit): self-heal current audit partition

### DIFF
--- a/docs/development/audit-log-current-month-partition-lifecycle-20260527.md
+++ b/docs/development/audit-log-current-month-partition-lifecycle-20260527.md
@@ -1,0 +1,51 @@
+# audit_logs Current-Month Partition Lifecycle
+
+Date: 2026-05-27
+Issue: #503
+
+## Scope
+
+This note covers the operational lifecycle for the partitioned `audit_logs` table. It does not change attendance strict-gate behavior or the `operation_audit_logs` table used by newer attendance admin routes.
+
+## Expected lifecycle
+
+- The audit table migration creates the partition for the month in which the migration runs.
+- `create_audit_partition()` remains the pre-provisioning helper for the next month.
+- `AuditRepository.createAuditLog()` now treats PostgreSQL's `no partition of relation "audit_logs" found for row` response as a recoverable lifecycle gap:
+  - create the database server's current-month `audit_logs_YYYY_MM` partition;
+  - retry the original audit insert once;
+  - rethrow unrelated insert errors and any retry failure.
+
+The self-heal path uses the database server calendar (`CURRENT_DATE`) so it stays aligned with the `created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP` value produced by PostgreSQL during the insert.
+
+## Operator verification
+
+Check the current partition:
+
+```sql
+SELECT to_regclass('audit_logs_' || to_char(date_trunc('month', CURRENT_DATE), 'YYYY_MM')) AS current_partition;
+```
+
+Expected result is a non-null relation name such as `audit_logs_2026_05`.
+
+Check the next pre-provisioned partition when the scheduled monthly helper is enabled:
+
+```sql
+SELECT to_regclass('audit_logs_' || to_char(date_trunc('month', CURRENT_DATE + INTERVAL '1 month'), 'YYYY_MM')) AS next_partition;
+```
+
+If the current partition is missing, a normal audit write should recreate it automatically. To preflight without waiting for traffic, call the repository guard from a maintenance script or run the equivalent DO block used by `AuditRepository.ensureCurrentMonthPartition()`.
+
+## Failure handling
+
+- Missing current-month partition: audit repository creates the partition and retries once.
+- Concurrent first writes in the same month: the self-heal block takes a transaction-scoped advisory lock for the computed partition name before creating it.
+- Missing parent table, permissions, invalid table shape, or any non-partition insert error: not swallowed by the repository.
+
+## Verification
+
+Focused unit coverage lives in `packages/core-backend/tests/unit/audit-repository-partition.test.ts` and covers:
+
+- self-heal plus one retry after the PostgreSQL missing-partition error;
+- no retry for unrelated insert errors;
+- direct current-month partition guard SQL.

--- a/docs/development/audit-log-current-month-partition-lifecycle-20260527.md
+++ b/docs/development/audit-log-current-month-partition-lifecycle-20260527.md
@@ -16,7 +16,7 @@ This note covers the operational lifecycle for the partitioned `audit_logs` tabl
   - retry the original audit insert once;
   - rethrow unrelated insert errors and any retry failure.
 
-The self-heal path uses the database server calendar (`CURRENT_DATE`) so it stays aligned with the `created_at TIMESTAMPTZ DEFAULT CURRENT_TIMESTAMP` value produced by PostgreSQL during the insert.
+The self-heal path uses the database server calendar (`CURRENT_DATE`) so it stays aligned with the `created_at DEFAULT CURRENT_TIMESTAMP` value produced by PostgreSQL during the insert.
 
 ## Operator verification
 

--- a/packages/core-backend/src/audit/AuditRepository.ts
+++ b/packages/core-backend/src/audit/AuditRepository.ts
@@ -171,6 +171,18 @@ export interface AuditLogRow {
 
 type QueryValue = string | number | boolean | Date | string[] | null | undefined;
 
+function isMissingAuditLogPartitionError(error: unknown): boolean {
+  if (error instanceof Error) {
+    return /no partition of relation "audit_logs" found/i.test(error.message);
+  }
+
+  if (typeof error === 'object' && error !== null && 'message' in error) {
+    return /no partition of relation "audit_logs" found/i.test(String(error.message));
+  }
+
+  return false;
+}
+
 export class AuditRepository {
   constructor(private dbPool: Pool = pool!) {
     if (!this.dbPool) {
@@ -249,8 +261,21 @@ export class AuditRepository {
       data.parentEventId
     ];
 
-    const result = await query<{ id: number }>(sql, values);
-    return result.rows[0].id;
+    const insertAuditLog = async (): Promise<number> => {
+      const result = await query<{ id: number }>(sql, values);
+      return result.rows[0].id;
+    };
+
+    try {
+      return await insertAuditLog();
+    } catch (error) {
+      if (!isMissingAuditLogPartitionError(error)) {
+        throw error;
+      }
+
+      await this.ensureCurrentMonthPartition();
+      return insertAuditLog();
+    }
   }
 
   /**
@@ -514,5 +539,34 @@ export class AuditRepository {
    */
   async createMonthlyPartition(): Promise<void> {
     await query('SELECT create_audit_partition()');
+  }
+
+  /**
+   * Ensure the audit_logs partition for the database server's current month exists.
+   */
+  async ensureCurrentMonthPartition(): Promise<void> {
+    await query(`
+      DO $$
+      DECLARE
+        partition_date DATE;
+        partition_name TEXT;
+        start_date DATE;
+        end_date DATE;
+      BEGIN
+        partition_date := DATE_TRUNC('month', CURRENT_DATE);
+        partition_name := 'audit_logs_' || TO_CHAR(partition_date, 'YYYY_MM');
+        start_date := partition_date;
+        end_date := partition_date + INTERVAL '1 month';
+
+        PERFORM pg_advisory_xact_lock(hashtext('audit_logs_partition_' || partition_name)::bigint);
+
+        IF to_regclass(partition_name) IS NULL THEN
+          EXECUTE format(
+            'CREATE TABLE IF NOT EXISTS %I PARTITION OF audit_logs FOR VALUES FROM (%L) TO (%L)',
+            partition_name, start_date, end_date
+          );
+        END IF;
+      END $$;
+    `);
   }
 }

--- a/packages/core-backend/src/audit/AuditRepository.ts
+++ b/packages/core-backend/src/audit/AuditRepository.ts
@@ -263,7 +263,11 @@ export class AuditRepository {
 
     const insertAuditLog = async (): Promise<number> => {
       const result = await query<{ id: number }>(sql, values);
-      return result.rows[0].id;
+      const row = result.rows[0];
+      if (!row) {
+        throw new Error('Failed to insert audit log: no rows returned');
+      }
+      return row.id;
     };
 
     try {
@@ -558,7 +562,7 @@ export class AuditRepository {
         start_date := partition_date;
         end_date := partition_date + INTERVAL '1 month';
 
-        PERFORM pg_advisory_xact_lock(hashtext('audit_logs_partition_' || partition_name)::bigint);
+        PERFORM pg_advisory_xact_lock(hashtext('audit_logs_partition'), hashtext(partition_name));
 
         IF to_regclass(partition_name) IS NULL THEN
           EXECUTE format(

--- a/packages/core-backend/tests/unit/audit-repository-partition.test.ts
+++ b/packages/core-backend/tests/unit/audit-repository-partition.test.ts
@@ -72,6 +72,17 @@ describe('AuditRepository audit_logs partition lifecycle', () => {
     expect(queryMock).toHaveBeenCalledTimes(1)
   })
 
+  it('throws a clear error if INSERT RETURNING produces no row', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0 })
+
+    const repository = new AuditRepository()
+
+    await expect(repository.createAuditLog(buildAuditLogData())).rejects.toThrow(
+      'Failed to insert audit log: no rows returned',
+    )
+    expect(queryMock).toHaveBeenCalledTimes(1)
+  })
+
   it('can ensure the database server current-month partition directly', async () => {
     queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0 })
 
@@ -82,6 +93,8 @@ describe('AuditRepository audit_logs partition lifecycle', () => {
     expect(queryMock).toHaveBeenCalledTimes(1)
     expect(queryMock.mock.calls[0][0]).toContain("partition_name := 'audit_logs_'")
     expect(queryMock.mock.calls[0][0]).toContain("DATE_TRUNC('month', CURRENT_DATE)")
-    expect(queryMock.mock.calls[0][0]).toContain('pg_advisory_xact_lock')
+    expect(queryMock.mock.calls[0][0]).toContain(
+      "pg_advisory_xact_lock(hashtext('audit_logs_partition'), hashtext(partition_name))",
+    )
   })
 })

--- a/packages/core-backend/tests/unit/audit-repository-partition.test.ts
+++ b/packages/core-backend/tests/unit/audit-repository-partition.test.ts
@@ -1,0 +1,87 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const { queryMock } = vi.hoisted(() => ({
+  queryMock: vi.fn(),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  pool: {},
+  query: queryMock,
+}))
+
+import { AuditRepository, type AuditLogData } from '../../src/audit/AuditRepository'
+
+function buildAuditLogData(overrides: Partial<AuditLogData> = {}): AuditLogData {
+  return {
+    eventType: 'ATTENDANCE_POLICY_UPDATED',
+    eventCategory: 'attendance',
+    action: 'update',
+    resourceType: 'attendance-policy',
+    resourceId: 'policy-1',
+    actionDetails: { changed: ['timezone'] },
+    ...overrides,
+  }
+}
+
+function missingAuditLogPartitionError(): Error & { code: string } {
+  return Object.assign(new Error('no partition of relation "audit_logs" found for row'), {
+    code: '23514',
+  })
+}
+
+describe('AuditRepository audit_logs partition lifecycle', () => {
+  beforeEach(() => {
+    queryMock.mockReset()
+  })
+
+  it('keeps the normal audit insert path to one query', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [{ id: 200 }], rowCount: 1 })
+
+    const repository = new AuditRepository()
+
+    await expect(repository.createAuditLog(buildAuditLogData())).resolves.toBe(200)
+
+    expect(queryMock).toHaveBeenCalledTimes(1)
+    expect(queryMock.mock.calls[0][0]).toContain('INSERT INTO audit_logs')
+  })
+
+  it('self-heals the current-month partition and retries the audit insert once', async () => {
+    queryMock
+      .mockRejectedValueOnce(missingAuditLogPartitionError())
+      .mockResolvedValueOnce({ rows: [], rowCount: 0 })
+      .mockResolvedValueOnce({ rows: [{ id: 503 }], rowCount: 1 })
+
+    const repository = new AuditRepository()
+
+    await expect(repository.createAuditLog(buildAuditLogData())).resolves.toBe(503)
+
+    expect(queryMock).toHaveBeenCalledTimes(3)
+    expect(queryMock.mock.calls[0][0]).toContain('INSERT INTO audit_logs')
+    expect(queryMock.mock.calls[1][0]).toContain("DATE_TRUNC('month', CURRENT_DATE)")
+    expect(queryMock.mock.calls[1][0]).toContain('CREATE TABLE IF NOT EXISTS %I PARTITION OF audit_logs')
+    expect(queryMock.mock.calls[2][0]).toContain('INSERT INTO audit_logs')
+  })
+
+  it('does not retry unrelated audit insert errors', async () => {
+    const error = new Error('permission denied for table audit_logs')
+    queryMock.mockRejectedValueOnce(error)
+
+    const repository = new AuditRepository()
+
+    await expect(repository.createAuditLog(buildAuditLogData())).rejects.toThrow(error)
+    expect(queryMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('can ensure the database server current-month partition directly', async () => {
+    queryMock.mockResolvedValueOnce({ rows: [], rowCount: 0 })
+
+    const repository = new AuditRepository()
+
+    await repository.ensureCurrentMonthPartition()
+
+    expect(queryMock).toHaveBeenCalledTimes(1)
+    expect(queryMock.mock.calls[0][0]).toContain("partition_name := 'audit_logs_'")
+    expect(queryMock.mock.calls[0][0]).toContain("DATE_TRUNC('month', CURRENT_DATE)")
+    expect(queryMock.mock.calls[0][0]).toContain('pg_advisory_xact_lock')
+  })
+})


### PR DESCRIPTION
## Summary
- self-heal `audit_logs` current-month partition when PostgreSQL reports a missing partition during audit insert
- retry the original audit insert once after creating the database-server current-month partition
- document the audit partition lifecycle and operator verification path

Fixes #503

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/audit-repository-partition.test.ts tests/unit/audit-wrapper.test.ts --reporter=verbose`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`