### PR TITLE
feat(multitable): 'value hidden by permissions' for redacted filter conditions in the view editor

### DIFF
--- a/apps/web/src/multitable/components/MetaViewManager.vue
+++ b/apps/web/src/multitable/components/MetaViewManager.vue
@@ -331,8 +331,14 @@
                 >
                   <option v-for="operator in operatorsForField(rule.fieldId)" :key="operator.value" :value="operator.value">{{ filterOperatorLabel(operator.value, operator.label, isZh) }}</option>
                 </select>
+                <span
+                  v-if="isPermissionHiddenFilterValue(rule)"
+                  class="meta-view-mgr__rule-empty meta-view-mgr__rule-hidden"
+                  :title="ml('view.valueHiddenByPermission')"
+                  data-test="filter-value-hidden"
+                >&#x1F512; {{ ml('view.valueHiddenByPermission') }}</span>
                 <input
-                  v-if="!isUnaryFilterOperator(rule.operator)"
+                  v-else-if="!isUnaryFilterOperator(rule.operator)"
                   class="meta-view-mgr__input"
                   :type="inputTypeForField(rule.fieldId)"
                   :value="rule.value ?? ''"
@@ -432,6 +438,7 @@ import type {
   ConditionalFormattingRule,
   MetaCalendarViewConfig,
   MetaField,
+  MetaFieldPermission,
   MetaGanttViewConfig,
   MetaGalleryViewConfig,
   MetaHierarchyViewConfig,
@@ -488,6 +495,9 @@ const props = defineProps<{
   fields: MetaField[]
   sheetId: string
   activeViewId: string
+  // #UX-redacted-filter: the viewer's field-read permissions, so a filter value on a field they can't read
+  // renders as "value hidden by permissions" (non-editable) instead of a misleading empty input.
+  fieldPermissions?: Record<string, MetaFieldPermission>
 }>()
 
 const emit = defineEmits<{
@@ -996,6 +1006,12 @@ const UNARY_FILTER_OPERATORS = new Set(['isEmpty', 'isNotEmpty'])
 
 function isUnaryFilterOperator(operator: string): boolean {
   return UNARY_FILTER_OPERATORS.has(operator)
+}
+
+// #UX-redacted-filter: a value-taking condition on a field the viewer can't read (layer-3) — its literal
+// was redacted on read (#2059), so the value input is meaningless/misleading. Show a hidden hint instead.
+function isPermissionHiddenFilterValue(rule: FilterRule): boolean {
+  return !isUnaryFilterOperator(rule.operator) && props.fieldPermissions?.[rule.fieldId]?.visible === false
 }
 
 function operatorsForField(fieldId: string) {

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -67,7 +67,7 @@ export type MetaManagerLabelKey =
   | 'view.orphanRecords' | 'view.noAdditionalConfig'
   | 'view.filterSortGroup' | 'view.sharedByViews'
   | 'view.filters' | 'view.sorts' | 'view.allConditions'
-  | 'view.anyCondition' | 'view.noValue' | 'view.addFilter'
+  | 'view.anyCondition' | 'view.noValue' | 'view.valueHiddenByPermission' | 'view.addFilter'
   | 'view.addSort' | 'view.sortAsc' | 'view.sortDesc'
   | 'view.changedWarning' | 'view.latestMetadataLoaded'
   | 'view.latestFieldMetadataLoaded'
@@ -251,6 +251,9 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'view.allConditions': { en: 'all conditions', zh: '满足全部条件' },
   'view.anyCondition': { en: 'any condition', zh: '满足任一条件' },
   'view.noValue': { en: 'no value', zh: '无值' },
+  // #UX-redacted-filter: a filter condition on a field the viewer can't read — the literal is hidden by
+  // permissions (server preserves it on re-save, #2074), so show a non-editable hint, not an empty input.
+  'view.valueHiddenByPermission': { en: 'value hidden by permissions', zh: '该值因权限隐藏' },
   'view.addFilter': { en: '+ Add filter', zh: '+ 添加筛选' },
   'view.addSort': { en: '+ Add sort', zh: '+ 添加排序' },
   'view.sortAsc': { en: 'A to Z', zh: 'A 到 Z' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -358,7 +358,7 @@
     />
     <MetaViewManager
       :visible="showViewManager" :views="workbench.views.value" :fields="propertyVisibleWorkbenchFields" :sheet-id="workbench.activeSheetId.value"
-      :active-view-id="workbench.activeViewId.value"
+      :active-view-id="workbench.activeViewId.value" :field-permissions="effectiveFieldPermissions"
       @update:dirty="viewManagerDirty = $event"
       @close="showViewManager = false" @create-view="onCreateView" @update-view="onUpdateView" @delete-view="onDeleteView"
     />

--- a/apps/web/tests/multitable-view-manager.spec.ts
+++ b/apps/web/tests/multitable-view-manager.spec.ts
@@ -961,4 +961,53 @@ describe('MetaViewManager', () => {
 
     app.unmount()
   })
+
+  it('shows a permission-hidden hint (not an editable input) for a filter on a field the viewer cannot read', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaViewManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          activeViewId: 'view_grid',
+          fields: [
+            { id: 'fld_name', name: 'Name', type: 'string' },
+            { id: 'fld_secret', name: 'Secret', type: 'string' },
+          ],
+          views: [
+            {
+              id: 'view_grid', sheetId: 'sheet_1', name: 'Grid', type: 'grid',
+              // fld_secret arrives as a #2059-redacted echo (no `value`); fld_name carries a literal.
+              filterInfo: { conjunction: 'and', conditions: [
+                { fieldId: 'fld_secret', operator: 'is' },
+                { fieldId: 'fld_name', operator: 'is', value: 'keep-me' },
+              ] },
+            },
+          ],
+          fieldPermissions: { fld_secret: { visible: false, readOnly: false } }, // viewer can't read fld_secret
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+    ;(container.querySelector('.meta-view-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await nextTick()
+
+    const filterRows = Array.from(container.querySelectorAll('.meta-view-mgr__rule-row--filter'))
+    expect(filterRows.length).toBe(2)
+    // the denied field's condition → hidden hint, and NO editable value input
+    const hiddenRow = filterRows.find((row) => row.querySelector('[data-test="filter-value-hidden"]'))
+    expect(hiddenRow).toBeTruthy()
+    expect(hiddenRow!.textContent).toContain('value hidden by permissions')
+    expect(hiddenRow!.querySelector('input.meta-view-mgr__input')).toBeNull()
+    // the readable field's condition → normal editable input, no hidden hint
+    const readableRow = filterRows.find((row) => !row.querySelector('[data-test="filter-value-hidden"]'))
+    expect(readableRow).toBeTruthy()
+    expect((readableRow!.querySelector('input.meta-view-mgr__input') as HTMLInputElement | null)?.value).toBe('keep-me')
+
+    app.unmount()
+  })
 })

--- a/apps/web/tests/multitable-view-manager.spec.ts
+++ b/apps/web/tests/multitable-view-manager.spec.ts
@@ -1010,4 +1010,39 @@ describe('MetaViewManager', () => {
 
     app.unmount()
   })
+
+  it('a UNARY operator on a denied field shows the no-value span, NOT the hidden hint (isUnaryFilterOperator guard)', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaViewManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          activeViewId: 'view_grid',
+          fields: [{ id: 'fld_secret', name: 'Secret', type: 'string' }],
+          views: [
+            { id: 'view_grid', sheetId: 'sheet_1', name: 'Grid', type: 'grid',
+              filterInfo: { conjunction: 'and', conditions: [{ fieldId: 'fld_secret', operator: 'isNotEmpty' }] } },
+          ],
+          fieldPermissions: { fld_secret: { visible: false, readOnly: false } },
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+    ;(container.querySelector('.meta-view-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await nextTick()
+
+    const filterRow = container.querySelector('.meta-view-mgr__rule-row--filter') as HTMLElement
+    expect(filterRow).toBeTruthy()
+    // unary operator → no value to hide → the existing no-value span, NOT the permission-hidden hint
+    expect(filterRow.querySelector('[data-test="filter-value-hidden"]')).toBeNull()
+    expect(filterRow.querySelector('input.meta-view-mgr__input')).toBeNull()
+    expect(filterRow.textContent).toContain('no value')
+
+    app.unmount()
+  })
 })


### PR DESCRIPTION
## Redacted-filter UX — "value hidden by permissions" in the view editor

Small design + impl slice (backlog item #1, the user-visible non-security follow-up to the field-read-gate arc). Pure frontend.

### Problem
After #2059 (read redaction) + #2074 (re-save guard), a field-denied `canManageViews` user editing a saved view saw a filter condition on a denied field as an **empty editable value input** (the literal was redacted on read) — easily misread as "no value." The server preserves the real literal on re-save (#2074), but the UX was misleading.

### Design
- **Detect:** `isPermissionHiddenFilterValue(rule)` = value-taking operator (`!isUnaryFilterOperator`) **and** `fieldPermissions[rule.fieldId]?.visible === false`.
- **Render:** a non-editable **🔒 "value hidden by permissions"** hint instead of the empty input → clear that a value exists but is hidden (and not user-editable; the server keeps the real literal). Unary operators keep the existing no-value span; readable fields keep the normal editable input.

### Changes (4 files, frontend-only)
- `MetaViewManager.vue`: optional `fieldPermissions` prop + the helper + the template branch (`v-if` redacted → `v-else-if` editable → `v-else` unary).
- `MultitableWorkbench.vue`: passes `:field-permissions="effectiveFieldPermissions"` (the layer-3 map it already computes).
- `meta-manager-labels.ts`: new typed key `view.valueHiddenByPermission` (en/zh).
- `multitable-view-manager.spec.ts`: a denied-field condition renders the hint with **no editable input**; a readable condition stays editable (value present). 13/13 green, vue-tsc clean.

### Posture / non-goals
Non-security (server #2074 is the data-safety floor); no backend/RBAC touch. **Not** in scope: stable condition IDs (to relax the reorder-400 backstop), the grid's read-only filter display, or any server change.

### Merge note
Frontend feature PR — at merge needs `base == origin/main` (not-stale) **plus an explicit greenlight**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
