### PR TITLE
feat(integration): DF-T2b per-field replace/preserve authoring UI (no wire)

### DIFF
--- a/apps/web/src/components/integration/MetaIntegrationFieldRuleAuthoring.vue
+++ b/apps/web/src/components/integration/MetaIntegrationFieldRuleAuthoring.vue
@@ -1,0 +1,111 @@
+<template>
+  <div class="integration-field-rule-authoring" data-testid="field-rule-authoring">
+    <p class="integration-field-rule-authoring__hint">
+      逐字段选择 替换(replace,来自清洗表列)或 保留(preserve,沿用模板)。参照字段锁定为 preserve;gated 字段不可编辑。仅产出 fieldRules 草案,不写入 K3,也不调用 preview。
+    </p>
+
+    <ol class="integration-field-rule-authoring__list" data-testid="field-rule-list">
+      <li
+        v-for="(rule, index) in rules"
+        :key="rule.targetField"
+        class="integration-field-rule-authoring__row"
+        :data-testid="`field-rule-${rule.targetField}`"
+      >
+        <code class="integration-field-rule-authoring__field">{{ rule.targetField }}</code>
+        <span class="integration-field-rule-authoring__shape" :data-shape="rule.shape">{{ rule.shape }}</span>
+
+        <template v-if="editability(rule).locked">
+          <span
+            class="integration-field-rule-authoring__mode integration-field-rule-authoring__mode--locked"
+            :data-testid="`field-rule-mode-${rule.targetField}`"
+          >{{ editability(rule).reason === 'gated' ? 'gated（锁定,不可授权）' : 'preserve（参照字段锁定）' }}</span>
+          <span
+            class="integration-field-rule-authoring__hint integration-field-rule-authoring__hint--strong"
+            :data-testid="`field-rule-locked-${rule.targetField}`"
+          >{{ editability(rule).reason === 'gated' ? 'gated 字段不可编辑(不可授权)' : 'v1:参照字段不可降级为 scalar replace' }}</span>
+        </template>
+
+        <template v-else>
+          <select
+            class="integration-field-rule-authoring__mode"
+            :data-testid="`field-rule-mode-${rule.targetField}`"
+            :value="rule.sourceType === 'from_staging' ? 'replace' : 'preserve'"
+            @change="onModeChange(index, ($event.target as HTMLSelectElement).value)"
+          >
+            <option value="replace">替换(staging)</option>
+            <option value="preserve">保留(template)</option>
+          </select>
+          <input
+            v-if="rule.sourceType === 'from_staging'"
+            class="integration-field-rule-authoring__source"
+            :data-testid="`field-rule-source-${rule.targetField}`"
+            :value="rule.sourceField || ''"
+            placeholder="清洗表列名"
+            @input="onSourceFieldChange(index, ($event.target as HTMLInputElement).value)"
+          />
+        </template>
+      </li>
+    </ol>
+
+    <div
+      v-if="gatedFields.length > 0"
+      class="integration-field-rule-authoring__gated"
+      data-testid="field-rule-gated"
+    >
+      <h4>锁定字段(gated,不可授权)</h4>
+      <ul>
+        <li v-for="field in gatedFields" :key="field" :data-testid="`field-rule-gated-${field}`">
+          <code>{{ field }}</code> · 锁定
+        </li>
+      </ul>
+    </div>
+  </div>
+</template>
+
+<script setup lang="ts">
+// DF-T2b: per-field replace/preserve authoring UI. Edits a DF-T2a draft fieldRules set and emits
+// the result. It holds NO payloadTemplate / customer values (the rules carry field names + shape
+// only); it makes NO backend call (no preview wire — that is DF-T2c) and never writes to K3.
+import { computed } from 'vue'
+import {
+  fieldRuleEditability,
+  setFieldRuleReplace,
+  setFieldRulePreserve,
+  type IntegrationFieldRule,
+} from '../../services/integration/workbench'
+
+const props = withDefaults(
+  defineProps<{
+    modelValue: IntegrationFieldRule[]
+    gatedFields?: string[]
+  }>(),
+  { gatedFields: () => [] },
+)
+
+const emit = defineEmits<{ (e: 'update:modelValue', rules: IntegrationFieldRule[]): void }>()
+
+const rules = computed(() => props.modelValue)
+const gatedFields = computed(() => props.gatedFields ?? [])
+
+function editability(rule: IntegrationFieldRule) {
+  return fieldRuleEditability(rule, gatedFields.value)
+}
+
+function emitUpdated(index: number, next: IntegrationFieldRule): void {
+  emit('update:modelValue', props.modelValue.map((rule, i) => (i === index ? next : rule)))
+}
+
+function onModeChange(index: number, mode: string): void {
+  const rule = props.modelValue[index]
+  // Guard: a reference/gated field is locked — never downgrade it to a scalar replace.
+  if (!editability(rule).editable) return
+  if (mode === 'replace') emitUpdated(index, setFieldRuleReplace(rule, rule.sourceField || ''))
+  else emitUpdated(index, setFieldRulePreserve(rule))
+}
+
+function onSourceFieldChange(index: number, sourceField: string): void {
+  const rule = props.modelValue[index]
+  if (!editability(rule).editable) return
+  emitUpdated(index, setFieldRuleReplace(rule, sourceField))
+}
+</script>

