### PR TITLE
docs(data-sources): add SQL Server smoke runbook

### DIFF
--- a/docs/development/sqlserver-smoke-runbook-20260528.md
+++ b/docs/development/sqlserver-smoke-runbook-20260528.md
@@ -1,0 +1,102 @@
+# SQL Server Data Source Smoke Runbook
+
+Date: 2026-05-28
+
+This runbook validates the generic `type=sqlserver` data source path that landed in Lane B PR1. It is intentionally a real-connection smoke check, not a unit test replacement.
+
+## What This Proves
+
+- The backend runtime can load the `mssql` driver.
+- The target SQL Server accepts TCP connections from the backend host.
+- The default TLS posture works: `encrypt=true` and `trustServerCertificate=true`.
+- Basic read operations work through `MSSQLAdapter`: connect, `SELECT 1`, parameterized query, schema introspection, table info, and sample select.
+
+## Prerequisites
+
+- SQL Server TCP/IP is enabled.
+- The backend host can reach the SQL Server port, normally `1433`.
+- A SQL username/password exists. Windows Integrated Auth / SSPI / Kerberos is outside this smoke path.
+- Use a read-only database account for customer or production-like databases.
+
+## Environment
+
+Required:
+
+```bash
+export MSSQL_HOST='192.168.1.20'
+export MSSQL_PORT='1433'
+export MSSQL_DATABASE='ERP'
+export MSSQL_USERNAME='readonly_user'
+export MSSQL_PASSWORD='...'
+```
+
+Optional:
+
+```bash
+export MSSQL_SCHEMA='dbo'
+export MSSQL_TABLE='SomeReadOnlyTable'
+export MSSQL_ENCRYPT='true'
+export MSSQL_TRUST_SERVER_CERTIFICATE='true'
+export MSSQL_CONNECTION_TIMEOUT_MS='10000'
+export MSSQL_REQUEST_TIMEOUT_MS='30000'
+```
+
+Compatibility alias:
+
+```bash
+export MSSQL_SERVER='192.168.1.20,1433'
+```
+
+Use either `MSSQL_HOST` plus `MSSQL_PORT`, or `MSSQL_SERVER`. If both are supplied, `MSSQL_HOST` wins. If `MSSQL_SERVER` embeds a port and `MSSQL_PORT` is also supplied, the two ports must agree.
+
+## Run
+
+```bash
+pnpm --filter @metasheet/core-backend smoke:sqlserver
+```
+
+For very large customer databases, schema introspection may be noisy because it walks table metadata. Use this narrower smoke when needed:
+
+```bash
+export MSSQL_SKIP_SCHEMA='true'
+pnpm --filter @metasheet/core-backend smoke:sqlserver
+```
+
+## Expected Output
+
+The successful path prints:
+
+```text
+[ok] connected
+[ok] testConnection SELECT 1
+[ok] parameterized query
+[ok] schema introspection
+```
+
+If `MSSQL_TABLE` is set, it should also print:
+
+```text
+[ok] table exists
+[ok] table info
+[ok] select sample
+```
+
+## Local SQL Server Option
+
+Microsoft SQL Server itself is not open source. For local testing, use SQL Server Developer or Express, or the official SQL Server container image. The container requires accepting Microsoft's EULA and is commonly amd64-oriented; on Apple Silicon, Docker Desktop may need amd64 emulation.
+
+Do not run the container against customer data. For customer verification, prefer the real Windows SQL Server host with a read-only SQL login.
+
+## Pass Criteria
+
+- All required `[ok]` lines appear.
+- No password or token is printed.
+- `MSSQL_ENCRYPT=true` works with the target server, or any `MSSQL_ENCRYPT=false` fallback is explicitly recorded as a legacy compatibility exception.
+- If a real table is supplied, `select sample` returns without write permissions.
+
+## Failure Triage
+
+- `mssql package is not installed`: run `pnpm install` from the repo root and verify `pnpm-lock.yaml` includes `mssql`.
+- Login failure: verify SQL authentication is enabled and the account is not a Windows-only login.
+- Timeout or refused connection: verify SQL Server TCP/IP, firewall, port, VPN, and backend host routing.
+- TLS/pre-login failure: first try the default `encrypt=true` and `trustServerCertificate=true`; use `MSSQL_ENCRYPT=false` only as an explicit legacy escape hatch.

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -17,6 +17,7 @@
     "seed:demo": "echo 'Seeding demo data...' && exit 0",
     "seed:rbac": "tsx scripts/seed-rbac.ts",
     "smoke:plugins": "tsx scripts/smoke-plugins.ts",
