### PR TITLE
ci(attendance): fallback branch protection token

### DIFF
--- a/.github/workflows/attendance-branch-policy-drift-prod.yml
+++ b/.github/workflows/attendance-branch-policy-drift-prod.yml
@@ -61,7 +61,8 @@ jobs:
       rc: ${{ steps.run_check.outputs.rc }}
       reason: ${{ steps.run_check.outputs.reason }}
     env:
-      GH_TOKEN: ${{ secrets.ATTENDANCE_ADMIN_GH_TOKEN || secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.ATTENDANCE_ADMIN_GH_TOKEN || github.token }}
+      GH_TOKEN_FALLBACK: ${{ github.token }}
       BRANCH: ${{ inputs.branch || 'main' }}
       REQUIRED_CHECKS_CSV: ${{ inputs.required_checks_csv || 'contracts (strict),contracts (dashboard)' }}
       REQUIRE_STRICT: ${{ inputs.require_strict || 'true' }}
@@ -82,18 +83,42 @@ jobs:
           set -o pipefail
           mkdir -p output/branch-policy
           log_file="output/branch-policy/policy.log"
+          : > "$log_file"
 
-          REPO="${GITHUB_REPOSITORY}" \
-          BRANCH="${BRANCH}" \
-          REQUIRED_CHECKS_CSV="${REQUIRED_CHECKS_CSV}" \
-          REQUIRE_STRICT="${REQUIRE_STRICT}" \
-          REQUIRE_ENFORCE_ADMINS="${REQUIRE_ENFORCE_ADMINS}" \
-          REQUIRE_PR_REVIEWS="${REQUIRE_PR_REVIEWS}" \
-          MIN_APPROVING_REVIEW_COUNT="${MIN_APPROVING_REVIEW_COUNT}" \
-          REQUIRE_CODE_OWNER_REVIEWS="${REQUIRE_CODE_OWNER_REVIEWS}" \
-          OUTPUT_JSON="output/branch-policy/policy.json" \
-          ./scripts/ops/attendance-check-branch-protection.sh 2>&1 | tee "$log_file"
-          rc="${PIPESTATUS[0]}"
+          run_check_once() {
+            local token="$1"
+            local label="$2"
+            echo "[attendance-branch-policy-drift] token_source=${label}" | tee -a "$log_file"
+            GH_TOKEN="${token}" \
+            REPO="${GITHUB_REPOSITORY}" \
+            BRANCH="${BRANCH}" \
+            REQUIRED_CHECKS_CSV="${REQUIRED_CHECKS_CSV}" \
+            REQUIRE_STRICT="${REQUIRE_STRICT}" \
+            REQUIRE_ENFORCE_ADMINS="${REQUIRE_ENFORCE_ADMINS}" \
+            REQUIRE_PR_REVIEWS="${REQUIRE_PR_REVIEWS}" \
+            MIN_APPROVING_REVIEW_COUNT="${MIN_APPROVING_REVIEW_COUNT}" \
+            REQUIRE_CODE_OWNER_REVIEWS="${REQUIRE_CODE_OWNER_REVIEWS}" \
+            OUTPUT_JSON="output/branch-policy/policy.json" \
+            ./scripts/ops/attendance-check-branch-protection.sh 2>&1 | tee -a "$log_file"
+            return "${PIPESTATUS[0]}"
+          }
+
+          if run_check_once "${GH_TOKEN:-}" "configured"; then
+            rc=0
+          else
+            rc="$?"
+          fi
+
+          if [[ "$rc" != "0" ]] \
+            && grep -Eqi "Bad credentials|HTTP 401" "$log_file" \
+            && [[ -n "${GH_TOKEN_FALLBACK:-}" && "${GH_TOKEN_FALLBACK}" != "${GH_TOKEN:-}" ]]; then
+            echo "[attendance-branch-policy-drift] configured token failed with 401; retrying with github.token fallback" | tee -a "$log_file"
+            if run_check_once "${GH_TOKEN_FALLBACK}" "github-token-fallback"; then
+              rc=0
+            else
+              rc="$?"
+            fi
+          fi
 
           if [[ "${DRILL_FAIL}" == "true" ]]; then
             echo "[attendance-branch-policy-drift][drill] forcing failure after check" | tee -a "$log_file"

--- a/.github/workflows/attendance-branch-protection-prod.yml
+++ b/.github/workflows/attendance-branch-protection-prod.yml
@@ -61,7 +61,8 @@ jobs:
       rc: ${{ steps.run_check.outputs.rc }}
       reason: ${{ steps.run_check.outputs.reason }}
     env:
-      GH_TOKEN: ${{ secrets.ATTENDANCE_ADMIN_GH_TOKEN || secrets.GITHUB_TOKEN }}
+      GH_TOKEN: ${{ secrets.ATTENDANCE_ADMIN_GH_TOKEN || github.token }}
+      GH_TOKEN_FALLBACK: ${{ github.token }}
       BRANCH: ${{ inputs.branch || 'main' }}
       REQUIRED_CHECKS_CSV: ${{ inputs.required_checks_csv || 'contracts (strict),contracts (dashboard)' }}
       REQUIRE_STRICT: ${{ inputs.require_strict || 'true' }}
@@ -82,18 +83,42 @@ jobs:
           set -o pipefail
           mkdir -p output/branch-protection
           log_file="output/branch-protection/protection.log"
+          : > "$log_file"
 
