### PR TITLE
feat(attendance): add group list delete action

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -3120,15 +3120,26 @@
                         <span>{{ attendanceGroupTypeLabel(readAttendanceGroupType(item)) }}</span>
                         <span>{{ resolveRuleSetName(item.ruleSetId) }}</span>
                       </button>
-                      <button
-                        class="attendance__btn attendance__btn--compact"
-                        type="button"
-                        :disabled="attendanceGroupCopyingId === item.id"
-                        data-attendance-group-copy
-                        @click="copyAttendanceGroup(item)"
-                      >
-                        {{ attendanceGroupCopyingId === item.id ? tr('Copying...', '复制中...') : tr('Copy', '复制') }}
-                      </button>
+                      <div class="attendance__group-list-row-actions">
+                        <button
+                          class="attendance__btn attendance__btn--compact"
+                          type="button"
+                          :disabled="attendanceGroupCopyingId === item.id || attendanceGroupDeletingId === item.id"
+                          data-attendance-group-copy
+                          @click="copyAttendanceGroup(item)"
+                        >
+                          {{ attendanceGroupCopyingId === item.id ? tr('Copying...', '复制中...') : tr('Copy', '复制') }}
+                        </button>
+                        <button
+                          class="attendance__btn attendance__btn--compact attendance__btn--danger"
+                          type="button"
+                          :disabled="attendanceGroupDeletingId === item.id"
+                          data-attendance-group-row-delete
+                          @click="deleteAttendanceGroupFromList(item)"
+                        >
+                          {{ attendanceGroupDeletingId === item.id ? tr('Deleting...', '删除中...') : tr('Delete', '删除') }}
+                        </button>
+                      </div>
                     </div>
                   </div>
                 </aside>
@@ -3148,10 +3159,11 @@
                       <button
                         class="attendance__btn attendance__btn--danger"
                         type="button"
+                        :disabled="attendanceGroupDeletingId === attendanceGroupEditingId"
                         data-attendance-group-delete
                         @click="deleteSelectedAttendanceGroup"
                       >
-                        {{ tr('Delete group', '删除考勤组') }}
+                        {{ attendanceGroupDeletingId === attendanceGroupEditingId ? tr('Deleting...', '删除中...') : tr('Delete group', '删除考勤组') }}
                       </button>
                     </div>
                   </div>
@@ -8435,6 +8447,7 @@ const attendanceGroupSearch = ref('')
 const attendanceGroupRuleSetFilter = ref('')
 const attendanceGroupTypeFilter = ref<AttendanceGroupType | ''>('')
 const attendanceGroupCopyingId = ref<string | null>(null)
