### PR TITLE
feat(attendance): model attendance group type

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -3067,7 +3067,7 @@
                         id="attendance-group-search"
                         v-model.trim="attendanceGroupSearch"
                         type="search"
-                        :placeholder="tr('Name, code, rule, timezone...', '名称、编码、规则、时区...')"
+                        :placeholder="tr('Name, code, type, rule, timezone...', '名称、编码、类型、规则、时区...')"
                       />
                     </label>
                     <label class="attendance__field" for="attendance-group-rule-filter">
@@ -3077,6 +3077,15 @@
                         <option value="__default__">{{ tr('Default', '默认') }}</option>
                         <option v-for="ruleSet in ruleSets" :key="ruleSet.id" :value="ruleSet.id">
                           {{ ruleSet.name }}
+                        </option>
+                      </select>
+                    </label>
+                    <label class="attendance__field" for="attendance-group-type-filter">
+                      <span>{{ tr('Type', '类型') }}</span>
+                      <select id="attendance-group-type-filter" v-model="attendanceGroupTypeFilter">
+                        <option value="">{{ tr('All types', '全部类型') }}</option>
+                        <option v-for="option in ATTENDANCE_GROUP_TYPE_OPTIONS" :key="option.value" :value="option.value">
+                          {{ tr(option.labelEn, option.labelZh) }}
                         </option>
                       </select>
                     </label>
@@ -3108,6 +3117,7 @@
                           <strong>{{ item.name }}</strong>
                           <small>{{ item.code || item.id }}</small>
                         </span>
+                        <span>{{ attendanceGroupTypeLabel(readAttendanceGroupType(item)) }}</span>
                         <span>{{ resolveRuleSetName(item.ruleSetId) }}</span>
                       </button>
                       <button
@@ -3132,6 +3142,7 @@
                     <div v-if="attendanceGroupEditingId" class="attendance__group-detail-actions">
                       <div class="attendance__admin-meta">
                         <span>{{ tr('Code', '编码') }}: {{ attendanceGroupForm.code || '-' }}</span>
+                        <span>{{ tr('Type', '类型') }}: {{ attendanceGroupTypeLabel(attendanceGroupForm.attendanceType) }}</span>
                         <span>{{ tr('Timezone', '时区') }}: {{ displayTimezone(attendanceGroupForm.timezone) }}</span>
                       </div>
                       <button
@@ -3180,6 +3191,24 @@
                             {{ item.name }}
                           </option>
                         </select>
+                      </label>
+                      <label class="attendance__field" for="attendance-group-type">
+                        <span>{{ tr('Group type', '考勤组类型') }}</span>
+                        <select
+                          id="attendance-group-type"
+                          v-model="attendanceGroupForm.attendanceType"
+                          :disabled="Boolean(attendanceGroupEditingId)"
+                          data-attendance-group-type
+                        >
+                          <option v-for="option in ATTENDANCE_GROUP_TYPE_OPTIONS" :key="option.value" :value="option.value">
+                            {{ tr(option.labelEn, option.labelZh) }}
+                          </option>
+                        </select>
+                        <small class="attendance__field-hint">
+                          {{ attendanceGroupEditingId
+                            ? tr('Locked after creation to protect schedule semantics.', '创建后锁定，避免破坏排班语义。')
+                            : tr('Choose once at creation so each group keeps stable scheduling semantics.', '创建时选择一次，让每个考勤组保持稳定的排班语义。') }}
+                        </small>
                       </label>
                       <label class="attendance__field attendance__field--full" for="attendance-group-description">
                         <span>{{ tr('Description', '描述') }}</span>
@@ -3377,7 +3406,7 @@
                   </section>
 
                   <section
-                    v-if="attendanceGroupEditingId"
+                    v-if="attendanceGroupEditingId && attendanceGroupForm.attendanceType === 'fixed_shift'"
                     class="attendance__group-panel"
                     data-attendance-group-fixed-schedule-preview
                   >
@@ -3490,6 +3519,28 @@
                         {{ attendanceGroupFixedScheduleManagedConflictHint }}
                       </small>
                       <small class="attendance__field-hint">{{ tr('If blocking conflicts are present, apply stays disabled and writes nothing.', '如果存在阻断冲突，应用保持禁用且零写入。') }}</small>
