### PR TITLE
fix(attendance): classify highscale runtime failures

### DIFF
--- a/.github/workflows/attendance-import-perf-highscale.yml
+++ b/.github/workflows/attendance-import-perf-highscale.yml
@@ -339,6 +339,7 @@ jobs:
           log_dir="output/playwright/attendance-import-perf-highscale"
           final_log="${log_dir}/perf.log"
           mismatch_file="${log_dir}/perf-capacity-mismatch.json"
+          runtime_file="${log_dir}/perf-runtime-failure.json"
           if PERF_LOG="${final_log}" \
             OUTPUT_FILE="${mismatch_file}" \
             ROWS="${ROWS}" \
@@ -362,6 +363,22 @@ jobs:
               echo "- csv rows limit hint: \`${hint_value}\`"
               echo "- remote csv rows limit: \`${remote_value}\` (${remote_value_source:-unknown})"
               echo "- failure: \`${last_failure_line}\`"
+            } >> "$GITHUB_STEP_SUMMARY"
+          elif PERF_LOG="${final_log}" \
+            OUTPUT_FILE="${runtime_file}" \
+            node ./scripts/ops/attendance-classify-perf-runtime-failure.mjs >/dev/null; then
+            runtime_classification="$(jq -r '.classification // empty' "${runtime_file}")"
+            runtime_signals="$(jq -r '(.signals // []) | join(",")' "${runtime_file}")"
+            last_failure_line="$(jq -r '.failureLine // empty' "${runtime_file}")"
+            suggested_action="$(jq -r '.suggestedAction // empty' "${runtime_file}")"
+            echo "classification=${runtime_classification}" >> "$GITHUB_OUTPUT"
+            {
+              echo "High-scale perf benchmark classified as runtime failure."
+              echo
+              echo "- classification: \`${runtime_classification}\`"
+              echo "- signals: \`${runtime_signals:-<none>}\`"
+              echo "- failure: \`${last_failure_line:-<missing>}\`"
+              echo "- suggested action: ${suggested_action:-inspect perf.log and rerun after remediation}"
             } >> "$GITHUB_STEP_SUMMARY"
           fi
 

