### PR TITLE
docs(integration): DF-T1 — Template-alignment retry (customer Save template) (#1792)

### DIFF
--- a/docs/operations/integration-k3wise-df-t1-preview-evidence-runbook-20260527.md
+++ b/docs/operations/integration-k3wise-df-t1-preview-evidence-runbook-20260527.md
@@ -176,6 +176,41 @@ The `bodyTemplate` holds **real customer values** — it stays on the entity mac
 POST it to GitHub or paste/attach the config blob on #1792; evidence stays counts-and-presence
 only.
 
+## Template-alignment retry (customer Save template)
+
+If the persisted base is an incomplete `Material/GetDetail` clone, the preview fails completeness
+(e.g. `FUnitGroupID` comes back `{FName}`-only) and the pipeline composes a field the customer's
+K3 contract doesn't use (e.g. `FBaseUnitID`), so the dry-run cross-check won't match. Prefer the
+customer's own working `Material/Save` template as the authoritative base — this **refines the
+"GetDetail clone" framing above** for the customer case:
+
+1. **Base = the customer Save template, not a `GetDetail` clone.** Persist
+   `config.objects.material.bodyTemplate = { "Data": <customer Material/Save template object> }`
+   (operator-reviewed, real values, on-box, off-Git — same persist + `[redacted]` scan rule as
+   above). The customer's working template carries complete reference objects (e.g. `FUnitGroupID`
+   as `{FName, FNumber}`) that a `GetDetail` clone may lack.
+2. **Drop fields the customer contract doesn't use from the pipeline `fieldMappings`.** If the
+   customer's Material model has no `FBaseUnitID` (it uses `FUnitID` + the unit family), remove
+   the `FBaseUnitID` mapping. `projectRecordForBody` only projects schema fields the staging
+   record provides, so dropping the mapping stops the dry-run adding it — **no code change
+   needed**.
+3. **Preview replaces scalars only; references preserve the template.** Set `fieldRules` to
+   replace just the staging-sourced scalars (typically `FNumber`/`FName`/`FModel`/`FPlanPrice`)
+   as `from_staging`; keep **every** reference object as `preserve_template` (they come complete
+   from the customer template).
+4. **Re-run the no-write preview and require full parity:** the 7-field bar green,
+   `unresolvedReferenceComponents = 0`, **and** `preview.records[0].targetPayload.Data` field set
+   == `payload.Data` field set **including recursive (nested) shape**, not just top-level. A
+   top-level match with `recursive shape match: false` is **not** closed.
+5. **Post (sanitized):** the 7-field bar + `unresolvedReferenceComponents: 0` + `top-level field
+   match: yes` + `recursive shape match: yes` — names / counts / shape-presence only. If fields
+   still diverge, post the diverging field **names** only (no values) so the profile/schema/mapping
+   can be aligned (a separate change).
+
+This still **does not authorize a Save** — config-track parity proves the Save *body shape* (that
+we will Save exactly the customer's own template shape), not that K3 will accept it. The next
+Save-only attempt remains a separate, fresh approval.
+
 ## What to post on #1792 (sanitized only)
 
 Post the **acceptance result**, not the payload. A safe shape:

--- a/docs/operations/integration-k3wise-df-t1-preview-evidence-template.json
+++ b/docs/operations/integration-k3wise-df-t1-preview-evidence-template.json
@@ -8,10 +8,11 @@
     "integration-k3wise-df-t1-preview-evidence-runbook-20260527.md. This _instructions key is",
     "a sibling of sourceRecord/payloadTemplate and is ignored by the preview; sourceRecord and",
     "payloadTemplate below contain ONLY real fields (no annotation keys) so nothing pollutes",
-    "the composed payload. SCOPE (proven clone-Save path, NOT a general K3 authoring UI):",
-    "payloadTemplate MUST be a sanitized Material/GetDetail clone — the object-preservation path",
-    "already proven at the GATE — not a hand-built object. fieldRules v1 REPLACES ONLY the",
-    "identity fields FNumber/FName (from_staging); every reference object stays preserve_template",
+    "the composed payload. SCOPE (proven Save-template path, NOT a general K3 authoring UI):",
+    "payloadTemplate MUST be a sanitized real K3 Material object — the customer's working",
+    "Material/Save template is authoritative (a Material/GetDetail clone is a fallback and may be",
+    "incomplete, e.g. FUnitGroupID {FName}-only). fieldRules replace ONLY staging scalars",
+    "(typically FNumber/FName/FModel/FPlanPrice); every reference object stays preserve_template",
     "+ completeness (FNumber/FName or FID/FName). Do NOT author reference fields one-by-one. Fill",
     "materialCode/materialName from a staging row. The reference fields below are ILLUSTRATIVE:",
     "substitute the whole payloadTemplate with your sanitized clone (it usually carries more",
@@ -22,7 +23,9 @@
     "bodyTemplate (see runbook section 'Binding the preview to the pipeline'); the preview adds",
     "the Data wrapper itself. An ad-hoc clone is NOT acceptable; the pipeline dry-run cross-check",
     "must compare preview.records[0].targetPayload.Data (adapter-composed Save body) against the",
-    "previewed payload.Data, NOT preview.records[0].transformed — that is the authoritative gate."
+    "previewed payload.Data, NOT preview.records[0].transformed — that is the authoritative gate.",
+    "FBaseUnitID is intentionally omitted from the sample below — this customer's K3 contract uses",
+    "FUnitID + the unit family; see runbook section 'Template-alignment retry (customer Save template)'."
   ],
   "bodyKey": "Data",
   "sourceRecord": {
@@ -32,7 +35,6 @@
   "payloadTemplate": {
     "FUnitGroupID": { "FNumber": "<unit-group-number>", "FName": "<unit-group-name>" },
     "FUnitID": { "FNumber": "<unit-number>", "FName": "<unit-name>" },
-    "FBaseUnitID": { "FNumber": "<base-unit-number>", "FName": "<base-unit-name>" },
     "FErpClsID": { "FID": "<erp-cls-id>", "FName": "<erp-cls-name>" },
     "FUseState": { "FID": "<use-state-id>", "FName": "<use-state-name>" }
   },
@@ -41,7 +43,6 @@
     { "targetField": "FName", "sourceType": "from_staging", "sourceField": "materialName", "required": true, "shape": "scalar" },
     { "targetField": "FUnitGroupID", "sourceType": "preserve_template", "required": true, "completeness": "require-fnumber-fname" },
     { "targetField": "FUnitID", "sourceType": "preserve_template", "required": true, "completeness": "require-fnumber-fname" },
-    { "targetField": "FBaseUnitID", "sourceType": "preserve_template", "required": true, "completeness": "require-fnumber-fname" },
     { "targetField": "FErpClsID", "sourceType": "preserve_template", "required": true, "completeness": "require-fid-fname" },
     { "targetField": "FUseState", "sourceType": "preserve_template", "required": true, "completeness": "require-fid-fname" }
   ]


