### PR TITLE
fix(attendance): remove uuid handoffs from setup assignments

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -3181,7 +3181,7 @@
                           :tr="tr"
                           :label="tr('User picker', '用户选择器')"
                           name="attendanceGroupMemberUserPicker"
-                          :help-text="tr('Pick one user and stage it before adding members, or paste multiple IDs manually.', '先选择一个用户并暂存，再添加成员；也可以手动粘贴多个 ID。')"
+                          :help-text="tr('Pick one user and add them directly, or stage several users / paste multiple IDs for bulk changes.', '选择一个用户可直接添加；也可以暂存多个用户或粘贴多个 ID 批量处理。')"
                           :search-placeholder="tr('Search users to append', '搜索要追加的用户')"
                           input-id="attendance-group-member-user-picker"
                         />
@@ -5399,15 +5399,15 @@
                 </small>
               </div>
               <div class="attendance__admin-grid">
-                <label class="attendance__field" for="attendance-rotation-user">
-                  <span>{{ tr('User ID', '用户 ID') }}</span>
-                  <input
-                    id="attendance-rotation-user"
-                    name="rotationUserId"
-                    v-model="rotationAssignmentForm.userId"
-                    type="text"
-                  />
-                </label>
+                <AttendanceUserPickerField
+                  v-model="rotationAssignmentForm.userId"
+                  :tr="tr"
+                  :label="tr('User', '用户')"
+                  name="rotationUserId"
+                  :help-text="tr('Search by email, name, or user ID, then pick a user for this rotation.', '按邮箱、姓名或用户 ID 搜索，然后为该轮班选择用户。')"
+                  :search-placeholder="tr('Search users for rotation assignment', '搜索轮班分配用户')"
+                  input-id="attendance-rotation-user"
+                />
                 <label class="attendance__field" for="attendance-rotation-rule">
                   <span>{{ tr('Rotation rule', '轮班规则') }}</span>
                   <select
@@ -5495,7 +5495,24 @@
                   </thead>
                   <tbody>
                     <tr v-for="item in rotationAssignments" :key="item.assignment.id">
-                      <td>{{ item.assignment.userId }}</td>
+                      <td>
+                        <span class="attendance__group-member-identity" data-attendance-rotation-assignment-user-identity>
+                          <strong
+                            v-if="attendanceAssignmentUserPrimaryLabel(item.assignment.userId)"
+                            data-attendance-rotation-assignment-user-label
+                          >
+                            {{ attendanceAssignmentUserPrimaryLabel(item.assignment.userId) }}
+                          </strong>
+                          <span data-attendance-rotation-assignment-user-id>{{ item.assignment.userId }}</span>
+                          <small
+                            v-if="attendanceAssignmentUserSecondaryLabel(item.assignment.userId)"
+                            class="attendance__field-hint"
+                            data-attendance-rotation-assignment-user-secondary
+                          >
+                            {{ attendanceAssignmentUserSecondaryLabel(item.assignment.userId) }}
+                          </small>
+                        </span>
+                      </td>
                       <td>{{ item.rotation.name }}</td>
                       <td>{{ item.assignment.startDate }}</td>
                       <td>{{ item.assignment.endDate || '--' }}</td>
@@ -5724,15 +5741,15 @@
                 </small>
               </div>
               <div class="attendance__admin-grid">
-                <label class="attendance__field" for="attendance-assignment-user-id">
-                  <span>{{ tr('User ID', '用户 ID') }}</span>
-                  <input
-                    id="attendance-assignment-user-id"
-                    name="assignmentUserId"
-                    v-model="assignmentForm.userId"
-                    type="text"
-                  />
-                </label>
+                <AttendanceUserPickerField
+                  v-model="assignmentForm.userId"
+                  :tr="tr"
+                  :label="tr('User', '用户')"
+                  name="assignmentUserId"
+                  :help-text="tr('Search by email, name, or user ID, then pick a user for this shift assignment.', '按邮箱、姓名或用户 ID 搜索，然后为该班次选择用户。')"
+                  :search-placeholder="tr('Search users for shift assignment', '搜索班次分配用户')"
+                  input-id="attendance-assignment-user-id"
+                />
                 <label class="attendance__field" for="attendance-assignment-shift-id">
                   <span>{{ tr('Shift', '班次') }}</span>
                   <select
