### PR TITLE
feat(attendance): add group owner roster routes

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260529233000_create_attendance_group_managers.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260529233000_create_attendance_group_managers.ts
@@ -1,0 +1,50 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists, createIndexIfNotExists } from './_patterns'
+
+const DEFAULT_ORG_ID = 'default'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  const groupsExists = await checkTableExists(db, 'attendance_groups')
+  if (!groupsExists) return
+
+  const managersExists = await checkTableExists(db, 'attendance_group_managers')
+  if (!managersExists) {
+    await db.schema
+      .createTable('attendance_group_managers')
+      .ifNotExists()
+      .addColumn('id', 'uuid', col => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('org_id', 'text', col => col.notNull().defaultTo(DEFAULT_ORG_ID))
+      .addColumn('group_id', 'uuid', col => col.notNull().references('attendance_groups.id').onDelete('cascade'))
+      .addColumn('user_id', 'text', col => col.notNull())
+      .addColumn('role', 'text', col => col.notNull())
+      .addColumn('created_by', 'text')
+      .addColumn('created_at', 'timestamptz', col => col.defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', col => col.defaultTo(sql`now()`))
+      .execute()
+  }
+
+  await sql`
+    ALTER TABLE attendance_group_managers
+    DROP CONSTRAINT IF EXISTS attendance_group_managers_role_check
+  `.execute(db)
+  await sql`
+    ALTER TABLE attendance_group_managers
+    ADD CONSTRAINT attendance_group_managers_role_check
+    CHECK (role IN ('owner', 'sub_owner'))
+  `.execute(db)
+
+  await createIndexIfNotExists(db, 'idx_attendance_group_managers_org', 'attendance_group_managers', 'org_id')
+  await createIndexIfNotExists(db, 'idx_attendance_group_managers_group', 'attendance_group_managers', 'group_id')
+  await createIndexIfNotExists(db, 'idx_attendance_group_managers_user', 'attendance_group_managers', 'user_id')
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS idx_attendance_group_managers_unique
+    ON attendance_group_managers(org_id, group_id, user_id, role)
+  `.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable('attendance_group_managers').ifExists().cascade().execute()
+}

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -253,6 +253,122 @@ describe('attendance UUID route validation', () => {
     )
   })
 
+  it('manages attendance group owners separately from attendance members', async () => {
+    const { db, routes } = await createHarness()
+    const groupId = '00000000-0000-4000-8000-000000000101'
+    const managerId = '00000000-0000-4000-8000-000000000201'
+    const createdAt = '2026-05-29T22:00:00.000Z'
+    const managerRow = {
+      id: managerId,
+      org_id: 'default',
+      group_id: groupId,
+      user_id: 'owner-user-1',
+      role: 'owner',
+      created_by: 'attendance-user-1',
+      created_at: createdAt,
+      updated_at: createdAt,
+    }
+
+    db.query
+      .mockResolvedValueOnce([{ total: 1 }])
+      .mockResolvedValueOnce([managerRow])
+
+    const listRes = await invokeRoute(routes, 'GET /api/attendance/groups/:id/managers', {
+      params: { id: groupId },
+    })
+
+    expect(listRes.statusCode).toBe(200)
+    expect(listRes.body).toMatchObject({
+      ok: true,
+      data: {
+        items: [
+          {
+            id: managerId,
+            groupId,
+            userId: 'owner-user-1',
+            role: 'owner',
+            createdBy: 'attendance-user-1',
+          },
+        ],
+        total: 1,
+      },
+    })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('attendance_group_managers'),
+      ['default', groupId, 50, 0],
+    )
+    expect(db.query.mock.calls.map(call => String(call[0])).join('\n')).not.toContain('attendance_group_members')
+
+    db.query.mockClear()
+    db.query.mockResolvedValueOnce([{ ...managerRow, role: 'sub_owner' }])
+
+    const createRes = await invokeRoute(routes, 'POST /api/attendance/groups/:id/managers', {
+      params: { id: groupId },
+      body: {
+        userId: 'owner-user-1',
+        role: 'sub-owner',
+      },
+    })
+
+    expect(createRes.statusCode).toBe(200)
+    expect(createRes.body).toMatchObject({
+      ok: true,
+      data: {
+        id: managerId,
+        groupId,
+        userId: 'owner-user-1',
+        role: 'sub_owner',
+        createdBy: 'attendance-user-1',
+      },
+    })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('attendance_group_managers'),
+      ['default', groupId, 'owner-user-1', 'sub_owner', 'attendance-user-1'],
+    )
+
+    db.query.mockClear()
+    db.query.mockResolvedValueOnce([{ id: managerId }])
+
+    const deleteRes = await invokeRoute(routes, 'DELETE /api/attendance/groups/:id/managers/:managerId', {
+      params: { id: groupId, managerId },
+    })
+
+    expect(deleteRes.statusCode).toBe(200)
+    expect(deleteRes.body).toMatchObject({
+      ok: true,
+      data: {
+        id: managerId,
+      },
+    })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('attendance_group_managers'),
+      [managerId, 'default', groupId],
+    )
+  })
+
+  it('rejects invalid attendance group manager roles before writing', async () => {
+    const { db, routes } = await createHarness()
+    const groupId = '00000000-0000-4000-8000-000000000101'
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/groups/:id/managers', {
+      params: { id: groupId },
+      body: {
+        userId: 'owner-user-1',
+        role: 'manager',
+      },
+    })
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'role must be owner or sub_owner',
+      },
+    })
+    expect(db.query).not.toHaveBeenCalled()
+  })
+
   it('rejects malformed route UUID params before hitting the database', async () => {
     const { db, routes } = await createHarness()
     const cases = [
@@ -274,6 +390,21 @@ describe('attendance UUID route validation', () => {
       { key: 'GET /api/attendance/payroll-cycles/:id/summary' },
       { key: 'GET /api/attendance/payroll-cycles/:id/summary/export' },
       { key: 'GET /api/attendance/payroll-cycles/:id/export' },
+      { key: 'GET /api/attendance/groups/:id/managers' },
+      {
+        key: 'POST /api/attendance/groups/:id/managers',
+        body: {
+          userId: 'owner-user-1',
+          role: 'owner',
+        },
+      },
+      {
+        key: 'DELETE /api/attendance/groups/:id/managers/:managerId',
+        params: {
+          id: 'not-a-uuid',
+          managerId: '00000000-0000-4000-8000-000000000201',
+        },
+      },
       {
         key: 'POST /api/attendance/groups/:id/fixed-schedule/preview',
         body: {
@@ -323,6 +454,29 @@ describe('attendance UUID route validation', () => {
       })
     }
 
+    expect(db.query).not.toHaveBeenCalled()
+    expect(db.transaction).not.toHaveBeenCalled()
+  })
+
+  it('rejects malformed attendance group manager ids before hitting the database', async () => {
+    const { db, routes } = await createHarness()
+    const groupId = '00000000-0000-4000-8000-000000000101'
+
+    const res = await invokeRoute(routes, 'DELETE /api/attendance/groups/:id/managers/:managerId', {
+      params: {
+        id: groupId,
+        managerId: 'not-a-uuid',
+      },
+    })
+
+    expect(res.statusCode).toBe(400)
+    expect(res.body).toMatchObject({
+      ok: false,
+      error: {
+        code: 'VALIDATION_ERROR',
+        message: 'managerId must be a UUID',
+      },
+    })
     expect(db.query).not.toHaveBeenCalled()
     expect(db.transaction).not.toHaveBeenCalled()
   })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -51,6 +51,7 @@ const ATTENDANCE_SCHEDULER_SCOPE_SUBJECT_TYPES = new Set(['user', 'role', 'role_
 const ATTENDANCE_SCHEDULER_SCOPE_ACTIONS = new Set(['view', 'edit', 'import', 'export', 'clear', 'approve', 'dispatch'])
 const ATTENDANCE_GROUP_TYPES = new Set(['fixed_shift', 'scheduled_shift', 'free_time'])
 const DEFAULT_ATTENDANCE_GROUP_TYPE = 'fixed_shift'
+const ATTENDANCE_GROUP_MANAGER_ROLES = new Set(['owner', 'sub_owner'])
 
 const SETTINGS_KEY = 'attendance.settings'
 const SETTINGS_CACHE_TTL_MS = 60000
@@ -1225,6 +1226,14 @@ function normalizeAttendanceGroupType(value, fallback = DEFAULT_ATTENDANCE_GROUP
   const normalized = normalizeCatalogString(value, fallback).toLowerCase().replace(/-/g, '_')
   if (!ATTENDANCE_GROUP_TYPES.has(normalized)) {
     throw new HttpError(400, 'VALIDATION_ERROR', 'attendanceType must be fixed_shift, scheduled_shift, or free_time')
+  }
+  return normalized
+}
+
+function normalizeAttendanceGroupManagerRole(value) {
+  const normalized = normalizeCatalogString(value).replace(/([a-z])([A-Z])/g, '$1_$2').toLowerCase().replace(/-/g, '_')
+  if (!ATTENDANCE_GROUP_MANAGER_ROLES.has(normalized)) {
+    throw new HttpError(400, 'VALIDATION_ERROR', 'role must be owner or sub_owner')
   }
   return normalized
 }
@@ -7382,6 +7391,20 @@ function mapAttendanceGroupMemberRow(row) {
   }
 }
 
+function mapAttendanceGroupManagerRow(row) {
+  return {
+    id: row.id,
+    orgId: row.org_id ?? DEFAULT_ORG_ID,
+    groupId: row.group_id,
+    userId: row.user_id,
+    role: normalizeAttendanceGroupManagerRole(row.role),
+    createdBy: row.created_by ?? null,
+    created_by: row.created_by ?? null,
+    createdAt: row.created_at ? new Date(row.created_at).toISOString() : undefined,
+    updatedAt: row.updated_at ? new Date(row.updated_at).toISOString() : undefined,
+  }
+}
+
 function normalizeNullableText(value) {
   if (value === undefined || value === null) return null
   const text = String(value).trim()
@@ -8469,6 +8492,14 @@ function normalizeGroupMembersPayload(value) {
     ...payload,
     userId: firstDefinedValue(payload.userId, payload.user_id),
     userIds: firstDefinedValue(payload.userIds, payload.user_ids),
+  }
+}
+
+function normalizeGroupManagerPayload(value) {
+  const payload = normalizeObjectPayload(value)
+  return {
+    ...payload,
+    userId: firstDefinedValue(payload.userId, payload.user_id),
   }
 }
 
@@ -26510,6 +26541,146 @@ module.exports = {
           }
           logger.error('Attendance group member delete failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to remove group member' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/groups/:id/managers',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const groupId = normalizeUuidString(req.params.id)
+        if (!groupId) {
+          respondInvalidUuid(res)
+          return
+        }
+        const { page, pageSize, offset } = parsePagination(req.query)
+
+        try {
+          const countRows = await db.query(
+            'SELECT COUNT(*)::int AS total FROM attendance_group_managers WHERE org_id = $1 AND group_id = $2',
+            [orgId, groupId]
+          )
+          const total = Number(countRows[0]?.total ?? 0)
+          const rows = await db.query(
+            `SELECT *
+             FROM attendance_group_managers
+             WHERE org_id = $1 AND group_id = $2
+             ORDER BY CASE role WHEN 'owner' THEN 0 ELSE 1 END, created_at DESC
+             LIMIT $3 OFFSET $4`,
+            [orgId, groupId, pageSize, offset]
+          )
+          res.json({
+            ok: true,
+            data: {
+              items: rows.map(mapAttendanceGroupManagerRow),
+              total,
+              page,
+              pageSize,
+            },
+          })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance group manager tables missing' } })
+            return
+          }
+          logger.error('Attendance group managers fetch failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load group managers' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/groups/:id/managers',
+      withPermission('attendance:admin', async (req, res) => {
+        const schema = z.object({
+          userId: z.string().trim().min(1),
+          role: z.string(),
+        })
+
+        const parsed = schema.safeParse(normalizeGroupManagerPayload(req.body ?? {}))
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+
+        const orgId = getOrgId(req)
+        const groupId = normalizeUuidString(req.params.id)
+        if (!groupId) {
+          respondInvalidUuid(res)
+          return
+        }
+
+        let role
+        try {
+          role = normalizeAttendanceGroupManagerRole(parsed.data.role)
+        } catch (error) {
+          if (error instanceof HttpError) {
+            res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+            return
+          }
+          throw error
+        }
+
+        try {
+          const rows = await db.query(
+            `INSERT INTO attendance_group_managers (org_id, group_id, user_id, role, created_by, created_at, updated_at)
+             VALUES ($1, $2, $3, $4, $5, now(), now())
+             ON CONFLICT (org_id, group_id, user_id, role)
+             DO UPDATE SET updated_at = attendance_group_managers.updated_at
+             RETURNING *`,
+            [orgId, groupId, parsed.data.userId.trim(), role, getUserId(req) ?? null]
+          )
+          res.json({ ok: true, data: mapAttendanceGroupManagerRow(rows[0]) })
+        } catch (error) {
+          if (error?.code === '23503') {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Group not found' } })
+            return
+          }
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance group manager tables missing' } })
+            return
+          }
+          logger.error('Attendance group manager create failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to add group manager' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'DELETE',
+      '/api/attendance/groups/:id/managers/:managerId',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const groupId = normalizeUuidString(req.params.id)
+        if (!groupId) {
+          respondInvalidUuid(res)
+          return
+        }
+        const managerId = normalizeUuidString(req.params.managerId)
+        if (!managerId) {
+          respondInvalidUuid(res, 'managerId')
+          return
+        }
+        try {
+          const rows = await db.query(
+            'DELETE FROM attendance_group_managers WHERE id = $1 AND org_id = $2 AND group_id = $3 RETURNING id',
+            [managerId, orgId, groupId]
+          )
+          if (!rows.length) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Group manager not found' } })
+            return
+          }
+          res.json({ ok: true, data: { id: managerId } })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance group manager tables missing' } })
+            return
+          }
+          logger.error('Attendance group manager delete failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to remove group manager' } })
         }
       })
     )


### PR DESCRIPTION
## Summary
- add an `attendance_group_managers` migration for owner/sub-owner roster rows separate from attendance members
- add admin-only `/api/attendance/groups/:id/managers` list/add/remove routes
- keep owner roster rows separate from member counts and fixed-schedule targets; no delegated permission semantics are added
- extend attendance route unit coverage for manager list/add/delete, invalid roles, and UUID validation

## Scope
- advances #1924 owner/sub-owner backend O1
- no frontend owner panel yet; no scoped delegation; no changes to existing group/member/fixed-schedule route guards
- no punch, record, import, rule set, holiday, schedule-group, or attendance fact writes

## Verification
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts --watch=false --reporter=dot (8 passed)
- node -c plugins/plugin-attendance/index.cjs
- pnpm --filter @metasheet/core-backend build
- git diff --cached --check