### PR TITLE
feat(integration): DF-N2-3 read-only per-row provenance timeline (dead-letter expand)

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -579,6 +579,53 @@ export async function listIntegrationDeadLetters(
   return Array.isArray(data) ? data : []
 }
 
+// DF-N2-3 read-only: one redacted provenance event in a row's cross-run timeline.
+// Mirrors the DF-N2-2c OpenAPI ProvenanceTimelineEntry (GET /api/integration/provenance).
+// attrs were redacted at write (DF-N2-2b scrub gate); this read path does NOT re-redact.
+export interface IntegrationProvenanceTimelineEntry {
+  runId: string
+  pipelineId: string
+  rowId: string
+  eventType: string
+  at: string
+  attrs: Record<string, unknown>
+  eventIndex: number
+  runStatus: string
+  runMode: string
+  runCreatedAt: string
+}
+
+export interface IntegrationProvenanceQuery extends IntegrationScope {
+  rowId: string
+  // pipelineId is sent to avoid cross-pipeline idempotency-key collisions merging
+  // unrelated row timelines; the read route applies it as an extra view filter.
+  pipelineId?: string
+  from?: string
+  to?: string
+  limit?: number
+  offset?: number
+}
+
+// DF-N2-3 (read-only): a row's cross-run provenance timeline from the DF-N2-2c
+// by-rowId route. rowId is the idempotency key the provenance view groups on. No
+// write/replay/retry; the route is read-only and 501s on hosts without it.
+export async function listIntegrationProvenanceByRow(
+  query: IntegrationProvenanceQuery,
+): Promise<IntegrationProvenanceTimelineEntry[]> {
+  const response = await apiFetch(`/api/integration/provenance?${buildQueryString({
+    tenantId: query.tenantId,
+    workspaceId: query.workspaceId,
+    rowId: query.rowId,
+    pipelineId: query.pipelineId,
+    from: query.from,
+    to: query.to,
+    limit: query.limit,
+    offset: query.offset,
+  })}`)
+  const data = await parseIntegrationResponse<IntegrationProvenanceTimelineEntry[]>(response)
+  return Array.isArray(data) ? data : []
+}
+
 export interface IntegrationDeadLetterReplayPayload extends IntegrationScope {
   mode?: IntegrationPipelineMode
 }

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -767,6 +767,68 @@
                   </template>
                 </template>
               </div>
+              <div class="integration-workbench__dead-letter-provenance">
+                <button
+                  type="button"
+                  class="integration-workbench__link-button"
+                  :data-testid="`toggle-dead-letter-provenance-${deadLetter.id}`"
+                  :disabled="!canViewRowProvenance(deadLetter)"
+                  :title="canViewRowProvenance(deadLetter) ? '查看该行(rowId)跨 run 的写入血缘（只读）' : '该 dead letter 无 idempotency key（rowId），无法查询血缘'"
+                  @click="toggleDeadLetterProvenance(deadLetter)"
+                >{{ isRowProvenanceExpanded(deadLetter.id) ? '收起血缘' : '查看跨-run 血缘' }}</button>
+                <span
+                  v-if="!canViewRowProvenance(deadLetter)"
+                  class="integration-workbench__hint"
+                  :data-testid="`dead-letter-provenance-unavailable-${deadLetter.id}`"
+                >无 rowId（idempotency key），不可查血缘</span>
+                <div
+                  v-if="isRowProvenanceExpanded(deadLetter.id)"
+                  class="integration-workbench__provenance-timeline"
+                  :data-testid="`dead-letter-provenance-${deadLetter.id}`"
+                >
+                  <div
+                    v-if="isRowProvenanceLoading(deadLetter.id)"
+                    class="integration-workbench__hint"
+                    :data-testid="`dead-letter-provenance-loading-${deadLetter.id}`"
+                  >血缘加载中…</div>
+                  <div
+                    v-else-if="rowProvenanceError(deadLetter.id)"
+                    class="integration-workbench__hint integration-workbench__hint--strong"
+                    :data-testid="`dead-letter-provenance-error-${deadLetter.id}`"
+                  >{{ rowProvenanceError(deadLetter.id) }}</div>
+                  <ol
+                    v-else-if="rowProvenanceTimeline(deadLetter.id).length > 0"
+                    class="integration-workbench__record-list"
+                    :data-testid="`dead-letter-provenance-timeline-${deadLetter.id}`"
+                  >
+                    <li
+                      v-for="(entry, index) in rowProvenanceTimeline(deadLetter.id)"
+                      :key="`${entry.runId}-${entry.eventIndex}`"
+                      :data-testid="`provenance-entry-${deadLetter.id}-${index}`"
+                    >
+                      <div class="integration-workbench__provenance-event-head">
+                        <strong>{{ entry.eventType }}</strong>
+                        <span
+                          class="integration-workbench__run-status"
+                          :class="`integration-workbench__run-status--${entry.runStatus}`"
+                        >run {{ entry.runStatus }}</span>
+                        <span>{{ entry.runCreatedAt || entry.at }}</span>
+                      </div>
+                      <small>runId {{ entry.runId }} · pipeline {{ entry.pipelineId }} · {{ entry.runMode }}</small>
+                      <p
+                        v-if="rowProvenanceAttrsSummary(entry.attrs)"
+                        class="integration-workbench__provenance-attrs"
+                      >{{ rowProvenanceAttrsSummary(entry.attrs) }}</p>
+                    </li>
+                  </ol>
+                  <div
+                    v-else
+                    class="integration-workbench__empty"
+                    :data-testid="`dead-letter-provenance-empty-${deadLetter.id}`"
+                  >暂无血缘事件。</div>
+                  <p class="integration-workbench__hint">只读：仅展示脱敏后的事件，不含 payload 原文，不触发任何写入/重放。</p>
+                </div>
+              </div>
             </li>
           </ol>
         </div>
