### PR TITLE
feat(data-sources): Lane C — portable sandbox workDir (C1) + A/B/C deploy runbook (C2)

### DIFF
--- a/docs/development/data-sources-mssql-windows-deploy-design-20260527.md
+++ b/docs/development/data-sources-mssql-windows-deploy-design-20260527.md
@@ -144,9 +144,9 @@
 - 🔒 B6(后续切片)Windows 集成认证 `authType:'windows'` —— Kerberos/keytab/AD,独立设计
 
 ### Phase C — 部署形态(随 A/B 决策)
-- ⬜ C1 `/tmp/sandbox` → `os.tmpdir()`
-- ⬜ C2 A/B/C 三档部署 runbook
-- 🔒 C3 (仅走 C 时)Windows 原生运行时验证 pass
+- ✅ **C1** `'/tmp/sandbox'` → `path.join(os.tmpdir(),'sandbox')`(`ScriptSandbox.ts` + `script-sandbox-workdir.test.ts`;测试 mock `os.tmpdir()` 到非 `/tmp` sentinel,断言 workDir 派生自 `os.tmpdir()` 而非硬编码字面量 —— 否则 Linux CI 上 `os.tmpdir()===/tmp` 会让回退到字面量仍然 pass)
+- ✅ **C2** A/B/C 三档部署 runbook —— `docs/development/data-sources-mssql-windows-deploy-runbook-20260529.md`
+- 🔒 C3 (仅走 C 时)Windows 原生运行时验证 pass(需 Windows VM/快照,本预算未含)
 
 **推进顺序(已按裁示更新)**:Phase 0 → **A0 + A0.1(持久化 + scope 收口)→ A-RO + A1 + A4(基础面安全)→ A2/A3/A5/A6** → **B(仅当 A0/A0.1/A-RO/A1/A4 定住后才 opt-in)** → C(随部署形态)。
 - **Lane B 不再与 A 并行**:MSSQL 连接器必须落在已安全的框架上,故 gated 在 A0/A0.1/A-RO/A1/A4 之后(P0-4 裁示)。

