### PR TITLE
fix(attendance): surface request and rejection reasons

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -235,6 +235,12 @@
                 <span>{{ formatDate(item.work_date) }}</span>
                 <span>{{ selfServiceRequestSubtitle(item) }}</span>
               </div>
+              <div class="attendance__request-meta" v-if="requestReasonText(item)">
+                <span>{{ tr('Reason', '原因') }}: {{ requestReasonText(item) }}</span>
+              </div>
+              <div class="attendance__request-meta" v-if="requestDecisionCommentText(item)">
+                <span>{{ requestDecisionCommentLabel(item) }}: {{ requestDecisionCommentText(item) }}</span>
+              </div>
               <p class="attendance__request-note">
                 {{ describeRequestStatus(item.status, item) }}
               </p>
@@ -803,6 +809,12 @@
                   <span v-if="item.metadata.leaveType">{{ tr('Leave', '请假') }}: {{ item.metadata.leaveType.name }}</span>
                   <span v-if="item.metadata.overtimeRule">{{ tr('Overtime', '加班') }}: {{ item.metadata.overtimeRule.name }}</span>
                   <span v-if="item.metadata.minutes">{{ tr('Minutes', '分钟') }}: {{ item.metadata.minutes }}</span>
+                </div>
+                <div class="attendance__request-meta" v-if="requestReasonText(item)">
+                  <span>{{ tr('Reason', '原因') }}: {{ requestReasonText(item) }}</span>
+                </div>
+                <div class="attendance__request-meta" v-if="requestDecisionCommentText(item)">
+                  <span>{{ requestDecisionCommentLabel(item) }}: {{ requestDecisionCommentText(item) }}</span>
                 </div>
                 <div class="attendance__request-meta">
                   <span>{{ tr('In', '入') }}: {{ formatDateTime(item.requested_in_at) }}</span>
@@ -6105,6 +6117,7 @@ interface AttendanceRequest {
   request_type: string
   requested_in_at: string | null
   requested_out_at: string | null
+  reason?: string | null
   status: string
   metadata?: Record<string, any>
 }
@@ -10078,6 +10091,33 @@ function selfServiceRequestSubtitle(item: AttendanceRequest): string {
   ].filter(Boolean)
   if (pieces.length > 0) return pieces.join(' · ')
   return tr('No explicit time range', '没有显式时间段')
