### PR TITLE
fix(multitable): tolerate missing member-group directory in permission lists

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -3820,36 +3820,68 @@ export function univerMetaRouter(): Router {
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!capabilities.canManageViews) return sendForbidden(res)
 
-      const result = await pool.query(
-        `SELECT
-            vp.id,
-            vp.view_id,
-            vp.subject_type,
-            vp.subject_id,
-            vp.permission,
-            vp.created_at,
-            vp.created_by,
-            u.name AS user_name,
-            u.email AS user_email,
-            u.is_active AS user_is_active,
-            r.name AS role_name,
-            r.description AS role_description,
-            g.name AS group_name,
-            g.description AS group_description
-         FROM meta_view_permissions vp
-         LEFT JOIN users u
-           ON vp.subject_type = 'user'
-          AND u.id = vp.subject_id
-         LEFT JOIN roles r
-           ON vp.subject_type = 'role'
-          AND r.id::text = vp.subject_id
-         LEFT JOIN platform_member_groups g
-           ON vp.subject_type = 'member-group'
-          AND g.id::text = vp.subject_id
-         WHERE vp.view_id = $1
-         ORDER BY vp.created_at ASC`,
-        [viewId],
-      )
+      let result: { rows: any[] }
+      try {
+        result = await pool.query(
+          `SELECT
+              vp.id,
+              vp.view_id,
+              vp.subject_type,
+              vp.subject_id,
+              vp.permission,
+              vp.created_at,
+              vp.created_by,
+              u.name AS user_name,
+              u.email AS user_email,
+              u.is_active AS user_is_active,
+              r.name AS role_name,
+              r.description AS role_description,
+              g.name AS group_name,
+              g.description AS group_description
+           FROM meta_view_permissions vp
+           LEFT JOIN users u
+             ON vp.subject_type = 'user'
+            AND u.id = vp.subject_id
+           LEFT JOIN roles r
+             ON vp.subject_type = 'role'
+            AND r.id::text = vp.subject_id
+           LEFT JOIN platform_member_groups g
+             ON vp.subject_type = 'member-group'
+            AND g.id::text = vp.subject_id
+           WHERE vp.view_id = $1
+           ORDER BY vp.created_at ASC`,
+          [viewId],
+        )
+      } catch (err) {
+        if (!isUndefinedTableError(err, 'platform_member_groups')) throw err
+        result = await pool.query(
+          `SELECT
+              vp.id,
+              vp.view_id,
+              vp.subject_type,
+              vp.subject_id,
+              vp.permission,
+              vp.created_at,
+              vp.created_by,
+              u.name AS user_name,
+              u.email AS user_email,
+              u.is_active AS user_is_active,
+              r.name AS role_name,
+              r.description AS role_description,
+              NULL::text AS group_name,
+              NULL::text AS group_description
+           FROM meta_view_permissions vp
+           LEFT JOIN users u
+             ON vp.subject_type = 'user'
+            AND u.id = vp.subject_id
+           LEFT JOIN roles r
+             ON vp.subject_type = 'role'
+            AND r.id::text = vp.subject_id
+           WHERE vp.view_id = $1
+           ORDER BY vp.created_at ASC`,
+          [viewId],
+        )
+      }
       const items = (result.rows as any[]).map((row) => ({
         id: String(row.id),
         viewId: String(row.view_id),
@@ -3966,37 +3998,70 @@ export function univerMetaRouter(): Router {
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), sheetId)
       if (!capabilities.canManageFields) return sendForbidden(res)
 
-      const result = await pool.query(
-        `SELECT
-            fp.id,
-            fp.sheet_id,
-            fp.field_id,
-            fp.subject_type,
-            fp.subject_id,
-            fp.visible,
-            fp.read_only,
-            fp.created_at,
-            u.name AS user_name,
-            u.email AS user_email,
-            u.is_active AS user_is_active,
-            r.name AS role_name,
-            r.description AS role_description,
-            g.name AS group_name,
-            g.description AS group_description
-         FROM field_permissions fp
-         LEFT JOIN users u
-           ON fp.subject_type = 'user'
-          AND u.id = fp.subject_id
-         LEFT JOIN roles r
-           ON fp.subject_type = 'role'
-          AND r.id::text = fp.subject_id
-         LEFT JOIN platform_member_groups g
-           ON fp.subject_type = 'member-group'
-          AND g.id::text = fp.subject_id
-         WHERE fp.sheet_id = $1
-         ORDER BY fp.field_id ASC, fp.created_at ASC`,
-        [sheetId],
-      )
+      let result: { rows: any[] }
+      try {
+        result = await pool.query(
+          `SELECT
+              fp.id,
+              fp.sheet_id,
+              fp.field_id,
+              fp.subject_type,
+              fp.subject_id,
+              fp.visible,
+              fp.read_only,
+              fp.created_at,
+              u.name AS user_name,
+              u.email AS user_email,
+              u.is_active AS user_is_active,
+              r.name AS role_name,
+              r.description AS role_description,
+              g.name AS group_name,
+              g.description AS group_description
+           FROM field_permissions fp
+           LEFT JOIN users u
+             ON fp.subject_type = 'user'
+            AND u.id = fp.subject_id
+           LEFT JOIN roles r
+             ON fp.subject_type = 'role'
+            AND r.id::text = fp.subject_id
+           LEFT JOIN platform_member_groups g
+             ON fp.subject_type = 'member-group'
+            AND g.id::text = fp.subject_id
+           WHERE fp.sheet_id = $1
+           ORDER BY fp.field_id ASC, fp.created_at ASC`,
+          [sheetId],
+        )
+      } catch (err) {
+        if (!isUndefinedTableError(err, 'platform_member_groups')) throw err
+        result = await pool.query(
+          `SELECT
+              fp.id,
+              fp.sheet_id,
+              fp.field_id,
+              fp.subject_type,
+              fp.subject_id,
+              fp.visible,
+              fp.read_only,
+              fp.created_at,
+              u.name AS user_name,
+              u.email AS user_email,
+              u.is_active AS user_is_active,
+              r.name AS role_name,
+              r.description AS role_description,
+              NULL::text AS group_name,
+              NULL::text AS group_description
+           FROM field_permissions fp
+           LEFT JOIN users u
+             ON fp.subject_type = 'user'
+            AND u.id = fp.subject_id
+           LEFT JOIN roles r
+             ON fp.subject_type = 'role'
+            AND r.id::text = fp.subject_id
+           WHERE fp.sheet_id = $1
+           ORDER BY fp.field_id ASC, fp.created_at ASC`,
+          [sheetId],
+        )
+      }
       const items = (result.rows as any[]).map((row) => ({
         id: String(row.id),
         sheetId: String(row.sheet_id),

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -124,6 +124,10 @@ async function createApp(args: {
   return { app, mockPool }
 }
 
+function undefinedTableError(tableName: string) {
+  return Object.assign(new Error(`relation "${tableName}" does not exist`), { code: '42P01' })
+}
+
 describe('Multitable sheet-scoped permissions API', () => {
   afterEach(() => {
     vi.restoreAllMocks()
@@ -1098,7 +1102,7 @@ describe('Multitable sheet-scoped permissions API', () => {
           expect(params).toEqual(['sheet_ops'])
           return { rows: [{ id: 'sheet_ops' }] }
         }
-        if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1 ORDER BY "order" ASC, id ASC LIMIT 500')) {
+        if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1 ORDER BY "order" ASC, id ASC')) {
           expect(params).toEqual(['sheet_ops'])
           return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 0 }] }
         }
@@ -3072,5 +3076,65 @@ describe('Multitable sheet-scoped permissions API', () => {
         createdAt: '',
       },
     ])
+  })
+
+  test('lists field permissions when the optional member-group directory table is absent', async () => {
+    const { app, mockPool } = await createApp({
+      tokenPerms: ['multitable:read'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, base_id, name, description FROM meta_sheets WHERE id = $1')) {
+          expect(params).toEqual(['sheet_ops'])
+          return { rows: [{ id: 'sheet_ops', base_id: 'base_ops', name: 'Ops', description: null }] }
+        }
+        if (sql.includes('FROM spreadsheet_permissions') && sql.includes('sheet_id = ANY')) {
+          expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
+          return { rows: [{ sheet_id: 'sheet_ops', perm_code: 'spreadsheet:admin', subject_type: 'user' }] }
+        }
+        if (sql.includes('FROM field_permissions fp') && sql.includes('LEFT JOIN platform_member_groups g')) {
+          throw undefinedTableError('platform_member_groups')
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/sheets/sheet_ops/field-permissions')
+      .expect(200)
+
+    expect(response.body.data.items).toEqual([])
+    const fieldPermissionCalls = mockPool.query.mock.calls.filter(([sql]) => String(sql).includes('FROM field_permissions fp'))
+    expect(fieldPermissionCalls).toHaveLength(2)
+    expect(String(fieldPermissionCalls[0]?.[0])).toContain('LEFT JOIN platform_member_groups g')
+    expect(String(fieldPermissionCalls[1]?.[0])).not.toContain('LEFT JOIN platform_member_groups g')
+  })
+
+  test('lists view permissions when the optional member-group directory table is absent', async () => {
+    const { app, mockPool } = await createApp({
+      tokenPerms: ['multitable:read'],
+      queryHandler: async (sql, params) => {
+        if (sql.includes('SELECT id, sheet_id FROM meta_views WHERE id = $1')) {
+          expect(params).toEqual(['view_ops'])
+          return { rows: [{ id: 'view_ops', sheet_id: 'sheet_ops' }] }
+        }
+        if (sql.includes('FROM spreadsheet_permissions') && sql.includes('sheet_id = ANY')) {
+          expect(params).toEqual(['user_sheet_acl_1', ['sheet_ops']])
+          return { rows: [{ sheet_id: 'sheet_ops', perm_code: 'spreadsheet:admin', subject_type: 'user' }] }
+        }
+        if (sql.includes('FROM meta_view_permissions vp') && sql.includes('LEFT JOIN platform_member_groups g')) {
+          throw undefinedTableError('platform_member_groups')
+        }
+        throw new Error(`Unhandled SQL in test: ${sql}`)
+      },
+    })
+
+    const response = await request(app)
+      .get('/api/multitable/views/view_ops/permissions')
+      .expect(200)
+
+    expect(response.body.data.items).toEqual([])
+    const viewPermissionCalls = mockPool.query.mock.calls.filter(([sql]) => String(sql).includes('FROM meta_view_permissions vp'))
+    expect(viewPermissionCalls).toHaveLength(2)
+    expect(String(viewPermissionCalls[0]?.[0])).toContain('LEFT JOIN platform_member_groups g')
+    expect(String(viewPermissionCalls[1]?.[0])).not.toContain('LEFT JOIN platform_member_groups g')
   })
 })


### PR DESCRIPTION
## Summary
- keep multitable field/view permission list endpoints from returning 500 when the optional `platform_member_groups` directory table is absent in a partially migrated environment
- retry the list query without the member-group label join and fall back to subject ids when labels cannot be hydrated
- add regression coverage for both field and view permission list fallback paths

Fixes #1969 by addressing the remaining blocking permission API 500 called out in the retest notes.

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-sheet-permissions.api.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check origin/main...HEAD`
