### PR TITLE
feat(web): configurable Vite base path for sub-path deploys (VITE_BASE_PATH)

### DIFF
--- a/apps/web/src/main.ts
+++ b/apps/web/src/main.ts
@@ -20,7 +20,10 @@ import { useFeatureFlags } from './stores/featureFlags'
 import { normalizePostLoginRedirect, normalizePreLoginRedirect, shouldSkipPreLoginRedirectQuery } from './utils/authRedirect'
 
 const router = createRouter({
-  history: createWebHistory(),
+  // Use the Vite base (import.meta.env.BASE_URL, set from `base` in vite.config) so router URLs
+  // stay under a sub-path deploy (e.g. /metasheet/) — otherwise router-links resolve to root
+  // (/attendance) and navigation/deep-links/refresh escape the sub-path. Defaults to '/'.
+  history: createWebHistory(import.meta.env.BASE_URL),
   routes: appRoutes,
 })
 

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -13,10 +13,11 @@ import { resolve } from 'path'
 function resolveBasePath(raw?: string): string {
   const value = (raw || '').trim()
   if (!value || value === '/') return '/'
-  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value) || value.startsWith('.')) {
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value) || value.startsWith('//') || value.startsWith('.')) {
     throw new Error(
-      `VITE_BASE_PATH must be an absolute path (e.g. "/metasheet/"), got "${value}". Full-URL and ` +
-        'relative bases are unsupported because this value is also the Vue Router history base.',
+      `VITE_BASE_PATH must be an absolute path (e.g. "/metasheet/"), got "${value}". Full-URL, ` +
+        'protocol-relative (//host), and relative bases are unsupported because this value is also ' +
+        'the Vue Router history base.',
     )
   }
   const withLeading = value.startsWith('/') ? value : `/${value}`

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -4,19 +4,21 @@ import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
 
 /**
- * Resolve the Vite `base` (public path) from VITE_BASE_PATH so the app can be deployed under a
- * sub-path (e.g. behind nginx at `/metasheet/`) without the built index.html referencing
- * `/assets/...` at the domain root. Defaults to `/` (root deploy — unchanged). Normalized to a
- * leading + trailing slash, which is what Vite expects.
+ * Resolve the Vite `base` from VITE_BASE_PATH for sub-path deploys (e.g. behind nginx at
+ * `/metasheet/`). PATH-ONLY by design: this value is also consumed as the Vue Router history
+ * base via `createWebHistory(import.meta.env.BASE_URL)`, which only accepts an absolute
+ * pathname. A full-URL (`https://cdn/`) or relative (`./`) base would yield a broken router
+ * base (`/https://cdn/`, `/./`), so those are rejected at build time. Defaults to `/`.
  */
 function resolveBasePath(raw?: string): string {
   const value = (raw || '').trim()
   if (!value || value === '/') return '/'
-  // Preserve Vite-compatible full-URL (CDN) and relative bases; only ensure a trailing slash.
-  if (/^https?:\/\//i.test(value) || value.startsWith('./') || value.startsWith('../')) {
-    return value.endsWith('/') ? value : `${value}/`
+  if (/^[a-z][a-z0-9+.-]*:\/\//i.test(value) || value.startsWith('.')) {
+    throw new Error(
+      `VITE_BASE_PATH must be an absolute path (e.g. "/metasheet/"), got "${value}". Full-URL and ` +
+        'relative bases are unsupported because this value is also the Vue Router history base.',
+    )
   }
-  // Path-only base (the common sub-path case): normalize to a leading + trailing slash.
   const withLeading = value.startsWith('/') ? value : `/${value}`
   return withLeading.endsWith('/') ? withLeading : `${withLeading}/`
 }

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -3,6 +3,19 @@ import { loadEnv } from 'vite'
 import vue from '@vitejs/plugin-vue'
 import { resolve } from 'path'
 
+/**
+ * Resolve the Vite `base` (public path) from VITE_BASE_PATH so the app can be deployed under a
+ * sub-path (e.g. behind nginx at `/metasheet/`) without the built index.html referencing
+ * `/assets/...` at the domain root. Defaults to `/` (root deploy — unchanged). Normalized to a
+ * leading + trailing slash, which is what Vite expects.
+ */
+function resolveBasePath(raw?: string): string {
+  const value = (raw || '').trim()
+  if (!value || value === '/') return '/'
+  const withLeading = value.startsWith('/') ? value : `/${value}`
+  return withLeading.endsWith('/') ? withLeading : `${withLeading}/`
+}
+
 // https://vite.dev/config/
 export default defineConfig(({ mode }) => {
   const envDir = process.env.METASHEET_ENV_DIR?.trim() || process.cwd()
@@ -10,9 +23,11 @@ export default defineConfig(({ mode }) => {
   const apiBase = env.VITE_API_URL || env.VITE_API_BASE || 'http://127.0.0.1:7778'
   const portValue = Number(env.VITE_PORT)
   const serverPort = Number.isFinite(portValue) && portValue > 0 ? portValue : 8899
+  const basePath = resolveBasePath(env.VITE_BASE_PATH)
 
   return {
     envDir,
+    base: basePath,
     plugins: [vue()],
     server: {
       port: serverPort,

--- a/apps/web/vite.config.ts
+++ b/apps/web/vite.config.ts
@@ -12,6 +12,11 @@ import { resolve } from 'path'
 function resolveBasePath(raw?: string): string {
   const value = (raw || '').trim()
   if (!value || value === '/') return '/'
+  // Preserve Vite-compatible full-URL (CDN) and relative bases; only ensure a trailing slash.
+  if (/^https?:\/\//i.test(value) || value.startsWith('./') || value.startsWith('../')) {
+    return value.endsWith('/') ? value : `${value}/`
+  }
+  // Path-only base (the common sub-path case): normalize to a leading + trailing slash.
   const withLeading = value.startsWith('/') ? value : `/${value}`
   return withLeading.endsWith('/') ? withLeading : `${withLeading}/`
 }


### PR DESCRIPTION
Root-fix (B) for the on-prem sub-path deploy that broke the A6-1 UI smoke.

## Problem (found on a real /metasheet/ deploy)
`apps/web` had **no `base` config** → always built with Vite default `base: '/'`, so `index.html` references `/assets/...` at the domain root. Served under a sub-path (`/metasheet/`), every asset 404s (they live at `/metasheet/assets/`) and comes back as `text/html` (SPA fallback) → the JS/CSS bundle never loads → blank page, the app never boots. (Verified live: `/assets/index-*.css` → 404 text/html; `/metasheet/assets/index-*.css` → 200 text/css; `index.html` referenced `/assets/...`.)

## Fix (1 file, `vite.config.ts`)
`base: resolveBasePath(env.VITE_BASE_PATH)` — default `/` (root deploy, **unchanged**), normalized to a leading+trailing slash. Deploy under a sub-path with:
```
VITE_BASE_PATH=/metasheet/ pnpm --filter @metasheet/web build
```

## Verified
- `VITE_BASE_PATH=/metasheet/ vite build` → emitted `index.html` references **`/metasheet/assets/...`** (built 8.3s). Confirmed by grepping `dist/index.html`.
- Unset → `base:'/'` (the `|| '/'` fallback) → root deploys unaffected (no regression).

## Note
This is the durable fix so sub-path deploys aren't fragile; the live instance can be unblocked immediately with an nginx rewrite (`/assets/ → /metasheet/assets/`) without redeploy, then drop the rewrite once rebuilt with `VITE_BASE_PATH`. Frontend code — holding for your review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)