### PR TITLE
fix(phase5): resolve nightly branch date

### DIFF
--- a/.github/workflows/phase5-nightly-validation-regression.yml
+++ b/.github/workflows/phase5-nightly-validation-regression.yml
@@ -166,12 +166,18 @@ jobs:
         run: |
           bash scripts/phase5-slo-tighten-suggestions.sh results/nightly claudedocs/PHASE5_SLO_SUGGESTIONS.json 30 || echo "tighten suggestions skipped"
 
+      - name: Resolve nightly branch date
+        id: nightly_date
+        if: success() && steps.probe.outputs.available == 'true'
+        shell: bash
+        run: echo "date=$(date -u '+%Y%m%d')" >> "$GITHUB_OUTPUT"
+
       - name: Create PR with nightly JSON (for trend, suggestions & baseline rotation)
         if: success() && steps.probe.outputs.available == 'true'
         uses: peter-evans/create-pull-request@v5
         with:
-          commit-message: "chore(phase5): nightly JSON, weekly trend & SLO suggestions $(date -u '+%Y-%m-%d')"
-          title: "Phase5 Nightly: JSON + Trend + SLO Suggestions $(date -u '+%Y-%m-%d')"
+          commit-message: "chore(phase5): nightly JSON, weekly trend & SLO suggestions ${{ steps.nightly_date.outputs.date }}"
+          title: "Phase5 Nightly: JSON + Trend + SLO Suggestions ${{ steps.nightly_date.outputs.date }}"
           body: |
             Automated nightly Phase 5 validation.
             Includes:
@@ -179,7 +185,7 @@ jobs:
             - Weekly trend (last 7): claudedocs/PHASE5_WEEKLY_TREND.md
             - SLO tightening suggestions (window 30d): claudedocs/PHASE5_SLO_SUGGESTIONS.json
             Supports future baseline rotation after sustained PASS streak.
-          branch: chore/phase5-nightly-$(date -u '+%Y%m%d')
+          branch: chore/phase5-nightly-${{ steps.nightly_date.outputs.date }}
 
       - name: Auto-rotate baseline (if streak met)
         if: success() && steps.probe.outputs.available == 'true'

--- a/scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
+++ b/scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
@@ -38,3 +38,12 @@ test('regression workflow uploads deploy-host metrics token fallback diagnostics
 
   assert.match(raw, /\/tmp\/phase5-metrics-token-fallback\.log/)
 })
+
+test('regression workflow resolves a valid nightly PR branch name', () => {
+  const raw = readWorkflow('.github/workflows/phase5-nightly-validation-regression.yml')
+
+  assert.match(raw, /id: nightly_date/)
+  assert.match(raw, /echo "date=\$\(date -u '\+%Y%m%d'\)" >> "\$GITHUB_OUTPUT"/)
+  assert.match(raw, /branch: chore\/phase5-nightly-\$\{\{ steps\.nightly_date\.outputs\.date \}\}/)
+  assert.doesNotMatch(raw, /branch: chore\/phase5-nightly-\$\(date/)
+})


### PR DESCRIPTION
## Summary

- Add a `nightly_date` step in the Phase 5 regression workflow.
- Use that step output for the nightly create-pull-request commit message, title, and branch name.
- Add a contract test so the workflow cannot regress to the literal invalid `$(date ...)` branch name.

Refs #1. This fixes the workflow failure exposed after the Phase 5 metrics endpoint became reachable; it does not make the current production SLO validation pass by itself.

## Verification

- `node --test scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs`
- `ruby -e 'require "yaml"; YAML.load_file(".github/workflows/phase5-nightly-validation-regression.yml"); puts "yaml ok"'`
- `git diff --check`
