### PR TITLE
feat(attendance): enforce scheduler scope assignment dispatch

### DIFF
--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
@@ -49,6 +49,18 @@ describe('attendance advanced scheduling scope foundation', () => {
     expect(pluginSource).toMatch(
       /'DELETE',\s*\n\s*'\/api\/attendance\/schedule-groups\/:id\/members\/:memberId',\s*\n\s*async \(req, res\)/,
     )
+    const scopedDispatchRoutes = [
+      '/api/attendance/assignments',
+      '/api/attendance/assignments/:id',
+      '/api/attendance/rotation-assignments',
+      '/api/attendance/rotation-assignments/:id',
+    ]
+    scopedDispatchRoutes.forEach((path) => {
+      const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+      expect(pluginSource).toMatch(new RegExp(`['"]${escaped}['"],\\s*\\n\\s*async \\(req, res\\)`))
+    })
+    expect(pluginSource).toContain('resolveAttendanceScheduleAssignmentScopeTarget')
+    expect(pluginSource).toContain('assertAttendanceScheduleAssignmentDispatchAllowed')
   })
 
   it('normalizes schedule groups without overloading attendance_groups semantics', () => {

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -107,6 +107,10 @@ async function invokeRoute(
 
 const scheduleGroupId = '00000000-0000-4000-8000-000000000301'
 const scheduleGroupMemberId = '00000000-0000-4000-8000-000000000302'
+const shiftId = '00000000-0000-4000-8000-000000000303'
+const shiftAssignmentId = '00000000-0000-4000-8000-000000000304'
+const rotationRuleId = '00000000-0000-4000-8000-000000000305'
+const rotationAssignmentId = '00000000-0000-4000-8000-000000000306'
 
 function schedulerScopeRow(overrides: Record<string, unknown> = {}) {
   return {
@@ -142,6 +146,53 @@ function scheduleGroupMemberRow(overrides: Record<string, unknown> = {}) {
     source: 'manual',
     created_by: 'scheduler-1',
     updated_by: 'scheduler-1',
+    created_at: '2026-05-30T10:00:00.000Z',
+    updated_at: '2026-05-30T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function shiftRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: shiftId,
+    org_id: 'default',
+    name: 'Day Shift',
+    timezone: 'UTC',
+    work_start_time: '09:00',
+    work_end_time: '18:00',
+    is_overnight: false,
+    late_grace_minutes: 10,
+    early_grace_minutes: 10,
+    rounding_minutes: 5,
+    working_days: [1, 2, 3, 4, 5],
+    ...overrides,
+  }
+}
+
+function shiftAssignmentRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: shiftAssignmentId,
+    org_id: 'default',
+    user_id: 'worker-1',
+    shift_id: shiftId,
+    start_date: '2026-06-10',
+    end_date: null,
+    is_active: true,
+    created_at: '2026-05-30T10:00:00.000Z',
+    updated_at: '2026-05-30T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function rotationAssignmentRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: rotationAssignmentId,
+    org_id: 'default',
+    user_id: 'worker-1',
+    rotation_rule_id: rotationRuleId,
+    start_date: '2026-06-10',
+    end_date: null,
+    is_active: true,
     created_at: '2026-05-30T10:00:00.000Z',
     updated_at: '2026-05-30T10:00:00.000Z',
     ...overrides,
@@ -869,6 +920,143 @@ describe('attendance UUID route validation', () => {
     expect(res.statusCode).toBe(200)
     expect(res.body).toEqual({ ok: true, data: { id: scheduleGroupMemberId } })
     expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('DELETE FROM attendance_schedule_group_members'))).toBe(true)
+  })
+
+  it('lets full attendance admins create shift assignments without scheduler scopes', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params, true)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('SELECT * FROM attendance_shifts')) return [shiftRow()]
+      if (sql.includes('pg_advisory_xact_lock')) return []
+      if (sql.includes('FROM attendance_shift_assignments') && sql.includes('LIMIT 1')) return []
+      if (sql.includes('FROM attendance_rotation_assignments') && sql.includes('LIMIT 1')) return []
+      if (sql.includes('INSERT INTO attendance_shift_assignments')) return [shiftAssignmentRow()]
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/assignments', {
+      body: { userId: 'worker-1', shiftId, startDate: '2026-06-10' },
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(201)
+    expect(res.body).toMatchObject({ ok: true, data: { assignment: { userId: 'worker-1', shiftId } } })
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('SELECT DISTINCT m.schedule_group_id'))).toBe(false)
+    expect(db.query).not.toHaveBeenCalledWith(expect.stringContaining('FROM attendance_scheduler_scopes'), expect.anything())
+  })
+
+  it('lets scoped non-admin schedulers create shift assignments inside resolved schedule group scope', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('SELECT DISTINCT m.schedule_group_id')) return [{ schedule_group_id: scheduleGroupId }]
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeRow()]
+      if (sql.includes('SELECT * FROM attendance_shifts')) return [shiftRow()]
+      if (sql.includes('pg_advisory_xact_lock')) return []
+      if (sql.includes('FROM attendance_shift_assignments') && sql.includes('LIMIT 1')) return []
+      if (sql.includes('FROM attendance_rotation_assignments') && sql.includes('LIMIT 1')) return []
+      if (sql.includes('INSERT INTO attendance_shift_assignments')) return [shiftAssignmentRow()]
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/assignments', {
+      body: { userId: 'worker-1', shiftId, startDate: '2026-06-10' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(201)
+    expect(res.body).toMatchObject({ ok: true, data: { assignment: { userId: 'worker-1', shiftId } } })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT DISTINCT m.schedule_group_id'),
+      ['default', 'worker-1', '2026-06-10', null],
+    )
+    expect(db.transaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects scoped shift assignment dispatch without resolved schedule group membership', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('SELECT DISTINCT m.schedule_group_id')) return []
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/assignments', {
+      body: { userId: 'worker-1', shiftId, startDate: '2026-06-10' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
+    expect(db.transaction).not.toHaveBeenCalled()
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('INSERT INTO attendance_shift_assignments'))).toBe(false)
+  })
+
+  it('requires scoped shift assignment updates to cover both existing and next targets', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('SELECT * FROM attendance_shift_assignments WHERE id = $1')) return [shiftAssignmentRow()]
+      if (sql.includes('SELECT DISTINCT m.schedule_group_id')) return [{ schedule_group_id: scheduleGroupId }]
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeRow()]
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'PUT /api/attendance/assignments/:id', {
+      params: { id: shiftAssignmentId },
+      body: { userId: 'worker-2' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT DISTINCT m.schedule_group_id'),
+      ['default', 'worker-1', '2026-06-10', null],
+    )
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT DISTINCT m.schedule_group_id'),
+      ['default', 'worker-2', '2026-06-10', null],
+    )
+    expect(db.transaction).not.toHaveBeenCalled()
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('UPDATE attendance_shift_assignments'))).toBe(false)
+  })
+
+  it('lets scoped non-admin schedulers delete rotation assignments inside resolved schedule group scope', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('SELECT * FROM attendance_rotation_assignments WHERE id = $1')) return [rotationAssignmentRow()]
+      if (sql.includes('SELECT DISTINCT m.schedule_group_id')) return [{ schedule_group_id: scheduleGroupId }]
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeRow()]
+      if (sql.includes('DELETE FROM attendance_rotation_assignments')) return [{ id: rotationAssignmentId }]
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'DELETE /api/attendance/rotation-assignments/:id', {
+      params: { id: rotationAssignmentId },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toEqual({ ok: true, data: { id: rotationAssignmentId } })
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('DELETE FROM attendance_rotation_assignments'))).toBe(true)
   })
 
   it('does not relabel handler failures as permission check failures', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -15283,6 +15283,48 @@ module.exports = {
       }
     }
 
