### PR TITLE
fix(data-sources): executePython wrapPythonScript double-indent (C3 audit follow-up)

### DIFF
--- a/docs/development/data-sources-windows-c3-validation-plan-20260529.md
+++ b/docs/development/data-sources-windows-c3-validation-plan-20260529.md
@@ -53,7 +53,7 @@
 - ⬜ **PostgreSQL**(Windows 安装包):`DATABASE_URL` 连通;`migrate -- --list` 无 pending。
 - ⬜ **Redis 替代**(Garnet / Memurai):`REDIS_HOST`/`REDIS_PORT` 连通;缓存读写正常。
 - ⬜ **文件 / 路径**:`ScriptSandbox` workDir 落 `%TEMP%\sandbox` 可创建/写/清理;`uploads` 落 `<cwd>\uploads`。
-- ⬜ **Python**(仅当用到 workflow Python 脚本节点):设 `PYTHON_BIN`(见 §5);`validateScript` 通(注意 §6 的 executePython 预存 bug)。
+- ⬜ **Python**(仅当用到 workflow Python 脚本节点):设 `PYTHON_BIN`(见 §5);`validateScript` 与 `executePython` 均通(executePython 双重缩进 bug 已修,见 §6)。
 - ⬜ **Auth round-trip**:登录 → 带 token 调鉴权接口 → 200(**静默 401 = schema gap**,先查迁移)。
 - ⬜ **数据源只读**:`GET /api/data-sources/:id/test` 通;SQL Server smoke(如已配)通。
 - ⬜ **凭据加密**:`ENCRYPTION_KEY`/`ENCRYPTION_SALT` 稳定;服务重启后已存数据源仍可解密(decrypt fail-loud)。
@@ -78,6 +78,6 @@
 
 ## 6. 已知缺口(独立 follow-up,非本刀)
 
-- 🐛 **`executePython` 的 `wrapPythonScript` 双重缩进 bug(可移植性审计期发现,与本刀正交)**:模板行 `    ${...}` 已含 4 空格,而每行又 `map(line => '    ' + line)` 再加 4 空格 → 用户代码落 **8 空格缩进**于 4 空格的 `result = None` 之下 → **任何非空 python 脚本均 `IndentationError`**。这是**预存 bug**,使 `executePython` 端到端在**所有平台**均不可用(`validateScript` 路径无 wrapper,不受影响)。修复 trivial(去掉模板多余 4 空格),但属**功能正确性**、超出 C3 可移植范围 → 建议作**独立切片**(opt-in)修复 + 补 e2e。本刀的 python 可移植性修复(binary 解析 + cleanup)对此 bug 无影响也不依赖它。
+- ✅ **`executePython` 的 `wrapPythonScript` 双重缩进 bug —— 已修(独立小切片 PR,2026-05-29)**:模板行 `    ${...}` 已含 4 空格,而每行又 `map(line => '    ' + line)` 再加 4 空格 → 用户代码落 **8 空格缩进**于 4 空格的 `result = None` 之下 → 曾使**任何非空 python 脚本均 `IndentationError`**(`executePython` 端到端在所有平台不可用;`validateScript` 路径无 wrapper 不受影响)。修复 = 去掉模板插值行的多余 4 空格(由每行 `map` 提供唯一缩进)+ 补 e2e(`script-sandbox-python-portability.test.ts`:单行/多行/context/运行时错误,经真 python 证)。与 C3 可移植性正交,故按裁示作**独立切片**,不混 C3-env。
 - 🔒 **2008R2 / 2012 真实验证**(需 Windows VM —— 无 Linux 容器)。
 - 🔒 **B6 Windows 集成认证**(`authType:'windows'`,Kerberos/keytab/AD)。

