### PR TITLE
feat(data-sources): add schema browser UI

### DIFF
--- a/apps/web/src/data-sources/api.ts
+++ b/apps/web/src/data-sources/api.ts
@@ -7,6 +7,7 @@ import type {
   DataSourceSchemaInfo,
   DataSourceSelectPayload,
   DataSourceSelectResult,
+  DataSourceTableInfo,
   DataSourceTestResult,
   RotateDataSourceCredentialsPayload,
   UpdateDataSourcePayload,
@@ -30,6 +31,11 @@ interface TestEnvelope {
 interface SchemaEnvelope {
   ok: boolean
   data?: DataSourceSchemaInfo
+}
+
+interface TableInfoEnvelope {
+  ok: boolean
+  data?: DataSourceTableInfo
 }
 
 interface SelectEnvelope {
@@ -117,6 +123,27 @@ export async function getDataSourceSchema(id: string): Promise<DataSourceSchemaI
   const body = await res.json() as SchemaEnvelope
   if (!body.data) {
     throw new Error('Failed to load data source schema: empty response')
+  }
+  return body.data
+}
+
+export async function getDataSourceTableInfo(
+  id: string,
+  table: string,
+  schema?: string,
+): Promise<DataSourceTableInfo> {
+  const params = new URLSearchParams()
+  if (schema) params.set('schema', schema)
+  const query = params.toString()
+  const res = await apiFetch(
+    `/api/data-sources/${encodeURIComponent(id)}/tables/${encodeURIComponent(table)}${query ? `?${query}` : ''}`,
+  )
+  if (!res.ok) {
+    throw new Error(await errorFrom(res, 'Failed to load data source table info'))
+  }
+  const body = await res.json() as TableInfoEnvelope
+  if (!body.data) {
+    throw new Error('Failed to load data source table info: empty response')
   }
   return body.data
 }

--- a/apps/web/src/data-sources/types.ts
+++ b/apps/web/src/data-sources/types.ts
@@ -42,6 +42,8 @@ export interface DataSourceColumnInfo {
   name: string
   type?: string
   nullable?: boolean
+  primaryKey?: boolean
+  defaultValue?: unknown
 }
 
 export interface DataSourceTableInfo {

--- a/apps/web/src/stores/dataSources.ts
+++ b/apps/web/src/stores/dataSources.ts
@@ -6,6 +6,7 @@ import {
   deleteDataSource,
   getDataSource,
   getDataSourceSchema,
+  getDataSourceTableInfo,
   listDataSources,
   previewDataSourceRows,
   rotateDataSourceCredentials,
@@ -19,10 +20,15 @@ import type {
   DataSourceSchemaInfo,
   DataSourceSelectPayload,
   DataSourceSelectResult,
+  DataSourceTableInfo,
   DataSourceTestResult,
   RotateDataSourceCredentialsPayload,
   UpdateDataSourcePayload,
 } from '../data-sources/types'
+
+function tableDetailKey(id: string, table: string, schema?: string): string {
+  return `${id}:${schema ? `${schema}.` : ''}${table}`
+}
 
 export const useDataSourcesStore = defineStore('dataSources', () => {
   const items = ref<DataSourceListItem[]>([])
@@ -31,8 +37,11 @@ export const useDataSourcesStore = defineStore('dataSources', () => {
   const testing = ref<Record<string, boolean>>({})
   const testResults = ref<Record<string, DataSourceTestResult>>({})
   const schemaLoading = ref<Record<string, boolean>>({})
+  const tableInfoLoading = ref<Record<string, boolean>>({})
   const previewLoading = ref<Record<string, boolean>>({})
   const schemas = ref<Record<string, DataSourceSchemaInfo>>({})
+  const tableDetails = ref<Record<string, DataSourceTableInfo>>({})
+  const schemaErrors = ref<Record<string, string>>({})
   const previewResults = ref<Record<string, DataSourceSelectResult>>({})
   const previewErrors = ref<Record<string, string>>({})
 
@@ -149,11 +158,16 @@ export const useDataSourcesStore = defineStore('dataSources', () => {
     return previewLoading.value[id] === true
   }
 
+  function isTableInfoLoading(key: string): boolean {
+    return tableInfoLoading.value[key] === true
+  }
+
   function clearPreviewError(id: string): void {
     previewErrors.value = { ...previewErrors.value, [id]: '' }
   }
 
   async function loadSchema(id: string): Promise<DataSourceSchemaInfo | null> {
+    schemaErrors.value = { ...schemaErrors.value, [id]: '' }
     clearPreviewError(id)
     schemaLoading.value = { ...schemaLoading.value, [id]: true }
     try {
@@ -162,12 +176,32 @@ export const useDataSourcesStore = defineStore('dataSources', () => {
       return schema
     } catch (e) {
       const message = e instanceof Error ? e.message : 'Failed to load data source schema'
+      schemaErrors.value = { ...schemaErrors.value, [id]: message }
       previewErrors.value = { ...previewErrors.value, [id]: message }
       return null
     } finally {
       const remaining = { ...schemaLoading.value }
       delete remaining[id]
       schemaLoading.value = remaining
+    }
+  }
+
+  async function loadTableInfo(id: string, table: string, schema?: string): Promise<DataSourceTableInfo | null> {
+    const key = tableDetailKey(id, table, schema)
+    schemaErrors.value = { ...schemaErrors.value, [id]: '' }
+    tableInfoLoading.value = { ...tableInfoLoading.value, [key]: true }
+    try {
+      const detail = await getDataSourceTableInfo(id, table, schema)
+      tableDetails.value = { ...tableDetails.value, [key]: detail }
+      return detail
+    } catch (e) {
+      const message = e instanceof Error ? e.message : 'Failed to load data source table info'
+      schemaErrors.value = { ...schemaErrors.value, [id]: message }
+      return null
+    } finally {
+      const remaining = { ...tableInfoLoading.value }
+      delete remaining[key]
+      tableInfoLoading.value = remaining
     }
   }
 
@@ -196,14 +230,19 @@ export const useDataSourcesStore = defineStore('dataSources', () => {
     testing,
     testResults,
     schemaLoading,
+    tableInfoLoading,
     previewLoading,
     schemas,
+    tableDetails,
+    schemaErrors,
     previewResults,
     previewErrors,
     isTesting,
     isSchemaLoading,
+    isTableInfoLoading,
     isPreviewLoading,
     clearPreviewError,
+    tableDetailKey,
     fetchAll,
     create,
     loadDetail,
@@ -212,6 +251,7 @@ export const useDataSourcesStore = defineStore('dataSources', () => {
     remove,
     testConnection,
     loadSchema,
+    loadTableInfo,
     previewRows,
   }
 })

--- a/apps/web/src/views/DataSourcesView.vue
+++ b/apps/web/src/views/DataSourcesView.vue
@@ -145,6 +145,14 @@
                   v-if="isSqlSource(ds.type)"
                   type="button"
                   class="data-sources__btn"
+                  data-testid="ds-schema"
+                  :disabled="store.isSchemaLoading(ds.id)"
+                  @click="openSchemaBrowser(ds.id)"
+                >结构</button>
+                <button
+                  v-if="isSqlSource(ds.type)"
+                  type="button"
+                  class="data-sources__btn"
                   data-testid="ds-preview"
                   :disabled="store.isSchemaLoading(ds.id) || store.isPreviewLoading(ds.id)"
                   @click="openPreview(ds.id)"
@@ -174,6 +182,76 @@
           </tr>
         </tbody>
       </table>
+
+      <section v-if="activeSchemaId" class="data-sources__preview" data-testid="ds-schema-panel">
+        <header class="data-sources__preview-header">
+          <div>
+            <h2>库表结构</h2>
+            <p class="data-sources__muted">只读浏览 schema / table / columns,不读取业务数据。</p>
+          </div>
+          <button type="button" class="data-sources__btn" @click="closeSchemaBrowser">关闭</button>
+        </header>
+
+        <div class="data-sources__preview-controls">
+          <label>表 / 视图
+            <select
+              v-model="schemaTable"
+              data-testid="ds-schema-table"
+              :disabled="schemaTableChoices.length === 0 || activeSchemaBusy"
+              @change="loadActiveTableInfo"
+            >
+              <option value="" disabled>选择表</option>
+              <option v-for="choice in schemaTableChoices" :key="choice.value" :value="choice.value">
+                {{ choice.label }}
+              </option>
+            </select>
+          </label>
+          <button
+            type="button"
+            class="data-sources__btn data-sources__btn--primary"
+            data-testid="ds-schema-refresh"
+            :disabled="!schemaTable || activeSchemaBusy"
+            @click="loadActiveTableInfo"
+          >
+            {{ activeSchemaBusy ? '读取中…' : '读取字段' }}
+          </button>
+        </div>
+
+        <p
+          v-if="activeSchemaId && store.schemaErrors[activeSchemaId]"
+          class="data-sources__error"
+          data-testid="ds-schema-error"
+          role="alert"
+        >
+          {{ store.schemaErrors[activeSchemaId] }}
+        </p>
+        <p v-else-if="activeSchemaBusy" class="data-sources__muted" data-testid="ds-schema-loading">读取中…</p>
+        <p v-else-if="schemaTableChoices.length === 0" class="data-sources__muted" data-testid="ds-schema-empty">
+          当前数据源未返回表或视图。
+        </p>
+
+        <div v-if="activeTableDetail" class="data-sources__preview-result" data-testid="ds-schema-detail">
+          <p class="data-sources__muted">
+            {{ tableDisplayName(activeTableDetail) }} · {{ activeTableDetail.columns?.length ?? 0 }} 个字段
+          </p>
+          <div v-if="(activeTableDetail.columns?.length ?? 0) > 0" class="data-sources__preview-scroll">
+            <table class="data-sources__table data-sources__preview-table">
+              <thead>
+                <tr><th>字段</th><th>类型</th><th>约束</th><th>默认值</th></tr>
+              </thead>
+              <tbody>
+                <tr v-for="column in activeTableDetail.columns" :key="column.name">
+                  <td data-testid="ds-schema-column">{{ column.name }}</td>
+                  <td>{{ column.type || '-' }}</td>
+                  <td>{{ columnConstraintText(column) }}</td>
+                  <td>{{ formatCell(column.defaultValue) || '-' }}</td>
+                </tr>
+              </tbody>
+            </table>
+          </div>
+          <p v-else class="data-sources__muted" data-testid="ds-schema-empty-columns">该表未返回字段信息。</p>
+        </div>
+      </section>
 
       <section v-if="activePreviewId" class="data-sources__preview" data-testid="ds-preview-panel">
         <header class="data-sources__preview-header">
@@ -255,6 +333,7 @@ import { useDataSourcesStore } from '../stores/dataSources'
 import {
   DATA_SOURCE_TYPES,
   DATA_SOURCE_TYPE_LABELS,
+  type DataSourceColumnInfo,
   type DataSourceDetail,
   type DataSourceTableInfo,
   type DataSourceType,
@@ -268,8 +347,18 @@ const formMode = ref<'create' | 'edit' | 'credentials'>('create')
 const editingId = ref<string | null>(null)
 const submitting = ref(false)
 const detailLoading = ref(false)
+const activeSchemaId = ref<string | null>(null)
+const schemaTable = ref('')
 const activePreviewId = ref<string | null>(null)
 const previewTable = ref('')
+
+interface TableChoice {
+  value: string
+  label: string
+  name: string
+  schema?: string
+  kind: 'table' | 'view'
+}
 
 const form = reactive({
   id: '',
@@ -327,26 +416,56 @@ function tableLabel(table: DataSourceTableInfo, kind: 'table' | 'view'): string 
   return `${qualified} · ${kind === 'view' ? '视图' : '表'}`
 }
 
-const activeSchema = computed(() => (
+function tableChoice(table: DataSourceTableInfo, kind: 'table' | 'view'): TableChoice {
+  return {
+    value: tableValue(table),
+    label: tableLabel(table, kind),
+    name: table.name,
+    schema: table.schema,
+    kind,
+  }
+}
+
+function tableChoicesFor(schema: { tables?: DataSourceTableInfo[]; views?: DataSourceTableInfo[] } | null): TableChoice[] {
+  const tables = (schema?.tables ?? []).map((table) => tableChoice(table, 'table'))
+  const views = (schema?.views ?? []).map((view) => tableChoice(view, 'view'))
+  return [...tables, ...views]
+}
+
+const activePreviewSchema = computed(() => (
   activePreviewId.value ? store.schemas[activePreviewId.value] : null
 ))
 
-const previewTableChoices = computed(() => {
-  const schema = activeSchema.value
-  const tables = (schema?.tables ?? []).map((table) => ({
-    value: tableValue(table),
-    label: tableLabel(table, 'table'),
-  }))
-  const views = (schema?.views ?? []).map((view) => ({
-    value: tableValue(view),
-    label: tableLabel(view, 'view'),
-  }))
-  return [...tables, ...views]
+const activeSchemaInfo = computed(() => (
+  activeSchemaId.value ? store.schemas[activeSchemaId.value] : null
+))
+
+const previewTableChoices = computed(() => tableChoicesFor(activePreviewSchema.value))
+
+const schemaTableChoices = computed(() => tableChoicesFor(activeSchemaInfo.value))
+
+const selectedSchemaChoice = computed(() => (
+  schemaTableChoices.value.find((choice) => choice.value === schemaTable.value) ?? null
+))
+
+const activeTableDetail = computed(() => {
+  const id = activeSchemaId.value
+  const choice = selectedSchemaChoice.value
+  if (!id || !choice) return null
+  return store.tableDetails[store.tableDetailKey(id, choice.name, choice.schema)] ?? null
 })
 
 const activePreviewResult = computed(() => (
   activePreviewId.value ? store.previewResults[activePreviewId.value] : null
 ))
+
+const activeSchemaBusy = computed(() => {
+  const id = activeSchemaId.value
+  const choice = selectedSchemaChoice.value
+  if (!id) return false
+  const tableBusy = choice ? store.isTableInfoLoading(store.tableDetailKey(id, choice.name, choice.schema)) : false
+  return store.isSchemaLoading(id) || tableBusy
+})
 
 const activePreviewBusy = computed(() => {
   const id = activePreviewId.value
@@ -375,6 +494,17 @@ function testResultText(id: string): string {
     return `通过${result.latency ? ` · ${result.latency}` : ''}`
   }
   return `失败${result.error?.message ? ` · ${result.error.message}` : ''}`
+}
+
+function tableDisplayName(table: DataSourceTableInfo): string {
+  return table.schema ? `${table.schema}.${table.name}` : table.name
+}
+
+function columnConstraintText(column: DataSourceColumnInfo): string {
+  const parts = []
+  if (column.primaryKey) parts.push('PK')
+  parts.push(column.nullable === false ? 'NOT NULL' : 'NULL')
+  return parts.join(' · ')
 }
 
 function toggleCreateForm(): void {
@@ -472,6 +602,28 @@ async function submit(): Promise<void> {
 
 async function testConnection(id: string): Promise<void> {
   await store.testConnection(id)
+}
+
+async function openSchemaBrowser(id: string): Promise<void> {
+  activeSchemaId.value = id
+  const schema = store.schemas[id] ?? await store.loadSchema(id)
+  const firstChoice = tableChoicesFor(schema)[0]
+  schemaTable.value = firstChoice?.value ?? ''
+  if (firstChoice) {
+    await store.loadTableInfo(id, firstChoice.name, firstChoice.schema)
+  }
+}
+
+async function loadActiveTableInfo(): Promise<void> {
+  const id = activeSchemaId.value
+  const choice = selectedSchemaChoice.value
+  if (!id || !choice) return
+  await store.loadTableInfo(id, choice.name, choice.schema)
+}
+
+function closeSchemaBrowser(): void {
+  activeSchemaId.value = null
+  schemaTable.value = ''
 }
 
 async function openPreview(id: string): Promise<void> {

--- a/apps/web/tests/data-sources-api-preview.spec.ts
+++ b/apps/web/tests/data-sources-api-preview.spec.ts
@@ -8,7 +8,7 @@ vi.mock('../src/utils/api', () => ({
   apiGet: apiGetMock,
 }))
 
-import { getDataSourceSchema, previewDataSourceRows } from '../src/data-sources/api'
+import { getDataSourceSchema, getDataSourceTableInfo, previewDataSourceRows } from '../src/data-sources/api'
 
 function jsonResponse(status: number, body: unknown): Response {
   return {
@@ -35,6 +35,18 @@ describe('data-sources preview API client', () => {
 
     expect(schema.tables?.[0].name).toBe('items')
     expect(apiFetchMock).toHaveBeenCalledWith('/api/data-sources/pg%2Fsource/schema')
+  })
+
+  it('loads table details through the table-info endpoint with schema query', async () => {
+    apiFetchMock.mockResolvedValue(jsonResponse(200, {
+      ok: true,
+      data: { name: 'items', schema: 'public', columns: [{ name: 'id', type: 'int', nullable: false }] },
+    }))
+
+    const table = await getDataSourceTableInfo('pg/source', 'items', 'public')
+
+    expect(table.columns?.[0].name).toBe('id')
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/data-sources/pg%2Fsource/tables/items?schema=public')
   })
 
   it('previews rows through bounded /select and never calls raw /query', async () => {

--- a/apps/web/tests/data-sources-ui.spec.ts
+++ b/apps/web/tests/data-sources-ui.spec.ts
@@ -18,6 +18,7 @@ const rotateCredentialsMock = vi.hoisted(() => vi.fn())
 const deleteMock = vi.hoisted(() => vi.fn())
 const testConnectionMock = vi.hoisted(() => vi.fn())
 const getSchemaMock = vi.hoisted(() => vi.fn())
+const getTableInfoMock = vi.hoisted(() => vi.fn())
 const previewRowsMock = vi.hoisted(() => vi.fn())
 vi.mock('../src/data-sources/api', () => ({
   listDataSources: listMock,
@@ -28,6 +29,7 @@ vi.mock('../src/data-sources/api', () => ({
   deleteDataSource: deleteMock,
   testDataSourceConnection: testConnectionMock,
   getDataSourceSchema: getSchemaMock,
+  getDataSourceTableInfo: getTableInfoMock,
   previewDataSourceRows: previewRowsMock,
 }))
 
@@ -298,6 +300,21 @@ describe('useDataSourcesStore (UI-1)', () => {
     expect(store.previewErrors.pg).toBe('')
   })
 
+  it('loads table details through schema-scoped table info', async () => {
+    getTableInfoMock.mockResolvedValue({
+      name: 'items',
+      schema: 'public',
+      columns: [{ name: 'id', type: 'int', nullable: false, primaryKey: true }],
+    })
+    const store = useDataSourcesStore()
+
+    const detail = await store.loadTableInfo('pg', 'items', 'public')
+
+    expect(getTableInfoMock).toHaveBeenCalledWith('pg', 'items', 'public')
+    expect(detail?.columns?.[0].primaryKey).toBe(true)
+    expect(store.tableDetails[store.tableDetailKey('pg', 'items', 'public')].columns?.[0].name).toBe('id')
+    expect(store.schemaErrors.pg).toBe('')
+  })
 })
 
 describe('DataSourcesView (UI-2 connection test reachability)', () => {
@@ -449,6 +466,46 @@ describe('DataSourcesView (UI-2 connection test reachability)', () => {
     })
     expect(rotateCredentialsMock.mock.calls[0][1]).not.toHaveProperty('connection')
     expect(rotateCredentialsMock.mock.calls[0][1]).not.toHaveProperty('options')
+  })
+
+  it('opens a SQL schema browser and renders table columns without previewing rows', async () => {
+    listMock.mockResolvedValue([
+      { id: 'pg', name: 'Warehouse DB', type: 'postgres', connected: true },
+      { id: 'api', name: 'API', type: 'http', connected: true },
+    ])
+    getSchemaMock.mockResolvedValue({
+      tables: [{
+        name: 'items',
+        schema: 'public',
+        columns: [{ name: 'id', type: 'int' }],
+      }],
+      views: [{ name: 'active_items', schema: 'public', columns: [] }],
+    })
+    getTableInfoMock.mockResolvedValue({
+      name: 'items',
+      schema: 'public',
+      columns: [
+        { name: 'id', type: 'int', nullable: false, primaryKey: true },
+        { name: 'name', type: 'text', nullable: true },
+      ],
+    })
+
+    const container = await mountView()
+    const schemaButtons = container.querySelectorAll('[data-testid="ds-schema"]')
+    expect(schemaButtons).toHaveLength(1)
+
+    ;(schemaButtons[0] as HTMLButtonElement).click()
+    await flush()
+    await flush()
+    await flush()
+
+    expect(getSchemaMock).toHaveBeenCalledWith('pg')
+    expect(getTableInfoMock).toHaveBeenCalledWith('pg', 'items', 'public')
+    expect(previewRowsMock).not.toHaveBeenCalled()
+    expect(container.querySelector('[data-testid="ds-schema-panel"]')?.textContent).toContain('库表结构')
+    expect(container.querySelector('[data-testid="ds-schema-detail"]')?.textContent).toContain('public.items')
+    expect(container.querySelector('[data-testid="ds-schema-detail"]')?.textContent).toContain('NOT NULL')
+    expect(container.querySelectorAll('[data-testid="ds-schema-column"]')).toHaveLength(2)
   })
 
   it('opens a read-only SQL table preview via schema + bounded select and renders rows', async () => {

--- a/docs/development/data-sources-mssql-windows-deploy-design-20260527.md
+++ b/docs/development/data-sources-mssql-windows-deploy-design-20260527.md
@@ -114,7 +114,7 @@
 
 ## 4. 门控 TODO 清单(✅ 完成 / 🔒 硬件或独立闸 / ⬜ 可选债务)
 
-> **状态回填 2026-05-31**:按 `origin/main` 至 #2161 核准。外接数据源 / SQL Server 连接器已从 API-only 走到**后端安全闭环 + Windows 部署/验证 kit + UI list/create/delete/test/edit/credential rotation**。剩余项不再阻塞"连接客户 SQL Server"目标:仅客户硬件证据(C3-env、2008R2/2012)与可选技术债(B0/B6/UI-schema/UI-preview/真 cursor/Knex)。
+> **状态回填 2026-06-01**:按 `origin/main` 至 #2171 + stacked UI-schema/UI-preview 切片核准。外接数据源 / SQL Server 连接器已从 API-only 走到**后端安全闭环 + Windows 部署/验证 kit + UI list/create/delete/test/edit/credential rotation/schema/preview**。剩余项不再阻塞"连接客户 SQL Server"目标:仅客户硬件证据(C3-env、2008R2/2012)与可选技术债(B0/B6/真 cursor/Knex)。
 
 ### Phase 0 — 决策与开闸(裁示见 §5)
 - ✅ P0-3 Lane A 放行(归入内核打磨/安全修复)
@@ -155,10 +155,10 @@
 - ✅ UI-2 test connection(#2151):列表行测试连接,展示 A3 脱敏错误与 latency。
 - ✅ UI-3 edit non-secret config(#2154 + #2155 + #2161):编辑 name/connection/readOnly;后端深合并 `connection` 防止丢 TLS/security keys;前端支持 server-only MSSQL 且不削弱 Postgres host 规则。
 - ✅ Credential rotation(#2160 `82d6317b2`):独立凭据模式/接口,只提交填写字段,留空不覆盖旧凭据。
-- ⬜ UI-schema 库表/字段浏览:surface `GET /api/data-sources/:id/schema` + `GET /api/data-sources/:id/tables/:table`;后端端点已就位,前端尚未暴露。
-- ⬜ UI-preview bounded read preview:surface `POST /api/data-sources/:id/select`;A5 已在后端提供上限保护,前端预览不是连接器可用性的硬门槛。
+- ✅ UI-schema 库表/字段浏览(本刀,stacked on #2172):surface `GET /api/data-sources/:id/schema` + `GET /api/data-sources/:id/tables/:table`;展示表/视图与字段明细,不读取业务数据。
+- ✅ UI-preview bounded read preview(#2172):surface `POST /api/data-sources/:id/select`;A5 已在后端提供上限保护,只读预览最多 100 行。
 
-**完成态判定(2026-05-31)**:A/B/C-code + UI 管理主线(连/测/改/删/轮换)均已合并;独立管理工具完整性还剩 UI-schema + UI-preview 两个 surface-only 前端切片。继续推进只应围绕:(1)客户/VM 实跑证据回填;(2)独立 opt-in 的可选债务,不要再把它们并入连接器核心完成标准。
+**完成态判定(2026-06-01)**:A/B/C-code + UI 管理主线(连/测/改/删/轮换/浏览/预览)均已闭环。继续推进只应围绕:(1)客户/VM 实跑证据回填;(2)独立 opt-in 的可选债务;(3)阶段二 gated 的 read→multitable/import 设计,不要再把它们并入连接器核心完成标准。
 
 ---
 


### PR DESCRIPTION
## Summary
- Stacked on #2172 to avoid colliding with the open read-only preview branch that touches the same UI files.
- Adds a read-only schema browser action for SQL sources: load `/schema`, choose a table/view, then load `/tables/:table?schema=...` for field details.
- Displays columns with type, nullable/PK constraint, and default value; this does not call `/select` or read business rows.
- Updates the data-sources tracker so UI-schema + UI-preview are marked complete once the stack lands.

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/data-sources-ui.spec.ts tests/data-sources-api-preview.spec.ts --watch=false` (33/33)
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/web exec eslint src/data-sources/api.ts src/data-sources/types.ts src/stores/dataSources.ts src/views/DataSourcesView.vue tests/data-sources-ui.spec.ts tests/data-sources-api-preview.spec.ts --max-warnings=0`
- `git diff --check`

## Notes
- This PR intentionally targets #2172's branch as its base. After #2172 merges, rebase/retarget this PR onto `main` before final squash.
- Browser/manual visual smoke not run in this turn; coverage is via jsdom UI specs + type/lint gates.
