### PR TITLE
refactor(integration): DF-T1-0 — K3 preview↔Save composition parity (single source of truth)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/k3-save-body-composer.parity.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-save-body-composer.parity.test.cjs
@@ -1,0 +1,164 @@
+'use strict'
+
+// DF-T1-0 contract test: the no-write preview must compose a payload BYTE-IDENTICAL to what
+// the adapter actually Saves, and must fail-closed on the same placeholders. This is the test
+// that justifies the shared k3-save-body-composer existing. Sibling to the composer (grep gate).
+
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const { createK3WiseWebApiAdapter } = require('../lib/adapters/k3-wise-webapi-adapter.cjs')
+const { __internals: httpInternals } = require('../lib/http-routes.cjs')
+const { getK3WiseMaterialProfile, getK3WiseDocumentObjectDefaults } = require('../lib/adapters/k3-wise-document-templates.cjs')
+const composer = require('../lib/adapters/k3-save-body-composer.cjs')
+
+const PROFILE_ID = 'material-k3wise-customer-profile-v1'
+const { buildTemplatePreview } = httpInternals
+
+function jsonResponse(status, body) {
+  return { ok: status >= 200 && status < 300, status, headers: { get: () => null }, async text() { return JSON.stringify(body) } }
+}
+
+function mockFetchCapturing() {
+  const calls = []
+  const fetchImpl = async (url, options = {}) => {
+    const u = new URL(url)
+    const body = options.body ? JSON.parse(options.body) : undefined
+    calls.push({ pathname: u.pathname, body })
+    if (u.pathname === '/K3API/Login') return jsonResponse(200, { success: true, sessionId: 's1' })
+    if (u.pathname === '/K3API/Token/Create') return jsonResponse(200, { StatusCode: 200, Data: { Code: 'Y', Token: 't1' } })
+    if (u.pathname === '/K3API/Material/Save') {
+      return jsonResponse(200, { StatusCode: 200, Message: 'Successful', Data: [{ FStatus: true, FItemID: 1, FNumber: body && body.Data && body.Data.FNumber }] })
+    }
+    return jsonResponse(404, { success: false, message: 'not found' })
+  }
+  return { calls, fetchImpl }
+}
+
+function presetSystem() {
+  return {
+    id: 'k3_1', name: 'K3', kind: 'erp:k3-wise-webapi', role: 'target',
+    credentials: { username: 'u', password: 'p', acctId: '1' },
+    config: { baseUrl: 'https://k3.example.test', autoSubmit: false, autoAudit: false, objects: { material: { profile: PROFILE_ID } } },
+  }
+}
+
+const identityMappings = (record) => Object.keys(record).map((k) => ({ sourceField: k, targetField: k }))
+const presetSchema = () => getK3WiseMaterialProfile(PROFILE_ID).schema
+
+// Capture the exact Save body the adapter sends for a record under the customer profile.
+async function adapterSaveBody(record) {
+  const { calls, fetchImpl } = mockFetchCapturing()
+  const adapter = createK3WiseWebApiAdapter({ system: presetSystem(), fetchImpl })
+  const result = await adapter.upsert({ object: 'material', records: [record], keyFields: ['FNumber'] })
+  const save = calls.find((c) => c.pathname === '/K3API/Material/Save')
+  return { result, body: save ? save.body : null }
+}
+
+function previewPayload(record) {
+  return buildTemplatePreview({
+    sourceRecord: record,
+    fieldMappings: identityMappings(record),
+    template: { bodyKey: 'Data', schema: presetSchema() },
+  })
+}
+
+// ---- Parity 1: scalar reference shaping (preset) — preview ≡ adapter Save body ----
+async function testScalarShapeParity() {
+  const record = { FNumber: 'MAT-1', FName: 'Bolt', FUnitGroupID: '10', FErpClsID: '1001' }
+  const { body } = await adapterSaveBody(record)
+  const preview = previewPayload(record)
+  const expected = { Data: { FNumber: 'MAT-1', FName: 'Bolt', FUnitGroupID: { FNumber: '10' }, FErpClsID: { FID: '1001' } } }
+  assert.deepEqual(body, expected, 'adapter Save body shapes by-FNumber / by-FID per preset')
+  assert.deepEqual(preview.payload, expected, 'preview payload matches the adapter Save body exactly')
+  assert.deepEqual(preview.payload, body, 'preview ≡ adapter Save (byte parity)')
+  assert.equal(preview.valid, true)
+}
+
+// ---- Parity 2: object passthrough — two-field {FNumber,FName}/{FID,FName} preserved both sides ----
+async function testObjectPassthroughParity() {
+  const record = {
+    FNumber: 'MAT-2', FName: 'Nut',
+    FUnitGroupID: { FNumber: '10', FName: 'Each' },
+    FErpClsID: { FID: '1001', FName: 'Raw' },
+  }
+  const { body } = await adapterSaveBody(record)
+  const preview = previewPayload(record)
+  assert.deepEqual(body.Data.FUnitGroupID, { FNumber: '10', FName: 'Each' }, 'adapter preserves two-field object')
+  assert.deepEqual(preview.payload, body, 'preview ≡ adapter Save with object passthrough')
+}
+
+// ---- Parity 3: placeholder — same detection, dispositions differ (Save throws, preview valid:false) ----
+async function testPlaceholderParity() {
+  const record = { FNumber: 'MAT-3', FName: 'X', FUnitGroupID: '<unit-group-number>' }
+  const { result, body } = await adapterSaveBody(record)
+  assert.equal(body, null, 'adapter made NO Save call — fail-closed before HTTP')
+  assert.equal(result.written, 0)
+  assert.equal(result.errors[0].code, 'K3_WISE_PRESET_PLACEHOLDER_UNFILLED', 'Save throws the placeholder code')
+
+  const preview = previewPayload(record)
+  assert.equal(preview.valid, false, 'preview reports invalid for the same placeholder')
+  assert.ok(preview.placeholderErrors.length > 0, 'preview lists the unfilled placeholder')
+  assert.ok(preview.placeholderErrors.some((e) => /FUnitGroupID/.test(e.field)), 'preview names the placeholder field')
+
+  // Shared detection: the composer finds the same path for the same composed body.
+  const composed = composer.composeSchemaBody({ FUnitGroupID: '<unit-group-number>' }, { bodyKey: 'Data', schema: presetSchema() })
+  assert.ok(composer.findUnfilledPlaceholders(composed).some((p) => /FUnitGroupID/.test(p)))
+}
+
+// ---- no-write: the preview composes with zero network/login/Save calls ----
+async function testPreviewIsNoWrite() {
+  const { calls, fetchImpl } = mockFetchCapturing()
+  // buildTemplatePreview takes no fetch and performs no I/O; prove it by running it while a
+  // fetch mock is in scope and asserting the mock recorded nothing.
+  void fetchImpl
+  const out = previewPayload({ FNumber: 'MAT-9', FName: 'Y' })
+  assert.ok(out && out.payload, 'preview returns a payload')
+  assert.equal(calls.length, 0, 'preview made no login/fetch/Submit/Audit/BOM/list/search calls')
+}
+
+// ---- opt-in: the GENERIC material template never carries the customer-profile fields ----
+function testPresetIsOptIn() {
+  const genericSchema = getK3WiseDocumentObjectDefaults().material.schema
+  const record = { FNumber: 'MAT-5', FName: 'Z', FErpClsID: '1001' }
+  // Generic template has no FErpClsID → it is dropped (not silently composed as the preset would).
+  const generic = buildTemplatePreview({ sourceRecord: record, fieldMappings: identityMappings(record), template: { bodyKey: 'Data', schema: genericSchema } })
+  assert.equal(generic.payload.Data.FErpClsID, undefined, 'generic preview omits the preset-only field')
+  // Only the explicitly-selected preset schema includes + shapes it.
+  const withPreset = previewPayload(record)
+  assert.deepEqual(withPreset.payload.Data.FErpClsID, { FID: '1001' }, 'preset preview shapes the field by FID')
+}
+
+// ---- grep gate: no divergent duplicate may reappear ----
+function testNoDivergentDuplicate() {
+  const read = (rel) => fs.readFileSync(path.join(__dirname, '..', 'lib', rel), 'utf8')
+  const httpRoutes = read('http-routes.cjs')
+  const adapter = read('adapters/k3-wise-webapi-adapter.cjs')
+  const comp = read('adapters/k3-save-body-composer.cjs')
+
+  // Gate on function DEFINITIONS (the deleted copies were `function …`), not bare mentions —
+  // "moved to the composer" comments legitimately reference the old names.
+  assert.equal(/function\s+applyPreviewReferenceShape|function\s+projectRecordForTemplate/.test(httpRoutes), false,
+    'http-routes must not re-introduce a preview-side shaper/projector copy')
+  assert.equal(/function applyReferenceShape|function projectRecordForBody/.test(adapter), false,
+    'adapter must not re-define composition functions (they live in the composer)')
+  assert.ok(/function applyReferenceShape/.test(comp) && /function projectRecordForBody/.test(comp),
+    'the composer is the sole home of applyReferenceShape / projectRecordForBody')
+}
+
+async function main() {
+  await testScalarShapeParity()
+  await testObjectPassthroughParity()
+  await testPlaceholderParity()
+  await testPreviewIsNoWrite()
+  testPresetIsOptIn()
+  testNoDivergentDuplicate()
+  console.log('✓ k3-save-body-composer.parity: preview ≡ adapter Save (shape/passthrough/placeholder), no-write, opt-in, no divergent duplicate')
+}
+
+main().catch((err) => {
+  console.error('✗ k3-save-body-composer.parity FAILED')
+  console.error(err)
+  process.exit(1)
+})

