### PR TITLE
feat(multitable): A6-1 persistent WorkflowJob runtime (opt-in linear job plane)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -177,6 +177,7 @@ jobs:
             tests/integration/multitable-viewconfig-resave-guard.test.ts \
             tests/integration/multitable-records-list-authz.test.ts \
             tests/integration/multitable-automation-retry.test.ts \
+            tests/integration/multitable-automation-jobs.test.ts \
             --reporter=dot
 
       - name: Start core backend (background)

--- a/docs/development/multitable-automation-a6-1-workflowjob-runtime-verification-20260530.md
+++ b/docs/development/multitable-automation-a6-1-workflowjob-runtime-verification-20260530.md
@@ -1,0 +1,47 @@
+# Multitable Automation A6-1 — Persistent WorkflowJob Runtime (verification) — 2026-05-30
+
+- **Slice**: A6-1 — opt-in persistent linear WorkflowJob runtime. Implements the A6-1 scout (#2112) after explicit owner opt-in ("启动 A6-1 runtime"). First A6 capability-half runtime.
+- **Status**: ✅ implemented + verified. A6-2+ (suspend/resume, branch/parallel, BPMN, approval-as-job) remain frozen / demand-gated.
+- **Lock**: post-GATE (K3 blanket lock retired, #1993); A6-1 governed by the run-governance demand gate, not K3. Automation is multitable-kernel (no integration-core / RBAC / K3-write touch).
+
+## What shipped
+
+| File | Change |
+|---|---|
+| migration `zzzz20260530120000` | new `multitable_automation_jobs` (+ `idx…execution_id`) + nullable `automation_rules.execution_mode`. |
+| `db/types.ts` | `MultitableAutomationJobsTable` + `execution_mode` on the rules table + Database registration. |
+| `automation-executor.ts` | `AutomationRule.executionMode?`; `ActionJobLifecycle` (onStart/onSettled/onSkipped) + `ActionJobLifecycleFactory`; `execute(rule, evt, jobLifecycleFactory?)`; `executeActions(..., jobLifecycle?)` fires hooks **outside the inner per-action try/catch**. |
+| `automation-job-service.ts` (new) | `lifecycleFor(executionId, rule)` (job persistence around each action) + `listByExecution(executionId)` (C1 views). Reuses `redactValue`/`redactString`; statuses via `legacyAutomationStatusToJobStatus`/`normalizeWorkflowJobStatus`. |
+| `automation-service.ts` | `AutomationRule.execution_mode`; `toExecutorRule`/`mapRow` plumb it; `executeRule` builds the factory ONLY for `workflow_job_v1` (single path-choice point → retries of opt-in rules also write jobs); `get jobs()` accessor. |
+| `routes/automation.ts` | A2 detail prefers persisted jobs (`svc.jobs.listByExecution`) → C1 step view; falls back to legacy steps when none (list unchanged — no N+1). |
+
+## A6-1 scout questions → implementation
+
+| Scout Q | Implemented |
+|---|---|
+| 1. table shape | separate `multitable_automation_jobs` (NOT extending `steps`); scout columns; index on `execution_id`. |
+| 2. opt-in | rule-level `execution_mode` (`NULL`/`legacy` = no jobs; `workflow_job_v1` = jobs). Not a global env flag. |
+| 3. worker | none — inline; job created **`running`** before the action (no vestigial `queued`; the invariant is *created-before-side-effect*, so a crash leaves an observable `running` row). |
+| 4. txn boundary | **fail-closed for opt-in** (see below). |
+| 5. redaction | reuse `automation-log-redact` (`redactValue` result / `redactString` error). No job-specific redactor; no integration-core import → A1 invariant preserved. |
+| 6. mixed read | A2 detail prefers jobs, falls back to legacy steps; no new response field (shape stable; job ids `:job:i` vs legacy `:step:i`). |
+| 7. legacy-off | opt-out rule → no factory → zero job rows + byte-identical execution/log shape (tested). |
+
+## Fail-closed design (the load-bearing correctness point)
+The lifecycle hooks run **OUTSIDE** the inner per-action `try/catch` (which converts action throws into a `failed` STEP). So a job-write failure propagates to `execute()`'s outer catch and fails the **EXECUTION**, not a swallowed step. Two pinned sub-cases:
+- **(a) onStart throws** (job create fails) → the action's side effect **never runs**; execution `failed`.
+- **(b) onSettled throws** (job update fails) *after* the action → the side effect **ran once**; execution `failed` — "must not pretend the action didn't run."
+
+This is stricter than the legacy log-write swallow and the `/test`+retry fail-OPEN (#2053) — deliberately, because A6-1 is opt-in durable provenance. **Operator-visible consequence (accepted, per scout):** a transient job-write blip turns a side-effect-completed opt-in run into `failed`; an operator A5 retry can then double-fire those side effects. Surfaced here so it's a conscious trade, not a surprise.
+
+## Verification
+- `tsc --noEmit` (core-backend): ✅ 0.
+- Unit: ✅ **181** (`automation-v1` adds: executor lifecycle ordering, fail-stop skipped, **fail-closed (a) side-effect-never-ran + (b) side-effect-ran-once**, legacy-no-factory unchanged; service path-choice opt-out-no-factory / opt-in-factory; `AutomationJobService` onStart-running / onSettled-redacted+C1-status / `listByExecution` C1 views pass `normalizeWorkflowJob`; `automation-runs-api` adds A2-detail-prefers-jobs vs legacy-steps-fallback). Existing automation suites unchanged.
+- Real-DB round-trip: `tests/integration/multitable-automation-jobs.test.ts` (describeIfDatabase + sentinel) — lifecycle onStart→onSettled→onSkipped → `listByExecution` + raw-SQL confirm the new table/columns; wired into `plugin-tests.yml` (closes the wire-vs-fixture gap for the new table).
+- ESLint (my files): clean. One **pre-existing** `prefer-const` in `parseCreateRuleInput` (unrelated; core-backend has no `lint` script so CI doesn't flag it) — left as-is.
+
+## Latency — runtime present, enable path deferred (dormant in production)
+The read path is fully wired: all `automation_rules` reads use `.selectAll()`, so `execution_mode` flows through `mapRow` → `toExecutorRule` → `executeRule` at runtime (verified — NOT dead-on-arrival). **But no write path sets it**: `createRule`/`updateRule` deliberately do NOT accept/passthrough `execution_mode` (enable path is scout-deferred). So in production the job plane is **dormant** — a rule can be opted in only by **direct DB / fixture** (`execution_mode='workflow_job_v1'`), not via the API. A follow-up (its own opt-in) adds the API/UI enable writer. This is intended: the runtime lands and is provable, while turning it on stays a separate, reviewable step.
+
+## Scope held / out of scope
+NO suspend/resume, resume tokens, delay/timer, worker/claim, branch/parallel graph columns, BPMN, approval-as-job, `start_approval`, or default per-action writes for existing rules — **A6-2..A6-5 stay frozen / demand-gated**. Job ids use `${exec}:job:i` (vs legacy `${exec}:step:i`); consumers must not assume a stable step-id shape across an opt-in flip.

--- a/packages/core-backend/src/db/migrations/zzzz20260530120000_create_automation_jobs_and_execution_mode.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260530120000_create_automation_jobs_and_execution_mode.ts
@@ -1,0 +1,58 @@
+/**
+ * Migration: A6-1 persistent WorkflowJob runtime — opt-in linear job plane
+ *
+ * Purpose: persist one C1-shaped job row per automation action for explicitly
+ *   opted-in rules (`automation_rules.execution_mode = 'workflow_job_v1'`), while
+ *   existing rules stay on the legacy `multitable_automation_executions.steps`
+ *   path by default. Jobs are an ADDITIVE detail plane; A2 detail prefers them
+ *   when present and falls back to legacy steps.
+ * Tables: multitable_automation_jobs (new); automation_rules (+ execution_mode)
+ * Breaking: No — new table; execution_mode nullable (NULL = legacy).
+ */
+
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const jobsExists = await checkTableExists(db, 'multitable_automation_jobs')
+  if (!jobsExists) {
+    await sql`
+      CREATE TABLE IF NOT EXISTS multitable_automation_jobs (
+        id TEXT PRIMARY KEY,
+        execution_id TEXT NOT NULL,
+        rule_id TEXT NOT NULL,
+        sheet_id TEXT,
+        step_index INTEGER NOT NULL,
+        step_key TEXT NOT NULL,
+        action_type TEXT NOT NULL,
+        status TEXT NOT NULL,
+        upstream_job_id TEXT,
+        result JSONB,
+        error TEXT,
+        started_at TIMESTAMPTZ,
+        finished_at TIMESTAMPTZ,
+        duration_ms INTEGER,
+        schema_version INTEGER NOT NULL DEFAULT 1,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+      )
+    `.execute(db)
+    // A2 detail reads jobs by execution_id (scout: index required).
+    await sql`CREATE INDEX IF NOT EXISTS idx_mt_auto_jobs_execution_id ON multitable_automation_jobs (execution_id)`.execute(db)
+  }
+
+  const rulesExists = await checkTableExists(db, 'automation_rules')
+  if (rulesExists) {
+    // Opt-in flag — NULL/'legacy' = current path (no job rows); 'workflow_job_v1' = write jobs.
+    await sql`ALTER TABLE automation_rules ADD COLUMN IF NOT EXISTS execution_mode TEXT`.execute(db)
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS multitable_automation_jobs`.execute(db)
+  const rulesExists = await checkTableExists(db, 'automation_rules')
+  if (rulesExists) {
+    await sql`ALTER TABLE automation_rules DROP COLUMN IF EXISTS execution_mode`.execute(db)
+  }
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -106,6 +106,7 @@ export interface Database {
   meta_widgets: MetaWidgetsTable
   // Multitable automation & dashboard
   automation_rules: AutomationRulesTable
+  multitable_automation_jobs: MultitableAutomationJobsTable
   multitable_automation_executions: MultitableAutomationExecutionsTable
   multitable_charts: MultitableChartsTable
   multitable_dashboards: MultitableDashboardsTable
@@ -1241,6 +1242,30 @@ export interface AutomationRulesTable {
   created_by: string | null
   conditions: JSONColumnType<Record<string, unknown> | null>
   actions: JSONColumnType<Record<string, unknown>[] | null>
+  // A6-1 opt-in flag: NULL/'legacy' = legacy execution path (no job rows);
+  // 'workflow_job_v1' = persist one C1 job per action.
+  execution_mode: string | null
+}
+
+/** A6-1 persistent WorkflowJob rows — opt-in linear job plane (additive to executions). */
+export interface MultitableAutomationJobsTable {
+  id: string
+  execution_id: string
+  rule_id: string
+  sheet_id: string | null
+  step_index: number
+  step_key: string
+  action_type: string
+  status: string
+  upstream_job_id: string | null
+  result: JsonValueColumn
+  error: string | null
+  started_at: Date | string | null
+  finished_at: Date | string | null
+  duration_ms: number | null
+  schema_version: number
+  created_at: CreatedAt
+  updated_at: UpdatedAt
 }
 
 export interface MultitableAutomationExecutionsTable {

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -476,6 +476,8 @@ export interface AutomationRule {
  * provenance), instead of being swallowed into a failed STEP result.
  */
 export interface ActionJobLifecycle {
+  /** Before any condition/action side effects — persist a visible parent execution row. */
+  onExecutionStarted?(execution: AutomationExecution): Promise<void>
   /** Before the action's side effect runs — create the job as `running` (observable on crash). */
   onStart(stepIndex: number, action: AutomationAction): Promise<void>
   /** After the action settled — update the job to resolved/failed. */
@@ -582,6 +584,10 @@ export class AutomationExecutor {
       schemaVersion: AUTOMATION_EXECUTION_SCHEMA_VERSION,
     }
 
+    // A6-1: opt-in job persistence needs a visible parent execution before any
+    // job row/action side effect. If this write fails, no action has run yet.
+    if (jobLifecycle?.onExecutionStarted) await jobLifecycle.onExecutionStarted(execution)
+
     // Build execution context from trigger event
     const payload = triggerEvent as Record<string, unknown>
     const context: ExecutionContext = {
@@ -607,7 +613,7 @@ export class AutomationExecutor {
 
     // Execute actions in sequence
     try {
-      execution.steps = await this.executeActions(rule.actions, context, jobLifecycle)
+      await this.executeActions(rule.actions, context, execution.steps, jobLifecycle)
 
       const hasFailed = execution.steps.some((s) => s.status === 'failed')
       const allSkipped = execution.steps.length > 0 && execution.steps.every((s) => s.status === 'skipped')
@@ -632,10 +638,9 @@ export class AutomationExecutor {
   private async executeActions(
     actions: AutomationAction[],
     context: ExecutionContext,
+    results: AutomationStepResult[],
     jobLifecycle?: ActionJobLifecycle,
   ): Promise<AutomationStepResult[]> {
-    const results: AutomationStepResult[] = []
-
     for (let index = 0; index < actions.length; index++) {
       const action = actions[index]
       // A6-1 fail-closed: onStart runs BEFORE the inner try, so a job-create failure propagates

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -463,7 +463,29 @@ export interface AutomationRule {
   createdBy: string
   createdAt: string
   updatedAt?: string
+  /** A6-1 opt-in: 'workflow_job_v1' persists one job per action; undefined/'legacy' = no jobs. */
+  executionMode?: string
 }
+
+/**
+ * A6-1 per-action job lifecycle hooks. The job-persisting path supplies these so
+ * one C1 job row is written around each action; the legacy path passes none → no jobs.
+ *
+ * Fail-closed contract: these run OUTSIDE the inner per-action try/catch, so a thrown
+ * hook propagates to execute()'s outer catch and fails the EXECUTION (opt-in durable
+ * provenance), instead of being swallowed into a failed STEP result.
+ */
+export interface ActionJobLifecycle {
+  /** Before the action's side effect runs — create the job as `running` (observable on crash). */
+  onStart(stepIndex: number, action: AutomationAction): Promise<void>
+  /** After the action settled — update the job to resolved/failed. */
+  onSettled(stepIndex: number, action: AutomationAction, result: AutomationStepResult): Promise<void>
+  /** A fail-stop-skipped action — record a terminal `skipped` job. */
+  onSkipped(stepIndex: number, action: AutomationAction): Promise<void>
+}
+
+/** Builds the per-execution job lifecycle once the executionId is known (service-supplied for opt-in rules). */
+export type ActionJobLifecycleFactory = (executionId: string) => ActionJobLifecycle
 
 /** Snapshot schema version stamped on every execution row (A1 run-governance). */
 export const AUTOMATION_EXECUTION_SCHEMA_VERSION = 1
@@ -535,8 +557,15 @@ export class AutomationExecutor {
    * Execute a rule against a trigger event.
    * Returns an execution record with step results.
    */
-  async execute(rule: AutomationRule, triggerEvent: unknown): Promise<AutomationExecution> {
+  async execute(
+    rule: AutomationRule,
+    triggerEvent: unknown,
+    jobLifecycleFactory?: ActionJobLifecycleFactory,
+  ): Promise<AutomationExecution> {
     const executionId = `axe_${randomUUID()}`
+    // A6-1: opt-in rules get a per-action job lifecycle bound to this executionId. The factory
+    // is supplied by the service ONLY for 'workflow_job_v1' rules → legacy rules never write jobs.
+    const jobLifecycle = jobLifecycleFactory ? jobLifecycleFactory(executionId) : undefined
     const startTime = Date.now()
     const execution: AutomationExecution = {
       id: executionId,
@@ -578,7 +607,7 @@ export class AutomationExecutor {
 
     // Execute actions in sequence
     try {
-      execution.steps = await this.executeActions(rule.actions, context)
+      execution.steps = await this.executeActions(rule.actions, context, jobLifecycle)
 
       const hasFailed = execution.steps.some((s) => s.status === 'failed')
       const allSkipped = execution.steps.length > 0 && execution.steps.every((s) => s.status === 'skipped')
@@ -603,10 +632,15 @@ export class AutomationExecutor {
   private async executeActions(
     actions: AutomationAction[],
     context: ExecutionContext,
+    jobLifecycle?: ActionJobLifecycle,
   ): Promise<AutomationStepResult[]> {
     const results: AutomationStepResult[] = []
 
-    for (const action of actions) {
+    for (let index = 0; index < actions.length; index++) {
+      const action = actions[index]
+      // A6-1 fail-closed: onStart runs BEFORE the inner try, so a job-create failure propagates
+      // to execute()'s outer catch (execution fails) — and the action's side effect never runs.
+      if (jobLifecycle) await jobLifecycle.onStart(index, action)
       const startMs = Date.now()
       let result: AutomationStepResult
 
@@ -668,10 +702,17 @@ export class AutomationExecutor {
 
       results.push(result)
 
+      // A6-1 fail-closed: onSettled runs AFTER the inner try/catch (+durationMs +dingtalk) — i.e.
+      // OUTSIDE it — so a job-UPDATE failure propagates to execute()'s outer catch (execution
+      // fails) rather than being swallowed into a failed step. The action's side effect already
+      // ran by here, so this is the "must not pretend the action didn't run" case.
+      if (jobLifecycle) await jobLifecycle.onSettled(index, action, result)
+
       // Stop on failure
       if (result.status === 'failed') {
         // Mark remaining actions as skipped
         for (let i = results.length; i < actions.length; i++) {
+          if (jobLifecycle) await jobLifecycle.onSkipped(i, actions[i])
           results.push({
             actionType: actions[i].type,
             status: 'skipped',

--- a/packages/core-backend/src/multitable/automation-job-service.ts
+++ b/packages/core-backend/src/multitable/automation-job-service.ts
@@ -1,0 +1,143 @@
+/**
+ * Automation Job Service — A6-1 persistent WorkflowJob runtime (opt-in).
+ *
+ * Responsible ONLY for persisting one C1-shaped job row per action of an opted-in
+ * automation rule (`execution_mode = 'workflow_job_v1'`) and reading them back as
+ * C1 WorkflowJob views. It does NOT execute actions — `AutomationExecutor` owns the
+ * side effects; this service is the lifecycle/persistence plane around them.
+ *
+ * Invariants:
+ * - reuses the A1 redaction helper (no job-specific redactor; result via redactValue,
+ *   error via redactString) — no new unredacted plane;
+ * - statuses are the C1 vocabulary via `legacyAutomationStatusToJobStatus` (no second
+ *   status vocabulary);
+ * - fail-closed: the lifecycle hooks throw on a DB failure so the executor's outer
+ *   catch fails the execution (opt-in durable provenance), never a silent warning.
+ */
+
+import { db } from '../db/db'
+import { toJsonValue } from '../db/type-helpers'
+import { legacyAutomationStatusToJobStatus, normalizeWorkflowJobStatus, type WorkflowJobStatus } from './workflow-job-contract'
+import type { ActionJobLifecycle } from './automation-executor'
+import type { AutomationAction } from './automation-actions'
+import { redactString, redactValue } from './automation-log-redact'
+
+const JOB_SCHEMA_VERSION = 1
+
+export class AutomationJobService {
+  /**
+   * Build the per-action lifecycle for ONE opted-in execution. The executor calls
+   * onStart/onSettled/onSkipped around each action; we persist job rows accordingly.
+   * A6-1 inline has no queue/worker → a job is created directly as `running` (the
+   * vestigial `queued` state belongs to A6-2's worker/claim). The row is created
+   * BEFORE the action runs, so a crash leaves an observable `running` row.
+   */
+  lifecycleFor(executionId: string, rule: { id: string; sheetId?: string }): ActionJobLifecycle {
+    // Deterministic id (no random) → idempotent shape, same `${exec}:<kind>:<i>` family as the
+    // legacy step-view id (`${exec}:step:i`); jobs use `:job:`.
+    const jobId = (stepIndex: number): string => `${executionId}:job:${stepIndex}`
+    const upstream = (stepIndex: number): string | null => (stepIndex > 0 ? jobId(stepIndex - 1) : null)
+
+    return {
+      onStart: async (stepIndex, action) => {
+        const id = jobId(stepIndex)
+        const now = new Date().toISOString()
+        await db
+          .insertInto('multitable_automation_jobs')
+          .values({
+            id,
+            execution_id: executionId,
+            rule_id: rule.id,
+            sheet_id: rule.sheetId ?? null,
+            step_index: stepIndex,
+            step_key: String(stepIndex),
+            action_type: action.type,
+            status: 'running', // C1 'running'
+            upstream_job_id: upstream(stepIndex),
+            result: null,
+            error: null,
+            started_at: now,
+            finished_at: null,
+            duration_ms: null,
+            schema_version: JOB_SCHEMA_VERSION,
+          })
+          .execute()
+      },
+      onSettled: async (stepIndex, _action, result) => {
+        await db
+          .updateTable('multitable_automation_jobs')
+          .set({
+            status: legacyAutomationStatusToJobStatus(result.status), // success→resolved, else identity
+            // Same A1 redaction as record() — secret-shaped values scrubbed before persist.
+            result: result.output == null ? null : (toJsonValue(redactValue(result.output)) as never),
+            error: result.error != null ? redactString(result.error) : null,
+            finished_at: new Date().toISOString(),
+            duration_ms: result.durationMs ?? null,
+            updated_at: new Date().toISOString() as never,
+          })
+          .where('id', '=', jobId(stepIndex))
+          .execute()
+      },
+      onSkipped: async (stepIndex, action) => {
+        // Fail-stop remainder — a terminal skipped job (created directly, never ran).
+        const now = new Date().toISOString()
+        await db
+          .insertInto('multitable_automation_jobs')
+          .values({
+            id: jobId(stepIndex),
+            execution_id: executionId,
+            rule_id: rule.id,
+            sheet_id: rule.sheetId ?? null,
+            step_index: stepIndex,
+            step_key: String(stepIndex),
+            action_type: action.type,
+            status: 'skipped',
+            upstream_job_id: upstream(stepIndex),
+            result: null,
+            error: null,
+            started_at: null,
+            finished_at: now,
+            duration_ms: 0,
+            schema_version: JOB_SCHEMA_VERSION,
+          })
+          .execute()
+      },
+    }
+  }
+
+  /**
+   * Read persisted jobs for an execution as C1 WorkflowJob views, ordered by step.
+   * Returns [] when the execution has no jobs (legacy execution → caller falls back
+   * to AutomationExecution.steps). The shape matches the A2 step view (id/executionId/
+   * stepKey/status/upstreamJobId/result/error) so the read boundary is uniform.
+   */
+  async listByExecution(executionId: string): Promise<Array<{
+    id: string
+    executionId: string
+    stepKey: string
+    status: WorkflowJobStatus
+    upstreamJobId: string | null
+    result: unknown
+    error?: string
+  }>> {
+    const rows = await db
+      .selectFrom('multitable_automation_jobs')
+      .selectAll()
+      .where('execution_id', '=', executionId)
+      .orderBy('step_index', 'asc')
+      .execute()
+
+    return rows.map((row) => ({
+      id: row.id as string,
+      executionId: row.execution_id as string,
+      stepKey: row.step_key as string,
+      // Stored status is a C1 value (running on start; resolved/failed via bridge on settle; skipped) —
+      // normalize (validates / fail-loud on a corrupt status) so the read boundary stays enum-strict.
+      status: normalizeWorkflowJobStatus(row.status),
+      upstreamJobId: (row.upstream_job_id as string) ?? null,
+      result: typeof row.result === 'string' ? JSON.parse(row.result) : (row.result ?? null),
+      // error string-or-ABSENT to satisfy the C1 normalizeWorkflowJob contract (never null).
+      ...(typeof row.error === 'string' ? { error: row.error } : {}),
+    }))
+  }
+}

--- a/packages/core-backend/src/multitable/automation-log-service.ts
+++ b/packages/core-backend/src/multitable/automation-log-service.ts
@@ -24,21 +24,7 @@ export class AutomationLogService {
    * Record an execution log by inserting into the database.
    */
   async record(execution: AutomationExecution): Promise<void> {
-    // Redact secret-shaped values out of ALL FOUR free-form channels BEFORE they
-    // hit the DB (they ride into the runs UI and would survive any future replay):
-    // steps (recursive — covers step.output/step.error), trigger_event,
-    // rule_snapshot, and the execution-level error. Business field values are
-    // preserved — this is secret-shaped value scrubbing only.
-    // node-postgres treats JS arrays as PostgreSQL array literals unless we cast explicit JSON text.
-    const stepsJsonb = toJsonValue(redactValue(execution.steps)) as unknown as Record<string, unknown>[]
-    const triggerEventJsonb =
-      execution.triggerEvent == null
-        ? null
-        : (toJsonValue(redactValue(execution.triggerEvent)) as unknown as Record<string, unknown>)
-    const ruleSnapshotJsonb =
-      execution.ruleSnapshot == null
-        ? null
-        : (toJsonValue(redactValue(execution.ruleSnapshot)) as unknown as Record<string, unknown>)
+    const persisted = toPersistedExecutionValues(execution)
     await db
       .insertInto('multitable_automation_executions')
       .values({
@@ -47,18 +33,44 @@ export class AutomationLogService {
         triggered_by: execution.triggeredBy,
         triggered_at: execution.triggeredAt,
         status: execution.status,
-        steps: stepsJsonb,
-        error: execution.error != null ? redactString(execution.error) : null,
+        steps: persisted.stepsJsonb,
+        error: persisted.error,
         duration: execution.duration ?? null,
         sheet_id: execution.sheetId ?? null,
-        trigger_event: triggerEventJsonb,
-        rule_snapshot: ruleSnapshotJsonb,
+        trigger_event: persisted.triggerEventJsonb,
+        rule_snapshot: persisted.ruleSnapshotJsonb,
         finished_at: execution.finishedAt ?? null,
         schema_version: execution.schemaVersion ?? AUTOMATION_EXECUTION_SCHEMA_VERSION,
         // A5 retry provenance — plain identifiers, NOT redacted (an execution id / a user id).
         rerun_of_execution_id: execution.rerunOfExecutionId ?? null,
         initiated_by: execution.initiatedBy ?? null,
       })
+      .execute()
+  }
+
+  /**
+   * Update an already-inserted execution row. A6-1 uses this after pre-creating
+   * the parent execution before job/action side effects, so job rows never become
+   * invisible orphans just because final execution persistence is delayed.
+   */
+  async updateRecordedExecution(execution: AutomationExecution): Promise<void> {
+    const persisted = toPersistedExecutionValues(execution)
+    await db
+      .updateTable('multitable_automation_executions')
+      .set({
+        status: execution.status,
+        steps: persisted.stepsJsonb,
+        error: persisted.error,
+        duration: execution.duration ?? null,
+        sheet_id: execution.sheetId ?? null,
+        trigger_event: persisted.triggerEventJsonb,
+        rule_snapshot: persisted.ruleSnapshotJsonb,
+        finished_at: execution.finishedAt ?? null,
+        schema_version: execution.schemaVersion ?? AUTOMATION_EXECUTION_SCHEMA_VERSION,
+        rerun_of_execution_id: execution.rerunOfExecutionId ?? null,
+        initiated_by: execution.initiatedBy ?? null,
+      })
+      .where('id', '=', execution.id)
       .execute()
   }
 
@@ -161,6 +173,35 @@ export class AutomationLogService {
       .executeTakeFirst()
 
     return Number(result.numDeletedRows ?? 0)
+  }
+}
+
+function toPersistedExecutionValues(execution: AutomationExecution): {
+  stepsJsonb: Record<string, unknown>[]
+  triggerEventJsonb: Record<string, unknown> | null
+  ruleSnapshotJsonb: Record<string, unknown> | null
+  error: string | null
+} {
+  // Redact secret-shaped values out of ALL FOUR free-form channels BEFORE they
+  // hit the DB (they ride into the runs UI and would survive any future replay):
+  // steps (recursive — covers step.output/step.error), trigger_event,
+  // rule_snapshot, and the execution-level error. Business field values are
+  // preserved — this is secret-shaped value scrubbing only.
+  // node-postgres treats JS arrays as PostgreSQL array literals unless we cast explicit JSON text.
+  const stepsJsonb = toJsonValue(redactValue(execution.steps)) as unknown as Record<string, unknown>[]
+  const triggerEventJsonb =
+    execution.triggerEvent == null
+      ? null
+      : (toJsonValue(redactValue(execution.triggerEvent)) as unknown as Record<string, unknown>)
+  const ruleSnapshotJsonb =
+    execution.ruleSnapshot == null
+      ? null
+      : (toJsonValue(redactValue(execution.ruleSnapshot)) as unknown as Record<string, unknown>)
+  return {
+    stepsJsonb,
+    triggerEventJsonb,
+    ruleSnapshotJsonb,
+    error: execution.error != null ? redactString(execution.error) : null,
   }
 }
 

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -22,6 +22,7 @@ import { RedisLeaderLock, type RedisLeaderLockClient } from './redis-leader-lock
 import { getRedisClient } from '../db/redis'
 import { randomBytes } from 'crypto'
 import { AutomationLogService } from './automation-log-service'
+import { AutomationJobService } from './automation-job-service'
 import {
   normalizeDingTalkAutomationActionInputs,
   validateDingTalkAutomationActionConfigs,
@@ -131,6 +132,8 @@ export type AutomationRule = {
   // V1 extended fields (nullable for backward compat)
   conditions?: ConditionGroup | null
   actions?: AutomationAction[] | null
+  // A6-1 opt-in (nullable; NULL/'legacy' = no job rows, 'workflow_job_v1' = persist jobs)
+  execution_mode?: string | null
 }
 
 export type AutomationQueryFn = (
@@ -212,6 +215,7 @@ function toExecutorRule(rule: AutomationRule): ExecutorRule {
     createdBy: rule.created_by ?? '',
     createdAt: rule.created_at,
     updatedAt: rule.updated_at,
+    executionMode: rule.execution_mode ?? undefined,
   }
 }
 
@@ -268,6 +272,7 @@ export class AutomationService {
   private executor: AutomationExecutor
   private scheduler: AutomationScheduler
   private logService: AutomationLogService
+  private jobService: AutomationJobService
   /** Kept for backward-compat with raw SQL in executor actions */
   private queryFn: AutomationQueryFn
 
@@ -292,6 +297,7 @@ export class AutomationService {
     }
     this.executor = new AutomationExecutor(deps)
     this.logService = new AutomationLogService()
+    this.jobService = new AutomationJobService()
     this.scheduler = new AutomationScheduler(
       async (rule) => {
         await this.executeRule(rule, { _triggeredBy: 'schedule' })
@@ -304,6 +310,10 @@ export class AutomationService {
   /** Expose log service for routes */
   get logs(): AutomationLogService {
     return this.logService
+  }
+
+  get jobs(): AutomationJobService {
+    return this.jobService
   }
 
   /** Expose executor for manual test runs */
@@ -675,7 +685,13 @@ export class AutomationService {
     triggerEvent: unknown,
     retryMeta?: { rerunOfExecutionId: string; initiatedBy: string },
   ): Promise<AutomationExecution> {
-    const execution = await this.executor.execute(rule, triggerEvent)
+    // A6-1: ONLY opted-in rules ('workflow_job_v1') get a per-action job lifecycle. Legacy rules
+    // pass no factory → executor writes zero job rows (opt-out path is byte-identical to today).
+    // This is the single place the path is chosen, so a retry of an opt-in rule also writes jobs.
+    const jobLifecycleFactory = rule.executionMode === 'workflow_job_v1'
+      ? (executionId: string) => this.jobService.lifecycleFor(executionId, { id: rule.id, sheetId: rule.sheetId })
+      : undefined
+    const execution = await this.executor.execute(rule, triggerEvent, jobLifecycleFactory)
     if (retryMeta) {
       // A5: stamp retry provenance onto the NEW execution before persistence.
       execution.rerunOfExecutionId = retryMeta.rerunOfExecutionId
@@ -785,6 +801,7 @@ export class AutomationService {
       created_by: (row.created_by as string) ?? null,
       conditions: (row.conditions as ConditionGroup) ?? null,
       actions: (row.actions as AutomationAction[]) ?? null,
+      execution_mode: (row.execution_mode as string) ?? null,
     }
   }
 }

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -685,11 +685,15 @@ export class AutomationService {
     triggerEvent: unknown,
     retryMeta?: { rerunOfExecutionId: string; initiatedBy: string },
   ): Promise<AutomationExecution> {
+    const persistJobs = rule.executionMode === 'workflow_job_v1'
     // A6-1: ONLY opted-in rules ('workflow_job_v1') get a per-action job lifecycle. Legacy rules
     // pass no factory → executor writes zero job rows (opt-out path is byte-identical to today).
     // This is the single place the path is chosen, so a retry of an opt-in rule also writes jobs.
-    const jobLifecycleFactory = rule.executionMode === 'workflow_job_v1'
-      ? (executionId: string) => this.jobService.lifecycleFor(executionId, { id: rule.id, sheetId: rule.sheetId })
+    const jobLifecycleFactory = persistJobs
+      ? (executionId: string) => ({
+          onExecutionStarted: (execution: AutomationExecution) => this.logService.record(execution),
+          ...this.jobService.lifecycleFor(executionId, { id: rule.id, sheetId: rule.sheetId }),
+        })
       : undefined
     const execution = await this.executor.execute(rule, triggerEvent, jobLifecycleFactory)
     if (retryMeta) {
@@ -698,7 +702,11 @@ export class AutomationService {
       execution.initiatedBy = retryMeta.initiatedBy
     }
     try {
-      await this.logService.record(execution)
+      if (persistJobs) {
+        await this.logService.updateRecordedExecution(execution)
+      } else {
+        await this.logService.record(execution)
+      }
     } catch (err) {
       logger.error('Automation execution log persistence failed', err instanceof Error ? err : undefined)
     }

--- a/packages/core-backend/src/routes/automation.ts
+++ b/packages/core-backend/src/routes/automation.ts
@@ -68,7 +68,14 @@ function toWorkflowJobView(execution: AutomationExecution, step: AutomationStepR
 }
 
 /** Map a persisted execution to the runs-API view; `includeSnapshot` adds the redacted blobs (detail only). */
-function toRunView(execution: AutomationExecution, { includeSnapshot }: { includeSnapshot: boolean }) {
+// `jobs` (A6-1) are persisted C1 WorkflowJob views (already in the step-view shape). When present
+// (an opted-in execution), they are the detail source-of-truth; otherwise we synthesize the C1 view
+// from the legacy `execution.steps`. Job ids are `${exec}:job:i`; legacy fallback is `${exec}:step:i`.
+function toRunView(
+  execution: AutomationExecution,
+  { includeSnapshot, jobs }: { includeSnapshot: boolean; jobs?: ReturnType<typeof toWorkflowJobView>[] },
+) {
+  const hasJobs = Array.isArray(jobs) && jobs.length > 0
   return {
     id: execution.id,
     ruleId: execution.ruleId,
@@ -85,7 +92,8 @@ function toRunView(execution: AutomationExecution, { includeSnapshot }: { includ
     // can see a run is a re-run and who triggered it).
     rerunOfExecutionId: execution.rerunOfExecutionId ?? null,
     initiatedBy: execution.initiatedBy ?? null,
-    steps: (execution.steps ?? []).map((s, i) => toWorkflowJobView(execution, s, i)),
+    // A6-1: prefer persisted jobs when present; fall back to legacy steps for old/opt-out executions.
+    steps: hasJobs ? jobs : (execution.steps ?? []).map((s, i) => toWorkflowJobView(execution, s, i)),
     ...(includeSnapshot
       ? { triggerEvent: execution.triggerEvent ?? null, ruleSnapshot: execution.ruleSnapshot ?? null }
       : {}),
@@ -260,7 +268,10 @@ export function createAutomationRoutes(
       if (!execution) {
         return res.status(404).json({ error: 'execution not found' })
       }
-      return res.json(toRunView(execution, { includeSnapshot: true }))
+      // A6-1: prefer persisted jobs for the detail step view (empty for legacy/opt-out executions →
+      // toRunView falls back to legacy steps). Detail-only: list avoids the per-row job fetch (N+1).
+      const jobs = await svc.jobs.listByExecution(executionId)
+      return res.json(toRunView(execution, { includeSnapshot: true, jobs }))
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load run'
       return res.status(500).json({ error: message })

--- a/packages/core-backend/src/routes/automation.ts
+++ b/packages/core-backend/src/routes/automation.ts
@@ -71,11 +71,13 @@ function toWorkflowJobView(execution: AutomationExecution, step: AutomationStepR
 // `jobs` (A6-1) are persisted C1 WorkflowJob views (already in the step-view shape). When present
 // (an opted-in execution), they are the detail source-of-truth; otherwise we synthesize the C1 view
 // from the legacy `execution.steps`. Job ids are `${exec}:job:i`; legacy fallback is `${exec}:step:i`.
+const TERMINAL_JOB_STATUSES = new Set(['resolved', 'failed', 'skipped', 'rejected', 'errored'])
+
 function toRunView(
   execution: AutomationExecution,
   { includeSnapshot, jobs }: { includeSnapshot: boolean; jobs?: ReturnType<typeof toWorkflowJobView>[] },
 ) {
-  const hasJobs = Array.isArray(jobs) && jobs.length > 0
+  const hasCompleteTerminalJobs = shouldUsePersistedJobs(execution, jobs)
   return {
     id: execution.id,
     ruleId: execution.ruleId,
@@ -92,12 +94,33 @@ function toRunView(
     // can see a run is a re-run and who triggered it).
     rerunOfExecutionId: execution.rerunOfExecutionId ?? null,
     initiatedBy: execution.initiatedBy ?? null,
-    // A6-1: prefer persisted jobs when present; fall back to legacy steps for old/opt-out executions.
-    steps: hasJobs ? jobs : (execution.steps ?? []).map((s, i) => toWorkflowJobView(execution, s, i)),
+    // A6-1: prefer persisted jobs only when they are coherent for this execution;
+    // fall back to legacy steps for old/opt-out/degraded executions.
+    steps: hasCompleteTerminalJobs ? jobs : (execution.steps ?? []).map((s, i) => toWorkflowJobView(execution, s, i)),
     ...(includeSnapshot
       ? { triggerEvent: execution.triggerEvent ?? null, ruleSnapshot: execution.ruleSnapshot ?? null }
       : {}),
   }
+}
+
+function shouldUsePersistedJobs(
+  execution: AutomationExecution,
+  jobs: ReturnType<typeof toWorkflowJobView>[] | undefined,
+): jobs is ReturnType<typeof toWorkflowJobView>[] {
+  if (!Array.isArray(jobs) || jobs.length === 0) return false
+
+  const legacyStepCount = execution.steps?.length ?? 0
+  if (legacyStepCount > 0 && jobs.length < legacyStepCount) return false
+
+  // If the parent execution is terminal, stale non-terminal job rows usually mean
+  // a fail-closed job-update failure happened after the action. The legacy step
+  // row carries the action result/error, so prefer it over a misleading `running`
+  // persisted job view.
+  if (execution.status !== 'running' && jobs.some((job) => !TERMINAL_JOB_STATUSES.has(job.status))) {
+    return false
+  }
+
+  return true
 }
 
 /**
@@ -268,9 +291,11 @@ export function createAutomationRoutes(
       if (!execution) {
         return res.status(404).json({ error: 'execution not found' })
       }
-      // A6-1: prefer persisted jobs for the detail step view (empty for legacy/opt-out executions →
-      // toRunView falls back to legacy steps). Detail-only: list avoids the per-row job fetch (N+1).
-      const jobs = await svc.jobs.listByExecution(executionId)
+      // A6-1: prefer persisted jobs for the detail step view (empty/unreadable for
+      // legacy/opt-out/degraded executions → toRunView falls back to legacy steps).
+      // Detail-only: list avoids the per-row job fetch (N+1). A job-read failure
+      // must not hide the parent execution behind a 500.
+      const jobs = await safeListJobs(svc, executionId)
       return res.json(toRunView(execution, { includeSnapshot: true, jobs }))
     } catch (err) {
       const message = err instanceof Error ? err.message : 'Failed to load run'
@@ -333,4 +358,15 @@ export function createAutomationRoutes(
   })
 
   return router
+}
+
+async function safeListJobs(
+  svc: AutomationService,
+  executionId: string,
+): Promise<ReturnType<typeof toWorkflowJobView>[] | undefined> {
+  try {
+    return await svc.jobs.listByExecution(executionId)
+  } catch {
+    return undefined
+  }
 }

--- a/packages/core-backend/tests/integration/multitable-automation-jobs.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-jobs.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Real-DB round-trip for the A6-1 persistent WorkflowJob plane.
+ *
+ * Closes the wire-vs-fixture gap for the NEW `multitable_automation_jobs` table:
+ * unit tests assert insert/update payloads via a MOCK db, which does NOT prove the
+ * migration created the table/columns, the Kysely types allow them, or the row
+ * mapper reads them back. This drives AutomationJobService against REAL Postgres
+ * (lifecycleFor onStart→onSettled→onSkipped → listByExecution + raw-SQL confirm).
+ * Runs only with DATABASE_URL (plugin-tests.yml real-DB job).
+ */
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { AutomationJobService } from '../../src/multitable/automation-job-service'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const EXEC_ID = `axe_jobs_${TS}`
+const RULE_ID = `atr_jobs_${TS}`
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const jobs = new AutomationJobService()
+
+describeIfDatabase('multitable automation jobs (A6-1, real DB)', () => {
+  beforeAll(async () => {
+    await q('DELETE FROM multitable_automation_jobs WHERE execution_id = $1', [EXEC_ID])
+  })
+  afterAll(async () => {
+    await q('DELETE FROM multitable_automation_jobs WHERE execution_id = $1', [EXEC_ID])
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('lifecycle round-trips through real Postgres: onStart(running) → onSettled(resolved, redacted) → listByExecution(C1)', async () => {
+    const lc = jobs.lifecycleFor(EXEC_ID, { id: RULE_ID, sheetId: 'sheet_jobs' })
+
+    // onStart — if the migration/table/columns were missing this insert would throw.
+    await lc.onStart(0, { type: 'send_webhook', config: {} } as never)
+    let raw = await q('SELECT status, upstream_job_id FROM multitable_automation_jobs WHERE id = $1', [`${EXEC_ID}:job:0`])
+    expect(raw.rows[0].status).toBe('running')
+    expect(raw.rows[0].upstream_job_id).toBeNull()
+
+    // onSettled — secret-shaped result/error scrubbed before persist (A1 invariant).
+    await lc.onSettled(0, { type: 'send_webhook' } as never, {
+      actionType: 'send_webhook', status: 'success',
+      output: { token: 'LIVE-SECRET', ok: true }, durationMs: 7,
+    } as never)
+    raw = await q('SELECT status, result, error FROM multitable_automation_jobs WHERE id = $1', [`${EXEC_ID}:job:0`])
+    expect(raw.rows[0].status).toBe('resolved') // success → resolved (C1 bridge)
+    expect(JSON.stringify(raw.rows[0].result)).not.toContain('LIVE-SECRET') // redactValue (token key masked)
+
+    // second action fails → fail-stop onSkipped for a third
+    await lc.onStart(1, { type: 'send_webhook' } as never)
+    await lc.onSettled(1, { type: 'send_webhook' } as never, {
+      actionType: 'send_webhook', status: 'failed', error: 'boom', durationMs: 2,
+    } as never)
+    await lc.onSkipped(2, { type: 'send_email' } as never)
+
+    // listByExecution → C1 views in step order, with the right statuses + upstream chain.
+    const views = await jobs.listByExecution(EXEC_ID)
+    expect(views.map((v) => v.status)).toEqual(['resolved', 'failed', 'skipped'])
+    expect(views.map((v) => v.id)).toEqual([`${EXEC_ID}:job:0`, `${EXEC_ID}:job:1`, `${EXEC_ID}:job:2`])
+    expect(views[1].upstreamJobId).toBe(`${EXEC_ID}:job:0`)
+    expect(views[0].error).toBeUndefined() // resolved → no error key
+    expect(views[1].error).toBe('boom')
+  })
+
+  test('listByExecution returns [] for an execution with no jobs (legacy fallback signal)', async () => {
+    const views = await jobs.listByExecution(`axe_none_${TS}`)
+    expect(views).toEqual([])
+  })
+})

--- a/packages/core-backend/tests/unit/automation-runs-api.test.ts
+++ b/packages/core-backend/tests/unit/automation-runs-api.test.ts
@@ -180,6 +180,7 @@ describe('A2 runs API — GET /automation-executions/:id (detail)', () => {
       jobs: {
         listByExecution: vi.fn().mockResolvedValue([
           { id: 'axe_1:job:0', executionId: 'axe_1', stepKey: '0', status: 'resolved', upstreamJobId: null, result: { ok: true } },
+          { id: 'axe_1:job:1', executionId: 'axe_1', stepKey: '1', status: 'failed', upstreamJobId: 'axe_1:job:0', error: 'boom' },
         ]),
       },
     })
@@ -191,6 +192,46 @@ describe('A2 runs API — GET /automation-executions/:id (detail)', () => {
     const noJobs = makeMockService() // default jobs.listByExecution → []
     const r2 = await request(buildApp(noJobs)).get('/api/multitable/automation-executions/axe_1').expect(200)
     expect(r2.body.steps[0].id).toBe('axe_1:step:0') // legacy synth
+  })
+
+  it('A6-1: terminal execution falls back to legacy steps when persisted jobs are stale/non-terminal', async () => {
+    const failedExec = {
+      ...sampleExec,
+      status: 'failed',
+      error: 'job update failed',
+      steps: [
+        { actionType: 'send_webhook', status: 'success', output: { sideEffectRan: true }, durationMs: 4 },
+      ],
+    }
+    const svc = makeMockService(
+      { getById: vi.fn().mockResolvedValue(failedExec) },
+      {
+        jobs: {
+          listByExecution: vi.fn().mockResolvedValue([
+            { id: 'axe_1:job:0', executionId: 'axe_1', stepKey: '0', status: 'running', upstreamJobId: null, result: null },
+          ]),
+        },
+      },
+    )
+    const res = await request(buildApp(svc)).get('/api/multitable/automation-executions/axe_1').expect(200)
+    expect(res.body.status).toBe('failed')
+    expect(res.body.steps[0].id).toBe('axe_1:step:0')
+    expect(res.body.steps[0].status).toBe('resolved')
+    expect(res.body.steps[0].result).toEqual({ sideEffectRan: true })
+  })
+
+  it('A6-1: detail falls back to legacy steps when persisted job rows are unreadable', async () => {
+    const svc = makeMockService(
+      {},
+      {
+        jobs: {
+          listByExecution: vi.fn().mockRejectedValue(new Error('jobs table temporarily unavailable')),
+        },
+      },
+    )
+    const res = await request(buildApp(svc)).get('/api/multitable/automation-executions/axe_1').expect(200)
+    expect(res.body.steps[0].id).toBe('axe_1:step:0')
+    expect(res.body.steps[0].status).toBe('resolved')
   })
 })
 

--- a/packages/core-backend/tests/unit/automation-runs-api.test.ts
+++ b/packages/core-backend/tests/unit/automation-runs-api.test.ts
@@ -55,6 +55,11 @@ function makeMockService(logsOverrides: Record<string, unknown> = {}, svcOverrid
       getById: vi.fn().mockResolvedValue(sampleExec),
       ...logsOverrides,
     },
+    // A6-1: detail route re-fetches jobs; default [] → falls back to legacy steps.
+    jobs: {
+      listByExecution: vi.fn().mockResolvedValue([]),
+      ...(svcOverrides.jobs as Record<string, unknown> ?? {}),
+    },
     retryExecution: vi.fn().mockResolvedValue({
       execution: { ...sampleExec, id: 'axe_new', status: 'success', rerunOfExecutionId: 'axe_1', initiatedBy: 'admin1' },
     }),
@@ -167,6 +172,25 @@ describe('A2 runs API — GET /automation-executions/:id (detail)', () => {
     const res = await request(buildApp(svc)).get('/api/multitable/automation-executions/axe_1').expect(200)
     expect(res.body).toHaveProperty('rerunOfExecutionId', null)
     expect(res.body).toHaveProperty('initiatedBy', null)
+  })
+
+  it('A6-1: detail PREFERS persisted jobs when present (job ids `:job:`), else falls back to legacy steps (`:step:`)', async () => {
+    // jobs present → steps come from jobs
+    const withJobs = makeMockService({}, {
+      jobs: {
+        listByExecution: vi.fn().mockResolvedValue([
+          { id: 'axe_1:job:0', executionId: 'axe_1', stepKey: '0', status: 'resolved', upstreamJobId: null, result: { ok: true } },
+        ]),
+      },
+    })
+    const r1 = await request(buildApp(withJobs)).get('/api/multitable/automation-executions/axe_1').expect(200)
+    expect(r1.body.steps[0].id).toBe('axe_1:job:0') // from persisted jobs
+    expect(withJobs.jobs.listByExecution).toHaveBeenCalledWith('axe_1')
+
+    // no jobs → legacy steps fallback (synthesized `:step:` ids)
+    const noJobs = makeMockService() // default jobs.listByExecution → []
+    const r2 = await request(buildApp(noJobs)).get('/api/multitable/automation-executions/axe_1').expect(200)
+    expect(r2.body.steps[0].id).toBe('axe_1:step:0') // legacy synth
   })
 })
 

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -2866,6 +2866,11 @@ describe('AutomationExecutor — A6-1 job lifecycle hooks', () => {
     const execution = await executor.execute(rule, { recordId: 'r1', data: {}, sheetId: 'sheet_1' }, lc.factory)
     expect(execution.status).toBe('failed') // NOT pretended successful
     expect(deps.fetchFn).toHaveBeenCalledTimes(1) // the action DID run (must not pretend otherwise)
+    expect(execution.steps[0]).toMatchObject({
+      actionType: 'send_webhook',
+      status: 'success',
+      output: { httpStatus: 200 },
+    })
     expect(execution.error).toContain('job update failed')
   })
 
@@ -2893,6 +2898,47 @@ describe('AutomationService — A6-1 opt-in path choice', () => {
     const execSpy = vi.spyOn(service['executor'], 'execute').mockResolvedValue(storedExecutionForPath())
     await service.executeRule(execRule({ executionMode: 'workflow_job_v1' }), { recordId: 'r1' })
     expect(typeof execSpy.mock.calls[0][2]).toBe('function')
+  })
+
+  it('opt-IN rule pre-creates the parent execution before side effects, then final-updates it', async () => {
+    const events: string[] = []
+    const fetchFn = vi.fn(async () => {
+      events.push('side-effect')
+      return new Response('OK', { status: 200 })
+    }) as unknown as typeof fetch
+    service = new AutomationService(
+      new EventBus(),
+      {} as never,
+      vi.fn(async () => ({ rows: [], rowCount: 0 })),
+      fetchFn,
+    )
+    vi.spyOn(service.logs, 'record').mockImplementation(async () => { events.push('parent-start') })
+    vi.spyOn(service.logs, 'updateRecordedExecution').mockImplementation(async () => { events.push('parent-final') })
+
+    const execution = await service.executeRule(execRule({
+      executionMode: 'workflow_job_v1',
+      actions: [{ type: 'send_webhook', config: { url: 'https://example.com/hook' } }],
+    }), { recordId: 'r1', data: {} })
+
+    expect(execution.status).toBe('success')
+    expect(events).toEqual(['parent-start', 'side-effect', 'parent-final'])
+  })
+
+  it('opt-IN rule fails before side effects when the parent execution cannot be pre-created', async () => {
+    const fetchFn = vi.fn(async () => new Response('OK', { status: 200 })) as unknown as typeof fetch
+    service = new AutomationService(
+      new EventBus(),
+      {} as never,
+      vi.fn(async () => ({ rows: [], rowCount: 0 })),
+      fetchFn,
+    )
+    vi.spyOn(service.logs, 'record').mockRejectedValue(new Error('parent execution insert failed'))
+
+    await expect(service.executeRule(execRule({
+      executionMode: 'workflow_job_v1',
+      actions: [{ type: 'send_webhook', config: { url: 'https://example.com/hook' } }],
+    }), { recordId: 'r1', data: {} })).rejects.toThrow('parent execution insert failed')
+    expect(fetchFn).not.toHaveBeenCalled()
   })
 
   function execRule(over: Record<string, unknown>) {

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -11,6 +11,7 @@ import { EventBus } from '../../src/integration/events/event-bus'
 const _executeResults: unknown[] = []
 const _executeTakeFirstResults: unknown[] = []
 const _valuesCalls: unknown[] = []
+const _setCalls: unknown[] = [] // A6-1: captures updateTable().set(...) payloads (job onSettled)
 
 function makeChain(): Record<string, unknown> {
   const self: Record<string, unknown> = {}
@@ -24,11 +25,10 @@ function makeChain(): Record<string, unknown> {
   ]
   for (const m of methods) {
     self[m] = m === 'values'
-      ? vi.fn((value: unknown) => {
-        _valuesCalls.push(value)
-        return self
-      })
-      : vi.fn(chainFn)
+      ? vi.fn((value: unknown) => { _valuesCalls.push(value); return self })
+      : m === 'set'
+        ? vi.fn((value: unknown) => { _setCalls.push(value); return self })
+        : vi.fn(chainFn)
   }
   self.execute = vi.fn(async () => {
     return _executeResults.shift() ?? []
@@ -54,6 +54,8 @@ vi.mock('../../src/db/db', () => {
 
 import { AutomationLogService } from '../../src/multitable/automation-log-service'
 import { AutomationRuleValidationError, AutomationService } from '../../src/multitable/automation-service'
+import { AutomationJobService } from '../../src/multitable/automation-job-service'
+import { normalizeWorkflowJob } from '../../src/multitable/workflow-job-contract'
 
 // ── Helpers ─────────────────────────────────────────────────────────────
 
@@ -2792,5 +2794,153 @@ describe('AutomationService — retryExecution (A5)', () => {
     const r = await service.retryExecution('axe_orig', 'admin1')
     expect('execution' in r).toBe(true)
     expect(execSpy).toHaveBeenCalledTimes(1) // skipped → re-runs against the current rule (its conditions may now pass)
+  })
+})
+
+describe('AutomationExecutor — A6-1 job lifecycle hooks', () => {
+  let deps: AutomationDeps
+  let executor: AutomationExecutor
+
+  beforeEach(() => {
+    deps = createMockDeps()
+    executor = new AutomationExecutor(deps)
+  })
+
+  // A recording lifecycle; throwOn lets a test simulate a job-write failure at a phase.
+  function recordingLifecycle(throwOn?: { phase: 'start' | 'settled'; index: number }) {
+    const calls: string[] = []
+    return {
+      calls,
+      factory: (_executionId: string) => ({
+        onStart: async (i: number) => {
+          calls.push(`start:${i}`)
+          if (throwOn?.phase === 'start' && throwOn.index === i) throw new Error('job create failed')
+        },
+        onSettled: async (i: number, _a: unknown, r: { status: string }) => {
+          calls.push(`settled:${i}:${r.status}`)
+          if (throwOn?.phase === 'settled' && throwOn.index === i) throw new Error('job update failed')
+        },
+        onSkipped: async (i: number) => { calls.push(`skipped:${i}`) },
+      }),
+    }
+  }
+
+  it('fires onStart→onSettled per action in order for an opted-in (factory-supplied) run', async () => {
+    const rule = createMockRule({
+      actions: [
+        { type: 'send_webhook', config: { url: 'https://example.com/a' } },
+        { type: 'send_webhook', config: { url: 'https://example.com/b' } },
+      ],
+    })
+    const lc = recordingLifecycle()
+    const execution = await executor.execute(rule, { recordId: 'r1', data: {}, sheetId: 'sheet_1' }, lc.factory)
+    expect(execution.status).toBe('success')
+    expect(lc.calls).toEqual(['start:0', 'settled:0:success', 'start:1', 'settled:1:success'])
+  })
+
+  it('fires onSkipped for the fail-stop remainder', async () => {
+    const rule = createMockRule({
+      actions: [
+        { type: 'send_webhook', config: {} }, // missing url → fails
+        { type: 'send_webhook', config: { url: 'https://example.com/b' } },
+      ],
+    })
+    const lc = recordingLifecycle()
+    const execution = await executor.execute(rule, { recordId: 'r1', data: {}, sheetId: 'sheet_1' }, lc.factory)
+    expect(execution.status).toBe('failed')
+    expect(lc.calls).toEqual(['start:0', 'settled:0:failed', 'skipped:1'])
+  })
+
+  it('FAIL-CLOSED (a): onStart throw → side effect NEVER runs + execution failed', async () => {
+    const rule = createMockRule({ actions: [{ type: 'send_webhook', config: { url: 'https://example.com/a' } }] })
+    const lc = recordingLifecycle({ phase: 'start', index: 0 })
+    const execution = await executor.execute(rule, { recordId: 'r1', data: {}, sheetId: 'sheet_1' }, lc.factory)
+    expect(execution.status).toBe('failed') // outer catch, not a swallowed step
+    expect(deps.fetchFn).not.toHaveBeenCalled() // the webhook (side effect) never fired
+    expect(execution.error).toContain('job create failed')
+  })
+
+  it('FAIL-CLOSED (b): onSettled throw AFTER the action → side effect ran once + execution failed', async () => {
+    const rule = createMockRule({ actions: [{ type: 'send_webhook', config: { url: 'https://example.com/a' } }] })
+    const lc = recordingLifecycle({ phase: 'settled', index: 0 })
+    const execution = await executor.execute(rule, { recordId: 'r1', data: {}, sheetId: 'sheet_1' }, lc.factory)
+    expect(execution.status).toBe('failed') // NOT pretended successful
+    expect(deps.fetchFn).toHaveBeenCalledTimes(1) // the action DID run (must not pretend otherwise)
+    expect(execution.error).toContain('job update failed')
+  })
+
+  it('legacy run (no factory) fires no lifecycle and behaves exactly as today', async () => {
+    const rule = createMockRule({ actions: [{ type: 'send_webhook', config: { url: 'https://example.com/a' } }] })
+    const execution = await executor.execute(rule, { recordId: 'r1', data: {}, sheetId: 'sheet_1' })
+    expect(execution.status).toBe('success')
+    expect(execution.steps).toHaveLength(1) // legacy steps unchanged; no jobs involved
+  })
+})
+
+describe('AutomationService — A6-1 opt-in path choice', () => {
+  let service: AutomationService
+  beforeEach(() => {
+    service = new AutomationService(new EventBus(), {} as never, vi.fn(async () => ({ rows: [], rowCount: 0 })))
+  })
+
+  it('opt-OUT rule (no execution_mode) → executor.execute called WITHOUT a job factory (no jobs)', async () => {
+    const execSpy = vi.spyOn(service['executor'], 'execute').mockResolvedValue(storedExecutionForPath())
+    await service.executeRule(execRule({ executionMode: undefined }), { recordId: 'r1' })
+    expect(execSpy.mock.calls[0][2]).toBeUndefined() // 3rd arg = jobLifecycleFactory
+  })
+
+  it('opt-IN rule (workflow_job_v1) → executor.execute called WITH a job factory', async () => {
+    const execSpy = vi.spyOn(service['executor'], 'execute').mockResolvedValue(storedExecutionForPath())
+    await service.executeRule(execRule({ executionMode: 'workflow_job_v1' }), { recordId: 'r1' })
+    expect(typeof execSpy.mock.calls[0][2]).toBe('function')
+  })
+
+  function execRule(over: Record<string, unknown>) {
+    return {
+      id: 'rule_1', name: 'R', sheetId: 'sheet_1', trigger: { type: 'record.created', config: {} },
+      actions: [{ type: 'update_record', config: { fields: { x: 1 } } }], enabled: true,
+      createdBy: 'u1', createdAt: '2026-01-01T00:00:00Z', ...over,
+    } as never
+  }
+  function storedExecutionForPath(): AutomationExecution {
+    return { id: 'axe_1', ruleId: 'rule_1', triggeredBy: 'event', triggeredAt: '2026-05-30T00:00:00Z', status: 'success', steps: [] }
+  }
+})
+
+describe('AutomationJobService — A6-1 persistence + C1 read', () => {
+  beforeEach(() => { _valuesCalls.length = 0; _setCalls.length = 0; _executeResults.length = 0; _executeTakeFirstResults.length = 0 })
+
+  it('onStart inserts a running job; onSettled redacts result/error and maps status to C1', async () => {
+    const svc = new AutomationJobService()
+    const lc = svc.lifecycleFor('axe_x', { id: 'rule_1', sheetId: 'sheet_1' })
+    _executeResults.push([]) // onStart insert
+    await lc.onStart(0, { type: 'send_webhook', config: {} } as never)
+    const inserted = _valuesCalls.at(-1) as Record<string, unknown>
+    expect(inserted.id).toBe('axe_x:job:0')
+    expect(inserted.status).toBe('running')
+    expect(inserted.upstream_job_id).toBeNull()
+
+    _executeResults.push([]) // onSettled update
+    await lc.onSettled(0, { type: 'send_webhook' } as never, {
+      actionType: 'send_webhook', status: 'failed',
+      error: 'connect postgres://u:SECRETPW@h/db failed', output: { token: 'LIVE-SECRET' }, durationMs: 5,
+    } as never)
+    const upd = _setCalls.at(-1) as Record<string, unknown> // updateTable().set(...) payload
+    expect(upd.status).toBe('failed') // C1 (failed identity)
+    expect(String(upd.error)).not.toContain('SECRETPW') // redactString
+    expect(JSON.stringify(upd)).not.toContain('LIVE-SECRET') // redactValue on result (token key masked)
+  })
+
+  it('listByExecution maps rows to C1 views that pass normalizeWorkflowJob (error string-or-absent)', async () => {
+    const svc = new AutomationJobService()
+    _executeResults.push([
+      { id: 'axe_x:job:0', execution_id: 'axe_x', step_key: '0', status: 'resolved', upstream_job_id: null, result: { ok: true }, error: null },
+      { id: 'axe_x:job:1', execution_id: 'axe_x', step_key: '1', status: 'failed', upstream_job_id: 'axe_x:job:0', result: null, error: 'boom' },
+    ])
+    const views = await svc.listByExecution('axe_x')
+    expect(views[0].status).toBe('resolved')
+    expect(views[0].error).toBeUndefined() // null → absent (C1)
+    expect(views[1].error).toBe('boom')
+    for (const v of views) expect(() => normalizeWorkflowJob(v)).not.toThrow()
   })
 })


### PR DESCRIPTION
## What

Implements the A6-1 scout (**#2112**) after explicit owner opt-in. **First A6 capability-half runtime**: opted-in rules (`automation_rules.execution_mode='workflow_job_v1'`) persist one **C1-shaped job per action**; existing rules stay on the legacy steps path by default.

- **migration** `zzzz20260530120000`: new `multitable_automation_jobs` (+ `execution_id` index) + nullable `automation_rules.execution_mode`.
- **`ActionJobLifecycle`** (onStart/onSettled/onSkipped) threaded `execute(rule,evt,factory?)`→`executeActions`; hooks fire **OUTSIDE the inner per-action try/catch** so a job-write failure fails the EXECUTION (fail-closed), not a swallowed step.
- **`AutomationJobService`**: `lifecycleFor` (running on start; resolved/failed via C1 bridge on settle; skipped on fail-stop; `result` via `redactValue`, `error` via `redactString` — A1 invariant) + `listByExecution` (C1 views, enum-strict).
- `executeRule` builds the factory **only** for opt-in rules (single path-choice point → retries of opt-in rules also write jobs). A2 detail prefers persisted jobs, falls back to legacy steps (list unchanged, no N+1).

## ⚠️ Latency — runtime present, enable path deferred (dormant in prod)
Read path fully wired (all rule reads use `.selectAll()` → `execution_mode` reaches `executeRule` at runtime — **verified, not dead-on-arrival**). But **no write path sets it**: `createRule`/`updateRule` deliberately don't accept `execution_mode` (enable path scout-deferred). So the job plane is **dormant in production** — a rule is opt-in-able only by **direct DB / fixture**, not the API. A follow-up (its own opt-in) adds the enable writer. Intended: runtime lands + is provable; turning it on is a separate reviewable step.

## Fail-closed (opt-in durable provenance)
Stricter than the legacy log-write swallow / the `/test`+retry fail-OPEN (#2053), deliberately because A6-1 is opt-in: **(a)** onStart throw → side effect **never runs** + execution failed; **(b)** onSettled throw *after* the action → side effect **ran once** + execution failed ("must not pretend the action didn't run"). **Operator-visible (scout-accepted):** a job-write blip turns a side-effect-completed opt-in run into `failed` → an A5 retry can double-fire. Surfaced in the verification doc.

## Scope held
NO suspend/resume / branch/parallel / BPMN / approval-as-job / worker / default per-action writes — **A6-2..A6-5 stay frozen / demand-gated**. Lock: post-GATE (#1993); A6-1 governed by the run-governance demand gate, not K3; no integration-core/RBAC/K3-write touch.

## Tests
**181 unit** (executor lifecycle ordering / fail-stop skipped / **both fail-closed sub-cases** / opt-out-no-jobs-byte-identical / service path-choice / job persistence+redaction+C1 read / A2 detail prefer-jobs-vs-legacy) + **real-DB round-trip** `multitable-automation-jobs.test.ts` wired into `plugin-tests.yml` (closes the new-table wire-vs-fixture gap). `tsc` clean; eslint clean for new files (one pre-existing `prefer-const` in `parseCreateRuleInput` left as-is — core-backend has no lint script).

🤖 Generated with [Claude Code](https://claude.com/claude-code)