--- a/docs/development/data-sources-mssql-windows-deploy-runbook-20260529.md
+++ b/docs/development/data-sources-mssql-windows-deploy-runbook-20260529.md
@@ -1,0 +1,141 @@
+# 外接数据源 + SQL Server 连接器 — 部署 runbook(A/B/C 三档)
+
+> **范围**:本 runbook 对应设计稿 Lane C 的 **C2**(A/B/C 三档部署操作手册)。配套 **C1**(`ScriptSandbox` workDir `/tmp/sandbox` → `os.tmpdir()`,去掉运行时唯一的 POSIX 假设)在同一刀落地。**C3**(Windows 原生运行时验证)仍 **🔒 未验证** —— 见 §7。
+> **权威设计稿**:`docs/development/data-sources-mssql-windows-deploy-design-20260527.md`。本 runbook 只讲"**怎么部署**";为什么三档都可行、治理/裁示/降级决策树看设计稿 §0/§1/§5。
+> **承袭原则**(设计稿 §1):① 对客户数据源**零改动、零风险**;② **只读优先**(MVP 强制,框架级);③ **适配器与部署形态解耦** —— 连 SQL Server 的能力**不依赖后端跑在哪**(A/B/C 三档对 Lane B 连接能力无影响)。
+
+---
+
+## 0. 为何三档都可行(关键事实)
+
+- 生产启动即 `node packages/core-backend/dist/src/index.js`(见 `Dockerfile.backend` CMD),**不 spawn 任何 shell 脚本**(仓库 `.sh` 全是 CI/部署/开发工具,非运行时)。
+- `src` 内**唯一**的运行时 POSIX 假设是 `ScriptSandbox.ts` 的 workDir 默认值 `'/tmp/sandbox'` —— **本刀 C1 已改为 `path.join(os.tmpdir(),'sandbox')`**,原生 Windows 落 `%TEMP%\sandbox`,不再有 `/tmp` 依赖。
+- `pg` / `redis` / `mssql(tedious)` 驱动**纯 JS,无原生编译** → 不挑 OS/CPU。
+- 因此"原生 Windows 跑"成本远低于初估;**唯一真麻烦是依赖侧的 Redis**(见 §5)。
+
+依赖侧:后端需 **PostgreSQL** + **Redis**。Postgres 三档都有现成形态;Redis 在原生 Windows 无官方版,故 C 档需替代实现(§5)。
+
+---
+
+## 1. 选档决策(A > B > C)
+
+| 档 | 形态 | 移植代价 | 适用客户 |
+|---|---|---|---|
+| **A(首选)** | 客户给一台**同网段 Linux VM**,跑现有镜像 / `docker-compose.app.yml` | **零移植** | 能给内网 Linux VM |
+| **B** | **Windows + Docker/WSL2**,`docker compose` 起 app+PG+Redis | 客户需接受 Docker(注意 Docker Desktop 企业授权) | 允许 Docker/WSL2 |
+| **C(兜底)** | **全原生 Windows**:Node 注册为 Windows 服务 + PostgreSQL Windows 安装包 + Garnet/Memurai 替代 Redis | C1(本刀已修)+ 一次 Windows 运行时验证(C3,🔒)+ 引入 Garnet/Memurai | Windows 且**禁** Docker |
+
+> 选档只看**客户 IT 接受度**,与"能不能连客户的 SQL Server"无关 —— 后者三档一致。**先问两件事**:① 客户能否给内网 Linux VM?能 → A。② 否则,允许 Docker/WSL2 吗?允许 → B,不允许 → C。
+
+---
+
+## 2. 通用前置(三档共用)
+
+### 2.1 构建产物 / 镜像
+- 镜像:`ghcr.io/${IMAGE_OWNER:-zensgit}/metasheet2-backend:${IMAGE_TAG}` + `…/metasheet2-web:${IMAGE_TAG}`(`pnpm docker:build` 本地构建,或从 ghcr 拉)。
+- 原生(C 档):`pnpm install && pnpm --filter @metasheet/core-backend build`(`tsc` → `dist/`),启动 `node packages/core-backend/dist/src/index.js`。
+
+### 2.2 必备环境变量(`docker/app.env` 或 Windows 服务环境)
+| 变量 | 用途 | 备注 |
+|---|---|---|
+| `DATABASE_URL` | Postgres 连接串 | 三档必填 |
+| `REDIS_HOST` / `REDIS_PORT` / `REDIS_PASSWORD` | Redis/RESP 连接 | 见 `docker/app.env`(默认 `redis:6379`);C 档指向 Garnet/Memurai 的 host:port |
+| `PORT` | 后端监听端口 | 默认 8900 |
+| `JWT_SECRET` | 鉴权签名密钥 | **每环境独立**;变更会令旧 token 401 |
+| **`ENCRYPTION_KEY`** | **数据源凭据落库加密主密钥(A1)** | **必须稳定 + 备份**:凭据以 AES-256-GCM 落库,`ENCRYPTION_KEY` 变更后解密**失败即抛**(`DataSourceManager` decrypt fail-loud),已存数据源不可用 |
+| `ENCRYPTION_SALT` | 凭据加密 salt(A1) | 同上,稳定 + 备份 |
+
+> ⚠️ **A1 凭据加密红线**:`ENCRYPTION_KEY`/`ENCRYPTION_SALT` 一旦丢失/变更,**所有已落库数据源凭据无法解密**。三档部署都必须把这两个值纳入密钥备份流程,不能只写在临时 env 里。
+
+### 2.3 数据库迁移(部署 SOP — 不可跳)
+- 执行:`pnpm --filter @metasheet/core-backend migrate`(= `tsx src/db/migrate.ts`,支持 `--list` / `--rollback`)。
+- **镜像拉取式部署必须先 diff 待跑迁移**,部署后**验证一次 auth round-trip**:部署后**静默 401 通常是 schema gap(迁移没跑全),不是 `JWT_SECRET` 错** —— 见部署 SOP。
+
+### 2.4 数据源连接默认(承袭 Lane A/B,三档一致)
+- `readOnly` **默认 `true`**(框架级双层:路由级 SELECT-only 分类器 + 适配器层 `assertWritable`)—— MVP 只暴露读路径,写能力解禁是后续独立闸。
+- SQL Server 源默认 `encrypt=true` + `trustServerCertificate=true`(线缆始终加密 + 信任内网自签证书;PR1 #1985 既定)。
+- 老库握手不拢时,用 **B3 per-source TLS 降级旋钮**(`tlsMinVersion` / `tlsCiphers` / `legacyTls`)—— **仍加密**,作用域限该源,客户服务器零改动;与 `encrypt:false` 互斥(同设即抛),降级落 `tls-downgrade` 审计 + warn。
+
+---
+
+## 3. 档 A — 客户 Linux VM(首选,零移植)
+
+1. **VM 要求**:与客户 SQL Server **同网段可达**;装 Docker + docker compose(或直接跑镜像)。
+2. **放置** `docker-compose.app.yml` + `docker/app.env`(按 §2.2 填),`docker/nginx.conf`。
+3. **拉镜像 / 构建**:`IMAGE_TAG=<tag> docker compose -f docker-compose.app.yml pull`(或 `pnpm docker:build` 后本地 tag)。
+4. **起依赖 + 应用**:`IMAGE_TAG=<tag> docker compose -f docker-compose.app.yml up -d`(postgres:15 + redis:7 + backend@`127.0.0.1:8900` + web@`8081`,PG/Redis 带 healthcheck,backend `depends_on` 健康)。
+5. **迁移**:进 backend 容器或用同镜像跑 `migrate`(§2.3),diff 待跑迁移。
+6. **冒烟**:auth round-trip(§2.3);若已配 SQL Server 源,跑 §6 的只读连通冒烟。
+
+## 4. 档 B — Windows + Docker/WSL2
+
+与档 A **完全相同的 compose 与命令**,差异仅在宿主 OS:
+1. 前提:客户 Windows 上装 **Docker Desktop**(注意企业授权)或 **WSL2 + Docker Engine**。
+2. 其余步骤同 §3(同一 `docker-compose.app.yml`)。
+3. 卷路径:compose 用 named volume(`metasheet-postgres-data` 等),Windows + Docker 下由 Docker 管理,无需手改路径。
+
+> B 档本质是"把 A 档的 Linux 容器跑在 Windows 的 Docker 里",故移植代价仍≈零;真正的成本是**客户是否接受 Docker**。
+
+## 5. 档 C — 全原生 Windows(兜底;⚠️ C3 🔒 未验证)
+
+> **状态标注(勿当已签收)**:C1(workDir 可移植)**本刀已落**;但 **C3(Windows 原生运行时整体验证)仍 🔒 未做** —— 路径/文件操作/服务化/PG+Garnet/Memurai 连通**未在真实 Windows 上跑通过**。本节是**设计 + 已修可移植性**的部署指引,**不是已验证的签收路径**。真实落 C 档前必须先完成 §7 的 C3。
+
+1. **Node 运行时**:装 Node ≥18;`pnpm --filter @metasheet/core-backend build` 出 `dist/`。
+2. **注册为 Windows 服务**:用 `nssm` 或 `node-windows` 把 `node packages/core-backend/dist/src/index.js` 注册为服务(开机自启、崩溃重启);服务环境注入 §2.2 的全部变量。
+3. **PostgreSQL**:用 PostgreSQL 官方 **Windows 安装包**;`DATABASE_URL` 指向它。
+4. **Redis 替代(C 档关键)**:Windows 无官方原生 Redis →
+   - **Garnet**(Microsoft,MIT 开源,.NET,RESP 兼容)= **OSS 首选**;
+   - **Memurai**(开发版免费 / 商业版付费)= 稳定商业 fallback。
+   - 二者均 RESP 兼容,后端 `REDIS_HOST`(及端口)指向其监听地址即可,**应用侧无需改代码**。
+5. **沙箱临时目录**:C1 后 `ScriptSandbox` 默认落 `%TEMP%\sandbox`(`os.tmpdir()`),无需手配。
+6. **迁移 + 冒烟**:`pnpm --filter @metasheet/core-backend migrate`(§2.3)+ §6 验证。
+
+---
+
+## 6. 部署后验证(三档共用)
+
+1. **迁移完整性**:`migrate --list` 确认无 pending;部署 SOP 的 migration-pending diff。
+2. **Auth round-trip**:登录 → 带 token 调一个鉴权接口 → 200。**静默 401 = schema gap**,回查迁移,别先怀疑 `JWT_SECRET`。
+3. **数据源只读连通**:对已配置的 SQL Server 源调 `GET /api/data-sources/:id/test`(鉴权 `data_sources:read`)—— 失败时响应 `data.error.message` 会带**已脱敏**的错因(A3:`password`/`token` 等不出现在 response/log)。
+4. **SQL Server 真连通冒烟(可选,需真实库)**:配 `MSSQL_HOST`/`MSSQL_SERVER` 等后跑
+   `pnpm --filter @metasheet/core-backend smoke:sqlserver`
+   (B5A:**只读**,无 `MSSQL_HOST`/`MSSQL_SERVER` 时 **exit 0 跳过**;覆盖 connect/select/OFFSET-FETCH/schema-qualified `[schema].[table]`)。
+   **绝不**在客户库跑 `smoke:sqlserver:seed`(写库,仅 CI,需 `MSSQL_SEED_ALLOW_WRITE=true`)—— 承袭"对客户数据源零改动"。
+
+---
+
+## 7. 已知缺口 / 仍 gated(执行期回填)
+
+| 项 | 状态 | 说明 |
+|---|---|---|
+| **C3 Windows 原生运行时验证** | 🔒 未做 | 走 C 档前必须验:路径/文件操作(含 `%TEMP%\sandbox`)、Node-as-service、PG + Garnet/Memurai 连通、端到端只读拉数。**需 Windows VM/快照**,本预算未含。 |
+| **2008R2 / 2012 真实验证** | ⬜ follow-up | B4 已覆盖 2019/2022 真容器;2008R2/2012 是 Windows-only 二进制无 Linux 容器,真实验证需 **Windows VM**(P0-6:仅当客户明确是 legacy 或进最终 signoff 才投)。 |
+| **B6 Windows 集成认证** | 🔒 独立切片 | `authType:'windows'`(Kerberos/keytab/AD)未做;本期连接器只支持 `authType:'sql'`。 |
+| **共享 workDir 跨实例** | ⬜ 观察项 | C1 只改 base path(`/tmp/sandbox` → `os.tmpdir()/sandbox`),**语义不变**:多个 `ScriptSandbox` 实例仍共享同一 `<tmpdir>/sandbox`,`cleanup()` 递归删该目录。per-instance 隔离不在 C1 范围,留作后续独立项(非本刀引入)。 |
+
+> **执行期仍待确认**(设计稿 §5):客户 SQL Server 具体版本、客户能否给 Linux VM / 是否允许 Docker/WSL2 —— 这三点决定最终落 A/B/C 哪档。
+
+---
+
+## 附录:命令速查
+
+```bash
+# 构建镜像(A/B)
+pnpm docker:build                                              # 出 metasheet-backend / metasheet-web 镜像
+
+# 起 / 停(A/B,生产 compose)
+IMAGE_TAG=<tag> docker compose -f docker-compose.app.yml up -d
+docker compose -f docker-compose.app.yml down
+
+# 迁移(三档)
+pnpm --filter @metasheet/core-backend migrate                  # 跑迁移
+pnpm --filter @metasheet/core-backend migrate -- --list        # 看 pending
+
+# 原生 Windows 启动(C)
+pnpm --filter @metasheet/core-backend build                    # tsc → dist
+node packages/core-backend/dist/src/index.js                   # 由 nssm/node-windows 包成服务
+
+# SQL Server 只读连通冒烟(B5A;无 MSSQL_HOST/SERVER 自动跳过)
+MSSQL_HOST=<host> MSSQL_USERNAME=<u> MSSQL_PASSWORD=<p> MSSQL_DATABASE=<db> \
+  pnpm --filter @metasheet/core-backend smoke:sqlserver
+```

--- a/packages/core-backend/src/sandbox/ScriptSandbox.ts
+++ b/packages/core-backend/src/sandbox/ScriptSandbox.ts
@@ -2,6 +2,7 @@
 import { Worker, MessageChannel } from 'worker_threads'
 import { EventEmitter } from 'eventemitter3'
 import path from 'path'
+import os from 'os'
 import crypto from 'crypto'
 import fs from 'fs/promises'
 
@@ -105,7 +106,10 @@ export class ScriptSandbox extends EventEmitter {
         'worker_threads'
       ],
       env: options.env || {},
-      workDir: options.workDir || '/tmp/sandbox',
+      // Lane C / C1: default under the OS temp dir (os.tmpdir()) instead of the hardcoded POSIX
+      // '/tmp/sandbox', so the sandbox is portable to native Windows (no '/tmp'). Identical value
+      // on POSIX where os.tmpdir() resolves to /tmp; resolves under %TEMP% on Windows.
+      workDir: options.workDir || path.join(os.tmpdir(), 'sandbox'),
       maxOutputSize: options.maxOutputSize || 1024 * 1024, // 1MB
       maxExecutions: options.maxExecutions || 1000,
       isolateContext: options.isolateContext !== false

--- a/packages/core-backend/tests/unit/script-sandbox-workdir.test.ts
+++ b/packages/core-backend/tests/unit/script-sandbox-workdir.test.ts
@@ -1,0 +1,41 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import os from 'os'
+import path from 'path'
+
+import { ScriptSandbox } from '../../src/sandbox/ScriptSandbox'
+
+// Read the private `workDir` without `any` (ESLint forbids `any`), mirroring the typed-cast
+// pattern used in data-source-identifier-quoting.test.ts.
+const workDirOf = (s: ScriptSandbox): string => (s as unknown as { workDir: string }).workDir
+
+// Lane C / C1: the default sandbox workDir must derive from os.tmpdir() (portable to native
+// Windows), not the hardcoded POSIX literal '/tmp/sandbox'.
+describe('ScriptSandbox workDir portability (Lane C / C1)', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+  })
+
+  it('derives the default workDir from os.tmpdir() (no hardcoded POSIX /tmp)', () => {
+    // Force tmpdir to a sentinel that is NOT /tmp. This is the discriminating requirement: on
+    // Linux CI os.tmpdir() already IS /tmp, so asserting equality with path.join(os.tmpdir(),
+    // 'sandbox') would coincide with the literal '/tmp/sandbox' and a regression would still pass.
+    // Mocking to a non-/tmp value makes a revert-to-literal fail on ANY platform.
+    const spy = vi.spyOn(os, 'tmpdir').mockReturnValue('/sentinel-tmp-xyz')
+
+    const sandbox = new ScriptSandbox()
+
+    // (1) the production default actually consults os.tmpdir() — if it were reverted to the
+    // literal, os.tmpdir() would never be called and this fails. This also confirms the spy is
+    // wired to the same `os` namespace ScriptSandbox imports (else it would never register a call).
+    expect(spy).toHaveBeenCalled()
+    // (2) ...and the resulting path is derived from that value, not the hardcoded literal.
+    expect(workDirOf(sandbox)).toBe(path.join('/sentinel-tmp-xyz', 'sandbox'))
+    expect(workDirOf(sandbox)).not.toBe('/tmp/sandbox')
+  })
+
+  it('honors an explicit workDir override', () => {
+    const custom = path.join(os.tmpdir(), 'custom-sandbox-override')
+    const sandbox = new ScriptSandbox({ workDir: custom })
+    expect(workDirOf(sandbox)).toBe(custom)
+  })
+})


