### PR TITLE
fix(data-sources): guard schema browser against stale schema responses

### DIFF
--- a/apps/web/src/views/DataSourcesView.vue
+++ b/apps/web/src/views/DataSourcesView.vue
@@ -633,9 +633,16 @@ function closeSchemaBrowser(): void {
 }
 
 async function openPreview(id: string): Promise<void> {
+  const requestedId = id
   activePreviewId.value = id
+  // Clear the prior panel's selection up front so it cannot linger while the new schema loads.
+  previewTable.value = ''
   store.clearPreviewError(id)
   const schema = store.schemas[id] ?? await store.loadSchema(id)
+  // A newer preview may have opened while loadSchema was in flight (fast A→B switch). Drop this
+  // stale response so it cannot set previewTable to the wrong source's table and then run a
+  // cross-source query — runActivePreview() reads the *current* activePreviewId.
+  if (activePreviewId.value !== requestedId) return
   const firstChoice = [
     ...(schema?.tables ?? []),
     ...(schema?.views ?? []),

--- a/apps/web/src/views/DataSourcesView.vue
+++ b/apps/web/src/views/DataSourcesView.vue
@@ -605,8 +605,14 @@ async function testConnection(id: string): Promise<void> {
 }
 
 async function openSchemaBrowser(id: string): Promise<void> {
+  const requestedId = id
   activeSchemaId.value = id
+  // Clear the prior panel's selection up front so it cannot linger while the new schema loads.
+  schemaTable.value = ''
   const schema = store.schemas[id] ?? await store.loadSchema(id)
+  // A newer panel may have opened while loadSchema was in flight (fast A→B switch). Drop this
+  // stale response so it cannot clobber schemaTable or load the wrong source's table info.
+  if (activeSchemaId.value !== requestedId) return
   const firstChoice = tableChoicesFor(schema)[0]
   schemaTable.value = firstChoice?.value ?? ''
   if (firstChoice) {

--- a/apps/web/tests/data-sources-ui.spec.ts
+++ b/apps/web/tests/data-sources-ui.spec.ts
@@ -594,6 +594,57 @@ describe('DataSourcesView (UI-2 connection test reachability)', () => {
     expect(container.querySelector('[data-testid="ds-preview-panel"]')?.textContent).toContain('limit=100')
   })
 
+  it('drops a stale preview schema response: a fast A→B switch never queries A table against B', async () => {
+    listMock.mockResolvedValue([
+      { id: 'a', name: 'Alpha DB', type: 'postgres', connected: true },
+      { id: 'b', name: 'Bravo DB', type: 'postgres', connected: true },
+    ])
+    // A's schema load is parked (slow); B's resolves immediately (fast).
+    let resolveA: ((schema: unknown) => void) | null = null
+    const aSchema = new Promise<unknown>((resolve) => {
+      resolveA = resolve
+    })
+    getSchemaMock.mockImplementation((id: string) =>
+      id === 'a'
+        ? aSchema
+        : Promise.resolve({
+            tables: [{ name: 'b_orders', schema: 'public', columns: [{ name: 'id', type: 'int' }] }],
+          }),
+    )
+    previewRowsMock.mockResolvedValue({
+      data: [{ id: 1, name: 'BravoWidget' }],
+      metadata: { columns: [{ name: 'id', type: 'int' }, { name: 'name', type: 'text' }] },
+    })
+
+    const container = await mountView()
+    const previewButtons = container.querySelectorAll('[data-testid="ds-preview"]')
+    expect(previewButtons).toHaveLength(2)
+
+    // Click preview A (parks on the pending schema), then preview B (resolves fast) before A returns.
+    ;(previewButtons[0] as HTMLButtonElement).click()
+    await flush()
+    ;(previewButtons[1] as HTMLButtonElement).click()
+    await flush()
+    await flush()
+
+    // Only B's bounded select ran.
+    expect(previewRowsMock).toHaveBeenCalledWith('b', { table: 'public.b_orders', limit: 100 })
+    expect(previewRowsMock).toHaveBeenCalledTimes(1)
+
+    // A's slow response now arrives last. Without the guard it would set previewTable to A's table
+    // and runActivePreview() would query previewRows('b', { table: 'public.a_items' }) — a
+    // cross-source wrong query. The guard must drop it.
+    resolveA?.({
+      tables: [{ name: 'a_items', schema: 'public', columns: [{ name: 'id', type: 'int' }] }],
+    })
+    await flush()
+    await flush()
+
+    expect(previewRowsMock).toHaveBeenCalledTimes(1)
+    expect(previewRowsMock).not.toHaveBeenCalledWith('b', { table: 'public.a_items', limit: 100 })
+    expect(container.querySelector('[data-testid="ds-preview-result"]')?.textContent).toContain('BravoWidget')
+  })
+
   it('clears stale preview errors through the cached empty-schema preview path', async () => {
     listMock.mockResolvedValue([{ id: 'pg', name: 'Warehouse DB', type: 'postgres', connected: true }])
 

--- a/apps/web/tests/data-sources-ui.spec.ts
+++ b/apps/web/tests/data-sources-ui.spec.ts
@@ -508,6 +508,59 @@ describe('DataSourcesView (UI-2 connection test reachability)', () => {
     expect(container.querySelectorAll('[data-testid="ds-schema-column"]')).toHaveLength(2)
   })
 
+  it('drops a stale schema response: a fast A→B switch keeps B and never loads A table info', async () => {
+    listMock.mockResolvedValue([
+      { id: 'a', name: 'Alpha DB', type: 'postgres', connected: true },
+      { id: 'b', name: 'Bravo DB', type: 'postgres', connected: true },
+    ])
+    // A's schema load is parked (slow); B's resolves immediately (fast). This is the out-of-order
+    // race: the user clicks A then B before A returns, and A's response arrives last.
+    let resolveA: ((schema: unknown) => void) | null = null
+    const aSchema = new Promise<unknown>((resolve) => {
+      resolveA = resolve
+    })
+    getSchemaMock.mockImplementation((id: string) =>
+      id === 'a'
+        ? aSchema
+        : Promise.resolve({
+            tables: [{ name: 'b_orders', schema: 'public', columns: [{ name: 'id', type: 'int' }] }],
+          }),
+    )
+    getTableInfoMock.mockResolvedValue({
+      name: 'b_orders',
+      schema: 'public',
+      columns: [{ name: 'id', type: 'int', nullable: false, primaryKey: true }],
+    })
+
+    const container = await mountView()
+    const schemaButtons = container.querySelectorAll('[data-testid="ds-schema"]')
+    expect(schemaButtons).toHaveLength(2)
+
+    // Click A (parks on the pending schema), then B (resolves fast) before A returns.
+    ;(schemaButtons[0] as HTMLButtonElement).click()
+    await flush()
+    ;(schemaButtons[1] as HTMLButtonElement).click()
+    await flush()
+    await flush()
+
+    // B is the active panel and only B's table info loaded.
+    const select = container.querySelector('[data-testid="ds-schema-table"]') as HTMLSelectElement
+    expect(select.value).toBe('public.b_orders')
+    expect(getTableInfoMock).toHaveBeenCalledWith('b', 'b_orders', 'public')
+
+    // A's slow response now arrives last — the stale-response guard must drop it.
+    resolveA?.({
+      tables: [{ name: 'a_items', schema: 'public', columns: [{ name: 'id', type: 'int' }] }],
+    })
+    await flush()
+    await flush()
+
+    // Still B: schemaTable not clobbered to A's table, and A's table info was never loaded.
+    expect(select.value).toBe('public.b_orders')
+    expect(getTableInfoMock).not.toHaveBeenCalledWith('a', 'a_items', 'public')
+    expect(container.querySelector('[data-testid="ds-schema-detail"]')?.textContent).toContain('public.b_orders')
+  })
+
   it('opens a read-only SQL table preview via schema + bounded select and renders rows', async () => {
     listMock.mockResolvedValue([
       { id: 'pg', name: 'Warehouse DB', type: 'postgres', connected: true },


### PR DESCRIPTION
Follow-up to the #2173 post-merge review: hardens this view against async schema-browser/preview stale-response races. Read-only boundary unchanged (still `schema` / `tables/:table`, no `/query`, `data_sources:read` + `assertAccess` intact, no new credential read path) — these are UI-state-consistency fixes.

## 1. `openSchemaBrowser` (the originally-flagged one)
`openSchemaBrowser(id)` set `activeSchemaId = id`, then `await store.loadSchema(id)` without re-checking afterward. On a fast A→B switch, A's slow response arrives last, clobbers the global `schemaTable` to A's first table (not a valid option in the displayed B panel → the `<select>` collapses to empty) and fires `loadTableInfo(A, …)` while B is showing.

**Fix:** capture `requestedId`, clear `schemaTable` on open, and `if (activeSchemaId.value !== requestedId) return` after the await. Single guard suffices — the later `loadTableInfo` await writes only the keyed `tableDetails[id:table:schema]` cache and clears the *old* id's `schemaErrors`, neither read by the new panel.

## 2. `openPreview` (added per review — same class, stronger)
Same race, but worse: A's late continuation sets the global `previewTable` to A's table, then `runActivePreview()` reads `activePreviewId` (= the *new* source B) → `previewRows(B, { table: A's table })`, a **cross-source wrong query**. Fixed with the identical pattern (capture `requestedId`, clear `previewTable` on open, recheck `activePreviewId` after the await, then run preview).

## Tests (out-of-order, each proven red without its guard)
`data-sources-ui.spec.ts` adds two parallel out-of-order tests (park A's schema → switch to B fast → resolve A last):
- schema browser: B stays selected, `loadTableInfo(A,…)` never called. Red without guard → `select.value` collapses to `''`.
- preview: `previewRows` called exactly once for B, never the cross-source query. Red without guard → **2 calls** (the legit B preview + the stale `previewRows('b', {table: A})`).

Full spec **33/33**; `eslint` + `vue-tsc -b` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)