### PR TITLE
fix(multitable): D1 — layer-3 echo mask on form-context + form-submit (field-read-gate arc 12/12)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -180,6 +180,7 @@ jobs:
             tests/integration/multitable-records-summary-field-mask.test.ts \
             tests/integration/multitable-summary-display-field-mask.test.ts \
             tests/integration/multitable-link-summary-display-field-mask.test.ts \
+            tests/integration/multitable-form-context-submit-field-mask.test.ts \
             tests/integration/multitable-dashboard-chart-authz.test.ts \
             tests/integration/multitable-write-echo-field-mask.test.ts \
             tests/integration/multitable-create-echo-field-mask.test.ts \

--- a/docs/development/multitable-field-read-gate-tracker-20260602.md
+++ b/docs/development/multitable-field-read-gate-tracker-20260602.md
@@ -46,12 +46,13 @@ The **locking test** is the real-DB integration test wired into `.github/workflo
 | ✅🔒 | **F4** `POST /records` create-echo mask | Low-Med | #2186 | `multitable-create-echo-field-mask` |
 | ✅🔒 | **F5** `loadRecordSummaries` display: `link-options` `data.records` + `people-search` `items` (foreign/people default-display value) | Low | #2198 | `multitable-summary-display-field-mask` |
 | ✅🔒 | **linkSummaries** (`buildLinkSummaries`) foreign default-display value across `GET /view` · single-record read · link-options `data.selected` · write-echo (review follow-up to F5) | Med | #2198 | `multitable-link-summary-display-field-mask` |
-| ⬜ | **D1** `form-context` + form-submit layer-3 (anonymous-form design question — likely intentional) | Design-Q | — | *(decide first)* |
+| ✅🔒 | **D1** `form-context` (recordId load) + `POST /views/:id/submit` echo layer-3 mask — **identified-path leak (NOT no-op)**; anonymous moot (no subject) | Med | #2210 | `multitable-form-context-submit-field-mask` |
 | ✅ | **kanban / gallery / calendar** view-data egress scan — **scan-clean, no live egress** (standalone view plugins are dead-sample/unreachable; product reuses the gated `/view`) | Diligence | #2206 | *scan-clean — no test (no live egress); see scan doc + §3 latent-risk note* |
 
 ### Completion
-- **By item: 11 / 12 findings closed (≈ 92 %)** — 10 **CI-locked masks** (each with a real-DB locking test) + 1 **scan-clean** (kanban/gallery/calendar view-data: scanned, **no live egress found → no locking test**, see scan doc). The scan-clean item is a *coverage conclusion*, not a CI-enforced mask — its continued validity rests on §3 Layer-3 (the latent-risk re-scan trigger), not a test.
-- **By risk: every High + Med + Low leak channel is closed.** Remaining = 1 **design question** (D1, anonymous forms have no subject to scope to). Residual attack surface ≈ retired.
+- **By item: 12 / 12 findings closed (100 %) — ARC COMPLETE.** 11 **CI-locked masks** (each with a real-DB locking test) + 1 **scan-clean** (kanban/gallery/calendar view-data: scanned, **no live egress found → no locking test**, see scan doc). The scan-clean item is a *coverage conclusion*, not a CI-enforced mask — its continued validity rests on §3 Layer-3 (the latent-risk re-scan trigger), not a test.
+- **By risk: every High + Med + Low leak channel is closed.** D1 turned out to be a **real identified-path layer-3 leak** (not the presumed no-op) — fixed + locked. Anonymous form callers remain correctly out of layer-3 (no subject to scope to). Residual attack surface ≈ retired.
+- **Open follow-ups are optional hardening only** (§4): delete the dead sample view plugins; build the §3 egress-coverage guard. Neither is an open leak.
 
 ---
 
@@ -84,11 +85,14 @@ Layers 1–2 protect *known* channels. A *new* record-data egress endpoint could
 
 ---
 
-## 4. Remaining work (each a separate, explicit opt-in)
+## 4. Remaining work (optional hardening only — the arc's leak findings are all closed)
 
-1. **D1** — decide whether `form-context`/form-submit should apply layer-3 for *identified* (non-anonymous) form callers. Product decision first; likely no code (anonymous submitter has no subject to scope to).
-2. *(optional hardening)* — **delete the dead sample view plugins** (`plugins/plugin-view-kanban` / `plugin-view-gallery` / `plugin-view-calendar`) to remove the latent ungated `/records` egress routes outright. Deferred from the scan-closure (separate code/product cleanup; touches the plugin-sample retention policy) — its own opt-in.
-3. *(optional hardening)* — build the §3 "egress coverage guard".
+The 12 findings are closed (§2). What remains is **non-leak hardening**, each a separate explicit opt-in:
+
+1. *(optional hardening)* — **delete the dead sample view plugins** (`plugins/plugin-view-kanban` / `plugin-view-gallery` / `plugin-view-calendar`) to remove the latent ungated `/records` egress routes outright. Deferred from the scan-closure (separate code/product cleanup; touches the plugin-sample retention policy) — its own opt-in.
+2. *(optional hardening)* — build the §3 "egress coverage guard".
+
+> **D1 closed** (#2210): the presumed no-op turned out to be a **real identified-path layer-3 leak** on `form-context` (recordId load) + `POST /views/:id/submit` echo — masked by layer-1∧2 only, leaking a denied field's value to an authenticated caller (anonymous moot). Fixed with the #2015 composite + locking test `multitable-form-context-submit-field-mask`. Design: `multitable-form-context-submit-field-mask-design-20260602.md`.
 
 ---
 

--- a/docs/development/multitable-form-context-submit-field-mask-design-20260602.md
+++ b/docs/development/multitable-form-context-submit-field-mask-design-20260602.md
@@ -1,0 +1,42 @@
+# D1 — form-context / form-submit layer-3 echo gate: decision & design
+
+**Slice:** D1, the last open item of the multitable field-read-gate arc (tracker `multitable-field-read-gate-tracker-20260602.md` §2b; #2106 inventory finding D1, framed there as "anonymous-form design question — likely intentional"). **Date:** 2026-06-02.
+
+## The question (as posed)
+Should `GET /form-context` and `POST /views/:viewId/submit` apply the subject-scoped layer-3 (`field_permissions.visible`) read gate to the **record data they echo**, the way `/view` + `/records/:id` do (#2028)? The #2106 inventory tagged this "layer-1+2, anonymous-form, likely no-op." On close reading, **the no-op assumption is wrong for the identified path** — there is a real layer-3 leak. This doc records why, and the fix.
+
+## Caller model: both routes are MIXED (public-token OR authenticated)
+Both `form-context` (@6693) and `submit` (@6848) accept an optional `publicToken` and branch on `isPublicFormAccessAllowed`:
+- **Anonymous (valid public token):** `effectiveAccess = { userId: '', … }`, `effectiveCapabilities = PUBLIC_FORM_CAPABILITIES`. Crucially, public callers **cannot load or update an existing record** — `recordId` → 400 (form-context @6735, submit @6902). So anonymous only ever *creates*.
+- **Authenticated (JWT, no token):** real `access.userId` + real per-sheet capabilities; must hold `canRead`/`canCreateRecord`/`canEditRecord`. Can load (form-context `recordId`) and update (submit `recordId`).
+
+## Answer 1 — why anonymous has no subject (layer-3 is moot, correctly)
+`field_permissions` rows are keyed to a **subject** (`subject_type` ∈ user/role/member-group + `subject_id`). An anonymous caller has **no `userId`** → `loadFieldPermissionScopeMap` is never called (or returns nothing) → the scope map is empty → `deriveFieldPermissions(...).visible` carries **no layer-3 denial**. There is no subject to deny against. So applying layer-3 to an anonymous caller is a **strict no-op by construction** — not a policy choice we can "turn on." The #2106 "likely intentional" read was right *for anonymous*. (Anonymous create still can't leak a *cross-subject* denial, because the deny targets a specific user, not "the public.")
+
+## Answer 2 — identified callers SHOULD apply layer-3, and today they DON'T (the leak)
+Both routes mask the echoed `record.data` by `visible*FieldIds` = **layer-1 (view.hidden) ∧ layer-2 (`property.hidden`) only** — they never intersect the layer-3 `fieldScopeMap`:
+- **form-context** loads `fieldScopeMap` (@6763) but feeds it **only to the `fieldPermissions` metadata** (@6765/6816); the data mask at @6794 uses `visibleFieldIds` (layer-1∧2).
+- **submit** loads **no `fieldScopeMap` at all**; the echo mask at @7198 (+ attachment @7210, + recalculated-formula overlay @7238) uses `visibleFormFieldIds` (layer-1∧2).
+
+Consequence: an **authenticated** caller who is `field_permissions.visible=false` on field X (yet can read the sheet) reads X's value by:
+- `GET /form-context?recordId=R` → `data.record.data[X]`, or
+- `POST /views/:viewId/submit` (update or create) → `data.record.data[X]`,
+
+even though `/view` and `/records/:id` mask X (#2028). This is the **same egress-vs-metadata split** as the original #2015 finding (the layer-3 deny is shipped as metadata but the value is in the payload), on two read/echo paths the arc had not yet covered for the identified case. So D1 is **not no-code** — it is a real layer-3 leak requiring the same composite fix.
+
+## Answer 3 — context-echo and submit-echo: same MECHANISM, not the same test
+Both get the identical fix: mask the echoed `record.data` (and attachment summaries) by the **layer-2 ∧ layer-3 composite** (`deriveFieldPermissions(...).visible !== false` → `allowedFieldIds`), keyed to the requester — exactly #2015/#2028. But the **submit echo carries the F3/F4 subtleties** the read path does not:
+- **write-only-no-read (F3):** a caller may *submit* a value to a layer-2-visible-but-layer-3-denied field. The write still happens (the write-validation gates @6920–6977 are layer-2 and are **left unchanged** — a field can be writable yet read-denied); the **echo must omit it**.
+- **server-assigned (F4):** a denied field the submitter **never sent** — a recalculated **formula** (@7238 overlays formula values gated only by `visibleFormFieldIds`) or a server default — must not surface in the echo. This is the *unambiguous* canary: its presence can't be a "user submitted it" artifact. The locking test's create case (C4) uses a denied formula field for exactly this reason.
+
+## Fix (minimal — add layer-3, don't re-litigate layer-1)
+- **form-context:** `visibleFields` already applied layer-1∧2; intersect with layer-3 via the already-computed `fieldPermissions` → `readableFieldIds = visibleFields.filter(f => fieldPermissions[f.id].visible !== false)`; use it for the `record.data` + attachment masks. Field **definitions** (`fields: visibleFields`) and the `fieldPermissions` metadata stay unchanged (the client hides denied columns via metadata, per #2028 — layer-1 stays display-only; we do not switch to `/view`'s "value stays" semantics here).
+- **submit:** add `loadFieldPermissionScopeMap` (the handler had none) → `echoFieldPermissions` → `readableEchoFieldIds`; use it for the `record.data` mask, attachment mask, and the formula overlay.
+- **Anonymous:** `effectiveAccess.userId=''` → empty scope map → `readableFieldIds`/`readableEchoFieldIds` **equal** the existing `visible*FieldIds` → the public-form path is byte-for-byte unchanged (proven by the locking test's C6).
+- **Out of scope / untouched:** write-validation gates, central RBAC/auth, record-level read-deny (K3 Stage-1 lock).
+
+## Locking test (fail-first, real DB)
+`tests/integration/multitable-form-context-submit-field-mask.test.ts` — 7 cases: C1 form-context recordId read (RED), C3 submit update echo (RED), **C4 submit create server-assigned formula (RED — the F4-style unambiguous canary)**, C2/C5 per-subject positive controls, **C6 anonymous public create = fix is a no-op** (the framing guard). RED on unmodified `origin/main` (C1/C3/C4 leak) → 7/7 GREEN. Wired into `plugin-tests.yml`.
+
+## Verdict
+D1 is a **real, identified-only layer-3 leak** on form-context (record load) + submit (create/update echo); anonymous is correctly moot. Fixed with the #2015 composite + a real-DB locking test. This closes the arc's last open finding → **12/12**.

--- a/docs/development/multitable-form-context-submit-field-mask-verification-20260602.md
+++ b/docs/development/multitable-form-context-submit-field-mask-verification-20260602.md
@@ -1,0 +1,37 @@
+# D1 — form-context / form-submit echo field mask — verification
+
+**Slice:** D1 (final finding) of the multitable field-read-gate arc. **Design-lock:** `multitable-form-context-submit-field-mask-design-20260602.md`. **Date:** 2026-06-02 · **Pattern:** layer-3 echo gate, fail-first.
+
+## The leak
+`GET /form-context?recordId=` and `POST /views/:viewId/submit` echo `record.data` masked by `visible*FieldIds` = **layer-1 ∧ layer-2 only** — not the subject-scoped layer-3 (`field_permissions.visible`) gate `/view`+`/records/:id` enforce (#2028). form-context loads `fieldScopeMap` but uses it only for metadata; submit loads none. So an **authenticated** field-denied caller reads a denied field's value via either path. Anonymous is moot (no subject; public can't load/update existing records → 400). Full rationale: the design doc.
+
+## The fix (`packages/core-backend/src/routes/univer-meta.ts`)
+- **form-context:** `readableFieldIds = visibleFields.filter(f => fieldPermissions[f.id].visible !== false)` (the already-computed layer-1∧2∧3 composite) → used for the `record.data` + attachment-summary masks.
+- **submit:** added `loadFieldPermissionScopeMap` → `echoFieldPermissions` → `readableEchoFieldIds` → used for the `record.data` mask, attachment mask, **and the recalculated-formula overlay** (the server-assigned path).
+- Anonymous (`effectiveAccess.userId=''`) → empty scope map → both sets equal the prior `visible*FieldIds` → public-form path unchanged.
+- Untouched: write-validation gates (layer-2, correct — write-only-no-read preserved), central RBAC/auth, record-level read-deny (K3 Stage-1 lock).
+
+## Fail-first evidence
+`tests/integration/multitable-form-context-submit-field-mask.test.ts` (real DB). Seed (deny solely layer-3, `property={}`): `FLD_VISIBLE` (readable control), `FLD_SECRET` (string, denied to USER), `FLD_FORMULA` (`={FLD_VISIBLE}+1`, denied to USER, + `formula_dependencies` row), a record `{FLD_VISIBLE:'v0', FLD_SECRET:canary}`, and a `form` view with `config.publicForm` enabled (for C6).
+
+| Case | Path | Assertion | Pre-fix |
+|---|---|---|---|
+| C1 | form-context `recordId` (USER) | `record.data[FLD_SECRET]` undefined + body ∌ canary; `FLD_VISIBLE` present | **RED** (canary leaked) |
+| C2 | form-context `recordId` (USER_2) | `record.data[FLD_SECRET]` === canary (per-subject) | green |
+| C3 | submit UPDATE echo (USER) | `record.data[FLD_SECRET]` undefined (not submitted, resurfaced) | **RED** |
+| C4 | submit CREATE echo (USER) | `record.data[FLD_FORMULA]` undefined — **server-assigned, never sent** | **RED** (leaked `43`) |
+| C5 | submit CREATE echo (USER_2) | `record.data[FLD_FORMULA]` present (non-vacuous channel) | green |
+| C6 | anonymous public CREATE | `record.data[FLD_FORMULA]` present — **fix is a no-op for anonymous** | green |
+
+RED on unmodified `origin/main` (C1/C3/C4 leak; sentinel + C2/C5/C6 pass) → **7/7 GREEN** after the fix.
+
+## Regression
+- `tsc` (core-backend) — exit **0**.
+- Real-DB neighbors **31/31** — new test 7/7, `records-read-field-mask` 8/8, `write-echo` 5/5, `create-echo` 4/4, `records-summary` 7/7.
+- Gating real-DB `viewconfig-filter-literal-redaction` (covers form-context's filter-literal echo) — **10/10**, unaffected.
+- `field-validation-flow` 15/15 · `public-form-flow` (mocked) **22/22** (already stubs `field_permissions`).
+- **Mock-stub cascade (F4 lesson):** the submit handler's new `loadFieldPermissionScopeMap` query broke **one** mocked test — `sheet-realtime.api` "publishes … after form submit" (baseline 3/3 → 1 failed: unhandled `SELECT … FROM field_permissions`). Fixed by adding a `field_permissions → []` stub to that test's dispatcher → back to **3/3**. Verified by running **every** mocked test that hits `/submit` or `/form-context`, not just the new one. `record-form.api` 8==8 and `sheet-permissions.api` 1==1 confirmed **pre-existing** (stash-baseline; not net-new).
+
+## CI wiring & tracker
+- `plugin-tests.yml` — `multitable-form-context-submit-field-mask.test.ts` added to the real-DB integration step.
+- Tracker §2b: **D1 → ✅🔒** (locking test `multitable-form-context-submit-field-mask`); completion **12/12 — arc COMPLETE**. Every record-cell-value egress channel now applies the field-read gate (or is scan-clean), each backed by a real-DB locking test except the kanban/gallery/calendar scan-clean coverage item.

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -6767,6 +6767,12 @@ export function univerMetaRouter(): Router {
         allowCreateOnly: !record,
         fieldScopeMap,
       })
+      // D1 (#2106): the record-value echo must honor layer-3 (field_permissions), not just layer-1∧2 — the
+      // same composite /view + /records enforce (#2028). visibleFields already applied layer-1 (view.hidden) ∧
+      // layer-2 (property.hidden); fieldPermissions[].visible adds layer-3. For an ANONYMOUS public-form caller
+      // effectiveAccess.userId='' → fieldScopeMap is empty → this equals visibleFieldIds (the public path is
+      // unchanged; anonymous has no subject to scope to).
+      const readableFieldIds = new Set(visibleFields.filter((field) => fieldPermissions[field.id]?.visible !== false).map((field) => field.id))
       const viewPermissions = resolved.view ? deriveViewPermissions([resolved.view], effectiveCapabilities, viewScopeMap) : {}
       const rowActions = record
         ? deriveRecordRowActions(effectiveCapabilities, effectiveSheetScope, effectiveAccess, record.createdBy)
@@ -6787,11 +6793,11 @@ export function univerMetaRouter(): Router {
                 attachmentFields,
               ),
             )[record.id] ?? {},
-            visibleFieldIds,
+            readableFieldIds,
           )
         : undefined
       if (record) {
-        record.data = filterRecordDataByFieldIds(record.data, visibleFieldIds)
+        record.data = filterRecordDataByFieldIds(record.data, readableFieldIds)
       }
 
       return res.json({
@@ -7186,6 +7192,13 @@ export function univerMetaRouter(): Router {
       }
       const visibleFormFields = fields.filter((field) => !hiddenFieldIds.has(field.id) && !isFieldPermissionHidden(field))
       const visibleFormFieldIds = new Set(visibleFormFields.map((field) => field.id))
+      // D1 (#2106): gate the write echo by layer-2 ∧ layer-3 (the #2028 composite), not just layer-1∧2. This
+      // covers a denied field the submitter never sent — a server-assigned / recalculated formula value. The
+      // submit handler loads no fieldScopeMap today; add one. ANONYMOUS (effectiveAccess.userId='') → empty
+      // scope map → readableEchoFieldIds equals visibleFormFieldIds, so the public-form echo is unchanged.
+      const echoFieldScopeMap = effectiveAccess.userId ? await loadFieldPermissionScopeMap(pool.query.bind(pool), view.sheetId, effectiveAccess.userId) : new Map()
+      const echoFieldPermissions = deriveFieldPermissions(fields, effectiveCapabilities, { hiddenFieldIds: view.hiddenFieldIds ?? [], fieldScopeMap: echoFieldScopeMap })
+      const readableEchoFieldIds = new Set(visibleFormFields.filter((field) => echoFieldPermissions[field.id]?.visible !== false).map((field) => field.id))
 
       const relationalLinkFields = fields
         .map((field) => (field.type === 'link' ? { fieldId: field.id, cfg: parseLinkFieldConfig(field.property) } : null))
@@ -7195,7 +7208,7 @@ export function univerMetaRouter(): Router {
       for (const { fieldId } of relationalLinkFields) {
         record.data[fieldId] = linkValuesByRecord.get(record.id)?.get(fieldId) ?? []
       }
-      record.data = filterRecordDataByFieldIds(record.data, visibleFormFieldIds)
+      record.data = filterRecordDataByFieldIds(record.data, readableEchoFieldIds)
       const attachmentSummaries = attachmentFields.length > 0
         ? filterSingleRecordFieldSummaryMap(
             serializeAttachmentSummaryMap(
@@ -7207,7 +7220,7 @@ export function univerMetaRouter(): Router {
                 attachmentFields,
               ),
             )[record.id] ?? {},
-            visibleFormFieldIds,
+            readableEchoFieldIds,
           )
         : undefined
 
@@ -7235,7 +7248,7 @@ export function univerMetaRouter(): Router {
               // visible formula fields rather than replacing it (avoids clobbering the
               // normalized link values).
               for (const field of fields) {
-                if (field.type === 'formula' && field.id in recalculated && visibleFormFieldIds.has(field.id)) {
+                if (field.type === 'formula' && field.id in recalculated && readableEchoFieldIds.has(field.id)) {
                   record.data[field.id] = recalculated[field.id]
                 }
               }

--- a/packages/core-backend/tests/integration/multitable-form-context-submit-field-mask.test.ts
+++ b/packages/core-backend/tests/integration/multitable-form-context-submit-field-mask.test.ts
@@ -1,0 +1,146 @@
+/**
+ * Real-DB integration test for D1 — the form-context / form-submit echo field mask.
+ * Design-lock: docs/development/multitable-form-context-submit-field-mask-design-20260602.md.
+ *
+ * `GET /form-context?recordId=` and `POST /views/:viewId/submit` echo `record.data`, but mask it by
+ * `visible*FieldIds` = layer-1 (view.hidden) ∧ layer-2 (`property.hidden`) ONLY — they do NOT apply the
+ * subject-scoped layer-3 (`field_permissions.visible`) gate that `/view` + `/records/:id` (#2028) enforce.
+ * So an AUTHENTICATED, field-denied caller can read a denied field's value through these two paths.
+ * (Public/anonymous callers are moot: no subject → no field_permissions deny applies, and public can't
+ * load/update existing records — @6735/@6902 → 400.)
+ *
+ * D1 verdict: anonymous = no subject (mask is a strict no-op); IDENTIFIED = must apply layer-3; context-echo
+ * and submit-echo judged the SAME. Fix = mask the echo by the layer-2 ∧ layer-3 composite (#2015), keyed to
+ * the requester. The submit-echo carries the F3/F4 subtleties: a denied field the submitter did NOT send
+ * (server-assigned / recalculated formula) is the unambiguous create-echo canary (C4).
+ *
+ * Seed non-negotiable: denied fields' property carries no `hidden` → deny is solely layer-3.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_d1_${TS}`
+const SHEET_ID = `sheet_d1_${TS}`
+const VIEW_ID = `view_d1_${TS}`
+const FLD_VISIBLE = `fld_d1_vis_${TS}` // readable — positive control + the bystander edit target
+const FLD_SECRET = `fld_d1_secret_${TS}` // string, layer-3-denied to USER — the read/update echo canary
+const FLD_FORMULA = `fld_d1_formula_${TS}` // formula ={FLD_VISIBLE}+1, layer-3-denied — the server-assigned create-echo canary
+const REC_ID = `rec_d1_${TS}`
+const USER_ID = `u_d1_${TS}` // denied FLD_SECRET + FLD_FORMULA
+const USER_ID_2 = `u_d1_other_${TS}` // no deny — positive control
+const PUBLIC_TOKEN = `tok_d1_${TS}`
+const SECRET_CANARY = `do-not-leak-d1-${TS}`
+
+let app: Express
+let testUserId: string | null = USER_ID
+let testPerms: string[] = ['multitable:read', 'multitable:write']
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const formContext = (recordId?: string) =>
+  request(app).get('/api/multitable/form-context').query({ sheetId: SHEET_ID, viewId: VIEW_ID, ...(recordId ? { recordId } : {}) })
+const submit = (body: Record<string, unknown>, publicToken?: string) => {
+  let r = request(app).post(`/api/multitable/views/${VIEW_ID}/submit`)
+  if (publicToken) r = r.query({ publicToken })
+  return r.send(body)
+}
+
+describeIfDatabase('D1 form-context / form-submit echo field mask (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = testUserId ? { id: testUserId, roles: [], perms: testPerms } : undefined; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'D1 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'D1 Sheet'])
+    // a 'form' view with a public-form config (so the anonymous path C6 is reachable)
+    await q(
+      'INSERT INTO meta_views (id, sheet_id, name, type, hidden_field_ids, config) VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb)',
+      [VIEW_ID, SHEET_ID, 'D1 Form', 'form', '[]', JSON.stringify({ publicForm: { enabled: true, publicToken: PUBLIC_TOKEN, accessMode: 'public' } })],
+    )
+    // all fields property '{}' → no layer-2 hidden; deny is solely layer-3
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_VISIBLE, SHEET_ID, 'Visible', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRET, SHEET_ID, 'Secret', 'string', '{}', 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_FORMULA, SHEET_ID, 'Derived', 'formula', JSON.stringify({ expression: `={${FLD_VISIBLE}}+1` }), 3])
+    // direct-SQL field insert skips the create path that records formula deps → seed it (recalc gates on it)
+    await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,$4)', [SHEET_ID, FLD_FORMULA, FLD_VISIBLE, SHEET_ID])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_ID, SHEET_ID, JSON.stringify({ [FLD_VISIBLE]: 'v0', [FLD_SECRET]: SECRET_CANARY })])
+    // layer-3 read deny on FLD_SECRET + FLD_FORMULA for USER only (USER_2 = positive control)
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER_ID, false, false])
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_FORMULA, 'user', USER_ID, false, false])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM formula_dependencies WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('C1 (form-context recordId, USER): a denied field value is omitted from the loaded record echo', async () => {
+    testUserId = USER_ID; testPerms = ['multitable:read', 'multitable:write']
+    const res = await formContext(REC_ID)
+    expect(res.status).toBe(200)
+    expect(res.body.data.record.data[FLD_VISIBLE]).toBe('v0') // positive control: readable value present
+    expect(res.body.data.record.data[FLD_SECRET]).toBeUndefined() // THE LEAK (RED pre-fix)
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY)
+  })
+
+  test('C2 (form-context recordId, USER_2 positive): an ungranted-to-deny user DOES get the value (per-subject)', async () => {
+    testUserId = USER_ID_2; testPerms = ['multitable:read', 'multitable:write']
+    const res = await formContext(REC_ID)
+    expect(res.status).toBe(200)
+    expect(res.body.data.record.data[FLD_SECRET]).toBe(SECRET_CANARY)
+    testUserId = USER_ID
+  })
+
+  test('C3 (submit UPDATE echo, USER): a denied pre-existing field is omitted from the write echo', async () => {
+    testUserId = USER_ID; testPerms = ['multitable:read', 'multitable:write']
+    // edit only the readable bystander field; FLD_SECRET is NOT submitted but is resurfaced server-side in the echo
+    const res = await submit({ recordId: REC_ID, data: { [FLD_VISIBLE]: 'v1' } })
+    expect(res.status).toBe(200)
+    expect(res.body.data.record.data[FLD_VISIBLE]).toBe('v1') // positive control: write applied + echoed
+    expect(res.body.data.record.data[FLD_SECRET]).toBeUndefined() // THE LEAK (RED pre-fix)
+    expect(JSON.stringify(res.body)).not.toContain(SECRET_CANARY)
+  })
+
+  test('C4 (submit CREATE echo, USER): a denied SERVER-ASSIGNED (recalculated formula) field is omitted', async () => {
+    // the unambiguous create canary (F4-style): the submitter never sends FLD_FORMULA — the server computes it,
+    // so its presence in the echo cannot be a "user submitted it" artifact.
+    testUserId = USER_ID; testPerms = ['multitable:read', 'multitable:write']
+    const res = await submit({ data: { [FLD_VISIBLE]: '42' } })
+    expect(res.status).toBe(200)
+    expect(res.body.data.record.data[FLD_VISIBLE]).toBe('42') // positive control
+    expect(res.body.data.record.data[FLD_FORMULA]).toBeUndefined() // THE LEAK (RED pre-fix): denied server-assigned value
+  })
+
+  test('C5 (submit CREATE echo, USER_2 positive): the formula echo channel DOES carry the value (non-vacuous)', async () => {
+    testUserId = USER_ID_2; testPerms = ['multitable:read', 'multitable:write']
+    const res = await submit({ data: { [FLD_VISIBLE]: '42' } })
+    expect(res.status).toBe(200)
+    expect(res.body.data.record.data[FLD_FORMULA]).not.toBeUndefined() // proves C4's absence is a real mask, not an empty channel
+    testUserId = USER_ID
+  })
+
+  test('C6 (anonymous public CREATE): the fix is a NO-OP for an anonymous caller (no subject → moot)', async () => {
+    // proves the framing: anonymous has no field_permissions subject, so the layer-3 mask adds nothing and the
+    // pre-existing layer-1∧2 behavior is unchanged — the denied-to-USER formula field is STILL echoed here.
+    testUserId = null
+    const res = await submit({ publicToken: PUBLIC_TOKEN, data: { [FLD_VISIBLE]: '7' } }, PUBLIC_TOKEN)
+    expect(res.status).toBe(200)
+    expect(res.body.data.record.data[FLD_FORMULA]).not.toBeUndefined() // anonymous: USER's deny does not apply → unchanged
+    testUserId = USER_ID
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-sheet-realtime.api.test.ts
+++ b/packages/core-backend/tests/integration/multitable-sheet-realtime.api.test.ts
@@ -187,6 +187,10 @@ describe('Multitable sheet realtime events', () => {
         if (sql.includes('FROM formula_dependencies')) {
           return { rows: [] }
         }
+        // D1 (#2106): the form-submit echo now loads field_permissions (loadFieldPermissionScopeMap); no denials in this mock.
+        if (sql.includes('field_permissions')) {
+          return { rows: [] }
+        }
         throw new Error(`Unhandled SQL in test: ${sql}`)
       },
     })


### PR DESCRIPTION
Closes **D1**, the final finding of the multitable field-read-gate arc (tracker `multitable-field-read-gate-tracker-20260602.md` §2b). Design: `multitable-form-context-submit-field-mask-design-20260602.md`.

## D1 is NOT a no-op — it's a real identified-path layer-3 leak
#2106 tagged D1 "anonymous-form, likely no-op." Close reading shows otherwise. `GET /form-context?recordId=` and `POST /views/:viewId/submit` echo `record.data` masked by `visible*FieldIds` = **layer-1 (view.hidden) ∧ layer-2 (property.hidden) only** — never the subject-scoped **layer-3** (`field_permissions.visible`) gate that `/view` + `/records/:id` enforce (#2028):
- form-context loads `fieldScopeMap` but feeds it **only to the `fieldPermissions` metadata**; the data mask uses layer-1∧2.
- submit loads **no** `fieldScopeMap` at all.

So an **authenticated**, field-denied caller (who can read the sheet) reads a denied field's value via either path — the same egress-vs-metadata split as the original #2015 finding, on two paths the arc hadn't covered for the identified case.

**Anonymous is moot (correctly):** no `userId` → empty `fieldScopeMap` → no subject to deny; public callers can't load/update existing records (→ 400). The fix is a strict **no-op** for anonymous.

## Fix (add layer-3; don't re-litigate layer-1)
- **form-context:** `readableFieldIds = visibleFields ∩ {fieldPermissions[].visible !== false}` → `record.data` + attachment masks.
- **submit:** add `loadFieldPermissionScopeMap` → `readableEchoFieldIds` → `record.data` mask + attachment mask + **the recalculated-formula overlay** (the server-assigned path).
- Write-validation gates (layer-2) untouched — write-only-no-read preserved. K3 Stage-1-lock-safe.

## Fail-first + regression
New real-DB test `multitable-form-context-submit-field-mask` (**7/7**): RED on `origin/main` — **C1** form-context recordId read, **C3** submit update echo, **C4** submit CREATE server-assigned formula (the unambiguous F4-style canary: a denied field the submitter never sent) → GREEN; **C2/C5** per-subject positive controls; **C6** anonymous public create proves the no-op. Wired into `plugin-tests.yml`.

- `tsc` 0 · real-DB neighbors **31/31** · gating `viewconfig-filter-literal-redaction` **10/10**.
- **Mock cascade (F4 lesson):** the submit `fieldScopeMap` query broke `sheet-realtime.api` "form submit" (3/3 → 1 fail, unhandled `field_permissions`) → added a `field_permissions → []` stub → **3/3**. Ran **every** mocked test on `/submit` + `/form-context`: `record-form.api` 8==8, `sheet-permissions.api` 1==1, `public-form-flow` 22/22 — all pre-existing/unchanged (stash-verified).

## Tracker
§2b **D1 → ✅🔒** (locking test `multitable-form-context-submit-field-mask`); completion **12/12 — field-read-gate arc COMPLETE**. Remaining items are optional hardening only (delete dead sample plugins; egress-coverage guard), no open leak.

🤖 Generated with [Claude Code](https://claude.com/claude-code)