### PR TITLE
feat(multitable): F5 record-summary display mask + buildLinkSummaries foreign-display mask (cross-sheet read paths)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -178,6 +178,7 @@ jobs:
             tests/integration/multitable-records-list-authz.test.ts \
             tests/integration/multitable-record-history-field-mask.test.ts \
             tests/integration/multitable-records-summary-field-mask.test.ts \
+            tests/integration/multitable-summary-display-field-mask.test.ts \
             tests/integration/multitable-dashboard-chart-authz.test.ts \
             tests/integration/multitable-write-echo-field-mask.test.ts \
             tests/integration/multitable-create-echo-field-mask.test.ts \

--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -179,6 +179,7 @@ jobs:
             tests/integration/multitable-record-history-field-mask.test.ts \
             tests/integration/multitable-records-summary-field-mask.test.ts \
             tests/integration/multitable-summary-display-field-mask.test.ts \
+            tests/integration/multitable-link-summary-display-field-mask.test.ts \
             tests/integration/multitable-dashboard-chart-authz.test.ts \
             tests/integration/multitable-write-echo-field-mask.test.ts \
             tests/integration/multitable-create-echo-field-mask.test.ts \

--- a/docs/development/multitable-field-read-gate-tracker-20260602.md
+++ b/docs/development/multitable-field-read-gate-tracker-20260602.md
@@ -44,12 +44,13 @@ The **locking test** is the real-DB integration test wired into `.github/workflo
 | ✅🔒 | **crossSheetRelated** echo mask (new finding) | Med | #2176 design · #2178 impl | `multitable-cross-sheet-related-echo-mask` |
 | ✅🔒 | **realtime** broadcast: D0 `join-sheet` authz + D1 value-free invalidation (new finding) | **High** (no-auth room) | #2181 design · #2183 impl | `multitable-sheet-realtime.api` + `rooms.basic` |
 | ✅🔒 | **F4** `POST /records` create-echo mask | Low-Med | #2186 | `multitable-create-echo-field-mask` |
-| ✅🔒 | **F5** `link-options` + `people-search` (`loadRecordSummaries` foreign/people display value) | Low | #2198 | `multitable-summary-display-field-mask` |
+| ✅🔒 | **F5** `loadRecordSummaries` display: `link-options` `data.records` + `people-search` `items` (foreign/people default-display value) | Low | #2198 | `multitable-summary-display-field-mask` |
+| ✅🔒 | **linkSummaries** (`buildLinkSummaries`) foreign default-display value across `GET /view` · single-record read · link-options `data.selected` · write-echo (review follow-up to F5) | Med | #2198 | `multitable-link-summary-display-field-mask` |
 | ⬜ | **D1** `form-context` + form-submit layer-3 (anonymous-form design question — likely intentional) | Design-Q | — | *(decide first)* |
 | ⬜ | **kanban / gallery / calendar** view-data egress scan (deferred coverage scan) | Diligence | — | *(scan → maybe add)* |
 
 ### Completion
-- **By item: 9 / 11 findings closed (≈ 82 %)** — through F5.
+- **By item: 10 / 12 findings closed (≈ 83 %)** — through F5 + its `buildLinkSummaries` review follow-up.
 - **By risk: every High + Med + Low leak channel is closed.** Remaining = 1 **design question** (D1, anonymous forms have no subject to scope to) + 1 **coverage scan** (kanban/gallery/calendar). Residual attack surface ≈ retired.
 
 ---
@@ -71,7 +72,8 @@ A finding is only ticked ✅🔒 here when **all** of:
 
 ### Layer 3 — New-surface detection (the gap to watch)
 Layers 1–2 protect *known* channels. A *new* record-data egress endpoint could reintroduce the leak class. To confirm continuously:
-- **Trigger:** whenever a new endpoint returns record cell values (new read, echo, summary, export, broadcast), **re-run the #2106 egress inventory method** (grep every `res.json`/`filterRecordDataByFieldIds`/`loadRecordSummaries`/raw `data[fieldId]` egress; classify gated vs ungated).
+- **Trigger:** whenever a new endpoint returns record cell values (new read, echo, summary, export, broadcast), **re-run the #2106 egress inventory method** (grep every `res.json`/`filterRecordDataByFieldIds`/`loadRecordSummaries`/`buildLinkSummaries`/`linkSummaries`/raw `data[fieldId]` egress; classify gated vs ungated).
+  - **Lesson (the `buildLinkSummaries` follow-up):** a cell value can leak even when it is *not* a direct `data[fieldId]` egress — `buildLinkSummaries` reads a *foreign* sheet's display field into a computed `display`, and the `filter*FieldSummaryMap` wrappers only drop unreadable *link fields* (caller-side), never the foreign display *value*. So the grep set must include **derived/summary display values keyed to another sheet**, masked by *that* sheet's `allowedFieldIds` (per-sheet keying), not just first-class `data[fieldId]` writes.
 - **Forward-defense (proposed, not yet built):** an "egress coverage guard" — a test that enumerates the record-data egress sites and asserts each one routes through `allowedFieldIds`, so a new *ungated* egress fails CI by construction. Tracked as a future hardening item (see §4).
 - **Pending re-scan:** the kanban/gallery/calendar view-data scan (matrix §2b, last row).
 

--- a/docs/development/multitable-field-read-gate-tracker-20260602.md
+++ b/docs/development/multitable-field-read-gate-tracker-20260602.md
@@ -44,13 +44,13 @@ The **locking test** is the real-DB integration test wired into `.github/workflo
 | ✅🔒 | **crossSheetRelated** echo mask (new finding) | Med | #2176 design · #2178 impl | `multitable-cross-sheet-related-echo-mask` |
 | ✅🔒 | **realtime** broadcast: D0 `join-sheet` authz + D1 value-free invalidation (new finding) | **High** (no-auth room) | #2181 design · #2183 impl | `multitable-sheet-realtime.api` + `rooms.basic` |
 | ✅🔒 | **F4** `POST /records` create-echo mask | Low-Med | #2186 | `multitable-create-echo-field-mask` |
