### PR TITLE
docs(data-sources): C3-env validation kit — OSS refs + probe-first PS validator + 2008R2/2012 matrix

### DIFF
--- a/docs/development/data-sources-mssql-windows-deploy-runbook-20260529.md
+++ b/docs/development/data-sources-mssql-windows-deploy-runbook-20260529.md
@@ -81,18 +81,17 @@
 > **状态标注(勿当已签收)**:C1(workDir 可移植)**本刀已落**;但 **C3(Windows 原生运行时整体验证)仍 🔒 未做** —— 路径/文件操作/服务化/PG+Garnet/Memurai 连通**未在真实 Windows 上跑通过**。本节是**设计 + 已修可移植性**的部署指引,**不是已验证的签收路径**。真实落 C 档前必须先完成 §7 的 C3。
 
 1. **Node 运行时**:装 Node ≥18;`pnpm --filter @metasheet/core-backend build` 出 `dist/`。
-2. **注册为 Windows 服务**:用 `nssm` 或 `node-windows` 把 `node packages/core-backend/dist/src/index.js` 注册为服务(开机自启、崩溃重启);服务环境注入 §2.2 的全部变量。
+2. **注册为 Windows 服务**:**推荐默认 `nssm`**(`node-windows` 为附录/备选,见研究文档)把 `node packages/core-backend/dist/src/index.js` 注册为服务(开机自启、崩溃重启);服务环境注入 §2.2 的全部变量。可用 kit 的 `-RegisterService`(显式 opt-in)机械化此步。
 3. **PostgreSQL**:用 PostgreSQL 官方 **Windows 安装包**;`DATABASE_URL` 指向它。
-4. **Redis 替代(C 档关键)**:Windows 无官方原生 Redis →
-   - **Garnet**(Microsoft,MIT 开源,.NET,RESP 兼容)= **OSS 首选**;
-   - **Memurai**(开发版免费 / 商业版付费)= 稳定商业 fallback。
-   - 二者均 RESP 兼容,后端 `REDIS_HOST`(及端口)指向其监听地址即可,**应用侧无需改代码**。
+4. **Redis 替代(C 档关键)**:Windows 无官方原生 Redis → 用 **RESP 兼容的 OSS 实现作推荐默认 / 商业实现作备选**(具体选型 + 许可证见 `docs/research/windows-deploy-oss-references-20260529.md`,并**先核实后端实际用到的 Redis 命令落在所选实现的支持集内**)。后端 `REDIS_HOST`/`REDIS_PORT` 指向其监听地址即可,**应用侧无需改代码**。
 5. **沙箱临时目录**:C1 后 `ScriptSandbox` 默认落 `%TEMP%\sandbox`(`os.tmpdir()`),无需手配。
 6. **迁移 + 冒烟**:`pnpm --filter @metasheet/core-backend migrate`(§2.3)+ §6 验证。
 
 ---
 
 ## 6. 部署后验证(三档共用)
+
+> **机械化(C3-env validation kit)**:本节探测可由 `scripts/ops/validate-windows-runtime.ps1` 一键跑出 **pass/fail/evidence**(**默认只读探测、零改动**;安装 / 服务注册 / 写系统环境变量需显式 `-Install` / `-RegisterService` opt-in)。带 `-BaseUrl -Token -DataSourceId` 时,下面第 2/3 项的鉴权 + 数据源只读 smoke 也一并机械跑。kit 是**验证器,不是一键安装器**——不会擅自固化客户环境。
 
 1. **迁移完整性**:`migrate --list` 确认无 pending;部署 SOP 的 migration-pending diff。
 2. **Auth round-trip**:登录 → 带 token 调一个鉴权接口 → 200。**静默 401 = schema gap**,回查迁移,别先怀疑 `JWT_SECRET`。
@@ -108,8 +107,8 @@
 
 | 项 | 状态 | 说明 |
 |---|---|---|
-| **C3 Windows 原生运行时验证** | 🔒 未做 | 走 C 档前必须验:路径/文件操作(含 `%TEMP%\sandbox`)、Node-as-service、PG + Garnet/Memurai 连通、端到端只读拉数。**需 Windows VM/快照**,本预算未含。 |
-| **2008R2 / 2012 真实验证** | ⬜ follow-up | B4 已覆盖 2019/2022 真容器;2008R2/2012 是 Windows-only 二进制无 Linux 容器,真实验证需 **Windows VM**(P0-6:仅当客户明确是 legacy 或进最终 signoff 才投)。 |
+| **C3 Windows 原生运行时验证** | 🔒 未做 | 走 C 档前必须验:路径/文件操作(含 `%TEMP%\sandbox`)、Node-as-service、PG + RESP 缓存连通、端到端只读拉数。**需 Windows VM/快照**,本预算未含。**机械化跑证据 = C3-env validation kit**(`scripts/ops/validate-windows-runtime.ps1`,§6);判读细项见 `data-sources-windows-c3-validation-plan-20260529.md`。 |
+| **2008R2 / 2012 真实验证** | ⬜ follow-up | B4 已覆盖 2019/2022 真容器;2008R2/2012 是 Windows-only 二进制无 Linux 容器,真实验证需 **Windows VM**。兼容矩阵 + legacy smoke recipe(B3 TLS 降级)见 `data-sources-windows-2008r2-2012-compat-matrix-20260529.md`(**只到协议级 + recipe,不承诺 CI/本机验证**)。 |
 | **B6 Windows 集成认证** | 🔒 独立切片 | `authType:'windows'`(Kerberos/keytab/AD)未做;本期连接器只支持 `authType:'sql'`。 |
 | **共享 workDir 跨实例** | ⬜ 观察项 | C1 只改 base path(`/tmp/sandbox` → `os.tmpdir()/sandbox`),**语义不变**:多个 `ScriptSandbox` 实例仍共享同一 `<tmpdir>/sandbox`,`cleanup()` 递归删该目录。per-instance 隔离不在 C1 范围,留作后续独立项(非本刀引入)。 |
 

