### PR TITLE
fix(multitable): mask record history field values

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -176,6 +176,7 @@ jobs:
             tests/integration/multitable-viewconfig-filter-literal-redaction.test.ts \
             tests/integration/multitable-viewconfig-resave-guard.test.ts \
             tests/integration/multitable-records-list-authz.test.ts \
+            tests/integration/multitable-record-history-field-mask.test.ts \
             tests/integration/multitable-dashboard-chart-authz.test.ts \
             tests/integration/multitable-automation-retry.test.ts \
             tests/integration/multitable-automation-jobs.test.ts \

--- a/docs/development/multitable-record-history-field-mask-verification-20260530.md
+++ b/docs/development/multitable-record-history-field-mask-verification-20260530.md
@@ -1,0 +1,80 @@
+# Multitable F1 Record History Field-Mask Verification — 2026-05-30
+
+## Scope
+
+Implementation for `docs/development/multitable-record-history-field-mask-design-20260530.md`:
+
+- `GET /api/multitable/sheets/:sheetId/records/:recordId/history`
+- Value-only response redaction for revision `patch`, `snapshot`, and `changedFieldIds`
+- Layer-2 ∧ layer-3 field-read gate, reusing the same allowed-field composite as the interactive read paths
+- No mutation of persisted `meta_record_revisions` rows
+- Existing sheet-read and record-read gates unchanged
+
+Out of scope: full field-definition strip, other record egress endpoints, dashboard/chart authz, and form/public paths.
+
+## Fail-First Evidence
+
+Command, against a fresh migrated real Postgres database before the route fix:
+
+```bash
+DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_f1hist_test_74665 \
+  pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts \
+  run tests/integration/multitable-record-history-field-mask.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+- `3 failed | 5 passed`
+- `R1` failed because the layer-3 denied canary was present in `patch` / `snapshot`
+- `R2` failed because `changedFieldIds` still included the denied/static-hidden fields
+- `R3` failed because the static `property.hidden=true` canary was present in `patch` / `snapshot`
+
+This proves the test is not fixture-green and that the leak is on the record-history wire response.
+
+## Post-Fix Evidence
+
+Same command after the route fix:
+
+```text
+✓ tests/integration/multitable-record-history-field-mask.test.ts (8 tests)
+Test Files 1 passed (1)
+Tests 8 passed (8)
+```
+
+What the test matrix pins:
+
+- `R1`: `field_permissions.visible=false` values are absent from `patch` and `snapshot`; visible-field values remain
+- `R2`: `changedFieldIds` is redacted to the allowed field set
+- `R3`: static `property.hidden=true` values are also absent, independent of field_permissions rows
+- `R4`: a readable subject with no layer-3 deny still sees readable non-static values
+- `R5`: non-readers still receive `403`
+- `R6`: missing records still receive `404`
+- `R7`: `snapshot: null` remains `null`
+
+## CI Wiring
+
+The test is added to `.github/workflows/plugin-tests.yml` under the Node 20.x real-DB multitable integration step, next to the existing read-path permission suites. This ensures it runs against a real migrated Postgres database in CI, not only locally.
+
+## Commands To Re-Run
+
+```bash
+DATABASE_URL=postgresql://chouhua@localhost:5432/<db> \
+  pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts \
+  run tests/integration/multitable-record-history-field-mask.test.ts \
+  --reporter=dot
+
+DATABASE_URL=postgresql://chouhua@localhost:5432/<db> \
+  pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts \
+  run \
+  tests/integration/multitable-record-history-field-mask.test.ts \
+  tests/integration/multitable-records-read-field-mask.test.ts \
+  tests/integration/multitable-records-list-authz.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm validate:plugins
+```

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -147,7 +147,7 @@ import {
   createYjsInvalidationPostCommitHook,
   type YjsInvalidator,
 } from '../multitable/post-commit-hooks'
-import { listRecordRevisions } from '../multitable/record-history-service'
+import { listRecordRevisions, type RecordRevisionEntry } from '../multitable/record-history-service'
 import {
   getRecordSubscriptionStatus,
   listRecordSubscriptionNotifications,
@@ -2248,6 +2248,15 @@ function filterRecordDataByFieldIds(data: unknown, allowedFieldIds: Set<string>)
   )
 }
 
+function redactRecordRevisionEntry(item: RecordRevisionEntry, allowedFieldIds: Set<string>): RecordRevisionEntry {
+  return {
+    ...item,
+    changedFieldIds: item.changedFieldIds.filter((fieldId) => allowedFieldIds.has(fieldId)),
+    patch: filterRecordDataByFieldIds(item.patch, allowedFieldIds),
+    snapshot: item.snapshot === null ? null : filterRecordDataByFieldIds(item.snapshot, allowedFieldIds),
+  }
+}
+
 // #2052 (b): the layer-2 ∧ layer-3 allowed-field set (the #2015 composite, hiddenFieldIds: [] — layer-1
 // excluded). Reused as the redaction gate for view-config filter literals.
 function computeAllowedFieldIds(fields: UniverMetaField[], capabilities: MultitableCapabilities, fieldScopeMap: Map<string, FieldPermissionScope>): Set<string> {
@@ -4301,7 +4310,9 @@ export function univerMetaRouter(): Router {
         }
       }
 
-      const items = await listRecordRevisions(pool.query.bind(pool), { sheetId, recordId, limit, offset })
+      const allowedFieldIds = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
+      const items = (await listRecordRevisions(pool.query.bind(pool), { sheetId, recordId, limit, offset }))
+        .map((item) => redactRecordRevisionEntry(item, allowedFieldIds))
       return res.json({ ok: true, data: { items, limit, offset } })
     } catch (err) {
       if (isUndefinedTableError(err, 'meta_record_revisions')) {

--- a/packages/core-backend/tests/integration/multitable-record-history-field-mask.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-history-field-mask.test.ts
@@ -1,0 +1,213 @@
+/**
+ * Real-DB integration test for F1 — record history response field mask.
+ * Design-lock: docs/development/multitable-record-history-field-mask-design-20260530.md (#2144).
+ *
+ * Record history already has sheet + record read gates, but pre-F1 it returned revision `patch`,
+ * `snapshot`, and `changedFieldIds` verbatim. This suite proves the response is now filtered by
+ * the same layer-2 and layer-3 allowed-field set used by the interactive read paths.
+ *
+ * Seed non-negotiable: FLD_SECRET.property = {} so the deny is solely layer-3
+ * (field_permissions.visible=false). FLD_STATIC_HIDDEN has property.hidden=true and no
+ * field-permission row, proving layer-2 also applies.
+ */
+import { randomUUID } from 'crypto'
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_f1hist_${TS}`
+const SHEET_ID = `sheet_f1hist_${TS}`
+const RECORD_ID = `rec_f1hist_${TS}`
+const MISSING_RECORD_ID = `rec_f1hist_missing_${TS}`
+const FLD_VISIBLE = `fld_f1hist_visible_${TS}`
+const FLD_SECRET = `fld_f1hist_secret_${TS}`
+const FLD_STATIC_HIDDEN = `fld_f1hist_static_hidden_${TS}`
+const USER_DENIED = `u_f1hist_denied_${TS}`
+const USER_ALLOWED = `u_f1hist_allowed_${TS}`
+const VISIBLE_CANARY = 'visible-history-canary'
+const SECRET_CANARY = 'do-not-leak-history-secret'
+const STATIC_HIDDEN_CANARY = 'do-not-leak-history-static-hidden'
+
+type RevisionBody = {
+  version: number
+  changedFieldIds: string[]
+  patch: Record<string, unknown>
+  snapshot: Record<string, unknown> | null
+}
+
+let app: Express
+let testUserId = USER_DENIED
+let testPerms: string[] = ['multitable:read']
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const historyReq = (recordId = RECORD_ID) =>
+  request(app).get(`/api/multitable/sheets/${SHEET_ID}/records/${recordId}/history`)
+
+function itemsOf(res: { body: { data?: { items?: RevisionBody[] } } }): RevisionBody[] {
+  return res.body.data?.items ?? []
+}
+
+function versionOf(res: { body: { data?: { items?: RevisionBody[] } } }, version: number): RevisionBody {
+  const item = itemsOf(res).find((entry) => entry.version === version)
+  expect(item).toBeDefined()
+  return item as RevisionBody
+}
+
+describeIfDatabase('F1 record history field mask (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = testUserId ? { id: testUserId, roles: [], perms: testPerms } : undefined
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'F1 History Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'F1 History Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_VISIBLE, SHEET_ID, 'Visible', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRET, SHEET_ID, 'Secret', 'string', '{}', 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_STATIC_HIDDEN, SHEET_ID, 'Static Hidden', 'string', '{"hidden":true}', 3])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,2)', [
+      RECORD_ID,
+      SHEET_ID,
+      JSON.stringify({
+        [FLD_VISIBLE]: VISIBLE_CANARY,
+        [FLD_SECRET]: SECRET_CANARY,
+        [FLD_STATIC_HIDDEN]: STATIC_HIDDEN_CANARY,
+      }),
+    ])
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER_DENIED, false, false])
+
+    await q(
+      `INSERT INTO meta_record_revisions (
+         id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, patch, snapshot
+       )
+       VALUES ($1::uuid,$2,$3,$4,$5,$6,$7,$8::text[],$9::jsonb,$10::jsonb)`,
+      [
+        randomUUID(),
+        SHEET_ID,
+        RECORD_ID,
+        2,
+        'update',
+        'rest',
+        USER_ALLOWED,
+        [FLD_VISIBLE, FLD_SECRET, FLD_STATIC_HIDDEN],
+        JSON.stringify({
+          [FLD_VISIBLE]: VISIBLE_CANARY,
+          [FLD_SECRET]: SECRET_CANARY,
+          [FLD_STATIC_HIDDEN]: STATIC_HIDDEN_CANARY,
+        }),
+        JSON.stringify({
+          [FLD_VISIBLE]: VISIBLE_CANARY,
+          [FLD_SECRET]: SECRET_CANARY,
+          [FLD_STATIC_HIDDEN]: STATIC_HIDDEN_CANARY,
+        }),
+      ],
+    )
+    await q(
+      `INSERT INTO meta_record_revisions (
+         id, sheet_id, record_id, version, action, source, actor_id, changed_field_ids, patch, snapshot
+       )
+       VALUES ($1::uuid,$2,$3,$4,$5,$6,$7,$8::text[],$9::jsonb,$10::jsonb)`,
+      [
+        randomUUID(),
+        SHEET_ID,
+        RECORD_ID,
+        1,
+        'create',
+        'rest',
+        USER_ALLOWED,
+        [FLD_VISIBLE],
+        JSON.stringify({ [FLD_VISIBLE]: VISIBLE_CANARY }),
+        null,
+      ],
+    )
+  })
+
+  beforeEach(() => {
+    testUserId = USER_DENIED
+    testPerms = ['multitable:read']
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_record_revisions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('R1: denied layer-3 field values are absent from patch and snapshot while visible values remain', async () => {
+    const res = await historyReq()
+    expect(res.status).toBe(200)
+    const item = versionOf(res, 2)
+
+    expect(item.patch[FLD_VISIBLE]).toBe(VISIBLE_CANARY)
+    expect(item.snapshot?.[FLD_VISIBLE]).toBe(VISIBLE_CANARY)
+    expect(item.patch[FLD_SECRET]).toBeUndefined()
+    expect(item.snapshot?.[FLD_SECRET]).toBeUndefined()
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY)
+  })
+
+  test('R2: changedFieldIds drops denied fields and stays aligned with the visible patch keys', async () => {
+    const res = await historyReq()
+    expect(res.status).toBe(200)
+    const item = versionOf(res, 2)
+
+    expect(item.changedFieldIds).toContain(FLD_VISIBLE)
+    expect(item.changedFieldIds).not.toContain(FLD_SECRET)
+    expect(item.changedFieldIds).not.toContain(FLD_STATIC_HIDDEN)
+  })
+
+  test('R3: static-hidden field values are absent without relying on a field_permissions row', async () => {
+    const res = await historyReq()
+    expect(res.status).toBe(200)
+    const item = versionOf(res, 2)
+
+    expect(item.patch[FLD_STATIC_HIDDEN]).toBeUndefined()
+    expect(item.snapshot?.[FLD_STATIC_HIDDEN]).toBeUndefined()
+    expect(JSON.stringify(res.body)).not.toContain(STATIC_HIDDEN_CANARY)
+  })
+
+  test('R4: a readable subject with no layer-3 deny still sees the non-static secret value', async () => {
+    testUserId = USER_ALLOWED
+    testPerms = ['multitable:read']
+
+    const res = await historyReq()
+    expect(res.status).toBe(200)
+    const item = versionOf(res, 2)
+    expect(item.patch[FLD_SECRET]).toBe(SECRET_CANARY)
+    expect(item.snapshot?.[FLD_SECRET]).toBe(SECRET_CANARY)
+    expect(JSON.stringify(res.body)).toContain(SECRET_CANARY)
+  })
+
+  test('R5: existing authz guard remains intact for non-readers', async () => {
+    testPerms = []
+    const res = await historyReq()
+    expect(res.status).toBe(403)
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY)
+  })
+
+  test('R6: existing record gate remains intact for missing records', async () => {
+    const res = await historyReq(MISSING_RECORD_ID)
+    expect(res.status).toBe(404)
+  })
+
+  test('R7: null snapshots stay null', async () => {
+    const res = await historyReq()
+    expect(res.status).toBe(200)
+    expect(versionOf(res, 1).snapshot).toBeNull()
+  })
+})


