### PR TITLE
feat(attendance): add group punch method drawer

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -3559,6 +3559,75 @@
                     </aside>
                   </div>
 
+                  <div
+                    v-if="attendanceGroupPunchMethodDrawerOpen"
+                    class="attendance__drawer-backdrop"
+                    data-attendance-group-punch-method-drawer
+                    @click.self="closeAttendanceGroupPunchMethodDrawer"
+                  >
+                    <aside
+                      class="attendance__work-time-drawer"
+                      role="dialog"
+                      aria-modal="true"
+                      aria-labelledby="attendance-group-punch-method-drawer-title"
+                    >
+                      <div class="attendance__work-time-drawer-header">
+                        <div>
+                          <h6 id="attendance-group-punch-method-drawer-title">{{ tr('Punch method settings', '打卡方式设置') }}</h6>
+                          <span class="attendance__field-hint">
+                            {{ tr('Current enforcement comes from workspace settings; this drawer is read-only for attendance groups.', '当前打卡校验来自工作区设置；此抽屉对考勤组保持只读。') }}
+                          </span>
+                        </div>
+                        <button
+                          class="attendance__btn attendance__btn--compact"
+                          type="button"
+                          data-attendance-group-punch-method-close
+                          @click="closeAttendanceGroupPunchMethodDrawer"
+                        >
+                          {{ tr('Close', '关闭') }}
+                        </button>
+                      </div>
+
+                      <div class="attendance__work-time-drawer-body" data-attendance-group-punch-method-scope>
+                        <strong>{{ tr('Workspace-level policy', '工作区级策略') }}</strong>
+                        <span>
+                          {{ tr('These settings apply to every attendance group until group-owned punch policies are designed and persisted.', '这些设置当前适用于所有考勤组；考勤组级打卡策略需等后续设计与持久化契约。') }}
+                        </span>
+                      </div>
+
+                      <ul class="attendance__group-summary-policy" data-attendance-group-punch-method-policy>
+                        <li
+                          v-for="line in attendanceGroupPunchPolicyLines"
+                          :key="`punch-method-drawer-${line.key}`"
+                          :data-attendance-group-punch-method-line="line.key"
+                        >
+                          <span class="attendance__group-summary-policy-label">{{ line.label }}</span>:
+                          <span class="attendance__group-summary-policy-value">{{ line.value }}</span>
+                        </li>
+                      </ul>
+
+                      <div class="attendance__work-time-holiday-callout" data-attendance-group-punch-method-boundary>
+                        <div>
+                          <strong>{{ tr('Group-owned controls deferred', '考勤组级控制暂缓') }}</strong>
+                          <span>
+                            {{ tr('Location, Wi-Fi, device, photo, face verification, and field-work policies need a separate backend contract before editable controls appear here.', '地点、Wi-Fi、设备、拍照、人脸与外勤策略需要独立后端契约后，才会在这里出现可编辑控件。') }}
+                          </span>
+                        </div>
+                      </div>
+
+                      <div class="attendance__work-time-drawer-actions">
+                        <button
+                          class="attendance__btn"
+                          type="button"
+                          data-attendance-group-punch-method-settings-open
+                          @click="selectAdminSection(ATTENDANCE_ADMIN_SECTION_IDS.settings); closeAttendanceGroupPunchMethodDrawer()"
+                        >
+                          {{ tr('Open Settings', '打开设置') }}
+                        </button>
+                      </div>
+                    </aside>
+                  </div>
+
                   <section
                     v-if="attendanceGroupEditingId && attendanceGroupForm.attendanceType === 'fixed_shift'"
                     class="attendance__group-panel"
@@ -6889,7 +6958,7 @@ type AttendanceGroupSummaryAction = {
   key: string
   label: string
   sectionId?: string
-  drawer?: 'work-time'
+  drawer?: 'work-time' | 'punch-method'
 }
 
 type AttendanceGroupSummaryPolicyLine = {
@@ -8605,6 +8674,7 @@ const attendanceGroupTypeFilter = ref<AttendanceGroupType | ''>('')
 const attendanceGroupCopyingId = ref<string | null>(null)
 const attendanceGroupDeletingId = ref<string | null>(null)
 const attendanceGroupWorkTimeDrawerOpen = ref(false)
+const attendanceGroupPunchMethodDrawerOpen = ref(false)
 const payrollTemplates = ref<AttendancePayrollTemplate[]>([])
 const payrollCycles = ref<AttendancePayrollCycle[]>([])
 const payrollSummaryFieldOptions = ref<AttendancePayrollSummaryFieldOption[]>(
@@ -8905,6 +8975,8 @@ function buildAttendanceGroupPunchPolicyLines(): AttendanceGroupSummaryPolicyLin
   ]
 }
 
