### PR TITLE
feat(attendance): enforce scheduler scope exports

### DIFF
--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
@@ -80,7 +80,9 @@ describe('attendance advanced scheduling scope foundation', () => {
     expect(pluginSource).toContain('assertAttendanceGroupFixedScheduleRebuildAllowed')
     expect(pluginSource).toContain('assertAttendanceGroupFixedScheduleClearAllowed')
     expect(pluginSource).toContain('assertAttendanceRequestApprovalAllowed')
+    expect(pluginSource).toContain('assertAttendanceRecordExportAllowed')
     expect(pluginSource).toContain('resolveAttendanceRequestApprovalScopeFacts')
+    expect(pluginSource).toContain('resolveAttendanceUserSchedulerScopeFacts')
     expect(pluginSource).toContain('buildAttendanceAssignmentViewSql')
   })
 

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -232,6 +232,21 @@ function schedulerScopeApproveRow(overrides: Record<string, unknown> = {}) {
   })
 }
 
+function schedulerScopeExportRow(overrides: Record<string, unknown> = {}) {
+  return schedulerScopeRow({
+    actions: ['export'],
+    scope: {
+      scheduleGroupIds: [scheduleGroupId],
+      attendanceGroupIds: [],
+      userIds: [],
+      departments: [],
+      roles: [],
+      roleTags: [],
+    },
+    ...overrides,
+  })
+}
+
 function scheduleGroupMemberRow(overrides: Record<string, unknown> = {}) {
   return {
     id: scheduleGroupMemberId,
@@ -369,6 +384,30 @@ function attendanceRequestRow(overrides: Record<string, unknown> = {}) {
   }
 }
 
+function attendanceRecordRow(overrides: Record<string, unknown> = {}) {
+  return {
+    user_id: 'worker-1',
+    org_id: 'default',
+    work_date: '2026-06-10',
+    timezone: 'UTC',
+    first_in_at: '2026-06-10T09:00:00.000Z',
+    last_out_at: '2026-06-10T18:00:00.000Z',
+    work_minutes: 480,
+    late_minutes: 0,
+    early_leave_minutes: 0,
+    status: 'normal',
+    is_workday: true,
+    meta: {},
+    user_name: 'Worker One',
+    username: 'worker1',
+    employee_no: 'E001',
+    department: 'Ops',
+    position: 'Operator',
+    hire_date: null,
+    ...overrides,
+  }
+}
+
 function approvalInstanceRow(overrides: Record<string, unknown> = {}) {
   return {
     id: approvalInstanceId,
@@ -399,6 +438,14 @@ function fixedScheduleQueryResult(sql: string) {
 
 function rbacQueryResult(sql: string, params: unknown[] = [], admin = false) {
   if (sql.includes('FROM user_roles') && sql.includes('role_id = $2')) return admin ? [{ ok: 1 }] : []
+  if (sql.includes('FROM user_permissions')) return []
+  if (sql.includes('JOIN role_permissions')) return []
+  return undefined
+}
+
+function attendanceReadOnlyRbacQueryResult(sql: string, params: unknown[] = []) {
+  if (sql.includes('FROM user_roles') && sql.includes('role_id = $2')) return []
+  if (sql.includes('FROM user_permissions') && params[1] === 'attendance:read') return [{ ok: 1 }]
   if (sql.includes('FROM user_permissions')) return []
   if (sql.includes('JOIN role_permissions')) return []
   return undefined
@@ -1067,7 +1114,7 @@ describe('attendance UUID route validation', () => {
     )
     expect(db.query).toHaveBeenCalledWith(
       expect.stringContaining('SELECT DISTINCT m.schedule_group_id'),
-      ['default', 'worker-1', '2026-06-10'],
+      ['default', 'worker-1', '2026-06-10', '2026-06-10'],
     )
     expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('INSERT INTO approval_records'))).toBe(true)
   })
@@ -1110,6 +1157,108 @@ describe('attendance UUID route validation', () => {
     expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
     expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('SELECT * FROM approval_instances'))).toBe(false)
     expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('UPDATE attendance_requests'))).toBe(false)
