### PR TITLE
fix(attendance): unwrap raw client for import COPY streams

### DIFF
--- a/packages/core-backend/tests/unit/attendance-import-copy-stream.test.ts
+++ b/packages/core-backend/tests/unit/attendance-import-copy-stream.test.ts
@@ -7,6 +7,22 @@ const attendancePlugin = require('../../../../plugins/plugin-attendance/index.cj
 const helpers = attendancePlugin.__attendanceReportFieldCatalogForTests
 
 describe('attendance import COPY stream safeguards', () => {
+  it('unwraps nested transaction adapters to the real pg client before COPY', () => {
+    const poolClient = {
+      query() {},
+    }
+    const transactionClient = {
+      query: async () => undefined,
+      __rawClient: poolClient,
+    }
+    const pluginTransaction = {
+      query: async () => undefined,
+      __rawClient: transactionClient,
+    }
+
+    expect(helpers.resolveAttendanceImportRawClient(pluginTransaction)).toBe(poolClient)
+  })
+
   it('uses the attendance heavy-query timeout for COPY FROM STDIN query objects', () => {
     const query = helpers.buildAttendanceImportCopyQuery(
       (sql: string) => ({

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -13598,10 +13598,19 @@ async function batchUpsertAttendanceRecordsUnnest(client, rows) {
 }
 
 function resolveAttendanceImportRawClient(client) {
-  if (!client || typeof client !== 'object') return null
-  const raw = client.__rawClient ?? client.rawClient ?? null
-  if (!raw || typeof raw.query !== 'function') return null
-  return raw
+  const seen = new Set()
+  let current = client
+  while (current && typeof current === 'object' && !seen.has(current)) {
+    seen.add(current)
+    const nested = current.__rawClient ?? current.rawClient ?? null
+    if (nested && typeof nested === 'object' && !seen.has(nested)) {
+      current = nested
+      continue
+    }
+    if (typeof current.query === 'function') return current
+    break
+  }
+  return null
 }
 
 function buildAttendanceImportCopyQuery(copyFromFactory, sql) {
@@ -15027,6 +15036,7 @@ module.exports = {
     attendanceReportRecordRowKey,
     buildAttendanceImportMultiPunchMeta,
     computeAttendanceRecordUpsertValues,
+    resolveAttendanceImportRawClient,
     buildAttendanceImportCopyQuery,
     attachAttendanceImportCopyStreamErrorSink,
     ATTENDANCE_REPORT_RECORDS_OBJECT_ID,


### PR DESCRIPTION
## Summary
- unwrap nested plugin/database transaction adapters until the real pg client is reached before starting attendance COPY streams
- keep the COPY query timeout/error-sink protections from #2127 attached to the actual `CopyStreamQuery`
- extend the focused COPY stream unit test to cover the nested `__rawClient` shape seen in production

## Context
Follow-up for #447 after #2127. The post-merge high-scale rerun still produced a late `CopyStreamQuery` `Query read timeout` because `resolveAttendanceImportRawClient()` returned the async transaction wrapper instead of the underlying pg `PoolClient`; the real COPY stream was started but the caller attached listeners to the wrong object.

Evidence:
- high-scale rerun: https://github.com/zensgit/metasheet2/actions/runs/26679946038
- remote log snapshot: https://github.com/zensgit/metasheet2/actions/runs/26680078440

## Verification
- `/Users/chouhua/Downloads/Github/metasheet2/node_modules/.bin/vitest run packages/core-backend/tests/unit/attendance-import-copy-stream.test.ts --watch=false`
- `node -c plugins/plugin-attendance/index.cjs`
- `git diff --check`
