### PR TITLE
fix(multitable): gate dashboard chart routes

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -160,7 +160,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + automation retry provenance)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + dashboard authz + automation retry provenance)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -176,6 +176,7 @@ jobs:
             tests/integration/multitable-viewconfig-filter-literal-redaction.test.ts \
             tests/integration/multitable-viewconfig-resave-guard.test.ts \
             tests/integration/multitable-records-list-authz.test.ts \
+            tests/integration/multitable-dashboard-chart-authz.test.ts \
             tests/integration/multitable-automation-retry.test.ts \
             tests/integration/multitable-automation-jobs.test.ts \
             --reporter=dot

--- a/docs/development/multitable-dashboard-chart-authz-verification-20260530.md
+++ b/docs/development/multitable-dashboard-chart-authz-verification-20260530.md
@@ -1,0 +1,99 @@
+# Multitable Dashboard / Chart Authz Verification (F0b)
+
+Date: 2026-05-30
+
+Design lock: `docs/development/multitable-dashboard-chart-authz-design-20260530.md` (#2125).
+
+## Scope
+
+F0b gates the dashboard/chart module's 11 endpoints:
+
+- Chart config reads require sheet `canRead`; chart config writes require `canManageViews`.
+- Dashboard reads require sheet `canRead`; dashboard writes require `canManageViews`.
+- `GET /sheets/:sheetId/charts/:id/data` also applies the layer-2 ∧ layer-3 field-read composite to chart field references and returns a restricted empty chart result if a referenced field is not readable.
+
+Out of scope: a new dashboard-specific capability, ownership semantics, central RBAC/auth changes, and wiring a production record provider for chart aggregation.
+
+## Fail-First Evidence
+
+Ran against a fresh local Postgres database migrated with the CI migration exclude list.
+
+Command:
+
+```bash
+DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_f0b_test_79225 \
+  pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts \
+  run tests/integration/multitable-dashboard-chart-authz.test.ts --reporter=dot
+```
+
+Origin behavior before the fix:
+
+- `R1` non-reader chart list: `200`, expected `403`.
+- `R2` non-reader chart get: `200`, expected `403`.
+- `R3` non-reader chart data: `200`, expected `403`.
+- `R4` reader chart create: `201`, expected `403`.
+- `R5` non-reader dashboard list: `200`, expected `403`.
+- `R8` denied chart data: canary label present, expected restricted empty result.
+
+Summary: `6 failed | 3 passed`.
+
+## Post-Fix Verification
+
+Same command after implementation:
+
+```text
+Test Files 1 passed (1)
+Tests 9 passed (9)
+```
+
+Additional local regression checks:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/dashboard-routes-wiring.test.ts --reporter=dot
+```
+
+Result: `7 passed`.
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run \
+  tests/unit/dashboard-routes-wiring.test.ts \
+  tests/unit/chart-dashboard.test.ts --reporter=dot
+```
+
+Result: `56 passed`.
+
+```bash
+DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_f0b_test_79225 \
+  pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts \
+  run tests/integration/multitable-dashboard-chart-authz.test.ts \
+      tests/integration/multitable-view-aggregate.test.ts \
+      tests/integration/multitable-records-read-field-mask.test.ts \
+      tests/integration/multitable-records-list-authz.test.ts \
+  --reporter=dot
+```
+
+Result: `42 passed`.
+
+```bash
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm validate:plugins
+```
+
+Result: both clean (`validate:plugins` reports existing manifest warnings only; zero errors).
+
+## CI Wiring
+
+`.github/workflows/plugin-tests.yml` now includes:
+
+```text
+tests/integration/multitable-dashboard-chart-authz.test.ts
+```
+
+under the Node 20 real-DB multitable integration step, so the F0b real-DB tests run in CI and cannot silently skip when `DATABASE_URL` is available.
+
+## Follow-Ups
+
+`metadata.restricted=true` is intentionally returned by the backend. A frontend render affordance for restricted chart data is not included in this backend slice and should be handled as a small UI follow-up if product wants an explicit restricted-state display.

--- a/packages/core-backend/src/multitable/chart-aggregation-service.ts
+++ b/packages/core-backend/src/multitable/chart-aggregation-service.ts
@@ -23,6 +23,7 @@ export interface ChartData {
     groupByField?: string
     aggregationFunction?: string
     recordCount?: number
+    restricted?: boolean
   }
 }
 

