### PR TITLE
feat(attendance): punch-policy group S0 — latent punchPolicy settings foundation

### DIFF
--- a/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
@@ -131,6 +131,29 @@ describe('attendance scheduling assignment conflict guard', () => {
     expect(merged.shiftEditPolicy).toEqual({ mode: 'past_locked', windowDays: 14 })
   })
 
+  it('normalizes and nested-deep-merges punch-policy settings (latent S0 foundation)', () => {
+    expect(helpers.normalizePunchPolicySetting(undefined)).toEqual({
+      unscheduled: { mode: 'allow' },
+      merge: { internalWinsOnIn: false, externalWinsOnOut: false },
+      outdoor: { requireApproval: false, requireNote: false, requirePhoto: false, approvalFlowId: '' },
+    })
+    // invalid unscheduled mode -> default allow (no regression); partial fields filled from defaults
+    expect(helpers.normalizePunchPolicySetting({ unscheduled: { mode: 'surprise' } }).unscheduled.mode).toBe('allow')
+    expect(helpers.normalizePunchPolicySetting({ unscheduled: { mode: 'block' } }).unscheduled.mode).toBe('block')
+    expect(helpers.normalizePunchPolicySetting({ outdoor: { requireApproval: true } }).outdoor.requireApproval).toBe(true)
+
+    // nested 2-level merge: updating only `merge` must NOT clear unscheduled / outdoor
+    const merged = helpers.mergeSettings(
+      { punchPolicy: { unscheduled: { mode: 'block' }, outdoor: { requireApproval: true } } },
+      { punchPolicy: { merge: { internalWinsOnIn: true } } },
+    )
+    expect(merged.punchPolicy).toEqual({
+      unscheduled: { mode: 'block' },
+      merge: { internalWinsOnIn: true, externalWinsOnOut: false },
+      outdoor: { requireApproval: true, requireNote: false, requirePhoto: false, approvalFlowId: '' },
+    })
+  })
+
   it('takes a per-org/user advisory lock before transactional writes', async () => {
     const db = { query: vi.fn().mockResolvedValue([]) }
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -99,6 +99,14 @@ const DEFAULT_SETTINGS = {
     mode: 'unrestricted',
     windowDays: 0,
   },
+  // 打卡策略组 (punch-policy group) — LATENT foundation (design-lock #2203 / S0). NOTHING reads this
+  // yet; each enforcement slice wires + exposes its own field (S1 unscheduled-punch / S2 in-out merge /
+  // S3 outdoor approval). All defaults = current behaviour (no regression).
+  punchPolicy: {
+    unscheduled: { mode: 'allow' },
+    merge: { internalWinsOnIn: false, externalWinsOnOut: false },
+    outdoor: { requireApproval: false, requireNote: false, requirePhoto: false, approvalFlowId: '' },
+  },
   formula: {
     allowRawAliases: true,
   },
@@ -10805,6 +10813,7 @@ function normalizeSettings(raw) {
     geoFence,
     minPunchIntervalMinutes: Math.max(0, parseNumber(raw.minPunchIntervalMinutes, DEFAULT_SETTINGS.minPunchIntervalMinutes)),
     shiftEditPolicy: normalizeShiftEditPolicySetting(raw.shiftEditPolicy),
+    punchPolicy: normalizePunchPolicySetting(raw.punchPolicy),
     formula: {
       allowRawAliases: parseBoolean(formula.allowRawAliases, DEFAULT_SETTINGS.formula.allowRawAliases),
     },
@@ -10843,6 +10852,35 @@ function normalizeShiftEditPolicySetting(raw) {
   }
 }
 
+// Punch-policy group (design-lock #2203 / S0). Pure normalize of the latent foundation: validates
+// the nested shape (unscheduled / merge / outdoor) and fills every field from DEFAULT_SETTINGS so an
+// unset / partial / malformed value can never change behaviour. require_approval & outdoor.* are part
+// of the shape but stay at their defaults until the S3 slice exposes them.
+function normalizePunchPolicySetting(raw) {
+  const policy = raw && typeof raw === 'object' ? raw : {}
+  const unscheduled = policy.unscheduled && typeof policy.unscheduled === 'object' ? policy.unscheduled : {}
+  const merge = policy.merge && typeof policy.merge === 'object' ? policy.merge : {}
+  const outdoor = policy.outdoor && typeof policy.outdoor === 'object' ? policy.outdoor : {}
+  const unscheduledModeRaw = typeof unscheduled.mode === 'string' ? unscheduled.mode.trim() : ''
+  const unscheduledMode = ['allow', 'block', 'require_approval'].includes(unscheduledModeRaw)
+    ? unscheduledModeRaw
+    : DEFAULT_SETTINGS.punchPolicy.unscheduled.mode
+  const bool = (value, fallback) => (typeof value === 'boolean' ? value : fallback)
+  return {
+    unscheduled: { mode: unscheduledMode },
+    merge: {
+      internalWinsOnIn: bool(merge.internalWinsOnIn, DEFAULT_SETTINGS.punchPolicy.merge.internalWinsOnIn),
+      externalWinsOnOut: bool(merge.externalWinsOnOut, DEFAULT_SETTINGS.punchPolicy.merge.externalWinsOnOut),
+    },
+    outdoor: {
+      requireApproval: bool(outdoor.requireApproval, DEFAULT_SETTINGS.punchPolicy.outdoor.requireApproval),
+      requireNote: bool(outdoor.requireNote, DEFAULT_SETTINGS.punchPolicy.outdoor.requireNote),
+      requirePhoto: bool(outdoor.requirePhoto, DEFAULT_SETTINGS.punchPolicy.outdoor.requirePhoto),
+      approvalFlowId: typeof outdoor.approvalFlowId === 'string' ? outdoor.approvalFlowId.trim() : DEFAULT_SETTINGS.punchPolicy.outdoor.approvalFlowId,
+    },
+  }
+}
+
 function mergeSettings(base, update) {
   return normalizeSettings({
     ...base,
@@ -10870,6 +10908,13 @@ function mergeSettings(base, update) {
     shiftEditPolicy: {
       ...(base?.shiftEditPolicy || {}),
       ...(update?.shiftEditPolicy || {}),
+    },
+    // Nested 2-level merge so a partial update (e.g. only { unscheduled }) does not clear the
+    // other punch-policy sub-objects (merge / outdoor).
+    punchPolicy: {
+      unscheduled: { ...(base?.punchPolicy?.unscheduled || {}), ...(update?.punchPolicy?.unscheduled || {}) },
+      merge: { ...(base?.punchPolicy?.merge || {}), ...(update?.punchPolicy?.merge || {}) },
+      outdoor: { ...(base?.punchPolicy?.outdoor || {}), ...(update?.punchPolicy?.outdoor || {}) },
     },
     comprehensiveHours: {
       ...(base?.comprehensiveHours || {}),
@@ -15169,6 +15214,7 @@ module.exports = {
     resolveAttendanceComprehensiveHoursPeriod,
     normalizeAttendanceComprehensiveHoursSettings,
     normalizeShiftEditPolicySetting,
+    normalizePunchPolicySetting,
     evaluateShiftEditWindow,
     bridgeAttendanceDateRangeToComprehensiveHoursPeriod,
     resolveAttendanceComprehensiveHoursCap,


### PR DESCRIPTION
First slice of the punch-policy group (**design-lock #2203**). **LATENT** — establishes the shared config shape only; **nothing reads it yet, behaviour unchanged**. Each enforcement slice wires + exposes its own field later (S1 unscheduled-punch / S2 in-out merge / S3 outdoor approval).

- `DEFAULT_SETTINGS.punchPolicy` = `{ unscheduled.mode:'allow', merge{false,false}, outdoor{all false} }` — every default = current behaviour (no regression).
- `normalizePunchPolicySetting()`: validates the nested shape + fills every field from defaults (unset/partial/malformed can't change behaviour; invalid mode → `allow`).
- `mergeSettings`: **nested 2-level merge** so a partial update (e.g. only `{ merge }`) doesn't clear the other sub-objects.
- exported for tests; **NOT added to the settings PUT schema** — per design-lock §0/§5 a field is exposed only by the slice that enforces it (no half-baked config).

`node --check` ✓ · unit test green (defaults / invalid→default / partial + nested deep-merge preserves siblings) · 20/20 in the file.

Next: **S1** (`isUserScheduledForDate` with the fixed/free applicability guard + unscheduled-punch allow/block at the punch route + PUT exposure of `unscheduled.mode`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)