### PR TITLE
feat(data-sources): A1 encrypt credentials at rest (Lane A)

### DIFF
--- a/packages/core-backend/src/data-adapters/DataSourceManager.ts
+++ b/packages/core-backend/src/data-adapters/DataSourceManager.ts
@@ -119,15 +119,18 @@ export class DataSourceManager extends EventEmitter {
   /**
    * Encrypt secret credential fields for storage (A1). Uses
    * encryptStoredSecretValue (NOT normalize) so secret values are not trimmed —
-   * a trailing space in a password is significant. Idempotent: already-encrypted
-   * values are skipped.
+   * a trailing space in a password is significant. ALWAYS encrypts: it does NOT
+   * use the enc: prefix to detect "already encrypted", because a real plaintext
+   * secret can legitimately start with "enc:" and persistDataSource always
+   * receives plaintext config (create = user plaintext; PUT doesn't touch
+   * credentials; load decrypts before re-persist) — there is nothing to skip.
    */
   private encryptCredentials(creds?: Credentials): Credentials | undefined {
     if (!creds) return creds
     const out: Credentials = { ...creds }
     for (const key of SENSITIVE_CREDENTIAL_KEYS) {
       const v = out[key]
-      if (typeof v === 'string' && v.length > 0 && !isEncryptedSecretValue(v)) {
+      if (typeof v === 'string' && v.length > 0) {
         out[key] = encryptStoredSecretValue(v)
       }
     }

--- a/packages/core-backend/src/data-adapters/DataSourceManager.ts
+++ b/packages/core-backend/src/data-adapters/DataSourceManager.ts
@@ -5,6 +5,12 @@ import { PostgresAdapter } from './PostgresAdapter'
 import { MySQLAdapter } from './MySQLAdapter'
 import { HTTPAdapter } from './HTTPAdapter'
 import { MongoDBAdapter } from './MongoDBAdapter'
+import { encryptStoredSecretValue, decryptStoredSecretValue, isEncryptedSecretValue } from '../security/encrypted-secrets'
+
+// Credential fields that hold secrets and are encrypted at rest. Identifiers
+// like `username` are left as-is (matching the codebase's encrypt-secrets-only
+// convention).
+const SENSITIVE_CREDENTIAL_KEYS = ['password', 'apiKey', 'token']
 
 type AdapterConstructor = new (config: DataSourceConfig) => BaseDataAdapter
 
@@ -110,6 +116,48 @@ export class DataSourceManager extends EventEmitter {
     }
   }
 
+  /**
+   * Encrypt secret credential fields for storage (A1). Uses
+   * encryptStoredSecretValue (NOT normalize) so secret values are not trimmed —
+   * a trailing space in a password is significant. Idempotent: already-encrypted
+   * values are skipped.
+   */
+  private encryptCredentials(creds?: Credentials): Credentials | undefined {
+    if (!creds) return creds
+    const out: Credentials = { ...creds }
+    for (const key of SENSITIVE_CREDENTIAL_KEYS) {
+      const v = out[key]
+      if (typeof v === 'string' && v.length > 0 && !isEncryptedSecretValue(v)) {
+        out[key] = encryptStoredSecretValue(v)
+      }
+    }
+    return out
+  }
+
+  /**
+   * Decrypt secret credential fields after load (A1). Encrypted values are
+   * decrypted and FAIL LOUD on a key mismatch (a ciphertext is never passed
+   * through to the adapter). Legacy plaintext passes through unchanged — lazy
+   * migration: it is re-encrypted on the next persist.
+   */
+  private decryptCredentials(creds?: Credentials): Credentials | undefined {
+    if (!creds) return creds
+    const out: Credentials = { ...creds }
+    for (const key of SENSITIVE_CREDENTIAL_KEYS) {
+      const v = out[key]
+      if (typeof v === 'string' && isEncryptedSecretValue(v)) {
+        try {
+          out[key] = decryptStoredSecretValue(v)
+        } catch (err) {
+          throw new Error(
+            `Failed to decrypt credential '${key}' (ENCRYPTION_KEY may have changed): ${err instanceof Error ? err.message : String(err)}`
+          )
+        }
+      }
+    }
+    return out
+  }
+
   private recordToConfig(record: DataSourceRecord): DataSourceConfig {
     const configData = record.config as Record<string, unknown>
     return {
@@ -117,7 +165,7 @@ export class DataSourceManager extends EventEmitter {
       name: record.name,
       type: record.type,
       connection: (configData.connection || {}) as ConnectionConfig,
-      credentials: configData.credentials as Credentials | undefined,
+      credentials: this.decryptCredentials(configData.credentials as Credentials | undefined),
       options: configData.options as AdapterOptions | undefined,
       poolConfig: configData.poolConfig as DataSourceConfig['poolConfig']
     }
@@ -135,7 +183,7 @@ export class DataSourceManager extends EventEmitter {
       description: null,
       config: {
         connection: config.connection,
-        credentials: config.credentials, // TODO: Encrypt sensitive fields
+        credentials: this.encryptCredentials(config.credentials),
         options: config.options,
         poolConfig: config.poolConfig
       },

--- a/packages/core-backend/src/data-adapters/DataSourceManager.ts
+++ b/packages/core-backend/src/data-adapters/DataSourceManager.ts
@@ -121,9 +121,9 @@ export class DataSourceManager extends EventEmitter {
    * encryptStoredSecretValue (NOT normalize) so secret values are not trimmed —
    * a trailing space in a password is significant. ALWAYS encrypts: it does NOT
    * use the enc: prefix to detect "already encrypted", because a real plaintext
-   * secret can legitimately start with "enc:" and persistDataSource always
-   * receives plaintext config (create = user plaintext; PUT doesn't touch
-   * credentials; load decrypts before re-persist) — there is nothing to skip.
+   * secret can legitimately start with "enc:". Callers always pass plaintext
+   * credentials — user input on create, and the preserved or freshly-decrypted
+   * value on update/load — so there is nothing already-encrypted to skip.
    */
   private encryptCredentials(creds?: Credentials): Credentials | undefined {
     if (!creds) return creds

--- a/packages/core-backend/tests/unit/data-source-credential-encryption.test.ts
+++ b/packages/core-backend/tests/unit/data-source-credential-encryption.test.ts
@@ -110,4 +110,32 @@ describe('A1 credential encryption at rest', () => {
     expect(() => m.getDataSource('ok')).not.toThrow() // valid row still loads
     expect(() => m.getDataSource('corrupt')).toThrow(/not found/) // undecryptable row skipped
   })
+
+  it('round-trips a secret that literally starts with the enc: prefix', async () => {
+    const { db, rows } = statefulFakeDb()
+    const m1 = new DataSourceManager({ db: db as never })
+    await m1.addDataSource(
+      {
+        id: 'pfx',
+        name: 'pfx',
+        type: 'postgres',
+        connection: { host: 'localhost', port: 5432, database: 'x' },
+        credentials: { username: 'u', password: 'enc:literal-secret', apiKey: 'enc:also', token: 'enc:too' },
+        options: { autoConnect: false },
+      },
+      { ownerId: 'a' },
+    )
+
+    // must be genuinely encrypted, NOT passed through because it looked encrypted
+    const stored = (rows.get('pfx') as { config: { credentials: Record<string, string> } }).config.credentials
+    expect(stored.password).toMatch(/^enc:/)
+    expect(stored.password).not.toBe('enc:literal-secret')
+
+    const m2 = new DataSourceManager()
+    await m2.initialize(db as never)
+    const creds = m2.getDataSource('pfx').getConfig().credentials as Record<string, string>
+    expect(creds.password).toBe('enc:literal-secret')
+    expect(creds.apiKey).toBe('enc:also')
+    expect(creds.token).toBe('enc:too')
+  })
 })

--- a/packages/core-backend/tests/unit/data-source-credential-encryption.test.ts
+++ b/packages/core-backend/tests/unit/data-source-credential-encryption.test.ts
@@ -1,0 +1,113 @@
+import { describe, expect, it } from 'vitest'
+
+import { DataSourceManager } from '../../src/data-adapters/DataSourceManager'
+import type { DataSourceConfig } from '../../src/data-adapters/BaseAdapter'
+
+// Stateful Kysely stand-in: insert captures the persisted record (with its
+// encrypted-at-rest config), select returns active rows for loadFromDatabase.
+function statefulFakeDb() {
+  const rows = new Map<string, Record<string, unknown>>()
+  const insertBuilder = () => {
+    let pending: Record<string, unknown> = {}
+    const b = {
+      values: (v: Record<string, unknown>) => { pending = v; return b },
+      onConflict: () => b,
+      execute: async () => { rows.set(pending.id as string, { ...pending }); return [] },
+    }
+    return b
+  }
+  const selectBuilder = () => {
+    const b = {
+      selectAll: () => b,
+      where: () => b,
+      execute: async () => [...rows.values()].filter((r) => r.is_active === true && r.deleted_at == null),
+    }
+    return b
+  }
+  return {
+    rows,
+    db: {
+      selectFrom: () => selectBuilder(),
+      insertInto: () => insertBuilder(),
+      updateTable: () => ({ set: () => ({ where: () => ({ execute: async () => [] }) }) }),
+      deleteFrom: () => ({ where: () => ({ execute: async () => [] }) }),
+    },
+  }
+}
+
+function dbRow(id: string, credentials: Record<string, unknown>) {
+  return {
+    id,
+    name: id,
+    type: 'postgres',
+    description: null,
+    config: { connection: {}, credentials },
+    status: 'disconnected',
+    last_connected_at: null,
+    last_error: null,
+    owner_id: 'a',
+    workspace_id: null,
+    is_active: true,
+    auto_connect: false,
+    metadata: null,
+    tags: null,
+    created_at: new Date(),
+    updated_at: new Date(),
+    deleted_at: null,
+  }
+}
+
+function pgConfigWithCreds(id: string): DataSourceConfig {
+  return {
+    id,
+    name: id,
+    type: 'postgres',
+    connection: { host: 'localhost', port: 5432, database: 'x' },
+    // trailing space in password is significant and must survive the round-trip
+    credentials: { username: 'u', password: 'p@ss ', apiKey: 'key-123', token: 'tok-xyz' },
+    options: { autoConnect: false },
+  }
+}
+
+describe('A1 credential encryption at rest', () => {
+  it('encrypts secret fields at rest and decrypts on reload (username plaintext, no trim)', async () => {
+    const { db, rows } = statefulFakeDb()
+    const m1 = new DataSourceManager({ db: db as never })
+    await m1.addDataSource(pgConfigWithCreds('ds1'), { ownerId: 'a' })
+
+    // at rest: secrets are enc:, the identifier is not
+    const stored = (rows.get('ds1') as { config: { credentials: Record<string, string> } }).config.credentials
+    expect(stored.password).toMatch(/^enc:/)
+    expect(stored.apiKey).toMatch(/^enc:/)
+    expect(stored.token).toMatch(/^enc:/)
+    expect(stored.username).toBe('u')
+
+    // reload (fresh manager) decrypts back to the exact plaintext
+    const m2 = new DataSourceManager()
+    await m2.initialize(db as never)
+    const creds = m2.getDataSource('ds1').getConfig().credentials as Record<string, string>
+    expect(creds.password).toBe('p@ss ') // exact, incl. trailing space (no trim)
+    expect(creds.apiKey).toBe('key-123')
+    expect(creds.token).toBe('tok-xyz')
+    expect(creds.username).toBe('u')
+  })
+
+  it('passes legacy plaintext credentials through unchanged (lazy migration)', async () => {
+    const { db, rows } = statefulFakeDb()
+    rows.set('legacy', dbRow('legacy', { username: 'u', password: 'plain-pw' }))
+    const m = new DataSourceManager()
+    await m.initialize(db as never)
+    const creds = m.getDataSource('legacy').getConfig().credentials as Record<string, string>
+    expect(creds.password).toBe('plain-pw')
+  })
+
+  it('fails loud (skips the source on load) when an encrypted credential cannot be decrypted', async () => {
+    const { db, rows } = statefulFakeDb()
+    rows.set('ok', dbRow('ok', { password: 'plain' }))
+    rows.set('corrupt', dbRow('corrupt', { password: 'enc:invalid' }))
+    const m = new DataSourceManager()
+    await m.initialize(db as never)
+    expect(() => m.getDataSource('ok')).not.toThrow() // valid row still loads
+    expect(() => m.getDataSource('corrupt')).toThrow(/not found/) // undecryptable row skipped
+  })
+})


### PR DESCRIPTION
## Summary
- Encrypt sensitive `credentials` fields (`password`, `apiKey`, `token`) before persisting `data_sources.config`, storing `enc:` ciphertext instead of plaintext.
- Decrypt secrets when loading sources back into memory so adapters still receive plaintext credentials at runtime.
- Keep `username` plaintext, preserve significant whitespace in secrets, and support lazy migration by accepting legacy plaintext rows until they are re-persisted.
- Fail loud on undecryptable `enc:` values: the source is skipped on load and never receives ciphertext as a runtime credential.
- Fix the `enc:`-prefixed plaintext edge case by always encrypting secrets at persist time rather than guessing from the prefix.

## Deployment dependency
- `ENCRYPTION_KEY` must be set in the runtime environment. If omitted, encryption falls back to the existing insecure default (`default-key-change-in-production`).
- If `ENCRYPTION_KEY` changes later, previously encrypted source credentials will fail to decrypt and those sources will be skipped on load until re-encrypted with the active key.

## Notes
- This is a lazy migration, not a one-shot migration: existing plaintext rows still load, and the next persist rewrites them encrypted.
- Real runtime behavior is unchanged for adapters: they still receive plaintext credentials after load/decrypt.

## Test plan
- [x] `vitest run tests/unit/data-source-credential-encryption.test.ts tests/unit/data-source-scope.test.ts tests/unit/data-source-readonly.test.ts`
- [x] `tsc --noEmit`
