### PR TITLE
fix(phase5): support authenticated metrics validation

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -44,8 +44,8 @@ This folder contains GitHub Actions that validate Phase 5 SLOs against a Prometh
 
 ## Required Secrets
 
- - `METRICS_URL`: e.g., `https://staging.example.com/metrics/prom`.
- - `METRICS_AUTH_HEADER` (optional): e.g., `Authorization: Bearer <token>`.
+ - `METRICS_URL` (optional for scheduled Phase 5 workflows when `METASHEET_BASE_URL` is set): e.g., `https://staging.example.com/metrics/prom`.
+ - `METRICS_AUTH_HEADER` (optional): e.g., `Authorization: Bearer <token>`. Scheduled Phase 5 workflows can derive this from `ATTENDANCE_ADMIN_JWT` only when they fall back to the trusted `METASHEET_BASE_URL` `/api/metrics/prom` endpoint.
  - `ALERTMANAGER_WEBHOOK_URL`, `ALERT_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, or `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL` (one optional webhook secret is used to self-heal on-prem Alertmanager config before DingTalk OAuth stability checks; `SLACK_WEBHOOK_URL` also powers older nightly notification workflows).
  - `SLACK_CHANNEL` (optional): e.g., `alerts`.
  - `GRAFANA_API_TOKEN` (ops deploy only, for dashboard upload).
@@ -121,7 +121,7 @@ REDIS_GET_P95_MAX=0.08 REDIS_SET_P95_MAX=0.08 bash scripts/phase5-regression-che
 ## Notes
 
 - If the metrics endpoint is unreachable or not configured, runs are marked as skipped and do not block PRs.
-- If the endpoint requires auth, set `METRICS_AUTH_HEADER` (full header string).
+- If the endpoint requires auth, set `METRICS_AUTH_HEADER` (full header string), or let scheduled Phase 5 runs use the existing `ATTENDANCE_ADMIN_JWT` fallback for the repository `METASHEET_BASE_URL` app metrics endpoint.
 - Validation scripts expect a Prometheus exposition at the given URL.
 - `phase5-ops-deploy.yml`
   - Manual dispatch for Prometheus rule + Grafana dashboard deployment.

--- a/.github/workflows/phase5-nightly-validation-regression.yml
+++ b/.github/workflows/phase5-nightly-validation-regression.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       metrics_url:
-        description: 'Override metrics URL (default http://localhost:8900/metrics/prom)'
+        description: 'Override metrics URL (default METRICS_URL or METASHEET_BASE_URL/api/metrics/prom)'
         required: false
 
 jobs:
@@ -18,20 +18,47 @@ jobs:
 
       - name: Determine metrics URL
         id: cfg
+        shell: bash
         env:
           METRICS_URL_SECRET: ${{ secrets.METRICS_URL }}
+          METRICS_AUTH_HEADER_SECRET: ${{ secrets.METRICS_AUTH_HEADER }}
+          ATTENDANCE_ADMIN_JWT: ${{ secrets.ATTENDANCE_ADMIN_JWT || vars.ATTENDANCE_ADMIN_JWT || '' }}
+          METASHEET_BASE_URL: ${{ vars.METASHEET_BASE_URL || vars.PUBLIC_APP_URL || vars.ATTENDANCE_WEB_BASE_URL || '' }}
         run: |
           URL_INPUT="${{ github.event.inputs.metrics_url }}"
+          URL_SOURCE=""
           if [ -n "$URL_INPUT" ]; then
-            echo "url=$URL_INPUT" >> $GITHUB_OUTPUT
+            URL="$URL_INPUT"
+            URL_SOURCE="input"
           elif [ -n "$METRICS_URL_SECRET" ]; then
-            echo "url=$METRICS_URL_SECRET" >> $GITHUB_OUTPUT
+            URL="$METRICS_URL_SECRET"
+            URL_SOURCE="secret"
+          elif [ -n "$METASHEET_BASE_URL" ]; then
+            URL="${METASHEET_BASE_URL%/}/api/metrics/prom"
+            URL_SOURCE="metasheet_base_url"
           else
-            echo "url=" >> $GITHUB_OUTPUT
+            URL=""
+          fi
+
+          echo "url=$URL" >> "$GITHUB_OUTPUT"
+          echo "source=$URL_SOURCE" >> "$GITHUB_OUTPUT"
+
+          AUTH_HEADER="$METRICS_AUTH_HEADER_SECRET"
+          if [ -z "$AUTH_HEADER" ] && [ "$URL_SOURCE" = "metasheet_base_url" ] && [ -n "$ATTENDANCE_ADMIN_JWT" ]; then
+            echo "::add-mask::$ATTENDANCE_ADMIN_JWT"
+            AUTH_HEADER="Authorization: Bearer $ATTENDANCE_ADMIN_JWT"
+          fi
+          if [ -n "$AUTH_HEADER" ]; then
+            echo "::add-mask::$AUTH_HEADER"
+            echo "METRICS_AUTH_HEADER=$AUTH_HEADER" >> "$GITHUB_ENV"
+            echo "auth_configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "auth_configured=false" >> "$GITHUB_OUTPUT"
           fi
 
       - name: Probe metrics endpoint
         id: probe
+        shell: bash
         run: |
           URL="${{ steps.cfg.outputs.url }}"
           if [ -z "$URL" ]; then
@@ -41,7 +68,11 @@ jobs:
             echo "Regression check skipped: no METRICS_URL provided." > /tmp/regression.txt
             exit 0
           fi
-          if curl -sSf -m 5 "$URL" >/dev/null; then
+          CURL_ARGS=(-sSf -m 5)
+          if [ -n "${METRICS_AUTH_HEADER:-}" ]; then
+            CURL_ARGS+=(-H "$METRICS_AUTH_HEADER")
+          fi
+          if curl "${CURL_ARGS[@]}" "$URL" >/dev/null; then
             echo "available=true" >> $GITHUB_OUTPUT
           else
             echo "available=false" >> $GITHUB_OUTPUT

--- a/.github/workflows/phase5-nightly-validation.yml
+++ b/.github/workflows/phase5-nightly-validation.yml
@@ -19,18 +19,50 @@ jobs:
 
       - name: Probe metrics URL
         id: probe
+        shell: bash
         env:
-          METRICS_URL: ${{ inputs.metrics_url || secrets.METRICS_URL }}
-          METRICS_AUTH_HEADER: ${{ secrets.METRICS_AUTH_HEADER }}
+          METRICS_URL_INPUT: ${{ inputs.metrics_url }}
+          METRICS_URL_SECRET: ${{ secrets.METRICS_URL }}
+          METRICS_AUTH_HEADER_SECRET: ${{ secrets.METRICS_AUTH_HEADER }}
+          ATTENDANCE_ADMIN_JWT: ${{ secrets.ATTENDANCE_ADMIN_JWT || vars.ATTENDANCE_ADMIN_JWT || '' }}
+          METASHEET_BASE_URL: ${{ vars.METASHEET_BASE_URL || vars.PUBLIC_APP_URL || vars.ATTENDANCE_WEB_BASE_URL || '' }}
         run: |
-          echo "metrics_url=${METRICS_URL}" >> $GITHUB_OUTPUT
+          URL_SOURCE=""
+          if [ -n "${METRICS_URL_INPUT}" ]; then
+            METRICS_URL="$METRICS_URL_INPUT"
+            URL_SOURCE="input"
+          elif [ -n "${METRICS_URL_SECRET}" ]; then
+            METRICS_URL="$METRICS_URL_SECRET"
+            URL_SOURCE="secret"
+          elif [ -n "${METASHEET_BASE_URL}" ]; then
+            METRICS_URL="${METASHEET_BASE_URL%/}/api/metrics/prom"
+            URL_SOURCE="metasheet_base_url"
+          else
+            METRICS_URL=""
+          fi
+
           if [ -z "${METRICS_URL}" ]; then
+            echo "metrics_url=" >> "$GITHUB_OUTPUT"
             echo "No METRICS_URL configured; skipping." && exit 0
           fi
-          if [ -n "${METRICS_AUTH_HEADER}" ]; then
-            curl -s -H "${METRICS_AUTH_HEADER}" "${METRICS_URL}" >/dev/null || exit 0
+
+          AUTH_HEADER="$METRICS_AUTH_HEADER_SECRET"
+          if [ -z "$AUTH_HEADER" ] && [ "$URL_SOURCE" = "metasheet_base_url" ] && [ -n "$ATTENDANCE_ADMIN_JWT" ]; then
+            echo "::add-mask::$ATTENDANCE_ADMIN_JWT"
+            AUTH_HEADER="Authorization: Bearer $ATTENDANCE_ADMIN_JWT"
+          fi
+          CURL_ARGS=(-sSf -m 5)
+          if [ -n "$AUTH_HEADER" ]; then
+            echo "::add-mask::$AUTH_HEADER"
+            echo "METRICS_AUTH_HEADER=$AUTH_HEADER" >> "$GITHUB_ENV"
+            CURL_ARGS+=(-H "$AUTH_HEADER")
+          fi
+
+          if curl "${CURL_ARGS[@]}" "${METRICS_URL}" >/dev/null; then
+            echo "metrics_url=${METRICS_URL}" >> "$GITHUB_OUTPUT"
           else
-            curl -s "${METRICS_URL}" >/dev/null || exit 0
+            echo "metrics_url=" >> "$GITHUB_OUTPUT"
+            echo "Metrics endpoint unreachable; skipping."
           fi
 
       - name: Setup Node
@@ -53,13 +85,8 @@ jobs:
         if: steps.probe.outputs.metrics_url != ''
         env:
           METRICS_URL: ${{ steps.probe.outputs.metrics_url }}
-          METRICS_AUTH_HEADER: ${{ secrets.METRICS_AUTH_HEADER }}
         run: |
           chmod +x scripts/phase5-full-validate.sh || true
-          if [ -n "${METRICS_AUTH_HEADER}" ]; then
-            # pass through via curl in script if needed
-            export METRICS_AUTH_HEADER
-          fi
           ./scripts/phase5-full-validate.sh -o /tmp/phase5.json "${METRICS_URL}" || true
           ./scripts/phase5-generate-report.sh /tmp/phase5.json /tmp/phase5.md || true
 

--- a/.github/workflows/phase5-nightly.yml
+++ b/.github/workflows/phase5-nightly.yml
@@ -12,21 +12,50 @@ on:
 jobs:
   validate:
     runs-on: ubuntu-latest
-    env:
-      METRICS_URL: ${{ github.event.inputs.metrics_url || secrets.METRICS_URL }}
-      METRICS_AUTH_HEADER: ${{ secrets.METRICS_AUTH_HEADER }}
     steps:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Ensure metrics URL configured
+      - name: Resolve metrics config
         shell: bash
+        env:
+          METRICS_URL_INPUT: ${{ github.event.inputs.metrics_url }}
+          METRICS_URL_SECRET: ${{ secrets.METRICS_URL }}
+          METRICS_AUTH_HEADER_SECRET: ${{ secrets.METRICS_AUTH_HEADER }}
+          ATTENDANCE_ADMIN_JWT: ${{ secrets.ATTENDANCE_ADMIN_JWT || vars.ATTENDANCE_ADMIN_JWT || '' }}
+          METASHEET_BASE_URL: ${{ vars.METASHEET_BASE_URL || vars.PUBLIC_APP_URL || vars.ATTENDANCE_WEB_BASE_URL || '' }}
         run: |
-          if [ -z "${METRICS_URL}" ]; then
+          URL_SOURCE=""
+          if [ -n "$METRICS_URL_INPUT" ]; then
+            URL="$METRICS_URL_INPUT"
+            URL_SOURCE="input"
+          elif [ -n "$METRICS_URL_SECRET" ]; then
+            URL="$METRICS_URL_SECRET"
+            URL_SOURCE="secret"
+          elif [ -n "$METASHEET_BASE_URL" ]; then
+            URL="${METASHEET_BASE_URL%/}/api/metrics/prom"
+            URL_SOURCE="metasheet_base_url"
+          else
+            URL=""
+          fi
+
+          if [ -z "$URL" ]; then
             echo "METRICS_URL not set via input or secret; skipping validation." > unreachable.txt
             echo "skip=true" >> $GITHUB_OUTPUT
           else
-            echo "Using METRICS_URL=${METRICS_URL}"
+            echo "METRICS_URL=$URL" >> "$GITHUB_ENV"
+            echo "skip=false" >> "$GITHUB_OUTPUT"
+            echo "Using METRICS_URL=${URL}"
+          fi
+
+          AUTH_HEADER="$METRICS_AUTH_HEADER_SECRET"
+          if [ -z "$AUTH_HEADER" ] && [ "$URL_SOURCE" = "metasheet_base_url" ] && [ -n "$ATTENDANCE_ADMIN_JWT" ]; then
+            echo "::add-mask::$ATTENDANCE_ADMIN_JWT"
+            AUTH_HEADER="Authorization: Bearer $ATTENDANCE_ADMIN_JWT"
+          fi
+          if [ -n "$AUTH_HEADER" ]; then
+            echo "::add-mask::$AUTH_HEADER"
+            echo "METRICS_AUTH_HEADER=$AUTH_HEADER" >> "$GITHUB_ENV"
           fi
         id: config
 
@@ -40,8 +69,8 @@ jobs:
             HDRS=( -H "${METRICS_AUTH_HEADER}" )
           fi
           # Try a quick HEAD, fall back to GET
-          if ! curl -sS -I "${METRICS_URL}" "${HDRS[@]}" | head -n 1 | grep -q "200"; then
-            if ! curl -sS "${METRICS_URL}" "${HDRS[@]}" | head -n 1 >/dev/null; then
+          if ! curl -sSf -I "${METRICS_URL}" "${HDRS[@]}" | head -n 1 | grep -q "200"; then
+            if ! curl -sSf "${METRICS_URL}" "${HDRS[@]}" | head -n 1 >/dev/null; then
               echo "Metrics endpoint unreachable: ${METRICS_URL}" > unreachable.txt
               echo "skip=true" >> $GITHUB_OUTPUT
             fi
@@ -62,14 +91,7 @@ jobs:
       - name: Run Phase 5 validation
         if: steps.config.outputs.skip != 'true' && steps.probe.outputs.skip != 'true'
         shell: bash
-        env:
-          METRICS_URL: ${{ env.METRICS_URL }}
-          METRICS_AUTH_HEADER: ${{ env.METRICS_AUTH_HEADER }}
         run: |
-          # Export auth header to scripts when supported
-          if [ -n "${METRICS_AUTH_HEADER}" ]; then
-            export EXTRA_CURL_HEADER="${METRICS_AUTH_HEADER}"
-          fi
           bash scripts/phase5-full-validate.sh "${METRICS_URL}" /tmp/phase5.json
           bash scripts/phase5-generate-report.sh /tmp/phase5.json /tmp/phase5.md
 

--- a/.github/workflows/phase5-validate.yml
+++ b/.github/workflows/phase5-validate.yml
@@ -17,15 +17,26 @@ jobs:
 
       - name: Determine metrics URL
         id: probe
+        shell: bash
         env:
           METRICS_URL: ${{ secrets.METRICS_URL }}
+          METRICS_AUTH_HEADER: ${{ secrets.METRICS_AUTH_HEADER }}
         run: |
-          echo "metrics_url=${METRICS_URL}" >> $GITHUB_OUTPUT
           if [ -z "${METRICS_URL}" ]; then
+            echo "metrics_url=" >> $GITHUB_OUTPUT
             echo "No METRICS_URL configured; marking as skipped." >> $GITHUB_STEP_SUMMARY
             exit 0
           fi
-          curl -s "${METRICS_URL}" >/dev/null || exit 0
+          CURL_ARGS=(-sSf -m 5)
+          if [ -n "${METRICS_AUTH_HEADER}" ]; then
+            CURL_ARGS+=(-H "${METRICS_AUTH_HEADER}")
+          fi
+          if curl "${CURL_ARGS[@]}" "${METRICS_URL}" >/dev/null; then
+            echo "metrics_url=${METRICS_URL}" >> $GITHUB_OUTPUT
+          else
+            echo "metrics_url=" >> $GITHUB_OUTPUT
+            echo "METRICS_URL unreachable; marking as skipped." >> $GITHUB_STEP_SUMMARY
+          fi
 
       - name: Setup Node
         if: steps.probe.outputs.metrics_url != ''

--- a/scripts/phase5-cache-audit.sh
+++ b/scripts/phase5-cache-audit.sh
@@ -10,25 +10,63 @@ MIN_TOTAL="${2:-50}"          # Only consider patterns with total >= MIN_TOTAL
 MAX_HIT_RATE="${3:-70}"       # Report patterns with hit rate <= MAX_HIT_RATE
 
 TMP=$(mktemp)
-curl -sf "$METRICS_URL" > "$TMP" || { echo "Failed to fetch metrics from $METRICS_URL" >&2; exit 1; }
+CURL_ARGS=(-sf)
+AUTH_HEADER="${METRICS_AUTH_HEADER:-${EXTRA_CURL_HEADER:-}}"
+if [ -n "$AUTH_HEADER" ]; then
+  CURL_ARGS+=(-H "$AUTH_HEADER")
+fi
+curl "${CURL_ARGS[@]}" "$METRICS_URL" > "$TMP" || { echo "Failed to fetch metrics from $METRICS_URL" >&2; exit 1; }
 
-declare -A hits misses
+keys=()
+hits=()
+misses=()
+HIT_RE='cache_hits_total\{impl="([^"]+)",key_pattern="([^"]+)"\} ([0-9]+)'
+MISS_RE='cache_miss_total\{impl="([^"]+)",key_pattern="([^"]+)"\} ([0-9]+)'
+
+set_count() {
+  local key="$1"
+  local kind="$2"
+  local value="$3"
+  local idx=-1
+  local i
+
+  for ((i=0; i<${#keys[@]}; i++)); do
+    if [ "${keys[$i]}" = "$key" ]; then
+      idx=$i
+      break
+    fi
+  done
+
+  if [ "$idx" -lt 0 ]; then
+    keys+=("$key")
+    hits+=(0)
+    misses+=(0)
+    idx=$((${#keys[@]} - 1))
+  fi
+
+  if [ "$kind" = "hit" ]; then
+    hits[$idx]="$value"
+  else
+    misses[$idx]="$value"
+  fi
+}
 
 while read -r line; do
-  if [[ $line =~ cache_hits_total\{impl="([^"]+)",key_pattern="([^"]+)"\}\ ([0-9]+) ]]; then
+  if [[ $line =~ $HIT_RE ]]; then
     impl="${BASH_REMATCH[1]}"; key="${BASH_REMATCH[2]}"; val="${BASH_REMATCH[3]}"
-    hits["$impl:$key"]=$val
-  elif [[ $line =~ cache_miss_total\{impl="([^"]+)",key_pattern="([^"]+)"\}\ ([0-9]+) ]]; then
+    set_count "$impl:$key" hit "$val"
+  elif [[ $line =~ $MISS_RE ]]; then
     impl="${BASH_REMATCH[1]}"; key="${BASH_REMATCH[2]}"; val="${BASH_REMATCH[3]}"
-    misses["$impl:$key"]=$val
+    set_count "$impl:$key" miss "$val"
   fi
 done < "$TMP"
 
 printf "[cache-audit] impl:key_pattern hits misses hit_rate total candidate\n"
 
-for k in "${!hits[@]}"; do
-  h=${hits[$k]:-0}
-  m=${misses[$k]:-0}
+for ((i=0; i<${#keys[@]}; i++)); do
+  k=${keys[$i]}
+  h=${hits[$i]:-0}
+  m=${misses[$i]:-0}
   total=$((h+m))
   if (( total < MIN_TOTAL )); then continue; fi
   rate=0

--- a/scripts/phase5-full-validate.sh
+++ b/scripts/phase5-full-validate.sh
@@ -41,10 +41,12 @@ readonly COUNT_CACHE_MISS_AS_FALLBACK="${COUNT_CACHE_MISS_AS_FALLBACK:-false}"
 # Usage
 usage() {
     echo "Usage: $0 <metrics-url> [output-json-path]"
+    echo "       $0 -o <output-json-path> <metrics-url>"
     echo ""
     echo "Examples:"
     echo "  $0 http://localhost:8900/metrics/prom"
     echo "  $0 http://localhost:8900/metrics/prom /tmp/validation.json"
+    echo "  $0 -o /tmp/validation.json http://localhost:8900/metrics/prom"
     exit 1
 }
 
@@ -63,6 +65,10 @@ log_warning() {
 
 log_error() {
     echo -e "${RED}[ERROR]${NC} $*" >&2
+}
+
+metrics_auth_header() {
+    printf '%s' "${METRICS_AUTH_HEADER:-${EXTRA_CURL_HEADER:-}}"
 }
 
 # Validate prerequisites
@@ -99,7 +105,14 @@ fetch_raw_metrics() {
 
     log_info "Fetching raw metrics from $metrics_url..."
 
-    if ! curl -fsS "$metrics_url" > "$temp_file"; then
+    local curl_args=(-fsS)
+    local auth_header
+    auth_header=$(metrics_auth_header)
+    if [ -n "$auth_header" ]; then
+        curl_args+=(-H "$auth_header")
+    fi
+
+    if ! curl "${curl_args[@]}" "$metrics_url" > "$temp_file"; then
         log_error "Failed to fetch metrics from $metrics_url"
         exit 1
     fi
@@ -109,7 +122,7 @@ fetch_raw_metrics() {
 
 # Resolve a TS runner (prefer pnpm workspace tsx, fallback to npx tsx)
 resolve_tsx_runner() {
-    if command -v pnpm >/dev/null 2>&1; then
+    if command -v pnpm >/dev/null 2>&1 && pnpm -F @metasheet/core-backend exec tsx --version >/dev/null 2>&1; then
         echo "pnpm -F @metasheet/core-backend exec tsx"
         return
     fi
@@ -431,12 +444,42 @@ EOF
 # Main validation logic
 main() {
     # Parse arguments
-    if [ $# -lt 1 ]; then
+    local metrics_url=""
+    local output_path=""
+
+    while [ $# -gt 0 ]; do
+        case "$1" in
+            -o|--output)
+                if [ $# -lt 2 ]; then
+                    usage
+                fi
+                output_path="$2"
+                shift 2
+                ;;
+            -h|--help)
+                usage
+                ;;
+            -*)
+                log_error "Unknown option: $1"
+                usage
+                ;;
+            *)
+                if [ -z "$metrics_url" ]; then
+                    metrics_url="$1"
+                elif [ -z "$output_path" ]; then
+                    output_path="$1"
+                else
+                    log_error "Unexpected extra argument: $1"
+                    usage
+                fi
+                shift
+                ;;
+        esac
+    done
+
+    if [ -z "$metrics_url" ]; then
         usage
     fi
-
-    local metrics_url="$1"
-    local output_path="${2:-}"
 
     validate_prerequisites
 

--- a/scripts/phase5-metrics-percentiles.ts
+++ b/scripts/phase5-metrics-percentiles.ts
@@ -48,14 +48,32 @@ interface MetricsOutput {
   };
 }
 
+function parseMetricsAuthHeader(): Record<string, string> | undefined {
+  const rawHeader = (process.env.METRICS_AUTH_HEADER || process.env.EXTRA_CURL_HEADER || '').trim();
+  if (!rawHeader) return undefined;
+
+  const separatorIndex = rawHeader.indexOf(':');
+  const name = rawHeader.slice(0, separatorIndex).trim();
+  const value = rawHeader.slice(separatorIndex + 1).trim();
+
+  if (separatorIndex <= 0 || !name || !value) {
+    throw new Error('METRICS_AUTH_HEADER must use "Name: value" format');
+  }
+
+  return { [name]: value };
+}
+
 /**
  * Fetch metrics from Prometheus endpoint
  */
 async function fetchMetrics(url: string): Promise<string> {
   return new Promise((resolve, reject) => {
     const client = url.startsWith('https') ? https : http;
+    const requestOptions = {
+      headers: parseMetricsAuthHeader() || {},
+    };
 
-    const req = client.get(url, (res) => {
+    const req = client.get(url, requestOptions, (res) => {
       let data = '';
 
       res.on('data', (chunk) => {
@@ -338,6 +356,7 @@ export {
   parsePrometheusMetrics,
   calculatePercentile,
   calculatePercentiles,
+  parseMetricsAuthHeader,
   filterHistograms,
   type Histogram,
   type PercentileResult,


### PR DESCRIPTION
## Summary

This PR removes another Phase 5 validation-path blocker for issue #1 without treating #1 as complete.

- Make `scripts/phase5-full-validate.sh` send `METRICS_AUTH_HEADER` / `EXTRA_CURL_HEADER` to the raw metrics curl fetch.
- Make `scripts/phase5-metrics-percentiles.ts` use the same auth header for histogram percentile fetching.
- Keep the existing `-o /tmp/phase5.json <url>` workflow call shape working by adding `-o|--output` parsing.
- Make Phase 5 workflows probe with real HTTP failure handling (`curl -f`) and authenticated headers.
- Let scheduled Phase 5 workflows fall back to `${METASHEET_BASE_URL}/api/metrics/prom` and derive `Authorization: Bearer <ATTENDANCE_ADMIN_JWT>` only for that trusted repository app URL fallback. Manual/secret URL overrides do not receive the admin JWT fallback.
- Let `phase5-cache-audit.sh` fetch authenticated metrics and run on the local macOS Bash 3.2 as well as Ubuntu Bash.

## Boundary

This is validation plumbing for #1, not close-out evidence. #1 should remain open until a main-branch Phase 5 run executes against reachable production metrics and uploads non-fallback JSON/Markdown artifacts.

## Verification

- `bash -n scripts/phase5-full-validate.sh && bash -n scripts/phase5-cache-audit.sh`
- `git diff --check`
- `ruby -e 'require "yaml"; ARGV.each { |path| YAML.load_file(path); puts "ok #{path}" }' .github/workflows/phase5-nightly-validation-regression.yml .github/workflows/phase5-nightly-validation.yml .github/workflows/phase5-nightly.yml .github/workflows/phase5-validate.yml`
- Local protected metrics smoke:
  - no auth: `phase5-full-validate.sh` fails to fetch metrics
  - with `METRICS_AUTH_HEADER`: full Phase 5 validation returns PASS, 11/11 checks
  - with `METRICS_AUTH_HEADER`: `phase5-cache-audit.sh` fetches and summarizes cache metrics
