### PR TITLE
fix(multitable): mask write-path echo by field_permissions (F3)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -179,6 +179,7 @@ jobs:
             tests/integration/multitable-record-history-field-mask.test.ts \
             tests/integration/multitable-records-summary-field-mask.test.ts \
             tests/integration/multitable-dashboard-chart-authz.test.ts \
+            tests/integration/multitable-write-echo-field-mask.test.ts \
             tests/integration/multitable-automation-retry.test.ts \
             tests/integration/multitable-automation-jobs.test.ts \
             --reporter=dot

--- a/docs/development/multitable-write-echo-field-mask-verification-20260531.md
+++ b/docs/development/multitable-write-echo-field-mask-verification-20260531.md
@@ -1,0 +1,49 @@
+# F3 — write-path echo field mask · verification
+
+**Date:** 2026-05-31
+**Design-lock:** `docs/development/multitable-record-egress-fieldperm-inventory-20260529.md` (#2106) §3 F3.
+**Scope:** the **same-sheet** write-echo of `PATCH /records/:recordId` + `POST /patch`. No central RBAC/auth (K3 Stage-1 lock).
+
+## The hole
+
+After a write, both endpoints echo the record back masked by `visiblePropertyFieldIds` = **layer-2 only** (`property.hidden`). A `field_permissions.visible=false` (layer-3 read-denied) value was echoed anyway. The write gate is **layer-2 only too** (`canEditRecord` + `fieldById`'s `isFieldPermissionHidden`/`isFieldAlwaysReadOnly` — it never consults `field_permissions`), so a field can be **writable yet read-denied** ("write-only-no-read"): a user can PATCH `FLD_SECRET`, the write persists, and the echo handed the value right back.
+
+## The fix — narrow the echo set, leave the write set
+
+Both routes now compute the **layer-2 ∧ layer-3** composite (the #2028 read-mask pattern) and pass it as the echo read-back set:
+- **PATCH** (`univer-meta.ts`): `readableEchoFields`/`readableEchoFieldIds` feed the record-data mask + attachment-summary mask + attachment-field selection (the write already happened upstream via `RecordService`).
+- **POST /patch**: the route passes `readableEchoFields`/`Ids` into `RecordWriteService` (used there **only** for the echo — masks at `record-write-service.ts:828/854/882/914/929; computed-extract @834`). **`fieldById` stays built from ALL fields**, so write-only-no-read fields remain writable; only the echo omits them. (`RecordPatchInput.visiblePropertyFields/Ids` now carries a doc comment that it is the echo/read-back set, not the writable set.)
+
+Mechanism choice = narrow-the-echo (no service signature change); `crossSheetRelated`/computed-echo ordering verified safe (see below).
+
+## Fail-first (real DB)
+
+`tests/integration/multitable-write-echo-field-mask.test.ts` (wired into the `plugin-tests.yml` real-DB step). Seed: `FLD_SECRET`/`FLD_FORMULA.property` carry no `hidden` → deny is **solely** layer-3.
+
+| # | Scenario | Pre-fix | Post-fix |
+|---|---|---|---|
+| R1 | PATCH a readable field → full-record echo | `FLD_SECRET` value present | omitted (+ `FLD_VISIBLE` positive control) |
+| **R2** | **PATCH `FLD_SECRET` itself (write-only-no-read)** | echoes the just-written value | **echo omits it; DB still persists it** |
+| R3 | POST /patch → computed (FORMULA) echo | denied formula value present | omitted (USER_ID_2 positive-control first) |
+| R5 | PATCH as an ungranted-to-deny user | — | denied field **present** (mask is per-subject) |
+
+- **RED proven**: R1/R2/R3 failed on unmodified origin/main (`expected '<canary>' to be undefined`; R3 `expected 31 to be undefined`) → **5/5 GREEN** post-fix.
+- **R2 is the F3-specific proof** — it closes what F0a's *read* mask did not: a field the caller **wrote** but cannot read. The DB-readback assertion confirms the write persisted (the mask is echo-only, not a write block).
+- **R3 non-vacuous**: POST /patch echoes only computed/dependent data (`mergedRecords`), so a plain field would make the assertion vacuous. A **formula** field is the minimal computed seed (echoed @882); the USER_ID_2 positive control proves the channel carries the value before asserting the denied user's omission. (Direct-SQL field inserts skip the create-field path that records `formula_dependencies`, so the test seeds that row — `recalculateFormulaFields` gates on it.)
+
+## Out of F3 scope — TWO NEW findings (not in the #2106 inventory; surfaced for re-ranking)
+
+While mapping the POST /patch echo I found two leaks **beyond** the layer-2-only same-sheet echo F3 targets. Neither is fixed here; both are different mechanisms:
+
+- **`crossSheetRelated` returned UNMASKED (`record-write-service.ts:985`).** Cross-sheet related records (recomputed lookup/rollup of dependents in *other* sheets) are returned in `result.relatedRecords` with **no field filter at all** — not even layer-2. Masking needs each *related* sheet's per-subject `allowedFieldIds` (a different resolution than F3's single edited-sheet set). **Severity: this is *unmasked*, so it arguably outranks F4/F5** — worth re-ranking ahead of them. (Verified independent of `visiblePropertyField*` — F3's narrowing leaves it byte-identical, no regression, no half-fix.)
+- **Realtime broadcast carries unmasked values (`record-write-service.ts:~949-961`).** `publishMultitableSheetRealtime` emits `recordPatches` (`patch` = changed + materialized formula values) + `fieldIds` to **all** sheet subscribers — a per-recipient surface where the writer's perms aren't the right gate. Separate fix (per-recipient or don't-broadcast-values).
+
+## Regression / type
+
+- `tsc --noEmit` exit 0.
+- `multitable-record-patch.api.test.ts` (mocked SQL) needed a one-line `field_permissions` stub (F3 adds that query to the echo path; the mock returns no denials) → **31/31** with the read-mask + partial-success + view-aggregate siblings.
+- The `view-config` / `record-form` / `sheet-realtime` mocked tests fail **identically on pristine origin/main** (Unhandled SQL: `pg_advisory_xact_lock`, `/views meta_fields`, record-context — none `field_permissions`) → **pre-existing local-env mock gaps, not an F3 regression** (green in CI).
+
+## Diff scope
+
+`univer-meta.ts` (PATCH echo + POST /patch), `record-write-service.ts` (input-type doc comment), the new test, a one-line mock stub, the CI wiring, this doc. Write gating unchanged.

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -209,6 +209,10 @@ export interface RecordPatchInput {
   changesByRecord: Map<string, RecordChange[]>
   actorId: string | null
   fields: UniverMetaField[]
+  /**
+   * Echo / read-back field set ONLY (NOT the writable set). Callers pass the layer-2 ∧ layer-3 readable
+   * fields (F3, #2106 §3 F3) so a field_permissions-denied value is never echoed. Write gating is `fieldById`.
+   */
   visiblePropertyFields: UniverMetaField[]
   visiblePropertyFieldIds: Set<string>
   attachmentFields: UniverMetaField[]

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -7371,17 +7371,24 @@ export function univerMetaRouter(): Router {
         data: normalizeJson(row.data),
       }
       const visiblePropertyFields = filterVisiblePropertyFields(fields)
-      const visiblePropertyFieldIds = new Set(visiblePropertyFields.map((field) => field.id))
+      // F3 (#2106 §3 F3): the write already happened above; this set gates ONLY the read-back echo, so it must
+      // honor layer-3 field_permissions, not just layer-2 (property.hidden). Same composite as the #2028 read
+      // mask. The write gate (canEditRecord + RecordService) is unchanged — a write-only-no-read field is still
+      // writable, just omitted from the echo.
+      const echoFieldScopeMap = access.userId ? await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, access.userId) : new Map()
+      const echoFieldPermissions = deriveFieldPermissions(visiblePropertyFields, capabilities, { hiddenFieldIds: [], fieldScopeMap: echoFieldScopeMap })
+      const readableEchoFields = visiblePropertyFields.filter((field) => echoFieldPermissions[field.id]?.visible !== false)
+      const readableEchoFieldIds = new Set(readableEchoFields.map((field) => field.id))
 
       const relationalLinkFields = fields
         .map((field) => (field.type === 'link' ? { fieldId: field.id, cfg: parseLinkFieldConfig(field.property) } : null))
         .filter((value): value is RelationalLinkField => !!value && !!value.cfg)
-      const attachmentFields = visiblePropertyFields.filter((field) => field.type === 'attachment')
+      const attachmentFields = readableEchoFields.filter((field) => field.type === 'attachment')
       const linkValuesByRecord = await loadLinkValuesByRecord(pool.query.bind(pool), [record.id], relationalLinkFields)
       for (const { fieldId } of relationalLinkFields) {
         record.data[fieldId] = linkValuesByRecord.get(record.id)?.get(fieldId) ?? []
       }
-      record.data = filterRecordDataByFieldIds(record.data, visiblePropertyFieldIds)
+      record.data = filterRecordDataByFieldIds(record.data, readableEchoFieldIds)
       const attachmentSummaries = attachmentFields.length > 0
         ? filterSingleRecordFieldSummaryMap(
             serializeAttachmentSummaryMap(
@@ -7393,7 +7400,7 @@ export function univerMetaRouter(): Router {
                 attachmentFields,
               ),
             )[record.id] ?? {},
-            visiblePropertyFieldIds,
+            readableEchoFieldIds,
           )
         : undefined
 
@@ -8319,8 +8326,16 @@ export function univerMetaRouter(): Router {
 
       const fields = (fieldRes.rows as any[]).map(serializeFieldRow)
       const visiblePropertyFields = filterVisiblePropertyFields(fields)
-      const visiblePropertyFieldIds = new Set(visiblePropertyFields.map((field) => field.id))
-      const attachmentFields = visiblePropertyFields.filter((field) => field.type === 'attachment')
+      // F3 (#2106 §3 F3): RecordWriteService uses these ONLY for the read-back echo (it masks record / related /
+      // formula data + summaries at record-write-service.ts:828/854/882/914/929), so narrow them to the
+      // layer-2 ∧ layer-3 readable set — a field_permissions-denied value must not be echoed. fieldById (the
+      // write gate, below) stays from ALL fields, so a write-only-no-read field remains writable. (crossSheetRelated
+      // @record-write-service.ts:985 is returned UNMASKED — a separate finding, see the verification doc.)
+      const echoFieldScopeMap = access.userId ? await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, access.userId) : new Map()
+      const echoFieldPermissions = deriveFieldPermissions(visiblePropertyFields, capabilities, { hiddenFieldIds: [], fieldScopeMap: echoFieldScopeMap })
+      const readableEchoFields = visiblePropertyFields.filter((field) => echoFieldPermissions[field.id]?.visible !== false)
+      const readableEchoFieldIds = new Set(readableEchoFields.map((field) => field.id))
+      const attachmentFields = readableEchoFields.filter((field) => field.type === 'attachment')
       const fieldById = buildFieldMutationGuardMap(fields)
 
       const changesByRecord = new Map<string, typeof parsed.data.changes>()
@@ -8372,8 +8387,8 @@ export function univerMetaRouter(): Router {
               changesByRecord: new Map([[recordId, recordChanges]]) as Map<string, Array<{ fieldId: string; value: unknown; expectedVersion?: number }>>,
               actorId: getRequestActorId(req),
               fields,
-              visiblePropertyFields,
-              visiblePropertyFieldIds,
+              visiblePropertyFields: readableEchoFields,
+              visiblePropertyFieldIds: readableEchoFieldIds,
               attachmentFields,
               fieldById,
               capabilities,
@@ -8414,8 +8429,8 @@ export function univerMetaRouter(): Router {
         changesByRecord: changesByRecord as Map<string, Array<{ fieldId: string; value: unknown; expectedVersion?: number }>>,
         actorId: getRequestActorId(req),
         fields,
-        visiblePropertyFields,
-        visiblePropertyFieldIds,
+        visiblePropertyFields: readableEchoFields,
+        visiblePropertyFieldIds: readableEchoFieldIds,
         attachmentFields,
         fieldById,
         capabilities,

--- a/packages/core-backend/tests/integration/multitable-record-patch.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-record-patch.api.test.ts
@@ -95,6 +95,7 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
       yjsInvalidator: yjsInvalidatorSpy,
       queryHandler: async (sql, params) => {
         if (sql.includes('FROM spreadsheet_permissions')) return { rows: [] }
+        if (sql.includes('field_permissions')) return { rows: [] } // F3: echo read-back resolves field perms (no denials in this mock)
         if (sql.includes('SELECT id, sheet_id FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
           expect(params).toEqual(['rec_1', 'sheet_ops'])
           return { rows: [{ id: 'rec_1', sheet_id: 'sheet_ops' }] }
@@ -187,6 +188,7 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
       tokenPerms: ['multitable:write'],
       queryHandler: async (sql, _params) => {
         if (sql.includes('FROM spreadsheet_permissions')) return { rows: [] }
+        if (sql.includes('field_permissions')) return { rows: [] } // F3: echo read-back resolves field perms (no denials in this mock)
         if (sql.includes('SELECT id, sheet_id FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
           return { rows: [{ id: 'rec_1', sheet_id: 'sheet_ops' }] }
         }
@@ -224,6 +226,7 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
       tokenPerms: ['multitable:write'],
       queryHandler: async (sql, _params) => {
         if (sql.includes('FROM spreadsheet_permissions')) return { rows: [] }
+        if (sql.includes('field_permissions')) return { rows: [] } // F3: echo read-back resolves field perms (no denials in this mock)
         if (sql.includes('SELECT id, sheet_id FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
           return { rows: [{ id: 'rec_1', sheet_id: 'sheet_ops' }] }
         }
@@ -259,6 +262,7 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
       tokenPerms: ['multitable:write'],
       queryHandler: async (sql, _params) => {
         if (sql.includes('FROM spreadsheet_permissions')) return { rows: [] }
+        if (sql.includes('field_permissions')) return { rows: [] } // F3: echo read-back resolves field perms (no denials in this mock)
         if (sql.includes('SELECT id, sheet_id FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
           return { rows: [{ id: 'rec_1', sheet_id: 'sheet_ops' }] }
         }
@@ -297,6 +301,7 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
       queryHandler: async (sql, params) => {
         captured.push({ sql, ...(params !== undefined ? { params } : {}) })
         if (sql.includes('FROM spreadsheet_permissions')) return { rows: [] }
+        if (sql.includes('field_permissions')) return { rows: [] } // F3: echo read-back resolves field perms (no denials in this mock)
         if (sql.includes('SELECT id, sheet_id FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
           return { rows: [{ id: 'rec_1', sheet_id: 'sheet_ops' }] }
         }
@@ -416,6 +421,7 @@ describe('Multitable PATCH /records/:recordId (record-service extraction)', () =
       yjsInvalidator: yjsInvalidatorSpy,
       queryHandler: async (sql, _params) => {
         if (sql.includes('FROM spreadsheet_permissions')) return { rows: [] }
+        if (sql.includes('field_permissions')) return { rows: [] } // F3: echo read-back resolves field perms (no denials in this mock)
         if (sql.includes('SELECT id, sheet_id FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
           return { rows: [{ id: 'rec_1', sheet_id: 'sheet_ops' }] }
         }

--- a/packages/core-backend/tests/integration/multitable-write-echo-field-mask.test.ts
+++ b/packages/core-backend/tests/integration/multitable-write-echo-field-mask.test.ts
@@ -1,0 +1,131 @@
+/**
+ * Real-DB integration test for F3 — write-path echo field mask.
+ * Design-lock: docs/development/multitable-record-egress-fieldperm-inventory-20260529.md (#2106) §3 F3.
+ *
+ * PATCH /records/:recordId and POST /patch echo the written record back masked by the SAME-SHEET set
+ * `visiblePropertyFieldIds` = LAYER-2 only (property.hidden). F3 upgrades the same-sheet echo to the
+ * layer-2 ∧ layer-3 composite (the #2028 read-path pattern) so a `field_permissions.visible=false` value
+ * is never echoed. The WRITE gate is untouched: writability is `canEditRecord` + `fieldById` (layer-2
+ * hidden / readOnly / type), which never consults field_permissions — so a field can be WRITABLE yet
+ * READ-denied (write-only-no-read). R2/R4 prove that exact case: PATCH FLD_SECRET itself succeeds and
+ * PERSISTS, but the echo must still omit it. That is what F3 closes that F0a's read mask did not.
+ *
+ * Out of F3 scope (flagged separately in the verification doc): crossSheetRelated (returned UNMASKED at
+ * record-write-service.ts:985 — a different mechanism needing per-related-sheet perms) and the realtime
+ * broadcast (record-write-service.ts:~949 — a per-subscriber surface).
+ *
+ * POST /patch echoes ONLY computed/dependent data (`mergedRecords`), never a plain field — so a 2-field
+ * sheet would make the POST /patch assertion VACUOUS (empty `records`, passes pre+post). R3 therefore uses
+ * a FORMULA field (echoed at :882) with a USER_ID_2 positive-control FIRST, so the denied-omission is real.
+ *
+ * Seed non-negotiable: FLD_SECRET/FLD_FORMULA.property carry no `hidden` → deny is SOLELY layer-3.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_f3_${TS}`
+const SHEET_ID = `sheet_f3_${TS}`
+const FLD_VISIBLE = `fld_f3_visible_${TS}` // number, readable — formula source + positive control
+const FLD_SECRET = `fld_f3_secret_${TS}` // string, layer-3-denied — the full-record echo canary (PATCH)
+const FLD_FORMULA = `fld_f3_formula_${TS}` // formula ={FLD_VISIBLE}+1, layer-3-denied — the computed echo (POST /patch)
+const REC_ID = `rec_f3_${TS}`
+const USER_ID = `u_f3_${TS}` // FLD_SECRET + FLD_FORMULA denied
+const USER_ID_2 = `u_f3_other_${TS}` // no deny → positive control
+const VISIBLE_INITIAL = 5
+const SECRET_INITIAL = 'do-not-leak-f3-initial'
+
+let app: Express
+let currentUser: { id: string; roles: string[]; perms: string[] } = { id: USER_ID, roles: ['member'], perms: ['multitable:write'] }
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const patchReq = (recordId: string, body: Record<string, unknown>) =>
+  request(app).patch(`/api/multitable/records/${recordId}`).send(body)
+const batchPatch = (body: Record<string, unknown>) =>
+  request(app).post('/api/multitable/patch').send(body)
+const dbField = async (fieldId: string) => {
+  const r = await q('SELECT data FROM meta_records WHERE id = $1', [REC_ID])
+  const data = (r.rows[0]?.data ?? {}) as Record<string, unknown>
+  return data[fieldId]
+}
+const echoRec = (res: { body: { data?: { records?: Array<{ recordId: string; data: Record<string, unknown> }> } } }) =>
+  res.body.data?.records?.find((r) => r.recordId === REC_ID)
+
+describeIfDatabase('F3 write-echo field mask (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = currentUser; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'F3 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'F3 Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_VISIBLE, SHEET_ID, 'Visible', 'number', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRET, SHEET_ID, 'Secret', 'string', '{}', 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_FORMULA, SHEET_ID, 'Derived', 'formula', JSON.stringify({ expression: `={${FLD_VISIBLE}}+1` }), 3])
+    // Direct-SQL field insert bypasses the create-field path that normally records formula deps, so seed it
+    // explicitly — recalculateFormulaFields gates on formula_dependencies (no row → no recompute → vacuous echo).
+    await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,$4)', [SHEET_ID, FLD_FORMULA, FLD_VISIBLE, SHEET_ID])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_ID, SHEET_ID, JSON.stringify({ [FLD_VISIBLE]: VISIBLE_INITIAL, [FLD_SECRET]: SECRET_INITIAL })])
+    // layer-3 read deny (subject-scoped). property carries no hidden → deny is solely here.
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER_ID, false, false])
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_FORMULA, 'user', USER_ID, false, false])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('R1 (PATCH bystander): editing a readable field still echoes the full record masked — a denied field is omitted', async () => {
+    currentUser = { id: USER_ID, roles: ['member'], perms: ['multitable:write'] }
+    const res = await patchReq(REC_ID, { sheetId: SHEET_ID, data: { [FLD_VISIBLE]: 10 } })
+    expect(res.status).toBe(200)
+    expect(res.body.data.record.data[FLD_VISIBLE]).toBe(10) // write applied + echoed (positive control)
+    expect(res.body.data.record.data[FLD_SECRET]).toBeUndefined() // THE LEAK (RED pre-fix)
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_INITIAL)
+  })
+
+  test('R2 (PATCH write-only-no-read): PATCH a denied field itself → write PERSISTS but echo omits it', async () => {
+    currentUser = { id: USER_ID, roles: ['member'], perms: ['multitable:write'] }
+    const rewrite = `do-not-leak-f3-rewrite-${TS}`
+    const res = await patchReq(REC_ID, { sheetId: SHEET_ID, data: { [FLD_SECRET]: rewrite } })
+    expect(res.status).toBe(200) // writable: the write gate is layer-2, never field_permissions
+    expect(res.body.data.record.data[FLD_SECRET]).toBeUndefined() // echo omits the value just written (RED pre-fix)
+    expect(JSON.stringify(res.body)).not.toContain(rewrite)
+    expect(await dbField(FLD_SECRET)).toBe(rewrite) // ...but the write really happened — mask is echo-only
+  })
+
+  test('R3 (POST /patch computed echo): a denied FORMULA value is masked from the records echo — positive control first', async () => {
+    // POST /patch echoes only computed/dependent data (mergedRecords). Use the formula field so the
+    // assertion is non-vacuous. Positive control FIRST: the ungranted user DOES receive the formula value.
+    currentUser = { id: USER_ID_2, roles: ['member'], perms: ['multitable:write'] }
+    const granted = await batchPatch({ sheetId: SHEET_ID, changes: [{ recordId: REC_ID, fieldId: FLD_VISIBLE, value: 20 }] })
+    expect(granted.status).toBe(200)
+    expect(echoRec(granted)?.data?.[FLD_FORMULA]).toBeDefined() // proves the echo channel carries the formula value
+
+    currentUser = { id: USER_ID, roles: ['member'], perms: ['multitable:write'] }
+    const denied = await batchPatch({ sheetId: SHEET_ID, changes: [{ recordId: REC_ID, fieldId: FLD_VISIBLE, value: 30 }] })
+    expect(denied.status).toBe(200)
+    expect(echoRec(denied)?.data?.[FLD_FORMULA]).toBeUndefined() // THE LEAK (RED pre-fix, GREEN post-fix)
+  })
+
+  test('R5 (positive): an ungranted-to-deny user still gets the denied field in the PATCH echo (mask is per-subject)', async () => {
+    currentUser = { id: USER_ID_2, roles: ['member'], perms: ['multitable:write'] }
+    const res = await patchReq(REC_ID, { sheetId: SHEET_ID, data: { [FLD_VISIBLE]: 40 } })
+    expect(res.status).toBe(200)
+    expect(res.body.data.record.data[FLD_SECRET]).toBe(await dbField(FLD_SECRET)) // present, equals persisted value
+    currentUser = { id: USER_ID, roles: ['member'], perms: ['multitable:write'] }
+  })
+})


### PR DESCRIPTION
## Summary

Closes **F3** from the #2106 record-egress inventory: `PATCH /records/:recordId` and `POST /patch` echoed the written record back masked **layer-2 only** (`visiblePropertyFieldIds` = `property.hidden`), so a `field_permissions.visible=false` (layer-3 read-denied) value was handed back. F3 narrows the **same-sheet** echo to the layer-2 ∧ layer-3 composite (the #2028 read-mask pattern); the write gate (`canEditRecord` + `fieldById`, all fields) is untouched.

**The F3-specific risk (≠ F0a's read mask): write-only-no-read.** The write gate is layer-2 only, so a field can be *writable yet read-denied* — a user PATCHes `FLD_SECRET`, the write persists, and the echo handed the value back. **R2** proves it: echo omits it, DB still persists it.

## ⚠️ Two NEW findings surfaced (not in #2106) — re-ranking decision for you

Mapping the POST /patch echo turned up two leaks **beyond** F3's layer-2-only target, both different mechanisms (flagged, **not** fixed here):

- **`crossSheetRelated` is returned UNMASKED** (`record-write-service.ts:985`) — cross-sheet related records' recomputed values, **no field filter at all (not even layer-2)**. Masking needs each related sheet's per-subject perms. **Because it's *unmasked*, this arguably outranks F4/F5** — worth re-ranking ahead of them. (Verified independent of the echo set, so F3 leaves it byte-identical: no regression, no half-fix.)
- **Realtime broadcast** (`~:949-961`) emits unmasked `patch`/`fieldIds` to all subscribers — a per-recipient surface, separate fix.

## Fix

PATCH + POST /patch compute `readableEchoFields`/`Ids` (layer-2 ∧ layer-3) and use them for the echo (record data + computed/formula + link/attachment summaries); `fieldById` stays from ALL fields so write-only fields remain writable. `RecordWriteService` input documented as echo-only. No service signature change.

## Fail-first (real DB)

`multitable-write-echo-field-mask.test.ts`: R1 (PATCH full-record echo) / **R2 (write-only-no-read + DB-persist)** / R3 (POST /patch computed echo via a formula field, positive-control-first — the echo carries only computed/dependent data, so a plain field would be vacuous) RED on origin/main → **5/5 GREEN**. tsc exit 0; `record-patch.api` mock stub + read-mask/partial-success/view-aggregate **31/31**. The `view-config`/`record-form`/`sheet-realtime` mocked failures are **pre-existing** (proven identical on pristine origin/main; none `field_permissions`).

See `docs/development/multitable-write-echo-field-mask-verification-20260531.md`.

## Scope

Same-sheet echo only; reuses the #2028 composite; no new capability, no central RBAC/auth (K3 Stage-1 lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)