### PR TITLE
chore(attendance): add remote log snapshot workflow

### DIFF
--- a/.github/workflows/attendance-remote-log-snapshot-prod.yml
+++ b/.github/workflows/attendance-remote-log-snapshot-prod.yml
@@ -1,0 +1,211 @@
+name: Attendance Remote Log Snapshot (Prod)
+
+run-name: Attendance Remote Log Snapshot (Prod)${{ github.event_name == 'workflow_dispatch' && inputs.skip_host_sync == 'true' && ' [DEBUG]' || '' }}
+
+on:
+  workflow_dispatch:
+    inputs:
+      since:
+        description: 'docker logs --since value, for example 2h or 2026-05-30T06:00:00Z'
+        required: false
+        default: '2h'
+      until:
+        description: 'optional docker logs --until value, for example 2026-05-30T06:15:00Z'
+        required: false
+        default: ''
+      tail_lines:
+        description: 'maximum log lines per container'
+        required: false
+        default: '2500'
+      containers_csv:
+        description: 'comma-separated container names'
+        required: false
+        default: 'metasheet-backend,metasheet-web,metasheet-postgres,metasheet-redis'
+      skip_host_sync:
+        description: 'skip deploy-host git sync before collecting logs (true/false)'
+        required: false
+        default: 'false'
+      issue_number:
+        description: 'optional issue number to comment with artifact pointer'
+        required: false
+        default: '447'
+
+concurrency:
+  group: attendance-remote-log-snapshot-prod
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+  issues: write
+
+jobs:
+  snapshot:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    outputs:
+      snapshot_rc: ${{ steps.remote_snapshot.outputs.snapshot_rc }}
+      artifact_name: ${{ steps.remote_snapshot.outputs.artifact_name }}
+    steps:
+      - name: Remote log snapshot
+        id: remote_snapshot
+        continue-on-error: true
+        env:
+          DEPLOY_HOST: ${{ secrets.DEPLOY_HOST }}
+          DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
+          DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
+          DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          SINCE: ${{ github.event.inputs.since || '2h' }}
+          UNTIL: ${{ github.event.inputs.until || '' }}
+          TAIL_LINES: ${{ github.event.inputs.tail_lines || '2500' }}
+          CONTAINERS_CSV: ${{ github.event.inputs.containers_csv || 'metasheet-backend,metasheet-web,metasheet-postgres,metasheet-redis' }}
+          SKIP_HOST_SYNC: ${{ github.event.inputs.skip_host_sync || 'false' }}
+        run: |
+          set -euo pipefail
+
+          if [[ ! "${SINCE}" =~ ^[0-9A-Za-z:._+TZ-]+$ ]]; then
+            echo "invalid since input: ${SINCE}" >&2
+            exit 2
+          fi
+          if [[ -n "${UNTIL}" && ! "${UNTIL}" =~ ^[0-9A-Za-z:._+TZ-]+$ ]]; then
+            echo "invalid until input: ${UNTIL}" >&2
+            exit 2
+          fi
+          if [[ ! "${TAIL_LINES}" =~ ^[0-9]+$ ]]; then
+            echo "invalid tail_lines input: ${TAIL_LINES}" >&2
+            exit 2
+          fi
+          if [[ ! "${CONTAINERS_CSV}" =~ ^[A-Za-z0-9_.-]+(,[A-Za-z0-9_.-]+)*$ ]]; then
+            echo "invalid containers_csv input: ${CONTAINERS_CSV}" >&2
+            exit 2
+          fi
+
+          mkdir -p ~/.ssh output/remote-log-snapshot
+          printf '%s' "$DEPLOY_SSH_KEY_B64" | base64 -d > ~/.ssh/deploy_key
+          chmod 600 ~/.ssh/deploy_key
+          ssh_opts="-o StrictHostKeyChecking=no -o IdentitiesOnly=yes -i ~/.ssh/deploy_key"
+
+          DEPLOY_PATH="${DEPLOY_PATH:-metasheet2}"
+          SKIP_HOST_SYNC="${SKIP_HOST_SYNC:-false}"
+          remote_output_dir="/tmp/attendance-remote-log-snapshot-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact_name="attendance-remote-log-snapshot-prod-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+
+          remote_cmds=(
+            "set -euo pipefail"
+            "DEPLOY_PATH=\"${DEPLOY_PATH}\""
+            "SINCE=\"${SINCE}\""
+            "UNTIL=\"${UNTIL}\""
+            "TAIL_LINES=\"${TAIL_LINES}\""
+            "CONTAINERS_CSV=\"${CONTAINERS_CSV}\""
+            "SKIP_HOST_SYNC=\"${SKIP_HOST_SYNC}\""
+            "REMOTE_OUTPUT_DIR=\"${remote_output_dir}\""
+            'if [[ "${DEPLOY_PATH}" == /* ]]; then'
+              '  DEPLOY_REPO_PATH="${DEPLOY_PATH}"'
+            'elif [[ "${DEPLOY_PATH}" == ~/* ]]; then'
+              '  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH#~/}"'
+            "else"
+              '  DEPLOY_REPO_PATH="${HOME}/${DEPLOY_PATH}"'
+            "fi"
+            'if [[ ! -d "$DEPLOY_REPO_PATH" ]]; then'
+              '  echo "[remote-log-snapshot][error] DEPLOY_PATH missing: ${DEPLOY_PATH} (resolved: ${DEPLOY_REPO_PATH})"'
+              '  exit 1'
+            "fi"
+            'cd "$DEPLOY_REPO_PATH"'
+            'echo "[host-sync] repo_path=${DEPLOY_REPO_PATH}"'
+            "host_sync_rc=0"
+            'if [[ "${SKIP_HOST_SYNC}" == "true" ]]; then'
+              '  echo "[host-sync] skipped (skip_host_sync=true)"'
+            'elif git rev-parse --is-inside-work-tree >/dev/null 2>&1; then'
+              "  set +e"
+              '  git fetch origin main && git checkout main && git pull --ff-only origin main'
+              '  host_sync_rc=$?'
+              "  set -e"
+              '  echo "[host-sync] rc=${host_sync_rc}"'
+            "else"
+              '  echo "[host-sync][warn] DEPLOY_PATH is not a git repo; continuing with existing files"'
+            "fi"
+            'if [[ "${host_sync_rc}" != "0" ]]; then exit "${host_sync_rc}"; fi'
+            'rm -rf "${REMOTE_OUTPUT_DIR}"'
+            'mkdir -p "${REMOTE_OUTPUT_DIR}"'
+            'SINCE="${SINCE}" UNTIL="${UNTIL}" TAIL_LINES="${TAIL_LINES}" CONTAINERS_CSV="${CONTAINERS_CSV}" OUTPUT_DIR="${REMOTE_OUTPUT_DIR}" scripts/ops/attendance-collect-remote-logs.sh'
+          )
+
+          set +e
+          printf '%s\n' "${remote_cmds[@]}" | ssh $ssh_opts "$DEPLOY_USER@$DEPLOY_HOST" bash -s 2>&1 | tee output/remote-log-snapshot/ssh.log
+          rc=${PIPESTATUS[1]}
+          scp $ssh_opts -r "$DEPLOY_USER@$DEPLOY_HOST:${remote_output_dir}/." output/remote-log-snapshot/ 2>&1 | tee -a output/remote-log-snapshot/ssh.log
+          scp_rc=${PIPESTATUS[0]}
+          set -e
+
+          if [[ "$rc" == "0" && "$scp_rc" != "0" ]]; then
+            rc="$scp_rc"
+          fi
+
+          echo "snapshot_rc=$rc" >> "$GITHUB_OUTPUT"
+          echo "artifact_name=$artifact_name" >> "$GITHUB_OUTPUT"
+          exit 0
+
+      - name: Write step summary
+        if: always()
+        env:
+          SNAPSHOT_RC: ${{ steps.remote_snapshot.outputs.snapshot_rc }}
+          ARTIFACT_NAME: ${{ steps.remote_snapshot.outputs.artifact_name }}
+          SINCE: ${{ github.event.inputs.since || '2h' }}
+          UNTIL: ${{ github.event.inputs.until || '' }}
+          TAIL_LINES: ${{ github.event.inputs.tail_lines || '2500' }}
+          CONTAINERS_CSV: ${{ github.event.inputs.containers_csv || 'metasheet-backend,metasheet-web,metasheet-postgres,metasheet-redis' }}
+        run: |
+          set -euo pipefail
+          echo "## Attendance Remote Log Snapshot" >> "$GITHUB_STEP_SUMMARY"
+          echo "" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Snapshot rc: \`${SNAPSHOT_RC:-missing}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Artifact: \`${ARTIFACT_NAME:-missing}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Since: \`${SINCE}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Until: \`${UNTIL:-<none>}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Tail lines: \`${TAIL_LINES}\`" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Containers: \`${CONTAINERS_CSV}\`" >> "$GITHUB_STEP_SUMMARY"
+          if [[ -f output/remote-log-snapshot/snapshot-summary.md ]]; then
+            echo "" >> "$GITHUB_STEP_SUMMARY"
+            cat output/remote-log-snapshot/snapshot-summary.md >> "$GITHUB_STEP_SUMMARY"
+          fi
+
+      - name: Upload artifacts
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: ${{ steps.remote_snapshot.outputs.artifact_name || format('attendance-remote-log-snapshot-prod-{0}-{1}', github.run_id, github.run_attempt) }}
+          path: output/remote-log-snapshot
+
+      - name: Comment on issue
+        if: always() && github.event.inputs.issue_number != ''
+        env:
+          GH_TOKEN: ${{ github.token }}
+          ISSUE_NUMBER: ${{ github.event.inputs.issue_number || '447' }}
+          SNAPSHOT_RC: ${{ steps.remote_snapshot.outputs.snapshot_rc }}
+          ARTIFACT_NAME: ${{ steps.remote_snapshot.outputs.artifact_name }}
+          SINCE: ${{ github.event.inputs.since || '2h' }}
+          UNTIL: ${{ github.event.inputs.until || '' }}
+          CONTAINERS_CSV: ${{ github.event.inputs.containers_csv || 'metasheet-backend,metasheet-web,metasheet-postgres,metasheet-redis' }}
+        run: |
+          set -euo pipefail
+          run_url="${GITHUB_SERVER_URL}/${GITHUB_REPOSITORY}/actions/runs/${GITHUB_RUN_ID}"
+          body="$(mktemp)"
+          {
+            echo "Remote log snapshot collected."
+            echo
+            echo "- Run: ${run_url}"
+            echo "- Artifact: \`${ARTIFACT_NAME:-attendance-remote-log-snapshot-prod-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}\`"
+            echo "- Snapshot rc: \`${SNAPSHOT_RC:-missing}\`"
+            echo "- Since: \`${SINCE}\`"
+            echo "- Until: \`${UNTIL:-<none>}\`"
+            echo "- Containers: \`${CONTAINERS_CSV}\`"
+            echo
+            echo "Download:"
+            echo '```bash'
+            echo "gh run download ${GITHUB_RUN_ID} -n \"${ARTIFACT_NAME:-attendance-remote-log-snapshot-prod-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}\" -D \"output/playwright/ga/${GITHUB_RUN_ID}/remote-log-snapshot\""
+            echo '```'
+          } >"$body"
+          gh issue comment "$ISSUE_NUMBER" --body-file "$body"
+
+      - name: Fail on snapshot error
+        if: steps.remote_snapshot.outputs.snapshot_rc != '0'
+        run: exit 1

