### PR TITLE
feat(multitable): A6-1 admin UI toggle for execution_mode (enable-writer follow slice)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -260,6 +260,7 @@ function normalizeAutomationRulePayload(value: unknown): AutomationRule {
     createdAt: optionalStringValue(record.createdAt ?? record.created_at),
     updatedAt: optionalStringValue(record.updatedAt ?? record.updated_at),
     createdBy: optionalStringValue(record.createdBy ?? record.created_by),
+    executionMode: optionalStringValue(record.executionMode ?? record.execution_mode) ?? null,
   }
 }
 

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -13,6 +13,18 @@
         <label class="meta-rule-editor__label">{{ automationLabel('editor.name', isZh) }}</label>
         <input v-model="draft.name" class="meta-rule-editor__input" type="text" :placeholder="automationLabel('editor.namePlaceholder', isZh)" data-field="name" />
 
+        <!-- Execution mode (A6-1 opt-in): persist a per-action WorkflowJob plane -->
+        <label class="meta-rule-editor__label" data-field="executionModeToggle">
+          <input
+            type="checkbox"
+            :checked="draft.executionMode === 'workflow_job_v1'"
+            data-field="executionMode"
+            @change="setExecutionMode(($event.target as HTMLInputElement).checked)"
+          />
+          {{ automationLabel('editor.executionModeLabel', isZh) }}
+        </label>
+        <div class="meta-rule-editor__hint" data-field="executionModeHint">{{ automationLabel('editor.executionModeHint', isZh) }}</div>
+
         <!-- 1. Trigger selector -->
         <section class="meta-rule-editor__section">
           <div class="meta-rule-editor__section-title">{{ automationLabel('trigger.title', isZh) }}</div>
@@ -1025,6 +1037,7 @@ interface Draft {
   triggerConfig: Record<string, unknown>
   conditions: ConditionGroup & { conjunction: 'AND' | 'OR' }
   actions: DraftAction[]
+  executionMode: string | null
 }
 
 type FieldOption = { value: string; label?: string; color?: string }
@@ -1482,6 +1495,7 @@ function emptyDraft(): Draft {
     triggerConfig: {},
     conditions: { conjunction: 'AND', conditions: [] },
     actions: [{ type: 'update_record', config: defaultConfigForActionType('update_record') }],
+    executionMode: null,
   }
 }
 
@@ -1540,11 +1554,17 @@ function draftFromRule(rule: AutomationRule): Draft {
     actions: rule.actions && rule.actions.length
       ? rule.actions.map((a) => ({ type: a.type, config: draftConfigFromAction(a.type, a.config) }))
       : [{ type: rule.actionType, config: draftConfigFromAction(rule.actionType, rule.actionConfig) }],
+    executionMode: rule.executionMode ?? null,
   }
 }
 
 const draft = ref<Draft>(emptyDraft())
 const conditionEditorEntries = computed(() => collectConditionEditorEntries(draft.value.conditions.conditions))
