### PR TITLE
feat(integration): DF-T3b-2d from_reference_table authoring opt-in (reference → resolve-via-mapping)

### DIFF
--- a/apps/web/src/components/integration/MetaIntegrationFieldRuleAuthoring.vue
+++ b/apps/web/src/components/integration/MetaIntegrationFieldRuleAuthoring.vue
@@ -1,7 +1,7 @@
 <template>
   <div class="integration-field-rule-authoring" data-testid="field-rule-authoring">
     <p class="integration-field-rule-authoring__hint">
-      逐字段选择 替换(replace,来自清洗表列)或 保留(preserve,沿用模板)。参照字段锁定为 preserve;gated 字段不可编辑。仅产出 fieldRules 草案,不写入 K3,也不调用 preview。
+      逐字段选择 替换(replace,来自清洗表列)或 保留(preserve,沿用模板)。参照字段可在 保留(preserve) 与 从映射表解析(from_reference_table,需选 domain)间切换,但不可降级为 scalar;gated 字段不可编辑。仅产出 fieldRules 草案,不写入 K3,也不调用 preview。
     </p>
 
     <ol class="integration-field-rule-authoring__list" data-testid="field-rule-list">
@@ -14,15 +14,44 @@
         <code class="integration-field-rule-authoring__field">{{ rule.targetField }}</code>
         <span class="integration-field-rule-authoring__shape" :data-shape="rule.shape">{{ rule.shape }}</span>
 
-        <template v-if="editability(rule).locked">
+        <template v-if="editability(rule).reason === 'gated'">
           <span
             class="integration-field-rule-authoring__mode integration-field-rule-authoring__mode--locked"
             :data-testid="`field-rule-mode-${rule.targetField}`"
-          >{{ editability(rule).reason === 'gated' ? 'gated（锁定,不可授权）' : 'preserve（参照字段锁定）' }}</span>
+          >gated（锁定,不可授权）</span>
           <span
             class="integration-field-rule-authoring__hint integration-field-rule-authoring__hint--strong"
             :data-testid="`field-rule-locked-${rule.targetField}`"
-          >{{ editability(rule).reason === 'gated' ? 'gated 字段不可编辑(不可授权)' : 'v1:参照字段不可降级为 scalar replace' }}</span>
+          >gated 字段不可编辑(不可授权)</span>
+        </template>
+
+        <template v-else-if="editability(rule).isReference">
+          <!-- DF-T3b-2d: a reference may flip preserve ↔ from_reference_table (+domain); NEVER scalar. -->
+          <select
+            class="integration-field-rule-authoring__mode"
+            :data-testid="`field-rule-mode-${rule.targetField}`"
+            :value="rule.sourceType === 'from_reference_table' ? 'mapping' : 'preserve'"
+            @change="onReferenceModeChange(index, ($event.target as HTMLSelectElement).value)"
+          >
+            <option value="preserve">保留(template)</option>
+            <option value="mapping">从映射表解析(reference table)</option>
+          </select>
+          <template v-if="rule.sourceType === 'from_reference_table'">
+            <select
+              class="integration-field-rule-authoring__domain"
+              :data-testid="`field-rule-domain-${rule.targetField}`"
+              :value="rule.domain || ''"
+              @change="onReferenceDomainChange(index, ($event.target as HTMLSelectElement).value)"
+            >
+              <option value="">— 选择 domain —</option>
+              <option v-for="domain in referenceDomains" :key="domain" :value="domain">{{ domain }}</option>
+            </select>
+            <span
+              v-if="!rule.domain"
+              class="integration-field-rule-authoring__hint integration-field-rule-authoring__hint--strong"
+              :data-testid="`field-rule-domain-required-${rule.targetField}`"
+            >需选择 domain(否则该参照字段保持未解析)</span>
+          </template>
         </template>
 
         <template v-else>
@@ -68,9 +97,12 @@
 // only); it makes NO backend call (no preview wire — that is DF-T2c) and never writes to K3.
 import { computed } from 'vue'
 import {
+  DF_T3_REFERENCE_DOMAINS,
   fieldRuleEditability,
   setFieldRuleReplace,
   setFieldRulePreserve,
+  setFieldRuleFromReferenceTable,
+  setFieldRuleReferencePreserve,
   type IntegrationFieldRule,
 } from '../../services/integration/workbench'
 