--- a/scripts/ops/attendance-collect-remote-logs.sh
+++ b/scripts/ops/attendance-collect-remote-logs.sh
@@ -1,0 +1,112 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+OUTPUT_DIR="${OUTPUT_DIR:-output/remote-log-snapshot}"
+SINCE="${SINCE:-2h}"
+UNTIL="${UNTIL:-}"
+TAIL_LINES="${TAIL_LINES:-2500}"
+CONTAINERS_CSV="${CONTAINERS_CSV:-metasheet-backend,metasheet-web,metasheet-postgres,metasheet-redis}"
+
+function info() {
+  echo "[attendance-collect-remote-logs] $*" >&2
+}
+
+function sanitize_name() {
+  printf '%s' "$1" | sed -E 's/[^A-Za-z0-9_.-]+/_/g'
+}
+
+function redact_stream() {
+  sed -E \
+    -e 's#(Bearer[[:space:]]+)[A-Za-z0-9._~+/=-]+#\1[REDACTED]#g' \
+    -e 's#((authorization|cookie|set-cookie)[[:space:]]*:[[:space:]]*)[^[:space:]]+#\1[REDACTED]#Ig' \
+    -e 's#(postgres(ql)?://)[^/@[:space:]]+@#\1[REDACTED]@#Ig' \
+    -e 's#((access[_-]?token|refresh[_-]?token|id[_-]?token|password|passwd|secret|jwt|session|authorityCode)[A-Za-z0-9_.-]*[[:space:]]*[:=][[:space:]]*"?)[^"[:space:],}]+#\1[REDACTED]#Ig'
+}
+
+function run_redacted() {
+  "$@" 2>&1 | redact_stream
+}
+
+mkdir -p "$OUTPUT_DIR/logs" "$OUTPUT_DIR/inspect"
+
+generated_at="$(date -u '+%Y-%m-%dT%H:%M:%SZ')"
+summary_path="$OUTPUT_DIR/snapshot-summary.md"
+
+{
+  echo "# Attendance Remote Log Snapshot"
+  echo
+  echo "- Generated at: \`${generated_at}\`"
+  echo "- Since: \`${SINCE}\`"
+  echo "- Until: \`${UNTIL:-<none>}\`"
+  echo "- Tail lines: \`${TAIL_LINES}\`"
+  echo "- Containers: \`${CONTAINERS_CSV}\`"
+} >"$summary_path"
+
+{
+  echo "generated_at=${generated_at}"
+  echo "since=${SINCE}"
+  echo "until=${UNTIL:-}"
+  echo "tail_lines=${TAIL_LINES}"
+  echo "containers=${CONTAINERS_CSV}"
+} >"$OUTPUT_DIR/snapshot.env"
+
+{
+  echo "=== host ==="
+  date -u '+date_utc=%Y-%m-%dT%H:%M:%SZ'
+  uname -a || true
+  uptime || true
+  echo
+  echo "=== disk ==="
+  df -h / || true
+  echo
+  echo "=== memory ==="
+  free -m || true
+  echo
+  echo "=== docker ==="
+  docker version --format 'Client={{.Client.Version}} Server={{.Server.Version}}' 2>/dev/null || docker version || true
+  docker compose version 2>/dev/null || docker-compose version 2>/dev/null || true
+} 2>&1 | redact_stream >"$OUTPUT_DIR/host-health.txt"
+
+run_redacted docker ps -a --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}' >"$OUTPUT_DIR/docker-ps.txt" || true
+run_redacted docker stats --no-stream --format 'table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}\t{{.NetIO}}\t{{.BlockIO}}\t{{.PIDs}}' >"$OUTPUT_DIR/docker-stats.txt" || true
+
+IFS=',' read -r -a containers <<< "$CONTAINERS_CSV"
+for raw_container in "${containers[@]}"; do
+  container="$(printf '%s' "$raw_container" | sed -E 's/^[[:space:]]+|[[:space:]]+$//g')"
+  [[ -n "$container" ]] || continue
+  safe_container="$(sanitize_name "$container")"
+  inspect_path="$OUTPUT_DIR/inspect/${safe_container}.inspect.txt"
+  log_path="$OUTPUT_DIR/logs/${safe_container}.log"
+
+  info "collecting container=${container}"
+  {
+    echo "container=${container}"
+    docker inspect --format 'Name={{.Name}}
+Image={{.Config.Image}}
+State={{.State.Status}}
+StartedAt={{.State.StartedAt}}
+FinishedAt={{.State.FinishedAt}}
+RestartCount={{.RestartCount}}
+OOMKilled={{.State.OOMKilled}}
+ExitCode={{.State.ExitCode}}
+Health={{if .State.Health}}{{.State.Health.Status}}{{else}}none{{end}}' "$container" || true
+  } 2>&1 | redact_stream >"$inspect_path"
+
+  docker_args=(logs --timestamps --tail "$TAIL_LINES" --since "$SINCE")
+  if [[ -n "$UNTIL" ]]; then
+    docker_args+=(--until "$UNTIL")
+  fi
+  docker_args+=("$container")
+
+  run_redacted docker "${docker_args[@]}" >"$log_path" || true
+
+  {
+    echo
+    echo "## ${container}"
+    echo
+    echo "- Inspect: \`inspect/${safe_container}.inspect.txt\`"
+    echo "- Log: \`logs/${safe_container}.log\`"
+  } >>"$summary_path"
+done
+
+info "snapshot written to ${OUTPUT_DIR}"

