### PR TITLE
fix(multitable): gate records summary display fields

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -177,6 +177,7 @@ jobs:
             tests/integration/multitable-viewconfig-resave-guard.test.ts \
             tests/integration/multitable-records-list-authz.test.ts \
             tests/integration/multitable-record-history-field-mask.test.ts \
+            tests/integration/multitable-records-summary-field-mask.test.ts \
             tests/integration/multitable-dashboard-chart-authz.test.ts \
             tests/integration/multitable-automation-retry.test.ts \
             tests/integration/multitable-automation-jobs.test.ts \

--- a/docs/development/multitable-records-summary-field-mask-verification-20260530.md
+++ b/docs/development/multitable-records-summary-field-mask-verification-20260530.md
@@ -1,0 +1,80 @@
+# Multitable F2 Records-Summary Field-Mask Verification — 2026-05-30
+
+## Scope
+
+Implements F2 from `docs/development/multitable-record-egress-fieldperm-inventory-20260529.md` / PR #2106:
+
+- Endpoint: `GET /api/multitable/records-summary`
+- Gate caller-controlled `displayFieldId` against the layer-2 ∧ layer-3 allowed-field set
+- Reject denied and non-existent `displayFieldId` with the same generic `400` response
+- When `displayFieldId` is omitted, choose the default display field from readable fields only
+- Keep scope to records-summary; link-options/person-fields remain separate F5 follow-up
+
+## Fail-First Evidence
+
+Command, against a fresh migrated real Postgres database before the route fix:
+
+```bash
+DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_f2summary_test_48689 \
+  pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts \
+  run tests/integration/multitable-records-summary-field-mask.test.ts \
+  --reporter=dot
+```
+
+Result:
+
+- `5 failed | 2 passed`
+- `R1`: explicit layer-3 denied `displayFieldId` returned `200`, exposing bulk display values
+- `R2`: non-existent `displayFieldId` returned `200` instead of the generic rejection
+- `R3`: omitted `displayFieldId` defaulted to the first string field even though it was denied
+- `R4`: `search` filtered against the denied default display field
+- `R6`: static `property.hidden=true` `displayFieldId` returned `200`
+
+This proves both explicit and default display-field paths were reachable leaks before the fix.
+
+## Post-Fix Evidence
+
+Same command after the route fix:
+
+```text
+✓ tests/integration/multitable-records-summary-field-mask.test.ts (7 tests)
+Test Files 1 passed (1)
+Tests 7 passed (7)
+```
+
+What the test matrix pins:
+
+- `R1`: denied `displayFieldId` is rejected with generic `400` and no canary values
+- `R2`: non-existent `displayFieldId` gets the same generic `400`, avoiding a field-existence oracle
+- `R3`: omitted `displayFieldId` falls back to the first readable field
+- `R4`: search applies to the readable effective display field only
+- `R5`: a readable subject with no layer-3 deny can still use the requested display field
+- `R6`: static hidden fields are rejected by the same gate
+
+## CI Wiring
+
+The test is added to `.github/workflows/plugin-tests.yml` under the Node 20.x real-DB multitable integration step, next to the existing read-path permission suites.
+
+## Commands To Re-Run
+
+```bash
+DATABASE_URL=postgresql://chouhua@localhost:5432/<db> \
+  pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts \
+  run tests/integration/multitable-records-summary-field-mask.test.ts \
+  --reporter=dot
+
+DATABASE_URL=postgresql://chouhua@localhost:5432/<db> \
+  pnpm --filter @metasheet/core-backend exec vitest \
+  --config vitest.integration.config.ts \
+  run \
+  tests/integration/multitable-records-summary-field-mask.test.ts \
+  tests/integration/multitable-records-read-field-mask.test.ts \
+  tests/integration/multitable-records-list-authz.test.ts \
+  tests/integration/multitable-record-history-field-mask.test.ts \
+  --reporter=dot
+
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+pnpm validate:plugins
+```

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -2877,6 +2877,7 @@ async function loadRecordSummaries(
   sheetId: string,
   args: {
     displayFieldId?: string | null
+    allowedFieldIds?: Set<string>
     search?: string
     limit?: number
     offset?: number
@@ -2891,11 +2892,14 @@ async function loadRecordSummaries(
     [sheetId],
   )
   const fields = fieldRes.rows as Array<{ id: string; name: string; type: string }>
+  const selectableFields = args.allowedFieldIds
+    ? fields.filter((field) => args.allowedFieldIds?.has(field.id))
+    : fields
 
   let effectiveDisplayFieldId = args.displayFieldId ?? null
-  if (!effectiveDisplayFieldId && fields.length > 0) {
-    const stringField = fields.find((field) => mapFieldType(field.type) === 'string')
-    effectiveDisplayFieldId = stringField?.id ?? fields[0]?.id ?? null
+  if (!effectiveDisplayFieldId && selectableFields.length > 0) {
+    const stringField = selectableFields.find((field) => mapFieldType(field.type) === 'string')
+    effectiveDisplayFieldId = stringField?.id ?? selectableFields[0]?.id ?? null
   }
 
   const recordRes = await query(
@@ -7754,8 +7758,14 @@ export function univerMetaRouter(): Router {
       }
       if (!capabilities.canRead) return sendForbidden(res)
 
+      const allowedFieldIds = await loadAllowedFieldIds(pool.query.bind(pool), sheetId, access.userId, capabilities)
+      if (displayFieldId && !allowedFieldIds.has(displayFieldId)) {
+        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Invalid displayFieldId' } })
+      }
+
       const summary = await loadRecordSummaries(pool.query.bind(pool), sheetId, {
         displayFieldId,
+        allowedFieldIds,
         search,
         limit,
         offset,

--- a/packages/core-backend/tests/integration/multitable-records-summary-field-mask.test.ts
+++ b/packages/core-backend/tests/integration/multitable-records-summary-field-mask.test.ts
@@ -1,0 +1,155 @@
+/**
+ * Real-DB integration test for F2 — records-summary display field gate.
+ *
+ * F2 closes the caller-controlled displayFieldId bulk-read channel:
+ * a sheet reader denied one field must not be able to request
+ * /records-summary?displayFieldId=<denied> and receive that field for every row.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_f2summary_${TS}`
+const SHEET_ID = `sheet_f2summary_${TS}`
+const REC_1 = `rec_f2summary_1_${TS}`
+const REC_2 = `rec_f2summary_2_${TS}`
+const FLD_SECRET = `fld_f2summary_secret_${TS}`
+const FLD_VISIBLE = `fld_f2summary_visible_${TS}`
+const FLD_STATIC_HIDDEN = `fld_f2summary_static_hidden_${TS}`
+const USER_DENIED = `u_f2summary_denied_${TS}`
+const USER_ALLOWED = `u_f2summary_allowed_${TS}`
+const SECRET_CANARY_1 = 'secret-summary-canary-alpha'
+const SECRET_CANARY_2 = 'secret-summary-canary-beta'
+const VISIBLE_1 = 'Visible Alpha'
+const VISIBLE_2 = 'Visible Beta'
+const STATIC_HIDDEN_CANARY = 'static-hidden-summary-canary'
+
+let app: Express
+let testUserId = USER_DENIED
+let testPerms: string[] = ['multitable:read']
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const summaryReq = (query: Record<string, string | number | null | undefined> = {}) =>
+  request(app).get('/api/multitable/records-summary').query({ sheetId: SHEET_ID, ...query })
+
+describeIfDatabase('F2 records-summary field mask (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => {
+      ;(req as any).user = testUserId ? { id: testUserId, roles: [], perms: testPerms } : undefined
+      next()
+    })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'F2 Summary Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'F2 Summary Sheet'])
+    // Secret is ordered first so the pre-F2 default fallback leaks it when displayFieldId is omitted.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRET, SHEET_ID, 'Secret', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_VISIBLE, SHEET_ID, 'Visible', 'string', '{}', 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_STATIC_HIDDEN, SHEET_ID, 'Static Hidden', 'string', '{"hidden":true}', 3])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1),($4,$2,$5::jsonb,1)', [
+      REC_1,
+      SHEET_ID,
+      JSON.stringify({
+        [FLD_SECRET]: SECRET_CANARY_1,
+        [FLD_VISIBLE]: VISIBLE_1,
+        [FLD_STATIC_HIDDEN]: STATIC_HIDDEN_CANARY,
+      }),
+      REC_2,
+      JSON.stringify({
+        [FLD_SECRET]: SECRET_CANARY_2,
+        [FLD_VISIBLE]: VISIBLE_2,
+        [FLD_STATIC_HIDDEN]: STATIC_HIDDEN_CANARY,
+      }),
+    ])
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER_DENIED, false, false])
+  })
+
+  beforeEach(() => {
+    testUserId = USER_DENIED
+    testPerms = ['multitable:read']
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('R1: explicit layer-3 denied displayFieldId is rejected generically and leaks no bulk values', async () => {
+    const res = await summaryReq({ displayFieldId: FLD_SECRET })
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      ok: false,
+      error: { code: 'VALIDATION_ERROR', message: 'Invalid displayFieldId' },
+    })
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY_1)
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY_2)
+  })
+
+  test('R2: non-existent displayFieldId uses the same generic rejection as a denied field', async () => {
+    const res = await summaryReq({ displayFieldId: `fld_f2summary_missing_${TS}` })
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      ok: false,
+      error: { code: 'VALIDATION_ERROR', message: 'Invalid displayFieldId' },
+    })
+  })
+
+  test('R3: omitted displayFieldId defaults to the first readable field, not the first string field blindly', async () => {
+    const res = await summaryReq()
+    expect(res.status).toBe(200)
+    expect(res.body.data.records).toEqual([
+      { id: REC_1, display: VISIBLE_1 },
+      { id: REC_2, display: VISIBLE_2 },
+    ])
+    expect(res.body.data.displayMap).toEqual({
+      [REC_1]: VISIBLE_1,
+      [REC_2]: VISIBLE_2,
+    })
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY_1)
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY_2)
+  })
+
+  test('R4: search applies only to the readable effective display field', async () => {
+    const res = await summaryReq({ search: 'secret-summary-canary' })
+    expect(res.status).toBe(200)
+    expect(res.body.data.records).toEqual([])
+    expect(res.body.data.displayMap).toEqual({})
+    expect(res.body.data.page).toMatchObject({ total: 0, hasMore: false })
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY_1)
+  })
+
+  test('R5: a readable subject with no layer-3 deny can explicitly use the secret display field', async () => {
+    testUserId = USER_ALLOWED
+    const res = await summaryReq({ displayFieldId: FLD_SECRET })
+    expect(res.status).toBe(200)
+    expect(res.body.data.records).toEqual([
+      { id: REC_1, display: SECRET_CANARY_1 },
+      { id: REC_2, display: SECRET_CANARY_2 },
+    ])
+  })
+
+  test('R6: static-hidden displayFieldId is rejected by the same gate', async () => {
+    const res = await summaryReq({ displayFieldId: FLD_STATIC_HIDDEN })
+    expect(res.status).toBe(400)
+    expect(res.body).toEqual({
+      ok: false,
+      error: { code: 'VALIDATION_ERROR', message: 'Invalid displayFieldId' },
+    })
+    expect(JSON.stringify(res.body)).not.toContain(STATIC_HIDDEN_CANARY)
+  })
+})


### PR DESCRIPTION
## Summary

Implements F2 from the record-egress field-permission inventory.

`GET /api/multitable/records-summary` now gates the caller-controlled `displayFieldId` against the same layer-2 ∧ layer-3 allowed-field set used by the interactive read paths. Denied and non-existent display fields return the same generic `400`, avoiding a field-existence oracle. When `displayFieldId` is omitted, the default display field is selected from readable fields only.

Scope is intentionally limited to records-summary; link-options/person-fields remain the later F5 slice.

## Verification

Fail-first on unmodified route, real Postgres:

- `5 failed | 2 passed`
- R1 proved explicit layer-3 denied `displayFieldId` returned `200` and exposed bulk display values
- R2 proved non-existent `displayFieldId` returned `200`
- R3 proved omitted `displayFieldId` defaulted to the first string field even when denied
- R4 proved `search` filtered against the denied default display field
- R6 proved static `property.hidden=true` display fields were accepted

Post-fix local checks:

- `DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_f2summary_test_48689 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-records-summary-field-mask.test.ts --reporter=dot` → 7/7 passed
- `DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_f2summary_test_48689 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-records-summary-field-mask.test.ts tests/integration/multitable-records-read-field-mask.test.ts tests/integration/multitable-records-list-authz.test.ts tests/integration/multitable-record-history-field-mask.test.ts --reporter=dot` → 33/33 passed
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit` → passed
- `pnpm validate:plugins` → passed, existing warnings only

## CI

Adds `multitable-records-summary-field-mask.test.ts` to the Node 20.x real-DB multitable integration step in `plugin-tests.yml`.
