### PR TITLE
feat(attendance): add fixed-schedule assignment provenance columns

### DIFF
--- a/docs/development/attendance-group-admin-ux-fixed-schedule-provenance-fsd1-verification-20260528.md
+++ b/docs/development/attendance-group-admin-ux-fixed-schedule-provenance-fsd1-verification-20260528.md
@@ -1,0 +1,86 @@
+# Attendance Group Fixed-Schedule Provenance FS-D1 Verification
+
+Date: 2026-05-28
+Branch: `codex/attendance-group-fsd1-provenance-20260528`
+Status: runtime slice verification
+
+## 1. Scope
+
+FS-D1 implements only the migration and mapper exposure from `attendance-group-admin-ux-fixed-schedule-managed-provenance-design-20260528.md`.
+
+This slice adds nullable producer metadata to `attendance_shift_assignments`:
+
+- `producer_type`
+- `producer_ref_id`
+- `producer_key`
+- `producer_run_id`
+
+It also exposes the fields through `mapAssignmentRow` in both camelCase and snake_case forms.
+
+## 2. Boundaries
+
+- No route changes.
+- No frontend changes.
+- No FS-C apply tagging.
+- No rebuild or clear operation.
+- No `attendance_schedule_groups` reuse.
+- No new schedule fact table.
+- Existing/manual/legacy rows remain all-null and unmanaged.
+
+FS-D2 remains the first slice that may tag newly created group fixed-schedule rows. FS-D3 remains the rebuild/clear slice.
+
+## 3. Migration Shape
+
+Migration: `packages/core-backend/src/db/migrations/zzzz20260528200000_add_attendance_shift_assignment_provenance.ts`
+
+Locked choices:
+
+- Adds columns only to `attendance_shift_assignments`.
+- Adds all-null-or-all-non-null check constraint `chk_attendance_shift_assignments_producer_metadata`.
+- Adds lookup indexes:
+  - `idx_attendance_shift_assignments_producer_key` on `(org_id, producer_type, producer_key)`.
+  - `idx_attendance_shift_assignments_producer_ref` on `(org_id, producer_type, producer_ref_id)`.
+- Down migration drops the check, indexes, and columns.
+- Does not create a second schedule table.
+
+Deployment note:
+
+- The migration uses the repo's existing plain `ADD CONSTRAINT ... CHECK` style rather than `NOT VALID` + later `VALIDATE CONSTRAINT`.
+- PostgreSQL validates existing rows when the constraint is added. Here the four columns were just added as nullable, so existing rows are all-null and satisfy the check, but the validation still scans `attendance_shift_assignments` while the DDL lock is held.
+- For unusually large production attendance-assignment tables, schedule this migration with the normal migration window; a future migration SOP could split large-table checks into `NOT VALID` plus a separate validation step.
+
+## 4. Verification
+
+Commands run from `/tmp/metasheet2-attendance-group-fsd1-provenance-20260528`:
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-scheduling-assignment-conflict.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/migration-provider.test.ts tests/unit/migrations.rollback.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+git diff --check
+```
+
+Results:
+
+- `node --check plugins/plugin-attendance/index.cjs` — PASS.
+- `attendance-scheduling-assignment-conflict.test.ts` — PASS, 11/11.
+- `migration-provider.test.ts` + `migrations.rollback.test.ts` — PASS, 16/16.
+- `pnpm --filter @metasheet/core-backend exec tsc --noEmit` — PASS.
+- `git diff --check` — PASS.
+
+## 5. Tests Added
+
+`attendance-scheduling-assignment-conflict.test.ts` now locks:
+
+- legacy rows with no producer columns map to `producerType/producerRefId/producerKey/producerRunId = null`;
+- managed rows map producer metadata in both camelCase and snake_case forms;
+- migration source adds the four nullable producer columns, the all-null-or-all-non-null check, and both producer indexes;
+- migration source does not create a second attendance group or schedule fact table.
+
+## 6. Deferred
+
+- FS-D2: populate producer metadata for newly created group fixed-schedule rows.
+- FS-D3: managed rebuild/clear with soft-deactivation by `producer_key`.
+- Any UI for clear/rebuild.
+- Weekly matrix, daily multi-shift modeling, group punch configuration, owner/sub-owner, export/copy, or comprehensive-hours writes.

--- a/packages/core-backend/src/db/migrations/zzzz20260528200000_add_attendance_shift_assignment_provenance.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260528200000_add_attendance_shift_assignment_provenance.ts
@@ -1,0 +1,68 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import {
+  addColumnIfNotExists,
+  checkTableExists,
+  createIndexIfNotExists,
+  dropColumnIfExists,
+  dropIndexIfExists,
+} from './_patterns'
+
+const TABLE_NAME = 'attendance_shift_assignments'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, TABLE_NAME)
+  if (!exists) return
+
+  await addColumnIfNotExists(db, TABLE_NAME, 'producer_type', 'text')
+  await addColumnIfNotExists(db, TABLE_NAME, 'producer_ref_id', 'uuid')
+  await addColumnIfNotExists(db, TABLE_NAME, 'producer_key', 'text')
+  await addColumnIfNotExists(db, TABLE_NAME, 'producer_run_id', 'uuid')
+
+  await sql`ALTER TABLE attendance_shift_assignments DROP CONSTRAINT IF EXISTS chk_attendance_shift_assignments_producer_metadata`.execute(db)
+  await sql`
+    ALTER TABLE attendance_shift_assignments
+    ADD CONSTRAINT chk_attendance_shift_assignments_producer_metadata
+    CHECK (
+      (
+        producer_type IS NULL
+        AND producer_ref_id IS NULL
+        AND producer_key IS NULL
+        AND producer_run_id IS NULL
+      )
+      OR
+      (
+        producer_type IS NOT NULL
+        AND producer_ref_id IS NOT NULL
+        AND producer_key IS NOT NULL
+        AND producer_run_id IS NOT NULL
+      )
+    )
+  `.execute(db)
+
+  await createIndexIfNotExists(
+    db,
+    'idx_attendance_shift_assignments_producer_key',
+    TABLE_NAME,
+    ['org_id', 'producer_type', 'producer_key'],
+  )
+  await createIndexIfNotExists(
+    db,
+    'idx_attendance_shift_assignments_producer_ref',
+    TABLE_NAME,
+    ['org_id', 'producer_type', 'producer_ref_id'],
+  )
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, TABLE_NAME)
+  if (!exists) return
+
+  await sql`ALTER TABLE attendance_shift_assignments DROP CONSTRAINT IF EXISTS chk_attendance_shift_assignments_producer_metadata`.execute(db)
+  await dropIndexIfExists(db, 'idx_attendance_shift_assignments_producer_ref')
+  await dropIndexIfExists(db, 'idx_attendance_shift_assignments_producer_key')
+  await dropColumnIfExists(db, TABLE_NAME, 'producer_run_id')
+  await dropColumnIfExists(db, TABLE_NAME, 'producer_key')
+  await dropColumnIfExists(db, TABLE_NAME, 'producer_ref_id')
+  await dropColumnIfExists(db, TABLE_NAME, 'producer_type')
+}

--- a/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
@@ -1,9 +1,15 @@
+import { readFileSync } from 'node:fs'
 import { createRequire } from 'node:module'
 import { describe, expect, it, vi } from 'vitest'
 
 const require = createRequire(import.meta.url)
 const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
 const helpers = attendancePlugin.__attendanceReportFieldCatalogForTests
+
+const provenanceMigrationSource = readFileSync(
+  new URL('../../src/db/migrations/zzzz20260528200000_add_attendance_shift_assignment_provenance.ts', import.meta.url),
+  'utf8',
+)
 
 describe('attendance scheduling assignment conflict guard', () => {
   it('detects same-kind and cross-kind active assignment overlaps', async () => {
@@ -102,6 +108,60 @@ describe('attendance scheduling assignment conflict guard', () => {
     expect(helpers.getAttendanceScheduleAssignmentConflictType('rotation', 'rotation')).toBe('rotation_assignment_overlap')
     expect(helpers.getAttendanceScheduleAssignmentConflictType('rotation', 'shift')).toBe('rotation_overrides_shift')
     expect(helpers.getAttendanceScheduleAssignmentConflictType('shift', 'rotation')).toBe('rotation_overrides_shift')
+  })
+
+  it('maps optional shift-assignment producer metadata without claiming legacy rows', () => {
+    expect(helpers.mapAssignmentRow({
+      id: 'assignment-legacy',
+      org_id: 'org-a',
+      user_id: 'user-a',
+      shift_id: 'shift-a',
+      start_date: '2026-06-01',
+      end_date: '2026-06-30',
+      is_active: true,
+    })).toEqual(expect.objectContaining({
+      producerType: null,
+      producerRefId: null,
+      producerKey: null,
+      producerRunId: null,
+    }))
+
+    expect(helpers.mapAssignmentRow({
+      id: 'assignment-managed',
+      org_id: 'org-a',
+      user_id: 'user-a',
+      shift_id: 'shift-a',
+      start_date: '2026-06-01',
+      end_date: '2026-06-30',
+      is_active: true,
+      producer_type: 'attendance_group_fixed_schedule',
+      producer_ref_id: '11111111-1111-4111-8111-111111111111',
+      producer_key: 'attendance_group_fixed_schedule:11111111-1111-4111-8111-111111111111:22222222-2222-4222-8222-222222222222:2026-06-01:2026-06-30',
+      producer_run_id: '33333333-3333-4333-8333-333333333333',
+    })).toEqual(expect.objectContaining({
+      producerType: 'attendance_group_fixed_schedule',
+      producerRefId: '11111111-1111-4111-8111-111111111111',
+      producerKey: 'attendance_group_fixed_schedule:11111111-1111-4111-8111-111111111111:22222222-2222-4222-8222-222222222222:2026-06-01:2026-06-30',
+      producerRunId: '33333333-3333-4333-8333-333333333333',
+      producer_type: 'attendance_group_fixed_schedule',
+      producer_ref_id: '11111111-1111-4111-8111-111111111111',
+      producer_key: 'attendance_group_fixed_schedule:11111111-1111-4111-8111-111111111111:22222222-2222-4222-8222-222222222222:2026-06-01:2026-06-30',
+      producer_run_id: '33333333-3333-4333-8333-333333333333',
+    }))
+  })
+
+  it('adds nullable shift-assignment producer metadata without creating a second schedule fact table', () => {
+    expect(provenanceMigrationSource).toContain("addColumnIfNotExists(db, TABLE_NAME, 'producer_type', 'text')")
+    expect(provenanceMigrationSource).toContain("addColumnIfNotExists(db, TABLE_NAME, 'producer_ref_id', 'uuid')")
+    expect(provenanceMigrationSource).toContain("addColumnIfNotExists(db, TABLE_NAME, 'producer_key', 'text')")
+    expect(provenanceMigrationSource).toContain("addColumnIfNotExists(db, TABLE_NAME, 'producer_run_id', 'uuid')")
+    expect(provenanceMigrationSource).toContain('chk_attendance_shift_assignments_producer_metadata')
+    expect(provenanceMigrationSource).toContain('producer_type IS NULL')
+    expect(provenanceMigrationSource).toContain('producer_run_id IS NOT NULL')
+    expect(provenanceMigrationSource).toContain('idx_attendance_shift_assignments_producer_key')
+    expect(provenanceMigrationSource).toContain('idx_attendance_shift_assignments_producer_ref')
+    expect(provenanceMigrationSource).not.toContain("createTable('attendance_group")
+    expect(provenanceMigrationSource).not.toContain("createTable('attendance_schedule")
   })
 
   it('builds fixed-schedule group previews from the complete member set without writes', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -7969,6 +7969,14 @@ function mapAssignmentRow(row) {
     end_date: normalizeDateOnly(row.end_date) ?? row.end_date ?? null,
     isActive: row.is_active ?? true,
     is_active: row.is_active ?? true,
+    producerType: row.producer_type ?? null,
+    producer_type: row.producer_type ?? null,
+    producerRefId: row.producer_ref_id ?? null,
+    producer_ref_id: row.producer_ref_id ?? null,
+    producerKey: row.producer_key ?? null,
+    producer_key: row.producer_key ?? null,
+    producerRunId: row.producer_run_id ?? null,
+    producer_run_id: row.producer_run_id ?? null,
   }
 }
 
@@ -14512,6 +14520,7 @@ module.exports = {
     normalizeAttendanceComprehensiveHoursPreviewInput,
     resolveAttendanceComprehensiveHoursPreviewPeriod,
     previewAttendanceComprehensiveHours,
+    mapAssignmentRow,
     findAttendanceScheduleAssignmentConflict,
     buildAttendanceGroupFixedSchedulePlan,
     buildAttendanceGroupFixedSchedulePreview,


### PR DESCRIPTION
## Summary
- implement FS-D1 from the fixed-schedule managed-provenance design
- add nullable producer metadata columns to attendance_shift_assignments: producer_type, producer_ref_id, producer_key, producer_run_id
- add all-null-or-all-non-null check constraint plus producer lookup indexes
- expose producer metadata through mapAssignmentRow in camelCase and snake_case forms
- add verification doc for the FS-D1 slice

## Boundaries
- no route changes
- no frontend changes
- no FS-C apply tagging yet
- no rebuild/clear operation
- no attendance_schedule_groups reuse and no second schedule fact table
- existing/manual/legacy rows remain all-null and unmanaged

## Verification
- node --check plugins/plugin-attendance/index.cjs
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-scheduling-assignment-conflict.test.ts --watch=false (11/11)
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/migration-provider.test.ts tests/unit/migrations.rollback.test.ts --watch=false (16/16)
- pnpm --filter @metasheet/core-backend exec tsc --noEmit
- git diff --check

## Deferred
- FS-D2: populate producer metadata on newly created group fixed-schedule rows
- FS-D3: managed rebuild/clear with soft-deactivation by producer_key
- UI for clear/rebuild and all larger schedule editor features