--- a/scripts/ops/attendance-remote-log-snapshot-workflow-contract.test.mjs
+++ b/scripts/ops/attendance-remote-log-snapshot-workflow-contract.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+
+function readRepoFile(relativePath) {
+  return readFileSync(path.join(repoRoot, relativePath), 'utf8')
+}
+
+test('remote log snapshot workflow uses deploy-host secrets and uploads artifacts', () => {
+  const raw = readRepoFile('.github/workflows/attendance-remote-log-snapshot-prod.yml')
+
+  assert.match(raw, /DEPLOY_HOST:\s+\$\{\{\s*secrets\.DEPLOY_HOST\s*\}\}/)
+  assert.match(raw, /DEPLOY_USER:\s+\$\{\{\s*secrets\.DEPLOY_USER\s*\}\}/)
+  assert.match(raw, /DEPLOY_SSH_KEY_B64:\s+\$\{\{\s*secrets\.DEPLOY_SSH_KEY_B64\s*\}\}/)
+  assert.match(raw, /scripts\/ops\/attendance-collect-remote-logs\.sh/)
+  assert.match(raw, /scp \$ssh_opts -r/)
+  assert.match(raw, /uses: actions\/upload-artifact@v4/)
+})
+
+test('remote log snapshot workflow can comment with a run artifact pointer', () => {
+  const raw = readRepoFile('.github/workflows/attendance-remote-log-snapshot-prod.yml')
+
+  assert.match(raw, /issues: write/)
+  assert.match(raw, /gh issue comment "\$ISSUE_NUMBER" --body-file "\$body"/)
+  assert.match(raw, /gh run download \$\{GITHUB_RUN_ID\}/)
+})
+
+test('remote log collector redacts common secret shapes and avoids full inspect env dumps', () => {
+  const raw = readRepoFile('scripts/ops/attendance-collect-remote-logs.sh')
+
+  assert.match(raw, /Bearer\[\[:space:\]\]\+/)
+  assert.match(raw, /authorization\|cookie\|set-cookie/)
+  assert.match(raw, /postgres\(ql\)\?:\/\//)
+  assert.match(raw, /access\[_-\]\?token\|refresh\[_-\]\?token\|id\[_-\]\?token\|password\|passwd\|secret\|jwt\|session\|authorityCode/)
+  assert.match(raw, /docker inspect --format/)
+  assert.doesNotMatch(raw, /\.Config\.Env/)
+  assert.doesNotMatch(raw, /docker inspect "\$container" >/)
+})


### PR DESCRIPTION
## Summary
- add a manual Attendance Remote Log Snapshot workflow for #447 runtime triage
- collect deploy-host Docker status, host health, and redacted logs for backend/web/postgres/redis
- upload the snapshot as an Actions artifact and optionally comment the target issue with a download command
- add a contract test to guard deploy-host secret usage, artifact upload, issue comment, and redaction boundaries

## Verification
- bash -n scripts/ops/attendance-collect-remote-logs.sh
- node --test scripts/ops/attendance-remote-log-snapshot-workflow-contract.test.mjs
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/attendance-remote-log-snapshot-prod.yml'); puts 'yaml ok'"
- git diff --check

Refs #447