### PR TITLE
feat(attendance): apply fixed schedules for groups

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -3300,6 +3300,15 @@
                       >
                         {{ attendanceGroupFixedSchedulePreviewLoading ? tr('Previewing...', '预览中...') : tr('Preview fixed schedule', '预览固定排班') }}
                       </button>
+                      <button
+                        class="attendance__btn"
+                        type="button"
+                        :disabled="!attendanceGroupFixedScheduleApplyAvailable"
+                        data-attendance-group-fixed-schedule-apply-submit
+                        @click="applyAttendanceGroupFixedSchedulePreview"
+                      >
+                        {{ attendanceGroupFixedScheduleApplyLoading ? tr('Applying...', '应用中...') : tr('Apply preview', '应用预览') }}
+                      </button>
                     </div>
                     <div
                       v-if="attendanceGroupFixedSchedulePreviewResult"
@@ -3311,8 +3320,9 @@
                         <span data-attendance-group-fixed-schedule-preview-create>{{ tr('Would create', '将创建') }}: {{ attendanceGroupFixedSchedulePreviewResult.wouldCreate.length }}</span>
                         <span data-attendance-group-fixed-schedule-preview-skip>{{ tr('Skipped', '跳过') }}: {{ attendanceGroupFixedSchedulePreviewResult.skipped.length }}</span>
                         <span data-attendance-group-fixed-schedule-preview-conflict>{{ tr('Blocking conflicts', '阻断冲突') }}: {{ attendanceGroupFixedSchedulePreviewResult.blockingConflicts.length }}</span>
+                        <span v-if="attendanceGroupFixedSchedulePreviewResult.applied" data-attendance-group-fixed-schedule-apply-created>{{ tr('Created', '已创建') }}: {{ attendanceGroupFixedSchedulePreviewResult.created?.length ?? 0 }}</span>
                       </div>
-                      <small class="attendance__field-hint">{{ tr('If blocking conflicts are present, the future apply step must write nothing.', '如果存在阻断冲突，后续应用步骤必须零写入。') }}</small>
+                      <small class="attendance__field-hint">{{ tr('If blocking conflicts are present, apply stays disabled and writes nothing.', '如果存在阻断冲突，应用保持禁用且零写入。') }}</small>
                     </div>
                   </section>
                 </section>
