### PR TITLE
feat(multitable): #5c-b honest-label tooltip on the record dry-run preview (design §1.1)

### DIFF
--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -193,6 +193,7 @@
               type="button"
               class="meta-field-mgr__dryrun-btn meta-field-mgr__dryrun-btn--record"
               :disabled="!dryRunCanEvaluate"
+              :title="ml('field.formulaDryRun.recordHint')"
               @click="runDryRunWithRecord"
             >
               {{ dryRunRunning ? ml('field.formulaDryRun.evaluating') : ml('field.formulaDryRun.testWithRecord') }}

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -28,7 +28,7 @@ export type MetaManagerLabelKey =
   | 'field.optionalOverride' | 'field.aggregation'
   | 'field.expression' | 'field.insertFieldToken'
   | 'field.formulaReference' | 'field.formulaSearchPlaceholder'
-  | 'field.formulaDryRun.test' | 'field.formulaDryRun.testWithRecord' | 'field.formulaDryRun.sampleHeading' | 'field.formulaDryRun.evaluating'
+  | 'field.formulaDryRun.test' | 'field.formulaDryRun.testWithRecord' | 'field.formulaDryRun.recordHint' | 'field.formulaDryRun.sampleHeading' | 'field.formulaDryRun.evaluating'
   | 'field.formulaDryRun.resultHeading' | 'field.formulaDryRun.errorHeading' | 'field.formulaDryRun.invalidNumber'
   | 'field.formulaDryRun.forbidden' | 'field.formulaDryRun.tooLarge' | 'field.formulaDryRun.requestFailed'
   | 'field.allCategories' | 'field.noMatchingFunctions'
@@ -160,6 +160,10 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'field.formulaReference': { en: 'Formula reference', zh: '公式参考' },
   'field.formulaDryRun.test': { en: 'Test with sample data', zh: '用示例数据试算' },
   'field.formulaDryRun.testWithRecord': { en: 'Preview with current record', zh: '用当前记录预览/校验' },
+  // #5c-b honest-label (design §1.1): the record sampler is sheet-scoped + permission-safe + raw saved values,
+  // NOT a mirror of the current view's displayed columns. A field readable to you but hidden in your current
+  // view may still be sampled; a field denied by field-permissions never is.
+  'field.formulaDryRun.recordHint': { en: "Samples this record's saved values across the whole sheet, with your field-read permissions applied — not a mirror of the columns shown in the current view.", zh: '按整张表取该记录已保存的值，并按你的字段读取权限脱敏——并非镜像当前视图所显示的列。' },
   'field.formulaDryRun.sampleHeading': { en: 'Sample values', zh: '示例值' },
   'field.formulaDryRun.evaluating': { en: 'Evaluating…', zh: '试算中…' },
   'field.formulaDryRun.resultHeading': { en: 'Result', zh: '结果' },

--- a/apps/web/tests/multitable-formula-dryrun-panel.spec.ts
+++ b/apps/web/tests/multitable-formula-dryrun-panel.spec.ts
@@ -208,4 +208,30 @@ describe('MetaFieldManager formula dry-run — current-record sampling (#5c)', (
     expect(zone.querySelectorAll('.meta-field-mgr__formula-diagnostic').length).toBeGreaterThan(0) // missing_sample shown
     expect(zone.textContent).not.toContain('LEAK_CANARY_DO_NOT_RENDER') // diagnostic.message never rendered (no leak)
   })
+
+  it('record button carries the §1.1 honest-label tooltip (sheet-scope / permission-safe / NOT a view-column mirror)', async () => {
+    const fn = vi.fn().mockResolvedValue({ success: true, result: 1, resultType: 'number', referencedFields: ['fld_price'], diagnostics: [] } satisfies DryRunResult)
+    const { container } = await mountFormulaConfig(fn, [], 'rec_42')
+    await setExpression(container, '={fld_price}+1')
+    const btn = recordBtn(container)
+    expect(btn).not.toBeNull()
+    // the load-bearing honest claim from design §1.1: it is NOT a mirror of the current view's displayed columns
+    expect(btn!.title).toContain('not a mirror of the columns shown in the current view')
+    expect(btn!.title).toContain('field-read permissions') // ...and it is permission-safe
+  })
+
+  it('T7: drops a STALE record-path dry-run superseded mid-flight (record path rides the same dryRunSeq guard)', async () => {
+    let resolveFn!: (r: DryRunResult) => void
+    const fn = vi.fn().mockReturnValue(new Promise<DryRunResult>((r) => { resolveFn = r }))
+    const { container } = await mountFormulaConfig(fn, [], 'rec_42')
+    await setExpression(container, '={fld_price}+1')
+    clickRecordPreview(container) // record dry-run seq N, pending
+    await nextTick()
+    await setExpression(container, '={fld_price}+2') // supersede: bumps dryRunSeq + clears running + clears result
+    resolveFn({ success: true, result: 999, resultType: 'number', referencedFields: ['fld_price'], diagnostics: [] }) // stale record resolve
+    await flush()
+    expect(container.querySelector('.meta-field-mgr__dryrun-result')).toBeNull() // stale record response NOT shown
+    const btn = container.querySelector('.meta-field-mgr__dryrun-btn') as HTMLButtonElement
+    expect(btn.disabled).toBe(false) // panel recovered (not stuck-disabled)
+  })
 })


### PR DESCRIPTION
## #5c-b residual — the §1.1 honest-label tooltip

#5c-b's record-sampling UI shipped in **#2021** (`currentRecordId` prop + "Preview with current record" button + `recordId` passthrough + workbench wiring + 11/11 tests). But the #5c design-lock **§1.1** requires the honest-label sentence to appear in **three** places — design MD, the **frontend tooltip on the record-sampling affordance**, and the verification MD's non-goals — and #2021 left the **frontend tooltip** out (the record button had no `:title`; copy isn't asserted by tests, so it slipped through). This closes that residual.

### Change (frontend only, 3 files)
- **i18n** (`meta-manager-labels.ts`): new typed key `field.formulaDryRun.recordHint` (en/zh) stating the record sampler is **sheet-scoped + permission-safe + raw saved values**, and is **NOT a mirror of the current view's displayed columns** (the design's load-bearing anti-misread claim — a field readable to you but view-hidden may still be sampled; a `field_permissions`-denied field never is).
- **`MetaFieldManager.vue`**: bind it as the record button's `:title`.
- **Tests** (`multitable-formula-dryrun-panel.spec.ts`): assert the honest-label renders on the button (pins "not a mirror of the columns shown in the current view" + "field-read permissions"); plus a **T7** case proving the record path rides the same `dryRunSeq` stale-drop guard (a superseded record-path dry-run is dropped, panel recovers).

### Verification
- 13/13 panel tests green (11 prior + 2 new). vue-tsc clean.
- No backend / RBAC / `formula/engine.ts` touch (K3 stage-1 lock). i18n goes through the existing typed module (strict-zero discipline; `Record<Key,{en,zh}>` enforces both langs).

### Merge note
Frontend feature PR — at merge needs `base == origin/main` (not-stale) **plus an explicit greenlight**. Do not merge on review alone.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
