### PR TITLE
feat(integration): DF-T3b dual-binding picker — sheet binding + sourceCode-column binding

### DIFF
--- a/apps/web/src/components/integration/MetaIntegrationFieldRuleAuthoring.vue
+++ b/apps/web/src/components/integration/MetaIntegrationFieldRuleAuthoring.vue
@@ -51,6 +51,19 @@
               class="integration-field-rule-authoring__hint integration-field-rule-authoring__hint--strong"
               :data-testid="`field-rule-domain-required-${rule.targetField}`"
             >需选择 domain(否则该参照字段保持未解析)</span>
+            <!-- DF-T3b dual-binding: the sourceCode COLUMN the resolver reads (the second binding). -->
+            <input
+              class="integration-field-rule-authoring__source"
+              :data-testid="`field-rule-source-code-${rule.targetField}`"
+              :value="rule.sourceField || ''"
+              placeholder="sourceCode 列名(清洗表列)"
+              @input="onReferenceSourceFieldChange(index, ($event.target as HTMLInputElement).value)"
+            />
+            <span
+              v-if="!rule.sourceField"
+              class="integration-field-rule-authoring__hint integration-field-rule-authoring__hint--strong"
+              :data-testid="`field-rule-source-code-required-${rule.targetField}`"
+            >需填写 sourceCode 列(否则解析读到的列不对)</span>
           </template>
         </template>
 
@@ -103,6 +116,7 @@ import {
   setFieldRulePreserve,
   setFieldRuleFromReferenceTable,
   setFieldRuleReferencePreserve,
+  setFieldRuleReferenceSourceField,
   type IntegrationFieldRule,
 } from '../../services/integration/workbench'
 
@@ -160,5 +174,13 @@ function onReferenceDomainChange(index: number, domain: string): void {
   const e = editability(rule)
   if (!e.editable || !e.isReference) return
   emitUpdated(index, setFieldRuleFromReferenceTable(rule, domain))
+}
+
+// DF-T3b dual-binding: the sourceCode column (rule.sourceField) for a from_reference_table reference.
+function onReferenceSourceFieldChange(index: number, sourceField: string): void {
+  const rule = props.modelValue[index]
+  const e = editability(rule)
+  if (!e.editable || !e.isReference || rule.sourceType !== 'from_reference_table') return
+  emitUpdated(index, setFieldRuleReferenceSourceField(rule, sourceField))
 }
 </script>

