### PR TITLE
feat(attendance): enforce scheduler scope group edits

### DIFF
--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
@@ -16,9 +16,15 @@ const migrationSource = readFileSync(
   'utf8',
 )
 
-function expectAdminRoute(path: string) {
+function expectAdminRoute(method: string, path: string) {
   const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-  const pattern = new RegExp(`['"]${escaped}['"],\\s*\\n\\s*withPermission\\(['"]attendance:admin['"]`)
+  const pattern = new RegExp(`['"]${method}['"],\\s*\\n\\s*['"]${escaped}['"],\\s*\\n\\s*withPermission\\(['"]attendance:admin['"]`)
+  expect(pluginSource).toMatch(pattern)
+}
+
+function expectDirectAsyncRoute(method: string, path: string) {
+  const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const pattern = new RegExp(`['"]${method}['"],\\s*\\n\\s*['"]${escaped}['"],\\s*\\n\\s*async \\(req, res\\)`)
   expect(pluginSource).toMatch(pattern)
 }
 
@@ -34,33 +40,34 @@ describe('attendance advanced scheduling scope foundation', () => {
     expect(migrationSource).not.toContain("dropTable('attendance_group_members')")
   })
 
-  it('guards the new scheduling group and scheduler-scope routes behind attendance admin or scoped dispatch', () => {
+  it('guards the new scheduling group and scheduler-scope routes behind attendance admin or scoped scheduler actions', () => {
     [
-      '/api/attendance/schedule-groups',
-      '/api/attendance/schedule-groups/:id',
-      '/api/attendance/schedule-groups/:id/members',
-      '/api/attendance/scheduler-scopes',
-      '/api/attendance/scheduler-scopes/:id',
-    ].forEach(expectAdminRoute)
+      ['GET', '/api/attendance/schedule-groups'],
+      ['POST', '/api/attendance/schedule-groups'],
+      ['GET', '/api/attendance/schedule-groups/:id'],
+      ['GET', '/api/attendance/schedule-groups/:id/members'],
+      ['GET', '/api/attendance/scheduler-scopes'],
+      ['POST', '/api/attendance/scheduler-scopes'],
+      ['PUT', '/api/attendance/scheduler-scopes/:id'],
+      ['DELETE', '/api/attendance/scheduler-scopes/:id'],
+    ].forEach(([method, path]) => expectAdminRoute(method, path))
     expect(pluginSource).toContain('SCHEDULER_SCOPE_FORBIDDEN')
-    expect(pluginSource).toMatch(
-      /'POST',\s*\n\s*'\/api\/attendance\/schedule-groups\/:id\/members',\s*\n\s*async \(req, res\)/,
-    )
-    expect(pluginSource).toMatch(
-      /'DELETE',\s*\n\s*'\/api\/attendance\/schedule-groups\/:id\/members\/:memberId',\s*\n\s*async \(req, res\)/,
-    )
+    expectDirectAsyncRoute('POST', '/api/attendance/schedule-groups/:id/members')
+    expectDirectAsyncRoute('DELETE', '/api/attendance/schedule-groups/:id/members/:memberId')
+    expectDirectAsyncRoute('PUT', '/api/attendance/schedule-groups/:id')
+    expectDirectAsyncRoute('DELETE', '/api/attendance/schedule-groups/:id')
     const scopedDispatchRoutes = [
-      '/api/attendance/assignments',
-      '/api/attendance/assignments/:id',
-      '/api/attendance/rotation-assignments',
-      '/api/attendance/rotation-assignments/:id',
+      ['POST', '/api/attendance/assignments'],
+      ['PUT', '/api/attendance/assignments/:id'],
+      ['DELETE', '/api/attendance/assignments/:id'],
+      ['POST', '/api/attendance/rotation-assignments'],
+      ['PUT', '/api/attendance/rotation-assignments/:id'],
+      ['DELETE', '/api/attendance/rotation-assignments/:id'],
     ]
-    scopedDispatchRoutes.forEach((path) => {
-      const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
-      expect(pluginSource).toMatch(new RegExp(`['"]${escaped}['"],\\s*\\n\\s*async \\(req, res\\)`))
-    })
+    scopedDispatchRoutes.forEach(([method, path]) => expectDirectAsyncRoute(method, path))
     expect(pluginSource).toContain('resolveAttendanceScheduleAssignmentScopeTarget')
     expect(pluginSource).toContain('assertAttendanceScheduleAssignmentDispatchAllowed')
+    expect(pluginSource).toContain('assertAttendanceScheduleGroupEditAllowed')
   })
 
   it('normalizes schedule groups without overloading attendance_groups semantics', () => {

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -112,6 +112,26 @@ const shiftAssignmentId = '00000000-0000-4000-8000-000000000304'
 const rotationRuleId = '00000000-0000-4000-8000-000000000305'
 const rotationAssignmentId = '00000000-0000-4000-8000-000000000306'
 
+function scheduleGroupRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: scheduleGroupId,
+    org_id: 'default',
+    name: 'Line A',
+    code: 'line-a',
+    description: null,
+    attendance_group_id: null,
+    parent_id: null,
+    department_ref: null,
+    source: 'manual',
+    is_active: true,
+    created_by: 'admin-1',
+    updated_by: 'admin-1',
+    created_at: '2026-05-30T10:00:00.000Z',
+    updated_at: '2026-05-30T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
 function schedulerScopeRow(overrides: Record<string, unknown> = {}) {
   return {
     id: 'scope-1',
@@ -132,6 +152,21 @@ function schedulerScopeRow(overrides: Record<string, unknown> = {}) {
     updated_at: '2026-05-30T10:00:00.000Z',
     ...overrides,
   }
+}
+
+function schedulerScopeEditRow(overrides: Record<string, unknown> = {}) {
+  return schedulerScopeRow({
+    actions: ['edit'],
+    scope: {
+      scheduleGroupIds: [scheduleGroupId],
+      attendanceGroupIds: [],
+      userIds: [],
+      departments: [],
+      roles: [],
+      roleTags: [],
+    },
+    ...overrides,
+  })
 }
 
 function scheduleGroupMemberRow(overrides: Record<string, unknown> = {}) {
@@ -920,6 +955,168 @@ describe('attendance UUID route validation', () => {
     expect(res.statusCode).toBe(200)
     expect(res.body).toEqual({ ok: true, data: { id: scheduleGroupMemberId } })
     expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('DELETE FROM attendance_schedule_group_members'))).toBe(true)
+  })
+
+  it('keeps schedule group creation admin-only because new groups have no scoped target id yet', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/schedule-groups', {
+      body: { name: 'Line B' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('INSERT INTO attendance_schedule_groups'))).toBe(false)
+  })
+
+  it('lets full attendance admins edit schedule groups without scheduler scopes', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params, true)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('SELECT * FROM attendance_schedule_groups WHERE id = $1')) return [scheduleGroupRow()]
+      if (sql.includes('UPDATE attendance_schedule_groups') && sql.includes('SET name = $3')) {
+        return [scheduleGroupRow({ name: 'Line A Prime', updated_by: params[10] })]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'PUT /api/attendance/schedule-groups/:id', {
+      params: { id: scheduleGroupId },
+      body: { name: 'Line A Prime' },
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({ ok: true, data: { id: scheduleGroupId, name: 'Line A Prime' } })
+    expect(db.query).not.toHaveBeenCalledWith(expect.stringContaining('FROM attendance_scheduler_scopes'), expect.anything())
+  })
+
+  it('lets scoped non-admin schedulers edit schedule groups inside their scheduler scope', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('SELECT * FROM attendance_schedule_groups WHERE id = $1')) return [scheduleGroupRow()]
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeEditRow()]
+      if (sql.includes('UPDATE attendance_schedule_groups') && sql.includes('SET name = $3')) {
+        return [scheduleGroupRow({ name: 'Line A Prime', updated_by: params[10] })]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'PUT /api/attendance/schedule-groups/:id', {
+      params: { id: scheduleGroupId },
+      body: { name: 'Line A Prime' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({ ok: true, data: { id: scheduleGroupId, name: 'Line A Prime' } })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM attendance_scheduler_scopes'),
+      ['default', 'scheduler-1', [], []],
+    )
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('UPDATE attendance_schedule_groups'),
+      [
+        scheduleGroupId,
+        'default',
+        'Line A Prime',
+        'line-a',
+        null,
+        null,
+        null,
+        null,
+        'manual',
+        true,
+        'scheduler-1',
+      ],
+    )
+  })
+
+  it('rejects scoped schedule group edits without edit action and does not write', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('SELECT * FROM attendance_schedule_groups WHERE id = $1')) return [scheduleGroupRow()]
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeRow()]
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'PUT /api/attendance/schedule-groups/:id', {
+      params: { id: scheduleGroupId },
+      body: { name: 'Line A Prime' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('UPDATE attendance_schedule_groups'))).toBe(false)
+  })
+
+  it('lets scoped non-admin schedulers deactivate schedule groups inside their scheduler scope', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('SELECT * FROM attendance_schedule_groups WHERE id = $1')) return [scheduleGroupRow()]
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeEditRow()]
+      if (sql.includes('UPDATE attendance_schedule_groups') && sql.includes('SET is_active = false')) {
+        return [scheduleGroupRow({ is_active: false, updated_by: params[2] })]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'DELETE /api/attendance/schedule-groups/:id', {
+      params: { id: scheduleGroupId },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({ ok: true, data: { id: scheduleGroupId, isActive: false } })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('SET is_active = false'),
+      [scheduleGroupId, 'default', 'scheduler-1'],
+    )
+  })
+
+  it('does not disclose missing schedule groups to scoped non-admin schedulers', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('SELECT * FROM attendance_schedule_groups WHERE id = $1')) return []
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'DELETE /api/attendance/schedule-groups/:id', {
+      params: { id: scheduleGroupId },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
+    expect(db.query).not.toHaveBeenCalledWith(expect.stringContaining('FROM attendance_scheduler_scopes'), expect.anything())
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('UPDATE attendance_schedule_groups'))).toBe(false)
   })
 
   it('lets full attendance admins create shift assignments without scheduler scopes', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -15325,6 +15325,18 @@ module.exports = {
       })
     }
 
