### PR TITLE
fix(attendance): guard payroll cycle creation

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -4184,6 +4184,8 @@
                     name="payrollCycleStartDate"
                     v-model="payrollCycleForm.startDate"
                     type="date"
+                    :class="{ 'attendance__input--invalid': payrollCycleManualPeriodRequired && !payrollCycleForm.startDate }"
+                    :aria-invalid="payrollCycleManualPeriodRequired && !payrollCycleForm.startDate ? 'true' : 'false'"
                   />
                 </label>
                 <label class="attendance__field" for="attendance-payroll-cycle-end">
@@ -4193,6 +4195,8 @@
                     name="payrollCycleEndDate"
                     v-model="payrollCycleForm.endDate"
                     type="date"
+                    :class="{ 'attendance__input--invalid': payrollCycleManualPeriodRequired && !payrollCycleForm.endDate }"
+                    :aria-invalid="payrollCycleManualPeriodRequired && !payrollCycleForm.endDate ? 'true' : 'false'"
                   />
                 </label>
                 <label class="attendance__field" for="attendance-payroll-cycle-status">
@@ -4211,15 +4215,15 @@
               <div class="attendance__admin-actions">
                 <button
                   class="attendance__btn attendance__btn--primary"
-                  :disabled="payrollCycleSaving"
+                  :disabled="payrollCycleSaving || !payrollCycleCanSave"
                   @click="savePayrollCycle"
                 >
                   {{ payrollCycleSaving ? tr('Saving...', '保存中...') : payrollCycleEditingId ? tr('Update cycle', '更新周期') : tr('Create cycle', '创建周期') }}
                 </button>
-                <button class="attendance__btn" :disabled="payrollCycleSaving" @click="loadPayrollCycleSummary">
+                <button class="attendance__btn" :disabled="payrollCycleSaving || !payrollCycleEditingId" @click="loadPayrollCycleSummary">
                   {{ tr('Load summary', '加载汇总') }}
                 </button>
-                <button class="attendance__btn" :disabled="payrollCycleSaving" @click="exportPayrollCycleSummary">
+                <button class="attendance__btn" :disabled="payrollCycleSaving || !payrollCycleEditingId" @click="exportPayrollCycleSummary">
                   {{ tr('Export CSV', '导出 CSV') }}
                 </button>
                 <button
@@ -4231,6 +4235,13 @@
                   {{ tr('Cancel edit', '取消编辑') }}
                 </button>
               </div>
+              <small
+                v-if="payrollCycleValidationHint"
+                class="attendance__field-hint attendance__field-hint--error"
+                data-payroll-cycle-validation-hint
+              >
+                {{ payrollCycleValidationHint }}
+              </small>
               <small class="attendance__field-hint">
                 {{ payrollCycleTemplateTimezoneHint }}
               </small>
