### PR TITLE
feat(attendance): capture HR profile fields

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1804,6 +1804,8 @@
                     <tr>
                       <th>{{ tr('Email', '邮箱') }}</th>
                       <th>{{ tr('Name', '姓名') }}</th>
+                      <th>{{ tr('Employee no.', '员工号') }}</th>
+                      <th>{{ tr('Department', '部门') }}</th>
                       <th>{{ tr('User ID', '用户 ID') }}</th>
                       <th>{{ tr('Actions', '操作') }}</th>
                     </tr>
@@ -1812,6 +1814,8 @@
                     <tr v-for="user in provisionSearchResults" :key="user.id">
                       <td>{{ user.email }}</td>
                       <td>{{ user.name || '--' }}</td>
+                      <td>{{ user.employeeNo || '--' }}</td>
+                      <td>{{ user.department || '--' }}</td>
                       <td><code>{{ user.id.slice(0, 8) }}</code></td>
                       <td class="attendance__table-actions">
                         <button class="attendance__btn" @click="selectProvisionUser(user)">{{ tr('Select', '选择') }}</button>
@@ -6283,6 +6287,8 @@ interface AttendanceAdminUserSearchItem {
   id: string
   email: string
   name: string | null
+  employeeNo?: string | null
+  department?: string | null
   role: string
   is_active: boolean
   is_admin: boolean
@@ -6300,6 +6306,8 @@ interface AttendanceAdminBatchResolveItem {
   id: string
   email: string
   name: string | null
+  employeeNo?: string | null
+  department?: string | null
   is_active: boolean
 }
 
@@ -8378,6 +8386,8 @@ function normalizeAttendanceGroupMemberResolvedUsers(payload: any, requestedUser
       id,
       email: String((raw as any).email || ''),
       name: (raw as any).name === null || (raw as any).name === undefined ? null : String((raw as any).name),
+      employeeNo: (raw as any).employeeNo === null || (raw as any).employeeNo === undefined ? null : String((raw as any).employeeNo),
+      department: (raw as any).department === null || (raw as any).department === undefined ? null : String((raw as any).department),
       is_active: (raw as any).is_active === false ? false : true,
     }
   }
