### PR TITLE
fix(attendance): harden import COPY stream timeouts

### DIFF
--- a/packages/core-backend/tests/unit/attendance-import-copy-stream.test.ts
+++ b/packages/core-backend/tests/unit/attendance-import-copy-stream.test.ts
@@ -1,0 +1,36 @@
+import { EventEmitter } from 'node:events'
+import { createRequire } from 'node:module'
+import { describe, expect, it } from 'vitest'
+
+const require = createRequire(import.meta.url)
+const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cjs')
+const helpers = attendancePlugin.__attendanceReportFieldCatalogForTests
+
+describe('attendance import COPY stream safeguards', () => {
+  it('uses the attendance heavy-query timeout for COPY FROM STDIN query objects', () => {
+    const query = helpers.buildAttendanceImportCopyQuery(
+      (sql: string) => ({
+        text: sql,
+        callback() {},
+        submit() {},
+      }),
+      'COPY attendance_import_records_stage FROM STDIN',
+    )
+
+    expect(query.text).toBe('COPY attendance_import_records_stage FROM STDIN')
+    expect(query.query_timeout).toBe(180000)
+    expect(query.statement_timeout).toBe(180000)
+  })
+
+  it('attaches an immediate error sink for late pg-copy-streams errors', () => {
+    const copyStream = new EventEmitter()
+    const error = new Error('Query read timeout')
+
+    const returned = helpers.attachAttendanceImportCopyStreamErrorSink(copyStream)
+
+    expect(returned).toBe(copyStream)
+    expect(copyStream.listenerCount('error')).toBeGreaterThan(0)
+    expect(() => copyStream.emit('error', error)).not.toThrow()
+    expect((copyStream as any).__attendanceImportCopyLastError).toBe(error)
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -13604,6 +13604,27 @@ function resolveAttendanceImportRawClient(client) {
   return raw
 }
 
+function buildAttendanceImportCopyQuery(copyFromFactory, sql) {
+  const copyQuery = copyFromFactory(sql)
+  const timeoutMs = Number(ATTENDANCE_IMPORT_HEAVY_QUERY_TIMEOUT_MS)
+  if (copyQuery && typeof copyQuery === 'object' && Number.isFinite(timeoutMs) && timeoutMs > 0) {
+    const normalized = Math.floor(timeoutMs)
+    copyQuery.query_timeout = normalized
+    copyQuery.statement_timeout = normalized
+  }
+  return copyQuery
+}
+
+function attachAttendanceImportCopyStreamErrorSink(copyStream) {
+  if (!copyStream || typeof copyStream.on !== 'function') return copyStream
+  if (copyStream.__attendanceImportCopyErrorSinkAttached === true) return copyStream
+  copyStream.__attendanceImportCopyErrorSinkAttached = true
+  copyStream.on('error', (error) => {
+    copyStream.__attendanceImportCopyLastError = error
+  })
+  return copyStream
+}
+
 function shouldUseAttendanceImportCopyStdin({ client, totalRows }) {
   if (!ATTENDANCE_IMPORT_COPY_ENABLED) return false
   if (ATTENDANCE_IMPORT_COPY_STREAM_MODE === 'off') return false
@@ -13654,12 +13675,14 @@ async function copyAttendanceImportRowsToStage(client, rows) {
   const rawClient = resolveAttendanceImportRawClient(client)
   const copyFromFactory = resolveAttendanceCopyFromFactory()
   if (!rawClient || !copyFromFactory) return false
-  const copyStream = rawClient.query(
-    copyFromFactory(
-      `COPY attendance_import_records_stage
-        (user_id, org_id, work_date, timezone, first_in_at, last_out_at, work_minutes, late_minutes, early_leave_minutes, status, is_workday, meta_json, source_batch_id)
-       FROM STDIN WITH (FORMAT csv, NULL '\\N')`
-    )
+  const copyQuery = buildAttendanceImportCopyQuery(
+    copyFromFactory,
+    `COPY attendance_import_records_stage
+      (user_id, org_id, work_date, timezone, first_in_at, last_out_at, work_minutes, late_minutes, early_leave_minutes, status, is_workday, meta_json, source_batch_id)
+     FROM STDIN WITH (FORMAT csv, NULL '\\N')`
+  )
+  const copyStream = attachAttendanceImportCopyStreamErrorSink(
+    rawClient.query(copyQuery)
   )
   await pipeline(Readable.from(iterAttendanceImportStageCsvLines(rows)), copyStream)
   return true
@@ -13687,12 +13710,14 @@ async function copyAttendanceImportItemsToStage(client, { batchId, orgId, items 
   const rawClient = resolveAttendanceImportRawClient(client)
   const copyFromFactory = resolveAttendanceCopyFromFactory()
   if (!rawClient || !copyFromFactory) return false
-  const copyStream = rawClient.query(
-    copyFromFactory(
-      `COPY attendance_import_items_stage
-        (id, batch_id, org_id, user_id, work_date, record_id, preview_snapshot)
-       FROM STDIN WITH (FORMAT csv, NULL '\\N')`
-    )
+  const copyQuery = buildAttendanceImportCopyQuery(
+    copyFromFactory,
+    `COPY attendance_import_items_stage
+      (id, batch_id, org_id, user_id, work_date, record_id, preview_snapshot)
+     FROM STDIN WITH (FORMAT csv, NULL '\\N')`
+  )
+  const copyStream = attachAttendanceImportCopyStreamErrorSink(
+    rawClient.query(copyQuery)
   )
   await pipeline(
     Readable.from(iterAttendanceImportItemsStageCsvLines({ batchId, orgId, items })),
@@ -15002,6 +15027,8 @@ module.exports = {
     attendanceReportRecordRowKey,
     buildAttendanceImportMultiPunchMeta,
     computeAttendanceRecordUpsertValues,
+    buildAttendanceImportCopyQuery,
+    attachAttendanceImportCopyStreamErrorSink,
     ATTENDANCE_REPORT_RECORDS_OBJECT_ID,
     ATTENDANCE_REPORT_RECORDS_FIELDS,
     mergeAttendanceReportFieldDefinitions,


### PR DESCRIPTION
## Summary
- apply the attendance heavy-query timeout to pg-copy-streams COPY query objects so bulk import COPY does not inherit the default 30s pg read timeout
- attach an immediate COPY stream error sink so late pg-copy-streams errors are captured instead of becoming process-level unhandled `error` events
- add focused unit coverage for the timeout and error-sink safeguards

## Context
Follow-up for #447. Remote log snapshot evidence from runs `26679446112`, `26679491555`, and `26679539693` showed the active 100k blocker is no longer row-cap drift; backend restarted during COPY with `Error: Query read timeout` emitted on `CopyStreamQuery`.

## Verification
- `/Users/chouhua/Downloads/Github/metasheet2/node_modules/.bin/vitest run packages/core-backend/tests/unit/attendance-import-copy-stream.test.ts --watch=false`
- `node -c plugins/plugin-attendance/index.cjs`
- `git diff --check`
