### PR TITLE
feat(attendance): rebuild managed fixed schedules

### DIFF
--- a/docs/development/attendance-group-admin-ux-fixed-schedule-managed-rebuild-clear-verification-20260528.md
+++ b/docs/development/attendance-group-admin-ux-fixed-schedule-managed-rebuild-clear-verification-20260528.md
@@ -1,0 +1,89 @@
+# Attendance Group Fixed-Schedule Managed Rebuild/Clear Verification - 2026-05-28
+
+## Scope
+
+FS-D3 completes the managed provenance runtime for attendance-group fixed schedules.
+
+This slice adds backend-only explicit operations:
+
+- `POST /api/attendance/groups/:id/fixed-schedule/rebuild`
+- `POST /api/attendance/groups/:id/fixed-schedule/clear`
+
+It follows:
+
+- `attendance-group-admin-ux-fixed-schedule-managed-provenance-design-20260528.md`
+- `attendance-group-admin-ux-fixed-schedule-provenance-fsd1-verification-20260528.md`
+- `attendance-group-admin-ux-fixed-schedule-provenance-fsd2-verification-20260528.md`
+
+## Delivered Behavior
+
+### Rebuild
+
+Rebuild resolves the current group members for the provided shift/date window, then:
+
+- locks target users and currently active managed-row users for the same `producer_key`;
+- reuses the fixed-schedule classifier;
+- returns 409 and writes nothing when `blockingConflicts[]` is non-empty;
+- inserts missing `wouldCreate[]` rows with producer metadata;
+- soft-deactivates active managed rows for the same `producer_key` whose users are no longer in the group;
+- never claims or mutates unmanaged exact-match rows.
+
+### Clear
+
+Clear soft-deactivates only active rows matching:
+
+- `org_id`;
+- `producer_type = attendance_group_fixed_schedule`;
+- `producer_ref_id = groupId`;
+- the exact `producer_key`.
+
+It does not hard-delete and does not touch unmanaged rows or rows from another producer key.
+
+## Boundary Notes
+
+- Backend-only: no frontend controls were added.
+- No migration: FS-D1 already added the nullable producer columns.
+- No `attendance_schedule_groups` read/write.
+- No weekly matrix, punch-method config, owner/sub-owner, export/copy, or comprehensive-hours write surface.
+- `producer_run_id` remains diagnostic; rebuild/clear ownership is by `producer_key`.
+
+## F1 Handling
+
+If a same-group fixed-schedule managed row from a different producer key blocks the requested window, the conflict now carries:
+
+```json
+{
+  "managedScheduleAction": "clear_existing_managed_schedule_first"
+}
+```
+
+This keeps overlap safety fail-closed while giving later UI work a specific affordance for "clear the previous managed schedule first."
+
+## Verification
+
+Commands run:
+
+```bash
+node --check plugins/plugin-attendance/index.cjs
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-scheduling-assignment-conflict.test.ts tests/unit/attendance-uuid-validation-routes.test.ts --watch=false
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+git diff --check
+```
+
+Results:
+
+- `node --check`: PASS
+- targeted backend unit tests: PASS, 20/20
+- `tsc --noEmit`: PASS
+- `git diff --check`: PASS
+
+New coverage:
+
+- rebuild creates missing rows, keeps exact managed/unmanaged skips separate, and soft-deactivates stale managed rows only;
+- rebuild refuses a different-key same-group managed overlap with zero insert/update writes and the clear-first action hint;
+- clear soft-deactivates only rows for the exact producer key;
+- new rebuild/clear routes reject malformed group UUIDs before touching DB.
+
+## Deferred
+
+Frontend controls for rebuild/clear remain a separate opt-in. This slice only exposes the safe backend operations and their tests.

--- a/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
@@ -278,8 +278,15 @@ describe('attendance scheduling assignment conflict guard', () => {
         shiftId: 'shift-a',
         startDate: '2026-06-01',
         endDate: '2026-06-30',
+        ownership: 'unmanaged',
+        producerType: null,
+        producerRefId: null,
+        producerKey: null,
       },
     ])
