### PR TITLE
feat(attendance): surface HR profile fields in reports

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -6152,6 +6152,12 @@ interface AttendanceRecord {
   user_id?: string
   user_name?: string | null
   username?: string | null
+  employee_no?: string | null
+  employeeNo?: string | null
+  department?: string | null
+  position?: string | null
+  hire_date?: string | null
+  hireDate?: string | null
   first_in_at: string | null
   last_out_at: string | null
   work_minutes: number
@@ -10728,6 +10734,7 @@ function formatRecordReportFieldLabel(field: AttendanceRecordReportField): strin
     employee_no: tr('Employee No.', '工号'),
     department: tr('Department', '部门'),
     position: tr('Position', '职位'),
+    hire_date: tr('Hire date', '入职日期'),
     attendance_group: tr('Attendance group', '考勤组'),
     punch_times: tr('Punch times', '打卡时间'),
     punch_result: tr('Punch result', '打卡结果'),
@@ -10784,11 +10791,28 @@ function formatRecordReportCell(record: AttendanceRecord, field: AttendanceRecor
     case 'employee_name':
       return firstRecordValue(record.user_name, record.username, record.user_id)
     case 'employee_no':
-      return firstRecordValue(recordMetaValue(record, ['empNo', 'employeeNo', 'employee_no', '工号']), record.user_id)
+      return firstRecordValue(
+        serverValue,
+        record.employee_no,
+        record.employeeNo,
+        recordMetaValue(record, ['empNo', 'employeeNo', 'employee_no', '工号']),
+        record.user_id,
+      )
     case 'department':
-      return firstRecordValue(recordMetaValue(record, ['department', '部门']))
+      return firstRecordValue(serverValue, record.department, recordMetaValue(record, ['department', '部门']))
     case 'position':
-      return firstRecordValue(recordMetaValue(record, ['position', 'role', 'roleTags', 'role_tags', '职位']))
+      return firstRecordValue(
+        serverValue,
+        record.position,
+        recordMetaValue(record, ['position', 'role', 'roleTags', 'role_tags', '职位']),
+      )
+    case 'hire_date':
+      return firstRecordValue(
+        serverValue,
+        record.hire_date,
+        record.hireDate,
+        recordMetaValue(record, ['hireDate', 'hire_date', '入职日期']),
+      )
     case 'attendance_group':
       return firstRecordValue(recordMetaValue(record, ['attendanceGroup', 'attendance_group', '考勤组']))
     case 'punch_times':

--- a/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
+++ b/packages/core-backend/tests/unit/attendance-report-field-catalog.test.ts
@@ -380,6 +380,47 @@ describe('attendance report field catalog multitable foundation', () => {
     ], fields, { headerMode: 'code' })).toBe('work_date,late_duration\n2026-05-13,12')
   })
 