+
+function setExecutionMode(checked: boolean): void {
+  // A6-1 opt-in: checkbox → the rule's persistent WorkflowJob mode (off = legacy/null).
+  draft.value.executionMode = checked ? 'workflow_job_v1' : null
+}
 
 function conditionPathKey(path: ConditionPath): string {
   return path.join('-') || 'root'
@@ -2405,6 +2425,7 @@ function buildPayload(): Partial<AutomationRule> {
     actions,
     actionType: actions[0]?.type ?? 'update_record',
     actionConfig: actions[0]?.config ?? {},
+    executionMode: d.executionMode,
   }
 }
 

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -805,6 +805,8 @@ export interface AutomationRule {
   actionType: AutomationActionType
   actionConfig: Record<string, unknown>
   enabled: boolean
+  // A6-1 opt-in: 'workflow_job_v1' persists a per-action WorkflowJob plane; null/'legacy' = off.
+  executionMode?: string | null
   createdAt?: string
   updatedAt?: string
   createdBy?: string

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -91,6 +91,8 @@ export type AutomationLabelKey =
   | 'editor.moveUpTitle'
   | 'editor.moveDownTitle'
   | 'editor.removeActionTitle'
+  | 'editor.executionModeLabel'
+  | 'editor.executionModeHint'
   | 'trigger.title'
   | 'trigger.watchField'
   | 'trigger.selectField'
@@ -296,6 +298,8 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'editor.moveUpTitle',
   'editor.moveDownTitle',
   'editor.removeActionTitle',
+  'editor.executionModeLabel',
+  'editor.executionModeHint',
   'trigger.title',
   'trigger.watchField',
   'trigger.selectField',
@@ -502,6 +506,14 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'editor.moveUpTitle': { en: 'Move up', zh: '上移' },
   'editor.moveDownTitle': { en: 'Move down', zh: '下移' },
   'editor.removeActionTitle': { en: 'Remove action', zh: '移除动作' },
+  'editor.executionModeLabel': {
+    en: 'Persist a per-action run record (advanced)',
+    zh: '持久化每步运行记录（高级）',
+  },
+  'editor.executionModeHint': {
+    en: 'When on, each action run for this rule is saved as a durable WorkflowJob record. Leave off for the default lightweight log.',
+    zh: '开启后，本规则每个动作的运行都会保存为持久的 WorkflowJob 记录；关闭则使用默认的轻量日志。',
+  },
   'trigger.title': { en: 'Trigger', zh: '触发器' },
   'trigger.watchField': { en: 'Watch field', zh: '监听字段' },
   'trigger.selectField': { en: '-- select field --', zh: '-- 选择字段 --' },

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -516,6 +516,54 @@ describe('MetaAutomationRuleEditor', () => {
     })
   })
 
+  it('A6-1: execution-mode toggle is off by default and emits workflow_job_v1 when enabled', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'job rule'
+    nameInput.dispatchEvent(new Event('input'))
+
+    const toggle = container.querySelector('[data-field="executionMode"]') as HTMLInputElement
+    expect(toggle).not.toBeNull()
+    expect(toggle.checked).toBe(false) // default off — existing rules unaffected
+
+    toggle.checked = true
+    toggle.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].executionMode).toBe('workflow_job_v1')
+  })
+
+  it('A6-1: reflects a saved opt-in rule (checked) and can toggle back to off (null)', async () => {
+    const saved = vi.fn()
+    const rule: AutomationRule = {
+      id: 'atr_x', sheetId: 'sheet_1', name: 'existing', triggerType: 'record.created',
+      triggerConfig: {}, actionType: 'update_record', actionConfig: {}, enabled: true,
+      executionMode: 'workflow_job_v1',
+    }
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule, onSave: saved })
+    await flushPromises()
+
+    const toggle = container.querySelector('[data-field="executionMode"]') as HTMLInputElement
+    expect(toggle.checked).toBe(true) // draftFromRule reflected the saved opt-in
+
+    toggle.checked = false
+    toggle.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].executionMode).toBeNull()
+  })
+
   it('serializes numeric condition values as numbers', async () => {
     const saved = vi.fn()
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })

--- a/apps/web/tests/multitable-client.spec.ts
+++ b/apps/web/tests/multitable-client.spec.ts
@@ -255,6 +255,23 @@ describe('MultitableApiClient', () => {
     expect(rule.executionMode).toBe('workflow_job_v1')
   })
 
