### PR TITLE
feat(integration): add DF-N2 provenance storage migration

### DIFF
--- a/docs/development/data-factory-df-n2-2a-provenance-storage-verification-20260528.md
+++ b/docs/development/data-factory-df-n2-2a-provenance-storage-verification-20260528.md
@@ -1,0 +1,70 @@
+# Data Factory DF-N2-2a provenance storage verification - 2026-05-28
+
+## Scope
+
+DF-N2-2a is the storage-only sub-slice from
+`data-factory-df-n2-2-provenance-runtime-design-20260528.md`.
+
+This PR prepares storage for per-row provenance and intentionally does not write
+or read provenance at runtime.
+
+## Files
+
+- `packages/core-backend/migrations/060_integration_runs_provenance.sql`
+- `plugins/plugin-integration-core/__tests__/migration-sql.test.cjs`
+- `docs/development/data-factory-df-n2-2a-provenance-storage-verification-20260528.md`
+
+## Storage Contract
+
+The migration adds:
+
+- `integration_runs.provenance_events JSONB NOT NULL DEFAULT '[]'::jsonb`
+- `integration_provenance_by_row`, a read-only view that unnests run-local
+  provenance events by `rowId`
+
+The storage anchor is the existing database table `integration_runs`. The
+staging multitable object names `integration_run_log` and
+`integration_exceptions` are not DB storage anchors and are not referenced as
+SQL objects.
+
+## Boundary Checks
+
+- No new event table.
+- No runtime write wiring.
+- No read route.
+- No frontend.
+- No K3 adapter behavior change.
+- No Submit / Audit / BOM / multi-record unlock.
+- No RBAC or OpenAPI route change.
+
+## Test Coverage
+
+`migration-sql.test.cjs` now checks the 060 migration for:
+
+- JSONB column addition on `integration_runs`
+- by-row view creation
+- `jsonb_array_elements(... ) WITH ORDINALITY`
+- safe handling for non-array / null provenance payloads
+- `rowId`, `eventType`, `at`, `attrs`, and raw event projection
+- object + `rowId` filtering
+- no new table creation or destructive DDL
+- no SQL object references to staging multitable object names
+
+## Commands
+
+```bash
+node plugins/plugin-integration-core/__tests__/migration-sql.test.cjs
+git diff --check
+```
+
+Expected result:
+
+- migration SQL structure test passes for 057/058/059/060
+- diff check exits 0
+
+## Deferred
+
+- DF-N2-2b: runtime writes to append redacted `ProvenanceEvent` values.
+- DF-N2-2c: by-`rowId` GET route, RBAC, OpenAPI parity, and wire-vs-fixture
+  route tests.
+- DF-N2-3: frontend lineage timeline.

--- a/packages/core-backend/migrations/060_integration_runs_provenance.sql
+++ b/packages/core-backend/migrations/060_integration_runs_provenance.sql
@@ -1,0 +1,42 @@
+-- 060_integration_runs_provenance.sql
+-- plugin-integration-core · DF-N2-2a provenance storage
+--
+-- Storage-only migration for the Data Factory per-record provenance chain.
+-- Runtime writes stay locked behind DF-N2-2b; read routes stay locked behind
+-- DF-N2-2c. This migration only prepares the existing run table and a
+-- read-only by-row view.
+--
+-- Important boundary: the DB storage anchor is integration_runs. The staging
+-- multitable objects named integration_run_log / integration_exceptions are
+-- not database tables and must not be referenced here.
+-- ---------------------------------------------------------------------------
+
+ALTER TABLE integration_runs
+  ADD COLUMN IF NOT EXISTS provenance_events JSONB NOT NULL DEFAULT '[]'::jsonb;
+
+CREATE OR REPLACE VIEW integration_provenance_by_row AS
+SELECT
+  r.tenant_id,
+  r.workspace_id,
+  r.pipeline_id,
+  r.id AS run_id,
+  r.mode AS run_mode,
+  r.status AS run_status,
+  r.created_at AS run_created_at,
+  r.started_at AS run_started_at,
+  r.finished_at AS run_finished_at,
+  provenance_item.ordinality AS event_index,
+  provenance_item.event ->> 'rowId' AS row_id,
+  provenance_item.event ->> 'eventType' AS event_type,
+  provenance_item.event ->> 'at' AS event_at,
+  COALESCE(provenance_item.event -> 'attrs', '{}'::jsonb) AS attrs,
+  provenance_item.event AS event
+FROM integration_runs r
+CROSS JOIN LATERAL jsonb_array_elements(
+  CASE
+    WHEN jsonb_typeof(r.provenance_events) = 'array' THEN r.provenance_events
+    ELSE '[]'::jsonb
+  END
+) WITH ORDINALITY AS provenance_item(event, ordinality)
+WHERE jsonb_typeof(provenance_item.event) = 'object'
+  AND provenance_item.event ? 'rowId';

