### PR TITLE
feat(attendance): show resolved labels for group members

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -3168,14 +3168,31 @@
                         <table class="attendance__table">
                           <thead>
                             <tr>
-                              <th>{{ tr('User ID', '用户 ID') }}</th>
+                              <th>{{ tr('Member', '成员') }}</th>
                               <th>{{ tr('Joined', '加入时间') }}</th>
                               <th>{{ tr('Actions', '操作') }}</th>
                             </tr>
                           </thead>
                           <tbody>
                             <tr v-for="member in attendanceGroupMembers" :key="member.id">
-                              <td>{{ member.userId }}</td>
+                              <td>
+                                <span class="attendance__group-member-identity" data-attendance-group-member-identity>
+                                  <strong
+                                    v-if="attendanceGroupMemberPrimaryLabel(member.userId)"
+                                    data-attendance-group-member-label
+                                  >
+                                    {{ attendanceGroupMemberPrimaryLabel(member.userId) }}
+                                  </strong>
+                                  <span data-attendance-group-member-user-id>{{ member.userId }}</span>
+                                  <small
+                                    v-if="attendanceGroupMemberSecondaryLabel(member.userId)"
+                                    class="attendance__field-hint"
+                                    data-attendance-group-member-secondary
+                                  >
+                                    {{ attendanceGroupMemberSecondaryLabel(member.userId) }}
+                                  </small>
+                                </span>
+                              </td>
                               <td>{{ formatDateTime(member.createdAt ?? null) }}</td>
                               <td class="attendance__table-actions">
                                 <button
@@ -6195,6 +6212,8 @@ interface AttendanceGroupMember {
   createdAt?: string
 }
 
