### PR TITLE
fix(phase5): derive cache hit rate from active counters

### DIFF
--- a/scripts/ops/phase5-cache-hit-rate-contract.test.mjs
+++ b/scripts/ops/phase5-cache-hit-rate-contract.test.mjs
@@ -1,0 +1,85 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, rm, writeFile } from 'node:fs/promises';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { promisify } from 'node:util';
+import test from 'node:test';
+
+const execFileAsync = promisify(execFile);
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+
+async function calculateCacheHitRate(metricsText) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'phase5-cache-hit-rate-'));
+  const metricsPath = path.join(dir, 'metrics.prom');
+
+  try {
+    await writeFile(metricsPath, metricsText);
+    const { stdout } = await execFileAsync('bash', ['scripts/phase5-cache-hit-rate.sh', metricsPath], {
+      cwd: repoRoot,
+    });
+    return JSON.parse(stdout);
+  } finally {
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+test('uses generic cache counters when they have samples', async () => {
+  const result = await calculateCacheHitRate(`
+# HELP cache_hits_total Total cache hits
+cache_hits_total{impl="memory",key_pattern="foo"} 8
+cache_miss_total{impl="memory",key_pattern="foo"} 2
+rbac_perm_cache_hits_total 100
+rbac_perm_cache_miss_total 1
+`);
+
+  assert.equal(result.source, 'generic_cache');
+  assert.equal(result.hits, 8);
+  assert.equal(result.misses, 2);
+  assert.equal(result.total, 10);
+  assert.equal(result.hit_rate, 80);
+});
+
+test('falls back to RBAC permission cache counters when generic cache is idle', async () => {
+  const result = await calculateCacheHitRate(`
+# HELP cache_hits_total Total cache hits
+# HELP rbac_perm_cache_hits_total Total RBAC permission cache hits
+rbac_perm_cache_hits_total 10
+rbac_perm_cache_miss_total 1
+`);
+
+  assert.equal(result.source, 'rbac_permission_cache');
+  assert.equal(result.hits, 10);
+  assert.equal(result.misses, 1);
+  assert.equal(result.total, 11);
+  assert.equal(result.hit_rate, 90.91);
+});
+
+test('supports the legacy plural RBAC miss counter when singular misses are absent', async () => {
+  const result = await calculateCacheHitRate(`
+rbac_perm_cache_hits_total 9
+rbac_perm_cache_misses_total 1
+`);
+
+  assert.equal(result.source, 'rbac_permission_cache_legacy');
+  assert.equal(result.hits, 9);
+  assert.equal(result.misses, 1);
+  assert.equal(result.total, 10);
+  assert.equal(result.hit_rate, 90);
+});
+
+test('returns a zero none source when no supported cache counters have samples', async () => {
+  const result = await calculateCacheHitRate(`
+# HELP cache_hits_total Total cache hits
+# HELP rbac_perm_cache_hits_total Total RBAC permission cache hits
+http_requests_total{method="GET",status="200"} 5
+`);
+
+  assert.equal(result.source, 'none');
+  assert.equal(result.hits, 0);
+  assert.equal(result.misses, 0);
+  assert.equal(result.total, 0);
+  assert.equal(result.hit_rate, 0);
+});

--- a/scripts/phase5-cache-hit-rate.sh
+++ b/scripts/phase5-cache-hit-rate.sh
@@ -1,0 +1,73 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+RAW_FILE="${1:-}"
+
+if [ -z "$RAW_FILE" ] || [ ! -f "$RAW_FILE" ]; then
+  echo "Usage: $0 <prometheus-raw-metrics-file>" >&2
+  exit 2
+fi
+
+sum_metric() {
+  local metric_name="$1"
+
+  awk -v metric="$metric_name" '
+    $0 !~ /^#/ && ($1 == metric || index($1, metric "{") == 1) {
+      sum += $2
+    }
+    END { printf "%.0f", sum + 0 }
+  ' "$RAW_FILE"
+}
+
+emit_result() {
+  local source="$1"
+  local hits="$2"
+  local misses="$3"
+  local total=$((hits + misses))
+  local hit_rate="0"
+
+  if [ "$total" -gt 0 ]; then
+    hit_rate=$(awk -v h="$hits" -v t="$total" 'BEGIN { printf "%.2f", (h * 100) / t }')
+  fi
+
+  jq -n \
+    --arg source "$source" \
+    --argjson hits "$hits" \
+    --argjson misses "$misses" \
+    --argjson total "$total" \
+    --argjson hit_rate "$hit_rate" \
+    '{
+      source: $source,
+      hits: $hits,
+      misses: $misses,
+      total: $total,
+      hit_rate: $hit_rate
+    }'
+}
+
+generic_hits=$(sum_metric cache_hits_total)
+generic_misses=$(sum_metric cache_miss_total)
+generic_total=$((generic_hits + generic_misses))
+
+if [ "$generic_total" -gt 0 ]; then
+  emit_result generic_cache "$generic_hits" "$generic_misses"
+  exit 0
+fi
+
+rbac_hits=$(sum_metric rbac_perm_cache_hits_total)
+rbac_misses=$(sum_metric rbac_perm_cache_miss_total)
+rbac_total=$((rbac_hits + rbac_misses))
+legacy_rbac_misses=$(sum_metric rbac_perm_cache_misses_total)
+legacy_rbac_total=$((rbac_hits + legacy_rbac_misses))
+
+if [ "$rbac_misses" -eq 0 ] && [ "$legacy_rbac_total" -gt 0 ]; then
+  emit_result rbac_permission_cache_legacy "$rbac_hits" "$legacy_rbac_misses"
+  exit 0
+fi
+
+if [ "$rbac_total" -gt 0 ]; then
+  emit_result rbac_permission_cache "$rbac_hits" "$rbac_misses"
+  exit 0
+fi
+
+emit_result none 0 0

