### PR TITLE
feat(attendance): admin workbench T2 — create scheduler scope (free-text targets)

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1307,6 +1307,80 @@
               <p class="attendance__scheduler-scope-notice" data-attendance-scheduler-scopes-intent>
                 {{ tr('These scopes are an administrative registry only and are not yet enforced at runtime. Runtime enforcement is a separate later capability.', '此处仅为管理登记，运行时尚未强制执行；运行时强制为后续独立能力。') }}
               </p>
+              <form class="attendance__scheduler-scope-form" data-attendance-scheduler-scope-form @submit.prevent="createSchedulerScope">
+                <h5>{{ tr('New scope', '新建范围') }}</h5>
+                <div class="attendance__admin-grid">
+                  <label class="attendance__field" for="attendance-scheduler-scope-subject-type">
+                    <span>{{ tr('Subject type', '主体类型') }}</span>
+                    <select id="attendance-scheduler-scope-subject-type" v-model="schedulerScopeForm.subjectType">
+                      <option value="user">{{ tr('Employee', '员工') }}</option>
+                      <option value="role">{{ tr('Role', '角色') }}</option>
+                      <option value="role_tag">{{ tr('Role tag', '角色标签') }}</option>
+                    </select>
+                  </label>
+                  <AttendanceUserPickerField
+                    v-if="schedulerScopeForm.subjectType === 'user'"
+                    v-model="schedulerScopeForm.subjectRef"
+                    :tr="tr"
+                    :label="tr('Subject user', '主体用户')"
+                    name="attendanceSchedulerScopeSubject"
+                    :search-placeholder="tr('Search the subject user', '搜索主体用户')"
+                    input-id="attendance-scheduler-scope-subject-ref"
+                  />
+                  <label v-else class="attendance__field" for="attendance-scheduler-scope-subject-ref">
+                    <span>{{ tr('Subject (role / role tag)', '主体（角色 / 角色标签）') }}</span>
+                    <input
+                      id="attendance-scheduler-scope-subject-ref"
+                      v-model="schedulerScopeForm.subjectRef"
+                      type="text"
+                      :placeholder="tr('e.g. attendance_admin', '如 attendance_admin')"
+                    />
+                  </label>
+                </div>
+                <fieldset class="attendance__scheduler-scope-actions-field" data-attendance-scheduler-scope-actions>
+                  <legend>{{ tr('Actions', '动作') }}</legend>
+                  <label
+                    v-for="action in ATTENDANCE_SCHEDULER_SCOPE_ALL_ACTIONS"
+                    :key="action"
+                    class="attendance__field attendance__field--checkbox"
+                  >
+                    <input type="checkbox" :value="action" v-model="schedulerScopeForm.actions" :data-action="action" />
+                    <span>{{ schedulerScopeActionLabel(action) }}</span>
+                  </label>
+                </fieldset>
+                <div class="attendance__admin-grid">
+                  <label class="attendance__field" for="attendance-scheduler-scope-target-departments">
+                    <span>{{ tr('Departments', '部门') }}</span>
+                    <textarea id="attendance-scheduler-scope-target-departments" v-model="schedulerScopeForm.departments" rows="1" :placeholder="tr('dept-a, dept-b', 'dept-a, dept-b')"></textarea>
+                  </label>
+                  <label class="attendance__field" for="attendance-scheduler-scope-target-attendance-groups">
+                    <span>{{ tr('Attendance groups', '考勤组') }}</span>
+                    <textarea id="attendance-scheduler-scope-target-attendance-groups" v-model="schedulerScopeForm.attendanceGroupIds" rows="1" :placeholder="tr('attendance group id(s)', '考勤组 ID')"></textarea>
+                  </label>
+                  <label class="attendance__field" for="attendance-scheduler-scope-target-schedule-groups">
+                    <span>{{ tr('Schedule groups', '排班组') }}</span>
+                    <textarea id="attendance-scheduler-scope-target-schedule-groups" v-model="schedulerScopeForm.scheduleGroupIds" rows="1" :placeholder="tr('schedule group id(s)', '排班组 ID')"></textarea>
+                  </label>
+                  <label class="attendance__field" for="attendance-scheduler-scope-target-users">
+                    <span>{{ tr('Users', '员工') }}</span>
+                    <textarea id="attendance-scheduler-scope-target-users" v-model="schedulerScopeForm.userIds" rows="1" :placeholder="tr('user id(s)', '员工 ID')"></textarea>
+                  </label>
+                  <label class="attendance__field" for="attendance-scheduler-scope-target-roles">
+                    <span>{{ tr('Roles', '角色') }}</span>
+                    <textarea id="attendance-scheduler-scope-target-roles" v-model="schedulerScopeForm.roles" rows="1" :placeholder="tr('role(s)', '角色')"></textarea>
+                  </label>
+                  <label class="attendance__field" for="attendance-scheduler-scope-target-role-tags">
+                    <span>{{ tr('Role tags', '角色标签') }}</span>
+                    <textarea id="attendance-scheduler-scope-target-role-tags" v-model="schedulerScopeForm.roleTags" rows="1" :placeholder="tr('role tag(s)', '角色标签')"></textarea>
+                  </label>
+                </div>
+                <p class="attendance__field-hint">
+                  {{ tr('Separate multiple IDs with commas or new lines. At least one target and one action are required. Picker-based targets land in a later slice; this slice accepts free-text.', '多个 ID 用逗号或换行分隔；至少需要一个目标和一个动作。下拉选择器在后续切片提供，本切片用 free-text。') }}
+                </p>
+                <button type="submit" class="attendance__btn" :disabled="schedulerScopeCreating" data-attendance-scheduler-scope-create>
+                  {{ schedulerScopeCreating ? tr('Creating...', '创建中...') : tr('Create scope', '创建范围') }}
+                </button>
+              </form>
               <div v-if="!schedulerScopesLoading && schedulerScopes.length === 0" class="attendance__empty">
                 {{ tr('No scheduler scopes yet.', '暂无排班管理范围记录。') }}
               </div>
