### PR TITLE
feat(integration): K3 M1 — align material-k3wise-customer-profile-v1 to the proven Save shape (drop FBaseUnitID) (#1792)

### DIFF
--- a/docs/development/integration-k3wise-m1-customer-profile-fbaseunitid-alignment-verification-20260528.md
+++ b/docs/development/integration-k3wise-m1-customer-profile-fbaseunitid-alignment-verification-20260528.md
@@ -1,0 +1,71 @@
+# K3 WISE M1 — customer-profile FBaseUnitID alignment (verification, 2026-05-28)
+
+Issue: **#1792** (customer GATE). Scope: **Step 7** — productionize the M1 Material Save-only
+shape that PASSed on the entity machine by aligning the `material-k3wise-customer-profile-v1`
+preset to the customer's actual K3 WISE 15.1 Material contract. **One preset edit + tests + this
+doc; no Save authorization; no Submit / Audit / BOM / multi-record.**
+
+## Evidence (what was proven before this change)
+
+On 2026-05-28 the operator ran, on the on-prem bridge machine, an evidence-first sequence that
+closed the config track and then passed a single Material Save-only:
+
+- **Config track PASS** — using the customer's working `Material/Save` template (from their
+  `ErpController#doAddMaterial()`) as `config.objects.material.bodyTemplate.Data`, with the
+  pipeline mapping reduced to `FNumber`/`FName`/`FModel` and **no `FBaseUnitID`**: the DF-T1
+  no-write preview was green (`valid` and `eligibleForSaveOnly` true; 0 placeholders / 0
+  unresolved references / 0 missing required; redaction self-check clean; `compositionSource =
+  k3-save-body-composer`) and the pipeline dry-run cross-check matched the preview on both the
+  top-level field set (28 == 28) and recursive shape (77 == 77).
+- **M1 one-record Material Save-only PASS** — Save HTTP 200 + envelope/business success true +
+  row status/message present + item id present + number echo present; one readonly readback
+  returned the saved record (189 fields). Boundaries held (one record, `Material/Save` only; no
+  Submit / Audit / BOM / multi-record / retry).
+
+The two earlier M1 Save attempts FAILED at the row level. Root cause, confirmed by the above: the
+base used an incomplete `Material/GetDetail` clone (`FUnitGroupID` returned `{FName}`-only) **and**
+the pipeline composed `FBaseUnitID`, a field the customer's K3 contract does not use.
+
+## Change
+
+`material-k3wise-customer-profile-v1` (`plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs`):
+**remove `FBaseUnitID` from the profile schema.** The customer contract uses `FUnitID` + the unit
+family (`FOrderUnitID` / `FSaleUnitID` / `FProductUnitID` / `FStoreUnitID`); `FBaseUnitID` is not
+part of it.
+
+Why schema-only: `FBaseUnitID` stays in the shared `MATERIAL_FIELD_MAPPINGS` table (which also
+serves BOM). Removing it from the **schema** is sufficient and load-bearing because the Save body
+is composed by `projectRecordForBody`, which only iterates **schema** fields — so a staging record
+(or mapping) carrying `FBaseUnitID` no longer reaches the Save body. Touching the shared mappings
+is out of scope (the "do not expand functionality" boundary); the new parity test proves the schema
+removal alone defends the Save body.
+
+This is **structure only** — no customer dictionary values are baked into the preset; operators
+still supply real values at runtime via the on-prem `bodyTemplate` (off Git).
+
+## Tests
+
+- `k3-wise-material-presets.test.cjs` — `testCustomerProfileOmitsFBaseUnitID`: the profile schema
+  has no `FBaseUnitID` and keeps `FUnitID` + the unit family. `testPerFieldShapeDeclared` updated
+  (its by-FNumber assertion list dropped `FBaseUnitID`, which it had asserted since #1912 — the
+  pre-PASS design assumption that the M1 evidence now supersedes).
+- `k3-save-body-composer.parity.test.cjs` — `testCustomerProfileDropsFBaseUnitID`: a staging record
+  that *carries* `FBaseUnitID` composes a Save body (and a no-write preview) that **omit** it, and
+  `preview.payload` equals the adapter Save body (no divergence). Identity / `FModel` scalars still
+  compose.
+
+### Negative control
+
+Re-adding `FBaseUnitID` to the profile schema makes both new tests fail:
+`testCustomerProfileDropsFBaseUnitID` (the record's `FBaseUnitID` is then projected into
+`body.Data`, so `'FBaseUnitID' in body.Data` is true) and `testCustomerProfileOmitsFBaseUnitID`
+(the schema then contains it). Reverting restores green. Run locally on 2026-05-28.
+
+Full integration-core test set re-run after the change — presets / parity / adapters / DF-T1
+preview / http-routes / external-systems — all pass.
+
+## Scope boundary
+
+Step 7 solidifies the PASSed one-record Material Save-only shape only. **Still locked / out of
+scope:** Submit, Audit, BOM, multi-record, production batch — each a separate gated step. This
+change does not authorize any Save; a Save-only attempt remains a separate, fresh #1792 approval.

