### PR TITLE
feat(data-sources): Lane C C3-code — Windows python-binary portability + windows-latest CI evidence

### DIFF
--- a/.github/workflows/sandbox-windows-portability.yml
+++ b/.github/workflows/sandbox-windows-portability.yml
@@ -1,0 +1,71 @@
+name: Sandbox Windows portability (C3)
+
+# Lane C / C3: GitHub windows-latest gives REAL native-Windows evidence for the sandbox
+# code-portability layer — that ScriptSandbox's workDir resolves under %TEMP% (C1) and that the
+# Python subprocess uses a Windows-resolvable interpreter (`python`, not the POSIX `python3`).
+# The *environment* layer (PostgreSQL/Garnet/Memurai on Windows, nssm/node-windows service
+# lifecycle, end-to-end boot) cannot be CI'd and stays a manual checklist in the C3 validation-plan
+# doc (docs/development/data-sources-windows-c3-validation-plan-20260529.md).
+#
+# TARGETED + PATH-FILTERED on purpose: this is NOT a whole-repo Windows gate on every PR. It
+# triggers ONLY when the sandbox or its portability tests change, and runs ONLY the sandbox/Python
+# portability vitest — no PG/Redis, no full suite. Windows runners cost more minutes, so the
+# path-filter keeps it off unrelated PRs.
+
+on:
+  workflow_dispatch:
+  pull_request:
+    branches: [main, develop]
+    paths:
+      - 'packages/core-backend/src/sandbox/**'
+      - 'packages/core-backend/tests/unit/script-sandbox-*.test.ts'
+      - '.github/workflows/sandbox-windows-portability.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'packages/core-backend/src/sandbox/**'
+      - 'packages/core-backend/tests/unit/script-sandbox-*.test.ts'
+      - '.github/workflows/sandbox-windows-portability.yml'
+
+jobs:
+  sandbox-windows:
+    name: Sandbox + Python portability (windows-latest)
+    runs-on: windows-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Setup Python
+        id: setup-python
+        uses: actions/setup-python@v5
+        with:
+          python-version: '3.x'
+
+      - name: Confirm python on PATH (fail loudly if absent — defeats the skip-trap)
+        run: python --version
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Sandbox + Python portability vitest (no PG/Redis)
+        env:
+          # Force the real-wire python test to RUN (never skip) on Windows — a broken python path
+          # then fails the job instead of masquerading as a green skip.
+          SANDBOX_REQUIRE_PYTHON: '1'
+          # Native-Windows escape hatch (the documented C3 guidance): point at the interpreter
+          # explicitly rather than relying on a bare `python` being on the (service) PATH/PATHEXT.
+          # The bare-default `python` resolution is still asserted by the pure resolvePythonBinary
+          # test, which runs here on real win32.
+          PYTHON_BIN: ${{ steps.setup-python.outputs.python-path }}
+        run: pnpm --filter @metasheet/core-backend exec vitest run script-sandbox

--- a/docs/development/data-sources-mssql-windows-deploy-design-20260527.md
+++ b/docs/development/data-sources-mssql-windows-deploy-design-20260527.md
@@ -92,7 +92,7 @@
 
 ### Lane C — 部署形态(基础设施;运行时已基本可移植)
 
-**关键发现**:后端运行时是干净的 —— 生产启动即 `node dist/index.js`,**不 spawn 任何 shell 脚本**(仓库 189 个 `.sh` 全是 CI/部署/开发工具,非运行时);`src` 内唯一 runtime POSIX 假设是 `ScriptSandbox.ts:108` 的 `'/tmp/sandbox'` 默认值;pg/redis 驱动纯 JS 无原生编译。故"原生 Windows 跑"成本远低于最初估计。
+**关键发现(2026-05-29 全面审计已纠正)**:后端运行时是干净的 —— 生产启动即 `node dist/src/index.js`,**不 spawn 任何 shell 脚本**(仓库 `.sh` 全是 CI/部署/开发工具,非运行时);pg/redis/mssql 驱动纯 JS 无原生编译。`src`(+ 已加载 plugins + 部署期 `migrate`)内的 runtime POSIX 假设经全面审计共 **两处**,均已处理:① `ScriptSandbox` workDir `'/tmp/sandbox'`(C1,已修为 `os.tmpdir()`);② `ScriptSandbox` 两处 `spawn('python3')`(C3-code,已修为平台感知 `resolvePythonBinary` + `PYTHON_BIN`)。**初稿"唯一 `/tmp/sandbox`"的说法不完整 —— `python3` spawn 是审计补出的第二处。** 故"原生 Windows 跑"成本仍远低于最初估计,且代码层已 `windows-latest` CI 真证(见 C3 验证计划)。
 
 依赖侧:后端自身需 PostgreSQL + Redis。Postgres 有 Windows 官方安装包;**Redis 无官方 Windows 原生版** → Windows 原生兼容选项:**Microsoft Garnet(MIT 开源,.NET 8,RESP 兼容)** 作 OSS 首选,**Memurai**(开发版免费/商业版付费)作稳定商业 fallback;或 WSL2 / Docker。这才是 Docker 省事的真正原因,而非 Node app 本身。
 
@@ -128,8 +128,8 @@
 - ✅ **A0.1 scope/ownership 收口**(#1960):写路径带 owner + `assertAccess` 每个 `:id` 操作越权 404 + list 过滤 + 越权拒绝测试
 - ✅ **A-RO 框架级只读**(#1964 `b0f7c54df`):per-source `readOnly`(默认 true)+ 路由级 SELECT-only 分类器 + 适配器层 `assertWritable`
 - ✅ A1 凭据落库加密(#1972 `5e11ee72c`):用 `encrypted-secrets` AES-256-GCM(非 SecretManager)+ 惰性迁移 + decrypt fail-loud
-- ⬜ A2 `sanitizeIdentifier` 违规即抛 + schema-qualified 支持 + 非法值测试
-- ⬜ A3 query/testConnection 错误不吞,保留错因 + 集成测试
+- ✅ A2 `sanitizeIdentifier` 违规即抛 + schema-qualified 支持(#2037 `bf0eefc78`):按 `.` 分段校验、非法即抛(不再静默改写);MSSQL/MySQL per-segment quote;`[dbo].[table]` schema-qualified 经 SQL Server 容器 matrix 真 wire 证
+- ✅ A3 query/testConnection 错误不吞,保留错因(#2034):`testConnection` 返回 `{success,error?}`;错因经 `redactSecrets` 脱敏(`password`/`token` 不入 response/log);manager 仅转发 redacted `connectionError`;真 wire 集成测试覆盖
 - ✅ A4 enum↔registry↔驱动三方对齐(#1976 `f5013324e`):`SUPPORTED_DATA_SOURCE_TYPES` 单一支持矩阵 + 非法 type 400 + load 跳过不支持行
 - ⬜ A5 `stream()` 真游标流 或 明确文档标注 + 上限保护
 - ⬜ A6 Postgres connect/query/transaction/错误路径单测
@@ -146,7 +146,8 @@
 ### Phase C — 部署形态(随 A/B 决策)
 - ✅ **C1** `'/tmp/sandbox'` → `path.join(os.tmpdir(),'sandbox')`(`ScriptSandbox.ts` + `script-sandbox-workdir.test.ts`;测试 mock `os.tmpdir()` 到非 `/tmp` sentinel,断言 workDir 派生自 `os.tmpdir()` 而非硬编码字面量 —— 否则 Linux CI 上 `os.tmpdir()===/tmp` 会让回退到字面量仍然 pass)
 - ✅ **C2** A/B/C 三档部署 runbook —— `docs/development/data-sources-mssql-windows-deploy-runbook-20260529.md`
-- 🔒 C3 (仅走 C 时)Windows 原生运行时验证 pass(需 Windows VM/快照,本预算未含)
+- ✅ **C3-code** 代码可移植层(本刀):`ScriptSandbox` 两处 `spawn('python3')` → `resolvePythonBinary()`(平台感知 `win32→python` + `PYTHON_BIN` 逃生口)+ `executePython` error-path 临时文件 cleanup;`script-sandbox-python-portability.test.ts`(resolve 纯测 + bogus-binary error path + 真 wire `validateScript`)+ **`windows-latest` CI lane**(`sandbox-windows-portability.yml`,path-filtered + targeted,真 win32 证 workDir/python 解析/真 wire/error-path,无 PG/Redis)。审计纠正了"唯一 `/tmp/sandbox`"说法
+- 🔒 **C3-env** 环境集成层(仍 🔒,需客户 Windows 主机):PG/Garnet\|Memurai 连通 + nssm/node-windows 服务化 + 端到端启动,无法 CI → 手动 checklist 见 `docs/development/data-sources-windows-c3-validation-plan-20260529.md`
 
 **推进顺序(已按裁示更新)**:Phase 0 → **A0 + A0.1(持久化 + scope 收口)→ A-RO + A1 + A4(基础面安全)→ A2/A3/A5/A6** → **B(仅当 A0/A0.1/A-RO/A1/A4 定住后才 opt-in)** → C(随部署形态)。
 - **Lane B 不再与 A 并行**:MSSQL 连接器必须落在已安全的框架上,故 gated 在 A0/A0.1/A-RO/A1/A4 之后(P0-4 裁示)。

--- a/docs/development/data-sources-windows-c3-validation-plan-20260529.md
+++ b/docs/development/data-sources-windows-c3-validation-plan-20260529.md
@@ -1,0 +1,83 @@
+# C3 — Windows 原生运行时验证计划(代码可移植层已 CI 真证 · 环境层待客户主机)
+
+> **配套**:设计稿 `data-sources-mssql-windows-deploy-design-20260527.md`(§Lane C / §5 权威)+ 部署 runbook `data-sources-mssql-windows-deploy-runbook-20260529.md`(档 C 部署步骤)。
+> **范围**:设计稿把 C3 列为单条 🔒「Windows 原生运行时验证 pass」。本计划把它**拆成两层**,因为两层的可验证性根本不同:
+> - **① 代码可移植层** —— backend 运行时本身在 Windows 上是否成立(路径/子进程/信号)。**可在 GitHub `windows-latest` 上真证,无需客户硬件 → 本刀已做。**
+> - **② 环境集成层** —— PostgreSQL/Garnet|Memurai/nssm 服务化 + 端到端启动。**无法 CI,留作客户 Windows 主机的手动 checklist(§3,仍 🔒)。**
+
+---
+
+## 0. 结论速读
+
+- **代码可移植层(本刀已闭环)**:backend 运行时(`node dist/src/index.js` + 其 import graph + 部署期 `migrate`)经审计为 Windows-clean,**仅两处** POSIX 假设,均已处理:
+  - **C1**:`ScriptSandbox` workDir `'/tmp/sandbox'` → `path.join(os.tmpdir(),'sandbox')`(已合 **PR #2041**)。
+  - **C3-code**:`ScriptSandbox` 两处 `spawn('python3')` → `resolvePythonBinary()`(平台感知 + `PYTHON_BIN` 逃生口)+ `executePython` error-path 临时文件 cleanup(**本刀**)。
+  - **windows-latest CI lane**(本刀)在**真 Windows** 上证 workDir 解析 + python 解释器解析 + 真 wire 执行 + 缺失解释器的优雅失败。
+- **环境集成层(仍 🔒)**:待客户 Windows 主机,逐项走 §3 手动 checklist。
+
+---
+
+## 1. 可移植性审计结果(纠正设计稿「唯一 /tmp/sandbox」说法)
+
+设计稿 §Lane C 关键发现称运行时唯一 POSIX 假设是 `ScriptSandbox.ts` 的 `/tmp/sandbox`。**审计(全 `core-backend/src` + 已加载 plugins 包 + 部署期 `migrate`)证明该说法不完整** —— 完整清单:
+
+| 类别 | 审计结果 |
+|---|---|
+| 硬编码 POSIX 绝对路径 | 仅 C1 的 `/tmp/sandbox`(已修);`uploads` 用 `process.env.STORAGE_PATH \|\| path.join(process.cwd(),'uploads')`(可移植);其余 `/`-拼接均为 **URL / S3 object key / metric label**,非文件系统路径 |
+| 子进程 `spawn`/`exec` | 仅 `ScriptSandbox` 两处 `spawn('python3')`(`executePython` + `validateScript`,**已修**);plugins(`plugin-attendance` index.cjs、`plugin-integration-core` K3 executor 等)**0 spawn/exec** |
+| 平台分支 | 仅 `process.platform` 作**诊断上报值**(health / isolation),无平台分支逻辑 |
+| 权限 / 符号链接 | runtime 路径无 `chmod`/`symlink` 使用 |
+| 信号 | `SIGTERM`/`SIGINT` 优雅停机(见 §4 服务停止语义) |
+
+> 结论:除 C1 + C3-code 两处外,backend 运行时(含 plugins、uploads、migrate)在 Windows 上无其它已知阻断。
+
+---
+
+## 2. 代码可移植层 — `windows-latest` CI 证据(本刀)
+
+- **workflow**:`.github/workflows/sandbox-windows-portability.yml`。**path-filtered**(仅 `sandbox/**` + `script-sandbox-*.test.ts` + 本 workflow 变化触发)、**targeted**(仅跑 `script-sandbox` portability vitest,**无 PG/Redis**、不跑全套)—— 不是全仓每 PR 的 Windows 大门。
+- **证什么(在真 win32 上)**:
+  1. workDir 派生自 `os.tmpdir()`(`script-sandbox-workdir.test.ts`)。
+  2. `resolvePythonBinary('win32', undefined) === 'python'`(pure test,真 win32 执行)。
+  3. **真 wire**:经解析出的解释器 `spawn` + 执行 python(`validateScript`)。`SANDBOX_REQUIRE_PYTHON=1` 强制该测试**不跳过**(缺 python 则硬失败,杜绝 skip-when-unreachable 假绿);`PYTHON_BIN` 指向 `setup-python` 解释器(确定性,且即档 C 推荐配置,见 §5)。
+  4. **error path**:解释器缺失时优雅失败(不抛)+ 错误信息含解析出的 binary 名(便于 `PYTHON_BIN` 诊断)+ 临时 `.py` 不泄漏 —— 确定性,全平台跑(bogus binary 在哪都是 ENOENT)。
+
+---
+
+## 3. 环境集成层 — 手动验证 checklist(🔒 需客户 Windows 主机)
+
+按 runbook **档 C** 部署后逐项验证(每项含 pass 判据):
+
+- ⬜ **服务化**(nssm / node-windows):`node …/dist/src/index.js` 注册为服务 → 开机自启 + 崩溃重启生效。
+- ⬜ **服务停止语义**(见 §4):停服务时进程优雅退出(连接/事务收尾)。
+- ⬜ **PostgreSQL**(Windows 安装包):`DATABASE_URL` 连通;`migrate -- --list` 无 pending。
+- ⬜ **Redis 替代**(Garnet / Memurai):`REDIS_HOST`/`REDIS_PORT` 连通;缓存读写正常。
+- ⬜ **文件 / 路径**:`ScriptSandbox` workDir 落 `%TEMP%\sandbox` 可创建/写/清理;`uploads` 落 `<cwd>\uploads`。
+- ⬜ **Python**(仅当用到 workflow Python 脚本节点):设 `PYTHON_BIN`(见 §5);`validateScript` 通(注意 §6 的 executePython 预存 bug)。
+- ⬜ **Auth round-trip**:登录 → 带 token 调鉴权接口 → 200(**静默 401 = schema gap**,先查迁移)。
+- ⬜ **数据源只读**:`GET /api/data-sources/:id/test` 通;SQL Server smoke(如已配)通。
+- ⬜ **凭据加密**:`ENCRYPTION_KEY`/`ENCRYPTION_SALT` 稳定;服务重启后已存数据源仍可解密(decrypt fail-loud)。
+
+---
+
+## 4. 服务停止语义(SIGTERM —— P3,降级为说明非代码 bug)
+
+- 主入口只监听 `SIGTERM`/`SIGINT`(`index.ts:2263-2264`)做 graceful shutdown。
+- **native Windows 无 OS 级 `SIGTERM` 投递**;Windows 服务的停止由 nssm/node-windows 自身机制触发。
+- 验证(归入 §3):用 nssm/node-windows 停服务时确认进程优雅退出;必要时配置服务管理器发送 Ctrl+C(→`SIGINT`)或其 graceful-stop。**非代码 bug**,无需改 `process.on('SIGTERM')`。
+
+---
+
+## 5. `PYTHON_BIN` 指南(Windows 服务 PATH 不可靠时)
+
+- **默认**:win32 → `python`,posix → `python3`。
+- Windows **服务**的 PATH 常与交互式 shell 不同(服务以受限账户/不同环境运行),bare `python` 可能找不到,或撞 Microsoft Store 启动器别名(不真正执行)。
+- 故档 C 推荐**显式设 `PYTHON_BIN` 为 `python.exe` 绝对路径**(如 `C:\Python312\python.exe`)。`resolvePythonBinary` 的 `PYTHON_BIN` 优先级正是此逃生口。
+
+---
+
+## 6. 已知缺口(独立 follow-up,非本刀)
+
+- 🐛 **`executePython` 的 `wrapPythonScript` 双重缩进 bug(可移植性审计期发现,与本刀正交)**:模板行 `    ${...}` 已含 4 空格,而每行又 `map(line => '    ' + line)` 再加 4 空格 → 用户代码落 **8 空格缩进**于 4 空格的 `result = None` 之下 → **任何非空 python 脚本均 `IndentationError`**。这是**预存 bug**,使 `executePython` 端到端在**所有平台**均不可用(`validateScript` 路径无 wrapper,不受影响)。修复 trivial(去掉模板多余 4 空格),但属**功能正确性**、超出 C3 可移植范围 → 建议作**独立切片**(opt-in)修复 + 补 e2e。本刀的 python 可移植性修复(binary 解析 + cleanup)对此 bug 无影响也不依赖它。
+- 🔒 **2008R2 / 2012 真实验证**(需 Windows VM —— 无 Linux 容器)。
+- 🔒 **B6 Windows 集成认证**(`authType:'windows'`,Kerberos/keytab/AD)。

--- a/packages/core-backend/src/sandbox/ScriptSandbox.ts
+++ b/packages/core-backend/src/sandbox/ScriptSandbox.ts
@@ -71,6 +71,25 @@ interface TypeScriptDiagnostic {
   messageText: string | { messageText: string }
 }
 
+/**
+ * Resolve the Python interpreter command for the sandbox subprocess.
+ *
+ * Lane C / C3: `python3` is the conventional command on POSIX, but on native Windows the
+ * interpreter is normally `python` — a bare `python3` often does not exist (or is a Microsoft
+ * Store launcher alias that does not actually run). `PYTHON_BIN` is an explicit escape hatch for
+ * hosts where the interpreter is not on a predictable PATH (e.g. a Windows service whose PATH
+ * differs from the interactive shell): set it to an absolute path or a specific command.
+ */
+export function resolvePythonBinary(
+  platform: NodeJS.Platform,
+  pythonBinEnv: string | undefined
+): string {
+  if (pythonBinEnv && pythonBinEnv.trim() !== '') {
+    return pythonBinEnv.trim()
+  }
+  return platform === 'win32' ? 'python' : 'python3'
+}
+
 export class ScriptSandbox extends EventEmitter {
   private options: SandboxOptions
   private worker: Worker | null = null
@@ -298,6 +317,10 @@ export class ScriptSandbox extends EventEmitter {
     })
   }
 
