### PR TITLE
feat(multitable): #5c UI — preview formula dry-run against the current record

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1063,12 +1063,15 @@ export class MultitableApiClient {
 
   // Formula dry-run (#5b): evaluate an UNSAVED expression against caller-supplied sample values.
   // 200 (even on success:false runtime errors) → DryRunResult; 403/413/422 → MultitableApiError.
-  async dryRunFormula(params: { sheetId: string; expression: string; sampleValues: Record<string, unknown> }): Promise<DryRunResult> {
-    const { sheetId, expression, sampleValues } = params
+  // recordId (#5c): sample an existing record's RAW values server-side (manual sampleValues still
+  // override per-field). The server applies field-read masking, so a denied/hidden field's value is
+  // never returned — it degrades to a missing_sample diagnostic.
+  async dryRunFormula(params: { sheetId: string; expression: string; sampleValues: Record<string, unknown>; recordId?: string }): Promise<DryRunResult> {
+    const { sheetId, expression, sampleValues, recordId } = params
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/formula/dry-run`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify({ expression, sampleValues }),
+      body: JSON.stringify({ expression, sampleValues, ...(recordId ? { recordId } : {}) }),
     })
     return this.parseJson(res)
   }

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -188,6 +188,15 @@
             <button type="button" class="meta-field-mgr__dryrun-btn" :disabled="!dryRunCanEvaluate" @click="runDryRun">
               {{ dryRunRunning ? ml('field.formulaDryRun.evaluating') : ml('field.formulaDryRun.test') }}
             </button>
+            <button
+              v-if="dryRunHasRecord"
+              type="button"
+              class="meta-field-mgr__dryrun-btn meta-field-mgr__dryrun-btn--record"
+              :disabled="!dryRunCanEvaluate"
+              @click="runDryRunWithRecord"
+            >
+              {{ dryRunRunning ? ml('field.formulaDryRun.evaluating') : ml('field.formulaDryRun.testWithRecord') }}
+            </button>
             <div v-if="dryRunTransportError" class="meta-field-mgr__dryrun-result meta-field-mgr__dryrun-result--error">{{ dryRunTransportError }}</div>
             <div v-else-if="dryRunResult" class="meta-field-mgr__dryrun-result">
               <div class="meta-field-mgr__dryrun-result-head">
@@ -574,7 +583,10 @@ const props = defineProps<{
   sheetId: string
   // #5b: formula dry-run callback (the workbench wires it to client.dryRunFormula). Optional so the
   // panel degrades gracefully (button hidden) where no fn is provided.
-  dryRunFn?: (params: { sheetId: string; expression: string; sampleValues: Record<string, unknown> }) => Promise<DryRunResult>
+  dryRunFn?: (params: { sheetId: string; expression: string; sampleValues: Record<string, unknown>; recordId?: string }) => Promise<DryRunResult>
+  // #5c: the currently-selected record, if any. When present, a "preview with current record" button
+  // appears that samples this record's real values server-side (manual samples still override).
+  currentRecordId?: string | null
 }>()
 
 const emit = defineEmits<{
@@ -750,13 +762,22 @@ function buildDryRunSampleValues(): Record<string, unknown> {
   }
   return out
 }
-async function runDryRun() {
+// #5c: a record is available to sample from → show the "preview with current record" button.
+const dryRunHasRecord = computed(() => Boolean(props.currentRecordId))
+// Shared core. recordId omitted → manual-sample path (#5b); recordId present → server samples that
+// record's RAW values (#5c) with manual samples as per-field overrides. Same seq/stale/error handling.
+async function executeDryRun(recordId?: string) {
   if (!props.dryRunFn || !dryRunCanEvaluate.value) return
   const seq = ++dryRunSeq
   dryRunRunning.value = true
   dryRunTransportError.value = null
   try {
-    const res = await props.dryRunFn({ sheetId: props.sheetId, expression: formulaDraft.expression, sampleValues: buildDryRunSampleValues() })
+    const res = await props.dryRunFn({
+      sheetId: props.sheetId,
+      expression: formulaDraft.expression,
+      sampleValues: buildDryRunSampleValues(),
+      ...(recordId ? { recordId } : {}),
+    })
     if (seq !== dryRunSeq) return // stale response superseded
     dryRunResult.value = res
   } catch (err) {
@@ -770,6 +791,8 @@ async function runDryRun() {
     if (seq === dryRunSeq) dryRunRunning.value = false
   }
 }
+function runDryRun() { void executeDryRun() }
+function runDryRunWithRecord() { void executeDryRun(props.currentRecordId ?? undefined) }
 // C2: result describes the current expression; any edit clears it + invalidates an in-flight response.
 // Also clear `running` — otherwise a superseded request's `finally` skips the reset (seq !== dryRunSeq)
 // and the Evaluate button would stay disabled for the new expression.

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -28,7 +28,7 @@ export type MetaManagerLabelKey =
   | 'field.optionalOverride' | 'field.aggregation'
   | 'field.expression' | 'field.insertFieldToken'
   | 'field.formulaReference' | 'field.formulaSearchPlaceholder'
-  | 'field.formulaDryRun.test' | 'field.formulaDryRun.sampleHeading' | 'field.formulaDryRun.evaluating'
+  | 'field.formulaDryRun.test' | 'field.formulaDryRun.testWithRecord' | 'field.formulaDryRun.sampleHeading' | 'field.formulaDryRun.evaluating'
   | 'field.formulaDryRun.resultHeading' | 'field.formulaDryRun.errorHeading' | 'field.formulaDryRun.invalidNumber'
   | 'field.formulaDryRun.forbidden' | 'field.formulaDryRun.tooLarge' | 'field.formulaDryRun.requestFailed'
   | 'field.allCategories' | 'field.noMatchingFunctions'
@@ -159,6 +159,7 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'field.insertFieldToken': { en: 'Insert field token', zh: '插入字段令牌' },
   'field.formulaReference': { en: 'Formula reference', zh: '公式参考' },
   'field.formulaDryRun.test': { en: 'Test with sample data', zh: '用示例数据试算' },
+  'field.formulaDryRun.testWithRecord': { en: 'Preview with current record', zh: '用当前记录预览/校验' },
   'field.formulaDryRun.sampleHeading': { en: 'Sample values', zh: '示例值' },
   'field.formulaDryRun.evaluating': { en: 'Evaluating…', zh: '试算中…' },
   'field.formulaDryRun.resultHeading': { en: 'Result', zh: '结果' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -352,6 +352,7 @@
     <MetaFieldManager
       :visible="showFieldManager" :fields="propertyVisibleWorkbenchFields" :sheets="workbench.sheets.value" :sheet-id="workbench.activeSheetId.value"
       :dry-run-fn="dryRunFormulaFn"
+      :current-record-id="selectedRecordId"
       @update:dirty="fieldManagerDirty = $event"
       @close="showFieldManager = false" @create-field="onCreateField" @update-field="onUpdateField" @delete-field="onDeleteField"
     />
@@ -1757,7 +1758,7 @@ const aggregateValues = ref<Record<string, { fn: string; value: number }>>({})
 const aggregateTooLarge = ref(false)
 const aggregateGroups = ref<import('../api/client').ViewAggregateGroup[]>([]) // #4-3b-2a server per-group subtotals
 // #5b: formula dry-run passthrough to the API client (MetaFieldManager is emit-based, so it takes a fn prop)
-const dryRunFormulaFn = (params: { sheetId: string; expression: string; sampleValues: Record<string, unknown> }) =>
+const dryRunFormulaFn = (params: { sheetId: string; expression: string; sampleValues: Record<string, unknown>; recordId?: string }) =>
   workbench.client.dryRunFormula(params)
 const activeAggregationConfig = computed<Record<string, string>>(() => {
   const raw = workbench.activeView.value?.config?.aggregations

--- a/apps/web/tests/multitable-formula-dryrun-panel.spec.ts
+++ b/apps/web/tests/multitable-formula-dryrun-panel.spec.ts
@@ -7,8 +7,9 @@ import { localizeDryRunDiagnostic } from '../src/multitable/utils/meta-formula-l
 
 // Drives MetaFieldManager into formula-config state and exposes the dry-run panel (#5b).
 async function mountFormulaConfig(
-  dryRunFn: (p: { sheetId: string; expression: string; sampleValues: Record<string, unknown> }) => Promise<DryRunResult>,
+  dryRunFn: (p: { sheetId: string; expression: string; sampleValues: Record<string, unknown>; recordId?: string }) => Promise<DryRunResult>,
   extraFields: Array<{ id: string; name: string; type: string }> = [],
+  currentRecordId: string | null = null, // #5c: when set, the "preview with current record" button appears
 ) {
   const container = document.createElement('div')
   document.body.appendChild(container)
@@ -25,6 +26,7 @@ async function mountFormulaConfig(
           { id: 'fld_total', name: 'Total', type: 'formula', property: { expression: '' } },
         ],
         dryRunFn,
+        currentRecordId,
       })
     },
   })
@@ -49,6 +51,8 @@ async function setSample(container: HTMLElement, value: string) {
   await nextTick()
 }
 const clickEvaluate = (c: HTMLElement) => (c.querySelector('.meta-field-mgr__dryrun-btn') as HTMLButtonElement).click()
+const recordBtn = (c: HTMLElement) => c.querySelector('.meta-field-mgr__dryrun-btn--record') as HTMLButtonElement | null
+const clickRecordPreview = (c: HTMLElement) => recordBtn(c)!.click()
 async function flush() { for (let i = 0; i < 6; i++) { await Promise.resolve(); await nextTick() } }
 
 afterEach(() => { useLocale().setLocale('en'); document.body.innerHTML = '' ; vi.restoreAllMocks() })
@@ -152,5 +156,56 @@ describe('MetaFieldManager formula dry-run panel (#5b)', () => {
     const future = localizeDryRunDiagnostic({ kind: 'some_future_kind' }, true)
     expect(future).toContain('some_future_kind')
     expect(future).toBe('诊断：some_future_kind')
+  })
+})
+
+describe('MetaFieldManager formula dry-run — current-record sampling (#5c)', () => {
+  it('no current record → record-preview button absent; manual payload carries no recordId', async () => {
+    const fn = vi.fn().mockResolvedValue({ success: true, result: 2, resultType: 'number', referencedFields: ['fld_price'], diagnostics: [] } satisfies DryRunResult)
+    const { container } = await mountFormulaConfig(fn) // no currentRecordId
+    await setExpression(container, '={fld_price}+1')
+    expect(recordBtn(container)).toBeNull() // button hidden without a record
+    await setSample(container, '1')
+    clickEvaluate(container)
+    await flush()
+    expect(fn.mock.calls[0][0]).not.toHaveProperty('recordId') // manual path never sends recordId
+  })
+
+  it('with a current record → button appears and clicking it sends recordId in the payload', async () => {
+    const fn = vi.fn().mockResolvedValue({ success: true, result: 30, resultType: 'number', referencedFields: ['fld_price'], diagnostics: [] } satisfies DryRunResult)
+    const { container } = await mountFormulaConfig(fn, [], 'rec_42')
+    await setExpression(container, '={fld_price}+1')
+    expect(recordBtn(container)).not.toBeNull()
+    clickRecordPreview(container)
+    await flush()
+    expect(fn.mock.calls[0][0].recordId).toBe('rec_42') // server samples this record's RAW values
+  })
+
+  it('manual sample overrides still ride along on the record path (server merges record + overrides)', async () => {
+    const fn = vi.fn().mockResolvedValue({ success: true, result: 100, resultType: 'number', referencedFields: ['fld_price'], diagnostics: [] } satisfies DryRunResult)
+    const { container } = await mountFormulaConfig(fn, [], 'rec_42')
+    await setExpression(container, '={fld_price}+1')
+    await setSample(container, '99') // manual override for fld_price
+    clickRecordPreview(container)
+    await flush()
+    expect(fn.mock.calls[0][0].recordId).toBe('rec_42')
+    expect(fn.mock.calls[0][0].sampleValues).toEqual({ fld_price: 99 }) // override forwarded as a number
+  })
+
+  it('record path: a masked (denied/hidden) field shows a diagnostic and never leaks a value', async () => {
+    const fn = vi.fn().mockResolvedValue({
+      success: true, result: 42, resultType: 'number', referencedFields: ['fld_price', 'fld_secret'],
+      // server masked fld_secret → no value returned, only a missing_sample diagnostic (message is debug-only)
+      diagnostics: [{ severity: 'info', kind: 'missing_sample', fieldId: 'fld_secret', message: 'LEAK_CANARY_DO_NOT_RENDER' }],
+    } satisfies DryRunResult)
+    const { container } = await mountFormulaConfig(fn, [{ id: 'fld_secret', name: 'Secret', type: 'number' }], 'rec_42')
+    await setExpression(container, '={fld_price}+{fld_secret}')
+    clickRecordPreview(container)
+    await flush()
+    const zone = container.querySelector('.meta-field-mgr__dryrun-result') as HTMLElement
+    expect(zone).not.toBeNull()
+    expect(zone.textContent).toContain('42') // visible result rendered
+    expect(zone.querySelectorAll('.meta-field-mgr__formula-diagnostic').length).toBeGreaterThan(0) // missing_sample shown
+    expect(zone.textContent).not.toContain('LEAK_CANARY_DO_NOT_RENDER') // diagnostic.message never rendered (no leak)
   })
 })


### PR DESCRIPTION
Wires the #5c backend (record-aware dry-run, merged in #2006) into the field manager UI.

## What
The formula dry-run panel (in `MetaFieldManager`) gains a **"Preview with current record"** button alongside the existing manual-sample "Test" button. It samples the **selected record's real values server-side**; manual sample inputs still override per-field. Absent a selected record the button is hidden and the manual path (#5b) is unchanged.

- `client.dryRunFormula` forwards optional `recordId`.
- `MetaFieldManager`: new `currentRecordId` prop + record-preview button, sharing the existing result/diagnostics + seq/stale/error handling via a small `executeDryRun(recordId?)` core (no duplication).
- `MultitableWorkbench` passes `:current-record-id="selectedRecordId"`; `dryRunFormulaFn` forwards `recordId`.
- i18n: `field.formulaDryRun.testWithRecord` (en `Preview with current record` / zh `用当前记录预览/校验`) in the typed `meta-manager-labels` module (union + value).

## Security (server-enforced, #2006)
Field-read masking (`field_permissions.visible` + `property.hidden`) and the grant-additive record-read model are enforced **server-side**; a denied/hidden field's value is never returned (degrades to `missing_sample`). The UI never renders `diagnostic.message`.

## Tests — `multitable-formula-dryrun-panel.spec.ts` (11/11 green, `vue-tsc` clean)
- no record → record button **absent**, manual payload carries **no** `recordId`
- with record → button **present**, click sends `recordId`
- manual override **rides along** on the record path (server merges record + overrides)
- masked field → diagnostic **shown**, the canary value (`diagnostic.message`) **never rendered**

## Scope notes
Front-end only. `MultitableWorkbench.vue` has **2 pre-existing lint findings** (an unused `apiFetch` import + a `vue/first-attribute-linebreak` warning) **outside my edit region** — present on `origin/main`, left untouched per minimal-scope.

🤖 Generated with [Claude Code](https://claude.com/claude-code)