### PR TITLE
docs(integration): DF-T1 no-write preview evidence runbook + fillable template (#1792)

### DIFF
--- a/docs/operations/integration-k3wise-df-t1-preview-evidence-runbook-20260527.md
+++ b/docs/operations/integration-k3wise-df-t1-preview-evidence-runbook-20260527.md
@@ -1,0 +1,98 @@
+# K3 WISE — DF-T1 target-payload preview evidence runbook (2026-05-27)
+
+Issue: **#1792** (customer GATE). Purpose: before the next M1 Material **Save-only** attempt,
+use the **DF-T1 no-write preview** (PR #1945, on the #1936 composition-parity seam) to verify
+the **exact target payload** an operator would Save — replacing "blind Save attempts" with
+"verify the payload first, then request Save".
+
+> **This runbook does NOT authorize a Save.** It produces *preview evidence* only. Save-only
+> approval is a separate, explicit request after this evidence is accepted (see the end).
+
+## Scope / safety
+
+- **No-write only.** The DF-T1 preview makes zero external calls (no login / fetch / Save /
+  Submit / Audit / BOM / list / search). It only composes and validates a payload.
+- **Proven clone-Save path, not authoring.** `payloadTemplate` is a sanitized `Material/GetDetail`
+  clone — the object-preservation path already proven at the GATE — not a hand-built object.
+  `fieldRules` v1 replaces **only** the identity fields `FNumber`/`FName` (`from_staging`); every
+  reference object stays `preserve_template` + completeness. This is *preview of the proven
+  clone-Save*, not a general K3 authoring UI; do not author reference fields one-by-one.
+- **Real values stay off Git.** The real `payloadTemplate` (a sanitized `Material/GetDetail`
+  clone with the customer's reference objects) and the real staging row are filled **at
+  runtime on the entity machine**, never committed. The template in this repo is placeholders
+  only.
+- **#1792 comments are sanitized.** Post only the redacted acceptance result (below). Never
+  paste a raw `FNumber` / `FName` / reference object / customer host / token / authorityCode.
+
+## Prerequisites
+
+- An on-prem package built from `main` at or after #1945 (DF-T1) — it carries the
+  `/api/integration/templates/preview` `payloadTemplate` + `fieldRules` mode and the shared
+  `k3-save-body-composer`.
+- The customer Material profile shape (`material-k3wise-customer-profile-v1`) and a
+  **sanitized** `Material/GetDetail` clone to use as the `payloadTemplate` base.
+- One real cleansed **staging row** for the material under test.
+
+## Steps
+
+1. **Copy the fillable template off Git** and fill it on the entity machine with the
+   customer's real values:
+   - `docs/operations/integration-k3wise-df-t1-preview-evidence-template.json`
+   - `sourceRecord` ← one real staging row.
+   - `payloadTemplate` ← your sanitized GetDetail clone. The template's reference fields are
+     **illustrative**; substitute the whole clone (it usually carries more objects, e.g.
+     org/stock fields) and leave any value you cannot fill as its `<…>` placeholder — DF-T1
+     fail-closes on it.
+   - `fieldRules` ← keep the provided rules (identity fields `from_staging`; reference objects
+     `preserve_template` with the right `completeness`); add a `preserve_template` rule for any
+     extra required reference field your clone carries.
+   - Save the filled copy as `df-t1-preview-evidence.filled.json` (the name step 2 reads).
+2. **Run the no-write preview** (replace host/token at runtime; do not record them):
+
+   ```bash
+   curl -sS -X POST "$K3_PREVIEW_BASE/api/integration/templates/preview" \
+     -H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json' \
+     --data @df-t1-preview-evidence.filled.json
+   ```
+
+3. **Check the acceptance bar** (all must hold):
+
+   | Field | Required value |
+   |---|---|
+   | `valid` | `true` |
+   | `targetPayloadPreview.eligibleForSaveOnly` | `true` |
+   | `targetPayloadPreview.unresolvedPlaceholders` | `[]` |
+   | `targetPayloadPreview.unresolvedReferenceComponents` | `[]` |
+   | `targetPayloadPreview.missingRequiredFields` | `[]` |
+   | `targetPayloadPreview.redactionSelfCheck.clean` | `true` |
+   | `targetPayloadPreview.compositionSource` | `'k3-save-body-composer'` |
+
+   If any fails: the preview is **not** ready. `unresolvedPlaceholders` lists `<…>` values
+   still to fill; `unresolvedReferenceComponents` lists reference fields missing a required
+   `FNumber/FName` or `FID/FName`; `missingRequiredFields` lists required fields with no value.
+   Fix the template/staging row and re-run. Do **not** proceed to a Save request until the bar
+   is green.
+
+## What to post on #1792 (sanitized only)
+
+Post the **acceptance result**, not the payload. A safe shape:
+
+```
+DF-T1 no-write preview evidence (package <tag>, profile material-k3wise-customer-profile-v1):
+- valid: true
+- eligibleForSaveOnly: true
+- unresolvedPlaceholders: 0 | unresolvedReferenceComponents: 0 | missingRequiredFields: 0
+- redactionSelfCheck.clean: true | compositionSource: k3-save-body-composer
+- fields composed: <count> (identity from staging; <count> reference objects preserved) — count fieldProvenance, do not paste it
+```
+
+Do **not** paste `payload` / `targetRecord` / `fieldProvenance` values, raw `FNumber`/`FName`,
+reference objects, the host, or the token. If you must reference a record, use a masked key.
+
+## After acceptance — Save is a SEPARATE gated request
+
+Once the owner/customer accepts this preview evidence, raise a **separate explicit Save-only
+approval request** on #1792 (installed package, approved record count, profile, operator-
+reviewed dictionaries confirmed, rollback owner/strategy per the #1830 rollback design).
+**This runbook does not authorize any Save / Submit / Audit / BOM / multi-record / production
+write** — only the no-write preview above.

--- a/docs/operations/integration-k3wise-df-t1-preview-evidence-template.json
+++ b/docs/operations/integration-k3wise-df-t1-preview-evidence-template.json
@@ -1,0 +1,43 @@
+{
+  "_instructions": [
+    "DF-T1 no-write preview evidence template (#1792). Copy this OFF Git, fill the real",
+    "customer values on the entity machine, then POST to /api/integration/templates/preview.",
+    "NO-WRITE only — this does not Save. Do NOT commit real FNumber/FName/reference codes,",
+    "customer host, or token. Leave any value you cannot fill as its <...> placeholder;",
+    "DF-T1 fail-closes on unfilled placeholders. Acceptance bar is in the companion runbook",
+    "integration-k3wise-df-t1-preview-evidence-runbook-20260527.md. This _instructions key is",
+    "a sibling of sourceRecord/payloadTemplate and is ignored by the preview; sourceRecord and",
+    "payloadTemplate below contain ONLY real fields (no annotation keys) so nothing pollutes",
+    "the composed payload. SCOPE (proven clone-Save path, NOT a general K3 authoring UI):",
+    "payloadTemplate MUST be a sanitized Material/GetDetail clone — the object-preservation path",
+    "already proven at the GATE — not a hand-built object. fieldRules v1 REPLACES ONLY the",
+    "identity fields FNumber/FName (from_staging); every reference object stays preserve_template",
+    "+ completeness (FNumber/FName or FID/FName). Do NOT author reference fields one-by-one. Fill",
+    "materialCode/materialName from a staging row. The reference fields below are ILLUSTRATIVE:",
+    "substitute the whole payloadTemplate with your sanitized clone (it usually carries more",
+    "objects, e.g. org/stock fields), keeping each object's shape and a <...> placeholder for",
+    "anything you cannot fill; mirror each new required reference field with a preserve_template",
+    "fieldRule."
+  ],
+  "bodyKey": "Data",
+  "sourceRecord": {
+    "materialCode": "<staging-material-code>",
+    "materialName": "<staging-material-name>"
+  },
+  "payloadTemplate": {
+    "FUnitGroupID": { "FNumber": "<unit-group-number>", "FName": "<unit-group-name>" },
+    "FUnitID": { "FNumber": "<unit-number>", "FName": "<unit-name>" },
+    "FBaseUnitID": { "FNumber": "<base-unit-number>", "FName": "<base-unit-name>" },
+    "FErpClsID": { "FID": "<erp-cls-id>", "FName": "<erp-cls-name>" },
+    "FUseState": { "FID": "<use-state-id>", "FName": "<use-state-name>" }
+  },
+  "fieldRules": [
+    { "targetField": "FNumber", "sourceType": "from_staging", "sourceField": "materialCode", "required": true, "shape": "scalar" },
+    { "targetField": "FName", "sourceType": "from_staging", "sourceField": "materialName", "required": true, "shape": "scalar" },
+    { "targetField": "FUnitGroupID", "sourceType": "preserve_template", "required": true, "completeness": "require-fnumber-fname" },
+    { "targetField": "FUnitID", "sourceType": "preserve_template", "required": true, "completeness": "require-fnumber-fname" },
+    { "targetField": "FBaseUnitID", "sourceType": "preserve_template", "required": true, "completeness": "require-fnumber-fname" },
+    { "targetField": "FErpClsID", "sourceType": "preserve_template", "required": true, "completeness": "require-fid-fname" },
+    { "targetField": "FUseState", "sourceType": "preserve_template", "required": true, "completeness": "require-fid-fname" }
+  ]
+}


### PR DESCRIPTION
## Purpose

Adds an operator runbook + a placeholders-only fillable template for using **DF-T1**
(target-payload no-write preview, #1945, on the #1936 composition-parity seam) as
evidence for **#1792**'s GATE: *verify the exact Save payload before requesting a Save*,
replacing the blind-Save pattern.

## Files (docs-only, no code)

- `docs/operations/integration-k3wise-df-t1-preview-evidence-runbook-20260527.md` (98 lines)
- `docs/operations/integration-k3wise-df-t1-preview-evidence-template.json` (43 lines)

## Scope (and what this is NOT)

- **No-write only.** The DF-T1 preview makes zero external calls. This runbook produces
  *preview evidence only*; it does **not** authorize any Save.
- **Save-only is a separate, explicit request** raised on #1792 *after* the owner/customer
  accepts this preview evidence (the closing section of the runbook says this verbatim).
- **Real values stay off Git.** The committed template is placeholders only; the operator
  fills the sanitized `Material/GetDetail` clone + a real staging row at runtime on the
  entity machine. The K3 Stage-1 lock holds.
- **Scope-locked to the proven clone-Save path.** `payloadTemplate` = sanitized GetDetail
  clone (the object-preservation path already proven at the GATE); `fieldRules` v1 replaces
  only `FNumber`/`FName`, reference objects stay `preserve_template` + completeness. This
  is *preview of the proven clone-Save*, not a general K3 authoring UI.

## Acceptance bar (all seven must hold to be evidence-ready)

| Field | Required |
|---|---|
| `valid` | `true` |
| `targetPayloadPreview.eligibleForSaveOnly` | `true` |
| `targetPayloadPreview.unresolvedPlaceholders` | `[]` |
| `targetPayloadPreview.unresolvedReferenceComponents` | `[]` |
| `targetPayloadPreview.missingRequiredFields` | `[]` |
| `targetPayloadPreview.redactionSelfCheck.clean` | `true` |
| `targetPayloadPreview.compositionSource` | `'k3-save-body-composer'` |

## Validation (non-vacuous local smoke against the live DF-T1 code)

- Template as-is (placeholders) → `valid:false`, `eligibleForSaveOnly:false`,
  `unresolvedPlaceholders:12` (fail-closed actually fires).
- Filled copy (`FNumber/FName` + 5 reference objects) → `valid:true`,
  `eligibleForSaveOnly:true`, all three arrays empty, `redactionSelfCheck.clean:true`,
  `compositionSource:'k3-save-body-composer'`.
- Composed `Data` keys are exactly the 7 K3 fields — the `_instructions` annotation key is
  ignored by `buildTargetPayloadPreview` and does not pollute the composed payload.

## #1792 comment hygiene

The runbook's *"What to post on #1792 (sanitized only)"* section explicitly forbids pasting
raw `payload` / `targetRecord` / `fieldProvenance` / `FNumber` / `FName` / reference objects
/ host / token, and gives a safe acceptance-only shape.

## Refs

- #1792 — customer GATE issue (target consumer of this evidence)
- #1945 — DF-T1 target-payload no-write preview (the implementation this runbook drives)
- #1936 — `k3-save-body-composer` composition-parity seam (the single source of truth the
  preview shares with the adapter Save)

Closes none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
