### PR TITLE
feat(attendance): create onboarding group and shift links

### DIFF
--- a/apps/web/src/views/UserManagementView.vue
+++ b/apps/web/src/views/UserManagementView.vue
@@ -63,6 +63,35 @@
         <input v-model.trim="createForm.department" class="user-admin__search" type="text" placeholder="部门（可选）" />
         <input v-model.trim="createForm.position" class="user-admin__search" type="text" placeholder="岗位（可选）" />
         <input v-model="createForm.hireDate" class="user-admin__search" type="date" aria-label="入职日期（可选）" />
+        <select
+          v-model="createForm.attendanceGroupId"
+          class="user-admin__select"
+          :disabled="attendanceSetupLoading || attendanceGroups.length === 0"
+          aria-label="考勤组（可选）"
+        >
+          <option value="">考勤组（可选）</option>
+          <option v-for="group in attendanceGroups" :key="group.id" :value="group.id">
+            {{ group.name }}{{ group.code ? ` · ${group.code}` : '' }}
+          </option>
+        </select>
+        <select
+          v-model="createForm.defaultShiftId"
+          class="user-admin__select"
+          :disabled="attendanceSetupLoading || attendanceShifts.length === 0"
+          aria-label="默认班次（可选）"
+        >
+          <option value="">默认班次（可选）</option>
+          <option v-for="shift in attendanceShifts" :key="shift.id" :value="shift.id">
+            {{ shift.name }}{{ formatShiftOptionTime(shift) }}
+          </option>
+        </select>
+        <input
+          v-model="createForm.defaultShiftStartDate"
+          class="user-admin__search"
+          type="date"
+          aria-label="默认班次生效日期（可选）"
+          :disabled="!createForm.defaultShiftId"
+        />
         <input v-model.trim="createForm.password" class="user-admin__search" type="text" placeholder="可选：初始密码" />
         <select v-model="presetModeFilter" class="user-admin__select">
           <option value="">预设模式（全部）</option>
@@ -88,6 +117,9 @@
           <span>创建后立即启用</span>
         </label>
       </div>
+      <p v-if="attendanceSetupLoadError" class="user-admin__hint">
+        {{ attendanceSetupLoadError }}
+      </p>
       <div class="user-admin__role-actions">
         <button class="user-admin__button" type="button" :disabled="busy" @click="void createUser()">
           创建用户
