### PR TITLE
test(attendance): align anchor-nav member tests with no-uuid-handoffs (496e3a082)

### DIFF
--- a/apps/web/tests/attendance-admin-anchor-nav.spec.ts
+++ b/apps/web/tests/attendance-admin-anchor-nav.spec.ts
@@ -545,7 +545,7 @@ describe('Attendance admin anchor navigation', () => {
     expect(container!.textContent).not.toContain('resolver unavailable')
   })
 
-  it('skips non-UUID attendance group member IDs before resolving labels', async () => {
+  it('sends non-UUID (legacy) member IDs to label resolve and falls back to the raw ID (no uuid handoffs)', async () => {
     const resolveBodies: unknown[] = []
     vi.mocked(apiFetch).mockImplementation(async (input: RequestInfo | URL, init?: RequestInit) => {
       const url = typeof input === 'string' ? input : input.toString()
@@ -605,7 +605,10 @@ describe('Attendance admin anchor navigation', () => {
 
     const people = container!.querySelector<HTMLElement>('[data-attendance-group-people]')
     expect(people).toBeTruthy()
-    expect(resolveBodies).toEqual([])
+    // No uuid handoffs (496e3a082): non-UUID / legacy member IDs are now sent to the label
+    // resolver too (the resolver no longer pre-filters to UUIDs).
+    expect(resolveBodies).toEqual([{ userIds: ['legacy-user-1'] }])
+    // The resolver rejects the legacy ID (400), so the UI falls back to showing the raw ID.
     expect(people!.querySelector('[data-attendance-group-member-label]')).toBeNull()
     expect(people!.querySelector('[data-attendance-group-member-user-id]')?.textContent).toContain('legacy-user-1')
   })
@@ -678,7 +681,7 @@ describe('Attendance admin anchor navigation', () => {
     await flushUi(4)
 
     expect(postBodies).toEqual([])
-    expect(container!.textContent).toContain('All entered IDs are already in this group or pending.')
+    expect(container!.textContent).toContain('All selected or entered users are already in this group or pending.')
     expect(container!.textContent).not.toContain('Enter at least one user ID.')
   })
 


### PR DESCRIPTION
## What
**Test-only, single-file**: realigns the two stale `attendance-admin-anchor-nav.spec.ts` tests with the behaviour shipped in **`496e3a082` (fix: remove uuid handoffs from setup assignments)**.

## Why (not a source regression — a missed spec update)
`496e3a082` deliberately:
- dropped the `isUuid` pre-filter from `attendanceGroupMemberResolverUserIds`, so **non-UUID / legacy** member IDs are now sent to the label resolver too (uniform user-picker + resolved-label flow, no UUID handoffs), and
- reworded the duplicate-add message to **"All selected or entered users are already in this group or pending."**

It updated `attendance-admin-regressions.spec.ts` (new test *"keeps attendance setup flows on user pickers and resolved labels instead of UUID handoffs"*) but **missed `attendance-admin-anchor-nav.spec.ts`** — leaving 2 tests asserting the old behaviour. Since web vitest isn't in CI (see `attendance-web-guard.yml`), the reds went unnoticed.

## Changes (no source touched)
- `test1`: renamed; now asserts the non-UUID/legacy ID **is** sent to resolve, then the UI falls back to the raw ID when the resolver rejects it (400).
- `test2`: duplicate-add assertion updated to the new message text. (The no-POST-on-all-duplicates logic is unchanged.)

## Verification
`attendance-admin-anchor-nav.spec.ts` **30/30** green. Test-only single-file change.

Follow-up (separate, not here): anchor-nav is now green → candidate to add to the `attendance-web-guard` gate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
