### PR TITLE
fix(multitable): mask POST /records create echo by field_permissions (F4)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -180,6 +180,7 @@ jobs:
             tests/integration/multitable-records-summary-field-mask.test.ts \
             tests/integration/multitable-dashboard-chart-authz.test.ts \
             tests/integration/multitable-write-echo-field-mask.test.ts \
+            tests/integration/multitable-create-echo-field-mask.test.ts \
             tests/integration/multitable-cross-sheet-related-echo-mask.test.ts \
             tests/integration/multitable-sheet-realtime.api.test.ts \
             tests/integration/rooms.basic.test.ts \

--- a/docs/development/multitable-create-echo-field-mask-verification-20260601.md
+++ b/docs/development/multitable-create-echo-field-mask-verification-20260601.md
@@ -1,0 +1,38 @@
+# F4 — `POST /records` create-echo field mask · verification
+
+**Date:** 2026-06-01
+**Design-lock:** `docs/development/multitable-record-egress-fieldperm-inventory-20260529.md` (#2106) §3 F4.
+**Scope:** the `POST /records` create echo only. No central RBAC/auth (K3 Stage-1 lock).
+
+## The hole
+
+`POST /records` returned the created record's `result.data` **unmasked**. The create write gate is **layer-2 only** (`createRecord` checks `canCreateRecord` + `isFieldAlwaysReadOnly`, never `field_permissions`), so a `field_permissions.visible=false` value reached the echo two ways:
+- **write-only-no-read** — a denied non-readonly field is *writable*, so the creator could supply it and get it echoed back (the F3 principle: a read-gated echo must omit it even when the caller wrote it); and
+- **server-assigned** — a denied **auto-number** the creator never supplied is allocated by `allocateAutoNumberValues` and echoed back as genuinely new info.
+
+## The fix
+
+After `createRecord`, compute the layer-2 ∧ layer-3 `allowedFieldIds` composite (the #2028 read-mask pattern, keyed to the creator) and `filterRecordDataByFieldIds(result.data, allowedFieldIds)` before echoing. The create **write** is unchanged (still layer-2), so write-only fields persist; only the echo is masked. One site, no service change.
+
+## Fail-first (real DB)
+
+`tests/integration/multitable-create-echo-field-mask.test.ts` (wired into `plugin-tests.yml`). Seed: `FLD_SECRET`/`FLD_AUTONUM.property` carry no `hidden` → deny is solely layer-3.
+
+| # | Scenario | Pre-fix | Post-fix |
+|---|---|---|---|
+| R1 | create supplying a denied field (write-only-no-read) | echoes the value | omitted; DB still persists it (`+` positive control `FLD_VISIBLE`) |
+| **R2** | create → denied **auto-number** the creator never supplied | echoes the assigned number | omitted; DB still has it assigned |
+| R3 | create as an ungranted-to-deny user | — | denied field + auto-number **present** (mask is per-subject) |
+
+- **RED proven**: R1 (`expected '<canary>' to be undefined`) + R2 (`expected 2 to be undefined`) failed on unmodified origin/main → **4/4 GREEN** post-fix. R3's positive control confirms the auto-number actually materializes, so R2's RED is a real server-assigned leak, not a vacuous empty.
+
+## Regression / type
+
+- `tsc --noEmit` exit 0.
+- `records-read-field-mask` + `write-echo-field-mask` → **13/13**; `sheet-realtime.api` → **3/3** (after the stub below).
+- **Mock stub — F4 adds a query to the create path.** `multitable-sheet-realtime.api.test.ts` runs in the real-DB step but **mocks the pool**; its create dispatcher didn't handle F4's `loadSheetFields` (`…, "order" FROM meta_fields …`) + `field_permissions` queries → the create returned **500**. Added both stubs (no denials, mirroring its existing `meta_fields` handler). **CI caught this** — my first local regression batch missed `sheet-realtime`; lesson: run every mocked test that hits the changed route (the F3 record-patch analog).
+- `multitable-record-form.api.test.ts` etc. fail under the **integration config** locally but pass in CI's **default** config — the default suite ran **265 files / 3521 tests green** with F4 — so those are config artifacts, not F4 regressions.
+
+## Diff scope
+
+`univer-meta.ts` (create echo, +mask), the new test, the one-line CI wiring, this doc.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -8199,13 +8199,25 @@ export function univerMetaRouter(): Router {
         data,
       })
 
+      // F4 (#2106 §3 F4): the create echo previously returned result.data UNMASKED, so a field_permissions-
+      // denied value — whether the creator wrote it (the create write gate is layer-2 only) or the server
+      // assigned it (e.g. an auto-number) — was handed back. Apply the layer-2 ∧ layer-3 read mask (the #2028
+      // composite); the create write itself is unchanged. access.userId is guaranteed truthy past the 401 above.
+      const fields = await loadSheetFields(pool as unknown as { query: QueryFn }, sheetId)
+      const visiblePropertyFields = filterVisiblePropertyFields(fields)
+      const fieldScopeMap = await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, access.userId)
+      const securityFieldPermissions = deriveFieldPermissions(visiblePropertyFields, capabilities, { hiddenFieldIds: [], fieldScopeMap })
+      const allowedFieldIds = new Set(
+        visiblePropertyFields.filter((field) => securityFieldPermissions[field.id]?.visible !== false).map((field) => field.id),
+      )
+
       return res.json({
         ok: true,
         data: {
           record: {
             id: result.recordId,
             version: result.version,
-            data: result.data,
+            data: filterRecordDataByFieldIds(result.data, allowedFieldIds),
           },
         },
       })

