### PR TITLE
feat(attendance): add managed fixed-schedule controls

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -3260,7 +3260,7 @@
                         <select
                           id="attendance-group-fixed-schedule-shift"
                           v-model="attendanceGroupFixedSchedulePreviewForm.shiftId"
-                          :disabled="shifts.length === 0 || attendanceGroupFixedSchedulePreviewLoading"
+                          :disabled="shifts.length === 0 || attendanceGroupFixedScheduleFormBusy"
                           data-attendance-group-fixed-schedule-shift
                         >
                           <option value="">{{ tr('Select shift', '选择班次') }}</option>
@@ -3275,7 +3275,7 @@
                           id="attendance-group-fixed-schedule-start"
                           v-model="attendanceGroupFixedSchedulePreviewForm.startDate"
                           type="date"
-                          :disabled="attendanceGroupFixedSchedulePreviewLoading"
+                          :disabled="attendanceGroupFixedScheduleFormBusy"
                           data-attendance-group-fixed-schedule-start
                         />
                       </label>
@@ -3285,7 +3285,7 @@
                           id="attendance-group-fixed-schedule-end"
                           v-model="attendanceGroupFixedSchedulePreviewForm.endDate"
                           type="date"
-                          :disabled="attendanceGroupFixedSchedulePreviewLoading"
+                          :disabled="attendanceGroupFixedScheduleFormBusy"
                           data-attendance-group-fixed-schedule-end
                         />
                       </label>
@@ -3309,6 +3309,24 @@
                       >
                         {{ attendanceGroupFixedScheduleApplyLoading ? tr('Applying...', '应用中...') : tr('Apply preview', '应用预览') }}
                       </button>
+                      <button
+                        class="attendance__btn"
+                        type="button"
+                        :disabled="!attendanceGroupFixedScheduleRebuildAvailable"
+                        data-attendance-group-fixed-schedule-rebuild-submit
+                        @click="rebuildAttendanceGroupFixedScheduleManagedRows"
+                      >
+                        {{ attendanceGroupFixedScheduleRebuildLoading ? tr('Rebuilding...', '重建中...') : tr('Rebuild managed rows', '重建已管理排班') }}
+                      </button>
+                      <button
+                        class="attendance__btn"
+                        type="button"
+                        :disabled="!attendanceGroupFixedScheduleClearAvailable"
+                        data-attendance-group-fixed-schedule-clear-submit
+                        @click="clearAttendanceGroupFixedScheduleManagedRows"
+                      >
+                        {{ attendanceGroupFixedScheduleClearLoading ? tr('Clearing...', '清除中...') : tr('Clear managed rows', '清除已管理排班') }}
+                      </button>
                     </div>
                     <div
                       v-if="attendanceGroupFixedSchedulePreviewResult"
@@ -3321,7 +3339,16 @@
                         <span data-attendance-group-fixed-schedule-preview-skip>{{ tr('Skipped', '跳过') }}: {{ attendanceGroupFixedSchedulePreviewResult.skipped.length }}</span>
                         <span data-attendance-group-fixed-schedule-preview-conflict>{{ tr('Blocking conflicts', '阻断冲突') }}: {{ attendanceGroupFixedSchedulePreviewResult.blockingConflicts.length }}</span>
                         <span v-if="attendanceGroupFixedSchedulePreviewResult.applied" data-attendance-group-fixed-schedule-apply-created>{{ tr('Created', '已创建') }}: {{ attendanceGroupFixedSchedulePreviewResult.created?.length ?? 0 }}</span>
+                        <span v-if="attendanceGroupFixedSchedulePreviewResult.rebuilt" data-attendance-group-fixed-schedule-rebuild-created>{{ tr('Created', '已创建') }}: {{ attendanceGroupFixedSchedulePreviewResult.created?.length ?? 0 }}</span>
+                        <span v-if="attendanceGroupFixedSchedulePreviewResult.deactivated" data-attendance-group-fixed-schedule-deactivated>{{ tr('Deactivated', '已停用') }}: {{ attendanceGroupFixedSchedulePreviewResult.deactivated.length }}</span>
                       </div>
