### PR TITLE
feat(integration): C2b — workbench source picker for the data-source:sql-readonly bridge

### DIFF
--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -1338,8 +1338,9 @@ const connectionDraftJsonError = computed(() => {
   }
 })
 const canSaveConnectionDraft = computed(() => {
-  // The bridge kind requires a picked data source (config is built from it, not the JSON textarea).
-  if (isDataSourceBridgeKind.value && !connectionDraft.dataSourceId.trim()) return false
+  // The bridge kind requires BOTH a picked data source AND an object (table/view) — without the
+  // object the source is not readable (v1 has no schema dropdown, so the text input is load-bearing).
+  if (isDataSourceBridgeKind.value && (!connectionDraft.dataSourceId.trim() || !connectionDraft.dataSourceObject.trim())) return false
   return Boolean(
     connectionDraft.name.trim()
     && connectionDraft.kind

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -174,13 +174,28 @@
             </select>
           </label>
         </div>
+        <div v-if="isDataSourceBridgeKind" class="integration-workbench__grid integration-workbench__grid--compact" data-testid="data-source-bridge-picker">
+          <label>
+            <span>数据源(只读)</span>
+            <select v-model="connectionDraft.dataSourceId" data-testid="data-source-bridge-id">
+              <option value="">请选择已配置的数据源</option>
+              <option v-for="ds in bridgeDataSources" :key="ds.id" :value="ds.id">{{ ds.name }} · {{ ds.type }}</option>
+            </select>
+          </label>
+          <label>
+            <span>对象(表 / 视图)</span>
+            <input v-model="connectionDraft.dataSourceObject" data-testid="data-source-bridge-object" placeholder="例如 public.items" />
+          </label>
+          <p class="integration-workbench__hint" data-testid="data-source-bridge-hint">凭据由 /data-sources 管理,这里只引用 dataSourceId,不复制账号密码。</p>
+          <p v-if="bridgeDataSourcesError" class="integration-workbench__hint integration-workbench__hint--strong" data-testid="data-source-bridge-error">{{ bridgeDataSourcesError }}</p>
+        </div>
         <div v-if="connectionDraftDuplicateWarning" class="integration-workbench__hint integration-workbench__hint--strong" data-testid="connection-duplicate-warning">
           {{ connectionDraftDuplicateWarning }}
         </div>
         <div v-if="connectionDraftRoleWarning" class="integration-workbench__hint integration-workbench__hint--strong" data-testid="connection-role-warning">
           {{ connectionDraftRoleWarning }}
         </div>
-        <details class="integration-workbench__details">
+        <details v-if="!isDataSourceBridgeKind" class="integration-workbench__details">
           <summary>高级 JSON 配置（不会显示或保存凭证）</summary>
           <div class="integration-workbench__grid integration-workbench__grid--compact">
             <label>
@@ -928,6 +943,8 @@
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref, watch } from 'vue'
 import { buildXlsxBuffer } from '../multitable/import/xlsx-mapping'
+import { listDataSources } from '../data-sources/api'
+import type { DataSourceListItem } from '../data-sources/types'
 import {
   canReadFromSystem,
   canWriteToSystem,
@@ -1022,6 +1039,10 @@ interface ConnectionDraft {
   status: ConnectionDraftStatus
   configText: string
   capabilitiesText: string
+  // C2b: structured config for the read-only data-source bridge (kind 'data-source:sql-readonly').
+  // The connection only ever references a data_sources id — credentials stay in /data-sources.
+  dataSourceId: string
+  dataSourceObject: string
 }
 
 type ExportCell = string | number | boolean | null
@@ -1162,10 +1183,49 @@ const connectionDraft = reactive<ConnectionDraft>({
   status: 'active',
   configText: '{}',
   capabilitiesText: '{}',
+  dataSourceId: '',
+  dataSourceObject: '',
 })
 const connectionDraftMode = ref<'new' | 'edit' | 'copy'>('new')
 const savingConnectionDraft = ref(false)
 const deletingConnectionId = ref('')
+
+// C2b — read-only data-source bridge connection (kind 'data-source:sql-readonly'): a structured
+// picker that references an existing /data-sources connection by id (never copies credentials).
+const DATA_SOURCE_BRIDGE_KIND = 'data-source:sql-readonly'
+const bridgeDataSources = ref<DataSourceListItem[]>([])
+const bridgeDataSourcesError = ref('')
+const bridgeDataSourcesLoaded = ref(false)
+const isDataSourceBridgeKind = computed(() => connectionDraft.kind === DATA_SOURCE_BRIDGE_KIND)
+
+async function loadBridgeDataSources(): Promise<void> {
+  if (bridgeDataSourcesLoaded.value) return
+  try {
+    bridgeDataSources.value = await listDataSources()
+    bridgeDataSourcesLoaded.value = true
+  } catch (error) {
+    bridgeDataSourcesError.value = error instanceof Error ? error.message : String(error)
+  }
+}
+
+// Lazy: only fetch the data-source list when the operator actually picks the bridge kind.
+watch(() => connectionDraft.kind, (kind) => {
+  if (kind === DATA_SOURCE_BRIDGE_KIND) void loadBridgeDataSources()
+})
+
+function buildDataSourceBridgeConfig(): Record<string, unknown> {
+  const object = connectionDraft.dataSourceObject.trim()
+  // Only the data_sources reference + object — NO credentials are ever entered for this kind.
+  return {
+    dataSourceId: connectionDraft.dataSourceId.trim(),
+    ...(object ? { object } : {}),
+  }
+}
+
+function bridgeConfigString(config: unknown, key: string): string {
+  const value = config && typeof config === 'object' ? (config as Record<string, unknown>)[key] : undefined
+  return typeof value === 'string' ? value : ''
+}
 
 const adapterMetadataByKind = computed(() => new Map(adapters.value.map((adapter) => [adapter.kind, adapter])))
 const inventorySummary = computed(() => `已配置连接 ${systems.value.length} 个（可编辑 / 复制 / 停用 / 删除） · ${adapters.value.length} 个适配器 · ${stagingDescriptors.value.length} 个 staging 表`)
@@ -1278,11 +1338,13 @@ const connectionDraftJsonError = computed(() => {
   }
 })
 const canSaveConnectionDraft = computed(() => {
+  // The bridge kind requires a picked data source (config is built from it, not the JSON textarea).
+  if (isDataSourceBridgeKind.value && !connectionDraft.dataSourceId.trim()) return false
   return Boolean(
     connectionDraft.name.trim()
     && connectionDraft.kind
     && !connectionDraftRoleWarning.value
-    && !connectionDraftJsonError.value,
+    && (isDataSourceBridgeKind.value || !connectionDraftJsonError.value),
   )
 })
 const sourceDatasetTitle = computed(() => selectedObjectLabel('source') || '请选择来源数据集')
@@ -1565,6 +1627,8 @@ function resetConnectionDraft(): void {
   connectionDraft.status = 'active'
   connectionDraft.configText = '{}'
   connectionDraft.capabilitiesText = '{}'
+  connectionDraft.dataSourceId = ''
+  connectionDraft.dataSourceObject = ''
   connectionDraftMode.value = 'new'
 }
 
@@ -1576,6 +1640,8 @@ function editConnection(system: WorkbenchExternalSystem): void {
   connectionDraft.status = system.status
   connectionDraft.configText = stringifyConnectionDraftJson(system.config)
   connectionDraft.capabilitiesText = stringifyConnectionDraftJson(system.capabilities)
+  connectionDraft.dataSourceId = bridgeConfigString(system.config, 'dataSourceId')
+  connectionDraft.dataSourceObject = bridgeConfigString(system.config, 'object')
   connectionDraftMode.value = 'edit'
   inventoryExpanded.value = true
   setStatus(`已载入连接草稿：${system.name}`, 'idle')
@@ -1589,6 +1655,8 @@ function copyConnection(system: WorkbenchExternalSystem): void {
   connectionDraft.status = 'inactive'
   connectionDraft.configText = stringifyConnectionDraftJson(system.config)
   connectionDraft.capabilitiesText = stringifyConnectionDraftJson(system.capabilities)
+  connectionDraft.dataSourceId = bridgeConfigString(system.config, 'dataSourceId')
+  connectionDraft.dataSourceObject = bridgeConfigString(system.config, 'object')
   connectionDraftMode.value = 'copy'
   inventoryExpanded.value = true
   setStatus(`已复制 ${system.name} 为新连接草稿；保存前请改名并确认用途。`, 'idle')
@@ -1703,7 +1771,9 @@ async function saveConnectionDraft(): Promise<void> {
       kind: connectionDraft.kind,
       role: connectionDraft.role,
       status: connectionDraft.status,
-      config: parseConnectionDraftJson(connectionDraft.configText, 'config JSON'),
+      config: isDataSourceBridgeKind.value
+        ? buildDataSourceBridgeConfig()
+        : parseConnectionDraftJson(connectionDraft.configText, 'config JSON'),
       capabilities: parseConnectionDraftJson(connectionDraft.capabilitiesText, 'capabilities JSON'),
     })
     replaceSystem(system)

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -2,9 +2,11 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 import { createApp, h, nextTick, type App as VueApp, type Component } from 'vue'
 
 const apiFetchMock = vi.fn()
+const apiGetMock = vi.fn()
 
 vi.mock('../src/utils/api', () => ({
   apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+  apiGet: (...args: unknown[]) => apiGetMock(...args),
 }))
 
 function jsonResponse(data: unknown): Response {
@@ -1925,5 +1927,94 @@ describe('IntegrationWorkbenchView', () => {
     ;(container.querySelector('[data-testid="preview-payload"]') as HTMLButtonElement).click()
     await flushUi()
     expect(previewBodies.at(-1)!).not.toHaveProperty('referenceMappingSources')
+  })
+
+  it('C2b: data-source:sql-readonly connection uses the structured picker and references a data source by id (no credentials)', async () => {
+    const upsertBodies: Array<Record<string, unknown>> = []
+    apiGetMock.mockReset()
+    apiGetMock.mockImplementation(async (url: string) => {
+      if (url === '/api/data-sources') {
+        return { ok: true, data: { items: [
+          { id: 'pg-1', name: 'Warehouse PG', type: 'postgres', connected: true },
+          { id: 'mssql-2', name: 'ERP MSSQL', type: 'sqlserver', connected: true },
+        ] } }
+      }
+      throw new Error(`unexpected apiGet ${url}`)
+    })
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'http', label: 'HTTP API', roles: ['source', 'target', 'bidirectional'], supports: ['read', 'upsert'], advanced: false },
+          { kind: 'data-source:sql-readonly', label: 'Read-only SQL data source', roles: ['source'], supports: ['testConnection', 'listObjects', 'getSchema', 'read'], advanced: true, guardrails: { write: { supported: false } } },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/external-systems' && init?.method === 'POST') {
+        const body = JSON.parse(String(init.body || '{}')) as Record<string, unknown>
+        upsertBodies.push(body)
+        return jsonResponse({ id: 'ds_bridge_1', ...body })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    // eslint-disable-next-line vue/one-component-per-file
+    app.component('RouterLink', {
+      props: { to: { type: [String, Object], required: false, default: '' } },
+      setup(_props, { slots }) { return () => h('a', slots.default?.()) },
+    })
+    app.mount(container)
+    await flushUi()
+
+    // Picker is hidden until the operator picks the bridge kind, and the data-source list is NOT fetched yet (lazy).
+    expect(container.querySelector('[data-testid="data-source-bridge-picker"]')).toBeNull()
+    expect(apiGetMock.mock.calls.some(([url]) => url === '/api/data-sources')).toBe(false)
+
+    // data-source:sql-readonly is an advanced connector — reveal it via the advanced toggle first.
+    const advancedToggle = container.querySelector('[data-testid="show-advanced-connectors"]') as HTMLInputElement
+    advancedToggle.checked = true
+    advancedToggle.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    const kindSelect = container.querySelector('[data-testid="connection-draft-kind"]') as HTMLSelectElement
+    kindSelect.value = 'data-source:sql-readonly'
+    kindSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    // Picker appears + lists the data sources; the raw-JSON config is hidden for this kind.
+    expect(container.querySelector('[data-testid="data-source-bridge-picker"]')).not.toBeNull()
+    expect(container.querySelector('[data-testid="connection-draft-config"]')).toBeNull()
+    const dsSelect = container.querySelector('[data-testid="data-source-bridge-id"]') as HTMLSelectElement
+    const dsOptions = Array.from(dsSelect.options).map((option) => option.textContent?.trim())
+    expect(dsOptions).toContain('Warehouse PG · postgres')
+    expect(dsOptions).toContain('ERP MSSQL · sqlserver')
+    expect(container.querySelector('[data-testid="data-source-bridge-hint"]')?.textContent).toContain('凭据由 /data-sources 管理')
+
+    const nameInput = container.querySelector('[data-testid="connection-draft-name"]') as HTMLInputElement
+    nameInput.value = 'Warehouse bridge'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    dsSelect.value = 'pg-1'
+    dsSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const objInput = container.querySelector('[data-testid="data-source-bridge-object"]') as HTMLInputElement
+    objInput.value = 'public.items'
+    objInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    ;(container.querySelector('[data-testid="save-connection-draft"]') as HTMLButtonElement).click()
+    await flushUi(8)
+
+    // The saved connection references the data source by id (+ object) and carries NO credentials.
+    expect(upsertBodies).toHaveLength(1)
+    const saved = upsertBodies[0]
+    expect(saved.kind).toBe('data-source:sql-readonly')
+    expect(saved.role).toBe('source')
+    expect(saved.config).toEqual({ dataSourceId: 'pg-1', object: 'public.items' })
+    expect(saved).not.toHaveProperty('credentials')
+    expect(JSON.stringify(saved.config)).not.toMatch(/password|token|secret|credential/i)
+    expect(container.textContent).toContain('连接已保存：Warehouse bridge')
   })
 })

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -1955,6 +1955,9 @@ describe('IntegrationWorkbenchView', () => {
         upsertBodies.push(body)
         return jsonResponse({ id: 'ds_bridge_1', ...body })
       }
+      if (url.startsWith('/api/integration/external-systems/ds_bridge_1/objects')) {
+        return jsonResponse([{ name: 'public.items', label: 'public.items', operations: ['read'], source: 'data-source:sql-readonly' }])
+      }
       throw new Error(`unexpected URL ${url}`)
     })
 
