### PR TITLE
fix(multitable): route record reads through record gate

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -2192,7 +2192,12 @@ async function requireRecordReadable(
   query: QueryFn,
   sheetId: string,
   recordId: string,
-): Promise<{ access: ResolvedRequestAccess; capabilities: MultitableCapabilities } | { status: number; body: unknown }> {
+): Promise<{
+  access: ResolvedRequestAccess
+  capabilities: MultitableCapabilities
+  capabilityOrigin: MultitableCapabilityOrigin
+  sheetScope?: SheetPermissionScope
+} | { status: number; body: unknown }> {
   const recordCheck = await query(
     'SELECT id, sheet_id FROM meta_records WHERE id = $1 AND sheet_id = $2',
     [recordId, sheetId],
@@ -2204,7 +2209,7 @@ async function requireRecordReadable(
     }
   }
 
-  const { access, capabilities } = await resolveSheetReadableCapabilities(req, query, sheetId)
+  const { access, capabilities, capabilityOrigin, sheetScope } = await resolveSheetReadableCapabilities(req, query, sheetId)
   if (!access.userId) {
     return { status: 401, body: { error: 'Authentication required' } }
   }
@@ -2228,7 +2233,7 @@ async function requireRecordReadable(
     }
   }
 
-  return { access, capabilities }
+  return { access, capabilities, capabilityOrigin, ...(sheetScope ? { sheetScope } : {}) }
 }
 
 type FieldMutationGuard = {
@@ -7419,11 +7424,9 @@ export function univerMetaRouter(): Router {
       }
 
       sheetId = String(row.sheet_id)
-      const { access, capabilities, capabilityOrigin, sheetScope } = await resolveSheetReadableCapabilities(req, pool.query.bind(pool), sheetId)
-      if (!access.userId) {
-        return res.status(401).json({ error: 'Authentication required' })
-      }
-      if (!capabilities.canRead) return sendForbidden(res)
+      const readable = await requireRecordReadable(req, pool.query.bind(pool), sheetId, recordId)
+      if ('status' in readable) return res.status(readable.status).json(readable.body)
+      const { access, capabilities, capabilityOrigin, sheetScope } = readable
       const sheet = await loadSheetRow(pool.query.bind(pool), sheetId)
       if (!sheet) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Sheet not found: ${sheetId}` } })

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -27,6 +27,9 @@ function createMockPool(
       return { rows: [], rowCount: 0 }
     }
     if (sql.includes('FROM record_permissions') && !sql.includes('FROM record_permissions rp')) return { rows: [], rowCount: 0 }
+    if (sql.includes('SELECT id, sheet_id FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
+      return { rows: [{ id: String(params?.[0] ?? ''), sheet_id: String(params?.[1] ?? '') }], rowCount: 1 }
+    }
     if (sql.includes('SELECT pg_advisory_xact_lock(hashtext($1))')) {
       return { rows: [], rowCount: 1 }
     }
@@ -128,7 +131,7 @@ describe('Multitable sheet-scoped permissions API', () => {
   })
 
   test('narrows context and record actions when sheet permission is read-only', async () => {
-    const { app } = await createApp({
+    const { app, mockPool } = await createApp({
       tokenPerms: ['multitable:read', 'multitable:write', 'comments:write'],
       queryHandler: async (sql, params) => {
         if (sql.includes('FROM meta_sheets s') && sql.includes('LEFT JOIN meta_bases')) {
@@ -230,6 +233,10 @@ describe('Multitable sheet-scoped permissions API', () => {
       source: 'sheet-scope',
       hasSheetAssignments: true,
     })
+    expect(mockPool.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT id, sheet_id FROM meta_records WHERE id = $1 AND sheet_id = $2'),
+      ['rec_1', 'sheet_ops'],
+    )
   })
 
   test('allows context when sheet read grant exists without global multitable permission', async () => {


### PR DESCRIPTION
## Summary
- Route `GET /api/multitable/records/:recordId` through the audited `requireRecordReadable` primitive instead of only doing sheet-level readable capability checks.
- Preserve the existing response metadata by returning `capabilityOrigin` and `sheetScope` from the shared record-read helper.
- Extend the sheet-permission route test mock and assert the record-read path now performs the record-readable existence/gate query.

Closes #2015

## Verification
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-sheet-permissions.api.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-records-read-field-mask.test.ts --reporter=dot (skips locally without DATABASE_URL)
- git diff --check HEAD~1..HEAD