### PR TITLE
docs(integration): DF-N2-2 provenance runtime — design (docs-only, gated 2a/2b/2c)

### DIFF
--- a/docs/development/data-factory-df-n2-2-provenance-runtime-design-20260528.md
+++ b/docs/development/data-factory-df-n2-2-provenance-runtime-design-20260528.md
@@ -1,0 +1,82 @@
+# Data Factory DF-N2-2 — provenance runtime (design, 2026-05-28)
+
+**Docs-only.** Execution design for the **runtime** slice of DF-N2 (per-record provenance), splitting
+it into three gated sub-PRs — **DF-N2-2a / 2b / 2c** — instead of one large runtime change. **Not a
+build authorization:** each sub-PR is a separate explicit opt-in behind the 阶段二 unlock.
+
+## Basis (build on — do NOT redesign)
+
+- **#1839** `data-factory-nifi-inspired-run-provenance-design` — the `ProvenanceEvent` model + DF-N0..N4
+  phasing; the **11 event types** are fixed there (`source_read` / `row_imported` / `row_edited` /
+  `mapping_applied` / `validation_failed` / `dry_run_previewed` / `target_write_attempted` /
+  `target_write_succeeded` / `target_write_failed` / `row_retried` / `row_exported`).
+- **#1882** (merged) — `plugins/plugin-integration-core/lib/provenance-contracts.cjs` (enum-strict
+  normalizer + OpenAPI parity) is the **runtime's contract source**: DF-N2-2 validates/normalizes
+  through it and adds **no new event shape**.
+- **#1877** `data-factory-stage2-execution-plan` — DF-N2 is the first unlock-day move; this expands its
+  DF-N2-2 row.
+- **#1880** NiFi bounded benchmark — validated **JSONB-on-existing-tables** (NiFi's repo machinery is
+  over-engineering at our scale); the one capability NiFi has that we lack is a **retention/aging
+  policy** (designed below); `dry_run` + `validation_failed` provenance is our moat.
+- **`data-factory-df-n2-task-checklist-20260526.md`** — the task-level checklist; this design
+  sub-splits its **DF-N2-2 (runtime)** row into 2a/2b/2c and adds retention/aging + the redaction
+  pre-storage gate.
+
+## Storage decision (locked)
+
+**JSONB on existing tables + a by-`rowId` view — NO new event table** (#1874). A JSONB lineage column
+on the existing run / `integration_run_log` surface, events tagged by `rowId`; an
+`integration_provenance_by_row` view unnests across runs (joining `integration_dead_letters` /
+`integration_exceptions`). No new write-path table.
+
+## Redaction — a pre-storage HARD GATE (not optional)
+
+Provenance is **persisted and queryable**, so any secret leak is **durable**. Every event field is
+value-scrubbed via `scrubSecretStringValue` **before** it is written — presence flags + safe ids only;
+never token / password / connection-string / customer secret / raw error text. This **reuses the same
+`scrubSecretStringValue` that the in-flight `fix/df-run-provenance-hardening` is strengthening** (it
+value-scrubs dead-letter `errorMessage`); **DF-N2-2b should land after that hardening** so persisted
+provenance gets the strengthened scrub, and must not re-implement it. A stored-event redaction test (a
+token planted in `attrs` → stripped) is a 2b exit gate.
+
+## Retention / aging (the #1880 gap — REQUIRED here)
+
+NiFi has a provenance retention/aging policy we currently lack; unbounded per-row events + cross-run
+accumulation would bloat the JSONB surface. DF-N2-2 must define:
+- **Per-row cap** (already in the checklist): a per-row event count / size cap, mirroring the
+  `targetWriteSummaries` cap-50 discipline (count-capped with an overflow marker; oldest events trimmed).
+- **Aging** (new): a documented retention window (default: keep ≤ N days / ≤ M runs per `rowId`) and a
+  prune path. The **prune job itself is out of DF-N2-2 scope**, but the JSONB shape + the window knob
+  MUST be designed now so aging is possible later **without a further migration**.
+
+## Sub-split (each a SEPARATE gated opt-in)
+
+- **DF-N2-2a — storage / migration** (schema only, no behavior): the JSONB lineage column + the
+  `integration_provenance_by_row` view, via integration-core's own SQL migration (guarded by
+  `migration-sql.test.cjs`); back-compat (existing runs → null/empty; the view tolerates it). *Exit:
+  migration green, zero runtime behavior change.*
+- **DF-N2-2b — runtime write** (the redaction gate lives here): wire `pipeline-runner.cjs` to append a
+  **redacted** `ProvenanceEvent` (validated through `provenance-contracts.cjs`) at each lifecycle
+  point; per-row capacity guard; redaction hard gate (reuses the hardened `scrubSecretStringValue`).
+  *Exit: per-step events appended, redacted, capped; replay does not duplicate events.*
+- **DF-N2-2c — read surface**: a by-`rowId` GET route with **OpenAPI parity + RBAC read permission**,
+  returning the cross-run timeline; a **wire-vs-fixture route test** (the lineage field survives the
+  real route serialization). *Exit: per-row cross-run lineage queryable, read-only.* (Frontend timeline
+  is DF-N2-3, separate.)
+
+## Acceptance (impl-time, per sub-PR)
+
+- **2a:** `migration-sql.test.cjs` green; the view tolerates empty/null.
+- **2b:** stored-event redaction test (no secret stored); per-step append test; replay-no-duplicate;
+  per-row capacity-cap test.
+- **2c:** by-`rowId` cross-run timeline test (seed 2 runs for the same `rowId` → ordered); RBAC
+  read-permission test; **wire-vs-fixture round-trip** (lineage survives the real route — the
+  reachability discipline reinforced by #1970).
+
+## Boundaries
+
+Docs-only design; **no** runtime / migration / route code here. Each of 2a / 2b / 2c is a **separate
+explicit opt-in** behind the 阶段二 unlock, in order (2a → 2b → 2c; 2b depends on 2a's column, 2c on
+2b's events). No K3 write, no connector behavior, no new event shape (uses #1882's contract). **2b is
+gated on the in-flight redaction value-scrub (`fix/df-run-provenance-hardening`) landing first.**
+DF-N2-3 (frontend lineage timeline) stays a separate slice after 2c.

--- a/docs/development/data-factory-df-n2-2-provenance-runtime-design-20260528.md
+++ b/docs/development/data-factory-df-n2-2-provenance-runtime-design-20260528.md
@@ -24,34 +24,50 @@ build authorization:** each sub-PR is a separate explicit opt-in behind the 阶�
 
 ## Storage decision (locked)
 
-**JSONB on existing tables + a by-`rowId` view — NO new event table** (#1874). A JSONB lineage column
-on the existing run / `integration_run_log` surface, events tagged by `rowId`; an
-`integration_provenance_by_row` view unnests across runs (joining `integration_dead_letters` /
-`integration_exceptions`). No new write-path table.
+**JSONB on existing tables + a by-`rowId` view — NO new event table** (#1874). The DB anchor is the
+existing `integration_runs` table (see `057_create_integration_core_tables.sql`), not the staging
+multitable objects named `integration_run_log` / `integration_exceptions`. Add a JSONB lineage column
+to `integration_runs`; each event is tagged by `rowId`. An `integration_provenance_by_row` view unnests
+those run-local event arrays across runs. If the read route later needs dead-letter context, join only
+real DB tables such as `integration_dead_letters`; do not make the provenance view depend on staging
+sheet object names. No new write-path table.
 
 ## Redaction — a pre-storage HARD GATE (not optional)
 
 Provenance is **persisted and queryable**, so any secret leak is **durable**. Every event field is
 value-scrubbed via `scrubSecretStringValue` **before** it is written — presence flags + safe ids only;
-never token / password / connection-string / customer secret / raw error text. This **reuses the same
-`scrubSecretStringValue` that the in-flight `fix/df-run-provenance-hardening` is strengthening** (it
-value-scrubs dead-letter `errorMessage`); **DF-N2-2b should land after that hardening** so persisted
-provenance gets the strengthened scrub, and must not re-implement it. A stored-event redaction test (a
-token planted in `attrs` → stripped) is a 2b exit gate.
+never token / password / connection-string / customer secret / raw error text. Reuse the shared
+`scrubSecretStringValue`; do not re-implement a provenance-local redactor. Current main already carries
+the hardening chain this depends on (#1895 value-scrub for token/API-key/JWT shapes, #1898 shared
+http-route redaction, #1917 dead-letter `errorMessage` value-scrub), so 2b's gate is to **prove** that
+shared scrubber covers stored provenance values, including query-string secrets such as
+`?token=` / `?access_token=` / `?api_key=`. A stored-event redaction test (a token planted in `attrs` →
+stripped before persistence) is a 2b exit gate.
 
 ## Retention / aging (the #1880 gap — REQUIRED here)
 
 NiFi has a provenance retention/aging policy we currently lack; unbounded per-row events + cross-run
-accumulation would bloat the JSONB surface. DF-N2-2 must define:
-- **Per-row cap** (already in the checklist): a per-row event count / size cap, mirroring the
-  `targetWriteSummaries` cap-50 discipline (count-capped with an overflow marker; oldest events trimmed).
-- **Aging** (new): a documented retention window (default: keep ≤ N days / ≤ M runs per `rowId`) and a
-  prune path. The **prune job itself is out of DF-N2-2 scope**, but the JSONB shape + the window knob
-  MUST be designed now so aging is possible later **without a further migration**.
+accumulation would bloat the JSONB surface. Because events live inside historical `integration_runs`
+JSONB, retention must avoid rewriting old run rows per `rowId`.
+
+DF-N2-2 must define:
+- **Write-time per-run/per-row cap** (already in the checklist): while appending events to the current
+  run, cap each row's event count / JSON size, mirroring the `targetWriteSummaries` cap-50 discipline
+  (count-capped with an overflow marker; oldest events in the current run's row bucket trimmed before
+  the run is finalized).
+- **Run-level aging window** (new): a documented retention window based on `integration_runs.created_at`
+  / `finished_at` (default: keep <= N days or <= M newest runs per pipeline). The future prune job can
+  delete/archive old run rows or clear old run-level provenance arrays by run scope; it must not require
+  scanning every `rowId` across historical JSONB arrays.
+- **Read-time windowing**: the by-`rowId` route must accept/own a bounded run/time window so long-lived
+  rows do not force unbounded cross-run scans. The prune job itself is out of DF-N2-2 scope, but the JSONB
+  shape + run-level window knob must be designed now so aging is possible later **without a further
+  migration**.
 
 ## Sub-split (each a SEPARATE gated opt-in)
 
-- **DF-N2-2a — storage / migration** (schema only, no behavior): the JSONB lineage column + the
+- **DF-N2-2a — storage / migration** (schema only, no behavior): the `integration_runs` JSONB lineage
+  column + the
   `integration_provenance_by_row` view, via integration-core's own SQL migration (guarded by
   `migration-sql.test.cjs`); back-compat (existing runs → null/empty; the view tolerates it). *Exit:
   migration green, zero runtime behavior change.*
@@ -78,5 +94,5 @@ accumulation would bloat the JSONB surface. DF-N2-2 must define:
 Docs-only design; **no** runtime / migration / route code here. Each of 2a / 2b / 2c is a **separate
 explicit opt-in** behind the 阶段二 unlock, in order (2a → 2b → 2c; 2b depends on 2a's column, 2c on
 2b's events). No K3 write, no connector behavior, no new event shape (uses #1882's contract). **2b is
-gated on the in-flight redaction value-scrub (`fix/df-run-provenance-hardening`) landing first.**
-DF-N2-3 (frontend lineage timeline) stays a separate slice after 2c.
+gated on a stored-provenance redaction proof against the already-shared scrubber**, not on a new
+redaction implementation. DF-N2-3 (frontend lineage timeline) stays a separate slice after 2c.

--- a/docs/development/data-factory-df-n2-task-checklist-20260526.md
+++ b/docs/development/data-factory-df-n2-task-checklist-20260526.md
@@ -15,10 +15,11 @@ DF-N2 is the **recommended first move** on unlock day (lowest risk, zero new con
 - ▸ Exit: contract frozen, zero runtime change
 
 ## DF-N2-2 — runtime + migration 〔lane: runtime〕
-- [ ] 🔒 Pick storage: a JSONB lineage column on the existing run / `integration_run_log` surface, events tagged by `rowId` — **no new write-path table**
-- [ ] 🔒 Plugin SQL migration (integration-core's own SQL, guarded by `migration-sql.test.cjs`): add the JSONB column + an `integration_provenance_by_row` **view** (unnest across runs, join `integration_dead_letters` / `integration_exceptions`)
-- [ ] 🔒 Wire `lib/pipeline-runner.cjs` to append a **redacted** event at each lifecycle point (reuse `sanitizeIntegrationPayload`)
-- [ ] 🔒 Capacity guard: per-row event count / size cap (mirror the `targetWriteSummaries` cap-50 discipline)
+- [ ] 🔒 Pick storage: a JSONB lineage column on the existing DB table `integration_runs`, events tagged by `rowId` — **no new write-path table**; `integration_run_log` / `integration_exceptions` are staging multitable objects, not the DB storage anchor
+- [ ] 🔒 Plugin SQL migration (integration-core's own SQL, guarded by `migration-sql.test.cjs`): add the JSONB column + an `integration_provenance_by_row` **view** (unnest across `integration_runs`; optional context may join real DB tables such as `integration_dead_letters`, not staging object names)
+- [ ] 🔒 Wire `lib/pipeline-runner.cjs` to append a **redacted** event at each lifecycle point (normalize through `provenance-contracts.cjs`; prove the shared scrubber removes secret-shaped values before persistence)
+- [ ] 🔒 Capacity guard: per-run/per-row event count / size cap while writing the current run (mirror the `targetWriteSummaries` cap-50 discipline; do not prune old run JSONB by scanning every historical `rowId`)
+- [ ] 🔒 Retention/aging: run-level retention window (`integration_runs.created_at` / `finished_at`, <= N days or <= M newest runs per pipeline) + bounded read-window parameters on the by-`rowId` route
 - [ ] 🔒 Back-compat: existing runs have no events → the view tolerates empty/null
 - [ ] 🔒 Tests: redaction (stored events carry no sensitive field) · correct event appended per step · **by-`rowId` cross-run timeline** (seed 2 runs for the same rowId, assert ordered) · **real-wire round-trip** (the lineage field survives real API serialization — wire-vs-fixture guard) · `migration-sql.test.cjs` green · replay does not wrongly duplicate events
 - ▸ Exit: per-record events queryable across runs, redacted

--- a/docs/development/data-factory-df-n2-task-checklist-20260526.md
+++ b/docs/development/data-factory-df-n2-task-checklist-20260526.md
@@ -22,6 +22,7 @@ DF-N2 is the **recommended first move** on unlock day (lowest risk, zero new con
 - [ ] 🔒 Back-compat: existing runs have no events → the view tolerates empty/null
 - [ ] 🔒 Tests: redaction (stored events carry no sensitive field) · correct event appended per step · **by-`rowId` cross-run timeline** (seed 2 runs for the same rowId, assert ordered) · **real-wire round-trip** (the lineage field survives real API serialization — wire-vs-fixture guard) · `migration-sql.test.cjs` green · replay does not wrongly duplicate events
 - ▸ Exit: per-record events queryable across runs, redacted
+- ▸ **Design (sub-split 2a storage / 2b runtime-write / 2c read-route + retention/aging + redaction pre-storage gate):** `data-factory-df-n2-2-provenance-runtime-design-20260528.md` — each sub-PR a separate opt-in.
 
 ## DF-N2-3 — frontend 〔lane: frontend〕
 - [ ] 🔒 `apps/web/src/services/integration/workbench.ts`: read-only types + by-`rowId` provenance read (client over the new GET route)


### PR DESCRIPTION
## DF-N2-2 provenance runtime — design (docs-only, for boundary review)

Docs-only execution design for the DF-N2 **runtime** slice, split into gated sub-PRs. **Not a build authorization** — each sub-PR is a separate explicit opt-in behind the 阶段二 unlock.

### Boundaries (as locked)
- **docs-only** — no runtime / migration / route code.
- **Builds on, doesn't redesign:** #1882 (merged `provenance-contracts.cjs` = contract source), #1839 (ProvenanceEvent model + 11 event types), #1877 (阶段二 plan), #1880 (NiFi benchmark), + the existing `data-factory-df-n2-task-checklist-20260526.md`.
- **JSONB-on-existing-tables**, no new event table (#1874).
- **Storage anchor corrected:** real DB table is `integration_runs`; `integration_run_log` / `integration_exceptions` are staging multitable objects, not DB storage anchors.
- **Retention/aging corrected:** write-time per-run/per-row cap + run-level retention window + bounded read window; no per-rowId pruning by rewriting historical JSONB run rows.
- **Redaction as a pre-storage hard gate:** every event value-scrubbed through the shared scrubber before write; current main already carries #1895/#1898/#1917 redaction hardening, so 2b proves it rather than waiting on a phantom in-flight branch.
- **by-`rowId` GET + RBAC + wire-vs-fixture test** = DF-N2-2c impl acceptance.
- **split into 2a / 2b / 2c**, each a separate opt-in (not one big runtime).

### The split
- **2a** storage/migration (JSONB column on `integration_runs` + `integration_provenance_by_row` view; `migration-sql.test.cjs`; back-compat).
- **2b** runtime write (`pipeline-runner` appends redacted events via the #1882 contract; capacity guard; redaction gate).
- **2c** read surface (by-`rowId` GET + RBAC + OpenAPI parity + wire-vs-fixture round-trip).

### Review patches folded in
- Fixed table naming inconsistency (`integration_runs`, not `integration_run_log`).
- Avoided inefficient per-rowId historical JSONB retention; moved to run-level aging + bounded read windows.
- Replaced stale `fix/df-run-provenance-hardening` gating with merged #1895/#1898/#1917 redaction chain + stored-event proof gate.

### Refs
#1882 / #1839 / #1877 / #1880 / `df-n2-task-checklist-20260526.md`. Closes none.
