### PR TITLE
fix(phase5): limit nightly artifact PR paths

### DIFF
--- a/.github/workflows/phase5-nightly-validation-regression.yml
+++ b/.github/workflows/phase5-nightly-validation-regression.yml
@@ -190,6 +190,10 @@ jobs:
             - SLO tightening suggestions (window 30d): claudedocs/PHASE5_SLO_SUGGESTIONS.json
             Supports future baseline rotation after sustained PASS streak.
           branch: chore/phase5-nightly-${{ steps.nightly_date.outputs.date }}
+          add-paths: |
+            results/nightly/*.json
+            claudedocs/PHASE5_WEEKLY_TREND.md
+            claudedocs/PHASE5_SLO_SUGGESTIONS.json
 
       - name: Auto-rotate baseline (if streak met)
         if: success() && steps.probe.outputs.available == 'true'

--- a/scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
+++ b/scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
@@ -54,3 +54,11 @@ test('regression workflow can write nightly artifact pull requests', () => {
   assert.match(raw, /\npermissions:\n  contents: write\n  pull-requests: write\n/)
   assert.match(raw, /uses: peter-evans\/create-pull-request@v5/)
 })
+
+test('regression workflow limits nightly artifact PR contents', () => {
+  const raw = readWorkflow('.github/workflows/phase5-nightly-validation-regression.yml')
+
+  assert.match(raw, /add-paths:\s+\|\n\s+results\/nightly\/\*\.json\n\s+claudedocs\/PHASE5_WEEKLY_TREND\.md\n\s+claudedocs\/PHASE5_SLO_SUGGESTIONS\.json/)
+  assert.doesNotMatch(raw, /add-paths:[\s\S]*node_modules/)
+  assert.doesNotMatch(raw, /add-paths:[\s\S]*package\.json/)
+})


### PR DESCRIPTION
## Summary
- restrict the Phase 5 nightly create-pull-request step to intended artifact files only
- add a workflow contract test to prevent package.json/node_modules pollution in generated nightly PRs
- deleted the bad generated chore/phase5-nightly-20260530 branch before this fix

## Verification
- node --test scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/phase5-nightly-validation-regression.yml'); puts 'yaml ok'"
- git diff --check

Refs #1