--- a/scripts/phase5-full-validate.sh
+++ b/scripts/phase5-full-validate.sh
@@ -34,6 +34,7 @@ readonly PROJECT_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
 # Configuration files
 readonly THRESHOLDS_FILE="${SCRIPT_DIR}/phase5-thresholds.json"
 readonly PERCENTILES_SCRIPT="${SCRIPT_DIR}/phase5-metrics-percentiles.ts"
+readonly CACHE_HIT_RATE_SCRIPT="${SCRIPT_DIR}/phase5-cache-hit-rate.sh"
 
 # Environment configuration
 readonly COUNT_CACHE_MISS_AS_FALLBACK="${COUNT_CACHE_MISS_AS_FALLBACK:-false}"
@@ -158,23 +159,15 @@ extract_metric() {
     grep "^${metric_name}[{ ]" "$raw_file" | grep -v "^#" | awk '{print $2}' | head -1 || echo "0"
 }
 
-# Calculate cache hit rate
-# Note: Uses cache_miss_total (singular) which is the actual metric name
-calculate_cache_hit_rate() {
+# Calculate cache hit rate.
+#
+# Generic cache counters are preferred. Production may only exercise the RBAC
+# permission cache counters, so fall back to those when generic cache counters
+# have no samples.
+calculate_cache_hit_rate_json() {
     local raw_file="$1"
 
-    # Sum all cache_hits_total entries (may have labels)
-    local cache_hits=$(grep "^cache_hits_total" "$raw_file" | grep -v "^#" | awk '{sum+=$2} END {print sum+0}')
-    # Sum all cache_miss_total entries (singular, not misses)
-    local cache_misses=$(grep "^cache_miss_total" "$raw_file" | grep -v "^#" | awk '{sum+=$2} END {print sum+0}')
-
-    local total=$((cache_hits + cache_misses))
-
-    if [ "$total" -gt 0 ]; then
-        echo "scale=2; $cache_hits * 100 / $total" | bc
-    else
-        echo "0"
-    fi
+    bash "$CACHE_HIT_RATE_SCRIPT" "$raw_file"
 }
 
 # Calculate HTTP metrics (success rate and error rate)
@@ -498,8 +491,13 @@ main() {
     local percentiles_json=$(cat "$temp_percentiles")
 
     # Extract cache hit rate
-    local cache_hit_rate=$(calculate_cache_hit_rate "$temp_raw")
-    log_info "Cache hit rate: ${cache_hit_rate}%"
+    local cache_hit_json=$(calculate_cache_hit_rate_json "$temp_raw")
+    local cache_hit_rate=$(echo "$cache_hit_json" | jq -r '.hit_rate')
+    local cache_hit_rate_source=$(echo "$cache_hit_json" | jq -r '.source')
+    local cache_hits=$(echo "$cache_hit_json" | jq -r '.hits')
+    local cache_misses=$(echo "$cache_hit_json" | jq -r '.misses')
+    local cache_total=$(echo "$cache_hit_json" | jq -r '.total')
+    log_info "Cache hit rate: ${cache_hit_rate}% (source=${cache_hit_rate_source}, hits=${cache_hits}, misses=${cache_misses}, total=${cache_total})"
 
     # Redis recent failures (15m): derive from last_failure_timestamp if present
     local redis_recent_failures=0
@@ -639,6 +637,10 @@ main() {
   "percentiles": $(echo "$percentiles_json" | jq '.metrics'),
   "counters": {
     "cache_hit_rate": $cache_hit_rate,
+    "cache_hit_rate_source": "$cache_hit_rate_source",
+    "cache_hits": $cache_hits,
+    "cache_misses": $cache_misses,
+    "cache_total": $cache_total,
     "raw_fallback": $raw_fallback,
     "effective_fallback": $effective_fallback,
     "fallback_effective_ratio": $fallback_effective_ratio,

--- a/scripts/phase5-generate-report.sh
+++ b/scripts/phase5-generate-report.sh
@@ -188,6 +188,10 @@ EOF
 "
 
     local cache_hit_rate=$(echo "$json" | jq -r '.counters.cache_hit_rate')
+    local cache_hit_rate_source=$(echo "$json" | jq -r '.counters.cache_hit_rate_source // "unknown"')
+    local cache_hits=$(echo "$json" | jq -r '.counters.cache_hits // 0')
+    local cache_misses=$(echo "$json" | jq -r '.counters.cache_misses // 0')
+    local cache_total=$(echo "$json" | jq -r '.counters.cache_total // 0')
     local http_success_rate=$(echo "$json" | jq -r '.counters.http_success_rate')
     local error_rate=$(echo "$json" | jq -r '.counters.error_rate')
     local raw_fallback=$(echo "$json" | jq -r '.counters.raw_fallback')
@@ -195,7 +199,7 @@ EOF
     local fallback_effective_ratio=$(echo "$json" | jq -r '.counters.fallback_effective_ratio')
     local memory_rss=$(echo "$json" | jq -r '.counters.memory_rss_mb')
 
-    report+="- **Cache Hit Rate**: ${cache_hit_rate}%
+    report+="- **Cache Hit Rate**: ${cache_hit_rate}% (${cache_hit_rate_source}, hits=${cache_hits}, misses=${cache_misses}, total=${cache_total})
 - **HTTP Success Rate**: ${http_success_rate}%
 - **Error Rate**: ${error_rate}%
 - **Raw Fallback Count**: $raw_fallback

--- a/scripts/phase5-thresholds.json
+++ b/scripts/phase5-thresholds.json
@@ -70,9 +70,14 @@
       "threshold": 80.0,
       "unit": "percent",
       "type": "lower_bound",
-      "prometheus_metrics": ["cache_hits_total", "cache_miss_total"],
-      "calculation": "cache_hits_total / (cache_hits_total + cache_miss_total) * 100",
-      "description": "Cache hot hit rate should be at least 80%"
+      "prometheus_metrics": [
+        "cache_hits_total",
+        "cache_miss_total",
+        "rbac_perm_cache_hits_total",
+        "rbac_perm_cache_miss_total"
+      ],
+      "calculation": "Prefer generic cache_hits_total / (cache_hits_total + cache_miss_total) * 100; when generic cache has no samples, use RBAC permission cache counters.",
+      "description": "Observed cache hit rate should be at least 80%"
     },
     {
       "metric": "fallback_effective_ratio",


### PR DESCRIPTION
## Summary
- Add a Phase 5 cache-hit-rate helper that prefers generic cache counters, then falls back to RBAC permission cache counters when generic cache counters have no samples.
- Carry cache source, hits, misses, and total into phase5-full-validate JSON and the generated markdown report.
- Expand threshold metadata and add contract coverage for generic, RBAC, legacy RBAC miss counter, and no-sample cases.

## Verification
- node --test scripts/ops/phase5-cache-hit-rate-contract.test.mjs
- bash -n scripts/phase5-cache-hit-rate.sh scripts/phase5-full-validate.sh scripts/phase5-generate-report.sh
- jq empty scripts/phase5-thresholds.json
- git diff --check
- bash scripts/phase5-cache-hit-rate.sh /private/tmp/phase5-prod-current.prom -> rbac_permission_cache, hits=10, misses=1, hit_rate=90.91
- bash scripts/phase5-full-validate.sh http://127.0.0.1:39001/metrics/prom /private/tmp/phase5-main-smoke.json against the production scrape fixture -> 5 pass / 0 fail / 6 N/A

Follow-up for #1. This intentionally does not close #1 because latency histogram samples are still N/A and Phase 5 regression thresholds still need a separately approved sampling/baseline pass.