### PR TITLE
feat(data-sources): add credential rotation flow

### DIFF
--- a/apps/web/src/data-sources/api.ts
+++ b/apps/web/src/data-sources/api.ts
@@ -5,6 +5,7 @@ import type {
   DataSourceDetail,
   DataSourceListItem,
   DataSourceTestResult,
+  RotateDataSourceCredentialsPayload,
   UpdateDataSourcePayload,
 } from './types'
 
@@ -60,6 +61,19 @@ export async function updateDataSource(id: string, payload: UpdateDataSourcePayl
   })
   if (!res.ok) {
     throw new Error(await errorFrom(res, 'Failed to update data source'))
+  }
+}
+
+export async function rotateDataSourceCredentials(
+  id: string,
+  payload: RotateDataSourceCredentialsPayload,
+): Promise<void> {
+  const res = await apiFetch(`/api/data-sources/${encodeURIComponent(id)}/credentials`, {
+    method: 'PUT',
+    body: JSON.stringify(payload),
+  })
+  if (!res.ok) {
+    throw new Error(await errorFrom(res, 'Failed to update data source credentials'))
   }
 }
 

--- a/apps/web/src/data-sources/buildPayload.ts
+++ b/apps/web/src/data-sources/buildPayload.ts
@@ -1,7 +1,11 @@
 // Pure builder for the create payload — extracted so the credential-safety rule (OMIT blank
 // optional fields; never send an empty string as a value) is unit-testable without mounting the view.
-import type { CreateDataSourcePayload, DataSourceType } from './types'
-import type { UpdateDataSourcePayload } from './types'
+import type {
+  CreateDataSourcePayload,
+  DataSourceType,
+  RotateDataSourceCredentialsPayload,
+  UpdateDataSourcePayload,
+} from './types'
 
 export interface CreateFormState {
   id: string
@@ -71,4 +75,22 @@ export function buildUpdatePayload(form: CreateFormState): UpdateDataSourcePaylo
     options: { readOnly: form.readOnly },
   }
   return payload
+}
+
+/**
+ * Build the credential-rotation payload. Blank fields are omitted, never sent as empty
+ * strings, so "leave blank to keep current credential" is a real wire invariant.
+ */
+export function buildCredentialRotationPayload(form: CreateFormState): RotateDataSourceCredentialsPayload {
+  const isSql = form.type !== 'http'
+  const credentials: RotateDataSourceCredentialsPayload['credentials'] = {}
+
+  if (isSql) {
+    if (form.username) credentials.username = form.username
+    if (form.password) credentials.password = form.password
+  } else if (form.apiKey) {
+    credentials.apiKey = form.apiKey
+  }
+
+  return { credentials }
 }

--- a/apps/web/src/data-sources/types.ts
+++ b/apps/web/src/data-sources/types.ts
@@ -2,7 +2,7 @@
 //
 // IMPORTANT: credentials are WRITE-ONLY across the wire. A1 encrypts them at rest and the backend
 // never returns them in any GET/list response — so read types here carry NO credentials. Credentials
-// only appear in the CREATE payload.
+// only appear in the CREATE / credential-rotation payloads.
 
 // Keep in sync with backend SUPPORTED_DATA_SOURCE_TYPES (postgresql is an accepted alias of postgres;
 // the UI offers the three distinct kinds).
@@ -59,9 +59,14 @@ export interface CreateDataSourcePayload {
   options?: { readOnly?: boolean; autoConnect?: boolean }
 }
 
-/** Payload for `PUT /api/data-sources/:id`. Credential rotation is intentionally out of this UI slice. */
+/** Payload for `PUT /api/data-sources/:id`. Credentials use the dedicated rotation endpoint. */
 export interface UpdateDataSourcePayload {
   name?: string
   connection?: DataSourceConnectionInput
   options?: { readOnly?: boolean; autoConnect?: boolean }
+}
+
+/** Payload for `PUT /api/data-sources/:id/credentials`. Blank fields are omitted by the UI. */
+export interface RotateDataSourceCredentialsPayload {
+  credentials: { username?: string; password?: string; apiKey?: string; token?: string }
 }

