### PR TITLE
feat(attendance): admin workbench T4 — picker-backed scope targets (users + groups)

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -1353,18 +1353,6 @@
                     <span>{{ tr('Departments', '部门') }}</span>
                     <textarea id="attendance-scheduler-scope-target-departments" v-model="schedulerScopeForm.departments" rows="1" :placeholder="tr('dept-a, dept-b', 'dept-a, dept-b')"></textarea>
                   </label>
-                  <label class="attendance__field" for="attendance-scheduler-scope-target-attendance-groups">
-                    <span>{{ tr('Attendance groups', '考勤组') }}</span>
-                    <textarea id="attendance-scheduler-scope-target-attendance-groups" v-model="schedulerScopeForm.attendanceGroupIds" rows="1" :placeholder="tr('attendance group id(s)', '考勤组 ID')"></textarea>
-                  </label>
-                  <label class="attendance__field" for="attendance-scheduler-scope-target-schedule-groups">
-                    <span>{{ tr('Schedule groups', '排班组') }}</span>
-                    <textarea id="attendance-scheduler-scope-target-schedule-groups" v-model="schedulerScopeForm.scheduleGroupIds" rows="1" :placeholder="tr('schedule group id(s)', '排班组 ID')"></textarea>
-                  </label>
-                  <label class="attendance__field" for="attendance-scheduler-scope-target-users">
-                    <span>{{ tr('Users', '员工') }}</span>
-                    <textarea id="attendance-scheduler-scope-target-users" v-model="schedulerScopeForm.userIds" rows="1" :placeholder="tr('user id(s)', '员工 ID')"></textarea>
-                  </label>
                   <label class="attendance__field" for="attendance-scheduler-scope-target-roles">
                     <span>{{ tr('Roles', '角色') }}</span>
                     <textarea id="attendance-scheduler-scope-target-roles" v-model="schedulerScopeForm.roles" rows="1" :placeholder="tr('role(s)', '角色')"></textarea>
@@ -1374,8 +1362,61 @@
                     <textarea id="attendance-scheduler-scope-target-role-tags" v-model="schedulerScopeForm.roleTags" rows="1" :placeholder="tr('role tag(s)', '角色标签')"></textarea>
                   </label>
                 </div>
+                <fieldset class="attendance__scheduler-scope-targets-field" data-attendance-scheduler-scope-attendance-groups-field>
+                  <legend>{{ tr('Attendance groups', '考勤组') }}</legend>
+                  <p v-if="attendanceGroups.length === 0" class="attendance__field-hint">{{ tr('No attendance groups loaded.', '暂无考勤组。') }}</p>
+                  <div v-else class="attendance__scheduler-scope-checkbox-list">
+                    <label
+                      v-for="group in attendanceGroups"
+                      :key="group.id"
+                      class="attendance__field attendance__field--checkbox"
+                    >
+                      <input
+                        type="checkbox"
+                        :value="group.id"
+                        v-model="schedulerScopeForm.attendanceGroupIds"
+                        :data-attendance-scheduler-scope-attendance-group="group.id"
+                      />
+                      <span>{{ group.name }}</span>
+                    </label>
+                  </div>
+                  <p
+                    v-if="schedulerScopeAttendanceGroupsTruncated"
+                    class="attendance__field-hint attendance__field-hint--error"
+                    data-attendance-scheduler-scope-attendance-groups-truncated
+                  >
+                    {{ tr(`Showing first ${attendanceGroups.length} of ${attendanceGroupsTotal} attendance groups; not all are listed.`, `仅显示前 ${attendanceGroups.length}/${attendanceGroupsTotal} 个考勤组，部分未列出。`) }}
+                  </p>
+                </fieldset>
+                <fieldset class="attendance__scheduler-scope-targets-field" data-attendance-scheduler-scope-schedule-groups-field>
+                  <legend>{{ tr('Schedule groups', '排班组') }}</legend>
+                  <p v-if="advancedSchedulingWorkbenchGroups.length === 0" class="attendance__field-hint">{{ tr('No schedule groups loaded.', '暂无排班组。') }}</p>
+                  <div v-else class="attendance__scheduler-scope-checkbox-list">
+                    <label
+                      v-for="group in advancedSchedulingWorkbenchGroups"
+                      :key="group.id"
+                      class="attendance__field attendance__field--checkbox"
+                    >
+                      <input
+                        type="checkbox"
+                        :value="group.id"
+                        v-model="schedulerScopeForm.scheduleGroupIds"
+                        :data-attendance-scheduler-scope-schedule-group="group.id"
+                      />
+                      <span>{{ group.name }}</span>
+                    </label>
+                  </div>
+                </fieldset>
+                <AttendanceUserMultiPickerField
+                  v-model="schedulerScopeForm.userIds"
+                  :tr="tr"
+                  :label="tr('Users', '员工')"
+                  name="attendanceSchedulerScopeUsers"
+                  :search-placeholder="tr('Search the target users', '搜索目标员工')"
+                  input-id="attendance-scheduler-scope-target-users"
+                />
                 <p class="attendance__field-hint">
