### PR TITLE
feat(data-sources): A-RO read-only guard on raw query path (Lane A)

### DIFF
--- a/packages/core-backend/src/data-adapters/BaseAdapter.ts
+++ b/packages/core-backend/src/data-adapters/BaseAdapter.ts
@@ -335,4 +335,33 @@ export abstract class BaseDataAdapter extends EventEmitter {
   getType(): string {
     return this.config.type
   }
+
+  /**
+   * Whether this adapter speaks SQL (so a read-only SELECT classifier applies
+   * to its raw query path). Non-SQL adapters (HTTP/Mongo/Redis/ES) return false;
+   * the read-only route then disables the raw query path entirely instead of
+   * trying to classify a non-SQL payload.
+   */
+  isSqlDialect(): boolean {
+    return false
+  }
+
+  /**
+   * Read-only flag for this source. Defaults to TRUE — a source is writable
+   * only when options.readOnly is explicitly false.
+   */
+  isReadOnly(): boolean {
+    return this.config.options?.readOnly !== false
+  }
+
+  /**
+   * Defense-in-depth guard for mutating operations. Throws on a read-only
+   * source. NOTE: the real read-only guarantee must come from connecting with
+   * a read-only database account; this is only an application-layer gate.
+   */
+  assertWritable(): void {
+    if (this.isReadOnly()) {
+      throw new Error('Data source is read-only; write operations are not permitted')
+    }
+  }
 }

