### PR TITLE
docs(attendance): shift-compliance-engine design-lock (block-on-save day/week/month hour caps)

### DIFF
--- a/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
+++ b/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
@@ -23,7 +23,7 @@
 
 | 档 | 项 | 关键约束 |
 |---|---|---|
-| **MUST** | **排班合规引擎**（日/周/月工时 cap，**超限阻断保存**） | 钉钉最硬护城河。**MUST 口径 = 排班时阻断保存；warning-only 只算报表/预警红利，不算 MUST ✅**（避免实现方交 warning 充数） |
+| **MUST** | **排班合规引擎**（日/周/月工时 cap，**超限阻断保存**） | 钉钉最硬护城河。**MUST 口径 = 排班时阻断保存；warning-only 只算报表/预警红利，不算 MUST ✅**（避免实现方交 warning 充数）。**design-lock 2026-06-02（本 PR）**：新建 `shiftCompliance`（不并入 comprehensiveHours）/ 全 save 路径事务内投影 / 首版 block / 完成口径 = 日周月三粒度×全路径 |
 | | **未排班提醒**（提醒负责人/本人） | ⚠️ **不是小 feature**：attendance 无调度器、无事件→通知消费者（2026-06-01 verify 证伪"渠道已有"）→ 实为"**attendance scheduler + notifier 基座**"基础设施刀（镜像 `ApprovalSlaScheduler`，leader-elected + env 渠道 notifier）；与**假期过期提醒共建/复用同一基座**。估时 **2–3pd**（原 1–2pd 作废）；排序靠后（§3）。**未排班处理策略 → 归 ③ 打卡策略组，不在此单建** |
 | | **排班修改窗**（可改 N 天内、超窗锁；钉钉默认 180） | 与合规引擎 + 历史数据可信度强绑；无它则报表不可信。实现量小、治理价值高 |
 | | **打卡策略组**（外勤审批 + 内外勤卡合并 + **未排班打卡策略**） | 三项同属 punch policy → 一个"**打卡策略配置基座**"design-lock（greenfield，0 现有字段）；抽屉已在只差配置写入；未排班"阻断/允许打卡"默认 **allow**（不回归） |
@@ -49,7 +49,7 @@
 | 主/子负责人 | （已成） | ✅ | group owner roster/panel/scope（#2099–2103） |
 | 综合工时（报表侧） | （已成，OUT 之外的红利） | ✅ | #1801 等（113 hits，`enforcement:'warn'`） |
 | 固定班 preview/apply + provenance + managed controls · 周矩阵展示 · 打卡只读抽屉 · HR 字段/onboarding/work-time drawer · FormulaEngine（仅差 4–5 函数） | （红利） | ✅ | 并行 session 两天内落地 |
-| 排班合规引擎（超出禁止保存） | MUST | ⬜ | 综合工时仅报表 warn；排班时 block = 0 |
+| 排班合规引擎（超出禁止保存） | MUST | ⬜ | **design-lock ✅ 2026-06-02**（`attendance-shift-compliance-engine-design-lock-20260602.md`，本 PR）；impl S0/S1/S2 gated **未开**，排班时 block 仍 = 0。完成口径 = 日周月三粒度×全路径（见下方合规回填注） |
 | 未排班提醒（= scheduler+notifier 基座刀） | MUST | ⬜ | **verify 2026-06-01 证伪"渠道已有"**：attendance 无调度器、无事件→通知消费者 → 镜像 `ApprovalSlaScheduler`+notifier；2–3pd；与假期过期提醒共建。处理策略已移入 ③ |
 | 排班修改窗 | MUST | ✅ | #2197（squash `2d4808fe`，2026-06-02）：org-level `shiftEditPolicy` 入 attendance settings JSON（默认 `unrestricted`，无 DDL）+ shift/rotation assignment POST/PUT/DELETE 6 写路由显式 422 `SHIFT_EDIT_WINDOW_EXCEEDED`；PUT/DELETE 同看 existing start date + next start date 防历史绕窗；unit + CI real-DB attendance integration 绿 |
 | 外勤审批 | MUST | ⬜ | 0 |
