### PR TITLE
feat(attendance): tag fixed-schedule assignment provenance

### DIFF
--- a/docs/development/attendance-group-admin-ux-fixed-schedule-provenance-fsd2-verification-20260528.md
+++ b/docs/development/attendance-group-admin-ux-fixed-schedule-provenance-fsd2-verification-20260528.md
@@ -1,0 +1,63 @@
+# Attendance Group Fixed-Schedule Provenance FS-D2 Verification - 2026-05-28
+
+## Scope
+
+FS-D2 starts populating provenance metadata for rows newly created by the attendance-group fixed-schedule apply route.
+
+This follows:
+
+- `attendance-group-admin-ux-fixed-schedule-managed-provenance-design-20260528.md`
+- `attendance-group-admin-ux-fixed-schedule-provenance-fsd1-verification-20260528.md`
+
+## Delivered Behavior
+
+Newly inserted `attendance_shift_assignments` rows from group fixed-schedule apply now carry:
+
+- `producer_type = attendance_group_fixed_schedule`
+- `producer_ref_id = groupId`
+- `producer_key = attendance_group_fixed_schedule:{groupId}:{shiftId}:{startDate}:{endDate-or-null}`
+- `producer_run_id = one UUID shared across all rows created by the same apply run`
+
+The existing FS-C preview/apply classifier remains the source of truth:
+
+- exact active matches stay `skipped`;
+- overlapping non-exact rows stay `blockingConflicts`;
+- only `wouldCreate[]` rows are inserted and tagged.
+
+## Boundaries Held
+
+- No migration: FS-D1 already added the nullable columns.
+- No route or API shape change beyond returned assignment rows now reflecting populated metadata.
+- No UI change.
+- No rebuild/clear operation.
+- No soft-deactivation.
+- No claiming or mutating existing exact-match rows.
+- No second schedule fact table.
+
+## Verification
+
+Commands run:
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-scheduling-assignment-conflict.test.ts --watch=false
+```
+
+Results:
+
+- `node --check`: PASS
+- `attendance-scheduling-assignment-conflict.test.ts`: PASS, 14/14
+
+New/updated assertions:
+
+- stable finite-window and open-ended `producer_key` helper output;
+- apply insert SQL includes all four producer columns;
+- inserted rows map back with populated `producerType`, `producerRefId`, `producerKey`, and `producerRunId`;
+- one apply run reuses a single `producer_run_id` across multiple created rows;
+- exact-match skipped rows are not updated or retroactively claimed;
+- open-ended schedules use `...:{startDate}:null` in the producer key;
+- blocking conflicts still produce zero inserts.
+
+## Deferred
+
+FS-D3 remains separate: managed rebuild/clear and soft-deactivation by `producer_key` are not implemented here.

--- a/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
@@ -164,6 +164,27 @@ describe('attendance scheduling assignment conflict guard', () => {
     expect(provenanceMigrationSource).not.toContain("createTable('attendance_schedule")
   })
 
+  it('builds stable fixed-schedule producer keys for finite and open-ended windows', () => {
+    const input = {
+      orgId: 'org-a',
+      groupId: '11111111-1111-4111-8111-111111111111',
+      shiftId: '22222222-2222-4222-8222-222222222222',
+      startDate: '2026-06-01',
+      endDate: '2026-06-30',
+    }
+
+    expect(helpers.ATTENDANCE_GROUP_FIXED_SCHEDULE_PRODUCER_TYPE).toBe('attendance_group_fixed_schedule')
+    expect(helpers.buildAttendanceGroupFixedScheduleProducerKey(input)).toBe(
+      'attendance_group_fixed_schedule:11111111-1111-4111-8111-111111111111:22222222-2222-4222-8222-222222222222:2026-06-01:2026-06-30',
+    )
+    expect(helpers.buildAttendanceGroupFixedScheduleProducerKey({
+      ...input,
+      endDate: null,
+    })).toBe(
+      'attendance_group_fixed_schedule:11111111-1111-4111-8111-111111111111:22222222-2222-4222-8222-222222222222:2026-06-01:null',
+    )
+  })
+
   it('builds fixed-schedule group previews from the complete member set without writes', async () => {
     const db = {
       query: vi.fn()
@@ -301,35 +322,45 @@ describe('attendance scheduling assignment conflict guard', () => {
   })
 
   it('applies fixed-schedule group plans by locking users, skipping exact matches, and inserting only missing rows', async () => {
+    const pendingRows = [
+      [{ id: 'group-a', org_id: 'org-a', name: 'Operations', timezone: 'UTC' }],
+      [{ id: 'shift-a', org_id: 'org-a', name: 'Day shift', timezone: 'UTC' }],
+      [{ user_id: 'user-create' }, { user_id: 'user-skip' }],
+      [],
+      [],
+      [
+        {
+          id: 'assignment-skip',
+          user_id: 'user-skip',
+          shift_id: 'shift-a',
+          start_date: '2026-06-01',
+          end_date: '2026-06-30',
+          kind: 'shift',
+        },
+      ],
+      [],
+    ]
     const db = {
-      query: vi.fn()
-        .mockResolvedValueOnce([{ id: 'group-a', org_id: 'org-a', name: 'Operations', timezone: 'UTC' }])
-        .mockResolvedValueOnce([{ id: 'shift-a', org_id: 'org-a', name: 'Day shift', timezone: 'UTC' }])
-        .mockResolvedValueOnce([{ user_id: 'user-create' }, { user_id: 'user-skip' }])
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([
-          {
-            id: 'assignment-skip',
-            user_id: 'user-skip',
-            shift_id: 'shift-a',
-            start_date: '2026-06-01',
-            end_date: '2026-06-30',
-            kind: 'shift',
-          },
-        ])
-        .mockResolvedValueOnce([])
-        .mockResolvedValueOnce([
-          {
-            id: 'assignment-created',
-            org_id: 'org-a',
-            user_id: 'user-create',
-            shift_id: 'shift-a',
-            start_date: '2026-06-01',
-            end_date: '2026-06-30',
-            is_active: true,
-          },
-        ]),
+      query: vi.fn(async (sql: string, params: any[] = []) => {
+        if (/\bINSERT INTO attendance_shift_assignments\b/i.test(String(sql))) {
+          return [
+            {
+              id: 'assignment-created',
+              org_id: params[1],
+              user_id: params[2],
+              shift_id: params[3],
+              start_date: params[4],
+              end_date: params[5],
+              is_active: true,
+              producer_type: params[6],
+              producer_ref_id: params[7],
+              producer_key: params[8],
+              producer_run_id: params[9],
+            },
+          ]
+        }
+        return pendingRows.shift() ?? []
+      }),
     }
 
     const result = await helpers.applyAttendanceGroupFixedSchedule(db, {
@@ -353,12 +384,139 @@ describe('attendance scheduling assignment conflict guard', () => {
         startDate: '2026-06-01',
         endDate: '2026-06-30',
         isActive: true,
+        producerType: 'attendance_group_fixed_schedule',
+        producerRefId: 'group-a',
+        producerKey: 'attendance_group_fixed_schedule:group-a:shift-a:2026-06-01:2026-06-30',
       }),
     ])
 
     const queries = db.query.mock.calls.map(call => String(call[0]))
+    const insertCalls = db.query.mock.calls.filter(call => /\bINSERT INTO attendance_shift_assignments\b/i.test(String(call[0])))
     expect(queries.filter(sql => sql.includes('pg_advisory_xact_lock'))).toHaveLength(2)
-    expect(queries.filter(sql => /\bINSERT INTO attendance_shift_assignments\b/i.test(sql))).toHaveLength(1)
+    expect(insertCalls).toHaveLength(1)
+    expect(insertCalls[0][0]).toContain('producer_type, producer_ref_id, producer_key, producer_run_id')
+    expect(insertCalls[0][1]).toEqual(expect.arrayContaining([
+      'attendance_group_fixed_schedule',
+      'group-a',
+      'attendance_group_fixed_schedule:group-a:shift-a:2026-06-01:2026-06-30',
+    ]))
+    expect(insertCalls[0][1][9]).toMatch(/^[0-9a-f-]{36}$/i)
+    expect(queries.join('\n')).not.toMatch(/\bUPDATE attendance_shift_assignments\b/i)
+  })
+
+  it('uses one producer run id across multiple fixed-schedule creates without mutating skips', async () => {
+    const pendingRows = [
+      [{ id: 'group-a', org_id: 'org-a', name: 'Operations', timezone: 'UTC' }],
+      [{ id: 'shift-a', org_id: 'org-a', name: 'Day shift', timezone: 'UTC' }],
+      [{ user_id: 'user-a' }, { user_id: 'user-b' }, { user_id: 'user-skip' }],
+      [],
+      [],
+      [],
+      [
+        {
+          id: 'assignment-skip',
+          user_id: 'user-skip',
+          shift_id: 'shift-a',
+          start_date: '2026-06-01',
+          end_date: '2026-06-30',
+          kind: 'shift',
+        },
+      ],
+      [],
+    ]
+    const db = {
+      query: vi.fn(async (sql: string, params: any[] = []) => {
+        if (/\bINSERT INTO attendance_shift_assignments\b/i.test(String(sql))) {
+          return [
+            {
+              id: params[0],
+              org_id: params[1],
+              user_id: params[2],
+              shift_id: params[3],
+              start_date: params[4],
+              end_date: params[5],
+              is_active: true,
+              producer_type: params[6],
+              producer_ref_id: params[7],
+              producer_key: params[8],
+              producer_run_id: params[9],
+            },
+          ]
+        }
+        return pendingRows.shift() ?? []
+      }),
+    }
+
+    const result = await helpers.applyAttendanceGroupFixedSchedule(db, {
+      orgId: 'org-a',
+      groupId: 'group-a',
+      shiftId: 'shift-a',
+      startDate: '2026-06-01',
+      endDate: '2026-06-30',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.data.created.map((item: any) => item.userId)).toEqual(['user-a', 'user-b'])
+    expect(result.data.skipped.map((item: any) => item.userId)).toEqual(['user-skip'])
+    expect(new Set(result.data.created.map((item: any) => item.producerRunId))).toHaveLength(1)
+    expect(new Set(result.data.created.map((item: any) => item.producerKey))).toEqual(new Set([
+      'attendance_group_fixed_schedule:group-a:shift-a:2026-06-01:2026-06-30',
+    ]))
+
+    const queries = db.query.mock.calls.map(call => String(call[0]))
+    expect(queries.filter(sql => /\bINSERT INTO attendance_shift_assignments\b/i.test(sql))).toHaveLength(2)
+    expect(queries.join('\n')).not.toMatch(/\bUPDATE attendance_shift_assignments\b/i)
+  })
+
+  it('leaves open-ended fixed-schedule creates under an explicit null-ended producer key', async () => {
+    const pendingRows = [
+      [{ id: 'group-a', org_id: 'org-a', name: 'Operations', timezone: 'UTC' }],
+      [{ id: 'shift-a', org_id: 'org-a', name: 'Day shift', timezone: 'UTC' }],
+      [{ user_id: 'user-a' }],
+      [],
+      [],
+      [],
+      [],
+    ]
+    const db = {
+      query: vi.fn(async (sql: string, params: any[] = []) => {
+        if (/\bINSERT INTO attendance_shift_assignments\b/i.test(String(sql))) {
+          return [
+            {
+              id: params[0],
+              org_id: params[1],
+              user_id: params[2],
+              shift_id: params[3],
+              start_date: params[4],
+              end_date: params[5],
+              is_active: true,
+              producer_type: params[6],
+              producer_ref_id: params[7],
+              producer_key: params[8],
+              producer_run_id: params[9],
+            },
+          ]
+        }
+        return pendingRows.shift() ?? []
+      }),
+    }
+
+    const result = await helpers.applyAttendanceGroupFixedSchedule(db, {
+      orgId: 'org-a',
+      groupId: 'group-a',
+      shiftId: 'shift-a',
+      startDate: '2026-06-01',
+      endDate: null,
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.data.created).toEqual([
+      expect.objectContaining({
+        userId: 'user-a',
+        endDate: null,
+        producerKey: 'attendance_group_fixed_schedule:group-a:shift-a:2026-06-01:null',
+      }),
+    ])
   })
 
   it('refuses fixed-schedule group applies without inserting when a blocking conflict exists', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8677,6 +8677,28 @@ function mapAttendanceGroupFixedSchedulePreviewCandidate(userId, input) {
   }
 }
 
+const ATTENDANCE_GROUP_FIXED_SCHEDULE_PRODUCER_TYPE = 'attendance_group_fixed_schedule'
+
+function buildAttendanceGroupFixedScheduleProducerKey(input) {
+  const endDate = normalizeAttendanceScheduleAssignmentEndDate(input.endDate)
+  return [
+    ATTENDANCE_GROUP_FIXED_SCHEDULE_PRODUCER_TYPE,
+    input.groupId,
+    input.shiftId,
+    input.startDate,
+    endDate ?? 'null',
+  ].join(':')
+}
+
+function buildAttendanceGroupFixedScheduleProducerMetadata(input, producerRunId) {
+  return {
+    producerType: ATTENDANCE_GROUP_FIXED_SCHEDULE_PRODUCER_TYPE,
+    producerRefId: input.groupId,
+    producerKey: buildAttendanceGroupFixedScheduleProducerKey(input),
+    producerRunId,
+  }
+}
+
 function mapAttendanceGroupFixedScheduleSkipped(row, draft) {
   return {
     assignmentId: row.id,
@@ -8859,11 +8881,12 @@ async function applyAttendanceGroupFixedSchedule(db, input) {
   }
 
   const created = []
+  const producerMetadata = buildAttendanceGroupFixedScheduleProducerMetadata(input, randomUUID())
   for (const item of plan.wouldCreate) {
     const rows = await db.query(
       `INSERT INTO attendance_shift_assignments
