### PR TITLE
fix(phase5): use metrics endpoint fallback path

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -45,7 +45,7 @@ This folder contains GitHub Actions that validate Phase 5 SLOs against a Prometh
 ## Required Secrets
 
  - `METRICS_URL` (optional for scheduled Phase 5 workflows when `METASHEET_BASE_URL` is set): e.g., `https://staging.example.com/metrics/prom`.
- - `METRICS_AUTH_HEADER` (optional): e.g., `Authorization: Bearer <token>`. Scheduled Phase 5 workflows can derive this from the deploy-host backend `METRICS_SCRAPE_TOKEN` only when they fall back to the trusted `METASHEET_BASE_URL` `/api/metrics/prom` endpoint.
+ - `METRICS_AUTH_HEADER` (optional): e.g., `Authorization: Bearer <token>`. Scheduled Phase 5 workflows can derive this from the deploy-host backend `METRICS_SCRAPE_TOKEN` only when they fall back to the trusted `METASHEET_BASE_URL` `/metrics/prom` endpoint.
  - `ALERTMANAGER_WEBHOOK_URL`, `ALERT_WEBHOOK_URL`, `SLACK_WEBHOOK_URL`, or `ATTENDANCE_ALERT_SLACK_WEBHOOK_URL` (one optional webhook secret is used to self-heal on-prem Alertmanager config before DingTalk OAuth stability checks; `SLACK_WEBHOOK_URL` also powers older nightly notification workflows).
  - `SLACK_CHANNEL` (optional): e.g., `alerts`.
  - `GRAFANA_API_TOKEN` (ops deploy only, for dashboard upload).

--- a/.github/workflows/phase5-nightly-validation-regression.yml
+++ b/.github/workflows/phase5-nightly-validation-regression.yml
@@ -6,7 +6,7 @@ on:
   workflow_dispatch:
     inputs:
       metrics_url:
-        description: 'Override metrics URL (default METRICS_URL or METASHEET_BASE_URL/api/metrics/prom)'
+        description: 'Override metrics URL (default METRICS_URL or METASHEET_BASE_URL/metrics/prom)'
         required: false
 
 jobs:
@@ -38,7 +38,7 @@ jobs:
             URL="$METRICS_URL_SECRET"
             URL_SOURCE="secret"
           elif [ -n "$METASHEET_BASE_URL" ]; then
-            URL="${METASHEET_BASE_URL%/}/api/metrics/prom"
+            URL="${METASHEET_BASE_URL%/}/metrics/prom"
             URL_SOURCE="metasheet_base_url"
           else
             URL=""

--- a/.github/workflows/phase5-nightly-validation.yml
+++ b/.github/workflows/phase5-nightly-validation.yml
@@ -39,7 +39,7 @@ jobs:
             METRICS_URL="$METRICS_URL_SECRET"
             URL_SOURCE="secret"
           elif [ -n "${METASHEET_BASE_URL}" ]; then
-            METRICS_URL="${METASHEET_BASE_URL%/}/api/metrics/prom"
+            METRICS_URL="${METASHEET_BASE_URL%/}/metrics/prom"
             URL_SOURCE="metasheet_base_url"
           else
             METRICS_URL=""

--- a/.github/workflows/phase5-nightly.yml
+++ b/.github/workflows/phase5-nightly.yml
@@ -37,7 +37,7 @@ jobs:
             URL="$METRICS_URL_SECRET"
             URL_SOURCE="secret"
           elif [ -n "$METASHEET_BASE_URL" ]; then
-            URL="${METASHEET_BASE_URL%/}/api/metrics/prom"
+            URL="${METASHEET_BASE_URL%/}/metrics/prom"
             URL_SOURCE="metasheet_base_url"
           else
             URL=""

--- a/scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
+++ b/scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
@@ -26,6 +26,8 @@ for (const workflowPath of workflowPaths) {
     assert.match(raw, /METRICS_SCRAPE_TOKEN_RESOLVE_REQUIRED=false\s+bash scripts\/ops\/resolve-metrics-scrape-token\.sh/)
     assert.match(raw, /AUTH_HEADER="Authorization: Bearer \$metrics_token"/)
     assert.match(raw, /METRICS_AUTH_HEADER=\$AUTH_HEADER/)
+    assert.match(raw, /\$\{METASHEET_BASE_URL%\/\}\/metrics\/prom/)
+    assert.doesNotMatch(raw, /\/api\/metrics\/prom/)
     assert.doesNotMatch(raw, /ATTENDANCE_ADMIN_JWT/)
     assert.doesNotMatch(raw, /Authorization: Bearer \$ATTENDANCE_ADMIN_JWT/)
   })


### PR DESCRIPTION
## Summary

- Change scheduled Phase 5 `METASHEET_BASE_URL` fallback from `/api/metrics/prom` to the supported `/metrics/prom` endpoint.
- Keep the deploy-host `METRICS_SCRAPE_TOKEN` auth fallback; only the URL path changes.
- Add a contract assertion so the three Phase 5 workflows cannot drift back to `/api/metrics/prom`.

Refs #1. The previous run already proved runtime token resolution works; it failed with HTTP 401 because `/api/metrics/prom` routes through the API path. This PR points the fallback at the actual metrics route.

## Verification

- `node --test scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs`
- `ruby -e 'require "yaml"; %w[.github/workflows/phase5-nightly-validation-regression.yml .github/workflows/phase5-nightly-validation.yml .github/workflows/phase5-nightly.yml].each { |f| YAML.load_file(f) }; puts "yaml ok"'`
- `git diff --check`
- `rg -n "/api/metrics/prom" .github/workflows/phase5-nightly-validation-regression.yml .github/workflows/phase5-nightly-validation.yml .github/workflows/phase5-nightly.yml .github/workflows/README.md scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs || true`
