### PR TITLE
docs(multitable): harmonize A6 tracker status to A6-1 runtime landed (#2130)

### DIFF
--- a/docs/development/multitable-automation-a6-convergence-scout-20260529.md
+++ b/docs/development/multitable-automation-a6-convergence-scout-20260529.md
@@ -77,7 +77,8 @@ The dependency order is fixed, but it is not a schedule.
 | Step | Name | First deliverable after opt-in | Gate |
 |---|---|---|---|
 | A6-0 | Scout / scope gate | This docs-only document | done by this slice |
-| A6-1 | Persistent WorkflowJob runtime | design scout recorded; next is feature-flagged linear job persistence | named demand |
+| A6-1 | Persistent WorkflowJob runtime | ✅ LANDED #2130 (dormant; enable path deferred) | done (dormant) |
+| A6-1e | Enable-writer (API/UI sets `execution_mode`) | makes A6-1 live in production | named demand |
 | A6-2 | Suspend/resume | external-event/webhook resume before delay/timer resume | named demand |
 | A6-3 | Branch/parallel DAG | condition/parallel nodes with upstream/downstream graph fields | named demand |
 | A6-4 | BPMN adapter | compile/preview + gap report only; no live BPMN runtime | named demand |

--- a/docs/development/multitable-automation-run-governance-todo-20260527.md
+++ b/docs/development/multitable-automation-run-governance-todo-20260527.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-27
 Scope: multitable automation run governance + whole-execution retry only
-Status: A0-A5 closed through retry runtime + redaction invariant hardening (2026-05-29); A6-0 and A6-1 docs-only scouts recorded; A6 runtime remains frozen / demand-gated
+Status: A0-A5 closed through retry runtime + redaction invariant hardening (2026-05-29); A6-0/A6-1 scouts recorded; A6-1 persistent WorkflowJob runtime LANDED (#2130, 2026-05-30) but DORMANT (enable path deferred); A6-1 enable-writer + A6-2..A6-5 remain frozen / demand-gated
 Companion: multitable-automation-run-governance-development-20260527.md
 Depends on (landed): C1 contract workflow-job-contract.ts (#1889, read-boundary wired only); RFC #1885
 
@@ -18,12 +18,17 @@ The governance half and named A5 retry runtime are complete on `origin/main`:
 - A4 retry scope gate / design lock: #2039.
 - A5 whole-execution retry runtime: #2047.
 - A1/A5 HTTP serialization hardening: #2051 + #2053.
-- A6-0 convergence scout and A6-1 persistent `WorkflowJob` runtime scout are
-  recorded as docs-only planning artifacts. Runtime remains unstarted.
+- A6-0 convergence scout + A6-1 runtime scout: docs-only planning artifacts.
+- A6-1 persistent `WorkflowJob` runtime: LANDED #2130 (2026-05-30) — opt-in linear
+  job plane (new `multitable_automation_jobs`, rule-level `execution_mode`, fail-closed,
+  A1-redaction reuse, A2 detail prefer-jobs). **DORMANT**: createRule/updateRule do not
+  accept `execution_mode`, so no rule is opt-in-able via the API (DB/fixture only) →
+  existing rules unaffected.
 
-This closeout does NOT mark the convergence engine complete. A6 remains frozen /
-demand-gated: persistent WorkflowJob runtime, suspend/resume, branch/parallel,
-BPMN adapter, and approval-as-job are still separate future unlocks.
+This closeout does NOT mark the convergence engine complete. A6-1 runtime landed but is
+dormant; the rest remains frozen / demand-gated: A6-1 enable-writer (API/UI to set
+`execution_mode`), suspend/resume, branch/parallel, BPMN adapter, and approval-as-job are
+still separate future unlocks.
 
 ## Doctrine — Two Gates (definition of "not lopsided")
 
@@ -97,9 +102,12 @@ Completed by the named A4/A5 retry line:
 - whole-execution retry route, provenance, and side-effect confirmation — #2047.
 - HTTP response serialization invariant for `/test` + retry — #2051 + #2053.
 
-Deferred (capability half — A6, frozen/demand-gated; A6-0/A6-1 scouts only are recorded):
+Landed (capability half):
+- A6-1 persistent WorkflowJob runtime — #2130 (DORMANT; enable path deferred).
 
-- persistent automation_jobs runtime; suspend/resume; branch/parallel
+Deferred (capability half — A6, frozen/demand-gated):
+- A6-1 enable-writer (API/UI to set `execution_mode` → make A6-1 live in production)
+- suspend/resume; branch/parallel
 - BPMN compile/preview adapter; approval-as-job bridge
 
 ## Milestones
@@ -248,7 +256,8 @@ mark the convergence engine complete.
 - [x] No runtime in this milestone.
 - [x] A6-1 persistent WorkflowJob runtime scout recorded in
       `multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md`.
-- [ ] A6-1 persistent WorkflowJob runtime implementation — not started.
+- [x] A6-1 persistent WorkflowJob runtime — LANDED #2130 (dormant; enable path deferred).
+- [ ] A6-1 enable-writer (API/UI to set `execution_mode` → make A6-1 live) — not started.
 - [ ] A6-2 suspend/resume runtime — not started.
 - [ ] A6-3 branch/parallel DAG runtime — not started.
 - [ ] A6-4 BPMN compile/preview adapter — not started.

--- a/docs/development/run-governance-forward-plan-20260528.md
+++ b/docs/development/run-governance-forward-plan-20260528.md
@@ -2,7 +2,7 @@
 
 > 类型：**前向开发安排（forward plan）**，非开工清单。
 > **2026-05-29 update**：A4 retry scope-gate (#2039) + A5 whole-execution retry runtime (#2047) 已按具名 opt-in 落地；`/test` + retry HTTP serialization redaction/fail-open hardening 已由 #2051/#2053 闭合。A6-0 docs-only scout 已记录在 `multitable-automation-a6-convergence-scout-20260529.md`；A6 runtime 仍 frozen / demand-gated。
-> **2026-05-30 update**：A6-1 persistent `WorkflowJob` runtime scout 已记录在 `multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md`。它回答 table shape / opt-in / worker / side-effect boundary / redaction / mixed read model / legacy-off tests；runtime 仍未启动。
+> **2026-05-30 update**：A6-1 persistent `WorkflowJob` runtime scout（`…-a6-1-workflowjob-runtime-scout-20260530.md`）+ **runtime 已落地（#2130，verification `…-a6-1-workflowjob-runtime-verification-20260530.md`）**：opt-in `workflow_job_v1` 规则 inline 写 C1 job（fail-closed、A1 redaction 复用、A2 detail prefer-jobs）。**但 DORMANT** —— API/UI enable 路径 deferred（createRule/updateRule 不接 `execution_mode`），现有规则零影响。剩余 A6-1 enable-writer + A6-2..A6-5 仍 demand-gated。
 > 配套（已收口）：`multitable-automation-run-governance-development-20260527.md` + `-todo-20260527.md`（#1987 固化）。
 > 上游契约：C1 `workflow-job-contract.ts`（#1889，landed）· 收敛 RFC #1885。
 > 锁：**K3 Stage-1 blanket 锁已退役（#1993；#1792 = M1 单条 Material Save-only PASS）→ 改用 post-GATE scoped gates（见 `k3-post-gate-scoped-governance-20260528.md`）**。这不改变本线纪律：**治理半（A0–A3）属于内核治理 / observability，已关闭**；**能力半（A4–A6）仍各受需求闸 / 独立具名 opt-in**（本线天然为 multitable 内核范畴，不依赖 integration-core / RBAC / auth），除非对应 scout 明确授权。
@@ -17,9 +17,9 @@
 |---|---|---|---|
 | **治理半**（observability：快照→脱敏→只读 API→admin UI→可达） | 运行可观测/可审计/可诊断 | **✅ 100% + 文档固化** | 否 —— 已关闭，不重开 |
 | **Retry 能力薄片**（A4/A5：whole-execution retry） | 失败/跳过 run 可由 admin 显式确认后整 run 重跑 | **✅ 100% for A5 v1** | 否 —— 已关闭；UI/idempotency/record-refresh 另需 opt-in |
-| **收敛引擎能力半**（A6：persistent jobs / suspend/resume / branch / DAG / approval-as-job） | automation+approval 统一到 WorkflowJob 引擎 | **⬜ 引擎本体 0%**（A6-0/A6-1 scout 已记录；契约层就位、被读边界消费；机器本体未建） | 否 —— **受需求闸，未触发即过早工程** |
+| **收敛引擎能力半**（A6：persistent jobs / suspend/resume / branch / DAG / approval-as-job） | automation+approval 统一到 WorkflowJob 引擎 | **🟡 A6-1 持久 WorkflowJob runtime 已落地（#2130，2026-05-30）但 DORMANT** —— enable 路径 deferred（createRule/updateRule 不接 execution_mode；只能 DB/fixture 开）；**A6-1 enable-writer + A6-2..A6-5（suspend/branch/DAG/approval-as-job）未建** | 否 —— **A6-1 已落但 dormant；其余受需求闸，未触发即过早工程** |
 
-> **grounded 2026-05-29**：`/retry` 路由已存在且仅实现 A5 whole-execution retry；`automation-executor.ts` 仍无 suspend/resume/branch/persist-job runtime；C1 契约仅被 `routes/automation.ts` 在 A2 读边界用作状态映射（`success→resolved`），job/suspend/branch 机器未被任何 runtime 引用。
+> **grounded 2026-05-30**：`/retry` 路由实现 A5 whole-execution retry；**A6-1 persist-job runtime 已存在**（#2130：`multitable_automation_jobs` 表 + `AutomationJobService` + rule-level `execution_mode` opt-in + A2 detail prefer-jobs），对 opted-in `workflow_job_v1` 规则 inline 写 C1 job（fail-closed），但 **DORMANT**（enable 路径 deferred）。C1 契约现既被 A2 读边界用作状态映射、也被 A6-1 job 持久化引用。**仍无** suspend/resume、branch/parallel、BPMN、approval-as-job runtime。
 
 **所以"接下去的开发安排" = 触发条件账本 + 不自动推进纪律，不是任务队列。**
 
@@ -66,9 +66,10 @@
 ### A6 — 收敛引擎 🔒 frozen / 需求驱动
 依赖序：**持久 WorkflowJob runtime → suspend/resume（先 webhook 后 delay）→ branch/parallel（DAG）→ BPMN compile/preview adapter → approval-as-job**。
 - **A6-0 scout**：`multitable-automation-a6-convergence-scout-20260529.md` 只记录边界/顺序/测试面；它不是 runtime unlock。
-- **A6-1 scout**：`multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md` 已回答第一片 runtime 的七个设计问题；它仍不是 runtime unlock。
+- **A6-1 scout**：`multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md` 已回答第一片 runtime 的七个设计问题。
+- **✅ A6-1 runtime 已落地（#2130，2026-05-30；verification: `multitable-automation-a6-1-workflowjob-runtime-verification-20260530.md`）**：新 `multitable_automation_jobs` 表、rule-level `execution_mode` opt-in、inline linear job persistence（fail-closed）、A1 redaction 复用、A2 detail prefer-jobs/legacy-fallback。**但 DORMANT** —— createRule/updateRule **不接** `execution_mode`，生产无规则可经 API opt-in（只能 DB/fixture），故现有 fire-and-forget 规则零影响。
+- **剩余依赖序（未建，各需具名 opt-in）**：**A6-1 enable-writer**（API/UI 设 `execution_mode`，让 A6-1 在生产真正可用）→ **A6-2 suspend/resume**（先 webhook 后 delay）→ **A6-3 branch/parallel DAG** → **A6-4 BPMN compile/preview** → **A6-5 approval-as-job**。
 - **触发信号**：某个**集成/DF 流水线真的需要 human-in-the-loop**（"导入→清洗→**等人工审批**→导出"= suspend + approval-as-job）或按记录分支；**且本就在 K3 GATE 下游**。
-- **解锁后第一步**：持久 WorkflowJob runtime（wire #1889）—— 按 A6-1 scout 的推荐形状：新 `multitable_automation_jobs` 表、rule-level opt-in、inline linear job persistence、A1 redaction 复用、A2/A3 混合 legacy/persisted 渲染。**风险：热路径重写（每 action 一次 DB 写 = 写放大 + 事务性 + 旧规则兼容）→ 必带 flag / 向后兼容**，现有 fire-and-forget 规则不得突然全量持久。
 - **治理继承硬契约**：A6 任一能力落地必须**复用本线的 run/job/status/provenance/redaction 底座**，不得新建二等可观测层。
 - **BPMN 永久定位**：compile/preview adapter（编译成 auto/approval 定义），**永不自己执行**（否则第四套状态孤岛）。
 - **锁姿态**：🔒🔒 全 frozen。approval-as-job 排最后（最高价值+最高风险，completion-event-contract 先行）。


### PR DESCRIPTION
## What

#2130 merged the A6-1 persistent WorkflowJob runtime (2026-05-30), but the run-governance tracker docs still said *"A6-1 runtime not started / 引擎本体 0% / A6 runtime remains frozen"* — stale (same drift class as the #2042 lock-posture harmonization). This corrects the 3 status surfaces to reality.

## Changes (3 docs, docs-only)
- `run-governance-forward-plan-20260528.md`: A6 row `⬜ 引擎本体 0%` → `🟡 A6-1 runtime LANDED (#2130, DORMANT)`; §A6 "解锁后第一步" → records A6-1 landed + the remaining ladder.
- `...run-governance-todo-20260527.md`: Status line + closeout snapshot + deferred list → A6-1 runtime LANDED (dormant) under "Landed", with the enable-writer + A6-2..A6-5 under "Deferred".
- `...a6-convergence-scout-20260529.md`: ladder table A6-1 → ✅ LANDED (dormant); adds an A6-1e enable-writer row.

## Truth recorded
A6-1 runtime is **landed but DORMANT** — `createRule`/`updateRule` don't accept `execution_mode`, so no rule is opt-in-able via the API (DB/fixture only); existing rules unaffected. Remaining, each demand-gated: **A6-1 enable-writer** → A6-2 suspend/resume → A6-3 branch/parallel → A6-4 BPMN → A6-5 approval-as-job.

## Acceptance
- [x] Docs-only (3 files); no runtime/code change.
- [x] No residual "0% / not-started / frozen" claims that contradict #2130.

🤖 Generated with [Claude Code](https://claude.com/claude-code)