-       (id, org_id, user_id, shift_id, start_date, end_date, is_active)
-       VALUES ($1, $2, $3, $4, $5, $6, true)
+       (id, org_id, user_id, shift_id, start_date, end_date, is_active, producer_type, producer_ref_id, producer_key, producer_run_id)
+       VALUES ($1, $2, $3, $4, $5, $6, true, $7, $8, $9, $10)
        RETURNING *`,
       [
         randomUUID(),
@@ -8872,6 +8895,10 @@ async function applyAttendanceGroupFixedSchedule(db, input) {
         item.shiftId,
         item.startDate,
         item.endDate,
+        producerMetadata.producerType,
+        producerMetadata.producerRefId,
+        producerMetadata.producerKey,
+        producerMetadata.producerRunId,
       ]
     )
     if (rows[0]) created.push(mapAssignmentRow(rows[0]))
@@ -14525,6 +14552,9 @@ module.exports = {
     buildAttendanceGroupFixedSchedulePlan,
     buildAttendanceGroupFixedSchedulePreview,
     applyAttendanceGroupFixedSchedule,
+    ATTENDANCE_GROUP_FIXED_SCHEDULE_PRODUCER_TYPE,
+    buildAttendanceGroupFixedScheduleProducerKey,
+    buildAttendanceGroupFixedScheduleProducerMetadata,
     acquireAttendanceScheduleAssignmentLock,
     getAttendanceScheduleAssignmentConflictMessage,
     getAttendanceScheduleAssignmentConflictType,


### PR DESCRIPTION
## Summary

- tag newly-created group fixed-schedule assignment rows with FS-D provenance metadata
- add stable producer key helpers for `attendance_group_fixed_schedule:{groupId}:{shiftId}:{startDate}:{endDate-or-null}`
- lock tests for finite/open-ended keys, shared `producer_run_id`, insert metadata, blocking zero-write, and no retroactive claiming of exact-match skipped rows
- add FS-D2 verification notes

## Boundaries

- no migration: FS-D1 already added nullable provenance columns
- no UI, route, permission, or schema-surface change
- no rebuild/clear or soft-deactivation
- no claiming/mutating existing exact-match rows
- no second schedule fact table

## Verification

- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-scheduling-assignment-conflict.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `git diff --check`