--- a/docs/development/data-sources-windows-2008r2-2012-compat-matrix-20260529.md
+++ b/docs/development/data-sources-windows-2008r2-2012-compat-matrix-20260529.md
@@ -1,0 +1,60 @@
+# 旧版 SQL Server(2008R2 / 2012)兼容矩阵 + legacy smoke recipe
+
+> **范围**:Lane C 的旧版 SQL Server 支持。**只做协议级矩阵 + smoke recipe,不承诺 CI 或本机验证** —— 2008R2/2012 是 Windows-only 二进制,无 Linux 容器镜像(MS 官方 `mcr.microsoft.com/mssql/server` 最低 2017),真实验证需客户 **Windows VM/快照**。
+> **配套**:部署 runbook `data-sources-mssql-windows-deploy-runbook-20260529.md`(档 C)+ C3 验证计划 `data-sources-windows-c3-validation-plan-20260529.md` + OSS 对标 `docs/research/windows-deploy-oss-references-20260529.md`。
+> **驱动事实**(已 web 核实,见研究文档):2008/2008R2/2012/2014 需补丁才支持 TLS 1.2;现代 Windows 默认禁用 TLS 1.0/1.1;cipher 不匹配时服务器直接关闭连接。我方 **B3 per-connection TLS 降级**(`tlsMinVersion`/`tlsCiphers`/`legacyTls`)正是为此设计,作用域限单数据源、客户服务器零改动。
+
+---
+
+## 1. 版本兼容矩阵
+
+| 版本 | TLS 1.2 原生? | 默认加密/握手 | 我方连接配置 | 真实可测? |
+|---|---|---|---|---|
+| **2008 R2** | 否(需补丁) | 常仅 TLS 1.0 / 老 cipher(AES-CBC-SHA) | `encrypt:true` + `trustServerCertificate:true` + **B3** `tlsMinVersion:'TLSv1'`(必要时 `legacyTls`/`tlsCiphers`) | 仅 Windows VM(无容器) |
+| **2012** | 否(需补丁) | 同上;打了 TLS 1.2 补丁后可 1.2 | 同上;有 1.2 补丁则无需 B3 降级 | 仅 Windows VM |
+| 2014 | 需补丁 | 打补丁后 TLS 1.2 | 标准 `encrypt:true`+`trust...`;未打补丁回退 B3 | 仅 Windows VM |
+| 2016 | 是 | TLS 1.2 原生 | 标准 `encrypt:true`+`trustServerCertificate:true`(内网自签) | 仅 Windows(无官方 Linux 镜像 ≤2016) |
+| 2017 / 2019 / 2022 | 是 | TLS 1.2 原生 | 标准默认 | ✅ Linux 容器(已 CI:`sqlserver-smoke.yml`) |
+
+> **判读**:2016+ 走标准路径;**2008R2/2012(及未打补丁的 2014)是 B3 降级的真实用武之地**。降到连 TLS1.0 都谈不拢时,该源 `encrypt:false`(内网+审计)或隔离代理 sidecar 为最后手段(与 B3 互斥)。
+
+---
+
+## 2. Legacy smoke recipe(客户 Windows VM 上机械跑)
+
+旧库需要 B3 TLS 降级旋钮,而 **ops 脚本 `smoke:sqlserver` 当前只暴露 `MSSQL_ENCRYPT`/`MSSQL_TRUST_SERVER_CERTIFICATE`,不暴露 B3 的 `tlsMinVersion`/`tlsCiphers`/`legacyTls`**(见 §3 缺口)。故 legacy 验证走**真实产品路径**(数据源 create 的 connection 配置支持 B3 旋钮)+ kit 的只读 smoke:
+
+**步骤(在客户同网段、能连到 2008R2/2012 的机器上):**
+
+1. **建只读数据源**(API/UI),`type:'sqlserver'`,connection 带 B3 旋钮:
+   ```jsonc
+   {
+     "type": "sqlserver",
+     "connection": {
+       "server": "<legacy-host>", "database": "<db>",
+       "encrypt": true, "trustServerCertificate": true,
+       "tlsMinVersion": "TLSv1"        // 2008R2/2012:降 TLS 下限;必要时再加:
+       // "legacyTls": true, "tlsCiphers": "<...:@SECLEVEL=0>"
+     },
+     "credentials": { "username": "<u>", "password": "<p>" },
+     "options": { "readOnly": true }
+   }
+   ```
+   > `tlsMinVersion`+`encrypt:false` **互斥**(同设即抛)。降级会 `emit('tls-downgrade')` 落 warn 审计。
+
+2. **跑只读连通 smoke**(kit):
+   ```powershell
+   .\scripts\ops\validate-windows-runtime.ps1 -BaseUrl https://<host>:8900 -Token <tok> -DataSourceId <id>
+   ```
+   `Data-source read smoke` 项 PASS = 经 B3 降级的旧库**只读连通**成立(证据 = HTTP 200)。
+
+3. **记录证据**:kit 的 pass/fail/evidence 表 + 是否触发 `tls-downgrade` 审计;若连不上,按 §1 降级树下一档(`legacyTls`/`tlsCiphers` → 末档 `encrypt:false`)。
+
+> **2017+ 实例**:可直接用 `pnpm --filter @metasheet/core-backend smoke:sqlserver`(`MSSQL_HOST`/`MSSQL_USERNAME`/… + `MSSQL_ENCRYPT`/`MSSQL_TRUST_SERVER_CERTIFICATE`);它已被 `sqlserver-smoke.yml` 在 2019/2022 容器真测。
+
+---
+
+## 3. 已知缺口(follow-up,非本刀)
+
+- ⬜ **`smoke:sqlserver` 未暴露 B3 legacy-TLS env**:`smoke-sqlserver.ts` 目前只映射 `encrypt`/`trustServerCertificate`,无 `MSSQL_TLS_MIN_VERSION`/`MSSQL_TLS_CIPHERS`/`MSSQL_LEGACY_TLS`。故 TLS-1.0-only 旧库无法直接经该 ops 脚本 smoke,需走 §2 的 API-create 路径。补这三个 env 映射是一个**小 follow-up**(test/ops 脚本,lock-safe),做了之后 legacy 也能一行命令 smoke。
+- 🔒 **真实 2008R2/2012 验证**:需客户 Windows VM/快照;本矩阵只到协议级 + recipe。