+    expect(preview.data.skippedManaged).toEqual([])
+    expect(preview.data.skippedUnmanaged).toEqual(preview.data.skipped)
+    expect(preview.data.skippedExternalManaged).toEqual([])
     expect(preview.data.blockingConflicts.map((item: any) => item.userId)).toEqual([
       'user-shift-conflict',
       'user-rotation-conflict',
@@ -555,5 +562,229 @@ describe('attendance scheduling assignment conflict guard', () => {
     expect(result.details.blockingConflicts.map((item: any) => item.userId)).toEqual(['user-conflict'])
     const queries = db.query.mock.calls.map(call => String(call[0])).join('\n')
     expect(queries).not.toMatch(/\bINSERT INTO attendance_shift_assignments\b/i)
+  })
+
+  it('rebuilds managed fixed schedules by creating missing rows and soft-deactivating stale managed rows only', async () => {
+    const producerKey = 'attendance_group_fixed_schedule:group-a:shift-a:2026-06-01:2026-06-30'
+    const managedRows = [
+      {
+        id: '00000000-0000-4000-8000-000000000101',
+        user_id: 'user-managed',
+        shift_id: 'shift-a',
+        start_date: '2026-06-01',
+        end_date: '2026-06-30',
+        is_active: true,
+        producer_type: 'attendance_group_fixed_schedule',
+        producer_ref_id: 'group-a',
+        producer_key: producerKey,
+        producer_run_id: '00000000-0000-4000-8000-000000000001',
+        kind: 'shift',
+      },
+      {
+        id: '00000000-0000-4000-8000-000000000102',
+        user_id: 'user-stale',
+        shift_id: 'shift-a',
+        start_date: '2026-06-01',
+        end_date: '2026-06-30',
+        is_active: true,
+        producer_type: 'attendance_group_fixed_schedule',
+        producer_ref_id: 'group-a',
+        producer_key: producerKey,
+        producer_run_id: '00000000-0000-4000-8000-000000000001',
+        kind: 'shift',
+      },
+    ]
+    const db = {
+      query: vi.fn(async (sql: string, params: any[] = []) => {
+        const text = String(sql)
+        if (/FROM attendance_groups/.test(text)) return [{ id: 'group-a', org_id: 'org-a', name: 'Operations', timezone: 'UTC' }]
+        if (/FROM attendance_shifts/.test(text)) return [{ id: 'shift-a', org_id: 'org-a', name: 'Day shift', timezone: 'UTC' }]
+        if (/FROM attendance_group_members/.test(text)) return [{ user_id: 'user-create' }, { user_id: 'user-managed' }, { user_id: 'user-unmanaged' }]
+        if (/pg_advisory_xact_lock/.test(text)) return []
+        if (/\bINSERT INTO attendance_shift_assignments\b/i.test(text)) {
+          return [{
+            id: '00000000-0000-4000-8000-000000000201',
+            org_id: params[1],
+            user_id: params[2],
+            shift_id: params[3],
+            start_date: params[4],
+            end_date: params[5],
+            is_active: true,
+            producer_type: params[6],
+            producer_ref_id: params[7],
+            producer_key: params[8],
+            producer_run_id: params[9],
+          }]
+        }
+        if (/\bUPDATE attendance_shift_assignments\b/i.test(text)) {
+          return [{
+            ...managedRows[1],
+            is_active: false,
+          }]
+        }
+        if (/producer_type = \$2/.test(text) && /producer_key = \$4/.test(text)) return managedRows
+        if (/FROM attendance_shift_assignments/.test(text) && /user_id = ANY/.test(text)) {
+          return [
+            managedRows[0],
+            {
+              id: '00000000-0000-4000-8000-000000000103',
+              user_id: 'user-unmanaged',
+              shift_id: 'shift-a',
+              start_date: '2026-06-01',
+              end_date: '2026-06-30',
+              kind: 'shift',
+            },
+          ]
+        }
+        if (/FROM attendance_rotation_assignments/.test(text)) return []
+        return []
+      }),
+    }
+
+    const result = await helpers.rebuildAttendanceGroupFixedSchedule(db, {
+      orgId: 'org-a',
+      groupId: 'group-a',
+      shiftId: 'shift-a',
+      startDate: '2026-06-01',
+      endDate: '2026-06-30',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.data.created.map((item: any) => item.userId)).toEqual(['user-create'])
+    expect(result.data.deactivated.map((item: any) => item.id)).toEqual(['00000000-0000-4000-8000-000000000102'])
+    expect(result.data.skippedManaged.map((item: any) => item.userId)).toEqual(['user-managed'])
+    expect(result.data.skippedUnmanaged.map((item: any) => item.userId)).toEqual(['user-unmanaged'])
+    expect(result.data.skippedExternalManaged).toEqual([])
+
+    const queries = db.query.mock.calls.map(call => String(call[0]))
+    const updateCalls = db.query.mock.calls.filter(call => /\bUPDATE attendance_shift_assignments\b/i.test(String(call[0])))
+    expect(queries.filter(sql => sql.includes('pg_advisory_xact_lock'))).toHaveLength(6)
+    expect(queries.filter(sql => /\bINSERT INTO attendance_shift_assignments\b/i.test(sql))).toHaveLength(1)
+    expect(updateCalls).toHaveLength(1)
+    expect(updateCalls[0][0]).toContain('producer_key = $4')
+    expect(updateCalls[0][1][4]).toEqual(['00000000-0000-4000-8000-000000000102'])
+    expect(queries.join('\n')).not.toMatch(/\bDELETE FROM attendance_shift_assignments\b/i)
+  })
+
+  it('refuses managed fixed-schedule rebuilds when another managed window blocks the target', async () => {
+    const db = {
+      query: vi.fn(async (sql: string) => {
+        const text = String(sql)
+        if (/FROM attendance_groups/.test(text)) return [{ id: 'group-a', org_id: 'org-a', name: 'Operations', timezone: 'UTC' }]
+        if (/FROM attendance_shifts/.test(text)) return [{ id: 'shift-a', org_id: 'org-a', name: 'Day shift', timezone: 'UTC' }]
+        if (/FROM attendance_group_members/.test(text)) return [{ user_id: 'user-a' }]
+        if (/pg_advisory_xact_lock/.test(text)) return []
+        if (/producer_type = \$2/.test(text) && /producer_key = \$4/.test(text)) return []
+        if (/FROM attendance_shift_assignments/.test(text) && /user_id = ANY/.test(text)) {
+          return [{
+            id: '00000000-0000-4000-8000-000000000301',
+            user_id: 'user-a',
+            shift_id: 'shift-a',
+            start_date: '2026-05-15',
+            end_date: '2026-06-15',
+            producer_type: 'attendance_group_fixed_schedule',
+            producer_ref_id: 'group-a',
+            producer_key: 'attendance_group_fixed_schedule:group-a:shift-a:2026-05-15:2026-06-15',
+            producer_run_id: '00000000-0000-4000-8000-000000000003',
+            kind: 'shift',
+          }]
+        }
+        if (/FROM attendance_rotation_assignments/.test(text)) return []
+        return []
+      }),
+    }
+
+    const result = await helpers.rebuildAttendanceGroupFixedSchedule(db, {
+      orgId: 'org-a',
+      groupId: 'group-a',
+      shiftId: 'shift-a',
+      startDate: '2026-06-01',
+      endDate: '2026-06-30',
+    })
+
+    expect(result).toMatchObject({
+      ok: false,
+      status: 409,
+      code: 'ATTENDANCE_GROUP_FIXED_SCHEDULE_BLOCKING_CONFLICT',
+    })
+    expect(result.details.blockingConflicts[0]).toEqual(expect.objectContaining({
+      userId: 'user-a',
+      managedScheduleAction: 'clear_existing_managed_schedule_first',
+    }))
+    const queries = db.query.mock.calls.map(call => String(call[0])).join('\n')
+    expect(queries).not.toMatch(/\bINSERT INTO attendance_shift_assignments\b/i)
+    expect(queries).not.toMatch(/\bUPDATE attendance_shift_assignments\b/i)
+  })
+
+  it('clears only managed rows for the exact fixed-schedule producer key', async () => {
+    const managedRows = [
+      {
+        id: '00000000-0000-4000-8000-000000000401',
+        user_id: 'user-a',
+        shift_id: 'shift-a',
+        start_date: '2026-06-01',
+        end_date: '2026-06-30',
+        is_active: true,
+        producer_type: 'attendance_group_fixed_schedule',
+        producer_ref_id: 'group-a',
+        producer_key: 'attendance_group_fixed_schedule:group-a:shift-a:2026-06-01:2026-06-30',
+        producer_run_id: '00000000-0000-4000-8000-000000000004',
+      },
+      {
+        id: '00000000-0000-4000-8000-000000000402',
+        user_id: 'user-b',
+        shift_id: 'shift-a',
+        start_date: '2026-06-01',
+        end_date: '2026-06-30',
+        is_active: true,
+        producer_type: 'attendance_group_fixed_schedule',
+        producer_ref_id: 'group-a',
+        producer_key: 'attendance_group_fixed_schedule:group-a:shift-a:2026-06-01:2026-06-30',
+        producer_run_id: '00000000-0000-4000-8000-000000000004',
+      },
+    ]
+    const db = {
+      query: vi.fn(async (sql: string, params: any[] = []) => {
+        const text = String(sql)
+        if (/pg_advisory_xact_lock/.test(text)) return []
+        if (/\bUPDATE attendance_shift_assignments\b/i.test(text)) {
+          return managedRows
+            .filter(row => params[4].includes(row.id))
+            .map(row => ({ ...row, is_active: false }))
+        }
+        if (/producer_type = \$2/.test(text) && /producer_key = \$4/.test(text)) return managedRows
+        return []
+      }),
+    }
+
+    const result = await helpers.clearAttendanceGroupFixedScheduleManagedRows(db, {
+      orgId: 'org-a',
+      groupId: 'group-a',
+      shiftId: 'shift-a',
+      startDate: '2026-06-01',
+      endDate: '2026-06-30',
+    })
+
+    expect(result.ok).toBe(true)
+    expect(result.data.producer).toEqual({
+      type: 'attendance_group_fixed_schedule',
+      refId: 'group-a',
+      key: 'attendance_group_fixed_schedule:group-a:shift-a:2026-06-01:2026-06-30',
+    })
+    expect(result.data.deactivated.map((item: any) => item.id)).toEqual([
+      '00000000-0000-4000-8000-000000000401',
+      '00000000-0000-4000-8000-000000000402',
+    ])
+    const queries = db.query.mock.calls.map(call => String(call[0]))
+    const updateCalls = db.query.mock.calls.filter(call => /\bUPDATE attendance_shift_assignments\b/i.test(String(call[0])))
+    expect(queries.filter(sql => sql.includes('pg_advisory_xact_lock'))).toHaveLength(2)
+    expect(updateCalls).toHaveLength(1)
+    expect(updateCalls[0][0]).toContain('producer_ref_id = $3')
+    expect(updateCalls[0][0]).toContain('producer_key = $4')
+    expect(updateCalls[0][1][4]).toEqual([
+      '00000000-0000-4000-8000-000000000401',
+      '00000000-0000-4000-8000-000000000402',
+    ])
+    expect(queries.join('\n')).not.toMatch(/\bDELETE FROM attendance_shift_assignments\b/i)
   })
 })

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -150,6 +150,22 @@ describe('attendance UUID route validation', () => {
           endDate: '2026-06-30',
         },
       },
+      {
+        key: 'POST /api/attendance/groups/:id/fixed-schedule/rebuild',
+        body: {
+          shiftId: '00000000-0000-4000-8000-000000000001',
+          startDate: '2026-06-01',
+          endDate: '2026-06-30',
+        },
+      },
+      {
+        key: 'POST /api/attendance/groups/:id/fixed-schedule/clear',
+        body: {
+          shiftId: '00000000-0000-4000-8000-000000000001',
+          startDate: '2026-06-01',
+          endDate: '2026-06-30',
+        },
+      },
       { key: 'GET /api/attendance/holidays/:id' },
       { key: 'PUT /api/attendance/holidays/:id' },
       { key: 'DELETE /api/attendance/holidays/:id' },

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8699,13 +8699,27 @@ function buildAttendanceGroupFixedScheduleProducerMetadata(input, producerRunId)
   }
 }
 