+}
+
+function normalizeRequestNoteText(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function requestReasonText(item: AttendanceRequest): string {
+  return normalizeRequestNoteText(item.reason)
+}
+
+function requestDecisionCommentText(item: AttendanceRequest): string {
+  const metadata = item.metadata ?? {}
+  const resolution = metadata.resolution && typeof metadata.resolution === 'object'
+    ? metadata.resolution as Record<string, unknown>
+    : {}
+  return normalizeRequestNoteText(
+    resolution.comment
+      ?? metadata.rejectionComment
+      ?? metadata.rejection_comment
+      ?? metadata.rejectComment
+  )
+}
+
+function requestDecisionCommentLabel(item: AttendanceRequest): string {
+  return String(item.status || '').toLowerCase() === 'rejected'
+    ? tr('Rejection note', '驳回说明')
+    : tr('Decision note', '审批说明')
 }
 
 function requestTypeCtaLabel(value: string): string {
@@ -14407,10 +14447,28 @@ async function submitRequest() {
 }
 
 async function resolveRequest(id: string, action: 'approve' | 'reject') {
+  const payload: { comment?: string } = {}
+  if (action === 'reject') {
+    const comment = window.prompt(
+      tr('Rejection reason is required', '请填写驳回原因'),
+      '',
+    )
+    if (comment === null) return
+    const normalizedComment = comment.trim()
+    if (!normalizedComment) {
+      setStatus(
+        appendStatusContext(tr('Rejection reason is required.', '驳回原因不能为空。'), requestTimezoneContextHint.value),
+        'error',
+      )
+      return
+    }
+    payload.comment = normalizedComment
+  }
+
   try {
     const response = await apiFetch(`/api/attendance/requests/${id}/${action}`, {
       method: 'POST',
-      body: JSON.stringify({})
+      body: JSON.stringify(payload)
     })
     const data = await response.json()
     if (!response.ok || !data.ok) {

--- a/apps/web/tests/attendance-selfservice-dashboard.spec.ts
+++ b/apps/web/tests/attendance-selfservice-dashboard.spec.ts
@@ -117,6 +117,7 @@ function installOverviewMock(): void {
               request_type: 'leave',
               requested_in_at: '2026-04-15T09:00:00+08:00',
               requested_out_at: '2026-04-15T18:00:00+08:00',
+              reason: 'Family medical appointment',
               status: 'pending',
               metadata: { minutes: 480 },
             },
@@ -135,8 +136,15 @@ function installOverviewMock(): void {
               request_type: 'missed_check_in',
               requested_in_at: '2026-04-09T09:00:00+08:00',
               requested_out_at: null,
+              reason: 'Forgot to check in at the lobby kiosk',
               status: 'rejected',
-              metadata: {},
+              metadata: {
+                resolution: {
+                  action: 'reject',
+                  status: 'rejected',
+                  comment: 'Please attach lobby access evidence.',
+                },
+              },
             },
           ],
         },
@@ -403,10 +411,35 @@ describe('Attendance self-service dashboard', () => {
     expect(requestsCard).toContain('Rejected · 1')
     expect(requestsCard).toContain('In:')
     expect(requestsCard).toContain('Out:')
+    expect(requestsCard).toContain('Reason: Family medical appointment')
+    expect(requestsCard).toContain('Reason: Forgot to check in at the lobby kiosk')
+    expect(requestsCard).toContain('Rejection note: Please attach lobby access evidence.')
     expect(requestsCard).toContain('has already been approved')
     expect(requestsCard).toContain('was rejected')
     expect(actionsCard).toContain('Resolve anomaly reminders')
     expect(actionsCard).toContain('Start with missing-punch handling to resolve the current anomaly reminder.')
+  })
+
+  it('requires and submits a rejection note when rejecting an attendance request', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('Needs manager evidence')
+    try {
+      app = createApp(AttendanceView, { mode: 'overview' })
+      app.mount(container!)
+      await flushUi()
+
+      findButton(container!, 'Reject').click()
+      await flushUi()
+
+      const rejectCall = vi.mocked(apiFetch).mock.calls.find(call =>
+        String(call[0]).includes('/api/attendance/requests/request-pending/reject')
+      )
+      expect(rejectCall).toBeTruthy()
+      expect(JSON.parse(String(rejectCall?.[1]?.body))).toEqual({
+        comment: 'Needs manager evidence',
+      })
+    } finally {
+      promptSpy.mockRestore()
+    }
   })
 
   it('prefills the request form from quick actions without leaving overview', async () => {

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -3882,6 +3882,92 @@ attendanceIntegrationDescribe(
     expect((requestGetAfterDeleteRes.body as { data?: { request?: { status?: string } } } | undefined)?.data?.request?.status).toBe('cancelled')
   })
 
+  it('requires rejection comments and exposes request reason plus rejection note', async () => {
+    if (!baseUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const testUserId = `attendance-reject-note-${runSuffix}`
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(testUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin,attendance:approve`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const workDate = new Date().toISOString().slice(0, 10)
+    const requestReason = 'I need to correct the check-in time from the kiosk.'
+    const rejectionComment = 'Please attach kiosk or manager evidence.'
+    const requestCreateRes = await requestJson(`${baseUrl}/api/attendance/requests`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        workDate,
+        requestType: 'time_correction',
+        requestedInAt: new Date().toISOString(),
+        reason: requestReason,
+      }),
+    })
+    expect(requestCreateRes.status).toBe(201)
+    const createdRequest = (requestCreateRes.body as { data?: { request?: { id?: string; reason?: string } } } | undefined)?.data?.request
+    expect(createdRequest?.reason).toBe(requestReason)
+    const requestId = createdRequest?.id
+    expect(requestId).toBeTruthy()
+    if (!requestId) return
+
+    const emptyRejectRes = await requestJson(`${baseUrl}/api/attendance/requests/${requestId}/reject`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ comment: '   ' }),
+    })
+    expect(emptyRejectRes.status).toBe(400)
+    const emptyRejectBody = (emptyRejectRes.body as {
+      ok?: boolean
+      error?: { code?: string; message?: string; details?: Array<{ field?: string }> }
+    } | undefined) ?? {}
+    expect(emptyRejectBody.ok).toBe(false)
+    expect(emptyRejectBody.error?.code).toBe('VALIDATION_ERROR')
+    expect(emptyRejectBody.error?.message).toBe('Rejection comment is required')
+    expect(emptyRejectBody.error?.details?.[0]?.field).toBe('comment')
+
+    const rejectRes = await requestJson(`${baseUrl}/api/attendance/requests/${requestId}/reject`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ comment: rejectionComment }),
+    })
+    expect(rejectRes.status).toBe(200)
+    expect((rejectRes.body as { data?: { status?: string } } | undefined)?.data?.status).toBe('rejected')
+
+    const requestGetRes = await requestJson(`${baseUrl}/api/attendance/requests/${requestId}`, {
+      headers: {
+        Authorization: `Bearer ${token}`,
+      },
+    })
+    expect(requestGetRes.status).toBe(200)
+    const rejectedRequest = (requestGetRes.body as {
+      data?: {
+        request?: {
+          status?: string
+          reason?: string
+          metadata?: { resolution?: { action?: string; status?: string; comment?: string } }
+        }
+      }
+    } | undefined)?.data?.request
+    expect(rejectedRequest?.status).toBe('rejected')
+    expect(rejectedRequest?.reason).toBe(requestReason)
+    expect(rejectedRequest?.metadata?.resolution?.action).toBe('reject')
+    expect(rejectedRequest?.metadata?.resolution?.status).toBe('rejected')
+    expect(rejectedRequest?.metadata?.resolution?.comment).toBe(rejectionComment)
+  })
+
   it('returns validation errors for malformed attendance UUID route params', async () => {
     if (!baseUrl) return
 

--- a/packages/openapi/dist-sdk/index.d.ts
+++ b/packages/openapi/dist-sdk/index.d.ts
@@ -1541,10 +1541,11 @@ export interface paths {
                 };
                 cookie?: never;
             };
-            requestBody?: {
+            requestBody: {
                 content: {
                     "application/json": {
-                        comment?: string;
+                        /** @description Required rejection note shown back to the requester. */
+                        comment: string;
                         metadata?: Record<string, never>;
                     };
                 };
@@ -1568,6 +1569,7 @@ export interface paths {
                         };
                     };
                 };
+                400: components["responses"]["ValidationError"];
                 401: components["responses"]["Unauthorized"];
                 403: components["responses"]["Forbidden"];
             };

--- a/packages/openapi/dist/combined.openapi.yml
+++ b/packages/openapi/dist/combined.openapi.yml
@@ -6152,7 +6152,7 @@ paths:
           schema:
             type: string
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
@@ -6160,8 +6160,12 @@ paths:
               properties:
                 comment:
                   type: string
+                  minLength: 1
+                  description: Required rejection note shown back to the requester.
                 metadata:
                   type: object
+              required:
+                - comment
       responses:
         '200':
           description: OK
@@ -6237,6 +6241,8 @@ paths:
                         nullable: true
                         allOf:
                           - $ref: '#/components/schemas/AttendanceRecord'
+        '400':
+          $ref: '#/components/responses/ValidationError'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/packages/openapi/dist/openapi.json
+++ b/packages/openapi/dist/openapi.json
@@ -8904,19 +8904,24 @@
           }
         ],
         "requestBody": {
-          "required": false,
+          "required": true,
           "content": {
             "application/json": {
               "schema": {
                 "type": "object",
                 "properties": {
                   "comment": {
-                    "type": "string"
+                    "type": "string",
+                    "minLength": 1,
+                    "description": "Required rejection note shown back to the requester."
                   },
                   "metadata": {
                     "type": "object"
                   }
-                }
+                },
+                "required": [
+                  "comment"
+                ]
               }
             }
           }
@@ -9043,6 +9048,9 @@
                 }
               }
             }
+          },
+          "400": {
+            "$ref": "#/components/responses/ValidationError"
           },
           "401": {
             "$ref": "#/components/responses/Unauthorized"

--- a/packages/openapi/dist/openapi.yaml
+++ b/packages/openapi/dist/openapi.yaml
@@ -6152,7 +6152,7 @@ paths:
           schema:
             type: string
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
@@ -6160,8 +6160,12 @@ paths:
               properties:
                 comment:
                   type: string
+                  minLength: 1
+                  description: Required rejection note shown back to the requester.
                 metadata:
                   type: object
+              required:
+                - comment
       responses:
         '200':
           description: OK
@@ -6237,6 +6241,8 @@ paths:
                         nullable: true
                         allOf:
                           - $ref: '#/components/schemas/AttendanceRecord'
+        '400':
+          $ref: '#/components/responses/ValidationError'
         '401':
           $ref: '#/components/responses/Unauthorized'
         '403':

--- a/packages/openapi/src/paths/attendance.yml
+++ b/packages/openapi/src/paths/attendance.yml
@@ -618,14 +618,18 @@ paths:
           required: true
           schema: { type: string }
       requestBody:
-        required: false
+        required: true
         content:
           application/json:
             schema:
               type: object
               properties:
-                comment: { type: string }
+                comment:
+                  type: string
+                  minLength: 1
+                  description: Required rejection note shown back to the requester.
                 metadata: { type: object }
+              required: [comment]
       responses:
         '200':
           description: OK
@@ -686,6 +690,7 @@ paths:
                           - { $ref: '#/components/schemas/AttendanceRecord' }
         '401': { $ref: '#/components/responses/Unauthorized' }
         '403': { $ref: '#/components/responses/Forbidden' }
+        '400': { $ref: '#/components/responses/ValidationError' }
   /api/attendance/requests/{id}/cancel:
     x-plugin: plugin-attendance
     post:

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -18682,6 +18682,18 @@ module.exports = {
         return
       }
 
+      const decisionComment = normalizeOptionalText(parsed.data.comment)
+      if (action === 'reject' && !decisionComment) {
+        res.status(400).json(
+          validationErrorBody(
+            'Rejection comment is required',
+            singleValidationDetail('comment', 'Required when rejecting an attendance request')
+          )
+        )
+        return
+      }
+      const decisionActorName = getUserLabel(req, requesterId)
+
       try {
         const result = await db.transaction(async (trx) => {
           const requestRows = await trx.query(
@@ -18735,6 +18747,7 @@ module.exports = {
             ? (isFinalApproval ? 'approved' : 'pending')
             : 'rejected'
           const newVersion = Number(approval.version ?? 0) + 1
+          const resolvedAt = new Date()
 
           await trx.query(
             'UPDATE approval_instances SET status = $1, version = $2, updated_at = now() WHERE id = $3',
@@ -18755,8 +18768,8 @@ module.exports = {
               approvalId,
               action,
               requesterId,
-              getUserLabel(req, requesterId),
-              parsed.data.comment ?? null,
+              decisionActorName,
+              decisionComment,
               approval.status,
               newStatus,
               approval.version,
@@ -18767,7 +18780,6 @@ module.exports = {
             ]
           )
 
-          const resolvedAt = new Date()
           const nextMetadata = { ...requestMetadata }
           if (flowMeta.id || flowMeta.name || flowSteps.length > 0) {
             nextMetadata.approvalFlow = {
@@ -18775,6 +18787,16 @@ module.exports = {
               name: flowMeta.name,
               steps: flowSteps,
               currentStep: isFinalApproval ? currentStepIndex : currentStepIndex + 1,
+            }
+          }
+          if (isFinalApproval) {
+            nextMetadata.resolution = {
+              action,
+              status: newStatus,
+              comment: decisionComment,
+              actorId: requesterId,
+              actorName: decisionActorName,
+              resolvedAt: resolvedAt.toISOString(),
             }
           }
 


### PR DESCRIPTION
## Summary
- show submitted request reasons and final decision notes in attendance self-service request cards and the detailed request list
- require a rejection comment when rejecting attendance requests, persist it in request metadata, and return it with the request
- update the attendance OpenAPI reject contract and focused regression coverage

Closes #2011

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/attendance-selfservice-dashboard.spec.ts --watch=false
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web build
- pnpm --filter @metasheet/web lint
- pnpm run verify:multitable-openapi:parity
- git diff --check

## Notes
- Attendance integration targeted test was invoked with vitest.integration.config.ts, but this local environment has no DATABASE_URL/ATTENDANCE_TEST_DATABASE_URL, so the suite was skipped by design.