### PR DESCRIPTION
## Summary

Implements F1 from `multitable-record-history-field-mask-design-20260530.md`.

`GET /api/multitable/sheets/:sheetId/records/:recordId/history` now redacts revision `patch`, `snapshot`, and `changedFieldIds` by the same layer-2 ∧ layer-3 allowed-field composite used by the interactive read paths. Persisted `meta_record_revisions` rows are not mutated; existing sheet-read and record-read gates are unchanged.

## Verification

Fail-first on unmodified route, real Postgres:

- `3 failed | 5 passed`
- R1 proved `field_permissions.visible=false` values leaked through `patch` / `snapshot`
- R2 proved `changedFieldIds` included denied/static-hidden fields
- R3 proved static `property.hidden=true` values leaked through `patch` / `snapshot`

Post-fix local checks:

- `DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_f1hist_test_74665 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-record-history-field-mask.test.ts --reporter=dot` → 8/8 passed
- `DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_f1hist_test_74665 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-record-history-field-mask.test.ts tests/integration/multitable-records-read-field-mask.test.ts tests/integration/multitable-records-list-authz.test.ts --reporter=dot` → 26/26 passed
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit` → passed
- `pnpm validate:plugins` → passed, existing warnings only

## CI

Adds `multitable-record-history-field-mask.test.ts` to the Node 20.x real-DB multitable integration step in `plugin-tests.yml` so this runs against a migrated Postgres DB in CI.