@@ -924,11 +956,27 @@ type CreateUserForm = {
   department: string
   position: string
   hireDate: string
+  attendanceGroupId: string
+  defaultShiftId: string
+  defaultShiftStartDate: string
   password: string
   presetId: string
   role: string
   roleId: string
   isActive: boolean
+}
+
+type AttendanceGroupOption = {
+  id: string
+  name: string
+  code: string
+}
+
+type AttendanceShiftOption = {
+  id: string
+  name: string
+  workStartTime: string
+  workEndTime: string
 }
 
 type AccessPreset = {
@@ -1018,6 +1066,7 @@ const loadingInvites = ref(false)
 const loadingSessions = ref(false)
 const loadingDingTalk = ref(false)
 const loadingAdmission = ref(false)
+const attendanceSetupLoading = ref(false)
 const bulkBusy = ref(false)
 const busy = ref(false)
 const status = ref('')
@@ -1028,6 +1077,9 @@ const selectedUserIds = ref<string[]>([])
 const userListFilter = ref<UserListFilter>(readInitialUserNavigation().filter)
 const roleCatalog = ref<RoleCatalogItem[]>([])
 const accessPresets = ref<AccessPreset[]>([])
+const attendanceGroups = ref<AttendanceGroupOption[]>([])
+const attendanceShifts = ref<AttendanceShiftOption[]>([])
+const attendanceSetupLoadError = ref('')
 const presetModeFilter = ref<'' | 'platform' | 'attendance' | 'plm-workbench'>('')
 const selectedNamespace = ref('')
 const selectedUserId = ref('')
@@ -1059,6 +1111,9 @@ const createForm = ref<CreateUserForm>({
   department: '',
   position: '',
   hireDate: '',
+  attendanceGroupId: '',
+  defaultShiftId: '',
+  defaultShiftStartDate: '',
   password: '',
   presetId: '',
   role: 'user',
@@ -1847,6 +1902,78 @@ async function readJson(response: Response): Promise<Record<string, unknown>> {
   }
 }
 
+function readOptionalString(value: unknown): string {
+  return typeof value === 'string' ? value : ''
+}
+
+function firstOptionalString(...values: unknown[]): string {
+  for (const value of values) {
+    const text = readOptionalString(value)
+    if (text) return text
+  }
+  return ''
+}
+
+function normalizeAttendanceGroupOptions(payload: Record<string, unknown>): AttendanceGroupOption[] {
+  const data = payload.data as { items?: Array<Record<string, unknown>> } | undefined
+  const items = Array.isArray(data?.items) ? data.items : []
+  return items
+    .map((item) => ({
+      id: readOptionalString(item.id),
+      name: firstOptionalString(item.name, item.code, item.id),
+      code: readOptionalString(item.code),
+    }))
+    .filter((item) => item.id.length > 0 && item.name.length > 0)
+}
+
+function normalizeAttendanceShiftOptions(payload: Record<string, unknown>): AttendanceShiftOption[] {
+  const data = payload.data as { items?: Array<Record<string, unknown>> } | undefined
+  const items = Array.isArray(data?.items) ? data.items : []
+  return items
+    .map((item) => ({
+      id: readOptionalString(item.id),
+      name: firstOptionalString(item.name, item.id),
+      workStartTime: firstOptionalString(item.workStartTime, item.work_start_time),
+      workEndTime: firstOptionalString(item.workEndTime, item.work_end_time),
+    }))
+    .filter((item) => item.id.length > 0 && item.name.length > 0)
+}
+
+function formatShiftOptionTime(shift: AttendanceShiftOption): string {
+  if (!shift.workStartTime || !shift.workEndTime) return ''
+  return ` · ${shift.workStartTime}-${shift.workEndTime}`
+}
+
+async function loadAttendanceOnboardingOptions(): Promise<void> {
+  attendanceSetupLoading.value = true
+  attendanceSetupLoadError.value = ''
+  try {
+    const [groupsResponse, shiftsResponse] = await Promise.all([
+      apiFetch('/api/attendance/groups?page=1&pageSize=100'),
+      apiFetch('/api/attendance/shifts?page=1&pageSize=100'),
+    ])
+    const [groupsPayload, shiftsPayload] = await Promise.all([
+      readJson(groupsResponse),
+      readJson(shiftsResponse),
+    ])
+    if (!groupsResponse.ok || groupsPayload.ok !== true) {
+      throw new Error(String((groupsPayload.error as Record<string, unknown> | undefined)?.message || '加载考勤组失败'))
+    }
+    if (!shiftsResponse.ok || shiftsPayload.ok !== true) {
+      throw new Error(String((shiftsPayload.error as Record<string, unknown> | undefined)?.message || '加载班次失败'))
+    }
+
+    attendanceGroups.value = normalizeAttendanceGroupOptions(groupsPayload)
+    attendanceShifts.value = normalizeAttendanceShiftOptions(shiftsPayload)
+  } catch {
+    attendanceGroups.value = []
+    attendanceShifts.value = []
+    attendanceSetupLoadError.value = '考勤配置选项暂不可用，可创建后从下一步进入考勤管理配置。'
+  } finally {
+    attendanceSetupLoading.value = false
+  }
+}
+
 async function loadUsers(): Promise<void> {
   loading.value = true
   try {
@@ -2323,6 +2450,9 @@ async function createUser(): Promise<void> {
         department: createForm.value.department || undefined,
         position: createForm.value.position || undefined,
         hireDate: createForm.value.hireDate || undefined,
+        attendanceGroupId: createForm.value.attendanceGroupId || undefined,
+        defaultShiftId: createForm.value.defaultShiftId || undefined,
+        defaultShiftStartDate: createForm.value.defaultShiftStartDate || undefined,
         password: createForm.value.password || undefined,
         presetId: createForm.value.presetId || undefined,
         role: createForm.value.role || undefined,
@@ -2353,6 +2483,9 @@ async function createUser(): Promise<void> {
       department: '',
       position: '',
       hireDate: '',
+      attendanceGroupId: '',
+      defaultShiftId: '',
+      defaultShiftStartDate: '',
       password: '',
       presetId: '',
       role: 'user',
@@ -2432,6 +2565,15 @@ watch(presetModeFilter, async () => {
   await loadAccessPresets()
   if (createForm.value.presetId && !accessPresets.value.some((preset) => preset.id === createForm.value.presetId)) {
     createForm.value.presetId = ''
+  }
+})
+
+watch(() => createForm.value.defaultShiftId, (shiftId) => {
+  if (shiftId && !createForm.value.defaultShiftStartDate && createForm.value.hireDate) {
+    createForm.value.defaultShiftStartDate = createForm.value.hireDate
+  }
+  if (!shiftId) {
+    createForm.value.defaultShiftStartDate = ''
   }
 })
 
@@ -2660,7 +2802,7 @@ const stopUserLocationSync = subscribeToLocationChanges(() => {
 })
 
 onMounted(async () => {
-  await Promise.all([loadRoles(), loadUsers(), loadAccessPresets(), loadInviteRecords()])
+  await Promise.all([loadRoles(), loadUsers(), loadAccessPresets(), loadInviteRecords(), loadAttendanceOnboardingOptions()])
 })
 
 onUnmounted(() => {

--- a/apps/web/tests/userManagementView.spec.ts
+++ b/apps/web/tests/userManagementView.spec.ts
@@ -423,6 +423,37 @@ function createApiImplementation(
       })
     }
 
+    if (pathname === '/api/attendance/groups') {
+      return createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: '11111111-1111-4111-8111-111111111111',
+              name: '总装一组',
+              code: 'ASM-1',
+            },
+          ],
+        },
+      })
+    }
+
+    if (pathname === '/api/attendance/shifts') {
+      return createJsonResponse({
+        ok: true,
+        data: {
+          items: [
+            {
+              id: '22222222-2222-4222-8222-222222222222',
+              name: '早班',
+              workStartTime: '09:00',
+              workEndTime: '18:00',
+            },
+          ],
+        },
+      })
+    }
+
     if (pathname === '/api/admin/users' && (init?.method || 'GET').toUpperCase() === 'POST') {
       const rawBody = typeof init?.body === 'string' ? init.body : ''
       const parsed = rawBody ? JSON.parse(rawBody) as {
@@ -1581,7 +1612,21 @@ describe('UserManagementView', () => {
     const departmentInput = inputs.find((candidate) => candidate.getAttribute('placeholder') === '部门（可选）') as HTMLInputElement | undefined
     const positionInput = inputs.find((candidate) => candidate.getAttribute('placeholder') === '岗位（可选）') as HTMLInputElement | undefined
     const hireDateInput = inputs.find((candidate) => candidate.getAttribute('aria-label') === '入职日期（可选）') as HTMLInputElement | undefined
-    if (!nameInput || !usernameInput || !mobileInput || !employeeNoInput || !departmentInput || !positionInput || !hireDateInput) {
+    const groupSelect = container!.querySelector<HTMLSelectElement>('select[aria-label="考勤组（可选）"]')
+    const shiftSelect = container!.querySelector<HTMLSelectElement>('select[aria-label="默认班次（可选）"]')
+    const shiftStartDateInput = inputs.find((candidate) => candidate.getAttribute('aria-label') === '默认班次生效日期（可选）') as HTMLInputElement | undefined
+    if (
+      !nameInput
+      || !usernameInput
+      || !mobileInput
+      || !employeeNoInput
+      || !departmentInput
+      || !positionInput
+      || !hireDateInput
+      || !groupSelect
+      || !shiftSelect
+      || !shiftStartDateInput
+    ) {
       throw new Error('Create-user form inputs not found')
     }
 
@@ -1599,6 +1644,10 @@ describe('UserManagementView', () => {
     positionInput.dispatchEvent(new Event('input', { bubbles: true }))
     hireDateInput.value = '2026-05-29'
     hireDateInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await setSelectValue(groupSelect, '11111111-1111-4111-8111-111111111111')
+    await setSelectValue(shiftSelect, '22222222-2222-4222-8222-222222222222')
+    shiftStartDateInput.value = '2026-06-01'
+    shiftStartDateInput.dispatchEvent(new Event('input', { bubbles: true }))
     await flushUi(2)
 
     findButtonByText(container!, '创建用户').click()
@@ -1616,6 +1665,9 @@ describe('UserManagementView', () => {
       department: 'Assembly',
       position: 'Operator',
       hireDate: '2026-05-29',
+      attendanceGroupId: '11111111-1111-4111-8111-111111111111',
+      defaultShiftId: '22222222-2222-4222-8222-222222222222',
+      defaultShiftStartDate: '2026-06-01',
       role: 'user',
       isActive: true,
     })

--- a/packages/core-backend/src/routes/admin-users.ts
+++ b/packages/core-backend/src/routes/admin-users.ts
@@ -267,6 +267,10 @@ type CreateUserRequestBody = {
   department?: string
   position?: string
   hireDate?: string
+  orgId?: string
+  attendanceGroupId?: string
+  defaultShiftId?: string
+  defaultShiftStartDate?: string
   name?: string
   password?: string
   role?: string
@@ -275,11 +279,28 @@ type CreateUserRequestBody = {
   isActive?: boolean
 }
 
+type AttendanceOnboardingResponse = {
+  orgId: string
+  group: {
+    id: string
+    name: string | null
+    memberCreated: boolean
+  } | null
+  defaultShift: {
+    id: string
+    name: string | null
+    startDate: string
+    assignmentId: string | null
+  } | null
+}
+
 const ADMIN_AUDIT_RESOURCE_TYPES = ['user', 'user-role', 'user-auth-grant', 'user-namespace-admission', 'user-password', 'user-session', 'user-invite', 'role', 'permission', 'permission-template', 'delegated-admin-scope', 'delegated-admin-scope-template', 'platform-member-group', 'delegated-admin-group-scope'] as const
 const DINGTALK_PROVIDER = 'dingtalk'
 const DINGTALK_OPEN_ID_REQUIRED_FOR_GRANT_ERROR =
   'Directory account is missing DingTalk openId and cannot enable DingTalk login grant; resync DingTalk directory or complete DingTalk OAuth binding first'
 const PLATFORM_ADMIN_ROLE_ID = 'admin'
+const DEFAULT_ATTENDANCE_ORG_ID = 'default'
+const UUID_PATTERN = /^[0-9a-f]{8}-[0-9a-f]{4}-[1-5][0-9a-f]{3}-[89ab][0-9a-f]{3}-[0-9a-f]{12}$/i
 const ATTENDANCE_ROLE_IDS = new Set(['attendance_employee', 'attendance_approver', 'attendance_admin'])
 const ADMIN_USER_PROFILE_SELECT = `
   id,
@@ -428,6 +449,29 @@ function sanitizeHireDate(value: string): string | null | undefined {
   const parsed = new Date(`${normalized}T00:00:00.000Z`)
   if (Number.isNaN(parsed.getTime()) || parsed.toISOString().slice(0, 10) !== normalized) return undefined
   return normalized
+}
+
+function sanitizeOptionalUuid(value: unknown): string | null | undefined {
+  if (value === undefined || value === null) return null
+  if (typeof value !== 'string') return undefined
+  const normalized = value.trim()
+  if (!normalized) return null
+  return UUID_PATTERN.test(normalized) ? normalized : undefined
+}
+
+function resolveAttendanceOnboardingOrgId(req: Request): string {
+  const user = req.user as Record<string, unknown> | undefined
+  const headerOrg = req.headers['x-org-id']
+  const header = Array.isArray(headerOrg) ? headerOrg[0] : headerOrg
+  const body = req.body as Record<string, unknown> | undefined
+  const raw = body?.orgId ?? req.query?.orgId ?? user?.orgId ?? user?.workspaceId ?? header
+  if (typeof raw === 'string' && raw.trim().length > 0) return raw.trim()
+  if (typeof raw === 'number' && Number.isFinite(raw)) return String(raw)
+  return DEFAULT_ATTENDANCE_ORG_ID
+}
+
+function todayUtcDate(): string {
+  return new Date().toISOString().slice(0, 10)
 }
 
 function validateUsername(username: string | null): string | null {
@@ -3032,6 +3076,9 @@ export function adminUsersRouter(): Router {
       const cleanDepartment = typeof body.department === 'string' ? sanitizeOptionalProfileText(body.department, 100) : null
       const cleanPosition = typeof body.position === 'string' ? sanitizeOptionalProfileText(body.position, 100) : null
       const cleanHireDate = typeof body.hireDate === 'string' ? sanitizeHireDate(body.hireDate) : null
+      const cleanAttendanceGroupId = sanitizeOptionalUuid(body.attendanceGroupId)
+      const cleanDefaultShiftId = sanitizeOptionalUuid(body.defaultShiftId)
+      const cleanDefaultShiftStartDate = typeof body.defaultShiftStartDate === 'string' ? sanitizeHireDate(body.defaultShiftStartDate) : null
       const cleanName = typeof body.name === 'string' ? sanitizeName(body.name) : ''
       const preset = getAccessPreset(typeof body.presetId === 'string' ? body.presetId.trim() : '')
       const cleanRole = typeof body.role === 'string' && body.role.trim()
@@ -3065,6 +3112,15 @@ export function adminUsersRouter(): Router {
       }
       if (cleanHireDate === undefined) {
         return jsonError(res, 400, 'INVALID_HIRE_DATE', 'hireDate must be YYYY-MM-DD or blank')
+      }
+      if (cleanAttendanceGroupId === undefined) {
+        return jsonError(res, 400, 'INVALID_ATTENDANCE_GROUP_ID', 'attendanceGroupId must be a UUID or blank')
+      }
+      if (cleanDefaultShiftId === undefined) {
+        return jsonError(res, 400, 'INVALID_DEFAULT_SHIFT_ID', 'defaultShiftId must be a UUID or blank')
+      }
+      if (cleanDefaultShiftStartDate === undefined) {
+        return jsonError(res, 400, 'INVALID_DEFAULT_SHIFT_START_DATE', 'defaultShiftStartDate must be YYYY-MM-DD or blank')
       }
 
       const password = requestedPassword || generateTemporaryPassword()
@@ -3105,6 +3161,39 @@ export function adminUsersRouter(): Router {
         if (!roleRow.rows.length) {
           return jsonError(res, 404, 'ROLE_NOT_FOUND', 'Role not found')
         }
+      }
+
+      const attendanceOrgId = cleanAttendanceGroupId || cleanDefaultShiftId
+        ? resolveAttendanceOnboardingOrgId(req)
+        : null
+      const defaultShiftStartDate = cleanDefaultShiftId
+        ? (cleanDefaultShiftStartDate || cleanHireDate || todayUtcDate())
+        : null
+      let attendanceGroupName: string | null = null
+      let defaultShiftName: string | null = null
+      if (attendanceOrgId && cleanAttendanceGroupId) {
+        const groupRow = await query<{ id: string; name: string | null }>(
+          `SELECT id, name
+           FROM attendance_groups
+           WHERE id = $1 AND org_id = $2`,
+          [cleanAttendanceGroupId, attendanceOrgId],
+        )
+        if (!groupRow.rows.length) {
+          return jsonError(res, 404, 'ATTENDANCE_GROUP_NOT_FOUND', 'Attendance group not found')
+        }
+        attendanceGroupName = groupRow.rows[0]?.name ?? null
+      }
+      if (attendanceOrgId && cleanDefaultShiftId) {
+        const shiftRow = await query<{ id: string; name: string | null }>(
+          `SELECT id, name
+           FROM attendance_shifts
+           WHERE id = $1 AND org_id = $2`,
+          [cleanDefaultShiftId, attendanceOrgId],
+        )
+        if (!shiftRow.rows.length) {
+          return jsonError(res, 404, 'DEFAULT_SHIFT_NOT_FOUND', 'Default shift not found')
+        }
+        defaultShiftName = shiftRow.rows[0]?.name ?? null
       }
 
       const userId = crypto.randomUUID()
@@ -3162,6 +3251,44 @@ export function adminUsersRouter(): Router {
         invalidateUserPerms(userId)
       }
 
+      const attendanceOnboarding: AttendanceOnboardingResponse | null = attendanceOrgId
+        ? {
+            orgId: attendanceOrgId,
+            group: null,
+            defaultShift: null,
+          }
+        : null
+      if (attendanceOnboarding && cleanAttendanceGroupId) {
+        const memberResult = await query<{ memberId: string }>(
+          `INSERT INTO attendance_group_members (org_id, group_id, user_id, created_at, updated_at)
+           VALUES ($1, $2, $3, NOW(), NOW())
+           ON CONFLICT (org_id, group_id, user_id) DO NOTHING
+           RETURNING id AS "memberId"`,
+          [attendanceOrgId, cleanAttendanceGroupId, userId],
+        )
+        attendanceOnboarding.group = {
+          id: cleanAttendanceGroupId,
+          name: attendanceGroupName,
+          memberCreated: memberResult.rows.length > 0,
+        }
+      }
+      if (attendanceOnboarding && cleanDefaultShiftId && defaultShiftStartDate) {
+        const assignmentId = crypto.randomUUID()
+        const assignmentResult = await query<{ assignmentId: string }>(
+          `INSERT INTO attendance_shift_assignments
+             (id, org_id, user_id, shift_id, start_date, is_active, created_at, updated_at)
+           VALUES ($1, $2, $3, $4, $5::date, true, NOW(), NOW())
+           RETURNING id AS "assignmentId"`,
+          [assignmentId, attendanceOrgId, userId, cleanDefaultShiftId, defaultShiftStartDate],
+        )
+        attendanceOnboarding.defaultShift = {
+          id: cleanDefaultShiftId,
+          name: defaultShiftName,
+          startDate: defaultShiftStartDate,
+          assignmentId: assignmentResult.rows[0]?.assignmentId ?? assignmentId,
+        }
+      }
+
       await auditLog({
         actorId: adminUserId,
         actorType: 'user',
@@ -3182,6 +3309,7 @@ export function adminUsersRouter(): Router {
           must_change_password: mustChangePassword,
           permissions: directPermissions,
           generatedPassword: requestedPassword.length === 0,
+          attendanceOnboarding,
         },
       })
 
@@ -3221,8 +3349,12 @@ export function adminUsersRouter(): Router {
           preset,
           inviteToken,
         }),
+        attendanceOnboarding,
       })
     } catch (error) {
+      if (isDatabaseSchemaError(error)) {
+        return jsonError(res, 503, 'USER_CREATE_SCHEMA_UNAVAILABLE', 'Required user or attendance tables are not available until migrations are applied')
+      }
       return jsonError(res, 500, 'USER_CREATE_FAILED', (error as Error)?.message || 'Failed to create user')
     }
   })

--- a/packages/core-backend/tests/unit/admin-users-routes.test.ts
+++ b/packages/core-backend/tests/unit/admin-users-routes.test.ts
@@ -2791,6 +2791,129 @@ describe('admin-users routes', () => {
     expect(auditMocks.auditLog).toHaveBeenCalled()
   })
 
+  it('creates attendance group membership and default shift assignment during user provisioning', async () => {
+    const groupId = '11111111-1111-4111-8111-111111111111'
+    const shiftId = '22222222-2222-4222-8222-222222222222'
+    rbacMocks.isAdmin
+      .mockResolvedValueOnce(true)
+      .mockResolvedValueOnce(false)
+    rbacMocks.listUserPermissions.mockResolvedValue([])
+    bcryptMocks.hash.mockResolvedValue('hashed-initial-password')
+    pgMocks.query.mockImplementation(async (sql: string, params?: unknown[]) => {
+      const statement = String(sql)
+      if (statement.includes('SELECT id FROM users WHERE lower(username)')) return { rows: [] }
+      if (statement.includes('FROM attendance_groups')) {
+        return { rows: [{ id: groupId, name: '总装一组' }] }
+      }
+      if (statement.includes('FROM attendance_shifts')) {
+        return { rows: [{ id: shiftId, name: '早班' }] }
+      }
+      if (statement.includes('INSERT INTO users (')) return { rows: [] }
+      if (statement.includes('INSERT INTO attendance_group_members')) {
+        expect(params).toEqual(['default', groupId, expect.any(String)])
+        return { rows: [{ memberId: 'member-1' }] }
+      }
+      if (statement.includes('INSERT INTO attendance_shift_assignments')) {
+        expect(params).toEqual([expect.any(String), 'default', expect.any(String), shiftId, '2026-06-01'])
+        return { rows: [{ assignmentId: 'assignment-1' }] }
+      }
+      if (statement.includes('FROM users') && statement.includes('WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'user-new',
+            email: null,
+            username: 'newuser',
+            name: 'New User',
+            employeeNo: 'E-2026-011',
+            department: 'Assembly',
+            position: 'Operator',
+            hireDate: '2026-05-29',
+            role: 'user',
+            is_active: true,
+            is_admin: false,
+            last_login_at: null,
+            created_at: '2026-03-12T00:00:00.000Z',
+            updated_at: '2026-03-12T00:00:00.000Z',
+          }],
+        }
+      }
+      if (statement.includes('FROM user_roles')) return { rows: [] }
+      return { rows: [] }
+    })
+
+    const response = await invokeRoute('post', '/api/admin/users', {
+      body: {
+        username: 'newuser',
+        name: 'New User',
+        employeeNo: 'E-2026-011',
+        department: 'Assembly',
+        position: 'Operator',
+        hireDate: '2026-05-29',
+        attendanceGroupId: groupId,
+        defaultShiftId: shiftId,
+        defaultShiftStartDate: '2026-06-01',
+        password: 'WelcomePass9A',
+        isActive: true,
+      },
+    })
+
+    expect(response.statusCode).toBe(200)
+    expect((response.body as Record<string, any>).data.attendanceOnboarding).toMatchObject({
+      orgId: 'default',
+      group: {
+        id: groupId,
+        name: '总装一组',
+        memberCreated: true,
+      },
+      defaultShift: {
+        id: shiftId,
+        name: '早班',
+        startDate: '2026-06-01',
+        assignmentId: 'assignment-1',
+      },
+    })
+    expect(auditMocks.auditLog).toHaveBeenCalledWith(expect.objectContaining({
+      action: 'create',
+      resourceType: 'user',
+      meta: expect.objectContaining({
+        attendanceOnboarding: expect.objectContaining({
+          orgId: 'default',
+          group: expect.objectContaining({ id: groupId }),
+          defaultShift: expect.objectContaining({ id: shiftId, startDate: '2026-06-01' }),
+        }),
+      }),
+    }))
+  })
+
+  it('rejects attendance onboarding when the selected group does not exist', async () => {
+    const groupId = '11111111-1111-4111-8111-111111111111'
+    rbacMocks.isAdmin.mockResolvedValue(true)
+    bcryptMocks.hash.mockResolvedValue('hashed-initial-password')
+    pgMocks.query.mockImplementation(async (sql: string) => {
+      const statement = String(sql)
+      if (statement.includes('SELECT id FROM users WHERE email = $1')) return { rows: [] }
+      if (statement.includes('FROM attendance_groups')) return { rows: [] }
+      if (statement.includes('INSERT INTO users (')) {
+        throw new Error('unexpected user insert')
+      }
+      return { rows: [] }
+    })
+
+    const response = await invokeRoute('post', '/api/admin/users', {
+      body: {
+        email: 'new@example.com',
+        name: 'New User',
+        attendanceGroupId: groupId,
+        password: 'WelcomePass9A',
+        isActive: true,
+      },
+    })
+
+    expect(response.statusCode).toBe(404)
+    expect((response.body as Record<string, any>).error.code).toBe('ATTENDANCE_GROUP_NOT_FOUND')
+    expect(pgMocks.query.mock.calls.some(([sql]) => String(sql).includes('INSERT INTO users ('))).toBe(false)
+  })
+
   it('rejects create user requests when password policy fails', async () => {
     rbacMocks.isAdmin.mockResolvedValue(true)
 


### PR DESCRIPTION
Refs #2077

## Summary
- adds optional attendance group/default shift fields to Admin user creation
- validates selected attendance refs against the request org and writes attendance_group_members plus attendance_shift_assignments during provisioning
- loads attendance group/shift options in User Management and sends the selected onboarding links with the create request

## Boundary
- does not close #2077 yet
- approver capture remains deferred because the current implementation models approvers through attendance approval flows/steps, not a per-user profile field

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/admin-users-routes.test.ts --reporter=dot
- pnpm --filter @metasheet/web exec vitest run tests/userManagementView.spec.ts --watch=false --reporter=dot
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web build
- git diff --check
- git diff --check origin/main...HEAD

## Notes
- Direct lint of apps/web/tests/userManagementView.spec.ts still reports existing RouterLink stub warnings when max-warnings=0 is used.
- Direct lint of packages/core-backend/src/routes/admin-users.ts still reports an existing no-useless-escape finding around delegated role SQL.