### PR TITLE
fix(multitable): redact the /test endpoint response (A1/A5 invariant hardening)

### DIFF
--- a/packages/core-backend/src/multitable/automation-log-service.ts
+++ b/packages/core-backend/src/multitable/automation-log-service.ts
@@ -203,3 +203,23 @@ function parseJsonColumn(value: unknown): unknown {
   if (value == null) return undefined
   return typeof value === 'string' ? JSON.parse(value) : value
 }
+
+/**
+ * Redact an IN-MEMORY AutomationExecution for an HTTP response — the same four
+ * secret channels `record()` scrubs at persist (steps / triggerEvent / ruleSnapshot
+ * / error), returning a NEW object with the flat AutomationExecution shape intact.
+ *
+ * Used as the SAFE fallback when the persisted (already-redacted) row can't be
+ * re-fetched: a fresh in-memory execution carries the live rule (credentials) in
+ * `ruleSnapshot` and raw action output in `steps`, which must never be serialized
+ * raw. Prefer the persisted row; fall back to this — never the raw execution.
+ */
+export function redactAutomationExecutionForResponse(execution: AutomationExecution): AutomationExecution {
+  return {
+    ...execution,
+    steps: redactValue(execution.steps) as AutomationStepResult[],
+    triggerEvent: redactValue(execution.triggerEvent),
+    ruleSnapshot: redactValue(execution.ruleSnapshot) as AutomationExecution['ruleSnapshot'],
+    error: execution.error !== undefined ? redactString(execution.error) : undefined,
+  }
+}

--- a/packages/core-backend/src/routes/automation.ts
+++ b/packages/core-backend/src/routes/automation.ts
@@ -19,6 +19,7 @@
 
 import { Router, type Request, type Response } from 'express'
 import type { AutomationService } from '../multitable/automation-service'
+import { redactAutomationExecutionForResponse } from '../multitable/automation-log-service'
 import type { AutomationExecution, AutomationStepResult } from '../multitable/automation-executor'
 import { legacyAutomationStatusToJobStatus } from '../multitable/workflow-job-contract'
 import { requireAdminRole } from '../guards/audit-integration'