+type AttendanceGroupMemberResolvedUsers = Record<string, AttendanceAdminBatchResolveItem>
+
 type AttendanceGroupSummaryAction = {
   key: string
   label: string
@@ -7876,6 +7895,7 @@ const attendanceGroupMemberUserIds = ref('')
 const attendanceGroupPendingMemberIds = ref<string[]>([])
 const attendanceGroupMemberDuplicateNotice = ref('')
 const attendanceGroupMemberTotal = ref(0)
+const attendanceGroupMemberResolvedUsers = ref<AttendanceGroupMemberResolvedUsers>({})
 const payrollTemplateEditingId = ref<string | null>(null)
 const payrollCycleEditingId = ref<string | null>(null)
 const payrollCycleSummary = ref<AttendanceSummary | null>(null)
@@ -7917,6 +7937,56 @@ const attendanceGroupMemberCountLabel = computed(() => {
   if (count === 1) return tr('1 member', '1 位成员')
   return tr(`${count} members`, `${count} 位成员`)
 })
+
+function normalizeAttendanceGroupMemberResolvedUsers(payload: any, requestedUserIds: string[]): AttendanceGroupMemberResolvedUsers {
+  const requested = new Set(requestedUserIds)
+  const itemsRaw = Array.isArray(payload?.items) ? payload.items : []
+  const resolved: AttendanceGroupMemberResolvedUsers = {}
+
+  for (const raw of itemsRaw) {
+    if (!raw || typeof raw !== 'object') continue
+    const id = String((raw as any).id || '').trim()
+    if (!id || !requested.has(id) || resolved[id]) continue
+    resolved[id] = {
+      id,
+      email: String((raw as any).email || ''),
+      name: (raw as any).name === null || (raw as any).name === undefined ? null : String((raw as any).name),
+      is_active: (raw as any).is_active === false ? false : true,
+    }
+  }
+
+  return resolved
+}
+
+function attendanceGroupMemberResolverUserIds(members: AttendanceGroupMember[]): string[] {
+  const seen = new Set<string>()
+  const userIds: string[] = []
+  for (const member of members) {
+    const userId = String(member.userId || '').trim()
+    if (!isUuid(userId) || seen.has(userId)) continue
+    seen.add(userId)
+    userIds.push(userId)
+  }
+  return userIds
+}
+
+function attendanceGroupMemberPrimaryLabel(userId: string): string {
+  const item = attendanceGroupMemberResolvedUsers.value[userId]
+  if (!item) return ''
+  return item.name?.trim() || item.email.trim() || ''
+}
+
+function attendanceGroupMemberSecondaryLabel(userId: string): string {
+  const item = attendanceGroupMemberResolvedUsers.value[userId]
+  if (!item) return ''
+  const primary = attendanceGroupMemberPrimaryLabel(userId)
+  const parts: string[] = []
+  const email = item.email.trim()
+  if (email && email !== primary) parts.push(email)
+  if (!item.is_active) parts.push(tr('Inactive', '已停用'))
+  return parts.join(' · ')
+}
+
 const attendanceGroupSummaryCards = computed<AttendanceGroupSummaryCard[]>(() => {
   const groupSaved = Boolean(attendanceGroupEditingId.value)
   const ruleSetName = groupSaved
@@ -15694,6 +15764,7 @@ function resetAttendanceGroupForm() {
   attendanceGroupMemberGroupId.value = ''
   attendanceGroupMembers.value = []
   attendanceGroupMemberTotal.value = 0
+  attendanceGroupMemberResolvedUsers.value = {}
   resetAttendanceGroupMemberDraft()
 }
 
@@ -15709,6 +15780,7 @@ function editAttendanceGroup(item: AttendanceGroup) {
   if (groupChanged) {
     attendanceGroupMembers.value = []
     attendanceGroupMemberTotal.value = 0
+    attendanceGroupMemberResolvedUsers.value = {}
     resetAttendanceGroupMemberDraft()
   }
 }
@@ -15821,6 +15893,7 @@ async function loadAttendanceGroupMembers() {
   if (!groupId) {
     attendanceGroupMembers.value = []
     attendanceGroupMemberTotal.value = 0
+    attendanceGroupMemberResolvedUsers.value = {}
     return
   }
   attendanceGroupMemberLoading.value = true
@@ -15838,10 +15911,43 @@ async function loadAttendanceGroupMembers() {
     const items = Array.isArray(data.data?.items) ? data.data.items : []
     attendanceGroupMembers.value = items
     attendanceGroupMemberTotal.value = Number(data.data?.total ?? items.length) || items.length
+    void resolveAttendanceGroupMemberLabels(groupId, items)
   } catch (error: any) {
     setStatus(readErrorMessage(error, tr('Failed to load group members', '加载分组成员失败')), 'error')
   } finally {
     attendanceGroupMemberLoading.value = false
+  }
+}
+
+async function resolveAttendanceGroupMemberLabels(groupId: string, members: AttendanceGroupMember[]) {
+  const userIds = attendanceGroupMemberResolverUserIds(members)
+  if (userIds.length === 0) {
+    if (attendanceGroupMemberGroupId.value === groupId) {
+      attendanceGroupMemberResolvedUsers.value = {}
+    }
+    return
+  }
+
+  try {
+    const response = await apiFetch('/api/attendance-admin/users/batch/resolve', {
+      method: 'POST',
+      body: JSON.stringify({ userIds }),
+    })
+    if (attendanceGroupMemberGroupId.value !== groupId) return
+    if (response.status === 403 || response.status === 404) {
+      attendanceGroupMemberResolvedUsers.value = {}
+      return
+    }
+    const data = await response.json().catch(() => null)
+    if (!response.ok || !data?.ok) {
+      attendanceGroupMemberResolvedUsers.value = {}
+      return
+    }
+    attendanceGroupMemberResolvedUsers.value = normalizeAttendanceGroupMemberResolvedUsers(data.data, userIds)
+  } catch {
+    if (attendanceGroupMemberGroupId.value === groupId) {
+      attendanceGroupMemberResolvedUsers.value = {}
+    }
   }
 }
 
@@ -18691,6 +18797,17 @@ const holidaySectionBindings = {
   font-size: 14px;
   line-height: 1;
   padding: 0;
+}
+
+.attendance__group-member-identity {
+  display: grid;
+  gap: 3px;
+  min-width: 0;
+}
+
+.attendance__group-member-identity strong {
+  color: #111827;
+  font-size: 13px;
 }
 
 .attendance__group-sticky-actions {

--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -244,9 +244,30 @@ describe('Attendance admin anchor navigation', () => {
   })
 
   it('stages attendance group members before posting unique pending IDs', async () => {
+    const existingMemberUserId = '11111111-1111-4111-8111-111111111111'
     const postBodies: unknown[] = []
+    const resolveBodies: unknown[] = []
     vi.mocked(apiFetch).mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input.toString()
+      if (url === '/api/attendance-admin/users/batch/resolve') {
+        resolveBodies.push(JSON.parse(String(init?.body || '{}')))
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            requested: 1,
+            items: [
+              {
+                id: existingMemberUserId,
+                email: 'alice.member@example.com',
+                name: 'Alice Member',
+                is_active: true,
+              },
+            ],
+            missingUserIds: [],
+            inactiveUserIds: [],
+          },
+        })
+      }
       if (url.startsWith('/api/admin/users')) {
         return jsonResponse(200, {
           ok: true,
@@ -291,7 +312,7 @@ describe('Attendance admin anchor navigation', () => {
           ok: true,
           data: {
             items: [
-              { id: 'member-1', groupId: 'group-a', userId: 'user-1', createdAt: '2026-05-27T08:00:00.000Z' },
+              { id: 'member-1', groupId: 'group-a', userId: existingMemberUserId, createdAt: '2026-05-27T08:00:00.000Z' },
             ],
             total: 25,
           },
@@ -313,11 +334,15 @@ describe('Attendance admin anchor navigation', () => {
     const groupsAnchor = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-groups"]')
     expect(groupsAnchor).toBeTruthy()
     groupsAnchor!.click()
-    await flushUi(4)
+    await flushUi(8)
 
     const people = container!.querySelector<HTMLElement>('[data-attendance-group-people]')
     expect(people).toBeTruthy()
     expect(people!.querySelector('[data-attendance-group-member-count]')?.textContent).toContain('Showing 1 of 25 members')
+    expect(resolveBodies.at(-1)).toEqual({ userIds: [existingMemberUserId] })
+    expect(people!.querySelector('[data-attendance-group-member-label]')?.textContent).toContain('Alice Member')
+    expect(people!.querySelector('[data-attendance-group-member-user-id]')?.textContent).toContain(existingMemberUserId)
+    expect(people!.querySelector('[data-attendance-group-member-secondary]')?.textContent).toContain('alice.member@example.com')
 
     const userSelect = people!.querySelector<HTMLSelectElement>('.attendance__user-picker select')
     expect(userSelect).toBeTruthy()
@@ -354,7 +379,7 @@ describe('Attendance admin anchor navigation', () => {
 
     const bulkInput = people!.querySelector<HTMLTextAreaElement>('#attendance-group-member-user-ids')
     expect(bulkInput).toBeTruthy()
-    bulkInput!.value = 'user-2, user-3\nuser-1'
+    bulkInput!.value = `user-2, user-3\n${existingMemberUserId}`
     bulkInput!.dispatchEvent(new Event('input', { bubbles: true }))
 
     const addButton = Array.from(people!.querySelectorAll<HTMLButtonElement>('button'))
@@ -368,6 +393,221 @@ describe('Attendance admin anchor navigation', () => {
         userIds: ['user-2', 'user-3'],
       },
     ])
+  })
+
+  it('keeps same-label attendance group members distinct and removes by user ID', async () => {
+    const firstMemberUserId = '22222222-2222-4222-8222-222222222222'
+    const secondMemberUserId = '33333333-3333-4333-8333-333333333333'
+    const deleteUrls: string[] = []
+    vi.mocked(apiFetch).mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url === '/api/attendance-admin/users/batch/resolve') {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            requested: 2,
+            items: [
+              { id: firstMemberUserId, email: 'one@example.com', name: 'Shared Label', is_active: true },
+              { id: secondMemberUserId, email: 'two@example.com', name: 'Shared Label', is_active: true },
+            ],
+            missingUserIds: [],
+            inactiveUserIds: [],
+          },
+        })
+      }
+      if (url.startsWith('/api/attendance/groups?')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'group-a',
+                name: 'Operations floor',
+                code: 'ops_floor',
+                timezone: 'Asia/Shanghai',
+                ruleSetId: null,
+              },
+            ],
+          },
+        })
+      }
+      if (url === `/api/attendance/groups/group-a/members/${secondMemberUserId}` && init?.method === 'DELETE') {
+        deleteUrls.push(url)
+        return jsonResponse(200, { ok: true, data: { removed: true } })
+      }
+      if (url === '/api/attendance/groups/group-a/members') {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              { id: 'member-1', groupId: 'group-a', userId: firstMemberUserId, createdAt: '2026-05-27T08:00:00.000Z' },
+              { id: 'member-2', groupId: 'group-a', userId: secondMemberUserId, createdAt: '2026-05-27T08:05:00.000Z' },
+            ],
+            total: 2,
+          },
+        })
+      }
+      return jsonResponse(200, {
+        ok: true,
+        data: {
+          items: [],
+          summary: null,
+        },
+      })
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const groupsAnchor = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-groups"]')
+    expect(groupsAnchor).toBeTruthy()
+    groupsAnchor!.click()
+    await flushUi(8)
+
+    const rows = Array.from(container!.querySelectorAll<HTMLTableRowElement>('[data-attendance-group-people] tbody tr'))
+    expect(rows).toHaveLength(2)
+    expect(rows[0]?.textContent).toContain('Shared Label')
+    expect(rows[0]?.textContent).toContain(firstMemberUserId)
+    expect(rows[1]?.textContent).toContain('Shared Label')
+    expect(rows[1]?.textContent).toContain(secondMemberUserId)
+
+    const secondRemove = Array.from(rows[1]!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Remove'))
+    expect(secondRemove).toBeTruthy()
+    secondRemove!.click()
+    await flushUi(8)
+
+    expect(deleteUrls).toEqual([`/api/attendance/groups/group-a/members/${secondMemberUserId}`])
+  })
+
+  it('falls back to saved user IDs when attendance group member label resolution fails', async () => {
+    const memberUserId = '44444444-4444-4444-8444-444444444444'
+    vi.mocked(apiFetch).mockImplementation(async (input: RequestInfo | URL) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url === '/api/attendance-admin/users/batch/resolve') {
+        return jsonResponse(500, {
+          ok: false,
+          error: {
+            message: 'resolver unavailable',
+          },
+        })
+      }
+      if (url.startsWith('/api/attendance/groups?')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'group-a',
+                name: 'Operations floor',
+                code: 'ops_floor',
+                timezone: 'Asia/Shanghai',
+                ruleSetId: null,
+              },
+            ],
+          },
+        })
+      }
+      if (url === '/api/attendance/groups/group-a/members') {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              { id: 'member-1', groupId: 'group-a', userId: memberUserId, createdAt: '2026-05-27T08:00:00.000Z' },
+            ],
+            total: 1,
+          },
+        })
+      }
+      return jsonResponse(200, {
+        ok: true,
+        data: {
+          items: [],
+          summary: null,
+        },
+      })
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const groupsAnchor = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-groups"]')
+    expect(groupsAnchor).toBeTruthy()
+    groupsAnchor!.click()
+    await flushUi(8)
+
+    const people = container!.querySelector<HTMLElement>('[data-attendance-group-people]')
+    expect(people).toBeTruthy()
+    expect(people!.querySelector('[data-attendance-group-member-label]')).toBeNull()
+    expect(people!.querySelector('[data-attendance-group-member-user-id]')?.textContent).toContain(memberUserId)
+    expect(container!.textContent).not.toContain('resolver unavailable')
+  })
+
+  it('skips non-UUID attendance group member IDs before resolving labels', async () => {
+    const resolveBodies: unknown[] = []
+    vi.mocked(apiFetch).mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      if (url === '/api/attendance-admin/users/batch/resolve') {
+        resolveBodies.push(JSON.parse(String(init?.body || '{}')))
+        return jsonResponse(400, {
+          ok: false,
+          error: {
+            message: 'Invalid user IDs',
+          },
+        })
+      }
+      if (url.startsWith('/api/attendance/groups?')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'group-a',
+                name: 'Operations floor',
+                code: 'ops_floor',
+                timezone: 'Asia/Shanghai',
+                ruleSetId: null,
+              },
+            ],
+          },
+        })
+      }
+      if (url === '/api/attendance/groups/group-a/members') {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              { id: 'member-1', groupId: 'group-a', userId: 'legacy-user-1', createdAt: '2026-05-27T08:00:00.000Z' },
+            ],
+            total: 1,
+          },
+        })
+      }
+      return jsonResponse(200, {
+        ok: true,
+        data: {
+          items: [],
+          summary: null,
+        },
+      })
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const groupsAnchor = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-groups"]')
+    expect(groupsAnchor).toBeTruthy()
+    groupsAnchor!.click()
+    await flushUi(8)
+
+    const people = container!.querySelector<HTMLElement>('[data-attendance-group-people]')
+    expect(people).toBeTruthy()
+    expect(resolveBodies).toEqual([])
+    expect(people!.querySelector('[data-attendance-group-member-label]')).toBeNull()
+    expect(people!.querySelector('[data-attendance-group-member-user-id]')?.textContent).toContain('legacy-user-1')
   })
 
   it('explains duplicate-only attendance group member input without posting', async () => {


### PR DESCRIPTION
## Summary
- Resolve labels for the currently loaded attendance-group member page through the existing attendance-scoped batch resolver.
- Render name/email above the immutable userId, while preserving userId as the only identity and write payload fact.
- Fail closed: resolver 403/404/500/network errors silently fall back to saved userIds; member loading, add, and remove flows stay usable.

## Boundaries
- Frontend-only: 2 files.
- No backend, schema, migration, route, permission, OpenAPI, or plugin changes.
- No persisted labels, no enrichment endpoint, no member pagination change, no picker semantics change.
- AttendanceRulesAndGroupsSection remains retired.

## Tests
- pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-anchor-nav.spec.ts tests/attendance-admin-regressions.spec.ts --watch=false
- pnpm --filter @metasheet/web type-check

## Review notes
- Locks current-page-only resolution by asserting the resolver body is the visible member userId list.
- Locks same-label/different-userId behavior by keeping two rows distinct and removing by userId.
- Locks resolver failure fallback by asserting no label is rendered and userId remains visible.