### PR TITLE
ci(attendance): reselect import section in full-flow gate

### DIFF
--- a/scripts/ops/attendance-prod-auth-fallback-workflow-contract.test.mjs
+++ b/scripts/ops/attendance-prod-auth-fallback-workflow-contract.test.mjs
@@ -66,3 +66,15 @@ test('attendance strict gates default product mode matches current shared prod',
     /EXPECT_PRODUCT_MODE:\s+\$\{\{\s*inputs\.expect_product_mode\s+\|\|\s+'attendance'\s*\}\}/,
   )
 })
+
+test('attendance full-flow reselects import section after payroll readiness check', () => {
+  const raw = readFileSync(path.join(repoRoot, 'scripts/verify-attendance-full-flow.mjs'), 'utf8')
+  const payrollSelect = raw.indexOf('payrollSection = await selectAdminSection(page, adminSectionIds.payrollCycles')
+  const reselect = raw.indexOf('importSection = await selectAdminSection(page, adminSectionIds.import, labels.importHeading)', payrollSelect + 1)
+  const retryAssertion = raw.indexOf('await assertAdminRetryState(page, importSection)', payrollSelect + 1)
+
+  assert.notEqual(payrollSelect, -1)
+  assert.notEqual(reselect, -1)
+  assert.notEqual(retryAssertion, -1)
+  assert.ok(reselect < retryAssertion)
+})

--- a/scripts/verify-attendance-full-flow.mjs
+++ b/scripts/verify-attendance-full-flow.mjs
@@ -1106,6 +1106,14 @@ async function run() {
       }
 
       const importSectionCount = await importSection.count()
+      const needsImportSection = importSectionCount > 0 && (
+        assertImportScalabilityHint
+        || assertAdminRetry
+        || assertImportJobRecovery
+      )
+      if (needsImportSection) {
+        importSection = await selectAdminSection(page, adminSectionIds.import, labels.importHeading)
+      }
       if (assertImportScalabilityHint && importSectionCount > 0) {
         await importSection.getByText(/Auto mode:\s*preview\s*>=\s*\d+\s*rows/i).first().waitFor({ timeout: timeoutMs })
         logInfo('Import scalability hint verified')


### PR DESCRIPTION
## Summary
- reselect the Admin Import section after the payroll readiness probe before running import-specific full-flow assertions
- add a workflow/verifier contract check so the retry assertion cannot reuse a hidden import section after quick-jump navigation

## Why
Refs #189. After #1940 aligned the product-mode expectation, strict gates reached the real desktop full-flow check and timed out waiting for `#attendance-import-payload` because the script had switched the admin quick-jump to Payroll cycles first.

## Verification
- `node --test scripts/ops/attendance-prod-auth-fallback-workflow-contract.test.mjs`
- `node --check scripts/verify-attendance-full-flow.mjs`
- `git diff --check origin/main...HEAD`