### PR TITLE
docs(multitable): scope A6 workflow job runtime scout

### DIFF
--- a/docs/development/multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md
+++ b/docs/development/multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md
@@ -1,0 +1,273 @@
+# Multitable Automation A6-1 Persistent WorkflowJob Runtime Scout — 2026-05-30
+
+Status: docs-only scout / runtime not started
+Scope: A6-1 persistent linear `WorkflowJob` runtime planning
+Companions:
+- `docs/development/multitable-automation-a6-convergence-scout-20260529.md`
+- `docs/development/multitable-automation-run-governance-todo-20260527.md`
+- `docs/development/run-governance-forward-plan-20260528.md`
+- `docs/research/approval-automation-convergence-rfc-20260526.md`
+
+## Verdict
+
+A6-1 may be developed next, but only as a separately reviewed, opt-in, linear
+job-persistence runtime. It is no longer blocked by the retired K3 Stage-1
+blanket lock, but it is still governed by the run-governance demand gate.
+
+This scout does not authorize A6-2+ capabilities. The first runtime slice must
+persist one C1-shaped job per action for explicitly opted-in automation rules,
+while leaving existing rules on the current legacy execution path by default.
+
+## Grounding In Current Main
+
+Current `origin/main` has the governance substrate but not the job engine:
+
+- C1 `WorkflowJob` contract exists in
+  `packages/core-backend/src/multitable/workflow-job-contract.ts`. It defines the
+  status vocabulary and strict normalizers.
+- A2 runs API maps legacy `AutomationExecution.steps` into C1 at the read
+  boundary in `packages/core-backend/src/routes/automation.ts`. It already treats
+  future statuses such as `queued` and `suspended` as legal filters with empty
+  results.
+- `packages/core-backend/src/multitable/automation-executor.ts` is still a
+  private, sequential, fail-stop loop. `executeActions()` runs actions in order,
+  stops after the first failed action, and appends skipped results for the
+  remaining actions.
+- `packages/core-backend/src/multitable/automation-service.ts` still persists a
+  single execution row through `AutomationLogService.record()`. A5 retry is
+  whole-execution replay, not step-level resume.
+- `packages/core-backend/src/multitable/automation-log-service.ts` is the
+  redaction boundary. `record()` redacts steps, trigger event, rule snapshot, and
+  execution-level error before persistence.
+- `multitable_automation_executions` remains the execution log table. There is
+  no `automation_jobs` / `workflow_jobs` table and no runtime import of C1 by the
+  executor.
+
+Therefore A6-1 should be the smallest runtime bridge between the existing linear
+executor and the C1 contract, not a new engine.
+
+## Scope Decision
+
+A6-1 runtime may add:
+
+- a new additive job table for opt-in linear action jobs;
+- a rule-level opt-in flag / capability gate;
+- executor/service wiring that records one job per action for opted-in rules;
+- A2/A3 read integration that prefers persisted jobs when present and falls back
+  to legacy `steps` for old executions;
+- focused tests proving opt-out compatibility, opt-in job persistence, redaction,
+  and read-boundary behavior.
+
+A6-1 runtime must not add:
+
+- suspend/resume endpoints or resume tokens;
+- delay/timer persistence or worker claiming;
+- branch/parallel graph execution;
+- BPMN import, compile, preview, or runtime;
+- approval-as-job, `start_approval`, approval completion events, trigger
+  bindings, or approval result backwrite;
+- default per-action job writes for every existing rule;
+- K3 Submit/Audit/BOM/multi-record write expansion or any direct K3 unlock.
+
+## A6-0 Scout Questions Answered
+
+### 1. Table Shape
+
+Use a new table rather than extending `multitable_automation_executions.steps`.
+Recommended name: `multitable_automation_jobs`.
+
+Minimal A6-1 columns:
+
+| Column | Type | Notes |
+|---|---|---|
+| `id` | TEXT PRIMARY KEY | Stable C1 job id, e.g. `awj_<uuid>` or deterministic execution/action key. |
+| `execution_id` | TEXT NOT NULL | References `multitable_automation_executions(id)`; index required. |
+| `rule_id` | TEXT NOT NULL | Denormalized for filtering/debugging; index optional. |
+| `sheet_id` | TEXT NULL | Mirrors execution snapshot; nullable for safety. |
+| `step_index` | INTEGER NOT NULL | Legacy action index, unique per execution. |
+| `step_key` | TEXT NOT NULL | C1 step key; A6-1 can use `String(step_index)`. |
+| `action_type` | TEXT NOT NULL | Diagnostic anchor. |
+| `status` | TEXT NOT NULL | C1 status; A6-1 writes only `queued/running/resolved/failed/skipped`. |
+| `upstream_job_id` | TEXT NULL | Linear predecessor only; first job is null. |
+| `result` | JSONB NULL | Redacted before persistence. |
+| `error` | TEXT NULL | Redacted before persistence. |
+| `started_at` | TIMESTAMPTZ NULL | Set when action begins. |
+| `finished_at` | TIMESTAMPTZ NULL | Set when action reaches terminal status. |
+| `duration_ms` | INTEGER NULL | Mirrors current step duration. |
+| `schema_version` | INTEGER NOT NULL DEFAULT 1 | Forward compatibility. |
+| `created_at` | TIMESTAMPTZ NOT NULL DEFAULT NOW() | Audit. |
+| `updated_at` | TIMESTAMPTZ NOT NULL DEFAULT NOW() | Audit. |
+
+Do not add `suspend`, `resume_token`, `branch_index`, downstream edges, join
+mode, or worker claim columns in A6-1. Those belong to A6-2/A6-3 when the runtime
+can actually use them.
+
+### 2. Opt-in Flag
+
+Existing rules must remain legacy by default.
+
+The preferred A6-1 flag is rule-level and explicit, for example an additive
+nullable/defaulted `execution_mode` column on `automation_rules` with:
+
+- `NULL` / `legacy` = current path, no job rows;
+- `workflow_job_v1` = write linear job rows.
+
+This is deliberately not a global environment flag: write amplification and
+compatibility should be reviewable per rule/use-case. The route/UI that enables
+the flag can be deferred if A6-1 starts with controlled backend fixtures or an
+admin-only maintenance toggle; what matters is that runtime default stays
+legacy.
+
+### 3. Worker / Claim Model
+
+A6-1 should not introduce a worker or claim model.
+
+The first implementation can run inline inside the existing execution call:
+
+1. create job as `queued`;
+2. mark it `running` just before executing the action;
+3. update it to `resolved` / `failed`;
+4. create terminal `skipped` jobs for remaining actions when fail-stop triggers.
+
+Worker claiming starts only when A6-2 needs durable resume or delay wakeups. A
+worker in A6-1 would create scheduler semantics before there is any resumable
+job.
+
+### 4. Side-effect Transaction Boundary
+
+The hard problem is external side effects: record writes, webhooks, email, and
+DingTalk cannot be rolled back by a database transaction.
+
+Recommended A6-1 rule:
+
+- for an opted-in rule, if the job row cannot be created/updated before the
+  action starts, fail the execution before performing the action;
+- after a side effect has run, a job-update failure must not pretend the action
+  did not run. It should fail the execution with an operator-visible error and
+  preserve whatever execution/job state was successfully persisted.
+
+This is stricter than the legacy execution log, where log-write failure is
+swallowed. The stricter behavior is acceptable only because A6-1 is opt-in; it is
+the price of durable per-action provenance.
+
+The implementation PR must make this behavior explicit in tests. Do not hide job
+persistence failure as a background warning for opted-in rules.
+
+### 5. Redaction Helper
+
+Use the existing multitable automation redactor:
+
+- `packages/core-backend/src/multitable/automation-log-redact.ts`
+- `redactValue()` for `result`;
+- `redactString()` for `error`.
+
+Do not create a job-specific redactor and do not import integration-core
+redaction into multitable. A6-1 must preserve the A1 invariant: no new unredacted
+execution/job plane.
+
+### 6. Mixed Legacy / Persisted Read Model
+
+A2/A3 should keep their external response shape stable.
+
+Read order:
+
+1. If persisted jobs exist for an execution, map those rows to C1 `WorkflowJob`
+   view.
+2. If no job rows exist, keep the current legacy fallback:
+   `AutomationExecution.steps -> toWorkflowJobView()`.
+
+Optional diagnostic field: add `stepsSource: 'persisted_jobs' | 'legacy_steps'`
+only if frontend/debugging needs it. The first implementation can avoid adding a
+new response field and preserve the current shape.
+
+Status filtering should remain compatible with the existing A2 behavior:
+
+- stored execution status continues to drive list-level execution filtering;
+- step/job statuses are detail-level data until a named product need requires
+  job-level filtering.
+
+### 7. Legacy-Off Tests
+
+A6-1 must prove the feature flag is real:
+
+- rule without opt-in produces the exact same execution/log shape as today;
+- no job rows are inserted when opt-in is off;
+- existing automation-v1 / retry / test-run behavior remains unchanged.
+
+This is the key compatibility gate. If opt-out behavior changes, the runtime
+slice is too broad.
+
+## Runtime Implementation Shape
+
+Recommended structure for the future runtime PR:
+
+1. Add migration + DB types for `multitable_automation_jobs` and the rule
+   opt-in flag.
+2. Add a small `AutomationJobService` responsible only for job persistence and
+   C1 row mapping.
+3. Extend `AutomationService.executeRule()` to choose legacy executor vs
+   job-persisting executor path based on the rule opt-in flag.
+4. Refactor `AutomationExecutor.executeActions()` only as much as needed to
+   expose per-action lifecycle callbacks or a small linear action runner.
+5. Update A2 detail mapping to prefer persisted jobs when present.
+
+Avoid putting DB writes directly inside each individual action executor. The
+action executors should continue to perform domain side effects; job lifecycle
+should sit around them.
+
+## Required Runtime Tests
+
+Focused unit tests:
+
+- opt-out rule inserts no job rows and preserves current execution shape;
+- opt-in success path writes one queued/running/resolved job per action;
+- opt-in failed action writes failed job plus skipped jobs for remaining actions;
+- job rows pass `normalizeWorkflowJob()`;
+- result/error are redacted before job persistence;
+- A2 detail prefers persisted jobs and falls back to legacy steps;
+- future-state status filters remain legal empty results before A6-2.
+
+Real DB / migration tests:
+
+- migration replay creates the jobs table and rule opt-in field;
+- execution row + job rows round-trip through Kysely;
+- delete/retention behavior is explicit. If execution cleanup deletes old
+  execution rows, job cleanup must not leave orphaned job rows.
+
+Regression tests:
+
+- A5 whole-execution retry still creates a new execution and does not become
+  step-level retry;
+- `/test` and retry routes continue returning redacted persisted/fallback
+  execution responses;
+- schedule-trigger and event-trigger legacy paths remain unchanged when opt-in
+  is off.
+
+## Open Decisions Before Runtime
+
+These must be answered in the A6-1 implementation PR body before code is merged:
+
+1. Is `execution_mode` the final opt-in storage, or should the flag live in a
+   JSON config column to avoid widening `automation_rules`?
+2. Should A6-1 use deterministic job ids based on execution + step index, or
+   random ids plus a unique `(execution_id, step_index)` constraint?
+3. Should job write failure before action start fail closed for opted-in rules?
+   This scout recommends yes.
+4. Should execution cleanup cascade to jobs or should jobs have their own
+   retention policy?
+5. Should A2 expose a `stepsSource` diagnostic field, or keep response shape
+   unchanged?
+
+## Acceptance For This Scout
+
+- Docs-only diff.
+- A6-1 scout answers the seven A6-0 questions.
+- Canonical TODO/forward docs say A6-1 scout is recorded while runtime remains
+  unstarted.
+- No migration, route, service, executor, frontend, or test files changed.
+
+## Current Recommendation
+
+Proceed to A6-1 runtime only after owner confirms the concrete demand and
+accepts the opt-in persistent-job write cost. The implementation should be one
+small runtime PR, not an A6 monolith.

