### PR TITLE
fix(web): data-sources UI supports connection.server (P2) — server-only MSSQL sources are editable

### DIFF
--- a/apps/web/src/data-sources/buildPayload.ts
+++ b/apps/web/src/data-sources/buildPayload.ts
@@ -12,6 +12,7 @@ export interface CreateFormState {
   name: string
   type: DataSourceType
   host: string
+  server: string
   port: number | '' | undefined
   database: string
   username: string
@@ -32,6 +33,9 @@ export function buildCreatePayload(form: CreateFormState): CreateDataSourcePaylo
 
   if (isSql) {
     if (form.host) connection.host = form.host
+    // ONLY SQL Server uses `server` (named instance) as a host alternative — Postgres ignores it, so
+    // scope it to sqlserver. Otherwise a server-only Postgres source would bypass the host requirement.
+    if (form.type === 'sqlserver' && form.server) connection.server = form.server
     if (typeof form.port === 'number' && Number.isFinite(form.port)) connection.port = form.port
     if (form.database) connection.database = form.database
     if (form.username) credentials.username = form.username
@@ -63,6 +67,7 @@ export function buildUpdatePayload(form: CreateFormState): UpdateDataSourcePaylo
 
   if (isSql) {
     if (form.host) connection.host = form.host
+    if (form.type === 'sqlserver' && form.server) connection.server = form.server
     if (typeof form.port === 'number' && Number.isFinite(form.port)) connection.port = form.port
     if (form.database) connection.database = form.database
   } else if (form.baseURL) {

--- a/apps/web/src/views/DataSourcesView.vue
+++ b/apps/web/src/views/DataSourcesView.vue
@@ -39,7 +39,10 @@
       <!-- SQL connection -->
       <div v-if="isSql && formMode !== 'credentials'" class="data-sources__grid">
         <label>Host
-          <input v-model.trim="form.host" required data-testid="ds-field-host" placeholder="10.0.0.5" />
+          <input v-model.trim="form.host" data-testid="ds-field-host" placeholder="10.0.0.5" />
+        </label>
+        <label v-if="form.type === 'sqlserver'">Server
+          <input v-model.trim="form.server" data-testid="ds-field-server" placeholder="命名实例(Host 备选)" />
         </label>
         <label>Port
           <input v-model.number="form.port" type="number" data-testid="ds-field-port" :placeholder="defaultPort" />
@@ -168,7 +171,7 @@
 </template>
 
 <script setup lang="ts">
-import { computed, onMounted, reactive, ref } from 'vue'
+import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { useDataSourcesStore } from '../stores/dataSources'
 import {
   DATA_SOURCE_TYPES,
@@ -190,6 +193,7 @@ const form = reactive({
   name: '',
   type: 'postgres' as DataSourceType,
   host: '',
+  server: '',
   port: undefined as number | undefined,
   database: '',
   username: '',
@@ -213,6 +217,12 @@ const submitLabel = computed(() => {
   if (submitting.value) return '保存中…'
   if (formMode.value === 'credentials') return '更新凭据'
   return formMode.value === 'edit' ? '保存' : '创建'
+})
+
+// `server` is a SQL-Server-only concept; clear it when switching away so a stale value can't linger
+// (the builder + guard already ignore it for non-sqlserver — this keeps the form state clean).
+watch(() => form.type, (type) => {
+  if (type !== 'sqlserver') form.server = ''
 })
 
 function typeLabel(type: string): string {
@@ -242,7 +252,7 @@ function toggleCreateForm(): void {
 
 function resetForm(): void {
   Object.assign(form, {
-    id: '', name: '', type: 'postgres', host: '', port: undefined, database: '',
+    id: '', name: '', type: 'postgres', host: '', server: '', port: undefined, database: '',
     username: '', password: '', baseURL: '', apiKey: '', readOnly: true,
   })
 }
@@ -256,6 +266,7 @@ function fillFormFromDetail(detail: DataSourceDetail): void {
     ? detail.type as DataSourceType
     : 'postgres'
   form.host = String(connection.host ?? '')
+  form.server = String(connection.server ?? '')
   form.port = typeof connection.port === 'number' ? connection.port : undefined
   form.database = String(connection.database ?? '')
   form.baseURL = String(connection.baseURL ?? '')
@@ -291,6 +302,17 @@ async function openCredentialForm(id: string): Promise<void> {
 }
 
 async function submit(): Promise<void> {
+  // P2: `server` (SQL Server named instance) is a host alternative ONLY for sqlserver — Postgres
+  // ignores it, so Postgres still requires host (UI-1's rule), while SQL Server accepts host OR
+  // server (so a server-only source is editable/savable rather than blocked by an empty Host).
+  if (isSql.value) {
+    const hasHost = !!form.host.trim()
+    const hasServer = form.type === 'sqlserver' && !!form.server.trim()
+    if (!hasHost && !hasServer) {
+      store.error = form.type === 'sqlserver' ? 'SQL Server 源需填写 Host 或 Server 之一' : '请填写 Host'
+      return
+    }
+  }
   submitting.value = true
   try {
     const ok = editingId.value && formMode.value === 'edit'

--- a/apps/web/tests/data-sources-ui.spec.ts
+++ b/apps/web/tests/data-sources-ui.spec.ts
@@ -32,7 +32,7 @@ import DataSourcesView from '../src/views/DataSourcesView.vue'
 
 function form(overrides: Partial<CreateFormState> = {}): CreateFormState {
   return {
-    id: 'db', name: 'DB', type: 'postgres', host: '', port: undefined, database: '',
+    id: 'db', name: 'DB', type: 'postgres', host: '', server: '', port: undefined, database: '',
     username: '', password: '', baseURL: '', apiKey: '', readOnly: true, ...overrides,
   }
 }
@@ -68,6 +68,19 @@ describe('buildCreatePayload — credential safety (omit blank, never send empty
     expect(p.connection).toEqual({ baseURL: 'https://x' })
     expect(p.credentials).toEqual({ apiKey: 'k' })
   })
+
+  it('P2: a SQL Server source can connect by `server` instead of `host`', () => {
+    const p = buildCreatePayload(form({ type: 'sqlserver', server: 'sql-prod', database: 'd' }))
+    expect(p.connection).toEqual({ server: 'sql-prod', database: 'd' })
+    expect(p.connection).not.toHaveProperty('host')
+  })
+
+  it('P2 follow-up: Postgres does NOT send `server` (it is sqlserver-only)', () => {
+    // A stale `server` (e.g. from switching type) must not let a Postgres source skip host.
+    const p = buildCreatePayload(form({ type: 'postgres', server: 'stale', host: '', database: 'd' }))
+    expect(p.connection).toEqual({ database: 'd' })
+    expect(p.connection).not.toHaveProperty('server')
+  })
 })
 
 describe('buildUpdatePayload — non-secret update safety', () => {
@@ -96,6 +109,11 @@ describe('buildUpdatePayload — non-secret update safety', () => {
   it('omits a blank update port instead of sending port: ""', () => {
     const p = buildUpdatePayload(form({ type: 'sqlserver', host: 'h', port: '', database: 'd' }))
     expect(p.connection).toEqual({ host: 'h', database: 'd' })
+  })
+
+  it('P2: update can carry `server` (no host) for a server-only source', () => {
+    const p = buildUpdatePayload(form({ type: 'sqlserver', server: 'sql-prod', database: 'd' }))
+    expect(p.connection).toEqual({ server: 'sql-prod', database: 'd' })
   })
 })
 


### PR DESCRIPTION
## P2 from the #2154 review — `connection.server` support

**The bug (now on main after #2154):** the edit/create form read only `form.host` and (UI-1) marked host `required`. A SQL Server source created via API/runbook with **`connection.server`** (named instance, no `host`) loaded with a blank Host and **couldn't be saved**. `types.ts` already supported `server`; the form ignored it.

### Fix
- **`CreateFormState` + both builders** (`buildCreatePayload`/`buildUpdatePayload`) carry `server` and send it when set (omit-blank discipline kept).
- **`DataSourcesView`**: a **Server** field (shown for `sqlserver`), `fillFormFromDetail` reads `connection.server`, **host is no longer hard-required**, and submit validates **"host OR server"** for SQL — so a `server`-only source is savable while an empty SQL connection is still blocked.

### Tests
`form()` helper carries `server`; +2 cases — create/update can connect by `server` (no host). **20/20 green** · `vue-tsc` 0 · eslint clean. Lock-safe: frontend only.

Pairs with **#2155** (the backend `connection` deep-merge): together, editing a SQL Server source now neither drops its TLS keys (backend) nor blocks on a `server`-only connection (frontend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)