--- a/packages/core-backend/tests/integration/multitable-create-echo-field-mask.test.ts
+++ b/packages/core-backend/tests/integration/multitable-create-echo-field-mask.test.ts
@@ -1,0 +1,106 @@
+/**
+ * Real-DB integration test for F4 — POST /records create-echo field mask.
+ * Design-lock: docs/development/multitable-record-egress-fieldperm-inventory-20260529.md (#2106) §3 F4.
+ *
+ * `POST /records` echoes the created record's `result.data` UNMASKED (`univer-meta.ts`, create handler).
+ * The create write gate is layer-2 only (`canCreateRecord` + `isFieldAlwaysReadOnly`; `createRecord` never
+ * consults field_permissions), so:
+ *   - a `field_permissions.visible=false` non-readonly field is WRITABLE → the creator can supply it and the
+ *     echo hands it back (write-only-no-read, R1 — the F3-parallel principle: a read-gated echo must omit it
+ *     even when the caller wrote it); and
+ *   - a SERVER-ASSIGNED value on a denied field — e.g. an auto-number the creator never supplied — is echoed
+ *     back as genuinely new info (R2, the unambiguous leak).
+ * F4 applies the layer-2 ∧ layer-3 mask (the #2028 composite) to the create echo, leaving the write untouched.
+ *
+ * Seed non-negotiable: FLD_SECRET/FLD_AUTONUM.property carry no `hidden` → deny is solely layer-3.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_f4_${TS}`
+const SHEET_ID = `sheet_f4_${TS}`
+const FLD_VISIBLE = `fld_f4_visible_${TS}` // string, readable — positive control
+const FLD_SECRET = `fld_f4_secret_${TS}` // string, layer-3-denied — write-only-no-read (R1)
+const FLD_AUTONUM = `fld_f4_auto_${TS}` // autoNumber, layer-3-denied — server-assigned leak (R2)
+const USER_ID = `u_f4_${TS}` // FLD_SECRET + FLD_AUTONUM denied
+const USER_ID_2 = `u_f4_other_${TS}` // no deny → positive control
+
+let app: Express
+let currentUser: { id: string; roles: string[]; perms: string[] } = { id: USER_ID, roles: ['member'], perms: ['multitable:write'] }
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const createReq = (body: Record<string, unknown>) => request(app).post('/api/multitable/records').send(body)
+const dbField = async (recordId: string, fieldId: string) => {
+  const r = await q('SELECT data FROM meta_records WHERE id = $1', [recordId])
+  return ((r.rows[0]?.data ?? {}) as Record<string, unknown>)[fieldId]
+}
+
+describeIfDatabase('F4 create-echo field mask (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = currentUser; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'F4 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'F4 Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_VISIBLE, SHEET_ID, 'Visible', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRET, SHEET_ID, 'Secret', 'string', '{}', 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_AUTONUM, SHEET_ID, 'Auto', 'autoNumber', '{}', 3])
+    // layer-3 read deny (subject-scoped); property carries no hidden so the deny is solely here.
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER_ID, false, false])
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_AUTONUM, 'user', USER_ID, false, false])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_field_auto_number_sequences WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('R1 (write-only-no-read): creating with a denied field → write persists but the create echo omits it', async () => {
+    currentUser = { id: USER_ID, roles: ['member'], perms: ['multitable:write'] }
+    const canary = `do-not-leak-f4-create-${TS}`
+    const res = await createReq({ sheetId: SHEET_ID, data: { [FLD_VISIBLE]: 'r1-vis', [FLD_SECRET]: canary } })
+    expect(res.status).toBe(200)
+    const rec = res.body.data.record
+    expect(rec.data[FLD_VISIBLE]).toBe('r1-vis') // positive control
+    expect(rec.data[FLD_SECRET]).toBeUndefined() // THE LEAK (RED pre-fix)
+    expect(rec.data[FLD_AUTONUM]).toBeUndefined() // server-assigned but denied → also omitted
+    expect(JSON.stringify(res.body)).not.toContain(canary)
+    expect(await dbField(rec.id, FLD_SECRET)).toBe(canary) // ...but the write really happened — mask is echo-only
+  })
+
+  test('R2 (server-assigned leak): a denied AUTO-NUMBER the creator never supplied is omitted from the echo (but assigned in DB)', async () => {
+    currentUser = { id: USER_ID, roles: ['member'], perms: ['multitable:write'] }
+    const res = await createReq({ sheetId: SHEET_ID, data: { [FLD_VISIBLE]: 'r2-vis' } }) // FLD_AUTONUM NOT supplied
+    expect(res.status).toBe(200)
+    const rec = res.body.data.record
+    expect(rec.data[FLD_VISIBLE]).toBe('r2-vis')
+    expect(rec.data[FLD_AUTONUM]).toBeUndefined() // THE LEAK (RED pre-fix): server-assigned, creator can't read it
+    expect(await dbField(rec.id, FLD_AUTONUM)).toBeDefined() // ...the auto-number WAS assigned, just masked from the echo
+  })
+
+  test('R3 (positive): an ungranted-to-deny user gets the denied + auto-number values back (mask is per-subject)', async () => {
+    currentUser = { id: USER_ID_2, roles: ['member'], perms: ['multitable:write'] }
+    const canary = `f4-other-${TS}`
+    const res = await createReq({ sheetId: SHEET_ID, data: { [FLD_VISIBLE]: 'r3-vis', [FLD_SECRET]: canary } })
+    expect(res.status).toBe(200)
+    const rec = res.body.data.record
+    expect(rec.data[FLD_SECRET]).toBe(canary)
+    expect(rec.data[FLD_AUTONUM]).toBeDefined()
+    currentUser = { id: USER_ID, roles: ['member'], perms: ['multitable:write'] }
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-sheet-realtime.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-realtime.api.test.ts
@@ -91,6 +91,14 @@ describe('Multitable sheet realtime events', () => {
         if (sql.includes('INSERT INTO meta_record_revisions')) {
           return { rows: [], rowCount: 1 }
         }
+        // F4: the create echo now resolves the layer-2 ∧ layer-3 field-read mask
+        // (loadSheetFields with "order" + field_permissions); no denials in this mock.
+        if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1')) {
+          return { rows: [{ id: 'fld_title', name: 'Title', type: 'string', property: {}, order: 1 }] }
+        }
+        if (sql.includes('field_permissions')) {
+          return { rows: [] }
+        }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })


### PR DESCRIPTION
## Summary

Closes **F4** from the #2106 inventory: `POST /records` returned the created record's `result.data` **unmasked**. The create write gate is **layer-2 only** (`createRecord` checks `canCreateRecord` + always-readonly, never `field_permissions`), so a `visible=false` value reached the echo two ways:
- **write-only-no-read** — a denied non-readonly field is writable, so the creator can supply it and get it echoed back (the F3 principle);
- **server-assigned** — a denied **auto-number** the creator never supplied is allocated and echoed back as genuinely new info.

F4 applies the layer-2 ∧ layer-3 `allowedFieldIds` mask (the #2028 composite) to the create echo; the **write is unchanged** (write-only fields persist, just masked from the echo). One site, no service change.

## Fail-first (real DB)

`multitable-create-echo-field-mask.test.ts`: **R1** write-only-no-read (creator supplies a denied field → echo omits, DB persists) + **R2** server-assigned auto-number (denied auto-number the creator never supplied → echo omits, DB still assigns it) RED on origin/main → **4/4 GREEN**. R3's positive control confirms the auto-number materializes, so R2 is a real leak (not a vacuous empty).

## Regression / type

tsc exit 0; `records-read-field-mask` + `write-echo-field-mask` **13/13**. `record-form.api` fails **8/19 identically with F4 stashed (pristine)** — `pg_advisory_xact_lock`/context/`meta_fields` mock gaps, **none `field_permissions`** → pre-existing, not an F4 regression (no mock stub needed).

See `docs/development/multitable-create-echo-field-mask-verification-20260601.md`.

## Scope

Create echo only; reuses the #2028 composite; no new capability, no central RBAC/auth (K3 Stage-1 lock).

🤖 Generated with [Claude Code](https://claude.com/claude-code)