### PR TITLE
feat(attendance): enforce scheduler scope member dispatch

### DIFF
--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
@@ -34,15 +34,21 @@ describe('attendance advanced scheduling scope foundation', () => {
     expect(migrationSource).not.toContain("dropTable('attendance_group_members')")
   })
 
-  it('guards the new scheduling group and scheduler-scope routes behind attendance admin', () => {
+  it('guards the new scheduling group and scheduler-scope routes behind attendance admin or scoped dispatch', () => {
     [
       '/api/attendance/schedule-groups',
       '/api/attendance/schedule-groups/:id',
       '/api/attendance/schedule-groups/:id/members',
-      '/api/attendance/schedule-groups/:id/members/:memberId',
       '/api/attendance/scheduler-scopes',
       '/api/attendance/scheduler-scopes/:id',
     ].forEach(expectAdminRoute)
+    expect(pluginSource).toContain('SCHEDULER_SCOPE_FORBIDDEN')
+    expect(pluginSource).toMatch(
+      /'POST',\s*\n\s*'\/api\/attendance\/schedule-groups\/:id\/members',\s*\n\s*async \(req, res\)/,
+    )
+    expect(pluginSource).toMatch(
+      /'DELETE',\s*\n\s*'\/api\/attendance\/schedule-groups\/:id\/members\/:memberId',\s*\n\s*async \(req, res\)/,
+    )
   })
 
   it('normalizes schedule groups without overloading attendance_groups semantics', () => {
@@ -166,5 +172,45 @@ describe('attendance advanced scheduling scope foundation', () => {
       actions: ['view'],
       scope: {},
     })).toThrow(/scope must include at least one target/)
+  })
+
+  it('matches scheduler scopes by actor subject, action, and target for runtime enforcement', () => {
+    const scope = {
+      subjectType: 'role_tag',
+      subjectRef: 'line_scheduler',
+      actions: ['dispatch'],
+      scope: {
+        scheduleGroupIds: ['sg-1'],
+        attendanceGroupIds: [],
+        userIds: ['u-1'],
+        departments: [],
+        roles: [],
+        roleTags: [],
+      },
+      isActive: true,
+    }
+    const actor = {
+      userId: 'actor-1',
+      roles: ['ops'],
+      roleTags: ['line_scheduler'],
+    }
+
+    expect(helpers.attendanceSchedulerScopeMatchesActor(scope, actor)).toBe(true)
+    expect(helpers.attendanceSchedulerScopeAllowsActorActionTarget(scope, actor, 'dispatch', {
+      scheduleGroupIds: ['sg-1'],
+      userIds: ['u-1'],
+    })).toBe(true)
+    expect(helpers.attendanceSchedulerScopeAllowsActorActionTarget(scope, actor, 'edit', {
+      scheduleGroupIds: ['sg-1'],
+      userIds: ['u-1'],
+    })).toBe(false)
+    expect(helpers.attendanceSchedulerScopeAllowsActorActionTarget(scope, actor, 'dispatch', {
+      scheduleGroupIds: ['sg-2'],
+      userIds: ['u-1'],
+    })).toBe(false)
+    expect(helpers.attendanceSchedulerScopeAllowsActorActionTarget({ ...scope, isActive: false }, actor, 'dispatch', {
+      scheduleGroupIds: ['sg-1'],
+      userIds: ['u-1'],
+    })).toBe(false)
   })
 })

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -105,6 +105,63 @@ async function invokeRoute(
   return res
 }
 
