### PR TITLE
feat(attendance): enforce scheduler scope request approvals

### DIFF
--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
@@ -53,6 +53,8 @@ describe('attendance advanced scheduling scope foundation', () => {
     expectDirectAsyncRoute('POST', '/api/attendance/groups/:id/fixed-schedule/apply')
     expectDirectAsyncRoute('POST', '/api/attendance/groups/:id/fixed-schedule/rebuild')
     expectDirectAsyncRoute('POST', '/api/attendance/groups/:id/fixed-schedule/clear')
+    expectDirectAsyncRoute('POST', '/api/attendance/requests/:id/approve')
+    expectDirectAsyncRoute('POST', '/api/attendance/requests/:id/reject')
     expectDirectAsyncRoute('GET', '/api/attendance/schedule-groups')
     expectDirectAsyncRoute('GET', '/api/attendance/schedule-groups/:id')
     expectDirectAsyncRoute('GET', '/api/attendance/schedule-groups/:id/members')
@@ -77,6 +79,8 @@ describe('attendance advanced scheduling scope foundation', () => {
     expect(pluginSource).toContain('assertAttendanceGroupFixedScheduleDispatchAllowed')
     expect(pluginSource).toContain('assertAttendanceGroupFixedScheduleRebuildAllowed')
     expect(pluginSource).toContain('assertAttendanceGroupFixedScheduleClearAllowed')
+    expect(pluginSource).toContain('assertAttendanceRequestApprovalAllowed')
+    expect(pluginSource).toContain('resolveAttendanceRequestApprovalScopeFacts')
     expect(pluginSource).toContain('buildAttendanceAssignmentViewSql')
   })
 

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -112,6 +112,8 @@ const shiftAssignmentId = '00000000-0000-4000-8000-000000000304'
 const rotationRuleId = '00000000-0000-4000-8000-000000000305'
 const rotationAssignmentId = '00000000-0000-4000-8000-000000000306'
 const attendanceGroupId = '00000000-0000-4000-8000-000000000307'
+const attendanceRequestId = '00000000-0000-4000-8000-000000000308'
+const approvalInstanceId = 'apv_00000000-0000-4000-8000-000000000309'
 
 function scheduleGroupRow(overrides: Record<string, unknown> = {}) {
   return {
@@ -206,6 +208,21 @@ function schedulerScopeFixedScheduleRow(actions: string[], overrides: Record<str
     scope: {
       scheduleGroupIds: [],
       attendanceGroupIds: [attendanceGroupId],
+      userIds: [],
+      departments: [],
+      roles: [],
+      roleTags: [],
+    },
+    ...overrides,
+  })
+}
+
+function schedulerScopeApproveRow(overrides: Record<string, unknown> = {}) {
+  return schedulerScopeRow({
+    actions: ['approve'],
+    scope: {
+      scheduleGroupIds: [scheduleGroupId],
+      attendanceGroupIds: [],
       userIds: [],
       departments: [],
       roles: [],
@@ -320,6 +337,48 @@ function attendanceGroupRow(overrides: Record<string, unknown> = {}) {
     member_count: 1,
     created_at: '2026-05-29T20:00:00.000Z',
     updated_at: '2026-05-29T20:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function attendanceRequestRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: attendanceRequestId,
+    user_id: 'worker-1',
+    org_id: 'default',
+    work_date: '2026-06-10',
+    request_type: 'leave',
+    requested_in_at: null,
+    requested_out_at: null,
+    reason: 'annual leave',
+    status: 'pending',
+    approval_instance_id: approvalInstanceId,
+    metadata: {
+      minutes: 60,
+      approvalFlow: {
+        steps: [
+          { name: 'Line lead', approverUserIds: ['scheduler-1'], approverRoleIds: [] },
+          { name: 'HR', approverUserIds: ['hr-1'], approverRoleIds: [] },
+        ],
+        currentStep: 0,
+      },
+    },
+    created_at: '2026-05-30T10:00:00.000Z',
+    updated_at: '2026-05-30T10:00:00.000Z',
+    ...overrides,
+  }
+}
+
+function approvalInstanceRow(overrides: Record<string, unknown> = {}) {
+  return {
+    id: approvalInstanceId,
+    status: 'pending',
+    version: 1,
+    current_step: 0,
+    current_node_key: 'attendance_request_step_0',
+    metadata: {},
+    created_at: '2026-05-30T10:00:00.000Z',
+    updated_at: '2026-05-30T10:00:00.000Z',
     ...overrides,
   }
 }
@@ -926,6 +985,131 @@ describe('attendance UUID route validation', () => {
 
     expect(db.query).not.toHaveBeenCalled()
     expect(db.transaction).not.toHaveBeenCalled()
+  })
+
+  it('keeps existing attendance approval permission resolving requests without scheduler scopes', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      if (sql.includes('FROM user_roles') && sql.includes('role_id = $2')) return []
+      if (sql.includes('FROM user_permissions') && params[1] === 'attendance:approve') return [{ ok: 1 }]
+      if (sql.includes('FROM user_permissions')) return []
+      if (sql.includes('JOIN role_permissions')) return []
+      if (sql.includes('SELECT * FROM attendance_requests WHERE id = $1 FOR UPDATE')) return [attendanceRequestRow()]
+      if (sql.includes('SELECT * FROM approval_instances WHERE id = $1 FOR UPDATE')) return [approvalInstanceRow()]
+      if (sql.includes('UPDATE approval_instances')) return []
+      if (sql.includes('UPDATE approval_assignments')) return []
+      if (sql.includes('INSERT INTO approval_records')) return []
+      if (sql.includes('UPDATE attendance_requests')) return []
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/requests/:id/reject', {
+      params: { id: attendanceRequestId },
+      body: { comment: 'Not enough context' },
+      user: { id: 'approver-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: {
+        requestId: attendanceRequestId,
+        status: 'rejected',
+        userId: 'worker-1',
+      },
+    })
+    expect(db.query).not.toHaveBeenCalledWith(expect.stringContaining('FROM attendance_scheduler_scopes'), expect.anything())
+    expect(db.transaction).toHaveBeenCalledTimes(1)
+  })
+
+  it('lets scoped non-admin schedulers approve requests inside their scheduler scope', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('SELECT * FROM attendance_requests WHERE id = $1 FOR UPDATE')) return [attendanceRequestRow()]
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeApproveRow()]
+      if (sql.includes('SELECT DISTINCT group_id') && sql.includes('FROM attendance_group_members')) return []
+      if (sql.includes('SELECT DISTINCT m.schedule_group_id')) {
+        return [{ schedule_group_id: scheduleGroupId, department_ref: 'factory-1' }]
+      }
+      if (sql.includes('SELECT * FROM approval_instances WHERE id = $1 FOR UPDATE')) return [approvalInstanceRow()]
+      if (sql.includes('UPDATE approval_instances')) return []
+      if (sql.includes('UPDATE approval_assignments')) return []
+      if (sql.includes('INSERT INTO approval_assignments')) return []
+      if (sql.includes('INSERT INTO approval_records')) return []
+      if (sql.includes('UPDATE attendance_requests')) return []
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/requests/:id/approve', {
+      params: { id: attendanceRequestId },
+      body: { comment: 'Looks good' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: {
+        requestId: attendanceRequestId,
+        status: 'pending',
+        approvalStep: { index: 1, total: 2 },
+      },
+    })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM attendance_scheduler_scopes'),
+      ['default', 'scheduler-1', [], []],
+    )
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT DISTINCT m.schedule_group_id'),
+      ['default', 'worker-1', '2026-06-10'],
+    )
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('INSERT INTO approval_records'))).toBe(true)
+  })
+
+  it('rejects scoped request approval outside scheduler scope before writing', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('SELECT * FROM attendance_requests WHERE id = $1 FOR UPDATE')) return [attendanceRequestRow()]
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) {
+        return [schedulerScopeApproveRow({
+          scope: {
+            scheduleGroupIds: ['00000000-0000-4000-8000-000000009999'],
+            attendanceGroupIds: [],
+            userIds: [],
+            departments: [],
+            roles: [],
+            roleTags: [],
+          },
+        })]
+      }
+      if (sql.includes('SELECT DISTINCT group_id') && sql.includes('FROM attendance_group_members')) return []
+      if (sql.includes('SELECT DISTINCT m.schedule_group_id')) {
+        return [{ schedule_group_id: scheduleGroupId, department_ref: 'factory-1' }]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/requests/:id/approve', {
+      params: { id: attendanceRequestId },
+      body: { comment: 'Looks good' },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('SELECT * FROM approval_instances'))).toBe(false)
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('UPDATE attendance_requests'))).toBe(false)
   })
 
   it('lets full attendance admins add schedule group members without scheduler scopes', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -15235,9 +15235,9 @@ module.exports = {
       }
     }
 
