### PR TITLE
feat(attendance): filter scheduler scope read surfaces

### DIFF
--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
@@ -42,32 +42,35 @@ describe('attendance advanced scheduling scope foundation', () => {
 
   it('guards the new scheduling group and scheduler-scope routes behind attendance admin or scoped scheduler actions', () => {
     [
-      ['GET', '/api/attendance/schedule-groups'],
       ['POST', '/api/attendance/schedule-groups'],
-      ['GET', '/api/attendance/schedule-groups/:id'],
-      ['GET', '/api/attendance/schedule-groups/:id/members'],
       ['GET', '/api/attendance/scheduler-scopes'],
       ['POST', '/api/attendance/scheduler-scopes'],
       ['PUT', '/api/attendance/scheduler-scopes/:id'],
       ['DELETE', '/api/attendance/scheduler-scopes/:id'],
     ].forEach(([method, path]) => expectAdminRoute(method, path))
     expect(pluginSource).toContain('SCHEDULER_SCOPE_FORBIDDEN')
+    expectDirectAsyncRoute('GET', '/api/attendance/schedule-groups')
+    expectDirectAsyncRoute('GET', '/api/attendance/schedule-groups/:id')
+    expectDirectAsyncRoute('GET', '/api/attendance/schedule-groups/:id/members')
     expectDirectAsyncRoute('POST', '/api/attendance/schedule-groups/:id/members')
     expectDirectAsyncRoute('DELETE', '/api/attendance/schedule-groups/:id/members/:memberId')
     expectDirectAsyncRoute('PUT', '/api/attendance/schedule-groups/:id')
     expectDirectAsyncRoute('DELETE', '/api/attendance/schedule-groups/:id')
-    const scopedDispatchRoutes = [
+    const scopedSchedulerRoutes = [
+      ['GET', '/api/attendance/assignments'],
       ['POST', '/api/attendance/assignments'],
       ['PUT', '/api/attendance/assignments/:id'],
       ['DELETE', '/api/attendance/assignments/:id'],
+      ['GET', '/api/attendance/rotation-assignments'],
       ['POST', '/api/attendance/rotation-assignments'],
       ['PUT', '/api/attendance/rotation-assignments/:id'],
       ['DELETE', '/api/attendance/rotation-assignments/:id'],
     ]
-    scopedDispatchRoutes.forEach(([method, path]) => expectDirectAsyncRoute(method, path))
+    scopedSchedulerRoutes.forEach(([method, path]) => expectDirectAsyncRoute(method, path))
     expect(pluginSource).toContain('resolveAttendanceScheduleAssignmentScopeTarget')
     expect(pluginSource).toContain('assertAttendanceScheduleAssignmentDispatchAllowed')
     expect(pluginSource).toContain('assertAttendanceScheduleGroupEditAllowed')
+    expect(pluginSource).toContain('buildAttendanceAssignmentViewSql')
   })
 
   it('normalizes schedule groups without overloading attendance_groups semantics', () => {

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -169,6 +169,21 @@ function schedulerScopeEditRow(overrides: Record<string, unknown> = {}) {
   })
 }
 
+function schedulerScopeViewRow(overrides: Record<string, unknown> = {}) {
+  return schedulerScopeRow({
+    actions: ['view'],
+    scope: {
+      scheduleGroupIds: [scheduleGroupId],
+      attendanceGroupIds: [],
+      userIds: [],
+      departments: [],
+      roles: [],
+      roleTags: [],
+    },
+    ...overrides,
+  })
+}
+
 function scheduleGroupMemberRow(overrides: Record<string, unknown> = {}) {
   return {
     id: scheduleGroupMemberId,
@@ -219,6 +234,22 @@ function shiftAssignmentRow(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function shiftAssignmentListRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ...shiftAssignmentRow(),
+    shift_name: 'Day Shift',
+    shift_timezone: 'UTC',
+    shift_work_start_time: '09:00',
+    shift_work_end_time: '18:00',
+    shift_is_overnight: false,
+    shift_late_grace_minutes: 10,
+    shift_early_grace_minutes: 10,
+    shift_rounding_minutes: 5,
+    shift_working_days: [1, 2, 3, 4, 5],
+    ...overrides,
+  }
+}
+
 function rotationAssignmentRow(overrides: Record<string, unknown> = {}) {
   return {
     id: rotationAssignmentId,
@@ -230,6 +261,17 @@ function rotationAssignmentRow(overrides: Record<string, unknown> = {}) {
     is_active: true,
     created_at: '2026-05-30T10:00:00.000Z',
     updated_at: '2026-05-30T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function rotationAssignmentListRow(overrides: Record<string, unknown> = {}) {
+  return {
+    ...rotationAssignmentRow(),
+    rotation_name: 'Weekly Rotation',
+    rotation_timezone: 'UTC',
+    rotation_shift_sequence: [shiftId],
+    rotation_is_active: true,
     ...overrides,
   }
 }
@@ -955,6 +997,200 @@ describe('attendance UUID route validation', () => {
     expect(res.statusCode).toBe(200)
     expect(res.body).toEqual({ ok: true, data: { id: scheduleGroupMemberId } })
     expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('DELETE FROM attendance_schedule_group_members'))).toBe(true)
+  })
+
+  it('filters schedule group lists for scoped view actors before pagination', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeViewRow()]
+      if (sql.includes('COUNT(*)::int AS total') && sql.includes('FROM attendance_schedule_groups g')) {
+        expect(sql).toContain('g.id = ANY')
+        expect(params).toEqual(['default', [scheduleGroupId]])
+        return [{ total: 1 }]
+      }
+      if (sql.includes('FROM attendance_schedule_groups g') && sql.includes('ORDER BY g.is_active')) {
+        expect(sql).toContain('g.id = ANY')
+        expect(params).toEqual(['default', [scheduleGroupId], 50, 0])
+        return [scheduleGroupRow()]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'GET /api/attendance/schedule-groups', {
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({ ok: true, data: { total: 1, items: [{ id: scheduleGroupId }] } })
+  })
+
+  it('does not disclose schedule group lookup outside scoped view targets', async () => {
+    const { db, routes } = await createHarness('false')
+    const otherGroupId = '00000000-0000-4000-8000-000000000399'
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) {
+        return [schedulerScopeViewRow({ scope: { scheduleGroupIds: [otherGroupId] } })]
+      }
+      if (sql.includes('SELECT * FROM attendance_schedule_groups WHERE id = $1')) return [scheduleGroupRow()]
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'GET /api/attendance/schedule-groups/:id', {
+      params: { id: scheduleGroupId },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
+  })
+
+  it('filters schedule group member lists by scoped view user targets', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) {
+        return [schedulerScopeViewRow({
+          scope: {
+            scheduleGroupIds: [scheduleGroupId],
+            attendanceGroupIds: [],
+            userIds: ['worker-1'],
+            departments: [],
+            roles: [],
+            roleTags: [],
+          },
+        })]
+      }
+      if (sql.includes('SELECT * FROM attendance_schedule_groups WHERE id = $1')) return [scheduleGroupRow()]
+      if (sql.includes('COUNT(*)::int AS total') && sql.includes('FROM attendance_schedule_group_members')) {
+        expect(sql).toContain('user_id = ANY')
+        expect(params).toEqual(['default', scheduleGroupId, ['worker-1']])
+        return [{ total: 1 }]
+      }
+      if (sql.includes('FROM attendance_schedule_group_members') && sql.includes('ORDER BY effective_from')) {
+        expect(sql).toContain('user_id = ANY')
+        expect(params).toEqual(['default', scheduleGroupId, ['worker-1'], 50, 0])
+        return [scheduleGroupMemberRow()]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'GET /api/attendance/schedule-groups/:id/members', {
+      params: { id: scheduleGroupId },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({ ok: true, data: { total: 1, items: [{ userId: 'worker-1' }] } })
+  })
+
+  it('filters shift assignment lists through scoped schedule group membership windows', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeViewRow()]
+      if (sql.includes('COUNT(*)::int AS total') && sql.includes('FROM attendance_shift_assignments a')) {
+        expect(sql).toContain('EXISTS')
+        expect(sql).toContain('attendance_schedule_group_members')
+        expect(params).toEqual(['default', [scheduleGroupId]])
+        return [{ total: 1 }]
+      }
+      if (sql.includes('FROM attendance_shift_assignments a') && sql.includes('JOIN attendance_shifts')) {
+        expect(sql).toContain('EXISTS')
+        expect(sql).toContain('m.schedule_group_id = ANY')
+        expect(params).toEqual(['default', [scheduleGroupId], 50, 0])
+        return [shiftAssignmentListRow()]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'GET /api/attendance/assignments', {
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: { total: 1, items: [{ assignment: { userId: 'worker-1', shiftId } }] },
+    })
+  })
+
+  it('filters rotation assignment lists through scoped schedule group membership windows', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeViewRow()]
+      if (sql.includes('COUNT(*)::int AS total') && sql.includes('FROM attendance_rotation_assignments a')) {
+        expect(sql).toContain('attendance_schedule_group_members')
+        expect(params).toEqual(['default', [scheduleGroupId]])
+        return [{ total: 1 }]
+      }
+      if (sql.includes('FROM attendance_rotation_assignments a') && sql.includes('JOIN attendance_rotation_rules')) {
+        expect(sql).toContain('m.schedule_group_id = ANY')
+        expect(params).toEqual(['default', [scheduleGroupId], 50, 0])
+        return [rotationAssignmentListRow()]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'GET /api/attendance/rotation-assignments', {
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: { total: 1, items: [{ assignment: { userId: 'worker-1', rotationRuleId } }] },
+    })
+  })
+
+  it('keeps full attendance admin assignment lists unfiltered by scheduler scopes', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params, true)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('COUNT(*)::int AS total') && sql.includes('FROM attendance_shift_assignments a')) {
+        expect(sql).not.toContain('attendance_schedule_group_members')
+        expect(params).toEqual(['default'])
+        return [{ total: 1 }]
+      }
+      if (sql.includes('FROM attendance_shift_assignments a') && sql.includes('JOIN attendance_shifts')) {
+        expect(sql).not.toContain('attendance_schedule_group_members')
+        expect(params).toEqual(['default', 50, 0])
+        return [shiftAssignmentListRow()]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'GET /api/attendance/assignments', {
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({ ok: true, data: { total: 1 } })
+    expect(db.query).not.toHaveBeenCalledWith(expect.stringContaining('FROM attendance_scheduler_scopes'), expect.anything())
   })
 
   it('keeps schedule group creation admin-only because new groups have no scoped target id yet', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -15283,6 +15283,143 @@ module.exports = {
       }
     }
 
