### PR TITLE
feat(multitable): A6-1 enable-writer — accept execution_mode on rule create/update

### DIFF
--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -67,6 +67,24 @@ const VALID_ACTION_TYPES = new Set([
   'lock_record',
 ])
 
+// A6-1 opt-in (#2130 runtime): a rule may persist one C1 WorkflowJob row per action.
+// `null`/`'legacy'` both mean the legacy fire-and-forget path (no job rows); only
+// `'workflow_job_v1'` switches on persistence (executor gate: `persistJobs === 'workflow_job_v1'`).
+const VALID_EXECUTION_MODES = new Set(['legacy', 'workflow_job_v1'])
+
+/**
+ * Validate the A6-1 `execution_mode` opt-in flag. Lives in the service (not the route
+ * parser) because `createRule`/`updateRule` are the unbypassable persistence boundary —
+ * a direct service caller must not be able to write a junk mode. `undefined`/`null` →
+ * `null` (off); a recognized string passes through; anything else is rejected so the
+ * caller never silently falls back to a default. Throws `AutomationRuleValidationError`.
+ */
+function normalizeExecutionMode(value: unknown): string | null {
+  if (value === undefined || value === null) return null
+  if (typeof value === 'string' && VALID_EXECUTION_MODES.has(value)) return value
+  throw new AutomationRuleValidationError(`Invalid execution_mode: ${String(value)}`)
+}
+
 function normalizeStringList(value: unknown): string[] {
   if (!Array.isArray(value)) return []
   return value
@@ -175,6 +193,8 @@ export interface CreateRuleInput {
   createdBy?: string | null
   conditions?: ConditionGroup | null
   actions?: AutomationAction[] | null
+  // A6-1 opt-in; validated by normalizeExecutionMode in createRule (not here).
+  executionMode?: string | null
 }
 
 /** Input for updating a rule */
@@ -187,6 +207,8 @@ export interface UpdateRuleInput {
   enabled?: boolean
   conditions?: ConditionGroup | null
   actions?: AutomationAction[] | null
+  // A6-1 opt-in; validated by normalizeExecutionMode in updateRule (not here).
+  executionMode?: string | null
 }
 
 /**
@@ -381,6 +403,8 @@ export class AutomationService {
     )
     if (linkValidationError) throw new AutomationRuleValidationError(linkValidationError)
 
+    const executionMode = normalizeExecutionMode(input.executionMode)
+
     const row = {
       id: ruleId,
       sheet_id: sheetId,
@@ -393,6 +417,7 @@ export class AutomationService {
       created_by: input.createdBy ?? null,
       conditions: input.conditions ? JSON.stringify(input.conditions) : null,
       actions: actions ? JSON.stringify(actions) : null,
+      execution_mode: executionMode,
     }
 
     await this.db
@@ -414,6 +439,7 @@ export class AutomationService {
       created_by: input.createdBy ?? null,
       conditions: input.conditions ?? null,
       actions,
+      execution_mode: executionMode,
     }
 
     this.registerSchedule(rule)
@@ -511,6 +537,7 @@ export class AutomationService {
     if (input.enabled !== undefined) updates.enabled = input.enabled
     if (input.conditions !== undefined) updates.conditions = input.conditions ? JSON.stringify(input.conditions) : null
     if (input.actions !== undefined) updates.actions = normalizedActionsForUpdate ? JSON.stringify(normalizedActionsForUpdate) : null
+    if (input.executionMode !== undefined) updates.execution_mode = normalizeExecutionMode(input.executionMode)
 
     if (Object.keys(updates).length === 0) return this.getRule(ruleId)
 
@@ -831,6 +858,7 @@ export type SerializedAutomationRule = {
   createdAt: string
   updatedAt: string
   createdBy: string | undefined
+  executionMode: string | null
 }
 
 /**
@@ -859,6 +887,7 @@ export function serializeAutomationRule(rule: AutomationRule): SerializedAutomat
     createdAt: rule.created_at,
     updatedAt: rule.updated_at,
     createdBy: rule.created_by ?? undefined,
+    executionMode: rule.execution_mode ?? null,
   }
 }
 
@@ -885,7 +914,7 @@ export function parseCreateRuleInput(
   const triggerConfig = body?.triggerConfig && typeof body.triggerConfig === 'object'
     ? body.triggerConfig as Record<string, unknown>
     : {}
-  let actions: unknown[] | null = Array.isArray(body?.actions) ? body!.actions as unknown[] : null
+  const actions: unknown[] | null = Array.isArray(body?.actions) ? body!.actions as unknown[] : null
   const firstAction = actions?.find(
     (item): item is Record<string, unknown> => !!item && typeof item === 'object' && !Array.isArray(item),
   )
@@ -925,6 +954,8 @@ export function parseCreateRuleInput(
     createdBy,
     conditions,
     actions: actions as AutomationAction[] | null,
+    // Forwarded raw; createRule's normalizeExecutionMode validates/rejects (single source).
+    executionMode: body?.executionMode as string | null | undefined,
   }
 }
 
@@ -975,6 +1006,12 @@ export function parseUpdateRuleInput(body: Record<string, unknown> | undefined):
   }
   if (body?.actions !== undefined) {
     input.actions = Array.isArray(body.actions) ? (body.actions as AutomationAction[]) : null
+    touched = true
+  }
+  if (body?.executionMode !== undefined) {
+    // Forwarded raw (incl. explicit null = reset to off); updateRule's
+    // normalizeExecutionMode validates/rejects (single source).
+    input.executionMode = body.executionMode as string | null
     touched = true
   }
 

--- a/packages/core-backend/tests/integration/multitable-automation-jobs.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-jobs.test.ts
@@ -12,6 +12,9 @@ import { afterAll, beforeAll, describe, expect, test } from 'vitest'
 
 import { poolManager } from '../../src/integration/db/connection-pool'
 import { AutomationJobService } from '../../src/multitable/automation-job-service'
+import { AutomationService } from '../../src/multitable/automation-service'
+import { EventBus } from '../../src/integration/events/event-bus'
+import { db } from '../../src/db/db'
 
 const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
 
@@ -70,5 +73,37 @@ describeIfDatabase('multitable automation jobs (A6-1, real DB)', () => {
   test('listByExecution returns [] for an execution with no jobs (legacy fallback signal)', async () => {
     const views = await jobs.listByExecution(`axe_none_${TS}`)
     expect(views).toEqual([])
+  })
+
+  // A6-1 enable-writer: the opt-in flag must round-trip through the REAL automation_rules
+  // column. Mock-db unit tests assert the INSERT payload; only this proves the migration
+  // column exists, Kysely accepts it, and mapRow reads it back (the wire-vs-fixture gap).
+  test('enable-writer: createRule persists execution_mode and getRule reads it back; off-path is null', async () => {
+    const sheetId = `sheet_enable_${TS}`
+    const svc = new AutomationService(
+      new EventBus(),
+      db as never,
+      (async () => ({ rows: [], rowCount: 0 })) as never,
+    )
+    const createdIds: string[] = []
+    try {
+      const optIn = await svc.createRule(sheetId, {
+        name: 'opt-in', triggerType: 'record.created', triggerConfig: {},
+        actionType: 'update_record', actionConfig: { fields: { status: 'done' } },
+        executionMode: 'workflow_job_v1',
+      })
+      createdIds.push(optIn.id)
+      expect(optIn.execution_mode).toBe('workflow_job_v1')
+      expect((await svc.getRule(optIn.id))?.execution_mode).toBe('workflow_job_v1')
+
+      const legacy = await svc.createRule(sheetId, {
+        name: 'legacy', triggerType: 'record.created', triggerConfig: {},
+        actionType: 'update_record', actionConfig: { fields: { status: 'done' } },
+      })
+      createdIds.push(legacy.id)
+      expect((await svc.getRule(legacy.id))?.execution_mode).toBeNull()
+    } finally {
+      for (const id of createdIds) await q('DELETE FROM automation_rules WHERE id = $1', [id])
+    }
   })
 })

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -2673,6 +2673,65 @@ describe('AutomationService — Rule CRUD', () => {
     expect(rules).toHaveLength(1)
     expect(rules[0].enabled).toBe(true)
   })
+
+  it('A6-1: createRule writes execution_mode to the INSERT row + returned rule; rejects an invalid mode', async () => {
+    // Self-contained capturing db so we can inspect the INSERT payload — the row whitelist at
+    // createRule 384-396 that a returned-object assertion alone would not catch (wire-vs-fixture).
+    const insertValues: Record<string, unknown>[] = []
+    const chain: Record<string, unknown> = {}
+    const chainFn = () => chain
+    for (const m of [
+      'selectFrom', 'selectAll', 'select', 'where', 'orderBy', 'limit', 'offset', 'groupBy',
+      'insertInto', 'onConflict', 'columns', 'doUpdateSet', 'updateTable', 'set', 'deleteFrom',
+      'returningAll', 'leftJoin',
+    ]) chain[m] = vi.fn(chainFn)
+    chain.values = vi.fn((v: Record<string, unknown>) => { insertValues.push(v); return chain })
+    chain.execute = vi.fn(async () => [])
+    chain.executeTakeFirst = vi.fn(async () => undefined)
+    const localService = new AutomationService(
+      new EventBus(),
+      chain as never,
+      vi.fn(async () => ({ rows: [], rowCount: 0 })) as never,
+    )
+
+    const rule = await localService.createRule('sheet_1', {
+      name: 'opt-in', triggerType: 'record.created', triggerConfig: {},
+      actionType: 'update_record', actionConfig: { fields: { status: 'done' } }, createdBy: 'u1',
+      executionMode: 'workflow_job_v1',
+    })
+    expect(insertValues.at(-1)?.execution_mode).toBe('workflow_job_v1') // INSERT-row whitelist guard
+    expect(rule.execution_mode).toBe('workflow_job_v1')                 // returned-object whitelist guard
+
+    await expect(localService.createRule('sheet_1', {
+      name: 'bad', triggerType: 'record.created', triggerConfig: {},
+      actionType: 'update_record', actionConfig: { fields: { status: 'done' } },
+      executionMode: 'nope' as unknown as string,
+    })).rejects.toThrow(AutomationRuleValidationError)
+  })
+
+  it('A6-1: updateRule writes execution_mode into the UPDATE set payload', async () => {
+    const setPayloads: Record<string, unknown>[] = []
+    const ruleRow = makeRuleRow({ execution_mode: 'workflow_job_v1' })
+    const chain: Record<string, unknown> = {}
+    const chainFn = () => chain
+    for (const m of [
+      'selectFrom', 'selectAll', 'select', 'where', 'orderBy', 'limit', 'offset', 'groupBy',
+      'insertInto', 'values', 'onConflict', 'columns', 'doUpdateSet', 'updateTable', 'deleteFrom',
+      'returningAll', 'leftJoin',
+    ]) chain[m] = vi.fn(chainFn)
+    chain.set = vi.fn((v: Record<string, unknown>) => { setPayloads.push(v); return chain })
+    chain.execute = vi.fn(async () => [ruleRow])
+    chain.executeTakeFirst = vi.fn(async () => undefined)
+    const localService = new AutomationService(
+      new EventBus(),
+      chain as never,
+      vi.fn(async () => ({ rows: [], rowCount: 0 })) as never,
+    )
+
+    const updated = await localService.updateRule('atr_1', 'sheet_1', { executionMode: 'workflow_job_v1' })
+    expect(setPayloads.at(-1)?.execution_mode).toBe('workflow_job_v1') // UPDATE-set whitelist guard
+    expect(updated?.execution_mode).toBe('workflow_job_v1')
+  })
 })
 
 describe('AutomationService — retryExecution (A5)', () => {

--- a/packages/core-backend/tests/unit/multitable-automation-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-service.test.ts
@@ -385,6 +385,7 @@ describe('M5 — Automation route helpers', () => {
         createdAt: '2026-01-02T03:04:05Z',
         updatedAt: '2026-01-02T03:04:05Z',
         createdBy: 'user_a',
+        executionMode: null,
       })
     })
 
@@ -393,6 +394,13 @@ describe('M5 — Automation route helpers', () => {
       const out = serializeAutomationRule(rule)
       expect(out.name).toBe('')
       expect(out.createdBy).toBeUndefined()
+    })
+
+    it('A6-1: emits executionMode (null when unset, the opt-in value when set)', () => {
+      expect(serializeAutomationRule(createMockRule({})).executionMode).toBeNull()
+      expect(
+        serializeAutomationRule(createMockRule({ execution_mode: 'workflow_job_v1' })).executionMode,
+      ).toBe('workflow_job_v1')
     })
   })
 
@@ -524,6 +532,22 @@ describe('M5 — Automation route helpers', () => {
       expect(input.conditions).toBeNull()
       expect(input.actions).toBeNull()
     })
+
+    it('A6-1: forwards executionMode raw for the service to validate', () => {
+      expect(
+        parseCreateRuleInput(
+          { triggerType: 'record.created', actionType: 'send_notification', executionMode: 'workflow_job_v1' },
+          null,
+        ).executionMode,
+      ).toBe('workflow_job_v1')
+      // Absent → undefined (createRule normalizes to null = off).
+      expect(
+        parseCreateRuleInput(
+          { triggerType: 'record.created', actionType: 'send_notification' },
+          null,
+        ).executionMode,
+      ).toBeUndefined()
+    })
   })
 
   describe('parseUpdateRuleInput', () => {
@@ -587,6 +611,14 @@ describe('M5 — Automation route helpers', () => {
     it('accepts the legacy `notify` and `update_field` action types', () => {
       expect(parseUpdateRuleInput({ actionType: 'notify' })?.actionType).toBe('notify')
       expect(parseUpdateRuleInput({ actionType: 'update_field' })?.actionType).toBe('update_field')
+    })
+
+    it('A6-1: forwards executionMode (incl. explicit null) as a touched field', () => {
+      expect(parseUpdateRuleInput({ executionMode: 'workflow_job_v1' })?.executionMode).toBe('workflow_job_v1')
+      // Explicit null is a real update (reset to off), so the body is touched, not null-returned.
+      const reset = parseUpdateRuleInput({ executionMode: null })
+      expect(reset).not.toBeNull()
+      expect(reset?.executionMode).toBeNull()
     })
   })
 


### PR DESCRIPTION
First runtime rung of the A6 convergence-engine plan (#2187 §1). Makes the **DORMANT** A6-1 persistent WorkflowJob runtime (#2130) reachable: a rule can now opt into `execution_mode: 'workflow_job_v1'` through the normal create/update API. The column, db type, `mapRow`, and the executor gate (`persistJobs === 'workflow_job_v1'`) all shipped in #2130 but no rule could opt in via the API (DB/fixture only). **No migration; no new engine semantics.**

## Wire path (every hop threaded; verified, not assumed)
`execution_mode` had to thread through a multi-hop whitelist gauntlet (the wire-vs-fixture trap):
- inbound: `parseCreateRuleInput` / `parseUpdateRuleInput` (forward raw) → `preflightDingTalkAutomation*` (spread `...input`, pass-through) → `createRule` INSERT **row** + returned object → `updateRule` partial `set`.
- outbound: `SerializedAutomationRule` type + `serializeAutomationRule`. (`mapRow` already mapped it from #2130.)

## Validation — in the service, not the parser
`normalizeExecutionMode()` lives in `createRule`/`updateRule` (the unbypassable persistence boundary, where `triggerType`/`actionType` are also validated) — a direct service caller can't write a junk mode. Accepts `null`/`'legacy'`/`'workflow_job_v1'`; **rejects anything else** (400 via the route's existing `AutomationRuleValidationError` catch) — no silent default. Parsers forward raw so an invalid value still reaches the validator. `updateRule`: absent = unchanged, explicit `null` = reset to off.

## Tests — drift guards that run every PR + real-DB proof
- **unit (no DB, every PR):** parse forwards it; `createRule` writes it to the **INSERT row** (`insertValues.at(-1).execution_mode`) and the returned rule; `updateRule` writes it to the **set payload**; `serializeAutomationRule` emits it; invalid mode rejected. **Proven red** by stashing the INSERT-row field-add (guard catches the whitelist drop).
- **integration (`DATABASE_URL`):** `createRule → getRule` round-trips `execution_mode` through real Postgres; off-path reads back `null`. (Existing #2130 jobs test already proves the opted-in executor writes jobs end-to-end.)
- Full backend unit suite green (2654); `tsc` + eslint clean.

## Scope / posture
- **API-first**; a minimal admin UI toggle is deferred to a follow slice (the backend on-switch is the load-bearing part).
- Existing fire-and-forget rules unaffected (default off). Automations aren't in the OpenAPI parity surface → no spec delta.
- Incidental: `prefer-const` on a pre-existing `let actions` in the function this PR extends.

Per the established §6 discipline this is **review-then-merge** — holding for your explicit review/approve (not self-merging on CI-green). A6-2+ remain demand-gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)