--- a/plugins/plugin-integration-core/__tests__/k3-save-body-composer.parity.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-save-body-composer.parity.test.cjs
@@ -171,6 +171,22 @@ function testNoDivergentDuplicate() {
     'the composer is the sole home of applyReferenceShape / projectRecordForBody')
 }
 
+// Step 7 (#1792 M1 one-record Save PASSED 2026-05-28): the customer profile must NOT compose
+// FBaseUnitID into the Save body even if a staging record carries it — schema-driven projection
+// drops it (the field is omitted from the profile schema). Composing FBaseUnitID was the dry-run
+// cross-check mismatch behind the 2 failed M1 Saves; the proven shape uses FUnitID + the unit
+// family. Negative control: re-add FBaseUnitID to the profile schema → this test fails.
+async function testCustomerProfileDropsFBaseUnitID() {
+  const record = { FNumber: 'MAT-7', FName: 'Widget', FModel: 'M-1', FBaseUnitID: { FNumber: '10', FName: 'Each' } }
+  const { body } = await adapterSaveBody(record)
+  const preview = previewPayload(record)
+  assert.equal('FBaseUnitID' in body.Data, false, 'adapter Save body omits FBaseUnitID (not in customer profile schema)')
+  assert.equal('FBaseUnitID' in preview.payload.Data, false, 'preview payload omits FBaseUnitID')
+  assert.deepEqual(preview.payload, body, 'preview ≡ adapter Save (no FBaseUnitID divergence)')
+  assert.equal(body.Data.FNumber, 'MAT-7', 'scalar identity still composes')
+  assert.equal(body.Data.FModel, 'M-1', 'FModel scalar still composes')
+}
+
 async function main() {
   await testScalarShapeParity()
   await testObjectPassthroughParity()
@@ -180,7 +196,8 @@ async function main() {
   testGenericNestedProjectionPreserved()
   testIdentifierEmptyStringFallback()
   testNoDivergentDuplicate()
-  console.log('✓ k3-save-body-composer.parity: preview ≡ adapter Save (shape/passthrough/placeholder), nested-path preserved, identifier-fallback, no-write, opt-in, no divergent duplicate')
+  await testCustomerProfileDropsFBaseUnitID()
+  console.log('✓ k3-save-body-composer.parity: preview ≡ adapter Save (shape/passthrough/placeholder), nested-path preserved, identifier-fallback, no-write, opt-in, no divergent duplicate, customer-profile drops FBaseUnitID')
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/__tests__/k3-wise-material-presets.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-wise-material-presets.test.cjs
@@ -42,13 +42,27 @@ function testPresetIsDistinctAndOptIn() {
 function testPerFieldShapeDeclared() {
   const profile = getK3WiseMaterialProfile(MATERIAL_CUSTOMER_PROFILE_ID)
   const byName = new Map(profile.schema.map((field) => [field.name, field]))
-  const byNumber = ['FUnitGroupID', 'FUnitID', 'FBaseUnitID', 'FAcctID', 'FDefaultLoc']
+  const byNumber = ['FUnitGroupID', 'FUnitID', 'FAcctID', 'FDefaultLoc']
   const byId = ['FErpClsID', 'FUseState', 'FInspectionLevel', 'FProChkMde', 'FPlanTrategy']
   for (const name of byNumber) {
     assert.equal(byName.get(name).reference.identifier, 'FNumber', `${name} is by-FNumber`)
   }
   for (const name of byId) {
     assert.equal(byName.get(name).reference.identifier, 'FID', `${name} is by-FID (enum/category)`)
+  }
+}
+
+// Step 7 (#1792 M1 one-record Save PASSED 2026-05-28): the customer K3 contract (doAddMaterial)
+// uses FUnitID + the unit family but NOT FBaseUnitID. The profile omits it; default-projecting it
+// caused the dry-run cross-check mismatch behind the failed Save attempts. Composition behaviour
+// (a staging FBaseUnitID is dropped from the Save body) is covered in
+// k3-save-body-composer.parity.test.cjs.
+function testCustomerProfileOmitsFBaseUnitID() {
+  const profile = getK3WiseMaterialProfile(MATERIAL_CUSTOMER_PROFILE_ID)
+  const fields = new Set(profile.schema.map((field) => field.name))
+  assert.equal(fields.has('FBaseUnitID'), false, 'customer profile omits FBaseUnitID (M1 PASS shape)')
+  for (const name of ['FUnitID', 'FUnitGroupID', 'FOrderUnitID', 'FSaleUnitID', 'FProductUnitID', 'FStoreUnitID']) {
+    assert.ok(fields.has(name), `customer profile keeps the validated unit field ${name}`)
   }
 }
 
@@ -88,10 +102,11 @@ function testUnknownProfileResolvesNull() {
 function main() {
   testPresetIsDistinctAndOptIn()
   testPerFieldShapeDeclared()
+  testCustomerProfileOmitsFBaseUnitID()
   testOperationsStayUpsertOnly()
   testNoHardcodedCustomerValues()
   testUnknownProfileResolvesNull()
-  console.log('✓ k3-wise-material-presets: preset opt-in, per-field shape, operations, no-hardcoded-values, unknown-profile passed')
+  console.log('✓ k3-wise-material-presets: preset opt-in, per-field shape, FBaseUnitID-omitted, operations, no-hardcoded-values, unknown-profile passed')
 }
 
 main()

--- a/plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/k3-wise-document-templates.cjs
@@ -198,7 +198,10 @@ const MATERIAL_CUSTOMER_PROFILE = {
     // Unit family + accounts + warehouse + manager — numbered base data ({FNumber,FName})
     { name: 'FUnitGroupID', label: 'Unit group', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
     { name: 'FUnitID', label: 'Unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
-    { name: 'FBaseUnitID', label: 'Base unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
+    // FBaseUnitID intentionally omitted: the customer K3 15.1 Material contract (doAddMaterial)
+    // uses FUnitID + the unit family, not FBaseUnitID. Default-projecting it caused the M1 dry-run
+    // cross-check mismatch and contributed to the failed Save attempts; M1 one-record Save PASSED
+    // 2026-05-28 with it removed. See integration-k3wise-m1-customer-profile-fbaseunitid-alignment-*.
     { name: 'FOrderUnitID', label: 'Order unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
     { name: 'FSaleUnitID', label: 'Sales unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },
     { name: 'FProductUnitID', label: 'Production unit', type: 'reference', reference: K3_REFERENCE_BY_NUMBER },


### PR DESCRIPTION
## Step 7 — align `material-k3wise-customer-profile-v1` to the proven M1 Save shape

Productionizes the M1 one-record Material Save-only shape that **PASSed** on the entity machine
2026-05-28 (#1792). The customer K3 15.1 contract (their `doAddMaterial()` `Material/Save`) uses
`FUnitID` + the unit family but **not** `FBaseUnitID`; default-projecting `FBaseUnitID` caused the
dry-run cross-check mismatch and contributed to the two earlier failed Save attempts.

### Change (integration-core, M1 carve-out)
- `material-k3wise-customer-profile-v1` (`k3-wise-document-templates.cjs`): **remove `FBaseUnitID`
  from the profile schema.** Schema-only is sufficient and load-bearing — composition
  (`projectRecordForBody`) is schema-driven, so a staging record/mapping carrying `FBaseUnitID` no
  longer reaches the Save body. `FBaseUnitID` stays in the shared `MATERIAL_FIELD_MAPPINGS` (also
  serves BOM); touching shared mappings is out of scope. The **generic** `k3wise.material.v1`
  template is untouched.
- **Structure only** — no customer values baked in; operators supply real values at runtime via the
  on-prem `bodyTemplate`.

### Tests (negative-controlled)
- `k3-save-body-composer.parity.test.cjs` → `testCustomerProfileDropsFBaseUnitID`: a record
  **carrying** `FBaseUnitID` composes a Save body + no-write preview that both **omit** it, and
  `preview.payload` equals the adapter Save body.
- `k3-wise-material-presets.test.cjs` → `testCustomerProfileOmitsFBaseUnitID` (schema omits
  `FBaseUnitID`, keeps the unit family); `testPerFieldShapeDeclared`'s by-FNumber list dropped
  `FBaseUnitID` (asserted since #1912 — the pre-PASS assumption the M1 evidence supersedes).
- **Negative control run locally:** re-adding `FBaseUnitID` to the schema fails both new tests;
  reverting restores green. Full integration-core suite (presets / parity / adapters / DF-T1 preview
  / http-routes / external-systems) passes.

### Evidence
#1792: config-track PASS (DF-T1 preview green + dry-run cross-check 28==28 top-level, 77==77
recursive) → M1 one-record Save-only PASS (Save HTTP 200 + business success + item id + number echo;
readback 189 fields). Summarized in the verification doc.

### Scope boundary
Step 7 solidifies the PASSed one-record Material Save-only shape only. **No Save authorization.**
Submit / Audit / BOM / multi-record / production stay locked (separate gates). `lifecycle:'save-only'`
+ autoSubmit/autoAudit hard-lock unchanged.

## Refs
- #1792 — customer GATE (M1 PASS evidence)
- #1912 — M1 Save-only backend (created the profile); #1936 / #1945 — composer + DF-T1 preview
- #1959 — the operator Step 6 runbook this productionizes

Closes none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
