### PR TITLE
fix(phase5): allow nightly artifact PR creation

### DIFF
--- a/.github/workflows/phase5-nightly-validation-regression.yml
+++ b/.github/workflows/phase5-nightly-validation-regression.yml
@@ -9,6 +9,10 @@ on:
         description: 'Override metrics URL (default METRICS_URL or METASHEET_BASE_URL/metrics/prom)'
         required: false
 
+permissions:
+  contents: write
+  pull-requests: write
+
 jobs:
   validate:
     runs-on: ubuntu-latest

--- a/scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
+++ b/scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
@@ -47,3 +47,10 @@ test('regression workflow resolves a valid nightly PR branch name', () => {
   assert.match(raw, /branch: chore\/phase5-nightly-\$\{\{ steps\.nightly_date\.outputs\.date \}\}/)
   assert.doesNotMatch(raw, /branch: chore\/phase5-nightly-\$\(date/)
 })
+
+test('regression workflow can write nightly artifact pull requests', () => {
+  const raw = readWorkflow('.github/workflows/phase5-nightly-validation-regression.yml')
+
+  assert.match(raw, /\npermissions:\n  contents: write\n  pull-requests: write\n/)
+  assert.match(raw, /uses: peter-evans\/create-pull-request@v5/)
+})


### PR DESCRIPTION
## Summary
- grant the Phase 5 regression workflow write permissions needed by peter-evans/create-pull-request
- add a workflow contract test so nightly artifact PR creation does not regress to read-only token permissions

## Verification
- node --test scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/phase5-nightly-validation-regression.yml'); puts 'yaml ok'"
- git diff --check

Refs #1