### PR TITLE
feat(web): data-sources UI-3 non-secret edit flow

### DIFF
--- a/apps/web/src/data-sources/api.ts
+++ b/apps/web/src/data-sources/api.ts
@@ -1,10 +1,21 @@
 // Typed client for the generic external data-source connector API.
 import { apiGet, apiFetch } from '../utils/api'
-import type { CreateDataSourcePayload, DataSourceListItem, DataSourceTestResult } from './types'
+import type {
+  CreateDataSourcePayload,
+  DataSourceDetail,
+  DataSourceListItem,
+  DataSourceTestResult,
+  UpdateDataSourcePayload,
+} from './types'
 
 interface ListEnvelope {
   ok: boolean
   data?: { items?: DataSourceListItem[]; total?: number }
+}
+
+interface DetailEnvelope {
+  ok: boolean
+  data?: DataSourceDetail
 }
 
 interface TestEnvelope {
@@ -27,10 +38,28 @@ export async function listDataSources(): Promise<DataSourceListItem[]> {
   return res.data?.items ?? []
 }
 
+export async function getDataSource(id: string): Promise<DataSourceDetail> {
+  const res = await apiGet<DetailEnvelope>(`/api/data-sources/${encodeURIComponent(id)}`)
+  if (!res.data) {
+    throw new Error('Failed to load data source: empty response')
+  }
+  return res.data
+}
+
 export async function createDataSource(payload: CreateDataSourcePayload): Promise<void> {
   const res = await apiFetch('/api/data-sources', { method: 'POST', body: JSON.stringify(payload) })
   if (!res.ok) {
     throw new Error(await errorFrom(res, 'Failed to create data source'))
+  }
+}
+
+export async function updateDataSource(id: string, payload: UpdateDataSourcePayload): Promise<void> {
+  const res = await apiFetch(`/api/data-sources/${encodeURIComponent(id)}`, {
+    method: 'PUT',
+    body: JSON.stringify(payload),
+  })
+  if (!res.ok) {
+    throw new Error(await errorFrom(res, 'Failed to update data source'))
   }
 }
 

--- a/apps/web/src/data-sources/buildPayload.ts
+++ b/apps/web/src/data-sources/buildPayload.ts
@@ -1,6 +1,7 @@
 // Pure builder for the create payload — extracted so the credential-safety rule (OMIT blank
 // optional fields; never send an empty string as a value) is unit-testable without mounting the view.
 import type { CreateDataSourcePayload, DataSourceType } from './types'
+import type { UpdateDataSourcePayload } from './types'
 
 export interface CreateFormState {
   id: string
@@ -44,5 +45,30 @@ export function buildCreatePayload(form: CreateFormState): CreateDataSourcePaylo
     options: { readOnly: form.readOnly },
   }
   if (Object.keys(credentials).length > 0) payload.credentials = credentials
+  return payload
+}
+
+/**
+ * Build the `PUT /api/data-sources/:id` payload from the same form state.
+ * Credentials are deliberately excluded: the backend update schema does not
+ * accept them, and blank secret inputs must never be interpreted as rotation.
+ */
+export function buildUpdatePayload(form: CreateFormState): UpdateDataSourcePayload {
+  const isSql = form.type !== 'http'
+  const connection: UpdateDataSourcePayload['connection'] = {}
+
+  if (isSql) {
+    if (form.host) connection.host = form.host
+    if (typeof form.port === 'number' && Number.isFinite(form.port)) connection.port = form.port
+    if (form.database) connection.database = form.database
+  } else if (form.baseURL) {
+    connection.baseURL = form.baseURL
+  }
+
+  const payload: UpdateDataSourcePayload = {
+    name: form.name,
+    connection,
+    options: { readOnly: form.readOnly },
+  }
   return payload
 }

--- a/apps/web/src/data-sources/types.ts
+++ b/apps/web/src/data-sources/types.ts
@@ -23,6 +23,13 @@ export interface DataSourceListItem {
   connected: boolean
 }
 