-    async function loadActiveAttendanceSchedulerScopesForActor(orgId, actorContext) {
+    async function loadActiveAttendanceSchedulerScopesForActor(orgId, actorContext, client = db) {
       const actor = attendanceSchedulerScopeActorRefs(actorContext)
-      const rows = await db.query(
+      const rows = await client.query(
         `SELECT *
          FROM attendance_scheduler_scopes
          WHERE org_id = $1
@@ -15525,6 +15525,106 @@ module.exports = {
         actions: ['clear'],
         actorAccess,
       })
+    }
+
+    function buildAttendanceSchedulerScopeFactTarget(scopeRow, facts) {
+      const scope = normalizeAttendanceSchedulerScopeBody(scopeRow?.scope ?? scopeRow)
+      const target = {}
+      let constrained = false
+      for (const key of ['scheduleGroupIds', 'attendanceGroupIds', 'userIds', 'departments', 'roles', 'roleTags']) {
+        const scopeValues = normalizeStringArray(scope[key])
+        if (scopeValues.length === 0) continue
+        constrained = true
+        const factValues = new Set(normalizeStringArray(facts?.[key]))
+        const matches = scopeValues.filter(value => factValues.has(value))
+        if (matches.length === 0) return null
+        target[key] = matches
+      }
+      return constrained ? target : null
+    }
+
+    function attendanceSchedulerScopeAllowsActorActionFacts(scopeRow, actorContext, action, facts) {
+      if (!scopeRow || scopeRow.isActive === false || scopeRow.is_active === false) return false
+      if (!attendanceSchedulerScopeMatchesActor(scopeRow, actorContext)) return false
+      if (!normalizeStringArray(scopeRow.actions).includes(action)) return false
+      const target = buildAttendanceSchedulerScopeFactTarget(scopeRow, facts)
+      return target ? attendanceSchedulerScopeMatchesTarget(scopeRow, target) : false
+    }
+
+    async function resolveAttendanceRequestApprovalScopeFacts(client, orgId, requestRow) {
+      const userId = normalizeAttendanceSchedulerScopeRef(requestRow?.user_id)
+      const workDate = normalizeDateOnly(requestRow?.work_date) ?? requestRow?.work_date
+      const facts = {
+        scheduleGroupIds: [],
+        attendanceGroupIds: [],
+        userIds: userId ? [userId] : [],
+        departments: [],
+        roles: [],
+        roleTags: [],
+      }
+      if (!userId) return facts
+
+      const targetContext = await loadAttendanceScopeContextForUser(client, orgId, userId)
+      const targetActorRefs = attendanceSchedulerScopeActorRefs(targetContext)
+      facts.roles = targetActorRefs.roles
+      facts.roleTags = targetActorRefs.roleTags
+
+      const attendanceGroupRows = await client.query(
+        `SELECT DISTINCT group_id
+         FROM attendance_group_members
+         WHERE org_id = $1
+           AND user_id = $2
+           AND group_id IS NOT NULL
+         ORDER BY group_id ASC`,
+        [orgId, userId]
+      )
+      facts.attendanceGroupIds = attendanceGroupRows.map(row => row.group_id).filter(Boolean)
+
+      if (workDate) {
+        const scheduleGroupRows = await client.query(
+          `SELECT DISTINCT m.schedule_group_id, g.department_ref
+           FROM attendance_schedule_group_members m
+           JOIN attendance_schedule_groups g
+             ON g.id = m.schedule_group_id
+            AND g.org_id = m.org_id
+            AND COALESCE(g.is_active, true) = true
+           WHERE m.org_id = $1
+             AND m.user_id = $2
+             AND m.schedule_group_id IS NOT NULL
+             AND COALESCE(m.effective_from, DATE '0001-01-01') <= $3::date
+             AND COALESCE(m.effective_to, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
+           ORDER BY m.schedule_group_id ASC`,
+          [orgId, userId, workDate]
+        )
+        facts.scheduleGroupIds = scheduleGroupRows.map(row => row.schedule_group_id).filter(Boolean)
+        facts.departments = sortedUnique(scheduleGroupRows.map(row => row.department_ref).filter(Boolean))
+      }
+
+      return facts
+    }
+
+    async function assertAttendanceRequestApprovalAllowed(req, { client, requestRow }) {
+      const requesterId = getUserId(req)
+      if (!requesterId) {
+        throw new HttpError(401, 'UNAUTHORIZED', 'User ID not found')
+      }
+      const orgId = requestRow?.org_id ?? getOrgId(req)
+
+      if (await canAccessOtherUsers(requesterId)) return
+
+      const actorContext = await loadAttendanceScopeContextForUser(client, orgId, requesterId)
+      const scopes = await loadActiveAttendanceSchedulerScopesForActor(orgId, actorContext, client)
+      const facts = await resolveAttendanceRequestApprovalScopeFacts(client, orgId, requestRow)
+      const allowed = scopes.some(scope =>
+        attendanceSchedulerScopeAllowsActorActionFacts(scope, actorContext, 'approve', facts)
+      )
+      if (!allowed) {
+        throw new HttpError(
+          403,
+          'SCHEDULER_SCOPE_FORBIDDEN',
+          'Scheduler scope does not allow this attendance approval action'
+        )
+      }
     }
 
     function withAttendanceGroupMemberAccess(handler) {
@@ -19478,12 +19578,6 @@ module.exports = {
         return
       }
 
-      const allowed = await canAccessOtherUsers(requesterId)
-      if (!allowed) {
-        res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'No approval access' } })
-        return
-      }
-
       const requestId = normalizeUuidString(req.params.id)
       if (!requestId) {
         respondInvalidUuid(res)
@@ -19513,6 +19607,7 @@ module.exports = {
           }
 
           const requestRow = requestRows[0]
+          await assertAttendanceRequestApprovalAllowed(req, { client: trx, requestRow })
           if (requestRow.status !== 'pending') {
             throw new HttpError(400, 'INVALID_STATUS', 'Request already resolved')
           }
@@ -19878,13 +19973,13 @@ module.exports = {
     context.api.http.addRoute(
       'POST',
       '/api/attendance/requests/:id/approve',
-      withAnyPermission(['attendance:approve', 'attendance:admin'], async (req, res) => resolveRequest(req, res, 'approve'))
+      async (req, res) => resolveRequest(req, res, 'approve')
     )
 
     context.api.http.addRoute(
       'POST',
       '/api/attendance/requests/:id/reject',
-      withAnyPermission(['attendance:approve', 'attendance:admin'], async (req, res) => resolveRequest(req, res, 'reject'))
+      async (req, res) => resolveRequest(req, res, 'reject')
     )
 
     context.api.http.addRoute(


### PR DESCRIPTION
## Summary
- opens attendance request approve/reject routes to matching scheduler-scope actors while preserving existing attendance:approve / attendance:admin behavior
- resolves approval targets from the locked request row using user, attendance group, schedule group, department, role, and role-tag facts
- fails scoped actors closed with SCHEDULER_SCOPE_FORBIDDEN before approval writes when no active approve scope matches

## Verification
- node --check plugins/plugin-attendance/index.cjs
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts tests/unit/attendance-advanced-scheduling-scope.test.ts --watch=false
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/core-backend test:unit -- --watch=false

## Notes
- Rebased on origin/main 0ec767cc before final verification.
- Import/export and broader approval inbox/read filtering remain separate slices.