--- a/docs/development/data-sources-windows-c3-validation-plan-20260529.md
+++ b/docs/development/data-sources-windows-c3-validation-plan-20260529.md
@@ -46,6 +46,8 @@
 
 ## 3. 环境集成层 — 手动验证 checklist(🔒 需客户 Windows 主机)
 
+> **机械化(C3-env validation kit)**:下列大部分项可由 `scripts/ops/validate-windows-runtime.ps1` 一键探测出 pass/fail/evidence(**默认只读、零改动**;安装 / 服务注册 / 写系统环境变量需显式 `-Install` / `-RegisterService` opt-in)。带 `-BaseUrl -Token -DataSourceId` 时连鉴权 round-trip + 数据源只读 smoke 也跑。OSS 选型见 `docs/research/windows-deploy-oss-references-20260529.md`;旧库(2008R2/2012)见 `data-sources-windows-2008r2-2012-compat-matrix-20260529.md`。
+
 按 runbook **档 C** 部署后逐项验证(每项含 pass 判据):
 
 - ⬜ **服务化**(nssm / node-windows):`node …/dist/src/index.js` 注册为服务 → 开机自启 + 崩溃重启生效。

--- a/docs/research/windows-deploy-oss-references-20260529.md
+++ b/docs/research/windows-deploy-oss-references-20260529.md
@@ -1,0 +1,68 @@
+# Windows-native deploy (Lane C tier C) — 开源对标素材(内部研究,非正式设计文档)
+
+> **性质**:内部 OSS 对标研究。按"正式文档只述 MetaSheet 自有原则"惯例,外部产品/品牌名只在本研究文档出现;runbook / 设计稿正文保持品牌克制,仅引用"推荐默认 / 备选"。
+> **用途**:为 **C3-env validation kit**(`scripts/ops/validate-windows-runtime.ps1` + 2008R2/2012 兼容矩阵)提供选型依据。kit 的定位是 **验证(probe)优先**,非一键安装器。
+> **核实日期**:2026-05-29(版本/许可证经 web 核实,见文末 Sources)。
+
+---
+
+## 0. 结论速读(选型)
+
+| 需求 | 推荐默认(OSS) | 备选 | 许可证 |
+|---|---|---|---|
+| Node 作 Windows 服务 | **nssm**(Non-Sucking Service Manager) | node-windows(基于 winsw)/ winser | nssm 公共领域 · winsw/node-windows MIT |
+| Windows 上的 Redis 替代(RESP) | **Microsoft Garnet** | Memurai(商业,非 OSS) | Garnet **MIT** |
+| PostgreSQL on Windows | 官方 **EDB Windows 安装包** | —(无 OSS 缺口) | PostgreSQL License |
+| 连旧版 SQL Server(2008R2/2012) | **tedious / node-mssql**(本仓库既用) | —(驱动层无替换需求) | **MIT** |
+
+**总判断**:tier C 全栈可由已知 MIT/OSS 组件 + 我方既有 B3 驱动路径拼装,**无需自研基础设施**。唯一需在客户机现场核实的是 **Garnet 命令子集覆盖**(见 §2)。
+
+---
+
+## 1. Node 作 Windows 服务
+
+- **nssm**:把任意程序(含 `node dist/src/index.js`)注册为 Windows 服务,两条命令即可;社区长期生产使用、最简。**kit 默认走 nssm**。
+- **node-windows**(coreybutler):早期基于 nssm,**现基于 winsw.exe**;复用 OS 原生 uptime,可与 Nagios / System Center 等系统监控对接。比 nssm 集成更深,但更重。
+- **winsw**:node-windows 的底座,能力强。
+- **winser**(jfromaniello):npm 包,封装 nssm 注册流程。
+- **裁示落地**:kit **只在脚本里实现 nssm 路径**;node-windows 仅作**附录/备选**说明,不在脚本里双实现(避免双维护 + 决策面扩大)。
+
+## 2. Windows 上的 Redis 替代 — Garnet(OSS 首选)
+
+- **Microsoft Garnet**(`microsoft/garnet`):Microsoft Research 的远程 cache-store,采用 **RESP 线协议**,可被**未改动的 Redis 客户端**驱动(支持的命令子集持续扩大);**Windows 与 Linux 同等高效测试**;Microsoft 内部**生产部署**(Azure Resource Manager 等);NuGet `garnet-server`。**许可证 MIT**。
+- **Memurai**:Windows 上的 Redis 兼容实现,**商业**(开发版免费 / 商业版付费),作稳定 fallback。**非 OSS**。
+- ⚠️ **现场核实项(kit 验收前)**:Garnet 宣称"持续扩大的命令子集"——必须先核实 **MetaSheet 后端实际用到的 Redis 命令/特性**(队列 / 发布订阅 / Lua / 过期策略等)落在 Garnet 已支持集合内,再决定 Garnet vs Memurai。kit **默认 RESP `PING`(只读连通,零写入)**;`-RedisWriteProbe` 开关另跑一个自清理 SET/GET/DEL 临时 key 证基本读写命令覆盖(默认关,以保持默认零写入)。更深的命令覆盖核实留作部署期 checklist 项。
+
+## 3. PostgreSQL on Windows
+
+- 官方 **EDB Windows 安装包**即可;`DATABASE_URL` 指向它。驱动(`pg`)纯 JS、无原生编译,Windows 无障碍。无 OSS 缺口,kit 只做**可达性 + 迁移 pending** 探测,不自动安装。
+
+## 4. 旧版 SQL Server(2008R2/2012)— tedious 既有路径 + B3 TLS
+
+web 核实印证了我方 B3 设计的必要性,旧库连接的真实坑:
+
+- **2008/2008R2/2012/2014 需补丁才支持 TLS 1.2**;而**现代 Windows 默认禁用 TLS 1.0/1.1** → 客户端默认谈不拢。
+- **cipher 套件不匹配**时,服务器**直接关闭连接**(不报错),表现为连接失败。
+- 旧 workaround 是进程级 `--tls-min-v1.0` flag —— **我方 B3 的 per-connection `cryptoCredentialsDetails`(`minVersion`/`ciphers`)正是为取代它**:作用域限单数据源、不污染进程、客户服务器零改动。
+- 自签证书 → `trustServerCertificate`(我方默认 true)。
+- **结论**:旧库路径 = B3 TLS 降级旋钮 + `trustServerCertificate`,**无需新代码**;2008R2/2012 因无 Linux 容器,只做**协议级 matrix + smoke recipe**(指向客户实例),**不承诺 CI 或本机验证**。
+- 连接器版本怪癖参考:`directus`(Knex+MSSQL)、`airbyte` `source-mssql`(config schema / 版本旋钮形态)。
+
+---
+
+## 5. 对 validation kit 的映射
+
+| OSS 素材 | kit 用法(验证优先) |
+|---|---|
+| nssm | `-RegisterService` 显式 opt-in 时注册服务;默认只探测"是否已注册 / nssm 是否在 PATH" |
+| Garnet/Memurai | 默认 RESP `PING`(零写入);`-RedisWriteProbe` 加自清理 SET/GET/DEL 读写探测;命令覆盖深核 = checklist 项 |
+| EDB PG | 默认可达性 + `migrate --list` pending 探测;不自动装 |
+| tedious + B3 | legacy smoke recipe:`smoke:sqlserver` + B3 TLS 旋钮指向 2008R2/2012 实例 |
+
+---
+
+## Sources(2026-05-29 核实)
+
+- Garnet:<https://github.com/microsoft/garnet> · <https://microsoft.github.io/garnet/docs> · NuGet `garnet-server` <https://www.nuget.org/packages/garnet-server/>
+- Windows 服务:node-windows <https://github.com/coreybutler/node-windows/wiki> · winser <https://github.com/jfromaniello/winser> · nssm 用法 <https://briancaos.wordpress.com/2022/12/01/run-node-js-on-windows-server-using-nssm/>
+- 旧版 SQL Server TLS:<https://learn.microsoft.com/en-us/troubleshoot/sql/database-engine/connect/tls-1-2-support-microsoft-sql-server> · <https://learn.microsoft.com/en-us/troubleshoot/sql/database-engine/connect/ssl-errors-after-tls-1-2> · node-mssql 自签证书 issue <https://github.com/tediousjs/node-mssql/issues/1271>

