### PR TITLE
feat(attendance): preview fixed schedules for groups

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -3235,6 +3235,86 @@
                       </div>
                     </div>
                   </section>
+
+                  <section
+                    v-if="attendanceGroupEditingId"
+                    class="attendance__group-panel"
+                    data-attendance-group-fixed-schedule-preview
+                  >
+                    <div class="attendance__admin-section-header">
+                      <div>
+                        <h6>{{ tr('Fixed schedule preview', '固定排班预览') }}</h6>
+                        <span class="attendance__field-hint">{{ tr('Preview only: target members are resolved server-side and no assignments are written.', '仅预览：目标成员由服务端完整枚举，不写入任何排班。') }}</span>
+                      </div>
+                      <button
+                        class="attendance__btn"
+                        type="button"
+                        @click="selectAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.assignments)"
+                      >
+                        {{ tr('Open Assignments', '打开排班分配') }}
+                      </button>
+                    </div>
+                    <div class="attendance__admin-grid">
+                      <label class="attendance__field" for="attendance-group-fixed-schedule-shift">
+                        <span>{{ tr('Shift', '班次') }}</span>
+                        <select
+                          id="attendance-group-fixed-schedule-shift"
+                          v-model="attendanceGroupFixedSchedulePreviewForm.shiftId"
+                          :disabled="shifts.length === 0 || attendanceGroupFixedSchedulePreviewLoading"
+                          data-attendance-group-fixed-schedule-shift
+                        >
+                          <option value="">{{ tr('Select shift', '选择班次') }}</option>
+                          <option v-for="shift in shifts" :key="shift.id" :value="shift.id">
+                            {{ shift.name }}
+                          </option>
+                        </select>
+                      </label>
+                      <label class="attendance__field" for="attendance-group-fixed-schedule-start">
+                        <span>{{ tr('Start date', '开始日期') }}</span>
+                        <input
+                          id="attendance-group-fixed-schedule-start"
+                          v-model="attendanceGroupFixedSchedulePreviewForm.startDate"
+                          type="date"
+                          :disabled="attendanceGroupFixedSchedulePreviewLoading"
+                          data-attendance-group-fixed-schedule-start
+                        />
+                      </label>
+                      <label class="attendance__field" for="attendance-group-fixed-schedule-end">
+                        <span>{{ tr('End date', '结束日期') }}</span>
+                        <input
+                          id="attendance-group-fixed-schedule-end"
+                          v-model="attendanceGroupFixedSchedulePreviewForm.endDate"
+                          type="date"
+                          :disabled="attendanceGroupFixedSchedulePreviewLoading"
+                          data-attendance-group-fixed-schedule-end
+                        />
+                      </label>
+                    </div>
+                    <div class="attendance__admin-actions">
+                      <button
+                        class="attendance__btn attendance__btn--primary"
+                        type="button"
+                        :disabled="!attendanceGroupFixedSchedulePreviewAvailable"
+                        data-attendance-group-fixed-schedule-preview-submit
+                        @click="previewAttendanceGroupFixedSchedule"
+                      >
+                        {{ attendanceGroupFixedSchedulePreviewLoading ? tr('Previewing...', '预览中...') : tr('Preview fixed schedule', '预览固定排班') }}
+                      </button>
+                    </div>
+                    <div
+                      v-if="attendanceGroupFixedSchedulePreviewResult"
+                      class="attendance__group-preview-result"
+                      data-attendance-group-fixed-schedule-preview-result
+                    >
+                      <strong data-attendance-group-fixed-schedule-preview-summary>{{ attendanceGroupFixedSchedulePreviewSummary }}</strong>
+                      <div class="attendance__group-preview-counts">
+                        <span data-attendance-group-fixed-schedule-preview-create>{{ tr('Would create', '将创建') }}: {{ attendanceGroupFixedSchedulePreviewResult.wouldCreate.length }}</span>
+                        <span data-attendance-group-fixed-schedule-preview-skip>{{ tr('Skipped', '跳过') }}: {{ attendanceGroupFixedSchedulePreviewResult.skipped.length }}</span>
+                        <span data-attendance-group-fixed-schedule-preview-conflict>{{ tr('Blocking conflicts', '阻断冲突') }}: {{ attendanceGroupFixedSchedulePreviewResult.blockingConflicts.length }}</span>
+                      </div>
+                      <small class="attendance__field-hint">{{ tr('If blocking conflicts are present, the future apply step must write nothing.', '如果存在阻断冲突，后续应用步骤必须零写入。') }}</small>
+                    </div>
+                  </section>
                 </section>
               </div>
             </div>
