### PR TITLE
fix(phase5): reconcile metrics scrape token

### DIFF
--- a/.github/workflows/attendance-remote-env-reconcile-prod.yml
+++ b/.github/workflows/attendance-remote-env-reconcile-prod.yml
@@ -9,6 +9,10 @@ on:
         description: 'Value for ATTENDANCE_IMPORT_CSV_MAX_ROWS (default 100000)'
         required: false
         default: '100000'
+      ensure_metrics_scrape_token:
+        description: 'Ensure backend runtime METRICS_SCRAPE_TOKEN exists for Phase 5 metrics auth fallback (true/false)'
+        required: false
+        default: 'true'
       skip_host_sync:
         description: 'Optional: skip deploy-host git sync step (true/false). Use for debugging when host sync is broken.'
         required: false
@@ -36,9 +40,11 @@ jobs:
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
           DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
           CSV_MAX_ROWS: ${{ github.event.inputs.csv_max_rows || '100000' }}
+          ENSURE_METRICS_SCRAPE_TOKEN: ${{ github.event.inputs.ensure_metrics_scrape_token || 'true' }}
           SKIP_HOST_SYNC: ${{ github.event.inputs.skip_host_sync || 'false' }}
           DEPLOY_JWT_SECRET: ${{ secrets.DEPLOY_JWT_SECRET || secrets.JWT_SECRET || '' }}
           DEPLOY_BCRYPT_SALT_ROUNDS: ${{ vars.DEPLOY_BCRYPT_SALT_ROUNDS || '12' }}
+          DEPLOY_METRICS_SCRAPE_TOKEN: ${{ secrets.METRICS_SCRAPE_TOKEN || '' }}
         run: |
           set -euo pipefail
           mkdir -p ~/.ssh
@@ -49,6 +55,7 @@ jobs:
           DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
           DEPLOY_COMPOSE_FILE="${DEPLOY_COMPOSE_FILE:-docker-compose.app.yml}"
           CSV_MAX_ROWS="${CSV_MAX_ROWS:-100000}"
+          ENSURE_METRICS_SCRAPE_TOKEN="${ENSURE_METRICS_SCRAPE_TOKEN:-true}"
           SKIP_HOST_SYNC="${SKIP_HOST_SYNC:-false}"
 
           if [[ ! "${CSV_MAX_ROWS}" =~ ^[0-9]+$ ]]; then
@@ -68,9 +75,11 @@ jobs:
             "DEPLOY_PATH=\"${DEPLOY_PATH}\""
             "DEPLOY_COMPOSE_FILE=\"${DEPLOY_COMPOSE_FILE}\""
             "CSV_MAX_ROWS=\"${CSV_MAX_ROWS}\""
+            "ENSURE_METRICS_SCRAPE_TOKEN=\"${ENSURE_METRICS_SCRAPE_TOKEN}\""
             "SKIP_HOST_SYNC=\"${SKIP_HOST_SYNC}\""
             "DEPLOY_JWT_SECRET=\"${DEPLOY_JWT_SECRET:-}\""
             "DEPLOY_BCRYPT_SALT_ROUNDS=\"${DEPLOY_BCRYPT_SALT_ROUNDS:-12}\""
+            "DEPLOY_METRICS_SCRAPE_TOKEN=\"${DEPLOY_METRICS_SCRAPE_TOKEN:-}\""
             'if [[ "${DEPLOY_PATH}" == /* ]]; then'
               '  DEPLOY_REPO_PATH="${DEPLOY_PATH}"'
             'elif [[ "${DEPLOY_PATH}" == ~/* ]]; then'
@@ -118,7 +127,7 @@ jobs:
             '  reconcile_rc="$host_sync_rc"'
             "else"
               "  set +e"