### PR DESCRIPTION
## Step 6 — operator-config-only config-track retry (no code)

Surfaced by #1792's corrected-retry evidence (05:45): the persisted `GetDetail` clone is incomplete
(`FUnitGroupID` `{FName}`-only) and the pipeline composes `FBaseUnitID` — a field the customer's K3
15.1 contract (their `doAddMaterial()` `Material/Save`) doesn't use — so the dry-run cross-check
mismatched (190 vs 189). This is **docs-only** and **operator-config-only** — no code, no Save.

### Runbook: new "Template-alignment retry (customer Save template)"
1. `bodyTemplate` = the customer's working `Material/Save` template (authoritative; complete
   references), not a `GetDetail` clone.
2. Drop `FBaseUnitID` from the pipeline `fieldMappings` — `projectRecordForBody` only projects
   schema fields the staging record provides, so dropping the mapping stops the dry-run adding it
   (no code).
3. Preview `fieldRules` replace scalars only (`FNumber`/`FName`/`FModel`/`FPlanPrice`); references
   `preserve_template`.
4. Require full parity **incl recursive shape** (`targetPayload.Data` field set == `payload.Data`).
5. Sanitized post shape.

### Template
- Drop the `FBaseUnitID` sample (payloadTemplate + fieldRule) — it contradicted the new guidance.
- Reframe `_instructions` base → "customer `Material/Save` template authoritative; a `GetDetail`
  clone is a fallback (may be incomplete)"; note `FBaseUnitID` intentionally omitted (customer uses
  `FUnitID` + unit family).

### Validation
Smoke re-verified against current `main`: placeholders → fail-closed (10 unresolved); filled →
eligible, `compositionSource=k3-save-body-composer`, composed `Data` carries **no** `FBaseUnitID`.

### Scope boundary
This is **Step 6** (operator-config retry to confirm parity, no code). **Step 7** — the preset/schema
alignment that makes the customer shape the *default* (remove `FBaseUnitID` from
`material-k3wise-customer-profile-v1` + a dry-run parity test) — is a **separate gated PR**, only
after this retry confirms parity. No Save / Submit / Audit / BOM authorized.

## Refs
- #1792 — customer GATE; config track
- #1956 / #1953 / #1951 — the runbook this extends
- #1945 / #1936 — DF-T1 preview + composer (unchanged)

Closes none. No code change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