@@ -71,7 +71,7 @@
 
 ① **排班修改窗**（✅ #2197 已落；纯 write-time 校验，不碰 scheduler/notifier 新基座；治理价值高）
 ② **打卡策略组**（design-lock #2203）：S0 基座 ✅#2204 · S1 未排班打卡 ✅#2209 · **子序修正 → S1→S3→S2**（S2 内外勤合并依赖 S3 先建"外勤打卡"事实类型）· **S3 外勤 + S2 产品 2026-06-02 暂缓**（外勤=重刀/移动现场）→ 组在 S1 后暂停
-③ **排班合规引擎**（招牌）
+③ **排班合规引擎**（招牌）— **← 当前主线（2026-06-02）**；**design-lock 已落**（`attendance-shift-compliance-engine-design-lock-20260602.md`，本 PR）：新建 `shiftCompliance` / 全 save 路径事务内投影经 `loadAttendanceComprehensivePlannedMinutesByUser`（复用 effective-calendar，零漂移）/ 首版 block / 切片 S0 latent→S1 daily→S2 weekly+monthly / **完成口径 = 三粒度×全路径才算 ③ ✅，daily-only 是切片**（见下方合规回填注）
 ④ **加班调休 + 假期过期**（假勤闭环；假期过期提醒在此**首建** scheduler/notifier 基座）
 ⑤ **未排班提醒**（**复用 ④ 的 scheduler+notifier 基座**；镜像 `ApprovalSlaScheduler`）
 ⑥ **自动对班**（灰度门，feature-flag 默认关 → preview → 自动写）
@@ -79,6 +79,8 @@
 > **回填（2026-06-01 pre-flight 发现）**：原排序把"未排班提醒"列首，依据"渠道已有/最便宜"——**verify 证伪**（attendance 无调度器、无事件→通知消费者）。故改：**排班修改窗为首刀**（真·最便宜 + 治理高）；未排班提醒降级为后续"scheduler+notifier 基座"基础设施刀（2–3pd，与假期过期提醒共建）；未排班处理策略归 ③ 打卡策略组。
 
 > **回填（2026-06-02 决定）**：打卡策略组 S0 ✅#2204 + S1 ✅#2209 后**暂停**。pre-flight 证 **S2 内外勤合并依赖 S3 外勤**（当前模型无内/外勤打卡区分——geofence 只在围栏外拒绝、不分类保留；打卡 → first-in/last-out）→ #2203 子序改为 **S1→S3→S2**（S2 可并入 S3 后半段）。S3 外勤=重刀（外勤动作/审批流/报表口径/移动现场），**暂缓**；**下一主线转 ③ 排班合规引擎**（钉钉硬招牌、无此依赖、直接服务"排班保存时禁止越界"）。
+
+> **回填（2026-06-02 合规引擎 design-lock）**：③ 排班合规引擎 design-lock 落地（`attendance-shift-compliance-engine-design-lock-20260602.md`，本 PR）。owner 决策锁定：(1) 新建 `shiftCompliance`（日/周/月 maxMinutes + enforcement warn|block，**不并入** comprehensiveHours——save-time/planned/日周月 vs report/actual/月季年）；(2) 强制 = **全部** save 路径（shift POST/PUT `29445/29538` + rotation POST/PUT `21452` + fixed-apply `27818/9193`，DELETE 不拦）；(3) **首版只 block**，warn 预留惰性。**keystone**：投影**复用** `loadAttendanceComprehensivePlannedMinutesByUser`（`13163`，经 effective-calendar resolver，与 comprehensiveHours **同一套** planned-minutes 算法 → 零漂移），**事务内写后投影 → 超限 throw → rollback → 422**（PUT 排除自身自动成立）。切片 **S0 latent config → S1 daily → S2 weekly+monthly**（各 gated + 真 DB route-level 反向 integration）。**完成口径（partial-MUST bar）：③ 仅在 daily∧weekly∧monthly × 全路径 + 反向 integration + staging 全满足才 ✅；daily-only 的 S1 是切片不是"引擎完成"**（防 P2 式 warning/切片充数）。
 
 > **⚠️ schema 成组迁移，别一刀一迁。** 首刀"排班修改窗"已按 #2197 路线**无 DDL 落地**：policy 先进 org-level attendance settings JSON（`shiftEditPolicy`），write-time 按受影响日期判窗。后续若要把排班合规（`shift_constraints`）、发布（`status`）、多班次（`slot`）、或持久锁窗（`locked_at`）落到 `attendance_shift_assignments`/`rule_sets`，这些 schema 变更再打一个协调 migration，再分层叠 service/UI（v1 阶段2 已是此意）。
 

