### PR TITLE
fix(attendance): require user map for identified import rows

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -6384,7 +6384,7 @@ attendanceIntegrationDescribe(
     }
   })
 
-  it('accepts fileId alias and defaults uploaded CSV imports to the daily summary profile', async () => {
+  it('rejects default-template CSV rows with 工号 when no userMap resolves them', async () => {
     if (!baseUrl) return
     if (!importUploadDir) return
 
@@ -6441,10 +6441,19 @@ attendanceIntegrationDescribe(
       }),
     })
     expect(previewRes.status).toBe(200)
-    const previewItems = (previewRes.body as { data?: { items?: Array<{ userId?: string; workDate?: string }> } } | undefined)?.data?.items ?? []
+    const previewItems = (
+      previewRes.body as {
+        data?: {
+          items?: Array<{ userId?: string; workDate?: string; status?: string; warnings?: string[] }>
+        }
+      } | undefined
+    )?.data?.items ?? []
     expect(previewItems.length).toBeGreaterThan(0)
-    expect(previewItems[0]?.userId).toBe(requesterId)
+    expect(previewItems[0]?.userId).toBe('unknown')
     expect(previewItems[0]?.workDate).toBe(workDate)
+    expect(previewItems[0]?.status).toBe('invalid')
+    expect(previewItems[0]?.warnings?.join('\n')).toContain('Unresolved user identifier')
+    expect(previewItems[0]?.warnings?.join('\n')).toContain('工号')
 
     const prepareCommitRes = await requestJson(`${baseUrl}/api/attendance/import/prepare`, {
       method: 'POST',
@@ -6475,8 +6484,10 @@ attendanceIntegrationDescribe(
     })
     expect(commitRes.status).toBe(200)
     const commitData = (commitRes.body as { data?: any } | undefined)?.data
-    expect(Number(commitData?.processedRows ?? 0)).toBeGreaterThanOrEqual(1)
-    expect(Number(commitData?.failedRows ?? 0)).toBeGreaterThanOrEqual(0)
+    expect(Number(commitData?.processedRows ?? -1)).toBe(0)
+    expect(Number(commitData?.failedRows ?? -1)).toBeGreaterThanOrEqual(1)
+    expect(commitData?.skipped?.[0]?.userId).toBeNull()
+    expect(commitData?.skipped?.[0]?.warnings?.join('\n')).toContain('Unresolved user identifier')
 
     const csvPath = path.join(importUploadDir, orgId, `${fileId}.csv`)
     const metaPath = path.join(importUploadDir, orgId, `${fileId}.json`)

--- a/packages/core-backend/tests/unit/attendance-import-user-resolution.test.ts
+++ b/packages/core-backend/tests/unit/attendance-import-user-resolution.test.ts
@@ -1,0 +1,83 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceImportForTests
+
+describe('attendance import row user resolution', () => {
+  it('maps template employee numbers through userMap before falling back', () => {
+    const row = {
+      fields: {
+        '工号': 'A001',
+        '姓名': 'Alice',
+      },
+    }
+
+    expect(helpers.resolveRowUserId({
+      row,
+      fallbackUserId: 'requester-admin',
+      userMap: {
+        A001: 'employee-a001',
+      },
+      userMapKeyField: '工号',
+      userMapSourceFields: ['工号', '姓名'],
+    })).toBe('employee-a001')
+  })
+
+  it('does not silently fall back to requester when a row has an unmapped user identifier', () => {
+    const row = {
+      fields: {
+        '工号': 'A001',
+        '姓名': 'Alice',
+      },
+    }
+
+    expect(helpers.resolveRowUserId({
+      row,
+      fallbackUserId: 'requester-admin',
+      userMap: {},
+      userMapKeyField: '工号',
+      userMapSourceFields: ['工号', '姓名'],
+    })).toBeNull()
+
+    expect(helpers.buildUnresolvedRowUserWarning({
+      row,
+      userMapKeyField: '工号',
+      userMapSourceFields: ['工号', '姓名'],
+    })).toContain('工号')
+  })
+
+  it('keeps single-user fallback when no row-level user identity is present', () => {
+    const row = {
+      fields: {
+        status: '正常',
+      },
+    }
+
+    expect(helpers.resolveRowUserId({
+      row,
+      fallbackUserId: 'requester-admin',
+      userMap: {},
+      userMapKeyField: '工号',
+      userMapSourceFields: ['工号', '姓名'],
+    })).toBe('requester-admin')
+  })
+
+  it('honors direct userId columns without requiring userMap', () => {
+    const row = {
+      fields: {
+        userId: 'employee-direct',
+        '工号': 'A001',
+      },
+    }
+
+    expect(helpers.resolveRowUserId({
+      row,
+      fallbackUserId: 'requester-admin',
+      userMap: {},
+      userMapKeyField: '工号',
+      userMapSourceFields: ['工号', '姓名'],
+    })).toBe('employee-direct')
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -6922,6 +6922,28 @@ function resolveUserMapEntry(userMap, key) {
   return null
 }
 
+function collectRowUserIdentityValues({ row, userMapKeyField, userMapSourceFields }) {
+  if (!row) return []
+  const fields = row.fields ?? {}
+  const candidates = []
+  if (userMapKeyField) candidates.push(userMapKeyField)
+  if (Array.isArray(userMapSourceFields)) candidates.push(...userMapSourceFields)
+  candidates.push('empNo', '工号', 'sourceUserKey', 'userKey', 'userName', '姓名')
+
+  const seenKeys = new Set()
+  const values = []
+  for (const key of candidates) {
+    if (!key || seenKeys.has(key)) continue
+    seenKeys.add(key)
+    const value = fields[key]
+    if (value === null || value === undefined || value === '') continue
+    const normalized = String(value).trim()
+    if (!normalized) continue
+    values.push({ field: key, value: normalized })
+  }
+  return values
+}
+
 function resolveRowUserId({ row, fallbackUserId, userMap, userMapKeyField, userMapSourceFields }) {
   if (!row) return fallbackUserId ?? null
   if (row.userId) return row.userId
@@ -6929,18 +6951,20 @@ function resolveRowUserId({ row, fallbackUserId, userMap, userMapKeyField, userM
   const fields = row.fields ?? {}
   const direct = fields.userId ?? fields.user_id
   if (direct) return direct
-  const candidates = []
-  if (userMapKeyField) candidates.push(userMapKeyField)
-  if (Array.isArray(userMapSourceFields)) candidates.push(...userMapSourceFields)
-  candidates.push('empNo', '工号', 'sourceUserKey', 'userKey', 'userName', '姓名')
-  for (const key of candidates) {
-    if (!key) continue
-    const value = fields[key]
-    if (value === null || value === undefined || value === '') continue
-    const mapped = resolveUserMapValue(userMap, String(value).trim())
+  const identityValues = collectRowUserIdentityValues({ row, userMapKeyField, userMapSourceFields })
+  for (const { value } of identityValues) {
+    const mapped = resolveUserMapValue(userMap, value)
     if (mapped) return mapped
   }
+  if (identityValues.length > 0) return null
   return fallbackUserId ?? null
+}
+
+function buildUnresolvedRowUserWarning({ row, userMapKeyField, userMapSourceFields }) {
+  const identityValues = collectRowUserIdentityValues({ row, userMapKeyField, userMapSourceFields })
+  if (!identityValues.length) return 'Missing userId'
+  const fields = Array.from(new Set(identityValues.map((entry) => entry.field))).join(', ')
+  return `Unresolved user identifier (${fields}); configure userMap or include userId`
 }
 
 function resolveRowUserProfile({ row, fallbackUserId, userMap, userMapKeyField, userMapSourceFields }) {
@@ -14596,6 +14620,11 @@ async function isApproverAllowed(db, userId, step, logger) {
 }
 
 module.exports = {
+  __attendanceImportForTests: {
+    buildUnresolvedRowUserWarning,
+    collectRowUserIdentityValues,
+    resolveRowUserId,
+  },
   __attendanceReportFieldCatalogForTests: {
     ATTENDANCE_REPORT_FIELD_CATALOG_FIELDS,
     ATTENDANCE_REPORT_FIELD_CATALOG_OBJECT_ID,
@@ -15937,10 +15966,16 @@ module.exports = {
 	          userMap: payload.userMap,
 	          userMapKeyField: payload.userMapKeyField,
 	          userMapSourceFields: payload.userMapSourceFields,
-	        })
-	        const warnings = []
-	        if (!rowUserId) warnings.push('Missing userId')
-	        if (!workDate) warnings.push('Missing workDate')
+        })
+        const warnings = []
+        if (!rowUserId) {
+          warnings.push(buildUnresolvedRowUserWarning({
+            row,
+            userMapKeyField: payload.userMapKeyField,
+            userMapSourceFields: payload.userMapSourceFields,
+          }))
+        }
+        if (!workDate) warnings.push('Missing workDate')
 	        if (requiredFields.length) {
 	          const missingRequired = requiredFields.filter((field) => {
 	            const value = resolveRequiredFieldValue(row, field)
@@ -16721,10 +16756,16 @@ module.exports = {
 	            userMap: payload.userMap,
 	            userMapKeyField: payload.userMapKeyField,
 	            userMapSourceFields: payload.userMapSourceFields,
-	          })
-	          const importWarnings = []
-	          if (!rowUserId) importWarnings.push('Missing userId')
-	          if (!workDate) importWarnings.push('Missing workDate')
+          })
+          const importWarnings = []
+          if (!rowUserId) {
+            importWarnings.push(buildUnresolvedRowUserWarning({
+              row,
+              userMapKeyField: payload.userMapKeyField,
+              userMapSourceFields: payload.userMapSourceFields,
+            }))
+          }
+          if (!workDate) importWarnings.push('Missing workDate')
 	          if (requiredFields.length) {
 	            const missingRequired = requiredFields.filter((field) => {
 	              const value = resolveRequiredFieldValue(row, field)
@@ -21446,7 +21487,13 @@ module.exports = {
               userMapSourceFields: parsed.data.userMapSourceFields,
             })
             const importWarnings = []
-            if (!rowUserId) importWarnings.push('Missing userId')
+            if (!rowUserId) {
+              importWarnings.push(buildUnresolvedRowUserWarning({
+                row,
+                userMapKeyField: parsed.data.userMapKeyField,
+                userMapSourceFields: parsed.data.userMapSourceFields,
+              }))
+            }
             if (!workDate) importWarnings.push('Missing workDate')
             if (requiredFields.length) {
               const missingRequired = requiredFields.filter((field) => {
@@ -22296,7 +22343,13 @@ module.exports = {
                 userMapSourceFields: parsed.data.userMapSourceFields,
               })
               const importWarnings = []
-              if (!rowUserId) importWarnings.push('Missing userId')
+              if (!rowUserId) {
+                importWarnings.push(buildUnresolvedRowUserWarning({
+                  row,
+                  userMapKeyField: parsed.data.userMapKeyField,
+                  userMapSourceFields: parsed.data.userMapSourceFields,
+                }))
+              }
               if (!workDate) importWarnings.push('Missing workDate')
               if (requiredFields.length) {
                 const missingRequired = requiredFields.filter((field) => {
@@ -23310,7 +23363,13 @@ module.exports = {
                 userMapSourceFields: parsed.data.userMapSourceFields,
               })
               const importWarnings = []
-              if (!rowUserId) importWarnings.push('Missing userId')
+              if (!rowUserId) {
+                importWarnings.push(buildUnresolvedRowUserWarning({
+                  row,
+                  userMapKeyField: parsed.data.userMapKeyField,
+                  userMapSourceFields: parsed.data.userMapSourceFields,
+                }))
+              }
               if (!workDate) importWarnings.push('Missing workDate')
               if (requiredFields.length) {
                 const missingRequired = requiredFields.filter((field) => {
@@ -24071,7 +24130,13 @@ module.exports = {
                       userMapSourceFields: parsedImport.data.userMapSourceFields,
                     })
                     const importWarnings = []
-                    if (!rowUserId) importWarnings.push('Missing userId')
+                    if (!rowUserId) {
+                      importWarnings.push(buildUnresolvedRowUserWarning({
+                        row,
+                        userMapKeyField: parsedImport.data.userMapKeyField,
+                        userMapSourceFields: parsedImport.data.userMapSourceFields,
+                      }))
+                    }
                     if (!workDate) importWarnings.push('Missing workDate')
                     if (requiredFields.length) {
                       const missingRequired = requiredFields.filter((field) => {


### PR DESCRIPTION
## Summary
- stop attendance import rows with user-identifying fields such as `工号`/`empNo` from silently falling back to the requester/admin user when no userMap entry resolves them
- keep the existing requester fallback for true single-user imports without row-level user identity columns
- surface an explicit unresolved-user warning in preview/commit skipped rows, and cover the resolver with unit tests

Closes #2013

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run --watch=false tests/unit/attendance-import-user-resolution.test.ts`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "rejects default-template CSV rows with 工号" --reporter=dot` (local integration suite skipped because DATABASE_URL/ATTENDANCE_TEST_DATABASE_URL is not configured)