### PR TITLE
feat(multitable): expose automation runs admin nav entry

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -32,6 +32,7 @@
             <router-link v-if="canManageUsers" to="/admin/roles" class="nav-link">{{ navLabels.roles }}</router-link>
             <router-link v-if="canManageUsers" to="/admin/permissions" class="nav-link">{{ navLabels.permissions }}</router-link>
             <router-link v-if="canManageUsers" to="/admin/audit" class="nav-link">{{ navLabels.adminAudit }}</router-link>
+            <router-link v-if="canManageUsers" to="/admin/automation-executions" class="nav-link">{{ navLabels.automationRuns }}</router-link>
             <router-link v-if="canManageUsers" to="/approvals/metrics" class="nav-link">{{ navLabels.approvalMetrics }}</router-link>
             <router-link v-if="canUseIntegration" to="/integrations/workbench" class="nav-link">{{ navLabels.systemIntegration }}</router-link>
             <router-link v-if="isAdmin" to="/admin/plugins" class="nav-link">{{ navLabels.plugins }}</router-link>
@@ -124,6 +125,7 @@ const navLabels = computed(() => {
       roles: '角色',
       permissions: '权限',
       adminAudit: '管理审计',
+      automationRuns: '自动化运行',
       approvalMetrics: '审批 SLA',
       systemIntegration: '数据工厂',
       plugins: '插件',
@@ -145,6 +147,7 @@ const navLabels = computed(() => {
     roles: 'Roles',
     permissions: 'Permissions',
     adminAudit: 'Admin Audit',
+    automationRuns: 'Automation Runs',
     approvalMetrics: 'Approval SLA',
     systemIntegration: 'Data Factory',
     plugins: 'Plugins',

--- a/apps/web/tests/platform-shell-nav.spec.ts
+++ b/apps/web/tests/platform-shell-nav.spec.ts
@@ -214,6 +214,67 @@ describe('platform shell navigation', () => {
     expect(links.some((link) => link.href === '/gallery')).toBe(false)
     expect(links.some((link) => link.href === '/form')).toBe(false)
     expect(links.some((link) => link.href === '/admin/users')).toBe(false)
+    // A3 runs view is admin-only (canManageUsers === snapshot.isAdmin) — hidden here.
+    expect(links.some((link) => link.href === '/admin/automation-executions')).toBe(false)
+  })
+
+  it('shows the automation runs admin nav entry for an admin user', async () => {
+    vi.doMock('vue-router', () => ({
+      useRoute: () => ({ path: '/grid', fullPath: '/grid', meta: { requiresAuth: true } }),
+    }))
+    vi.doMock('../src/composables/usePlugins', () => ({
+      usePlugins: () => ({ navItems: ref([]), fetchPlugins: vi.fn().mockResolvedValue(undefined) }),
+    }))
+    vi.doMock('../src/stores/featureFlags', () => ({
+      useFeatureFlags: () => ({
+        loadProductFeatures: vi.fn().mockResolvedValue(undefined),
+        isAttendanceFocused: () => false,
+        isPlmWorkbenchFocused: () => false,
+        hasFeature: () => false,
+      }),
+    }))
+    vi.doMock('../src/composables/useLocale', () => ({
+      useLocale: () => ({ locale: ref('zh-CN'), isZh: ref(true), setLocale: vi.fn() }),
+    }))
+    vi.doMock('../src/composables/useAuth', () => ({
+      useAuth: () => ({
+        clearToken: vi.fn(),
+        getAccessSnapshot: () => ({
+          email: 'admin@test.local',
+          roles: ['admin'],
+          permissions: ['*:*'],
+          isAdmin: true,
+        }),
+        getToken: () => 'session-token',
+        hasPermission: () => true,
+      }),
+    }))
+    vi.doMock('../src/utils/api', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../src/utils/api')>()
+      return { ...actual, getApiBase: () => 'http://example.test' }
+    })
+
+    const { default: App } = await import('../src/App.vue')
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(App as Component)
+    app.component('router-view', { render: () => h('div') })
+    app.component('router-link', {
+      props: ['to'],
+      render() {
+        return h('a', { href: this.$props.to }, this.$slots.default ? this.$slots.default() : [])
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    const links = Array.from(container.querySelectorAll('a')).map((node) => ({
+      href: node.getAttribute('href'),
+      text: node.textContent?.trim(),
+    }))
+    expect(links).toEqual(expect.arrayContaining([
+      expect.objectContaining({ href: '/admin/automation-executions', text: '自动化运行' }),
+    ]))
   })
 
   it('keeps platform shell nav labels from wrapping vertically on desktop', async () => {


### PR DESCRIPTION
## What

A3 **discoverability follow-up** (#1975): the read-only admin runs view at `/admin/automation-executions` shipped without a nav entry, so it was reachable only by URL. Add an **admin-only** nav link alongside `/admin/users · /roles · /permissions · /audit`.

- `App.vue`: `<router-link v-if="canManageUsers" to="/admin/automation-executions">` + `navLabels` EN **"Automation Runs"** / ZH **"自动化运行"**.
- **No** route / A2 API / A3 view change; **no** retry or runtime action — pure discoverability of the already-merged read-only view (`canManageUsers === snapshot.isAdmin`).

## Acceptance (your three)
1. ✅ admin user sees **Automation Runs / 自动化运行** in nav.
2. ✅ non-admin does **not** (platform-shell-nav test: integration operator, isAdmin:false → entry absent).
3. ✅ click → `/admin/automation-executions`; **no new runtime action capability**.

## Tests / validation
`platform-shell-nav` — new admin-visible test + non-admin-absent assertion (**7/7**); `App.spec` green (no regression); web type-check + `App.vue` ESLint clean.

Closes the last run-governance governance-half loose end (A0–A3 now reachable + complete).

🤖 Generated with [Claude Code](https://claude.com/claude-code)