### PR TITLE
fix(after-sales): gate runtime admin on manifest capability

### DIFF
--- a/apps/web/src/views/AfterSalesView.vue
+++ b/apps/web/src/views/AfterSalesView.vue
@@ -2114,6 +2114,9 @@ import { apiFetch } from '../utils/api'
 interface AfterSalesManifest {
   id: string
   displayName: string
+  capabilities?: {
+    runtimeAdmin?: boolean
+  }
   platformDependencies: string[]
   objects: Array<{ id: string; name: string; backing: string }>
   workflows: Array<{ id: string; name: string }>
@@ -2656,9 +2659,7 @@ const createdObjectLabels = computed(() => current.value.installResult?.createdO
 const createdViewLabels = computed(() => current.value.installResult?.createdViews ?? [])
 const isInstalled = computed(() => current.value.status === 'installed' || current.value.status === 'partial')
 const isDegraded = computed(() => current.value.status === 'partial' || current.value.status === 'failed')
-const hasRuntimeAdminSupport = computed(
-  () => Array.isArray(manifest.value?.workflows) && manifest.value.workflows.some((workflow) => workflow && workflow.id === 'sla-watcher'),
-)
+const hasRuntimeAdminSupport = computed(() => manifest.value?.capabilities?.runtimeAdmin === true)
 const showRuntimeAdminSection = computed(
   () => isInstalled.value && hasRuntimeAdminSupport.value && !runtimeAdminAccessDenied.value,
 )

--- a/apps/web/tests/AfterSalesView.spec.ts
+++ b/apps/web/tests/AfterSalesView.spec.ts
@@ -1466,20 +1466,16 @@ describe('AfterSalesView', () => {
     await waitForText(container!, 'Requested refund for AF-001')
   })
 
-  it('renders runtime admin controls when the manifest exposes the runtime-admin workflow', async () => {
+  it('renders runtime admin controls when the manifest exposes the runtime-admin capability', async () => {
     apiFetchMock.mockImplementation(async (path: string) => {
       if (path === '/api/after-sales/app-manifest') {
         return createResponse({
           id: 'after-sales-default',
           displayName: 'After Sales',
+          capabilities: { runtimeAdmin: true },
           platformDependencies: ['core-backend'],
           objects: [],
-          workflows: [
-            { id: 'ticket-triage', name: 'Ticket Triage' },
-            { id: 'sla-watcher', name: 'SLA Watcher' },
-            { id: 'refund-approval', name: 'Refund Approval' },
-            { id: 'service-record-notify', name: 'Service Record Notification' },
-          ],
+          workflows: [],
         })
       }
 
@@ -1550,7 +1546,7 @@ describe('AfterSalesView', () => {
 
     expect(container?.querySelector('#after-sales-runtime-admin')).not.toBeNull()
     expect(container?.textContent).toContain('Default automation rules')
-    expect(container?.textContent).toContain('SLA Watcher')
+    expect(container?.textContent).toContain('SLA watcher')
     expect(container?.textContent).toContain('refundAmount role matrix')
   })
 
@@ -1560,6 +1556,7 @@ describe('AfterSalesView', () => {
         return createResponse({
           id: 'after-sales-default',
           displayName: 'After Sales',
+          capabilities: { runtimeAdmin: true },
           platformDependencies: ['core-backend'],
           objects: [],
           workflows: [
@@ -1643,6 +1640,7 @@ describe('AfterSalesView', () => {
         return createResponse({
           id: 'after-sales-default',
           displayName: 'After Sales',
+          capabilities: { runtimeAdmin: true },
           platformDependencies: ['core-backend'],
           objects: [],
           workflows: [
@@ -1770,6 +1768,7 @@ describe('AfterSalesView', () => {
         return createResponse({
           id: 'after-sales-default',
           displayName: 'After Sales',
+          capabilities: { runtimeAdmin: true },
           platformDependencies: ['core-backend'],
           objects: [],
           workflows: [
@@ -1871,6 +1870,7 @@ describe('AfterSalesView', () => {
         return createResponse({
           id: 'after-sales-default',
           displayName: 'After Sales',
+          capabilities: { runtimeAdmin: true },
           platformDependencies: ['core-backend'],
           objects: [],
           workflows: [
@@ -2055,6 +2055,7 @@ describe('AfterSalesView', () => {
         return createResponse({
           id: 'after-sales-default',
           displayName: 'After Sales',
+          capabilities: { runtimeAdmin: true },
           platformDependencies: ['core-backend'],
           objects: [],
           workflows: [
@@ -2225,6 +2226,7 @@ describe('AfterSalesView', () => {
         return createResponse({
           id: 'after-sales-default',
           displayName: 'After Sales',
+          capabilities: { runtimeAdmin: true },
           platformDependencies: ['core-backend'],
           objects: [],
           workflows: [

--- a/packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
+++ b/packages/core-backend/tests/unit/after-sales-plugin-routes.test.ts
@@ -887,6 +887,24 @@ describe('plugin-after-sales routes', () => {
     await plugin.activate(setup.context)
   })
 
+  it('exposes runtime admin as an explicit app-manifest capability', async () => {
+    const handler = routes.get('GET /api/after-sales/app-manifest')
+    const res = new FakeResponse()
+
+    await handler?.({}, res)
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: {
+        id: 'after-sales',
+        capabilities: {
+          runtimeAdmin: true,
+        },
+      },
+    })
+  })
+
   it('returns 401 for current when user is missing', async () => {
     const handler = routes.get('GET /api/after-sales/projects/current')
     const res = new FakeResponse()

--- a/plugins/plugin-after-sales/app.manifest.json
+++ b/plugins/plugin-after-sales/app.manifest.json
@@ -15,6 +15,9 @@
       "templateId": "after-sales-default"
     }
   },
+  "capabilities": {
+    "runtimeAdmin": true
+  },
   "platformDependencies": [
     "auth",
     "rbac",


### PR DESCRIPTION
## Summary
- add an explicit app-manifest capabilities.runtimeAdmin flag for the after-sales app
- gate AfterSalesView runtime-admin UI on that capability instead of inferring support from the sla-watcher workflow id
- update runtime-admin UI tests and add backend manifest coverage for the new capability

## Context
- Refs #790. The part-item vertical slice described there is already present on current main; this PR handles the remaining runtime-admin capability-contract backlog point without touching tenant/project communication fallback semantics.

## Verification
- pnpm --filter @metasheet/web exec vitest run --watch=false tests/AfterSalesView.spec.ts
- pnpm --filter @metasheet/web exec vitest run --watch=false tests/AfterSalesView.part-items.spec.ts
- pnpm --filter @metasheet/core-backend exec vitest run --watch=false tests/unit/after-sales-plugin-routes.test.ts
- pnpm --filter @metasheet/web type-check
- git diff --check

## Notes
- pnpm --filter @metasheet/core-backend type-check is not available because @metasheet/core-backend has no type-check script.