### PR TITLE
fix(attendance): count corrected rest-day minutes in summaries

### DIFF
--- a/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
+++ b/packages/core-backend/tests/unit/attendance-comprehensive-hours-control.test.ts
@@ -643,7 +643,7 @@ describe('comprehensive-hours period value-plumbing (PR6)', () => {
         const s = String(sql)
         queries.push({ sql: s, params })
         if (/FROM system_configs/i.test(s)) return [{ value: JSON.stringify(settings) }]
-        if (/is_workday THEN work_minutes/i.test(s)) return [summaryRow]
+        if (/FROM attendance_records/i.test(s) && /AS total_minutes/i.test(s)) return [summaryRow]
         if (/FROM attendance_requests/i.test(s)) return []
         if (/FROM users u/i.test(s)) return [{ user_name: 'U One', username: 'u1', meta: null }]
         if (/FROM attendance_leave_types/i.test(s)) return []
@@ -945,7 +945,7 @@ describe('comprehensive-hours payroll_cycle cap-mapping (§7 precise template-wi
       async query(sql: string) {
         const s = String(sql)
         if (/FROM system_configs/i.test(s)) return [{ value: JSON.stringify(settings) }]
-        if (/is_workday THEN work_minutes/i.test(s)) return [{ total_days: 22, total_minutes: 13000, total_late_minutes: 0, total_early_leave_minutes: 0, normal_days: 22, late_days: 0, early_leave_days: 0, late_early_days: 0, partial_days: 0, absent_days: 0, adjusted_days: 0, off_days: 9 }]
+        if (/FROM attendance_records/i.test(s) && /AS total_minutes/i.test(s)) return [{ total_days: 22, total_minutes: 13000, total_late_minutes: 0, total_early_leave_minutes: 0, normal_days: 22, late_days: 0, early_leave_days: 0, late_early_days: 0, partial_days: 0, absent_days: 0, adjusted_days: 0, off_days: 9 }]
         if (/FROM attendance_requests/i.test(s)) return []
         if (/FROM users u/i.test(s)) return [{ user_name: 'U One', username: 'u1', meta: null }]
         if (/FROM attendance_leave_types/i.test(s)) return []

--- a/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
+++ b/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
@@ -1538,7 +1538,7 @@ describe('attendance report field catalog multitable foundation', () => {
           return [{ id: 'leave-annual', code: 'annual', name: '年假', is_active: true }]
         }
         if (/FROM attendance_overtime_rules/.test(sql)) return []
-        if (/SELECT\s+COALESCE\(SUM\(CASE WHEN is_workday THEN 1 ELSE 0 END\)/.test(sql)) {
+        if (/FROM attendance_records/.test(sql) && /AS total_minutes/.test(sql)) {
           return [{
             total_days: 2,
             total_minutes: 960,
@@ -1674,7 +1674,7 @@ describe('attendance report field catalog multitable foundation', () => {
     const db = {
       query: async (sql: string) => {
         if (/FROM attendance_leave_types/.test(sql) || /FROM attendance_overtime_rules/.test(sql)) return []
-        if (/SELECT\s+COALESCE\(SUM\(CASE WHEN is_workday THEN 1 ELSE 0 END\)/.test(sql)) {
+        if (/FROM attendance_records/.test(sql) && /AS total_minutes/.test(sql)) {
           return [{
             total_days: 1,
             total_minutes: 480,

--- a/packages/core-backend/tests/unit/attendance-summary-aggregation.test.ts
+++ b/packages/core-backend/tests/unit/attendance-summary-aggregation.test.ts
@@ -1,0 +1,54 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it, vi } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceReportFieldCatalogForTests
+
+describe('attendance summary aggregation', () => {
+  it('counts adjusted worked rows even when the stored workday flag is false', async () => {
+    const db = {
+      query: vi.fn()
+        .mockResolvedValueOnce([
+          {
+            total_days: 1,
+            total_minutes: 395,
+            total_late_minutes: 0,
+            total_early_leave_minutes: 0,
+            normal_days: 0,
+            late_days: 0,
+            early_leave_days: 0,
+            late_early_days: 0,
+            partial_days: 0,
+            absent_days: 0,
+            adjusted_days: 1,
+            off_days: 0,
+          },
+        ])
+        .mockResolvedValueOnce([]),
+    }
+
+    const summary = await helpers.loadAttendanceSummary(
+      db,
+      'org-1',
+      'new-hire-1',
+      '2026-05-01',
+      '2026-05-31',
+    )
+
+    expect(summary.total_minutes).toBe(395)
+    expect(summary.adjusted_days).toBe(1)
+    expect(summary.off_days).toBe(0)
+
+    const aggregateSql = String(db.query.mock.calls[0]?.[0] || '')
+    expect(aggregateSql).toContain('COALESCE(work_minutes, 0) > 0')
+    expect(aggregateSql).toContain("status IN ('normal', 'late', 'early_leave', 'late_early', 'partial', 'adjusted')")
+    expect(aggregateSql).toContain('NOT (is_workday = true OR COALESCE(work_minutes, 0) > 0')
+  })
+
+  it('can qualify the counted-day predicate for joined summary queries', () => {
+    expect(helpers.buildAttendanceSummaryCountedDaySql('ar')).toBe(
+      "(ar.is_workday = true OR COALESCE(ar.work_minutes, 0) > 0 OR ar.status IN ('normal', 'late', 'early_leave', 'late_early', 'partial', 'adjusted'))",
+    )
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -10333,21 +10333,27 @@ function applyEngineOverrides(metrics, engineResult) {
   return { metrics: nextMetrics, meta: { base, overrides } }
 }
 
+function buildAttendanceSummaryCountedDaySql(alias = '') {
+  const prefix = alias ? `${alias}.` : ''
+  return `(${prefix}is_workday = true OR COALESCE(${prefix}work_minutes, 0) > 0 OR ${prefix}status IN ('normal', 'late', 'early_leave', 'late_early', 'partial', 'adjusted'))`
+}
+
 async function loadAttendanceSummary(db, orgId, userId, from, to) {
+  const countedDaySql = buildAttendanceSummaryCountedDaySql()
   const rows = await db.query(
     `SELECT
-       COALESCE(SUM(CASE WHEN is_workday THEN 1 ELSE 0 END), 0)::int AS total_days,
-       COALESCE(SUM(CASE WHEN is_workday THEN work_minutes ELSE 0 END), 0)::int AS total_minutes,
-       COALESCE(SUM(CASE WHEN is_workday THEN late_minutes ELSE 0 END), 0)::int AS total_late_minutes,
-       COALESCE(SUM(CASE WHEN is_workday THEN early_leave_minutes ELSE 0 END), 0)::int AS total_early_leave_minutes,
-       COALESCE(SUM(CASE WHEN is_workday AND status = 'normal' THEN 1 ELSE 0 END), 0)::int AS normal_days,
-       COALESCE(SUM(CASE WHEN is_workday AND status = 'late' THEN 1 ELSE 0 END), 0)::int AS late_days,
-       COALESCE(SUM(CASE WHEN is_workday AND status = 'early_leave' THEN 1 ELSE 0 END), 0)::int AS early_leave_days,
-       COALESCE(SUM(CASE WHEN is_workday AND status = 'late_early' THEN 1 ELSE 0 END), 0)::int AS late_early_days,
-       COALESCE(SUM(CASE WHEN is_workday AND status = 'partial' THEN 1 ELSE 0 END), 0)::int AS partial_days,
-       COALESCE(SUM(CASE WHEN is_workday AND status = 'absent' THEN 1 ELSE 0 END), 0)::int AS absent_days,
-       COALESCE(SUM(CASE WHEN is_workday AND status = 'adjusted' THEN 1 ELSE 0 END), 0)::int AS adjusted_days,
-       COALESCE(SUM(CASE WHEN NOT is_workday THEN 1 ELSE 0 END), 0)::int AS off_days
+       COALESCE(SUM(CASE WHEN ${countedDaySql} THEN 1 ELSE 0 END), 0)::int AS total_days,
+       COALESCE(SUM(CASE WHEN ${countedDaySql} THEN work_minutes ELSE 0 END), 0)::int AS total_minutes,
+       COALESCE(SUM(CASE WHEN ${countedDaySql} THEN late_minutes ELSE 0 END), 0)::int AS total_late_minutes,
+       COALESCE(SUM(CASE WHEN ${countedDaySql} THEN early_leave_minutes ELSE 0 END), 0)::int AS total_early_leave_minutes,
+       COALESCE(SUM(CASE WHEN ${countedDaySql} AND status = 'normal' THEN 1 ELSE 0 END), 0)::int AS normal_days,
+       COALESCE(SUM(CASE WHEN ${countedDaySql} AND status = 'late' THEN 1 ELSE 0 END), 0)::int AS late_days,
+       COALESCE(SUM(CASE WHEN ${countedDaySql} AND status = 'early_leave' THEN 1 ELSE 0 END), 0)::int AS early_leave_days,
+       COALESCE(SUM(CASE WHEN ${countedDaySql} AND status = 'late_early' THEN 1 ELSE 0 END), 0)::int AS late_early_days,
+       COALESCE(SUM(CASE WHEN ${countedDaySql} AND status = 'partial' THEN 1 ELSE 0 END), 0)::int AS partial_days,
+       COALESCE(SUM(CASE WHEN ${countedDaySql} AND status = 'absent' THEN 1 ELSE 0 END), 0)::int AS absent_days,
+       COALESCE(SUM(CASE WHEN ${countedDaySql} AND status = 'adjusted' THEN 1 ELSE 0 END), 0)::int AS adjusted_days,
+       COALESCE(SUM(CASE WHEN NOT ${countedDaySql} THEN 1 ELSE 0 END), 0)::int AS off_days
      FROM attendance_records
      WHERE user_id = $1 AND org_id = $2 AND work_date BETWEEN $3 AND $4`,
     [userId, orgId, from, to]
@@ -14704,6 +14710,8 @@ module.exports = {
     buildAttendanceOvertimeSubtypeReportFieldDefinitions,
     loadAttendanceReportDynamicSubtypeContext,
     loadApprovedMinutesRange,
+    buildAttendanceSummaryCountedDaySql,
+    loadAttendanceSummary,
     resolveAttendanceRecordReportFields,
     resolveAttendanceFormulaSourceFields,
     resolveAttendanceSummaryFormulaFields,


### PR DESCRIPTION
## Summary
- count adjusted/worked rest-day attendance records in summary and payroll rollups
- keep off-day totals from treating corrected worked rows as rest days
- update period-summary/comprehensive-hours unit fixtures for the new summary SQL predicate

Fixes #1999

## Verification
- node --check plugins/plugin-attendance/index.cjs
- git diff --check origin/main...HEAD
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-summary-aggregation.test.ts tests/unit/attendance-comprehensive-hours-control.test.ts tests/unit/attendance-report-field-catalog.test.ts --watch=false
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-runtime-teardown.test.ts --watch=false