@@ -86,6 +118,7 @@ const emit = defineEmits<{ (e: 'update:modelValue', rules: IntegrationFieldRule[
 
 const rules = computed(() => props.modelValue)
 const gatedFields = computed(() => props.gatedFields ?? [])
+const referenceDomains = DF_T3_REFERENCE_DOMAINS
 
 function editability(rule: IntegrationFieldRule) {
   return fieldRuleEditability(rule, gatedFields.value)
@@ -95,17 +128,37 @@ function emitUpdated(index: number, next: IntegrationFieldRule): void {
   emit('update:modelValue', props.modelValue.map((rule, i) => (i === index ? next : rule)))
 }
 
+// SCALAR mode (replace/preserve). Guards against gated AND reference fields — a reference must never be
+// downgraded to a scalar replace (its mode is handled by onReferenceModeChange).
 function onModeChange(index: number, mode: string): void {
   const rule = props.modelValue[index]
-  // Guard: a reference/gated field is locked — never downgrade it to a scalar replace.
-  if (!editability(rule).editable) return
+  const e = editability(rule)
+  if (!e.editable || e.isReference) return
   if (mode === 'replace') emitUpdated(index, setFieldRuleReplace(rule, rule.sourceField || ''))
   else emitUpdated(index, setFieldRulePreserve(rule))
 }
 
 function onSourceFieldChange(index: number, sourceField: string): void {
   const rule = props.modelValue[index]
-  if (!editability(rule).editable) return
+  const e = editability(rule)
+  if (!e.editable || e.isReference) return
   emitUpdated(index, setFieldRuleReplace(rule, sourceField))
+}
+
+// DF-T3b-2d: REFERENCE mode (preserve ↔ from_reference_table). Keeps shape/completeness; never scalar.
+// Switching to 'mapping' yields the half-state (no domain yet) → the operator must pick a domain.
+function onReferenceModeChange(index: number, mode: string): void {
+  const rule = props.modelValue[index]
+  const e = editability(rule)
+  if (!e.editable || !e.isReference) return
+  if (mode === 'mapping') emitUpdated(index, setFieldRuleFromReferenceTable(rule, rule.domain || ''))
+  else emitUpdated(index, setFieldRuleReferencePreserve(rule))
+}
+
+function onReferenceDomainChange(index: number, domain: string): void {
+  const rule = props.modelValue[index]
+  const e = editability(rule)
+  if (!e.editable || !e.isReference) return
+  emitUpdated(index, setFieldRuleFromReferenceTable(rule, domain))
 }
 </script>

--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -326,7 +326,17 @@ export interface IntegrationFieldRule {
   shape: 'scalar' | 'object-passthrough' | 'by-fnumber' | 'by-fid'
   completeness?: 'none' | 'require-fnumber-fname' | 'require-fid-fname'
   required?: boolean
+  // DF-T3b-2d: the reference-mapping domain a from_reference_table rule resolves against.
+  domain?: string
 }
+
+// DF-T3b-2d: the reference-mapping domains an operator may bind a from_reference_table field to.
+// Mirrors the backend built-in templates (K3_REFERENCE_MAPPING_TEMPLATES, #2043). The backend
+// validates the domain (unknown → 400), so a stale list here is a non-correctness gap, not a bug.
+export const DF_T3_REFERENCE_DOMAINS = [
+  'unit', 'unit-group', 'account', 'warehouse', 'manager', 'category',
+  'use-state', 'track', 'planning-strategy', 'order-strategy', 'inspection-level', 'inspection-mode',
+] as const
 
 export interface IntegrationFieldRuleEditability {
   editable: boolean
@@ -335,11 +345,13 @@ export interface IntegrationFieldRuleEditability {
   isReference: boolean
 }
 
-// DF-T2b: whether a field's replace/preserve mode may be edited. The durable REFERENCE identity
-// is the SHAPE (object-passthrough / by-* — set by DF-T2a for object values), NOT the sourceType:
-// a *scalar* may legitimately be `from_staging` (replace) OR `preserve_template` (preserve), so
-// sourceType is the editable mode, not the lock signal. A non-scalar (reference) field is locked
-// to preserve and may NOT be downgraded to a scalar replace in v1. Gated fields are locked outright.
+// Whether a field's mode may be edited, and how. The durable REFERENCE identity is the SHAPE
+// (object-passthrough / by-* — set by DF-T2a for object values), NOT the sourceType: a *scalar* may
+// legitimately be `from_staging` (replace) OR `preserve_template` (preserve). DF-T3b-2d: a reference is
+// now **reference-editable** — it may flip between preserve_template and from_reference_table(+domain),
+// but is STILL never downgradable to a scalar replace (the v1 no-downgrade rule holds; from_reference_table
+// keeps a full reference object, resolved per-material). Gated fields are locked outright and win over
+// reference-editability (the gated check is first — e.g. FBaseUnitID stays closed even though it's a reference).
 export function fieldRuleEditability(
   rule: Pick<IntegrationFieldRule, 'targetField' | 'shape'>,
   gatedFields: string[] = [],
@@ -348,22 +360,41 @@ export function fieldRuleEditability(
     return { editable: false, locked: true, reason: 'gated', isReference: false }
   }
   if (rule.shape !== 'scalar') {
-    return { editable: false, locked: true, reason: 'reference', isReference: true }
+    return { editable: true, locked: false, reason: 'reference', isReference: true }
   }
   return { editable: true, locked: false, reason: null, isReference: false }
 }
 
-// Pure mode setters — called only on an editable (scalar) field. Shape stays 'scalar'; only the
-// replace/preserve mode flips. These never run on a reference/gated field (the UI locks those).
+// Pure SCALAR mode setters — called only on an editable scalar field. Shape stays 'scalar'; only the
+// replace/preserve mode flips. These never run on a reference/gated field (the UI routes those elsewhere).
 export function setFieldRuleReplace(rule: IntegrationFieldRule, sourceField: string): IntegrationFieldRule {
   const next: IntegrationFieldRule = { ...rule, sourceType: 'from_staging', shape: 'scalar', sourceField }
   delete next.completeness
+  delete next.domain
   return next
 }
 
 export function setFieldRulePreserve(rule: IntegrationFieldRule): IntegrationFieldRule {
   const next: IntegrationFieldRule = { ...rule, sourceType: 'preserve_template', shape: 'scalar' }
   delete next.sourceField
+  delete next.domain
+  return next
+}
+
+// DF-T3b-2d: pure REFERENCE mode setters — keep the reference SHAPE (object-passthrough / by-*) and
+// completeness; flip only between preserve_template and from_reference_table (+domain). NEVER scalar.
+// `setFieldRuleFromReferenceTable(rule, '')` yields the half-state (from_reference_table, no domain) —
+// safe: the backend resolver fail-closes a domain-less rule (no index → unresolved), never silently picks.
+export function setFieldRuleFromReferenceTable(rule: IntegrationFieldRule, domain: string): IntegrationFieldRule {
+  const next: IntegrationFieldRule = { ...rule, sourceType: 'from_reference_table' }
+  if (domain) next.domain = domain
+  else delete next.domain
+  return next
+}
+
+export function setFieldRuleReferencePreserve(rule: IntegrationFieldRule): IntegrationFieldRule {
+  const next: IntegrationFieldRule = { ...rule, sourceType: 'preserve_template' }
+  delete next.domain
   return next
 }
 

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -1868,7 +1868,12 @@ describe('IntegrationWorkbenchView', () => {
     expect((deriveBodies[0].payloadTemplate as Record<string, unknown>).FUnitID).toBeDefined()
     // the authoring UI is driven by the REAL derived draft
     expect(container.querySelector('[data-testid="field-rule-FNumber"]')).not.toBeNull()
-    expect(container.querySelector('[data-testid="field-rule-locked-FUnitID"]')).not.toBeNull() // reference locked
+    // DF-T3b-2d: a reference is now reference-EDITABLE (preserve↔from_reference_table), not locked — it
+    // renders an editable mode <select>, and there is still no scalar source input (never downgradable).
+    const refMode = container.querySelector('[data-testid="field-rule-mode-FUnitID"]') as HTMLSelectElement
+    expect(refMode?.tagName).toBe('SELECT')
+    expect(container.querySelector('[data-testid="field-rule-locked-FUnitID"]')).toBeNull()
+    expect(container.querySelector('[data-testid="field-rule-source-FUnitID"]')).toBeNull()
 
     // author: set FNumber's cleansed staging column
     const source = container.querySelector('[data-testid="field-rule-source-FNumber"]') as HTMLInputElement

--- a/apps/web/tests/MetaIntegrationFieldRuleAuthoring.spec.ts
+++ b/apps/web/tests/MetaIntegrationFieldRuleAuthoring.spec.ts
@@ -2,32 +2,58 @@ import { afterEach, describe, expect, it } from 'vitest'
 import { createApp, h, nextTick, type App as VueApp } from 'vue'
 import MetaIntegrationFieldRuleAuthoring from '../src/components/integration/MetaIntegrationFieldRuleAuthoring.vue'
 import {
+  DF_T3_REFERENCE_DOMAINS,
   fieldRuleEditability,
   setFieldRuleReplace,
   setFieldRulePreserve,
+  setFieldRuleFromReferenceTable,
+  setFieldRuleReferencePreserve,
   type IntegrationFieldRule,
 } from '../src/services/integration/workbench'
 
 // --- pure helper unit tests (DOM-independent) ---
-describe('fieldRuleEditability (DF-T2b)', () => {
-  it('scalar is editable; a non-scalar (reference) shape is locked to preserve; gated is locked', () => {
+describe('fieldRuleEditability + setters (DF-T2b / DF-T3b-2d)', () => {
+  it('scalar editable; reference is reference-EDITABLE (DF-T3b-2d, not locked); gated locked & wins', () => {
     expect(fieldRuleEditability({ targetField: 'FNumber', shape: 'scalar' })).toMatchObject({ editable: true, reason: null, isReference: false })
-    expect(fieldRuleEditability({ targetField: 'FUnitID', shape: 'object-passthrough' })).toMatchObject({ editable: false, locked: true, reason: 'reference', isReference: true })
-    expect(fieldRuleEditability({ targetField: 'FErpClsID', shape: 'by-fid' })).toMatchObject({ reason: 'reference' })
+    // DF-T3b-2d: a reference is now editable (preserve ↔ from_reference_table), NOT locked.
+    expect(fieldRuleEditability({ targetField: 'FUnitID', shape: 'object-passthrough' })).toMatchObject({ editable: true, locked: false, reason: 'reference', isReference: true })
+    expect(fieldRuleEditability({ targetField: 'FErpClsID', shape: 'by-fid' })).toMatchObject({ editable: true, reason: 'reference', isReference: true })
+    // gated WINS over reference-editability — a gated REFERENCE stays locked (FBaseUnitID stays closed).
+    expect(fieldRuleEditability({ targetField: 'FBaseUnitID', shape: 'object-passthrough' }, ['FBaseUnitID'])).toMatchObject({ editable: false, locked: true, reason: 'gated' })
     expect(fieldRuleEditability({ targetField: 'FBaseUnitID', shape: 'scalar' }, ['FBaseUnitID'])).toMatchObject({ editable: false, reason: 'gated' })
   })
 
   it('a preserved SCALAR stays editable (lock keys on shape, not sourceType)', () => {
-    // preserve_template + scalar shape = a scalar the operator chose to preserve — still editable.
-    expect(fieldRuleEditability({ targetField: 'FModel', shape: 'scalar' })).toMatchObject({ editable: true })
+    expect(fieldRuleEditability({ targetField: 'FModel', shape: 'scalar' })).toMatchObject({ editable: true, isReference: false })
   })
 
-  it('setters keep shape scalar and only flip the mode', () => {
+  it('scalar setters keep shape scalar and only flip the mode (+ drop domain)', () => {
     const replaced = setFieldRuleReplace({ targetField: 'FNumber', sourceType: 'preserve_template', shape: 'scalar' }, 'materialCode')
     expect(replaced).toMatchObject({ sourceType: 'from_staging', shape: 'scalar', sourceField: 'materialCode' })
     const preserved = setFieldRulePreserve({ targetField: 'FNumber', sourceType: 'from_staging', shape: 'scalar', sourceField: 'x' })
     expect(preserved).toMatchObject({ sourceType: 'preserve_template', shape: 'scalar' })
     expect(preserved.sourceField).toBeUndefined()
+  })
+
+  it('DF-T3b-2d reference setters keep SHAPE + completeness, flip preserve ↔ from_reference_table(+domain), never scalar', () => {
+    const ref: IntegrationFieldRule = { targetField: 'FUnitID', sourceType: 'preserve_template', shape: 'object-passthrough', completeness: 'require-fnumber-fname' }
+    const mapped = setFieldRuleFromReferenceTable(ref, 'unit')
+    expect(mapped).toMatchObject({ targetField: 'FUnitID', sourceType: 'from_reference_table', shape: 'object-passthrough', completeness: 'require-fnumber-fname', domain: 'unit' })
+    // half-state: empty domain → from_reference_table with domain ABSENT (backend fail-closes on it)
+    const halfState = setFieldRuleFromReferenceTable(ref, '')
+    expect(halfState).toMatchObject({ sourceType: 'from_reference_table', shape: 'object-passthrough' })
+    expect(halfState.domain).toBeUndefined()
+    // back to preserve drops domain, keeps the reference shape
+    const back = setFieldRuleReferencePreserve(mapped)
+    expect(back).toMatchObject({ sourceType: 'preserve_template', shape: 'object-passthrough', completeness: 'require-fnumber-fname' })
+    expect(back.domain).toBeUndefined()
+  })
+
+  it('DF_T3_REFERENCE_DOMAINS pins the exact 12-domain set (mirrors the backend templates)', () => {
+    expect([...DF_T3_REFERENCE_DOMAINS].sort()).toEqual([
+      'account', 'category', 'inspection-level', 'inspection-mode', 'manager', 'order-strategy',
+      'planning-strategy', 'track', 'unit', 'unit-group', 'use-state', 'warehouse',
+    ])
   })
 })
 
@@ -97,17 +123,50 @@ describe('MetaIntegrationFieldRuleAuthoring (DF-T2b)', () => {
     expect(updates.at(-1)![0]).toMatchObject({ targetField: 'FNumber', sourceType: 'from_staging', shape: 'scalar', sourceField: 'materialCode' })
   })
 
-  it('a REFERENCE field is locked to preserve — no editable control (v1: cannot downgrade to scalar replace)', async () => {
-    mount(draft())
+  it('DF-T3b-2d: a REFERENCE field is editable (preserve↔mapping), never scalar; switch→mapping emits the half-state', async () => {
+    const updates = mount(draft()) // FUnitID = preserve_template object-passthrough
     await nextTick()
-    // the reference row shows the locked label + hint...
-    expect(container!.querySelector('[data-testid="field-rule-locked-FUnitID"]')).not.toBeNull()
-    // ...and its "mode" element is a locked span, NOT an editable <select> — so there is no UI
-    // path to set replace on a reference field.
-    const refMode = container!.querySelector('[data-testid="field-rule-mode-FUnitID"]') as HTMLElement
-    expect(refMode).not.toBeNull()
-    expect(refMode.tagName).not.toBe('SELECT')
+    // reference row now has an editable mode <select>, NOT a locked label
+    const mode = container!.querySelector('[data-testid="field-rule-mode-FUnitID"]') as HTMLSelectElement
+    expect(mode.tagName).toBe('SELECT')
+    expect(container!.querySelector('[data-testid="field-rule-locked-FUnitID"]')).toBeNull()
+    // no scalar source input on a reference — cannot downgrade to scalar replace
     expect(container!.querySelector('[data-testid="field-rule-source-FUnitID"]')).toBeNull()
+    // switch to mapping → emits from_reference_table, SHAPE + completeness kept, NO domain yet (half-state)
+    mode.value = 'mapping'
+    mode.dispatchEvent(new Event('change'))
+    await nextTick()
+    const emitted = updates.at(-1)![1]
+    expect(emitted).toMatchObject({ targetField: 'FUnitID', sourceType: 'from_reference_table', shape: 'object-passthrough', completeness: 'require-fnumber-fname' })
+    expect(emitted.domain).toBeUndefined()
+  })
+
+  it('DF-T3b-2d: a from_reference_table reference shows the domain picker + "需选择 domain"; picking emits the domain', async () => {
+    const updates = mount([
+      { targetField: 'FUnitID', sourceType: 'from_reference_table', shape: 'object-passthrough', completeness: 'require-fnumber-fname' },
+    ])
+    await nextTick()
+    const domainSel = container!.querySelector('[data-testid="field-rule-domain-FUnitID"]') as HTMLSelectElement
+    expect(domainSel.tagName).toBe('SELECT')
+    expect(container!.querySelector('[data-testid="field-rule-domain-required-FUnitID"]')).not.toBeNull()
+    // offers the 12 domains + the placeholder option
+    expect(domainSel.querySelectorAll('option').length).toBe(DF_T3_REFERENCE_DOMAINS.length + 1)
+    domainSel.value = 'unit'
+    domainSel.dispatchEvent(new Event('change'))
+    await nextTick()
+    expect(updates.at(-1)![0]).toMatchObject({ targetField: 'FUnitID', sourceType: 'from_reference_table', shape: 'object-passthrough', completeness: 'require-fnumber-fname', domain: 'unit' })
+  })
+
+  it('DF-T3b-2d: a GATED reference stays locked (gated wins over reference-editability)', async () => {
+    const updates = mount([
+      { targetField: 'FBaseUnitID', sourceType: 'preserve_template', shape: 'object-passthrough', completeness: 'require-fnumber-fname' },
+    ], ['FBaseUnitID'])
+    await nextTick()
+    expect(container!.querySelector('[data-testid="field-rule-locked-FBaseUnitID"]')).not.toBeNull()
+    const mode = container!.querySelector('[data-testid="field-rule-mode-FBaseUnitID"]') as HTMLElement
+    expect(mode.tagName).not.toBe('SELECT') // locked label, not the reference mode select
+    expect(container!.querySelector('[data-testid="field-rule-domain-FBaseUnitID"]')).toBeNull() // no domain picker
+    expect(updates).toHaveLength(0)
   })
 
   it('a GATED field present in modelValue renders locked (no select, no source input, no emit)', async () => {

--- a/docs/development/data-factory-df-t3b-2d-from-reference-table-authoring-development-20260529.md
+++ b/docs/development/data-factory-df-t3b-2d-from-reference-table-authoring-development-20260529.md
@@ -1,0 +1,66 @@
+# DF-T3b-2d — from_reference_table authoring opt-in (reference → resolve-via-mapping) — development verification (2026-05-29)
+
+> The **authoring half** of operator-facing from_reference_table (owner sequence A: authoring-first,
+> then picker). Lets a reference field opt into "resolve via mapping sheet" (`from_reference_table` +
+> `domain`) in `MetaIntegrationFieldRuleAuthoring`, lifting the DF-T2b "references locked to preserve"
+> **only for the resolve-via-mapping case** (NOT a scalar downgrade — the v1 no-downgrade rule holds).
+> **Frontend-only. No backend change. No mapping-sheet read.**
+
+## Reachability — authorable, NOT yet resolvable end-to-end (honest framing)
+
+This makes from_reference_table **authorable**. It does **not** make it **resolvable** for the operator.
+Resolution still needs, beyond this slice: (1) the **binding picker** (`referenceMappingSources` — which
+staging sheet each domain reads, the next slice); (2) the **sourceCode-column binding** — `rule.sourceField`,
+i.e. which staging column holds the material's source code the resolver looks up (2d authors the domain
+but not this); and (3) the #2073 route. So after 2d an operator can mark a field `from_reference_table` +
+pick a `domain`, but the preview won't resolve it until the picker **and** the sourceCode column are
+bound. 2d is the authoring half — the picker is the *next* half, not the last.
+
+The intermediate **half-state** (`from_reference_table` with no `domain` yet) is **safe**: the backend
+resolver fail-closes a domain-less rule (no index → unresolved), never silently picks. The UI flags it
+("需选择 domain").
+
+## Locked scope (owner-set)
+
+- A reference field can switch **preserve_template ↔ from_reference_table**; switching to the latter
+  requires picking a **domain**.
+- `domain` only from the **T3a 12 templates** (`DF_T3_REFERENCE_DOMAINS`, mirrors the backend).
+- `shape` stays **object-passthrough** (never scalar); `completeness` stays `require-fnumber-fname` /
+  `require-fid-fname`.
+- **Gated fields stay locked** and **win** over reference-editability (e.g. `FBaseUnitID` stays closed).
+- ❌ no mapping-sheet read / no backend capability; ❌ no real Save / pipeline runner / K3 write.
+
+## What shipped (frontend-only)
+
+- `apps/web/src/services/integration/workbench.ts`:
+  - `IntegrationFieldRule` += `domain?`; `DF_T3_REFERENCE_DOMAINS` (the 12, mirrors `K3_REFERENCE_MAPPING_TEMPLATES`;
+    backend validates unknown → 400, so a stale list is non-correctness).
+  - `fieldRuleEditability`: a reference is now **reference-editable** (`{editable:true, reason:'reference',
+    isReference:true}`), no longer locked — **gated check stays first** (gated wins).
+  - reference setters `setFieldRuleFromReferenceTable(rule, domain)` (keeps shape + completeness; empty
+    domain → half-state) + `setFieldRuleReferencePreserve(rule)` (back to preserve, domain dropped). The
+    scalar setters now also drop `domain`.
+- `apps/web/src/components/integration/MetaIntegrationFieldRuleAuthoring.vue`: three render branches —
+  gated (locked label) / **reference** (mode select 保留↔从映射表解析 + a required `domain` select with
+  "需选择 domain" hint) / scalar (existing replace/preserve). `onModeChange`/`onSourceFieldChange` now
+  guard `isReference` (a reference can never reach the scalar setters).
+- Tests: `MetaIntegrationFieldRuleAuthoring.spec.ts` extended; `IntegrationWorkbenchView.spec.ts` DF-T2c
+  assertion updated (reference is now editable, not locked).
+
+## Tests + negative control
+
+`MetaIntegrationFieldRuleAuthoring.spec.ts` + `IntegrationWorkbenchView.spec.ts` (26 passed): reference
+is editable (mode select, no locked label, no scalar source input); switch→mapping emits the
+`from_reference_table` **half-state** (shape + completeness kept, domain absent); the domain picker shows
+the 12 + placeholder and picking emits the `domain`; a **gated reference stays locked**; `DF_T3_REFERENCE_DOMAINS`
+pinned to the exact 12 (sorted `deepEqual`). **Negative control**: reordering `fieldRuleEditability` so
+the reference check precedes the gated check → the gated-reference tests fail (proves gated-wins is
+load-bearing — the `FBaseUnitID`-stays-closed invariant). vue-tsc clean for changed files.
+
+## Next (gated, separate opt-in)
+
+- **Binding picker** — `referenceMappingSources` per from_reference_table domain (which staging
+  system/object holds the mapping sheet) so the authored rules resolve in the preview. **Note for that
+  slice's scope:** it must also bind the **sourceCode column** (`rule.sourceField`) — the picker's sheet
+  binding alone is not sufficient for the resolver to read the right field.
+- **DF-T3b-2c** — real-Save compose-before-`upsert` (separate; its recorded checklist).


### PR DESCRIPTION
## DF-T3b-2d — from_reference_table authoring opt-in

The **authoring half** of operator-facing from_reference_table (owner sequence A: authoring-first, picker next). Lets a reference field opt into `from_reference_table` + `domain` in `MetaIntegrationFieldRuleAuthoring`, lifting the DF-T2b "references locked to preserve" **only for resolve-via-mapping** (NOT a scalar downgrade — the v1 rule holds). **Frontend-only; no backend change; no mapping-sheet read.**

### Reachability — authorable, NOT yet resolvable end-to-end (honest)
Resolution still needs, beyond this slice: **(1)** the binding **picker** (`referenceMappingSources` — which staging sheet each domain reads, next slice); **(2)** the **sourceCode-column binding** (`rule.sourceField` — which staging column holds the source code; 2d authors the domain, not this); **(3)** the #2073 route. The half-state (`from_reference_table`, no domain yet) is **safe** — the backend fail-closes a domain-less rule (no index → unresolved); the UI flags "需选择 domain". 2d is the authoring half; the picker is the *next* half, not the last.

### What shipped
- `workbench.ts`: `IntegrationFieldRule` += `domain?`; `DF_T3_REFERENCE_DOMAINS` (the 12, mirrors `K3_REFERENCE_MAPPING_TEMPLATES`; backend validates unknown→400); `fieldRuleEditability` — reference is now **reference-editable** (gated check stays first, **gated wins**); reference setters keep shape+completeness, never scalar.
- `MetaIntegrationFieldRuleAuthoring.vue`: three render branches (gated locked / reference mode-select + required domain picker / scalar); `onModeChange`/`onSourceFieldChange` guard `isReference`.

### Tests (26 passed) + negative control
reference editable (no locked label, no scalar source); switch→mapping emits the half-state (shape+completeness kept, domain absent); domain picker shows 12 + placeholder, picking emits `domain`; **gated reference stays locked**; `DF_T3_REFERENCE_DOMAINS` pinned to the exact 12. **Negative control**: reorder editability (reference before gated) → gated-reference tests fail (gated-wins / `FBaseUnitID`-stays-closed is load-bearing). vue-tsc clean for changed files.

Verification MD: `docs/development/data-factory-df-t3b-2d-from-reference-table-authoring-development-20260529.md`. Left for owner review — no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)