--- a/apps/web/src/stores/dataSources.ts
+++ b/apps/web/src/stores/dataSources.ts
@@ -1,5 +1,4 @@
-// External data-source connector store (UI-1/UI-2/UI-3: list / create / update / delete / test).
-// Credential rotation is intentionally deferred; the update route currently accepts non-secret config only.
+// External data-source connector store (UI-1..UI-4: list / create / update / credential rotation / delete / test).
 import { defineStore } from 'pinia'
 import { ref } from 'vue'
 import {
@@ -7,6 +6,7 @@ import {
   deleteDataSource,
   getDataSource,
   listDataSources,
+  rotateDataSourceCredentials,
   testDataSourceConnection,
   updateDataSource,
 } from '../data-sources/api'
@@ -15,6 +15,7 @@ import type {
   DataSourceDetail,
   DataSourceListItem,
   DataSourceTestResult,
+  RotateDataSourceCredentialsPayload,
   UpdateDataSourcePayload,
 } from '../data-sources/types'
 
@@ -76,6 +77,22 @@ export const useDataSourcesStore = defineStore('dataSources', () => {
     }
   }
 
+  /** Rotate write-only credentials then refresh. Blank fields are omitted by the payload builder. */
+  async function rotateCredentials(id: string, payload: RotateDataSourceCredentialsPayload): Promise<boolean> {
+    error.value = null
+    try {
+      await rotateDataSourceCredentials(id, payload)
+      const remainingResults = { ...testResults.value }
+      delete remainingResults[id]
+      testResults.value = remainingResults
+      await fetchAll()
+      return true
+    } catch (e) {
+      error.value = e instanceof Error ? e.message : 'Failed to update data source credentials'
+      return false
+    }
+  }
+
   /** Delete then refresh. Returns true on success; on failure sets `error` and returns false. */
   async function remove(id: string): Promise<boolean> {
     error.value = null
@@ -125,6 +142,7 @@ export const useDataSourcesStore = defineStore('dataSources', () => {
     create,
     loadDetail,
     update,
+    rotateCredentials,
     remove,
     testConnection,
   }

--- a/apps/web/src/views/DataSourcesView.vue
+++ b/apps/web/src/views/DataSourcesView.vue
@@ -24,20 +24,20 @@
     <form v-if="formOpen" class="data-sources__form" data-testid="ds-create-form" @submit.prevent="submit">
       <div class="data-sources__grid">
         <label>ID
-          <input v-model.trim="form.id" required data-testid="ds-field-id" :disabled="formMode === 'edit'" placeholder="my-erp-db" />
+          <input v-model.trim="form.id" required data-testid="ds-field-id" :disabled="formMode !== 'create'" placeholder="my-erp-db" />
         </label>
         <label>名称 Name
-          <input v-model.trim="form.name" required data-testid="ds-field-name" placeholder="客户 ERP 库" />
+          <input v-model.trim="form.name" required data-testid="ds-field-name" :disabled="formMode === 'credentials'" placeholder="客户 ERP 库" />
         </label>
         <label>类型 Type
-          <select v-model="form.type" data-testid="ds-field-type" :disabled="formMode === 'edit'">
+          <select v-model="form.type" data-testid="ds-field-type" :disabled="formMode !== 'create'">
             <option v-for="t in DATA_SOURCE_TYPES" :key="t" :value="t">{{ DATA_SOURCE_TYPE_LABELS[t] }}</option>
           </select>
         </label>
       </div>
 
       <!-- SQL connection -->
-      <div v-if="isSql" class="data-sources__grid">
+      <div v-if="isSql && formMode !== 'credentials'" class="data-sources__grid">
         <label>Host
           <input v-model.trim="form.host" required data-testid="ds-field-host" placeholder="10.0.0.5" />
         </label>
@@ -56,7 +56,7 @@
       </div>
 
       <!-- HTTP connection -->
-      <div v-else class="data-sources__grid">
+      <div v-else-if="formMode !== 'credentials'" class="data-sources__grid">
         <label>Base URL
           <input v-model.trim="form.baseURL" required data-testid="ds-field-baseurl" placeholder="https://api.example.com" />
         </label>
@@ -69,14 +69,32 @@
         凭据保持不变;如需轮换凭据,请走单独的凭据更新流程。
       </p>
 
-      <label class="data-sources__checkbox">
+      <div v-if="formMode === 'credentials'" class="data-sources__grid" data-testid="ds-credential-fields">
+        <template v-if="isSql">
+          <label>Username
+            <input v-model.trim="form.username" autocomplete="off" data-testid="ds-field-username" placeholder="留空则保持不变" />
+          </label>
+          <label>Password
+            <input v-model="form.password" type="password" autocomplete="new-password" data-testid="ds-field-password" placeholder="留空则保持不变" />
+          </label>
+        </template>
+        <label v-else>API Key
+          <input v-model="form.apiKey" type="password" autocomplete="off" data-testid="ds-field-apikey" placeholder="留空则保持不变" />
+        </label>
+      </div>
+
+      <p v-if="formMode === 'credentials'" class="data-sources__muted" data-testid="ds-credential-note">
+        仅更新填写的凭据字段;留空字段保持不变,不会作为空字符串提交。
+      </p>
+
+      <label v-if="formMode !== 'credentials'" class="data-sources__checkbox">
         <input v-model="form.readOnly" type="checkbox" data-testid="ds-field-readonly" />
         只读(推荐;关闭后允许写 SQL)
       </label>
 
       <div class="data-sources__form-actions">
-        <button type="submit" class="data-sources__btn data-sources__btn--primary" :disabled="submitting" data-testid="ds-submit">
-          {{ submitting ? '保存中…' : formMode === 'edit' ? '保存' : '创建' }}
+        <button type="submit" class="data-sources__btn data-sources__btn--primary" :disabled="submitDisabled" data-testid="ds-submit">
+          {{ submitLabel }}
         </button>
       </div>
     </form>
@@ -129,6 +147,13 @@
                 >编辑</button>
                 <button
                   type="button"
+                  class="data-sources__btn"
+                  data-testid="ds-credentials"
+                  :disabled="detailLoading"
+                  @click="openCredentialForm(ds.id)"
+                >凭据</button>
+                <button
+                  type="button"
                   class="data-sources__btn data-sources__btn--danger"
                   data-testid="ds-delete"
                   @click="confirmRemove(ds.id, ds.name)"
@@ -151,11 +176,11 @@ import {
   type DataSourceDetail,
   type DataSourceType,
 } from '../data-sources/types'
-import { buildCreatePayload, buildUpdatePayload } from '../data-sources/buildPayload'
+import { buildCreatePayload, buildCredentialRotationPayload, buildUpdatePayload } from '../data-sources/buildPayload'
 
 const store = useDataSourcesStore()
 const formOpen = ref(false)
-const formMode = ref<'create' | 'edit'>('create')
+const formMode = ref<'create' | 'edit' | 'credentials'>('create')
 const editingId = ref<string | null>(null)
 const submitting = ref(false)
 const detailLoading = ref(false)
@@ -176,6 +201,19 @@ const form = reactive({
 
 const isSql = computed(() => form.type !== 'http')
 const defaultPort = computed(() => (form.type === 'sqlserver' ? '1433' : '5432'))
+const credentialFieldsFilled = computed(() => (
+  form.type === 'http'
+    ? form.apiKey.length > 0
+    : form.username.length > 0 || form.password.length > 0
+))
+const submitDisabled = computed(() => (
+  submitting.value || (formMode.value === 'credentials' && !credentialFieldsFilled.value)
+))
+const submitLabel = computed(() => {
+  if (submitting.value) return '保存中…'
+  if (formMode.value === 'credentials') return '更新凭据'
+  return formMode.value === 'edit' ? '保存' : '创建'
+})
 
 function typeLabel(type: string): string {
   return DATA_SOURCE_TYPE_LABELS[type as DataSourceType] ?? type
@@ -238,12 +276,28 @@ async function openEditForm(id: string): Promise<void> {
   }
 }
 
+async function openCredentialForm(id: string): Promise<void> {
+  detailLoading.value = true
+  try {
+    const detail = await store.loadDetail(id)
+    if (!detail) return
+    fillFormFromDetail(detail)
+    formMode.value = 'credentials'
+    editingId.value = id
+    formOpen.value = true
+  } finally {
+    detailLoading.value = false
+  }
+}
+
 async function submit(): Promise<void> {
   submitting.value = true
   try {
-    const ok = formMode.value === 'edit' && editingId.value
+    const ok = editingId.value && formMode.value === 'edit'
       ? await store.update(editingId.value, buildUpdatePayload(form))
-      : await store.create(buildCreatePayload(form))
+      : editingId.value && formMode.value === 'credentials'
+        ? await store.rotateCredentials(editingId.value, buildCredentialRotationPayload(form))
+        : await store.create(buildCreatePayload(form))
     if (ok) {
       resetForm()
       formMode.value = 'create'

--- a/apps/web/tests/data-sources-ui.spec.ts
+++ b/apps/web/tests/data-sources-ui.spec.ts
@@ -2,13 +2,19 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createPinia, setActivePinia } from 'pinia'
 import { createApp, nextTick } from 'vue'
 
-import { buildCreatePayload, buildUpdatePayload, type CreateFormState } from '../src/data-sources/buildPayload'
+import {
+  buildCreatePayload,
+  buildCredentialRotationPayload,
+  buildUpdatePayload,
+  type CreateFormState,
+} from '../src/data-sources/buildPayload'
 
 // Mock the api client so the store is tested in isolation.
 const listMock = vi.hoisted(() => vi.fn())
 const getMock = vi.hoisted(() => vi.fn())
 const createMock = vi.hoisted(() => vi.fn())
 const updateMock = vi.hoisted(() => vi.fn())
+const rotateCredentialsMock = vi.hoisted(() => vi.fn())
 const deleteMock = vi.hoisted(() => vi.fn())
 const testConnectionMock = vi.hoisted(() => vi.fn())
 vi.mock('../src/data-sources/api', () => ({
@@ -16,6 +22,7 @@ vi.mock('../src/data-sources/api', () => ({
   getDataSource: getMock,
   createDataSource: createMock,
   updateDataSource: updateMock,
+  rotateDataSourceCredentials: rotateCredentialsMock,
   deleteDataSource: deleteMock,
   testDataSourceConnection: testConnectionMock,
 }))
@@ -89,6 +96,30 @@ describe('buildUpdatePayload — non-secret update safety', () => {
   it('omits a blank update port instead of sending port: ""', () => {
     const p = buildUpdatePayload(form({ type: 'sqlserver', host: 'h', port: '', database: 'd' }))
     expect(p.connection).toEqual({ host: 'h', database: 'd' })
+  })
+})
+
+describe('buildCredentialRotationPayload — write-only credential safety', () => {
+  it('sends only filled SQL credential fields and omits blank secrets', () => {
+    const p = buildCredentialRotationPayload(form({
+      type: 'postgres',
+      username: 'new-user',
+      password: '',
+      host: 'ignored',
+      database: 'ignored',
+    }))
+    expect(p).toEqual({ credentials: { username: 'new-user' } })
+    expect(p.credentials).not.toHaveProperty('password')
+  })
+
+  it('sends only filled HTTP credential fields', () => {
+    const p = buildCredentialRotationPayload(form({
+      type: 'http',
+      apiKey: 'new-key',
+      username: 'ignored',
+      password: 'ignored',
+    }))
+    expect(p).toEqual({ credentials: { apiKey: 'new-key' } })
   })
 })
 
@@ -168,6 +199,28 @@ describe('useDataSourcesStore (UI-1)', () => {
     expect(updateMock).toHaveBeenCalledWith('a', payload)
     expect(store.testResults.a).toBeUndefined()
     expect(store.items[0].name).toBe('Renamed')
+  })
+
+  it('rotateCredentials posts write-only credentials, clears stale test result, and refetches', async () => {
+    rotateCredentialsMock.mockResolvedValue(undefined)
+    listMock.mockResolvedValue([{ id: 'a', name: 'A', type: 'postgres', connected: false }])
+    const store = useDataSourcesStore()
+    store.testResults.a = { id: 'a', success: false }
+
+    const payload = { credentials: { password: 'new-secret' } }
+    const ok = await store.rotateCredentials('a', payload)
+    expect(ok).toBe(true)
+    expect(rotateCredentialsMock).toHaveBeenCalledWith('a', payload)
+    expect(store.testResults.a).toBeUndefined()
+    expect(store.items[0].id).toBe('a')
+  })
+
+  it('rotateCredentials returns false and surfaces the backend message on failure', async () => {
+    rotateCredentialsMock.mockRejectedValue(new Error('credentials: at least one credential field is required'))
+    const store = useDataSourcesStore()
+    const ok = await store.rotateCredentials('a', { credentials: {} })
+    expect(ok).toBe(false)
+    expect(store.error).toBe('credentials: at least one credential field is required')
   })
 
   it('remove deletes by id and refetches', async () => {
@@ -303,5 +356,55 @@ describe('DataSourcesView (UI-2 connection test reachability)', () => {
       options: { readOnly: true },
     })
     expect(updateMock.mock.calls[0][1]).not.toHaveProperty('credentials')
+  })
+
+  it('opens credential mode and submits only filled credential fields', async () => {
+    listMock.mockResolvedValue([{ id: 'a', name: 'A', type: 'postgres', connected: false }])
+    getMock.mockResolvedValue({
+      id: 'a',
+      name: 'A',
+      type: 'postgres',
+      connected: false,
+      hasCredentials: true,
+      connection: { host: 'db.internal', port: 5432, database: 'erp' },
+      options: { readOnly: true },
+    })
+    rotateCredentialsMock.mockResolvedValue(undefined)
+
+    const container = await mountView()
+    const credentialsButton = container.querySelector('[data-testid="ds-credentials"]') as HTMLButtonElement | null
+    expect(credentialsButton).not.toBeNull()
+
+    credentialsButton!.click()
+    await flush()
+    await flush()
+    await flush()
+
+    expect(getMock).toHaveBeenCalledWith('a')
+    expect(container.querySelector('[data-testid="ds-credential-fields"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="ds-field-id"]')?.getAttribute('disabled')).not.toBeNull()
+    expect(container.querySelector('[data-testid="ds-field-type"]')?.getAttribute('disabled')).not.toBeNull()
+    expect(container.querySelector('[data-testid="ds-field-host"]')).toBeNull()
+    expect(container.querySelector('[data-testid="ds-field-readonly"]')).toBeNull()
+
+    const submit = container.querySelector('[data-testid="ds-submit"]') as HTMLButtonElement
+    expect(submit.disabled).toBe(true)
+
+    const passwordInput = container.querySelector('[data-testid="ds-field-password"]') as HTMLInputElement
+    passwordInput.value = 'new-password'
+    passwordInput.dispatchEvent(new Event('input'))
+    await flush()
+    expect(submit.disabled).toBe(false)
+
+    submit.click()
+    await flush()
+    await flush()
+    await flush()
+
+    expect(rotateCredentialsMock).toHaveBeenCalledWith('a', {
+      credentials: { password: 'new-password' },
+    })
+    expect(rotateCredentialsMock.mock.calls[0][1]).not.toHaveProperty('connection')
+    expect(rotateCredentialsMock.mock.calls[0][1]).not.toHaveProperty('options')
   })
 })

--- a/packages/core-backend/src/routes/data-sources.ts
+++ b/packages/core-backend/src/routes/data-sources.ts
@@ -69,6 +69,15 @@ const DataSourceUpdateSchema = z.object({
   }).optional()
 })
 
+const DataSourceCredentialsUpdateSchema = z.object({
+  credentials: z.object({
+    username: z.string().min(1).optional(),
+    password: z.string().min(1).optional(),
+    apiKey: z.string().min(1).optional(),
+    token: z.string().min(1).optional()
+  }).strict()
+}).strict()
+
 const QuerySchema = z.object({
   sql: z.string().min(1, 'SQL query is required'),
   params: z.array(z.unknown()).optional()
@@ -410,6 +419,92 @@ export function dataSourcesRouter(): Router {
         error: {
           code: 'INTERNAL_ERROR',
           message: error instanceof Error ? error.message : 'Failed to update data source'
+        }
+      })
+    }
+  })
+
+  /**
+   * PUT /api/data-sources/:id/credentials
+   * Rotate write-only credentials. Non-secret config updates stay on PUT /:id.
+   */
+  router.put('/api/data-sources/:id/credentials', rbacGuard('data_sources', 'write'), async (req: Request, res: Response) => {
+    const parse = DataSourceCredentialsUpdateSchema.safeParse(req.body)
+    if (!parse.success) {
+      return res.status(400).json({
+        ok: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: parse.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join('; ')
+        }
+      })
+    }
+    const changedCredentialKeys = Object.keys(parse.data.credentials)
+    if (changedCredentialKeys.length === 0) {
+      return res.status(400).json({
+        ok: false,
+        error: {
+          code: 'VALIDATION_ERROR',
+          message: 'credentials: at least one credential field is required'
+        }
+      })
+    }
+
+    try {
+      const manager = getManager()
+      const id = req.params.id
+      manager.assertAccess(id, resolveUserId(req))
+
+      const existing = manager.getDataSource(id)
+      const oldConfig = existing.getConfig()
+      const scope = manager.getScope(id)
+
+      const newConfig: DataSourceConfig = {
+        ...oldConfig,
+        credentials: {
+          ...oldConfig.credentials,
+          ...parse.data.credentials
+        },
+        id
+      }
+
+      const adapter = await manager.updateDataSource(id, newConfig, {
+        ownerId: scope?.ownerId ?? resolveUserId(req)!,
+        workspaceId: scope?.workspaceId ?? undefined
+      })
+
+      await auditLog({
+        actorId: req.user?.id?.toString(),
+        actorType: 'user',
+        action: 'update_credentials',
+        resourceType: 'data_source',
+        resourceId: id,
+        meta: {
+          changedCredentialKeys,
+          before: sanitizeConfig(oldConfig),
+          after: sanitizeConfig(newConfig)
+        }
+      })
+
+      return res.json({
+        ok: true,
+        data: {
+          ...sanitizeConfig(newConfig),
+          connected: adapter.isConnected()
+        }
+      })
+    } catch (error) {
+      if (error instanceof Error && error.message.includes('not found')) {
+        return res.status(404).json({
+          ok: false,
+          error: { code: 'NOT_FOUND', message: `Data source '${req.params.id}' not found` }
+        })
+      }
+      return res.status(500).json({
+        ok: false,
+        error: {
+          code: 'INTERNAL_ERROR',
+          message: error instanceof Error ? error.message : 'Failed to update data source credentials'
         }
       })
     }

--- a/packages/core-backend/tests/unit/data-source-readonly.test.ts
+++ b/packages/core-backend/tests/unit/data-source-readonly.test.ts
@@ -4,8 +4,9 @@ import { describe, expect, it, vi } from 'vitest'
 
 vi.mock('../../src/audit/audit', () => ({ auditLog: vi.fn(async () => {}) }))
 
+import { auditLog } from '../../src/audit/audit'
 import { DataSourceManager } from '../../src/data-adapters/DataSourceManager'
-import { dataSourcesRouter, isReadOnlySql } from '../../src/routes/data-sources'
+import { dataSourcesRouter, getDataSourceManager, isReadOnlySql } from '../../src/routes/data-sources'
 import type { DataSourceConfig } from '../../src/data-adapters/BaseAdapter'
 
 function sqlConfig(id: string, readOnly?: boolean): DataSourceConfig {
@@ -163,5 +164,78 @@ describe('data-sources PUT deep-merge (A-RO)', () => {
     // credentials are still never returned, and the merge does not resurrect them into the response
     expect(got.body.data).not.toHaveProperty('credentials')
     expect(got.body.data.hasCredentials).toBe(true)
+  })
+
+  it('rotates credentials without exposing them or wiping omitted keys', async () => {
+    currentUser = admin('alice')
+    await request(app).post('/api/data-sources').send({
+      id: 'rotate-creds', name: 'rotate-creds', type: 'postgres',
+      connection: { host: 'db', database: 'erp' },
+      credentials: { username: 'old-user', password: 'old-password', apiKey: 'kept-key' },
+      options: { autoConnect: false, readOnly: true },
+    })
+
+    const put = await request(app)
+      .put('/api/data-sources/rotate-creds/credentials')
+      .send({ credentials: { password: 'new-password' } })
+    expect(put.status).toBe(200)
+    expect(put.body.data).not.toHaveProperty('credentials')
+    expect(put.body.data.hasCredentials).toBe(true)
+
+    const got = await request(app).get('/api/data-sources/rotate-creds')
+    expect(got.body.data).not.toHaveProperty('credentials')
+    expect(got.body.data.hasCredentials).toBe(true)
+
+    const config = getDataSourceManager().getDataSource('rotate-creds').getConfig()
+    expect(config.credentials).toMatchObject({
+      username: 'old-user',
+      password: 'new-password',
+      apiKey: 'kept-key',
+    })
+    const auditMeta = vi.mocked(auditLog).mock.calls.at(-1)?.[0]?.meta
+    expect(auditMeta).toMatchObject({ changedCredentialKeys: ['password'] })
+    expect(JSON.stringify(auditMeta)).not.toContain('new-password')
+    expect(JSON.stringify(auditMeta)).not.toContain('old-password')
+  })
+
+  it('fails closed on empty credential rotation payloads', async () => {
+    currentUser = admin('alice')
+    await request(app).post('/api/data-sources').send({
+      id: 'rotate-empty', name: 'rotate-empty', type: 'postgres',
+      connection: { host: 'db', database: 'erp' },
+      credentials: { username: 'u', password: 'p' },
+      options: { autoConnect: false, readOnly: true },
+    })
+
+    const empty = await request(app)
+      .put('/api/data-sources/rotate-empty/credentials')
+      .send({ credentials: {} })
+    expect(empty.status).toBe(400)
+    expect(empty.body.error.code).toBe('VALIDATION_ERROR')
+
+    const blank = await request(app)
+      .put('/api/data-sources/rotate-empty/credentials')
+      .send({ credentials: { password: '' } })
+    expect(blank.status).toBe(400)
+    expect(blank.body.error.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('scopes credential rotation to the source owner', async () => {
+    currentUser = admin('alice')
+    await request(app).post('/api/data-sources').send({
+      id: 'rotate-scope', name: 'rotate-scope', type: 'postgres',
+      connection: { host: 'db', database: 'erp' },
+      credentials: { username: 'u', password: 'alice-password' },
+      options: { autoConnect: false, readOnly: true },
+    })
+
+    currentUser = admin('bob')
+    const denied = await request(app)
+      .put('/api/data-sources/rotate-scope/credentials')
+      .send({ credentials: { password: 'bob-password' } })
+    expect(denied.status).toBe(404)
+
+    const config = getDataSourceManager().getDataSource('rotate-scope').getConfig()
+    expect(config.credentials?.password).toBe('alice-password')
   })
 })


### PR DESCRIPTION
## Summary

Adds UI-4 credential rotation for generic data sources, kept separate from the non-secret edit flow.

- backend: new scoped `PUT /api/data-sources/:id/credentials` endpoint for write-only credential updates
- backend safety: rejects empty/blank rotation payloads, preserves omitted credential keys, never returns or audits raw secret values
- frontend: adds a row-level credential rotation mode; blank fields stay omitted and disabled submit prevents empty rotations
- tests: backend route coverage for no-secret response / preserve omitted / empty fail-closed / owner scope, plus frontend payload/store/reachability coverage

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/data-source-readonly.test.ts --watch=false`
- `pnpm --filter @metasheet/web exec vitest run tests/data-sources-ui.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `pnpm --filter @metasheet/web exec eslint 'src/data-sources/*.ts' src/stores/dataSources.ts src/views/DataSourcesView.vue tests/data-sources-ui.spec.ts --max-warnings=0`
- `pnpm --filter @metasheet/core-backend exec eslint src/routes/data-sources.ts --max-warnings=0`
- `git diff --check`

## Boundaries

- does not expose credentials in GET/list/detail responses
- does not mix credential rotation into ordinary `PUT /:id` config updates
- does not add connector write/query behavior
