### PR TITLE
ci(attendance): add deploy-host auth fallback to prod alert gates

### DIFF
--- a/.github/workflows/attendance-import-perf-baseline.yml
+++ b/.github/workflows/attendance-import-perf-baseline.yml
@@ -157,6 +157,11 @@ jobs:
       LOGIN_EMAIL: ${{ secrets.ATTENDANCE_ADMIN_EMAIL || vars.ATTENDANCE_ADMIN_EMAIL || '' }}
       LOGIN_PASSWORD: ${{ secrets.ATTENDANCE_ADMIN_PASSWORD || vars.ATTENDANCE_ADMIN_PASSWORD || '' }}
       AUTH_RESOLVE_ALLOW_INSECURE_HTTP: ${{ vars.ATTENDANCE_ALLOW_INSECURE_HTTP || 'true' }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+      DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+      DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
       PERF_PROFILE: ${{ github.event_name == 'schedule' && 'standard' || inputs.profile || vars.ATTENDANCE_PERF_BASELINE_PROFILE || 'standard' }}
       # Schedule runs must stay stable and short. Keep manual dispatch flexible.
       ROWS: ${{ github.event_name == 'schedule' && (vars.ATTENDANCE_PERF_BASELINE_ROWS_SCHEDULE || '10000') || (inputs.profile == 'high-scale' && (vars.ATTENDANCE_PERF_BASELINE_ROWS_HIGH || '100000')) || inputs.rows || vars.ATTENDANCE_PERF_BASELINE_ROWS || '20000' }}
@@ -195,8 +200,11 @@ jobs:
           set -euo pipefail
           mkdir -p output/playwright/attendance-import-perf
           meta_file="output/playwright/attendance-import-perf/auth-resolve-meta.txt"
+          fallback_log="output/playwright/attendance-import-perf/deploy-host-auth-fallback.log"
 
-          if ! resolved_token="$(
+          resolved_token=""
+          set +e
+          resolved_token="$(
             API_BASE="${API_BASE}" \
             AUTH_TOKEN="${AUTH_TOKEN}" \
             LOGIN_EMAIL="${LOGIN_EMAIL}" \
@@ -204,7 +212,43 @@ jobs:
             AUTH_RESOLVE_ALLOW_INSECURE_HTTP="${AUTH_RESOLVE_ALLOW_INSECURE_HTTP}" \
             AUTH_RESOLVE_META_FILE="${meta_file}" \
             ./scripts/ops/attendance-resolve-auth.sh
-          )"; then
+          )"
+          resolve_rc=$?
+          set -e
+
+          if [[ "${resolve_rc}" != "0" ]]; then
+            echo "[attendance-import-perf] configured auth failed; trying deploy-host token fallback" | tee "${fallback_log}"
+            set +e
+            fallback_token="$(
+              ATTENDANCE_TOKEN_RESOLVE_REQUIRED=false \
+              DEPLOY_HOST="${DEPLOY_HOST}" \
+              DEPLOY_USER="${DEPLOY_USER}" \
+              DEPLOY_SSH_KEY_B64="${DEPLOY_SSH_KEY_B64}" \
+              DEPLOY_PATH="${DEPLOY_PATH}" \
+              DEPLOY_COMPOSE_FILE="${DEPLOY_COMPOSE_FILE}" \
+              ./scripts/ops/resolve-attendance-smoke-token.sh 2> >(tee -a "${fallback_log}" >&2)
+            )"
+            fallback_rc=$?
+            set -e
+
+            if [[ "${fallback_rc}" == "0" && -n "${fallback_token}" ]]; then
+              echo "::add-mask::${fallback_token}"
+              set +e
+              resolved_token="$(
+                API_BASE="${API_BASE}" \
+                AUTH_TOKEN="${fallback_token}" \
+                LOGIN_EMAIL="" \
+                LOGIN_PASSWORD="" \
+                AUTH_RESOLVE_ALLOW_INSECURE_HTTP="${AUTH_RESOLVE_ALLOW_INSECURE_HTTP}" \
+                AUTH_RESOLVE_META_FILE="${meta_file}" \
+                ./scripts/ops/attendance-resolve-auth.sh
+              )"
+              resolve_rc=$?
+              set -e
+            fi
+          fi
+
+          if [[ "${resolve_rc}" != "0" || -z "${resolved_token}" ]]; then
             API_BASE="${API_BASE}" \
             ./scripts/ops/attendance-write-auth-error.sh \
               "${meta_file}" \