+    async function loadAttendanceSchedulerScopesForAction(req, res, { action, actorAccess } = {}) {
+      const access = actorAccess ?? await resolveAttendanceSchedulerScopeActor(req, res)
+      if (!access) return null
+      if (access.fullAdmin) return { access, scopes: [] }
+
+      try {
+        const actorContext = await loadAttendanceScopeContextForUser(db, access.orgId, access.userId)
+        const scopes = (await loadActiveAttendanceSchedulerScopesForActor(access.orgId, actorContext))
+          .filter(scope => normalizeStringArray(scope.actions).includes(action))
+        return { access, scopes }
+      } catch (error) {
+        if (isDatabaseSchemaError(error)) {
+          res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+          return null
+        }
+        logger.error('Attendance scheduler scope action load failed', error)
+        res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Scheduler scope check failed' } })
+        return null
+      }
+    }
+
+    function schedulerScopeUuidArray(values) {
+      return normalizeStringArray(values)
+        .map(value => normalizeUuidString(value))
+        .filter(Boolean)
+    }
+
+    function schedulerScopeSqlBody(scopeRow) {
+      const scope = normalizeAttendanceSchedulerScopeBody(scopeRow?.scope ?? scopeRow)
+      return {
+        scheduleGroupIds: schedulerScopeUuidArray(scope.scheduleGroupIds),
+        attendanceGroupIds: schedulerScopeUuidArray(scope.attendanceGroupIds),
+        userIds: normalizeStringArray(scope.userIds),
+        departments: normalizeStringArray(scope.departments),
+      }
+    }
+
+    function addScopeArrayParam(params, values, cast) {
+      params.push(values)
+      return `$${params.length}::${cast}[]`
+    }
+
+    function buildAttendanceScheduleGroupViewSql(scopes, params, alias = 'g') {
+      const clauses = []
+      for (const scopeRow of scopes) {
+        const scope = schedulerScopeSqlBody(scopeRow)
+        const conditions = []
+        if (scope.scheduleGroupIds.length) {
+          conditions.push(`${alias}.id = ANY(${addScopeArrayParam(params, scope.scheduleGroupIds, 'uuid')})`)
+        }
+        if (scope.attendanceGroupIds.length) {
+          conditions.push(`${alias}.attendance_group_id = ANY(${addScopeArrayParam(params, scope.attendanceGroupIds, 'uuid')})`)
+        }
+        if (scope.departments.length) {
+          conditions.push(`${alias}.department_ref = ANY(${addScopeArrayParam(params, scope.departments, 'text')})`)
+        }
+        if (conditions.length) clauses.push(`(${conditions.join(' AND ')})`)
+      }
+      return clauses.length ? `(${clauses.join(' OR ')})` : 'FALSE'
+    }
+
+    function attendanceSchedulerScopeMatchesScheduleGroupRow(scopeRow, groupRow) {
+      const scope = schedulerScopeSqlBody(scopeRow)
+      let constrained = false
+      if (scope.scheduleGroupIds.length) {
+        constrained = true
+        if (!scope.scheduleGroupIds.includes(groupRow.id)) return false
+      }
+      if (scope.attendanceGroupIds.length) {
+        constrained = true
+        if (!groupRow.attendance_group_id || !scope.attendanceGroupIds.includes(groupRow.attendance_group_id)) return false
+      }
+      if (scope.departments.length) {
+        constrained = true
+        if (!groupRow.department_ref || !scope.departments.includes(groupRow.department_ref)) return false
+      }
+      return constrained
+    }
+
+    function resolveAttendanceScheduleGroupMemberViewFilter(scopes, groupRow) {
+      const userIds = new Set()
+      let fullGroup = false
+      for (const scopeRow of scopes) {
+        if (!attendanceSchedulerScopeMatchesScheduleGroupRow(scopeRow, groupRow)) continue
+        const scope = schedulerScopeSqlBody(scopeRow)
+        if (scope.userIds.length === 0) {
+          fullGroup = true
+        } else {
+          for (const userId of scope.userIds) userIds.add(userId)
+        }
+      }
+      return { allowed: fullGroup || userIds.size > 0, fullGroup, userIds: [...userIds].sort() }
+    }
+
+    function buildAttendanceAssignmentViewSql(scopes, params, alias = 'a') {
+      const clauses = []
+      for (const scopeRow of scopes) {
+        const scope = schedulerScopeSqlBody(scopeRow)
+        const conditions = []
+        if (scope.userIds.length) {
+          conditions.push(`${alias}.user_id = ANY(${addScopeArrayParam(params, scope.userIds, 'text')})`)
+        }
+
+        const groupConditions = []
+        if (scope.scheduleGroupIds.length) {
+          groupConditions.push(`m.schedule_group_id = ANY(${addScopeArrayParam(params, scope.scheduleGroupIds, 'uuid')})`)
+        }
+        if (scope.attendanceGroupIds.length) {
+          groupConditions.push(`g.attendance_group_id = ANY(${addScopeArrayParam(params, scope.attendanceGroupIds, 'uuid')})`)
+        }
+        if (scope.departments.length) {
+          groupConditions.push(`g.department_ref = ANY(${addScopeArrayParam(params, scope.departments, 'text')})`)
+        }
+        if (groupConditions.length) {
+          conditions.push(
+            `EXISTS (
+               SELECT 1
+               FROM attendance_schedule_group_members m
+               JOIN attendance_schedule_groups g
+                 ON g.id = m.schedule_group_id
+                AND g.org_id = m.org_id
+                AND COALESCE(g.is_active, true) = true
+               WHERE m.org_id = ${alias}.org_id
+                 AND m.user_id = ${alias}.user_id
+                 AND m.schedule_group_id IS NOT NULL
+                 AND COALESCE(m.effective_from, DATE '0001-01-01') <= COALESCE(${alias}.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}')
+                 AND COALESCE(m.effective_to, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= ${alias}.start_date
+                 AND ${groupConditions.join(' AND ')}
+             )`
+          )
+        }
+
+        if (conditions.length) clauses.push(`(${conditions.join(' AND ')})`)
+      }
+      return clauses.length ? `AND (${clauses.join(' OR ')})` : 'AND FALSE'
+    }
+
     async function resolveAttendanceScheduleAssignmentScopeTarget(orgId, payload) {
       const userId = payload?.userId ?? payload?.user_id
       const startDate = normalizeDateOnly(payload?.startDate ?? payload?.start_date) ?? payload?.startDate ?? payload?.start_date
@@ -20803,7 +20940,7 @@ module.exports = {
     context.api.http.addRoute(
       'GET',
       '/api/attendance/rotation-assignments',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const schema = z.object({
           orgId: z.string().optional(),
         })
@@ -20819,26 +20956,37 @@ module.exports = {
 
         const { page, pageSize, offset } = parsePagination(req.query)
         const orgId = getOrgId(req)
+        const viewAccess = await loadAttendanceSchedulerScopesForAction(req, res, { action: 'view' })
+        if (!viewAccess) return
 
         try {
+          const countParams = [orgId]
+          const countScopeClause = viewAccess.access.fullAdmin
+            ? ''
+            : buildAttendanceAssignmentViewSql(viewAccess.scopes, countParams, 'a')
           const countRows = await db.query(
             `SELECT COUNT(*)::int AS total
-             FROM attendance_rotation_assignments
-             WHERE org_id = $1`,
-            [orgId]
+             FROM attendance_rotation_assignments a
+             WHERE a.org_id = $1 ${countScopeClause}`,
+            countParams
           )
           const total = Number(countRows[0]?.total ?? 0)
 
+          const rowParams = [orgId]
+          const rowScopeClause = viewAccess.access.fullAdmin
+            ? ''
+            : buildAttendanceAssignmentViewSql(viewAccess.scopes, rowParams, 'a')
+          rowParams.push(pageSize, offset)
           const rows = await db.query(
             `SELECT a.id, a.org_id, a.user_id, a.rotation_rule_id, a.start_date, a.end_date, a.is_active,
                     r.name AS rotation_name, r.timezone AS rotation_timezone, r.shift_sequence AS rotation_shift_sequence,
                     r.is_active AS rotation_is_active
              FROM attendance_rotation_assignments a
              JOIN attendance_rotation_rules r ON r.id = a.rotation_rule_id
-             WHERE a.org_id = $1
+             WHERE a.org_id = $1 ${rowScopeClause}
              ORDER BY a.start_date DESC, a.created_at DESC
-             LIMIT $2 OFFSET $3`,
-            [orgId, pageSize, offset]
+             LIMIT $${rowParams.length - 1} OFFSET $${rowParams.length}`,
+            rowParams
           )
 
           const items = rows.map(row => ({
@@ -20863,7 +21011,7 @@ module.exports = {
           logger.error('Attendance rotation assignments query failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load rotation assignments' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(
@@ -27343,26 +27491,37 @@ module.exports = {
     context.api.http.addRoute(
       'GET',
       '/api/attendance/schedule-groups',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const orgId = getOrgId(req)
         const { page, pageSize, offset } = parsePagination(req.query)
         const includeInactive = parseBoolean(req.query.includeInactive, false)
+        const viewAccess = await loadAttendanceSchedulerScopesForAction(req, res, { action: 'view' })
+        if (!viewAccess) return
         try {
-          const activeClause = includeInactive ? '' : 'AND is_active = true'
+          const activeClause = includeInactive ? '' : 'AND g.is_active = true'
+          const countParams = [orgId]
+          const countScopeClause = viewAccess.access.fullAdmin
+            ? ''
+            : `AND ${buildAttendanceScheduleGroupViewSql(viewAccess.scopes, countParams, 'g')}`
           const countRows = await db.query(
             `SELECT COUNT(*)::int AS total
-             FROM attendance_schedule_groups
-             WHERE org_id = $1 ${activeClause}`,
-            [orgId]
+             FROM attendance_schedule_groups g
+             WHERE g.org_id = $1 ${activeClause} ${countScopeClause}`,
+            countParams
           )
           const total = Number(countRows[0]?.total ?? 0)
+          const rowParams = [orgId]
+          const rowScopeClause = viewAccess.access.fullAdmin
+            ? ''
+            : `AND ${buildAttendanceScheduleGroupViewSql(viewAccess.scopes, rowParams, 'g')}`
+          rowParams.push(pageSize, offset)
           const rows = await db.query(
             `SELECT *
-             FROM attendance_schedule_groups
-             WHERE org_id = $1 ${activeClause}
-             ORDER BY is_active DESC, name ASC, created_at DESC
-             LIMIT $2 OFFSET $3`,
-            [orgId, pageSize, offset]
+             FROM attendance_schedule_groups g
+             WHERE g.org_id = $1 ${activeClause} ${rowScopeClause}
+             ORDER BY g.is_active DESC, g.name ASC, g.created_at DESC
+             LIMIT $${rowParams.length - 1} OFFSET $${rowParams.length}`,
+            rowParams
           )
           res.json({ ok: true, data: { items: rows.map(mapAttendanceScheduleGroupRow), total, page, pageSize } })
         } catch (error) {
@@ -27373,26 +27532,36 @@ module.exports = {
           logger.error('Attendance schedule groups fetch failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load schedule groups' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(
       'GET',
       '/api/attendance/schedule-groups/:id',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const orgId = getOrgId(req)
         const groupId = normalizeUuidString(req.params.id)
         if (!groupId) {
           respondInvalidUuid(res)
           return
         }
+        const viewAccess = await loadAttendanceSchedulerScopesForAction(req, res, { action: 'view' })
+        if (!viewAccess) return
         try {
           const rows = await db.query(
             'SELECT * FROM attendance_schedule_groups WHERE id = $1 AND org_id = $2',
             [groupId, orgId]
           )
           if (!rows.length) {
+            if (!viewAccess.access.fullAdmin) {
+              respondAttendanceSchedulerScopeForbidden(res)
+              return
+            }
             res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Schedule group not found' } })
+            return
+          }
+          if (!viewAccess.access.fullAdmin && !viewAccess.scopes.some(scope => attendanceSchedulerScopeMatchesScheduleGroupRow(scope, rows[0]))) {
+            respondAttendanceSchedulerScopeForbidden(res)
             return
           }
           res.json({ ok: true, data: mapAttendanceScheduleGroupRow(rows[0]) })
@@ -27404,7 +27573,7 @@ module.exports = {
           logger.error('Attendance schedule group lookup failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load schedule group' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(
@@ -27599,7 +27768,7 @@ module.exports = {
     context.api.http.addRoute(
       'GET',
       '/api/attendance/schedule-groups/:id/members',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const orgId = getOrgId(req)
         const groupId = normalizeUuidString(req.params.id)
         if (!groupId) {
@@ -27607,20 +27776,47 @@ module.exports = {
           return
         }
         const { page, pageSize, offset } = parsePagination(req.query)
+        const viewAccess = await loadAttendanceSchedulerScopesForAction(req, res, { action: 'view' })
+        if (!viewAccess) return
         try {
+          let memberFilter = { fullGroup: true, userIds: [] }
+          if (!viewAccess.access.fullAdmin) {
+            const groupRows = await db.query(
+              'SELECT * FROM attendance_schedule_groups WHERE id = $1 AND org_id = $2',
+              [groupId, orgId]
+            )
+            if (!groupRows.length) {
+              respondAttendanceSchedulerScopeForbidden(res)
+              return
+            }
+            memberFilter = resolveAttendanceScheduleGroupMemberViewFilter(viewAccess.scopes, groupRows[0])
+            if (!memberFilter.allowed) {
+              respondAttendanceSchedulerScopeForbidden(res)
+              return
+            }
+          }
+          const countParams = [orgId, groupId]
+          const memberUserClause = !viewAccess.access.fullAdmin && !memberFilter.fullGroup
+            ? `AND user_id = ANY(${addScopeArrayParam(countParams, memberFilter.userIds, 'text')})`
+            : ''
           const countRows = await db.query(
             `SELECT COUNT(*)::int AS total
              FROM attendance_schedule_group_members
-             WHERE org_id = $1 AND schedule_group_id = $2`,
-            [orgId, groupId]
+             WHERE org_id = $1 AND schedule_group_id = $2 ${memberUserClause}`,
+            countParams
           )
+          const rowParams = [orgId, groupId]
+          const rowUserClause = !viewAccess.access.fullAdmin && !memberFilter.fullGroup
+            ? `AND user_id = ANY(${addScopeArrayParam(rowParams, memberFilter.userIds, 'text')})`
+            : ''
+          rowParams.push(pageSize, offset)
           const rows = await db.query(
             `SELECT *
              FROM attendance_schedule_group_members
-             WHERE org_id = $1 AND schedule_group_id = $2
+             WHERE org_id = $1 AND schedule_group_id = $2 ${rowUserClause}
              ORDER BY effective_from ASC NULLS FIRST, user_id ASC, created_at DESC
-             LIMIT $3 OFFSET $4`,
-            [orgId, groupId, pageSize, offset]
+             LIMIT $${rowParams.length - 1} OFFSET $${rowParams.length}`,
+            rowParams
           )
           res.json({
             ok: true,
@@ -27634,7 +27830,7 @@ module.exports = {
           logger.error('Attendance schedule group members fetch failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load schedule group members' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(
@@ -28559,7 +28755,7 @@ module.exports = {
     context.api.http.addRoute(
       'GET',
       '/api/attendance/assignments',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const schema = z.object({
           orgId: z.string().optional(),
           userId: z.string().optional(),
@@ -28579,24 +28775,38 @@ module.exports = {
 
         const orgId = getOrgId(req)
         const { page, pageSize, offset } = parsePagination(req.query)
+        const viewAccess = await loadAttendanceSchedulerScopesForAction(req, res, { action: 'view' })
+        if (!viewAccess) return
 
         try {
-          const params = [orgId]
+          const countParams = [orgId]
           let userFilter = ''
           if (parsed.data.userId) {
-            params.push(parsed.data.userId)
-            userFilter = `AND a.user_id = $${params.length}`
+            countParams.push(parsed.data.userId)
+            userFilter = `AND a.user_id = $${countParams.length}`
           }
+          const countScopeClause = viewAccess.access.fullAdmin
+            ? ''
+            : buildAttendanceAssignmentViewSql(viewAccess.scopes, countParams, 'a')
 
           const countRows = await db.query(
             `SELECT COUNT(*)::int AS total
              FROM attendance_shift_assignments a
-             WHERE a.org_id = $1 ${userFilter}`,
-            params
+             WHERE a.org_id = $1 ${userFilter} ${countScopeClause}`,
+            countParams
           )
           const total = Number(countRows[0]?.total ?? 0)
 
-          params.push(pageSize, offset)
+          const rowParams = [orgId]
+          let rowUserFilter = ''
+          if (parsed.data.userId) {
+            rowParams.push(parsed.data.userId)
+            rowUserFilter = `AND a.user_id = $${rowParams.length}`
+          }
+          const rowScopeClause = viewAccess.access.fullAdmin
+            ? ''
+            : buildAttendanceAssignmentViewSql(viewAccess.scopes, rowParams, 'a')
+          rowParams.push(pageSize, offset)
           const rows = await db.query(
             `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.start_date, a.end_date, a.is_active,
                     s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
@@ -28605,10 +28815,10 @@ module.exports = {
                     s.working_days AS shift_working_days
              FROM attendance_shift_assignments a
              JOIN attendance_shifts s ON s.id = a.shift_id
-             WHERE a.org_id = $1 ${userFilter}
+             WHERE a.org_id = $1 ${rowUserFilter} ${rowScopeClause}
              ORDER BY a.start_date DESC, a.created_at DESC
-             LIMIT $${params.length - 1} OFFSET $${params.length}`,
-            params
+             LIMIT $${rowParams.length - 1} OFFSET $${rowParams.length}`,
+            rowParams
           )
 
           res.json({
@@ -28631,7 +28841,7 @@ module.exports = {
           logger.error('Attendance assignments query failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load assignments' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(


### PR DESCRIPTION
## Summary
- adds scheduler-scope `view` filtering to schedule group list/detail, schedule group member list, shift assignment list, and rotation assignment list
- keeps full attendance admins on the existing unfiltered read path
- keeps scheduler-scope registry, group creation, UI delegation, import/export/clear/approve, and enforcement expansion out of this slice

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts tests/unit/attendance-advanced-scheduling-scope.test.ts --watch=false` (40/40)
- `pnpm --filter @metasheet/core-backend build`

## Known local baseline
- `pnpm --filter @metasheet/core-backend test:unit` was run before the final helper cleanup and hit the existing local baseline red at `tests/unit/script-sandbox-python-portability.test.ts:127` (`expected false to be true` in the Python sandbox end-to-end portability spec). This same red was confirmed on a clean `origin/main` baseline in the previous E3 pass; not part of this slice.