+  it('A6-1: updateAutomationRule sends executionMode in the PATCH body', async () => {
+    // Symmetric guard for the update path: if the client ever grows a body whitelist, this
+    // catches a dropped executionMode on PATCH the same way the create test guards POST.
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({ ok: true, data: { rule: {} } }), { status: 200 }))
+    const client = new MultitableApiClient({ fetchFn })
+
+    await client.updateAutomationRule('sheet_1', 'atr_1', { executionMode: 'workflow_job_v1' })
+
+    expect(fetchFn).toHaveBeenCalledWith(
+      '/api/multitable/sheets/sheet_1/automations/atr_1',
+      expect.objectContaining({
+        method: 'PATCH',
+        body: JSON.stringify({ executionMode: 'workflow_job_v1' }),
+      }),
+    )
+  })
+
   it('updates and deletes comments through dedicated endpoints', async () => {
     const fetchFn = vi.fn(async (input: string, init?: RequestInit) => {
       if (input === '/api/comments/c1' && init?.method === 'PATCH') {

--- a/apps/web/tests/multitable-client.spec.ts
+++ b/apps/web/tests/multitable-client.spec.ts
@@ -147,6 +147,7 @@ describe('MultitableApiClient', () => {
       createdAt: '2026-04-21T00:00:00.000Z',
       updatedAt: '2026-04-21T00:01:00.000Z',
       createdBy: 'user_1',
+      executionMode: null,
       conditions: { conjunction: 'AND', conditions: [] },
       actions: [{
         type: 'send_dingtalk_group_message',
@@ -219,6 +220,39 @@ describe('MultitableApiClient', () => {
       method: 'POST',
       body: JSON.stringify(input),
     }))
+  })
+
+  it('A6-1: createAutomationRule sends executionMode in the body and reads execution_mode back', async () => {
+    const fetchFn = vi.fn(async () => new Response(JSON.stringify({
+      ok: true,
+      data: {
+        rule: {
+          id: 'atr_job', sheetId: 'sheet_1', name: 'job rule',
+          triggerType: 'record.created', triggerConfig: {},
+          actionType: 'update_record', actionConfig: {}, enabled: true,
+          execution_mode: 'workflow_job_v1', // server response (snake_case tolerated by the mapper)
+        },
+      },
+    }), { status: 200 }))
+    const client = new MultitableApiClient({ fetchFn })
+    const input: Omit<AutomationRule, 'id' | 'sheetId' | 'enabled' | 'createdAt' | 'updatedAt' | 'createdBy'> = {
+      name: 'job rule',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'update_record',
+      actionConfig: {},
+      executionMode: 'workflow_job_v1',
+    }
+
+    const rule = await client.createAutomationRule('sheet_1', input)
+
+    // outbound: the opt-in survives in the request body verbatim (exact-match guards the drop).
+    expect(fetchFn).toHaveBeenCalledWith('/api/multitable/sheets/sheet_1/automations', expect.objectContaining({
+      method: 'POST',
+      body: JSON.stringify(input),
+    }))
+    // inbound: the mapper reads execution_mode → executionMode so the editor can reflect state.
+    expect(rule.executionMode).toBe('workflow_job_v1')
   })
 
   it('updates and deletes comments through dedicated endpoints', async () => {


### PR DESCRIPTION
**Stacked on #2191** (base = its branch, so this diff is UI-only). Completes A6-1: the rule editor can now set the `execution_mode` opt-in, so a maintainer flips a rule onto the persistent WorkflowJob plane from the UI — not just the API.

## What
- **Type/client:** frontend `AutomationRule += executionMode`; `createAutomationRule` sends it in the body (no client whitelist — exact-match test guards the drop); `normalizeAutomationRulePayload` reads `execution_mode`/`executionMode` back so the control reflects saved state.
- **Editor:** a checkbox (**default OFF**) after the name field, bound to `draft.executionMode` via `setExecutionMode` (checked → `'workflow_job_v1'`, else `null`); `emptyDraft`/`draftFromRule`/`buildPayload` thread it.
- **i18n:** `editor.executionModeLabel` + `editor.executionModeHint` through `meta-automation-labels` (zh+en, typed — the strict-zero module; its spec stays green).
- **Gating:** implicit — the editor only opens for `canManageAutomation`.

## Tests
- editor spec: off by default · toggle → save emits `executionMode: 'workflow_job_v1'` · reflects a saved opt-in (checked) then toggles back to `null`.
- client spec: request body carries `executionMode`; mapper reads `execution_mode` back.
- `vue-tsc -b` clean; `meta-automation-labels` strict-zero spec green.
- Note: 16 unrelated full-suite failures (attendance/aftersales/featureFlags/workbench-view) are **pre-existing/flaky** — I verified they reproduce identically on the base branch with my changes stashed (harness issues: "Failed to resolve component router-link", spy-count flakiness). Not introduced here.

## Stacking
Base is the #2191 branch. After #2191 merges I'll rebase this onto main and retarget the base. If your #2191 review changes the `execution_mode` contract, this rebases trivially (one string field). Holding both for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)