+const scheduleGroupId = '00000000-0000-4000-8000-000000000301'
+const scheduleGroupMemberId = '00000000-0000-4000-8000-000000000302'
+
+function schedulerScopeRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: 'scope-1',
+    org_id: 'default',
+    subject_type: 'user',
+    subject_ref: 'scheduler-1',
+    actions: ['dispatch'],
+    scope: {
+      scheduleGroupIds: [scheduleGroupId],
+      attendanceGroupIds: [],
+      userIds: ['worker-1'],
+      departments: [],
+      roles: [],
+      roleTags: [],
+    },
+    is_active: true,
+    created_at: '2026-05-30T10:00:00.000Z',
+    updated_at: '2026-05-30T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function scheduleGroupMemberRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: scheduleGroupMemberId,
+    org_id: 'default',
+    schedule_group_id: scheduleGroupId,
+    user_id: 'worker-1',
+    effective_from: '2026-06-01',
+    effective_to: null,
+    role: 'member',
+    source: 'manual',
+    created_by: 'scheduler-1',
+    updated_by: 'scheduler-1',
+    created_at: '2026-05-30T10:00:00.000Z',
+    updated_at: '2026-05-30T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function rbacQueryResult(sql: string, params: unknown[] = [], admin = false) {
+  if (sql.includes('FROM user_roles') && sql.includes('role_id = $2')) return admin ? [{ ok: 1 }] : []
+  if (sql.includes('FROM user_permissions')) return []
+  if (sql.includes('JOIN role_permissions')) return []
+  return undefined
+}
+
+function actorContextQueryResult(sql: string) {
+  if (sql.includes('SELECT name, role FROM users')) return [{ name: 'Scoped scheduler', role: null }]
+  if (sql.includes('FROM attendance_group_members m')) return []
+  if (sql.includes('SELECT ur.role_id')) return []
+  return undefined
+}
+
 afterEach(async () => {
   restoreEnv('RBAC_BYPASS', originalRbacBypass)
   restoreEnv('ATTENDANCE_IMPORT_ASYNC_ENABLED', originalAsyncEnabled)
@@ -679,6 +736,139 @@ describe('attendance UUID route validation', () => {
 
     expect(db.query).not.toHaveBeenCalled()
     expect(db.transaction).not.toHaveBeenCalled()
+  })
+
+  it('lets full attendance admins add schedule group members without scheduler scopes', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params, true)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('pg_advisory_xact_lock')) return []
+      if (sql.includes('FROM attendance_schedule_group_members') && sql.includes('LIMIT 1')) return []
+      if (sql.includes('INSERT INTO attendance_schedule_group_members')) return [scheduleGroupMemberRow()]
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/schedule-groups/:id/members', {
+      params: { id: scheduleGroupId },
+      body: { userIds: ['worker-1'], effectiveFrom: '2026-06-01' },
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({ ok: true, data: { items: [{ userId: 'worker-1' }] } })
+    expect(db.query).not.toHaveBeenCalledWith(expect.stringContaining('FROM attendance_scheduler_scopes'), expect.anything())
+    expect(db.transaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('lets scoped non-admin schedulers add members inside their scheduler scope', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeRow()]
+      if (sql.includes('pg_advisory_xact_lock')) return []
+      if (sql.includes('FROM attendance_schedule_group_members') && sql.includes('LIMIT 1')) return []
+      if (sql.includes('INSERT INTO attendance_schedule_group_members')) return [scheduleGroupMemberRow()]
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/schedule-groups/:id/members', {
+      params: { id: scheduleGroupId },
+      body: { userIds: ['worker-1'], effectiveFrom: '2026-06-01' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({ ok: true, data: { items: [{ userId: 'worker-1' }] } })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM attendance_scheduler_scopes'),
+      ['default', 'scheduler-1', [], []],
+    )
+    expect(db.transaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects member dispatch outside scheduler scope and does not write', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) {
+        return [schedulerScopeRow({ scope: { scheduleGroupIds: [scheduleGroupId], userIds: ['someone-else'] } })]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/schedule-groups/:id/members', {
+      params: { id: scheduleGroupId },
+      body: { userIds: ['worker-1'], effectiveFrom: '2026-06-01' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
+    expect(db.transaction).not.toHaveBeenCalled()
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('INSERT INTO attendance_schedule_group_members'))).toBe(false)
+  })
+
+  it('checks existing member targets before scoped scheduler deletes', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('SELECT user_id') && sql.includes('FROM attendance_schedule_group_members')) {
+        return [{ user_id: 'worker-1' }]
+      }
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) {
+        return [schedulerScopeRow({ scope: { scheduleGroupIds: [scheduleGroupId], userIds: ['someone-else'] } })]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'DELETE /api/attendance/schedule-groups/:id/members/:memberId', {
+      params: { id: scheduleGroupId, memberId: scheduleGroupMemberId },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('DELETE FROM attendance_schedule_group_members'))).toBe(false)
+  })
+
+  it('lets scoped non-admin schedulers delete members inside their scheduler scope', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('SELECT user_id') && sql.includes('FROM attendance_schedule_group_members')) {
+        return [{ user_id: 'worker-1' }]
+      }
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeRow()]
+      if (sql.includes('DELETE FROM attendance_schedule_group_members')) return [{ id: scheduleGroupMemberId }]
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'DELETE /api/attendance/schedule-groups/:id/members/:memberId', {
+      params: { id: scheduleGroupId, memberId: scheduleGroupMemberId },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({ ok: true, data: { id: scheduleGroupMemberId } })
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('DELETE FROM attendance_schedule_group_members'))).toBe(true)
   })
 
   it('does not relabel handler failures as permission check failures', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -7627,6 +7627,43 @@ function attendanceSchedulerScopeMatchesTarget(scopeRow, target) {
   return true
 }
 
+function normalizeAttendanceSchedulerScopeRef(value) {
+  return String(value ?? '').trim()
+}
+
+function attendanceSchedulerScopeActorRefs(actorContext) {
+  const roles = sortedUnique([
+    ...ensureStringArray(actorContext?.role),
+    ...ensureStringArray(actorContext?.roles),
+  ].map(normalizeAttendanceSchedulerScopeRef).filter(Boolean))
+  const roleTags = sortedUnique(ensureStringArray(actorContext?.roleTags)
+    .map(normalizeAttendanceSchedulerScopeRef)
+    .filter(Boolean))
+  return {
+    userId: normalizeAttendanceSchedulerScopeRef(actorContext?.userId),
+    roles,
+    roleTags,
+  }
+}
+
+function attendanceSchedulerScopeMatchesActor(scopeRow, actorContext) {
+  const subjectType = scopeRow?.subjectType ?? scopeRow?.subject_type
+  const subjectRef = normalizeAttendanceSchedulerScopeRef(scopeRow?.subjectRef ?? scopeRow?.subject_ref)
+  if (!subjectType || !subjectRef) return false
+  const actor = attendanceSchedulerScopeActorRefs(actorContext)
+  if (subjectType === 'user') return actor.userId === subjectRef
+  if (subjectType === 'role') return actor.roles.includes(subjectRef)
+  if (subjectType === 'role_tag') return actor.roleTags.includes(subjectRef)
+  return false
+}
+
+function attendanceSchedulerScopeAllowsActorActionTarget(scopeRow, actorContext, action, target) {
+  if (!scopeRow || scopeRow.isActive === false || scopeRow.is_active === false) return false
+  if (!attendanceSchedulerScopeMatchesActor(scopeRow, actorContext)) return false
+  if (!normalizeStringArray(scopeRow.actions).includes(action)) return false
+  return attendanceSchedulerScopeMatchesTarget(scopeRow, target)
+}
+
 function countBy(items, resolveKey) {
   const counts = new Map()
   for (const item of Array.isArray(items) ? items : []) {
@@ -15132,6 +15169,8 @@ module.exports = {
     normalizeAttendanceSchedulerScopeInput,
     mapAttendanceSchedulerScopeRow,
     attendanceSchedulerScopeMatchesTarget,
+    attendanceSchedulerScopeMatchesActor,
+    attendanceSchedulerScopeAllowsActorActionTarget,
     matchScopeFilters,
     loadAttendanceScopeContextForUser,
     loadAttendanceScopeContextMapForUsers,
@@ -15167,6 +15206,81 @@ module.exports = {
         [orgId, groupId, userId]
       )
       return rows.length > 0
+    }
+
+    function respondAttendanceSchedulerScopeForbidden(res) {
+      res.status(403).json({
+        ok: false,
+        error: {
+          code: 'SCHEDULER_SCOPE_FORBIDDEN',
+          message: 'Scheduler scope does not allow this attendance scheduling action',
+        },
+      })
+    }
+
+    async function resolveAttendanceSchedulerScopeActor(req, res) {
+      const userId = getUserId(req)
+      if (!userId) {
+        res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
+        return null
+      }
+      const orgId = getOrgId(req)
+      try {
+        const fullAdmin = await hasAttendanceAdminAccess(userId)
+        return { userId, orgId, fullAdmin }
+      } catch (error) {
+        logger.error('Attendance scheduler scope actor resolution failed', error)
+        res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Permission check failed' } })
+        return null
+      }
+    }
+
+    async function loadActiveAttendanceSchedulerScopesForActor(orgId, actorContext) {
+      const actor = attendanceSchedulerScopeActorRefs(actorContext)
+      const rows = await db.query(
+        `SELECT *
+         FROM attendance_scheduler_scopes
+         WHERE org_id = $1
+           AND is_active = true
+           AND (
+             (subject_type = 'user' AND subject_ref = $2)
+             OR (subject_type = 'role' AND subject_ref = ANY($3::text[]))
+             OR (subject_type = 'role_tag' AND subject_ref = ANY($4::text[]))
+           )
+         ORDER BY updated_at DESC NULLS LAST, created_at DESC NULLS LAST`,
+        [orgId, actor.userId, actor.roles, actor.roleTags]
+      )
+      return rows.map(mapAttendanceSchedulerScopeRow)
+    }
+
+    async function assertAttendanceSchedulerScopeAllowed(req, res, { action, target, actorAccess } = {}) {
+      const access = actorAccess ?? await resolveAttendanceSchedulerScopeActor(req, res)
+      if (!access) return null
+      if (access.fullAdmin) return access
+
+      try {
+        const actorContext = await loadAttendanceScopeContextForUser(db, access.orgId, access.userId)
+        const scopes = await loadActiveAttendanceSchedulerScopesForActor(access.orgId, actorContext)
+        const allowed = scopes.some((scope) => attendanceSchedulerScopeAllowsActorActionTarget(
+          scope,
+          actorContext,
+          action,
+          target
+        ))
+        if (!allowed) {
+          respondAttendanceSchedulerScopeForbidden(res)
+          return null
+        }
+        return access
+      } catch (error) {
+        if (isDatabaseSchemaError(error)) {
+          res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+          return null
+        }
+        logger.error('Attendance scheduler scope guard failed', error)
+        res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Scheduler scope check failed' } })
+        return null
+      }
     }
 
     function withAttendanceGroupMemberAccess(handler) {
@@ -27404,14 +27518,13 @@ module.exports = {
     context.api.http.addRoute(
       'POST',
       '/api/attendance/schedule-groups/:id/members',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const parsed = scheduleGroupMemberSchema.safeParse(req.body ?? {})
         if (!parsed.success) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
           return
         }
         const orgId = getOrgId(req)
-        const actorId = getUserId(req)
         const groupId = normalizeUuidString(req.params.id)
         if (!groupId) {
           respondInvalidUuid(res)
@@ -27427,6 +27540,12 @@ module.exports = {
           }
           throw error
         }
+        const access = await assertAttendanceSchedulerScopeAllowed(req, res, {
+          action: 'dispatch',
+          target: { scheduleGroupIds: [groupId], userIds: input.userIds },
+        })
+        if (!access) return
+        const actorId = access.userId
         try {
           const created = []
           await db.transaction(async (trx) => {
@@ -27475,13 +27594,13 @@ module.exports = {
           logger.error('Attendance schedule group member create failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to add schedule group members' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(
       'DELETE',
       '/api/attendance/schedule-groups/:id/members/:memberId',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const orgId = getOrgId(req)
         const groupId = normalizeUuidString(req.params.id)
         const memberId = normalizeUuidString(req.params.memberId)
@@ -27493,7 +27612,30 @@ module.exports = {
           respondInvalidUuid(res, 'memberId')
           return
         }
+        const actorAccess = await resolveAttendanceSchedulerScopeActor(req, res)
+        if (!actorAccess) return
         try {
+          const existingRows = await db.query(
+            `SELECT user_id
+             FROM attendance_schedule_group_members
+             WHERE id = $1 AND org_id = $2 AND schedule_group_id = $3
+             LIMIT 1`,
+            [memberId, orgId, groupId]
+          )
+          if (!existingRows.length) {
+            if (!actorAccess.fullAdmin) {
+              respondAttendanceSchedulerScopeForbidden(res)
+              return
+            }
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Schedule group member not found' } })
+            return
+          }
+          const access = await assertAttendanceSchedulerScopeAllowed(req, res, {
+            action: 'dispatch',
+            target: { scheduleGroupIds: [groupId], userIds: [existingRows[0].user_id] },
+            actorAccess,
+          })
+          if (!access) return
           const rows = await db.query(
             `DELETE FROM attendance_schedule_group_members
              WHERE id = $1 AND org_id = $2 AND schedule_group_id = $3
@@ -27513,7 +27655,7 @@ module.exports = {
           logger.error('Attendance schedule group member delete failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to remove schedule group member' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(


### PR DESCRIPTION
## Summary
- add an attendance-local scheduler scope guard that composes actor subject, action, and target checks without changing central RBAC
- enable scoped non-admin dispatch only for schedule group member POST/DELETE; full admins still bypass scope
- return 403 SCHEDULER_SCOPE_FORBIDDEN for out-of-scope dispatch and avoid writes on denied requests

## Scope lock
- E1 only: /api/attendance/schedule-groups/:id/members POST and DELETE
- no assignment, rotation assignment, import, approval, report/payroll, or read-filter enforcement in this PR

## Verification
- node --check plugins/plugin-attendance/index.cjs
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-advanced-scheduling-scope.test.ts tests/unit/attendance-uuid-validation-routes.test.ts --watch=false
- pnpm --filter @metasheet/core-backend test:unit (201 files / 2579 tests)
- pnpm --filter @metasheet/core-backend build