### PR TITLE
feat(integration): DF-T1 — target payload template no-write preview (shape B)

### DIFF
--- a/plugins/plugin-integration-core/__tests__/k3-df-t1-target-payload-preview.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-df-t1-target-payload-preview.test.cjs
@@ -1,0 +1,191 @@
+'use strict'
+
+// DF-T1 — target payload template preview (shape B). Verifies the 5 owner requirements:
+// (1) legacy preview fields compatible + DF-T1 evidence under targetPayloadPreview;
+// (2) targetPayloadPreview ONLY when payloadTemplate present;
+// (3) composes through the #1936 shared composer (no new K3 shaper/projector);
+// (4) no-write / fail-closed / redaction / preview≡Save shaping parity all tested.
+
+const assert = require('node:assert')
+const fs = require('node:fs')
+const path = require('node:path')
+
+const { __internals } = require('../lib/http-routes.cjs')
+const composer = require('../lib/adapters/k3-save-body-composer.cjs')
+const { buildTemplatePreview } = __internals
+
+const STAGING = { materialCode: ' mat-001 ', materialName: 'Bolt', unit: '10' }
+const TEMPLATE = {
+  FUnitGroupID: { FNumber: '10', FName: 'Each' }, // a full reference object default
+  FErpClsID: '<erp-cls-id>',                       // an unfilled placeholder default
+}
+const RULES = [
+  { targetField: 'FNumber', sourceType: 'from_staging', sourceField: 'materialCode', required: true, shape: 'scalar' },
+  { targetField: 'FName', sourceType: 'from_staging', sourceField: 'materialName', required: true },
+  { targetField: 'FUnitGroupID', sourceType: 'preserve_template', completeness: 'require-fnumber-fname' },
+]
+
+// ---- Req 1 + 2: legacy fields compatible; targetPayloadPreview only in DF-T1 mode ----
+function testModeNamespacing() {
+  // Legacy mode (no payloadTemplate) — existing contract, NO targetPayloadPreview.
+  const legacy = buildTemplatePreview({
+    sourceRecord: { code: 'X' },
+    fieldMappings: [{ sourceField: 'code', targetField: 'FNumber', transform: { fn: 'trim' } }],
+    template: { bodyKey: 'Data', schema: [{ name: 'FNumber' }] },
+  })
+  assert.equal('targetPayloadPreview' in legacy, false, 'legacy preview must NOT carry targetPayloadPreview (req 2)')
+  assert.ok('valid' in legacy && 'payload' in legacy && 'errors' in legacy, 'legacy fields preserved (req 1)')
+
+  // DF-T1 mode — legacy fields still present + DF-T1 evidence namespaced.
+  const dft1 = buildTemplatePreview({ sourceRecord: STAGING, payloadTemplate: TEMPLATE, fieldRules: RULES })
+  assert.ok('valid' in dft1 && 'payload' in dft1 && 'errors' in dft1, 'DF-T1 keeps the compatible fields (req 1)')
+  assert.ok(dft1.targetPayloadPreview && typeof dft1.targetPayloadPreview === 'object', 'DF-T1 evidence under targetPayloadPreview (req 1)')
+  for (const k of ['eligibleForSaveOnly', 'unresolvedPlaceholders', 'unresolvedReferenceComponents', 'redactionSelfCheck', 'compositionSource']) {
+    assert.ok(k in dft1.targetPayloadPreview, `targetPayloadPreview.${k} present (DoD)`)
+  }
+}
+
+// ---- merge semantics: preserve whole-object defaults; replace only declared fields ----
+function testMergeSemantics() {
+  const out = buildTemplatePreview({ sourceRecord: STAGING, payloadTemplate: TEMPLATE, fieldRules: RULES })
+  // preserve_template keeps the full two-field object verbatim.
+  assert.deepEqual(out.payload.Data.FUnitGroupID, { FNumber: '10', FName: 'Each' }, 'preserve_template keeps the customer default object')
+  // from_staging replaced only the declared fields (trim transform is the legacy path's job;
+  // DF-T1 takes the staging value as-is for scalar, so materialCode comes through trimmed by the row).
+  assert.equal(out.payload.Data.FName, 'Bolt', 'from_staging replaced FName')
+  assert.equal(out.targetPayloadPreview.fieldProvenance.FName, 'staging')
+  assert.equal(out.targetPayloadPreview.fieldProvenance.FUnitGroupID, 'template')
+}
+
+// ---- Req 4: fail-closed on an unresolved placeholder (same code as Save) ----
+function testFailClosedPlaceholder() {
+  const out = buildTemplatePreview({ sourceRecord: STAGING, payloadTemplate: TEMPLATE, fieldRules: RULES })
+  // FErpClsID is left as the template placeholder (no rule fills it).
+  assert.equal(out.valid, false, 'placeholder makes the preview invalid')
+  assert.equal(out.targetPayloadPreview.eligibleForSaveOnly, false, 'not Save-only eligible with an unfilled placeholder')
+  assert.deepEqual(out.targetPayloadPreview.unresolvedPlaceholders, ['Data.FErpClsID'])
+  assert.ok(out.errors.some((e) => e.code === 'K3_WISE_PRESET_PLACEHOLDER_UNFILLED' && /FErpClsID/.test(e.field)),
+    'placeholder error uses the same code the Save path throws')
+
+  // Fill it → eligible.
+  const filled = buildTemplatePreview({
+    sourceRecord: STAGING,
+    payloadTemplate: { ...TEMPLATE, FErpClsID: { FID: '1001', FName: 'Raw' } },
+    fieldRules: RULES,
+  })
+  assert.equal(filled.valid, true)
+  assert.equal(filled.targetPayloadPreview.eligibleForSaveOnly, true, 'eligible once no placeholder / required / incomplete remain')
+}
+
+// ---- Req 3 + 4: shaping goes through the shared composer; preview≡Save shaping parity ----
+function testSharedComposerShapingParity() {
+  const out = buildTemplatePreview({
+    sourceRecord: { u: 'PCS', cat: '1001' },
+    payloadTemplate: { FNumber: 'M-1', FName: 'x' },
+    fieldRules: [
+      { targetField: 'FBaseUnitID', sourceType: 'from_staging', sourceField: 'u', shape: 'by-fnumber' },
+      { targetField: 'FErpClsID', sourceType: 'from_staging', sourceField: 'cat', shape: 'by-fid' },
+    ],
+  })
+  // The DF-T1 shaping output must equal the SAME composer.applyReferenceShape the Save uses.
+  assert.deepEqual(out.payload.Data.FBaseUnitID, composer.applyReferenceShape('PCS', { reference: { identifier: 'FNumber' } }))
+  assert.deepEqual(out.payload.Data.FErpClsID, composer.applyReferenceShape('1001', { reference: { identifier: 'FID' } }))
+  assert.deepEqual(out.payload.Data.FBaseUnitID, { FNumber: 'PCS' })
+  assert.deepEqual(out.payload.Data.FErpClsID, { FID: '1001' })
+  assert.equal(out.targetPayloadPreview.compositionSource, 'k3-save-body-composer', 'composition-source marker (DoD)')
+}
+
+// ---- object passthrough: a two-field object staging value is preserved verbatim ----
+function testObjectPassthrough() {
+  const out = buildTemplatePreview({
+    sourceRecord: { unitObj: { FNumber: '10', FName: 'Each' } },
+    payloadTemplate: { FNumber: 'M-2', FName: 'y' },
+    fieldRules: [{ targetField: 'FUnitID', sourceType: 'from_staging', sourceField: 'unitObj', shape: 'object-passthrough', completeness: 'require-fnumber-fname' }],
+  })
+  assert.deepEqual(out.payload.Data.FUnitID, { FNumber: '10', FName: 'Each' }, 'object passthrough preserved verbatim')
+  assert.equal(out.targetPayloadPreview.unresolvedReferenceComponents.length, 0, 'two-field object satisfies completeness')
+}
+
+// ---- completeness: a one-field object fails require-fnumber-fname (readiness, not shaping) ----
+function testCompletenessReadiness() {
+  const out = buildTemplatePreview({
+    sourceRecord: { u: '10' },
+    payloadTemplate: { FNumber: 'M-3', FName: 'z' },
+    fieldRules: [{ targetField: 'FUnitID', sourceType: 'from_staging', sourceField: 'u', shape: 'by-fnumber', completeness: 'require-fnumber-fname' }],
+  })
+  // by-fnumber yields {FNumber:'10'} — only one component → completeness unmet.
+  assert.deepEqual(out.payload.Data.FUnitID, { FNumber: '10' })
+  assert.ok(out.targetPayloadPreview.unresolvedReferenceComponents.some((u) => u.field === 'FUnitID' && u.rule === 'require-fnumber-fname'))
+  assert.equal(out.targetPayloadPreview.eligibleForSaveOnly, false, 'incomplete reference is not Save-only eligible')
+}
+
+// ---- Req 4: redaction — a secret-shaped value is scrubbed; self-check reports clean ----
+function testRedaction() {
+  const out = buildTemplatePreview({
+    sourceRecord: { code: 'M-4', note: 'connect postgres://u:s3cretpw@db/erp' },
+    payloadTemplate: { FNumber: '<n>', FRemark: '<r>' },
+    fieldRules: [
+      { targetField: 'FNumber', sourceType: 'from_staging', sourceField: 'code', required: true },
+      { targetField: 'FRemark', sourceType: 'from_staging', sourceField: 'note' },
+    ],
+  })
+  const serialized = JSON.stringify(out)
+  assert.equal(serialized.includes('s3cretpw'), false, 'secret-shaped DSN password scrubbed from the preview')
+  assert.equal(out.targetPayloadPreview.redactionSelfCheck.applied, true)
+  assert.equal(out.targetPayloadPreview.redactionSelfCheck.clean, true, 'no secret-shape survived the sanitizer')
+}
+
+// ---- Req 4: no-write — buildTargetPayloadPreview is a pure compose (no fetch/login/Save) ----
+function testNoWrite() {
+  // It takes no fetch impl and performs no I/O; guard against a future import of one.
+  const before = global.fetch
+  let fetched = false
+  global.fetch = () => { fetched = true; throw new Error('no fetch in preview') }
+  try {
+    const out = buildTemplatePreview({ sourceRecord: STAGING, payloadTemplate: TEMPLATE, fieldRules: RULES })
+    assert.ok(out.payload, 'preview returns a payload')
+    assert.equal(fetched, false, 'DF-T1 preview made no network call')
+  } finally {
+    global.fetch = before
+  }
+}
+
+// ---- Req 3 grep gate: DF-T1 must not define a new K3 reference shaper/projector ----
+function testNoNewShaper() {
+  const src = fs.readFileSync(path.join(__dirname, '..', 'lib', 'http-routes.cjs'), 'utf8')
+  assert.equal(/function\s+applyPreviewReferenceShape|function\s+projectRecordForTemplate/.test(src), false,
+    'no resurrected preview shaper/projector')
+  // applyDfT1Shape is allowed ONLY as a thin delegator to the composer (it must reference applyReferenceShape).
+  assert.ok(/applyReferenceShape\(/.test(src), 'DF-T1 shaping delegates to the shared composer applyReferenceShape')
+}
+
+// ---- input validation: invalid sourceType/shape/completeness → 400 ----
+function testInputValidation() {
+  for (const bad of [
+    { fieldRules: [{ targetField: 'F', sourceType: 'evil' }] },
+    { fieldRules: [{ targetField: 'F', shape: 'evil' }] },
+    { fieldRules: [{ targetField: 'F', completeness: 'evil' }] },
+    { fieldRules: [{ sourceType: 'from_staging' }] }, // no targetField
+    { fieldRules: 'nope' },
+  ]) {
+    let threw = null
+    try { buildTemplatePreview({ sourceRecord: {}, payloadTemplate: { F: '1' }, ...bad }) } catch (e) { threw = e }
+    assert.ok(threw && threw.code === 'INVALID_TEMPLATE_PREVIEW', `invalid DF-T1 input rejected: ${JSON.stringify(bad)}`)
+  }
+}
+
+function main() {
+  testModeNamespacing()
+  testMergeSemantics()
+  testFailClosedPlaceholder()
+  testSharedComposerShapingParity()
+  testObjectPassthrough()
+  testCompletenessReadiness()
+  testRedaction()
+  testNoWrite()
+  testNoNewShaper()
+  testInputValidation()
+  console.log('✓ k3-df-t1-target-payload-preview: namespacing, merge, fail-closed, shared-composer parity, passthrough, completeness, redaction, no-write, input-validation')
+}
+
+main()

--- a/plugins/plugin-integration-core/__tests__/k3-df-t1-target-payload-preview.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-df-t1-target-payload-preview.test.cjs
@@ -167,11 +167,29 @@ function testInputValidation() {
     { fieldRules: [{ targetField: 'F', completeness: 'evil' }] },
     { fieldRules: [{ sourceType: 'from_staging' }] }, // no targetField
     { fieldRules: 'nope' },
+    { bodyKey: '__proto__' },     // P2-1: DF-T1 must not bypass the unsafe-key guard
+    { bodyKey: 'badkey' },  // P2-1: control char rejected
   ]) {
     let threw = null
     try { buildTemplatePreview({ sourceRecord: {}, payloadTemplate: { F: '1' }, ...bad }) } catch (e) { threw = e }
     assert.ok(threw && threw.code === 'INVALID_TEMPLATE_PREVIEW', `invalid DF-T1 input rejected: ${JSON.stringify(bad)}`)
   }
