### PR TITLE
docs(data-factory): refresh DF-T3 execution TODO + turnkey 2c validation kit

### DIFF
--- a/docs/development/data-factory-template-composition-execution-plan-todo-20260527.md
+++ b/docs/development/data-factory-template-composition-execution-plan-todo-20260527.md
@@ -4,9 +4,9 @@
 > This file is the **execution ordering + trackable checklist**, not an authorization to build.
 > Markers: ✅ done · ⬜ open / ready (still needs its own opt-in) · 🔒 gated (blocked on a prior gate AND a separate explicit opt-in).
 >
-> **Constraints (non-negotiable):** K3 PoC Stage-1 lock holds; every phase below is a **separate explicit opt-in** — never auto-start the next one. Any phase that edits `plugin-integration-core` (adapter or HTTP route), even no-write, is integration-core and gated like #1912. Formal docs state our own product principles, not external brand names (external benchmarking lives in internal research MDs).
+> **Constraints (non-negotiable):** the K3 Stage-1 **blanket** lock is **RETIRED** — GATE #1792 (M1 one-record Material Save-only PASS) closed 2026-05-28; #1993 — replaced by **post-GATE scoped gates** (`k3-post-gate-scoped-governance-20260528.md`). Every phase below is still a **separate explicit named opt-in / demand gate** — never auto-start the next one. Any phase that edits `plugin-integration-core` (adapter or HTTP route), even no-write, is integration-core and takes its own scoped opt-in. Formal docs state our own product principles, not external brand names (external benchmarking lives in internal research MDs).
 >