+const attendanceGroupDeletingId = ref<string | null>(null)
 const payrollTemplates = ref<AttendancePayrollTemplate[]>([])
 const payrollCycles = ref<AttendancePayrollCycle[]>([])
 const payrollSummaryFieldOptions = ref<AttendancePayrollSummaryFieldOption[]>(
@@ -16773,6 +16786,10 @@ function deleteSelectedAttendanceGroup() {
   void deleteAttendanceGroup(attendanceGroupEditingId.value)
 }
 
+function deleteAttendanceGroupFromList(item: AttendanceGroup) {
+  void deleteAttendanceGroup(item.id)
+}
+
 function resolveRuleSetName(ruleSetId?: string | null): string {
   if (!ruleSetId) return tr('Default', '默认')
   return ruleSets.value.find(item => item.id === ruleSetId)?.name ?? tr('Default', '默认')
@@ -17306,6 +17323,7 @@ async function removeAttendanceGroupMember(userId: string) {
 
 async function deleteAttendanceGroup(id: string) {
   if (!window.confirm(tr('Delete this attendance group?', '确认删除该考勤分组吗？'))) return
+  attendanceGroupDeletingId.value = id
   try {
     const response = await apiFetch(`/api/attendance/groups/${id}`, { method: 'DELETE' })
     if (response.status === 403) {
@@ -17329,6 +17347,8 @@ async function deleteAttendanceGroup(id: string) {
     setStatus(tr('Attendance group deleted.', '考勤分组已删除。'))
   } catch (error: any) {
     setStatus(readErrorMessage(error, tr('Failed to delete attendance group', '删除考勤分组失败')), 'error')
+  } finally {
+    attendanceGroupDeletingId.value = null
   }
 }
 
@@ -20129,6 +20149,13 @@ const holidaySectionBindings = {
 .attendance__group-list-main span {
   display: grid;
   gap: 4px;
+}
+
+.attendance__group-list-row-actions {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+  justify-content: flex-end;
 }
 
 .attendance__group-list-item small,

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -888,11 +888,12 @@ describe('Attendance admin regressions', () => {
     expect(groupsSection!.querySelector('[data-attendance-group-summary-card="rule-policy"]')?.textContent).toContain('Choose or save a group first')
   })
 
-  it('filters, exports, and copies attendance groups from the list tools', async () => {
+  it('filters, exports, copies, and deletes attendance groups from the list tools', async () => {
     const originalCreateObjectURL = URL.createObjectURL
     const originalRevokeObjectURL = URL.revokeObjectURL
     const createObjectURL = vi.fn(() => 'blob:attendance-groups')
     const revokeObjectURL = vi.fn()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
     Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: createObjectURL })
     Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: revokeObjectURL })
 
@@ -921,6 +922,7 @@ describe('Attendance admin regressions', () => {
       },
     ]
     const copyBodies: Array<Record<string, unknown>> = []
+    const deletedGroupIds: string[] = []
 
     vi.mocked(apiFetch).mockImplementation(async (input, init) => {
       const url = typeof input === 'string' ? input : input.toString()
@@ -968,6 +970,12 @@ describe('Attendance admin regressions', () => {
         }
         savedGroups.unshift(copied)
         return jsonResponse(200, { ok: true, data: copied })
+      }
+      if (url === '/api/attendance/groups/group-b' && method === 'DELETE') {
+        deletedGroupIds.push('group-b')
+        const index = savedGroups.findIndex(group => group.id === 'group-b')
+        if (index >= 0) savedGroups.splice(index, 1)
+        return jsonResponse(200, { ok: true, data: { id: 'group-b' } })
       }
       if (url === '/api/attendance/groups/group-a/members' || url === '/api/attendance/groups/group-copy/members') {
         return jsonResponse(200, { ok: true, data: { items: [], total: 0 } })
@@ -1047,9 +1055,29 @@ describe('Attendance admin regressions', () => {
       ])
       expect(list.textContent).toContain('Ops Team copy')
       expect(groupsSection.querySelector('[data-attendance-group-detail]')?.textContent).toContain('Ops Team copy')
+
+      const qaRowForDelete = Array.from(groupsSection.querySelectorAll<HTMLElement>('[data-attendance-group-row]'))
+        .find(row => row.textContent?.includes('QA Team'))
+      expect(qaRowForDelete).toBeTruthy()
+      qaRowForDelete!.querySelector<HTMLButtonElement>('[data-attendance-group-row-delete]')!.click()
+      await flushUi(8)
+
+      expect(confirmSpy).toHaveBeenCalledTimes(1)
+      expect(deletedGroupIds).toEqual(['group-b'])
+      expect(list.textContent).not.toContain('QA Team')
+      expect(groupsSection.querySelector('[data-attendance-group-detail]')?.textContent).toContain('Ops Team copy')
+      expect(vi.mocked(apiFetch).mock.calls.some(([input, init]) =>
+        String(input).includes('/api/attendance/groups/group-b/members')
+        && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(String(init?.method || 'GET').toUpperCase())
+      )).toBe(false)
+      expect(vi.mocked(apiFetch).mock.calls.some(([input, init]) =>
+        String(input).includes('/api/attendance/assignments')
+        && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(String(init?.method || 'GET').toUpperCase())
+      )).toBe(false)
     } finally {
       Object.defineProperty(URL, 'createObjectURL', { configurable: true, value: originalCreateObjectURL })
       Object.defineProperty(URL, 'revokeObjectURL', { configurable: true, value: originalRevokeObjectURL })
+      confirmSpy.mockRestore()
     }
   })
 


### PR DESCRIPTION
## Summary
- add a direct delete action to each attendance group list row, alongside the existing copy action
- reuse the existing `DELETE /api/attendance/groups/:id` flow and keep detail/list delete states guarded against double submits
- extend the attendance admin regression spec to cover row delete refresh behavior and ensure it does not write members or assignments

## Scope
- advances #1924 list-row parity for attendance group operations
- intentionally does not add group-owned punch-method config, shift authoring, scheduling semantics, or new backend schema

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false --reporter=dot`
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/web build`
- `git diff --check`