### PR DESCRIPTION
## Lane C slice — docs/small-fix (C1 + C2)

Opened fresh from `origin/main`, per the staged-opt-in discipline (one slice, held for review). Closes Lane C's C1 + C2; **C3 stays 🔒** (Windows native runtime validation needs a Windows VM).

### C1 — portable sandbox workDir (code)
`ScriptSandbox` default workDir `'/tmp/sandbox'` → `path.join(os.tmpdir(), 'sandbox')`. This was the **only runtime POSIX assumption in `src`** (verified: prod start is `node dist/src/index.js`, no shell spawns; pg/redis/mssql drivers are pure-JS). Now portable to native Windows (`%TEMP%\sandbox`). Identical value on POSIX (`os.tmpdir()` === `/tmp`). `SandboxManager` passes `options` through unchanged — semantics preserved.

**Test (`script-sandbox-workdir.test.ts`)** mocks `os.tmpdir()` to a **non-`/tmp` sentinel** and asserts (a) the production default actually *calls* `os.tmpdir()` and (b) workDir derives from it. So a regression to the hardcoded literal **fails on any platform** — asserting `=== path.join(os.tmpdir(),'sandbox')` alone would silently pass on Linux CI (where `os.tmpdir()` already is `/tmp`). Verified **red-on-revert**. No `any` (typed private cast).