--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -305,6 +305,57 @@ export function deriveFieldRulesFromMappings(
     })
 }
 
+// DF-T2b: a typed DF-T1 field rule (produced by the DF-T2a derive helper, edited by the
+// authoring UI). Vocabulary mirrors http-routes.cjs DF_T1_* (route-local on the backend).
+export interface IntegrationFieldRule {
+  targetField: string
+  sourceType: 'from_staging' | 'from_constant' | 'preserve_template' | 'from_reference_table'
+  sourceField?: string
+  value?: unknown
+  shape: 'scalar' | 'object-passthrough' | 'by-fnumber' | 'by-fid'
+  completeness?: 'none' | 'require-fnumber-fname' | 'require-fid-fname'
+  required?: boolean
+}
+
+export interface IntegrationFieldRuleEditability {
+  editable: boolean
+  locked: boolean
+  reason: 'gated' | 'reference' | null
+  isReference: boolean
+}
+
+// DF-T2b: whether a field's replace/preserve mode may be edited. The durable REFERENCE identity
+// is the SHAPE (object-passthrough / by-* — set by DF-T2a for object values), NOT the sourceType:
+// a *scalar* may legitimately be `from_staging` (replace) OR `preserve_template` (preserve), so
+// sourceType is the editable mode, not the lock signal. A non-scalar (reference) field is locked
+// to preserve and may NOT be downgraded to a scalar replace in v1. Gated fields are locked outright.
+export function fieldRuleEditability(
+  rule: Pick<IntegrationFieldRule, 'targetField' | 'shape'>,
+  gatedFields: string[] = [],
+): IntegrationFieldRuleEditability {
+  if (gatedFields.includes(rule.targetField)) {
+    return { editable: false, locked: true, reason: 'gated', isReference: false }
+  }
+  if (rule.shape !== 'scalar') {
+    return { editable: false, locked: true, reason: 'reference', isReference: true }
+  }
+  return { editable: true, locked: false, reason: null, isReference: false }
+}
+
+// Pure mode setters — called only on an editable (scalar) field. Shape stays 'scalar'; only the
+// replace/preserve mode flips. These never run on a reference/gated field (the UI locks those).
+export function setFieldRuleReplace(rule: IntegrationFieldRule, sourceField: string): IntegrationFieldRule {
+  const next: IntegrationFieldRule = { ...rule, sourceType: 'from_staging', shape: 'scalar', sourceField }
+  delete next.completeness
+  return next
+}
+
+export function setFieldRulePreserve(rule: IntegrationFieldRule): IntegrationFieldRule {
+  const next: IntegrationFieldRule = { ...rule, sourceType: 'preserve_template', shape: 'scalar' }
+  delete next.sourceField
+  return next
+}
+
 export type IntegrationFieldProvenanceSource = 'staging' | 'template' | 'constant' | 'reference_table'
 
 // DF-T1 target-payload preview evidence — present only when the request carried a payloadTemplate.

