### PR TITLE
feat(multitable): chart rendering via ECharts (Slice 1)

### DIFF
--- a/apps/web/package.json
+++ b/apps/web/package.json
@@ -16,6 +16,7 @@
     "@metasheet/sdk": "workspace:*",
     "axios": "^1.8.0",
     "bpmn-js": "^18.10.1",
+    "echarts": "^5.5.0",
     "element-plus": "^2.10.1",
     "file-saver": "^2.0.5",
     "lib0": "^0.2.117",

--- a/apps/web/src/multitable/components/MetaChartRenderer.vue
+++ b/apps/web/src/multitable/components/MetaChartRenderer.vue
@@ -2,104 +2,15 @@
   <div class="meta-chart" :data-chart-type="chartData.chartType">
     <div v-if="displayConfig?.title" class="meta-chart__title">{{ displayConfig.title }}</div>
 
-    <!-- Bar chart -->
-    <template v-if="chartData.chartType === 'bar'">
-      <svg :viewBox="`0 0 ${barWidth} ${barHeight}`" class="meta-chart__svg" preserveAspectRatio="xMidYMid meet" data-chart="bar">
-        <g v-for="(pt, idx) in chartData.dataPoints" :key="idx">
-          <rect
-            v-if="isVertical"
-            :x="barPadding + idx * barSlotWidth + barSlotWidth * 0.1"
-            :y="barHeight - barBottomPad - barScale(pt.value)"
-            :width="barSlotWidth * 0.8"
-            :height="barScale(pt.value)"
-            :fill="pt.color || defaultColor(idx)"
-            :data-bar-index="idx"
-          />
-          <rect
-            v-else
-            :x="barLeftPad"
-            :y="barPadding + idx * barSlotHeight + barSlotHeight * 0.1"
-            :width="hBarScale(pt.value)"
-            :height="barSlotHeight * 0.8"
-            :fill="pt.color || defaultColor(idx)"
-            :data-bar-index="idx"
-          />
-          <text
-            v-if="isVertical"
-            :x="barPadding + idx * barSlotWidth + barSlotWidth / 2"
-            :y="barHeight - 4"
-            text-anchor="middle"
-            class="meta-chart__bar-label"
-          >{{ pt.label }}</text>
-          <text
-            v-if="isVertical && displayConfig?.showValues !== false"
-            :x="barPadding + idx * barSlotWidth + barSlotWidth / 2"
-            :y="barHeight - barBottomPad - barScale(pt.value) - 4"
-            text-anchor="middle"
-            class="meta-chart__bar-value"
-          >{{ pt.value }}</text>
-          <text
-            v-if="!isVertical"
-            :x="barLeftPad - 4"
-            :y="barPadding + idx * barSlotHeight + barSlotHeight / 2 + 4"
-            text-anchor="end"
-            class="meta-chart__bar-label"
-          >{{ pt.label }}</text>
-          <text
-            v-if="!isVertical && displayConfig?.showValues !== false"
-            :x="barLeftPad + hBarScale(pt.value) + 4"
-            :y="barPadding + idx * barSlotHeight + barSlotHeight / 2 + 4"
-            text-anchor="start"
-            class="meta-chart__bar-value"
-          >{{ pt.value }}</text>
-        </g>
-      </svg>
-    </template>
-
-    <!-- Line chart -->
-    <template v-else-if="chartData.chartType === 'line'">
-      <svg :viewBox="`0 0 ${lineWidth} ${lineHeight}`" class="meta-chart__svg" preserveAspectRatio="xMidYMid meet" data-chart="line">
-        <polyline
-          :points="linePoints"
-          fill="none"
-          stroke="#2563eb"
-          stroke-width="2"
-          stroke-linejoin="round"
-          class="meta-chart__line"
-        />
-        <circle
-          v-for="(pt, idx) in lineCoords"
-          :key="idx"
-          :cx="pt.x"
-          :cy="pt.y"
-          r="4"
-          fill="#2563eb"
-          :data-point-index="idx"
-        />
-        <text
-          v-for="(pt, idx) in lineCoords"
-          :key="'l' + idx"
-          :x="pt.x"
-          :y="lineHeight - 4"
-          text-anchor="middle"
-          class="meta-chart__line-label"
-        >{{ chartData.dataPoints[idx].label }}</text>
-      </svg>
-    </template>
-
-    <!-- Pie chart -->
-    <template v-else-if="chartData.chartType === 'pie'">
-      <div class="meta-chart__pie-wrapper">
-        <svg viewBox="0 0 200 200" class="meta-chart__svg meta-chart__svg--pie" preserveAspectRatio="xMidYMid meet" data-chart="pie">
-          <path
-            v-for="(seg, idx) in pieSegments"
-            :key="idx"
-            :d="seg.d"
-            :fill="seg.color"
-            :data-pie-index="idx"
-          />
-        </svg>
-        <div v-if="displayConfig?.showLegend !== false" class="meta-chart__legend" data-legend="true">
+    <!-- bar / line / pie → ECharts canvas. Title + (pie) legend stay as HTML chrome. -->
+    <template v-if="isEChartsType">
+      <div class="meta-chart__plot" :class="{ 'meta-chart__plot--pie': chartData.chartType === 'pie' }">
+        <div ref="chartEl" class="meta-chart__echarts" data-chart-canvas="true"></div>
+        <div
+          v-if="chartData.chartType === 'pie' && displayConfig?.showLegend !== false"
+          class="meta-chart__legend"
+          data-legend="true"
+        >
           <div v-for="(pt, idx) in chartData.dataPoints" :key="idx" class="meta-chart__legend-item">
             <span class="meta-chart__legend-swatch" :style="{ background: pt.color || defaultColor(idx) }"></span>
             <span class="meta-chart__legend-label">{{ pt.label }}</span>
@@ -140,10 +51,19 @@
 </template>
 
 <script setup lang="ts">
-import { computed } from 'vue'
+import { computed, onBeforeUnmount, onMounted, ref, watch } from 'vue'
+import * as echarts from 'echarts/core'
+import { BarChart, LineChart, PieChart } from 'echarts/charts'
+import { GridComponent, TooltipComponent } from 'echarts/components'
+import { CanvasRenderer } from 'echarts/renderers'
 import type { ChartData, ChartDisplayConfig } from '../types'
+import { buildChartOption, CHART_COLORS } from '../utils/buildChartOption'
 import { useLocale } from '../../composables/useLocale'
 import { viewRenderLabel } from '../utils/meta-view-render-labels'