-              '  CSV_MAX_ROWS="${CSV_MAX_ROWS}" ENV_FILE="docker/app.env" COMPOSE_FILE="${DEPLOY_COMPOSE_FILE}" NGINX_CONF="docker/nginx.conf" DEPLOY_JWT_SECRET="${DEPLOY_JWT_SECRET:-}" DEPLOY_BCRYPT_SALT_ROUNDS="${DEPLOY_BCRYPT_SALT_ROUNDS:-12}" RESTART_BACKEND=true scripts/ops/attendance-reconcile-csv-cap.sh'
+              '  CSV_MAX_ROWS="${CSV_MAX_ROWS}" ENV_FILE="docker/app.env" COMPOSE_FILE="${DEPLOY_COMPOSE_FILE}" NGINX_CONF="docker/nginx.conf" DEPLOY_JWT_SECRET="${DEPLOY_JWT_SECRET:-}" DEPLOY_BCRYPT_SALT_ROUNDS="${DEPLOY_BCRYPT_SALT_ROUNDS:-12}" ENSURE_METRICS_SCRAPE_TOKEN="${ENSURE_METRICS_SCRAPE_TOKEN}" DEPLOY_METRICS_SCRAPE_TOKEN="${DEPLOY_METRICS_SCRAPE_TOKEN:-}" RESTART_BACKEND=true scripts/ops/attendance-reconcile-csv-cap.sh'
               '  reconcile_rc=$?'
               "  set -e"
             "fi"
@@ -140,6 +149,7 @@ jobs:
         env:
           RECONCILE_RC: ${{ steps.remote_reconcile.outputs.reconcile_rc }}
           CSV_MAX_ROWS: ${{ github.event.inputs.csv_max_rows || '100000' }}
+          ENSURE_METRICS_SCRAPE_TOKEN: ${{ github.event.inputs.ensure_metrics_scrape_token || 'true' }}
           SKIP_HOST_SYNC: ${{ github.event.inputs.skip_host_sync || 'false' }}
         run: |
           set -euo pipefail
@@ -158,6 +168,7 @@ jobs:
           echo "- Overall: **${overall}**" >> "$GITHUB_STEP_SUMMARY"
           echo "- Remote exit code: \`${RECONCILE_RC:-missing}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Applied target: \`ATTENDANCE_IMPORT_CSV_MAX_ROWS=${CSV_MAX_ROWS}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Ensure metrics scrape token: \`${ENSURE_METRICS_SCRAPE_TOKEN}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Skip host sync: \`${SKIP_HOST_SYNC}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "" >> "$GITHUB_STEP_SUMMARY"
 

--- a/docker/app.env.example
+++ b/docker/app.env.example
@@ -9,6 +9,9 @@ PRODUCT_MODE=platform
 # - onprem | hybrid | saas
 DEPLOYMENT_MODEL=onprem
 JWT_SECRET=change-me
+# Optional: when set, /metrics and /metrics/prom require Authorization: Bearer <token>
+# or x-metrics-token. Production reconcile can generate this for Phase 5 validation.
+METRICS_SCRAPE_TOKEN=
 # If the target PostgreSQL does not have SSL enabled (typical for local / on-prem
 # dev), append `?sslmode=disable` to DATABASE_URL to avoid migrate.js failing
 # with "The server does not support SSL connections".

--- a/scripts/ops/attendance-reconcile-csv-cap.sh
+++ b/scripts/ops/attendance-reconcile-csv-cap.sh
@@ -9,6 +9,7 @@ CSV_MAX_ROWS="${CSV_MAX_ROWS:-100000}"
 DEPLOY_BCRYPT_SALT_ROUNDS="${DEPLOY_BCRYPT_SALT_ROUNDS:-12}"
 RUN_ATTENDANCE_PREFLIGHT="${RUN_ATTENDANCE_PREFLIGHT:-true}"
 RESTART_BACKEND="${RESTART_BACKEND:-true}"
