### PR TITLE
docs(ops): refresh docker deploy SSH timeout runbook refs

### DIFF
--- a/docs/development/docker-build-deploy-ssh-timeout-runbook-design-20260522.md
+++ b/docs/development/docker-build-deploy-ssh-timeout-runbook-design-20260522.md
@@ -52,15 +52,17 @@ The failure is operational, not code. Three signals say so:
   (firewall, SG, sshd state), not code changes.
 
 So the deliverable is operator knowledge in a single place, citing the
-exact step and line in the workflow so an operator triaging the next
-recurrence does not have to read the YAML to find what failed.
+workflow, deploy job, step name, and current line references so an
+operator triaging the next recurrence does not have to read the YAML to
+find what failed.
 
 ## Runbook shape decisions
 
 1. **Symptom-first**, not failure-class-first. The runbook opens with
-   the exact step name, the exact line number, and the exact sanitized
-   error text. The operator's eye should match-in-one-pass without
-   reading the whole doc.
+   the exact step name, current line references, and the exact
+   sanitized error text. The operator's eye should match-in-one-pass
+   without reading the whole doc; if the workflow YAML shifts, the
+   workflow / job / step / first-`ssh` shape remains the contract.
 
 2. **Order the checklist by failure probability**, not by OSI layer.
    Most recurrences will be DNS drift / cloud-SG edit / runner CIDR

--- a/docs/development/docker-build-deploy-ssh-timeout-runbook-verification-20260522.md
+++ b/docs/development/docker-build-deploy-ssh-timeout-runbook-verification-20260522.md
@@ -25,8 +25,8 @@ Each marker the task required, counted via `grep -cF` against
 | `Re-run failed jobs` | 2 (section 9 instruction + the closing reference) |
 | `26293551077` | 3 (cited as the workflow run, in symptom + step 9 + "Related" footer) |
 | `#1772` | 3 (top tracking line + step 9 reference + "Related" footer) |
-| `docker-build.yml:71` | 1 (the failing step's exact line) |
-| `docker-build.yml:88` | 1 (the failing `ssh` command's exact line inside the step) |
+| `docker-build.yml:83` | 1 (the failing step's current exact line) |
+| `docker-build.yml:100` | 1 (the failing `ssh` command's current exact line inside the step) |
 
 All eight checklist items from the task acceptance are present
 (DNS/IP, port 22, security group / firewall, deploy user, deploy key,
@@ -35,19 +35,19 @@ GitHub runner outbound, manual `ssh -v`, when to rerun).
 ### 2. Workflow grounding (cite-only, no edit)
 
 The runbook cites `.github/workflows/docker-build.yml` line numbers
-verified against `origin/main` (HEAD `18dccc36d` at the time of this
-PR's branch creation):
+verified against current `origin/main` (HEAD `e4f5d1a91` at the time of
+the 2026-05-30 refresh):
 
 - `name: Build and Push Docker Images` on line 1
 - `jobs:` on line 19
-- `deploy:` job on line 64
-- `Sync deploy host files` step on line 71
-- the first `ssh` command inside that step on line 88
+- `deploy:` job on line 76
+- `Sync deploy host files` step on line 83
+- the first `ssh` command inside that step on line 100
 
 The runbook does **not** modify the workflow YAML. The line numbers are
-load-bearing for operator triage, so they are cited; the runbook also
-notes "the workflow is fine when the host is reachable; do not add a
-debug step to docker-build.yml itself".
+helpful for operator triage but intentionally not the contract; the
+runbook now tells operators to match by workflow name, deploy job, step
+name, and first `ssh $ssh_opts` invocation if the YAML shifts.
 
 ### 3. Secret-shape sweep
 
@@ -91,7 +91,7 @@ git diff --check  -> exit 0
 | Operator checklist: GitHub runner outbound IPs | section 5 cites `https://api.github.com/meta` |
 | Operator checklist: manual `ssh -v` | section 8 with the `ssh -vv -o ConnectTimeout=10 ...` placeholder-only reproduction shape |
 | Operator checklist: when to rerun failed jobs | section 9 with the "fix first, rerun once" discipline |
-| Cite #1772 and workflow failure point | tracking line + step 9 + Related-workflows footer; line numbers 71 and 88 for the step and the ssh call |
+| Cite #1772 and workflow failure point | tracking line + step 9 + Related-workflows footer; current line numbers 83 and 100 for the step and ssh call, with an explicit "match by shape if YAML shifts" caveat |
 | Design MD + verification MD | this PR adds both |
 | No secret / host / user / key emitted | secret-shape sweep above; `0.0.0.0/0` is the only IPv4 literal and it is the CIDR-any placeholder, not a leak |
 

--- a/docs/operations/docker-build-deploy-ssh-timeout-runbook.md
+++ b/docs/operations/docker-build-deploy-ssh-timeout-runbook.md
@@ -9,9 +9,9 @@ all succeed), but the downstream `deploy` job fails at the very first
 step:
 
 - failing step: `Sync deploy host files`
-  (`.github/workflows/docker-build.yml:71`)
+  (`.github/workflows/docker-build.yml:83` on current main)
 - failing command: the first `ssh` inside that step
-  (`.github/workflows/docker-build.yml:88`)
+  (`.github/workflows/docker-build.yml:100` on current main)
 - failing error shape:
 
   ```text
@@ -246,8 +246,11 @@ system API. It is operator documentation only.
 
 - Workflow: `Build and Push Docker Images` -
   `.github/workflows/docker-build.yml` (`name:` on line 1, `deploy:`
-  job starts at line 64, `Sync deploy host files` step at line 71,
-  first `ssh` command inside that step on line 88).
+  job starts at line 76, `Sync deploy host files` step at line 83,
+  first `ssh` command inside that step on line 100 as of
+  `origin/main` `e4f5d1a91`). If the YAML shifts, match by workflow
+  name, deploy job, step name, and the first `ssh $ssh_opts` invocation
+  rather than treating the line numbers as the contract.
 - Tracking issue: #1772.
 - First failing run: workflow run `26293551077` after the
   `d23472167` main commit (`fix(multitable): hint when calendar


### PR DESCRIPTION
## Summary

- refresh the docker-build deploy SSH timeout runbook line references against current `origin/main` (`e4f5d1a91`)
- update the operator doc and verification note from stale `docker-build.yml:71/88` references to current `83/100`
- make the runbook less brittle by saying the workflow/job/step/first-ssh shape is the contract if YAML lines shift again

## Verification

- `git diff --check origin/main..HEAD`
- `rg` sweep confirmed old `docker-build.yml:71/88` references are gone from the touched docs

## Scope

Docs only. No workflow, runtime, DB, API, frontend, customer-GATE, or Save-only changes.
