### PR TITLE
ci(attendance): wait for locale holiday badges

### DIFF
--- a/scripts/ops/attendance-locale-zh-workflow-contract.test.mjs
+++ b/scripts/ops/attendance-locale-zh-workflow-contract.test.mjs
@@ -52,3 +52,12 @@ test('attendance locale zh smoke workflow keeps drill before resolver and real s
   assert.match(raw, /if:\s+\$\{\{\s+env\.DRILL_FAIL != 'true'\s+\}\}\n\s+id: resolve-auth-token/)
   assert.match(raw, /if:\s+\$\{\{\s+env\.DRILL_FAIL != 'true'\s+\}\}\n\s+env:\n\s+AUTH_TOKEN:/)
 })
+
+test('attendance locale zh smoke waits for async holiday badges while probing months', () => {
+  const raw = readFileSync(path.join(repoRoot, 'scripts/verify-attendance-locale-zh-smoke.mjs'), 'utf8')
+
+  assert.match(raw, /const holidayBadgeProbeWaitMsRaw = Number\(process\.env\.HOLIDAY_BADGE_WAIT_MS \|\| 10000\)/)
+  assert.match(raw, /const holidayBadgeProbeWaitMs = Number\.isFinite\(holidayBadgeProbeWaitMsRaw\) && holidayBadgeProbeWaitMsRaw > 0/)
+  assert.match(raw, /await target\.waitFor\(\{ timeout: holidayBadgeProbeWaitMs \}\)/)
+  assert.match(raw, /await target\.first\(\)\.waitFor\(\{ timeout: holidayBadgeProbeWaitMs \}\)/)
+})

--- a/scripts/verify-attendance-locale-zh-smoke.mjs
+++ b/scripts/verify-attendance-locale-zh-smoke.mjs
@@ -14,6 +14,10 @@ const orgId = String(process.env.ORG_ID || 'default').trim()
 const verifyHoliday = process.env.VERIFY_HOLIDAY !== 'false'
 const requireToggleChecks = process.env.REQUIRE_TOGGLE_CHECKS === 'true'
 const requireShellTabChecks = process.env.REQUIRE_SHELL_TAB_CHECKS === 'true'
+const holidayBadgeProbeWaitMsRaw = Number(process.env.HOLIDAY_BADGE_WAIT_MS || 10000)
+const holidayBadgeProbeWaitMs = Number.isFinite(holidayBadgeProbeWaitMsRaw) && holidayBadgeProbeWaitMsRaw > 0
+  ? Math.min(timeoutMs, holidayBadgeProbeWaitMsRaw)
+  : Math.min(timeoutMs, 10000)
 
 function normalizeUrl(value) {
   return String(value || '').trim().replace(/\/+$/, '')
@@ -280,10 +284,11 @@ async function findHolidayBadgeAcrossMonths(page, holidayName) {
       await navButtonByStep[step].first().click()
       await page.waitForLoadState('networkidle', { timeout: timeoutMs })
     }
-    const count = await target.count()
-    if (count > 0) {
-      await target.waitFor({ timeout: 5000 })
+    try {
+      await target.waitFor({ timeout: holidayBadgeProbeWaitMs })
       return true
+    } catch {
+      // Keep probing adjacent months; effective-calendar chips load asynchronously.
     }
   }
   const calendarLabel = await page.locator('.attendance__calendar-label').first().textContent().catch(() => '')
@@ -312,6 +317,11 @@ async function findAnyHolidayBadgeAcrossMonths(page) {
     if (step) {
       await navButtonByStep[step].first().click()
       await page.waitForLoadState('networkidle', { timeout: timeoutMs })
+    }
+    try {
+      await target.first().waitFor({ timeout: holidayBadgeProbeWaitMs })
+    } catch {
+      // Keep probing adjacent months; badge data may still be loading for this month.
     }
     const count = await target.count()
     if (count > 0) {


### PR DESCRIPTION
## Summary
- wait for the target holiday badge while probing locale-zh calendar months instead of using an immediate locator count
- wait for any holiday badge before collecting samples, so async effective-calendar chip loading has time to settle
- add a contract test for the explicit badge wait path

## Why
Refs #402. The latest locale zh smoke created a temporary May holiday, but the verifier sampled the calendar before the async effective-calendar chips had refreshed, then navigated away and failed on the April label.

## Verification
- `node --test scripts/ops/attendance-locale-zh-workflow-contract.test.mjs`
- `node --check scripts/verify-attendance-locale-zh-smoke.mjs`
- `git diff --check origin/main...HEAD`