### PR TITLE
fix(multitable): harden formula value substitution (A2b — defensive)

### DIFF
--- a/packages/core-backend/src/multitable/formula-engine.ts
+++ b/packages/core-backend/src/multitable/formula-engine.ts
@@ -101,15 +101,36 @@ export class MultitableFormulaEngine {
       expression = expression.substring(1)
     }
 
-    // Replace {fld_xxx} references with actual values from recordData
+    // Replace {fld_xxx} references with actual values from recordData. Complex values must become
+    // SAFE literals, never raw-substituted — the old `String(value)` injected `[object Object]`
+    // (object) or an unquoted `a,b` (array) straight into the expression, polluting/breaking the
+    // parse (A2b hardening; `evaluateField` is shared by record recalc + dry-run).
+    let hasUnusableValue = false
     const resolved = expression.replace(FIELD_REF_PATTERN, (_match, fieldId: string) => {
       const value = recordData[fieldId]
       if (value === null || value === undefined) return '0'
       if (typeof value === 'string') return JSON.stringify(value)
       if (typeof value === 'number') return String(value)
       if (typeof value === 'boolean') return value ? 'TRUE' : 'FALSE'
-      return String(value)
+      // multi-value lookup / multiSelect of SCALARS → quoted joined string literal. An array that
+      // holds an object/array (e.g. a multi-value lookup of an object/location-valued field — a real
+      // lookup shape) is NOT coercible → #VALUE!, never a fake "[object Object]" join.
+      if (Array.isArray(value)) {
+        const allScalar = value.every(
+          (v) => v == null || typeof v === 'string' || typeof v === 'number' || typeof v === 'boolean',
+        )
+        if (allScalar) return JSON.stringify(value.join(','))
+        hasUnusableValue = true
+        return '0'
+      }
+      // any other complex value (e.g. a person/location object) is not a valid formula operand →
+      // propagate as an error rather than injecting it (placeholder keeps the replace well-formed)
+      hasUnusableValue = true
+      return '0'
     })
