### PR TITLE
fix(integration): C1 hardening — facade-enforced read-only guard + adapter metadata

### DIFF
--- a/docs/development/data-factory-sql-data-source-bridge-execution-plan-todo-20260601.md
+++ b/docs/development/data-factory-sql-data-source-bridge-execution-plan-todo-20260601.md
@@ -57,6 +57,8 @@ Acceptance locks (covered by `tests/unit/data-source-plugin-facade.test.ts` + `_
 - [ ] **Run uses `pipeline.createdBy`** (not request user, not null) — **moved to C2** (needs a real run).
 - [ ] `maxPages` loop fail-closed — **C2** (the pipeline-runner page loop bounds it; the adapter already returns correct `done`/`nextCursor`).
 
+**Post-merge hardening (review of #2192):** two fixes landed after C1 merged — (a) the **writable-source guard moved into the host facade's `authorize()`**, so a writable `data_sources` binding now fails closed on **every** read method (`test/getSchema/getTableInfo/select`), not only when `testConnection()` ran first (the dry-run/pipeline read paths skip it); (b) **adapter metadata** added in `http-routes.cjs` so `/api/integration/adapters` advertises `data-source:sql-readonly` as **`roles:['source']`, no `upsert`, `write:{supported:false}`** instead of the default `source,target,bidirectional`+`upsert`. Both locked by tests (`data-source-plugin-facade.test.ts` writable-every-method · `http-routes.test.cjs` metadata).
+
 ### ⬜ C2 — Impl-2: workbench source-system wiring + runner principal-threading
 Gated on: C1 + opt-in. Frontend + the one runner seam.
 - [ ] **Runner provides the principal**: `createAdapter(sourceSystem, { role:'source', principal: pipeline.createdBy })` (pipeline loaded via `pipelines.cjs:302`); direct external-system test/schema uses the request user. **Lock: a run uses `pipeline.createdBy` (not request user, not null); a NULL-`createdBy` pipeline fails closed with a legible config error.** Also bounds the page loop (`maxPages` fail-closed, no silent truncation).

--- a/packages/core-backend/src/data-adapters/data-source-plugin-facade.ts
+++ b/packages/core-backend/src/data-adapters/data-source-plugin-facade.ts
@@ -18,7 +18,6 @@ import type { DbValue, QueryResult, SchemaInfo, TableInfo } from './BaseAdapter'
  */
 export interface DataSourceReadOnlyFacadeTestResult {
   success: boolean
-  readOnly: boolean
 }
 
 export interface DataSourceReadOnlyFacade {
@@ -39,6 +38,10 @@ export interface DataSourceReadOnlyFacade {
 }
 
 export const MISSING_PRINCIPAL_MESSAGE = 'data source read requires an owner principal (none provided)'
+
+export function writableSourceMessage(dataSourceId: string): string {
+  return `data source '${dataSourceId}' is writable; the read-only bridge refuses a writable binding`
+}
 
 function requirePrincipal(principal: string | undefined): string {
   // Fail-closed: a read MUST carry an owner principal. We deliberately do NOT fall back to a
@@ -64,6 +67,12 @@ export function createDataSourcePluginFacade(
     // Throws the uniform "not found" on owner mismatch — no existence leak.
     manager.assertAccess(dataSourceId, owner)
     const adapter = manager.getDataSource(dataSourceId)
+    // Read-only-source guard at the choke point: EVERY read method routes through authorize, so a
+    // writable data source fails closed here — on getSchema/getTableInfo/select/test alike, not only
+    // when testConnection happens to run first. Checked before connecting (it is a config flag).
+    if (!adapter.isReadOnly()) {
+      throw new Error(writableSourceMessage(dataSourceId))
+    }
     if (!adapter.isConnected()) {
       await manager.connectDataSource(dataSourceId)
     }
@@ -74,7 +83,8 @@ export function createDataSourcePluginFacade(
     async test(dataSourceId, principal) {
       const { adapter } = await authorize(dataSourceId, principal)
       const healthy = await adapter.testConnection()
-      return { success: healthy === true, readOnly: adapter.isReadOnly() }
+      // A writable source already failed closed in authorize(); reaching here means read-only.
+      return { success: healthy === true }
     },
     async getSchema(dataSourceId, principal, schema) {
       const { adapter } = await authorize(dataSourceId, principal)

--- a/packages/core-backend/tests/unit/data-source-plugin-facade.test.ts
+++ b/packages/core-backend/tests/unit/data-source-plugin-facade.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { createDataSourcePluginFacade, MISSING_PRINCIPAL_MESSAGE } from '../../src/data-adapters/data-source-plugin-facade'
+import { createDataSourcePluginFacade, MISSING_PRINCIPAL_MESSAGE, writableSourceMessage } from '../../src/data-adapters/data-source-plugin-facade'
 import type { DataSourceManager } from '../../src/data-adapters/DataSourceManager'
 
 interface AdapterStubOptions {
@@ -93,9 +93,24 @@ describe('createDataSourcePluginFacade', () => {
     expect(m.adapter.getSchema).toHaveBeenCalled()
   })
 
-  it('test reports success + the source readOnly flag (used to refuse a writable binding)', async () => {
-    const m = managerStub({ adapter: adapterStub({ healthy: true, readOnly: false }) })
+  it('test on a read-only source returns { success }', async () => {
+    const m = managerStub({ adapter: adapterStub({ healthy: true, readOnly: true }) })
     const facade = createDataSourcePluginFacade(() => m.manager)
-    expect(await facade.test('pg', 'owner-1')).toEqual({ success: true, readOnly: false })
+    expect(await facade.test('pg', 'owner-1')).toEqual({ success: true })
+  })
+
+  it('fails closed on a WRITABLE source for EVERY read method (not just test) — read never performed', async () => {
+    const m = managerStub({ adapter: adapterStub({ readOnly: false }) })
+    const facade = createDataSourcePluginFacade(() => m.manager)
+    await expect(facade.test('pg', 'owner-1')).rejects.toThrow(writableSourceMessage('pg'))
+    await expect(facade.getSchema('pg', 'owner-1')).rejects.toThrow(writableSourceMessage('pg'))
+    await expect(facade.getTableInfo('pg', 'items', 'owner-1')).rejects.toThrow(writableSourceMessage('pg'))
+    await expect(facade.select('pg', 'items', { limit: 10 }, 'owner-1')).rejects.toThrow(writableSourceMessage('pg'))
+    // The writable source is rejected before any read is performed — and before it is even connected.
+    expect(m.stub.select).not.toHaveBeenCalled()
+    expect(m.adapter.getSchema).not.toHaveBeenCalled()
+    expect(m.adapter.getTableInfo).not.toHaveBeenCalled()
+    expect(m.adapter.testConnection).not.toHaveBeenCalled()
+    expect(m.stub.connectDataSource).not.toHaveBeenCalled()
   })
 })

--- a/plugins/plugin-integration-core/__tests__/data-source-sql-readonly-source-adapter.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/data-source-sql-readonly-source-adapter.test.cjs
@@ -92,10 +92,22 @@ async function main() {
     assert.equal(f.calls.select[0].table, 'public.items')
   }
 
-  // 5. Read-only-source binding required: a writable source is refused.
+  // 5. Read-only-source guard now lives in the host facade and fires on EVERY read path: a facade
+  //    that rejects a writable binding makes read / listObjects / getSchema / testConnection all fail
+  //    closed — NOT only when testConnection() runs first (the dry-run/pipeline paths skip it).
   {
-    const f = fakeFacade({ test: () => ({ success: true, readOnly: false }) })
-    await assert.rejects(() => adapterWith(f).testConnection(), /writable|read-only/i, 'a writable data source binding must be rejected')
+    const writableErr = new Error("data source 'pg-1' is writable; the read-only bridge refuses a writable binding")
+    const f = fakeFacade({
+      test: () => { throw writableErr },
+      getSchema: () => { throw writableErr },
+      getTableInfo: () => { throw writableErr },
+      select: () => { throw writableErr },
+    })
+    const a = adapterWith(f)
+    await assert.rejects(() => a.read({ object: 'items', limit: 5 }), /writable/, 'read fails closed on a writable source')
+    await assert.rejects(() => a.listObjects(), /writable/, 'listObjects fails closed on a writable source')
+    await assert.rejects(() => a.getSchema({ object: 'items' }), /writable/, 'getSchema fails closed on a writable source')
+    await assert.rejects(() => a.testConnection(), /writable/, 'testConnection fails closed on a writable source')
   }
 
   // 6. Offset paging: cursor->offset, short page => done + null nextCursor.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -722,7 +722,7 @@ async function testDiscoveryRoutes() {
     adapterRegistry: {
       listAdapterKinds() {
         calls.push(['listAdapterKinds'])
-        return ['http', 'erp:k3-wise-sqlserver', 'bridge:legacy-sql-readonly', 'metasheet:staging', 'metasheet:multitable', 'custom:unknown']
+        return ['http', 'erp:k3-wise-sqlserver', 'bridge:legacy-sql-readonly', 'metasheet:staging', 'metasheet:multitable', 'data-source:sql-readonly', 'custom:unknown']
       },
       createAdapter(input) {
         calls.push(['createAdapter', input])
@@ -825,6 +825,13 @@ async function testDiscoveryRoutes() {
     supportsAppend: true,
     supportsUpsertByKey: true,
   })
+  const dataSourceMetadata = res.body.data.find((adapter) => adapter.kind === 'data-source:sql-readonly')
+  assert.equal(dataSourceMetadata.label, 'Read-only SQL data source')
+  assert.equal(dataSourceMetadata.advanced, true)
+  assert.deepEqual(dataSourceMetadata.roles, ['source'], 'data-source:sql-readonly is source-only (NOT source/target/bidirectional)')
+  assert.deepEqual(dataSourceMetadata.supports, ['testConnection', 'listObjects', 'getSchema', 'read'], 'data-source:sql-readonly supports has no upsert')
+  assert.equal(dataSourceMetadata.supports.includes('upsert'), false, 'data-source:sql-readonly never advertises upsert')
+  assert.deepEqual(dataSourceMetadata.guardrails.write, { supported: false }, 'data-source:sql-readonly write is unsupported')
   const unknownMetadata = res.body.data.find((adapter) => adapter.kind === 'custom:unknown')
   assert.equal(unknownMetadata.label, 'custom:unknown')
   assert.equal(unknownMetadata.advanced, false)

--- a/plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs
@@ -108,16 +108,11 @@ function createDataSourceSqlReadonlySourceAdapter({ system, context, principal }
   return {
     async testConnection() {
       const api = getDataSourcesApi(context)
+      // The read-only-source guard lives in the host facade: a writable data source fails closed in
+      // authorize() on EVERY read method (test/listObjects/getSchema/read), not just here — so the
+      // dry-run / pipeline read paths that never call testConnection() are covered too.
       const result = await api.test(dataSourceId, principal)
-      // Read-only-source lock: refuse to bind a writable data source (defense in depth — this is
-      // a read-only source).
-      if (!result || result.readOnly !== true) {
-        throw new AdapterValidationError(
-          'data-source:sql-readonly requires a read-only data source binding; the referenced data source is writable',
-          { field: 'config.dataSourceId' }
-        )
-      }
-      const ok = result.success === true
+      const ok = Boolean(result && result.success === true)
       return {
         ok,
         status: ok ? 'connected' : 'error',

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -397,6 +397,28 @@ const ADAPTER_METADATA = {
       },
     },
   },
+  'data-source:sql-readonly': {
+    label: 'Read-only SQL data source',
+    roles: ['source'],
+    supports: ['testConnection', 'listObjects', 'getSchema', 'read'],
+    advanced: true,
+    guardrails: {
+      read: {
+        readOnlyBindingOnly: true,
+        ownerScoped: true,
+        offsetPagingOnly: true,
+        maxRowsPerPage: 10000,
+        noRawSql: true,
+        dryRunFriendly: true,
+      },
+      write: {
+        supported: false,
+      },
+      ui: {
+        referencesDataSources: true,
+      },
+    },
+  },
 }
 
 // Route-level secret-text redaction delegates to the shared scrubber


### PR DESCRIPTION
## Summary

Two **P1** review fixes for the `data-source:sql-readonly` bridge (C1, #2192). The runner `pipeline.createdBy` threading stays C2 (per review).

### P1 #1 — writable `data_sources` could be read on paths that skip `testConnection()`
The writable-binding guard lived only in the adapter's `testConnection()` (`readOnly !== true`), but `listObjects()` / `getSchema()` / `read()` go straight through the facade, and dry-run/pipeline paths don't guarantee a `testConnection()` first — so a **writable** generic source could be read by the "read-only" bridge. The facade's `authorize()` also only did `assertAccess` + connect.

**Fix:** move the guard into the host facade's `authorize()` — the choke point **every** read method routes through — so a writable source **fails closed on `test`/`getSchema`/`getTableInfo`/`select` alike** (checked *before* connecting). Removed the now-dead adapter-level `readOnly` check and the facade's vestigial `readOnly` result field.

### P1 #2 — `/api/integration/adapters` advertised the adapter as writable/target-capable
`data-source:sql-readonly` had no `ADAPTER_METADATA` entry, so `describeAdapterKind()` fell back to the defaults `roles: source,target,bidirectional` and `supports` incl. `upsert` — contradicting the read-only/source-only contract.

**Fix:** added metadata — `roles:['source']`, `supports:['testConnection','listObjects','getSchema','read']` (no `upsert`), `guardrails.write:{ supported:false }` (+ read guardrails: read-only-binding-only, owner-scoped, offset-paging, 10k/page, no-raw-sql).

## Verification
- `data-source-plugin-facade.test.ts` (**8**) — new: a **writable source rejects on every read method**, and the read is **never performed (not even connected)**.
- `data-source-sql-readonly-source-adapter.test.cjs` (**10**) — test #5 reworked: `read/listObjects/getSchema/testConnection` all fail closed on a writable-rejecting facade, **without relying on `testConnection()`**.
- `http-routes.test.cjs` — new metadata lock: source-only, **no `upsert`**, `write:{supported:false}`.
- `tsc` + `eslint` clean; plugin loads/registers cleanly.
- Plan #2189 C1 updated with a "post-merge hardening" note.

Leaving for review — not auto-merging.