### PR TITLE
feat(integration): DF-N2-2b provenance runtime write

### DIFF
--- a/docs/development/data-factory-df-n2-2b-provenance-runtime-write-verification-20260528.md
+++ b/docs/development/data-factory-df-n2-2b-provenance-runtime-write-verification-20260528.md
@@ -1,0 +1,75 @@
+# DF-N2-2b — provenance runtime write (verification, 2026-05-28)
+
+Implements the **runtime write** slice of the merged DF-N2-2 design
+(`data-factory-df-n2-2-provenance-runtime-design-20260528.md`, #1979), building on the DF-N2-2a
+storage migration (#1981, `integration_runs.provenance_events` + `integration_provenance_by_row`) and
+the DF-N2-1 contract (#1882, `provenance-contracts.cjs`). **Runtime write only — separate gated opt-in.**
+
+## What it does (the tight slice)
+`pipeline-runner.cjs` collects **per-row write-outcome** provenance during a live run and hands it to
+`run-log.finishRun`, which **normalizes + redacts** each event and persists the array to the
+`integration_runs.provenance_events` JSONB column via `pipelines.cjs`. The `rowId` is the record's
+**idempotency key** — the stable cross-run identity the DF-N2-2a by-row view groups on.
+
+- Emits `target_write_succeeded` / `target_write_failed`, keyed by idempotency key.
+- Events are appended **raw in-memory** during the run; the **normalize + shared-redaction gate runs
+  once at `finishRun`, before persist** — the *persistence boundary is the security boundary* (this is
+  also where the failed-run path writes, so pre-throw rows keep their lineage).
+- `attrs` carry only a small summary (`{}` for success; `{errorCode, errorMessage}` for failure).
+
+## Scope boundary (what this PR does NOT do — confirmed against #1979)
+- **Write-outcome events only.** Pre-write failures (`transform_failed` / `validation_failed`) lack an
+  idempotency key (computed only after validation) and are already captured in dead-letters → **deferred**.
+- **No `dry_run_previewed` emission** — dry runs perform no real write, so they record no provenance.
+- **No read surface.** `pipelines.cjs rowToPipelineRun` is **not** changed to map the column back — reading
+  provenance is **DF-N2-2c** (a separate opt-in by-`rowId` GET route + RBAC + wire test).
+- **No route / OpenAPI / RBAC / frontend / K3 / connector behavior change.** All edits are inside
+  `plugin-integration-core/lib` (`pipelines.cjs` is plugin-local, not core-backend); the write/upsert
+  path and its return shape (`{run, metrics, preview}`) are unchanged.
+- **Success-emission rule (the unitemized-failure trap):** `target_write_succeeded` is emitted **only when
+  per-row attribution is unambiguous** (`unitemizedFailures === 0 && writeResult.inconsistent !== true`).
+  When the adapter reports failures it cannot itemize, success events are **skipped** for that batch and
+  the gap is recorded as `details.provenanceAttributionSkipped` — never infer "succeeded" from "absent
+  from the error list", which would silently mislabel unattributed failures as writes.
+
+## Acceptance points (each test-locked, in `pipeline-runner.test.cjs` §14–20 + `pipelines.test.cjs` §8b)
+1. **Normalize before persist** — §14 asserts the canonical contract shape only (`runId/rowId/eventType/
+   at/attrs`), ISO `at`, `eventType` from the enum; proves `normalizeProvenanceEvent` ran at `finishRun`.
+2. **Shared redaction before persist (KEYSTONE)** — §15 plants a secret-shaped **value** in a failed-write
+   `errorMessage` (`postgres://erp:S3cretPass@…`) and asserts the persisted `attrs.errorMessage` has the
+   password **masked** (`postgres://erp:[redacted]@10.0.0.5`) with context kept. This exercises the
+   #1882-F1 value-scrubber (`SECRET_VALUE_PATTERNS`) and **fails if normalize/scrub is bypassed** (proven
+   by negative control — see below); it is **not** a key-name redaction that would pass without the scrub.
+3. **Per-run / per-row cap** — §16: 502 rows → exactly 500 events, `details.provenanceDropped === 2`,
+   `details.provenanceCap === 500`, and one event per row (no duplicate `rowId`). Overflow is a **counter
+   in `details`**, never a sentinel event (keeps the 2a by-row view uniform).
+4. **Replay must NOT duplicate lineage** — §17: a failed row → dead-letter → replay creates a **new run**;
+   the replay run holds one `target_write_succeeded`, and the **original run's lineage is unchanged** (one
+   `target_write_failed`). Same `rowId` across two runs is correct cross-run lineage, not duplication.
+5. **No route/frontend/K3 behavior + best-effort** — diff scope (lib-only) + §20: a malformed event makes
+   `run-log` **drop provenance and surface `details.provenanceWarning`** rather than throw — a bad event
+   never loses the run record. §18 (failed-run path): rows written before a mid-run throw keep their
+   lineage on the `failed` run (events passed to **both** `finishRun` sites).
+- §8b (`pipelines.test.cjs`): the array is serialized to the `provenance_events` column when present, and
+  **omitted from the SET when absent** so migration 060's `'[]'` default is preserved (no overwrite).
+
+## Retention (unchanged direction, per #1979 §Retention — recorded so 2b does not drift)
+Retention stays **run-level aging** (drop whole old runs by `integration_runs.created_at`/`finished_at`) +
+**read-time bounded window** (owned by the 2c route). The per-run cap here bounds a single row; it is **not**
+a per-row/per-event JSONB pruning pass — #1979 explicitly avoids rewriting old run rows per `rowId`.
+
+## Files
+- `lib/pipeline-runner.cjs` — collect + cap + emit (write-stage) + pass to both `finishRun` sites.
+- `lib/run-log.cjs` — normalize+redact gate (best-effort) → `updatePipelineRun({provenanceEvents})`.
+- `lib/pipelines.cjs` — serialize `provenanceEvents` → `provenance_events` column (dumb persister).
+- `__tests__/pipeline-runner.test.cjs` (§14–20), `__tests__/pipelines.test.cjs` (§8b).
+
+## Test result
+All **26** `plugin-integration-core` `*.test.cjs` pass (with deps available; `provenance-contracts.test.cjs`
+needs `js-yaml` from `node_modules`). Negative controls run: (a) bypassing `normalizeProvenanceEvents` in
+`run-log` → §15 fails (raw `S3cretPass` persists); (b) dropping `provenanceEvents` from the failed-path
+`finishRun` → §18 fails. Both restored; suite green.
+
+## Gated next (separate opt-ins, do NOT auto-start)
+**DF-N2-2c** (by-`rowId` read route + RBAC + wire test) → **DF-N2-3** (frontend timeline). K3
+Submit/Audit/BOM/multi-record/production stay gated.

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -99,6 +99,7 @@ function createPipelineRegistry(pipeline, db) {
         duration_ms: input.durationMs,
         error_summary: input.errorSummary || null,
         details: input.details || {},
+        ...(input.provenanceEvents !== undefined && { provenance_events: input.provenanceEvents }),
       }, {
         tenant_id: input.tenantId,
         workspace_id: input.workspaceId ?? null,
@@ -118,6 +119,7 @@ function createPipelineRegistry(pipeline, db) {
         durationMs: row.duration_ms,
         errorSummary: row.error_summary,
         details: row.details,
+        provenanceEvents: row.provenance_events ?? [],
       }
     },
   }
