### PR TITLE
feat(multitable): A3 admin runs view (frontend, consumes A2 C1 runs API)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -47,6 +47,7 @@ import type {
   RecordPermissionEntry,
   AutomationRule,
   AutomationExecution,
+  AutomationRunView,
   AutomationStats,
   ChartConfig,
   ChartCreateInput,
@@ -1572,6 +1573,25 @@ export class MultitableApiClient {
       `/api/multitable/sheets/${encodeURIComponent(sheetId)}/automations/${encodeURIComponent(ruleId)}/stats`,
     )
     return this.parseJson<AutomationStats>(res)
+  }
+
+  // --- A2: read-only cross-rule runs API (admin-only; status emitted as C1 WorkflowJobStatus) ---
+  async listAutomationRuns(filters?: {
+    sheetId?: string
+    ruleId?: string
+    status?: string
+    limit?: number
+  }): Promise<AutomationRunView[]> {
+    const res = await this.fetch(`/api/multitable/automation-executions${qs({ ...filters })}`)
+    const data = await this.parseJson<{ executions: AutomationRunView[] }>(res)
+    return Array.isArray(data?.executions) ? data.executions : []
+  }
+
+  async getAutomationRun(executionId: string): Promise<AutomationRunView> {
+    const res = await this.fetch(
+      `/api/multitable/automation-executions/${encodeURIComponent(executionId)}`,
+    )
+    return this.parseJson<AutomationRunView>(res)
   }
 
   async getAutomationDingTalkPersonDeliveries(sheetId: string, ruleId: string, limit?: number): Promise<DingTalkPersonDelivery[]> {

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -846,6 +846,55 @@ export interface AutomationExecution {
   error?: string
 }
 
+/**
+ * Converged workflow-job status (C1 contract). The A2 read-only runs API emits
+ * these at the read boundary (e.g. legacy `success` → `resolved`); the legacy
+ * `multitable_automation_executions.status` storage is unchanged.
+ */
+export type WorkflowJobStatus =
+  | 'queued'
+  | 'running'
+  | 'suspended'
+  | 'resolved'
+  | 'failed'
+  | 'skipped'
+  | 'rejected'
+  | 'errored'
+
+/** One step of a run, mapped to the C1 WorkflowJob view by the A2 read boundary. */
+export interface AutomationRunStepView {
+  id: string
+  executionId: string
+  stepKey: string
+  status: WorkflowJobStatus
+  upstreamJobId: string | null
+  result?: unknown
+  error?: string
+}
+
+/**
+ * A run as returned by the A2 read-only runs API
+ * (`GET /api/multitable/automation-executions` + `/:id`, admin-only). Status is
+ * the C1 vocabulary; `statusLegacy` keeps the stored value for diagnosis.
+ * `triggerEvent` / `ruleSnapshot` are detail-only (omitted in the list view).
+ */
+export interface AutomationRunView {
+  id: string
+  ruleId: string
+  sheetId: string | null
+  status: WorkflowJobStatus
+  statusLegacy: string
+  triggeredBy: string
+  triggeredAt: string
+  finishedAt: string | null
+  duration: number | null
+  error: string | null
+  schemaVersion: number | null
+  steps: AutomationRunStepView[]
+  triggerEvent?: unknown
+  ruleSnapshot?: unknown
+}
+
 export interface AutomationStats {
   total: number
   success: number

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -9,9 +9,12 @@ import type {
   AutomationExecution,
   AutomationTriggerType,
   ConditionOperator,
+  WorkflowJobStatus,
 } from '../types'
 
-export type AutomationStatus = AutomationExecution['status'] | 'running'
+// Legacy execution/step statuses (success/failed/skipped) + the converged C1
+// WorkflowJobStatus set surfaced by the A2 runs API (resolved/queued/suspended/…).
+export type AutomationStatus = AutomationExecution['status'] | WorkflowJobStatus
 
 // Keep in sync with MetaAutomationRuleEditor.vue ConditionValueWidget.
 export type AutomationConditionValueWidget =
@@ -239,6 +242,19 @@ export type AutomationLabelKey =
   | 'status.failed'
   | 'status.skipped'
   | 'status.running'
+  | 'status.resolved'
+  | 'status.queued'
+  | 'status.suspended'
+  | 'status.rejected'
+  | 'status.errored'
+  | 'runs.title'
+  | 'runs.subtitle'
+  | 'runs.adminOnly'
+  | 'runs.sheetFilter'
+  | 'runs.triggerEvent'
+  | 'runs.ruleSnapshot'
+  | 'runs.steps'
+  | 'runs.loadingDetail'
 
 export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'log.title',
@@ -431,6 +447,19 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'status.failed',
   'status.skipped',
   'status.running',
+  'status.resolved',
+  'status.queued',
+  'status.suspended',
+  'status.rejected',
+  'status.errored',
+  'runs.title',
+  'runs.subtitle',
+  'runs.adminOnly',
+  'runs.sheetFilter',
+  'runs.triggerEvent',
+  'runs.ruleSnapshot',
+  'runs.steps',
+  'runs.loadingDetail',
 ]
 
 const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
@@ -624,6 +653,19 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'status.failed': { en: 'failed', zh: '失败' },
   'status.skipped': { en: 'skipped', zh: '跳过' },
   'status.running': { en: 'running', zh: '运行中' },
+  'status.resolved': { en: 'resolved', zh: '已完成' },
+  'status.queued': { en: 'queued', zh: '排队中' },
+  'status.suspended': { en: 'suspended', zh: '已挂起' },
+  'status.rejected': { en: 'rejected', zh: '已拒绝' },
+  'status.errored': { en: 'errored', zh: '异常' },
+  'runs.title': { en: 'Automation Runs', zh: '自动化运行记录' },
+  'runs.subtitle': { en: 'Cross-sheet · admin only · read-only', zh: '跨表 · 仅管理员 · 只读' },
+  'runs.adminOnly': { en: 'Admin access required', zh: '需要管理员权限' },
+  'runs.sheetFilter': { en: 'Sheet ID', zh: '表 ID' },
+  'runs.triggerEvent': { en: 'Trigger event', zh: '触发事件' },
+  'runs.ruleSnapshot': { en: 'Rule snapshot', zh: '规则快照' },
+  'runs.steps': { en: 'Steps', zh: '步骤' },
+  'runs.loadingDetail': { en: 'Loading detail…', zh: '加载详情…' },
 }
 
 export function automationLabel(key: AutomationLabelKey, isZh: boolean): string {
@@ -636,6 +678,11 @@ export function automationStatusLabel(status: AutomationStatus | (string & {}), 
   if (status === 'failed') return automationLabel('status.failed', isZh)
   if (status === 'skipped') return automationLabel('status.skipped', isZh)
   if (status === 'running') return automationLabel('status.running', isZh)
+  if (status === 'resolved') return automationLabel('status.resolved', isZh)
+  if (status === 'queued') return automationLabel('status.queued', isZh)
+  if (status === 'suspended') return automationLabel('status.suspended', isZh)
+  if (status === 'rejected') return automationLabel('status.rejected', isZh)
+  if (status === 'errored') return automationLabel('status.errored', isZh)
   return String(status)
 }
 

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -190,6 +190,12 @@ export const appRoutes: RouteRecordRaw[] = [
     meta: { title: 'Permission Management', requiresAuth: true }
   },
   {
+    path: '/admin/automation-executions',
+    name: 'automation-executions',
+    component: () => import('../views/AutomationExecutionsView.vue'),
+    meta: { title: 'Automation Runs', titleZh: '自动化运行记录', requiresAuth: true }
+  },
+  {
     path: '/admin/audit',
     name: 'admin-audit',
     component: () => import('../views/AdminAuditView.vue'),

--- a/apps/web/src/views/AutomationExecutionsView.vue
+++ b/apps/web/src/views/AutomationExecutionsView.vue
@@ -1,0 +1,215 @@
+<template>
+  <section class="automation-runs">
+    <header class="automation-runs__header">
+      <h1 class="automation-runs__title">{{ automationLabel('runs.title', isZh) }}</h1>
+      <p class="automation-runs__subtitle">{{ automationLabel('runs.subtitle', isZh) }}</p>
+    </header>
+
+    <!-- Admin-only surface (backend is gated by requireAdminRole; this is the UX mirror) -->
+    <div v-if="!isAdmin" class="automation-runs__denied" role="alert" data-denied="true">
+      {{ automationLabel('runs.adminOnly', isZh) }}
+    </div>
+
+    <template v-else>
+      <div class="automation-runs__toolbar">
+        <select v-model="statusFilter" class="automation-runs__select" data-field="statusFilter">
+          <option value="">{{ automationLabel('status.all', isZh) }}</option>
+          <option v-for="s in STATUS_OPTIONS" :key="s" :value="s">{{ automationStatusLabel(s, isZh) }}</option>
+        </select>
+        <input
+          v-model.trim="sheetFilter"
+          class="automation-runs__input"
+          data-field="sheetFilter"
+          :placeholder="automationLabel('runs.sheetFilter', isZh)"
+        />
+        <button class="automation-runs__btn" type="button" data-action="refresh" @click="loadData">
+          {{ automationLabel('log.refresh', isZh) }}
+        </button>
+      </div>
+
+      <div v-if="loadError" class="automation-runs__error" role="alert" data-error="true">
+        <span>{{ automationLabel('log.errorPrefix', isZh) }}</span>
+        <span data-field="error-message">{{ loadError }}</span>
+        <button class="automation-runs__btn" type="button" data-action="retry" @click="loadData">
+          {{ automationLabel('log.retry', isZh) }}
+        </button>
+      </div>
+
+      <div v-if="loading" class="automation-runs__empty">{{ automationLabel('log.loading', isZh) }}</div>
+      <div v-else-if="!loadError && runs.length === 0" class="automation-runs__empty" data-empty="true">
+        {{ automationLabel('log.empty', isZh) }}
+      </div>
+
+      <div
+        v-for="run in runs"
+        :key="run.id"
+        class="automation-runs__item"
+        :data-run-id="run.id"
+        @click="toggleExpand(run.id)"
+      >
+        <div class="automation-runs__summary">
+          <span class="automation-runs__time">{{ formatTime(run.triggeredAt) }}</span>
+          <span class="automation-runs__badge" :class="`automation-runs__badge--${run.status}`" :data-status="run.status">
+            {{ automationStatusLabel(run.status, isZh) }}
+          </span>
+          <span class="automation-runs__rule" data-field="ruleId">{{ run.ruleId }}</span>
+          <span v-if="run.sheetId" class="automation-runs__sheet" data-field="sheetId">{{ run.sheetId }}</span>
+          <span class="automation-runs__trigger" data-field="triggeredBy">{{ run.triggeredBy }}</span>
+          <span class="automation-runs__duration">{{ run.duration ?? '-' }}ms</span>
+        </div>
+
+        <div v-if="expandedId === run.id" class="automation-runs__detail" data-detail="true">
+          <div v-if="detailLoading" class="automation-runs__empty">{{ automationLabel('runs.loadingDetail', isZh) }}</div>
+          <template v-else-if="detail">
+            <h2 class="automation-runs__detail-h">{{ automationLabel('runs.steps', isZh) }}</h2>
+            <div
+              v-for="step in detail.steps"
+              :key="step.id"
+              class="automation-runs__step"
+            >
+              <span class="automation-runs__step-key">{{ step.stepKey }}</span>
+              <span class="automation-runs__badge automation-runs__badge--sm" :class="`automation-runs__badge--${step.status}`">
+                {{ automationStatusLabel(step.status, isZh) }}
+              </span>
+              <div v-if="step.error" class="automation-runs__step-error" data-field="step-error">
+                {{ summarizeStepError(step.error) }}
+              </div>
+              <div v-if="step.result !== undefined && step.result !== null" class="automation-runs__step-output" data-field="step-output">
+                {{ summarizeStepOutput(step.result) }}
+              </div>
+            </div>
+
+            <h2 class="automation-runs__detail-h">{{ automationLabel('runs.triggerEvent', isZh) }}</h2>
+            <pre class="automation-runs__json" data-field="trigger-event">{{ jsonView(detail.triggerEvent) }}</pre>
+            <h2 class="automation-runs__detail-h">{{ automationLabel('runs.ruleSnapshot', isZh) }}</h2>
+            <pre class="automation-runs__json" data-field="rule-snapshot">{{ jsonView(detail.ruleSnapshot) }}</pre>
+          </template>
+        </div>
+      </div>
+    </template>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { ref } from 'vue'
+import { useLocale } from '../composables/useLocale'
+import { useAuth } from '../composables/useAuth'
+import { multitableClient, type MultitableApiClient } from '../multitable/api/client'
+import type { AutomationRunView, WorkflowJobStatus } from '../multitable/types'
+import { automationLabel, automationStatusLabel } from '../multitable/utils/meta-automation-labels'
+import { redactString, summarizeStepError, summarizeStepOutput } from '../multitable/utils/automation-log-redact'
+
+const props = defineProps<{ client?: MultitableApiClient }>()
+const client = props.client ?? multitableClient
+
+const { isZh } = useLocale()
+const auth = useAuth()
+const isAdmin = auth.hasAdminAccess()
+
+// Statuses a stored run can currently carry (legacy 4-state mapped to C1). The other
+// C1 states (queued/suspended/rejected/errored) only appear once the convergence
+// engine lands — the A2 API returns empty for them, so they are omitted from the UI.
+const STATUS_OPTIONS: WorkflowJobStatus[] = ['resolved', 'failed', 'skipped', 'running']
+
+const runs = ref<AutomationRunView[]>([])
+const loading = ref(false)
+const loadError = ref<string | null>(null)
+const statusFilter = ref('')
+const sheetFilter = ref('')
+const expandedId = ref<string | null>(null)
+const detail = ref<AutomationRunView | null>(null)
+const detailLoading = ref(false)
+
+async function loadData() {
+  loading.value = true
+  loadError.value = null
+  expandedId.value = null
+  detail.value = null
+  try {
+    runs.value = await client.listAutomationRuns({
+      status: statusFilter.value || undefined,
+      sheetId: sheetFilter.value || undefined,
+      limit: 100,
+    })
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err)
+    loadError.value = redactString(message) || automationLabel('error.unknown', isZh.value)
+    runs.value = []
+  } finally {
+    loading.value = false
+  }
+}
+
+async function toggleExpand(id: string) {
+  if (expandedId.value === id) {
+    expandedId.value = null
+    return
+  }
+  expandedId.value = id
+  detail.value = null
+  detailLoading.value = true
+  try {
+    detail.value = await client.getAutomationRun(id)
+  } catch {
+    // Detail is best-effort; the row summary stays. Collapse silently.
+    detailLoading.value = false
+    expandedId.value = null
+    return
+  }
+  detailLoading.value = false
+}
+
+function formatTime(ts: string): string {
+  try {
+    return new Date(ts).toLocaleString()
+  } catch {
+    return ts
+  }
+}
+
+/** Render a redacted snapshot blob (A2 already scrubs at persist; this is defense-in-depth). */
+function jsonView(value: unknown): string {
+  if (value === undefined || value === null) return '—'
+  try {
+    return redactString(JSON.stringify(value, null, 2))
+  } catch {
+    return '—'
+  }
+}
+
+if (isAdmin) void loadData()
+</script>
+
+<style scoped>
+.automation-runs { padding: 20px 24px; max-width: 1000px; margin: 0 auto; }
+.automation-runs__header { margin-bottom: 16px; }
+.automation-runs__title { margin: 0; font-size: 20px; font-weight: 700; color: #0f172a; }
+.automation-runs__subtitle { margin: 4px 0 0; font-size: 13px; color: #64748b; }
+.automation-runs__denied { padding: 14px 16px; border-radius: 10px; background: #fef2f2; color: #b91c1c; font-size: 14px; }
+.automation-runs__toolbar { display: flex; gap: 8px; align-items: center; margin-bottom: 12px; flex-wrap: wrap; }
+.automation-runs__select, .automation-runs__input { border: 1px solid #cbd5e1; border-radius: 8px; padding: 6px 10px; font-size: 13px; background: #fff; }
+.automation-runs__btn { border: 1px solid #cbd5e1; border-radius: 8px; padding: 6px 14px; background: #fff; color: #0f172a; font-size: 13px; cursor: pointer; }
+.automation-runs__empty { padding: 10px 12px; border-radius: 10px; font-size: 13px; background: #f8fafc; color: #64748b; }
+.automation-runs__error { padding: 10px 12px; border-radius: 10px; font-size: 13px; background: #fef2f2; color: #b91c1c; display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-bottom: 12px; }
+.automation-runs__item { border: 1px solid #e2e8f0; border-radius: 8px; padding: 10px 12px; cursor: pointer; margin-bottom: 8px; }
+.automation-runs__item:hover { background: #f8fafc; }
+.automation-runs__summary { display: flex; align-items: center; gap: 10px; font-size: 13px; flex-wrap: wrap; }
+.automation-runs__time { color: #64748b; min-width: 150px; }
+.automation-runs__rule { color: #334155; font-weight: 600; }
+.automation-runs__sheet { color: #475569; }
+.automation-runs__trigger { color: #475569; }
+.automation-runs__duration { margin-left: auto; color: #94a3b8; }
+.automation-runs__badge { display: inline-block; padding: 2px 8px; border-radius: 6px; font-size: 11px; font-weight: 600; text-transform: uppercase; background: #f1f5f9; color: #475569; }
+.automation-runs__badge--resolved { background: #dcfce7; color: #16a34a; }
+.automation-runs__badge--failed, .automation-runs__badge--errored, .automation-runs__badge--rejected { background: #fef2f2; color: #dc2626; }
+.automation-runs__badge--skipped { background: #f1f5f9; color: #64748b; }
+.automation-runs__badge--running, .automation-runs__badge--queued, .automation-runs__badge--suspended { background: #eff6ff; color: #2563eb; }
+.automation-runs__badge--sm { font-size: 10px; padding: 1px 6px; }
+.automation-runs__detail { margin-top: 8px; padding-top: 8px; border-top: 1px solid #e2e8f0; display: flex; flex-direction: column; gap: 6px; }
+.automation-runs__detail-h { margin: 6px 0 2px; font-size: 12px; font-weight: 700; color: #475569; text-transform: uppercase; }
+.automation-runs__step { display: flex; align-items: center; gap: 8px; font-size: 12px; flex-wrap: wrap; }
+.automation-runs__step-key { font-weight: 700; color: #2563eb; }
+.automation-runs__step-error { width: 100%; padding: 4px 8px; background: #fef2f2; color: #dc2626; border-radius: 4px; font-size: 11px; }
+.automation-runs__step-output { width: 100%; padding: 4px 8px; background: #f8fafc; color: #475569; border-radius: 4px; font-size: 11px; word-break: break-all; }
+.automation-runs__json { width: 100%; margin: 0; padding: 8px; background: #f8fafc; color: #334155; border-radius: 6px; font-size: 11px; white-space: pre-wrap; word-break: break-all; max-height: 200px; overflow: auto; }
+</style>

--- a/apps/web/src/views/AutomationExecutionsView.vue
+++ b/apps/web/src/views/AutomationExecutionsView.vue
@@ -97,7 +97,7 @@ import { useAuth } from '../composables/useAuth'
 import { multitableClient, type MultitableApiClient } from '../multitable/api/client'
 import type { AutomationRunView, WorkflowJobStatus } from '../multitable/types'
 import { automationLabel, automationStatusLabel } from '../multitable/utils/meta-automation-labels'
-import { redactString, summarizeStepError, summarizeStepOutput } from '../multitable/utils/automation-log-redact'
+import { redactString, redactValue, summarizeStepError, summarizeStepOutput } from '../multitable/utils/automation-log-redact'
 
 const props = defineProps<{ client?: MultitableApiClient }>()
 const client = props.client ?? multitableClient
@@ -143,18 +143,26 @@ async function loadData() {
 async function toggleExpand(id: string) {
   if (expandedId.value === id) {
     expandedId.value = null
+    detail.value = null
     return
   }
   expandedId.value = id
   detail.value = null
   detailLoading.value = true
+  let run: AutomationRunView | null = null
   try {
-    detail.value = await client.getAutomationRun(id)
+    run = await client.getAutomationRun(id)
   } catch {
-    // Detail is best-effort; the row summary stays. Collapse silently.
-    detailLoading.value = false
-    expandedId.value = null
-    return
+    run = null
+  }
+  // Drop a STALE response: if a newer row was expanded while this fetch was in
+  // flight, expandedId has moved on — that newer flow owns the state, so this
+  // (older) response must not paint its detail under the wrong row.
+  if (expandedId.value !== id) return
+  if (run) {
+    detail.value = run
+  } else {
+    expandedId.value = null // detail failed for the still-current row → collapse
   }
   detailLoading.value = false
 }
@@ -167,11 +175,16 @@ function formatTime(ts: string): string {
   }
 }
 
-/** Render a redacted snapshot blob (A2 already scrubs at persist; this is defense-in-depth). */
+/**
+ * Render a redacted snapshot blob (A2 already scrubs at persist; this is
+ * defense-in-depth). Uses redactValue (not redactString) so the UI-side guard
+ * also masks structured secret keys (authorization/cookie/…), matching the
+ * step-output redaction path — not just in-string patterns.
+ */
 function jsonView(value: unknown): string {
   if (value === undefined || value === null) return '—'
   try {
-    return redactString(JSON.stringify(value, null, 2))
+    return JSON.stringify(redactValue(value), null, 2)
   } catch {
     return '—'
   }

--- a/apps/web/tests/AutomationExecutionsView.spec.ts
+++ b/apps/web/tests/AutomationExecutionsView.spec.ts
@@ -118,4 +118,33 @@ describe('AutomationExecutionsView (A3 admin runs view)', () => {
     await settle()
     expect(client.listAutomationRuns).toHaveBeenLastCalledWith(expect.objectContaining({ status: 'failed' }))
   })
+
+  it('drops a STALE detail response when a newer run is expanded (out-of-order race)', async () => {
+    const runA = { ...RUN_LIST, id: 'axe_A' }
+    const runB = { ...RUN_LIST, id: 'axe_B' }
+    const detailA = { ...RUN_DETAIL, id: 'axe_A', triggerEvent: { recordId: 'recA' } }
+    const detailB = { ...RUN_DETAIL, id: 'axe_B', triggerEvent: { recordId: 'recB' } }
+    const resolvers: Record<string, (v: AutomationRunView) => void> = {}
+    const client = makeClient({
+      listAutomationRuns: vi.fn().mockResolvedValue([runA, runB]),
+      getAutomationRun: vi.fn(
+        (id: string) => new Promise<AutomationRunView>((resolve) => { resolvers[id] = resolve }),
+      ),
+    })
+    mounted = mount(client)
+    await settle()
+    // Expand A, then B before A's detail resolves (both fetches now in flight).
+    ;(mounted.container.querySelector('[data-run-id="axe_A"]') as HTMLElement).click()
+    await nextTick()
+    ;(mounted.container.querySelector('[data-run-id="axe_B"]') as HTMLElement).click()
+    await nextTick()
+    // Resolve B (the current row) first, then A (now stale) LAST — out of order.
+    resolvers['axe_B'](detailB)
+    resolvers['axe_A'](detailA)
+    await settle()
+    // Detail must reflect B (current), never the stale A response that resolved last.
+    const trigger = mounted.container.querySelector('[data-field="trigger-event"]')?.textContent ?? ''
+    expect(trigger).toContain('recB')
+    expect(trigger).not.toContain('recA')
+  })
 })

--- a/apps/web/tests/AutomationExecutionsView.spec.ts
+++ b/apps/web/tests/AutomationExecutionsView.spec.ts
@@ -1,0 +1,121 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import AutomationExecutionsView from '../src/views/AutomationExecutionsView.vue'
+import { useLocale } from '../src/composables/useLocale'
+import type { AutomationRunView } from '../src/multitable/types'
+
+let mockIsAdmin = true
+vi.mock('../src/composables/useAuth', () => ({
+  useAuth: () => ({ hasAdminAccess: () => mockIsAdmin }),
+}))
+
+const RUN_LIST: AutomationRunView = {
+  id: 'axe_1',
+  ruleId: 'rule-1',
+  sheetId: 'sheet-a',
+  status: 'resolved',
+  statusLegacy: 'success',
+  triggeredBy: 'event',
+  triggeredAt: '2026-05-28T00:00:00.000Z',
+  finishedAt: '2026-05-28T00:00:01.000Z',
+  duration: 12,
+  error: null,
+  schemaVersion: 1,
+  steps: [
+    { id: 'axe_1:step:0', executionId: 'axe_1', stepKey: '0', status: 'resolved', upstreamJobId: null, result: { ok: true } },
+    { id: 'axe_1:step:1', executionId: 'axe_1', stepKey: '1', status: 'failed', upstreamJobId: 'axe_1:step:0', error: 'boom' },
+  ],
+}
+const RUN_DETAIL: AutomationRunView = {
+  ...RUN_LIST,
+  triggerEvent: { recordId: 'rec1', secret: 'Bearer abc.def.ghijklmnop12345' },
+  ruleSnapshot: { id: 'rule-1', name: 'Notify' },
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeClient(over: Record<string, any> = {}): any {
+  return {
+    listAutomationRuns: vi.fn().mockResolvedValue([RUN_LIST]),
+    getAutomationRun: vi.fn().mockResolvedValue(RUN_DETAIL),
+    ...over,
+  }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mount(client: any) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(AutomationExecutionsView, { client }) })
+  app.mount(container)
+  return { container, app }
+}
+
+// Flush pending microtasks (mock promise resolution) THEN the Vue render queue —
+// the view fires loadData() at setup, so a bare nextTick can race the fetch.
+async function settle() {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await nextTick()
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mounted: { container: HTMLElement; app: any } | null = null
+beforeEach(() => {
+  mockIsAdmin = true
+  useLocale().setLocale('en')
+})
+afterEach(() => {
+  if (mounted) {
+    mounted.app.unmount()
+    mounted.container.remove()
+    mounted = null
+  }
+})
+
+describe('AutomationExecutionsView (A3 admin runs view)', () => {
+  it('lists runs with the C1 status label (success → resolved) for admins', async () => {
+    const client = makeClient()
+    mounted = mount(client)
+    await settle()
+    expect(client.listAutomationRuns).toHaveBeenCalled()
+    expect(mounted.container.querySelector('[data-run-id="axe_1"]')).not.toBeNull()
+    expect(mounted.container.querySelector('[data-status="resolved"]')).not.toBeNull()
+    expect(mounted.container.textContent ?? '').toContain('resolved')
+  })
+
+  it('shows the admin-only notice and does NOT call the API when not admin', async () => {
+    mockIsAdmin = false
+    const client = makeClient()
+    mounted = mount(client)
+    await nextTick()
+    expect(mounted.container.querySelector('[data-denied="true"]')).not.toBeNull()
+    expect(client.listAutomationRuns).not.toHaveBeenCalled()
+  })
+
+  it('expanding a run fetches detail and renders C1 steps + redacted snapshot', async () => {
+    const client = makeClient()
+    mounted = mount(client)
+    await settle()
+    const row = mounted.container.querySelector('[data-run-id="axe_1"]') as HTMLElement
+    row.click()
+    await settle()
+    expect(client.getAutomationRun).toHaveBeenCalledWith('axe_1')
+    expect(mounted.container.querySelector('[data-detail="true"]')).not.toBeNull()
+    expect(mounted.container.querySelector('[data-field="step-error"]')?.textContent ?? '').toContain('boom')
+    const trigger = mounted.container.querySelector('[data-field="trigger-event"]')?.textContent ?? ''
+    expect(trigger).toContain('rec1')
+    // jsonView redacts secret-shaped values defensively
+    expect(trigger).not.toContain('abc.def.ghijklmnop12345')
+  })
+
+  it('passes the status filter through to the API', async () => {
+    const client = makeClient()
+    mounted = mount(client)
+    await settle()
+    const select = mounted.container.querySelector('[data-field="statusFilter"]') as HTMLSelectElement
+    select.value = 'failed'
+    select.dispatchEvent(new Event('change'))
+    ;(mounted.container.querySelector('[data-action="refresh"]') as HTMLElement).click()
+    await settle()
+    expect(client.listAutomationRuns).toHaveBeenLastCalledWith(expect.objectContaining({ status: 'failed' }))
+  })
+})


### PR DESCRIPTION
## What

Run-governance **A3** — an **admin-only, cross-sheet, read-only** "Automation Runs" view consuming the **A2** API (`GET /api/multitable/automation-executions` + `/:id`, `requireAdminRole`-gated). Renders the **C1 WorkflowJob** vocabulary natively (the A2 read shape is distinct from the legacy `AutomationExecution` log shape).

- **`views/AutomationExecutionsView.vue`** (new) — admin-gated via `useAuth().hasAdminAccess()` (shows an admin-only notice + **skips the fetch** when not admin); runs list + status/sheet filters; expandable detail = C1 steps + **redacted** `trigger_event`/`rule_snapshot` (`jsonView` defensively re-scrubs). **No retry** affordance (A4/A5 still gated).
- **`api/client.ts`**: `listAutomationRuns(filters)` + `getAutomationRun(id)`.
- **`types.ts`**: `WorkflowJobStatus` + `AutomationRunView` + `AutomationRunStepView` (the C1 read shape).
- **`meta-automation-labels.ts`**: `WorkflowJobStatus` labels (resolved/queued/suspended/rejected/errored) + `runs.*` view strings — through the i18n module (no inline bilingual).
- **`router/appRoutes.ts`**: `/admin/automation-executions`.

## Scope

Frontend read-only only. Consumes A2; **no backend change**; no retry. The admin-only boundary mirrors A2's `requireAdminRole` (owner picked admin-only in #1973).

## Tests / validation

`AutomationExecutionsView.spec` — **4/4**: C1 status render (`success→resolved`), admin-only gate **skips the fetch**, expand→detail fetch + C1 step render + **snapshot redaction** (secret-shaped value scrubbed), status-filter passthrough. `meta-automation-labels` + `MetaAutomationLogViewer` specs green. `vue-tsc` clean for these files.

> Note: the existing 13 `(string & {})` autocomplete idioms in `meta-automation-labels.ts` are pre-existing (on main) and outside the web `lint` script's file scope; this PR adds none.

🤖 Generated with [Claude Code](https://claude.com/claude-code)