-| ⬜ | **F5** `link-options` + `person-fields/prepare` (`loadRecordSummaries` foreign/source display value) | Low | — | *(to add)* |
+| ✅🔒 | **F5** `link-options` + `people-search` (`loadRecordSummaries` foreign/people display value) | Low | #2198 | `multitable-summary-display-field-mask` |
 | ⬜ | **D1** `form-context` + form-submit layer-3 (anonymous-form design question — likely intentional) | Design-Q | — | *(decide first)* |
 | ⬜ | **kanban / gallery / calendar** view-data egress scan (deferred coverage scan) | Diligence | — | *(scan → maybe add)* |
 
 ### Completion
-- **By item: 8 / 11 findings closed (≈ 73 %)** — through F4 (#2186).
-- **By risk: every High + Med leak channel is closed.** Remaining = 1 **Low** (F5), 1 **design question** (D1, anonymous forms have no subject to scope to), 1 **coverage scan** (kanban). Residual attack surface ≈ retired.
+- **By item: 9 / 11 findings closed (≈ 82 %)** — through F5.
+- **By risk: every High + Med + Low leak channel is closed.** Remaining = 1 **design question** (D1, anonymous forms have no subject to scope to) + 1 **coverage scan** (kanban/gallery/calendar). Residual attack surface ≈ retired.
 
 ---
 
@@ -83,10 +83,9 @@ Layers 1–2 protect *known* channels. A *new* record-data egress endpoint could
 
 ## 4. Remaining work (each a separate, explicit opt-in)
 
-1. **F5** — gate `loadRecordSummaries`' display value in `link-options` (foreign-sheet primary field) + `person-fields/prepare`. Direct impl slice (design-locked in #2106 §F5); fail-first like F2.
-2. **D1** — decide whether `form-context`/form-submit should apply layer-3 for *identified* (non-anonymous) form callers. Product decision first; likely no code (anonymous submitter has no subject to scope to).
-3. **kanban / gallery / calendar scan** (kanban first, then gallery/calendar) — Layer-3 re-scan of these view-data egress paths; add a locking test only if a real ungated egress is found.
-4. *(optional hardening)* — build the §3 "egress coverage guard".
+1. **D1** — decide whether `form-context`/form-submit should apply layer-3 for *identified* (non-anonymous) form callers. Product decision first; likely no code (anonymous submitter has no subject to scope to).
+2. **kanban / gallery / calendar scan** (kanban first, then gallery/calendar) — Layer-3 re-scan of these view-data egress paths; add a locking test only if a real ungated egress is found.
+3. *(optional hardening)* — build the §3 "egress coverage guard".
 
 ---
 

--- a/docs/development/multitable-link-summary-display-field-mask-verification-20260602.md
+++ b/docs/development/multitable-link-summary-display-field-mask-verification-20260602.md
@@ -1,0 +1,67 @@
+# `buildLinkSummaries` foreign-display-value field mask — verification (F5 review follow-up)
+
+**Slice:** review follow-up to F5 of the multitable field-read-permission-gate arc (tracker `docs/development/multitable-field-read-gate-tracker-20260602.md` §2b).
+**Origin:** independent review of #2198 (F5) surfaced a second, distinct egress on `link-options` (`data.selected`) — investigation showed it is a shared-helper leak across **four** surfaces, not one branch.
+**Date:** 2026-06-02 · **Risk:** Med · **Pattern:** root-cause fix in the shared helper, fail-first.
+
+---
+
+## 1. The leak
+
+`buildLinkSummaries` derives each linked foreign record's `display` from the **foreign sheet's default display field** and echoes it into `linkSummaries` / `selected`. It gated **sheet-level** read (`resolveReadableSheetIds`) but picked the display field as `fields.find(type==='string') ?? fields[0]` and read `data[displayFieldId]` with **no field-level mask**. So when the *link field* is readable but the *foreign sheet's display field* is `field_permissions.visible=false` for the caller, the denied value leaked on every consumer of the helper:
+
+| Surface | Response shape |
+|---|---|
+| `GET /view` (records-list) | `data.linkSummaries[recordId][fieldId][].display` |
+| `GET /records/:recordId` (single-record read, #2015 path) | `data.linkSummaries[fieldId][].display` |
+| `GET /fields/:fieldId/link-options?recordId=` | `data.selected[].display` |
+| write/patch echo (`RecordWriteService`, F3 path) | `data.linkSummaries[…].display` |
+
+The existing `filterRecordFieldSummaryMap` / `filterSingleRecordFieldSummaryMap` wrappers only drop summaries for *link fields* the caller can't read (top-level `fieldId` keys, caller-side) — they never touch the foreign `display` **value**. This is the **complement** of `records-read` R6 (which denies the *link field*, so the whole summary key drops); here the link field is visible and only the foreign display field is denied.
+
+**Why F5 (#2198) didn't catch it:** F5 gated the `loadRecordSummaries` path (`link-options` `data.records` + `people-search`). `data.selected` and the other `linkSummaries` surfaces come from a *different* helper (`buildLinkSummaries`), and the original #2106 grep set keyed on `loadRecordSummaries` / `data[fieldId]`, not on derived foreign-keyed display values. (Tracker §3 Layer-3 grep set updated with this lesson.)
+
+## 2. The fix
+
+`packages/core-backend/src/routes/univer-meta.ts`, inside `buildLinkSummaries`, the per-foreign-sheet display-field selection loop now consults **that foreign sheet's own** layer-2 ∧ layer-3 allowed set for the requester, and picks the display field only from it:
+
+```ts
+const fields = await loadFieldsForSheet(query, sheetId)
+const { access, capabilities } = await resolveSheetReadableCapabilities(req, query, sheetId)
+const allowedFieldIds = await loadAllowedFieldIds(query, sheetId, access.userId, capabilities)
+const allowedFields = fields.filter((field) => allowedFieldIds.has(field.id))
+const stringField = allowedFields.find((field) => field.type === 'string')
+displayFieldBySheet.set(sheetId, stringField?.id ?? allowedFields[0]?.id ?? null)
+```
+
+Selecting the display field only from allowed fields makes the later `data[displayFieldId]` read inherently safe (no separate value gate needed). Same primitives as F5 (`resolveSheetReadableCapabilities` + `loadAllowedFieldIds`), keyed to the **foreign** sheet + requester — the crossSheetRelated per-sheet-keying rule. One root fix closes all four surfaces.
+
+**Admin-safe (verified, not assumed):** there is **no admin bypass for field visibility** anywhere — `deriveFieldPermissions` computes `visible = baseVisible && (scope?.visible ?? true)`; `capabilities` only affects `readOnly`, and `computeAllowedFieldIds` reads only `.visible`. So visibility masking depends solely on `(sheetId, userId)` via `field_permissions` (the same uniform semantics as the #2015 read path), and an admin / ungranted user with no deny row still sees the value. No new query shapes; **K3 Stage-1-lock-safe** (no central RBAC/auth touched).
+
+## 3. Fail-first evidence
+
+New real-DB test: `packages/core-backend/tests/integration/multitable-link-summary-display-field-mask.test.ts`.
+
+**Seed** (deny solely layer-3 — `property = {}`): `SHEET_A` (source) + readable `FLD_LINK` (link → `SHEET_B`) + `REC_A`; `SHEET_B` (foreign) + `FLD_B_DISPLAY` (string default display, `B_CANARY`, **denied to USER on `SHEET_B`**) + `REC_B`; `meta_links(FLD_LINK, REC_A, REC_B)`. `USER_2` has no deny (positive control). The link field is **not** denied — so the leak is purely the surviving summary's `display`.
+
+**Cases** (each positive-control-first to defeat an empty-summary false-green):
+- `sentinel` — `DATABASE_URL` set.
+- `S1` `GET /view` — USER_2 gets `linkSummaries[REC_A][FLD_LINK][0].display === B_CANARY`; USER gets the **same summary entry** (`id === REC_B`, proving the link-field key survives — not the R6 case) but `display !== B_CANARY` and `B_CANARY` is nowhere in the body.
+- `S2` `GET /records/:recordId` — same on the single-record `linkSummaries[FLD_LINK]`.
+- `S3` `GET /fields/:fieldId/link-options?recordId=` — same on `data.selected` (find by `id === REC_B`).
+- `S4` `POST /patch` (write-echo) — patch a readable bystander field on `SHEET_A` (write perm) so `RecordWriteService` rebuilds `linkSummaries` for `REC_A`; same mask assertion on `data.linkSummaries[REC_A][FLD_LINK]`. (`PATCH /records/:recordId` echoes link *IDs*, not summaries — so `POST /patch` is the write-echo `linkSummaries` surface.)
+
+**Result:** RED on the un-fixed helper (S1–S4 **all four** leak `B_CANARY`; sentinel passes) → **5/5 GREEN** after the fix. All four surfaces listed in the tracker row now carry a real-DB assertion.
+
+## 4. Regression scope
+
+- `tsc` (core-backend) — exit **0**.
+- Real-DB neighbors that exercise `buildLinkSummaries` / the changed routes — **33/33**: `records-read-field-mask` **8/8** (incl. R6 link-field-denied — the orthogonal case still drops the whole key), `summary-display` (F5) 5/5, `records-summary` (F2) 7/7, `write-echo` 5/5, `create-echo` 4/4, `cross-sheet-related-echo` 4/4.
+- **Mocked-suite cascade check (the F4-lesson / advisor):** the new field-perm queries fire only when a sheet has link fields + linked records; `buildLinkSummaries` early-returns otherwise, so the mocked tests are unaffected. Verified by stash-diff: combined mocked run was **identical to baseline** (9 failed | 60 passed). Gating mocked suites pristine — `sheet-permissions.api` **1 failed / 40 passed** (the pre-existing F2-era records-summary case, out of scope) and `sheet-realtime.api` **3/3** — both unchanged from baseline. `record-form.api` retains its 8 pre-existing (non-gating) failures, unchanged.
+
+**Gating suites unaffected.** The real-DB locking suite gains one test; no existing locking test changed behavior.
+
+## 5. CI wiring & tracker
+
+- `.github/workflows/plugin-tests.yml` — `tests/integration/multitable-link-summary-display-field-mask.test.ts` added to the real-DB integration step (after the F5 test). Runs on every PR ⇒ a future drop of the per-foreign-sheet gate turns this **RED and blocks merge**.
+- Tracker §2b: F5 row made precise (`loadRecordSummaries` display: link-options `data.records` + people-search); **new row** for this `buildLinkSummaries` finding (locking test `multitable-link-summary-display-field-mask`). Completion **10 / 12**; every High + Med + Low leak channel closed. §3 Layer-3 grep set + lesson updated.

--- a/docs/development/multitable-summary-display-field-mask-verification-20260602.md
+++ b/docs/development/multitable-summary-display-field-mask-verification-20260602.md
@@ -65,6 +65,8 @@ Real-DB integration test (new): `packages/core-backend/tests/integration/multita
 
 **Result:** RED on unmodified `origin/main` (R1 + R3 canaries present) → **5/5 GREEN** after the fix.
 
+> **Scope note:** this doc covers only the `loadRecordSummaries` egress (`link-options` `data.records` + `people-search` `items`). An independent review of this PR surfaced a **second, distinct** foreign-display leak on `link-options` via a *different* helper (`buildLinkSummaries`, feeding `data.selected` + the `linkSummaries` on `/view` / single-record read / write-echo) — fixed in the same PR and recorded separately in `multitable-link-summary-display-field-mask-verification-20260602.md` (tracker §2b adjacent row). So "link-options is gated" is true only with **both** rows closed.
+
 ## 4. Regression scope
 
 - `tsc` (core-backend) — exit **0**.

--- a/docs/development/multitable-summary-display-field-mask-verification-20260602.md
+++ b/docs/development/multitable-summary-display-field-mask-verification-20260602.md
@@ -1,0 +1,80 @@
+# F5 — record-summary display-value field mask (cross-sheet read paths) — verification
+
+**Slice:** F5 of the multitable field-read-permission-gate arc (tracker: `docs/development/multitable-field-read-gate-tracker-20260602.md`, §2b).
+**Design-lock:** `docs/development/multitable-record-egress-fieldperm-inventory-20260529.md` (#2106) §F5.
+**Date:** 2026-06-02 · **Risk:** Low · **Pattern:** direct impl slice, fail-first (like F2 #2157).
+
+---
+
+## 1. The leak
+
+`loadRecordSummaries(query, sheetId, opts)` derives a per-record **`display`** string from a *display field*. When the caller passes no `displayFieldId`, it picks a **default** display field — the sheet's primary/first field. F2 (#2157) gated the caller-controlled `displayFieldId` on `GET /records-summary` **and** started passing `allowedFieldIds` so the default is chosen only from readable fields.
+
+But two **cross-sheet** callers still passed **no `allowedFieldIds`**, so the default display field of the *target* sheet was picked without consulting field permissions — and its cell value was echoed via `display`:
+
+| Site | Target sheet | Leak |
+|---|---|---|
+| `GET /fields/:fieldId/link-options` | the **foreign** sheet (`linkConfig.foreignSheetId`) | foreign sheet's default display field value |
+| `GET /people-search` | the **people** sheet (`description = '__metasheet_system:people__'`) | people sheet's default display field value |
+
+Because the default display field is keyed to **that** sheet (not the caller's sheet), a `field_permissions.visible = false` field on the foreign/people sheet leaked its value through `display` even though every other egress on that sheet is gated. This is the **crossSheetRelated per-sheet-keying** lesson (#2176/#2178): mask by *that* sheet's own `allowedFieldIds`, not the caller's.
+
+`person-fields/prepare` itself (the `GET /person-fields` prepare path) returns a static preset (`targetSheet` + `fieldProperty`) and does **not** call `loadRecordSummaries` — the live summary-display site is `GET /people-search`. The tracker row name is corrected accordingly (`person-fields/prepare` → `people-search`).
+
+## 2. The fix
+
+Both callers now load the **target sheet's own** layer-2 ∧ layer-3 readable set and pass it to `loadRecordSummaries`, so the default display field is chosen only from fields the caller may read — and a denied default is skipped (or, when present as an explicit value, omitted) rather than echoed.
+
+`packages/core-backend/src/routes/univer-meta.ts`:
+
+- **`link-options`** — capture the foreign sheet's access alongside capabilities, then load that sheet's allowed fields:
+  ```ts
+  const { access: foreignAccess, capabilities } =
+    await resolveSheetReadableCapabilities(req, pool.query.bind(pool), linkConfig.foreignSheetId)
+  // …
+  const foreignAllowedFieldIds = await loadAllowedFieldIds(
+    pool.query.bind(pool), linkConfig.foreignSheetId, foreignAccess.userId, capabilities)
+  // passed to loadRecordSummaries(..., { allowedFieldIds: foreignAllowedFieldIds })
+  ```
+- **`people-search`** — same shape against the people sheet:
+  ```ts
+  const { access, capabilities } = /* resolveSheetReadableCapabilities(... peopleSheetId) */
+  const peopleAllowedFieldIds = await loadAllowedFieldIds(query, peopleSheetId, access.userId, capabilities)
+  // passed to loadRecordSummaries(query, peopleSheetId, { search: q, limit, offset: 0, allowedFieldIds: peopleAllowedFieldIds })
+  ```
+
+`loadAllowedFieldIds` is the shared helper (introduced in this arc): returns an empty set when `!userId || !sheetId` (fail-closed), else `loadFieldsForSheet` + `loadFieldPermissionScopeMap` → `computeAllowedFieldIds`. `loadRecordSummaries` already honors `allowedFieldIds` (added in F2): `selectableFields = fields.filter(f => allowedFieldIds.has(f.id))` for default-display selection, while an explicit `displayFieldId` is still gated at the caller.
+
+No new query shapes, no central RBAC/auth touched — K3 Stage-1-lock-safe.
+
+## 3. Fail-first evidence
+
+Real-DB integration test (new): `packages/core-backend/tests/integration/multitable-summary-display-field-mask.test.ts`.
+
+**Seed** (deny is solely layer-3 — denied fields' `property = {}`, no `hidden`):
+- `SHEET_A` (source) + `FLD_LINK` (link → `SHEET_B`); `SHEET_B` (foreign) + `FLD_B_DISPLAY` (string, default display, value `B_CANARY`) + `REC_B`.
+- `PEOPLE_SHEET` (`description = '__metasheet_system:people__'`) + `FLD_P_NAME` (string, default display, value `P_CANARY`) + `REC_P`.
+- `field_permissions` deny `FLD_B_DISPLAY` (on `SHEET_B`) and `FLD_P_NAME` (on `PEOPLE_SHEET`) for `USER` only; `USER_2` has no deny (positive control).
+
+**Cases:**
+- `sentinel` — `DATABASE_URL` set (fails-not-skips).
+- `R1` (link-options, USER) — `rec.display !== B_CANARY` **and** whole body excludes `B_CANARY`, **and** `REC_B` is still listed (positive control: not an empty response). ← **THE LEAK, RED pre-fix.**
+- `R2` (link-options, USER_2 positive) — `display === B_CANARY` (mask is per-subject, not a blanket strip).
+- `R3` (people-search, USER) — `item.display !== P_CANARY` and body excludes `P_CANARY`, item present. ← **THE LEAK, RED pre-fix.**
+- `R4` (people-search, USER_2 positive) — `display === P_CANARY`.
+
+**Result:** RED on unmodified `origin/main` (R1 + R3 canaries present) → **5/5 GREEN** after the fix.
+
+## 4. Regression scope
+
+- `tsc` (core-backend) — exit **0**.
+- F2 sibling `multitable-records-summary-field-mask` — **7/7** (the same-helper neighbor: unchanged).
+- `record-form` real-DB suite — **8 = 8** (no net-new failure).
+- `multitable-sheet-permissions.api` (mocked, in the real-DB step) — F5's new `loadAllowedFieldIds` in `link-options` issued two queries the "allows link options" mock dispatcher didn't stub (a `meta_fields` order-select + a `field_permissions` lookup) → 1 → 2 failures. Restored to **pristine 1 failed / 40 passed** by adding two handlers to that test's create dispatcher (return one `string` field with `property: {}`, and `field_permissions` → `[]`). The one remaining failure is the pre-existing F2-era records-summary case, out of F5 scope.
+
+**Gating suites unaffected.** The real-DB locking suite (`plugin-tests.yml` "multitable real-DB integration") gains one test; no existing locking test changed behavior. The mocked `sheet-permissions` and `sheet-realtime.api` cases in that step were re-confirmed (the F4-lesson: every mocked test that hits the changed route was re-run, not just the new one).
+
+## 5. CI wiring & tracker
+
+- `.github/workflows/plugin-tests.yml` — `tests/integration/multitable-summary-display-field-mask.test.ts` added to the real-DB integration step (after `multitable-records-summary-field-mask.test.ts`). It runs on every PR against freshly-migrated Postgres with the `DATABASE_URL` hard-guard + sentinel ⇒ a future drop of either `allowedFieldIds` pass-through turns this **RED and blocks merge**.
+- Tracker §2b: **F5 → ✅🔒** (locking test `multitable-summary-display-field-mask`); completion **9 / 11**; "every High + Med + Low leak channel is closed." Remaining = D1 (design question) + kanban/gallery/calendar (coverage scan), each a separate explicit opt-in.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -2808,12 +2808,22 @@ async function buildLinkSummaries(
 
   const readableSheetIds = await resolveReadableSheetIds(req, query, idsBySheet.keys())
 
+  // F5-followup (#2106): the foreign-record `display` echoed in link summaries is the value of the foreign
+  // sheet's default display field. resolveReadableSheetIds gates SHEET-level read, but the display field
+  // itself can be field_permissions.visible=false for this caller — so pick it only from the foreign sheet's
+  // OWN layer-2 ∧ layer-3 allowed set (keyed to that sheet + the requester, the crossSheetRelated per-sheet
+  // rule). Otherwise the denied value leaks via every buildLinkSummaries consumer (/view, single-record read,
+  // link-options `selected`, write-echo). Selecting only from allowed fields makes the value read at the
+  // displayValue line below inherently safe.
   const displayFieldBySheet = new Map<string, string | null>()
   for (const [sheetId] of idsBySheet.entries()) {
     if (!readableSheetIds.has(sheetId)) continue
     const fields = await loadFieldsForSheet(query, sheetId)
-    const stringField = fields.find((field) => field.type === 'string')
-    displayFieldBySheet.set(sheetId, stringField?.id ?? fields[0]?.id ?? null)
+    const { access, capabilities } = await resolveSheetReadableCapabilities(req, query, sheetId)
+    const allowedFieldIds = await loadAllowedFieldIds(query, sheetId, access.userId, capabilities)
+    const allowedFields = fields.filter((field) => allowedFieldIds.has(field.id))
+    const stringField = allowedFields.find((field) => field.type === 'string')
+    displayFieldBySheet.set(sheetId, stringField?.id ?? allowedFields[0]?.id ?? null)
   }
 
   const foreignRecordsBySheet = new Map<string, Map<string, Record<string, unknown>>>()

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -4849,10 +4849,12 @@ export function univerMetaRouter(): Router {
         return res.json({ ok: true, data: { items: [] } })
       }
 
-      const { capabilities } = await resolveSheetReadableCapabilities(req, query, peopleSheetId)
+      const { access, capabilities } = await resolveSheetReadableCapabilities(req, query, peopleSheetId)
       if (!capabilities.canRead) return sendForbidden(res)
 
-      const summary = await loadRecordSummaries(query, peopleSheetId, { search: q, limit, offset: 0 })
+      // F5 (#2106 §3 F5): gate the people sheet's default display field by its own layer-2 ∧ layer-3 allowed set.
+      const peopleAllowedFieldIds = await loadAllowedFieldIds(query, peopleSheetId, access.userId, capabilities)
+      const summary = await loadRecordSummaries(query, peopleSheetId, { search: q, limit, offset: 0, allowedFieldIds: peopleAllowedFieldIds })
       return res.json({ ok: true, data: { items: summary.records } })
     } catch (err) {
       const hint = getDbNotReadyMessage(err)
@@ -7850,7 +7852,7 @@ export function univerMetaRouter(): Router {
       if (!targetSheet) {
         return res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: `Target sheet not found: ${linkConfig.foreignSheetId}` } })
       }
-      const { capabilities } = await resolveSheetReadableCapabilities(req, pool.query.bind(pool), linkConfig.foreignSheetId)
+      const { access: foreignAccess, capabilities } = await resolveSheetReadableCapabilities(req, pool.query.bind(pool), linkConfig.foreignSheetId)
       if (!capabilities.canRead) return sendForbidden(res)
 
       let selected: LinkedRecordSummary[] = []
@@ -7878,10 +7880,15 @@ export function univerMetaRouter(): Router {
         selected = linkSummaries.get(recordId)?.get(fieldId) ?? []
       }
 
+      // F5 (#2106 §3 F5): gate the FOREIGN sheet's default display field by ITS OWN layer-2 ∧ layer-3 allowed
+      // set (keyed to the foreign sheet, not the caller's) so a field_permissions-denied display value never
+      // leaks via the summary `display`.
+      const foreignAllowedFieldIds = await loadAllowedFieldIds(pool.query.bind(pool), linkConfig.foreignSheetId, foreignAccess.userId, capabilities)
       const summary = await loadRecordSummaries(pool.query.bind(pool), linkConfig.foreignSheetId, {
         search,
         limit,
         offset,
+        allowedFieldIds: foreignAllowedFieldIds,
       })
 
       return res.json({

--- a/packages/core-backend/tests/integration/multitable-link-summary-display-field-mask.test.ts
+++ b/packages/core-backend/tests/integration/multitable-link-summary-display-field-mask.test.ts
@@ -1,0 +1,153 @@
+/**
+ * Real-DB integration test for the `buildLinkSummaries` foreign-display-value leak (a #2106 follow-up to F5).
+ *
+ * `buildLinkSummaries` derives each linked foreign record's `display` from the foreign sheet's default display
+ * field and echoes it into `linkSummaries` / `selected`. `resolveReadableSheetIds` gates SHEET-level read, and
+ * the `filter*FieldSummaryMap` wrappers drop summaries for *link fields* the caller cannot read — but NOTHING
+ * masked the foreign `display` VALUE when the link field is readable yet the foreign sheet's display field is
+ * `field_permissions.visible=false` for the caller. So the denied value leaked via every consumer:
+ *   - GET /view                         (data.linkSummaries[recordId][fieldId][].display)
+ *   - GET /records/:recordId            (data.linkSummaries[fieldId][].display)
+ *   - GET /fields/:fieldId/link-options?recordId=  (data.selected[].display)
+ * The fix picks the foreign display field only from THAT sheet's own layer-2 ∧ layer-3 allowed set (the
+ * crossSheetRelated per-sheet-keying rule), so the read at `data[displayFieldId]` is inherently safe.
+ *
+ * This is the complement of records-read R6 (which denies the LINK field → the whole summary key drops):
+ * here the link field is VISIBLE (the key survives) and only the foreign DISPLAY field is denied, so the
+ * leak is the surviving summary's `display` value. Seed non-negotiable: the denied display field's property
+ * carries no `hidden` → deny is solely layer-3.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_lsd_${TS}`
+const SHEET_A = `sheet_lsd_src_${TS}` // source sheet holding the (readable) link field
+const FLD_LINK = `fld_lsd_link_${TS}` // link field → SHEET_B; NOT denied (so the summary key survives)
+const FLD_A_NOTE = `fld_lsd_anote_${TS}` // readable bystander field on SHEET_A — the write target for S4
+const REC_A = `rec_lsd_a_${TS}` // source record linked to REC_B
+const SHEET_B = `sheet_lsd_foreign_${TS}` // foreign sheet
+const FLD_B_DISPLAY = `fld_lsd_bdisplay_${TS}` // foreign default display (string), DENIED to USER on SHEET_B
+const REC_B = `rec_lsd_b_${TS}`
+const USER_ID = `u_lsd_${TS}` // denied FLD_B_DISPLAY on SHEET_B
+const USER_ID_2 = `u_lsd_other_${TS}` // no deny → positive control
+const B_CANARY = `do-not-leak-lsd-${TS}`
+
+let app: Express
+let testUserId = USER_ID
+let testPerms: string[] = ['multitable:read']
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const viewReq = () => request(app).get('/api/multitable/view').query({ sheetId: SHEET_A, includeLinkSummaries: 'true' })
+const recordReq = () => request(app).get(`/api/multitable/records/${REC_A}`).query({ sheetId: SHEET_A })
+const linkOptions = () => request(app).get(`/api/multitable/fields/${FLD_LINK}/link-options`).query({ recordId: REC_A })
+const batchPatch = (body: Record<string, unknown>) => request(app).post('/api/multitable/patch').send(body)
+
+describeIfDatabase('buildLinkSummaries foreign-display-value field mask (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = testUserId ? { id: testUserId, roles: [], perms: testPerms } : undefined; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'Link Summary Display Base'])
+    // source sheet A + a readable link field → B, and a source record
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_A, BASE_ID, 'LSD Source'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LINK, SHEET_A, 'Linked', 'link', JSON.stringify({ foreignSheetId: SHEET_B }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_A_NOTE, SHEET_A, 'Note', 'string', '{}', 2])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_A, SHEET_A, '{}'])
+    // foreign sheet B: its only string field is the (denied-to-USER) default display
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_B, BASE_ID, 'LSD Foreign'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_B_DISPLAY, SHEET_B, 'BName', 'string', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_B, SHEET_B, JSON.stringify({ [FLD_B_DISPLAY]: B_CANARY })])
+    // link REC_A → REC_B
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [FLD_LINK, REC_A, REC_B])
+    // layer-3 read deny on the FOREIGN display field, for USER only (NOT on the source link field)
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_B, FLD_B_DISPLAY, 'user', USER_ID, false, false])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_B]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id = $1', [FLD_LINK]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SHEET_A, SHEET_B]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('S1 (GET /view): the FOREIGN display value is masked in linkSummaries, but the (readable) link-field key survives', async () => {
+    // positive control FIRST (defeats an empty-summary false-green): an ungranted-to-deny user DOES get B_CANARY
+    testUserId = USER_ID_2
+    const granted = await viewReq()
+    expect(granted.status).toBe(200)
+    expect(granted.body.data.linkSummaries?.[REC_A]?.[FLD_LINK]?.[0]?.display).toBe(B_CANARY)
+
+    // the denied user: the link-field summary is STILL present (link field is readable) but its display is masked
+    testUserId = USER_ID
+    const denied = await viewReq()
+    expect(denied.status).toBe(200)
+    const summary = denied.body.data.linkSummaries?.[REC_A]?.[FLD_LINK]
+    expect(summary?.[0]?.id).toBe(REC_B) // the summary key/entry survives (this is NOT the link-field-denied R6 case)
+    expect(summary?.[0]?.display).not.toBe(B_CANARY) // THE LEAK (RED pre-fix): foreign display value
+    expect(JSON.stringify(denied.body)).not.toContain(B_CANARY)
+  })
+
+  test('S2 (GET /records/:recordId): the FOREIGN display value is masked in the single-record linkSummaries', async () => {
+    testUserId = USER_ID_2
+    const granted = await recordReq()
+    expect(granted.status).toBe(200)
+    expect(granted.body.data.linkSummaries?.[FLD_LINK]?.[0]?.display).toBe(B_CANARY)
+
+    testUserId = USER_ID
+    const denied = await recordReq()
+    expect(denied.status).toBe(200)
+    const summary = denied.body.data.linkSummaries?.[FLD_LINK]
+    expect(summary?.[0]?.id).toBe(REC_B)
+    expect(summary?.[0]?.display).not.toBe(B_CANARY) // THE LEAK (RED pre-fix)
+    expect(JSON.stringify(denied.body)).not.toContain(B_CANARY)
+  })
+
+  test('S3 (GET /fields/:fieldId/link-options?recordId=): the FOREIGN display value is masked in data.selected', async () => {
+    testUserId = USER_ID_2
+    const granted = await linkOptions()
+    expect(granted.status).toBe(200)
+    expect(granted.body.data.selected.find((r: { id: string }) => r.id === REC_B)?.display).toBe(B_CANARY)
+
+    testUserId = USER_ID
+    const denied = await linkOptions()
+    expect(denied.status).toBe(200)
+    const sel = denied.body.data.selected.find((r: { id: string }) => r.id === REC_B)
+    expect(sel).toBeDefined() // the linked record is still listed in `selected`
+    expect(sel.display).not.toBe(B_CANARY) // THE LEAK (RED pre-fix)
+    expect(JSON.stringify(denied.body)).not.toContain(B_CANARY)
+  })
+
+  test('S4 (POST /patch write-echo): the FOREIGN display value is masked in the linkSummaries echo of a patched record', async () => {
+    // RecordWriteService rebuilds linkSummaries for the updated record (→ buildLinkSummaries) whenever the sheet
+    // has a link field and a row is updated. Edit a readable BYSTANDER field so updates.length>0 triggers the
+    // echo; the link itself is untouched. (PATCH /records/:id echoes link IDs, not summaries — POST /patch is
+    // the linkSummaries write surface.)
+    testPerms = ['multitable:read', 'multitable:write']
+    testUserId = USER_ID_2
+    const granted = await batchPatch({ sheetId: SHEET_A, changes: [{ recordId: REC_A, fieldId: FLD_A_NOTE, value: 'granted-edit' }] })
+    expect(granted.status).toBe(200)
+    expect(granted.body.data.linkSummaries?.[REC_A]?.[FLD_LINK]?.[0]?.display).toBe(B_CANARY)
+
+    testUserId = USER_ID
+    const denied = await batchPatch({ sheetId: SHEET_A, changes: [{ recordId: REC_A, fieldId: FLD_A_NOTE, value: 'denied-edit' }] })
+    expect(denied.status).toBe(200)
+    const summary = denied.body.data.linkSummaries?.[REC_A]?.[FLD_LINK]
+    expect(summary?.[0]?.id).toBe(REC_B) // the (readable) link-field summary survives in the echo
+    expect(summary?.[0]?.display).not.toBe(B_CANARY) // THE LEAK (RED pre-fix)
+    expect(JSON.stringify(denied.body)).not.toContain(B_CANARY)
+    testPerms = ['multitable:read']
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-permissions.api.test.ts
@@ -2588,6 +2588,13 @@ describe('Multitable sheet-scoped permissions API', () => {
             ],
           }
         }
+        // F5: link-options now resolves the FOREIGN sheet's allowed-field set (loadFieldsForSheet + field_permissions; no denials here).
+        if (sql.includes('SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1')) {
+          return { rows: [{ id: 'fld_vendor_name', name: 'Vendor Name', type: 'string', property: {}, order: 1 }] }
+        }
+        if (sql.includes('field_permissions')) {
+          return { rows: [] }
+        }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })

--- a/packages/core-backend/tests/integration/multitable-summary-display-field-mask.test.ts
+++ b/packages/core-backend/tests/integration/multitable-summary-display-field-mask.test.ts
@@ -1,0 +1,117 @@
+/**
+ * Real-DB integration test for F5 — record-summary display-value field mask on the cross-sheet read paths.
+ * Design-lock: docs/development/multitable-record-egress-fieldperm-inventory-20260529.md (#2106) §3 F5.
+ *
+ * `loadRecordSummaries` derives a per-record `display` value from a display field. F2 (#2157) gated the
+ * caller-controlled `displayFieldId` on `GET /records-summary` and passes `allowedFieldIds` so the DEFAULT
+ * display field is picked only from readable fields. But two cross-sheet callers still pass NO allowedFieldIds:
+ *   - `GET /fields/:fieldId/link-options` → loadRecordSummaries(FOREIGN sheet)
+ *   - `GET /people-search`               → loadRecordSummaries(PEOPLE sheet)
+ * So the default display field of the FOREIGN/PEOPLE sheet — keyed to THAT sheet, not the caller's — can be a
+ * `field_permissions.visible=false` field, and its value leaks via `display`. F5 passes the foreign/people
+ * sheet's own layer-2 ∧ layer-3 allowedFieldIds (the crossSheetRelated per-sheet-keying lesson).
+ *
+ * Seed non-negotiable: the denied display field's property carries no `hidden` → deny is solely layer-3.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+const PEOPLE_DESC = '__metasheet_system:people__'
+
+const TS = Date.now()
+const BASE_ID = `base_f5_${TS}`
+const SHEET_A = `sheet_f5_src_${TS}` // source sheet holding the link field
+const FLD_LINK = `fld_f5_link_${TS}` // link field → SHEET_B
+const SHEET_B = `sheet_f5_foreign_${TS}` // foreign sheet
+const FLD_B_DISPLAY = `fld_f5_bdisplay_${TS}` // foreign default display (string), denied to USER
+const REC_B = `rec_f5_b_${TS}`
+const PEOPLE_SHEET = `sheet_f5_people_${TS}` // people sheet (description marker)
+const FLD_P_NAME = `fld_f5_pname_${TS}` // people default display (string), denied to USER
+const REC_P = `rec_f5_p_${TS}`
+const USER_ID = `u_f5_${TS}` // denied FLD_B_DISPLAY + FLD_P_NAME
+const USER_ID_2 = `u_f5_other_${TS}` // no deny → positive control
+const B_CANARY = `do-not-leak-f5-link-${TS}`
+const P_CANARY = `do-not-leak-f5-people-${TS}`
+
+let app: Express
+let testUserId = USER_ID
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const linkOptions = () => request(app).get(`/api/multitable/fields/${FLD_LINK}/link-options`)
+const peopleSearch = () => request(app).get('/api/multitable/people-search').query({ baseId: BASE_ID })
+
+describeIfDatabase('F5 record-summary display-value field mask (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = testUserId ? { id: testUserId, roles: [], perms: ['multitable:read'] } : undefined; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'F5 Base'])
+    // source sheet A + link field → B
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_A, BASE_ID, 'F5 Source'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LINK, SHEET_A, 'Linked', 'link', JSON.stringify({ foreignSheetId: SHEET_B }), 1])
+    // foreign sheet B: its only string field is the (denied) default display
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_B, BASE_ID, 'F5 Foreign'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_B_DISPLAY, SHEET_B, 'BName', 'string', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_B, SHEET_B, JSON.stringify({ [FLD_B_DISPLAY]: B_CANARY })])
+    // people sheet (description marker) + denied display field
+    await q('INSERT INTO meta_sheets (id, base_id, name, description) VALUES ($1,$2,$3,$4)', [PEOPLE_SHEET, BASE_ID, 'F5 People', PEOPLE_DESC])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_P_NAME, PEOPLE_SHEET, 'PName', 'string', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_P, PEOPLE_SHEET, JSON.stringify({ [FLD_P_NAME]: P_CANARY })])
+    // layer-3 read deny (subject-scoped) on the foreign/people display fields, for USER only
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_B, FLD_B_DISPLAY, 'user', USER_ID, false, false])
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [PEOPLE_SHEET, FLD_P_NAME, 'user', USER_ID, false, false])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = ANY($1::text[])', [[SHEET_B, PEOPLE_SHEET]]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SHEET_B, PEOPLE_SHEET]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[SHEET_A, SHEET_B, PEOPLE_SHEET]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SHEET_A, SHEET_B, PEOPLE_SHEET]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('R1 (link-options): a denied FOREIGN-sheet display field is not echoed as the summary display value', async () => {
+    testUserId = USER_ID
+    const res = await linkOptions()
+    expect(res.status).toBe(200)
+    const rec = res.body.data.records.find((r: { id: string }) => r.id === REC_B)
+    expect(rec).toBeDefined() // the record is still listed (positive control: not an empty response)
+    expect(rec.display).not.toBe(B_CANARY) // THE LEAK (RED pre-fix): denied foreign display value
+    expect(JSON.stringify(res.body)).not.toContain(B_CANARY)
+  })
+
+  test('R2 (link-options positive): an ungranted-to-deny user DOES get the foreign display value (mask is per-subject)', async () => {
+    testUserId = USER_ID_2
+    const res = await linkOptions()
+    expect(res.status).toBe(200)
+    expect(res.body.data.records.find((r: { id: string }) => r.id === REC_B)?.display).toBe(B_CANARY)
+    testUserId = USER_ID
+  })
+
+  test('R3 (people-search): a denied PEOPLE-sheet display field is not echoed as the summary display value', async () => {
+    testUserId = USER_ID
+    const res = await peopleSearch()
+    expect(res.status).toBe(200)
+    const item = res.body.data.items.find((r: { id: string }) => r.id === REC_P)
+    expect(item).toBeDefined()
+    expect(item.display).not.toBe(P_CANARY) // THE LEAK (RED pre-fix)
+    expect(JSON.stringify(res.body)).not.toContain(P_CANARY)
+  })
+
+  test('R4 (people-search positive): an ungranted-to-deny user DOES get the people display value', async () => {
+    testUserId = USER_ID_2
+    const res = await peopleSearch()
+    expect(res.status).toBe(200)
+    expect(res.body.data.items.find((r: { id: string }) => r.id === REC_P)?.display).toBe(P_CANARY)
+    testUserId = USER_ID
+  })
+})


### PR DESCRIPTION
Closes the **F5** finding of the multitable field-read-permission-gate arc **and** a distinct review-discovered follow-up in the shared `buildLinkSummaries` helper (tracker `docs/development/multitable-field-read-gate-tracker-20260602.md` §2b; design-lock #2106 §F5).

## Finding 1 — F5: `loadRecordSummaries` default-display value (`commit 1`)
`loadRecordSummaries` echoes a per-record `display` from a default display field. F2 (#2157) gated `GET /records-summary`, but two cross-sheet callers passed no `allowedFieldIds`, leaking a `field_permissions`-denied default-display value of the **target** sheet:
- `GET /fields/:id/link-options` → foreign sheet (`data.records`)
- `GET /people-search` → people sheet (`__metasheet_system:people__`)

**Fix:** each loads the target sheet's own layer-2 ∧ layer-3 `allowedFieldIds` and passes it through. Locking test `multitable-summary-display-field-mask` (5/5, RED→GREEN).

## Finding 2 — `buildLinkSummaries` foreign-display value (`commit 2`, review follow-up)
Independent review found `link-options` `data.selected` *still* leaks. Root cause is the shared **`buildLinkSummaries`** helper: it picks the foreign sheet's first string field as `display` and reads it with **no field-level mask** (only sheet-level read is gated). The `filter*FieldSummaryMap` wrappers drop unreadable *link fields* (caller-side) but never mask the foreign `display` **value**. So the denied value leaks on **four** surfaces:
- `GET /view` (`data.linkSummaries[recordId][fieldId][].display`)
- `GET /records/:recordId` (`data.linkSummaries[fieldId][].display`)
- `GET /fields/:id/link-options?recordId=` (`data.selected[].display`)
- write/patch echo (`data.linkSummaries[…].display`)

**Fix (root, closes all four):** select the foreign display field only from **that sheet's own** allowed set (`resolveSheetReadableCapabilities` + `loadAllowedFieldIds`, per-sheet keying). This is the **complement** of `records-read` R6 (which denies the link field → whole key drops); here the link field is visible and only the foreign display field is denied. Locking test `multitable-link-summary-display-field-mask` (4/4, RED→GREEN on all 3 read surfaces).

**Admin-safe (verified):** `deriveFieldPermissions` has no admin bypass for *visibility* — it depends only on `(sheetId, userId)` scope; `capabilities` affects only `readOnly`. So an admin/ungranted user with no deny row still sees the value (per-subject positive controls). No new query shapes; **K3 Stage-1-lock-safe**.

## Regression
- `tsc` 0.
- Real-DB neighbors **33/33** incl. `records-read-field-mask` R6 (link-field-denied still drops the key), F2/F5/write-echo/create-echo/cross-sheet.
- Gating mocked suites pristine: `sheet-permissions.api` 1 failed/40 passed (pre-existing F2-era case) + `sheet-realtime.api` 3/3 — both unchanged (verified by stash-diff: combined mocked run identical to baseline). `buildLinkSummaries` early-returns for link-less sheets, so no mock-stub cascade.

## Tracker
§2b: F5 row made precise (`loadRecordSummaries`) + **new row** for the `buildLinkSummaries` finding; completion **10/12**; every High + Med + Low leak channel closed. §3 Layer-3 grep set + lesson updated (derived foreign-keyed display values). Remaining = D1 (design question) + kanban/gallery/calendar (coverage scan), each a separate opt-in.

Verification: `multitable-summary-display-field-mask-verification-20260602.md` + `multitable-link-summary-display-field-mask-verification-20260602.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)