--- a/docs/development/multitable-automation-a6-convergence-scout-20260529.md
+++ b/docs/development/multitable-automation-a6-convergence-scout-20260529.md
@@ -6,6 +6,7 @@ Runtime: not started
 Companions:
 - `docs/development/run-governance-forward-plan-20260528.md`
 - `docs/development/multitable-automation-run-governance-todo-20260527.md`
+- `docs/development/multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md`
 - `docs/research/approval-automation-convergence-rfc-20260526.md`
 
 ## Verdict
@@ -13,9 +14,10 @@ Companions:
 A6 can be opened only as a docs-only scout / scope-gate slice right now. A6
 runtime remains frozen and demand-gated.
 
-The next runtime step is not "build the workflow engine". If a named product or
-integration demand arrives, the first runtime slice must be a separately
-reviewed A6-1 persistent `WorkflowJob` runtime scout, with a feature flag /
+The next runtime step is not "build the workflow engine". The A6-1 persistent
+`WorkflowJob` runtime scout is now recorded in
+`multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md`; runtime
+still requires a separate implementation unlock with a feature flag /
 compatibility gate and no default behavior change for existing automation rules.
 
 This document records the sequence, boundaries, risks, and future test surface so
@@ -75,7 +77,7 @@ The dependency order is fixed, but it is not a schedule.
 | Step | Name | First deliverable after opt-in | Gate |
 |---|---|---|---|
 | A6-0 | Scout / scope gate | This docs-only document | done by this slice |