@@ -839,6 +901,7 @@ import {
   isDeadLetterReplayable,
   listIntegrationDeadLetters,
   listIntegrationPipelineRuns,
+  listIntegrationProvenanceByRow,
   listIntegrationStagingDescriptors,
   listExternalSystemObjects,
   listIntegrationAdapters,
@@ -859,6 +922,7 @@ import {
   type IntegrationPipelineMode,
   type IntegrationPipelineRun,
   type IntegrationPipelineRunResult,
+  type IntegrationProvenanceTimelineEntry,
   type IntegrationTargetWriteSummary,
   type IntegrationStagingDescriptor,
   type IntegrationStagingInstallResult,
@@ -1003,6 +1067,12 @@ const lastDryRunResult = ref<IntegrationPipelineRunResult | null>(null)
 const pipelineRuns = ref<IntegrationPipelineRun[]>([])
 const deadLetters = ref<IntegrationDeadLetter[]>([])
 const expandedRunIds = ref<Set<string>>(new Set())
+// DF-N2-3 (read-only): per-dead-letter cross-run provenance timeline, fetched lazily
+// on expand by the row's idempotency key (rowId). No write/replay affordance here.
+const expandedDeadLetterProvenanceIds = ref<Set<string>>(new Set())
+const rowProvenanceByDeadLetterId = ref<Map<string, IntegrationProvenanceTimelineEntry[]>>(new Map())
+const rowProvenanceLoadingIds = ref<Set<string>>(new Set())
+const rowProvenanceErrorById = ref<Map<string, string>>(new Map())
 const confirmReplayDeadLetterId = ref('')
 const replayingDeadLetterId = ref('')
 const statusMessage = ref('')
@@ -2418,6 +2488,84 @@ function toggleRunSummaries(runId: string): void {
   expandedRunIds.value = next
 }
 
+// DF-N2-3 (read-only): a dead-letter's row (idempotency key) is the only typed rowId
+// in this panel. Expanding fetches that row's cross-run provenance timeline once via
+// the DF-N2-2c by-rowId GET; pipelineId is passed to avoid cross-pipeline key
+// collisions. This is observation only — never a write, replay, or retry.
+function canViewRowProvenance(deadLetter: IntegrationDeadLetter): boolean {
+  return typeof deadLetter.idempotencyKey === 'string' && deadLetter.idempotencyKey.trim().length > 0
+}
+
+function isRowProvenanceExpanded(deadLetterId: string): boolean {
+  return expandedDeadLetterProvenanceIds.value.has(deadLetterId)
+}
+
+function isRowProvenanceLoading(deadLetterId: string): boolean {
+  return rowProvenanceLoadingIds.value.has(deadLetterId)
+}
+
+function rowProvenanceTimeline(deadLetterId: string): IntegrationProvenanceTimelineEntry[] {
+  return rowProvenanceByDeadLetterId.value.get(deadLetterId) ?? []
+}
+
+function rowProvenanceError(deadLetterId: string): string {
+  return rowProvenanceErrorById.value.get(deadLetterId) ?? ''
+}
+
+// Compact, names-safe summary of the already-redacted attrs (no raw payload dump).
+function rowProvenanceAttrsSummary(attrs: Record<string, unknown> | undefined): string {
+  if (!attrs || typeof attrs !== 'object') return ''
+  const parts: string[] = []
+  for (const [key, value] of Object.entries(attrs)) {
+    if (value === null || value === undefined) continue
+    const text = typeof value === 'object' ? JSON.stringify(value) : String(value)
+    parts.push(`${key}=${text.length > 60 ? `${text.slice(0, 60)}…` : text}`)
+    if (parts.length >= 4) break
+  }
+  const remaining = Object.keys(attrs).length - parts.length
+  return remaining > 0 ? `${parts.join(' · ')} · +${remaining}` : parts.join(' · ')
+}
+
+async function toggleDeadLetterProvenance(deadLetter: IntegrationDeadLetter): Promise<void> {
+  // No rowId (idempotency key) → nothing to look up (the toggle is disabled in the
+  // UI too); guard before toggling so a no-key row never opens an empty panel.
+  if (!canViewRowProvenance(deadLetter)) return
+  const next = new Set(expandedDeadLetterProvenanceIds.value)
+  if (next.has(deadLetter.id)) {
+    next.delete(deadLetter.id)
+    expandedDeadLetterProvenanceIds.value = next
+    return
+  }
+  next.add(deadLetter.id)
+  expandedDeadLetterProvenanceIds.value = next
+  // Fetch once per row; re-expanding a collapsed row reuses the cached timeline.
+  if (rowProvenanceByDeadLetterId.value.has(deadLetter.id)) return
+  const loading = new Set(rowProvenanceLoadingIds.value)
+  loading.add(deadLetter.id)
+  rowProvenanceLoadingIds.value = loading
+  const clearedError = new Map(rowProvenanceErrorById.value)
+  clearedError.delete(deadLetter.id)
+  rowProvenanceErrorById.value = clearedError
+  try {
+    const entries = await listIntegrationProvenanceByRow({
+      ...currentScope(),
+      rowId: String(deadLetter.idempotencyKey),
+      pipelineId: deadLetter.pipelineId,
+    })
+    const map = new Map(rowProvenanceByDeadLetterId.value)
+    map.set(deadLetter.id, entries)
+    rowProvenanceByDeadLetterId.value = map
+  } catch (error) {
+    const map = new Map(rowProvenanceErrorById.value)
+    map.set(deadLetter.id, error instanceof Error ? error.message : String(error))
+    rowProvenanceErrorById.value = map
+  } finally {
+    const done = new Set(rowProvenanceLoadingIds.value)
+    done.delete(deadLetter.id)
+    rowProvenanceLoadingIds.value = done
+  }
+}
+
 // Two-step confirm before any live replay. Replay re-runs the pipeline with the
 // stored payload (a real target/ERP write), so it mirrors the deliberate
 // allowSaveOnlyRun opt-in used for Save-only runs in this view.
@@ -3471,6 +3619,33 @@ watch(showAdvancedConnectors, () => {
   flex-wrap: wrap;
   align-items: center;
   gap: 8px;
+}
+
+/* DF-N2-3 read-only cross-run provenance timeline (per dead-letter row). */
+.integration-workbench__dead-letter-provenance {
+  margin-top: 6px;
+  display: grid;
+  gap: 4px;
+}
+
+.integration-workbench__provenance-timeline {
+  display: grid;
+  gap: 6px;
+  padding: 6px 0 0;
+}
+
+.integration-workbench__provenance-event-head {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  gap: 8px;
+}
+
+.integration-workbench__provenance-attrs {
+  margin: 2px 0 0;
+  font-size: 12px;
+  color: #5a6473;
+  word-break: break-word;
 }
 
 .integration-workbench__badge--retryable {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -1402,6 +1402,176 @@ describe('IntegrationWorkbenchView', () => {
     expect(container.textContent).toContain('Replay 成功')
   })
 
+  it('expands a dead-letter into a read-only cross-run provenance timeline (fires by-rowId GET with rowId+pipelineId)', async () => {
+    const provenanceCalls: Array<{ url: string; method?: string }> = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems')) return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/runs?tenantId=default&pipelineId=pipe_prov&limit=5') return jsonResponse([])
+      if (url === '/api/integration/dead-letters?tenantId=default&pipelineId=pipe_prov&status=open&limit=5') {
+        return jsonResponse([
+          {
+            id: 'dl_prov_1',
+            tenantId: 'default',
+            workspaceId: null,
+            pipelineId: 'pipe_prov',
+            runId: 'run_prov_2',
+            idempotencyKey: 'MAT-777',
+            errorCode: 'VALIDATION_FAILED',
+            errorMessage: 'missing name',
+            status: 'open',
+          },
+        ])
+      }
+      if (url.startsWith('/api/integration/provenance')) {
+        provenanceCalls.push({ url, method: init?.method })
+        // Cross-run: the same rowId failed across two runs (still open → no success arc yet).
+        return jsonResponse([
+          {
+            runId: 'run_prov_1',
+            pipelineId: 'pipe_prov',
+            rowId: 'MAT-777',
+            eventType: 'target_write_failed',
+            at: '2026-05-27T02:00:00.000Z',
+            attrs: { errorCode: 'VALIDATION_FAILED', step: 'write' },
+            eventIndex: 0,
+            runStatus: 'partial',
+            runMode: 'manual',
+            runCreatedAt: '2026-05-27T02:00:00.000Z',
+          },
+          {
+            runId: 'run_prov_2',
+            pipelineId: 'pipe_prov',
+            rowId: 'MAT-777',
+            eventType: 'target_write_failed',
+            at: '2026-05-28T03:00:00.000Z',
+            attrs: { errorCode: 'VALIDATION_FAILED', step: 'write' },
+            eventIndex: 0,
+            runStatus: 'partial',
+            runMode: 'manual',
+            runCreatedAt: '2026-05-28T03:00:00.000Z',
+          },
+        ])
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    const pipelineIdInput = container.querySelector('[data-testid="pipeline-id"]') as HTMLInputElement
+    pipelineIdInput.value = 'pipe_prov'
+    pipelineIdInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="refresh-observation"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    // Dead-letter present; timeline NOT fetched until the row is expanded.
+    expect(container.querySelector('[data-testid="dead-letter-dl_prov_1"]')).not.toBeNull()
+    expect(provenanceCalls).toHaveLength(0)
+    expect(container.querySelector('[data-testid="dead-letter-provenance-dl_prov_1"]')).toBeNull()
+
+    // KEYSTONE (real wire): expanding the row FIRES the by-rowId provenance GET,
+    // and the query carries rowId + pipelineId — not a pre-mocked render.
+    ;(container.querySelector('[data-testid="toggle-dead-letter-provenance-dl_prov_1"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(provenanceCalls).toHaveLength(1)
+    expect(provenanceCalls[0].url).toContain('/api/integration/provenance')
+    expect(provenanceCalls[0].url).toContain('rowId=MAT-777')
+    expect(provenanceCalls[0].url).toContain('pipelineId=pipe_prov')
+    // Read-only: the fetch is a GET, never a POST/write.
+    expect(provenanceCalls[0].method ?? 'GET').toBe('GET')
+
+    // Cross-run timeline rendered: both runs + the event type are visible.
+    const timeline = container.querySelector('[data-testid="dead-letter-provenance-timeline-dl_prov_1"]') as HTMLElement
+    expect(timeline).not.toBeNull()
+    expect(timeline.textContent).toContain('target_write_failed')
+    expect(timeline.textContent).toContain('run_prov_1')
+    expect(timeline.textContent).toContain('run_prov_2')
+
+    // Read-only: the timeline introduces no replay/confirm affordance.
+    expect(container.querySelector('[data-testid="confirm-replay-dead-letter-dl_prov_1"]')).toBeNull()
+
+    // Collapse hides the timeline; re-expanding reuses the cached fetch (no refetch).
+    ;(container.querySelector('[data-testid="toggle-dead-letter-provenance-dl_prov_1"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(container.querySelector('[data-testid="dead-letter-provenance-timeline-dl_prov_1"]')).toBeNull()
+    ;(container.querySelector('[data-testid="toggle-dead-letter-provenance-dl_prov_1"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(provenanceCalls).toHaveLength(1)
+  })
+
+  it('disables the provenance lookup for a dead-letter without an idempotency key (no rowId)', async () => {
+    const provenanceCalls: string[] = []
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems')) return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/runs?tenantId=default&pipelineId=pipe_nokey&limit=5') return jsonResponse([])
+      if (url === '/api/integration/dead-letters?tenantId=default&pipelineId=pipe_nokey&status=open&limit=5') {
+        return jsonResponse([
+          {
+            id: 'dl_nokey_1',
+            tenantId: 'default',
+            workspaceId: null,
+            pipelineId: 'pipe_nokey',
+            runId: 'run_nokey_1',
+            idempotencyKey: null,
+            errorCode: 'WRITE_FAILED',
+            errorMessage: 'no key',
+            status: 'open',
+          },
+        ])
+      }
+      if (url.startsWith('/api/integration/provenance')) {
+        provenanceCalls.push(url)
+        return jsonResponse([])
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    const pipelineIdInput = container.querySelector('[data-testid="pipeline-id"]') as HTMLInputElement
+    pipelineIdInput.value = 'pipe_nokey'
+    pipelineIdInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="refresh-observation"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    // No rowId → the toggle is disabled, an explicit hint shows, and clicking fires no GET.
+    const toggle = container.querySelector('[data-testid="toggle-dead-letter-provenance-dl_nokey_1"]') as HTMLButtonElement
+    expect(toggle).not.toBeNull()
+    expect(toggle.disabled).toBe(true)
+    expect(container.querySelector('[data-testid="dead-letter-provenance-unavailable-dl_nokey_1"]')).not.toBeNull()
+    toggle.click()
+    await flushUi()
+    expect(provenanceCalls).toHaveLength(0)
+    expect(container.querySelector('[data-testid="dead-letter-provenance-dl_nokey_1"]')).toBeNull()
+  })
+
   it('treats a successful replay carrying a markReplayed warning as success (no false retry prompt)', async () => {
     apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
       if (url === '/api/integration/adapters') return jsonResponse([])

--- a/apps/web/tests/integrationWorkbench.spec.ts
+++ b/apps/web/tests/integrationWorkbench.spec.ts
@@ -6,6 +6,7 @@ import {
   listExternalSystemObjects,
   listIntegrationAdapters,
   listIntegrationPipelineRuns,
+  listIntegrationProvenanceByRow,
   listIntegrationStagingDescriptors,
   listWorkbenchExternalSystems,
   previewIntegrationTemplate,
@@ -444,5 +445,67 @@ describe('integration dead-letter replay service', () => {
     ))
     await expect(replayIntegrationDeadLetter('dl 1', { tenantId: 'default' }))
       .rejects.toThrow('write permission required')
+  })
+})
+
+describe('integration provenance read service (DF-N2-3)', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+  })
+
+  it('reads a row cross-run timeline by-rowId with rowId + pipelineId + scope on the GET, and coerces to an array', async () => {
+    const calls: Array<{ url: string; method?: string }> = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      calls.push({ url, method: init?.method })
+      if (url.startsWith('/api/integration/provenance')) {
+        return jsonResponse([
+          {
+            runId: 'run_a',
+            pipelineId: 'pipe_x',
+            rowId: 'MAT-9',
+            eventType: 'target_write_failed',
+            at: '2026-05-28T00:00:00.000Z',
+            attrs: { errorCode: 'VALIDATION_FAILED' },
+            eventIndex: 0,
+            runStatus: 'partial',
+            runMode: 'manual',
+            runCreatedAt: '2026-05-28T00:00:00.000Z',
+          },
+        ])
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const entries = await listIntegrationProvenanceByRow({
+      tenantId: 'default',
+      rowId: 'MAT-9',
+      pipelineId: 'pipe_x',
+    })
+    expect(entries).toHaveLength(1)
+    expect(entries[0]).toMatchObject({ runId: 'run_a', rowId: 'MAT-9', eventType: 'target_write_failed' })
+
+    // The GET carries rowId + pipelineId (collision guard) + tenant scope; read-only.
+    expect(calls).toHaveLength(1)
+    expect(calls[0].url).toContain('/api/integration/provenance?')
+    expect(calls[0].url).toContain('rowId=MAT-9')
+    expect(calls[0].url).toContain('pipelineId=pipe_x')
+    expect(calls[0].url).toContain('tenantId=default')
+    expect(calls[0].method ?? 'GET').toBe('GET')
+  })
+
+  it('omits empty optional params and tolerates a non-array body', async () => {
+    const calls: string[] = []
+    apiFetchMock.mockImplementation(async (url: string) => {
+      calls.push(url)
+      // Non-array body (e.g. an unexpected envelope) must coerce to [].
+      return jsonResponse({ unexpected: true })
+    })
+    const entries = await listIntegrationProvenanceByRow({ tenantId: 'default', rowId: 'MAT-1' })
+    expect(entries).toEqual([])
+    // No pipelineId/from/to/limit/offset provided → those keys are absent from the query.
+    expect(calls[0]).not.toContain('pipelineId=')
+    expect(calls[0]).not.toContain('from=')
+    expect(calls[0]).not.toContain('limit=')
+    expect(calls[0]).toContain('rowId=MAT-1')
   })
 })

--- a/docs/development/data-factory-df-n2-3-provenance-timeline-ui-verification-20260528.md
+++ b/docs/development/data-factory-df-n2-3-provenance-timeline-ui-verification-20260528.md
@@ -1,0 +1,83 @@
+# DF-N2-3 — read-only per-row provenance timeline (verification, 2026-05-28)
+
+Closes the DF-N2 provenance arc on the operator side: **storage (2a) + runtime write
+(2b) + read route (2c) + now the read-only UI surface (2-3)**. Frontend-only; no
+backend / route / OpenAPI / RBAC / migration / connector change.
+
+## Scope (owner-locked)
+
+- In the run-monitoring panel, **expand a dead-letter** to see that row's **cross-run**
+  provenance timeline.
+- Calls the DF-N2-2c by-rowId route `GET /api/integration/provenance`, using the
+  dead-letter's **`idempotencyKey` as `rowId`** and passing **`pipelineId`** to avoid
+  cross-pipeline idempotency-key collisions merging unrelated timelines.
+- Renders run time (`runCreatedAt`), `eventType`, `runStatus`, `runId`/`pipelineId`/`runMode`,
+  and a compact **redacted `attrs` summary** — never raw payload.
+- **Read-only**: separate from the existing replay button; no write / replay / retry /
+  K3 action.
+- When a dead-letter has **no `idempotencyKey`** (no rowId): the toggle is **disabled**
+  with an explicit hint; clicking fires no GET.
+
+## Key decisions
+
+1. **Anchor = dead-letter expand**, not the run "行级结果" (`targetWriteSummaries`).
+   The summaries are opaque sanitized target *business responses*
+   (`{[key:string]:unknown}`, built from `writeResult.metadata.businessResponses`) and
+   carry **no reliable rowId**. The dead-letter's `idempotencyKey` is the only typed
+   value in the panel and is exactly the row identity the provenance view groups on
+   (`_integration_idempotency_key`). It also matches the locked test wording
+   ("展开某行后真实发出 provenance GET") — a per-row expand, not a search box.
+2. **v1 = open dead-letters only (Option A).** The panel lists only `open` dead-letters,
+   so a row that **failed → succeeded on replay** (status `replayed`) drops off the list;
+   its completed fail→succeed arc is **not reachable** by this anchor. v1 still delivers
+   real cross-run value — a *still-failing* row's failure history across runs, before the
+   replay decision. The completed arc is a **follow-up history view**, explicitly out of v1.
+3. **No manual rowId input.** A free-text rowId cannot scope by `pipelineId`
+   (cross-pipeline key collisions) and was not the locked primitive; dropped.
+4. **No read-path re-redaction.** `attrs` were redacted at write (DF-N2-2b scrub gate);
+   the read path does not re-redact (persistence boundary = security boundary). The UI
+   shows only a compact summary of those already-safe attrs.
+5. **Lazy fetch, cached once.** The GET fires on first expand; collapse/re-expand reuses
+   the cached timeline (no refetch). Optional-method **501** on older hosts is surfaced as
+   a per-row error, never a crash.
+
+## Tests
+
+Frontend specs (vitest/jsdom), all green (view 14/14, service 37/37):
+
+- **Keystone (real wire) — `IntegrationWorkbenchView.spec.ts`**: expanding a dead-letter
+  **fires** `GET /api/integration/provenance` and the query carries **`rowId` + `pipelineId`**
+  (asserted on the `apiFetch` mock); the cross-run timeline (two `runId`s) then renders.
+  This is the wire-vs-fixture lesson from #1968 — it asserts the request goes out, not a
+  pre-mocked response render.
+  - **Negative control (verified)**: suppressing the GET on expand makes the keystone fail
+    (`expected [] to have a length of 1`) — proving the assertion is load-bearing.
+- **Disabled-no-key — view spec**: a dead-letter without `idempotencyKey` renders a
+  **disabled** toggle + unavailable hint; clicking fires no GET and opens no panel.
+- **Service — `integrationWorkbench.spec.ts`**: `listIntegrationProvenanceByRow` builds a
+  GET with `rowId` + `pipelineId` + tenant scope, coerces a non-array body to `[]`, and
+  omits empty optional params.
+- **Read-only**: the timeline introduces no replay/confirm affordance; the provenance call
+  is a GET, never a POST.
+
+Type-check: `vue-tsc --noEmit` clean for the changed files. (A local `vue-tsc -b` reports
+pre-existing `echarts` module-resolution errors in `MetaChartRenderer.vue` /
+`buildChartOption.ts` — unrelated; `echarts` is absent from the local node_modules snapshot,
+present in CI.)
+
+## Files
+
+- `apps/web/src/services/integration/workbench.ts` — `IntegrationProvenanceTimelineEntry` +
+  `IntegrationProvenanceQuery` types, `listIntegrationProvenanceByRow()` (mirrors the
+  dead-letter/run list helpers).
+- `apps/web/src/views/IntegrationWorkbenchView.vue` — per-dead-letter expand + timeline
+  render + lazy-fetch state/methods + minimal styles.
+- `apps/web/tests/IntegrationWorkbenchView.spec.ts` — keystone + disabled-no-key.
+- `apps/web/tests/integrationWorkbench.spec.ts` — service URL/param + array-coercion tests.
+
+## Still gated (separate opt-ins, not started)
+
+- DF-N2-3 follow-up: a rowId entry point for non-open rows (the completed fail→succeed arc).
+- DF-N3 (bounded/**manual** retry + stop-rules — auto-retry stays hard-gated), DF-N4
+  (connector catalog + 2nd ERP), FaaS. K3 Submit/Audit/BOM/multi-record/production remain
+  gated.


### PR DESCRIPTION
Closes the **DF-N2 provenance arc on the operator side**: storage (2a #1981) + runtime write (2b #1988) + read route (2c #1990) + this read-only UI. **Frontend-only** — no backend / route / OpenAPI / RBAC / migration / connector change.

## What it does
Expand a dead-letter in 运行监控 to see that row's **cross-run** provenance timeline — fetched via the DF-N2-2c by-rowId GET (`GET /api/integration/provenance`) using the dead-letter's **`idempotencyKey` as `rowId`** and passing **`pipelineId`** (cross-pipeline key-collision guard). Renders run time / `eventType` / `runStatus` / `runId`·`pipelineId`·`runMode` + a compact **redacted `attrs` summary**.

## Key decisions
- **Anchor = dead-letter expand**, not the run "行级结果" — `targetWriteSummaries` are opaque target business-responses with no reliable rowId; the dead-letter `idempotencyKey` is the only typed row identity in the panel (and the one the provenance view groups on).
- **v1 = open dead-letters only.** A row that failed→succeeded-on-replay (`replayed`) leaves the open list, so its completed arc isn't reachable here — that's a separate **follow-up history view**, out of v1. Open-only still shows a still-failing row's cross-run failure history (the replay-decision case).
- **Read-only**: separate from the replay button; disabled + hint when no `idempotencyKey`; no write/replay/retry/K3; no read-path re-redaction (attrs redacted at write); lazy-fetch cached once; optional-method 501 surfaced per-row.
- No manual rowId input (can't scope by pipelineId; not the locked primitive).

## Tests (51 green: view 14/14, service 37/37; vue-tsc clean for changed files)
- **Keystone real-wire**: expanding fires the GET with **rowId + pipelineId** (asserted on the mock), not a pre-mocked render — **negative-controlled** (suppressing the GET makes it fail).
- Disabled-no-key; service URL/param construction + non-array coercion.

## Still gated (separate opt-ins)
DF-N2-3 follow-up (non-open rowId entry point) · DF-N3 (bounded/**manual** retry — auto-retry hard-gated) · DF-N4 · FaaS · K3 Submit/Audit/BOM/multi-record/production.

Verification: `docs/development/data-factory-df-n2-3-provenance-timeline-ui-verification-20260528.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)