### PR TITLE
feat(multitable): #5c formula dry-run real-record sampling (record-read gated)

### DIFF
--- a/docs/development/multitable-formula-dryrun-5c-a-verification-20260529.md
+++ b/docs/development/multitable-formula-dryrun-5c-a-verification-20260529.md
@@ -1,0 +1,73 @@
+# Multitable Formula Dry-run #5c-a — backend verification
+
+- **Slice**: #5c-a — backend for real-record sampling in the formula dry-run endpoint. Implements the design-lock `multitable-formula-dryrun-5c-design-20260528.md` (#1995).
+- **Status**: ✅ implemented + verified (this doc). Frontend **#5c-b is a separate explicit opt-in** (not in this slice).
+- **Date**: 2026-05-29
+- **Grounding**: worktree off `origin/main 01c753a6b`, branch `runtime/multitable-formula-5c-a-20260529`. Anchors below verified against that tip (the design-lock's `bb61fee2d` anchors are unchanged at `01c753a6b` for these regions).
+- **Lock posture**: additive only. `src/formula/engine.ts` (K3-frozen, attendance-shared), RBAC/auth, and `plugin-integration-core` are NOT touched.
+
+## What shipped (2 files)
+
+1. **`packages/core-backend/src/routes/univer-meta.ts`**
+   - `requireRecordReadable` (`:2190`): success return extended `{access}` → **`{access, capabilities}`** (`:2195`/`:2231`) — additive; the 3 existing callers (`:4212/:4247/:4273`) destructure only `{access}`.
+   - `POST /sheets/:sheetId/formula/dry-run` (`:6020`): optional `recordId` in the body. When present → `requireRecordReadable` gate (yields access+capabilities) → `canManageFields` → RAW `SELECT data` → D3c field mask (`hiddenFieldIds: []`) → `effectiveSampleValues = { ...maskedData, ...sampleValues }` → unchanged no-DB `dryRunFormulaEngine.dryRun(...)`. Absent `recordId` → byte-identical to the prior #5b path.
+2. **`packages/core-backend/tests/integration/multitable-formula-dryrun.test.ts`**
+   - Extended with the #5c real-record cases (runs in `plugin-tests.yml:163-172`, real-DB, node 20.x).
+
+## Verification results
+
+| Check | Result |
+|---|---|
+| `tsc --noEmit` (whole core-backend) | ✅ exit 0, clean |
+| Integration (real DB, local PG + `DATABASE_URL`) | ✅ **18/18** (`multitable-formula-dryrun.test.ts`) |
+| Unit (`tests/unit/formula-dryrun.test.ts`, engine — unchanged) | ✅ 9/9 |
+| `contracts (openapi)` parity gate | ✅ green (no spec change — see §"OpenAPI") |
+| Adversarial multi-lens review (security / behavior / test-adequacy / frozen-lock) | ✅ 4× **pass-with-nits**, no leak vector, no blocking |
+
+### Test → design matrix (what each case proves)
+
+| Test | Proves |
+|---|---|
+| T1a | recordId not on sheet → **404** (record-gate existence) |
+| T1b | valid recordId, user lacks sheet read → **403** (record-gate sheet `canRead`) |
+| T1c | valid recordId, unauthenticated → **401** (record-gate no `userId`) |
+| T1d *(review-added)* | recordId branch, `multitable:read` (canRead=true, canManageFields=false) → **403** — pins the `canManageFields` check to the recordId branch (`:6068`), not only the no-recordId path |
+| T2 | field_permissions-denied field's value **never leaks** + `missing_sample`; also proves `userId` was resolved (else empty-map → leak) |
+| T2b *(review-added)* | `property.hidden` field's value **never leaks** (second mask channel via `filterVisiblePropertyFields`) |
+| T3 | visible record values are sampled (result from the record); explicit manual `sampleValues` override per-field (record-as-base) |
+| T4 | lookup ref → `missing_sample` (RAW read, NOT materialized) — preview==production; not `unknown_field` |
+| T5 | no recordId → unchanged #5b manual path (additive, not regressed) |
+
+## Empirical refinements to the design-lock (recorded on-record)
+
+The design-lock was authored against assumptions about the permission model; reading the code/schema during implementation refined three of them. None changes the chosen approach; they correct the test matrix and an item's framing.
+
+### 1. Design §7-T1 ("record-scope-denied → 403") is a DEAD BRANCH under the current schema — reframed to T1a/T1b/T1c
+
+`record_permissions.access_level` is `CHECK (access_level IN ('read','write','admin'))` (migration `zzzz20260413100000_create_record_permissions.ts:20`) — **no deny level**. `deriveRecordPermissions` (`permission-derivation.ts:130-142`) returns `canRead = capabilities.canRead && accessLevel ∈ {read,write,admin}`, i.e. `canRead = capabilities.canRead` for any stored row. And `loadRecordPermissionScopeMap` (`permission-service.ts:830`) returns only rows whose subject matches the requesting user, so a non-empty map can never describe a *non-granted* user. Therefore the deny branch in `requireRecordReadable` (`:2218-2225`, `recordScopeMap.size>0 && !deriveRecordPermissions(...).canRead`) is **unreachable for read** — record-read is **grant-additive** (consistent with the D3 permission-matrix golden "record-read is a non-gate" finding; the golden suite seeds no `record_permissions`).
+
+Consequence: a "record-scope-denied → 403" test cannot be made to fail-then-pass. The record gate's *real* protections are **existence (404)** and **sheet-level `canRead` (403)** + `userId` (401), which T1a/T1b/T1c verify. `requireRecordReadable` is still the correct primitive (audited path, existence + sheet-read, and it auto-inherits any future record-read-deny level). The route comment at `:6052-6054` states this.
+
+### 2. OpenAPI item T6 is a no-op (endpoint not modeled) — pre-existing, not a #5c regression
+
+The dry-run endpoint (and now its `recordId` field) is absent from the OpenAPI source spec; the parity gate `scripts/ops/multitable-openapi-parity.test.mjs` is a curated allowlist that does **not** assert the dry-run path. So `#5c-a` requires **no OpenAPI change** and the `contracts (openapi)` gate stays green. This gap predates #5c-a (#5a/#5b also shipped the endpoint un-modeled). **Optional follow-up** (separate, non-blocking): model the dry-run path in the OpenAPI source.
+
+### 3. View context = option B (locked) — display-consistency defer, NOT security
+
+The mask passes `hiddenFieldIds: []` (sheet-scope). `deriveFieldPermissions` (`permission-derivation.ts:79-90`) computes `visible` as 3 ANDed layers: view.hiddenFieldIds (display) · static `property.hidden` · subject `field_permissions` (`scope.visible`, the real read gate). Option B omits only layer-1 (per-view display hiding) — layer-3 (the read gate) is fully enforced (proven by T2). The honest label (sheet-scope, permission-safe, raw-record sampling — **not** "mirror current view's columns") is carried by the design-lock §1.1; the frontend tooltip (#5c-b) must also carry it.
+
+## Adversarial review outcome (4 lenses)
+
+All four lenses returned **pass-with-nits**; no blocking/high.
+- **Security / field-read leak**: NO leak vector across 6 attack surfaces (mask drops before engine; merge `{...maskedData,...sampleValues}` cannot surface the record's denied value; empty-scope-map trap closed by the `userId` 401 guard; diagnostics echo only field ids/types, never values; gate precedes eval; mask list consistent with the audited export-xlsx composite). Ship-as-is.
+- **Behavior / contract**: no-recordId path identical; additive helper return backward-compatible; gate codes/ordering correct.
+- **Test adequacy**: 2 LOW gaps → **folded in** as T1d (canManageFields on recordId branch) and T2b (property.hidden channel).
+- **Frozen-core / lock safety**: `formula/engine.ts` untouched; engine still issues zero DB queries (route does the read); no RBAC/auth/integration-core; no dependency/lockfile change; only additive `requireRecordReadable` return.
+
+## Out of scope / follow-ups (each a separate opt-in)
+
+- **#5c-b frontend** — record picker + `recordId` passthrough + honest-label tooltip + C2/C4 (stale-drop on record swap, never gates save). NEXT opt-in.
+- **Faithful lookup/rollup preview** (materialize) — deferred behind the #1971 Layer-2 fix.
+- **OpenAPI modeling** of the dry-run endpoint (incl. `recordId`) — pre-existing gap, optional.
+- **role / member-group field-deny** wire tests — covered by shared SQL (`loadFieldPermissionScopeMap`); user-subject + property.hidden channels are wire-proven (T2/T2b).
+- **`GET /records/:recordId`** (`:7319`) lacks the record-scope gate AND uses static-only field masking — flagged, not fixed here.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -2192,7 +2192,7 @@ async function requireRecordReadable(
   query: QueryFn,
   sheetId: string,
   recordId: string,
-): Promise<{ access: ResolvedRequestAccess } | { status: number; body: unknown }> {
+): Promise<{ access: ResolvedRequestAccess; capabilities: MultitableCapabilities } | { status: number; body: unknown }> {
   const recordCheck = await query(
     'SELECT id, sheet_id FROM meta_records WHERE id = $1 AND sheet_id = $2',
     [recordId, sheetId],
@@ -2228,7 +2228,7 @@ async function requireRecordReadable(
     }
   }
 
-  return { access }
+  return { access, capabilities }
 }
 
 type FieldMutationGuard = {
@@ -6019,8 +6019,9 @@ export function univerMetaRouter(): Router {
   // sample values. Pure in-memory ({fldId} refs only; A1/range rejected) over a no-DB engine.
   router.post('/sheets/:sheetId/formula/dry-run', async (req: Request, res: Response) => {
     const sheetId = typeof req.params.sheetId === 'string' ? req.params.sheetId.trim() : ''
-    const body = (req.body ?? {}) as { expression?: unknown; sampleValues?: unknown }
+    const body = (req.body ?? {}) as { expression?: unknown; sampleValues?: unknown; recordId?: unknown }
     const expression = typeof body.expression === 'string' ? body.expression : ''
+    const recordId = typeof body.recordId === 'string' ? body.recordId.trim() : ''
     if (!sheetId || !expression.trim()) {
       return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'sheetId and a non-empty expression are required' } })
     }
@@ -6047,14 +6048,56 @@ export function univerMetaRouter(): Router {
       if (!sheet) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })
       }
-      const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+      // #5c: when recordId is present, the record-level read gate (requireRecordReadable) yields
+      // access + capabilities (404 record-not-on-sheet / 401 / 403 sheet-!canRead). Per the current
+      // schema record-read is grant-additive (record_permissions.access_level is read|write|admin,
+      // no deny level), so this gate enforces existence + sheet-read, not a per-record read-deny.
+      // Absent recordId → unchanged #5b path. The dry-run ENGINE stays no-DB; the read below is route-level.
+      let capabilities: MultitableCapabilities
+      let recordReadAccess: ResolvedRequestAccess | undefined
+      if (recordId) {
+        const readable = await requireRecordReadable(req, pool.query.bind(pool), sheetId, recordId)
+        if ('status' in readable) {
+          return res.status(readable.status).json(readable.body)
+        }
+        capabilities = readable.capabilities
+        recordReadAccess = readable.access
+      } else {
+        const resolved = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
+        capabilities = resolved.capabilities
+      }
       if (!capabilities.canManageFields) return sendForbidden(res)
 
       if (dryRunFormulaEngine.extractFieldReferences(expression).length > DRY_RUN_MAX_REFERENCED_FIELDS) {
         return res.status(422).json({ ok: false, error: { code: 'DRYRUN_TOO_MANY_REFS', message: `Expression references more than ${DRY_RUN_MAX_REFERENCED_FIELDS} fields` } })
       }
       const fields = await loadFieldsForSheetShared(pool.query.bind(pool), sheetId)
-      const data = await dryRunFormulaEngine.dryRun(expression, sampleValues, fields.map((f) => ({ id: f.id, type: f.type })))
+
+      // #5c: optional real-record sampling. RAW persisted data only (no applyLookupRollup) so the preview
+      // matches production recalc; lookup/rollup keys are absent in raw → existing missing_sample diagnostic.
+      let effectiveSampleValues: Record<string, unknown> = sampleValues
+      if (recordId && recordReadAccess) {
+        const userId = recordReadAccess.userId
+        if (userId) {
+          const recordRes = await pool.query(
+            'SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2',
+            [recordId, sheetId],
+          )
+          const rawData = recordRes.rows.length > 0 ? normalizeJson(recordRes.rows[0].data) : {}
+          // D3c field mask, sheet-scope (hiddenFieldIds: [] — display-consistency defer, see #5c design-lock §4).
+          // scope.visible is the real field-read gate; a denied field is omitted → becomes missing_sample.
+          const visibleFields = filterVisiblePropertyFields(fields)
+          const fieldScopeMap = await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, userId)
+          const fieldPermissions = deriveFieldPermissions(visibleFields, capabilities, { hiddenFieldIds: [], fieldScopeMap })
+          const allowedIds = new Set(
+            visibleFields.filter((field) => fieldPermissions[field.id]?.visible !== false).map((field) => field.id),
+          )
+          const maskedData = filterRecordDataByFieldIds(rawData, allowedIds)
+          // Record values are the base; explicit manual sampleValues override per-field (denied keys stay omitted).
+          effectiveSampleValues = { ...maskedData, ...sampleValues }
+        }
+      }
+      const data = await dryRunFormulaEngine.dryRun(expression, effectiveSampleValues, fields.map((f) => ({ id: f.id, type: f.type })))
       return res.json({ ok: true, data })
     } catch (err) {
       const hint = getDbNotReadyMessage(err)

--- a/packages/core-backend/tests/integration/multitable-formula-dryrun.test.ts
+++ b/packages/core-backend/tests/integration/multitable-formula-dryrun.test.ts
@@ -15,11 +15,22 @@ const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 const TS = Date.now()
 const BASE_ID = `base_dry_${TS}`
 const SHEET_ID = `sheet_dry_${TS}`
-const FLD_A = `fld_a_${TS}`
-const FLD_B = `fld_b_${TS}`
+// Field IDs are namespaced `fld_dry_*` (like base_dry_/sheet_dry_) so they can never collide with a
+// sibling integration test's fixtures in the shared real-DB run — multitable-view-aggregate.test.ts
+// also derives `fld_secret_${TS}` and meta_fields.id is a global PK (the TS alone is not collision-safe).
+const FLD_A = `fld_dry_a_${TS}`
+const FLD_B = `fld_dry_b_${TS}`
+const FLD_SECRET = `fld_dry_secret_${TS}` // #5c: field the requesting user is denied (field_permissions.visible=false)
+const FLD_HIDDEN = `fld_dry_hidden_${TS}` // #5c: statically hidden field (property.hidden=true) — second mask channel
+const FLD_LOOKUP = `fld_dry_lookup_${TS}` // #5c: lookup field — never persisted in raw record data
+const REC_ID = `rec_dry_${TS}`
+const USER_ID = `u_dry_${TS}`
+const SECRET_CANARY = 'do-not-leak-canary' // #5c: proves a field_permissions-denied field never leaks
+const HIDDEN_CANARY = 'do-not-leak-hidden' // #5c: proves a property.hidden field never leaks
 
 let app: Express
 let testPerms: string[] = ['multitable:write'] // canManageFields requires multitable:write
+let testUserId: string = USER_ID // #5c: mutable so a test can drop the user to assert 401
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
 const post = (body: unknown) => request(app).post(`/api/multitable/sheets/${SHEET_ID}/formula/dry-run`).send(body as object)
 
@@ -27,7 +38,7 @@ describeIfDatabase('multitable formula dry-run (real DB)', () => {
   beforeAll(async () => {
     app = express()
     app.use(express.json())
-    app.use((req, _res, next) => { ;(req as any).user = { id: `u_dry_${TS}`, roles: [], perms: testPerms }; next() })
+    app.use((req, _res, next) => { ;(req as any).user = testUserId ? { id: testUserId, roles: [], perms: testPerms } : undefined; next() })
     app.use('/api/multitable', univerMetaRouter())
 
     await q('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [BASE_ID, 'Dry Base'])
@@ -35,9 +46,21 @@ describeIfDatabase('multitable formula dry-run (real DB)', () => {
     for (const [fid, name, order] of [[FLD_A, 'A', 1], [FLD_B, 'B', 2]] as const) {
       await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [fid, SHEET_ID, name, 'number', '{}', order])
     }
+    // #5c real-record sampling fixtures:
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRET, SHEET_ID, 'Secret', 'number', '{}', 3])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LOOKUP, SHEET_ID, 'Looked', 'lookup', '{}', 4])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_HIDDEN, SHEET_ID, 'Hidden', 'number', '{"hidden":true}', 5])
+    // Record carries A/B/Secret/Hidden as RAW persisted values; the lookup key is intentionally ABSENT
+    // (lookups are computed-on-read, never persisted) → the raw-read path yields missing_sample for it.
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_ID, SHEET_ID, JSON.stringify({ [FLD_A]: 10, [FLD_B]: 20, [FLD_SECRET]: SECRET_CANARY, [FLD_HIDDEN]: HIDDEN_CANARY })])
+    // Deny FLD_SECRET to the requesting user — the real D3c field-read deny gate (subject-scoped).
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER_ID, false, false])
   })
 
   afterAll(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
   })