--- a/scripts/ops/attendance-classify-perf-runtime-failure.mjs
+++ b/scripts/ops/attendance-classify-perf-runtime-failure.mjs
@@ -1,0 +1,135 @@
+import fs from 'node:fs/promises'
+
+function findLastFailureLine(logText) {
+  const lines = String(logText || '')
+    .split(/\r?\n/)
+    .map((line) => line.trim())
+    .filter(Boolean)
+
+  for (let index = lines.length - 1; index >= 0; index -= 1) {
+    const line = lines[index]
+    if (/^\[attendance-import-perf\] Failed:/.test(line)) {
+      return line
+    }
+  }
+
+  return lines.slice(-40).join(' ').trim()
+}
+
+function hasAny(upper, needles) {
+  return needles.some((needle) => upper.includes(needle))
+}
+
+function collectSignals(logText, failureLine) {
+  const upper = `${logText || ''}\n${failureLine || ''}`.toUpperCase()
+  const signals = []
+
+  if (hasAny(upper, ['HTTP 502', 'BAD GATEWAY'])) signals.push('http_502')
+  if (upper.includes('HTTP 503')) signals.push('http_503')
+  if (upper.includes('HTTP 504')) signals.push('http_504')
+  if (hasAny(upper, ['FETCH FAILED', 'ECONNRESET', 'ETIMEDOUT', 'NETWORK ERROR'])) {
+    signals.push('network_error')
+  }
+  if (upper.includes('ASYNC COMMIT JOB POLL TIMED OUT')) {
+    signals.push('async_commit_poll_timeout')
+  }
+  if (upper.includes('ASYNC COMMIT JOB TIMED OUT')) {
+    signals.push('async_commit_timeout')
+  }
+  if (hasAny(upper, ['STALLMS=', 'NO PROGRESS', 'STALLED'])) {
+    signals.push('async_commit_stall')
+  }
+  if (upper.includes('STATEMENT TIMEOUT')) signals.push('db_statement_timeout')
+  if (upper.includes('DEADLOCK DETECTED')) signals.push('db_deadlock')
+
+  return [...new Set(signals)]
+}
+
+function classifyRuntimeFailure({ logText, failureLine }) {
+  const upper = `${logText || ''}\n${failureLine || ''}`.toUpperCase()
+  if (upper.includes('CSV EXCEEDS MAX ROWS')) return null
+
+  const signals = collectSignals(logText, failureLine)
+  if (signals.length === 0) return null
+
+  const hasGatewayOrNetwork = signals.some((signal) => (
+    signal === 'http_502'
+    || signal === 'http_503'
+    || signal === 'http_504'
+    || signal === 'network_error'
+  ))
+  const hasAsyncCommit = signals.some((signal) => signal.startsWith('async_commit_'))
+
+  if (hasAsyncCommit && hasGatewayOrNetwork) {
+    return {
+      classification: 'async_commit_runtime_unstable',
+      signals,
+      suggestedAction: 'Inspect backend, web/nginx, and container health during the import job window; then decide whether the fix is infra capacity, import throughput, or timeout budget.',
+    }
+  }
+
+  if (signals.includes('async_commit_timeout') || signals.includes('async_commit_poll_timeout')) {
+    return {
+      classification: 'async_commit_timeout',
+      signals,
+      suggestedAction: 'Inspect async import worker throughput and timeout settings for the high-scale commit workload, then rerun the benchmark.',
+    }
+  }
+
+  if (signals.includes('http_502')) {
+    return {
+      classification: 'upstream_502',
+      signals,
+      suggestedAction: 'Inspect web/nginx upstream and backend container health around the benchmark window, then rerun.',
+    }
+  }
+
+  if (signals.includes('http_503') || signals.includes('http_504')) {
+    return {
+      classification: 'upstream_5xx',
+      signals,
+      suggestedAction: 'Inspect gateway upstream health and timeout budget around the benchmark window, then rerun.',
+    }
+  }
+
+  if (signals.includes('db_statement_timeout') || signals.includes('db_deadlock')) {
+    return {
+      classification: 'database_contention',
+      signals,
+      suggestedAction: 'Inspect database slow queries and lock/timeout evidence during the import window, then rerun.',
+    }
+  }
+
+  return null
+}
+
+async function main() {
+  const perfLogPath = process.env.PERF_LOG
+  if (!perfLogPath) {
+    console.error('PERF_LOG is required')
+    process.exit(2)
+  }
+
+  const logText = await fs.readFile(perfLogPath, 'utf8')
+  const failureLine = findLastFailureLine(logText)
+  const classification = classifyRuntimeFailure({ logText, failureLine })
+  if (!classification) {
+    process.exit(1)
+  }
+
+  const payload = {
+    ...classification,
+    failureLine,
+  }
+  const outputJson = `${JSON.stringify(payload, null, 2)}\n`
+  const outputFile = process.env.OUTPUT_FILE
+  if (outputFile) {
+    await fs.writeFile(outputFile, outputJson, 'utf8')
+  }
+  process.stdout.write(outputJson)
+}
+
+main().catch((error) => {
+  console.error(error instanceof Error ? error.message : String(error))
+  process.exit(2)
+})

