### PR TITLE
docs(multitable): close field-read-gate scan item — kanban/gallery/calendar scan-clean

### DIFF
--- a/docs/development/multitable-field-read-gate-tracker-20260602.md
+++ b/docs/development/multitable-field-read-gate-tracker-20260602.md
@@ -47,11 +47,11 @@ The **locking test** is the real-DB integration test wired into `.github/workflo
 | ✅🔒 | **F5** `loadRecordSummaries` display: `link-options` `data.records` + `people-search` `items` (foreign/people default-display value) | Low | #2198 | `multitable-summary-display-field-mask` |
 | ✅🔒 | **linkSummaries** (`buildLinkSummaries`) foreign default-display value across `GET /view` · single-record read · link-options `data.selected` · write-echo (review follow-up to F5) | Med | #2198 | `multitable-link-summary-display-field-mask` |
 | ⬜ | **D1** `form-context` + form-submit layer-3 (anonymous-form design question — likely intentional) | Design-Q | — | *(decide first)* |
-| ⬜ | **kanban / gallery / calendar** view-data egress scan (deferred coverage scan) | Diligence | — | *(scan → maybe add)* |
+| ✅ | **kanban / gallery / calendar** view-data egress scan — **scan-clean, no live egress** (standalone view plugins are dead-sample/unreachable; product reuses the gated `/view`) | Diligence | #2206 | *scan-clean — no test (no live egress); see scan doc + §3 latent-risk note* |
 
 ### Completion
-- **By item: 10 / 12 findings closed (≈ 83 %)** — through F5 + its `buildLinkSummaries` review follow-up.
-- **By risk: every High + Med + Low leak channel is closed.** Remaining = 1 **design question** (D1, anonymous forms have no subject to scope to) + 1 **coverage scan** (kanban/gallery/calendar). Residual attack surface ≈ retired.
+- **By item: 11 / 12 findings closed (≈ 92 %)** — 10 **CI-locked masks** (each with a real-DB locking test) + 1 **scan-clean** (kanban/gallery/calendar view-data: scanned, **no live egress found → no locking test**, see scan doc). The scan-clean item is a *coverage conclusion*, not a CI-enforced mask — its continued validity rests on §3 Layer-3 (the latent-risk re-scan trigger), not a test.
+- **By risk: every High + Med + Low leak channel is closed.** Remaining = 1 **design question** (D1, anonymous forms have no subject to scope to). Residual attack surface ≈ retired.
 
 ---
 
@@ -75,7 +75,8 @@ Layers 1–2 protect *known* channels. A *new* record-data egress endpoint could
 - **Trigger:** whenever a new endpoint returns record cell values (new read, echo, summary, export, broadcast), **re-run the #2106 egress inventory method** (grep every `res.json`/`filterRecordDataByFieldIds`/`loadRecordSummaries`/`buildLinkSummaries`/`linkSummaries`/raw `data[fieldId]` egress; classify gated vs ungated).
   - **Lesson (the `buildLinkSummaries` follow-up):** a cell value can leak even when it is *not* a direct `data[fieldId]` egress — `buildLinkSummaries` reads a *foreign* sheet's display field into a computed `display`, and the `filter*FieldSummaryMap` wrappers only drop unreadable *link fields* (caller-side), never the foreign display *value*. So the grep set must include **derived/summary display values keyed to another sheet**, masked by *that* sheet's `allowedFieldIds` (per-sheet keying), not just first-class `data[fieldId]` writes.
 - **Forward-defense (proposed, not yet built):** an "egress coverage guard" — a test that enumerates the record-data egress sites and asserts each one routes through `allowedFieldIds`, so a new *ungated* egress fails CI by construction. Tracked as a future hardening item (see §4).
-- **Pending re-scan:** the kanban/gallery/calendar view-data scan (matrix §2b, last row).
+- **Done re-scan:** the kanban/gallery/calendar view-data scan — **scan-clean** (2026-06-02, `multitable-view-data-egress-scan-20260602.md`): no live egress; the standalone view plugins are dead-sample (sample-kanban's `records` table doesn't exist; gallery/calendar forward to an **unhandled** `spreadsheet:records:query` event) and unreachable (gallery/calendar have no manifest), and the product renders these view-types client-side off the gated `/view`.
+  - **Lesson (sample-plugin latent egress):** "scan-clean" on a *dead* path is NOT "no egress code exists." The gallery/calendar samples ship fully-formed `/records` + `/records/:recordId` egress routes with **no authz and no field mask** — inert only because nothing wires them. **Adding a manifest, wiring a `spreadsheet:records:query` handler, or creating the bare `records` table re-arms them → any such change MUST re-enter this egress inventory and route record data through the target sheet's `allowedFieldIds` before shipping.** (Same shape as F0b latent-not-live.)
 
 ### Confirmation checklist
 - **Per PR (automatic):** CI `test (20.x)` real-DB step green ⇒ all locking tests pass ⇒ no regression. Reviewer confirms any new egress has a locking test.
@@ -86,7 +87,7 @@ Layers 1–2 protect *known* channels. A *new* record-data egress endpoint could
 ## 4. Remaining work (each a separate, explicit opt-in)
 
 1. **D1** — decide whether `form-context`/form-submit should apply layer-3 for *identified* (non-anonymous) form callers. Product decision first; likely no code (anonymous submitter has no subject to scope to).
-2. **kanban / gallery / calendar scan** (kanban first, then gallery/calendar) — Layer-3 re-scan of these view-data egress paths; add a locking test only if a real ungated egress is found.
+2. *(optional hardening)* — **delete the dead sample view plugins** (`plugins/plugin-view-kanban` / `plugin-view-gallery` / `plugin-view-calendar`) to remove the latent ungated `/records` egress routes outright. Deferred from the scan-closure (separate code/product cleanup; touches the plugin-sample retention policy) — its own opt-in.
 3. *(optional hardening)* — build the §3 "egress coverage guard".
 
 ---

--- a/docs/development/multitable-view-data-egress-scan-20260602.md
+++ b/docs/development/multitable-view-data-egress-scan-20260602.md
@@ -1,0 +1,30 @@
+# kanban / gallery / calendar view-data egress scan — verdict: CLEAN (no live egress)
+
+**Closes:** the deferred coverage scan in the multitable field-read-gate arc (tracker `multitable-field-read-gate-tracker-20260602.md` §2b last row; #2106 inventory §1/§8 "deferred, NOT claimed clean here"). **Date:** 2026-06-02. **Method:** the #2106 egress-inventory method applied to the view-data plugins + their routes, anchored to fresh `origin/main` (`9f558d522`), Read-verified (Bash/grep output was character-mangled in this environment — every hit confirmed by Reading the file).
+
+## Question
+Do the kanban / gallery / calendar view-data paths (plugins + routes) egress `meta_records` cell values **without** the layer-2 ∧ layer-3 field mask that the grid/read/echo/summary surfaces now enforce?
+
+## Per-surface findings
+
+| Surface | Loaded in prod? | Record-data source | authz | field-mask | Verdict |
+|---|---|---|---|---|---|
+| `src/routes/kanban.ts` `GET /:viewId` (the real `kanban.ts:114`, hardcoded-mounted) | **yes** | `views` + `view_states` (view config + per-user view state) — **not** `meta_records` | view-existence | n/a (no cell values) | **SAFE** — `payload` is config/state, not record data; the #2106 worry was a false alarm |
+| boards-kanban plugin `packages/core-backend/plugins/plugin-view-kanban` (has `plugin.json`) | loadable | `FROM views` + kanban board config — no `meta_records`, no `.data` | — | n/a | **SAFE** (config only) |
+| root sample-kanban `plugins/plugin-view-kanban` (has `plugin.json`) | maybe | `SELECT * FROM records` — **a bare `records` table that does not exist in any migration** (only `meta_records` does) | none | none | **DEAD** — query errors → 500, no egress |
+| gallery plugin `plugins/plugin-view-gallery` | **no — no manifest** (`plugin.json`/`manifest.json` absent → loader throws "manifest not found") | all record data via `api.events.request('spreadsheet:records:query', …)`; direct `pool.query` only on `gallery_configs` | none | none | **DEAD + unreachable** |
+| calendar plugin `plugins/plugin-view-calendar` | **no — no manifest** | all record data via `api.events.request('spreadsheet:…', …)`; direct `pool.query` only on `calendar_configs` | none | none | **DEAD + unreachable** |
+| product kanban/gallery/calendar **view-types** (the actual UI) | yes | client-side re-layout of `GET /api/multitable/view` | gated | **masked** (#2015/#2028) | **SAFE** — no separate server egress |
+| automation `test` / `logs` routes | yes | `redactAutomationExecutionForResponse` | `requireAdminRole` | redacted | **SAFE** |
+
+Two facts make the dead/unreachable verdicts hard:
+1. **`spreadsheet:records:query` has zero registered handlers** — it appears in the codebase only as `.request(...)` callers (gallery `:402`, calendar `:444`/`:779`). With no responder, `recordsResult` is never `success` → the routes throw → 500. Every gallery/calendar record-data route (list **and** detail) is event-mediated this way; none does a direct `meta_records` read.
+2. **No bare `records` table** exists in `packages/core-backend/src/db/migrations/*` or `packages/core-backend/migrations/*` — only `meta_records`. The sample kanban's `SELECT * FROM records` cannot run.
+
+## Verdict
+**No live, reachable, unmasked egress of `meta_records` cell values through kanban / gallery / calendar / automation.** The standalone view plugins are non-functional samples (missing table / missing event handler / no manifest); the real product renders these view-types client-side from the already-gated `GET /api/multitable/view`. **No new finding; no locking test added.**
+
+## Latent risk (record, do not ignore — the F0b latent-not-live pattern)
+The gallery and calendar sample plugins ship **fully-formed `GET /…/records` and `/records/:recordId` egress routes with no authz and no field mask.** They are inert **only** because (a) they have no manifest to load and (b) `spreadsheet:records:query` has no handler. If a future change adds a manifest **or** wires a `spreadsheet:records:query` handler that returns raw `meta_records.data`, these routes bypass the entire field-read gate — exactly F0b's "wire the provider and it leaks."
+
+**Forward defense:** any future `spreadsheet:records:query` handler (or revival of these plugins) MUST route record data through the target sheet's `allowedFieldIds` (layer-2 ∧ layer-3) and re-enter this egress inventory before shipping. Deleting the dead sample plugins outright would remove the latent guns entirely — tracked as **optional hardening** (tracker §4), deliberately kept out of this scan-closure to avoid entangling it with the plugin-sample retention policy.


### PR DESCRIPTION
Docs-only. Closes the **kanban / gallery / calendar view-data egress scan** — the last deferred coverage item of the multitable field-read-gate arc (#2106 inventory §1/§8; tracker `multitable-field-read-gate-tracker-20260602.md` §2b).

## Verdict: scan-clean — no live egress
No live, reachable, unmasked egress of `meta_records` cell values through kanban/gallery/calendar/automation:

| Surface | Loaded? | Source | Verdict |
|---|---|---|---|
| `src/routes/kanban.ts` (mounted) | yes | `views`+`view_states` (config) | SAFE — not record data |
| boards-kanban plugin | loadable | `views`+kanban config | SAFE |
| sample-kanban plugin | maybe | `SELECT * FROM records` (table doesn't exist) | DEAD |
| gallery / calendar plugins | **no — no manifest** | unhandled `spreadsheet:records:query` event; direct queries only on `*_configs` | DEAD + unreachable |
| product view-types | yes | client-side off gated `GET /view` | SAFE (masked, #2015/#2028) |
| automation test/logs | yes | `requireAdminRole` + redacted | SAFE |

Two hard facts: `spreadsheet:records:query` has **zero registered handlers** (only `.request` callers), and **no bare `records` table** exists in migrations.

## Tracker changes (docs-only)
- Scan row → **✅ scan-clean** (deliberately **no 🔒 / no locking test** — there's no live egress to lock; this is a coverage *conclusion*, not a CI-enforced mask).
- Completion **10/12 → 11/12** (10 CI-locked masks + 1 scan-clean), with the caveat that the scan-clean item's validity rests on §3 Layer-3 (re-scan trigger), not a test.
- **§3 latent-risk lesson:** the gallery/calendar samples ship fully-formed `/records` egress routes with **no authz/mask** — inert only because nothing wires them. Adding a manifest / wiring the event / creating the `records` table **re-arms them** → MUST re-enter the egress inventory and route through `allowedFieldIds` (F0b latent-not-live shape).
- **§4 remaining = D1 only.** Deleting the dead sample plugins is recorded as a **separate optional-hardening opt-in** (not bundled here — it's a code/product cleanup touching the plugin-sample retention policy).

New evidence doc: `multitable-view-data-egress-scan-20260602.md`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)