@@ -1441,7 +1443,157 @@ async function main() {
     assert.equal(hugeOptionLimits[0], 10000, 'huge batchSize is capped before adapter read()')
   }
 
+  // --- 14. DF-N2-2b: per-row write-outcome provenance, normalized + idempotency-keyed ---
+  {
+    const harness = createRunnerHarness({
+      sourceRecords: [
+        { code: 'prov-ok', revision: 'r1', qty: '2', name: 'Widget', updatedAt: '2026-04-24T01:00:00.000Z' },
+      ],
+    })
+    const res = await harness.runner.runPipeline({ tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'full', triggeredBy: 'manual' })
+    assert.equal(res.run.status, 'succeeded')
+    const events = res.run.provenanceEvents
+    assert.equal(events.length, 1, 'one write-outcome event for the one written row')
+    const ev = events[0]
+    assert.equal(ev.eventType, 'target_write_succeeded')
+    assert.ok(typeof ev.rowId === 'string' && ev.rowId.length > 0, 'rowId is the idempotency key')
+    assert.equal(ev.runId, res.run.id, 'event carries the run id')
+    assert.match(ev.at, /^\d{4}-\d{2}-\d{2}T.*Z$/, 'at normalized to ISO (proves normalizeProvenanceEvent ran)')
+    assert.deepEqual(Object.keys(ev).sort(), ['at', 'attrs', 'eventType', 'rowId', 'runId'], 'canonical contract shape only')
+    assert.equal(res.run.details.provenanceCap, 500, 'cap surfaced in run details')
+  }
+
+  // --- 15. DF-N2-2b KEYSTONE: a secret-shaped VALUE in attrs is scrubbed BEFORE persist ---
+  // Proves the shared value-scrubber (payload-redaction SECRET_VALUE_PATTERNS, the #1882 F1
+  // fix) actually runs on provenance attrs via normalizeProvenanceEvents — not trusted blind.
+  // This assertion FAILS if normalize/scrub is bypassed (raw password would survive).
+  {
+    const harness = createRunnerHarness({
+      sourceRecords: [
+        { code: 'leak-01', revision: 'r1', qty: '1', name: 'Leak', updatedAt: '2026-04-24T01:00:00.000Z' },
+      ],
+      targetUpsert: async (input) => createUpsertResult({
+        written: 0,
+        failed: 1,
+        errors: [{
+          key: input.records[0]._integration_idempotency_key,
+          code: 'TARGET_AUTH',
+          message: 'connect failed: postgres://erp:S3cretPass@10.0.0.5:5432/k3db',
+        }],
+      }),
+    })
+    const res = await harness.runner.runPipeline({ tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'full', triggeredBy: 'manual' })
+    const events = res.run.provenanceEvents
+    assert.equal(events.length, 1, 'one target_write_failed event')
+    assert.equal(events[0].eventType, 'target_write_failed')
+    const msg = events[0].attrs.errorMessage
+    assert.ok(!msg.includes('S3cretPass'), 'password VALUE scrubbed from provenance attrs (value-scrub ran)')
+    assert.match(msg, /postgres:\/\/erp:\[redacted\]@10\.0\.0\.5/, 'DSN context preserved, password masked')
+  }
+
+  // --- 16. DF-N2-2b: per-run cap (drop overflow, counter in details) + per-row uniqueness ---
+  {
+    const many = Array.from({ length: 502 }, (_, i) => ({
+      code: `cap-${i}`, revision: 'r1', qty: '1', name: `N${i}`, updatedAt: '2026-04-24T01:00:00.000Z',
+    }))
+    const harness = createRunnerHarness({ sourceRecords: many })
+    const res = await harness.runner.runPipeline({ tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'full', triggeredBy: 'manual' })
+    assert.equal(res.run.status, 'succeeded')
+    const events = res.run.provenanceEvents
+    assert.equal(events.length, 500, 'events capped at MAX_PROVENANCE_EVENTS')
+    assert.equal(res.run.details.provenanceDropped, 2, 'overflow counted in details, not appended')
+    assert.equal(res.run.details.provenanceCap, 500)
+    assert.equal(new Set(events.map((e) => e.rowId)).size, 500, 'one event per row (no duplicate rowIds)')
+  }
+
+  // --- 17. DF-N2-2b: replay does NOT duplicate lineage (new run, original untouched) ---
+  {
+    let attempt = 0
+    const harness = createRunnerHarness({
+      sourceRecords: [
+        { code: 'replay-01', revision: 'r1', qty: '1', name: 'Replay', updatedAt: '2026-04-24T01:00:00.000Z' },
+      ],
+      targetUpsert: async (input) => {
+        attempt += 1
+        if (attempt === 1) {
+          return createUpsertResult({ written: 0, failed: 1, errors: [{ key: input.records[0]._integration_idempotency_key, code: 'TARGET_TEMP', message: 'temporary target failure' }] })
+        }
+        return createUpsertResult({ written: 1, failed: 0, results: input.records.map((r) => ({ key: r._integration_idempotency_key })) })
+      },
+    })
+    const firstRun = await harness.runner.runPipeline({ tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'full', triggeredBy: 'manual' })
+    const firstRunId = firstRun.run.id
+    assert.equal(firstRun.run.provenanceEvents.length, 1)
+    assert.equal(firstRun.run.provenanceEvents[0].eventType, 'target_write_failed')
+    const deadLetter = harness.db.tables.get('integration_dead_letters')[0]
+    assert.ok(deadLetter, 'first run produced a dead letter to replay')
+    const replay = await harness.runner.replayDeadLetter({ tenantId: 'tenant_1', workspaceId: null, id: deadLetter.id })
+    const replayRunId = replay.replay.run.id
+    assert.notEqual(replayRunId, firstRunId, 'replay creates a NEW run')
+    assert.equal(replay.replay.run.provenanceEvents.length, 1, 'replay run has exactly one event')
+    assert.equal(replay.replay.run.provenanceEvents[0].eventType, 'target_write_succeeded')
+    const originalRow = harness.db.tables.get('integration_runs').find((r) => r.id === firstRunId)
+    assert.equal(originalRow.provenance_events.length, 1, 'original run lineage is NOT rewritten/duplicated by replay')
+    assert.equal(originalRow.provenance_events[0].eventType, 'target_write_failed')
+  }
+
+  // --- 18. DF-N2-2b: failed-run path keeps lineage for rows written before a mid-run throw ---
+  {
+    let pageReads = 0
+    const harness = createRunnerHarness({
+      sourceRecords: [],
+      sourceRead: async () => {
+        pageReads += 1
+        if (pageReads === 1) {
+          return createReadResult({ records: [{ code: 'pre-throw', revision: 'r1', qty: '1', name: 'Early', updatedAt: '2026-04-24T01:00:00.000Z' }], done: false, nextCursor: 'page-2' })
+        }
+        throw new Error('source read exploded on page 2')
+      },
+    })
+    await assert.rejects(
+      () => harness.runner.runPipeline({ tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'full', triggeredBy: 'manual' }),
+      /pipeline run failed/,
+    )
+    const runRow = harness.db.tables.get('integration_runs')[0]
+    assert.equal(runRow.status, 'failed', 'run marked failed')
+    assert.equal(runRow.provenance_events.length, 1, 'pre-throw written row keeps its lineage on the failed run')
+    assert.equal(runRow.provenance_events[0].eventType, 'target_write_succeeded')
+  }
+
+  // --- 19. DF-N2-2b: unitemized failures → NO false success events (attribution gap recorded) ---
+  {
+    const harness = createRunnerHarness({
+      sourceRecords: [
+        { code: 'unitemized-a', revision: 'r1', qty: '1', name: 'A', updatedAt: '2026-04-24T01:00:00.000Z' },
+        { code: 'unitemized-b', revision: 'r1', qty: '1', name: 'B', updatedAt: '2026-04-24T01:00:00.000Z' },
+      ],
+      targetUpsert: async () => createUpsertResult({ written: 0, failed: 2, errors: [] }),
+    })
+    const res = await harness.runner.runPipeline({ tenantId: 'tenant_1', pipelineId: 'pipe_1', mode: 'full', triggeredBy: 'manual' })
+    assert.equal(res.run.provenanceEvents.length, 0, 'no events emitted when failures are unattributed (no false success)')
+    assert.equal(res.run.details.provenanceAttributionSkipped, 2, 'attribution gap recorded in details')
+  }
+
+  // --- 20. DF-N2-2b: run-log normalize is best-effort — a bad event never loses the run record ---
+  {
+    let captured = null
+    const registry = {
+      async createPipelineRun(input) { return { id: input.id || 'run_x', ...input } },
+      async updatePipelineRun(input) { captured = input; return { id: input.id, details: input.details } },
+    }
+    const logger = createRunLogger({ pipelineRegistry: registry })
+    const run = { id: 'run_x', tenantId: 'tenant_1', workspaceId: null, startedAt: '2026-04-24T00:00:00.000Z', details: {} }
+    await logger.finishRun(run, { rowsWritten: 1 }, 'succeeded', {
+      provenanceEvents: [{ runId: 'run_x', rowId: 'r1', eventType: 'NOT_A_REAL_TYPE', at: '2026-04-24T00:00:00.000Z', attrs: {} }],
+    })
+    assert.ok(captured, 'run still persisted despite a malformed provenance event')
+    assert.equal(captured.provenanceEvents, undefined, 'bad provenance dropped (not persisted)')
+    assert.ok(captured.details.provenanceWarning, 'details surfaces a provenance warning')
+    assert.equal(captured.details.provenanceWarning.code, 'PROVENANCE_NORMALIZE_FAILED')
+  }
+
   console.log('✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed')
