### PR TITLE
ci(onprem): add base_path input to on-prem package build (VITE_BASE_PATH)

### DIFF
--- a/.github/workflows/multitable-onprem-package-build.yml
+++ b/.github/workflows/multitable-onprem-package-build.yml
@@ -7,6 +7,10 @@ on:
         description: 'Optional package tag suffix (default: run number)'
         required: false
         default: ''
+      base_path:
+        description: 'Web base path → Vite VITE_BASE_PATH (e.g. /metasheet/ for a sub-path deploy). Path-only; default / (root).'
+        required: false
+        default: '/'
       publish_release:
         description: 'Publish build outputs to GitHub Releases'
         required: false
@@ -46,6 +50,10 @@ jobs:
         run: pnpm install --frozen-lockfile
 
       - name: Build web/backend dist
+        env:
+          # Threads the dispatch input into the web build so sub-path deploys (e.g. /metasheet/)
+          # emit correct asset + Vue Router bases. Default '/' = root (unchanged). See #2207.
+          VITE_BASE_PATH: ${{ inputs.base_path }}
         run: |
           pnpm --filter @metasheet/web build
           pnpm --filter @metasheet/core-backend build


### PR DESCRIPTION
Lets the on-prem package workflow cut a correct **sub-path** build, completing #2207 on the CI side.

## Why
`multitable-onprem-package-build.yml` built `apps/web` with no `VITE_BASE_PATH` → default `base:'/'`. Deployed under `/metasheet/`, that 404s assets + the Vue Router escapes the sub-path (the live on-prem bug). #2207 made `base` configurable; the workflow just needs to pass it.

## Change (1 file, +8)
- New `base_path` `workflow_dispatch` input — default `'/'` (root, **unchanged**).
- Threaded as `VITE_BASE_PATH: ${{ inputs.base_path }}` env on the web build step.

Dispatch with `base_path=/metasheet/` → CI builds the on-prem package with correct asset + router bases. YAML validated. Additive + default-preserving (no behavior change for existing dispatches).

🤖 Generated with [Claude Code](https://claude.com/claude-code)