### PR TITLE
feat(integration): DF-T1A connector action metadata contract (latent)

### DIFF
--- a/docs/development/data-factory-df-t1a-connector-action-metadata-verification-20260528.md
+++ b/docs/development/data-factory-df-t1a-connector-action-metadata-verification-20260528.md
@@ -1,0 +1,79 @@
+# DF-T1A — connector action metadata contract (verification, 2026-05-28)
+
+First slice of the DF-T template-composition line after DF-T1-0/T1/T1.5 shipped. A
+**latent contract** (mirrors #1882's `provenance-contracts.cjs`): it describes and
+gates connector actions; it is **not wired to any runtime**, route, or HTTP client.
+
+## Scope (owner-locked)
+
+- A connector **action** = one safe, named operation exposed by a connector profile,
+  expressed as metadata around an **existing** adapter method.
+- New `lib/connector-action-contracts.cjs` + OpenAPI `ConnectorAction` /
+  `ConnectorActionInput` / `ConnectorActionOperation` (parity-locked, **no path** — #1882
+  precedent) + the **first K3 sample** + tests + this MD.
+- **Latent only**: authorizes no generic HTTP client, no user JavaScript, no SQL, no new
+  connector runtime. Does **not** unlock Submit / Audit / BOM / multi-record. Write
+  actions are annotated **gated/disabled**, never enabled here. Leave for review.
+
+## Contract + invariants (`normalizeConnectorAction`)
+
+Shape: `actionId` · `connectorKind` · `operation` (enum) · `label?` ·
+`request{method, path, inputs{path,query,header,body}}` · `output{recordPath, successPath,
+successValue?, errorPath}` · `safety{readOnly, allowBatch, maxRowsPreview, requiresApproval}`
+· derived `gated` · `help?`. Three hard invariants:
+
+1. **enum-strict `operation`** — `read` / `preview` / `upsert` / `export` only.
+2. **relative-path only** — `request.path` must be `/…`; scheme (`http:`),
+   protocol-relative (`//host`), backslashes, and **query (`?`) / fragment (`#`)** are
+   rejected → blocks a generic HTTP client / SSRF and forces query/header/body through
+   `inputs` (not the endpoint path). (Standalone check; the contract carries no adapter dependency.)
+3. **no inline secrets** — inputs reference data by `source` (e.g. `record.FNumber`); an
+   inline `value` on any input is rejected (secrets come from the profile's `secretsRef` at
+   runtime). `help` free-text is scrubbed through the shared `sanitizeIntegrationPayload`.
+4. **write-gating** — the **write set** is `{upsert}` (NOT `!== 'read'`, so the no-write
+   `preview`/`export` are not over-gated). A write op MUST set `requiresApproval:true` and
+   cannot be `readOnly`; conversely a **non-write op (read/preview/export) MUST set
+   `readOnly:true`** (it may not pose as mutating). `gated` is derived `true` for any write
+   op or explicit approval. Submit/Audit/BOM are intentionally NOT modeled — they stay
+   gated outside this contract.
+
+## First K3 sample (`K3_WISE_MATERIAL_ACTIONS`)
+
+The **existing** K3 WISE WebAPI Material adapter operations, as metadata (output paths
+match the adapter's real envelope — `StatusCode`/`Message`; save success via
+`Result.ResponseStatus.IsSuccess`):
+
+- `k3wise.material.get-detail` — `read`, `POST /K3API/Material/GetDetail`, body `Number`
+  ← `record.FNumber`, **runnable** (`gated:false`).
+- `k3wise.material.save` — `upsert`, `POST /K3API/Material/Save`, **gated/disabled**
+  (`gated:true`, `requiresApproval:true`) — Save-only stays behind its own approval.
+
+## Tests (`__tests__/connector-action-contracts.test.cjs`, green)
+
+- **OpenAPI parity (load-bearing)**: `ConnectorActionOperation`/`ConnectorAction`/
+  `ConnectorActionInput` present; `enum === CONNECTOR_ACTION_OPERATIONS`; `operation.$ref`
+  reuses the enum; `additionalProperties:false`; `required` set matches.
+- Sample catalog: read runnable / save gated; no inline `value` in sample inputs.
+- enum-strict · relative-path (4 rejects incl. `http://`, `//host`, backslash, no-leading-`/`)
+  · no-inline-secret (header `value` rejected) · write-gating (upsert without
+  `requiresApproval` rejected; write can't be readOnly) · **over-gating guard** (`preview`
+  and `export` are NOT gated; write set is `upsert` only) · redaction self-check (a
+  `postgres://erp:…@` value in `help` is scrubbed, not stored raw).
+- **Negative control (verified)**: reintroducing the buggy `operation !== 'read'` gating
+  predicate makes the `preview not gated` assertion fail — proving the over-gating guard is
+  load-bearing (the advisor-caught case).
+- Re-ran neighbors (provenance-contracts / adapter-contracts / payload-redaction /
+  k3-wise-adapters) green — additive change, no breakage.
+
+## Files
+
+- `plugins/plugin-integration-core/lib/connector-action-contracts.cjs` (new, latent)
+- `packages/openapi/src/base.yml` (+3 components) · `packages/openapi/dist/*` (regenerated, additive)
+- `plugins/plugin-integration-core/__tests__/connector-action-contracts.test.cjs` (new) +
+  `package.json` (test chain + `test:connector-action-contracts`)
+
+## Still gated (separate opt-ins, not started)
+
+- **DF-T2** — K3 customer-profile authoring UI (the product surface; consumes this contract).
+- DF-T3..T6. The contract is **not imported by any runtime** — wiring it (into preview/
+  authoring) is a later opt-in. No K3 write capability added.

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -1420,6 +1420,137 @@ components:
         - runStatus
         - runMode
         - runCreatedAt
+    ConnectorActionOperation:
+      type: string
+      description: >-
+        DF-T1A connector action operation kind. read/preview/export are
+        non-mutating; upsert is a write (always gated). Submit/Audit/BOM are
+        intentionally NOT modeled here.
+      enum:
+        - read
+        - preview
+        - upsert
+        - export
+    ConnectorActionInput:
+      type: object
+      additionalProperties: false
+      description: >-
+        One business input for a connector action. References data by `source`
+        (e.g. record.FNumber); never an inline literal value (no secrets in
+        metadata).
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+        source:
+          type: string
+        required:
+          type: boolean
+    ConnectorAction:
+      type: object
+      description: >-
+        DF-T1A connector action metadata — one safe, named operation exposed by
+        a connector profile, as metadata around an existing adapter method.
+        Latent contract: authorizes no generic HTTP client, user JavaScript, or
+        SQL. Write actions (upsert) are always gated.
+      additionalProperties: false
+      properties:
+        actionId:
+          type: string
+          minLength: 1
+        connectorKind:
+          type: string
+          minLength: 1
+        operation:
+          $ref: '#/components/schemas/ConnectorActionOperation'
+        label:
+          type: string
+        request:
+          type: object
+          additionalProperties: false
+          required:
+            - method
+            - path
+            - inputs
+          properties:
+            method:
+              type: string
+            path:
+              type: string
+              description: >-
+                Relative to the connector base URL — no scheme/host/backslash,
+                and no query (?) or fragment (#); query/header/body go through
+                inputs.
+            inputs:
+              type: object
+              additionalProperties: false
+              properties:
+                path:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ConnectorActionInput'
+                query:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ConnectorActionInput'
+                header:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ConnectorActionInput'
+                body:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ConnectorActionInput'
+        output:
+          type: object
+          additionalProperties: false
+          required:
+            - recordPath
+            - successPath
+            - errorPath
+          properties:
+            recordPath:
+              type: string
+            successPath:
+              type: string
+            successValue: {}
+            errorPath:
+              type: string
+        safety:
+          type: object
+          additionalProperties: false
+          required:
+            - readOnly
+            - allowBatch
+            - maxRowsPreview
+            - requiresApproval
+          properties:
+            readOnly:
+              type: boolean
+            allowBatch:
+              type: boolean
+            maxRowsPreview:
+              type: integer
+            requiresApproval:
+              type: boolean
+        gated:
+          type: boolean
+          description: >-
+            Derived — true for a write op OR requiresApproval; the UI renders
+            gated actions disabled.
+        help:
+          type: object
+          additionalProperties: true
+      required:
+        - actionId
+        - connectorKind
+        - operation
+        - request
+        - output
+        - safety
+        - gated
     AttendanceShift:
       type: object
       properties:

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -2009,6 +2009,167 @@
           "runCreatedAt"
         ]
       },
