### PR TITLE
fix(attendance): load self-service leave policies

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -723,6 +723,9 @@
                   {{ item.name }}
                 </option>
               </select>
+              <small v-if="leaveTypes.length === 0" class="attendance__field-hint">
+                {{ tr('Ask an attendance admin to enable an active leave type before submitting leave requests.', '请联系考勤管理员启用可用请假类型后再提交请假申请。') }}
+              </small>
             </label>
             <label v-if="isOvertimeRequest" class="attendance__field" for="attendance-request-overtime-rule">
               <span>{{ tr('Overtime rule', '加班规则') }}</span>
@@ -737,6 +740,9 @@
                   {{ rule.name }}
                 </option>
               </select>
+              <small v-if="overtimeRules.length === 0" class="attendance__field-hint">
+                {{ tr('Ask an attendance admin to enable an active overtime rule before submitting overtime requests.', '请联系考勤管理员启用可用加班规则后再提交加班申请。') }}
+              </small>
             </label>
             <label class="attendance__field" for="attendance-request-in">
               <span>{{ isLeaveOrOvertimeRequest ? tr('Start', '开始') : tr('Requested in', '申请打卡入') }}</span>
@@ -4401,7 +4407,7 @@
             >
               <div class="attendance__admin-section-header">
                 <h4>{{ tr('Leave Types', '请假类型') }}</h4>
-                <button class="attendance__btn" :disabled="leaveTypeLoading" @click="loadLeaveTypes">
+                <button class="attendance__btn" :disabled="leaveTypeLoading" @click="() => loadLeaveTypes()">
                   {{ leaveTypeLoading ? tr('Loading...', '加载中...') : tr('Reload leave types', '重载请假类型') }}
                 </button>
               </div>
@@ -4506,7 +4512,7 @@
             >
               <div class="attendance__admin-section-header">
                 <h4>{{ tr('Overtime Rules', '加班规则') }}</h4>
-                <button class="attendance__btn" :disabled="overtimeRuleLoading" @click="loadOvertimeRules">
+                <button class="attendance__btn" :disabled="overtimeRuleLoading" @click="() => loadOvertimeRules()">
                   {{ overtimeRuleLoading ? tr('Loading...', '加载中...') : tr('Reload overtime rules', '重载加班规则') }}
                 </button>
               </div>
