### PR TITLE
feat(data-sources): A3 — surface a redacted connection-test failure cause

### DIFF
--- a/packages/core-backend/src/data-adapters/BaseAdapter.ts
+++ b/packages/core-backend/src/data-adapters/BaseAdapter.ts
@@ -185,6 +185,8 @@ export abstract class BaseDataAdapter extends EventEmitter {
   protected config: DataSourceConfig
   protected connected: boolean = false
   protected pool: ConnectionPool
+  // A3: redacted cause of the most recent connect/test failure, surfaced by manager.testConnection.
+  protected lastConnectionError: string | null = null
 
   constructor(config: DataSourceConfig) {
     super()
@@ -302,8 +304,31 @@ export abstract class BaseDataAdapter extends EventEmitter {
     return operators[op] || '='
   }
 
+  // A3: the redacted cause of the most recent connect/test failure (null when healthy).
+  get connectionError(): string | null {
+    return this.lastConnectionError
+  }
+
+  // A3: scrub configured secret values + common secret patterns out of a message before it can be
+  // returned to a client or logged. Defense-in-depth: a connection error must never carry a password.
+  protected redactSecrets(message: string): string {
+    let out = message
+    const creds = this.config.credentials ?? {}
+    const conn = this.config.connection ?? {}
+    const secretValues = [creds.password, creds.token, creds.apiKey, creds.secret, conn.password]
+      .filter((v): v is string => typeof v === 'string' && v.length > 0)
+    for (const secret of secretValues) {
+      out = out.split(secret).join('***')
+    }
+    return out.replace(
+      /(\b(?:password|pwd|pass|token|api[_-]?key|secret|authorization)\b\s*[=:]\s*)("[^"]*"|'[^']*'|[^\s;,)]+)/gi,
+      '$1***'
+    )
+  }
+
   // Lifecycle hooks
   protected async onConnect(): Promise<void> {
+    this.lastConnectionError = null // A3: a successful connect clears the prior failure cause
     this.emit('connected', { adapter: this.config.name })
   }
 
@@ -312,6 +337,8 @@ export abstract class BaseDataAdapter extends EventEmitter {
   }
 
   protected async onError(error: Error): Promise<void> {
+    // A3: capture the redacted cause so a connection-test failure is explainable; never store secrets.
+    this.lastConnectionError = this.redactSecrets(error.message)
     this.emit('error', { adapter: this.config.name, error })
   }
 

--- a/packages/core-backend/src/data-adapters/BaseAdapter.ts
+++ b/packages/core-backend/src/data-adapters/BaseAdapter.ts
@@ -320,8 +320,15 @@ export abstract class BaseDataAdapter extends EventEmitter {
     for (const secret of secretValues) {
       out = out.split(secret).join('***')
     }
+    // key=value / key: value with a single-token value.
+    out = out.replace(
+      /(\b(?:password|pwd|pass|token|api[_-]?key|secret)\b\s*[=:]\s*)("[^"]*"|'[^']*'|[^\s;,)]+)/gi,
+      '$1***'
+    )
+    // Authorization carries a scheme + token (e.g. "Bearer xyz"); consume the whole credential so the
+    // token after the scheme is not left behind (a single-token rule would leave "Bearer ***  xyz").
     return out.replace(
-      /(\b(?:password|pwd|pass|token|api[_-]?key|secret|authorization)\b\s*[=:]\s*)("[^"]*"|'[^']*'|[^\s;,)]+)/gi,
+      /(\bauthorization\b\s*[=:]\s*)(?:bearer|basic|digest|negotiate)?\s*[^\s;,)]+/gi,
       '$1***'
     )
   }

--- a/packages/core-backend/src/data-adapters/DataSourceManager.ts
+++ b/packages/core-backend/src/data-adapters/DataSourceManager.ts
@@ -337,9 +337,13 @@ export class DataSourceManager extends EventEmitter {
       this.emit('adapter:disconnected', { ...data, id: config.id })
       this.updateStatus(config.id, 'disconnected').catch(() => {})
     })
