### PR TITLE
fix(integration): Bridge Agent recovery legibility — unreachable message + stale-error retest hint (#2223)

### DIFF
--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -2148,7 +2148,7 @@ async function refreshBootstrap(): Promise<void> {
 function connectionStatusLabel(system: WorkbenchExternalSystem | null): string {
   if (!system) return '未选择'
   if (system.status === 'active') return system.lastTestedAt ? '已连接' : '可用'
-  if (system.status === 'error') return system.lastError ? `异常：${system.lastError}` : '异常'
+  if (system.status === 'error') return system.lastError ? `异常：${system.lastError}（点击"测试连接"重新激活）` : '异常（点击"测试连接"重新激活）'
   return '未启用'
 }
 
@@ -2167,11 +2167,18 @@ async function testSystem(side: WorkbenchSide): Promise<void> {
     setStatus(`${side === 'source' ? '数据源' : '目标'}系统未选择`, 'error')
     return
   }
+  const label = side === 'source' ? '数据源' : '目标'
+  // Capture the status BEFORE the test so a recovery (error → active) can be reported explicitly —
+  // result.system already carries the post-test status, so it can't tell us where we came from.
+  const priorStatus = (side === 'source' ? selectedSourceSystem.value : selectedTargetSystem.value)?.status
   try {
     const result = await testExternalSystemConnection(systemId, currentScope())
     if (result.system) replaceSystem(result.system)
-    const label = side === 'source' ? '数据源' : '目标'
-    setStatus(result.ok ? `${label}连接测试通过` : `${label}连接测试失败：${result.message || result.code || 'unknown error'}`, result.ok ? 'success' : 'error')
+    if (result.ok) {
+      setStatus(priorStatus === 'error' ? `${label}连接已恢复，已重新激活` : `${label}连接测试通过`, 'success')
+    } else {
+      setStatus(`${label}连接测试失败：${result.message || result.code || 'unknown error'}`, 'error')
+    }
   } catch (error) {
     setStatus(error instanceof Error ? error.message : String(error), 'error')
   }

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -493,6 +493,9 @@ describe('IntegrationWorkbenchView', () => {
     await flushUi(8)
     expect(container.textContent).toContain('目标连接测试失败：ERP endpoint unavailable')
     expect(container.textContent).toContain('异常：ERP endpoint unavailable')
+    // #2223: a stale `error` connection names the recovery action, so an operator retests it rather than
+    // assuming the dry-run itself is broken.
+    expect(container.textContent).toContain('点击"测试连接"重新激活')
     expect(container.textContent).toContain('不要手写 /grid 或 /spreadsheets/standard_materials')
     const refreshStagingLinkButton = container.querySelector('[data-testid="refresh-staging-link-standard_materials"]') as HTMLButtonElement
     expect(refreshStagingLinkButton.disabled).toBe(false)

--- a/plugins/plugin-integration-core/__tests__/bridge-agent-readonly-adapter.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/bridge-agent-readonly-adapter.test.cjs
@@ -211,6 +211,49 @@ async function main() {
     UnsupportedAdapterOperationError,
   )
 
+  // --- 7. A down Bridge Agent (unreachable localhost) → clear operator message, not generic fetch fail (#2223)
+  // The fixture throws the VERIFIED real undici shape on a dead port: `TypeError: fetch failed`
+  // (cause.code / cause.errors are NOT populated on every Node version → detection keys on the message,
+  // with codes as enrichment; the fixture matches the verified shape so test ≡ production).
+  {
+    const fetchFailed = () => {
+      const err = new TypeError('fetch failed')
+      err.cause = new Error('connect ECONNREFUSED 127.0.0.1:19091')
+      throw err
+    }
+    const downAgent = createBridgeAgentReadonlyAdapter({ system: createSystem(), fetchImpl: fetchFailed })
+
+    const test = await downAgent.testConnection()
+    assert.equal(test.ok, false, 'unreachable agent → connection test red')
+    assert.equal(test.connected, false)
+    assert.equal(test.code, 'BRIDGE_AGENT_UNREACHABLE', 'unreachable surfaces a specific code, not a generic fetch failure')
+    assert.match(test.message, /not reachable/i, 'message names the unreachable agent')
+    assert.match(test.message, /retest the source connection/i, 'message names the recovery action')
+
+    // The same clear error reaches the objects read path (operators hit it there too, not only on test).
+    const objErr = await downAgent.listObjects().then(() => null, (e) => e)
+    assert.ok(objErr instanceof BridgeAgentReadonlyAdapterError, 'objects read wraps unreachable in the adapter error')
+    assert.equal(objErr.code, 'BRIDGE_AGENT_UNREACHABLE')
+
+    // Enrichment shapes also detected: code-bearing cause (older Node) and dual-stack AggregateError.
+    for (const [label, impl] of [
+      ['cause.code', () => { const e = new Error('boom'); e.cause = { code: 'ECONNREFUSED' }; throw e }],
+      ['cause.errors[]', () => { const e = new TypeError('x'); e.cause = { errors: [{ code: 'ECONNREFUSED' }] }; throw e }],
+    ]) {
+      const t = await createBridgeAgentReadonlyAdapter({ system: createSystem(), fetchImpl: impl }).testConnection()
+      assert.equal(t.code, 'BRIDGE_AGENT_UNREACHABLE', `unreachable detected via ${label}`)
+    }
+
+    // Negative control: a genuine HTTP error from a REACHABLE agent must NOT be mislabeled unreachable.
+    const http500 = createBridgeAgentReadonlyAdapter({
+      system: createSystem(),
+      fetchImpl: async () => jsonResponse(500, { error: { code: 'BRIDGE_DB_ERROR', message: 'boom' } }),
+    })
+    const httpErr = await http500.listObjects().then(() => null, (e) => e)
+    assert.ok(httpErr, 'a 500 from a reachable agent still errors')
+    assert.notEqual(httpErr.code, 'BRIDGE_AGENT_UNREACHABLE', 'a reachable-agent HTTP error is NOT labeled unreachable')
+  }
+
   console.log('✓ bridge-agent-readonly-adapter: BA-M2 source contract tests passed')
 }
 

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -588,6 +588,55 @@ async function testExternalSystemTestPersistsFailureAndPreservesInactive() {
   assert.equal(inactiveUpdate.lastError, null)
 }
 
+async function testExternalSystemTestClearsErrorToActiveOnSuccess() {
+  // #2223 recovery: a source that went to `error` (e.g. the Bridge Agent was down) returns to `active`
+  // on a successful retest — the symmetric lock to inactive-preservation above (error clears; inactive
+  // does NOT auto-activate).
+  const { calls, services } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        calls.push(['getExternalSystemForAdapter', input])
+        return {
+          id: input.id,
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId,
+          projectId: 'project_err',
+          name: 'Recovered Source',
+          kind: 'erp',
+          role: 'source',
+          status: 'error',
+          credentials: { bearerToken: 'secret-token' },
+        }
+      },
+    },
+    adapterRegistry: {
+      createAdapter(input) {
+        calls.push(['createAdapter', input])
+        return {
+          async testConnection() {
+            calls.push(['testConnection'])
+            return { ok: true, status: 200 }
+          },
+        }
+      },
+    },
+  })
+  const { routes } = mountRoutes(services)
+
+  const res = await invoke(routes, 'POST', '/api/integration/external-systems/:id/test', {
+    user: WRITE_USER,
+    params: { id: 'sys_err' },
+    query: { workspaceId: 'workspace_1' },
+  })
+
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.ok, true)
+  assert.equal(res.body.data.system.status, 'active', 'a successful retest clears error → active')
+  const update = findCall(calls, 'upsertExternalSystem')[1]
+  assert.equal(update.status, 'active', 'recovery persists status=active')
+  assert.equal(update.lastError, null, 'recovery clears lastError')
+}
+
 async function testExternalSystemTestRequiresSavedSystem() {
   const { calls, services } = createMockServices({
     externalSystemRegistry: {
@@ -2167,6 +2216,7 @@ async function main() {
   await testExternalSystemRoutes()
   await testExternalSystemUpsertPreservesObjectSchema()
   await testExternalSystemTestPersistsFailureAndPreservesInactive()
+  await testExternalSystemTestClearsErrorToActiveOnSuccess()
   await testExternalSystemTestRequiresSavedSystem()
   await testExternalSystemTestRedactsAdapterResultSecrets()
   await testDiscoveryRoutes()

--- a/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/pipeline-runner.test.cjs
@@ -3,7 +3,7 @@
 const assert = require('node:assert/strict')
 const path = require('node:path')
 const { createAdapterRegistry, createReadResult, createUpsertResult } = require(path.join(__dirname, '..', 'lib', 'contracts.cjs'))
-const { createPipelineRunner } = require(path.join(__dirname, '..', 'lib', 'pipeline-runner.cjs'))
+const { createPipelineRunner, assertActiveSystem } = require(path.join(__dirname, '..', 'lib', 'pipeline-runner.cjs'))
 const { createDeadLetterStore } = require(path.join(__dirname, '..', 'lib', 'dead-letter.cjs'))
 const { createWatermarkStore } = require(path.join(__dirname, '..', 'lib', 'watermark.cjs'))
 const { createRunLogger } = require(path.join(__dirname, '..', 'lib', 'run-log.cjs'))
@@ -1711,9 +1711,39 @@ async function main() {
     assert.equal(h.targetRows.size, 0, 'C2a: nothing is written when the source principal is missing')
   }
 
+  // --- C2-recovery (#2223): assertActiveSystem stale-status legibility hint ------------------
+  // A recovered-but-not-retested source sits in `error`; the run must point the operator at the
+  // retest/reactivate action (not read as "the dry-run itself broke"), while PRESERVING the
+  // {field, systemId, status} details #2205's evidence references. `inactive` gets a distinct hint
+  // (a connection test deliberately won't reactivate an inactive system). `active` does not throw.
+  {
+    assert.doesNotThrow(
+      () => assertActiveSystem({ id: 'sys_ok', status: 'active' }, 'sourceSystem'),
+      'active system passes',
+    )
+    const tryAssert = (system) => {
+      try { assertActiveSystem(system, 'sourceSystem'); return null } catch (e) { return e }
+    }
+
+    const errThrown = tryAssert({ id: 'sys_err', status: 'error' })
+    assert.ok(errThrown, 'error-status system throws')
+    assert.match(errThrown.message, /external system is not active/, 'keeps the base reason')
+    assert.match(errThrown.message, /retest\/reactivate/i, 'error status points at the retest/reactivate action')
+    assert.equal(errThrown.details.field, 'sourceSystem', 'details preserve field')
+    assert.equal(errThrown.details.systemId, 'sys_err', 'details preserve systemId (#2205 evidence)')
+    assert.equal(errThrown.details.status, 'error', 'details preserve status')
+
+    const inactiveThrown = tryAssert({ id: 'sys_inact', status: 'inactive' })
+    assert.ok(inactiveThrown, 'inactive-status system throws')
+    assert.match(inactiveThrown.message, /activate it before running/i, 'inactive status says activate')
+    assert.doesNotMatch(inactiveThrown.message, /retest/i, 'inactive must NOT tell the operator to retest (a test will not reactivate it)')
+    assert.equal(inactiveThrown.details.status, 'inactive', 'details preserve inactive status')
+  }
+
   console.log('✓ pipeline-runner: cleanse/idempotency/incremental E2E tests passed')
   console.log('✓ pipeline-runner: DF-N2-2b provenance write tests passed (14-20)')
   console.log('✓ pipeline-runner: C2a data-source bridge principal-threading tests passed')
+  console.log('✓ pipeline-runner: C2-recovery stale-status hint tests passed (#2223)')
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/lib/adapters/bridge-agent-readonly-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/bridge-agent-readonly-adapter.cjs
@@ -41,6 +41,36 @@ function isPlainObject(value) {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
 }
 
+// Network-layer codes that mean the localhost Bridge Agent endpoint is not reachable
+// (process down / wrong port / not listening) — distinct from an HTTP error the agent itself returned.
+const CONNECTION_ERROR_CODES = new Set([
+  'ECONNREFUSED', 'ECONNRESET', 'ENOTFOUND', 'EHOSTUNREACH', 'EHOSTDOWN', 'ENETUNREACH', 'EADDRNOTAVAIL', 'EPIPE',
+])
+
+// Collect error codes across the shapes Node/undici uses for a failed fetch: the error itself, its
+// `cause`, and (dual-stack localhost → AggregateError) `cause.errors[]`.
+function collectErrorCodes(error) {
+  const codes = []
+  const push = (code) => { if (typeof code === 'string') codes.push(code) }
+  if (error) push(error.code)
+  const cause = error && error.cause
+  if (cause) {
+    push(cause.code)
+    if (Array.isArray(cause.errors)) for (const inner of cause.errors) push(inner && inner.code)
+  }
+  return codes
+}
+
+// True when the failure is "the Bridge Agent endpoint is unreachable" rather than an HTTP/application
+// error. Primary signal is undici's `TypeError: fetch failed` — the verified shape on a dead localhost
+// port (where `cause.code` / `cause.errors` are NOT populated on every Node version, so they are
+// secondary enrichment, not the gate).
+function isAgentUnreachable(error) {
+  if (!error) return false
+  if (error.name === 'TypeError' && /fetch failed/i.test(String(error.message || ''))) return true
+  return collectErrorCodes(error).some((code) => CONNECTION_ERROR_CODES.has(code))
+}
+
 function requiredString(value, field) {
   if (typeof value !== 'string' || value.trim().length === 0) {
     throw new AdapterValidationError(`${field} is required`, { field })
@@ -295,6 +325,14 @@ function createBridgeAgentReadonlyAdapter({ system, fetchImpl = globalThis.fetch
         })
       }
       if (error instanceof BridgeAgentReadonlyAdapterError) throw error
+      if (isAgentUnreachable(error)) {
+        // Operator-facing: a generic "fetch failed" here means the localhost agent isn't listening, not a
+        // backend bug. Name the recovery action so the source can be retested back to `active`.
+        throw new BridgeAgentReadonlyAdapterError(
+          `Bridge Agent is not reachable at ${baseUrl} — the readonly Bridge Agent service may not be running. Start its scheduled task / process, then retest the source connection.`,
+          { code: 'BRIDGE_AGENT_UNREACHABLE', method, path },
+        )
+      }
       if (logger && typeof logger.warn === 'function') {
         logger.warn(`[plugin-integration-core] Bridge Agent request failed: ${method} ${path}`)
       }

--- a/plugins/plugin-integration-core/lib/pipeline-runner.cjs
+++ b/plugins/plugin-integration-core/lib/pipeline-runner.cjs
@@ -209,7 +209,16 @@ function assertActiveSystem(system, field) {
     throw new PipelineRunnerError(`${field} external system not found`, { field })
   }
   if (system.status && system.status !== 'active') {
-    throw new PipelineRunnerError(`${field} external system is not active`, {
+    // Stale-status legibility: an `error` source usually means a recovered-but-not-retested connection
+    // (e.g. the Bridge Agent was restarted) — point the operator at the retest/reactivate action rather
+    // than letting them think the dry-run itself broke. `inactive` is deliberate (a test won't reactivate
+    // it), so it gets a different hint.
+    const hint = system.status === 'error'
+      ? ' — the source connection last failed its test; retest/reactivate it (Workbench 测试连接) then re-run'
+      : system.status === 'inactive'
+        ? ' — the source is inactive; activate it before running'
+        : ` (status=${system.status})`
+    throw new PipelineRunnerError(`${field} external system is not active${hint}`, {
       field,
       systemId: system.id,
       status: system.status,
@@ -835,4 +844,6 @@ function createPipelineRunner(deps = {}) {
 module.exports = {
   PipelineRunnerError,
   createPipelineRunner,
+  // Exported for unit tests of the stale-status legibility hint (error→retest / inactive→activate).
+  assertActiveSystem,
 }


### PR DESCRIPTION
## Summary

Operator-recovery slice for **#2223**: when the readonly **Bridge Agent stops**, the source system goes to `error`; after the agent restarts and objects/schema read fine, the pipeline dry-run stays **blocked by the stale `error`** and the failure reads as a generic fetch error — so an operator can't tell the source just needs a retest.

**Read-only legibility only.** No K3 Save/Submit/Audit/BOM, no C3 incremental, no external write, no RBAC/auth touch.

## What changed

The error→active transition **already existed** (`resolveTestedStatus` clears `error`→`active` on a successful test and won't auto-activate `inactive`) — this slice makes the recovery **legible** and **test-locks** it. Two messages + one UI affordance:

1. **Bridge Agent unreachable → clear message (not generic fetch failure).** `requestJson` now detects a down localhost agent and throws `BRIDGE_AGENT_UNREACHABLE`: *"Bridge Agent is not reachable at … — the readonly Bridge Agent service may not be running. Start its scheduled task / process, then retest the source connection."* Detection keys on undici's **verified** `TypeError: fetch failed` (I probed a dead localhost port — `cause.code`/`cause.errors[]` are **not** populated on every Node version, so they're secondary enrichment, not the gate). Covers **both** `testConnection` and the objects/schema read path (one site).
2. **Dry-run stale error → retest hint.** `assertActiveSystem` appends *"the source connection last failed its test; retest/reactivate it (Workbench 测试连接) then re-run"* when a source sits in `error` — and a distinct *"activate it"* hint for `inactive` (a connection test deliberately won't reactivate inactive). The `{field, systemId, status}` details (#2205 references `systemId`) are preserved.
3. **Workbench affordance.** `testSystem` reports recovery explicitly (`error`→`active` ⇒ "数据源连接已恢复，已重新激活"); the `error` status label names the retest action so the readiness panel hint is actionable.

## Maps to #2223 acceptance

- ✅ Bridge Agent down → source test fails → `status=error`, **message clear** (`BRIDGE_AGENT_UNREACHABLE`)
- ✅ Bridge Agent restored → retest succeeds → `status=active` (existing `resolveTestedStatus`, now locked)
- ✅ objects/schema pass (unchanged read path; unreachable message also clear there)
- ✅ dry-run no longer reads as broken when blocked by stale error → **retest hint** points at the fix
- ✅ inactive source retest success does **NOT** auto-activate (existing guard, now locked symmetrically)

## Tests

- bridge-agent: unreachable via the verified `fetch failed` shape + `cause.code` / dual-stack `cause.errors[]` enrichment shapes + a **negative control** (reachable-agent HTTP 500 is NOT mislabeled unreachable).
- pipeline-runner: `assertActiveSystem` 3-branch hint (error→retest / inactive→activate / other→status) + details preserved.
- http-routes: explicit **error→active** recovery lock (symmetric to the existing inactive-preservation test).
- web spec: actionable error-label lock.
- **Full plugin-integration-core suite (33 files) + web spec (17) green; web type-check clean.**

The recovery-message string branch (`已恢复…`) is a trivial `priorStatus==='error'` ternary backed by the backend error→active lock; the more complex/visible readiness-hint label is the one frontend-locked.

**Leave-for-review — not auto-merging.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)