+
+// Tree-shakeable: only the chart types + components actually used. Legend/title are HTML
+// chrome (not ECharts components), so LegendComponent/TitleComponent are deliberately absent.
+echarts.use([BarChart, LineChart, PieChart, GridComponent, TooltipComponent, CanvasRenderer])
 
 const props = defineProps<{
   chartData: ChartData
@@ -151,88 +71,56 @@ const props = defineProps<{
 }>()
 const { isZh } = useLocale()
 
-const COLORS = ['#2563eb', '#16a34a', '#f59e0b', '#ef4444', '#8b5cf6', '#06b6d4', '#ec4899', '#84cc16']
+const isEChartsType = computed(() =>
+  props.chartData.chartType === 'bar'
+  || props.chartData.chartType === 'line'
+  || props.chartData.chartType === 'pie',
+)
 
+// Legend swatch fallback color — same palette as buildChartOption so canvas + HTML legend match.
 function defaultColor(idx: number): string {
-  return COLORS[idx % COLORS.length]
+  return CHART_COLORS[idx % CHART_COLORS.length]
 }
 
-const isVertical = computed(() => props.displayConfig?.orientation !== 'horizontal')
+const chartEl = ref<HTMLElement | null>(null)
+let chart: ReturnType<typeof echarts.init> | null = null
+let resizeObserver: ResizeObserver | null = null
 
-// Bar chart helpers
-const barWidth = 400
-const barHeight = 250
-const barPadding = 20
-const barBottomPad = 24
-const barLeftPad = 80
-const barSlotWidth = computed(() => {
-  const count = props.chartData.dataPoints.length || 1
-  return (barWidth - barPadding * 2) / count
-})
-const barSlotHeight = computed(() => {
-  const count = props.chartData.dataPoints.length || 1
-  return (barHeight - barPadding * 2) / count
-})
-const barMax = computed(() => Math.max(1, ...props.chartData.dataPoints.map((p) => p.value)))
-
-function barScale(val: number): number {
-  return (val / barMax.value) * (barHeight - barPadding - barBottomPad - 20)
+// Attach the resize observer once the canvas exists. Idempotent + called on every render, so it
+// also wires up when the canvas appears LATER via a number/table → bar/line/pie type switch.
+function ensureResizeObserver(): void {
+  if (resizeObserver || !chartEl.value || typeof ResizeObserver === 'undefined') return
+  resizeObserver = new ResizeObserver(() => chart?.resize())
+  resizeObserver.observe(chartEl.value)
 }
 
-function hBarScale(val: number): number {
-  return (val / barMax.value) * (barWidth - barLeftPad - 20)
+function teardownChart(): void {
+  resizeObserver?.disconnect()
+  resizeObserver = null
+  chart?.dispose()
+  chart = null
 }
 
-// Line chart helpers
-const lineWidth = 400
-const lineHeight = 250
-const linePad = 30
-const lineCoords = computed(() => {
-  const pts = props.chartData.dataPoints
-  if (!pts.length) return []
-  const max = Math.max(1, ...pts.map((p) => p.value))
-  const xStep = pts.length > 1 ? (lineWidth - linePad * 2) / (pts.length - 1) : 0
-  return pts.map((p, i) => ({
-    x: linePad + i * xStep,
-    y: lineHeight - linePad - 20 - (p.value / max) * (lineHeight - linePad * 2 - 20),
-  }))
-})
-
-const linePoints = computed(() => lineCoords.value.map((c) => `${c.x},${c.y}`).join(' '))
-
-// Pie chart helpers
-const pieSegments = computed(() => {
-  const pts = props.chartData.dataPoints
-  const total = pts.reduce((s, p) => s + p.value, 0) || 1
-  const segments: Array<{ d: string; color: string }> = []
-  let startAngle = -Math.PI / 2
-  for (let i = 0; i < pts.length; i++) {
-    const angle = (pts[i].value / total) * Math.PI * 2
-    const endAngle = startAngle + angle
-    const largeArc = angle > Math.PI ? 1 : 0
-    const cx = 100
-    const cy = 100
-    const r = 90
-    const x1 = cx + r * Math.cos(startAngle)
-    const y1 = cy + r * Math.sin(startAngle)
-    const x2 = cx + r * Math.cos(endAngle)
-    const y2 = cy + r * Math.sin(endAngle)
-    // For a single-item pie, draw a full circle
-    if (pts.length === 1) {
-      segments.push({
-        d: `M ${cx - r} ${cy} A ${r} ${r} 0 1 1 ${cx + r} ${cy} A ${r} ${r} 0 1 1 ${cx - r} ${cy} Z`,
-        color: pts[i].color || defaultColor(i),
-      })
-    } else {
-      segments.push({
-        d: `M ${cx} ${cy} L ${x1} ${y1} A ${r} ${r} 0 ${largeArc} 1 ${x2} ${y2} Z`,
-        color: pts[i].color || defaultColor(i),
-      })
-    }
-    startAngle = endAngle
+function renderChart(): void {
+  // non-chart type (number/table) → release any canvas instance + observer
+  if (!isEChartsType.value) {
+    teardownChart()
+    return
   }
-  return segments
-})
+  if (!chartEl.value) return
+  if (!chart) chart = echarts.init(chartEl.value)
+  ensureResizeObserver()
+  const option = buildChartOption(props.chartData, props.displayConfig)
+  if (option) chart.setOption(option, true)
+}
+
+onMounted(renderChart)
+
+// flush: 'post' — run AFTER the DOM updates so the canvas container exists when chartType
+// switches into bar/line/pie; a pre-flush watch would no-op on the not-yet-rendered ref.
+watch(() => [props.chartData, props.displayConfig], renderChart, { deep: true, flush: 'post' })
+
+onBeforeUnmount(teardownChart)
 </script>
 
 <style scoped>
@@ -246,19 +134,11 @@ const pieSegments = computed(() => {
   text-align: center;
 }
 
-.meta-chart__svg {
-  width: 100%;
-  height: auto;
-  display: block;
-}
+.meta-chart__plot { width: 100%; }
+.meta-chart__plot--pie { display: flex; align-items: flex-start; gap: 16px; }
+.meta-chart__plot--pie .meta-chart__echarts { flex: 1; min-width: 0; }
 
-.meta-chart__svg--pie { max-width: 200px; }
-
-.meta-chart__bar-label { font-size: 10px; fill: #64748b; }
-.meta-chart__bar-value { font-size: 9px; fill: #0f172a; font-weight: 600; }
-.meta-chart__line-label { font-size: 10px; fill: #64748b; }
-
-.meta-chart__pie-wrapper { display: flex; align-items: flex-start; gap: 16px; }
+.meta-chart__echarts { width: 100%; height: 250px; }
 
 .meta-chart__legend { display: flex; flex-direction: column; gap: 4px; }
 .meta-chart__legend-item { display: flex; align-items: center; gap: 6px; font-size: 12px; }

--- a/apps/web/src/multitable/utils/buildChartOption.ts
+++ b/apps/web/src/multitable/utils/buildChartOption.ts
@@ -1,0 +1,111 @@
+import type { EChartsOption } from 'echarts'
+import type { ChartData, ChartDisplayConfig } from '../types'
+
+/**
+ * Categorical palette mirroring the previous hand-rolled SVG renderer's COLORS,
+ * so the ECharts swap stays visually continuous.
+ */
+export const CHART_COLORS = [
+  '#2563eb', '#16a34a', '#f59e0b', '#ef4444',
+  '#8b5cf6', '#06b6d4', '#ec4899', '#84cc16',
+]
+
+/**
+ * Map a ChartData (+ optional display config) to an ECharts option for the
+ * bar / line / pie chart types. Returns `null` for `number` / `table`, which the
+ * renderer keeps as plain HTML (ECharts has no native equivalent).
+ *
+ * Behavior contract — deliberately matches the previous hand-rolled SVG so the
+ * swap is visually equivalent (only hover tooltips are added):
+ *   - **No ECharts legend on any type.** Only pie had a legend before, and it was
+ *     an HTML "swatch + label + value" list; the renderer keeps that HTML legend.
+ *   - **Pie sectors carry no labels** (`label.show:false`) — the value stays in the
+ *     HTML legend, not moved onto the sectors.
+ *   - **Bar** shows per-bar value labels, toggled by `showValues` (default on);
+ *     **line** shows none (it only ever showed category labels, which the x-axis covers).
+ *   - **No ECharts title** — the title stays HTML chrome in the renderer (avoids a double title).
+ *   - `title` + `showLegend` are renderer-level HTML chrome, not handled here.
+ *
+ * Pure function with type-only echarts imports → unit-testable without a canvas.
+ * The renderer feeds the result to `chart.setOption(...)`.
+ */
+export function buildChartOption(
+  chartData: ChartData,
+  displayConfig?: ChartDisplayConfig,
+): EChartsOption | null {
+  const { chartType, dataPoints } = chartData
+  if (chartType !== 'bar' && chartType !== 'line' && chartType !== 'pie') return null
+
+  const showValues = displayConfig?.showValues !== false
+  const labels = dataPoints.map((p) => p.label)
+
+  // title + legend stay HTML chrome in the renderer (behavior-exact; no double title /
+  // redundant legend). buildChartOption owns only the plot + palette.
+  const base: EChartsOption = {
+    color: CHART_COLORS,
+  }
+
+  if (chartType === 'pie') {
+    return {
+      ...base,
+      tooltip: { trigger: 'item' },
+      series: [
+        {
+          type: 'pie',
+          radius: '70%',
+          // sectors stay label-less; value is shown by the renderer's HTML legend
+          label: { show: false },
+          data: dataPoints.map((p) => ({
+            name: p.label,
+            value: p.value,
+            ...(p.color ? { itemStyle: { color: p.color } } : {}),
+          })),
+        },
+      ],
+    }
+  }
+
+  // bar | line share value-encoded data; bar additionally supports horizontal orientation.
+  const seriesData = dataPoints.map((p) => ({
+    value: p.value,
+    ...(p.color ? { itemStyle: { color: p.color } } : {}),
+  }))
+  const categoryAxis = { type: 'category' as const, data: labels }
+  const valueAxis = { type: 'value' as const }
+  const grid = { left: '3%', right: '4%', bottom: '3%', containLabel: true }
+
+  if (chartType === 'bar') {
+    const horizontal = displayConfig?.orientation === 'horizontal'
+    return {
+      ...base,
+      tooltip: { trigger: 'axis' },
+      grid,
+      xAxis: horizontal ? valueAxis : categoryAxis,
+      yAxis: horizontal ? categoryAxis : valueAxis,
+      series: [
+        {
+          type: 'bar',
+          colorBy: 'data',
+          label: { show: showValues, position: horizontal ? 'right' : 'top' },
+          data: seriesData,
+        },
+      ],
+    }
+  }
+
+  // line — category labels come from the x-axis; no per-point value labels (matches old SVG)
+  return {
+    ...base,
+    tooltip: { trigger: 'axis' },
+    grid,
+    xAxis: categoryAxis,
+    yAxis: valueAxis,
+    series: [
+      {
+        type: 'line',
+        label: { show: false },
+        data: seriesData,
+      },
+    ],
+  }
+}

--- a/apps/web/tests/multitable-build-chart-option.spec.ts
+++ b/apps/web/tests/multitable-build-chart-option.spec.ts
@@ -1,0 +1,93 @@
+import { describe, it, expect } from 'vitest'
+import { buildChartOption, CHART_COLORS } from '../src/multitable/utils/buildChartOption'
+import type { ChartData } from '../src/multitable/types'
+
+// Reaching into ECharts' broad option unions in assertions; `any` is local to the test.
+/* eslint-disable @typescript-eslint/no-explicit-any */
+const opt = (v: unknown) => v as any
+
+function chart(
+  chartType: ChartData['chartType'],
+  points: Array<{ label: string; value: number; color?: string }>,
+): ChartData {
+  return { chartType, dataPoints: points }
+}
+
+describe('buildChartOption', () => {
+  it('returns null for number/table (HTML-rendered, no ECharts)', () => {
+    expect(buildChartOption(chart('number', [{ label: 'x', value: 1 }]))).toBeNull()
+    expect(buildChartOption(chart('table', [{ label: 'x', value: 1 }]))).toBeNull()
+  })
+
+  it('maps a vertical bar: category x-axis, value y-axis, bar series', () => {
+    const o = opt(buildChartOption(chart('bar', [{ label: 'A', value: 10 }, { label: 'B', value: 20 }])))
+    expect(o.xAxis.type).toBe('category')
+    expect(o.xAxis.data).toEqual(['A', 'B'])
+    expect(o.yAxis.type).toBe('value')
+    expect(o.series[0].type).toBe('bar')
+    expect(o.series[0].data.map((d: any) => d.value)).toEqual([10, 20])
+  })
+
+  it('swaps axes for a horizontal bar', () => {
+    const o = opt(buildChartOption(chart('bar', [{ label: 'A', value: 10 }]), { orientation: 'horizontal' }))
+    expect(o.xAxis.type).toBe('value')
+    expect(o.yAxis.type).toBe('category')
+    expect(o.yAxis.data).toEqual(['A'])
+    expect(o.series[0].label.position).toBe('right')
+  })
+
+  it('maps a line series on a category axis', () => {
+    const o = opt(buildChartOption(chart('line', [{ label: 'A', value: 5 }])))
+    expect(o.series[0].type).toBe('line')
+    expect(o.xAxis.type).toBe('category')
+  })
+
+  it('maps pie to {name,value} slices', () => {
+    const o = opt(buildChartOption(chart('pie', [{ label: 'A', value: 3 }, { label: 'B', value: 7 }])))
+    expect(o.series[0].type).toBe('pie')
+    expect(o.series[0].data).toEqual([{ name: 'A', value: 3 }, { name: 'B', value: 7 }])
+  })
+
+  it('uses per-point color via itemStyle, palette otherwise', () => {
+    const o = opt(buildChartOption(chart('pie', [{ label: 'A', value: 1, color: '#123456' }])))
+    expect(o.series[0].data[0].itemStyle.color).toBe('#123456')
+    expect(o.color).toEqual(CHART_COLORS)
+  })
+
+  // --- behavior-equivalence contracts (locked per pre-renderer review) ---
+
+  it('emits NO ECharts legend on any type (legend stays HTML, pie-only, in the renderer)', () => {
+    for (const t of ['bar', 'line', 'pie'] as const) {
+      const o = opt(buildChartOption(chart(t, [{ label: 'A', value: 1 }])))
+      expect(o.legend).toBeUndefined()
+    }
+  })
+
+  it('keeps pie sectors label-less (value shown by the HTML legend, not on sectors)', () => {
+    const o = opt(buildChartOption(chart('pie', [{ label: 'A', value: 1 }])))
+    expect(o.series[0].label.show).toBe(false)
+  })
+
+  it('shows no value labels on line points (only bar shows values)', () => {
+    const o = opt(buildChartOption(chart('line', [{ label: 'A', value: 1 }])))
+    expect(o.series[0].label.show).toBe(false)
+  })
+
+  it('bar value labels default on, hidden when showValues=false', () => {
+    const on = opt(buildChartOption(chart('bar', [{ label: 'A', value: 1 }])))
+    expect(on.series[0].label.show).toBe(true)
+    const off = opt(buildChartOption(chart('bar', [{ label: 'A', value: 1 }]), { showValues: false }))
+    expect(off.series[0].label.show).toBe(false)
+  })
+
+  it('does NOT emit an ECharts title (title stays HTML chrome, like the legend)', () => {
+    const o = opt(buildChartOption(chart('bar', [{ label: 'A', value: 1 }]), { title: 'Sales' }))
+    expect(o.title).toBeUndefined()
+  })
+
+  it('does not crash on empty dataPoints', () => {
+    const o = opt(buildChartOption(chart('bar', [])))
+    expect(o.series[0].data).toEqual([])
+    expect(o.xAxis.data).toEqual([])
+  })
+})

--- a/apps/web/tests/multitable-chart-renderer.spec.ts
+++ b/apps/web/tests/multitable-chart-renderer.spec.ts
@@ -1,11 +1,28 @@
-import { afterEach, describe, expect, it } from 'vitest'
-import { createApp, h, nextTick } from 'vue'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, reactive } from 'vue'
 
 function flushPromises() {
   return new Promise<void>((resolve) => setTimeout(resolve, 0)).then(() => nextTick())
 }
 
+// ECharts needs a real canvas (absent in jsdom) → mock the runtime entry points. The renderer's
+// option-building is the pure `buildChartOption` (imported real below), so we assert the wiring:
+// init once + setOption(buildChartOption(...)). Legend/title/number/table are HTML and asserted directly.
+const mocks = vi.hoisted(() => {
+  const setOption = vi.fn()
+  const resize = vi.fn()
+  const dispose = vi.fn()
+  const instance = { setOption, resize, dispose }
+  const init = vi.fn(() => instance)
+  return { setOption, resize, dispose, init, instance }
+})
+vi.mock('echarts/core', () => ({ init: mocks.init, use: vi.fn() }))
+vi.mock('echarts/charts', () => ({ BarChart: {}, LineChart: {}, PieChart: {} }))
+vi.mock('echarts/components', () => ({ GridComponent: {}, TooltipComponent: {} }))
+vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }))
+
 import MetaChartRenderer from '../src/multitable/components/MetaChartRenderer.vue'
+import { buildChartOption } from '../src/multitable/utils/buildChartOption'
 import type { ChartData, ChartDisplayConfig } from '../src/multitable/types'
 import { useLocale } from '../src/composables/useLocale'
 
@@ -59,60 +76,101 @@ const tableData: ChartData = {
 }
 
 describe('MetaChartRenderer', () => {
+  // jsdom has no ResizeObserver — stub it so the renderer's resize wiring is exercisable.
+  const realResizeObserver = (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver
+  const roObserve = vi.fn()
+  const roDisconnect = vi.fn()
+  let resizeObserverCb: (() => void) | null = null
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    resizeObserverCb = null
+    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = vi.fn((cb: () => void) => {
+      resizeObserverCb = cb
+      return { observe: roObserve, unobserve: vi.fn(), disconnect: roDisconnect }
+    })
+  })
   afterEach(() => {
     useLocale().setLocale('en')
     document.body.innerHTML = ''
+    ;(globalThis as unknown as { ResizeObserver: unknown }).ResizeObserver = realResizeObserver
   })
 
-  it('renders bar chart with correct number of bars', async () => {
+  function mountReactive(initial: { chartData: ChartData; displayConfig?: ChartDisplayConfig }) {
+    const state = reactive<{ chartData: ChartData; displayConfig?: ChartDisplayConfig }>({
+      chartData: initial.chartData,
+      displayConfig: initial.displayConfig,
+    })
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const app = createApp({
+      render: () => h(MetaChartRenderer, { chartData: state.chartData, displayConfig: state.displayConfig }),
+    })
+    app.mount(container)
+    return { container, app, state }
+  }
+
+  it('renders bar via ECharts canvas: init once + setOption(buildChartOption)', async () => {
     const { container } = mount({ chartData: barData })
     await flushPromises()
 
     expect(container.querySelector('[data-chart-type="bar"]')).toBeTruthy()
-    const svg = container.querySelector('[data-chart="bar"]')
-    expect(svg).toBeTruthy()
-    const bars = container.querySelectorAll('[data-bar-index]')
-    expect(bars.length).toBe(3)
+    expect(container.querySelector('[data-chart-canvas]')).toBeTruthy()
+    expect(mocks.init).toHaveBeenCalledTimes(1)
+    expect(mocks.setOption).toHaveBeenCalledTimes(1)
+    // the renderer feeds the pure mapper's output straight to setOption
+    expect(mocks.setOption.mock.calls[0][0]).toEqual(buildChartOption(barData))
   })
 
-  it('renders horizontal bar chart when orientation is horizontal', async () => {
+  it('renders horizontal bar by passing orientation through to the option', async () => {
     const config: ChartDisplayConfig = { orientation: 'horizontal' }
-    const { container } = mount({ chartData: barData, displayConfig: config })
+    mount({ chartData: barData, displayConfig: config })
     await flushPromises()
-
-    const bars = container.querySelectorAll('[data-bar-index]')
-    expect(bars.length).toBe(3)
+    expect(mocks.setOption.mock.calls[0][0]).toEqual(buildChartOption(barData, config))
   })
 
-  it('renders line chart with polyline and data points', async () => {
+  it('renders line via ECharts canvas', async () => {
     const { container } = mount({ chartData: lineData })
     await flushPromises()
 
-    expect(container.querySelector('[data-chart="line"]')).toBeTruthy()
-    const points = container.querySelectorAll('[data-point-index]')
-    expect(points.length).toBe(3)
-    const polyline = container.querySelector('.meta-chart__line')
-    expect(polyline).toBeTruthy()
-    expect(polyline?.getAttribute('points')).toBeTruthy()
+    expect(container.querySelector('[data-chart-type="line"]')).toBeTruthy()
+    expect(mocks.init).toHaveBeenCalledTimes(1)
+    expect((mocks.setOption.mock.calls[0][0] as { series: { type: string }[] }).series[0].type).toBe('line')
   })
 
-  it('renders pie chart with segments and legend', async () => {
+  it('renders pie via ECharts canvas + keeps the HTML legend (swatch/label/value)', async () => {
     const { container } = mount({ chartData: pieData })
     await flushPromises()
 
-    expect(container.querySelector('[data-chart="pie"]')).toBeTruthy()
-    const segments = container.querySelectorAll('[data-pie-index]')
-    expect(segments.length).toBe(3)
-    expect(container.querySelector('[data-legend]')).toBeTruthy()
+    expect(container.querySelector('[data-chart-type="pie"]')).toBeTruthy()
+    expect(mocks.init).toHaveBeenCalledTimes(1)
+    const legend = container.querySelector('[data-legend]')
+    expect(legend).toBeTruthy()
+    expect(container.querySelectorAll('.meta-chart__legend-item').length).toBe(3)
+    expect(legend?.textContent).toContain('Red')
+    expect(legend?.textContent).toContain('30')
   })
 
-  it('renders number chart with value', async () => {
-    const { container } = mount({ chartData: numberData })
+  // V-S1-3b: showLegend is only provable at the renderer layer (HTML legend, pie-only)
+  it('hides the pie HTML legend when showLegend is false', async () => {
+    const { container } = mount({ chartData: pieData, displayConfig: { showLegend: false } })
     await flushPromises()
+    expect(container.querySelector('[data-legend]')).toBeNull()
+  })
 
-    expect(container.querySelector('[data-chart="number"]')).toBeTruthy()
-    const valueEl = container.querySelector('.meta-chart__number-value')
-    expect(valueEl?.textContent).toBe('42000')
+  it('does NOT init ECharts for number/table (HTML-rendered)', async () => {
+    const num = mount({ chartData: numberData })
+    await flushPromises()
+    expect(num.container.querySelector('[data-chart="number"]')).toBeTruthy()
+    expect(num.container.querySelector('.meta-chart__number-value')?.textContent).toBe('42000')
+
+    vi.clearAllMocks()
+    const tbl = mount({ chartData: tableData })
+    await flushPromises()
+    expect(tbl.container.querySelector('[data-chart="table"]')).toBeTruthy()
+    expect(tbl.container.querySelectorAll('.meta-chart__table tbody tr').length).toBe(2)
+
+    expect(mocks.init).not.toHaveBeenCalled()
   })
 
   it('renders number chart with prefix and suffix', async () => {
@@ -126,22 +184,69 @@ describe('MetaChartRenderer', () => {
     expect(affixes[1].textContent).toBe('USD')
   })
 
-  it('renders table chart with rows', async () => {
-    const { container } = mount({ chartData: tableData })
-    await flushPromises()
-
-    expect(container.querySelector('[data-chart="table"]')).toBeTruthy()
-    const rows = container.querySelectorAll('.meta-chart__table tbody tr')
-    expect(rows.length).toBe(2)
-  })
-
-  it('shows title from display config', async () => {
+  it('shows the HTML title from display config (single source, no ECharts title)', async () => {
     const config: ChartDisplayConfig = { title: 'Sales Overview' }
     const { container } = mount({ chartData: barData, displayConfig: config })
     await flushPromises()
 
-    const title = container.querySelector('.meta-chart__title')
-    expect(title?.textContent).toBe('Sales Overview')
+    const titles = container.querySelectorAll('.meta-chart__title')
+    expect(titles.length).toBe(1)
+    expect(titles[0].textContent).toBe('Sales Overview')
+    // title is HTML chrome, not in the ECharts option
+    expect((mocks.setOption.mock.calls[0][0] as { title?: unknown }).title).toBeUndefined()
+  })
+
+  it('disposes the ECharts instance on unmount', async () => {
+    const { app } = mount({ chartData: barData })
+    await flushPromises()
+    expect(mocks.dispose).not.toHaveBeenCalled()
+    app.unmount()
+    expect(mocks.dispose).toHaveBeenCalled()
+  })
+
+  // --- lifecycle (V-S1-4): prop update, cross-type switch, resize wiring ---
+
+  it('re-runs setOption when the chart data changes (prop update)', async () => {
+    const { state } = mountReactive({ chartData: barData })
+    await flushPromises()
+    expect(mocks.setOption).toHaveBeenCalledTimes(1)
+
+    state.chartData = { chartType: 'bar', dataPoints: [{ label: 'Z', value: 99 }] }
+    await flushPromises()
+    expect(mocks.setOption).toHaveBeenCalledTimes(2)
+    expect((mocks.setOption.mock.calls[1][0] as { xAxis: { data: string[] } }).xAxis.data).toEqual(['Z'])
+  })
+
+  it('inits ECharts when switching number → bar (post-flush: canvas now exists)', async () => {
+    const { container, state } = mountReactive({ chartData: numberData })
+    await flushPromises()
+    expect(mocks.init).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-chart-canvas]')).toBeNull()
+
+    state.chartData = barData
+    await flushPromises()
+    expect(container.querySelector('[data-chart-canvas]')).toBeTruthy()
+    expect(mocks.init).toHaveBeenCalledTimes(1)
+    expect(mocks.setOption).toHaveBeenCalled()
+  })
+
+  it('disposes the canvas when switching bar → number', async () => {
+    const { state } = mountReactive({ chartData: barData })
+    await flushPromises()
+    expect(mocks.init).toHaveBeenCalledTimes(1)
+
+    state.chartData = numberData
+    await flushPromises()
+    expect(mocks.dispose).toHaveBeenCalled()
+  })
+
+  it('wires the resize observer to chart.resize()', async () => {
+    mountReactive({ chartData: barData })
+    await flushPromises()
+    expect(roObserve).toHaveBeenCalled()
+    expect(typeof resizeObserverCb).toBe('function')
+    resizeObserverCb?.()
+    expect(mocks.resize).toHaveBeenCalled()
   })
 
   it('localizes table headers while keeping chart data labels raw', async () => {

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -5,6 +5,16 @@ function flushPromises() {
   return new Promise<void>((resolve) => setTimeout(resolve, 0)).then(() => nextTick())
 }
 
+// MetaDashboardView renders MetaChartRenderer, which now uses ECharts (needs a canvas absent in
+// jsdom) → mock the runtime entry points so the dashboard mounts cleanly.
+vi.mock('echarts/core', () => ({
+  init: vi.fn(() => ({ setOption: vi.fn(), resize: vi.fn(), dispose: vi.fn() })),
+  use: vi.fn(),
+}))
+vi.mock('echarts/charts', () => ({ BarChart: {}, LineChart: {}, PieChart: {} }))
+vi.mock('echarts/components', () => ({ GridComponent: {}, TooltipComponent: {} }))
+vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }))
+
 import MetaDashboardView from '../src/multitable/components/MetaDashboardView.vue'
 import { MultitableApiClient } from '../src/multitable/api/client'
 import type { Dashboard, ChartConfig, ChartData } from '../src/multitable/types'

--- a/docs/development/multitable-open-items-development-plan-20260527.md
+++ b/docs/development/multitable-open-items-development-plan-20260527.md
@@ -1,0 +1,104 @@
+# 多维表 — 剩余 open 项开发方案（clean, origin/main-grounded）
+
+> Date: 2026-05-27 · Author: Claude · Status: **PLAN — 非开工**
+> **Grounded in `origin/main` @ `8fd73257d`**（不是落后的本地 checkout —— 教训：做 benchmark/方案前先 `git fetch` + `git rev-list --count HEAD..origin/main` 对照基线，落后则以 `git show origin/main:<file>` 为准）。
+> K3 PoC Stage-1 锁：以下均为多维表内核打磨，允许；**每项仍是独立 opt-in**，不碰 integration-core/RBAC/auth。
+
+## 0. 范围：只列 `origin/main` 上**确认仍未做**的项
+
+**已 shipped（不在本方案内，仅备查）**：agg-footer 后端#1841 + 分组小计#1852 + 前端 `<tfoot>`；formula recalc-on-patch#1883 + A1.1#1890 + A2-defense#1896 + F1#1897；formula dry-run #1865/#1873；frozen-col#1837；inline-create#1834；D2 perf#1815；D3 权限矩阵#1820/#1827/#1831。
+
+**本方案 = 3 项 still-open**：
+
+| Slice | 项 | 深度 | K3 |
+|---|---|---|---|
+| **1** | charts → **ECharts**（渲染层替换） | **PR 级**（最现实的下一刀） | 允许 |
+| **2** | grid 分组头 count + 滚动 UX | 2a **非 quick-win**（前端触发 gated on aggregations）→ 建议折叠进 2b；2b/2c 架构级需 C0 决策 | 允许 |
+| **3** | **A2b** 宏展开转义加固 | 小项（借鉴计划） | 允许 |
+
+---
+
+## Slice 1 — charts → ECharts（PR 级，建议下一刀）
+
+### 现状（origin/main 实读）
+- `ChartType` = `bar | line | pie | number | table`（`types.ts:863`，5 类）。
+- `MetaChartRenderer.vue`（293 行）手搓：bar 用 `<rect>`（含 `orientation==='horizontal'` 横向分支）、line 用 `<polyline>`+`<circle>`、pie 用手算 `<path>` 弧段 + HTML 图例、number/table 用 HTML。8 色 `COLORS` 调色板 + `defaultColor(idx)`。
+- props = `chartData: ChartData` + `displayConfig?: ChartDisplayConfig`；`ChartData.dataPoints: {label,value,color?}[]` + `total` + `chartType`；`ChartDisplayConfig` = `title/showLegend/showValues/prefix/suffix/orientation` + **`colorScheme?: string`**（后者 **dormant**：`types.ts:878`/`charts.ts:42` 仅类型声明、无渲染器/服务消费者 → 本 slice **显式不接、沿用现有 8 色 `COLORS`**，不静默收窄类型；wire `colorScheme`→ECharts palette 留 follow-up）。
+- **唯一消费者** = `MetaDashboardView.vue:82`（`import @:121`）。后端 `ChartAggregationService` 产出 `dataPoints` —— **本 slice 后端零改动**。
+
+### OSS 借鉴
+**Apache ECharts（Apache-2.0，可作依赖）** —— 中国 BI 事实标准、Element Plus 共存好。轻量备选 Chart.js（MIT，≈70KB）仅当确定不扩类型。
+
+### 改造范围（小）：1 个组件 + 1 个消费者；number/table 保留 HTML
+
+**checklist**：
+- ⬜ **1.1 [包体闸门]** tree-shakeable 引入：`import * as echarts from 'echarts/core'` + `echarts/charts` 的 `BarChart/LineChart/PieChart` + `echarts/components` 的 `GridComponent/TooltipComponent` + `echarts/renderers` 的 `CanvasRenderer`，再 `echarts.use([...])`。**不引 `LegendComponent`/`TitleComponent`**（legend/title 走 HTML chrome）。**禁止 runtime `from 'echarts'`**（type-only `import type` 例外）。实测 tree-shaking 剔除 **~537KB raw / ~174KB gzip**（vs 全量 echarts）。
+- ⬜ **1.2** `MetaChartRenderer.vue` 的 bar/line/pie 三个 `<template>` 分支替换为单一 `<div ref="chartEl">` + ECharts canvas；**number/table 两分支原样保留 HTML**（ECharts 无对应、保留即可保住其现有测试）。
+- ⬜ **1.3** option 映射（纯函数 `buildOption(chartData, displayConfig)`，便于单测）：
+  - bar 竖：`xAxis{type:'category',data:labels}` + `yAxis{type:'value'}` + `series[{type:'bar',data:values,label:{show:showValues!==false}}]`；`orientation==='horizontal'` → 交换 x/y 轴。
+  - line：`xAxis category` + `series[{type:'line',data:values}]`。
+  - pie：`series[{type:'pie',data:dataPoints.map(p=>({name:p.label,value:p.value,itemStyle:{color:p.color}}))}]` + `tooltip{trigger:'item'}`。
+  - 颜色：option 级 `color: COLORS`（复用现有 8 色数组），per-point `p.color` 走 `itemStyle.color`。
+  - `displayConfig`：**`title`/`showLegend` 不进 option（= HTML chrome：标题恒 HTML，legend 仅 pie 的 HTML legend 块）**；`showValues`→**仅 bar** 系列 `label.show`（**pie/line label-less**）；`orientation`→仅 bar 轴交换；`prefix/suffix` 仅 number（HTML）；`colorScheme` dormant 不接。**最终 option 不含 `legend`/`title`。**
+- ⬜ **1.4 [生命周期]** `onMounted` init（仅 bar/line/pie）；`watch([()=>props.chartData, ()=>props.displayConfig], ()=>inst.setOption(buildOption(...), true), {deep:true})`；`ResizeObserver` → `inst.resize()`；`onUnmounted` → `inst.dispose()`（防泄漏）。
+- ⬜ **1.5 [测试迁移 — 风险，两层]** ① **renderer spec**：现有断言 SVG DOM 选择器（`data-chart="bar"`/`data-bar-index`/`data-legend`）—— ECharts 渲染到 **canvas**，会失效，且 **jsdom 无 canvas → 必须 `vi.mock('echarts/core')`**；改为断言纯函数 `buildOption` 输出（labels/values/series.type 映射、空数据降级）。number/table 的 HTML 测试原样保留；保留 wrapper `data-chart-type`（模板 L2）做类型断言。② **dashboard consumer spec（owner review 补）**：`MetaDashboardView.vue:121` 静态 import `MetaChartRenderer`，且有独立挂载测试 `apps/web/tests/multitable-dashboard-view.spec.ts`（mock client 返回 chart data）—— 该 spec 也要补 `vi.mock('echarts/core')`，否则 dashboard 挂载即因 canvas 缺失报错。**reviewer 不要以为只改 renderer-spec 就够。**
+- ⬜ **1.6 [包体优化 — 建议拆为独立 follow-up]** `defineAsyncComponent` 让 ECharts 落异步 chunk 收益真实（≈150KB 离主包），但会把 dashboard spec 从同步挂载变成需 `flushPromises`/await 异步解析。**建议 Slice 1 先用静态 import（只 mock echarts，dashboard spec 改动最小），把 async-import 作为单独 follow-up** —— 降低本刀的测试面与风险。
+- 🔒 **1.7** 新增图表类型（scatter/area/funnel/gauge/堆叠/组合）= **后续独立 opt-in**；扩 area/堆叠/组合时后端 `ChartAggregationService` 当前是**单 series**，需补多 series 维度。
+
+**验收**：dashboard 4 类面板（bar/line/pie/number）视觉冒烟一致；横向 bar 生效；resize 不变形；切换 base/卸载无 canvas 泄漏；`buildOption` 单测覆盖 5 类型 + 空数据。
+
+---
+
+## Slice 2 — grid 分组头 count + 滚动 UX（拆 3 个 opt-in）
+
+### 现状（origin/main 实读）
+- grid 仍**翻页器**（50/页）；`groupedRows`（`MetaGridTable.vue:450`）对**当前页** `filteredRows` 分组，header 显示 `group.count = rows.length`（:462/:40）= **页局部计数**。
+- 但 #1852 已让 **server 分组数据**经 `props.aggregateGroups`（`:376`，含 `count` + per-field `aggregates`）流入，已建 `serverGroupAggByKey`（:601）只用于脚注小计，**未用于 header count**。
+
+#### 2a — 分组头 count 用 server 全集值 ⚠️ **不是 quick-win（owner review 勘误）—— 建议折叠进 2b**
+- **比文档初稿大**：前端 `loadAggregates()`（`MultitableWorkbench.vue:1770`）在 `view.config.aggregations` 为空时**直接清空 `aggregateGroups` 并 return**（`:1774-1779`），且 watch（`:1793`）只听 aggregationConfig、**不听 groupField**。所以"仅分组、未开 footer aggregation"的视图**根本拿不到 server count** —— 只改 header 映射是 no-op。
+- **后端其实已 ready**：`/view-aggregate`（`univer-meta.ts:6004-6009`）按 `view.groupInfo.fieldId` 返回 `groups[{key,count,aggregates}]`，**aggConfig 为空也返回 count**（`computeAggregates({})={}`）。所以要让它生效，需扩前端触发：`groupField` 存在即调端点（不止 aggregations 非空）。
+- ⚠️ **但即便修了 count 仍是半修 + 有 UX 风险**：grid 只渲染当前页、页局部分组 → header 显示"(250)"而下面只有 ~30 行，且**整组行都在第 2 页的组在第 1 页根本不出现**。count≠可见行 + 缺组，比现状（页局部 count 与可见行一致）**更易误导**。
+- ✅ **建议（我的推荐）**：**不单独做 2a**。把"分组 count 正确性"**折叠进 2b 的服务端分组行投递**（server 对全集分组、返回 groups+count、前端以 server groups 为渲染源），count 与行一起对。若一定要现在有个 interim，则"扩触发到 groupField + 渲染 server count + 加'当前页'提示"，但价值有限。
+
+#### 2b — 翻页器 → 连续滚动 / 服务端分组行投递 🔒（需 C0 决策先行）
+- 🔒 **C0 决策**：保留确定性"第 N/M 页"（部分企业用户偏好）vs 飞书式连续滚动。**D2 已证 DOM 非瓶颈** → 纯 UX 取舍，非性能驱动。**未决策不启动。**
+- 🔒 决策=连续滚动后：`useMultitableGrid` 加 `appendViewData`（push 不替换）+ 触底 IntersectionObserver；或走服务端分组行投递（组不被分页切断）。
+
+#### 2c — 真窗口化 🔒（仅当 2b 实测暴露 DOM 问题；spike-first）
+- 🔒 **前置 spike（1 天）**：现 frozen 列是 `position:sticky;left:<px>`，窗口化常用 absolute+`translateY` 行 → **sticky 在 transform 父级内是已知浏览器坑**。1k 行窗口化 + 横向滚动验证 frozen 仍钉住。
+- 🔒 通过 → TanStack Virtual（MIT，固定行高按 `RowDensity` 28/36/52px）；失败 → 手搓固定行高 + 手算 sticky 偏移（不同 effort）。
+
+---
+
+## Slice 3 — A2b 宏展开转义加固 ⬜（借鉴计划项）→ **contract-first（owner review 勘误）**
+
+### 现状（origin/main 实读）
+- `formula-engine.ts:108-111`：null/undefined→`'0'`、string→`JSON.stringify`（**已转义、非裸拼接**）、number→`String`、boolean→`TRUE/FALSE`、**其余→`return String(value)`（:111）兜底**。
+- **关键事实（勘误）**：lookup/rollup **被允许作为公式输入**（前端 `MetaFieldManager.vue:669` 只排除 `formula`、不排除 lookup/rollup；后端 `univer-meta.ts:1015` 注释明示"lookup/rollup ARE permitted as formula references"）。所以 `:111` 兜底分支**真实承载** lookup 的复杂值（多值 lookup = array、date、object）。
+- **因此把 array/object/date 一刀切成 `#N/A` 不是 hardening，是行为变更** —— 会破坏现有"lookup 值进公式"的用户公式。
+
+### 建议（我的推荐）：**先锁 contract，做 compatibility-preserving 收口，不做行为纠偏**
+- ⬜ **3.1 [先锁 contract，再写实现]** 定一张 per-type 表，**显式声明每类的产出 + 是否兼容现行为**，例如：
+  | 输入值类型 | 现状（`String(value)`） | A2b 收口（建议） | 是否行为变更 |
+  |---|---|---|---|
+  | string/number/boolean | 已安全 | 不动 | 否 |
+  | date | `String(date)` = locale 串、**未加引号→注入** | 产出 ISO 字符串 **literal（加引号）** | 值近似、修注入 |
+  | array（多值 lookup） | `"a,b"` **未引号→注入/语法污染** | **加引号**成字符串 literal（保留"拼成串"语义） | 仅修安全、值不变 |
+  | object | `[object Object]` 未引号 | 加引号 literal 或 `#VALUE!`（**需决策**） | 需 owner 拍板 |
+- ⬜ **3.2** 回归测试 **pin 现行标量行为**（string/number/boolean/rollup-number 产出不变）+ 对抗性单测（值含 `"`、`{fld_x}`、`1+1`、array、object、date、超长串）断言**无注入**。
+- ⬜ **3.3 [保持最小]** 任何**语义纠偏**（如"lookup array 应可被 SUM"）= **单独决策**，不并进本 hardening PR。且 Track B（Teable `packages/formula` 真解析器）若上马会整体取代宏展开转义 → **A2b 不过度投入**。
+- 权威跟踪 `multitable-derived-field-borrow-plan-20260526.md`；**A2-full（链式 topo）仍 gated/future**。
+
+---
+
+## 横切
+
+- **license**：ECharts(Apache)/TanStack Virtual(MIT)/Teable `packages/formula`(MIT) 可作依赖；引入仍是**独立 opt-in**。Chart.js(MIT) 为 ECharts 轻量备选。
+- **grounding 纪律**（本轮教训）：任何 benchmark/方案先 `git fetch && git rev-list --count HEAD..origin/main`，落后则以 `git show origin/main:<file>` 为准 —— 落后 checkout 的 file:line 会误导。
+- **staged opt-in**：**Slice 1 与 3（A2b）可各自独立起步**；**2b/2c 受 C0 gate**（2a 已折叠进 2b、非独立起跑项）；不自动开下一刀。
+- **建议起点**：**Slice 1（ECharts）**，且**先静态 import（只 mock echarts）**，async-import 拆 follow-up —— 改造面收敛到 1 组件 + 1 消费者、后端零改动、视觉收益最直接、测试面最小。
+
+> **Owner review v2（2026-05-27）已折入**：① 2a 比初稿大（前端 `loadAggregates` gated on `view.config.aggregations`、不听 groupField）→ 降级、建议折叠进 2b；② A2b 是行为变更不是纯 hardening（lookup/rollup 允许作公式输入，复杂值走 `String(value)`）→ 改 contract-first；③ Slice 1 测试漏了 dashboard consumer spec → 已补，且建议静态 import 先行。主排序不变（Slice 1 仍最干净）。
+
+**一句话**：剩余真正 open 的就三件 —— **Slice 1 ECharts**（PR 级、下一刀、静态 import 先行）、**grid 分组/滚动**（2a 非 quick-win，折叠进 2b 服务端分组投递；2b/2c 需 C0 决策）、**A2b**（contract-first、兼容收口、Track B 或将取代）。其余 BI-polish + formula 主线均已 shipped。

--- a/docs/development/multitable-open-items-todo-20260527.md
+++ b/docs/development/multitable-open-items-todo-20260527.md
@@ -1,0 +1,59 @@
+# 多维表剩余 open 项 — TODO 追踪清单
+
+> Date: 2026-05-27 · Status: **TRACKER（非开工）** · 配套：开发计划 `multitable-open-items-development-plan-20260527.md` + 验证 `multitable-open-items-verification-20260527.md`
+> Grounded in `origin/main @ 8fd73257d`。K3 锁：均为内核打磨，允许；**每个 slice 仍是独立 opt-in，不自动开下一刀**。
+> 标记：✅ done · ⬜ todo（opt-in 后可动手）· 🔒 gated（被决策/前置阻塞）· ☑️ 需 owner 拍板的决策点
+
+---
+
+## Slice 1 — charts → ECharts（推荐下一刀，静态 import 先行）
+
+**前置**：`pnpm --filter @metasheet/web add echarts`（Apache-2.0）。范围：`MetaChartRenderer.vue`（1 组件）+ `MetaDashboardView.vue`（1 消费者）；后端零改动。
+
+- ⬜ **S1-1** tree-shakeable 引入：`import * as echarts from 'echarts/core'` + `echarts/charts`(`BarChart/LineChart/PieChart`) + `echarts/components`(`GridComponent/TooltipComponent`) + `echarts/renderers`(`CanvasRenderer`) + `echarts.use([...])`。**不引 LegendComponent/TitleComponent**（legend/title = HTML chrome）。**禁 runtime `from 'echarts'`**（type-only 例外）。
+- ⬜ **S1-2** 纯函数 `buildOption(chartData, displayConfig): EChartsOption`（独立文件，便于单测）：bar 竖/横（`orientation`）、line、pie 三类映射；复用现有 8 色 `COLORS`（`displayConfig.colorScheme` 当前 dormant、本 slice 不接、wire→palette 留 follow-up）；仅 `showValues`→**bar** 系列 label + `orientation`→bar 轴 映射进 option；**`title`/`showLegend` = HTML chrome 不进 option**；**pie/line label-less**；最终 option 无 `legend`/`title`。
+- ⬜ **S1-3** `MetaChartRenderer.vue`：bar/line/pie 三个 `<template>` 分支 → 单一 `<div ref="chartEl">`；**number/table 两分支原样保留 HTML**；保留 wrapper `data-chart-type`（模板 L2）。
+- ⬜ **S1-4** 生命周期：`onMounted` init（仅 bar/line/pie）；`watch([()=>chartData,()=>displayConfig], ()=>inst.setOption(buildOption(...), true), {deep:true})`；`ResizeObserver`→`inst.resize()`；`onUnmounted`→`inst.dispose()`。
+- ⬜ **S1-5** **静态 import**（不用 `defineAsyncComponent`——见 S1-9 follow-up）。
+- ⬜ **S1-6** renderer spec 迁移：`vi.mock('echarts/core')`（jsdom 无 canvas）；断言 `buildOption` 输出（5 类型 + 空数据 + 横向 bar + per-point color + displayConfig 映射）；number/table HTML 断言保留。
+- ⬜ **S1-7** dashboard spec 补 `vi.mock('echarts/core')`（`multitable-dashboard-view.spec.ts` 挂载即用 renderer，否则 canvas 崩）。
+- ⬜ **S1-8** i18n 走既有 `meta-view-render-labels`，**不新建 label 模块**。
+- ⬜ **S1-9** 🔒 follow-up：`defineAsyncComponent` 让 echarts 落异步 chunk（+ dashboard spec 改 `flushPromises`）。**单独 PR**，不进 S1 本刀。
+- ⬜ **S1-10** 🔒 follow-up：新图表类型（scatter/area/funnel/gauge/堆叠/组合）——需后端 `ChartAggregationService` 补多 series 维度。**单独 opt-in**。
+
+---
+
+## Slice 2 — grid 分组 count + 滚动 UX（gated）
+
+> 2a（仅改 header count）已勘误为**非 quick-win**，折叠进 2b（理由见开发计划 §Slice 2）。
+
+- 🔒 ☑️ **C0 决策（owner 拍板）**：翻页器（确定性 N/M 页）vs 飞书式连续滚动。D2 已证 DOM 非瓶颈 → 纯 UX 取舍。**未决策不启动 2b/2c。**
+- 🔒 **2b-1**（决策后）服务端分组行投递：扩 `/view` 或新端点按 `view.groupInfo.fieldId` 对**全集**分组返回 groups+count（后端 `groupRowsByField` 已具备）；前端以 server groups 为渲染源，`group.count` 用 server 全集值（替代 `MetaGridTable.vue:462` 页局部）。
+- 🔒 **2b-2** 分组分页模型（组内/跨组分页，组不被分页切断）。
+- 🔒 **2b-3** 字段权限 parity：group field 不可见 → 422（端点 `:5994` 已有；前端要处理该错误态）。
+- 🔒 **2c-0 [spike 先行，1 天]** 现 frozen 列 `position:sticky;left:<px>` 与窗口化 `translateY` 行的兼容性（1k 行 + 横向滚动验证 frozen 仍钉住）。
+- 🔒 **2c-1** spike 通过 → TanStack Virtual（MIT，行高按 `RowDensity` 28/36/52px）；失败 → 手搓固定行高 + 手算 sticky 偏移。
+
+---
+
+## Slice 3 — A2b 宏展开转义加固（contract-first）
+
+> 勘误：lookup/rollup 合法进公式（`MetaFieldManager.vue:669` 不排除、后端 `univer-meta.ts:1015` 允许），复杂值真实走 `formula-engine.ts:111` `String(value)`。**改其字面化 = 行为变更，故先锁 contract。**
+
+- ⬜ ☑️ **A2b-1（owner 拍板）** 锁 per-type contract 表（开发计划 §Slice 3 有草表）：标量不变；array→加引号 literal（值不变、修注入）；date→ISO 引号 literal；**object → `#VALUE!` 还是引号 literal？需拍板**。
+- ⬜ **A2b-2** 实现：`String(value)` 分支按 contract 安全编码（兼容保留为主）。
+- ⬜ **A2b-3** 回归测试 pin 现行标量行为 + 对抗性单测（`"`/`{fld_x}`/`1+1`/array/object/date/超长串）。
+- ⬜ **A2b-4** lookup-进-公式真 DB 集成测试（wire-vs-fixture：lookup 值经真 patch 流入 formula）。
+- 🔒 **A2b-5** Track B（Teable `packages/formula` MIT 真解析器取代宏展开）——**单独 RFC**，若上马则 A2b 可作废，故 A2b 保持最小。
+
+---
+
+## 决策点汇总（☑️ 待 owner）
+
+1. **C0**：翻页器 vs 连续滚动（解锁 2b/2c）。
+2. **A2b-1**：object 值进公式 → `#VALUE!` 还是引号 literal。
+3. **起点确认**：是否从 Slice 1（ECharts，静态 import）开工。
+
+## 落地提示
+
+**这些 docs（及后续实现）若要 land，先 `git fetch` 后从 `origin/main` 切新分支提交**，不要从可能落后的本地分支提交（规划/实现前先 `git rev-list --count HEAD..origin/main` 确认基线）。

--- a/docs/development/multitable-open-items-verification-20260527.md
+++ b/docs/development/multitable-open-items-verification-20260527.md
@@ -1,0 +1,69 @@
+# 多维表剩余 open 项 — 验证 / 验收矩阵
+
+> Date: 2026-05-27 · Status: **验收标准（实现后逐条填 ✅/❌）** · 配套：`multitable-open-items-development-plan-20260527.md` + `multitable-open-items-todo-20260527.md`
+> 每个 slice 的"done"= 下方该节全绿 + `pnpm validate:all` 绿。
+
+## 0. 横切验收纪律（所有 slice 适用 — 来自 PR-hardening 经验）
+
+- **production code 无 `any`**（测试可用局部 `any`/cast 断言 ECharts 宽 option 联合）、type-only import（ESLint 强制）、无 dead helper、commit message Conventional + scope。
+- **exact body assertions**（断状态码 **且** 断 body 结构/字段），不止断 200。
+- **MD ↔ spec/code parity**：本验证文档与实现行为一致；RC/contract 同 commit 勾选。
+- **wire-vs-fixture 纪律**：任何经 copy/whitelist/pick/select 投影的字段，**必须真 wire 集成测试**（手搓 fixture 抓不到 drop）。
+- **no skip-when-unreachable**：集成/e2e 在真实路径不可达时必须 **fail 或显式标 not-run**，不得 early-return 静默绿。
+- 权限相关用 **real-DB**（`describeIfDatabase` + `DATABASE_URL` 硬门；默认 `pnpm test` 会跳过，需专门跑）。
+
+---
+
+## Slice 1 — ECharts（可立即验收）
+
+| ID | 验收项 | 方法 | 通过判据 |
+|---|---|---|---|
+| **V-S1-1** | `buildOption` 映射正确 | vitest 单测（纯函数，无需 echarts 运行时） | bar 竖：`xAxis.type='category'`+`.data=labels`、`series[0].type='bar'`；横向（`orientation='horizontal'`）x/y 轴交换；line：`series[0].type='line'`、category 轴；pie：`series[0]={type:'pie',data:[{name,value}]}`；**空 dataPoints 不崩**；per-point color→`itemStyle.color`，缺省 8 色 palette；number/table→`null` |
+| **V-S1-2** | **行为契约（已锁，单测断言）** | vitest 单测 | **option 无 `legend`、无 `title`**（二者是 HTML chrome、不进 ECharts）；**pie/line `label.show=false`**（仅 bar 显值）；bar `showValues` 默认 on、`false`→`label.show=false`；`orientation` 仅切 bar 轴；`colorScheme` dormant 不接 |
+| **V-S1-3** | renderer 分支正确 | vitest 挂载（mock echarts） | bar/line/pie 渲染 `<div ref>`（`data-chart-type` 在）、`echarts.init` 调用 1 次；**number/table 仍 HTML**（`data-chart="number"/"table"` + 值在），number/table **不** init echarts |
+| **V-S1-3b** | **HTML chrome 契约（renderer-only，必须有 spec）** | renderer spec | `showLegend` 只能在 renderer 层证：pie + `showLegend=false` → HTML legend **不渲染**（`data-legend` 缺席）；pie 默认 → HTML legend 在、含 label+value；**title 单源**：仅一个 HTML 标题（option 无 title 已由 V-S1-1 锁），无双标题 |
+| **V-S1-4** | 生命周期（含跨类型切换） | vitest（mock + reactive 重渲染） | prop data 变 → `setOption(...,true)` 二次调；**number/table → bar/line/pie 切换**（watch `flush:'post'`，canvas 此时才在 DOM）→ `init()` + observer 补挂；**chart → number 切换** → `dispose()`；observer 回调 → `chart.resize()`；卸载 → `dispose()` |
+| **V-S1-5** | dashboard 消费者不崩 | `multitable-dashboard-view.spec.ts` + `vi.mock('echarts/core')` | 现有挂载测试在 mock 下绿（无 canvas 崩） |
+| **V-S1-6** | 包体 tree-shaken | grep + `pnpm --filter @metasheet/web build` | **runtime** 只 `from 'echarts/core'` 及子路径（**无 runtime `from 'echarts'`**）；`import type … from 'echarts'`（如 `EChartsOption`）**例外**——编译期擦除、不进 bundle；构建产物里 echarts 不进首屏主 chunk（静态 import 下进 dashboard 路由 chunk 或 vendor，仅 used modules）。**✅ 验证 2026-05-27**：build 绿；echarts 仅在 `MultitableEmbedHost` chunk（**不在首屏 `index`**）；tree-shaking 确认 = 子集 **1254kB** vs 全量 echarts **1791kB**（受控实验，剔除 **~537kB raw / ~174kB gzip**） |
+| **V-S1-7** | 视觉冒烟 | 手动 / Playwright（stack 起则跑，否则**显式标 not-run**） | **⏸ NOT-RUN（2026-05-27，无 stack）** — 待 dev server 起后人工核对：dashboard 5 类面板渲染一致、横向 bar 生效、resize 重排、切换/卸载无 console error、无 canvas 泄漏 |
+| **V-S1-8** | 质量门 | `pnpm validate:all` | validate:plugins + lint + type-check 全绿；**production code 无 `any`**（测试局部 any 例外）；i18n 走既有模块无新模块 |
+
+**Slice 1 done = V-S1-1..8 全绿**（V-S1-7 若 stack 不可达，显式标 not-run + 列手动复核步骤，不算静默通过）。
+
+---
+
+## Slice 3 — A2b 宏展开转义（contract-first 验收）
+
+| ID | 验收项 | 方法 | 通过判据 |
+|---|---|---|---|
+| **V-A2b-0** | contract 表已锁 | 评审 | 开发计划 §Slice 3 的 per-type 表经 owner 拍板（含 object 分支裁决），与实现同 commit |
+| **V-A2b-1** | **标量行为零回归** | vitest golden | string/number/boolean/rollup-number 进公式的求值输出**改动前后逐字相同**（pin 现行为） |
+| **V-A2b-2** | 对抗性无注入 | vitest | 值含 `"`、`{fld_x}`、`1+1`、array、object、date、超长串 → ① 表达式**不被污染/注入**；② 产出符合锁定 contract（如 array→引号 literal） |
+| **V-A2b-3** | lookup-进-公式真 wire | **real-DB 集成**（非 fixture） | 建 string 字段 X → lookup L 拉 X → formula F 引用 L；经真 patch 路径写入；断 F 产出符合 contract（wire-vs-fixture 纪律） |
+| **V-A2b-4** | 最小化 | 评审 | 未越界做语义纠偏（如"lookup array 可 SUM"另开决策）；若 Track B 决定上马则记录 A2b 作废条件 |
+
+**A2b done = V-A2b-0..4 全绿**；**V-A2b-1（零回归）是硬门** —— 任何标量产出变化都视为契约破坏，需回到 V-A2b-0 重新拍板。
+
+---
+
+## Slice 2 — grid 分组/滚动（gated：C0 决策后再执行，先定标准）
+
+> 未启动；以下为**待执行验收标准**，C0 拍板后填实。
+
+| ID | 验收项 | 通过判据（预定） |
+|---|---|---|
+| **V-2b-1** | 分组完整性 | grouped view 显示**全集所有组**（不再页局部丢组）；每组 `count` = 全集计数（非当页） |
+| **V-2b-2** | 分组行正确 | 组下行覆盖全集（按分页模型），无重复/缺失 |
+| **V-2b-3** | 权限 parity | group field 不可见 → 422 `AGGREGATE_GROUP_FIELD_DENIED` 前端正确处理；real-DB |
+| **V-2c-0** | 窗口化 spike | 1k 行窗口化 + 横向滚动下 frozen 列仍钉住、无 jank（**spike 不过则改手搓方案，重估**） |
+| **V-2c-1** | 窗口化正确 | 滚动行回收无重复/缺失；focus/selection 跨窗口保持；frozen + 条件格式不丢 |
+
+---
+
+## 验收执行顺序
+
+1. **Slice 1** 现在可执行（V-S1-1..8）。
+2. **A2b** 待 A2b-1 contract 拍板后执行（V-A2b-0 先行）。
+3. **Slice 2** 待 C0 决策后执行。
+
+**落地提示**：docs 与后续实现若要 land，先 `git fetch` 后从 `origin/main` 切新分支提交，勿从可能落后的本地分支提交（先 `git rev-list --count HEAD..origin/main` 确认基线）。

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -75,6 +75,9 @@ importers:
       bpmn-js:
         specifier: ^18.10.1
         version: 18.10.1
+      echarts:
+        specifier: ^5.5.0
+        version: 5.6.0
       element-plus:
         specifier: ^2.10.1
         version: 2.11.8(vue@3.5.24(typescript@5.8.3))
@@ -2336,6 +2339,9 @@ packages:
   ecdsa-sig-formatter@1.0.11:
     resolution: {integrity: sha512-nagl3RYrbNv6kQkeJIpt6NJZy8twLB/2vtz6yN9Z4vRKHN4/QZJIEbqohALSgwKdnksuY3k5Addp5lg8sVoVcQ==}
 
+  echarts@5.6.0:
+    resolution: {integrity: sha512-oTbVTsXfKuEhxftHqL5xprgLoc0k7uScAwtryCgWF6hPYFLRwOUHiFmHGCBKP5NPFNkDVopOieyUqYGH8Fa3kA==}
+
   ee-first@1.1.1:
     resolution: {integrity: sha512-WMwm9LhRUo+WUaRN+vRuETqG89IgZphVSNkdFgeb6sS/E4OrDIN7t48CAewSHXc6C8lefD8KKfr5vY61brQlow==}
 
@@ -4159,6 +4165,9 @@ packages:
     peerDependencies:
       typescript: '>=4.2.0'
 
+  tslib@2.3.0:
+    resolution: {integrity: sha512-N82ooyxVNm6h1riLCoyS9e3fuJ3AMG2zIZs2Gd1ATcSFjSA23Q0fzjjZeh0jbJvWVDZ0cJT8yaNNaaXHzueNjg==}
+
   tslib@2.8.1:
     resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
 
@@ -4577,6 +4586,9 @@ packages:
 
   zod@3.25.76:
     resolution: {integrity: sha512-gzUt/qt81nXsFGKIFcC3YnfEAx5NkunCfnDlvuBSSFS02bcXu4Lmea0AFIUwbLWxWPx3d9p8S5QoaujKcNQxcQ==}
+
+  zrender@5.6.1:
+    resolution: {integrity: sha512-OFXkDJKcrlx5su2XbzJvj/34Q3m6PvyCZkVPHGYpcCJ52ek4U/ymZyfuV1nKE23AyBJ51E/6Yr0mhZ7xGTO4ag==}
 
 snapshots:
 
@@ -6492,6 +6504,11 @@ snapshots:
   ecdsa-sig-formatter@1.0.11:
     dependencies:
       safe-buffer: 5.2.1
+
+  echarts@5.6.0:
+    dependencies:
+      tslib: 2.3.0
+      zrender: 5.6.1
 
   ee-first@1.1.1: {}
 
@@ -8636,6 +8653,8 @@ snapshots:
     dependencies:
       typescript: 5.8.3
 
+  tslib@2.3.0: {}
+
   tslib@2.8.1: {}
 
   tsx@4.20.6:
@@ -9079,3 +9098,7 @@ snapshots:
   yoctocolors-cjs@2.1.3: {}
 
   zod@3.25.76: {}
+
+  zrender@5.6.1:
+    dependencies:
+      tslib: 2.3.0


### PR DESCRIPTION
## Slice 1 — charts → ECharts (multitable BI polish, benchmark #4)

Swaps the hand-rolled SVG chart renderer (bar/line/pie) to tree-shakeable **Apache ECharts**; `number`/`table` stay HTML. **Behavior-exact** — title + pie legend stay HTML chrome, the only addition is hover tooltips. Backend `ChartAggregationService` untouched (it already produced the data points).

### Changed
- `buildChartOption.ts` — pure mapper (`ChartData` → ECharts option; `null` for number/table); type-only echarts import so it unit-tests without a canvas
- `MetaChartRenderer.vue` — bar/line/pie → ECharts canvas + lifecycle (init / setOption / resize / dispose). Handles prop updates and `number/table ↔ chart` switches via `watch{flush:'post'}` + an idempotent resize-observer
- specs: buildChartOption (12) · renderer (14) · dashboard echarts-mock (7) = **33**
- docs: open-items dev plan + TODO + verification (the tracker for the remaining BI items)

### Verification
| Gate | Result |
|---|---|
| unit / component / integration specs | ✅ 33 passed |
| `vue-tsc -b` type-check | ✅ clean |
| `vite build` + tree-shaking | ✅ controlled experiment: subset vs full echarts = **~537 kB / 174 kB-gzip stripped**; echarts lands only in the `MultitableEmbedHost` chunk (**not** first-paint `index`) |
| **V-S1-7 visual smoke** | ⏸ **NOT-RUN** — no live stack. Must be eyeballed in a running dashboard (canvas render / resize feel / tooltip look) before this is relied on. |

### Behavior contract (locked over review)
ECharts owns the plot; HTML owns the chrome. No ECharts `legend`/`title` in the option; pie legend (swatch+label+value) stays HTML and `showLegend`-gated (proven at the renderer layer); pie/line are value-label-less, only bar shows values (`showValues`). `colorScheme` is dormant (deferred).

### Out of scope (gated follow-ups, per the open-items plan)
- S1-9 async-import code-split of echarts · S1-10 new chart types (scatter/area/funnel/gauge — needs backend multi-series)
- grid grouping 2b/2c (needs the C0 pager-vs-continuous-scroll decision) · A2b formula macro-escaping

🤖 Generated with [Claude Code](https://claude.com/claude-code)