+                      <small
+                        v-if="attendanceGroupFixedScheduleManagedConflictHint"
+                        class="attendance__field-hint"
+                        data-attendance-group-fixed-schedule-clear-first-hint
+                      >
+                        {{ attendanceGroupFixedScheduleManagedConflictHint }}
+                      </small>
                       <small class="attendance__field-hint">{{ tr('If blocking conflicts are present, apply stays disabled and writes nothing.', '如果存在阻断冲突，应用保持禁用且零写入。') }}</small>
                     </div>
                   </section>
@@ -6318,6 +6345,10 @@ interface AttendanceGroupFixedSchedulePreviewSkipped {
   shiftId: string
   startDate: string
   endDate: string | null
+  ownership?: 'managed' | 'unmanaged' | 'externalManaged'
+  producerType?: string | null
+  producerRefId?: string | null
+  producerKey?: string | null
 }
 
 interface AttendanceGroupFixedSchedulePreviewConflict {
@@ -6331,6 +6362,7 @@ interface AttendanceGroupFixedSchedulePreviewConflict {
   existingStartDate: string
   existingEndDate: string | null
   message?: string
+  managedScheduleAction?: 'clear_existing_managed_schedule_first'
 }
 
 interface AttendanceGroupFixedSchedulePreviewResult {
@@ -6346,9 +6378,14 @@ interface AttendanceGroupFixedSchedulePreviewResult {
   }
   wouldCreate: AttendanceGroupFixedSchedulePreviewCandidate[]
   skipped: AttendanceGroupFixedSchedulePreviewSkipped[]
+  skippedManaged?: AttendanceGroupFixedSchedulePreviewSkipped[]
+  skippedUnmanaged?: AttendanceGroupFixedSchedulePreviewSkipped[]
+  skippedExternalManaged?: AttendanceGroupFixedSchedulePreviewSkipped[]
   blockingConflicts: AttendanceGroupFixedSchedulePreviewConflict[]
   created?: AttendanceAssignment[]
+  deactivated?: AttendanceAssignment[]
   applied?: boolean
+  rebuilt?: boolean
 }
 
 type AttendanceGroupSummaryAction = {
@@ -6933,6 +6970,8 @@ const attendanceGroupMemberLoading = ref(false)
 const attendanceGroupMemberSaving = ref(false)
 const attendanceGroupFixedSchedulePreviewLoading = ref(false)
 const attendanceGroupFixedScheduleApplyLoading = ref(false)
+const attendanceGroupFixedScheduleRebuildLoading = ref(false)
+const attendanceGroupFixedScheduleClearLoading = ref(false)
 const payrollTemplateLoading = ref(false)
 const payrollTemplateSaving = ref(false)
 const payrollSummaryFieldOptionsLoading = ref(false)
@@ -8234,7 +8273,22 @@ const attendanceGroupFixedSchedulePreviewAvailable = computed(() =>
       && attendanceGroupFixedSchedulePreviewForm.shiftId
       && attendanceGroupFixedSchedulePreviewForm.startDate
       && attendanceGroupFixedSchedulePreviewForm.endDate
-      && !attendanceGroupFixedSchedulePreviewLoading.value,
+      && !attendanceGroupFixedScheduleFormBusy.value,
+  )
+)
+const attendanceGroupFixedScheduleFormBusy = computed(() =>
+  attendanceGroupFixedSchedulePreviewLoading.value
+    || attendanceGroupFixedScheduleApplyLoading.value
+    || attendanceGroupFixedScheduleRebuildLoading.value
+    || attendanceGroupFixedScheduleClearLoading.value
+)
+const attendanceGroupFixedScheduleManagedActionAvailable = computed(() =>
+  Boolean(
+    attendanceGroupEditingId.value
+      && attendanceGroupFixedSchedulePreviewForm.shiftId
+      && attendanceGroupFixedSchedulePreviewForm.startDate
+      && attendanceGroupFixedSchedulePreviewForm.endDate
+      && !attendanceGroupFixedScheduleFormBusy.value,
   )
 )
 const attendanceGroupFixedScheduleApplyAvailable = computed(() =>
@@ -8242,16 +8296,26 @@ const attendanceGroupFixedScheduleApplyAvailable = computed(() =>
     attendanceGroupFixedSchedulePreviewResult.value
       && attendanceGroupFixedSchedulePreviewResult.value.blockingConflicts.length === 0
       && !attendanceGroupFixedSchedulePreviewResult.value.applied
-      && !attendanceGroupFixedSchedulePreviewLoading.value
-      && !attendanceGroupFixedScheduleApplyLoading.value,
+      && !attendanceGroupFixedSchedulePreviewResult.value.rebuilt
+      && !attendanceGroupFixedScheduleFormBusy.value,
   )
 )
+const attendanceGroupFixedScheduleRebuildAvailable = computed(() => attendanceGroupFixedScheduleManagedActionAvailable.value)
+const attendanceGroupFixedScheduleClearAvailable = computed(() => attendanceGroupFixedScheduleManagedActionAvailable.value)
 const attendanceGroupFixedSchedulePreviewSummary = computed(() => {
   const result = attendanceGroupFixedSchedulePreviewResult.value
   if (!result) return ''
   return tr(
     `${result.target.total} target members · ${result.wouldCreate.length} would create · ${result.skipped.length} skipped · ${result.blockingConflicts.length} blocking conflicts`,
     `${result.target.total} 位目标成员 · ${result.wouldCreate.length} 位将创建 · ${result.skipped.length} 位跳过 · ${result.blockingConflicts.length} 个阻断冲突`,
+  )
+})
+const attendanceGroupFixedScheduleManagedConflictHint = computed(() => {
+  const result = attendanceGroupFixedSchedulePreviewResult.value
+  if (!result?.blockingConflicts.some(item => item.managedScheduleAction === 'clear_existing_managed_schedule_first')) return ''
+  return tr(
+    'A different managed schedule for this group is blocking the selected window. Clear the existing managed rows first, then preview again.',
+    '此考勤组已有不同窗口的已管理排班阻断当前选择。请先清除旧的已管理排班，再重新预览。',
   )
 })
 const importCsvFile = ref<File | null>(null)
@@ -16146,6 +16210,15 @@ async function previewAttendanceGroupFixedSchedule() {
   }
 }
 