@@ -6337,6 +6347,8 @@ interface AttendanceGroupFixedSchedulePreviewResult {
   wouldCreate: AttendanceGroupFixedSchedulePreviewCandidate[]
   skipped: AttendanceGroupFixedSchedulePreviewSkipped[]
   blockingConflicts: AttendanceGroupFixedSchedulePreviewConflict[]
+  created?: AttendanceAssignment[]
+  applied?: boolean
 }
 
 type AttendanceGroupSummaryAction = {
@@ -6920,6 +6932,7 @@ const attendanceGroupSaving = ref(false)
 const attendanceGroupMemberLoading = ref(false)
 const attendanceGroupMemberSaving = ref(false)
 const attendanceGroupFixedSchedulePreviewLoading = ref(false)
+const attendanceGroupFixedScheduleApplyLoading = ref(false)
 const payrollTemplateLoading = ref(false)
 const payrollTemplateSaving = ref(false)
 const payrollSummaryFieldOptionsLoading = ref(false)
@@ -8222,6 +8235,15 @@ const attendanceGroupFixedSchedulePreviewAvailable = computed(() =>
       && attendanceGroupFixedSchedulePreviewForm.startDate
       && attendanceGroupFixedSchedulePreviewForm.endDate
       && !attendanceGroupFixedSchedulePreviewLoading.value,
+  )
+)
+const attendanceGroupFixedScheduleApplyAvailable = computed(() =>
+  Boolean(
+    attendanceGroupFixedSchedulePreviewResult.value
+      && attendanceGroupFixedSchedulePreviewResult.value.blockingConflicts.length === 0
+      && !attendanceGroupFixedSchedulePreviewResult.value.applied
+      && !attendanceGroupFixedSchedulePreviewLoading.value
+      && !attendanceGroupFixedScheduleApplyLoading.value,
   )
 )
 const attendanceGroupFixedSchedulePreviewSummary = computed(() => {
@@ -16121,6 +16143,47 @@ async function previewAttendanceGroupFixedSchedule() {
     setStatus(readErrorMessage(error, tr('Failed to preview fixed schedule', '预览固定排班失败')), 'error')
   } finally {
     attendanceGroupFixedSchedulePreviewLoading.value = false
+  }
+}
+
+async function applyAttendanceGroupFixedSchedulePreview() {
+  const groupId = attendanceGroupEditingId.value
+  const preview = attendanceGroupFixedSchedulePreviewResult.value
+  if (!groupId || !preview) {
+    setStatus(tr('Preview the fixed schedule before applying.', '请先预览固定排班再应用。'), 'error')
+    return
+  }
+  if (preview.blockingConflicts.length > 0) {
+    setStatus(tr('Resolve blocking conflicts before applying.', '请先解决阻断冲突再应用。'), 'error')
+    return
+  }
+  attendanceGroupFixedScheduleApplyLoading.value = true
+  try {
+    const response = await apiFetch(`/api/attendance/groups/${groupId}/fixed-schedule/apply`, {
+      method: 'POST',
+      body: JSON.stringify({
+        shiftId: attendanceGroupFixedSchedulePreviewForm.shiftId,
+        startDate: attendanceGroupFixedSchedulePreviewForm.startDate,
+        endDate: attendanceGroupFixedSchedulePreviewForm.endDate,
+        orgId: normalizedOrgId(),
+      }),
+    })
+    if (response.status === 403) {
+      adminForbidden.value = true
+      throw new Error(tr('Admin permissions required', '需要管理员权限'))
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to apply fixed schedule', '应用固定排班失败')))
+    }
+    adminForbidden.value = false
+    attendanceGroupFixedSchedulePreviewResult.value = data.data as AttendanceGroupFixedSchedulePreviewResult
+    await loadAssignments()
+    setStatus(tr('Fixed schedule applied.', '固定排班已应用。'))
+  } catch (error: any) {
+    setStatus(readErrorMessage(error, tr('Failed to apply fixed schedule', '应用固定排班失败')), 'error')
+  } finally {
+    attendanceGroupFixedScheduleApplyLoading.value = false
   }
 }
 

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -677,7 +677,7 @@ describe('Attendance admin regressions', () => {
     expect(window.getComputedStyle(container!.querySelector<HTMLElement>('#attendance-admin-groups')!).display).toBe('none')
   })
 
-  it('previews fixed schedule coverage without writing assignments', async () => {
+  it('previews fixed schedule coverage and disables apply when blocking conflicts exist', async () => {
     const previewBodies: unknown[] = []
     vi.mocked(apiFetch).mockImplementation(async (input, init) => {
       const url = typeof input === 'string' ? input : input.url
@@ -825,7 +825,163 @@ describe('Attendance admin regressions', () => {
     expect(previewPanel!.querySelector('[data-attendance-group-fixed-schedule-preview-create]')?.textContent).toContain('1')
     expect(previewPanel!.querySelector('[data-attendance-group-fixed-schedule-preview-skip]')?.textContent).toContain('1')
     expect(previewPanel!.querySelector('[data-attendance-group-fixed-schedule-preview-conflict]')?.textContent).toContain('1')
-    expect(previewPanel!.textContent).not.toContain('Apply')
+    expect(previewPanel!.querySelector<HTMLButtonElement>('[data-attendance-group-fixed-schedule-apply-submit]')?.disabled).toBe(true)
+    expect(vi.mocked(apiFetch).mock.calls.some(([input, init]) =>
+      String(input) === '/api/attendance/assignments' && init?.method === 'POST'
+    )).toBe(false)
+  })
+
+  it('applies a fixed schedule preview through the group route without posting individual assignments', async () => {
+    const previewBodies: unknown[] = []
+    const applyBodies: unknown[] = []
+    const previewData = {
+      group: {
+        id: 'group-a',
+        name: 'Ops Team',
+        timezone: 'Asia/Shanghai',
+      },
+      shift: {
+        id: 'shift-a',
+        name: 'Day shift',
+        timezone: 'Asia/Shanghai',
+        workStartTime: '09:00',
+        workEndTime: '18:00',
+        lateGraceMinutes: 10,
+        earlyGraceMinutes: 5,
+        roundingMinutes: 5,
+        workingDays: [1, 2, 3, 4, 5],
+      },
+      window: { startDate: '2026-06-01', endDate: '2026-06-30' },
+      target: { total: 2, userIds: ['user-create', 'user-skip'] },
+      wouldCreate: [
+        { userId: 'user-create', shiftId: 'shift-a', startDate: '2026-06-01', endDate: '2026-06-30', isActive: true },
+      ],
+      skipped: [
+        { assignmentId: 'assignment-skip', userId: 'user-skip', shiftId: 'shift-a', startDate: '2026-06-01', endDate: '2026-06-30' },
+      ],
+      blockingConflicts: [],
+    }
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/rule-sets')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              { id: 'rule-set-1', name: 'Ops Rules', scope: 'org', version: 3, isDefault: true },
+            ],
+            total: 1,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/groups/group-a/fixed-schedule/preview') && init?.method === 'POST') {
+        previewBodies.push(JSON.parse(String(init.body || '{}')))
+        return jsonResponse(200, { ok: true, data: previewData })
+      }
+      if (url.includes('/api/attendance/groups/group-a/fixed-schedule/apply') && init?.method === 'POST') {
+        applyBodies.push(JSON.parse(String(init.body || '{}')))
+        return jsonResponse(201, {
+          ok: true,
+          data: {
+            ...previewData,
+            applied: true,
+            created: [
+              { id: 'assignment-created', userId: 'user-create', shiftId: 'shift-a', startDate: '2026-06-01', endDate: '2026-06-30', isActive: true },
+            ],
+          },
+        })
+      }
+      if (url.includes('/api/attendance/groups/group-a/members')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              { id: 'member-1', groupId: 'group-a', userId: 'user-create', createdAt: '2026-03-28T08:00:00.000Z' },
+            ],
+            total: 2,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/groups')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'group-a',
+                name: 'Ops Team',
+                code: 'ops-team',
+                timezone: 'Asia/Shanghai',
+                ruleSetId: 'rule-set-1',
+                description: 'Operations attendance group',
+              },
+            ],
+            total: 1,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/shifts')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'shift-a',
+                name: 'Day shift',
+                timezone: 'Asia/Shanghai',
+                workStartTime: '09:00',
+                workEndTime: '18:00',
+                lateGraceMinutes: 10,
+                earlyGraceMinutes: 5,
+                roundingMinutes: 5,
+                workingDays: [1, 2, 3, 4, 5],
+              },
+            ],
+          },
+        })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const groupsNav = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-groups"]')
+    expect(groupsNav).toBeTruthy()
+    groupsNav!.click()
+    await flushUi(4)
+
+    const previewPanel = container!.querySelector<HTMLElement>('[data-attendance-group-fixed-schedule-preview]')
+    expect(previewPanel).toBeTruthy()
+    const shiftSelect = previewPanel!.querySelector<HTMLSelectElement>('[data-attendance-group-fixed-schedule-shift]')
+    expect(shiftSelect).toBeTruthy()
+    shiftSelect!.value = 'shift-a'
+    shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(previewPanel!, '[data-attendance-group-fixed-schedule-start]', '2026-06-01')
+    setInput(previewPanel!, '[data-attendance-group-fixed-schedule-end]', '2026-06-30')
+    await flushUi(2)
+
+    previewPanel!.querySelector<HTMLButtonElement>('[data-attendance-group-fixed-schedule-preview-submit]')!.click()
+    await flushUi(8)
+    const applyButton = previewPanel!.querySelector<HTMLButtonElement>('[data-attendance-group-fixed-schedule-apply-submit]')
+    expect(applyButton).toBeTruthy()
+    expect(applyButton!.disabled).toBe(false)
+    applyButton!.click()
+    await flushUi(8)
+
+    const expectedBody = {
+      shiftId: 'shift-a',
+      startDate: '2026-06-01',
+      endDate: '2026-06-30',
+    }
+    expect(previewBodies).toEqual([expectedBody])
+    expect(applyBodies).toEqual([expectedBody])
+    expect(previewPanel!.querySelector('[data-attendance-group-fixed-schedule-apply-created]')?.textContent).toContain('1')
+    expect(applyButton!.disabled).toBe(true)
+    applyButton!.click()
+    await flushUi(2)
+    expect(applyBodies).toEqual([expectedBody])
     expect(vi.mocked(apiFetch).mock.calls.some(([input, init]) =>
       String(input) === '/api/attendance/assignments' && init?.method === 'POST'
     )).toBe(false)