--- a/packages/core-backend/src/data-adapters/DataSourceManager.ts
+++ b/packages/core-backend/src/data-adapters/DataSourceManager.ts
@@ -476,6 +476,7 @@ export class DataSourceManager extends EventEmitter {
     data: Record<string, DbValue> | Record<string, DbValue>[]
   ): Promise<QueryResult<T>> {
     const adapter = this.getDataSource(dataSourceId)
+    adapter.assertWritable() // defense-in-depth: reject mutations on a read-only source
 
     if (!adapter.isConnected()) {
       await this.connectDataSource(dataSourceId)
@@ -491,6 +492,7 @@ export class DataSourceManager extends EventEmitter {
     where: Record<string, WhereValue>
   ): Promise<QueryResult<T>> {
     const adapter = this.getDataSource(dataSourceId)
+    adapter.assertWritable() // defense-in-depth: reject mutations on a read-only source
 
     if (!adapter.isConnected()) {
       await this.connectDataSource(dataSourceId)
@@ -505,6 +507,7 @@ export class DataSourceManager extends EventEmitter {
     where: Record<string, WhereValue>
   ): Promise<QueryResult<T>> {
     const adapter = this.getDataSource(dataSourceId)
+    adapter.assertWritable() // defense-in-depth: reject mutations on a read-only source
 
     if (!adapter.isConnected()) {
       await this.connectDataSource(dataSourceId)

--- a/packages/core-backend/src/data-adapters/MySQLAdapter.ts
+++ b/packages/core-backend/src/data-adapters/MySQLAdapter.ts
@@ -59,6 +59,10 @@ import {
 export class MySQLAdapter extends BaseDataAdapter {
   protected override pool: MySQLPool | null = null
 
+  override isSqlDialect(): boolean {
+    return true
+  }
+
   /**
    * Convert DbValue to string, ensuring it's a valid database name
    */

--- a/packages/core-backend/src/data-adapters/PostgresAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PostgresAdapter.ts
@@ -61,6 +61,10 @@ function mapFKAction(rule: string): FKActionType {
 export class PostgresAdapter extends BaseDataAdapter {
   protected override pool: PgPool | null = null
 
+  override isSqlDialect(): boolean {
+    return true
+  }
+
   async connect(): Promise<void> {
     if (this.connected) {
       return

--- a/packages/core-backend/src/routes/data-sources.ts
+++ b/packages/core-backend/src/routes/data-sources.ts
@@ -32,7 +32,9 @@ const DataSourceCreateSchema = z.object({
   options: z.object({
     autoConnect: z.boolean().optional(),
     timeout: z.number().optional(),
-    retryAttempts: z.number().optional()
+    retryAttempts: z.number().optional(),
+    // Read-only is the default; set false to permit write SQL via /query.
+    readOnly: z.boolean().optional()
   }).optional(),
   credentials: z.object({
     username: z.string().optional(),
@@ -54,7 +56,9 @@ const DataSourceUpdateSchema = z.object({
   options: z.object({
     autoConnect: z.boolean().optional(),
     timeout: z.number().optional(),
-    retryAttempts: z.number().optional()
+    retryAttempts: z.number().optional(),
+    // Read-only is the default; set false to permit write SQL via /query.
+    readOnly: z.boolean().optional()
   }).optional(),
   poolConfig: z.object({
     min: z.number().min(0).optional(),
@@ -117,6 +121,23 @@ function resolveUserId(req: Request): string | undefined {
   if (!u) return undefined
   const raw = u.id ?? u.userId ?? u.sub
   return raw != null ? String(raw) : undefined
+}
+
+/**
+ * Conservative read-only SQL classifier for the raw /query path on read-only
+ * SQL sources. Allows a single statement starting with SELECT / WITH / EXPLAIN
+ * / SHOW; rejects multiple statements and SELECT ... INTO.
+ *
+ * Best-effort application-layer gate, NOT a sandbox: it does NOT catch
+ * data-modifying CTEs (e.g. WITH t AS (DELETE ... RETURNING) SELECT ...) and
+ * over-rejects a query led by a comment. The real read-only guarantee must
+ * come from connecting the data source with a read-only database account.
+ */
+export function isReadOnlySql(raw: string): boolean {
+  const sql = raw.trim().replace(/;\s*$/, '') // drop a single trailing semicolon
+  if (sql.includes(';')) return false // no multiple statements
+  if (/\binto\b/i.test(sql)) return false // reject SELECT ... INTO
+  return /^\s*(select|with|explain|show)\b/i.test(sql)
 }
 
 // Helper to sanitize config for response (remove credentials)
@@ -290,6 +311,10 @@ export function dataSourcesRouter(): Router {
       const newConfig: DataSourceConfig = {
         ...oldConfig,
         ...parse.data,
+        // Deep-merge nested config: a partial update (e.g. only options.timeout)
+        // must not wipe sibling keys like readOnly / autoConnect / poolConfig.
+        options: { ...oldConfig.options, ...parse.data.options },
+        poolConfig: { ...oldConfig.poolConfig, ...parse.data.poolConfig },
         id // Preserve original ID
       }
 
@@ -549,6 +574,25 @@ export function dataSourcesRouter(): Router {
       const manager = getManager()
       manager.assertAccess(req.params.id, resolveUserId(req))
       const { sql, params } = parse.data
+
+      // A-RO: enforce read-only at the raw query path. SQL sources get a
+      // SELECT-only classifier; non-SQL sources have the raw path disabled
+      // entirely when read-only (a SQL classifier doesn't apply to them).
+      const adapter = manager.getDataSource(req.params.id)
+      if (adapter.isReadOnly()) {
+        if (!adapter.isSqlDialect()) {
+          return res.status(403).json({
+            ok: false,
+            error: { code: 'READ_ONLY', message: 'Data source is read-only; the raw query endpoint is disabled for non-SQL sources' }
+          })
+        }
+        if (!isReadOnlySql(sql)) {
+          return res.status(403).json({
+            ok: false,
+            error: { code: 'READ_ONLY', message: 'Data source is read-only; only read-only SQL (SELECT/WITH/EXPLAIN/SHOW) is permitted' }
+          })
+        }
+      }
 
       const result = await manager.query(req.params.id, sql, params as (string | number | boolean | null | Date | Buffer)[])
 

--- a/packages/core-backend/tests/unit/data-source-readonly.test.ts
+++ b/packages/core-backend/tests/unit/data-source-readonly.test.ts
@@ -1,0 +1,135 @@
+import express from 'express'
+import request from 'supertest'
+import { describe, expect, it, vi } from 'vitest'
+
+vi.mock('../../src/audit/audit', () => ({ auditLog: vi.fn(async () => {}) }))
+
+import { DataSourceManager } from '../../src/data-adapters/DataSourceManager'
+import { dataSourcesRouter, isReadOnlySql } from '../../src/routes/data-sources'
+import type { DataSourceConfig } from '../../src/data-adapters/BaseAdapter'
+
+function sqlConfig(id: string, readOnly?: boolean): DataSourceConfig {
+  return {
+    id,
+    name: id,
+    type: 'postgres',
+    connection: { host: 'localhost', port: 5432, database: 'x' },
+    options: { autoConnect: false, ...(readOnly === undefined ? {} : { readOnly }) },
+  }
+}
+
+function httpConfig(id: string, readOnly?: boolean): DataSourceConfig {
+  return {
+    id,
+    name: id,
+    type: 'http',
+    connection: { baseURL: 'http://example.test' },
+    options: { autoConnect: false, ...(readOnly === undefined ? {} : { readOnly }) },
+  }
+}
+
+describe('isReadOnlySql classifier (A-RO)', () => {
+  it('allows read-only leading verbs (case-insensitive, trailing semicolon ok)', () => {
+    expect(isReadOnlySql('SELECT * FROM t')).toBe(true)
+    expect(isReadOnlySql('  select 1;')).toBe(true)
+    expect(isReadOnlySql('WITH x AS (SELECT 1) SELECT * FROM x')).toBe(true)
+    expect(isReadOnlySql('EXPLAIN SELECT 1')).toBe(true)
+    expect(isReadOnlySql('show tables')).toBe(true)
+  })
+
+  it('rejects writes, multiple statements and SELECT ... INTO', () => {
+    expect(isReadOnlySql('DELETE FROM t')).toBe(false)
+    expect(isReadOnlySql('UPDATE t SET a=1')).toBe(false)
+    expect(isReadOnlySql('INSERT INTO t VALUES (1)')).toBe(false)
+    expect(isReadOnlySql('DROP TABLE t')).toBe(false)
+    expect(isReadOnlySql('TRUNCATE t')).toBe(false)
+    expect(isReadOnlySql('SELECT 1; DROP TABLE t')).toBe(false) // multiple statements
+    expect(isReadOnlySql('SELECT * INTO backup FROM t')).toBe(false) // SELECT ... INTO
+  })
+})
+
+describe('BaseDataAdapter read-only flags (A-RO)', () => {
+  it('defaults to read-only; writable only when options.readOnly === false', async () => {
+    const m = new DataSourceManager()
+    const ro = await m.addDataSource(sqlConfig('ro'), { ownerId: 'a' })
+    expect(ro.isReadOnly()).toBe(true)
+    expect(() => ro.assertWritable()).toThrow(/read-only/)
+
+    const rw = await m.addDataSource(sqlConfig('rw', false), { ownerId: 'a' })
+    expect(rw.isReadOnly()).toBe(false)
+    expect(() => rw.assertWritable()).not.toThrow()
+  })
+
+  it('classifies SQL vs non-SQL adapters', async () => {
+    const m = new DataSourceManager()
+    const pg = await m.addDataSource(sqlConfig('pg'), { ownerId: 'a' })
+    const http = await m.addDataSource(httpConfig('http'), { ownerId: 'a' })
+    expect(pg.isSqlDialect()).toBe(true)
+    expect(http.isSqlDialect()).toBe(false)
+  })
+})
+
+describe('DataSourceManager mutation guard (A-RO)', () => {
+  it('rejects insert/update/delete on a read-only source', async () => {
+    const m = new DataSourceManager()
+    await m.addDataSource(sqlConfig('ro'), { ownerId: 'a' })
+    await expect(m.insert('ro', 't', { a: 1 })).rejects.toThrow(/read-only/)
+    await expect(m.update('ro', 't', { a: 1 }, { id: 1 })).rejects.toThrow(/read-only/)
+    await expect(m.delete('ro', 't', { id: 1 })).rejects.toThrow(/read-only/)
+  })
+})
+
+describe('data-sources /query read-only gate (A-RO)', () => {
+  let currentUser: { id: string; role?: string } | undefined
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    req.user = currentUser as never
+    next()
+  })
+  app.use(dataSourcesRouter())
+  const admin = (id: string) => ({ id, role: 'admin' })
+
+  it('rejects write SQL on a read-only SQL source with 403 READ_ONLY', async () => {
+    currentUser = admin('alice')
+    await request(app).post('/api/data-sources').send(sqlConfig('ro-sql'))
+    const res = await request(app).post('/api/data-sources/ro-sql/query').send({ sql: 'DELETE FROM t' })
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('READ_ONLY')
+  })
+
+  it('disables the raw query path entirely for a read-only non-SQL source', async () => {
+    currentUser = admin('alice')
+    await request(app).post('/api/data-sources').send(httpConfig('ro-http'))
+    const res = await request(app).post('/api/data-sources/ro-http/query').send({ sql: 'GET /whatever' })
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('READ_ONLY')
+  })
+})
+
+describe('data-sources PUT deep-merge (A-RO)', () => {
+  let currentUser: { id: string; role?: string } | undefined
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    req.user = currentUser as never
+    next()
+  })
+  app.use(dataSourcesRouter())
+  const admin = (id: string) => ({ id, role: 'admin' })
+
+  it('a partial options update preserves sibling option keys', async () => {
+    currentUser = admin('alice')
+    await request(app)
+      .post('/api/data-sources')
+      .send({ ...sqlConfig('pm'), options: { autoConnect: true, readOnly: false } })
+
+    const put = await request(app).put('/api/data-sources/pm').send({ options: { timeout: 5 } })
+    expect(put.status).toBe(200)
+
+    const got = await request(app).get('/api/data-sources/pm')
+    expect(got.status).toBe(200)
+    // shallow merge would have wiped readOnly/autoConnect; deep merge keeps them
+    expect(got.body.data.options).toMatchObject({ autoConnect: true, readOnly: false, timeout: 5 })
+  })
+})


### PR DESCRIPTION
## Summary
- Per-source `options.readOnly`, default **TRUE** (writable only when explicitly `false`).
- Raw `POST /:id/query` gate: SQL sources get a SELECT-only classifier (allow `SELECT`/`WITH`/`EXPLAIN`/`SHOW`; reject multi-statement + `SELECT…INTO`); non-SQL sources (HTTP/Mongo/Redis/ES) have the raw path disabled entirely when read-only.
- Defense-in-depth: `BaseDataAdapter.assertWritable()` invoked in `DataSourceManager.insert/update/delete`.
- `PUT` now deep-merges `options`/`poolConfig` — the prior shallow merge wiped sibling keys like `readOnly`/`autoConnect` (prerequisite for storing `readOnly` in `options`).

## Not a sandbox
The classifier is a best-effort application-layer gate (it does NOT catch data-modifying CTEs and over-rejects comment-led queries). The real read-only guarantee must come from connecting the source with a **read-only database account**.

## Follow-ups (not in this PR)
- `assertWritable` placement: invoked at the manager mutation-routing layer; a per-adapter-method guard (which would also catch `copyData()`'s direct `adapter.insert()`) is deferred — `copyData` has no callers today, so the bypass is dormant.
- Future write routes (`POST /:id/insert` etc.) must route through `manager.insert` or call `assertWritable()`, or they bypass read-only.

## Test plan
- [x] 22 unit tests — classifier, adapter read-only/SQL flags, manager mutation guard, route 403 (write-SQL on SQL source + any query on non-SQL source), PUT deep-merge preservation (incl. A0.1 regression)
- [x] `tsc --noEmit` 0 errors, ESLint clean on changed source

🤖 Generated with [Claude Code](https://claude.com/claude-code)