### PR TITLE
feat(data-sources): B5A — opt-in real-wire SQL Server smoke gate

### DIFF
--- a/docs/development/sqlserver-smoke-runbook-20260528.md
+++ b/docs/development/sqlserver-smoke-runbook-20260528.md
@@ -51,6 +51,11 @@ Use either `MSSQL_HOST` plus `MSSQL_PORT`, or `MSSQL_SERVER`. If both are suppli
 
 ## Run
 
+> Opt-in gate (B5A): with no `MSSQL_HOST`/`MSSQL_SERVER` set, this command **skips (exit 0)** and is
+> therefore CI-safe; configure a target (above) to run it for real. The gate behavior, strengthened
+> coverage (incl. the OFFSET/FETCH branch), and a 2019/2022 container recipe are in
+> `sqlserver-smoke-wire-gate-verification-20260529.md`.
+
 ```bash
 pnpm --filter @metasheet/core-backend smoke:sqlserver
 ```

--- a/docs/development/sqlserver-smoke-runbook-20260528.md
+++ b/docs/development/sqlserver-smoke-runbook-20260528.md
@@ -83,8 +83,14 @@ If `MSSQL_TABLE` is set, it should also print:
 ```text
 [ok] table exists
 [ok] table info
-[ok] select sample
+[ok] select sample (TOP)
+[ok] select page (OFFSET/FETCH)
 ```
+
+The two `select` lines cover both pagination branches (`TOP` and `OFFSET…FETCH`). They run only when
+`MSSQL_SCHEMA` is the default `dbo`: `adapter.select()` is not schema-qualified, so on a non-`dbo`
+schema you instead see `[skip] select probes …` and only the schema-qualified metadata checks
+(`table exists` / `table info`) run.
 
 ## Local SQL Server Option
 
@@ -97,7 +103,7 @@ Do not run the container against customer data. For customer verification, prefe
 - All required `[ok]` lines appear.
 - No password or token is printed.
 - `MSSQL_ENCRYPT=true` works with the target server, or any `MSSQL_ENCRYPT=false` fallback is explicitly recorded as a legacy compatibility exception.
-- If a real table is supplied, `select sample` returns without write permissions.
+- If a real table is supplied on the default `dbo` schema, both `select sample (TOP)` and `select page (OFFSET/FETCH)` return without write permissions. On a non-`dbo` schema the select probes are skipped (`adapter.select()` is not schema-qualified); the schema-qualified metadata checks still run.
 
 ## Failure Triage
 

--- a/docs/development/sqlserver-smoke-wire-gate-verification-20260529.md
+++ b/docs/development/sqlserver-smoke-wire-gate-verification-20260529.md
@@ -32,8 +32,12 @@ The smoke drives `MSSQLAdapter` end-to-end against the target:
 2. `testConnection()` — `SELECT 1`.
 3. parameterized query — `SELECT $1` → exercises the `$N`→`@pN` translation.
 4. `getSchema(schema)` — `INFORMATION_SCHEMA` + `sys.*` introspection (skippable via `MSSQL_SKIP_SCHEMA`).
-5. (with `MSSQL_TABLE`) `tableExists` + `getTableInfo` (columns + PK) + `select` **TOP** (`{limit}`) + `select`
-   **OFFSET/FETCH** (`{limit, offset, orderBy}`) — both pagination branches.
+5. (with `MSSQL_TABLE`) `tableExists` + `getTableInfo` (columns + PK), and — **only on the default `dbo`
+   schema** — `select` **TOP** (`{limit}`) + `select` **OFFSET/FETCH** (`{limit, offset, orderBy}`), both
+   pagination branches. `adapter.select()` emits `FROM [table]` (unqualified → resolves against the login
+   default schema), so on a non-`dbo` `MSSQL_SCHEMA` the select probes are **skipped** (`[skip] select
+   probes …`) while the schema-qualified `tableExists`/`getTableInfo` still run. (Making `select()`
+   schema-aware is a separate adapter enhancement, not B5A.)
 
 No write path is exercised (the source is read-only by default; write-enable is a separate gate).
 