+ENSURE_METRICS_SCRAPE_TOKEN="${ENSURE_METRICS_SCRAPE_TOKEN:-false}"
 
 is_truthy() {
   case "${1:-}" in
@@ -40,7 +41,7 @@ backup="${ENV_FILE}.bak.$(date -u +%Y%m%d-%H%M%S)"
 cp "${ENV_FILE}" "${backup}"
 echo "[attendance-env-reconcile] backup=${backup}"
 
-python3 - "${ENV_FILE}" "${CSV_MAX_ROWS}" "${DEPLOY_JWT_SECRET:-}" "${DEPLOY_BCRYPT_SALT_ROUNDS}" <<'PY'
+python3 - "${ENV_FILE}" "${CSV_MAX_ROWS}" "${DEPLOY_JWT_SECRET:-}" "${DEPLOY_BCRYPT_SALT_ROUNDS}" "${ENSURE_METRICS_SCRAPE_TOKEN}" "${DEPLOY_METRICS_SCRAPE_TOKEN:-}" <<'PY'
 from pathlib import Path
 import secrets
 import sys
@@ -49,6 +50,12 @@ path = Path(sys.argv[1])
 csv_max_rows = sys.argv[2]
 deploy_jwt_secret = sys.argv[3].strip()
 deploy_bcrypt_rounds = sys.argv[4].strip() or "12"
+ensure_metrics_token = sys.argv[5].strip().lower() in {"true", "1", "yes", "on"}
+deploy_metrics_token = sys.argv[6].strip()
+
+if "\n" in deploy_metrics_token or "\r" in deploy_metrics_token:
+    print("[attendance-env-reconcile] ERROR: DEPLOY_METRICS_SCRAPE_TOKEN must be a single-line value", file=sys.stderr)
+    sys.exit(4)
 
 text = path.read_text()
 if "\\n" in text and text.count("\n") <= 1:
@@ -85,6 +92,21 @@ if not entries.get("BCRYPT_SALT_ROUNDS"):
     if "BCRYPT_SALT_ROUNDS" not in order:
         order.append("BCRYPT_SALT_ROUNDS")
 
+metrics_status = "skipped"
+if ensure_metrics_token:
+    if entries.get("METRICS_SCRAPE_TOKEN"):
+        metrics_status = "present"
+    elif deploy_metrics_token:
+        entries["METRICS_SCRAPE_TOKEN"] = deploy_metrics_token
+        metrics_status = "injected"
+        if "METRICS_SCRAPE_TOKEN" not in order:
+            order.append("METRICS_SCRAPE_TOKEN")
+    else:
+        entries["METRICS_SCRAPE_TOKEN"] = secrets.token_urlsafe(32)
+        metrics_status = "generated and persisted"
+        if "METRICS_SCRAPE_TOKEN" not in order:
+            order.append("METRICS_SCRAPE_TOKEN")
+
 updated = []
 seen = set()
 for line in lines:
@@ -119,10 +141,20 @@ if not verified.get("JWT_SECRET"):
 if not verified.get("BCRYPT_SALT_ROUNDS"):
     print("[attendance-env-reconcile] ERROR: BCRYPT_SALT_ROUNDS is missing after reconcile", file=sys.stderr)
     sys.exit(4)
+if ensure_metrics_token:
+    metrics_token = verified.get("METRICS_SCRAPE_TOKEN", "")
+    if not metrics_token:
+        print("[attendance-env-reconcile] ERROR: METRICS_SCRAPE_TOKEN is missing after reconcile", file=sys.stderr)
+        sys.exit(4)
+    if "\n" in metrics_token or "\r" in metrics_token:
+        print("[attendance-env-reconcile] ERROR: METRICS_SCRAPE_TOKEN must be a single-line value", file=sys.stderr)
+        sys.exit(4)
 
 print(f"[attendance-env-reconcile] ensured ATTENDANCE_IMPORT_CSV_MAX_ROWS={current_cap}")
 print(f"[attendance-env-reconcile] JWT_SECRET {jwt_status}")
 print("[attendance-env-reconcile] BCRYPT_SALT_ROUNDS present")
+if ensure_metrics_token:
+    print(f"[attendance-env-reconcile] METRICS_SCRAPE_TOKEN {metrics_status}")
 PY
 
 if is_truthy "${RUN_ATTENDANCE_PREFLIGHT}"; then
@@ -148,6 +180,16 @@ if is_truthy "${RESTART_BACKEND}"; then
     die "backend runtime ATTENDANCE_IMPORT_CSV_MAX_ROWS mismatch: expected ${CSV_MAX_ROWS}, got ${runtime_cap:-<missing>}"
   fi
   echo "[attendance-env-reconcile] runtime ATTENDANCE_IMPORT_CSV_MAX_ROWS=${runtime_cap}"
+  if is_truthy "${ENSURE_METRICS_SCRAPE_TOKEN}"; then
+    runtime_metrics_token="$("${compose_cmd[@]}" -f "${COMPOSE_FILE}" exec -T backend sh -lc 'printf "%s" "${METRICS_SCRAPE_TOKEN:-}"' < /dev/null)"
+    if [[ -z "${runtime_metrics_token}" ]]; then
+      die "backend runtime METRICS_SCRAPE_TOKEN missing after reconcile"
+    fi
+    if [[ "${runtime_metrics_token}" == *$'\n'* || "${runtime_metrics_token}" == *$'\r'* ]]; then
+      die "backend runtime METRICS_SCRAPE_TOKEN must be a single-line value"
+    fi
+    echo "[attendance-env-reconcile] runtime METRICS_SCRAPE_TOKEN present"
+  fi
 else
   echo "[attendance-env-reconcile] backend recreate skipped (RESTART_BACKEND=${RESTART_BACKEND})"
 fi

--- a/scripts/ops/attendance-reconcile-csv-cap.test.mjs
+++ b/scripts/ops/attendance-reconcile-csv-cap.test.mjs
@@ -73,6 +73,35 @@ test('reconciles CSV cap and normalizes literal newline env files without printi
   }
 })
 