+  })
+
+  it('lets scoped non-admin schedulers export records inside their scheduler export scope', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = attendanceReadOnlyRbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeExportRow()]
+      if (sql.includes('SELECT DISTINCT group_id') && sql.includes('FROM attendance_group_members')) return []
+      if (sql.includes('SELECT DISTINCT m.schedule_group_id')) {
+        return [{ schedule_group_id: scheduleGroupId, department_ref: 'factory-1' }]
+      }
+      if (sql.includes('FROM attendance_records ar')) return [attendanceRecordRow()]
+      if (sql.includes('FROM attendance_requests') && sql.includes('GROUP BY work_date, request_type')) return []
+      if (sql.includes('FROM attendance_leave_types')) return []
+      if (sql.includes('FROM attendance_overtime_rules')) return []
+      if (sql.includes('SELECT value FROM system_configs')) return []
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'GET /api/attendance/export', {
+      query: {
+        userId: 'worker-1',
+        from: '2026-06-01',
+        to: '2026-06-30',
+        format: 'json',
+      },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: {
+        total: 1,
+        from: '2026-06-01',
+        to: '2026-06-30',
+        format: 'json',
+      },
+    })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM attendance_scheduler_scopes'),
+      ['default', 'scheduler-1', [], []],
+    )
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT DISTINCT m.schedule_group_id'),
+      ['default', 'worker-1', '2026-06-01', '2026-06-30'],
+    )
+    const scheduleScopeSql = db.query.mock.calls
+      .map(([sql]) => String(sql))
+      .find(sql => sql.includes('SELECT DISTINCT m.schedule_group_id')) ?? ''
+    expect(scheduleScopeSql).toContain("COALESCE(m.effective_from, DATE '0001-01-01') <= $3::date")
+    expect(scheduleScopeSql).toContain("COALESCE(m.effective_to, DATE '9999-12-31') >= $4::date")
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM attendance_records ar'),
+      ['worker-1', 'default', '2026-06-01', '2026-06-30', 1000],
+    )
+  })
+
+  it('rejects scoped attendance export outside scheduler scope before reading records', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = attendanceReadOnlyRbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) {
+        return [schedulerScopeExportRow({
+          scope: {
+            scheduleGroupIds: ['00000000-0000-4000-8000-000000009999'],
+            attendanceGroupIds: [],
+            userIds: [],
+            departments: [],
+            roles: [],
+            roleTags: [],
+          },
+        })]
+      }
+      if (sql.includes('SELECT DISTINCT group_id') && sql.includes('FROM attendance_group_members')) return []
+      if (sql.includes('SELECT DISTINCT m.schedule_group_id')) {
+        return [{ schedule_group_id: scheduleGroupId, department_ref: 'factory-1' }]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'GET /api/attendance/export', {
+      query: {
+        userId: 'worker-1',
+        from: '2026-06-01',
+        to: '2026-06-30',
+        format: 'json',
+      },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_records ar'))).toBe(false)
   })
 
   it('lets full attendance admins add schedule group members without scheduler scopes', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -15551,9 +15551,13 @@ module.exports = {
       return target ? attendanceSchedulerScopeMatchesTarget(scopeRow, target) : false
     }
 
-    async function resolveAttendanceRequestApprovalScopeFacts(client, orgId, requestRow) {
-      const userId = normalizeAttendanceSchedulerScopeRef(requestRow?.user_id)
-      const workDate = normalizeDateOnly(requestRow?.work_date) ?? requestRow?.work_date
+    async function resolveAttendanceUserSchedulerScopeFacts(client, orgId, userIdValue, { workDate, from, to } = {}) {
+      const userId = normalizeAttendanceSchedulerScopeRef(userIdValue)
+      const normalizedWorkDate = normalizeDateOnly(workDate) ?? workDate
+      const normalizedFrom = normalizeDateOnly(from) ?? from
+      const normalizedTo = normalizeDateOnly(to) ?? to
+      const rangeFrom = normalizedFrom ?? normalizedWorkDate
+      const rangeTo = normalizedTo ?? normalizedWorkDate ?? rangeFrom
       const facts = {
         scheduleGroupIds: [],
         attendanceGroupIds: [],
@@ -15580,7 +15584,8 @@ module.exports = {
       )
       facts.attendanceGroupIds = attendanceGroupRows.map(row => row.group_id).filter(Boolean)
 
-      if (workDate) {
+      if (rangeFrom && rangeTo) {
+        // Range exports must not be authorized by a partial membership overlap.
         const scheduleGroupRows = await client.query(
           `SELECT DISTINCT m.schedule_group_id, g.department_ref
            FROM attendance_schedule_group_members m
@@ -15592,15 +15597,20 @@ module.exports = {
              AND m.user_id = $2
              AND m.schedule_group_id IS NOT NULL
              AND COALESCE(m.effective_from, DATE '0001-01-01') <= $3::date
-             AND COALESCE(m.effective_to, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
+             AND COALESCE(m.effective_to, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $4::date
            ORDER BY m.schedule_group_id ASC`,
-          [orgId, userId, workDate]
+          [orgId, userId, rangeFrom, rangeTo]
         )
         facts.scheduleGroupIds = scheduleGroupRows.map(row => row.schedule_group_id).filter(Boolean)
         facts.departments = sortedUnique(scheduleGroupRows.map(row => row.department_ref).filter(Boolean))
       }
 
       return facts
+    }
+
+    async function resolveAttendanceRequestApprovalScopeFacts(client, orgId, requestRow) {
+      const workDate = normalizeDateOnly(requestRow?.work_date) ?? requestRow?.work_date
+      return resolveAttendanceUserSchedulerScopeFacts(client, orgId, requestRow?.user_id, { workDate })
     }
 
     async function assertAttendanceRequestApprovalAllowed(req, { client, requestRow }) {
@@ -15624,6 +15634,34 @@ module.exports = {
           'SCHEDULER_SCOPE_FORBIDDEN',
           'Scheduler scope does not allow this attendance approval action'
         )
+      }
+    }
+
+    async function assertAttendanceRecordExportAllowed(req, res, { orgId, userId, from, to }) {
+      const access = await resolveAttendanceSchedulerScopeActor(req, res)
+      if (!access) return null
+      if (access.fullAdmin) return access
+
+      try {
+        const actorContext = await loadAttendanceScopeContextForUser(db, orgId, access.userId)
+        const scopes = await loadActiveAttendanceSchedulerScopesForActor(orgId, actorContext)
+        const facts = await resolveAttendanceUserSchedulerScopeFacts(db, orgId, userId, { from, to })
+        const allowed = scopes.some(scope =>
+          attendanceSchedulerScopeAllowsActorActionFacts(scope, actorContext, 'export', facts)
+        )
+        if (!allowed) {
+          respondAttendanceSchedulerScopeForbidden(res)
+          return null
+        }
+        return access
+      } catch (error) {
+        if (isDatabaseSchemaError(error)) {
+          res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+          return null
+        }
+        logger.error('Attendance export scheduler scope guard failed', error)
+        res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Scheduler scope check failed' } })
+        return null
       }
     }
 
@@ -30460,20 +30498,25 @@ module.exports = {
 
         const orgId = getOrgId(req)
         const targetUserId = parsed.data.userId ?? requesterId
+        const dateRange = resolveAttendanceDateRange(parsed.data.from, parsed.data.to)
+        if (!dateRange.ok) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: dateRange.message } })
+          return
+        }
+        const { from, to } = dateRange
         if (targetUserId !== requesterId) {
           const allowed = await canAccessOtherUsers(requesterId)
           if (!allowed) {
-            res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'No access to other users' } })
-            return
+            const scopedAccess = await assertAttendanceRecordExportAllowed(req, res, {
+              orgId,
+              userId: targetUserId,
+              from,
+              to,
+            })
+            if (!scopedAccess) return
           }
         }
 
-	        const dateRange = resolveAttendanceDateRange(parsed.data.from, parsed.data.to)
-	        if (!dateRange.ok) {
-	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: dateRange.message } })
-	          return
-	        }
-	        const { from, to } = dateRange
         const requestedLimit = parseNumber(parsed.data.limit, 1000)
         const limit = Math.min(Math.max(requestedLimit, 1), 5000)
 


### PR DESCRIPTION
## Summary
- allow scoped non-admin schedulers to export another user attendance records when an active scheduler scope grants the `export` action for that target
- reuse a shared user/date-range scheduler-scope fact resolver for approval and export checks
- require schedule-group/department facts to cover the full export window so a partial membership overlap cannot authorize a broad export

## Scope
- This PR only wires `GET /api/attendance/export`.
- Attendance CSV import, import batches, rollback, and batch export remain out of scope for a separate design/pass.

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts tests/unit/attendance-advanced-scheduling-scope.test.ts --watch=false` (53/53)
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend test:unit` (202 files / 2635 tests)