### PR TITLE
ops(onprem): attest build provenance and verify #1912 markers

### DIFF
--- a/scripts/ops/multitable-onprem-package-build.sh
+++ b/scripts/ops/multitable-onprem-package-build.sh
@@ -365,6 +365,65 @@ EOF
 EOF
 }
 
+function write_build_provenance() {
+  # Build-time source provenance + #1912 fix-marker attestation. The verify flow
+  # (multitable-onprem-package-verify.sh) requires this file, asserts a real
+  # 40-hex gitCommit, and cross-checks the issue1912 marker against the packaged
+  # adapter. Helpers only — no customer runtime is touched here.
+  local git_commit git_commit_short git_ref on_main marker_file marker_str embedded
+  git_commit="${GITHUB_SHA:-$(git -C "$ROOT_DIR" rev-parse HEAD 2>/dev/null || echo unknown)}"
+  if [[ "$git_commit" =~ ^[0-9a-f]{40}$ ]]; then
+    git_commit_short="${git_commit:0:12}"
+  else
+    git_commit="unknown"
+    git_commit_short="unknown"
+  fi
+  git_ref="${GITHUB_REF_NAME:-$(git -C "$ROOT_DIR" rev-parse --abbrev-ref HEAD 2>/dev/null || echo unknown)}"
+  # Soft provenance signal: is the build commit reachable on origin/main? Never fail
+  # (offline/disconnected builds are legitimate) — just record it for the reviewer.
+  on_main="unknown"
+  if [[ "$git_commit" != "unknown" ]] && git -C "$ROOT_DIR" rev-parse --verify -q origin/main >/dev/null 2>&1; then
+    if git -C "$ROOT_DIR" merge-base --is-ancestor "$git_commit" origin/main 2>/dev/null; then
+      on_main="true"
+    else
+      on_main="false"
+      info "WARNING: build commit ${git_commit_short} is not on origin/main; package provenance is local-only"
+    fi
+  fi
+  # Compute the #1912 marker presence from the STAGED adapter (the exact file about
+  # to be packaged) — not a hardcoded literal — so the verify cross-check is real.
+  marker_file="${PACKAGE_ROOT}/plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs"
+  marker_str="material-k3wise-customer-profile-v1"
+  if [[ -f "$marker_file" ]] && grep -qF -- "$marker_str" "$marker_file"; then
+    embedded="true"
+  else
+    embedded="false"
+  fi
+  cat > "${PACKAGE_ROOT}/BUILD_PROVENANCE.json" <<EOF
+{
+  "schema": "metasheet-onprem-build-provenance/v1",
+  "packageName": "${PACKAGE_NAME}",
+  "version": "${PACKAGE_VERSION}",
+  "tag": "${PACKAGE_TAG}",
+  "gitCommit": "${git_commit}",
+  "gitCommitShort": "${git_commit_short}",
+  "gitRef": "${git_ref}",
+  "sourceIsOnOriginMain": "${on_main}",
+  "ciRunId": "${GITHUB_RUN_ID:-local}",
+  "ciRunAttempt": "${GITHUB_RUN_ATTEMPT:-local}",
+  "builtAt": "$(date -u +"%Y-%m-%dT%H:%M:%SZ")",
+  "fixMarkers": {
+    "issue1912": {
+      "title": "K3 WISE M1 Material Save-only backend fix",
+      "adapter": "plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs",
+      "marker": "${marker_str}",
+      "embedded": ${embedded}
+    }
+  }
+}
+EOF
+}
+
 function cleanup() {
   [[ -n "$checksum_tmp" ]] && rm -f "$checksum_tmp" || true
   rm -rf "$TMP_OUTPUT_DIR" || true
@@ -417,6 +476,7 @@ stamp_packaged_version "package.json"
 stamp_packaged_version "packages/core-backend/package.json"
 write_windows_entrypoints
 write_deployment_guides
+write_build_provenance
 
 cat > "${PACKAGE_ROOT}/INSTALL.txt" <<EOF
 MetaSheet Multitable On-Prem Package

--- a/scripts/ops/multitable-onprem-package-verify.provenance.test.sh
+++ b/scripts/ops/multitable-onprem-package-verify.provenance.test.sh
@@ -1,0 +1,81 @@
+#!/usr/bin/env bash
+# Focused test for the #1912 / build-provenance checks added to
+# multitable-onprem-package-verify.sh. It sources the verify script (functions only,
+# via its direct-execution guard) and exercises verify_build_provenance +
+# verify_integration_fix_markers against synthesized fixtures — one positive case and
+# three drift negatives, each asserting a SPECIFIC failure message. No real on-prem
+# package is required, so this runs in well under a second.
+#
+#   bash scripts/ops/multitable-onprem-package-verify.provenance.test.sh
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+VERIFY="${SCRIPT_DIR}/multitable-onprem-package-verify.sh"
+FAKE_COMMIT="0123456789abcdef0123456789abcdef01234567"
+MARKER="material-k3wise-customer-profile-v1"
+FAILCLOSED="Unknown K3 WISE material profile"
+pass=0
+fail=0
+
+make_fixture() {
+  # $1=dir  $2=embedded(true|false)  $3=gitCommit  $4=include_marker(1|0)
+  local d="$1" emb="$2" commit="$3" inc="$4"
+  local ad="${d}/plugins/plugin-integration-core/lib/adapters"
+  mkdir -p "$ad"
+  cat > "${d}/BUILD_PROVENANCE.json" <<JSON
+{
+  "schema": "metasheet-onprem-build-provenance/v1",
+  "packageName": "fixture",
+  "gitCommit": "${commit}",
+  "gitCommitShort": "${commit:0:12}",
+  "builtAt": "2026-05-27T00:00:00Z",
+  "fixMarkers": { "issue1912": { "embedded": ${emb} } }
+}
+JSON
+  if [[ "$inc" == "1" ]]; then
+    printf "const MATERIAL_CUSTOMER_PROFILE_ID = '%s'\n" "$MARKER" > "${ad}/k3-wise-document-templates.cjs"
+  else
+    printf "const X = 'no #1912 marker here'\n" > "${ad}/k3-wise-document-templates.cjs"
+  fi
+  printf "throw new AdapterValidationError(\`%s: x\`)\n" "$FAILCLOSED" > "${ad}/k3-wise-webapi-adapter.cjs"
+}
+
+run_case() {
+  # $1=label  $2=expect(pass|<die-substring>)  $3=fixture_dir  $4=func
+  local label="$1" expect="$2" root="$3" func="$4" err rc
+  err="$( ( source "$VERIFY"; "$func" "$root" ) 2>&1 )"
+  rc=$?
+  if [[ "$expect" == "pass" ]]; then
+    if [[ $rc -eq 0 ]]; then echo "  PASS: ${label}"; pass=$((pass+1));
+    else echo "  FAIL: ${label} — expected pass, rc=${rc}: ${err}"; fail=$((fail+1)); fi
+  else
+    if [[ $rc -ne 0 && "$err" == *"$expect"* ]]; then echo "  PASS: ${label} — died as expected (…${expect}…)"; pass=$((pass+1));
+    else echo "  FAIL: ${label} — expected die containing '${expect}', rc=${rc}: ${err}"; fail=$((fail+1)); fi
+  fi
+}
+
+TMP="$(mktemp -d)"
+trap 'rm -rf "$TMP"' EXIT
+
+echo "## build-provenance / #1912 marker verify — focused test"
+
+# Positive: real 40-hex commit, marker present, provenance claims embedded:true.
+make_fixture "${TMP}/ok" true "$FAKE_COMMIT" 1
+run_case "valid provenance shape"                 pass "${TMP}/ok" verify_build_provenance
+run_case "marker present + provenance agrees"     pass "${TMP}/ok" verify_integration_fix_markers
+
+# Negative (a): provenance claims embedded:true but the adapter marker is gone → stale adapter.
+make_fixture "${TMP}/stale_adapter" true "$FAKE_COMMIT" 0
+run_case "stale adapter (marker missing, prov claims true)" "stale adapter in the package" "${TMP}/stale_adapter" verify_integration_fix_markers
+
+# Negative (b): blank gitCommit → provenance cannot prove its source.
+make_fixture "${TMP}/bad_commit" true "" 1
+run_case "blank gitCommit rejected" "gitCommit must be a full 40-hex" "${TMP}/bad_commit" verify_build_provenance
+
+# Negative (c): marker present but provenance says embedded!=true → stale/lying provenance.
+make_fixture "${TMP}/lying_prov" false "$FAKE_COMMIT" 1
+run_case "provenance disagrees with present marker" "provenance file is stale or wrong" "${TMP}/lying_prov" verify_integration_fix_markers
+
+echo
+echo "RESULT: ${pass} passed, ${fail} failed"
+[[ $fail -eq 0 ]]

--- a/scripts/ops/multitable-onprem-package-verify.sh
+++ b/scripts/ops/multitable-onprem-package-verify.sh
@@ -194,6 +194,49 @@ function verify_deployable_artifact_contract() {
   search_fixed_string '"windowsEntryPoint": "deploy.bat <package.zip|package.tgz>"' "$metadata_json" || die "PACKAGE-METADATA.json must document the Windows entrypoint"
 }
 
+function verify_build_provenance() {
+  local root="$1"
+  local prov="${root}/BUILD_PROVENANCE.json"
+
+  [[ -f "$prov" ]] || die "BUILD_PROVENANCE.json must be present in the package (build provenance attestation missing)"
+  search_fixed_string '"schema": "metasheet-onprem-build-provenance/v1"' "$prov" || die "BUILD_PROVENANCE.json must declare schema metasheet-onprem-build-provenance/v1"
+  # gitCommit must be a real 40-hex SHA, never the "unknown" fallback or a short SHA,
+  # so a reviewer can independently check ancestry (e.g. merge-base --is-ancestor c4c40934d).
+  if ! grep -Eq '"gitCommit": *"[0-9a-f]{40}"' "$prov"; then
+    die "BUILD_PROVENANCE.json gitCommit must be a full 40-hex commit (got a missing/short/unknown value); the package cannot prove its source provenance"
+  fi
+  search_fixed_string '"builtAt"' "$prov" || die "BUILD_PROVENANCE.json must record builtAt"
+}
+
+function verify_integration_fix_markers() {
+  # #1912 (K3 WISE M1 Material Save-only) must be present in the packaged adapters AND
+  # BUILD_PROVENANCE must agree. Each side is checked independently with a distinct
+  # failure message, so a stale adapter (build predates the fix) or a stale/lying
+  # provenance file is caught and the disagreeing side is named.
+  local root="$1"
+  local prov="${root}/BUILD_PROVENANCE.json"
+  local doc_templates="${root}/plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs"
+  local webapi_adapter="${root}/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs"
+  local marker='material-k3wise-customer-profile-v1'
+  local adapter_has=0
+  local prov_claims=0
+
+  search_fixed_string "$marker" "$doc_templates" && adapter_has=1 || true
+  search_fixed_string '"embedded": true' "$prov" && prov_claims=1 || true
+
+  if [[ "$prov_claims" == "1" && "$adapter_has" == "0" ]]; then
+    die "BUILD_PROVENANCE claims issue1912 embedded=true but packaged k3-wise-document-templates.cjs is MISSING the '${marker}' marker (stale adapter in the package)"
+  fi
+  if [[ "$prov_claims" == "0" && "$adapter_has" == "1" ]]; then
+    die "Packaged k3-wise-document-templates.cjs contains the '${marker}' marker but BUILD_PROVENANCE reports issue1912 embedded!=true (provenance file is stale or wrong)"
+  fi
+  if [[ "$adapter_has" == "0" ]]; then
+    die "#1912 marker '${marker}' not found in packaged k3-wise-document-templates.cjs (build predates the M1 Material Save-only fix)"
+  fi
+  # Fail-closed validation half of #1912 (separate adapter file).
+  search_fixed_string 'Unknown K3 WISE material profile' "$webapi_adapter" || die "#1912 fail-closed marker ('Unknown K3 WISE material profile') not found in packaged k3-wise-webapi-adapter.cjs"
+}
+
 function verify_migration_bridge_contract() {
   local root="$1"
   local provider="${root}/packages/core-backend/dist/src/db/migration-provider.js"
@@ -568,6 +611,10 @@ function verify_sha() {
   fi
 }
 
+# When sourced (e.g. by the focused test), define functions only — do not run the
+# package verification main flow. Direct execution (BASH_SOURCE[0] == $0) runs normally.
+if [[ "${BASH_SOURCE[0]:-}" == "${0:-}" ]]; then
+
 [[ -n "$PACKAGE_FILE" ]] || die "Usage: scripts/ops/multitable-onprem-package-verify.sh <package.tgz|package.zip>"
 [[ -f "$PACKAGE_FILE" ]] || die "Package not found: ${PACKAGE_FILE}"
 
@@ -618,6 +665,7 @@ pkg_root="${EXTRACT_ROOT}/${pkg_name}"
 required=(
   "DEPLOYMENT.txt"
   "PACKAGE-METADATA.json"
+  "BUILD_PROVENANCE.json"
   "apps/web/dist/index.html"
   "apps/web/package.json"
   "packages/core-backend/dist/src/index.js"
@@ -746,6 +794,8 @@ verify_windows_entrypoints "$pkg_root"
 verify_root_runtime_dependencies "$pkg_root"
 verify_integration_plugin_runtime_dependencies "$pkg_root"
 verify_deployable_artifact_contract "$pkg_root"
+verify_build_provenance "$pkg_root"
+verify_integration_fix_markers "$pkg_root"
 verify_migration_bridge_contract "$pkg_root"
 verify_generic_integration_workbench_contract "$pkg_root"
 verify_bridge_agent_tooling_contract "$pkg_root"
@@ -765,3 +815,5 @@ fi
 if [[ -n "$VERIFY_REPORT_MD" ]]; then
   info "  verify_report_md: ${VERIFY_REPORT_MD}"
 fi
+
+fi  # end direct-execution guard


### PR DESCRIPTION
## What

Sink the **#1912** (K3 WISE M1 Material Save-only) runtime-marker + source-provenance checks into the on-prem package **verify** flow, and have the **build** emit a `BUILD_PROVENANCE.json`. A stale build (adapters predating #1912) or an unprovenanced package now **fails verification** instead of passing the structural-only contract.

**Helpers only — no customer runtime touched** (3 files; no `plugin-integration-core` adapter changes).

## Changes
- **`scripts/ops/multitable-onprem-package-build.sh`** — `write_build_provenance()` emits `BUILD_PROVENANCE.json` at the package root: schema, package identity, `gitCommit`(+short)/`gitRef` (`GITHUB_SHA`→`git rev-parse` fallback), `ciRunId`, `builtAt`, a **soft** `sourceIsOnOriginMain` (never fails — offline builds are legitimate), and `fixMarkers.issue1912.embedded` computed by grepping the **staged** adapter (so the verify cross-check is real, not a shared constant).
- **`scripts/ops/multitable-onprem-package-verify.sh`** — require `BUILD_PROVENANCE.json`; `verify_build_provenance` (schema + a real 40-hex `gitCommit`, rejects unknown/short, + `builtAt`); `verify_integration_fix_markers` (independently greps the packaged adapters for the #1912 markers **and** cross-checks `BUILD_PROVENANCE` — two sides, two distinct failure messages naming the disagreeing side). Adds a `BASH_SOURCE==$0` direct-exec guard so the test can source the functions.
- **`scripts/ops/multitable-onprem-package-verify.provenance.test.sh`** — synthesized-fixture focused test (1 positive + 3 drift negatives), runs in <1s, no real package needed.

## Verification
- Focused test: **5 passed, 0 failed** (`bash scripts/ops/multitable-onprem-package-verify.provenance.test.sh`).
- New verify **rejects** the old pre-provenance package (`Required package content missing: BUILD_PROVENANCE.json`).
- End-to-end CI build on this branch (run `26524076435`, rebased head `33fec1c33`): **success**, including the in-workflow self-verify (step "Build on-prem package" runs the new verify on tgz+zip).
- Emitted `BUILD_PROVENANCE.json` carries a real 40-hex `gitCommit`; reviewer confirms `#1912` ancestry out-of-band: `git merge-base --is-ancestor c4c40934d <gitCommit>` ⇒ true.

## Notes
- `sourceIsOnOriginMain` resolves to `"unknown"` under CI's shallow checkout (no local `origin/main`) — by design soft/non-failing; ancestry is confirmed out-of-band via `gitCommit`. Making it resolve in CI (fetch `origin/main`) is a small follow-up, out of scope here.
- No customer-facing action: nothing posted to #1792, no Save-only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)