+      "ConnectorActionOperation": {
+        "type": "string",
+        "description": "DF-T1A connector action operation kind. read/preview/export are non-mutating; upsert is a write (always gated). Submit/Audit/BOM are intentionally NOT modeled here.",
+        "enum": [
+          "read",
+          "preview",
+          "upsert",
+          "export"
+        ]
+      },
+      "ConnectorActionInput": {
+        "type": "object",
+        "additionalProperties": false,
+        "description": "One business input for a connector action. References data by `source` (e.g. record.FNumber); never an inline literal value (no secrets in metadata).",
+        "required": [
+          "name"
+        ],
+        "properties": {
+          "name": {
+            "type": "string",
+            "minLength": 1
+          },
+          "source": {
+            "type": "string"
+          },
+          "required": {
+            "type": "boolean"
+          }
+        }
+      },
+      "ConnectorAction": {
+        "type": "object",
+        "description": "DF-T1A connector action metadata — one safe, named operation exposed by a connector profile, as metadata around an existing adapter method. Latent contract: authorizes no generic HTTP client, user JavaScript, or SQL. Write actions (upsert) are always gated.",
+        "additionalProperties": false,
+        "properties": {
+          "actionId": {
+            "type": "string",
+            "minLength": 1
+          },
+          "connectorKind": {
+            "type": "string",
+            "minLength": 1
+          },
+          "operation": {
+            "$ref": "#/components/schemas/ConnectorActionOperation"
+          },
+          "label": {
+            "type": "string"
+          },
+          "request": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "method",
+              "path",
+              "inputs"
+            ],
+            "properties": {
+              "method": {
+                "type": "string"
+              },
+              "path": {
+                "type": "string",
+                "description": "Relative to the connector base URL — no scheme/host/backslash, and no query (?) or fragment (#); query/header/body go through inputs."
+              },
+              "inputs": {
+                "type": "object",
+                "additionalProperties": false,
+                "properties": {
+                  "path": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ConnectorActionInput"
+                    }
+                  },
+                  "query": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ConnectorActionInput"
+                    }
+                  },
+                  "header": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ConnectorActionInput"
+                    }
+                  },
+                  "body": {
+                    "type": "array",
+                    "items": {
+                      "$ref": "#/components/schemas/ConnectorActionInput"
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "output": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "recordPath",
+              "successPath",
+              "errorPath"
+            ],
+            "properties": {
+              "recordPath": {
+                "type": "string"
+              },
+              "successPath": {
+                "type": "string"
+              },
+              "successValue": {},
+              "errorPath": {
+                "type": "string"
+              }
+            }
+          },
+          "safety": {
+            "type": "object",
+            "additionalProperties": false,
+            "required": [
+              "readOnly",
+              "allowBatch",
+              "maxRowsPreview",
+              "requiresApproval"
+            ],
+            "properties": {
+              "readOnly": {
+                "type": "boolean"
+              },
+              "allowBatch": {
+                "type": "boolean"
+              },
+              "maxRowsPreview": {
+                "type": "integer"
+              },
+              "requiresApproval": {
+                "type": "boolean"
+              }
+            }
+          },
+          "gated": {
+            "type": "boolean",
+            "description": "Derived — true for a write op OR requiresApproval; the UI renders gated actions disabled."
+          },
+          "help": {
+            "type": "object",
+            "additionalProperties": true
+          }
+        },
+        "required": [
+          "actionId",
+          "connectorKind",
+          "operation",
+          "request",
+          "output",
+          "safety",
+          "gated"
+        ]
+      },
       "AttendanceShift": {
         "type": "object",
         "properties": {

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -1420,6 +1420,137 @@ components:
         - runStatus
         - runMode
         - runCreatedAt
+    ConnectorActionOperation:
+      type: string
+      description: >-
+        DF-T1A connector action operation kind. read/preview/export are
+        non-mutating; upsert is a write (always gated). Submit/Audit/BOM are
+        intentionally NOT modeled here.
+      enum:
+        - read
+        - preview
+        - upsert
+        - export
+    ConnectorActionInput:
+      type: object
+      additionalProperties: false
+      description: >-
+        One business input for a connector action. References data by `source`
+        (e.g. record.FNumber); never an inline literal value (no secrets in
+        metadata).
+      required:
+        - name
+      properties:
+        name:
+          type: string
+          minLength: 1
+        source:
+          type: string
+        required:
+          type: boolean
+    ConnectorAction:
+      type: object
+      description: >-
+        DF-T1A connector action metadata — one safe, named operation exposed by
+        a connector profile, as metadata around an existing adapter method.
+        Latent contract: authorizes no generic HTTP client, user JavaScript, or
+        SQL. Write actions (upsert) are always gated.
+      additionalProperties: false
+      properties:
+        actionId:
+          type: string
+          minLength: 1
+        connectorKind:
+          type: string
+          minLength: 1
+        operation:
+          $ref: '#/components/schemas/ConnectorActionOperation'
+        label:
+          type: string
+        request:
+          type: object
+          additionalProperties: false
+          required:
+            - method
+            - path
+            - inputs
+          properties:
+            method:
+              type: string
+            path:
+              type: string
+              description: >-
+                Relative to the connector base URL — no scheme/host/backslash,
+                and no query (?) or fragment (#); query/header/body go through
+                inputs.
+            inputs:
+              type: object
+              additionalProperties: false
+              properties:
+                path:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ConnectorActionInput'
+                query:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ConnectorActionInput'
+                header:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ConnectorActionInput'
+                body:
+                  type: array
+                  items:
+                    $ref: '#/components/schemas/ConnectorActionInput'
+        output:
+          type: object
+          additionalProperties: false
+          required:
+            - recordPath
+            - successPath
+            - errorPath
+          properties:
+            recordPath:
+              type: string
+            successPath:
+              type: string
+            successValue: {}
+            errorPath:
+              type: string
+        safety:
+          type: object
+          additionalProperties: false
+          required:
+            - readOnly
+            - allowBatch
+            - maxRowsPreview
+            - requiresApproval
+          properties:
+            readOnly:
+              type: boolean
+            allowBatch:
+              type: boolean
+            maxRowsPreview:
+              type: integer
+            requiresApproval:
+              type: boolean
+        gated:
+          type: boolean
+          description: >-
+            Derived — true for a write op OR requiresApproval; the UI renders
+            gated actions disabled.
+        help:
+          type: object
+          additionalProperties: true
+      required:
+        - actionId
+        - connectorKind
+        - operation
+        - request
+        - output
+        - safety
+        - gated
     AttendanceShift:
       type: object
       properties:

--- a/packages/openapi/src/base.yml
+++ b/packages/openapi/src/base.yml
@@ -1337,6 +1337,105 @@ components:
           format: date-time
           description: Run creation time; the read-route from/to window bounds whole runs by this field.
       required: [runId, pipelineId, rowId, eventType, at, attrs, eventIndex, runStatus, runMode, runCreatedAt]
+    ConnectorActionOperation:
+      type: string
+      description: >-
+        DF-T1A connector action operation kind. read/preview/export are non-mutating;
+        upsert is a write (always gated). Submit/Audit/BOM are intentionally NOT modeled here.
+      enum: [read, preview, upsert, export]
+    ConnectorActionInput:
+      type: object
+      additionalProperties: false
+      description: >-
+        One business input for a connector action. References data by `source`
+        (e.g. record.FNumber); never an inline literal value (no secrets in metadata).
+      required: [name]
+      properties:
+        name:
+          type: string
+          minLength: 1
+        source:
+          type: string
+        required:
+          type: boolean
+    ConnectorAction:
+      type: object
+      description: >-
+        DF-T1A connector action metadata — one safe, named operation exposed by a connector
+        profile, as metadata around an existing adapter method. Latent contract: authorizes no
+        generic HTTP client, user JavaScript, or SQL. Write actions (upsert) are always gated.
+      additionalProperties: false
+      properties:
+        actionId:
+          type: string
+          minLength: 1
+        connectorKind:
+          type: string
+          minLength: 1
+        operation:
+          $ref: '#/components/schemas/ConnectorActionOperation'
+        label:
+          type: string
+        request:
+          type: object
+          additionalProperties: false
+          required: [method, path, inputs]
+          properties:
+            method:
+              type: string
+            path:
+              type: string
+              description: >-
+                Relative to the connector base URL — no scheme/host/backslash, and no query (?)
+                or fragment (#); query/header/body go through inputs.
+            inputs:
+              type: object
+              additionalProperties: false
+              properties:
+                path:
+                  type: array
+                  items: { $ref: '#/components/schemas/ConnectorActionInput' }
+                query:
+                  type: array
+                  items: { $ref: '#/components/schemas/ConnectorActionInput' }
+                header:
+                  type: array
+                  items: { $ref: '#/components/schemas/ConnectorActionInput' }
+                body:
+                  type: array
+                  items: { $ref: '#/components/schemas/ConnectorActionInput' }
+        output:
+          type: object
+          additionalProperties: false
+          required: [recordPath, successPath, errorPath]
+          properties:
+            recordPath:
+              type: string
+            successPath:
+              type: string
+            successValue: {}
+            errorPath:
+              type: string
+        safety:
+          type: object
+          additionalProperties: false
+          required: [readOnly, allowBatch, maxRowsPreview, requiresApproval]
+          properties:
+            readOnly:
+              type: boolean
+            allowBatch:
+              type: boolean
+            maxRowsPreview:
+              type: integer
+            requiresApproval:
+              type: boolean
+        gated:
+          type: boolean
+          description: Derived — true for a write op OR requiresApproval; the UI renders gated actions disabled.
+        help:
+          type: object
+          additionalProperties: true
+      required: [actionId, connectorKind, operation, request, output, safety, gated]
     AttendanceShift:
       type: object
       properties:

--- a/plugins/plugin-integration-core/__tests__/connector-action-contracts.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/connector-action-contracts.test.cjs
@@ -1,0 +1,161 @@
+'use strict'
+
+// DF-T1A connector action metadata contract tests. Mirrors provenance-contracts.test.cjs:
+// OpenAPI parity (load-bearing) + contract invariants. Plain node test (throws on failure).
+
+const assert = require('node:assert/strict')
+const fs = require('node:fs')
+const path = require('node:path')
+const yaml = require('js-yaml')
+
+const {
+  CONNECTOR_ACTION_OPERATIONS,
+  WRITE_OPERATIONS,
+  ConnectorActionContractValidationError,
+  normalizeConnectorAction,
+  K3_WISE_MATERIAL_ACTIONS,
+} = require(path.join(__dirname, '..', 'lib', 'connector-action-contracts.cjs'))
+
+const ROOT_DIR = path.join(__dirname, '..', '..', '..')
+
+function baseAction(overrides = {}) {
+  return {
+    actionId: 'k3wise.material.get-detail',
+    connectorKind: 'erp:k3-wise-webapi',
+    operation: 'read',
+    label: 'Material GetDetail',
+    request: {
+      method: 'POST',
+      path: '/K3API/Material/GetDetail',
+      inputs: { body: [{ name: 'Number', source: 'record.FNumber', required: true }] },
+    },
+    output: { recordPath: 'Data[0].Data', successPath: 'StatusCode', successValue: 200, errorPath: 'Message' },
+    safety: { readOnly: true, allowBatch: false, maxRowsPreview: 1, requiresApproval: false },
+    ...overrides,
+  }
+}
+
+// OpenAPI parity is load-bearing: the contract enum/shape and base.yml must not drift.
+function assertOpenApiParity() {
+  const basePath = path.join(ROOT_DIR, 'packages', 'openapi', 'src', 'base.yml')
+  const doc = yaml.load(fs.readFileSync(basePath, 'utf8'))
+  const schemas = (doc.components && doc.components.schemas) || {}
+  const opSchema = schemas.ConnectorActionOperation
+  const actionSchema = schemas.ConnectorAction
+  const inputSchema = schemas.ConnectorActionInput
+  assert.ok(opSchema, 'OpenAPI ConnectorActionOperation schema exists')
+  assert.deepEqual(opSchema.enum, [...CONNECTOR_ACTION_OPERATIONS], 'operation enum matches the contract (load-bearing)')
+  assert.ok(actionSchema, 'OpenAPI ConnectorAction schema exists')
+  assert.ok(inputSchema, 'OpenAPI ConnectorActionInput schema exists')
+  assert.equal(actionSchema.additionalProperties, false, 'ConnectorAction is additionalProperties:false')
+  assert.equal(
+    actionSchema.properties.operation.$ref,
+    '#/components/schemas/ConnectorActionOperation',
+    'operation reuses the enum-locked ConnectorActionOperation type',
+  )
+  for (const field of ['actionId', 'connectorKind', 'operation', 'request', 'output', 'safety', 'gated']) {
+    assert.ok(actionSchema.required.includes(field), `ConnectorAction.required includes ${field}`)
+  }
+}
+
+function main() {
+  assertOpenApiParity()
+
+  // The shipped sample catalog describes the EXISTING K3 adapter ops as metadata.
+  assert.equal(K3_WISE_MATERIAL_ACTIONS.length, 2, 'K3 sample has get-detail + save')
+  const byId = Object.fromEntries(K3_WISE_MATERIAL_ACTIONS.map((a) => [a.actionId, a]))
+  const getDetail = byId['k3wise.material.get-detail']
+  const save = byId['k3wise.material.save']
+
+  // read action is runnable (not gated); save (write) is gated/disabled, never enabled.
+  assert.equal(getDetail.operation, 'read')
+  assert.equal(getDetail.gated, false, 'read action is not gated')
+  assert.equal(getDetail.request.path, '/K3API/Material/GetDetail')
+  assert.equal(getDetail.request.inputs.body[0].source, 'record.FNumber')
+  assert.equal(save.operation, 'upsert')
+  assert.equal(save.gated, true, 'upsert (write) is always gated')
+  assert.equal(save.safety.requiresApproval, true)
+  // No inline values rode into the sample metadata (no embedded secrets).
+  assert.ok(!('value' in save.request.inputs.body[0]), 'sample inputs carry no inline value')
+
+  // enum-strict
+  assert.throws(
+    () => normalizeConnectorAction(baseAction({ operation: 'delete' })),
+    ConnectorActionContractValidationError,
+    'unknown operation rejected',
+  )
+
+  // relative-path only — no generic HTTP client / SSRF via metadata; and no query/
+  // fragment in the path (query/header/body go through inputs, not the endpoint path).
+  for (const bad of [
+    'http://evil.example/x',
+    '//evil.example/x',
+    'K3API/Material/GetDetail',
+    '\\\\host\\share',
+    '/K3API/Material/GetDetail?token=abc',
+    '/K3API/Material/GetDetail#frag',
+  ]) {
+    assert.throws(
+      () => normalizeConnectorAction(baseAction({ request: { method: 'POST', path: bad, inputs: {} } })),
+      ConnectorActionContractValidationError,
+      `path rejected: ${bad}`,
+    )
+  }
+
+  // no inline secret value on inputs (must use source/secretsRef)
+  assert.throws(
+    () => normalizeConnectorAction(baseAction({
+      request: { method: 'POST', path: '/x', inputs: { header: [{ name: 'Authorization', value: 'Bearer abc' }] } },
+    })),
+    ConnectorActionContractValidationError,
+    'inline input value rejected',
+  )
+
+  // write-gating: an upsert without requiresApproval cannot be silently enabled
+  assert.throws(
+    () => normalizeConnectorAction(baseAction({
+      operation: 'upsert',
+      output: { recordPath: 'R', successPath: 'S', errorPath: 'E' },
+      safety: { readOnly: false, allowBatch: false, maxRowsPreview: 1, requiresApproval: false },
+    })),
+    ConnectorActionContractValidationError,
+    'write op without requiresApproval rejected',
+  )
+  // ...and a write op cannot claim readOnly.
+  assert.throws(
+    () => normalizeConnectorAction(baseAction({
+      operation: 'upsert',
+      output: { recordPath: 'R', successPath: 'S', errorPath: 'E' },
+      safety: { readOnly: true, allowBatch: false, maxRowsPreview: 1, requiresApproval: true },
+    })),
+    ConnectorActionContractValidationError,
+    'write op cannot be readOnly',
+  )
+
+  // write-SET gating must NOT over-gate the no-write preview/export (advisor-caught)
+  assert.equal(normalizeConnectorAction(baseAction({ operation: 'preview' })).gated, false, 'preview not gated')
+  assert.equal(normalizeConnectorAction(baseAction({ operation: 'export' })).gated, false, 'export not gated')
+  assert.deepEqual([...WRITE_OPERATIONS], ['upsert'], 'write set is upsert only (Submit/Audit/BOM not modeled here)')
+
+  // non-write ops (read/preview/export) must declare readOnly:true — must not pose as mutating.
+  for (const op of ['read', 'preview', 'export']) {
+    assert.throws(
+      () => normalizeConnectorAction(baseAction({
+        operation: op,
+        safety: { readOnly: false, allowBatch: false, maxRowsPreview: 1, requiresApproval: false },
+      })),
+      ConnectorActionContractValidationError,
+      `non-write ${op} with readOnly:false rejected`,
+    )
+  }
+
+  // redaction self-check: a secret-shaped value in help is scrubbed, never stored raw
+  const withSecret = normalizeConnectorAction(baseAction({
+    help: { currentStep: 'connect via postgres://erp:S3cretPass@db/x', note: 'ok' },
+  }))
+  assert.ok(!JSON.stringify(withSecret.help).includes('S3cretPass'), 'secret-shaped value in help scrubbed')
+
+  console.log('connector-action-contracts.test.cjs OK')
+}
+
+main()

--- a/plugins/plugin-integration-core/lib/connector-action-contracts.cjs
+++ b/plugins/plugin-integration-core/lib/connector-action-contracts.cjs
@@ -1,0 +1,291 @@
+'use strict'
+
+// DF-T1A connector action metadata — a LATENT contract (not wired to any runtime).
+// A connector action is ONE safe, named operation exposed by a connector profile,
+// expressed as metadata around an EXISTING adapter method. This contract does NOT
+// authorize a generic HTTP client, user JavaScript, direct SQL, or a new connector
+// runtime; it only describes and gates. Mirrors provenance-contracts.cjs (#1882).
+
+const { sanitizeIntegrationPayload } = require('./payload-redaction.cjs')
+
+const CONNECTOR_ACTION_OPERATIONS = Object.freeze(['read', 'preview', 'upsert', 'export'])
+const CONNECTOR_ACTION_OPERATION_SET = new Set(CONNECTOR_ACTION_OPERATIONS)
+
+// Operations that MUTATE the target system. A write action can never be silently
+// enabled: it must carry requiresApproval and is always normalized `gated`. This is
+// the write SET (not "!== read"), so the no-write `preview`/`export` actions are not
+// over-gated. Submit/Audit/BOM are intentionally NOT modeled here — they remain
+// gated outside this contract.
+const WRITE_OPERATIONS = Object.freeze(['upsert'])
+const WRITE_OPERATION_SET = new Set(WRITE_OPERATIONS)
+
+const INPUT_GROUPS = Object.freeze(['path', 'query', 'header', 'body'])
+
+class ConnectorActionContractValidationError extends Error {
+  constructor(message, details = {}) {
+    super(message)
+    this.name = 'ConnectorActionContractValidationError'
+    this.details = details
+  }
+}
+
+function isPlainObject(value) {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) return false
+  const prototype = Object.getPrototypeOf(value)
+  return prototype === Object.prototype || prototype === null
+}
+
+function requiredString(value, field) {
+  if (typeof value !== 'string' || value.trim().length === 0) {
+    throw new ConnectorActionContractValidationError(`${field} is required`, { field })
+  }
+  return value.trim()
+}
+
+function optionalString(value, field) {
+  if (value === undefined || value === null) return undefined
+  if (typeof value !== 'string') {
+    throw new ConnectorActionContractValidationError(`${field} must be a string`, { field })
+  }
+  return value.trim()
+}
+
+function requiredBoolean(value, field) {
+  if (typeof value !== 'boolean') {
+    throw new ConnectorActionContractValidationError(`${field} must be a boolean`, { field })
+  }
+  return value
+}
+
+function normalizeOperation(value) {
+  const operation = requiredString(value, 'operation')
+  if (!CONNECTOR_ACTION_OPERATION_SET.has(operation)) {
+    throw new ConnectorActionContractValidationError(
+      `operation must be one of ${CONNECTOR_ACTION_OPERATIONS.join(', ')}`,
+      { field: 'operation', value: operation },
+    )
+  }
+  return operation
+}
+
+// Relative path only — reject scheme (`http:`), protocol-relative (`//host`), and
+// backslashes, and require a leading `/`. Blocks a generic HTTP client / SSRF via
+// action metadata. Kept standalone so the contract carries no adapter dependency
+// (mirrors the adapter's assertRelativePath rule).
+function normalizeRelativePath(value) {
+  const path = requiredString(value, 'request.path')
+  const hasScheme = /^[A-Za-z][A-Za-z0-9+.-]*:/.test(path)
+  if (hasScheme || path.startsWith('//') || path.includes('\\')) {
+    throw new ConnectorActionContractValidationError(
+      'request.path must be relative to the connector base URL (no scheme/host/backslash)',
+      { field: 'request.path', value: path },
+    )
+  }
+  // No query (?) or fragment (#) in the path — query/header/body must go through
+  // `inputs` (structured + secret-safe), not be smuggled into the endpoint path.
+  if (path.includes('?') || path.includes('#')) {
+    throw new ConnectorActionContractValidationError(
+      'request.path must not contain a query (?) or fragment (#); use request.inputs (query/header/body) instead',
+      { field: 'request.path', value: path },
+    )
+  }
+  if (!path.startsWith('/')) {
+    throw new ConnectorActionContractValidationError('request.path must start with "/"', {
+      field: 'request.path',
+      value: path,
+    })
+  }
+  return path
+}
+
+// One business input. References data by `source` (e.g. `record.FNumber`); never an
+// inline literal. An inline `value` is rejected so secrets/tokens can't be embedded
+// in action metadata — secret values come from the connector profile's secretsRef
+// at runtime, not from the template.
+function normalizeInput(input, group, index) {
+  const at = `request.inputs.${group}[${index}]`
+  if (!isPlainObject(input)) {
+    throw new ConnectorActionContractValidationError(`${at} must be an object`, { field: at })
+  }
+  if ('value' in input) {
+    throw new ConnectorActionContractValidationError(
+      `${at} must not carry an inline value (use source/secretsRef; no secrets in metadata)`,
+      { field: `${at}.value` },
+    )
+  }
+  const normalized = { name: requiredString(input.name, `${at}.name`) }
+  const source = optionalString(input.source, `${at}.source`)
+  if (source !== undefined) normalized.source = source
+  if (input.required !== undefined) {
+    normalized.required = requiredBoolean(input.required, `${at}.required`)
+  }
+  return normalized
+}
+
+function normalizeInputs(value) {
+  const inputs = value === undefined ? {} : value
+  if (!isPlainObject(inputs)) {
+    throw new ConnectorActionContractValidationError('request.inputs must be an object', { field: 'request.inputs' })
+  }
+  const out = {}
+  for (const group of INPUT_GROUPS) {
+    const list = inputs[group] === undefined ? [] : inputs[group]
+    if (!Array.isArray(list)) {
+      throw new ConnectorActionContractValidationError(`request.inputs.${group} must be an array`, {
+        field: `request.inputs.${group}`,
+      })
+    }
+    out[group] = list.map((input, index) => normalizeInput(input, group, index))
+  }
+  return out
+}
+
+function normalizeRequest(value) {
+  if (!isPlainObject(value)) {
+    throw new ConnectorActionContractValidationError('request must be an object', { field: 'request' })
+  }
+  return {
+    method: requiredString(value.method, 'request.method').toUpperCase(),
+    path: normalizeRelativePath(value.path),
+    inputs: normalizeInputs(value.inputs),
+  }
+}
+
+function normalizeOutput(value) {
+  if (!isPlainObject(value)) {
+    throw new ConnectorActionContractValidationError('output must be an object', { field: 'output' })
+  }
+  const out = {
+    recordPath: requiredString(value.recordPath, 'output.recordPath'),
+    successPath: requiredString(value.successPath, 'output.successPath'),
+    errorPath: requiredString(value.errorPath, 'output.errorPath'),
+  }
+  if (value.successValue !== undefined) out.successValue = value.successValue
+  return out
+}
+
+function normalizeSafety(value, operation) {
+  if (!isPlainObject(value)) {
+    throw new ConnectorActionContractValidationError('safety must be an object', { field: 'safety' })
+  }
+  const readOnly = requiredBoolean(value.readOnly, 'safety.readOnly')
+  const allowBatch = requiredBoolean(value.allowBatch, 'safety.allowBatch')
+  if (!Number.isInteger(value.maxRowsPreview) || value.maxRowsPreview < 0) {
+    throw new ConnectorActionContractValidationError('safety.maxRowsPreview must be a non-negative integer', {
+      field: 'safety.maxRowsPreview',
+    })
+  }
+  const requiresApproval = requiredBoolean(value.requiresApproval, 'safety.requiresApproval')
+  const isWrite = WRITE_OPERATION_SET.has(operation)
+  // A write action (target mutation) can never be silently enabled.
+  if (isWrite && !requiresApproval) {
+    throw new ConnectorActionContractValidationError(
+      `write operation "${operation}" must set safety.requiresApproval=true (write actions stay gated/disabled)`,
+      { field: 'safety.requiresApproval', operation },
+    )
+  }
+  if (isWrite && readOnly) {
+    throw new ConnectorActionContractValidationError(
+      `write operation "${operation}" cannot be readOnly`,
+      { field: 'safety.readOnly', operation },
+    )
+  }
+  // A non-write op (read/preview/export) must declare readOnly:true — it must not
+  // pose as mutating; a non-readOnly non-write action is a contract error.
+  if (!isWrite && !readOnly) {
+    throw new ConnectorActionContractValidationError(
+      `non-write operation "${operation}" must set safety.readOnly=true`,
+      { field: 'safety.readOnly', operation },
+    )
+  }
+  return { readOnly, allowBatch, maxRowsPreview: value.maxRowsPreview, requiresApproval }
+}
+
+function normalizeHelp(value) {
+  if (value === undefined || value === null) return undefined
+  if (!isPlainObject(value)) {
+    throw new ConnectorActionContractValidationError('help must be a plain object', { field: 'help' })
+  }
+  // Operator-facing free text — scrub through the shared redactor so no secret-shaped
+  // value can ride along inside action metadata.
+  return sanitizeIntegrationPayload(value)
+}
+
+function normalizeConnectorAction(input) {
+  if (!isPlainObject(input)) {
+    throw new ConnectorActionContractValidationError('input must be a plain object')
+  }
+  const operation = normalizeOperation(input.operation)
+  const safety = normalizeSafety(input.safety, operation)
+  const action = {
+    actionId: requiredString(input.actionId, 'actionId'),
+    connectorKind: requiredString(input.connectorKind, 'connectorKind'),
+    operation,
+    request: normalizeRequest(input.request),
+    output: normalizeOutput(input.output),
+    safety,
+    // Derived: a write op OR an explicit approval requirement is gated. The UI must
+    // render a gated action disabled until its own approval gate is satisfied;
+    // DF-T1A only annotates — it never enables a write.
+    gated: WRITE_OPERATION_SET.has(operation) || safety.requiresApproval === true,
+  }
+  const label = optionalString(input.label, 'label')
+  if (label !== undefined) action.label = label
+  const help = normalizeHelp(input.help)
+  if (help !== undefined) action.help = help
+  return action
+}
+
+// First built-in sample: the EXISTING K3 WISE WebAPI Material adapter operations as
+// action metadata. get-detail (read) is runnable; save (upsert) is gated/disabled —
+// Save-only/write stays behind its own approval, NOT unlocked here. Output paths
+// match the adapter's real K3 WISE envelope (StatusCode/Message; save success via
+// Result.ResponseStatus.IsSuccess).
+const K3_WISE_MATERIAL_ACTIONS = Object.freeze([
+  normalizeConnectorAction({
+    actionId: 'k3wise.material.get-detail',
+    connectorKind: 'erp:k3-wise-webapi',
+    operation: 'read',
+    label: 'Material GetDetail',
+    request: {
+      method: 'POST',
+      path: '/K3API/Material/GetDetail',
+      inputs: { body: [{ name: 'Number', source: 'record.FNumber', required: true }] },
+    },
+    output: { recordPath: 'Data[0].Data', successPath: 'StatusCode', successValue: 200, errorPath: 'Message' },
+    safety: { readOnly: true, allowBatch: false, maxRowsPreview: 1, requiresApproval: false },
+  }),
+  normalizeConnectorAction({
+    actionId: 'k3wise.material.save',
+    connectorKind: 'erp:k3-wise-webapi',
+    operation: 'upsert',
+    label: 'Material Save (Save-only — gated)',
+    request: {
+      method: 'POST',
+      path: '/K3API/Material/Save',
+      inputs: { body: [{ name: 'Model', source: 'record', required: true }] },
+    },
+    output: {
+      recordPath: 'Result.ResponseStatus.SuccessEntitys',
+      successPath: 'Result.ResponseStatus.IsSuccess',
+      successValue: true,
+      errorPath: 'Message',
+    },
+    safety: { readOnly: false, allowBatch: false, maxRowsPreview: 1, requiresApproval: true },
+  }),
+])
+
+module.exports = {
+  CONNECTOR_ACTION_OPERATIONS,
+  WRITE_OPERATIONS,
+  ConnectorActionContractValidationError,
+  normalizeConnectorAction,
+  K3_WISE_MATERIAL_ACTIONS,
+  __internals: {
+    isPlainObject,
+    normalizeOperation,
+    normalizeRelativePath,
+    normalizeInputs,
+    normalizeSafety,
+  },
+}

--- a/plugins/plugin-integration-core/package.json
+++ b/plugins/plugin-integration-core/package.json
@@ -6,7 +6,7 @@
   "license": "UNLICENSED",
   "private": true,
   "scripts": {
-    "test": "node __tests__/plugin-runtime-smoke.test.cjs && node --import tsx __tests__/host-loader-smoke.test.mjs && node __tests__/credential-store.test.cjs && node __tests__/db.test.cjs && node __tests__/external-systems.test.cjs && node __tests__/adapter-contracts.test.cjs && node __tests__/provenance-contracts.test.cjs && node __tests__/http-adapter.test.cjs && node __tests__/bridge-agent-readonly-adapter.test.cjs && node __tests__/metasheet-staging-source-adapter.test.cjs && node __tests__/metasheet-multitable-target-adapter.test.cjs && node __tests__/plm-yuantus-wrapper.test.cjs && node __tests__/pipelines.test.cjs && node __tests__/transform-validator.test.cjs && node __tests__/runner-support.test.cjs && node __tests__/payload-redaction.test.cjs && node __tests__/pipeline-runner.test.cjs && node __tests__/df-n2-2c-provenance-read.test.cjs && node __tests__/http-routes.test.cjs && node __tests__/http-routes-plm-k3wise-poc.test.cjs && node __tests__/k3-wise-adapters.test.cjs && node __tests__/erp-feedback.test.cjs && node __tests__/e2e-plm-k3wise-writeback.test.cjs && node __tests__/staging-installer.test.cjs && node __tests__/migration-sql.test.cjs",
+    "test": "node __tests__/plugin-runtime-smoke.test.cjs && node --import tsx __tests__/host-loader-smoke.test.mjs && node __tests__/credential-store.test.cjs && node __tests__/db.test.cjs && node __tests__/external-systems.test.cjs && node __tests__/adapter-contracts.test.cjs && node __tests__/provenance-contracts.test.cjs && node __tests__/connector-action-contracts.test.cjs && node __tests__/http-adapter.test.cjs && node __tests__/bridge-agent-readonly-adapter.test.cjs && node __tests__/metasheet-staging-source-adapter.test.cjs && node __tests__/metasheet-multitable-target-adapter.test.cjs && node __tests__/plm-yuantus-wrapper.test.cjs && node __tests__/pipelines.test.cjs && node __tests__/transform-validator.test.cjs && node __tests__/runner-support.test.cjs && node __tests__/payload-redaction.test.cjs && node __tests__/pipeline-runner.test.cjs && node __tests__/df-n2-2c-provenance-read.test.cjs && node __tests__/http-routes.test.cjs && node __tests__/http-routes-plm-k3wise-poc.test.cjs && node __tests__/k3-wise-adapters.test.cjs && node __tests__/erp-feedback.test.cjs && node __tests__/e2e-plm-k3wise-writeback.test.cjs && node __tests__/staging-installer.test.cjs && node __tests__/migration-sql.test.cjs",
     "test:runtime": "node __tests__/plugin-runtime-smoke.test.cjs",
     "test:host-loader": "node --import tsx __tests__/host-loader-smoke.test.mjs",
     "test:credential": "node __tests__/credential-store.test.cjs",
@@ -14,6 +14,7 @@
     "test:external-systems": "node __tests__/external-systems.test.cjs",
     "test:adapter-contracts": "node __tests__/adapter-contracts.test.cjs",
     "test:provenance-contracts": "node __tests__/provenance-contracts.test.cjs",
+    "test:connector-action-contracts": "node __tests__/connector-action-contracts.test.cjs",
     "test:http-adapter": "node __tests__/http-adapter.test.cjs",
     "test:bridge-agent-readonly": "node __tests__/bridge-agent-readonly-adapter.test.cjs",
     "test:metasheet-staging-source": "node __tests__/metasheet-staging-source-adapter.test.cjs",


### PR DESCRIPTION
First DF-T slice after DF-T1-0/T1/T1.5: a **latent** connector-action-metadata contract (mirrors #1882 `provenance-contracts`) — describes + gates named actions around **existing** adapter methods. **Not wired to any runtime / route / HTTP client.**

## Contract (`lib/connector-action-contracts.cjs`)
`normalizeConnectorAction` → `actionId`/`connectorKind`/`operation`(enum)/`request{method,path,inputs{path,query,header,body}}`/`output`/`safety`/`gated`/`help`, with hard invariants:
- **enum-strict** operation (`read`/`preview`/`upsert`/`export`);
- **relative-path only** (reject scheme / `//host` / backslash) → no generic HTTP client / SSRF;
- **no inline secrets** — inputs use `source`/secretsRef, never an inline `value`; `help` scrubbed via the shared redactor;
- **write-gating** on the write **set** `{upsert}` (not `!== 'read'`, so `preview`/`export` aren't over-gated): a write op must `requiresApproval:true`, can't be `readOnly`, and is derived `gated:true`.

## First K3 sample (`K3_WISE_MATERIAL_ACTIONS`)
The existing K3 WISE Material ops as metadata: `material.get-detail` (read, **runnable**) + `material.save` (upsert, **gated/disabled** — Save-only stays behind its own approval). Output paths match the adapter's real envelope.

## OpenAPI + tests
`ConnectorAction`/`ConnectorActionInput`/`ConnectorActionOperation` (parity-locked, **no path** — #1882 precedent) + `dist/` regenerated. Tests: OpenAPI parity + all four invariants + **over-gating guard, negative-controlled** (buggy `!== 'read'` predicate → the preview-gating assertion fails). Neighbors (provenance / adapter / redaction / k3-wise) re-run green.

## Boundaries (latent only)
No runtime wiring · no generic HTTP client · no user JS/SQL · **no Submit/Audit/BOM/multi-record** · write actions gated/disabled only. **Leave for review — no auto-merge.** DF-T2 (authoring UI consuming this contract) is the next, separate opt-in.

Verification: `docs/development/data-factory-df-t1a-connector-action-metadata-verification-20260528.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)