### PR TITLE
fix(multitable): enforce field_permissions read mask on /view + GET /records (#2015)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -160,7 +160,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -171,6 +171,7 @@ jobs:
             tests/integration/multitable-permission-golden-d3d2.test.ts \
             tests/integration/multitable-view-aggregate.test.ts \
             tests/integration/multitable-formula-dryrun.test.ts \
+            tests/integration/multitable-records-read-field-mask.test.ts \
             --reporter=dot
 
       - name: Start core backend (background)

--- a/docs/development/multitable-records-read-field-mask-verification-20260529.md
+++ b/docs/development/multitable-records-read-field-mask-verification-20260529.md
@@ -1,0 +1,84 @@
+# Multitable interactive-read field mask (#2015) — implementation & verification
+
+- **Issue**: #2015 — interactive read paths used static-only (layer-2) field masking, shipping a `field_permissions`-denied value in the JSON payload.
+- **Design-lock**: [`multitable-records-read-field-mask-design-20260529.md`](./multitable-records-read-field-mask-design-20260529.md) (#2024, scope B / value-only).
+- **Status**: implemented + real-DB verified (fail-first). Backend-only; awaiting merge greenlight.
+- **Date**: 2026-05-29
+- **Grounding**: worktree off `origin/main 14f48cd73`. Lock posture: multitable read-path **kernel-polish** only — RBAC/auth, central permission model, `plugin-integration-core`, and `src/formula/engine.ts` are **NOT touched** ([[k3-poc-stage1-lock]]).
+
+## 1. What changed
+
+Two handlers in `packages/core-backend/src/routes/univer-meta.ts` now mask `row.data`/`record.data` (and link/attachment summaries) by the **D3c security composite** — layer-2 (`property.hidden`) ∧ layer-3 (`field_permissions.visible`, the subject-scoped read gate) — instead of layer-2 alone. This is the exact composite already shipped on export-xlsx (`:5839`), view-aggregate (`:5943`), and formula dry-run #5c-a (`:6089`).
+
+**`GET /view`** and **`GET /records/:recordId`**, each (3 edits per handler):
+1. Introduce `securityFieldPermissions = deriveFieldPermissions(visiblePropertyFields, capabilities, { hiddenFieldIds: [], fieldScopeMap })` → `allowedFieldIds`. `hiddenFieldIds: []` deliberately omits **layer-1** (`view.hidden_field_ids`) — it stays a display-only concern carried in the returned `fieldPermissions` metadata, not a server-side data drop.
+2. Swap the **3 data/summary** mask sites (`row.data`/`record.data`, `linkSummaries`, `attachmentSummaries`) from the layer-2 `visiblePropertyFieldIds` to `allowedFieldIds`.
+3. Load `fieldScopeMap` **once** before the mask and **reuse** it for the returned-metadata derive (deleted the redundant second `loadFieldPermissionScopeMap` call — `/view` is the hottest read endpoint). `access.userId` is guaranteed truthy at mask time (both handlers 401 before the mask), so the empty-map trap is closed by construction.
+
+The now-dead layer-2 `visiblePropertyFieldIds` declaration was removed from both handlers. The returned `fieldPermissions` **metadata** derive (all fields + layer-1, for the client display signal) is **unchanged** — only its `fieldScopeMap` source is now the shared single load.
+
+**Value-only** (design §2.1 = (i)): values + summaries are masked; the denied field's **definition** (name/type/config in `fields[]`) and its `fieldPermissions` metadata entry remain (the client never renders the column). Full field-definition stripping (ii) is deferred behind a "missing field definition" compat scan.
+
+## 2. Fail-first proof (design §5 #2 — the security regression's actual evidence)
+
+Run against local real DB (`DATABASE_URL=postgresql://<user>@localhost:5432/<db>`), `vitest.integration.config.ts`, new file `tests/integration/multitable-records-read-field-mask.test.ts`.
+
+**Pre-fix (route reverted via `git stash`, test present) — the leak is live:**
+```
+Tests  4 failed | 4 passed (8)
+  × R1 (GET /view)  → row.data[FLD_SECRET] = 'do-not-leak-canary'   (leak)
+  × R2 (GET /records) → record.data[FLD_SECRET] = 'do-not-leak-canary' (leak)
+  × R4 (embedded FLD_SECRET-absence on the /view path)               (leak)
+  × R6 (denied link field's summary carried the foreign canary)      (leak)
+  ✓ sentinel, R3 (no over-strip), R5 (ungranted user), R7 (401)
+```
+Each of R1/R2 failed on the **leak** assertion (`row.data[FLD_SECRET]).toBeUndefined()`) while its **preceding** assertions passed — the positive control (`FLD_VISIBLE` present) **and** the metadata control (`fieldPermissions[FLD_SECRET].visible === false`, computed regardless of the fix). So the response is well-formed, the deny is correctly wired, and the **only** defect is the value leaking at the wire. That split is the proof; a bare red (empty response, 500, dropped row) would false-green the "canary absent" check — the positive control defeats it.
+
+**Post-fix (R1–R7) — all green:**
+```
+Tests  8 passed (8)
+```
+The exact assertions that were RED now pass; nothing else changed.
+
+## 3. Test design
+
+`describeIfDatabase` + a `DATABASE_URL` sentinel (fails-not-skips in CI). TS-namespaced IDs (global-PK collision trap). Seed non-negotiable: **`FLD_SECRET.property = {}` → `property.hidden` UNSET** so the deny is **solely** layer-3 (else layer-2 would mask it pre-fix and R1/R2 would prove nothing).
+
+| Test | Path | Asserts |
+|---|---|---|
+| **R1** (required) | `GET /view` | positive control (`REC_ID` present, `FLD_VISIBLE`=10) → metadata `fieldPermissions[FLD_SECRET].visible===false` → `row.data` omits `FLD_SECRET`, canary absent from whole body |
+| **R2** (required) | `GET /records/:recordId` | same shape on `record.data` |
+| R3 | both | non-denied `FLD_VISIBLE` present (mask doesn't over-strip) |
+| R4 | both | layer-1 (`view.hidden_field_ids`) field value **STAYS** in data, hidden only via metadata (pins the §2 non-goal; FLD_SECRET still denied on the view path) |
+| R5 | both | **ungranted-to-deny** user (no `field_permissions` row) still sees `FLD_SECRET` (per-subject grant-additive) |
+| R6 | `GET /view` | a **denied link field's summary** is masked too — **positive control first** (ungranted user *does* receive the summary carrying the foreign canary, proving the fixture is non-vacuous), then the denied user's summary key is gone + foreign canary absent from body |
+| R7 | both | unauth → 401 (mask never runs on an empty `fieldScopeMap`) |
+
+Canary assertions scan the **whole serialized body** (not just `data[id]`) so a value re-surfacing via a summary/nested field is caught.
+
+## 4. Regression — clean
+
+- **tsc** (`tsc --noEmit -p tsconfig.json`): no errors in `univer-meta.ts` / the new test / `permission-derivation.ts`.
+- **`multitable-view-aggregate.test.ts`** (the metadata-path sibling — exercises `deriveFieldPermissions` + `loadFieldPermissionScopeMap` like this change): **passes** pre and post-fix. This is the key regression check for the one non-mechanical edit (relocating + de-duplicating the `fieldScopeMap` load).
+- **`multitable-formula-dryrun.test.ts`** (#5c-a sibling): passes.
+- **`d3d1` / `d3d2` golden suites fail _locally only_, proven pre-existing**: identical failures on **unmodified** code (`git stash` baseline). Causes are local-DB-schema gaps — `field_permissions_subject_type_check` allows only `user`/`role` (rejects `member-group`, d3d2 seed) and `column "modified_by" does not exist` in the export query (d3d1, a handler this change never touches). CI's freshly-migrated `metasheet_test` has both; these suites are green on `main`.
+- **CI wiring**: the new file is added to the `plugin-tests.yml` real-DB integration step (DATABASE_URL hard-guard) alongside the golden / view-aggregate / dry-run suites.
+
+## 5. Scope adherence & deferred (same-class) items
+
+**In scope (done):** `/view` + `GET /records/:recordId` value+summary mask; value-only; golden-doc §0/§1 reconciliation (this change, not a model change).
+
+**Deferred same-class — NOT touched (each a separate opt-in):**
+- **(ii) full field-definition strip** — gated on a "missing field definition" compat scan (design §2.1).
+- **Other layer-2-only read sites** — `POST /patch` write-echo (`:8090`), `GET /form-context`, `POST /views/:viewId/submit`, `GET /records` list (`:7298`), `GET /records-summary` (`:7202`-class). Public-form paths use their own narrower form-field model.
+- **Sort / search / filter operate on layer-2** (`searchableFieldIds` / `fieldTypeById`), unchanged by this slice. Note (verified, not assumed): `/view` `search=` filters server-side on field **values** (`buildRecordSearchPredicateSql` → SQL `ILIKE`, `:6204`), so a `field_permissions`-denied-but-`property`-visible field remains **searchable by value** (a `search=` term can probe its existence/ordering). This is **pre-existing** (search already ran on layer-2 before this change) and the data mask being tightened to layer-3 does **not** worsen it. Listed honestly as a deferred same-class candidate — out of the locked scope.
+- **Returned `view: viewConfig` carries raw `filterInfo`/`sortInfo`** (verified: `MetaFilterCondition` = `{ fieldId, operator, value?: unknown }`; `parseMetaFilterInfo` keeps `value`; both handlers return `...(viewConfig ? { view: viewConfig } : {})` at `:6497` / `:7483`). A view configured to filter on a denied field with a literal comparison value (e.g. `FLD_SECRET = "topsecret"`) ships that literal in the body via the view config — a denied-value leak through a **non-data channel** that this slice's `row.data`/summary mask does not touch. **Pre-existing** (the raw view config was always returned) and **out of the locked scope** (scope B = the data/summary mask). Same class as the search-on-values note above; deferred candidate — not fixed here.
+- **Record-scope gate consolidation on `GET /records`** — under the current schema `record_permissions.access_level` is grant-only (no deny), so record-read is grant-additive; the "lacks record-scope gate" half of the #2015 title is **assessed-inert**, not silently dropped (golden §2 record-read non-gate; same finding as #5c-a's T1 reframe). The live half of #2015 is the field mask, which this slice fixes.
+
+## 6. Gated TODO (updated)
+
+- ✅ Impl (`/view` + `GET /records` value+summary mask swap; single shared `fieldScopeMap` load; dead layer-2 set removed).
+- ✅ R1–R7 real-DB tests, **fail-first demonstrated** (R1/R2/R4/R6 red → all green); wired into `plugin-tests.yml`.
+- ✅ Golden-doc reconciliation (§0 gate-#1 + §1 matrix rows; not a model change).
+- 🔒 **(ii) full field-strip hardening** — precondition: missing-field-def compat scan, then its own opt-in.
+- 🔒 Deferred same-class (other read sites · sort/search layer-2 · record-gate consolidation) — separate, not started.

--- a/docs/development/permission-matrix-golden-20260525.md
+++ b/docs/development/permission-matrix-golden-20260525.md
@@ -26,12 +26,14 @@ Knowing this prevents re-litigating the same phantoms:
 
 | # | gate | mechanism | proven by |
 |---|---|---|---|
-| 1 | **Field masking** | `field_permissions.visible=false` → field stripped from export + view projection | D3d-1 (#1827) |
+| 1 | **Field masking** | `field_permissions.visible=false` → field value stripped from export **and** the interactive `/view` / `GET /records/:recordId` reads (+ view-aggregate, formula dry-run) | D3d-1 (#1827, export) · #2015 (#2024 design / interactive reads) |
 | 2 | **Field via member-group** | same, via `platform_member_group_members` membership | D3d-2 |
 | 3 | **Sheet write-intersection** | base `multitable:write` + read-only sheet row → `scopedCanWrite=false` → PATCH 403 | D3d-2 |
 | 4 | **Record write-own** | write-own sheet scope + non-creator → PATCH 403 | D3d-2 |
 
 Everything else is annotation/grant-additive (non-gates, §2).
+
+> **#2015 reconciliation (2026-05-29, not a model change).** Gate #1 was originally evidenced on **export only** (D3d-1); the interactive read paths masked `row.data`/`record.data` by **static layer-2 (`property.hidden`)** alone and shipped a `field_permissions`-denied value inside the JSON payload, relying on the client to hide it from the returned `fieldPermissions` metadata (a client-side-only control — the documented "skip-when-unreachable / wire-vs-fixture" blind spot: the gate was proven on the path it was tested on and the conclusion generalized). #2015 (#2024 design-lock, scope B / value-only) made `/view` + `GET /records/:recordId` honor the subject-scoped layer-3 gate at the wire, asserted real-DB in `multitable-records-read-field-mask.test.ts` (R1/R2, fail-first). **Layer-1 (`view.hidden_field_ids`) stays display-only on the interactive reads** (value present, hidden via metadata — R4), unlike export which bakes it in; that asymmetry is intentional (one-shot egress vs. interactive feed). Field-**definition** stripping (name/type/config) is deferred (value-only), gated on a missing-field-def compat scan.
 
 ## 1. Golden matrix — real gates (asserted, real DB)
 
@@ -41,7 +43,11 @@ Everything else is annotation/grant-additive (non-gates, §2).
 | field | denied (user visible=false) | export-xlsx | field absent (header+cells) | D3d-1 |
 | field | inherited-via-role (role visible=false) | export-xlsx | field absent | D3d-1 |
 | field | inherited-via-member-group (group visible=false) | export-xlsx | field absent | D3d-2 |
+| field | denied (user visible=false) | `GET /view` (`rows[].data`; link summaries — attachment summaries ride the identical `allowedFieldIds` set) | value absent (canary never on the wire) | #2015 (R1 data; R6 link summary) |
+| field | denied (user visible=false) | `GET /records/:recordId` (`record.data`) | value absent | #2015 (R2) |
+| field | denied (user visible=false) | `GET /view` / `GET /records` | **ungranted-to-deny** user still sees the value (per-subject; mask doesn't deny the wrong user) | #2015 (R5) |
 | view-projection | granted / denied (`view.hidden_field_ids`) | export-xlsx | present / absent | D3d-1 |
+| view-projection | `view.hidden_field_ids` | `GET /view` / `GET /records` | value **present** in data, hidden via `fieldPermissions` metadata (layer-1 = display-only on interactive reads, unlike export) | #2015 (R4) |
 | sheet | inherited (no row, base write) | PATCH /records | 200 | D3d-2 |
 | sheet | granted (`spreadsheet:write`) | PATCH /records | 200 | D3d-2 |
 | sheet | **write-downgraded** (`spreadsheet:read` only) | PATCH /records | **403** | D3d-2 |

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -6147,7 +6147,20 @@ export function univerMetaRouter(): Router {
       }
 
       const visiblePropertyFields = filterVisiblePropertyFields(fields)
-      const visiblePropertyFieldIds = new Set(visiblePropertyFields.map((field) => field.id))
+      // #2015 read-path field mask: the D3c security composite — layer-2 (property.hidden, already applied
+      // by filterVisiblePropertyFields) ∧ layer-3 (field_permissions.visible, the subject-scoped read gate).
+      // Mirrors export-xlsx (:5839) and formula dry-run #5c-a (:6089). hiddenFieldIds:[] deliberately omits
+      // layer-1 (view.hidden_field_ids) — that stays a display-only concern carried in the returned
+      // fieldPermissions metadata below, not a server-side data drop. access.userId is guaranteed truthy
+      // here (401 at the top of the handler); loaded ONCE and reused for the metadata derive below — do not
+      // re-load (this is the hottest read endpoint).
+      const fieldScopeMap = access.userId
+        ? await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, access.userId)
+        : new Map()
+      const securityFieldPermissions = deriveFieldPermissions(visiblePropertyFields, capabilities, { hiddenFieldIds: [], fieldScopeMap })
+      const allowedFieldIds = new Set(
+        visiblePropertyFields.filter((field) => securityFieldPermissions[field.id]?.visible !== false).map((field) => field.id),
+      )
       const fieldTypeById = new Map(visiblePropertyFields.map((f) => [f.id, f.type] as const))
       const searchableFieldIds = visiblePropertyFields
         .filter((field) => isSearchableFieldType(field.type))
@@ -6395,7 +6408,7 @@ export function univerMetaRouter(): Router {
         linkValuesByRecord,
       )
       for (const row of rows) {
-        row.data = filterRecordDataByFieldIds(row.data, visiblePropertyFieldIds)
+        row.data = filterRecordDataByFieldIds(row.data, allowedFieldIds)
       }
       const linkSummaries = includeLinkSummaries
         ? filterRecordFieldSummaryMap(
@@ -6408,7 +6421,7 @@ export function univerMetaRouter(): Router {
                 linkValuesByRecord,
               ),
             ),
-            visiblePropertyFieldIds,
+            allowedFieldIds,
           )
         : undefined
       const attachmentSummaries = attachmentFields.length > 0
@@ -6422,7 +6435,7 @@ export function univerMetaRouter(): Router {
                 attachmentFields,
               ),
             ),
-            visiblePropertyFieldIds,
+            allowedFieldIds,
           )
         : undefined
       // Record-level permission filtering: remove records user cannot read (admin bypass)
@@ -6453,7 +6466,6 @@ export function univerMetaRouter(): Router {
         sheetScope,
         access,
       )
-      const fieldScopeMap = access.userId ? await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, access.userId) : new Map()
       const viewScopeMap = (access.userId && viewConfig) ? await loadViewPermissionScopeMap(pool.query.bind(pool), [viewConfig.id], access.userId) : new Map()
       const permissions: MultitableScopedPermissions = {
         fieldPermissions: deriveFieldPermissions(fields, capabilities, {
@@ -7422,13 +7434,24 @@ export function univerMetaRouter(): Router {
       }
       await applyLookupRollup(req, pool.query.bind(pool), fields, [record], relationalLinkFields, linkValuesByRecord)
       const visiblePropertyFields = filterVisiblePropertyFields(fields)
-      const visiblePropertyFieldIds = new Set(visiblePropertyFields.map((field) => field.id))
-      record.data = filterRecordDataByFieldIds(record.data, visiblePropertyFieldIds)
+      // #2015 read-path field mask: D3c security composite (layer-2 property.hidden ∧ layer-3
+      // field_permissions.visible), mirroring export-xlsx / dry-run #5c-a. hiddenFieldIds:[] keeps layer-1
+      // (view.hidden_field_ids) a display-only concern in the returned fieldPermissions metadata, not a
+      // data drop. access.userId is guaranteed truthy here (401 at :7399); loaded ONCE and reused for the
+      // metadata derive below.
+      const fieldScopeMap = access.userId
+        ? await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, access.userId)
+        : new Map()
+      const securityFieldPermissions = deriveFieldPermissions(visiblePropertyFields, capabilities, { hiddenFieldIds: [], fieldScopeMap })
+      const allowedFieldIds = new Set(
+        visiblePropertyFields.filter((field) => securityFieldPermissions[field.id]?.visible !== false).map((field) => field.id),
+      )
+      record.data = filterRecordDataByFieldIds(record.data, allowedFieldIds)
       const linkSummaries = filterSingleRecordFieldSummaryMap(
         Object.fromEntries(
           Array.from((await buildLinkSummaries(req, pool.query.bind(pool), [record], relationalLinkFields, linkValuesByRecord)).get(record.id)?.entries() ?? []),
         ),
-        visiblePropertyFieldIds,
+        allowedFieldIds,
       )
       const attachmentSummaries = visiblePropertyFields.some((field) => field.type === 'attachment')
         ? filterSingleRecordFieldSummaryMap(
@@ -7441,11 +7464,10 @@ export function univerMetaRouter(): Router {
                 visiblePropertyFields.filter((field) => field.type === 'attachment'),
               ),
             )[record.id] ?? {},
-            visiblePropertyFieldIds,
+            allowedFieldIds,
           )
         : undefined
 
-      const fieldScopeMap = access.userId ? await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, access.userId) : new Map()
       const viewScopeMap = (access.userId && viewConfig) ? await loadViewPermissionScopeMap(pool.query.bind(pool), [viewConfig.id], access.userId) : new Map()
       const fieldPermissions = deriveFieldPermissions(fields, capabilities, {
         hiddenFieldIds: viewConfig?.hiddenFieldIds ?? [],

--- a/packages/core-backend/tests/integration/multitable-records-read-field-mask.test.ts
+++ b/packages/core-backend/tests/integration/multitable-records-read-field-mask.test.ts
@@ -1,0 +1,189 @@
+/**
+ * Real-DB integration test for the interactive read-path field mask (#2015, design-lock
+ * docs/development/multitable-records-read-field-mask-design-20260529.md, scope B / value-only).
+ *
+ * Proves that `GET /view` and `GET /records/:recordId` honor the subject-scoped layer-3 read gate
+ * (field_permissions.visible=false), not only static layer-2 (property.hidden). Before the fix these
+ * paths masked row/record data by layer-2 only and shipped a field_permissions-denied value inside
+ * the JSON payload, relying on the client to hide it from the returned fieldPermissions metadata.
+ *
+ * Fail-first discipline (design §5, non-negotiable #2): R1/R2 were demonstrated RED against the
+ * unmodified origin/main route code (the denied canary present in the response body) and GREEN after
+ * the mask swap. Each of R1/R2 folds in a POSITIVE control (the record is present with its visible
+ * value) so an empty/dropped response can never false-green the "canary absent" assertion.
+ *
+ * Seed non-negotiable (design §5 #1): FLD_SECRET.property is `{}` — property.hidden is UNSET — so the
+ * deny comes SOLELY from layer-3 field_permissions. If it were also static-hidden, layer-2
+ * (filterVisiblePropertyFields) would already mask it on origin/main and R1/R2 would prove nothing.
+ *
+ * Runs only with DATABASE_URL (describeIfDatabase + a sentinel test so it fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+// IDs are namespaced (`*_mask_*_${TS}`) so they can never collide with a sibling integration test's
+// fixtures in the shared real-DB run — meta_fields.id / meta_records.id are global PKs (TS alone is
+// not collision-safe; multitable-view-aggregate.test.ts and -formula-dryrun.test.ts share the DB).
+const BASE_ID = `base_mask_${TS}`
+const SHEET_ID = `sheet_mask_${TS}`
+const FLD_VISIBLE = `fld_mask_visible_${TS}` // never denied — the positive control
+const FLD_SECRET = `fld_mask_secret_${TS}` // denied to USER_ID via field_permissions.visible=false (layer-3 only)
+const FLD_VIEWHIDDEN = `fld_mask_viewhidden_${TS}` // layer-1 only (in view.hidden_field_ids) — value must STAY (display-only)
+const FLD_LINK = `fld_mask_link_${TS}` // link field denied to USER_ID — its summary must be masked too
+const REC_ID = `rec_mask_${TS}`
+const VIEW_ID = `view_mask_${TS}` // a view whose hidden_field_ids = [FLD_VIEWHIDDEN] (the layer-1 control)
+const FSHEET_ID = `sheet_mask_foreign_${TS}` // link target sheet
+const FPRIM = `fld_mask_foreign_prim_${TS}` // foreign display field (type 'string' → chosen by the summary builder)
+const FREC_ID = `rec_mask_foreign_${TS}` // foreign record linked from REC_ID via FLD_LINK
+const USER_ID = `u_mask_${TS}` // FLD_SECRET + FLD_LINK denied to this subject
+const USER_ID_2 = `u_mask_other_${TS}` // NO deny row → must still see FLD_SECRET / the link summary (per-subject, grant-additive)
+const VISIBLE_VALUE = 10
+const VIEWHIDDEN_VALUE = 77
+const SECRET_CANARY = 'do-not-leak-canary' // proves a field_permissions-denied value never reaches the wire
+const LINK_CANARY = 'do-not-leak-link-canary' // the foreign record's display value — must not leak via a denied field's summary
+
+let app: Express
+let testUserId: string = USER_ID // mutable: a test can drop the user (401) or swap to the ungranted user
+let testPerms: string[] = ['multitable:read']
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const viewReq = (query: Record<string, string>) => request(app).get('/api/multitable/view').query(query)
+const recordReq = (recordId: string, query: Record<string, string>) =>
+  request(app).get(`/api/multitable/records/${recordId}`).query(query)
+
+describeIfDatabase('multitable interactive read-path field mask (#2015, real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = testUserId ? { id: testUserId, roles: [], perms: testPerms } : undefined
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [BASE_ID, 'Mask Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_ID, BASE_ID, 'Mask Sheet'])
+    // All fields property `{}` → property.hidden UNSET. The deny must come solely from layer-3 (below).
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_VISIBLE, SHEET_ID, 'Visible', 'number', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRET, SHEET_ID, 'Secret', 'number', '{}', 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_VIEWHIDDEN, SHEET_ID, 'ViewHidden', 'number', '{}', 3])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LINK, SHEET_ID, 'Linked', 'link', JSON.stringify({ foreignSheetId: FSHEET_ID }), 4])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_ID, SHEET_ID, JSON.stringify({ [FLD_VISIBLE]: VISIBLE_VALUE, [FLD_SECRET]: SECRET_CANARY, [FLD_VIEWHIDDEN]: VIEWHIDDEN_VALUE })])
+    // The real D3c field-read deny gate: subject-scoped, layer-3. USER_ID_2 gets NO row (R5 / R6 control).
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER_ID, false, false])
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_LINK, 'user', USER_ID, false, false])
+    // R4 layer-1 control: a view whose hidden_field_ids = [FLD_VIEWHIDDEN] (display-only, NOT a data drop).
+    await q('INSERT INTO meta_views (id, sheet_id, name, type, hidden_field_ids) VALUES ($1,$2,$3,$4,$5::jsonb)', [VIEW_ID, SHEET_ID, 'Mask View', 'grid', JSON.stringify([FLD_VIEWHIDDEN])])
+    // R6 link-summary fixtures: foreign sheet + a 'string' display field carrying LINK_CANARY + a link row.
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [FSHEET_ID, BASE_ID, 'Mask Foreign Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FPRIM, FSHEET_ID, 'ForeignName', 'string', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [FREC_ID, FSHEET_ID, JSON.stringify({ [FPRIM]: LINK_CANARY })])
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [FLD_LINK, REC_ID, FREC_ID])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_links WHERE field_id = $1', [FLD_LINK]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SHEET_ID, FSHEET_ID]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[SHEET_ID, FSHEET_ID]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SHEET_ID, FSHEET_ID]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('R1 (required): GET /view omits a field_permissions-denied value from rows[].data (canary never on the wire)', async () => {
+    testUserId = USER_ID; testPerms = ['multitable:read']
+    const res = await viewReq({ sheetId: SHEET_ID })
+    expect(res.status).toBe(200)
+    const row = res.body.data.rows.find((r: { id: string }) => r.id === REC_ID)
+    // positive control: the record is present with its visible value (defeats an empty-response false-green)
+    expect(row).toBeDefined()
+    expect(row.data[FLD_VISIBLE]).toBe(VISIBLE_VALUE)
+    // metadata intact: the deny is still reported to the client (computed regardless of the data-mask fix → GREEN even pre-fix)
+    expect(res.body.data.meta.permissions.fieldPermissions[FLD_SECRET].visible).toBe(false)
+    // THE LEAK (RED pre-fix, GREEN post-fix): the denied value is gone from data AND from anywhere in the body
+    expect(row.data[FLD_SECRET]).toBeUndefined()
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY)
+  })
+
+  test('R2 (required): GET /records/:recordId omits a field_permissions-denied value from record.data (canary never on the wire)', async () => {
+    testUserId = USER_ID; testPerms = ['multitable:read']
+    const res = await recordReq(REC_ID, { sheetId: SHEET_ID })
+    expect(res.status).toBe(200)
+    // positive control
+    expect(res.body.data.record.data[FLD_VISIBLE]).toBe(VISIBLE_VALUE)
+    // metadata intact (GREEN pre-fix too)
+    expect(res.body.data.fieldPermissions[FLD_SECRET].visible).toBe(false)
+    // THE LEAK (RED pre-fix, GREEN post-fix)
+    expect(res.body.data.record.data[FLD_SECRET]).toBeUndefined()
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY)
+  })
+
+  test('R3: the mask does not over-strip — a non-denied field value is present on both paths', async () => {
+    testUserId = USER_ID; testPerms = ['multitable:read']
+    const view = await viewReq({ sheetId: SHEET_ID })
+    expect(view.body.data.rows.find((r: { id: string }) => r.id === REC_ID).data[FLD_VISIBLE]).toBe(VISIBLE_VALUE)
+    const record = await recordReq(REC_ID, { sheetId: SHEET_ID })
+    expect(record.body.data.record.data[FLD_VISIBLE]).toBe(VISIBLE_VALUE)
+  })
+
+  test('R4: layer-1 (view.hidden_field_ids) is NOT a data drop — the value STAYS, only the metadata hides it', async () => {
+    testUserId = USER_ID; testPerms = ['multitable:read']
+    // Pins the §2 non-goal: layer-1 stays a display concern on the interactive reads (client toggles the
+    // column via fieldPermissions metadata without a round-trip). Only layer-3 (field_permissions) drops data.
+    const view = await viewReq({ viewId: VIEW_ID })
+    expect(view.status).toBe(200)
+    const row = view.body.data.rows.find((r: { id: string }) => r.id === REC_ID)
+    expect(row.data[FLD_VIEWHIDDEN]).toBe(VIEWHIDDEN_VALUE) // value present in data (NOT security-dropped)
+    expect(view.body.data.meta.permissions.fieldPermissions[FLD_VIEWHIDDEN].visible).toBe(false) // hidden via metadata
+    expect(row.data[FLD_SECRET]).toBeUndefined() // FLD_SECRET still layer-3-denied even on the view path
+
+    const record = await recordReq(REC_ID, { viewId: VIEW_ID })
+    expect(record.status).toBe(200)
+    expect(record.body.data.record.data[FLD_VIEWHIDDEN]).toBe(VIEWHIDDEN_VALUE)
+    expect(record.body.data.fieldPermissions[FLD_VIEWHIDDEN].visible).toBe(false)
+  })
+
+  test('R6: a denied field\'s link SUMMARY is masked too (not just row.data) — foreign display value never leaks', async () => {
+    // Positive control FIRST (defeats an empty-summary false-green): the ungranted user DOES receive the
+    // link summary carrying LINK_CANARY, proving the fixtures actually produce a summary.
+    testUserId = USER_ID_2; testPerms = ['multitable:read']
+    const granted = await viewReq({ sheetId: SHEET_ID, includeLinkSummaries: 'true' })
+    expect(granted.status).toBe(200)
+    expect(granted.body.data.linkSummaries?.[REC_ID]?.[FLD_LINK]).toBeDefined()
+    expect(JSON.stringify(granted.body)).toContain(LINK_CANARY)
+
+    // The denied user: the link field's summary key is gone, and LINK_CANARY is nowhere in the body.
+    testUserId = USER_ID; testPerms = ['multitable:read']
+    const denied = await viewReq({ sheetId: SHEET_ID, includeLinkSummaries: 'true' })
+    expect(denied.status).toBe(200)
+    expect(denied.body.data.linkSummaries?.[REC_ID]?.[FLD_LINK]).toBeUndefined()
+    expect(JSON.stringify(denied.body)).not.toContain(LINK_CANARY)
+  })
+
+  test('R5: an ungranted-to-deny user still sees the value (per-subject; the mask does not deny the wrong user)', async () => {
+    testUserId = USER_ID_2; testPerms = ['multitable:read'] // no field_permissions deny row for this subject
+    const view = await viewReq({ sheetId: SHEET_ID })
+    expect(view.status).toBe(200)
+    expect(view.body.data.rows.find((r: { id: string }) => r.id === REC_ID).data[FLD_SECRET]).toBe(SECRET_CANARY)
+    const record = await recordReq(REC_ID, { sheetId: SHEET_ID })
+    expect(record.status).toBe(200)
+    expect(record.body.data.record.data[FLD_SECRET]).toBe(SECRET_CANARY)
+    testUserId = USER_ID
+  })
+
+  test('R7: unauthenticated → 401 on both paths (the mask never runs on an empty fieldScopeMap)', async () => {
+    testUserId = ''; testPerms = ['multitable:read'] // no user object on the request
+    expect((await viewReq({ sheetId: SHEET_ID })).status).toBe(401)
+    expect((await recordReq(REC_ID, { sheetId: SHEET_ID })).status).toBe(401)
+    testUserId = USER_ID
+  })
+})


### PR DESCRIPTION
## #2015 — interactive-read field mask (scope B, value-only)

Implements the merged design-lock #2024. The interactive JSON read paths masked `row.data`/`record.data` by **static layer-2 (`property.hidden`) only** and shipped a `field_permissions`-denied value inside the payload, relying on the client to hide it from the returned `fieldPermissions` metadata — a **client-side-only control**, trivially read off the network response. (Classic wire-vs-fixture / skip-when-unreachable blind spot: field-masking was proven on **export** and the conclusion generalized.)

### The fix
`GET /view` and `GET /records/:recordId` now mask **values + link/attachment summaries** by the **D3c security composite** — layer-2 (`property.hidden`) ∧ layer-3 (`field_permissions.visible`, the subject-scoped read gate) — the exact composite already shipped on export-xlsx (`:5839`), view-aggregate (`:5943`), and formula dry-run #5c-a (`:6089`).

- **Layer-1 (`view.hidden_field_ids`) stays display-only** on the interactive reads (value present, hidden via metadata), **unlike export** (one-shot egress) — pinned by test R4.
- `fieldScopeMap` is loaded **once** and reused for the returned metadata derive (the redundant second `loadFieldPermissionScopeMap` call is removed — `/view` is the hottest read endpoint).
- **Value-only** (design §2.1 = (i)): field *definitions* stay; full field-strip is deferred behind a "missing field definition" compat scan.

### Fail-first proof (real DB)
New `multitable-records-read-field-mask.test.ts`, wired into the `plugin-tests.yml` real-DB step.

| | pre-fix (route stashed) | post-fix |
|---|---|---|
| R1 `/view`, R2 `/records`, R4 (embedded), R6 (link summary) | **RED — leak** | ✅ |
| sentinel, R3 (no over-strip), R5 (ungranted user), R7 (401) | ✅ | ✅ |

R1/R2 each fail on the **leak** line while the positive control (`FLD_VISIBLE` present) **and** metadata control (`fieldPermissions[FLD_SECRET].visible===false`) stay green — so the response is well-formed and the deny is correctly wired; the only defect is the value at the wire. Seed non-negotiable: `FLD_SECRET.property={}` (layer-2 UNSET) → the deny is **solely** layer-3. R6 leads with an ungranted-user **positive control** so it can't false-green on an empty summary.

### Regression — clean
- `tsc --noEmit`: clean on touched files.
- **`multitable-view-aggregate.test.ts`** (the metadata-path sibling — the one non-mechanical change is relocating/de-duplicating the `fieldScopeMap` load): **passes** pre and post.
- `d3d1`/`d3d2` golden suites fail **locally only**, proven pre-existing (identical on unmodified code) — local-DB-schema gaps (`subject_type` CHECK without `member-group`; missing `modified_by` in the export query, a handler this PR never touches). Green in CI's freshly-migrated DB.

### Scope / lock
RBAC/auth, central permission model, `plugin-integration-core`, `src/formula/engine.ts` **untouched** (K3 stage-1 lock). Deferred same-class (each a separate opt-in, listed in the verification doc): full field-def strip · other layer-2-only read sites (`POST /patch` echo, form paths, records list, records-summary) · sort/search on layer-2 (search filters on **values** server-side) · returned `view: viewConfig` carries raw `filterInfo` literals · `GET /records` record-gate consolidation (assessed-inert under the grant-only schema).

### Merge note
Backend feature PR — at merge needs `base == origin/main` (not-stale) **and** an explicit greenlight. **Do not merge on review alone.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)
