### PR TITLE
docs(attendance): punch-policy reorder S1→S3→S2 (S2 depends on S3); pause outdoor, next = compliance engine

### DIFF
--- a/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
+++ b/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
@@ -70,13 +70,15 @@
 ## 3. H2 执行排序（产品负责人 2026-06-01）
 
 ① **排班修改窗**（✅ #2197 已落；纯 write-time 校验，不碰 scheduler/notifier 新基座；治理价值高）
-② **打卡策略组**（外勤审批 + 内外勤合并 + 未排班打卡策略；一个 punch-policy 配置基座 design-lock）
+② **打卡策略组**（design-lock #2203）：S0 基座 ✅#2204 · S1 未排班打卡 ✅#2209 · **子序修正 → S1→S3→S2**（S2 内外勤合并依赖 S3 先建"外勤打卡"事实类型）· **S3 外勤 + S2 产品 2026-06-02 暂缓**（外勤=重刀/移动现场）→ 组在 S1 后暂停
 ③ **排班合规引擎**（招牌）
 ④ **加班调休 + 假期过期**（假勤闭环；假期过期提醒在此**首建** scheduler/notifier 基座）
 ⑤ **未排班提醒**（**复用 ④ 的 scheduler+notifier 基座**；镜像 `ApprovalSlaScheduler`）
 ⑥ **自动对班**（灰度门，feature-flag 默认关 → preview → 自动写）
 
 > **回填（2026-06-01 pre-flight 发现）**：原排序把"未排班提醒"列首，依据"渠道已有/最便宜"——**verify 证伪**（attendance 无调度器、无事件→通知消费者）。故改：**排班修改窗为首刀**（真·最便宜 + 治理高）；未排班提醒降级为后续"scheduler+notifier 基座"基础设施刀（2–3pd，与假期过期提醒共建）；未排班处理策略归 ③ 打卡策略组。
+
+> **回填（2026-06-02 决定）**：打卡策略组 S0 ✅#2204 + S1 ✅#2209 后**暂停**。pre-flight 证 **S2 内外勤合并依赖 S3 外勤**（当前模型无内/外勤打卡区分——geofence 只在围栏外拒绝、不分类保留；打卡 → first-in/last-out）→ #2203 子序改为 **S1→S3→S2**（S2 可并入 S3 后半段）。S3 外勤=重刀（外勤动作/审批流/报表口径/移动现场），**暂缓**；**下一主线转 ③ 排班合规引擎**（钉钉硬招牌、无此依赖、直接服务"排班保存时禁止越界"）。
 
 > **⚠️ schema 成组迁移，别一刀一迁。** 首刀"排班修改窗"已按 #2197 路线**无 DDL 落地**：policy 先进 org-level attendance settings JSON（`shiftEditPolicy`），write-time 按受影响日期判窗。后续若要把排班合规（`shift_constraints`）、发布（`status`）、多班次（`slot`）、或持久锁窗（`locked_at`）落到 `attendance_shift_assignments`/`rule_sets`，这些 schema 变更再打一个协调 migration，再分层叠 service/UI（v1 阶段2 已是此意）。
 

