### PR TITLE
feat(data-sources): Lane B B3 — per-connection legacy-TLS lever for MSSQL

### DIFF
--- a/docs/development/data-sources-mssql-windows-deploy-design-20260527.md
+++ b/docs/development/data-sources-mssql-windows-deploy-design-20260527.md
@@ -24,7 +24,7 @@
 
 1. **对客户数据源零改动、零风险**:不要求客户升级 SQL Server、不要求客户改服务器 TLS/证书配置、不要求客户开维护窗口。一切兼容性在我方 runtime 侧消化。
 2. **只读优先(MVP 强制,框架级,非装饰)**:MVP 只暴露读路径。只读保障必须做到**框架级双层**(不能只靠适配器层):① 路由级 —— readOnly 源拒绝 raw `POST /:id/query` 写语句(SELECT-only 分类器,或对 readOnly 源直接禁用 raw query);② 适配器层 —— 拒绝 `insert/update/delete/transaction` 写。由 per-source `readOnly` 旗标(默认 `true`)统一控制。落地见 Lane A 的 **A-RO**(框架级,适用全部适配器),MSSQL 仅继承该保障。写能力解禁是后续独立闸。
-3. **默认安全,放宽显式且可审计**:连接默认 `encrypt=true`、`trustServerCertificate=false`;任何"降级"(跳证书校验 / 关加密 / 降 TLS 版本)都是**单数据源**级别的显式配置,并在降级时落 warn 审计日志。
+3. **默认安全,放宽显式且可审计**:连接默认 `encrypt=true`(线缆始终加密);`trustServerCertificate` 默认 `true`(信任内网自签证书、跳过证书身份校验,但**仍全程加密**——ERP 内网部署常态,PR1 #1985 既定默认)。更进一步的降级(降 TLS 版本/cipher、或关加密走明文)都是**单数据源**级别的显式配置,并在降级时落 warn 审计日志。降 TLS(B3,仍加密)与关加密(明文)互斥,不可同设。
 4. **线缆加密与存储加密正交**:网络 TLS 与"凭据落库加密"是两件事,都要做;内网部署不豁免存储加密。
 5. **适配器与部署形态解耦**:连 SQL Server 的能力不依赖后端跑在哪(Linux VM / 容器 / 原生 Windows 三档通用)。
 
@@ -78,16 +78,16 @@
 |---|---|
 | B1 契约(先行) | `connection` 新增 per-source 旋钮:`version` / `encrypt` / `trustServerCertificate`;zod enum 加 `mssql` + **registry 同步注册 `mssql`**(避免重蹈 A4 的 enum/registry 不一致);OpenAPI parity 同步;非法 `type` 必须报错不回落。`readOnly` 旗标由 A-RO 统一定义,MSSQL 默认 `true`。**`authType` 本期只定 `'sql'`**;`'windows'`(集成认证)从 Linux runtime 走需 Kerberos/keytab/AD 信任/票据续期,是独立切片(B6),不在本期契约里半成品化 |
 | B2 适配器实现 | `MSSQLAdapter extends BaseDataAdapter`(tedious,长连接/池化生命周期,**非 new-pool-per-call**),对齐 connect/query/select/getSchema/stream;**继承 A-RO 框架级只读保障**(路由级 + 适配器层);TLS 旋钮经 tedious `cryptoCredentialsDetails` 的 **per-connection** `minVersion` + `ciphers`(含 `@SECLEVEL=0`)落地——明确走 per-connection,不用进程级 `--tls-min-v1.0` flag;复用 §Lane B 抽出的共享 mssql helper |
-| B3 TLS 放宽策略(我方侧) | 默认 `encrypt:true,trustServerCertificate:false`;内网自签 → per-source 开 `trustServerCertificate`(仍加密);老库 TLS1.0/老 cipher(AES-CBC-SHA)→ **per-connection** 放宽(`cryptoCredentialsDetails.minVersion='TLSv1'` + cipher 串带 `@SECLEVEL=0`),作用域限该源、客户服务器零改动;**两个机制非 per-source、需进程级**:(i) 若误用 `--tls-min-v1.0` flag 是进程级——不采用;(ii) OpenSSL3 legacy provider(仅当撞上 RC4/3DES/MD5)经 `openssl.cnf` 进程级加载,**不可 per-source** → 这类极老库一律走隔离代理 sidecar 分支,不在主进程放 legacy provider;再不行该源 `encrypt:false`(仅内网 + 审计) |
+| B3 TLS 放宽策略(我方侧) | 默认 `encrypt:true` + `trustServerCertificate:true`(信任内网自签证书,仍加密;PR1 #1985 既定默认,有受信 CA 时可 per-source 收紧为 `false`);老库 TLS1.0/老 cipher(AES-CBC-SHA)→ **per-connection** 放宽(`cryptoCredentialsDetails.minVersion='TLSv1'` + cipher 串带 `@SECLEVEL=0`),作用域限该源、客户服务器零改动,**仍加密;与 `encrypt:false` 互斥(同设即抛)**;**两个机制非 per-source、需进程级**:(i) 若误用 `--tls-min-v1.0` flag 是进程级——不采用;(ii) OpenSSL3 legacy provider(仅当撞上 RC4/3DES/MD5)经 `openssl.cnf` 进程级加载,**不可 per-source** → 这类极老库一律走隔离代理 sidecar 分支,不在主进程放 legacy provider;再不行该源 `encrypt:false`(仅内网 + 审计) |
 | B4 版本兼容矩阵 | 2008R2 / 2012 / 2016 / 2019 / 2022 行为表(默认加密要求、TLS 版本、握手关键字)。**真实容器只能测 2017+**(MS 官方 Linux mssql 镜像最低 SQL Server 2017;2008R2/2012 是 Windows-only 二进制,无 Linux 容器)→ 2017/2019/2022 用 `mcr.microsoft.com/mssql/server` 真测;2008R2/2012 用协议级 mock。**真实 legacy(2008R2/2012)验证需 Windows VM/快照** —— 这条会给 B4 带来 Windows 测试基础设施依赖,本预算未含,列为 P0 待裁示项 |
 | B5 测试 | connect/query/transaction 单测 + 经真实 wire 的集成测试(round-trip 校验,套用 wire-vs-fixture 纪律) |
 
 **降级决策树(B3 核心)**:
 ```
-默认: encrypt=true, trustServerCertificate=false        ← 2016+ 直接用
- └ 自签证书连不上 → trustServerCertificate=true          ← 仍加密,放弃证书身份校验(内网可接受)
-    └ 老库 TLS<1.2 握手断 → 我方 runtime 放宽 TLS 下限    ← 仍加密,客户服务器不动
-       └ 连 TLS1.0 都谈不拢 → 该源 encrypt=false(内网+审计) 或 隔离代理 sidecar  ← 明文为最后手段,作用域限一台
+默认: encrypt=true, trustServerCertificate=true         ← PR1 既定:加密 + 信任内网自签证书(2016+/内网直接用)
+ ├ (可选收紧) 有受信 CA 证书 → trustServerCertificate=false  ← 校验证书身份,更严
+ └ 老库 TLS<1.2 握手断 → per-connection 降 TLS 下限/cipher(B3)  ← 仍加密(cryptoCredentialsDetails),客户服务器不动
+    └ 连 TLS1.0 都谈不拢 → 该源 encrypt=false(内网+审计) 或 隔离代理 sidecar  ← 明文为最后手段,作用域限一台;与 B3 互斥
 ```
 
 ### Lane C — 部署形态(基础设施;运行时已基本可移植)
@@ -114,31 +114,33 @@
 
 ## 4. 门控 TODO 清单(🔒 待开闸 / ⬜ 待办未阻塞 / ✅ 完成)
 
+> **状态回填 2026-05-28**:本清单原为 #1960 落仓时的快照、之后未更新。现按 `origin/main` 真实状态回填:Lane A 安全核心(A0/A0.1/A-RO/A1/A4)与 Lane B B1/B2/B3 已落地;剩余待办 = A2/A3/A5/A6、B0(共享 helper)、B4(真容器/legacy 矩阵)、B5 的真 wire 集成测试;B6 + Lane C(C3)仍 gated。
+
 ### Phase 0 — 决策与开闸(裁示见 §5)
 - ✅ P0-3 Lane A 放行(归入内核打磨/安全修复)
-- 🔒 P0-4 Lane B hold,待 A0+A-RO+A1+A4 后再 opt-in
+- ✅ P0-4 Lane B 已 opt-in(A0/A0.1/A-RO/A1/A4 定住后,2026-05-28):通用连接器 PR1 #1985 + B3 legacy-TLS 本刀
 - ✅ P0-5 落点 `docs/development/data-sources-mssql-windows-deploy-design-20260527.md` + 新分支 `codex/data-sources-lane-a-hardening-20260527`(从 `origin/main`)
 - ✅ P0-6 现做协议 mock + 2017+ 容器真测;legacy VM 延后
 - ✅ P0-1/P0-2 优先级 A>B>C(C 兜底);客户 Linux VM / Docker 事实执行期回填
 
 ### Phase A — 适配器修复(P0-3 已放行;A0 最前置)
-- ⬜ **A0 持久化接线**:`DataSourceManager` 绑 Kysely + `initialize(db)` 启动调用 + autoload/persist + 确认/补 `data_sources` 表(**A1/A4 的前置,先做**)
-- ⬜ **A0.1 scope/ownership 收口**:写路径带 owner/workspace + 读/list/load 及每个 `:id` 操作按 scope 收口 + 越权拒绝测试(**与 A0 同前置,否则持久化=跨 workspace 全局缓存**)
-- ⬜ **A-RO 框架级只读**:per-source `readOnly` 旗标 + 路由级 raw-query 写拦截(SELECT-only 或禁用)+ 适配器层 mutation guard + 测试
-- ⬜ A1 凭据落库加密(**用真正的 crypto service,非 SecretManager**)+ 密钥来源/轮换/存量一次性迁移 + wire round-trip 集成测试
+- ✅ **A0 持久化接线**(#1960 `ec0516b5d`):`DataSourceManager.initialize(db)` 启动调用 + autoload/persist + `data_sources` 表
+- ✅ **A0.1 scope/ownership 收口**(#1960):写路径带 owner + `assertAccess` 每个 `:id` 操作越权 404 + list 过滤 + 越权拒绝测试
+- ✅ **A-RO 框架级只读**(#1964 `b0f7c54df`):per-source `readOnly`(默认 true)+ 路由级 SELECT-only 分类器 + 适配器层 `assertWritable`
+- ✅ A1 凭据落库加密(#1972 `5e11ee72c`):用 `encrypted-secrets` AES-256-GCM(非 SecretManager)+ 惰性迁移 + decrypt fail-loud
 - ⬜ A2 `sanitizeIdentifier` 违规即抛 + schema-qualified 支持 + 非法值测试
 - ⬜ A3 query/testConnection 错误不吞,保留错因 + 集成测试
-- ⬜ A4 enum↔registry↔驱动三方对齐(收敛 enum 到可用集 / 或注册+装驱动)+ 破坏性契约迁移 + 非法 type 测试
+- ✅ A4 enum↔registry↔驱动三方对齐(#1976 `f5013324e`):`SUPPORTED_DATA_SOURCE_TYPES` 单一支持矩阵 + 非法 type 400 + load 跳过不支持行
 - ⬜ A5 `stream()` 真游标流 或 明确文档标注 + 上限保护
 - ⬜ A6 Postgres connect/query/transaction/错误路径单测
 
-### Phase B — MSSQL 连接器(🔒 仍 hold;P0-4 裁示:待 A0+A0.1+A-RO+A1+A4 定住后再 opt-in;contracts-first)
-- 🔒 B0 抽共享 mssql helper(连接/TLS/类型映射,通用侧,不碰 integration-core)
-- 🔒 B1 契约:config 旋钮 + zod enum `mssql` + **registry 同步注册** + OpenAPI parity + 非法值测试(`readOnly` 用 A-RO,`authType` 仅 `sql`)
-- 🔒 B2 `MSSQLAdapter`(tedious)实现 + 只读 guard + per-connection TLS 旋钮(`cryptoCredentialsDetails`)
-- 🔒 B3 TLS 降级策略(per-connection 优先;legacy provider/明文走 sidecar 或内网+审计)+ 降级时审计日志
-- 🔒 B4 2016/2019/2022 真实容器测 + 2008R2/2012 协议级 mock(真实 legacy 验证依 P0-6 决策)
-- 🔒 B5 单测 + 经真实 wire 集成测试(wire-vs-fixture 纪律)
+### Phase B — MSSQL 连接器(Lane B 已 opt-in 2026-05-28;contracts-first)
+- ⬜ B0 抽共享 mssql helper(连接/TLS/类型映射)—— PR1 暂内联在 `MSSQLAdapter`,helper 抽取留作收口项(不碰 integration-core)
+- ✅ B1 契约(#1985 `ff0bcd0cc`):`type=sqlserver` zod enum + registry 同步注册(`SUPPORTED_DATA_SOURCE_TYPES`)+ config 旋钮(encrypt/trustServerCertificate)+ 非法 type 400;`readOnly` 用 A-RO 默认 true;`authType` 仅 `sql`
+- ✅ B2 `MSSQLAdapter`(mssql 驱动,池化生命周期)实现(#1985):connect/query/select/getSchema/stream + 继承 A-RO 只读 guard + `[ ]`/TOP/OFFSET-FETCH/`@pN`
+- ✅ B3 per-connection TLS 降级旋钮(本刀):`cryptoCredentialsDetails.minVersion`/`ciphers`(经 `tlsMinVersion`/`tlsCiphers`/`legacyTls` 便捷开关),secure-by-default,非法 minVersion 即抛,降级 `emit('tls-downgrade')` 审计 + warn;仍加密(明文/legacy-provider 仍走 sidecar)
+- ⬜ B4 版本兼容矩阵:2017/2019/2022 真容器测 + 2008R2/2012 协议级 mock(真实 legacy 验证需 Windows VM,依 P0-6,**follow-up**)
+- ⬜ B5 单测 ✅(#1985 + 本刀 B3 共 24 例:config/SQL 生成/路由/TLS 旋钮);**经真实 wire 的集成测试待 B4 容器**(wire-vs-fixture 纪律:fake-driver 单测不替代真 wire)
 - 🔒 B6(后续切片)Windows 集成认证 `authType:'windows'` —— Kerberos/keytab/AD,独立设计
 
 ### Phase C — 部署形态(随 A/B 决策)

--- a/packages/core-backend/src/data-adapters/MSSQLAdapter.ts
+++ b/packages/core-backend/src/data-adapters/MSSQLAdapter.ts
@@ -1,7 +1,11 @@
-// Generic SQL Server (modern direct path) data-source adapter (Lane B PR1).
-// Driver: `mssql` (^10), aligned with plugin-integration-core. Legacy SQL Server
-// (pre-2017 / TLS-negotiation issues) is out of scope here — that stays with the
-// Bridge Agent / Lane C line. stream() uses batch fetch, not a true cursor.
+// Generic SQL Server data-source adapter (Lane B). Driver: `mssql` (^10),
+// aligned with plugin-integration-core. Modern servers connect securely by
+// default; a legacy SQL Server (2008R2/2012) that cannot negotiate modern TLS
+// can opt down PER-SOURCE via the B3 lever (buildLegacyTlsOptions) — scoped to
+// this one connection, the customer's server is never changed. Genuinely
+// unreachable cases (RC4/3DES needing the OpenSSL legacy provider, or plaintext)
+// stay on the sidecar / Bridge Agent line. stream() uses batch fetch, not a true
+// cursor.
 import type {
   QueryOptions,
   QueryResult,
@@ -12,7 +16,8 @@ import type {
   ForeignKeyInfo,
   DbValue,
   WhereValue,
-  Transaction
+  Transaction,
+  ConnectionConfig
 } from './BaseAdapter';
 import { BaseDataAdapter, getStringConfig, getNumberConfig } from './BaseAdapter'
 
@@ -110,9 +115,88 @@ export class MSSQLAdapter extends BaseDataAdapter {
     throw new Error('SQL Server data source requires connection.host or connection.server')
   }
 
+  // Valid TLS protocol floors accepted by Node's tls module (B3 validation).
+  private static readonly VALID_TLS_MIN_VERSIONS: readonly string[] = [
+    'TLSv1',
+    'TLSv1.1',
+    'TLSv1.2',
+    'TLSv1.3'
+  ]
+
+  /**
+   * B3 — per-connection legacy-TLS escape hatch. SECURE BY DEFAULT: returns
+   * undefined unless this source explicitly opts down. When a legacy SQL Server
+   * (e.g. 2008R2/2012) cannot negotiate modern TLS, an operator may lower the
+   * TLS floor / cipher security level for THIS connection only — the customer's
+   * server is never touched, and the scope is never process-wide.
+   *
+   *   connection.tlsMinVersion  -> cryptoCredentialsDetails.minVersion ('TLSv1' …)
+   *   connection.tlsCiphers     -> cryptoCredentialsDetails.ciphers    ('DEFAULT@SECLEVEL=0' …)
+   *   connection.legacyTls=true -> convenience: applies the documented legacy
+   *                                defaults above unless an explicit key overrides.
+   *
+   * The wire stays encrypted (this lowers the floor, it is not `encrypt:false`).
+   * Lowering below the secure default emits an audit signal.
+   */
+  private buildLegacyTlsOptions(conn: ConnectionConfig): { minVersion?: string; ciphers?: string } | undefined {
+    const legacyTls = coerceBoolean(conn.legacyTls, false)
+    let minVersion = getStringConfig(conn.tlsMinVersion)
+    let ciphers = getStringConfig(conn.tlsCiphers)
+
+    if (legacyTls) {
+      // Documented legacy defaults; explicit keys win.
+      minVersion = minVersion ?? 'TLSv1'
+      ciphers = ciphers ?? 'DEFAULT@SECLEVEL=0'
+    }
+
+    // No downgrade requested → keep Node/tedious secure defaults (TLSv1.2 floor).
+    if (minVersion === undefined && ciphers === undefined) return undefined
+
+    // B3 lowers the TLS floor but keeps the wire ENCRYPTED. It must not be
+    // combined with connection.encrypt=false — that is a SEPARATE plaintext
+    // escape hatch with a different security posture. Allowing both would make
+    // the audit below falsely claim "wire stays encrypted" for a plaintext
+    // source. Reject the contradiction loudly; the plaintext path is opt-in on
+    // its own (encrypt=false with no TLS-downgrade keys).
+    if (coerceBoolean(conn.encrypt, true) === false) {
+      throw new Error(
+        'connection.encrypt=false cannot be combined with the legacy-TLS lever ' +
+          '(legacyTls / tlsMinVersion / tlsCiphers): the TLS downgrade keeps the wire ' +
+          'encrypted, while encrypt=false is a separate plaintext escape hatch — use one or the other.'
+      )
+    }
+
+    // Enum-strict: never silently fall back to a default for a bad floor value.
+    if (minVersion !== undefined && !MSSQLAdapter.VALID_TLS_MIN_VERSIONS.includes(minVersion)) {
+      throw new Error(
+        `Invalid connection.tlsMinVersion "${minVersion}" ` +
+          `(expected one of ${MSSQLAdapter.VALID_TLS_MIN_VERSIONS.join(', ')})`
+      )
+    }
+
+    // Audit: this source is connecting with a deliberately lowered TLS posture.
+    const detail = [
+      minVersion !== undefined ? `minVersion=${minVersion}` : null,
+      ciphers !== undefined ? `ciphers=${ciphers}` : null
+    ]
+      .filter(Boolean)
+      .join(', ')
+    this.emit('tls-downgrade', { adapter: this.config.name, minVersion, ciphers })
+    console.warn(
+      `[MSSQLAdapter] legacy TLS enabled for data source "${this.config.name}" (${detail}); ` +
+        `wire stays encrypted, scope is this connection only.`
+    )
+
+    return {
+      ...(minVersion !== undefined ? { minVersion } : {}),
+      ...(ciphers !== undefined ? { ciphers } : {})
+    }
+  }
+
   private buildPoolConfig(): Record<string, unknown> {
     const conn = this.config.connection
     const { server, port } = this.resolveServerAndPort()
+    const legacyTls = this.buildLegacyTlsOptions(conn)
     return {
       server,
       ...(port != null ? { port } : {}),
@@ -122,9 +206,12 @@ export class MSSQLAdapter extends BaseDataAdapter {
       // Secure by default: encrypt the wire; trust the (typically self-signed)
       // intranet certificate. Set connection.encrypt=false only as an explicit
       // per-source escape hatch for a legacy server that cannot negotiate TLS.
+      // cryptoCredentialsDetails (B3) lowers the TLS floor/ciphers per-source
+      // for genuinely old servers — still encrypted, opt-in only.
       options: {
         encrypt: coerceBoolean(conn.encrypt, true),
-        trustServerCertificate: coerceBoolean(conn.trustServerCertificate, true)
+        trustServerCertificate: coerceBoolean(conn.trustServerCertificate, true),
+        ...(legacyTls ? { cryptoCredentialsDetails: legacyTls } : {})
       },
       // ?? (not ||) so an explicit 0 ("no timeout" in mssql) is not overridden.
       connectionTimeout: getNumberConfig(conn.connectionTimeoutMs) ?? 10000,

--- a/packages/core-backend/tests/unit/mssql-adapter.test.ts
+++ b/packages/core-backend/tests/unit/mssql-adapter.test.ts
@@ -14,7 +14,11 @@ type PoolConfig = {
   database?: string
   user?: string
   password?: string
-  options: { encrypt: boolean; trustServerCertificate: boolean }
+  options: {
+    encrypt: boolean
+    trustServerCertificate: boolean
+    cryptoCredentialsDetails?: { minVersion?: string; ciphers?: string }
+  }
   connectionTimeout: number
   requestTimeout: number
 }
@@ -95,6 +99,82 @@ describe('MSSQLAdapter — config mapping', () => {
 
   it('throws on a server-embedded port that conflicts with an explicit port', () => {
     expect(() => poolConfig({ server: 'h,1444', port: 9999, database: 'D' })).toThrow(/Conflicting port/)
+  })
+})
+
+describe('MSSQLAdapter — legacy TLS lever (B3)', () => {
+  // Build an adapter so we can subscribe to the audit event before buildPoolConfig.
+  function adapter(connection: Record<string, unknown>, name = 's'): MSSQLAdapter {
+    return new MSSQLAdapter({
+      id: 's', name, type: 'sqlserver',
+      connection: connection as DataSourceConfig['connection'],
+      credentials: { username: 'u', password: 'p' }, options: { autoConnect: false },
+    })
+  }
+  const build = (a: MSSQLAdapter): PoolConfig =>
+    (a as unknown as { buildPoolConfig(): PoolConfig }).buildPoolConfig()
+
+  it('secure by default: no TLS keys → no cryptoCredentialsDetails', () => {
+    const cfg = poolConfig({ host: 'db', database: 'D' })
+    expect(cfg.options.cryptoCredentialsDetails).toBeUndefined()
+    expect(cfg.options.encrypt).toBe(true)
+  })
+
+  it('explicit tlsMinVersion lowers the floor but keeps the wire encrypted', () => {
+    const cfg = poolConfig({ host: 'db', database: 'D', tlsMinVersion: 'TLSv1' })
+    expect(cfg.options.cryptoCredentialsDetails).toEqual({ minVersion: 'TLSv1' })
+    expect(cfg.options.encrypt).toBe(true) // a downgrade lowers the floor, not encryption
+  })
+
+  it('explicit tlsCiphers sets cryptoCredentialsDetails.ciphers', () => {
+    const cfg = poolConfig({ host: 'db', database: 'D', tlsCiphers: 'DEFAULT@SECLEVEL=0' })
+    expect(cfg.options.cryptoCredentialsDetails).toEqual({ ciphers: 'DEFAULT@SECLEVEL=0' })
+  })
+
+  it('legacyTls:true applies the documented legacy defaults', () => {
+    const cfg = poolConfig({ host: 'db', database: 'D', legacyTls: true })
+    expect(cfg.options.cryptoCredentialsDetails).toEqual({ minVersion: 'TLSv1', ciphers: 'DEFAULT@SECLEVEL=0' })
+  })
+
+  it('explicit keys override the legacyTls convenience defaults', () => {
+    const cfg = poolConfig({ host: 'db', database: 'D', legacyTls: true, tlsMinVersion: 'TLSv1.1', tlsCiphers: 'HIGH' })
+    expect(cfg.options.cryptoCredentialsDetails).toEqual({ minVersion: 'TLSv1.1', ciphers: 'HIGH' })
+  })
+
+  it('throws on an invalid tlsMinVersion (enum-strict, no silent fallback)', () => {
+    expect(() => poolConfig({ host: 'db', database: 'D', tlsMinVersion: 'SSLv3' })).toThrow(/Invalid connection\.tlsMinVersion/)
+  })
+
+  it('rejects combining a B3 TLS downgrade with encrypt:false (plaintext is a separate hatch)', () => {
+    expect(() => poolConfig({ host: 'db', database: 'D', legacyTls: true, encrypt: false }))
+      .toThrow(/encrypt=false cannot be combined/)
+    expect(() => poolConfig({ host: 'db', database: 'D', tlsMinVersion: 'TLSv1', encrypt: false }))
+      .toThrow(/encrypt=false cannot be combined/)
+    expect(() => poolConfig({ host: 'db', database: 'D', tlsCiphers: 'DEFAULT@SECLEVEL=0', encrypt: false }))
+      .toThrow(/encrypt=false cannot be combined/)
+  })
+
+  it('still allows encrypt:false on its own (plaintext escape hatch, no B3 keys)', () => {
+    const cfg = poolConfig({ host: 'db', database: 'D', encrypt: false })
+    expect(cfg.options.encrypt).toBe(false)
+    expect(cfg.options.cryptoCredentialsDetails).toBeUndefined()
+  })
+
+  it('emits a tls-downgrade audit event (with source name + params) when downgrading', () => {
+    const a = adapter({ host: 'db', database: 'D', legacyTls: true }, 'legacy-erp')
+    const events: Array<{ adapter: string; minVersion?: string; ciphers?: string }> = []
+    a.on('tls-downgrade', e => events.push(e as never))
+    build(a)
+    expect(events).toHaveLength(1)
+    expect(events[0]).toMatchObject({ adapter: 'legacy-erp', minVersion: 'TLSv1', ciphers: 'DEFAULT@SECLEVEL=0' })
+  })
+
+  it('emits no audit event for a secure-default source', () => {
+    const a = adapter({ host: 'db', database: 'D' })
+    const events: unknown[] = []
+    a.on('tls-downgrade', e => events.push(e))
+    build(a)
+    expect(events).toHaveLength(0)
   })
 })
 


### PR DESCRIPTION
## What

Adds the **B3 legacy-TLS lever** to `MSSQLAdapter` — the slice that lets us connect to a customer's genuinely-old SQL Server (2008R2/2012) **without changing their server**. Secure by default; opt-down is per-source.

| connection key | effect |
|---|---|
| `tlsMinVersion` | → `cryptoCredentialsDetails.minVersion` (e.g. `TLSv1`) |
| `tlsCiphers` | → `cryptoCredentialsDetails.ciphers` (e.g. `DEFAULT@SECLEVEL=0`) |
| `legacyTls: true` | convenience: applies the documented legacy defaults above unless an explicit key overrides |

- **Secure by default**: no key set → no `cryptoCredentialsDetails` → Node/tedious keeps the TLSv1.2 floor.
- **Still encrypted**: this lowers the TLS *floor / cipher level*, it is not `encrypt:false`.
- **Enum-strict**: an invalid `tlsMinVersion` **throws** (no silent fallback) — per the repo's enum-strictness discipline.
- **Audited**: a downgrade emits a `tls-downgrade` event (subscribable) + a `console.warn`, carrying source name + params (no secrets).
- **Per-connection scope only**, never process-wide. RC4/3DES (needing the OpenSSL legacy provider) and plaintext still go to the sidecar / Bridge Agent line, per the §3 downgrade decision tree.

## Why

This is the gap directly tied to the track's original goal ("连客户 Windows + 多版本 SQL Server，TLS 在我们这边降，不逼客户升级"). PR1 (#1985) shipped the modern connector with `encrypt`/`trustServerCertificate`; that handles self-signed intranet certs but **not** a 2008R2/2012 server whose TLS1.0/weak-cipher handshake modern OpenSSL3 rejects. B3 is that lever.

## Scope

- `MSSQLAdapter.ts` — `buildLegacyTlsOptions()` + wired into `buildPoolConfig().options.cryptoCredentialsDetails` (+79/-6).
- `mssql-adapter.test.ts` — 8 new tests (secure-default / minVersion / ciphers / legacyTls defaults / explicit override / invalid-throws / audit-event / no-event-when-secure). **24 total green.**
- design doc §4 — reconciled the gated-TODO to `origin/main` reality (the markers were a #1960 snapshot that under-counted; now A0/A0.1/A-RO/A1/A4 + B1/B2/B3 marked done, with the remaining items honest).
- **Does NOT touch** `plugin-integration-core`'s `k3-wise-sqlserver` channel, RBAC, or auth (K3 Stage-1 lock unaffected).

## Deferred (honest, not in this PR)

- **B4** real version-compat matrix: 2017/2019/2022 containers + 2008R2/2012 protocol mock; **real legacy validation needs a Windows VM** (no hardware) — follow-up.
- **B5** real-wire integration test (fake-driver units don't satisfy the wire-vs-fixture discipline) — tied to B4 containers.
- **B0** shared mssql helper extraction (still inlined).

🤖 Generated with [Claude Code](https://claude.com/claude-code)