### PR TITLE
ci(data-sources): B4 — SQL Server 2019/2022 real-wire smoke matrix

### DIFF
--- a/.github/workflows/sqlserver-smoke.yml
+++ b/.github/workflows/sqlserver-smoke.yml
@@ -78,6 +78,10 @@ jobs:
         # (a not-yet-started container fails connect and is retried).
         env:
           MSSQL_DATABASE: master
+          # Explicit write opt-in — the seed MUTATES the DB; allowed ONLY here, against the throwaway
+          # service container. Without it the seed fails loudly (guards against an accidental run with
+          # MSSQL_* pointed at a real/customer server).
+          MSSQL_SEED_ALLOW_WRITE: 'true'
         run: |
           for i in $(seq 1 40); do
             if pnpm --filter @metasheet/core-backend smoke:sqlserver:seed; then

--- a/.github/workflows/sqlserver-smoke.yml
+++ b/.github/workflows/sqlserver-smoke.yml
@@ -1,0 +1,98 @@
+name: SQL Server smoke (real-wire)
+
+# B4: run the opt-in SQL Server smoke against REAL SQL Server 2019/2022 service containers, so the
+# generic `type=sqlserver` adapter (MSSQLAdapter) is validated across versions — not only the
+# fake-driver unit tests. The image is large (~1.5GB) and SQL Server takes ~30s to start, so this is
+# PATH-FILTERED to the data-source adapter/smoke surface, not run on every PR.
+#
+# SQL Server 2008R2/2012 have no Linux container image (Windows-only binaries) → they stay on the
+# protocol-mock / Windows-VM follow-up path, per the smoke verification doc. amd64 runners run the
+# image natively.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'packages/core-backend/src/data-adapters/**'
+      - 'packages/core-backend/scripts/smoke-sqlserver*.ts'
+      - 'packages/core-backend/package.json'
+      - '.github/workflows/sqlserver-smoke.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/core-backend/src/data-adapters/**'
+      - 'packages/core-backend/scripts/smoke-sqlserver*.ts'
+      - '.github/workflows/sqlserver-smoke.yml'
+
+jobs:
+  sqlserver-smoke:
+    name: SQL Server ${{ matrix.mssql }} real-wire smoke
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        mssql: ['2019', '2022']
+    services:
+      mssql:
+        image: mcr.microsoft.com/mssql/server:${{ matrix.mssql }}-latest
+        env:
+          ACCEPT_EULA: 'Y'
+          # Ephemeral, throwaway container password (destroyed with the job) — not a real credential.
+          MSSQL_SA_PASSWORD: 'Smoke!Probe2026'
+          SA_PASSWORD: 'Smoke!Probe2026'
+        ports:
+          - 1433:1433
+    env:
+      MSSQL_HOST: 127.0.0.1
+      MSSQL_PORT: '1433'
+      MSSQL_USERNAME: sa
+      MSSQL_PASSWORD: 'Smoke!Probe2026'
+      MSSQL_ENCRYPT: 'true'
+      MSSQL_TRUST_SERVER_CERTIFICATE: 'true'
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Wait for SQL Server + seed probe table
+        # The seed connects to master; retrying it doubles as the SQL-Server-readiness wait
+        # (a not-yet-started container fails connect and is retried).
+        env:
+          MSSQL_DATABASE: master
+        run: |
+          for i in $(seq 1 40); do
+            if pnpm --filter @metasheet/core-backend smoke:sqlserver:seed; then
+              echo "seeded on attempt $i"
+              exit 0
+            fi
+            echo "attempt $i: SQL Server not ready yet; sleeping 5s"
+            sleep 5
+          done
+          echo "SQL Server never became ready within timeout"
+          exit 1
+
+      - name: SQL Server real-wire smoke (connect / param / introspection / tableInfo / TOP + OFFSET-FETCH)
+        env:
+          MSSQL_DATABASE: smoke_db
+          MSSQL_SCHEMA: dbo
+          MSSQL_TABLE: smoke_probe
+        run: pnpm --filter @metasheet/core-backend smoke:sqlserver