--- a/scripts/ops/attendance-classify-perf-runtime-failure.test.mjs
+++ b/scripts/ops/attendance-classify-perf-runtime-failure.test.mjs
@@ -1,0 +1,65 @@
+import assert from 'node:assert/strict'
+import { existsSync, mkdtempSync, readFileSync, writeFileSync } from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import { spawnSync } from 'node:child_process'
+import test from 'node:test'
+
+const ROOT_DIR = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..')
+const SCRIPT_PATH = path.join(ROOT_DIR, 'scripts', 'ops', 'attendance-classify-perf-runtime-failure.mjs')
+
+function runClassifier(logText) {
+  const tempRoot = mkdtempSync(path.join(os.tmpdir(), 'attendance-runtime-classify-'))
+  const perfLog = path.join(tempRoot, 'perf.log')
+  const outputFile = path.join(tempRoot, 'perf-runtime-failure.json')
+  writeFileSync(perfLog, logText, 'utf8')
+
+  const result = spawnSync('node', [SCRIPT_PATH], {
+    cwd: ROOT_DIR,
+    env: {
+      ...process.env,
+      PERF_LOG: perfLog,
+      OUTPUT_FILE: outputFile,
+    },
+    encoding: 'utf8',
+  })
+
+  return { ...result, outputFile }
+}
+
+test('classifier marks async commit timeout with gateway errors as runtime unstable', () => {
+  const result = runClassifier([
+    '[attendance-import-perf] WARN: GET /attendance/import/jobs/f0e9 returned HTTP 502; retry 1/2 in 1000ms',
+    '[attendance-import-perf] Failed: async commit job poll timed out after transient errors (last status=502)',
+    '[attendance-import-perf] scenario=100000-commit',
+    '[attendance-import-perf] Failed: async commit job timed out',
+    '',
+  ].join('\n'))
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`)
+  assert.equal(existsSync(result.outputFile), true)
+
+  const payload = JSON.parse(readFileSync(result.outputFile, 'utf8'))
+  assert.equal(payload.classification, 'async_commit_runtime_unstable')
+  assert.deepEqual(
+    payload.signals.sort(),
+    ['async_commit_poll_timeout', 'async_commit_timeout', 'http_502'].sort(),
+  )
+  assert.equal(payload.failureLine, '[attendance-import-perf] Failed: async commit job timed out')
+})
+
+test('classifier marks async commit timeout without gateway evidence separately', () => {
+  const result = runClassifier('[attendance-import-perf] Failed: async commit job timed out\n')
+
+  assert.equal(result.status, 0, `${result.stderr}\n${result.stdout}`)
+  const payload = JSON.parse(readFileSync(result.outputFile, 'utf8'))
+  assert.equal(payload.classification, 'async_commit_timeout')
+  assert.deepEqual(payload.signals, ['async_commit_timeout'])
+})
+
+test('classifier skips capacity mismatch so the dedicated classifier owns that case', () => {
+  const result = runClassifier('[attendance-import-perf] Failed: async commit job failed: CSV exceeds max rows (20000)\n')
+
+  assert.notEqual(result.status, 0)
+  assert.equal(existsSync(result.outputFile), false)
+})

--- a/scripts/ops/attendance-fast-parallel-regression.sh
+++ b/scripts/ops/attendance-fast-parallel-regression.sh
@@ -96,7 +96,7 @@ if [[ "$PROFILE" == "full" || "$PROFILE" == "ops" ]]; then
 
   add_check \
     "ops-perf-highscale-runner-tests" \
-    "node --test scripts/ops/attendance-run-perf-highscale.test.mjs"
+    "node --test scripts/ops/attendance-run-perf-highscale.test.mjs scripts/ops/attendance-classify-perf-capacity-mismatch.test.mjs scripts/ops/attendance-classify-perf-runtime-failure.test.mjs scripts/ops/attendance-highscale-workflow-classification-contract.test.mjs"
 fi
 
 if [[ "$PROFILE" == "contracts" || "$RUN_CONTRACT_CASES" == "true" ]]; then

--- a/scripts/ops/attendance-highscale-workflow-classification-contract.test.mjs
+++ b/scripts/ops/attendance-highscale-workflow-classification-contract.test.mjs
@@ -1,0 +1,31 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+
+const ROOT_DIR = path.resolve(path.dirname(new URL(import.meta.url).pathname), '..', '..')
+const WORKFLOW_PATH = path.join(ROOT_DIR, '.github', 'workflows', 'attendance-import-perf-highscale.yml')
+
+function workflowRaw() {
+  return readFileSync(WORKFLOW_PATH, 'utf8')
+}
+
+test('highscale workflow keeps capacity mismatch as the first classifier', () => {
+  const raw = workflowRaw()
+  const capacityIndex = raw.indexOf('attendance-classify-perf-capacity-mismatch.mjs')
+  const runtimeIndex = raw.indexOf('attendance-classify-perf-runtime-failure.mjs')
+
+  assert.ok(capacityIndex > 0, 'capacity classifier missing')
+  assert.ok(runtimeIndex > 0, 'runtime classifier missing')
+  assert.ok(capacityIndex < runtimeIndex, 'capacity classifier must run before runtime classifier')
+  assert.match(raw, /mismatch_file="\$\{log_dir\}\/perf-capacity-mismatch\.json"/)
+})
+
+test('highscale workflow writes runtime classification into issue output and artifacts', () => {
+  const raw = workflowRaw()
+
+  assert.match(raw, /runtime_file="\$\{log_dir\}\/perf-runtime-failure\.json"/)
+  assert.match(raw, /echo "classification=\$\{runtime_classification\}" >> "\$GITHUB_OUTPUT"/)
+  assert.match(raw, /High-scale perf benchmark classified as runtime failure\./)
+  assert.match(raw, /PERF_CLASSIFICATION: \$\{\{ needs\.perf\.outputs\.classification \|\| '' \}\}/)
+})

--- a/scripts/ops/attendance-run-workflow-dispatch.sh
+++ b/scripts/ops/attendance-run-workflow-dispatch.sh
@@ -90,10 +90,21 @@ if [[ -n "$REF" ]]; then
   fi
 fi
 
+function dispatch_workflow() {
+  local -a args=("$WORKFLOW")
+  if (( ${#workflow_run_args[@]} > 0 )); then
+    args+=("${workflow_run_args[@]}")
+  fi
+  if (( ${#dispatch_attempt_args[@]} > 0 )); then
+    args+=("${dispatch_attempt_args[@]}")
+  fi
+  gh workflow run "${args[@]}"
+}
+
 dispatch_output=''
 dispatch_rc=0
 declare -a dispatch_attempt_args=("${dispatch_args[@]}")
-dispatch_output="$(gh workflow run "$WORKFLOW" "${workflow_run_args[@]}" "${dispatch_attempt_args[@]}" 2>&1)" || dispatch_rc=$?
+dispatch_output="$(dispatch_workflow 2>&1)" || dispatch_rc=$?
 if [[ "$dispatch_rc" -ne 0 ]]; then
   unsupported_inputs="$(extract_unexpected_workflow_inputs "$dispatch_output" || true)"
   if [[ -n "$unsupported_inputs" ]]; then
@@ -121,7 +132,7 @@ if [[ "$dispatch_rc" -ne 0 ]]; then
       dispatch_attempt_args=("${filtered_dispatch_args[@]}")
       dispatch_output=''
       dispatch_rc=0
-      dispatch_output="$(gh workflow run "$WORKFLOW" "${workflow_run_args[@]}" "${dispatch_attempt_args[@]}" 2>&1)" || dispatch_rc=$?
+      dispatch_output="$(dispatch_workflow 2>&1)" || dispatch_rc=$?
     fi
   fi
 fi


### PR DESCRIPTION
## Summary

- Keep the existing high-scale capacity mismatch classifier as the first pass.
- Add a runtime failure classifier for the new #447 shape: HTTP 502 / network instability combined with async commit poll timeout or async commit timeout.
- Emit `perf-runtime-failure.json`, step-summary details, and `PERF_CLASSIFICATION` so future highscale issue comments are actionable instead of generic.
- Fix `attendance-run-workflow-dispatch.sh` on Bash 3.2 + `set -u` when no `--ref` args are present; this was exposed by the ops fast regression.

Refs #447. This is diagnostic/alert hygiene; it does not close the high-scale runtime blocker.

## Verification

- `node --test scripts/ops/attendance-run-workflow-dispatch.test.mjs scripts/ops/attendance-classify-perf-runtime-failure.test.mjs scripts/ops/attendance-highscale-workflow-classification-contract.test.mjs scripts/ops/attendance-classify-perf-capacity-mismatch.test.mjs scripts/ops/attendance-run-perf-highscale.test.mjs`
- `bash -n scripts/ops/attendance-run-workflow-dispatch.sh scripts/ops/attendance-run-perf-highscale.sh scripts/ops/attendance-fast-parallel-regression.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/attendance-import-perf-highscale.yml"); puts "yaml ok"'`
- `git diff --check`
- `PROFILE=ops MAX_PARALLEL=2 bash scripts/ops/attendance-fast-parallel-regression.sh`

## Live evidence

- The new classifier maps the failed high-scale run `26676263080` perf log to `async_commit_runtime_unstable` with signals `http_502`, `async_commit_poll_timeout`, and `async_commit_timeout`.
- Post-failure remote health checks are green:
  - Preflight: https://github.com/zensgit/metasheet2/actions/runs/26676690439
  - Metrics: https://github.com/zensgit/metasheet2/actions/runs/26676690097
