### PR TITLE
fix(multitable): preserve denied-field filter literals on view re-save (#2068 guard)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -174,6 +174,7 @@ jobs:
             tests/integration/multitable-records-read-field-mask.test.ts \
             tests/integration/multitable-readpath-search-filter-field-mask.test.ts \
             tests/integration/multitable-viewconfig-filter-literal-redaction.test.ts \
+            tests/integration/multitable-viewconfig-resave-guard.test.ts \
             tests/integration/multitable-automation-retry.test.ts \
             --reporter=dot
 

--- a/docs/development/multitable-viewconfig-resave-guard-verification-20260529.md
+++ b/docs/development/multitable-viewconfig-resave-guard-verification-20260529.md
@@ -1,0 +1,44 @@
+# Multitable view-config re-save guard — impl & verification
+
+- **Slice**: impl of the #2068 design-lock (`multitable-viewconfig-resave-guard-design-20260529.md`); follow-up to priority-#2 (b) (#2052 design / #2059 impl).
+- **Status**: implemented + real-DB verified (fail-first). Backend-only; awaiting merge greenlight.
+- **Grounding**: worktree off `origin/main 0f8fd882c`. Lock posture: multitable write-path **kernel-polish** — RBAC/auth, central permission model, `plugin-integration-core`, `src/formula/engine.ts` **NOT touched** ([[k3-poc-stage1-lock]]).
+
+## 1. What changed
+
+#2059 redacts saved-view filter literals on read (omits `filterInfo.conditions[].value` for fields the requester can't read). Write-path edge: a field-denied `canManageViews` user re-saving a view echoes the redacted condition back **without a `value`** → `PATCH /views/:viewId` overwrote `meta_views.filter_info` and **silently erased** the literal. This guard preserves it.
+
+- **`mergeRedactedFilterInfoForUpdate(incoming, current, allowedFieldIds)`** (`univer-meta.ts`, after the #2059 redactor) — **PURE**; returns the merged `filterInfo` or **`null`** on structural mismatch (route → 400). Rules (per design §3): allowed field → trust incoming; denied + explicit `value` key → trust incoming (existing `canManageViews` write behavior, **not** a new policy); denied + **no** `value` key → match the **same-index** current condition by `(fieldId, operator)` and **restore the current literal** (or keep as-is if current is also unary; **reject `null`** if no safe match). Iterates incoming only → a removed condition stays removed. Value-only: `operator`/`fieldId`/`sortInfo`/`groupInfo`/`config` pass through untouched.
+- **`PATCH /views/:viewId` wiring**: `allowedFieldIds` (the #2059 `loadAllowedFieldIds`) is computed **up front**; when `filterInfo` is present, `nextFilter` runs through the merge helper; `null` → `400 VALIDATION_ERROR` (DB untouched). The existing `metaViewConfigCache.set(viewId, view)` already caches the **unredacted** `view` (built from `nextFilter` = the merged filter), and the response returns `redactViewConfigFilterLiterals(view, allowedFieldIds)` — so the #2059 cache invariant (cache unredacted, redact per-response) holds for free (R8).
+
+## 2. Fail-first proof (real DB)
+
+`tests/integration/multitable-viewconfig-resave-guard.test.ts`, wired into `plugin-tests.yml`. Assertions read `meta_views.filter_info` **directly** (the response is redacted either way).
+
+**Pre-fix (unmodified `0f8fd882c`):** `Tests 5 failed | 5 passed (10)`:
+```
+× R1 redacted denied condition re-save → DB literal ERASED (the mandated corruption proof)
+× R2 (the denied literal is also erased while a visible field updates)
+× R5 structural mismatch → no guard → 200 (expected 400) + literal erased
+× R6 property.hidden (layer-2) literal ERASED (mandated corruption proof)
+× R8 allowed reader can't see the (erased) literal afterward
+✓ sentinel, R3 (explicit write), R4 (remove), R7 (layer-1 normal write), R9 (unary)
+```
+**Post-fix:** `Tests 10 passed`. R1/R6 (the §5 mandated fail-first) flip from erased → preserved.
+
+Matrix: **R1** preserve on no-op edit · **R2** allowed field still updates (denied still preserved) · **R3** explicit denied value written, response redacts (scope boundary — not a new write policy) · **R4** removed-stays-removed · **R5** structural mismatch → 400, DB unchanged · **R6** layer-2 `property.hidden` preserved · **R7** layer-1 view-hidden writes normally (readable) · **R8** cross-user: allowed reader sees the preserved literal while the denied writer's response omitted it (cache unredacted + per-response redaction) · **R9** unary denied (`isNotEmpty`) re-saves without rejection or a manufactured value.
+
+> Note (matches design §3/§6): removing a denied condition that **precedes** a still-redacted one shifts indices → the same-index match fails → **400** (intentional; R4 therefore prunes to the allowed condition rather than removing one mid-list). Reorder/structural change of a redacted condition → 400 is the data-safety backstop, not a regression.
+
+## 3. Regression — clean
+- **tsc** clean on the touched file.
+- **#2059 `multitable-viewconfig-filter-literal-redaction`** (exercises `PATCH /views/:viewId` at its R9) + read-path siblings (#2044 search/filter/sort, #2028 records-read-mask, view-aggregate) + the new test: **5 files green together**.
+- `d3d1`/`d3d2` skip-or-fail locally only on the known pre-existing schema gaps; green in CI's fresh DB.
+
+## 4. Scope & non-goals (per design)
+In scope: `PATCH /views/:viewId`, `filterInfo.conditions[].value` only, preserve-on-redacted-echo. Out of scope (unchanged): `POST /views` (no prior literal); whether a field-denied `canManageViews` user may *author* a denied-field literal (explicit `value` still follows existing semantics); frontend redacted-input UX; full field-def strip; other layer-2 read sites; RBAC/auth.
+
+## 5. Gated TODO
+- ✅ Pure merge helper + `PATCH /views/:viewId` wiring (cache stays unredacted).
+- ✅ R1–R9 real-DB, fail-first on R1/R6; wired into `plugin-tests.yml`; tsc clean; regression clean.
+- 🔒 Frontend UX (disabled redacted inputs / "value hidden by permissions" badge / stable condition IDs to relax the reorder-400) — separate later opt-in.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -2321,6 +2321,37 @@ function redactViewConfigFilterLiterals<T extends { filterInfo?: unknown } | nul
   return { ...(view as object), filterInfo: { ...(filterInfo as object), conditions: redactedConditions } } as T
 }
 
+// #2068 re-save guard: PURE merge of an incoming PATCH filterInfo against the current DB filterInfo, so a
+// field-denied user re-saving a view (whose denied conditions came back from #2059 redaction with NO `value`
+// key) does not silently erase the literal they were never allowed to see. Value-only, mirroring #2059 —
+// only filterInfo.conditions[].value is ever preserved; sortInfo/groupInfo/config/operator/fieldId pass through.
+// Matches by array-index + (fieldId, operator) (no stable condition IDs); rejects on structural mismatch
+// rather than guess. Returns null on structural mismatch so the route can answer 400 (never persist a missing literal).
+function mergeRedactedFilterInfoForUpdate(incoming: Record<string, unknown>, current: unknown, allowedFieldIds: Set<string>): Record<string, unknown> | null {
+  if (!Array.isArray((incoming as { conditions?: unknown }).conditions)) {
+    return incoming // not a conditions-bearing filter → nothing to preserve
+  }
+  const incomingConditions = (incoming as { conditions: Array<Record<string, unknown>> }).conditions
+  const currentConditions = (current && typeof current === 'object' && Array.isArray((current as { conditions?: unknown }).conditions))
+    ? (current as { conditions: Array<Record<string, unknown>> }).conditions
+    : []
+  const merged: Array<Record<string, unknown>> = []
+  for (let i = 0; i < incomingConditions.length; i++) {
+    const c = incomingConditions[i]
+    const fieldId = typeof c?.fieldId === 'string' ? c.fieldId : null
+    const allowed = fieldId !== null && allowedFieldIds.has(fieldId)
+    const hasValue = !!c && typeof c === 'object' && Object.prototype.hasOwnProperty.call(c, 'value')
+    if (allowed || hasValue) { merged.push(c); continue } // allowed field, or explicit value (incl. denied) → trust incoming
+    // denied field with NO value key → must restore from the same-index current condition or reject.
+    const cur = currentConditions[i]
+    const sameShape = !!cur && typeof cur === 'object' && cur.fieldId === c.fieldId && cur.operator === c.operator
+    if (!sameShape) return null // structural mismatch → reject (route answers 400; never persist a missing literal)
+    if (Object.prototype.hasOwnProperty.call(cur, 'value')) merged.push({ ...c, value: (cur as { value?: unknown }).value }) // restore the literal
+    else merged.push(c) // current is also unary (no value) → nothing to protect; keep as-is
+  }
+  return { ...incoming, conditions: merged }
+}
+
 async function loadXlsxModule(): Promise<XlsxModule> {
   return await import('xlsx') as unknown as XlsxModule
 }
@@ -5263,9 +5294,20 @@ export function univerMetaRouter(): Router {
       const row: any = current.rows[0]
       const { capabilities } = await resolveSheetCapabilities(req, pool.query.bind(pool), String(row.sheet_id))
       if (!capabilities.canManageViews) return sendForbidden(res)
+      // #2068 re-save guard: compute the writer's allowed-field set up front, then merge the incoming
+      // filterInfo against the current DB filter so a redacted denied condition (echoed back with NO `value`)
+      // preserves the persisted literal instead of erasing it; reject 400 on a structural mismatch.
+      const allowedFieldIds = await loadAllowedFieldIds(pool.query.bind(pool), String(row.sheet_id), (await resolveRequestAccess(req)).userId, capabilities)
       const nextName = parsed.data.name ?? String(row.name)
       const nextType = parsed.data.type ?? String(row.type ?? 'grid')
-      const nextFilter = parsed.data.filterInfo ?? normalizeJson(row.filter_info)
+      let nextFilter: Record<string, unknown> = normalizeJson(row.filter_info)
+      if (parsed.data.filterInfo !== undefined) {
+        const mergedFilter = mergeRedactedFilterInfoForUpdate(parsed.data.filterInfo, normalizeJson(row.filter_info), allowedFieldIds)
+        if (mergedFilter === null) {
+          return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Cannot re-save a hidden filter value that no longer matches the saved view; resubmit an explicit value or remove the condition.' } })
+        }
+        nextFilter = mergedFilter
+      }
       const nextSort = parsed.data.sortInfo ?? normalizeJson(row.sort_info)
       const nextGroup = parsed.data.groupInfo ?? normalizeJson(row.group_info)
       const nextHiddenFieldIds = parsed.data.hiddenFieldIds ?? normalizeJsonArray(row.hidden_field_ids)
@@ -5325,7 +5367,6 @@ export function univerMetaRouter(): Router {
       }
 
       metaViewConfigCache.set(viewId, view)
-      const allowedFieldIds = await loadAllowedFieldIds(pool.query.bind(pool), String(row.sheet_id), (await resolveRequestAccess(req)).userId, capabilities)
       return res.json({ ok: true, data: { view: redactViewConfigFilterLiterals(view, allowedFieldIds) } })
     } catch (err) {
       const hint = getDbNotReadyMessage(err)

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -2338,7 +2338,8 @@ function mergeRedactedFilterInfoForUpdate(incoming: Record<string, unknown>, cur
   const merged: Array<Record<string, unknown>> = []
   for (let i = 0; i < incomingConditions.length; i++) {
     const c = incomingConditions[i]
-    const fieldId = typeof c?.fieldId === 'string' ? c.fieldId : null
+    if (!c || typeof c !== 'object' || Array.isArray(c)) return null // malformed condition (null/non-object) → reject (route → 400), never a 500 or persisted garbage
+    const fieldId = typeof c.fieldId === 'string' ? c.fieldId : null
     const allowed = fieldId !== null && allowedFieldIds.has(fieldId)
     const hasValue = !!c && typeof c === 'object' && Object.prototype.hasOwnProperty.call(c, 'value')
     if (allowed || hasValue) { merged.push(c); continue } // allowed field, or explicit value (incl. denied) → trust incoming

--- a/packages/core-backend/tests/integration/multitable-viewconfig-resave-guard.test.ts
+++ b/packages/core-backend/tests/integration/multitable-viewconfig-resave-guard.test.ts
@@ -167,4 +167,12 @@ describeIfDatabase('multitable view-config re-save guard (#2068, real DB)', () =
     expect(secretCond).toBeDefined()
     expect(Object.prototype.hasOwnProperty.call(secretCond ?? {}, 'value')).toBe(false) // no manufactured value
   })
+
+  test('R10: a malformed condition (null) → 400 VALIDATION_ERROR, DB unchanged (never a 500)', async () => {
+    // z.record(z.unknown()) lets a client send conditions: [..., null]; the guard must reject, not throw.
+    const res = await patch({ filterInfo: { conjunction: 'and', conditions: [{ fieldId: FLD_VISIBLE, operator: 'is', value: VIS_LIT }, null] } })
+    expect(res.status).toBe(400)
+    expect(res.body.error?.code).toBe('VALIDATION_ERROR')
+    expect(valueOf(await dbFilterInfo(), FLD_SECRET)).toBe(SECRET_LIT) // DB untouched on reject
+  })
 })

--- a/packages/core-backend/tests/integration/multitable-viewconfig-resave-guard.test.ts
+++ b/packages/core-backend/tests/integration/multitable-viewconfig-resave-guard.test.ts
@@ -1,0 +1,170 @@
+/**
+ * Real-DB integration test for the view-config re-save guard (#2068 design-lock, impl).
+ *
+ * #2059 redacts saved-view filter literals on read (omits filterInfo.conditions[].value for fields the
+ * requester can't read). Write-path edge: a field-denied canManageViews user who re-saves a view echoes
+ * the redacted condition back WITHOUT a value → PATCH /views/:viewId would overwrite meta_views.filter_info
+ * and silently ERASE the literal they were never allowed to see. This guard preserves the existing DB
+ * literal when a redacted echo (denied field, NO `value` key) is re-saved.
+ *
+ * Fail-first (design §5): R1/R6 must be RED on unmodified main (DB literal erased after PATCH). Assertions
+ * read meta_views.filter_info DIRECTLY (the response is redacted either way — advisor #2). Seed non-negotiable:
+ * FLD_SECRET denied SOLELY via layer-3 (property.hidden UNSET). PATCH conditions mirror the seeded order
+ * (the guard matches by array-index + (fieldId, operator); reorder → intentional 400, R5).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_rsg_${TS}`
+const SHEET_ID = `sheet_rsg_${TS}`
+const FLD_VISIBLE = `fld_rsg_visible_${TS}`
+const FLD_SECRET = `fld_rsg_secret_${TS}` // layer-3 denied (property.hidden UNSET)
+const FLD_STATIC_HIDDEN = `fld_rsg_statichidden_${TS}` // layer-2 property.hidden=true
+const FLD_VIEWHIDDEN = `fld_rsg_viewhidden_${TS}` // layer-1: in hidden_field_ids, readable
+const VIEW_ID = `view_rsg_${TS}`
+const USER_ID = `u_rsg_${TS}` // canManageViews + FLD_SECRET denied
+const USER_ID_2 = `u_rsg_other_${TS}` // no deny (R8 allowed reader)
+const VIS_LIT = 'visible-literal'
+const SECRET_LIT = 'secret-literal-do-not-erase'
+const STATIC_LIT = 'statichidden-literal-do-not-erase'
+const VH_LIT = 'viewhidden-literal'
+
+// the seeded view's filter, in canonical order — the PATCH echoes mirror this order.
+const SEED_CONDITIONS = [
+  { fieldId: FLD_VISIBLE, operator: 'is', value: VIS_LIT },
+  { fieldId: FLD_SECRET, operator: 'is', value: SECRET_LIT },
+  { fieldId: FLD_STATIC_HIDDEN, operator: 'is', value: STATIC_LIT },
+  { fieldId: FLD_VIEWHIDDEN, operator: 'is', value: VH_LIT },
+]
+
+let app: Express
+let testUserId: string = USER_ID
+let testPerms: string[] = ['multitable:read', 'multitable:write'] // write → canManageViews
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const patch = (b: unknown) => request(app).patch(`/api/multitable/views/${VIEW_ID}`).send(b as object)
+const dbFilterInfo = async (): Promise<{ conditions?: Array<Record<string, unknown>> }> => {
+  const r = await q('SELECT filter_info FROM meta_views WHERE id = $1', [VIEW_ID])
+  const fi = (r.rows[0] as { filter_info?: unknown })?.filter_info
+  return (typeof fi === 'string' ? JSON.parse(fi) : fi) as { conditions?: Array<Record<string, unknown>> }
+}
+const valueOf = (fi: { conditions?: Array<Record<string, unknown>> }, fieldId: string) =>
+  fi.conditions?.find((c) => c.fieldId === fieldId)?.value
+
+async function seedView() {
+  await q('INSERT INTO meta_views (id, sheet_id, name, type, filter_info, hidden_field_ids) VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb)',
+    [VIEW_ID, SHEET_ID, 'RSG View', 'grid', JSON.stringify({ conjunction: 'and', conditions: SEED_CONDITIONS }), JSON.stringify([FLD_VIEWHIDDEN])])
+}
+
+describeIfDatabase('multitable view-config re-save guard (#2068, real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = testUserId ? { id: testUserId, roles: [], perms: testPerms } : undefined; next() })
+    app.use('/api/multitable', univerMetaRouter())
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [BASE_ID, 'RSG Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_ID, BASE_ID, 'RSG Sheet'])
+    for (const [fid, name, order, prop] of [
+      [FLD_VISIBLE, 'Visible', 1, '{}'], [FLD_SECRET, 'Secret', 2, '{}'],
+      [FLD_STATIC_HIDDEN, 'StaticHidden', 3, '{"hidden":true}'], [FLD_VIEWHIDDEN, 'ViewHidden', 4, '{}'],
+    ] as const) {
+      await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [fid, SHEET_ID, name, 'string', prop, order])
+    }
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER_ID, false, false])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  // each test starts from the canonical seeded view
+  beforeEach(async () => { testUserId = USER_ID; testPerms = ['multitable:read', 'multitable:write']; await q('DELETE FROM meta_views WHERE id = $1', [VIEW_ID]); await seedView() })
+
+  // a redacted echo of the seeded conditions: omit `value` for denied fields (FLD_SECRET / FLD_STATIC_HIDDEN)
+  const redactedEcho = () => SEED_CONDITIONS.map((c) => (c.fieldId === FLD_SECRET || c.fieldId === FLD_STATIC_HIDDEN) ? { fieldId: c.fieldId, operator: c.operator } : { ...c })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('R1 (req, fail-first): re-saving a redacted denied condition PRESERVES the DB literal (no-op title edit)', async () => {
+    const res = await patch({ name: 'RSG Renamed', filterInfo: { conjunction: 'and', conditions: redactedEcho() } })
+    expect(res.status).toBe(200)
+    expect(valueOf(await dbFilterInfo(), FLD_SECRET)).toBe(SECRET_LIT) // DB literal preserved (RED on unmodified: erased)
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_LIT) // response still redacts it
+  })
+
+  test('R2: an allowed field condition updates its value normally', async () => {
+    const conds = redactedEcho().map((c) => c.fieldId === FLD_VISIBLE ? { ...c, value: 'visible-updated' } : c)
+    expect((await patch({ filterInfo: { conjunction: 'and', conditions: conds } })).status).toBe(200)
+    expect(valueOf(await dbFilterInfo(), FLD_VISIBLE)).toBe('visible-updated')
+    expect(valueOf(await dbFilterInfo(), FLD_SECRET)).toBe(SECRET_LIT) // denied still preserved
+  })
+
+  test('R3: an explicit value for a denied field is written (existing canManageViews behavior, not a new policy)', async () => {
+    const conds = redactedEcho().map((c) => c.fieldId === FLD_SECRET ? { fieldId: c.fieldId, operator: c.operator, value: 'secret-rewritten' } : c)
+    const res = await patch({ filterInfo: { conjunction: 'and', conditions: conds } })
+    expect(res.status).toBe(200)
+    expect(valueOf(await dbFilterInfo(), FLD_SECRET)).toBe('secret-rewritten') // explicit write trusted
+    expect(JSON.stringify(res.body)).not.toContain('secret-rewritten') // response redacts the denied field
+  })
+
+  test('R4: a removed denied condition stays removed (guard does not resurrect it)', async () => {
+    // prune to the allowed condition only — FLD_SECRET (+ the other denied conds) dropped from the incoming list.
+    // (removing FLD_SECRET while keeping a later still-redacted condition would shift indices → intentional 400, R5.)
+    const conds = [{ fieldId: FLD_VISIBLE, operator: 'is', value: VIS_LIT }]
+    expect((await patch({ filterInfo: { conjunction: 'and', conditions: conds } })).status).toBe(200)
+    const fi = await dbFilterInfo()
+    expect(fi.conditions?.some((c) => c.fieldId === FLD_SECRET)).toBe(false) // removed, NOT resurrected by the guard
+  })
+
+  test('R5: a redacted denied condition that no longer matches same-index → 400, DB unchanged', async () => {
+    // drop FLD_VISIBLE so the denied FLD_SECRET echo lands at index 0, where current has FLD_VISIBLE (mismatch)
+    const conds = redactedEcho().filter((c) => c.fieldId !== FLD_VISIBLE)
+    const res = await patch({ filterInfo: { conjunction: 'and', conditions: conds } })
+    expect(res.status).toBe(400)
+    expect(valueOf(await dbFilterInfo(), FLD_SECRET)).toBe(SECRET_LIT) // DB untouched on reject
+  })
+
+  test('R6 (req, fail-first): re-saving a redacted property.hidden (layer-2) condition PRESERVES its literal', async () => {
+    expect((await patch({ name: 'RSG R6', filterInfo: { conjunction: 'and', conditions: redactedEcho() } })).status).toBe(200)
+    expect(valueOf(await dbFilterInfo(), FLD_STATIC_HIDDEN)).toBe(STATIC_LIT) // layer-2 preserved (RED on unmodified)
+  })
+
+  test('R7: a readable-but-view-hidden (layer-1) field writes normally — no preservation trigger', async () => {
+    const conds = redactedEcho().map((c) => c.fieldId === FLD_VIEWHIDDEN ? { ...c, value: 'viewhidden-updated' } : c)
+    expect((await patch({ filterInfo: { conjunction: 'and', conditions: conds } })).status).toBe(200)
+    expect(valueOf(await dbFilterInfo(), FLD_VIEWHIDDEN)).toBe('viewhidden-updated') // layer-1 is readable → normal write
+  })
+
+  test('R8: after a preserved update, a fully-allowed reader sees the literal; the denied writer\'s response omitted it', async () => {
+    const writerRes = await patch({ name: 'RSG R8', filterInfo: { conjunction: 'and', conditions: redactedEcho() } })
+    expect(JSON.stringify(writerRes.body)).not.toContain(SECRET_LIT) // denied writer's immediate response: redacted
+    testUserId = USER_ID_2; testPerms = ['multitable:read'] // allowed reader (no deny row)
+    const readerRes = await request(app).get('/api/multitable/view').query({ sheetId: SHEET_ID, viewId: VIEW_ID })
+    expect(readerRes.status).toBe(200)
+    expect(JSON.stringify(readerRes.body)).toContain(SECRET_LIT) // allowed reader sees the preserved literal (cache held unredacted)
+  })
+
+  test('R9: a unary denied condition (no value, e.g. isNotEmpty) re-saves without rejection or a manufactured value', async () => {
+    // seed FLD_SECRET as a unary condition (no value), then re-save the redacted echo (also no value)
+    await q('DELETE FROM meta_views WHERE id = $1', [VIEW_ID])
+    const unarySeed = [{ fieldId: FLD_VISIBLE, operator: 'is', value: VIS_LIT }, { fieldId: FLD_SECRET, operator: 'isNotEmpty' }]
+    await q('INSERT INTO meta_views (id, sheet_id, name, type, filter_info, hidden_field_ids) VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb)',
+      [VIEW_ID, SHEET_ID, 'RSG U', 'grid', JSON.stringify({ conjunction: 'and', conditions: unarySeed }), JSON.stringify([])])
+    const res = await patch({ name: 'RSG U2', filterInfo: { conjunction: 'and', conditions: [{ fieldId: FLD_VISIBLE, operator: 'is', value: VIS_LIT }, { fieldId: FLD_SECRET, operator: 'isNotEmpty' }] } })
+    expect(res.status).toBe(200) // not rejected
+    const fi = await dbFilterInfo()
+    const secretCond = fi.conditions?.find((c) => c.fieldId === FLD_SECRET)
+    expect(secretCond).toBeDefined()
+    expect(Object.prototype.hasOwnProperty.call(secretCond ?? {}, 'value')).toBe(false) // no manufactured value
+  })
+})


### PR DESCRIPTION
## Re-save guard impl — preserve denied-field filter literals (#2068)

Implements the #2068 design-lock (follow-up to priority-#2 (b): #2052 design / #2059 impl). #2059 redacts saved-view filter literals on read; the **write-path edge** was that a field-denied `canManageViews` user re-saving a view echoes the redacted condition back **without a `value`** → `PATCH /views/:viewId` overwrote `meta_views.filter_info` and **silently erased** the literal they were never allowed to see. This preserves it.

### The fix
- **`mergeRedactedFilterInfoForUpdate(incoming, current, allowedFieldIds)`** — **PURE**; returns the merged `filterInfo` or **`null`** on structural mismatch (route → 400). Rules: allowed field → trust incoming; denied + **explicit** `value` key → trust (existing `canManageViews` behavior, **not** a new write policy); denied + **no** `value` → same-index `(fieldId, operator)` match → **restore the current literal** (keep as-is if current also unary; **reject** if no safe match — no condition IDs, don't guess); iterate incoming only → removed-stays-removed. Value-only (mirrors #2059).
- **`PATCH /views/:viewId`**: `allowedFieldIds` computed up front; `nextFilter` runs through the merge when `filterInfo` is present; `null` → `400` (DB untouched). The existing `metaViewConfigCache.set` already caches the **unredacted** merged view → the #2059 cache invariant (cache unredacted, redact per-response) holds for free.

### Fail-first (real DB)
`multitable-viewconfig-resave-guard.test.ts` — assertions read `meta_views.filter_info` **directly** (response is redacted either way).

| | pre-fix | post-fix |
|---|---|---|
| R1 redacted re-save · R6 `property.hidden` (the mandated corruption proofs) · R2 · R5 mismatch→400 · R8 cross-user | **RED — literal erased** | ✅ |
| sentinel · R3 explicit write · R4 remove · R7 layer-1 · R9 unary | ✅ | ✅ |

`5 failed → 10 passed`. R8 pins the cache invariant (allowed reader sees the preserved literal; denied writer's response omits it). Note: removing a denied condition that precedes a still-redacted one shifts indices → intentional 400 (data-safety backstop, per design §6).

### Regression — clean
tsc clean; **#2059** (exercises the same PATCH path) + #2044 / #2028 / view-aggregate + the new test — 5 files green together.

### Scope
`PATCH /views/:viewId`, value-only, preserve-on-redacted-echo. Out of scope (unchanged): `POST /views`; whether a field-denied user may *author* a denied-field literal (explicit value still follows `canManageViews`); frontend UX. No RBAC/auth/`engine.ts` touch (K3 lock).

### Merge note
Backend feature PR — at merge needs `base == origin/main` (not-stale) **plus an explicit greenlight**; no docs-only shortcut.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
