### PR TITLE
ci(attendance): align strict gate product mode

### DIFF
--- a/.github/workflows/attendance-strict-gates-prod.yml
+++ b/.github/workflows/attendance-strict-gates-prod.yml
@@ -39,9 +39,9 @@ on:
         required: false
         default: 'http://23.254.236.11:8081/api'
       expect_product_mode:
-        description: 'Expected product mode (from /api/auth/me -> features.mode)'
+        description: 'Expected product mode from /api/auth/me -> features.mode (platform for current shared prod; use attendance for attendance-only deployments)'
         required: false
-        default: 'attendance'
+        default: 'platform'
       require_attendance_admin_api:
         description: 'Require attendance admin API endpoints (true/false)'
         required: false
@@ -269,7 +269,7 @@ jobs:
       DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
       DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
       PROVISION_USER_ID: ${{ vars.ATTENDANCE_PROVISION_USER_ID }}
-      EXPECT_PRODUCT_MODE: ${{ inputs.expect_product_mode || 'attendance' }}
+      EXPECT_PRODUCT_MODE: ${{ inputs.expect_product_mode || vars.ATTENDANCE_EXPECT_PRODUCT_MODE || 'platform' }}
       RUN_PREFLIGHT: 'false'
       REQUIRE_ATTENDANCE_ADMIN_API: ${{ inputs.require_attendance_admin_api || 'true' }}
       REQUIRE_IDEMPOTENCY: ${{ inputs.require_idempotency || 'true' }}

