### PR TITLE
feat(attendance): enforce schedule edit window

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -83,6 +83,15 @@ function randomUuidV4(): string {
   })
 }
 
+function localDateKeyOffset(days: number): string {
+  const date = new Date()
+  date.setDate(date.getDate() + days)
+  const year = date.getFullYear()
+  const month = String(date.getMonth() + 1).padStart(2, '0')
+  const day = String(date.getDate()).padStart(2, '0')
+  return `${year}-${month}-${day}`
+}
+
 function resolvePositiveIntEnvForTest(name: string, fallback: number, min: number, max?: number): number {
   const raw = process.env[name]
   if (raw == null || raw === '') return fallback
@@ -2316,6 +2325,201 @@ attendanceIntegrationDescribe(
     expect(invalidRotationRangeRes.status).toBe(400)
     const invalidRangeError = (invalidRotationRangeRes.body as { error?: { code?: string } } | undefined)?.error
     expect(invalidRangeError?.code).toBe('VALIDATION_ERROR')
+  })
+
+  it('enforces schedule-edit windows on shift and rotation assignment writes', async () => {
+    if (!baseUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const adminUserId = `attendance-shift-edit-window-admin-${runSuffix}`
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const settingsRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+    expect(settingsRes.status).toBe(200)
+    const originalSettings = ((settingsRes.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
+
+    const pastDate = '2020-01-10'
+    const yesterday = localDateKeyOffset(-1)
+
+    async function saveShiftEditPolicy(shiftEditPolicy: Record<string, unknown>) {
+      const res = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ shiftEditPolicy }),
+      })
+      expect(res.status).toBe(200)
+      return (res.body as { data?: { shiftEditPolicy?: Record<string, unknown> } } | undefined)?.data?.shiftEditPolicy
+    }
+
+    async function createShift(name: string): Promise<string> {
+      const shiftRes = await requestJson(`${baseUrl}/api/attendance/shifts`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name,
+          timezone: 'Asia/Shanghai',
+          workStartTime: '09:00',
+          workEndTime: '18:00',
+          workingDays: [1, 2, 3, 4, 5],
+        }),
+      })
+      expect(shiftRes.status).toBe(201)
+      const shiftId = (shiftRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(shiftId).toBeTruthy()
+      if (!shiftId) throw new Error('missing shift id')
+      return shiftId
+    }
+
+    async function createRotationRule(shiftId: string): Promise<string> {
+      const ruleRes = await requestJson(`${baseUrl}/api/attendance/rotation-rules`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({
+          name: `Edit Window Rotation ${runSuffix}`,
+          timezone: 'Asia/Shanghai',
+          shiftSequence: [shiftId],
+          isActive: true,
+        }),
+      })
+      expect(ruleRes.status).toBe(201)
+      const ruleId = (ruleRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(ruleId).toBeTruthy()
+      if (!ruleId) throw new Error('missing rotation rule id')
+      return ruleId
+    }
+
+    async function createShiftAssignment(userId: string, shiftId: string, startDate: string) {
+      return requestJson(`${baseUrl}/api/attendance/assignments`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ userId, shiftId, startDate, isActive: true }),
+      })
+    }
+
+    async function createRotationAssignment(userId: string, rotationRuleId: string, startDate: string) {
+      return requestJson(`${baseUrl}/api/attendance/rotation-assignments`, {
+        method: 'POST',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ userId, rotationRuleId, startDate, isActive: true }),
+      })
+    }
+
+    function expectShiftEditWindowExceeded(res: HttpResponse) {
+      expect(res.status).toBe(422)
+      const error = (res.body as { error?: { code?: string; details?: { earliestDate?: string } } } | undefined)?.error
+      expect(error?.code).toBe('SHIFT_EDIT_WINDOW_EXCEEDED')
+      expect(error?.details?.earliestDate).toBe(pastDate)
+    }
+
+    try {
+      await saveShiftEditPolicy({ mode: 'unrestricted', windowDays: 0 })
+      const shiftId = await createShift(`Edit Window Shift ${runSuffix}`)
+      const rotationRuleId = await createRotationRule(shiftId)
+
+      const existingShiftUpdateRes = await createShiftAssignment(`${adminUserId}-shift-update`, shiftId, pastDate)
+      expect(existingShiftUpdateRes.status).toBe(201)
+      const existingShiftUpdateId = (existingShiftUpdateRes.body as { data?: { assignment?: { id?: string } } } | undefined)?.data?.assignment?.id
+      expect(existingShiftUpdateId).toBeTruthy()
+      if (!existingShiftUpdateId) return
+
+      const existingShiftDeleteRes = await createShiftAssignment(`${adminUserId}-shift-delete`, shiftId, pastDate)
+      expect(existingShiftDeleteRes.status).toBe(201)
+      const existingShiftDeleteId = (existingShiftDeleteRes.body as { data?: { assignment?: { id?: string } } } | undefined)?.data?.assignment?.id
+      expect(existingShiftDeleteId).toBeTruthy()
+      if (!existingShiftDeleteId) return
+
+      const existingRotationUpdateRes = await createRotationAssignment(`${adminUserId}-rotation-update`, rotationRuleId, pastDate)
+      expect(existingRotationUpdateRes.status).toBe(201)
+      const existingRotationUpdateId = (existingRotationUpdateRes.body as { data?: { assignment?: { id?: string } } } | undefined)?.data?.assignment?.id
+      expect(existingRotationUpdateId).toBeTruthy()
+      if (!existingRotationUpdateId) return
+
+      const existingRotationDeleteRes = await createRotationAssignment(`${adminUserId}-rotation-delete`, rotationRuleId, pastDate)
+      expect(existingRotationDeleteRes.status).toBe(201)
+      const existingRotationDeleteId = (existingRotationDeleteRes.body as { data?: { assignment?: { id?: string } } } | undefined)?.data?.assignment?.id
+      expect(existingRotationDeleteId).toBeTruthy()
+      if (!existingRotationDeleteId) return
+
+      await saveShiftEditPolicy({ mode: 'past_locked', windowDays: 0 })
+
+      expectShiftEditWindowExceeded(await createShiftAssignment(`${adminUserId}-shift-create-blocked`, shiftId, pastDate))
+      expectShiftEditWindowExceeded(await createRotationAssignment(`${adminUserId}-rotation-create-blocked`, rotationRuleId, pastDate))
+
+      const blockedShiftUpdateRes = await requestJson(`${baseUrl}/api/attendance/assignments/${existingShiftUpdateId}`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ endDate: pastDate }),
+      })
+      expectShiftEditWindowExceeded(blockedShiftUpdateRes)
+
+      const blockedShiftDeleteRes = await requestJson(`${baseUrl}/api/attendance/assignments/${existingShiftDeleteId}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      expectShiftEditWindowExceeded(blockedShiftDeleteRes)
+
+      const blockedRotationUpdateRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments/${existingRotationUpdateId}`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify({ endDate: pastDate }),
+      })
+      expectShiftEditWindowExceeded(blockedRotationUpdateRes)
+
+      const blockedRotationDeleteRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments/${existingRotationDeleteId}`, {
+        method: 'DELETE',
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      expectShiftEditWindowExceeded(blockedRotationDeleteRes)
+
+      const policy = await saveShiftEditPolicy({ mode: 'past_within_window', windowDays: 7 })
+      expect(policy).toEqual({ mode: 'past_within_window', windowDays: 7 })
+
+      const windowShiftRes = await createShiftAssignment(`${adminUserId}-shift-window-ok`, shiftId, yesterday)
+      expect(windowShiftRes.status).toBe(201)
+      const windowRotationRes = await createRotationAssignment(`${adminUserId}-rotation-window-ok`, rotationRuleId, yesterday)
+      expect(windowRotationRes.status).toBe(201)
+
+      await saveShiftEditPolicy({ mode: 'unrestricted', windowDays: 0 })
+      const unrestrictedPastRes = await createShiftAssignment(`${adminUserId}-shift-unrestricted-ok`, shiftId, pastDate)
+      expect(unrestrictedPastRes.status).toBe(201)
+    } finally {
+      await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers: {
+          Authorization: `Bearer ${token}`,
+          'Content-Type': 'application/json',
+        },
+        body: JSON.stringify(originalSettings),
+      }).catch(() => undefined)
+    }
   })
 
   it('rejects non-UUID shift references for rotation rules, including UUID-like shift names', async () => {

--- a/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
@@ -92,6 +92,45 @@ describe('attendance scheduling assignment conflict guard', () => {
     expect(helpers.resolveAttendanceScheduleAssignmentUpdateEndDate({ endDate: '2026-06-20' }, '2026-06-10')).toBe('2026-06-20')
   })
 
+  it('evaluates schedule-edit windows from the earliest affected date', () => {
+    expect(helpers.evaluateShiftEditWindow(undefined, ['2026-05-01'], '2026-06-01')).toBeNull()
+    expect(helpers.evaluateShiftEditWindow({ mode: 'unrestricted' }, ['2026-05-01'], '2026-06-01')).toBeNull()
+    expect(helpers.evaluateShiftEditWindow({ mode: 'past_locked' }, ['2026-06-01'], '2026-06-01')).toBeNull()
+    expect(helpers.evaluateShiftEditWindow({ mode: 'past_locked' }, ['2026-05-31'], '2026-06-01')).toEqual({
+      earliest: '2026-05-31',
+      boundary: '2026-06-01',
+      mode: 'past_locked',
+    })
+    expect(helpers.evaluateShiftEditWindow(
+      { mode: 'past_within_window', windowDays: 7 },
+      ['2026-05-25', '2026-06-10'],
+      '2026-06-01',
+    )).toBeNull()
+    expect(helpers.evaluateShiftEditWindow(
+      { mode: 'past_within_window', windowDays: 7 },
+      ['2026-05-24', '2026-06-10'],
+      '2026-06-01',
+    )).toEqual({
+      earliest: '2026-05-24',
+      boundary: '2026-05-25',
+      mode: 'past_within_window',
+    })
+  })
+
+  it('normalizes and deep-merges schedule-edit policy settings', () => {
+    expect(helpers.normalizeShiftEditPolicySetting(undefined)).toEqual({ mode: 'unrestricted', windowDays: 0 })
+    expect(helpers.normalizeShiftEditPolicySetting({ mode: 'past_within_window', windowDays: '3.9' }))
+      .toEqual({ mode: 'past_within_window', windowDays: 3 })
+    expect(helpers.normalizeShiftEditPolicySetting({ mode: 'surprise', windowDays: -1 }))
+      .toEqual({ mode: 'unrestricted', windowDays: 0 })
+
+    const merged = helpers.mergeSettings(
+      { shiftEditPolicy: { mode: 'past_within_window', windowDays: 14 } },
+      { shiftEditPolicy: { mode: 'past_locked' } },
+    )
+    expect(merged.shiftEditPolicy).toEqual({ mode: 'past_locked', windowDays: 14 })
+  })
+
   it('takes a per-org/user advisory lock before transactional writes', async () => {
     const db = { query: vi.fn().mockResolvedValue([]) }
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -95,6 +95,10 @@ const DEFAULT_SETTINGS = {
   ipAllowlist: [],
   geoFence: null,
   minPunchIntervalMinutes: 1,
+  shiftEditPolicy: {
+    mode: 'unrestricted',
+    windowDays: 0,
+  },
   formula: {
     allowRawAliases: true,
   },
@@ -5913,6 +5917,33 @@ function addDaysToDateKey(dateKey, days) {
   return date.toISOString().slice(0, 10)
 }
 
+// 排班修改窗 (schedule-edit window): pure evaluator. Given the org shiftEditPolicy, the dates a
+// write touches, and today's date-key, returns a violation when the EARLIEST touched date falls
+// before the editable boundary — so editing / creating / deleting a past-dated assignment is
+// blocked uniformly (guard the write, not the verb). Unset / unrestricted / unknown mode => null
+// (no regression). Org-level for v1; per-rule_set granularity is a follow-up.
+function evaluateShiftEditWindow(policy, dates, todayKey) {
+  const mode = policy && typeof policy === 'object' ? policy.mode : undefined
+  if (!mode || mode === 'unrestricted') return null
+  const today = normalizeDateOnly(todayKey)
+  if (!today) return null
+  const affected = (Array.isArray(dates) ? dates : [dates])
+    .map((value) => normalizeDateOnly(value))
+    .filter(Boolean)
+  if (affected.length === 0) return null
+  const earliest = affected.reduce((min, value) => (value < min ? value : min))
+  let boundary
+  if (mode === 'past_locked') {
+    boundary = today
+  } else if (mode === 'past_within_window') {
+    const windowDays = Math.max(0, Math.floor(parseNumber(policy.windowDays, 0)))
+    boundary = addDaysToDateKey(today, -windowDays) ?? today
+  } else {
+    return null
+  }
+  return earliest < boundary ? { earliest, boundary, mode } : null
+}
+
 function inferOvernightFlag(workStartTime, workEndTime) {
   const normalizedStart = normalizeTimeString(workStartTime)
   const normalizedEnd = normalizeTimeString(workEndTime)
@@ -10773,6 +10804,7 @@ function normalizeSettings(raw) {
     ipAllowlist,
     geoFence,
     minPunchIntervalMinutes: Math.max(0, parseNumber(raw.minPunchIntervalMinutes, DEFAULT_SETTINGS.minPunchIntervalMinutes)),
+    shiftEditPolicy: normalizeShiftEditPolicySetting(raw.shiftEditPolicy),
     formula: {
       allowRawAliases: parseBoolean(formula.allowRawAliases, DEFAULT_SETTINGS.formula.allowRawAliases),
     },
@@ -10799,6 +10831,18 @@ function normalizeAttendanceComprehensiveHoursSettings(raw) {
   }
 }
 
+function normalizeShiftEditPolicySetting(raw) {
+  const policy = raw && typeof raw === 'object' ? raw : {}
+  const modeRaw = typeof policy.mode === 'string' ? policy.mode.trim() : ''
+  const mode = ['unrestricted', 'past_locked', 'past_within_window'].includes(modeRaw)
+    ? modeRaw
+    : DEFAULT_SETTINGS.shiftEditPolicy.mode
+  return {
+    mode,
+    windowDays: Math.max(0, Math.floor(parseNumber(policy.windowDays, DEFAULT_SETTINGS.shiftEditPolicy.windowDays))),
+  }
+}
+
 function mergeSettings(base, update) {
   return normalizeSettings({
     ...base,
@@ -10822,6 +10866,10 @@ function mergeSettings(base, update) {
     formula: {
       ...(base?.formula || {}),
       ...(update?.formula || {}),
+    },
+    shiftEditPolicy: {
+      ...(base?.shiftEditPolicy || {}),
+      ...(update?.shiftEditPolicy || {}),
     },
     comprehensiveHours: {
       ...(base?.comprehensiveHours || {}),
@@ -15120,6 +15168,8 @@ module.exports = {
     resolveEffectiveCalendar,
     resolveAttendanceComprehensiveHoursPeriod,
     normalizeAttendanceComprehensiveHoursSettings,
+    normalizeShiftEditPolicySetting,
+    evaluateShiftEditWindow,
     bridgeAttendanceDateRangeToComprehensiveHoursPeriod,
     resolveAttendanceComprehensiveHoursCap,
     buildAttendanceComprehensiveHoursCapEffectiveKey,
@@ -15229,6 +15279,29 @@ module.exports = {
           message: 'Scheduler scope does not allow this attendance scheduling action',
         },
       })
+    }
+
+    function respondShiftEditWindowExceeded(res, violation) {
+      res.status(422).json({
+        ok: false,
+        error: {
+          code: 'SHIFT_EDIT_WINDOW_EXCEEDED',
+          message: `Schedule edit window exceeded: ${violation.earliest} is before the earliest editable date ${violation.boundary}`,
+          details: {
+            earliestDate: violation.earliest,
+            boundaryDate: violation.boundary,
+            mode: violation.mode,
+          },
+        },
+      })
+    }
+
+    async function enforceShiftEditWindow(res, dates) {
+      const settings = await getSettings(db)
+      const violation = evaluateShiftEditWindow(settings?.shiftEditPolicy, dates, normalizeDateOnly(new Date()))
+      if (!violation) return true
+      respondShiftEditWindowExceeded(res, violation)
+      return false
     }
 
     async function resolveAttendanceSchedulerScopeActor(req, res) {
@@ -15943,6 +16016,15 @@ module.exports = {
         radiusMeters: z.number().int().min(1),
       }).nullable().optional(),
       minPunchIntervalMinutes: z.number().int().min(0).optional(),
+      // Org-level schedule-edit window (排班修改窗): governs how far back assignment writes
+      // (create / update / delete) may reach. Default unrestricted = current behaviour (no
+      // regression). past_locked blocks any past-dated write; past_within_window allows the last
+      // windowDays. Applies to the earliest date the write touches; org-level for v1 (per-rule_set
+      // granularity is a follow-up).
+      shiftEditPolicy: z.object({
+        mode: z.enum(['unrestricted', 'past_locked', 'past_within_window']).optional(),
+        windowDays: z.number().int().min(0).optional(),
+      }).optional(),
       formula: z.object({
         allowRawAliases: z.boolean().optional(),
       }).optional(),
@@ -21348,6 +21430,9 @@ module.exports = {
         }
 
         try {
+          const windowAccess = await enforceShiftEditWindow(res, [payload.startDate])
+          if (!windowAccess) return
+
           const access = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, { orgId, payload })
           if (!access) return
 
@@ -21465,6 +21550,9 @@ module.exports = {
             return
           }
 
+          const windowAccess = await enforceShiftEditWindow(res, [existing.start_date, payload.startDate])
+          if (!windowAccess) return
+
           const existingAccess = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
             orgId,
             payload: existing,
@@ -21570,6 +21658,9 @@ module.exports = {
             res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Rotation assignment not found' } })
             return
           }
+
+          const windowAccess = await enforceShiftEditWindow(res, [existingRows[0].start_date])
+          if (!windowAccess) return
 
           const access = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
             orgId,
@@ -29255,6 +29346,9 @@ module.exports = {
         }
 
         try {
+          const windowAccess = await enforceShiftEditWindow(res, [payload.startDate])
+          if (!windowAccess) return
+
           const access = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, { orgId, payload })
           if (!access) return
 
@@ -29372,6 +29466,9 @@ module.exports = {
             return
           }
 
+          const windowAccess = await enforceShiftEditWindow(res, [existing.start_date, payload.startDate])
+          if (!windowAccess) return
+
           const existingAccess = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
             orgId,
             payload: existing,
@@ -29477,6 +29574,9 @@ module.exports = {
             res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Assignment not found' } })
             return
           }
+
+          const windowAccess = await enforceShiftEditWindow(res, [existingRows[0].start_date])
+          if (!windowAccess) return
 
           const access = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
             orgId,


### PR DESCRIPTION
## Summary
- add `shiftEditPolicy` settings persistence with default `unrestricted`, normalizer, and deep-merge support
- enforce the schedule-edit window on shift and rotation assignment create/update/delete with explicit 422 `SHIFT_EDIT_WINDOW_EXCEEDED`
- guard updates/deletes by the existing assignment start date as well as the next payload date, so historical rows cannot be moved forward to bypass the window
- add unit coverage for the evaluator/settings merge and an integration wire test covering all 6 write routes

## Scope notes
- no DDL; policy is stored in existing attendance settings JSON
- applies to admins too for v1; break-glass override remains a later explicit product slice

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `git diff --check origin/main..HEAD`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-scheduling-assignment-conflict.test.ts --reporter=dot` (19/19)
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-comprehensive-hours-control.test.ts --reporter=dot` (44/44)
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts --reporter=dot -t "enforces schedule-edit windows"` (local DB env absent, suite skipped: 81 skipped)