-| A6-1 | Persistent WorkflowJob runtime | design scout, then feature-flagged linear job persistence | named demand |
+| A6-1 | Persistent WorkflowJob runtime | design scout recorded; next is feature-flagged linear job persistence | named demand |
 | A6-2 | Suspend/resume | external-event/webhook resume before delay/timer resume | named demand |
 | A6-3 | Branch/parallel DAG | condition/parallel nodes with upstream/downstream graph fields | named demand |
 | A6-4 | BPMN adapter | compile/preview + gap report only; no live BPMN runtime | named demand |
@@ -84,6 +86,12 @@ The dependency order is fixed, but it is not a schedule.
 ### A6-1 — Persistent WorkflowJob Runtime
 
 Goal: persist per-step job state without changing default execution semantics.
+
+The docs-only runtime scout is recorded in
+`multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md`. It recommends
+a new `multitable_automation_jobs` table, rule-level opt-in, inline linear job
+persistence, A1 redaction reuse, and A2/A3 mixed legacy/persisted rendering.
+It does not start runtime.
 
 Runtime unlock requirements:
 
@@ -256,9 +264,9 @@ A6 must not:
 
 ## Current Recommendation
 
-Stop after this A6-0 document unless a named A6 demand is provided.
+Stop after the A6-1 scout unless a named A6 runtime demand is provided.
 
