### PR TITLE
fix(multitable): fail-open on persisted-row re-fetch in /test + retry routes

### DIFF
--- a/packages/core-backend/src/routes/automation.ts
+++ b/packages/core-backend/src/routes/automation.ts
@@ -93,6 +93,23 @@ function toRunView(execution: AutomationExecution, { includeSnapshot }: { includ
 }
 
 /**
+ * Re-fetch the persisted (redacted) execution after a run/test/retry. A log-READ
+ * failure must NOT mask an already-completed run (testRun/retry swallow log-WRITE
+ * failures by design) — on throw, return undefined so the caller uses its redacted
+ * fallback instead of bubbling a 500.
+ */
+async function safeGetPersistedExecution(
+  svc: AutomationService,
+  executionId: string,
+): Promise<AutomationExecution | undefined> {
+  try {
+    return await svc.logs.getById(executionId)
+  } catch {
+    return undefined
+  }
+}
+
+/**
  * Build the automation routes router.
  *
  * Accepts either an AutomationService instance or a resolver function. The
@@ -136,7 +153,8 @@ export function createAutomationRoutes(
       // NOT mutate it. Serialize the PERSISTED (redacted) row; if it didn't land, fall back to
       // a response-level redaction (NEVER the raw execution). Flat AutomationExecution shape is
       // preserved either way (client does parseJson<AutomationExecution>(res)).
-      const persisted = await svc.logs.getById(execution.id)
+      // safeGet: a log-read failure must not 500 a completed test run → redacted fallback.
+      const persisted = await safeGetPersistedExecution(svc, execution.id)
       return res.json(persisted ?? redactAutomationExecutionForResponse(execution))
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Test run failed'
@@ -282,7 +300,9 @@ export function createAutomationRoutes(
       // output) are only scrubbed by record()'s at-persist redaction, which returns new
       // objects and does NOT mutate the in-memory execution. Re-fetch so the response
       // equals what is stored — same contract as the detail GET (no raw-secret leak).
-      const persisted = await svc.logs.getById(result.execution.id)
+      // safeGet: a log-read failure must not 500 a retry whose side effects already ran →
+      // fall through to the minimal safe body below (never a 500 that hides the completed run).
+      const persisted = await safeGetPersistedExecution(svc, result.execution.id)
       if (persisted) {
         return res.json(toRunView(persisted, { includeSnapshot: true }))
       }

--- a/packages/core-backend/tests/unit/automation-routes-wiring.test.ts
+++ b/packages/core-backend/tests/unit/automation-routes-wiring.test.ts
@@ -100,6 +100,25 @@ describe('createAutomationRoutes HTTP mounting', () => {
     expect(JSON.stringify(res.body)).not.toContain('LIVE-SECRET-TOKEN') // came from the persisted redacted row
   })
 
+  it('POST /test stays 200 (redacted fallback) when the persisted-row re-fetch THROWS — a log read must not 500 a completed test', async () => {
+    const svc = makeMockService()
+    svc.testRun.mockResolvedValue({
+      id: 'exec-4', ruleId: 'rule-1', triggeredBy: 'manual_test', triggeredAt: '2026-05-29T00:00:00Z', status: 'success',
+      ruleSnapshot: { actions: [{ config: { token: 'LIVE-SECRET-TOKEN' } }] },
+      // secret-SHAPED error (conn-string) — the redactor scrubs by shape, not bare strings.
+      steps: [{ actionType: 'send_webhook', status: 'failed', error: 'connect postgres://u:SECRETPW@h/db failed' }],
+    })
+    svc.logs.getById.mockRejectedValue(new Error('db down')) // log read fails
+
+    const res = await request(buildApp(svc))
+      .post('/api/multitable/sheets/sheet-a/automations/rule-1/test')
+      .expect(200) // NOT 500 — the test run completed; only the log read failed
+    expect(res.body.id).toBe('exec-4') // flat shape via redacted fallback
+    const serialized = JSON.stringify(res.body)
+    expect(serialized).not.toContain('LIVE-SECRET-TOKEN')
+    expect(serialized).not.toContain('SECRETPW')
+  })
+
   it('GET /logs returns shape { executions: [...] } — NOT { logs }', async () => {
     const svc = makeMockService()
     svc.logs.getByRule.mockResolvedValue([

--- a/packages/core-backend/tests/unit/automation-runs-api.test.ts
+++ b/packages/core-backend/tests/unit/automation-runs-api.test.ts
@@ -251,4 +251,28 @@ describe('A5 runs API — POST /automation-executions/:id/retry', () => {
     expect(serialized).not.toContain('LIVE-SECRET-TOKEN')
     expect(serialized).not.toContain('SECRETPW')
   })
+
+  it('retry stays 200 (minimal safe body) when the persisted-row re-fetch THROWS — a log read must not 500 a retry whose side effects already ran', async () => {
+    const rawNew = {
+      id: 'axe_new', ruleId: 'rule-1', status: 'success', triggeredBy: 'retry', triggeredAt: '2026-05-29T00:00:00.000Z',
+      rerunOfExecutionId: 'axe_1', initiatedBy: 'admin1',
+      ruleSnapshot: { actions: [{ config: { token: 'LIVE-SECRET-TOKEN' } }] },
+      steps: [{ actionType: 'send_webhook', status: 'failed', error: 'SECRETPW' }],
+    }
+    const svc = makeMockService(
+      { getById: vi.fn().mockRejectedValue(new Error('db down')) }, // log READ throws
+      { retryExecution: vi.fn().mockResolvedValue({ execution: rawNew }) },
+    )
+    const res = await request(buildApp(svc))
+      .post('/api/multitable/automation-executions/axe_1/retry')
+      .send({ confirmSideEffects: true })
+      .expect(200) // NOT 500 — the retry ran; only the log read failed
+    expect(res.body.id).toBe('axe_new')
+    expect(res.body.status).toBe('resolved')
+    expect(res.body.steps).toBeUndefined()
+    expect(res.body.ruleSnapshot).toBeUndefined()
+    const serialized = JSON.stringify(res.body)
+    expect(serialized).not.toContain('LIVE-SECRET-TOKEN')
+    expect(serialized).not.toContain('SECRETPW')
+  })
 })


### PR DESCRIPTION
## What

Review follow-up to **#2051** (your REQUEST CHANGES). The `/test` and retry routes re-fetch the persisted (redacted) execution via `svc.logs.getById` to avoid serializing the raw in-memory execution. But the re-fetch was **unguarded**: if `getById` **throws** (DB read error), the outer `catch` turns the whole endpoint into a **500** — even though `testRun()`/`retryExecution()` deliberately swallow log-**write** failures and the run/test already completed (retry's external side effects already ran).

**A log-read failure must not mask a completed run.** Add `safeGetPersistedExecution()` (try/catch → `undefined` on throw) so both routes fall through to their redacted fallback instead of 500:
- `/test` → response-level redaction (`redactAutomationExecutionForResponse`)
- retry → minimal safe body (ids/status only)

## Applies to BOTH routes
You flagged `/test`; the **retry route had the identical gap** (same `getById` re-fetch added in #2047) — and worse, its side effects already ran. Fixed both with the one shared helper.

## Tests (2)
- `/test` `getById` **rejects** → **200** + redacted flat `AutomationExecution`, no secret-shaped leak.
- retry `getById` **rejects** → **200** + minimal safe body (no `steps`/`ruleSnapshot`), no leak.
- **171 unit** green; `tsc` + ESLint clean.

> Note: redaction is secret-**shape**-based (A1 contract) — the tests use shaped secrets (conn-string / structured `token` key); a bare opaque string is intentionally not scrubbed (indistinguishable from business data), same as the persisted-row path.

## Scope
A1/A5 invariant hardening (robustness) — no testRun/retry semantic change, no migration, no A6.

🤖 Generated with [Claude Code](https://claude.com/claude-code)