--- a/scripts/ops/attendance-daily-gate-report.mjs
+++ b/scripts/ops/attendance-daily-gate-report.mjs
@@ -1313,7 +1313,7 @@ function renderMarkdown({
         } else if (apiReason === 'RATE_LIMITED') {
           lines.push('- Strict Gates: `apiSmoke` was rate-limited. Wait briefly and rerun; consider reviewing rate-limit settings if this is frequent.')
         } else if (apiReason === 'PRODUCT_MODE_MISMATCH') {
-          lines.push('- Strict Gates: `apiSmoke` product mode mismatch. Ensure `PRODUCT_MODE=attendance` and `/api/auth/me -> features.mode` matches, then rerun.')
+          lines.push('- Strict Gates: `apiSmoke` product mode mismatch. Align `EXPECT_PRODUCT_MODE` / `ATTENDANCE_EXPECT_PRODUCT_MODE` with production `/api/auth/me -> features.mode` (current shared prod uses `platform`; attendance-only deployments use `attendance`), then rerun.')
         } else if (apiReason === 'FEATURE_DISABLED') {
           lines.push('- Strict Gates: `apiSmoke` feature disabled. Ensure attendance plugin is enabled in the target environment, then rerun.')
         } else if (apiReason === 'ADMIN_API_MISSING') {
@@ -1384,7 +1384,7 @@ function renderMarkdown({
         if (pwReason === 'AUTH_FAILED') {
           lines.push('- Strict Gates: `playwrightProd` auth failed. Refresh the admin token and rerun.')
         } else if (pwReason === 'PRODUCT_MODE_MISMATCH') {
-          lines.push('- Strict Gates: `playwrightProd` product mode mismatch. Ensure `PRODUCT_MODE=attendance` and `/api/auth/me -> features.mode` matches, then rerun.')
+          lines.push('- Strict Gates: `playwrightProd` product mode mismatch. Align `EXPECT_PRODUCT_MODE` / `ATTENDANCE_EXPECT_PRODUCT_MODE` with production `/api/auth/me -> features.mode` (current shared prod uses `platform`; attendance-only deployments use `attendance`), then rerun.')
         } else if (pwReason === 'FEATURE_DISABLED') {
           lines.push('- Strict Gates: `playwrightProd` feature disabled. Ensure attendance plugin is enabled, then rerun.')
         } else if (pwReason === 'RATE_LIMITED') {
@@ -1408,7 +1408,7 @@ function renderMarkdown({
         if (pwReason === 'AUTH_FAILED') {
           lines.push('- Strict Gates: `playwrightDesktop` auth failed. Refresh the admin token and rerun.')
         } else if (pwReason === 'PRODUCT_MODE_MISMATCH') {
-          lines.push('- Strict Gates: `playwrightDesktop` product mode mismatch. Ensure `PRODUCT_MODE=attendance` and `/api/auth/me -> features.mode` matches, then rerun.')
+          lines.push('- Strict Gates: `playwrightDesktop` product mode mismatch. Align `EXPECT_PRODUCT_MODE` / `ATTENDANCE_EXPECT_PRODUCT_MODE` with production `/api/auth/me -> features.mode` (current shared prod uses `platform`; attendance-only deployments use `attendance`), then rerun.')
         } else if (pwReason === 'FEATURE_DISABLED') {
           lines.push('- Strict Gates: `playwrightDesktop` feature disabled. Ensure attendance plugin is enabled, then rerun.')
         } else if (pwReason === 'RATE_LIMITED') {
@@ -1432,7 +1432,7 @@ function renderMarkdown({
         if (pwReason === 'AUTH_FAILED') {
           lines.push('- Strict Gates: `playwrightMobile` auth failed. Refresh the admin token and rerun.')
         } else if (pwReason === 'PRODUCT_MODE_MISMATCH') {
-          lines.push('- Strict Gates: `playwrightMobile` product mode mismatch. Ensure `PRODUCT_MODE=attendance` and `/api/auth/me -> features.mode` matches, then rerun.')
+          lines.push('- Strict Gates: `playwrightMobile` product mode mismatch. Align `EXPECT_PRODUCT_MODE` / `ATTENDANCE_EXPECT_PRODUCT_MODE` with production `/api/auth/me -> features.mode` (current shared prod uses `platform`; attendance-only deployments use `attendance`), then rerun.')
         } else if (pwReason === 'FEATURE_DISABLED') {
           lines.push('- Strict Gates: `playwrightMobile` feature disabled. Ensure attendance plugin is enabled, then rerun.')
         } else if (pwReason === 'RATE_LIMITED') {

--- a/scripts/ops/attendance-prod-auth-fallback-workflow-contract.test.mjs
+++ b/scripts/ops/attendance-prod-auth-fallback-workflow-contract.test.mjs
@@ -45,3 +45,24 @@ for (const item of cases) {
     assert.match(raw, /AUTH_TOKEN_EFFECTIVE=\$\{resolved_token\}/)
   })
 }
+
+test('attendance strict gates default product mode matches current shared prod', () => {
+  const raw = readFileSync(
+    path.join(repoRoot, '.github/workflows/attendance-strict-gates-prod.yml'),
+    'utf8',
+  )
+
+  assert.match(
+    raw,
+    /expect_product_mode:\n\s+description:\s+'Expected product mode from \/api\/auth\/me -> features\.mode \(platform for current shared prod; use attendance for attendance-only deployments\)'/,
+  )
+  assert.match(raw, /default:\s+'platform'/)
+  assert.match(
+    raw,
+    /EXPECT_PRODUCT_MODE:\s+\$\{\{\s*inputs\.expect_product_mode\s+\|\|\s+vars\.ATTENDANCE_EXPECT_PRODUCT_MODE\s+\|\|\s+'platform'\s*\}\}/,
+  )
+  assert.doesNotMatch(
+    raw,
+    /EXPECT_PRODUCT_MODE:\s+\$\{\{\s*inputs\.expect_product_mode\s+\|\|\s+'attendance'\s*\}\}/,
+  )
+})


### PR DESCRIPTION
## Summary
- default Attendance Strict Gates prod product-mode expectation to current shared production (`platform`)
- keep an explicit override via workflow input or `ATTENDANCE_EXPECT_PRODUCT_MODE` for attendance-only deployments
- update daily gate guidance so PRODUCT_MODE_MISMATCH points operators at the expected-mode config instead of hard-coding attendance

## Why
Refs #189. After the auth fallback landed, strict gates now reach the real checks and fail because current prod reports `/api/auth/me -> features.mode = platform`, matching the recent production verification docs.

## Verification
- `node --test scripts/ops/attendance-prod-auth-fallback-workflow-contract.test.mjs`
- `node --check scripts/ops/attendance-daily-gate-report.mjs`
- `git diff --check origin/main...HEAD`