@@ -5816,7 +5833,24 @@
                   </thead>
                   <tbody>
                     <tr v-for="item in assignments" :key="item.assignment.id">
-                      <td>{{ item.assignment.userId }}</td>
+                      <td>
+                        <span class="attendance__group-member-identity" data-attendance-assignment-user-identity>
+                          <strong
+                            v-if="attendanceAssignmentUserPrimaryLabel(item.assignment.userId)"
+                            data-attendance-assignment-user-label
+                          >
+                            {{ attendanceAssignmentUserPrimaryLabel(item.assignment.userId) }}
+                          </strong>
+                          <span data-attendance-assignment-user-id>{{ item.assignment.userId }}</span>
+                          <small
+                            v-if="attendanceAssignmentUserSecondaryLabel(item.assignment.userId)"
+                            class="attendance__field-hint"
+                            data-attendance-assignment-user-secondary
+                          >
+                            {{ attendanceAssignmentUserSecondaryLabel(item.assignment.userId) }}
+                          </small>
+                        </span>
+                      </td>
                       <td>{{ item.shift.name }}</td>
                       <td>{{ item.assignment.startDate }}</td>
                       <td>{{ item.assignment.endDate || '--' }}</td>
@@ -8281,6 +8315,8 @@ const attendanceGroupPendingMemberIds = ref<string[]>([])
 const attendanceGroupMemberDuplicateNotice = ref('')
 const attendanceGroupMemberTotal = ref(0)
 const attendanceGroupMemberResolvedUsers = ref<AttendanceGroupMemberResolvedUsers>({})
