### PR TITLE
fix(attendance): hide self-service approval actions

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -828,8 +828,6 @@
                 </div>
                 <div class="attendance__request-actions" v-if="item.status === 'pending'">
                   <button class="attendance__btn" @click="cancelRequest(item.id)">{{ tr('Cancel', '取消') }}</button>
-                  <button class="attendance__btn" @click="resolveRequest(item.id, 'approve')">{{ tr('Approve', '批准') }}</button>
-                  <button class="attendance__btn attendance__btn--danger" @click="resolveRequest(item.id, 'reject')">{{ tr('Reject', '驳回') }}</button>
                 </div>
               </li>
             </ul>

--- a/apps/web/tests/attendance-selfservice-dashboard.spec.ts
+++ b/apps/web/tests/attendance-selfservice-dashboard.spec.ts
@@ -420,26 +420,21 @@ describe('Attendance self-service dashboard', () => {
     expect(actionsCard).toContain('Start with missing-punch handling to resolve the current anomaly reminder.')
   })
 
-  it('requires and submits a rejection note when rejecting an attendance request', async () => {
-    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValue('Needs manager evidence')
-    try {
-      app = createApp(AttendanceView, { mode: 'overview' })
-      app.mount(container!)
-      await flushUi()
+  it('hides approval actions from employee self-service request cards', async () => {
+    app = createApp(AttendanceView, { mode: 'overview' })
+    app.mount(container!)
+    await flushUi()
 
-      findButton(container!, 'Reject').click()
-      await flushUi()
-
-      const rejectCall = vi.mocked(apiFetch).mock.calls.find(call =>
-        String(call[0]).includes('/api/attendance/requests/request-pending/reject')
-      )
-      expect(rejectCall).toBeTruthy()
-      expect(JSON.parse(String(rejectCall?.[1]?.body))).toEqual({
-        comment: 'Needs manager evidence',
-      })
-    } finally {
-      promptSpy.mockRestore()
-    }
+    expect(findButton(container!, 'Cancel')).toBeTruthy()
+    expect(Array.from(container!.querySelectorAll('button')).some(
+      candidate => candidate.textContent?.trim() === 'Approve'
+    )).toBe(false)
+    expect(Array.from(container!.querySelectorAll('button')).some(
+      candidate => candidate.textContent?.trim() === 'Reject'
+    )).toBe(false)
+    expect(vi.mocked(apiFetch).mock.calls.some(call =>
+      /\/api\/attendance\/requests\/request-pending\/(?:approve|reject)/.test(String(call[0]))
+    )).toBe(false)
   })
 
   it('prefills the request form from quick actions without leaving overview', async () => {


### PR DESCRIPTION
## Summary
- hide approve/reject controls from employee self-service request cards
- keep pending submitter action limited to cancel on the overview surface
- replace the old self-service reject test with a guard that approval endpoints are not exposed from employee cards

Fixes #2001

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/attendance-selfservice-dashboard.spec.ts --watch=false
- git diff --check origin/main...HEAD
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web lint
- pnpm --filter @metasheet/web build