-The healthiest next technical action, when demand appears, is A6-1 scout only:
-feature-flagged persistent job runtime for linear automation, with legacy rules
-unchanged by default. Anything beyond that is exciting, sharp, and currently too
-large to sneak in through a side door.
+The healthiest next technical action, when demand appears, is a small A6-1
+runtime PR: feature-flagged persistent job runtime for linear automation, with
+legacy rules unchanged by default. Anything beyond that is exciting, sharp, and
+currently too large to sneak in through a side door.

--- a/docs/development/multitable-automation-run-governance-todo-20260527.md
+++ b/docs/development/multitable-automation-run-governance-todo-20260527.md
@@ -2,9 +2,9 @@
 
 Date: 2026-05-27
 Scope: multitable automation run governance + whole-execution retry only
-Status: A0-A5 closed through retry runtime + redaction invariant hardening (2026-05-29); A6-0 docs-only scout recorded; A6 runtime remains frozen / demand-gated
+Status: A0-A5 closed through retry runtime + redaction invariant hardening (2026-05-29); A6-0 and A6-1 docs-only scouts recorded; A6 runtime remains frozen / demand-gated
 Companion: multitable-automation-run-governance-development-20260527.md
-Depends on (landed): C1 contract workflow-job-contract.ts (#1889, not-wired); RFC #1885
+Depends on (landed): C1 contract workflow-job-contract.ts (#1889, read-boundary wired only); RFC #1885
 
 ## Closeout Snapshot — 2026-05-29
 
@@ -18,6 +18,8 @@ The governance half and named A5 retry runtime are complete on `origin/main`:
 - A4 retry scope gate / design lock: #2039.
 - A5 whole-execution retry runtime: #2047.
 - A1/A5 HTTP serialization hardening: #2051 + #2053.
+- A6-0 convergence scout and A6-1 persistent `WorkflowJob` runtime scout are
+  recorded as docs-only planning artifacts. Runtime remains unstarted.
 
 This closeout does NOT mark the convergence engine complete. A6 remains frozen /
 demand-gated: persistent WorkflowJob runtime, suspend/resume, branch/parallel,
@@ -74,7 +76,8 @@ Already present before this line:
 - frontend redacted support packet utility
 - scheduler leader lock for in-memory timers
 - DingTalk-specific redactor in executor (redactDingTalkFailureAlertText) — to be CONSOLIDATED, not extended
-- C1 WorkflowJob contract (workflow-job-contract.ts, #1889) — LANDED, NOT WIRED
+- C1 WorkflowJob contract (workflow-job-contract.ts, #1889) — LANDED, wired only
+  at the A2 read boundary; not runtime-wired into the executor
   (WorkflowJobStatus 8-state; legacyAutomationStatusToJobStatus: success->resolved, rest identity)
 
 Completed by this governance-half line:
@@ -94,7 +97,7 @@ Completed by the named A4/A5 retry line:
 - whole-execution retry route, provenance, and side-effect confirmation — #2047.
 - HTTP response serialization invariant for `/test` + retry — #2051 + #2053.
 
-Deferred (capability half — A6, frozen/demand-gated; A6-0 scout only is recorded):
+Deferred (capability half — A6, frozen/demand-gated; A6-0/A6-1 scouts only are recorded):
 
 - persistent automation_jobs runtime; suspend/resume; branch/parallel
 - BPMN compile/preview adapter; approval-as-job bridge
@@ -243,7 +246,9 @@ mark the convergence engine complete.
 - [x] Governance inheritance: any capability reuses this line's
       run/job/status/provenance/redaction/replay substrate (no second-class layer).
 - [x] No runtime in this milestone.
-- [ ] A6-1 persistent WorkflowJob runtime scout / implementation — not started.
+- [x] A6-1 persistent WorkflowJob runtime scout recorded in
+      `multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md`.
+- [ ] A6-1 persistent WorkflowJob runtime implementation — not started.
 - [ ] A6-2 suspend/resume runtime — not started.
 - [ ] A6-3 branch/parallel DAG runtime — not started.
 - [ ] A6-4 BPMN compile/preview adapter — not started.

--- a/docs/development/run-governance-forward-plan-20260528.md
+++ b/docs/development/run-governance-forward-plan-20260528.md
@@ -2,6 +2,7 @@
 
 > 类型：**前向开发安排（forward plan）**，非开工清单。
 > **2026-05-29 update**：A4 retry scope-gate (#2039) + A5 whole-execution retry runtime (#2047) 已按具名 opt-in 落地；`/test` + retry HTTP serialization redaction/fail-open hardening 已由 #2051/#2053 闭合。A6-0 docs-only scout 已记录在 `multitable-automation-a6-convergence-scout-20260529.md`；A6 runtime 仍 frozen / demand-gated。
+> **2026-05-30 update**：A6-1 persistent `WorkflowJob` runtime scout 已记录在 `multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md`。它回答 table shape / opt-in / worker / side-effect boundary / redaction / mixed read model / legacy-off tests；runtime 仍未启动。
 > 配套（已收口）：`multitable-automation-run-governance-development-20260527.md` + `-todo-20260527.md`（#1987 固化）。
 > 上游契约：C1 `workflow-job-contract.ts`（#1889，landed）· 收敛 RFC #1885。
 > 锁：**K3 Stage-1 blanket 锁已退役（#1993；#1792 = M1 单条 Material Save-only PASS）→ 改用 post-GATE scoped gates（见 `k3-post-gate-scoped-governance-20260528.md`）**。这不改变本线纪律：**治理半（A0–A3）属于内核治理 / observability，已关闭**；**能力半（A4–A6）仍各受需求闸 / 独立具名 opt-in**（本线天然为 multitable 内核范畴，不依赖 integration-core / RBAC / auth），除非对应 scout 明确授权。
@@ -16,7 +17,7 @@
 |---|---|---|---|
 | **治理半**（observability：快照→脱敏→只读 API→admin UI→可达） | 运行可观测/可审计/可诊断 | **✅ 100% + 文档固化** | 否 —— 已关闭，不重开 |
 | **Retry 能力薄片**（A4/A5：whole-execution retry） | 失败/跳过 run 可由 admin 显式确认后整 run 重跑 | **✅ 100% for A5 v1** | 否 —— 已关闭；UI/idempotency/record-refresh 另需 opt-in |
-| **收敛引擎能力半**（A6：suspend/resume / branch / DAG / approval-as-job） | automation+approval 统一到 WorkflowJob 引擎 | **⬜ 引擎本体 0%**（契约层就位、被读边界消费；机器本体未建） | 否 —— **受需求闸，未触发即过早工程** |
+| **收敛引擎能力半**（A6：persistent jobs / suspend/resume / branch / DAG / approval-as-job） | automation+approval 统一到 WorkflowJob 引擎 | **⬜ 引擎本体 0%**（A6-0/A6-1 scout 已记录；契约层就位、被读边界消费；机器本体未建） | 否 —— **受需求闸，未触发即过早工程** |
 
 > **grounded 2026-05-29**：`/retry` 路由已存在且仅实现 A5 whole-execution retry；`automation-executor.ts` 仍无 suspend/resume/branch/persist-job runtime；C1 契约仅被 `routes/automation.ts` 在 A2 读边界用作状态映射（`success→resolved`），job/suspend/branch 机器未被任何 runtime 引用。
 
@@ -65,8 +66,9 @@
 ### A6 — 收敛引擎 🔒 frozen / 需求驱动
 依赖序：**持久 WorkflowJob runtime → suspend/resume（先 webhook 后 delay）→ branch/parallel（DAG）→ BPMN compile/preview adapter → approval-as-job**。
 - **A6-0 scout**：`multitable-automation-a6-convergence-scout-20260529.md` 只记录边界/顺序/测试面；它不是 runtime unlock。
+- **A6-1 scout**：`multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md` 已回答第一片 runtime 的七个设计问题；它仍不是 runtime unlock。
 - **触发信号**：某个**集成/DF 流水线真的需要 human-in-the-loop**（"导入→清洗→**等人工审批**→导出"= suspend + approval-as-job）或按记录分支；**且本就在 K3 GATE 下游**。
-- **解锁后第一步**：持久 WorkflowJob runtime（wire #1889）—— **风险：热路径重写（每 action 一次 DB 写 = 写放大 + 事务性 + 旧规则兼容）→ 必带 flag / 向后兼容**，现有 fire-and-forget 规则不得突然全量持久。
+- **解锁后第一步**：持久 WorkflowJob runtime（wire #1889）—— 按 A6-1 scout 的推荐形状：新 `multitable_automation_jobs` 表、rule-level opt-in、inline linear job persistence、A1 redaction 复用、A2/A3 混合 legacy/persisted 渲染。**风险：热路径重写（每 action 一次 DB 写 = 写放大 + 事务性 + 旧规则兼容）→ 必带 flag / 向后兼容**，现有 fire-and-forget 规则不得突然全量持久。
 - **治理继承硬契约**：A6 任一能力落地必须**复用本线的 run/job/status/provenance/redaction 底座**，不得新建二等可观测层。
 - **BPMN 永久定位**：compile/preview adapter（编译成 auto/approval 定义），**永不自己执行**（否则第四套状态孤岛）。
 - **锁姿态**：🔒🔒 全 frozen。approval-as-job 排最后（最高价值+最高风险，completion-event-contract 先行）。
@@ -113,4 +115,4 @@
 
 ## 8. 一句话排期
 
-**治理半已完成、A5 whole-execution retry v1 已完成、文档固化后不重开。A6 收敛引擎仍 frozen / demand-gated。** 近期"开发安排"实质是：**本 session 待命做点名 review；A5 的运行效果用于判断是否需要 retry UI / idempotency / A6；A6 本就排在 K3/DF 成熟需求下游。** 触发出现 → 走 §7 流程。无触发 → 不动，这就是正确的安排。
+**治理半已完成、A5 whole-execution retry v1 已完成、A6-0/A6-1 scout 已记录、文档固化后不重开。A6 收敛引擎 runtime 仍 frozen / demand-gated。** 近期"开发安排"实质是：**本 session 待命做点名 review；A5 的运行效果用于判断是否需要 retry UI / idempotency / A6；A6 本就排在 K3/DF 成熟需求下游。** 触发出现 → 走 §7 流程。无触发 → 不动，这就是正确的安排。


### PR DESCRIPTION
## Summary

- Adds the A6-1 persistent `WorkflowJob` runtime scout for multitable automation.
- Answers the seven A6-0 runtime-scout questions: table shape, opt-in flag, worker/claim posture, side-effect boundary, redaction helper, mixed legacy/persisted read model, and legacy-off tests.
- Updates the canonical A6 / run-governance TODO / forward-plan docs to record A6-1 scout as done while keeping A6 runtime frozen / demand-gated.

## Scope

Docs-only:

- `docs/development/multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md`
- `docs/development/multitable-automation-a6-convergence-scout-20260529.md`
- `docs/development/multitable-automation-run-governance-todo-20260527.md`
- `docs/development/run-governance-forward-plan-20260528.md`

No migration, route, service, executor, frontend, or test file changes.

## Key Decisions Captured

- A6-1 runtime may be next, but only as a separate opt-in implementation PR.
- Recommended first runtime shape: new `multitable_automation_jobs` table, rule-level opt-in, inline linear job persistence, A1 redaction reuse, and A2/A3 mixed legacy/persisted rendering.
- No worker/claim, suspend/resume, branch/parallel, BPMN, or approval-as-job in A6-1.
- Existing automation rules must stay legacy by default; no sudden per-action DB write amplification.

## Verification

- `git diff --check origin/main..HEAD`
- docs-only guard: `git diff --name-only origin/main..HEAD | grep -vE '^docs/development/.*\.md$' || true`

No runtime tests run; this is docs-only.