--- a/plugins/plugin-integration-core/__tests__/migration-sql.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/migration-sql.test.cjs
@@ -8,9 +8,11 @@ const repoRoot = path.resolve(__dirname, '..', '..', '..')
 const migrationPath = path.join(repoRoot, 'packages', 'core-backend', 'migrations', '057_create_integration_core_tables.sql')
 const runningUniqueMigrationPath = path.join(repoRoot, 'packages', 'core-backend', 'migrations', '058_integration_runs_running_unique.sql')
 const runHistoryIndexMigrationPath = path.join(repoRoot, 'packages', 'core-backend', 'migrations', '059_integration_runs_history_index.sql')
+const runProvenanceMigrationPath = path.join(repoRoot, 'packages', 'core-backend', 'migrations', '060_integration_runs_provenance.sql')
 const sql = fs.readFileSync(migrationPath, 'utf8')
 const runningUniqueSql = fs.readFileSync(runningUniqueMigrationPath, 'utf8')
 const runHistoryIndexSql = fs.readFileSync(runHistoryIndexMigrationPath, 'utf8')
+const runProvenanceSql = fs.readFileSync(runProvenanceMigrationPath, 'utf8')
 
 const expectedTables = [
   'integration_external_systems',
@@ -112,6 +114,63 @@ function main() {
     '059 migration adds run-history lookup index with workspace scope and created_at ordering',
   )
   assert.doesNotMatch(runHistoryIndexSql, /\bDROP\s+(?:TABLE|INDEX)\b/i, '059 migration must not drop objects')
+  assert.match(
+    runProvenanceSql,
+    /ALTER TABLE integration_runs\s+ADD COLUMN IF NOT EXISTS provenance_events JSONB NOT NULL DEFAULT '\[\]'::jsonb;/m,
+    '060 migration adds provenance_events JSONB column to integration_runs',
+  )
+  assert.match(
+    runProvenanceSql,
+    /CREATE OR REPLACE VIEW integration_provenance_by_row AS/m,
+    '060 migration creates the by-row provenance view',
+  )
+  assert.match(
+    runProvenanceSql,
+    /FROM integration_runs r\s+CROSS JOIN LATERAL jsonb_array_elements\(/m,
+    '060 provenance view unnests events from integration_runs',
+  )
+  assert.match(
+    runProvenanceSql,
+    /WITH ORDINALITY AS provenance_item\(event, ordinality\)/m,
+    '060 provenance view keeps stable event ordering per run',
+  )
+  assert.match(
+    runProvenanceSql,
+    /WHEN jsonb_typeof\(r\.provenance_events\) = 'array' THEN r\.provenance_events\s+ELSE '\[\]'::jsonb/m,
+    '060 provenance view tolerates null or non-array lineage payloads',
+  )
+  assert.match(
+    runProvenanceSql,
+    /provenance_item\.event ->> 'rowId' AS row_id/m,
+    '060 provenance view exposes rowId for the future read route',
+  )
+  assert.match(
+    runProvenanceSql,
+    /provenance_item\.event ->> 'eventType' AS event_type/m,
+    '060 provenance view exposes eventType for timeline rendering',
+  )
+  assert.match(
+    runProvenanceSql,
+    /provenance_item\.event ->> 'at' AS event_at/m,
+    '060 provenance view exposes event timestamps as text',
+  )
+  assert.match(
+    runProvenanceSql,
+    /COALESCE\(provenance_item\.event -> 'attrs', '\{\}'::jsonb\) AS attrs/m,
+    '060 provenance view exposes attrs with an object fallback',
+  )
+  assert.match(
+    runProvenanceSql,
+    /WHERE jsonb_typeof\(provenance_item\.event\) = 'object'\s+AND provenance_item\.event \? 'rowId';/m,
+    '060 provenance view filters to object events that carry rowId',
+  )
+  assert.doesNotMatch(runProvenanceSql, /\bCREATE\s+TABLE\b/i, '060 migration must not create a new event table')
+  assert.doesNotMatch(runProvenanceSql, /\bDROP\s+(?:TABLE|INDEX|VIEW)\b/i, '060 migration must not drop objects')
+  assert.doesNotMatch(
+    runProvenanceSql,
+    /\b(?:FROM|JOIN|ALTER\s+TABLE|CREATE\s+TABLE|UPDATE|INSERT\s+INTO|DELETE\s+FROM)\s+integration_(?:run_log|exceptions)\b/i,
+    '060 migration must not reference staging multitable object names as DB tables',
+  )
 
   const ddlTableRefs = Array.from(sql.matchAll(/\b(?:CREATE|ALTER|DROP|TRUNCATE)\s+TABLE(?:\s+IF\s+(?:NOT\s+)?EXISTS)?\s+([a-zA-Z_][a-zA-Z0-9_]*)/gi))
     .map((match) => match[1])
@@ -126,11 +185,17 @@ function main() {
     .map((match) => match[1])
   assertOnlyIntegrationTableRefs('index', indexTableRefs.concat(runningUniqueIndexTableRefs, runHistoryIndexTableRefs))
 
+  const provenanceAlterTableRefs = Array.from(runProvenanceSql.matchAll(/\bALTER\s+TABLE\s+([a-zA-Z_][a-zA-Z0-9_]*)/gi))
+    .map((match) => match[1])
+  const provenanceViewTableRefs = Array.from(runProvenanceSql.matchAll(/\bFROM\s+([a-zA-Z_][a-zA-Z0-9_]*)\b/gi))
+    .map((match) => match[1])
+  assertOnlyIntegrationTableRefs('060 DDL/view', provenanceAlterTableRefs.concat(provenanceViewTableRefs))
+
   const foreignTableRefs = Array.from(sql.matchAll(/\bREFERENCES\s+([a-zA-Z_][a-zA-Z0-9_]*)\s*\(/gi))
     .map((match) => match[1])
   assertOnlyIntegrationTableRefs('foreign key', foreignTableRefs)
 
-  console.log('✓ migration-sql: 057/058/059 integration migration structure passed')
+  console.log('✓ migration-sql: 057/058/059/060 integration migration structure passed')
 }
 
 main()


### PR DESCRIPTION
## Summary

- add DF-N2-2a storage-only migration `060_integration_runs_provenance.sql`
- add `integration_runs.provenance_events` JSONB storage and the read-only `integration_provenance_by_row` view
- extend the migration SQL structure test and add verification notes

## Boundaries

- storage/migration only
- no runtime provenance writes
- no read route / OpenAPI / RBAC changes
- no frontend
- no K3 write, Submit, Audit, BOM, multi-record, or connector behavior change

## Verification

- `node plugins/plugin-integration-core/__tests__/migration-sql.test.cjs`
- `git diff --check`
