### PR TITLE
fix(phase5): derive metrics auth from deploy token

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -45,12 +45,12 @@ This folder contains GitHub Actions that validate Phase 5 SLOs against a Prometh
 ## Required Secrets
 
  - `METRICS_URL` (optional for scheduled Phase 5 workflows when `METASHEET_BASE_URL` is set): e.g., `https://staging.example.com/metrics/prom`.
- - `METRICS_AUTH_HEADER` (optional): e.g., `Authorization: Bearer <token>`. Scheduled Phase 5 workflows can derive this from `ATTENDANCE_ADMIN_JWT` only when they fall back to the trusted `METASHEET_BASE_URL` `/api/metrics/prom` endpoint.
+ - `METRICS_AUTH_HEADER` (optional): e.g., `Authorization: Bearer <token>`. Scheduled Phase 5 workflows can derive this from the deploy-host backend `METRICS_SCRAPE_TOKEN` only when they fall back to the trusted `METASHEET_BASE_URL` `/api/metrics/prom` endpoint.
  - `ALERTMANAGER_WEBHOOK_URL`, `ALERT_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, or `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL` (one optional webhook secret is used to self-heal on-prem Alertmanager config before DingTalk OAuth stability checks; `SLACK_WEBHOOK_URL` also powers older nightly notification workflows).
  - `SLACK_CHANNEL` (optional): e.g., `alerts`.
  - `GRAFANA_API_TOKEN` (ops deploy only, for dashboard upload).
  - `REDIS_URL` (optional: enables Redis-backed cache validation).
- - `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY_B64` (required for `dingtalk-oauth-stability-recording-lite.yml`).
+ - `DEPLOY_HOST`, `DEPLOY_USER`, `DEPLOY_SSH_KEY_B64` (required for `dingtalk-oauth-stability-recording-lite.yml`; optional fallback inputs for scheduled Phase 5 app metrics auth).
 
 ## Runtime Readiness
 ```bash
@@ -121,7 +121,7 @@ REDIS_GET_P95_MAX=0.08 REDIS_SET_P95_MAX=0.08 bash scripts/phase5-regression-che
 ## Notes
 
 - If the metrics endpoint is unreachable or not configured, runs are marked as skipped and do not block PRs.
-- If the endpoint requires auth, set `METRICS_AUTH_HEADER` (full header string), or let scheduled Phase 5 runs use the existing `ATTENDANCE_ADMIN_JWT` fallback for the repository `METASHEET_BASE_URL` app metrics endpoint.
+- If the endpoint requires auth, set `METRICS_AUTH_HEADER` (full header string), or let scheduled Phase 5 runs use the deploy-host `METRICS_SCRAPE_TOKEN` fallback for the repository `METASHEET_BASE_URL` app metrics endpoint.
 - Validation scripts expect a Prometheus exposition at the given URL.
 - `phase5-ops-deploy.yml`
   - Manual dispatch for Prometheus rule + Grafana dashboard deployment.

--- a/.github/workflows/phase5-nightly-validation-regression.yml
+++ b/.github/workflows/phase5-nightly-validation-regression.yml
@@ -22,8 +22,12 @@ jobs:
         env:
           METRICS_URL_SECRET: ${{ secrets.METRICS_URL }}
           METRICS_AUTH_HEADER_SECRET: ${{ secrets.METRICS_AUTH_HEADER }}
