### PR TITLE
feat(integration): C2a — runner threads pipeline.createdBy to the bridge source

### DIFF
--- a/docs/development/data-factory-sql-data-source-bridge-execution-plan-todo-20260601.md
+++ b/docs/development/data-factory-sql-data-source-bridge-execution-plan-todo-20260601.md
@@ -59,13 +59,20 @@ Acceptance locks (covered by `tests/unit/data-source-plugin-facade.test.ts` + `_
 
 **Post-merge hardening (review of #2192):** two fixes landed after C1 merged — (a) the **writable-source guard moved into the host facade's `authorize()`**, so a writable `data_sources` binding now fails closed on **every** read method (`test/getSchema/getTableInfo/select`), not only when `testConnection()` ran first (the dry-run/pipeline read paths skip it); (b) **adapter metadata** added in `http-routes.cjs` so `/api/integration/adapters` advertises `data-source:sql-readonly` as **`roles:['source']`, no `upsert`, `write:{supported:false}`** instead of the default `source,target,bidirectional`+`upsert`. Both locked by tests (`data-source-plugin-facade.test.ts` writable-every-method · `http-routes.test.cjs` metadata).
 
-### ⬜ C2 — Impl-2: workbench source-system wiring + runner principal-threading
-Gated on: C1 + opt-in. Frontend + the one runner seam.
-- [ ] **Runner provides the principal**: `createAdapter(sourceSystem, { role:'source', principal: pipeline.createdBy })` (pipeline loaded via `pipelines.cjs:302`); direct external-system test/schema uses the request user. **Lock: a run uses `pipeline.createdBy` (not request user, not null); a NULL-`createdBy` pipeline fails closed with a legible config error.** Also bounds the page loop (`maxPages` fail-closed, no silent truncation).
+### 🟢 C2a — Impl-2a: runner principal-threading (backend) — LANDED 2026-06-02
+Gated on: C1 + opt-in. The one shared-runtime seam, isolated for focused review.
+- [x] **Runner provides the principal**: `createContext` now calls `createAdapter(sourceSystem, { role:'source', principal: pipeline.createdBy })`; the target adapter is unchanged. Adapters that don't need a principal (staging/k3/http) ignore the extra dep (verified: full runner + e2e suite green).
+- [x] **Reachability (backend)**: a runner test runs a `data-source:sql-readonly` pipeline whose source reads through the **real** bridge adapter + a faithful fake facade; **dry-run reads real rows** (`rowsRead=2`, cleansed preview, no target write).
+- [x] **Lock — run uses `pipeline.createdBy`**: the facade receives `principal = pipeline.createdBy` (not the request user, not null).
+- [x] **Lock — NULL `createdBy` fails closed**: a null-`createdBy` pipeline fails closed (facade missing-principal error surfaced via the run failure); **no read is performed** (no fallback identity) and nothing is written.
+- The `maxPages` page-loop bound is the existing pipeline-runner behavior; the adapter returns correct `done`/`nextCursor` (C1). No new paging logic added here.
+
+### ⬜ C2b — Impl-2b: workbench source picker (frontend)
+Gated on: C2a + opt-in. Frontend-only.
 - [ ] Workbench "select source system" surfaces a `data-source:sql-readonly` system; pick the data source → object (table/view) → fields.
 - [ ] Enters the **existing** dry-run / staging / provenance flow (no new pipeline machinery).
-- [ ] **Reachability test**: author a source → dry-run → rows appear in staging/provenance — read-only, no write.
-- [ ] `/data-sources` stays the sole connection/credential surface; the workbench **references** it (a `dataSourceId` picker), does not embed connection CRUD.
+- [ ] **Reachability test (UI)**: author a source via the picker → dry-run → rows appear — read-only, no write.
+- [ ] `/data-sources` stays the sole connection/credential surface; the workbench **references** it (a `dataSourceId` picker, **no credential copy**), does not embed connection CRUD.
 
 ### 🔒 C3 — Incremental / watermark reads
 Gated on: C1/C2 + a watermark-column convention + opt-in.

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -7,6 +7,7 @@ const { createPipelineRunner } = require(path.join(__dirname, '..', 'lib', 'pipe
 const { createDeadLetterStore } = require(path.join(__dirname, '..', 'lib', 'dead-letter.cjs'))
 const { createWatermarkStore } = require(path.join(__dirname, '..', 'lib', 'watermark.cjs'))
 const { createRunLogger } = require(path.join(__dirname, '..', 'lib', 'run-log.cjs'))
+const { createDataSourceSqlReadonlySourceAdapterFactory } = require(path.join(__dirname, '..', 'lib', 'adapters', 'data-source-sql-readonly-source-adapter.cjs'))
 
 function createMockDb() {
   const tables = new Map([
@@ -229,6 +230,84 @@ function createRunnerHarness({ sourceRecords, pipelineOverrides = {}, sourceRead
   })
 
   return { adapterSystems, db, pipeline, runner, sourceRecords, targetRows }
+}
+
+// C2a harness: runs a pipeline whose SOURCE is the real `data-source:sql-readonly` bridge adapter,
+// reading through a faithful fake of the host facade (which fails closed on a missing principal,
+// exactly like the real createDataSourcePluginFacade). Proves the runner threads pipeline.createdBy
+// to the source read, that a dry-run reads real rows, and that a NULL createdBy fails closed.
+function createDataSourceBridgeHarness({ rows, createdBy }) {
+  const db = createMockDb()
+  const targetRows = new Map()
+  const facadeCalls = { test: [], getSchema: [], getTableInfo: [], select: [] }
+  function requirePrincipal(principal) {
+    if (typeof principal !== 'string' || principal.trim() === '') {
+      throw new Error('data source read requires an owner principal (none provided)')
+    }
+  }
+  const dataSourcesApi = {
+    async test(id, principal) { requirePrincipal(principal); facadeCalls.test.push({ id, principal }); return { success: true } },
+    async getSchema(id, principal) { requirePrincipal(principal); facadeCalls.getSchema.push({ id, principal }); return { tables: [{ name: 'items', schema: 'public', columns: [] }], views: [] } },
+    async getTableInfo(id, object, principal) { requirePrincipal(principal); facadeCalls.getTableInfo.push({ id, object, principal }); return { columns: [{ name: 'id', type: 'int' }, { name: 'name', type: 'text' }] } },
+    async select(id, table, options, principal) {
+      requirePrincipal(principal)
+      facadeCalls.select.push({ id, table, options, principal })
+      const offset = options.offset || 0
+      const limit = options.limit || rows.length
+      return { data: rows.slice(offset, offset + limit), metadata: {} }
+    },
+  }
+  const pipeline = {
+    id: 'pipe_ds',
+    tenantId: 'tenant_1',
+    workspaceId: null,
+    projectId: 'project_1',
+    createdBy,
+    sourceSystemId: 'source_ds',
+    sourceObject: 'public.items',
+    targetSystemId: 'target_1',
+    targetObject: 'BD_MATERIAL',
+    mode: 'full',
+    status: 'active',
+    idempotencyKeyFields: ['id'],
+    options: { batchSize: 100 },
+    fieldMappings: [
+      { sourceField: 'id', targetField: 'FID', validation: [{ type: 'required' }] },
+      { sourceField: 'name', targetField: 'FName', validation: [{ type: 'required' }] },
+    ],
+  }
+  const systems = new Map([
+    ['source_ds', { id: 'source_ds', name: 'DS bridge', kind: 'data-source:sql-readonly', role: 'source', config: { dataSourceId: 'pg-1' } }],
+    ['target_1', { id: 'target_1', name: 'ERP mock', kind: 'mock-target', role: 'target', config: {} }],
+  ])
+  const externalSystemRegistry = {
+    async getExternalSystem(input) { return systems.get(input.id) },
+    async getExternalSystemForAdapter(input) { const s = systems.get(input.id); return s ? { ...s } : null },
+  }
+  const adapterRegistry = createAdapterRegistry()
+    .registerAdapter('data-source:sql-readonly', createDataSourceSqlReadonlySourceAdapterFactory({ context: { api: { dataSources: dataSourcesApi } } }))
+    .registerAdapter('mock-target', ({ system }) => ({
+      system,
+      async testConnection() { return { ok: true } },
+      async listObjects() { return [{ name: 'BD_MATERIAL' }] },
+      async getSchema() { return { fields: [] } },
+      async read() { return createReadResult({ records: [] }) },
+      async upsert(input) {
+        for (const record of input.records) targetRows.set(record._integration_idempotency_key, record)
+        return createUpsertResult({ written: input.records.length, skipped: 0, results: input.records.map((record) => ({ key: record._integration_idempotency_key })) })
+      },
+    }))
+  const pipelineRegistry = createPipelineRegistry(pipeline, db)
+  const runner = createPipelineRunner({
+    pipelineRegistry,
+    externalSystemRegistry,
+    adapterRegistry,
+    deadLetterStore: createDeadLetterStore({ db, idGenerator: () => `dl_${db.tables.get('integration_dead_letters').length + 1}` }),
+    watermarkStore: createWatermarkStore({ db }),
+    runLogger: createRunLogger({ pipelineRegistry }),
+    clock: (() => { let tick = 0; return () => tick++ * 25 })(),
+  })
+  return { db, pipeline, runner, facadeCalls, targetRows }
 }
 
 async function main() {
@@ -1592,8 +1671,49 @@ async function main() {
     assert.equal(captured.details.provenanceWarning.code, 'PROVENANCE_NORMALIZE_FAILED')
   }
 
+  // --- C2a: runner threads pipeline.createdBy to the data-source:sql-readonly source -----------
+  {
+    const h = createDataSourceBridgeHarness({
+      rows: [{ id: 1, name: 'Widget' }, { id: 2, name: 'Gadget' }],
+      createdBy: 'owner-7',
+    })
+    const dry = await h.runner.runPipeline({
+      tenantId: 'tenant_1', pipelineId: 'pipe_ds', mode: 'full', triggeredBy: 'manual', dryRun: true, sampleLimit: 10,
+    })
+    // Reachability keystone: the dry-run read real rows end-to-end through the real bridge adapter -> facade.
+    assert.equal(dry.metrics.rowsRead, 2, 'C2a: dry-run reads rows from the data-source:sql-readonly bridge')
+    assert.ok(dry.preview.records.length >= 1, 'C2a: dry-run produced a cleansed preview')
+    assert.equal(h.targetRows.size, 0, 'C2a: dry-run does not write the target')
+    // Principal keystone: the facade saw pipeline.createdBy, not the request user and not null.
+    assert.ok(h.facadeCalls.select.length >= 1, 'C2a: the source read routed through the host facade')
+    assert.equal(h.facadeCalls.select[0].principal, 'owner-7', 'C2a: run uses pipeline.createdBy as the source principal')
+  }
+
+  // --- C2a: NULL createdBy fails closed (no fallback principal, no read performed) --------------
+  {
+    const h = createDataSourceBridgeHarness({ rows: [{ id: 1, name: 'Widget' }], createdBy: null })
+    let failed = false
+    let message = ''
+    try {
+      const run = await h.runner.runPipeline({
+        tenantId: 'tenant_1', pipelineId: 'pipe_ds', mode: 'full', triggeredBy: 'manual', dryRun: true, sampleLimit: 10,
+      })
+      if (run && run.run && run.run.status === 'failed') { failed = true; message = run.run.errorSummary || '' }
+    } catch (err) {
+      failed = true
+      // The runner wraps a source-read failure in PipelineRunnerError('pipeline run failed') and keeps
+      // the original message under details.cause — here the facade's missing-principal fail-closed.
+      message = (err && err.details && err.details.cause) || (err && err.message) || String(err)
+    }
+    assert.ok(failed, 'C2a: a pipeline with NULL createdBy fails closed (no silent success)')
+    assert.match(message, /owner principal/i, 'C2a: the fail-closed reason is the missing owner principal')
+    assert.equal(h.facadeCalls.select.length, 0, 'C2a: no read is performed without a principal (no fallback identity)')
+    assert.equal(h.targetRows.size, 0, 'C2a: nothing is written when the source principal is missing')
+  }
+
   console.log('✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed')
   console.log('✓ pipeline-runner: DF-N2-2b provenance write tests passed (14-20)')
+  console.log('✓ pipeline-runner: C2a data-source bridge principal-threading tests passed')
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -280,7 +280,11 @@ function createPipelineRunner(deps = {}) {
       pipeline,
       sourceSystem,
       targetSystem,
-      sourceAdapter: adapterRegistry.createAdapter(sourceSystem, { role: 'source' }),
+      // C2a: thread the pipeline owner (createdBy) as the SOURCE read principal. Source adapters that
+      // read a per-owner-scoped backend (the data-source:sql-readonly bridge) authorize reads with it;
+      // adapters that don't need it (staging/k3/http) ignore the extra dep. A null createdBy stays
+      // null here, so an owner-scoped source fails closed downstream — no fallback identity.
+      sourceAdapter: adapterRegistry.createAdapter(sourceSystem, { role: 'source', principal: pipeline.createdBy }),
       targetAdapter: adapterRegistry.createAdapter(targetSystem, { role: 'target' }),
     }
   }


### PR DESCRIPTION
## Summary

**C2a** of the `data-source:sql-readonly` convergence (plan #2189). The pipeline-runner now threads the **pipeline owner (`createdBy`) as the SOURCE read principal**, so the read-only bridge authorizes per-owner reads. Backend-only; the workbench source picker is **C2b** (separate opt-in).

The change is one line in `createContext`:
```js
sourceAdapter: adapterRegistry.createAdapter(sourceSystem, { role: 'source', principal: pipeline.createdBy }),
```
The **target** adapter is unchanged. Adapters that don't need a principal (staging / k3 / http) ignore the extra dep — verified by the full runner + e2e suite staying green.

## Review keystones (all locked by tests)
The C2a tests live in `pipeline-runner.test.cjs` and run the **real** `data-source:sql-readonly` adapter against a **faithful fake facade** that fails closed on a missing principal — exactly like the real `createDataSourcePluginFacade`:
- **Reachability** — a **dry-run reads real rows** through the bridge end-to-end (`rowsRead=2`, cleansed preview, **no** target write).
- **Run uses `pipeline.createdBy`** — the facade receives `principal === 'owner-7'` (not the request user, not null).
- **NULL `createdBy` fails closed** — a null-`createdBy` pipeline fails closed (the facade's missing-principal error surfaces via the run failure, `details.cause`); **no read is performed** (no fallback identity) and **nothing is written**.

## Verification
- `pipeline-runner.test.cjs` green incl. the new C2a block; no regression across `erp-feedback`, `e2e-plm-k3wise-writeback`, `adapter-contracts`, `data-source-sql-readonly-source-adapter`, `plugin-runtime-smoke`.
- Runner-only; **read-only**, **no frontend**, **no K3 / RBAC / auth** touch.
- Plan #2189 updated: C2 split into **C2a (this PR, done)** and **C2b (frontend picker, pending)**.

Direct external-system test/schema using the request user, and the workbench picker (no-cred-copy + UI reachability), are **C2b**. Leaving for review — not auto-merging.