### PR TITLE
feat(integration): DF-T1.5 — read-only preview provenance display (阶段二)

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -273,6 +273,21 @@ export interface IntegrationTemplatePreviewRequest {
   }
 }
 
+export type IntegrationFieldProvenanceSource = 'staging' | 'template' | 'constant' | 'reference_table'
+
+// DF-T1 target-payload preview evidence — present only when the request carried a payloadTemplate.
+// All fields are sanitized metadata (names, counts, provenance sources); never raw payload values.
+export interface IntegrationTargetPayloadPreview {
+  eligibleForSaveOnly?: boolean
+  unresolvedPlaceholders?: string[]
+  unresolvedReferenceComponents?: Array<Record<string, unknown>>
+  missingRequiredFields?: string[]
+  // target field name -> provenance source ((string & {}) keeps autocomplete + tolerates new sources)
+  fieldProvenance?: Record<string, IntegrationFieldProvenanceSource | (string & {})>
+  compositionSource?: string
+  redactionSelfCheck?: { applied?: boolean; clean?: boolean }
+}
+
 export interface IntegrationTemplatePreviewResult {
   valid: boolean
   payload: Record<string, unknown>
@@ -282,6 +297,48 @@ export interface IntegrationTemplatePreviewResult {
   validationErrors: Array<Record<string, unknown>>
   schemaErrors: Array<Record<string, unknown>>
   template?: Record<string, unknown>
+  // DF-T1.5: present only in the DF-T1 payloadTemplate preview mode; the legacy preview omits it.
+  targetPayloadPreview?: IntegrationTargetPayloadPreview
+}
+
+export interface IntegrationFieldProvenanceEntry {
+  field: string
+  source: string
+}
+
+export interface IntegrationFieldProvenanceSummary {
+  entries: IntegrationFieldProvenanceEntry[]
+  stats: Array<{ source: string; count: number }>
+}
+
+// Canonical source order for the DF-T1.5 provenance stats badges.
+const FIELD_PROVENANCE_SOURCE_ORDER: IntegrationFieldProvenanceSource[] = ['staging', 'template', 'constant', 'reference_table']
+
+// DF-T1.5 (read-only): derive a names-only provenance view from a DF-T1 targetPayloadPreview.
+// Returns null when there is no fieldProvenance (legacy preview) so the UI renders nothing.
+// NEVER reads payload values — only field names and their declared source.
+export function summarizeFieldProvenance(
+  preview: IntegrationTargetPayloadPreview | null | undefined,
+): IntegrationFieldProvenanceSummary | null {
+  const provenance = preview?.fieldProvenance
+  if (!provenance || typeof provenance !== 'object') return null
+  const entries: IntegrationFieldProvenanceEntry[] = Object.keys(provenance)
+    .sort((a, b) => a.localeCompare(b))
+    .map((field) => ({ field, source: String(provenance[field]) }))
+  if (entries.length === 0) return null
+  const counts = new Map<string, number>()
+  for (const { source } of entries) counts.set(source, (counts.get(source) || 0) + 1)
+  const stats: Array<{ source: string; count: number }> = []
+  for (const source of FIELD_PROVENANCE_SOURCE_ORDER) {
+    if (counts.has(source)) {
+      stats.push({ source, count: counts.get(source) as number })
+      counts.delete(source)
+    }
+  }
+  for (const source of [...counts.keys()].sort((a, b) => a.localeCompare(b))) {
+    stats.push({ source, count: counts.get(source) as number })
+  }
+  return { entries, stats }
 }
 
 async function parseIntegrationResponse<T>(response: Response): Promise<T> {

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -789,6 +789,28 @@
           </button>
         </div>
         <pre data-testid="payload-preview">{{ previewText }}</pre>
+        <div
+          v-if="previewProvenance"
+          class="integration-workbench__provenance"
+          data-testid="preview-provenance"
+        >
+          <h3 class="integration-workbench__provenance-title">字段来源</h3>
+          <p class="integration-workbench__provenance-stats" data-testid="preview-provenance-stats">
+            <span
+              v-for="stat in previewProvenance.stats"
+              :key="stat.source"
+              class="integration-workbench__provenance-badge"
+              :data-source="stat.source"
+            >{{ provenanceSourceLabel(stat.source) }}: {{ stat.count }}</span>
+          </p>
+          <ul class="integration-workbench__provenance-list">
+            <li v-for="entry in previewProvenance.entries" :key="entry.field" :data-field="entry.field">
+              <code>{{ entry.field }}</code>
+              <span class="integration-workbench__provenance-badge" :data-source="entry.source">{{ provenanceSourceLabel(entry.source) }}</span>
+            </li>
+          </ul>
+          <p class="integration-workbench__hint">仅显示字段名与来源，不含字段值。</p>
+        </div>
       </div>
     </section>
   </section>
@@ -816,6 +838,7 @@ import {
   previewIntegrationTemplate,
   replayIntegrationDeadLetter,
   runIntegrationPipeline,
+  summarizeFieldProvenance,
   testExternalSystemConnection,
   upsertWorkbenchExternalSystem,
   upsertIntegrationPipeline,
@@ -963,6 +986,8 @@ const sourceSchema = ref<IntegrationObjectSchema>({ object: '', fields: [] })
 const targetSchema = ref<IntegrationObjectSchema>({ object: '', fields: [] })
 const mappings = ref<EditableMapping[]>([])
 const previewText = ref('尚未生成预览')
+// DF-T1.5: read-only provenance summary derived from a DF-T1 targetPayloadPreview (null = nothing to show).
+const previewProvenance = ref<ReturnType<typeof summarizeFieldProvenance>>(null)
 const pipelineResultText = ref('尚未执行')
 const lastDryRunResult = ref<IntegrationPipelineRunResult | null>(null)
 const pipelineRuns = ref<IntegrationPipelineRun[]>([])
@@ -2478,6 +2503,16 @@ async function executePipeline(dryRun: boolean): Promise<void> {
   }
 }
 
+const PROVENANCE_SOURCE_LABELS: Record<string, string> = {
+  staging: '暂存源',
+  template: '模板',
+  constant: '常量',
+  reference_table: '引用表',
+}
+function provenanceSourceLabel(source: string): string {
+  return PROVENANCE_SOURCE_LABELS[source] || source
+}
+
 async function previewPayload(): Promise<void> {
   try {
     const sourceRecord = JSON.parse(sampleRecordText.value) as Record<string, unknown>
@@ -2495,9 +2530,11 @@ async function previewPayload(): Promise<void> {
       },
     })
     previewText.value = JSON.stringify(result, null, 2)
+    previewProvenance.value = summarizeFieldProvenance(result.targetPayloadPreview)
     setStatus(result.valid ? 'Payload 预览通过' : `Payload 预览发现 ${result.errors.length} 个问题`, result.valid ? 'success' : 'error')
   } catch (error) {
     previewText.value = '预览失败'
+    previewProvenance.value = null
     setStatus(error instanceof Error ? error.message : String(error), 'error')
   }
 }
