### PR TITLE
fix(data-sources): scope health endpoint

### DIFF
--- a/packages/core-backend/src/data-adapters/DataSourceManager.ts
+++ b/packages/core-backend/src/data-adapters/DataSourceManager.ts
@@ -719,7 +719,7 @@ export class DataSourceManager extends EventEmitter {
     return sources
   }
 
-  async healthCheck(): Promise<Map<string, {
+  async healthCheck(filter?: { ownerId?: string }): Promise<Map<string, {
     connected: boolean
     responsive: boolean
     latency?: number
@@ -731,6 +731,15 @@ export class DataSourceManager extends EventEmitter {
     }>()
 
     for (const [id, adapter] of this.adapters) {
+      // A0.1: health is a read surface too; keep it scoped with list/get so
+      // fixing the /health route shadow does not leak cross-owner source ids.
+      if (filter?.ownerId !== undefined) {
+        const scope = this.scopes.get(id)
+        if (!scope || scope.ownerId !== filter.ownerId) {
+          continue
+        }
+      }
+
       const startTime = Date.now()
       const connected = adapter.isConnected()
       let responsive = false

--- a/packages/core-backend/src/routes/data-sources.ts
+++ b/packages/core-backend/src/routes/data-sources.ts
@@ -187,6 +187,55 @@ export function dataSourcesRouter(): Router {
   })
 
   /**
+   * GET /api/data-sources/health
+   * Get health status of the caller's data sources
+   *
+   * Keep this route before /api/data-sources/:id. Otherwise Express treats
+   * "health" as a data-source id and the endpoint becomes unreachable.
+   */
+  router.get('/api/data-sources/health', rbacGuard('data_sources', 'read'), async (req: Request, res: Response) => {
+    try {
+      const userId = resolveUserId(req)
+      if (!userId) {
+        return res.status(401).json({
+          ok: false,
+          error: { code: 'UNAUTHENTICATED', message: 'Authentication required' }
+        })
+      }
+
+      const manager = getManager()
+      const healthMap = await manager.healthCheck({ ownerId: userId })
+
+      const health: Array<{
+        id: string
+        connected: boolean
+        responsive: boolean
+        latency?: number
+      }> = []
+
+      healthMap.forEach((status, id) => {
+        health.push({ id, ...status })
+      })
+
+      return res.json({
+        ok: true,
+        data: {
+          items: health,
+          timestamp: new Date().toISOString()
+        }
+      })
+    } catch (error) {
+      return res.status(500).json({
+        ok: false,
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: error instanceof Error ? error.message : 'Health check failed'
+        }
+      })
+    }
+  })
+
+  /**
    * GET /api/data-sources/:id
    * Get details of a specific data source
    */
@@ -515,44 +564,6 @@ export function dataSourcesRouter(): Router {
         error: {
           code: 'TEST_FAILED',
           message: error instanceof Error ? error.message : 'Connection test failed'
-        }
-      })
-    }
-  })
-
-  /**
-   * GET /api/data-sources/health
-   * Get health status of all data sources
-   */
-  router.get('/api/data-sources/health', rbacGuard('data_sources', 'read'), async (_req: Request, res: Response) => {
-    try {
-      const manager = getManager()
-      const healthMap = await manager.healthCheck()
-
-      const health: Array<{
-        id: string
-        connected: boolean
-        responsive: boolean
-        latency?: number
-      }> = []
-
-      healthMap.forEach((status, id) => {
-        health.push({ id, ...status })
-      })
-
-      return res.json({
-        ok: true,
-        data: {
-          items: health,
-          timestamp: new Date().toISOString()
-        }
-      })
-    } catch (error) {
-      return res.status(500).json({
-        ok: false,
-        error: {
-          code: 'INTERNAL_ERROR',
-          message: error instanceof Error ? error.message : 'Health check failed'
         }
       })
     }

--- a/packages/core-backend/tests/unit/data-source-scope.test.ts
+++ b/packages/core-backend/tests/unit/data-source-scope.test.ts
@@ -156,6 +156,16 @@ describe('DataSourceManager ownership scope (A0.1)', () => {
     expect(m.listDataSources().map((s) => s.id).sort()).toEqual(['a1', 'b1'])
   })
 
+  it('healthCheck filters by owner', async () => {
+    const m = new DataSourceManager()
+    await m.addDataSource(pgConfig('health-a'), { ownerId: 'alice' })
+    await m.addDataSource(pgConfig('health-b'), { ownerId: 'bob' })
+
+    expect([...((await m.healthCheck({ ownerId: 'alice' })).keys())]).toEqual(['health-a'])
+    expect([...((await m.healthCheck({ ownerId: 'bob' })).keys())]).toEqual(['health-b'])
+    expect([...((await m.healthCheck()).keys())].sort()).toEqual(['health-a', 'health-b'])
+  })
+
   it('removeDataSource clears the scope entry', async () => {
     const m = new DataSourceManager()
     await m.addDataSource(pgConfig('ds1'), { ownerId: 'alice' })
@@ -223,6 +233,20 @@ describe('data-sources route ownership scope (A0.1)', () => {
     const ids = (list.body.data.items as Array<{ id: string }>).map((i) => i.id)
     expect(ids).toContain('ds-list-a')
     expect(ids).not.toContain('ds-list-b')
+  })
+
+  it('health route is reachable and returns only the caller’s own data sources', async () => {
+    currentUser = admin('alice-health')
+    await request(app).post('/api/data-sources').send(pgConfig('ds-health-a'))
+    currentUser = admin('bob-health')
+    await request(app).post('/api/data-sources').send(pgConfig('ds-health-b'))
+
+    currentUser = admin('alice-health')
+    const res = await request(app).get('/api/data-sources/health')
+    expect(res.status).toBe(200)
+    const ids = (res.body.data.items as Array<{ id: string }>).map((i) => i.id)
+    expect(ids).toContain('ds-health-a')
+    expect(ids).not.toContain('ds-health-b')
   })
 
   it('PUT preserves the owner — a non-owner still gets 404 after the update', async () => {


### PR DESCRIPTION
## Summary
- scope data-source health checks to the authenticated owner
- keep /api/data-sources/health reachable before the :id route
- add manager + route regression coverage for owner-filtered health output

## Tests
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/data-source-scope.test.ts --watch=false
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/data-source-result-boundary.test.ts --watch=false
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/postgres-adapter.test.ts --watch=false

## Boundaries
- backend data-sources scope fix only
- no data adapter behavior change beyond health filtering
- no frontend files included