--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -395,6 +395,18 @@ export function setFieldRuleFromReferenceTable(rule: IntegrationFieldRule, domai
 export function setFieldRuleReferencePreserve(rule: IntegrationFieldRule): IntegrationFieldRule {
   const next: IntegrationFieldRule = { ...rule, sourceType: 'preserve_template' }
   delete next.domain
+  delete next.sourceField
+  return next
+}
+
+// DF-T3b dual-binding picker: set the sourceCode COLUMN (rule.sourceField) the resolver reads for a
+// from_reference_table reference — the SECOND binding (the sheet binding is referenceMappingSources).
+// The preview path reads getPath(sourceRecord, rule.sourceField) (http-routes.cjs), so without this the
+// resolver would default to the targetField column and read the wrong value. Empty → drop sourceField.
+export function setFieldRuleReferenceSourceField(rule: IntegrationFieldRule, sourceField: string): IntegrationFieldRule {
+  const next: IntegrationFieldRule = { ...rule }
+  if (sourceField) next.sourceField = sourceField
+  else delete next.sourceField
   return next
 }
 

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -847,14 +847,32 @@
           placeholder='{ "FNumber": "&lt;code&gt;", "FName": "&lt;name&gt;" }'
         ></textarea>
         <small class="integration-workbench__hint">可选。填写后使用 DF-T1 no-write payloadTemplate 预览；留空则保持 legacy preview。</small>
-        <h2>引用映射来源 JSON</h2>
-        <textarea
-          v-model="referenceMappingSourcesText"
-          data-testid="reference-mapping-sources"
-          spellcheck="false"
-          placeholder='[ { "domain": "unit", "systemId": "…", "object": "…" } ]'
-        ></textarea>
-        <small class="integration-workbench__hint">可选。为 from_reference_table 字段绑定各 domain 的映射表（staging 系统 / 对象）；填写后预览会实时 bulk-read 解析，留空则不解析。仅在已填写目标模板 JSON 时生效。</small>
+        <h2>引用映射来源(各 domain 绑定 staging 表)</h2>
+        <div v-if="referenceMappingDomains.length > 0" data-testid="reference-mapping-picker">
+          <div
+            v-for="domain in referenceMappingDomains"
+            :key="domain"
+            class="integration-workbench__ref-mapping-row"
+            :data-testid="`ref-mapping-row-${domain}`"
+          >
+            <code>{{ domain }}</code>
+            <select
+              :data-testid="`ref-mapping-system-${domain}`"
+              :value="referenceMappingBindings[domain]?.systemId || ''"
+              @change="onRefMappingSystemChange(domain, ($event.target as HTMLSelectElement).value)"
+            >
+              <option value="">— staging 系统 —</option>
+              <option v-for="system in stagingSystems" :key="system.id" :value="system.id">{{ system.name }}</option>
+            </select>
+            <input
+              :data-testid="`ref-mapping-object-${domain}`"
+              :value="referenceMappingBindings[domain]?.object || ''"
+              placeholder="对象/表名"
+              @input="onRefMappingObjectChange(domain, ($event.target as HTMLInputElement).value)"
+            />
+          </div>
+        </div>
+        <small class="integration-workbench__hint">将 reference 字段授权为「从映射表解析」并选 domain 后,这里按 domain 绑定其 staging 映射表(系统按名称选,对象填表名);预览会实时 bulk-read 解析。sourceCode 列在上方字段规则里填。</small>
         <button
           type="button"
           class="integration-workbench__button"
@@ -1127,10 +1145,9 @@ const sampleRecordText = ref(JSON.stringify({
 // DF-T1.5 reachability wire: optional payloadTemplate JSON. When filled, previewPayload sends the
 // DF-T1 no-write preview shape so the backend returns targetPayloadPreview (provenance); empty = legacy.
 const payloadTemplateText = ref('')
-// DF-T3b-2b UI-wire: optional referenceMappingSources JSON; when filled (and a payloadTemplate is set),
-// previewPayload sends it so the route live-bulk-reads each domain's mapping sheet and resolves
-// from_reference_table per-material. Empty = no live resolution (byte-compatible).
-const referenceMappingSourcesText = ref('')
+// DF-T3b dual-binding picker: per-domain staging-table binding (sheet half of from_reference_table
+// resolution). Keyed by domain (the distinct from_reference_table domains the operator authored above).
+const referenceMappingBindings = ref<Record<string, { systemId: string; object: string }>>({})
 // DF-T2c: the authored fieldRules draft (from the read-only derive route, then edited via the
 // authoring UI) + the gated fields it returns. previewPayload sends these (not a re-derive) when set.
 const authoredFieldRules = ref<IntegrationFieldRule[]>([])
@@ -1165,6 +1182,18 @@ const hiddenAdvancedSystemCount = computed(() => systems.value.filter((system) =
 const visibleSystems = computed(() => systems.value.filter((system) => showAdvancedConnectors.value || !isAdvancedSystem(system)))
 const sourceSystems = computed(() => visibleSystems.value.filter((system) => canUseSystemForSide(system, 'source')))
 const targetSystems = computed(() => visibleSystems.value.filter((system) => canUseSystemForSide(system, 'target')))
+// DF-T3b dual-binding picker: only metasheet:staging systems may back a mapping sheet (matches the
+// route's P1 staging-kind guard); the picker shows their NAMES so the operator never types a systemId.
+const stagingSystems = computed(() => systems.value.filter((system) => system.kind === 'metasheet:staging'))
+// the distinct from_reference_table domains the operator authored — the picker binds exactly these
+// (a binding for a domain no longer authored is dropped at send time).
+const referenceMappingDomains = computed(() => {
+  const seen = new Set<string>()
+  for (const rule of authoredFieldRules.value) {
+    if (rule.sourceType === 'from_reference_table' && typeof rule.domain === 'string' && rule.domain) seen.add(rule.domain)
+  }
+  return [...seen]
+})
 const runnableSourceSystems = computed(() => sourceSystems.value.filter((system) => !isSourceOptionDisabled(system)))
 const hasRunnableSourceSystem = computed(() => runnableSourceSystems.value.length > 0)
 const selectedTargetObject = computed(() => targetObjects.value.find((object) => object.name === targetObjectName.value) || null)
@@ -2744,6 +2773,18 @@ async function deriveTemplateDraft(): Promise<void> {
   }
 }
 
+// DF-T3b dual-binding picker: bind a domain's mapping sheet (staging system + object). Stored per-domain;
+// previewPayload assembles referenceMappingSources from the currently-authored domains.
+function onRefMappingSystemChange(domain: string, systemId: string): void {
+  const current = referenceMappingBindings.value[domain] || { systemId: '', object: '' }
+  referenceMappingBindings.value = { ...referenceMappingBindings.value, [domain]: { ...current, systemId } }
+}
+
+function onRefMappingObjectChange(domain: string, object: string): void {
+  const current = referenceMappingBindings.value[domain] || { systemId: '', object: '' }
+  referenceMappingBindings.value = { ...referenceMappingBindings.value, [domain]: { ...current, object } }
+}
+
 async function previewPayload(): Promise<void> {
   try {
     const sourceRecord = JSON.parse(sampleRecordText.value) as Record<string, unknown>
@@ -2776,17 +2817,19 @@ async function previewPayload(): Promise<void> {
       request.fieldRules = authoredFieldRules.value.length > 0
         ? authoredFieldRules.value
         : deriveFieldRulesFromMappings(fieldMappings)
-      // DF-T3b-2b UI-wire: when the operator provides reference mapping sources, send them so the route
-      // live-bulk-reads each domain's mapping sheet (from_reference_table resolves per-material). Empty =
-      // omitted (byte-compatible); invalid JSON / non-array throws here → error path, no backend call.
-      const referenceMappingSourcesRaw = referenceMappingSourcesText.value.trim()
-      if (referenceMappingSourcesRaw) {
-        const parsedSources = JSON.parse(referenceMappingSourcesRaw) as unknown
-        if (!Array.isArray(parsedSources)) {
-          throw new Error('引用映射来源 JSON 必须是一个数组')
+      // DF-T3b dual-binding picker: build referenceMappingSources from the per-domain picker bindings,
+      // for ONLY the domains currently authored as from_reference_table (stale bindings for removed
+      // domains are dropped; incomplete bindings — missing system or object — are skipped). The route
+      // live-bulk-reads each. The SECOND binding (sourceCode column) rides on the from_reference_table
+      // rules' sourceField, already in request.fieldRules above.
+      const referenceMappingSources: IntegrationReferenceMappingSource[] = []
+      for (const domain of referenceMappingDomains.value) {
+        const binding = referenceMappingBindings.value[domain]
+        if (binding && binding.systemId && binding.object) {
+          referenceMappingSources.push({ domain, systemId: binding.systemId, object: binding.object })
         }
-        request.referenceMappingSources = parsedSources as IntegrationReferenceMappingSource[]
       }
+      if (referenceMappingSources.length > 0) request.referenceMappingSources = referenceMappingSources
     }
     const result = await previewIntegrationTemplate(request)
     previewText.value = JSON.stringify(result, null, 2)

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -659,25 +659,8 @@ describe('IntegrationWorkbenchView', () => {
     expect(wiredText).not.toContain('Bolt')
     expect(wiredText).not.toContain('Pcs')
 
-    // DF-T3b-2b UI-wire — filling reference mapping sources sends them in the preview POST so the route
-    // live-bulk-reads (from_reference_table resolution becomes operator-UI-reachable). The #1968
-    // request-body keystone: assert the POST body carries referenceMappingSources (not just a render).
-    expect(previewBodies[1]).not.toHaveProperty('referenceMappingSources') // empty before → omitted
-    const refSourcesInput = container.querySelector('[data-testid="reference-mapping-sources"]') as HTMLTextAreaElement
-    refSourcesInput.value = JSON.stringify([{ domain: 'unit', systemId: 'metasheet_staging_project_1', object: 'unit_dict' }])
-    refSourcesInput.dispatchEvent(new Event('input'))
-    await flushUi()
-    ;(container.querySelector('[data-testid="preview-payload"]') as HTMLButtonElement).click()
-    await flushUi()
-    expect(previewBodies).toHaveLength(3)
-    expect(previewBodies[2]).toHaveProperty('payloadTemplate') // still the DF-T1 path
-    expect((previewBodies[2] as Record<string, unknown>).referenceMappingSources).toEqual([
-      { domain: 'unit', systemId: 'metasheet_staging_project_1', object: 'unit_dict' },
-    ])
-    // reset so the invalid-payloadTemplate test below keeps its original semantics
-    refSourcesInput.value = ''
-    refSourcesInput.dispatchEvent(new Event('input'))
-    await flushUi()
+    // (DF-T3b dual-binding picker has its own focused test below — it needs authored from_reference_table
+    // rules, which this DF-T1 derive path does not produce.)
 
     // DF-T1.5 reachability — Test 3 (invalid payloadTemplate JSON blocks the request): no new POST
     // is made and an error is surfaced.
@@ -686,7 +669,7 @@ describe('IntegrationWorkbenchView', () => {
     await flushUi()
     ;(container.querySelector('[data-testid="preview-payload"]') as HTMLButtonElement).click()
     await flushUi()
-    expect(previewBodies).toHaveLength(3)
+    expect(previewBodies).toHaveLength(2)
     expect(container.textContent).toContain('预览失败')
 
     // reset to legacy for the remainder of the test (pipeline save below is preview-independent)
@@ -1810,7 +1793,10 @@ describe('IntegrationWorkbenchView', () => {
     const previewBodies: Array<Record<string, unknown>> = []
     apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
       if (url === '/api/integration/adapters') return jsonResponse([])
-      if (url.startsWith('/api/integration/external-systems')) return jsonResponse([])
+      // a metasheet:staging system so the DF-T3b dual-binding picker has a system to bind
+      if (url.startsWith('/api/integration/external-systems')) return jsonResponse([
+        { id: 'ms_staging_1', name: 'MetaSheet staging', kind: 'metasheet:staging', status: 'active' },
+      ])
       if (url === '/api/integration/staging/descriptors') return jsonResponse([])
       if (url === '/api/integration/templates/derive') {
         deriveBodies.push(JSON.parse(String(init?.body)))
@@ -1891,5 +1877,53 @@ describe('IntegrationWorkbenchView', () => {
     const rules = previewBodies[0].fieldRules as Array<Record<string, unknown>>
     expect(rules.find((r) => r.targetField === 'FNumber')).toMatchObject({ sourceType: 'from_staging', sourceField: 'materialCode', shape: 'scalar' })
     expect(rules.find((r) => r.targetField === 'FUnitID')).toMatchObject({ sourceType: 'preserve_template' })
+
+    // KEYSTONE 3 (DF-T3b DUAL-BINDING) — author FUnitID as from_reference_table, bind BOTH halves via the
+    // structured picker, and assert the preview POST carries both: the sheet binding (referenceMappingSources)
+    // AND the sourceCode-column binding (rule.sourceField on the from_reference_table rule).
+    const refModeK3 = container.querySelector('[data-testid="field-rule-mode-FUnitID"]') as HTMLSelectElement
+    refModeK3.value = 'mapping'
+    refModeK3.dispatchEvent(new Event('change'))
+    await flushUi()
+    const domainSel = container.querySelector('[data-testid="field-rule-domain-FUnitID"]') as HTMLSelectElement
+    domainSel.value = 'unit'
+    domainSel.dispatchEvent(new Event('change'))
+    await flushUi()
+    const srcCol = container.querySelector('[data-testid="field-rule-source-code-FUnitID"]') as HTMLInputElement
+    expect(srcCol).not.toBeNull() // the sourceCode-column input (binding #2)
+    srcCol.value = 'unitSourceCode'
+    srcCol.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    // the picker now lists the 'unit' domain (derived from the authored from_reference_table rule) — bind it
+    const sysSel = container.querySelector('[data-testid="ref-mapping-system-unit"]') as HTMLSelectElement
+    expect(sysSel?.tagName).toBe('SELECT') // staging-system dropdown (by NAME → id; no typed systemId)
+    sysSel.value = 'ms_staging_1'
+    sysSel.dispatchEvent(new Event('change'))
+    await flushUi()
+    const objInput = container.querySelector('[data-testid="ref-mapping-object-unit"]') as HTMLInputElement
+    objInput.value = 'unit_dict'
+    objInput.dispatchEvent(new Event('input'))
+    await flushUi()
+
+    ;(container.querySelector('[data-testid="preview-payload"]') as HTMLButtonElement).click()
+    await flushUi()
+    const lastBody = previewBodies.at(-1)!
+    // binding #1 — the sheet binding
+    expect(lastBody.referenceMappingSources).toEqual([{ domain: 'unit', systemId: 'ms_staging_1', object: 'unit_dict' }])
+    // binding #2 — the sourceCode column on the from_reference_table rule (NOT just the sheet)
+    const rules2 = lastBody.fieldRules as Array<Record<string, unknown>>
+    expect(rules2.find((r) => r.targetField === 'FUnitID')).toMatchObject({ sourceType: 'from_reference_table', domain: 'unit', sourceField: 'unitSourceCode' })
+
+    // orphan-drop — revert FUnitID to preserve → 'unit' is no longer an authored from_reference_table
+    // domain → the (now stale) sheet binding is dropped from the next preview POST (the send loop iterates
+    // the CURRENT domains, not the bindings map).
+    const refModeRevert = container.querySelector('[data-testid="field-rule-mode-FUnitID"]') as HTMLSelectElement
+    refModeRevert.value = 'preserve'
+    refModeRevert.dispatchEvent(new Event('change'))
+    await flushUi()
+    ;(container.querySelector('[data-testid="preview-payload"]') as HTMLButtonElement).click()
+    await flushUi()
+    expect(previewBodies.at(-1)!).not.toHaveProperty('referenceMappingSources')
   })
 })

--- a/apps/web/tests/MetaIntegrationFieldRuleAuthoring.spec.ts
+++ b/apps/web/tests/MetaIntegrationFieldRuleAuthoring.spec.ts
@@ -8,6 +8,7 @@ import {
   setFieldRulePreserve,
   setFieldRuleFromReferenceTable,
   setFieldRuleReferencePreserve,
+  setFieldRuleReferenceSourceField,
   type IntegrationFieldRule,
 } from '../src/services/integration/workbench'
 
@@ -43,10 +44,18 @@ describe('fieldRuleEditability + setters (DF-T2b / DF-T3b-2d)', () => {
     const halfState = setFieldRuleFromReferenceTable(ref, '')
     expect(halfState).toMatchObject({ sourceType: 'from_reference_table', shape: 'object-passthrough' })
     expect(halfState.domain).toBeUndefined()
-    // back to preserve drops domain, keeps the reference shape
-    const back = setFieldRuleReferencePreserve(mapped)
+    // back to preserve drops domain AND sourceField, keeps the reference shape
+    const back = setFieldRuleReferencePreserve({ ...mapped, sourceField: 'unitSourceCode' })
     expect(back).toMatchObject({ sourceType: 'preserve_template', shape: 'object-passthrough', completeness: 'require-fnumber-fname' })
     expect(back.domain).toBeUndefined()
+    expect(back.sourceField).toBeUndefined()
+  })
+
+  it('DF-T3b setFieldRuleReferenceSourceField sets/clears the sourceCode column, keeps everything else', () => {
+    const ref: IntegrationFieldRule = { targetField: 'FUnitID', sourceType: 'from_reference_table', shape: 'object-passthrough', completeness: 'require-fnumber-fname', domain: 'unit' }
+    const bound = setFieldRuleReferenceSourceField(ref, 'unitSourceCode')
+    expect(bound).toMatchObject({ sourceType: 'from_reference_table', domain: 'unit', shape: 'object-passthrough', completeness: 'require-fnumber-fname', sourceField: 'unitSourceCode' })
+    expect(setFieldRuleReferenceSourceField(bound, '').sourceField).toBeUndefined()
   })
 
   it('DF_T3_REFERENCE_DOMAINS pins the exact 12-domain set (mirrors the backend templates)', () => {
@@ -155,6 +164,21 @@ describe('MetaIntegrationFieldRuleAuthoring (DF-T2b)', () => {
     domainSel.dispatchEvent(new Event('change'))
     await nextTick()
     expect(updates.at(-1)![0]).toMatchObject({ targetField: 'FUnitID', sourceType: 'from_reference_table', shape: 'object-passthrough', completeness: 'require-fnumber-fname', domain: 'unit' })
+  })
+
+  it('DF-T3b: a from_reference_table reference shows the sourceCode-column input + "需填写" hint; typing emits sourceField', async () => {
+    const updates = mount([
+      { targetField: 'FUnitID', sourceType: 'from_reference_table', shape: 'object-passthrough', completeness: 'require-fnumber-fname', domain: 'unit' },
+    ])
+    await nextTick()
+    const srcCol = container!.querySelector('[data-testid="field-rule-source-code-FUnitID"]') as HTMLInputElement
+    expect(srcCol).not.toBeNull()
+    expect(container!.querySelector('[data-testid="field-rule-source-code-required-FUnitID"]')).not.toBeNull() // required while empty
+    srcCol.value = 'unitSourceCode'
+    srcCol.dispatchEvent(new Event('input'))
+    await nextTick()
+    // emits sourceField, keeping sourceType/domain/shape/completeness (the second binding, on the rule)
+    expect(updates.at(-1)![0]).toMatchObject({ targetField: 'FUnitID', sourceType: 'from_reference_table', domain: 'unit', shape: 'object-passthrough', completeness: 'require-fnumber-fname', sourceField: 'unitSourceCode' })
   })
 
   it('DF-T3b-2d: a GATED reference stays locked (gated wins over reference-editability)', async () => {

--- a/docs/development/data-factory-df-t3b-dual-binding-picker-development-20260530.md
+++ b/docs/development/data-factory-df-t3b-dual-binding-picker-development-20260530.md
@@ -1,0 +1,65 @@
+# DF-T3b dual-binding picker — sheet binding + sourceCode-column binding — development verification (2026-05-30)
+
+> The **binding half** that completes operator-facing from_reference_table (owner sequence: 2d authoring
+> → this picker). Binds **both** halves the resolver needs, owner-locked so it can't ship sheet-only:
+> **(1)** `referenceMappingSources` (domain → staging system/object — which sheet each domain reads) via a
+> structured picker that **replaces the #2080 JSON textarea**; **(2)** `rule.sourceField` (the sourceCode
+> **column** the resolver looks up) authored per from_reference_table rule. **Frontend-only, read-only.**
+
+## Why both — and why sheet-only would be a half-product
+
+The preview path reads the source code at `getPath(input.sourceRecord, rule.sourceField)`
+(`http-routes.cjs:721`), and `normalizeFieldRules` defaults `sourceField` to `targetField` when absent —
+so **without binding `sourceField`, the resolver reads the wrong column** (the K3 field name, not the
+material's source code). A sheet-only picker would look bound but resolve wrong. Hence both bindings here.
+
+## What shipped (frontend-only)
+
+- **Binding #2 — sourceCode column (`workbench.ts` + `MetaIntegrationFieldRuleAuthoring.vue`):**
+  `setFieldRuleReferenceSourceField(rule, sourceField)` (keeps sourceType/domain/shape/completeness;
+  empty → drop). The from_reference_table reference control now has a `sourceField` input (data-testid
+  `field-rule-source-code-*`) + a "需填写 sourceCode 列" hint. `setFieldRuleReferencePreserve` also drops
+  `sourceField`.
+- **Binding #1 — sheet picker (`IntegrationWorkbenchView.vue`):** the #2080 JSON textarea is replaced by a
+  **structured picker** that auto-lists the **distinct from_reference_table domains** from the authored
+  rules; per domain, a **staging-system `<select>`** (names → id; `kind === 'metasheet:staging'` only —
+  matches the route's P1 guard) + an **object text input**. `previewPayload` assembles
+  `referenceMappingSources` from these bindings for **only the currently-authored domains** (stale
+  bindings for removed domains are dropped; incomplete bindings skipped).
+
+## Key decisions
+
+- **Object = text input, not a dropdown.** The friction the owner named was the **`systemId`** (names
+  shown, id hidden) — the system `<select>` closes that. Object names are already discoverable
+  (source-object dropdown, staging descriptors), so a text input avoids per-row `listExternalSystemObjects`
+  loading/caching for no friction gain. An object dropdown is future polish.
+- **Domains derive from authored rules; stale dropped at send.** The picker shows exactly the distinct
+  from_reference_table domains currently authored; a binding for a domain no longer present is dropped
+  when assembling `referenceMappingSources` (the send loop iterates the **current** domains, not the
+  bindings map — tested both ways: present→sent, and reverted-to-preserve→dropped).
+- **Shared domain = one sheet binding, per-rule sourceCode column.** Two from_reference_table rules on the
+  same domain (e.g. `FUnitID` + `FStoreUnitID` → `unit`) share **one** sheet binding (one sheet per
+  domain, #2036) but each carries its **own** `sourceField` (its own sourceCode column). Intended model.
+
+## Reachability — now resolvable end-to-end (in preview)
+
+With 2d (authoring) + this slice (both bindings) + #2073 (route + bulk-read), an operator can mark a
+field from_reference_table, pick a domain, bind the sourceCode column **and** the staging sheet, and the
+preview resolves the reference per-material. (Backend resolution consuming `sourceField` is verified in
+the merged backend; the route's staging-kind + duplicate guards live in #2073.)
+
+## Tests + negative control
+
+`MetaIntegrationFieldRuleAuthoring.spec.ts` + `IntegrationWorkbenchView.spec.ts` (28 passed). The
+**dual-binding keystone** (in the DF-T2c flow test): author FUnitID → from_reference_table + domain +
+sourceField, bind the picker (system dropdown + object) → the preview POST carries **both** —
+`referenceMappingSources: [{domain:'unit', systemId, object}]` **and** the FUnitID rule with
+`sourceType:'from_reference_table'` + `domain` + `sourceField:'unitSourceCode'`. **Negative control**:
+neutering the sourceCode-column handler (sheet binds, `sourceField` never set) → the keystone fails —
+proving the second binding is load-bearing, not just the sheet. vue-tsc clean for changed files.
+
+## Next (gated, separate opt-in)
+
+- **DF-T3b-2c** — real-Save compose-before-`upsert` (changes K3 Save bytes), with its recorded checklist
+  (per-row fail-closed → dead-letter/provenance, same bindings as preview, I/O failure its own category).
+- Optional later polish: an object dropdown (loaded per system) in place of the object text input.


### PR DESCRIPTION
## DF-T3b dual-binding picker

The **binding half** that completes operator-facing from_reference_table (owner sequence: 2d authoring → this picker). Binds **both** halves the resolver needs (owner-locked, **not** sheet-only). **Frontend-only, read-only.**

### Why both
The preview path reads `getPath(input.sourceRecord, rule.sourceField)` (`http-routes.cjs:721`) and `normalizeFieldRules` defaults `sourceField` to `targetField`, so **without binding `sourceField` the resolver reads the wrong column** — a sheet-only picker would look bound but resolve wrong.

### What shipped
- **Binding #2 — sourceCode column:** `setFieldRuleReferenceSourceField`; the from_reference_table reference control gets a `sourceField` input (`field-rule-source-code-*`) + required hint.
- **Binding #1 — sheet picker:** the #2080 JSON textarea → a **structured picker** that auto-lists the distinct from_reference_table domains from authored rules; per domain a **staging-system `<select>`** (names→id, `metasheet:staging` only) + an **object text input**. `previewPayload` assembles `referenceMappingSources` for **only currently-authored domains** (stale dropped, incomplete skipped).

### Decisions
- **Object = text input** — the system dropdown closes the actual `systemId` friction; object names are already discoverable, so no per-row `listExternalSystemObjects`. (Object dropdown = future polish.)
- **Shared domain → one sheet binding, per-rule `sourceField`** (one sheet per domain, #2036).

### Tests (28 passed) + negative control
**Dual-binding keystone**: author from_reference_table + domain + sourceField, bind the picker → the preview POST carries **both** `referenceMappingSources` **and** the rule's `sourceField`; plus orphan-drop (revert to preserve → stale sheet binding dropped). **Negative control**: neuter the sourceCode-column handler (sheet binds, `sourceField` unset) → keystone fails (second binding is load-bearing). vue-tsc clean for changed files.

Verification MD: `docs/development/data-factory-df-t3b-dual-binding-picker-development-20260530.md`. Left for owner review — no auto-merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)