### PR TITLE
feat(attendance): add group row edit action

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -3125,6 +3125,15 @@
                         <button
                           class="attendance__btn attendance__btn--compact"
                           type="button"
+                          :disabled="attendanceGroupDeletingId === item.id"
+                          data-attendance-group-row-edit
+                          @click="selectAttendanceGroup(item)"
+                        >
+                          {{ tr('Edit', '编辑') }}
+                        </button>
+                        <button
+                          class="attendance__btn attendance__btn--compact"
+                          type="button"
                           :disabled="attendanceGroupCopyingId === item.id || attendanceGroupDeletingId === item.id"
                           data-attendance-group-copy
                           @click="copyAttendanceGroup(item)"

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -1078,8 +1078,13 @@ describe('Attendance admin regressions', () => {
       const qaRow = Array.from(groupsSection.querySelectorAll<HTMLElement>('[data-attendance-group-row]'))
         .find(row => row.textContent?.includes('QA Team'))
       expect(qaRow).toBeTruthy()
-      qaRow!.querySelector<HTMLButtonElement>('.attendance__group-list-main')!.click()
+      expect(qaRow!.querySelector<HTMLButtonElement>('[data-attendance-group-row-edit]')?.textContent).toContain('Edit')
+      const beforeEditCalls = vi.mocked(apiFetch).mock.calls.length
+      qaRow!.querySelector<HTMLButtonElement>('[data-attendance-group-row-edit]')!.click()
       await flushUi(2)
+      expect(vi.mocked(apiFetch).mock.calls.slice(beforeEditCalls).filter(([, init]) =>
+        ['POST', 'PUT', 'PATCH', 'DELETE'].includes(String(init?.method || 'GET').toUpperCase())
+      )).toEqual([])
       expect(groupsSection.querySelector('[data-attendance-group-schedule-type-placeholder]')?.textContent).toContain('Scheduled shift')
       expect(groupsSection.querySelector('[data-attendance-group-fixed-schedule-preview]')).toBeNull()
 


### PR DESCRIPTION
## Summary
- add an explicit row-level Edit action to Attendance groups
- reuse the existing select/edit detail behavior instead of introducing a new write path
- keep Copy/Delete row actions unchanged
- add regression coverage that Edit can open a scheduled-shift group without API writes

Advances #1924.

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false --reporter=dot`
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/web lint`
- `pnpm --filter @metasheet/web build`
- `git diff --check`