@@ -14232,7 +14238,11 @@ async function refreshAll(): Promise<boolean> {
   committedCalendarUserId.value = normalizedUserId() ?? currentUserId.value ?? null
   let success = true
   try {
-    const results = await Promise.allSettled([loadSummary(), loadRecords(), loadRequests(), loadAnomalies(), loadRequestReport(), loadHolidays()])
+    const tasks = [loadSummary(), loadRecords(), loadRequests(), loadAnomalies(), loadRequestReport(), loadHolidays()]
+    if (showOverview.value) {
+      tasks.push(loadLeaveTypes({ activeOnly: true }), loadOvertimeRules({ activeOnly: true }))
+    }
+    const results = await Promise.allSettled(tasks)
     const failed = results.find((result): result is PromiseRejectedResult => result.status === 'rejected')
     if (failed) throw failed.reason
     if (showReports.value) {
@@ -15101,10 +15111,10 @@ function editLeaveType(item: AttendanceLeaveType) {
   leaveTypeForm.isActive = item.isActive
 }
 
-async function loadLeaveTypes() {
+async function loadLeaveTypes(options: { activeOnly?: boolean } = {}) {
   leaveTypeLoading.value = true
   try {
-    const query = buildQuery({ orgId: normalizedOrgId() })
+    const query = buildQuery({ orgId: normalizedOrgId(), isActive: options.activeOnly ? 'true' : undefined })
     const response = await apiFetch(`/api/attendance/leave-types?${query.toString()}`)
     if (response.status === 403) {
       adminForbidden.value = true
@@ -15208,10 +15218,10 @@ function editOvertimeRule(item: AttendanceOvertimeRule) {
   overtimeRuleForm.isActive = item.isActive
 }
 
-async function loadOvertimeRules() {
+async function loadOvertimeRules(options: { activeOnly?: boolean } = {}) {
   overtimeRuleLoading.value = true
   try {
-    const query = buildQuery({ orgId: normalizedOrgId() })
+    const query = buildQuery({ orgId: normalizedOrgId(), isActive: options.activeOnly ? 'true' : undefined })
     const response = await apiFetch(`/api/attendance/overtime-rules?${query.toString()}`)
     if (response.status === 403) {
       adminForbidden.value = true

--- a/apps/web/src/views/attendance/useAttendanceAdminLeavePolicies.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminLeavePolicies.ts
@@ -82,14 +82,19 @@ interface UseAttendanceAdminLeavePoliciesOptions {
   tr?: Translate
 }
 
+interface LoadPolicyOptions {
+  activeOnly?: boolean
+}
+
 function defaultTranslate(en: string): string {
   return en
 }
 
-function buildOrgQuery(orgId?: string): URLSearchParams {
+function buildOrgQuery(orgId?: string, options: LoadPolicyOptions = {}): URLSearchParams {
   const query = new URLSearchParams()
   const normalizedOrgId = typeof orgId === 'string' ? orgId.trim() : ''
   if (normalizedOrgId) query.set('orgId', normalizedOrgId)
+  if (options.activeOnly) query.set('isActive', 'true')
   return query
 }
 
@@ -228,10 +233,10 @@ export function useAttendanceAdminLeavePolicies({
     leaveTypeForm.isActive = item.isActive
   }
 
-  async function loadLeaveTypes() {
+  async function loadLeaveTypes(options: LoadPolicyOptions = {}) {
     leaveTypeLoading.value = true
     try {
-      const query = buildOrgQuery(getOrgId())
+      const query = buildOrgQuery(getOrgId(), options)
       const response = await apiFetch(`/api/attendance/leave-types?${query.toString()}`)
       if (response.status === 403) {
         adminForbidden.value = true
@@ -340,10 +345,10 @@ export function useAttendanceAdminLeavePolicies({
     overtimeRuleForm.isActive = item.isActive
   }
 
-  async function loadOvertimeRules() {
+  async function loadOvertimeRules(options: LoadPolicyOptions = {}) {
     overtimeRuleLoading.value = true
     try {
-      const query = buildOrgQuery(getOrgId())
+      const query = buildOrgQuery(getOrgId(), options)
       const response = await apiFetch(`/api/attendance/overtime-rules?${query.toString()}`)
       if (response.status === 403) {
         adminForbidden.value = true

--- a/apps/web/tests/attendance-selfservice-dashboard.spec.ts
+++ b/apps/web/tests/attendance-selfservice-dashboard.spec.ts
@@ -468,6 +468,41 @@ describe('Attendance self-service dashboard', () => {
     expect(workDate?.value).toBe('2026-04-15')
   })
 
+  it('loads active leave and overtime policies into self-service request selectors', async () => {
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
+
+    expect(vi.mocked(apiFetch).mock.calls.some(call =>
+      String(call[0]) === '/api/attendance/leave-types?isActive=true'
+    )).toBe(true)
+    expect(vi.mocked(apiFetch).mock.calls.some(call =>
+      String(call[0]) === '/api/attendance/overtime-rules?isActive=true'
+    )).toBe(true)
+
+    const requestType = container!.querySelector<HTMLSelectElement>('#attendance-request-type')
+    expect(requestType).toBeTruthy()
+    requestType!.value = 'leave'
+    requestType!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const leaveType = container!.querySelector<HTMLSelectElement>('#attendance-request-leave-type')
+    expect(leaveType).toBeTruthy()
+    expect(leaveType!.disabled).toBe(false)
+    expect(leaveType!.value).toBe('leave-annual')
+    expect(leaveType!.textContent).toContain('Annual Leave')
+
+    requestType!.value = 'overtime'
+    requestType!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const overtimeRule = container!.querySelector<HTMLSelectElement>('#attendance-request-overtime-rule')
+    expect(overtimeRule).toBeTruthy()
+    expect(overtimeRule!.disabled).toBe(false)
+    expect(overtimeRule!.value).toBe('ot-default')
+    expect(overtimeRule!.textContent).toContain('Standard Overtime')
+  })
+
   it('explains zero-data onboarding when no attendance records exist yet', async () => {
     installZeroStateMock()
     app = createApp(AttendanceView, { mode: 'overview' })
@@ -484,6 +519,26 @@ describe('Attendance self-service dashboard', () => {
     expect(setupHint).toContain('confirm your group and shift setup')
     expect(focusList).toContain('Check attendance setup')
     expect(actionsCard).toContain('Wait for attendance setup')
+
+    const requestType = container!.querySelector<HTMLSelectElement>('#attendance-request-type')
+    expect(requestType).toBeTruthy()
+    requestType!.value = 'leave'
+    requestType!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const leaveType = container!.querySelector<HTMLSelectElement>('#attendance-request-leave-type')
+    expect(leaveType).toBeTruthy()
+    expect(leaveType!.disabled).toBe(true)
+    expect(container!.textContent).toContain('Ask an attendance admin to enable an active leave type')
+
+    requestType!.value = 'overtime'
+    requestType!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    const overtimeRule = container!.querySelector<HTMLSelectElement>('#attendance-request-overtime-rule')
+    expect(overtimeRule).toBeTruthy()
+    expect(overtimeRule!.disabled).toBe(true)
+    expect(container!.textContent).toContain('Ask an attendance admin to enable an active overtime rule')
   })
 
   it('surfaces punch-too-soon failures with status code, hint, and retry affordance', async () => {

--- a/apps/web/tests/useAttendanceAdminLeavePolicies.spec.ts
+++ b/apps/web/tests/useAttendanceAdminLeavePolicies.spec.ts
@@ -46,6 +46,65 @@ describe('useAttendanceAdminLeavePolicies', () => {
     expect(adminForbidden.value).toBe(false)
   })
 
+  it('loads active-only leave and overtime policies for self-service selectors', async () => {
+    const adminForbidden = ref(false)
+    const requestForm = reactive({ leaveTypeId: '', overtimeRuleId: '' })
+    const apiFetch = vi.fn(async (input: string) => {
+      if (input === '/api/attendance/leave-types?isActive=true') {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'leave-active',
+                code: 'annual',
+                name: 'Annual Leave',
+                paid: true,
+                requiresApproval: true,
+                requiresAttachment: false,
+                defaultMinutesPerDay: 480,
+                isActive: true,
+              },
+            ],
+          },
+        })
+      }
+      if (input === '/api/attendance/overtime-rules?isActive=true') {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                id: 'ot-active',
+                name: 'Weekday OT',
+                minMinutes: 0,
+                roundingMinutes: 15,
+                maxMinutesPerDay: 600,
+                requiresApproval: true,
+                isActive: true,
+              },
+            ],
+          },
+        })
+      }
+      throw new Error(`Unexpected request: ${input}`)
+    })
+
+    const policies = useAttendanceAdminLeavePolicies({
+      adminForbidden,
+      requestForm,
+      apiFetch,
+    })
+
+    await policies.loadLeaveTypes({ activeOnly: true })
+    await policies.loadOvertimeRules({ activeOnly: true })
+
+    expect(apiFetch).toHaveBeenCalledWith('/api/attendance/leave-types?isActive=true')
+    expect(apiFetch).toHaveBeenCalledWith('/api/attendance/overtime-rules?isActive=true')
+    expect(requestForm.leaveTypeId).toBe('leave-active')
+    expect(requestForm.overtimeRuleId).toBe('ot-active')
+  })
+
   it('saves a leave type, reloads the list, resets the form, and forwards success status', async () => {
     const adminForbidden = ref(false)
     const requestForm = reactive({ leaveTypeId: '', overtimeRuleId: '' })

--- a/packages/core-backend/src/sandbox/ScriptSandbox.ts
+++ b/packages/core-backend/src/sandbox/ScriptSandbox.ts
@@ -338,13 +338,15 @@ export class ScriptSandbox extends EventEmitter {
       const scriptPath = path.join(this.workDir, `${executionId}.py`)
       fs.writeFile(scriptPath, this.wrapPythonScript(script, context))
         .then(() => {
-          const pythonProcess = spawn(this.getPythonBinary(), [scriptPath], {
+          const pythonBinary = this.getPythonBinary()
+          const pythonProcess = spawn(pythonBinary, [scriptPath], {
             env: { ...process.env, ...this.options.env },
             timeout: this.options.timeout
           })
 
           let stdout = ''
           let stderr = ''
+          let isResolved = false
 
           pythonProcess.stdout.on('data', (data: Buffer) => {
             stdout += data.toString()
@@ -355,6 +357,8 @@ export class ScriptSandbox extends EventEmitter {
           })
 
           pythonProcess.on('close', async (code: number) => {
+            if (isResolved) return
+            isResolved = true
             // Clean up temp file
             await fs.unlink(scriptPath).catch(() => {})
 
@@ -395,6 +399,8 @@ export class ScriptSandbox extends EventEmitter {
           })
 
           pythonProcess.on('error', async (error: Error) => {
+            if (isResolved) return
+            isResolved = true
             // Lane C / C3: a spawn 'error' (e.g. ENOENT when the python binary is not found — the
             // common native-Windows case) fires WITHOUT 'close', so the temp script must be cleaned
             // up here too or it leaks. Surface the resolved binary in the message to aid PYTHON_BIN
@@ -402,7 +408,7 @@ export class ScriptSandbox extends EventEmitter {
             await fs.unlink(scriptPath).catch(() => {})
             resolve({
               success: false,
-              error: `Failed to run python ('${this.getPythonBinary()}'): ${error.message}`,
+              error: `Failed to run python ('${pythonBinary}'): ${error.message}`,
               logs,
               metrics: {
                 executionTime: Date.now() - startTime,

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -1119,6 +1119,89 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('lets attendance self-service users read only active leave and overtime policies', async () => {
+    if (!baseUrl) return
+    const runSuffix = Date.now().toString(36)
+    const adminUserId = `attendance-policy-admin-${runSuffix}`
+    const employeeUserId = `attendance-policy-employee-${runSuffix}`
+    const adminTokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const employeeTokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(employeeUserId)}&roles=user&perms=attendance:read,attendance:write`
+    )
+    const adminToken = (adminTokenRes.body as { token?: string } | undefined)?.token
+    const employeeToken = (employeeTokenRes.body as { token?: string } | undefined)?.token
+    expect(adminToken).toBeTruthy()
+    expect(employeeToken).toBeTruthy()
+    if (!adminToken || !employeeToken) return
+
+    const activeLeaveName = `Policy Active Leave ${runSuffix}`
+    const inactiveLeaveName = `Policy Inactive Leave ${runSuffix}`
+    const activeOvertimeName = `Policy Active OT ${runSuffix}`
+    const inactiveOvertimeName = `Policy Inactive OT ${runSuffix}`
+
+    for (const payload of [
+      { code: `active-leave-${runSuffix}`, name: activeLeaveName, isActive: true },
+      { code: `inactive-leave-${runSuffix}`, name: inactiveLeaveName, isActive: false },
+    ]) {
+      const res = await requestJson(`${baseUrl}/api/attendance/leave-types`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      })
+      expect(res.status).toBe(201)
+    }
+
+    for (const payload of [
+      { name: activeOvertimeName, minMinutes: 0, isActive: true },
+      { name: inactiveOvertimeName, minMinutes: 0, isActive: false },
+    ]) {
+      const res = await requestJson(`${baseUrl}/api/attendance/overtime-rules`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${adminToken}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(payload),
+      })
+      expect(res.status).toBe(201)
+    }
+
+    const employeeLeaveList = await requestJson(`${baseUrl}/api/attendance/leave-types?isActive=false`, {
+      headers: { Authorization: `Bearer ${employeeToken}` },
+    })
+    expect(employeeLeaveList.status).toBe(200)
+    const leaveItems =
+      (employeeLeaveList.body as { data?: { items?: Array<{ name?: string; isActive?: boolean }> } } | undefined)
+        ?.data?.items ?? []
+    expect(leaveItems.some(item => item.name === activeLeaveName && item.isActive === true)).toBe(true)
+    expect(leaveItems.some(item => item.name === inactiveLeaveName)).toBe(false)
+
+    const employeeOvertimeList = await requestJson(`${baseUrl}/api/attendance/overtime-rules?isActive=false`, {
+      headers: { Authorization: `Bearer ${employeeToken}` },
+    })
+    expect(employeeOvertimeList.status).toBe(200)
+    const overtimeItems =
+      (employeeOvertimeList.body as { data?: { items?: Array<{ name?: string; isActive?: boolean }> } } | undefined)
+        ?.data?.items ?? []
+    expect(overtimeItems.some(item => item.name === activeOvertimeName && item.isActive === true)).toBe(true)
+    expect(overtimeItems.some(item => item.name === inactiveOvertimeName)).toBe(false)
+
+    const forbiddenCreate = await requestJson(`${baseUrl}/api/attendance/leave-types`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${employeeToken}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ name: `Forbidden Leave ${runSuffix}` }),
+    })
+    expect(forbiddenCreate.status).toBe(403)
+  })
+
   it('lists raw punch events with stable timeline fields and cross-user guardrails', async () => {
     if (!baseUrl) return
 

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -1121,85 +1121,123 @@ attendanceIntegrationDescribe(
 
   it('lets attendance self-service users read only active leave and overtime policies', async () => {
     if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
     const runSuffix = Date.now().toString(36)
     const adminUserId = `attendance-policy-admin-${runSuffix}`
     const employeeUserId = `attendance-policy-employee-${runSuffix}`
-    const adminTokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
-    )
-    const employeeTokenRes = await requestJson(
-      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(employeeUserId)}&roles=user&perms=attendance:read,attendance:write`
-    )
-    const adminToken = (adminTokenRes.body as { token?: string } | undefined)?.token
-    const employeeToken = (employeeTokenRes.body as { token?: string } | undefined)?.token
-    expect(adminToken).toBeTruthy()
-    expect(employeeToken).toBeTruthy()
-    if (!adminToken || !employeeToken) return
+    const previousRbacBypass = process.env.RBAC_BYPASS
+    const pool = new Pool({ connectionString: dbUrl })
 
-    const activeLeaveName = `Policy Active Leave ${runSuffix}`
-    const inactiveLeaveName = `Policy Inactive Leave ${runSuffix}`
-    const activeOvertimeName = `Policy Active OT ${runSuffix}`
-    const inactiveOvertimeName = `Policy Inactive OT ${runSuffix}`
+    try {
+      process.env.RBAC_BYPASS = 'false'
+      await pool.query(
+        `INSERT INTO permissions (code, name, description)
+         VALUES
+           ('attendance:read', 'Attendance Read', 'Read attendance data'),
+           ('attendance:write', 'Attendance Write', 'Write attendance data'),
+           ('attendance:admin', 'Attendance Admin', 'Administer attendance')
+         ON CONFLICT (code) DO NOTHING`
+      )
+      await pool.query(
+        `INSERT INTO user_permissions (user_id, permission_code)
+         VALUES
+           ($1, 'attendance:read'),
+           ($1, 'attendance:write'),
+           ($1, 'attendance:admin'),
+           ($2, 'attendance:read'),
+           ($2, 'attendance:write')
+         ON CONFLICT DO NOTHING`,
+        [adminUserId, employeeUserId]
+      )
 
-    for (const payload of [
-      { code: `active-leave-${runSuffix}`, name: activeLeaveName, isActive: true },
-      { code: `inactive-leave-${runSuffix}`, name: inactiveLeaveName, isActive: false },
-    ]) {
-      const res = await requestJson(`${baseUrl}/api/attendance/leave-types`, {
+      const adminTokenRes = await requestJson(
+        `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+      )
+      const employeeTokenRes = await requestJson(
+        `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(employeeUserId)}&roles=user&perms=attendance:read,attendance:write`
+      )
+      const adminToken = (adminTokenRes.body as { token?: string } | undefined)?.token
+      const employeeToken = (employeeTokenRes.body as { token?: string } | undefined)?.token
+      expect(adminToken).toBeTruthy()
+      expect(employeeToken).toBeTruthy()
+      if (!adminToken || !employeeToken) return
+
+      const activeLeaveName = `Policy Active Leave ${runSuffix}`
+      const inactiveLeaveName = `Policy Inactive Leave ${runSuffix}`
+      const activeOvertimeName = `Policy Active OT ${runSuffix}`
+      const inactiveOvertimeName = `Policy Inactive OT ${runSuffix}`
+
+      for (const payload of [
+        { code: `active-leave-${runSuffix}`, name: activeLeaveName, isActive: true },
+        { code: `inactive-leave-${runSuffix}`, name: inactiveLeaveName, isActive: false },
+      ]) {
+        const res = await requestJson(`${baseUrl}/api/attendance/leave-types`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${adminToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        })
+        expect(res.status).toBe(201)
+      }
+
+      for (const payload of [
+        { name: activeOvertimeName, minMinutes: 0, isActive: true },
+        { name: inactiveOvertimeName, minMinutes: 0, isActive: false },
+      ]) {
+        const res = await requestJson(`${baseUrl}/api/attendance/overtime-rules`, {
+          method: 'POST',
+          headers: {
+            Authorization: `Bearer ${adminToken}`,
+            'Content-Type': 'application/json',
+          },
+          body: JSON.stringify(payload),
+        })
+        expect(res.status).toBe(201)
+      }
+
+      const employeeLeaveList = await requestJson(`${baseUrl}/api/attendance/leave-types?isActive=false`, {
+        headers: { Authorization: `Bearer ${employeeToken}` },
+      })
+      expect(employeeLeaveList.status).toBe(200)
+      const leaveItems =
+        (employeeLeaveList.body as { data?: { items?: Array<{ name?: string; isActive?: boolean }> } } | undefined)
+          ?.data?.items ?? []
+      expect(
+        leaveItems.some(item => item.name === activeLeaveName && item.isActive === true),
+        employeeLeaveList.raw
+      ).toBe(true)
+      expect(leaveItems.some(item => item.name === inactiveLeaveName)).toBe(false)
+
+      const employeeOvertimeList = await requestJson(`${baseUrl}/api/attendance/overtime-rules?isActive=false`, {
+        headers: { Authorization: `Bearer ${employeeToken}` },
+      })
+      expect(employeeOvertimeList.status).toBe(200)
+      const overtimeItems =
+        (employeeOvertimeList.body as { data?: { items?: Array<{ name?: string; isActive?: boolean }> } } | undefined)
+          ?.data?.items ?? []
+      expect(
+        overtimeItems.some(item => item.name === activeOvertimeName && item.isActive === true),
+        employeeOvertimeList.raw
+      ).toBe(true)
+      expect(overtimeItems.some(item => item.name === inactiveOvertimeName)).toBe(false)
+
+      const forbiddenCreate = await requestJson(`${baseUrl}/api/attendance/leave-types`, {
         method: 'POST',
         headers: {
-          Authorization: `Bearer ${adminToken}`,
+          Authorization: `Bearer ${employeeToken}`,
           'Content-Type': 'application/json',
         },
-        body: JSON.stringify(payload),
+        body: JSON.stringify({ name: `Forbidden Leave ${runSuffix}` }),
       })
-      expect(res.status).toBe(201)
+      expect(forbiddenCreate.status).toBe(403)
+    } finally {
+      process.env.RBAC_BYPASS = previousRbacBypass
+      await pool.query('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[adminUserId, employeeUserId]]).catch(() => undefined)
+      await pool.end()
     }
-
-    for (const payload of [
-      { name: activeOvertimeName, minMinutes: 0, isActive: true },
-      { name: inactiveOvertimeName, minMinutes: 0, isActive: false },
-    ]) {
-      const res = await requestJson(`${baseUrl}/api/attendance/overtime-rules`, {
-        method: 'POST',
-        headers: {
-          Authorization: `Bearer ${adminToken}`,
-          'Content-Type': 'application/json',
-        },
-        body: JSON.stringify(payload),
-      })
-      expect(res.status).toBe(201)
-    }
-
-    const employeeLeaveList = await requestJson(`${baseUrl}/api/attendance/leave-types?isActive=false`, {
-      headers: { Authorization: `Bearer ${employeeToken}` },
-    })
-    expect(employeeLeaveList.status).toBe(200)
-    const leaveItems =
-      (employeeLeaveList.body as { data?: { items?: Array<{ name?: string; isActive?: boolean }> } } | undefined)
-        ?.data?.items ?? []
-    expect(leaveItems.some(item => item.name === activeLeaveName && item.isActive === true)).toBe(true)
-    expect(leaveItems.some(item => item.name === inactiveLeaveName)).toBe(false)
-
-    const employeeOvertimeList = await requestJson(`${baseUrl}/api/attendance/overtime-rules?isActive=false`, {
-      headers: { Authorization: `Bearer ${employeeToken}` },
-    })
-    expect(employeeOvertimeList.status).toBe(200)
-    const overtimeItems =
-      (employeeOvertimeList.body as { data?: { items?: Array<{ name?: string; isActive?: boolean }> } } | undefined)
-        ?.data?.items ?? []
-    expect(overtimeItems.some(item => item.name === activeOvertimeName && item.isActive === true)).toBe(true)
-    expect(overtimeItems.some(item => item.name === inactiveOvertimeName)).toBe(false)
-
-    const forbiddenCreate = await requestJson(`${baseUrl}/api/attendance/leave-types`, {
-      method: 'POST',
-      headers: {
-        Authorization: `Bearer ${employeeToken}`,
-        'Content-Type': 'application/json',
-      },
-      body: JSON.stringify({ name: `Forbidden Leave ${runSuffix}` }),
-    })
-    expect(forbiddenCreate.status).toBe(403)
   })
 
   it('lists raw punch events with stable timeline fields and cross-user guardrails', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -19076,7 +19076,7 @@ module.exports = {
     context.api.http.addRoute(
       'GET',
       '/api/attendance/leave-types',
-      withPermission('attendance:admin', async (req, res) => {
+      withPermission('attendance:read', async (req, res) => {
         const schema = z.object({
           orgId: z.string().optional(),
           isActive: z.string().optional(),
@@ -19094,14 +19094,20 @@ module.exports = {
 
         const { page, pageSize, offset } = parsePagination(req.query)
         const orgId = getOrgId(req)
+        const userId = getUserId(req)
         const params = [orgId]
         let activeFilter = ''
-        if (parsed.data.isActive !== undefined) {
-          params.push(parseBoolean(parsed.data.isActive, true))
-          activeFilter = `AND is_active = $${params.length}`
-        }
 
         try {
+          const canManagePolicies = userId ? await hasAttendanceAdminAccess(userId) : false
+          const activeOnly = canManagePolicies
+            ? (parsed.data.isActive === undefined ? null : parseBoolean(parsed.data.isActive, true))
+            : true
+          if (activeOnly !== null) {
+            params.push(activeOnly)
+            activeFilter = `AND is_active = $${params.length}`
+          }
+
           const countRows = await db.query(
             `SELECT COUNT(*)::int AS total
              FROM attendance_leave_types
@@ -19356,7 +19362,7 @@ module.exports = {
     context.api.http.addRoute(
       'GET',
       '/api/attendance/overtime-rules',
-      withPermission('attendance:admin', async (req, res) => {
+      withPermission('attendance:read', async (req, res) => {
         const schema = z.object({
           orgId: z.string().optional(),
           isActive: z.string().optional(),
@@ -19374,14 +19380,20 @@ module.exports = {
 
         const { page, pageSize, offset } = parsePagination(req.query)
         const orgId = getOrgId(req)
+        const userId = getUserId(req)
         const params = [orgId]
         let activeFilter = ''
-        if (parsed.data.isActive !== undefined) {
-          params.push(parseBoolean(parsed.data.isActive, true))
-          activeFilter = `AND is_active = $${params.length}`
-        }
 
         try {
+          const canManagePolicies = userId ? await hasAttendanceAdminAccess(userId) : false
+          const activeOnly = canManagePolicies
+            ? (parsed.data.isActive === undefined ? null : parseBoolean(parsed.data.isActive, true))
+            : true
+          if (activeOnly !== null) {
+            params.push(activeOnly)
+            activeFilter = `AND is_active = $${params.length}`
+          }
+
           const countRows = await db.query(
             `SELECT COUNT(*)::int AS total
              FROM attendance_overtime_rules


### PR DESCRIPTION
## Summary
- allow attendance self-service users to read leave types and overtime rules through the existing read permission while forcing non-admin reads to active policies only
- load active leave/overtime policy lists during the overview refresh so request selectors are populated for employees
- show clear employee-facing admin setup hints when no active leave type or overtime rule is available
- stabilize the Python sandbox spawn error path that CI exposed while validating this PR, so missing interpreter errors cannot race with the close handler and lose the resolved binary name

Fixes #2002

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/useAttendanceAdminLeavePolicies.spec.ts tests/attendance-selfservice-dashboard.spec.ts --watch=false
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/core-backend build
- node --check plugins/plugin-attendance/index.cjs
- git diff --check origin/main...HEAD
- pnpm --filter @metasheet/web lint
- pnpm --filter @metasheet/web build
- pnpm --filter @metasheet/web exec eslint src/views/attendance/useAttendanceAdminLeavePolicies.ts tests/useAttendanceAdminLeavePolicies.spec.ts --max-warnings=0
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/script-sandbox-python-portability.test.ts --watch=false
- CI=true pnpm --filter @metasheet/core-backend test
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts --watch=false --testNamePattern "self-service users read only active leave and overtime policies" (local harness skipped: no integration DB/baseUrl)

## Notes
- Admin create/update/delete policy endpoints stay protected by attendance:admin.
- Admin list endpoints keep their existing all-policy default; only non-admin readers are constrained to active policies.
- The sandbox change is included because both Node 18 and Node 20 CI failed deterministically on that existing race before this PR could be merged.