### PR TITLE
feat(attendance): enforce scheduler scope legacy import

### DIFF
--- a/packages/core-backend/tests/unit/attendance-import-permission.test.ts
+++ b/packages/core-backend/tests/unit/attendance-import-permission.test.ts
@@ -39,7 +39,6 @@ describe('attendance import permission wiring', () => {
       '/api/attendance/import/preview-async',
       '/api/attendance/import/commit-async',
       '/api/attendance/import/jobs/:id',
-      '/api/attendance/import',
       '/api/attendance/integrations',
       '/api/attendance/integrations/:id/runs',
       '/api/attendance/integrations/:id/sync',
@@ -51,11 +50,12 @@ describe('attendance import permission wiring', () => {
     ].forEach(expectImportGuard)
   })
 
-  it('lets scheduler-scoped import prepare, preview, and commit use direct runtime guards', () => {
+  it('lets scheduler-scoped sync import routes use direct runtime guards', () => {
     [
       '/api/attendance/import/prepare',
       '/api/attendance/import/preview',
       '/api/attendance/import/commit',
+      '/api/attendance/import',
     ].forEach(expectDirectAsyncImportRoute)
     expect(pluginSource).toContain('assertAttendanceImportPrepareAllowed')
     expect(pluginSource).toContain('assertAttendanceImportPreviewAllowed')

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -1548,6 +1548,134 @@ describe('attendance UUID route validation', () => {
     expect(db.transaction).not.toHaveBeenCalled()
   })
 
+  it('lets scoped non-admin schedulers run legacy import rows inside their import scope', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (query: unknown, paramsArg: unknown[] = []) => {
+      const sql = typeof query === 'string' ? query : String((query as { text?: unknown })?.text ?? query)
+      const params = typeof query === 'string'
+        ? paramsArg
+        : ((query as { values?: unknown[] })?.values ?? paramsArg)
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeImportRow()]
+      if (sql.includes('SELECT DISTINCT group_id') && sql.includes('FROM attendance_group_members')) return []
+      if (sql.includes('SELECT DISTINCT m.schedule_group_id')) {
+        return [{ schedule_group_id: scheduleGroupId, department_ref: 'factory-1' }]
+      }
+      if (sql.includes('FROM attendance_rules')) return []
+      if (sql.includes('SELECT value FROM system_configs')) return []
+      if (sql.includes('SELECT name, code, rule_set_id FROM attendance_groups')) return []
+      if (sql.includes('SET LOCAL statement_timeout')) return []
+      if (sql.includes('FROM attendance_holidays')) return []
+      if (sql.includes('FROM attendance_shift_assignments')) return []
+      if (sql.includes('FROM attendance_rotation_assignments')) return []
+      if (sql.includes('FROM attendance_records ar')) return []
+      if (sql.includes('FROM attendance_records WHERE user_id = $1')) return []
+      if (sql.includes('INSERT INTO attendance_records')) {
+        return [{
+          id: '00000000-0000-4000-8000-000000000402',
+          user_id: 'worker-1',
+          work_date: '2026-06-10',
+        }]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/import', {
+      body: {
+        rows: [
+          {
+            userId: 'worker-1',
+            workDate: '2026-06-10',
+            fields: {
+              firstInAt: '2026-06-10T09:00:00.000Z',
+              lastOutAt: '2026-06-10T18:00:00.000Z',
+            },
+          },
+        ],
+      },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: {
+        imported: 1,
+        processedRows: 1,
+        failedRows: 0,
+        batchId: null,
+        items: [
+          {
+            id: '00000000-0000-4000-8000-000000000402',
+            userId: 'worker-1',
+            workDate: '2026-06-10',
+          },
+        ],
+      },
+    })
+    expect(db.transaction).toHaveBeenCalledTimes(1)
+    expect(db.query.mock.calls.map(([query]) => typeof query === 'string' ? query : String((query as { text?: unknown })?.text ?? query))
+      .some(sql => sql.includes('INSERT INTO attendance_records'))).toBe(true)
+  })
+
+  it('rejects scoped legacy import outside scheduler scope before rule evaluation or writes', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (sql: string, params: unknown[] = []) => {
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) {
+        return [schedulerScopeImportRow({
+          scope: {
+            scheduleGroupIds: ['00000000-0000-4000-8000-000000009999'],
+            attendanceGroupIds: [],
+            userIds: [],
+            departments: [],
+            roles: [],
+            roleTags: [],
+          },
+        })]
+      }
+      if (sql.includes('SELECT DISTINCT group_id') && sql.includes('FROM attendance_group_members')) return []
+      if (sql.includes('SELECT DISTINCT m.schedule_group_id')) {
+        return [{ schedule_group_id: scheduleGroupId, department_ref: 'factory-1' }]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/import', {
+      body: {
+        rows: [
+          {
+            userId: 'worker-1',
+            workDate: '2026-06-10',
+            fields: {
+              firstInAt: '2026-06-10T09:00:00.000Z',
+              lastOutAt: '2026-06-10T18:00:00.000Z',
+            },
+          },
+        ],
+      },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(403)
+    expect(res.body).toMatchObject({ ok: false, error: { code: 'SCHEDULER_SCOPE_FORBIDDEN' } })
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT DISTINCT m.schedule_group_id'),
+      ['default', 'worker-1', '2026-06-10', '2026-06-10'],
+    )
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_rules'))).toBe(false)
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('INSERT INTO attendance_records'))).toBe(false)
+    expect(db.transaction).not.toHaveBeenCalled()
+  })
+
   it('lets full attendance admins add schedule group members without scheduler scopes', async () => {
     const { db, routes } = await createHarness('false')
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -24380,7 +24380,7 @@ module.exports = {
     context.api.http.addRoute(
       'POST',
       '/api/attendance/import',
-      withAttendanceImportPermission(async (req, res) => {
+      async (req, res) => {
         const parsed = importPayloadSchema.safeParse(normalizeImportPayload(req.body ?? {}))
         if (!parsed.success) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
@@ -24388,7 +24388,9 @@ module.exports = {
         }
 
         const orgId = getOrgId(req)
-        const requesterId = getUserId(req)
+        const importAccess = await assertAttendanceImportPrepareAllowed(req, res)
+        if (!importAccess) return
+        const requesterId = importAccess.userId
 		        const userId = parsed.data.userId ?? requesterId
 		        if (!userId) {
 		          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'userId is required' } })
@@ -24406,32 +24408,10 @@ module.exports = {
 	          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to validate import size' } })
 	          return
 	        }
-	        if (requireImportCommitToken) {
-          if (!requesterId) {
-            res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED', message: 'User ID not found' } })
-            return
-          }
-          const commitToken = parsed.data.commitToken
-          if (!commitToken) {
-            res.status(400).json({ ok: false, error: { code: 'COMMIT_TOKEN_REQUIRED', message: 'commitToken is required' } })
-            return
-          }
-          let tokenOk = false
-          try {
-            tokenOk = await consumeImportCommitToken(commitToken, { db, orgId, userId: requesterId })
-          } catch (error) {
-            if (error instanceof HttpError) {
-              res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
-              return
-            }
-            logger.error('Attendance import token validation failed (legacy import)', error)
-            res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to validate commit token' } })
-            return
-          }
-          if (!tokenOk) {
-            res.status(403).json({ ok: false, error: { code: 'COMMIT_TOKEN_INVALID', message: 'commitToken invalid or expired' } })
-            return
-          }
+        const commitToken = parsed.data.commitToken
+	        if (!commitToken && requireImportCommitToken) {
+          res.status(400).json({ ok: false, error: { code: 'COMMIT_TOKEN_REQUIRED', message: 'commitToken is required' } })
+          return
         }
 
         try {
@@ -24465,6 +24445,32 @@ module.exports = {
 	            res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'No rows to import' } })
 	            return
 	          }
+          const scopedAccess = await assertAttendanceImportCommitAllowed(req, res, {
+            orgId,
+            rows,
+            payload: parsed.data,
+            fallbackUserId: parsed.data.userId ?? userId,
+            actorAccess: importAccess,
+          })
+          if (!scopedAccess) return
+	        if (requireImportCommitToken) {
+          let tokenOk = false
+          try {
+            tokenOk = await consumeImportCommitToken(commitToken, { db, orgId, userId: requesterId })
+          } catch (error) {
+            if (error instanceof HttpError) {
+              res.status(error.status).json({ ok: false, error: { code: error.code, message: error.message } })
+              return
+            }
+            logger.error('Attendance import token validation failed (legacy import)', error)
+            res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to validate commit token' } })
+            return
+          }
+          if (!tokenOk) {
+            res.status(403).json({ ok: false, error: { code: 'COMMIT_TOKEN_INVALID', message: 'commitToken invalid or expired' } })
+            return
+          }
+        }
 	          const importEngine = resolveImportEngineByRowCount(rows.length)
 	          const importRecordUpsertStrategy = resolveImportRecordUpsertStrategy({
 	            rowCount: rows.length,
@@ -24921,7 +24927,7 @@ module.exports = {
           logger.error('Attendance import failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to import attendance' } })
         }
-      })
+      }
     )
 
     context.api.http.addRoute(


### PR DESCRIPTION
## Summary
- Allow scheduler-scoped attendance actors with the `import` scheduler action to run synchronous legacy `POST /api/attendance/import`.
- Reuse the import row target scope guard so every resolvable user/date is checked before rule evaluation and before the write transaction.
- Keep full `attendance:import` / `attendance:admin` behavior unchanged for existing importers and admins.

## Scope
- In scope: synchronous legacy `POST /api/attendance/import`.
- Out of scope: template/upload, preview-async, commit-async, jobs, batches, batch export, rollback, and integration import routes. Those remain guarded by the existing import/admin permission path.

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts tests/unit/attendance-import-permission.test.ts tests/unit/attendance-advanced-scheduling-scope.test.ts --watch=false` (63/63)
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend test:unit` (202 files / 2646 tests)