### PR TITLE
docs(multitable): reconcile open-items tracker (Slice 1 #1950 + A2b #1958 shipped)

### DIFF
--- a/docs/development/multitable-open-items-development-plan-20260527.md
+++ b/docs/development/multitable-open-items-development-plan-20260527.md
@@ -1,26 +1,30 @@
 # 多维表 — 剩余 open 项开发方案（clean, origin/main-grounded）
 
 > Date: 2026-05-27 · Author: Claude · Status: **PLAN — 非开工**
-> **Grounded in `origin/main` @ `8fd73257d`**（不是落后的本地 checkout —— 教训：做 benchmark/方案前先 `git fetch` + `git rev-list --count HEAD..origin/main` 对照基线，落后则以 `git show origin/main:<file>` 为准）。
+> **Drafting base `origin/main@8fd73257d`，reconciled through #1958（2026-05-28）** —— 下方状态已对齐当前现实（Slice 1 #1950 + A2b #1958 已 shipped）；`8fd73257d` 仅是初稿基线、非当前 HEAD。（纪律：方案/benchmark 前先 `git fetch` 对照 `origin/main`。）
 > K3 PoC Stage-1 锁：以下均为多维表内核打磨，允许；**每项仍是独立 opt-in**，不碰 integration-core/RBAC/auth。
 
 ## 0. 范围：只列 `origin/main` 上**确认仍未做**的项
 
-**已 shipped（不在本方案内，仅备查）**：agg-footer 后端#1841 + 分组小计#1852 + 前端 `<tfoot>`；formula recalc-on-patch#1883 + A1.1#1890 + A2-defense#1896 + F1#1897；formula dry-run #1865/#1873；frozen-col#1837；inline-create#1834；D2 perf#1815；D3 权限矩阵#1820/#1827/#1831。
+> **状态 reconcile（2026-05-28，docs-only）**：Slice 1 已 shipped（#1950）+ A2b 已 merged（#1958），本文随之收口；唯一 still-open = **Slice 2（C0-gated）**。下方各节标 ✅ 并保留为 as-built 记录。
 
-**本方案 = 3 项 still-open**：
+**已 shipped（不在本方案内，仅备查）**：agg-footer 后端#1841 + 分组小计#1852 + 前端 `<tfoot>`；formula recalc-on-patch#1883 + A1.1#1890 + A2-defense#1896 + F1#1897；formula dry-run #1865/#1873；frozen-col#1837；inline-create#1834；D2 perf#1815；D3 权限矩阵#1820/#1827/#1831；**charts → ECharts Slice 1 #1950（merge `b665b2b1c`）**；**A2b formula hardening #1958（squash `d9b5b031a`，defensive）**。
 
-| Slice | 项 | 深度 | K3 |
+**本方案 = 1 项 still-open（Slice 2，C0-gated）**：
+
+| Slice | 项 | 状态 | K3 |
 |---|---|---|---|
-| **1** | charts → **ECharts**（渲染层替换） | **PR 级**（最现实的下一刀） | 允许 |
-| **2** | grid 分组头 count + 滚动 UX | 2a **非 quick-win**（前端触发 gated on aggregations）→ 建议折叠进 2b；2b/2c 架构级需 C0 决策 | 允许 |
-| **3** | **A2b** 宏展开转义加固 | 小项（借鉴计划） | 允许 |
+| ~~1~~ | charts → ECharts | ✅ **SHIPPED** #1950 | — |
+| **2** | grid 分组头 count + 滚动 UX | ⬜ still-open，**C0 gated**（2a 非 quick-win→折叠进 2b；2b/2c 架构级） | 允许 |
+| ~~3~~ | A2b 宏展开转义加固 | ✅ **MERGED** #1958（defensive） | — |
 
 ---
 
-## Slice 1 — charts → ECharts（PR 级，建议下一刀）
+## Slice 1 — charts → ECharts ✅ **SHIPPED (#1950, merge `b665b2b1c`)** — 下方为 as-built 设计记录
 
-### 现状（origin/main 实读）
+> 实际落地：bar/line/pie→ECharts canvas；title + pie legend 留 HTML chrome；number/table HTML；tooltip 为唯一 additive。33 specs + `vue-tsc -b` + build/tree-shaking 绿；**V-S1-7 视觉冒烟 NOT-RUN（无 stack，须有 stack 时人工核对）**。S1-9 async-import / S1-10 新图表类型仍为独立 follow-up。
+
+### 现状（origin/main 实读，as-built 前）
 - `ChartType` = `bar | line | pie | number | table`（`types.ts:863`，5 类）。
 - `MetaChartRenderer.vue`（293 行）手搓：bar 用 `<rect>`（含 `orientation==='horizontal'` 横向分支）、line 用 `<polyline>`+`<circle>`、pie 用手算 `<path>` 弧段 + HTML 图例、number/table 用 HTML。8 色 `COLORS` 调色板 + `defaultColor(idx)`。
 - props = `chartData: ChartData` + `displayConfig?: ChartDisplayConfig`；`ChartData.dataPoints: {label,value,color?}[]` + `total` + `chartType`；`ChartDisplayConfig` = `title/showLegend/showValues/prefix/suffix/orientation` + **`colorScheme?: string`**（后者 **dormant**：`types.ts:878`/`charts.ts:42` 仅类型声明、无渲染器/服务消费者 → 本 slice **显式不接、沿用现有 8 色 `COLORS`**，不静默收窄类型；wire `colorScheme`→ECharts palette 留 follow-up）。
@@ -71,24 +75,27 @@
 
 ---
 
-## Slice 3 — A2b 宏展开转义加固 ⬜（借鉴计划项）→ **contract-first（owner review 勘误）**
+## Slice 3 — A2b 宏展开转义加固 ✅ **MERGED (#1958, squash `d9b5b031a`, 2026-05-28)** — defensive hardening
 
-### 现状（origin/main 实读）
-- `formula-engine.ts:108-111`：null/undefined→`'0'`、string→`JSON.stringify`（**已转义、非裸拼接**）、number→`String`、boolean→`TRUE/FALSE`、**其余→`return String(value)`（:111）兜底**。
-- **关键事实（勘误）**：lookup/rollup **被允许作为公式输入**（前端 `MetaFieldManager.vue:669` 只排除 `formula`、不排除 lookup/rollup；后端 `univer-meta.ts:1015` 注释明示"lookup/rollup ARE permitted as formula references"）。所以 `:111` 兜底分支**真实承载** lookup 的复杂值（多值 lookup = array、date、object）。
-- **因此把 array/object/date 一刀切成 `#N/A` 不是 hardening，是行为变更** —— 会破坏现有"lookup 值进公式"的用户公式。
+### 落地 contract（owner 拍板：object → `#VALUE!`）
+`formula-engine.ts evaluateField` 的 `String(value)` 兜底分支收口（仅此一处，不碰 frozen `formula/engine.ts`）：
 
-### 建议（我的推荐）：**先锁 contract，做 compatibility-preserving 收口，不做行为纠偏**
-- ⬜ **3.1 [先锁 contract，再写实现]** 定一张 per-type 表，**显式声明每类的产出 + 是否兼容现行为**，例如：
-  | 输入值类型 | 现状（`String(value)`） | A2b 收口（建议） | 是否行为变更 |
-  |---|---|---|---|
-  | string/number/boolean | 已安全 | 不动 | 否 |
-  | date | `String(date)` = locale 串、**未加引号→注入** | 产出 ISO 字符串 **literal（加引号）** | 值近似、修注入 |
-  | array（多值 lookup） | `"a,b"` **未引号→注入/语法污染** | **加引号**成字符串 literal（保留"拼成串"语义） | 仅修安全、值不变 |
-  | object | `[object Object]` 未引号 | 加引号 literal 或 `#VALUE!`（**需决策**） | 需 owner 拍板 |
-- ⬜ **3.2** 回归测试 **pin 现行标量行为**（string/number/boolean/rollup-number 产出不变）+ 对抗性单测（值含 `"`、`{fld_x}`、`1+1`、array、object、date、超长串）断言**无注入**。
-- ⬜ **3.3 [保持最小]** 任何**语义纠偏**（如"lookup array 应可被 SUM"）= **单独决策**，不并进本 hardening PR。且 Track B（Teable `packages/formula` 真解析器）若上马会整体取代宏展开转义 → **A2b 不过度投入**。
-- 权威跟踪 `multitable-derived-field-borrow-plan-20260526.md`；**A2-full（链式 topo）仍 gated/future**。
+| 输入值类型 | A2b 落地 | 行为变更 |
+|---|---|---|
+| string（含 JSONB ISO 日期）/ number / boolean | 不动（string 已 `JSON.stringify` 引号、安全） | 否 |
+| **scalar array**（多值 lookup of scalars） | 引号 joined literal（`["a","b"]→"a,b"`，值保留、修注入） | 仅修安全 |
+| **array-with-object + 裸 object** | **`#VALUE!`**（Excel 式错误传播，无 `[object Object]` 假 join、无注入） | 破→诚实 |
+
+> date 在此层是 JSONB ISO **字符串** → 走 string 分支（quoted）；裸 `Date` 对象无调用面 → `#VALUE!`（可接受）。
+
+### 性质 = DEFENSIVE，不是 live bug fix（owner-confirmed）
+**当前没有路径把 `applyLookupRollup` 的内存 object-array 喂进 `evaluateField`**：`recalculateRecord` 走 DB reload（`formula-engine.ts:249`）；lookup 是 computed-on-read / 不 materialize（`applyLookupRollup` 只写内存 `row.data`，`univer-meta.ts:1795`）。故 A2b 是"若复杂值真进 eval 则安全"的加固。13 unit 测试（标量回归 + array/object contract + 对抗性无注入）绿；既有 formula/dry-run/write-path 套件无回归。
+
+### V-A2b-3 → **NOT-APPLICABLE as a gate**
+原"real-DB lookup→formula→`#VALUE!`"end-to-end 断言与真实架构不符（该组合当前不发生，见上）→ 改为 architecture note，不作硬门。
+
+### 🆕 Backlog（独立、既有架构 gap，out-of-scope，不在本 PR）
+formula 引用 lookup 字段时，recalc 按 DB raw data 重算、lookup 值缺席 → `evaluateField` 把 `undefined→'0'`（`formula-engine.ts:109`）→ 实际"按 0 算"，不是用 lookup 值。**characterization/design-note only**（本 reconcile 不写该 note 本身）；需 materialize 或在 recalc 前喂 hydrated row 才能改 —— 单独决策。Track B（Teable `packages/formula` 真解析器）若上马会整体取代 A2b 宏展开转义。权威跟踪 `multitable-derived-field-borrow-plan-20260526.md`；**A2-full（链式 topo）仍 gated/future**。
 
 ---
 
@@ -96,9 +103,9 @@
 
 - **license**：ECharts(Apache)/TanStack Virtual(MIT)/Teable `packages/formula`(MIT) 可作依赖；引入仍是**独立 opt-in**。Chart.js(MIT) 为 ECharts 轻量备选。
 - **grounding 纪律**（本轮教训）：任何 benchmark/方案先 `git fetch && git rev-list --count HEAD..origin/main`，落后则以 `git show origin/main:<file>` 为准 —— 落后 checkout 的 file:line 会误导。
-- **staged opt-in**：**Slice 1 与 3（A2b）可各自独立起步**；**2b/2c 受 C0 gate**（2a 已折叠进 2b、非独立起跑项）；不自动开下一刀。
-- **建议起点**：**Slice 1（ECharts）**，且**先静态 import（只 mock echarts）**，async-import 拆 follow-up —— 改造面收敛到 1 组件 + 1 消费者、后端零改动、视觉收益最直接、测试面最小。
+- **staged opt-in**：Slice 1（#1950）+ A2b（#1958）均已落；**唯一 still-open = Slice 2，受 C0 gate**（2a 已折叠进 2b、非独立起跑项）；不自动开下一刀。
+- **下一刀（无 C0 不开实现）**：仅剩 Slice 2 的 **C0 决策**（翻页器 vs 连续滚动）+ 上面的 formula-over-lookup backlog characterization/design note（非实现）。
 
 > **Owner review v2（2026-05-27）已折入**：① 2a 比初稿大（前端 `loadAggregates` gated on `view.config.aggregations`、不听 groupField）→ 降级、建议折叠进 2b；② A2b 是行为变更不是纯 hardening（lookup/rollup 允许作公式输入，复杂值走 `String(value)`）→ 改 contract-first；③ Slice 1 测试漏了 dashboard consumer spec → 已补，且建议静态 import 先行。主排序不变（Slice 1 仍最干净）。
 
-**一句话**：剩余真正 open 的就三件 —— **Slice 1 ECharts**（PR 级、下一刀、静态 import 先行）、**grid 分组/滚动**（2a 非 quick-win，折叠进 2b 服务端分组投递；2b/2c 需 C0 决策）、**A2b**（contract-first、兼容收口、Track B 或将取代）。其余 BI-polish + formula 主线均已 shipped。
+**一句话**：Slice 1 ECharts（#1950）+ A2b（#1958，defensive）均已 shipped；**剩余真正 open 的只有 grid 分组/滚动（Slice 2）**，2b/2c 受 **C0 决策**（翻页器 vs 连续滚动）gate（2a 非 quick-win、折叠进 2b）。另有 formula-over-lookup→`'0'` 的既有架构 gap = backlog（characterization/design note，非实现）。其余 BI-polish + formula 主线均已 shipped。

--- a/docs/development/multitable-open-items-todo-20260527.md
+++ b/docs/development/multitable-open-items-todo-20260527.md
@@ -1,23 +1,19 @@
 # 多维表剩余 open 项 — TODO 追踪清单
 
-> Date: 2026-05-27 · Status: **TRACKER（非开工）** · 配套：开发计划 `multitable-open-items-development-plan-20260527.md` + 验证 `multitable-open-items-verification-20260527.md`
-> Grounded in `origin/main @ 8fd73257d`。K3 锁：均为内核打磨，允许；**每个 slice 仍是独立 opt-in，不自动开下一刀**。
+> Date: 2026-05-27 · Refreshed: 2026-05-28 · Status: **TRACKER（post-#1950 + #1958）** · 配套：开发计划 `multitable-open-items-development-plan-20260527.md` + 验证 `multitable-open-items-verification-20260527.md`
+> **Reconcile 2026-05-28**：Slice 1 ✅ SHIPPED #1950 · A2b ✅ MERGED #1958（defensive）· 唯一 still-open = **Slice 2（C0-gated）**。
+> Drafting base `origin/main@8fd73257d`，reconciled through #1958（2026-05-28，状态已对齐现实）。K3 锁：均为内核打磨，允许；**每个 slice 仍是独立 opt-in，不自动开下一刀**。
 > 标记：✅ done · ⬜ todo（opt-in 后可动手）· 🔒 gated（被决策/前置阻塞）· ☑️ 需 owner 拍板的决策点
 
 ---
 
-## Slice 1 — charts → ECharts（推荐下一刀，静态 import 先行）
+## Slice 1 — charts → ECharts ✅ **SHIPPED (#1950, merge `b665b2b1c`)**
 
-**前置**：`pnpm --filter @metasheet/web add echarts`（Apache-2.0）。范围：`MetaChartRenderer.vue`（1 组件）+ `MetaDashboardView.vue`（1 消费者）；后端零改动。
+> as-built：bar/line/pie→ECharts canvas；title + pie legend 留 HTML chrome；number/table HTML；tooltip 唯一 additive。33 specs + `vue-tsc -b` + build/tree-shaking 绿；**V-S1-7 视觉冒烟 NOT-RUN（无 stack）**。下方 S1-1..8 = as-built 记录（均已落）；**S1-9 async-import / S1-10 新图表类型** 仍为独立 follow-up。
 
-- ⬜ **S1-1** tree-shakeable 引入：`import * as echarts from 'echarts/core'` + `echarts/charts`(`BarChart/LineChart/PieChart`) + `echarts/components`(`GridComponent/TooltipComponent`) + `echarts/renderers`(`CanvasRenderer`) + `echarts.use([...])`。**不引 LegendComponent/TitleComponent**（legend/title = HTML chrome）。**禁 runtime `from 'echarts'`**（type-only 例外）。
-- ⬜ **S1-2** 纯函数 `buildOption(chartData, displayConfig): EChartsOption`（独立文件，便于单测）：bar 竖/横（`orientation`）、line、pie 三类映射；复用现有 8 色 `COLORS`（`displayConfig.colorScheme` 当前 dormant、本 slice 不接、wire→palette 留 follow-up）；仅 `showValues`→**bar** 系列 label + `orientation`→bar 轴 映射进 option；**`title`/`showLegend` = HTML chrome 不进 option**；**pie/line label-less**；最终 option 无 `legend`/`title`。
-- ⬜ **S1-3** `MetaChartRenderer.vue`：bar/line/pie 三个 `<template>` 分支 → 单一 `<div ref="chartEl">`；**number/table 两分支原样保留 HTML**；保留 wrapper `data-chart-type`（模板 L2）。
-- ⬜ **S1-4** 生命周期：`onMounted` init（仅 bar/line/pie）；`watch([()=>chartData,()=>displayConfig], ()=>inst.setOption(buildOption(...), true), {deep:true})`；`ResizeObserver`→`inst.resize()`；`onUnmounted`→`inst.dispose()`。
-- ⬜ **S1-5** **静态 import**（不用 `defineAsyncComponent`——见 S1-9 follow-up）。
-- ⬜ **S1-6** renderer spec 迁移：`vi.mock('echarts/core')`（jsdom 无 canvas）；断言 `buildOption` 输出（5 类型 + 空数据 + 横向 bar + per-point color + displayConfig 映射）；number/table HTML 断言保留。
-- ⬜ **S1-7** dashboard spec 补 `vi.mock('echarts/core')`（`multitable-dashboard-view.spec.ts` 挂载即用 renderer，否则 canvas 崩）。
-- ⬜ **S1-8** i18n 走既有 `meta-view-render-labels`，**不新建 label 模块**。
+**前置（as-built）**：`pnpm --filter @metasheet/web add echarts`（Apache-2.0）。范围：`MetaChartRenderer.vue`（1 组件）+ `MetaDashboardView.vue`（1 消费者）；后端零改动。
+
+- ✅ **S1-1..S1-8 done（as-built，#1950）**：tree-shakeable `echarts/core` + `charts`/`components`/`renderers`（不引 Legend/Title）· 纯函数 `buildOption`（scalar / scalar-array / pie 映射；title+legend 留 HTML chrome；pie/line label-less；option 无 legend/title）· renderer bar/line/pie→canvas + number/table HTML（保留 `data-chart-type`）· 生命周期 init/`setOption`/`watch{flush:'post'}`/`ResizeObserver`/`dispose` · 静态 import · renderer+dashboard specs `vi.mock('echarts/core')` · i18n 走既有 `meta-view-render-labels`。
 - ⬜ **S1-9** 🔒 follow-up：`defineAsyncComponent` 让 echarts 落异步 chunk（+ dashboard spec 改 `flushPromises`）。**单独 PR**，不进 S1 本刀。
 - ⬜ **S1-10** 🔒 follow-up：新图表类型（scatter/area/funnel/gauge/堆叠/组合）——需后端 `ChartAggregationService` 补多 series 维度。**单独 opt-in**。
 
@@ -36,23 +32,24 @@
 
 ---
 
-## Slice 3 — A2b 宏展开转义加固（contract-first）
+## Slice 3 — A2b 宏展开转义加固 ✅ **MERGED (#1958, squash `d9b5b031a`)** — defensive hardening
 
-> 勘误：lookup/rollup 合法进公式（`MetaFieldManager.vue:669` 不排除、后端 `univer-meta.ts:1015` 允许），复杂值真实走 `formula-engine.ts:111` `String(value)`。**改其字面化 = 行为变更，故先锁 contract。**
+> 落地 contract（owner 拍板 **object → `#VALUE!`**）：`formula-engine.ts evaluateField` 的 `String(value)` 兜底收口 —— 标量不变；**scalar array** → 引号 joined literal（值保留、修注入）；**array-with-object + 裸 object → `#VALUE!`**（无 `[object Object]` 假 join、无注入）。不碰 frozen `formula/engine.ts`。
 
-- ⬜ ☑️ **A2b-1（owner 拍板）** 锁 per-type contract 表（开发计划 §Slice 3 有草表）：标量不变；array→加引号 literal（值不变、修注入）；date→ISO 引号 literal；**object → `#VALUE!` 还是引号 literal？需拍板**。
-- ⬜ **A2b-2** 实现：`String(value)` 分支按 contract 安全编码（兼容保留为主）。
-- ⬜ **A2b-3** 回归测试 pin 现行标量行为 + 对抗性单测（`"`/`{fld_x}`/`1+1`/array/object/date/超长串）。
-- ⬜ **A2b-4** lookup-进-公式真 DB 集成测试（wire-vs-fixture：lookup 值经真 patch 流入 formula）。
+- ✅ **A2b-1** 拍板：object（含 array-with-object）→ `#VALUE!`；scalar array → 引号 join；date 在此层是 ISO 字符串走 string 分支。
+- ✅ **A2b-2** 实现已落（仅 `String(value)` 分支）。
+- ✅ **A2b-3** 13 unit：标量回归 + array/object contract（含 lookup-of-object 形状）+ 对抗性无注入（`"`/`{fld_x}`/`1+1`/object-array/超长串）；既有 formula/dry-run/write-path 套件无回归。
+- ⛔ **A2b-4 → NOT-APPLICABLE**（原 V-A2b-3 real-DB lookup→formula）：hydrated lookup 数据当前不流入 formula recalc（`recalculateRecord` 走 DB reload；lookup computed-on-read 不 materialize）→ A2b 是 **defensive**，该 e2e 断言与架构不符。
 - 🔒 **A2b-5** Track B（Teable `packages/formula` MIT 真解析器取代宏展开）——**单独 RFC**，若上马则 A2b 可作废，故 A2b 保持最小。
+- 🆕 **Backlog（独立、out-of-scope，本 reconcile 不写 note 本身）**：formula 引用 lookup → recalc 缺席 lookup 值 → `undefined→'0'`（`formula-engine.ts:109`，"按 0 算"）；characterization/design note only，单独决策。
 
 ---
 
 ## 决策点汇总（☑️ 待 owner）
 
-1. **C0**：翻页器 vs 连续滚动（解锁 2b/2c）。
-2. **A2b-1**：object 值进公式 → `#VALUE!` 还是引号 literal。
-3. **起点确认**：是否从 Slice 1（ECharts，静态 import）开工。
+1. **C0**：翻页器 vs 连续滚动（解锁 Slice 2 的 2b/2c）—— **唯一未决**。
+2. ✅ ~~A2b-1：object → `#VALUE!`~~（已拍板，#1958 落地）。
+3. ✅ ~~起点确认：Slice 1 ECharts~~（已 shipped #1950）。
 
 ## 落地提示
 

--- a/docs/development/multitable-open-items-verification-20260527.md
+++ b/docs/development/multitable-open-items-verification-20260527.md
@@ -1,7 +1,7 @@
 # 多维表剩余 open 项 — 验证 / 验收矩阵
 
 > Date: 2026-05-27 · Status: **验收标准（实现后逐条填 ✅/❌）** · 配套：`multitable-open-items-development-plan-20260527.md` + `multitable-open-items-todo-20260527.md`
-> 每个 slice 的"done"= 下方该节全绿 + `pnpm validate:all` 绿。
+> 每个**未 shipped** slice 的"done"= 下方该节全绿 + `pnpm validate:all` 绿。已 shipped 的 Slice 1/A2b 节为 **historical 证据快照**（非前置门）。
 
 ## 0. 横切验收纪律（所有 slice 适用 — 来自 PR-hardening 经验）
 
@@ -14,7 +14,9 @@
 
 ---
 
-## Slice 1 — ECharts（可立即验收）
+## Slice 1 — ECharts ✅ **SHIPPED (#1950, merge `b665b2b1c`)** — 证据快照
+
+> 结果：V-S1-1..6/8 ✅（33 specs + `vue-tsc -b` + build/tree-shaking 绿，受控实验剔除 ~537KB / 174KB-gzip）；**V-S1-7 视觉冒烟 = NOT-RUN（无 stack，须有 stack 时人工核对）**。下表为 as-verified 记录。
 
 | ID | 验收项 | 方法 | 通过判据 |
 |---|---|---|---|
@@ -28,21 +30,21 @@
 | **V-S1-7** | 视觉冒烟 | 手动 / Playwright（stack 起则跑，否则**显式标 not-run**） | **⏸ NOT-RUN（2026-05-27，无 stack）** — 待 dev server 起后人工核对：dashboard 5 类面板渲染一致、横向 bar 生效、resize 重排、切换/卸载无 console error、无 canvas 泄漏 |
 | **V-S1-8** | 质量门 | `pnpm validate:all` | validate:plugins + lint + type-check 全绿；**production code 无 `any`**（测试局部 any 例外）；i18n 走既有模块无新模块 |
 
-**Slice 1 done = V-S1-1..8 全绿**（V-S1-7 若 stack 不可达，显式标 not-run + 列手动复核步骤，不算静默通过）。
+**Slice 1 = shipped via #1950（historical snapshot）**：V-S1-1..6/8 ✅；**V-S1-7 视觉冒烟仍 outstanding（NOT-RUN，待 stack 人工核对）** —— 唯一 post-merge 未做项，非阻塞门。
 
 ---
 
-## Slice 3 — A2b 宏展开转义（contract-first 验收）
+## Slice 3 — A2b 宏展开转义 ✅ **MERGED (#1958, squash `d9b5b031a`)** — defensive hardening
 
-| ID | 验收项 | 方法 | 通过判据 |
-|---|---|---|---|
-| **V-A2b-0** | contract 表已锁 | 评审 | 开发计划 §Slice 3 的 per-type 表经 owner 拍板（含 object 分支裁决），与实现同 commit |
-| **V-A2b-1** | **标量行为零回归** | vitest golden | string/number/boolean/rollup-number 进公式的求值输出**改动前后逐字相同**（pin 现行为） |
-| **V-A2b-2** | 对抗性无注入 | vitest | 值含 `"`、`{fld_x}`、`1+1`、array、object、date、超长串 → ① 表达式**不被污染/注入**；② 产出符合锁定 contract（如 array→引号 literal） |
-| **V-A2b-3** | lookup-进-公式真 wire | **real-DB 集成**（非 fixture） | 建 string 字段 X → lookup L 拉 X → formula F 引用 L；经真 patch 路径写入；断 F 产出符合 contract（wire-vs-fixture 纪律） |
-| **V-A2b-4** | 最小化 | 评审 | 未越界做语义纠偏（如"lookup array 可 SUM"另开决策）；若 Track B 决定上马则记录 A2b 作废条件 |
+| ID | 验收项 | 结果 |
+|---|---|---|
+| **V-A2b-0** | contract 表已锁 | ✅ owner 拍板 **object → `#VALUE!`**；scalar array→引号 join；array-with-object→`#VALUE!`；date 走 string 分支（quoted） |
+| **V-A2b-1** | 标量行为零回归 | ✅ unit：string/number/boolean 求值逐字不变（`String(value)` 兜底分支外未动） |
+| **V-A2b-2** | 对抗性无注入 | ✅ unit：`"`/`{fld_x}`/`1+1`/object-array/超长串 → 表达式不被注入、产出合 contract（13 测试；既有 formula/dry-run/write-path 套件无回归） |
+| **V-A2b-3** | ~~lookup→formula 真 wire~~ | ⛔ **NOT-APPLICABLE（architecture note）**：hydrated lookup 数据当前不流入 formula recalc（`recalculateRecord` 走 DB reload `formula-engine.ts:249`；lookup computed-on-read 不 materialize，`applyLookupRollup` 只写内存 `row.data` `univer-meta.ts:1795`）→ A2b 是 defensive，e2e `#VALUE!` 断言与架构不符 |
+| **V-A2b-4** | 最小化 | ✅ 仅收口 `String(value)` 一处、未做语义纠偏；Track B 若上马则 A2b 作废 |
 
-**A2b done = V-A2b-0..4 全绿**；**V-A2b-1（零回归）是硬门** —— 任何标量产出变化都视为契约破坏，需回到 V-A2b-0 重新拍板。
+**A2b = MERGED**（defensive hardening）。**🆕 Backlog（独立、out-of-scope）**：formula 引用 lookup → recalc 缺席 lookup 值 → `undefined→'0'`（`formula-engine.ts:109`，"按 0 算"）；characterization/design note only，单独决策。
 
 ---
 
@@ -62,8 +64,8 @@
 
 ## 验收执行顺序
 
-1. **Slice 1** 现在可执行（V-S1-1..8）。
-2. **A2b** 待 A2b-1 contract 拍板后执行（V-A2b-0 先行）。
-3. **Slice 2** 待 C0 决策后执行。
+1. ✅ **Slice 1** — done（#1950；V-S1-7 视觉冒烟 NOT-RUN，待 stack 人工核对）。
+2. ✅ **A2b** — done（#1958，defensive；V-A2b-3 → NOT-APPLICABLE）。
+3. **Slice 2** 待 **C0 决策** 后执行（唯一未决）。
 
 **落地提示**：docs 与后续实现若要 land，先 `git fetch` 后从 `origin/main` 切新分支提交，勿从可能落后的本地分支提交（先 `git rev-list --count HEAD..origin/main` 确认基线）。


### PR DESCRIPTION
## Docs-only: reconcile the multitable open-items tracker to reality

Status-only reconcile of the 3 open-items tracker docs (plan / todo / verification) to current `origin/main` — **no scope or implementation change**.

### Changes (5, locked scope)
1. **Slice 1 charts→ECharts → SHIPPED** (#1950, merge `b665b2b1c`) — header ✅ + as-built note across all 3 docs
2. **shipped-list += #1950** (and #1958) in the dev-plan §0
3. **V-A2b-3 → NOT-APPLICABLE / architecture note** — hydrated lookup data doesn't flow into formula recalc (`recalculateRecord` reloads DB raw data; lookups are computed-on-read, not materialized), so the e2e `lookup→formula→#VALUE!` assertion doesn't match the architecture
4. **A2b → MERGED** (#1958, defensive) + the locked contract: object / array-with-object → `#VALUE!`, scalar array → quoted join, scalars unchanged
5. **formula-over-lookup → `'0'`** recorded as a separate **out-of-scope backlog** (the characterization/design note is NOT written here)

### Consistency
Shipped slices now read as historical/as-built (TODO S1-1..8 collapsed to one ✅ line; verification "全绿" gate scoped to un-shipped slices); the grounded-hash is reframed as "drafting base `@8fd73257d`, reconciled through #1958". Only **Slice 2 (C0-gated)** remains prospective.

### Known non-blocking
- **V-S1-7 visual smoke = NOT-RUN** — the honest tracker state carried from #1950 (awaits a running stack); not introduced here.

Docs-only; no code, no tests affected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
