### PR TITLE
feat(attendance): enforce scheduler scope import commit

### DIFF
--- a/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
+++ b/packages/core-backend/tests/unit/attendance-advanced-scheduling-scope.test.ts
@@ -83,6 +83,7 @@ describe('attendance advanced scheduling scope foundation', () => {
     expect(pluginSource).toContain('assertAttendanceRecordExportAllowed')
     expect(pluginSource).toContain('assertAttendanceImportPrepareAllowed')
     expect(pluginSource).toContain('assertAttendanceImportPreviewAllowed')
+    expect(pluginSource).toContain('assertAttendanceImportCommitAllowed')
     expect(pluginSource).toContain('resolveAttendanceRequestApprovalScopeFacts')
     expect(pluginSource).toContain('resolveAttendanceUserSchedulerScopeFacts')
     expect(pluginSource).toContain('buildAttendanceAssignmentViewSql')

--- a/packages/core-backend/tests/unit/attendance-import-permission.test.ts
+++ b/packages/core-backend/tests/unit/attendance-import-permission.test.ts
@@ -36,7 +36,6 @@ describe('attendance import permission wiring', () => {
       '/api/attendance/import/template',
       '/api/attendance/import/template.csv',
       '/api/attendance/import/upload',
-      '/api/attendance/import/commit',
       '/api/attendance/import/preview-async',
       '/api/attendance/import/commit-async',
       '/api/attendance/import/jobs/:id',
@@ -52,12 +51,14 @@ describe('attendance import permission wiring', () => {
     ].forEach(expectImportGuard)
   })
 
-  it('lets scheduler-scoped import prepare and preview use direct runtime guards', () => {
+  it('lets scheduler-scoped import prepare, preview, and commit use direct runtime guards', () => {
     [
       '/api/attendance/import/prepare',
       '/api/attendance/import/preview',
+      '/api/attendance/import/commit',
     ].forEach(expectDirectAsyncImportRoute)
     expect(pluginSource).toContain('assertAttendanceImportPrepareAllowed')
     expect(pluginSource).toContain('assertAttendanceImportPreviewAllowed')
+    expect(pluginSource).toContain('assertAttendanceImportCommitAllowed')
   })
 })

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -1418,6 +1418,136 @@ describe('attendance UUID route validation', () => {
     expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_rules'))).toBe(false)
   })
 
+  it('lets scoped non-admin schedulers commit import rows inside their import scope', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (query: unknown, paramsArg: unknown[] = []) => {
+      const sql = typeof query === 'string' ? query : String((query as { text?: unknown })?.text ?? query)
+      const params = typeof query === 'string'
+        ? paramsArg
+        : ((query as { values?: unknown[] })?.values ?? paramsArg)
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeImportRow()]
+      if (sql.includes('SELECT DISTINCT group_id') && sql.includes('FROM attendance_group_members')) return []
+      if (sql.includes('SELECT DISTINCT m.schedule_group_id')) {
+        return [{ schedule_group_id: scheduleGroupId, department_ref: 'factory-1' }]
+      }
+      if (sql.includes('FROM attendance_rules')) return []
+      if (sql.includes('SELECT value FROM system_configs')) return []
+      if (sql.includes('SELECT name, code, rule_set_id FROM attendance_groups')) return []
+      if (sql.includes('SET LOCAL statement_timeout')) return []
+      if (sql.includes('INSERT INTO attendance_import_batches')) return []
+      if (sql.includes('FROM attendance_holidays')) return []
+      if (sql.includes('FROM attendance_shift_assignments')) return []
+      if (sql.includes('FROM attendance_rotation_assignments')) return []
+      if (sql.includes('FROM attendance_records ar')) return []
+      if (sql.includes('INSERT INTO attendance_records')) {
+        return [{
+          id: '00000000-0000-4000-8000-000000000401',
+          user_id: 'worker-1',
+          work_date: '2026-06-10',
+        }]
+      }
+      if (sql.includes('INSERT INTO attendance_import_items')) return []
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/import/commit', {
+      body: {
+        rows: [
+          {
+            userId: 'worker-1',
+            workDate: '2026-06-10',
+            fields: {
+              firstInAt: '2026-06-10T09:00:00.000Z',
+              lastOutAt: '2026-06-10T18:00:00.000Z',
+            },
+          },
+        ],
+      },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({
+      ok: true,
+      success: true,
+      data: {
+        imported: 1,
+        processedRows: 1,
+        failedRows: 0,
+        items: [
+          {
+            id: '00000000-0000-4000-8000-000000000401',
+            userId: 'worker-1',
+            workDate: '2026-06-10',
+          },
+        ],
+      },
+    })
+    expect(db.transaction).toHaveBeenCalledTimes(1)
+    expect(db.query.mock.calls.map(([query]) => typeof query === 'string' ? query : String((query as { text?: unknown })?.text ?? query))
+      .some(sql => sql.includes('INSERT INTO attendance_records'))).toBe(true)
+  })
+
+  it('rejects scoped import commit outside scheduler scope before token consumption or writes', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) {
+        return [schedulerScopeImportRow({
+          scope: {
+            scheduleGroupIds: ['00000000-0000-4000-8000-000000009999'],
+            attendanceGroupIds: [],
+            userIds: [],
+            departments: [],
+            roles: [],
+            roleTags: [],
+          },
+        })]
+      }
+      if (sql.includes('SELECT DISTINCT group_id') && sql.includes('FROM attendance_group_members')) return []
+      if (sql.includes('SELECT DISTINCT m.schedule_group_id')) {
+        return [{ schedule_group_id: scheduleGroupId, department_ref: 'factory-1' }]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/import/commit', {
+      body: {
+        commitToken: 'commit-token-1',
+        rows: [
+          {
+            userId: 'worker-1',
+            workDate: '2026-06-10',
+            fields: {
+              firstInAt: '2026-06-10T09:00:00.000Z',
+              lastOutAt: '2026-06-10T18:00:00.000Z',
+            },
+          },
+        ],
+      },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT DISTINCT m.schedule_group_id'),
+      ['default', 'worker-1', '2026-06-10', '2026-06-10'],
+    )
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('DELETE FROM attendance_import_tokens'))).toBe(false)
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_rules'))).toBe(false)
+    expect(db.transaction).not.toHaveBeenCalled()
+  })
+
   it('lets full attendance admins add schedule group members without scheduler scopes', async () => {
     const { db, routes } = await createHarness('false')
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -15731,7 +15731,7 @@ module.exports = {
       return Array.from(targets.values())
     }
 
-    async function assertAttendanceImportPreviewAllowed(req, res, { orgId, rows, payload, fallbackUserId, actorAccess }) {
+    async function assertAttendanceImportRowsAllowed(req, res, { orgId, rows, payload, fallbackUserId, actorAccess, operation }) {
       const access = actorAccess ?? await resolveAttendanceImportActor(req, res)
       if (!access) return null
       if (access.fullImport) return access
@@ -15762,10 +15762,18 @@ module.exports = {
           res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance scheduling tables missing' } })
           return null
         }
-        logger.error('Attendance import preview scheduler scope guard failed', error)
+        logger.error(`Attendance import ${operation || 'rows'} scheduler scope guard failed`, error)
         res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Scheduler scope check failed' } })
         return null
       }
+    }
+
+    async function assertAttendanceImportPreviewAllowed(req, res, options) {
+      return assertAttendanceImportRowsAllowed(req, res, { ...options, operation: 'preview' })
+    }
+
+    async function assertAttendanceImportCommitAllowed(req, res, options) {
+      return assertAttendanceImportRowsAllowed(req, res, { ...options, operation: 'commit' })
     }
 
     function withAttendanceGroupMemberAccess(handler) {
@@ -23007,7 +23015,7 @@ module.exports = {
     context.api.http.addRoute(
       'POST',
       '/api/attendance/import/commit',
-      withAttendanceImportPermission(async (req, res) => {
+      async (req, res) => {
         const parsed = importPayloadSchema.safeParse(normalizeImportPayload(req.body ?? {}))
         if (!parsed.success) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
@@ -23015,11 +23023,11 @@ module.exports = {
         }
 
 	        const orgId = getOrgId(req)
-	        const requesterId = getUserId(req)
-	        if (!requesterId) {
-	          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'userId is required' } })
+        const importAccess = await assertAttendanceImportPrepareAllowed(req, res)
+	        if (!importAccess) {
 	          return
 	        }
+        const requesterId = importAccess.userId
 
 		        const idempotencyKey = typeof parsed.data.idempotencyKey === 'string'
 		          ? parsed.data.idempotencyKey.trim()
@@ -23073,27 +23081,6 @@ module.exports = {
 	          res.status(400).json({ ok: false, error: { code: 'COMMIT_TOKEN_REQUIRED', message: 'commitToken is required' } })
 	          return
         }
-	        if (commitToken) {
-	          let tokenOk = false
-          try {
-            tokenOk = await consumeImportCommitToken(commitToken, { db, orgId, userId: requesterId })
-          } catch (error) {
-            if (error instanceof HttpError) {
-              res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
-              return
-            }
-            logger.error('Attendance import token validation failed (commit)', error)
-            res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to validate commit token' } })
-            return
-          }
-          if (!tokenOk && requireImportCommitToken) {
-            res.status(403).json({ ok: false, error: { code: 'COMMIT_TOKEN_INVALID', message: 'commitToken invalid or expired' } })
-            return
-          }
-	          if (!tokenOk && !requireImportCommitToken) {
-	            logger.warn('Attendance import commit token invalid; continuing without enforcement.')
-	          }
-	        }
 	        const commitStartedAtMs = Date.now()
 
 	        try {
@@ -23151,6 +23138,35 @@ module.exports = {
               })
 	            return
 	          }
+          const scopedAccess = await assertAttendanceImportCommitAllowed(req, res, {
+            orgId,
+            rows,
+            payload: parsed.data,
+            fallbackUserId: parsed.data.userId ?? requesterId,
+            actorAccess: importAccess,
+          })
+          if (!scopedAccess) return
+	        if (commitToken) {
+	          let tokenOk = false
+            try {
+              tokenOk = await consumeImportCommitToken(commitToken, { db, orgId, userId: requesterId })
+            } catch (error) {
+              if (error instanceof HttpError) {
+                res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+                return
+              }
+              logger.error('Attendance import token validation failed (commit)', error)
+              res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to validate commit token' } })
+              return
+            }
+            if (!tokenOk && requireImportCommitToken) {
+              res.status(403).json({ ok: false, error: { code: 'COMMIT_TOKEN_INVALID', message: 'commitToken invalid or expired' } })
+              return
+            }
+	          if (!tokenOk && !requireImportCommitToken) {
+	            logger.warn('Attendance import commit token invalid; continuing without enforcement.')
+	          }
+	        }
 	          const importEngine = resolveImportEngineByRowCount(rows.length)
 	          const importChunkConfig = resolveImportChunkConfig(importEngine)
 	          const importRecordUpsertStrategy = resolveImportRecordUpsertStrategy({
@@ -24020,7 +24036,7 @@ module.exports = {
           logger.error('Attendance import commit failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to import attendance' } })
 	        }
-      })
+      }
     )
 
     // Async preview endpoint for ultra-large imports. Enqueues preview computation and lets clients


### PR DESCRIPTION
## Summary
- Allow scheduler-scoped attendance actors with the `import` scheduler action to run synchronous `POST /api/attendance/import/commit`.
- Reuse the import row target scope guard so every resolvable user/date is checked before token consumption and before the write transaction.
- Keep full `attendance:import` / `attendance:admin` behavior unchanged for existing importers and admins.

## Scope
- In scope: `POST /api/attendance/import/commit`.
- Out of scope: legacy `POST /api/attendance/import`, preview-async, commit-async, jobs, batches, batch export, rollback, upload/template routes. Those remain guarded by the existing import/admin permission path.

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts tests/unit/attendance-advanced-scheduling-scope.test.ts tests/unit/attendance-import-permission.test.ts --watch=false` (61/61)
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend test:unit` (202 files / 2644 tests)