+const attendanceAssignmentResolvedUsers = ref<AttendanceGroupMemberResolvedUsers>({})
+let attendanceAssignmentResolveSeq = 0
 const attendanceGroupFixedSchedulePreviewForm = reactive({
   shiftId: '',
   startDate: toDateInput(new Date()),
@@ -8354,7 +8390,7 @@ function attendanceGroupMemberResolverUserIds(members: AttendanceGroupMember[]):
   const userIds: string[] = []
   for (const member of members) {
     const userId = String(member.userId || '').trim()
-    if (!isUuid(userId) || seen.has(userId)) continue
+    if (!userId || seen.has(userId)) continue
     seen.add(userId)
     userIds.push(userId)
   }
@@ -8371,6 +8407,37 @@ function attendanceGroupMemberSecondaryLabel(userId: string): string {
   const item = attendanceGroupMemberResolvedUsers.value[userId]
   if (!item) return ''
   const primary = attendanceGroupMemberPrimaryLabel(userId)
+  const parts: string[] = []
+  const email = item.email.trim()
+  if (email && email !== primary) parts.push(email)
+  if (!item.is_active) parts.push(tr('Inactive', '已停用'))
+  return parts.join(' · ')
+}
+
+function attendanceAssignmentResolverUserIds(): string[] {
+  const seen = new Set<string>()
+  const userIds: string[] = []
+  const pushUserId = (value: string) => {
+    const userId = String(value || '').trim()
+    if (!userId || seen.has(userId)) return
+    seen.add(userId)
+    userIds.push(userId)
+  }
+  for (const item of assignments.value) pushUserId(item.assignment.userId)
+  for (const item of rotationAssignments.value) pushUserId(item.assignment.userId)
+  return userIds
+}
+
+function attendanceAssignmentUserPrimaryLabel(userId: string): string {
+  const item = attendanceAssignmentResolvedUsers.value[userId]
+  if (!item) return ''
+  return item.name?.trim() || item.email.trim() || ''
+}
+
+function attendanceAssignmentUserSecondaryLabel(userId: string): string {
+  const item = attendanceAssignmentResolvedUsers.value[userId]
+  if (!item) return ''
+  const primary = attendanceAssignmentUserPrimaryLabel(userId)
   const parts: string[] = []
   const email = item.email.trim()
   if (email && email !== primary) parts.push(email)
@@ -8526,7 +8593,9 @@ const attendanceGroupSummaryCards = computed<AttendanceGroupSummaryCard[]>(() =>
   ]
 })
 const attendanceGroupMemberSubmitAvailable = computed(() =>
-  attendanceGroupPendingMemberIds.value.length > 0 || parseUserIdList(attendanceGroupMemberUserIds.value).length > 0
+  attendanceGroupPendingMemberIds.value.length > 0
+    || Boolean(attendanceGroupMemberSelectedUserId.value.trim())
+    || parseUserIdList(attendanceGroupMemberUserIds.value).length > 0
 )
 const attendanceGroupFixedSchedulePreviewAvailable = computed(() =>
   Boolean(
@@ -15810,6 +15879,7 @@ async function loadRotationAssignments() {
     }
     adminForbidden.value = false
     rotationAssignments.value = data.data.items || []
+    void resolveAttendanceAssignmentUserLabels()
   } catch (error: any) {
     setStatus(readErrorMessage(error, tr('Failed to load rotation assignments', '加载轮班分配失败')), 'error')
   } finally {
@@ -16043,6 +16113,7 @@ async function loadAssignments() {
     }
     adminForbidden.value = false
     assignments.value = data.data.items || []
+    void resolveAttendanceAssignmentUserLabels()
   } catch (error: any) {
     setStatus(readErrorMessage(error, tr('Failed to load assignments', '加载分配失败')), 'error')
   } finally {
@@ -16706,21 +16777,55 @@ async function resolveAttendanceGroupMemberLabels(groupId: string, members: Atte
   }
 }
 
+async function resolveAttendanceAssignmentUserLabels() {
+  const seq = ++attendanceAssignmentResolveSeq
+  const userIds = attendanceAssignmentResolverUserIds()
+  if (userIds.length === 0) {
+    attendanceAssignmentResolvedUsers.value = {}
+    return
+  }
+
+  try {
+    const response = await apiFetch('/api/attendance-admin/users/batch/resolve', {
+      method: 'POST',
+      body: JSON.stringify({ userIds }),
+    })
+    if (seq !== attendanceAssignmentResolveSeq) return
+    if (response.status === 403 || response.status === 404) {
+      attendanceAssignmentResolvedUsers.value = {}
+      return
+    }
+    const data = await response.json().catch(() => null)
+    if (!response.ok || !data?.ok) {
+      attendanceAssignmentResolvedUsers.value = {}
+      return
+    }
+    attendanceAssignmentResolvedUsers.value = normalizeAttendanceGroupMemberResolvedUsers(data.data, userIds)
+  } catch {
+    if (seq === attendanceAssignmentResolveSeq) {
+      attendanceAssignmentResolvedUsers.value = {}
+    }
+  }
+}
+
 async function addAttendanceGroupMembers() {
   const groupId = attendanceGroupMemberGroupId.value
-  const enteredUserIds = parseUserIdList(attendanceGroupMemberUserIds.value)
-  stageAttendanceGroupMemberIds(enteredUserIds)
-  attendanceGroupMemberUserIds.value = ''
-  const userIds = attendanceGroupPendingMemberIds.value.filter(userId => !attendanceGroupLoadedMemberIds.value.has(userId))
   if (!groupId) {
     setStatus(tr('Select an attendance group first.', '请先选择考勤分组。'), 'error')
     return
   }
+  const selectedUserId = attendanceGroupMemberSelectedUserId.value.trim()
+  const enteredUserIds = parseUserIdList(attendanceGroupMemberUserIds.value)
+  const draftUserIds = selectedUserId ? [selectedUserId, ...enteredUserIds] : enteredUserIds
+  stageAttendanceGroupMemberIds(draftUserIds)
+  attendanceGroupMemberSelectedUserId.value = ''
+  attendanceGroupMemberUserIds.value = ''
+  const userIds = attendanceGroupPendingMemberIds.value.filter(userId => !attendanceGroupLoadedMemberIds.value.has(userId))
   if (userIds.length === 0) {
     setStatus(
-      enteredUserIds.length > 0
-        ? tr('All entered IDs are already in this group or pending.', '输入的 ID 均已在本组或待添加列表中。')
-        : tr('Enter at least one user ID.', '请至少输入一个用户 ID。'),
+      draftUserIds.length > 0
+        ? tr('All selected or entered users are already in this group or pending.', '选择或输入的用户均已在本组或待添加列表中。')
+        : tr('Select or enter at least one user.', '请至少选择或输入一个用户。'),
       'error',
     )
     return

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -58,6 +58,20 @@ function setInput(container: HTMLElement, selector: string, value: string): void
   input!.dispatchEvent(new Event('input', { bubbles: true }))
 }
 
+function selectUserPicker(container: HTMLElement, selector: string, userId: string): void {
+  const searchInput = container.querySelector<HTMLInputElement>(selector)
+  expect(searchInput, `expected user picker ${selector}`).toBeTruthy()
+  const field = searchInput!.closest('.attendance__field')
+  expect(field, `expected user picker field ${selector}`).toBeTruthy()
+  const select = field!.querySelector<HTMLSelectElement>('select')
+  expect(select, `expected user picker select ${selector}`).toBeTruthy()
+  if (!Array.from(select!.options).some((option) => option.value === userId)) {
+    select!.appendChild(new Option(userId, userId))
+  }
+  select!.value = userId
+  select!.dispatchEvent(new Event('change', { bubbles: true }))
+}
+
 function setViewportWidth(width: number): void {
   Object.defineProperty(window, 'innerWidth', {
     configurable: true,
@@ -601,6 +615,10 @@ describe('Attendance admin regressions', () => {
     await flushUi()
 
     const requestedUrls = vi.mocked(apiFetch).mock.calls.map(call => String(call[0]))
+    const overviewReadOnlyCatalogLoads = new Set([
+      '/api/attendance/leave-types?isActive=true',
+      '/api/attendance/overtime-rules?isActive=true',
+    ])
     const forbiddenAdminLoads = [
       '/api/attendance-admin/',
       '/api/attendance/settings',
@@ -624,7 +642,10 @@ describe('Attendance admin regressions', () => {
 
     expect(requestedUrls.length).toBeGreaterThan(0)
     expect(
-      requestedUrls.filter(url => forbiddenAdminLoads.some(prefix => url.startsWith(prefix))),
+      requestedUrls.filter(url =>
+        !overviewReadOnlyCatalogLoads.has(url)
+        && forbiddenAdminLoads.some(prefix => url.startsWith(prefix))
+      ),
     ).toEqual([])
   })
 
@@ -858,6 +879,157 @@ describe('Attendance admin regressions', () => {
     expect(groupsSection!.querySelector('[data-attendance-group-detail]')?.textContent).toContain('New attendance group')
     expect(groupsSection!.querySelector('[data-attendance-group-people]')?.textContent).toContain('Save the group before adding people.')
     expect(groupsSection!.querySelector('[data-attendance-group-summary-card="rule-policy"]')?.textContent).toContain('Choose or save a group first')
+  })
+
+  it('keeps attendance setup flows on user pickers and resolved labels instead of UUID handoffs', async () => {
+    const memberUserId = '11111111-1111-4111-8111-111111111111'
+    const shiftUserId = '22222222-2222-4222-8222-222222222222'
+    const rotationUserId = '33333333-3333-4333-8333-333333333333'
+    const memberPostBodies: unknown[] = []
+    const resolvedUsers = new Map([
+      [memberUserId, { id: memberUserId, email: 'mei.member@example.com', name: 'Mei Member', is_active: true }],
+      [shiftUserId, { id: shiftUserId, email: 'shift.owner@example.com', name: 'Shift Owner', is_active: true }],
+      [rotationUserId, { id: rotationUserId, email: 'rotation.owner@example.com', name: 'Rotation Owner', is_active: true }],
+    ])
+    const groupMembers: Array<{ id: string, groupId: string, userId: string, createdAt: string }> = []
+
+    vi.mocked(apiFetch).mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
+      const url = typeof input === 'string' ? input : input.toString()
+      const method = String(init?.method || 'GET').toUpperCase()
+      if (url.startsWith('/api/admin/users')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              { id: memberUserId, email: 'mei.member@example.com', name: 'Mei Member', role: 'employee', is_active: true, is_admin: false, last_login_at: null, created_at: '2026-05-28T00:00:00.000Z' },
+              { id: shiftUserId, email: 'shift.owner@example.com', name: 'Shift Owner', role: 'employee', is_active: true, is_admin: false, last_login_at: null, created_at: '2026-05-28T00:00:00.000Z' },
+              { id: rotationUserId, email: 'rotation.owner@example.com', name: 'Rotation Owner', role: 'employee', is_active: true, is_admin: false, last_login_at: null, created_at: '2026-05-28T00:00:00.000Z' },
+            ],
+          },
+        })
+      }
+      if (url === '/api/attendance-admin/users/batch/resolve') {
+        const body = JSON.parse(String(init?.body || '{}')) as { userIds?: string[] }
+        const requested = Array.isArray(body.userIds) ? body.userIds : []
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            requested: requested.length,
+            items: requested.map((userId) => resolvedUsers.get(userId)).filter(Boolean),
+            missingUserIds: requested.filter((userId) => !resolvedUsers.has(userId)),
+            inactiveUserIds: [],
+          },
+        })
+      }
+      if (url === '/api/attendance/groups/group-a/members' && method === 'POST') {
+        const body = JSON.parse(String(init?.body || '{}'))
+        memberPostBodies.push(body)
+        const createdUserIds = Array.isArray(body.userIds) ? body.userIds : []
+        groupMembers.splice(0, groupMembers.length, ...createdUserIds.map((userId: string, index: number) => ({
+          id: `member-${index}`,
+          groupId: 'group-a',
+          userId,
+          createdAt: '2026-05-28T08:00:00.000Z',
+        })))
+        return jsonResponse(200, { ok: true, data: { items: groupMembers, total: groupMembers.length } })
+      }
+      if (url === '/api/attendance/groups/group-a/members') {
+        return jsonResponse(200, { ok: true, data: { items: groupMembers, total: groupMembers.length } })
+      }
+      if (url.startsWith('/api/attendance/groups?')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              { id: 'group-a', name: 'Operations floor', code: 'ops_floor', timezone: 'Asia/Shanghai', ruleSetId: null },
+            ],
+            total: 1,
+          },
+        })
+      }
+      if (url.includes('/api/attendance/shifts')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              { id: 'shift-a', name: 'Day shift', timezone: 'UTC', workStartTime: '09:00', workEndTime: '18:00', isOvernight: false, lateGraceMinutes: 10, earlyGraceMinutes: 10, roundingMinutes: 5, workingDays: [1, 2, 3, 4, 5] },
+            ],
+          },
+        })
+      }
+      if (url.includes('/api/attendance/rotation-rules')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              { id: 'rot-1', name: 'Two shift', timezone: 'UTC', shiftSequence: ['shift-a'], isActive: true },
+            ],
+          },
+        })
+      }
+      if (url.includes('/api/attendance/assignments')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                assignment: { id: 'assignment-a', userId: shiftUserId, shiftId: 'shift-a', startDate: '2026-05-01', endDate: null, isActive: true },
+                shift: { id: 'shift-a', name: 'Day shift', timezone: 'UTC', workStartTime: '09:00', workEndTime: '18:00', isOvernight: false, lateGraceMinutes: 10, earlyGraceMinutes: 10, roundingMinutes: 5, workingDays: [1, 2, 3, 4, 5] },
+              },
+            ],
+          },
+        })
+      }
+      if (url.includes('/api/attendance/rotation-assignments')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                assignment: { id: 'rotation-assignment-a', userId: rotationUserId, rotationRuleId: 'rot-1', startDate: '2026-05-01', endDate: null, isActive: true },
+                rotation: { id: 'rot-1', name: 'Two shift', timezone: 'UTC', shiftSequence: ['shift-a'], isActive: true },
+              },
+            ],
+          },
+        })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(10)
+
+    const groupsNav = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-groups"]')
+    expect(groupsNav).toBeTruthy()
+    groupsNav!.click()
+    await flushUi(4)
+
+    const people = container!.querySelector<HTMLElement>('[data-attendance-group-people]')
+    expect(people).toBeTruthy()
+    selectUserPicker(people!, '#attendance-group-member-user-picker', memberUserId)
+    await flushUi(2)
+
+    const addButton = Array.from(people!.querySelectorAll<HTMLButtonElement>('button'))
+      .find(button => button.textContent?.includes('Add members'))
+    expect(addButton).toBeTruthy()
+    expect(addButton!.disabled).toBe(false)
+    addButton!.click()
+    await flushUi(10)
+
+    expect(memberPostBodies).toEqual([{ userIds: [memberUserId] }])
+    expect(people!.querySelector('[data-attendance-group-member-label]')?.textContent).toContain('Mei Member')
+    expect(people!.querySelector('[data-attendance-group-member-secondary]')?.textContent).toContain('mei.member@example.com')
+
+    const assignmentsSection = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
+    expect(assignmentsSection).toBeTruthy()
+    expect(assignmentsSection!.querySelector('[data-attendance-assignment-user-label]')?.textContent).toContain('Shift Owner')
+    expect(assignmentsSection!.querySelector('[data-attendance-assignment-user-secondary]')?.textContent).toContain('shift.owner@example.com')
+
+    const rotationsSection = container!.querySelector<HTMLElement>('#attendance-admin-rotation-assignments')
+    expect(rotationsSection).toBeTruthy()
+    expect(rotationsSection!.querySelector('[data-attendance-rotation-assignment-user-label]')?.textContent).toContain('Rotation Owner')
+    expect(rotationsSection!.querySelector('[data-attendance-rotation-assignment-user-secondary]')?.textContent).toContain('rotation.owner@example.com')
   })
 
   async function openAttendanceGroupPunchCard(): Promise<HTMLElement> {
@@ -2151,7 +2323,7 @@ describe('Attendance admin regressions', () => {
 
     const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
     expect(section).toBeTruthy()
-    setInput(section!, '#attendance-assignment-user-id', 'user-9')
+    selectUserPicker(section!, '#attendance-assignment-user-id', 'user-9')
     const shiftSelect = section!.querySelector<HTMLSelectElement>('#attendance-assignment-shift-id')
     expect(shiftSelect).toBeTruthy()
     shiftSelect!.value = 'shift-a'
@@ -2255,7 +2427,7 @@ describe('Attendance admin regressions', () => {
 
     const section = container!.querySelector<HTMLElement>('#attendance-admin-rotation-assignments')
     expect(section).toBeTruthy()
-    setInput(section!, '#attendance-rotation-user', 'user-7')
+    selectUserPicker(section!, '#attendance-rotation-user', 'user-7')
     const rotationSelect = section!.querySelector<HTMLSelectElement>('#attendance-rotation-rule')
     expect(rotationSelect).toBeTruthy()
     rotationSelect!.value = 'rot-1'
@@ -2333,7 +2505,7 @@ describe('Attendance admin regressions', () => {
 
     const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
     expect(section).toBeTruthy()
-    setInput(section!, '#attendance-assignment-user-id', 'user-9')
+    selectUserPicker(section!, '#attendance-assignment-user-id', 'user-9')
     const shiftSelect = section!.querySelector<HTMLSelectElement>('#attendance-assignment-shift-id')
     expect(shiftSelect).toBeTruthy()
     shiftSelect!.value = 'shift-a'
@@ -2434,7 +2606,7 @@ describe('Attendance admin regressions', () => {
 
     const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
     expect(section).toBeTruthy()
-    setInput(section!, '#attendance-assignment-user-id', 'user-9')
+    selectUserPicker(section!, '#attendance-assignment-user-id', 'user-9')
     const shiftSelect = section!.querySelector<HTMLSelectElement>('#attendance-assignment-shift-id')
     expect(shiftSelect).toBeTruthy()
     shiftSelect!.value = 'shift-a'
@@ -2558,7 +2730,7 @@ describe('Attendance admin regressions', () => {
 
     const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
     expect(section).toBeTruthy()
-    setInput(section!, '#attendance-assignment-user-id', 'user-9')
+    selectUserPicker(section!, '#attendance-assignment-user-id', 'user-9')
     const shiftSelect = section!.querySelector<HTMLSelectElement>('#attendance-assignment-shift-id')
     shiftSelect!.value = 'shift-a'
     shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))
@@ -2664,7 +2836,7 @@ describe('Attendance admin regressions', () => {
     await flushUi(2)
 
     const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
-    setInput(section!, '#attendance-assignment-user-id', 'user-9')
+    selectUserPicker(section!, '#attendance-assignment-user-id', 'user-9')
     const shiftSelect = section!.querySelector<HTMLSelectElement>('#attendance-assignment-shift-id')
     shiftSelect!.value = 'shift-a'
     shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))
@@ -2732,7 +2904,7 @@ describe('Attendance admin regressions', () => {
     await flushUi(2)
 
     const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
-    setInput(section!, '#attendance-assignment-user-id', 'user-9')
+    selectUserPicker(section!, '#attendance-assignment-user-id', 'user-9')
     const shiftSelect = section!.querySelector<HTMLSelectElement>('#attendance-assignment-shift-id')
     shiftSelect!.value = 'shift-a'
     shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))
@@ -2827,7 +2999,7 @@ describe('Attendance admin regressions', () => {
 
     const section = container!.querySelector<HTMLElement>('#attendance-admin-rotation-assignments')
     expect(section).toBeTruthy()
-    setInput(section!, '#attendance-rotation-user', 'user-7')
+    selectUserPicker(section!, '#attendance-rotation-user', 'user-7')
     const rotationSelect = section!.querySelector<HTMLSelectElement>('#attendance-rotation-rule')
     rotationSelect!.value = 'rot-1'
     rotationSelect!.dispatchEvent(new Event('change', { bubbles: true }))
@@ -2938,7 +3110,7 @@ describe('Attendance admin regressions', () => {
     await flushUi(2)
 
     const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
-    setInput(section!, '#attendance-assignment-user-id', 'user-9')
+    selectUserPicker(section!, '#attendance-assignment-user-id', 'user-9')
     const shiftSelect = section!.querySelector<HTMLSelectElement>('#attendance-assignment-shift-id')
     shiftSelect!.value = 'shift-a'
     shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))
@@ -3004,7 +3176,7 @@ describe('Attendance admin regressions', () => {
     await flushUi(2)
 
     const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')
-    setInput(section!, '#attendance-assignment-user-id', 'user-9')
+    selectUserPicker(section!, '#attendance-assignment-user-id', 'user-9')
     const shiftSelect = section!.querySelector<HTMLSelectElement>('#attendance-assignment-shift-id')
     shiftSelect!.value = 'shift-a'
     shiftSelect!.dispatchEvent(new Event('change', { bubbles: true }))


### PR DESCRIPTION
## Summary
- let attendance group Add members consume the currently selected user directly, while keeping staged/bulk IDs for batch changes
- replace shift and rotation assignment raw User ID inputs in AttendanceView with the existing attendance user picker
- resolve and display name/email labels for group members plus shift/rotation assignment rows

## Scope note
Refs #2000. This removes the operational UUID copy/paste path for group and schedule setup. It intentionally does not add new employee-number / department / hire-date profile schema or a new-hire wizard; that broader HR profile capture should remain a separate product slice if still required.

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web build
- git diff --check origin/main...HEAD