### PR TITLE
feat(attendance): enforce scheduler scope import preview

### DIFF
--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
@@ -81,6 +81,8 @@ describe('attendance advanced scheduling scope foundation', () => {
     expect(pluginSource).toContain('assertAttendanceGroupFixedScheduleClearAllowed')
     expect(pluginSource).toContain('assertAttendanceRequestApprovalAllowed')
     expect(pluginSource).toContain('assertAttendanceRecordExportAllowed')
+    expect(pluginSource).toContain('assertAttendanceImportPrepareAllowed')
+    expect(pluginSource).toContain('assertAttendanceImportPreviewAllowed')
     expect(pluginSource).toContain('resolveAttendanceRequestApprovalScopeFacts')
     expect(pluginSource).toContain('resolveAttendanceUserSchedulerScopeFacts')
     expect(pluginSource).toContain('buildAttendanceAssignmentViewSql')

--- a/packages/core-backend/tests/unit/attendance-import-permission.test.ts
+++ b/packages/core-backend/tests/unit/attendance-import-permission.test.ts
@@ -14,6 +14,12 @@ function expectImportGuard(path: string) {
   expect(pluginSource).toMatch(pattern)
 }
 
+function expectDirectAsyncImportRoute(path: string) {
+  const escaped = path.replace(/[.*+?^${}()|[\]\\]/g, '\\$&')
+  const pattern = new RegExp(`['"]${escaped}['"],\\s*\\n\\s*async \\(req, res\\)`)
+  expect(pluginSource).toMatch(pattern)
+}
+
 describe('attendance import permission wiring', () => {
   it('exposes a dedicated importer preset and keeps admins import-capable', () => {
     const presets = listAccessPresets()
@@ -30,8 +36,6 @@ describe('attendance import permission wiring', () => {
       '/api/attendance/import/template',
       '/api/attendance/import/template.csv',
       '/api/attendance/import/upload',
-      '/api/attendance/import/prepare',
-      '/api/attendance/import/preview',
       '/api/attendance/import/commit',
       '/api/attendance/import/preview-async',
       '/api/attendance/import/commit-async',
@@ -46,5 +50,14 @@ describe('attendance import permission wiring', () => {
       '/api/attendance/import/batches/:id/export.csv',
       '/api/attendance/import/rollback/:id',
     ].forEach(expectImportGuard)
+  })
+
+  it('lets scheduler-scoped import prepare and preview use direct runtime guards', () => {
+    [
+      '/api/attendance/import/prepare',
+      '/api/attendance/import/preview',
+    ].forEach(expectDirectAsyncImportRoute)
+    expect(pluginSource).toContain('assertAttendanceImportPrepareAllowed')
+    expect(pluginSource).toContain('assertAttendanceImportPreviewAllowed')
   })
 })

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -247,6 +247,21 @@ function schedulerScopeExportRow(overrides: Record<string, unknown> = {}) {
   })
 }
 
+function schedulerScopeImportRow(overrides: Record<string, unknown> = {}) {
+  return schedulerScopeRow({
+    actions: ['import'],
+    scope: {
+      scheduleGroupIds: [scheduleGroupId],
+      attendanceGroupIds: [],
+      userIds: [],
+      departments: [],
+      roles: [],
+      roleTags: [],
+    },
+    ...overrides,
+  })
+}
+
 function scheduleGroupMemberRow(overrides: Record<string, unknown> = {}) {
   return {
     id: scheduleGroupMemberId,
@@ -1259,6 +1274,148 @@ describe('attendance UUID route validation', () => {
     expect(res.statusCode).toBe(403)
     expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
     expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_records ar'))).toBe(false)
+  })
+
+  it('lets scoped non-admin schedulers prepare import tokens when they have import scope', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeImportRow()]
+      if (sql.includes('DELETE FROM attendance_import_tokens')) return []
+      if (sql.includes('INSERT INTO attendance_import_tokens')) return []
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/import/prepare', {
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: {
+        ttlSeconds: 600,
+      },
+    })
+    expect((res.body as any).data.commitToken).toEqual(expect.any(String))
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('FROM attendance_scheduler_scopes'),
+      ['default', 'scheduler-1', [], []],
+    )
+  })
+
+  it('lets scoped non-admin schedulers preview import rows inside their import scope', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeImportRow()]
+      if (sql.includes('SELECT DISTINCT group_id') && sql.includes('FROM attendance_group_members')) return []
+      if (sql.includes('SELECT DISTINCT m.schedule_group_id')) {
+        return [{ schedule_group_id: scheduleGroupId, department_ref: 'factory-1' }]
+      }
+      if (sql.includes('FROM attendance_rules')) return []
+      if (sql.includes('SELECT value FROM system_configs')) return []
+      if (sql.includes('SELECT name, code, rule_set_id FROM attendance_groups')) return []
+      if (sql.includes('FROM attendance_holidays')) return []
+      if (sql.includes('FROM attendance_rotation_assignments')) return []
+      if (sql.includes('FROM attendance_shift_assignments')) return []
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/import/preview', {
+      body: {
+        rows: [
+          {
+            userId: 'worker-1',
+            workDate: '2026-06-10',
+            fields: {
+              firstInAt: '2026-06-10T09:00:00.000Z',
+              lastOutAt: '2026-06-10T18:00:00.000Z',
+            },
+          },
+        ],
+      },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: {
+        total: 1,
+        rowCount: 1,
+        items: [
+          {
+            userId: 'worker-1',
+            workDate: '2026-06-10',
+          },
+        ],
+      },
+    })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT DISTINCT m.schedule_group_id'),
+      ['default', 'worker-1', '2026-06-10', '2026-06-10'],
+    )
+  })
+
+  it('rejects scoped import preview outside scheduler scope before rule evaluation', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) {
+        return [schedulerScopeImportRow({
+          scope: {
+            scheduleGroupIds: ['00000000-0000-4000-8000-000000009999'],
+            attendanceGroupIds: [],
+            userIds: [],
+            departments: [],
+            roles: [],
+            roleTags: [],
+          },
+        })]
+      }
+      if (sql.includes('SELECT DISTINCT group_id') && sql.includes('FROM attendance_group_members')) return []
+      if (sql.includes('SELECT DISTINCT m.schedule_group_id')) {
+        return [{ schedule_group_id: scheduleGroupId, department_ref: 'factory-1' }]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/import/preview', {
+      body: {
+        rows: [
+          {
+            userId: 'worker-1',
+            workDate: '2026-06-10',
+            fields: {
+              firstInAt: '2026-06-10T09:00:00.000Z',
+              lastOutAt: '2026-06-10T18:00:00.000Z',
+            },
+          },
+        ],
+      },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT DISTINCT m.schedule_group_id'),
+      ['default', 'worker-1', '2026-06-10', '2026-06-10'],
+    )
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_rules'))).toBe(false)
   })
 
   it('lets full attendance admins add schedule group members without scheduler scopes', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -14733,12 +14733,18 @@ function createRbacHelpers(db, logger) {
     return withAnyPermission([permission], handler)
   }
 
+  async function hasAttendanceImportAccess(userId) {
+    if (process.env.RBAC_BYPASS === 'true') return true
+    if (await hasAttendanceAdminAccess(userId)) return true
+    return userHasPermission(userId, 'attendance:import')
+  }
+
   async function canAccessOtherUsers(userId) {
     if (await hasAttendanceAdminAccess(userId)) return true
     return userHasPermission(userId, 'attendance:approve')
   }
 
-  return { hasAttendanceAdminAccess, withAnyPermission, withPermission, canAccessOtherUsers }
+  return { hasAttendanceAdminAccess, hasAttendanceImportAccess, withAnyPermission, withPermission, canAccessOtherUsers }
 }
 
 function normalizeApprovalSteps(value) {
@@ -15187,7 +15193,7 @@ module.exports = {
   async activate(context) {
     const db = context.api.database
     const logger = context.logger
-    const { hasAttendanceAdminAccess, withAnyPermission, withPermission, canAccessOtherUsers } = createRbacHelpers(db, logger)
+    const { hasAttendanceAdminAccess, hasAttendanceImportAccess, withAnyPermission, withPermission, canAccessOtherUsers } = createRbacHelpers(db, logger)
     const withAttendanceImportPermission = (handler) => withAnyPermission(['attendance:import', 'attendance:admin'], handler)
     const emitEvent = (type, data) => {
       if (context.api?.events?.emit) {
@@ -15660,6 +15666,103 @@ module.exports = {
           return null
         }
         logger.error('Attendance export scheduler scope guard failed', error)
+        res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Scheduler scope check failed' } })
+        return null
+      }
+    }
+
+    async function resolveAttendanceImportActor(req, res) {
+      const access = await resolveAttendanceSchedulerScopeActor(req, res)
+      if (!access) return null
+      try {
+        return {
+          ...access,
+          fullImport: access.fullAdmin || await hasAttendanceImportAccess(access.userId),
+        }
+      } catch (error) {
+        logger.error('Attendance import actor resolution failed', error)
+        res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Permission check failed' } })
+        return null
+      }
+    }
+
+    async function assertAttendanceImportPrepareAllowed(req, res) {
+      const access = await resolveAttendanceImportActor(req, res)
+      if (!access) return null
+      if (access.fullImport) return access
+
+      try {
+        const actorContext = await loadAttendanceScopeContextForUser(db, access.orgId, access.userId)
+        const scopes = await loadActiveAttendanceSchedulerScopesForActor(access.orgId, actorContext)
+        const allowed = scopes.some(scope =>
+          attendanceSchedulerScopeMatchesActor(scope, actorContext)
+          && normalizeStringArray(scope.actions).includes('import')
+        )
+        if (!allowed) {
+          respondAttendanceSchedulerScopeForbidden(res)
+          return null
+        }
+        return access
+      } catch (error) {
+        if (isDatabaseSchemaError(error)) {
+          res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+          return null
+        }
+        logger.error('Attendance import prepare scheduler scope guard failed', error)
+        res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Scheduler scope check failed' } })
+        return null
+      }
+    }
+
+    function resolveAttendanceImportScopeTargets(rows, payload, fallbackUserId) {
+      const targets = new Map()
+      for (const row of Array.isArray(rows) ? rows : []) {
+        const userId = resolveRowUserId({
+          row,
+          fallbackUserId,
+          userMap: payload?.userMap,
+          userMapKeyField: payload?.userMapKeyField,
+          userMapSourceFields: payload?.userMapSourceFields,
+        })
+        const workDate = normalizeDateOnly(row?.workDate) ?? row?.workDate
+        if (!userId || !workDate) continue
+        targets.set(`${userId}:${workDate}`, { userId, workDate })
+      }
+      return Array.from(targets.values())
+    }
+
+    async function assertAttendanceImportPreviewAllowed(req, res, { orgId, rows, payload, fallbackUserId, actorAccess }) {
+      const access = actorAccess ?? await resolveAttendanceImportActor(req, res)
+      if (!access) return null
+      if (access.fullImport) return access
+
+      try {
+        const actorContext = await loadAttendanceScopeContextForUser(db, orgId, access.userId)
+        const scopes = (await loadActiveAttendanceSchedulerScopesForActor(orgId, actorContext))
+          .filter(scope => normalizeStringArray(scope.actions).includes('import'))
+        const targets = resolveAttendanceImportScopeTargets(rows, payload, fallbackUserId)
+        let allowed = targets.length > 0
+        for (const target of targets) {
+          const facts = await resolveAttendanceUserSchedulerScopeFacts(db, orgId, target.userId, { workDate: target.workDate })
+          const targetAllowed = scopes.some(scope =>
+            attendanceSchedulerScopeAllowsActorActionFacts(scope, actorContext, 'import', facts)
+          )
+          if (!targetAllowed) {
+            allowed = false
+            break
+          }
+        }
+        if (!allowed) {
+          respondAttendanceSchedulerScopeForbidden(res)
+          return null
+        }
+        return access
+      } catch (error) {
+        if (isDatabaseSchemaError(error)) {
+          res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
+          return null
+        }
+        logger.error('Attendance import preview scheduler scope guard failed', error)
         res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Scheduler scope check failed' } })
         return null
       }
@@ -22330,13 +22433,13 @@ module.exports = {
 	    context.api.http.addRoute(
 	      'POST',
 	      '/api/attendance/import/prepare',
-      withAttendanceImportPermission(async (req, res) => {
+      async (req, res) => {
         const orgId = getOrgId(req)
-        const requesterId = getUserId(req)
-        if (!requesterId) {
-          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'userId is required' } })
+        const access = await assertAttendanceImportPrepareAllowed(req, res)
+        if (!access) {
           return
         }
+        const requesterId = access.userId
 
         try {
           const { token, expiresAt } = await createImportCommitToken({ db, orgId, userId: requesterId })
@@ -22356,13 +22459,13 @@ module.exports = {
           logger.error('Attendance import token prepare failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to prepare import token' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(
       'POST',
       '/api/attendance/import/preview',
-      withAttendanceImportPermission(async (req, res) => {
+      async (req, res) => {
         const parsed = importPayloadSchema.safeParse(normalizeImportPayload(req.body ?? {}))
         if (!parsed.success) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
@@ -22371,6 +22474,12 @@ module.exports = {
 
         const orgId = getOrgId(req)
         const requesterId = getUserId(req)
+        if (!requesterId) {
+          res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
+          return
+        }
+        const importAccess = await assertAttendanceImportPrepareAllowed(req, res)
+        if (!importAccess) return
 	        const userId = parsed.data.userId ?? requesterId
 	        if (!userId) {
 	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'userId is required' } })
@@ -22389,34 +22498,6 @@ module.exports = {
 	          return
 	        }
 	        const previewStartedAtMs = Date.now()
-	        if (requireImportCommitToken) {
-          if (!requesterId) {
-            res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
-            return
-          }
-          const commitToken = parsed.data.commitToken
-          if (!commitToken) {
-            res.status(400).json({ ok: false, error: { code: 'COMMIT_TOKEN_REQUIRED', message: 'commitToken is required' } })
-            return
-          }
-          let tokenOk = false
-          try {
-            // Tokens are bound to the requester, not the imported row's userId.
-            tokenOk = await consumeImportCommitToken(commitToken, { db, orgId, userId: requesterId })
-          } catch (error) {
-            if (error instanceof HttpError) {
-              res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
-              return
-            }
-            logger.error('Attendance import token validation failed (preview)', error)
-            res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to validate commit token' } })
-            return
-          }
-          if (!tokenOk) {
-            res.status(403).json({ ok: false, error: { code: 'COMMIT_TOKEN_INVALID', message: 'commitToken invalid or expired' } })
-            return
-          }
-        }
 
         try {
           let ruleSetConfig = null
@@ -22473,6 +22554,42 @@ module.exports = {
               })
 	            return
 	          }
+          const scopedAccess = await assertAttendanceImportPreviewAllowed(req, res, {
+            orgId,
+            rows,
+            payload: parsed.data,
+            fallbackUserId: parsed.data.userId ?? userId,
+            actorAccess: importAccess,
+          })
+          if (!scopedAccess) return
+	        if (requireImportCommitToken) {
+            if (!requesterId) {
+              res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
+              return
+            }
+            const commitToken = parsed.data.commitToken
+            if (!commitToken) {
+              res.status(400).json({ ok: false, error: { code: 'COMMIT_TOKEN_REQUIRED', message: 'commitToken is required' } })
+              return
+            }
+            let tokenOk = false
+            try {
+              // Tokens are bound to the requester, not the imported row's userId.
+              tokenOk = await consumeImportCommitToken(commitToken, { db, orgId, userId: requesterId })
+            } catch (error) {
+              if (error instanceof HttpError) {
+                res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+                return
+              }
+              logger.error('Attendance import token validation failed (preview)', error)
+              res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to validate commit token' } })
+              return
+            }
+            if (!tokenOk) {
+              res.status(403).json({ ok: false, error: { code: 'COMMIT_TOKEN_INVALID', message: 'commitToken invalid or expired' } })
+              return
+            }
+          }
 
           const baseRule = await loadDefaultRule(db, orgId)
           const settings = await getSettings(db)
@@ -22884,7 +23001,7 @@ module.exports = {
           logger.error('Attendance import preview failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to preview import' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(


### PR DESCRIPTION
## Summary
- Allow scheduler-scoped attendance actors with the `import` scheduler action to prepare import commit tokens and run synchronous import preview.
- Enforce preview row targets through existing scheduler-scope facts before rule evaluation, returning `SCHEDULER_SCOPE_FORBIDDEN` when any resolvable user/date is outside scope.
- Keep full `attendance:import` / `attendance:admin` behavior unchanged for existing importers and admins.

## Scope
- In scope: `POST /api/attendance/import/prepare` and `POST /api/attendance/import/preview`.
- Out of scope: commit, commit-async, preview-async, jobs, batches, batch export, rollback, upload/template routes. Those remain guarded by the existing import/admin permission path.

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `git diff --check origin/main..HEAD`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts tests/unit/attendance-advanced-scheduling-scope.test.ts tests/unit/attendance-import-permission.test.ts --watch=false` (59/59)
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend test:unit` (202 files / 2642 tests)