--- a/apps/web/tests/MetaIntegrationFieldRuleAuthoring.spec.ts
+++ b/apps/web/tests/MetaIntegrationFieldRuleAuthoring.spec.ts
@@ -1,0 +1,129 @@
+import { afterEach, describe, expect, it } from 'vitest'
+import { createApp, h, nextTick, type App as VueApp } from 'vue'
+import MetaIntegrationFieldRuleAuthoring from '../src/components/integration/MetaIntegrationFieldRuleAuthoring.vue'
+import {
+  fieldRuleEditability,
+  setFieldRuleReplace,
+  setFieldRulePreserve,
+  type IntegrationFieldRule,
+} from '../src/services/integration/workbench'
+
+// --- pure helper unit tests (DOM-independent) ---
+describe('fieldRuleEditability (DF-T2b)', () => {
+  it('scalar is editable; a non-scalar (reference) shape is locked to preserve; gated is locked', () => {
+    expect(fieldRuleEditability({ targetField: 'FNumber', shape: 'scalar' })).toMatchObject({ editable: true, reason: null, isReference: false })
+    expect(fieldRuleEditability({ targetField: 'FUnitID', shape: 'object-passthrough' })).toMatchObject({ editable: false, locked: true, reason: 'reference', isReference: true })
+    expect(fieldRuleEditability({ targetField: 'FErpClsID', shape: 'by-fid' })).toMatchObject({ reason: 'reference' })
+    expect(fieldRuleEditability({ targetField: 'FBaseUnitID', shape: 'scalar' }, ['FBaseUnitID'])).toMatchObject({ editable: false, reason: 'gated' })
+  })
+
+  it('a preserved SCALAR stays editable (lock keys on shape, not sourceType)', () => {
+    // preserve_template + scalar shape = a scalar the operator chose to preserve — still editable.
+    expect(fieldRuleEditability({ targetField: 'FModel', shape: 'scalar' })).toMatchObject({ editable: true })
+  })
+
+  it('setters keep shape scalar and only flip the mode', () => {
+    const replaced = setFieldRuleReplace({ targetField: 'FNumber', sourceType: 'preserve_template', shape: 'scalar' }, 'materialCode')
+    expect(replaced).toMatchObject({ sourceType: 'from_staging', shape: 'scalar', sourceField: 'materialCode' })
+    const preserved = setFieldRulePreserve({ targetField: 'FNumber', sourceType: 'from_staging', shape: 'scalar', sourceField: 'x' })
+    expect(preserved).toMatchObject({ sourceType: 'preserve_template', shape: 'scalar' })
+    expect(preserved.sourceField).toBeUndefined()
+  })
+})
+
+// --- component render / emit / lock tests ---
+describe('MetaIntegrationFieldRuleAuthoring (DF-T2b)', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  afterEach(() => {
+    if (app) app.unmount()
+    if (container) container.remove()
+    app = null
+    container = null
+  })
+
+  function draft(): IntegrationFieldRule[] {
+    return [
+      { targetField: 'FNumber', sourceType: 'from_staging', sourceField: 'FNumber', shape: 'scalar', required: false },
+      { targetField: 'FUnitID', sourceType: 'preserve_template', shape: 'object-passthrough', completeness: 'require-fnumber-fname' },
+    ]
+  }
+
+  function mount(modelValue: IntegrationFieldRule[], gatedFields: string[] = []): IntegrationFieldRule[][] {
+    const updates: IntegrationFieldRule[][] = []
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp({
+      render: () => h(MetaIntegrationFieldRuleAuthoring, {
+        modelValue,
+        gatedFields,
+        'onUpdate:modelValue': (rules: IntegrationFieldRule[]) => updates.push(rules),
+      }),
+    })
+    app.mount(container)
+    return updates
+  }
+
+  it('renders a row per rule + a locked gated section', async () => {
+    mount(draft(), ['FBaseUnitID'])
+    await nextTick()
+    expect(container!.querySelector('[data-testid="field-rule-FNumber"]')).not.toBeNull()
+    expect(container!.querySelector('[data-testid="field-rule-FUnitID"]')).not.toBeNull()
+    expect(container!.querySelector('[data-testid="field-rule-gated-FBaseUnitID"]')).not.toBeNull()
+    // no customer values rendered — only field names + shapes
+    expect(container!.textContent).toContain('object-passthrough')
+  })
+
+  it('a scalar field toggles preserve→replace and edits its sourceField (emits each time)', async () => {
+    const updates = mount(draft())
+    await nextTick()
+    const mode = container!.querySelector('[data-testid="field-rule-mode-FNumber"]') as HTMLSelectElement
+    expect(mode.tagName).toBe('SELECT')
+    mode.value = 'preserve'
+    mode.dispatchEvent(new Event('change'))
+    await nextTick()
+    expect(updates.at(-1)![0]).toMatchObject({ targetField: 'FNumber', sourceType: 'preserve_template', shape: 'scalar' })
+    expect(updates.at(-1)![0].sourceField).toBeUndefined()
+
+    mode.value = 'replace'
+    mode.dispatchEvent(new Event('change'))
+    await nextTick()
+    const source = container!.querySelector('[data-testid="field-rule-source-FNumber"]') as HTMLInputElement
+    expect(source).not.toBeNull()
+    source.value = 'materialCode'
+    source.dispatchEvent(new Event('input'))
+    await nextTick()
+    expect(updates.at(-1)![0]).toMatchObject({ targetField: 'FNumber', sourceType: 'from_staging', shape: 'scalar', sourceField: 'materialCode' })
+  })
+
+  it('a REFERENCE field is locked to preserve — no editable control (v1: cannot downgrade to scalar replace)', async () => {
+    mount(draft())
+    await nextTick()
+    // the reference row shows the locked label + hint...
+    expect(container!.querySelector('[data-testid="field-rule-locked-FUnitID"]')).not.toBeNull()
+    // ...and its "mode" element is a locked span, NOT an editable <select> — so there is no UI
+    // path to set replace on a reference field.
+    const refMode = container!.querySelector('[data-testid="field-rule-mode-FUnitID"]') as HTMLElement
+    expect(refMode).not.toBeNull()
+    expect(refMode.tagName).not.toBe('SELECT')
+    expect(container!.querySelector('[data-testid="field-rule-source-FUnitID"]')).toBeNull()
+  })
+
+  it('a GATED field present in modelValue renders locked (no select, no source input, no emit)', async () => {
+    // Defensive: even a scalar-shaped rule is locked when its field is gated — it must render as a
+    // locked label, not an inert-but-editable-looking select (the DF-T2b gated contract).
+    const withGated: IntegrationFieldRule[] = [
+      ...draft(),
+      { targetField: 'FBaseUnitID', sourceType: 'preserve_template', shape: 'scalar' },
+    ]
+    const updates = mount(withGated, ['FBaseUnitID'])
+    await nextTick()
+    expect(container!.querySelector('[data-testid="field-rule-locked-FBaseUnitID"]')).not.toBeNull()
+    const mode = container!.querySelector('[data-testid="field-rule-mode-FBaseUnitID"]') as HTMLElement
+    expect(mode).not.toBeNull()
+    expect(mode.tagName).not.toBe('SELECT') // locked label, not an editable control
+    expect(container!.querySelector('[data-testid="field-rule-source-FBaseUnitID"]')).toBeNull()
+    expect(updates).toHaveLength(0) // no editable control → no emit
+  })
+})