@@ -8408,6 +8418,10 @@ function attendanceGroupMemberSecondaryLabel(userId: string): string {
   if (!item) return ''
   const primary = attendanceGroupMemberPrimaryLabel(userId)
   const parts: string[] = []
+  const employeeNo = item.employeeNo?.trim()
+  if (employeeNo && employeeNo !== primary) parts.push(employeeNo)
+  const department = item.department?.trim()
+  if (department && department !== primary) parts.push(department)
   const email = item.email.trim()
   if (email && email !== primary) parts.push(email)
   if (!item.is_active) parts.push(tr('Inactive', '已停用'))
@@ -8439,6 +8453,10 @@ function attendanceAssignmentUserSecondaryLabel(userId: string): string {
   if (!item) return ''
   const primary = attendanceAssignmentUserPrimaryLabel(userId)
   const parts: string[] = []
+  const employeeNo = item.employeeNo?.trim()
+  if (employeeNo && employeeNo !== primary) parts.push(employeeNo)
+  const department = item.department?.trim()
+  if (department && department !== primary) parts.push(department)
   const email = item.email.trim()
   if (email && email !== primary) parts.push(email)
   if (!item.is_active) parts.push(tr('Inactive', '已停用'))

--- a/apps/web/src/views/UserManagementView.vue
+++ b/apps/web/src/views/UserManagementView.vue
@@ -15,7 +15,7 @@
           v-model.trim="search"
           class="user-admin__search"
           type="search"
-          placeholder="搜索邮箱、用户名、手机号、姓名或用户 ID"
+          placeholder="搜索邮箱、用户名、手机号、姓名、员工号、部门或用户 ID"
           @keyup.enter="void loadUsers()"
         />
         <button class="user-admin__button" type="button" :disabled="loading" @click="void loadUsers()">
@@ -59,6 +59,10 @@
         <input v-model.trim="createForm.email" class="user-admin__search" type="email" placeholder="邮箱（可选）" />
         <input v-model.trim="createForm.username" class="user-admin__search" type="text" placeholder="用户名（可选）" />
         <input v-model.trim="createForm.mobile" class="user-admin__search" type="text" placeholder="手机号（可选）" />
+        <input v-model.trim="createForm.employeeNo" class="user-admin__search" type="text" placeholder="员工号（可选）" />
+        <input v-model.trim="createForm.department" class="user-admin__search" type="text" placeholder="部门（可选）" />
+        <input v-model.trim="createForm.position" class="user-admin__search" type="text" placeholder="岗位（可选）" />
+        <input v-model="createForm.hireDate" class="user-admin__search" type="date" aria-label="入职日期（可选）" />
         <input v-model.trim="createForm.password" class="user-admin__search" type="text" placeholder="可选：初始密码" />
         <select v-model="presetModeFilter" class="user-admin__select">
           <option value="">预设模式（全部）</option>
@@ -348,6 +352,7 @@
               <h2>{{ access.user.name || formatManagedUserLabel(access.user) }}</h2>
               <p>{{ formatManagedUserIdentifier(access.user) }}</p>
               <p v-if="access.user.mobile" class="user-admin__hint">手机号：{{ access.user.mobile }}</p>
+              <p v-if="profileSummaryLine" class="user-admin__hint">{{ profileSummaryLine }}</p>
             </div>
             <div class="user-admin__badges">
               <span class="user-admin__badge">{{ access.user.role }}</span>
@@ -379,6 +384,30 @@
                 class="user-admin__search"
                 type="text"
                 placeholder="手机号，可留空"
+              />
+              <input
+                v-model.trim="profileDraftEmployeeNo"
+                class="user-admin__search"
+                type="text"
+                placeholder="员工号，可留空"
+              />
+              <input
+                v-model.trim="profileDraftDepartment"
+                class="user-admin__search"
+                type="text"
+                placeholder="部门，可留空"
+              />
+              <input
+                v-model.trim="profileDraftPosition"
+                class="user-admin__search"
+                type="text"
+                placeholder="岗位，可留空"
+              />
+              <input
+                v-model="profileDraftHireDate"
+                class="user-admin__search"
+                type="date"
+                aria-label="入职日期，可留空"
               />
             </div>
             <div class="user-admin__role-actions">
@@ -723,6 +752,10 @@ type ManagedUser = {
   username?: string | null
   name: string | null
   mobile?: string | null
+  employeeNo?: string | null
+  department?: string | null
+  position?: string | null
+  hireDate?: string | null
   role: string
   is_active: boolean
   is_admin: boolean
@@ -863,6 +896,10 @@ type CreateUserForm = {
   email: string
   username: string
   mobile: string
+  employeeNo: string
+  department: string
+  position: string
+  hireDate: string
   password: string
   presetId: string
   role: string
@@ -974,12 +1011,20 @@ const dingtalkAccess = ref<DingTalkAccess | null>(null)
 const memberAdmission = ref<MemberAdmission | null>(null)
 const profileDraftName = ref('')
 const profileDraftMobile = ref('')
+const profileDraftEmployeeNo = ref('')
+const profileDraftDepartment = ref('')
+const profileDraftPosition = ref('')
+const profileDraftHireDate = ref('')
 const appliedUserNavigationKey = ref('')
 const createForm = ref<CreateUserForm>({
   name: '',
   email: '',
   username: '',
   mobile: '',
+  employeeNo: '',
+  department: '',
+  position: '',
+  hireDate: '',
   password: '',
   presetId: '',
   role: 'user',
@@ -1071,7 +1116,24 @@ const filteredAccessPresets = computed(() => {
 })
 const hasProfileDraftChanges = computed(() => {
   if (!access.value) return false
-  return profileDraftName.value !== (access.value.user.name || '') || profileDraftMobile.value !== (access.value.user.mobile || '')
+  return profileDraftName.value !== (access.value.user.name || '')
+    || profileDraftMobile.value !== (access.value.user.mobile || '')
+    || profileDraftEmployeeNo.value !== (access.value.user.employeeNo || '')
+    || profileDraftDepartment.value !== (access.value.user.department || '')
+    || profileDraftPosition.value !== (access.value.user.position || '')
+    || profileDraftHireDate.value !== (access.value.user.hireDate || '')
+})
+
+const profileSummaryLine = computed(() => {
+  const user = access.value?.user
+  if (!user) return ''
+  const parts = [
+    user.employeeNo ? `员工号：${user.employeeNo}` : '',
+    user.department ? `部门：${user.department}` : '',
+    user.position ? `岗位：${user.position}` : '',
+    user.hireDate ? `入职：${user.hireDate}` : '',
+  ].filter(Boolean)
+  return parts.join(' · ')
 })
 
 function formatManagedUserIdentifier(user: ManagedUser | null | undefined): string {
@@ -1574,6 +1636,10 @@ function syncUserNavigationFromLocation(): boolean {
 function syncProfileDraftFromAccess(): void {
   profileDraftName.value = access.value?.user.name || ''
   profileDraftMobile.value = access.value?.user.mobile || ''
+  profileDraftEmployeeNo.value = access.value?.user.employeeNo || ''
+  profileDraftDepartment.value = access.value?.user.department || ''
+  profileDraftPosition.value = access.value?.user.position || ''
+  profileDraftHireDate.value = access.value?.user.hireDate || ''
 }
 
 function extractNamespaceFromPermission(permission: string): string | null {
@@ -2181,6 +2247,10 @@ async function createUser(): Promise<void> {
         email: createForm.value.email,
         username: createForm.value.username || undefined,
         mobile: createForm.value.mobile || undefined,
+        employeeNo: createForm.value.employeeNo || undefined,
+        department: createForm.value.department || undefined,
+        position: createForm.value.position || undefined,
+        hireDate: createForm.value.hireDate || undefined,
         password: createForm.value.password || undefined,
         presetId: createForm.value.presetId || undefined,
         role: createForm.value.role || undefined,
@@ -2206,6 +2276,10 @@ async function createUser(): Promise<void> {
       email: '',
       username: '',
       mobile: '',
+      employeeNo: '',
+      department: '',
+      position: '',
+      hireDate: '',
       password: '',
       presetId: '',
       role: 'user',
@@ -2465,6 +2539,10 @@ async function saveUserProfile(): Promise<void> {
       body: JSON.stringify({
         name: profileDraftName.value,
         mobile: profileDraftMobile.value,
+        employeeNo: profileDraftEmployeeNo.value,
+        department: profileDraftDepartment.value,
+        position: profileDraftPosition.value,
+        hireDate: profileDraftHireDate.value,
         expectedMobile: baselineMobile,
       }),
     })

--- a/apps/web/src/views/attendance/useAttendanceAdminUsers.ts
+++ b/apps/web/src/views/attendance/useAttendanceAdminUsers.ts
@@ -9,6 +9,8 @@ export interface AttendanceAdminUserSearchItem {
   email: string
   name: string | null
   role: string
+  employeeNo?: string | null
+  department?: string | null
   is_active: boolean
   is_admin: boolean
   last_login_at: string | null
@@ -44,7 +46,8 @@ function formatUserLabel(user: AttendanceAdminUserSearchItem, tr: Translate): st
   }
   const primary = user.name?.trim() || user.email.trim() || user.id
   const secondary = user.email.trim() && user.email.trim() !== primary ? user.email.trim() : user.id
-  return user.id ? `${primary} · ${secondary}` : tr('Unknown user', '未知用户')
+  const profileParts = [user.employeeNo?.trim(), user.department?.trim()].filter(Boolean)
+  return user.id ? [primary, ...profileParts, secondary].join(' · ') : tr('Unknown user', '未知用户')
 }
 
 export function useAttendanceAdminUsers({
@@ -100,6 +103,8 @@ export function useAttendanceAdminUsers({
         id: normalizedUserId,
         email: normalizedUserId,
         name: null,
+        employeeNo: null,
+        department: null,
         role: '',
         is_active: true,
         is_admin: false,

--- a/apps/web/tests/userManagementView.spec.ts
+++ b/apps/web/tests/userManagementView.spec.ts
@@ -96,6 +96,10 @@ type UserFixture = {
   username?: string | null
   name: string
   mobile: string | null
+  employeeNo?: string | null
+  department?: string | null
+  position?: string | null
+  hireDate?: string | null
   role: string
   is_active: boolean
   grantEnabled: boolean
@@ -151,6 +155,10 @@ function createApiState(): UserFixture[] {
       username: 'bravo',
       name: 'Bravo',
       mobile: null,
+      employeeNo: 'E-2002',
+      department: 'Production',
+      position: 'Assembler',
+      hireDate: '2026-05-01',
       role: 'user',
       is_active: true,
       grantEnabled: false,
@@ -246,7 +254,16 @@ function createApiImplementation(
     const pathname = url.pathname
     const query = url.searchParams.get('q')?.trim().toLowerCase() || ''
     const filteredUsers = query
-      ? state.filter((user) => [user.name, user.email || '', user.username || '', user.id, user.role, user.mobile || ''].some((field) => field.toLowerCase().includes(query)))
+      ? state.filter((user) => [
+        user.name,
+        user.email || '',
+        user.username || '',
+        user.id,
+        user.role,
+        user.mobile || '',
+        user.employeeNo || '',
+        user.department || '',
+      ].some((field) => field.toLowerCase().includes(query)))
       : state
 
     const findUserById = (userId: string) => state.find((user) => user.id === userId) || state[0]
@@ -257,6 +274,10 @@ function createApiImplementation(
       username: user.username ?? null,
       name: user.name,
       mobile: user.mobile,
+      employeeNo: user.employeeNo ?? null,
+      department: user.department ?? null,
+      position: user.position ?? null,
+      hireDate: user.hireDate ?? null,
       role: user.role,
       is_active: user.is_active,
       is_admin: user.role === 'admin',
@@ -409,6 +430,10 @@ function createApiImplementation(
         email?: unknown
         username?: unknown
         mobile?: unknown
+        employeeNo?: unknown
+        department?: unknown
+        position?: unknown
+        hireDate?: unknown
       } : {}
       const newUser: UserFixture = {
         id: 'user-created',
@@ -416,6 +441,10 @@ function createApiImplementation(
         username: typeof parsed.username === 'string' && parsed.username.trim().length > 0 ? parsed.username.trim() : null,
         name: typeof parsed.name === 'string' && parsed.name.trim().length > 0 ? parsed.name.trim() : '新用户',
         mobile: typeof parsed.mobile === 'string' && parsed.mobile.trim().length > 0 ? parsed.mobile.trim() : null,
+        employeeNo: typeof parsed.employeeNo === 'string' && parsed.employeeNo.trim().length > 0 ? parsed.employeeNo.trim() : null,
+        department: typeof parsed.department === 'string' && parsed.department.trim().length > 0 ? parsed.department.trim() : null,
+        position: typeof parsed.position === 'string' && parsed.position.trim().length > 0 ? parsed.position.trim() : null,
+        hireDate: typeof parsed.hireDate === 'string' && parsed.hireDate.trim().length > 0 ? parsed.hireDate.trim() : null,
         role: 'user',
         is_active: true,
         grantEnabled: false,
@@ -553,9 +582,20 @@ function createApiImplementation(
     if (profileMatch) {
       const user = findUserById(decodeURIComponent(profileMatch[1]))
       const rawBody = typeof init?.body === 'string' ? init.body : ''
-      const parsed = rawBody ? JSON.parse(rawBody) as { name?: unknown; mobile?: unknown } : {}
+      const parsed = rawBody ? JSON.parse(rawBody) as {
+        name?: unknown
+        mobile?: unknown
+        employeeNo?: unknown
+        department?: unknown
+        position?: unknown
+        hireDate?: unknown
+      } : {}
       if (typeof parsed.name === 'string') user.name = parsed.name
       if (typeof parsed.mobile === 'string') user.mobile = parsed.mobile.trim() || null
+      if (typeof parsed.employeeNo === 'string') user.employeeNo = parsed.employeeNo.trim() || null
+      if (typeof parsed.department === 'string') user.department = parsed.department.trim() || null
+      if (typeof parsed.position === 'string') user.position = parsed.position.trim() || null
+      if (typeof parsed.hireDate === 'string') user.hireDate = parsed.hireDate.trim() || null
       return createJsonResponse({
         ok: true,
         data: {
@@ -1351,11 +1391,72 @@ describe('UserManagementView', () => {
     expect(JSON.parse(String((profileCall[1] as RequestInit | undefined)?.body))).toEqual({
       name: 'Bravo',
       mobile: '13800138000',
+      employeeNo: 'E-2002',
+      department: 'Production',
+      position: 'Assembler',
+      hireDate: '2026-05-01',
       expectedMobile: null,
     })
 
     await waitForCondition(() => container?.textContent?.includes('用户资料已更新') ?? false)
     expect(container?.textContent).toContain('手机号：13800138000')
+  })
+
+  it('can update attendance HR profile fields from the user detail panel', async () => {
+    app = createApp(UserManagementView)
+    registerRouterLink(app)
+    app.mount(container!)
+    await flushUi(20)
+
+    const bravoRow = findUserRow(container!, 'Bravo')
+    const bravoDetailButton = Array.from(bravoRow.querySelectorAll('button')).find((candidate) => candidate.textContent?.includes('Bravo'))
+    if (!(bravoDetailButton instanceof HTMLButtonElement)) {
+      throw new Error('Bravo detail button not found')
+    }
+    bravoDetailButton.click()
+    await waitForCondition(() => callLog.includes('/api/admin/users/user-2/access'))
+    const detailPanel = () => container!.querySelector('.user-admin__panel--detail') as HTMLElement | null
+    await waitForCondition(() => detailPanel()?.textContent?.includes('员工号：E-2002') ?? false)
+    expect(detailPanel()?.textContent).toContain('部门：Production')
+
+    const inputs = Array.from(container!.querySelectorAll('input'))
+    const employeeNoInput = inputs.find((candidate) => (candidate as HTMLInputElement).placeholder === '员工号，可留空')
+    const departmentInput = inputs.find((candidate) => (candidate as HTMLInputElement).placeholder === '部门，可留空')
+    const positionInput = inputs.find((candidate) => (candidate as HTMLInputElement).placeholder === '岗位，可留空')
+    const hireDateInput = inputs.find((candidate) => (candidate as HTMLInputElement).getAttribute('aria-label') === '入职日期，可留空')
+    if (!(employeeNoInput instanceof HTMLInputElement) || !(departmentInput instanceof HTMLInputElement) || !(positionInput instanceof HTMLInputElement) || !(hireDateInput instanceof HTMLInputElement)) {
+      throw new Error('HR profile inputs not found')
+    }
+
+    employeeNoInput.value = 'E-2026-009'
+    employeeNoInput.dispatchEvent(new Event('input', { bubbles: true }))
+    departmentInput.value = 'Assembly'
+    departmentInput.dispatchEvent(new Event('input', { bubbles: true }))
+    positionInput.value = 'Line Lead'
+    positionInput.dispatchEvent(new Event('input', { bubbles: true }))
+    hireDateInput.value = '2026-05-29'
+    hireDateInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    findButtonByText(container!, '保存资料').click()
+    await waitForCondition(() => apiFetchMock.mock.calls.some((args) => String(args[0]) === '/api/admin/users/user-2/profile'))
+
+    const profileCall = apiFetchMock.mock.calls.find((args) => String(args[0]) === '/api/admin/users/user-2/profile')
+    if (!profileCall) throw new Error('Profile update request not found')
+    expect(JSON.parse(String((profileCall[1] as RequestInit | undefined)?.body))).toEqual({
+      name: 'Bravo',
+      mobile: '',
+      employeeNo: 'E-2026-009',
+      department: 'Assembly',
+      position: 'Line Lead',
+      hireDate: '2026-05-29',
+      expectedMobile: null,
+    })
+
+    await waitForCondition(() => container?.textContent?.includes('员工号：E-2026-009') ?? false)
+    expect(container?.textContent).toContain('部门：Assembly')
+    expect(container?.textContent).toContain('岗位：Line Lead')
+    expect(container?.textContent).toContain('入职：2026-05-29')
   })
 
   it('refreshes and surfaces the latest mobile when a PROFILE_MOBILE_CONFLICT happens', async () => {
@@ -1476,7 +1577,11 @@ describe('UserManagementView', () => {
     const nameInput = inputs.find((candidate) => candidate.getAttribute('placeholder') === '姓名') as HTMLInputElement | undefined
     const usernameInput = inputs.find((candidate) => candidate.getAttribute('placeholder') === '用户名（可选）') as HTMLInputElement | undefined
     const mobileInput = inputs.find((candidate) => candidate.getAttribute('placeholder') === '手机号（可选）') as HTMLInputElement | undefined
-    if (!nameInput || !usernameInput || !mobileInput) {
+    const employeeNoInput = inputs.find((candidate) => candidate.getAttribute('placeholder') === '员工号（可选）') as HTMLInputElement | undefined
+    const departmentInput = inputs.find((candidate) => candidate.getAttribute('placeholder') === '部门（可选）') as HTMLInputElement | undefined
+    const positionInput = inputs.find((candidate) => candidate.getAttribute('placeholder') === '岗位（可选）') as HTMLInputElement | undefined
+    const hireDateInput = inputs.find((candidate) => candidate.getAttribute('aria-label') === '入职日期（可选）') as HTMLInputElement | undefined
+    if (!nameInput || !usernameInput || !mobileInput || !employeeNoInput || !departmentInput || !positionInput || !hireDateInput) {
       throw new Error('Create-user form inputs not found')
     }
 
@@ -1486,6 +1591,14 @@ describe('UserManagementView', () => {
     usernameInput.dispatchEvent(new Event('input', { bubbles: true }))
     mobileInput.value = '13900001234'
     mobileInput.dispatchEvent(new Event('input', { bubbles: true }))
+    employeeNoInput.value = 'E-2026-010'
+    employeeNoInput.dispatchEvent(new Event('input', { bubbles: true }))
+    departmentInput.value = 'Assembly'
+    departmentInput.dispatchEvent(new Event('input', { bubbles: true }))
+    positionInput.value = 'Operator'
+    positionInput.dispatchEvent(new Event('input', { bubbles: true }))
+    hireDateInput.value = '2026-05-29'
+    hireDateInput.dispatchEvent(new Event('input', { bubbles: true }))
     await flushUi(2)
 
     findButtonByText(container!, '创建用户').click()
@@ -1499,6 +1612,10 @@ describe('UserManagementView', () => {
       email: '',
       username: 'linlan',
       mobile: '13900001234',
+      employeeNo: 'E-2026-010',
+      department: 'Assembly',
+      position: 'Operator',
+      hireDate: '2026-05-29',
       role: 'user',
       isActive: true,
     })

--- a/packages/core-backend/migrations/060_add_users_hr_profile_fields.sql
+++ b/packages/core-backend/migrations/060_add_users_hr_profile_fields.sql
@@ -1,0 +1,21 @@
+-- 060_add_users_hr_profile_fields.sql
+-- Optional HR profile fields used by attendance onboarding and reports
+
+DO $$
+BEGIN
+  IF to_regclass('public.users') IS NOT NULL THEN
+    ALTER TABLE users
+      ADD COLUMN IF NOT EXISTS employee_no TEXT,
+      ADD COLUMN IF NOT EXISTS department TEXT,
+      ADD COLUMN IF NOT EXISTS position TEXT,
+      ADD COLUMN IF NOT EXISTS hire_date DATE;
+
+    CREATE INDEX IF NOT EXISTS idx_users_employee_no
+      ON users (lower(employee_no))
+      WHERE employee_no IS NOT NULL;
+
+    CREATE INDEX IF NOT EXISTS idx_users_department
+      ON users (lower(department))
+      WHERE department IS NOT NULL;
+  END IF;
+END $$;

--- a/packages/core-backend/src/db/migrations/zzzz20260529190000_add_users_hr_profile_fields.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260529190000_add_users_hr_profile_fields.ts
@@ -1,0 +1,53 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'users')
+  if (!exists) {
+    return
+  }
+
+  await sql`
+    ALTER TABLE users
+    ADD COLUMN IF NOT EXISTS employee_no TEXT,
+    ADD COLUMN IF NOT EXISTS department TEXT,
+    ADD COLUMN IF NOT EXISTS position TEXT,
+    ADD COLUMN IF NOT EXISTS hire_date DATE
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_users_employee_no
+    ON users (lower(employee_no))
+    WHERE employee_no IS NOT NULL
+  `.execute(db)
+
+  await sql`
+    CREATE INDEX IF NOT EXISTS idx_users_department
+    ON users (lower(department))
+    WHERE department IS NOT NULL
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'users')
+  if (!exists) {
+    return
+  }
+
+  await sql`
+    DROP INDEX IF EXISTS idx_users_department
+  `.execute(db)
+
+  await sql`
+    DROP INDEX IF EXISTS idx_users_employee_no
+  `.execute(db)
+
+  await sql`
+    ALTER TABLE users
+    DROP COLUMN IF EXISTS hire_date,
+    DROP COLUMN IF EXISTS position,
+    DROP COLUMN IF EXISTS department,
+    DROP COLUMN IF EXISTS employee_no
+  `.execute(db)
+}

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -34,6 +34,10 @@ type AdminUserProfile = {
   username: string | null
   name: string | null
   mobile: string | null
+  employeeNo: string | null
+  department: string | null
+  position: string | null
+  hireDate: string | null
   role: string
   is_active: boolean
   is_admin: boolean
@@ -259,6 +263,10 @@ type CreateUserRequestBody = {
   email?: string
   username?: string
   mobile?: string
+  employeeNo?: string
+  department?: string
+  position?: string
+  hireDate?: string
   name?: string
   password?: string
   role?: string
@@ -273,6 +281,23 @@ const DINGTALK_OPEN_ID_REQUIRED_FOR_GRANT_ERROR =
   'Directory account is missing DingTalk openId and cannot enable DingTalk login grant; resync DingTalk directory or complete DingTalk OAuth binding first'
 const PLATFORM_ADMIN_ROLE_ID = 'admin'
 const ATTENDANCE_ROLE_IDS = new Set(['attendance_employee', 'attendance_approver', 'attendance_admin'])
+const ADMIN_USER_PROFILE_SELECT = `
+  id,
+  email,
+  username,
+  name,
+  mobile,
+  employee_no AS "employeeNo",
+  department,
+  position,
+  hire_date AS "hireDate",
+  role,
+  is_active,
+  is_admin,
+  last_login_at,
+  created_at,
+  updated_at
+`
 
 function getRequestUserId(req: Request): string {
   const raw = req.user as Record<string, unknown> | undefined
@@ -307,7 +332,7 @@ async function ensurePlatformAdmin(req: Request, res: Response): Promise<string 
 
 async function fetchUserProfile(userId: string): Promise<AdminUserProfile | null> {
   const result = await query<AdminUserProfile>(
-    `SELECT id, email, username, name, mobile, role, is_active, is_admin, last_login_at, created_at, updated_at
+    `SELECT ${ADMIN_USER_PROFILE_SELECT}
      FROM users
      WHERE id = $1`,
     [userId],
@@ -388,6 +413,21 @@ function sanitizeUsername(username: string): string | null {
   const value = username.trim().toLowerCase()
   if (!value) return null
   return value.slice(0, 64)
+}
+
+function sanitizeOptionalProfileText(value: string, maxLength: number): string | null {
+  const normalized = value.trim().replace(/[<>'"&;]/g, '')
+  if (!normalized) return null
+  return normalized.slice(0, maxLength)
+}
+
+function sanitizeHireDate(value: string): string | null | undefined {
+  const normalized = value.trim()
+  if (!normalized) return null
+  if (!/^\d{4}-\d{2}-\d{2}$/.test(normalized)) return undefined
+  const parsed = new Date(`${normalized}T00:00:00.000Z`)
+  if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== normalized) return undefined
+  return normalized
 }
 
 function validateUsername(username: string | null): string | null {
@@ -1229,7 +1269,15 @@ async function fetchScopedDelegationUsers(adminUserId: string, namespaces: strin
 
   const term = search.trim() ? `%${search.trim()}%` : ''
   const filterSql = term
-    ? `AND (u.email ILIKE $3 OR COALESCE(u.name, '') ILIKE $3 OR u.id ILIKE $3)`
+    ? `AND (
+      u.email ILIKE $3
+      OR COALESCE(u.username, '') ILIKE $3
+      OR COALESCE(u.name, '') ILIKE $3
+      OR COALESCE(u.mobile, '') ILIKE $3
+      OR COALESCE(u.employee_no, '') ILIKE $3
+      OR COALESCE(u.department, '') ILIKE $3
+      OR u.id ILIKE $3
+    )`
     : ''
   const paginationParams = term ? [adminUserId, namespaces, term, pageSize, offset] : [adminUserId, namespaces, pageSize, offset]
 
@@ -1318,7 +1366,13 @@ async function fetchScopedDelegationUsers(adminUserId: string, namespaces: strin
       SELECT DISTINCT
         u.id,
         u.email,
+        u.username,
         u.name,
+        u.mobile,
+        u.employee_no AS "employeeNo",
+        u.department,
+        u.position,
+        u.hire_date AS "hireDate",
         u.role,
         u.is_active,
         u.is_admin,
@@ -1342,7 +1396,13 @@ async function fetchScopedDelegationUsers(adminUserId: string, namespaces: strin
       SELECT DISTINCT
         u.id,
         u.email,
+        u.username,
         u.name,
+        u.mobile,
+        u.employee_no AS "employeeNo",
+        u.department,
+        u.position,
+        u.hire_date AS "hireDate",
         u.role,
         u.is_active,
         u.is_admin,
@@ -1357,7 +1417,7 @@ async function fetchScopedDelegationUsers(adminUserId: string, namespaces: strin
       WHERE 1 = 1
       ${filterSql}
     )
-    SELECT id, email, name, role, is_active, is_admin, last_login_at, created_at, updated_at
+    SELECT id, email, username, name, mobile, "employeeNo", department, position, "hireDate", role, is_active, is_admin, last_login_at, created_at, updated_at
     FROM scoped_users
     ORDER BY created_at DESC
     LIMIT $${term ? 4 : 3} OFFSET $${term ? 5 : 4}
@@ -2311,10 +2371,10 @@ export function adminUsersRouter(): Router {
           Promise.resolve([]),
           (async () => {
             const term = q ? `%${q}%` : '%'
-            const where = q ? 'WHERE COALESCE(email, \'\') ILIKE $1 OR COALESCE(username, \'\') ILIKE $1 OR name ILIKE $1 OR COALESCE(mobile, \'\') ILIKE $1 OR id ILIKE $1' : ''
+            const where = q ? 'WHERE COALESCE(email, \'\') ILIKE $1 OR COALESCE(username, \'\') ILIKE $1 OR name ILIKE $1 OR COALESCE(mobile, \'\') ILIKE $1 OR COALESCE(employee_no, \'\') ILIKE $1 OR COALESCE(department, \'\') ILIKE $1 OR id ILIKE $1' : ''
             const countSql = `SELECT COUNT(*)::int AS c FROM users ${where}`
             const listSql = `
-              SELECT id, email, username, name, mobile, role, is_active, is_admin, last_login_at, created_at, updated_at
+              SELECT ${ADMIN_USER_PROFILE_SELECT}
               FROM users
               ${where}
               ORDER BY created_at DESC
@@ -2617,10 +2677,10 @@ export function adminUsersRouter(): Router {
       })
 
       const term = q ? `%${q}%` : '%'
-      const where = q ? 'WHERE COALESCE(email, \'\') ILIKE $1 OR COALESCE(username, \'\') ILIKE $1 OR name ILIKE $1 OR COALESCE(mobile, \'\') ILIKE $1 OR id ILIKE $1' : ''
+      const where = q ? 'WHERE COALESCE(email, \'\') ILIKE $1 OR COALESCE(username, \'\') ILIKE $1 OR name ILIKE $1 OR COALESCE(mobile, \'\') ILIKE $1 OR COALESCE(employee_no, \'\') ILIKE $1 OR COALESCE(department, \'\') ILIKE $1 OR id ILIKE $1' : ''
       const countSql = `SELECT COUNT(*)::int AS c FROM users ${where}`
       const listSql = `
-        SELECT id, email, username, name, mobile, role, is_active, is_admin, last_login_at, created_at, updated_at
+        SELECT ${ADMIN_USER_PROFILE_SELECT}
         FROM users
         ${where}
         ORDER BY created_at DESC
@@ -2637,7 +2697,7 @@ export function adminUsersRouter(): Router {
         // Deep-link target was not in the paginated window — fetch the single
         // row so the caller can focus it without a second round-trip.
         const pinned = await query<AdminUserProfile>(
-          `SELECT id, email, username, name, mobile, role, is_active, is_admin, last_login_at, created_at, updated_at
+          `SELECT ${ADMIN_USER_PROFILE_SELECT}
            FROM users
            WHERE id = $1`,
           [pinUserId],
@@ -2968,6 +3028,10 @@ export function adminUsersRouter(): Router {
       const cleanEmail = typeof body.email === 'string' ? sanitizeEmail(body.email) : ''
       const cleanUsername = typeof body.username === 'string' ? sanitizeUsername(body.username) : null
       const cleanMobile = typeof body.mobile === 'string' ? sanitizeMobile(body.mobile) : null
+      const cleanEmployeeNo = typeof body.employeeNo === 'string' ? sanitizeOptionalProfileText(body.employeeNo, 64) : null
+      const cleanDepartment = typeof body.department === 'string' ? sanitizeOptionalProfileText(body.department, 100) : null
+      const cleanPosition = typeof body.position === 'string' ? sanitizeOptionalProfileText(body.position, 100) : null
+      const cleanHireDate = typeof body.hireDate === 'string' ? sanitizeHireDate(body.hireDate) : null
       const cleanName = typeof body.name === 'string' ? sanitizeName(body.name) : ''
       const preset = getAccessPreset(typeof body.presetId === 'string' ? body.presetId.trim() : '')
       const cleanRole = typeof body.role === 'string' && body.role.trim()
@@ -2998,6 +3062,9 @@ export function adminUsersRouter(): Router {
 
       if (cleanName.length < 2 || cleanName.length > 100) {
         return jsonError(res, 400, 'INVALID_NAME', 'Name must be between 2 and 100 characters')
+      }
+      if (cleanHireDate === undefined) {
+        return jsonError(res, 400, 'INVALID_HIRE_DATE', 'hireDate must be YYYY-MM-DD or blank')
       }
 
       const password = requestedPassword || generateTemporaryPassword()
@@ -3050,14 +3117,21 @@ export function adminUsersRouter(): Router {
       })
 
       await query(
-        `INSERT INTO users (id, email, username, name, mobile, password_hash, must_change_password, role, permissions, is_active, is_admin, created_at, updated_at)
-         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::jsonb, $10, $11, NOW(), NOW())`,
+        `INSERT INTO users (
+           id, email, username, name, mobile, employee_no, department, position, hire_date,
+           password_hash, must_change_password, role, permissions, is_active, is_admin, created_at, updated_at
+         )
+         VALUES ($1, $2, $3, $4, $5, $6, $7, $8, $9::date, $10, $11, $12, $13::jsonb, $14, $15, NOW(), NOW())`,
         [
           userId,
           cleanEmail || null,
           cleanUsername,
           cleanName,
           cleanMobile,
+          cleanEmployeeNo,
+          cleanDepartment,
+          cleanPosition,
+          cleanHireDate,
           passwordHash,
           mustChangePassword,
           effectiveRole,
@@ -3163,9 +3237,13 @@ export function adminUsersRouter(): Router {
 
       const hasName = typeof req.body?.name === 'string'
       const hasMobile = typeof req.body?.mobile === 'string'
+      const hasEmployeeNo = typeof req.body?.employeeNo === 'string'
+      const hasDepartment = typeof req.body?.department === 'string'
+      const hasPosition = typeof req.body?.position === 'string'
+      const hasHireDate = typeof req.body?.hireDate === 'string'
       const hasExpectedMobile = Object.prototype.hasOwnProperty.call(req.body ?? {}, 'expectedMobile')
-      if (!hasName && !hasMobile) {
-        return jsonError(res, 400, 'PROFILE_FIELDS_REQUIRED', 'name or mobile is required')
+      if (!hasName && !hasMobile && !hasEmployeeNo && !hasDepartment && !hasPosition && !hasHireDate) {
+        return jsonError(res, 400, 'PROFILE_FIELDS_REQUIRED', 'At least one profile field is required')
       }
 
       const profile = await fetchUserProfile(userId)
@@ -3173,6 +3251,10 @@ export function adminUsersRouter(): Router {
 
       const nextName = hasName ? sanitizeName(String(req.body.name)) : profile.name
       const nextMobile = hasMobile ? sanitizeMobile(String(req.body.mobile)) : profile.mobile
+      const nextEmployeeNo = hasEmployeeNo ? sanitizeOptionalProfileText(String(req.body.employeeNo), 64) : profile.employeeNo
+      const nextDepartment = hasDepartment ? sanitizeOptionalProfileText(String(req.body.department), 100) : profile.department
+      const nextPosition = hasPosition ? sanitizeOptionalProfileText(String(req.body.position), 100) : profile.position
+      const nextHireDate = hasHireDate ? sanitizeHireDate(String(req.body.hireDate)) : profile.hireDate
       const expectedMobile = hasExpectedMobile
         ? req.body?.expectedMobile === null
           ? null
@@ -3187,6 +3269,9 @@ export function adminUsersRouter(): Router {
       if (hasExpectedMobile && expectedMobile === undefined) {
         return jsonError(res, 400, 'INVALID_EXPECTED_MOBILE', 'expectedMobile must be string or null')
       }
+      if (nextHireDate === undefined) {
+        return jsonError(res, 400, 'INVALID_HIRE_DATE', 'hireDate must be YYYY-MM-DD or blank')
+      }
 
       // Both the stored value and the witness are normalised the same way
       // (strip all whitespace, map empty to NULL) before comparison so legacy
@@ -3196,16 +3281,30 @@ export function adminUsersRouter(): Router {
         `UPDATE users
          SET name = $1,
              mobile = $2,
+             employee_no = $3,
+             department = $4,
+             position = $5,
+             hire_date = $6::date,
              updated_at = NOW()
-         WHERE id = $3
+         WHERE id = $7
            AND (
-             $4::boolean = FALSE
+             $8::boolean = FALSE
              OR NULLIF(regexp_replace(COALESCE(mobile, ''), '\\s+', '', 'g'), '')
                 IS NOT DISTINCT FROM
-                NULLIF(regexp_replace(COALESCE($5::text, ''), '\\s+', '', 'g'), '')
+                NULLIF(regexp_replace(COALESCE($9::text, ''), '\\s+', '', 'g'), '')
            )
          RETURNING id`,
-        [nextName, nextMobile, userId, hasExpectedMobile, expectedMobile ?? null],
+        [
+          nextName,
+          nextMobile,
+          nextEmployeeNo,
+          nextDepartment,
+          nextPosition,
+          nextHireDate,
+          userId,
+          hasExpectedMobile,
+          expectedMobile ?? null,
+        ],
       )
       if (updateResult.rows.length === 0) {
         return jsonError(res, 409, 'PROFILE_MOBILE_CONFLICT', 'User mobile changed before update was applied')
@@ -3222,10 +3321,18 @@ export function adminUsersRouter(): Router {
           before: {
             name: profile.name,
             mobile: profile.mobile,
+            employeeNo: profile.employeeNo,
+            department: profile.department,
+            position: profile.position,
+            hireDate: profile.hireDate,
           },
           after: {
             name: nextName,
             mobile: nextMobile,
+            employeeNo: nextEmployeeNo,
+            department: nextDepartment,
+            position: nextPosition,
+            hireDate: nextHireDate,
           },
         },
       })

--- a/packages/core-backend/src/routes/attendance-admin.ts
+++ b/packages/core-backend/src/routes/attendance-admin.ts
@@ -221,13 +221,15 @@ async function fetchUserProfile(userId: string): Promise<Record<string, unknown>
     id: string
     email: string
     name: string | null
+    employeeNo: string | null
+    department: string | null
     role: string
     is_active: boolean
     is_admin: boolean
     last_login_at: string | null
     created_at: string
   }>(
-    `SELECT id, email, name, role, is_active, is_admin, last_login_at, created_at
+    `SELECT id, email, name, employee_no AS "employeeNo", department, role, is_active, is_admin, last_login_at, created_at
      FROM users
      WHERE id = $1`,
     [userId],
@@ -266,6 +268,8 @@ type AttendanceAdminResolvedUser = {
   id: string
   email: string
   name: string | null
+  employeeNo: string | null
+  department: string | null
   is_active: boolean
 }
 
@@ -279,7 +283,7 @@ async function resolveBatchUsers(userIds: string[]): Promise<{
   }
 
   const found = await query<AttendanceAdminResolvedUser>(
-    `SELECT id, email, name, is_active
+    `SELECT id, email, name, employee_no AS "employeeNo", department, is_active
      FROM users
      WHERE id = ANY($1::text[])`,
     [userIds],
@@ -332,10 +336,12 @@ export function attendanceAdminRouter(): Router {
       })
 
       const term = q ? `%${q}%` : '%'
-      const where = q ? 'WHERE email ILIKE $1 OR name ILIKE $1 OR id ILIKE $1' : ''
+      const where = q
+        ? 'WHERE COALESCE(email, \'\') ILIKE $1 OR COALESCE(username, \'\') ILIKE $1 OR name ILIKE $1 OR COALESCE(mobile, \'\') ILIKE $1 OR COALESCE(employee_no, \'\') ILIKE $1 OR COALESCE(department, \'\') ILIKE $1 OR id ILIKE $1'
+        : ''
       const countSql = `SELECT COUNT(*)::int AS c FROM users ${where}`
       const listSql = `
-        SELECT id, email, name, role, is_active, is_admin, last_login_at, created_at
+        SELECT id, email, name, employee_no AS "employeeNo", department, role, is_active, is_admin, last_login_at, created_at
         FROM users
         ${where}
         ORDER BY created_at DESC

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -484,6 +484,10 @@ describe('admin-users routes', () => {
           email: 'alpha@example.com',
           name: 'Alpha',
           mobile: null,
+          employeeNo: null,
+          department: null,
+          position: null,
+          hireDate: null,
           role: 'user',
           is_active: true,
           is_admin: false,
@@ -499,6 +503,10 @@ describe('admin-users routes', () => {
           email: 'alpha@example.com',
           name: 'Alpha Prime',
           mobile: '13800138000',
+          employeeNo: null,
+          department: null,
+          position: null,
+          hireDate: null,
           role: 'user',
           is_active: true,
           is_admin: false,
@@ -519,15 +527,29 @@ describe('admin-users routes', () => {
     expect(response.statusCode).toBe(200)
     expect(pgMocks.query).toHaveBeenNthCalledWith(2,
       expect.stringContaining('UPDATE users'),
-      ['Alpha Prime', '13800138000', 'user-1', true, null],
+      ['Alpha Prime', '13800138000', null, null, null, null, 'user-1', true, null],
     )
     expect(auditMocks.auditLog).toHaveBeenCalledWith(expect.objectContaining({
       action: 'update',
       resourceType: 'user',
       resourceId: 'user-1',
       meta: expect.objectContaining({
-        before: { name: 'Alpha', mobile: null },
-        after: { name: 'Alpha Prime', mobile: '13800138000' },
+        before: {
+          name: 'Alpha',
+          mobile: null,
+          employeeNo: null,
+          department: null,
+          position: null,
+          hireDate: null,
+        },
+        after: {
+          name: 'Alpha Prime',
+          mobile: '13800138000',
+          employeeNo: null,
+          department: null,
+          position: null,
+          hireDate: null,
+        },
       }),
     }))
     expect((response.body as Record<string, any>).data.user).toMatchObject({
@@ -535,6 +557,125 @@ describe('admin-users routes', () => {
       name: 'Alpha Prime',
       mobile: '13800138000',
     })
+  })
+
+  it('updates attendance HR profile fields', async () => {
+    rbacMocks.isAdmin
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+    rbacMocks.listUserPermissions.mockResolvedValue([])
+    pgMocks.query
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          mobile: '13800138000',
+          employeeNo: null,
+          department: null,
+          position: null,
+          hireDate: null,
+          role: 'user',
+          is_active: true,
+          is_admin: false,
+          last_login_at: null,
+          created_at: '2026-03-12T00:00:00.000Z',
+          updated_at: '2026-03-12T00:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [{ id: 'user-1' }] })
+      .mockResolvedValueOnce({
+        rows: [{
+          id: 'user-1',
+          email: 'alpha@example.com',
+          name: 'Alpha',
+          mobile: '13800138000',
+          employeeNo: 'E-2026-009',
+          department: 'Assembly',
+          position: 'Line Lead',
+          hireDate: '2026-05-29',
+          role: 'user',
+          is_active: true,
+          is_admin: false,
+          last_login_at: null,
+          created_at: '2026-03-12T00:00:00.000Z',
+          updated_at: '2026-05-29T00:00:00.000Z',
+        }],
+      })
+      .mockResolvedValueOnce({ rows: [] })
+
+    const response = await invokeRoute('patch', '/api/admin/users/:userId/profile', {
+      params: { userId: 'user-1' },
+      body: {
+        employeeNo: ' E-2026-009 ',
+        department: ' Assembly ',
+        position: ' Line Lead ',
+        hireDate: '2026-05-29',
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect(pgMocks.query).toHaveBeenNthCalledWith(2,
+      expect.stringContaining('UPDATE users'),
+      ['Alpha', '13800138000', 'E-2026-009', 'Assembly', 'Line Lead', '2026-05-29', 'user-1', false, null],
+    )
+    expect(auditMocks.auditLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'update',
+      resourceType: 'user',
+      resourceId: 'user-1',
+      meta: expect.objectContaining({
+        before: expect.objectContaining({
+          employeeNo: null,
+          department: null,
+          position: null,
+          hireDate: null,
+        }),
+        after: expect.objectContaining({
+          employeeNo: 'E-2026-009',
+          department: 'Assembly',
+          position: 'Line Lead',
+          hireDate: '2026-05-29',
+        }),
+      }),
+    }))
+    expect((response.body as Record<string, any>).data.user).toMatchObject({
+      id: 'user-1',
+      employeeNo: 'E-2026-009',
+      department: 'Assembly',
+      position: 'Line Lead',
+      hireDate: '2026-05-29',
+    })
+  })
+
+  it('rejects invalid HR profile hire dates', async () => {
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    pgMocks.query.mockResolvedValueOnce({
+      rows: [{
+        id: 'user-1',
+        email: 'alpha@example.com',
+        name: 'Alpha',
+        mobile: null,
+        employeeNo: null,
+        department: null,
+        position: null,
+        hireDate: null,
+        role: 'user',
+        is_active: true,
+        is_admin: false,
+        last_login_at: null,
+        created_at: '2026-03-12T00:00:00.000Z',
+        updated_at: '2026-03-12T00:00:00.000Z',
+      }],
+    })
+
+    const response = await invokeRoute('patch', '/api/admin/users/:userId/profile', {
+      params: { userId: 'user-1' },
+      body: { hireDate: '2026-02-31' },
+    })
+
+    expect(response.statusCode).toBe(400)
+    expect((response.body as Record<string, any>).error.code).toBe('INVALID_HIRE_DATE')
+    expect(auditMocks.auditLog).not.toHaveBeenCalled()
   })
 
   it('clears user mobile profile field', async () => {
@@ -549,6 +690,10 @@ describe('admin-users routes', () => {
           email: 'alpha@example.com',
           name: 'Alpha',
           mobile: '13800138000',
+          employeeNo: null,
+          department: null,
+          position: null,
+          hireDate: null,
           role: 'user',
           is_active: true,
           is_admin: false,
@@ -564,6 +709,10 @@ describe('admin-users routes', () => {
           email: 'alpha@example.com',
           name: 'Alpha',
           mobile: null,
+          employeeNo: null,
+          department: null,
+          position: null,
+          hireDate: null,
           role: 'user',
           is_active: true,
           is_admin: false,
@@ -584,7 +733,7 @@ describe('admin-users routes', () => {
     expect(response.statusCode).toBe(200)
     expect(pgMocks.query).toHaveBeenNthCalledWith(2,
       expect.stringContaining('UPDATE users'),
-      ['Alpha', null, 'user-1', true, '13800138000'],
+      ['Alpha', null, null, null, null, null, 'user-1', true, '13800138000'],
     )
     expect((response.body as Record<string, any>).data.user).toMatchObject({
       id: 'user-1',
@@ -605,6 +754,10 @@ describe('admin-users routes', () => {
           email: 'alpha@example.com',
           name: 'Alpha',
           mobile: '138 0013 8000',
+          employeeNo: null,
+          department: null,
+          position: null,
+          hireDate: null,
           role: 'user',
           is_active: true,
           is_admin: false,
@@ -621,6 +774,10 @@ describe('admin-users routes', () => {
           email: 'alpha@example.com',
           name: 'Alpha',
           mobile: '13800138000',
+          employeeNo: null,
+          department: null,
+          position: null,
+          hireDate: null,
           role: 'user',
           is_active: true,
           is_admin: false,
@@ -640,7 +797,7 @@ describe('admin-users routes', () => {
     const updateCall = pgMocks.query.mock.calls[1]
     expect(String(updateCall[0])).toContain('regexp_replace')
     expect(String(updateCall[0])).toContain('IS NOT DISTINCT FROM')
-    expect(updateCall[1]).toEqual(['Alpha', '13800138000', 'user-1', true, '13800138000'])
+    expect(updateCall[1]).toEqual(['Alpha', '13800138000', null, null, null, null, 'user-1', true, '13800138000'])
   })
 
   it('returns 409 when expected mobile no longer matches current value', async () => {
@@ -652,6 +809,10 @@ describe('admin-users routes', () => {
           email: 'alpha@example.com',
           name: 'Alpha',
           mobile: '13600000000',
+          employeeNo: null,
+          department: null,
+          position: null,
+          hireDate: null,
           role: 'user',
           is_active: true,
           is_admin: false,
@@ -2558,6 +2719,10 @@ describe('admin-users routes', () => {
           id: 'user-new',
           email: 'new@example.com',
           name: 'New User',
+          employeeNo: 'E-2026-010',
+          department: 'Assembly',
+          position: 'Operator',
+          hireDate: '2026-05-29',
           role: 'user',
           is_active: true,
           is_admin: false,
@@ -2592,6 +2757,10 @@ describe('admin-users routes', () => {
       body: {
         email: 'new@example.com',
         name: 'New User',
+        employeeNo: ' E-2026-010 ',
+        department: ' Assembly ',
+        position: ' Operator ',
+        hireDate: '2026-05-29',
         password: 'WelcomePass9A',
         presetId: 'attendance-employee',
         isActive: true,
@@ -2600,12 +2769,25 @@ describe('admin-users routes', () => {
 
     expect(response.statusCode).toBe(200)
     expect((response.body as Record<string, any>).data.user.email).toBe('new@example.com')
+    expect((response.body as Record<string, any>).data.user).toMatchObject({
+      employeeNo: 'E-2026-010',
+      department: 'Assembly',
+      position: 'Operator',
+      hireDate: '2026-05-29',
+    })
     expect((response.body as Record<string, any>).data.roles).toEqual(['attendance_employee'])
     expect((response.body as Record<string, any>).data.onboarding.productMode).toBe('attendance')
     expect((response.body as Record<string, any>).data.inviteToken).toBe('invite-token-fixed')
     expect(String((response.body as Record<string, any>).data.onboarding.acceptInviteUrl)).toContain('invite-token-fixed')
     expect(String((response.body as Record<string, any>).data.onboarding.inviteMessage)).toContain('推荐入口：/attendance')
     expect(bcryptMocks.hash).toHaveBeenCalledWith('WelcomePass9A', 10)
+    const insertCall = pgMocks.query.mock.calls.find((args) => String(args[0]).includes('INSERT INTO users ('))
+    expect(insertCall?.[1]).toEqual(expect.arrayContaining([
+      'E-2026-010',
+      'Assembly',
+      'Operator',
+      '2026-05-29',
+    ]))
     expect(auditMocks.auditLog).toHaveBeenCalled()
   })
 


### PR DESCRIPTION
## Summary
- Add optional user HR profile fields: employee number, department, position, and hire date.
- Wire Admin User create/detail profile forms and admin user search to read/write the fields.
- Surface employee number and department in attendance user search, picker labels, group/assignment labels, and provisioning search results.

## Scope
Refs #2077. This is the first slice only: it does not add default shift assignment, default approver capture, attendance group membership schema, or report/payroll mapping.

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-users-routes.test.ts --reporter=dot`
- `pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts tests/useAttendanceAdminUsers.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/web build`
- `pnpm lint`
- `git diff --check origin/main...HEAD && git diff --check`
