### PR TITLE
fix(approvals): hide center from users without read access

### DIFF
--- a/apps/web/src/App.vue
+++ b/apps/web/src/App.vue
@@ -12,14 +12,14 @@
             <router-link to="/plm" class="nav-link">{{ navLabels.plm }}</router-link>
             <router-link v-if="canUsePlm" to="/plm/audit" class="nav-link">{{ navLabels.audit }}</router-link>
             <router-link v-if="hasFeature('workflow')" to="/workflows" class="nav-link">{{ navLabels.workflows }}</router-link>
-            <router-link to="/approvals" class="nav-link">{{ navLabels.approvals }}</router-link>
+            <router-link v-if="canUseApprovals" to="/approvals" class="nav-link">{{ navLabels.approvals }}</router-link>
           </template>
           <template v-else>
             <router-link v-if="hasFeature('attendance')" to="/attendance" class="nav-link">{{ navLabels.attendance }}</router-link>
             <router-link to="/apps" class="nav-link">{{ navLabels.apps }}</router-link>
             <router-link to="/multitable" class="nav-link">{{ navLabels.multitable }}</router-link>
             <router-link v-if="hasFeature('workflow')" to="/workflows" class="nav-link">{{ navLabels.workflows }}</router-link>
-            <router-link to="/approvals" class="nav-link">{{ navLabels.approvals }}</router-link>
+            <router-link v-if="canUseApprovals" to="/approvals" class="nav-link">{{ navLabels.approvals }}</router-link>
             <router-link
               v-for="item in pluginNavItems"
               :key="item.id"
@@ -107,6 +107,10 @@ const canManageUsers = computed(() => {
 const canUseIntegration = computed(() => {
   void route.fullPath
   return hasPermission('integration:write')
+})
+const canUseApprovals = computed(() => {
+  void route.fullPath
+  return hasPermission('approvals:read')
 })
 const isLoggedIn = computed(() => {
   void route.fullPath

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -229,7 +229,7 @@ export const appRoutes: RouteRecordRaw[] = [
     path: '/approvals',
     name: 'approval-list',
     component: () => import('../views/approval/ApprovalCenterView.vue'),
-    meta: { title: 'Approvals', titleZh: '审批中心', requiresAuth: true }
+    meta: { title: 'Approvals', titleZh: '审批中心', requiresAuth: true, permissions: ['approvals:read'] }
   },
   {
     path: '/approvals/new/:templateId',

--- a/apps/web/tests/platform-shell-nav.spec.ts
+++ b/apps/web/tests/platform-shell-nav.spec.ts
@@ -113,8 +113,8 @@ describe('platform shell navigation', () => {
     expect(links).toEqual(expect.arrayContaining([
       expect.objectContaining({ href: '/attendance', text: '考勤' }),
       expect.objectContaining({ href: '/multitable', text: '多维表' }),
-      expect.objectContaining({ href: '/approvals', text: '审批中心' }),
     ]))
+    expect(links.some((link) => link.href === '/approvals')).toBe(false)
     expect(links.some((link) => link.href === '/grid')).toBe(false)
     expect(links.some((link) => link.href === '/spreadsheets')).toBe(false)
     expect(links.some((link) => link.href === '/kanban')).toBe(false)
@@ -214,8 +214,72 @@ describe('platform shell navigation', () => {
     expect(links.some((link) => link.href === '/gallery')).toBe(false)
     expect(links.some((link) => link.href === '/form')).toBe(false)
     expect(links.some((link) => link.href === '/admin/users')).toBe(false)
+    expect(links.some((link) => link.href === '/approvals')).toBe(false)
     // A3 runs view is admin-only (canManageUsers === snapshot.isAdmin) — hidden here.
     expect(links.some((link) => link.href === '/admin/automation-executions')).toBe(false)
+  })
+
+  it('shows the approval center nav entry only when approval read permission is present', async () => {
+    vi.doMock('vue-router', () => ({
+      useRoute: () => ({ path: '/multitable', fullPath: '/multitable', meta: { requiresAuth: true } }),
+    }))
+    vi.doMock('../src/composables/usePlugins', () => ({
+      usePlugins: () => ({ navItems: ref([]), fetchPlugins: vi.fn().mockResolvedValue(undefined) }),
+    }))
+    vi.doMock('../src/stores/featureFlags', () => ({
+      useFeatureFlags: () => ({
+        loadProductFeatures: vi.fn().mockResolvedValue(undefined),
+        isAttendanceFocused: () => false,
+        isPlmWorkbenchFocused: () => false,
+        hasFeature: () => false,
+      }),
+    }))
+    vi.doMock('../src/composables/useLocale', () => ({
+      useLocale: () => ({ locale: ref('zh-CN'), isZh: ref(true), setLocale: vi.fn() }),
+    }))
+    vi.doMock('../src/composables/useAuth', () => ({
+      useAuth: () => ({
+        clearToken: vi.fn(),
+        getAccessSnapshot: () => ({
+          email: 'approver@test.local',
+          roles: ['approval_viewer'],
+          permissions: ['approvals:read'],
+          isAdmin: false,
+        }),
+        getToken: () => 'session-token',
+        hasPermission: (permission: string) => permission === 'approvals:read',
+      }),
+    }))
+    vi.doMock('../src/utils/api', async (importOriginal) => {
+      const actual = await importOriginal<typeof import('../src/utils/api')>()
+      return {
+        ...actual,
+        getApiBase: () => 'http://example.test',
+      }
+    })
+
+    const { default: App } = await import('../src/App.vue')
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(App as Component)
+    app.component('router-view', { render: () => h('div') })
+    app.component('router-link', {
+      props: ['to'],
+      render() {
+        return h('a', { href: this.$props.to }, this.$slots.default ? this.$slots.default() : [])
+      },
+    })
+
+    app.mount(container)
+    await flushUi()
+
+    const links = Array.from(container.querySelectorAll('a')).map((node) => ({
+      href: node.getAttribute('href'),
+      text: node.textContent?.trim(),
+    }))
+    expect(links).toEqual(expect.arrayContaining([
+      expect.objectContaining({ href: '/approvals', text: '审批中心' }),
+    ]))
   })
 
   it('shows the automation runs admin nav entry for an admin user', async () => {
@@ -319,6 +383,7 @@ describe('platform shell navigation', () => {
     expect(source).toContain("path: '/approvals'")
     expect(source).toContain("import('../views/approval/ApprovalCenterView.vue')")
     expect(source).toContain("titleZh: '审批中心'")
+    expect(source).toContain("permissions: ['approvals:read']")
     expect(source).toContain("path: '/p/plugin-attendance/attendance'")
     expect(source).toContain("redirect: '/attendance'")
   })


### PR DESCRIPTION
## Summary
- hide the global Approval Center nav entry unless the user has `approvals:read`
- add `permissions: ['approvals:read']` to the `/approvals` route so direct links redirect before the raw 403 page shell renders
- cover both hidden/no-permission and visible/read-permission shell nav cases

Closes #2009

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/platform-shell-nav.spec.ts --watch=false
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web build
- pnpm --filter @metasheet/web exec eslint src/App.vue src/router/appRoutes.ts --max-warnings=0
- pnpm --filter @metasheet/web lint
- git diff --check