--- a/docs/development/data-factory-df-t2b-field-rule-authoring-verification-20260528.md
+++ b/docs/development/data-factory-df-t2b-field-rule-authoring-verification-20260528.md
@@ -1,0 +1,67 @@
+# DF-T2b — per-field replace/preserve authoring UI (verification, 2026-05-28)
+
+Second DF-T2 implementation slice (design #2017; builds on DF-T2a derive #2023). A **frontend
+authoring component** that edits a DF-T2a draft `fieldRules` set and **emits** the result. No K3
+write, **no preview wire** (that is DF-T2c), no backend call at all. Leave for review.
+
+## What shipped
+
+- `apps/web/src/components/integration/MetaIntegrationFieldRuleAuthoring.vue` — per-field row with
+  a **replace / preserve** control; `v-model:modelValue` in/out (`IntegrationFieldRule[]`),
+  optional `gatedFields`. Emits `update:modelValue` on each edit. **No backend call.**
+- `apps/web/src/services/integration/workbench.ts` — typed `IntegrationFieldRule` +
+  `fieldRuleEditability(rule, gatedFields)` + pure `setFieldRuleReplace` / `setFieldRulePreserve`.
+
+## Behaviour (owner-locked scope)
+
+- **scalar** field → editable: toggle **replace** (`from_staging` + a `sourceField` staging-column
+  input) ↔ **preserve** (`preserve_template`); shape stays `scalar`.
+- **reference** field → **locked to `preserve_template`**, rendered as a locked label + hint, with
+  **no editable control** — there is no UI path to downgrade it to a scalar replace in v1.
+- **gated** field (e.g. `FBaseUnitID`) → **locked everywhere**: the dedicated gated section lists it,
+  and (P2 review fix) a gated rule that appears in `modelValue` renders as a **locked label row**, not
+  an editable-looking `<select>`; **emits no rule** either way.
+
+## Key decisions
+
+- **Lock predicate = `shape !== 'scalar'`, NOT `sourceType`.** DF-T2a encodes a reference as *both*
+  `sourceType: 'preserve_template'` *and* `shape: 'object-passthrough'`. `sourceType` is the
+  editable **mode** (a *scalar* may also be `preserve_template` once the operator preserves it), so
+  it cannot be the lock signal; the durable **reference identity is the shape** (which T2a sets to
+  `object-passthrough`/`by-*` for object values). Keying on shape keeps a preserved-scalar editable
+  and a reference locked — and agrees with T2a's reference encoding. (Cross-file-predicate-drift
+  guard, per the T1A lesson.)
+- **No `payloadTemplate` prop / no customer values in the DOM.** The component works only from the
+  rules (`targetField` + `sourceType` + `shape`) + `gatedFields`; it never holds the live customer
+  object, so no operator-local reference values reach the DOM/screenshots (the DF-T2 redaction
+  boundary, upheld at the UI layer).
+- **No wire.** The component imports only the pure helpers; it makes no `apiFetch`/preview/K3 call.
+  Feeding it a real derived draft + wiring the DF-T1 preview is **DF-T2c** (with a wire-vs-fixture
+  reachability test, per the #1968 lesson).
+
+## Tests (`apps/web/tests/MetaIntegrationFieldRuleAuthoring.spec.ts`, 6/6 green; vue-tsc clean)
+
+- **Helper**: scalar editable · non-scalar (reference) shape locked (`reason: 'reference'`) ·
+  gated locked · a preserved-scalar stays editable (lock keys on shape) · setters keep `shape:'scalar'`
+  and flip only the mode.
+- **Component**: renders a row per rule + a locked gated section (no customer values) · scalar
+  toggles preserve→replace and edits `sourceField` (emits each time) · **a REFERENCE field is locked
+  to preserve — its mode element is a locked span, not a `<select>`, and there is no `sourceField`
+  input** (the v1 no-downgrade rule) · **a GATED field present in `modelValue`** (scalar-shaped +
+  `gatedFields=['FBaseUnitID']`) renders a locked label — no `<select>`, no `sourceField` input, no
+  emit (P2 review fix). **Negative-controlled (both)**: disabling the reference lock fails the
+  reference assertions; reverting the gated-render fix (`reason==='reference'`-only `v-if`) fails the
+  gated assertion. 7/7 green.
+
+## Boundaries (held)
+
+Frontend-only authoring component; no K3 write; no preview/backend wire (DF-T2c); reference fields
+preserve-only (#1824); gated fields locked; no Submit/Audit/BOM/multi-record. Not yet mounted into
+`IntegrationWorkbenchView` — wiring + a real derived-draft source + the preview round-trip are DF-T2c.
+
+## Files
+
+- `apps/web/src/components/integration/MetaIntegrationFieldRuleAuthoring.vue` (new)
+- `apps/web/src/services/integration/workbench.ts` (+ `IntegrationFieldRule`, `fieldRuleEditability`,
+  `setFieldRuleReplace`, `setFieldRulePreserve`)
+- `apps/web/tests/MetaIntegrationFieldRuleAuthoring.spec.ts` (new)


### PR DESCRIPTION
Second **DF-T2 implementation** slice (design #2017; builds on DF-T2a #2023). A **frontend authoring component** that edits a DF-T2a draft `fieldRules` set and **emits** the result. **No K3 write, no preview/backend wire (that's DF-T2c), no customer values in the DOM.**

## What it does
`MetaIntegrationFieldRuleAuthoring.vue` (`v-model:modelValue` = `IntegrationFieldRule[]`, optional `gatedFields`) renders a per-field **replace/preserve** control:
- **scalar** → editable (replace = `from_staging` + a staging-column `sourceField`; preserve = `preserve_template`);
- **reference** → **locked to preserve**, no editable control — **cannot downgrade to scalar replace (v1)**;
- **gated** (e.g. `FBaseUnitID`) → locked read-only row, **emits no rule**.

## Key decisions
- **Lock predicate = `shape !== 'scalar'`, not `sourceType`** — T2a encodes references as *both* `preserve_template` *and* `object-passthrough`; `sourceType` is the editable *mode* (a scalar can also become `preserve_template`), so the durable reference identity is the **shape** (matches T2a's `object-passthrough`). Cross-file-predicate-drift guard.
- **No `payloadTemplate` prop** → the component never holds the live customer object; only field names + shape reach the DOM (the DF-T2 redaction boundary, upheld at the UI layer).
- **No wire** — imports only pure helpers; feeding a real derived draft + the DF-T1 preview round-trip is **DF-T2c** (with the wire-vs-fixture reachability test).

## Tests (6/6 green; vue-tsc clean)
helper (editability + setters) + component (render / scalar toggle+`sourceField` emit / **reference locked — no editable control** / gated locked). **Negative-controlled**: disabling the reference lock fails both the helper and component assertions.

**Leave for review.** Next gated: **DF-T2c** (mount + wire into DF-T1 preview + wire-vs-fixture). No Submit/Audit/BOM/multi-record; references preserve-only (#1824).

Verification: `docs/development/data-factory-df-t2b-field-rule-authoring-verification-20260528.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)