+                    </div>
+                  </section>
+                  <section
+                    v-else-if="attendanceGroupEditingId"
+                    class="attendance__group-panel"
+                    data-attendance-group-schedule-type-placeholder
+                  >
+                    <div class="attendance__admin-section-header">
+                      <div>
+                        <h6>{{ attendanceGroupTypeLabel(attendanceGroupForm.attendanceType) }}</h6>
+                        <span class="attendance__field-hint">{{ attendanceGroupTypeDetail(attendanceGroupForm.attendanceType) }}</span>
+                      </div>
+                      <button
+                        class="attendance__btn"
+                        type="button"
+                        @click="selectAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.advancedSchedulingWorkbench)"
+                      >
+                        {{ tr('Open Advanced scheduling', '打开高级排班') }}
+                      </button>
+                    </div>
+                    <div class="attendance__empty">
+                      {{ tr('This type keeps the group as a people and policy boundary here. Scheduling details stay in Advanced scheduling.', '该类型在这里作为人员与策略边界；排班细节仍在高级排班维护。') }}
                     </div>
                   </section>
                 </section>
@@ -6508,6 +6559,8 @@ interface AttendanceRuleTemplateVersion {
   templates?: unknown[] | null
 }
 
+type AttendanceGroupType = 'fixed_shift' | 'scheduled_shift' | 'free_time'
+
 interface AttendanceGroup {
   id: string
   orgId?: string
@@ -6516,8 +6569,63 @@ interface AttendanceGroup {
   timezone: string
   ruleSetId?: string | null
   description?: string | null
+  attendanceType?: AttendanceGroupType | null
+  attendance_type?: AttendanceGroupType | null
   createdAt?: string
   updatedAt?: string
+}
+
+const ATTENDANCE_GROUP_TYPE_OPTIONS: Array<{
+  value: AttendanceGroupType
+  labelEn: string
+  labelZh: string
+  detailEn: string
+  detailZh: string
+}> = [
+  {
+    value: 'fixed_shift',
+    labelEn: 'Fixed shift',
+    labelZh: '固定班制',
+    detailEn: 'Uses the group fixed schedule preview and apply panel. Weekly patterns stay in the existing shift and assignment surfaces.',
+    detailZh: '使用考勤组固定排班预览与应用面板；周模式仍在现有班次与排班界面维护。',
+  },
+  {
+    value: 'scheduled_shift',
+    labelEn: 'Scheduled shift',
+    labelZh: '排班制',
+    detailEn: 'Routed to Advanced scheduling for rotation and coverage workflows.',
+    detailZh: '轮班与覆盖工作流仍进入高级排班。',
+  },
+  {
+    value: 'free_time',
+    labelEn: 'Free time',
+    labelZh: '自由工时',
+    detailEn: 'Keeps people and policy grouping here; detailed work-time rules stay out of this slice.',
+    detailZh: '此处仅维护人员与策略分组；详细工时规则不在本切片内。',
+  },
+]
+
+function normalizeAttendanceGroupType(value: unknown): AttendanceGroupType {
+  const normalized = typeof value === 'string' ? value.trim().toLowerCase().replace(/-/g, '_') : ''
+  return ATTENDANCE_GROUP_TYPE_OPTIONS.some(option => option.value === normalized)
+    ? normalized as AttendanceGroupType
+    : 'fixed_shift'
+}
+
+function readAttendanceGroupType(group?: AttendanceGroup | null): AttendanceGroupType {
+  return normalizeAttendanceGroupType(group?.attendanceType ?? group?.attendance_type)
+}
+
+function attendanceGroupTypeLabel(value?: AttendanceGroupType | null): string {
+  const normalized = normalizeAttendanceGroupType(value)
+  const option = ATTENDANCE_GROUP_TYPE_OPTIONS.find(item => item.value === normalized) ?? ATTENDANCE_GROUP_TYPE_OPTIONS[0]
+  return tr(option.labelEn, option.labelZh)
+}
+
+function attendanceGroupTypeDetail(value?: AttendanceGroupType | null): string {
+  const normalized = normalizeAttendanceGroupType(value)
+  const option = ATTENDANCE_GROUP_TYPE_OPTIONS.find(item => item.value === normalized) ?? ATTENDANCE_GROUP_TYPE_OPTIONS[0]
+  return tr(option.detailEn, option.detailZh)
 }
 
 interface AttendanceGroupMember {
@@ -8293,6 +8401,7 @@ const attendanceGroups = ref<AttendanceGroup[]>([])
 const attendanceGroupMembers = ref<AttendanceGroupMember[]>([])
 const attendanceGroupSearch = ref('')
 const attendanceGroupRuleSetFilter = ref('')
+const attendanceGroupTypeFilter = ref<AttendanceGroupType | ''>('')
 const attendanceGroupCopyingId = ref<string | null>(null)
 const payrollTemplates = ref<AttendancePayrollTemplate[]>([])
 const payrollCycles = ref<AttendancePayrollCycle[]>([])
@@ -8400,14 +8509,16 @@ const selectedAttendanceGroup = computed(() =>
   attendanceGroups.value.find(group => group.id === attendanceGroupEditingId.value) ?? null
 )
 const attendanceGroupFilterActive = computed(() =>
-  attendanceGroupSearch.value.trim().length > 0 || attendanceGroupRuleSetFilter.value !== ''
+  attendanceGroupSearch.value.trim().length > 0 || attendanceGroupRuleSetFilter.value !== '' || attendanceGroupTypeFilter.value !== ''
 )
 const filteredAttendanceGroups = computed(() => {
   const term = attendanceGroupSearch.value.trim().toLowerCase()
   const ruleSetFilter = attendanceGroupRuleSetFilter.value
+  const typeFilter = attendanceGroupTypeFilter.value
   return attendanceGroups.value.filter((group) => {
     if (ruleSetFilter === '__default__' && group.ruleSetId) return false
     if (ruleSetFilter && ruleSetFilter !== '__default__' && group.ruleSetId !== ruleSetFilter) return false
+    if (typeFilter && readAttendanceGroupType(group) !== typeFilter) return false
     if (!term) return true
     return [
       group.name,
@@ -8415,6 +8526,7 @@ const filteredAttendanceGroups = computed(() => {
       group.timezone ?? '',
       group.description ?? '',
       resolveRuleSetName(group.ruleSetId),
+      attendanceGroupTypeLabel(readAttendanceGroupType(group)),
     ].some(value => value.toLowerCase().includes(term))
   })
 })
@@ -8596,6 +8708,27 @@ const attendanceGroupSummaryCards = computed<AttendanceGroupSummaryCard[]>(() =>
   const ruleSetName = groupSaved
     ? resolveRuleSetName(attendanceGroupForm.ruleSetId)
     : tr('Choose or save a group first', '先选择或保存考勤组')
+  const attendanceGroupType = normalizeAttendanceGroupType(attendanceGroupForm.attendanceType)
+  const workTimeActions: AttendanceGroupSummaryAction[] = attendanceGroupType === 'fixed_shift'
+    ? [
+        {
+          key: 'open-shifts',
+          label: tr('Open Shifts', '打开班次'),
+          sectionId: ATTENDANCE_ADMIN_SECTION_IDS.shifts,
+        },
+        {
+          key: 'open-assignments',
+          label: tr('Open Assignments', '打开排班分配'),
+          sectionId: ATTENDANCE_ADMIN_SECTION_IDS.assignments,
+        },
+      ]
+    : [
+        {
+          key: 'open-advanced-scheduling',
+          label: tr('Open Advanced scheduling', '打开高级排班'),
+          sectionId: ATTENDANCE_ADMIN_SECTION_IDS.advancedSchedulingWorkbench,
+        },
+      ]
 
   return [
     {
@@ -8616,20 +8749,13 @@ const attendanceGroupSummaryCards = computed<AttendanceGroupSummaryCard[]>(() =>
     {
       key: 'work-time',
       title: tr('Work time', '考勤时间'),
-      value: tr('Configured in Shifts and Assignments', '在班次与排班分配中配置'),
-      detail: tr('This card does not claim a group schedule type or mutate schedules.', '此卡片不声明考勤组排班类型，也不修改排班。'),
-      actions: [
-        {
-          key: 'open-shifts',
-          label: tr('Open Shifts', '打开班次'),
-          sectionId: ATTENDANCE_ADMIN_SECTION_IDS.shifts,
-        },
-        {
-          key: 'open-assignments',
-          label: tr('Open Assignments', '打开排班分配'),
-          sectionId: ATTENDANCE_ADMIN_SECTION_IDS.assignments,
-        },
-      ],
+      value: groupSaved
+        ? attendanceGroupTypeLabel(attendanceGroupType)
+        : tr('Choose or save a group first', '先选择或保存考勤组'),
+      detail: groupSaved
+        ? attendanceGroupTypeDetail(attendanceGroupType)
+        : tr('Group type is selected at creation and locked afterward.', '考勤组类型在创建时选择，保存后锁定。'),
+      actions: workTimeActions,
     },
     {
       key: 'scheduling-coverage',
@@ -10014,6 +10140,7 @@ const attendanceGroupForm = reactive({
   code: '',
   timezone: defaultTimezone,
   ruleSetId: '',
+  attendanceType: 'fixed_shift' as AttendanceGroupType,
   description: '',
 })
 
@@ -16527,6 +16654,7 @@ function resetAttendanceGroupForm() {
   attendanceGroupForm.code = ''
   attendanceGroupForm.timezone = defaultTimezone
   attendanceGroupForm.ruleSetId = ''
+  attendanceGroupForm.attendanceType = 'fixed_shift'
   attendanceGroupForm.description = ''
   attendanceGroupMemberGroupId.value = ''
   attendanceGroupMembers.value = []
@@ -16550,6 +16678,7 @@ function editAttendanceGroup(item: AttendanceGroup) {
   attendanceGroupForm.code = item.code ?? ''
   attendanceGroupForm.timezone = item.timezone ?? defaultTimezone
   attendanceGroupForm.ruleSetId = item.ruleSetId ?? ''
+  attendanceGroupForm.attendanceType = readAttendanceGroupType(item)
   attendanceGroupForm.description = item.description ?? ''
   attendanceGroupMemberGroupId.value = item.id
   if (groupChanged) {
@@ -16590,6 +16719,7 @@ function resolveRuleSetName(ruleSetId?: string | null): string {
 function clearAttendanceGroupFilters() {
   attendanceGroupSearch.value = ''
   attendanceGroupRuleSetFilter.value = ''
+  attendanceGroupTypeFilter.value = ''
 }
 
 function nextAttendanceGroupCopyName(sourceName: string): string {
@@ -16610,10 +16740,11 @@ function exportAttendanceGroupsCsv() {
     setStatus(tr('No attendance groups to export.', '没有可导出的考勤组。'), 'error')
     return
   }
-  const headers = ['Name', 'Code', 'Rule policy', 'Timezone', 'Description', 'Created at', 'Updated at']
+  const headers = ['Name', 'Code', 'Type', 'Rule policy', 'Timezone', 'Description', 'Created at', 'Updated at']
   const csvRows = rows.map(group => [
     group.name,
     group.code ?? '',
+    attendanceGroupTypeLabel(readAttendanceGroupType(group)),
     resolveRuleSetName(group.ruleSetId),
     group.timezone ?? '',
     group.description ?? '',
@@ -16632,6 +16763,7 @@ async function copyAttendanceGroup(item: AttendanceGroup) {
       code: null,
       timezone: item.timezone || defaultTimezone,
       ruleSetId: item.ruleSetId || null,
+      attendanceType: readAttendanceGroupType(item),
       description: item.description || null,
       orgId: normalizedOrgId(),
     }
@@ -16701,6 +16833,7 @@ async function saveAttendanceGroup() {
       code: attendanceGroupForm.code.trim() || null,
       timezone: attendanceGroupForm.timezone.trim() || defaultTimezone,
       ruleSetId: attendanceGroupForm.ruleSetId || null,
+      attendanceType: normalizeAttendanceGroupType(attendanceGroupForm.attendanceType),
       description: attendanceGroupForm.description.trim() || null,
       orgId: normalizedOrgId(),
     }

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -251,6 +251,7 @@ describe('Attendance admin regressions', () => {
                 code: 'ops-team',
                 timezone: 'Asia/Shanghai',
                 ruleSetId: 'rule-set-1',
+                attendanceType: 'fixed_shift',
                 description: 'Operations attendance group',
                 createdAt: '2026-03-28T08:00:00.000Z',
                 updatedAt: '2026-03-28T08:30:00.000Z',
@@ -866,7 +867,8 @@ describe('Attendance admin regressions', () => {
     const summaryGrid = groupsSection!.querySelector<HTMLElement>('[data-attendance-group-summaries]')
     expect(summaryGrid).toBeTruthy()
     expect(summaryGrid!.querySelector('[data-attendance-group-summary-card="rule-policy"]')?.textContent).toContain('Ops Rules')
-    expect(summaryGrid!.querySelector('[data-attendance-group-summary-card="work-time"]')?.textContent).toContain('Configured in Shifts and Assignments')
+    expect(summaryGrid!.querySelector('[data-attendance-group-summary-card="work-time"]')?.textContent).toContain('Fixed shift')
+    expect(groupsSection!.querySelector<HTMLSelectElement>('[data-attendance-group-type]')?.disabled).toBe(true)
     expect(summaryGrid!.querySelector('[data-attendance-group-summary-card="scheduling-coverage"]')?.textContent).toContain('Advanced scheduling owns rotation and coverage checks')
     expect(summaryGrid!.querySelector('[data-attendance-group-summary-card="comprehensive-hours"]')?.textContent).toContain('Review and reporting live in their own admin surface')
     expect(summaryGrid!.querySelector('[data-attendance-group-summary-card="punch-method"]')?.textContent).toContain('applies to all attendance groups')
@@ -881,6 +883,7 @@ describe('Attendance admin regressions', () => {
     await flushUi(2)
 
     expect(groupsSection!.querySelector('[data-attendance-group-detail]')?.textContent).toContain('New attendance group')
+    expect(groupsSection!.querySelector<HTMLSelectElement>('[data-attendance-group-type]')?.disabled).toBe(false)
     expect(groupsSection!.querySelector('[data-attendance-group-people]')?.textContent).toContain('Save the group before adding people.')
     expect(groupsSection!.querySelector('[data-attendance-group-summary-card="rule-policy"]')?.textContent).toContain('Choose or save a group first')
   })
@@ -900,6 +903,7 @@ describe('Attendance admin regressions', () => {
         code: 'ops-team',
         timezone: 'Asia/Shanghai',
         ruleSetId: 'rule-set-1',
+        attendanceType: 'fixed_shift',
         description: 'Operations attendance group',
         createdAt: '2026-03-28T08:00:00.000Z',
         updatedAt: '2026-03-28T08:30:00.000Z',
@@ -910,6 +914,7 @@ describe('Attendance admin regressions', () => {
         code: 'qa-team',
         timezone: 'Asia/Shanghai',
         ruleSetId: null,
+        attendanceType: 'scheduled_shift',
         description: 'Quality attendance group',
         createdAt: '2026-03-29T08:00:00.000Z',
         updatedAt: '2026-03-29T08:30:00.000Z',
@@ -956,6 +961,7 @@ describe('Attendance admin regressions', () => {
           code: 'ops-team-copy',
           timezone: String(body.timezone || 'Asia/Shanghai'),
           ruleSetId: typeof body.ruleSetId === 'string' ? body.ruleSetId : null,
+          attendanceType: String(body.attendanceType || 'fixed_shift'),
           description: typeof body.description === 'string' ? body.description : null,
           createdAt: '2026-03-30T08:00:00.000Z',
           updatedAt: '2026-03-30T08:00:00.000Z',
@@ -998,9 +1004,30 @@ describe('Attendance admin regressions', () => {
       expect(list.textContent).toContain('Ops Team')
       expect(list.textContent).toContain('QA Team')
 
+      const typeFilter = groupsSection.querySelector<HTMLSelectElement>('#attendance-group-type-filter')!
+      typeFilter.value = 'fixed_shift'
+      typeFilter.dispatchEvent(new Event('change', { bubbles: true }))
+      await flushUi(2)
+      expect(list.textContent).toContain('Ops Team')
+      expect(list.textContent).not.toContain('QA Team')
+      expect(list.textContent).toContain('1 of 2 groups')
+
+      groupsSection.querySelector<HTMLButtonElement>('.attendance__group-list-tool-actions button:nth-child(2)')!.click()
+      await flushUi(2)
+      expect(list.textContent).toContain('Ops Team')
+      expect(list.textContent).toContain('QA Team')
+
       groupsSection.querySelector<HTMLButtonElement>('[data-attendance-group-list-tools] .attendance__btn')!.click()
       expect(createObjectURL).toHaveBeenCalledTimes(1)
       expect(revokeObjectURL).toHaveBeenCalledWith('blob:attendance-groups')
+
+      const qaRow = Array.from(groupsSection.querySelectorAll<HTMLElement>('[data-attendance-group-row]'))
+        .find(row => row.textContent?.includes('QA Team'))
+      expect(qaRow).toBeTruthy()
+      qaRow!.querySelector<HTMLButtonElement>('.attendance__group-list-main')!.click()
+      await flushUi(2)
+      expect(groupsSection.querySelector('[data-attendance-group-schedule-type-placeholder]')?.textContent).toContain('Scheduled shift')
+      expect(groupsSection.querySelector('[data-attendance-group-fixed-schedule-preview]')).toBeNull()
 
       const opsRow = Array.from(groupsSection.querySelectorAll<HTMLElement>('[data-attendance-group-row]'))
         .find(row => row.textContent?.includes('Ops Team'))
@@ -1014,6 +1041,7 @@ describe('Attendance admin regressions', () => {
           code: null,
           timezone: 'Asia/Shanghai',
           ruleSetId: 'rule-set-1',
+          attendanceType: 'fixed_shift',
           description: 'Operations attendance group',
         }),
       ])

--- a/packages/core-backend/src/db/migrations/zzzz20260529213000_add_attendance_group_type.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260529213000_add_attendance_group_type.ts
@@ -1,0 +1,38 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { addColumnIfNotExists, checkTableExists, dropColumnIfExists } from './_patterns'
+
+const TABLE_NAME = 'attendance_groups'
+const DEFAULT_ATTENDANCE_GROUP_TYPE = 'fixed_shift'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, TABLE_NAME)
+  if (!exists) return
+
+  await addColumnIfNotExists(db, TABLE_NAME, 'attendance_type', 'text', {
+    notNull: true,
+    defaultTo: DEFAULT_ATTENDANCE_GROUP_TYPE,
+  })
+
+  await sql`
+    UPDATE attendance_groups
+    SET attendance_type = ${DEFAULT_ATTENDANCE_GROUP_TYPE}
+    WHERE attendance_type IS NULL
+       OR attendance_type NOT IN ('fixed_shift', 'scheduled_shift', 'free_time')
+  `.execute(db)
+
+  await sql`ALTER TABLE attendance_groups DROP CONSTRAINT IF EXISTS attendance_groups_attendance_type_check`.execute(db)
+  await sql`
+    ALTER TABLE attendance_groups
+    ADD CONSTRAINT attendance_groups_attendance_type_check
+    CHECK (attendance_type IN ('fixed_shift', 'scheduled_shift', 'free_time'))
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, TABLE_NAME)
+  if (!exists) return
+
+  await sql`ALTER TABLE attendance_groups DROP CONSTRAINT IF EXISTS attendance_groups_attendance_type_check`.execute(db)
+  await dropColumnIfExists(db, TABLE_NAME, 'attendance_type')
+}

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -848,6 +848,7 @@ attendanceIntegrationDescribe(
       body: JSON.stringify({
         name: groupName,
         timezone: 'UTC',
+        attendanceType: 'fixed_shift',
         description: 'integration-test',
       }),
     })
@@ -855,7 +856,9 @@ attendanceIntegrationDescribe(
     const groupId = (createGroupRes.body as { data?: { id?: string } } | undefined)?.data?.id
     expect(groupId).toBeTruthy()
     const createdGroupCode = (createGroupRes.body as { data?: { code?: string } } | undefined)?.data?.code
+    const createdGroupType = (createGroupRes.body as { data?: { attendanceType?: string } } | undefined)?.data?.attendanceType
     expect(createdGroupCode).toMatch(/^[a-z0-9-]+-[a-f0-9]{8}$/)
+    expect(createdGroupType).toBe('fixed_shift')
 
     if (groupId) {
       const updateGroupRes = await requestJson(`${baseUrl}/api/attendance/groups/${groupId}`, {
@@ -872,7 +875,25 @@ attendanceIntegrationDescribe(
       })
       expect(updateGroupRes.status).toBe(200)
       const updatedGroupCode = (updateGroupRes.body as { data?: { code?: string } } | undefined)?.data?.code
+      const updatedGroupType = (updateGroupRes.body as { data?: { attendanceType?: string } } | undefined)?.data?.attendanceType
       expect(updatedGroupCode).toBe(createdGroupCode)
+      expect(updatedGroupType).toBe('fixed_shift')
+
+      const changeGroupTypeRes = await requestJson(`${baseUrl}/api/attendance/groups/${groupId}`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: `${groupName} Updated`,
+          timezone: 'UTC',
+          attendanceType: 'scheduled_shift',
+          description: 'integration-test-updated',
+        }),
+      })
+      expect(changeGroupTypeRes.status).toBe(409)
+      expect((changeGroupTypeRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('ATTENDANCE_GROUP_TYPE_LOCKED')
 
       const addGroupMemberRes = await requestJson(`${baseUrl}/api/attendance/groups/${groupId}/members`, {
         method: 'POST',

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -113,6 +113,82 @@ afterEach(async () => {
 })
 
 describe('attendance UUID route validation', () => {
+  it('persists attendance group type on create and rejects type changes on update', async () => {
+    const { db, routes } = await createHarness()
+    const groupId = '00000000-0000-4000-8000-000000000101'
+    const createdAt = '2026-05-29T20:00:00.000Z'
+    const groupRow = {
+      id: groupId,
+      org_id: 'default',
+      name: 'Ops Team',
+      code: 'ops-team',
+      timezone: 'UTC',
+      rule_set_id: null,
+      description: 'unit-test',
+      attendance_type: 'scheduled_shift',
+      created_at: createdAt,
+      updated_at: createdAt,
+    }
+
+    db.query.mockResolvedValueOnce([groupRow])
+
+    const createRes = await invokeRoute(routes, 'POST /api/attendance/groups', {
+      body: {
+        name: 'Ops Team',
+        code: 'ops-team',
+        timezone: 'UTC',
+        attendanceType: 'scheduled-shift',
+        description: 'unit-test',
+      },
+    })
+
+    expect(createRes.statusCode).toBe(200)
+    expect(createRes.body).toMatchObject({
+      ok: true,
+      data: {
+        id: groupId,
+        attendanceType: 'scheduled_shift',
+        attendance_type: 'scheduled_shift',
+      },
+    })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('attendance_type'),
+      expect.arrayContaining(['scheduled_shift']),
+    )
+
+    db.query.mockClear()
+    db.query.mockResolvedValueOnce([
+      {
+        ...groupRow,
+        attendance_type: 'fixed_shift',
+      },
+    ])
+
+    const updateRes = await invokeRoute(routes, 'PUT /api/attendance/groups/:id', {
+      params: { id: groupId },
+      body: {
+        name: 'Ops Team',
+        code: 'ops-team',
+        timezone: 'UTC',
+        attendanceType: 'free_time',
+        description: 'unit-test',
+      },
+    })
+
+    expect(updateRes.statusCode).toBe(409)
+    expect(updateRes.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'ATTENDANCE_GROUP_TYPE_LOCKED',
+      },
+    })
+    expect(db.query).toHaveBeenCalledTimes(1)
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT * FROM attendance_groups'),
+      [groupId, 'default'],
+    )
+  })
+
   it('rejects malformed route UUID params before hitting the database', async () => {
     const { db, routes } = await createHarness()
     const cases = [

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -49,6 +49,8 @@ const ATTENDANCE_SCHEDULE_GROUP_SOURCES = new Set(['manual', 'import', 'integrat
 const ATTENDANCE_SCHEDULE_GROUP_MEMBER_ROLES = new Set(['member', 'lead', 'backup'])
 const ATTENDANCE_SCHEDULER_SCOPE_SUBJECT_TYPES = new Set(['user', 'role', 'role_tag'])
 const ATTENDANCE_SCHEDULER_SCOPE_ACTIONS = new Set(['view', 'edit', 'import', 'export', 'clear', 'approve', 'dispatch'])
+const ATTENDANCE_GROUP_TYPES = new Set(['fixed_shift', 'scheduled_shift', 'free_time'])
+const DEFAULT_ATTENDANCE_GROUP_TYPE = 'fixed_shift'
 
 const SETTINGS_KEY = 'attendance.settings'
 const SETTINGS_CACHE_TTL_MS = 60000
@@ -1217,6 +1219,14 @@ function readAttendanceReportFieldCatalogCell(record, fieldIds, logicalFieldId) 
 function normalizeCatalogString(value, fallback = '') {
   const normalized = typeof value === 'string' ? value.trim() : ''
   return normalized || fallback
+}
+
+function normalizeAttendanceGroupType(value, fallback = DEFAULT_ATTENDANCE_GROUP_TYPE) {
+  const normalized = normalizeCatalogString(value, fallback).toLowerCase().replace(/-/g, '_')
+  if (!ATTENDANCE_GROUP_TYPES.has(normalized)) {
+    throw new HttpError(400, 'VALIDATION_ERROR', 'attendanceType must be fixed_shift, scheduled_shift, or free_time')
+  }
+  return normalized
 }
 
 function normalizeCatalogBoolean(value, fallback) {
@@ -7343,6 +7353,7 @@ function mapShiftRow(row) {
 }
 
 function mapAttendanceGroupRow(row) {
+  const attendanceType = normalizeAttendanceGroupType(row.attendance_type)
   return {
     id: row.id,
     orgId: row.org_id ?? DEFAULT_ORG_ID,
@@ -7351,6 +7362,8 @@ function mapAttendanceGroupRow(row) {
     timezone: row.timezone ?? DEFAULT_RULE.timezone,
     ruleSetId: row.rule_set_id ?? null,
     description: row.description ?? null,
+    attendanceType,
+    attendance_type: attendanceType,
     createdAt: row.created_at ? new Date(row.created_at).toISOString() : undefined,
     updatedAt: row.updated_at ? new Date(row.updated_at).toISOString() : undefined,
   }
@@ -26156,6 +26169,7 @@ module.exports = {
           timezone: z.string().optional().nullable(),
           ruleSetId: z.string().uuid().optional().nullable(),
           description: z.string().optional().nullable(),
+          attendanceType: z.string().optional().nullable(),
         })
 
         const parsed = schema.safeParse(req.body ?? {})
@@ -26167,9 +26181,11 @@ module.exports = {
         const orgId = getOrgId(req)
         let name
         let timezone
+        let attendanceType
         try {
           name = normalizeSafeDisplayName('name', parsed.data.name)
           timezone = resolveExplicitTimeZoneOrThrow(parsed.data.timezone, DEFAULT_RULE.timezone)
+          attendanceType = normalizeAttendanceGroupType(parsed.data.attendanceType)
         } catch (error) {
           if (error instanceof HttpError) {
             res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
@@ -26188,10 +26204,10 @@ module.exports = {
 
         try {
           const rows = await db.query(
-            `INSERT INTO attendance_groups (org_id, name, code, timezone, rule_set_id, description, created_at, updated_at)
-             VALUES ($1, $2, $3, $4, $5, $6, now(), now())
+            `INSERT INTO attendance_groups (org_id, name, code, timezone, rule_set_id, description, attendance_type, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5, $6, $7, now(), now())
              RETURNING *`,
-            [orgId, name, code, timezone, ruleSetId, description]
+            [orgId, name, code, timezone, ruleSetId, description, attendanceType]
           )
           res.json({ ok: true, data: mapAttendanceGroupRow(rows[0]) })
         } catch (error) {
@@ -26219,6 +26235,7 @@ module.exports = {
           timezone: z.string().optional().nullable(),
           ruleSetId: z.string().uuid().optional().nullable(),
           description: z.string().optional().nullable(),
+          attendanceType: z.string().optional().nullable(),
         })
 
         const parsed = schema.safeParse(req.body ?? {})
@@ -26245,15 +26262,31 @@ module.exports = {
         const existing = existingRows[0]
         let name
         let timezone
+        let requestedAttendanceType
+        let existingAttendanceType
         try {
           name = normalizeSafeDisplayName('name', parsed.data.name)
           timezone = resolveExplicitTimeZoneOrThrow(parsed.data.timezone, DEFAULT_RULE.timezone)
+          existingAttendanceType = normalizeAttendanceGroupType(existing.attendance_type)
+          requestedAttendanceType = parsed.data.attendanceType == null
+            ? existingAttendanceType
+            : normalizeAttendanceGroupType(parsed.data.attendanceType, existingAttendanceType)
         } catch (error) {
           if (error instanceof HttpError) {
             res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
             return
           }
           throw error
+        }
+        if (requestedAttendanceType !== existingAttendanceType) {
+          res.status(409).json({
+            ok: false,
+            error: {
+              code: 'ATTENDANCE_GROUP_TYPE_LOCKED',
+              message: 'Attendance group type cannot be changed after creation',
+            },
+          })
+          return
         }
         const code = resolveAttendanceCode({
           explicitCode: parsed.data.code,


### PR DESCRIPTION
Refs #1924

## Summary
- add `attendance_groups.attendance_type` with `fixed_shift`, `scheduled_shift`, and `free_time`, defaulting existing groups to `fixed_shift`
- expose `attendanceType` through the attendance group API and reject post-create type changes with `ATTENDANCE_GROUP_TYPE_LOCKED`
- show group type in Attendance admin list/detail/form, add type filtering/export/copy payload support, and gate the existing fixed schedule preview/apply panel to fixed-shift groups only

## Scope boundary
- this advances #1924 but does not close it
- no weekly workday/shift matrix yet
- no group-owned punch method config yet
- no rewrite of the existing fixed-schedule preview/apply planner
- scheduled-shift and free-time groups route scheduling details to the existing Advanced scheduling surface for now

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false --reporter=dot` (43 passed; existing jsdom navigation warning)
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts --reporter=dot` (4 passed; Vite CJS deprecation warning)
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/web build` (existing Vite chunk/dynamic-import warnings)
- `node -c plugins/plugin-attendance/index.cjs`
- `git diff --check`

## Notes
- `pnpm --filter @metasheet/core-backend test:integration:attendance` ran with the integration config but skipped 80/80 locally because the integration environment is unavailable here.
- Direct `eslint src/views/AttendanceView.vue --max-warnings=0` remains blocked by existing unused/v-html findings in that large file; no new source lint was isolated from this slice.