### PR TITLE
feat(attendance): admin workbench T3 — edit + deactivate scheduler scope (CRUD loop)

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1307,8 +1307,8 @@
               <p class="attendance__scheduler-scope-notice" data-attendance-scheduler-scopes-intent>
                 {{ tr('These scopes are an administrative registry only and are not yet enforced at runtime. Runtime enforcement is a separate later capability.', '此处仅为管理登记，运行时尚未强制执行；运行时强制为后续独立能力。') }}
               </p>
-              <form class="attendance__scheduler-scope-form" data-attendance-scheduler-scope-form @submit.prevent="createSchedulerScope">
-                <h5>{{ tr('New scope', '新建范围') }}</h5>
+              <form class="attendance__scheduler-scope-form" data-attendance-scheduler-scope-form @submit.prevent="submitSchedulerScope">
+                <h5>{{ schedulerScopeEditingId ? tr('Edit scope', '编辑范围') : tr('New scope', '新建范围') }}</h5>
                 <div class="attendance__admin-grid">
                   <label class="attendance__field" for="attendance-scheduler-scope-subject-type">
                     <span>{{ tr('Subject type', '主体类型') }}</span>
@@ -1377,9 +1377,20 @@
                 <p class="attendance__field-hint">
                   {{ tr('Separate multiple values with commas or new lines. At least one target and one action are required.', '多个值用逗号或换行分隔；至少需要一个目标和一个动作。') }}
                 </p>
-                <button type="submit" class="attendance__btn" :disabled="schedulerScopeCreating" data-attendance-scheduler-scope-create>
-                  {{ schedulerScopeCreating ? tr('Creating...', '创建中...') : tr('Create scope', '创建范围') }}
-                </button>
+                <div class="attendance__scheduler-scope-form-actions">
+                  <button type="submit" class="attendance__btn" :disabled="schedulerScopeCreating" data-attendance-scheduler-scope-create>
+                    {{ schedulerScopeCreating ? tr('Saving...', '保存中...') : (schedulerScopeEditingId ? tr('Update scope', '更新范围') : tr('Create scope', '创建范围')) }}
+                  </button>
+                  <button
+                    v-if="schedulerScopeEditingId"
+                    type="button"
+                    class="attendance__btn"
+                    @click="cancelSchedulerScopeEdit"
+                    data-attendance-scheduler-scope-cancel
+                  >
+                    {{ tr('Cancel', '取消') }}
+                  </button>
+                </div>
               </form>
               <div v-if="!schedulerScopesLoading && schedulerScopes.length === 0" class="attendance__empty">
                 {{ tr('No scheduler scopes yet.', '暂无排班管理范围记录。') }}
@@ -1405,6 +1416,25 @@
                     >{{ schedulerScopeActionLabel(action) }}</span>
                   </div>
                   <div class="attendance__scheduler-scope-targets">{{ schedulerScopeTargetSummary(scope.scope) }}</div>
+                  <div class="attendance__scheduler-scope-row-actions">
+                    <button
+                      type="button"
+                      class="attendance__btn"
+                      @click="editSchedulerScope(scope)"
+                      data-attendance-scheduler-scope-edit
+                    >
+                      {{ tr('Edit', '编辑') }}
+                    </button>
+                    <button
+                      type="button"
+                      class="attendance__btn"
+                      :disabled="schedulerScopeDeactivatingId === scope.id"
+                      @click="deactivateSchedulerScope(scope.id)"
+                      data-attendance-scheduler-scope-deactivate
+                    >
+                      {{ schedulerScopeDeactivatingId === scope.id ? tr('Deactivating...', '停用中...') : tr('Deactivate', '停用') }}
+                    </button>
+                  </div>
                 </li>
               </ul>
               <p
@@ -7922,9 +7952,16 @@ const schedulerScopeForm = reactive({
   roleTags: '',
 })
 const schedulerScopeCreating = ref(false)
+const schedulerScopeEditingId = ref<string | null>(null)
+const schedulerScopeDeactivatingId = ref<string | null>(null)
+// True only while editSchedulerScope() programmatically hydrates the form from an existing scope,
+// so the subjectType watcher below does NOT wipe the prefilled subjectRef. A user-initiated type
+// change (hydrating === false) still clears it.
+let schedulerScopeFormHydrating = false
 // Subject ref is type-specific (a user UUID via the picker vs a role/role-tag string); clear it
