### PR TITLE
feat(integration): DF-T2c wire authoring → real preview (read-only derive route)

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -591,6 +591,41 @@ export async function previewIntegrationTemplate(
   return parseIntegrationResponse<IntegrationTemplatePreviewResult>(response)
 }
 
+// DF-T2c: a values-free entry in the derive evidence summary (field names + shape presence only).
+export interface IntegrationTemplateEvidenceField {
+  field: string
+  sourceType: string
+  shape: string
+  completeness?: string
+  isReference: boolean
+  hasValue: boolean
+}
+
+// DF-T2c: the draft returned by the read-only derive route. Deliberately carries NO raw
+// payloadTemplate (the operator-local customer values stay off the wire) — only the rules, the
+// gated field names, and a values-free evidence summary.
+export interface IntegrationTemplateDraft {
+  fieldRules: IntegrationFieldRule[]
+  gatedFields: string[]
+  evidence?: {
+    fields: IntegrationTemplateEvidenceField[]
+    gatedFields: string[]
+  }
+}
+
+// DF-T2c: derive a draft { payloadTemplate, fieldRules, gatedFields } from a RAW operator-local
+// payloadTemplate via the read-only derive route (which runs the DF-T2a helper server-side — no
+// duplication, no write; fails closed on redaction markers / secrets / outer {Data:…} envelopes).
+export async function deriveIntegrationTemplate(
+  payloadTemplate: Record<string, unknown>,
+): Promise<IntegrationTemplateDraft> {
+  const response = await apiFetch('/api/integration/templates/derive', {
+    method: 'POST',
+    body: JSON.stringify({ payloadTemplate }),
+  })
+  return parseIntegrationResponse<IntegrationTemplateDraft>(response)
+}
+
 export async function upsertIntegrationPipeline(
   payload: IntegrationPipelineUpsertRequest,
 ): Promise<IntegrationPipeline> {

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -847,6 +847,19 @@
           placeholder='{ "FNumber": "&lt;code&gt;", "FName": "&lt;name&gt;" }'
         ></textarea>
         <small class="integration-workbench__hint">可选。填写后使用 DF-T1 no-write payloadTemplate 预览；留空则保持 legacy preview。</small>
+        <button
+          type="button"
+          class="integration-workbench__button"
+          data-testid="derive-template-draft"
+          :disabled="derivingDraft"
+          @click="deriveTemplateDraft"
+        >{{ derivingDraft ? '派生中…' : '从模板派生字段规则草案' }}</button>
+        <p v-if="deriveError" class="integration-workbench__hint integration-workbench__hint--strong" data-testid="derive-error">{{ deriveError }}</p>
+        <MetaIntegrationFieldRuleAuthoring
+          v-if="authoredFieldRules.length > 0"
+          v-model="authoredFieldRules"
+          :gated-fields="authoredGatedFields"
+        />
       </div>
       <div>
         <div class="integration-workbench__panel-head">
@@ -910,6 +923,7 @@ import {
   replayIntegrationDeadLetter,
   runIntegrationPipeline,
   deriveFieldRulesFromMappings,
+  deriveIntegrationTemplate,
   summarizeFieldProvenance,
   testExternalSystemConnection,
   upsertWorkbenchExternalSystem,
@@ -928,9 +942,11 @@ import {
   type IntegrationStagingInstallResult,
   type IntegrationStagingOpenTarget,
   type IntegrationSystemObject,
+  type IntegrationFieldRule,
   type IntegrationTemplatePreviewRequest,
   type WorkbenchExternalSystem,
 } from '../services/integration/workbench'
+import MetaIntegrationFieldRuleAuthoring from '../components/integration/MetaIntegrationFieldRuleAuthoring.vue'
 
 type WorkbenchSide = 'source' | 'target'
 type TransformFn = '' | 'trim' | 'upper' | 'lower' | 'toNumber' | 'dictMap'
@@ -1102,6 +1118,12 @@ const sampleRecordText = ref(JSON.stringify({
 // DF-T1.5 reachability wire: optional payloadTemplate JSON. When filled, previewPayload sends the
 // DF-T1 no-write preview shape so the backend returns targetPayloadPreview (provenance); empty = legacy.
 const payloadTemplateText = ref('')
+// DF-T2c: the authored fieldRules draft (from the read-only derive route, then edited via the
+// authoring UI) + the gated fields it returns. previewPayload sends these (not a re-derive) when set.
+const authoredFieldRules = ref<IntegrationFieldRule[]>([])
+const authoredGatedFields = ref<string[]>([])
+const derivingDraft = ref(false)
+const deriveError = ref('')
 const connectionDraft = reactive<ConnectionDraft>({
   id: '',
   name: '',
@@ -2674,6 +2696,41 @@ function provenanceSourceLabel(source: string): string {
   return PROVENANCE_SOURCE_LABELS[source] || source
 }
 
+// DF-T2c: derive a draft via the READ-ONLY route, then drive the authoring UI with it. The pasted
+// payloadTemplate is RAW/operator-local; the route (DF-T2a) fails closed on redaction markers /
+// secrets / outer {Data:…} envelopes, surfaced here as deriveError. No write, no K3 call.
+async function deriveTemplateDraft(): Promise<void> {
+  deriveError.value = ''
+  const raw = payloadTemplateText.value.trim()
+  if (!raw) {
+    deriveError.value = '请先填写目标模板 JSON'
+    return
+  }
+  let parsed: unknown
+  try {
+    parsed = JSON.parse(raw)
+  } catch {
+    deriveError.value = '目标模板 JSON 解析失败'
+    return
+  }
+  if (!parsed || typeof parsed !== 'object' || Array.isArray(parsed)) {
+    deriveError.value = '目标模板 JSON 必须是一个对象'
+    return
+  }
+  derivingDraft.value = true
+  try {
+    const draft = await deriveIntegrationTemplate(parsed as Record<string, unknown>)
+    authoredFieldRules.value = Array.isArray(draft.fieldRules) ? draft.fieldRules : []
+    authoredGatedFields.value = Array.isArray(draft.gatedFields) ? draft.gatedFields : []
+  } catch (error) {
+    deriveError.value = error instanceof Error ? error.message : String(error)
+    authoredFieldRules.value = []
+    authoredGatedFields.value = []
+  } finally {
+    derivingDraft.value = false
+  }
+}
+
 async function previewPayload(): Promise<void> {
   try {
     const sourceRecord = JSON.parse(sampleRecordText.value) as Record<string, unknown>
@@ -2701,7 +2758,11 @@ async function previewPayload(): Promise<void> {
         throw new Error('目标模板 JSON 必须是一个对象')
       }
       request.payloadTemplate = parsed as Record<string, unknown>
-      request.fieldRules = deriveFieldRulesFromMappings(fieldMappings)
+      // DF-T2c: send the AUTHORED rules (derived via the read-only route + edited in the authoring
+      // UI) when present; else fall back to the legacy mapping-derived rules (byte-compatible w/ #1970).
+      request.fieldRules = authoredFieldRules.value.length > 0
+        ? authoredFieldRules.value
+        : deriveFieldRulesFromMappings(fieldMappings)
     }
     const result = await previewIntegrationTemplate(request)
     previewText.value = JSON.stringify(result, null, 2)

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -1784,4 +1784,87 @@ describe('IntegrationWorkbenchView', () => {
     expect(replayCalls).toBe(1)
     expect(container.textContent).toContain('Replay 成功')
   })
+
+  it('DF-T2c: derives a draft via the read-only route, and authoring edits reach the real preview request body', async () => {
+    const deriveBodies: Array<Record<string, unknown>> = []
+    const previewBodies: Array<Record<string, unknown>> = []
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url.startsWith('/api/integration/external-systems')) return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/templates/derive') {
+        deriveBodies.push(JSON.parse(String(init?.body)))
+        // the read-only route returns the DF-T2a draft (scalar→replace, reference→preserve, gated excluded)
+        // route returns values-free { fieldRules, gatedFields, evidence } — NO raw payloadTemplate
+        return jsonResponse({
+          fieldRules: [
+            { targetField: 'FNumber', sourceType: 'from_staging', sourceField: 'FNumber', shape: 'scalar' },
+            { targetField: 'FUnitID', sourceType: 'preserve_template', shape: 'object-passthrough', completeness: 'require-fnumber-fname' },
+          ],
+          gatedFields: ['FBaseUnitID'],
+          evidence: {
+            fields: [
+              { field: 'FNumber', sourceType: 'from_staging', shape: 'scalar', isReference: false, hasValue: true },
+              { field: 'FUnitID', sourceType: 'preserve_template', shape: 'object-passthrough', completeness: 'require-fnumber-fname', isReference: true, hasValue: true },
+            ],
+            gatedFields: ['FBaseUnitID'],
+          },
+        })
+      }
+      if (url === '/api/integration/templates/preview') {
+        previewBodies.push(JSON.parse(String(init?.body)))
+        return jsonResponse({ targetPayloadPreview: { fieldProvenance: {}, eligibleForSaveOnly: true } })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    // raw operator-local sample + a payloadTemplate to derive from
+    const sample = container.querySelector('[data-testid="sample-record"]') as HTMLTextAreaElement
+    sample.value = JSON.stringify({ materialCode: 'MAT-1' })
+    sample.dispatchEvent(new Event('input'))
+    const tpl = container.querySelector('[data-testid="payload-template"]') as HTMLTextAreaElement
+    tpl.value = JSON.stringify({ FNumber: 'MAT-1', FName: 'Widget', FUnitID: { FNumber: '01', FName: 'PCS' } })
+    tpl.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    // KEYSTONE 1 — derive FIRES the read-only route with the payloadTemplate (not a fixture)
+    ;(container.querySelector('[data-testid="derive-template-draft"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(deriveBodies).toHaveLength(1)
+    expect(deriveBodies[0]).toHaveProperty('payloadTemplate')
+    expect((deriveBodies[0].payloadTemplate as Record<string, unknown>).FUnitID).toBeDefined()
+    // the authoring UI is driven by the REAL derived draft
+    expect(container.querySelector('[data-testid="field-rule-FNumber"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="field-rule-locked-FUnitID"]')).not.toBeNull() // reference locked
+
+    // author: set FNumber's cleansed staging column
+    const source = container.querySelector('[data-testid="field-rule-source-FNumber"]') as HTMLInputElement
+    expect(source).not.toBeNull()
+    source.value = 'materialCode'
+    source.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    // KEYSTONE 2 — the PREVIEW request body carries payloadTemplate + the AUTHORED fieldRules
+    // (the edit flowed through to the wire; this is a request-body assertion, not a render check).
+    ;(container.querySelector('[data-testid="preview-payload"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(previewBodies).toHaveLength(1)
+    expect(previewBodies[0]).toHaveProperty('payloadTemplate')
+    const rules = previewBodies[0].fieldRules as Array<Record<string, unknown>>
+    expect(rules.find((r) => r.targetField === 'FNumber')).toMatchObject({ sourceType: 'from_staging', sourceField: 'materialCode', shape: 'scalar' })
+    expect(rules.find((r) => r.targetField === 'FUnitID')).toMatchObject({ sourceType: 'preserve_template' })
+  })
 })

--- a/docs/development/data-factory-df-t2c-authoring-preview-wire-verification-20260528.md
+++ b/docs/development/data-factory-df-t2c-authoring-preview-wire-verification-20260528.md
@@ -1,0 +1,58 @@
+# DF-T2c — authoring → real preview wire (verification, 2026-05-28)
+
+Third DF-T2 slice (design #2017; builds on T2a derive #2023 + T2b authoring UI #2027). Wires the
+authoring component into the workbench, driven by a **real derived draft** from a **read-only
+route that reuses T2a**, so the **preview request truly carries the authored `payloadTemplate` +
+`fieldRules`**. Still no K3 write. Left for review.
+
+## Hard acceptance (all met)
+
+| Requirement | How |
+|---|---|
+| Mount `MetaIntegrationFieldRuleAuthoring` in the workbench | Mounted in the payload-preview panel of `IntegrationWorkbenchView.vue`, fed by the derived draft. |
+| Real derived draft, **not fixture-only** | New **read-only** `POST /api/integration/templates/derive` runs the **T2a** helper (`deriveK3MaterialTemplateDraft`) on the operator's pasted `payloadTemplate` → returns the **values-free** `{ fieldRules, gatedFields, evidence }` (**P1: NOT** the raw `payloadTemplate` — `summarizeTemplateForEvidence` strips values; customer values never come back over the wire). **Reuses T2a — no duplication.** |
+| Preview request truly carries authored `payloadTemplate` + `fieldRules` | `previewPayload()` sends `request.payloadTemplate` + `request.fieldRules = authoredFieldRules` (the derived **and edited** rules) when present (else the legacy mapping-derive — byte-compatible with #1970). |
+| Test asserts the **request body**, not just render | Frontend keystone asserts the preview POST body's `fieldRules` carries the **edited** `FNumber.sourceField = 'materialCode'` + `FUnitID` `preserve_template`. **Negative-controlled** (ignore authored rules → assertion fails). |
+| No K3 write; no Submit/Audit/BOM/multi-record | Derive route is pure compute (`requireAccess('read')`, no external call/write); preview is no-write; nothing reachable to Submit/Audit/BOM. |
+| `payloadTemplate` values not rendered; only the request path | The **authoring component / provenance display render no `payloadTemplate` values** (rules carry field names + shape only — T2b), and the **derive-route response is values-free** (P1). The raw `payloadTemplate` exists only as the operator's own input textarea (operator-local input) and flows into the derive/preview **request bodies** — not into a value-rendering display panel. |
+
+## What shipped
+
+- **Backend** `http-routes.cjs`: `['POST','/api/integration/templates/derive','templatesDerive']` →
+  `requireAccess('read')` · 400 `PAYLOAD_TEMPLATE_REQUIRED` if no object · runs `deriveK3MaterialTemplateDraft`
+  and returns the **values-free** `{ fieldRules, gatedFields, evidence }` (`summarizeTemplateForEvidence`; **P1:
+  the raw `payloadTemplate` is NOT echoed back**) · **fails closed → 400 `TEMPLATE_DERIVE_REJECTED`** on a
+  `TemplateDeriveError` (redaction marker / unfilled placeholder / secret-shaped / outer `{Data:…}` envelope —
+  the T2a guards). No write.
+- **Service** `workbench.ts`: `IntegrationTemplateDraft` + `deriveIntegrationTemplate(payloadTemplate)` → the route.
+- **View** `IntegrationWorkbenchView.vue`: `derive-template-draft` button → `deriveTemplateDraft()` (parses the
+  pasted template, calls the route, sets `authoredFieldRules`/`authoredGatedFields`, surfaces `deriveError`) ·
+  mounts `<MetaIntegrationFieldRuleAuthoring v-model="authoredFieldRules" :gated-fields>` · `previewPayload()`
+  sends the authored rules when present.
+
+## Tests (green; vue-tsc clean for changed files)
+
+- **Backend route** (`http-routes.test.cjs`): unauth → 401/403 · `READ_USER` → 200 with the T2a-derived rules
+  (FNumber `from_staging`, FUnitID `preserve_template`, FBaseUnitID gated-excluded) · **P1: asserts the response
+  has NO `payloadTemplate`, includes a values-free `evidence`, and contains none of the sample values
+  (`Widget`/`PCS`)** · 400 on missing `payloadTemplate` · 400 (`TEMPLATE_DERIVE_REJECTED`) on an outer `{Data:…}`
+  envelope **and** a redaction marker.
+- **Frontend keystone** (`IntegrationWorkbenchView.spec.ts`, 15/15): paste template → **derive fires the route**
+  (request carries `payloadTemplate`) → the **real derived draft** drives the authoring UI (reference `FUnitID`
+  locked) → edit `FNumber`'s staging column → click preview → **the preview request body carries
+  `payloadTemplate` + the authored `fieldRules`** (`FNumber.sourceField='materialCode'`, `FUnitID` preserved).
+  **Negative-controlled**: breaking the authored-rules wiring (re-derive from mappings) fails the request-body assertion.
+- Neighbors (T2b component spec, integrationWorkbench service spec, plugin route suite) re-run green.
+
+## Boundaries (held)
+
+Read-only derive route (no write/K3/external call); preview no-write; references preserve-only (#1824);
+no Submit/Audit/BOM/multi-record; `payloadTemplate` values stay out of display DOM. DF-T2 (K3 customer-profile
+authoring) is now end-to-end: T2a derive → T2b author → **T2c wire to real preview**.
+
+## Files
+
+- `plugins/plugin-integration-core/lib/http-routes.cjs` (derive route + handler) + `__tests__/http-routes.test.cjs`
+- `apps/web/src/services/integration/workbench.ts` (`deriveIntegrationTemplate` + `IntegrationTemplateDraft`)
+- `apps/web/src/views/IntegrationWorkbenchView.vue` (derive button + mount + `previewPayload` authored rules)
+- `apps/web/tests/IntegrationWorkbenchView.spec.ts` (the request-body keystone)

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -1897,6 +1897,52 @@ async function testProvenanceReadRoute() {
   assert.equal(res.body.error.code, 'PROVENANCE_READ_NOT_IMPLEMENTED')
 }
 
+async function testTemplatesDeriveRoute() {
+  const { services } = createMockServices()
+  const { routes } = mountRoutes(services)
+  const sample = {
+    FNumber: 'M1',
+    FName: 'Widget',
+    FUnitID: { FNumber: '01', FName: 'PCS' },
+    FBaseUnitID: { FNumber: '01', FName: 'PCS' },
+  }
+
+  // unauthenticated → 401/403
+  let res = await invoke(routes, 'POST', '/api/integration/templates/derive', { body: { payloadTemplate: sample } })
+  assertErrorResponse(res, [401, 403])
+
+  // read user → 200 (READ-ONLY route); response is the DF-T2a draft (the route reuses T2a)
+  res = await invoke(routes, 'POST', '/api/integration/templates/derive', { user: READ_USER, body: { payloadTemplate: sample } })
+  assertOkResponse(res, 200)
+  const draft = res.body.data
+  const byField = Object.fromEntries(draft.fieldRules.map((rule) => [rule.targetField, rule]))
+  assert.equal(byField.FNumber.sourceType, 'from_staging', 'scalar → replace')
+  assert.equal(byField.FUnitID.sourceType, 'preserve_template', 'reference → preserve')
+  assert.ok(!('FBaseUnitID' in byField), 'gated FBaseUnitID excluded from authorable rules')
+  assert.deepEqual(draft.gatedFields, ['FBaseUnitID'])
+  // P1: the response does NOT echo the raw payloadTemplate (no operator-local customer values);
+  // it returns a values-free evidence summary instead.
+  assert.ok(!('payloadTemplate' in draft), 'response does not echo the raw payloadTemplate')
+  assert.ok(draft.evidence && Array.isArray(draft.evidence.fields), 'response includes a values-free evidence summary')
+  const draftJson = JSON.stringify(draft)
+  assert.ok(!draftJson.includes('Widget') && !draftJson.includes('PCS'), 'response carries no raw customer values')
+
+  // 400 when payloadTemplate is missing / not an object
+  res = await invoke(routes, 'POST', '/api/integration/templates/derive', { user: READ_USER, body: {} })
+  assertErrorResponse(res, [400])
+  assert.equal(res.body.error.code, 'PAYLOAD_TEMPLATE_REQUIRED')
+
+  // 400 (fail-closed) on an outer K3 { Data: … } envelope — the DF-T2a guard, surfaced by the route
+  res = await invoke(routes, 'POST', '/api/integration/templates/derive', { user: READ_USER, body: { payloadTemplate: { Data: { FNumber: 'X' } } } })
+  assertErrorResponse(res, [400])
+  assert.equal(res.body.error.code, 'TEMPLATE_DERIVE_REJECTED')
+
+  // 400 (fail-closed) on a redaction marker — never derive an executable template from it
+  res = await invoke(routes, 'POST', '/api/integration/templates/derive', { user: READ_USER, body: { payloadTemplate: { FNumber: '[redacted]', FName: 'X' } } })
+  assertErrorResponse(res, [400])
+  assert.equal(res.body.error.code, 'TEMPLATE_DERIVE_REJECTED')
+}
+
 async function main() {
   await testUnauthenticatedWriteRequestIsRejected()
   await testExternalSystemRoutes()
@@ -1909,6 +1955,7 @@ async function main() {
   await testDocumentTemplateValidation()
   await testPipelineRoutes()
   await testTemplatePreviewRoute()
+  await testTemplatesDeriveRoute()
   await testStagingRoutes()
   await testRunAndDeadLetterRoutes()
   await testProvenanceReadRoute()

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -24,6 +24,7 @@ const ROUTES = [
   ['POST', '/api/integration/pipelines/:id/run', 'pipelinesRun'],
   ['POST', '/api/integration/pipelines/:id/dry-run', 'pipelinesDryRun'],
   ['POST', '/api/integration/templates/preview', 'templatesPreview'],
+  ['POST', '/api/integration/templates/derive', 'templatesDerive'],
   ['GET', '/api/integration/staging/descriptors', 'stagingDescriptors'],
   ['POST', '/api/integration/staging/install', 'stagingInstall'],
   ['GET', '/api/integration/runs', 'runsList'],
@@ -39,6 +40,8 @@ const { getPath, setPath, transformRecord } = require('./transform-engine.cjs')
 // DF-T1 reuses applyReferenceShape (shaping) + findUnfilledPlaceholders (detection); it does
 // NOT introduce a new K3 shaper/projector.
 const { projectRecordForBody, findUnfilledPlaceholders, applyReferenceShape, isBlankValue } = require('./adapters/k3-save-body-composer.cjs')
+// DF-T2c: read-only derive route reuses the DF-T2a helper (no duplication; pure compute, no write).
+const { deriveK3MaterialTemplateDraft, summarizeTemplateForEvidence, TemplateDeriveError } = require('./connector-template-derive.cjs')
 const { validateRecord } = require('./validator.cjs')
 
 class HttpRouteError extends Error {
@@ -1055,6 +1058,35 @@ function createHandlers(services) {
     async templatesPreview(req, res) {
       requireAccess(req, 'write')
       return sendOk(res, buildTemplatePreview(requestBody(req)))
+    },
+
+    // DF-T2c: read-only derive — run the DF-T2a helper on an operator-supplied (raw, operator-local)
+    // payloadTemplate and return the draft { payloadTemplate, fieldRules, gatedFields }. Pure compute:
+    // no external call, no write, no K3. Fails closed (400) on a redaction marker / unfilled
+    // placeholder / secret-shaped value / outer {Data:…} envelope — the DF-T2a guards.
+    async templatesDerive(req, res) {
+      requireAccess(req, 'read')
+      const body = requestBody(req)
+      if (!isPlainObject(body.payloadTemplate)) {
+        throw new HttpRouteError(400, 'PAYLOAD_TEMPLATE_REQUIRED', 'payloadTemplate (an object) is required')
+      }
+      try {
+        const draft = deriveK3MaterialTemplateDraft(body.payloadTemplate)
+        // P1: do NOT echo the raw payloadTemplate (operator-local customer values) in the response.
+        // Return the rules + gated field names + a VALUES-FREE evidence summary only.
+        return sendOk(res, {
+          fieldRules: draft.fieldRules,
+          gatedFields: draft.gatedFields,
+          evidence: summarizeTemplateForEvidence(draft),
+        })
+      } catch (error) {
+        if (error instanceof TemplateDeriveError) {
+          throw new HttpRouteError(400, 'TEMPLATE_DERIVE_REJECTED', error.message, {
+            reason: error.details && error.details.reason,
+          })
+        }
+        throw error
+      }
     },
 
     async stagingDescriptors(req, res) {


### PR DESCRIPTION
Third **DF-T2** slice (design #2017; builds on T2a derive #2023 + T2b authoring UI #2027). Wires the authoring component into the workbench via a **read-only derive route that reuses T2a**, so the **preview request truly carries the authored `payloadTemplate` + `fieldRules`**. No K3 write.

## Hard acceptance (all met)
- **Mount** `MetaIntegrationFieldRuleAuthoring` in the workbench payload-preview panel.
- **Real derived draft (not fixture):** new read-only `POST /api/integration/templates/derive` runs **T2a** (`deriveK3MaterialTemplateDraft`) → `{payloadTemplate, fieldRules, gatedFields}`. **Reuses T2a — no duplication.**
- **Preview request truly carries authored template+rules:** `previewPayload` sends `payloadTemplate` + `authoredFieldRules` (derived **and edited**) when present (else the legacy mapping-derive).
- **Request-body assertion (not render):** the frontend keystone asserts the preview POST body's `fieldRules` carries the edited `FNumber.sourceField='materialCode'` + `FUnitID` `preserve_template`. **Negative-controlled.**
- **No K3 write / no Submit·Audit·BOM·multi-record:** derive route is `requireAccess('read')`, pure compute, fails closed (400 `TEMPLATE_DERIVE_REJECTED`) on redaction marker / placeholder / secret / outer `{Data:…}` envelope (the T2a guards).
- **`payloadTemplate` stays out of display DOM:** the authoring component holds no values (names+shape only); `payloadTemplate` flows operator-input → derive/preview **requests**.

## Tests (green; vue-tsc clean for changed files)
- Backend route: unauth→401/403 · `READ_USER`→200 with the T2a draft (FNumber `from_staging`, FUnitID `preserve_template`, FBaseUnitID gated-excluded) · 400 missing · 400 fail-closed (outer envelope **and** redaction marker).
- Frontend **keystone**: derive fires the route → the real draft drives the UI (reference `FUnitID` locked) → edit → preview **request body** carries `payloadTemplate` + authored `fieldRules`. **Negative-controlled** (ignore authored → assertion fails).
- Neighbors (T2b spec, service spec, plugin route suite) re-run green.

DF-T2 (K3 customer-profile authoring) is now end-to-end: **T2a derive → T2b author → T2c wire to real preview.** Leave for review.

Verification: `docs/development/data-factory-df-t2c-authoring-preview-wire-verification-20260528.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)