@@ -7085,6 +7096,35 @@ const payrollCycleTemplateTimezoneHint = computed(() =>
 const payrollCycleGenerateTimezoneHint = computed(() =>
   `${tr('Generate timezone context', '生成时区上下文')}: ${resolvePayrollTemplateTimezoneLabel(payrollCycleGenerateForm.templateId, 'default')}`
 )
+const payrollCycleManualPeriodRequired = computed(() => !payrollCycleForm.templateId)
+const payrollCycleManualPeriodComplete = computed(() =>
+  Boolean(payrollCycleForm.startDate && payrollCycleForm.endDate)
+)
+const payrollCycleCanSave = computed(() =>
+  Boolean(payrollCycleForm.templateId) || payrollCycleManualPeriodComplete.value
+)
+const payrollCycleValidationHint = computed(() => {
+  if (!payrollCycleManualPeriodRequired.value) return ''
+  if (!payrollCycleForm.startDate && !payrollCycleForm.endDate) {
+    return tr(
+      'Select a payroll template, or enter both start and end dates for a manual cycle.',
+      '请选择计薪模板，或为手工周期填写开始和结束日期。',
+    )
+  }
+  if (!payrollCycleForm.startDate) {
+    return tr(
+      'Enter a start date for this manual payroll cycle.',
+      '请填写手工计薪周期的开始日期。',
+    )
+  }
+  if (!payrollCycleForm.endDate) {
+    return tr(
+      'Enter an end date for this manual payroll cycle.',
+      '请填写手工计薪周期的结束日期。',
+    )
+  }
+  return ''
+})
 const rotationRuleTimezoneLabel = computed(() => displayTimezone(rotationRuleForm.timezone))
 const shiftTimezoneLabel = computed(() => displayTimezone(shiftForm.timezone))
 
@@ -17170,6 +17210,14 @@ async function generatePayrollCycles() {
 }
 
 async function savePayrollCycle() {
+  if (!payrollCycleCanSave.value) {
+    setStatus(
+      payrollCycleValidationHint.value || tr('Payroll cycle dates are required.', '计薪周期日期为必填项。'),
+      'error',
+    )
+    return
+  }
+
   payrollCycleSaving.value = true
   try {
     const payload: Record<string, any> = {
@@ -17200,9 +17248,18 @@ async function savePayrollCycle() {
       throw new Error(readErrorMessage(data, tr('Failed to save payroll cycle', '保存计薪周期失败')))
     }
     adminForbidden.value = false
-    resetPayrollCycleForm()
+    const savedCycle = data.data ?? null
+    const savedCycleId = savedCycle?.id ?? payrollCycleEditingId.value
     await loadPayrollCycles()
-    setStatus(tr('Payroll cycle saved.', '计薪周期已保存。'))
+    const selectedCycle = savedCycleId
+      ? payrollCycles.value.find(item => item.id === savedCycleId) ?? savedCycle
+      : savedCycle
+    if (selectedCycle?.id) {
+      editPayrollCycle(selectedCycle)
+    } else {
+      resetPayrollCycleForm()
+    }
+    setStatus(tr('Payroll cycle saved and selected.', '计薪周期已保存并已选中。'))
   } catch (error: any) {
     setStatus(readErrorMessage(error, tr('Failed to save payroll cycle', '保存计薪周期失败')), 'error')
   } finally {
@@ -17515,6 +17572,11 @@ const holidaySectionBindings = {
   border: 1px solid #d0d0d0;
   border-radius: 6px;
   min-width: 180px;
+}
+
+.attendance__input--invalid {
+  border-color: #c0392b;
+  box-shadow: 0 0 0 1px rgba(192, 57, 43, 0.2);
 }
 
 .attendance__field--full {

--- a/apps/web/src/views/attendance/AttendancePayrollAdminSection.vue
+++ b/apps/web/src/views/attendance/AttendancePayrollAdminSection.vue
@@ -263,6 +263,8 @@
           v-model="payrollCycleForm.startDate"
           name="payrollCycleStartDate"
           type="date"
+          :class="{ 'attendance__input--invalid': payrollCycleManualPeriodRequired && !payrollCycleForm.startDate }"
+          :aria-invalid="payrollCycleManualPeriodRequired && !payrollCycleForm.startDate ? 'true' : 'false'"
         />
       </label>
       <label class="attendance__field" for="attendance-payroll-cycle-end">
@@ -272,6 +274,8 @@
           v-model="payrollCycleForm.endDate"
           name="payrollCycleEndDate"
           type="date"
+          :class="{ 'attendance__input--invalid': payrollCycleManualPeriodRequired && !payrollCycleForm.endDate }"
+          :aria-invalid="payrollCycleManualPeriodRequired && !payrollCycleForm.endDate ? 'true' : 'false'"
         />
       </label>
       <label class="attendance__field" for="attendance-payroll-cycle-status">
@@ -288,13 +292,13 @@
       </label>
     </div>
     <div class="attendance__admin-actions">
-      <button class="attendance__btn attendance__btn--primary" :disabled="payrollCycleSaving" @click="savePayrollCycle">
+      <button class="attendance__btn attendance__btn--primary" :disabled="payrollCycleSaving || !payrollCycleCanSave" @click="savePayrollCycle">
         {{ payrollCycleSaving ? tr('Saving...', '保存中...') : payrollCycleEditingId ? tr('Update cycle', '更新周期') : tr('Create cycle', '创建周期') }}
       </button>
-      <button class="attendance__btn" :disabled="payrollCycleSaving" @click="loadPayrollCycleSummary">
+      <button class="attendance__btn" :disabled="payrollCycleSaving || !payrollCycleEditingId" @click="loadPayrollCycleSummary">
         {{ tr('Load summary', '加载汇总') }}
       </button>
-      <button class="attendance__btn" :disabled="payrollCycleSaving" @click="exportPayrollCycleSummary">
+      <button class="attendance__btn" :disabled="payrollCycleSaving || !payrollCycleEditingId" @click="exportPayrollCycleSummary">
         {{ tr('Export CSV', '导出 CSV') }}
       </button>
       <button
@@ -306,6 +310,13 @@
         {{ tr('Cancel edit', '取消编辑') }}
       </button>
     </div>
+    <small
+      v-if="payrollCycleValidationHint"
+      class="attendance__field-hint attendance__field-hint--error"
+      data-payroll-cycle-validation-hint
+    >
+      {{ payrollCycleValidationHint }}
+    </small>
 
     <details class="attendance__details">
       <summary class="attendance__details-summary">{{ tr('Batch generate cycles', '批量生成周期') }}</summary>
@@ -513,6 +524,9 @@ interface PayrollBindings {
   payrollTemplateForm: PayrollTemplateFormState
   payrollCycleForm: PayrollCycleFormState
   payrollCycleGenerateForm: PayrollCycleGenerateFormState
+  payrollCycleCanSave: Readonly<Ref<boolean>>
+  payrollCycleManualPeriodRequired: Readonly<Ref<boolean>>
+  payrollCycleValidationHint: Readonly<Ref<string>>
   payrollTemplateName: (templateId?: string | null) => string
   resetPayrollTemplateForm: () => MaybePromise<void>
   editPayrollTemplate: (item: AttendancePayrollTemplate) => MaybePromise<void>
@@ -559,6 +573,9 @@ const payrollCycleSummary = props.payroll.payrollCycleSummary
 const payrollTemplateForm = props.payroll.payrollTemplateForm
 const payrollCycleForm = props.payroll.payrollCycleForm
 const payrollCycleGenerateForm = props.payroll.payrollCycleGenerateForm
+const payrollCycleCanSave = props.payroll.payrollCycleCanSave
+const payrollCycleManualPeriodRequired = props.payroll.payrollCycleManualPeriodRequired
+const payrollCycleValidationHint = props.payroll.payrollCycleValidationHint
 const payrollTemplateTimezoneOptionGroups = computed(() => buildTimezoneOptionGroups(payrollTemplateForm.timezone))
 const payrollTemplateName = props.payroll.payrollTemplateName
 const resetPayrollTemplateForm = () => props.payroll.resetPayrollTemplateForm()
@@ -624,6 +641,11 @@ const exportPayrollCycleSummary = () => props.payroll.exportPayrollCycleSummary(
 
 .attendance__field--checkbox {
   justify-content: flex-end;
+}
+
+.attendance__input--invalid {
+  border-color: #c0392b;
+  box-shadow: 0 0 0 1px rgba(192, 57, 43, 0.2);
 }
 
 .attendance__btn {
@@ -709,6 +731,10 @@ const exportPayrollCycleSummary = () => props.payroll.exportPayrollCycleSummary(
 .attendance__field-hint {
   color: #666;
   font-size: 12px;
+}
+
+.attendance__field-hint--error {
+  color: #c0392b;
 }
 
 .attendance__payroll-summary-fields {

--- a/apps/web/src/views/attendance/useAttendanceAdminPayroll.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminPayroll.ts
@@ -376,6 +376,36 @@ export function useAttendanceAdminPayroll({
     metadata: '{}',
   })
 
+  const payrollCycleManualPeriodRequired = computed(() => !payrollCycleForm.templateId)
+  const payrollCycleManualPeriodComplete = computed(() =>
+    Boolean(payrollCycleForm.startDate && payrollCycleForm.endDate)
+  )
+  const payrollCycleCanSave = computed(() =>
+    Boolean(payrollCycleForm.templateId) || payrollCycleManualPeriodComplete.value
+  )
+  const payrollCycleValidationHint = computed(() => {
+    if (!payrollCycleManualPeriodRequired.value) return ''
+    if (!payrollCycleForm.startDate && !payrollCycleForm.endDate) {
+      return tr(
+        'Select a payroll template, or enter both start and end dates for a manual cycle.',
+        '请选择计薪模板，或为手工周期填写开始和结束日期。',
+      )
+    }
+    if (!payrollCycleForm.startDate) {
+      return tr(
+        'Enter a start date for this manual payroll cycle.',
+        '请填写手工计薪周期的开始日期。',
+      )
+    }
+    if (!payrollCycleForm.endDate) {
+      return tr(
+        'Enter an end date for this manual payroll cycle.',
+        '请填写手工计薪周期的结束日期。',
+      )
+    }
+    return ''
+  })
+
   function resetPayrollTemplateForm() {
     payrollTemplateEditingId.value = null
     payrollTemplateForm.name = ''
@@ -671,6 +701,14 @@ export function useAttendanceAdminPayroll({
   }
 
   async function savePayrollCycle() {
+    if (!payrollCycleCanSave.value) {
+      setStatus(
+        payrollCycleValidationHint.value || tr('Payroll cycle dates are required.', '计薪周期日期为必填项。'),
+        'error',
+      )
+      return
+    }
+
     payrollCycleSaving.value = true
     try {
       const payload: Record<string, any> = {
@@ -701,9 +739,18 @@ export function useAttendanceAdminPayroll({
         throw new Error(extractErrorMessage(data, tr('Failed to save payroll cycle', '保存计薪周期失败')))
       }
       adminForbidden.value = false
-      resetPayrollCycleForm()
+      const savedCycle = data.data ?? null
+      const savedCycleId = savedCycle?.id ?? payrollCycleEditingId.value
       await loadPayrollCycles()
-      setStatus(tr('Payroll cycle saved.', '计薪周期已保存。'))
+      const selectedCycle = savedCycleId
+        ? payrollCycles.value.find(item => item.id === savedCycleId) ?? savedCycle
+        : savedCycle
+      if (selectedCycle?.id) {
+        editPayrollCycle(selectedCycle)
+      } else {
+        resetPayrollCycleForm()
+      }
+      setStatus(tr('Payroll cycle saved and selected.', '计薪周期已保存并已选中。'))
     } catch (error) {
       const message = error instanceof Error && error.message
         ? error.message
@@ -814,6 +861,9 @@ export function useAttendanceAdminPayroll({
     payrollTemplateForm,
     payrollCycleForm,
     payrollCycleGenerateForm,
+    payrollCycleCanSave,
+    payrollCycleManualPeriodRequired,
+    payrollCycleValidationHint,
     payrollTemplateName,
     resetPayrollTemplateForm,
     editPayrollTemplate,

--- a/apps/web/tests/AttendancePayrollAdminSection.spec.ts
+++ b/apps/web/tests/AttendancePayrollAdminSection.spec.ts
@@ -57,6 +57,9 @@ function mountSection(overrides: Partial<Record<string, unknown>> = {}) {
       endDate: '',
       status: 'open',
     }),
+    payrollCycleCanSave: ref(false),
+    payrollCycleManualPeriodRequired: ref(true),
+    payrollCycleValidationHint: ref('Select a payroll template, or enter both start and end dates for a manual cycle.'),
     payrollCycleGenerateForm: reactive({
       templateId: '',
       anchorDate: '2026-05-18',
@@ -128,5 +131,40 @@ describe('AttendancePayrollAdminSection', () => {
     await nextTick()
 
     expect(payroll.movePayrollSummaryFieldCode).toHaveBeenCalledWith('work_duration', 1)
+  })
+
+  it('shows manual cycle validation and disables summary until a cycle is selected', async () => {
+    const canSave = ref(false)
+    const editingId = ref<string | null>(null)
+    const validationHint = ref('Select a payroll template, or enter both start and end dates for a manual cycle.')
+    const { payroll } = mountSection({
+      payrollCycleCanSave: canSave,
+      payrollCycleEditingId: editingId,
+      payrollCycleValidationHint: validationHint,
+    })
+
+    const createButton = Array.from(container!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Create cycle'))
+    const loadSummaryButton = Array.from(container!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Load summary'))
+    const startInput = container!.querySelector<HTMLInputElement>('#attendance-payroll-cycle-start')
+    const endInput = container!.querySelector<HTMLInputElement>('#attendance-payroll-cycle-end')
+
+    expect(createButton?.disabled).toBe(true)
+    expect(loadSummaryButton?.disabled).toBe(true)
+    expect(startInput?.getAttribute('aria-invalid')).toBe('true')
+    expect(endInput?.getAttribute('aria-invalid')).toBe('true')
+    expect(container!.querySelector('[data-payroll-cycle-validation-hint]')?.textContent).toContain('start and end dates')
+
+    payroll.payrollCycleForm.startDate = '2026-05-01'
+    payroll.payrollCycleForm.endDate = '2026-05-31'
+    canSave.value = true
+    validationHint.value = ''
+    editingId.value = 'cycle-1'
+    await nextTick()
+
+    expect(createButton?.disabled).toBe(false)
+    expect(loadSummaryButton?.disabled).toBe(false)
+    expect(container!.querySelector('[data-payroll-cycle-validation-hint]')).toBeNull()
   })
 })

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -625,6 +625,108 @@ describe('Attendance admin regressions', () => {
     expect(container!.textContent).toContain('Open Attendance groups')
   })
 
+  it('blocks empty manual payroll cycles and selects a newly saved cycle for summary', async () => {
+    const savedCycle = {
+      id: 'cycle-new',
+      templateId: null,
+      name: 'Manual May',
+      startDate: '2026-05-01',
+      endDate: '2026-05-31',
+      status: 'open',
+    }
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      const method = String((init as { method?: string } | undefined)?.method || 'GET').toUpperCase()
+      if (url.includes('/api/attendance/payroll-cycles/cycle-new/summary')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            summary: {
+              total_days: 20,
+              total_minutes: 9600,
+              normal_days: 20,
+              late_days: 0,
+              early_leave_days: 0,
+              late_early_days: 0,
+              partial_days: 0,
+              absent_days: 0,
+              adjusted_days: 0,
+              off_days: 8,
+            },
+          },
+        })
+      }
+      if (url === '/api/attendance/payroll-cycles' && method === 'POST') {
+        return jsonResponse(200, { ok: true, data: savedCycle })
+      }
+      if (url.includes('/api/attendance/payroll-cycles')) {
+        return jsonResponse(200, { ok: true, data: { items: [savedCycle] } })
+      }
+      if (url.includes('/api/attendance/payroll-templates')) {
+        return jsonResponse(200, { ok: true, data: { items: [] } })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi()
+
+    const dataPayrollHeader = Array.from(container!.querySelectorAll<HTMLButtonElement>('.attendance__admin-nav-group-header'))
+      .find(button => button.textContent?.includes('Data & Payroll'))
+    expect(dataPayrollHeader).toBeTruthy()
+    if (dataPayrollHeader!.getAttribute('aria-expanded') === 'false') {
+      dataPayrollHeader!.click()
+      await flushUi(2)
+    }
+
+    const payrollCyclesNav = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-payroll-cycles"]')
+    expect(payrollCyclesNav).toBeTruthy()
+    payrollCyclesNav!.click()
+    await flushUi(2)
+
+    const payrollCyclesSection = container!.querySelector<HTMLElement>('[data-admin-section="attendance-admin-payroll-cycles"]')
+    expect(payrollCyclesSection).toBeTruthy()
+    const createButton = Array.from(payrollCyclesSection!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Create cycle'))
+    expect(createButton).toBeTruthy()
+    expect(createButton!.disabled).toBe(true)
+    expect(payrollCyclesSection!.querySelector('[data-payroll-cycle-validation-hint]')?.textContent).toContain('start and end dates')
+    expect(payrollCyclesSection!.querySelector<HTMLInputElement>('#attendance-payroll-cycle-start')?.getAttribute('aria-invalid')).toBe('true')
+
+    setInput(payrollCyclesSection!, '#attendance-payroll-cycle-name', 'Manual May')
+    setInput(payrollCyclesSection!, '#attendance-payroll-cycle-start', '2026-05-01')
+    setInput(payrollCyclesSection!, '#attendance-payroll-cycle-end', '2026-05-31')
+    await flushUi(2)
+
+    expect(createButton!.disabled).toBe(false)
+    createButton!.click()
+    await flushUi(6)
+
+    const postCall = vi.mocked(apiFetch).mock.calls.find(call =>
+      String(call[0]) === '/api/attendance/payroll-cycles' &&
+      String((call[1] as { method?: string } | undefined)?.method || '').toUpperCase() === 'POST'
+    )
+    expect(postCall).toBeTruthy()
+    expect(JSON.parse(String((postCall![1] as { body?: string }).body))).toMatchObject({
+      name: 'Manual May',
+      startDate: '2026-05-01',
+      endDate: '2026-05-31',
+    })
+
+    const loadSummaryButton = Array.from(payrollCyclesSection!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Load summary'))
+    expect(loadSummaryButton?.disabled).toBe(false)
+    loadSummaryButton!.click()
+    await flushUi(6)
+
+    expect(vi.mocked(apiFetch).mock.calls.some(call =>
+      String(call[0]).includes('/api/attendance/payroll-cycles/cycle-new/summary')
+    )).toBe(true)
+    expect(payrollCyclesSection!.textContent).toContain('Cycle total minutes')
+    expect(payrollCyclesSection!.textContent).toContain('9600')
+  })
+
   it('renders attendance groups as a list-detail manager with people inside the selected group', async () => {
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)

--- a/apps/web/tests/useAttendanceAdminPayroll.spec.ts
+++ b/apps/web/tests/useAttendanceAdminPayroll.spec.ts
@@ -280,6 +280,75 @@ describe('useAttendanceAdminPayroll', () => {
     expect(options.setStatus).toHaveBeenCalledWith('Payroll cycles generated.')
   })
 
+  it('blocks empty manual payroll cycles before posting', async () => {
+    const options = createOptions()
+    const payroll = useAttendanceAdminPayroll(options)
+
+    expect(payroll.payrollCycleCanSave.value).toBe(false)
+    expect(payroll.payrollCycleValidationHint.value).toContain('start and end dates')
+
+    await payroll.savePayrollCycle()
+
+    expect(options.apiFetch).not.toHaveBeenCalled()
+    expect(options.setStatus).toHaveBeenCalledWith(
+      'Select a payroll template, or enter both start and end dates for a manual cycle.',
+      'error',
+    )
+  })
+
+  it('selects a saved payroll cycle so summary actions target it immediately', async () => {
+    const savedCycle = {
+      id: 'cycle-new',
+      templateId: null,
+      name: 'Manual May',
+      startDate: '2026-05-01',
+      endDate: '2026-05-31',
+      status: 'open',
+    }
+    const apiFetch = vi.fn(async (input: string, init?: RequestInit) => {
+      if (input === '/api/attendance/payroll-cycles' && init?.method === 'POST') {
+        return jsonResponse(200, { ok: true, data: savedCycle })
+      }
+      if (input === '/api/attendance/payroll-cycles?orgId=org-1') {
+        return jsonResponse(200, { ok: true, data: { items: [savedCycle] } })
+      }
+      if (input === '/api/attendance/payroll-cycles/cycle-new/summary?orgId=org-1&userId=user-1') {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            summary: {
+              total_days: 20,
+              total_minutes: 9600,
+              normal_days: 20,
+              late_days: 0,
+              early_leave_days: 0,
+              late_early_days: 0,
+              partial_days: 0,
+              absent_days: 0,
+              adjusted_days: 0,
+              off_days: 8,
+            },
+          },
+        })
+      }
+      throw new Error(`Unexpected request: ${input}`)
+    })
+    const options = createOptions({ apiFetch })
+    const payroll = useAttendanceAdminPayroll(options)
+    payroll.payrollCycleForm.name = 'Manual May'
+    payroll.payrollCycleForm.startDate = '2026-05-01'
+    payroll.payrollCycleForm.endDate = '2026-05-31'
+
+    await payroll.savePayrollCycle()
+    await payroll.loadPayrollCycleSummary()
+
+    expect(payroll.payrollCycleEditingId.value).toBe('cycle-new')
+    expect(payroll.payrollCycleForm.name).toBe('Manual May')
+    expect(payroll.payrollCycleSummary.value?.total_minutes).toBe(9600)
+    expect(apiFetch).toHaveBeenCalledWith('/api/attendance/payroll-cycles/cycle-new/summary?orgId=org-1&userId=user-1')
+    expect(options.setStatus).toHaveBeenCalledWith('Payroll cycle saved and selected.')
+  })
+
   it('loads payroll summary and exports it through the injected downloader', async () => {
     const downloadFile = vi.fn()
     const apiFetch = vi.fn(async (input: string) => {


### PR DESCRIPTION
## Summary
- disable manual payroll cycle creation until a template is selected or both manual dates are filled
- show inline validation and mark missing manual dates as invalid
- keep a saved payroll cycle selected so summary/export actions target it immediately

Fixes #2003
Fixes #2004

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/useAttendanceAdminPayroll.spec.ts tests/AttendancePayrollAdminSection.spec.ts --watch=false
- pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false --testNamePattern "payroll cycle"
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web lint
- pnpm --filter @metasheet/web exec eslint src/views/attendance/useAttendanceAdminPayroll.ts src/views/attendance/AttendancePayrollAdminSection.vue tests/useAttendanceAdminPayroll.spec.ts tests/AttendancePayrollAdminSection.spec.ts --max-warnings=0
- pnpm --filter @metasheet/web build
- git diff --check origin/main...HEAD

Note: an extra full-file ESLint probe including AttendanceView.vue still reports pre-existing unrelated unused-variable/v-html findings outside this change. The repo lint script passed.