### PR TITLE
docs(data-sources): reconcile track docs — A6 ✅ + UI-track closeout/TODO

### DIFF
--- a/docs/development/data-sources-mssql-windows-deploy-design-20260527.md
+++ b/docs/development/data-sources-mssql-windows-deploy-design-20260527.md
@@ -132,7 +132,7 @@
 - ✅ A3 query/testConnection 错误不吞,保留错因(#2034):`testConnection` 返回 `{success,error?}`;错因经 `redactSecrets` 脱敏(`password`/`token` 不入 response/log);manager 仅转发 redacted `connectionError`;真 wire 集成测试覆盖
 - ✅ A4 enum↔registry↔驱动三方对齐(#1976 `f5013324e`):`SUPPORTED_DATA_SOURCE_TYPES` 单一支持矩阵 + 非法 type 400 + load 跳过不支持行
 - ✅ A5 结果边界策略(本刀,取「明确上限保护」而非真 cursor):共享 `DATA_SOURCE_DEFAULT_LIMIT=1000` / `DATA_SOURCE_MAX_ROWS=10000`;**适配器层 `select()` 硬防线**(omit→MAX cap、>MAX→抛、非法→抛,经 `resolveEffectiveLimit`),挡住绕过路由的直连内部调用(`DataSourceManager` 复制循环已显式分页,不受影响);路由 `/select` 入口补默认 limit、超限 400(zod);raw `/query` 无法安全自动限界 → 标为非大表导出通道 + 无 `LIMIT/TOP/OFFSET/FETCH` 时 best-effort warning + audit;`stream()`(raw SQL、未经路由暴露、内部唯一)仍为非流式,真 cursor 留作后续 thorough。测试 `data-source-result-boundary.test.ts`(13 例:常量 + resolveEffectiveLimit + PG/MSSQL select 真 wire + 路由默认/400/warning)
-- ⬜ A6 Postgres connect/query/transaction/错误路径单测
+- ✅ A6 Postgres 适配器单测(#2139 `0e35ae94e`,并行会话):connect/query/transaction/错误路径覆盖 —— `packages/core-backend/tests/unit/postgres-adapter.test.ts`
 
 ### Phase B — MSSQL 连接器(Lane B 已 opt-in 2026-05-28;contracts-first)
 - ⬜ B0 抽共享 mssql helper(连接/TLS/类型映射)—— PR1 暂内联在 `MSSQLAdapter`,helper 抽取留作收口项(不碰 integration-core)

--- a/docs/development/data-sources-ui-track-closeout-20260531.md
+++ b/docs/development/data-sources-ui-track-closeout-20260531.md
@@ -1,0 +1,66 @@
+# 外接数据源连接器 — 前端 UI 轨收口 + 门控 TODO(2026-05-31)
+
+> 状态:**收口**。后端 + 部署轨的设计/门控见 `data-sources-mssql-windows-deploy-design-20260527.md`(§4 门控 TODO);本稿补齐**前端 UI 轨**——该轨此前按会话内规划逐切片落地,从未写入任何 committed 计划文档,导致"代码已完成、计划文档缺失"。本稿让 docs 与现实对齐,并把剩余前端切片显式列为 ⬜。
+>
+> 门控记号:🔒 待开闸 / ⬜ 待办未阻塞 / ✅ 完成。
+>
+> 轨纪律(贯穿全轨):**只读优先**(源数据零修改)、**凭据 write-only 过线**(后端从不回吐凭据,`sanitizeConfig` 剥离后只回 `hasCredentials`)、**不碰** integration-core / K3 `k3-wise-sqlserver` 通道 / central RBAC·auth。
+
+---
+
+## 1. 这是什么 / 边界
+
+外接连接器在本轨之前是 **API-only**(后端 `routes/data-sources.ts` + `DataSourceManager` + 各 `*Adapter`)。本轨把它做成**可用的管理界面**:管理员能在 `apps/web` 里增/删/改/测一个外部数据源(Postgres / SQL Server / HTTP)。
+
+- 落点:`apps/web/src/data-sources/`(`types.ts` / `api.ts` / `buildPayload.ts`)+ `apps/web/src/stores/dataSources.ts`(Pinia)+ `apps/web/src/views/DataSourcesView.vue` + `apps/web/tests/data-sources-ui.spec.ts`。
+- **本轨 = 内核打磨/安全修复**(管理界面 + 编辑路径安全),lock-safe;不属于 🔒 的阶段二(数据流入 multitable,见 §4)。
+
+---
+
+## 2. 已交付(✅)
+
+- ✅ **UI-1 列表/新建/删除**(#2147 `1054444a8`):`DataSourcesView.vue` 列表 + 新建表单 + 删除;`useDataSourcesStore`(items/loading/error)+ `listDataSources`/`createDataSource`/`deleteDataSource`;list 经 `data.items` 解包;凭据仅出站(create 携带,response 不回吐)。
+- ✅ **UI-2 连接测试**(#2151 `d76b220c7`):每行 `GET /api/data-sources/:id/test` 触发;store `testing`/`testResults`;**请求层保持 `ok:true`**,连通失败体现在 `data.success===false`(不把传输层降级为 4xx)。
+- ✅ **UI-3 非密编辑**(#2154 `a2390ad34`):编辑既有源的非密字段(name/connection 可见项/options);编辑态密钥提示 `ds-edit-secret-note`;凭据不在编辑表单回显。
+- ✅ **凭据轮换路径**(#2160 `82d6317b2`):`PUT /api/data-sources/:id/credentials` 专用通道——轮换凭据与改非密字段解耦,避免"留空即清空"误删。
+- ✅ **P1 编辑不丢隐藏安全键**(#2155 `6698c9b9a`,后端):`PUT` 对 `connection`/`options`/`poolConfig` **深合并**而非整体替换——编辑可见项不再静默丢掉 `encrypt`/`trustServerCertificate`/`tlsMinVersion` 等隐藏 TLS 键;回归测试 `data-source-readonly.test.ts` 锁定。
+- ✅ **P2 + P2-followup `connection.server` 支持**(#2161 `e61b463ed`,前端):SQL Server 的 `server`-only 源可编辑;**且 server 语义限定 `type==='sqlserver'`**——builder 仅在 sqlserver 发 `connection.server`、提交守卫 Postgres 仍强制 `host`/SQL Server 接受 `host||server`、`watch(form.type)` 切换离开 sqlserver 即清空 `form.server`;`data-sources-ui.spec.ts` 21 例(含 "Postgres 不发 server")。
+
+**当前 UI 能力面**:连 / 测 / 改(含凭据轮换)/ 删。后端已暴露但 UI 尚未 surface 的只读端点见 §3。
+
+---
+
+## 3. 剩余前端切片(⬜ —— surface-only,后端端点已就位)
+
+这两片是**纯前端、surface 既有后端**(已验证后端路由在 main 上存在),各约等于 UI-2 体量,lock-safe:
+
+- ⬜ **UI-schema 库表/字段浏览**:surface `GET /api/data-sources/:id/schema` + `GET /api/data-sources/:id/tables/:table`——让管理员看到源里有哪些表/字段。
+- ⬜ **UI-preview 数据行预览**:surface `POST /api/data-sources/:id/select`(已被 A5 上限保护:`DEFAULT_LIMIT=1000`/`MAX_ROWS=10000`,超限 400)——只读预览若干行。
+
+> **协作注意**:data-sources UI 一直由**并行会话**推进(UI-1/2/3 均其所出)。开这两片前需先与该会话对齐归属,避免重复/冲突(本轨曾发生 worktree 串线)。
+>
+> 完成这两片后,连接器作为**独立管理工具**即功能完整(连/测/改/删/浏览/预览)。
+
+---
+
+## 4. 真正的产品价值(🔒 gated,大头,未放行)
+
+- 🔒 **读路径接入 multitable(import 流)**:已验证 `DataSourceManager` 当前仅被自身模块 + `routes/data-sources` + 内核 host(`index.ts`)引用,**从未被 multitable/import 调用**。即:用户能连接并浏览外部库,但**还不能把一张表 import 进 multitable**。这条接线 = 阶段二 / Data Factory 的实际落点,**gated + 设计暂停(待 K3 PoC 证据)**,非本轨范围,不在未开闸前启动。
+
+---
+
+## 5. 后端/部署轨收尾(交叉引用,不在本前端稿展开)
+
+详见 `data-sources-mssql-windows-deploy-design-20260527.md` §4。截至本稿:
+
+- ✅ A6 Postgres 适配器单测(#2139)——本次同稿把设计文档 §4 的过期 ⬜ 标记纠正为 ✅。
+- ⬜ B0 抽共享 mssql helper(重构收口,解锁不了功能)。
+- ⬜ B4 legacy 2008R2/2012 真机验证(需 Windows VM = 硬件门,非代码)。
+- 🔒 B6 Windows 集成认证(`authType:'windows'`,独立设计)。
+- 真 cursor stream:A5 只做了上限封顶,非真流式,留作后续 thorough。
+
+---
+
+## 6. 一句话结论
+
+**独立工具距完成 ≈ 2 个前端小切片**(UI-schema + UI-preview,后端已就位);**真正的产品价值**(import 接入 multitable)是大头且**未放行**(阶段二 gated)。


### PR DESCRIPTION
Docs-only, lock-safe. Makes the data-sources track docs match what's merged on main.

## Changes
1. **Design doc §4** — A6 (Postgres adapter unit tests) `⬜ → ✅`. It shipped via **#2139** (`0e35ae94e`, parallel session; `tests/unit/postgres-adapter.test.ts`) but the marker was stale.
2. **New `data-sources-ui-track-closeout-20260531.md`** — the frontend UI track was built per in-chat plan and was never written into any committed doc. It now records:
   - **✅ shipped**: UI-1 list/create/delete (#2147) · UI-2 test (#2151) · UI-3 edit (#2154) · credential rotation (#2160) · P1 backend connection deep-merge (#2155) · P2 `server` scoped-to-sqlserver (#2161)
   - **⬜ remaining (surface-only, backend live)**: UI-schema (browse `/:id/schema`+`/tables/:table`), UI-preview (read `/:id/select`, A5-capped)
   - **🔒 gated**: read→multitable import wiring (阶段二, design-paused pending K3 evidence)

## Verification
- Docs-only: `git diff` touches **2 `.md` files, 0 code** (verified).
- Every cited PR#/SHA/test-file/endpoint checked against `origin/main`.
- A6 evidence: `packages/core-backend/tests/unit/postgres-adapter.test.ts` exists on main.
- Read→multitable absence: `DataSourceManager` referenced only by its module + `routes/data-sources` + `index.ts`.

No code touched; no impact on Build/runtime/142.

🤖 Generated with [Claude Code](https://claude.com/claude-code)