### PR TITLE
feat(web): data-sources UI-2 connection test action

### DIFF
--- a/apps/web/src/data-sources/api.ts
+++ b/apps/web/src/data-sources/api.ts
@@ -1,10 +1,15 @@
-// Typed client for the generic external data-source connector API (UI-1: list / create / delete).
+// Typed client for the generic external data-source connector API.
 import { apiGet, apiFetch } from '../utils/api'
-import type { CreateDataSourcePayload, DataSourceListItem } from './types'
+import type { CreateDataSourcePayload, DataSourceListItem, DataSourceTestResult } from './types'
 
 interface ListEnvelope {
   ok: boolean
   data?: { items?: DataSourceListItem[]; total?: number }
+}
+
+interface TestEnvelope {
+  ok: boolean
+  data?: DataSourceTestResult
 }
 
 interface ErrorEnvelope {
@@ -34,4 +39,16 @@ export async function deleteDataSource(id: string): Promise<void> {
   if (!res.ok) {
     throw new Error(await errorFrom(res, 'Failed to delete data source'))
   }
+}
+
+export async function testDataSourceConnection(id: string): Promise<DataSourceTestResult> {
+  const res = await apiFetch(`/api/data-sources/${encodeURIComponent(id)}/test`)
+  if (!res.ok) {
+    throw new Error(await errorFrom(res, 'Failed to test data source'))
+  }
+  const body = await res.json() as TestEnvelope
+  if (!body.data) {
+    throw new Error('Failed to test data source: empty response')
+  }
+  return body.data
 }

--- a/apps/web/src/data-sources/types.ts
+++ b/apps/web/src/data-sources/types.ts
@@ -23,6 +23,14 @@ export interface DataSourceListItem {
   connected: boolean
 }
 
+/** Result from `GET /api/data-sources/:id/test`. Request success is separate from connection success. */
+export interface DataSourceTestResult {
+  id: string
+  success: boolean
+  latency?: string
+  error?: { message?: string }
+}
+
 /** Connection fields — a free-form record on the wire; these are the common typed keys the form uses. */
 export interface DataSourceConnectionInput {
   host?: string

--- a/apps/web/src/stores/dataSources.ts
+++ b/apps/web/src/stores/dataSources.ts
@@ -1,14 +1,16 @@
-// External data-source connector store (UI-1: list / create / delete). Edit is deferred to UI-2 —
+// External data-source connector store (UI-1/UI-2: list / create / delete / test). Edit is deferred —
 // it needs omit-blank-not-empty credential handling + PUT deep-merge, which warrant their own slice.
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import { createDataSource, deleteDataSource, listDataSources } from '../data-sources/api'
-import type { CreateDataSourcePayload, DataSourceListItem } from '../data-sources/types'
+import { createDataSource, deleteDataSource, listDataSources, testDataSourceConnection } from '../data-sources/api'
+import type { CreateDataSourcePayload, DataSourceListItem, DataSourceTestResult } from '../data-sources/types'
 
 export const useDataSourcesStore = defineStore('dataSources', () => {
   const items = ref<DataSourceListItem[]>([])
   const loading = ref(false)
   const error = ref<string | null>(null)
+  const testing = ref<Record<string, boolean>>({})
+  const testResults = ref<Record<string, DataSourceTestResult>>({})
 
   async function fetchAll(): Promise<void> {
     loading.value = true
@@ -40,6 +42,9 @@ export const useDataSourcesStore = defineStore('dataSources', () => {
     error.value = null
     try {
       await deleteDataSource(id)
+      const remainingResults = { ...testResults.value }
+      delete remainingResults[id]
+      testResults.value = remainingResults
       await fetchAll()
       return true
     } catch (e) {
@@ -48,5 +53,27 @@ export const useDataSourcesStore = defineStore('dataSources', () => {
     }
   }
 
-  return { items, loading, error, fetchAll, create, remove }
+  function isTesting(id: string): boolean {
+    return testing.value[id] === true
+  }
+
+  async function testConnection(id: string): Promise<boolean> {
+    error.value = null
+    testing.value = { ...testing.value, [id]: true }
+    try {
+      const result = await testDataSourceConnection(id)
+      testResults.value = { ...testResults.value, [id]: result }
+      await fetchAll()
+      return result.success
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to test data source'
+      return false
+    } finally {
+      const remaining = { ...testing.value }
+      delete remaining[id]
+      testing.value = remaining
+    }
+  }
+
+  return { items, loading, error, testing, testResults, isTesting, fetchAll, create, remove, testConnection }
 })

--- a/apps/web/src/views/DataSourcesView.vue
+++ b/apps/web/src/views/DataSourcesView.vue
@@ -84,7 +84,7 @@
       </p>
       <table v-else class="data-sources__table">
         <thead>
-          <tr><th>名称</th><th>类型</th><th>状态</th><th></th></tr>
+          <tr><th>名称</th><th>类型</th><th>状态</th><th>连接测试</th><th></th></tr>
         </thead>
         <tbody>
           <tr v-for="ds in store.items" :key="ds.id" data-testid="ds-row" :data-ds-id="ds.id">
@@ -98,10 +98,31 @@
             <td>
               <button
                 type="button"
-                class="data-sources__btn data-sources__btn--danger"
-                data-testid="ds-delete"
-                @click="confirmRemove(ds.id, ds.name)"
-              >删除</button>
+                class="data-sources__btn"
+                data-testid="ds-test"
+                :disabled="store.isTesting(ds.id)"
+                @click="testConnection(ds.id)"
+              >
+                {{ store.isTesting(ds.id) ? '测试中…' : '测试连接' }}
+              </button>
+              <p
+                v-if="store.testResults[ds.id]"
+                class="data-sources__test-result"
+                :class="store.testResults[ds.id].success ? 'is-ok' : 'is-fail'"
+                data-testid="ds-test-result"
+              >
+                {{ testResultText(ds.id) }}
+              </p>
+            </td>
+            <td>
+              <div class="data-sources__actions">
+                <button
+                  type="button"
+                  class="data-sources__btn data-sources__btn--danger"
+                  data-testid="ds-delete"
+                  @click="confirmRemove(ds.id, ds.name)"
+                >删除</button>
+              </div>
             </td>
           </tr>
         </tbody>
@@ -145,6 +166,15 @@ function typeLabel(type: string): string {
   return DATA_SOURCE_TYPE_LABELS[type as DataSourceType] ?? type
 }
 
+function testResultText(id: string): string {
+  const result = store.testResults[id]
+  if (!result) return ''
+  if (result.success) {
+    return `通过${result.latency ? ` · ${result.latency}` : ''}`
+  }
+  return `失败${result.error?.message ? ` · ${result.error.message}` : ''}`
+}
+
 function toggleForm(): void {
   formOpen.value = !formOpen.value
   store.error = null
@@ -168,6 +198,10 @@ async function submit(): Promise<void> {
   } finally {
     submitting.value = false
   }
+}
+
+async function testConnection(id: string): Promise<void> {
+  await store.testConnection(id)
 }
 
 async function confirmRemove(id: string, name: string): Promise<void> {
@@ -194,14 +228,18 @@ onMounted(() => {
 .data-sources__checkbox { flex-direction: row; align-items: center; gap: 8px; }
 .data-sources__form-actions { margin-top: 8px; }
 .data-sources__btn { padding: 6px 14px; border-radius: 6px; border: 1px solid #d1d5db; background: #fff; cursor: pointer; font-size: 13px; }
+.data-sources__btn:disabled { opacity: 0.6; cursor: default; }
 .data-sources__btn--primary { background: #2563eb; border-color: #2563eb; color: #fff; }
-.data-sources__btn--primary:disabled { opacity: 0.6; cursor: default; }
 .data-sources__btn--danger { color: #cf1322; border-color: #ffccc7; }
 .data-sources__list { margin-top: 8px; }
 .data-sources__muted { color: #9ca3af; font-size: 13px; }
 .data-sources__table { width: 100%; border-collapse: collapse; font-size: 13px; }
 .data-sources__table th, .data-sources__table td { text-align: left; padding: 8px 10px; border-bottom: 1px solid #f0f0f0; vertical-align: top; }
-.data-sources__status { font-size: 12px; padding: 2px 8px; border-radius: 10px; }
+.data-sources__status { font-size: 12px; padding: 2px 8px; border-radius: 10px; white-space: nowrap; }
 .data-sources__status.is-on { background: #f6ffed; color: #389e0d; }
 .data-sources__status.is-off { background: #f5f5f5; color: #8c8c8c; }
+.data-sources__actions { display: flex; justify-content: flex-end; }
+.data-sources__test-result { margin: 6px 0 0; font-size: 12px; max-width: 260px; overflow-wrap: anywhere; }
+.data-sources__test-result.is-ok { color: #237804; }
+.data-sources__test-result.is-fail { color: #cf1322; }
 </style>

--- a/apps/web/tests/data-sources-ui.spec.ts
+++ b/apps/web/tests/data-sources-ui.spec.ts
@@ -1,5 +1,6 @@
-import { beforeEach, describe, expect, it, vi } from 'vitest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
+import { createApp, nextTick } from 'vue'
 
 import { buildCreatePayload, type CreateFormState } from '../src/data-sources/buildPayload'
 
@@ -7,13 +8,16 @@ import { buildCreatePayload, type CreateFormState } from '../src/data-sources/bu
 const listMock = vi.hoisted(() => vi.fn())
 const createMock = vi.hoisted(() => vi.fn())
 const deleteMock = vi.hoisted(() => vi.fn())
+const testConnectionMock = vi.hoisted(() => vi.fn())
 vi.mock('../src/data-sources/api', () => ({
   listDataSources: listMock,
   createDataSource: createMock,
   deleteDataSource: deleteMock,
+  testDataSourceConnection: testConnectionMock,
 }))
 
 import { useDataSourcesStore } from '../src/stores/dataSources'
+import DataSourcesView from '../src/views/DataSourcesView.vue'
 
 function form(overrides: Partial<CreateFormState> = {}): CreateFormState {
   return {
@@ -106,5 +110,85 @@ describe('useDataSourcesStore (UI-1)', () => {
     expect(ok).toBe(true)
     expect(deleteMock).toHaveBeenCalledWith('a')
     expect(store.items).toEqual([])
+  })
+
+  it('testConnection stores the per-source result and refetches connection state', async () => {
+    testConnectionMock.mockResolvedValue({ id: 'a', success: true, latency: '12ms' })
+    listMock.mockResolvedValue([{ id: 'a', name: 'A', type: 'postgres', connected: true }])
+    const store = useDataSourcesStore()
+    const ok = await store.testConnection('a')
+    expect(ok).toBe(true)
+    expect(testConnectionMock).toHaveBeenCalledWith('a')
+    expect(store.testResults.a).toEqual({ id: 'a', success: true, latency: '12ms' })
+    expect(store.items[0].connected).toBe(true)
+    expect(store.isTesting('a')).toBe(false)
+  })
+
+  it('testConnection keeps connection failure as a row result, not a global load error', async () => {
+    testConnectionMock.mockResolvedValue({ id: 'a', success: false, error: { message: 'timeout' } })
+    listMock.mockResolvedValue([{ id: 'a', name: 'A', type: 'postgres', connected: false }])
+    const store = useDataSourcesStore()
+    const ok = await store.testConnection('a')
+    expect(ok).toBe(false)
+    expect(store.error).toBeNull()
+    expect(store.testResults.a.success).toBe(false)
+    expect(store.testResults.a.error?.message).toBe('timeout')
+  })
+})
+
+describe('DataSourcesView (UI-2 connection test reachability)', () => {
+  let cleanup: (() => void) | null = null
+
+  beforeEach(() => {
+    vi.clearAllMocks()
+    document.body.innerHTML = ''
+  })
+
+  afterEach(() => {
+    cleanup?.()
+    cleanup = null
+    document.body.innerHTML = ''
+  })
+
+  async function flush(): Promise<void> {
+    await Promise.resolve()
+    await nextTick()
+    await Promise.resolve()
+    await nextTick()
+  }
+
+  async function mountView(): Promise<HTMLElement> {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const app = createApp(DataSourcesView)
+    app.use(createPinia())
+    app.mount(container)
+    cleanup = () => app.unmount()
+    await flush()
+    return container
+  }
+
+  it('clicking a row test button calls the test endpoint and renders the row result', async () => {
+    listMock.mockResolvedValue([{ id: 'a', name: 'A', type: 'postgres', connected: false }])
+    testConnectionMock.mockResolvedValue({
+      id: 'a',
+      success: false,
+      latency: '24ms',
+      error: { message: 'timeout' },
+    })
+
+    const container = await mountView()
+    const testButton = container.querySelector('[data-testid="ds-test"]') as HTMLButtonElement | null
+    expect(testButton).not.toBeNull()
+
+    testButton!.click()
+    await flush()
+    await flush()
+    await flush()
+
+    expect(testConnectionMock).toHaveBeenCalledWith('a')
+    const result = container.querySelector('[data-testid="ds-test-result"]')
+    expect(result?.textContent).toContain('失败')
+    expect(result?.textContent).toContain('timeout')
   })
 })


### PR DESCRIPTION
## Summary

Adds the next low-risk data-sources UI slice on top of #2147: a per-row connection-test action over the existing scoped read endpoint.

- Adds a typed client for `GET /api/data-sources/:id/test`
- Adds Pinia state for per-row testing/result display
- Adds a `测试连接` action in `DataSourcesView` with success/failure/latency feedback
- Refreshes the list after a completed test so the connected state stays current

## Scope

- Frontend only
- No credential edit/update UI
- No connect/disconnect write action
- No query/select/schema execution UI

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/data-sources-ui.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/web exec eslint 'src/data-sources/*.ts' src/stores/dataSources.ts src/views/DataSourcesView.vue tests/data-sources-ui.spec.ts --max-warnings=0`

## Test notes

Includes store coverage for request success vs connection failure, plus a component reachability test that mounts `DataSourcesView`, clicks the row test button, and asserts the API mock is called and the row result renders.
