### PR TITLE
ci(phase5): pin pnpm for validation workflows

### DIFF
--- a/.github/workflows/phase5-nightly-validation-regression.yml
+++ b/.github/workflows/phase5-nightly-validation-regression.yml
@@ -24,6 +24,7 @@ jobs:
       - name: Install dependencies
         run: |
           corepack enable
+          corepack prepare pnpm@10.16.1 --activate
           pnpm install --frozen-lockfile
 
       - name: Determine metrics URL

--- a/.github/workflows/phase5-nightly-validation.yml
+++ b/.github/workflows/phase5-nightly-validation.yml
@@ -43,7 +43,7 @@ jobs:
         if: steps.probe.outputs.metrics_url != ''
         run: |
           corepack enable
-          corepack prepare pnpm@latest --activate
+          corepack prepare pnpm@10.16.1 --activate
 
       - name: Install dependencies
         if: steps.probe.outputs.metrics_url != ''

--- a/.github/workflows/phase5-slo-validation.yml
+++ b/.github/workflows/phase5-slo-validation.yml
@@ -19,7 +19,7 @@ jobs:
       - name: Enable corepack and install pnpm
         run: |
           corepack enable
-          corepack prepare pnpm@latest --activate
+          corepack prepare pnpm@10.16.1 --activate
 
       - name: Install dependencies
         run: pnpm install --frozen-lockfile
@@ -44,4 +44,3 @@ jobs:
             /tmp/phase5.json
             /tmp/phase5.md
             /tmp/server.log
-

--- a/.github/workflows/phase5-validate.yml
+++ b/.github/workflows/phase5-validate.yml
@@ -37,7 +37,7 @@ jobs:
         if: steps.probe.outputs.metrics_url != ''
         run: |
           corepack enable
-          corepack prepare pnpm@latest --activate
+          corepack prepare pnpm@10.16.1 --activate
 
       - name: Install dependencies
         if: steps.probe.outputs.metrics_url != ''
@@ -74,4 +74,3 @@ jobs:
           if [ "${STATUS}" != "pass" ]; then
             echo "Phase 5 PR validation failed" && exit 1
           fi
-


### PR DESCRIPTION
## Summary
- Pin Phase 5 validation workflows that explicitly prepared `pnpm@latest` to `pnpm@10.16.1`.
- Add the same explicit prepare step to the Phase 5 nightly regression workflow.
- Keep the pin scoped to Phase 5 workflows so existing `pnpm/action-setup` lanes are not affected.

## Why
The 2026-05-30 `Phase 5 Nightly Validation (with Regression)` scheduled run failed before metrics probing because Corepack auto-selected `pnpm@11.5.0` on Node 18 and hit `ERR_VM_DYNAMIC_IMPORT_CALLBACK_MISSING`:
https://github.com/zensgit/metasheet2/actions/runs/26672683932

This removes that CI/toolchain drift from the Phase 5 validation path. It is only a prerequisite cleanup for issue #1; issue #1 still requires `METRICS_URL` / `METRICS_AUTH_HEADER` configuration and a real Phase 5 run with non-fallback metrics artifacts.

Refs #1.

## Verification
- `git diff --check origin/main...HEAD`
- `rg -n "pnpm@latest|pnpm@10\\.16\\.1|packageManager" package.json .github/workflows/phase5-nightly-validation.yml .github/workflows/phase5-nightly-validation-regression.yml .github/workflows/phase5-slo-validation.yml .github/workflows/phase5-validate.yml`

Note: local `corepack prepare pnpm@10.16.1 --activate` could not be run because this machine does not have the `corepack` executable installed; CI runners do have Corepack in the Node setup path.