-    adapter.on('error', (data) => {
-      this.emit('adapter:error', { ...data, id: config.id })
-      this.updateStatus(config.id, 'error', (data as { error?: string }).error).catch(() => {})
+    adapter.on('error', () => {
+      // A3 leak-fix: forward the REDACTED cause (adapter.connectionError, set by onError just before
+      // this fires), never the raw Error — the adapter:error event AND the persisted last_error must
+      // not carry a secret. The manager is the only consumer of an adapter's 'error' event.
+      const redacted = adapter.connectionError ?? 'connection error'
+      this.emit('adapter:error', { id: config.id, adapter: config.name, error: redacted })
+      this.updateStatus(config.id, 'error', redacted).catch(() => {})
     })
 
     this.adapters.set(config.id, adapter)

--- a/packages/core-backend/src/data-adapters/DataSourceManager.ts
+++ b/packages/core-backend/src/data-adapters/DataSourceManager.ts
@@ -492,9 +492,20 @@ export class DataSourceManager extends EventEmitter {
     await adapter.disconnect()
   }
 
-  async testConnection(id: string): Promise<boolean> {
+  // A3: returns success + the redacted failure cause. Ensures a connection is attempted (so the
+  // operator learns WHY it fails), then probes. The adapter stays Promise<boolean>; it records the
+  // redacted cause in `connectionError` (via onError) which we aggregate here.
+  async testConnection(id: string): Promise<{ success: boolean; error?: string }> {
     const adapter = this.getDataSource(id)
-    return adapter.testConnection()
+    try {
+      if (!adapter.isConnected()) {
+        await adapter.connect() // throws on failure; onError has recorded the redacted cause
+      }
+    } catch {
+      return { success: false, error: adapter.connectionError ?? undefined }
+    }
+    const ok = await adapter.testConnection()
+    return ok ? { success: true } : { success: false, error: adapter.connectionError ?? undefined }
   }
 
   // Query routing methods

--- a/packages/core-backend/src/data-adapters/HTTPAdapter.ts
+++ b/packages/core-backend/src/data-adapters/HTTPAdapter.ts
@@ -242,7 +242,8 @@ export class HTTPAdapter extends BaseDataAdapter {
       try {
         const response = await this.client.head('/')
         return response.status >= 200 && response.status < 300
-      } catch {
+      } catch (error) {
+        await this.onError(error as Error) // A3: record the redacted cause of the final test failure
         return false
       }
     }

--- a/packages/core-backend/src/data-adapters/MSSQLAdapter.ts
+++ b/packages/core-backend/src/data-adapters/MSSQLAdapter.ts
@@ -263,7 +263,8 @@ export class MSSQLAdapter extends BaseDataAdapter {
     try {
       const result = await this.pool.request().query<{ ok: number }>('SELECT 1 AS ok')
       return (result.recordset?.length ?? 0) > 0
-    } catch {
+    } catch (error) {
+      await this.onError(error as Error) // A3: record the redacted cause (else the test failure is silent)
       return false
     }
   }

--- a/packages/core-backend/src/data-adapters/PostgresAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PostgresAdapter.ts
@@ -127,7 +127,8 @@ export class PostgresAdapter extends BaseDataAdapter {
     try {
       const result = await this.pool.query('SELECT NOW()')
       return result.rows.length > 0
-    } catch {
+    } catch (error) {
+      await this.onError(error as Error) // A3: record the redacted cause (else the test failure is silent)
       return false
     }
   }

--- a/packages/core-backend/src/routes/data-sources.ts
+++ b/packages/core-backend/src/routes/data-sources.ts
@@ -488,15 +488,18 @@ export function dataSourcesRouter(): Router {
       manager.assertAccess(id, resolveUserId(req))
       const startTime = Date.now()
 
-      const success = await manager.testConnection(id)
+      const result = await manager.testConnection(id)
       const latency = Date.now() - startTime
 
+      // A3: keep request-layer ok:true (a completed test is a successful request); the connection
+      // outcome is data.success, with a redacted cause in data.error.message on failure.
       return res.json({
         ok: true,
         data: {
           id,
-          success,
-          latency: `${latency}ms`
+          success: result.success,
+          latency: `${latency}ms`,
+          ...(result.error ? { error: { message: result.error } } : {})
         }
       })
     } catch (error) {

--- a/packages/core-backend/tests/unit/data-source-test-error-fidelity.test.ts
+++ b/packages/core-backend/tests/unit/data-source-test-error-fidelity.test.ts
@@ -95,6 +95,33 @@ describe('data-source /test error fidelity (A3)', () => {
     expect(out).not.toContain(SECRET)   // configured secret value scrubbed
     expect(out).not.toContain('hunter2') // password=… pattern scrubbed
     expect(out).not.toContain('abc.def.ghi') // token: … pattern scrubbed
+    expect(out).not.toContain('xyz') // P2: the bearer token after "authorization=Bearer" is fully removed
     expect(out).toContain('***')
+  })
+
+  it('does not leak the secret via the adapter:error event / forwarded status (P1)', async () => {
+    const manager = getDataSourceManager()
+    manager.registerAdapterType('faildb', FailingConnectAdapter as never)
+    const id = `ds_evt_${Date.now()}`
+    await manager.addDataSource(
+      {
+        id, name: id, type: 'faildb',
+        connection: { host: 'unreachable' },
+        credentials: { username: 'u', password: SECRET },
+        options: { autoConnect: false },
+      },
+      { ownerId: 'tester', persist: false }
+    )
+    const events: Array<{ error?: unknown }> = []
+    manager.on('adapter:error', (p) => events.push(p as { error?: unknown }))
+
+    await manager.testConnection(id) // connect fails → onError → adapter emits 'error' → manager forwards
+
+    expect(events.length).toBeGreaterThan(0)
+    for (const e of events) {
+      // the forwarded event (and thus the persisted last_error) must NOT carry the secret
+      expect(JSON.stringify(e)).not.toContain(SECRET)
+    }
+    expect(events.some((e) => typeof e.error === 'string' && e.error.includes('***'))).toBe(true)
   })
 })

--- a/packages/core-backend/tests/unit/data-source-test-error-fidelity.test.ts
+++ b/packages/core-backend/tests/unit/data-source-test-error-fidelity.test.ts
@@ -1,0 +1,100 @@
+import express from 'express'
+import request from 'supertest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+// auditLog hits the DB; no-op it for these in-memory tests.
+vi.mock('../../src/audit/audit', () => ({ auditLog: vi.fn(async () => {}) }))
+
+import { BaseDataAdapter } from '../../src/data-adapters/BaseAdapter'
+import type {
+  DataSourceConfig,
+  QueryResult,
+  SchemaInfo,
+  TableInfo,
+  ColumnInfo,
+  Transaction,
+  DbValue,
+} from '../../src/data-adapters/BaseAdapter'
+import { dataSourcesRouter, getDataSourceManager } from '../../src/routes/data-sources'
+
+const SECRET = 'SuperSecretPw!2026'
+
+// A fake adapter whose connect() fails with an error that EMBEDS the configured password — to prove the
+// surfaced cause is redacted and the secret never reaches the wire (A3 safety guardrail).
+class FailingConnectAdapter extends BaseDataAdapter {
+  async connect(): Promise<void> {
+    const err = new Error(
+      `ECONNREFUSED 127.0.0.1: login failed (password=${this.config.credentials?.password}; ` +
+        `conn=Server=db;Pwd=${this.config.credentials?.password})`
+    )
+    await this.onError(err) // records redactSecrets(err.message) into lastConnectionError
+    throw err
+  }
+  async disconnect(): Promise<void> {}
+  isConnected(): boolean { return false }
+  async testConnection(): Promise<boolean> { return false }
+  async query<T = Record<string, DbValue>>(): Promise<QueryResult<T>> { return { data: [] } }
+  async select<T = Record<string, DbValue>>(): Promise<QueryResult<T>> { return { data: [] } }
+  async insert<T = Record<string, DbValue>>(): Promise<QueryResult<T>> { return { data: [] } }
+  async update<T = Record<string, DbValue>>(): Promise<QueryResult<T>> { return { data: [] } }
+  async delete<T = Record<string, DbValue>>(): Promise<QueryResult<T>> { return { data: [] } }
+  async getSchema(): Promise<SchemaInfo> { return { tables: [] } }
+  async getTableInfo(): Promise<TableInfo> { return { name: '', columns: [] } }
+  async getColumns(): Promise<ColumnInfo[]> { return [] }
+  async tableExists(): Promise<boolean> { return false }
+  async beginTransaction(): Promise<Transaction> { return {} as Transaction }
+  async commit(): Promise<void> {}
+  async rollback(): Promise<void> {}
+  async inTransaction<R = unknown>(_t: Transaction, cb: () => Promise<R>): Promise<R> { return cb() }
+  async *stream<T = Record<string, DbValue>>(): AsyncIterableIterator<T> { /* no rows */ }
+}
+
+function appAs(userId: string) {
+  const a = express()
+  a.use(express.json())
+  a.use((req, _res, next) => { req.user = { id: userId, role: 'admin' } as never; next() })
+  a.use(dataSourcesRouter())
+  return a
+}
+
+afterEach(() => { vi.restoreAllMocks() })
+
+describe('data-source /test error fidelity (A3)', () => {
+  it('surfaces a redacted failure cause (ok:true, success:false, error.message) and never the secret', async () => {
+    const manager = getDataSourceManager()
+    manager.registerAdapterType('faildb', FailingConnectAdapter as never)
+    const id = `ds_fail_${Date.now()}`
+    await manager.addDataSource(
+      {
+        id, name: id, type: 'faildb',
+        connection: { host: 'unreachable' },
+        credentials: { username: 'u', password: SECRET },
+        options: { autoConnect: false },
+      },
+      { ownerId: 'tester', persist: false }
+    )
+
+    const res = await request(appAs('tester')).get(`/api/data-sources/${id}/test`)
+
+    expect(res.status).toBe(200)                       // the request itself completed
+    expect(res.body.ok).toBe(true)                     // backward-compatible: request layer stays ok:true
+    expect(res.body.data.success).toBe(false)          // the connection failed
+    expect(res.body.data.error?.message).toBeTruthy()  // the cause is surfaced (A3 observability)
+    expect(res.body.data.error.message).toContain('ECONNREFUSED') // real cause visible
+    // SAFETY: the password must appear NOWHERE in the response, and the message is scrubbed.
+    expect(JSON.stringify(res.body)).not.toContain(SECRET)
+    expect(res.body.data.error.message).toContain('***')
+  })
+
+  it('redactSecrets scrubs both the configured secret value and password=/token= patterns', () => {
+    const adapter = new FailingConnectAdapter({
+      id: 'x', name: 'x', type: 'faildb', connection: {}, credentials: { password: SECRET }, options: {},
+    } as DataSourceConfig)
+    const redact = (adapter as unknown as { redactSecrets(m: string): string }).redactSecrets.bind(adapter)
+    const out = redact(`boom: value=${SECRET} password=hunter2 token: abc.def.ghi authorization=Bearer xyz`)
+    expect(out).not.toContain(SECRET)   // configured secret value scrubbed
+    expect(out).not.toContain('hunter2') // password=… pattern scrubbed
+    expect(out).not.toContain('abc.def.ghi') // token: … pattern scrubbed
+    expect(out).toContain('***')
+  })
+})


### PR DESCRIPTION
Lane A finishing **A3**: `GET /api/data-sources/:id/test` now tells operators **why** a connection failed, with secrets redacted — instead of a bare `success: false`.

## Behavior (backward-compatible, per the agreed guardrails)
- `manager.testConnection` ensures a connection is **attempted** (so a real cause exists), then probes; returns `{ success, error? }`.
- Route keeps **`ok: true`** (a completed test is a successful request — no 4xx/`ok:false` flip) and returns:
  `data: { id, success, latency, error?: { message } }` (`success` + `latency` unchanged → additive).
- Adapters stay `Promise<boolean>`: `BaseAdapter` records the cause in `lastConnectionError` via `onError` (every `connect()` catch already calls it), and the 3 registered adapters' `testConnection` catches now call it too → minimal cross-cut, no per-adapter signature change.

## Redaction (defense-in-depth)
`BaseAdapter.redactSecrets` scrubs **configured secret values** (`password`/`token`/`apiKey`/`secret`) **and** `password=` / `token=` / `authorization=` **patterns** from any message before it can be returned or logged.

## Tests (30 green: 3 existing data-source suites + 2 new)
- A fake adapter whose `connect()` embeds the configured password → `/test` returns `ok:true`, `success:false`, `error.message` (contains `ECONNREFUSED`), the **password is absent from the response**, and the message shows `***`.
- `redactSecrets` unit-check: scrubs the configured value + `password=`/`token:`/`authorization=` patterns.

## Scope
- A4-registered adapters (postgres/http/sqlserver) covered; MySQL/ES share the `BaseAdapter` `onError` hook on the connect path — `testConnection`-catch parity for them is a trivial follow-up.
- **Does not touch identifiers** — that's the next PR (**A2**: `sanitizeIdentifier` throw + per-segment-quoted schema-qualified).
- This PR touches `data-adapters/**` → the **SQL Server 2019/2022 real-wire matrix runs** here too (backstop for the `MSSQLAdapter` change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)