### PR TITLE
fix(data-sources): deep-merge connection on PUT — an edit can't silently drop hidden TLS/security keys (P1)

### DIFF
--- a/packages/core-backend/src/routes/data-sources.ts
+++ b/packages/core-backend/src/routes/data-sources.ts
@@ -361,8 +361,12 @@ export function dataSourcesRouter(): Router {
       const newConfig: DataSourceConfig = {
         ...oldConfig,
         ...parse.data,
-        // Deep-merge nested config: a partial update (e.g. only options.timeout)
-        // must not wipe sibling keys like readOnly / autoConnect / poolConfig.
+        // Deep-merge nested config: a partial update must NOT wipe sibling keys. For `connection`
+        // this is security-sensitive — an edit UI that re-sends connection with only {host,port,
+        // database} would otherwise drop encrypt / trustServerCertificate / tlsMinVersion / tlsCiphers
+        // / legacyTls / timeouts (weakening cert validation or breaking legacy TLS). Removing a
+        // connection key requires an explicit delete, not a partial PUT.
+        connection: { ...oldConfig.connection, ...parse.data.connection },
         options: { ...oldConfig.options, ...parse.data.options },
         poolConfig: { ...oldConfig.poolConfig, ...parse.data.poolConfig },
         id // Preserve original ID

--- a/packages/core-backend/tests/unit/data-source-readonly.test.ts
+++ b/packages/core-backend/tests/unit/data-source-readonly.test.ts
@@ -132,4 +132,36 @@ describe('data-sources PUT deep-merge (A-RO)', () => {
     // shallow merge would have wiped readOnly/autoConnect; deep merge keeps them
     expect(got.body.data.options).toMatchObject({ autoConnect: true, readOnly: false, timeout: 5 })
   })
+
+  it('a partial connection update preserves hidden security keys (P1 regression)', async () => {
+    currentUser = admin('alice')
+    // A source whose connection carries security-sensitive keys an edit UI does NOT surface.
+    await request(app).post('/api/data-sources').send({
+      id: 'tlsmerge', name: 'tlsmerge', type: 'postgres',
+      connection: {
+        host: 'old-host', database: 'db',
+        encrypt: true, trustServerCertificate: false, tlsMinVersion: 'TLSv1',
+      },
+      credentials: { username: 'u', password: 'p' },
+      options: { autoConnect: false, readOnly: true },
+    })
+
+    // The edit flow re-sends connection with only the visible field {host}. Wholesale replace would
+    // drop encrypt/trustServerCertificate/tlsMinVersion (weakening cert validation / breaking TLS).
+    const put = await request(app).put('/api/data-sources/tlsmerge').send({ connection: { host: 'new-host' } })
+    expect(put.status).toBe(200)
+
+    const got = await request(app).get('/api/data-sources/tlsmerge')
+    expect(got.status).toBe(200)
+    expect(got.body.data.connection).toMatchObject({
+      host: 'new-host',        // visible edit applied
+      database: 'db',          // hidden key preserved
+      encrypt: true,           // hidden security key preserved
+      trustServerCertificate: false,
+      tlsMinVersion: 'TLSv1',
+    })
+    // credentials are still never returned, and the merge does not resurrect them into the response
+    expect(got.body.data).not.toHaveProperty('credentials')
+    expect(got.body.data.hasCredentials).toBe(true)
+  })
 })


### PR DESCRIPTION
## P1 from the #2154 (UI-3 edit) review — backend defense-in-depth fix

**The bug:** PUT did `{...oldConfig, ...parse.data}` and deep-merged only `options` + `poolConfig` — **`connection` was spread wholesale** (`data-sources.ts:362`). So an edit flow that re-sends `connection` with just `{host,port,database}` (which #2154 does) **silently dropped** `encrypt` / `trustServerCertificate` / `tlsMinVersion` / `tlsCiphers` / `legacyTls` / timeouts → **weakened cert validation / broke legacy TLS**. A real security+availability regression.

**The fix (1 line, mirrors the existing `options`/`poolConfig` merge):**
```diff
+ connection: { ...oldConfig.connection, ...parse.data.connection },
  options: { ...oldConfig.options, ...parse.data.options },
  poolConfig: { ...oldConfig.poolConfig, ...parse.data.poolConfig },
```
Chosen as a **backend defense-in-depth** fix (not the frontend) so **any** client's partial update preserves hidden keys, regardless of what the form sends — and it doesn't touch the parallel session's #2154 branch. Connection-key *removal* would need an explicit delete, not a partial PUT (safe default for TLS).

**Regression test** (`data-source-readonly.test.ts`): a source with `encrypt`/`trustServerCertificate:false`/`tlsMinVersion` edited via `connection:{host:'new-host'}` → hidden security keys **preserved** (new host applied), credentials still never returned. **Verified red-on-revert.**

**Not in scope (stays on #2154):** P2 — the edit view ignores `connection.server` and `required`-blocks on `host`, so a `server`-only MSSQL source can't be saved. That's frontend; noted on #2154 for the other session.

Verified: eslint clean · `tsc --noEmit` 0 errors · 9/9 (incl. the new P1 regression). Lock-safe: route + test only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)