+/** Sanitized detail from `GET /api/data-sources/:id`; credentials are never returned. */
+export interface DataSourceDetail extends DataSourceListItem {
+  connection: DataSourceConnectionInput
+  options?: { readOnly?: boolean; autoConnect?: boolean }
+  hasCredentials?: boolean
+}
+
 /** Result from `GET /api/data-sources/:id/test`. Request success is separate from connection success. */
 export interface DataSourceTestResult {
   id: string
@@ -49,5 +56,12 @@ export interface CreateDataSourcePayload {
   type: DataSourceType
   connection: DataSourceConnectionInput
   credentials?: { username?: string; password?: string; apiKey?: string; token?: string }
+  options?: { readOnly?: boolean; autoConnect?: boolean }
+}
+
+/** Payload for `PUT /api/data-sources/:id`. Credential rotation is intentionally out of this UI slice. */
+export interface UpdateDataSourcePayload {
+  name?: string
+  connection?: DataSourceConnectionInput
   options?: { readOnly?: boolean; autoConnect?: boolean }
 }

--- a/apps/web/src/stores/dataSources.ts
+++ b/apps/web/src/stores/dataSources.ts
@@ -1,9 +1,22 @@
-// External data-source connector store (UI-1/UI-2: list / create / delete / test). Edit is deferred —
-// it needs omit-blank-not-empty credential handling + PUT deep-merge, which warrant their own slice.
+// External data-source connector store (UI-1/UI-2/UI-3: list / create / update / delete / test).
+// Credential rotation is intentionally deferred; the update route currently accepts non-secret config only.
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
-import { createDataSource, deleteDataSource, listDataSources, testDataSourceConnection } from '../data-sources/api'
-import type { CreateDataSourcePayload, DataSourceListItem, DataSourceTestResult } from '../data-sources/types'
+import {
+  createDataSource,
+  deleteDataSource,
+  getDataSource,
+  listDataSources,
+  testDataSourceConnection,
+  updateDataSource,
+} from '../data-sources/api'
+import type {
+  CreateDataSourcePayload,
+  DataSourceDetail,
+  DataSourceListItem,
+  DataSourceTestResult,
+  UpdateDataSourcePayload,
+} from '../data-sources/types'
 
 export const useDataSourcesStore = defineStore('dataSources', () => {
   const items = ref<DataSourceListItem[]>([])
@@ -33,6 +46,32 @@ export const useDataSourcesStore = defineStore('dataSources', () => {
       return true
     } catch (e) {
       error.value = e instanceof Error ? e.message : 'Failed to create data source'
+      return false
+    }
+  }
+
+  async function loadDetail(id: string): Promise<DataSourceDetail | null> {
+    error.value = null
+    try {
+      return await getDataSource(id)
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to load data source'
+      return null
+    }
+  }
+
+  /** Update non-secret config then refresh. Credential rotation is not part of UI-3. */
+  async function update(id: string, payload: UpdateDataSourcePayload): Promise<boolean> {
+    error.value = null
+    try {
+      await updateDataSource(id, payload)
+      const remainingResults = { ...testResults.value }
+      delete remainingResults[id]
+      testResults.value = remainingResults
+      await fetchAll()
+      return true
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to update data source'
       return false
     }
   }
@@ -75,5 +114,18 @@ export const useDataSourcesStore = defineStore('dataSources', () => {
     }
   }
 
-  return { items, loading, error, testing, testResults, isTesting, fetchAll, create, remove, testConnection }
+  return {
+    items,
+    loading,
+    error,
+    testing,
+    testResults,
+    isTesting,
+    fetchAll,
+    create,
+    loadDetail,
+    update,
+    remove,
+    testConnection,
+  }
 })

--- a/apps/web/src/views/DataSourcesView.vue
+++ b/apps/web/src/views/DataSourcesView.vue
@@ -11,9 +11,9 @@
         type="button"
         class="data-sources__btn data-sources__btn--primary"
         data-testid="ds-new-button"
-        @click="toggleForm"
+        @click="toggleCreateForm"
       >
-        {{ formOpen ? '取消' : '新建数据源' }}
+        {{ formOpen && formMode === 'create' ? '取消' : '新建数据源' }}
       </button>
     </header>
 
@@ -24,13 +24,13 @@
     <form v-if="formOpen" class="data-sources__form" data-testid="ds-create-form" @submit.prevent="submit">
       <div class="data-sources__grid">
         <label>ID
-          <input v-model.trim="form.id" required data-testid="ds-field-id" placeholder="my-erp-db" />
+          <input v-model.trim="form.id" required data-testid="ds-field-id" :disabled="formMode === 'edit'" placeholder="my-erp-db" />
         </label>
         <label>名称 Name
           <input v-model.trim="form.name" required data-testid="ds-field-name" placeholder="客户 ERP 库" />
         </label>
         <label>类型 Type
-          <select v-model="form.type" data-testid="ds-field-type">
+          <select v-model="form.type" data-testid="ds-field-type" :disabled="formMode === 'edit'">
             <option v-for="t in DATA_SOURCE_TYPES" :key="t" :value="t">{{ DATA_SOURCE_TYPE_LABELS[t] }}</option>
           </select>
         </label>
@@ -47,10 +47,10 @@
         <label>Database
           <input v-model.trim="form.database" required data-testid="ds-field-database" placeholder="erp" />
         </label>
-        <label>Username
+        <label v-if="formMode === 'create'">Username
           <input v-model.trim="form.username" autocomplete="off" data-testid="ds-field-username" />
         </label>
-        <label>Password
+        <label v-if="formMode === 'create'">Password
           <input v-model="form.password" type="password" autocomplete="new-password" data-testid="ds-field-password" />
         </label>
       </div>
@@ -60,10 +60,14 @@
         <label>Base URL
           <input v-model.trim="form.baseURL" required data-testid="ds-field-baseurl" placeholder="https://api.example.com" />
         </label>
-        <label>API Key
+        <label v-if="formMode === 'create'">API Key
           <input v-model="form.apiKey" type="password" autocomplete="off" data-testid="ds-field-apikey" />
         </label>
       </div>
+
+      <p v-if="formMode === 'edit'" class="data-sources__muted" data-testid="ds-edit-secret-note">
+        凭据保持不变;如需轮换凭据,请走单独的凭据更新流程。
+      </p>
 
       <label class="data-sources__checkbox">
         <input v-model="form.readOnly" type="checkbox" data-testid="ds-field-readonly" />
@@ -72,7 +76,7 @@
 
       <div class="data-sources__form-actions">
         <button type="submit" class="data-sources__btn data-sources__btn--primary" :disabled="submitting" data-testid="ds-submit">
-          {{ submitting ? '创建中…' : '创建' }}
+          {{ submitting ? '保存中…' : formMode === 'edit' ? '保存' : '创建' }}
         </button>
       </div>
     </form>
@@ -118,6 +122,13 @@
               <div class="data-sources__actions">
                 <button
                   type="button"
+                  class="data-sources__btn"
+                  data-testid="ds-edit"
+                  :disabled="detailLoading"
+                  @click="openEditForm(ds.id)"
+                >编辑</button>
+                <button
+                  type="button"
                   class="data-sources__btn data-sources__btn--danger"
                   data-testid="ds-delete"
                   @click="confirmRemove(ds.id, ds.name)"
@@ -137,13 +148,17 @@ import { useDataSourcesStore } from '../stores/dataSources'
 import {
   DATA_SOURCE_TYPES,
   DATA_SOURCE_TYPE_LABELS,
+  type DataSourceDetail,
   type DataSourceType,
 } from '../data-sources/types'
-import { buildCreatePayload } from '../data-sources/buildPayload'
+import { buildCreatePayload, buildUpdatePayload } from '../data-sources/buildPayload'
 
 const store = useDataSourcesStore()
 const formOpen = ref(false)
+const formMode = ref<'create' | 'edit'>('create')
+const editingId = ref<string | null>(null)
 const submitting = ref(false)
+const detailLoading = ref(false)
 
 const form = reactive({
   id: '',
@@ -175,8 +190,15 @@ function testResultText(id: string): string {
   return `失败${result.error?.message ? ` · ${result.error.message}` : ''}`
 }
 
-function toggleForm(): void {
-  formOpen.value = !formOpen.value
+function toggleCreateForm(): void {
+  if (formOpen.value && formMode.value === 'create') {
+    formOpen.value = false
+    return
+  }
+  resetForm()
+  formMode.value = 'create'
+  editingId.value = null
+  formOpen.value = true
   store.error = null
 }
 
@@ -187,12 +209,45 @@ function resetForm(): void {
   })
 }
 
+function fillFormFromDetail(detail: DataSourceDetail): void {
+  resetForm()
+  const connection = detail.connection ?? {}
+  form.id = detail.id
+  form.name = detail.name
+  form.type = DATA_SOURCE_TYPES.includes(detail.type as DataSourceType)
+    ? detail.type as DataSourceType
+    : 'postgres'
+  form.host = String(connection.host ?? '')
+  form.port = typeof connection.port === 'number' ? connection.port : undefined
+  form.database = String(connection.database ?? '')
+  form.baseURL = String(connection.baseURL ?? '')
+  form.readOnly = detail.options?.readOnly !== false
+}
+
+async function openEditForm(id: string): Promise<void> {
+  detailLoading.value = true
+  try {
+    const detail = await store.loadDetail(id)
+    if (!detail) return
+    fillFormFromDetail(detail)
+    formMode.value = 'edit'
+    editingId.value = id
+    formOpen.value = true
+  } finally {
+    detailLoading.value = false
+  }
+}
+
 async function submit(): Promise<void> {
   submitting.value = true
   try {
-    const ok = await store.create(buildCreatePayload(form))
+    const ok = formMode.value === 'edit' && editingId.value
+      ? await store.update(editingId.value, buildUpdatePayload(form))
+      : await store.create(buildCreatePayload(form))
     if (ok) {
       resetForm()
+      formMode.value = 'create'
+      editingId.value = null
       formOpen.value = false
     }
   } finally {
@@ -238,7 +293,7 @@ onMounted(() => {
 .data-sources__status { font-size: 12px; padding: 2px 8px; border-radius: 10px; white-space: nowrap; }
 .data-sources__status.is-on { background: #f6ffed; color: #389e0d; }
 .data-sources__status.is-off { background: #f5f5f5; color: #8c8c8c; }
-.data-sources__actions { display: flex; justify-content: flex-end; }
+.data-sources__actions { display: flex; justify-content: flex-end; gap: 8px; }
 .data-sources__test-result { margin: 6px 0 0; font-size: 12px; max-width: 260px; overflow-wrap: anywhere; }
 .data-sources__test-result.is-ok { color: #237804; }
 .data-sources__test-result.is-fail { color: #cf1322; }

--- a/apps/web/tests/data-sources-ui.spec.ts
+++ b/apps/web/tests/data-sources-ui.spec.ts
@@ -2,16 +2,20 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { createApp, nextTick } from 'vue'
 
-import { buildCreatePayload, type CreateFormState } from '../src/data-sources/buildPayload'
+import { buildCreatePayload, buildUpdatePayload, type CreateFormState } from '../src/data-sources/buildPayload'
 
 // Mock the api client so the store is tested in isolation.
 const listMock = vi.hoisted(() => vi.fn())
+const getMock = vi.hoisted(() => vi.fn())
 const createMock = vi.hoisted(() => vi.fn())
+const updateMock = vi.hoisted(() => vi.fn())
 const deleteMock = vi.hoisted(() => vi.fn())
 const testConnectionMock = vi.hoisted(() => vi.fn())
 vi.mock('../src/data-sources/api', () => ({
   listDataSources: listMock,
+  getDataSource: getMock,
   createDataSource: createMock,
+  updateDataSource: updateMock,
   deleteDataSource: deleteMock,
   testDataSourceConnection: testConnectionMock,
 }))
@@ -59,6 +63,35 @@ describe('buildCreatePayload — credential safety (omit blank, never send empty
   })
 })
 
+describe('buildUpdatePayload — non-secret update safety', () => {
+  it('updates name / connection / options without sending id, type, or credentials', () => {
+    const p = buildUpdatePayload(form({
+      id: 'db',
+      name: 'Renamed',
+      type: 'postgres',
+      host: 'h',
+      port: 5432,
+      database: 'd',
+      username: 'u',
+      password: 'secret',
+      readOnly: false,
+    }))
+    expect(p).toEqual({
+      name: 'Renamed',
+      connection: { host: 'h', port: 5432, database: 'd' },
+      options: { readOnly: false },
+    })
+    expect(p).not.toHaveProperty('id')
+    expect(p).not.toHaveProperty('type')
+    expect(p).not.toHaveProperty('credentials')
+  })
+
+  it('omits a blank update port instead of sending port: ""', () => {
+    const p = buildUpdatePayload(form({ type: 'sqlserver', host: 'h', port: '', database: 'd' }))
+    expect(p.connection).toEqual({ host: 'h', database: 'd' })
+  })
+})
+
 describe('useDataSourcesStore (UI-1)', () => {
   beforeEach(() => {
     setActivePinia(createPinia())
@@ -100,6 +133,41 @@ describe('useDataSourcesStore (UI-1)', () => {
     const ok = await store.create({ id: 'x', name: 'X', type: 'postgres', connection: {} })
     expect(ok).toBe(false)
     expect(store.error).toBe('Unsupported data source type')
+  })
+
+  it('loadDetail returns a sanitized data source detail', async () => {
+    getMock.mockResolvedValue({
+      id: 'a',
+      name: 'A',
+      type: 'postgres',
+      connected: false,
+      hasCredentials: true,
+      connection: { host: 'h', database: 'd' },
+      options: { readOnly: true },
+    })
+    const store = useDataSourcesStore()
+    const detail = await store.loadDetail('a')
+    expect(getMock).toHaveBeenCalledWith('a')
+    expect(detail?.hasCredentials).toBe(true)
+    expect(detail).not.toHaveProperty('credentials')
+  })
+
+  it('update posts non-secret config, clears stale test result, and refetches', async () => {
+    updateMock.mockResolvedValue(undefined)
+    listMock.mockResolvedValue([{ id: 'a', name: 'Renamed', type: 'postgres', connected: false }])
+    const store = useDataSourcesStore()
+    store.testResults.a = { id: 'a', success: false }
+
+    const payload = {
+      name: 'Renamed',
+      connection: { host: 'h', database: 'd' },
+      options: { readOnly: true },
+    }
+    const ok = await store.update('a', payload)
+    expect(ok).toBe(true)
+    expect(updateMock).toHaveBeenCalledWith('a', payload)
+    expect(store.testResults.a).toBeUndefined()
+    expect(store.items[0].name).toBe('Renamed')
   })
 
   it('remove deletes by id and refetches', async () => {
@@ -190,5 +258,50 @@ describe('DataSourcesView (UI-2 connection test reachability)', () => {
     const result = container.querySelector('[data-testid="ds-test-result"]')
     expect(result?.textContent).toContain('失败')
     expect(result?.textContent).toContain('timeout')
+  })
+
+  it('opens edit mode from a sanitized detail and submits a credential-free update payload', async () => {
+    listMock.mockResolvedValue([{ id: 'a', name: 'A', type: 'postgres', connected: false }])
+    getMock.mockResolvedValue({
+      id: 'a',
+      name: 'A',
+      type: 'postgres',
+      connected: false,
+      hasCredentials: true,
+      connection: { host: 'db.internal', port: 5432, database: 'erp' },
+      options: { readOnly: true },
+    })
+    updateMock.mockResolvedValue(undefined)
+
+    const container = await mountView()
+    const editButton = container.querySelector('[data-testid="ds-edit"]') as HTMLButtonElement | null
+    expect(editButton).not.toBeNull()
+
+    editButton!.click()
+    await flush()
+    await flush()
+    await flush()
+
+    expect(getMock).toHaveBeenCalledWith('a')
+    expect(container.querySelector('[data-testid="ds-field-password"]')).toBeNull()
+    expect(container.querySelector('[data-testid="ds-field-id"]')?.getAttribute('disabled')).not.toBeNull()
+
+    const nameInput = container.querySelector('[data-testid="ds-field-name"]') as HTMLInputElement
+    nameInput.value = 'Renamed'
+    nameInput.dispatchEvent(new Event('input'))
+    await flush()
+
+    const submit = container.querySelector('[data-testid="ds-submit"]') as HTMLButtonElement
+    submit.click()
+    await flush()
+    await flush()
+    await flush()
+
+    expect(updateMock).toHaveBeenCalledWith('a', {
+      name: 'Renamed',
+      connection: { host: 'db.internal', port: 5432, database: 'erp' },
+      options: { readOnly: true },
+    })
+    expect(updateMock.mock.calls[0][1]).not.toHaveProperty('credentials')
   })
 })


### PR DESCRIPTION
## Summary

Adds the next data-sources CRUD slice after #2147/#2151: editing non-secret data-source configuration from the UI.

- Adds a typed `GET /api/data-sources/:id` detail client and `PUT /api/data-sources/:id` update client
- Adds store actions for loading a sanitized detail and updating non-secret config
- Adds row-level `编辑` in `DataSourcesView`
- Reuses the create form in edit mode with `id`/`type` locked
- Hides credential inputs in edit mode and never sends `credentials` in the PUT payload

## Scope / boundaries

- Frontend only
- Updates name, connection fields, and `readOnly`
- Does not rotate credentials; backend update schema does not accept credentials yet
- Does not add query/select/schema execution UI
- Does not add connect/disconnect write buttons

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/data-sources-ui.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/web exec eslint 'src/data-sources/*.ts' src/stores/dataSources.ts src/views/DataSourcesView.vue tests/data-sources-ui.spec.ts --max-warnings=0`
- `git diff --check`

## Test notes

Adds builder/store/component coverage for the edit path. The component test mounts `DataSourcesView`, clicks `编辑`, loads a sanitized detail, verifies password inputs are not rendered, submits, and asserts the PUT payload is credential-free.
