### PR TITLE
docs(multitable): close automation A5 retry governance ledger

### DIFF
--- a/docs/development/multitable-automation-retry-a5-verification-20260529.md
+++ b/docs/development/multitable-automation-retry-a5-verification-20260529.md
@@ -1,7 +1,7 @@
 # Multitable Automation A5 — Whole-execution Retry Runtime (verification) — 2026-05-29
 
 - **Slice**: A5 — runtime for `POST /api/multitable/automation-executions/:executionId/retry`. Implements the A4 scope-gate `multitable-automation-retry-scope-gate-20260529.md` (#2039). Owner opt-in given 2026-05-29 ("start A5 whole-execution retry runtime, current enabled rule + stored trigger event, admin-only, side-effect confirmation").
-- **Status**: ✅ implemented + verified (this doc). A6 convergence engine remains frozen / demand-gated.
+- **Status**: ✅ implemented + verified (this doc). Follow-up response hardening landed in #2051/#2053. A6 convergence engine remains frozen / demand-gated.
 - **Grounding**: worktree off `origin/main`. Automation is multitable-kernel (never `integration-core`); post-GATE the K3 Stage-1 blanket lock is retired (#1993), but A5 is gated by its own named opt-in (retry re-runs external side effects).
 
 ## What shipped
@@ -51,4 +51,4 @@ The new execution built by `executor.execute` carries `ruleSnapshot = the curren
 - Frontend retry button (A3 is read-only; #2039 says no button until backend + provenance + tests land — now they have, so a frontend slice could follow as its own opt-in).
 - External idempotency keys for webhook/email/DingTalk retries (#2039 D5 follow-up).
 - Re-fetch-current-record retry context (addresses the redacted-trigger limitation) — separate design.
-- **PRE-EXISTING (flagged, NOT fixed here):** `POST /sheets/:sheetId/automations/:ruleId/test` (`automation.ts:134`) does `res.json(execution)` on the raw in-memory execution. Since **A1** added `ruleSnapshot` to `AutomationExecution`, that endpoint likely serializes the raw (live-credential) snapshot the same way the retry route would have. This is an A1-era gap, not an A5 regression — out of scope for this PR; recommend a separate fix (re-fetch persisted row, or redact at serialization). Surfaced consciously.
+- **Closed after #2047:** the pre-existing `POST /sheets/:sheetId/automations/:ruleId/test` raw in-memory response gap was fixed by #2051: the route now prefers the persisted redacted row and falls back to response-level redaction while preserving the flat `AutomationExecution` shape. #2053 additionally made both `/test` and retry fail-open on persisted-row read failures, so a log-read error no longer 500s an already-completed run.

--- a/docs/development/multitable-automation-retry-scope-gate-20260529.md
+++ b/docs/development/multitable-automation-retry-scope-gate-20260529.md
@@ -1,14 +1,15 @@
 # Multitable Automation Retry Scope Gate (A4) — 2026-05-29
 
-Status: design-only scope gate / scout complete
+Status: design-only scope gate / scout complete; consumed by A5 runtime (#2047)
 Scope: `POST /api/multitable/automation-executions/:id/retry` planning only
-Runtime: not started
+Runtime: implemented later by #2047; response hardening by #2051/#2053
 Companion: `docs/development/run-governance-forward-plan-20260528.md`
 
 ## Verdict
 
 Automation retry can proceed only as a separately named A5 runtime unlock. This
-A4 document does not add runtime, route, migration, UI, or retry behavior.
+A4 document itself did not add runtime, route, migration, UI, or retry behavior;
+that later happened through the explicit A5 unlock in #2047.
 
 The key design constraint is that A1 deliberately persists redacted execution
 snapshots. Therefore A5 must not blindly replay the stored `rule_snapshot` for
@@ -28,7 +29,8 @@ Recommended A5 direction:
 
 ## Grounding
 
-Current code on `origin/main` supports A4 planning but not A5 runtime:
+At A4 authoring time, code on `origin/main` supported planning but not A5
+runtime:
 
 - `AutomationExecutor.execute()` captures `triggerEvent` and `ruleSnapshot` on
   the in-memory execution object before persistence.
@@ -154,6 +156,11 @@ fields, `automation_jobs`, or BPMN/approval bridges in A5. Retry is a whole-run
 rerun, not the convergence engine.
 
 ## A5 Minimal Implementation Shape (Future Unlock)
+
+> Closeout note (2026-05-29): A5 was unlocked and implemented by #2047 using
+> this design's current-rule + stored-trigger-event direction. #2051/#2053 then
+> closed the `/test` and retry response-redaction / log-read fail-open
+> hardening. The implementation did not unlock A6.
 
 Files likely touched by A5:
 

--- a/docs/development/multitable-automation-run-governance-development-20260527.md
+++ b/docs/development/multitable-automation-run-governance-development-20260527.md
@@ -1,11 +1,12 @@
 # Multitable Automation 运行治理开发计划（development MD · v2 · 2026-05-27）
 
-> **Closeout update · 2026-05-28**：治理半已在 `origin/main` 闭环到 A3 + admin nav。落地链路：
+> **Closeout update · 2026-05-29**：治理半已在 `origin/main` 闭环到 A3 + admin nav，且 A4/A5 retry v1 已按具名 opt-in 落地。落地链路：
 > A0 scope gate / two-gate doctrine (#1932) → A1 execution snapshot + before-persist redaction (#1937) →
 > A2 read-only runs API + C1 boundary mapping + admin-only gate (#1967 + #1973) →
-> A3 admin runs view + navigation entry (#1975 + #1983). `#1917` 另补 dead-letter error secret scrub。
-> 能力半未完成也未启动：A4 retry scope-gate 等显式需求；A5 retry runtime gated；A6 convergence-engine runtime
-> frozen / demand-gated.
+> A3 admin runs view + navigation entry (#1975 + #1983) →
+> A4 retry scope-gate (#2039) → A5 whole-execution retry runtime (#2047) →
+> HTTP serialization redaction/fail-open hardening (#2051 + #2053). `#1917` 另补 dead-letter error secret scrub。
+> A6 convergence-engine runtime 仍 frozen / demand-gated：persistent WorkflowJob、suspend/resume、branch/parallel、BPMN adapter、approval-as-job 均未启动。
 >
 > **v2 定位**：在原“运行治理”线（A0–A5）基础上，折入复审敲定的修订，使本线**不偏科**且实现阶段不踩契约坑。
 > v2 相对 v1 的实质变更（复审 Blocking/High 全部采纳）：
@@ -52,8 +53,8 @@
 | A1 | execution 快照字段（含落盘前脱敏）+ 边界映射准备 | 🟡 **S1 observability 具名解锁**（加 nullable 列 + executor 脱敏，低风险但需显式 opt-in） |
 | A2 | 只读 runs/detail API + `toWorkflowJobView` 映射 | 🟡 **S1 observability 具名解锁**（新只读 route） |
 | A3 | 前端只读 runs view | 🟡 **S1 observability 具名解锁**（新只读 UI） |
-| A4 | retry scope gate（design only） | ✅ docs；**runtime 🔒 gated** |
-| A5 | whole-execution retry runtime（+ `rerun_of`/`initiated_by` 列） | 🔒 **gated**（retry = 未来 resume 的退化特例） |
+| A4 | retry scope gate（design only） | ✅ **DONE** (#2039) |
+| A5 | whole-execution retry runtime（+ `rerun_of`/`initiated_by` 列） | ✅ **DONE** (#2047; hardened by #2051/#2053) |
 | A6 | 能力半 bridge（design only） | ✅ docs；**所有 runtime 🔒 frozen / 需求驱动** |
 
 > 复审纪律：A1/A2/A3 虽属低风险只读/可观测，**仍是 named unlock，不写成“自然 lock-safe / 只读不用审”**（staged-opt-in）。
@@ -149,17 +150,17 @@ function toWorkflowJobView(execution, step, index) {
 
 在现有 automation manager/log viewer 上增加只读 runs list：按 status/rule/sheet 筛选；展示 status（**label 取自共享 `WorkflowJobStatus` i18n 词条**）、rule name/id、triggeredBy、duration、finished_at、error；可展开 steps（C1 视图）；复用现有 support-packet builder；**不提供 Retry 按钮**（或 disabled “retry requires next gate”）。
 
-### A4 — Retry Scope Gate（后续 PR · design only）
+### A4 — Retry Scope Gate（design only）— DONE (#2039)
 
-只做设计，不写 runtime。锁定 retry 语义：仅 failed/skipped；复用原始 `trigger_event`；用 `rule_snapshot` 还是当前 rule 在 gate 决定（默认 `rule_snapshot`）；新 execution id；写 `rerun_of_execution_id`；外部副作用动作需用户确认或 idempotency key。**声明 retry = 未来 resume 的退化特例**（A6 落地后复用 resume 路径）。**并决定 §A1 标记的 business-field/PII 遮罩开放问题**（retry 重放是否暴露/遮罩业务数据）。
+设计已落地为 #2039；A5 v1 采用 **current enabled rule + stored trigger_event**，不 replay redacted `rule_snapshot`；仅 failed/skipped；新 execution id；写 `rerun_of_execution_id`；外部副作用动作需 `confirmSideEffects === true`。A5 v1 不扩展 PII masking；secret-shaped values 继续遵循 A1 redaction。retry UI、external idempotency keys、re-fetch-current-record context 都是独立后续 opt-in。
 
-### A5 — Whole-execution Retry（后续 PR · runtime 🔒 gated）
+### A5 — Whole-execution Retry（runtime）— DONE (#2047 + #2051 + #2053)
 
 ```http
 POST /api/multitable/automation-executions/:executionId/retry
 ```
 
-**本里程碑迁移加列**：`rerun_of_execution_id TEXT NULL`、`initiated_by TEXT NULL`（此时才有写入者）。从 `rule_snapshot` 重建 executor rule；复用 `trigger_event`；持久新 execution；`rerun_of_execution_id` 回链。不做步骤级 retry。**runtime 受锁，需具名解锁。**
+**本里程碑已加列**：`rerun_of_execution_id TEXT NULL`、`initiated_by TEXT NULL`。执行 current enabled rule + stored `trigger_event`；持久新 execution；`rerun_of_execution_id` 回链；admin-only + side-effect confirmation；不做步骤级 retry。#2051/#2053 补齐 `/test` 与 retry response serialization invariant：HTTP 出口只返回 persisted redacted row 或 safe fallback，不吐 raw in-memory `ruleSnapshot` / `steps`。
 
 ### A6 —（新增 · design only · 冻结 / 需求驱动）能力半 Bridge
 
@@ -214,9 +215,9 @@ pnpm --filter @metasheet/web exec vitest run --watch=false \
 
 ## 5. Assumptions
 
-- 下一个 PR 是 A0 docs-only；首个 runtime PR 是 A1（非 retry），**且 A1/A2/A3 各需 S1 named unlock**。
+- A0-A5 已落地；后续不是自动继续排期，而是按新需求触发 retry UI / idempotency / A6 scout。
 - automation 路由保持 flat 响应风格。
-- A1 新列仅含“现在写真值”的列；`rerun_of`/`initiated_by` 随 A5 落地。
+- A1 新列仅含“当时写真值”的列；`rerun_of`/`initiated_by` 已随 A5 落地。
 - **C1 `WorkflowJobStatus` 是唯一状态词汇**；本线映射到它，绝不另 fork。
 - **脱敏在落盘前**，收敛为单一 multitable/core helper，不反向 import integration-core；secret-scrub 保留业务字段，业务/PII 遮罩留 A4 决定。
 - **能力半（A6）frozen/需求驱动**；治理继承是硬契约。
@@ -231,7 +232,7 @@ pnpm --filter @metasheet/web exec vitest run --watch=false \
 | steps 前向兼容 | “持久化 superset / 过 normalize”（不自洽） | **存储不动；A2 `toWorkflowJobView` 读边界合成；测断映射器输出** |
 | graph 字段 | A1 预留 upstreamStepKey/branchIndex | **删，挪 A6** |
 | 脱敏 | 仅泛提“继承 redaction” | **落盘前脱 rule_snapshot+trigger_event+step.output/error；单脱敏器收敛；secret-only 保业务字段；PII 遮罩留 A4** |
-| A1 字段 | sheet_id/trigger_event/rule_snapshot/rerun_of/created_by/finished_at/schema_version | **ultra-narrow：去 rerun_of+created_by（→A5），其余保留** |
+| A1 字段 | sheet_id/trigger_event/rule_snapshot/rerun_of/created_by/finished_at/schema_version | **ultra-narrow：A1 去 rerun_of+created_by；A5 后续补 rerun_of+initiated_by** |
 | 锁姿态 | A2/A3“现在可做” | **A1/A2/A3 = S1 named unlock（非自然 lock-safe）** |
 | status filter | “接受两种” | **C1 规范+legacy 宽限；未来态合法但空结果** |
 | status 映射 | 表述含 no-op 三元风险 | **直接 `legacyAutomationStatusToJobStatus(step.status)`（已核实子集）** |

--- a/docs/development/multitable-automation-run-governance-todo-20260527.md
+++ b/docs/development/multitable-automation-run-governance-todo-20260527.md
@@ -1,24 +1,27 @@
 # Multitable Automation Run Governance TODO
 
 Date: 2026-05-27
-Scope: multitable automation run governance only (the "governance half")
-Status: governance half closed at A3 + admin nav (2026-05-28)
+Scope: multitable automation run governance + whole-execution retry only
+Status: A0-A5 closed through retry runtime + redaction invariant hardening (2026-05-29); A6 remains frozen / demand-gated
 Companion: multitable-automation-run-governance-development-20260527.md
 Depends on (landed): C1 contract workflow-job-contract.ts (#1889, not-wired); RFC #1885
 
-## Closeout Snapshot — 2026-05-28
+## Closeout Snapshot — 2026-05-29
 
-The governance half is complete on `origin/main`:
+The governance half and named A5 retry runtime are complete on `origin/main`:
 
 - A0 scope gate / two-gate doctrine: #1932.
 - A1 execution snapshot + before-persist redaction + consolidated backend redactor: #1937.
 - Dead-letter error message secret scrub: #1917.
 - A2 read-only runs API + C1 boundary mapping + admin-only gate: #1967 + #1973.
 - A3 admin runs view + admin navigation entry: #1975 + #1983.
+- A4 retry scope gate / design lock: #2039.
+- A5 whole-execution retry runtime: #2047.
+- A1/A5 HTTP serialization hardening: #2051 + #2053.
 
-This closeout does NOT mark the capability half complete. A4 remains a future
-retry scope-gate, A5 retry runtime remains gated, and A6 convergence-engine
-runtime remains frozen / demand-gated.
+This closeout does NOT mark the convergence engine complete. A6 remains frozen /
+demand-gated: persistent WorkflowJob runtime, suspend/resume, branch/parallel,
+BPMN adapter, and approval-as-job are still separate future unlocks.
 
 ## Doctrine — Two Gates (definition of "not lopsided")
 
@@ -55,7 +58,8 @@ The K3 Stage-1 blanket lock is retired (#1993; #1792 = M1 one-record Material Sa
 - A0: docs-only, can do now.
 - A1 / A2 / A3: S1 observability — low risk, but each still a NAMED UNLOCK
   (explicit opt-in; not "read-only so no review needed").
-- A4: docs only (design); A5 runtime gated/frozen.
+- A4 / A5: completed by explicit opt-in (#2039 + #2047); retry UI,
+  idempotency keys, and re-fetch-current-record context remain future opt-ins.
 - A6: docs only; all runtime frozen / demand-gated.
 
 ## Current Baseline
@@ -83,6 +87,12 @@ Completed by this governance-half line:
 - execution detail API — #1967.
 - platform-admin-only gate for cross-sheet runs/detail snapshots — #1973.
 - frontend admin runs view and admin navigation entry — #1975 + #1983.
+
+Completed by the named A4/A5 retry line:
+
+- retry scope gate with current-rule + stored-trigger-event decision — #2039.
+- whole-execution retry route, provenance, and side-effect confirmation — #2047.
+- HTTP response serialization invariant for `/test` + retry — #2051 + #2053.
 
 Deferred (capability half — A6, frozen/demand-gated):
 
@@ -188,28 +198,35 @@ Acceptance:
 - [x] UI tests: loading, admin gate, status filter, expanded steps, stale-response race guard.
 - [x] Existing MetaAutomationLogViewer tests still pass.
 
-### A4 — Retry Scope Gate  (lock: design only)
+### A4 — Retry Scope Gate  (lock: design only) — DONE (#2039)
 
-- [ ] Deferred until explicit retry demand / named opt-in.
-- [ ] Decide retry source: rule_snapshot vs current rule (default rule_snapshot).
-- [ ] Decide side-effect confirmation UX (explicit action / idempotency key).
-- [ ] Define audit fields + permission requirement + deleted-rule failure behavior.
-- [ ] State retry = degenerate case of future resume (A6); reuse resume path later.
-- [ ] DECIDE the A1-flagged open question: business-field/PII masking in replayed snapshots.
+- [x] Explicit retry demand / named opt-in captured.
+- [x] Decide retry source: current enabled rule + stored trigger_event (not redacted rule_snapshot).
+- [x] Decide side-effect confirmation UX: `confirmSideEffects === true`.
+- [x] Define provenance fields + admin-only permission + missing/deleted-rule failure behavior.
+- [x] State retry = whole-run rerun, not A6 suspend/resume.
+- [x] Decide the A1-flagged business-field/PII question for A5 v1: no broader PII masking;
+      secret-shaped values remain redacted per A1, re-fetch-current-record context is a future opt-in.
 
-### A5 — Whole-execution Retry  (lock: runtime gated)
+### A5 — Whole-execution Retry  (lock: runtime gated) — DONE (#2047 + #2051 + #2053)
 
-- [ ] Runtime remains gated; do not start without explicit unlock.
-- [ ] Migration: add rerun_of_execution_id TEXT NULL, initiated_by TEXT NULL (writers exist now).
-- [ ] Add POST /api/multitable/automation-executions/:executionId/retry.
-- [ ] Reconstruct executor rule from rule_snapshot; reuse trigger_event.
-- [ ] Persist new execution; link via rerun_of_execution_id; record initiated_by.
+- [x] Runtime started only after explicit unlock.
+- [x] Migration: add rerun_of_execution_id TEXT NULL, initiated_by TEXT NULL.
+- [x] Add POST /api/multitable/automation-executions/:executionId/retry.
+- [x] Execute current enabled rule with stored trigger_event; never execute persisted redacted rule_snapshot.
+- [x] Persist new execution; link via rerun_of_execution_id; record initiated_by.
+- [x] Require admin-only access + explicit side-effect confirmation.
+- [x] Fail closed for missing/non-retryable/invalid trigger/missing rule cases.
+- [x] Serialize persisted redacted row; safe fallback on log-read failure.
+- [x] Harden `/test` endpoint to follow the same response-redaction invariant.
 
 Acceptance:
 
-- [ ] Failed/skipped retry creates new execution id; original unchanged.
-- [ ] Success and failed retry both persist logs.
-- [ ] Retry rejects success/running executions.
+- [x] Failed/skipped retry creates new execution id; original unchanged.
+- [x] Retry persists logs + retry provenance.
+- [x] Retry rejects success/running executions.
+- [x] Retry rejects missing / empty / invalid trigger events without loading rule or executing actions.
+- [x] Retry response and `/test` response never serialize raw in-memory ruleSnapshot / steps.
 
 ### A6 — Capability-half Bridge  (lock: design only, frozen / demand-gated)
 

--- a/docs/development/run-governance-forward-plan-20260528.md
+++ b/docs/development/run-governance-forward-plan-20260528.md
@@ -1,6 +1,7 @@
 # 运行治理 / 收敛引擎线 — 前向开发安排（需求闸账本 · 2026-05-28）
 
 > 类型：**前向开发安排（forward plan）**，非开工清单。
+> **2026-05-29 update**：A4 retry scope-gate (#2039) + A5 whole-execution retry runtime (#2047) 已按具名 opt-in 落地；`/test` + retry HTTP serialization redaction/fail-open hardening 已由 #2051/#2053 闭合。A6 收敛引擎仍 frozen / demand-gated。
 > 配套（已收口）：`multitable-automation-run-governance-development-20260527.md` + `-todo-20260527.md`（#1987 固化）。
 > 上游契约：C1 `workflow-job-contract.ts`（#1889，landed）· 收敛 RFC #1885。
 > 锁：**K3 Stage-1 blanket 锁已退役（#1993；#1792 = M1 单条 Material Save-only PASS）→ 改用 post-GATE scoped gates（见 `k3-post-gate-scoped-governance-20260528.md`）**。这不改变本线纪律：**治理半（A0–A3）属于内核治理 / observability，已关闭**；**能力半（A4–A6）仍各受需求闸 / 独立具名 opt-in**（本线天然为 multitable 内核范畴，不依赖 integration-core / RBAC / auth），除非对应 scout 明确授权。
@@ -14,9 +15,10 @@
 | 半 | 100% = | 完成度 | 是否该现在排期 |
 |---|---|---|---|
 | **治理半**（observability：快照→脱敏→只读 API→admin UI→可达） | 运行可观测/可审计/可诊断 | **✅ 100% + 文档固化** | 否 —— 已关闭，不重开 |
-| **能力半**（收敛引擎：suspend/resume / branch / DAG / approval-as-job） | automation+approval 统一到 WorkflowJob 引擎 | **⬜ 引擎本体 0%**（契约层就位、被读边界消费；机器本体未建） | 否 —— **受需求闸，未触发即过早工程** |
+| **Retry 能力薄片**（A4/A5：whole-execution retry） | 失败/跳过 run 可由 admin 显式确认后整 run 重跑 | **✅ 100% for A5 v1** | 否 —— 已关闭；UI/idempotency/record-refresh 另需 opt-in |
+| **收敛引擎能力半**（A6：suspend/resume / branch / DAG / approval-as-job） | automation+approval 统一到 WorkflowJob 引擎 | **⬜ 引擎本体 0%**（契约层就位、被读边界消费；机器本体未建） | 否 —— **受需求闸，未触发即过早工程** |
 
-> **grounded 2026-05-28**：`automation-executor.ts` 无 suspend/resume/branch/persist-job 任何 runtime；`/retry` 路由不存在；C1 契约仅被 `routes/automation.ts` 在 A2 读边界用作状态映射（`success→resolved`），job/suspend/branch 机器未被任何 runtime 引用。
+> **grounded 2026-05-29**：`/retry` 路由已存在且仅实现 A5 whole-execution retry；`automation-executor.ts` 仍无 suspend/resume/branch/persist-job runtime；C1 契约仅被 `routes/automation.ts` 在 A2 读边界用作状态映射（`success→resolved`），job/suspend/branch 机器未被任何 runtime 引用。
 
 **所以"接下去的开发安排" = 触发条件账本 + 不自动推进纪律，不是任务队列。**
 
@@ -39,8 +41,11 @@
 | A2 只读 runs API + C1 读边界映射 + admin-only gate | #1967 / #1973 | 9468a6816 / 0e06ebf19 |
 | A3 admin runs view + 导航入口 | #1975 / #1983 | 9e504de38 |
 | 文档固化（TODO 不再 proposed） | #1987 | e7faf9799 |
+| A4 retry scope-gate / design lock | #2039 | 06cb7bf6a |
+| A5 whole-execution retry runtime | #2047 | c83ab6ca1 |
+| `/test` + retry response redaction / fail-open hardening | #2051 / #2053 | 84fa45d12 / a3ba6afde |
 
-治理半链路完整且可达；每层继承治理。**这部分不在前向安排内。**
+治理半链路完整且可达；A5 retry v1 也已按具名 opt-in 落地。**这些部分不在前向安排内。**
 
 ---
 
@@ -48,15 +53,14 @@
 
 > 顺序是**依赖序**（前节是后节地基），**不是排期**。每节标注：触发它的真实信号、解锁后第一步、锁姿态。
 
-### A4 — Retry scope-gate（design-only）🔒 deferred
-- **触发信号**：**A3 视图（已上线）暴露出真实运营痛** —— admin 频繁看到失败 run 且需要手动重跑。A3 正是产生这个信号的仪器（见 §4）。
-- **解锁后第一步**：docs-only 设计 scout —— 定 retry 源（`rule_snapshot` vs 当前 rule，默认前者）、副作用确认 UX（idempotency key）、审计字段、**并决定 A1 标记的 business-field/PII-in-replay 遮罩开放问题**。
-- **锁姿态**：docs 本身锁安全；但产出的 retry runtime（A5）受 gate。
+### A4 — Retry scope-gate（design-only）✅ closed (#2039)
+- **已落地**：当前 enabled rule + stored trigger_event；admin-only；explicit side-effect confirmation；provenance; fail-closed matrix；A5 不 replay redacted rule_snapshot。
+- **仍不自动打开**：retry UI、external idempotency keys、re-fetch-current-record context、broader PII display policy。
 
-### A5 — Retry runtime 🔒 gated
-- **触发信号**：A4 设计获采纳 + 具名 unlock。
-- **解锁后第一步**：迁移加 `rerun_of_execution_id` / `initiated_by`（此时才有写入者）；`POST /api/multitable/automation-executions/:id/retry`；从 `rule_snapshot` 重建、复用 `trigger_event`、回链。
-- **锁姿态**：🔒 runtime，需具名 unlock。retry = 未来 resume 的退化特例（与 A6 复用恢复路径）。
+### A5 — Retry runtime ✅ closed (#2047 + #2051 + #2053)
+- **已落地**：`POST /api/multitable/automation-executions/:id/retry`；`rerun_of_execution_id` / `initiated_by`; failed/skipped only; current rule + stored trigger_event; persisted-redacted response.
+- **健壮性闭合**：`/test` 与 retry 的 HTTP serialization invariant 已闭合；log-read failure uses safe fallback, not 500.
+- **锁姿态**：本 A5 v1 closed。后续 retry UI / idempotency / live-record-context 都是新 opt-in，不属于本 closed slice。
 
 ### A6 — 收敛引擎 🔒 frozen / 需求驱动
 依赖序：**持久 WorkflowJob runtime → suspend/resume（先 webhook 后 delay）→ branch/parallel（DAG）→ BPMN compile/preview adapter → approval-as-job**。
@@ -68,11 +72,11 @@
 
 ---
 
-## 4. A3 = 需求探针（observability-first 闭环 — 本线最该被看见的设计）
+## 4. A3/A5 = 需求探针（observability + controlled replay）
 
-我们**先建可观测（A0–A3）、后建能力（A4+）**，是刻意的：
+我们**先建可观测（A0–A3）、再用具名 opt-in 建最小 replay（A4/A5）、仍不建引擎（A6）**，是刻意的：
 
-> A3 admin runs view 上线后，"运营是否真的需要 retry"从**猜测**变成**证据**。在 A3 暴露足够真实的失败-重跑痛之前，A4/A5 都是过早工程。**A3 自己就是 A4/A5 需求闸的测量仪。** 这是两闸纪律按设计运作 —— 不靠拍脑袋决定建不建引擎，靠数据。
+> A3 admin runs view 把"是否需要 retry"从猜测变成证据；A4/A5 只补 whole-execution retry v1，不进入 suspend/resume 或 branch/parallel。现在 A5 自己也是 A6 的需求探针：如果 whole-run retry 不够，才说明需要更细粒度 resume/job graph。
 
 ---
 
@@ -88,10 +92,10 @@
 
 | 角色 | 负责 | 现在状态 |
 |---|---|---|
-| **本线（run-governance）** | 治理半 | ✅ 收口，停 |
-| **本 session** | 点名 review（K3/DF/data-sources 主线优先）+ 能力半具名 opt-in 时的 scout/impl | 待命，不主动推 |
+| **本线（run-governance / retry v1）** | A0-A5 | ✅ 收口，停 |
+| **本 session** | 点名 review（K3/DF/data-sources 主线优先）+ A6 具名 opt-in 时的 scout/impl | 待命，不主动推 |
 | **并行 session** | K3 GATE 主线、DF-N/DF-T、data-sources lanes | 进行中 |
-| **Owner（你）** | 需求闸决策：是否"要 retry"（开 A4）、其余 owner 决策点（如 grid C0 已拍） | 决策位 |
+| **Owner（你）** | 需求闸决策：是否进入 retry UI/idempotency/A6 等新项；其余 owner 决策点（如 grid C0 已拍） | 决策位 |
 | **Customer / Owner** | K3 下游 scoped-gate 签核（Save 扩展 / Submit/Audit/BOM / 多条 — 间接拉动 A6 编排需求） | macro-GATE ✅ PASS（#1792 M1）；下游 scoped gates 仍待 |
 
 ---
@@ -108,4 +112,4 @@
 
 ## 8. 一句话排期
 
-**治理半已完成、文档固化、不重开。能力半（A4→A5→A6）= 依赖序就绪、但全部受需求闸，眼下不主动建任何一项。** 近期"开发安排"实质是：**本 session 待命做点名 review；A4 的解锁信号由已上线的 A3 视图去测量；A6 本就排在 K3 GATE 下游。** 触发出现 → 走 §7 流程。无触发 → 不动,这就是正确的安排。
+**治理半已完成、A5 whole-execution retry v1 已完成、文档固化后不重开。A6 收敛引擎仍 frozen / demand-gated。** 近期"开发安排"实质是：**本 session 待命做点名 review；A5 的运行效果用于判断是否需要 retry UI / idempotency / A6；A6 本就排在 K3/DF 成熟需求下游。** 触发出现 → 走 §7 流程。无触发 → 不动，这就是正确的安排。


### PR DESCRIPTION
## Summary

- mark automation run-governance A0-A5 as closed after #2039/#2047/#2051/#2053
- keep A6 convergence engine explicitly frozen / demand-gated
- update the A4 scope-gate and A5 verification docs so stale pre-runtime / pre-hardening wording no longer misleads readers

## Verification

- `git diff --check origin/main..HEAD`
- stale wording grep for old A4/A5 deferred/runtime-not-started phrases returned 0 hits
- diff name-only limited to `docs/development/`
