### PR TITLE
fix(phase5): fail validation when required samples are missing

### DIFF
--- a/scripts/ops/phase5-required-samples-contract.test.mjs
+++ b/scripts/ops/phase5-required-samples-contract.test.mjs
@@ -1,0 +1,122 @@
+import assert from 'node:assert/strict';
+import { execFile } from 'node:child_process';
+import { mkdtemp, readFile, rm } from 'node:fs/promises';
+import { createServer } from 'node:http';
+import os from 'node:os';
+import path from 'node:path';
+import { fileURLToPath } from 'node:url';
+import test from 'node:test';
+
+const __dirname = path.dirname(fileURLToPath(import.meta.url));
+const repoRoot = path.resolve(__dirname, '../..');
+
+function execFileResult(file, args, options) {
+  return new Promise((resolve) => {
+    execFile(file, args, options, (error, stdout, stderr) => {
+      resolve({
+        code: error && typeof error.code === 'number' ? error.code : 0,
+        stdout,
+        stderr,
+      });
+    });
+  });
+}
+
+async function listen(server) {
+  await new Promise((resolve, reject) => {
+    server.once('error', reject);
+    server.listen(0, '127.0.0.1', resolve);
+  });
+
+  const address = server.address();
+  assert(address && typeof address === 'object');
+  return `http://127.0.0.1:${address.port}/metrics/prom`;
+}
+
+async function close(server) {
+  await new Promise((resolve, reject) => {
+    server.close((error) => {
+      if (error) {
+        reject(error);
+      } else {
+        resolve();
+      }
+    });
+  });
+}
+
+async function runPhase5Validation(metricsText) {
+  const dir = await mkdtemp(path.join(os.tmpdir(), 'phase5-required-samples-'));
+  const outputPath = path.join(dir, 'phase5.json');
+  const server = createServer((req, res) => {
+    if (req.url !== '/metrics/prom') {
+      res.writeHead(404);
+      res.end('not found');
+      return;
+    }
+
+    res.writeHead(200, { 'content-type': 'text/plain; version=0.0.4' });
+    res.end(metricsText);
+  });
+
+  try {
+    const metricsUrl = await listen(server);
+    const result = await execFileResult(
+      'bash',
+      ['scripts/phase5-full-validate.sh', metricsUrl, outputPath],
+      {
+        cwd: repoRoot,
+        env: { ...process.env, METRICS_AUTH_HEADER: '', EXTRA_CURL_HEADER: '' },
+        maxBuffer: 1024 * 1024 * 10,
+        timeout: 60_000,
+      },
+    );
+    const json = JSON.parse(await readFile(outputPath, 'utf8'));
+    return { ...result, json };
+  } finally {
+    await close(server);
+    await rm(dir, { recursive: true, force: true });
+  }
+}
+
+const passingCounters = `
+rbac_perm_cache_hits_total 10
+rbac_perm_cache_miss_total 1
+http_requests_total{method="GET",status="200"} 100
+process_resident_memory_bytes 104857600
+`;
+
+const passingLatencySamples = `
+metasheet_plugin_reload_duration_seconds_bucket{plugin_name="example-plugin",le="1"} 10
+metasheet_plugin_reload_duration_seconds_sum{plugin_name="example-plugin"} 5
+metasheet_plugin_reload_duration_seconds_count{plugin_name="example-plugin"} 10
+
+metasheet_snapshot_operation_duration_seconds_bucket{operation="restore",le="1"} 10
+metasheet_snapshot_operation_duration_seconds_sum{operation="restore"} 5
+metasheet_snapshot_operation_duration_seconds_count{operation="restore"} 10
+
+metasheet_snapshot_operation_duration_seconds_bucket{operation="create",le="1"} 10
+metasheet_snapshot_operation_duration_seconds_sum{operation="create"} 5
+metasheet_snapshot_operation_duration_seconds_count{operation="create"} 10
+`;
+
+test('marks overall status fail when required latency samples are missing', async () => {
+  const result = await runPhase5Validation(passingCounters);
+
+  assert.equal(result.code, 1);
+  assert.equal(result.json.summary.overall_status, 'fail');
+  assert.equal(result.json.summary.failed, 0);
+  assert.equal(result.json.summary.na, 6);
+  assert.equal(result.json.summary.passed, 5);
+  assert.equal(result.json.assertions.filter((assertion) => assertion.status === 'na').length, 6);
+});
+
+test('keeps overall status pass when required latency samples satisfy thresholds', async () => {
+  const result = await runPhase5Validation(`${passingCounters}\n${passingLatencySamples}`);
+
+  assert.equal(result.code, 0);
+  assert.equal(result.json.summary.overall_status, 'pass');
+  assert.equal(result.json.summary.failed, 0);
+  assert.equal(result.json.summary.na, 0);
+  assert.equal(result.json.summary.passed, 11);
+});

--- a/scripts/phase5-full-validate.sh
+++ b/scripts/phase5-full-validate.sh
@@ -619,11 +619,12 @@ main() {
 
     log_success "Dynamic assertions generated ($(echo "$assertions" | jq 'length') checks)"
 
-    # Calculate overall pass/fail
+    # Calculate overall pass/fail. Missing latency samples are blocking because
+    # Phase 5 SLO validation cannot prove target latency health from N/A data.
     local pass_count=$(echo "$assertions" | jq '[.[] | select(.status == "pass")] | length')
     local fail_count=$(echo "$assertions" | jq '[.[] | select(.status == "fail")] | length')
     local na_count=$(echo "$assertions" | jq '[.[] | select(.status == "na")] | length')
-    local overall_status=$([ "$fail_count" -eq 0 ] && echo "pass" || echo "fail")
+    local overall_status=$([ "$fail_count" -eq 0 ] && [ "$na_count" -eq 0 ] && echo "pass" || echo "fail")
 
     # Construct final JSON
     local final_json=$(cat <<EOF

--- a/scripts/phase5-generate-report.sh
+++ b/scripts/phase5-generate-report.sh
@@ -97,7 +97,12 @@ EOF
         local comparison=$(echo "$assertions" | jq -r ".[$i].comparison")
         local status=$(echo "$assertions" | jq -r ".[$i].status")
 
-        local status_icon=$([ "$status" = "pass" ] && echo "✅" || echo "❌")
+        local status_icon="❌"
+        if [ "$status" = "pass" ]; then
+            status_icon="✅"
+        elif [ "$status" = "na" ]; then
+            status_icon="⚪"
+        fi
 
         # Format actual and threshold based on unit
         local actual_str="$actual"


### PR DESCRIPTION
## Summary
- make Phase 5 validation fail overall when latency SLO assertions are N/A from missing samples
- render N/A assertion rows distinctly in the markdown report
- add a contract test for missing required samples and the sampled pass path

Related issue: https://github.com/zensgit/metasheet2/issues/1

## Verification
- bash -n scripts/phase5-full-validate.sh scripts/phase5-generate-report.sh scripts/phase5-cache-hit-rate.sh
- node --test scripts/ops/phase5-cache-hit-rate-contract.test.mjs scripts/ops/phase5-required-samples-contract.test.mjs
- git diff --check