### PR TITLE
feat(multitable): A5 whole-execution automation retry runtime

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -160,7 +160,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + automation retry provenance)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -173,6 +173,7 @@ jobs:
             tests/integration/multitable-formula-dryrun.test.ts \
             tests/integration/multitable-records-read-field-mask.test.ts \
             tests/integration/multitable-readpath-search-filter-field-mask.test.ts \
+            tests/integration/multitable-automation-retry.test.ts \
             --reporter=dot
 
       - name: Start core backend (background)

--- a/docs/development/multitable-automation-retry-a5-verification-20260529.md
+++ b/docs/development/multitable-automation-retry-a5-verification-20260529.md
@@ -1,0 +1,54 @@
+# Multitable Automation A5 — Whole-execution Retry Runtime (verification) — 2026-05-29
+
+- **Slice**: A5 — runtime for `POST /api/multitable/automation-executions/:executionId/retry`. Implements the A4 scope-gate `multitable-automation-retry-scope-gate-20260529.md` (#2039). Owner opt-in given 2026-05-29 ("start A5 whole-execution retry runtime, current enabled rule + stored trigger event, admin-only, side-effect confirmation").
+- **Status**: ✅ implemented + verified (this doc). A6 convergence engine remains frozen / demand-gated.
+- **Grounding**: worktree off `origin/main`. Automation is multitable-kernel (never `integration-core`); post-GATE the K3 Stage-1 blanket lock is retired (#1993), but A5 is gated by its own named opt-in (retry re-runs external side effects).
+
+## What shipped
+
+| File | Change |
+|---|---|
+| `db/migrations/zzzz20260529120000_…retry_attempt_fields.ts` | ADD COLUMN IF NOT EXISTS `rerun_of_execution_id TEXT`, `initiated_by TEXT` (both nullable). |
+| `db/types.ts` | 2 nullable columns on `MultitableAutomationExecutionsTable`. |
+| `automation-executor.ts` | `AutomationExecution` += `rerunOfExecutionId?` / `initiatedBy?` (plain ids; not redacted). |
+| `automation-log-service.ts` | `record()` persists the 2 columns (no redaction — identifiers); `toExecution` maps them back null-safe. |
+| `automation-service.ts` | `executeRule(rule, triggerEvent, retryMeta?)` stamps provenance before persist; new `retryExecution(executionId, initiatedBy)` (discriminated result). |
+| `routes/automation.ts` | `POST /automation-executions/:id/retry` (admin-only); serializes the **persisted (redacted) row** via `getById` re-fetch — NOT the raw in-memory execution (see Security note). `toRunView` surfaces `rerunOfExecutionId`/`initiatedBy` (list + detail). |
+| tests | `automation-v1` (retryExecution orchestration ×9), `automation-runs-api` (route ×3 + detail provenance + guard-count 3), `tests/integration/multitable-automation-retry.test.ts` (real-DB column round-trip) + wired into `plugin-tests.yml`. |
+
+## A4 design decisions → implementation
+
+| A4 (#2039) | Implemented |
+|---|---|
+| **D1** current enabled rule + stored trigger_event; never replay redacted `rule_snapshot` | `retryExecution` loads `getRule(original.ruleId)` (live creds) + reuses `original.triggerEvent`; never reads `ruleSnapshot`. Test: "uses CURRENT rule (live token), never the redacted snapshot". |
+| **D2** retry `failed`/`skipped`; reject `success`/`running` | status check → 409 NOT_RETRYABLE. `skipped` retryable (current rule's conditions may now pass). |
+| **D3** admin-only | route `requireAdminRole()` (same posture as A2/A3, #1973). |
+| **D4** side-effect confirmation | route requires `confirmSideEffects === true` → else 400; lists the side-effecting actions in #2039. |
+| **D5** provenance, not exactly-once | `rerun_of_execution_id` + `initiated_by` + new execution id; original immutable. No idempotency-key promise (follow-up). |
+| **D6** don't broaden PII masking | A1 redaction unchanged; no new masking. |
+| **D7** fail-closed | 404 missing / 409 not-retryable / 409 missing-trigger-event / 409 rule-missing-or-disabled / 503 service-down. `isRetryableStoredTriggerEvent` requires a **non-empty plain object** — rejects null / array / `{}` so the executor's `recordId ?? '' / recordData ?? {}` fallback can NEVER silent-retry with empty context (a record-less `{_triggeredBy:'schedule'}` is still valid). No silent `{}`. |
+| **D8** A5 ≠ A6 | legacy execution storage shape; A2 maps to C1 at read. NO WorkflowJob storage / suspend / branch / automation_jobs / BPMN / approval bridge. |
+
+## ⚠️ Known limitation (owner-visible) — redacted record fields in the replayed trigger_event
+
+A1 redacts `trigger_event` **including the record `data` map** before persist (secret-shaped values + secret/auth structured keys → `<redacted>`). A5-D1 locked "replay the stored trigger_event", so on retry a record field that was secret-shaped (e.g. a field literally named `token`/`password`, or a token-shaped value) replays into `context.recordData` as `<redacted>` — which feeds both `evaluateConditions(...)` and action execution. A condition could branch differently, or an `update_record`/`send_webhook` could write the literal `<redacted>`.
+
+This is **inherent to D1's choice** (the rejected alternatives were re-fetching the live record or storing raw secrets). **Accepted for A5 v1**: credentials come from the current rule (correct); business record fields are preserved by A1 (only secret-shaped ones are scrubbed, which is rare in record data). Pinned by a test ("redacted field inside the stored trigger_event replays deterministically (no crash)"). If this becomes a real problem, a future opt-in could re-fetch the current record for retry context — a separate design.
+
+## Security note — the retry response must NOT serialize the raw in-memory execution
+
+The new execution built by `executor.execute` carries `ruleSnapshot = the current rule` (**LIVE credentials**) and `steps` with raw action output (responseBody/error). `record()`'s `redactValue` returns NEW objects — it scrubs the DB row but does **not** mutate the in-memory execution. A2 read paths read from the DB (redacted), so the A1 at-persist-redaction invariant held — but the retry route is the first place an in-memory (raw) execution could be serialized to HTTP. **Fix: the route re-fetches the persisted (redacted) row via `getById` and serializes that** (response == stored, same contract as the detail GET). If persistence was swallowed (record() is fire-and-forget), it returns a minimal safe body (ids/status only — no `steps`/`ruleSnapshot`). Two route tests pin this (secret-bearing raw execution → response contains none of it; null persisted → minimal safe body). Caught in review; the no-secret fixture had hidden it.
+
+## Verification
+
+- `tsc --noEmit` (core-backend): ✅ 0 errors.
+- Unit: ✅ **167** (`automation-v1` retryExecution: 404 / 409-not-retryable / **409-missing-trigger fail-closed {} | [] | non-object → no getRule/executeRule** / record-less-schedule-trigger-retryable / 409-rule-disabled / delegate-with-provenance / D1-current-rule / redacted-passthrough / skipped-retryable; `automation-runs-api` retry route: **no-secret-leak (serialize persisted-redacted)** + safe-fallback + confirmSideEffects-400 + 409-mapping + initiatedBy→provenance('admin1') + detail provenance + guard-count=3; `automation-routes-wiring` unchanged).
+- Real-DB round-trip: `tests/integration/multitable-automation-retry.test.ts` (describeIfDatabase + sentinel) — `record()` writes + `getById()` maps + raw-SQL confirms the 2 columns; wired into `plugin-tests.yml` real-DB job (hard-guard on DATABASE_URL).
+- ESLint (my changed files): clean. One **pre-existing** `prefer-const` on `let actions` in `parseCreateRuleInput` (origin/main, unrelated function, not introduced here; core-backend has no `lint` script so CI does not flag it) — **left as-is** (scope discipline; not an A5 regression).
+
+## Out of scope / follow-ups (each a separate opt-in)
+- **A6** convergence engine (suspend/resume / branch / approval-as-job / BPMN adapter) — frozen / demand-gated.
+- Frontend retry button (A3 is read-only; #2039 says no button until backend + provenance + tests land — now they have, so a frontend slice could follow as its own opt-in).
+- External idempotency keys for webhook/email/DingTalk retries (#2039 D5 follow-up).
+- Re-fetch-current-record retry context (addresses the redacted-trigger limitation) — separate design.
+- **PRE-EXISTING (flagged, NOT fixed here):** `POST /sheets/:sheetId/automations/:ruleId/test` (`automation.ts:134`) does `res.json(execution)` on the raw in-memory execution. Since **A1** added `ruleSnapshot` to `AutomationExecution`, that endpoint likely serializes the raw (live-credential) snapshot the same way the retry route would have. This is an A1-era gap, not an A5 regression — out of scope for this PR; recommend a separate fix (re-fetch persisted row, or redact at serialization). Surfaced consciously.

--- a/packages/core-backend/src/db/migrations/zzzz20260529120000_add_automation_retry_attempt_fields.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260529120000_add_automation_retry_attempt_fields.ts
@@ -1,0 +1,38 @@
+/**
+ * Migration: Add A5 whole-execution retry provenance fields to automation executions
+ *
+ * Purpose: A5 lets an admin re-run a failed/skipped automation execution (current
+ *   enabled rule + the original stored trigger_event). The NEW execution records
+ *   which run it re-ran (`rerun_of_execution_id`) and who triggered it
+ *   (`initiated_by`). These are plain identifiers (an execution id / a user id),
+ *   not free-form secret channels — no redaction.
+ * Table: multitable_automation_executions
+ * Breaking: No — both columns nullable; pre-A5 rows and normal (non-retry) runs
+ *   leave them NULL.
+ */
+
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'multitable_automation_executions')
+  if (!exists) return
+
+  await sql`
+    ALTER TABLE multitable_automation_executions
+      ADD COLUMN IF NOT EXISTS rerun_of_execution_id TEXT,
+      ADD COLUMN IF NOT EXISTS initiated_by TEXT
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'multitable_automation_executions')
+  if (!exists) return
+
+  await sql`
+    ALTER TABLE multitable_automation_executions
+      DROP COLUMN IF EXISTS rerun_of_execution_id,
+      DROP COLUMN IF EXISTS initiated_by
+  `.execute(db)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1258,6 +1258,9 @@ export interface MultitableAutomationExecutionsTable {
   rule_snapshot: JsonObjectColumn
   finished_at: Date | string | null
   schema_version: number
+  // A5 retry provenance columns (nullable; set only on a retry-created execution).
+  rerun_of_execution_id: string | null
+  initiated_by: string | null
   created_at: CreatedAt
 }
 

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -488,6 +488,11 @@ export interface AutomationExecution {
   finishedAt?: string
   /** Forward-compat tag for the snapshot shape. */
   schemaVersion?: number
+  // ── A5 retry provenance (set by AutomationService.retryExecution; plain ids, not redacted) ──
+  /** The original execution id this run re-ran (only on a retry-created execution). */
+  rerunOfExecutionId?: string
+  /** The admin user id that initiated the retry (only on a retry-created execution). */
+  initiatedBy?: string
 }
 
 export interface AutomationStepResult {

--- a/packages/core-backend/src/multitable/automation-log-service.ts
+++ b/packages/core-backend/src/multitable/automation-log-service.ts
@@ -55,6 +55,9 @@ export class AutomationLogService {
         rule_snapshot: ruleSnapshotJsonb,
         finished_at: execution.finishedAt ?? null,
         schema_version: execution.schemaVersion ?? AUTOMATION_EXECUTION_SCHEMA_VERSION,
+        // A5 retry provenance — plain identifiers, NOT redacted (an execution id / a user id).
+        rerun_of_execution_id: execution.rerunOfExecutionId ?? null,
+        initiated_by: execution.initiatedBy ?? null,
       })
       .execute()
   }
@@ -189,6 +192,9 @@ function toExecution(row: Record<string, unknown>): AutomationExecution {
           ? row.finished_at.toISOString()
           : String(row.finished_at),
     schemaVersion: row.schema_version != null ? Number(row.schema_version) : undefined,
+    // A5 retry provenance — null-safe for non-retry / pre-A5 rows.
+    rerunOfExecutionId: (row.rerun_of_execution_id as string) ?? undefined,
+    initiatedBy: (row.initiated_by as string) ?? undefined,
   }
 }
 

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -215,6 +215,21 @@ function toExecutorRule(rule: AutomationRule): ExecutorRule {
   }
 }
 
+/**
+ * A5 retry fail-closed guard (A4-D7): the stored trigger_event must be a NON-EMPTY
+ * plain object. Reject null/undefined, arrays, and `{}` — otherwise the executor's
+ * `recordId ?? '' / recordData ?? {}` fallback would silently retry with empty
+ * context (e.g. send_webhook firing with no record, update_record on an empty id).
+ * `recordId` is NOT required: a scheduler trigger is legitimately `{ _triggeredBy:
+ * 'schedule' }` (record-less but valid).
+ */
+function isRetryableStoredTriggerEvent(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object'
+    && value !== null
+    && !Array.isArray(value)
+    && Object.keys(value as Record<string, unknown>).length > 0
+}
+
 let sharedAutomationService: AutomationService | null = null
 
 export function setAutomationServiceInstance(service: AutomationService | null): void {
@@ -655,14 +670,68 @@ export class AutomationService {
   /**
    * Execute a rule via the V1 executor and log the result.
    */
-  async executeRule(rule: ExecutorRule, triggerEvent: unknown): Promise<AutomationExecution> {
+  async executeRule(
+    rule: ExecutorRule,
+    triggerEvent: unknown,
+    retryMeta?: { rerunOfExecutionId: string; initiatedBy: string },
+  ): Promise<AutomationExecution> {
     const execution = await this.executor.execute(rule, triggerEvent)
+    if (retryMeta) {
+      // A5: stamp retry provenance onto the NEW execution before persistence.
+      execution.rerunOfExecutionId = retryMeta.rerunOfExecutionId
+      execution.initiatedBy = retryMeta.initiatedBy
+    }
     try {
       await this.logService.record(execution)
     } catch (err) {
       logger.error('Automation execution log persistence failed', err instanceof Error ? err : undefined)
     }
     return execution
+  }
+
+  /**
+   * A5 — whole-execution retry. Re-runs a failed/skipped execution using the
+   * CURRENT enabled rule (live credentials) + the original STORED trigger_event,
+   * producing a NEW execution linked by `rerun_of_execution_id`. The original run
+   * is immutable. Returns a discriminated result (mirrors `requireRecordReadable`)
+   * so the route maps precise status codes (A4 design-lock #2039, D1/D2/D7).
+   *
+   * NOTE (A4-D1 / known limitation): the stored trigger_event is REDACTED — A1
+   * scrubs secret-shaped values (incl. inside the record `data` map) before
+   * persist. Retry credentials come from the current rule, never the snapshot;
+   * but a record field that was secret-shaped will replay as `<redacted>` into
+   * conditions/actions. Documented in the A5 verification doc; raw-secret storage
+   * was explicitly rejected.
+   */
+  async retryExecution(
+    executionId: string,
+    initiatedBy: string,
+  ): Promise<{ execution: AutomationExecution } | { status: number; code: string; message: string }> {
+    const original = await this.logService.getById(executionId)
+    if (!original) {
+      return { status: 404, code: 'NOT_FOUND', message: `Execution ${executionId} not found` }
+    }
+    if (original.status !== 'failed' && original.status !== 'skipped') {
+      return {
+        status: 409,
+        code: 'NOT_RETRYABLE',
+        message: `Only failed/skipped executions can be retried (got ${original.status})`,
+      }
+    }
+    if (!isRetryableStoredTriggerEvent(original.triggerEvent)) {
+      // Fail closed (A4-D7): null/undefined, array, or empty `{}` cannot rebuild context.
+      return { status: 409, code: 'MISSING_TRIGGER_EVENT', message: 'Original execution has no usable stored trigger event to retry' }
+    }
+    const rule = await this.getRule(original.ruleId)
+    if (!rule || !rule.enabled) {
+      return { status: 409, code: 'RULE_MISSING_OR_DISABLED', message: `Rule ${original.ruleId} is missing or disabled; cannot retry` }
+    }
+    const execRule = toExecutorRule(rule)
+    const execution = await this.executeRule(execRule, original.triggerEvent, {
+      rerunOfExecutionId: original.id,
+      initiatedBy,
+    })
+    return { execution }
   }
 
   /**

--- a/packages/core-backend/src/routes/automation.ts
+++ b/packages/core-backend/src/routes/automation.ts
@@ -80,6 +80,10 @@ function toRunView(execution: AutomationExecution, { includeSnapshot }: { includ
     duration: execution.duration ?? null,
     error: execution.error ?? null,
     schemaVersion: execution.schemaVersion ?? null,
+    // A5 retry provenance (plain ids; surfaced in both list + detail so an operator
+    // can see a run is a re-run and who triggered it).
+    rerunOfExecutionId: execution.rerunOfExecutionId ?? null,
+    initiatedBy: execution.initiatedBy ?? null,
     steps: (execution.steps ?? []).map((s, i) => toWorkflowJobView(execution, s, i)),
     ...(includeSnapshot
       ? { triggerEvent: execution.triggerEvent ?? null, ruleSnapshot: execution.ruleSnapshot ?? null }
@@ -235,6 +239,58 @@ export function createAutomationRoutes(
       return res.json(toRunView(execution, { includeSnapshot: true }))
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load run'
+      return res.status(500).json({ error: message })
+    }
+  })
+
+  // A5 — whole-execution retry (admin-only; re-runs real side effects). Reconstructs from
+  // the CURRENT enabled rule + the original stored trigger_event; new execution links back
+  // via rerun_of_execution_id. (A4 design-lock #2039.)
+  router.post('/automation-executions/:executionId/retry', requireAdminRole(), async (req: Request, res: Response) => {
+    const executionId = typeof req.params.executionId === 'string' ? req.params.executionId : ''
+    if (!executionId) {
+      return res.status(400).json({ error: 'executionId is required' })
+    }
+    // D4: retry re-runs external side effects (record writes / webhook / email / DingTalk) —
+    // require an explicit confirmation flag; absence is a 400, not a silent run.
+    const body = (req.body ?? {}) as { confirmSideEffects?: unknown }
+    if (body.confirmSideEffects !== true) {
+      return res.status(400).json({
+        ok: false,
+        error: { code: 'CONFIRM_SIDE_EFFECTS_REQUIRED', message: 'confirmSideEffects must be true to retry (re-runs external side effects)' },
+      })
+    }
+
+    const svc = getService(res)
+    if (!svc) return undefined
+
+    const initiatedBy = req.user?.id?.toString() ?? req.user?.sub?.toString() ?? req.user?.userId?.toString() ?? ''
+
+    try {
+      const result = await svc.retryExecution(executionId, initiatedBy)
+      if ('status' in result) {
+        return res.status(result.status).json({ ok: false, error: { code: result.code, message: result.message } })
+      }
+      // Serialize the PERSISTED (redacted) row, NOT the raw in-memory execution: the new
+      // execution's ruleSnapshot (current rule = LIVE credentials) + steps (raw action
+      // output) are only scrubbed by record()'s at-persist redaction, which returns new
+      // objects and does NOT mutate the in-memory execution. Re-fetch so the response
+      // equals what is stored — same contract as the detail GET (no raw-secret leak).
+      const persisted = await svc.logs.getById(result.execution.id)
+      if (persisted) {
+        return res.json(toRunView(persisted, { includeSnapshot: true }))
+      }
+      // record() is fire-and-forget; if persistence was swallowed, return a minimal safe
+      // body (ids/status only) — never the raw in-memory snapshot/steps.
+      return res.json({
+        id: result.execution.id,
+        status: legacyAutomationStatusToJobStatus(result.execution.status),
+        statusLegacy: result.execution.status,
+        rerunOfExecutionId: result.execution.rerunOfExecutionId ?? null,
+        initiatedBy: result.execution.initiatedBy ?? null,
+      })
+    } catch (err) {
+      const message = err instanceof Error ? err.message : 'Retry failed'
       return res.status(500).json({ error: message })
     }
   })

--- a/packages/core-backend/tests/integration/multitable-automation-retry.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-retry.test.ts
@@ -1,0 +1,77 @@
+/**
+ * Real-DB round-trip for the A5 retry provenance columns (#2039 design-lock).
+ *
+ * Closes the wire-vs-fixture gap: the unit tests assert the insert payload via a
+ * MOCK db, which does NOT prove the migration created the columns, the Kysely DB
+ * types allow them, or the row mapper reads them back. This test writes + reads
+ * `rerun_of_execution_id` + `initiated_by` through the REAL Postgres wire
+ * (AutomationLogService.record → getById), plus a raw-SQL check that the values
+ * actually persisted. Runs only with DATABASE_URL (plugin-tests.yml real-DB job).
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { AutomationLogService } from '../../src/multitable/automation-log-service'
+import type { AutomationExecution } from '../../src/multitable/automation-executor'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const ORIG_ID = `axe_retry_orig_${TS}`
+const NEW_ID = `axe_retry_new_${TS}`
+const RULE_ID = `atr_retry_${TS}`
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+const logs = new AutomationLogService()
+
+function exec(over: Partial<AutomationExecution> = {}): AutomationExecution {
+  return {
+    id: NEW_ID,
+    ruleId: RULE_ID,
+    triggeredBy: 'event',
+    triggeredAt: new Date().toISOString(),
+    status: 'success',
+    steps: [],
+    ...over,
+  }
+}
+
+describeIfDatabase('multitable automation retry provenance (real DB)', () => {
+  beforeAll(async () => {
+    await q('DELETE FROM multitable_automation_executions WHERE id = ANY($1)', [[ORIG_ID, NEW_ID]])
+  })
+  afterAll(async () => {
+    await q('DELETE FROM multitable_automation_executions WHERE id = ANY($1)', [[ORIG_ID, NEW_ID]])
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('record() persists rerun_of_execution_id + initiated_by; getById() maps them back', async () => {
+    // record() with the A5 provenance set — if the migration/columns/types were missing
+    // this insert would throw (the column names must exist on the real table).
+    await logs.record(exec({ rerunOfExecutionId: ORIG_ID, initiatedBy: `admin_${TS}` }))
+
+    // Mapper reads the new columns back through the real wire.
+    const got = await logs.getById(NEW_ID)
+    expect(got).toBeTruthy()
+    expect(got?.rerunOfExecutionId).toBe(ORIG_ID)
+    expect(got?.initiatedBy).toBe(`admin_${TS}`)
+
+    // Raw-SQL confirmation that the values actually landed in the columns.
+    const raw = await q('SELECT rerun_of_execution_id, initiated_by FROM multitable_automation_executions WHERE id = $1', [NEW_ID])
+    expect(raw.rows[0].rerun_of_execution_id).toBe(ORIG_ID)
+    expect(raw.rows[0].initiated_by).toBe(`admin_${TS}`)
+  })
+
+  test('a normal (non-retry) run leaves both columns NULL', async () => {
+    await logs.record(exec({ id: ORIG_ID }))
+    const got = await logs.getById(ORIG_ID)
+    expect(got?.rerunOfExecutionId).toBeUndefined()
+    expect(got?.initiatedBy).toBeUndefined()
+    const raw = await q('SELECT rerun_of_execution_id, initiated_by FROM multitable_automation_executions WHERE id = $1', [ORIG_ID])
+    expect(raw.rows[0].rerun_of_execution_id).toBeNull()
+    expect(raw.rows[0].initiated_by).toBeNull()
+  })
+})

--- a/packages/core-backend/tests/unit/automation-runs-api.test.ts
+++ b/packages/core-backend/tests/unit/automation-runs-api.test.ts
@@ -21,6 +21,10 @@ vi.mock('../../src/guards/audit-integration', () => ({
 function buildApp(service: unknown) {
   const app = express()
   app.use(express.json())
+  // requireAdminRole is mocked pass-through (doesn't set req.user); inject a stable admin id
+  // so the retry route can resolve initiatedBy and tests can assert it lands in provenance.
+  // eslint-disable-next-line @typescript-eslint/no-explicit-any
+  app.use((req: any, _res, next) => { req.user = { id: 'admin1' }; next() })
   // eslint-disable-next-line @typescript-eslint/no-explicit-any
   app.use('/api/multitable', createAutomationRoutes(service as any))
   return app
@@ -44,13 +48,17 @@ const sampleExec = {
   ],
 }
 
-function makeMockService(logsOverrides: Record<string, unknown> = {}) {
+function makeMockService(logsOverrides: Record<string, unknown> = {}, svcOverrides: Record<string, unknown> = {}) {
   return {
     logs: {
       listExecutions: vi.fn().mockResolvedValue([sampleExec]),
       getById: vi.fn().mockResolvedValue(sampleExec),
       ...logsOverrides,
     },
+    retryExecution: vi.fn().mockResolvedValue({
+      execution: { ...sampleExec, id: 'axe_new', status: 'success', rerunOfExecutionId: 'axe_1', initiatedBy: 'admin1' },
+    }),
+    ...svcOverrides,
   }
 }
 
@@ -123,11 +131,11 @@ describe('A2 runs API — GET /automation-executions (list)', () => {
     expect(svc.logs.listExecutions).toHaveBeenLastCalledWith(expect.objectContaining({ limit: 1 }))
   })
 
-  it('both runs routes (list + detail) are gated by requireAdminRole()', () => {
+  it('all runs routes (list + detail + retry) are gated by requireAdminRole()', () => {
     vi.mocked(requireAdminRole).mockClear()
     buildApp(makeMockService())
     // exactly two guarded routes were constructed: list + detail
-    expect(vi.mocked(requireAdminRole)).toHaveBeenCalledTimes(2)
+    expect(vi.mocked(requireAdminRole)).toHaveBeenCalledTimes(3)
   })
 })
 
@@ -152,5 +160,95 @@ describe('A2 runs API — GET /automation-executions/:id (detail)', () => {
     app.use(express.json())
     app.use('/api/multitable', createAutomationRoutes(() => undefined))
     await request(app).get('/api/multitable/automation-executions').expect(503)
+  })
+
+  it('detail view surfaces retry provenance fields (null for a normal run)', async () => {
+    const svc = makeMockService()
+    const res = await request(buildApp(svc)).get('/api/multitable/automation-executions/axe_1').expect(200)
+    expect(res.body).toHaveProperty('rerunOfExecutionId', null)
+    expect(res.body).toHaveProperty('initiatedBy', null)
+  })
+})
+
+describe('A5 runs API — POST /automation-executions/:id/retry', () => {
+  it('400 CONFIRM_SIDE_EFFECTS_REQUIRED when confirmSideEffects is not true (no run)', async () => {
+    const svc = makeMockService()
+    const res = await request(buildApp(svc)).post('/api/multitable/automation-executions/axe_1/retry').send({}).expect(400)
+    expect(res.body.error.code).toBe('CONFIRM_SIDE_EFFECTS_REQUIRED')
+    expect(svc.retryExecution).not.toHaveBeenCalled()
+  })
+
+  it('maps the service discriminated error to its status + code (e.g. 409 NOT_RETRYABLE)', async () => {
+    const svc = makeMockService({}, {
+      retryExecution: vi.fn().mockResolvedValue({ status: 409, code: 'NOT_RETRYABLE', message: 'only failed/skipped' }),
+    })
+    const res = await request(buildApp(svc))
+      .post('/api/multitable/automation-executions/axe_1/retry')
+      .send({ confirmSideEffects: true })
+      .expect(409)
+    expect(res.body.error.code).toBe('NOT_RETRYABLE')
+  })
+
+  it('success serializes the PERSISTED (redacted) row, never the raw in-memory execution (no secret leak)', async () => {
+    // retryExecution returns the RAW in-memory execution: ruleSnapshot = current rule
+    // (LIVE credentials) + steps with raw action output. record() only scrubs the DB row.
+    const rawNew = {
+      id: 'axe_new', ruleId: 'rule-1', status: 'success', triggeredBy: 'retry', triggeredAt: '2026-05-29T00:00:00.000Z',
+      rerunOfExecutionId: 'axe_1', initiatedBy: 'admin1',
+      ruleSnapshot: { id: 'rule-1', actions: [{ type: 'send_webhook', config: { token: 'LIVE-SECRET-TOKEN' } }] },
+      steps: [{ actionType: 'send_webhook', status: 'failed', error: 'connect postgres://u:SECRETPW@h/db failed' }],
+    }
+    // getById returns what record() persisted — the REDACTED row.
+    const redactedNew = {
+      id: 'axe_new', ruleId: 'rule-1', status: 'success', triggeredBy: 'retry', triggeredAt: '2026-05-29T00:00:00.000Z',
+      rerunOfExecutionId: 'axe_1', initiatedBy: 'admin1',
+      ruleSnapshot: { id: 'rule-1', actions: [{ type: 'send_webhook', config: { token: '<redacted>' } }] },
+      steps: [{ actionType: 'send_webhook', status: 'failed', error: 'connect postgres://<redacted>@h/db failed' }],
+    }
+    const svc = makeMockService(
+      { getById: vi.fn().mockResolvedValue(redactedNew) },
+      { retryExecution: vi.fn().mockResolvedValue({ execution: rawNew }) },
+    )
+    const res = await request(buildApp(svc))
+      .post('/api/multitable/automation-executions/axe_1/retry')
+      .send({ confirmSideEffects: true })
+      .expect(200)
+    expect(svc.retryExecution).toHaveBeenCalledWith('axe_1', 'admin1') // admin id from req.user → provenance
+    // response is built from the re-fetched persisted (redacted) row, not the raw execution
+    expect(svc.logs.getById).toHaveBeenCalledWith('axe_new')
+    expect(res.body.id).toBe('axe_new')
+    expect(res.body.rerunOfExecutionId).toBe('axe_1')
+    expect(res.body.initiatedBy).toBe('admin1')
+    expect(res.body.status).toBe('resolved') // C1 mapping
+    // the raw live credentials / raw action error MUST NOT appear in the response
+    const serialized = JSON.stringify(res.body)
+    expect(serialized).not.toContain('LIVE-SECRET-TOKEN')
+    expect(serialized).not.toContain('SECRETPW')
+  })
+
+  it('falls back to a minimal SAFE body (no steps/snapshot) when the persisted row is unreadable', async () => {
+    const rawNew = {
+      id: 'axe_new', ruleId: 'rule-1', status: 'success', triggeredBy: 'retry', triggeredAt: '2026-05-29T00:00:00.000Z',
+      rerunOfExecutionId: 'axe_1', initiatedBy: 'admin1',
+      ruleSnapshot: { actions: [{ config: { token: 'LIVE-SECRET-TOKEN' } }] },
+      steps: [{ actionType: 'send_webhook', status: 'failed', error: 'SECRETPW' }],
+    }
+    const svc = makeMockService(
+      { getById: vi.fn().mockResolvedValue(undefined) }, // record() swallowed → not found
+      { retryExecution: vi.fn().mockResolvedValue({ execution: rawNew }) },
+    )
+    const res = await request(buildApp(svc))
+      .post('/api/multitable/automation-executions/axe_1/retry')
+      .send({ confirmSideEffects: true })
+      .expect(200)
+    expect(res.body.id).toBe('axe_new')
+    expect(res.body.status).toBe('resolved')
+    expect(res.body.rerunOfExecutionId).toBe('axe_1')
+    expect(res.body.initiatedBy).toBe('admin1')
+    expect(res.body.steps).toBeUndefined() // never emit raw steps from the in-memory object
+    expect(res.body.ruleSnapshot).toBeUndefined()
+    const serialized = JSON.stringify(res.body)
+    expect(serialized).not.toContain('LIVE-SECRET-TOKEN')
+    expect(serialized).not.toContain('SECRETPW')
   })
 })

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -2672,3 +2672,125 @@ describe('AutomationService — Rule CRUD', () => {
     expect(rules[0].enabled).toBe(true)
   })
 })
+
+describe('AutomationService — retryExecution (A5)', () => {
+  let service: AutomationService
+
+  beforeEach(() => {
+    const eventBus = new EventBus()
+    const queryFn = vi.fn(async () => ({ rows: [], rowCount: 0 }))
+    // Minimal kysely-ish stub; retryExecution collaborators are spied, so the db is unused.
+    service = new AutomationService(eventBus, {} as never, queryFn)
+  })
+
+  function storedExecution(over: Partial<AutomationExecution> = {}): AutomationExecution {
+    return {
+      id: 'axe_orig',
+      ruleId: 'atr_1',
+      triggeredBy: 'event',
+      triggeredAt: '2026-05-29T00:00:00.000Z',
+      status: 'failed',
+      steps: [],
+      triggerEvent: { recordId: 'rec1', data: { name: 'Bolt' } },
+      ...over,
+    }
+  }
+  // Shape returned by service.getRule (DB-ish AutomationRule row).
+  function currentRule(over: Record<string, unknown> = {}) {
+    return {
+      id: 'atr_1', sheet_id: 'sheet_1', name: 'R', trigger_type: 'record.created',
+      trigger_config: {}, action_type: 'send_webhook', action_config: { url: 'https://x', token: 'LIVE-TOKEN' },
+      enabled: true, actions: null, conditions: null,
+      ...over,
+    } as never
+  }
+
+  it('404 NOT_FOUND when the original execution is missing', async () => {
+    vi.spyOn(service.logs, 'getById').mockResolvedValue(undefined)
+    const r = await service.retryExecution('axe_missing', 'admin1')
+    expect(r).toMatchObject({ status: 404, code: 'NOT_FOUND' })
+  })
+
+  it('409 NOT_RETRYABLE for success/running originals', async () => {
+    for (const status of ['success', 'running'] as const) {
+      vi.spyOn(service.logs, 'getById').mockResolvedValue(storedExecution({ status }))
+      const r = await service.retryExecution('axe_orig', 'admin1')
+      expect(r).toMatchObject({ status: 409, code: 'NOT_RETRYABLE' })
+    }
+  })
+
+  it('409 MISSING_TRIGGER_EVENT fail-closed: absent / empty {} / array — never silent empty-context retry', async () => {
+    const getRule = vi.spyOn(service, 'getRule')
+    const execSpy = vi.spyOn(service, 'executeRule')
+    for (const bad of [undefined, {}, [] as unknown, 'x' as unknown, 0 as unknown]) {
+      vi.spyOn(service.logs, 'getById').mockResolvedValue(storedExecution({ triggerEvent: bad }))
+      const r = await service.retryExecution('axe_orig', 'admin1')
+      expect(r).toMatchObject({ status: 409, code: 'MISSING_TRIGGER_EVENT' })
+    }
+    // fail-closed: never loaded the rule nor executed anything
+    expect(getRule).not.toHaveBeenCalled()
+    expect(execSpy).not.toHaveBeenCalled()
+  })
+
+  it('a record-less scheduler trigger ({_triggeredBy:"schedule"}) is still retryable (non-empty object)', async () => {
+    vi.spyOn(service.logs, 'getById').mockResolvedValue(storedExecution({ status: 'failed', triggerEvent: { _triggeredBy: 'schedule' } }))
+    vi.spyOn(service, 'getRule').mockResolvedValue(currentRule())
+    const execSpy = vi.spyOn(service, 'executeRule').mockResolvedValue(storedExecution({ id: 'axe_new', status: 'success' }))
+    const r = await service.retryExecution('axe_orig', 'admin1')
+    expect('execution' in r).toBe(true)
+    expect(execSpy.mock.calls[0][1]).toEqual({ _triggeredBy: 'schedule' }) // passes the non-empty guard
+  })
+
+  it('409 RULE_MISSING_OR_DISABLED when current rule is gone or disabled', async () => {
+    vi.spyOn(service.logs, 'getById').mockResolvedValue(storedExecution())
+    const getRule = vi.spyOn(service, 'getRule').mockResolvedValue(null)
+    expect(await service.retryExecution('axe_orig', 'admin1')).toMatchObject({ status: 409, code: 'RULE_MISSING_OR_DISABLED' })
+    getRule.mockResolvedValue(currentRule({ enabled: false }))
+    expect(await service.retryExecution('axe_orig', 'admin1')).toMatchObject({ status: 409, code: 'RULE_MISSING_OR_DISABLED' })
+  })
+
+  it('failed retry delegates to executeRule with stored trigger_event + retry provenance', async () => {
+    vi.spyOn(service.logs, 'getById').mockResolvedValue(storedExecution())
+    vi.spyOn(service, 'getRule').mockResolvedValue(currentRule())
+    const newExec = storedExecution({ id: 'axe_new', status: 'success', rerunOfExecutionId: 'axe_orig', initiatedBy: 'admin1' })
+    const execSpy = vi.spyOn(service, 'executeRule').mockResolvedValue(newExec)
+    const r = await service.retryExecution('axe_orig', 'admin1')
+    expect(r).toEqual({ execution: newExec })
+    const [, triggerEvent, retryMeta] = execSpy.mock.calls[0]
+    expect(triggerEvent).toEqual({ recordId: 'rec1', data: { name: 'Bolt' } }) // original stored trigger event reused
+    expect(retryMeta).toEqual({ rerunOfExecutionId: 'axe_orig', initiatedBy: 'admin1' })
+  })
+
+  it('D1 — retry uses the CURRENT rule (live token), never the redacted rule_snapshot', async () => {
+    // stored snapshot carries a scrubbed token; the current rule carries the real one.
+    vi.spyOn(service.logs, 'getById').mockResolvedValue(storedExecution({
+      ruleSnapshot: { id: 'atr_1', actions: [{ type: 'send_webhook', config: { token: '<redacted>' } }] } as never,
+    }))
+    vi.spyOn(service, 'getRule').mockResolvedValue(currentRule())
+    const execSpy = vi.spyOn(service, 'executeRule').mockResolvedValue(storedExecution({ id: 'axe_new', status: 'success' }))
+    await service.retryExecution('axe_orig', 'admin1')
+    const execRule = execSpy.mock.calls[0][0] as { actions: { config: Record<string, unknown> }[] }
+    expect(execRule.actions[0].config.token).toBe('LIVE-TOKEN') // from current rule
+    expect(JSON.stringify(execRule)).not.toContain('<redacted>') // never the snapshot
+  })
+
+  it('redacted field inside the stored trigger_event replays deterministically (no crash)', async () => {
+    // A1 may scrub a secret-shaped record field to <redacted>; retry passes it through unchanged.
+    const redactedEvent = { recordId: 'rec1', data: { name: 'Bolt', token: '<redacted>' } }
+    vi.spyOn(service.logs, 'getById').mockResolvedValue(storedExecution({ triggerEvent: redactedEvent }))
+    vi.spyOn(service, 'getRule').mockResolvedValue(currentRule())
+    const execSpy = vi.spyOn(service, 'executeRule').mockResolvedValue(storedExecution({ id: 'axe_new', status: 'success' }))
+    const r = await service.retryExecution('axe_orig', 'admin1')
+    expect('execution' in r).toBe(true)
+    expect(execSpy.mock.calls[0][1]).toEqual(redactedEvent) // passed through verbatim
+  })
+
+  it('skipped originals are retryable (delegates with the current rule)', async () => {
+    vi.spyOn(service.logs, 'getById').mockResolvedValue(storedExecution({ status: 'skipped' }))
+    vi.spyOn(service, 'getRule').mockResolvedValue(currentRule())
+    const execSpy = vi.spyOn(service, 'executeRule').mockResolvedValue(storedExecution({ id: 'axe_new', status: 'success' }))
+    const r = await service.retryExecution('axe_orig', 'admin1')
+    expect('execution' in r).toBe(true)
+    expect(execSpy).toHaveBeenCalledTimes(1) // skipped → re-runs against the current rule (its conditions may now pass)
+  })
+})


### PR DESCRIPTION
## What

Run-governance **A5** — implements the A4 retry scope-gate (**#2039**) after explicit owner opt-in. An admin re-runs a **failed/skipped** automation execution; a **new** execution is created (original immutable), linked by `rerun_of_execution_id`.

**Per A4-D1**: retry uses the **CURRENT enabled rule** (live credentials) + the original **stored `trigger_event`** — never the redacted `rule_snapshot`.

## Changes (11 files)
- **migration** `zzzz20260529120000`: nullable `rerun_of_execution_id` + `initiated_by` (plain ids, not redacted). `AutomationExecution` += both; `record()` persists; `toExecution` maps.
- **`AutomationService.retryExecution(executionId, initiatedBy)`**: discriminated result — 404 missing / 409 not-retryable (success|running) / 409 missing-trigger-event / 409 rule-missing-or-disabled / else `executeRule(currentRule, storedTriggerEvent, retryMeta)`. `executeRule` gains an optional `retryMeta` param.
- **route** `POST /automation-executions/:id/retry` (`requireAdminRole`) + `confirmSideEffects === true` guard (400 otherwise). `toRunView` surfaces the provenance (list + detail).

## 🔒 Security — response serializes the PERSISTED (redacted) row, not the raw in-memory execution
The new execution carries `ruleSnapshot` = the **current rule (LIVE credentials)** + raw action `steps`; `record()`'s redaction returns new objects and does **not** mutate the in-memory execution. The retry route therefore **re-fetches via `getById`** and serializes the stored (redacted) row (response == detail-GET contract); if persistence was swallowed, returns a minimal safe body (ids/status only). **Two route tests** pin no-leak (secret-bearing raw execution → response contains none of it) + the safe-fallback. *(Caught in review — the no-secret fixture had hidden it.)*

## Known limitation (owner-accepted, A5 v1)
A1 redacts the stored `trigger_event` **including the record `data` map**, so a secret-shaped record field replays as `<redacted>` into conditions/actions. Inherent to D1's stored-trigger replay; pinned by a deterministic test; documented in the verification doc. Re-fetch-current-record is a separate future opt-in.

## Scope held to A5
NO suspend / branch / WorkflowJob-storage / `automation_jobs` / BPMN / approval bridge — **A6 stays frozen**. Automation is multitable-kernel (never integration-core); A5 gated by its own named opt-in (retry re-runs external side effects), not by the (retired) K3 blanket lock.

## Tests / validation
- **166 unit** (`retryExecution` ×9 incl. D1-current-rule-not-snapshot + redacted-trigger-passthrough + skipped-retryable; route ×4 incl. **no-secret-leak** + safe-fallback + confirmSideEffects-400 + 409-mapping; detail provenance; guard-count=3). `tsc` 0.
- **Real-DB round-trip** `tests/integration/multitable-automation-retry.test.ts` (describeIfDatabase + sentinel) — `record()`→`getById`→raw-SQL confirm the 2 columns; **wired into `plugin-tests.yml`** (closes the wire-vs-fixture gap A1 left on its columns).
- ESLint: my files clean. One **pre-existing** `prefer-const` in an unrelated function (`parseCreateRuleInput`) left as-is — core-backend has no `lint` script, not an A5 regression.

## Flagged (pre-existing, NOT fixed here)
`POST /sheets/:sheetId/automations/:ruleId/test` does `res.json(execution)` on the raw in-memory execution — since A1 added `ruleSnapshot`, it likely serializes the raw live-credential snapshot. A1-era gap, separate fix recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)