--- a/.github/workflows/attendance-import-perf-highscale.yml
+++ b/.github/workflows/attendance-import-perf-highscale.yml
@@ -145,6 +145,11 @@ jobs:
       LOGIN_EMAIL: ${{ secrets.ATTENDANCE_ADMIN_EMAIL || vars.ATTENDANCE_ADMIN_EMAIL || '' }}
       LOGIN_PASSWORD: ${{ secrets.ATTENDANCE_ADMIN_PASSWORD || vars.ATTENDANCE_ADMIN_PASSWORD || '' }}
       AUTH_RESOLVE_ALLOW_INSECURE_HTTP: ${{ vars.ATTENDANCE_ALLOW_INSECURE_HTTP || 'true' }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+      DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+      DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
       PERF_PROFILE: high-scale
       ROWS: ${{ inputs.rows || vars.ATTENDANCE_PERF_HIGHSCALE_ROWS || '100000' }}
       MODE: ${{ inputs.mode || 'commit' }}
@@ -182,8 +187,11 @@ jobs:
           set -euo pipefail
           mkdir -p output/playwright/attendance-import-perf-highscale
           meta_file="output/playwright/attendance-import-perf-highscale/auth-resolve-meta.txt"
+          fallback_log="output/playwright/attendance-import-perf-highscale/deploy-host-auth-fallback.log"
 
-          if ! resolved_token="$(
+          resolved_token=""
+          set +e
+          resolved_token="$(
             API_BASE="${API_BASE}" \
             AUTH_TOKEN="${AUTH_TOKEN}" \
             LOGIN_EMAIL="${LOGIN_EMAIL}" \
@@ -191,7 +199,43 @@ jobs:
             AUTH_RESOLVE_ALLOW_INSECURE_HTTP="${AUTH_RESOLVE_ALLOW_INSECURE_HTTP}" \
             AUTH_RESOLVE_META_FILE="${meta_file}" \
             ./scripts/ops/attendance-resolve-auth.sh
-          )"; then
+          )"
+          resolve_rc=$?
+          set -e
+
+          if [[ "${resolve_rc}" != "0" ]]; then
+            echo "[attendance-import-perf-highscale] configured auth failed; trying deploy-host token fallback" | tee "${fallback_log}"
+            set +e
+            fallback_token="$(
+              ATTENDANCE_TOKEN_RESOLVE_REQUIRED=false \
+              DEPLOY_HOST="${DEPLOY_HOST}" \
+              DEPLOY_USER="${DEPLOY_USER}" \
+              DEPLOY_SSH_KEY_B64="${DEPLOY_SSH_KEY_B64}" \
+              DEPLOY_PATH="${DEPLOY_PATH}" \
+              DEPLOY_COMPOSE_FILE="${DEPLOY_COMPOSE_FILE}" \
+              ./scripts/ops/resolve-attendance-smoke-token.sh 2> >(tee -a "${fallback_log}" >&2)
+            )"
+            fallback_rc=$?
+            set -e
+
+            if [[ "${fallback_rc}" == "0" && -n "${fallback_token}" ]]; then
+              echo "::add-mask::${fallback_token}"
+              set +e
+              resolved_token="$(
+                API_BASE="${API_BASE}" \
+                AUTH_TOKEN="${fallback_token}" \
+                LOGIN_EMAIL="" \
+                LOGIN_PASSWORD="" \
+                AUTH_RESOLVE_ALLOW_INSECURE_HTTP="${AUTH_RESOLVE_ALLOW_INSECURE_HTTP}" \
+                AUTH_RESOLVE_META_FILE="${meta_file}" \
+                ./scripts/ops/attendance-resolve-auth.sh
+              )"
+              resolve_rc=$?
+              set -e
+            fi
+          fi
+
+          if [[ "${resolve_rc}" != "0" || -z "${resolved_token}" ]]; then
             API_BASE="${API_BASE}" \
             ./scripts/ops/attendance-write-auth-error.sh \
               "${meta_file}" \
@@ -203,12 +247,19 @@ jobs:
           echo "::add-mask::${resolved_token}"
           echo "AUTH_TOKEN_EFFECTIVE=${resolved_token}" >> "$GITHUB_ENV"
 
