### PR TITLE
feat(attendance): enforce scheduler scope fixed schedule apply

### DIFF
--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
@@ -48,10 +48,10 @@ describe('attendance advanced scheduling scope foundation', () => {
       ['PUT', '/api/attendance/scheduler-scopes/:id'],
       ['DELETE', '/api/attendance/scheduler-scopes/:id'],
       ['POST', '/api/attendance/groups/:id/fixed-schedule/preview'],
-      ['POST', '/api/attendance/groups/:id/fixed-schedule/apply'],
-      ['POST', '/api/attendance/groups/:id/fixed-schedule/rebuild'],
     ].forEach(([method, path]) => expectAdminRoute(method, path))
     expect(pluginSource).toContain('SCHEDULER_SCOPE_FORBIDDEN')
+    expectDirectAsyncRoute('POST', '/api/attendance/groups/:id/fixed-schedule/apply')
+    expectDirectAsyncRoute('POST', '/api/attendance/groups/:id/fixed-schedule/rebuild')
     expectDirectAsyncRoute('POST', '/api/attendance/groups/:id/fixed-schedule/clear')
     expectDirectAsyncRoute('GET', '/api/attendance/schedule-groups')
     expectDirectAsyncRoute('GET', '/api/attendance/schedule-groups/:id')
@@ -74,6 +74,8 @@ describe('attendance advanced scheduling scope foundation', () => {
     expect(pluginSource).toContain('resolveAttendanceScheduleAssignmentScopeTarget')
     expect(pluginSource).toContain('assertAttendanceScheduleAssignmentDispatchAllowed')
     expect(pluginSource).toContain('assertAttendanceScheduleGroupEditAllowed')
+    expect(pluginSource).toContain('assertAttendanceGroupFixedScheduleDispatchAllowed')
+    expect(pluginSource).toContain('assertAttendanceGroupFixedScheduleRebuildAllowed')
     expect(pluginSource).toContain('assertAttendanceGroupFixedScheduleClearAllowed')
     expect(pluginSource).toContain('buildAttendanceAssignmentViewSql')
   })

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -200,6 +200,21 @@ function schedulerScopeClearRow(overrides: Record<string, unknown> = {}) {
   })
 }
 
