### PR TITLE
fix(attendance): reveal import batch admin section

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -3855,22 +3855,22 @@
                   </tbody>
                 </table>
               </div>
+            </div>
 
-              <div
-                v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.importBatches)"
-                class="attendance__admin-section"
-                v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.importBatches)"
-              >
-                <AttendanceImportBatchesSection
-                  :tr="tr"
-                  :workflow="attendanceImportBatchSectionBindings"
-                  :resolve-rule-set-name="resolveRuleSetName"
-                  :format-status="formatStatus"
-                  :format-date-time="formatDateTime"
-                  :format-json="formatJson"
-                  :storage-key="attendanceImportBatchStorageKey"
-                />
-              </div>
+            <div
+              v-show="shouldShowAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.importBatches)"
+              class="attendance__admin-section"
+              v-bind="adminSectionBinding(ATTENDANCE_ADMIN_SECTION_IDS.importBatches)"
+            >
+              <AttendanceImportBatchesSection
+                :tr="tr"
+                :workflow="attendanceImportBatchSectionBindings"
+                :resolve-rule-set-name="resolveRuleSetName"
+                :format-status="formatStatus"
+                :format-date-time="formatDateTime"
+                :format-json="formatJson"
+                :storage-key="attendanceImportBatchStorageKey"
+              />
             </div>
 
             <div

--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -745,6 +745,12 @@ describe('Attendance admin anchor navigation', () => {
     expect(button?.getAttribute('aria-current')).toBe('true')
     expect(button?.classList.contains('attendance__admin-nav-link--active')).toBe(true)
     expect(container!.querySelector('[data-admin-shortcut="attendance-admin-import-batches"]')?.textContent).toContain('Data & Payroll · Import batches')
+
+    const importSection = container!.querySelector<HTMLElement>('[data-admin-section="attendance-admin-import"]')
+    const importBatchesSection = container!.querySelector<HTMLElement>('[data-admin-section="attendance-admin-import-batches"]')
+    expect(importSection?.style.display).toBe('none')
+    expect(importBatchesSection?.style.display).not.toBe('none')
+    expect(importBatchesSection?.closest('[data-admin-section="attendance-admin-import"]')).toBeNull()
   })
 
   it('keeps the right pane focused on the active admin section and ignores legacy show-all preferences', async () => {


### PR DESCRIPTION
## Summary
- Move the Import batches admin section out of the Import section wrapper so focused navigation can reveal it independently.
- Add an admin rail regression assertion that Import batches is not nested under the hidden Import panel after navigation.

Closes #2014

## Verification
- pnpm --filter @metasheet/web exec vitest run --watch=false tests/attendance-admin-anchor-nav.spec.ts
- pnpm --filter @metasheet/web exec vitest run --watch=false tests/attendance-admin-regressions.spec.ts
- pnpm --filter @metasheet/web build
- git diff --check HEAD~1..HEAD