--- a/docs/development/attendance-shift-compliance-engine-design-lock-20260602.md
+++ b/docs/development/attendance-shift-compliance-engine-design-lock-20260602.md
@@ -1,0 +1,129 @@
+# 排班合规引擎 design-lock（日/周/月工时 cap，超限阻断保存）
+
+> **版本** 2026-06-02 · owner 决策已拍板锁定 · H2 **MUST 招牌**（钉钉最硬护城河）
+> **基线** origin/main @ `77ebd86a0`（证据均为 `plugins/plugin-attendance/index.cjs:line`；main 会动，实现分支落地前 re-grep 行号）
+> **账本** 本设计是 `attendance-dingtalk-benchmark-target-and-tracker-20260601.md` ③ 项的 design-lock；落地回填账本。
+> **前置** pre-flight 2026-06-02 clean（`shift_constraints`/`complianceEngine` 在 main = 0；无 open PR / 近期 commit；老 `codex/...row-cap/highscale` 分支 = 无关的高并发行数上限）。
+
+---
+
+## 0. 一句话
+
+排班保存时，**投影**该用户在受影响的 日/周/月 的**计划工时**（planned minutes），任一窗口超出对应 cap → **阻断保存（422）**。不是报表侧事后预警，是写入时的硬门。
+
+与已有 `comprehensiveHours`（报表侧、**事后累计 `actualMinutes`**、月/季/年 warn）**语义并行但不同**：本引擎是 **保存时、计划 `plannedMinutes`、日/周/月、block**。两者共用底层工时算法，但**不是同一配置对象**。
+
+---
+
+## 1. owner 决策（2026-06-02 锁定，不再 re-litigate）
+
+1. **配置 = 新建 `shiftCompliance`，不并入 `comprehensiveHours`。** 理由：时机（save vs report）、口径（planned vs actual）、粒度（日/周/月 vs 月/季/年）都不同，强行复用会让语义混住。
+2. **强制点 = 全部 assignment-save 路径**（否则"正门拦、侧门进"，被排班批量应用绕过）：shift POST/PUT + rotation POST/PUT + fixed-schedule apply。**DELETE 不 block**（删除不会增加工时）；**PUT 改日期/范围/启停要算**。
+3. **schema 留 `enforcement: warn|block`，首版只交付 `block`。** 默认无 cap 不强制（不回归）。MUST 验收 = "超出禁止保存"（422 + 反向 integration），**不做 UI/报表软提示**（避免和现有 comprehensiveHours warn 口径打架）。`warn` 为预留枚举，v1 解析+持久化但**惰性**（不 block、不提示）——**显式文档化，不是静默 no-op**。
+
+---
+
+## 2. 配置形状（`shiftCompliance`，attendance org-settings JSON，无 DDL）
+
+与 `punchPolicy`(#2203)/`shiftEditPolicy`(#2197) 同列，挂在 attendance 组织设置 JSON：
+
+```
+shiftCompliance: {
+  enforcement: 'block',     // 'block' | 'warn'（warn 预留，v1 惰性）
+  dailyMaxMinutes: null,    // null = 未设 = 该粒度不强制（不回归）
+  weeklyMaxMinutes: null,
+  monthlyMaxMinutes: null,
+}
+```
+
+- `normalizeShiftComplianceSetting(raw)`：复用 `comprehensiveHours` 的 `normalizeCap`（正整数分钟，否则 null）；`enforcement ∈ {block,warn}` 否则回落 `'block'`。镜像 `normalizePunchPolicySetting`/`normalizeAttendanceComprehensiveHoursSettings` 的"任何 unset/partial/malformed 都不改变行为"。
+- `DEFAULT_SETTINGS.shiftCompliance`（全 null + block）+ `mergeSettings` per-key 浅合并（本对象一层即可，无需 punchPolicy 的两层嵌套）。
+- `settingsSchema`（PUT 输入）：`shiftCompliance: z.object({ enforcement: z.enum(['block','warn']).optional(), dailyMaxMinutes/weeklyMaxMinutes/monthlyMaxMinutes: z.number().int().positive().nullable().optional() }).optional()`。
+
+---
+
+## 3. 投影模型（**keystone** — 复用既有 resolver，不手搓两表 union）
+
+**投影源 = `loadAttendanceComprehensivePlannedMinutesByUser(db, orgId, [userId], { from, to })`（`index.cjs:13163`）。** 它内部：prefetch（`buildWorkContextPrefetch`）→ 逐日 `resolveWorkContextFromPrefetch`（**effective-per-day resolver，跨 shift+rotation+override+holiday 拥有 day-level 优先级** — 见 `index.cjs:7883` 注释）→ `buildAttendanceComprehensivePlannedMinutesFromDays` → 每日 `plannedMinutes` 求和。
+
+为什么用它而非手搓 union：
+- **零漂移**：与 `comprehensiveHours` 报表用的是**同一套** planned-minutes 计算（`calculateAttendanceComprehensiveShiftPlannedMinutes`）。引擎 enforce 的分钟数 = 日历/报表 compute 的分钟数。手搓第二套两表 union 就是 wire-vs-fixture 漂移陷阱的上一层。
+- **绕开共存歧义**：rotation 在独立表 `attendance_rotation_assignments`；resolver 已拥有 day-level 精度，不需要我们判"同日 shift+rotation 谁赢"。（且 `findAttendanceScheduleAssignmentConflict` 是**跨 kind** 的 `index.cjs:8825` → 同一用户同日至多一条 active 派班，跨两表；进一步保证逐日 ≤1 班。）
+
+**Cap 对象 = `plannedMinutes`（计划），不是 actual（实打）。** 这是排班合规（约束**计划**不越界），与 comprehensiveHours 的 actual 报表口径互补。
+
+**强制机制 = 事务内、写后、提交前**（各 save 路由已有 `db.transaction(trx => …)`，见 `29488`/`29618`）：
+1. 在既有事务里执行 INSERT/UPDATE（写入待持久状态）；
+2. 对每个**已设 cap** 的粒度，调 `loadAttendanceComprehensivePlannedMinutesByUser(trx, orgId, [userId], { from, to })`（传 **trx** → 读到未提交的写后状态）：
+   - daily：`{from: D, to: D}`（仅受影响的那些日）；
+   - weekly：`{from: 周一, to: 周日}`（受影响日所在周，org tz，ISO 周一起）；
+   - monthly：`{from: 月初, to: 月末}`（受影响日所在自然月，org tz）；
+3. 任一窗口 `plannedMinutes > maxMinutes` → **throw 一个有类型的 `ShiftComplianceCapExceeded`** → 事务回滚（写被撤销）→ 路由 catch 映射为 **422**。
+4. 全部窗口 ≤ cap → 正常提交。
+
+> PUT 的"排除自身旧值"**自动成立**：trx 已是 UPDATE 后状态，resolver 读到的是新派班，旧值已被覆盖——无需手算 delta。这正是用 trx-内投影而非内存 overlay 的收益。
+
+---
+
+## 4. 强制点（全部，line @ 77ebd86a0 — 实现前 re-grep）
+
+| 路由 | 行 | 处置 |
+|---|---|---|
+| shift assignment **POST** `/api/attendance/assignments` | `29445` | 事务内写后投影；紧贴现有 `enforceShiftEditWindow`(`29473`)/conflict-finder 之后 |
+| shift assignment **PUT** `/api/attendance/assignments/:id` | `29538` | 同上；trx 含 UPDATE 后状态 |
+| rotation assignment **POST/PUT** `/api/attendance/rotation-assignments[/:id]` | `21452` 起 | 同机制；resolver 已能展开 rotation pattern（`attendance_rotation_rules.shift_sequence`） |
+| **fixed-schedule apply** `/api/attendance/groups/:id/fixed-schedule/apply` → `applyAttendanceGroupFixedSchedule` | `27818` / `9193` | **批量**：对 plan 内**每个受影响用户**逐一投影；任一超限 → 整个 apply 回滚 422（不可半应用） |
+| GET（list）`/api/attendance/assignments` | `29353` | 读，**不拦** |
+| DELETE / soft-deactivate | — | **不拦**（删除不增工时） |
+
+**共享 guard** `enforceShiftComplianceCap(trx, res, { orgId, userId, affectedDates })`：镜像 `enforceShiftEditWindow` 的 `if (!access) return` 形态（throw→rollback→catch→422）。一处实现，五个 hook 共用。
+
+---
+
+## 5. 422 契约
+
+```
+422 { ok:false, error:{ code:'SHIFT_COMPLIANCE_CAP_EXCEEDED',
+  message, granularity:'daily'|'weekly'|'monthly', capMinutes, projectedMinutes, periodStart, periodEnd } }
+```
+路由 catch 增一分支：`error instanceof ShiftComplianceCapExceeded → 422`（与现有 `isDatabaseSchemaError→503` / else `500` 并列，`index.cjs:29527`）。不可走 500。
+
+---
+
+## 6. 不回归 + 边界（lock 进文档）
+
+- **默认不强制**：任一 `maxMinutes=null` → 该粒度跳过；全 null → 引擎完全惰性 = 当前行为。
+- **org 时区 + 周起**：日/周/月边界用 **org tz**（复用打卡 workDate 的 tz 处理，勿用 server UTC）；**周一起（ISO）**，org 可配周起 = 延后。
+- **开口派班**（`end_date = null`）：只投影**本次变更触及的**周期（受影响日 + 其所在周/月），**不投影 all-time**（否则月 cap 对开口派班无界）。
+- **PUT 排除自身**：靠 trx-内投影自动成立（§3）。
+- **rotation pattern 展开**由 resolver 负责，引擎不另写展开逻辑。
+- **性能**：月窗口 prefetch 受 §"仅触及周期"约束有界；trx 内投影会延长行锁持有（已有 `acquireAttendanceScheduleAssignmentLock`），v1 规模可接受，宽窗口 perf 作 S2 验证项。
+
+---
+
+## 7. ⛔ 完成口径（partial-MUST bar — 防"切片充数"）
+
+**③ 排班合规引擎仅在以下全部满足时才算 ✅：daily **且** weekly **且** monthly 三粒度，**全部** save 路径（shift/rotation/fixed-apply）均运行时 block + 每条强制点有真 DB route-level 反向 integration + 1 条 staging 联调。**
+
+- **daily-only 的 S1 是一个切片，不是"引擎完成"。** 账本 ③ 不得在仅日 cap 时打 ✅。
+- 同 #2203 的"无半成品"纪律 + 关闭过的 P2 漏洞（warning-only 充当 MUST）。`warn` 惰性预留也不得被当作"已交付 warn 模式"。
+
+---
+
+## 8. 实现切片（各独立 gated opt-in；CONTRACTS/默认不回归先行）
+
+- 🔒 **S0 latent config**：`DEFAULT_SETTINGS.shiftCompliance` + `normalizeShiftComplianceSetting` + `mergeSettings` 接线 + `settingsSchema` 暴露（enforcement warn|block + 三 maxMinutes）。**latent，无强制**，node --check + unit（normalize 边界）。镜像 punch-policy S0(#2204)。
+- 🔒 **S1 daily cap**：`enforceShiftComplianceCap` 共享 guard（事务内投影，仅受影响日窗口）+ 接入**全部** save 路径 + `dailyMaxMinutes` block + unit + **真 DB route-level integration**（PUT 设 cap → 保存超限 → 422 + 无行持久 → 窗内 → 200）。derisk 机制（in-txn 投影/rollback/422/全路径）于最小窗口。
+- 🔒 **S2 weekly + monthly cap**：扩 guard 到周/月窗口（受影响日所在周/月，org tz，开口派班仅触及周期）+ `weeklyMaxMinutes`/`monthlyMaxMinutes` block + 全路径 + integration（含跨派班累计：他派班占周前段 + 本次占后段 → 周和超限）。**S2 合入后③才满足完成口径（§7）。**
+- （`warn` 模式 = 预留，v1 不建；未来单独 slice 建 warn 通道时再激活。）
+
+> **schema-batch 提醒**（账本 §"成组迁移"）：本引擎 config + 投影**无需 DDL**（投影读既有派班/班次行）。若未来某 slice 真要给热表 `attendance_shift_assignments`/`rule_sets` 加 `shift_constraints` 列，须与 edit-window/publish/multi-slot 的待迁 ALTER 协调一次性迁。
+
+---
+
+## 9. 反漂移
+
+- 投影**只**经 `loadAttendanceComprehensivePlannedMinutesByUser` / `resolveWorkContextFromPrefetch`；**禁止**手搓第二套两表 union（漂移陷阱）。
+- 任何新强制点（未来若新增 save 路径）须同样接 `enforceShiftComplianceCap`，否则即 §1 决策2 的"侧门"。
+- enforcement=`block` 是 v1 唯一生效模式；`warn` 惰性必须**显式注释**（解析+存但不动作），不得静默。
+- 每条强制点的反向 integration 是合入前置（非 fast-follow）—— #2209 教训：enforcement 的 helper unit test 不足，须 wire 级（settings→getSettings→workDate/period→route→422→无写）证明。


### PR DESCRIPTION
H2 **MUST headline** (tracker ③ 排班合规引擎 — the DingTalk benchmark's hardest moat). **Design-lock only**; impl deferred to gated slices.

## Owner decisions (locked 2026-06-02)
1. **NEW `shiftCompliance` config** (org-settings JSON, no DDL): day/week/month `maxMinutes` + `enforcement: warn|block`. **NOT merged into `comprehensiveHours`** — save-time/**planned**/日周月 vs report-side/**actual**/月季年. Related, distinct config.
2. **Enforce at ALL assignment-save paths** (else 正门拦侧门进): shift POST/PUT, rotation POST/PUT, fixed-schedule apply. **DELETE not blocked**; PUT changing date/range/active **does** count.
3. **Schema reserves `warn|block`; v1 ships `block` only.** Default no-cap = no enforcement (no regression). MUST acceptance = 422-on-save, not a warning; `warn` is a documented **inert** reserve in v1 (no silent no-op).

## Keystone — projection source (verified against source, not assumed)
- Reuses the **ready-made** `loadAttendanceComprehensivePlannedMinutesByUser` (`index.cjs:13163`) → `resolveWorkContextFromPrefetch` (the effective-per-day resolver that **owns day-level precedence** across shift+rotation+overrides+holidays, `index.cjs:7883`) → planned minutes. This is the **same compute `comprehensiveHours` uses → zero wire-vs-fixture drift**; explicitly **not** a hand-rolled two-table union.
- Coexistence question retired: `findAttendanceScheduleAssignmentConflict` is **cross-kind** (`index.cjs:8825`) → ≤1 active assignment per user/day across both tables.
- **Enforce inside the existing route transaction, after the write, before commit**: project the affected day/week/month via the resolver reading the **txn** (uncommitted post-write state) → exceed → `throw` → rollback → **422 `SHIFT_COMPLIANCE_CAP_EXCEEDED`**. PUT exclude-self is automatic (txn holds the updated row); no overlay/delta math.

## Slices (each a gated opt-in; real-DB route-level integration before merge — #2209 lesson)
**S0** latent config → **S1** daily → **S2** weekly+monthly.

## ⛔ Partial-MUST bar (locked)
Tracker ③ is ✅ **only** when daily **and** weekly **and** monthly are enforced across **all** save paths + reverse integration + staging. **Daily-only S1 is a slice, not 'engine done'** — closes the warning-only/partial-as-MUST loophole class (the P2 shape).

Tracker backfilled (§1 goal / §2 status / §3 sequence + dated 合规 note). Docs-only — no runtime change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)