--- a/docs/development/attendance-group-admin-ux-fixed-schedule-apply-verification-20260528.md
+++ b/docs/development/attendance-group-admin-ux-fixed-schedule-apply-verification-20260528.md
@@ -1,0 +1,71 @@
+# Attendance Group Fixed-Schedule Apply Verification — 2026-05-28
+
+## Scope
+
+FS-C extends the fixed-schedule preview chain with an apply path.
+
+The slice deliberately stays narrow:
+
+- Reuses the FS-B fixed-schedule plan/classifier for both preview and apply.
+- Adds `POST /api/attendance/groups/:id/fixed-schedule/apply`.
+- Runs apply inside a transaction.
+- Acquires the existing per-org/user attendance schedule advisory lock for every target user.
+- Re-runs the shared plan/classifier inside the transaction.
+- Inserts only `wouldCreate[]` rows into `attendance_shift_assignments`.
+- Leaves `skipped[]` as no-op exact matches.
+- Returns `409 ATTENDANCE_GROUP_FIXED_SCHEDULE_BLOCKING_CONFLICT` and writes nothing when `blockingConflicts[]` is non-empty.
+
+## Boundaries
+
+- No migration.
+- No schema change.
+- No new permission.
+- No `attendance_schedule_groups` reuse.
+- No group schedule fact table.
+- No fixed/shift/free schedule type modeling.
+- No weekly matrix.
+- No punch method configuration.
+
+## Verification
+
+Commands run from `/tmp/metasheet2-attendance-group-fixed-schedule-apply-20260528`:
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-scheduling-assignment-conflict.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts --watch=false
+pnpm --filter @metasheet/web exec vitest run --watch=false tests/attendance-admin-regressions.spec.ts
+pnpm --filter @metasheet/web type-check
+git diff --check
+```
+
+Results:
+
+- `node --check plugins/plugin-attendance/index.cjs` — PASS.
+- `attendance-scheduling-assignment-conflict.test.ts` — PASS, 9/9.
+- `attendance-uuid-validation-routes.test.ts` — PASS, 3/3.
+- `attendance-admin-regressions.spec.ts` — PASS, 30/30.
+- `git diff --check` — PASS.
+- `pnpm --filter @metasheet/web type-check` — BLOCKED by the borrowed worktree dependency tree missing existing `echarts/*` modules (`echarts/core`, `echarts/charts`, `echarts/components`, `echarts/renderers`, `echarts`). The failure is outside this attendance slice; the focused frontend regression suite above ran cleanly.
+
+Locked behaviors:
+
+- Preview and apply both use `buildAttendanceGroupFixedSchedulePlan`.
+- Apply locks every target user before the transaction-time overlap query.
+- Apply creates only missing exact assignments.
+- Apply skips exact matches without treating them as conflicts.
+- Apply performs no insert when a blocking conflict exists.
+- The frontend calls the group apply route, not `/api/attendance/assignments`.
+- Apply stays disabled when preview has blocking conflicts.
+- Apply is disabled after a successful apply, so a second click requires a fresh preview and does not re-submit.
+- The apply route emits the existing `attendance.assignment.created` event for created assignments; this slice does not introduce a new event type.
+
+## Deferred
+
+These remain separate explicit opt-ins:
+
+- Fixed-schedule producer/source metadata and managed-row rebuild/delete semantics.
+- Group-owned weekly schedule matrix.
+- Group-specific punch method configuration.
+- Owner/sub-owner roles.
+- Export/copy controls.

--- a/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
@@ -239,4 +239,103 @@ describe('attendance scheduling assignment conflict guard', () => {
     })
     expect(db.query).toHaveBeenCalledTimes(3)
   })
+
+  it('applies fixed-schedule group plans by locking users, skipping exact matches, and inserting only missing rows', async () => {
+    const db = {
+      query: vi.fn()
+        .mockResolvedValueOnce([{ id: 'group-a', org_id: 'org-a', name: 'Operations', timezone: 'UTC' }])
+        .mockResolvedValueOnce([{ id: 'shift-a', org_id: 'org-a', name: 'Day shift', timezone: 'UTC' }])
+        .mockResolvedValueOnce([{ user_id: 'user-create' }, { user_id: 'user-skip' }])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            id: 'assignment-skip',
+            user_id: 'user-skip',
+            shift_id: 'shift-a',
+            start_date: '2026-06-01',
+            end_date: '2026-06-30',
+            kind: 'shift',
+          },
+        ])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            id: 'assignment-created',
+            org_id: 'org-a',
+            user_id: 'user-create',
+            shift_id: 'shift-a',
+            start_date: '2026-06-01',
+            end_date: '2026-06-30',
+            is_active: true,
+          },
+        ]),
+    }
+
+    const result = await helpers.applyAttendanceGroupFixedSchedule(db, {
+      orgId: 'org-a',
+      groupId: 'group-a',
+      shiftId: 'shift-a',
+      startDate: '2026-06-01',
+      endDate: '2026-06-30',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.data.wouldCreate.map((item: any) => item.userId)).toEqual(['user-create'])
+    expect(result.data.skipped.map((item: any) => item.userId)).toEqual(['user-skip'])
+    expect(result.data.blockingConflicts).toEqual([])
+    expect(result.data.created).toEqual([
+      expect.objectContaining({
+        id: 'assignment-created',
+        orgId: 'org-a',
+        userId: 'user-create',
+        shiftId: 'shift-a',
+        startDate: '2026-06-01',
+        endDate: '2026-06-30',
+        isActive: true,
+      }),
+    ])
+
+    const queries = db.query.mock.calls.map(call => String(call[0]))
+    expect(queries.filter(sql => sql.includes('pg_advisory_xact_lock'))).toHaveLength(2)
+    expect(queries.filter(sql => /\bINSERT INTO attendance_shift_assignments\b/i.test(sql))).toHaveLength(1)
+  })
+
+  it('refuses fixed-schedule group applies without inserting when a blocking conflict exists', async () => {
+    const db = {
+      query: vi.fn()
+        .mockResolvedValueOnce([{ id: 'group-a', org_id: 'org-a', name: 'Operations', timezone: 'UTC' }])
+        .mockResolvedValueOnce([{ id: 'shift-a', org_id: 'org-a', name: 'Day shift', timezone: 'UTC' }])
+        .mockResolvedValueOnce([{ user_id: 'user-conflict' }])
+        .mockResolvedValueOnce([])
+        .mockResolvedValueOnce([
+          {
+            id: 'assignment-conflict',
+            user_id: 'user-conflict',
+            shift_id: 'shift-b',
+            start_date: '2026-06-10',
+            end_date: '2026-06-20',
+            kind: 'shift',
+          },
+        ])
+        .mockResolvedValueOnce([]),
+    }
+
+    const result = await helpers.applyAttendanceGroupFixedSchedule(db, {
+      orgId: 'org-a',
+      groupId: 'group-a',
+      shiftId: 'shift-a',
+      startDate: '2026-06-01',
+      endDate: '2026-06-30',
+    })
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 409,
+      code: 'ATTENDANCE_GROUP_FIXED_SCHEDULE_BLOCKING_CONFLICT',
+    })
+    expect(result.details.blockingConflicts.map((item: any) => item.userId)).toEqual(['user-conflict'])
+    const queries = db.query.mock.calls.map(call => String(call[0])).join('\n')
+    expect(queries).not.toMatch(/\bINSERT INTO attendance_shift_assignments\b/i)
+  })
 })

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -142,6 +142,14 @@ describe('attendance UUID route validation', () => {
           endDate: '2026-06-30',
         },
       },
+      {
+        key: 'POST /api/attendance/groups/:id/fixed-schedule/apply',
+        body: {
+          shiftId: '00000000-0000-4000-8000-000000000001',
+          startDate: '2026-06-01',
+          endDate: '2026-06-30',
+        },
+      },
       { key: 'GET /api/attendance/holidays/:id' },
       { key: 'PUT /api/attendance/holidays/:id' },
       { key: 'DELETE /api/attendance/holidays/:id' },

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8695,7 +8695,7 @@ function mapAttendanceGroupFixedScheduleBlockingConflict(row, draft) {
   }
 }
 
-async function buildAttendanceGroupFixedSchedulePreview(db, input) {
+async function buildAttendanceGroupFixedSchedulePlan(db, input, options = {}) {
   const groupRows = await db.query(
     'SELECT * FROM attendance_groups WHERE id = $1 AND org_id = $2',
     [input.groupId, input.orgId]
@@ -8741,6 +8741,12 @@ async function buildAttendanceGroupFixedSchedulePreview(db, input) {
       status: 400,
       code: 'VALIDATION_ERROR',
       message: 'Group has no members to schedule',
+    }
+  }
+
+  if (options.lockTargets) {
+    for (const userId of userIds) {
+      await acquireAttendanceScheduleAssignmentLock(db, input.orgId, userId)
     }
   }
 
@@ -8822,6 +8828,53 @@ async function buildAttendanceGroupFixedSchedulePreview(db, input) {
       wouldCreate,
       skipped,
       blockingConflicts,
+    },
+  }
+}
+
+async function buildAttendanceGroupFixedSchedulePreview(db, input) {
+  return buildAttendanceGroupFixedSchedulePlan(db, input)
+}
+
+async function applyAttendanceGroupFixedSchedule(db, input) {
+  const result = await buildAttendanceGroupFixedSchedulePlan(db, input, { lockTargets: true })
+  if (!result.ok) return result
+  const plan = result.data
+  if (plan.blockingConflicts.length > 0) {
+    return {
+      ok: false,
+      status: 409,
+      code: 'ATTENDANCE_GROUP_FIXED_SCHEDULE_BLOCKING_CONFLICT',
+      message: 'Fixed schedule apply has blocking conflicts',
+      details: plan,
+    }
+  }
+
+  const created = []
+  for (const item of plan.wouldCreate) {
+    const rows = await db.query(
+      `INSERT INTO attendance_shift_assignments
+       (id, org_id, user_id, shift_id, start_date, end_date, is_active)
+       VALUES ($1, $2, $3, $4, $5, $6, true)
+       RETURNING *`,
+      [
+        randomUUID(),
+        input.orgId,
+        item.userId,
+        item.shiftId,
+        item.startDate,
+        item.endDate,
+      ]
+    )
+    if (rows[0]) created.push(mapAssignmentRow(rows[0]))
+  }
+
+  return {
+    ok: true,
+    data: {
+      ...plan,
+      created,
+      applied: true,
     },
   }
 }
@@ -14460,7 +14513,9 @@ module.exports = {
     resolveAttendanceComprehensiveHoursPreviewPeriod,
     previewAttendanceComprehensiveHours,
     findAttendanceScheduleAssignmentConflict,
+    buildAttendanceGroupFixedSchedulePlan,
     buildAttendanceGroupFixedSchedulePreview,
+    applyAttendanceGroupFixedSchedule,
     acquireAttendanceScheduleAssignmentLock,
     getAttendanceScheduleAssignmentConflictMessage,
     getAttendanceScheduleAssignmentConflictType,
@@ -25852,6 +25907,83 @@ module.exports = {
           }
           logger.error('Attendance group fixed schedule preview failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to preview fixed schedule' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/groups/:id/fixed-schedule/apply',
+      withPermission('attendance:admin', async (req, res) => {
+        const schema = z.object({
+          shiftId: z.string().min(1),
+          startDate: z.string().min(1),
+          endDate: z.string().min(1),
+          orgId: z.string().optional(),
+        }).strict()
+
+        const parsed = schema.safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+
+        const orgId = getOrgId(req)
+        const groupId = normalizeUuidString(req.params.id)
+        if (!groupId) {
+          respondInvalidUuid(res)
+          return
+        }
+        const shiftId = normalizeUuidString(parsed.data.shiftId)
+        if (!shiftId) {
+          respondInvalidUuid(res, 'shiftId')
+          return
+        }
+        const startDate = normalizeDateOnlyStrict(parsed.data.startDate)
+        if (!startDate) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid "startDate" date. Use YYYY-MM-DD.' } })
+          return
+        }
+        const endDate = normalizeDateOnlyStrict(parsed.data.endDate)
+        if (!endDate) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid "endDate" date. Use YYYY-MM-DD.' } })
+          return
+        }
+        if (startDate > endDate) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: '"startDate" must be on or before "endDate".' } })
+          return
+        }
+
+        try {
+          const result = await db.transaction((trx) => applyAttendanceGroupFixedSchedule(trx, {
+            orgId,
+            groupId,
+            shiftId,
+            startDate,
+            endDate,
+          }))
+          if (!result.ok) {
+            res.status(result.status).json({
+              ok: false,
+              error: {
+                code: result.code,
+                message: result.message,
+                details: result.details,
+              },
+            })
+            return
+          }
+          for (const assignment of result.data.created) {
+            emitEvent('attendance.assignment.created', { orgId, assignmentId: assignment.id })
+          }
+          res.status(201).json({ ok: true, data: result.data })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance group fixed schedule apply failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to apply fixed schedule' } })
         }
       })
     )


### PR DESCRIPTION
## Summary
- add the FS-C group fixed-schedule apply route: POST /api/attendance/groups/:id/fixed-schedule/apply
- share the FS-B plan/classifier between preview and apply, so exact-match rows are skipped, missing rows are created, and blocking overlaps fail closed
- run apply in a transaction, acquire the existing per-org/user schedule locks for every target, insert only wouldCreate rows, and emit the existing attendance.assignment.created event for created assignments
- add the frontend Apply preview action, disabled when preview has blocking conflicts, and keep writes on the group route rather than /api/attendance/assignments
- add verification doc for the FS-C slice

## Boundaries
- no migration, schema, permission, OpenAPI, weekly matrix, punch-method config, or attendance_schedule_groups reuse
- no producer/source metadata or managed-row rebuild/delete semantics; FS-D remains deferred

## Verification
- node --check plugins/plugin-attendance/index.cjs
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-scheduling-assignment-conflict.test.ts --watch=false (9/9)
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts --watch=false (3/3)
- pnpm --filter @metasheet/web exec vitest run --watch=false tests/attendance-admin-regressions.spec.ts (30/30)
- git diff --check

## Caveat
- pnpm --filter @metasheet/web type-check was attempted from the isolated worktree with borrowed node_modules, but is blocked by the existing dependency-tree gap for echarts/* modules. The focused frontend regression suite for this slice passes.