+}
+
+// ---- P2-2: DF-T1 response keeps the legacy fixed array fields (Shape B compatibility) ----
+function testShapeBCompatibility() {
+  const out = buildTemplatePreview({ sourceRecord: STAGING, payloadTemplate: TEMPLATE, fieldRules: RULES })
+  for (const f of ['transformErrors', 'validationErrors', 'schemaErrors']) {
+    assert.ok(Array.isArray(out[f]), `DF-T1 response keeps legacy array field ${f}`)
+    assert.equal(out[f].length, 0, `${f} is empty in DF-T1 mode`)
+  }
+  // P2-1 positive: a safe custom bodyKey (through normalizePreviewBodyKey) is honored.
+  const custom = buildTemplatePreview({
+    sourceRecord: { c: 'X' }, bodyKey: 'Model',
+    payloadTemplate: { FNumber: 'v' },
+    fieldRules: [{ targetField: 'FNumber', sourceType: 'from_staging', sourceField: 'c' }],
+  })
+  assert.ok('Model' in custom.payload && custom.payload.Model.FNumber === 'X', 'safe custom bodyKey honored')
 }
 
 function main() {
@@ -185,7 +203,8 @@ function main() {
   testNoWrite()
   testNoNewShaper()
   testInputValidation()
-  console.log('✓ k3-df-t1-target-payload-preview: namespacing, merge, fail-closed, shared-composer parity, passthrough, completeness, redaction, no-write, input-validation')
+  testShapeBCompatibility()
+  console.log('✓ k3-df-t1-target-payload-preview: namespacing, merge, fail-closed, shared-composer parity, passthrough, completeness, redaction, no-write, input-validation, bodyKey-guard, shape-B-compat')
 }
 
 main()

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -650,9 +650,11 @@ function buildTargetPayloadPreview(input) {
   if (!isPlainObject(input.sourceRecord)) {
     throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', 'sourceRecord must be an object', { field: 'sourceRecord' })
   }
-  const bodyKey = firstString(input.bodyKey)
-    || (isPlainObject(input.template) ? firstString(input.template.bodyKey) : null)
-    || 'Data'
+  // Reuse the legacy preview's bodyKey guard (rejects __proto__/prototype/constructor and
+  // control chars) — DF-T1 must NOT bypass it (P2).
+  const bodyKey = normalizePreviewBodyKey(
+    firstString(input.bodyKey) || (isPlainObject(input.template) ? firstString(input.template.bodyKey) : null),
+  )
   const fieldRules = normalizeFieldRules(input.fieldRules)
   // Preserve whole-object payloadTemplate defaults; rules replace only the declared fields.
   const merged = cloneJson(input.payloadTemplate)
@@ -703,6 +705,11 @@ function buildTargetPayloadPreview(input) {
     targetRecord: cloneJson(merged),
     errors,
     placeholderErrors: placeholderErrors.map((e) => cloneJson(e)),
+    // Shape-B compatibility: keep the legacy preview's fixed array fields (empty in DF-T1
+    // mode — DF-T1 merges via fieldRules, not fieldMappings transform/validation) (P2).
+    transformErrors: [],
+    validationErrors: [],
+    schemaErrors: [],
     targetPayloadPreview: {
       eligibleForSaveOnly: errors.length === 0,
       unresolvedPlaceholders: placeholderErrors.map((e) => e.field),

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -31,11 +31,13 @@ const ROUTES = [
   ['POST', '/api/integration/dead-letters/:id/replay', 'deadLettersReplay'],
 ]
 const { sanitizeIntegrationPayload, scrubSecretStringValue } = require('./payload-redaction.cjs')
-const { getPath, transformRecord } = require('./transform-engine.cjs')
-// DF-T1-0: compose the no-write preview through the SAME K3 Save-body composer the adapter
-// uses, so the preview is byte-identical to the real Save (single source of truth — replaces
-// the former divergent applyPreviewReferenceShape/projectRecordForTemplate copies).
-const { projectRecordForBody, findUnfilledPlaceholders } = require('./adapters/k3-save-body-composer.cjs')
+const { getPath, setPath, transformRecord } = require('./transform-engine.cjs')
+// DF-T1-0/DF-T1: compose the no-write preview through the SAME K3 Save-body composer the
+// adapter uses, so the preview is byte-identical to the real Save (single source of truth —
+// replaces the former divergent applyPreviewReferenceShape/projectRecordForTemplate copies).
+// DF-T1 reuses applyReferenceShape (shaping) + findUnfilledPlaceholders (detection); it does
+// NOT introduce a new K3 shaper/projector.
+const { projectRecordForBody, findUnfilledPlaceholders, applyReferenceShape, isBlankValue } = require('./adapters/k3-save-body-composer.cjs')
 const { validateRecord } = require('./validator.cjs')
 
 class HttpRouteError extends Error {
@@ -585,9 +587,149 @@ function schemaRequiredErrors(record, schema) {
 // moved to the shared K3 Save-body composer (DF-T1-0): the preview now composes
 // byte-identically to the adapter Save instead of via a divergent duplicate.
 
+// ---- DF-T1: target payload template preview (shape B — evidence under targetPayloadPreview) ----
+const DF_T1_SOURCE_TYPES = new Set(['from_staging', 'from_constant', 'preserve_template', 'from_reference_table'])
+const DF_T1_SHAPES = new Set(['scalar', 'object-passthrough', 'by-fnumber', 'by-fid'])
+const DF_T1_COMPLETENESS = new Set(['none', 'require-fnumber-fname', 'require-fid-fname'])
+
+function normalizeFieldRules(value) {
+  if (value === undefined || value === null) return []
+  if (!Array.isArray(value)) {
+    throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', 'fieldRules must be an array', { field: 'fieldRules' })
+  }
+  return value.map((rule, index) => {
+    if (!isPlainObject(rule)) {
+      throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', `fieldRules[${index}] must be an object`, { field: `fieldRules[${index}]` })
+    }
+    const targetField = firstString(rule.targetField)
+    if (!targetField) {
+      throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', `fieldRules[${index}].targetField is required`, { field: `fieldRules[${index}].targetField` })
+    }
+    const sourceType = firstString(rule.sourceType) || 'from_staging'
+    if (!DF_T1_SOURCE_TYPES.has(sourceType)) {
+      throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', `fieldRules[${index}].sourceType is invalid`, { field: `fieldRules[${index}].sourceType` })
+    }
+    const shape = firstString(rule.shape) || 'scalar'
+    if (!DF_T1_SHAPES.has(shape)) {
+      throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', `fieldRules[${index}].shape is invalid`, { field: `fieldRules[${index}].shape` })
+    }
+    const completeness = firstString(rule.completeness) || 'none'
+    if (!DF_T1_COMPLETENESS.has(completeness)) {
+      throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', `fieldRules[${index}].completeness is invalid`, { field: `fieldRules[${index}].completeness` })
+    }
+    return {
+      targetField,
+      sourceType,
+      sourceField: firstString(rule.sourceField) || targetField,
+      value: rule.value,
+      shape,
+      completeness,
+      required: rule.required === true,
+    }
+  })
+}
+
+// Reuse the shared composer's reference shaping — never a new K3 shaper (DF-T1 req #3).
+function applyDfT1Shape(value, shape) {
+  if (shape === 'by-fnumber') return applyReferenceShape(value, { reference: { identifier: 'FNumber' } })
+  if (shape === 'by-fid') return applyReferenceShape(value, { reference: { identifier: 'FID' } })
+  return value // scalar / object-passthrough → as-is
+}
+
+function checkReferenceCompleteness(completeness, value) {
+  if (completeness === 'require-fnumber-fname') {
+    return isPlainObject(value) && !isBlankValue(value.FNumber) && !isBlankValue(value.FName) ? null : 'require-fnumber-fname'
+  }
+  if (completeness === 'require-fid-fname') {
+    return isPlainObject(value) && !isBlankValue(value.FID) && !isBlankValue(value.FName) ? null : 'require-fid-fname'
+  }
+  return null
+}
+
+function buildTargetPayloadPreview(input) {
+  if (!isPlainObject(input.sourceRecord)) {
+    throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', 'sourceRecord must be an object', { field: 'sourceRecord' })
+  }
+  const bodyKey = firstString(input.bodyKey)
+    || (isPlainObject(input.template) ? firstString(input.template.bodyKey) : null)
+    || 'Data'
+  const fieldRules = normalizeFieldRules(input.fieldRules)
+  // Preserve whole-object payloadTemplate defaults; rules replace only the declared fields.
+  const merged = cloneJson(input.payloadTemplate)
+  const fieldProvenance = {}
+  const missingRequiredFields = []
+  const unresolvedReferenceComponents = []
+  for (const rule of fieldRules) {
+    if (rule.sourceType === 'preserve_template') {
+      fieldProvenance[rule.targetField] = 'template'
+    } else {
+      let raw
+      if (rule.sourceType === 'from_staging') raw = getPath(input.sourceRecord, rule.sourceField)
+      else raw = rule.value // from_constant, or from_reference_table (v1 = pre-resolved scalar)
+      fieldProvenance[rule.targetField] = rule.sourceType === 'from_staging' ? 'staging'
+        : rule.sourceType === 'from_constant' ? 'constant' : 'reference_table'
+      const shaped = applyDfT1Shape(raw, rule.shape)
+      if (isBlankValue(shaped)) {
+        if (rule.required) missingRequiredFields.push(rule.targetField)
+        // leave the template default in place; if it is a placeholder, fail-closed catches it.
+      } else {
+        setPath(merged, rule.targetField, shaped)
+      }
+    }
+    const finalValue = getPath(merged, rule.targetField)
+    if (rule.required && isBlankValue(finalValue) && !missingRequiredFields.includes(rule.targetField)) {
+      missingRequiredFields.push(rule.targetField)
+    }
+    const incomplete = checkReferenceCompleteness(rule.completeness, finalValue)
+    if (incomplete) unresolvedReferenceComponents.push({ field: rule.targetField, rule: incomplete })
+  }
+
+  const payload = { [bodyKey]: cloneJson(merged) }
+  // Same placeholder DETECTION + CODE as the Save path (shared composer findUnfilledPlaceholders).
+  const placeholderErrors = findUnfilledPlaceholders(payload).map((path) => ({
+    field: path,
+    code: 'K3_WISE_PRESET_PLACEHOLDER_UNFILLED',
+    message: `unfilled template placeholder at ${path}`,
+  }))
+  const errors = [
+    ...placeholderErrors,
+    ...missingRequiredFields.map((field) => ({ field, code: 'REQUIRED', message: `${field} is required` })),
+    ...unresolvedReferenceComponents.map((u) => ({ field: u.field, code: 'INCOMPLETE_REFERENCE', message: `${u.field} requires ${u.rule}` })),
+  ].map((e) => cloneJson(e))
+
+  const response = sanitizeIntegrationPayload({
+    valid: errors.length === 0,
+    payload,
+    targetRecord: cloneJson(merged),
+    errors,
+    placeholderErrors: placeholderErrors.map((e) => cloneJson(e)),
+    targetPayloadPreview: {
+      eligibleForSaveOnly: errors.length === 0,
+      unresolvedPlaceholders: placeholderErrors.map((e) => e.field),
+      unresolvedReferenceComponents: cloneJson(unresolvedReferenceComponents),
+      missingRequiredFields: cloneJson(missingRequiredFields),
+      fieldProvenance: cloneJson(fieldProvenance),
+      compositionSource: 'k3-save-body-composer',
+    },
+  })
+  // Redaction self-check: no secret-shaped value survived the sanitizer (DF-T1 req #4).
+  const serialized = JSON.stringify(response)
+  response.targetPayloadPreview.redactionSelfCheck = {
+    applied: true,
+    clean: serialized === scrubSecretStringValue(serialized),
+  }
+  return response
+}
+
 function buildTemplatePreview(input) {
   if (!isPlainObject(input)) {
     throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', 'input must be an object')
+  }
+  // DF-T1: target payload template mode (payloadTemplate + fieldRules). DF-T1 evidence is
+  // namespaced under `targetPayloadPreview`; the legacy fieldMappings/schema preview is unchanged
+  // and never carries that field (DF-T1 req #1, #2).
+  if (isPlainObject(input.payloadTemplate)) {
+    return buildTargetPayloadPreview(input)
   }
   if (!isPlainObject(input.sourceRecord)) {
     throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', 'sourceRecord must be an object', { field: 'sourceRecord' })


### PR DESCRIPTION
## What

**DF-T1** (next per the gated DF-T TODO, on the #1936 parity seam): extend the existing `/api/integration/templates/preview` with a `payloadTemplate` + `fieldRules` merge mode — start from the whole-object `payloadTemplate` (defaults preserved), apply `fieldRules` (replace only declared fields), → the **exact target payload an operator can verify before any Save**. This breaks the "blind Save" cycle the live #1792 GATE has been stuck in.

## Owner requirements (all met + tested)

1. ✅ **Legacy fields compatible; DF-T1 evidence namespaced** under `targetPayloadPreview` (`eligibleForSaveOnly` / `unresolvedPlaceholders` / `unresolvedReferenceComponents` / `missingRequiredFields` / `fieldProvenance` / `redactionSelfCheck` / `compositionSource`).
2. ✅ **`targetPayloadPreview` only when `payloadTemplate` present** — legacy `fieldMappings`/`schema` preview is byte-unchanged and never carries it (test asserts both directions).
3. ✅ **Composes through the #1936 shared composer** — shaping via `applyReferenceShape`, placeholder detection via `findUnfilledPlaceholders`; **no new K3 shaper/projector** (grep-gated; `applyDfT1Shape` only delegates).
4. ✅ **no-write / fail-closed / redaction / preview≡Save parity** all tested:
   - no-write: zero fetch (guarded).
   - fail-closed: unfilled placeholder → `valid:false` + `K3_WISE_PRESET_PLACEHOLDER_UNFILLED` (same code the Save throws); **negative-controlled** (neutralize the shared detector → the test fails).
   - redaction: a DSN-password in staging is scrubbed; `redactionSelfCheck.clean:true`.
   - parity: DF-T1 `by-fnumber`/`by-fid` output `===` `composer.applyReferenceShape` (the shaper the Save uses).

Plus: merge semantics (preserve template defaults / replace declared / preserve_template), object-passthrough, **shape-vs-completeness layering** (`require-fnumber-fname`/`require-fid-fname` = readiness → `unresolvedReferenceComponents`, not a Save-body concern), and input validation (invalid sourceType/shape/completeness → 400).

## Scope / safety

Full integration-core sweep green; legacy preview tests unchanged. No route/migration/RBAC/auth; **no write** (pure compose). TODO tick is its own PR (#1942) to avoid conflict; a later tick marks DF-T1 ✅.

🤖 Generated with [Claude Code](https://claude.com/claude-code)