+  console.log('✓ pipeline-runner: DF-N2-2b provenance write tests passed (14-20)')
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/__tests__/pipelines.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipelines.test.cjs
@@ -372,6 +372,26 @@ async function main() {
   assert.equal(completedRun.durationMs, 1234)
   assert.ok(completedRun.finishedAt, 'terminal update sets finishedAt')
 
+  // --- 8b. DF-N2-2b: provenance_events array is serialized to the JSONB column ---
+  await registry.updatePipelineRun({
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    id: 'id_4',
+    status: 'succeeded',
+    rowsWritten: 1,
+    provenanceEvents: [{ runId: 'id_4', rowId: 'k1', eventType: 'target_write_succeeded', at: '2026-04-24T00:00:00.000Z', attrs: {} }],
+  })
+  const provUpdate = db.calls.filter(call => call[0] === 'updateRow' && call[1] === 'integration_runs').pop()
+  assert.equal(
+    provUpdate[2].provenance_events,
+    '[{"runId":"id_4","rowId":"k1","eventType":"target_write_succeeded","at":"2026-04-24T00:00:00.000Z","attrs":{}}]',
+    'provenanceEvents array serialized to the provenance_events JSONB column',
+  )
+  // omitted from SET when not provided → migration 060 default '[]' is preserved (no overwrite)
+  await registry.updatePipelineRun({ tenantId: 'tenant_1', workspaceId: null, id: 'id_4', status: 'succeeded', rowsWritten: 1 })
+  const noProvUpdate = db.calls.filter(call => call[0] === 'updateRow' && call[1] === 'integration_runs').pop()
+  assert.equal('provenance_events' in noProvUpdate[2], false, 'provenance_events omitted from SET when absent')
+
   const runs = await registry.listPipelineRuns({ tenantId: 'tenant_1', workspaceId: null, pipelineId: 'id_1', status: 'succeeded' })
   assert.equal(runs.length, 1)
   assert.equal(runs[0].id, 'id_4')

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -26,6 +26,12 @@ const DEFAULT_BATCH_SIZE = 1000
 const MAX_BATCH_SIZE = 10000
 const DEFAULT_MAX_PAGES = 100
 const MAX_RUN_PAGES = 10000
+// DF-N2-2b: per-run cap on appended provenance events. Keeps the
+// integration_runs.provenance_events JSONB column bounded (~300 bytes/event →
+// ~150KB) so a large run cannot bloat the row. Overflow is surfaced as a counter
+// in run details (provenanceDropped), never as a sentinel event, so the DF-N2-2a
+// by-row view stays uniform. Retention/aging stays run-level (DF-N2-2 design).
+const MAX_PROVENANCE_EVENTS = 500
 
 function coerceTruthyFlag(value, field) {
   if (value === undefined || value === null) return false
@@ -495,6 +501,33 @@ function createPipelineRunner(deps = {}) {
       },
     })
 
