### PR TITLE
feat(attendance): guide user onboarding into attendance setup

### DIFF
--- a/apps/web/src/views/UserManagementView.vue
+++ b/apps/web/src/views/UserManagementView.vue
@@ -99,6 +99,30 @@
       <p v-if="createdTemporaryPassword" class="user-admin__status">
         新用户临时密码：{{ createdTemporaryPassword }}
       </p>
+      <div v-if="createdAttendanceOnboardingTarget" class="user-admin__preset user-admin__attendance-next" data-attendance-onboarding-next-step>
+        <strong>下一步：补齐考勤配置</strong>
+        <p>{{ createdAttendanceOnboardingSummary }}</p>
+        <div class="user-admin__role-actions">
+          <router-link
+            class="user-admin__button user-admin__button--secondary user-admin__button-link"
+            :to="buildAttendanceAdminSectionLocation('attendance-admin-group-members')"
+          >
+            考勤组成员
+          </router-link>
+          <router-link
+            class="user-admin__button user-admin__button--secondary user-admin__button-link"
+            :to="buildAttendanceAdminSectionLocation('attendance-admin-assignments')"
+          >
+            班次分配
+          </router-link>
+          <router-link
+            class="user-admin__button user-admin__button--secondary user-admin__button-link"
+            :to="buildAttendanceAdminSectionLocation('attendance-admin-approval-flows')"
+          >
+            审批流
+          </router-link>
+        </div>
+      </div>
       <div v-if="selectedPreset" class="user-admin__preset">
         <strong>{{ selectedPreset.name }}</strong>
         <p>{{ selectedPreset.description }}</p>
@@ -951,6 +975,15 @@ type InviteLedgerRecord = {
   createdAt: string
 }
 