+function buildAttendanceGroupFixedScheduleRequestBody(): Record<string, string | undefined> {
+  return {
+    shiftId: attendanceGroupFixedSchedulePreviewForm.shiftId,
+    startDate: attendanceGroupFixedSchedulePreviewForm.startDate,
+    endDate: attendanceGroupFixedSchedulePreviewForm.endDate,
+    orgId: normalizedOrgId(),
+  }
+}
+
 async function applyAttendanceGroupFixedSchedulePreview() {
   const groupId = attendanceGroupEditingId.value
   const preview = attendanceGroupFixedSchedulePreviewResult.value
@@ -16161,12 +16234,7 @@ async function applyAttendanceGroupFixedSchedulePreview() {
   try {
     const response = await apiFetch(`/api/attendance/groups/${groupId}/fixed-schedule/apply`, {
       method: 'POST',
-      body: JSON.stringify({
-        shiftId: attendanceGroupFixedSchedulePreviewForm.shiftId,
-        startDate: attendanceGroupFixedSchedulePreviewForm.startDate,
-        endDate: attendanceGroupFixedSchedulePreviewForm.endDate,
-        orgId: normalizedOrgId(),
-      }),
+      body: JSON.stringify(buildAttendanceGroupFixedScheduleRequestBody()),
     })
     if (response.status === 403) {
       adminForbidden.value = true
@@ -16184,6 +16252,78 @@ async function applyAttendanceGroupFixedSchedulePreview() {
     setStatus(readErrorMessage(error, tr('Failed to apply fixed schedule', '应用固定排班失败')), 'error')
   } finally {
     attendanceGroupFixedScheduleApplyLoading.value = false
+  }
+}
+
+async function rebuildAttendanceGroupFixedScheduleManagedRows() {
+  const groupId = attendanceGroupEditingId.value
+  if (!groupId) {
+    setStatus(tr('Save the group before rebuilding managed fixed schedules.', '请先保存考勤组，再重建已管理固定排班。'), 'error')
+    return
+  }
+  if (!attendanceGroupFixedScheduleManagedActionAvailable.value) return
+  attendanceGroupFixedScheduleRebuildLoading.value = true
+  try {
+    const response = await apiFetch(`/api/attendance/groups/${groupId}/fixed-schedule/rebuild`, {
+      method: 'POST',
+      body: JSON.stringify(buildAttendanceGroupFixedScheduleRequestBody()),
+    })
+    if (response.status === 403) {
+      adminForbidden.value = true
+      throw new Error(tr('Admin permissions required', '需要管理员权限'))
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to rebuild managed fixed schedule rows', '重建已管理固定排班失败')))
+    }
+    adminForbidden.value = false
+    attendanceGroupFixedSchedulePreviewResult.value = data.data as AttendanceGroupFixedSchedulePreviewResult
+    await loadAssignments()
+    setStatus(tr('Managed fixed schedule rows rebuilt.', '已重建已管理固定排班。'))
+  } catch (error: any) {
+    setStatus(readErrorMessage(error, tr('Failed to rebuild managed fixed schedule rows', '重建已管理固定排班失败')), 'error')
+  } finally {
+    attendanceGroupFixedScheduleRebuildLoading.value = false
+  }
+}
+
+async function clearAttendanceGroupFixedScheduleManagedRows() {
+  const groupId = attendanceGroupEditingId.value
+  if (!groupId) {
+    setStatus(tr('Save the group before clearing managed fixed schedules.', '请先保存考勤组，再清除已管理固定排班。'), 'error')
+    return
+  }
+  if (!attendanceGroupFixedScheduleManagedActionAvailable.value) return
+  if (!window.confirm(tr(
+    'Clear managed fixed schedule rows for this shift and date window? Unmanaged/manual rows will not be touched.',
+    '确认清除此班次与日期窗口的已管理固定排班吗？未管理/手工排班不会被修改。',
+  ))) return
+  attendanceGroupFixedScheduleClearLoading.value = true
+  try {
+    const response = await apiFetch(`/api/attendance/groups/${groupId}/fixed-schedule/clear`, {
+      method: 'POST',
+      body: JSON.stringify(buildAttendanceGroupFixedScheduleRequestBody()),
+    })
+    if (response.status === 403) {
+      adminForbidden.value = true
+      throw new Error(tr('Admin permissions required', '需要管理员权限'))
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to clear managed fixed schedule rows', '清除已管理固定排班失败')))
+    }
+    adminForbidden.value = false
+    attendanceGroupFixedSchedulePreviewResult.value = null
+    await loadAssignments()
+    const count = Array.isArray(data.data?.deactivated) ? data.data.deactivated.length : 0
+    setStatus(tr(
+      `Cleared ${count} managed fixed schedule rows.`,
+      `已清除 ${count} 条已管理固定排班。`,
+    ))
+  } catch (error: any) {
+    setStatus(readErrorMessage(error, tr('Failed to clear managed fixed schedule rows', '清除已管理固定排班失败')), 'error')
+  } finally {
+    attendanceGroupFixedScheduleClearLoading.value = false
   }
 }
 

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -987,6 +987,315 @@ describe('Attendance admin regressions', () => {
     )).toBe(false)
   })
 
+  it('rebuilds and clears managed fixed schedule rows through group routes', async () => {
+    const rebuildBodies: unknown[] = []
+    const clearBodies: unknown[] = []
+    const confirmSpy = vi.spyOn(window, 'confirm')
+      .mockReturnValueOnce(false)
+      .mockReturnValueOnce(true)
+    const rebuiltData = {
+      group: { id: 'group-a', name: 'Ops Team', timezone: 'Asia/Shanghai' },
+      shift: {
+        id: 'shift-a',
+        name: 'Day shift',
+        timezone: 'Asia/Shanghai',
+        workStartTime: '09:00',
+        workEndTime: '18:00',
+        lateGraceMinutes: 10,
+        earlyGraceMinutes: 5,
+        roundingMinutes: 5,
+        workingDays: [1, 2, 3, 4, 5],
+      },
+      window: { startDate: '2026-06-01', endDate: '2026-06-30' },
+      target: { total: 2, userIds: ['user-create', 'user-stale'] },
+      wouldCreate: [
+        { userId: 'user-create', shiftId: 'shift-a', startDate: '2026-06-01', endDate: '2026-06-30', isActive: true },
+      ],
+      skipped: [],
+      skippedManaged: [],
+      skippedUnmanaged: [],
+      skippedExternalManaged: [],
+      blockingConflicts: [],
+      rebuilt: true,
+      created: [
+        { id: 'assignment-created', userId: 'user-create', shiftId: 'shift-a', startDate: '2026-06-01', endDate: '2026-06-30', isActive: true },
+      ],
+      deactivated: [
+        { id: 'assignment-stale', userId: 'user-stale', shiftId: 'shift-a', startDate: '2026-06-01', endDate: '2026-06-30', isActive: false },
+      ],
+    }
+
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/rule-sets')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              { id: 'rule-set-1', name: 'Ops Rules', scope: 'org', version: 3, isDefault: true },
+            ],
+            total: 1,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/groups/group-a/fixed-schedule/rebuild') && init?.method === 'POST') {
+        rebuildBodies.push(JSON.parse(String(init.body || '{}')))
+        return jsonResponse(200, { ok: true, data: rebuiltData })
+      }
+      if (url.includes('/api/attendance/groups/group-a/fixed-schedule/clear') && init?.method === 'POST') {
+        clearBodies.push(JSON.parse(String(init.body || '{}')))
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            producer: {
+              type: 'attendance_group_fixed_schedule',
+              refId: 'group-a',
+              key: 'attendance_group_fixed_schedule:group-a:shift-a:2026-06-01:2026-06-30',
+            },
+            deactivated: [
+              { id: 'assignment-created', userId: 'user-create', shiftId: 'shift-a', startDate: '2026-06-01', endDate: '2026-06-30', isActive: false },
+              { id: 'assignment-stale', userId: 'user-stale', shiftId: 'shift-a', startDate: '2026-06-01', endDate: '2026-06-30', isActive: false },
+            ],
+            cleared: true,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/groups/group-a/members')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              { id: 'member-1', groupId: 'group-a', userId: 'user-create', createdAt: '2026-03-28T08:00:00.000Z' },
+            ],
+            total: 2,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/groups')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'group-a',
+                name: 'Ops Team',
+                code: 'ops-team',
+                timezone: 'Asia/Shanghai',
+                ruleSetId: 'rule-set-1',
+                description: 'Operations attendance group',
+              },
+            ],
+            total: 1,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/shifts')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'shift-a',
+                name: 'Day shift',
+                timezone: 'Asia/Shanghai',
+                workStartTime: '09:00',
+                workEndTime: '18:00',
+                lateGraceMinutes: 10,
+                earlyGraceMinutes: 5,
+                roundingMinutes: 5,
+                workingDays: [1, 2, 3, 4, 5],
+              },
+            ],
+          },
+        })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-groups"]')!.click()
+    await flushUi(4)
+
+    const previewPanel = container!.querySelector<HTMLElement>('[data-attendance-group-fixed-schedule-preview]')
+    expect(previewPanel).toBeTruthy()
+    const shiftSelect = previewPanel!.querySelector<HTMLSelectElement>('[data-attendance-group-fixed-schedule-shift]')
+    expect(shiftSelect).toBeTruthy()
+    shiftSelect!.value = 'shift-a'
+    shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(previewPanel!, '[data-attendance-group-fixed-schedule-start]', '2026-06-01')
+    setInput(previewPanel!, '[data-attendance-group-fixed-schedule-end]', '2026-06-30')
+    await flushUi(2)
+
+    const expectedBody = {
+      shiftId: 'shift-a',
+      startDate: '2026-06-01',
+      endDate: '2026-06-30',
+    }
+    const rebuildButton = previewPanel!.querySelector<HTMLButtonElement>('[data-attendance-group-fixed-schedule-rebuild-submit]')
+    const clearButton = previewPanel!.querySelector<HTMLButtonElement>('[data-attendance-group-fixed-schedule-clear-submit]')
+    expect(rebuildButton).toBeTruthy()
+    expect(clearButton).toBeTruthy()
+    expect(rebuildButton!.disabled).toBe(false)
+    expect(clearButton!.disabled).toBe(false)
+
+    try {
+      rebuildButton!.click()
+      await flushUi(8)
+
+      expect(rebuildBodies).toEqual([expectedBody])
+      expect(previewPanel!.querySelector('[data-attendance-group-fixed-schedule-rebuild-created]')?.textContent).toContain('1')
+      expect(previewPanel!.querySelector('[data-attendance-group-fixed-schedule-deactivated]')?.textContent).toContain('1')
+
+      clearButton!.click()
+      await flushUi(2)
+      expect(confirmSpy).toHaveBeenCalledTimes(1)
+      expect(clearBodies).toEqual([])
+
+      clearButton!.click()
+      await flushUi(8)
+
+      expect(clearBodies).toEqual([expectedBody])
+      expect(previewPanel!.querySelector('[data-attendance-group-fixed-schedule-preview-result]')).toBeNull()
+      expect(container!.textContent).toContain('Cleared 2 managed fixed schedule rows.')
+      expect(vi.mocked(apiFetch).mock.calls.some(([input, init]) =>
+        String(input) === '/api/attendance/assignments' && init?.method === 'POST'
+      )).toBe(false)
+    } finally {
+      confirmSpy.mockRestore()
+    }
+  })
+
+  it('shows a clear-first hint when a managed fixed schedule blocks the selected window', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      if (url.includes('/api/attendance/rule-sets')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              { id: 'rule-set-1', name: 'Ops Rules', scope: 'org', version: 3, isDefault: true },
+            ],
+            total: 1,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/groups/group-a/fixed-schedule/preview') && init?.method === 'POST') {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            group: { id: 'group-a', name: 'Ops Team', timezone: 'Asia/Shanghai' },
+            shift: {
+              id: 'shift-a',
+              name: 'Day shift',
+              timezone: 'Asia/Shanghai',
+              workStartTime: '09:00',
+              workEndTime: '18:00',
+              lateGraceMinutes: 10,
+              earlyGraceMinutes: 5,
+              roundingMinutes: 5,
+              workingDays: [1, 2, 3, 4, 5],
+            },
+            window: { startDate: '2026-06-01', endDate: '2026-06-30' },
+            target: { total: 1, userIds: ['user-a'] },
+            wouldCreate: [],
+            skipped: [],
+            blockingConflicts: [
+              {
+                conflictType: 'shift_assignment_overlap',
+                draftKind: 'shift',
+                existingKind: 'shift',
+                assignmentId: 'assignment-managed-old-window',
+                userId: 'user-a',
+                startDate: '2026-06-01',
+                endDate: '2026-06-30',
+                existingStartDate: '2026-05-15',
+                existingEndDate: '2026-06-15',
+                managedScheduleAction: 'clear_existing_managed_schedule_first',
+                message: 'Shift assignment overlaps an active shift assignment for the same user',
+              },
+            ],
+          },
+        })
+      }
+      if (url.includes('/api/attendance/groups/group-a/members')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              { id: 'member-1', groupId: 'group-a', userId: 'user-a', createdAt: '2026-03-28T08:00:00.000Z' },
+            ],
+            total: 1,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/groups')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'group-a',
+                name: 'Ops Team',
+                code: 'ops-team',
+                timezone: 'Asia/Shanghai',
+                ruleSetId: 'rule-set-1',
+                description: 'Operations attendance group',
+              },
+            ],
+            total: 1,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/shifts')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'shift-a',
+                name: 'Day shift',
+                timezone: 'Asia/Shanghai',
+                workStartTime: '09:00',
+                workEndTime: '18:00',
+                lateGraceMinutes: 10,
+                earlyGraceMinutes: 5,
+                roundingMinutes: 5,
+                workingDays: [1, 2, 3, 4, 5],
+              },
+            ],
+          },
+        })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-groups"]')!.click()
+    await flushUi(4)
+
+    const previewPanel = container!.querySelector<HTMLElement>('[data-attendance-group-fixed-schedule-preview]')
+    expect(previewPanel).toBeTruthy()
+    const shiftSelect = previewPanel!.querySelector<HTMLSelectElement>('[data-attendance-group-fixed-schedule-shift]')
+    expect(shiftSelect).toBeTruthy()
+    shiftSelect!.value = 'shift-a'
+    shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(previewPanel!, '[data-attendance-group-fixed-schedule-start]', '2026-06-01')
+    setInput(previewPanel!, '[data-attendance-group-fixed-schedule-end]', '2026-06-30')
+    await flushUi(2)
+
+    previewPanel!.querySelector<HTMLButtonElement>('[data-attendance-group-fixed-schedule-preview-submit]')!.click()
+    await flushUi(8)
+
+    expect(previewPanel!.querySelector('[data-attendance-group-fixed-schedule-clear-first-hint]')?.textContent).toContain('Clear the existing managed rows first')
+    expect(previewPanel!.querySelector<HTMLButtonElement>('[data-attendance-group-fixed-schedule-apply-submit]')?.disabled).toBe(true)
+  })
+
   it('renders the production calendar-policy quick-add panel and appends a group day-index row', async () => {
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)

--- a/docs/development/attendance-group-admin-ux-fixed-schedule-managed-rebuild-clear-ui-verification-20260528.md
+++ b/docs/development/attendance-group-admin-ux-fixed-schedule-managed-rebuild-clear-ui-verification-20260528.md
@@ -1,0 +1,82 @@
+# Attendance Group Fixed-Schedule Managed Rebuild/Clear UI Verification - 2026-05-28
+
+## Scope
+
+This slice wires the existing FS-D3 backend operations into the production attendance group admin surface.
+
+It follows:
+
+- `attendance-group-admin-ux-fixed-schedule-managed-provenance-design-20260528.md`
+- `attendance-group-admin-ux-fixed-schedule-managed-rebuild-clear-verification-20260528.md`
+
+## Delivered Behavior
+
+The fixed-schedule panel now exposes two explicit managed-row controls for a saved attendance group, selected shift, and date window:
+
+- `Rebuild managed rows` posts to `POST /api/attendance/groups/:id/fixed-schedule/rebuild`.
+- `Clear managed rows` asks for confirmation, then posts to `POST /api/attendance/groups/:id/fixed-schedule/clear`.
+
+Both controls reuse the same request body as preview/apply:
+
+- `shiftId`
+- `startDate`
+- `endDate`
+- optional `orgId`
+
+The UI shows rebuild created/deactivated counts from the backend result. A successful clear removes the stale preview result and reports the number of soft-deactivated managed rows.
+
+## Clear-First Hint
+
+When backend preview/rebuild classification reports:
+
+```json
+{
+  "managedScheduleAction": "clear_existing_managed_schedule_first"
+}
+```
+
+the panel shows a clear-first hint. This keeps the F1 operator path explicit: if an older managed schedule with a different producer key blocks the selected window, the operator should clear those managed rows first, then preview/rebuild again.
+
+## Boundaries Held
+
+- Frontend-only.
+- No backend, schema, migration, route, permission, or OpenAPI change.
+- No direct `/api/attendance/assignments` fallback.
+- No weekly matrix, daily multi-shift modeling, rotation generation, punch-method config, owner/sub-owner, export/copy, or comprehensive-hours write surface.
+- The retired `AttendanceRulesAndGroupsSection.vue` component stays retired.
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+git diff --check
+```
+
+Results:
+
+- frontend regression suite: PASS, 32/32
+- `vue-tsc --noEmit`: PASS
+- `git diff --check`: PASS
+
+New coverage:
+
+- rebuild posts once to the group rebuild route with the selected shift/date body;
+- clear asks for confirmation, does not post when cancelled, and posts once when confirmed;
+- rebuild/clear never fall back to `POST /api/attendance/assignments`;
+- clear removes the preview result and reports the deactivated count;
+- managed different-key conflicts render the clear-first hint and keep apply disabled.
+
+## Deferred
+
+The following remain separate opt-ins:
+
+- weekly matrix;
+- daily multi-shift modeling;
+- group-owned rotation generation;
+- group-specific punch method configuration;
+- owner/sub-owner roles;
+- export/copy controls;
+- comprehensive-hours writes from group detail.


### PR DESCRIPTION
## Summary
- add production attendance-group UI controls for the existing managed fixed-schedule rebuild and clear routes
- show rebuild created/deactivated counts and clear-first guidance for managed different-window conflicts
- clear requires confirmation, removes stale preview state, and never falls back to single assignment POSTs
- add a verification note for the FS-D3 UI closure

## Boundaries
- frontend/docs only; no backend, schema, migration, route, permission, or OpenAPI changes
- consumes the existing #2019 rebuild/clear backend routes
- no weekly matrix, multi-shift modeling, punch-method config, owner/sub-owner, export/copy, or comprehensive-hours write surface

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false
- pnpm --filter @metasheet/web exec vue-tsc --noEmit
- git diff --check origin/main..HEAD