+const attendanceGroupPunchPolicyLines = computed(() => buildAttendanceGroupPunchPolicyLines())
+
 const attendanceGroupSummaryCards = computed<AttendanceGroupSummaryCard[]>(() => {
   const groupSaved = Boolean(attendanceGroupEditingId.value)
   const ruleSetName = groupSaved
@@ -9005,12 +9077,12 @@ const attendanceGroupSummaryCards = computed<AttendanceGroupSummaryCard[]>(() =>
       title: tr('Punch method', '打卡方式'),
       value: tr('Workspace-level policy · applies to all attendance groups', '工作区级策略 · 适用于所有考勤组'),
       detail: tr('Wi-Fi, device, photo, and face verification are not available here.', 'Wi-Fi、设备、拍照与人脸识别在此不可用。'),
-      policyLines: buildAttendanceGroupPunchPolicyLines(),
+      policyLines: attendanceGroupPunchPolicyLines.value,
       actions: [
         {
-          key: 'open-settings',
-          label: tr('Open Settings', '打开设置'),
-          sectionId: ATTENDANCE_ADMIN_SECTION_IDS.settings,
+          key: 'open-punch-method-drawer',
+          label: tr('Open Punch method', '打开打卡方式'),
+          drawer: 'punch-method',
         },
       ],
     },
@@ -9073,6 +9145,10 @@ function handleAttendanceGroupSummaryAction(action: AttendanceGroupSummaryAction
     openAttendanceGroupWorkTimeDrawer()
     return
   }
+  if (action.drawer === 'punch-method') {
+    openAttendanceGroupPunchMethodDrawer()
+    return
+  }
   if (action.sectionId) {
     selectAdminSection(action.sectionId)
   }
@@ -9084,6 +9160,14 @@ function openAttendanceGroupWorkTimeDrawer() {
 
 function closeAttendanceGroupWorkTimeDrawer() {
   attendanceGroupWorkTimeDrawerOpen.value = false
+}
+
+function openAttendanceGroupPunchMethodDrawer() {
+  attendanceGroupPunchMethodDrawerOpen.value = true
+}
+
+function closeAttendanceGroupPunchMethodDrawer() {
+  attendanceGroupPunchMethodDrawerOpen.value = false
 }
 
 function setAttendanceGroupWorkTimeType(type: AttendanceGroupType) {

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -1314,6 +1314,37 @@ describe('Attendance admin regressions', () => {
     expect(card.textContent).not.toContain('192.168.0.0/16')
   })
 
+  it('opens a read-only group punch-method drawer without issuing API writes', async () => {
+    attendanceSettingsData = {
+      ipAllowlist: ['10.0.0.0/8', '192.168.0.0/16'],
+      geoFence: { lat: 31.2, lng: 121.5, radiusMeters: 200 },
+      minPunchIntervalMinutes: 5,
+    }
+    const card = await openAttendanceGroupPunchCard()
+    const openDrawer = card.querySelector<HTMLButtonElement>('[data-attendance-group-summary-action="open-punch-method-drawer"]')
+    expect(openDrawer).toBeTruthy()
+
+    const beforeCalls = vi.mocked(apiFetch).mock.calls.length
+    openDrawer!.click()
+    await flushUi(2)
+
+    const drawer = container!.querySelector<HTMLElement>('[data-attendance-group-punch-method-drawer]')
+    expect(drawer).toBeTruthy()
+    expect(drawer!.querySelector('[data-attendance-group-punch-method-scope]')?.textContent).toContain('Workspace-level policy')
+    expect(drawer!.querySelector('[data-attendance-group-punch-method-line="ip"]')?.textContent).toContain('Restricted to 2 address range(s)')
+    expect(drawer!.querySelector('[data-attendance-group-punch-method-line="geofence"]')?.textContent).toContain('Geofence enabled · 200 m radius')
+    expect(drawer!.querySelector('[data-attendance-group-punch-method-line="interval"]')?.textContent).toContain('5 minutes')
+    expect(drawer!.querySelector('[data-attendance-group-punch-method-boundary]')?.textContent).toContain('Group-owned controls deferred')
+    expect(drawer!.querySelectorAll('input, select, textarea').length).toBe(0)
+    expect(drawer!.textContent).not.toContain('10.0.0.0/8')
+    expect(drawer!.textContent).not.toContain('192.168.0.0/16')
+    expect(vi.mocked(apiFetch).mock.calls.slice(beforeCalls)).toHaveLength(0)
+
+    drawer!.querySelector<HTMLButtonElement>('[data-attendance-group-punch-method-close]')!.click()
+    await flushUi(2)
+    expect(container!.querySelector('[data-attendance-group-punch-method-drawer]')).toBeNull()
+  })
+
   it('renders default punch policy as unrestricted in the group punch-method card', async () => {
     attendanceSettingsData = null
     const card = await openAttendanceGroupPunchCard()
@@ -1368,7 +1399,7 @@ describe('Attendance admin regressions', () => {
     expect(refreshed.textContent).not.toContain('100 m radius')
   })
 
-  it('keeps the group punch-method card read-only with only an Open Settings nav', async () => {
+  it('keeps the group punch-method card read-only with only an Open drawer action', async () => {
     const card = await openAttendanceGroupPunchCard()
     // PM4: no inputs/toggles/save controls inside the punch card
     expect(card.querySelectorAll('input, select, textarea').length).toBe(0)
@@ -1384,7 +1415,14 @@ describe('Attendance admin regressions', () => {
 
   it('does not write punch policy or touch clock events from the group detail', async () => {
     const card = await openAttendanceGroupPunchCard()
-    const settingsAction = card.querySelector<HTMLButtonElement>('[data-attendance-group-summary-action="open-settings"]')
+    const openDrawer = card.querySelector<HTMLButtonElement>('[data-attendance-group-summary-action="open-punch-method-drawer"]')
+    expect(openDrawer).toBeTruthy()
+    openDrawer!.click()
+    await flushUi(2)
+
+    const drawer = container!.querySelector<HTMLElement>('[data-attendance-group-punch-method-drawer]')
+    expect(drawer).toBeTruthy()
+    const settingsAction = drawer!.querySelector<HTMLButtonElement>('[data-attendance-group-punch-method-settings-open]')
     expect(settingsAction).toBeTruthy()
     settingsAction!.click()
     await flushUi(2)
@@ -1403,6 +1441,7 @@ describe('Attendance admin regressions', () => {
       String(url).includes('/api/attendance/records')
       && ['POST', 'PUT', 'PATCH', 'DELETE'].includes(String((init as { method?: string } | undefined)?.method || 'GET').toUpperCase()))
     expect(recordWrites).toEqual([])
+    expect(container!.querySelector('[data-attendance-group-punch-method-drawer]')).toBeNull()
   })
 
   it('navigates from attendance group summary cards without issuing API writes', async () => {


### PR DESCRIPTION
## Summary
- add a read-only Punch method drawer from the attendance group summary card
- show the live workspace-level punch policy inside the drawer without exposing raw IP ranges
- keep group-owned location/Wi-Fi/device/photo/face/field-work controls explicitly deferred until a backend contract exists

## Scope
- UI-only: no backend route, schema, RBAC, settings write, punch event, or attendance record write path added
- Advances #1924 but does not close it; true group-owned punch-method configuration remains a separate follow-up

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts --watch=false --reporter=dot (45 passed)
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web lint
- pnpm --filter @metasheet/web build
- pnpm --filter @metasheet/web exec eslint "src/views/AttendanceView.vue" "tests/attendance-admin-regressions.spec.ts" --rule "@typescript-eslint/no-unused-vars: off" --rule "vue/no-v-html: off" --rule "vue/one-component-per-file: off" --max-warnings=0
- git diff --check -- apps/web/src/views/AttendanceView.vue apps/web/tests/attendance-admin-regressions.spec.ts