### PR TITLE
ci(attendance): expand web guard gate to include attendance-admin-anchor-nav

### DIFF
--- a/.github/workflows/attendance-web-guard.yml
+++ b/.github/workflows/attendance-web-guard.yml
@@ -5,11 +5,12 @@
 # specs. As a result, employee/admin surface guard regressions in AttendanceView slipped
 # through green CI (e.g. the overview admin-only-preload guard going red unnoticed).
 #
-# Scope (deliberately TARGETED, first step): run only attendance-admin-regressions.spec.ts,
-# which is currently green and holds the admin-surface guards we care about. The full
+# Scope (deliberately TARGETED): run the green attendance admin-surface guard specs —
+# attendance-admin-regressions.spec.ts (overview admin-only-preload guard) and
+# attendance-admin-anchor-nav.spec.ts (member resolve / nav guards). The full
 # `@metasheet/web` vitest suite still has historical/flaky failures, so wiring the whole
-# suite as a required gate now would be red on arrival. Expand the `vitest run` filter (or
-# move to the full web suite) as those specs are cleaned up.
+# suite as a required gate now would be red on arrival. Keep expanding the `vitest run`
+# filter (or move to the full web suite) as more web specs are cleaned up.
 name: Attendance Web Guard
 
 on:
@@ -18,6 +19,7 @@ on:
       - 'apps/web/src/views/AttendanceView.vue'
       - 'apps/web/src/views/attendance/**'
       - 'apps/web/tests/attendance-admin-regressions.spec.ts'
+      - 'apps/web/tests/attendance-admin-anchor-nav.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
   push:
     branches: [main]
@@ -25,6 +27,7 @@ on:
       - 'apps/web/src/views/AttendanceView.vue'
       - 'apps/web/src/views/attendance/**'
       - 'apps/web/tests/attendance-admin-regressions.spec.ts'
+      - 'apps/web/tests/attendance-admin-anchor-nav.spec.ts'
       - '.github/workflows/attendance-web-guard.yml'
 
 jobs:
@@ -67,4 +70,4 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Run attendance web guard specs (targeted)
-        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions --reporter=dot
+        run: pnpm --filter @metasheet/web exec vitest run attendance-admin-regressions attendance-admin-anchor-nav --reporter=dot


### PR DESCRIPTION
## What
**Workflow-only** change: expands the `attendance-web-guard` targeted gate to run **both** green attendance admin-surface guard specs.

- run command → `vitest run attendance-admin-regressions attendance-admin-anchor-nav --reporter=dot`
- trigger `paths` (pull_request + push) → add `apps/web/tests/attendance-admin-anchor-nav.spec.ts`

## Why
`attendance-admin-anchor-nav.spec.ts` was just realigned to the no-uuid-handoffs change (#2083) and is green (30/30). Adding it to the gate brings the just-fixed **41/41 + 30/30** under CI enforcement, so the same class of web-spec regression (which slipped through because web vitest isn't in the main CI gate) can't silently come back.

## Scope
No source, no T2/T3-T4/enforcement. The full `@metasheet/web` suite still has historical/flaky failures, so it stays out for now — keep expanding the `vitest run` filter as more web specs are cleaned up.

## Self-verifying
This PR edits the workflow (which is in its own trigger paths), so **`attendance-web-guard` runs on this PR** and must be green — proving the expanded gate works end-to-end.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
