### PR TITLE
docs(integration): cross-reference DF template-composition ↔ data-sources connector base

### DIFF
--- a/docs/development/data-factory-template-composition-open-source-design-20260527.md
+++ b/docs/development/data-factory-template-composition-open-source-design-20260527.md
@@ -17,6 +17,18 @@ preview and K3 Save must share one body-composition source of truth, or a
 byte-parity gate must prove that preview output equals the adapter Save body for
 the same input. A misleading no-write preview is just a slower blind Save.
 
+> **Scope boundary / related note.** This document covers only Data Factory
+> template composition and target-payload preview — how cleansed multitable rows
+> become a trustworthy target-system payload. It does **not** cover the external
+> data-source connector base (credential encryption, read-only protection, owner
+> scoping, supported-type matrix, connector extension boundary); that security /
+> governance layer and its open-source benchmarking live in
+> `docs/research/data-sources-oss-references-20260528.md`. The two are distinct
+> subsystems — target-write payload composition here vs source-read connector
+> base there — not a single feature. The only open-source references shared by
+> both documents are n8n and Airbyte, applied to different problems (templates /
+> actions / run evidence here; connector & credential governance there).
+
 ## Summary
 
 This document defines how MetaSheet Data Factory should provide a reusable

--- a/docs/research/data-sources-oss-references-20260528.md
+++ b/docs/research/data-sources-oss-references-20260528.md
@@ -4,6 +4,9 @@
 > 性质:**内部研究**,可出现外部产品名;**不进正式设计文档**(正式文档只述 MetaSheet 自有原则)。
 > 方法:**bounded patterns 研究**(基于公开资料/已知架构,不 clone、不逐行读源码——深度源码研究留到真要采用时)。
 > 目的:把我们已落的 Lane A 四件事(A0.1/A-RO/A1/A4 已合并)与成熟开源系统对标,确认选择、找可借鉴模式、明确"我们规模下该/不该做什么"。
+> 范围边界 / 关联说明:本文只讨论 **data-sources 外接数据源连接器底座**(凭据加密、只读保护、owner scope、支持类型矩阵、连接器扩展边界)——即"一个外部数据源怎样被安全地创建、保存、查询、权限收口"。
+> Data Factory 的模板 / payload / preview / 运行编排是另一个问题域,见 `docs/development/data-factory-template-composition-open-source-design-20260527.md` 及其 gated 执行清单 `data-factory-template-composition-execution-plan-todo-20260527.md`。
+> 两者是**不同子系统**(源读连接器底座 vs 目标写 payload 组合),非同一功能;与 DF 设计稿的开源引用**重叠仅 n8n / Airbyte 两家**,用途不同(此处借"连接器 / 凭据治理",DF 借"模板 / 动作 / 运行证据")。
 
 ## 0. 候选系统与 license(借鉴边界)
 | 系统 | 栈 | License | 借鉴边界 |


### PR DESCRIPTION
## What

Adds a one-line **scope-boundary note** to each of two existing docs so future readers don't mistake them for duplicate work:

- `docs/development/data-factory-template-composition-open-source-design-20260527.md` → points to the data-sources OSS research note for the connector/credential security base; clarifies this doc covers only template composition + target-payload preview.
- `docs/research/data-sources-oss-references-20260528.md` → points to the DF template-composition design + gated execution TODO; clarifies this doc covers only the source-read connector base.

## Why

The two docs are **distinct subsystems**, not duplicate development:

| | data-sources OSS notes | DF template-composition |
|---|---|---|
| Core question | how an external source connector is safely created / saved / queried / owner-scoped | how cleansed multitable rows become a trustworthy target-system payload |
| Subsystem | source-read connector base (`packages/core-backend/src/data-adapters/`) | target-write payload composition (`plugins/plugin-integration-core/`) |

The only **overlapping** OSS references between the two docs are **n8n** and **Airbyte** (verified), used for different problems — connector/credential governance here vs templates/actions/run-evidence there. NiFi/Node-RED appear only in the DF doc; Redash/Superset/Metabase/Knex only in the data-sources doc.

## Scope

Docs-only (+13 lines, 2 files). No code, no `plugin-integration-core` runtime, lock-safe (K3 Stage-1 lock unaffected). Branched from `origin/main`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)