### PR TITLE
ci(attendance): targeted web guard gate (attendance-admin-regressions)

### DIFF
--- a/.github/workflows/attendance-web-guard.yml
+++ b/.github/workflows/attendance-web-guard.yml
@@ -1,0 +1,70 @@
+# Attendance web guard (targeted gate).
+#
+# Why this exists: the main PR gate (plugin-tests.yml) runs core-backend tests and only
+# `pnpm --filter @metasheet/web build` for the web app — it does NOT run apps/web vitest
+# specs. As a result, employee/admin surface guard regressions in AttendanceView slipped
+# through green CI (e.g. the overview admin-only-preload guard going red unnoticed).
+#
+# Scope (deliberately TARGETED, first step): run only attendance-admin-regressions.spec.ts,
+# which is currently green and holds the admin-surface guards we care about. The full
+# `@metasheet/web` vitest suite still has historical/flaky failures, so wiring the whole
+# suite as a required gate now would be red on arrival. Expand the `vitest run` filter (or
+# move to the full web suite) as those specs are cleaned up.
+name: Attendance Web Guard
+
+on:
+  pull_request:
+    paths:
+      - 'apps/web/src/views/AttendanceView.vue'
+      - 'apps/web/src/views/attendance/**'
+      - 'apps/web/tests/attendance-admin-regressions.spec.ts'
+      - '.github/workflows/attendance-web-guard.yml'
+  push:
+    branches: [main]
+    paths:
+      - 'apps/web/src/views/AttendanceView.vue'
+      - 'apps/web/src/views/attendance/**'
+      - 'apps/web/tests/attendance-admin-regressions.spec.ts'
+      - '.github/workflows/attendance-web-guard.yml'
+
+jobs:
+  attendance-web-guard:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Setup Node.js 20.x
+        uses: actions/setup-node@v4
+        with:
+          node-version: 20.x
+
+      - name: Setup pnpm
+        uses: pnpm/action-setup@v4
+        with:
+          version: 10.16.1
+          run_install: false
+
+      - name: Use empty npmrc for pnpm
+        run: |
+          echo "" > /tmp/empty-npmrc
+          echo "NPM_CONFIG_USERCONFIG=/tmp/empty-npmrc" >> "$GITHUB_ENV"
+
+      - name: Get pnpm store directory
+        id: pnpm-cache
+        shell: bash
+        run: echo "STORE_PATH=$(pnpm store path)" >> "$GITHUB_OUTPUT"
+
+      - name: Setup pnpm cache
+        uses: actions/cache@v4
+        with:
+          path: ${{ steps.pnpm-cache.outputs.STORE_PATH }}
+          key: ${{ runner.os }}-pnpm-store-${{ hashFiles('**/pnpm-lock.yaml') }}
+          restore-keys: |
+            ${{ runner.os }}-pnpm-store-
+
+      - name: Install dependencies
+        run: pnpm install --frozen-lockfile
+
+      - name: Run attendance web guard specs (targeted)
+        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions --reporter=dot


### PR DESCRIPTION
## What
A small, dedicated CI workflow (`attendance-web-guard.yml`) that runs **`attendance-admin-regressions.spec.ts`** on PRs touching the attendance web surface (`AttendanceView.vue`, `views/attendance/**`, the spec, the workflow).

## Why (the gap, from #2075 investigation)
The main PR gate (`plugin-tests.yml`) runs **core-backend** tests and only `pnpm --filter @metasheet/web build` — **no apps/web vitest**. So AttendanceView surface-guard regressions slip through green CI:
- the overview admin-only-preload guard went red **unnoticed** (just realigned in #2075),
- `attendance-admin-anchor-nav.spec.ts` currently also has **2 unrelated red tests** from recent attendance work (UUID/member-id handling) — another regression that slipped the gap.

## Scope — deliberately targeted (per the agreed plan)
First step = gate **only** `attendance-admin-regressions` (green + holds the admin-surface guards). The **full `@metasheet/web` suite still has historical/flaky failures**, so wiring it wholesale would be red on arrival. Expand the `vitest run` filter (or move to the full suite) as web specs are cleaned up — including fixing the 2 anchor-nav reds, then adding anchor-nav here.

## Verification
`attendance-admin-regressions` is green on current main (41/41). This PR adds the workflow, so the gate runs on this PR itself.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
