### PR TITLE
fix(multitable): mask cross-sheet related echoes

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -160,7 +160,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + dashboard authz + automation retry provenance)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + dashboard authz + cross-sheet related echo + automation retry provenance)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -180,6 +180,7 @@ jobs:
             tests/integration/multitable-records-summary-field-mask.test.ts \
             tests/integration/multitable-dashboard-chart-authz.test.ts \
             tests/integration/multitable-write-echo-field-mask.test.ts \
+            tests/integration/multitable-cross-sheet-related-echo-mask.test.ts \
             tests/integration/multitable-automation-retry.test.ts \
             tests/integration/multitable-automation-jobs.test.ts \
             --reporter=dot

--- a/docs/development/multitable-cross-sheet-related-echo-mask-verification-20260601.md
+++ b/docs/development/multitable-cross-sheet-related-echo-mask-verification-20260601.md
@@ -1,0 +1,63 @@
+# Multitable cross-sheet related echo mask verification
+
+**Date:** 2026-06-01
+**Design-lock:** `docs/development/multitable-cross-sheet-related-echo-mask-design-20260601.md` (#2176)
+**Scope:** cross-sheet `relatedRecords` write echo from `POST /patch`; no realtime broadcast, F4 create echo, or F5 summary paths.
+
+## Implementation
+
+`computeDependentLookupRollupRecords` now computes a per-related-sheet allowed-field set before emitting related computed records:
+
+1. Group dependent records by their own `sheetId`.
+2. Resolve `resolveSheetReadableCapabilities(req, query, relatedSheetId)`.
+3. Drop the related sheet if there is no subject or `canRead=false`.
+4. Load that related sheet's `field_permissions` for the subject.
+5. Reuse `computeAllowedFieldIds(fields, capabilities, fieldScopeMap)` — layer-2 `property.hidden` ∧ layer-3 `field_permissions.visible`, with `hiddenFieldIds: []`.
+6. Emit `filterRecordDataByFieldIds(extractLookupRollupData(fields, row.data), allowedFieldIds)`.
+
+This deliberately does **not** reuse the edited sheet's F3 `readableEchoFieldIds`. `RecordWriteService` remains permission-service agnostic; the fix stays at the route helper / producer seam.
+
+## Fail-first proof
+
+New real-DB test: `packages/core-backend/tests/integration/multitable-cross-sheet-related-echo-mask.test.ts`.
+
+Temporary pre-fix run, with only the implementation hunk reverted and the new test kept:
+
+```text
+FAIL R1-R4/R6: expected [ Array(1) ] to be undefined
+at B_LOOKUP_SECRET
+```
+
+That is the live leak: a user who can write source sheet A and read related sheet B, but has `field_permissions.visible=false` for B's computed lookup field, received `relatedRecords[].data[B_LOOKUP_SECRET]` containing the secret lookup value.
+
+R5 stayed green in the pre-fix run, confirming the existing sheet-level `resolveReadableSheetIds` boundary: unreadable related sheets were already dropped. The fix targets field-level masking within readable related sheets.
+
+## Tests
+
+Local verification against a fresh migrated `metasheet_test`:
+
+```text
+DATABASE_URL=postgresql:///metasheet_test pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-cross-sheet-related-echo-mask.test.ts
+✓ 3 passed
+
+DATABASE_URL=postgresql:///metasheet_test pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-write-echo-field-mask.test.ts
+✓ 5 passed
+
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-record-patch.api.test.ts
+✓ 6 passed
+
+pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-patch-partial-success.api.test.ts
+✓ 2 passed
+
+pnpm --filter @metasheet/core-backend exec tsc --noEmit
+✓ clean
+```
+
+The new test is wired into `.github/workflows/plugin-tests.yml` under the existing Node 20.x real-DB multitable integration step, so CI must run it against fresh Postgres.
+
+## What remains out of scope
+
+- Realtime broadcast unmasked patches (`record-write-service.ts` broadcast payload) — separate per-recipient design.
+- F4 create echo.
+- F5 link-options/person-fields.
+- Full field-definition strip.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1868,10 +1868,20 @@ async function computeDependentLookupRollupRecords(
     fieldsBySheet.set(sheetId, list)
   }
 
+  const allowedFieldIdsBySheet = new Map<string, Set<string>>()
+  for (const sheetId of rowsBySheet.keys()) {
+    const fields = fieldsBySheet.get(sheetId) ?? []
+    if (fields.length === 0) continue
+    const { access, capabilities } = await resolveSheetReadableCapabilities(req, query, sheetId)
+    if (!access.userId || !capabilities.canRead) continue
+    const fieldScopeMap = await loadFieldPermissionScopeMap(query, sheetId, access.userId)
+    allowedFieldIdsBySheet.set(sheetId, computeAllowedFieldIds(fields, capabilities, fieldScopeMap))
+  }
+
   const results: RelatedComputedRecord[] = []
-  const readableSheetIds = await resolveReadableSheetIds(req, query, rowsBySheet.keys())
   for (const [sheetId, rows] of rowsBySheet.entries()) {
-    if (!readableSheetIds.has(sheetId)) continue
+    const allowedFieldIds = allowedFieldIdsBySheet.get(sheetId)
+    if (!allowedFieldIds) continue
     const fields = fieldsBySheet.get(sheetId) ?? []
     if (fields.length === 0) continue
     const hasComputed = fields.some((f) => f.type === 'lookup' || f.type === 'rollup')
@@ -1893,7 +1903,7 @@ async function computeDependentLookupRollupRecords(
       results.push({
         sheetId,
         recordId: row.id,
-        data: extractLookupRollupData(fields, row.data),
+        data: filterRecordDataByFieldIds(extractLookupRollupData(fields, row.data), allowedFieldIds),
       })
     }
   }

--- a/packages/core-backend/tests/integration/multitable-cross-sheet-related-echo-mask.test.ts
+++ b/packages/core-backend/tests/integration/multitable-cross-sheet-related-echo-mask.test.ts
@@ -1,0 +1,151 @@
+/**
+ * Real-DB integration test for cross-sheet related write echoes.
+ * Design-lock: docs/development/multitable-cross-sheet-related-echo-mask-design-20260601.md.
+ *
+ * POST /patch recomputes lookup/rollup dependents through computeDependentLookupRollupRecords().
+ * Same-sheet dependents are masked by the edited sheet's F3 echo set, but cross-sheet dependents
+ * were returned as-is. This test proves the related sheet's field-read gate is applied per sheet.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_xrel_${TS}`
+const SHEET_A = `sheet_xrel_a_${TS}`
+const SHEET_B = `sheet_xrel_b_${TS}`
+const SHEET_C = `sheet_xrel_c_${TS}`
+
+const A_EDIT = `fld_xrel_a_edit_${TS}`
+const A_VISIBLE = `fld_xrel_a_visible_${TS}`
+const A_SECRET = `fld_xrel_a_secret_${TS}`
+const A_SELF_LINK = `fld_xrel_a_self_link_${TS}`
+const A_SELF_LOOKUP = `fld_xrel_a_self_lookup_${TS}`
+
+const B_LINK = `fld_xrel_b_link_${TS}`
+const B_LOOKUP_VISIBLE = `fld_xrel_b_lookup_visible_${TS}`
+const B_LOOKUP_SECRET = `fld_xrel_b_lookup_secret_${TS}`
+const B_LOOKUP_HIDDEN = `fld_xrel_b_lookup_hidden_${TS}`
+
+const C_LINK = `fld_xrel_c_link_${TS}`
+const C_LOOKUP_VISIBLE = `fld_xrel_c_lookup_visible_${TS}`
+
+const A_REC = `rec_xrel_a_${TS}`
+const A_DEP = `rec_xrel_a_dep_${TS}`
+const B_REC = `rec_xrel_b_${TS}`
+const C_REC = `rec_xrel_c_${TS}`
+
+const USER_DENIED = `u_xrel_denied_${TS}`
+const USER_SHEET_A_ONLY = `u_xrel_a_only_${TS}`
+
+const VISIBLE_CANARY = `visible-cross-related-${TS}`
+const SECRET_CANARY = `do-not-leak-cross-related-${TS}`
+
+let app: Express
+let currentUser: { id: string; roles: string[]; perms: string[] } = {
+  id: USER_DENIED,
+  roles: ['member'],
+  perms: ['multitable:write'],
+}
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const batchPatch = (value: string) =>
+  request(app).post('/api/multitable/patch').send({
+    sheetId: SHEET_A,
+    changes: [{ recordId: A_REC, fieldId: A_EDIT, value }],
+  })
+
+const related = (body: any, sheetId: string, recordId: string) =>
+  body.data?.relatedRecords?.find((r: { sheetId: string; recordId: string }) => r.sheetId === sheetId && r.recordId === recordId)
+
+const sameSheetRecord = (body: any, recordId: string) =>
+  body.data?.records?.find((r: { recordId: string }) => r.recordId === recordId)
+
+describeIfDatabase('cross-sheet related write echo field mask (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = currentUser; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'Cross Related Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_A, BASE_ID, 'Source'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_B, BASE_ID, 'Dependent B'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_C, BASE_ID, 'Dependent C'])
+
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [A_EDIT, SHEET_A, 'Edit', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [A_VISIBLE, SHEET_A, 'Visible', 'string', '{}', 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [A_SECRET, SHEET_A, 'Secret Source', 'string', '{}', 3])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [A_SELF_LINK, SHEET_A, 'Self Link', 'link', JSON.stringify({ foreignSheetId: SHEET_A }), 4])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [A_SELF_LOOKUP, SHEET_A, 'Self Lookup', 'lookup', JSON.stringify({ linkFieldId: A_SELF_LINK, targetFieldId: A_VISIBLE, foreignSheetId: SHEET_A }), 5])
+
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [B_LINK, SHEET_B, 'Source Link', 'link', JSON.stringify({ foreignSheetId: SHEET_A }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [B_LOOKUP_VISIBLE, SHEET_B, 'Visible Lookup', 'lookup', JSON.stringify({ linkFieldId: B_LINK, targetFieldId: A_VISIBLE, foreignSheetId: SHEET_A }), 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [B_LOOKUP_SECRET, SHEET_B, 'Secret Lookup', 'lookup', JSON.stringify({ linkFieldId: B_LINK, targetFieldId: A_SECRET, foreignSheetId: SHEET_A }), 3])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [B_LOOKUP_HIDDEN, SHEET_B, 'Static Hidden Lookup', 'lookup', JSON.stringify({ linkFieldId: B_LINK, targetFieldId: A_SECRET, foreignSheetId: SHEET_A, hidden: true }), 4])
+
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [C_LINK, SHEET_C, 'Source Link', 'link', JSON.stringify({ foreignSheetId: SHEET_A }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [C_LOOKUP_VISIBLE, SHEET_C, 'Visible Lookup', 'lookup', JSON.stringify({ linkFieldId: C_LINK, targetFieldId: A_VISIBLE, foreignSheetId: SHEET_A }), 2])
+
+    await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [A_REC, SHEET_A, JSON.stringify({ [A_EDIT]: 'initial', [A_VISIBLE]: VISIBLE_CANARY, [A_SECRET]: SECRET_CANARY }), USER_DENIED])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [A_DEP, SHEET_A, '{}', USER_DENIED])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [B_REC, SHEET_B, '{}', USER_DENIED])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version, created_by) VALUES ($1,$2,$3::jsonb,1,$4)', [C_REC, SHEET_C, '{}', USER_DENIED])
+
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [A_SELF_LINK, A_DEP, A_REC])
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [B_LINK, B_REC, A_REC])
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [C_LINK, C_REC, A_REC])
+
+    // Deny solely at layer-3: B_LOOKUP_SECRET.property.hidden is unset.
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_B, B_LOOKUP_SECRET, 'user', USER_DENIED, false, false])
+    // Sheet-only user can edit A but cannot read B/C, pinning the existing unreadable-related-sheet drop behavior.
+    await q('INSERT INTO spreadsheet_permissions(sheet_id, user_id, subject_type, subject_id, perm_code) VALUES ($1,$2,$3,$4,$5)', [SHEET_A, USER_SHEET_A_ONLY, 'user', USER_SHEET_A_ONLY, 'spreadsheet:write'])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_links WHERE field_id = ANY($1::text[])', [[A_SELF_LINK, B_LINK, C_LINK]]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B, SHEET_C]]).catch(() => {})
+    await q('DELETE FROM spreadsheet_permissions WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B, SHEET_C]]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B, SHEET_C]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B, SHEET_C]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SHEET_A, SHEET_B, SHEET_C]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('R1-R4/R6: cross-sheet related echoes are masked per related sheet while same-sheet echo still works', async () => {
+    currentUser = { id: USER_DENIED, roles: ['member'], perms: ['multitable:write'] }
+    const res = await batchPatch(`edit-${TS}-1`)
+    expect(res.status, JSON.stringify(res.body)).toBe(200)
+
+    const b = related(res.body, SHEET_B, B_REC)
+    expect(b).toBeDefined()
+    expect(b.data[B_LOOKUP_VISIBLE]).toEqual([VISIBLE_CANARY]) // positive control: cross-sheet data is not dropped
+    expect(b.data[B_LOOKUP_SECRET]).toBeUndefined() // R1: layer-3 denied computed field omitted
+    expect(b.data[B_LOOKUP_HIDDEN]).toBeUndefined() // R3: layer-2 hidden computed field omitted
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY)
+
+    const c = related(res.body, SHEET_C, C_REC)
+    expect(c).toBeDefined()
+    expect(c.data[C_LOOKUP_VISIBLE]).toEqual([VISIBLE_CANARY]) // R4: independent per-related-sheet allow set
+
+    const same = sameSheetRecord(res.body, A_DEP)
+    expect(same).toBeDefined()
+    expect(same.data[A_SELF_LOOKUP]).toEqual([VISIBLE_CANARY]) // R6: same-sheet related echo regression guard
+  })
+
+  test('R5: unreadable related sheets are dropped rather than returned with empty data', async () => {
+    currentUser = { id: USER_SHEET_A_ONLY, roles: ['member'], perms: ['comments:write'] }
+    const res = await batchPatch(`edit-${TS}-2`)
+    expect(res.status, JSON.stringify(res.body)).toBe(200)
+    expect(related(res.body, SHEET_B, B_REC)).toBeUndefined()
+    expect(related(res.body, SHEET_C, C_REC)).toBeUndefined()
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY)
+  })
+})


### PR DESCRIPTION
## Summary
- masks cross-sheet relatedRecords emitted by computeDependentLookupRollupRecords with each related sheet's layer-2 ∧ layer-3 allowed-field set
- preserves existing unreadable-related-sheet drop behavior and same-sheet F3 echo behavior
- wires a real-DB regression into plugin-tests.yml

## Verification
- fail-first: temporarily reverted the implementation hunk; new real-DB test failed at B_LOOKUP_SECRET (field-denied related lookup leaked)
- DATABASE_URL=postgresql:///metasheet_test pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-cross-sheet-related-echo-mask.test.ts — 3 passed
- DATABASE_URL=postgresql:///metasheet_test pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-write-echo-field-mask.test.ts — 5 passed
- DATABASE_URL=postgresql:///metasheet_test pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run [workflow multitable real-DB list incl. new test] — 16 files / 135 tests passed
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-record-patch.api.test.ts — 6 passed
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-patch-partial-success.api.test.ts — 2 passed
- pnpm --filter @metasheet/core-backend exec tsc --noEmit — clean

## Non-goals
- realtime broadcast masking
- F4 create echo
- F5 link-options/person-fields