--- a/docs/development/sqlserver-smoke-wire-gate-verification-20260529.md
+++ b/docs/development/sqlserver-smoke-wire-gate-verification-20260529.md
@@ -43,7 +43,14 @@ No write path is exercised (the source is read-only by default; write-enable is 
 
 ## Run against a real SQL Server
 
-### Option A — 2019/2022 container (Linux, free official image — recommended for our own verification)
+### Automated — CI matrix (B4; recommended, no local docker needed)
+`.github/workflows/sqlserver-smoke.yml` runs this smoke against **real SQL Server 2019 + 2022 service
+containers** whenever the data-source adapter / smoke changes (path-filtered, plus `workflow_dispatch`).
+It seeds `smoke_db.dbo.smoke_probe`, then runs the full smoke (connect / `SELECT 1` / `$N`→`@pN` /
+introspection / tableInfo / TOP + OFFSET-FETCH). The **green `SQL Server <ver> real-wire smoke` job
+runs are the evidence** — `amd64` runners run the image natively, so no local docker is required.
+
+### Manual (local) — 2019/2022 container (Linux, free official image)
 ```bash
 # 2022 (or mcr.microsoft.com/mssql/server:2019-latest)
 docker run -d --name mssql-smoke -e 'ACCEPT_EULA=Y' -e 'MSSQL_SA_PASSWORD=Str0ng!Passw0rd' \
@@ -73,7 +80,8 @@ Use a **read-only** SQL login; never the container against customer data. See th
 | Gate skips cleanly without env (CI-safe) | ✅ **PASS (2026-05-29)** | `[skip] SQL Server smoke skipped — no MSSQL_HOST / MSSQL_SERVER set … Exiting 0.` · **exit code 0** (run on the authoring host with all `MSSQL_*` unset) |
 | `tsc --noEmit` (core-backend) | ✅ PASS | clean |
 | fake-driver unit suite (`mssql-adapter.test.ts`) | ✅ PASS (pre-existing, #1985/#1997) | green |
-| **Real-wire run against 2019/2022 container or customer SQL Server** | ⏳ **PENDING** | **No docker on the authoring machine** → not run here. To be executed per "Option A/B" above; **evidence to be backfilled into this table** (paste the `[ok]` lines). Not claimed as done until then. |
+| **Real-wire run, SQL Server 2019 + 2022** | ✅ **via CI matrix (B4), green-gated** | `.github/workflows/sqlserver-smoke.yml` seeds + runs the full smoke against 2019 + 2022 service containers; the `SQL Server 2019/2022 real-wire smoke` checks **gate this PR** (and run on `main`) — green = the adapter's connect + SQL codegen proven on both versions. Supersedes the earlier "no local docker" gap. |
+| Real-wire run, SQL Server 2008R2 / 2012 | ⏳ Windows-VM follow-up | No Linux container image (Windows-only binaries) → out of the B4 Linux-container scope; protocol-mock / a future Windows-VM run covers these. |
 
 ## Scope / non-goals
 - Read-only smoke; no write path, no schema mutation.

--- a/docs/development/sqlserver-smoke-wire-gate-verification-20260529.md
+++ b/docs/development/sqlserver-smoke-wire-gate-verification-20260529.md
@@ -87,4 +87,4 @@ Use a **read-only** SQL login; never the container against customer data. See th
 - Read-only smoke; no write path, no schema mutation.
 - Does **not** touch `plugin-integration-core`'s `k3-wise-sqlserver` channel, RBAC, or auth.
 - Not Windows-native deploy (Lane C) and not a new connector.
-- Next: **B4** (full 2017/2019/2022 version-compat matrix on this harness; 2008R2/2012 → Windows VM follow-up).
+- B4's modern matrix (**2019 + 2022**) is this slice. Next: **2008R2 / 2012** legacy validation (Windows VM — no Linux container image) and optionally **2017** (Linux container; add to the matrix if a customer needs it).

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -18,6 +18,7 @@
     "seed:rbac": "tsx scripts/seed-rbac.ts",
     "smoke:plugins": "tsx scripts/smoke-plugins.ts",
     "smoke:sqlserver": "tsx scripts/smoke-sqlserver.ts",
+    "smoke:sqlserver:seed": "tsx scripts/smoke-sqlserver-seed.ts",
     "yjs:status": "node ../../scripts/ops/check-yjs-rollout-status.mjs",
     "yjs:validate": "node scripts/ops/yjs-node-client.mjs",
     "test": "vitest",

--- a/packages/core-backend/scripts/smoke-sqlserver-seed.ts
+++ b/packages/core-backend/scripts/smoke-sqlserver-seed.ts
@@ -1,0 +1,76 @@
+// CI-only seed for the SQL Server real-wire smoke (B4 version-compat matrix).
+//
+// Creates `smoke_db.dbo.smoke_probe` (a tiny, isolated DB so the smoke's schema introspection stays
+// clean and fast) so `smoke:sqlserver` can exercise tableExists / getTableInfo and BOTH select
+// branches (TOP + OFFSET/FETCH) against a real engine — not only connect/SELECT.
+//
+// It uses the `mssql` driver DIRECTLY for the DDL/DML: the production MSSQLAdapter is read-only by
+// design, so seeding does not go through it. Env-gated exactly like the smoke (skips with no target),
+// and idempotent (drop-if-exists). The CI job runs it in a retry loop, so it doubles as the
+// SQL-Server-readiness wait (a not-yet-started container just fails the connect and is retried).
+const env = process.env
+
+interface MssqlRequest {
+  query(sql: string): Promise<unknown>
+}
+interface MssqlConnectionPool {
+  connect(): Promise<MssqlConnectionPool>
+  close(): Promise<void>
+  request(): MssqlRequest
+}
+interface MssqlModule {
+  ConnectionPool: new (config: Record<string, unknown>) => MssqlConnectionPool
+}
+
+let mssql: MssqlModule | null = null
+try {
+  // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
+  mssql = require('mssql') as MssqlModule
+} catch {
+  // reported below if actually needed
+}
+
+async function main(): Promise<void> {
+  if (!env.MSSQL_HOST && !env.MSSQL_SERVER) {
+    console.log('[skip] seed skipped — no MSSQL_HOST / MSSQL_SERVER set (opt-in, CI-only).')
+    return
+  }
+  if (!mssql) {
+    throw new Error('mssql package is not installed')
+  }
+
+  const pool = new mssql.ConnectionPool({
+    server: env.MSSQL_HOST || env.MSSQL_SERVER,
+    port: env.MSSQL_PORT ? Number(env.MSSQL_PORT) : 1433,
+    database: env.MSSQL_DATABASE || 'master',
+    user: env.MSSQL_USERNAME,
+    password: env.MSSQL_PASSWORD,
+    options: {
+      // CI containers use a self-signed cert; stay encrypted, skip cert identity.
+      encrypt: env.MSSQL_ENCRYPT !== 'false',
+      trustServerCertificate: env.MSSQL_TRUST_SERVER_CERTIFICATE !== 'false'
+    },
+    connectionTimeout: 5000
+  })
+
+  await pool.connect()
+  try {
+    // CREATE DATABASE must run in its own batch.
+    await pool.request().query("IF DB_ID('smoke_db') IS NULL CREATE DATABASE smoke_db;")
+    // 3-part names so we never depend on the connection's current database.
+    await pool.request().query(
+      "IF OBJECT_ID('smoke_db.dbo.smoke_probe', 'U') IS NOT NULL DROP TABLE smoke_db.dbo.smoke_probe;" +
+        ' CREATE TABLE smoke_db.dbo.smoke_probe (id INT NOT NULL PRIMARY KEY, name NVARCHAR(50) NULL);' +
+        " INSERT INTO smoke_db.dbo.smoke_probe (id, name) VALUES (1, 'a'), (2, 'b'), (3, 'c'), (4, 'd'), (5, 'e');"
+    )
+    console.log('[ok] seeded smoke_db.dbo.smoke_probe (5 rows)')
+  } finally {
+    await pool.close()
+  }
+}
+
+main().catch(error => {
+  console.error('[failed] SQL Server seed failed')
+  console.error(error)
+  process.exitCode = 1
+})

--- a/packages/core-backend/scripts/smoke-sqlserver-seed.ts
+++ b/packages/core-backend/scripts/smoke-sqlserver-seed.ts
@@ -35,6 +35,18 @@ async function main(): Promise<void> {
     console.log('[skip] seed skipped — no MSSQL_HOST / MSSQL_SERVER set (opt-in, CI-only).')
     return
   }
+  // SAFETY (track principle: ZERO modification to customer data sources). This seed MUTATES the
+  // target — CREATE DATABASE smoke_db + DROP/CREATE/INSERT smoke_probe — so it must NEVER touch a
+  // customer/production server. Refuse to run unless an explicit write opt-in is set; the CI workflow
+  // sets it only against the throwaway service container. Fails loudly (not skip) so an accidental run
+  // with MSSQL_* pointed at a real server is rejected, not silently ignored.
+  if (env.MSSQL_SEED_ALLOW_WRITE !== 'true') {
+    throw new Error(
+      'Refusing to seed: this script MUTATES the target SQL Server (CREATE DATABASE / DROP + CREATE + ' +
+        'INSERT). Set MSSQL_SEED_ALLOW_WRITE=true ONLY against a throwaway/CI database — never a customer ' +
+        'or production server.'
+    )
+  }
   if (!mssql) {
     throw new Error('mssql package is not installed')
   }


### PR DESCRIPTION
**B4**: validate the generic `type=sqlserver` adapter (`MSSQLAdapter`) against **real SQL Server 2019 + 2022** in CI — closing B5A's pending real-wire evidence **without** needing local docker (amd64 runners run the image natively).

## What
- **`.github/workflows/sqlserver-smoke.yml`**: matrix `{2019, 2022}` **service containers** (`mcr.microsoft.com/mssql/server:<ver>-latest`), **path-filtered** to the data-source adapter / smoke surface (the image is ~1.5GB + ~30s startup, so it does **not** run on every PR) + `workflow_dispatch`. A **seed-in-retry-loop** doubles as the SQL-Server-readiness wait, then the full smoke runs.
- **`smoke-sqlserver-seed.ts`** (+ `smoke:sqlserver:seed`): CI-only seed of `smoke_db.dbo.smoke_probe` (isolated DB → clean/fast introspection) so the smoke exercises `tableInfo` + **both** select branches (TOP + OFFSET/FETCH). Uses the `mssql` driver directly (the read-only adapter is not used for DDL); env-gated + idempotent.
- **verification doc**: the CI matrix is now the recommended no-docker evidence path; the 2019/2022 evidence row is **green-gated** by these checks.

## Evidence
- The **`SQL Server 2019/2022 real-wire smoke` checks on this PR are the evidence** — green = connect + `SELECT 1` + `$N`→`@pN` + introspection + tableInfo + TOP + OFFSET/FETCH all work on both versions. (This PR's own CI runs the new job, since the path filter includes the workflow file.)
- `tsc` clean; seed skip-path exits 0 without env.

## Scope
- **2008R2 / 2012 have no Linux container image** (Windows-only) → out of Linux-container scope; protocol-mock / Windows-VM follow-up.
- Read-only; does **not** touch `plugin-integration-core`'s `k3-wise-sqlserver` channel.
- New service-container jobs sometimes need a tweak (container readiness, version-specific TLS/password env) — if the first run is red I'll iterate before asking to merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)