-                  {{ tr('Separate multiple values with commas or new lines. At least one target and one action are required.', '多个值用逗号或换行分隔；至少需要一个目标和一个动作。') }}
+                  {{ tr('Pick users and groups above; departments, roles, and role tags accept comma- or newline-separated lists. At least one target and one action are required.', '在上方选择员工与分组；部门、角色、角色标签可用逗号或换行分隔多个值。至少需要一个目标和一个动作。') }}
                 </p>
                 <div class="attendance__scheduler-scope-form-actions">
                   <button type="submit" class="attendance__btn" :disabled="schedulerScopeCreating" data-attendance-scheduler-scope-create>
@@ -6558,6 +6599,7 @@ import AttendanceCalendarPolicyPreviewPanel from './attendance/AttendanceCalenda
 import AttendanceImportBatchesSection from './attendance/AttendanceImportBatchesSection.vue'
 import AttendanceHolidayDataSection from './attendance/AttendanceHolidayDataSection.vue'
 import AttendanceUserPickerField from './attendance/AttendanceUserPickerField.vue'
+import AttendanceUserMultiPickerField from './attendance/AttendanceUserMultiPickerField.vue'
 import AttendanceReportFieldsSection from './attendance/AttendanceReportFieldsSection.vue'
 import {
   buildCalendarPolicyOverrideDiagnostics,
@@ -7938,15 +7980,16 @@ const schedulerScopes = ref<AttendanceSchedulerScope[]>([])
 const schedulerScopesLoading = ref(false)
 const schedulerScopesTotal = ref(0)
 const ATTENDANCE_SCHEDULER_SCOPE_ALL_ACTIONS = ['view', 'edit', 'import', 'export', 'clear', 'approve', 'dispatch'] as const
-// T2 "new scope" create form. Targets are free-text (comma / new-line) this slice; each field
-// maps to one scope key — picker-based targets land in a later slice.
+// "New / edit scope" form. Targets are mixed input: users / attendance groups / schedule groups
+// are picker-backed arrays (T4); departments / roles / roleTags stay free-text (open vocabulary,
+// no enumerable source). Every field still maps to exactly one scope key and lands as an array.
 const schedulerScopeForm = reactive({
   subjectType: 'user' as 'user' | 'role' | 'role_tag',
   subjectRef: '',
   actions: [] as string[],
-  scheduleGroupIds: '',
-  attendanceGroupIds: '',
-  userIds: '',
+  scheduleGroupIds: [] as string[],
+  attendanceGroupIds: [] as string[],
+  userIds: [] as string[],
   departments: '',
   roles: '',
   roleTags: '',
@@ -9049,6 +9092,15 @@ const selectedRuleTemplateVersion = computed(
   () => ruleTemplateVersions.value.find(item => item.id === selectedRuleTemplateVersionId.value) ?? null,
 )
 const attendanceGroups = ref<AttendanceGroup[]>([])
+// No-silent-caps for the attendance-group picker: its loader caps at pageSize 200 while the
+// endpoint reports the real COUNT(*), so warn (mirroring the scheduler-scope list truncation
+// hint) when the loaded list is shorter than the total — otherwise a target group past the cap
+// would be silently un-pickable. Schedule groups are returned uncapped (workbench total echoes
+// items.length), so the schedule-group picker needs no such guard.
+const attendanceGroupsTotal = ref(0)
+const schedulerScopeAttendanceGroupsTruncated = computed(
+  () => attendanceGroupsTotal.value > attendanceGroups.value.length,
+)
 const attendanceGroupMembers = ref<AttendanceGroupMember[]>([])
 const attendanceGroupManagers = ref<AttendanceGroupManager[]>([])
 const attendanceGroupSearch = ref('')
@@ -17728,6 +17780,7 @@ async function loadAttendanceGroups() {
     adminForbidden.value = false
     const selectedId = attendanceGroupEditingId.value || attendanceGroupMemberGroupId.value
     attendanceGroups.value = data.data?.items ?? []
+    attendanceGroupsTotal.value = typeof data.data?.total === 'number' ? data.data.total : attendanceGroups.value.length
     const selected = selectedId ? attendanceGroups.value.find(item => item.id === selectedId) : null
     if (selected) {
       editAttendanceGroup(selected)
@@ -18982,9 +19035,9 @@ function resetSchedulerScopeForm(): void {
   schedulerScopeForm.subjectType = 'user'
   schedulerScopeForm.subjectRef = ''
   schedulerScopeForm.actions = []
-  schedulerScopeForm.scheduleGroupIds = ''
-  schedulerScopeForm.attendanceGroupIds = ''
-  schedulerScopeForm.userIds = ''
+  schedulerScopeForm.scheduleGroupIds = []
+  schedulerScopeForm.attendanceGroupIds = []
+  schedulerScopeForm.userIds = []
   schedulerScopeForm.departments = ''
   schedulerScopeForm.roles = ''
   schedulerScopeForm.roleTags = ''
@@ -19004,9 +19057,9 @@ function editSchedulerScope(scope: AttendanceSchedulerScope): void {
     : 'user'
   schedulerScopeForm.subjectRef = scope.subjectRef
   schedulerScopeForm.actions = [...scope.actions]
-  schedulerScopeForm.scheduleGroupIds = scope.scope.scheduleGroupIds.join(', ')
-  schedulerScopeForm.attendanceGroupIds = scope.scope.attendanceGroupIds.join(', ')
-  schedulerScopeForm.userIds = scope.scope.userIds.join(', ')
+  schedulerScopeForm.scheduleGroupIds = [...scope.scope.scheduleGroupIds]
+  schedulerScopeForm.attendanceGroupIds = [...scope.scope.attendanceGroupIds]
+  schedulerScopeForm.userIds = [...scope.scope.userIds]
   schedulerScopeForm.departments = scope.scope.departments.join(', ')
   schedulerScopeForm.roles = scope.scope.roles.join(', ')
   schedulerScopeForm.roleTags = scope.scope.roleTags.join(', ')
@@ -19031,9 +19084,9 @@ async function submitSchedulerScope() {
     return
   }
   const scope = {
-    scheduleGroupIds: parseUserIdList(schedulerScopeForm.scheduleGroupIds),
-    attendanceGroupIds: parseUserIdList(schedulerScopeForm.attendanceGroupIds),
-    userIds: parseUserIdList(schedulerScopeForm.userIds),
+    scheduleGroupIds: [...schedulerScopeForm.scheduleGroupIds],
+    attendanceGroupIds: [...schedulerScopeForm.attendanceGroupIds],
+    userIds: [...schedulerScopeForm.userIds],
     departments: parseUserIdList(schedulerScopeForm.departments),
     roles: parseUserIdList(schedulerScopeForm.roles),
     roleTags: parseUserIdList(schedulerScopeForm.roleTags),
@@ -21861,6 +21914,24 @@ const holidaySectionBindings = {
   padding: 0 4px;
   font-size: 12px;
   color: #5b6b7b;
+}
+.attendance__scheduler-scope-targets-field {
+  margin: 0 0 12px;
+  border: 1px solid #e3e8ef;
+  border-radius: 6px;
+  padding: 8px 10px;
+}
+.attendance__scheduler-scope-targets-field legend {
+  padding: 0 4px;
+  font-size: 12px;
+  color: #5b6b7b;
+}
+.attendance__scheduler-scope-checkbox-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px 16px;
+  max-height: 160px;
+  overflow-y: auto;
 }
 .attendance__scheduler-scope-form-actions {
   display: flex;

--- a/apps/web/src/views/attendance/AttendanceUserMultiPickerField.vue
+++ b/apps/web/src/views/attendance/AttendanceUserMultiPickerField.vue
@@ -1,0 +1,191 @@
+<template>
+  <label class="attendance__field attendance__field--full" :for="inputId">
+    <span>{{ label }}</span>
+    <div class="attendance__user-picker" :data-attendance-user-multi-picker="pickerName">
+      <div class="attendance__user-picker-controls">
+        <input
+          :id="inputId"
+          v-model.trim="searchQuery"
+          :disabled="disabled"
+          :placeholder="searchPlaceholderText"
+          :name="name"
+          type="search"
+          @keyup.enter.prevent="void loadUsers()"
+        />
+        <button
+          class="attendance__btn"
+          type="button"
+          :disabled="disabled || loading"
+          :data-attendance-user-multi-picker-search="pickerName"
+          @click="void loadUsers()"
+        >
+          {{ loading ? tr('Loading...', '加载中...') : tr('Search users', '搜索用户') }}
+        </button>
+      </div>
+      <div class="attendance__user-picker-controls">
+        <select
+          v-model="draftId"
+          :disabled="disabled || loading"
+          :data-attendance-user-multi-picker-select="pickerName"
+        >
+          <option value="">{{ tr('Select a user to add', '选择要添加的用户') }}</option>
+          <option v-for="user in addableUsers" :key="user.id" :value="user.id">{{ formatUserLabel(user) }}</option>
+        </select>
+        <button
+          class="attendance__btn"
+          type="button"
+          :disabled="disabled || !draftId"
+          :data-attendance-user-multi-picker-add="pickerName"
+          @click="addDraft"
+        >
+          {{ tr('Add', '添加') }}
+        </button>
+      </div>
+      <ul
+        v-if="modelValue.length"
+        class="attendance__chip-list"
+        :data-attendance-user-multi-picker-chips="pickerName"
+      >
+        <li v-for="id in modelValue" :key="id" class="attendance__chip" :data-chip-id="id">
+          <span>{{ chipLabel(id) }}</span>
+          <button
+            type="button"
+            class="attendance__chip-remove"
+            :aria-label="tr('Remove', '移除')"
+            :data-attendance-user-multi-picker-remove="id"
+            @click="removeId(id)"
+          >×</button>
+        </li>
+      </ul>
+      <small v-if="statusMessage" class="attendance__field-hint attendance__field-hint--error">{{ statusMessage }}</small>
+    </div>
+    <small v-if="helpText" class="attendance__field-hint">{{ helpText }}</small>
+  </label>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, reactive, ref } from 'vue'
+import { useAttendanceAdminUsers } from './useAttendanceAdminUsers'
+
+type Translate = (en: string, zh: string) => string
+
+const props = withDefaults(defineProps<{
+  modelValue: string[]
+  label: string
+  tr: Translate
+  name?: string
+  helpText?: string
+  searchPlaceholder?: string
+  disabled?: boolean
+  inputId?: string
+}>(), {
+  disabled: false,
+  inputId: undefined,
+  name: '',
+  searchPlaceholder: '',
+  helpText: '',
+})
+
+const emit = defineEmits<{
+  'update:modelValue': [value: string[]]
+}>()
+
+const { formatUserLabel, loading, loadUsers, searchQuery, statusMessage, users } = useAttendanceAdminUsers({ tr: props.tr })
+
+const draftId = ref('')
+// Display label captured when an id is added, so a chip keeps reading as a name even after a
+// later search swaps out the results list. The wire value is always the bare id array.
+const labelById = reactive<Record<string, string>>({})
+
+const pickerName = computed(() => props.name || 'users')
+const addableUsers = computed(() => users.value.filter((user) => !props.modelValue.includes(user.id)))
+const inputId = computed(() => props.inputId || `${props.name || 'attendance-user-multi-picker'}-${props.label.replace(/\s+/g, '-').toLowerCase()}`)
+const searchPlaceholderText = computed(() => props.searchPlaceholder || props.tr('Search by email, name, or user ID', '按邮箱、姓名或用户 ID 搜索'))
+
+function chipLabel(id: string): string {
+  // Prefer the label captured at add-time; otherwise resolve from the loaded directory (covers
+  // ids hydrated externally, e.g. an edit prefill); fall back to the bare id.
+  if (labelById[id]) return labelById[id]
+  const known = users.value.find((user) => user.id === id)
+  return known ? formatUserLabel(known) : id
+}
+
+function addDraft(): void {
+  const id = draftId.value.trim()
+  draftId.value = ''
+  if (!id || props.modelValue.includes(id)) return
+  const picked = users.value.find((user) => user.id === id)
+  if (picked) labelById[id] = formatUserLabel(picked)
+  emit('update:modelValue', [...props.modelValue, id])
+}
+
+function removeId(id: string): void {
+  emit('update:modelValue', props.modelValue.filter((value) => value !== id))
+}
+
+onMounted(() => {
+  void loadUsers()
+})
+</script>
+
+<style scoped>
+.attendance__user-picker {
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+}
+
+.attendance__user-picker-controls {
+  display: flex;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.attendance__user-picker-controls input,
+.attendance__user-picker-controls select {
+  flex: 1 1 220px;
+  min-width: 180px;
+}
+
+.attendance__chip-list {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 6px;
+  list-style: none;
+  padding: 0;
+  margin: 0;
+}
+
+.attendance__chip {
+  display: inline-flex;
+  align-items: center;
+  gap: 6px;
+  padding: 2px 10px;
+  border-radius: 12px;
+  background: #eef2ff;
+  font-size: 13px;
+}
+
+.attendance__chip-remove {
+  border: none;
+  background: transparent;
+  cursor: pointer;
+  font-size: 15px;
+  line-height: 1;
+  color: #666;
+  padding: 0;
+}
+
+.attendance__chip-remove:hover {
+  color: #c62828;
+}
+
+.attendance__field-hint {
+  color: #666;
+  font-size: 12px;
+}
+
+.attendance__field-hint--error {
+  color: #c62828;
+}
+</style>

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -744,7 +744,7 @@ describe('Attendance admin regressions', () => {
     expect(hint?.textContent || '').toContain('250')
   })
 
-  it('creates a scheduler scope, mapping each free-text target field to its scope key', async () => {
+  it('creates a scheduler scope: picks users / groups and maps each target to its scope key', async () => {
     const created: Array<Record<string, unknown>> = []
     vi.mocked(apiFetch).mockImplementation(async (input, init) => {
       const url = String(input)
@@ -755,6 +755,27 @@ describe('Attendance admin regressions', () => {
       }
       if (url.includes('/api/attendance/scheduler-scopes')) {
         return jsonResponse(200, { ok: true, data: { items: [], total: 0, page: 1, pageSize: 200 } })
+      }
+      // Picker sources — each returns exactly one distinct option so the A2 round-trip guard
+      // below catches a checkbox/chip wired to the wrong scope key.
+      if (url.startsWith('/api/admin/users')) {
+        return jsonResponse(200, { ok: true, data: { items: [
+          { id: 'user-x', email: 'user-x@example.com', name: 'User X', role: 'employee', is_active: true, is_admin: false, last_login_at: null, created_at: '2026-05-30T00:00:00.000Z' },
+        ] } })
+      }
+      if (url.includes('/api/attendance/advanced-scheduling/workbench')) {
+        return jsonResponse(200, { ok: true, data: {
+          summary: { scheduleGroups: 1 },
+          scheduleGroups: { total: 1, items: [
+            { id: 'sg-x', name: 'Schedule Group X', memberCount: 0, assignedUserCount: 0, shiftAssignmentCount: 0, rotationAssignmentCount: 0 },
+          ] },
+          diagnostics: [],
+        } })
+      }
+      if (url.includes('/api/attendance/groups')) {
+        return jsonResponse(200, { ok: true, data: { items: [
+          { id: 'ag-x', name: 'Attendance Group X', timezone: 'Asia/Shanghai' },
+        ], total: 1 } })
       }
       return emptyAttendanceResponse()
     })
@@ -775,20 +796,31 @@ describe('Attendance admin regressions', () => {
     subjectRef.dispatchEvent(new Event('input', { bubbles: true }))
     section.querySelector<HTMLInputElement>('[data-attendance-scheduler-scope-actions] input[data-action="view"]')!.click()
 
-    // Distinct sentinel per target field — catches a field wired to the wrong scope key
-    // (the backend normalizer silently drops unknown keys; this is the A2 round-trip guard).
-    const setTarget = (id: string, value: string): void => {
+    // Free-text targets keep their textareas; distinct sentinel per field (the A2 round-trip guard).
+    const setText = (id: string, value: string): void => {
       const el = section.querySelector<HTMLTextAreaElement>(`#${id}`)!
       el.value = value
       el.dispatchEvent(new Event('input', { bubbles: true }))
     }
-    setTarget('attendance-scheduler-scope-target-departments', 'dept-x')
-    setTarget('attendance-scheduler-scope-target-attendance-groups', 'ag-x')
-    setTarget('attendance-scheduler-scope-target-schedule-groups', 'sg-x')
-    setTarget('attendance-scheduler-scope-target-users', 'user-x')
-    setTarget('attendance-scheduler-scope-target-roles', 'role-x')
-    setTarget('attendance-scheduler-scope-target-role-tags', 'tag-x')
+    setText('attendance-scheduler-scope-target-departments', 'dept-x')
+    setText('attendance-scheduler-scope-target-roles', 'role-x')
+    setText('attendance-scheduler-scope-target-role-tags', 'tag-x')
+
+    // Picker targets: check the one attendance group + the one schedule group (array v-model).
+    section.querySelector<HTMLInputElement>('[data-attendance-scheduler-scope-attendance-group="ag-x"]')!.click()
+    section.querySelector<HTMLInputElement>('[data-attendance-scheduler-scope-schedule-group="sg-x"]')!.click()
+
+    // Users: load the directory, pick user-x in the add-select, then add it as a chip.
+    section.querySelector<HTMLButtonElement>('[data-attendance-user-multi-picker-search="attendanceSchedulerScopeUsers"]')!.click()
+    await flushUi(4)
+    const userSelect = section.querySelector<HTMLSelectElement>('[data-attendance-user-multi-picker-select="attendanceSchedulerScopeUsers"]')!
+    userSelect.value = 'user-x'
+    userSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(1)
+    section.querySelector<HTMLButtonElement>('[data-attendance-user-multi-picker-add="attendanceSchedulerScopeUsers"]')!.click()
     await flushUi(2)
+    // The added user reads as a chip, not a raw id typed into a textarea.
+    expect(section.querySelector('[data-attendance-user-multi-picker-chips="attendanceSchedulerScopeUsers"] [data-chip-id="user-x"]')).toBeTruthy()
 
     section.querySelector<HTMLButtonElement>('[data-attendance-scheduler-scope-create]')!.click()
     await flushUi(4)
@@ -796,6 +828,7 @@ describe('Attendance admin regressions', () => {
     expect(created).toHaveLength(1)
     // toEqual (not toMatchObject) so an extra body key — e.g. a re-added orgId, which the
     // backend's .strict() schema rejects with 400 — fails the test instead of slipping through.
+    // Picked arrays + free-text lists all land as arrays under the same six scope keys.
     expect(created[0]).toEqual({
       subjectType: 'role',
       subjectRef: 'attendance_admin',
@@ -932,6 +965,183 @@ describe('Attendance admin regressions', () => {
         roleTags: [],
       },
     })
+  })
+
+  it('edits a scope: prefills picked group checkboxes and user chips from the array targets', async () => {
+    const puts: Array<{ url: string; body: Record<string, unknown> }> = []
+    const existing = {
+      id: 'scope-9',
+      subjectType: 'role',
+      subjectRef: 'attendance_admin',
+      actions: ['view'],
+      scope: { scheduleGroupIds: ['sg-x'], attendanceGroupIds: ['ag-x'], userIds: ['user-x'], departments: [], roles: [], roleTags: [] },
+      isActive: true,
+    }
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      const method = String((init as { method?: string } | undefined)?.method || 'GET').toUpperCase()
+      if (url.includes('/api/attendance/scheduler-scopes/scope-9') && method === 'PUT') {
+        puts.push({ url, body: JSON.parse(String((init as { body?: string } | undefined)?.body || '{}')) })
+        return jsonResponse(200, { ok: true, data: { ...existing } })
+      }
+      if (url.includes('/api/attendance/scheduler-scopes')) {
+        return jsonResponse(200, { ok: true, data: { items: [existing], total: 1, page: 1, pageSize: 200 } })
+      }
+      if (url.startsWith('/api/admin/users')) {
+        return jsonResponse(200, { ok: true, data: { items: [
+          { id: 'user-x', email: 'user-x@example.com', name: 'User X', role: 'employee', is_active: true, is_admin: false, last_login_at: null, created_at: '2026-05-30T00:00:00.000Z' },
+        ] } })
+      }
+      if (url.includes('/api/attendance/advanced-scheduling/workbench')) {
+        return jsonResponse(200, { ok: true, data: {
+          summary: { scheduleGroups: 1 },
+          scheduleGroups: { total: 1, items: [
+            { id: 'sg-x', name: 'Schedule Group X', memberCount: 0, assignedUserCount: 0, shiftAssignmentCount: 0, rotationAssignmentCount: 0 },
+          ] },
+          diagnostics: [],
+        } })
+      }
+      if (url.includes('/api/attendance/groups')) {
+        return jsonResponse(200, { ok: true, data: { items: [
+          { id: 'ag-x', name: 'Attendance Group X', timezone: 'Asia/Shanghai' },
+        ], total: 1 } })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-scheduler-scopes"]')!.click()
+    await flushUi(4)
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-scheduler-scopes')!
+
+    section.querySelector<HTMLButtonElement>('[data-attendance-scheduler-scope-item] [data-attendance-scheduler-scope-edit]')!.click()
+    await flushUi(4)
+
+    // Array targets hydrate into the pickers — the regression most likely to break silently when
+    // the edit path switched from joined strings to arrays.
+    expect(section.querySelector<HTMLInputElement>('[data-attendance-scheduler-scope-attendance-group="ag-x"]')!.checked).toBe(true)
+    expect(section.querySelector<HTMLInputElement>('[data-attendance-scheduler-scope-schedule-group="sg-x"]')!.checked).toBe(true)
+    expect(section.querySelector('[data-attendance-user-multi-picker-chips="attendanceSchedulerScopeUsers"] [data-chip-id="user-x"]')).toBeTruthy()
+
+    section.querySelector<HTMLButtonElement>('[data-attendance-scheduler-scope-create]')!.click()
+    await flushUi(4)
+
+    expect(puts).toHaveLength(1)
+    expect(puts[0].url).toContain('/api/attendance/scheduler-scopes/scope-9')
+    // An unchanged submit round-trips the prefilled arrays back through the wire.
+    expect(puts[0].body).toEqual({
+      subjectType: 'role',
+      subjectRef: 'attendance_admin',
+      actions: ['view'],
+      scope: {
+        scheduleGroupIds: ['sg-x'],
+        attendanceGroupIds: ['ag-x'],
+        userIds: ['user-x'],
+        departments: [],
+        roles: [],
+        roleTags: [],
+      },
+    })
+  })
+
+  it('warns when the attendance-group picker source is capped (no silent caps)', async () => {
+    vi.mocked(apiFetch).mockImplementation(async (input) => {
+      const url = String(input)
+      if (url.includes('/api/attendance/scheduler-scopes')) {
+        return jsonResponse(200, { ok: true, data: { items: [], total: 0, page: 1, pageSize: 200 } })
+      }
+      if (url.includes('/api/attendance/advanced-scheduling/workbench')) {
+        // Schedule groups are returned uncapped (the workbench total echoes items.length), so
+        // there is nothing to warn about — total === items.length here, the realistic shape.
+        return jsonResponse(200, { ok: true, data: {
+          summary: { scheduleGroups: 1 },
+          scheduleGroups: { total: 1, items: [
+            { id: 'sg-1', name: 'SG 1', memberCount: 0, assignedUserCount: 0, shiftAssignmentCount: 0, rotationAssignmentCount: 0 },
+          ] },
+          diagnostics: [],
+        } })
+      }
+      if (url.includes('/api/attendance/groups')) {
+        // Real COUNT(*) total 4 but the loader caps at pageSize and only 1 item came back ->
+        // a target group past the cap would be silently un-pickable without this hint.
+        return jsonResponse(200, { ok: true, data: { items: [
+          { id: 'ag-1', name: 'AG 1', timezone: 'Asia/Shanghai' },
+        ], total: 4 } })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-scheduler-scopes"]')!.click()
+    await flushUi(4)
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-scheduler-scopes')!
+
+    expect(section.querySelector('[data-attendance-scheduler-scope-attendance-groups-truncated]')).toBeTruthy()
+    // Schedule groups are uncapped, so they intentionally carry no truncation hint.
+    expect(section.querySelector('[data-attendance-scheduler-scope-schedule-groups-truncated]')).toBeNull()
+  })
+
+  it('removes a user chip, emptying the target so the create guard refuses', async () => {
+    const posts: unknown[] = []
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = String(input)
+      const method = String((init as { method?: string } | undefined)?.method || 'GET').toUpperCase()
+      if (url.includes('/api/attendance/scheduler-scopes') && method === 'POST') {
+        posts.push(1)
+        return jsonResponse(200, { ok: true, data: {} })
+      }
+      if (url.includes('/api/attendance/scheduler-scopes')) {
+        return jsonResponse(200, { ok: true, data: { items: [], total: 0, page: 1, pageSize: 200 } })
+      }
+      if (url.startsWith('/api/admin/users')) {
+        return jsonResponse(200, { ok: true, data: { items: [
+          { id: 'user-x', email: 'user-x@example.com', name: 'User X', role: 'employee', is_active: true, is_admin: false, last_login_at: null, created_at: '2026-05-30T00:00:00.000Z' },
+        ] } })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-scheduler-scopes"]')!.click()
+    await flushUi(4)
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-scheduler-scopes')!
+
+    // Subject + action are valid, so only the (removed) user target is what blocks the POST.
+    const subjectType = section.querySelector<HTMLSelectElement>('#attendance-scheduler-scope-subject-type')!
+    subjectType.value = 'role'
+    subjectType.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(2)
+    const subjectRef = section.querySelector<HTMLInputElement>('#attendance-scheduler-scope-subject-ref')!
+    subjectRef.value = 'attendance_admin'
+    subjectRef.dispatchEvent(new Event('input', { bubbles: true }))
+    section.querySelector<HTMLInputElement>('[data-attendance-scheduler-scope-actions] input[data-action="view"]')!.click()
+
+    // Add the only target (a user), then remove its chip via the × button.
+    section.querySelector<HTMLButtonElement>('[data-attendance-user-multi-picker-search="attendanceSchedulerScopeUsers"]')!.click()
+    await flushUi(4)
+    const userSelect = section.querySelector<HTMLSelectElement>('[data-attendance-user-multi-picker-select="attendanceSchedulerScopeUsers"]')!
+    userSelect.value = 'user-x'
+    userSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(1)
+    section.querySelector<HTMLButtonElement>('[data-attendance-user-multi-picker-add="attendanceSchedulerScopeUsers"]')!.click()
+    await flushUi(2)
+    expect(section.querySelector('[data-attendance-user-multi-picker-chips="attendanceSchedulerScopeUsers"] [data-chip-id="user-x"]')).toBeTruthy()
+
+    section.querySelector<HTMLButtonElement>('[data-attendance-user-multi-picker-remove="user-x"]')!.click()
+    await flushUi(2)
+    // Chip gone -> userIds empty -> no target remains.
+    expect(section.querySelector('[data-attendance-user-multi-picker-chips="attendanceSchedulerScopeUsers"] [data-chip-id="user-x"]')).toBeNull()
+
+    section.querySelector<HTMLButtonElement>('[data-attendance-scheduler-scope-create]')!.click()
+    await flushUi(4)
+    expect(posts).toEqual([])
+    expect(container!.textContent).toContain('Add at least one scope target')
   })
 
   it('keeps the user subject ref through edit hydration (PUTs the original UUID, not blank)', async () => {


### PR DESCRIPTION
## What
Replaces the scheduler-scope form's **free-text target fields with real pickers**, so an admin no longer types raw UUIDs to scope a sub-admin (after read-only **T1 #2067** / create **T2 #2108** / edit+deactivate **T3 #2123**):

- **Users** → a new `AttendanceUserMultiPickerField` (search the directory via the shared `useAttendanceAdminUsers` composable, add results as **removable chips**), emits `string[]`.
- **Attendance groups + schedule groups** → checkbox multi-selects over the already-loaded `attendanceGroups` / advanced-scheduling-workbench `scheduleGroups` lists, **mirroring the existing actions checkbox-array pattern** (no new component for these).
- **Departments / roles / role tags** stay free-text (open vocabulary, no enumerable source); the form hint now describes the mixed input.

## No-silent-caps (attendance groups only — verified, not assumed)
The attendance-group loader caps at `pageSize 200` while the endpoint reports the real `COUNT(*)` (plugin-attendance `index.cjs:26237`), so a hint shows when the loaded list is shorter than the total — otherwise a group past the cap would be silently un-pickable. I **read the schedule-group source rather than assuming**: the workbench returns schedule groups **uncapped** and its `total` echoes `items.length` (`index.cjs:7851`), so the schedule-group picker **needs no hint and gets none** (no dead guard).

## Model / wire
The three picked fields move from `string` to `string[]`; submit/edit/reset spread the arrays. **All six targets still land as arrays under the same scope keys**, so the backend `.strict()` shape and the `>=1 target` guard are unchanged. **Pure frontend; no backend / enforcement touch.**

## Tests (gated `attendance-admin-regressions.spec.ts`)
- **create** picks a user + both group kinds + free-text dept/role/role-tag → asserts the full strict body round-trips (`toEqual`, distinct sentinel per key — the A2 wrong-key guard),
- **edit** prefills the group checkboxes + user chip from array targets and round-trips them on an unchanged PUT (the `string`→`string[]` hydration is the likeliest silent regression),
- a **capped** attendance-group source surfaces the hint; an **uncapped** schedule-group source carries none,
- **removing** the only user chip empties the target so the create guard refuses (covers the chip-remove path).

## Verification
`vue-tsc -b` clean · web **build** clean · gated specs green (**regressions 56/56**, **anchor-nav 30/30**). ~472 net lines. **Out of scope**: department/role/role-tag pickers (no source), enforcement.

> Not auto-merging — opened for your review first.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