+    async function assertAttendanceScheduleGroupEditAllowed(req, res, { groupId, actorAccess } = {}) {
+      const access = actorAccess ?? await resolveAttendanceSchedulerScopeActor(req, res)
+      if (!access) return null
+      if (access.fullAdmin) return access
+
+      return assertAttendanceSchedulerScopeAllowed(req, res, {
+        action: 'edit',
+        target: { scheduleGroupIds: [groupId] },
+        actorAccess: access,
+      })
+    }
+
     function withAttendanceGroupMemberAccess(handler) {
       return async (req, res, next) => {
         const groupId = normalizeUuidString(req.params.id)
@@ -27456,28 +27468,35 @@ module.exports = {
     context.api.http.addRoute(
       'PUT',
       '/api/attendance/schedule-groups/:id',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const parsed = scheduleGroupSchema.safeParse(req.body ?? {})
         if (!parsed.success) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
           return
         }
         const orgId = getOrgId(req)
-        const actorId = getUserId(req)
         const groupId = normalizeUuidString(req.params.id)
         if (!groupId) {
           respondInvalidUuid(res)
           return
         }
+        const actorAccess = await resolveAttendanceSchedulerScopeActor(req, res)
+        if (!actorAccess) return
         try {
           const existingRows = await db.query(
             'SELECT * FROM attendance_schedule_groups WHERE id = $1 AND org_id = $2',
             [groupId, orgId]
           )
           if (!existingRows.length) {
+            if (!actorAccess.fullAdmin) {
+              respondAttendanceSchedulerScopeForbidden(res)
+              return
+            }
             res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Schedule group not found' } })
             return
           }
+          const access = await assertAttendanceScheduleGroupEditAllowed(req, res, { groupId, actorAccess })
+          if (!access) return
           const input = normalizeAttendanceScheduleGroupInput(parsed.data, existingRows[0])
           const rows = await db.query(
             `UPDATE attendance_schedule_groups
@@ -27504,7 +27523,7 @@ module.exports = {
               input.departmentRef,
               input.source,
               input.isActive,
-              actorId,
+              access.userId,
             ]
           )
           res.json({ ok: true, data: mapAttendanceScheduleGroupRow(rows[0]) })
@@ -27524,27 +27543,42 @@ module.exports = {
           logger.error('Attendance schedule group update failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to update schedule group' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(
       'DELETE',
       '/api/attendance/schedule-groups/:id',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const orgId = getOrgId(req)
-        const actorId = getUserId(req)
         const groupId = normalizeUuidString(req.params.id)
         if (!groupId) {
           respondInvalidUuid(res)
           return
         }
+        const actorAccess = await resolveAttendanceSchedulerScopeActor(req, res)
+        if (!actorAccess) return
         try {
+          const existingRows = await db.query(
+            'SELECT * FROM attendance_schedule_groups WHERE id = $1 AND org_id = $2',
+            [groupId, orgId]
+          )
+          if (!existingRows.length) {
+            if (!actorAccess.fullAdmin) {
+              respondAttendanceSchedulerScopeForbidden(res)
+              return
+            }
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Schedule group not found' } })
+            return
+          }
+          const access = await assertAttendanceScheduleGroupEditAllowed(req, res, { groupId, actorAccess })
+          if (!access) return
           const rows = await db.query(
             `UPDATE attendance_schedule_groups
              SET is_active = false, updated_by = $3, updated_at = now()
              WHERE id = $1 AND org_id = $2
              RETURNING *`,
-            [groupId, orgId, actorId]
+            [groupId, orgId, access.userId]
           )
           if (!rows.length) {
             res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Schedule group not found' } })
@@ -27559,7 +27593,7 @@ module.exports = {
           logger.error('Attendance schedule group delete failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete schedule group' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(


### PR DESCRIPTION
## Summary
- enforce scheduler scope action=edit for schedule group PUT/DELETE while preserving full attendance admin bypass
- fail closed with SCHEDULER_SCOPE_FORBIDDEN for scoped non-admins when the schedule group is missing or outside scope
- keep schedule group create/read/list admin-only because create has no pre-insert scheduleGroupId target

## Tests
- node --check plugins/plugin-attendance/index.cjs
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts tests/unit/attendance-advanced-scheduling-scope.test.ts --watch=false
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/core-backend test:unit (fails only in tests/unit/script-sandbox-python-portability.test.ts:127; confirmed the same failure on clean origin/main 0e35ae94e baseline)