+    async function resolveAttendanceScheduleAssignmentScopeTarget(orgId, payload) {
+      const userId = payload?.userId ?? payload?.user_id
+      const startDate = normalizeDateOnly(payload?.startDate ?? payload?.start_date) ?? payload?.startDate ?? payload?.start_date
+      const endDate = normalizeAttendanceScheduleAssignmentEndDate(payload?.endDate ?? payload?.end_date)
+      const rows = await db.query(
+        `SELECT DISTINCT m.schedule_group_id
+         FROM attendance_schedule_group_members m
+         JOIN attendance_schedule_groups g
+           ON g.id = m.schedule_group_id
+          AND g.org_id = m.org_id
+          AND COALESCE(g.is_active, true) = true
+         WHERE m.org_id = $1
+           AND m.user_id = $2
+           AND m.schedule_group_id IS NOT NULL
+           AND COALESCE(m.effective_from, DATE '0001-01-01') <= COALESCE($4::date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}')
+           AND COALESCE(m.effective_to, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
+         ORDER BY m.schedule_group_id ASC`,
+        [orgId, userId, startDate, endDate]
+      )
+      return {
+        scheduleGroupIds: rows.map(row => row.schedule_group_id).filter(Boolean),
+        userIds: [userId],
+      }
+    }
+
+    async function assertAttendanceScheduleAssignmentDispatchAllowed(req, res, { orgId, payload, actorAccess } = {}) {
+      const access = actorAccess ?? await resolveAttendanceSchedulerScopeActor(req, res)
+      if (!access) return null
+      if (access.fullAdmin) return access
+
+      const target = await resolveAttendanceScheduleAssignmentScopeTarget(orgId, payload)
+      if (target.scheduleGroupIds.length === 0) {
+        respondAttendanceSchedulerScopeForbidden(res)
+        return null
+      }
+      return assertAttendanceSchedulerScopeAllowed(req, res, {
+        action: 'dispatch',
+        target,
+        actorAccess: access,
+      })
+    }
+
     function withAttendanceGroupMemberAccess(handler) {
       return async (req, res, next) => {
         const groupId = normalizeUuidString(req.params.id)
@@ -20815,7 +20857,7 @@ module.exports = {
     context.api.http.addRoute(
       'POST',
       '/api/attendance/rotation-assignments',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const parsed = rotationAssignmentCreateSchema.safeParse(normalizeRotationAssignmentPayload(req.body))
         if (!parsed.success) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
@@ -20842,6 +20884,9 @@ module.exports = {
         }
 
         try {
+          const access = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, { orgId, payload })
+          if (!access) return
+
           const ruleRows = await db.query(
             'SELECT * FROM attendance_rotation_rules WHERE id = $1 AND org_id = $2',
             [payload.rotationRuleId, orgId]
@@ -20898,13 +20943,13 @@ module.exports = {
           logger.error('Attendance rotation assignment creation failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create rotation assignment' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(
       'PUT',
       '/api/attendance/rotation-assignments/:id',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const parsed = rotationAssignmentUpdateSchema.safeParse(normalizeRotationAssignmentPayload(req.body ?? {}))
         if (!parsed.success) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
@@ -20919,11 +20964,18 @@ module.exports = {
         }
 
         try {
+          const actorAccess = await resolveAttendanceSchedulerScopeActor(req, res)
+          if (!actorAccess) return
+
           const existingRows = await db.query(
             'SELECT * FROM attendance_rotation_assignments WHERE id = $1 AND org_id = $2',
             [assignmentId, orgId]
           )
           if (!existingRows.length) {
+            if (!actorAccess.fullAdmin) {
+              respondAttendanceSchedulerScopeForbidden(res)
+              return
+            }
             res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Rotation assignment not found' } })
             return
           }
@@ -20948,6 +21000,19 @@ module.exports = {
             res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'End date must be after start date' } })
             return
           }
+
+          const existingAccess = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
+            orgId,
+            payload: existing,
+            actorAccess,
+          })
+          if (!existingAccess) return
+          const nextAccess = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
+            orgId,
+            payload,
+            actorAccess,
+          })
+          if (!nextAccess) return
 
           const ruleRows = await db.query(
             'SELECT * FROM attendance_rotation_rules WHERE id = $1 AND org_id = $2',
@@ -21011,13 +21076,13 @@ module.exports = {
           logger.error('Attendance rotation assignment update failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to update rotation assignment' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(
       'DELETE',
       '/api/attendance/rotation-assignments/:id',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const orgId = getOrgId(req)
         const assignmentId = normalizeUuidString(req.params.id)
         if (!assignmentId) {
@@ -21026,6 +21091,29 @@ module.exports = {
         }
 
         try {
+          const actorAccess = await resolveAttendanceSchedulerScopeActor(req, res)
+          if (!actorAccess) return
+
+          const existingRows = await db.query(
+            'SELECT * FROM attendance_rotation_assignments WHERE id = $1 AND org_id = $2',
+            [assignmentId, orgId]
+          )
+          if (!existingRows.length) {
+            if (!actorAccess.fullAdmin) {
+              respondAttendanceSchedulerScopeForbidden(res)
+              return
+            }
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Rotation assignment not found' } })
+            return
+          }
+
+          const access = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
+            orgId,
+            payload: existingRows[0],
+            actorAccess,
+          })
+          if (!access) return
+
           const rows = await db.query(
             'DELETE FROM attendance_rotation_assignments WHERE id = $1 AND org_id = $2 RETURNING id',
             [assignmentId, orgId]
@@ -21044,7 +21132,7 @@ module.exports = {
           logger.error('Attendance rotation assignment delete failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete rotation assignment' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(
@@ -28515,7 +28603,7 @@ module.exports = {
     context.api.http.addRoute(
       'POST',
       '/api/attendance/assignments',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const parsed = assignmentCreateSchema.safeParse(normalizeAssignmentPayload(req.body))
         if (!parsed.success) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
@@ -28542,6 +28630,9 @@ module.exports = {
         }
 
         try {
+          const access = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, { orgId, payload })
+          if (!access) return
+
           const shiftRows = await db.query(
             'SELECT * FROM attendance_shifts WHERE id = $1 AND org_id = $2',
             [payload.shiftId, orgId]
@@ -28598,13 +28689,13 @@ module.exports = {
           logger.error('Attendance assignment creation failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create assignment' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(
       'PUT',
       '/api/attendance/assignments/:id',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const parsed = assignmentUpdateSchema.safeParse(normalizeAssignmentPayload(req.body ?? {}))
         if (!parsed.success) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
@@ -28619,11 +28710,18 @@ module.exports = {
         }
 
         try {
+          const actorAccess = await resolveAttendanceSchedulerScopeActor(req, res)
+          if (!actorAccess) return
+
           const existingRows = await db.query(
             'SELECT * FROM attendance_shift_assignments WHERE id = $1 AND org_id = $2',
             [assignmentId, orgId]
           )
           if (!existingRows.length) {
+            if (!actorAccess.fullAdmin) {
+              respondAttendanceSchedulerScopeForbidden(res)
+              return
+            }
             res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Assignment not found' } })
             return
           }
@@ -28648,6 +28746,19 @@ module.exports = {
             res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'End date must be after start date' } })
             return
           }
+
+          const existingAccess = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
+            orgId,
+            payload: existing,
+            actorAccess,
+          })
+          if (!existingAccess) return
+          const nextAccess = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
+            orgId,
+            payload,
+            actorAccess,
+          })
+          if (!nextAccess) return
 
           const shiftRows = await db.query(
             'SELECT * FROM attendance_shifts WHERE id = $1 AND org_id = $2',
@@ -28711,13 +28822,13 @@ module.exports = {
           logger.error('Attendance assignment update failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to update assignment' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(
       'DELETE',
       '/api/attendance/assignments/:id',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const orgId = getOrgId(req)
         const assignmentId = normalizeUuidString(req.params.id)
         if (!assignmentId) {
@@ -28726,6 +28837,29 @@ module.exports = {
         }
 
         try {
+          const actorAccess = await resolveAttendanceSchedulerScopeActor(req, res)
+          if (!actorAccess) return
+
+          const existingRows = await db.query(
+            'SELECT * FROM attendance_shift_assignments WHERE id = $1 AND org_id = $2',
+            [assignmentId, orgId]
+          )
+          if (!existingRows.length) {
+            if (!actorAccess.fullAdmin) {
+              respondAttendanceSchedulerScopeForbidden(res)
+              return
+            }
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Assignment not found' } })
+            return
+          }
+
+          const access = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
+            orgId,
+            payload: existingRows[0],
+            actorAccess,
+          })
+          if (!access) return
+
           const rows = await db.query(
             'DELETE FROM attendance_shift_assignments WHERE id = $1 AND org_id = $2 RETURNING id',
             [assignmentId, orgId]
@@ -28744,7 +28878,7 @@ module.exports = {
           logger.error('Attendance assignment delete failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete assignment' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(


### PR DESCRIPTION
## Summary
- add date-aware schedule-group target resolution for shift/rotation assignment dispatch
- allow full attendance admins to keep existing assignment write behavior while scoped non-admins must match active scheduler scopes
- guard assignment POST/PUT/DELETE for shift and rotation writes; updates must cover both the existing and next targets

## Scope
- E2 only: `/api/attendance/assignments` and `/api/attendance/rotation-assignments` write routes
- no read/list filtering, schedule group CRUD enforcement, import/approval/payroll/report enforcement, or delegated UI exposure

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-advanced-scheduling-scope.test.ts tests/unit/attendance-uuid-validation-routes.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend test:unit` (201 files / 2598 tests)

## Notes
- Scoped assignment dispatch fails closed when the target user has no active schedule-group membership in the assignment date range.
- Full admin bypass avoids scheduler-scope and membership target lookup, preserving admin behavior.