--- a/docs/development/sqlserver-smoke-wire-gate-verification-20260529.md
+++ b/docs/development/sqlserver-smoke-wire-gate-verification-20260529.md
@@ -1,0 +1,78 @@
+# SQL Server real-wire smoke gate — verification (B5A)
+
+Date: 2026-05-29 · Track: data-sources Lane B · Slice: **B5A** (real-wire smoke gate)
+
+Companion to the run instructions in `sqlserver-smoke-runbook-20260528.md` (#1989). This slice makes
+the smoke an **opt-in gate** (CI-safe) and strengthens its coverage, so the generic `type=sqlserver`
+adapter (`MSSQLAdapter`, #1985) can be **proven against a real SQL Server**, not only the fake-driver
+unit tests. It does **not** touch the K3 `k3-wise-sqlserver` channel, Windows-native deploy, or add
+any new connector.
+
+## Why this slice
+Before B5A the `MSSQLAdapter` had been exercised **only against a structural fake driver** (unit tests
+in `mssql-adapter.test.ts`). There was **no evidence** that its generated SQL — `[bracket]` quoting,
+`TOP` / `OFFSET…FETCH`, `$N`→`@pN` parameter translation, `INFORMATION_SCHEMA`/`sys.*` introspection —
+actually executes against a real SQL Server engine. That is the classic wire-vs-fixture gap. B5A closes
+it with a real-connection smoke, gated so it never runs (and never falsely "passes") in normal CI.
+
+## Gate behavior (CI-safe, opt-in)
+`pnpm --filter @metasheet/core-backend smoke:sqlserver` now:
+- **Skips cleanly (exit 0)** when no target is configured (`MSSQL_HOST` and `MSSQL_SERVER` both unset).
+  Safe to invoke anywhere — normal CI has no SQL Server, so it is a no-op there, **not a failure and not
+  a silent green over a broken path**.
+- **Runs for real** when a target is configured. A configured-but-incomplete env (e.g. host set, password
+  missing) still fails loudly — that is a misconfiguration, not a skip.
+
+This avoids the "skip-when-unreachable" trap two ways: the skip is explicit and logged, and the real run
+is the only thing that can print the `[ok]` lines.
+
+## Coverage (read-only; matches the A-RO posture)
+The smoke drives `MSSQLAdapter` end-to-end against the target:
+1. `connect()` — loads the `mssql` driver, TCP + TLS handshake (default `encrypt=true`, `trustServerCertificate=true`).
+2. `testConnection()` — `SELECT 1`.
+3. parameterized query — `SELECT $1` → exercises the `$N`→`@pN` translation.
+4. `getSchema(schema)` — `INFORMATION_SCHEMA` + `sys.*` introspection (skippable via `MSSQL_SKIP_SCHEMA`).
+5. (with `MSSQL_TABLE`) `tableExists` + `getTableInfo` (columns + PK) + `select` **TOP** (`{limit}`) + `select`
+   **OFFSET/FETCH** (`{limit, offset, orderBy}`) — both pagination branches.
+
+No write path is exercised (the source is read-only by default; write-enable is a separate gate).
+
+## Run against a real SQL Server
+
+### Option A — 2019/2022 container (Linux, free official image — recommended for our own verification)
+```bash
+# 2022 (or mcr.microsoft.com/mssql/server:2019-latest)
+docker run -d --name mssql-smoke -e 'ACCEPT_EULA=Y' -e 'MSSQL_SA_PASSWORD=Str0ng!Passw0rd' \
+  -p 1433:1433 mcr.microsoft.com/mssql/server:2022-latest
+# wait for startup, then:
+export MSSQL_HOST=127.0.0.1 MSSQL_PORT=1433 MSSQL_DATABASE=master \
+       MSSQL_USERNAME=sa MSSQL_PASSWORD='Str0ng!Passw0rd' MSSQL_ENCRYPT=true MSSQL_TRUST_SERVER_CERTIFICATE=true
+pnpm --filter @metasheet/core-backend smoke:sqlserver
+# optionally point MSSQL_TABLE at a real table to exercise tableInfo + both select branches
+docker rm -f mssql-smoke
+```
+(On Apple Silicon the image is amd64 → Docker Desktop emulation; on an amd64 Linux host it runs natively.)
+
+### Option B — customer / real Windows SQL Server
+Use a **read-only** SQL login; never the container against customer data. See the runbook for prerequisites
+(TCP/IP enabled, port reachable) and failure triage.
+
+## Pass criteria
+- With no env: `[skip] … Exiting 0.` and exit code 0.
+- With a target: all applicable `[ok]` lines print; no password/token printed; `select` returns without
+  write permission; if `MSSQL_ENCRYPT=false` was needed it is recorded as an explicit legacy exception.
+
+## Evidence
+
+| Check | Status | Evidence |
+|---|---|---|
+| Gate skips cleanly without env (CI-safe) | ✅ **PASS (2026-05-29)** | `[skip] SQL Server smoke skipped — no MSSQL_HOST / MSSQL_SERVER set … Exiting 0.` · **exit code 0** (run on the authoring host with all `MSSQL_*` unset) |
+| `tsc --noEmit` (core-backend) | ✅ PASS | clean |
+| fake-driver unit suite (`mssql-adapter.test.ts`) | ✅ PASS (pre-existing, #1985/#1997) | green |
+| **Real-wire run against 2019/2022 container or customer SQL Server** | ⏳ **PENDING** | **No docker on the authoring machine** → not run here. To be executed per "Option A/B" above; **evidence to be backfilled into this table** (paste the `[ok]` lines). Not claimed as done until then. |
+
+## Scope / non-goals
+- Read-only smoke; no write path, no schema mutation.
+- Does **not** touch `plugin-integration-core`'s `k3-wise-sqlserver` channel, RBAC, or auth.
+- Not Windows-native deploy (Lane C) and not a new connector.
+- Next: **B4** (full 2017/2019/2022 version-compat matrix on this harness; 2008R2/2012 → Windows VM follow-up).

--- a/packages/core-backend/scripts/smoke-sqlserver.ts
+++ b/packages/core-backend/scripts/smoke-sqlserver.ts
@@ -162,27 +162,40 @@ async function main(): Promise<void> {
         primaryKey: tableInfo.primaryKey ?? []
       })
 
-      const sample = await adapter.select(table, { limit: 5 })
-      if (sample.error) throw sample.error
-      console.log('[ok] select sample (TOP)', {
-        table: `${schema}.${table}`,
-        rows: sample.data.length
-      })
-
-      // Exercise the OFFSET/FETCH + ORDER BY branch as well (the TOP path above does not cover it).
-      const orderColumn = tableInfo.primaryKey?.[0] ?? tableInfo.columns[0]?.name
-      if (orderColumn) {
-        const paged = await adapter.select(table, {
-          limit: 3,
-          offset: 1,
-          orderBy: [{ column: orderColumn, direction: 'asc' }]
-        })
-        if (paged.error) throw paged.error
-        console.log('[ok] select page (OFFSET/FETCH)', {
+      // adapter.select() emits `FROM [table]` WITHOUT a schema, so it resolves against the login's
+      // DEFAULT schema — not necessarily MSSQL_SCHEMA. Only run the select codegen probes when the
+      // target is the default schema (dbo); otherwise they'd query the wrong table (false-fail, or
+      // worse, silently sample a same-named table in the default schema). The metadata checks above
+      // ARE schema-qualified, so they still run for any schema.
+      if (schema === 'dbo') {
+        const sample = await adapter.select(table, { limit: 5 })
+        if (sample.error) throw sample.error
+        console.log('[ok] select sample (TOP)', {
           table: `${schema}.${table}`,
-          orderBy: orderColumn,
-          rows: paged.data.length
+          rows: sample.data.length
         })
+
+        // Exercise the OFFSET/FETCH + ORDER BY branch as well (the TOP path above does not cover it).
+        const orderColumn = tableInfo.primaryKey?.[0] ?? tableInfo.columns[0]?.name
+        if (orderColumn) {
+          const paged = await adapter.select(table, {
+            limit: 3,
+            offset: 1,
+            orderBy: [{ column: orderColumn, direction: 'asc' }]
+          })
+          if (paged.error) throw paged.error
+          console.log('[ok] select page (OFFSET/FETCH)', {
+            table: `${schema}.${table}`,
+            orderBy: orderColumn,
+            rows: paged.data.length
+          })
+        }
+      } else {
+        console.log(
+          '[skip] select probes (TOP / OFFSET-FETCH) — adapter.select() is not schema-qualified; it ' +
+            `queries the login default schema, not "${schema}". Use a dbo table (or MSSQL_SCHEMA=dbo) ` +
+            `to cover the select codegen paths. (Metadata above WAS checked against "${schema}".)`
+        )
       }
     }
   } finally {

--- a/packages/core-backend/scripts/smoke-sqlserver.ts
+++ b/packages/core-backend/scripts/smoke-sqlserver.ts
@@ -6,6 +6,9 @@ const env = process.env
 function printHelp(): void {
   console.log(`Usage: pnpm --filter @metasheet/core-backend smoke:sqlserver
 
+Opt-in real-wire gate: with no MSSQL_HOST/MSSQL_SERVER set it SKIPS (exit 0), so it is safe in
+normal CI. Configure a target to run it for real against a SQL Server.
+
 Required environment:
   MSSQL_HOST or MSSQL_SERVER
   MSSQL_DATABASE
@@ -90,6 +93,17 @@ function buildConfig(): DataSourceConfig {
 }
 
 async function main(): Promise<void> {
+  // Opt-in real-wire gate (B5A): skip cleanly (exit 0) when no SQL Server target is configured, so
+  // this is safe in normal CI and on machines without a SQL Server. A target (MSSQL_HOST or
+  // MSSQL_SERVER) present = opted in → run for real (a missing required var then fails loudly).
+  if (!env.MSSQL_HOST && !env.MSSQL_SERVER) {
+    console.log(
+      '[skip] SQL Server smoke skipped — no MSSQL_HOST / MSSQL_SERVER set. This is an opt-in ' +
+        'real-wire gate; export MSSQL_* (see docs/development/sqlserver-smoke-runbook-20260528.md) ' +
+        'to run it against a real SQL Server. Exiting 0.'
+    )
+    return
+  }
   const config = buildConfig()
   const schema = env.MSSQL_SCHEMA || 'dbo'
   const table = env.MSSQL_TABLE
@@ -150,10 +164,26 @@ async function main(): Promise<void> {
 
       const sample = await adapter.select(table, { limit: 5 })
       if (sample.error) throw sample.error
-      console.log('[ok] select sample', {
+      console.log('[ok] select sample (TOP)', {
         table: `${schema}.${table}`,
         rows: sample.data.length
       })
+
+      // Exercise the OFFSET/FETCH + ORDER BY branch as well (the TOP path above does not cover it).
+      const orderColumn = tableInfo.primaryKey?.[0] ?? tableInfo.columns[0]?.name
+      if (orderColumn) {
+        const paged = await adapter.select(table, {
+          limit: 3,
+          offset: 1,
+          orderBy: [{ column: orderColumn, direction: 'asc' }]
+        })
+        if (paged.error) throw paged.error
+        console.log('[ok] select page (OFFSET/FETCH)', {
+          table: `${schema}.${table}`,
+          orderBy: orderColumn,
+          rows: paged.data.length
+        })
+      }
     }
   } finally {
     await adapter.disconnect().catch(error => {


### PR DESCRIPTION
Lane B **B5A**: make the SQL Server smoke an opt-in, CI-safe gate and strengthen its coverage, so the generic `type=sqlserver` adapter (`MSSQLAdapter`, #1985) can be **proven against a real SQL Server** — not only the fake-driver unit tests.

## Why
Before B5A the adapter was exercised **only against a structural fake driver**. No evidence it actually connects to a real SQL Server or that its generated SQL (`[bracket]` quoting, `TOP`/`OFFSET…FETCH`, `$N`→`@pN`, `INFORMATION_SCHEMA`/`sys.*` introspection) runs on a real engine — the classic wire-vs-fixture gap.

## What
- **`smoke-sqlserver.ts`**: now **skips cleanly (exit 0)** when no `MSSQL_HOST`/`MSSQL_SERVER` is set → safe in normal CI, and **not** a silent green over a broken path (the skip is explicit + logged; only a real run prints `[ok]`). A configured-but-incomplete env still fails loudly. Adds an **OFFSET/FETCH + ORDER BY** select next to the existing TOP path (both pagination branches) + a help note.
- **verification doc** (`sqlserver-smoke-wire-gate-verification-20260529.md`): gate behavior, full read-only coverage, a **2019/2022 container recipe** (`mcr.microsoft.com/mssql/server` — Linux/free), and an **honest evidence table**.
- **runbook**: one-line note on the skip + pointer to the verification doc.

## Evidence (honest)
- ✅ **Gate skips cleanly without env** — captured: `[skip] … Exiting 0.`, **exit code 0**.
- ✅ `tsc --noEmit` clean; fake-driver unit suite green (pre-existing).
- ⏳ **Real-wire run against a 2019/2022 container / customer SQL Server: PENDING** — no docker on the authoring machine, so it was **not run here**. To be executed per the recipe and the `[ok]` output backfilled into the doc. **Not claimed as done until then.**

## Scope / notes
- Read-only; **no** `k3-wise-sqlserver` channel, **no** Windows-native deploy, **no** new connector. Next: **B4** version-compat matrix on this harness (2008R2/2012 → Windows VM follow-up).
- `eslint scripts/smoke-sqlserver.ts` reports a **pre-existing config gap** (the `scripts/` file isn't in eslint's tsconfig `project`) — present since #1989, not introduced here; the file type-checks clean under `tsc`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)