@@ -7833,6 +7907,26 @@ type AttendanceSchedulerScope = {
 const schedulerScopes = ref<AttendanceSchedulerScope[]>([])
 const schedulerScopesLoading = ref(false)
 const schedulerScopesTotal = ref(0)
+const ATTENDANCE_SCHEDULER_SCOPE_ALL_ACTIONS = ['view', 'edit', 'import', 'export', 'clear', 'approve', 'dispatch'] as const
+// T2 "new scope" create form. Targets are free-text (comma / new-line) this slice; each field
+// maps to one scope key — picker-based targets land in a later slice.
+const schedulerScopeForm = reactive({
+  subjectType: 'user' as 'user' | 'role' | 'role_tag',
+  subjectRef: '',
+  actions: [] as string[],
+  scheduleGroupIds: '',
+  attendanceGroupIds: '',
+  userIds: '',
+  departments: '',
+  roles: '',
+  roleTags: '',
+})
+const schedulerScopeCreating = ref(false)
+// Subject ref is type-specific (a user UUID via the picker vs a role/role-tag string); clear it
+// on type change so a picked user UUID can't be submitted as a role string.
+watch(() => schedulerScopeForm.subjectType, () => {
+  schedulerScopeForm.subjectRef = ''
+})
 const defaultTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
 const timezoneOptions = computed(() =>
   buildTimezoneOptions([defaultTimezone, 'UTC', 'Asia/Shanghai', 'America/Los_Angeles', 'America/New_York'])
@@ -18844,6 +18938,69 @@ function normalizeSchedulerScope(value: unknown): AttendanceSchedulerScope | nul
 // Read-only registry of scheduler scopes (T1). Mirrors loadAttendanceGroups: defensive,
 // 403 -> adminForbidden, non-ok -> caught. Scopes are administrative intent and are NOT
 // enforced at runtime yet (see design-lock §5); the section banner says so.
+// Create one scheduler scope (T2, create-only). Maps the 6 free-text target fields to the 6
+// scope keys (names MUST match the backend normalizer; a wrong key is silently dropped).
+// Mirrors the backend validation (>=1 action, >=1 target) client-side before POSTing.
+async function createSchedulerScope() {
+  const subjectRef = schedulerScopeForm.subjectRef.trim()
+  if (!subjectRef) {
+    setStatus(tr('Enter a subject for the scope.', '请填写范围主体。'), 'error')
+    return
+  }
+  const actions = [...schedulerScopeForm.actions]
+  if (actions.length === 0) {
+    setStatus(tr('Select at least one action.', '请至少选择一个动作。'), 'error')
+    return
+  }
+  const scope = {
+    scheduleGroupIds: parseUserIdList(schedulerScopeForm.scheduleGroupIds),
+    attendanceGroupIds: parseUserIdList(schedulerScopeForm.attendanceGroupIds),
+    userIds: parseUserIdList(schedulerScopeForm.userIds),
+    departments: parseUserIdList(schedulerScopeForm.departments),
+    roles: parseUserIdList(schedulerScopeForm.roles),
+    roleTags: parseUserIdList(schedulerScopeForm.roleTags),
+  }
+  if (!Object.values(scope).some(ids => ids.length > 0)) {
+    setStatus(tr('Add at least one scope target.', '请至少添加一个范围目标。'), 'error')
+    return
+  }
+  schedulerScopeCreating.value = true
+  try {
+    const response = await apiFetch('/api/attendance/scheduler-scopes', {
+      method: 'POST',
+      body: JSON.stringify({
+        subjectType: schedulerScopeForm.subjectType,
+        subjectRef,
+        actions,
+        scope,
+        orgId: normalizedOrgId(),
+      }),
+    })
+    if (response.status === 403) {
+      adminForbidden.value = true
+      return
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to create scheduler scope', '创建排班管理范围失败')))
+    }
+    schedulerScopeForm.subjectRef = ''
+    schedulerScopeForm.actions = []
+    schedulerScopeForm.scheduleGroupIds = ''
+    schedulerScopeForm.attendanceGroupIds = ''
+    schedulerScopeForm.userIds = ''
+    schedulerScopeForm.departments = ''
+    schedulerScopeForm.roles = ''
+    schedulerScopeForm.roleTags = ''
+    setStatus(tr('Scheduler scope created.', '已创建排班管理范围。'), 'info')
+    await loadSchedulerScopes()
+  } catch (error: unknown) {
+    setStatus(readErrorMessage(error, tr('Failed to create scheduler scope', '创建排班管理范围失败')), 'error')
+  } finally {
+    schedulerScopeCreating.value = false
+  }
+}
+
 async function loadSchedulerScopes() {
   schedulerScopesLoading.value = true
   try {
@@ -21565,5 +21722,31 @@ const holidaySectionBindings = {
   margin: 10px 0 0;
   font-size: 12px;
   color: #8a6d3b;
+}
+.attendance__scheduler-scope-form {
+  margin: 0 0 16px;
+  padding: 12px;
+  border: 1px solid #e3e8ef;
+  border-radius: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 10px;
+}
+.attendance__scheduler-scope-form h5 {
+  margin: 0;
+}
+.attendance__scheduler-scope-actions-field {
+  margin: 0;
+  border: 1px solid #e3e8ef;
+  border-radius: 6px;
+  padding: 8px 10px;
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+}
+.attendance__scheduler-scope-actions-field legend {
+  padding: 0 4px;
+  font-size: 12px;
+  color: #5b6b7b;
 }
 </style>

--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1375,7 +1375,7 @@
                   </label>
                 </div>
                 <p class="attendance__field-hint">
-                  {{ tr('Separate multiple IDs with commas or new lines. At least one target and one action are required. Picker-based targets land in a later slice; this slice accepts free-text.', '多个 ID 用逗号或换行分隔；至少需要一个目标和一个动作。下拉选择器在后续切片提供，本切片用 free-text。') }}
+                  {{ tr('Separate multiple values with commas or new lines. At least one target and one action are required.', '多个值用逗号或换行分隔；至少需要一个目标和一个动作。') }}
                 </p>
                 <button type="submit" class="attendance__btn" :disabled="schedulerScopeCreating" data-attendance-scheduler-scope-create>
                   {{ schedulerScopeCreating ? tr('Creating...', '创建中...') : tr('Create scope', '创建范围') }}
@@ -18966,14 +18966,16 @@ async function createSchedulerScope() {
   }
   schedulerScopeCreating.value = true
   try {
-    const response = await apiFetch('/api/attendance/scheduler-scopes', {
+    // orgId rides the query string (same as the GET); the POST body must match the backend's
+    // .strict() schedulerScopeCreateSchema exactly — an extra key (incl. orgId) is a 400.
+    const query = buildQuery({ orgId: normalizedOrgId() })
+    const response = await apiFetch(`/api/attendance/scheduler-scopes?${query.toString()}`, {
       method: 'POST',
       body: JSON.stringify({
         subjectType: schedulerScopeForm.subjectType,
         subjectRef,
         actions,
         scope,
-        orgId: normalizedOrgId(),
       }),
     })
     if (response.status === 403) {

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -744,6 +744,135 @@ describe('Attendance admin regressions', () => {
     expect(hint?.textContent || '').toContain('250')
   })
 
+  it('creates a scheduler scope, mapping each free-text target field to its scope key', async () => {
+    const created: Array<Record<string, unknown>> = []
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      const method = String((init as { method?: string } | undefined)?.method || 'GET').toUpperCase()
+      if (url.includes('/api/attendance/scheduler-scopes') && method === 'POST') {
+        created.push(JSON.parse(String((init as { body?: string } | undefined)?.body || '{}')))
+        return jsonResponse(200, { ok: true, data: { id: 'scope-new' } })
+      }
+      if (url.includes('/api/attendance/scheduler-scopes')) {
+        return jsonResponse(200, { ok: true, data: { items: [], total: 0, page: 1, pageSize: 200 } })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-scheduler-scopes"]')!.click()
+    await flushUi(4)
+
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-scheduler-scopes')!
+    const subjectType = section.querySelector<HTMLSelectElement>('#attendance-scheduler-scope-subject-type')!
+    subjectType.value = 'role'
+    subjectType.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+    const subjectRef = section.querySelector<HTMLInputElement>('#attendance-scheduler-scope-subject-ref')!
+    subjectRef.value = 'attendance_admin'
+    subjectRef.dispatchEvent(new Event('input', { bubbles: true }))
+    section.querySelector<HTMLInputElement>('[data-attendance-scheduler-scope-actions] input[data-action="view"]')!.click()
+
+    // Distinct sentinel per target field — catches a field wired to the wrong scope key
+    // (the backend normalizer silently drops unknown keys; this is the A2 round-trip guard).
+    const setTarget = (id: string, value: string): void => {
+      const el = section.querySelector<HTMLTextAreaElement>(`#${id}`)!
+      el.value = value
+      el.dispatchEvent(new Event('input', { bubbles: true }))
+    }
+    setTarget('attendance-scheduler-scope-target-departments', 'dept-x')
+    setTarget('attendance-scheduler-scope-target-attendance-groups', 'ag-x')
+    setTarget('attendance-scheduler-scope-target-schedule-groups', 'sg-x')
+    setTarget('attendance-scheduler-scope-target-users', 'user-x')
+    setTarget('attendance-scheduler-scope-target-roles', 'role-x')
+    setTarget('attendance-scheduler-scope-target-role-tags', 'tag-x')
+    await flushUi(2)
+
+    section.querySelector<HTMLButtonElement>('[data-attendance-scheduler-scope-create]')!.click()
+    await flushUi(4)
+
+    expect(created).toHaveLength(1)
+    expect(created[0]).toMatchObject({
+      subjectType: 'role',
+      subjectRef: 'attendance_admin',
+      actions: ['view'],
+      scope: {
+        departments: ['dept-x'],
+        attendanceGroupIds: ['ag-x'],
+        scheduleGroupIds: ['sg-x'],
+        userIds: ['user-x'],
+        roles: ['role-x'],
+        roleTags: ['tag-x'],
+      },
+    })
+  })
+
+  it('refuses to create a scheduler scope without a target and explains why', async () => {
+    const posts: unknown[] = []
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      const method = String((init as { method?: string } | undefined)?.method || 'GET').toUpperCase()
+      if (url.includes('/api/attendance/scheduler-scopes') && method === 'POST') {
+        posts.push(1)
+        return jsonResponse(200, { ok: true, data: {} })
+      }
+      if (url.includes('/api/attendance/scheduler-scopes')) {
+        return jsonResponse(200, { ok: true, data: { items: [], total: 0, page: 1, pageSize: 200 } })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-scheduler-scopes"]')!.click()
+    await flushUi(4)
+
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-scheduler-scopes')!
+    const subjectType = section.querySelector<HTMLSelectElement>('#attendance-scheduler-scope-subject-type')!
+    subjectType.value = 'role'
+    subjectType.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+    const subjectRef = section.querySelector<HTMLInputElement>('#attendance-scheduler-scope-subject-ref')!
+    subjectRef.value = 'attendance_admin'
+    subjectRef.dispatchEvent(new Event('input', { bubbles: true }))
+    section.querySelector<HTMLInputElement>('[data-attendance-scheduler-scope-actions] input[data-action="view"]')!.click()
+    await flushUi(2)
+
+    // No targets entered → client guard blocks the POST.
+    section.querySelector<HTMLButtonElement>('[data-attendance-scheduler-scope-create]')!.click()
+    await flushUi(4)
+
+    expect(posts).toEqual([])
+    expect(container!.textContent).toContain('Add at least one scope target')
+  })
+
+  it('clears the scheduler scope subject ref when the subject type changes', async () => {
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-scheduler-scopes"]')!.click()
+    await flushUi(4)
+
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-scheduler-scopes')!
+    const subjectType = section.querySelector<HTMLSelectElement>('#attendance-scheduler-scope-subject-type')!
+    subjectType.value = 'role'
+    subjectType.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+    const subjectRef = section.querySelector<HTMLInputElement>('#attendance-scheduler-scope-subject-ref')!
+    subjectRef.value = 'some-role'
+    subjectRef.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi(1)
+
+    subjectType.value = 'role_tag'
+    subjectType.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+
+    expect(section.querySelector<HTMLInputElement>('#attendance-scheduler-scope-subject-ref')!.value).toBe('')
+  })
+
   it('keeps the clicked admin section focused and retires the show-all toggle', async () => {
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -794,7 +794,9 @@ describe('Attendance admin regressions', () => {
     await flushUi(4)
 
     expect(created).toHaveLength(1)
-    expect(created[0]).toMatchObject({
+    // toEqual (not toMatchObject) so an extra body key — e.g. a re-added orgId, which the
+    // backend's .strict() schema rejects with 400 — fails the test instead of slipping through.
+    expect(created[0]).toEqual({
       subjectType: 'role',
       subjectRef: 'attendance_admin',
       actions: ['view'],


### PR DESCRIPTION
## What
**T2: the first edit capability** for the attendance-admin workbench (after read-only T1 #2067). A **"New scope"** form in the scheduler-scope section lets an admin create a scope end-to-end.

- **Subject**: type select (user / role / role_tag) + `subjectRef` — reuses `AttendanceUserPickerField` when type=user (avoids pasting UUIDs), free-text otherwise. `subjectRef` is **cleared on type change** (so a picked user UUID can't be POSTed as a role string).
- **7 action checkboxes**.
- **6 free-text target fields** (comma / new-line), each mapped to one `scope` key (`scheduleGroupIds`/`attendanceGroupIds`/`userIds`/`departments`/`roles`/`roleTags`).
- **Client validation** mirroring the backend (≥1 action, ≥1 target) → POST `/api/attendance/scheduler-scopes` → reload the read-only list.

## Scope (deliberately bounded)
Create-only. **Deferred to follow-ups**: edit/delete (PUT/DELETE), **picker-based targets** (user-search chips, group multi-select), enforcement.

> **Pre-empting a likely review note**: the **subject user** uses the picker, but the `userIds` **target** field is **free-text this slice** — consistent with the existing calendar-policy-override convention, and 4/6 targets have no catalog to pick from anyway. Proper target pickers are the next UX slice; this keeps the create slice minimal.

## Tests (in the gated `attendance-admin-regressions.spec.ts`)
- **create maps each free-text field to its scope key** — a *distinct sentinel per field*, asserting the full POST `scope` object. This guards the silent-drop surface (a field wired to the wrong key → backend drops it) called out in the design-lock A2.
- refuses to POST with no target + explains why.
- clears `subjectRef` on subject-type change.

## Verification
`vue-tsc -b` clean; both gated specs green (**regressions 49/49**, **anchor-nav 30/30**); ~312 net lines (under the 600 budget).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