@@ -102,5 +125,93 @@ describeIfDatabase('multitable formula dry-run (real DB)', () => {
     const res = await post({ expression: expr, sampleValues: {} })
     expect(res.status).toBe(422)
     expect(res.body.error.code).toBe('DRYRUN_TOO_MANY_REFS')
+  })
+
+  // ───────────────────────── #5c real-record sampling ─────────────────────────
+  // Record-read is grant-additive in the current schema (record_permissions.access_level is
+  // read|write|admin, no deny level), so requireRecordReadable enforces existence + sheet-read,
+  // NOT a per-record read-deny. The real field-read deny gate is field_permissions (T2).
+
+  test('#5c T1a: recordId not on this sheet → 404 (record-level gate, existence)', async () => {
+    testPerms = ['multitable:write']; testUserId = USER_ID
+    const res = await post({ expression: `={${FLD_A}}+1`, recordId: `rec_ghost_${TS}` })
+    expect(res.status).toBe(404)
+  })
+
+  test('#5c T1b: valid recordId but user lacks sheet read → 403 (record-level gate, sheet canRead)', async () => {
+    testPerms = []; testUserId = USER_ID // no multitable:read/write → canRead false
+    const res = await post({ expression: `={${FLD_A}}+1`, recordId: REC_ID })
+    expect(res.status).toBe(403)
+    testPerms = ['multitable:write']
+  })
+
+  test('#5c T1c: valid recordId but unauthenticated → 401 (record-level gate, no userId)', async () => {
+    testUserId = ''; testPerms = ['multitable:write'] // no user object on the request
+    const res = await post({ expression: `={${FLD_A}}+1`, recordId: REC_ID })
+    expect(res.status).toBe(401)
+    testUserId = USER_ID
+  })
+
+  test('#5c T2: field-scope-denied value never leaks via real-record sampling (wire round-trip)', async () => {
+    testPerms = ['multitable:write']; testUserId = USER_ID
+    // FLD_SECRET carries SECRET_CANARY in the record but is denied (field_permissions.visible=false).
+    const res = await post({ expression: `={${FLD_SECRET}}`, recordId: REC_ID })
+    expect(res.status).toBe(200)
+    // masked out → engine sees no sample → existing missing_sample diagnostic, never the value.
+    const missing = res.body.data.diagnostics.find((d: { kind: string; fieldId?: string }) => d.kind === 'missing_sample' && d.fieldId === FLD_SECRET)
+    expect(missing).toBeDefined()
+    // the denied value must appear nowhere in the wire response.
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY)
+    // NB: this also proves access.userId was resolved — without it loadFieldPermissionScopeMap returns
+    // an empty map, FLD_SECRET would NOT be denied, and the canary would leak (the empty-map trap).
+  })
+
+  test('#5c T3: visible record values are sampled; explicit manual values override per-field', async () => {
+    testPerms = ['multitable:write']; testUserId = USER_ID
+    const base = await post({ expression: `={${FLD_A}}+{${FLD_B}}`, recordId: REC_ID }) // record A=10,B=20
+    expect(base.status).toBe(200)
+    expect(base.body.data.success).toBe(true)
+    expect(base.body.data.result).toBe(30)
+    const overridden = await post({ expression: `={${FLD_A}}+{${FLD_B}}`, recordId: REC_ID, sampleValues: { [FLD_A]: 100 } })
+    expect(overridden.body.data.result).toBe(120) // manual override of A wins over the record's 10
+  })
+
+  test('#5c T4: lookup-ref → missing_sample (RAW read, NOT materialized) — preview==production', async () => {
+    testPerms = ['multitable:write']; testUserId = USER_ID
+    // FLD_LOOKUP is a known field on the sheet but absent from raw persisted data → must degrade
+    // to missing_sample, never a materialized lookup value (locks the raw-read decision).
+    const res = await post({ expression: `={${FLD_LOOKUP}}+1`, recordId: REC_ID })
+    expect(res.status).toBe(200)
+    const missing = res.body.data.diagnostics.find((d: { kind: string; fieldId?: string }) => d.kind === 'missing_sample' && d.fieldId === FLD_LOOKUP)
+    expect(missing).toBeDefined()
+    const unknown = res.body.data.diagnostics.find((d: { kind: string }) => d.kind === 'unknown_field')
+    expect(unknown).toBeUndefined() // it IS a known field, just not sampled — not unknown_field
+  })
+
+  test('#5c T5: no recordId → unchanged #5b manual-sample path (additive, not regressed)', async () => {
+    testPerms = ['multitable:write']; testUserId = USER_ID
+    const res = await post({ expression: `={${FLD_A}}+{${FLD_B}}`, sampleValues: { [FLD_A]: 2, [FLD_B]: 3 } })
+    expect(res.status).toBe(200)
+    expect(res.body.data.result).toBe(5) // manual values; record never consulted
+  })
+
+  test('#5c T1d: recordId branch — sheet-readable but not field-manager → 403 (canManageFields gate fires after the record gate)', async () => {
+    // canRead=true (passes requireRecordReadable) but canManageFields=false → must 403 at the post-gate
+    // capability check, ON the recordId branch (not only the no-recordId path).
+    testPerms = ['multitable:read']; testUserId = USER_ID
+    const res = await post({ expression: `={${FLD_A}}+1`, recordId: REC_ID })
+    expect(res.status).toBe(403)
+    testPerms = ['multitable:write']
+  })
+
+  test('#5c T2b: property.hidden field value never leaks via real-record sampling (second mask channel)', async () => {
+    testPerms = ['multitable:write']; testUserId = USER_ID
+    // FLD_HIDDEN is statically hidden (property.hidden=true) and carries HIDDEN_CANARY in the record;
+    // filterVisiblePropertyFields drops it → masked out → missing_sample, value never on the wire.
+    const res = await post({ expression: `={${FLD_HIDDEN}}`, recordId: REC_ID })
+    expect(res.status).toBe(200)
+    const missing = res.body.data.diagnostics.find((d: { kind: string; fieldId?: string }) => d.kind === 'missing_sample' && d.fieldId === FLD_HIDDEN)
+    expect(missing).toBeDefined()
+    expect(JSON.stringify(res.body)).not.toContain(HIDDEN_CANARY)
   })
 })