+type AttendanceOnboardingTarget = {
+  id: string
+  name: string
+  employeeNo: string
+  department: string
+  position: string
+  hireDate: string
+}
+
 type UserSessionRecord = {
   id: string
   userId: string
@@ -1004,6 +1037,7 @@ const temporaryPassword = ref('')
 const createdTemporaryPassword = ref('')
 const createdInviteMessage = ref('')
 const createdOnboarding = ref<OnboardingPacket | null>(null)
+const createdAttendanceOnboardingTarget = ref<AttendanceOnboardingTarget | null>(null)
 const inviteRecords = ref<InviteLedgerRecord[]>([])
 const userSessions = ref<UserSessionRecord[]>([])
 const access = ref<UserAccess | null>(null)
@@ -1032,6 +1066,19 @@ const createForm = ref<CreateUserForm>({
   isActive: true,
 })
 const selectedPreset = computed(() => accessPresets.value.find((preset) => preset.id === createForm.value.presetId) || null)
+const createdAttendanceOnboardingSummary = computed(() => {
+  const target = createdAttendanceOnboardingTarget.value
+  if (!target) return ''
+  const details = [
+    target.employeeNo ? `员工号 ${target.employeeNo}` : '',
+    target.department || '',
+    target.position || '',
+    target.hireDate ? `入职 ${target.hireDate}` : '',
+  ].filter(Boolean)
+  return details.length > 0
+    ? `${target.name || target.id} · ${details.join(' · ')}`
+    : `${target.name || target.id}`
+})
 const governanceSummary = computed(() => ({
   total: users.value.length,
   accountEnabled: users.value.filter((user) => user.is_active).length,
@@ -2234,11 +2281,36 @@ async function bulkUpdateNamespaceAdmissions(enabled: boolean): Promise<void> {
   }
 }
 
+function buildAttendanceOnboardingTarget(user: ManagedUser | undefined): AttendanceOnboardingTarget | null {
+  if (!user?.id) return null
+  return {
+    id: user.id,
+    name: String(user.name || user.username || user.email || user.id),
+    employeeNo: String(user.employeeNo || ''),
+    department: String(user.department || ''),
+    position: String(user.position || ''),
+    hireDate: String(user.hireDate || ''),
+  }
+}
+
+function buildAttendanceAdminSectionLocation(sectionId: string): string {
+  const params = new URLSearchParams({
+    tab: 'admin',
+    section: sectionId,
+  })
+  const target = createdAttendanceOnboardingTarget.value
+  if (target?.id) params.set('userId', target.id)
+  const query = target?.employeeNo || target?.name || target?.id || ''
+  if (query) params.set('q', query)
+  return `/attendance?${params.toString()}`
+}
+
 async function createUser(): Promise<void> {
   busy.value = true
   createdTemporaryPassword.value = ''
   createdInviteMessage.value = ''
   createdOnboarding.value = null
+  createdAttendanceOnboardingTarget.value = null
   try {
     const response = await apiFetch('/api/admin/users', {
       method: 'POST',
@@ -2271,6 +2343,7 @@ async function createUser(): Promise<void> {
     createdTemporaryPassword.value = String((payload.data as Record<string, unknown>).temporaryPassword || '')
     createdOnboarding.value = ((payload.data as Record<string, unknown>).onboarding as OnboardingPacket | undefined) || null
     createdInviteMessage.value = String(createdOnboarding.value?.inviteMessage || '')
+    createdAttendanceOnboardingTarget.value = buildAttendanceOnboardingTarget(access.value.user)
     createForm.value = {
       name: '',
       email: '',

--- a/apps/web/src/views/attendance/AttendanceExperienceView.vue
+++ b/apps/web/src/views/attendance/AttendanceExperienceView.vue
@@ -126,6 +126,11 @@ const overviewInitialSectionId = computed(() => {
   return section === 'attendance-overview-requests' ? section : ''
 })
 
+const adminInitialSectionId = computed(() => {
+  const section = Array.isArray(route.query.section) ? route.query.section[0] : route.query.section
+  return typeof section === 'string' && section.startsWith('attendance-admin-') ? section : ''
+})
+
 function matchesMediaQuery(query: string): boolean {
   try {
     return Boolean(window.matchMedia?.(query)?.matches)
@@ -167,7 +172,7 @@ const activeView = computed(() => {
       return {
         component: AttendanceAdminCenter,
         key: 'attendance-admin',
-        props: {},
+        props: { initialSectionId: adminInitialSectionId.value },
       }
     case 'import':
       if (!canAccessAdmin.value) return null

--- a/apps/web/tests/attendance-experience-entrypoints.spec.ts
+++ b/apps/web/tests/attendance-experience-entrypoints.spec.ts
@@ -133,6 +133,18 @@ describe('Attendance experience entrypoints', () => {
     expect(adminView?.dataset.section).toBe('attendance-admin-import')
   })
 
+  it('routes admin section shortcuts into the requested admin section', async () => {
+    routeState.query = { tab: 'admin', section: 'attendance-admin-assignments' }
+
+    app = createApp(AttendanceExperienceView)
+    app.mount(container!)
+    await flushUi()
+
+    const adminView = container!.querySelector<HTMLElement>('[data-view="admin"]')
+    expect(adminView).toBeTruthy()
+    expect(adminView?.dataset.section).toBe('attendance-admin-assignments')
+  })
+
   it('routes the attendance approval queue shortcut into the overview requests section', async () => {
     routeState.query = { section: 'attendance-overview-requests' }
 

--- a/apps/web/tests/userManagementView.spec.ts
+++ b/apps/web/tests/userManagementView.spec.ts
@@ -1569,7 +1569,7 @@ describe('UserManagementView', () => {
 
   it('creates a no-email user with username/mobile and surfaces temporary-password onboarding', async () => {
     app = createApp(UserManagementView)
-    registerRouterLink(app)
+    registerRouterLink(app, true)
     app.mount(container!)
     await flushUi(20)
 
@@ -1622,6 +1622,28 @@ describe('UserManagementView', () => {
     expect(container?.textContent).toContain('用户已创建')
     expect(container?.textContent).toContain('新用户临时密码：Temp#123456')
     expect(container?.textContent).toContain('账号：linlan')
+    const nextStep = container!.querySelector<HTMLElement>('[data-attendance-onboarding-next-step]')
+    expect(nextStep).toBeTruthy()
+    expect(nextStep?.textContent).toContain('下一步：补齐考勤配置')
+    expect(nextStep?.textContent).toContain('林岚 · 员工号 E-2026-010 · Assembly · Operator · 入职 2026-05-29')
+    const nextStepLinks = Array.from(nextStep!.querySelectorAll<HTMLAnchorElement>('a')).map(link => ({
+      text: link.textContent?.trim(),
+      href: link.getAttribute('href'),
+    }))
+    expect(nextStepLinks).toEqual([
+      {
+        text: '考勤组成员',
+        href: '/attendance?tab=admin&section=attendance-admin-group-members&userId=user-created&q=E-2026-010',
+      },
+      {
+        text: '班次分配',
+        href: '/attendance?tab=admin&section=attendance-admin-assignments&userId=user-created&q=E-2026-010',
+      },
+      {
+        text: '审批流',
+        href: '/attendance?tab=admin&section=attendance-admin-approval-flows&userId=user-created&q=E-2026-010',
+      },
+    ])
     expect(container?.textContent).not.toContain('首次设置密码链接：')
   })
 


### PR DESCRIPTION
## Summary
- show a post-create attendance setup next step in the admin user creation panel
- link the created user into attendance admin group members, shift assignments, and approval flows
- pass /attendance?tab=admin&section=... through the attendance shell into AttendanceAdminCenter

Refs #2077

## Scope
This is the guided-next-step slice only. It does not create default shift, approver, or attendance-group assignment records.

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts tests/attendance-experience-entrypoints.spec.ts --watch=false --reporter=dot
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web build
- git diff --check
- git diff --check origin/main...HEAD