-function mapAttendanceGroupFixedScheduleSkipped(row, draft) {
+function getAttendanceGroupFixedScheduleSkipOwnership(row, producerKey) {
+  if (row?.producer_type === ATTENDANCE_GROUP_FIXED_SCHEDULE_PRODUCER_TYPE && row?.producer_key === producerKey) {
+    return 'managed'
+  }
+  if (row?.producer_type == null && row?.producer_key == null) {
+    return 'unmanaged'
+  }
+  return 'externalManaged'
+}
+
+function mapAttendanceGroupFixedScheduleSkipped(row, draft, producerKey) {
   return {
     assignmentId: row.id,
     userId: draft.userId,
     shiftId: draft.shiftId,
     startDate: normalizeDateOnly(row.start_date) ?? row.start_date,
     endDate: normalizeAttendanceScheduleAssignmentEndDate(row.end_date),
+    ownership: getAttendanceGroupFixedScheduleSkipOwnership(row, producerKey),
+    producerType: row.producer_type ?? null,
+    producerRefId: row.producer_ref_id ?? null,
+    producerKey: row.producer_key ?? null,
   }
 }
 
@@ -8719,10 +8733,45 @@ function isExactAttendanceGroupFixedScheduleAssignment(row, draft) {
 function mapAttendanceGroupFixedScheduleBlockingConflict(row, draft) {
   const conflict = mapAttendanceScheduleAssignmentConflict(row, draft)
   if (!conflict) return null
-  return {
+  const mapped = {
     ...conflict,
     message: getAttendanceScheduleAssignmentConflictMessage(conflict),
   }
+  if (
+    row?.producer_type === ATTENDANCE_GROUP_FIXED_SCHEDULE_PRODUCER_TYPE
+    && row?.producer_ref_id === draft.groupId
+    && row?.producer_key
+  ) {
+    mapped.managedScheduleAction = 'clear_existing_managed_schedule_first'
+  }
+  return mapped
+}
+
+async function acquireAttendanceScheduleAssignmentLocks(db, orgId, userIds) {
+  const lockUserIds = Array.from(new Set(
+    (Array.isArray(userIds) ? userIds : [])
+      .map((value) => String(value || '').trim())
+      .filter(Boolean)
+  )).sort()
+  for (const userId of lockUserIds) {
+    await acquireAttendanceScheduleAssignmentLock(db, orgId, userId)
+  }
+  return lockUserIds
+}
+
+async function loadAttendanceGroupFixedScheduleManagedRows(db, input) {
+  const producerMetadata = buildAttendanceGroupFixedScheduleProducerMetadata(input, '00000000-0000-4000-8000-000000000000')
+  return db.query(
+    `SELECT id, user_id, shift_id, start_date, end_date, is_active, producer_type, producer_ref_id, producer_key, producer_run_id, 'shift'::text AS kind
+       FROM attendance_shift_assignments
+      WHERE org_id = $1
+        AND producer_type = $2
+        AND producer_ref_id = $3
+        AND producer_key = $4
+        AND COALESCE(is_active, true) = true
+      ORDER BY user_id ASC, start_date ASC, created_at ASC`,
+    [input.orgId, producerMetadata.producerType, producerMetadata.producerRefId, producerMetadata.producerKey]
+  )
 }
 
 async function buildAttendanceGroupFixedSchedulePlan(db, input, options = {}) {
@@ -8774,15 +8823,23 @@ async function buildAttendanceGroupFixedSchedulePlan(db, input, options = {}) {
     }
   }
 
-  if (options.lockTargets) {
-    for (const userId of userIds) {
-      await acquireAttendanceScheduleAssignmentLock(db, input.orgId, userId)
-    }
+  const extraLockUserIds = Array.isArray(options.extraLockUserIds) ? [...options.extraLockUserIds] : []
+  if (options.lockManagedRowsForProducerKey) {
+    const managedRowsForLocks = await loadAttendanceGroupFixedScheduleManagedRows(db, input)
+    extraLockUserIds.push(...managedRowsForLocks.map(row => row.user_id))
   }
 
+  if (options.lockTargets) {
+    await acquireAttendanceScheduleAssignmentLocks(db, input.orgId, [
+      ...userIds,
+      ...extraLockUserIds,
+    ])
+  }
+
+  const producerKey = buildAttendanceGroupFixedScheduleProducerKey(input)
   const overlapEndDate = normalizeAttendanceScheduleAssignmentEndDate(input.endDate) || ATTENDANCE_SCHEDULE_OPEN_END_DATE
   const shiftOverlapRows = await db.query(
-    `SELECT id, user_id, shift_id, start_date, end_date, 'shift'::text AS kind
+    `SELECT id, user_id, shift_id, start_date, end_date, producer_type, producer_ref_id, producer_key, producer_run_id, 'shift'::text AS kind
        FROM attendance_shift_assignments
       WHERE org_id = $1
         AND user_id = ANY($2::text[])
@@ -8815,12 +8872,16 @@ async function buildAttendanceGroupFixedSchedulePlan(db, input, options = {}) {
 
   const wouldCreate = []
   const skipped = []
+  const skippedManaged = []
+  const skippedUnmanaged = []
+  const skippedExternalManaged = []
   const blockingConflicts = []
 
   for (const userId of userIds) {
     const draft = {
       kind: 'shift',
       orgId: input.orgId,
+      groupId: input.groupId,
       userId,
       shiftId: input.shiftId,
       startDate: input.startDate,
@@ -8836,7 +8897,11 @@ async function buildAttendanceGroupFixedSchedulePlan(db, input, options = {}) {
     }
     const exactRow = overlaps.find(row => isExactAttendanceGroupFixedScheduleAssignment(row, draft))
     if (exactRow) {
-      skipped.push(mapAttendanceGroupFixedScheduleSkipped(exactRow, draft))
+      const skippedItem = mapAttendanceGroupFixedScheduleSkipped(exactRow, draft, producerKey)
+      skipped.push(skippedItem)
+      if (skippedItem.ownership === 'managed') skippedManaged.push(skippedItem)
+      else if (skippedItem.ownership === 'externalManaged') skippedExternalManaged.push(skippedItem)
+      else skippedUnmanaged.push(skippedItem)
       continue
     }
     wouldCreate.push(mapAttendanceGroupFixedSchedulePreviewCandidate(userId, input))
@@ -8857,6 +8922,9 @@ async function buildAttendanceGroupFixedSchedulePlan(db, input, options = {}) {
       },
       wouldCreate,
       skipped,
+      skippedManaged,
+      skippedUnmanaged,
+      skippedExternalManaged,
       blockingConflicts,
     },
   }
@@ -8866,23 +8934,9 @@ async function buildAttendanceGroupFixedSchedulePreview(db, input) {
   return buildAttendanceGroupFixedSchedulePlan(db, input)
 }
 
-async function applyAttendanceGroupFixedSchedule(db, input) {
-  const result = await buildAttendanceGroupFixedSchedulePlan(db, input, { lockTargets: true })
-  if (!result.ok) return result
-  const plan = result.data
-  if (plan.blockingConflicts.length > 0) {
-    return {
-      ok: false,
-      status: 409,
-      code: 'ATTENDANCE_GROUP_FIXED_SCHEDULE_BLOCKING_CONFLICT',
-      message: 'Fixed schedule apply has blocking conflicts',
-      details: plan,
-    }
-  }
-
+async function insertAttendanceGroupFixedScheduleAssignments(db, input, items, producerMetadata) {
   const created = []
-  const producerMetadata = buildAttendanceGroupFixedScheduleProducerMetadata(input, randomUUID())
-  for (const item of plan.wouldCreate) {
+  for (const item of items) {
     const rows = await db.query(
       `INSERT INTO attendance_shift_assignments
        (id, org_id, user_id, shift_id, start_date, end_date, is_active, producer_type, producer_ref_id, producer_key, producer_run_id)
@@ -8903,6 +8957,55 @@ async function applyAttendanceGroupFixedSchedule(db, input) {
     )
     if (rows[0]) created.push(mapAssignmentRow(rows[0]))
   }
+  return created
+}
+
+async function softDeactivateAttendanceGroupFixedScheduleManagedRows(db, input, assignmentIds) {
+  const ids = Array.from(new Set(
+    (Array.isArray(assignmentIds) ? assignmentIds : [])
+      .map((value) => String(value || '').trim())
+      .filter(Boolean)
+  ))
+  if (!ids.length) return []
+  const producerMetadata = buildAttendanceGroupFixedScheduleProducerMetadata(input, '00000000-0000-4000-8000-000000000000')
+  const rows = await db.query(
+    `UPDATE attendance_shift_assignments
+        SET is_active = false,
+            updated_at = now()
+      WHERE org_id = $1
+        AND producer_type = $2
+        AND producer_ref_id = $3
+        AND producer_key = $4
+        AND id = ANY($5::uuid[])
+        AND COALESCE(is_active, true) = true
+      RETURNING *`,
+    [
+      input.orgId,
+      producerMetadata.producerType,
+      producerMetadata.producerRefId,
+      producerMetadata.producerKey,
+      ids,
+    ]
+  )
+  return rows.map(mapAssignmentRow)
+}
+
+async function applyAttendanceGroupFixedSchedule(db, input) {
+  const result = await buildAttendanceGroupFixedSchedulePlan(db, input, { lockTargets: true })
+  if (!result.ok) return result
+  const plan = result.data
+  if (plan.blockingConflicts.length > 0) {
+    return {
+      ok: false,
+      status: 409,
+      code: 'ATTENDANCE_GROUP_FIXED_SCHEDULE_BLOCKING_CONFLICT',
+      message: 'Fixed schedule apply has blocking conflicts',
+      details: plan,
+    }
+  }
+
+  const producerMetadata = buildAttendanceGroupFixedScheduleProducerMetadata(input, randomUUID())
+  const created = await insertAttendanceGroupFixedScheduleAssignments(db, input, plan.wouldCreate, producerMetadata)
 
   return {
     ok: true,
@@ -8910,6 +9013,70 @@ async function applyAttendanceGroupFixedSchedule(db, input) {
       ...plan,
       created,
       applied: true,
+    },
+  }
+}
+
+async function rebuildAttendanceGroupFixedSchedule(db, input) {
+  const result = await buildAttendanceGroupFixedSchedulePlan(db, input, {
+    lockTargets: true,
+    lockManagedRowsForProducerKey: true,
+  })
+  if (!result.ok) return result
+  const plan = result.data
+  if (plan.blockingConflicts.length > 0) {
+    return {
+      ok: false,
+      status: 409,
+      code: 'ATTENDANCE_GROUP_FIXED_SCHEDULE_BLOCKING_CONFLICT',
+      message: 'Fixed schedule rebuild has blocking conflicts',
+      details: plan,
+    }
+  }
+
+  const activeManagedRows = await loadAttendanceGroupFixedScheduleManagedRows(db, input)
+  await acquireAttendanceScheduleAssignmentLocks(db, input.orgId, activeManagedRows.map(row => row.user_id))
+  const lockedManagedRows = await loadAttendanceGroupFixedScheduleManagedRows(db, input)
+  const targetUserIds = new Set(plan.target.userIds)
+  const deactivateIds = lockedManagedRows
+    .filter(row => !targetUserIds.has(String(row.user_id || '').trim()))
+    .map(row => row.id)
+
+  const producerMetadata = buildAttendanceGroupFixedScheduleProducerMetadata(input, randomUUID())
+  const created = await insertAttendanceGroupFixedScheduleAssignments(db, input, plan.wouldCreate, producerMetadata)
+  const deactivated = await softDeactivateAttendanceGroupFixedScheduleManagedRows(db, input, deactivateIds)
+
+  return {
+    ok: true,
+    data: {
+      ...plan,
+      created,
+      deactivated,
+      rebuilt: true,
+    },
+  }
+}
+
+async function clearAttendanceGroupFixedScheduleManagedRows(db, input) {
+  const activeManagedRows = await loadAttendanceGroupFixedScheduleManagedRows(db, input)
+  await acquireAttendanceScheduleAssignmentLocks(db, input.orgId, activeManagedRows.map(row => row.user_id))
+  const lockedManagedRows = await loadAttendanceGroupFixedScheduleManagedRows(db, input)
+  const deactivated = await softDeactivateAttendanceGroupFixedScheduleManagedRows(
+    db,
+    input,
+    lockedManagedRows.map(row => row.id)
+  )
+  const producerMetadata = buildAttendanceGroupFixedScheduleProducerMetadata(input, '00000000-0000-4000-8000-000000000000')
+  return {
+    ok: true,
+    data: {
+      producer: {
+        type: producerMetadata.producerType,
+        refId: producerMetadata.producerRefId,
+        key: producerMetadata.producerKey,
+      },
+      deactivated,
+      cleared: true,
     },
   }
 }
@@ -14552,10 +14719,15 @@ module.exports = {
     buildAttendanceGroupFixedSchedulePlan,
     buildAttendanceGroupFixedSchedulePreview,
     applyAttendanceGroupFixedSchedule,
+    rebuildAttendanceGroupFixedSchedule,
+    clearAttendanceGroupFixedScheduleManagedRows,
     ATTENDANCE_GROUP_FIXED_SCHEDULE_PRODUCER_TYPE,
     buildAttendanceGroupFixedScheduleProducerKey,
     buildAttendanceGroupFixedScheduleProducerMetadata,
+    loadAttendanceGroupFixedScheduleManagedRows,
+    softDeactivateAttendanceGroupFixedScheduleManagedRows,
     acquireAttendanceScheduleAssignmentLock,
+    acquireAttendanceScheduleAssignmentLocks,
     getAttendanceScheduleAssignmentConflictMessage,
     getAttendanceScheduleAssignmentConflictType,
     resolveAttendanceScheduleAssignmentUpdateEndDate,
@@ -26023,6 +26195,152 @@ module.exports = {
           }
           logger.error('Attendance group fixed schedule apply failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to apply fixed schedule' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/groups/:id/fixed-schedule/rebuild',
+      withPermission('attendance:admin', async (req, res) => {
+        const schema = z.object({
+          shiftId: z.string().min(1),
+          startDate: z.string().min(1),
+          endDate: z.string().min(1),
+          orgId: z.string().optional(),
+        }).strict()
+
+        const parsed = schema.safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+
+        const orgId = getOrgId(req)
+        const groupId = normalizeUuidString(req.params.id)
+        if (!groupId) {
+          respondInvalidUuid(res)
+          return
+        }
+        const shiftId = normalizeUuidString(parsed.data.shiftId)
+        if (!shiftId) {
+          respondInvalidUuid(res, 'shiftId')
+          return
+        }
+        const startDate = normalizeDateOnlyStrict(parsed.data.startDate)
+        if (!startDate) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid "startDate" date. Use YYYY-MM-DD.' } })
+          return
+        }
+        const endDate = normalizeDateOnlyStrict(parsed.data.endDate)
+        if (!endDate) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid "endDate" date. Use YYYY-MM-DD.' } })
+          return
+        }
+        if (startDate > endDate) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: '"startDate" must be on or before "endDate".' } })
+          return
+        }
+
+        try {
+          const result = await db.transaction((trx) => rebuildAttendanceGroupFixedSchedule(trx, {
+            orgId,
+            groupId,
+            shiftId,
+            startDate,
+            endDate,
+          }))
+          if (!result.ok) {
+            res.status(result.status).json({
+              ok: false,
+              error: {
+                code: result.code,
+                message: result.message,
+                details: result.details,
+              },
+            })
+            return
+          }
+          for (const assignment of result.data.created) {
+            emitEvent('attendance.assignment.created', { orgId, assignmentId: assignment.id })
+          }
+          for (const assignment of result.data.deactivated) {
+            emitEvent('attendance.assignment.updated', { orgId, assignmentId: assignment.id })
+          }
+          res.json({ ok: true, data: result.data })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance group fixed schedule rebuild failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to rebuild fixed schedule' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/groups/:id/fixed-schedule/clear',
+      withPermission('attendance:admin', async (req, res) => {
+        const schema = z.object({
+          shiftId: z.string().min(1),
+          startDate: z.string().min(1),
+          endDate: z.string().min(1),
+          orgId: z.string().optional(),
+        }).strict()
+
+        const parsed = schema.safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+
+        const orgId = getOrgId(req)
+        const groupId = normalizeUuidString(req.params.id)
+        if (!groupId) {
+          respondInvalidUuid(res)
+          return
+        }
+        const shiftId = normalizeUuidString(parsed.data.shiftId)
+        if (!shiftId) {
+          respondInvalidUuid(res, 'shiftId')
+          return
+        }
+        const startDate = normalizeDateOnlyStrict(parsed.data.startDate)
+        if (!startDate) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid "startDate" date. Use YYYY-MM-DD.' } })
+          return
+        }
+        const endDate = normalizeDateOnlyStrict(parsed.data.endDate)
+        if (!endDate) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid "endDate" date. Use YYYY-MM-DD.' } })
+          return
+        }
+        if (startDate > endDate) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: '"startDate" must be on or before "endDate".' } })
+          return
+        }
+
+        try {
+          const result = await db.transaction((trx) => clearAttendanceGroupFixedScheduleManagedRows(trx, {
+            orgId,
+            groupId,
+            shiftId,
+            startDate,
+            endDate,
+          }))
+          for (const assignment of result.data.deactivated) {
+            emitEvent('attendance.assignment.updated', { orgId, assignmentId: assignment.id })
+          }
+          res.json({ ok: true, data: result.data })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance group fixed schedule clear failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to clear fixed schedule' } })
         }
       })
     )


### PR DESCRIPTION
## Summary

- add backend-only fixed-schedule managed `rebuild` and `clear` routes
- classify fixed-schedule exact skips as managed / unmanaged / external-managed while preserving the existing wouldCreate / skipped / blocking conflict contract
- rebuild creates missing rows with provenance, soft-deactivates only stale active rows for the same `producer_key`, and writes nothing on blocking conflicts
- clear soft-deactivates only active rows for the exact `producer_type` + `producer_ref_id` + `producer_key`
- surface `managedScheduleAction: clear_existing_managed_schedule_first` for same-group different-key managed overlaps
- add FS-D3 verification notes

## Boundaries

- backend-only; no frontend controls
- no migration; FS-D1 already added nullable producer columns
- no hard-delete
- no claiming/mutating unmanaged exact-match rows
- no `attendance_schedule_groups` read/write introduced
- no weekly matrix, punch-method config, owner/sub-owner, export/copy, or comprehensive-hours write surface

## Verification

- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-scheduling-assignment-conflict.test.ts tests/unit/attendance-uuid-validation-routes.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `git diff --check`