@@ -2016,5 +2019,70 @@ describe('IntegrationWorkbenchView', () => {
     expect(saved).not.toHaveProperty('credentials')
     expect(JSON.stringify(saved.config)).not.toMatch(/password|token|secret|credential/i)
     expect(container.textContent).toContain('连接已保存：Warehouse bridge')
+
+    // Reachability: the saved bridge source is selectable as a Data Factory source, and loading its
+    // objects routes through the (now principal-threaded) objects endpoint — not fail-closed.
+    const sourceSystemSelect = container.querySelector('[data-testid="source-system"]') as HTMLSelectElement
+    expect(Array.from(sourceSystemSelect.options).some((option) => option.value === 'ds_bridge_1')).toBe(true)
+    sourceSystemSelect.value = 'ds_bridge_1'
+    sourceSystemSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    ;(container.querySelector('[data-testid="load-source-objects"]') as HTMLButtonElement).click()
+    await flushUi(8)
+    expect(apiFetchMock.mock.calls.some(([url]) => String(url).startsWith('/api/integration/external-systems/ds_bridge_1/objects'))).toBe(true)
+    const objectSelect = container.querySelector('[data-testid="source-object"]') as HTMLSelectElement
+    expect(Array.from(objectSelect.options).map((option) => option.value)).toContain('public.items')
+  })
+
+  it('C2b: the save gate requires an object (no half-config without a table/view)', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'http', label: 'HTTP API', roles: ['source', 'target', 'bidirectional'], supports: ['read', 'upsert'], advanced: false },
+          { kind: 'data-source:sql-readonly', label: 'Read-only SQL data source', roles: ['source'], supports: ['testConnection', 'listObjects', 'getSchema', 'read'], advanced: true, guardrails: { write: { supported: false } } },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      throw new Error(`unexpected URL ${url}`)
+    })
+    apiGetMock.mockReset()
+    apiGetMock.mockImplementation(async (url: string) => {
+      if (url === '/api/data-sources') return { ok: true, data: { items: [{ id: 'pg-1', name: 'Warehouse PG', type: 'postgres', connected: true }] } }
+      throw new Error(`unexpected apiGet ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    // eslint-disable-next-line vue/one-component-per-file
+    app.component('RouterLink', { props: { to: { type: [String, Object], required: false, default: '' } }, setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
+    app.mount(container)
+    await flushUi()
+
+    ;(container.querySelector('[data-testid="show-advanced-connectors"]') as HTMLInputElement).checked = true
+    container.querySelector('[data-testid="show-advanced-connectors"]')!.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    const kindSelect = container.querySelector('[data-testid="connection-draft-kind"]') as HTMLSelectElement
+    kindSelect.value = 'data-source:sql-readonly'
+    kindSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+    const nameInput = container.querySelector('[data-testid="connection-draft-name"]') as HTMLInputElement
+    nameInput.value = 'Half config'
+    nameInput.dispatchEvent(new Event('input', { bubbles: true }))
+    const dsSelect = container.querySelector('[data-testid="data-source-bridge-id"]') as HTMLSelectElement
+    dsSelect.value = 'pg-1'
+    dsSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi()
+
+    // dataSourceId picked but object empty → save must stay disabled.
+    expect((container.querySelector('[data-testid="save-connection-draft"]') as HTMLButtonElement).disabled).toBe(true)
+
+    const objInput = container.querySelector('[data-testid="data-source-bridge-object"]') as HTMLInputElement
+    objInput.value = 'public.items'
+    objInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect((container.querySelector('[data-testid="save-connection-draft"]') as HTMLButtonElement).disabled).toBe(false)
   })
 })

--- a/docs/development/data-factory-sql-data-source-bridge-execution-plan-todo-20260601.md
+++ b/docs/development/data-factory-sql-data-source-bridge-execution-plan-todo-20260601.md
@@ -67,12 +67,12 @@ Gated on: C1 + opt-in. The one shared-runtime seam, isolated for focused review.
 - [x] **Lock — NULL `createdBy` fails closed**: a null-`createdBy` pipeline fails closed (facade missing-principal error surfaced via the run failure); **no read is performed** (no fallback identity) and nothing is written.
 - The `maxPages` page-loop bound is the existing pipeline-runner behavior; the adapter returns correct `done`/`nextCursor` (C1). No new paging logic added here.
 
-### ⬜ C2b — Impl-2b: workbench source picker (frontend)
+### 🟢 C2b — Impl-2b: workbench source picker (frontend) — LANDED 2026-06-02
 Gated on: C2a + opt-in. Frontend-only.
-- [ ] Workbench "select source system" surfaces a `data-source:sql-readonly` system; pick the data source → object (table/view) → fields.
-- [ ] Enters the **existing** dry-run / staging / provenance flow (no new pipeline machinery).
-- [ ] **Reachability test (UI)**: author a source via the picker → dry-run → rows appear — read-only, no write.
-- [ ] `/data-sources` stays the sole connection/credential surface; the workbench **references** it (a `dataSourceId` picker, **no credential copy**), does not embed connection CRUD.
+- [x] The connection-manager surfaces a **structured picker** for `data-source:sql-readonly`: when that kind is selected, a data-source `<select>` (lazy-loaded from `/api/data-sources`) + an **object** text input (v1; schema/table dropdown deferred) replace the raw-JSON config. The created source then appears in the source selector and enters the **existing** dry-run/staging/provenance flow (backend read proven by C2a).
+- [x] **No credential copy**: for this kind the saved `config` is built from exactly `{ dataSourceId, object }` (the raw-JSON config field is hidden), so credentials can never be entered here — `/data-sources` stays the sole credential surface; the workbench only **references** `dataSourceId`.
+- [x] **UI test** (`IntegrationWorkbenchView.spec.ts`): select the bridge kind → picker lists the data sources (lazy; not fetched before) → pick one + object → the upsert payload is `config: { dataSourceId, object }`, `role: 'source'`, **no `credentials`**, no secret-shaped values.
+- Deferred (post-v1): schema/table dropdown (object is a text input for now); a full end-to-end dry-run-reads-rows assertion lives at the backend (C2a runner test).
 
 ### 🔒 C3 — Incremental / watermark reads
 Gated on: C1/C2 + a watermark-column convention + opt-in.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -724,9 +724,13 @@ async function testDiscoveryRoutes() {
         calls.push(['listAdapterKinds'])
         return ['http', 'erp:k3-wise-sqlserver', 'bridge:legacy-sql-readonly', 'metasheet:staging', 'metasheet:multitable', 'data-source:sql-readonly', 'custom:unknown']
       },
-      createAdapter(input) {
-        calls.push(['createAdapter', input])
+      createAdapter(input, deps) {
+        calls.push(['createAdapter', input, deps])
         return {
+          async testConnection() {
+            calls.push(['testConnection'])
+            return { ok: true }
+          },
           async listObjects() {
             calls.push(['listObjects'])
             return [
@@ -859,6 +863,10 @@ async function testDiscoveryRoutes() {
   assert.equal(supplierObject.template.endpointPath, '/api/suppliers/save')
   assert.equal(JSON.stringify(res.body).includes('template-secret-should-not-leak'), false)
   assert.equal(JSON.stringify(res.body).includes('secret-token'), false)
+  // C2b: the objects route runs the adapter AS the request user — the owner principal is threaded
+  // into createAdapter (so the data-source:sql-readonly bridge's facade authorizes), and it is the
+  // request user, NOT a system/admin fallback.
+  assert.deepEqual(findCall(calls, 'createAdapter')[2], { principal: 'user_read' }, 'objects route threads the request principal to createAdapter')
 
   calls.length = 0
   res = await invoke(routes, 'GET', '/api/integration/external-systems/:id/schema', {
@@ -871,6 +879,7 @@ async function testDiscoveryRoutes() {
   assert.deepEqual(findCall(calls, 'getSchema')[1], { object: 'customers_raw' })
   assert.equal(JSON.stringify(res.body).includes('schema-secret-should-not-leak'), false)
   assert.equal(res.body.data.raw.credentials, '[redacted]')
+  assert.deepEqual(findCall(calls, 'createAdapter')[2], { principal: 'user_read' }, 'schema route threads the request principal to createAdapter')
 
   calls.length = 0
   res = await invoke(routes, 'GET', '/api/integration/external-systems/:id/schema', {

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -100,6 +100,15 @@ function getUser(req) {
   return req.user || req.authUser || null
 }
 
+// C2b: the owner principal for a per-source-owner-scoped read (the data-source:sql-readonly bridge
+// facade authorizes reads with it). Direct external-system test/objects/schema calls run AS the
+// request user; a missing user yields undefined → the facade fails closed (never a system/admin
+// fallback). Adapters that don't need a principal (staging/k3/http) ignore the extra dep.
+function requestPrincipal(req) {
+  const user = getUser(req)
+  return user ? (user.id || user.email) : undefined
+}
+
 function listUserPermissions(user) {
   const permissions = []
   if (Array.isArray(user && user.permissions)) permissions.push(...user.permissions)
@@ -1023,7 +1032,7 @@ function createHandlers(services) {
         ? externalSystems.getExternalSystemForAdapter.bind(externalSystems)
         : externalSystems.getExternalSystem.bind(externalSystems)
       const system = await loadSystem(scopedInput(req, { id: requestParams(req).id }))
-      const adapter = adapterRegistry.createAdapter(system)
+      const adapter = adapterRegistry.createAdapter(system, { principal: requestPrincipal(req) })
       let result
       try {
         result = normalizeTestConnectionResult(await adapter.testConnection(requestBody(req)))
@@ -1043,7 +1052,7 @@ function createHandlers(services) {
         ? externalSystems.getExternalSystemForAdapter.bind(externalSystems)
         : externalSystems.getExternalSystem.bind(externalSystems)
       const system = await loadSystem(scopedInput(req, { id: requestParams(req).id }))
-      const adapter = adapterRegistry.createAdapter(system)
+      const adapter = adapterRegistry.createAdapter(system, { principal: requestPrincipal(req) })
       const adapterObjects = typeof adapter.listObjects === 'function'
         ? await adapter.listObjects()
         : []
@@ -1073,7 +1082,7 @@ function createHandlers(services) {
           template: template.template,
         }))
       }
-      const adapter = adapterRegistry.createAdapter(system)
+      const adapter = adapterRegistry.createAdapter(system, { principal: requestPrincipal(req) })
       const schema = typeof adapter.getSchema === 'function'
         ? await adapter.getSchema({ object })
         : { object, fields: [] }


### PR DESCRIPTION
## Summary

**C2b** of the `data-source:sql-readonly` convergence (plan #2189) — the last piece to make the bridge **operator-usable**. The integration workbench's connection-manager gains a **structured picker** for this kind. Frontend-only.

When `连接类型 = data-source:sql-readonly`:
- a **data-source `<select>`** (lazy-loaded from `/api/data-sources` only when the kind is picked) + an **object** text input (v1) replace the raw-JSON config;
- the saved `config` is built from **exactly `{ dataSourceId, object }`** (the raw-JSON field is hidden for this kind), so **credentials can never be entered here** — `/data-sources` stays the sole credential surface and the workbench only **references** `dataSourceId`;
- a hint: *凭据由 `/data-sources` 管理,这里只引用*.

The created source then appears in the source selector and enters the **existing** dry-run/staging/provenance flow (the backend read path is already proven by **C2a**).

## Review keystones (locked by `IntegrationWorkbenchView.spec.ts`)
- picker is **hidden until the bridge kind is selected**; the data-source list is **not fetched before** (lazy);
- the picker **lists the data sources**;
- selecting one + object → the upsert payload is `config: { dataSourceId, object }`, `role: 'source'`, **no `credentials`** property, and no secret-shaped values.

## Verification
- `IntegrationWorkbenchView.spec.ts`: **16/16** (15 existing + the new C2b test); no regression.
- `vue-tsc --noEmit` clean; `eslint` 0 errors.
- Frontend-only; **read-only**; **no K3 / RBAC / auth**. Object is a text input for **v1** (schema/table dropdown deferred). Plan #2189: **C2b done**.

Leaving for review — not auto-merging.