### PR TITLE
feat(data-sources): A5 result-boundary policy — bound reads so a large source table can't OOM

### DIFF
--- a/docs/development/data-sources-mssql-windows-deploy-design-20260527.md
+++ b/docs/development/data-sources-mssql-windows-deploy-design-20260527.md
@@ -131,7 +131,7 @@
 - ✅ A2 `sanitizeIdentifier` 违规即抛 + schema-qualified 支持(#2037 `bf0eefc78`):按 `.` 分段校验、非法即抛(不再静默改写);MSSQL/MySQL per-segment quote;`[dbo].[table]` schema-qualified 经 SQL Server 容器 matrix 真 wire 证
 - ✅ A3 query/testConnection 错误不吞,保留错因(#2034):`testConnection` 返回 `{success,error?}`;错因经 `redactSecrets` 脱敏(`password`/`token` 不入 response/log);manager 仅转发 redacted `connectionError`;真 wire 集成测试覆盖
 - ✅ A4 enum↔registry↔驱动三方对齐(#1976 `f5013324e`):`SUPPORTED_DATA_SOURCE_TYPES` 单一支持矩阵 + 非法 type 400 + load 跳过不支持行
-- ⬜ A5 `stream()` 真游标流 或 明确文档标注 + 上限保护
+- ✅ A5 结果边界策略(本刀,取「明确上限保护」而非真 cursor):共享 `DATA_SOURCE_DEFAULT_LIMIT=1000` / `DATA_SOURCE_MAX_ROWS=10000`;**适配器层 `select()` 硬防线**(omit→MAX cap、>MAX→抛、非法→抛,经 `resolveEffectiveLimit`),挡住绕过路由的直连内部调用(`DataSourceManager` 复制循环已显式分页,不受影响);路由 `/select` 入口补默认 limit、超限 400(zod);raw `/query` 无法安全自动限界 → 标为非大表导出通道 + 无 `LIMIT/TOP/OFFSET/FETCH` 时 best-effort warning + audit;`stream()`(raw SQL、未经路由暴露、内部唯一)仍为非流式,真 cursor 留作后续 thorough。测试 `data-source-result-boundary.test.ts`(13 例:常量 + resolveEffectiveLimit + PG/MSSQL select 真 wire + 路由默认/400/warning)
 - ⬜ A6 Postgres connect/query/transaction/错误路径单测
 
 ### Phase B — MSSQL 连接器(Lane B 已 opt-in 2026-05-28;contracts-first)

--- a/packages/core-backend/src/data-adapters/BaseAdapter.ts
+++ b/packages/core-backend/src/data-adapters/BaseAdapter.ts
@@ -67,6 +67,17 @@ export interface QueryOptions {
   raw?: boolean
 }
 
+/**
+ * Result-boundary policy (A5). Read paths MUST be bounded so a large source table cannot OOM the
+ * backend. `DATA_SOURCE_DEFAULT_LIMIT` is the friendly default the route/API entry applies when a
+ * caller omits `limit`; `DATA_SOURCE_MAX_ROWS` is the hard ceiling enforced at the ADAPTER layer
+ * — the chokepoint every structured read passes through, INCLUDING direct internal callers that
+ * bypass the route — so "omit limit" can never mean "whole table". Genuine full-volume copies must
+ * paginate explicitly (see DataSourceManager's copy loop) rather than rely on an unbounded read.
+ */
+export const DATA_SOURCE_MAX_ROWS = 10000
+export const DATA_SOURCE_DEFAULT_LIMIT = 1000
+
 export interface QueryResult<T = Record<string, DbValue>> {
   data: T[]
   metadata?: {
@@ -262,6 +273,31 @@ export abstract class BaseDataAdapter extends EventEmitter {
       }
     }
     return identifier
+  }
+
+  /**
+   * A5 result-boundary backstop. Resolve the row limit actually applied to a structured read,
+   * enforcing the hard ceiling at the adapter layer regardless of caller:
+   *  - omitted  -> DATA_SOURCE_MAX_ROWS (bounded; never "whole table")
+   *  - > MAX    -> throw (explicit over-ask is an error, NOT a silent clamp — paginate instead)
+   *  - invalid  -> throw
+   * The route applies the friendlier DATA_SOURCE_DEFAULT_LIMIT before reaching here; this is the
+   * defense-in-depth floor for direct internal callers (e.g. the DataSourceManager copy loop) that
+   * bypass the route and call adapter.select() straight.
+   */
+  protected resolveEffectiveLimit(limit?: number | null): number {
+    if (limit === undefined || limit === null) {
+      return DATA_SOURCE_MAX_ROWS
+    }
+    if (!Number.isInteger(limit) || limit < 1) {
+      throw new Error(`Invalid row limit ${JSON.stringify(limit)} (must be a positive integer)`)
+    }
+    if (limit > DATA_SOURCE_MAX_ROWS) {
+      throw new Error(
+        `Row limit ${limit} exceeds the maximum ${DATA_SOURCE_MAX_ROWS}; paginate with limit+offset instead`
+      )
+    }
+    return limit
   }
 
   protected buildWhereClause(where: Record<string, WhereValue>): { sql: string; params: DbValue[] } {

--- a/packages/core-backend/src/data-adapters/MSSQLAdapter.ts
+++ b/packages/core-backend/src/data-adapters/MSSQLAdapter.ts
@@ -303,10 +303,12 @@ export class MSSQLAdapter extends BaseDataAdapter {
       ? options.select.map(col => this.quoteIdent(col)).join(', ')
       : '*'
 
-    const limit = options.limit != null ? Math.floor(Number(options.limit)) : null
+    // A5: `limit` is always a bounded positive int (omit -> MAX cap, > MAX -> throw), so a direct
+    // internal caller cannot issue an unbounded read.
+    const limit = this.resolveEffectiveLimit(options.limit)
     const offset = options.offset != null ? Math.floor(Number(options.offset)) : null
     // limit-without-offset uses TOP (no ORDER BY required); offset uses OFFSET/FETCH.
-    const useTop = limit != null && limit >= 0 && (offset == null || offset === 0)
+    const useTop = offset == null || offset === 0
 
     let sql = `SELECT ${useTop ? `TOP (${limit}) ` : ''}${selectClause} FROM ${this.quoteIdent(table)}`
     let params: DbValue[] = []
@@ -331,9 +333,7 @@ export class MSSQLAdapter extends BaseDataAdapter {
     if (offset != null && offset > 0) {
       // OFFSET requires an ORDER BY; fall back to a stable no-op ordering.
       sql += ` ORDER BY ${orderBy ?? '(SELECT NULL)'} OFFSET ${offset} ROWS`
-      if (limit != null && limit >= 0) {
-        sql += ` FETCH NEXT ${limit} ROWS ONLY`
-      }
+      sql += ` FETCH NEXT ${limit} ROWS ONLY`
     } else if (orderBy) {
       sql += ` ORDER BY ${orderBy}`
     }

--- a/packages/core-backend/src/data-adapters/PostgresAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PostgresAdapter.ts
@@ -191,10 +191,10 @@ export class PostgresAdapter extends BaseDataAdapter {
       sql += ` ORDER BY ${orderClauses.join(', ')}`
     }
 
-    // Add limit and offset
-    if (options.limit) {
-      sql += ` LIMIT ${options.limit}`
-    }
+    // A5: always bound the read at the adapter layer (omit -> MAX cap, > MAX -> throw), so a direct
+    // internal caller cannot issue an unbounded SELECT. resolveEffectiveLimit returns a validated
+    // positive integer, so the interpolation is injection-safe.
+    sql += ` LIMIT ${this.resolveEffectiveLimit(options.limit)}`
     if (options.offset) {
       sql += ` OFFSET ${options.offset}`
     }

--- a/packages/core-backend/src/routes/data-sources.ts
+++ b/packages/core-backend/src/routes/data-sources.ts
@@ -18,6 +18,7 @@ import { rbacGuard } from '../rbac/rbac'
 import { auditLog } from '../audit/audit'
 import { DataSourceManager, SUPPORTED_DATA_SOURCE_TYPES } from '../data-adapters/DataSourceManager'
 import type { DataSourceConfig, QueryOptions } from '../data-adapters/BaseAdapter'
+import { DATA_SOURCE_DEFAULT_LIMIT, DATA_SOURCE_MAX_ROWS } from '../data-adapters/BaseAdapter'
 
 // Zod schemas for request validation
 const ConnectionConfigSchema = z.record(z.union([z.string(), z.number(), z.boolean()]))
@@ -81,8 +82,8 @@ const SelectSchema = z.object({
     column: z.string(),
     direction: z.enum(['asc', 'desc'])
   })).optional(),
-  limit: z.number().min(1).max(10000).optional(),
-  offset: z.number().min(0).optional()
+  limit: z.number().int().min(1).max(DATA_SOURCE_MAX_ROWS).optional(),
+  offset: z.number().int().min(0).optional()
 })
 
 // Singleton instance (can be replaced with dependency injection)
@@ -599,18 +600,31 @@ export function dataSourcesRouter(): Router {
 
       const result = await manager.query(req.params.id, sql, params as (string | number | boolean | null | Date | Buffer)[])
 
+      // A5: raw /query runs arbitrary SQL, so it cannot be safely auto-bounded (rewriting SQL is
+      // unsafe; rejecting no-LIMIT would break legitimately WHERE-bounded queries). It is therefore
+      // a non-large-export channel — surface a best-effort warning + audit annotation when no
+      // row-COUNT limiter is present, so a caller does not unknowingly pull an unbounded set.
+      // Only LIMIT / TOP / FETCH actually cap the row count; a bare OFFSET only SKIPS rows and still
+      // returns the rest of the table, so it must NOT count as a bound. Use /select (hard-capped at
+      // DATA_SOURCE_MAX_ROWS) for bounded structured reads.
+      const unbounded = !/\b(?:LIMIT|TOP|FETCH)\b/i.test(sql)
+      const warning = unbounded
+        ? `Query has no row-count limit (LIMIT/TOP/FETCH); raw /query is not a large-table export channel — add an explicit row bound (a bare OFFSET does not cap rows), or use /select (capped at ${DATA_SOURCE_MAX_ROWS} rows).`
+        : undefined
+
       await auditLog({
         actorId: req.user?.id?.toString(),
         actorType: 'user',
         action: 'query',
         resourceType: 'data_source',
         resourceId: req.params.id,
-        meta: { sql: sql.substring(0, 200), rowCount: result.data.length }
+        meta: { sql: sql.substring(0, 200), rowCount: result.data.length, ...(unbounded ? { unbounded: true } : {}) }
       })
 
       return res.json({
         ok: true,
-        data: result
+        data: result,
+        ...(warning ? { warning } : {})
       })
     } catch (error) {
       if (error instanceof Error && error.message.includes('not found')) {
@@ -649,6 +663,14 @@ export function dataSourcesRouter(): Router {
       const manager = getManager()
       manager.assertAccess(req.params.id, resolveUserId(req))
       const { table, ...options } = parse.data
+
+      // A5: apply the friendly default row limit at the API entry when the caller omits one, so a
+      // bare /select never pulls an unbounded result set. over-max is already rejected 400 by
+      // SelectSchema (max DATA_SOURCE_MAX_ROWS); the adapter still enforces the hard ceiling as a
+      // defense-in-depth backstop for callers that bypass this route.
+      if (options.limit === undefined) {
+        options.limit = DATA_SOURCE_DEFAULT_LIMIT
+      }
 
       // Cast options to proper QueryOptions type
       const result = await manager.select(req.params.id, table, options as QueryOptions)

--- a/packages/core-backend/tests/unit/data-source-result-boundary.test.ts
+++ b/packages/core-backend/tests/unit/data-source-result-boundary.test.ts
@@ -1,0 +1,183 @@
+import express from 'express'
+import request from 'supertest'
+import { describe, expect, it, vi, beforeEach } from 'vitest'
+
+vi.mock('../../src/audit/audit', () => ({ auditLog: vi.fn(async () => {}) }))
+
+import { PostgresAdapter } from '../../src/data-adapters/PostgresAdapter'
+import { MSSQLAdapter } from '../../src/data-adapters/MSSQLAdapter'
+import { DataSourceManager } from '../../src/data-adapters/DataSourceManager'
+import { dataSourcesRouter } from '../../src/routes/data-sources'
+import {
+  DATA_SOURCE_MAX_ROWS,
+  DATA_SOURCE_DEFAULT_LIMIT,
+  type DataSourceConfig,
+} from '../../src/data-adapters/BaseAdapter'
+
+// A5 — result-boundary policy: read paths must be bounded so a large source table cannot OOM the
+// backend. DEFAULT_LIMIT is the route's friendly default when limit is omitted; MAX_ROWS is the
+// hard ceiling enforced at the ADAPTER layer (the chokepoint every read passes through, including
+// direct internal callers that bypass the route).
+
+const cfg = (id: string, type = 'postgres'): DataSourceConfig => ({
+  id, name: id, type, connection: { host: 'localhost', database: 'x' }, options: { autoConnect: false },
+})
+const eff = (a: unknown, l?: number | null): number =>
+  (a as { resolveEffectiveLimit(l?: number | null): number }).resolveEffectiveLimit(l)
+
+describe('A5 constants + resolveEffectiveLimit backstop', () => {
+  const pg = new PostgresAdapter(cfg('postgres'))
+
+  it('exposes the agreed boundary values', () => {
+    expect(DATA_SOURCE_DEFAULT_LIMIT).toBe(1000)
+    expect(DATA_SOURCE_MAX_ROWS).toBe(10000)
+  })
+
+  it('omitted/null limit -> MAX (bounded, never "whole table")', () => {
+    expect(eff(pg)).toBe(DATA_SOURCE_MAX_ROWS)
+    expect(eff(pg, null)).toBe(DATA_SOURCE_MAX_ROWS)
+  })
+
+  it('within range -> passthrough (boundary inclusive)', () => {
+    expect(eff(pg, 1)).toBe(1)
+    expect(eff(pg, 5000)).toBe(5000)
+    expect(eff(pg, DATA_SOURCE_MAX_ROWS)).toBe(DATA_SOURCE_MAX_ROWS)
+  })
+
+  it('over MAX -> throw (no silent clamp); invalid -> throw', () => {
+    expect(() => eff(pg, DATA_SOURCE_MAX_ROWS + 1)).toThrow(/exceeds the maximum/)
+    expect(() => eff(pg, 0)).toThrow(/positive integer/)
+    expect(() => eff(pg, -5)).toThrow(/positive integer/)
+    expect(() => eff(pg, 1.5)).toThrow(/positive integer/)
+  })
+})
+
+// Fake mssql pool capturing executed SQL (same pattern as data-source-identifier-quoting.test.ts).
+function mssqlFakePool() {
+  const calls: string[] = []
+  const pool = {
+    request() {
+      const req = { input() { return req }, async query(sql: string) { calls.push(sql); return { recordset: [], rowsAffected: [] } } }
+      return req
+    },
+    async close() {},
+  }
+  const a = new MSSQLAdapter({
+    id: 's', name: 's', type: 'sqlserver',
+    connection: { host: 'db', database: 'D' }, credentials: { username: 'u', password: 'p' }, options: { autoConnect: false },
+  })
+  const internal = a as unknown as { pool: unknown; connected: boolean }
+  internal.pool = pool
+  internal.connected = true
+  return { a, calls }
+}
+
+function pgFakePool() {
+  const calls: string[] = []
+  const pool = { async query(sql: string) { calls.push(sql); return { rows: [], rowCount: 0, fields: [] } } }
+  const a = new PostgresAdapter(cfg('postgres'))
+  const internal = a as unknown as { pool: unknown; connected: boolean }
+  internal.pool = pool
+  internal.connected = true
+  return { a, calls }
+}
+
+describe('A5 adapter backstop on the wire (select is always bounded)', () => {
+  it('MSSQL: omitted limit emits TOP (MAX) — never an unbounded scan', async () => {
+    const { a, calls } = mssqlFakePool()
+    await a.select('dbo.orders', {})
+    expect(calls[0]).toContain(`TOP (${DATA_SOURCE_MAX_ROWS})`)
+  })
+
+  it('MSSQL: explicit in-range limit passes through as TOP (n)', async () => {
+    const { a, calls } = mssqlFakePool()
+    await a.select('orders', { limit: 50 })
+    expect(calls[0]).toContain('TOP (50)')
+  })
+
+  it('MSSQL: over-MAX throws and NEVER executes the query (no silent clamp)', async () => {
+    const { a, calls } = mssqlFakePool()
+    await expect(a.select('orders', { limit: DATA_SOURCE_MAX_ROWS + 1 })).rejects.toThrow(/exceeds the maximum/)
+    expect(calls.length).toBe(0)
+  })
+
+  it('Postgres: omitted limit emits LIMIT MAX; over-MAX throws without querying', async () => {
+    const omit = pgFakePool()
+    await omit.a.select('users', {})
+    expect(omit.calls[0]).toContain(`LIMIT ${DATA_SOURCE_MAX_ROWS}`)
+
+    const over = pgFakePool()
+    await expect(over.a.select('users', { limit: 99999 })).rejects.toThrow(/exceeds the maximum/)
+    expect(over.calls.length).toBe(0)
+  })
+})
+
+describe('A5 route layer (/select default + /query warning)', () => {
+  let currentUser: { id: string; role?: string } | undefined
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => { req.user = currentUser as never; next() })
+  app.use(dataSourcesRouter())
+  const admin = (id: string) => ({ id, role: 'admin' })
+
+  beforeEach(() => {
+    currentUser = admin('alice')
+    vi.restoreAllMocks()
+  })
+
+  it('/select applies DEFAULT_LIMIT when the caller omits limit', async () => {
+    const spy = vi.spyOn(DataSourceManager.prototype, 'select').mockResolvedValue({ data: [] })
+    await request(app).post('/api/data-sources').send(cfg('sel-default'))
+    const res = await request(app).post('/api/data-sources/sel-default/select').send({ table: 't' })
+    expect(res.status).toBe(200)
+    expect(spy).toHaveBeenCalled()
+    expect(spy.mock.calls[0][2]).toMatchObject({ limit: DATA_SOURCE_DEFAULT_LIMIT })
+  })
+
+  it('/select passes an explicit in-range limit through unchanged', async () => {
+    const spy = vi.spyOn(DataSourceManager.prototype, 'select').mockResolvedValue({ data: [] })
+    await request(app).post('/api/data-sources').send(cfg('sel-explicit'))
+    await request(app).post('/api/data-sources/sel-explicit/select').send({ table: 't', limit: 42 })
+    expect(spy.mock.calls[0][2]).toMatchObject({ limit: 42 })
+  })
+
+  it('/select rejects an over-MAX limit with 400 (schema gate, never reaches the adapter)', async () => {
+    const spy = vi.spyOn(DataSourceManager.prototype, 'select').mockResolvedValue({ data: [] })
+    await request(app).post('/api/data-sources').send(cfg('sel-over'))
+    const res = await request(app)
+      .post('/api/data-sources/sel-over/select')
+      .send({ table: 't', limit: DATA_SOURCE_MAX_ROWS + 1 })
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(spy).not.toHaveBeenCalled()
+  })
+
+  it('/query warns (response + audit) when the raw SQL has no row-count limit', async () => {
+    vi.spyOn(DataSourceManager.prototype, 'query').mockResolvedValue({ data: [] })
+    await request(app).post('/api/data-sources').send(cfg('q-warn'))
+    const res = await request(app).post('/api/data-sources/q-warn/query').send({ sql: 'SELECT * FROM big' })
+    expect(res.status).toBe(200)
+    expect(res.body.warning).toMatch(/no row-count limit \(LIMIT\/TOP\/FETCH\)/)
+  })
+
+  it('/query STILL warns for a bare OFFSET — it skips rows but does not cap them', async () => {
+    // P2: `SELECT * FROM big OFFSET 1000` returns the rest of a huge table; OFFSET is not a bound.
+    vi.spyOn(DataSourceManager.prototype, 'query').mockResolvedValue({ data: [] })
+    await request(app).post('/api/data-sources').send(cfg('q-offset'))
+    const res = await request(app).post('/api/data-sources/q-offset/query').send({ sql: 'SELECT * FROM big OFFSET 1000 ROWS' })
+    expect(res.status).toBe(200)
+    expect(res.body.warning).toMatch(/no row-count limit/)
+  })
+
+  it('/query does NOT warn when the SQL actually caps rows (LIMIT, or OFFSET+FETCH)', async () => {
+    vi.spyOn(DataSourceManager.prototype, 'query').mockResolvedValue({ data: [] })
+    await request(app).post('/api/data-sources').send(cfg('q-ok'))
+    const limited = await request(app).post('/api/data-sources/q-ok/query').send({ sql: 'SELECT * FROM big LIMIT 10' })
+    expect(limited.body.warning).toBeUndefined()
+    // OFFSET + FETCH NEXT is a genuine bound (T-SQL pagination)
+    const fetched = await request(app)
+      .post('/api/data-sources/q-ok/query')
+      .send({ sql: 'SELECT * FROM big ORDER BY id OFFSET 0 ROWS FETCH NEXT 10 ROWS ONLY' })
+    expect(fetched.body.warning).toBeUndefined()
+  })
+})


### PR DESCRIPTION
## A5 — result-boundary strategy (cheap MVP, per the in-chat co-design)

The "fake stream" was only one face of the OOM risk — **`/select` and raw `/query` also returned full result sets unbounded**. A "fetch-then-count" cap can't prevent OOM (everything's already materialized), so the boundary is enforced at **SQL-construction**, defense-in-depth across the read surface.

**Shared policy (BaseAdapter)**: `DATA_SOURCE_DEFAULT_LIMIT=1000` · `DATA_SOURCE_MAX_ROWS=10000`.

### Adapter backstop — the real guarantee
`resolveEffectiveLimit()`: omit → **MAX cap** (never whole-table), `> MAX` → **throw** (no silent clamp — paginate), invalid → throw. `PostgresAdapter.select()` + `MSSQLAdapter.select()` now **always** emit a bounded `LIMIT`/`TOP` via it. It lives at the **adapter** because the only internal caller (`DataSourceManager` copy loop, `:619`) calls `adapter.select()` **directly, bypassing the route** — and it already paginates explicitly (`limit: batchSize=1000`), so it's unaffected.

### Route + raw query
- **`/select`**: applies `DEFAULT_LIMIT` when omitted; over-max already 400 via `SelectSchema` (`max(DATA_SOURCE_MAX_ROWS)`, now DRY + `.int()`).
- **raw `/query`**: arbitrary SQL can't be safely auto-bounded → documented **non-large-export channel** + best-effort `warning` (response) + `unbounded` audit annotation when no `LIMIT/TOP/OFFSET/FETCH` is present. No hard reject (would break legit `WHERE`-bounded queries).
- **`stream()`**: raw-SQL, not route-exposed, internal-only → stays non-streaming; true cursor deferred as the *thorough* option.

### Tests (`data-source-result-boundary.test.ts`, 13)
constants · `resolveEffectiveLimit` (omit/null→MAX, in-range passthrough, over→throw, invalid→throw) · **PG + MSSQL `select()` on the wire** (omit→`LIMIT`/`TOP` MAX, explicit passthrough, over-MAX throws **without querying**) · route `/select` default + over-max 400 + `/query` warning present/absent. **13/13 green; existing data-source/mssql suites 55/55 unaffected.** eslint clean, `tsc --noEmit` exit 0.

> The **sqlserver-smoke** lane triggers here (touches `data-adapters/**`) → bonus real-SQL-Server 2019/2022 validation of the bounded `TOP`.

### Tracker / governance
Design doc §4 A5 ⬜→✅. Lock-safe: data-adapters + route + docs only; no integration-core / RBAC / auth.

🤖 Generated with [Claude Code](https://claude.com/claude-code)