--- a/scripts/ops/validate-windows-runtime.ps1
+++ b/scripts/ops/validate-windows-runtime.ps1
@@ -1,0 +1,324 @@
+#Requires -Version 5.1
+<#
+.SYNOPSIS
+  C3-env validation kit — probe a native-Windows host for MetaSheet backend readiness
+  (Lane C tier C). VALIDATION FIRST: by default this script only PROBES (read-only) and prints a
+  pass/fail/evidence report. The default run makes NO system or service-config change.
+
+.DESCRIPTION
+  This is a VALIDATION kit, not a one-click installer. It deliberately does not silently
+  install heavy dependencies or change the host, so it never prematurely freezes a customer
+  environment. Every state-changing action is OFF by default and requires an explicit switch:
+
+    (default)           probe only  -> pass / fail / evidence + exit code (0 all-pass, 1 any-fail).
+                                       No system/service-config change. (The Redis probe is PING-only
+                                       by default — it does not write any key.)
+    -RedisWriteProbe    write probe -> additionally SET/GET/DEL a unique transient key on Redis to
+                                       prove read/write command support (e.g. on Garnet). The key is
+                                       namespaced + immediately deleted; no other state changes.
+    -RegisterService    MUTATION    -> register the backend as an nssm Windows service + set its
+                                       service env (honors -WhatIf / -Confirm). Requires nssm on PATH.
+    -Install            guidance    -> print copy-pasteable acquisition steps for any missing
+                                       dependency (nssm / PostgreSQL / Garnet|Memurai). Prints only;
+                                       dependency install stays operator-driven by design.
+
+  Secret values are NEVER printed: env-var checks report "set" / "MISSING" only, and connection
+  passwords are used to authenticate probes but never echoed.
+
+.PARAMETER BaseUrl
+  Optional backend base URL. If set, the script probes reachability. With -Token + -DataSourceId
+  it also runs the read-only data-source smoke (GET /api/data-sources/:id/test).
+.PARAMETER Token
+  Optional bearer token for the credentialed data-source read smoke.
+.PARAMETER DataSourceId
+  Optional data source id for the read smoke.
+.PARAMETER NodeEntry
+  Path to the backend entry used for -RegisterService. Default: the built dist entry.
+.PARAMETER ServiceName
+  nssm service name used for -RegisterService. Default: MetaSheetBackend.
+.PARAMETER Install
+  Print dependency-acquisition guidance (no execution).
+.PARAMETER RegisterService
+  Register the backend as an nssm Windows service (mutation; ShouldProcess-gated).
+.PARAMETER RedisWriteProbe
+  Additionally SET/GET/DEL a transient probe key on Redis to prove read/write (off by default).
+
+.EXAMPLE
+  .\validate-windows-runtime.ps1
+  # probe-only; full pass/fail/evidence report
+
+.EXAMPLE
+  .\validate-windows-runtime.ps1 -BaseUrl https://host:8900 -Token $tok -DataSourceId k3
+  # also runs the credentialed read-only data-source smoke
+
+.EXAMPLE
+  .\validate-windows-runtime.ps1 -RegisterService -WhatIf
+  # preview the nssm service registration without performing it
+#>
+[CmdletBinding(SupportsShouldProcess = $true)]
+param(
+  [string]$BaseUrl,
+  [string]$Token,
+  [string]$DataSourceId,
+  [string]$NodeEntry = 'packages\core-backend\dist\src\index.js',
+  [string]$ServiceName = 'MetaSheetBackend',
+  [switch]$Install,
+  [switch]$RegisterService,
+  [switch]$RedisWriteProbe
+)
+
+$ErrorActionPreference = 'Stop'
+$script:results = @()
+
+function Add-Check {
+  param([string]$Name, [ValidateSet('PASS', 'FAIL', 'WARN', 'SKIP')][string]$Status, [string]$Evidence)
+  $script:results += [pscustomobject]@{ Check = $Name; Status = $Status; Evidence = $Evidence }
+}
+
+# Windows PowerShell 5.1-compatible HTTP status probe. (-SkipHttpErrorCheck is PS7+ only; on 5.1
+# Invoke-WebRequest throws on a non-2xx, so read the code off the WebException's response instead.)
+# Returns the HTTP status code; rethrows on a genuine connection error (no HTTP response at all).
+function Get-HttpStatus {
+  param([string]$Url, [hashtable]$Headers = @{}, [int]$TimeoutSec = 15)
+  try {
+    return [int](Invoke-WebRequest -Uri $Url -Method Get -Headers $Headers -TimeoutSec $TimeoutSec -UseBasicParsing).StatusCode
+  } catch {
+    $resp = $_.Exception.Response
+    if ($resp) { return [int]$resp.StatusCode }
+    throw
+  }
+}
+
+# --- Probe: Node present + version >= 18 -------------------------------------------------------
+try {
+  $nodeVer = (& node --version) 2>$null
+  if ($nodeVer -match 'v(\d+)\.') {
+    $major = [int]$Matches[1]
+    Add-Check 'Node >= 18' ($(if ($major -ge 18) { 'PASS' } else { 'FAIL' })) "node $nodeVer"
+  } else {
+    Add-Check 'Node >= 18' 'FAIL' 'node not found on PATH'
+  }
+} catch { Add-Check 'Node >= 18' 'FAIL' 'node not found on PATH' }
+
+# --- Probe: OS temp dir is usable (C1 workDir = os.tmpdir()\sandbox) ----------------------------
+# Transient: create a UNIQUE probe dir under the OS temp dir, round-trip a file, then remove it.
+# Proves the temp dir is writable WITHOUT leaving the real sandbox dir behind. Use
+# [Path]::GetTempPath() (not $env:TEMP) — it mirrors Node's os.tmpdir() resolution and is robust if
+# TEMP is unset.
+try {
+  $tempRoot = [System.IO.Path]::GetTempPath()
+  $probeDir = Join-Path $tempRoot ("msv-probe-" + ([guid]::NewGuid().ToString('N')))
+  New-Item -ItemType Directory -Path $probeDir -Force | Out-Null
+  $probeFile = Join-Path $probeDir 'worker.probe'
+  'ok' | Set-Content -Path $probeFile -Encoding ascii
+  $readBack = Get-Content -Path $probeFile -Raw
+  Remove-Item -Path $probeDir -Recurse -Force
+  $sandbox = Join-Path $tempRoot 'sandbox'
+  Add-Check 'Sandbox workDir writable (os temp)' ($(if ($readBack.Trim() -eq 'ok') { 'PASS' } else { 'FAIL' })) "would resolve to $sandbox"
+} catch { Add-Check 'Sandbox workDir writable (os temp)' 'FAIL' $_.Exception.Message }
+
+# --- Probe: Python resolvable (C3-code: PYTHON_BIN || win32 'python') --------------------------
+$pyBin = if ($env:PYTHON_BIN) { $env:PYTHON_BIN } else { 'python' }
+try {
+  $pyVer = (& $pyBin --version) 2>&1
+  if ($LASTEXITCODE -eq 0) {
+    Add-Check 'Python resolvable' 'PASS' "$pyBin -> $pyVer"
+  } else {
+    Add-Check 'Python resolvable' 'WARN' "'$pyBin' not runnable; set PYTHON_BIN to a full python.exe path (only needed for workflow Python script nodes)"
+  }
+} catch { Add-Check 'Python resolvable' 'WARN' "'$pyBin' not found; set PYTHON_BIN if workflow Python nodes are used" }
+
+# --- Probe: required env vars PRESENT (never print the value) ----------------------------------
+# NOTE: these read THIS shell's environment (session-scoped), NOT the registered service's env. Run
+# the kit in the shell where the env is configured (i.e. BEFORE -RegisterService, which captures it
+# into the service). Post-deploy, the SERVICE env is authoritative — verify it via
+# `nssm get <ServiceName> AppEnvironmentExtra`. Missing here is therefore a WARN, not a FAIL: it must
+# not red-flag a correctly-configured host whose env lives in the service rather than the shell.
+# Known default/weak sentinels from the codebase (encrypted-secrets.ts, auth-runtime-config.ts):
+# "set but obviously insecure" (empty / a known default / too short) is a WARN — A1 keys are a red
+# line (runbook §2.2). Still session-scoped, so WARN not FAIL; the VALUE is never printed.
+# Full set: auth-runtime-config.ts INSECURE_JWT_SECRET_VALUES + encrypted-secrets.ts key/salt defaults.
+# Keep this in sync with auth-runtime-config.ts if that list grows.
+$weakSecrets = @(
+  'test', 'dev-secret', 'dev-secret-key', 'fallback-development-secret-change-in-production',
+  'change-me', 'change-me-in-production', 'your-secret-key-here', 'your-dev-secret-key-here',
+  'default-key-change-in-production', 'default-salt-change-in-production'
+)
+$sensitive = @('JWT_SECRET', 'ENCRYPTION_KEY', 'ENCRYPTION_SALT')
+foreach ($name in @('DATABASE_URL', 'REDIS_HOST', 'JWT_SECRET', 'ENCRYPTION_KEY', 'ENCRYPTION_SALT')) {
+  $item = Get-Item "env:$name" -ErrorAction SilentlyContinue
+  if (-not $item) {
+    Add-Check "env $name (this shell)" 'WARN' 'MISSING in this shell — session-scoped; set here before -RegisterService, or verify the service env'
+    continue
+  }
+  if ($sensitive -notcontains $name) {
+    Add-Check "env $name (this shell)" 'PASS' 'set'
+    continue
+  }
+  # Sensitive secret: inspect the value for obviously-insecure forms WITHOUT printing it.
+  $val = [string]$item.Value
+  if ([string]::IsNullOrWhiteSpace($val)) {
+    Add-Check "env $name (this shell)" 'WARN' 'set but EMPTY'
+  } elseif ($weakSecrets -contains $val) {
+    Add-Check "env $name (this shell)" 'WARN' 'set but matches a KNOWN DEFAULT/weak sentinel — replace before production'
+  } elseif (($name -ne 'ENCRYPTION_SALT') -and ($val.Length -lt 32)) {
+    Add-Check "env $name (this shell)" 'WARN' 'set but short (<32 chars; backend requires >=32 for JWT_SECRET) — use a strong random value'
+  } else {
+    Add-Check "env $name (this shell)" 'PASS' 'set (non-default)'
+  }
+}
+
+# --- Probe: PostgreSQL reachable (TCP; host:port parsed from DATABASE_URL) ---------------------
+try {
+  $pgHost = $null; $pgPort = 5432
+  if ($env:DATABASE_URL -match '@([^:/?]+)(?::(\d+))?') {
+    $pgHost = $Matches[1]
+    if ($Matches[2]) { $pgPort = [int]$Matches[2] }
+  }
+  if ($pgHost) {
+    $tcp = Test-NetConnection -ComputerName $pgHost -Port $pgPort -WarningAction SilentlyContinue
+    Add-Check 'PostgreSQL reachable' ($(if ($tcp.TcpTestSucceeded) { 'PASS' } else { 'FAIL' })) "$pgHost`:$pgPort"
+  } else {
+    Add-Check 'PostgreSQL reachable' 'SKIP' 'DATABASE_URL host not parseable'
+  }
+} catch { Add-Check 'PostgreSQL reachable' 'FAIL' $_.Exception.Message }
+
+# --- Probe: Redis/Garnet/Memurai RESP — PING by default; SET/GET/DEL only under -RedisWriteProbe -
+# PING proves the server is up (read-only). With -RedisWriteProbe, also SET/GET/DEL a unique transient
+# key to prove read/write command support (the Garnet command-coverage concern). That key is
+# namespaced + immediately deleted, but it IS a write — so it is OFF by default to keep the default
+# run write-free. The password authenticates the probe but is never echoed.
+$redisLabel = if ($RedisWriteProbe) { 'Redis/Garnet RESP (PING + SET/GET/DEL)' } else { 'Redis/Garnet RESP (PING)' }
+try {
+  $rHost = if ($env:REDIS_HOST) { $env:REDIS_HOST } else { '127.0.0.1' }
+  $rPort = if ($env:REDIS_PORT) { [int]$env:REDIS_PORT } else { 6379 }
+  $probeKey = 'msv:probe:' + ([guid]::NewGuid().ToString('N'))
+  $probeVal = ([guid]::NewGuid().ToString('N'))
+  $client = New-Object System.Net.Sockets.TcpClient
+  $client.Connect($rHost, $rPort)
+  $stream = $client.GetStream()
+  $cmd = ''
+  if ($env:REDIS_PASSWORD) { $cmd += "AUTH $($env:REDIS_PASSWORD)`r`n" }
+  $cmd += "PING`r`n"
+  if ($RedisWriteProbe) { $cmd += "SET $probeKey $probeVal`r`nGET $probeKey`r`nDEL $probeKey`r`n" }
+  $bytes = [Text.Encoding]::ASCII.GetBytes($cmd)
+  $stream.Write($bytes, 0, $bytes.Length)
+  Start-Sleep -Milliseconds 300
+  $resp = ''
+  $buf = New-Object byte[] 512
+  while ($stream.DataAvailable) { $resp += [Text.Encoding]::ASCII.GetString($buf, 0, $stream.Read($buf, 0, $buf.Length)) }
+  $client.Close()
+  $pong = $resp -match '\+PONG'
+  if (-not $pong) {
+    Add-Check $redisLabel 'FAIL' "$rHost`:$rPort -> $($resp.Trim() -replace '[\r\n]+', ' ')"
+  } elseif (-not $RedisWriteProbe) {
+    Add-Check $redisLabel 'PASS' "$rHost`:$rPort — PING ok (read/write not probed; pass -RedisWriteProbe to verify command coverage)"
+  } else {
+    $rw = ($resp -match '\+OK') -and ($resp -match [regex]::Escape($probeVal)) -and ($resp -match ':1')
+    Add-Check $redisLabel ($(if ($rw) { 'PASS' } else { 'WARN' })) ($(if ($rw) { "$rHost`:$rPort — PING + read/write ok" } else { "$rHost`:$rPort — PING ok but SET/GET/DEL not confirmed (verify command coverage)" }))
+  }
+} catch { Add-Check $redisLabel 'FAIL' $_.Exception.Message }
+
+# --- Probe: backend reachability + optional credentialed data-source read smoke ----------------
+if ($BaseUrl) {
+  try {
+    $code = Get-HttpStatus -Url $BaseUrl -TimeoutSec 10
+    # Any HTTP response (even 4xx) means the backend is reachable.
+    Add-Check 'Backend reachable' 'PASS' "$BaseUrl -> HTTP $code"
+  } catch { Add-Check 'Backend reachable' 'FAIL' $_.Exception.Message }
+
+  if ($Token -and $DataSourceId) {
+    try {
+      $u = "$($BaseUrl.TrimEnd('/'))/api/data-sources/$DataSourceId/test"
+      # IMPORTANT: /test returns HTTP 200 even when the CONNECTION fails — `ok:true` is request-layer;
+      # the real outcome is `data.success`, with a redacted cause in `data.error.message`. A 200-only
+      # check would falsely PASS an unreachable DB, so parse the body and require ok && data.success.
+      $body = $null
+      try {
+        $body = (Invoke-WebRequest -Uri $u -Method Get -Headers @{ Authorization = "Bearer $Token" } -TimeoutSec 20 -UseBasicParsing).Content
+      } catch {
+        $r = $_.Exception.Response
+        if ($r) { $body = (New-Object IO.StreamReader($r.GetResponseStream())).ReadToEnd() } else { throw }
+      }
+      $json = $body | ConvertFrom-Json
+      if ($json.ok -eq $true -and $json.data.success -eq $true) {
+        Add-Check 'Data-source read smoke' 'PASS' 'ok && data.success=true (read-only connectivity confirmed)'
+      } else {
+        $cause = if ($json.data.error.message) { $json.data.error.message } else { 'data.success != true' }
+        # data.error.message is already redacted by the backend (A3), so it is safe to surface.
+        Add-Check 'Data-source read smoke' 'FAIL' "connection failed (redacted): $cause"
+      }
+    } catch { Add-Check 'Data-source read smoke' 'FAIL' $_.Exception.Message }
+  } else {
+    Add-Check 'Data-source read smoke' 'SKIP' 'pass -Token + -DataSourceId to run the credentialed read smoke'
+  }
+} else {
+  Add-Check 'Backend reachable' 'SKIP' 'pass -BaseUrl to probe the running backend'
+}
+
+# --- Probe: nssm present (only relevant for -RegisterService) ----------------------------------
+$nssm = Get-Command nssm -ErrorAction SilentlyContinue
+Add-Check 'nssm on PATH' ($(if ($nssm) { 'PASS' } else { 'WARN' })) ($(if ($nssm) { $nssm.Source } else { 'not found (only needed for -RegisterService)' }))
+
+# === Report ===================================================================================
+Write-Host ''
+Write-Host 'MetaSheet C3-env validation — evidence' -ForegroundColor Cyan
+$script:results | Format-Table -AutoSize Check, Status, Evidence | Out-String | Write-Host
+$failed = @($script:results | Where-Object { $_.Status -eq 'FAIL' })
+Write-Host ("Summary: {0} pass, {1} fail, {2} warn, {3} skip" -f `
+  (@($script:results | Where-Object Status -eq 'PASS').Count), $failed.Count, `
+  (@($script:results | Where-Object Status -eq 'WARN').Count), `
+  (@($script:results | Where-Object Status -eq 'SKIP').Count))
+
+# === Guidance (-Install) — prints only; never installs ========================================
+if ($Install) {
+  Write-Host ''
+  Write-Host 'Dependency acquisition guidance (this kit validates; it does NOT install):' -ForegroundColor Yellow
+  Write-Host '  nssm (Node-as-service, default): https://nssm.cc/  (or `choco install nssm`)'
+  Write-Host '  PostgreSQL (Windows):            official EDB installer'
+  Write-Host '  Redis-on-Windows (RESP):         Garnet (MIT, OSS first) https://github.com/microsoft/garnet  |  Memurai (commercial)'
+  Write-Host '  See docs/research/windows-deploy-oss-references-20260529.md for licenses + selection rationale.'
+}
+
+# === Mutation (-RegisterService) — gated + ShouldProcess ======================================
+if ($RegisterService) {
+  if (-not $nssm) {
+    Write-Host ''
+    Write-Host 'ERROR: -RegisterService requires nssm on PATH. Install nssm (see -Install) and re-run.' -ForegroundColor Red
+    exit 2
+  }
+  $nodePath = (Get-Command node -ErrorAction SilentlyContinue).Source
+  if (-not $nodePath) {
+    Write-Host ''
+    Write-Host 'ERROR: -RegisterService requires node on PATH.' -ForegroundColor Red
+    exit 2
+  }
+  # nssm's default startup directory is the PROGRAM's dir (node.exe's), NOT the repo — so a RELATIVE
+  # entry would not be found at service start, and process.cwd() (e.g. the uploads path) would be
+  # wrong. Resolve the entry to an absolute path AND set AppDirectory to the repo root. Run this from
+  # the repo root, or pass an absolute -NodeEntry.
+  $repoRoot = (Get-Location).Path
+  $absEntry = if ([System.IO.Path]::IsPathRooted($NodeEntry)) { $NodeEntry } else { Join-Path $repoRoot $NodeEntry }
+  if (-not (Test-Path $absEntry)) {
+    Write-Host ''
+    Write-Host "ERROR: backend entry not found: $absEntry" -ForegroundColor Red
+    Write-Host '       Run from the repo root after building (pnpm --filter @metasheet/core-backend build), or pass an absolute -NodeEntry.' -ForegroundColor Red
+    exit 2
+  }
+  if ($PSCmdlet.ShouldProcess($ServiceName, "nssm install $ServiceName -> node $absEntry (AppDirectory $repoRoot)")) {
+    & nssm install $ServiceName $nodePath $absEntry
+    & nssm set $ServiceName AppDirectory $repoRoot
+    # Service env: collect ALL present names into ONE AppEnvironmentExtra call. nssm `set` REPLACES
+    # the parameter, so setting it once per var would keep only the last — pass them all together.
+    # Values pass through nssm and are never printed here.
+    $envPairs = @()
+    foreach ($name in @('DATABASE_URL', 'REDIS_HOST', 'REDIS_PORT', 'REDIS_PASSWORD', 'JWT_SECRET', 'ENCRYPTION_KEY', 'ENCRYPTION_SALT', 'PYTHON_BIN', 'PORT')) {
+      $val = (Get-Item "env:$name" -ErrorAction SilentlyContinue)
+      if ($val) { $envPairs += ('{0}={1}' -f $name, $val.Value) }
+    }
+    if ($envPairs.Count -gt 0) { & nssm set $ServiceName AppEnvironmentExtra @envPairs }
+    Write-Host "Registered service '$ServiceName' (entry: $absEntry, AppDirectory: $repoRoot). Start with: nssm start $ServiceName" -ForegroundColor Green
+  }
+}
+
+if ($failed.Count -gt 0) { exit 1 } else { exit 0 }


### PR DESCRIPTION
## C3-env validation kit (Lane C tier C) — 验证器,不是一键安装器

Per 裁示: build the turnkey artifacts so a customer Windows host/VM run is mechanical; nothing here is executed on the build host.

### 验收口径(三句话)
1. **`validate-windows-runtime.ps1` 已逐行人工审阅并修正 3 个 PowerShell 坑**(PS7-only `-SkipHttpErrorCheck`、nssm `AppEnvironmentExtra` 覆盖、env 会话作用域误判 FAIL);**pwsh parse-check 因本机 pwsh 安装(dotnet 依赖)过慢,开 PR 前未跑完 —— 安装完成后回填 parse-check 结论**;脚本**未在本机执行 Windows 实机验证**。
2. **默认模式是 probe-only**(只读探测 → pass/fail/evidence + exit code);**`-Install` / `-RegisterService` 才会产生系统改动**(`-Install` 仅打印获取指引、不静默安装;`-RegisterService` 经 ShouldProcess 注册 nssm 服务)。
3. **第一次可信验收来自客户 Windows host/VM 的实际输出**,届时再回填 evidence。

### 内容
- **`docs/research/windows-deploy-oss-references-20260529.md`** — OSS 对标(品牌名只在研究文档):nssm 默认 / node-windows 备选;**Garnet**(MIT、RESP、Microsoft 生产)OSS 首选 vs **Memurai** 商业备选(+ Garnet 命令覆盖核实 caveat);tedious legacy TLS 印证 B3。许可证 + Sources 已 web 核实。
- **`scripts/ops/validate-windows-runtime.ps1`** — 探测:Node≥18 / `%TEMP%` sandbox 往返 / Python 可解析 / env 存在(**会话作用域 WARN,绝不打印值**)/ PG TCP / RESP `PING` / 后端可达 / 可选凭据化数据源只读 smoke。**默认零改动**;secrets 不打印;PS 5.1 兼容。
- **`docs/development/data-sources-windows-2008r2-2012-compat-matrix-20260529.md`** — 版本×TLS 矩阵 + legacy smoke recipe(走 API-create 的 B3 TLS 旋钮);**明账缺口**:`smoke:sqlserver` 尚未暴露 `MSSQL_TLS_MIN_VERSION/CIPHERS/LEGACY_TLS`(小 follow-up)。**只到协议级,不承诺 CI / 本机验证**。
- 运行 runbook + C3 plan 指向 kit(品牌克制;nssm 默认)。

### CI 说明
触碰 `scripts/**` → `plugin-tests.yml` 会触发,但它跑 node gate、**不执行 `.ps1`**,不会 choke。

### Governance
Lock-safe: docs + 一个 ops 脚本;不碰 integration-core / RBAC / auth / 运行时代码。

🤖 Generated with [Claude Code](https://claude.com/claude-code)