### PR TITLE
fix(attendance): surface requests in approval center

### DIFF
--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -455,7 +455,22 @@ function handlePageChange(page: number) {
   loadCurrentTab()
 }
 
+function isAttendanceApproval(row: UnifiedApprovalDTO): boolean {
+  return row.workflowKey === 'attendance.request'
+    || row.formSnapshot?.attendanceRequestId !== undefined
+}
+
 function handleRowClick(row: UnifiedApprovalDTO) {
+  if (isAttendanceApproval(row)) {
+    router.push({
+      name: 'attendance',
+      query: {
+        section: 'attendance-overview-requests',
+        requestId: String(row.formSnapshot?.attendanceRequestId ?? ''),
+      },
+    })
+    return
+  }
   router.push({ name: 'approval-detail', params: { id: row.id } })
 }
 

--- a/apps/web/tests/approvalCenterUnreadBadge.spec.ts
+++ b/apps/web/tests/approvalCenterUnreadBadge.spec.ts
@@ -143,7 +143,20 @@ const ElTable = defineComponent({
   props: { data: Array, loading: Boolean, stripe: Boolean, highlightCurrentRow: Boolean },
   emits: ['row-click'],
   render() {
-    return h('div', { 'data-el-table': 'true' }, this.$slots.default?.())
+    const rows = Array.isArray(this.data)
+      ? this.data.map((row: any) => h(
+        'button',
+        {
+          'data-testid': `approval-row-${row.id}`,
+          onClick: () => this.$emit('row-click', row),
+        },
+        row.title || row.id,
+      ))
+      : []
+    return h('div', { 'data-el-table': 'true' }, [
+      this.$slots.default?.(),
+      ...rows,
+    ])
   },
 })
 
@@ -505,6 +518,33 @@ describe('ApprovalCenterView 未读红点 (WP3 slice 2)', () => {
     expect(getPendingCountSpy).toHaveBeenLastCalledWith('plm')
     const updatedBadge = container!.querySelector('[data-testid="approval-pending-badge"]') as HTMLElement | null
     expect(updatedBadge?.getAttribute('data-badge-value')).toBe('1')
+  })
+
+  it('routes bridged attendance approval rows back to the attendance request queue', async () => {
+    mockPendingApprovals.value = [{
+      id: 'apv-attendance-1',
+      workflowKey: 'attendance.request',
+      formSnapshot: { attendanceRequestId: 'request-1' },
+      title: '考勤审批 · 漏打下班卡',
+      status: 'pending',
+      requester: { name: '新员工' },
+      createdAt: '2026-05-29T10:00:00.000Z',
+    }]
+
+    await mountCenter({ count: 1, unreadCount: 1 })
+
+    const row = container!.querySelector('[data-testid="approval-row-apv-attendance-1"]') as HTMLButtonElement
+    expect(row).toBeTruthy()
+    row.click()
+    await flushUi()
+
+    expect(pushSpy).toHaveBeenCalledWith({
+      name: 'attendance',
+      query: {
+        section: 'attendance-overview-requests',
+        requestId: 'request-1',
+      },
+    })
   })
 })
 

--- a/packages/core-backend/src/routes/approvals.ts
+++ b/packages/core-backend/src/routes/approvals.ts
@@ -546,6 +546,7 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         includeExternalTabSources: rawSourceSystem === 'all',
         actorId: actorId || undefined,
         actorRoles,
+        actorPermissions: resolveApprovalActorPermissions(req),
         limit,
         offset,
       })
@@ -750,6 +751,8 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         : (rawSourceSystem as 'platform' | 'plm')
       const actorRoles = resolveApprovalActorRoles(req)
       const actorRolesParam = actorRoles.length > 0 ? actorRoles : ['__none__']
+      const actorPermissions = resolveApprovalActorPermissions(req)
+      const actorPermissionsParam = actorPermissions.length > 0 ? actorPermissions : ['__none__']
 
       const conditions: string[] = [
         `a.is_active = TRUE`,
@@ -757,9 +760,10 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         `(
           (a.assignment_type = 'user' AND a.assignee_id = $1)
           OR (a.assignment_type = 'role' AND a.assignee_id = ANY($2))
+          OR (a.assignment_type = 'source_queue' AND a.assignee_id = ANY($3))
         )`,
       ]