### C2 — A/B/C deploy runbook (docs)
New `data-sources-mssql-windows-deploy-runbook-20260529.md`: operational guide for tiers **A** (Linux VM, preferred) · **B** (Windows + Docker/WSL2) · **C** (native Windows: Node-as-service + PostgreSQL installer + Garnet/Memurai for Redis). References the design doc as authority.

- Tier C **explicitly marked C1-done / C3-🔒-unproven** so it doesn't read as signed off.
- Embeds **verified** commands/env only: `docker-compose.app.yml`, `migrate`, `ENCRYPTION_KEY`/`ENCRYPTION_SALT` fail-loud (A1), `smoke:sqlserver` (read-only, skips w/o host), B3 TLS knobs.
- States the zero-customer-modification + read-only-first principles; names Garnet/Memurai/Docker/nssm only as **install targets** (not competitor benchmarking).

### Tracker
Design doc §4: C1 + C2 ticked ✅ (same-commit), C3 left 🔒.

### Verification
- `script-sandbox-workdir.test.ts` 2/2 green; proven red when reverted to the literal.
- `eslint` clean on `ScriptSandbox.ts`; `tsc --noEmit` exit 0, zero errors project-wide.

### Governance
Lock-safe: touches only the sandbox substrate + docs — **no** `plugin-integration-core` / central RBAC / auth. User-opted-in Lane C deploy slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)