### PR TITLE
feat(data-sources): add read-only table preview

### DIFF
--- a/apps/web/src/data-sources/api.ts
+++ b/apps/web/src/data-sources/api.ts
@@ -4,6 +4,9 @@ import type {
   CreateDataSourcePayload,
   DataSourceDetail,
   DataSourceListItem,
+  DataSourceSchemaInfo,
+  DataSourceSelectPayload,
+  DataSourceSelectResult,
   DataSourceTestResult,
   RotateDataSourceCredentialsPayload,
   UpdateDataSourcePayload,
@@ -22,6 +25,16 @@ interface DetailEnvelope {
 interface TestEnvelope {
   ok: boolean
   data?: DataSourceTestResult
+}
+
+interface SchemaEnvelope {
+  ok: boolean
+  data?: DataSourceSchemaInfo
+}
+
+interface SelectEnvelope {
+  ok: boolean
+  data?: DataSourceSelectResult
 }
 
 interface ErrorEnvelope {
@@ -92,6 +105,36 @@ export async function testDataSourceConnection(id: string): Promise<DataSourceTe
   const body = await res.json() as TestEnvelope
   if (!body.data) {
     throw new Error('Failed to test data source: empty response')
+  }
+  return body.data
+}
+
+export async function getDataSourceSchema(id: string): Promise<DataSourceSchemaInfo> {
+  const res = await apiFetch(`/api/data-sources/${encodeURIComponent(id)}/schema`)
+  if (!res.ok) {
+    throw new Error(await errorFrom(res, 'Failed to load data source schema'))
+  }
+  const body = await res.json() as SchemaEnvelope
+  if (!body.data) {
+    throw new Error('Failed to load data source schema: empty response')
+  }
+  return body.data
+}
+
+export async function previewDataSourceRows(
+  id: string,
+  payload: DataSourceSelectPayload,
+): Promise<DataSourceSelectResult> {
+  const res = await apiFetch(`/api/data-sources/${encodeURIComponent(id)}/select`, {
+    method: 'POST',
+    body: JSON.stringify(payload),
+  })
+  if (!res.ok) {
+    throw new Error(await errorFrom(res, 'Failed to preview data source rows'))
+  }
+  const body = await res.json() as SelectEnvelope
+  if (!body.data) {
+    throw new Error('Failed to preview data source rows: empty response')
   }
   return body.data
 }

--- a/apps/web/src/data-sources/types.ts
+++ b/apps/web/src/data-sources/types.ts
@@ -38,6 +38,38 @@ export interface DataSourceTestResult {
   error?: { message?: string }
 }
 
+export interface DataSourceColumnInfo {
+  name: string
+  type?: string
+  nullable?: boolean
+}
+
+export interface DataSourceTableInfo {
+  name: string
+  schema?: string
+  columns?: DataSourceColumnInfo[]
+}
+
+export interface DataSourceSchemaInfo {
+  tables?: DataSourceTableInfo[]
+  views?: DataSourceTableInfo[]
+}
+
+export interface DataSourceSelectPayload {
+  table: string
+  select?: string[]
+  limit?: number
+  offset?: number
+}
+
+export interface DataSourceSelectResult {
+  data: Array<Record<string, unknown>>
+  metadata?: {
+    totalCount?: number
+    columns?: DataSourceColumnInfo[]
+  }
+}
+
 /** Connection fields — a free-form record on the wire; these are the common typed keys the form uses. */
 export interface DataSourceConnectionInput {
   host?: string

--- a/apps/web/src/stores/dataSources.ts
+++ b/apps/web/src/stores/dataSources.ts
@@ -5,7 +5,9 @@ import {
   createDataSource,
   deleteDataSource,
   getDataSource,
+  getDataSourceSchema,
   listDataSources,
+  previewDataSourceRows,
   rotateDataSourceCredentials,
   testDataSourceConnection,
   updateDataSource,
@@ -14,6 +16,9 @@ import type {
   CreateDataSourcePayload,
   DataSourceDetail,
   DataSourceListItem,
+  DataSourceSchemaInfo,
+  DataSourceSelectPayload,
+  DataSourceSelectResult,
   DataSourceTestResult,
   RotateDataSourceCredentialsPayload,
   UpdateDataSourcePayload,
@@ -25,6 +30,11 @@ export const useDataSourcesStore = defineStore('dataSources', () => {
   const error = ref<string | null>(null)
   const testing = ref<Record<string, boolean>>({})
   const testResults = ref<Record<string, DataSourceTestResult>>({})
+  const schemaLoading = ref<Record<string, boolean>>({})
+  const previewLoading = ref<Record<string, boolean>>({})
+  const schemas = ref<Record<string, DataSourceSchemaInfo>>({})
+  const previewResults = ref<Record<string, DataSourceSelectResult>>({})
+  const previewErrors = ref<Record<string, string>>({})
 
   async function fetchAll(): Promise<void> {
     loading.value = true
@@ -131,13 +141,69 @@ export const useDataSourcesStore = defineStore('dataSources', () => {
     }
   }
 
+  function isSchemaLoading(id: string): boolean {
+    return schemaLoading.value[id] === true
+  }
+
+  function isPreviewLoading(id: string): boolean {
+    return previewLoading.value[id] === true
+  }
+
+  function clearPreviewError(id: string): void {
+    previewErrors.value = { ...previewErrors.value, [id]: '' }
+  }
+
+  async function loadSchema(id: string): Promise<DataSourceSchemaInfo | null> {
+    clearPreviewError(id)
+    schemaLoading.value = { ...schemaLoading.value, [id]: true }
+    try {
+      const schema = await getDataSourceSchema(id)
+      schemas.value = { ...schemas.value, [id]: schema }
+      return schema
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Failed to load data source schema'
+      previewErrors.value = { ...previewErrors.value, [id]: message }
+      return null
+    } finally {
+      const remaining = { ...schemaLoading.value }
+      delete remaining[id]
+      schemaLoading.value = remaining
+    }
+  }
+
+  async function previewRows(id: string, payload: DataSourceSelectPayload): Promise<DataSourceSelectResult | null> {
+    clearPreviewError(id)
+    previewLoading.value = { ...previewLoading.value, [id]: true }
+    try {
+      const result = await previewDataSourceRows(id, payload)
+      previewResults.value = { ...previewResults.value, [id]: result }
+      return result
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Failed to preview data source rows'
+      previewErrors.value = { ...previewErrors.value, [id]: message }
+      return null
+    } finally {
+      const remaining = { ...previewLoading.value }
+      delete remaining[id]
+      previewLoading.value = remaining
+    }
+  }
+
   return {
     items,
     loading,
     error,
     testing,
     testResults,
+    schemaLoading,
+    previewLoading,
+    schemas,
+    previewResults,
+    previewErrors,
     isTesting,
+    isSchemaLoading,
+    isPreviewLoading,
+    clearPreviewError,
     fetchAll,
     create,
     loadDetail,
@@ -145,5 +211,7 @@ export const useDataSourcesStore = defineStore('dataSources', () => {
     rotateCredentials,
     remove,
     testConnection,
+    loadSchema,
+    previewRows,
   }
 })

--- a/apps/web/src/views/DataSourcesView.vue
+++ b/apps/web/src/views/DataSourcesView.vue
@@ -142,6 +142,14 @@
             <td>
               <div class="data-sources__actions">
                 <button
+                  v-if="isSqlSource(ds.type)"
+                  type="button"
+                  class="data-sources__btn"
+                  data-testid="ds-preview"
+                  :disabled="store.isSchemaLoading(ds.id) || store.isPreviewLoading(ds.id)"
+                  @click="openPreview(ds.id)"
+                >{{ activePreviewId === ds.id ? '刷新预览' : '预览' }}</button>
+                <button
                   type="button"
                   class="data-sources__btn"
                   data-testid="ds-edit"
@@ -166,6 +174,77 @@
           </tr>
         </tbody>
       </table>
+
+      <section v-if="activePreviewId" class="data-sources__preview" data-testid="ds-preview-panel">
+        <header class="data-sources__preview-header">
+          <div>
+            <h2>只读数据预览</h2>
+            <p class="data-sources__muted">只读预览 · 最多 {{ PREVIEW_ROW_LIMIT }} 行。</p>
+          </div>
+          <button type="button" class="data-sources__btn" @click="closePreview">关闭</button>
+        </header>
+
+        <div class="data-sources__preview-controls">
+          <label>表 / 视图
+            <select
+              v-model="previewTable"
+              data-testid="ds-preview-table"
+              :disabled="previewTableChoices.length === 0 || activePreviewBusy"
+              @change="runActivePreview"
+            >
+              <option value="" disabled>选择表</option>
+              <option v-for="choice in previewTableChoices" :key="choice.value" :value="choice.value">
+                {{ choice.label }}
+              </option>
+            </select>
+          </label>
+          <button
+            type="button"
+            class="data-sources__btn data-sources__btn--primary"
+            data-testid="ds-preview-refresh"
+            :disabled="!previewTable || activePreviewBusy"
+            @click="runActivePreview"
+          >
+            {{ activePreviewBusy ? '读取中…' : '读取预览' }}
+          </button>
+        </div>
+
+        <p
+          v-if="activePreviewId && store.previewErrors[activePreviewId]"
+          class="data-sources__error"
+          data-testid="ds-preview-error"
+          role="alert"
+        >
+          {{ store.previewErrors[activePreviewId] }}
+        </p>
+        <p v-else-if="activePreviewBusy" class="data-sources__muted" data-testid="ds-preview-loading">读取中…</p>
+        <p v-else-if="previewTableChoices.length === 0" class="data-sources__muted" data-testid="ds-preview-empty-schema">
+          当前数据源没有可预览的表或视图。
+        </p>
+
+        <div v-if="activePreviewResult" class="data-sources__preview-result" data-testid="ds-preview-result">
+          <p class="data-sources__muted">
+            {{ previewRows.length }} 行 · {{ previewColumns.length }} 列 · limit={{ PREVIEW_ROW_LIMIT }}
+          </p>
+          <div v-if="previewRows.length > 0 && previewColumns.length > 0" class="data-sources__preview-scroll">
+            <table class="data-sources__table data-sources__preview-table">
+              <thead>
+                <tr>
+                  <th v-for="column in previewColumns" :key="column">{{ column }}</th>
+                </tr>
+              </thead>
+              <tbody>
+                <tr v-for="(row, rowIndex) in previewRows" :key="rowIndex">
+                  <td v-for="column in previewColumns" :key="column" data-testid="ds-preview-cell">
+                    {{ formatCell(row[column]) }}
+                  </td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p v-else class="data-sources__muted" data-testid="ds-preview-empty-result">该表暂无返回行。</p>
+        </div>
+      </section>
     </div>
   </section>
 </template>
@@ -177,16 +256,20 @@ import {
   DATA_SOURCE_TYPES,
   DATA_SOURCE_TYPE_LABELS,
   type DataSourceDetail,
+  type DataSourceTableInfo,
   type DataSourceType,
 } from '../data-sources/types'
 import { buildCreatePayload, buildCredentialRotationPayload, buildUpdatePayload } from '../data-sources/buildPayload'
 
+const PREVIEW_ROW_LIMIT = 100
 const store = useDataSourcesStore()
 const formOpen = ref(false)
 const formMode = ref<'create' | 'edit' | 'credentials'>('create')
 const editingId = ref<string | null>(null)
 const submitting = ref(false)
 const detailLoading = ref(false)
+const activePreviewId = ref<string | null>(null)
+const previewTable = ref('')
 
 const form = reactive({
   id: '',
@@ -228,6 +311,62 @@ watch(() => form.type, (type) => {
 function typeLabel(type: string): string {
   return DATA_SOURCE_TYPE_LABELS[type as DataSourceType] ?? type
 }
+
+function isSqlSource(type: string): boolean {
+  // Keep this in step with backend SUPPORTED_DATA_SOURCE_TYPES. It is intentionally fail-safe:
+  // an unknown future SQL type simply hides table preview until the UI mapping is reviewed.
+  return type === 'postgres' || type === 'postgresql' || type === 'sqlserver'
+}
+
+function tableValue(table: DataSourceTableInfo): string {
+  return table.schema ? `${table.schema}.${table.name}` : table.name
+}
+
+function tableLabel(table: DataSourceTableInfo, kind: 'table' | 'view'): string {
+  const qualified = tableValue(table)
+  return `${qualified} · ${kind === 'view' ? '视图' : '表'}`
+}
+
+const activeSchema = computed(() => (
+  activePreviewId.value ? store.schemas[activePreviewId.value] : null
+))
+
+const previewTableChoices = computed(() => {
+  const schema = activeSchema.value
+  const tables = (schema?.tables ?? []).map((table) => ({
+    value: tableValue(table),
+    label: tableLabel(table, 'table'),
+  }))
+  const views = (schema?.views ?? []).map((view) => ({
+    value: tableValue(view),
+    label: tableLabel(view, 'view'),
+  }))
+  return [...tables, ...views]
+})
+
+const activePreviewResult = computed(() => (
+  activePreviewId.value ? store.previewResults[activePreviewId.value] : null
+))
+
+const activePreviewBusy = computed(() => {
+  const id = activePreviewId.value
+  return !!id && (store.isSchemaLoading(id) || store.isPreviewLoading(id))
+})
+
+const previewRows = computed(() => activePreviewResult.value?.data ?? [])
+
+const previewColumns = computed(() => {
+  const metadataColumns = activePreviewResult.value?.metadata?.columns
+    ?.map((column) => column.name)
+    .filter(Boolean) ?? []
+  if (metadataColumns.length > 0) return metadataColumns
+
+  const names = new Set<string>()
+  for (const row of previewRows.value) {
+    Object.keys(row).forEach((key) => names.add(key))
+  }
+  return Array.from(names)
+})
 
 function testResultText(id: string): string {
   const result = store.testResults[id]
@@ -335,6 +474,48 @@ async function testConnection(id: string): Promise<void> {
   await store.testConnection(id)
 }
 
+async function openPreview(id: string): Promise<void> {
+  activePreviewId.value = id
+  store.clearPreviewError(id)
+  const schema = store.schemas[id] ?? await store.loadSchema(id)
+  const firstChoice = [
+    ...(schema?.tables ?? []),
+    ...(schema?.views ?? []),
+  ][0]
+  previewTable.value = firstChoice ? tableValue(firstChoice) : ''
+  if (previewTable.value) {
+    await runActivePreview()
+  }
+}
+
+async function runActivePreview(): Promise<void> {
+  const id = activePreviewId.value
+  if (!id || !previewTable.value) return
+  await store.previewRows(id, {
+    table: previewTable.value,
+    limit: PREVIEW_ROW_LIMIT,
+  })
+}
+
+function closePreview(): void {
+  activePreviewId.value = null
+  previewTable.value = ''
+}
+
+function formatCell(value: unknown): string {
+  if (value === null) return 'NULL'
+  if (value === undefined) return ''
+  if (value instanceof Date) return value.toISOString()
+  if (typeof value === 'object') {
+    try {
+      return JSON.stringify(value)
+    } catch {
+      return String(value)
+    }
+  }
+  return String(value)
+}
+
 async function confirmRemove(id: string, name: string): Promise<void> {
   if (typeof window !== 'undefined' && !window.confirm(`删除数据源「${name}」?此操作不可撤销。`)) return
   await store.remove(id)
@@ -346,7 +527,7 @@ onMounted(() => {
 </script>
 
 <style scoped>
-.data-sources { padding: 24px; max-width: 960px; margin: 0 auto; }
+.data-sources { padding: 24px; max-width: 1180px; margin: 0 auto; }
 .data-sources__header { display: flex; justify-content: space-between; align-items: flex-start; gap: 16px; }
 .data-sources__header h1 { font-size: 22px; margin: 0 0 4px; }
 .data-sources__sub { font-size: 13px; color: #8a8f99; font-weight: 400; }
@@ -369,8 +550,17 @@ onMounted(() => {
 .data-sources__status { font-size: 12px; padding: 2px 8px; border-radius: 10px; white-space: nowrap; }
 .data-sources__status.is-on { background: #f6ffed; color: #389e0d; }
 .data-sources__status.is-off { background: #f5f5f5; color: #8c8c8c; }
-.data-sources__actions { display: flex; justify-content: flex-end; gap: 8px; }
+.data-sources__actions { display: flex; justify-content: flex-end; gap: 8px; flex-wrap: wrap; }
 .data-sources__test-result { margin: 6px 0 0; font-size: 12px; max-width: 260px; overflow-wrap: anywhere; }
 .data-sources__test-result.is-ok { color: #237804; }
 .data-sources__test-result.is-fail { color: #cf1322; }
+.data-sources__preview { margin-top: 16px; padding: 16px; border: 1px solid #e5e7eb; border-radius: 8px; background: #fff; }
+.data-sources__preview-header { display: flex; align-items: flex-start; justify-content: space-between; gap: 16px; margin-bottom: 12px; }
+.data-sources__preview-header h2 { font-size: 16px; margin: 0 0 4px; }
+.data-sources__preview-controls { display: flex; align-items: flex-end; gap: 12px; flex-wrap: wrap; margin-bottom: 12px; }
+.data-sources__preview-controls label { display: flex; flex-direction: column; gap: 4px; min-width: 260px; font-size: 13px; color: #374151; }
+.data-sources__preview-controls select { padding: 6px 8px; border: 1px solid #d1d5db; border-radius: 6px; font-size: 13px; }
+.data-sources__preview-result { margin-top: 10px; }
+.data-sources__preview-scroll { max-width: 100%; overflow: auto; border: 1px solid #f0f0f0; border-radius: 6px; }
+.data-sources__preview-table th, .data-sources__preview-table td { white-space: nowrap; max-width: 280px; overflow: hidden; text-overflow: ellipsis; }
 </style>

--- a/apps/web/tests/data-sources-api-preview.spec.ts
+++ b/apps/web/tests/data-sources-api-preview.spec.ts
@@ -1,0 +1,58 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiFetchMock = vi.hoisted(() => vi.fn())
+const apiGetMock = vi.hoisted(() => vi.fn())
+
+vi.mock('../src/utils/api', () => ({
+  apiFetch: apiFetchMock,
+  apiGet: apiGetMock,
+}))
+
+import { getDataSourceSchema, previewDataSourceRows } from '../src/data-sources/api'
+
+function jsonResponse(status: number, body: unknown): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status >= 200 && status < 300 ? 'OK' : 'Bad Request',
+    json: async () => body,
+  } as Response
+}
+
+describe('data-sources preview API client', () => {
+  beforeEach(() => {
+    apiFetchMock.mockReset()
+    apiGetMock.mockReset()
+  })
+
+  it('loads schema through the schema endpoint', async () => {
+    apiFetchMock.mockResolvedValue(jsonResponse(200, {
+      ok: true,
+      data: { tables: [{ name: 'items', schema: 'public', columns: [] }] },
+    }))
+
+    const schema = await getDataSourceSchema('pg/source')
+
+    expect(schema.tables?.[0].name).toBe('items')
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/data-sources/pg%2Fsource/schema')
+  })
+
+  it('previews rows through bounded /select and never calls raw /query', async () => {
+    apiFetchMock.mockResolvedValue(jsonResponse(200, {
+      ok: true,
+      data: {
+        data: [{ id: 1 }],
+        metadata: { columns: [{ name: 'id', type: 'int' }] },
+      },
+    }))
+
+    const result = await previewDataSourceRows('pg', { table: 'public.items', limit: 100 })
+
+    expect(result.data).toEqual([{ id: 1 }])
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/data-sources/pg/select', {
+      method: 'POST',
+      body: JSON.stringify({ table: 'public.items', limit: 100 }),
+    })
+    expect(apiFetchMock.mock.calls.some(([path]) => String(path).includes('/query'))).toBe(false)
+  })
+})

--- a/apps/web/tests/data-sources-ui.spec.ts
+++ b/apps/web/tests/data-sources-ui.spec.ts
@@ -17,6 +17,8 @@ const updateMock = vi.hoisted(() => vi.fn())
 const rotateCredentialsMock = vi.hoisted(() => vi.fn())
 const deleteMock = vi.hoisted(() => vi.fn())
 const testConnectionMock = vi.hoisted(() => vi.fn())
+const getSchemaMock = vi.hoisted(() => vi.fn())
+const previewRowsMock = vi.hoisted(() => vi.fn())
 vi.mock('../src/data-sources/api', () => ({
   listDataSources: listMock,
   getDataSource: getMock,
@@ -25,6 +27,8 @@ vi.mock('../src/data-sources/api', () => ({
   rotateDataSourceCredentials: rotateCredentialsMock,
   deleteDataSource: deleteMock,
   testDataSourceConnection: testConnectionMock,
+  getDataSourceSchema: getSchemaMock,
+  previewDataSourceRows: previewRowsMock,
 }))
 
 import { useDataSourcesStore } from '../src/stores/dataSources'
@@ -273,6 +277,27 @@ describe('useDataSourcesStore (UI-1)', () => {
     expect(store.testResults.a.success).toBe(false)
     expect(store.testResults.a.error?.message).toBe('timeout')
   })
+
+  it('loads schema and previews rows through the bounded structured select path', async () => {
+    getSchemaMock.mockResolvedValue({
+      tables: [{ name: 'items', schema: 'public', columns: [{ name: 'id', type: 'int' }] }],
+    })
+    previewRowsMock.mockResolvedValue({
+      data: [{ id: 1, name: 'Widget' }],
+      metadata: { columns: [{ name: 'id', type: 'int' }, { name: 'name', type: 'text' }] },
+    })
+    const store = useDataSourcesStore()
+
+    const schema = await store.loadSchema('pg')
+    const result = await store.previewRows('pg', { table: 'public.items', limit: 100 })
+
+    expect(schema?.tables?.[0].name).toBe('items')
+    expect(result?.data[0].name).toBe('Widget')
+    expect(getSchemaMock).toHaveBeenCalledWith('pg')
+    expect(previewRowsMock).toHaveBeenCalledWith('pg', { table: 'public.items', limit: 100 })
+    expect(store.previewErrors.pg).toBe('')
+  })
+
 })
 
 describe('DataSourcesView (UI-2 connection test reachability)', () => {
@@ -424,5 +449,56 @@ describe('DataSourcesView (UI-2 connection test reachability)', () => {
     })
     expect(rotateCredentialsMock.mock.calls[0][1]).not.toHaveProperty('connection')
     expect(rotateCredentialsMock.mock.calls[0][1]).not.toHaveProperty('options')
+  })
+
+  it('opens a read-only SQL table preview via schema + bounded select and renders rows', async () => {
+    listMock.mockResolvedValue([
+      { id: 'pg', name: 'Warehouse DB', type: 'postgres', connected: true },
+      { id: 'api', name: 'API', type: 'http', connected: true },
+    ])
+    getSchemaMock.mockResolvedValue({
+      tables: [{
+        name: 'items',
+        schema: 'public',
+        columns: [{ name: 'id', type: 'int' }, { name: 'name', type: 'text' }],
+      }],
+    })
+    previewRowsMock.mockResolvedValue({
+      data: [{ id: 1, name: 'Widget' }],
+      metadata: { columns: [{ name: 'id', type: 'int' }, { name: 'name', type: 'text' }] },
+    })
+
+    const container = await mountView()
+    const previewButtons = container.querySelectorAll('[data-testid="ds-preview"]')
+    expect(previewButtons).toHaveLength(1)
+
+    ;(previewButtons[0] as HTMLButtonElement).click()
+    await flush()
+    await flush()
+    await flush()
+
+    expect(getSchemaMock).toHaveBeenCalledWith('pg')
+    expect(previewRowsMock).toHaveBeenCalledWith('pg', { table: 'public.items', limit: 100 })
+    expect(container.querySelector('[data-testid="ds-preview-panel"]')?.textContent).toContain('只读数据预览')
+    expect(container.querySelector('[data-testid="ds-preview-result"]')?.textContent).toContain('Widget')
+    expect(container.querySelector('[data-testid="ds-preview-panel"]')?.textContent).toContain('limit=100')
+  })
+
+  it('clears stale preview errors through the cached empty-schema preview path', async () => {
+    listMock.mockResolvedValue([{ id: 'pg', name: 'Warehouse DB', type: 'postgres', connected: true }])
+
+    const container = await mountView()
+    const store = useDataSourcesStore()
+    store.schemas.pg = { tables: [], views: [] }
+    store.previewErrors.pg = 'previous schema error'
+
+    ;(container.querySelector('[data-testid="ds-preview"]') as HTMLButtonElement).click()
+    await flush()
+    await flush()
+
+    expect(getSchemaMock).not.toHaveBeenCalled()
+    expect(previewRowsMock).not.toHaveBeenCalled()
+    expect(store.previewErrors.pg).toBe('')
+    expect(container.querySelector('[data-testid="ds-preview-empty-schema"]')?.textContent).toContain('没有可预览')
   })
 })


### PR DESCRIPTION
## Summary\n- add a SQL-only read-only preview action on the data-sources page\n- load schema/table choices via the existing /api/data-sources/:id/schema endpoint\n- preview rows through bounded /api/data-sources/:id/select with limit=100 and render the returned columns/rows\n- keep HTTP sources out of the table preview path and do not add raw query, export, writes, joins, or query-builder UI\n\n## Verification\n- pnpm --filter @metasheet/web exec vitest run tests/data-sources-ui.spec.ts tests/data-sources-api-preview.spec.ts --watch=false\n- pnpm --filter @metasheet/web exec vue-tsc --noEmit\n\n## Guardrails\n- API client test asserts the preview path calls /select and never /query\n- UI test asserts preview calls schema + bounded select, hides preview for HTTP sources, and renders returned rows\n