### PR TITLE
fix(multitable): gate realtime sheet broadcasts

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -160,7 +160,7 @@ jobs:
           : "${DATABASE_URL:?DATABASE_URL is required for after-sales integration}"
           pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot
 
-      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + dashboard authz + cross-sheet related echo + automation retry provenance)
+      - name: Run multitable real-DB integration (permission golden + view-aggregate + formula dry-run + read-path field mask + dashboard authz + realtime invalidation + automation retry provenance)
         if: matrix.node-version == '20.x'
         env:
           DATABASE_URL: postgresql://postgres@localhost:5432/metasheet_test
@@ -181,6 +181,8 @@ jobs:
             tests/integration/multitable-dashboard-chart-authz.test.ts \
             tests/integration/multitable-write-echo-field-mask.test.ts \
             tests/integration/multitable-cross-sheet-related-echo-mask.test.ts \
+            tests/integration/multitable-sheet-realtime.api.test.ts \
+            tests/integration/rooms.basic.test.ts \
             tests/integration/multitable-automation-retry.test.ts \
             tests/integration/multitable-automation-jobs.test.ts \
             --reporter=dot

--- a/apps/web/src/multitable/composables/useMultitableCommentRealtime.ts
+++ b/apps/web/src/multitable/composables/useMultitableCommentRealtime.ts
@@ -107,11 +107,12 @@ export function useMultitableCommentRealtime(options: UseMultitableCommentRealti
         const userId = await auth.getCurrentUserId().catch(() => null)
         if (disconnected) return null
         currentUserId = userId
+        const token = auth.getToken()
 
         const nextSocket = io(getApiBase() || window.location.origin, {
           autoConnect: true,
           transports: ['websocket'],
-          query: userId ? { userId } : undefined,
+          auth: token ? { token } : undefined,
         })
 
         nextSocket.on('comment:created', (payload: CommentEventPayload) => {

--- a/apps/web/src/multitable/composables/useMultitableSheetPresence.ts
+++ b/apps/web/src/multitable/composables/useMultitableSheetPresence.ts
@@ -88,11 +88,12 @@ export function useMultitableSheetPresence(options: UseMultitableSheetPresenceOp
         const userId = await auth.getCurrentUserId().catch(() => null)
         if (disconnected) return null
         currentUserId.value = userId
+        const token = auth.getToken()
 
         const nextSocket = io(getApiBase() || window.location.origin, {
           autoConnect: true,
           transports: ['websocket'],
-          query: userId ? { userId } : undefined,
+          auth: token ? { token } : undefined,
         })
 
         nextSocket.on('sheet:presence', (payload: SheetPresenceEventPayload) => {

--- a/apps/web/src/multitable/composables/useMultitableSheetRealtime.ts
+++ b/apps/web/src/multitable/composables/useMultitableSheetRealtime.ts
@@ -14,18 +14,7 @@ type SheetOpEvent = {
     recordId?: string
     recordIds?: string[]
     fieldIds?: string[]
-    recordPatches?: Array<{
-      recordId?: string
-      version?: number
-      patch?: Record<string, unknown> | null
-    }>
   } | null
-}
-
-type SheetOpRecordPatch = {
-  recordId: string
-  version?: number
-  patch: Record<string, unknown>
 }
 
 type NormalizedSheetOpEvent = {
@@ -35,7 +24,6 @@ type NormalizedSheetOpEvent = {
   recordId: string
   recordIds: string[]
   fieldIds: string[]
-  recordPatches: SheetOpRecordPatch[]
 }
 
 type UseMultitableSheetRealtimeOptions = {
@@ -72,21 +60,6 @@ function normalizeSheetOpEvent(payload: SheetOpEvent | null | undefined) {
   const fieldIds = Array.isArray(data?.fieldIds)
     ? data.fieldIds.filter((value): value is string => typeof value === 'string' && value.trim().length > 0)
     : []
-  const recordPatches = Array.isArray(data?.recordPatches)
-    ? data.recordPatches.flatMap((entry) => {
-      if (!entry || typeof entry !== 'object') return []
-      const recordId = typeof entry.recordId === 'string' ? entry.recordId.trim() : ''
-      const patch = entry.patch && typeof entry.patch === 'object' && !Array.isArray(entry.patch)
-        ? { ...entry.patch }
-        : null
-      if (!recordId || !patch) return []
-      return [{
-        recordId,
-        version: typeof entry.version === 'number' ? entry.version : undefined,
-        patch,
-      }]
-    })
-    : []
   return {
     spreadsheetId,
     actorId,
@@ -94,7 +67,6 @@ function normalizeSheetOpEvent(payload: SheetOpEvent | null | undefined) {
     recordId,
     recordIds,
     fieldIds,
-    recordPatches,
   }
 }
 
@@ -113,10 +85,6 @@ function buildTargetRecordIds(event: NormalizedSheetOpEvent): string[] {
     ...(event.recordId ? [event.recordId] : []),
     ...event.recordIds,
   ])
-}
-
-function buildRecordPatchMap(event: NormalizedSheetOpEvent): Map<string, SheetOpRecordPatch> {
-  return new Map(event.recordPatches.map((entry) => [entry.recordId, entry]))
 }
 
 export function useMultitableSheetRealtime(options: UseMultitableSheetRealtimeOptions) {
@@ -171,7 +139,6 @@ export function useMultitableSheetRealtime(options: UseMultitableSheetRealtimeOp
     const visibleRecordIds = uniqueIds(readValue(options.visibleRecordIds ?? []) ?? [])
     const structuralFieldIds = uniqueIds(readValue(options.structuralFieldIds ?? []) ?? [])
     const targetRecordIds = buildTargetRecordIds(event)
-    const recordPatchMap = buildRecordPatchMap(event)
     const localTargetRecordIds = targetRecordIds.filter((recordId) => (
       visibleRecordIds.includes(recordId) || (selectedRecordId != null && recordId === selectedRecordId)
     ))
@@ -202,21 +169,9 @@ export function useMultitableSheetRealtime(options: UseMultitableSheetRealtimeOp
       return
     }
 
-    const unresolvedRecordIds: string[] = []
-    for (const recordId of localTargetRecordIds) {
-      const patchEntry = recordPatchMap.get(recordId)
-      if (!patchEntry || !options.applyRemoteRecordPatch) {
-        unresolvedRecordIds.push(recordId)
-        continue
-      }
-      const applied = await options.applyRemoteRecordPatch({
-        recordId,
-        version: patchEntry.version,
-        fieldIds: event.fieldIds,
-        patch: patchEntry.patch,
-      })
-      if (!applied) unresolvedRecordIds.push(recordId)
-    }
+    // Realtime sheet ops are invalidation signals. Do not apply value-bearing
+    // patches even if an old sender accidentally includes them.
+    const unresolvedRecordIds = localTargetRecordIds
 
     if (unresolvedRecordIds.length === 0) return
 
@@ -245,11 +200,12 @@ export function useMultitableSheetRealtime(options: UseMultitableSheetRealtimeOp
         const userId = await auth.getCurrentUserId().catch(() => null)
         if (disconnected) return null
         currentUserId = userId
+        const token = auth.getToken()
 
         const nextSocket = io(getApiBase() || window.location.origin, {
           autoConnect: true,
           transports: ['websocket'],
-          query: userId ? { userId } : undefined,
+          auth: token ? { token } : undefined,
         })
 
         nextSocket.on('sheet:op', (payload: SheetOpEvent) => {

--- a/apps/web/tests/multitable-comment-realtime.spec.ts
+++ b/apps/web/tests/multitable-comment-realtime.spec.ts
@@ -20,6 +20,7 @@ vi.mock('socket.io-client', () => ({
 vi.mock('../src/composables/useAuth', () => ({
   useAuth: () => ({
     getCurrentUserId: vi.fn().mockResolvedValue('user_self'),
+    getToken: vi.fn(() => 'jwt-self'),
   }),
 }))
 
@@ -78,6 +79,12 @@ describe('useMultitableCommentRealtime', () => {
     await flushUi(6)
 
     expect(ioMock).toHaveBeenCalledTimes(1)
+    expect(ioMock.mock.calls[0]?.[1]).toMatchObject({
+      autoConnect: true,
+      transports: ['websocket'],
+      auth: { token: 'jwt-self' },
+    })
+    expect(ioMock.mock.calls[0]?.[1]).not.toHaveProperty('query')
     expect(emitMock).toHaveBeenCalledWith('join-sheet', 'sheet_ops')
 
     handlers.get('comment:created')?.({

--- a/apps/web/tests/multitable-sheet-presence.spec.ts
+++ b/apps/web/tests/multitable-sheet-presence.spec.ts
@@ -20,6 +20,7 @@ vi.mock('socket.io-client', () => ({
 vi.mock('../src/composables/useAuth', () => ({
   useAuth: () => ({
     getCurrentUserId: vi.fn().mockResolvedValue('user_self'),
+    getToken: vi.fn(() => 'jwt-self'),
   }),
 }))
 
@@ -69,6 +70,12 @@ describe('useMultitableSheetPresence', () => {
     await flushUi(6)
 
     expect(ioMock).toHaveBeenCalledTimes(1)
+    expect(ioMock.mock.calls[0]?.[1]).toMatchObject({
+      autoConnect: true,
+      transports: ['websocket'],
+      auth: { token: 'jwt-self' },
+    })
+    expect(ioMock.mock.calls[0]?.[1]).not.toHaveProperty('query')
     expect(emitMock).toHaveBeenCalledWith('join-sheet', 'sheet_ops')
     expect(activeCollaboratorCount.value).toBe(0)
 

--- a/apps/web/tests/multitable-sheet-realtime.spec.ts
+++ b/apps/web/tests/multitable-sheet-realtime.spec.ts
@@ -20,6 +20,7 @@ vi.mock('socket.io-client', () => ({
 vi.mock('../src/composables/useAuth', () => ({
   useAuth: () => ({
     getCurrentUserId: vi.fn().mockResolvedValue('user_self'),
+    getToken: vi.fn(() => 'jwt-self'),
   }),
 }))
 
@@ -54,7 +55,7 @@ describe('useMultitableSheetRealtime', () => {
     container = null
   })
 
-  it('joins sheet rooms and reloads the page for remote record updates only', async () => {
+  it('joins sheet rooms with token auth and refetches for remote record updates only', async () => {
     const reloadCurrentSheetPage = vi.fn().mockResolvedValue(undefined)
     const reloadSelectedRecordContext = vi.fn().mockResolvedValue(undefined)
     const applyRemoteRecordPatch = vi.fn().mockResolvedValue(true)
@@ -85,6 +86,12 @@ describe('useMultitableSheetRealtime', () => {
     await flushUi(6)
 
     expect(ioMock).toHaveBeenCalledTimes(1)
+    expect(ioMock.mock.calls[0]?.[1]).toMatchObject({
+      autoConnect: true,
+      transports: ['websocket'],
+      auth: { token: 'jwt-self' },
+    })
+    expect(ioMock.mock.calls[0]?.[1]).not.toHaveProperty('query')
     expect(emitMock).toHaveBeenCalledWith('join-sheet', 'sheet_ops')
 
     handlers.get('sheet:op')?.({
@@ -104,13 +111,8 @@ describe('useMultitableSheetRealtime', () => {
     })
     await flushUi(4)
 
-    expect(applyRemoteRecordPatch).toHaveBeenCalledWith({
-      recordId: 'rec_1',
-      version: 8,
-      fieldIds: ['fld_title'],
-      patch: { fld_title: 'Remote title' },
-    })
-    expect(mergeRemoteRecord).not.toHaveBeenCalled()
+    expect(applyRemoteRecordPatch).not.toHaveBeenCalled()
+    expect(mergeRemoteRecord).toHaveBeenCalledWith('rec_1')
     expect(reloadCurrentSheetPage).not.toHaveBeenCalled()
     expect(reloadSelectedRecordContext).not.toHaveBeenCalled()
 
@@ -124,8 +126,8 @@ describe('useMultitableSheetRealtime', () => {
       },
     })
     await flushUi(3)
-    expect(applyRemoteRecordPatch).toHaveBeenCalledTimes(1)
-    expect(mergeRemoteRecord).toHaveBeenCalledTimes(0)
+    expect(applyRemoteRecordPatch).not.toHaveBeenCalled()
+    expect(mergeRemoteRecord).toHaveBeenCalledTimes(1)
 
     handlers.get('sheet:op')?.({
       type: 'cell-update',
@@ -185,7 +187,7 @@ describe('useMultitableSheetRealtime', () => {
     expect(emitMock).toHaveBeenCalledWith('join-sheet', 'sheet_finance')
   })
 
-  it('falls back to record merge when local cell patch is rejected', async () => {
+  it('ignores legacy value patches and refetches the changed record', async () => {
     const reloadCurrentSheetPage = vi.fn().mockResolvedValue(undefined)
     const applyRemoteRecordPatch = vi.fn().mockResolvedValue(false)
     const mergeRemoteRecord = vi.fn().mockResolvedValue(true)
@@ -224,7 +226,7 @@ describe('useMultitableSheetRealtime', () => {
     })
     await flushUi(4)
 
-    expect(applyRemoteRecordPatch).toHaveBeenCalledTimes(1)
+    expect(applyRemoteRecordPatch).not.toHaveBeenCalled()
     expect(mergeRemoteRecord).toHaveBeenCalledWith('rec_1')
     expect(reloadCurrentSheetPage).not.toHaveBeenCalled()
   })

--- a/docs/development/multitable-realtime-broadcast-invalidation-verification-20260602.md
+++ b/docs/development/multitable-realtime-broadcast-invalidation-verification-20260602.md
@@ -1,0 +1,53 @@
+# Multitable realtime broadcast invalidation verification
+
+**Date:** 2026-06-02  
+**Slice:** realtime `sheet:op` room gate + value-free invalidation implementation  
+**Design lock:** `docs/development/multitable-realtime-broadcast-invalidation-design-20260601.md` (#2181)  
+**Status:** IMPLEMENTATION VERIFICATION SNAPSHOT
+
+---
+
+## Contract Verified
+
+- `join-sheet` no longer trusts `handshake.query.userId`; sheet room membership and presence use the token-derived user id.
+- `join-sheet` requires a trusted socket identity plus sheet `canRead` through the injected sheet-room auth checker.
+- `publishMultitableSheetRealtime` still invalidates the records cache, but publishes only metadata to `spreadsheet.cell.updated`; `recordPatches[].patch` does not reach `sheet:op`.
+- Frontend sheet/presence/comment realtime clients send the existing JWT through Socket.IO `auth.token`.
+- Frontend sheet realtime treats `sheet:op` as invalidation only; it does not apply value-bearing patches even if an old sender includes them.
+
+---
+
+## Tests Run
+
+| Gate | Command | Result |
+| --- | --- | --- |
+| Backend type-check | `pnpm --filter @metasheet/core-backend exec tsc --noEmit` | PASS |
+| Frontend type-check | `pnpm --filter @metasheet/web exec vue-tsc -b` | PASS |
+| Frontend realtime specs | `pnpm --filter @metasheet/web exec vitest run --watch=false tests/multitable-sheet-realtime.spec.ts tests/multitable-sheet-presence.spec.ts tests/multitable-comment-realtime.spec.ts` | PASS, 4/4 |
+| Realtime publish helper + record services | `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-realtime-publish.test.ts tests/unit/record-write-service.test.ts tests/unit/record-service.test.ts --reporter=dot` | PASS, 60/60 |
+| Socket.IO room gate + API publish regressions | `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/rooms.basic.test.ts tests/integration/multitable-sheet-realtime.api.test.ts tests/integration/multitable-attachments.api.test.ts --reporter=dot` | PASS, 20/20 |
+| CI wiring | `.github/workflows/plugin-tests.yml` multitable real-DB step now includes `multitable-sheet-realtime.api.test.ts` and `rooms.basic.test.ts` | VERIFIED BY DIFF |
+
+Notes:
+
+- The Socket.IO room tests use a real Socket.IO server and inject a deterministic token verifier / sheet-room checker into `CollabService`; they do not rely on spoofable query identity.
+- Local `rooms.basic.test.ts` server startup logged degraded DB initialization errors because the local default Postgres database is absent; the tested Socket.IO room behavior still ran and passed. CI runs this file in the existing Node 20 multitable real-DB step with `DATABASE_URL=postgresql://postgres@localhost:5432/metasheet_test`.
+- A broader non-gating frontend command that also included `tests/multitable-workbench-view.spec.ts` failed one unrelated automation router assertion (`opens workflow designer with multitable context when automation is enabled`). The three touched realtime composable specs passed in the same run.
+
+---
+
+## Coverage Mapping
+
+- R1/R2: `rooms.basic.test.ts` rejects unauthenticated and non-reader `join-sheet`, and asserts no `sheet:op` is received.
+- R3/R8: `rooms.basic.test.ts` accepts a reader, emits trusted-token presence, and receives a value-free `sheet:op` with canary values absent.
+- R5: `multitable-sheet-realtime.spec.ts` proves no-value / legacy-value `record-updated` events call `mergeRemoteRecord`, not `applyRemoteRecordPatch`.
+- R6: `multitable-sheet-realtime.api.test.ts` and `multitable-attachments.api.test.ts` prove create, form update, bulk patch, and attachment update publishers emit value-free EventBus payloads.
+- R7: `multitable-realtime-publish.test.ts` proves cache invalidation still runs while `recordPatches` are stripped.
+
+---
+
+## Non-Goals Preserved
+
+- Comment-specific rooms still carry comment payloads and are not treated as cell value channels.
+- Yjs document sync remains separate; this slice only covers Socket.IO `sheet:op` published by `publishMultitableSheetRealtime`.
+- Per-recipient masked value fan-out remains a future optimization, not part of this safety floor.

--- a/packages/core-backend/src/di/identifiers.ts
+++ b/packages/core-backend/src/di/identifiers.ts
@@ -53,6 +53,8 @@ export interface ILogger {
 
 export interface ICollabService {
   initialize(httpServer: HttpServer): void;
+  setTokenVerifier(verifier: (token: string) => Promise<string | null>): void;
+  setSheetRoomAuthChecker(checker: (input: { sheetId: string; userId: string; socketId: string }) => Promise<boolean>): void;
   broadcast(event: string, data: unknown): void;
   broadcastTo(room: string, event: string, data: unknown): void;
   sendTo(userId: string, event: string, data: unknown): void;

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -56,6 +56,7 @@ import {
   queryRecords as queryMultitableRecords,
   type MultitableRecordsQueryFn,
 } from './multitable/records'
+import { resolveSheetCapabilitiesForUser } from './multitable/sheet-capabilities'
 import {
   assertPluginOwnsObject,
   assertPluginOwnsSheet,
@@ -1961,6 +1962,23 @@ export class MetaSheetServer {
     // Initialize WebSocket Service
     try {
       const collabService = this.injector.get(ICollabService)
+      collabService.setTokenVerifier(async (token: string) => {
+        const user = await authService.verifyToken(token)
+        return user?.id?.toString() ?? null
+      })
+      collabService.setSheetRoomAuthChecker(async ({ sheetId, userId }) => {
+        try {
+          const pool = poolManager.get()
+          const { capabilities } = await resolveSheetCapabilitiesForUser(
+            pool.query.bind(pool),
+            sheetId,
+            userId,
+          )
+          return capabilities.canRead
+        } catch {
+          return false
+        }
+      })
       collabService.initialize(this.httpServer)
     } catch (e) {
       this.logger.error('Failed to initialize WebSocket service', e as Error)

--- a/packages/core-backend/src/multitable/realtime-publish.ts
+++ b/packages/core-backend/src/multitable/realtime-publish.ts
@@ -22,6 +22,8 @@ export type MultitableSheetRealtimePayload = {
   }>
 }
 
+export type MultitableSheetRealtimeBroadcastPayload = Omit<MultitableSheetRealtimePayload, 'recordPatches'>
+
 /**
  * Invalidate the lightweight cursor-paginated records cache for a sheet.
  *
@@ -40,8 +42,17 @@ export function setRealtimeCacheInvalidator(fn: InvalidateCacheFn): void {
 export function publishMultitableSheetRealtime(payload: MultitableSheetRealtimePayload): void {
   if (!payload.spreadsheetId) return
   _invalidateCache(payload.spreadsheetId)
+  const broadcastPayload: MultitableSheetRealtimeBroadcastPayload = {
+    spreadsheetId: payload.spreadsheetId,
+    source: payload.source,
+    kind: payload.kind,
+  }
+  if (payload.actorId !== undefined) broadcastPayload.actorId = payload.actorId
+  if (payload.recordId !== undefined) broadcastPayload.recordId = payload.recordId
+  if (payload.recordIds) broadcastPayload.recordIds = [...payload.recordIds]
+  if (payload.fieldIds) broadcastPayload.fieldIds = [...payload.fieldIds]
   try {
-    eventBus.publish('spreadsheet.cell.updated', payload)
+    eventBus.publish('spreadsheet.cell.updated', broadcastPayload)
   } catch (err) {
     console.warn('[multitable] failed to publish multitable sheet realtime update', err)
   }

--- a/packages/core-backend/src/services/CollabService.ts
+++ b/packages/core-backend/src/services/CollabService.ts
@@ -9,16 +9,40 @@ export function buildAuthenticatedUserRoom(userId: string): string {
   return `auth-user:${userId}`
 }
 
+export type SocketTokenVerifier = (token: string) => Promise<string | null>
+export type SheetRoomAuthChecker = (input: { sheetId: string; userId: string; socketId: string }) => Promise<boolean>
+
+type AuthenticatedSocketData = {
+  trustedUserId?: string | null
+  authPromise?: Promise<string | null>
+}
+
 export class CollabService {
   private io: SocketServer | null = null
   private sheetPresenceBySheet = new Map<string, Map<string, Set<string>>>()
   private sheetMembershipBySocket = new Map<string, Set<string>>()
+  private tokenVerifier: SocketTokenVerifier = async (token) => {
+    // AuthService pulls in RBAC/metrics modules; keep it lazy so importing CollabService
+    // does not register global metrics during parallel unit-test collection.
+    const { authService } = await import('../auth/AuthService')
+    const user = await authService.verifyToken(token)
+    return user?.id?.toString().trim() || null
+  }
+  private sheetRoomAuthChecker: SheetRoomAuthChecker = async () => false
 
   constructor(
     private logger: ILogger,
     private eventBus: EventBus,
   ) {
     this.setupEventListeners()
+  }
+
+  setTokenVerifier(verifier: SocketTokenVerifier): void {
+    this.tokenVerifier = verifier
+  }
+
+  setSheetRoomAuthChecker(checker: SheetRoomAuthChecker): void {
+    this.sheetRoomAuthChecker = checker
   }
 
   private setupEventListeners() {
@@ -34,33 +58,57 @@ export class CollabService {
     })
   }
 
-  private getUserIdFromSocket(socket: Socket): string | undefined {
-    const raw = socket.handshake.query.userId
-    const value = Array.isArray(raw) ? raw[0] : raw
-    if (typeof value === 'string' && value.trim().length > 0) return value.trim()
-    return undefined
-  }
-
   private getTokenFromSocket(socket: Socket): string | undefined {
     const authToken = (socket.handshake.auth as { token?: unknown } | undefined)?.token
     if (typeof authToken === 'string' && authToken.trim().length > 0) return authToken.trim()
-    const raw = socket.handshake.query.token
-    const value = Array.isArray(raw) ? raw[0] : raw
-    if (typeof value === 'string' && value.trim().length > 0) return value.trim()
     return undefined
   }
 
-  private async joinAuthenticatedUserRoom(socket: Socket): Promise<void> {
+  private getSocketData(socket: Socket): AuthenticatedSocketData {
+    return socket.data as AuthenticatedSocketData
+  }
+
+  private getTrustedUserId(socket: Socket): string | undefined {
+    const userId = this.getSocketData(socket).trustedUserId
+    return typeof userId === 'string' && userId.trim().length > 0 ? userId.trim() : undefined
+  }
+
+  private async resolveTrustedUserId(socket: Socket): Promise<string | null> {
+    const data = this.getSocketData(socket)
+    if (data.trustedUserId !== undefined) return data.trustedUserId
+    if (data.authPromise) return data.authPromise
+
     const token = this.getTokenFromSocket(socket)
-    if (!token) return
+    if (!token) {
+      data.trustedUserId = null
+      return null
+    }
+
+    data.authPromise = (async () => {
+      try {
+        const userId = await this.tokenVerifier(token)
+        data.trustedUserId = userId?.trim() || null
+        return data.trustedUserId
+      } catch (error) {
+        data.trustedUserId = null
+        this.logger.warn('WebSocket token verification failed', error instanceof Error ? error : undefined)
+        return null
+      } finally {
+        data.authPromise = undefined
+      }
+    })()
+
+    return data.authPromise
+  }
+
+  private async joinAuthenticatedUserRoom(socket: Socket): Promise<void> {
+    const userId = await this.resolveTrustedUserId(socket)
+    if (!userId || !socket.connected) return
     try {
-      // AuthService pulls in RBAC/metrics modules; keep it lazy so importing CollabService
-      // does not register global metrics during parallel unit-test collection.
-      const { authService } = await import('../auth/AuthService')
-      const user = await authService.verifyToken(token)
-      const userId = user?.id?.toString().trim()
-      if (!userId) return
       socket.join(buildAuthenticatedUserRoom(userId))
+      // Legacy plugin APIs address users by raw user id; keep that room, but only
+      // after token verification. Never join it from the spoofable query userId.
+      socket.join(userId)
       this.logger.debug(`WebSocket client ${socket.id} joined authenticated user room for ${userId}`)
     } catch (error) {
       this.logger.warn('WebSocket authenticated user room join failed', error instanceof Error ? error : undefined)
@@ -154,6 +202,43 @@ export class CollabService {
     })
   }
 
+  private denySheetJoin(socket: Socket, sheetId: string, reason: string): void {
+    socket.emit('join-denied', { sheetId, reason })
+    this.logger.warn(`Client ${socket.id} denied joining sheet:${sheetId}: ${reason}`)
+  }
+
+  private async handleJoinSheet(socket: Socket, payload: unknown): Promise<void> {
+    const sheetId = this.normalizeSheetId(payload)
+    if (!sheetId) return
+
+    const userId = await this.resolveTrustedUserId(socket)
+    if (!socket.connected) return
+    if (!userId) {
+      this.denySheetJoin(socket, sheetId, 'unauthorized')
+      return
+    }
+
+    let allowed = false
+    try {
+      allowed = await this.sheetRoomAuthChecker({ sheetId, userId, socketId: socket.id })
+    } catch (error) {
+      this.logger.warn('WebSocket sheet room auth check failed', error instanceof Error ? error : undefined)
+    }
+    if (!socket.connected) return
+    if (!allowed) {
+      this.denySheetJoin(socket, sheetId, 'forbidden')
+      return
+    }
+
+    const room = this.buildSheetRoom(sheetId)
+    socket.join(room)
+    this.trackSocketSheetMembership(socket.id, sheetId)
+    this.addSheetPresence(sheetId, userId, socket.id)
+    this.logger.info(`Client ${socket.id} joined ${room}`)
+    socket.emit('joined', { sheetId })
+    this.emitSheetPresence(sheetId)
+  }
+
   initialize(httpServer: HttpServer): void {
     this.io = new SocketServer(httpServer, {
       cors: {
@@ -168,15 +253,10 @@ export class CollabService {
 
     this.io.on('connection', (socket: Socket) => {
       this.logger.info(`WebSocket client connected: ${socket.id}`)
-      const userId = this.getUserIdFromSocket(socket)
-      if (userId) {
-        socket.join(userId)
-        this.logger.debug(`WebSocket client ${socket.id} joined user room ${userId}`)
-      }
       void this.joinAuthenticatedUserRoom(socket)
 
       socket.on('disconnect', () => {
-        const userId = this.getUserIdFromSocket(socket)
+        const userId = this.getTrustedUserId(socket)
         const sheetIds = [...(this.sheetMembershipBySocket.get(socket.id) ?? [])]
         for (const sheetId of sheetIds) {
           if (userId) this.removeSheetPresence(sheetId, userId, socket.id)
@@ -187,23 +267,14 @@ export class CollabService {
       })
 
       socket.on('join-sheet', (payload: unknown) => {
-        const sheetId = this.normalizeSheetId(payload)
-        if (!sheetId) return
-        const room = this.buildSheetRoom(sheetId)
-        const userId = this.getUserIdFromSocket(socket)
-        socket.join(room)
-        this.trackSocketSheetMembership(socket.id, sheetId)
-        if (userId) this.addSheetPresence(sheetId, userId, socket.id)
-        this.logger.info(`Client ${socket.id} joined ${room}`)
-        socket.emit('joined', { sheetId })
-        this.emitSheetPresence(sheetId)
+        void this.handleJoinSheet(socket, payload)
       })
 
       socket.on('leave-sheet', (payload: unknown) => {
         const sheetId = this.normalizeSheetId(payload)
         if (!sheetId) return
         const room = this.buildSheetRoom(sheetId)
-        const userId = this.getUserIdFromSocket(socket)
+        const userId = this.getTrustedUserId(socket)
         socket.leave(room)
         if (userId) this.removeSheetPresence(sheetId, userId, socket.id)
         this.untrackSocketSheetMembership(socket.id, sheetId)
@@ -335,10 +406,9 @@ export class CollabService {
       const sockets = await this.io.in(room).fetchSockets()
       const userIds = new Set<string>()
       for (const socket of sockets) {
-        const raw = socket.handshake?.query?.userId
-        const value = Array.isArray(raw) ? raw[0] : raw
-        if (typeof value === 'string' && value.trim().length > 0) {
-          userIds.add(value.trim())
+        const raw = (socket.data as AuthenticatedSocketData | undefined)?.trustedUserId
+        if (typeof raw === 'string' && raw.trim().length > 0) {
+          userIds.add(raw.trim())
         }
       }
       return [...userIds]

--- a/packages/core-backend/tests/integration/multitable-attachments.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-attachments.api.test.ts
@@ -491,7 +491,12 @@ describe('Multitable attachment API', () => {
             }
           }
           if (sql.includes('UPDATE meta_records') && sql.includes('version = version + 1')) {
-            expect(params).toEqual([JSON.stringify({ fld_files: ['att_keep'] }), 'rec_ops_1', 'sheet_ops'])
+            expect(params).toEqual([
+              JSON.stringify({ fld_files: ['att_keep'] }),
+              'rec_ops_1',
+              'sheet_ops',
+              'user_multitable_attachments',
+            ])
             return { rows: [{ version: 3 }] }
           }
           if (sql.includes('UPDATE multitable_attachments SET deleted_at = now(), updated_at = now()')) {
@@ -520,7 +525,8 @@ describe('Multitable attachment API', () => {
         ok: true,
         data: { deleted: uploadedAttachmentId },
       })
-      expect(publishSpy).toHaveBeenCalledWith('spreadsheet.cell.updated', {
+      const payload = publishSpy.mock.calls[0]?.[1]
+      expect(payload).toEqual({
         spreadsheetId: 'sheet_ops',
         actorId: 'user_multitable_attachments',
         source: 'multitable',
@@ -528,12 +534,9 @@ describe('Multitable attachment API', () => {
         recordId: 'rec_ops_1',
         recordIds: ['rec_ops_1'],
         fieldIds: ['fld_files'],
-        recordPatches: [{
-          recordId: 'rec_ops_1',
-          version: 3,
-          patch: { fld_files: ['att_keep'] },
-        }],
       })
+      expect(payload).not.toHaveProperty('recordPatches')
+      expect(JSON.stringify(payload)).not.toContain('att_keep')
       await expect(fs.stat(path.join(attachmentPath, storedPath))).rejects.toThrow()
     } finally {
       await fs.rm(attachmentPath, { recursive: true, force: true })
@@ -583,7 +586,12 @@ describe('Multitable attachment API', () => {
             }
           }
           if (sql.includes('UPDATE meta_records') && sql.includes('version = version + 1')) {
-            expect(params).toEqual([JSON.stringify({ fld_files: ['att_keep'] }), 'rec_acl_1', 'sheet_acl'])
+            expect(params).toEqual([
+              JSON.stringify({ fld_files: ['att_keep'] }),
+              'rec_acl_1',
+              'sheet_acl',
+              'user_multitable_attachments',
+            ])
             return { rows: [{ version: 5 }] }
           }
           if (sql.includes('UPDATE multitable_attachments SET deleted_at = now(), updated_at = now()')) {
@@ -602,7 +610,8 @@ describe('Multitable attachment API', () => {
         ok: true,
         data: { deleted: 'att_sheet_write' },
       })
-      expect(publishSpy).toHaveBeenCalledWith('spreadsheet.cell.updated', {
+      const payload = publishSpy.mock.calls[0]?.[1]
+      expect(payload).toEqual({
         spreadsheetId: 'sheet_acl',
         actorId: 'user_multitable_attachments',
         source: 'multitable',
@@ -610,12 +619,9 @@ describe('Multitable attachment API', () => {
         recordId: 'rec_acl_1',
         recordIds: ['rec_acl_1'],
         fieldIds: ['fld_files'],
-        recordPatches: [{
-          recordId: 'rec_acl_1',
-          version: 5,
-          patch: { fld_files: ['att_keep'] },
-        }],
       })
+      expect(payload).not.toHaveProperty('recordPatches')
+      expect(JSON.stringify(payload)).not.toContain('att_keep')
     } finally {
       await fs.rm(attachmentPath, { recursive: true, force: true })
     }

--- a/packages/core-backend/tests/integration/multitable-sheet-realtime.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-realtime.api.test.ts
@@ -76,6 +76,9 @@ describe('Multitable sheet realtime events', () => {
           expect(params).toEqual(['sheet_ops'])
           return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {} }] }
         }
+        if (sql.includes('SELECT pg_advisory_xact_lock')) {
+          return { rows: [] }
+        }
         if (sql.includes('INSERT INTO meta_records') && sql.includes('RETURNING version')) {
           expect(params).toEqual([
             expect.stringMatching(/^rec_/),
@@ -84,6 +87,9 @@ describe('Multitable sheet realtime events', () => {
             'user_realtime_1',
           ])
           return { rows: [{ version: 1 }] }
+        }
+        if (sql.includes('INSERT INTO meta_record_revisions')) {
+          return { rows: [], rowCount: 1 }
         }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
@@ -101,7 +107,8 @@ describe('Multitable sheet realtime events', () => {
       version: 1,
       data: { fld_title: 'Alpha' },
     })
-    expect(publishSpy).toHaveBeenCalledWith('spreadsheet.cell.updated', expect.objectContaining({
+    const payload = publishSpy.mock.calls[0]?.[1]
+    expect(payload).toMatchObject({
       spreadsheetId: 'sheet_ops',
       actorId: 'user_realtime_1',
       source: 'multitable',
@@ -109,12 +116,9 @@ describe('Multitable sheet realtime events', () => {
       recordId: response.body.data.record.id,
       recordIds: [response.body.data.record.id],
       fieldIds: ['fld_title'],
-      recordPatches: [{
-        recordId: response.body.data.record.id,
-        version: 1,
-        patch: { fld_title: 'Alpha' },
-      }],
-    }))
+    })
+    expect(payload).not.toHaveProperty('recordPatches')
+    expect(JSON.stringify(payload)).not.toContain('Alpha')
   })
 
   test('publishes spreadsheet.cell.updated after form submit updates a record', async () => {
@@ -149,17 +153,31 @@ describe('Multitable sheet realtime events', () => {
           expect(params).toEqual(['sheet_ops'])
           return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 1 }] }
         }
+        if (sql.includes('SELECT pg_advisory_xact_lock')) {
+          return { rows: [] }
+        }
         if (sql.includes('SELECT id, version, created_by FROM meta_records WHERE id = $1 AND sheet_id = $2 FOR UPDATE')) {
           expect(params).toEqual(['rec_1', 'sheet_ops'])
           return { rows: [{ id: 'rec_1', version: 4, created_by: 'user_realtime_1' }] }
         }
         if (sql.includes('UPDATE meta_records') && sql.includes('RETURNING version')) {
-          expect(params).toEqual([JSON.stringify({ fld_title: 'Updated title' }), 'rec_1', 'sheet_ops'])
+          expect(params).toEqual([
+            JSON.stringify({ fld_title: 'Updated title' }),
+            'rec_1',
+            'sheet_ops',
+            'user_realtime_1',
+          ])
           return { rows: [{ version: 5 }] }
+        }
+        if (sql.includes('INSERT INTO meta_record_revisions')) {
+          return { rows: [], rowCount: 1 }
         }
         if (sql.includes('SELECT id, version, data FROM meta_records WHERE id = $1 AND sheet_id = $2')) {
           expect(params).toEqual(['rec_1', 'sheet_ops'])
           return { rows: [{ id: 'rec_1', version: 5, data: { fld_title: 'Updated title' } }] }
+        }
+        if (sql.includes('FROM formula_dependencies')) {
+          return { rows: [] }
         }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
@@ -175,7 +193,8 @@ describe('Multitable sheet realtime events', () => {
       .expect(200)
 
     expect(response.body.data.mode).toBe('update')
-    expect(publishSpy).toHaveBeenCalledWith('spreadsheet.cell.updated', {
+    const payload = publishSpy.mock.calls[0]?.[1]
+    expect(payload).toEqual({
       spreadsheetId: 'sheet_ops',
       actorId: 'user_realtime_1',
       source: 'multitable',
@@ -183,12 +202,9 @@ describe('Multitable sheet realtime events', () => {
       recordId: 'rec_1',
       recordIds: ['rec_1'],
       fieldIds: ['fld_title'],
-      recordPatches: [{
-        recordId: 'rec_1',
-        version: 5,
-        patch: { fld_title: 'Updated title' },
-      }],
     })
+    expect(payload).not.toHaveProperty('recordPatches')
+    expect(JSON.stringify(payload)).not.toContain('Updated title')
   })
 
   test('publishes aggregate update events for bulk patch', async () => {
@@ -203,21 +219,38 @@ describe('Multitable sheet realtime events', () => {
           expect(params).toEqual(['sheet_ops'])
           return { rows: [{ id: 'sheet_ops' }] }
         }
-        if (sql.includes('SELECT id, name, type, property FROM meta_fields WHERE sheet_id = $1')) {
+        if (sql.includes('SELECT id, name, type, property')) {
           expect(params).toEqual(['sheet_ops'])
-          return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {} }] }
+          return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 1 }] }
         }
-        if (sql.includes('SELECT id, version, created_by FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE')) {
+        if (sql.includes('FROM field_permissions')) {
+          return { rows: [] }
+        }
+        if (sql.includes('SELECT id, version, data, created_by FROM meta_records WHERE sheet_id = $1 AND id = $2 FOR UPDATE')) {
           expect(params).toEqual(['sheet_ops', 'rec_1'])
-          return { rows: [{ id: 'rec_1', version: 2, created_by: 'user_realtime_1' }] }
+          return { rows: [{ id: 'rec_1', version: 2, data: { fld_title: 'Original title' }, created_by: 'user_realtime_1' }] }
         }
         if (sql.includes('UPDATE meta_records') && sql.includes('WHERE sheet_id = $2 AND id = $3')) {
-          expect(params).toEqual([JSON.stringify({ fld_title: 'Bulk patched' }), 'sheet_ops', 'rec_1'])
+          expect(params).toEqual([
+            JSON.stringify({ fld_title: 'Bulk patched' }),
+            'sheet_ops',
+            'rec_1',
+            'user_realtime_1',
+          ])
           return { rows: [{ version: 3 }] }
+        }
+        if (sql.includes('INSERT INTO meta_record_revisions')) {
+          return { rows: [], rowCount: 1 }
         }
         if (sql.includes('SELECT record_id FROM meta_links WHERE foreign_record_id = ANY($1::text[])')) {
           expect(params).toEqual([['rec_1']])
           return { rows: [] }
+        }
+        if (sql.includes('FROM meta_record_subscriptions')) {
+          return { rows: [] }
+        }
+        if (sql.includes('INSERT INTO meta_record_subscription_notifications')) {
+          return { rows: [], rowCount: 0 }
         }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
@@ -232,18 +265,16 @@ describe('Multitable sheet realtime events', () => {
       .expect(200)
 
     expect(response.body.data.updated).toEqual([{ recordId: 'rec_1', version: 3 }])
-    expect(publishSpy).toHaveBeenCalledWith('spreadsheet.cell.updated', {
+    const payload = publishSpy.mock.calls[0]?.[1]
+    expect(payload).toEqual({
       spreadsheetId: 'sheet_ops',
       actorId: 'user_realtime_1',
       source: 'multitable',
       kind: 'record-updated',
       recordIds: ['rec_1'],
       fieldIds: ['fld_title'],
-      recordPatches: [{
-        recordId: 'rec_1',
-        version: 3,
-        patch: { fld_title: 'Bulk patched' },
-      }],
     })
+    expect(payload).not.toHaveProperty('recordPatches')
+    expect(JSON.stringify(payload)).not.toContain('Bulk patched')
   })
 })

--- a/packages/core-backend/tests/integration/rooms.basic.test.ts
+++ b/packages/core-backend/tests/integration/rooms.basic.test.ts
@@ -2,10 +2,70 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import net from 'net'
 import { io as ioClient } from 'socket.io-client'
 import { MetaSheetServer } from '../../src/index'
+import { ICollabService, type ICollabService as CollabServicePort } from '../../src/di/identifiers'
+import { eventBus } from '../../src/integration/events/event-bus'
+import { publishMultitableSheetRealtime } from '../../src/multitable/realtime-publish'
+
+function waitForConnect(client: ReturnType<typeof ioClient>, label: string): Promise<void> {
+  return new Promise<void>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`${label} connect timeout`)), 3000)
+    client.on('connect', () => { clearTimeout(t); resolve() })
+  })
+}
+
+function waitForEvent<T = any>(
+  client: ReturnType<typeof ioClient>,
+  event: string,
+  label: string,
+  timeoutMs = 3000,
+): Promise<T> {
+  return new Promise<T>((resolve, reject) => {
+    const t = setTimeout(() => reject(new Error(`${label} timeout`)), timeoutMs)
+    client.once(event, (payload: T) => {
+      clearTimeout(t)
+      resolve(payload)
+    })
+  })
+}
+
+async function expectNoEvent(
+  client: ReturnType<typeof ioClient>,
+  event: string,
+  label: string,
+  timeoutMs = 120,
+): Promise<void> {
+  await new Promise<void>((resolve, reject) => {
+    const t = setTimeout(() => {
+      client.off(event, handler)
+      resolve()
+    }, timeoutMs)
+    const handler = (payload: unknown) => {
+      clearTimeout(t)
+      client.off(event, handler)
+      reject(new Error(`${label} unexpectedly received ${event}: ${JSON.stringify(payload)}`))
+    }
+    client.on(event, handler)
+  })
+}
+
+async function waitForRoomMember(
+  collabService: CollabServicePort,
+  room: string,
+  userId: string,
+): Promise<void> {
+  const deadline = Date.now() + 3000
+  while (Date.now() < deadline) {
+    const members = await collabService.getRoomMembers(room)
+    if (members.includes(userId)) return
+    await new Promise((resolve) => setTimeout(resolve, 20))
+  }
+  throw new Error(`Timed out waiting for ${userId} in room ${room}`)
+}
 
 describe('WebSocket Rooms - basic flow', () => {
   let server: MetaSheetServer | undefined
   let baseUrl: string | undefined
+  let collabService: CollabServicePort | undefined
 
   beforeAll(async () => {
     const canListen: boolean = await new Promise((resolve) => {
@@ -20,6 +80,16 @@ describe('WebSocket Rooms - basic flow', () => {
     const addr = server.getAddress()
     if (!addr || !addr.port) return
     baseUrl = `http://127.0.0.1:${addr.port}`
+    // @ts-expect-error integration test reaches into the server container to keep
+    // Socket.IO tests independent from real JWT/RBAC fixtures.
+    collabService = server.injector.get(ICollabService)
+    collabService.setTokenVerifier(async (token) => {
+      if (!token.startsWith('token:')) return null
+      return token.slice('token:'.length).trim() || null
+    })
+    collabService.setSheetRoomAuthChecker(async ({ sheetId, userId }) => {
+      return sheetId === 'sheet_ops' && ['user_a', 'user_b', 'user_reader', 'a', 'b'].includes(userId)
+    })
   })
 
   afterAll(async () => {
@@ -27,21 +97,14 @@ describe('WebSocket Rooms - basic flow', () => {
   })
 
   it('broadcastTo affects only members of the room', async () => {
-    if (!baseUrl || !server) return
-    // Connect two clients with userIds
-    const a = ioClient(`${baseUrl}?userId=a`, { transports: ['websocket'] })
-    const b = ioClient(`${baseUrl}?userId=b`, { transports: ['websocket'] })
+    if (!baseUrl || !server || !collabService) return
+    const a = ioClient(baseUrl, { transports: ['websocket'], auth: { token: 'token:a' } })
+    const b = ioClient(baseUrl, { transports: ['websocket'], auth: { token: 'token:b' } })
 
-    // Wait for connection
+    await Promise.all([waitForConnect(a, 'A'), waitForConnect(b, 'B')])
     await Promise.all([
-      new Promise<void>((resolve, reject) => {
-        const t = setTimeout(() => reject(new Error('A connect timeout')), 3000)
-        a.on('connect', () => { clearTimeout(t); resolve() })
-      }),
-      new Promise<void>((resolve, reject) => {
-        const t = setTimeout(() => reject(new Error('B connect timeout')), 3000)
-        b.on('connect', () => { clearTimeout(t); resolve() })
-      })
+      waitForRoomMember(collabService, 'a', 'a'),
+      waitForRoomMember(collabService, 'b', 'b'),
     ])
 
     // Join user a to room R via server API
@@ -68,6 +131,103 @@ describe('WebSocket Rooms - basic flow', () => {
     expect(gotB).toBe(false)
 
     a.close(); b.close()
+  })
+
+  it('rejects unauthenticated sheet joins and keeps the socket out of sheet broadcasts', async () => {
+    if (!baseUrl) return
+    const client = ioClient(baseUrl, { transports: ['websocket'] })
+    await waitForConnect(client, 'unauthenticated')
+
+    const denied = waitForEvent(client, 'join-denied', 'join denied')
+    client.emit('join-sheet', 'sheet_ops')
+    await expect(denied).resolves.toEqual({ sheetId: 'sheet_ops', reason: 'unauthorized' })
+
+    eventBus.publish('spreadsheet.cell.updated', {
+      spreadsheetId: 'sheet_ops',
+      actorId: 'user_editor',
+      source: 'multitable',
+      kind: 'record-updated',
+      recordIds: ['rec_1'],
+      fieldIds: ['fld_secret'],
+      recordPatches: [{ recordId: 'rec_1', patch: { fld_secret: 'SECRET_REALTIME_CANARY' } }],
+    })
+    await expectNoEvent(client, 'sheet:op', 'unauthenticated socket')
+    await expectNoEvent(client, 'sheet:presence', 'unauthenticated socket')
+
+    client.close()
+  })
+
+  it('rejects valid tokens without sheet read access', async () => {
+    if (!baseUrl) return
+    const client = ioClient(baseUrl, { transports: ['websocket'], auth: { token: 'token:user_denied' } })
+    await waitForConnect(client, 'non-reader')
+
+    const denied = waitForEvent(client, 'join-denied', 'join denied')
+    client.emit('join-sheet', 'sheet_ops')
+    await expect(denied).resolves.toEqual({ sheetId: 'sheet_ops', reason: 'forbidden' })
+
+    eventBus.publish('spreadsheet.cell.updated', {
+      spreadsheetId: 'sheet_ops',
+      actorId: 'user_editor',
+      source: 'multitable',
+      kind: 'record-updated',
+      recordIds: ['rec_1'],
+      fieldIds: ['fld_secret'],
+      recordPatches: [{ recordId: 'rec_1', patch: { fld_secret: 'SECRET_REALTIME_CANARY' } }],
+    })
+    await expectNoEvent(client, 'sheet:op', 'non-reader socket')
+
+    client.close()
+  })
+
+  it('uses token identity for presence and broadcasts value-free sheet invalidations to readers', async () => {
+    if (!baseUrl) return
+    const client = ioClient(`${baseUrl}?userId=spoofed_user`, {
+      transports: ['websocket'],
+      auth: { token: 'token:user_reader' },
+    })
+    await waitForConnect(client, 'reader')
+
+    const joined = waitForEvent(client, 'joined', 'reader join')
+    const presence = waitForEvent(client, 'sheet:presence', 'reader presence')
+    client.emit('join-sheet', 'sheet_ops')
+    await expect(joined).resolves.toEqual({ sheetId: 'sheet_ops' })
+    await expect(presence).resolves.toEqual({
+      sheetId: 'sheet_ops',
+      activeCount: 1,
+      users: [{ id: 'user_reader' }],
+    })
+
+    const op = waitForEvent(client, 'sheet:op', 'reader sheet op')
+    publishMultitableSheetRealtime({
+      spreadsheetId: 'sheet_ops',
+      actorId: 'user_editor',
+      source: 'multitable',
+      kind: 'record-updated',
+      recordIds: ['rec_1'],
+      fieldIds: ['fld_visible', 'fld_secret'],
+      recordPatches: [{
+        recordId: 'rec_1',
+        version: 10,
+        patch: { fld_visible: 'VISIBLE_CONTROL', fld_secret: 'SECRET_REALTIME_CANARY' },
+      }],
+    })
+    const payload = await op
+    expect(payload).toEqual({
+      type: 'cell-update',
+      data: {
+        spreadsheetId: 'sheet_ops',
+        actorId: 'user_editor',
+        source: 'multitable',
+        kind: 'record-updated',
+        recordIds: ['rec_1'],
+        fieldIds: ['fld_visible', 'fld_secret'],
+      },
+    })
+    expect(JSON.stringify(payload)).not.toContain('SECRET_REALTIME_CANARY')
+    expect(JSON.stringify(payload)).not.toContain('VISIBLE_CONTROL')
+
+    client.close()
   })
 
   it('join-comment-record scopes comment delivery to a single record room', async () => {
@@ -131,14 +291,9 @@ describe('WebSocket Rooms - basic flow', () => {
   it('join-sheet publishes deduplicated sheet presence for active users', async () => {
     if (!baseUrl || !server) return
 
-    const a1 = ioClient(`${baseUrl}?userId=user_a`, { transports: ['websocket'] })
-    const a2 = ioClient(`${baseUrl}?userId=user_a`, { transports: ['websocket'] })
-    const b = ioClient(`${baseUrl}?userId=user_b`, { transports: ['websocket'] })
-
-    const waitForConnect = (client: ReturnType<typeof ioClient>, label: string) => new Promise<void>((resolve, reject) => {
-      const t = setTimeout(() => reject(new Error(`${label} connect timeout`)), 3000)
-      client.on('connect', () => { clearTimeout(t); resolve() })
-    })
+    const a1 = ioClient(`${baseUrl}?userId=spoofed_a1`, { transports: ['websocket'], auth: { token: 'token:user_a' } })
+    const a2 = ioClient(`${baseUrl}?userId=spoofed_a2`, { transports: ['websocket'], auth: { token: 'token:user_a' } })
+    const b = ioClient(`${baseUrl}?userId=spoofed_b`, { transports: ['websocket'], auth: { token: 'token:user_b' } })
 
     const waitForPresence = (
       client: ReturnType<typeof ioClient>,

--- a/packages/core-backend/tests/unit/multitable-realtime-publish.test.ts
+++ b/packages/core-backend/tests/unit/multitable-realtime-publish.test.ts
@@ -1,0 +1,48 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+
+describe('publishMultitableSheetRealtime', () => {
+  afterEach(() => {
+    vi.resetModules()
+    vi.restoreAllMocks()
+  })
+
+  it('invalidates the records cache and publishes value-free sheet metadata', async () => {
+    const publish = vi.fn()
+    vi.doMock('../../src/integration/events/event-bus', () => ({
+      eventBus: { publish, emit: vi.fn(), subscribe: vi.fn(), unsubscribe: vi.fn() },
+    }))
+
+    const { publishMultitableSheetRealtime, setRealtimeCacheInvalidator } = await import('../../src/multitable/realtime-publish')
+    const invalidate = vi.fn()
+    setRealtimeCacheInvalidator(invalidate)
+
+    publishMultitableSheetRealtime({
+      spreadsheetId: 'sheet_ops',
+      actorId: 'user_editor',
+      source: 'multitable',
+      kind: 'record-updated',
+      recordId: 'rec_1',
+      recordIds: ['rec_1'],
+      fieldIds: ['fld_secret'],
+      recordPatches: [{
+        recordId: 'rec_1',
+        version: 9,
+        patch: { fld_secret: 'SECRET_REALTIME_CANARY' },
+      }],
+    })
+
+    expect(invalidate).toHaveBeenCalledWith('sheet_ops')
+    expect(publish).toHaveBeenCalledWith('spreadsheet.cell.updated', {
+      spreadsheetId: 'sheet_ops',
+      actorId: 'user_editor',
+      source: 'multitable',
+      kind: 'record-updated',
+      recordId: 'rec_1',
+      recordIds: ['rec_1'],
+      fieldIds: ['fld_secret'],
+    })
+    const payload = publish.mock.calls[0]?.[1]
+    expect(payload).not.toHaveProperty('recordPatches')
+    expect(JSON.stringify(payload)).not.toContain('SECRET_REALTIME_CANARY')
+  })
+})


### PR DESCRIPTION
## Summary
- gate Socket.IO sheet rooms with verified token identity + per-sheet canRead before joining
- strip value-bearing recordPatches from multitable sheet realtime broadcasts; clients refetch changed records through gated read paths
- switch realtime clients to auth.token, add backend/frontend regression coverage, and wire real-DB/plugin CI coverage

## Verification
- pnpm --filter @metasheet/core-backend exec tsc --noEmit
- pnpm --filter @metasheet/web exec vue-tsc -b
- pnpm --filter @metasheet/web exec vitest run --watch=false tests/multitable-sheet-realtime.spec.ts tests/multitable-sheet-presence.spec.ts tests/multitable-comment-realtime.spec.ts
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-realtime-publish.test.ts tests/unit/record-write-service.test.ts tests/unit/record-service.test.ts --reporter=dot
- pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/rooms.basic.test.ts tests/integration/multitable-sheet-realtime.api.test.ts tests/integration/multitable-attachments.api.test.ts --reporter=dot
- git diff --check

## Notes
- Implements the #2181 design-lock: room gate + value-free invalidation in one slice.
- A broader web workbench spec run still has one unrelated workflow-designer failure; touched realtime specs passed and this is recorded in the verification doc.
- Not merged; awaiting review/CI and explicit merge greenlight.