### PR TITLE
feat(integration): DF-T3b-2a resolver wire into target preview + resolved-record parity

### DIFF
--- a/docs/development/data-factory-df-t3b-2a-resolver-wire-parity-development-20260529.md
+++ b/docs/development/data-factory-df-t3b-2a-resolver-wire-parity-development-20260529.md
@@ -1,0 +1,128 @@
+# DF-T3b-2a — resolver wire into target preview + resolved-record schema parity + three-state fail-closed — development verification (2026-05-29)
+
+> Second slice of DF-T3b ([#2048](docs/development/data-factory-df-t3b-reference-resolver-design-20260529.md)
+> design; resolver = #2055). Wires the T3b-1 pure resolver into the composed Save body and locks
+> **preview ≡ Save byte-parity** for a `from_reference_table` reference. The live mapping-sheet
+> bulk-read / fuller pipeline wiring is **DF-T3b-2b** (a separate opt-in).
+
+## Locked scope (owner-set)
+
+In:
+- **Resolver wire into the target preview** — `from_reference_table` in `buildTargetPayloadPreview`
+  (the operator/DF-T2c surface) now resolves a per-material reference via an injected mapping index
+  instead of the old uniform `raw = rule.value` scalar (the #1824 limit).
+- **Resolved-record schema parity** — a shared step materializes the resolved reference INTO the
+  record; the parity test proves it composes **byte-identically** through the schema-path preview and
+  the real adapter Save.
+- **Three-state fail-closed** — `unresolved` / `ambiguous` / `incomplete` all block both compose paths
+  via the single `status !== 'resolved'` gate.
+
+Explicitly **out** (DF-T3b-2b / later):
+- ❌ No live source-adapter bulk-read (indexes are injected; the route does **not** source them yet).
+- ❌ No fuller pipeline wiring; ❌ no K3 write / Submit / Audit / BOM / multi-record; ❌ no UI /
+  authoring / import / export; ❌ no frontend change.
+
+## Architecture decisions (grounded, owner-confirmed)
+
+- **Option (a) + single-representation.** The resolved `{FNumber|FName}` / `{FID|FName}` **rides in the
+  record** and flows through the **existing** preset schema untouched (`applyReferenceShape` passes
+  objects through) — **no new schema descriptor**, avoiding the dual-representation drift DF-T1-0 was
+  built to kill.
+- **The operator surface is `buildTargetPayloadPreview` (fieldRules path), not the schema path** the
+  named parity test exercises. Wiring resolution only into the schema path would pass the named test
+  while the operator preview never resolved (wire-vs-fixture trap) — so `buildTargetPayloadPreview`
+  is wired **and** has its own direct tests (`http-routes.test.cjs`).
+- **Fail-closed = a placeholder sentinel, not a drop.** The schema-path preview does pure projection
+  with **no bodyTemplate**, and the adapter Save only throws on `findUnfilledPlaceholders` (an absent
+  field is silently omitted). So a *dropped* field would NOT fail-close either side. Instead a
+  non-resolved status sets the target field to `UNRESOLVED_PLACEHOLDER = '<unresolved>'` (a bare `<…>`
+  token) → `findUnfilledPlaceholders` fires on **both** sides with the same
+  `K3_WISE_PRESET_PLACEHOLDER_UNFILLED` code → **identical disposition** (preview `valid:false`, Save
+  throws). Reuses the existing machinery; no parallel error channel.
+
+## What shipped
+
+- `lib/reference-mapping-resolver.cjs` (T3b-1 module, extended):
+  - `UNRESOLVED_PLACEHOLDER` (exported sentinel constant).
+  - `resolveReferenceRuleValue(indexes, rule, sourceCode)` → `{ value, outcome }` — the **single
+    shared per-field decision** called by BOTH `buildTargetPayloadPreview` and the record materializer,
+    so the two surfaces cannot diverge on the composed value. `value` = the resolved object on
+    `resolved`, else `UNRESOLVED_PLACEHOLDER`.
+  - `resolveReferenceRulesIntoRecord(record, rules, indexes)` → `{ record, outcomes }` — materializes
+    the resolved object (or sentinel) into a record; pure, reads `sourceField` / writes `targetField`
+    via **`getPath`/`setPath`** — the SAME path semantics the operator preview uses (see P1 below).
+- `lib/http-routes.cjs`:
+  - `normalizeFieldRules` accepts an optional `domain` (selects the mapping index for a
+    `from_reference_table` rule).
+  - `buildTemplatePreview` / `buildTargetPayloadPreview` accept a **server-side `options` param**
+    (`options.referenceMappingIndexes`) — indexes are NOT read from the client body (un-injectable).
+  - `from_reference_table` resolves via the shared `resolveReferenceRuleValue`; non-resolved →
+    sentinel → fail-closed; a **values-free** `referenceResolutions` evidence array
+    (`field`/`domain`/`sourceCodePresent`/`errorType`) is added to `targetPayloadPreview`.
+- Tests: `reference-mapping-resolver.test.cjs` (+ materializer / shared-fn / 3-state), the keystone
+  `k3-save-body-composer.parity.test.cjs` (+ resolved-record parity + 3-state fail-closed + desync),
+  `http-routes.test.cjs` (+ operator-surface resolution).
+
+## `from_reference_table` semantics change — safe
+
+Changed from "pre-resolved scalar (`raw = rule.value`)" to "resolve via mapping index". Verified **zero
+scalar-dependent producers** exist (`rg from_reference_table`): it was only the enum membership, the
+`raw = rule.value` line, a TS union, and comments. The DF-T2 authoring UI uses `preserve_template` for
+references and never emits `from_reference_table`, so nothing relied on the old behavior.
+
+## Tests + negative controls
+
+Parity (the keystone) has **two regimes**, mirroring `testPlaceholderParity`:
+- **resolved** → `deepEqual(preview.payload, capturedAdapterSaveBody)` (byte-parity).
+- **non-resolved** (all 3) → the Save *throws* (no body) so we assert identical **disposition**:
+  preview `valid:false` + adapter `upsert` errors `K3_WISE_PRESET_PLACEHOLDER_UNFILLED`.
+
+Negative controls:
+1. **Wire** (Edit-revert) — make `buildTargetPayloadPreview` ignore the injected index → the operator
+   resolve test fails (proves the wire is load-bearing, not green-but-absent).
+2. **Sentinel** (Edit-revert) — set `UNRESOLVED_PLACEHOLDER = ''` (≈ a drop) → the fail-closed
+   assertions break on BOTH the parity test and the operator preview (proves the sentinel — not a drop
+   — is what fail-closes both sides).
+3. **Desync** (permanent test) — resolve the two sides with different indexes → `notDeepEqual` (proves
+   the byte-parity assertion catches a preview/Save resolver divergence; not vacuous).
+4. **Nested sourceField** (Edit-revert) — revert the materializer read to flat `out[sourceField]` → the
+   nested-sourceField test fails (proves the path-semantics fix below is load-bearing).
+5. **Overlap read-snapshot** (Edit-revert) — revert the materializer read to `getPath(out, …)` (the
+   mutated record) → the overlap tests (resolver-level + cross-path) fail (proves the read-snapshot fix).
+
+## P1 (owner review) — fixed: sourceField extraction divergence
+
+The shared **decision** (`resolveReferenceRuleValue`) was shared, but the **sourceCode extraction**
+before it was not: the operator preview read `getPath(input.sourceRecord, rule.sourceField)` (nested)
+while the materializer read flat `out[sourceField]`. A nested `sourceField` (e.g. `source.unitGroup`)
+therefore resolved in the preview but **sentinel'd** in the materializer — a latent preview-green /
+Save-fail-closed divergence that would surface when T3b-2b wires the Save side. Fixed by reading
+`sourceField` / writing `targetField` through `getPath`/`setPath` in `resolveReferenceRulesIntoRecord`
+— identical path semantics on both surfaces. A permanent cross-path test (`testNestedSourceFieldNoDivergence`)
+asserts the preview path and the materializer resolve the **same** object for a nested `sourceField`,
+so "the shared decision cannot diverge" is now genuinely closed (extraction + decision).
+
+## P2 (owner review) — fixed: read-snapshot divergence on overlapping rules
+
+Same class as P1, one level deeper. The materializer read its source from `out` — which **earlier rules
+rewrite** — while the operator preview always reads the **original** `input.sourceRecord`. So overlapping
+source/target rules diverged (repro: rule 1 `targetField:'source.unitGroup'` writes the path rule 2
+reads → preview `resolved`, materializer `unresolved`). Fixed: `resolveReferenceRulesIntoRecord` now
+reads every `sourceField` from the **original record snapshot** and writes to an **independent deep
+clone** (`out` no longer shares mutable refs with the read source, so a nested overlapping write can't
+corrupt a later read — and the input record is never mutated). Locked by a resolver-level overlap test
+(both rules resolve + input unmutated) and a cross-path `testSourceTargetOverlapNoDivergence`
+(preview ≡ materializer with overlapping rules). **Invariant: read snapshot = original `sourceRecord`;
+write = materialized `out`.**
+
+Affected + adjacent suites green: `reference-mapping-resolver`, `reference-mapping-templates`,
+`k3-save-body-composer.parity`, `http-routes`, `k3-df-t1-target-payload-preview`,
+`connector-template-derive`, `payload-redaction`, `k3-wise-adapters`, `http-routes-plm-k3wise-poc`,
+`e2e-plm-k3wise-writeback`, `adapter-contracts`.
+
+## Next (gated, separate opt-in)
+
+- **DF-T3b-2b** — source the mapping indexes from a **live mapping-sheet bulk-read** via the staging
+  source-adapter (the injection seam `options.referenceMappingIndexes` is shaped to be populated, not
+  replaced) + the fuller pipeline wiring so the resolver feeds the real Save end-to-end. Exact read
+  call shape per #2048 (confirm-at-impl).

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -1943,8 +1943,58 @@ async function testTemplatesDeriveRoute() {
   assert.equal(res.body.error.code, 'TEMPLATE_DERIVE_REJECTED')
 }
 
+// DF-T3b-2a: the OPERATOR preview surface (buildTargetPayloadPreview) must actually RESOLVE a
+// from_reference_table reference via the injected (server-side) mapping index — the parity test does
+// not exercise this path, so it gets its own coverage here (wire-vs-fixture: test the real surface).
+async function testTemplatePreviewReferenceMappingResolution() {
+  const { buildTargetPayloadPreview } = httpRoutes.__internals
+  const { buildReferenceMappingIndex } = require(path.join(__dirname, '..', 'lib', 'reference-mapping-resolver.cjs'))
+  const { K3_REFERENCE_MAPPING_TEMPLATES } = require(path.join(__dirname, '..', 'lib', 'reference-mapping-templates.cjs'))
+  const unitGroup = K3_REFERENCE_MAPPING_TEMPLATES.find((t) => t.domain === 'unit-group')
+  const input = {
+    bodyKey: 'Data',
+    payloadTemplate: {},
+    sourceRecord: { unitGroupSourceCode: 'STD' },
+    fieldRules: [{ targetField: 'FUnitGroupID', sourceType: 'from_reference_table', domain: 'unit-group', sourceField: 'unitGroupSourceCode', shape: 'object-passthrough', completeness: 'require-fnumber-fname' }],
+  }
+
+  // happy: injected index → resolved object in the payload; evidence 'resolved'; valid; values-free
+  const okIndexes = { 'unit-group': buildReferenceMappingIndex(unitGroup, [{ sourceCode: 'STD', fNumber: '10', fName: 'Each', enabled: true }]) }
+  const ok = buildTargetPayloadPreview(input, { referenceMappingIndexes: okIndexes })
+  // field-level asserts (the payload uses null-prototype objects from setPath — fine for JSON/wire,
+  // but node:assert/strict deepEqual is prototype-sensitive).
+  assert.equal(ok.payload.Data.FUnitGroupID.FNumber, '10', 'operator preview resolves FNumber via the injected index')
+  assert.equal(ok.payload.Data.FUnitGroupID.FName, 'Each', 'operator preview resolves FName via the injected index')
+  assert.equal(ok.valid, true)
+  const okRes = ok.targetPayloadPreview.referenceResolutions
+  assert.equal(okRes.length, 1)
+  assert.equal(okRes[0].status, 'resolved')
+  assert.equal(okRes[0].field, 'FUnitGroupID')
+  assert.equal(okRes[0].evidence.errorType, undefined, 'resolved → no errorType')
+  assert.ok(!JSON.stringify(okRes[0].evidence).includes('Each') && !JSON.stringify(okRes[0].evidence).includes('STD'), 'resolution evidence is values-free')
+
+  // three non-resolved statuses → valid:false (fail-closed via placeholder) + correct errorType
+  const cases = {
+    unresolved: [{ sourceCode: 'OTHER', fNumber: '9', fName: 'X', enabled: true }],
+    ambiguous: [{ sourceCode: 'STD', fNumber: 'A', fName: 'X', enabled: true }, { sourceCode: 'STD', fNumber: 'B', fName: 'Y', enabled: true }],
+    'incomplete-row': [{ sourceCode: 'STD', fNumber: 'A', enabled: true }],
+  }
+  for (const [errorType, rows] of Object.entries(cases)) {
+    const out = buildTargetPayloadPreview(input, { referenceMappingIndexes: { 'unit-group': buildReferenceMappingIndex(unitGroup, rows) } })
+    assert.equal(out.valid, false, `${errorType}: operator preview fail-closed`)
+    assert.ok(out.placeholderErrors.some((e) => /FUnitGroupID/.test(e.field)), `${errorType}: placeholder fires on the unresolved field`)
+    assert.equal(out.targetPayloadPreview.referenceResolutions[0].evidence.errorType, errorType, `${errorType}: evidence errorType`)
+  }
+
+  // no index injected (T3b-2a default; live bulk-read is T3b-2b) → unresolved fail-closed
+  const noIdx = buildTargetPayloadPreview(input, {})
+  assert.equal(noIdx.valid, false, 'no index → unresolved fail-closed')
+  assert.equal(noIdx.targetPayloadPreview.referenceResolutions[0].evidence.errorType, 'unresolved')
+}
+
 async function main() {
   await testUnauthenticatedWriteRequestIsRejected()
+  await testTemplatePreviewReferenceMappingResolution()
   await testExternalSystemRoutes()
   await testExternalSystemUpsertPreservesObjectSchema()
   await testExternalSystemTestPersistsFailureAndPreservesInactive()

--- a/plugins/plugin-integration-core/__tests__/k3-save-body-composer.parity.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/k3-save-body-composer.parity.test.cjs
@@ -12,9 +12,15 @@ const { createK3WiseWebApiAdapter } = require('../lib/adapters/k3-wise-webapi-ad
 const { __internals: httpInternals } = require('../lib/http-routes.cjs')
 const { getK3WiseMaterialProfile, getK3WiseDocumentObjectDefaults } = require('../lib/adapters/k3-wise-document-templates.cjs')
 const composer = require('../lib/adapters/k3-save-body-composer.cjs')
+// DF-T3b-2a: resolve from_reference_table INTO the record, then prove the resolved record composes
+// BYTE-IDENTICALLY through the schema-path preview and the real adapter Save.
+const { K3_REFERENCE_MAPPING_TEMPLATES } = require('../lib/reference-mapping-templates.cjs')
+const { buildReferenceMappingIndex, resolveReferenceRulesIntoRecord, UNRESOLVED_PLACEHOLDER } = require('../lib/reference-mapping-resolver.cjs')
 
 const PROFILE_ID = 'material-k3wise-customer-profile-v1'
-const { buildTemplatePreview } = httpInternals
+const { buildTemplatePreview, buildTargetPayloadPreview } = httpInternals
+const UNIT_GROUP_TEMPLATE = K3_REFERENCE_MAPPING_TEMPLATES.find((t) => t.domain === 'unit-group') // BY_NUMBER
+const REF_RULE = { targetField: 'FUnitGroupID', domain: 'unit-group', sourceField: 'unitGroupSourceCode' }
 
 function jsonResponse(status, body) {
   return { ok: status >= 200 && status < 300, status, headers: { get: () => null }, async text() { return JSON.stringify(body) } }
@@ -187,8 +193,111 @@ async function testCustomerProfileDropsFBaseUnitID() {
   assert.equal(body.Data.FModel, 'M-1', 'FModel scalar still composes')
 }
 
+// ---- DF-T3b-2a Parity 4: resolved-record byte-parity — a from_reference_table reference resolved
+//      INTO the record composes identically on the preview schema path and the adapter Save ----
+async function testResolvedRecordParity() {
+  const indexes = { 'unit-group': buildReferenceMappingIndex(UNIT_GROUP_TEMPLATE, [
+    { sourceCode: 'STD', fNumber: '10', fName: 'Each', enabled: true },
+  ]) }
+  const source = { FNumber: 'MAT-RM1', FName: 'Bolt', unitGroupSourceCode: 'STD' }
+  const { record: resolved } = resolveReferenceRulesIntoRecord(source, [REF_RULE], indexes)
+  // sanity: the resolver materialized the FULL reference object into the record
+  assert.deepEqual(resolved.FUnitGroupID, { FNumber: '10', FName: 'Each' }, 'resolver materialized the reference into the record')
+
+  const { body } = await adapterSaveBody(resolved)
+  const preview = previewPayload(resolved)
+  const expected = { Data: { FNumber: 'MAT-RM1', FName: 'Bolt', FUnitGroupID: { FNumber: '10', FName: 'Each' } } }
+  assert.deepEqual(body, expected, 'adapter Save composes the resolved reference (unitGroupSourceCode dropped — not in schema)')
+  assert.deepEqual(preview.payload, body, 'DF-T3b-2a: preview ≡ adapter Save with a from_reference_table-resolved reference')
+  assert.equal(preview.valid, true)
+}
+
+// ---- DF-T3b-2a Parity 5: all THREE non-resolved statuses → IDENTICAL fail-closed disposition on
+//      both sides (preview valid:false + adapter Save throws K3_WISE_PRESET_PLACEHOLDER_UNFILLED).
+//      Mirrors testPlaceholderParity — the Save throws (no body) so we assert disposition, not bytes. ----
+async function testNonResolvedFailClosedParity() {
+  const cases = {
+    unresolved: [{ sourceCode: 'OTHER', fNumber: '9', fName: 'X', enabled: true }],
+    ambiguous: [
+      { sourceCode: 'STD', fNumber: 'A', fName: 'X', enabled: true },
+      { sourceCode: 'STD', fNumber: 'B', fName: 'Y', enabled: true },
+    ],
+    'incomplete-row': [{ sourceCode: 'STD', fNumber: 'A', enabled: true }], // missing fName
+  }
+  for (const [label, rows] of Object.entries(cases)) {
+    const indexes = { 'unit-group': buildReferenceMappingIndex(UNIT_GROUP_TEMPLATE, rows) }
+    const { record: resolved } = resolveReferenceRulesIntoRecord({ FNumber: 'MAT-X', FName: 'Y', unitGroupSourceCode: 'STD' }, [REF_RULE], indexes)
+    assert.equal(resolved.FUnitGroupID, UNRESOLVED_PLACEHOLDER, `${label}: target field carries the sentinel`)
+
+    const { result, body } = await adapterSaveBody(resolved)
+    assert.equal(body, null, `${label}: adapter made NO Save call (fail-closed before HTTP)`)
+    assert.equal(result.written, 0, `${label}: nothing written`)
+    assert.equal(result.errors[0].code, 'K3_WISE_PRESET_PLACEHOLDER_UNFILLED', `${label}: Save throws the placeholder code`)
+
+    const preview = previewPayload(resolved)
+    assert.equal(preview.valid, false, `${label}: preview reports invalid`)
+    assert.ok(preview.placeholderErrors.some((e) => /FUnitGroupID/.test(e.field)), `${label}: preview names the unresolved field`)
+    assert.ok(preview.placeholderErrors.every((e) => e.code === 'K3_WISE_PRESET_PLACEHOLDER_UNFILLED'),
+      `${label}: preview placeholder code matches the Save throw code (identical disposition)`)
+  }
+}
+
+// ---- DF-T3b-2a Parity 6: desync NEGATIVE CONTROL — resolving the two sides with DIFFERENT indexes
+//      must break byte-parity, proving the assertion catches a preview/Save resolver divergence. ----
+async function testDesyncNegativeControl() {
+  const source = { FNumber: 'MAT-DS', FName: 'Z', unitGroupSourceCode: 'STD' }
+  const indexA = { 'unit-group': buildReferenceMappingIndex(UNIT_GROUP_TEMPLATE, [{ sourceCode: 'STD', fNumber: '10', fName: 'Each', enabled: true }]) }
+  const indexB = { 'unit-group': buildReferenceMappingIndex(UNIT_GROUP_TEMPLATE, [{ sourceCode: 'STD', fNumber: '99', fName: 'Box', enabled: true }]) }
+  const previewResolved = resolveReferenceRulesIntoRecord(source, [REF_RULE], indexA).record
+  const saveResolved = resolveReferenceRulesIntoRecord(source, [REF_RULE], indexB).record
+  const { body } = await adapterSaveBody(saveResolved)
+  const preview = previewPayload(previewResolved)
+  assert.notDeepEqual(preview.payload, body, 'desync (different indexes) → byte-parity assertion catches the divergence')
+}
+
+// ---- DF-T3b-2a Parity 7: NESTED sourceField — the operator preview and the record materializer must
+//      extract the sourceCode with the SAME path semantics (getPath), so they resolve the SAME object.
+//      Guards the "shared decision cannot diverge" claim against extraction drift (flat vs nested). ----
+function testNestedSourceFieldNoDivergence() {
+  const indexes = { 'unit-group': buildReferenceMappingIndex(UNIT_GROUP_TEMPLATE, [{ sourceCode: 'STD', fNumber: '10', fName: 'Each', enabled: true }]) }
+  const nestedRule = { targetField: 'FUnitGroupID', domain: 'unit-group', sourceField: 'source.unitGroup' }
+  const sourceRecord = { source: { unitGroup: 'STD' } }
+
+  const preview = buildTargetPayloadPreview(
+    { bodyKey: 'Data', payloadTemplate: {}, sourceRecord, fieldRules: [{ ...nestedRule, sourceType: 'from_reference_table', shape: 'object-passthrough', completeness: 'require-fnumber-fname' }] },
+    { referenceMappingIndexes: indexes },
+  )
+  const { record } = resolveReferenceRulesIntoRecord(sourceRecord, [nestedRule], indexes)
+  assert.equal(preview.payload.Data.FUnitGroupID.FNumber, '10', 'preview resolves a nested sourceField (getPath)')
+  assert.equal(record.FUnitGroupID.FNumber, '10', 'materializer resolves the SAME nested sourceField (no flat-vs-nested divergence)')
+  assert.deepEqual(preview.payload.Data.FUnitGroupID, record.FUnitGroupID, 'preview path ≡ materializer for a nested sourceField')
+}
+
+// ---- DF-T3b-2a Parity 8: OVERLAPPING source/target rules — the operator preview always reads the
+//      original sourceRecord; the materializer must too (read snapshot = original, write = clone), so an
+//      earlier rule writing a path a later rule reads cannot diverge between the two surfaces. ----
+function testSourceTargetOverlapNoDivergence() {
+  const indexes = { 'unit-group': buildReferenceMappingIndex(UNIT_GROUP_TEMPLATE, [{ sourceCode: 'STD', fNumber: '10', fName: 'Each', enabled: true }]) }
+  const overlapRules = [
+    { targetField: 'source.unitGroup', domain: 'unit-group', sourceField: 'source.unitGroup' }, // rule 1 writes the read path
+    { targetField: 'FUnitGroupID', domain: 'unit-group', sourceField: 'source.unitGroup' }, // rule 2 reads it
+  ]
+  const sourceRecord = { source: { unitGroup: 'STD' } }
+  const preview = buildTargetPayloadPreview(
+    { bodyKey: 'Data', payloadTemplate: {}, sourceRecord, fieldRules: overlapRules.map((r) => ({ ...r, sourceType: 'from_reference_table', shape: 'object-passthrough', completeness: 'require-fnumber-fname' })) },
+    { referenceMappingIndexes: indexes },
+  )
+  const { record } = resolveReferenceRulesIntoRecord(sourceRecord, overlapRules, indexes)
+  assert.equal(preview.payload.Data.FUnitGroupID.FNumber, '10', 'preview resolves FUnitGroupID (reads original snapshot)')
+  assert.equal(record.FUnitGroupID.FNumber, '10', 'materializer resolves FUnitGroupID identically (reads original, writes clone)')
+  assert.deepEqual(preview.payload.Data.FUnitGroupID, record.FUnitGroupID, 'preview ≡ materializer with overlapping source/target rules')
+  assert.equal(sourceRecord.source.unitGroup, 'STD', 'the input sourceRecord is not mutated')
+}
+
 async function main() {
   await testScalarShapeParity()
+  testNestedSourceFieldNoDivergence()
+  testSourceTargetOverlapNoDivergence()
   await testObjectPassthroughParity()
   await testPlaceholderParity()
   await testPreviewIsNoWrite()
@@ -197,7 +306,10 @@ async function main() {
   testIdentifierEmptyStringFallback()
   testNoDivergentDuplicate()
   await testCustomerProfileDropsFBaseUnitID()
-  console.log('✓ k3-save-body-composer.parity: preview ≡ adapter Save (shape/passthrough/placeholder), nested-path preserved, identifier-fallback, no-write, opt-in, no divergent duplicate, customer-profile drops FBaseUnitID')
+  await testResolvedRecordParity()
+  await testNonResolvedFailClosedParity()
+  await testDesyncNegativeControl()
+  console.log('✓ k3-save-body-composer.parity: preview ≡ adapter Save (shape/passthrough/placeholder), nested-path preserved, identifier-fallback, no-write, opt-in, no divergent duplicate, customer-profile drops FBaseUnitID, DF-T3b-2a resolved-record parity + 3-state fail-closed + desync neg-control')
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/__tests__/reference-mapping-resolver.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/reference-mapping-resolver.test.cjs
@@ -10,9 +10,12 @@ const path = require('node:path')
 const {
   OUTCOME,
   STATUS_TO_ERROR_TYPE,
+  UNRESOLVED_PLACEHOLDER,
   buildReferenceMappingIndex,
   resolveReference,
   resolveReferenceFromRows,
+  resolveReferenceRuleValue,
+  resolveReferenceRulesIntoRecord,
 } = require(path.join(__dirname, '..', 'lib', 'reference-mapping-resolver.cjs'))
 const { K3_REFERENCE_MAPPING_TEMPLATES, ReferenceMappingTemplateError } = require(path.join(__dirname, '..', 'lib', 'reference-mapping-templates.cjs'))
 
@@ -172,6 +175,67 @@ function main() {
     assert.deepEqual(resolveReference(idx, 'B').reference, { FNumber: '2', FName: 'Beta' })
     assert.equal(resolveReference(idx, 'C').status, OUTCOME.UNRESOLVED)
   }
+
+  // ====================== DF-T3b-2a: resolveReferenceRuleValue + resolveReferenceRulesIntoRecord ==
+
+  const unitIndex = buildReferenceMappingIndex(UNIT, [{ sourceCode: 'PCS', fNumber: '01', fName: 'Each', enabled: true }])
+  const indexes = { unit: unitIndex }
+  const rule = { targetField: 'FUnitID', domain: 'unit', sourceField: 'unitSourceCode' }
+
+  // ---- shared decision fn: resolved → reference object; non-resolved → UNRESOLVED_PLACEHOLDER ----
+  {
+    const ok = resolveReferenceRuleValue(indexes, rule, 'PCS')
+    assert.deepEqual(ok.value, { FNumber: '01', FName: 'Each' }, 'resolved → reference object as the value')
+    assert.equal(ok.outcome.status, OUTCOME.RESOLVED)
+    assert.equal(resolveReferenceRuleValue(indexes, rule, 'NOPE').value, UNRESOLVED_PLACEHOLDER, 'unresolved → sentinel')
+    assert.equal(resolveReferenceRuleValue({}, rule, 'PCS').value, UNRESOLVED_PLACEHOLDER, 'no index for domain → sentinel')
+    assert.equal(resolveReferenceRuleValue(indexes, { targetField: 'X' }, 'PCS').value, UNRESOLVED_PLACEHOLDER, 'no domain → sentinel')
+  }
+
+  // ---- materialize into record: resolved sets the full object; sourceCode field preserved ----
+  {
+    const { record, outcomes } = resolveReferenceRulesIntoRecord({ FNumber: 'MAT-1', unitSourceCode: 'PCS' }, [rule], indexes)
+    assert.deepEqual(record.FUnitID, { FNumber: '01', FName: 'Each' }, 'targetField set to resolved object')
+    assert.equal(record.unitSourceCode, 'PCS', 'sourceCode field left intact (schema drops it later)')
+    assert.equal(record.FNumber, 'MAT-1', 'other fields preserved')
+    assert.equal(outcomes[0].status, OUTCOME.RESOLVED)
+  }
+
+  // ---- materialize: all THREE non-resolved statuses → UNRESOLVED_PLACEHOLDER + correct errorType ----
+  {
+    const cases = [
+      { rows: [{ sourceCode: 'OTHER', fNumber: '9', fName: 'X', enabled: true }], sc: 'PCS', status: OUTCOME.UNRESOLVED, errorType: 'unresolved' },
+      { rows: [{ sourceCode: 'PCS', fNumber: 'A', fName: 'X', enabled: true }, { sourceCode: 'PCS', fNumber: 'B', fName: 'Y', enabled: true }], sc: 'PCS', status: OUTCOME.AMBIGUOUS, errorType: 'ambiguous' },
+      { rows: [{ sourceCode: 'PCS', fNumber: 'A', enabled: true }], sc: 'PCS', status: OUTCOME.INCOMPLETE, errorType: 'incomplete-row' },
+    ]
+    for (const c of cases) {
+      const idx = { unit: buildReferenceMappingIndex(UNIT, c.rows) }
+      const { record, outcomes } = resolveReferenceRulesIntoRecord({ unitSourceCode: c.sc }, [rule], idx)
+      assert.equal(record.FUnitID, UNRESOLVED_PLACEHOLDER, `${c.status} → sentinel`)
+      assert.equal(outcomes[0].status, c.status)
+      assert.equal(outcomes[0].evidence.errorType, c.errorType, `${c.status} → errorType ${c.errorType}`)
+      // evidence stays values-free even in the materializer outcomes (no sourceCode value leaks)
+      assert.ok(!JSON.stringify(outcomes[0].evidence).includes(c.sc), 'materializer evidence carries no sourceCode value')
+    }
+  }
+
+  // ---- read snapshot = ORIGINAL record; write = materialized out (overlapping source/target rules
+  //      must NOT let an earlier rule's WRITE change what a later rule READS) ----
+  {
+    const idx = { 'unit-group': buildReferenceMappingIndex(byDomain['unit-group'], [{ sourceCode: 'STD', fNumber: '10', fName: 'Each', enabled: true }]) }
+    const overlapRules = [
+      { targetField: 'source.unitGroup', domain: 'unit-group', sourceField: 'source.unitGroup' }, // rule 1 writes the read path
+      { targetField: 'FUnitGroupID', domain: 'unit-group', sourceField: 'source.unitGroup' }, // rule 2 reads it
+    ]
+    const original = { source: { unitGroup: 'STD' } }
+    const { record, outcomes } = resolveReferenceRulesIntoRecord(original, overlapRules, idx)
+    assert.deepEqual(outcomes.map((o) => o.status), [OUTCOME.RESOLVED, OUTCOME.RESOLVED], 'both rules read the ORIGINAL snapshot → both resolved')
+    assert.deepEqual(record.FUnitGroupID, { FNumber: '10', FName: 'Each' }, 'rule 2 resolves despite rule 1 writing the same path')
+    assert.equal(original.source.unitGroup, 'STD', 'the input record is NOT mutated (writes go to an independent clone)')
+  }
+
+  // ---- UNRESOLVED_PLACEHOLDER is a bare <…> sentinel (so findUnfilledPlaceholders catches it) ----
+  assert.match(UNRESOLVED_PLACEHOLDER, /^<[^>]+>$/, 'sentinel is a bare placeholder token')
 
   console.log('reference-mapping-resolver.test.cjs OK')
 }

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -40,6 +40,9 @@ const { getPath, setPath, transformRecord } = require('./transform-engine.cjs')
 // DF-T1 reuses applyReferenceShape (shaping) + findUnfilledPlaceholders (detection); it does
 // NOT introduce a new K3 shaper/projector.
 const { projectRecordForBody, findUnfilledPlaceholders, applyReferenceShape, isBlankValue } = require('./adapters/k3-save-body-composer.cjs')
+// DF-T3b-2a: from_reference_table resolves a per-material reference via the shared resolver (the
+// SAME decision both the preview and the record materializer use, so they cannot diverge).
+const { resolveReferenceRuleValue } = require('./reference-mapping-resolver.cjs')
 // DF-T2c: read-only derive route reuses the DF-T2a helper (no duplication; pure compute, no write).
 const { deriveK3MaterialTemplateDraft, summarizeTemplateForEvidence, TemplateDeriveError } = require('./connector-template-derive.cjs')
 const { validateRecord } = require('./validator.cjs')
@@ -629,6 +632,8 @@ function normalizeFieldRules(value) {
       shape,
       completeness,
       required: rule.required === true,
+      // DF-T3b-2a: domain selects the mapping index for a from_reference_table rule (else undefined).
+      domain: firstString(rule.domain) || undefined,
     }
   })
 }
@@ -650,10 +655,13 @@ function checkReferenceCompleteness(completeness, value) {
   return null
 }
 
-function buildTargetPayloadPreview(input) {
+function buildTargetPayloadPreview(input, options = {}) {
   if (!isPlainObject(input.sourceRecord)) {
     throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', 'sourceRecord must be an object', { field: 'sourceRecord' })
   }
+  // DF-T3b-2a: mapping indexes are SERVER-SIDE only (not from the client body) — passed via options.
+  // T3b-2a injects them in tests; T3b-2b will source them from a live mapping-sheet bulk-read.
+  const referenceMappingIndexes = isPlainObject(options.referenceMappingIndexes) ? options.referenceMappingIndexes : undefined
   // Reuse the legacy preview's bodyKey guard (rejects __proto__/prototype/constructor and
   // control chars) — DF-T1 must NOT bypass it (P2).
   const bodyKey = normalizePreviewBodyKey(
@@ -665,13 +673,25 @@ function buildTargetPayloadPreview(input) {
   const fieldProvenance = {}
   const missingRequiredFields = []
   const unresolvedReferenceComponents = []
+  const referenceResolutions = [] // DF-T3b-2a: values-free resolution evidence per from_reference_table rule
   for (const rule of fieldRules) {
     if (rule.sourceType === 'preserve_template') {
       fieldProvenance[rule.targetField] = 'template'
     } else {
       let raw
-      if (rule.sourceType === 'from_staging') raw = getPath(input.sourceRecord, rule.sourceField)
-      else raw = rule.value // from_constant, or from_reference_table (v1 = pre-resolved scalar)
+      if (rule.sourceType === 'from_staging') {
+        raw = getPath(input.sourceRecord, rule.sourceField)
+      } else if (rule.sourceType === 'from_reference_table') {
+        // DF-T3b-2a: resolve the material's sourceCode via the injected mapping index for rule.domain,
+        // through the SHARED decision fn (so preview ≡ the record materializer). Non-resolved
+        // (unresolved/ambiguous/incomplete) → UNRESOLVED sentinel → fail-closed via
+        // findUnfilledPlaceholders, identical to the Save side. Evidence is values-free.
+        const resolution = resolveReferenceRuleValue(referenceMappingIndexes, rule, getPath(input.sourceRecord, rule.sourceField))
+        raw = resolution.value
+        referenceResolutions.push({ field: rule.targetField, status: resolution.outcome.status, evidence: resolution.outcome.evidence })
+      } else {
+        raw = rule.value // from_constant
+      }
       fieldProvenance[rule.targetField] = rule.sourceType === 'from_staging' ? 'staging'
         : rule.sourceType === 'from_constant' ? 'constant' : 'reference_table'
       const shaped = applyDfT1Shape(raw, rule.shape)
@@ -729,6 +749,9 @@ function buildTargetPayloadPreview(input) {
       unresolvedReferenceComponents: cloneJson(unresolvedReferenceComponents),
       missingRequiredFields: cloneJson(missingRequiredFields),
       fieldProvenance: cloneJson(fieldProvenance),
+      // DF-T3b-2a: values-free per-reference resolution evidence (field/domain/sourceCode-presence/
+      // error-type only — never customer values). Empty unless from_reference_table rules ran.
+      referenceResolutions: cloneJson(referenceResolutions),
       compositionSource: 'k3-save-body-composer',
     },
   })
@@ -741,7 +764,7 @@ function buildTargetPayloadPreview(input) {
   return response
 }
 
-function buildTemplatePreview(input) {
+function buildTemplatePreview(input, options = {}) {
   if (!isPlainObject(input)) {
     throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', 'input must be an object')
   }
@@ -777,9 +800,9 @@ function buildTemplatePreview(input) {
         sourceRecord: transformed.value,
         transformErrors: transformed.errors,
         validationErrors: validation.errors,
-      })
+      }, options)
     }
-    return buildTargetPayloadPreview(input)
+    return buildTargetPayloadPreview(input, options)
   }
   if (!isPlainObject(input.sourceRecord)) {
     throw new HttpRouteError(400, 'INVALID_TEMPLATE_PREVIEW', 'sourceRecord must be an object', { field: 'sourceRecord' })
@@ -1212,6 +1235,7 @@ module.exports = {
   VALID_USER_RUN_MODES,
   __internals: {
     buildTemplatePreview,
+    buildTargetPayloadPreview,
     hasPermission,
     requireAccess,
     resolveTenantId,

--- a/plugins/plugin-integration-core/lib/reference-mapping-resolver.cjs
+++ b/plugins/plugin-integration-core/lib/reference-mapping-resolver.cjs
@@ -10,6 +10,10 @@
 // domain / sourceCode-PRESENCE / error-type only (the error-type tokens are locked by #2036/#2048).
 
 const { normalizeReferenceMappingTemplate } = require('./reference-mapping-templates.cjs')
+// DF-T3b-2a: read sourceCode / write the resolved value through the SAME path semantics the operator
+// preview (buildTargetPayloadPreview) uses (getPath/setPath) — so a nested sourceField resolves
+// identically on both surfaces and the "shared decision cannot diverge" guarantee actually holds.
+const { getPath, setPath } = require('./transform-engine.cjs')
 
 // Resolution status — the outcome vocabulary.
 const OUTCOME = Object.freeze({
@@ -124,11 +128,60 @@ function resolveReferenceFromRows(template, rows, sourceCode, opts = {}) {
   return resolveReference(buildReferenceMappingIndex(template, rows), sourceCode, opts)
 }
 
+// DF-T3b-2a: the UNRESOLVED sentinel placed at a target field when resolution fails. A bare `<…>`
+// token caught by the shared composer's findUnfilledPlaceholders → identical fail-closed disposition
+// (K3_WISE_PRESET_PLACEHOLDER_UNFILLED) on BOTH the preview compose and the adapter Save compose.
+// (Dropping the field instead would NOT fail-close: the schema-path preview has no bodyTemplate and
+// the adapter Save only throws on placeholders, so an absent field is silently omitted on the Save.)
+const UNRESOLVED_PLACEHOLDER = '<unresolved>'
+
+// SHARED per-field decision used by BOTH the operator preview (buildTargetPayloadPreview) and the
+// record materializer (resolveReferenceRulesIntoRecord) so the two surfaces CANNOT diverge on the
+// composed value. `indexes` = { [domain]: builtIndex }. Returns { value, outcome }: value = the
+// resolved reference object on 'resolved', else UNRESOLVED_PLACEHOLDER (any non-resolved status).
+function resolveReferenceRuleValue(indexes, rule, sourceCode) {
+  const domain = rule && typeof rule.domain === 'string' ? rule.domain : undefined
+  const field = rule && typeof rule.targetField === 'string' ? rule.targetField : undefined
+  const index = domain && isPlainObject(indexes) ? indexes[domain] : undefined
+  const outcome = index
+    ? resolveReference(index, sourceCode, { field })
+    : makeOutcome(OUTCOME.UNRESOLVED, domain, sourceCode, field) // no index for this domain → unresolved
+  const value = outcome.status === OUTCOME.RESOLVED ? outcome.reference : UNRESOLVED_PLACEHOLDER
+  return { value, outcome }
+}
+
+// Materialize from_reference_table rules INTO a record (single-representation): set each rule's
+// targetField to the resolved {FNumber|FID,FName} object, or the UNRESOLVED_PLACEHOLDER sentinel on
+// any non-resolved status. The resulting record composes IDENTICALLY through the preview's schema
+// path and the adapter Save (both projectRecordForBody) — the byte-parity DF-T3b-2a proves. Pure:
+// a new record object; flat field access (from_reference_table fields are flat K3 names). rules =
+// [{ targetField, domain, sourceField }] (sourceField defaults to targetField).
+function resolveReferenceRulesIntoRecord(record, rules, indexes) {
+  // READ snapshot = the ORIGINAL record (never mutated) — the operator preview always reads
+  // input.sourceRecord, so we must too. WRITE target = an INDEPENDENT deep clone, so an earlier
+  // rule's write can't change what a later rule reads (overlapping source/target → no divergence).
+  // getPath/setPath = the same path semantics as the preview (nested sourceField resolves identically).
+  const source = isPlainObject(record) ? record : {}
+  const out = JSON.parse(JSON.stringify(source))
+  const outcomes = []
+  for (const rule of (Array.isArray(rules) ? rules : [])) {
+    if (!isPlainObject(rule) || typeof rule.targetField !== 'string') continue
+    const sourceField = typeof rule.sourceField === 'string' && rule.sourceField ? rule.sourceField : rule.targetField
+    const { value, outcome } = resolveReferenceRuleValue(indexes, rule, getPath(source, sourceField))
+    setPath(out, rule.targetField, value)
+    outcomes.push({ field: rule.targetField, status: outcome.status, evidence: outcome.evidence })
+  }
+  return { record: out, outcomes }
+}
+
 module.exports = {
   OUTCOME,
   STATUS_TO_ERROR_TYPE,
+  UNRESOLVED_PLACEHOLDER,
   buildReferenceMappingIndex,
   resolveReference,
   resolveReferenceFromRows,
+  resolveReferenceRuleValue,
+  resolveReferenceRulesIntoRecord,
   __internals: { isBlank, isCompleteRow, identifierColumn, normalizeSourceCodeKey },
 }


### PR DESCRIPTION
## DF-T3b-2a — resolver wire into target preview + resolved-record schema parity + 3-state fail-closed

Second slice of DF-T3b (#2048 design; resolver #2055). Wires the T3b-1 pure resolver into the composed body. **Option (a) + single-representation** (owner-confirmed).

### What this PROVES (precise — option a, not b)
- **`schema-compose(resolvedRecord) ≡ adapterSave(resolvedRecord)`** byte-parity for a `from_reference_table` reference (extends `k3-save-body-composer.parity.test.cjs`, both `projectRecordForBody`).
- **The operator preview (`buildTargetPayloadPreview`) resolves and fail-closes correctly** (its own tests in `http-routes.test.cjs`).
- It does **not** establish byte-parity between `buildTargetPayloadPreview` and the Save directly — that's option (b), explicitly deferred.

### Production state: dormant until T3b-2b
The route does **not** pass indexes and the adapter Save isn't resolver-wired — both stay dormant (`from_reference_table` → unresolved sentinel) until **DF-T3b-2b** sources indexes from a live bulk-read. Parity is proven through the test harness feeding a resolved record, not a live Save.

### Key decisions
- **Single-representation**: the resolved `{FNumber|FID,FName}` rides in the record through the existing schema (`applyReferenceShape` passthrough) — **no new schema descriptor** (avoids DF-T1-0 dual-representation drift).
- **Fail-closed = sentinel, not drop**: schema-path preview has no bodyTemplate + adapter Save only throws on `findUnfilledPlaceholders`, so a dropped field is silently omitted. `'<unresolved>'` makes `findUnfilledPlaceholders` fire on **both** sides (same `K3_WISE_PRESET_PLACEHOLDER_UNFILLED`) → identical disposition for all 3 statuses (single `status !== 'resolved'` gate).
- **Shared decision fn** `resolveReferenceRuleValue` called by both the preview and the record materializer → can't diverge. Indexes are a **server-side options param** (not client-injectable).
- `from_reference_table` semantics change is safe — **zero scalar-dependent producers** (authoring uses `preserve_template`; T2a never emits it).

### Tests + negative controls
Parity two regimes (resolved → byte-equal; non-resolved → identical fail-closed disposition). Controls: **wire** (ignore index → operator test fails), **sentinel** (blank → fail-closed breaks both sides), **desync** (different indexes → parity catches divergence). Affected suites green locally; full 28-step chain runs in CI.

Verification MD: `docs/development/data-factory-df-t3b-2a-resolver-wire-parity-development-20260529.md`. Left for owner review — no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)