### PR TITLE
feat(data-sources): A2 — sanitizeIdentifier validate/throw + schema-qualified per-segment quoting

### DIFF
--- a/docs/development/sqlserver-smoke-runbook-20260528.md
+++ b/docs/development/sqlserver-smoke-runbook-20260528.md
@@ -85,6 +85,7 @@ If `MSSQL_TABLE` is set, it should also print:
 [ok] table info
 [ok] select sample (TOP)
 [ok] select page (OFFSET/FETCH)
+[ok] select schema-qualified ([schema].[table])
 ```
 
 The two `select` lines cover both pagination branches (`TOP` and `OFFSET…FETCH`). They run only when

--- a/docs/development/sqlserver-smoke-wire-gate-verification-20260529.md
+++ b/docs/development/sqlserver-smoke-wire-gate-verification-20260529.md
@@ -33,8 +33,9 @@ The smoke drives `MSSQLAdapter` end-to-end against the target:
 3. parameterized query — `SELECT $1` → exercises the `$N`→`@pN` translation.
 4. `getSchema(schema)` — `INFORMATION_SCHEMA` + `sys.*` introspection (skippable via `MSSQL_SKIP_SCHEMA`).
 5. (with `MSSQL_TABLE`) `tableExists` + `getTableInfo` (columns + PK), and — **only on the default `dbo`
-   schema** — `select` **TOP** (`{limit}`) + `select` **OFFSET/FETCH** (`{limit, offset, orderBy}`), both
-   pagination branches. `adapter.select()` emits `FROM [table]` (unqualified → resolves against the login
+   schema** — `select` **TOP** (`{limit}`) + `select` **OFFSET/FETCH** (`{limit, offset, orderBy}`) (both
+   pagination branches) + a **schema-qualified** `select` (`[dbo].[table]`) that proves the A2 per-segment
+   quoting against the live engine (not just the fake-pool unit test). `adapter.select()` emits `FROM [table]` (unqualified → resolves against the login
    default schema), so on a non-`dbo` `MSSQL_SCHEMA` the select probes are **skipped** (`[skip] select
    probes …`) while the schema-qualified `tableExists`/`getTableInfo` still run. (Making `select()`
    schema-aware is a separate adapter enhancement, not B5A.)

--- a/packages/core-backend/scripts/smoke-sqlserver.ts
+++ b/packages/core-backend/scripts/smoke-sqlserver.ts
@@ -190,6 +190,17 @@ async function main(): Promise<void> {
             rows: paged.data.length
           })
         }
+
+        // A2 real-wire proof: a SCHEMA-QUALIFIED select exercises the per-segment quoting
+        // ([schema].[table]) against the live engine — the bare-table probes above only cover the
+        // single-segment [table] form. Connected to MSSQL_DATABASE, so [dbo].[<table>] resolves.
+        const qualified = `${schema}.${table}`
+        const qualifiedSample = await adapter.select(qualified, { limit: 1 })
+        if (qualifiedSample.error) throw qualifiedSample.error
+        console.log('[ok] select schema-qualified ([schema].[table])', {
+          table: qualified,
+          rows: qualifiedSample.data.length
+        })
       } else {
         console.log(
           '[skip] select probes (TOP / OFFSET-FETCH) — adapter.select() is not schema-qualified; it ' +

--- a/packages/core-backend/src/data-adapters/BaseAdapter.ts
+++ b/packages/core-backend/src/data-adapters/BaseAdapter.ts
@@ -247,8 +247,21 @@ export abstract class BaseDataAdapter extends EventEmitter {
 
   // Helper methods
   protected sanitizeIdentifier(identifier: string): string {
-    // Remove or escape potentially dangerous characters
-    return identifier.replace(/[^a-zA-Z0-9_]/g, '')
+    // A2: validate (THROW on illegal) instead of silently stripping, and support schema-qualified
+    // names by validating each '.'-separated segment. Silent stripping mangled `public.foo` ->
+    // `publicfoo` and masked bad input. Quoting (brackets/backticks) is each SQL adapter's job,
+    // applied PER SEGMENT.
+    if (typeof identifier !== 'string' || identifier.length === 0) {
+      throw new Error(`Invalid identifier: ${JSON.stringify(identifier)}`)
+    }
+    for (const segment of identifier.split('.')) {
+      if (!/^[a-zA-Z0-9_]+$/.test(segment)) {
+        throw new Error(
+          `Invalid identifier segment "${segment}" in "${identifier}" (allowed: letters, digits, underscore)`
+        )
+      }
+    }
+    return identifier
   }
 
   protected buildWhereClause(where: Record<string, WhereValue>): { sql: string; params: DbValue[] } {

--- a/packages/core-backend/src/data-adapters/MSSQLAdapter.ts
+++ b/packages/core-backend/src/data-adapters/MSSQLAdapter.ts
@@ -269,9 +269,10 @@ export class MSSQLAdapter extends BaseDataAdapter {
     }
   }
 
-  // Bracket-quote an identifier after the base sanitizer strips dangerous chars.
+  // A2: bracket-quote PER SEGMENT so a schema-qualified name becomes [schema].[table]. The base
+  // sanitizer validates each segment and throws on illegal input.
   private quoteIdent(identifier: string): string {
-    return `[${this.sanitizeIdentifier(identifier)}]`
+    return this.sanitizeIdentifier(identifier).split('.').map(seg => `[${seg}]`).join('.')
   }
 
   async query<T = Record<string, DbValue>>(sql: string, params?: DbValue[]): Promise<QueryResult<T>> {

--- a/packages/core-backend/src/data-adapters/MySQLAdapter.ts
+++ b/packages/core-backend/src/data-adapters/MySQLAdapter.ts
@@ -81,10 +81,9 @@ export class MySQLAdapter extends BaseDataAdapter {
    * Prevents SQL injection by removing dangerous characters and properly quoting
    */
   private sanitizeMySQLIdentifier(identifier: string): string {
-    // First sanitize using parent method to remove dangerous characters
-    const sanitized = this.sanitizeIdentifier(identifier)
-    // Then wrap in backticks for MySQL
-    return `\`${sanitized}\``
+    // A2: backtick-quote PER SEGMENT so a schema-qualified name becomes `schema`.`table`. The base
+    // sanitizer validates each segment and throws on illegal input.
+    return this.sanitizeIdentifier(identifier).split('.').map(seg => `\`${seg}\``).join('.')
   }
 
   async connect(): Promise<void> {

--- a/packages/core-backend/tests/unit/data-source-identifier-quoting.test.ts
+++ b/packages/core-backend/tests/unit/data-source-identifier-quoting.test.ts
@@ -1,0 +1,82 @@
+import { describe, expect, it } from 'vitest'
+
+import { PostgresAdapter } from '../../src/data-adapters/PostgresAdapter'
+import { MySQLAdapter } from '../../src/data-adapters/MySQLAdapter'
+import { MSSQLAdapter } from '../../src/data-adapters/MSSQLAdapter'
+import type { DataSourceConfig } from '../../src/data-adapters/BaseAdapter'
+
+// A2: sanitizeIdentifier now VALIDATES (throws on illegal) instead of silently stripping, and supports
+// schema-qualified names; each SQL adapter quotes PER SEGMENT.
+const cfg = (type: string): DataSourceConfig => ({ id: 'x', name: 'x', type, connection: {}, options: {} })
+const pg = new PostgresAdapter(cfg('postgres'))
+const mysql = new MySQLAdapter(cfg('mysql'))
+const mssql = new MSSQLAdapter(cfg('sqlserver'))
+
+const sanitize = (a: unknown, id: string) => (a as { sanitizeIdentifier(s: string): string }).sanitizeIdentifier(id)
+const mssqlQuote = (id: string) => (mssql as unknown as { quoteIdent(s: string): string }).quoteIdent(id)
+const mysqlQuote = (id: string) => (mysql as unknown as { sanitizeMySQLIdentifier(s: string): string }).sanitizeMySQLIdentifier(id)
+
+// Fake mssql pool capturing executed SQL — covers that the quoting is actually applied on the wire.
+function fakePool() {
+  const calls: string[] = []
+  const pool = {
+    request() {
+      const req = { input() { return req }, async query(sql: string) { calls.push(sql); return { recordset: [], rowsAffected: [] } } }
+      return req
+    },
+    async close() {},
+  }
+  return { pool, calls }
+}
+function mssqlWithPool(fp: ReturnType<typeof fakePool>): MSSQLAdapter {
+  const a = new MSSQLAdapter({
+    id: 's', name: 's', type: 'sqlserver',
+    connection: { host: 'db', database: 'D' }, credentials: { username: 'u', password: 'p' }, options: { autoConnect: false },
+  })
+  const internal = a as unknown as { pool: unknown; connected: boolean }
+  internal.pool = fp.pool
+  internal.connected = true
+  return a
+}
+
+describe('A2 identifier validation + per-segment quoting', () => {
+  it('sanitizeIdentifier: valid passes, schema-qualified preserved (NOT collapsed), illegal throws', () => {
+    expect(sanitize(pg, 'users')).toBe('users')
+    expect(sanitize(pg, 'public.users')).toBe('public.users') // dot preserved — not the old "publicusers"
+    expect(() => sanitize(pg, 'bad-name')).toThrow(/Invalid identifier/)
+    expect(() => sanitize(pg, 'a;DROP TABLE x')).toThrow(/Invalid identifier/)
+    expect(() => sanitize(pg, 'public.')).toThrow(/Invalid identifier/) // empty segment
+    expect(() => sanitize(pg, '')).toThrow(/Invalid identifier/)
+  })
+
+  it('MSSQL brackets PER SEGMENT: dbo.orders -> [dbo].[orders]; illegal throws', () => {
+    expect(mssqlQuote('orders')).toBe('[orders]')
+    expect(mssqlQuote('dbo.orders')).toBe('[dbo].[orders]')
+    expect(() => mssqlQuote('bad-name')).toThrow(/Invalid identifier/)
+  })
+
+  it('MySQL backticks PER SEGMENT: shop.orders -> `shop`.`orders`; illegal throws', () => {
+    expect(mysqlQuote('orders')).toBe('`orders`')
+    expect(mysqlQuote('shop.orders')).toBe('`shop`.`orders`')
+    expect(() => mysqlQuote('bad name')).toThrow(/Invalid identifier/)
+  })
+
+  it('MSSQL select wire: table / select / orderBy quoted per segment; where key validated', async () => {
+    const fp = fakePool()
+    await mssqlWithPool(fp).select('dbo.orders', {
+      select: ['rpt.amount'],
+      where: { status: 'open' },
+      orderBy: [{ column: 'created', direction: 'asc' }],
+    })
+    const sql = fp.calls[0]
+    expect(sql).toContain('[dbo].[orders]') // table (schema-qualified)
+    expect(sql).toContain('[rpt].[amount]') // select column (schema-qualified)
+    expect(sql).toContain('[created]')       // orderBy column
+    expect(sql).toMatch(/\bstatus\b/)        // where key validated (base where-clause is unbracketed)
+  })
+
+  it('MSSQL select rejects an illegal table / where-key (throws — not a silent strip)', async () => {
+    await expect(mssqlWithPool(fakePool()).select('bad-table', {})).rejects.toThrow(/Invalid identifier/)
+    await expect(mssqlWithPool(fakePool()).select('orders', { where: { 'bad-key': 1 } })).rejects.toThrow(/Invalid identifier/)
+  })
+})


### PR DESCRIPTION
Lane A finisher **A2**: `BaseAdapter.sanitizeIdentifier` stops **silently stripping** (which mangled `public.foo` → `publicfoo` and masked bad input) and instead **validates + throws**, with **schema-qualified** support quoted **per segment** in each adapter.

## Change
- **`sanitizeIdentifier`**: validates each `.`-separated segment (`[a-zA-Z0-9_]+`); **throws** on an illegal/empty segment or empty input. Returns the identifier unchanged once valid (dot preserved).
- **Per-segment quoting**: MSSQL `dbo.orders` → `[dbo].[orders]`; MySQL `shop.orders` → `` `shop`.`orders` ``; Postgres uses `sanitizeIdentifier` raw → `schema.table` (no longer collapsed).

## Safety — silent-strip dependency check (done first, per the plan)
No test references `sanitizeIdentifier`, and no data-adapter caller passes a dotted identifier (the only `.`-hit was a **Kysely** `.select`, not the adapter). So throwing is safe. **One behavior change**: an invalid table/column on `/select` now **throws** (rejected, caught by the route) instead of silently querying a stripped name — a correctness improvement.

## Tests (62 green: 5 new + MSSQL adapter + the data-source suites — no regression)
- `sanitizeIdentifier`: valid passes · `public.users` preserved (not `publicusers`) · `bad-name` / `a;DROP` / `public.` / `''` throw.
- MSSQL `[dbo].[orders]` · MySQL `` `shop`.`orders` `` · illegal throws.
- MSSQL `select` **wire**: table / select / orderBy quoted per segment, where-key validated; illegal table **and** where-key reject.

## Scope
- Read-only-compatible; does **not** touch the K3 channel. This PR touches `data-adapters/**` → the **SQL Server 2019/2022 real-wire matrix runs** here too (backstop that `[schema].[table]` codegen works on a real engine).

🤖 Generated with [Claude Code](https://claude.com/claude-code)