### PR TITLE
docs(integration): retire K3 stage-1 lock

### DIFF
--- a/docs/development/data-factory-stage2-execution-plan-20260526.md
+++ b/docs/development/data-factory-stage2-execution-plan-20260526.md
@@ -6,17 +6,18 @@
 expands the already-merged `DF-N0..N4` phasing (#1839) plus the implementation-path
 preferences recorded in #1874 into **concrete PR-level steps** — scope, lane, test
 strategy, and the gate that unlocks each. It introduces **no new contracts or
-architecture**; per #1838's "PAUSE 阶段二 design", further *design* detail still
-waits for K3 PoC evidence. Everything here is gated behind **K3 PoC GATE PASS +
-an explicit 阶段二 unlock + a separate per-PR opt-in**.
+architecture**; per #1838's "PAUSE 阶段二 design", further *design* detail was
+waiting for K3 PoC evidence. As of 2026-05-28, #1792 satisfies the K3 M1
+GATE PASS precondition; everything here still requires **an explicit 阶段二
+unlock + a separate per-PR opt-in**.
 
 K3 WISE stays a **preset**, not the product center.
 
 ## 0. Reading rules (read first)
 
 - **Gate 0 (precondition for everything):** K3 PoC **GATE PASS** + 阶段二 unlock + per-PR opt-in.
-- **Current gate status (2026-05-26):** positive K3 Material Save proven 2026-05-25, but the **S3 read/list runtime decision + S4 single-record positive-Save regression are NOT closed**, and Submit/Audit/BOM/multi-record remain blocked → **Gate 0 is NOT passed → zero PRs below start now.**
-- **The whole 阶段二 touches `plugin-integration-core`** (plugin-managed SQL + the pipeline runner + routes) — which is exactly what the K3 Stage-1 lock freezes. Each step is therefore explicitly gated behind unlock; none is implied by this doc.
+- **Current gate status (2026-05-28):** K3 M1 one-record Material Save-only is PASS and #1792 is closed. The old Stage-1 blanket lock no longer blocks planning; Submit/Audit/BOM/multi-record/production remain separate K3 scoped gates. 阶段二 work still starts only by explicit owner unlock and per-PR opt-in.
+- **The whole 阶段二 touches `plugin-integration-core`** (plugin-managed SQL + the pipeline runner + routes). The old K3 Stage-1 freeze is lifted, but each step is still explicitly gated behind scoped unlock; none is implied by this doc.
 - **Hard locks that persist through every phase:** K3 stays Save-only / one-record; no Submit/Audit/BOM/multi-record K3 push without a separate owner decision; payload redaction mandatory; **never expose an arbitrary-JS / raw-SQL editor to business users**; OpenAPI parity gate; wire-vs-fixture round-trip test for any new serialized field; real-DB golden gate for anything touching permissions.
 - ⚠️ **The PoC may reshape DF-N4 / FaaS** (read model, write-back semantics, reference resolution — the open #1838 gating questions). Do **not** pre-build those.
 
@@ -121,4 +122,4 @@ Gate 0: K3 GATE PASS + 阶段二 unlock
 - #1838 (direction / gating, incl. the NiFi + Yida-FaaS takeaways) + its 2026-05-26 addendum #1874 (DF-N2 JSONB + FaaS-on-own-sandbox preferences).
 - #1839 (run/provenance + core data model + DF-N0..N4 phasing). #1844 (UX/IA 5-stage flow). #1826 (K3 ref-mapping UI contract). #1835/#1709 (read-only unlock decision / read-list track). #1792 (GATE).
 - Shipped: #1848 (DF-N1 read-only monitoring) · #1857 (DF-N1.5 single manual replay).
-- Locks: K3 PoC Stage-1 lock; K3 GATE Save-path progression (S3 read/list + S4 regression still open).
+- Locks: post-GATE scoped gates in `k3-post-gate-scoped-governance-20260528.md`; Submit/Audit/BOM/multi-record/production still need separate approval.

--- a/docs/development/data-factory-stage2-todo-20260526.md
+++ b/docs/development/data-factory-stage2-todo-20260526.md
@@ -1,11 +1,11 @@
 # Data Factory 阶段二 — TODO (gated checklist) - 2026-05-26
 
 > **图例:** 🔒 blocked-by-gate · ⬜ ready-when-unlocked · ✅ done · ⏸ deferred
-> **全部 gated:** K3 PoC GATE PASS + 阶段二 unlock + 每个 PR 单独 opt-in。**Gate 0 今天未过 → 下面一项都不启动。**
+> **全部 gated:** K3 PoC GATE PASS + 阶段二 unlock + 每个 PR 单独 opt-in。**2026-05-28: #1792 已满足 K3 M1 GATE PASS；后续仍需 owner 阶段二 unlock + 单 PR opt-in。**
 > 这是 #1839 DF-N0..N4 phasing + #1874 偏好的执行清单，**非新设计、非开建授权**。
 
-## Gate 0 — 前置门（未过）
-- [ ] 🔒 K3 PoC **GATE PASS**（S3 read/list 决定 + S4 单记录 Save 回归仍未闭）
+## Gate 0 — 前置门
+- [x] ✅ K3 PoC **GATE PASS**（#1792: M1 单条 Material Save-only PASS；非 Submit/Audit/BOM/多条/生产）
 - [ ] 🔒 阶段二 **unlock** 决定（owner）
 
 ## 已完成（Stage-5 监控）
@@ -54,5 +54,5 @@
 - [ ] ⬜ **不要**从 FaaS / DF-N4 起步；**不要**在 N2-1 契约冻结前先做 N2-2 runtime（契约优先）
 
 ## 永不违反的硬锁
-- K3 Save-only / 单记录；无 Submit/Audit/BOM/多记录（除非 owner 决定）
+- K3 M1 已证明的是 Material Save-only / 单记录；无 Submit/Audit/BOM/多记录/生产（除非 owner 以单独 scoped gate 决定）
 - 业务用户面**永远只配置**，绝不开任意 JS/SQL 编辑器

--- a/docs/development/integration-erp-platform-roadmap-20260425.md
+++ b/docs/development/integration-erp-platform-roadmap-20260425.md
@@ -5,6 +5,8 @@
 > 主笔：Claude（Sonnet 4.6, 1M context）+ 团队对话提取
 > 目的：在 K3 WISE Live PoC 进入门槛前，把"是否走平台化"这个战略问题落到文字，避免日后用错精力或错失时机
 
+> 2026-05-28 更新：#1792 已关闭为 M1 单条 Material Save-only PASS。本文中的"阶段一锁"不再作为全局规划冻结；后续按 `k3-post-gate-scoped-governance-20260528.md` 的 scoped gates 管理。Submit / Audit / BOM / 多条批量 / 生产签核仍未解锁。
+
 ---
 
 ## 1. 背景与问题
@@ -81,10 +83,10 @@
 ## 4. 四阶段路线图
 
 ```
-阶段一（现在 - 1 个月）·  K3 PoC 跑通
+阶段一（已完成 M1）·  K3 PoC 跑通
   目标：验证产品-市场契合度（PMF），不分散精力做平台化
-  关键交付：K3 真客户测试账套 Live PoC PASS
-  决策门槛：PoC PASS = 进入阶段二；FAIL = 修 K3 adapter 不开新战线
+  关键交付：K3 真客户测试账套 Live PoC PASS（#1792: M1 单条 Material Save-only）
+  决策门槛：M1 PoC PASS = 可进入阶段二评估；后续 K3 能力仍按 scoped gates 单独解锁
 
 阶段二（1-3 个月）· 抽离 + 第 2 家 ERP
   目标：用真实复用证明"通用"不是 PPT
@@ -116,7 +118,7 @@
 
 | 风险 | 表现 | 缓解 |
 |---|---|---|
-| **过度工程**（最大风险） | K3 PoC 还没过就投入平台化，结果客户没买单，平台化沉没成本巨大 | 阶段一锁定不开新战线；任何"K3 之外"的工作必须等 PoC PASS 才启动 |
+| **过度工程**（最大风险） | M1 PoC 已过，但把一次 Save-only 结果误读成"所有 K3/ERP 平台化已验证" | Stage-1 全局锁退役；改用 post-GATE scoped gates。Submit/Audit/BOM/多条/生产签核仍需单独 owner gate；平台化仍按阶段二单 PR opt-in 推进 |
 | **Vendor 长尾陷阱** | 看似 80/20 实际是 20/80：每接一家 ERP 维护成本上升，国内 ERP 版本碎片严重 | 阶段二只接 1 家，证明 ROI 后才扩展；自我设限"每季度最多 1 家新 ERP" |
 | **Schema 版本漂移** | K3 WISE 15 vs K3 WISE 14 字段差异；用友 U8 v15 vs v17 | Vendor profile 中心引入 `vendor.version` 字段；mappings 按版本绑定 |
 | **认证方式异构爆炸** | OAuth2 / SAP login ticket / Oracle SSWS / 用友 token / NetSuite TBA / SAP Ariba SOAP-WSSE | 阶段三 Adapter Builder 优先支持 top 5 auth 模式；其他走 vendor adapter 自定义 |
@@ -131,7 +133,7 @@
 
 | 决策点 | 问题 | 当前状态（2026-04-25） |
 |---|---|---|
-| D1 | K3 PoC 是否 PASS？ | 等客户 GATE 答卷 |
+| D1 | K3 PoC 是否 PASS？ | 已 PASS：#1792 M1 单条 Material Save-only；非 Submit/Audit/BOM/多条/生产 |
 | D2 | 第 2 家 ERP 是哪家？是否有真实客户需求？ | 未确定 |
 | D3 | 第 2 家 ERP 的接入是否 ≤ 3 周完成？ | N/A |
 | D4 | 是否已有 ≥ 3 家成功案例？ | N/A |
@@ -143,6 +145,7 @@
 
 - 本文（roadmap）：战略层
 - 同日 `integration-vendor-abstraction-checklist-20260425.md`：阶段二抽离工作的具体 task list
+- `k3-post-gate-scoped-governance-20260528.md`：#1792 之后的 scoped-gate 治理边界
 - 已有 `integration-core-k3wise-live-poc-design-20260425.md` + `*-verification-20260425.md`：阶段一执行
 - 已合 main · K3 PoC 运行手册（#1155）：
   - 本体：`packages/core-backend/claudedocs/integration-plm-k3wise-mvp.md`（703 行 runbook）

--- a/docs/development/integration-k3wise-read-runtime-unlock-decision-20260525.md
+++ b/docs/development/integration-k3wise-read-runtime-unlock-decision-20260525.md
@@ -6,6 +6,7 @@ This is a **decision document first, a design second.** The first-order question
 
 - **Docs-only. No runtime implemented.** Any runtime is a **separate opt-in PR on the #1709 track**, only after an explicit unlock (see §5).
 - Builds on the existing **#1593** read/list GATE-front contract — it **carves a minimal slice and does NOT redesign** read/list (memory discipline: post-GATE, *execute* the #1593 design, don't redesign).
+- 2026-05-28 update: #1792 is now closed as PASS for M1 one-record Material Save-only. The old Stage-1 blanket lock no longer blocks this discussion, but #1709 still needs explicit owner opt-in plus the read/list O1-O6 inputs before runtime.
 
 ## 1. The decision (first-order — owner's call)
 
@@ -13,7 +14,7 @@ This is a **decision document first, a design second.** The first-order question
 
 **Why it matters:** making *"staging auto-produces complete K3 reference objects"* stable structurally needs a **read** — the GATE positive Save sourced its 66 reference objects by reading an existing Material detail (clone). A4 (#1832) persists per-field *shape*, S2 (#1828) *previews* completeness, but **neither sources the objects**. Read is the missing producer.
 
-**Lock status:** read/list runtime is the frozen **#1709** ("[Post-GATE] K3 WebAPI read/list adapter for Material/BOM", OPEN) track; **#1593** front-loaded the contract (docs). Per the K3 Stage 1 Lock, implementing it requires an explicit owner unlock (or GATE PASS). #1526 is the now-closed umbrella; the read-adapter runtime moved to #1709.
+**Lock status:** read/list runtime remains the scoped **#1709** ("[Post-GATE] K3 WebAPI read/list adapter for Material/BOM", OPEN) track; **#1593** front-loaded the contract (docs). The K3 macro gate is satisfied by #1792, but implementation still requires an explicit owner unlock and current read/list inputs. #1526 is the now-closed umbrella; the read-adapter runtime moved to #1709.
 
 **Options (owner picks — this doc does not decide):**
 - **(a)** Unlock the minimal read slice now, citing the save+readback PASS as sufficient evidence.

--- a/docs/development/k3-post-gate-scoped-governance-20260528.md
+++ b/docs/development/k3-post-gate-scoped-governance-20260528.md
@@ -1,0 +1,53 @@
+# K3 WISE Post-GATE Scoped Governance - 2026-05-28
+
+## Status
+
+The project-wide **K3 PoC Stage-1 lock** is retired for planning purposes.
+Issue #1792 is closed as PASS for the accepted M1 scope:
+
+- K3 WISE Material Save-only, one record.
+- Save success confirmed.
+- Readonly readback confirmed.
+- Productized package deployed on the on-prem node.
+- Post-deploy no-write regression and authenticated smoke passed.
+
+This removes the blanket "no new work until customer GATE PASS" blocker. It does
+not unlock every K3 capability.
+
+## Replacement Rule
+
+Use **post-GATE scoped gates** instead of the global Stage-1 lock:
+
+| Scope | Status | Re-entry rule |
+|---|---|---|
+| M1 Material one-record Save-only | Passed / closed via #1792 | Safe as the proven baseline; further writes still need explicit approval. |
+| Material multi-record / batch Save | Locked | Separate owner-approved gate with no automatic retry unless designed. |
+| Submit | Locked | Separate owner-approved gate and fresh K3 evidence. |
+| Audit | Locked | Separate owner-approved gate and fresh K3 evidence. |
+| BOM Save | Locked | Separate owner-approved gate; relationship/reference evidence must be current. |
+| Production signoff | Locked | Separate production readiness and customer signoff. |
+| Broad `plugin-integration-core` refactors | Scoped | Allowed only when tied to a named slice, reviewed diff, and current tests. |
+
+## What This Authorizes
+
+- Planning docs may stop treating "K3 Stage-1 lock" as a global blocker.
+- Previously deferred non-K3 lanes may re-enter discussion if their own local
+  blockers are closed and the owner explicitly opts in.
+- Data Factory / connector work may proceed only through the already established
+  per-PR opt-in gates.
+
+## What This Does Not Authorize
+
+- No Submit / Audit / BOM.
+- No multi-record or production batch.
+- No automatic retry of K3 writes.
+- No direct writes to K3 core SQL tables.
+- No runtime relaxation of `autoSubmit=false`, `autoAudit=false`, Save-only, or
+  redaction boundaries.
+
+## Evidence
+
+- #1792: Customer GATE completed and closed for M1 one-record Material Save-only.
+- #1962: customer-proven Material Save template shape productized.
+- On-prem package deploy: post-deploy authenticated smoke plus no-write M1
+  customer-profile regression passed before #1792 closeout.

--- a/docs/development/memory-update-session-learnings-20260426.md
+++ b/docs/development/memory-update-session-learnings-20260426.md
@@ -13,7 +13,7 @@ load these on startup via `MEMORY.md` index.
 |------|------|------|
 | `feedback_stacked_pr_rebase_after_squash.md` | feedback | Use `git rebase --onto origin/main <old-parent-tip>` after parent squash-merge; naive rebase causes AA/UU collisions |
 | `feedback_channel_env_gating.md` | feedback | Optional notification channels register only when env configured; default-registration → per-tick warn noise under at-least-once retry |
-| `project_k3_poc_stage1_lock.md` | project | Roadmap阶段一锁定 — until K3 PoC customer GATE PASS, no new战线 / no integration-core touch; 内核打磨 permitted |
+| `project_k3_poc_stage1_lock.md` | project | Roadmap阶段一锁定 — retired for planning on 2026-05-28 after #1792 PASS; replaced by post-GATE scoped gates |
 
 ## M1 — Stacked-PR rebase after squash-merge (feedback)
 
@@ -59,6 +59,14 @@ but skips dispatch), (c) the no-op-stub / unwire-callback alternatives.
 
 ## M3 — K3 PoC Stage 1 lock (project)
 
+**2026-05-28 update**: The global Stage-1 lock is retired for planning
+purposes. #1792 closed as PASS for the accepted M1 scope (K3 WISE Material
+Save-only, one record, Save success + readonly readback + productized on-prem
+package + post-deploy no-write regression). Future work uses the scoped-gate
+rules in `docs/development/k3-post-gate-scoped-governance-20260528.md`.
+Submit, Audit, BOM, multi-record / batch, production signoff, and broad
+`plugin-integration-core` refactors remain separately gated.
+
 **Source**: `docs/development/integration-erp-platform-roadmap-20260425.md`
 explicitly states: 「阶段一锁定不开新战线; 任何 K3 之外的工作必须等
 PoC PASS 才启动」 and 「客户答卷与平台化路线解耦：阶段一可同步做内核
@@ -82,6 +90,10 @@ PoC PASS 才启动」 and 「客户答卷与平台化路线解耦：阶段一可
 
 **Lift conditions**: (a) user announces customer GATE PASSED, or (b)
 explicit "打破阶段一约束" (push back once before agreeing).
+
+**Lift result**: L-M-1 fired on 2026-05-28 via #1792. Do not use this
+Stage-1 lock as a blanket blocker for unrelated planning after that date; do
+keep the post-GATE K3 scope gates above.
 
 **Why it matters**: roadmap names "过度工程" as the #1 risk. The 4-stage
 path (PoC → 抽离+第2家ERP → 平台化基建 → Marketplace+SaaS) is

--- a/docs/development/multitable-feishu-phase3-ai-hardening-plan-20260514.md
+++ b/docs/development/multitable-feishu-phase3-ai-hardening-plan-20260514.md
@@ -2,6 +2,8 @@
 
 Date: 2026-05-14
 
+2026-05-28 update: #1792 satisfies the K3 macro gate for M1 one-record Material Save-only. Mentions of "stage-1 lock" below are historical activation context; they no longer block planning by themselves. Deferred lanes still require their T-numbered blockers and explicit operator opt-in before implementation.
+
 ## Status
 
 This document starts the next multitable Feishu-parity phase after the signed RC and Phase 2 closeout.
@@ -43,17 +45,17 @@ authorial intent — is:
 4. Phase 3C - template and industry solution center V2.
 5. Phase 3D1 - commercial hardening gates on 142 staging.
 
-The Activation Constraints section below supersedes the active-queue
-portion of this order under the K3 PoC stage-1 lock.
+The Activation Constraints section below records the active-queue decision made
+under the K3 PoC stage-1 lock, plus the post-GATE reading after #1792.
 
 ## Activation Constraints
 
 The K3 PoC stage-1 lock recorded in
 `docs/development/integration-erp-platform-roadmap-20260425.md` §4-§5
-is in effect at the time this plan lands. Under that lock, only kernel
-polish on already-shipped multitable features may proceed; new product
-战线 (AI surface, industry solution center, marketplace) must wait
-until K3 GATE PASS.
+was in effect when this plan landed. As of 2026-05-28, #1792 satisfies the K3
+macro gate. Re-entry is now governed by lane-local blockers, operator
+ratification, and the scoped-gate rules in
+`docs/development/k3-post-gate-scoped-governance-20260528.md`.
 
 ### Active queue (allowed under stage-1 lock)
 
@@ -71,11 +73,11 @@ do not touch `plugins/plugin-integration-core/*` or any K3 PoC path.
 
 | Lane | Status | Re-entry condition |
 | --- | --- | --- |
-| Lane A - AI Field Shortcuts V1 (A1 / A2 / A3) | deferred pending K3 GATE PASS | K3 GATE PASS plus T1, T2, T3, T6 closed |
-| Lane B - Formula AI Assist and Diagnostics (B1 / B2) | deferred pending K3 GATE PASS | K3 GATE PASS plus T1, T3, T6 closed |
+| Lane A - AI Field Shortcuts V1 (A1 / A2 / A3) | deferred pending T-blockers / operator ratification | T1, T2, T3, T6 closed; K3 macro gate satisfied via #1792 |
+| Lane B - Formula AI Assist and Diagnostics (B1 / B2) | deferred pending T-blockers / operator ratification | T1, T3, T6 closed; K3 macro gate satisfied via #1792 |
 | Lane C - Template / Industry Solution Center V2 (C1 / C2) | pending PM / SME assignment | PM / PD ownership plus domain SME for at least three of the five industry templates, plus T7 closed |
-| D2 - Large Table Performance Gate | deferred | K3-free staging environment available, or K3 GATE PASS; plus T4 closed |
-| D3 - Permission Matrix Gate | deferred | K3-free staging environment available, or K3 GATE PASS; plus T5 closed |
+| D2 - Large Table Performance Gate | deferred | K3 macro gate satisfied via #1792; still needs T4 / 142 host decision |
+| D3 - Permission Matrix Gate | deferred | K3 macro gate satisfied via #1792; still needs T5 and staging / 142 decision |
 
 ### Activation blockers — T1 through T7
 
@@ -107,14 +109,11 @@ closed, the corresponding lane stays deferred:
 
 ### Re-entry process
 
-When the stage-1 lock lifts — operator announces K3 GATE PASSED, or
-explicitly invokes "打破阶段一约束" per
-`project_k3_poc_stage1_lock.md` — the relevant lane becomes eligible
-for activation after closing its T-numbered blocker(s). Each
-activation must be recorded in this plan as a follow-up commit that
-moves the lane row from the Deferred table to the Active queue, and
-in the companion TODO as a Status field update from `deferred` to
-`pending`.
+Because #1792 has satisfied the K3 macro gate, the relevant lane becomes eligible
+for activation only after closing its T-numbered blocker(s) and receiving
+operator opt-in. Each activation must be recorded in this plan as a follow-up
+commit that moves the lane row from the Deferred table to the Active queue, and
+in the companion TODO as a Status field update from `deferred` to `pending`.
 
 ## Worktree Rule
 
@@ -536,20 +535,19 @@ Status: pending activation. Depends on PR R2 (D0 skeleton).
 
 ### Deferred — not in active queue
 
-The following PRs from the original sequence are deferred under the
-Activation Constraints above. They re-enter the active queue only
-after stage-1 lock lifts and the corresponding T-numbered blockers
-are closed.
+The following PRs from the original sequence remain deferred under the
+Activation Constraints above. After #1792, they re-enter the active queue only
+after the corresponding T-numbered blockers close and the operator opts in.
 
 | Original PR | Lane | Defer reason |
 | --- | --- | --- |
-| PR 3 — AI provider readiness | Lane A1 | Stage-1 lock plus T1 / T6 open |
-| PR 4 — AI field shortcut backend | Lane A2 | Stage-1 lock plus T1 / T2 / T3 open |
-| PR 5 — AI field shortcut frontend | Lane A3 | Stage-1 lock plus T3 / T6 open |
-| PR 6 — formula diagnostics | Lane B1 | Stage-1 lock |
-| PR 7 — formula AI assist | Lane B2 | Stage-1 lock plus T1 / T3 / T6 open |
-| PR 8 — template center preview | Lane C1 | Stage-1 lock plus PM / SME unassigned |
-| PR 9 — template onboarding | Lane C2 | Stage-1 lock plus T7 unbudgeted |
+| PR 3 — AI provider readiness | Lane A1 | T1 / T6 open; operator ratification missing |
+| PR 4 — AI field shortcut backend | Lane A2 | T1 / T2 / T3 open |
+| PR 5 — AI field shortcut frontend | Lane A3 | T3 / T6 open |
+| PR 6 — formula diagnostics | Lane B1 | Operator opt-in required |
+| PR 7 — formula AI assist | Lane B2 | T1 / T3 / T6 open |
+| PR 8 — template center preview | Lane C1 | PM / SME unassigned |
+| PR 9 — template onboarding | Lane C2 | T7 unbudgeted |
 | (Original PR 10 sub-gate) — large-table perf | D2 | T4 open; risk to 142 K3 PoC integrity |
 | (Original PR 10 sub-gate) — permission matrix | D3 | T5 open |
 

--- a/docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md
+++ b/docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md
@@ -8,6 +8,7 @@ Date: 2026-05-14
 - Goal: continue Feishu parity toward AI-assisted authoring and customer-trial hardening.
 - Rule: each completed implementation item must include PR, merge commit, development MD, verification MD, and verification summary.
 - Worktree rule: all implementation work starts from a clean worktree based on `origin/main`; do not develop from the dirty root checkout.
+- 2026-05-28 update: #1792 satisfies the K3 macro gate for M1 one-record Material Save-only. Status text that says `deferred pending K3 GATE PASS` should now be read as `deferred pending lane-local blockers and operator opt-in`; this TODO does not auto-flip any lane to active.
 
 ## Completion Rules
 
@@ -24,17 +25,16 @@ Mark an item complete only after all are true:
 
 The K3 PoC stage-1 lock recorded in
 `docs/development/integration-erp-platform-roadmap-20260425.md` §4-§5
-is in effect. Under that lock, lanes carry one of three statuses:
+was in effect when this TODO landed. As of 2026-05-28, #1792 satisfies the K3
+macro gate; lanes still carry explicit statuses and require follow-up operator
+opt-in before re-entry:
 
 - `pending` — in the active queue. Implementation may start once
   Phase 0 hygiene is complete.
-- `deferred pending K3 GATE PASS` — blocked by the stage-1 lock. The
-  lane re-enters `pending` only after the operator announces K3 GATE
-  PASSED (or explicitly invokes "打破阶段一约束" per
-  `project_k3_poc_stage1_lock.md`) **and** the lane's T-numbered
-  blockers from
+- `deferred pending K3 GATE PASS` — historical status text. After #1792,
+  read this as deferred pending the lane's T-numbered blockers from
   `docs/development/multitable-feishu-phase3-ai-hardening-review-20260514.md`
-  are closed.
+  plus explicit operator opt-in.
 - `pending PM / SME assignment` — blocked by missing non-engineering
   inputs. The lane re-enters `pending` only after PM / PD ownership
   and domain SME availability are confirmed, and rollback budget
@@ -42,8 +42,8 @@ is in effect. Under that lock, lanes carry one of three statuses:
 
 Active queue at the time this TODO lands: Lane D0, Lane D1, Lane D4.
 
-Deferred under stage-1 lock: Lane A1 / A2 / A3, Lane B1 / B2, Lane
-D2, Lane D3.
+Formerly deferred under the stage-1 lock, still deferred until local blockers /
+operator opt-in: Lane A1 / A2 / A3, Lane B1 / B2, Lane D2, Lane D3.
 
 Deferred under PM / SME assignment: Lane C1, Lane C2.
 

--- a/docs/development/multitable-phase3-lane-a1-ratification-table-20260515.md
+++ b/docs/development/multitable-phase3-lane-a1-ratification-table-20260515.md
@@ -2,17 +2,17 @@
 
 - Date: 2026-05-15
 - Author: Claude (Opus 4.7, 1M context), interactive harness; **read-only decision preparation, no code, no TODO Status change, no implementation PR**
-- Status: **Landed as read-only decision packet; not ratified.** This table consolidates seven outstanding ratification items for Lane A1 into a single operator-markup matrix. Until each item receives an operator answer AND the K3 PoC stage-1 lock lifts, A1 cannot ship — irrespective of this document landing.
+- Status: **Landed as read-only decision packet; not ratified.** This table consolidates seven outstanding ratification items for Lane A1 into a single operator-markup matrix. 2026-05-28 update: #1792 satisfies the K3 macro gate, but A1 still cannot ship until each item receives an operator answer.
 - Companion to: `/tmp/multitable-phase3-lane-a1-implementation-design-20260515.md` (A1 design draft, still in `/tmp/`, not committed to `docs/development/`).
 - Scope: consolidate the seven outstanding ratification items from the A1 design draft §15 into a single decision table the operator can mark up.
 
 ## 1. Charter
 
-The A1 design draft in `/tmp/multitable-phase3-lane-a1-implementation-design-20260515.md` carries proposed-but-not-ratified values across env names, RBAC posture, OpenAPI integration, response shape, provider allowlist, and default caps. Before A1 can become an implementation PR (which itself still needs K3 GATE PASS or `打破阶段一约束`), the operator must ratify each item.
+The A1 design draft in `/tmp/multitable-phase3-lane-a1-implementation-design-20260515.md` carries proposed-but-not-ratified values across env names, RBAC posture, OpenAPI integration, response shape, provider allowlist, and default caps. Before A1 can become an implementation PR, the operator must ratify each item.
 
 (Line count of the design draft intentionally omitted here — the draft may continue to evolve in `/tmp/` as the operator's review surfaces more refinements; this ratification table tracks decision content, not draft size.)
 
-This table consolidates them. **The macro gate (K3 lock) is a separate decision; this table does not propose lifting it.** Even if the operator ratifies every row below today, A1 still cannot ship until the macro gate lifts.
+This table consolidates them. **The K3 macro gate is now satisfied by #1792; this table still does not authorize implementation.** Even if the operator ratifies every row below today, A1 still needs a separate implementation opt-in.
 
 ## 2. Ratification matrix
 
@@ -120,12 +120,12 @@ Q-4: [accept 10 USD | =X]
 T-framing: [confirmed]
 ```
 
-Once **all** items above receive an operator answer AND the macro gate lifts (K3 GATE PASS or `打破阶段一约束`), A1 can move from `/tmp/` design draft to a Lane A1 implementation PR. **Until both happen, A1 stays deferred.**
+Once **all** items above receive an operator answer, A1 can move from `/tmp/` design draft to a Lane A1 implementation PR if the operator explicitly opts in. **Until then, A1 stays deferred.**
 
 ## 4. What this table did NOT do
 
 - Did NOT modify any TODO Status line.
-- Did NOT propose lifting the K3 lock.
+- Did NOT propose auto-starting A1 after #1792.
 - Did NOT propose an implementation PR.
 - Did NOT touch real provider keys, real env config, or real customer data.
 - Did NOT extend A1 scope into A2/A3 territory.

--- a/docs/development/multitable-phase3-unlock-checklist-20260515.md
+++ b/docs/development/multitable-phase3-unlock-checklist-20260515.md
@@ -5,22 +5,23 @@
 - Companion to: `docs/development/multitable-phase3-staging-verification-20260515.md`
 - Status: **Landed.** Read-only checklist of the explicit conditions that must be met before each currently-deferred Phase 3 lane can re-enter the active queue. Does NOT propose flipping any lane.
 - Intent: durable record of unlock conditions per lane; subsequent revisions land via follow-up commits once any lane unlocks.
+- 2026-05-28 update: the macro K3 gate is satisfied by #1792 M1 one-record Material Save-only PASS. This only removes the K3 Stage-1 blanket blocker; all lane-local blockers and operator ratification remain required.
 
 ## 1. Charter
 
 For each deferred Phase 3 lane, this checklist records:
 
-1. The **macro gate** (K3 PoC stage-1 lock state, or PM/SME availability) that must lift first.
+1. The **macro gate** (now satisfied by #1792 for the K3 path, or PM/SME availability for Lane C) that must lift first.
 2. The **lane-local blockers** (T1-T7 from the review) that must each be closed independently.
 3. The **non-engineering inputs** required (config values, env names, allowlists, RBAC tier, cost ceilings, etc.).
 4. The **artifact** required to flip the TODO Status line from `deferred` back to `pending`.
 
-The checklist is **prescriptive only**. Modifying TODO Status lines requires operator authorization (per stage-1 lock).
+The checklist is **prescriptive only**. Modifying TODO Status lines requires operator authorization under the scoped-gate discipline.
 
-## 2. Macro-gate: K3 PoC stage-1 lock
+## 2. Macro-gate: K3 PoC post-GATE state
 
 The lock recorded in `project_k3_poc_stage1_lock.md` and
-`docs/development/integration-erp-platform-roadmap-20260425.md` §4-§5 remains in force on `origin/main` HEAD `b49505c10` (audit captured at `4743ba44d`; re-checked `b49505c10` for Phase 3 drift — none, the new commit is Data-Factory-only).
+`docs/development/integration-erp-platform-roadmap-20260425.md` §4-§5 was in force when this checklist landed. As of 2026-05-28, L-M-1 has fired: #1792 is closed as PASS for the accepted M1 scope. Use `docs/development/k3-post-gate-scoped-governance-20260528.md` for the replacement scoped-gate rule.
 
 To lift the macro gate, one of:
 
@@ -29,7 +30,7 @@ To lift the macro gate, one of:
 | L-M-1 | Operator announces `K3 GATE PASSED` after customer-side sign-off on the K3 WISE PoC test account | The announcement message itself, plus an update commit on `project_k3_poc_stage1_lock.md` recording "Lock lifted on <date> after K3 GATE PASS." |
 | L-M-2 | Operator explicitly invokes `打破阶段一约束` in conversation, confirming awareness of the sunk-cost risk per the roadmap §5 | Same — memory edit recording the explicit override and the date. |
 
-Either trigger is sufficient on its own. Until one fires, lanes labeled `deferred pending K3 GATE PASS` cannot move regardless of T-blocker state.
+L-M-1 is now satisfied. Lanes formerly labeled `deferred pending K3 GATE PASS` may re-enter only after their lane-local blockers close and the operator opts in; this checklist does not flip any TODO status by itself.
 
 ## 3. T-blocker reference (from the independent review)
 
@@ -53,7 +54,7 @@ enumerates seven pre-launch blockers. They are reused throughout this checklist.
 
 | Required to flip Status `deferred → pending` | Currently |
 | --- | --- |
-| L-M-1 or L-M-2 (macro gate) | not lifted |
+| L-M-1 or L-M-2 (macro gate) | lifted via #1792 M1 PASS |
 | T1 closed (cost ledger shape + caps agreed) | not closed |
 | T6 closed (state enum agreed) | not closed |
 | Operator ratifies AI provider allowlist (e.g. `anthropic` + `openai`, or different) | not ratified |
@@ -62,7 +63,7 @@ enumerates seven pre-launch blockers. They are reused throughout this checklist.
 | Env-var names + provider allowlist + default cap values ratified | not ratified |
 | Pre-design draft exists at `/tmp/multitable-phase3-lane-a1-implementation-design-20260515.md` (revised 2026-05-15) | **draft exists, NOT ratified** — see caveat below |
 
-**Caveat on the A1 pre-design draft:** the draft is a Claude-authored proposal sitting in `/tmp/`. It is **not** committed to `docs/development/` and has **not** been ratified by the operator. Its existence does not close T1 or T6: per the draft itself (§3, §5.2, §8), T1 stays open until A2 ships the usage-ledger writer + cap enforcement and A3 ships consumption display, and T6 stays open until A2 derives the four reserved states (`rate_limited`, `quota_exhausted`, `provider_error`, `unsafe_input`). **A1 cannot be implemented until** (a) K3 GATE PASS or explicit `打破阶段一约束`, AND (b) the operator ratifies the seven outstanding design points enumerated in the draft's §20.
+**Caveat on the A1 pre-design draft:** the draft is a Claude-authored proposal sitting in `/tmp/`. It is **not** committed to `docs/development/` and has **not** been ratified by the operator. Its existence does not close T1 or T6: per the draft itself (§3, §5.2, §8), T1 stays open until A2 ships the usage-ledger writer + cap enforcement and A3 ships consumption display, and T6 stays open until A2 derives the four reserved states (`rate_limited`, `quota_exhausted`, `provider_error`, `unsafe_input`). The K3 macro gate is now satisfied, but **A1 still cannot be implemented until** the operator ratifies the seven outstanding design points enumerated in the draft's §20.
 
 Sequencing: A1 is the **first** AI lane and has no upstream lane dependency. But the macro gate plus the operator-ratification items above must all close before A1's implementation PR can start.
 
@@ -70,7 +71,7 @@ Sequencing: A1 is the **first** AI lane and has no upstream lane dependency. But
 
 | Required to flip Status `deferred → pending` | Currently |
 | --- | --- |
-| L-M-1 or L-M-2 | not lifted |
+| L-M-1 or L-M-2 | lifted via #1792 M1 PASS |
 | T1 closed | not closed |
 | T2 closed (sibling-service boundary stated) | not closed |
 | T3 closed (SLO numbers committed) | not closed |
@@ -83,7 +84,7 @@ Sequencing: A2 depends on A1 landing first.
 
 | Required to flip Status `deferred → pending` | Currently |
 | --- | --- |
-| L-M-1 or L-M-2 | not lifted |
+| L-M-1 or L-M-2 | lifted via #1792 M1 PASS |
 | T3 closed (cancel + streaming UX semantics) | not closed |
 | T6 closed (state enum) | not closed |
 | Lane A2 merged on `main` with preview / run endpoints reachable | not merged |
@@ -95,7 +96,7 @@ Sequencing: A3 depends on A1 and A2 landing first.
 
 | Required to flip Status `deferred → pending` | Currently |
 | --- | --- |
-| L-M-1 or L-M-2 | not lifted |
+| L-M-1 or L-M-2 | lifted via #1792 M1 PASS |
 | Formula engine surface frozen for the dry-run contract (no API breaking changes mid-lane) | not declared |
 | Mock formula evaluator interface declared so unit tests can run without a live formula sandbox | not declared |
 
@@ -105,7 +106,7 @@ Sequencing: B1 is the non-AI half of Lane B and has no AI dependency. Could tech
 
 | Required to flip Status `deferred → pending` | Currently |
 | --- | --- |
-| L-M-1 or L-M-2 | not lifted |
+| L-M-1 or L-M-2 | lifted via #1792 M1 PASS |
 | T1 closed | not closed |
 | T3 closed | not closed |
 | T6 closed | not closed |
@@ -122,7 +123,7 @@ Sequencing: B2 depends on A1 + B1.
 | Domain SME availability confirmed for at least three of the five templates | not confirmed |
 | T7 closed (rollback budget decision) | not closed |
 
-Sequencing: independent of K3 lock (Status quote is `pending PM / SME assignment`, NOT `pending K3 GATE PASS`). Could activate as soon as PM / SME inputs land, even before the macro gate lifts.
+Sequencing: independent of K3 macro-gate state (Status quote is `pending PM / SME assignment`, NOT `pending K3 GATE PASS`). Could activate as soon as PM / SME inputs land.
 
 ### 4.7 Lane C2 — Template Install & Onboarding
 
@@ -139,7 +140,7 @@ Sequencing: C2 depends on C1.
 
 | Required to flip Status `deferred → pending` | Currently |
 | --- | --- |
-| T4 closed: a K3-free staging environment is available, OR the K3 GATE has passed and 142 is no longer the K3 PoC stable host | not closed |
+| T4 closed: a K3-free staging environment is available, OR the K3 GATE has passed and 142 is no longer the K3 PoC stable host | K3 gate passed via #1792; 142 host availability still needs operator confirmation |
 | Perf thresholds NOT yet committed (per the TODO line `Avoid making performance thresholds strict until baseline is measured on 142`) — must remain non-strict on first activation | acknowledged |
 | Lane D0 release-gate skeleton merged on `main` | merged (PR #1541) |
 
@@ -150,7 +151,7 @@ Sequencing: D2 can activate independently of A/B/C as long as T4 is closed. Macr
 | Required to flip Status `deferred → pending` | Currently |
 | --- | --- |
 | T5 closed (snapshot-vs-golden-matrix semantics chosen) | not closed |
-| Macro gate or K3-free staging — same as D2 | not closed |
+| Macro gate or K3-free staging — same as D2 | macro gate lifted via #1792; staging/142 use still needs operator confirmation |
 | Lane D0 release-gate skeleton merged on `main` | merged (PR #1541) |
 
 Sequencing: D3 can activate independently of A/B/C; same macro-gate condition as D2.
@@ -158,7 +159,7 @@ Sequencing: D3 can activate independently of A/B/C; same macro-gate condition as
 ## 5. Cross-lane dependency graph
 
 ```
-                    L-M-1 / L-M-2 (macro gate)
+                    L-M-1 satisfied (#1792)
                     /        |        |       \
                    /         |        |        \
                   v          v        v         v
@@ -173,10 +174,10 @@ Sequencing: D3 can activate independently of A/B/C; same macro-gate condition as
 
 Notable observations:
 
-- **Lane C is the only deferred track NOT gated by K3 lock** — operator can unblock by securing PM / SME inputs alone. If the K3 GATE answer drags, Lane C can still be unblocked if those inputs surface.
-- **Lane B1 could ship as a non-AI formula-diagnostics PR before AI lanes** if the macro gate lifts — operator chose to keep it coherent with B2.
-- **Lane D2 / D3 are independent of A/B/C** and could activate as soon as their respective T-blocker and macro gate close.
-- **No lane outside Lane C has zero K3-gate dependency.**
+- **Lane C remains independent of the K3 macro gate** — operator can unblock it by securing PM / SME inputs.
+- **Lane B1 could ship as a non-AI formula-diagnostics PR before AI lanes** now that the macro gate has lifted, if the operator chooses to decouple it from B2.
+- **Lane D2 / D3 are independent of A/B/C** and could activate once their remaining T-blocker / staging conditions close.
+- **K3 is no longer the blanket blocker**, but this checklist still requires lane-local blockers and explicit operator opt-in.
 
 ## 6. Operator decision matrix
 
@@ -184,12 +185,12 @@ Two checkpoint questions for the operator, neither of which requires implementat
 
 | Question | Answer routes to |
 | --- | --- |
-| Q1: Is K3 GATE PASSED, OR are you explicitly breaking the lock? | A1 / A2 / A3 / B1 / B2 / D2 / D3 become eligible (each still needs T-closure). |
+| Q1: Is K3 GATE PASSED, OR are you explicitly breaking the lock? | YES via #1792. A1 / A2 / A3 / B1 / B2 / D2 / D3 become eligible only after their own T-closure and operator ratification. |
 | Q2: Do you have PM ownership + SME availability for at least 3 of the 5 industry templates, AND a rollback strategy choice for T7? | C1 / C2 become eligible regardless of Q1. |
 
-If both Q1 and Q2 answer NO, the only Phase 3 work eligible to ship is `pending` items already in the active queue — and that queue's implementation is merged on `main` as of `4743ba44d` (rechecked at `b49505c10` — the new commit `#1566` is Data Factory only, no Phase 3 drift). Until either Q1 or Q2 answers YES, no further Phase 3 lane can ship.
+Q1 now answers YES via #1792, but no Phase 3 lane flips automatically: the lane-local blockers and operator ratification rows above still decide actual re-entry.
 
-If Q1 answers YES but Q2 answers NO, the AI / Formula / Hardening (D2/D3) lanes become eligible.
+If Q1 answers YES but Q2 answers NO, the AI / Formula / Hardening (D2/D3) lanes become eligible only after their lane-local blockers close.
 
 If Q2 answers YES but Q1 answers NO, only Lane C becomes eligible.
 
@@ -200,7 +201,7 @@ If Q2 answers YES but Q1 answers NO, only Lane C becomes eligible.
 3. For each lane that becomes eligible:
    - The corresponding Status line in `multitable-feishu-phase3-ai-hardening-todo-20260514.md` is updated from `deferred ...` to `pending — active queue`.
    - The relevant T-blockers for that lane are closed via design MD commits.
-   - Implementation PRs follow the established stage-1 lock discipline (clean worktree, scoped diff, redaction tests, dev + verification MDs).
+   - Implementation PRs follow the established scoped-gate discipline (clean worktree, scoped diff, redaction tests, dev + verification MDs).
 4. This unlock checklist may be revised once any lane unlocks; subsequent revisions extend the dependency graph in §5.
 
 ## 8. What this checklist authored under
@@ -219,6 +220,7 @@ If Q2 answers YES but Q1 answers NO, only Lane C becomes eligible.
 - `docs/development/multitable-feishu-phase3-ai-hardening-todo-20260514.md`
 - `docs/development/multitable-feishu-phase3-ai-hardening-review-20260514.md`
 - `docs/development/multitable-phase3-active-queue-closeout-development-20260515.md`
-- `project_k3_poc_stage1_lock.md` (memory)
+- `project_k3_poc_stage1_lock.md` (memory; retired for planning after #1792)
+- `docs/development/k3-post-gate-scoped-governance-20260528.md`
 - `docs/development/integration-erp-platform-roadmap-20260425.md` §4-§5
-- `/tmp/multitable-phase3-lane-a1-implementation-design-20260515.md` (Claude's read-only A1 design draft — **still in `/tmp/`, not committed to `docs/development/`, awaiting K3 GATE PASS or explicit lock-break before ratification**)
+- `/tmp/multitable-phase3-lane-a1-implementation-design-20260515.md` (Claude's read-only A1 design draft — **still in `/tmp/`, not committed to `docs/development/`, awaiting operator ratification before implementation**)

--- a/docs/operations/integration-k3wise-material-only-process-control-plane-20260527.md
+++ b/docs/operations/integration-k3wise-material-only-process-control-plane-20260527.md
@@ -4,7 +4,7 @@ Status: operational process contract. **Docs-only control plane** — it describ
 
 It **references, does not re-derive** the existing operator docs: the C0–C11 sequence in `docs/operations/integration-k3wise-live-gate-execution-package.md`, `docs/operations/integration-k3wise-onprem-operator-handoff-checklist.md`, and the customer-sample manifests. All decision names and issue codes below are **anchored to the landed `scripts/ops/integration-k3wise-*.mjs`**, not invented here.
 
-K3 lock: the customer GATE (#1792) is not PASS. This doc governs **dry-run / read-only / preflight / packaging** process only; K3 Save / BOM / Submit / Audit and server-side reference resolution remain frozen (separate named opt-in / GATE).
+Post-GATE scope: #1792 is PASS for **M1 one-record Material Save-only**. This doc governs **dry-run / read-only / preflight / packaging** process only; additional K3 Save attempts, BOM, Submit, Audit, multi-record / batch, production signoff, and server-side reference resolution remain separate named opt-in gates.
 
 ## 1. Two lanes (do not merge into one linear flow)
 
@@ -65,7 +65,7 @@ Boundaries (not a staffing count — who is accountable for which artifact/gate)
 
 - No `automation-executor.ts` change; **does not import workflow-job-contract**; no runner, no report generator, no new schema.
 - Material-only readiness is **not** customer-trial signoff (§1, tool-enforced).
-- K3 Save / BOM / Submit / Audit and server-side reference resolver/composition stay frozen until the customer GATE PASS or a separate named opt-in.
+- Additional K3 Save attempts / BOM / Submit / Audit / multi-record and server-side reference resolver/composition stay frozen until a separate named opt-in.
 
 ## 6. Enforcement
 

--- a/docs/operations/integration-k3wise-webapi-read-list-customer-sample-manifest.md
+++ b/docs/operations/integration-k3wise-webapi-read-list-customer-sample-manifest.md
@@ -6,9 +6,10 @@ Before MetaSheet can implement K3 WISE Material/BOM **read/list** (pull data fro
 K3 into the cleansing multitable, issue #1526 finding #2), we need the customer
 to confirm the WebAPI read contract and provide redacted sample responses.
 
-This is an **intake checklist**, not an execution runbook. The read/list runtime
-is deferred until the customer GATE PASS; this document front-loads the inputs so
-implementation is fast once unblocked.
+This is an **intake checklist**, not an execution runbook. #1792 now satisfies
+the K3 M1 GATE PASS precondition, but the read/list runtime still needs explicit
+owner opt-in plus the O1-O6 inputs below; this document front-loads those inputs
+so implementation is fast once the scoped #1709 slice is approved.
 
 Read alongside:
 
@@ -102,8 +103,8 @@ write template); confirm or correct in O4-BOM.
 ## Hand-back
 
 Return Part A inline (redacted) and Part B as the four `*.redacted.json` files
-through the secure channel. On receipt and customer GATE PASS, the runtime slice
-proceeds per the post-GATE plan in the design and verification docs.
+through the secure channel. On receipt plus explicit owner opt-in, the runtime
+slice proceeds per the post-GATE plan in the design and verification docs.
 
 ## Machine check before runtime
 


### PR DESCRIPTION
## Summary
- Record #1792 as PASS for the accepted M1 one-record K3 WISE Material Save-only scope.
- Add a canonical post-GATE scoped-governance note that retires the global Stage-1 lock for planning.
- Update active planning/runbook docs so deferred work now depends on local blockers, owner opt-in, and scoped gates rather than the old blanket K3 lock.

## Boundaries
- Docs-only.
- Does not touch `plugins/plugin-integration-core`, runtime code, migrations, scripts, OpenAPI, RBAC, or package logic.
- Does not unlock Submit, Audit, BOM, multi-record/batch, production signoff, automatic retry, or direct K3 SQL writes.

## Test plan
- [x] `git diff --cached --check`
- [x] Verified `integration-k3wise-material-only-process-control-plane-20260527.md` still contains the package-verifier anchors: Material-only lane, Full / customer-trial lane, Blocked-reason taxonomy, Reviewer, and does not import workflow-job-contract.
