### PR TITLE
ci(phase5): probe metrics before regression install

### DIFF
--- a/.github/workflows/phase5-nightly-validation-regression.yml
+++ b/.github/workflows/phase5-nightly-validation-regression.yml
@@ -16,17 +16,6 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Setup Node.js
-        uses: actions/setup-node@v4
-        with:
-          node-version: '18'
-
-      - name: Install dependencies
-        run: |
-          corepack enable
-          corepack prepare pnpm@10.16.1 --activate
-          pnpm install --frozen-lockfile
-
       - name: Determine metrics URL
         id: cfg
         env:
@@ -49,6 +38,7 @@ jobs:
             echo "available=false" >> $GITHUB_OUTPUT
             echo "No METRICS_URL provided; skipping validation." > /tmp/phase5.md
             echo '{"summary":{"overall_status":"na"}}' > /tmp/phase5.json
+            echo "Regression check skipped: no METRICS_URL provided." > /tmp/regression.txt
             exit 0
           fi
           if curl -sSf -m 5 "$URL" >/dev/null; then
@@ -57,7 +47,21 @@ jobs:
             echo "available=false" >> $GITHUB_OUTPUT
             echo "Metrics endpoint unreachable: $URL" > /tmp/phase5.md
             echo '{"summary":{"overall_status":"na"}}' > /tmp/phase5.json
+            echo "Regression check skipped: metrics endpoint unreachable." > /tmp/regression.txt
           fi
+
+      - name: Setup Node.js
+        if: steps.probe.outputs.available == 'true'
+        uses: actions/setup-node@v4
+        with:
+          node-version: '18'
+
+      - name: Install dependencies
+        if: steps.probe.outputs.available == 'true'
+        run: |
+          corepack enable
+          corepack prepare pnpm@10.16.1 --activate
+          pnpm install --frozen-lockfile
 
       - name: Run Phase 5 validation
         if: steps.probe.outputs.available == 'true'


### PR DESCRIPTION
## Summary
- Move `Phase 5 Nightly Validation (with Regression)` metrics URL detection/probe ahead of Node setup and dependency install.
- Skip Node/Corepack/pnpm install when no reachable metrics endpoint is configured.
- Write `/tmp/regression.txt` on no-metrics and unreachable-metrics skip paths so uploaded artifacts explain the skip cleanly.

## Why
Issue #1 is currently blocked on production `METRICS_URL` configuration. The regression workflow should surface that as a clean skip artifact instead of running dependency installation before it even knows whether validation can run. This keeps the Phase 5 signal focused: dependency/toolchain failures are only possible when there is a real metrics endpoint to validate.

This is a CI hygiene follow-up to PR #2104. It does not complete issue #1; #1 still needs real production metrics configuration and non-fallback validation artifacts.

Refs #1.

## Verification
- `ruby -e "require 'yaml'; YAML.load_file('.github/workflows/phase5-nightly-validation-regression.yml'); puts 'yaml ok'"`
- `git diff --check`
- `rg -n "Setup Node.js|Install dependencies|Determine metrics URL|Probe metrics endpoint|Regression check skipped|steps\\.probe\\.outputs\\.available" .github/workflows/phase5-nightly-validation-regression.yml`
