### PR TITLE
ci(attendance): fix branch protection graphql fallback

### DIFF
--- a/scripts/ops/attendance-branch-token-fallback-workflow-contract.test.mjs
+++ b/scripts/ops/attendance-branch-token-fallback-workflow-contract.test.mjs
@@ -22,3 +22,11 @@ for (const workflow of workflows) {
     assert.match(raw, /run_check_once "\$\{GH_TOKEN_FALLBACK\}" "github-token-fallback"/)
   })
 }
+
+test('branch protection checker sends a single graphql query field', () => {
+  const raw = readFileSync(path.join(repoRoot, 'scripts/ops/attendance-check-branch-protection.sh'), 'utf8')
+  const queryFieldCount = [...raw.matchAll(/-f query=/g)].length
+
+  assert.equal(queryFieldCount, 1)
+  assert.match(raw, /requiredStatusCheckContexts/)
+})

--- a/scripts/ops/attendance-check-branch-protection.sh
+++ b/scripts/ops/attendance-check-branch-protection.sh
@@ -87,7 +87,6 @@ contexts_current=()
 function try_graphql_fallback() {
   set +e
   gh api graphql \
-    -f query='query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ branchProtectionRules(first:100){ nodes{ pattern requiresStrictStatusChecks isAdminEnforced requiredStatusCheckContexts requiresApprovingReviews requiredApprovingReviewCount requiresCodeOwnerReviews } } } }' \
     -f query='query($owner:String!,$name:String!){ repository(owner:$owner,name:$name){ branchProtectionRules(first:100){ nodes{ pattern requiresStrictStatusChecks isAdminEnforced requiresApprovingReviews requiredApprovingReviewCount requiresCodeOwnerReviews requiredStatusCheckContexts } } } }' \
     -f owner="$owner" \
     -f name="$repo_name" \


### PR DESCRIPTION
## Summary
- remove the duplicate `-f query=` argument from the branch protection checker GraphQL fallback
- extend the token-fallback contract test to lock the single-query invocation

## Why
Refs #190. After #1944, the workflow correctly retried with `github.token`, but the script-level GraphQL fallback failed before making a real permission/policy decision: `unexpected override existing field under "query"`.

## Verification
- `node --test scripts/ops/attendance-branch-token-fallback-workflow-contract.test.mjs`
- `bash -n scripts/ops/attendance-check-branch-protection.sh`
- `git diff --check origin/main...HEAD`