### PR TITLE
feat(integration): DF-T3b-2b UI-wire — preview sends referenceMappingSources (operator-UI-reachable)

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -260,6 +260,14 @@ export interface IntegrationStagingInstallResult {
   warnings: string[]
 }
 
+// DF-T3b-2b UI-wire: binds a from_reference_table domain to the staging system/object that holds its
+// mapping sheet. The preview route (DF-T3b-2b) live-bulk-reads each via the staging source-adapter.
+export interface IntegrationReferenceMappingSource {
+  domain: string
+  systemId: string
+  object: string
+}
+
 export interface IntegrationTemplatePreviewRequest {
   sourceRecord: Record<string, unknown>
   fieldMappings: IntegrationFieldMapping[]
@@ -275,6 +283,9 @@ export interface IntegrationTemplatePreviewRequest {
   // no-write preview and returns targetPayloadPreview; omitted = legacy preview (byte-compatible).
   payloadTemplate?: Record<string, unknown>
   fieldRules?: Array<Record<string, unknown>>
+  // DF-T3b-2b UI-wire: when present, the preview route live-bulk-reads each domain's mapping sheet so
+  // from_reference_table resolves per-material. Omitted = no live resolution (byte-compatible).
+  referenceMappingSources?: IntegrationReferenceMappingSource[]
 }
 
 // DF-T1.5 reachability wire: derive a minimal DF-T1 fieldRules set from the legacy preview's field

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -847,6 +847,14 @@
           placeholder='{ "FNumber": "&lt;code&gt;", "FName": "&lt;name&gt;" }'
         ></textarea>
         <small class="integration-workbench__hint">可选。填写后使用 DF-T1 no-write payloadTemplate 预览；留空则保持 legacy preview。</small>
+        <h2>引用映射来源 JSON</h2>
+        <textarea
+          v-model="referenceMappingSourcesText"
+          data-testid="reference-mapping-sources"
+          spellcheck="false"
+          placeholder='[ { "domain": "unit", "systemId": "…", "object": "…" } ]'
+        ></textarea>
+        <small class="integration-workbench__hint">可选。为 from_reference_table 字段绑定各 domain 的映射表（staging 系统 / 对象）；填写后预览会实时 bulk-read 解析，留空则不解析。仅在已填写目标模板 JSON 时生效。</small>
         <button
           type="button"
           class="integration-workbench__button"
@@ -943,6 +951,7 @@ import {
   type IntegrationStagingOpenTarget,
   type IntegrationSystemObject,
   type IntegrationFieldRule,
+  type IntegrationReferenceMappingSource,
   type IntegrationTemplatePreviewRequest,
   type WorkbenchExternalSystem,
 } from '../services/integration/workbench'
@@ -1118,6 +1127,10 @@ const sampleRecordText = ref(JSON.stringify({
 // DF-T1.5 reachability wire: optional payloadTemplate JSON. When filled, previewPayload sends the
 // DF-T1 no-write preview shape so the backend returns targetPayloadPreview (provenance); empty = legacy.
 const payloadTemplateText = ref('')
+// DF-T3b-2b UI-wire: optional referenceMappingSources JSON; when filled (and a payloadTemplate is set),
+// previewPayload sends it so the route live-bulk-reads each domain's mapping sheet and resolves
+// from_reference_table per-material. Empty = no live resolution (byte-compatible).
+const referenceMappingSourcesText = ref('')
 // DF-T2c: the authored fieldRules draft (from the read-only derive route, then edited via the
 // authoring UI) + the gated fields it returns. previewPayload sends these (not a re-derive) when set.
 const authoredFieldRules = ref<IntegrationFieldRule[]>([])
@@ -2763,6 +2776,17 @@ async function previewPayload(): Promise<void> {
       request.fieldRules = authoredFieldRules.value.length > 0
         ? authoredFieldRules.value
         : deriveFieldRulesFromMappings(fieldMappings)
+      // DF-T3b-2b UI-wire: when the operator provides reference mapping sources, send them so the route
+      // live-bulk-reads each domain's mapping sheet (from_reference_table resolves per-material). Empty =
+      // omitted (byte-compatible); invalid JSON / non-array throws here → error path, no backend call.
+      const referenceMappingSourcesRaw = referenceMappingSourcesText.value.trim()
+      if (referenceMappingSourcesRaw) {
+        const parsedSources = JSON.parse(referenceMappingSourcesRaw) as unknown
+        if (!Array.isArray(parsedSources)) {
+          throw new Error('引用映射来源 JSON 必须是一个数组')
+        }
+        request.referenceMappingSources = parsedSources as IntegrationReferenceMappingSource[]
+      }
     }
     const result = await previewIntegrationTemplate(request)
     previewText.value = JSON.stringify(result, null, 2)

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -659,6 +659,26 @@ describe('IntegrationWorkbenchView', () => {
     expect(wiredText).not.toContain('Bolt')
     expect(wiredText).not.toContain('Pcs')
 
+    // DF-T3b-2b UI-wire — filling reference mapping sources sends them in the preview POST so the route
+    // live-bulk-reads (from_reference_table resolution becomes operator-UI-reachable). The #1968
+    // request-body keystone: assert the POST body carries referenceMappingSources (not just a render).
+    expect(previewBodies[1]).not.toHaveProperty('referenceMappingSources') // empty before → omitted
+    const refSourcesInput = container.querySelector('[data-testid="reference-mapping-sources"]') as HTMLTextAreaElement
+    refSourcesInput.value = JSON.stringify([{ domain: 'unit', systemId: 'metasheet_staging_project_1', object: 'unit_dict' }])
+    refSourcesInput.dispatchEvent(new Event('input'))
+    await flushUi()
+    ;(container.querySelector('[data-testid="preview-payload"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(previewBodies).toHaveLength(3)
+    expect(previewBodies[2]).toHaveProperty('payloadTemplate') // still the DF-T1 path
+    expect((previewBodies[2] as Record<string, unknown>).referenceMappingSources).toEqual([
+      { domain: 'unit', systemId: 'metasheet_staging_project_1', object: 'unit_dict' },
+    ])
+    // reset so the invalid-payloadTemplate test below keeps its original semantics
+    refSourcesInput.value = ''
+    refSourcesInput.dispatchEvent(new Event('input'))
+    await flushUi()
+
     // DF-T1.5 reachability — Test 3 (invalid payloadTemplate JSON blocks the request): no new POST
     // is made and an error is surfaced.
     payloadTemplateInput.value = '{ not valid json'
@@ -666,7 +686,7 @@ describe('IntegrationWorkbenchView', () => {
     await flushUi()
     ;(container.querySelector('[data-testid="preview-payload"]') as HTMLButtonElement).click()
     await flushUi()
-    expect(previewBodies).toHaveLength(2)
+    expect(previewBodies).toHaveLength(3)
     expect(container.textContent).toContain('预览失败')
 
     // reset to legacy for the remainder of the test (pipeline save below is preview-independent)

--- a/docs/development/data-factory-df-t3b-2b-ui-wire-development-20260529.md
+++ b/docs/development/data-factory-df-t3b-2b-ui-wire-development-20260529.md
@@ -1,0 +1,73 @@
+# DF-T3b-2b UI-wire — preview sends referenceMappingSources (operator-UI-reachable) — development verification (2026-05-29)
+
+> Small follow-up to DF-T3b-2b (#2073). That slice made the preview **route** resolve
+> `from_reference_table` live from real mapping sheets, but it was **API-reachable only** — no shipped
+> client sent `referenceMappingSources`. This wires `IntegrationWorkbenchView.previewPayload` to send
+> them, so an operator clicking Preview gets live mapping-sheet resolution. **Frontend-only, read-only.**
+
+## Locked scope (owner-set)
+
+In:
+- `previewPayload` sends `referenceMappingSources` when the operator provides them (and a
+  `payloadTemplate` is set — the DF-T1 path where `from_reference_table` applies).
+- A minimal operator input: a `referenceMappingSources` JSON textarea, mirroring the existing
+  `payloadTemplate` textarea pattern.
+- A request-body keystone test (the POST carries `referenceMappingSources`) + a negative control.
+
+Out:
+- ❌ DF-T3b-2c real-Save compose-before-`upsert` (separate opt-in).
+- ❌ No richer structured authoring UI (domain/system/object pickers) — the JSON textarea is the
+  minimal wire; a structured editor is future polish.
+- ❌ No backend change (the route + bulk-read shipped in #2073).
+
+## What shipped (frontend-only)
+
+- `apps/web/src/services/integration/workbench.ts`: new `IntegrationReferenceMappingSource`
+  (`{domain, systemId, object}`) + optional `referenceMappingSources` on
+  `IntegrationTemplatePreviewRequest`.
+- `apps/web/src/views/IntegrationWorkbenchView.vue`:
+  - `referenceMappingSourcesText` ref + a `data-testid="reference-mapping-sources"` JSON textarea
+    (with an operator hint: binds each `from_reference_table` domain to its staging system/object; only
+    effective when a target template JSON is set).
+  - `previewPayload` (inside the `payloadTemplate` path) parses the textarea: non-empty → must be a JSON
+    **array** → `request.referenceMappingSources`; empty → omitted (byte-compatible); invalid JSON /
+    non-array → throws → error path, **no backend call**.
+- `apps/web/tests/IntegrationWorkbenchView.spec.ts`: extends the preview test.
+
+## Reachability — now closed for the operator
+
+DF-T3b-2b (#2073) was **API-reachable, not operator-UI-reachable**. With this wire, an operator who
+fills the reference-mapping-sources textarea and clicks Preview produces a POST that **carries
+`referenceMappingSources`**, which the #2073 route live-bulk-reads → `from_reference_table` resolves
+per-material in the preview. The three-state fail-closed + the server-side staging-kind / duplicate
+guards all live in #2073's route; this slice only supplies the input.
+
+## Test + negative control
+
+`IntegrationWorkbenchView.spec.ts` (15 passed): the **request-body keystone** (#1968 lesson — assert
+the POST body, not just a render) — before filling, `referenceMappingSources` is **absent** from the
+body; after filling the textarea and re-previewing, the POST body **carries** the parsed array (and
+still the DF-T1 `payloadTemplate`). Negative control: neutering the send (`void parsedSources`) makes
+the keystone assertion **fail**. vue-tsc clean for the changed files.
+
+## Known limitations / remaining operator friction (on record — not fixed here)
+
+- **`systemId` discoverability.** The wire is correct, but the textarea needs a `systemId`, and the
+  view surfaces system **names** (the source-system `<select>` binds `:value="system.id"` but displays
+  the label; ids appear only as option values / `data-testid`s). Object names and staging-descriptor
+  ids *are* visible, but the raw `systemId` is not plainly copyable. So "operator-UI-reachable" means
+  the input is wired and fillable — **full self-service still needs the operator to know the `systemId`
+  or a future structured picker** (domain/system/object). Honest framing: this closes the *send* gap,
+  not the *discover-the-binding* gap.
+- **Parse-error affordance.** Invalid reference-mapping-sources JSON throws into the existing preview
+  catch → the generic `预览失败`, indistinguishable from a backend preview error. Acceptable for a
+  minimal wire; a distinct "mapping-sources JSON malformed" message belongs with the structured-editor
+  polish.
+
+## Next (gated, separate opt-in)
+
+- **DF-T3b-2c** — real-Save compose-before-`upsert` (changes K3 Save bytes), with its recorded review
+  checklist (per-row fail-closed → dead-letter/provenance, same bindings as preview, I/O failure as its
+  own category).
+- Optional later polish: a structured reference-mapping-sources editor (domain/system/object pickers)
+  in place of the raw JSON textarea.


### PR DESCRIPTION
## DF-T3b-2b UI-wire — preview sends `referenceMappingSources`

Small follow-up to #2073. That slice made the preview **route** resolve `from_reference_table` live but was **API-reachable only** (no shipped client sent `referenceMappingSources`). This wires `IntegrationWorkbenchView.previewPayload` to send them. **Frontend-only, read-only.**

### What shipped
- `workbench.ts`: `IntegrationReferenceMappingSource {domain,systemId,object}` + optional `referenceMappingSources` on `IntegrationTemplatePreviewRequest`.
- `IntegrationWorkbenchView.vue`: a `reference-mapping-sources` JSON textarea + `previewPayload` (in the `payloadTemplate` path) parses it — non-empty must be a JSON **array** → `request.referenceMappingSources`; empty → omitted (byte-compatible); invalid/non-array → throws → error path, **no backend call**.

### Test (request-body keystone, #1968)
`IntegrationWorkbenchView.spec.ts` (15 passed): before filling, the POST **omits** `referenceMappingSources`; after filling the textarea + re-preview, the POST **carries** the parsed array (still with the DF-T1 `payloadTemplate`). **Negative control**: neutering the send fails the assertion. vue-tsc clean for changed files.

### Honest reachability + known friction (on record)
This closes the **send** gap. It does **not** close the **discover-the-binding** gap: the textarea needs a `systemId`, but the view surfaces system **names** (ids are only option values / `data-testid`s) — object names + staging-descriptor ids are visible, the raw `systemId` is not plainly copyable. So full self-service still needs the operator to know the `systemId` or a future **structured picker**. Also: invalid mapping-sources JSON shows the generic `预览失败` (no distinct affordance). Both noted for the structured-editor polish.

### Out of scope
No backend change (route + bulk-read in #2073); no DF-T3b-2c real-Save wiring; JSON textarea is the minimal wire.

Verification MD: `docs/development/data-factory-df-t3b-2b-ui-wire-development-20260529.md`. Left for owner review — no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)