+  it('resolves HR profile fields from joined user columns for record reports', () => {
+    const reportFields = helpers.resolveAttendanceRecordReportFields(
+      helpers.mergeAttendanceReportFieldDefinitions([], {}),
+    ).filter((field: { code: string }) => ['employee_no', 'department', 'position', 'hire_date'].includes(field.code))
+    expect(reportFields.map((field: { code: string }) => field.code)).toEqual([
+      'department',
+      'employee_no',
+      'position',
+      'hire_date',
+    ])
+
+    const row = {
+      user_id: 'user-uuid-fallback',
+      employee_no: 'E-1001',
+      department: 'Assembly',
+      position: 'Line Lead',
+      hire_date: new Date('2026-05-29T00:00:00.000Z'),
+      meta: {
+        employee_no: 'STALE-META-NO',
+        department: 'Stale Department',
+        position: 'Stale Position',
+        hire_date: '2026-01-01',
+      },
+    }
+
+    expect(helpers.getAttendanceRecordReportFieldValue(row, 'employee_no')).toBe('E-1001')
+    expect(helpers.getAttendanceRecordReportFieldValue(row, 'department')).toBe('Assembly')
+    expect(helpers.getAttendanceRecordReportFieldValue(row, 'position')).toBe('Line Lead')
+    expect(helpers.getAttendanceRecordReportFieldValue(row, 'hire_date')).toBe('2026-05-29')
+
+    const item = helpers.buildAttendanceRecordReportExportItem(row, reportFields)
+    expect(item).toEqual({
+      department: 'Assembly',
+      employee_no: 'E-1001',
+      position: 'Line Lead',
+      hire_date: '2026-05-29',
+    })
+    expect(helpers.buildAttendanceRecordReportCsv([item], reportFields))
+      .toBe('部门,工号,职位,入职日期\nAssembly,E-1001,Line Lead,2026-05-29')
+  })
+
   it('builds a shared report field config envelope for records and JSON exports', () => {
     const fields = helpers.resolveAttendanceRecordReportFields([
       {
@@ -1049,8 +1090,8 @@ describe('attendance report field catalog multitable foundation', () => {
       // NO findObjectSheet → catalog falls back to deterministic built-in field set
     }
     const attendanceRows = [
-      { user_id: 'u-1', org_id: 'org-1', work_date: '2026-05-13', timezone: 'UTC', first_in_at: '2026-05-13T09:00:00Z', last_out_at: '2026-05-13T18:00:00Z', work_minutes: 480, late_minutes: 0, early_leave_minutes: 0, status: 'normal', is_workday: true, meta: {}, user_name: '张三', username: 'zhangsan' },
-      { user_id: 'u-1', org_id: 'org-1', work_date: '2026-05-14', timezone: 'UTC', first_in_at: '2026-05-14T09:10:00Z', last_out_at: '2026-05-14T18:00:00Z', work_minutes: 470, late_minutes: 10, early_leave_minutes: 0, status: 'late', is_workday: true, meta: {}, user_name: '张三', username: 'zhangsan' },
+      { user_id: 'u-1', org_id: 'org-1', work_date: '2026-05-13', timezone: 'UTC', first_in_at: '2026-05-13T09:00:00Z', last_out_at: '2026-05-13T18:00:00Z', work_minutes: 480, late_minutes: 0, early_leave_minutes: 0, status: 'normal', is_workday: true, meta: {}, user_name: '张三', username: 'zhangsan', employee_no: 'E-1001', department: 'Assembly', position: 'Line Lead', hire_date: '2026-05-29' },
+      { user_id: 'u-1', org_id: 'org-1', work_date: '2026-05-14', timezone: 'UTC', first_in_at: '2026-05-14T09:10:00Z', last_out_at: '2026-05-14T18:00:00Z', work_minutes: 470, late_minutes: 10, early_leave_minutes: 0, status: 'late', is_workday: true, meta: {}, user_name: '张三', username: 'zhangsan', employee_no: 'E-1001', department: 'Assembly', position: 'Line Lead', hire_date: '2026-05-29' },
     ]
     const db = {
       query: async (sql: string) => {
@@ -1079,6 +1120,10 @@ describe('attendance report field catalog multitable foundation', () => {
       expect(valueEnsure.fields.filter(f => f.id === sk)).toHaveLength(1)
     }
     expect(store[0].data[rowKeyFid]).toBe('org-1:u-1:2026-05-13')
+    expect(store[0].data.fld_department).toBe('Assembly')
+    expect(store[0].data.fld_employee_no).toBe('E-1001')
+    expect(store[0].data.fld_position).toBe('Line Lead')
+    expect(store[0].data.fld_hire_date).toBe('2026-05-29')
     expect(typeof store[0].data['fld_field_fingerprint']).toBe('string')
     expect(typeof store[0].data['fld_source_fingerprint']).toBe('string')
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -1053,6 +1053,17 @@ const ATTENDANCE_REPORT_FIELD_DEFINITIONS = Object.freeze([
     description: '法定节假日或节假日规则下归集的加班分钟数。',
     internalKey: 'summary.holidayOvertimeMinutes',
   },
+  {
+    code: 'hire_date',
+    name: '入职日期',
+    category: 'fixed',
+    source: 'system',
+    unit: 'date',
+    dingtalkFieldName: '入职日期',
+    description: '员工入职日期。',
+    internalKey: 'user.hireDate',
+    sortOrder: 1006,
+  },
 ].map((field, index) => ({
   enabled: true,
   reportVisible: true,
@@ -2484,7 +2495,9 @@ async function syncAttendanceReportRecords(context, db, orgId, logger, params) {
   const rows = await db.query(
     `SELECT ar.user_id, ar.org_id, ar.work_date, ar.timezone, ar.first_in_at, ar.last_out_at,
             ar.work_minutes, ar.late_minutes, ar.early_leave_minutes, ar.status, ar.is_workday,
-            ar.meta, u.name AS user_name, u.username AS username
+            ar.meta, u.name AS user_name, u.username AS username,
+            u.employee_no AS employee_no, u.department AS department,
+            u.position AS position, u.hire_date AS hire_date
      FROM attendance_records ar
      LEFT JOIN users u ON u.id = ar.user_id
      WHERE ar.user_id = $1 AND ar.org_id = $2 AND ar.work_date BETWEEN $3 AND $4
@@ -2523,7 +2536,7 @@ async function syncAttendanceReportRecords(context, db, orgId, logger, params) {
         [ATTENDANCE_REPORT_RECORDS_FIELDS.orgId]: orgId,
         [ATTENDANCE_REPORT_RECORDS_FIELDS.userId]: userId,
         [ATTENDANCE_REPORT_RECORDS_FIELDS.employeeName]: firstNonEmptyValue(row.user_name, row.username, userId),
-        [ATTENDANCE_REPORT_RECORDS_FIELDS.department]: firstNonEmptyValue(readAttendanceRecordMeta(enrichedRow, ['department', '部门'])),
+        [ATTENDANCE_REPORT_RECORDS_FIELDS.department]: getAttendanceRecordReportFieldValue(enrichedRow, 'department'),
         [ATTENDANCE_REPORT_RECORDS_FIELDS.attendanceGroup]: firstNonEmptyValue(readAttendanceRecordMeta(enrichedRow, ['attendanceGroup', 'attendance_group', '考勤组'])),
         [ATTENDANCE_REPORT_RECORDS_FIELDS.workDate]: workDate,
       }
@@ -4007,6 +4020,7 @@ const ATTENDANCE_RECORD_REPORT_FIELD_CODES = Object.freeze([
   'employee_no',
   'department',
   'position',
+  'hire_date',
   'attendance_group',
   'punch_times',
   'punch_result',
@@ -4259,6 +4273,10 @@ function readAttendanceRecordMeta(row, keys) {
   return undefined
 }
 
+function normalizeAttendanceReportDateOnly(value) {
+  return normalizeDateOnlyValue(value) ?? firstNonEmptyValue(value)
+}
+
 function readAttendanceRecordMinutes(row, keys, fallback = 0) {
   const value = readAttendanceRecordMeta(row, keys)
   const parsed = Number(value)
@@ -4293,11 +4311,37 @@ function getAttendanceRecordReportFieldValue(row, fieldCode) {
     case 'employee_name':
       return firstNonEmptyValue(row?.user_name, row?.username, row?.user_id)
     case 'employee_no':
-      return firstNonEmptyValue(readAttendanceRecordMeta(row, ['empNo', 'employeeNo', 'employee_no', '工号']), row?.user_id)
+      return firstNonEmptyValue(
+        row?.employee_no,
+        row?.employeeNo,
+        row?.user?.employee_no,
+        row?.user?.employeeNo,
+        readAttendanceRecordMeta(row, ['empNo', 'employeeNo', 'employee_no', '工号']),
+        row?.user_id,
+      )
     case 'department':
-      return firstNonEmptyValue(readAttendanceRecordMeta(row, ['department', '部门']))
+      return firstNonEmptyValue(
+        row?.department,
+        row?.user_department,
+        row?.user?.department,
+        readAttendanceRecordMeta(row, ['department', '部门']),
+      )
     case 'position':
-      return firstNonEmptyValue(readAttendanceRecordMeta(row, ['position', 'role', 'roleTags', 'role_tags', '职位']))
+      return firstNonEmptyValue(
+        row?.position,
+        row?.user_position,
+        row?.user?.position,
+        readAttendanceRecordMeta(row, ['position', 'role', 'roleTags', 'role_tags', '职位']),
+      )
+    case 'hire_date':
+      return normalizeAttendanceReportDateOnly(firstNonEmptyValue(
+        row?.hire_date,
+        row?.hireDate,
+        row?.user_hire_date,
+        row?.user?.hire_date,
+        row?.user?.hireDate,
+        readAttendanceRecordMeta(row, ['hireDate', 'hire_date', '入职日期']),
+      ))
     case 'attendance_group':
       return firstNonEmptyValue(readAttendanceRecordMeta(row, ['attendanceGroup', 'attendance_group', '考勤组']))
     case 'punch_times':
@@ -17830,7 +17874,9 @@ module.exports = {
           const total = Number(countRows[0]?.total ?? 0)
 
           const rows = await db.query(
-            `SELECT ar.*, u.name AS user_name, u.username AS username
+            `SELECT ar.*, u.name AS user_name, u.username AS username,
+                    u.employee_no AS employee_no, u.department AS department,
+                    u.position AS position, u.hire_date AS hire_date
              FROM attendance_records ar
              LEFT JOIN users u ON u.id = ar.user_id
              WHERE ar.user_id = $1 AND ar.org_id = $2 AND ar.work_date BETWEEN $3 AND $4
@@ -29430,7 +29476,9 @@ module.exports = {
           const rows = await db.query(
             `SELECT ar.user_id, ar.org_id, ar.work_date, ar.timezone, ar.first_in_at, ar.last_out_at,
                     ar.work_minutes, ar.late_minutes, ar.early_leave_minutes, ar.status, ar.is_workday,
-                    ar.meta, u.name AS user_name, u.username AS username
+                    ar.meta, u.name AS user_name, u.username AS username,
+                    u.employee_no AS employee_no, u.department AS department,
+                    u.position AS position, u.hire_date AS hire_date
              FROM attendance_records ar
              LEFT JOIN users u ON u.id = ar.user_id
              WHERE ar.user_id = $1 AND ar.org_id = $2 AND ar.work_date BETWEEN $3 AND $4


### PR DESCRIPTION
## Summary
- join attendance record report/list/export queries to users HR profile fields
- add hire_date to the attendance record report field catalog and export values
- make the reports UI prefer backend report values for employee no, department, position, and hire date

Refs #2077

## Scope
This is the reports-display slice for #2077 only. It does not add default shift, approver, attendance group assignment, or guided onboarding next-step behavior.

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-catalog.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-report-field-formula-engine.test.ts --reporter=dot
- pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false --reporter=dot
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web build
- git diff --check
- git diff --check origin/main...HEAD