-      const params: unknown[] = [userId, actorRolesParam]
+      const params: unknown[] = [userId, actorRolesParam, actorPermissionsParam]
 
       if (sourceSystem) {
         conditions.push(`COALESCE(i.source_system, 'platform') = $${params.length + 1}`)
@@ -891,6 +895,8 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         : (rawSourceSystem as 'platform' | 'plm')
       const actorRoles = resolveApprovalActorRoles(req)
       const actorRolesParam = actorRoles.length > 0 ? actorRoles : ['__none__']
+      const actorPermissions = resolveApprovalActorPermissions(req)
+      const actorPermissionsParam = actorPermissions.length > 0 ? actorPermissions : ['__none__']
 
       const conditions: string[] = [
         `a.is_active = TRUE`,
@@ -898,9 +904,10 @@ export function approvalsRouter(options?: ApprovalRouterOptions): Router {
         `(
           (a.assignment_type = 'user' AND a.assignee_id = $2)
           OR (a.assignment_type = 'role' AND a.assignee_id = ANY($3))
+          OR (a.assignment_type = 'source_queue' AND a.assignee_id = ANY($4))
         )`,
       ]
-      const params: unknown[] = [userId, userId, actorRolesParam]
+      const params: unknown[] = [userId, userId, actorRolesParam, actorPermissionsParam]
 
       if (sourceSystem) {
         conditions.push(`COALESCE(i.source_system, 'platform') = $${params.length + 1}`)

--- a/packages/core-backend/src/services/ApprovalBridgeService.ts
+++ b/packages/core-backend/src/services/ApprovalBridgeService.ts
@@ -272,6 +272,7 @@ export class ApprovalBridgeService {
     const includeExternalTabSources = options?.includeExternalTabSources === true
     if (options?.tab && options.actorId) {
       const actorRoles = options.actorRoles && options.actorRoles.length > 0 ? options.actorRoles : ['__none__']
+      const actorPermissions = options.actorPermissions && options.actorPermissions.length > 0 ? options.actorPermissions : ['__none__']
 
       if (sourceSystem === 'plm') {
         // PLM assignment filtering is not available in phase 1. The source
@@ -301,6 +302,8 @@ export class ApprovalBridgeService {
         params.push(options.actorId)
         const actorRolesParam = paramIndex++
         params.push(actorRoles)
+        const actorPermissionsParam = paramIndex++
+        params.push(actorPermissions)
 
         if (options.tab === 'pending') {
           conditions.push(
@@ -315,6 +318,7 @@ export class ApprovalBridgeService {
                     AND (
                       (assignment_type = 'user' AND assignee_id = $${actorIdParam})
                       OR (assignment_type = 'role' AND assignee_id = ANY($${actorRolesParam}))
+                      OR (assignment_type = 'source_queue' AND assignee_id = ANY($${actorPermissionsParam}))
                     )
                 )
               )
@@ -363,6 +367,7 @@ export class ApprovalBridgeService {
                     FROM approval_assignments
                     WHERE (assignment_type = 'user' AND assignee_id = $${actorIdParam})
                        OR (assignment_type = 'role' AND assignee_id = ANY($${actorRolesParam}))
+                       OR (assignment_type = 'source_queue' AND assignee_id = ANY($${actorPermissionsParam}))
                   )
                 )
               )
@@ -378,6 +383,8 @@ export class ApprovalBridgeService {
         params.push(options.actorId)
         const actorRolesParam = paramIndex++
         params.push(actorRoles)
+        const actorPermissionsParam = paramIndex++
+        params.push(actorPermissions)
         conditions.push(`COALESCE(source_system, 'platform') = 'platform'`)
 
         if (options.tab === 'pending') {
@@ -390,6 +397,7 @@ export class ApprovalBridgeService {
                 AND (
                   (assignment_type = 'user' AND assignee_id = $${actorIdParam})
                   OR (assignment_type = 'role' AND assignee_id = ANY($${actorRolesParam}))
+                  OR (assignment_type = 'source_queue' AND assignee_id = ANY($${actorPermissionsParam}))
                 )
             )`,
           )
@@ -429,6 +437,7 @@ export class ApprovalBridgeService {
                 FROM approval_assignments
                 WHERE (assignment_type = 'user' AND assignee_id = $${actorIdParam})
                    OR (assignment_type = 'role' AND assignee_id = ANY($${actorRolesParam}))
+                   OR (assignment_type = 'source_queue' AND assignee_id = ANY($${actorPermissionsParam}))
               )
             )`,
           )

--- a/packages/core-backend/src/services/approval-bridge-types.ts
+++ b/packages/core-backend/src/services/approval-bridge-types.ts
@@ -95,6 +95,7 @@ export interface ApprovalQueryOptions {
   includeExternalTabSources?: boolean
   actorId?: string
   actorRoles?: string[]
+  actorPermissions?: string[]
   limit?: number
   offset?: number
 }

--- a/packages/core-backend/src/services/approval-realtime.ts
+++ b/packages/core-backend/src/services/approval-realtime.ts
@@ -27,6 +27,7 @@ export async function computeApprovalPendingCounts(
   input: {
     userId: string
     roles?: string[]
+    permissions?: string[]
     sourceSystem?: ApprovalCountSourceSystem
   },
 ): Promise<ApprovalCounts> {
@@ -35,15 +36,18 @@ export async function computeApprovalPendingCounts(
     : null
   const roles = input.roles?.filter((role) => role.trim().length > 0) ?? []
   const actorRolesParam = roles.length > 0 ? roles : ['__none__']
+  const permissions = input.permissions?.filter((permission) => permission.trim().length > 0) ?? []
+  const actorPermissionsParam = permissions.length > 0 ? permissions : ['__none__']
   const conditions = [
     `a.is_active = TRUE`,
     `i.status = 'pending'`,
     `(
       (a.assignment_type = 'user' AND a.assignee_id = $1)
       OR (a.assignment_type = 'role' AND a.assignee_id = ANY($2))
+      OR (a.assignment_type = 'source_queue' AND a.assignee_id = ANY($3))
     )`,
   ]
-  const params: unknown[] = [input.userId, actorRolesParam]
+  const params: unknown[] = [input.userId, actorRolesParam, actorPermissionsParam]
 
   if (sourceSystem) {
     conditions.push(`COALESCE(i.source_system, 'platform') = $${params.length + 1}`)
@@ -70,6 +74,7 @@ export async function buildApprovalCountsUpdatedPayload(
   input: {
     userId: string
     roles?: string[]
+    permissions?: string[]
     reason: string
     query?: ApprovalCountQuery
   },
@@ -78,9 +83,9 @@ export async function buildApprovalCountsUpdatedPayload(
   if (!query) return null
 
   const [all, platform, plm] = await Promise.all([
-    computeApprovalPendingCounts(query, { userId: input.userId, roles: input.roles, sourceSystem: 'all' }),
-    computeApprovalPendingCounts(query, { userId: input.userId, roles: input.roles, sourceSystem: 'platform' }),
-    computeApprovalPendingCounts(query, { userId: input.userId, roles: input.roles, sourceSystem: 'plm' }),
+    computeApprovalPendingCounts(query, { userId: input.userId, roles: input.roles, permissions: input.permissions, sourceSystem: 'all' }),
+    computeApprovalPendingCounts(query, { userId: input.userId, roles: input.roles, permissions: input.permissions, sourceSystem: 'platform' }),
+    computeApprovalPendingCounts(query, { userId: input.userId, roles: input.roles, permissions: input.permissions, sourceSystem: 'plm' }),
   ])
 
   return {
@@ -99,6 +104,7 @@ export async function publishApprovalCountsUpdate(
     logger?: Pick<ILogger, 'warn'>
     userId: string
     roles?: string[]
+    permissions?: string[]
     reason: string
     query?: ApprovalCountQuery
   },

--- a/packages/core-backend/tests/unit/approval-realtime.test.ts
+++ b/packages/core-backend/tests/unit/approval-realtime.test.ts
@@ -9,23 +9,25 @@ import {
 describe('approval realtime count publisher', () => {
   it('computes pending and unread counts with user, role, and source filters', async () => {
     const query = vi.fn<ApprovalCountQuery>(async (_sql, params) => {
-      expect(params).toEqual(['u1', ['finance'], 'platform'])
+      expect(params).toEqual(['u1', ['finance'], ['attendance:approve'], 'platform'])
       return { rows: [{ count: '4', unread_count: '2' }] }
     })
 
     const counts = await computeApprovalPendingCounts(query, {
       userId: 'u1',
       roles: ['finance'],
+      permissions: ['attendance:approve'],
       sourceSystem: 'platform',
     })
 
     expect(counts).toEqual({ count: 4, unreadCount: 2 })
-    expect(query.mock.calls[0][0]).toContain(`COALESCE(i.source_system, 'platform') = $3`)
+    expect(query.mock.calls[0][0]).toContain(`assignment_type = 'source_queue'`)
+    expect(query.mock.calls[0][0]).toContain(`COALESCE(i.source_system, 'platform') = $4`)
   })
 
   it('publishes all/platform/plm count snapshots to the current user room', async () => {
     const query = vi.fn<ApprovalCountQuery>(async (_sql, params) => {
-      const sourceSystem = params[2]
+      const sourceSystem = params[3]
       if (sourceSystem === 'platform') return { rows: [{ count: '2', unread_count: '1' }] }
       if (sourceSystem === 'plm') return { rows: [{ count: '1', unread_count: '1' }] }
       return { rows: [{ count: '3', unread_count: '2' }] }

--- a/packages/core-backend/tests/unit/approvals-bridge-routes.test.ts
+++ b/packages/core-backend/tests/unit/approvals-bridge-routes.test.ts
@@ -541,7 +541,7 @@ vi.mock('../../src/middleware/auth', () => ({
       sub: 'test-user',
       name: 'Test User',
       email: 'test@example.com',
-      permissions: ['*:*'],
+      permissions: ['*:*', 'attendance:approve'],
       roles: ['admin'],
     } as never
     next()
@@ -1081,6 +1081,20 @@ describe('approval bridge routes', () => {
 
     expect(response.body.total).toBe(1)
     expect(response.body.data[0].id).toBe('local-1')
+  })
+
+  it('lets source-queue approvals match the actor permission set for the pending tab', async () => {
+    const app = createApp(createPlmAdapterMock())
+    await request(app)
+      .get('/api/approvals?tab=pending&sourceSystem=platform')
+      .expect(200)
+
+    const listCall = routeState.pool.query.mock.calls.find(([sql]) => (
+      String(sql).includes('SELECT * FROM approval_instances')
+      && String(sql).includes("assignment_type = 'source_queue'")
+    ))
+    expect(listCall).toBeTruthy()
+    expect(listCall?.[1]).toContainEqual(['*:*', 'attendance:approve'])
   })
 
   it('keeps legacy pending approvals scoped to platform-owned rows', async () => {

--- a/packages/core-backend/tests/unit/attendance-approval-center-bridge.test.ts
+++ b/packages/core-backend/tests/unit/attendance-approval-center-bridge.test.ts
@@ -1,0 +1,93 @@
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceApprovalCenterForTests
+
+describe('attendance approval center bridge helpers', () => {
+  it('assigns flow-backed attendance requests to the current approval step', () => {
+    expect(helpers.buildAttendanceApprovalAssignments([
+      {
+        name: 'Line manager',
+        approverUserIds: ['manager-1', 'manager-1'],
+        approverRoleIds: ['attendance-reviewer'],
+      },
+      {
+        name: 'HR',
+        approverUserIds: ['hr-1'],
+      },
+    ], 0)).toEqual([
+      {
+        assignmentType: 'user',
+        assigneeId: 'manager-1',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: { source: 'attendance', stepName: 'Line manager' },
+      },
+      {
+        assignmentType: 'role',
+        assigneeId: 'attendance-reviewer',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: { source: 'attendance', stepName: 'Line manager' },
+      },
+    ])
+  })
+
+  it('falls back to the attendance approval permission queue when no flow exists', () => {
+    expect(helpers.buildAttendanceApprovalAssignments([], 0)).toEqual([
+      {
+        assignmentType: 'role',
+        assigneeId: 'admin',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: { source: 'attendance', queue: 'attendance-approval' },
+      },
+      {
+        assignmentType: 'source_queue',
+        assigneeId: 'attendance:approve',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: { source: 'attendance', queue: 'attendance-approval' },
+      },
+      {
+        assignmentType: 'source_queue',
+        assigneeId: 'attendance:admin',
+        sourceStep: 0,
+        nodeKey: 'attendance_request_step_0',
+        metadata: { source: 'attendance', queue: 'attendance-approval' },
+      },
+    ])
+  })
+
+  it('builds approval instance metadata that the global approval inbox can route back to attendance', () => {
+    const payload = helpers.buildAttendanceApprovalInstancePayload({
+      approvalId: 'apv-1',
+      requestId: 'request-1',
+      orgId: 'org-1',
+      userId: 'employee-1',
+      requesterName: 'Employee One',
+      draft: {
+        workDate: '2026-05-29',
+        requestType: 'missed_check_out',
+        requestedInAt: null,
+        requestedOutAt: new Date('2026-05-29T18:00:00.000Z'),
+        reason: 'forgot checkout',
+        metadata: { minutes: 395 },
+      },
+    })
+
+    expect(payload.workflowKey).toBe('attendance.request')
+    expect(payload.businessKey).toBe('attendance-request:request-1')
+    expect(payload.title).toContain('漏打下班卡')
+    expect(payload.requesterSnapshot).toEqual({ id: 'employee-1', name: 'Employee One' })
+    expect(payload.formSnapshot).toMatchObject({
+      attendanceRequestId: 'request-1',
+      requestType: 'missed_check_out',
+      workDate: '2026-05-29',
+      requestedOutAt: '2026-05-29T18:00:00.000Z',
+    })
+    expect(payload.policySnapshot).toMatchObject({ sourceOfTruth: 'attendance' })
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -43,6 +43,8 @@ const REQUEST_TYPES = [
   'leave',
   'overtime',
 ]
+const ATTENDANCE_APPROVAL_WORKFLOW_KEY = 'attendance.request'
+const ATTENDANCE_APPROVAL_QUEUE_PERMISSIONS = ['attendance:approve', 'attendance:admin']
 const ATTENDANCE_SCHEDULE_GROUP_SOURCES = new Set(['manual', 'import', 'integration'])
 const ATTENDANCE_SCHEDULE_GROUP_MEMBER_ROLES = new Set(['member', 'lead', 'backup'])
 const ATTENDANCE_SCHEDULER_SCOPE_SUBJECT_TYPES = new Set(['user', 'role', 'role_tag'])
@@ -14593,6 +14595,216 @@ function normalizeApprovalSteps(value) {
     .filter(Boolean)
 }
 
+function attendanceRequestTypeLabel(requestType) {
+  const labels = {
+    missed_check_in: '漏打上班卡',
+    missed_check_out: '漏打下班卡',
+    time_correction: '时间更正',
+    leave: '请假',
+    overtime: '加班',
+  }
+  return labels[requestType] ?? String(requestType ?? '考勤')
+}
+
+function buildAttendanceApprovalNodeKey(stepIndex) {
+  return `attendance_request_step_${Math.max(0, Number(stepIndex ?? 0))}`
+}
+
+function buildAttendanceApprovalAssignments(flowSteps, stepIndex = 0) {
+  const steps = normalizeApprovalSteps(flowSteps)
+  const index = steps.length > 0
+    ? Math.min(Math.max(Number.isFinite(Number(stepIndex)) ? Number(stepIndex) : 0, 0), steps.length - 1)
+    : 0
+  const currentStep = steps[index]
+  const nodeKey = buildAttendanceApprovalNodeKey(index)
+  const assignments = []
+  const seen = new Set()
+
+  const pushAssignment = (assignmentType, assigneeId, metadata = {}) => {
+    const normalizedAssignee = String(assigneeId ?? '').trim()
+    if (!normalizedAssignee) return
+    const key = `${assignmentType}:${normalizedAssignee}`
+    if (seen.has(key)) return
+    seen.add(key)
+    assignments.push({
+      assignmentType,
+      assigneeId: normalizedAssignee,
+      sourceStep: index,
+      nodeKey,
+      metadata,
+    })
+  }
+
+  if (currentStep) {
+    for (const approverUserId of currentStep.approverUserIds ?? []) {
+      pushAssignment('user', approverUserId, { source: 'attendance', stepName: currentStep.name ?? null })
+    }
+    for (const approverRoleId of currentStep.approverRoleIds ?? []) {
+      pushAssignment('role', approverRoleId, { source: 'attendance', stepName: currentStep.name ?? null })
+    }
+  }
+
+  if (assignments.length === 0) {
+    pushAssignment('role', 'admin', { source: 'attendance', queue: 'attendance-approval' })
+    for (const permission of ATTENDANCE_APPROVAL_QUEUE_PERMISSIONS) {
+      pushAssignment('source_queue', permission, { source: 'attendance', queue: 'attendance-approval' })
+    }
+  }
+
+  return assignments
+}
+
+function buildAttendanceApprovalInstancePayload({ approvalId, requestId, orgId, userId, requesterName, draft }) {
+  const requestType = draft?.requestType
+  const requestLabel = attendanceRequestTypeLabel(requestType)
+  const workDate = draft?.workDate ?? null
+  const flowSteps = normalizeApprovalSteps(draft?.metadata?.approvalFlow?.steps)
+  const totalSteps = flowSteps.length > 0 ? flowSteps.length : 1
+  const title = `考勤审批 · ${requestLabel} · ${workDate ?? '-'}`
+  const formSnapshot = {
+    attendanceRequestId: requestId,
+    orgId,
+    userId,
+    workDate,
+    requestType,
+    requestedInAt: draft?.requestedInAt ? new Date(draft.requestedInAt).toISOString() : null,
+    requestedOutAt: draft?.requestedOutAt ? new Date(draft.requestedOutAt).toISOString() : null,
+    reason: draft?.reason ?? null,
+    minutes: draft?.metadata?.minutes ?? null,
+  }
+
+  return {
+    id: approvalId,
+    status: 'pending',
+    version: 0,
+    sourceSystem: 'platform',
+    workflowKey: ATTENDANCE_APPROVAL_WORKFLOW_KEY,
+    businessKey: `attendance-request:${requestId}`,
+    title,
+    requesterSnapshot: {
+      id: userId,
+      name: requesterName || userId,
+    },
+    subjectSnapshot: {
+      type: 'attendance_request',
+      requestId,
+      orgId,
+      userId,
+      workDate,
+      requestType,
+      label: requestLabel,
+    },
+    policySnapshot: {
+      rejectCommentRequired: true,
+      sourceOfTruth: 'attendance',
+    },
+    metadata: {
+      source: 'attendance',
+      requestId,
+      orgId,
+      userId,
+      workDate,
+      requestType,
+      approvalFlow: draft?.metadata?.approvalFlow ?? null,
+    },
+    currentStep: 0,
+    totalSteps,
+    requestNo: `ATT-${requestId}`,
+    formSnapshot,
+    currentNodeKey: buildAttendanceApprovalNodeKey(0),
+  }
+}
+
+async function upsertAttendanceApprovalInstance(client, payload) {
+  await client.query(
+    `INSERT INTO approval_instances
+     (id, status, version, source_system, workflow_key, business_key, title,
+      requester_snapshot, subject_snapshot, policy_snapshot, metadata,
+      current_step, total_steps, request_no, form_snapshot, current_node_key,
+      sync_status, created_at, updated_at)
+     VALUES ($1, $2, $3, $4, $5, $6, $7,
+             $8::jsonb, $9::jsonb, $10::jsonb, $11::jsonb,
+             $12, $13, $14, $15::jsonb, $16,
+             'ok', now(), now())
+     ON CONFLICT (id) DO UPDATE
+       SET status = EXCLUDED.status,
+           source_system = EXCLUDED.source_system,
+           workflow_key = EXCLUDED.workflow_key,
+           business_key = EXCLUDED.business_key,
+           title = EXCLUDED.title,
+           requester_snapshot = EXCLUDED.requester_snapshot,
+           subject_snapshot = EXCLUDED.subject_snapshot,
+           policy_snapshot = EXCLUDED.policy_snapshot,
+           metadata = EXCLUDED.metadata,
+           current_step = EXCLUDED.current_step,
+           total_steps = EXCLUDED.total_steps,
+           request_no = EXCLUDED.request_no,
+           form_snapshot = EXCLUDED.form_snapshot,
+           current_node_key = EXCLUDED.current_node_key,
+           sync_status = 'ok',
+           updated_at = now()`,
+    [
+      payload.id,
+      payload.status,
+      payload.version,
+      payload.sourceSystem,
+      payload.workflowKey,
+      payload.businessKey,
+      payload.title,
+      JSON.stringify(payload.requesterSnapshot),
+      JSON.stringify(payload.subjectSnapshot),
+      JSON.stringify(payload.policySnapshot),
+      JSON.stringify(payload.metadata),
+      payload.currentStep,
+      payload.totalSteps,
+      payload.requestNo,
+      JSON.stringify(payload.formSnapshot),
+      payload.currentNodeKey,
+    ]
+  )
+}
+
+async function replaceAttendanceApprovalAssignments(client, approvalId, assignments) {
+  await client.query(
+    `UPDATE approval_assignments
+     SET is_active = FALSE, updated_at = now()
+     WHERE instance_id = $1 AND is_active = TRUE`,
+    [approvalId]
+  )
+
+  for (const assignment of assignments) {
+    await client.query(
+      `INSERT INTO approval_assignments
+       (instance_id, assignment_type, assignee_id, source_step, node_key, is_active, metadata)
+       VALUES ($1, $2, $3, $4, $5, TRUE, $6::jsonb)
+       ON CONFLICT (instance_id, assignment_type, assignee_id)
+       WHERE is_active = TRUE
+       DO UPDATE SET source_step = EXCLUDED.source_step,
+                     node_key = EXCLUDED.node_key,
+                     is_active = TRUE,
+                     metadata = EXCLUDED.metadata,
+                     updated_at = now()`,
+      [
+        approvalId,
+        assignment.assignmentType,
+        assignment.assigneeId,
+        assignment.sourceStep,
+        assignment.nodeKey,
+        JSON.stringify(assignment.metadata ?? {}),
+      ]
+    )
+  }
+}
+
+async function deactivateAttendanceApprovalAssignments(client, approvalId) {
+  await client.query(
+    `UPDATE approval_assignments
+     SET is_active = FALSE, updated_at = now()
+     WHERE instance_id = $1 AND is_active = TRUE`,
+    [approvalId]
+  )
+}
+
 async function userHasAnyRole(db, userId, roleIds, logger) {
   if (!roleIds || roleIds.length === 0) return false
   try {
@@ -14795,6 +15007,14 @@ module.exports = {
     matchScopeFilters,
     loadAttendanceScopeContextForUser,
     loadAttendanceScopeContextMapForUsers,
+  },
+  __attendanceApprovalCenterForTests: {
+    ATTENDANCE_APPROVAL_WORKFLOW_KEY,
+    ATTENDANCE_APPROVAL_QUEUE_PERMISSIONS,
+    attendanceRequestTypeLabel,
+    buildAttendanceApprovalNodeKey,
+    buildAttendanceApprovalAssignments,
+    buildAttendanceApprovalInstancePayload,
   },
 
   async activate(context) {
@@ -18355,7 +18575,17 @@ module.exports = {
           throw error
         }
 
+        const requestId = randomUUID()
         const approvalId = `apv_${randomUUID()}`
+        const approvalPayload = buildAttendanceApprovalInstancePayload({
+          approvalId,
+          requestId,
+          orgId,
+          userId,
+          requesterName: getUserLabel(req, userId),
+          draft,
+        })
+        const approvalAssignments = buildAttendanceApprovalAssignments(draft.metadata?.approvalFlow?.steps, 0)
 
         try {
           const request = await db.transaction(async (trx) => {
@@ -18369,10 +18599,8 @@ module.exports = {
             if (duplicateRequest) {
               throw new HttpError(409, 'DUPLICATE_REQUEST', 'Duplicate attendance request already exists for this date')
             }
-            await trx.query(
-              'INSERT INTO approval_instances (id, status, version) VALUES ($1, $2, $3)',
-              [approvalId, 'pending', 0]
-            )
+            await upsertAttendanceApprovalInstance(trx, approvalPayload)
+            await replaceAttendanceApprovalAssignments(trx, approvalId, approvalAssignments)
 
             const rows = await trx.query(
               `INSERT INTO attendance_requests
@@ -18380,7 +18608,7 @@ module.exports = {
                VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9, $10, $11::jsonb)
                RETURNING *`,
               [
-                randomUUID(),
+                requestId,
                 userId,
                 orgId,
                 draft.workDate,
@@ -18608,6 +18836,19 @@ module.exports = {
               throw new HttpError(409, 'DUPLICATE_REQUEST', 'Duplicate attendance request already exists for this date')
             }
 
+            const approvalId = existingRequest.approval_instance_id || `apv_${randomUUID()}`
+            const approvalPayload = buildAttendanceApprovalInstancePayload({
+              approvalId,
+              requestId,
+              orgId: existingRequest.org_id ?? DEFAULT_ORG_ID,
+              userId: existingRequest.user_id,
+              requesterName: existingRequest.user_id,
+              draft,
+            })
+            const approvalAssignments = buildAttendanceApprovalAssignments(draft.metadata?.approvalFlow?.steps, 0)
+            await upsertAttendanceApprovalInstance(trx, approvalPayload)
+            await replaceAttendanceApprovalAssignments(trx, approvalId, approvalAssignments)
+
             const rows = await trx.query(
               `UPDATE attendance_requests
                SET work_date = $2,
@@ -18616,6 +18857,7 @@ module.exports = {
                    requested_out_at = $5,
                    reason = $6,
                    metadata = $7::jsonb,
+                   approval_instance_id = $8,
                    updated_at = now()
                WHERE id = $1
                RETURNING *`,
@@ -18627,6 +18869,7 @@ module.exports = {
                 draft.requestedOutAt,
                 draft.reason,
                 JSON.stringify(draft.metadata),
+                approvalId,
               ]
             )
             return rows[0]
@@ -18757,10 +19000,27 @@ module.exports = {
           const newVersion = Number(approval.version ?? 0) + 1
           const resolvedAt = new Date()
 
+          const nextStepIndex = isFinalApproval ? currentStepIndex : currentStepIndex + 1
           await trx.query(
-            'UPDATE approval_instances SET status = $1, version = $2, updated_at = now() WHERE id = $3',
-            [newStatus, newVersion, approvalId]
+            `UPDATE approval_instances
+             SET status = $1,
+                 version = $2,
+                 current_step = $3,
+                 current_node_key = $4,
+                 updated_at = now()
+             WHERE id = $5`,
+            [newStatus, newVersion, nextStepIndex, buildAttendanceApprovalNodeKey(nextStepIndex), approvalId]
           )
+
+          if (isFinalApproval) {
+            await deactivateAttendanceApprovalAssignments(trx, approvalId)
+          } else {
+            await replaceAttendanceApprovalAssignments(
+              trx,
+              approvalId,
+              buildAttendanceApprovalAssignments(flowSteps, nextStepIndex)
+            )
+          }
 
           const recordMetadata = {
             ...(parsed.data.metadata ?? {}),
@@ -18794,7 +19054,7 @@ module.exports = {
               id: flowMeta.id,
               name: flowMeta.name,
               steps: flowSteps,
-              currentStep: isFinalApproval ? currentStepIndex : currentStepIndex + 1,
+              currentStep: nextStepIndex,
             }
           }
           if (isFinalApproval) {
@@ -18997,6 +19257,7 @@ module.exports = {
                 'UPDATE approval_instances SET status = $1, version = $2, updated_at = now() WHERE id = $3',
                 [newStatus, newVersion, approvalId]
               )
+              await deactivateAttendanceApprovalAssignments(trx, approvalId)
 
               await trx.query(
                 `INSERT INTO approval_records


### PR DESCRIPTION
## Summary
- create approval-center metadata and active assignments for attendance requests so pending requests can appear in the global approval queue
- match source-queue assignments against attendance approve/admin permissions and keep unread counts / mark-all-read aligned
- route bridged attendance approval rows back to the attendance request queue, and deactivate assignments when attendance requests resolve or cancel

Fixes #1919

## Verification
- node --check plugins/plugin-attendance/index.cjs
- git diff --check origin/main...HEAD
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-approval-center-bridge.test.ts tests/unit/approval-realtime.test.ts tests/unit/approvals-bridge-routes.test.ts --watch=false
- pnpm --filter @metasheet/web exec vitest run tests/approvalCenterUnreadBadge.spec.ts --watch=false
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web lint
- pnpm --filter @metasheet/web build
