### PR TITLE
fix(admin): gate admin routes before shell render

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -12,6 +12,7 @@ import 'element-plus/dist/index.css'
 import './styles/calendar-source-palette.css'
 import App from './App.vue'
 import { useAuth } from './composables/useAuth'
+import { resolveAdminRouteRedirect } from './router/adminAccess'
 import { appRoutes } from './router/appRoutes'
 import { ROUTE_PATHS } from './router/types'
 import { resolveRouteDocumentTitle } from './router/routeTitles'
@@ -95,6 +96,11 @@ router.beforeEach(async (to, _from, next) => {
         // Ignore transient feature load failures and fall back to default home.
       }
       return next(flags.resolveHomePath())
+    }
+
+    const adminRedirect = await resolveAdminRouteRedirect(to, auth, flags)
+    if (adminRedirect) {
+      return next(adminRedirect)
     }
   }
 

--- a/apps/web/src/router/adminAccess.ts
+++ b/apps/web/src/router/adminAccess.ts
@@ -1,0 +1,23 @@
+import type { RouteLocationNormalized } from 'vue-router'
+import type { useAuth } from '../composables/useAuth'
+import type { useFeatureFlags } from '../stores/featureFlags'
+
+type AuthAccess = Pick<ReturnType<typeof useAuth>, 'hasAdminAccess'>
+type FeatureFlagAccess = Pick<ReturnType<typeof useFeatureFlags>, 'loadProductFeatures' | 'resolveHomePath'>
+
+export async function resolveAdminRouteRedirect(
+  to: Pick<RouteLocationNormalized, 'meta'>,
+  auth: AuthAccess,
+  flags: FeatureFlagAccess,
+): Promise<string | null> {
+  if (to.meta?.requiresAdmin !== true) return null
+  if (auth.hasAdminAccess()) return null
+
+  try {
+    await flags.loadProductFeatures()
+  } catch {
+    // Keep the admin boundary closed even when feature probing is temporarily unavailable.
+  }
+
+  return flags.resolveHomePath()
+}

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -163,7 +163,7 @@ export const appRoutes: RouteRecordRaw[] = [
     path: '/admin/users',
     name: 'user-management',
     component: () => import('../views/UserManagementView.vue'),
-    meta: { title: 'User Management', requiresAuth: true }
+    meta: { title: 'User Management', requiresAuth: true, requiresAdmin: true }
   },
   {
     path: '/admin/role-delegation',
@@ -175,31 +175,31 @@ export const appRoutes: RouteRecordRaw[] = [
     path: '/admin/directory',
     name: AppRouteNames.DIRECTORY_MANAGEMENT,
     component: () => import('../views/DirectoryManagementView.vue'),
-    meta: { title: 'Directory Management', titleZh: '目录同步', requiresAuth: true }
+    meta: { title: 'Directory Management', titleZh: '目录同步', requiresAuth: true, requiresAdmin: true }
   },
   {
     path: '/admin/roles',
     name: 'role-management',
     component: () => import('../views/RoleManagementView.vue'),
-    meta: { title: 'Role Management', requiresAuth: true }
+    meta: { title: 'Role Management', requiresAuth: true, requiresAdmin: true }
   },
   {
     path: '/admin/permissions',
     name: 'permission-management',
     component: () => import('../views/PermissionManagementView.vue'),
-    meta: { title: 'Permission Management', requiresAuth: true }
+    meta: { title: 'Permission Management', requiresAuth: true, requiresAdmin: true }
   },
   {
     path: '/admin/automation-executions',
     name: 'automation-executions',
     component: () => import('../views/AutomationExecutionsView.vue'),
-    meta: { title: 'Automation Runs', titleZh: '自动化运行记录', requiresAuth: true }
+    meta: { title: 'Automation Runs', titleZh: '自动化运行记录', requiresAuth: true, requiresAdmin: true }
   },
   {
     path: '/admin/audit',
     name: 'admin-audit',
     component: () => import('../views/AdminAuditView.vue'),
-    meta: { title: 'Admin Audit', requiresAuth: true }
+    meta: { title: 'Admin Audit', requiresAuth: true, requiresAdmin: true }
   },
   {
     path: '/integrations/workbench',
@@ -265,7 +265,7 @@ export const appRoutes: RouteRecordRaw[] = [
     path: '/admin/plugins',
     name: 'plugin-manager',
     component: PluginManagerView,
-    meta: { title: 'Plugins', requiresAuth: true, requiredFeature: 'attendanceAdmin' }
+    meta: { title: 'Plugins', requiresAuth: true, requiresAdmin: true, requiredFeature: 'attendanceAdmin' }
   },
   {
     path: '/:pathMatch(.*)*',

--- a/apps/web/src/router/types.ts
+++ b/apps/web/src/router/types.ts
@@ -272,6 +272,7 @@ export interface RouteMeta {
   // Permission requirements
   permissions?: string[]
   roles?: string[]
+  requiresAdmin?: boolean
 
   // Layout settings
   layout?: 'default' | 'empty' | 'admin'

--- a/apps/web/tests/adminAccess.spec.ts
+++ b/apps/web/tests/adminAccess.spec.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import { resolveAdminRouteRedirect } from '../src/router/adminAccess'
+
+const platformAdminPaths = [
+  '/admin/users',
+  '/admin/directory',
+  '/admin/roles',
+  '/admin/permissions',
+  '/admin/automation-executions',
+  '/admin/audit',
+  '/admin/plugins',
+  '/approvals/metrics',
+]
+
+function routeWithMeta(meta: Record<string, unknown>): Parameters<typeof resolveAdminRouteRedirect>[0] {
+  return { meta } as Parameters<typeof resolveAdminRouteRedirect>[0]
+}
+
+function routeBlock(source: string, path: string): string {
+  const start = source.indexOf(`path: '${path}'`)
+  expect(start, `Expected ${path} route to be registered`).toBeGreaterThanOrEqual(0)
+  const end = source.indexOf('\n  {', start + 1)
+  return source.slice(start, end === -1 ? undefined : end)
+}
+
+describe('admin route access', () => {
+  it('marks platform-admin pages with requiresAdmin before their route components load', async () => {
+    const source = await readFile('src/router/appRoutes.ts', 'utf8')
+
+    for (const path of platformAdminPaths) {
+      const block = routeBlock(source, path)
+      expect(block, `${path} must require authentication`).toContain('requiresAuth: true')
+      expect(block, `${path} must be route-gated`).toContain('requiresAdmin: true')
+    }
+  })
+
+  it('keeps delegated role administration out of the platform-admin-only route list', async () => {
+    const source = await readFile('src/router/appRoutes.ts', 'utf8')
+    const block = routeBlock(source, '/admin/role-delegation')
+
+    expect(block).toContain('requiresAuth: true')
+    expect(block).not.toContain('requiresAdmin: true')
+  })
+
+  it('redirects non-admin users away from admin routes before rendering page shells', async () => {
+    const loadProductFeatures = vi.fn().mockResolvedValue(undefined)
+    const redirect = await resolveAdminRouteRedirect(
+      routeWithMeta({ requiresAdmin: true }),
+      { hasAdminAccess: () => false },
+      {
+        loadProductFeatures,
+        resolveHomePath: () => '/attendance',
+      },
+    )
+
+    expect(loadProductFeatures).toHaveBeenCalledTimes(1)
+    expect(redirect).toBe('/attendance')
+  })
+
+  it('keeps the admin boundary closed when feature probing fails', async () => {
+    const redirect = await resolveAdminRouteRedirect(
+      routeWithMeta({ requiresAdmin: true }),
+      { hasAdminAccess: () => false },
+      {
+        loadProductFeatures: vi.fn().mockRejectedValue(new Error('offline')),
+        resolveHomePath: () => '/multitable',
+      },
+    )
+
+    expect(redirect).toBe('/multitable')
+  })
+
+  it('allows admins and non-admin routes to continue normally', async () => {
+    await expect(resolveAdminRouteRedirect(
+      routeWithMeta({ requiresAdmin: true }),
+      { hasAdminAccess: () => true },
+      {
+        loadProductFeatures: vi.fn(),
+        resolveHomePath: () => '/multitable',
+      },
+    )).resolves.toBeNull()
+
+    await expect(resolveAdminRouteRedirect(
+      routeWithMeta({ requiresAuth: true }),
+      { hasAdminAccess: () => false },
+      {
+        loadProductFeatures: vi.fn(),
+        resolveHomePath: () => '/multitable',
+      },
+    )).resolves.toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary
- add a shared admin-route redirect guard so non-admin users leave `requiresAdmin` routes before page shells render
- mark platform-admin routes (`/admin/users`, `/admin/roles`, `/admin/permissions`, `/admin/audit`, plus adjacent admin-only surfaces) with `requiresAdmin`
- keep `/admin/role-delegation` separate because it supports delegated plugin-admin workflows

Closes #2008

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/adminAccess.spec.ts --watch=false
- pnpm --filter @metasheet/web exec vitest run tests/platform-shell-nav.spec.ts --watch=false
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web build
- pnpm --filter @metasheet/web exec eslint src/main.ts src/router/adminAccess.ts src/router/appRoutes.ts tests/adminAccess.spec.ts --max-warnings=0
- git diff --check