-// on type change so a picked user UUID can't be submitted as a role string.
+// on a user-initiated type change so a picked user UUID can't be submitted as a role string.
 watch(() => schedulerScopeForm.subjectType, () => {
+  if (schedulerScopeFormHydrating) return
   schedulerScopeForm.subjectRef = ''
 })
 const defaultTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone || 'UTC'
@@ -18941,7 +18978,48 @@ function normalizeSchedulerScope(value: unknown): AttendanceSchedulerScope | nul
 // Create one scheduler scope (T2, create-only). Maps the 6 free-text target fields to the 6
 // scope keys (names MUST match the backend normalizer; a wrong key is silently dropped).
 // Mirrors the backend validation (>=1 action, >=1 target) client-side before POSTing.
-async function createSchedulerScope() {
+function resetSchedulerScopeForm(): void {
+  schedulerScopeForm.subjectType = 'user'
+  schedulerScopeForm.subjectRef = ''
+  schedulerScopeForm.actions = []
+  schedulerScopeForm.scheduleGroupIds = ''
+  schedulerScopeForm.attendanceGroupIds = ''
+  schedulerScopeForm.userIds = ''
+  schedulerScopeForm.departments = ''
+  schedulerScopeForm.roles = ''
+  schedulerScopeForm.roleTags = ''
+  schedulerScopeEditingId.value = null
+}
+
+function cancelSchedulerScopeEdit(): void {
+  resetSchedulerScopeForm()
+}
+
+// Load an existing scope into the shared form for editing. The hydration guard (see the
+// subjectType watcher) keeps the prefilled subjectRef from being wiped while we set the type.
+function editSchedulerScope(scope: AttendanceSchedulerScope): void {
+  schedulerScopeFormHydrating = true
+  schedulerScopeForm.subjectType = scope.subjectType === 'role' || scope.subjectType === 'role_tag'
+    ? scope.subjectType
+    : 'user'
+  schedulerScopeForm.subjectRef = scope.subjectRef
+  schedulerScopeForm.actions = [...scope.actions]
+  schedulerScopeForm.scheduleGroupIds = scope.scope.scheduleGroupIds.join(', ')
+  schedulerScopeForm.attendanceGroupIds = scope.scope.attendanceGroupIds.join(', ')
+  schedulerScopeForm.userIds = scope.scope.userIds.join(', ')
+  schedulerScopeForm.departments = scope.scope.departments.join(', ')
+  schedulerScopeForm.roles = scope.scope.roles.join(', ')
+  schedulerScopeForm.roleTags = scope.scope.roleTags.join(', ')
+  schedulerScopeEditingId.value = scope.id
+  void nextTick(() => {
+    schedulerScopeFormHydrating = false
+  })
+}
+
+// Create (POST) or update (PUT) one scheduler scope. The PUT body is the same .strict() shape as
+// create (no orgId — that rides the query); the backend merges with the existing row, so omitting
+// isActive preserves the active flag.
+async function submitSchedulerScope() {
   const subjectRef = schedulerScopeForm.subjectRef.trim()
   if (!subjectRef) {
     setStatus(tr('Enter a subject for the scope.', '请填写范围主体。'), 'error')
@@ -18964,13 +19042,17 @@ async function createSchedulerScope() {
     setStatus(tr('Add at least one scope target.', '请至少添加一个范围目标。'), 'error')
     return
   }
+  const editingId = schedulerScopeEditingId.value
   schedulerScopeCreating.value = true
   try {
-    // orgId rides the query string (same as the GET); the POST body must match the backend's
-    // .strict() schedulerScopeCreateSchema exactly — an extra key (incl. orgId) is a 400.
+    // orgId rides the query string (same as the GET / create); the body must match the backend's
+    // .strict() schema exactly — an extra key (incl. orgId) is a 400.
     const query = buildQuery({ orgId: normalizedOrgId() })
-    const response = await apiFetch(`/api/attendance/scheduler-scopes?${query.toString()}`, {
-      method: 'POST',
+    const url = editingId
+      ? `/api/attendance/scheduler-scopes/${encodeURIComponent(editingId)}?${query.toString()}`
+      : `/api/attendance/scheduler-scopes?${query.toString()}`
+    const response = await apiFetch(url, {
+      method: editingId ? 'PUT' : 'POST',
       body: JSON.stringify({
         subjectType: schedulerScopeForm.subjectType,
         subjectRef,
@@ -18984,22 +19066,51 @@ async function createSchedulerScope() {
     }
     const data = await response.json()
     if (!response.ok || !data.ok) {
-      throw new Error(readErrorMessage(data, tr('Failed to create scheduler scope', '创建排班管理范围失败')))
+      throw new Error(readErrorMessage(data, editingId
+        ? tr('Failed to update scheduler scope', '更新排班管理范围失败')
+        : tr('Failed to create scheduler scope', '创建排班管理范围失败')))
     }
-    schedulerScopeForm.subjectRef = ''
-    schedulerScopeForm.actions = []
-    schedulerScopeForm.scheduleGroupIds = ''
-    schedulerScopeForm.attendanceGroupIds = ''
-    schedulerScopeForm.userIds = ''
-    schedulerScopeForm.departments = ''
-    schedulerScopeForm.roles = ''
-    schedulerScopeForm.roleTags = ''
-    setStatus(tr('Scheduler scope created.', '已创建排班管理范围。'), 'info')
+    resetSchedulerScopeForm()
+    setStatus(editingId
+      ? tr('Scheduler scope updated.', '已更新排班管理范围。')
+      : tr('Scheduler scope created.', '已创建排班管理范围。'), 'info')
     await loadSchedulerScopes()
   } catch (error: unknown) {
-    setStatus(readErrorMessage(error, tr('Failed to create scheduler scope', '创建排班管理范围失败')), 'error')
+    setStatus(readErrorMessage(error, editingId
+      ? tr('Failed to update scheduler scope', '更新排班管理范围失败')
+      : tr('Failed to create scheduler scope', '创建排班管理范围失败')), 'error')
   } finally {
     schedulerScopeCreating.value = false
+  }
+}
+
+// Soft-deactivate (DELETE => is_active=false). Deactivated scopes leave the active-only list;
+// reactivation / an inactive view is a follow-up slice.
+async function deactivateSchedulerScope(id: string) {
+  if (!window.confirm(tr('Deactivate this scheduler scope?', '确认停用该排班管理范围吗？'))) return
+  schedulerScopeDeactivatingId.value = id
+  try {
+    const query = buildQuery({ orgId: normalizedOrgId() })
+    const response = await apiFetch(`/api/attendance/scheduler-scopes/${encodeURIComponent(id)}?${query.toString()}`, {
+      method: 'DELETE',
+    })
+    if (response.status === 403) {
+      adminForbidden.value = true
+      return
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to deactivate scheduler scope', '停用排班管理范围失败')))
+    }
+    if (schedulerScopeEditingId.value === id) {
+      resetSchedulerScopeForm()
+    }
+    setStatus(tr('Scheduler scope deactivated.', '已停用排班管理范围。'), 'info')
+    await loadSchedulerScopes()
+  } catch (error: unknown) {
+    setStatus(readErrorMessage(error, tr('Failed to deactivate scheduler scope', '停用排班管理范围失败')), 'error')
+  } finally {
+    schedulerScopeDeactivatingId.value = null
   }
 }
 
@@ -21750,5 +21861,14 @@ const holidaySectionBindings = {
   padding: 0 4px;
   font-size: 12px;
   color: #5b6b7b;
+}
+.attendance__scheduler-scope-form-actions {
+  display: flex;
+  gap: 8px;
+}
+.attendance__scheduler-scope-row-actions {
+  display: flex;
+  gap: 8px;
+  margin-top: 4px;
 }
 </style>

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -875,6 +875,183 @@ describe('Attendance admin regressions', () => {
     expect(section.querySelector<HTMLInputElement>('#attendance-scheduler-scope-subject-ref')!.value).toBe('')
   })
 
+  it('edits a scope: prefills the form then PUTs the full strict body to the scope id', async () => {
+    const puts: Array<{ url: string; body: Record<string, unknown> }> = []
+    const existing = {
+      id: 'scope-7',
+      subjectType: 'role',
+      subjectRef: 'attendance_admin',
+      actions: ['view', 'edit'],
+      scope: { scheduleGroupIds: [], attendanceGroupIds: [], userIds: [], departments: ['dept-x'], roles: [], roleTags: [] },
+      isActive: true,
+    }
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      const method = String((init as { method?: string } | undefined)?.method || 'GET').toUpperCase()
+      if (url.includes('/api/attendance/scheduler-scopes/scope-7') && method === 'PUT') {
+        puts.push({ url, body: JSON.parse(String((init as { body?: string } | undefined)?.body || '{}')) })
+        return jsonResponse(200, { ok: true, data: { ...existing } })
+      }
+      if (url.includes('/api/attendance/scheduler-scopes')) {
+        return jsonResponse(200, { ok: true, data: { items: [existing], total: 1, page: 1, pageSize: 200 } })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-scheduler-scopes"]')!.click()
+    await flushUi(4)
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-scheduler-scopes')!
+
+    section.querySelector<HTMLButtonElement>('[data-attendance-scheduler-scope-item] [data-attendance-scheduler-scope-edit]')!.click()
+    await flushUi(2)
+    const dept = section.querySelector<HTMLTextAreaElement>('#attendance-scheduler-scope-target-departments')!
+    expect(dept.value).toContain('dept-x') // prefilled from the existing scope
+    dept.value = 'dept-y'
+    dept.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi(2)
+
+    section.querySelector<HTMLButtonElement>('[data-attendance-scheduler-scope-create]')!.click()
+    await flushUi(4)
+
+    expect(puts).toHaveLength(1)
+    expect(puts[0].url).toContain('/api/attendance/scheduler-scopes/scope-7')
+    // toEqual: no orgId (rides the query) and no isActive (backend merge preserves the flag).
+    expect(puts[0].body).toEqual({
+      subjectType: 'role',
+      subjectRef: 'attendance_admin',
+      actions: ['view', 'edit'],
+      scope: {
+        scheduleGroupIds: [],
+        attendanceGroupIds: [],
+        userIds: [],
+        departments: ['dept-y'],
+        roles: [],
+        roleTags: [],
+      },
+    })
+  })
+
+  it('keeps the user subject ref through edit hydration (PUTs the original UUID, not blank)', async () => {
+    const uuid = '11111111-1111-1111-1111-111111111111'
+    const puts: Array<Record<string, unknown>> = []
+    const existing = {
+      id: 'scope-u',
+      subjectType: 'user',
+      subjectRef: uuid,
+      actions: ['view'],
+      scope: { scheduleGroupIds: [], attendanceGroupIds: [], userIds: ['u-1'], departments: [], roles: [], roleTags: [] },
+      isActive: true,
+    }
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      const method = String((init as { method?: string } | undefined)?.method || 'GET').toUpperCase()
+      if (url.includes('/api/attendance/scheduler-scopes/scope-u') && method === 'PUT') {
+        puts.push(JSON.parse(String((init as { body?: string } | undefined)?.body || '{}')))
+        return jsonResponse(200, { ok: true, data: { ...existing } })
+      }
+      if (url.includes('/api/attendance/scheduler-scopes')) {
+        return jsonResponse(200, { ok: true, data: { items: [existing], total: 1, page: 1, pageSize: 200 } })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-scheduler-scopes"]')!.click()
+    await flushUi(4)
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-scheduler-scopes')!
+
+    section.querySelector<HTMLButtonElement>('[data-attendance-scheduler-scope-item] [data-attendance-scheduler-scope-edit]')!.click()
+    await flushUi(4) // hydration nextTick + the subjectType watcher must both flush
+
+    // Submit unchanged. If the hydration guard had let the watcher wipe subjectRef, it would be ''
+    // and client validation would block the PUT. A PUT carrying the original UUID proves the guard.
+    section.querySelector<HTMLButtonElement>('[data-attendance-scheduler-scope-create]')!.click()
+    await flushUi(4)
+
+    expect(puts).toHaveLength(1)
+    expect(puts[0].subjectType).toBe('user')
+    expect(puts[0].subjectRef).toBe(uuid)
+  })
+
+  it('deactivates a scope: DELETEs its id and drops it from the active list', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const deletes: string[] = []
+    let items: Array<Record<string, unknown>> = [
+      { id: 'scope-d', subjectType: 'role', subjectRef: 'r1', actions: ['view'], scope: { scheduleGroupIds: [], attendanceGroupIds: [], userIds: [], departments: ['d1'], roles: [], roleTags: [] }, isActive: true },
+    ]
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      const method = String((init as { method?: string } | undefined)?.method || 'GET').toUpperCase()
+      if (url.includes('/api/attendance/scheduler-scopes/scope-d') && method === 'DELETE') {
+        deletes.push(url)
+        items = [] // soft-deactivated rows leave the active-only list
+        return jsonResponse(200, { ok: true, data: { id: 'scope-d', isActive: false } })
+      }
+      if (url.includes('/api/attendance/scheduler-scopes')) {
+        return jsonResponse(200, { ok: true, data: { items, total: items.length, page: 1, pageSize: 200 } })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-scheduler-scopes"]')!.click()
+    await flushUi(4)
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-scheduler-scopes')!
+    expect(section.querySelector('[data-attendance-scheduler-scope-item]')).toBeTruthy()
+
+    section.querySelector<HTMLButtonElement>('[data-attendance-scheduler-scope-item] [data-attendance-scheduler-scope-deactivate]')!.click()
+    await flushUi(4)
+
+    expect(confirmSpy).toHaveBeenCalled() // gated behind a confirm, like the file's other destructive admin actions
+    expect(deletes).toHaveLength(1)
+    expect(deletes[0]).toContain('/api/attendance/scheduler-scopes/scope-d') // the specific id, not just "a DELETE"
+    // reactivation / an inactive view is a follow-up slice — the deactivated row is gone here.
+    expect(section.querySelector('[data-attendance-scheduler-scope-item]')).toBeNull()
+    confirmSpy.mockRestore()
+  })
+
+  it('does not deactivate a scope when the confirmation is dismissed', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const deletes: string[] = []
+    const items = [
+      { id: 'scope-d', subjectType: 'role', subjectRef: 'r1', actions: ['view'], scope: { scheduleGroupIds: [], attendanceGroupIds: [], userIds: [], departments: ['d1'], roles: [], roleTags: [] }, isActive: true },
+    ]
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      const method = String((init as { method?: string } | undefined)?.method || 'GET').toUpperCase()
+      if (url.includes('/api/attendance/scheduler-scopes/scope-d') && method === 'DELETE') {
+        deletes.push(url)
+        return jsonResponse(200, { ok: true, data: { id: 'scope-d', isActive: false } })
+      }
+      if (url.includes('/api/attendance/scheduler-scopes')) {
+        return jsonResponse(200, { ok: true, data: { items, total: items.length, page: 1, pageSize: 200 } })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-scheduler-scopes"]')!.click()
+    await flushUi(4)
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-scheduler-scopes')!
+
+    section.querySelector<HTMLButtonElement>('[data-attendance-scheduler-scope-item] [data-attendance-scheduler-scope-deactivate]')!.click()
+    await flushUi(4)
+
+    expect(confirmSpy).toHaveBeenCalled() // the confirm IS consulted...
+    expect(deletes).toHaveLength(0) // ...and dismissing it sends no DELETE
+    expect(section.querySelector('[data-attendance-scheduler-scope-item]')).toBeTruthy() // the row stays in the active list
+    confirmSpy.mockRestore()
+  })
+
   it('keeps the clicked admin section focused and retires the show-all toggle', async () => {
     app = createApp(AttendanceView, { mode: 'admin' })
     app.mount(container!)


### PR DESCRIPTION
## What
Completes **CRUD** on the workbench scheduler-scope registry (after read-only **T1 #2067** + create **T2 #2108**). The create form becomes a **create-OR-edit** form (`schedulerScopeEditingId`):

- Each list row gets **Edit** + **Deactivate** buttons.
- **Edit** prefills the shared form from the row (target arrays → free-text); submit **PUTs the full `.strict()` body** to `/scheduler-scopes/:id` — **no orgId** (rides the query, same as create) and **no isActive** (the backend merges with the existing row, preserving the active flag).
- **Deactivate** soft-deletes (`DELETE` ⇒ `is_active=false`).

> **Deactivate is one-way from this UI**: deactivated scopes leave the active-only list, and reactivation / an inactive view is a **follow-up slice** (deliberate, not a bug). The deactivate test asserts the row is gone after reload.

## Hydration guard (the subtle bit)
The T2 "clear `subjectRef` on `subjectType` change" watcher would wipe a *prefilled* subject when editing. A `schedulerScopeFormHydrating` flag suppresses it during programmatic prefill (a **user-initiated** type change still clears). **Proven empirically** — the edit-of-a-user-subject test PUTs the original UUID rather than a blank (if the guard failed, `subjectRef` would be `''` and client validation would block the PUT).

## Tests (gated `attendance-admin-regressions.spec.ts`)
- edit prefills → PUTs the full strict body (`toEqual`, **no orgId / no isActive**) to the **specific** scope id,
- edit of a user-subject scope keeps the UUID through hydration,
- deactivate DELETEs the **specific** id and the row leaves the active list.

## Verification
`vue-tsc -b` clean; gated specs green (**regressions 52/52**, **anchor-nav 30/30**); ~258 net lines. **Out of scope**: target-picker UX, enforcement.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
