### PR TITLE
feat(attendance): add holiday entry to work time drawer

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -3503,6 +3503,27 @@
                         </div>
                       </div>
 
+                      <div
+                        v-if="normalizeAttendanceGroupType(attendanceGroupForm.attendanceType) === 'fixed_shift'"
+                        class="attendance__work-time-holiday-callout"
+                        data-attendance-group-work-time-holidays
+                      >
+                        <div>
+                          <strong>{{ tr('Holiday calendar', '节假日日历') }}</strong>
+                          <span>
+                            {{ tr('Holiday auto-rest and special-date exceptions stay in the Holidays surface for this slice.', '本切片中节假日自动排休与特殊日期例外仍在节假日管理中维护。') }}
+                          </span>
+                        </div>
+                        <button
+                          class="attendance__btn attendance__btn--compact"
+                          type="button"
+                          data-attendance-group-work-time-holidays-open
+                          @click="selectAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.holidays); closeAttendanceGroupWorkTimeDrawer()"
+                        >
+                          {{ tr('Open Holidays', '打开节假日') }}
+                        </button>
+                      </div>
+
                       <div class="attendance__work-time-drawer-actions">
                         <button
                           class="attendance__btn"
@@ -20543,6 +20564,34 @@ const holidaySectionBindings = {
   border: 1px solid #dbe3ee;
   border-radius: 8px;
   background: #f9fafb;
+}
+
+.attendance__work-time-holiday-callout {
+  display: flex;
+  flex-wrap: wrap;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 10px;
+  padding: 12px;
+  border: 1px solid #d7dde7;
+  border-radius: 8px;
+  background: #fff7ed;
+}
+
+.attendance__work-time-holiday-callout div {
+  display: grid;
+  gap: 4px;
+  min-width: min(100%, 280px);
+}
+
+.attendance__work-time-holiday-callout strong {
+  color: #111827;
+  font-weight: 700;
+}
+
+.attendance__work-time-holiday-callout span {
+  color: #52606d;
+  font-size: 12px;
 }
 
 .attendance__work-time-drawer-actions {

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -890,6 +890,7 @@ describe('Attendance admin regressions', () => {
     expect(savedDrawer!.querySelector('[data-attendance-group-work-time-lock]')?.textContent).toContain('Type changes are blocked')
     expect(savedDrawer!.querySelector<HTMLButtonElement>('[data-attendance-group-work-time-option="free_time"]')?.disabled).toBe(true)
     expect(savedDrawer!.querySelectorAll('[data-attendance-group-work-time-week-day]').length).toBe(7)
+    expect(savedDrawer!.querySelector('[data-attendance-group-work-time-holidays]')?.textContent).toContain('Holiday calendar')
     expect(vi.mocked(apiFetch).mock.calls.slice(beforeSavedDrawerCalls)).toHaveLength(0)
 
     savedDrawer!.querySelector<HTMLButtonElement>('[data-attendance-group-work-time-close]')!.click()
@@ -924,6 +925,7 @@ describe('Attendance admin regressions', () => {
     expect(draftDrawer!.querySelector('[data-attendance-group-work-time-selected]')?.textContent).toContain('Free time')
     expect(draftDrawer!.querySelector('[data-attendance-group-work-time-draft]')?.textContent).toContain('selected type')
     expect(draftDrawer!.querySelector('[data-attendance-group-work-time-week-matrix]')).toBeNull()
+    expect(draftDrawer!.querySelector('[data-attendance-group-work-time-holidays]')).toBeNull()
   })
 
   it('filters, exports, copies, and deletes attendance groups from the list tools', async () => {
@@ -1432,6 +1434,37 @@ describe('Attendance admin regressions', () => {
     const newCalls = vi.mocked(apiFetch).mock.calls.slice(beforeNavCalls)
     expect(newCalls).toHaveLength(0)
     expect(window.getComputedStyle(container!.querySelector<HTMLElement>('#attendance-admin-shifts')!).display).not.toBe('none')
+    expect(window.getComputedStyle(container!.querySelector<HTMLElement>('#attendance-admin-groups')!).display).toBe('none')
+  })
+
+  it('opens the Holidays surface from the fixed-shift work-time drawer without writes', async () => {
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    const groupsNav = container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-groups"]')
+    expect(groupsNav).toBeTruthy()
+    groupsNav!.click()
+    await flushUi(4)
+
+    const openWorkTime = container!.querySelector<HTMLButtonElement>('[data-attendance-group-summary-action="open-work-time-drawer"]')
+    expect(openWorkTime).toBeTruthy()
+    openWorkTime!.click()
+    await flushUi(2)
+
+    const drawer = container!.querySelector<HTMLElement>('[data-attendance-group-work-time-drawer]')
+    expect(drawer).toBeTruthy()
+    expect(drawer!.querySelector('[data-attendance-group-work-time-holidays]')?.textContent).toContain('Holiday calendar')
+
+    const beforeCalls = vi.mocked(apiFetch).mock.calls.length
+    const openHolidays = drawer!.querySelector<HTMLButtonElement>('[data-attendance-group-work-time-holidays-open]')
+    expect(openHolidays).toBeTruthy()
+    openHolidays!.click()
+    await flushUi(4)
+
+    expect(vi.mocked(apiFetch).mock.calls.slice(beforeCalls)).toHaveLength(0)
+    expect(container!.querySelector('[data-attendance-group-work-time-drawer]')).toBeNull()
+    expect(window.getComputedStyle(container!.querySelector<HTMLElement>('#attendance-admin-holidays')!).display).not.toBe('none')
     expect(window.getComputedStyle(container!.querySelector<HTMLElement>('#attendance-admin-groups')!).display).toBe('none')
   })
 


### PR DESCRIPTION
## Summary
- add a fixed-shift Holiday calendar callout inside the attendance group Work time drawer
- route the callout to the existing Holidays admin surface and close the drawer
- keep the slice UI-only: no backend/schema/scheduling/holiday-rule writes
- hide the holiday entry when a draft group switches to non-fixed work time

Advances #1924.

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false --reporter=dot`
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/web lint`
- `pnpm --filter @metasheet/web build`
- `git diff --check`