+    // DF-N2-2b: collect per-row write-outcome provenance in-memory; normalized +
+    // redacted at finishRun before persist. Declared outside the try so the
+    // failed-run path (catch → finishRun 'failed') still records lineage for rows
+    // that succeeded before a mid-run throw.
+    const provenanceEvents = []
+    let provenanceDropped = 0
+    let provenanceAttributionSkipped = 0
+    const appendProvenanceEvent = (rowId, eventType, attrs) => {
+      if (!rowId) return
+      if (provenanceEvents.length >= MAX_PROVENANCE_EVENTS) {
+        provenanceDropped += 1
+        return
+      }
+      provenanceEvents.push({
+        runId: run.id,
+        rowId: String(rowId),
+        eventType,
+        at: new Date(clock()).toISOString(),
+        attrs: attrs || {},
+      })
+    }
+    const buildProvenanceDetails = () => ({
+      ...(provenanceEvents.length > 0 || provenanceDropped > 0 ? { provenanceCap: MAX_PROVENANCE_EVENTS } : {}),
+      ...(provenanceDropped > 0 ? { provenanceDropped } : {}),
+      ...(provenanceAttributionSkipped > 0 ? { provenanceAttributionSkipped } : {}),
+    })
+
     try {
       const watermarkConfig = resolveWatermarkConfig(context.pipeline)
       const currentWatermark = mode === 'incremental'
@@ -570,19 +603,33 @@ function createPipelineRunner(deps = {}) {
           metrics.rowsWritten += writeResult.written || 0
           metrics.rowsFailed += writeResult.failed || 0
           const targetErrors = writeResult.errors || []
+          const erroredProvenanceKeys = new Set()
           for (const error of targetErrors) {
             const matched = findCleanRecordForTargetError(cleanRecords, error)
+            const rowKey = errorKey(error) || matched?.targetRecord?._integration_idempotency_key
+            const failureErrorCode = matched ? (error.code || 'TARGET_WRITE_FAILED') : 'TARGET_WRITE_UNMATCHED_ERROR'
+            const failureErrorMessage = error.message || 'target write failed'
             await writeDeadLetter({
               tenantId: context.tenantId,
               workspaceId: context.workspaceId,
               runId: run.id,
               pipelineId: context.pipeline.id,
-              idempotencyKey: errorKey(error) || matched?.targetRecord?._integration_idempotency_key,
+              idempotencyKey: rowKey,
               sourcePayload: sanitizeIntegrationPayload(error.sourcePayload || matched?.sourceRecord || buildUnmatchedTargetErrorPayload(error)),
               transformedPayload: sanitizeIntegrationPayload(error.record || matched?.targetRecord || null),
-              errorCode: matched ? (error.code || 'TARGET_WRITE_FAILED') : 'TARGET_WRITE_UNMATCHED_ERROR',
-              errorMessage: error.message || 'target write failed',
+              errorCode: failureErrorCode,
+              errorMessage: failureErrorMessage,
             })
+            // DF-N2-2b: per-row target_write_failed provenance. Only when a stable
+            // rowId (idempotency key) resolves; attrs reuse the dead-letter code/
+            // message verbatim (redacted by normalizeAttrs at finishRun).
+            if (rowKey) {
+              erroredProvenanceKeys.add(rowKey)
+              appendProvenanceEvent(rowKey, 'target_write_failed', {
+                errorCode: failureErrorCode,
+                errorMessage: failureErrorMessage,
+              })
+            }
           }
           const unitemizedFailures = Math.max(0, (writeResult.failed || 0) - targetErrors.length)
           if (unitemizedFailures > 0) {
@@ -604,6 +651,21 @@ function createPipelineRunner(deps = {}) {
               errorCode: 'TARGET_WRITE_AGGREGATE_FAILED',
               errorMessage: `target write failed for ${unitemizedFailures} record(s) without itemized errors`,
             })
+          }
+          // DF-N2-2b: emit target_write_succeeded only when per-row attribution is
+          // unambiguous (no unitemized failures AND consistent counts) — never infer
+          // "succeeded" from "absent from the error list", which would silently
+          // mislabel unattributed failures as writes. When attribution is unclear,
+          // skip success events for the batch and record the gap in run details.
+          const cleanAttribution = unitemizedFailures === 0 && writeResult.inconsistent !== true
+          for (const item of cleanRecords) {
+            const rowKey = item.targetRecord && item.targetRecord._integration_idempotency_key
+            if (!rowKey || erroredProvenanceKeys.has(rowKey)) continue
+            if (cleanAttribution) {
+              appendProvenanceEvent(rowKey, 'target_write_succeeded', {})
+            } else {
+              provenanceAttributionSkipped += 1
+            }
           }
           const feedback = await writeErpFeedback({ context, run, writeResult, cleanRecords })
           if (feedback) erpFeedback.push(feedback)
@@ -640,6 +702,7 @@ function createPipelineRunner(deps = {}) {
       let finishRunWarning = null
       try {
         run = await runLogger.finishRun(run, metrics, status, {
+          provenanceEvents,
           details: {
             dryRun,
             watermarkAdvanced: !dryRun && metrics.rowsFailed === 0 && Boolean(lastSuccessfulWatermark),
@@ -648,6 +711,7 @@ function createPipelineRunner(deps = {}) {
             ...(targetWriteSummaries.length > 0 && {
               targetWriteSummaries,
             }),
+            ...buildProvenanceDetails(),
             maxPagesReached,
             pagesProcessed: page,
           },
@@ -673,7 +737,9 @@ function createPipelineRunner(deps = {}) {
       // The stuck 'running' run will be recovered by abandonStaleRuns on next trigger.
       try {
         run = await runLogger.finishRun(run, metrics, 'failed', {
+          provenanceEvents,
           errorSummary: error.message || String(error),
+          details: buildProvenanceDetails(),
         })
       } catch {
         // Secondary failure — original error takes priority

--- a/plugins/plugin-integration-core/lib/pipelines.cjs
+++ b/plugins/plugin-integration-core/lib/pipelines.cjs
@@ -256,6 +256,11 @@ function normalizeUpdateRunInput(input, now) {
     duration_ms: input.durationMs === undefined || input.durationMs === null ? null : nonNegativeInteger(input.durationMs, 'durationMs'),
     error_summary: optionalString(input.errorSummary, 'errorSummary'),
     details: input.details === undefined ? undefined : jsonbParam(jsonObject(input.details, 'details')),
+    // DF-N2-2b: persist per-row provenance to the integration_runs.provenance_events
+    // JSONB column (added by migration 060). The array is already normalized + redacted
+    // upstream in run-log.finishRun; this layer only serializes it. When absent, the
+    // undefined-cleanup below leaves the column at its '[]' default (no overwrite).
+    provenance_events: Array.isArray(input.provenanceEvents) ? jsonbParam(input.provenanceEvents) : undefined,
   }
   for (const key of Object.keys(set)) {
     if (set[key] === undefined || set[key] === null) delete set[key]

--- a/plugins/plugin-integration-core/lib/run-log.cjs
+++ b/plugins/plugin-integration-core/lib/run-log.cjs
@@ -1,5 +1,7 @@
 'use strict'
 
+const { normalizeProvenanceEvents } = require('./provenance-contracts.cjs')
+
 // Cap on the error_summary column so adapter errors that include full HTTP
 // response bodies or huge stack traces don't bloat the runs table. Long
 // summaries are truncated with a clear suffix so downstream tools can detect
@@ -84,6 +86,25 @@ function createRunLogger({ pipelineRegistry, clock = nowIso } = {}) {
     const normalizedMetrics = normalizeMetrics(metrics)
     const finishedAt = toIso(extra.finishedAt || clock())
     const durationMs = normalizedMetrics.durationMs ?? deriveDurationMs(run.startedAt, finishedAt)
+    // DF-N2-2b: normalize provenance events BEFORE persist. normalizeProvenanceEvents
+    // runs the shared payload redaction on each event's attrs (see
+    // provenance-contracts.normalizeAttrs → sanitizeIntegrationPayload) — this is the
+    // pre-storage scrub gate. Best-effort: a malformed event must never lose the run
+    // record, so a contract failure drops provenance for this run and surfaces a
+    // details.provenanceWarning instead of throwing.
+    let provenanceEvents
+    let provenanceWarning
+    if (Array.isArray(extra.provenanceEvents) && extra.provenanceEvents.length > 0) {
+      try {
+        provenanceEvents = normalizeProvenanceEvents(extra.provenanceEvents)
+      } catch (error) {
+        provenanceEvents = undefined
+        provenanceWarning = {
+          code: 'PROVENANCE_NORMALIZE_FAILED',
+          message: error && error.message ? error.message : String(error),
+        }
+      }
+    }
     return pipelineRegistry.updatePipelineRun({
       tenantId: run.tenantId,
       workspaceId: run.workspaceId,
@@ -96,9 +117,11 @@ function createRunLogger({ pipelineRegistry, clock = nowIso } = {}) {
       finishedAt,
       durationMs,
       errorSummary: sanitizeErrorSummary(extra.errorSummary),
+      ...(provenanceEvents !== undefined && { provenanceEvents }),
       details: {
         ...(run.details || {}),
         ...(extra.details || {}),
+        ...(provenanceWarning && { provenanceWarning }),
       },
     })
   }


### PR DESCRIPTION
Runtime-write slice of the merged **DF-N2-2 design** (#1979), on top of **DF-N2-2a storage** (#1981, `integration_runs.provenance_events` + by-row view) and the **DF-N2-1 contract** (#1882, `provenance-contracts.cjs`). Separate gated opt-in; **runtime write only**.

## What it does (tight slice)
`pipeline-runner` collects **per-row write-outcome** provenance during a live run and hands it to `run-log.finishRun`, which **normalizes + redacts** each event and persists the array to the `provenance_events` JSONB column via `pipelines.cjs`. `rowId` = the record's **idempotency key** (the cross-run identity the 2a view groups on). Emits `target_write_succeeded` / `target_write_failed`; written **once per run** (incl. the failed-run path).

## Acceptance points (test-locked — `pipeline-runner.test.cjs` §14–20 + `pipelines.test.cjs` §8b)
1. **Normalize before append** — §14 canonical shape only, ISO `at`, enum `eventType`.
2. **Shared redaction before append (KEYSTONE)** — §15 plants a secret-shaped *value* in a failed-write `errorMessage` (`postgres://erp:S3cretPass@…`) → asserts the persisted `attrs.errorMessage` is masked (`…erp:[redacted]@…`, context kept). Exercises the #1882-F1 value-scrubber; **fails if scrub is bypassed** (negative-controlled).
3. **Per-run / per-row cap** — §16: 502 rows → exactly 500 events, `provenanceDropped=2` + `provenanceCap=500` in `details`, one event per row. Overflow is a **counter in `details`**, not a sentinel event.
4. **Replay must NOT duplicate lineage** — §17: failed row → dead-letter → replay = **new run**; original run's lineage unchanged.
5. **No route/frontend/K3 + best-effort** — lib-only diff; §20 a malformed event drops provenance + surfaces `details.provenanceWarning` (never loses the run record); §18 failed-run path keeps pre-throw lineage (passed to both `finishRun` sites).

## Scope boundary (vs #1979)
- Write-outcome events only; `transform_failed`/`validation_failed` (no idempotency key yet, already in dead-letters) **deferred**.
- **No `dry_run_previewed`** (no real write).
- **No read surface** — `rowToPipelineRun` not changed; reading is **DF-N2-2c** (separate opt-in: by-`rowId` GET + RBAC + wire test).
- **No route / OpenAPI / RBAC / frontend / K3 / connector change**; `pipelines.cjs` is plugin-local (not core-backend).
- Success emitted **only on unambiguous attribution** (`unitemizedFailures===0 && !inconsistent`); else skipped + `provenanceAttributionSkipped` recorded — never infer "succeeded" from "absent from errors".

## Retention (unchanged, per #1979 §Retention)
Run-level aging + read-time bounded window (2c). The per-run cap bounds one row; it is **not** a per-row/event JSONB pruning pass.

## Tests
All **26** `plugin-integration-core` `*.test.cjs` green (with deps). Two negative controls run (scrub-bypass → §15 fails; failed-path-drop → §18 fails), both restored.

Verification: `docs/development/data-factory-df-n2-2b-provenance-runtime-write-verification-20260528.md`.

> Owner review requested — please do not auto-merge on green CI. DF-N2-2c / DF-N2-3 stay separate gated opt-ins.

🤖 Generated with [Claude Code](https://claude.com/claude-code)