+    "smoke:sqlserver": "tsx scripts/smoke-sqlserver.ts",
     "yjs:status": "node ../../scripts/ops/check-yjs-rollout-status.mjs",
     "yjs:validate": "node scripts/ops/yjs-node-client.mjs",
     "test": "vitest",

--- a/packages/core-backend/scripts/smoke-sqlserver.ts
+++ b/packages/core-backend/scripts/smoke-sqlserver.ts
@@ -1,0 +1,173 @@
+import { MSSQLAdapter } from '../src/data-adapters/MSSQLAdapter'
+import type { ConfigValue, DataSourceConfig } from '../src/data-adapters/BaseAdapter'
+
+const env = process.env
+
+function printHelp(): void {
+  console.log(`Usage: pnpm --filter @metasheet/core-backend smoke:sqlserver
+
+Required environment:
+  MSSQL_HOST or MSSQL_SERVER
+  MSSQL_DATABASE
+  MSSQL_USERNAME
+  MSSQL_PASSWORD
+
+Optional environment:
+  MSSQL_PORT
+  MSSQL_SCHEMA
+  MSSQL_TABLE
+  MSSQL_ENCRYPT
+  MSSQL_TRUST_SERVER_CERTIFICATE
+  MSSQL_CONNECTION_TIMEOUT_MS
+  MSSQL_REQUEST_TIMEOUT_MS
+  MSSQL_SKIP_SCHEMA`)
+}
+
+function required(name: string): string {
+  const value = env[name]
+  if (!value) {
+    throw new Error(`Missing required environment variable: ${name}`)
+  }
+  return value
+}
+
+function optionalNumber(name: string): number | undefined {
+  const value = env[name]
+  if (value == null || value.trim() === '') return undefined
+  const parsed = Number(value)
+  if (!Number.isFinite(parsed)) {
+    throw new Error(`${name} must be a number`)
+  }
+  return parsed
+}
+
+function optionalBoolean(name: string): boolean | undefined {
+  const value = env[name]
+  if (value == null || value.trim() === '') return undefined
+  const normalized = value.trim().toLowerCase()
+  if (['true', '1', 'yes', 'on'].includes(normalized)) return true
+  if (['false', '0', 'no', 'off'].includes(normalized)) return false
+  throw new Error(`${name} must be a boolean-like value`)
+}
+
+function putOptional(
+  target: Record<string, ConfigValue>,
+  name: string,
+  value: ConfigValue | undefined
+): void {
+  if (value !== undefined) {
+    target[name] = value
+  }
+}
+
+function buildConfig(): DataSourceConfig {
+  const connection: Record<string, ConfigValue> = {
+    database: required('MSSQL_DATABASE')
+  }
+
+  putOptional(connection, 'host', env.MSSQL_HOST)
+  putOptional(connection, 'server', env.MSSQL_SERVER)
+  putOptional(connection, 'port', optionalNumber('MSSQL_PORT'))
+  putOptional(connection, 'encrypt', optionalBoolean('MSSQL_ENCRYPT'))
+  putOptional(connection, 'trustServerCertificate', optionalBoolean('MSSQL_TRUST_SERVER_CERTIFICATE'))
+  putOptional(connection, 'connectionTimeoutMs', optionalNumber('MSSQL_CONNECTION_TIMEOUT_MS'))
+  putOptional(connection, 'requestTimeoutMs', optionalNumber('MSSQL_REQUEST_TIMEOUT_MS'))
+
+  return {
+    id: 'sqlserver-smoke',
+    name: 'SQL Server Smoke',
+    type: 'sqlserver',
+    connection,
+    credentials: {
+      username: required('MSSQL_USERNAME'),
+      password: required('MSSQL_PASSWORD')
+    },
+    options: {
+      readOnly: true,
+      autoConnect: false
+    }
+  }
+}
+
+async function main(): Promise<void> {
+  const config = buildConfig()
+  const schema = env.MSSQL_SCHEMA || 'dbo'
+  const table = env.MSSQL_TABLE
+  const skipSchema = optionalBoolean('MSSQL_SKIP_SCHEMA') === true
+
+  const adapter = new MSSQLAdapter(config)
+
+  console.log('[sqlserver-smoke] target', {
+    host: config.connection.host,
+    server: config.connection.server,
+    port: config.connection.port,
+    database: config.connection.database,
+    encrypt: config.connection.encrypt ?? true,
+    trustServerCertificate: config.connection.trustServerCertificate ?? true,
+    schema,
+    table: table || null
+  })
+
+  try {
+    await adapter.connect()
+    console.log('[ok] connected')
+
+    const healthy = await adapter.testConnection()
+    if (!healthy) {
+      throw new Error('testConnection returned false')
+    }
+    console.log('[ok] testConnection SELECT 1')
+
+    const one = await adapter.query<{ ok: number }>('SELECT $1 AS ok', [1])
+    if (one.error) throw one.error
+    if (one.data[0]?.ok !== 1) {
+      throw new Error(`Unexpected SELECT result: ${JSON.stringify(one.data)}`)
+    }
+    console.log('[ok] parameterized query')
+
+    if (!skipSchema) {
+      const info = await adapter.getSchema(schema)
+      console.log('[ok] schema introspection', {
+        schema,
+        tables: info.tables.length,
+        views: info.views?.length ?? 0
+      })
+    }
+
+    if (table) {
+      const exists = await adapter.tableExists(table, schema)
+      if (!exists) {
+        throw new Error(`Table not found: ${schema}.${table}`)
+      }
+      console.log('[ok] table exists', `${schema}.${table}`)
+
+      const tableInfo = await adapter.getTableInfo(table, schema)
+      console.log('[ok] table info', {
+        table: `${schema}.${table}`,
+        columns: tableInfo.columns.length,
+        primaryKey: tableInfo.primaryKey ?? []
+      })
+
+      const sample = await adapter.select(table, { limit: 5 })
+      if (sample.error) throw sample.error
+      console.log('[ok] select sample', {
+        table: `${schema}.${table}`,
+        rows: sample.data.length
+      })
+    }
+  } finally {
+    await adapter.disconnect().catch(error => {
+      console.warn('[warn] disconnect failed', error)
+    })
+  }
+}
+
+if (process.argv.includes('--help')) {
+  printHelp()
+} else {
+  main().catch(error => {
+    console.error('[failed] SQL Server smoke failed')
+    console.error(error)
+    process.exitCode = 1
+  })
+}


### PR DESCRIPTION
## Summary
- Adds a backend `smoke:sqlserver` script that exercises the generic `MSSQLAdapter` against a real SQL Server using environment variables.
- Adds a runbook for validating the modern direct SQL Server path after Lane B PR1.
- Keeps the check read-only: connect, `SELECT 1`, parameterized query, optional schema/table introspection, and optional sample select.

## Notes
- Does not accept the Microsoft SQL Server container EULA or start Docker automatically.
- Docker daemon is not currently running on this machine, so this PR prepares the smoke path rather than executing a local SQL Server container.
- Real customer verification should use a read-only SQL login and keep `encrypt=true`, `trustServerCertificate=true` unless a legacy exception is explicitly recorded.

## Test plan
- `pnpm --filter @metasheet/core-backend smoke:sqlserver -- --help`
- `pnpm exec tsc --noEmit` from `packages/core-backend`
- `pnpm exec vitest run tests/unit/mssql-adapter.test.ts` from `packages/core-backend`
- `pnpm exec eslint src/data-adapters/MSSQLAdapter.ts` from `packages/core-backend`