--- a/plugins/plugin-integration-core/__tests__/k3-save-body-composer.parity.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-save-body-composer.parity.test.cjs
@@ -101,6 +101,9 @@ async function testPlaceholderParity() {
   assert.equal(preview.valid, false, 'preview reports invalid for the same placeholder')
   assert.ok(preview.placeholderErrors.length > 0, 'preview lists the unfilled placeholder')
   assert.ok(preview.placeholderErrors.some((e) => /FUnitGroupID/.test(e.field)), 'preview names the placeholder field')
+  // Same error CODE both sides so the operator can correlate preview ↔ Save failure.
+  assert.ok(preview.placeholderErrors.every((e) => e.code === 'K3_WISE_PRESET_PLACEHOLDER_UNFILLED'),
+    'preview placeholder code matches the Save throw code')
 
   // Shared detection: the composer finds the same path for the same composed body.
   const composed = composer.composeSchemaBody({ FUnitGroupID: '<unit-group-number>' }, { bodyKey: 'Data', schema: presetSchema() })
@@ -130,6 +133,27 @@ function testPresetIsOptIn() {
   assert.deepEqual(withPreset.payload.Data.FErpClsID, { FID: '1001' }, 'preset preview shapes the field by FID')
 }
 
+// ---- generic preview nested-path contract must NOT regress (the shared composer must keep
+//      the old getPath/setPath path projection for non-K3 templates) ----
+function testGenericNestedProjectionPreserved() {
+  const out = buildTemplatePreview({
+    sourceRecord: { code: 'C-1' },
+    fieldMappings: [{ sourceField: 'code', targetField: 'nested.code' }],
+    template: { bodyKey: 'Data', schema: [{ name: 'nested.code', required: true }] },
+  })
+  assert.deepEqual(out.payload, { Data: { nested: { code: 'C-1' } } }, 'nested schema path projects (no silent field drop)')
+  assert.equal(out.valid, true)
+}
+
+// ---- reference identifier '' must fall back to identifierField / key (not disable wrapping) ----
+function testIdentifierEmptyStringFallback() {
+  const field = { name: 'FUnitGroupID', type: 'reference', reference: { identifier: '', identifierField: 'FNumber' } }
+  assert.deepEqual(composer.applyReferenceShape('PCS', field), { FNumber: 'PCS' }, 'empty identifier falls back to identifierField')
+  assert.equal(composer.normalizeReferenceIdentifier(field), 'FNumber')
+  // Only-empty identifier (no fallback) → no wrap.
+  assert.equal(composer.applyReferenceShape('PCS', { reference: { identifier: '' } }), 'PCS')
+}
+
 // ---- grep gate: no divergent duplicate may reappear ----
 function testNoDivergentDuplicate() {
   const read = (rel) => fs.readFileSync(path.join(__dirname, '..', 'lib', rel), 'utf8')
@@ -153,8 +177,10 @@ async function main() {
   await testPlaceholderParity()
   await testPreviewIsNoWrite()
   testPresetIsOptIn()
+  testGenericNestedProjectionPreserved()
+  testIdentifierEmptyStringFallback()
   testNoDivergentDuplicate()
-  console.log('✓ k3-save-body-composer.parity: preview ≡ adapter Save (shape/passthrough/placeholder), no-write, opt-in, no divergent duplicate')
+  console.log('✓ k3-save-body-composer.parity: preview ≡ adapter Save (shape/passthrough/placeholder), nested-path preserved, identifier-fallback, no-write, opt-in, no divergent duplicate')
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/lib/adapters/k3-save-body-composer.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-save-body-composer.cjs
@@ -1,0 +1,123 @@
+'use strict'
+
+// Single source of truth for K3 WISE Save-body composition (DF-T1-0).
+//
+// Both the adapter Save path (`k3-wise-webapi-adapter.cjs` `buildSaveBody`) and the no-write
+// template preview (`http-routes.cjs` `buildTemplatePreview`) compose through THIS module, so
+// a preview is byte-identical to what the adapter would actually Save. Previously each side
+// had its own copy (`applyReferenceShape` vs `applyPreviewReferenceShape`, `projectRecordForBody`
+// vs `projectRecordForTemplate`) and they had drifted (fail-closed + customer preset lived only
+// in the adapter), which made the preview a false-confidence surface.
+//
+// Ownership boundary: this module owns SHAPING + PROJECTION + placeholder DETECTION only. It
+// does NOT own disposition — the adapter Save throws on unfilled placeholders
+// (`K3_WISE_PRESET_PLACEHOLDER_UNFILLED`); the preview reports them as a validation error. Both
+// consume `findUnfilledPlaceholders()`, so detection is identical and disposition is the caller's.
+
+function isPlainObject(value) {
+  return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function isBlankValue(value) {
+  return value === undefined || value === null || (typeof value === 'string' && value.trim() === '')
+}
+
+function firstDefined(...values) {
+  for (const value of values) {
+    if (value !== undefined && value !== null) return value
+  }
+  return undefined
+}
+
+function normalizeReferenceIdentifier(field) {
+  const reference = field && isPlainObject(field.reference) ? field.reference : null
+  const identifier = firstDefined(
+    reference && reference.identifier,
+    reference && reference.identifierField,
+    reference && reference.key,
+  )
+  return typeof identifier === 'string' && identifier.trim() ? identifier.trim() : null
+}
+
+// Scalar reference values are wrapped as `{ [identifier]: value }`; values that are already
+// objects pass through verbatim (two-field `{FNumber,FName}` / `{FID,FName}` are preserved).
+function applyReferenceShape(value, field) {
+  const identifier = normalizeReferenceIdentifier(field)
+  if (!identifier || isBlankValue(value) || isPlainObject(value)) return value
+  return { [identifier]: value }
+}
+
+// Project an already field-mapped/transformed record into the schema's fields, applying the
+// per-field reference shape and dropping blank values. Pure: no placeholder enforcement here.
+function projectRecordForBody(record, objectConfig) {
+  if (objectConfig && objectConfig.passThroughBody === true) return record
+  if (!isPlainObject(record)) return record
+  const schema = Array.isArray(objectConfig && objectConfig.schema) ? objectConfig.schema : []
+  const hasNamedField = schema.some((field) => field && typeof field.name === 'string' && field.name.trim().length > 0)
+  if (!hasNamedField) return record
+  const projected = {}
+  for (const field of schema) {
+    const fieldName = field && field.name
+    if (typeof fieldName !== 'string' || fieldName.trim().length === 0) continue
+    if (Object.prototype.hasOwnProperty.call(record, fieldName)) {
+      const value = applyReferenceShape(record[fieldName], field)
+      if (!isBlankValue(value)) projected[fieldName] = value
+    }
+  }
+  return projected
+}
+
+// Wrap the projected record under the configured bodyKey, merging an optional bodyTemplate
+// base. Mirrors the adapter's schema-driven Save body. Function-style bodies (objectConfig.
+// buildBody) and passThroughBody stay the adapter's concern; this covers the schema-driven case.
+function composeSchemaBody(record, objectConfig) {
+  const bodyKey = (objectConfig && objectConfig.bodyKey) || 'Data'
+  const base = isPlainObject(objectConfig && objectConfig.bodyTemplate)
+    ? JSON.parse(JSON.stringify(objectConfig.bodyTemplate))
+    : {}
+  const projected = projectRecordForBody(record, objectConfig)
+  base[bodyKey] = isPlainObject(base[bodyKey]) && isPlainObject(projected)
+    ? { ...base[bodyKey], ...projected }
+    : projected
+  return base
+}
+
+// A value that IS exactly a `<…>` token (template placeholder), not one that merely contains
+// angle brackets — so a legitimate value like "<M6>" is not over-matched unless it is a bare
+// sentinel.
+const PLACEHOLDER_SENTINEL = /^<[^>]+>$/
+
+// Detection only: return the dotted paths of every unfilled `<…>` placeholder in `value`
+// (reference shapes nest the placeholder one level down). Callers own disposition — the
+// adapter Save throws, the preview reports `valid: false`.
+function findUnfilledPlaceholders(value, basePath = '') {
+  const found = []
+  const walk = (node, path) => {
+    if (typeof node === 'string') {
+      if (PLACEHOLDER_SENTINEL.test(node.trim())) found.push(path || '(root)')
+      return
+    }
+    if (Array.isArray(node)) {
+      node.forEach((item, index) => walk(item, `${path}[${index}]`))
+      return
+    }
+    if (isPlainObject(node)) {
+      for (const [key, child] of Object.entries(node)) {
+        walk(child, path ? `${path}.${key}` : key)
+      }
+    }
+  }
+  walk(value, basePath)
+  return found
+}
+
+module.exports = {
+  isPlainObject,
+  isBlankValue,
+  normalizeReferenceIdentifier,
+  applyReferenceShape,
+  projectRecordForBody,
+  composeSchemaBody,
+  PLACEHOLDER_SENTINEL,
+  findUnfilledPlaceholders,
+}

--- a/plugins/plugin-integration-core/lib/adapters/k3-save-body-composer.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-save-body-composer.cjs
@@ -14,6 +14,11 @@
 // (`K3_WISE_PRESET_PLACEHOLDER_UNFILLED`); the preview reports them as a validation error. Both
 // consume `findUnfilledPlaceholders()`, so detection is identical and disposition is the caller's.
 
+// Nested-path projection (getPath/setPath) so a schema field name like "nested.code" projects
+// correctly — the generic preview contract DF-T1-0 must not break. For flat K3 names (FNumber,
+// FUnitGroupID, …) these behave exactly like flat access, so adapter Save parity is preserved.
+const { getPath, setPath } = require('../transform-engine.cjs')
+
 function isPlainObject(value) {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
 }
@@ -22,21 +27,16 @@ function isBlankValue(value) {
   return value === undefined || value === null || (typeof value === 'string' && value.trim() === '')
 }
 
-function firstDefined(...values) {
-  for (const value of values) {
-    if (value !== undefined && value !== null) return value
-  }
-  return undefined
-}
-
+// Resolve the reference identifier, treating an empty/whitespace string as ABSENT and falling
+// back to identifierField / key (a `{ identifier: '' }` must not disable wrapping when an
+// identifierField is present). Returns the trimmed identifier or null.
 function normalizeReferenceIdentifier(field) {
   const reference = field && isPlainObject(field.reference) ? field.reference : null
-  const identifier = firstDefined(
-    reference && reference.identifier,
-    reference && reference.identifierField,
-    reference && reference.key,
-  )
-  return typeof identifier === 'string' && identifier.trim() ? identifier.trim() : null
+  if (!reference) return null
+  for (const candidate of [reference.identifier, reference.identifierField, reference.key]) {
+    if (typeof candidate === 'string' && candidate.trim()) return candidate.trim()
+  }
+  return null
 }
 
 // Scalar reference values are wrapped as `{ [identifier]: value }`; values that are already
@@ -59,10 +59,10 @@ function projectRecordForBody(record, objectConfig) {
   for (const field of schema) {
     const fieldName = field && field.name
     if (typeof fieldName !== 'string' || fieldName.trim().length === 0) continue
-    if (Object.prototype.hasOwnProperty.call(record, fieldName)) {
-      const value = applyReferenceShape(record[fieldName], field)
-      if (!isBlankValue(value)) projected[fieldName] = value
-    }
+    const raw = getPath(record, fieldName)
+    if (raw === undefined) continue
+    const value = applyReferenceShape(raw, field)
+    if (!isBlankValue(value)) setPath(projected, fieldName, value)
   }
   return projected
 }

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-webapi-adapter.cjs
@@ -27,6 +27,10 @@ const {
 } = require('./k3-wise-document-templates.cjs')
 const crypto = require('node:crypto')
 const { scrubSecretStringValue } = require('../payload-redaction.cjs')
+// DF-T1-0: single source of truth for Save-body composition, shared with the no-write
+// preview (http-routes.cjs). Placeholder detection (findUnfilledPlaceholders) is shared; the
+// Save path below owns the throw disposition, the preview owns the valid:false disposition.
+const { composeSchemaBody, findUnfilledPlaceholders, projectRecordForBody } = require('./k3-save-body-composer.cjs')
 
 class K3WiseWebApiAdapterError extends Error {
   constructor(message, details = {}) {
@@ -133,21 +137,7 @@ function isBlankValue(value) {
   return value === undefined || value === null || (typeof value === 'string' && value.trim() === '')
 }
 
-function normalizeReferenceIdentifier(field) {
-  const reference = field && isPlainObject(field.reference) ? field.reference : null
-  const identifier = firstDefined(
-    reference && reference.identifier,
-    reference && reference.identifierField,
-    reference && reference.key,
-  )
-  return typeof identifier === 'string' && identifier.trim() ? identifier.trim() : null
-}
-
-function applyReferenceShape(value, field) {
-  const identifier = normalizeReferenceIdentifier(field)
-  if (!identifier || isBlankValue(value) || isPlainObject(value)) return value
-  return { [identifier]: value }
-}
+// normalizeReferenceIdentifier + applyReferenceShape moved to k3-save-body-composer.cjs (DF-T1-0).
 
 function normalizeBusinessBoolean(value) {
   if (value === undefined || value === null || value === '') return null
@@ -467,43 +457,18 @@ function buildSaveBody(record, request, objectConfig) {
   if (typeof objectConfig.buildBody === 'function') {
     return objectConfig.buildBody(record, request)
   }
-  const bodyKey = objectConfig.bodyKey || 'Data'
-  const base = isPlainObject(objectConfig.bodyTemplate) ? cloneJson(objectConfig.bodyTemplate) : {}
-  const projected = projectRecordForBody(record, objectConfig)
-  base[bodyKey] = isPlainObject(base[bodyKey]) && isPlainObject(projected)
-    ? { ...base[bodyKey], ...projected }
-    : projected
-  return base
-}
-
-// A value that IS exactly a `<…>` token (template placeholder), not one that merely
-// contains angle brackets. Anchored so real values like "<M6>" specs are not over-matched
-// unless the whole value is a bare sentinel.
-const PLACEHOLDER_SENTINEL = /^<[^>]+>$/
-
-// Fail-closed: an unreplaced preset placeholder must never reach a K3 Save. Scan the
-// projected body recursively (reference shapes nest the placeholder one level down) and
-// reject BEFORE the HTTP call so a half-configured profile errors cleanly instead of
-// writing corrupt data to K3.
-function assertNoUnfilledPlaceholders(value, fieldPath) {
-  if (typeof value === 'string') {
-    if (PLACEHOLDER_SENTINEL.test(value.trim())) {
-      throw new AdapterValidationError(
-        `K3 WISE Save body has an unfilled placeholder at ${fieldPath}; supply the customer value before saving`,
-        { code: 'K3_WISE_PRESET_PLACEHOLDER_UNFILLED', field: fieldPath },
-      )
-    }
-    return
+  const body = composeSchemaBody(record, objectConfig)
+  // Fail-closed: an unreplaced preset placeholder must never reach a K3 Save. Detection is
+  // shared with the no-write preview (findUnfilledPlaceholders); the Save path rejects before
+  // the HTTP call so a half-configured profile errors cleanly instead of writing corrupt data.
+  const unfilled = findUnfilledPlaceholders(body)
+  if (unfilled.length > 0) {
+    throw new AdapterValidationError(
+      `K3 WISE Save body has an unfilled placeholder at ${unfilled[0]}; supply the customer value before saving`,
+      { code: 'K3_WISE_PRESET_PLACEHOLDER_UNFILLED', field: unfilled[0] },
+    )
   }
-  if (Array.isArray(value)) {
-    value.forEach((item, index) => assertNoUnfilledPlaceholders(item, `${fieldPath}[${index}]`))
-    return
-  }
-  if (isPlainObject(value)) {
-    for (const [key, child] of Object.entries(value)) {
-      assertNoUnfilledPlaceholders(child, `${fieldPath}.${key}`)
-    }
-  }
+  return body
 }
 
 const UUID_RE = /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i
@@ -552,27 +517,8 @@ function buildRowSaveDiagnostic({ status, record, key, rawMessage, code }) {
   }
 }
 
-function projectRecordForBody(record, objectConfig) {
-  if (objectConfig.passThroughBody === true) return record
-  if (!isPlainObject(record)) return record
-  const schemaFields = Array.isArray(objectConfig.schema)
-    ? objectConfig.schema
-      .map((field) => field && field.name)
-      .filter((name) => typeof name === 'string' && name.trim().length > 0)
-    : []
-  if (schemaFields.length === 0) return record
-  const projected = {}
-  for (const field of objectConfig.schema) {
-    const fieldName = field && field.name
-    if (typeof fieldName !== 'string' || fieldName.trim().length === 0) continue
-    if (Object.prototype.hasOwnProperty.call(record, fieldName)) {
-      const value = applyReferenceShape(record[fieldName], field)
-      if (!isBlankValue(value)) projected[fieldName] = value
-    }
-  }
-  assertNoUnfilledPlaceholders(projected, 'Data')
-  return projected
-}
+// projectRecordForBody moved to k3-save-body-composer.cjs (DF-T1-0); imported above and
+// re-exported via __internals for tests.
 
 function normalizeStringList(value, field) {
   if (value === undefined || value === null || value === '') return []

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -964,6 +964,7 @@ module.exports = {
   registerIntegrationRoutes,
   VALID_USER_RUN_MODES,
   __internals: {
+    buildTemplatePreview,
     hasPermission,
     requireAccess,
     resolveTenantId,

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -31,7 +31,11 @@ const ROUTES = [
   ['POST', '/api/integration/dead-letters/:id/replay', 'deadLettersReplay'],
 ]
 const { sanitizeIntegrationPayload, scrubSecretStringValue } = require('./payload-redaction.cjs')
-const { getPath, setPath, transformRecord } = require('./transform-engine.cjs')
+const { getPath, transformRecord } = require('./transform-engine.cjs')
+// DF-T1-0: compose the no-write preview through the SAME K3 Save-body composer the adapter
+// uses, so the preview is byte-identical to the real Save (single source of truth — replaces
+// the former divergent applyPreviewReferenceShape/projectRecordForTemplate copies).
+const { projectRecordForBody, findUnfilledPlaceholders } = require('./adapters/k3-save-body-composer.cjs')
 const { validateRecord } = require('./validator.cjs')
 
 class HttpRouteError extends Error {
@@ -577,31 +581,9 @@ function schemaRequiredErrors(record, schema) {
   return errors
 }
 
-function projectRecordForTemplate(record, schema) {
-  if (!Array.isArray(schema) || schema.length === 0) return record
-  const projected = {}
-  for (const field of schema) {
-    const value = getPath(record, field.name)
-    if (value !== undefined) setPath(projected, field.name, applyPreviewReferenceShape(value, field))
-  }
-  return projected
-}
-
-function normalizePreviewReferenceIdentifier(field) {
-  const reference = field && isPlainObject(field.reference) ? field.reference : null
-  const identifier = firstString(
-    reference && reference.identifier,
-    reference && reference.identifierField,
-    reference && reference.key,
-  )
-  return identifier || null
-}
-
-function applyPreviewReferenceShape(value, field) {
-  const identifier = normalizePreviewReferenceIdentifier(field)
-  if (!identifier || value === undefined || value === null || value === '' || isPlainObject(value)) return value
-  return { [identifier]: value }
-}
+// projectRecordForTemplate / applyPreviewReferenceShape / normalizePreviewReferenceIdentifier
+// moved to the shared K3 Save-body composer (DF-T1-0): the preview now composes
+// byte-identically to the adapter Save instead of via a divergent duplicate.
 
 function buildTemplatePreview(input) {
   if (!isPlainObject(input)) {
@@ -615,14 +597,24 @@ function buildTemplatePreview(input) {
   const transformed = transformRecord(input.sourceRecord, fieldMappings)
   const validation = transformed.ok ? validateRecord(transformed.value, fieldMappings) : { ok: true, valid: true, errors: [] }
   const requiredErrors = transformed.ok ? schemaRequiredErrors(transformed.value, template.schema) : []
-  const targetRecord = projectRecordForTemplate(transformed.value, template.schema)
+  // Compose through the shared composer (same projection + reference shaping + drop-blank the
+  // adapter Save uses). template carries .schema + .bodyKey, so it serves as the objectConfig.
+  const targetRecord = projectRecordForBody(transformed.value, template)
   const payload = {
     [template.bodyKey]: cloneJson(targetRecord),
   }
+  // Same placeholder DETECTION as the Save path; the preview's disposition is valid:false
+  // (the Save path throws). A clean preview therefore cannot hide a placeholder the Save rejects.
+  const placeholderErrors = findUnfilledPlaceholders(payload).map((path) => ({
+    field: path,
+    code: 'UNFILLED_PLACEHOLDER',
+    message: `unfilled template placeholder at ${path}`,
+  }))
   const errors = [
     ...transformed.errors,
     ...validation.errors,
     ...requiredErrors,
+    ...placeholderErrors,
   ].map((error) => cloneJson(error))
   return sanitizeIntegrationPayload({
     valid: errors.length === 0,
@@ -632,6 +624,7 @@ function buildTemplatePreview(input) {
     transformErrors: transformed.errors.map((error) => cloneJson(error)),
     validationErrors: validation.errors.map((error) => cloneJson(error)),
     schemaErrors: requiredErrors.map((error) => cloneJson(error)),
+    placeholderErrors: placeholderErrors.map((error) => cloneJson(error)),
     template: template.meta,
   })
 }

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -605,9 +605,11 @@ function buildTemplatePreview(input) {
   }
   // Same placeholder DETECTION as the Save path; the preview's disposition is valid:false
   // (the Save path throws). A clean preview therefore cannot hide a placeholder the Save rejects.
+  // Same error CODE as the Save path's throw, so an operator can correlate a preview-detected
+  // placeholder with the Save-side failure that would follow.
   const placeholderErrors = findUnfilledPlaceholders(payload).map((path) => ({
     field: path,
-    code: 'UNFILLED_PLACEHOLDER',
+    code: 'K3_WISE_PRESET_PLACEHOLDER_UNFILLED',
     message: `unfilled template placeholder at ${path}`,
   }))
   const errors = [


### PR DESCRIPTION
## What

**DF-T1-0** (the gated first step of the DF-T template track): converge the K3 no-write **preview** and the real adapter **Save** onto one Save-body composer, so a preview is byte-identical to what K3 actually receives. Previously the preview path (`http-routes.cjs` `applyPreviewReferenceShape`/`projectRecordForTemplate`) was a **divergent duplicate** of the adapter (`applyReferenceShape`/`projectRecordForBody`/`buildSaveBody`), and #1912's fail-closed-placeholder + customer-preset lived **only in the adapter** — making the preview a false-confidence surface. 3 commits: composer → adapter rewire → preview rewire + tests.

## Review against the 6 hard points

1. **preview/save share a composer / dry-build seam** — ✅ **seam B**: new `lib/adapters/k3-save-body-composer.cjs` is the single source; both the adapter `buildSaveBody` and the preview `buildTemplatePreview` compose through it.
2. **no third K3 shaper/projector** — ✅ deleted the preview's copies; **grep gate** test asserts no `function applyPreviewReferenceShape`/`projectRecordForTemplate` in http-routes, no `function applyReferenceShape`/`projectRecordForBody` in the adapter, and the composer is their sole home (blocks reappearance).
3. **parity tests cover preset / placeholder / object-passthrough** — ✅ all three in `k3-save-body-composer.parity.test.cjs`, comparing the **real preview output** vs the **real adapter Save body**. Placeholder: same detection (`findUnfilledPlaceholders`), dispositions differ — Save throws `K3_WISE_PRESET_PLACEHOLDER_UNFILLED`, preview reports `valid:false`. Two negative controls verified (neutralize detector → placeholder test fails; un-wire preview → byte parity fails).
4. **no-write (no login/fetch/Submit/Audit/BOM/list/search)** — ✅ the composer + preview are pure (no fetch param); test asserts the preview composes with zero captured calls.
5. **shape vs completeness layered** — ✅ the composer owns **shape only** (scalar-wrap / object-passthrough by `reference.identifier`); two-field **completeness** (`require-fnumber-fname`/`require-fid-fname`) is deliberately **NOT** in the composer — it's a readiness-validation concern for a later slice. `applyReferenceShape` does scalar-wrap + passthrough, never FName-presence validation.
6. **R-REDACT not regressed** — ✅ DF-T1-0 does not touch redaction; the preview still routes through `sanitizeIntegrationPayload`, the adapter diagnostics still use `scrubSecretStringValue`. Existing secret-not-leaking preview test stays green.

## Notes

- Behavior byte-stable: k3-wise-adapters / k3-wise-material-presets / http-routes / e2e-plm-k3wise-writeback / pipeline-runner all green (full integration-core sweep passes with deps).
- **Wire delta** (documented): the preview's `targetRecord` now omits a blank field (drop-blank, matching Save) instead of keeping it empty — no consumer outside tests reads it; more correct.
- Scope: K3 composition only; no route/migration/RBAC/auth; no DF-T1 `payloadTemplate`/`fieldRules` yet (this is purely the parity seam).

🤖 Generated with [Claude Code](https://claude.com/claude-code)