### PR DESCRIPTION
Implements #5c (design-locked in #1995): the formula dry-run preview can sample a **real record** instead of only manual values.

## Endpoint (`POST /sheets/:sheetId/formula/dry-run`)
- New optional `recordId`. When present, the record's **RAW persisted values** seed the formula inputs (manual `sampleValues` still override per-field). Absent `recordId` → unchanged #5b manual-sample path (additive).
- Record-read gated via `requireRecordReadable` → **404** (record∉sheet) / **401** / **403** (sheet `!canRead`). Per the current schema, record-read is **grant-additive** (`record_permissions.access_level ∈ {read,write,admin}`, no deny level), so this gate is existence + sheet-read, **not** a per-record read-deny.
- Field reads masked by `field_permissions.visible` (D3c) + `property.hidden`: a denied/hidden field's value **never reaches the preview** — it degrades to the existing `missing_sample` diagnostic.
- Lookup refs read **raw** (unmaterialized) → `missing_sample`, so preview == production recalc.

## Tests — `tests/integration/multitable-formula-dryrun.test.ts` (real-DB, runs in `plugin-tests.yml`)
- **T1a** record∉sheet → 404 · **T1b** no sheet read → 403 · **T1c** unauthenticated → 401 (uses an *existing* record, since the 404 existence check precedes auth) · **T1d** sheet-readable but not field-manager → 403 (`canManageFields` post-gate, on the recordId branch)
- **T2** `field_permissions.visible=false` canary never leaks (+ explicit empty-map-trap note: userId must resolve or the deny silently no-ops) · **T2b** `property.hidden` second mask channel
- **T3** record sampling + manual per-field override · **T4** lookup → `missing_sample` (raw, not materialized) · **T5** no-recordId unchanged

## Verification
- type-check ✅ · ESLint: no new errors (the 8 remaining are pre-existing elsewhere in this 8.4k-line file) · DB integration runs in `plugin-tests.yml` (no PR path filter → always runs).
- Kernel multitable polish; touches only the dry-run endpoint + its test. Record-read model unchanged (grant-additive).

🤖 Generated with [Claude Code](https://claude.com/claude-code)