### PR TITLE
test(attendance): align overview preload guard with self-service leave policies (#2066)

### DIFF
--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -609,9 +609,13 @@ describe('Attendance admin regressions', () => {
       '/api/attendance/groups',
       '/api/attendance/import/batches',
       '/api/attendance/report-fields',
-      '/api/attendance/overtime-rules',
+      // NOTE: leave-types / overtime-rules are intentionally NOT in this forbidden list.
+      // As of #2066 (self-service leave policies) the employee overview refresh loads the
+      // ACTIVE leave-types and overtime-rules (?isActive=true) so the self-service leave /
+      // overtime request form can populate its dropdowns (AttendanceView.vue:
+      // requestForm.leaveTypeId / requestForm.overtimeRuleId). Those are employee-facing
+      // reference reads, not admin-only preloads — the full admin lists stay showAdmin-gated.
       '/api/attendance/payroll-templates',
-      '/api/attendance/leave-types',
       '/api/attendance/approval-flows',
       '/api/attendance/payroll-cycles',
       '/api/attendance/advanced-scheduling/workbench',


### PR DESCRIPTION
## What
Single-file **test fix**: aligns the "does not preload admin-only attendance data on the employee overview surface" guard with the shipped self-service behaviour from **#2066**.

## Why
#2066 (*load self-service leave policies*) intentionally made the employee overview refresh load **active** `leave-types` + `overtime-rules` (`?isActive=true`) so the self-service leave/overtime **request form** can populate its dropdowns (`AttendanceView.vue`: `requestForm.leaveTypeId` / `requestForm.overtimeRuleId`, under `v-if="showOverview"`). Those are **employee-facing reference reads, not admin-only preloads**. The guard still listed them as forbidden, so it was **red locally**.

This removes only `leave-types` + `overtime-rules` from `forbiddenAdminLoads` (with an explanatory comment). **The shipped self-service feature is NOT touched** — removing the load would break employee leave/overtime requests. All truly admin-only endpoints (settings, rule-templates, groups, report-fields, payroll, approval-flows, shifts/rotation/assignments, advanced-scheduling, scheduler-scopes, `attendance-admin/*`) stay guarded.

## CI gap (FYI, separate)
This web spec is **not run in CI** — `plugin-tests.yml` runs core-backend tests and only `pnpm --filter @metasheet/web build` (no web vitest). That's why the guard was red locally yet CI stayed green (and why #2066 / #2067 merged without it failing). Wiring web vitest into the CI gate is a separate follow-up, not in this PR.

## Verification
`attendance-admin-regressions.spec.ts` **41/41** (the overview-preload guard now passes). Test-only single-file change; no source touched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