+test('can ensure metrics scrape token without printing its value', async () => {
+  const tmp = makeTmpDir()
+  const envFile = path.join(tmp, 'app.env')
+  try {
+    writeFileSync(
+      envFile,
+      'NODE_ENV=production\nJWT_SECRET=already-strong-secret-value-123456\nBCRYPT_SALT_ROUNDS=12\n',
+    )
+
+    const result = await runScript({
+      ENV_FILE: envFile,
+      CSV_MAX_ROWS: '100000',
+      ENSURE_METRICS_SCRAPE_TOKEN: 'true',
+      DEPLOY_METRICS_SCRAPE_TOKEN: 'metrics-secret-that-must-not-print',
+      RUN_ATTENDANCE_PREFLIGHT: 'false',
+      RESTART_BACKEND: 'false',
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /METRICS_SCRAPE_TOKEN injected/)
+    assert.doesNotMatch(result.stdout, /metrics-secret-that-must-not-print/)
+    assert.doesNotMatch(result.stderr, /metrics-secret-that-must-not-print/)
+    const envText = readFileSync(envFile, 'utf8')
+    assert.match(envText, /^METRICS_SCRAPE_TOKEN=metrics-secret-that-must-not-print$/m)
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
 test('recreates backend and verifies runtime CSV cap', async () => {
   const tmp = makeTmpDir()
   const envFile = path.join(tmp, 'app.env')
@@ -117,6 +146,54 @@ exit 9
     const dockerCalls = readFileSync(dockerLog, 'utf8')
     assert.match(dockerCalls, /compose -f .* up -d --no-deps --force-recreate backend/)
     assert.match(dockerCalls, /compose -f .* exec -T backend sh -lc/)
+  } finally {
+    rmSync(tmp, { recursive: true, force: true })
+  }
+})
+
+test('verifies backend runtime metrics scrape token when requested', async () => {
+  const tmp = makeTmpDir()
+  const envFile = path.join(tmp, 'app.env')
+  const composeFile = path.join(tmp, 'docker-compose.yml')
+  const binDir = path.join(tmp, 'bin')
+  try {
+    writeFileSync(envFile, 'JWT_SECRET=already-strong-secret-value-123456\nBCRYPT_SALT_ROUNDS=12\n')
+    writeFileSync(composeFile, 'services:\n  backend:\n    image: test\n')
+    mkdirSync(binDir)
+    const dockerPath = path.join(binDir, 'docker')
+    writeFileSync(dockerPath, `#!/usr/bin/env bash
+if [[ "$1" == "compose" && "$2" == "version" ]]; then
+  exit 0
+fi
+if [[ "$1" == "compose" && "$4" == "up" ]]; then
+  exit 0
+fi
+if [[ "$1" == "compose" && "$4" == "exec" ]]; then
+  if [[ "$*" == *"METRICS_SCRAPE_TOKEN"* ]]; then
+    printf 'runtime-metrics-token'
+  else
+    printf '100000'
+  fi
+  exit 0
+fi
+exit 9
+`)
+    chmodSync(dockerPath, 0o755)
+
+    const result = await runScript({
+      PATH: `${binDir}:${process.env.PATH || ''}`,
+      ENV_FILE: envFile,
+      COMPOSE_FILE: composeFile,
+      CSV_MAX_ROWS: '100000',
+      ENSURE_METRICS_SCRAPE_TOKEN: 'true',
+      RUN_ATTENDANCE_PREFLIGHT: 'false',
+      RESTART_BACKEND: 'true',
+    })
+
+    assert.equal(result.status, 0, result.stderr)
+    assert.match(result.stdout, /METRICS_SCRAPE_TOKEN generated and persisted/)
+    assert.match(result.stdout, /runtime METRICS_SCRAPE_TOKEN present/)
+    assert.doesNotMatch(result.stdout, /runtime-metrics-token/)
   } finally {
     rmSync(tmp, { recursive: true, force: true })
   }

--- a/scripts/ops/attendance-remote-env-reconcile-workflow-contract.test.mjs
+++ b/scripts/ops/attendance-remote-env-reconcile-workflow-contract.test.mjs
@@ -16,3 +16,13 @@ test('remote env reconcile applies CSV cap through the shared runtime verifier',
   assert.doesNotMatch(raw, /ERROR: failed to verify \$\{key\} in \$\{env_file\}/)
   assert.doesNotMatch(raw, /python3 - "\$env_file" "\$\{value\}"/)
 })
+
+test('remote env reconcile can ensure metrics scrape token for Phase 5 fallback', () => {
+  const raw = readFileSync(workflowPath, 'utf8')
+
+  assert.match(raw, /ensure_metrics_scrape_token:/)
+  assert.match(raw, /ENSURE_METRICS_SCRAPE_TOKEN: \$\{\{ github\.event\.inputs\.ensure_metrics_scrape_token \|\| 'true' \}\}/)
+  assert.match(raw, /DEPLOY_METRICS_SCRAPE_TOKEN: \$\{\{ secrets\.METRICS_SCRAPE_TOKEN \|\| '' \}\}/)
+  assert.match(raw, /ENSURE_METRICS_SCRAPE_TOKEN="\$\{ENSURE_METRICS_SCRAPE_TOKEN\}"/)
+  assert.match(raw, /Ensure metrics scrape token:/)
+})


### PR DESCRIPTION
## Summary

- Extend the production env reconcile path to ensure backend `METRICS_SCRAPE_TOKEN` exists for the Phase 5 deploy-host auth fallback.
- Keep token values out of logs: the script reports only `present` / `injected` / `generated and persisted`, then verifies runtime presence after backend recreate.
- Add `ensure_metrics_scrape_token` workflow input, defaulting to `true`, and allow an optional `secrets.METRICS_SCRAPE_TOKEN` override; otherwise the deploy host generates a single-line token.
- Document the env key in `docker/app.env.example`.

Refs #1. This PR supplies the missing runtime configuration path; #1 still needs post-merge remote reconcile + Phase 5 validation evidence before closing.

## Verification

- `node --test scripts/ops/attendance-reconcile-csv-cap.test.mjs scripts/ops/attendance-remote-env-reconcile-workflow-contract.test.mjs scripts/ops/resolve-metrics-scrape-token.test.mjs scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs`
- `bash -n scripts/ops/attendance-reconcile-csv-cap.sh scripts/ops/resolve-metrics-scrape-token.sh`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/attendance-remote-env-reconcile-prod.yml"); YAML.load_file(".github/workflows/phase5-nightly-validation-regression.yml"); puts "yaml ok"'`
- `git diff --check`
