### PR TITLE
fix(integration): split schema-qualified object in data-source:sql-readonly getSchema

### DIFF
--- a/plugins/plugin-integration-core/__tests__/data-source-sql-readonly-source-adapter.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/data-source-sql-readonly-source-adapter.test.cjs
@@ -150,6 +150,18 @@ async function main() {
     const schema = await a.getSchema({ object: 'public.t' })
     assert.equal(schema.object, 'public.t')
     assert.deepEqual(schema.fields, [{ name: 'id', type: 'int', nullable: false }])
+    // A schema-qualified object is split back into table + schema for getTableInfo (the entity-machine
+    // follow-up: getTableInfo/getSchema want bare table + separate schema; read/select take schema.table).
+    assert.equal(f.calls.getTableInfo[0].object, 't', 'getSchema splits schema.table → bare table for getTableInfo')
+    assert.equal(f.calls.getTableInfo[0].schema, 'public', 'getSchema passes the qualified schema to getTableInfo')
+  }
+
+  // 9b. A bare object passes through unsplit (uses config.schema, here unset → undefined).
+  {
+    const f = fakeFacade()
+    await adapterWith(f).getSchema({ object: 'items' })
+    assert.equal(f.calls.getTableInfo[0].object, 'items', 'bare object → table only')
+    assert.equal(f.calls.getTableInfo[0].schema, undefined, 'bare object → no schema split')
   }
 
   // 10. The factory threads the principal through to the adapter.

--- a/plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs
@@ -72,6 +72,18 @@ function parseOffsetCursor(cursor) {
   return numeric
 }
 
+// getSchema/getTableInfo want a BARE table name + a SEPARATE schema, but listObjects emits (and
+// read/select accept) a `schema.table` qualified name. Split a single-dot qualified object back into
+// { schema, table } so getTableInfo resolves the right table instead of looking for a table literally
+// named "schema.table"; a bare object keeps the connection's config-level schema (if any).
+function splitQualifiedObject(object, defaultSchema) {
+  const dot = object.indexOf('.')
+  if (dot > 0 && dot < object.length - 1 && object.indexOf('.', dot + 1) === -1) {
+    return { schema: object.slice(0, dot), table: object.slice(dot + 1) }
+  }
+  return { schema: defaultSchema, table: object }
+}
+
 function mapColumns(columns) {
   if (!Array.isArray(columns)) return []
   return columns.map((column) => ({
@@ -130,7 +142,10 @@ function createDataSourceSqlReadonlySourceAdapter({ system, context, principal }
     async getSchema(input = {}) {
       const object = requiredString(input.object, 'object')
       const api = getDataSourcesApi(context)
-      const tableInfo = await api.getTableInfo(dataSourceId, object, principal, schema)
+      // A schema-qualified object (e.g. `public.items`, as listObjects emits) is split back into
+      // table + schema for getTableInfo, which takes them separately; a bare object keeps config.schema.
+      const { schema: effectiveSchema, table } = splitQualifiedObject(object, schema)
+      const tableInfo = await api.getTableInfo(dataSourceId, table, principal, effectiveSchema)
       return {
         object,
         fields: mapColumns(tableInfo && tableInfo.columns),


### PR DESCRIPTION
## Summary

Small entity-machine validation follow-up (**#2205**). The `data-source:sql-readonly` bridge's `getSchema` passed the **whole** `object` to `getTableInfo`, but `getTableInfo`/`getSchema` want a **bare table + separate schema** (while `listObjects` emits, and `read`/`select` accept, a `schema.table` qualified name). So `getSchema('public.approval_instances')` looked for a table literally named `public.approval_instances` and returned **empty columns**.

**Fix:** split a single-dot qualified object back into `{ schema, table }` before `getTableInfo`; a bare object keeps the connection's config-level schema. `read`/`select` are unchanged (they already handle `schema.table` via per-segment quoting), so reads were never affected — only the schema-column display.

```js
getSchema('public.t')  -> facade.getTableInfo(id, 't',     principal, 'public')
getSchema('items')     -> facade.getTableInfo(id, 'items', principal, undefined)  // config.schema if set
```

## Context
- **#2205 main chain already PASSED** on the entity machine (real deploy, real DB, real end-to-end). This only fixes the schema-column display for schema-qualified object names — it was the one non-blocking follow-up.
- Confirmed on `origin/main` the unsplit call was still present and no open PR addressed it.

## Verification
- `data-source-sql-readonly-source-adapter.test.cjs` — extended: `getSchema('public.t')` → `getTableInfo(id, 't', principal, 'public')`; bare `items` → `(id, 'items', principal, undefined)`. All assertions pass.
- `plugin-runtime-smoke` + `http-routes` green (no regression).
- Plugin-only `.cjs`; **read-only; no K3 / RBAC / auth**.

Leaving for review — not auto-merging.