### PR TITLE
fix(attendance): scope import idempotency replay

### DIFF
--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -1501,6 +1501,11 @@ describe('attendance UUID route validation', () => {
       if (rbac !== undefined) return rbac
       const actor = actorContextQueryResult(sql)
       if (actor !== undefined) return actor
+      if (sql.includes('information_schema.columns') && sql.includes('attendance_import_batches')) return [{ ok: 1 }]
+      if (sql.includes('FROM attendance_import_batches')) {
+        return [{ id: 'external-batch-1', meta: { idempotencyKey: 'external-key' } }]
+      }
+      if (sql.includes('FROM attendance_import_items')) return [{ imported: 7, skipped: 1 }]
       if (sql.includes('FROM attendance_scheduler_scopes')) {
         return [schedulerScopeImportRow({
           scope: {
@@ -1522,6 +1527,7 @@ describe('attendance UUID route validation', () => {
 
     const res = await invokeRoute(routes, 'POST /api/attendance/import/commit', {
       body: {
+        idempotencyKey: 'external-key',
         commitToken: 'commit-token-1',
         rows: [
           {
@@ -1544,7 +1550,122 @@ describe('attendance UUID route validation', () => {
       ['default', 'worker-1', '2026-06-10', '2026-06-10'],
     )
     expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('DELETE FROM attendance_import_tokens'))).toBe(false)
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_import_batches'))).toBe(false)
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_import_items'))).toBe(false)
     expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_rules'))).toBe(false)
+    expect(db.transaction).not.toHaveBeenCalled()
+  })
+
+  it('replays scoped import commit idempotency only after target scope and creator checks', async () => {
+    const { db, routes } = await createHarness('false')
+    let batchLookups = 0
+
+    db.query.mockImplementation(async (query: unknown, paramsArg: unknown[] = []) => {
+      const sql = typeof query === 'string' ? query : String((query as { text?: unknown })?.text ?? query)
+      const params = typeof query === 'string'
+        ? paramsArg
+        : ((query as { values?: unknown[] })?.values ?? paramsArg)
+      const rbac = rbacQueryResult(sql, params)
+      if (rbac !== undefined) return rbac
+      const actor = actorContextQueryResult(sql)
+      if (actor !== undefined) return actor
+      if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeImportRow()]
+      if (sql.includes('SELECT DISTINCT group_id') && sql.includes('FROM attendance_group_members')) return []
+      if (sql.includes('SELECT DISTINCT m.schedule_group_id')) {
+        return [{ schedule_group_id: scheduleGroupId, department_ref: 'factory-1' }]
+      }
+      if (sql.includes('information_schema.columns') && sql.includes('attendance_import_batches')) return [{ ok: 1 }]
+      if (sql.includes('FROM attendance_import_batches')) {
+        batchLookups += 1
+        expect(sql).toContain('created_by = $4')
+        expect(params).toEqual(['default', 'repeat-scope', 'committed', 'scheduler-1'])
+        return [{ id: 'batch-scope-1', meta: { idempotencyKey: 'repeat-scope' } }]
+      }
+      if (sql.includes('FROM attendance_import_items')) {
+        expect(params).toEqual(['batch-scope-1', 'default'])
+        return [{ imported: 3, skipped: 1 }]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/import/commit', {
+      body: {
+        idempotencyKey: 'repeat-scope',
+        rows: [
+          {
+            userId: 'worker-1',
+            workDate: '2026-06-10',
+            fields: {
+              firstInAt: '2026-06-10T09:00:00.000Z',
+              lastOutAt: '2026-06-10T18:00:00.000Z',
+            },
+          },
+        ],
+      },
+      user: { id: 'scheduler-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: {
+        batchId: 'batch-scope-1',
+        imported: 3,
+        processedRows: 3,
+        failedRows: 1,
+        idempotent: true,
+      },
+    })
+    expect(batchLookups).toBe(1)
+    expect(db.query).toHaveBeenCalledWith(
+      expect.stringContaining('SELECT DISTINCT m.schedule_group_id'),
+      ['default', 'worker-1', '2026-06-10', '2026-06-10'],
+    )
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('DELETE FROM attendance_import_tokens'))).toBe(false)
+    expect(db.transaction).not.toHaveBeenCalled()
+  })
+
+  it('keeps full import admins on idempotent commit replay without row scope hydration', async () => {
+    const { db, routes } = await createHarness('false')
+
+    db.query.mockImplementation(async (query: unknown, paramsArg: unknown[] = []) => {
+      const sql = typeof query === 'string' ? query : String((query as { text?: unknown })?.text ?? query)
+      const params = typeof query === 'string'
+        ? paramsArg
+        : ((query as { values?: unknown[] })?.values ?? paramsArg)
+      const rbac = rbacQueryResult(sql, params, true)
+      if (rbac !== undefined) return rbac
+      if (sql.includes('information_schema.columns') && sql.includes('attendance_import_batches')) return [{ ok: 1 }]
+      if (sql.includes('FROM attendance_import_batches')) {
+        expect(sql).not.toContain('created_by = $4')
+        expect(params).toEqual(['default', 'repeat-admin', 'committed'])
+        return [{ id: 'batch-admin-1', meta: { idempotencyKey: 'repeat-admin' } }]
+      }
+      if (sql.includes('FROM attendance_import_items')) {
+        expect(params).toEqual(['batch-admin-1', 'default'])
+        return [{ imported: 5, skipped: 2 }]
+      }
+      throw new Error(`unexpected query: ${sql}`)
+    })
+
+    const res = await invokeRoute(routes, 'POST /api/attendance/import/commit', {
+      body: { idempotencyKey: 'repeat-admin' },
+      user: { id: 'admin-1', orgId: 'default' },
+    })
+
+    expect(res.statusCode).toBe(200)
+    expect(res.body).toMatchObject({
+      ok: true,
+      data: {
+        batchId: 'batch-admin-1',
+        imported: 5,
+        processedRows: 5,
+        failedRows: 2,
+        idempotent: true,
+      },
+    })
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('FROM attendance_scheduler_scopes'))).toBe(false)
+    expect(db.query.mock.calls.map(([sql]) => String(sql)).some(sql => sql.includes('SELECT DISTINCT m.schedule_group_id'))).toBe(false)
     expect(db.transaction).not.toHaveBeenCalled()
   })
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8299,21 +8299,28 @@ function mapImportBatchRow(row) {
 	  return snapshot
 	}
 
-	async function loadIdempotentImportBatch(client, orgId, idempotencyKey) {
+	async function loadIdempotentImportBatch(client, orgId, idempotencyKey, options = {}) {
 	  const hasColumn = await hasImportBatchIdempotencyColumn(client)
+	  const createdBy = typeof options?.createdBy === 'string' ? options.createdBy.trim() : ''
+	  const createdByClause = createdBy ? 'AND created_by = $4' : ''
+	  const params = createdBy
+	    ? [orgId, idempotencyKey, 'committed', createdBy]
+	    : [orgId, idempotencyKey, 'committed']
 	  const rows = await client.query(
 	    hasColumn
 	      ? `SELECT id, meta
 	         FROM attendance_import_batches
 	         WHERE org_id = $1 AND idempotency_key = $2 AND status = $3
+	         ${createdByClause}
 	         ORDER BY created_at DESC
 	         LIMIT 1`
 	      : `SELECT id, meta
 	         FROM attendance_import_batches
 	         WHERE org_id = $1 AND (meta->>'idempotencyKey') = $2 AND status = $3
+	         ${createdByClause}
 	         ORDER BY created_at DESC
 	         LIMIT 1`,
-	    [orgId, idempotencyKey, 'committed']
+	    params
 	  )
 	  if (!rows.length) return null
 	  const batch = rows[0]
@@ -23032,7 +23039,7 @@ module.exports = {
 		        const idempotencyKey = typeof parsed.data.idempotencyKey === 'string'
 		          ? parsed.data.idempotencyKey.trim()
 		          : ''
-	        if (idempotencyKey) {
+	        if (importAccess.fullImport && idempotencyKey) {
 	          const existing = await loadIdempotentImportBatch(db, orgId, idempotencyKey)
 	          if (existing) {
 	            const existingRowCount = existing.imported + existing.skipped
@@ -23144,8 +23151,38 @@ module.exports = {
             payload: parsed.data,
             fallbackUserId: parsed.data.userId ?? requesterId,
             actorAccess: importAccess,
-          })
-          if (!scopedAccess) return
+	          })
+	          if (!scopedAccess) return
+	        if (!importAccess.fullImport && idempotencyKey) {
+	          const existing = await loadIdempotentImportBatch(db, orgId, idempotencyKey, { createdBy: requesterId })
+	          if (existing) {
+	            const existingRowCount = existing.imported + existing.skipped
+	            const existingEngine = resolveImportEngineFromMeta(existing.meta, existingRowCount)
+	            res.json({
+	              ok: true,
+	              data: {
+	                batchId: existing.batchId,
+	                imported: existing.imported,
+	                processedRows: existing.imported,
+	                failedRows: existing.skipped,
+	                elapsedMs: 0,
+	                engine: existingEngine,
+	                recordUpsertStrategy: resolveImportRecordUpsertStrategyFromMeta(
+	                  existing.meta,
+	                  existingRowCount,
+	                  existingEngine
+	                ),
+	                items: [],
+	                skipped: [],
+	                csvWarnings: [],
+	                groupWarnings: [],
+	                meta: existing.meta,
+	                idempotent: true,
+	              },
+	            })
+	            return
+	          }
+	        }
 	        if (commitToken) {
 	          let tokenOk = false
             try {
@@ -23228,9 +23265,14 @@ module.exports = {
 
           await db.transaction(async (trx) => {
 	            await applyImportHeavyTransactionTimeout(trx)
-            if (idempotencyKey) {
-              await acquireImportIdempotencyLock(trx, orgId, idempotencyKey)
-              const existing = await loadIdempotentImportBatch(trx, orgId, idempotencyKey)
+	            if (idempotencyKey) {
+	              await acquireImportIdempotencyLock(trx, orgId, idempotencyKey)
+	              const existing = await loadIdempotentImportBatch(
+	                trx,
+	                orgId,
+	                idempotencyKey,
+	                importAccess.fullImport ? undefined : { createdBy: requesterId }
+	              )
               if (existing) {
                 idempotentInTransaction = existing
                 return
@@ -23997,7 +24039,12 @@ module.exports = {
           if ((isIdempotencyUnique || isConcurrentUploadCleanupRace) && await hasImportBatchIdempotencyColumn(db)) {
             try {
               for (let attempt = 0; attempt < 4; attempt += 1) {
-                const existing = await loadIdempotentImportBatch(db, orgId, idempotencyKey)
+	                const existing = await loadIdempotentImportBatch(
+	                  db,
+	                  orgId,
+	                  idempotencyKey,
+	                  importAccess.fullImport ? undefined : { createdBy: requesterId }
+	                )
                 if (existing) {
                   const existingRowCount = existing.imported + existing.skipped
                   const existingEngine = resolveImportEngineFromMeta(existing.meta, existingRowCount)


### PR DESCRIPTION
## Summary
- keep full import/admin commit idempotency replay on the existing fast path
- delay scheduler-scoped sync commit replay until row target scope passes
- require scheduler-scoped replay lookups to match the current actor via `created_by`

## Scope
- Sync `POST /api/attendance/import/commit` only.
- Async import jobs, batches, rollback, template, upload, and integrations stay out of this slice.

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts tests/unit/attendance-import-permission.test.ts tests/unit/attendance-advanced-scheduling-scope.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend test:unit -- --watch=false`