### PR TITLE
fix(attendance): make remote log snapshot issue comments repo-aware

### DIFF
--- a/.github/workflows/attendance-remote-log-snapshot-prod.yml
+++ b/.github/workflows/attendance-remote-log-snapshot-prod.yml
@@ -204,7 +204,7 @@ jobs:
             echo "gh run download ${GITHUB_RUN_ID} -n \"${ARTIFACT_NAME:-attendance-remote-log-snapshot-prod-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}}\" -D \"output/playwright/ga/${GITHUB_RUN_ID}/remote-log-snapshot\""
             echo '```'
           } >"$body"
-          gh issue comment "$ISSUE_NUMBER" --body-file "$body"
+          gh issue comment --repo "$GITHUB_REPOSITORY" "$ISSUE_NUMBER" --body-file "$body"
 
       - name: Fail on snapshot error
         if: steps.remote_snapshot.outputs.snapshot_rc != '0'

--- a/scripts/ops/attendance-collect-remote-logs.sh
+++ b/scripts/ops/attendance-collect-remote-logs.sh
@@ -40,6 +40,7 @@ summary_path="$OUTPUT_DIR/snapshot-summary.md"
   echo "- Until: \`${UNTIL:-<none>}\`"
   echo "- Tail lines: \`${TAIL_LINES}\`"
   echo "- Containers: \`${CONTAINERS_CSV}\`"
+  echo "- Docker events: \`docker-events.jsonl\`"
 } >"$summary_path"
 
 {
@@ -69,6 +70,12 @@ summary_path="$OUTPUT_DIR/snapshot-summary.md"
 
 run_redacted docker ps -a --format 'table {{.Names}}\t{{.Image}}\t{{.Status}}\t{{.Ports}}' >"$OUTPUT_DIR/docker-ps.txt" || true
 run_redacted docker stats --no-stream --format 'table {{.Name}}\t{{.CPUPerc}}\t{{.MemUsage}}\t{{.MemPerc}}\t{{.NetIO}}\t{{.BlockIO}}\t{{.PIDs}}' >"$OUTPUT_DIR/docker-stats.txt" || true
+events_until="${UNTIL:-$generated_at}"
+run_redacted docker events \
+  --since "$SINCE" \
+  --until "$events_until" \
+  --filter type=container \
+  --format '{{json .}}' >"$OUTPUT_DIR/docker-events.jsonl" || true
 
 IFS=',' read -r -a containers <<< "$CONTAINERS_CSV"
 for raw_container in "${containers[@]}"; do

--- a/scripts/ops/attendance-remote-log-snapshot-workflow-contract.test.mjs
+++ b/scripts/ops/attendance-remote-log-snapshot-workflow-contract.test.mjs
@@ -25,7 +25,7 @@ test('remote log snapshot workflow can comment with a run artifact pointer', () 
   const raw = readRepoFile('.github/workflows/attendance-remote-log-snapshot-prod.yml')
 
   assert.match(raw, /issues: write/)
-  assert.match(raw, /gh issue comment "\$ISSUE_NUMBER" --body-file "\$body"/)
+  assert.match(raw, /gh issue comment --repo "\$GITHUB_REPOSITORY" "\$ISSUE_NUMBER" --body-file "\$body"/)
   assert.match(raw, /gh run download \$\{GITHUB_RUN_ID\}/)
 })
 
@@ -37,6 +37,8 @@ test('remote log collector redacts common secret shapes and avoids full inspect 
   assert.match(raw, /postgres\(ql\)\?:\/\//)
   assert.match(raw, /access\[_-\]\?token\|refresh\[_-\]\?token\|id\[_-\]\?token\|password\|passwd\|secret\|jwt\|session\|authorityCode/)
   assert.match(raw, /docker inspect --format/)
+  assert.match(raw, /docker events/)
+  assert.match(raw, /docker-events\.jsonl/)
   assert.doesNotMatch(raw, /\.Config\.Env/)
   assert.doesNotMatch(raw, /docker inspect "\$container" >/)
 })


### PR DESCRIPTION
## Summary
- pass --repo to the remote log snapshot issue-comment step so it works without checkout
- include Docker container events in the remote snapshot artifact for restart/recreate triage
- extend the workflow contract test for the repo-aware comment and docker-events artifact

## Verification
- bash -n scripts/ops/attendance-collect-remote-logs.sh
- node --test scripts/ops/attendance-remote-log-snapshot-workflow-contract.test.mjs
- ruby -e "require 'yaml'; YAML.load_file('.github/workflows/attendance-remote-log-snapshot-prod.yml'); puts 'yaml ok'"
- git diff --check

Refs #447