### PR TITLE
feat(attendance): shift-compliance S1 — daily cap block-on-save (all assignment-save paths)

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -2603,6 +2603,152 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('enforces the daily shift-compliance cap (block) across all assignment-save paths and persists nothing on 422', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const runSuffix = Date.now().toString(36)
+    const adminUserId = `attendance-compliance-admin-${runSuffix}`
+    const targetUserId = `attendance-compliance-user-${runSuffix}`
+    const memberUserId = `attendance-compliance-member-${runSuffix}`
+    // The shift works all 7 weekdays (540 min/day), so each date is a working day → date-independent.
+    const startA = '2026-07-06' // shift POST
+    const startB = '2026-07-13' // shift PUT (small -> big)
+    const startC = '2026-07-20' // rotation POST
+    const startD = '2026-07-27' // fixed-schedule apply (member)
+    const startE = '2026-08-03' // no-regression: cap with headroom
+    const startF = '2026-08-10' // no-regression: cap unset (null)
+    const startG = '2026-08-17' // rotation PUT
+    const startH = '2026-08-24' // fixed-schedule rebuild
+    const previousRbacBypass = process.env.RBAC_BYPASS
+    const pool = new Pool({ connectionString: dbUrl })
+    let adminToken: string | undefined
+    let originalSettings: Record<string, unknown> = {}
+    let groupId: string | undefined
+    let bigShiftId: string | undefined
+    let smallShiftId: string | undefined
+    let rotationRuleId: string | undefined
+    let smallRotationRuleId: string | undefined
+    try {
+      // Compliance enforcement is orthogonal to RBAC (it runs after the dispatch check, inside the
+      // txn). Bypass RBAC so each save path reaches the guard without per-route permission plumbing.
+      process.env.RBAC_BYPASS = 'true'
+      const adminTokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`)
+      adminToken = (adminTokenRes.body as { token?: string } | undefined)?.token
+      if (!adminToken) return
+      const headers = { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' }
+
+      // Opt the org into block + a tiny daily cap, and confirm the PUT round-trips through GET.
+      const origRes = await requestJson(`${baseUrl}/api/attendance/settings`, { headers: { Authorization: `Bearer ${adminToken}` } })
+      originalSettings = ((origRes.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
+      const putRes = await requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers, body: JSON.stringify({ shiftCompliance: { enforcement: 'block', dailyMaxMinutes: 60 } }) })
+      expect(putRes.status).toBe(200)
+      const rt = await requestJson(`${baseUrl}/api/attendance/settings`, { headers: { Authorization: `Bearer ${adminToken}` } })
+      const rtCompliance = (rt.body as { data?: { shiftCompliance?: { dailyMaxMinutes?: number; enforcement?: string } } } | undefined)?.data?.shiftCompliance
+      expect(rtCompliance?.dailyMaxMinutes).toBe(60)
+      expect(rtCompliance?.enforcement).toBe('block')
+
+      // A 9h shift (540 min planned every day, > 60) and a 30-min shift (< 60).
+      const bigShiftRes = await requestJson(`${baseUrl}/api/attendance/shifts`, { method: 'POST', headers, body: JSON.stringify({ name: `compliance-big-${runSuffix}`, timezone: 'UTC', workStartTime: '09:00', workEndTime: '18:00', workingDays: [0, 1, 2, 3, 4, 5, 6] }) })
+      expect(bigShiftRes.status).toBe(201)
+      bigShiftId = (bigShiftRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      const smallShiftRes = await requestJson(`${baseUrl}/api/attendance/shifts`, { method: 'POST', headers, body: JSON.stringify({ name: `compliance-small-${runSuffix}`, timezone: 'UTC', workStartTime: '09:00', workEndTime: '09:30', workingDays: [0, 1, 2, 3, 4, 5, 6] }) })
+      expect(smallShiftRes.status).toBe(201)
+      smallShiftId = (smallShiftRes.body as { data?: { id?: string } } | undefined)?.data?.id
+
+      // (1) shift POST -> 422, and NO row written (rolled back before commit).
+      const shiftPostRes = await requestJson(`${baseUrl}/api/attendance/assignments`, { method: 'POST', headers, body: JSON.stringify({ userId: targetUserId, shiftId: bigShiftId, startDate: startA, endDate: startA, isActive: true }) })
+      expect(shiftPostRes.status).toBe(422)
+      expect((shiftPostRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_COMPLIANCE_CAP_EXCEEDED')
+      const afterShiftPost = await pool.query('SELECT 1 FROM attendance_shift_assignments WHERE user_id = $1 AND start_date = $2', [targetUserId, startA])
+      expect(afterShiftPost.rows.length).toBe(0)
+
+      // (2) shift PUT -> create with the small shift (under cap) succeeds, PUT to the big shift -> 422
+      // and the row is unchanged (still the small shift) because the txn rolled back.
+      const smallAssignRes = await requestJson(`${baseUrl}/api/attendance/assignments`, { method: 'POST', headers, body: JSON.stringify({ userId: targetUserId, shiftId: smallShiftId, startDate: startB, endDate: startB, isActive: true }) })
+      expect(smallAssignRes.status).toBe(201)
+      const shiftAssignmentId = (smallAssignRes.body as { data?: { assignment?: { id?: string } } } | undefined)?.data?.assignment?.id
+      const shiftPutRes = await requestJson(`${baseUrl}/api/attendance/assignments/${shiftAssignmentId}`, { method: 'PUT', headers, body: JSON.stringify({ shiftId: bigShiftId }) })
+      expect(shiftPutRes.status).toBe(422)
+      expect((shiftPutRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_COMPLIANCE_CAP_EXCEEDED')
+      const afterShiftPut = await pool.query('SELECT shift_id FROM attendance_shift_assignments WHERE id = $1', [shiftAssignmentId])
+      expect(String(afterShiftPut.rows[0]?.shift_id)).toBe(String(smallShiftId))
+
+      // (3) rotation POST (rotation rule whose only shift is the big one) -> 422, no rotation row.
+      const rotRuleRes = await requestJson(`${baseUrl}/api/attendance/rotation-rules`, { method: 'POST', headers, body: JSON.stringify({ name: `compliance-rot-${runSuffix}`, timezone: 'UTC', shiftSequence: [bigShiftId], isActive: true }) })
+      expect(rotRuleRes.status).toBe(201)
+      rotationRuleId = (rotRuleRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      const rotPostRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments`, { method: 'POST', headers, body: JSON.stringify({ userId: targetUserId, rotationRuleId, startDate: startC, isActive: true }) })
+      expect(rotPostRes.status).toBe(422)
+      expect((rotPostRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_COMPLIANCE_CAP_EXCEEDED')
+      const afterRotPost = await pool.query('SELECT 1 FROM attendance_rotation_assignments WHERE user_id = $1 AND start_date = $2', [targetUserId, startC])
+      expect(afterRotPost.rows.length).toBe(0)
+
+      // (3b) rotation PUT -> assign a small-shift rotation (under cap) succeeds, PUT it to the big-shift
+      // rotation rule -> 422 and the row is unchanged (still the small rule) because the txn rolled back.
+      const smallRotRuleRes = await requestJson(`${baseUrl}/api/attendance/rotation-rules`, { method: 'POST', headers, body: JSON.stringify({ name: `compliance-rot-small-${runSuffix}`, timezone: 'UTC', shiftSequence: [smallShiftId], isActive: true }) })
+      expect(smallRotRuleRes.status).toBe(201)
+      smallRotationRuleId = (smallRotRuleRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      const smallRotAssignRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments`, { method: 'POST', headers, body: JSON.stringify({ userId: targetUserId, rotationRuleId: smallRotationRuleId, startDate: startG, endDate: startG, isActive: true }) })
+      expect(smallRotAssignRes.status).toBe(201)
+      const rotationAssignmentId = (smallRotAssignRes.body as { data?: { assignment?: { id?: string } } } | undefined)?.data?.assignment?.id
+      const rotPutRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments/${rotationAssignmentId}`, { method: 'PUT', headers, body: JSON.stringify({ rotationRuleId }) })
+      expect(rotPutRes.status).toBe(422)
+      expect((rotPutRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_COMPLIANCE_CAP_EXCEEDED')
+      const afterRotPut = await pool.query('SELECT rotation_rule_id FROM attendance_rotation_assignments WHERE id = $1', [rotationAssignmentId])
+      expect(String(afterRotPut.rows[0]?.rotation_rule_id)).toBe(String(smallRotationRuleId))
+
+      // (4) fixed-schedule apply (bulk) -> 422, no managed row for the member (whole apply rolled back).
+      const groupRes = await requestJson(`${baseUrl}/api/attendance/groups`, { method: 'POST', headers, body: JSON.stringify({ name: `compliance-grp-${runSuffix}`, timezone: 'UTC', attendanceType: 'fixed_shift', description: 'integration-test' }) })
+      expect(groupRes.status).toBe(200)
+      groupId = (groupRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      const memberRes = await requestJson(`${baseUrl}/api/attendance/groups/${groupId}/members`, { method: 'POST', headers, body: JSON.stringify({ userIds: [memberUserId] }) })
+      expect(memberRes.status).toBe(200)
+      const applyRes = await requestJson(`${baseUrl}/api/attendance/groups/${groupId}/fixed-schedule/apply`, { method: 'POST', headers, body: JSON.stringify({ shiftId: bigShiftId, startDate: startD, endDate: startD }) })
+      expect(applyRes.status).toBe(422)
+      expect((applyRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_COMPLIANCE_CAP_EXCEEDED')
+      const afterApply = await pool.query('SELECT 1 FROM attendance_shift_assignments WHERE user_id = $1', [memberUserId])
+      expect(afterApply.rows.length).toBe(0)
+
+      // (4b) fixed-schedule REBUILD shares the managed-insert path with apply — guard it too (closes
+      // the rebuild side-door). Big shift -> 422, and no managed row persisted for the member.
+      const rebuildRes = await requestJson(`${baseUrl}/api/attendance/groups/${groupId}/fixed-schedule/rebuild`, { method: 'POST', headers, body: JSON.stringify({ shiftId: bigShiftId, startDate: startH, endDate: startH }) })
+      expect(rebuildRes.status).toBe(422)
+      expect((rebuildRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_COMPLIANCE_CAP_EXCEEDED')
+      const afterRebuild = await pool.query('SELECT 1 FROM attendance_shift_assignments WHERE user_id = $1', [memberUserId])
+      expect(afterRebuild.rows.length).toBe(0)
+
+      // (5) no regression — raise the cap above the shift: the same big-shift POST now succeeds.
+      const putHigh = await requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers, body: JSON.stringify({ shiftCompliance: { enforcement: 'block', dailyMaxMinutes: 600 } }) })
+      expect(putHigh.status).toBe(200)
+      const headroomRes = await requestJson(`${baseUrl}/api/attendance/assignments`, { method: 'POST', headers, body: JSON.stringify({ userId: targetUserId, shiftId: bigShiftId, startDate: startE, endDate: startE, isActive: true }) })
+      expect(headroomRes.status).toBe(201)
+
+      // (6) no regression — cap unset (null): enforcement is inert, the big-shift POST succeeds.
+      const putNull = await requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers, body: JSON.stringify({ shiftCompliance: { enforcement: 'block', dailyMaxMinutes: null } }) })
+      expect(putNull.status).toBe(200)
+      const unsetRes = await requestJson(`${baseUrl}/api/attendance/assignments`, { method: 'POST', headers, body: JSON.stringify({ userId: targetUserId, shiftId: bigShiftId, startDate: startF, endDate: startF, isActive: true }) })
+      expect(unsetRes.status).toBe(201)
+    } finally {
+      if (adminToken) {
+        await requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' }, body: JSON.stringify(originalSettings) }).catch(() => undefined)
+      }
+      await pool.query('DELETE FROM attendance_shift_assignments WHERE user_id = ANY($1::text[])', [[targetUserId, memberUserId]]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_rotation_assignments WHERE user_id = $1', [targetUserId]).catch(() => undefined)
+      if (rotationRuleId) await pool.query('DELETE FROM attendance_rotation_rules WHERE id = $1', [rotationRuleId]).catch(() => undefined)
+      if (smallRotationRuleId) await pool.query('DELETE FROM attendance_rotation_rules WHERE id = $1', [smallRotationRuleId]).catch(() => undefined)
+      if (groupId) {
+        await pool.query('DELETE FROM attendance_group_members WHERE group_id = $1', [groupId]).catch(() => undefined)
+        await pool.query('DELETE FROM attendance_groups WHERE id = $1', [groupId]).catch(() => undefined)
+      }
+      if (bigShiftId) await pool.query('DELETE FROM attendance_shifts WHERE id = $1', [bigShiftId]).catch(() => undefined)
+      if (smallShiftId) await pool.query('DELETE FROM attendance_shifts WHERE id = $1', [smallShiftId]).catch(() => undefined)
+      if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS
+      else process.env.RBAC_BYPASS = previousRbacBypass
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('rejects non-UUID shift references for rotation rules, including UUID-like shift names', async () => {
     if (!baseUrl) return
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -9215,6 +9215,18 @@ async function applyAttendanceGroupFixedSchedule(db, input) {
   const producerMetadata = buildAttendanceGroupFixedScheduleProducerMetadata(input, randomUUID())
   const created = await insertAttendanceGroupFixedScheduleAssignments(db, input, plan.wouldCreate, producerMetadata)
 
+  // S1 daily compliance cap: project every user that received a managed row over the apply window and
+  // roll the whole apply back (throw → txn rollback → 422) if any day would exceed the cap. Guards the
+  // bulk side-door alongside the per-record save routes (no known bypass window).
+  for (const targetUserId of new Set(plan.wouldCreate.map((item) => item.userId))) {
+    await enforceShiftComplianceCap(db, {
+      orgId: input.orgId,
+      userId: targetUserId,
+      fromDate: input.startDate,
+      toDate: input.endDate,
+    })
+  }
+
   return {
     ok: true,
     data: {
@@ -9253,6 +9265,17 @@ async function rebuildAttendanceGroupFixedSchedule(db, input) {
   const producerMetadata = buildAttendanceGroupFixedScheduleProducerMetadata(input, randomUUID())
   const created = await insertAttendanceGroupFixedScheduleAssignments(db, input, plan.wouldCreate, producerMetadata)
   const deactivated = await softDeactivateAttendanceGroupFixedScheduleManagedRows(db, input, deactivateIds)
+
+  // S1 daily compliance cap: project after BOTH insert + deactivate so the resolver sees the final
+  // active set (stale managed rows already deactivated). Throw → txn rollback → 422 on any over-cap day.
+  for (const targetUserId of new Set(plan.wouldCreate.map((item) => item.userId))) {
+    await enforceShiftComplianceCap(db, {
+      orgId: input.orgId,
+      userId: targetUserId,
+      fromDate: input.startDate,
+      toDate: input.endDate,
+    })
+  }
 
   return {
     ok: true,
@@ -13221,6 +13244,87 @@ async function loadAttendanceComprehensivePlannedMinutesByUser(db, orgId, userId
     plannedDetailsByUser.set(userId, planned)
   }
   return { plannedMinutesByUser, plannedDetailsByUser }
+}
+
+// Shift-compliance engine (design-lock #2213). S1 = DAILY cap, block-on-save. Thrown inside an
+// assignment-save transaction (after the write, before commit) when a user's projected scheduled
+// minutes for any calendar day in the affected window would exceed shiftCompliance.dailyMaxMinutes.
+// The throw rolls the write back; each save route's catch maps it to 422 via
+// respondShiftComplianceCapExceeded. S2 will extend the same guard to weekly/monthly windows.
+class ShiftComplianceCapExceeded extends Error {
+  constructor(detail) {
+    super('Shift compliance cap exceeded')
+    this.name = 'ShiftComplianceCapExceeded'
+    this.detail = detail
+  }
+}
+
+// Bound the DAILY projection window. The assigned shift (or rotation cycle) repeats per working day,
+// so projecting at most this many days from the change still surfaces the worst single day (covers
+// all weekday types + a rotation cycle + month-boundary holidays) while keeping the in-txn read
+// bounded for open-ended / very long assignments.
+const SHIFT_COMPLIANCE_DAILY_WINDOW_DAYS = 62
+
+// Project one user's effective planned minutes per day over the affected window THROUGH the shared
+// effective-calendar resolver (loadAttendanceComprehensivePlannedMinutesByUser → the SAME compute
+// comprehensiveHours uses → no wire-vs-fixture drift; it reads BOTH shift + rotation sources and owns
+// day-level precedence). Pass the transaction as `db` so it sees the uncommitted post-write state.
+// No-op (no regression) when the daily cap is unset OR enforcement !== 'block' (warn is persisted but
+// inert in v1). Throws ShiftComplianceCapExceeded when any day exceeds the cap.
+async function enforceShiftComplianceCap(db, { orgId, userId, fromDate, toDate }) {
+  const settings = await getSettings(db)
+  const compliance = settings?.shiftCompliance
+  const dailyCap = compliance?.dailyMaxMinutes
+  if (compliance?.enforcement !== 'block' || dailyCap == null || !userId) return
+  // Use the lenient normalizer: PUT paths pass `existing.start_date`/`end_date`, which pg returns as
+  // Date objects (normalizeDateOnlyStrict only accepts 'YYYY-MM-DD' strings → would silently skip).
+  const from = normalizeDateOnly(fromDate)
+  if (!from) return
+  const explicitTo = normalizeDateOnly(toDate)
+  const boundedTo = addDaysToDateKey(from, SHIFT_COMPLIANCE_DAILY_WINDOW_DAYS) || from
+  const to = explicitTo && explicitTo >= from && explicitTo < boundedTo ? explicitTo : boundedTo
+  const { plannedDetailsByUser } = await loadAttendanceComprehensivePlannedMinutesByUser(
+    db,
+    orgId,
+    [userId],
+    { from, to },
+  )
+  const detail = plannedDetailsByUser.get(userId)
+  // The per-day breakdown is `items` (array of {date, plannedMinutes, ...}); `days` on this shape is
+  // a COUNT, not the array — reading `days` here silently disables the cap.
+  const perDay = Array.isArray(detail?.items) ? detail.items : []
+  let worst = null
+  for (const day of perDay) {
+    const minutes = Number(day?.plannedMinutes ?? 0)
+    if (minutes > dailyCap && (worst == null || minutes > worst.plannedMinutes)) {
+      worst = { plannedMinutes: minutes, date: day?.date ?? null }
+    }
+  }
+  if (worst) {
+    throw new ShiftComplianceCapExceeded({
+      granularity: 'daily',
+      capMinutes: dailyCap,
+      projectedMinutes: worst.plannedMinutes,
+      periodStart: worst.date,
+      periodEnd: worst.date,
+      userId,
+    })
+  }
+}
+
+// Shared 422 responder — each assignment-save route's catch calls this first. Returns true when it
+// handled a ShiftComplianceCapExceeded (caller then returns), false otherwise.
+function respondShiftComplianceCapExceeded(res, error) {
+  if (!(error instanceof ShiftComplianceCapExceeded)) return false
+  res.status(422).json({
+    ok: false,
+    error: {
+      code: 'SHIFT_COMPLIANCE_CAP_EXCEEDED',
+      message: 'Saving this schedule would exceed the configured shift compliance cap',
+      ...error.detail,
+    },
+  })
+  return true
 }
 
 async function loadAttendanceComprehensiveActualMinutesByUser(db, orgId, userIds, period) {
@@ -21639,6 +21743,12 @@ module.exports = {
                 payload.isActive,
               ]
             )
+            await enforceShiftComplianceCap(trx, {
+              orgId,
+              userId: payload.userId,
+              fromDate: payload.startDate,
+              toDate: payload.endDate,
+            })
             return { row: rows[0] }
           })
 
@@ -21652,6 +21762,7 @@ module.exports = {
           emitEvent('attendance.rotationAssignment.created', { orgId, rotationAssignmentId: assignment.id })
           res.status(201).json({ ok: true, data: { assignment, rotation } })
         } catch (error) {
+          if (respondShiftComplianceCapExceeded(res, error)) return
           if (isDatabaseSchemaError(error)) {
             res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
             return
@@ -21775,6 +21886,12 @@ module.exports = {
                 payload.isActive,
               ]
             )
+            await enforceShiftComplianceCap(trx, {
+              orgId,
+              userId: payload.userId,
+              fromDate: payload.startDate,
+              toDate: payload.endDate,
+            })
             return { row: rows[0] }
           })
 
@@ -21788,6 +21905,7 @@ module.exports = {
           emitEvent('attendance.rotationAssignment.updated', { orgId, rotationAssignmentId: assignment.id })
           res.json({ ok: true, data: { assignment, rotation } })
         } catch (error) {
+          if (respondShiftComplianceCapExceeded(res, error)) return
           if (isDatabaseSchemaError(error)) {
             res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
             return
@@ -27926,6 +28044,7 @@ module.exports = {
           }
           res.status(201).json({ ok: true, data: result.data })
         } catch (error) {
+          if (respondShiftComplianceCapExceeded(res, error)) return
           if (isDatabaseSchemaError(error)) {
             res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
             return
@@ -28009,6 +28128,7 @@ module.exports = {
           }
           res.json({ ok: true, data: result.data })
         } catch (error) {
+          if (respondShiftComplianceCapExceeded(res, error)) return
           if (isDatabaseSchemaError(error)) {
             res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
             return
@@ -29555,6 +29675,12 @@ module.exports = {
                 payload.isActive,
               ]
             )
+            await enforceShiftComplianceCap(trx, {
+              orgId,
+              userId: payload.userId,
+              fromDate: payload.startDate,
+              toDate: payload.endDate,
+            })
             return { row: rows[0] }
           })
 
@@ -29568,6 +29694,7 @@ module.exports = {
           emitEvent('attendance.assignment.created', { orgId, assignmentId: assignment.id })
           res.status(201).json({ ok: true, data: { assignment, shift } })
         } catch (error) {
+          if (respondShiftComplianceCapExceeded(res, error)) return
           if (isDatabaseSchemaError(error)) {
             res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
             return
@@ -29691,6 +29818,12 @@ module.exports = {
                 payload.isActive,
               ]
             )
+            await enforceShiftComplianceCap(trx, {
+              orgId,
+              userId: payload.userId,
+              fromDate: payload.startDate,
+              toDate: payload.endDate,
+            })
             return { row: rows[0] }
           })
 
@@ -29704,6 +29837,7 @@ module.exports = {
           emitEvent('attendance.assignment.updated', { orgId, assignmentId: assignment.id })
           res.json({ ok: true, data: { assignment, shift } })
         } catch (error) {
+          if (respondShiftComplianceCapExceeded(res, error)) return
           if (isDatabaseSchemaError(error)) {
             res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
             return


### PR DESCRIPTION
S1 of the compliance-engine design-lock (**#2213**). **DAILY cap only** — weekly/monthly are S2. The tracker's **partial-MUST bar stands**: ③ is ✅ only when daily∧weekly∧monthly hold across all paths; this slice is not 'engine done'.

## What
- **Shared `enforceShiftComplianceCap(db, {orgId,userId,fromDate,toDate})`** projects the user's effective planned minutes per day over the affected window **through the existing `loadAttendanceComprehensivePlannedMinutesByUser`** — the SAME effective-calendar resolver + planned-minutes math `comprehensiveHours` uses (reads **both** shift + rotation sources, owns day-level precedence). No hand-rolled two-table union → no wire-vs-fixture drift.
- Runs **inside the save transaction**, after the write, reading the txn (uncommitted state); throws `ShiftComplianceCapExceeded` when any day exceeds `shiftCompliance.dailyMaxMinutes` → **txn ROLLBACK → 422 `SHIFT_COMPLIANCE_CAP_EXCEEDED`**. PUT exclude-self is automatic (txn holds the updated row). Daily window bounded to 62d for open-ended/long assignments (the shift/rotation cycle repeats → worst day still surfaced).
- Wired into **all** assignment-save paths: shift POST/PUT, rotation POST/PUT, and the shared fixed-schedule managed-insert (**apply + rebuild** — closes the bulk side-door; no known bypass window). DELETE not guarded (never increases minutes).
- **No regression**: no-op when `dailyMaxMinutes` unset OR `enforcement !== 'block'` (`warn` persisted-but-inert in v1).

## Verified before push (no local DB)
- Resolver leaves (`loadShiftAssignmentMapForUsersRange`/`loadRotationAssignmentMapForUsersRange`/`loadDefaultRule`/`loadHolidayMapByDates`) all query the **passed `db`** → trx threads through → projection sees the uncommitted write.
- connection-pool `transaction` does BEGIN→handler→COMMIT, catch→ROLLBACK→**rethrow** → throw-to-rollback + route-catch→422 holds.

## Test — real-DB route-level reverse, **every guarded path** (runs on test(20.x))
block + tiny cap → **422 with nothing persisted** on: shift POST · shift PUT (row unchanged) · rotation POST · rotation PUT (row unchanged) · fixed-schedule apply (member has no managed row) · rebuild. Plus no-regression: cap with headroom → 201; cap unset → 201.

🤖 Generated with [Claude Code](https://claude.com/claude-code)