### PR TITLE
feat(multitable): A2 read-only automation runs API (C1 WorkflowJob view)

### DIFF
--- a/packages/core-backend/src/multitable/automation-log-service.ts
+++ b/packages/core-backend/src/multitable/automation-log-service.ts
@@ -89,6 +89,23 @@ export class AutomationLogService {
   }
 
   /**
+   * List executions across rules with optional filters (A2 read-only runs API).
+   * `status` is the LEGACY stored value — the route resolves C1↔legacy (and the
+   * "future-state → empty" case) before calling, so this stays a plain equality.
+   */
+  async listExecutions(
+    filters: { sheetId?: string; ruleId?: string; status?: string; limit?: number } = {},
+  ): Promise<AutomationExecution[]> {
+    const limit = Math.min(Math.max(filters.limit ?? 50, 1), 200)
+    let q = db.selectFrom('multitable_automation_executions').selectAll()
+    if (filters.sheetId) q = q.where('sheet_id', '=', filters.sheetId)
+    if (filters.ruleId) q = q.where('rule_id', '=', filters.ruleId)
+    if (filters.status) q = q.where('status', '=', filters.status)
+    const rows = await q.orderBy('created_at', 'desc').limit(limit).execute()
+    return rows.map(toExecution)
+  }
+
+  /**
    * Get a specific execution by ID.
    */
   async getById(executionId: string): Promise<AutomationExecution | undefined> {

--- a/packages/core-backend/src/routes/automation.ts
+++ b/packages/core-backend/src/routes/automation.ts
@@ -21,6 +21,7 @@ import { Router, type Request, type Response } from 'express'
 import type { AutomationService } from '../multitable/automation-service'
 import type { AutomationExecution, AutomationStepResult } from '../multitable/automation-executor'
 import { legacyAutomationStatusToJobStatus } from '../multitable/workflow-job-contract'
+import { rbacGuard } from '../rbac/rbac'
 
 // ── A2 run-governance read mappers (boundary only — no storage change) ───────
 
@@ -179,7 +180,10 @@ export function createAutomationRoutes(
 
   // ── A2: read-only runs API (cross-rule; status emitted as C1 WorkflowJobStatus) ──
 
-  router.get('/automation-executions', async (req: Request, res: Response) => {
+  // Cross-sheet run snapshots (incl. detail's triggerEvent/ruleSnapshot) are an
+  // operator/admin governance surface, not a per-reader one — gate behind the
+  // multitable management permission (rbacGuard already lets platform admins / *:* through).
+  router.get('/automation-executions', rbacGuard('multitable', 'write'), async (req: Request, res: Response) => {
     const svc = getService(res)
     if (!svc) return undefined
 
@@ -196,7 +200,10 @@ export function createAutomationRoutes(
     }
 
     try {
-      const limit = Math.min(Math.max(parseInt(String(req.query.limit), 10) || 50, 1), 200)
+      // Default missing/NaN → 50; clamp to [1,200]. Use a finite check (not `|| 50`)
+      // so `?limit=0` clamps to 1 rather than falling back to the default.
+      const rawLimit = parseInt(String(req.query.limit), 10)
+      const limit = Math.min(Math.max(Number.isFinite(rawLimit) ? rawLimit : 50, 1), 200)
       const executions = await svc.logs.listExecutions({
         sheetId: typeof req.query.sheetId === 'string' ? req.query.sheetId : undefined,
         ruleId: typeof req.query.ruleId === 'string' ? req.query.ruleId : undefined,
@@ -210,7 +217,7 @@ export function createAutomationRoutes(
     }
   })
 
-  router.get('/automation-executions/:executionId', async (req: Request, res: Response) => {
+  router.get('/automation-executions/:executionId', rbacGuard('multitable', 'write'), async (req: Request, res: Response) => {
     const executionId = typeof req.params.executionId === 'string' ? req.params.executionId : ''
     if (!executionId) {
       return res.status(400).json({ error: 'executionId is required' })

--- a/packages/core-backend/src/routes/automation.ts
+++ b/packages/core-backend/src/routes/automation.ts
@@ -19,6 +19,72 @@
 
 import { Router, type Request, type Response } from 'express'
 import type { AutomationService } from '../multitable/automation-service'
+import type { AutomationExecution, AutomationStepResult } from '../multitable/automation-executor'
+import { legacyAutomationStatusToJobStatus } from '../multitable/workflow-job-contract'
+
+// ── A2 run-governance read mappers (boundary only — no storage change) ───────
+
+const LEGACY_STATUSES = new Set(['running', 'success', 'failed', 'skipped'])
+// C1 WorkflowJobStatus values that map 1:1 back to a stored legacy value (for filtering).
+const C1_TO_LEGACY: Record<string, string> = {
+  running: 'running',
+  resolved: 'success',
+  failed: 'failed',
+  skipped: 'skipped',
+}
+// C1 future states no stored row can match yet → legal filter, empty result (no contract churn at A6).
+const C1_FUTURE_STATUSES = new Set(['queued', 'suspended', 'rejected', 'errored'])
+
+type StatusFilter =
+  | { kind: 'none' }
+  | { kind: 'legacy'; value: string }
+  | { kind: 'empty' }
+  | { kind: 'invalid' }
+
+/** Resolve a `status=` query value (accepts C1 canonical OR legacy) to a stored-legacy equality. */
+function resolveStatusFilter(input: string | undefined): StatusFilter {
+  if (!input) return { kind: 'none' }
+  if (LEGACY_STATUSES.has(input)) return { kind: 'legacy', value: input }
+  if (Object.prototype.hasOwnProperty.call(C1_TO_LEGACY, input)) return { kind: 'legacy', value: C1_TO_LEGACY[input] }
+  if (C1_FUTURE_STATUSES.has(input)) return { kind: 'empty' }
+  return { kind: 'invalid' }
+}
+
+/** Map one persisted step to the C1 WorkflowJob view at the read boundary. */
+function toWorkflowJobView(execution: AutomationExecution, step: AutomationStepResult, index: number) {
+  return {
+    id: `${execution.id}:step:${index}`,
+    executionId: execution.id,
+    stepKey: String(index),
+    status: legacyAutomationStatusToJobStatus(step.status),
+    upstreamJobId: index > 0 ? `${execution.id}:step:${index - 1}` : null,
+    result: step.output ?? null,
+    // `error` must be string-or-ABSENT to satisfy the C1 WorkflowJob contract
+    // (normalizeWorkflowJob rejects a non-string error) — never emit null.
+    ...(typeof step.error === 'string' ? { error: step.error } : {}),
+  }
+}
+
+/** Map a persisted execution to the runs-API view; `includeSnapshot` adds the redacted blobs (detail only). */
+function toRunView(execution: AutomationExecution, { includeSnapshot }: { includeSnapshot: boolean }) {
+  return {
+    id: execution.id,
+    ruleId: execution.ruleId,
+    sheetId: execution.sheetId ?? null,
+    status: legacyAutomationStatusToJobStatus(execution.status),
+    statusLegacy: execution.status,
+    triggeredBy: execution.triggeredBy,
+    triggeredAt: execution.triggeredAt,
+    finishedAt: execution.finishedAt ?? null,
+    duration: execution.duration ?? null,
+    error: execution.error ?? null,
+    schemaVersion: execution.schemaVersion ?? null,
+    steps: (execution.steps ?? []).map((s, i) => toWorkflowJobView(execution, s, i)),
+    ...(includeSnapshot
+      ? { triggerEvent: execution.triggerEvent ?? null, ruleSnapshot: execution.ruleSnapshot ?? null }
+      : {}),
+  }
+}
 
 /**
  * Build the automation routes router.
@@ -107,6 +173,60 @@ export function createAutomationRoutes(
       return res.json(stats)
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load stats'
+      return res.status(500).json({ error: message })
+    }
+  })
+
+  // ── A2: read-only runs API (cross-rule; status emitted as C1 WorkflowJobStatus) ──
+
+  router.get('/automation-executions', async (req: Request, res: Response) => {
+    const svc = getService(res)
+    if (!svc) return undefined
+
+    const statusFilter = resolveStatusFilter(
+      typeof req.query.status === 'string' ? req.query.status : undefined,
+    )
+    if (statusFilter.kind === 'invalid') {
+      return res.status(400).json({ error: 'invalid status filter' })
+    }
+    // A future-state C1 filter (queued/suspended/rejected/errored) is legal but no stored
+    // row can match it yet — return empty rather than 400, so A6 adds no contract churn.
+    if (statusFilter.kind === 'empty') {
+      return res.json({ executions: [] })
+    }
+
+    try {
+      const limit = Math.min(Math.max(parseInt(String(req.query.limit), 10) || 50, 1), 200)
+      const executions = await svc.logs.listExecutions({
+        sheetId: typeof req.query.sheetId === 'string' ? req.query.sheetId : undefined,
+        ruleId: typeof req.query.ruleId === 'string' ? req.query.ruleId : undefined,
+        status: statusFilter.kind === 'legacy' ? statusFilter.value : undefined,
+        limit,
+      })
+      return res.json({ executions: executions.map((e) => toRunView(e, { includeSnapshot: false })) })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load runs'
+      return res.status(500).json({ error: message })
+    }
+  })
+
+  router.get('/automation-executions/:executionId', async (req: Request, res: Response) => {
+    const executionId = typeof req.params.executionId === 'string' ? req.params.executionId : ''
+    if (!executionId) {
+      return res.status(400).json({ error: 'executionId is required' })
+    }
+
+    const svc = getService(res)
+    if (!svc) return undefined
+
+    try {
+      const execution = await svc.logs.getById(executionId)
+      if (!execution) {
+        return res.status(404).json({ error: 'execution not found' })
+      }
+      return res.json(toRunView(execution, { includeSnapshot: true }))
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Failed to load run'
       return res.status(500).json({ error: message })
     }
   })

--- a/packages/core-backend/tests/unit/automation-runs-api.test.ts
+++ b/packages/core-backend/tests/unit/automation-runs-api.test.ts
@@ -8,6 +8,14 @@ import express from 'express'
 import request from 'supertest'
 import { createAutomationRoutes } from '../../src/routes/automation'
 import { normalizeWorkflowJob } from '../../src/multitable/workflow-job-contract'
+import { rbacGuard } from '../../src/rbac/rbac'
+
+// In prod the runs routes are gated by rbacGuard('multitable', 'write') (+ platform
+// admins via isAdmin/*:*). Here we pass it through so the handler logic is testable —
+// and separately assert the guard IS applied with the right permission.
+vi.mock('../../src/rbac/rbac', () => ({
+  rbacGuard: vi.fn(() => (_req: unknown, _res: unknown, next: () => void) => next()),
+}))
 
 function buildApp(service: unknown) {
   const app = express()
@@ -104,10 +112,19 @@ describe('A2 runs API — GET /automation-executions (list)', () => {
     expect(svc.logs.listExecutions).not.toHaveBeenCalled()
   })
 
-  it('limit clamps to [1,200]', async () => {
+  it('limit clamps to [1,200] — including the limit=0 corner (→ 1, not the 50 default)', async () => {
     const svc = makeMockService()
     await request(buildApp(svc)).get('/api/multitable/automation-executions?limit=5000').expect(200)
-    expect(svc.logs.listExecutions).toHaveBeenCalledWith(expect.objectContaining({ limit: 200 }))
+    expect(svc.logs.listExecutions).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 200 }))
+    await request(buildApp(svc)).get('/api/multitable/automation-executions?limit=0').expect(200)
+    expect(svc.logs.listExecutions).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 1 }))
+    await request(buildApp(svc)).get('/api/multitable/automation-executions?limit=-5').expect(200)
+    expect(svc.logs.listExecutions).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 1 }))
+  })
+
+  it('both runs routes are gated by rbacGuard("multitable", "write")', () => {
+    buildApp(makeMockService())
+    expect(vi.mocked(rbacGuard)).toHaveBeenCalledWith('multitable', 'write')
   })
 })
 

--- a/packages/core-backend/tests/unit/automation-runs-api.test.ts
+++ b/packages/core-backend/tests/unit/automation-runs-api.test.ts
@@ -1,0 +1,136 @@
+/**
+ * A2 read-only runs API — GET /api/multitable/automation-executions (+ /:id).
+ * Surfaces the A1 execution snapshot through the C1 WorkflowJob vocabulary at the
+ * READ boundary (toWorkflowJobView / toRunView); no storage change.
+ */
+import { describe, it, expect, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { createAutomationRoutes } from '../../src/routes/automation'
+import { normalizeWorkflowJob } from '../../src/multitable/workflow-job-contract'
+
+function buildApp(service: unknown) {
+  const app = express()
+  app.use(express.json())
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app.use('/api/multitable', createAutomationRoutes(service as any))
+  return app
+}
+
+const sampleExec = {
+  id: 'axe_1',
+  ruleId: 'rule-1',
+  sheetId: 'sheet-a',
+  triggeredBy: 'event',
+  triggeredAt: '2026-05-28T00:00:00.000Z',
+  status: 'success',
+  duration: 12,
+  finishedAt: '2026-05-28T00:00:01.000Z',
+  schemaVersion: 1,
+  triggerEvent: { recordId: 'rec1' },
+  ruleSnapshot: { id: 'rule-1', name: 'Notify' },
+  steps: [
+    { actionType: 'send_email', status: 'success', output: { ok: true }, durationMs: 5 },
+    { actionType: 'send_webhook', status: 'failed', error: 'boom', durationMs: 3 },
+  ],
+}
+
+function makeMockService(logsOverrides: Record<string, unknown> = {}) {
+  return {
+    logs: {
+      listExecutions: vi.fn().mockResolvedValue([sampleExec]),
+      getById: vi.fn().mockResolvedValue(sampleExec),
+      ...logsOverrides,
+    },
+  }
+}
+
+describe('A2 runs API — GET /automation-executions (list)', () => {
+  it('returns { executions }; status emitted as C1 (success → resolved); snapshot omitted in list', async () => {
+    const svc = makeMockService()
+    const res = await request(buildApp(svc))
+      .get('/api/multitable/automation-executions?sheetId=sheet-a')
+      .expect(200)
+
+    expect(res.body).toHaveProperty('executions')
+    const run = res.body.executions[0]
+    expect(run.status).toBe('resolved') // C1 vocabulary
+    expect(run.statusLegacy).toBe('success') // legacy preserved for diagnosis
+    expect(run.sheetId).toBe('sheet-a')
+    // list view omits the heavy redacted blobs (detail-only)
+    expect(run.triggerEvent).toBeUndefined()
+    expect(run.ruleSnapshot).toBeUndefined()
+    // steps mapped to the C1 WorkflowJob view
+    expect(run.steps[0].id).toBe('axe_1:step:0')
+    expect(run.steps[0].stepKey).toBe('0')
+    expect(run.steps[0].status).toBe('resolved')
+    expect(run.steps[0].upstreamJobId).toBeNull()
+    expect(run.steps[1].status).toBe('failed')
+    expect(run.steps[1].upstreamJobId).toBe('axe_1:step:0')
+    expect(svc.logs.listExecutions).toHaveBeenCalledWith(
+      expect.objectContaining({ sheetId: 'sheet-a', limit: 50 }),
+    )
+  })
+
+  it('every step view passes the C1 normalizeWorkflowJob contract (error string-or-absent, never null)', async () => {
+    const svc = makeMockService()
+    const res = await request(buildApp(svc)).get('/api/multitable/automation-executions').expect(200)
+    for (const step of res.body.executions[0].steps) {
+      expect(() => normalizeWorkflowJob(step)).not.toThrow()
+    }
+    const [ok, failed] = res.body.executions[0].steps
+    expect(ok.error).toBeUndefined() // success step → no error key (not null)
+    expect(failed.error).toBe('boom')
+  })
+
+  it('status filter accepts BOTH C1 and legacy (resolved & success → stored legacy "success")', async () => {
+    const svc = makeMockService()
+    await request(buildApp(svc)).get('/api/multitable/automation-executions?status=resolved').expect(200)
+    expect(svc.logs.listExecutions).toHaveBeenLastCalledWith(expect.objectContaining({ status: 'success' }))
+    await request(buildApp(svc)).get('/api/multitable/automation-executions?status=success').expect(200)
+    expect(svc.logs.listExecutions).toHaveBeenLastCalledWith(expect.objectContaining({ status: 'success' }))
+  })
+
+  it('future-state C1 filter (suspended) is legal but returns empty WITHOUT querying', async () => {
+    const svc = makeMockService()
+    const res = await request(buildApp(svc)).get('/api/multitable/automation-executions?status=suspended').expect(200)
+    expect(res.body.executions).toEqual([])
+    expect(svc.logs.listExecutions).not.toHaveBeenCalled()
+  })
+
+  it('invalid status filter → 400 (no silent fallback)', async () => {
+    const svc = makeMockService()
+    await request(buildApp(svc)).get('/api/multitable/automation-executions?status=bogus').expect(400)
+    expect(svc.logs.listExecutions).not.toHaveBeenCalled()
+  })
+
+  it('limit clamps to [1,200]', async () => {
+    const svc = makeMockService()
+    await request(buildApp(svc)).get('/api/multitable/automation-executions?limit=5000').expect(200)
+    expect(svc.logs.listExecutions).toHaveBeenCalledWith(expect.objectContaining({ limit: 200 }))
+  })
+})
+
+describe('A2 runs API — GET /automation-executions/:id (detail)', () => {
+  it('returns the run WITH snapshot blobs (detail view)', async () => {
+    const svc = makeMockService()
+    const res = await request(buildApp(svc)).get('/api/multitable/automation-executions/axe_1').expect(200)
+    expect(res.body.id).toBe('axe_1')
+    expect(res.body.status).toBe('resolved')
+    expect(res.body.triggerEvent).toEqual({ recordId: 'rec1' }) // detail includes snapshot
+    expect(res.body.ruleSnapshot).toEqual({ id: 'rule-1', name: 'Notify' })
+    expect(svc.logs.getById).toHaveBeenCalledWith('axe_1')
+  })
+
+  it('404 when the execution is missing', async () => {
+    const svc = makeMockService({ getById: vi.fn().mockResolvedValue(undefined) })
+    await request(buildApp(svc)).get('/api/multitable/automation-executions/nope').expect(404)
+  })
+
+  it('503 when the service is not initialized', async () => {
+    const app = express()
+    app.use(express.json())
+    app.use('/api/multitable', createAutomationRoutes(() => undefined))
+    await request(app).get('/api/multitable/automation-executions').expect(503)
+  })
+})


### PR DESCRIPTION
## What

Run-governance **A2** — surfaces the **A1 execution snapshot** (#1937) through two **read-only** routes, mapping to the **C1 WorkflowJob** vocabulary (#1889) at the read boundary. Implements A0 plan §A2 (#1932). No storage change, no write path.

- `AutomationLogService.listExecutions({ sheetId, ruleId, status, limit })` — filtered cross-rule query.
- `routes/automation.ts`:
  - `GET /api/multitable/automation-executions` (list) + `/:executionId` (detail).
  - Status emitted as `WorkflowJobStatus` via `legacyAutomationStatusToJobStatus` (`success → resolved`); `statusLegacy` preserved for diagnosis.
  - Steps mapped via `toWorkflowJobView` (`id`/`executionId`/`stepKey`/`status`/`upstreamJobId`/`result`/`error`). **`error` is string-or-ABSENT** so each step passes the C1 `normalizeWorkflowJob` (never `null` — caught + test-locked).
  - `status=` accepts **both** C1 and legacy; C1 future-states (`queued/suspended/rejected/errored`) are **legal but return empty** (no contract churn when A6 lands); invalid → **400**.
  - **List omits** the redacted snapshot blobs; **detail includes** them. `limit` clamp `1..200`.

## Scope (held to the A2 boundary)

Read-only only. **NO** retry (A4/A5) · **NO** migration · **NO** write path · **NO** frontend (A3). `rerun_of`/`initiated_by` still deferred to the retry gate.

## ⚠️ Permission note (flagged for review, not silently shipped)

A2 is a **cross-sheet operator governance view** — it does **not** currently filter runs by the caller's per-sheet access (it inherits the existing automation-route mount-level auth, same as the per-rule `/logs`). If runs must be restricted to sheets the caller can access, that is a **follow-up permission layer**. Surfacing this consciously per the repo's permission discipline.

## Tests / validation

- New `automation-runs-api` suite: list/detail/404/503, C1 status mapping (`success→resolved`), status-filter **both-vocabulary** + **future-state-empty** + **invalid→400**, limit clamp, and **every step view passes `normalizeWorkflowJob`** (error never null).
- Existing `automation-routes-wiring` + `automation-v1` green — **152 tests**. `tsc --noEmit` clean. ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)