+          auth_source="unknown"
+          if [[ -f "${meta_file}" ]]; then
+            auth_source="$(awk -F= '/^AUTH_SOURCE=/{print $2}' "${meta_file}" | tail -n1)"
+          fi
+          echo "auth_source=${auth_source}" >> "$GITHUB_OUTPUT"
+
       - name: Log resolved high-scale config
         run: |
           set -euo pipefail
           echo "event=${{ github.event_name }}"
           echo "api_base=${API_BASE}"
           echo "profile=${PERF_PROFILE}"
+          echo "auth_source=${{ steps.resolve-auth-token.outputs.auth_source || 'unknown' }}"
           echo "rows=${ROWS}"
           echo "mode=${MODE}"
           echo "preview_mode=${PREVIEW_MODE}"

--- a/.github/workflows/attendance-strict-gates-prod.yml
+++ b/.github/workflows/attendance-strict-gates-prod.yml
@@ -263,6 +263,11 @@ jobs:
       LOGIN_EMAIL: ${{ secrets.ATTENDANCE_ADMIN_EMAIL || vars.ATTENDANCE_ADMIN_EMAIL || '' }}
       LOGIN_PASSWORD: ${{ secrets.ATTENDANCE_ADMIN_PASSWORD || vars.ATTENDANCE_ADMIN_PASSWORD || '' }}
       AUTH_RESOLVE_ALLOW_INSECURE_HTTP: ${{ vars.ATTENDANCE_ALLOW_INSECURE_HTTP || 'true' }}
+      DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+      DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+      DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+      DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+      DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
       PROVISION_USER_ID: ${{ vars.ATTENDANCE_PROVISION_USER_ID }}
       EXPECT_PRODUCT_MODE: ${{ inputs.expect_product_mode || 'attendance' }}
       RUN_PREFLIGHT: 'false'
@@ -307,8 +312,11 @@ jobs:
           set -euo pipefail
           mkdir -p output/playwright/attendance-prod-acceptance
           meta_file="output/playwright/attendance-prod-acceptance/auth-resolve-meta.txt"
+          fallback_log="output/playwright/attendance-prod-acceptance/deploy-host-auth-fallback.log"
 
-          if ! resolved_token="$(
+          resolved_token=""
+          set +e
+          resolved_token="$(
             API_BASE="${API_BASE}" \
             AUTH_TOKEN="${AUTH_TOKEN}" \
             LOGIN_EMAIL="${LOGIN_EMAIL}" \
@@ -316,7 +324,43 @@ jobs:
             AUTH_RESOLVE_ALLOW_INSECURE_HTTP="${AUTH_RESOLVE_ALLOW_INSECURE_HTTP}" \
             AUTH_RESOLVE_META_FILE="${meta_file}" \
             ./scripts/ops/attendance-resolve-auth.sh
-          )"; then
+          )"
+          resolve_rc=$?
+          set -e
+
+          if [[ "${resolve_rc}" != "0" ]]; then
+            echo "[attendance-strict-gates] configured auth failed; trying deploy-host token fallback" | tee "${fallback_log}"
+            set +e
+            fallback_token="$(
+              ATTENDANCE_TOKEN_RESOLVE_REQUIRED=false \
+              DEPLOY_HOST="${DEPLOY_HOST}" \
+              DEPLOY_USER="${DEPLOY_USER}" \
+              DEPLOY_SSH_KEY_B64="${DEPLOY_SSH_KEY_B64}" \
+              DEPLOY_PATH="${DEPLOY_PATH}" \
+              DEPLOY_COMPOSE_FILE="${DEPLOY_COMPOSE_FILE}" \
+              ./scripts/ops/resolve-attendance-smoke-token.sh 2> >(tee -a "${fallback_log}" >&2)
+            )"
+            fallback_rc=$?
+            set -e
+
+            if [[ "${fallback_rc}" == "0" && -n "${fallback_token}" ]]; then
+              echo "::add-mask::${fallback_token}"
+              set +e
+              resolved_token="$(
+                API_BASE="${API_BASE}" \
+                AUTH_TOKEN="${fallback_token}" \
+                LOGIN_EMAIL="" \
+                LOGIN_PASSWORD="" \
+                AUTH_RESOLVE_ALLOW_INSECURE_HTTP="${AUTH_RESOLVE_ALLOW_INSECURE_HTTP}" \
+                AUTH_RESOLVE_META_FILE="${meta_file}" \
+                ./scripts/ops/attendance-resolve-auth.sh
+              )"
+              resolve_rc=$?
+              set -e
+            fi
+          fi
+
+          if [[ "${resolve_rc}" != "0" || -z "${resolved_token}" ]]; then
             API_BASE="${API_BASE}" \
             ./scripts/ops/attendance-write-auth-error.sh \
               "${meta_file}" \