+function schedulerScopeFixedScheduleRow(actions: string[], overrides: Record<string, unknown> = {}) {
+  return schedulerScopeRow({
+    actions,
+    scope: {
+      scheduleGroupIds: [],
+      attendanceGroupIds: [attendanceGroupId],
+      userIds: [],
+      departments: [],
+      roles: [],
+      roleTags: [],
+    },
+    ...overrides,
+  })
+}
+
 function scheduleGroupMemberRow(overrides: Record<string, unknown> = {}) {
   return {
     id: scheduleGroupMemberId,
@@ -290,6 +305,37 @@ function rotationAssignmentListRow(overrides: Record<string, unknown> = {}) {
     rotation_is_active: true,
     ...overrides,
   }
+}
+
+function attendanceGroupRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: attendanceGroupId,
+    org_id: 'default',
+    name: 'Ops Team',
+    code: 'ops-team',
+    timezone: 'UTC',
+    rule_set_id: null,
+    description: 'unit-test',
+    attendance_type: 'fixed_shift',
+    member_count: 1,
+    created_at: '2026-05-29T20:00:00.000Z',
+    updated_at: '2026-05-29T20:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function fixedScheduleQueryResult(sql: string) {
+  if (sql.includes('SELECT * FROM attendance_groups WHERE id = $1')) return { handled: true, rows: [attendanceGroupRow()] }
+  if (sql.includes('SELECT * FROM attendance_shifts WHERE id = $1')) return { handled: true, rows: [shiftRow()] }
+  if (sql.includes('SELECT DISTINCT user_id') && sql.includes('FROM attendance_group_members')) {
+    return { handled: true, rows: [{ user_id: 'worker-1' }] }
+  }
+  if (sql.includes('pg_advisory_xact_lock')) return { handled: true, rows: [] }
+  if (sql.includes('FROM attendance_shift_assignments') && sql.includes('producer_type = $2')) return { handled: true, rows: [] }
+  if (sql.includes('FROM attendance_shift_assignments') && sql.includes('user_id = ANY')) return { handled: true, rows: [] }
+  if (sql.includes('FROM attendance_rotation_assignments') && sql.includes('user_id = ANY')) return { handled: true, rows: [] }
+  if (sql.includes('INSERT INTO attendance_shift_assignments')) return { handled: true, rows: [shiftAssignmentRow()] }
+  return { handled: false, rows: [] }
 }
 
 function rbacQueryResult(sql: string, params: unknown[] = [], admin = false) {
@@ -1301,6 +1347,137 @@ describe('attendance UUID route validation', () => {
     expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
     expect(db.transaction).not.toHaveBeenCalled()
     expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('producer_type = $2'))).toBe(false)
+  })
+
+  it('lets full attendance admins apply fixed schedules without scheduler scopes', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params, true)
+      if (rbac !== undefined) return rbac
+      const fixedSchedule = fixedScheduleQueryResult(sql)
+      if (fixedSchedule.handled) return fixedSchedule.rows
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/groups/:id/fixed-schedule/apply', {
+      params: { id: attendanceGroupId },
+      body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' },
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(201)
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: {
+        applied: true,
+        created: [{ userId: 'worker-1', shiftId }],
+      },
+    })
+    expect(db.transaction).toHaveBeenCalledTimes(1)
+    expect(db.query).not.toHaveBeenCalledWith(expect.stringContaining('FROM attendance_scheduler_scopes'), expect.anything())
+  })
+
+  it('lets scoped non-admin schedulers apply fixed schedules inside their attendance group dispatch scope', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeFixedScheduleRow(['dispatch'])]
+      const fixedSchedule = fixedScheduleQueryResult(sql)
+      if (fixedSchedule.handled) return fixedSchedule.rows
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/groups/:id/fixed-schedule/apply', {
+      params: { id: attendanceGroupId },
+      body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(201)
+    expect(res.body).toMatchObject({ ok: true, data: { applied: true } })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM attendance_scheduler_scopes'),
+      ['default', 'scheduler-1', [], []],
+    )
+    expect(db.transaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects scoped fixed schedule applies without dispatch scope and does not apply', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeFixedScheduleRow(['clear'])]
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/groups/:id/fixed-schedule/apply', {
+      params: { id: attendanceGroupId },
+      body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
+    expect(db.transaction).not.toHaveBeenCalled()
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('INSERT INTO attendance_shift_assignments'))).toBe(false)
+  })
+
+  it('requires both clear and dispatch scope before scoped fixed schedule rebuilds', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeFixedScheduleRow(['clear', 'dispatch'])]
+      const fixedSchedule = fixedScheduleQueryResult(sql)
+      if (fixedSchedule.handled) return fixedSchedule.rows
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/groups/:id/fixed-schedule/rebuild', {
+      params: { id: attendanceGroupId },
+      body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({ ok: true, data: { rebuilt: true } })
+    expect(db.transaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('rejects scoped fixed schedule rebuilds without clear scope and does not rebuild', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeFixedScheduleRow(['dispatch'])]
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/groups/:id/fixed-schedule/rebuild', {
+      params: { id: attendanceGroupId },
+      body: { shiftId, startDate: '2026-06-01', endDate: '2026-06-30' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
+    expect(db.transaction).not.toHaveBeenCalled()
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('INSERT INTO attendance_shift_assignments'))).toBe(false)
   })
 
   it('keeps schedule group creation admin-only because new groups have no scoped target id yet', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -15474,15 +15474,56 @@ module.exports = {
       })
     }
 