-          REPO="${GITHUB_REPOSITORY}" \
-          BRANCH="${BRANCH}" \
-          REQUIRED_CHECKS_CSV="${REQUIRED_CHECKS_CSV}" \
-          REQUIRE_STRICT="${REQUIRE_STRICT}" \
-          REQUIRE_ENFORCE_ADMINS="${REQUIRE_ENFORCE_ADMINS}" \
-          REQUIRE_PR_REVIEWS="${REQUIRE_PR_REVIEWS}" \
-          MIN_APPROVING_REVIEW_COUNT="${MIN_APPROVING_REVIEW_COUNT}" \
-          REQUIRE_CODE_OWNER_REVIEWS="${REQUIRE_CODE_OWNER_REVIEWS}" \
-          OUTPUT_JSON="output/branch-protection/protection.json" \
-          ./scripts/ops/attendance-check-branch-protection.sh 2>&1 | tee "$log_file"
-          rc="${PIPESTATUS[0]}"
+          run_check_once() {
+            local token="$1"
+            local label="$2"
+            echo "[attendance-branch-protection] token_source=${label}" | tee -a "$log_file"
+            GH_TOKEN="${token}" \
+            REPO="${GITHUB_REPOSITORY}" \
+            BRANCH="${BRANCH}" \
+            REQUIRED_CHECKS_CSV="${REQUIRED_CHECKS_CSV}" \
+            REQUIRE_STRICT="${REQUIRE_STRICT}" \
+            REQUIRE_ENFORCE_ADMINS="${REQUIRE_ENFORCE_ADMINS}" \
+            REQUIRE_PR_REVIEWS="${REQUIRE_PR_REVIEWS}" \
+            MIN_APPROVING_REVIEW_COUNT="${MIN_APPROVING_REVIEW_COUNT}" \
+            REQUIRE_CODE_OWNER_REVIEWS="${REQUIRE_CODE_OWNER_REVIEWS}" \
+            OUTPUT_JSON="output/branch-protection/protection.json" \
+            ./scripts/ops/attendance-check-branch-protection.sh 2>&1 | tee -a "$log_file"
+            return "${PIPESTATUS[0]}"
+          }
+
+          if run_check_once "${GH_TOKEN:-}" "configured"; then
+            rc=0
+          else
+            rc="$?"
+          fi
+
+          if [[ "$rc" != "0" ]] \
+            && grep -Eqi "Bad credentials|HTTP 401" "$log_file" \
+            && [[ -n "${GH_TOKEN_FALLBACK:-}" && "${GH_TOKEN_FALLBACK}" != "${GH_TOKEN:-}" ]]; then
+            echo "[attendance-branch-protection] configured token failed with 401; retrying with github.token fallback" | tee -a "$log_file"
+            if run_check_once "${GH_TOKEN_FALLBACK}" "github-token-fallback"; then
+              rc=0
+            else
+              rc="$?"
+            fi
+          fi
 
           if [[ "${DRILL_FAIL}" == "true" ]]; then
             echo "[attendance-branch-protection][drill] forcing failure after check" | tee -a "$log_file"

--- a/scripts/ops/attendance-branch-token-fallback-workflow-contract.test.mjs
+++ b/scripts/ops/attendance-branch-token-fallback-workflow-contract.test.mjs
@@ -1,0 +1,24 @@
+import test from 'node:test'
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+
+const repoRoot = process.cwd()
+
+const workflows = [
+  '.github/workflows/attendance-branch-protection-prod.yml',
+  '.github/workflows/attendance-branch-policy-drift-prod.yml',
+]
+
+for (const workflow of workflows) {
+  test(`${workflow} retries with github.token when configured token is stale`, () => {
+    const raw = readFileSync(path.join(repoRoot, workflow), 'utf8')
+
+    assert.match(raw, /GH_TOKEN:\s+\$\{\{\s*secrets\.ATTENDANCE_ADMIN_GH_TOKEN\s+\|\|\s+github\.token\s*\}\}/)
+    assert.match(raw, /GH_TOKEN_FALLBACK:\s+\$\{\{\s*github\.token\s*\}\}/)
+    assert.match(raw, /run_check_once\(\)\s+\{/)
+    assert.match(raw, /grep -Eqi "Bad credentials\|HTTP 401" "\$log_file"/)
+    assert.match(raw, /retrying with github\.token fallback/)
+    assert.match(raw, /run_check_once "\$\{GH_TOKEN_FALLBACK\}" "github-token-fallback"/)
+  })
+}


### PR DESCRIPTION
## Summary
- retry branch protection/policy drift checks with `github.token` when the configured admin token returns `Bad credentials` / HTTP 401
- apply the fallback to both legacy branch-protection and current branch-policy workflows
- add a workflow contract test for the stale-token retry path

## Why
Refs #190. The latest alert artifact shows `gh: Bad credentials (HTTP 401)`, so the configured `ATTENDANCE_ADMIN_GH_TOKEN` is stale and prevents the workflow from reaching the actual branch-policy check.

## Verification
- `node --test scripts/ops/attendance-branch-token-fallback-workflow-contract.test.mjs`
- `ruby -e "require 'yaml'; %w[.github/workflows/attendance-branch-protection-prod.yml .github/workflows/attendance-branch-policy-drift-prod.yml].each { |p| YAML.load_file(p); puts \"yaml-ok #{p}\" }"`
- `git diff --check origin/main...HEAD`