### PR TITLE
fix(multitable): narrow A2 runs-API gate to platform-admin (requireAdminRole)

### DIFF
--- a/packages/core-backend/src/routes/automation.ts
+++ b/packages/core-backend/src/routes/automation.ts
@@ -21,7 +21,7 @@ import { Router, type Request, type Response } from 'express'
 import type { AutomationService } from '../multitable/automation-service'
 import type { AutomationExecution, AutomationStepResult } from '../multitable/automation-executor'
 import { legacyAutomationStatusToJobStatus } from '../multitable/workflow-job-contract'
-import { rbacGuard } from '../rbac/rbac'
+import { requireAdminRole } from '../guards/audit-integration'
 
 // ── A2 run-governance read mappers (boundary only — no storage change) ───────
 
@@ -180,10 +180,11 @@ export function createAutomationRoutes(
 
   // ── A2: read-only runs API (cross-rule; status emitted as C1 WorkflowJobStatus) ──
 
-  // Cross-sheet run snapshots (incl. detail's triggerEvent/ruleSnapshot) are an
-  // operator/admin governance surface, not a per-reader one — gate behind the
-  // multitable management permission (rbacGuard already lets platform admins / *:* through).
-  router.get('/automation-executions', rbacGuard('multitable', 'write'), async (req: Request, res: Response) => {
+  // Cross-sheet run snapshots (incl. detail's triggerEvent/ruleSnapshot) are a
+  // PLATFORM-ADMIN governance surface — gate behind requireAdminRole() (isAdmin,
+  // fail-safe 503 on RBAC error). Narrowed from multitable:write per review so a
+  // plain platform editor cannot read cross-sheet automation runs.
+  router.get('/automation-executions', requireAdminRole(), async (req: Request, res: Response) => {
     const svc = getService(res)
     if (!svc) return undefined
 
@@ -217,7 +218,7 @@ export function createAutomationRoutes(
     }
   })
 
-  router.get('/automation-executions/:executionId', rbacGuard('multitable', 'write'), async (req: Request, res: Response) => {
+  router.get('/automation-executions/:executionId', requireAdminRole(), async (req: Request, res: Response) => {
     const executionId = typeof req.params.executionId === 'string' ? req.params.executionId : ''
     if (!executionId) {
       return res.status(400).json({ error: 'executionId is required' })

--- a/packages/core-backend/tests/unit/automation-runs-api.test.ts
+++ b/packages/core-backend/tests/unit/automation-runs-api.test.ts
@@ -8,13 +8,14 @@ import express from 'express'
 import request from 'supertest'
 import { createAutomationRoutes } from '../../src/routes/automation'
 import { normalizeWorkflowJob } from '../../src/multitable/workflow-job-contract'
-import { rbacGuard } from '../../src/rbac/rbac'
+import { requireAdminRole } from '../../src/guards/audit-integration'
 
-// In prod the runs routes are gated by rbacGuard('multitable', 'write') (+ platform
-// admins via isAdmin/*:*). Here we pass it through so the handler logic is testable —
-// and separately assert the guard IS applied with the right permission.
-vi.mock('../../src/rbac/rbac', () => ({
-  rbacGuard: vi.fn(() => (_req: unknown, _res: unknown, next: () => void) => next()),
+// In prod the runs routes are gated by requireAdminRole() (platform-admin only).
+// Pass it through so the handler logic is testable — and separately assert the guard
+// IS applied to BOTH routes. Mocking the whole module also avoids pulling its heavy
+// audit/metrics deps into a unit test.
+vi.mock('../../src/guards/audit-integration', () => ({
+  requireAdminRole: vi.fn(() => (_req: unknown, _res: unknown, next: () => void) => next()),
 }))
 
 function buildApp(service: unknown) {
@@ -122,9 +123,11 @@ describe('A2 runs API — GET /automation-executions (list)', () => {
     expect(svc.logs.listExecutions).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 1 }))
   })
 
-  it('both runs routes are gated by rbacGuard("multitable", "write")', () => {
+  it('both runs routes (list + detail) are gated by requireAdminRole()', () => {
+    vi.mocked(requireAdminRole).mockClear()
     buildApp(makeMockService())
-    expect(vi.mocked(rbacGuard)).toHaveBeenCalledWith('multitable', 'write')
+    // exactly two guarded routes were constructed: list + detail
+    expect(vi.mocked(requireAdminRole)).toHaveBeenCalledTimes(2)
   })
 })
 


### PR DESCRIPTION
## What

Review follow-up to **#1967** — owner picked **option (b): admin-only**.

A2's runs API was gated by `rbacGuard('multitable','write')`, which let any platform **editor** read cross-sheet automation runs/snapshots. Narrow **both** `/automation-executions` (list) and `/:executionId` (detail) to **`requireAdminRole()`** — isAdmin-only, fail-safe **503** on RBAC error. Run governance is a platform-admin surface.

- Uses the **existing** admin guard (same as `/admin/*` and `/canary` routes) — no central RBAC/auth change (K3-lock safe).
- Closes the non-blocking concern from #1967 review (platform editor seeing cross-sheet runs).

## Tests

Guard pass-through mock + assert `requireAdminRole()` is applied to **BOTH** routes (`toHaveBeenCalledTimes(2)` — addresses the reviewer's per-route NIT). **17 tests** green; `tsc` + ESLint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)