--- a/packages/core-backend/src/routes/dashboard.ts
+++ b/packages/core-backend/src/routes/dashboard.ts
@@ -27,7 +27,20 @@
 
 import type { Request, Response } from 'express'
 import { Router } from 'express'
+import { poolManager } from '../integration/db/connection-pool'
+import type { MultitableCapabilities } from '../multitable/access'
+import type { ChartConfig } from '../multitable/charts'
+import type { ChartData } from '../multitable/chart-aggregation-service'
 import { DashboardService } from '../multitable/dashboard-service'
+import type { MultitableField } from '../multitable/field-codecs'
+import { loadFieldsForSheet } from '../multitable/loaders'
+import { deriveFieldPermissions, isFieldPermissionHidden } from '../multitable/permission-derivation'
+import {
+  loadFieldPermissionScopeMap,
+  resolveSheetCapabilities,
+  resolveSheetReadableCapabilities,
+  type QueryFn,
+} from '../multitable/permission-service'
 
 const dashboardService = new DashboardService()
 
@@ -42,6 +55,125 @@ function getUserId(req: Request): string {
   return raw ? String(raw) : 'anonymous'
 }
 
+function getQuery(): QueryFn {
+  const pool = poolManager.get()
+  return pool.query.bind(pool) as QueryFn
+}
+
+function sendUnauthorized(res: Response): void {
+  res.status(401).json({
+    error: {
+      code: 'UNAUTHORIZED',
+      message: 'Authentication required',
+    },
+  })
+}
+
+function sendForbidden(res: Response): void {
+  res.status(403).json({
+    error: {
+      code: 'FORBIDDEN',
+      message: 'Forbidden',
+    },
+  })
+}
+
+type SheetAuthContext = {
+  query: QueryFn
+  userId: string
+  capabilities: MultitableCapabilities
+}
+
+async function requireSheetRead(
+  req: Request,
+  res: Response,
+  sheetId: string,
+): Promise<SheetAuthContext | null> {
+  const query = getQuery()
+  const { access, capabilities } = await resolveSheetReadableCapabilities(req, query, sheetId)
+  if (!access.userId) {
+    sendUnauthorized(res)
+    return null
+  }
+  if (!capabilities.canRead) {
+    sendForbidden(res)
+    return null
+  }
+  return { query, userId: access.userId, capabilities }
+}
+
+async function requireSheetManageViews(
+  req: Request,
+  res: Response,
+  sheetId: string,
+): Promise<SheetAuthContext | null> {
+  const query = getQuery()
+  const { access, capabilities } = await resolveSheetCapabilities(req, query, sheetId)
+  if (!access.userId) {
+    sendUnauthorized(res)
+    return null
+  }
+  if (!capabilities.canManageViews) {
+    sendForbidden(res)
+    return null
+  }
+  return { query, userId: access.userId, capabilities }
+}
+
+function filterVisiblePropertyFields(fields: MultitableField[]): MultitableField[] {
+  return fields.filter((field) => !isFieldPermissionHidden(field))
+}
+
+async function loadAllowedFieldIds(
+  query: QueryFn,
+  sheetId: string,
+  userId: string,
+  capabilities: MultitableCapabilities,
+): Promise<Set<string>> {
+  const [fields, fieldScopeMap] = await Promise.all([
+    loadFieldsForSheet(query, sheetId),
+    loadFieldPermissionScopeMap(query, sheetId, userId),
+  ])
+  const visibleFields = filterVisiblePropertyFields(fields)
+  const fieldPermissions = deriveFieldPermissions(visibleFields, capabilities, {
+    hiddenFieldIds: [],
+    fieldScopeMap,
+  })
+  return new Set(
+    visibleFields
+      .filter((field) => fieldPermissions[field.id]?.visible !== false)
+      .map((field) => field.id),
+  )
+}
+
+function chartReferencedFieldIds(chart: ChartConfig): string[] {
+  const source = chart.dataSource
+  const ids = [
+    source.aggregation.fieldId,
+    source.groupByFieldId,
+    source.dateFieldId,
+    source.filterFieldId,
+  ]
+  return ids.filter((id): id is string => typeof id === 'string' && id.length > 0)
+}
+
+function isChartDataRestricted(chart: ChartConfig, allowedFieldIds: Set<string>): boolean {
+  return chartReferencedFieldIds(chart).some((fieldId) => !allowedFieldIds.has(fieldId))
+}
+
+function restrictedChartData(chart: ChartConfig): ChartData {
+  return {
+    chartId: chart.id,
+    chartType: chart.type,
+    dataPoints: [],
+    total: 0,
+    metadata: {
+      restricted: true,
+      recordCount: 0,
+    },
+  }
+}
+
 export function dashboardRouter() {
   const router = Router()
 
@@ -52,6 +184,8 @@ export function dashboardRouter() {
   /** GET /api/multitable/sheets/:sheetId/charts — list charts */
   router.get('/sheets/:sheetId/charts', async (req: Request, res: Response) => {
     try {
+      const auth = await requireSheetRead(req, res, req.params.sheetId)
+      if (!auth) return
       const charts = await dashboardService.listCharts(req.params.sheetId)
       res.json({ charts })
     } catch (err: unknown) {
@@ -62,6 +196,8 @@ export function dashboardRouter() {
   /** POST /api/multitable/sheets/:sheetId/charts — create chart */
   router.post('/sheets/:sheetId/charts', async (req: Request, res: Response) => {
     try {
+      const auth = await requireSheetManageViews(req, res, req.params.sheetId)
+      if (!auth) return
       const userId = getUserId(req)
       const chart = await dashboardService.createChart(req.params.sheetId, {
         ...req.body,
@@ -75,17 +211,25 @@ export function dashboardRouter() {
 
   /** GET /api/multitable/sheets/:sheetId/charts/:id — get chart config */
   router.get('/sheets/:sheetId/charts/:id', async (req: Request, res: Response) => {
-    const chart = await dashboardService.getChart(req.params.id)
-    if (!chart || chart.sheetId !== req.params.sheetId) {
-      res.status(404).json({ error: 'Chart not found' })
-      return
+    try {
+      const auth = await requireSheetRead(req, res, req.params.sheetId)
+      if (!auth) return
+      const chart = await dashboardService.getChart(req.params.id)
+      if (!chart || chart.sheetId !== req.params.sheetId) {
+        res.status(404).json({ error: 'Chart not found' })
+        return
+      }
+      res.json(chart)
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message })
     }
-    res.json(chart)
   })
 
   /** PATCH /api/multitable/sheets/:sheetId/charts/:id — update chart */
   router.patch('/sheets/:sheetId/charts/:id', async (req: Request, res: Response) => {
     try {
+      const auth = await requireSheetManageViews(req, res, req.params.sheetId)
+      if (!auth) return
       const chart = await dashboardService.getChart(req.params.id)
       if (!chart || chart.sheetId !== req.params.sheetId) {
         res.status(404).json({ error: 'Chart not found' })
@@ -100,21 +244,39 @@ export function dashboardRouter() {
 
   /** DELETE /api/multitable/sheets/:sheetId/charts/:id — delete chart */
   router.delete('/sheets/:sheetId/charts/:id', async (req: Request, res: Response) => {
-    const chart = await dashboardService.getChart(req.params.id)
-    if (!chart || chart.sheetId !== req.params.sheetId) {
-      res.status(404).json({ error: 'Chart not found' })
-      return
+    try {
+      const auth = await requireSheetManageViews(req, res, req.params.sheetId)
+      if (!auth) return
+      const chart = await dashboardService.getChart(req.params.id)
+      if (!chart || chart.sheetId !== req.params.sheetId) {
+        res.status(404).json({ error: 'Chart not found' })
+        return
+      }
+      await dashboardService.deleteChart(req.params.id)
+      res.status(204).send()
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message })
     }
-    await dashboardService.deleteChart(req.params.id)
-    res.status(204).send()
   })
 
   /** GET /api/multitable/sheets/:sheetId/charts/:id/data — get computed chart data */
   router.get('/sheets/:sheetId/charts/:id/data', async (req: Request, res: Response) => {
     try {
+      const auth = await requireSheetRead(req, res, req.params.sheetId)
+      if (!auth) return
       const chart = await dashboardService.getChart(req.params.id)
       if (!chart || chart.sheetId !== req.params.sheetId) {
         res.status(404).json({ error: 'Chart not found' })
+        return
+      }
+      const allowedFieldIds = await loadAllowedFieldIds(
+        auth.query,
+        req.params.sheetId,
+        auth.userId,
+        auth.capabilities,
+      )
+      if (isChartDataRestricted(chart, allowedFieldIds)) {
+        res.json(restrictedChartData(chart))
         return
       }
       const data = await dashboardService.getChartData(req.params.id)
@@ -131,6 +293,8 @@ export function dashboardRouter() {
   /** GET /api/multitable/sheets/:sheetId/dashboards — list dashboards */
   router.get('/sheets/:sheetId/dashboards', async (req: Request, res: Response) => {
     try {
+      const auth = await requireSheetRead(req, res, req.params.sheetId)
+      if (!auth) return
       const dashboards = await dashboardService.listDashboards(req.params.sheetId)
       res.json({ dashboards })
     } catch (err: unknown) {
@@ -141,6 +305,8 @@ export function dashboardRouter() {
   /** POST /api/multitable/sheets/:sheetId/dashboards — create dashboard */
   router.post('/sheets/:sheetId/dashboards', async (req: Request, res: Response) => {
     try {
+      const auth = await requireSheetManageViews(req, res, req.params.sheetId)
+      if (!auth) return
       const userId = getUserId(req)
       const dashboard = await dashboardService.createDashboard({
         name: req.body.name,
@@ -155,17 +321,25 @@ export function dashboardRouter() {
 
   /** GET /api/multitable/sheets/:sheetId/dashboards/:id — get dashboard */
   router.get('/sheets/:sheetId/dashboards/:id', async (req: Request, res: Response) => {
-    const dashboard = await dashboardService.getDashboard(req.params.id)
-    if (!dashboard || dashboard.sheetId !== req.params.sheetId) {
-      res.status(404).json({ error: 'Dashboard not found' })
-      return
+    try {
+      const auth = await requireSheetRead(req, res, req.params.sheetId)
+      if (!auth) return
+      const dashboard = await dashboardService.getDashboard(req.params.id)
+      if (!dashboard || dashboard.sheetId !== req.params.sheetId) {
+        res.status(404).json({ error: 'Dashboard not found' })
+        return
+      }
+      res.json(dashboard)
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message })
     }
-    res.json(dashboard)
   })
 
   /** PATCH /api/multitable/sheets/:sheetId/dashboards/:id — update dashboard */
   router.patch('/sheets/:sheetId/dashboards/:id', async (req: Request, res: Response) => {
     try {
+      const auth = await requireSheetManageViews(req, res, req.params.sheetId)
+      if (!auth) return
       const dashboard = await dashboardService.getDashboard(req.params.id)
       if (!dashboard || dashboard.sheetId !== req.params.sheetId) {
         res.status(404).json({ error: 'Dashboard not found' })
@@ -180,13 +354,19 @@ export function dashboardRouter() {
 
   /** DELETE /api/multitable/sheets/:sheetId/dashboards/:id — delete dashboard */
   router.delete('/sheets/:sheetId/dashboards/:id', async (req: Request, res: Response) => {
-    const dashboard = await dashboardService.getDashboard(req.params.id)
-    if (!dashboard || dashboard.sheetId !== req.params.sheetId) {
-      res.status(404).json({ error: 'Dashboard not found' })
-      return
+    try {
+      const auth = await requireSheetManageViews(req, res, req.params.sheetId)
+      if (!auth) return
+      const dashboard = await dashboardService.getDashboard(req.params.id)
+      if (!dashboard || dashboard.sheetId !== req.params.sheetId) {
+        res.status(404).json({ error: 'Dashboard not found' })
+        return
+      }
+      await dashboardService.deleteDashboard(req.params.id)
+      res.status(204).send()
+    } catch (err: unknown) {
+      res.status(500).json({ error: (err as Error).message })
     }
-    await dashboardService.deleteDashboard(req.params.id)
-    res.status(204).send()
   })
 
   return router

--- a/packages/core-backend/src/routes/dashboard.ts
+++ b/packages/core-backend/src/routes/dashboard.ts
@@ -49,12 +49,6 @@ export function getDashboardService(): DashboardService {
   return dashboardService
 }
 
-function getUserId(req: Request): string {
-  const user = (req as unknown as { user?: { id?: unknown } }).user
-  const raw = user?.id ?? req.headers['x-user-id']
-  return raw ? String(raw) : 'anonymous'
-}
-
 function getQuery(): QueryFn {
   const pool = poolManager.get()
   return pool.query.bind(pool) as QueryFn
@@ -198,10 +192,9 @@ export function dashboardRouter() {
     try {
       const auth = await requireSheetManageViews(req, res, req.params.sheetId)
       if (!auth) return
-      const userId = getUserId(req)
       const chart = await dashboardService.createChart(req.params.sheetId, {
         ...req.body,
-        createdBy: userId,
+        createdBy: auth.userId,
       })
       res.status(201).json(chart)
     } catch (err: unknown) {
@@ -307,11 +300,10 @@ export function dashboardRouter() {
     try {
       const auth = await requireSheetManageViews(req, res, req.params.sheetId)
       if (!auth) return
-      const userId = getUserId(req)
       const dashboard = await dashboardService.createDashboard({
         name: req.body.name,
         sheetId: req.params.sheetId,
-        createdBy: userId,
+        createdBy: auth.userId,
       })
       res.status(201).json(dashboard)
     } catch (err: unknown) {

--- a/packages/core-backend/tests/integration/multitable-dashboard-chart-authz.test.ts
+++ b/packages/core-backend/tests/integration/multitable-dashboard-chart-authz.test.ts
@@ -1,0 +1,263 @@
+/**
+ * Real-DB integration test for F0b — dashboard/chart route sheet authz + chart-data field mask.
+ * Design-lock: docs/development/multitable-dashboard-chart-authz-design-20260530.md (#2125).
+ *
+ * F0b closes the dashboard/chart counterpart of F0a: dashboard/chart config routes must enforce
+ * sheet canRead / canManageViews, and chart data must withhold output when the chart references a
+ * field the requester cannot read. The value-leak side is forward-defense: production chart data
+ * still has no real record provider, but the test injects one so future provider wiring cannot land
+ * without the mask.
+ *
+ * Seed non-negotiable: FLD_SECRET.property = {} (property.hidden UNSET) so the deny is SOLELY
+ * layer-3 (field_permissions.visible=false). If it were also static-hidden, layer-2 would prove
+ * the wrong thing.
+ *
+ * Runs only with DATABASE_URL (describeIfDatabase + a sentinel test so it fails-not-skips in CI).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { dashboardRouter, getDashboardService } from '../../src/routes/dashboard'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_f0b_${TS}`
+const SHEET_ID = `sheet_f0b_${TS}`
+const FLD_VISIBLE = `fld_f0b_visible_${TS}`
+const FLD_SECRET = `fld_f0b_secret_${TS}`
+const CHART_ID = `chart_f0b_visible_${TS}`
+const CHART_SECRET_ID = `chart_f0b_secret_${TS}`
+const DASHBOARD_ID = `dash_f0b_${TS}`
+const USER_ID = `u_f0b_reader_${TS}`
+const USER_ID_DENIED = `u_f0b_denied_${TS}`
+const MANAGER_ID = `u_f0b_manager_${TS}`
+const SECRET_CANARY = 'do-not-leak-dashboard-canary'
+
+let app: Express
+let testUserId = USER_ID
+let testPerms: string[] = ['multitable:read']
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const asJson = (value: unknown) => JSON.stringify(value)
+
+function installUser(req: express.Request, _res: express.Response, next: express.NextFunction) {
+  ;(req as any).user = testUserId ? { id: testUserId, roles: [], perms: testPerms } : undefined
+  next()
+}
+
+function chartPayload(name = 'Created Chart') {
+  return {
+    name,
+    type: 'bar',
+    dataSource: {
+      groupByFieldId: FLD_VISIBLE,
+      aggregation: { function: 'count' },
+    },
+    display: {},
+  }
+}
+
+async function insertChart(id: string, dataSource: Record<string, unknown> = {
+  groupByFieldId: FLD_VISIBLE,
+  aggregation: { function: 'count' },
+}) {
+  await q(
+    `INSERT INTO multitable_charts (id, name, type, sheet_id, data_source, display, created_by)
+     VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7)
+     ON CONFLICT (id) DO NOTHING`,
+    [id, `Chart ${id}`, 'bar', SHEET_ID, asJson(dataSource), '{}', MANAGER_ID],
+  )
+}
+
+async function insertDashboard(id: string) {
+  await q(
+    `INSERT INTO multitable_dashboards (id, name, sheet_id, panels, created_by)
+     VALUES ($1,$2,$3,$4::jsonb,$5)
+     ON CONFLICT (id) DO NOTHING`,
+    [id, `Dashboard ${id}`, SHEET_ID, asJson([{ id: `panel_${id}`, chartId: CHART_ID, x: 0, y: 0, w: 4, h: 4 }]), MANAGER_ID],
+  )
+}
+
+const chartList = () => request(app).get(`/api/multitable/sheets/${SHEET_ID}/charts`)
+const chartGet = (id = CHART_ID) => request(app).get(`/api/multitable/sheets/${SHEET_ID}/charts/${id}`)
+const chartData = (id = CHART_ID) => request(app).get(`/api/multitable/sheets/${SHEET_ID}/charts/${id}/data`)
+const dashboardList = () => request(app).get(`/api/multitable/sheets/${SHEET_ID}/dashboards`)
+const dashboardGet = (id = DASHBOARD_ID) => request(app).get(`/api/multitable/sheets/${SHEET_ID}/dashboards/${id}`)
+
+describeIfDatabase('F0b dashboard/chart authz + chart-data mask (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use(installUser)
+    app.use('/api/multitable', dashboardRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'F0b Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'F0b Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_VISIBLE, SHEET_ID, 'Visible', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRET, SHEET_ID, 'Secret', 'string', '{}', 2])
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER_ID_DENIED, false, false])
+
+    await insertChart(CHART_ID)
+    await insertChart(CHART_SECRET_ID, {
+      groupByFieldId: FLD_SECRET,
+      aggregation: { function: 'count' },
+    })
+    await insertDashboard(DASHBOARD_ID)
+  })
+
+  beforeEach(() => {
+    testUserId = USER_ID
+    testPerms = ['multitable:read']
+    getDashboardService().setRecordProvider(async () => [])
+  })
+
+  afterAll(async () => {
+    getDashboardService().setRecordProvider(async () => [])
+    await q('DELETE FROM multitable_dashboards WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM multitable_charts WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('R1: non-reader cannot list chart configs', async () => {
+    testPerms = []
+    const res = await chartList()
+    expect(res.status).toBe(403)
+    expect(JSON.stringify(res.body)).not.toContain(CHART_ID)
+  })
+
+  test('R2: non-reader cannot get an individual chart config', async () => {
+    testPerms = []
+    const res = await chartGet()
+    expect(res.status).toBe(403)
+    expect(JSON.stringify(res.body)).not.toContain(CHART_ID)
+  })
+
+  test('R3: non-reader cannot get chart data', async () => {
+    testPerms = []
+    const res = await chartData()
+    expect(res.status).toBe(403)
+    expect(JSON.stringify(res.body)).not.toContain('dataPoints')
+  })
+
+  test('R4: reader without canManageViews cannot create, update, or delete charts', async () => {
+    const deleteId = `chart_f0b_delete_denied_${TS}`
+    await insertChart(deleteId)
+
+    const create = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/charts`)
+      .send(chartPayload('Denied Create'))
+    expect(create.status).toBe(403)
+
+    const update = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/charts/${CHART_ID}`)
+      .send({ name: 'Denied Update' })
+    expect(update.status).toBe(403)
+
+    const del = await request(app).delete(`/api/multitable/sheets/${SHEET_ID}/charts/${deleteId}`)
+    expect(del.status).toBe(403)
+  })
+
+  test('R5: non-reader cannot read or manage dashboards', async () => {
+    testPerms = []
+    const deleteId = `dash_f0b_delete_denied_${TS}`
+    await insertDashboard(deleteId)
+
+    expect((await dashboardList()).status).toBe(403)
+    expect((await dashboardGet()).status).toBe(403)
+    expect((await request(app).post(`/api/multitable/sheets/${SHEET_ID}/dashboards`).send({ name: 'Denied' })).status).toBe(403)
+    expect((await request(app).patch(`/api/multitable/sheets/${SHEET_ID}/dashboards/${DASHBOARD_ID}`).send({ name: 'Denied' })).status).toBe(403)
+    expect((await request(app).delete(`/api/multitable/sheets/${SHEET_ID}/dashboards/${deleteId}`)).status).toBe(403)
+  })
+
+  test('R6: a sheet reader can list/get charts, get chart data, and list/get dashboards', async () => {
+    const charts = await chartList()
+    expect(charts.status).toBe(200)
+    expect(charts.body.charts.some((chart: { id?: string }) => chart.id === CHART_ID)).toBe(true)
+
+    expect((await chartGet()).status).toBe(200)
+
+    const data = await chartData()
+    expect(data.status).toBe(200)
+    expect(Array.isArray(data.body.dataPoints)).toBe(true)
+    expect(data.body.metadata?.restricted).toBeUndefined()
+
+    const dashboards = await dashboardList()
+    expect(dashboards.status).toBe(200)
+    expect(dashboards.body.dashboards.some((dashboard: { id?: string }) => dashboard.id === DASHBOARD_ID)).toBe(true)
+    expect((await dashboardGet()).status).toBe(200)
+  })
+
+  test('R7: a canManageViews user can create, update, and delete charts and dashboards', async () => {
+    testUserId = MANAGER_ID
+    testPerms = ['multitable:write']
+
+    const createChart = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/charts`)
+      .send(chartPayload('Manager Create'))
+    expect(createChart.status).toBe(201)
+    const createdChartId = createChart.body.id as string
+
+    const updateChart = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/charts/${createdChartId}`)
+      .send({ name: 'Manager Update' })
+    expect(updateChart.status).toBe(200)
+    expect(updateChart.body.name).toBe('Manager Update')
+
+    expect((await request(app).delete(`/api/multitable/sheets/${SHEET_ID}/charts/${createdChartId}`)).status).toBe(204)
+
+    const createDashboard = await request(app)
+      .post(`/api/multitable/sheets/${SHEET_ID}/dashboards`)
+      .send({ name: 'Manager Dashboard' })
+    expect(createDashboard.status).toBe(201)
+    const createdDashboardId = createDashboard.body.id as string
+
+    const updateDashboard = await request(app)
+      .patch(`/api/multitable/sheets/${SHEET_ID}/dashboards/${createdDashboardId}`)
+      .send({ name: 'Manager Dashboard Updated' })
+    expect(updateDashboard.status).toBe(200)
+    expect(updateDashboard.body.name).toBe('Manager Dashboard Updated')
+
+    expect((await request(app).delete(`/api/multitable/sheets/${SHEET_ID}/dashboards/${createdDashboardId}`)).status).toBe(204)
+  })
+
+  test('R8: chart data withholds a denied referenced field while proving the injected provider can leak it for an allowed user', async () => {
+    getDashboardService().setRecordProvider(async (sheetId: string) => {
+      if (sheetId !== SHEET_ID) return []
+      return [
+        { data: { [FLD_VISIBLE]: 'visible bucket', [FLD_SECRET]: SECRET_CANARY } },
+      ]
+    })
+
+    testUserId = USER_ID
+    testPerms = ['multitable:read']
+    const allowed = await chartData(CHART_SECRET_ID)
+    expect(allowed.status).toBe(200)
+    expect(JSON.stringify(allowed.body)).toContain(SECRET_CANARY)
+
+    testUserId = USER_ID_DENIED
+    testPerms = ['multitable:read']
+    const denied = await chartData(CHART_SECRET_ID)
+    expect(denied.status).toBe(200)
+    expect(denied.body).toMatchObject({
+      chartId: CHART_SECRET_ID,
+      chartType: 'bar',
+      dataPoints: [],
+      total: 0,
+      metadata: {
+        restricted: true,
+        recordCount: 0,
+      },
+    })
+    expect(JSON.stringify(denied.body)).not.toContain(SECRET_CANARY)
+  })
+})

--- a/packages/core-backend/tests/unit/dashboard-routes-wiring.test.ts
+++ b/packages/core-backend/tests/unit/dashboard-routes-wiring.test.ts
@@ -109,7 +109,7 @@ describe('dashboardRouter HTTP mounting', () => {
   })
 
   it('POST /api/multitable/sheets/:sheetId/charts creates and returns a chart', async () => {
-    vi.spyOn(service, 'createChart').mockResolvedValue({
+    const createChart = vi.spyOn(service, 'createChart').mockResolvedValue({
       id: 'new-chart',
       sheetId: 'sheet-a',
       name: 'New',
@@ -123,6 +123,9 @@ describe('dashboardRouter HTTP mounting', () => {
       .expect(201)
 
     expect(res.body).toMatchObject({ id: 'new-chart', name: 'New', type: 'bar' })
+    expect(createChart).toHaveBeenCalledWith('sheet-a', expect.objectContaining({
+      createdBy: 'unit-user',
+    }))
   })
 
   it('GET /api/multitable/sheets/:sheetId/charts/:id/data returns the computed data', async () => {

--- a/packages/core-backend/tests/unit/dashboard-routes-wiring.test.ts
+++ b/packages/core-backend/tests/unit/dashboard-routes-wiring.test.ts
@@ -14,6 +14,53 @@ import express from 'express'
 import request from 'supertest'
 import { dashboardRouter, getDashboardService } from '../../src/routes/dashboard'
 
+vi.mock('../../src/integration/db/connection-pool', () => ({
+  poolManager: {
+    get: () => ({
+      getInternalPool: () => ({}),
+      query: vi.fn(),
+    }),
+  },
+}))
+
+vi.mock('../../src/multitable/loaders', () => ({
+  loadFieldsForSheet: vi.fn(async () => []),
+}))
+
+vi.mock('../../src/multitable/permission-service', () => ({
+  resolveSheetReadableCapabilities: vi.fn(async () => ({
+    access: { userId: 'unit-user' },
+    capabilities: {
+      canRead: true,
+      canCreateRecord: true,
+      canEditRecord: true,
+      canDeleteRecord: true,
+      canManageFields: true,
+      canManageSheetAccess: true,
+      canManageViews: true,
+      canComment: true,
+      canManageAutomation: true,
+      canExport: true,
+    },
+  })),
+  resolveSheetCapabilities: vi.fn(async () => ({
+    access: { userId: 'unit-user' },
+    capabilities: {
+      canRead: true,
+      canCreateRecord: true,
+      canEditRecord: true,
+      canDeleteRecord: true,
+      canManageFields: true,
+      canManageSheetAccess: true,
+      canManageViews: true,
+      canComment: true,
+      canManageAutomation: true,
+      canExport: true,
+    },
+  })),
+  loadFieldPermissionScopeMap: vi.fn(async () => new Map()),
+}))
+
 // Mount on a fresh app in the same way index.ts does.
 function buildApp() {
   const app = express()
@@ -80,7 +127,11 @@ describe('dashboardRouter HTTP mounting', () => {
 
   it('GET /api/multitable/sheets/:sheetId/charts/:id/data returns the computed data', async () => {
     vi.spyOn(service, 'getChart').mockResolvedValue({
-      id: 'chart-1', sheetId: 'sheet-a', name: 'c', type: 'bar',
+      id: 'chart-1',
+      sheetId: 'sheet-a',
+      name: 'c',
+      type: 'bar',
+      dataSource: { aggregation: { function: 'count' } },
     } as any)
     vi.spyOn(service, 'getChartData').mockResolvedValue({
       dataPoints: [{ label: 'A', value: 1 }],
@@ -95,7 +146,11 @@ describe('dashboardRouter HTTP mounting', () => {
 
   it('GET on a chart that belongs to a different sheet returns 404', async () => {
     vi.spyOn(service, 'getChart').mockResolvedValue({
-      id: 'chart-x', sheetId: 'sheet-OTHER', name: 'c', type: 'bar',
+      id: 'chart-x',
+      sheetId: 'sheet-OTHER',
+      name: 'c',
+      type: 'bar',
+      dataSource: { aggregation: { function: 'count' } },
     } as any)
 
     await request(buildApp())


### PR DESCRIPTION
## Summary

Implements F0b per the #2125 design-lock: dashboard/chart endpoints now enforce sheet-level permissions, and chart-data output is withheld when the chart references a field the requester cannot read.

- Read endpoints (`charts`, `charts/:id`, `charts/:id/data`, `dashboards`, `dashboards/:id`) require `canRead`.
- Manage endpoints (`POST/PATCH/DELETE` for charts and dashboards) require `canManageViews`.
- `GET /charts/:id/data` computes the layer-2 + layer-3 allowed field set and returns a restricted empty chart result when `aggregation.fieldId`, `groupByFieldId`, `dateFieldId`, or `filterFieldId` is denied.
- Wires the new real-DB integration test into the Node 20 plugin-tests multitable step.

## Fail-first

Against a fresh migrated local Postgres DB before the route fix, `multitable-dashboard-chart-authz.test.ts` went RED as expected:

- R1/R2/R3: non-reader chart list/get/data returned `200`, expected `403`.
- R4: reader chart create returned `201`, expected `403`.
- R5: non-reader dashboard list returned `200`, expected `403`.
- R8: denied chart data returned the injected canary label, expected `metadata.restricted=true` and no canary.

After the fix: `9/9` green.

## Verification

- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_f0b_test_79225 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-dashboard-chart-authz.test.ts tests/integration/multitable-view-aggregate.test.ts tests/integration/multitable-records-read-field-mask.test.ts tests/integration/multitable-records-list-authz.test.ts --reporter=dot` → 42 passed
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/dashboard-routes-wiring.test.ts tests/unit/chart-dashboard.test.ts --reporter=dot` → 56 passed
- `pnpm validate:plugins` → valid, existing manifest warnings only

## Notes

`metadata.restricted=true` is returned by the backend. Frontend restricted-state rendering is intentionally left as a small follow-up if product wants explicit UI beyond empty chart data.