@@ -6214,6 +6294,51 @@ interface AttendanceGroupMember {
 
 type AttendanceGroupMemberResolvedUsers = Record<string, AttendanceAdminBatchResolveItem>
 
+interface AttendanceGroupFixedSchedulePreviewCandidate {
+  userId: string
+  shiftId: string
+  startDate: string
+  endDate: string | null
+  isActive: boolean
+}
+
+interface AttendanceGroupFixedSchedulePreviewSkipped {
+  assignmentId: string
+  userId: string
+  shiftId: string
+  startDate: string
+  endDate: string | null
+}
+
+interface AttendanceGroupFixedSchedulePreviewConflict {
+  conflictType: string
+  draftKind: string
+  existingKind: string
+  assignmentId: string
+  userId: string
+  startDate: string
+  endDate: string | null
+  existingStartDate: string
+  existingEndDate: string | null
+  message?: string
+}
+
+interface AttendanceGroupFixedSchedulePreviewResult {
+  group: AttendanceGroup
+  shift: AttendanceShift
+  window: {
+    startDate: string
+    endDate: string | null
+  }
+  target: {
+    total: number
+    userIds: string[]
+  }
+  wouldCreate: AttendanceGroupFixedSchedulePreviewCandidate[]
+  skipped: AttendanceGroupFixedSchedulePreviewSkipped[]
+  blockingConflicts: AttendanceGroupFixedSchedulePreviewConflict[]
+}
+
 type AttendanceGroupSummaryAction = {
   key: string
   label: string
@@ -6794,6 +6919,7 @@ const attendanceGroupLoading = ref(false)
 const attendanceGroupSaving = ref(false)
 const attendanceGroupMemberLoading = ref(false)
 const attendanceGroupMemberSaving = ref(false)
+const attendanceGroupFixedSchedulePreviewLoading = ref(false)
 const payrollTemplateLoading = ref(false)
 const payrollTemplateSaving = ref(false)
 const payrollSummaryFieldOptionsLoading = ref(false)
@@ -7896,6 +8022,12 @@ const attendanceGroupPendingMemberIds = ref<string[]>([])
 const attendanceGroupMemberDuplicateNotice = ref('')
 const attendanceGroupMemberTotal = ref(0)
 const attendanceGroupMemberResolvedUsers = ref<AttendanceGroupMemberResolvedUsers>({})
+const attendanceGroupFixedSchedulePreviewForm = reactive({
+  shiftId: '',
+  startDate: toDateInput(new Date()),
+  endDate: toDateInput(new Date()),
+})
+const attendanceGroupFixedSchedulePreviewResult = ref<AttendanceGroupFixedSchedulePreviewResult | null>(null)
 const payrollTemplateEditingId = ref<string | null>(null)
 const payrollCycleEditingId = ref<string | null>(null)
 const payrollCycleSummary = ref<AttendanceSummary | null>(null)
@@ -8083,6 +8215,23 @@ const attendanceGroupSummaryCards = computed<AttendanceGroupSummaryCard[]>(() =>
 const attendanceGroupMemberSubmitAvailable = computed(() =>
   attendanceGroupPendingMemberIds.value.length > 0 || parseUserIdList(attendanceGroupMemberUserIds.value).length > 0
 )
+const attendanceGroupFixedSchedulePreviewAvailable = computed(() =>
+  Boolean(
+    attendanceGroupEditingId.value
+      && attendanceGroupFixedSchedulePreviewForm.shiftId
+      && attendanceGroupFixedSchedulePreviewForm.startDate
+      && attendanceGroupFixedSchedulePreviewForm.endDate
+      && !attendanceGroupFixedSchedulePreviewLoading.value,
+  )
+)
+const attendanceGroupFixedSchedulePreviewSummary = computed(() => {
+  const result = attendanceGroupFixedSchedulePreviewResult.value
+  if (!result) return ''
+  return tr(
+    `${result.target.total} target members · ${result.wouldCreate.length} would create · ${result.skipped.length} skipped · ${result.blockingConflicts.length} blocking conflicts`,
+    `${result.target.total} 位目标成员 · ${result.wouldCreate.length} 位将创建 · ${result.skipped.length} 位跳过 · ${result.blockingConflicts.length} 个阻断冲突`,
+  )
+})
 const importCsvFile = ref<File | null>(null)
 const importCsvFileName = ref('')
 const importCsvFileId = ref('')
@@ -15356,6 +15505,9 @@ async function loadShifts() {
     if (!assignmentForm.shiftId && shifts.value.length > 0) {
       assignmentForm.shiftId = shifts.value[0].id
     }
+    if (!attendanceGroupFixedSchedulePreviewForm.shiftId && shifts.value.length > 0) {
+      attendanceGroupFixedSchedulePreviewForm.shiftId = shifts.value[0].id
+    }
   } catch (error: any) {
     setStatus(readErrorMessage(error, tr('Failed to load shifts', '加载班次失败')), 'error')
   } finally {
@@ -15765,7 +15917,15 @@ function resetAttendanceGroupForm() {
   attendanceGroupMembers.value = []
   attendanceGroupMemberTotal.value = 0
   attendanceGroupMemberResolvedUsers.value = {}
+  resetAttendanceGroupFixedSchedulePreview()
   resetAttendanceGroupMemberDraft()
+}
+
+function resetAttendanceGroupFixedSchedulePreview() {
+  attendanceGroupFixedSchedulePreviewResult.value = null
+  attendanceGroupFixedSchedulePreviewForm.startDate = toDateInput(today)
+  attendanceGroupFixedSchedulePreviewForm.endDate = toDateInput(today)
+  attendanceGroupFixedSchedulePreviewForm.shiftId = shifts.value[0]?.id ?? attendanceGroupFixedSchedulePreviewForm.shiftId
 }
 
 function editAttendanceGroup(item: AttendanceGroup) {
@@ -15781,6 +15941,7 @@ function editAttendanceGroup(item: AttendanceGroup) {
     attendanceGroupMembers.value = []
     attendanceGroupMemberTotal.value = 0
     attendanceGroupMemberResolvedUsers.value = {}
+    resetAttendanceGroupFixedSchedulePreview()
     resetAttendanceGroupMemberDraft()
   }
 }
@@ -15916,6 +16077,50 @@ async function loadAttendanceGroupMembers() {
     setStatus(readErrorMessage(error, tr('Failed to load group members', '加载分组成员失败')), 'error')
   } finally {
     attendanceGroupMemberLoading.value = false
+  }
+}
+
+async function previewAttendanceGroupFixedSchedule() {
+  const groupId = attendanceGroupEditingId.value
+  if (!groupId) {
+    setStatus(tr('Save the group before previewing a fixed schedule.', '请先保存考勤组，再预览固定排班。'), 'error')
+    return
+  }
+  if (!attendanceGroupFixedSchedulePreviewForm.shiftId) {
+    setStatus(tr('Select a shift before previewing.', '请先选择班次再预览。'), 'error')
+    return
+  }
+  if (!attendanceGroupFixedSchedulePreviewForm.startDate || !attendanceGroupFixedSchedulePreviewForm.endDate) {
+    setStatus(tr('Select a start and end date before previewing.', '请先选择开始和结束日期再预览。'), 'error')
+    return
+  }
+  attendanceGroupFixedSchedulePreviewLoading.value = true
+  attendanceGroupFixedSchedulePreviewResult.value = null
+  try {
+    const response = await apiFetch(`/api/attendance/groups/${groupId}/fixed-schedule/preview`, {
+      method: 'POST',
+      body: JSON.stringify({
+        shiftId: attendanceGroupFixedSchedulePreviewForm.shiftId,
+        startDate: attendanceGroupFixedSchedulePreviewForm.startDate,
+        endDate: attendanceGroupFixedSchedulePreviewForm.endDate,
+        orgId: normalizedOrgId(),
+      }),
+    })
+    if (response.status === 403) {
+      adminForbidden.value = true
+      throw new Error(tr('Admin permissions required', '需要管理员权限'))
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to preview fixed schedule', '预览固定排班失败')))
+    }
+    adminForbidden.value = false
+    attendanceGroupFixedSchedulePreviewResult.value = data.data as AttendanceGroupFixedSchedulePreviewResult
+    setStatus(tr('Fixed schedule preview ready. No assignments were written.', '固定排班预览已生成，未写入任何排班。'))
+  } catch (error: any) {
+    setStatus(readErrorMessage(error, tr('Failed to preview fixed schedule', '预览固定排班失败')), 'error')
+  } finally {
+    attendanceGroupFixedSchedulePreviewLoading.value = false
   }
 }
 
@@ -16771,6 +16976,17 @@ watch(attendanceGroupMemberGroupId, () => {
     loadAttendanceGroupMembers()
   }
 })
+
+watch(
+  () => [
+    attendanceGroupFixedSchedulePreviewForm.shiftId,
+    attendanceGroupFixedSchedulePreviewForm.startDate,
+    attendanceGroupFixedSchedulePreviewForm.endDate,
+  ],
+  () => {
+    attendanceGroupFixedSchedulePreviewResult.value = null
+  },
+)
 
 watch(importProfileId, () => {
   const profile = selectedImportProfile.value
@@ -18847,6 +19063,23 @@ const holidaySectionBindings = {
   flex-wrap: wrap;
   gap: 6px;
   margin-top: 4px;
+}
+
+.attendance__group-preview-result {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid #dbe3ee;
+  border-radius: 8px;
+  background: #f9fafb;
+}
+
+.attendance__group-preview-counts {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  color: #374151;
+  font-size: 12px;
 }
 
 .attendance__details {

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -677,6 +677,160 @@ describe('Attendance admin regressions', () => {
     expect(window.getComputedStyle(container!.querySelector<HTMLElement>('#attendance-admin-groups')!).display).toBe('none')
   })
 
+  it('previews fixed schedule coverage without writing assignments', async () => {
+    const previewBodies: unknown[] = []
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/rule-sets')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              { id: 'rule-set-1', name: 'Ops Rules', scope: 'org', version: 3, isDefault: true },
+            ],
+            total: 1,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/groups/group-a/fixed-schedule/preview') && init?.method === 'POST') {
+        previewBodies.push(JSON.parse(String(init.body || '{}')))
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            group: {
+              id: 'group-a',
+              name: 'Ops Team',
+              timezone: 'Asia/Shanghai',
+            },
+            shift: {
+              id: 'shift-a',
+              name: 'Day shift',
+              timezone: 'Asia/Shanghai',
+              workStartTime: '09:00',
+              workEndTime: '18:00',
+              lateGraceMinutes: 10,
+              earlyGraceMinutes: 5,
+              roundingMinutes: 5,
+              workingDays: [1, 2, 3, 4, 5],
+            },
+            window: { startDate: '2026-06-01', endDate: '2026-06-30' },
+            target: { total: 3, userIds: ['user-create', 'user-skip', 'user-conflict'] },
+            wouldCreate: [
+              { userId: 'user-create', shiftId: 'shift-a', startDate: '2026-06-01', endDate: '2026-06-30', isActive: true },
+            ],
+            skipped: [
+              { assignmentId: 'assignment-skip', userId: 'user-skip', shiftId: 'shift-a', startDate: '2026-06-01', endDate: '2026-06-30' },
+            ],
+            blockingConflicts: [
+              {
+                conflictType: 'shift_assignment_overlap',
+                draftKind: 'shift',
+                existingKind: 'shift',
+                assignmentId: 'assignment-conflict',
+                userId: 'user-conflict',
+                startDate: '2026-06-01',
+                endDate: '2026-06-30',
+                existingStartDate: '2026-06-10',
+                existingEndDate: '2026-06-20',
+                message: 'Shift assignment overlaps an active shift assignment for the same user',
+              },
+            ],
+          },
+        })
+      }
+      if (url.includes('/api/attendance/groups/group-a/members')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              { id: 'member-1', groupId: 'group-a', userId: 'user-create', createdAt: '2026-03-28T08:00:00.000Z' },
+            ],
+            total: 3,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/groups')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'group-a',
+                name: 'Ops Team',
+                code: 'ops-team',
+                timezone: 'Asia/Shanghai',
+                ruleSetId: 'rule-set-1',
+                description: 'Operations attendance group',
+              },
+            ],
+            total: 1,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/shifts')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'shift-a',
+                name: 'Day shift',
+                timezone: 'Asia/Shanghai',
+                workStartTime: '09:00',
+                workEndTime: '18:00',
+                lateGraceMinutes: 10,
+                earlyGraceMinutes: 5,
+                roundingMinutes: 5,
+                workingDays: [1, 2, 3, 4, 5],
+              },
+            ],
+          },
+        })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const groupsNav = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-groups"]')
+    expect(groupsNav).toBeTruthy()
+    groupsNav!.click()
+    await flushUi(4)
+
+    const previewPanel = container!.querySelector<HTMLElement>('[data-attendance-group-fixed-schedule-preview]')
+    expect(previewPanel).toBeTruthy()
+    const shiftSelect = previewPanel!.querySelector<HTMLSelectElement>('[data-attendance-group-fixed-schedule-shift]')
+    expect(shiftSelect).toBeTruthy()
+    shiftSelect!.value = 'shift-a'
+    shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(previewPanel!, '[data-attendance-group-fixed-schedule-start]', '2026-06-01')
+    setInput(previewPanel!, '[data-attendance-group-fixed-schedule-end]', '2026-06-30')
+    await flushUi(2)
+
+    const previewButton = previewPanel!.querySelector<HTMLButtonElement>('[data-attendance-group-fixed-schedule-preview-submit]')
+    expect(previewButton).toBeTruthy()
+    previewButton!.click()
+    await flushUi(8)
+
+    expect(previewBodies).toEqual([
+      {
+        shiftId: 'shift-a',
+        startDate: '2026-06-01',
+        endDate: '2026-06-30',
+      },
+    ])
+    expect(previewPanel!.querySelector('[data-attendance-group-fixed-schedule-preview-summary]')?.textContent).toContain('3 target members')
+    expect(previewPanel!.querySelector('[data-attendance-group-fixed-schedule-preview-create]')?.textContent).toContain('1')
+    expect(previewPanel!.querySelector('[data-attendance-group-fixed-schedule-preview-skip]')?.textContent).toContain('1')
+    expect(previewPanel!.querySelector('[data-attendance-group-fixed-schedule-preview-conflict]')?.textContent).toContain('1')
+    expect(previewPanel!.textContent).not.toContain('Apply')
+    expect(vi.mocked(apiFetch).mock.calls.some(([input, init]) =>
+      String(input) === '/api/attendance/assignments' && init?.method === 'POST'
+    )).toBe(false)
+  })
+
   it('renders the production calendar-policy quick-add panel and appends a group day-index row', async () => {
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)

--- a/docs/development/attendance-group-admin-ux-fixed-schedule-preview-verification-20260528.md
+++ b/docs/development/attendance-group-admin-ux-fixed-schedule-preview-verification-20260528.md
@@ -1,0 +1,79 @@
+# Attendance Group Fixed-Schedule Preview Verification — 2026-05-28
+
+## Scope
+
+FS-B implements the fixed-schedule preview slice from `attendance-group-admin-ux-fixed-schedule-design-20260528.md`.
+
+The slice is intentionally preview-only:
+
+- Adds `POST /api/attendance/groups/:id/fixed-schedule/preview`.
+- Enumerates all target members server-side from `attendance_group_members`.
+- Classifies targets as `wouldCreate[]`, `skipped[]`, or `blockingConflicts[]`.
+- Adds an Attendance groups UI preview panel that can submit the preview and render counts.
+- Does not write `attendance_shift_assignments`, `attendance_rotation_assignments`, `attendance_schedule_groups`, or any other table.
+- Does not add an apply button, migration, permission, route outside the preview endpoint, or schema change.
+
+## Verification
+
+Commands run from `/tmp/metasheet2-attendance-group-fixed-schedule-preview-20260528`:
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-scheduling-assignment-conflict.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run --watch=false tests/attendance-admin-regressions.spec.ts
+git diff --check
+```
+
+Results:
+
+- `node --check plugins/plugin-attendance/index.cjs`: PASS.
+- Backend conflict/preview targeted suite: PASS, `7/7`.
+- Backend route UUID validation targeted suite: PASS, `3/3`.
+- Frontend targeted suite: PASS, `29/29`.
+- `git diff --check`: PASS.
+
+Additional attempted check:
+
+```bash
+pnpm --filter @metasheet/web type-check
+```
+
+Result: blocked by missing local `echarts` install in the borrowed main worktree dependencies:
+
+```text
+Cannot find module 'echarts/core'
+Cannot find module 'echarts/charts'
+Cannot find module 'echarts/components'
+Cannot find module 'echarts/renderers'
+Cannot find module 'echarts'
+```
+
+`apps/web/package.json` declares `echarts: ^5.5.0`; the local dependency tree used for this isolated worktree does not currently contain `apps/web/node_modules/echarts`. This is a local dependency-install gap, not introduced by this slice.
+
+## Test Coverage Added
+
+Backend:
+
+- `buildAttendanceGroupFixedSchedulePreview` classifies one `wouldCreate`, one exact-match `skipped`, one shift blocking conflict, and one rotation blocking conflict.
+- The helper reads the full member set via `attendance_group_members` and queries assignment tables read-only.
+- The helper rejects empty groups before previewing.
+- The SQL source assertion rejects accidental `INSERT`, `UPDATE`, or `DELETE` in the preview helper test path.
+- The route rejects malformed group UUIDs before hitting the database.
+
+Frontend:
+
+- The Attendance groups panel can submit the preview to `/api/attendance/groups/:id/fixed-schedule/preview`.
+- The request body contains only `shiftId`, `startDate`, and `endDate` for the preview.
+- The preview result renders target/create/skip/conflict counts.
+- The preview panel has no "Apply" action and does not POST to `/api/attendance/assignments`.
+
+## Deferred
+
+FS-C remains a separate explicit opt-in:
+
+- Apply/write route.
+- Transactional per-user locks and revalidation.
+- Zero writes when `blockingConflicts[]` is non-empty.
+- Creation of missing exact assignments when skips are present.
+- Post-apply reload and production/staging acceptance.

--- a/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
@@ -103,4 +103,140 @@ describe('attendance scheduling assignment conflict guard', () => {
     expect(helpers.getAttendanceScheduleAssignmentConflictType('rotation', 'shift')).toBe('rotation_overrides_shift')
     expect(helpers.getAttendanceScheduleAssignmentConflictType('shift', 'rotation')).toBe('rotation_overrides_shift')
   })
+
+  it('builds fixed-schedule group previews from the complete member set without writes', async () => {
+    const db = {
+      query: vi.fn()
+        .mockResolvedValueOnce([
+          {
+            id: 'group-a',
+            org_id: 'org-a',
+            name: 'Operations',
+            code: 'ops',
+            timezone: 'Asia/Shanghai',
+            rule_set_id: null,
+            description: null,
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            id: 'shift-a',
+            org_id: 'org-a',
+            name: 'Day shift',
+            timezone: 'Asia/Shanghai',
+            work_start_time: '09:00',
+            work_end_time: '18:00',
+            late_grace_minutes: 10,
+            early_grace_minutes: 5,
+            rounding_minutes: 5,
+            working_days: [1, 2, 3, 4, 5],
+          },
+        ])
+        .mockResolvedValueOnce([
+          { user_id: 'user-create' },
+          { user_id: 'user-skip' },
+          { user_id: 'user-shift-conflict' },
+          { user_id: 'user-rotation-conflict' },
+        ])
+        .mockResolvedValueOnce([
+          {
+            id: 'assignment-skip',
+            user_id: 'user-skip',
+            shift_id: 'shift-a',
+            start_date: '2026-06-01',
+            end_date: '2026-06-30',
+            kind: 'shift',
+          },
+          {
+            id: 'assignment-conflict',
+            user_id: 'user-shift-conflict',
+            shift_id: 'shift-b',
+            start_date: '2026-06-10',
+            end_date: '2026-06-20',
+            kind: 'shift',
+          },
+        ])
+        .mockResolvedValueOnce([
+          {
+            id: 'rotation-conflict',
+            user_id: 'user-rotation-conflict',
+            rotation_rule_id: 'rotation-a',
+            start_date: '2026-06-01',
+            end_date: null,
+            kind: 'rotation',
+          },
+        ]),
+    }
+
+    const preview = await helpers.buildAttendanceGroupFixedSchedulePreview(db, {
+      orgId: 'org-a',
+      groupId: 'group-a',
+      shiftId: 'shift-a',
+      startDate: '2026-06-01',
+      endDate: '2026-06-30',
+    })
+
+    expect(preview.ok).toBe(true)
+    expect(preview.data.target).toEqual({
+      total: 4,
+      userIds: ['user-create', 'user-skip', 'user-shift-conflict', 'user-rotation-conflict'],
+    })
+    expect(preview.data.wouldCreate).toEqual([
+      {
+        userId: 'user-create',
+        shiftId: 'shift-a',
+        startDate: '2026-06-01',
+        endDate: '2026-06-30',
+        isActive: true,
+      },
+    ])
+    expect(preview.data.skipped).toEqual([
+      {
+        assignmentId: 'assignment-skip',
+        userId: 'user-skip',
+        shiftId: 'shift-a',
+        startDate: '2026-06-01',
+        endDate: '2026-06-30',
+      },
+    ])
+    expect(preview.data.blockingConflicts.map((item: any) => item.userId)).toEqual([
+      'user-shift-conflict',
+      'user-rotation-conflict',
+    ])
+    expect(preview.data.blockingConflicts.map((item: any) => item.conflictType)).toEqual([
+      'shift_assignment_overlap',
+      'rotation_overrides_shift',
+    ])
+
+    const queries = db.query.mock.calls.map(call => String(call[0])).join('\n')
+    expect(queries).toContain('attendance_group_members')
+    expect(queries).toContain('attendance_shift_assignments')
+    expect(queries).toContain('attendance_rotation_assignments')
+    expect(queries).not.toMatch(/\b(INSERT|UPDATE|DELETE)\b/i)
+  })
+
+  it('rejects fixed-schedule group previews for empty groups', async () => {
+    const db = {
+      query: vi.fn()
+        .mockResolvedValueOnce([{ id: 'group-a', org_id: 'org-a', name: 'Operations', timezone: 'UTC' }])
+        .mockResolvedValueOnce([{ id: 'shift-a', org_id: 'org-a', name: 'Day shift', timezone: 'UTC' }])
+        .mockResolvedValueOnce([]),
+    }
+
+    const preview = await helpers.buildAttendanceGroupFixedSchedulePreview(db, {
+      orgId: 'org-a',
+      groupId: 'group-a',
+      shiftId: 'shift-a',
+      startDate: '2026-06-01',
+      endDate: '2026-06-30',
+    })
+
+    expect(preview).toEqual({
+      ok: false,
+      status: 400,
+      code: 'VALIDATION_ERROR',
+      message: 'Group has no members to schedule',
+    })
+    expect(db.query).toHaveBeenCalledTimes(3)
+  })
 })

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -134,13 +134,21 @@ describe('attendance UUID route validation', () => {
       { key: 'GET /api/attendance/payroll-cycles/:id/summary' },
       { key: 'GET /api/attendance/payroll-cycles/:id/summary/export' },
       { key: 'GET /api/attendance/payroll-cycles/:id/export' },
+      {
+        key: 'POST /api/attendance/groups/:id/fixed-schedule/preview',
+        body: {
+          shiftId: '00000000-0000-4000-8000-000000000001',
+          startDate: '2026-06-01',
+          endDate: '2026-06-30',
+        },
+      },
       { key: 'GET /api/attendance/holidays/:id' },
       { key: 'PUT /api/attendance/holidays/:id' },
       { key: 'DELETE /api/attendance/holidays/:id' },
     ]
 
     for (const testCase of cases) {
-      const res = await invokeRoute(routes, testCase.key, { params: { id: 'not-a-uuid' } })
+      const res = await invokeRoute(routes, testCase.key, { params: { id: 'not-a-uuid' }, body: 'body' in testCase ? testCase.body : undefined })
       expect(res.statusCode, testCase.key).toBe(400)
       expect(res.body, testCase.key).toMatchObject({
         ok: false,

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8659,6 +8659,173 @@ async function findAttendanceScheduleAssignmentConflict(db, draft) {
   return mapAttendanceScheduleAssignmentConflict(otherKindRows[0], draft)
 }
 
+function mapAttendanceGroupFixedSchedulePreviewCandidate(userId, input) {
+  return {
+    userId,
+    shiftId: input.shiftId,
+    startDate: input.startDate,
+    endDate: input.endDate ?? null,
+    isActive: true,
+  }
+}
+
+function mapAttendanceGroupFixedScheduleSkipped(row, draft) {
+  return {
+    assignmentId: row.id,
+    userId: draft.userId,
+    shiftId: draft.shiftId,
+    startDate: normalizeDateOnly(row.start_date) ?? row.start_date,
+    endDate: normalizeAttendanceScheduleAssignmentEndDate(row.end_date),
+  }
+}
+
+function isExactAttendanceGroupFixedScheduleAssignment(row, draft) {
+  return row?.kind !== 'rotation'
+    && String(row?.shift_id || '') === String(draft.shiftId || '')
+    && (normalizeDateOnly(row?.start_date) ?? row?.start_date) === draft.startDate
+    && normalizeAttendanceScheduleAssignmentEndDate(row?.end_date) === normalizeAttendanceScheduleAssignmentEndDate(draft.endDate)
+}
+
+function mapAttendanceGroupFixedScheduleBlockingConflict(row, draft) {
+  const conflict = mapAttendanceScheduleAssignmentConflict(row, draft)
+  if (!conflict) return null
+  return {
+    ...conflict,
+    message: getAttendanceScheduleAssignmentConflictMessage(conflict),
+  }
+}
+
+async function buildAttendanceGroupFixedSchedulePreview(db, input) {
+  const groupRows = await db.query(
+    'SELECT * FROM attendance_groups WHERE id = $1 AND org_id = $2',
+    [input.groupId, input.orgId]
+  )
+  if (!groupRows.length) {
+    return {
+      ok: false,
+      status: 404,
+      code: 'NOT_FOUND',
+      message: 'Group not found',
+    }
+  }
+
+  const shiftRows = await db.query(
+    'SELECT * FROM attendance_shifts WHERE id = $1 AND org_id = $2',
+    [input.shiftId, input.orgId]
+  )
+  if (!shiftRows.length) {
+    return {
+      ok: false,
+      status: 404,
+      code: 'NOT_FOUND',
+      message: 'Shift not found',
+    }
+  }
+
+  const memberRows = await db.query(
+    `SELECT DISTINCT user_id
+       FROM attendance_group_members
+      WHERE org_id = $1
+        AND group_id = $2
+      ORDER BY user_id ASC`,
+    [input.orgId, input.groupId]
+  )
+  const userIds = Array.from(new Set(
+    memberRows
+      .map(row => String(row.user_id || '').trim())
+      .filter(Boolean)
+  ))
+  if (!userIds.length) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'VALIDATION_ERROR',
+      message: 'Group has no members to schedule',
+    }
+  }
+
+  const overlapEndDate = normalizeAttendanceScheduleAssignmentEndDate(input.endDate) || ATTENDANCE_SCHEDULE_OPEN_END_DATE
+  const shiftOverlapRows = await db.query(
+    `SELECT id, user_id, shift_id, start_date, end_date, 'shift'::text AS kind
+       FROM attendance_shift_assignments
+      WHERE org_id = $1
+        AND user_id = ANY($2::text[])
+        AND COALESCE(is_active, true) = true
+        AND start_date <= $4::date
+        AND COALESCE(end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
+      ORDER BY user_id ASC, start_date DESC, created_at DESC`,
+    [input.orgId, userIds, input.startDate, overlapEndDate]
+  )
+  const rotationOverlapRows = await db.query(
+    `SELECT id, user_id, rotation_rule_id, start_date, end_date, 'rotation'::text AS kind
+       FROM attendance_rotation_assignments
+      WHERE org_id = $1
+        AND user_id = ANY($2::text[])
+        AND COALESCE(is_active, true) = true
+        AND start_date <= $4::date
+        AND COALESCE(end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
+      ORDER BY user_id ASC, start_date DESC, created_at DESC`,
+    [input.orgId, userIds, input.startDate, overlapEndDate]
+  )
+
+  const overlapsByUserId = new Map()
+  for (const row of [...shiftOverlapRows, ...rotationOverlapRows]) {
+    const userId = String(row.user_id || '').trim()
+    if (!userId) continue
+    const existing = overlapsByUserId.get(userId) ?? []
+    existing.push(row)
+    overlapsByUserId.set(userId, existing)
+  }
+
+  const wouldCreate = []
+  const skipped = []
+  const blockingConflicts = []
+
+  for (const userId of userIds) {
+    const draft = {
+      kind: 'shift',
+      orgId: input.orgId,
+      userId,
+      shiftId: input.shiftId,
+      startDate: input.startDate,
+      endDate: input.endDate ?? null,
+      isActive: true,
+    }
+    const overlaps = overlapsByUserId.get(userId) ?? []
+    const blockingRow = overlaps.find(row => !isExactAttendanceGroupFixedScheduleAssignment(row, draft))
+    if (blockingRow) {
+      const conflict = mapAttendanceGroupFixedScheduleBlockingConflict(blockingRow, draft)
+      if (conflict) blockingConflicts.push(conflict)
+      continue
+    }
+    const exactRow = overlaps.find(row => isExactAttendanceGroupFixedScheduleAssignment(row, draft))
+    if (exactRow) {
+      skipped.push(mapAttendanceGroupFixedScheduleSkipped(exactRow, draft))
+      continue
+    }
+    wouldCreate.push(mapAttendanceGroupFixedSchedulePreviewCandidate(userId, input))
+  }
+
+  return {
+    ok: true,
+    data: {
+      group: mapAttendanceGroupRow(groupRows[0]),
+      shift: mapShiftRow(shiftRows[0]),
+      window: {
+        startDate: input.startDate,
+        endDate: input.endDate ?? null,
+      },
+      target: {
+        total: userIds.length,
+        userIds,
+      },
+      wouldCreate,
+      skipped,
+      blockingConflicts,
+    },
+  }
+}
+
 function respondAttendanceScheduleAssignmentConflict(res, conflict) {
   res.status(409).json({
     ok: false,
@@ -14293,6 +14460,7 @@ module.exports = {
     resolveAttendanceComprehensiveHoursPreviewPeriod,
     previewAttendanceComprehensiveHours,
     findAttendanceScheduleAssignmentConflict,
+    buildAttendanceGroupFixedSchedulePreview,
     acquireAttendanceScheduleAssignmentLock,
     getAttendanceScheduleAssignmentConflictMessage,
     getAttendanceScheduleAssignmentConflictType,
@@ -25611,6 +25779,79 @@ module.exports = {
           }
           logger.error('Attendance group member delete failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to remove group member' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/groups/:id/fixed-schedule/preview',
+      withPermission('attendance:admin', async (req, res) => {
+        const schema = z.object({
+          shiftId: z.string().min(1),
+          startDate: z.string().min(1),
+          endDate: z.string().min(1),
+          orgId: z.string().optional(),
+        }).strict()
+
+        const parsed = schema.safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+
+        const orgId = getOrgId(req)
+        const groupId = normalizeUuidString(req.params.id)
+        if (!groupId) {
+          respondInvalidUuid(res)
+          return
+        }
+        const shiftId = normalizeUuidString(parsed.data.shiftId)
+        if (!shiftId) {
+          respondInvalidUuid(res, 'shiftId')
+          return
+        }
+        const startDate = normalizeDateOnlyStrict(parsed.data.startDate)
+        if (!startDate) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid "startDate" date. Use YYYY-MM-DD.' } })
+          return
+        }
+        const endDate = normalizeDateOnlyStrict(parsed.data.endDate)
+        if (!endDate) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid "endDate" date. Use YYYY-MM-DD.' } })
+          return
+        }
+        if (startDate > endDate) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: '"startDate" must be on or before "endDate".' } })
+          return
+        }
+
+        try {
+          const preview = await buildAttendanceGroupFixedSchedulePreview(db, {
+            orgId,
+            groupId,
+            shiftId,
+            startDate,
+            endDate,
+          })
+          if (!preview.ok) {
+            res.status(preview.status).json({
+              ok: false,
+              error: {
+                code: preview.code,
+                message: preview.message,
+              },
+            })
+            return
+          }
+          res.json({ ok: true, data: preview.data })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance group fixed schedule preview failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to preview fixed schedule' } })
         }
       })
     )


### PR DESCRIPTION
## Summary

- Adds the FS-B fixed-schedule preview endpoint: `POST /api/attendance/groups/:id/fixed-schedule/preview`.
- Server-side enumerates all group members and classifies targets into `wouldCreate[]`, `skipped[]`, and `blockingConflicts[]` without writing assignments.
- Adds a read-only Attendance groups preview panel that posts to the preview endpoint, renders counts, and never shows an apply action.
- Adds verification notes in `docs/development/attendance-group-admin-ux-fixed-schedule-preview-verification-20260528.md`.

## Boundaries

- No apply/write route.
- No migration, schema change, permission change, or new group schedule fact.
- No writes to `attendance_shift_assignments`, `attendance_rotation_assignments`, or `attendance_schedule_groups` in this slice.
- FS-C remains a separate explicit opt-in.

## Verification

- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-scheduling-assignment-conflict.test.ts --watch=false` — 7/7
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts --watch=false` — 3/3
- `pnpm --filter @metasheet/web exec vitest run --watch=false tests/attendance-admin-regressions.spec.ts` — 29/29
- `git diff --check`

Note: `pnpm --filter @metasheet/web type-check` is locally blocked because the borrowed main worktree dependency tree is missing installed `echarts` packages, while `apps/web/package.json` declares `echarts: ^5.5.0`. This is recorded in the verification MD.
