### PR TITLE
test(multitable): strengthen cross-sheet related echo mask coverage

### DIFF
--- a/packages/core-backend/tests/integration/multitable-cross-sheet-related-echo-mask.test.ts
+++ b/packages/core-backend/tests/integration/multitable-cross-sheet-related-echo-mask.test.ts
@@ -42,6 +42,7 @@ const C_REC = `rec_xrel_c_${TS}`
 
 const USER_DENIED = `u_xrel_denied_${TS}`
 const USER_SHEET_A_ONLY = `u_xrel_a_only_${TS}`
+const USER_GRANTED = `u_xrel_granted_${TS}` // no deny row → per-subject positive control
 
 const VISIBLE_CANARY = `visible-cross-related-${TS}`
 const SECRET_CANARY = `do-not-leak-cross-related-${TS}`
@@ -147,5 +148,22 @@ describeIfDatabase('cross-sheet related write echo field mask (real DB)', () => 
     expect(related(res.body, SHEET_B, B_REC)).toBeUndefined()
     expect(related(res.body, SHEET_C, C_REC)).toBeUndefined()
     expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY)
+  })
+
+  test('per-subject: a user WITHOUT the deny row receives B_LOOKUP_SECRET — the mask is subject-scoped, not global', async () => {
+    // Direct contrast to R1: the SAME B_LOOKUP_SECRET that is masked for USER_DENIED is delivered to a user
+    // who has no field_permissions deny row. This proves the omission in R1 is the field-read gate firing for
+    // that subject — not the field being structurally absent / the lookup failing to resolve. USER_GRANTED has
+    // no deny row and (like USER_DENIED) reads sheet B under the default-allow sheet model, so the cross-sheet
+    // echo must carry the resolved value verbatim.
+    currentUser = { id: USER_GRANTED, roles: ['member'], perms: ['multitable:write'] }
+    const res = await batchPatch(`edit-${TS}-3`)
+    expect(res.status, JSON.stringify(res.body)).toBe(200)
+    const b = related(res.body, SHEET_B, B_REC)
+    expect(b).toBeDefined()
+    expect(b.data[B_LOOKUP_SECRET]).toEqual([SECRET_CANARY]) // present for the granted subject (was masked for USER_DENIED)
+    expect(b.data[B_LOOKUP_VISIBLE]).toEqual([VISIBLE_CANARY]) // visible field unchanged across subjects
+    expect(b.data[B_LOOKUP_HIDDEN]).toBeUndefined() // layer-2 static-hidden stays omitted for everyone (not subject-scoped)
+    currentUser = { id: USER_DENIED, roles: ['member'], perms: ['multitable:write'] }
   })
 })


### PR DESCRIPTION
**Test-only follow-up** to #2178 (the merged cross-sheet related echo fix, `5377c1830`). No production code touched.

## Context
This session built a parallel fix (#2179) for the same #2176 leak; the parallel session's #2178 merged first, so #2179 was closed as superseded. Per maintainer direction, the one thing worth salvaging from #2179 was its extra **test depth** — ported here onto the merged #2178 implementation.

## What #2178 already covers (not duplicated here)
Its real-DB test is already solid and value-pinned: **R1** (layer-3 deny omitted) · **R3** (layer-2 static-hidden omitted) · **R4** (independent per-related-sheet allow set) · **R5** (unreadable related sheet dropped) · **R6** (same-sheet echo regression). Positive controls resolve to concrete `[VISIBLE_CANARY]` values, and `not.toContain(SECRET_CANARY)` defeats wire-vs-fixture.

## What this adds (the one genuinely-additive case)
A **per-subject positive control**. #2178's R1 proves `B_LOOKUP_SECRET` is omitted for `USER_DENIED`, but never proves a user **without** the deny row receives it — so it can't, on its own, distinguish "masked by the field-read gate" from "absent for an unrelated reason." The new case patches as `USER_GRANTED` (no deny row) and asserts:
- `b.data[B_LOOKUP_SECRET]` **=== `[SECRET_CANARY]`** (present for the granted subject — the same field masked for `USER_DENIED`)
- `B_LOOKUP_VISIBLE` unchanged across subjects
- the layer-2 static-hidden field still omitted for everyone (not subject-scoped)

This makes the mask's **subject-scoping** self-proving in one run rather than inferred from a sibling field.

## Honest scope note
This is a **modest, single-case** strengthening, not a hole-closing fix — #2178 is already non-vacuous. (R-D5 / no-subject from #2179 was intentionally dropped: it only asserts the route 401s before an already-unreachable producer branch — a route-auth precondition, not echo-mask coverage.)

## Verification
- Extends the existing `multitable-cross-sheet-related-echo-mask.test.ts` (already in `plugin-tests.yml`'s DB-gated list) — reuses the seed, **no workflow touch**.
- Local Postgres: **4/4 pass**; the new assertion is a hard value (`toEqual([SECRET_CANARY])`), so it fails if the field were globally masked — non-vacuous.
- `tsc` 0 errors, eslint clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)