--- a/scripts/ops/attendance-prod-auth-fallback-workflow-contract.test.mjs
+++ b/scripts/ops/attendance-prod-auth-fallback-workflow-contract.test.mjs
@@ -1,0 +1,47 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+
+const cases = [
+  {
+    workflow: '.github/workflows/attendance-strict-gates-prod.yml',
+    outputDir: 'output/playwright/attendance-prod-acceptance',
+    marker: 'attendance-strict-gates',
+  },
+  {
+    workflow: '.github/workflows/attendance-import-perf-baseline.yml',
+    outputDir: 'output/playwright/attendance-import-perf',
+    marker: 'attendance-import-perf',
+  },
+  {
+    workflow: '.github/workflows/attendance-import-perf-highscale.yml',
+    outputDir: 'output/playwright/attendance-import-perf-highscale',
+    marker: 'attendance-import-perf-highscale',
+  },
+]
+
+for (const item of cases) {
+  test(`${item.workflow} can mint attendance auth from deploy host`, () => {
+    const raw = readFileSync(path.join(repoRoot, item.workflow), 'utf8')
+
+    assert.match(
+      raw,
+      /AUTH_TOKEN:\s+\$\{\{\s*secrets\.ATTENDANCE_ADMIN_JWT\s+\|\|\s+vars\.ATTENDANCE_ADMIN_JWT\s+\|\|\s+''\s*\}\}/,
+    )
+    assert.match(raw, /DEPLOY_HOST:\s+\$\{\{\s*secrets\.DEPLOY_HOST\s*\}\}/)
+    assert.match(raw, /DEPLOY_USER:\s+\$\{\{\s*secrets\.DEPLOY_USER\s*\}\}/)
+    assert.match(raw, /DEPLOY_SSH_KEY_B64:\s+\$\{\{\s*secrets\.DEPLOY_SSH_KEY_B64\s*\}\}/)
+    assert.match(raw, /DEPLOY_PATH:\s+\$\{\{\s*secrets\.DEPLOY_PATH\s*\}\}/)
+    assert.match(raw, /DEPLOY_COMPOSE_FILE:\s+\$\{\{\s*secrets\.DEPLOY_COMPOSE_FILE\s*\}\}/)
+    assert.match(raw, new RegExp(`${item.outputDir}/deploy-host-auth-fallback\\.log`))
+    assert.match(raw, new RegExp(`\\[${item.marker}\\] configured auth failed; trying deploy-host token fallback`))
+    assert.match(raw, /\.\/scripts\/ops\/attendance-resolve-auth\.sh/)
+    assert.match(raw, /\.\/scripts\/ops\/resolve-attendance-smoke-token\.sh/)
+    assert.match(raw, /\.\/scripts\/ops\/attendance-write-auth-error\.sh/)
+    assert.match(raw, /ATTENDANCE_TOKEN_RESOLVE_REQUIRED=false/)
+    assert.match(raw, /AUTH_TOKEN_EFFECTIVE=\$\{resolved_token\}/)
+  })
+}


### PR DESCRIPTION
## Summary
- add the existing deploy-host attendance smoke-token fallback to prod strict gates, perf baseline, and perf highscale workflows
- keep the normal `ATTENDANCE_ADMIN_JWT` / login resolver first, then mint a runtime token from the deploy host only when configured auth fails
- add a workflow-contract test that locks the fallback env, logs, resolver calls, and effective-token wiring for the three alert workflows

## Why
Latest open alert issues show auth infrastructure failure before the actual gates can run:
- #189 strict gates: `no valid auth token`, no `gate-summary.json`
- #213 perf baseline: `no valid auth token`
- #447 highscale uses the same resolver path and lacked the fallback too

This does not close those issues by itself. It removes the stale-token early-return so the next main runs can expose the real gate result.

## Verification
- `node --test scripts/ops/attendance-prod-auth-fallback-workflow-contract.test.mjs scripts/ops/attendance-locale-zh-workflow-contract.test.mjs scripts/ops/attendance-import-perf-longrun-workflow-contract.test.mjs`
- `node --check scripts/ops/attendance-prod-auth-fallback-workflow-contract.test.mjs`
- `bash -n scripts/ops/resolve-attendance-smoke-token.sh scripts/ops/attendance-resolve-auth.sh scripts/ops/attendance-write-auth-error.sh`
- `git diff --check origin/main...HEAD`

Refs #189, #213, #447.