@@ -130,8 +131,13 @@ export function createAutomationRoutes(
 
     try {
       const execution = await svc.testRun(ruleId, sheetId)
-      // Flat shape — client does parseJson<AutomationExecution>(res)
-      return res.json(execution)
+      // The in-memory execution carries the live rule (credentials) in ruleSnapshot + raw
+      // action output in steps; record()'s at-persist redaction returns new objects and does
+      // NOT mutate it. Serialize the PERSISTED (redacted) row; if it didn't land, fall back to
+      // a response-level redaction (NEVER the raw execution). Flat AutomationExecution shape is
+      // preserved either way (client does parseJson<AutomationExecution>(res)).
+      const persisted = await svc.logs.getById(execution.id)
+      return res.json(persisted ?? redactAutomationExecutionForResponse(execution))
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Test run failed'
       const code = message.includes('not found') ? 404 : 500

--- a/packages/core-backend/tests/unit/automation-routes-wiring.test.ts
+++ b/packages/core-backend/tests/unit/automation-routes-wiring.test.ts
@@ -29,6 +29,7 @@ function makeMockService() {
     logs: {
       getByRule: vi.fn(),
       getStats: vi.fn(),
+      getById: vi.fn(), // /test re-fetches the persisted (redacted) row; undefined → response-level redaction fallback
     },
   }
 }
@@ -55,6 +56,48 @@ describe('createAutomationRoutes HTTP mounting', () => {
     // Old envelope shape must NOT appear
     expect(res.body.data).toBeUndefined()
     expect(res.body.ok).toBeUndefined()
+  })
+
+  it('POST /test never serializes the raw in-memory execution (live creds / raw secrets redacted)', async () => {
+    const svc = makeMockService()
+    // testRun returns a fresh in-memory execution: ruleSnapshot = live rule, raw step error.
+    svc.testRun.mockResolvedValue({
+      id: 'exec-2', ruleId: 'rule-1', triggeredBy: 'manual_test', triggeredAt: '2026-05-29T00:00:00Z', status: 'failed',
+      ruleSnapshot: { id: 'rule-1', actions: [{ type: 'send_webhook', config: { token: 'LIVE-SECRET-TOKEN' } }] },
+      steps: [{ actionType: 'send_webhook', status: 'failed', error: 'connect postgres://u:SECRETPW@h/db failed' }],
+    })
+    svc.logs.getById.mockResolvedValue(undefined) // not persisted → response-level redaction fallback
+
+    const res = await request(buildApp(svc))
+      .post('/api/multitable/sheets/sheet-a/automations/rule-1/test')
+      .expect(200)
+
+    expect(res.body.id).toBe('exec-2') // flat shape preserved
+    const serialized = JSON.stringify(res.body)
+    expect(serialized).not.toContain('LIVE-SECRET-TOKEN')
+    expect(serialized).not.toContain('SECRETPW')
+  })
+
+  it('POST /test returns the PERSISTED (redacted) row when it exists, not the raw in-memory execution', async () => {
+    const svc = makeMockService()
+    svc.testRun.mockResolvedValue({
+      id: 'exec-3', ruleId: 'rule-1', triggeredBy: 'manual_test', triggeredAt: '2026-05-29T00:00:00Z', status: 'success',
+      ruleSnapshot: { actions: [{ config: { token: 'LIVE-SECRET-TOKEN' } }] }, // raw in-memory
+      steps: [],
+    })
+    svc.logs.getById.mockResolvedValue({
+      id: 'exec-3', ruleId: 'rule-1', triggeredBy: 'manual_test', triggeredAt: '2026-05-29T00:00:00Z', status: 'success',
+      ruleSnapshot: { actions: [{ config: { token: '<redacted>' } }] }, // persisted redacted row
+      steps: [],
+    })
+
+    const res = await request(buildApp(svc))
+      .post('/api/multitable/sheets/sheet-a/automations/rule-1/test')
+      .expect(200)
+
+    expect(svc.logs.getById).toHaveBeenCalledWith('exec-3')
+    expect(res.body.id).toBe('exec-3')
+    expect(JSON.stringify(res.body)).not.toContain('LIVE-SECRET-TOKEN') // came from the persisted redacted row
   })
 
   it('GET /logs returns shape { executions: [...] } — NOT { logs }', async () => {


### PR DESCRIPTION
## What

`POST /sheets/:sheetId/automations/:ruleId/test` did `res.json(execution)` on the **raw in-memory execution**. Since **A1** added `ruleSnapshot` to `AutomationExecution`, that serialized the live rule (**credentials**) + raw step output — the same leak class fixed for the A5 retry route (#2047). Pre-existing (A1-era), surfaced during #2047 review.

## Fix (route only — no testRun semantic change, no migration, no retry/A6 touch)
Re-fetch the **persisted (redacted) row** via `svc.logs.getById(execution.id)` and serialize that; if the log didn't land, fall back to **`redactAutomationExecutionForResponse(execution)`** — a response-level redaction of the 4 secret channels (steps / triggerEvent / ruleSnapshot / error) that **preserves the flat `AutomationExecution` shape** (the endpoint's existing contract). Never the raw execution.

`return res.json(persisted ?? redactAutomationExecutionForResponse(execution))`

New shared helper `redactAutomationExecutionForResponse` in `automation-log-service.ts` (same `redactValue`/`redactString` SSOT `record()` uses).

## Tests
- `/test` never serializes a live token / raw error secret (fallback path, getById → undefined).
- `/test` returns the **persisted redacted row** when it exists (not the raw in-memory exec; asserts getById called + no live secret).
- **169 unit** green; `tsc` clean.

## Scope
A1/A5 **invariant hardening**, not a new capability — does NOT touch testRun semantics, migrations, retry, or A6 (still frozen). Closes the pre-existing leak flagged in the #2047 verification doc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)