+    // An object-valued reference makes the whole field error (Excel-style propagation) instead of
+    // computing against a placeholder.
+    if (hasUnusableValue) return '#VALUE!'
 
     const context: FormulaContext = {
       sheetId: '',

--- a/packages/core-backend/tests/unit/formula-value-substitution.test.ts
+++ b/packages/core-backend/tests/unit/formula-value-substitution.test.ts
@@ -1,0 +1,72 @@
+/**
+ * A2b — value-substitution hardening for MultitableFormulaEngine.evaluateField (shared by record
+ * recalc + dry-run). Regression-pins scalar substitution (unchanged), locks the new complex-value
+ * contract (array → quoted joined literal; object/other → #VALUE!), and proves no expression
+ * injection from malicious string/array values. Pure, no DB (only {fld} refs).
+ */
+import { describe, expect, it } from 'vitest'
+
+import { FormulaEngine } from '../../src/formula/engine'
+import { MultitableFormulaEngine } from '../../src/multitable/formula-engine'
+
+type EngineDb = NonNullable<ConstructorParameters<typeof FormulaEngine>[0]>['db']
+const FIELDS = [
+  { id: 'fld_a', type: 'number' },
+  { id: 'fld_s', type: 'string' },
+]
+const engine = new MultitableFormulaEngine(
+  new FormulaEngine({ db: { selectFrom() { throw new Error('no db') } } as unknown as EngineDb }),
+)
+const evalField = (expr: string, data: Record<string, unknown>) => engine.evaluateField(expr, data, FIELDS)
+
+describe('evaluateField — scalar substitution (regression: unchanged by A2b)', () => {
+  it('number computes', async () => {
+    expect(await evalField('={fld_a}+1', { fld_a: 5 })).toBe(6)
+  })
+  it('null/undefined → 0', async () => {
+    expect(await evalField('={fld_a}+1', { fld_a: null })).toBe(1)
+    expect(await evalField('={fld_a}+1', {})).toBe(1)
+  })
+  it('string passes through as a (quoted) literal', async () => {
+    expect(await evalField('={fld_s}', { fld_s: 'hi' })).toBe('hi')
+  })
+})
+
+describe('evaluateField — complex values (A2b contract)', () => {
+  it('SCALAR array → quoted joined string literal (value preserved)', async () => {
+    expect(await evalField('={fld_s}', { fld_s: ['a', 'b'] })).toBe('a,b')
+    expect(await evalField('={fld_s}', { fld_s: [1, 2] })).toBe('1,2')
+  })
+  it('object → #VALUE! (not "[object Object]")', async () => {
+    expect(await evalField('={fld_s}', { fld_s: { x: 1 } })).toBe('#VALUE!')
+  })
+  it('object anywhere in the expression errors the whole field', async () => {
+    expect(await evalField('={fld_a}+1', { fld_a: { x: 1 } })).toBe('#VALUE!')
+  })
+  // the real lookup shape: a multi-value lookup of an object/location-valued field → array of objects
+  it('array of OBJECTS → #VALUE! (NOT a fake "[object Object]" join)', async () => {
+    expect(await evalField('={fld_s}', { fld_s: [{ x: 1 }, { y: 2 }] })).toBe('#VALUE!')
+  })
+  it('mixed scalar+object array → #VALUE!', async () => {
+    expect(await evalField('={fld_s}', { fld_s: ['a', { x: 1 }] })).toBe('#VALUE!')
+  })
+})
+
+describe('evaluateField — no injection from value content (A2b core)', () => {
+  it('a string with quotes/operators is a single literal, not executed', async () => {
+    expect(await evalField('={fld_s}', { fld_s: 'a"; 1+1 ;"b' })).toBe('a"; 1+1 ;"b')
+  })
+  it('a string "1+1" stays the literal text, not evaluated to 2', async () => {
+    expect(await evalField('={fld_s}', { fld_s: '1+1' })).toBe('1+1')
+  })
+  it('a string containing a {fld} token is not re-expanded', async () => {
+    expect(await evalField('={fld_s}', { fld_s: '{fld_a}' })).toBe('{fld_a}')
+  })
+  it('an array element with a quote stays quoted-safe (no injection)', async () => {
+    expect(await evalField('={fld_s}', { fld_s: ['x"', 'y'] })).toBe('x",y')
+  })
+  it('a very long string does not break substitution', async () => {
+    const long = 'z'.repeat(5000)
+    expect(await evalField('={fld_s}', { fld_s: long })).toBe(long)
+  })
+})


### PR DESCRIPTION
## A2b — formula value-substitution hardening (defensive)

`MultitableFormulaEngine.evaluateField` raw-substituted complex `{fld}` values via `String(value)`, which **injects/pollutes the expression** — `[object Object]` for objects, an unquoted `a,b` for arrays. This hardens the substitution so complex values become **safe literals or an error**, never raw-injected.

### Change (`multitable/formula-engine.ts`)
- scalars (string `JSON.stringify` / number / boolean) — **unchanged**
- **scalar array** (multi-value lookup / multiSelect of scalars) → quoted joined string literal (value preserved, e.g. `["a","b"] → "a,b"`)
- **array containing an object/array** + **bare object** → `#VALUE!` (Excel-style error propagation — the whole field errors; no `[object Object]` join, no injection)
- does **not** touch the frozen, attendance-shared `formula/engine.ts` core

### Tests (13 unit — `tests/unit/formula-value-substitution.test.ts`)
scalar regression (compute unchanged) · array/object contract (incl. the real lookup-of-object-field shape → `#VALUE!`) · adversarial no-injection (`"` / `{fld_x}` token / `1+1` literal / quoted array element / 5k string). Existing formula + dry-run + write-path suites green (no regression); `tsc` clean.

### Nature — defensive hardening, NOT a live bug fix
No current path feeds `applyLookupRollup`'s in-memory object-arrays into `evaluateField`:
- `recalculateRecord` reloads the record from the DB (`formula-engine.ts:249` `SELECT id, data FROM meta_records …`) and evaluates against that raw data;
- lookups are **computed-on-read / not materialized** — `applyLookupRollup` writes the array only into the in-memory `row.data` (`univer-meta.ts:1795`), never to `meta_records.data`.

So the object-array doesn't reach `evaluateField` via recalc today. This change makes the substitution **safe if any complex value ever reaches it** and closes the silent `[object Object]` join.

### V-A2b verification
- **V-A2b-0** contract locked ✅ · **V-A2b-1** scalar zero-regression ✅ (unit) · **V-A2b-2** adversarial no-injection ✅ (unit) · **V-A2b-4** minimal / no semantic correction ✅
- **V-A2b-3** (was: real-DB `lookup→formula→#VALUE!`) → **NOT-APPLICABLE as a gate**: per the architecture above, hydrated lookup data doesn't flow into formula recalc, so the end-to-end `#VALUE!` assertion doesn't match reality.
- date note: at this layer a date is a JSONB ISO **string** → handled by the string branch (quoted); a bare `Date` object has no call site → `#VALUE!` (acceptable).

### Separate pre-existing gap (out of scope — backlog)
A formula **referencing a lookup field** recalcs against DB data where the lookup is absent → `evaluateField` substitutes `undefined → '0'` (`formula-engine.ts:109`) → it computes "against 0", not the lookup value. Characterization-only; fixing needs materialization or feeding the hydrated row into recalc — a separate decision.

### Docs
Tracker docs (open-items plan/todo/verification) intentionally **not** in this PR — they're mid-refresh in a separate worktree. The V-A2b reframe above is the source of truth and will be reconciled into the tracker in a follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
