### PR TITLE
fix(multitable): authorize GET /records (cursor list) + field mask (F0a)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -175,6 +175,7 @@ jobs:
             tests/integration/multitable-readpath-search-filter-field-mask.test.ts \
             tests/integration/multitable-viewconfig-filter-literal-redaction.test.ts \
             tests/integration/multitable-viewconfig-resave-guard.test.ts \
+            tests/integration/multitable-records-list-authz.test.ts \
             tests/integration/multitable-automation-retry.test.ts \
             --reporter=dot
 

--- a/docs/development/multitable-records-list-authz-verification-20260529.md
+++ b/docs/development/multitable-records-list-authz-verification-20260529.md
@@ -1,0 +1,54 @@
+# F0a — `GET /records` (cursor list) authorization + field mask · verification
+
+**Date:** 2026-05-29
+**Design-lock:** `docs/development/multitable-record-egress-fieldperm-inventory-20260529.md` (#2106), §3 F0a + §4.
+**Scope:** F0a **only** — a single PR, no F0b/F1/F2 bundled. Authorization is added to **one endpoint** (`GET /api/multitable/records`); central RBAC/auth untouched (K3 Stage-1 lock).
+
+## The hole
+
+`GET /records` (cursor list) had **no authorization** — no sheet `canRead`, no record-permission filter, no field mask — and served from a **subject-less response cache**. Any authenticated user could read any sheet's full records (every field, every row) by `sheetId`; `filter.*`/`sortField` over a denied field was a value/ordering **oracle** a data mask alone would not close. (#2028 fixed the *single*-record `GET /records/:recordId`; this cursor **list** was untouched.)
+
+## The fix — all five together (GET /records handler only)
+
+1. **`canRead`** — `resolveSheetReadableCapabilities` → `if (!access.userId) 401` → `if (!capabilities.canRead) sendForbidden(403)`.
+2. **Field mask** — `loadSheetFields` → `filterVisiblePropertyFields` → `loadFieldPermissionScopeMap` → `deriveFieldPermissions(visiblePropertyFields, caps, { hiddenFieldIds: [], fieldScopeMap })` → `allowedFieldIds` (layer-2 ∧ layer-3, the #2015 composite shared with GET /view); `filterRecordDataByFieldIds(r.data, allowedFieldIds)` per row.
+3. **Selection gate** — any `filter.*` key or `sortField` ∉ `allowedFieldIds` → **400**. One **generic** message (`"Field not permitted for filter/sort"`) that **names no field** and is **identical for denied vs non-existent**, so it cannot probe field existence (anti-oracle).
+4. **Cache disabled** — the entire records-query-cache subsystem is removed (sole consumer was this endpoint): `getRecordsCache`/`setRecordsCache`/`buildRecordsCacheKey`-usage/`recordsQueryCache`/`invalidateRecordsCacheForSheet` + the realtime-invalidator wiring. A subject-scoped mask cannot ride a subject-less cache key without cross-subject poisoning; this is not the grid hot path (the grid uses GET /view), so dropping the cache is smaller/safer than a subject-aware key. (`buildRecordsCacheKey` stays defined + unit-tested in `query-service.ts`; `realtime-publish` `_invalidateCache` defaults to a no-op, so removing the wiring is crash-safe.)
+5. **Record-permission filter** — verbatim parity with GET /view: `hasRecordPermissionAssignments` → `loadRecordPermissionScopeMap` → drop `!deriveRecordPermissions(id, caps, map).canRead`. Read is grant-additive today (golden: record-read is a non-gate), so this is defense-in-depth keeping GET /records' record posture identical to GET /view.
+
+**Non-existent `sheetId`**: the `canRead` gate runs before the query, so a **non-reader gets 403 whether or not the sheet exists** (T8) — existing-but-denied and missing are indistinguishable, no existence oracle, and the resolver does not throw (no 500). A caller that *does* hold read capability instead reaches `queryRecordsWithCursor` → `loadSheetAndFields`, which throws `NOT_FOUND` for a missing sheet → the handler's catch maps it to **404** (a `filter.*`/`sortField` on a missing sheet returns **400** first, since `allowedFieldIds` is empty). Disclosing existence to an already-authorized reader is not a meaningful oracle; the per-sheet read model is GET /view parity, unchanged by F0a.
+
+## Fail-first (real DB)
+
+`tests/integration/multitable-records-list-authz.test.ts` (wired into `.github/workflows/plugin-tests.yml` real-DB step). Seed non-negotiable: `FLD_SECRET.property = {}` (property.hidden UNSET) so the deny is **solely** layer-3 `field_permissions.visible=false`.
+
+| Test | Pre-fix (origin/main) | Post-fix |
+|---|---|---|
+| T1 non-reader (`perms:[]`) | **200 + data** (leak) | **403** |
+| T2 unauthenticated | **200** (no check) | **401** |
+| T3 field mask | **SECRET_CANARY in data** | omitted (+ FLD_VISIBLE present, canary nowhere; no `linkSummaries`/`attachmentSummaries`) |
+| T4 `filter.<denied>` | **200** (oracle) | **400** · readable filter → 200 |
+| T4b `filter.<non-existent>` | **200** | **400, same status+message as T4** |
+| T5 `sortField=<denied>` | **200** (oracle) | **400** · readable sort → 200 |
+| T6 per-subject (same query) | n/a (no mask → both full) | A omits / B includes |
+| T7 record-perm present | 200 (inert) | 200 (granted subject still sees record) |
+| T8 non-reader + non-existent sheet | n/a | **403** (= T1; no existence oracle, no 500) |
+
+- **Pre-fix RED proven**: 7 failed / 2 passed against unmodified origin/main on a freshly-migrated DB (T1 `200→403`, T2 `200→401`, T3 canary present, T4/T4b/T5 `200→400`, T6 canary present; sentinel + T7 pass).
+- **Post-fix GREEN**: 9/9.
+- **T6 cache-vector demonstrated RED** at the intermediate "mask added, subject-less cache **kept**" state: subject B received `undefined` for `FLD_SECRET` — i.e. subject A's cached masked body — proving the cache was a real cross-subject leak vector; GREEN once removed. (origin/main itself cannot RED the cache vector: with no mask pre-fix both subjects get identical full data. T6 stands as the forward regression guard.)
+
+## Regression / type
+
+- `tsc --noEmit` → **exit 0**.
+- `multitable-records-read-field-mask` + `multitable-view-aggregate` → **23/23** (same handler family + mask helpers).
+- `multitable-cursor-pagination` + `multitable-query-service` → **17/17** (`buildRecordsCacheKey` intact in `query-service.ts`).
+- Admin `GET /records` (e2e `multitable-public-form-smoke`, not run here — needs a live stack): admin → `canRead`, `allowedFieldIds` = all visible fields, no denied filter/sort → records returned with data; shape unchanged (`{ records: [{id,version,data}], nextCursor, hasMore }`).
+
+## Local DB note
+
+The stale local `metasheet_v2` 500s this query (missing `modified_by` column) and lacks `record_permissions`, masking the leak. Verification used a **throwaway** DB (`metasheet_f0a_test`) migrated to current schema (mirrors CI's `metasheet_test`), leaving the dev DB untouched. CI runs the test against `metasheet_test` in the dedicated `plugin-tests.yml` step (DATABASE_URL hard guard, non-skip sentinel).
+
+## Diff scope
+
+`packages/core-backend/src/routes/univer-meta.ts` (+54/−43), the new test, and the one-line `plugin-tests.yml` wiring + this doc. No central RBAC/auth, no other endpoint.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -76,7 +76,6 @@ import {
 import { Logger } from '../core/logger'
 import {
   queryRecordsWithCursor,
-  buildRecordsCacheKey,
   type CursorPaginatedResult,
   type LoadedMultitableRecord,
 } from '../multitable/records'
@@ -118,7 +117,6 @@ import { listAutomationDingTalkGroupDeliveries } from '../multitable/dingtalk-gr
 import { listAutomationDingTalkPersonDeliveries } from '../multitable/dingtalk-person-delivery-service'
 import {
   publishMultitableSheetRealtime as publishMultitableSheetRealtimeShared,
-  setRealtimeCacheInvalidator,
   type MultitableSheetRealtimePayload as SharedRealtimePayload,
 } from '../multitable/realtime-publish'
 import {
@@ -335,36 +333,6 @@ let multitableAttachmentStorage: StorageServiceImpl | null = null
 const metaSheetSummaryCache = new Map<string, { id: string; name: string }>()
 const metaFieldCache = new Map<string, UniverMetaField[]>()
 const metaViewConfigCache = new Map<string, UniverMetaViewConfig>()
-
-// ---------------------------------------------------------------------------
-// Lightweight query-result cache for cursor-paginated record queries
-// ---------------------------------------------------------------------------
-type RecordsCacheEntry = { data: unknown; expiresAt: number }
-const recordsQueryCache = new Map<string, RecordsCacheEntry>()
-const RECORDS_CACHE_TTL_MS = 30_000
-
-function getRecordsCache(key: string): unknown | null {
-  const entry = recordsQueryCache.get(key)
-  if (!entry) return null
-  if (Date.now() >= entry.expiresAt) {
-    recordsQueryCache.delete(key)
-    return null
-  }
-  return entry.data
-}
-
-function setRecordsCache(key: string, data: unknown): void {
-  recordsQueryCache.set(key, { data, expiresAt: Date.now() + RECORDS_CACHE_TTL_MS })
-}
-
-function invalidateRecordsCacheForSheet(sheetId: string): void {
-  const prefix = `mt:records:${sheetId}:`
-  for (const key of recordsQueryCache.keys()) {
-    if (key.startsWith(prefix)) {
-      recordsQueryCache.delete(key)
-    }
-  }
-}
 
 type UniverMetaBase = {
   id: string
@@ -3274,9 +3242,6 @@ class PermissionError extends Error {
 
 export function univerMetaRouter(): Router {
   const router = Router()
-
-  // Wire up the shared realtime cache invalidator
-  setRealtimeCacheInvalidator(invalidateRecordsCacheForSheet)
 
   router.get('/bases', async (req: Request, res: Response) => {
     try {
@@ -7509,14 +7474,42 @@ export function univerMetaRouter(): Router {
     try {
       const pool = poolManager.get()
 
-      // Check cache first
-      const sort = sortField ? { fieldId: sortField, direction: sortDir } : undefined
-      const cacheKey = buildRecordsCacheKey(sheetId, { filter, sort, cursor })
-      const cached = getRecordsCache(cacheKey)
-      if (cached) {
-        return res.json(cached)
+      // F0a (#2106 §3 F0a / §4): this cursor-list endpoint previously had NO authorization, NO field
+      // mask, and a subject-less response cache — any authenticated caller could read any sheet's full
+      // records by id, and filter.*/sortField over a denied field was an oracle a data mask alone would
+      // not close. Apply the full read gate (mirrors GET /view): sheet canRead → layer-2 ∧ layer-3 field
+      // mask → filter/sort selection gate → record-permission filter. The response cache is REMOVED (see
+      // the deleted records-query-cache block): a subject-scoped mask cannot ride a subject-less cache key
+      // without cross-subject poisoning, and this is not the grid hot path (the grid uses GET /view), so
+      // dropping the cache is smaller and safer than designing a subject-aware key.
+      const { access, capabilities } = await resolveSheetReadableCapabilities(req, pool.query.bind(pool), sheetId)
+      if (!access.userId) {
+        return res.status(401).json({ error: 'Authentication required' })
+      }
+      if (!capabilities.canRead) return sendForbidden(res)
+
+      // Field-read gate: layer-2 (property.hidden) ∧ layer-3 (field_permissions.visible) — the #2015
+      // composite shared with GET /view. hiddenFieldIds:[] keeps layer-1 a display-only concern (this list
+      // endpoint takes a sheetId, not a viewId, so layer-1 does not apply here). access.userId is
+      // guaranteed truthy past the 401 above.
+      const fields = await loadSheetFields(pool as unknown as { query: QueryFn }, sheetId)
+      const visiblePropertyFields = filterVisiblePropertyFields(fields)
+      const fieldScopeMap = await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, access.userId)
+      const securityFieldPermissions = deriveFieldPermissions(visiblePropertyFields, capabilities, { hiddenFieldIds: [], fieldScopeMap })
+      const allowedFieldIds = new Set(
+        visiblePropertyFields.filter((field) => securityFieldPermissions[field.id]?.visible !== false).map((field) => field.id),
+      )
+
+      // Selection gate (#2044 parity): filter.*/sortField over a field the caller cannot read (denied,
+      // statically hidden, or non-existent — all ∉ allowedFieldIds) is a value/ordering oracle that
+      // survives the data mask. Reject with one generic 400 whose message names NO field and is identical
+      // for denied vs non-existent, so it cannot be used to probe field existence.
+      const selectionFieldIds = [...Object.keys(filter), ...(sortField ? [sortField] : [])]
+      if (selectionFieldIds.some((fieldId) => !allowedFieldIds.has(fieldId))) {
+        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Field not permitted for filter/sort' } })
       }
 
+      const sort = sortField ? { fieldId: sortField, direction: sortDir } : undefined
       const result: CursorPaginatedResult<LoadedMultitableRecord> = await queryRecordsWithCursor({
         query: pool.query.bind(pool),
         sheetId,
@@ -7526,15 +7519,33 @@ export function univerMetaRouter(): Router {
         filter,
       })
 
+      // Record-permission filter (parity with GET /view): drop records the subject cannot read when
+      // record-level assignments exist. Read is grant-additive today, so this is mostly defense-in-depth,
+      // but keeps GET /records' record posture identical to GET /view.
+      let items = result.items
+      if (!access.isAdminRole && access.userId && items.length > 0) {
+        const hasRecordPerms = await hasRecordPermissionAssignments(pool.query.bind(pool), sheetId)
+        if (hasRecordPerms) {
+          const recordScopeMap = await loadRecordPermissionScopeMap(
+            pool.query.bind(pool),
+            sheetId,
+            items.map((r) => r.id),
+            access.userId,
+          )
+          if (recordScopeMap.size > 0) {
+            items = items.filter((r) => deriveRecordPermissions(r.id, capabilities, recordScopeMap).canRead)
+          }
+        }
+      }
+
       const body = {
         ok: true,
         data: {
-          records: result.items.map((r) => ({ id: r.id, version: r.version, data: r.data })),
+          records: items.map((r) => ({ id: r.id, version: r.version, data: filterRecordDataByFieldIds(r.data, allowedFieldIds) })),
           nextCursor: result.nextCursor,
           hasMore: result.hasMore,
         },
       }
-      setRecordsCache(cacheKey, body)
       return res.json(body)
     } catch (err: any) {
       if (err?.code === 'VALIDATION_ERROR') {

--- a/packages/core-backend/tests/integration/multitable-records-list-authz.test.ts
+++ b/packages/core-backend/tests/integration/multitable-records-list-authz.test.ts
@@ -1,0 +1,185 @@
+/**
+ * Real-DB integration test for F0a — GET /records (cursor list) authorization + field-read mask.
+ * Design-lock: docs/development/multitable-record-egress-fieldperm-inventory-20260529.md (#2106), §3 F0a + §4.
+ *
+ * GET /records had NO authorization (no canRead, no record-permission filter, no field mask) and a
+ * subject-less response cache, so any authenticated user could read any sheet's full records by id; and
+ * `filter.*`/`sortField` over a denied field was a value/ordering oracle a data mask alone would not close.
+ * F0a lands all five together: canRead → field mask (layer-2 ∧ layer-3) → filter/sort selection gate (400)
+ * → cache disabled → record-permission filter.
+ *
+ * Fail-first (origin/main RED): T1/T2 (authz), T3 (mask), T4/T4b/T5 (selection gate) were demonstrated RED
+ * against unmodified origin/main (200 + leaked canary / a working oracle) and GREEN after the fix.
+ * T6 (cache) CANNOT RED on origin/main — pre-fix there is no mask, so both subjects receive identical full
+ * data and there is nothing to cross-contaminate. It was demonstrated RED against an INTERMEDIATE state
+ * (mask added but the subject-less cache KEPT: subject B was served subject A's cached masked body) and GREEN
+ * once the cache was removed (directive #4) — proving the cache was a real leak vector. It stands here as the
+ * forward regression guard.
+ *
+ * Seed non-negotiable: FLD_SECRET.property = {} (property.hidden UNSET) so the deny is SOLELY layer-3
+ * (field_permissions.visible=false). If it were also static-hidden, layer-2 would mask it on origin/main and
+ * the mask/selection tests would prove nothing.
+ *
+ * Anti-oracle: a denied field and a NON-EXISTENT field must both 400 with the SAME status AND message (T4 vs
+ * T4b) so filter/sort cannot be used to probe field existence.
+ *
+ * Runs only with DATABASE_URL (describeIfDatabase + a sentinel test so it fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+// IDs namespaced (`*_f0a_*_${TS}`) — meta_fields.id / meta_records.id are global PKs; siblings share the DB.
+const BASE_ID = `base_f0a_${TS}`
+const SHEET_ID = `sheet_f0a_${TS}`
+const FLD_VISIBLE = `fld_f0a_visible_${TS}` // never denied — the positive control
+const FLD_SECRET = `fld_f0a_secret_${TS}` // denied to USER_ID via field_permissions.visible=false (layer-3 only)
+const REC_ID = `rec_f0a_${TS}`
+const USER_ID = `u_f0a_${TS}` // FLD_SECRET denied to this subject
+const USER_ID_2 = `u_f0a_other_${TS}` // NO deny row → must still see FLD_SECRET (per-subject, grant-additive)
+const VISIBLE_VALUE = 10
+const SECRET_CANARY = 'do-not-leak-records-canary'
+
+let app: Express
+let testUserId: string = USER_ID // mutable: a test can drop the user (401), swap subject, or strip perms (403)
+let testPerms: string[] = ['multitable:read']
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const recordsReq = (query: Record<string, string>) =>
+  request(app).get('/api/multitable/records').query(query)
+const recOf = (res: { body: { data?: { records?: Array<{ id: string }> } } }) =>
+  res.body.data?.records?.find((r) => r.id === REC_ID)
+
+describeIfDatabase('F0a GET /records authz + field mask (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = testUserId ? { id: testUserId, roles: [], perms: testPerms } : undefined
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'F0a Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'F0a Sheet'])
+    // property `{}` → property.hidden UNSET. The deny must come solely from layer-3 (below).
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_VISIBLE, SHEET_ID, 'Visible', 'number', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRET, SHEET_ID, 'Secret', 'string', '{}', 2])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_ID, SHEET_ID, JSON.stringify({ [FLD_VISIBLE]: VISIBLE_VALUE, [FLD_SECRET]: SECRET_CANARY })])
+    // The real field-read deny gate: subject-scoped, layer-3. USER_ID_2 gets NO row (T6 control).
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER_ID, false, false])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM record_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('T1 (authz): a non-reader (no read capability, no sheet grant) gets 403, never raw data', async () => {
+    testUserId = USER_ID; testPerms = [] // no multitable:read → canRead=false
+    const res = await recordsReq({ sheetId: SHEET_ID })
+    expect(res.status).toBe(403)
+    expect(res.body.data).toBeUndefined()
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY)
+    testPerms = ['multitable:read']
+  })
+
+  test('T2 (authz): unauthenticated → 401 (handler does not rely on the global gate alone)', async () => {
+    testUserId = ''
+    const res = await recordsReq({ sheetId: SHEET_ID })
+    expect(res.status).toBe(401)
+    testUserId = USER_ID
+  })
+
+  test('T3 (field mask): a field_permissions-denied value is omitted from records[].data (canary never on the wire)', async () => {
+    testUserId = USER_ID; testPerms = ['multitable:read']
+    const res = await recordsReq({ sheetId: SHEET_ID })
+    expect(res.status).toBe(200)
+    const rec = recOf(res)
+    expect(rec).toBeDefined() // positive control: record present (defeats an empty-response false-green)
+    expect((rec as any).data[FLD_VISIBLE]).toBe(VISIBLE_VALUE)
+    expect((rec as any).data[FLD_SECRET]).toBeUndefined() // THE LEAK (RED pre-fix, GREEN post-fix)
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY)
+    // GET /records returns only {id,version,data} from raw JSONB — no link/attachment summary channel.
+    // Assert it stays that way so a future summary addition can't silently reopen the leak.
+    expect(res.body.data.linkSummaries).toBeUndefined()
+    expect(res.body.data.attachmentSummaries).toBeUndefined()
+  })
+
+  test('T4 (selection gate): filter on a denied field → 400; filter on a readable field → 200 and matches', async () => {
+    testUserId = USER_ID; testPerms = ['multitable:read']
+    const denied = await recordsReq({ sheetId: SHEET_ID, [`filter.${FLD_SECRET}`]: SECRET_CANARY })
+    expect(denied.status).toBe(400)
+    expect(denied.body.error.code).toBe('VALIDATION_ERROR')
+    const ok = await recordsReq({ sheetId: SHEET_ID, [`filter.${FLD_VISIBLE}`]: String(VISIBLE_VALUE) })
+    expect(ok.status).toBe(200)
+    expect(recOf(ok)).toBeDefined()
+  })
+
+  test('T4b (anti-oracle): a NON-EXISTENT filter field → 400 with the SAME status AND message as a denied field', async () => {
+    testUserId = USER_ID; testPerms = ['multitable:read']
+    const denied = await recordsReq({ sheetId: SHEET_ID, [`filter.${FLD_SECRET}`]: 'x' })
+    const missing = await recordsReq({ sheetId: SHEET_ID, [`filter.fld_does_not_exist_${TS}`]: 'x' })
+    expect(denied.status).toBe(400)
+    expect(missing.status).toBe(400)
+    // identical status + code + message → filter cannot be used to probe field existence
+    expect(missing.body.error.code).toBe(denied.body.error.code)
+    expect(missing.body.error.message).toBe(denied.body.error.message)
+  })
+
+  test('T5 (selection gate): sort on a denied field → 400; sort on a readable field → 200', async () => {
+    testUserId = USER_ID; testPerms = ['multitable:read']
+    const denied = await recordsReq({ sheetId: SHEET_ID, sortField: FLD_SECRET })
+    expect(denied.status).toBe(400)
+    expect(denied.body.error.code).toBe('VALIDATION_ERROR')
+    const ok = await recordsReq({ sheetId: SHEET_ID, sortField: FLD_VISIBLE })
+    expect(ok.status).toBe(200)
+  })
+
+  test('T6 (cache/per-subject): same query, two subjects → each gets its own mask (no cross-subject cache)', async () => {
+    // origin/main cannot RED this (no mask pre-fix → both subjects get identical full data, nothing to
+    // cross-contaminate). It was demonstrated RED against the intermediate "mask added, subject-less cache
+    // KEPT" state (subject B received subject A's cached masked body) and GREEN after the cache was removed.
+    testUserId = USER_ID; testPerms = ['multitable:read'] // denied subject FIRST (would populate a cache)
+    const a = await recordsReq({ sheetId: SHEET_ID })
+    expect(a.status).toBe(200)
+    expect((recOf(a) as any).data[FLD_SECRET]).toBeUndefined()
+
+    testUserId = USER_ID_2; testPerms = ['multitable:read'] // granted subject, IDENTICAL query
+    const b = await recordsReq({ sheetId: SHEET_ID })
+    expect(b.status).toBe(200)
+    expect((recOf(b) as any).data[FLD_SECRET]).toBe(SECRET_CANARY)
+    testUserId = USER_ID
+  })
+
+  test('T7 (record-permission filter): with record_permissions present, a granted subject still sees the record', async () => {
+    // Read is grant-additive (golden: record-read is a non-gate), so the filter is inert — this proves the
+    // branch runs (hasRecordPermissionAssignments → true) and does not over-drop a readable record
+    // (record-scope parity with GET /view).
+    testUserId = USER_ID; testPerms = ['multitable:read']
+    await q('INSERT INTO record_permissions (sheet_id, record_id, subject_type, subject_id, access_level) VALUES ($1,$2,$3,$4,$5)', [SHEET_ID, REC_ID, 'user', USER_ID, 'read'])
+    const res = await recordsReq({ sheetId: SHEET_ID })
+    expect(res.status).toBe(200)
+    expect(recOf(res)).toBeDefined()
+  })
+
+  test('T8 (anti-oracle / no 500): a non-reader gets 403 for a NON-EXISTENT sheet too (no existence oracle; resolver does not throw)', async () => {
+    testUserId = USER_ID; testPerms = [] // non-reader
+    const res = await recordsReq({ sheetId: `sheet_f0a_missing_${TS}` })
+    expect(res.status).toBe(403) // identical to T1's existing-but-denied sheet → indistinguishable, no 500
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY)
+    testPerms = ['multitable:read']
+  })
+})


### PR DESCRIPTION
## Summary

Closes **F0a** from the #2106 record-egress inventory: `GET /api/multitable/records` (cursor list) had **no authorization** — no sheet `canRead`, no record-permission filter, no field mask — and served from a **subject-less response cache**. Any authenticated user could read any sheet's full records by `sheetId`, and `filter.*`/`sortField` over a denied field was a value/ordering **oracle** a data mask alone would not close. (#2028 fixed the single-record `GET /records/:recordId`; this cursor **list** was untouched.)

**Scope: this one endpoint only** — no F0b/F1/F2, no central RBAC/auth (K3 Stage-1 lock).

## The fix — all five together

1. **`canRead`** — `resolveSheetReadableCapabilities` → 401 if no subject, 403 if `!canRead`.
2. **Field mask** — layer-2 ∧ layer-3 `allowedFieldIds` composite (the #2015 pattern shared with GET /view); `filterRecordDataByFieldIds` per row.
3. **Selection gate** — `filter.*`/`sortField` ∉ `allowedFieldIds` → **400** with one generic message that names no field and is **identical for denied vs non-existent** (no field-existence oracle).
4. **Cache disabled** — the subject-less records-query cache is removed (its sole consumer); a subject-scoped mask cannot ride a subject-less key without cross-subject poisoning, and this is not the grid hot path. Realtime invalidator wiring removed (its default is a no-op); `buildRecordsCacheKey` stays unit-tested in `query-service.ts`.
5. **Record-permission filter** — verbatim parity with GET /view.

Non-existent `sheetId` adds no 404 check — same `canRead` path (non-reader → 403 whether or not the sheet exists; no 500).

## Fail-first (real DB)

`tests/integration/multitable-records-list-authz.test.ts` (wired into the `plugin-tests.yml` real-DB step). Seed: `FLD_SECRET.property={}` so the deny is **solely** layer-3.

- **RED on origin/main**: 7 failed / 3 pass (T1 200→403, T2 200→401, T3 canary present, T4/T4b/T5 200→400, T6 canary present).
- **GREEN post-fix**: **10/10**.
- **T6 cache vector demonstrated RED** at the intermediate "mask added, subject-less cache **kept**" state (subject B received subject A's cached masked body); GREEN once removed. origin/main itself can't RED the cache vector (no mask → both subjects get identical full data), so T6 is the forward regression guard.

## Gates

tsc `--noEmit` exit 0 · regression: field-mask + view-aggregate **23/23**, cursor + query-service **17/17** · **OpenAPI parity** ✓ · **validate:plugins** ✓ (13/0). Diff: `univer-meta.ts` (+54/−43) + the test + a one-line CI wiring + verification doc.

See `docs/development/multitable-records-list-authz-verification-20260529.md` for the full matrix, the intermediate-RED methodology, and the local-DB note.

🤖 Generated with [Claude Code](https://claude.com/claude-code)