-    async function assertAttendanceGroupFixedScheduleClearAllowed(req, res, { groupId, actorAccess } = {}) {
+    async function assertAttendanceGroupFixedScheduleActionsAllowed(req, res, { groupId, actions, actorAccess } = {}) {
       const access = actorAccess ?? await resolveAttendanceSchedulerScopeActor(req, res)
       if (!access) return null
       if (access.fullAdmin) return access
 
-      return assertAttendanceSchedulerScopeAllowed(req, res, {
-        action: 'clear',
-        target: { attendanceGroupIds: [groupId] },
-        actorAccess: access,
+      const requiredActions = normalizeStringArray(actions)
+      const target = { attendanceGroupIds: [groupId] }
+      try {
+        const actorContext = await loadAttendanceScopeContextForUser(db, access.orgId, access.userId)
+        const scopes = await loadActiveAttendanceSchedulerScopesForActor(access.orgId, actorContext)
+        const allowed = requiredActions.length > 0 && requiredActions.every(action =>
+          scopes.some(scope => attendanceSchedulerScopeAllowsActorActionTarget(scope, actorContext, action, target))
+        )
+        if (!allowed) {
+          respondAttendanceSchedulerScopeForbidden(res)
+          return null
+        }
+        return access
+      } catch (error) {
+        if (isDatabaseSchemaError(error)) {
+          res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+          return null
+        }
+        logger.error('Attendance fixed schedule scheduler scope guard failed', error)
+        res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Scheduler scope check failed' } })
+        return null
+      }
+    }
+
+    async function assertAttendanceGroupFixedScheduleDispatchAllowed(req, res, { groupId, actorAccess } = {}) {
+      return assertAttendanceGroupFixedScheduleActionsAllowed(req, res, {
+        groupId,
+        actions: ['dispatch'],
+        actorAccess,
+      })
+    }
+
+    async function assertAttendanceGroupFixedScheduleRebuildAllowed(req, res, { groupId, actorAccess } = {}) {
+      return assertAttendanceGroupFixedScheduleActionsAllowed(req, res, {
+        groupId,
+        actions: ['clear', 'dispatch'],
+        actorAccess,
+      })
+    }
+
+    async function assertAttendanceGroupFixedScheduleClearAllowed(req, res, { groupId, actorAccess } = {}) {
+      return assertAttendanceGroupFixedScheduleActionsAllowed(req, res, {
+        groupId,
+        actions: ['clear'],
+        actorAccess,
       })
     }
 
@@ -27241,7 +27282,7 @@ module.exports = {
     context.api.http.addRoute(
       'POST',
       '/api/attendance/groups/:id/fixed-schedule/apply',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const schema = z.object({
           shiftId: z.string().min(1),
           startDate: z.string().min(1),
@@ -27282,6 +27323,9 @@ module.exports = {
         }
 
         try {
+          const access = await assertAttendanceGroupFixedScheduleDispatchAllowed(req, res, { groupId })
+          if (!access) return
+
           const result = await db.transaction((trx) => applyAttendanceGroupFixedSchedule(trx, {
             orgId,
             groupId,
@@ -27312,13 +27356,13 @@ module.exports = {
           logger.error('Attendance group fixed schedule apply failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to apply fixed schedule' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(
       'POST',
       '/api/attendance/groups/:id/fixed-schedule/rebuild',
-      withPermission('attendance:admin', async (req, res) => {
+      async (req, res) => {
         const schema = z.object({
           shiftId: z.string().min(1),
           startDate: z.string().min(1),
@@ -27359,6 +27403,9 @@ module.exports = {
         }
 
         try {
+          const access = await assertAttendanceGroupFixedScheduleRebuildAllowed(req, res, { groupId })
+          if (!access) return
+
           const result = await db.transaction((trx) => rebuildAttendanceGroupFixedSchedule(trx, {
             orgId,
             groupId,
@@ -27392,7 +27439,7 @@ module.exports = {
           logger.error('Attendance group fixed schedule rebuild failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to rebuild fixed schedule' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(


### PR DESCRIPTION
## Summary
- opens fixed-schedule `apply` to scoped schedulers only when `dispatch` covers the attendance group target
- opens fixed-schedule `rebuild` only when both `clear` and `dispatch` cover the same attendance group target
- keeps preview admin-only and preserves the shared fixed-schedule planner / transaction rerun semantics; import/export/approve and broader FS-D items stay out of scope

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts tests/unit/attendance-advanced-scheduling-scope.test.ts --watch=false` (48/48)
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend test:unit` (202 files / 2629 tests)