@@ -2512,6 +2549,41 @@ watch(showAdvancedConnectors, () => {
 </script>
 
 <style scoped>
+.integration-workbench__provenance {
+  margin-top: 12px;
+}
+.integration-workbench__provenance-title {
+  font-size: 14px;
+  margin: 0 0 6px;
+}
+.integration-workbench__provenance-stats {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  margin: 0 0 8px;
+}
+.integration-workbench__provenance-list {
+  list-style: none;
+  padding: 0;
+  margin: 0;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+.integration-workbench__provenance-list li {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+.integration-workbench__provenance-badge {
+  display: inline-block;
+  padding: 1px 8px;
+  border-radius: 10px;
+  font-size: 12px;
+  background: #eef2ff;
+  color: #3730a3;
+}
+
 .integration-workbench {
   max-width: 1280px;
   margin: 0 auto;

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -277,6 +277,15 @@ describe('IntegrationWorkbenchView', () => {
           transformErrors: [],
           validationErrors: [],
           schemaErrors: [],
+          targetPayloadPreview: {
+            eligibleForSaveOnly: true,
+            unresolvedPlaceholders: [],
+            unresolvedReferenceComponents: [],
+            missingRequiredFields: [],
+            fieldProvenance: { FNumber: 'staging', FName: 'staging', FUnitGroupID: 'template', FErpClsID: 'reference_table' },
+            compositionSource: 'k3-save-body-composer',
+            redactionSelfCheck: { applied: true, clean: true },
+          },
         })
       }
       if (url === '/api/integration/pipelines') {
@@ -583,6 +592,23 @@ describe('IntegrationWorkbenchView', () => {
 
     ;(container.querySelector('[data-testid="preview-payload"]') as HTMLButtonElement).click()
     await flushUi()
+
+    // DF-T1.5: targetPayloadPreview.fieldProvenance in the response → the read-only provenance
+    // panel renders field names + source badges + per-source stats, and never any payload values.
+    const provenancePanel = container.querySelector('[data-testid="preview-provenance"]') as HTMLElement | null
+    expect(provenancePanel).not.toBeNull()
+    const provenanceText = provenancePanel?.textContent || ''
+    expect(provenanceText).toContain('FNumber')
+    expect(provenanceText).toContain('FUnitGroupID')
+    expect(provenanceText).toContain('FErpClsID')
+    const statsText = container.querySelector('[data-testid="preview-provenance-stats"]')?.textContent || ''
+    expect(statsText).toContain('暂存源: 2')
+    expect(statsText).toContain('模板: 1')
+    expect(statsText).toContain('引用表: 1')
+    // Secret hygiene: the provenance panel shows NO payload values.
+    expect(provenanceText).not.toContain('MAT-001')
+    expect(provenanceText).not.toContain('Bolt')
+    expect(provenanceText).not.toContain('Pcs')
 
     expect(previewBodies).toHaveLength(1)
     expect(previewBodies[0]).toMatchObject({

--- a/apps/web/tests/integrationWorkbench.spec.ts
+++ b/apps/web/tests/integrationWorkbench.spec.ts
@@ -10,6 +10,7 @@ import {
   listWorkbenchExternalSystems,
   previewIntegrationTemplate,
   runIntegrationPipeline,
+  summarizeFieldProvenance,
   testExternalSystemConnection,
   upsertWorkbenchExternalSystem,
   upsertIntegrationPipeline,
@@ -31,6 +32,45 @@ function jsonResponse(data: unknown): Response {
     headers: { 'Content-Type': 'application/json' },
   })
 }
+
+describe('summarizeFieldProvenance (DF-T1.5 preview provenance)', () => {
+  it('returns null when there is no fieldProvenance (legacy preview / nothing to show)', () => {
+    expect(summarizeFieldProvenance(null)).toBeNull()
+    expect(summarizeFieldProvenance(undefined)).toBeNull()
+    expect(summarizeFieldProvenance({})).toBeNull()
+    expect(summarizeFieldProvenance({ fieldProvenance: {} })).toBeNull()
+  })
+
+  it('lists fields sorted by name with their declared source', () => {
+    const summary = summarizeFieldProvenance({
+      fieldProvenance: { FName: 'staging', FNumber: 'staging', FUnitGroupID: 'template', FErpClsID: 'reference_table' },
+    })
+    expect(summary).not.toBeNull()
+    expect(summary?.entries.map((entry) => entry.field)).toEqual(['FErpClsID', 'FName', 'FNumber', 'FUnitGroupID'])
+    expect(summary?.entries.find((entry) => entry.field === 'FUnitGroupID')?.source).toBe('template')
+  })
+
+  it('counts per source in canonical order (staging, template, constant, reference_table)', () => {
+    const summary = summarizeFieldProvenance({
+      fieldProvenance: { a: 'reference_table', b: 'staging', c: 'staging', d: 'template' },
+    })
+    expect(summary?.stats).toEqual([
+      { source: 'staging', count: 2 },
+      { source: 'template', count: 1 },
+      { source: 'reference_table', count: 1 },
+    ])
+  })
+
+  it('appends unknown/forward-compat sources after the canonical ones', () => {
+    const summary = summarizeFieldProvenance({
+      fieldProvenance: { a: 'staging', b: 'future_source' },
+    })
+    expect(summary?.stats).toEqual([
+      { source: 'staging', count: 1 },
+      { source: 'future_source', count: 1 },
+    ])
+  })
+})
 
 describe('integration project-scope helpers', () => {
   it.each([

--- a/docs/development/data-factory-df-t1_5-preview-provenance-display-verification-20260528.md
+++ b/docs/development/data-factory-df-t1_5-preview-provenance-display-verification-20260528.md
@@ -1,0 +1,50 @@
+# Data Factory DF-T1.5 — preview provenance display (verification, 2026-05-28)
+
+Part of 阶段二 (Data Factory). DF-T1.5 is a **read-only frontend** slice over data DF-T1 already
+emits — the first 阶段二 opt-in taken after the K3 PoC GATE PASS (#1792).
+
+## Scope (narrow, by design)
+
+Show, in the Data Factory payload-preview panel (`IntegrationWorkbenchView.vue`), the **source of
+each composed field** from `targetPayloadPreview.fieldProvenance`:
+
+- sources: `staging` / `template` / `constant` / `reference_table`;
+- rendered as **field name + source badge + per-source stats**;
+- shown **only when** the response carries `targetPayloadPreview.fieldProvenance` — the legacy
+  fieldMappings preview is unaffected (panel absent);
+- **field names + sources + counts only — never raw payload values** (preserves the secret hygiene
+  established for the K3 preview/Save evidence).
+
+## Explicitly NOT in this slice
+
+provenance persistence · JSONB migration · by-rowId route · K3 Save/Submit/Audit/BOM · multi-record
+gate · connector action metadata. No new runtime, no backend, no route.
+
+## Change
+
+- `apps/web/src/services/integration/workbench.ts`: type the DF-T1 evidence
+  (`IntegrationTargetPayloadPreview`, optional on `IntegrationTemplatePreviewResult`) + a **pure
+  helper** `summarizeFieldProvenance(preview) → { entries, stats } | null` (returns null when there
+  is no fieldProvenance, so the UI shows nothing; canonical source order; never reads values).
+- `apps/web/src/views/IntegrationWorkbenchView.vue`: a `previewProvenance` ref set from the helper
+  on preview (cleared on error) and a `v-if`-gated panel in the preview section rendering the
+  badges + stats + a "仅显示字段名与来源，不含字段值" note.
+
+## Verification
+
+- `apps/web/tests/integrationWorkbench.spec.ts` — `summarizeFieldProvenance` unit tests: null on
+  no/empty fieldProvenance; entries sorted by field with their source; canonical stats order +
+  counts; forward-compat unknown source appended after the known ones.
+- `apps/web/tests/IntegrationWorkbenchView.spec.ts` — the preview test now returns
+  `targetPayloadPreview.fieldProvenance`; asserts the panel renders field names + stats
+  (`暂存源: 2 · 模板: 1 · 引用表: 1`) and contains **none** of the payload values
+  (`MAT-001` / `Bolt` / `Pcs`).
+- Negative control (run locally 2026-05-28): reverting the `previewProvenance` wiring (so the panel
+  never renders) fails the view spec's panel assertion; restoring → green.
+- `vitest run` (both specs): 44 passed. `vue-tsc --noEmit`: 0 errors.
+
+## Next (one opt-in at a time)
+
+DF-T1.5 done → the next 阶段二 step is **DF-N2-2 (provenance runtime)** or **DF-T1A (connector
+action metadata)**, each a separate explicit opt-in. K3 write (Submit / Audit / BOM / multi-record)
+stays gated.

--- a/docs/development/data-factory-template-composition-execution-plan-todo-20260527.md
+++ b/docs/development/data-factory-template-composition-execution-plan-todo-20260527.md
@@ -85,10 +85,10 @@ Shape B (legacy preview fields compatible; DF-T1 evidence under `targetPayloadPr
 
 Closeout-verified on `main`: targetPayloadPreview + legacy arrays present; bodyKey guard active; no-write/fail-closed/redaction/grep-gate tests in place.
 
-### ⬜ DF-T1.5 — Preview provenance display — NEXT (gate satisfied; not auto-started)
-Gate satisfied: DF-T1 is green on `main` (#1945) and already emits `targetPayloadPreview.fieldProvenance`. Awaiting an explicit opt-in. (DF-T1.5 is a read-only display over that existing data — no new runtime.)
-- [ ] Per-field provenance (staging / template / constant / reference-table), derived read-only from the DF-T1 merge.
-- [ ] No new persisted provenance runtime field in this slice.
+### ✅ DF-T1.5 — Preview provenance display (DONE — 2026-05-28)
+Read-only display over the `targetPayloadPreview.fieldProvenance` DF-T1 emits; no new runtime. Frontend-only (`IntegrationWorkbenchView.vue` panel + pure `summarizeFieldProvenance` helper in `workbench.ts`); shows field name + source badge + per-source stats, gated on fieldProvenance presence (legacy preview unaffected), **never raw payload values**. Verification: `data-factory-df-t1_5-preview-provenance-display-verification-20260528.md`.
+- [x] Per-field provenance (staging / template / constant / reference-table), derived read-only from the DF-T1 merge.
+- [x] No new persisted provenance runtime field in this slice.
 
 ### 🔒 DF-T1A — Connector action metadata
 Gated on: DF-T1 + opt-in.
@@ -177,7 +177,7 @@ processors, or streaming cluster in this track.
 
 ## Sequencing rule
 
-One explicit opt-in per phase. Do not auto-start the next. **DF-T1-0 (#1936) and DF-T1 (#1945) are DONE; the active next is DF-T1.5** (preview provenance display — a read-only view over the `fieldProvenance` DF-T1 already emits). Everything below DF-T1.5 stays 🔒 until its predecessor gate is green and it is separately opted in.
+One explicit opt-in per phase. Do not auto-start the next. **DF-T1-0 (#1936), DF-T1 (#1945), and DF-T1.5 (preview provenance display) are DONE.** The next step is a separate explicit opt-in — either **DF-N2-2 (provenance runtime)** or **DF-T1A (connector action metadata)**; everything below stays 🔒 until its predecessor gate is green and it is separately opted in.
 
 ## Definition of done — DF-T1-0 (the immediate gate)
 


### PR DESCRIPTION
## DF-T1.5 — read-only preview provenance display (阶段二, first opt-in after the K3 GATE PASS)

First 阶段二 (Data Factory) slice taken after the #1792 PoC GATE PASS. **Read-only, frontend-only**,
over data DF-T1 already emits — no new runtime / route / persistence.

### Scope (narrow, by design)
In the DF payload-preview panel, show each composed field's **source** from
`targetPayloadPreview.fieldProvenance` (`staging` / `template` / `constant` / `reference_table`) as
**field name + source badge + per-source stats** — only when the response carries `fieldProvenance`
(legacy fieldMappings preview unaffected), and **never any raw payload value** (preserves the K3
secret hygiene).

### Change
- `workbench.ts`: type the DF-T1 evidence (`IntegrationTargetPayloadPreview`, optional on the
  result) + pure helper `summarizeFieldProvenance(preview) → {entries, stats} | null` (null when no
  fieldProvenance; canonical source order; reads names/sources only).
- `IntegrationWorkbenchView.vue`: `previewProvenance` ref + a `v-if`-gated panel + a
  "仅显示字段名与来源，不含字段值" note.

### Tests (negative-controlled)
- `integrationWorkbench.spec.ts`: `summarizeFieldProvenance` unit tests (gating / sort / canonical
  stats / forward-compat unknown source).
- `IntegrationWorkbenchView.spec.ts`: the preview test returns `fieldProvenance` → asserts the panel
  renders names + stats (`暂存源: 2 · 模板: 1 · 引用表: 1`) and contains **no** payload values
  (`MAT-001` / `Bolt` / `Pcs`).
- **Negative control run locally:** reverting the `previewProvenance` wiring fails the view panel
  assertion (`expected null not to be null`); restored → 44/44 green. `vue-tsc --noEmit`: 0 errors.

### NOT in scope
provenance persistence · JSONB migration · by-rowId route · K3 Save/Submit/Audit/BOM · multi-record
· connector action metadata.

### Next
DF-T1.5 done → the next 阶段二 step (DF-N2-2 provenance runtime, or DF-T1A) is a separate explicit
opt-in. K3 write (Submit/Audit/BOM/multi-record) stays gated.

## Refs
- #1792 — K3 PoC GATE (PASS); this is the first 阶段二 opt-in after it
- #1945 — DF-T1 (emits the `fieldProvenance` this displays)

Closes none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