+  private getPythonBinary(): string {
+    return resolvePythonBinary(process.platform, process.env.PYTHON_BIN)
+  }
+
   private async executePython(
     script: string,
     context: ExecutionContext,
@@ -315,7 +338,7 @@ export class ScriptSandbox extends EventEmitter {
       const scriptPath = path.join(this.workDir, `${executionId}.py`)
       fs.writeFile(scriptPath, this.wrapPythonScript(script, context))
         .then(() => {
-          const pythonProcess = spawn('python3', [scriptPath], {
+          const pythonProcess = spawn(this.getPythonBinary(), [scriptPath], {
             env: { ...process.env, ...this.options.env },
             timeout: this.options.timeout
           })
@@ -371,10 +394,15 @@ export class ScriptSandbox extends EventEmitter {
             }
           })
 
-          pythonProcess.on('error', (error: Error) => {
+          pythonProcess.on('error', async (error: Error) => {
+            // Lane C / C3: a spawn 'error' (e.g. ENOENT when the python binary is not found — the
+            // common native-Windows case) fires WITHOUT 'close', so the temp script must be cleaned
+            // up here too or it leaks. Surface the resolved binary in the message to aid PYTHON_BIN
+            // diagnosis on hosts where the interpreter is not on the service PATH.
+            await fs.unlink(scriptPath).catch(() => {})
             resolve({
               success: false,
-              error: error.message,
+              error: `Failed to run python ('${this.getPythonBinary()}'): ${error.message}`,
               logs,
               metrics: {
                 executionTime: Date.now() - startTime,
@@ -632,7 +660,7 @@ except Exception as e:
           // eslint-disable-next-line @typescript-eslint/no-require-imports, @typescript-eslint/no-var-requires
           const { spawn } = require('child_process')
           return new Promise((resolve) => {
-            const pythonProcess = spawn('python3', [
+            const pythonProcess = spawn(this.getPythonBinary(), [
               '-c',
               `import ast; import sys; ast.parse(sys.stdin.read())`
             ])

--- a/packages/core-backend/tests/unit/script-sandbox-python-portability.test.ts
+++ b/packages/core-backend/tests/unit/script-sandbox-python-portability.test.ts
@@ -1,0 +1,106 @@
+import { spawnSync } from 'child_process'
+import fs from 'fs/promises'
+import os from 'os'
+import path from 'path'
+import { afterEach, describe, expect, it } from 'vitest'
+
+import { ScriptSandbox, resolvePythonBinary } from '../../src/sandbox/ScriptSandbox'
+
+// Lane C / C3 — Windows python-portability. The sandbox used to hardcode spawn('python3'), which
+// does not resolve on native Windows (the interpreter is `python`/`py` there; `python3` is often
+// absent or a Store launcher alias). resolvePythonBinary() picks the right command per platform
+// with a PYTHON_BIN escape hatch.
+describe('resolvePythonBinary (pure)', () => {
+  it('defaults to python3 on POSIX', () => {
+    expect(resolvePythonBinary('linux', undefined)).toBe('python3')
+    expect(resolvePythonBinary('darwin', undefined)).toBe('python3')
+  })
+
+  it('defaults to python on native Windows (python3 usually absent there)', () => {
+    expect(resolvePythonBinary('win32', undefined)).toBe('python')
+  })
+
+  it('honors PYTHON_BIN over the platform default, on any platform', () => {
+    expect(resolvePythonBinary('win32', 'C:\\Python311\\python.exe')).toBe('C:\\Python311\\python.exe')
+    expect(resolvePythonBinary('linux', '/usr/bin/python3.11')).toBe('/usr/bin/python3.11')
+  })
+
+  it('ignores empty / whitespace-only PYTHON_BIN and falls back to the platform default', () => {
+    expect(resolvePythonBinary('win32', '')).toBe('python')
+    expect(resolvePythonBinary('win32', '   ')).toBe('python')
+    expect(resolvePythonBinary('linux', '')).toBe('python3')
+  })
+})
+
+// Error-path robustness (C3): a missing interpreter — the common native-Windows `python3` case —
+// must fail gracefully (no throw), surface the resolved binary to aid PYTHON_BIN diagnosis, and
+// NOT leak the temp .py script. Deterministic on every platform (a bogus binary is ENOENT
+// everywhere), so it needs no python install and no skip.
+describe('ScriptSandbox python error path (C3)', () => {
+  const prevPythonBin = process.env.PYTHON_BIN
+
+  afterEach(() => {
+    if (prevPythonBin === undefined) delete process.env.PYTHON_BIN
+    else process.env.PYTHON_BIN = prevPythonBin
+  })
+
+  it('fails gracefully, names the binary, and cleans up the temp script when python is missing', async () => {
+    process.env.PYTHON_BIN = '/nonexistent/python-bogus-xyz'
+    // Isolated workDir so the leftover-script assertion is not polluted by other sandbox instances.
+    const workDir = path.join(os.tmpdir(), `c3-pyerr-${process.pid}-${Date.now()}`)
+    const sandbox = new ScriptSandbox({ workDir, timeout: 8000 })
+    await sandbox.initialize()
+    try {
+      const result = await sandbox.execute('result = 1', {}, 'python')
+      expect(result.success).toBe(false)
+      expect(String(result.error)).toContain('/nonexistent/python-bogus-xyz')
+
+      // Temp-cleanup fix: the spawn 'error' fires without 'close', so the .py must be removed there.
+      const leftover = (await fs.readdir(workDir)).filter((f) => f.endsWith('.py'))
+      expect(leftover).toEqual([])
+    } finally {
+      await sandbox.cleanup()
+    }
+  })
+})
+
+// Real-wire execution: spawn the *resolved* interpreter and run python for real. On windows-latest
+// this is the actual "Windows native runtime" evidence for the sandbox code layer — it proves the
+// resolved binary (`python` on win32) is found and executes.
+//
+// Skip honestly when no python is resolvable (local dev without python) — BUT the windows-latest CI
+// job sets SANDBOX_REQUIRE_PYTHON=1, which converts the skip into a hard failure, so a broken python
+// path on Windows can never masquerade as a green run (the "skip-when-unreachable" trap).
+//
+// NB: this exercises validateScript() (spawn + ast.parse over stdin), NOT executePython()'s
+// wrapPythonScript path — the latter has a separate pre-existing double-indent bug (tracked in the
+// C3 plan doc) that makes wrapped execution fail on every platform, independent of this fix.
+const pythonBin = resolvePythonBinary(process.platform, process.env.PYTHON_BIN)
+const probe = spawnSync(pythonBin, ['--version'])
+const pythonAvailable = !probe.error && probe.status === 0
+const requirePython = process.env.SANDBOX_REQUIRE_PYTHON === '1'
+
+describe('ScriptSandbox python real-wire (C3)', () => {
+  it.skipIf(!pythonAvailable && !requirePython)(
+    'spawns the resolved python binary and validates a script end-to-end',
+    async () => {
+      // Reached under SANDBOX_REQUIRE_PYTHON with no runnable python → fail loudly, never skip-pass.
+      expect(
+        pythonAvailable,
+        `SANDBOX_REQUIRE_PYTHON=1 but python binary '${pythonBin}' is not runnable ` +
+          `(${probe.error?.message ?? `exit ${probe.status}`}). Set PYTHON_BIN to a valid interpreter.`
+      ).toBe(true)
+
+      const sandbox = new ScriptSandbox({ timeout: 20000 })
+      try {
+        const ok = await sandbox.validateScript('x = 1\n', 'python')
+        expect(ok.valid).toBe(true)
+
+        const bad = await sandbox.validateScript('def (:\n', 'python')
+        expect(bad.valid).toBe(false)
+      } finally {
+        await sandbox.cleanup()
+      }
+    }
+  )
+})


### PR DESCRIPTION
## Lane C C3 — code-portability layer (the half that needs no customer hardware)

Per the audit + your 裁示 (A + B, 2026-05-29). C3 splits into **code-portability** (provable on GitHub `windows-latest` now → this PR) and **environment integration** (PG/Garnet·Memurai/nssm/boot → manual checklist, still 🔒).

### Audit finding (corrects the design doc)
A full sweep of the backend runtime (`core-backend/src` + loaded plugin bundles + deploy-time `migrate`) found the design doc's "only POSIX assumption is `/tmp/sandbox`" claim **incomplete**: `ScriptSandbox` also `spawn('python3')` at **two** sites. `python3` doesn't resolve on native Windows (it's `python`/`py`; `python3` is often a Store alias) and is latent on Linux too. Everything else is clean — uploads use `path.join(process.cwd(),'uploads')`, plugins have **0** spawn/exec, the only `/`-concats are URL/S3-key/label strings, `process.platform` is diagnostic-only.

### A — fix (code)
`resolvePythonBinary(platform, PYTHON_BIN)` = `PYTHON_BIN || (win32 ? 'python' : 'python3')`, reused at both spawn sites. `executePython`'s `error` handler now also **unlinks the temp `.py`** (a spawn ENOENT fires without `close`, so it leaked) and **names the resolved binary** in the message to aid `PYTHON_BIN` diagnosis.

### B — windows-latest CI (path-filtered + targeted)
`.github/workflows/sandbox-windows-portability.yml`: triggers **only** on `sandbox/**` + `script-sandbox-*.test.ts` + the workflow file; runs **only** the sandbox/Python portability vitest — **no PG/Redis**, not the full suite. Never a whole-repo Windows gate. It gives **real native-Windows evidence**: workDir under `%TEMP%`, `resolvePythonBinary → 'python'` on real win32, and a real-wire `validateScript` that actually runs python (`SANDBOX_REQUIRE_PYTHON=1` forces the test to run, never skip-pass; `PYTHON_BIN` = the setup-python interpreter, which is also the documented Windows escape-hatch).

### Tests (`script-sandbox-python-portability.test.ts`) — 8/8 green locally
- `resolvePythonBinary` pure cases (incl. empty-`PYTHON_BIN` fallback).
- **Deterministic** error-path: bogus `PYTHON_BIN` → graceful fail + binary named + temp `.py` not leaked (no python needed, all platforms).
- Real-wire `validateScript` (skip-guarded locally; forced on windows-latest).

### Docs
New `data-sources-windows-c3-validation-plan-20260529.md` — audit result + windows-latest evidence + the manual **environment** checklist (🔒 needs customer Windows host) + `PYTHON_BIN`/SIGTERM guidance. Design doc §Lane C claim corrected; §4 splits C3 → **C3-code ✅** (this PR) vs **C3-env 🔒**.

### ⚠️ Out of scope (flagged, NOT fixed)
The audit also found `executePython`'s `wrapPythonScript` has a **separate pre-existing double-indent bug** that `IndentationError`s every non-empty script on all platforms — orthogonal to portability. Tracked in the plan doc §6 as an opt-in follow-up. The real-wire test uses `validateScript` (no wrapper), which is unaffected.

### Verification
- eslint clean on `ScriptSandbox.ts`; `tsc --noEmit` exit 0 (zero errors project-wide); 8/8 portability tests green locally against python3.
- The **windows-latest lane on this PR is the real-Windows proof** — watch it go green.

### Governance
Lock-safe: sandbox substrate + docs + one isolated CI lane; no `plugin-integration-core` / RBAC / auth. User-opted-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)