### PR TITLE
fix(data-sources): A4 align public type contract with runtime

### DIFF
--- a/packages/core-backend/src/data-adapters/DataSourceManager.ts
+++ b/packages/core-backend/src/data-adapters/DataSourceManager.ts
@@ -2,15 +2,14 @@ import { EventEmitter } from 'eventemitter3'
 import type { Kysely } from 'kysely'
 import type { BaseDataAdapter, DataSourceConfig, QueryOptions, QueryResult, DbValue, WhereValue, ConnectionConfig, Credentials, AdapterOptions } from './BaseAdapter'
 import { PostgresAdapter } from './PostgresAdapter'
-import { MySQLAdapter } from './MySQLAdapter'
 import { HTTPAdapter } from './HTTPAdapter'
-import { MongoDBAdapter } from './MongoDBAdapter'
 import { encryptStoredSecretValue, decryptStoredSecretValue, isEncryptedSecretValue } from '../security/encrypted-secrets'
 
 // Credential fields that hold secrets and are encrypted at rest. Identifiers
 // like `username` are left as-is (matching the codebase's encrypt-secrets-only
 // convention).
 const SENSITIVE_CREDENTIAL_KEYS = ['password', 'apiKey', 'token']
+export const SUPPORTED_DATA_SOURCE_TYPES = ['postgresql', 'postgres', 'http'] as const
 
 type AdapterConstructor = new (config: DataSourceConfig) => BaseDataAdapter
 
@@ -89,8 +88,12 @@ export class DataSourceManager extends EventEmitter {
         .where('deleted_at' as never, 'is', null as never)
         .execute() as DataSourceRecord[]
 
+      let loadedCount = 0
       for (const record of records) {
         try {
+          if (!this.adapterTypes.has(record.type.toLowerCase())) {
+            throw new Error(`Unsupported persisted data source type: ${record.type}`)
+          }
           const config = this.recordToConfig(record)
           await this.addDataSourceInternal(config, false) // Don't persist again
           // Ownership lives on the DB record, not in config (recordToConfig strips it)
@@ -104,12 +107,14 @@ export class DataSourceManager extends EventEmitter {
               console.error(`[DataSourceManager] Auto-connect failed for ${config.id}:`, err)
             })
           }
+          loadedCount += 1
         } catch (err) {
           console.error(`[DataSourceManager] Failed to load data source ${record.id}:`, err)
         }
       }
 
