### PR TITLE
fix(integration): reject malformed DF-T1 payload templates

### DIFF
--- a/plugins/plugin-integration-core/__tests__/k3-df-t1-target-payload-preview.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-df-t1-target-payload-preview.test.cjs
@@ -167,6 +167,9 @@ function testInputValidation() {
     { fieldRules: [{ targetField: 'F', completeness: 'evil' }] },
     { fieldRules: [{ sourceType: 'from_staging' }] }, // no targetField
     { fieldRules: 'nope' },
+    { payloadTemplate: null },
+    { payloadTemplate: [] },
+    { payloadTemplate: 'not-an-object' },
     { bodyKey: '__proto__' },     // P2-1: DF-T1 must not bypass the unsafe-key guard
     { bodyKey: 'badkey' },  // P2-1: control char rejected
   ]) {

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -735,6 +735,9 @@ function buildTemplatePreview(input) {
   // DF-T1: target payload template mode (payloadTemplate + fieldRules). DF-T1 evidence is
   // namespaced under `targetPayloadPreview`; the legacy fieldMappings/schema preview is unchanged
   // and never carries that field (DF-T1 req #1, #2).
+  if (Object.prototype.hasOwnProperty.call(input, 'payloadTemplate') && !isPlainObject(input.payloadTemplate)) {
+    throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', 'payloadTemplate must be an object', { field: 'payloadTemplate' })
+  }
   if (isPlainObject(input.payloadTemplate)) {
     return buildTargetPayloadPreview(input)
   }


### PR DESCRIPTION
## Summary
- reject explicitly present but non-object DF-T1 payloadTemplate values instead of silently falling back to legacy template preview
- lock null/array/string payloadTemplate cases into the DF-T1 input-validation test

## Scope
- integration preview route only
- no Save/write path changes
- no new routes, migrations, K3 Submit/Audit/BOM/list/search, or generic HTTP/JS/SQL capability

## Verification
- node plugins/plugin-integration-core/__tests__/k3-df-t1-target-payload-preview.test.cjs
- node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
- node plugins/plugin-integration-core/__tests__/http-routes-plm-k3wise-poc.test.cjs
- node plugins/plugin-integration-core/__tests__/payload-redaction.test.cjs
- git diff --check

Note: attempted pnpm -F plugin-integration-core test in the isolated worktree, but that worktree has no node_modules and failed at node --import tsx with ERR_MODULE_NOT_FOUND before reaching this change. The focused pure-Node route/redaction tests above passed.