--- a/packages/core-backend/src/sandbox/ScriptSandbox.ts
+++ b/packages/core-backend/src/sandbox/ScriptSandbox.ts
@@ -568,6 +568,10 @@ export class ScriptSandbox extends EventEmitter {
   private wrapPythonScript(script: string, context: ExecutionContext): string {
     const contextJson = JSON.stringify(context.data || {})
 
+    // NB: the user-script interpolation below is intentionally at column 0 in the template. Each
+    // line is indented to 4 spaces by `map(l => '    ' + l)` so it sits inside the `try:` block at
+    // the same level as `result = None`. A literal leading indent on the interpolation line would
+    // DOUBLE it (8 spaces) and IndentationError every non-empty script — do not re-indent it.
     return `
 import json
 import sys
@@ -609,7 +613,7 @@ data = json.loads('${contextJson.replace(/'/g, "\\'")}')
 # User script
 try:
     result = None
-    ${script.split('\n').map(line => '    ' + line).join('\n')}
+${script.split('\n').map(line => '    ' + line).join('\n')}
 
     # Output result
     output = {

--- a/packages/core-backend/tests/unit/script-sandbox-python-portability.test.ts
+++ b/packages/core-backend/tests/unit/script-sandbox-python-portability.test.ts
@@ -72,9 +72,9 @@ describe('ScriptSandbox python error path (C3)', () => {
 // job sets SANDBOX_REQUIRE_PYTHON=1, which converts the skip into a hard failure, so a broken python
 // path on Windows can never masquerade as a green run (the "skip-when-unreachable" trap).
 //
-// NB: this exercises validateScript() (spawn + ast.parse over stdin), NOT executePython()'s
-// wrapPythonScript path — the latter has a separate pre-existing double-indent bug (tracked in the
-// C3 plan doc) that makes wrapped execution fail on every platform, independent of this fix.
+// NB: this exercises validateScript() (spawn + ast.parse over stdin). The executePython()
+// wrapPythonScript path — whose double-indent bug is fixed in this slice — is covered end-to-end by
+// the executePython describe below.
 const pythonBin = resolvePythonBinary(process.platform, process.env.PYTHON_BIN)
 const probe = spawnSync(pythonBin, ['--version'])
 const pythonAvailable = !probe.error && probe.status === 0
@@ -98,6 +98,49 @@ describe('ScriptSandbox python real-wire (C3)', () => {
 
         const bad = await sandbox.validateScript('def (:\n', 'python')
         expect(bad.valid).toBe(false)
+      } finally {
+        await sandbox.cleanup()
+      }
+    }
+  )
+})
+
+// executePython end-to-end (indent-fix): wrapPythonScript used to double-indent the user script
+// (template `    ${...}` + per-line `map('    '+l)` = 8 spaces under a 4-space `result = None`),
+// IndentationError-ing EVERY non-empty script on all platforms. These lock the fix: real wrapped
+// execution must succeed (single-line, multi-line, context data) and surface runtime errors.
+describe('ScriptSandbox executePython end-to-end (indent-fix)', () => {
+  it.skipIf(!pythonAvailable && !requirePython)(
+    'runs wrapped python (single-line, multi-line, context) and surfaces runtime errors',
+    async () => {
+      expect(
+        pythonAvailable,
+        `SANDBOX_REQUIRE_PYTHON=1 but python binary '${pythonBin}' is not runnable ` +
+          `(${probe.error?.message ?? `exit ${probe.status}`}).`
+      ).toBe(true)
+
+      const sandbox = new ScriptSandbox({ timeout: 20000 })
+      await sandbox.initialize()
+      try {
+        // single-line — the minimal repro of the old double-indent IndentationError
+        const single = await sandbox.execute('result = 40 + 2', {}, 'python')
+        expect(single.success).toBe(true)
+        expect(single.output).toBe(42)
+
+        // multi-line — proves EVERY line (not just the first) is indented consistently
+        const multi = await sandbox.execute('a = 40\nb = 2\nresult = a + b', {}, 'python')
+        expect(multi.success).toBe(true)
+        expect(multi.output).toBe(42)
+
+        // context data is threaded in via json.loads
+        const withCtx = await sandbox.execute('result = data["x"] * 2', { data: { x: 21 } }, 'python')
+        expect(withCtx.success).toBe(true)
+        expect(withCtx.output).toBe(42)
+
+        // runtime error → graceful failure (NOT a thrown/IndentationError), error surfaced
+        const failure = await sandbox.execute('result = 1 / 0', {}, 'python')
+        expect(failure.success).toBe(false)
+        expect(String(failure.error)).toContain('ZeroDivisionError')
       } finally {
         await sandbox.cleanup()
       }


### PR DESCRIPTION
## Standalone slice — the executePython indent bug the C3 audit exposed

Per 裁示: a small, independent PR from latest origin/main, **not mixed with C3-env** or the deferred tail.

### Bug (pre-existing, surfaced by #2054's C3 audit)
`wrapPythonScript` prefixes the user-script interpolation line with **4 literal template spaces** AND indents each line via `map(l => '    ' + l)` — **8 spaces** total, under a 4-space `result = None`. So **every non-empty Python script `IndentationError`'d on all platforms** → `executePython` never worked end-to-end. Orthogonal to portability (`validateScript` has no wrapper, was unaffected), hence deferred to this slice.

### Fix
Dedent the interpolation line to column 0 so the per-line `map` indent (4 spaces) is the **only** one, sitting inside `try:` at the same level as `result = None`. Added a comment so the intentional dedent isn't "corrected" later.

```diff
 try:
     result = None
-    ${script.split('\n').map(line => '    ' + line).join('\n')}
+${script.split('\n').map(line => '    ' + line).join('\n')}
```

### Tests (+executePython end-to-end describe)
Real wrapped execution: **single-line** (the minimal repro), **multi-line** (proves every line is indented, not just the first), **context-data** threading, and a **runtime `ZeroDivisionError`** surfacing as a graceful failure (not a thrown/IndentationError). Skip-guarded locally / forced on windows-latest (`SANDBOX_REQUIRE_PYTHON`). **9/9 sandbox tests green locally** against python3.

### Real-Windows coverage
This PR changes `sandbox/**` + `script-sandbox-*.test.ts`, so the **windows-latest lane re-runs** → executePython is now proven end-to-end on **real Windows** too, not just Linux/mac.

### Tracker
C3 plan doc §6: indent bug ⬜→✅ (this slice); §3 Python checklist caveat updated.

### Scope / governance
Lock-safe: sandbox substrate + tests + one doc line. Does **not** touch C3-env, the deferred tail, integration-core, RBAC, or auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)