### PR TITLE
fix(phase5): proxy production metrics through nginx

### DIFF
--- a/docker/nginx.conf
+++ b/docker/nginx.conf
@@ -27,6 +27,26 @@ server {
     return 400;
   }
 
+  location = /metrics {
+    proxy_pass http://$backend_upstream;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Authorization $http_authorization;
+  }
+
+  location = /metrics/prom {
+    proxy_pass http://$backend_upstream;
+    proxy_http_version 1.1;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+    proxy_set_header Authorization $http_authorization;
+  }
+
   # Allow larger bodies only for the raw CSV upload endpoint (upload channel),
   # while keeping the global `client_max_body_size` bounded.
   location /api/attendance/import/upload {

--- a/scripts/ops/phase5-nginx-metrics-route-contract.test.mjs
+++ b/scripts/ops/phase5-nginx-metrics-route-contract.test.mjs
@@ -1,0 +1,42 @@
+import assert from 'node:assert/strict'
+import { readFileSync } from 'node:fs'
+import path from 'node:path'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const nginxConf = readFileSync(path.join(repoRoot, 'docker/nginx.conf'), 'utf8')
+
+function locationBlock(location) {
+  const escapedLocation = location.replaceAll('/', '\\/')
+  const match = nginxConf.match(new RegExp(`location = ${escapedLocation} \\{([\\s\\S]*?)\\n  \\}`))
+  assert.ok(match, `missing exact nginx location for ${location}`)
+  return match[1]
+}
+
+for (const route of ['/metrics', '/metrics/prom']) {
+  test(`nginx proxies ${route} to the backend metrics endpoint`, () => {
+    const block = locationBlock(route)
+
+    assert.match(block, /proxy_pass http:\/\/\$backend_upstream;/)
+    assert.match(block, /proxy_http_version 1\.1;/)
+    assert.match(block, /proxy_set_header Host \$host;/)
+    assert.match(block, /proxy_set_header X-Real-IP \$remote_addr;/)
+    assert.match(block, /proxy_set_header X-Forwarded-For \$proxy_add_x_forwarded_for;/)
+    assert.match(block, /proxy_set_header X-Forwarded-Proto \$scheme;/)
+    assert.match(block, /proxy_set_header Authorization \$http_authorization;/)
+    assert.doesNotMatch(block, /try_files/)
+  })
+}
+
+test('metrics proxy locations are checked before the SPA fallback', () => {
+  const metricsIndex = nginxConf.indexOf('location = /metrics')
+  const metricsPromIndex = nginxConf.indexOf('location = /metrics/prom')
+  const spaFallbackIndex = nginxConf.indexOf('location / {')
+
+  assert.ok(metricsIndex >= 0)
+  assert.ok(metricsPromIndex >= 0)
+  assert.ok(spaFallbackIndex >= 0)
+  assert.ok(metricsIndex < spaFallbackIndex)
+  assert.ok(metricsPromIndex < spaFallbackIndex)
+})


### PR DESCRIPTION
## Summary
- add exact nginx proxy locations for `/metrics` and `/metrics/prom` so external `${METASHEET_BASE_URL}/metrics/prom` reaches the backend Prometheus endpoint instead of the SPA fallback
- preserve the metrics scrape Authorization header when proxying through the web container
- add a contract test that prevents the Phase 5 metrics route from falling through to `try_files ... /index.html`

## Why
Refs #1. The latest Phase 5 regression runs can resolve the runtime scrape token and fetch `http://23.254.236.11:8081/metrics/prom`, but the raw scrape is only 17 lines with 0 histograms. Current `docker/nginx.conf` has no `/metrics` proxy location, so external metrics requests can be served by the SPA fallback instead of backend `/metrics/prom`.

This PR should not auto-close #1; close-out still requires deploying this, rerunning Phase 5, and attaching a non-fallback PASS artifact.

## Verification
- `node --test scripts/ops/phase5-nginx-metrics-route-contract.test.mjs scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs`
- `git diff --check`

## Not run
- `nginx -t` via Docker image: local Docker daemon is not running (`/Users/chouhua/.docker/run/docker.sock` missing). CI/deploy should still exercise the mounted nginx config.