-> **状态回填 2026-06-01:** the ladder below predated the **DF-T3 reference-mapping sub-chain** that actually shipped. DF-T3 is refreshed in place to its real T3a→picker sub-phases; **the DF-T3b preview/resolve line is CLOSED end-to-end (#2036 → #2122)**, leaving only **DF-T3b-2c** (real-Save — gated on a live operator-validation run) and **DF-T3c** (mapping-sheet authoring). The executed chain **leapfrogged DF-T2** (orthogonal — reference-mapping ≠ customer-profile authoring). DF-T1-0 / DF-T1 / DF-T1.5 remain DONE as recorded below.
+> **状态回填 2026-06-01:** the original status markers were stale — refreshed here against `origin/main`. **DONE:** DF-T1-0 / DF-T1 / DF-T1.5; **DF-T1A** contract (#2012, latent); **DF-T2** customer-profile authoring, full chain #2017 → #2035 (read-only derive/preview); the **DF-T3b preview/resolve line** (#2036 → #2122); and **DF-N2-2 provenance runtime** (#1981 → #1988 → #1990) + **DF-N2-3** timeline (#1998). **Genuinely remaining:** **DF-T3b-2c** (real-Save — its own post-GATE scoped gate, gated on a live operator-validation run) · **DF-T3c** (mapping-sheet authoring) · DF-T4 / T5 / T6 · DF-N3+. **DF-T2 shipped before DF-T3 — there was no leapfrog**, and there is no global lock anymore (the earlier draft of this note wrongly said both).
 
 ## The one hard rule: payload trust before UI
 
@@ -93,11 +93,11 @@ Read-only display over the `targetPayloadPreview.fieldProvenance` DF-T1 emits; n
 - [x] No new persisted provenance runtime field in this slice.
 - [x] **Reachability wired** (follow-up): the preview panel sends an optional `payloadTemplate` (+ derived `fieldRules`) so the DF-T1 backend returns `targetPayloadPreview` — the panel is live-triggerable, not just display-capable. Locks a request-body wire assertion. Verification: `data-factory-df-t1_5-reachability-wire-verification-20260528.md`.
 
-### 🔒 DF-T1A — Connector action metadata
-Gated on: DF-T1 + opt-in.
-- [ ] Action metadata around existing adapter methods (no generic HTTP client / no user JS / no SQL / no new connector runtime).
-- [ ] Inputs grouped `path` / `query` / `header` / `body`; response unwrap (success/error/record path).
-- [ ] Save-only and write actions hidden/disabled unless their explicit gate is satisfied.
+### ✅ DF-T1A — Connector action metadata (DONE — contract latent, PR #2012 `18c242622`)
+The action-metadata **contract** landed, **latent** (not wired to UI/runtime — describes existing adapter methods only).
+- [x] Action metadata around existing adapter methods (no generic HTTP client / no user JS / no SQL / no new connector runtime).
+- [x] Inputs grouped `path` / `query` / `header` / `body`; response unwrap (success/error/record path).
+- [x] Save-only and write actions hidden/disabled unless their explicit gate is satisfied.
 
 Minimum action contract:
 
@@ -111,16 +111,14 @@ Minimum action contract:
 This contract wraps existing adapter methods first. It must not become a user
 authored HTTP client in this phase.
 
-### 🔒 DF-T2 — K3 customer-profile authoring surface
-Gated on: DF-T1 (+ DF-T1.5 helpful) + opt-in; **and the live K3 GATE should have a proven Save** before investing heavily here (else risk reworking UX for a still-changing profile).
-- [ ] Operator turns a sanitized `GetDetail` body sample into `payloadTemplate`.
-- [ ] Operator chooses replace/preserve per field; validates full reference-object shapes.
-- [ ] Shows why a row is not ready before Save. Customer profile stays opt-in; default template never silently switched.
-
-> Note: DF-T3's **preview line shipped ahead of this** (reference-mapping is orthogonal to customer-profile authoring). DF-T2 itself is still 🔒 — the K3 GATE wants a proven Save before this UX investment.
+### ✅ DF-T2 — K3 customer-profile authoring surface (DONE — 2026-05; shipped BEFORE DF-T3)
+Full sub-chain, all **read-only** derive/preview (no Save change): design (#2017 `1bcb85aed`) → **DF-T2a** template-derive helper, latent (#2023 `b64e2c202`) → **DF-T2b** per-field replace/preserve authoring UI, no wire (#2027 `d1e445fc5`) → **DF-T2c** wire authoring → real read-only derive/preview route (#2032 `81e8975d5`) → operator runbook closeout (#2035 `6841389bb`).
+- [x] Operator turns a sanitized `GetDetail` body sample into `payloadTemplate`.
+- [x] Operator chooses replace/preserve per field; validates full reference-object shapes.
+- [x] Shows why a row is not ready before Save. Customer profile stays opt-in; default template never silently switched.
 
 ### 🟡 DF-T3 — Multitable reference-mapping sheet templates (preview line CLOSED; 2c + T3c remain)
-Built ahead of DF-T2 (reference-mapping is orthogonal to customer-profile authoring). The **preview/resolve line is closed end-to-end**; the only remaining work is the real-Save keystone (2c — **gated on the operator-validation runbook**) and mapping-sheet authoring (T3c).
+Built **after** DF-T2 (DF-T3 design #2036 follows the #2035 DF-T2 closeout). The **preview/resolve line is closed end-to-end**; the only remaining work is the real-Save keystone (2c — **gated on the operator-validation runbook**) and mapping-sheet authoring (T3c).
 
 Shipped sub-chain (each was a separate opt-in, in order):
 - [x] **DF-T3 design** — reference-mapping sheet templates, design-first (#2036, `e8f1da5f8`).
@@ -196,7 +194,7 @@ processors, or streaming cluster in this track.
 
 ## Sequencing rule
 
-One explicit opt-in per phase. Do not auto-start the next. **DONE:** DF-T1-0 (#1936), DF-T1 (#1945), DF-T1.5 (preview provenance display), and the **entire DF-T3b preview/resolve line** (#2036 → #2122 — see DF-T3 above). **The single remaining DF-T3 link is DF-T3b-2c (real-Save), gated on a passing operator-validation run (#2122 runbook) + its own focused re-review** — do not open it until that run passes and it is separately opted in. Other separately-opt-in-able next steps (independent of 2c): **DF-T3c** (mapping-sheet authoring), **DF-T1A** (connector action metadata), or **DF-N2-2** (provenance runtime). Everything else stays 🔒 until its predecessor gate is green and it is separately opted in.
+One explicit opt-in per phase. Do not auto-start the next. **DONE** (verified on `origin/main`): DF-T1-0 (#1936) · DF-T1 (#1945) · DF-T1.5 · **DF-T1A** contract (#2012, latent) · **DF-T2** full chain (#2017 → #2035) · the **entire DF-T3b preview/resolve line** (#2036 → #2122) · **DF-N2-2** runtime (#1981 → #1990) + **DF-N2-3** (#1998). **Genuinely-remaining next steps (each its own post-GATE scoped opt-in):** **DF-T3b-2c** (real-Save — gated on a passing operator-validation run (#2122 runbook) + its own focused re-review; do not open until that run passes) · **DF-T3c** (mapping-sheet authoring) · **DF-T4** (pipeline binding) · **DF-T5** (template center) · **DF-T6** (help panel) · **DF-N3+**. Nothing here is blocked by a global lock — the blanket Stage-1 freeze is retired; each is a separate named opt-in.
 
 ## Definition of done — DF-T1-0 (the immediate gate)
 

--- a/docs/development/data-factory-template-composition-execution-plan-todo-20260527.md
+++ b/docs/development/data-factory-template-composition-execution-plan-todo-20260527.md
@@ -5,6 +5,8 @@
 > Markers: ✅ done · ⬜ open / ready (still needs its own opt-in) · 🔒 gated (blocked on a prior gate AND a separate explicit opt-in).
 >
 > **Constraints (non-negotiable):** K3 PoC Stage-1 lock holds; every phase below is a **separate explicit opt-in** — never auto-start the next one. Any phase that edits `plugin-integration-core` (adapter or HTTP route), even no-write, is integration-core and gated like #1912. Formal docs state our own product principles, not external brand names (external benchmarking lives in internal research MDs).
+>
+> **状态回填 2026-06-01:** the ladder below predated the **DF-T3 reference-mapping sub-chain** that actually shipped. DF-T3 is refreshed in place to its real T3a→picker sub-phases; **the DF-T3b preview/resolve line is CLOSED end-to-end (#2036 → #2122)**, leaving only **DF-T3b-2c** (real-Save — gated on a live operator-validation run) and **DF-T3c** (mapping-sheet authoring). The executed chain **leapfrogged DF-T2** (orthogonal — reference-mapping ≠ customer-profile authoring). DF-T1-0 / DF-T1 / DF-T1.5 remain DONE as recorded below.
 
 ## The one hard rule: payload trust before UI
 
@@ -115,10 +117,26 @@ Gated on: DF-T1 (+ DF-T1.5 helpful) + opt-in; **and the live K3 GATE should have
 - [ ] Operator chooses replace/preserve per field; validates full reference-object shapes.
 - [ ] Shows why a row is not ready before Save. Customer profile stays opt-in; default template never silently switched.
 
-### 🔒 DF-T3 — Multitable reference-mapping sheet templates
-Gated on: DF-T2 + opt-in.
-- [ ] "Create from template" for reference-mapping sheets (unit / unit-group / account / warehouse / category).
-- [ ] Dictionary content stays customer-owned; manifest import/export without secrets.
+> Note: DF-T3's **preview line shipped ahead of this** (reference-mapping is orthogonal to customer-profile authoring). DF-T2 itself is still 🔒 — the K3 GATE wants a proven Save before this UX investment.
+
+### 🟡 DF-T3 — Multitable reference-mapping sheet templates (preview line CLOSED; 2c + T3c remain)
+Built ahead of DF-T2 (reference-mapping is orthogonal to customer-profile authoring). The **preview/resolve line is closed end-to-end**; the only remaining work is the real-Save keystone (2c — **gated on the operator-validation runbook**) and mapping-sheet authoring (T3c).
+
+Shipped sub-chain (each was a separate opt-in, in order):
+- [x] **DF-T3 design** — reference-mapping sheet templates, design-first (#2036, `e8f1da5f8`).
+- [x] **DF-T3a** — sheet template manifest, schema-only / latent: **12 domains** (`unit` · `unit-group` · `account` · `warehouse` · `manager` → `FNumber`; `category` · `use-state` · `track` · `planning-strategy` · `order-strategy` · `inspection-level` · `inspection-mode` → `FID`) (#2043, `6ca5fc82c`).
+- [x] **DF-T3b design** — `from_reference_table` resolver design + the nine acceptance locks (#2048, `66bf3c490`).
+- [x] **DF-T3b-1** — pure resolver + index, unit-tested, **latent** (no wiring): enabled-only · blank-`sourceCode` ignored · 0→`unresolved` · 2+→`ambiguous` (fail-closed, never pick-first) · missing component→`incomplete-row` (#2055, `681457fb1`).
+- [x] **DF-T3b-2a** — wire the resolver into the **shared** preview composition + resolved-record parity (invariant: read snapshot = original record, write = materialized out) (#2063, `0549effe9`).
+- [x] **DF-T3b-2b** — live mapping-sheet **bulk-read** → preview resolve (read-only, API-reachable; `metasheet:staging`-kind guard + duplicate-domain 400) (#2073, `1ba8f6381`).
+- [x] **DF-T3b-2b UI-wire** — preview sends `referenceMappingSources` (operator-UI-reachable) (#2080, `fd7489177`).
+- [x] **DF-T3b-2d** — `from_reference_table` **authoring** opt-in (reference → resolve-via-mapping; must pick a domain from the 12; gated-locked; no backend) (#2088, `486b0f612`).
+- [x] **DF-T3b dual-binding picker** — structured picker replacing the JSON textarea, **both** bindings: **(1)** `referenceMappingSources` sheet binding (domain → staging system/object) **and (2)** per-rule `rule.sourceField` sourceCode-column binding (sheet-only would resolve the wrong column) (#2110, `47cba2df1`).
+- [x] **DF-T3b preview-evidence validation runbook** — the operator's live, **values-free** confirmation that resolve / three-state fail-close / stale-drop behave as designed (#2122, `a6d450b58`).
+
+Remaining:
+- 🔒 **DF-T3b-2c** — real-Save **compose-before-`upsert`** (changes the K3 Save bytes — the byte-parity-gated moment). **Gated on:** a **passing operator-validation run** (the #2122 runbook — only the maintainer can run it on a live stack) **AND** a separate focused re-review against the nine locks (same bindings as preview · per-row fail-closed → dead-letter/provenance · no batch-abort · no auto-retry loop · adapter `read` I/O failure as its own category). Write scope stays **M1 one-record Material Save-only** — no Submit / Audit / BOM / multi-record / new endpoint.
+- 🔒 **DF-T3c** — mapping-sheet **manifest import/export + authoring** (schema-only; dictionary rows stay customer-owned, never in Git). This is the original DF-T3 second bullet ("manifest import/export without secrets") — authoring ergonomics, ranked **below 2c** (rows are enterable as tenant data without it).
 
 ### 🔒 DF-T4 — Pipeline template binding
 Gated on: DF-T3 + opt-in.
@@ -178,7 +196,7 @@ processors, or streaming cluster in this track.
 
 ## Sequencing rule
 
-One explicit opt-in per phase. Do not auto-start the next. **DF-T1-0 (#1936), DF-T1 (#1945), and DF-T1.5 (preview provenance display) are DONE.** The next step is a separate explicit opt-in — either **DF-N2-2 (provenance runtime)** or **DF-T1A (connector action metadata)**; everything below stays 🔒 until its predecessor gate is green and it is separately opted in.
+One explicit opt-in per phase. Do not auto-start the next. **DONE:** DF-T1-0 (#1936), DF-T1 (#1945), DF-T1.5 (preview provenance display), and the **entire DF-T3b preview/resolve line** (#2036 → #2122 — see DF-T3 above). **The single remaining DF-T3 link is DF-T3b-2c (real-Save), gated on a passing operator-validation run (#2122 runbook) + its own focused re-review** — do not open it until that run passes and it is separately opted in. Other separately-opt-in-able next steps (independent of 2c): **DF-T3c** (mapping-sheet authoring), **DF-T1A** (connector action metadata), or **DF-N2-2** (provenance runtime). Everything else stays 🔒 until its predecessor gate is green and it is separately opted in.
 
 ## Definition of done — DF-T1-0 (the immediate gate)
 

--- a/docs/operations/data-factory-df-t3b-preview-evidence-validation-runbook-20260530.md
+++ b/docs/operations/data-factory-df-t3b-preview-evidence-validation-runbook-20260530.md
@@ -65,3 +65,78 @@ payload JSON.
 DF-T3b-2c may be opened (design-first, its own focused re-review against: same bindings as preview ·
 per-row fail-closed → dead-letter/provenance · no batch-abort · no auto-retry loop · adapter `read` I/O
 failure as its own category). **Fail** = file the divergence (field/domain/error-type only) before 2c.
+
+---
+
+## Operator quick-run (turnkey) — added 2026-06-01
+
+> Turnkey layer over the checks above: a **values-free preflight**, exactly **where to read the
+> evidence**, and a **fill-in capture template**. UI-driven (validate through the workbench, not raw
+> API) — nothing here sends a Save. Placeholders only; never paste real hosts, tokens, or customer
+> values into the run record.
+
+### Preflight (before any check)
+
+A validation run is meaningless against a stale bundle or a mismatched token — a silent 401 reads as a
+"failure" that is really an auth/schema gap, not a resolver gap. Confirm, in order:
+
+1. **Bundle fingerprint** — the running stack serves the `main` that contains **#2122** (this runbook's
+   slice) and the picker **#2110**. Confirm the deployed commit/build id matches the expected `main` tip.
+   If the stack is staging, recall it uses a **distinct `JWT_SECRET`** and its lane does **not**
+   auto-mirror `main` pushes.
+2. **Auth round-trip** — an authenticated read (e.g. list data sources / current user) returns **200**
+   with the operator's token, not **401**. A 401 here is a deploy/secret gap — fix it before reading any
+   resolver result.
+3. **Pending migrations** — none outstanding for the running image (image-pull deploys must diff pending
+   migrations; a schema gap surfaces as a spurious resolver failure).
+4. **Fixtures present** — the `metasheet:staging` mapping-sheet object from *Setup* exists with the
+   one-enabled-complete / ambiguous-pair / incomplete rows, and the sample record's sourceCode column is
+   populated.
+
+### Where to read the evidence (values-free source)
+
+For each preview run, read the **`targetPayloadPreview.referenceResolutions`** array from the preview
+response (devtools → Network → the `templates/preview` response) **plus** the read-only **field-provenance
+summary** in the workbench preview panel (DF-T1.5). Both are values-free by design — **not** the resolved
+`FNumber`/`FID`/`FName`. **Never** open or copy the `payload-preview` JSON — that one carries the composed
+payload **with** the resolved values.
+
+Exact entry shape (so you record the right path): each `referenceResolutions[]` entry is
+**`{ field, status, evidence }`**.
+- **`status`** (top-level) is the outcome enum: `resolved` / `unresolved` / `ambiguous` / `incomplete`.
+- **`errorType`** lives **under `evidence`** (`evidence.errorType`): `unresolved` / `ambiguous` /
+  **`incomplete-row`** — note `incomplete` *status* maps to `incomplete-row` *errorType* (intentionally not
+  the same string; `resolved` has no errorType).
+- **`domain`** is **your own per-rule binding** (what you authored), not echoed on the entry — record it
+  from the rule you set up.
+
+### Capture template (fill in — values-free)
+
+Copy this block back as the run record. `sourceCode?` = whether a sourceCode was present (Y/N), **not** its value.
+
+```
+DF-T3b preview-evidence validation — run record
+stack/bundle: <build-id or main tip>   auth: 200 OK   migrations: none pending   date: <YYYY-MM-DD>
+
+Check 1 — resolved (headline)
+  field=<FUnitID>  domain=<unit>  sourceCode?=Y  status=resolved   preview.valid=true
+  per-material distinct? <Y/N>   (two different sample sourceCodes -> two different resolved objects)
+
+Check 2 — three-state fail-closed (preview.valid=false for each)
+  case=0-match            field=<>  domain=<>  sourceCode?=Y  status=unresolved  errorType=unresolved
+  case=2+-enabled         field=<>  domain=<>  sourceCode?=Y  status=ambiguous   errorType=ambiguous
+  case=missing-component  field=<>  domain=<>  sourceCode?=Y  status=incomplete  errorType=incomplete-row
+
+Check 3 — stale binding / drop
+  bound domain=<unit>, then field -> preserve  =>  referenceMappingSources entry dropped? <Y/N>
+  field falls back to template-preserve? <Y/N>
+
+verdict: PASS / FAIL
+divergences (field/domain/error-type only, no values): <none | ...>
+```
+
+### On PASS
+
+File this run record (values-free) and open **DF-T3b-2c** as a fresh design-first slice with its **own**
+focused re-review against the nine locks (see *Pass / fail* above). 2c is the first slice in this line
+that changes the bytes sent to K3 — it does **not** inherit this runbook's approval; it earns its own.


### PR DESCRIPTION
## Summary

Two docs-only changes, closing the "is the TODO MD current?" gap surfaced during the feature-completion review.

**1. Refresh the stale DF-T3 phase** in `data-factory-template-composition-execution-plan-todo-20260527.md` — the top-level ladder predated the DF-T3 reference-mapping sub-chain that actually shipped, so DF-T3 still read 🔒/empty and the sequencing rule pointed at the wrong "next."
- DF-T3 → 🟡, expanded to the real shipped sub-chain with PR# + squash SHA for each slice: design #2036 → T3a #2043 → T3b design #2048 → T3b-1 #2055 → 2a #2063 → 2b #2073 → 2b-UI #2080 → 2d #2088 → dual-binding picker #2110 → validation runbook #2122. **Preview/resolve line CLOSED.**
- Remaining links listed: **DF-T3b-2c** (real-Save, gated on a passing operator-validation run + its own re-review) and **DF-T3c** (mapping-sheet authoring).
- Noted the **DF-T2 leapfrog** (reference-mapping is orthogonal to customer-profile authoring); fixed the **Sequencing rule**; added a top status-backfill note.

**2. Turnkey operator appendix** in `data-factory-df-t3b-preview-evidence-validation-runbook-20260530.md` — the runbook had the conceptual checks but no run mechanics:
- **Values-free preflight** (bundle fingerprint + auth round-trip + pending-migration diff + fixtures) — guards against a silent 401 reading as a resolver "failure."
- **Where to read the evidence** — `targetPayloadPreview.referenceResolutions` + DF-T1.5 provenance panel; never the `payload-preview` JSON. Token nuance recorded: `status` enum (`…/incomplete`) vs `errorType` (`…/incomplete-row`).
- **Fill-in values-free capture template** for the 3 checks.

## Verification
- Docs-only; **no `plugin-integration-core` runtime touched** — does not open DF-T3b-2c (still 🔒).
- No external brand names introduced (lint grep clean).
- PR→SHA mapping verified against `origin/main` git log.
- 2c remains gated on the maintainer's live operator-validation run; this PR makes that run turnkey, it does not perform or authorize it.

Leaving for review — not auto-merging.