-      console.log(`[DataSourceManager] Loaded ${records.length} data sources from database`)
+      const skippedCount = records.length - loadedCount
+      console.log(`[DataSourceManager] Loaded ${loadedCount} data sources from database${skippedCount > 0 ? ` (${skippedCount} skipped)` : ''}`)
     } catch (err) {
       // Table might not exist yet
       console.warn('[DataSourceManager] Could not load from database:', err)
@@ -201,12 +206,10 @@ export class DataSourceManager extends EventEmitter {
   }
 
   private registerDefaultAdapters(): void {
-    // Cast adapters to AdapterConstructor - their pool property visibility differs but functionality is identical
+    // A4: public support is intentionally narrowed to the verified runtime set.
     this.registerAdapterType('postgresql', PostgresAdapter as unknown as AdapterConstructor)
     this.registerAdapterType('postgres', PostgresAdapter as unknown as AdapterConstructor)
-    this.registerAdapterType('mysql', MySQLAdapter as unknown as AdapterConstructor)
     this.registerAdapterType('http', HTTPAdapter as unknown as AdapterConstructor)
-    this.registerAdapterType('mongodb', MongoDBAdapter as unknown as AdapterConstructor)
   }
 
   registerAdapterType(type: string, adapterClass: AdapterConstructor): void {

--- a/packages/core-backend/src/db/migrations/20251206000001_create_data_sources_table.ts
+++ b/packages/core-backend/src/db/migrations/20251206000001_create_data_sources_table.ts
@@ -24,7 +24,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
         col.primaryKey().defaultTo(sql`gen_random_uuid()::text`)
       )
       .addColumn('name', 'text', col => col.notNull())
-      .addColumn('type', 'text', col => col.notNull()) // postgres, mysql, mongodb, http, redis, elasticsearch
+      .addColumn('type', 'text', col => col.notNull()) // persisted data-source type key; runtime support is enforced by the app layer
       .addColumn('description', 'text')
       // Connection config (encrypted sensitive fields like password)
       .addColumn('config', 'jsonb', col => col.notNull())

--- a/packages/core-backend/src/routes/data-sources.ts
+++ b/packages/core-backend/src/routes/data-sources.ts
@@ -2,7 +2,7 @@
  * Data Sources REST API Routes
  *
  * Provides API endpoints for managing external data source connections
- * including PostgreSQL, MySQL, MongoDB, HTTP/REST APIs, etc.
+ * including PostgreSQL and HTTP/REST APIs.
  *
  * V2 Features:
  * - Zod schema validation for all requests
@@ -16,7 +16,7 @@ import type { Kysely } from 'kysely'
 import { z } from 'zod'
 import { rbacGuard } from '../rbac/rbac'
 import { auditLog } from '../audit/audit'
-import { DataSourceManager } from '../data-adapters/DataSourceManager'
+import { DataSourceManager, SUPPORTED_DATA_SOURCE_TYPES } from '../data-adapters/DataSourceManager'
 import type { DataSourceConfig, QueryOptions } from '../data-adapters/BaseAdapter'
 
 // Zod schemas for request validation
@@ -25,7 +25,7 @@ const ConnectionConfigSchema = z.record(z.union([z.string(), z.number(), z.boole
 const DataSourceCreateSchema = z.object({
   id: z.string().min(1, 'ID is required'),
   name: z.string().min(1, 'Name is required'),
-  type: z.enum(['postgresql', 'postgres', 'mysql', 'mongodb', 'http', 'redis', 'elasticsearch'], {
+  type: z.enum(SUPPORTED_DATA_SOURCE_TYPES, {
     errorMap: () => ({ message: 'Unsupported data source type' })
   }),
   connection: ConnectionConfigSchema,

--- a/packages/core-backend/tests/unit/data-source-scope.test.ts
+++ b/packages/core-backend/tests/unit/data-source-scope.test.ts
@@ -109,11 +109,11 @@ function statefulFakeDb() {
   }
 }
 
-function dbRecord(id: string, ownerId: string, workspaceId: string | null) {
+function dbRecord(id: string, ownerId: string, workspaceId: string | null, type = 'postgres') {
   return {
     id,
     name: id,
-    type: 'postgres',
+    type,
     description: null,
     config: { connection: {} },
     status: 'disconnected',
@@ -171,6 +171,17 @@ describe('DataSourceManager ownership scope (A0.1)', () => {
     expect(m.getScope('b1')).toEqual({ ownerId: 'bob', workspaceId: 'ws-b' })
     expect(() => m.assertAccess('a1', 'bob')).toThrow(/not found/)
     expect(m.listDataSources({ ownerId: 'bob' }).map((s) => s.id)).toEqual(['b1'])
+  })
+
+  it('skips persisted rows whose type is no longer in the supported runtime set', async () => {
+    const m = new DataSourceManager()
+    await m.initialize(fakeDb([
+      dbRecord('pg-ok', 'alice', null, 'postgres'),
+      dbRecord('legacy-mysql', 'alice', null, 'mysql'),
+    ]) as never)
+    expect(() => m.getDataSource('pg-ok')).not.toThrow()
+    expect(() => m.getDataSource('legacy-mysql')).toThrow(/not found/)
+    expect(m.listDataSources({ ownerId: 'alice' }).map((s) => s.id)).toEqual(['pg-ok'])
   })
 })
 
@@ -234,6 +245,18 @@ describe('data-sources route ownership scope (A0.1)', () => {
     currentUser = undefined
     const res = await request(app).post('/api/data-sources').send(pgConfig('ds-unauth'))
     expect(res.status).toBe(401)
+  })
+
+  it('rejects unsupported create types at validation time', async () => {
+    currentUser = admin('alice4')
+    for (const unsupportedType of ['mysql', 'mongodb', 'redis', 'elasticsearch']) {
+      const res = await request(app)
+        .post('/api/data-sources')
+        .send({ ...pgConfig(`bad-${unsupportedType}`), type: unsupportedType })
+      expect(res.status).toBe(400)
+      expect(res.body.error.code).toBe('VALIDATION_ERROR')
+      expect(res.body.error.message).toContain('Unsupported data source type')
+    }
   })
 })
 


### PR DESCRIPTION
## Summary
- Narrow the public data-source support matrix to the runtime-verified set: `postgresql`, `postgres`, and `http`.
- Introduce a single `SUPPORTED_DATA_SOURCE_TYPES` source of truth and reuse it in both the create-route Zod contract and the manager's default adapter registration.
- Reject unsupported create requests (`mysql`, `mongodb`, `redis`, `elasticsearch`) at validation time instead of accepting them and failing later at runtime.
- Skip persisted legacy rows whose `type` is no longer in the supported runtime set, logging the skip explicitly instead of loading a broken adapter state.
- Clarify the `data_sources.type` migration comment so it no longer implies a broader guaranteed runtime matrix than the app actually supports.

## Intentional contract tightening
This is the final Lane A A4 alignment slice. It is intentionally a contract reduction, not a "add more adapters" slice:
- public create support is now only the end-to-end verified set;
- legacy unsupported rows are preserved in storage but skipped on load until they are migrated or deleted;
- adapter files for other types remain in-tree but are not part of the default supported runtime surface.

## Out of scope
- Adding new runtime support for `mysql`, `mongodb`, `redis`, or `elasticsearch`
- Lane B MSSQL connector work
- Lane C deployment work

## Test plan
- [x] `vitest run tests/unit/data-source-scope.test.ts tests/unit/data-source-readonly.test.ts tests/unit/data-source-credential-encryption.test.ts`
- [x] `tsc --noEmit`
- [x] `eslint src/data-adapters/DataSourceManager.ts src/routes/data-sources.ts src/db/migrations/20251206000001_create_data_sources_table.ts`