--- a/docs/development/attendance-punch-policy-group-design-lock-20260602.md
+++ b/docs/development/attendance-punch-policy-group-design-lock-20260602.md
@@ -52,7 +52,10 @@ punchPolicy: {
 | **S2** | 内外勤卡合并 | `punchPolicy.merge` | record-write/summary：内/外勤打卡谁赢上/下班卡 | 现状合并逻辑 |
 | **S3** | 外勤审批 | `punchPolicy.outdoor` | 外勤打卡→（requireApproval 时）经 `attendance_approval_flows` 进 pending，approved 才算考勤；报表只算 approved。**复用 attendance approval，不新建 flow 表/状态机** | 全 false |
 
-**切片序**（各独立 gated opt-in，CONTRACTS/默认不回归先行）：**S1 未排班打卡（最简、建共享原语、清晰 allow/block）→ S2 内外勤合并 → S3 外勤审批（最重，碰审批流）**。`require_approval`/外勤 pending 的对外配置随 S3 一起开放。
+**切片序**（**修正 2026-06-02：S2 依赖 S3，原 S1→S2→S3 排序作废**）：**S1 未排班打卡 ✅(#2209) → S3 外勤审批 → S2 内外勤合并**。
+> **⚠️ S2 依赖 S3**：内外勤合并需要"外勤打卡"这个**事实类型**才有可合并对象，而当前模型**无内/外勤区分**——geofence 只在围栏外**拒绝**打卡（`!isGeoAllowed → reject`，`index.cjs:~14511`），不分类保留；打卡是无类型 `check_in/check_out` → `first_in_at`/`last_out_at`（最早 in / 最晚 out）。"外勤打卡"由 **S3** 建立，故 **S2 必须在 S3 之后，或并入 S3 后半段**（外勤打卡落地时一起做"谁赢上/下班卡"）。`require_approval`/外勤 pending 的对外配置随 S3 一起开放。
+>
+> **产品决定 2026-06-02**：S0/S1 已落；**S3 外勤暂缓**（重刀，碰外勤动作 / 审批流 / 报表口径 / 移动现场场景），**下一主线转排班合规引擎**（钉钉对标硬招牌、无此依赖）。punch-policy 组在 S1 后暂停。
 
 ## 5. 默认 / 不回归锁（钉死）
 
@@ -80,10 +83,10 @@ punchPolicy: {
 - ✅ D3 钉死默认全保持现状 + `require_approval`/外勤 pending 仅随 S3 暴露。
 
 **实现阶段（全 🔒，须显式 opt-in）**
-- 🔒 S0 `punchPolicy` settings schema + normalize + deep-merge（latent，默认现状，require_approval/outdoor 不暴露）。
-- 🔒 S1 `isUserScheduledForDate` 共享原语 + 未排班打卡 allow/block 强制（punch 路由）+ 测试。
-- 🔒 S2 内外勤卡合并策略 + 强制 + 测试。
-- 🔒 S3 外勤审批（复用 attendance_approval_flows）+ pending/approved 报表过滤 + 暴露 require_approval/outdoor 配置 + 测试。
+- ✅ S0 `punchPolicy` settings schema + normalize + deep-merge（latent）— **#2204**。
+- ✅ S1 `isUserScheduledForDate` 共享原语 + 未排班打卡 allow/block 强制（punch 路由）+ unit + route-level real-DB integration — **#2209**。
+- 🔒 S3 外勤审批（复用 attendance_approval_flows）+ pending/approved 报表过滤 + 暴露 require_approval/outdoor 配置 + 测试 — **建立"外勤打卡"事实类型（= S2 的前置）；产品 2026-06-02 暂缓**。
+- 🔒 S2 内外勤卡合并策略 + 强制 + 测试 — **依赖 S3（无外勤打卡则无可合并对象）；可并入 S3 后半段**。
 
 ## 9. Owner 决策（LOCKED 2026-06-02）
 1. **配置粒度 = org 级 v1**（镜像 geoFence/ipAllowlist；per-group follow-up）。


### PR DESCRIPTION
Pre-flight for **S2** (in-out punch merge) found it **presupposes an internal/external punch distinction that does not exist on main**: geofence only **rejects** out-of-fence punches (doesn't classify/retain), and punches are untyped `check_in/check_out` → `first_in_at`/`last_out_at`. "External punch" is the 外勤 fact-type **S3** establishes → **S2 has no merge target until S3 exists**.

- **#2203 design-lock**: slice order corrected **S1 → S3 → S2** (was S1→S2→S3); S2 depends on S3 (may fold into S3's latter half); §8 marks **S0 ✅#2204 / S1 ✅#2209**.
- **tracker**: punch-policy group **paused after S1**; backfill records the dependency + the product decision (2026-06-02) to **defer outdoor (S3** — heaviest: outdoor action / approval / report semantics / mobile-field) and switch the **next mainline to the compliance engine** (③, the benchmark headline, no dependency, directly serves block-on-save).

Docs-only. (S1 #2209 already merged + CI real-DB integration green — punch-policy S0+S1 complete.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)