### PR TITLE
feat(attendance): show group member counts

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -3117,6 +3117,7 @@
                           <strong>{{ item.name }}</strong>
                           <small>{{ item.code || item.id }}</small>
                         </span>
+                        <span data-attendance-group-list-member-count>{{ attendanceGroupListMemberCountLabel(item) }}</span>
                         <span>{{ attendanceGroupTypeLabel(readAttendanceGroupType(item)) }}</span>
                         <span>{{ resolveRuleSetName(item.ruleSetId) }}</span>
                       </button>
@@ -3153,6 +3154,7 @@
                     <div v-if="attendanceGroupEditingId" class="attendance__group-detail-actions">
                       <div class="attendance__admin-meta">
                         <span>{{ tr('Code', '编码') }}: {{ attendanceGroupForm.code || '-' }}</span>
+                        <span>{{ tr('People', '考勤人员') }}: {{ attendanceGroupListMemberCountLabel(selectedAttendanceGroup) }}</span>
                         <span>{{ tr('Type', '类型') }}: {{ attendanceGroupTypeLabel(attendanceGroupForm.attendanceType) }}</span>
                         <span>{{ tr('Timezone', '时区') }}: {{ displayTimezone(attendanceGroupForm.timezone) }}</span>
                       </div>
@@ -6605,6 +6607,8 @@ interface AttendanceGroup {
   timezone: string
   ruleSetId?: string | null
   description?: string | null
+  memberCount?: number | null
+  member_count?: number | null
   attendanceType?: AttendanceGroupType | null
   attendance_type?: AttendanceGroupType | null
   createdAt?: string
@@ -6662,6 +6666,17 @@ function attendanceGroupTypeDetail(value?: AttendanceGroupType | null): string {
   const normalized = normalizeAttendanceGroupType(value)
   const option = ATTENDANCE_GROUP_TYPE_OPTIONS.find(item => item.value === normalized) ?? ATTENDANCE_GROUP_TYPE_OPTIONS[0]
   return tr(option.detailEn, option.detailZh)
+}
+
+function attendanceGroupListMemberCountValue(group?: AttendanceGroup | null): number {
+  const raw = group?.memberCount ?? group?.member_count
+  const count = Number(raw)
+  return Number.isFinite(count) && count > 0 ? Math.floor(count) : 0
+}
+
+function attendanceGroupListMemberCountLabel(group?: AttendanceGroup | null): string {
+  const count = attendanceGroupListMemberCountValue(group)
+  return count === 1 ? tr('1 member', '1 人') : tr(`${count} members`, `${count} 人`)
 }
 
 interface AttendanceGroupMember {
@@ -16819,11 +16834,12 @@ function exportAttendanceGroupsCsv() {
     setStatus(tr('No attendance groups to export.', '没有可导出的考勤组。'), 'error')
     return
   }
-  const headers = ['Name', 'Code', 'Type', 'Rule policy', 'Timezone', 'Description', 'Created at', 'Updated at']
+  const headers = ['Name', 'Code', 'Type', 'Member count', 'Rule policy', 'Timezone', 'Description', 'Created at', 'Updated at']
   const csvRows = rows.map(group => [
     group.name,
     group.code ?? '',
     attendanceGroupTypeLabel(readAttendanceGroupType(group)),
+    attendanceGroupListMemberCountValue(group),
     resolveRuleSetName(group.ruleSetId),
     group.timezone ?? '',
     group.description ?? '',
@@ -16974,12 +16990,21 @@ async function loadAttendanceGroupMembers() {
     const items = Array.isArray(data.data?.items) ? data.data.items : []
     attendanceGroupMembers.value = items
     attendanceGroupMemberTotal.value = Number(data.data?.total ?? items.length) || items.length
+    syncAttendanceGroupMemberCount(groupId, attendanceGroupMemberTotal.value)
     void resolveAttendanceGroupMemberLabels(groupId, items)
   } catch (error: any) {
     setStatus(readErrorMessage(error, tr('Failed to load group members', '加载分组成员失败')), 'error')
   } finally {
     attendanceGroupMemberLoading.value = false
   }
+}
+
+function syncAttendanceGroupMemberCount(groupId: string, count: number) {
+  const normalizedCount = Number.isFinite(count) && count > 0 ? Math.floor(count) : 0
+  const group = attendanceGroups.value.find(item => item.id === groupId)
+  if (!group) return
+  group.memberCount = normalizedCount
+  group.member_count = normalizedCount
 }
 
 async function previewAttendanceGroupFixedSchedule() {

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -253,6 +253,7 @@ describe('Attendance admin regressions', () => {
                 ruleSetId: 'rule-set-1',
                 attendanceType: 'fixed_shift',
                 description: 'Operations attendance group',
+                memberCount: 1,
                 createdAt: '2026-03-28T08:00:00.000Z',
                 updatedAt: '2026-03-28T08:30:00.000Z',
               },
@@ -906,6 +907,7 @@ describe('Attendance admin regressions', () => {
         ruleSetId: 'rule-set-1',
         attendanceType: 'fixed_shift',
         description: 'Operations attendance group',
+        memberCount: 3,
         createdAt: '2026-03-28T08:00:00.000Z',
         updatedAt: '2026-03-28T08:30:00.000Z',
       },
@@ -917,6 +919,7 @@ describe('Attendance admin regressions', () => {
         ruleSetId: null,
         attendanceType: 'scheduled_shift',
         description: 'Quality attendance group',
+        memberCount: 0,
         createdAt: '2026-03-29T08:00:00.000Z',
         updatedAt: '2026-03-29T08:30:00.000Z',
       },
@@ -965,6 +968,7 @@ describe('Attendance admin regressions', () => {
           ruleSetId: typeof body.ruleSetId === 'string' ? body.ruleSetId : null,
           attendanceType: String(body.attendanceType || 'fixed_shift'),
           description: typeof body.description === 'string' ? body.description : null,
+          memberCount: 0,
           createdAt: '2026-03-30T08:00:00.000Z',
           updatedAt: '2026-03-30T08:00:00.000Z',
         }
@@ -977,7 +981,10 @@ describe('Attendance admin regressions', () => {
         if (index >= 0) savedGroups.splice(index, 1)
         return jsonResponse(200, { ok: true, data: { id: 'group-b' } })
       }
-      if (url === '/api/attendance/groups/group-a/members' || url === '/api/attendance/groups/group-copy/members') {
+      if (url === '/api/attendance/groups/group-a/members') {
+        return jsonResponse(200, { ok: true, data: { items: [], total: 3 } })
+      }
+      if (url === '/api/attendance/groups/group-copy/members') {
         return jsonResponse(200, { ok: true, data: { items: [], total: 0 } })
       }
       return emptyAttendanceResponse()
@@ -1040,6 +1047,7 @@ describe('Attendance admin regressions', () => {
       const opsRow = Array.from(groupsSection.querySelectorAll<HTMLElement>('[data-attendance-group-row]'))
         .find(row => row.textContent?.includes('Ops Team'))
       expect(opsRow).toBeTruthy()
+      expect(opsRow!.querySelector('[data-attendance-group-list-member-count]')?.textContent).toContain('3 members')
       opsRow!.querySelector<HTMLButtonElement>('[data-attendance-group-copy]')!.click()
       await flushUi(8)
 

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -113,6 +113,70 @@ afterEach(async () => {
 })
 
 describe('attendance UUID route validation', () => {
+  it('returns attendance group member counts on list and lookup routes', async () => {
+    const { db, routes } = await createHarness()
+    const groupId = '00000000-0000-4000-8000-000000000101'
+    const groupRow = {
+      id: groupId,
+      org_id: 'default',
+      name: 'Ops Team',
+      code: 'ops-team',
+      timezone: 'UTC',
+      rule_set_id: null,
+      description: 'unit-test',
+      attendance_type: 'fixed_shift',
+      member_count: 3,
+      created_at: '2026-05-29T20:00:00.000Z',
+      updated_at: '2026-05-29T20:00:00.000Z',
+    }
+
+    db.query
+      .mockResolvedValueOnce([{ total: 1 }])
+      .mockResolvedValueOnce([groupRow])
+
+    const listRes = await invokeRoute(routes, 'GET /api/attendance/groups')
+
+    expect(listRes.statusCode).toBe(200)
+    expect(listRes.body).toMatchObject({
+      ok: true,
+      data: {
+        items: [
+          {
+            id: groupId,
+            memberCount: 3,
+            member_count: 3,
+          },
+        ],
+        total: 1,
+      },
+    })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('attendance_group_members'),
+      ['default', 50, 0],
+    )
+
+    db.query.mockClear()
+    db.query.mockResolvedValueOnce([{ ...groupRow, member_count: 4 }])
+
+    const lookupRes = await invokeRoute(routes, 'GET /api/attendance/groups/:id', {
+      params: { id: groupId },
+    })
+
+    expect(lookupRes.statusCode).toBe(200)
+    expect(lookupRes.body).toMatchObject({
+      ok: true,
+      data: {
+        id: groupId,
+        memberCount: 4,
+        member_count: 4,
+      },
+    })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('attendance_group_members'),
+      [groupId, 'default'],
+    )
+  })
+
   it('persists attendance group type on create and rejects type changes on update', async () => {
     const { db, routes } = await createHarness()
     const groupId = '00000000-0000-4000-8000-000000000101'

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -7354,6 +7354,7 @@ function mapShiftRow(row) {
 
 function mapAttendanceGroupRow(row) {
   const attendanceType = normalizeAttendanceGroupType(row.attendance_type)
+  const memberCount = Number(row.member_count ?? 0) || 0
   return {
     id: row.id,
     orgId: row.org_id ?? DEFAULT_ORG_ID,
@@ -7362,6 +7363,8 @@ function mapAttendanceGroupRow(row) {
     timezone: row.timezone ?? DEFAULT_RULE.timezone,
     ruleSetId: row.rule_set_id ?? null,
     description: row.description ?? null,
+    memberCount,
+    member_count: memberCount,
     attendanceType,
     attendance_type: attendanceType,
     createdAt: row.created_at ? new Date(row.created_at).toISOString() : undefined,
@@ -26100,9 +26103,16 @@ module.exports = {
           const total = Number(countRows[0]?.total ?? 0)
 
           const rows = await db.query(
-            `SELECT * FROM attendance_groups
-             WHERE org_id = $1
-             ORDER BY created_at DESC
+            `SELECT g.*, COALESCE(member_counts.member_count, 0)::int AS member_count
+             FROM attendance_groups g
+             LEFT JOIN (
+               SELECT group_id, COUNT(*)::int AS member_count
+               FROM attendance_group_members
+               WHERE org_id = $1
+               GROUP BY group_id
+             ) member_counts ON member_counts.group_id = g.id
+             WHERE g.org_id = $1
+             ORDER BY g.created_at DESC
              LIMIT $2 OFFSET $3`,
             [orgId, pageSize, offset]
           )
@@ -26140,7 +26150,15 @@ module.exports = {
 
         try {
           const rows = await db.query(
-            'SELECT * FROM attendance_groups WHERE id = $1 AND org_id = $2',
+            `SELECT g.*, COALESCE(member_counts.member_count, 0)::int AS member_count
+             FROM attendance_groups g
+             LEFT JOIN (
+               SELECT group_id, COUNT(*)::int AS member_count
+               FROM attendance_group_members
+               WHERE org_id = $2
+               GROUP BY group_id
+             ) member_counts ON member_counts.group_id = g.id
+             WHERE g.id = $1 AND g.org_id = $2`,
             [groupId, orgId]
           )
           if (!rows.length) {


### PR DESCRIPTION
## Summary
- add `memberCount` / `member_count` to attendance group list and lookup responses using `attendance_group_members`
- show the member count in the attendance group list row and selected group header
- include member count in group CSV export and keep the local row count in sync after member-list refreshes

## Scope
- advances #1924 list parity for the "people count" column/summary
- intentionally does not change member CRUD semantics, scheduling writes, group-owned punch-method config, or drawer authoring

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false --reporter=dot`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts --reporter=dot`
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/web build`
- `pnpm --filter @metasheet/core-backend build`
- `node -c plugins/plugin-attendance/index.cjs`
- `git diff --check`