-          ATTENDANCE_ADMIN_JWT: ${{ secrets.ATTENDANCE_ADMIN_JWT || vars.ATTENDANCE_ADMIN_JWT || '' }}
           METASHEET_BASE_URL: ${{ vars.METASHEET_BASE_URL || vars.PUBLIC_APP_URL || vars.ATTENDANCE_WEB_BASE_URL || '' }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
         run: |
           URL_INPUT="${{ github.event.inputs.metrics_url }}"
           URL_SOURCE=""
@@ -44,9 +48,18 @@ jobs:
           echo "source=$URL_SOURCE" >> "$GITHUB_OUTPUT"
 
           AUTH_HEADER="$METRICS_AUTH_HEADER_SECRET"
-          if [ -z "$AUTH_HEADER" ] && [ "$URL_SOURCE" = "metasheet_base_url" ] && [ -n "$ATTENDANCE_ADMIN_JWT" ]; then
-            echo "::add-mask::$ATTENDANCE_ADMIN_JWT"
-            AUTH_HEADER="Authorization: Bearer $ATTENDANCE_ADMIN_JWT"
+          if [ -z "$AUTH_HEADER" ] && [ "$URL_SOURCE" = "metasheet_base_url" ]; then
+            token_fallback_log="/tmp/phase5-metrics-token-fallback.log"
+            set +e
+            metrics_token="$(METRICS_SCRAPE_TOKEN_RESOLVE_REQUIRED=false bash scripts/ops/resolve-metrics-scrape-token.sh 2> >(tee "$token_fallback_log" >&2))"
+            token_resolve_status=$?
+            set -e
+            if [ "$token_resolve_status" -ne 0 ]; then
+              echo "::warning::deploy-host metrics token fallback failed (exit $token_resolve_status); metrics probe will continue without derived auth"
+            elif [ -n "$metrics_token" ]; then
+              echo "::add-mask::$metrics_token"
+              AUTH_HEADER="Authorization: Bearer $metrics_token"
+            fi
           fi
           if [ -n "$AUTH_HEADER" ]; then
             echo "::add-mask::$AUTH_HEADER"
@@ -133,6 +146,7 @@ jobs:
             /tmp/phase5.json
             /tmp/phase5.md
             /tmp/regression.txt
+            /tmp/phase5-metrics-token-fallback.log
 
       - name: Stage nightly JSON for repository trend tracking
         if: success() && steps.probe.outputs.available == 'true'

--- a/.github/workflows/phase5-nightly-validation.yml
+++ b/.github/workflows/phase5-nightly-validation.yml
@@ -24,8 +24,12 @@ jobs:
           METRICS_URL_INPUT: ${{ inputs.metrics_url }}
           METRICS_URL_SECRET: ${{ secrets.METRICS_URL }}
           METRICS_AUTH_HEADER_SECRET: ${{ secrets.METRICS_AUTH_HEADER }}
-          ATTENDANCE_ADMIN_JWT: ${{ secrets.ATTENDANCE_ADMIN_JWT || vars.ATTENDANCE_ADMIN_JWT || '' }}
           METASHEET_BASE_URL: ${{ vars.METASHEET_BASE_URL || vars.PUBLIC_APP_URL || vars.ATTENDANCE_WEB_BASE_URL || '' }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
         run: |
           URL_SOURCE=""
           if [ -n "${METRICS_URL_INPUT}" ]; then
@@ -47,9 +51,18 @@ jobs:
           fi
 
           AUTH_HEADER="$METRICS_AUTH_HEADER_SECRET"
-          if [ -z "$AUTH_HEADER" ] && [ "$URL_SOURCE" = "metasheet_base_url" ] && [ -n "$ATTENDANCE_ADMIN_JWT" ]; then
-            echo "::add-mask::$ATTENDANCE_ADMIN_JWT"
-            AUTH_HEADER="Authorization: Bearer $ATTENDANCE_ADMIN_JWT"
+          if [ -z "$AUTH_HEADER" ] && [ "$URL_SOURCE" = "metasheet_base_url" ]; then
+            token_fallback_log="/tmp/phase5-metrics-token-fallback.log"
+            set +e
+            metrics_token="$(METRICS_SCRAPE_TOKEN_RESOLVE_REQUIRED=false bash scripts/ops/resolve-metrics-scrape-token.sh 2> >(tee "$token_fallback_log" >&2))"
+            token_resolve_status=$?
+            set -e
+            if [ "$token_resolve_status" -ne 0 ]; then
+              echo "::warning::deploy-host metrics token fallback failed (exit $token_resolve_status); metrics probe will continue without derived auth"
+            elif [ -n "$metrics_token" ]; then
+              echo "::add-mask::$metrics_token"
+              AUTH_HEADER="Authorization: Bearer $metrics_token"
+            fi
           fi
           CURL_ARGS=(-sSf -m 5)
           if [ -n "$AUTH_HEADER" ]; then

--- a/.github/workflows/phase5-nightly.yml
+++ b/.github/workflows/phase5-nightly.yml
@@ -22,8 +22,12 @@ jobs:
           METRICS_URL_INPUT: ${{ github.event.inputs.metrics_url }}
           METRICS_URL_SECRET: ${{ secrets.METRICS_URL }}
           METRICS_AUTH_HEADER_SECRET: ${{ secrets.METRICS_AUTH_HEADER }}
-          ATTENDANCE_ADMIN_JWT: ${{ secrets.ATTENDANCE_ADMIN_JWT || vars.ATTENDANCE_ADMIN_JWT || '' }}
           METASHEET_BASE_URL: ${{ vars.METASHEET_BASE_URL || vars.PUBLIC_APP_URL || vars.ATTENDANCE_WEB_BASE_URL || '' }}
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
         run: |
           URL_SOURCE=""
           if [ -n "$METRICS_URL_INPUT" ]; then
@@ -49,9 +53,18 @@ jobs:
           fi
 
           AUTH_HEADER="$METRICS_AUTH_HEADER_SECRET"
-          if [ -z "$AUTH_HEADER" ] && [ "$URL_SOURCE" = "metasheet_base_url" ] && [ -n "$ATTENDANCE_ADMIN_JWT" ]; then
-            echo "::add-mask::$ATTENDANCE_ADMIN_JWT"
-            AUTH_HEADER="Authorization: Bearer $ATTENDANCE_ADMIN_JWT"
+          if [ -z "$AUTH_HEADER" ] && [ "$URL_SOURCE" = "metasheet_base_url" ]; then
+            token_fallback_log="/tmp/phase5-metrics-token-fallback.log"
+            set +e
+            metrics_token="$(METRICS_SCRAPE_TOKEN_RESOLVE_REQUIRED=false bash scripts/ops/resolve-metrics-scrape-token.sh 2> >(tee "$token_fallback_log" >&2))"
+            token_resolve_status=$?
+            set -e
+            if [ "$token_resolve_status" -ne 0 ]; then
+              echo "::warning::deploy-host metrics token fallback failed (exit $token_resolve_status); metrics probe will continue without derived auth"
+            elif [ -n "$metrics_token" ]; then
+              echo "::add-mask::$metrics_token"
+              AUTH_HEADER="Authorization: Bearer $metrics_token"
+            fi
           fi
           if [ -n "$AUTH_HEADER" ]; then
             echo "::add-mask::$AUTH_HEADER"

--- a/scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
+++ b/scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
@@ -1,0 +1,38 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+
+const workflowPaths = [
+  '.github/workflows/phase5-nightly-validation-regression.yml',
+  '.github/workflows/phase5-nightly-validation.yml',
+  '.github/workflows/phase5-nightly.yml',
+]
+
+function readWorkflow(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8')
+}
+
+for (const workflowPath of workflowPaths) {
+  test(`${workflowPath} derives app metrics auth from deploy-host METRICS_SCRAPE_TOKEN`, () => {
+    const raw = readWorkflow(workflowPath)
+
+    assert.match(raw, /DEPLOY_HOST:\s+\$\{\{\s*secrets\.DEPLOY_HOST\s*\}\}/)
+    assert.match(raw, /DEPLOY_USER:\s+\$\{\{\s*secrets\.DEPLOY_USER\s*\}\}/)
+    assert.match(raw, /DEPLOY_SSH_KEY_B64:\s+\$\{\{\s*secrets\.DEPLOY_SSH_KEY_B64\s*\}\}/)
+    assert.match(raw, /METRICS_SCRAPE_TOKEN_RESOLVE_REQUIRED=false\s+bash scripts\/ops\/resolve-metrics-scrape-token\.sh/)
+    assert.match(raw, /AUTH_HEADER="Authorization: Bearer \$metrics_token"/)
+    assert.match(raw, /METRICS_AUTH_HEADER=\$AUTH_HEADER/)
+    assert.doesNotMatch(raw, /ATTENDANCE_ADMIN_JWT/)
+    assert.doesNotMatch(raw, /Authorization: Bearer \$ATTENDANCE_ADMIN_JWT/)
+  })
+}
+
+test('regression workflow uploads deploy-host metrics token fallback diagnostics', () => {
+  const raw = readWorkflow('.github/workflows/phase5-nightly-validation-regression.yml')
+
+  assert.match(raw, /\/tmp\/phase5-metrics-token-fallback\.log/)
+})

--- a/scripts/ops/resolve-metrics-scrape-token.sh
+++ b/scripts/ops/resolve-metrics-scrape-token.sh
@@ -1,0 +1,132 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+required="${METRICS_SCRAPE_TOKEN_RESOLVE_REQUIRED:-false}"
+deploy_path="${DEPLOY_PATH:-metasheet2}"
+deploy_compose_file="${DEPLOY_COMPOSE_FILE:-docker-compose.app.yml}"
+token_begin="__METRICS_SCRAPE_TOKEN_BEGIN__"
+token_end="__METRICS_SCRAPE_TOKEN_END__"
+
+is_truthy() {
+  case "${1:-}" in
+    true|TRUE|True|1|yes|YES|Yes|on|ON|On)
+      return 0
+      ;;
+    *)
+      return 1
+      ;;
+  esac
+}
+
+is_required() {
+  is_truthy "${required}"
+}
+
+warn_or_fail() {
+  local message="$1"
+  if is_required; then
+    echo "::error::${message}" >&2
+    exit 1
+  fi
+  echo "::warning::${message}" >&2
+  exit 0
+}
+
+validate_single_line_token() {
+  local token="$1"
+  if [[ -z "${token}" ]]; then
+    warn_or_fail "deploy-host METRICS_SCRAPE_TOKEN was empty"
+  fi
+  if [[ "${token}" == *$'\n'* || "${token}" == *$'\r'* ]]; then
+    warn_or_fail "deploy-host METRICS_SCRAPE_TOKEN must be a single-line value"
+  fi
+}
+
+shell_quote() {
+  printf '%q' "$1"
+}
+
+tmp_ssh_key=""
+
+cleanup_tmp_key() {
+  if [[ -n "${tmp_ssh_key}" && -f "${tmp_ssh_key}" ]]; then
+    rm -f "${tmp_ssh_key}"
+  fi
+}
+
+if [[ -z "${DEPLOY_HOST:-}" || -z "${DEPLOY_USER:-}" || -z "${DEPLOY_SSH_KEY_B64:-}" ]]; then
+  warn_or_fail "METRICS_AUTH_HEADER is not set and DEPLOY_HOST/DEPLOY_USER/DEPLOY_SSH_KEY_B64 are incomplete for deploy-host metrics token fallback"
+fi
+
+tmp_ssh_key="$(mktemp "${TMPDIR:-/tmp}/metrics-scrape-ssh-key.XXXXXX")"
+trap cleanup_tmp_key EXIT
+if ! printf '%s' "${DEPLOY_SSH_KEY_B64}" | base64 -d > "${tmp_ssh_key}"; then
+  warn_or_fail "failed to decode DEPLOY_SSH_KEY_B64 for deploy-host metrics token fallback"
+fi
+chmod 600 "${tmp_ssh_key}"
+
+ssh_opts=(-o BatchMode=yes -o ConnectTimeout=15 -o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i "${tmp_ssh_key}")
+quoted_deploy_path="$(shell_quote "${deploy_path}")"
+quoted_compose_file="$(shell_quote "${deploy_compose_file}")"
+
+set +e
+raw_output="$(
+  ssh "${ssh_opts[@]}" "${DEPLOY_USER}@${DEPLOY_HOST}" \
+    "DEPLOY_PATH=${quoted_deploy_path} DEPLOY_COMPOSE_FILE=${quoted_compose_file} bash -s" <<'EOF'
+set -euo pipefail
+if [[ "${DEPLOY_PATH}" == /* ]]; then
+  DEPLOY_REPO_PATH="${DEPLOY_PATH}"
+elif [[ "${DEPLOY_PATH}" == ~/* ]]; then
+  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH#~/}"
+else
+  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH}"
+fi
+cd "${DEPLOY_REPO_PATH}"
+
+if docker compose version >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker compose)
+elif command -v docker-compose >/dev/null 2>&1; then
+  COMPOSE_CMD=(docker-compose)
+else
+  echo "docker compose is not available" >&2
+  exit 125
+fi
+
+token="$("${COMPOSE_CMD[@]}" -f "${DEPLOY_COMPOSE_FILE}" exec -T backend sh -lc 'printf "%s" "${METRICS_SCRAPE_TOKEN:-}"' < /dev/null)"
+if [[ -z "${token}" ]]; then
+  echo "METRICS_SCRAPE_TOKEN missing from backend runtime env" >&2
+  exit 4
+fi
+if [[ "${token}" == *$'\n'* || "${token}" == *$'\r'* ]]; then
+  echo "METRICS_SCRAPE_TOKEN must be a single-line value" >&2
+  exit 5
+fi
+
+printf '__METRICS_SCRAPE_TOKEN_BEGIN__%s__METRICS_SCRAPE_TOKEN_END__\n' "${token}"
+EOF
+)"
+rc=$?
+set -e
+
+token="$(
+  printf '%s\n' "${raw_output}" | awk -v begin="${token_begin}" -v end="${token_end}" '
+    {
+      start = index($0, begin)
+      finish = index($0, end)
+      if (start > 0 && finish > start) {
+        found = substr($0, start + length(begin), finish - start - length(begin))
+      }
+    }
+    END {
+      if (found != "") print found
+    }
+  '
+)"
+
+if [[ "${rc}" != "0" || -z "${token}" ]]; then
+  warn_or_fail "failed to resolve METRICS_SCRAPE_TOKEN from deploy-host backend runtime"
+fi
+
+validate_single_line_token "${token}"
+echo "[resolve-metrics-scrape-token] token resolved from deploy-host backend runtime" >&2
+printf '%s' "${token}"

--- a/scripts/ops/resolve-metrics-scrape-token.test.mjs
+++ b/scripts/ops/resolve-metrics-scrape-token.test.mjs
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict'
+import { spawn } from 'node:child_process'
+import { chmodSync, existsSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'resolve-metrics-scrape-token.sh')
+
+function makeTmpDir() {
+  return mkdtempSync(path.join(tmpdir(), 'resolve-metrics-scrape-token-'))
+}
+
+function runResolver(env = {}) {
+  return new Promise((resolve, reject) => {
+    const child = spawn('bash', [scriptPath], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        PATH: process.env.PATH || '',
+        HOME: process.env.HOME || '',
+        ...env,
+      },
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.on('error', reject)
+    child.on('close', (status) => {
+      resolve({ status, stdout, stderr })
+    })
+  })
+}
+
+test('metrics token resolver exits zero without deploy inputs when fallback is optional', async () => {
+  const result = await runResolver()
+
+  assert.equal(result.status, 0)
+  assert.equal(result.stdout, '')
+  assert.match(result.stderr, /DEPLOY_HOST\/DEPLOY_USER\/DEPLOY_SSH_KEY_B64 are incomplete/)
+})
+
+test('metrics token resolver fails without deploy inputs when fallback is required', async () => {
+  const result = await runResolver({ METRICS_SCRAPE_TOKEN_RESOLVE_REQUIRED: 'true' })
+
+  assert.equal(result.status, 1)
+  assert.equal(result.stdout, '')
+  assert.match(result.stderr, /::error::METRICS_AUTH_HEADER is not set and DEPLOY_HOST\/DEPLOY_USER\/DEPLOY_SSH_KEY_B64 are incomplete/)
+})
+
+test('metrics token resolver reads token through deploy-host fallback without logging it', async () => {
+  const tmp = makeTmpDir()
+  const binDir = path.join(tmp, 'bin')
+  const sshArgsPath = path.join(tmp, 'ssh-args')
+  try {
+    mkdirSync(binDir)
+    const sshPath = path.join(binDir, 'ssh')
+    writeFileSync(sshPath, `#!/usr/bin/env bash
+printf '%s\\n' "$*" > "$FAKE_SSH_ARGS_PATH"
+cat >/dev/null
+printf 'remote prelude\\n'
+printf '__METRICS_SCRAPE_TOKEN_BEGIN__metrics-secret__METRICS_SCRAPE_TOKEN_END__\\n'
+`)
+    chmodSync(sshPath, 0o755)
+
+    const result = await runResolver({
+      HOME: tmp,
+      PATH: `${binDir}:${process.env.PATH || ''}`,
+      FAKE_SSH_ARGS_PATH: sshArgsPath,
+      DEPLOY_HOST: 'deploy.example.test',
+      DEPLOY_USER: 'deployer',
+      DEPLOY_SSH_KEY_B64: Buffer.from('fake-key').toString('base64'),
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.equal(result.stdout, 'metrics-secret')
+    assert.match(result.stderr, /token resolved from deploy-host backend runtime/)
+    assert.doesNotMatch(result.stderr, /metrics-secret/)
+    assert.doesNotMatch(readFileSync(sshArgsPath, 'utf8'), /\.ssh\/deploy_key/)
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('metrics token resolver cleans up temporary deploy SSH key after fallback execution', async () => {
+  const tmp = makeTmpDir()
+  const binDir = path.join(tmp, 'bin')
+  const sshKeyPathFile = path.join(tmp, 'ssh-key-path')
+  try {
+    mkdirSync(binDir)
+    const sshPath = path.join(binDir, 'ssh')
+    writeFileSync(sshPath, `#!/usr/bin/env bash
+while [[ "$#" -gt 0 ]]; do
+  if [[ "$1" == "-i" ]]; then
+    shift
+    printf '%s\\n' "$1" > "$FAKE_SSH_KEY_PATH"
+    if [[ ! -f "$1" ]]; then
+      echo "missing ssh key" >&2
+      exit 9
+    fi
+    mode="$(stat -f %Lp "$1" 2>/dev/null || stat -c %a "$1")"
+    if [[ "$mode" != "600" ]]; then
+      echo "bad ssh key mode: $mode" >&2
+      exit 10
+    fi
+  fi
+  shift
+done
+cat >/dev/null
+printf '__METRICS_SCRAPE_TOKEN_BEGIN__metrics-secret__METRICS_SCRAPE_TOKEN_END__\\n'
+`)
+    chmodSync(sshPath, 0o755)
+
+    const result = await runResolver({
+      HOME: tmp,
+      TMPDIR: tmp,
+      PATH: `${binDir}:${process.env.PATH || ''}`,
+      FAKE_SSH_KEY_PATH: sshKeyPathFile,
+      DEPLOY_HOST: 'deploy.example.test',
+      DEPLOY_USER: 'deployer',
+      DEPLOY_SSH_KEY_B64: Buffer.from('fake-key').toString('base64'),
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    const usedKeyPath = readFileSync(sshKeyPathFile, 'utf8').trim()
+    assert.match(
+      usedKeyPath,
+      new RegExp(`^${tmp.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')}/metrics-scrape-ssh-key\\.`),
+    )
+    assert.equal(existsSync(usedKeyPath), false)
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('metrics token resolver fails when required fallback cannot find a token sentinel', async () => {
+  const tmp = makeTmpDir()
+  const binDir = path.join(tmp, 'bin')
+  try {
+    mkdirSync(binDir)
+    const sshPath = path.join(binDir, 'ssh')
+    writeFileSync(sshPath, `#!/usr/bin/env bash
+cat >/dev/null
+printf 'no token here\\n'
+`)
+    chmodSync(sshPath, 0o755)
+
+    const result = await runResolver({
+      HOME: tmp,
+      PATH: `${binDir}:${process.env.PATH || ''}`,
+      METRICS_SCRAPE_TOKEN_RESOLVE_REQUIRED: 'true',
+      DEPLOY_HOST: 'deploy.example.test',
+      DEPLOY_USER: 'deployer',
+      DEPLOY_SSH_KEY_B64: Buffer.from('fake-key').toString('base64'),
+    })
+
+    assert.equal(result.status, 1)
+    assert.equal(result.stdout, '')
+    assert.match(result.stderr, /::error::failed to resolve METRICS_SCRAPE_TOKEN/)
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})


### PR DESCRIPTION
## Summary
- add a deploy-host resolver for backend runtime `METRICS_SCRAPE_TOKEN` that prints only the token and keeps logs redaction-safe
- switch scheduled Phase 5 app-metrics fallbacks away from `ATTENDANCE_ADMIN_JWT` and toward `METRICS_SCRAPE_TOKEN` when using the trusted `METASHEET_BASE_URL` `/api/metrics/prom` endpoint
- add workflow contract coverage so the admin JWT fallback does not regress

Refs #1. This is validation-path plumbing, not close-out evidence by itself; #1 still needs a successful non-skip Phase 5 run on `main`.

## Verification
- `bash -n scripts/ops/resolve-metrics-scrape-token.sh`
- `node --test scripts/ops/resolve-metrics-scrape-token.test.mjs scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs`
- `ruby -e 'require "yaml"; %w[.github/workflows/phase5-nightly-validation-regression.yml .github/workflows/phase5-nightly-validation.yml .github/workflows/phase5-nightly.yml].each { |f| YAML.load_file(f) }; puts "yaml ok"'`\n- `git diff --check`