### PR TITLE
feat(attendance): ④ C1 — leave-balance grant-lot ledger + required events table (latent schema)

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260603120000_create_attendance_leave_balances.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260603120000_create_attendance_leave_balances.ts
@@ -1,0 +1,83 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists, createIndexIfNotExists } from './_patterns'
+
+const DEFAULT_ORG_ID = 'default'
+const BALANCES = 'attendance_leave_balances'
+const EVENTS = 'attendance_leave_balance_events'
+
+// ④ C1 (design-lock #2230). LATENT ledger schema only — no approve/expire hook reads or writes these
+// yet (C2+ wire the runtime accounting). Two tables:
+//   - attendance_leave_balances    : grant-LOT ledger (one row per grant; remaining_minutes is the fast
+//                                     read). Idempotency backstop = source_key NOT NULL + UNIQUE
+//                                     (org_id, source_key) — NOT source_id (a nullable back-link; a
+//                                     UNIQUE on source_id would let null manual/accrual grants double-
+//                                     credit, since Postgres allows many NULLs).
+//   - attendance_leave_balance_events : REQUIRED audit ledger — one +/- row per mutation (grant/deduct/
+//                                     expire/revoke). Created here (not an optional later slice) so every
+//                                     future mutation can record the fact a remaining_minutes change alone
+//                                     would lose (which leave request drew from which lot / what expired).
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  const balancesExists = await checkTableExists(db, BALANCES)
+  if (!balancesExists) {
+    await db.schema
+      .createTable(BALANCES)
+      .ifNotExists()
+      .addColumn('id', 'uuid', col => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('org_id', 'text', col => col.notNull().defaultTo(DEFAULT_ORG_ID))
+      .addColumn('user_id', 'text', col => col.notNull())
+      .addColumn('leave_type_code', 'text', col => col.notNull())
+      .addColumn('amount_minutes', 'integer', col => col.notNull())
+      .addColumn('remaining_minutes', 'integer', col => col.notNull())
+      .addColumn('source_type', 'text', col => col.notNull())
+      .addColumn('source_id', 'text')
+      .addColumn('source_key', 'text', col => col.notNull())
+      .addColumn('granted_at', 'timestamptz', col => col.notNull().defaultTo(sql`now()`))
+      .addColumn('expires_at', 'timestamptz')
+      .addColumn('status', 'text', col => col.notNull().defaultTo('active'))
+      .addColumn('created_at', 'timestamptz', col => col.defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', col => col.defaultTo(sql`now()`))
+      // DB-level balance invariants (design-lock #2230: 0 ≤ remaining ≤ amount) so no future code bug
+      // can persist an impossible balance (negative grant / negative or over-grant remaining).
+      .addCheckConstraint('chk_attendance_leave_balances_amount_positive', sql`amount_minutes > 0`)
+      .addCheckConstraint('chk_attendance_leave_balances_remaining_range', sql`remaining_minutes >= 0 AND remaining_minutes <= amount_minutes`)
+      .addCheckConstraint('chk_attendance_leave_balances_status', sql`status IN ('active', 'exhausted', 'expired', 'revoked')`)
+      .execute()
+  }
+  // The double-credit backstop. A unique INDEX (not just a constraint) so C2 can use
+  // INSERT ... ON CONFLICT (org_id, source_key) DO NOTHING for idempotent crediting.
+  await createIndexIfNotExists(db, 'uq_attendance_leave_balances_org_source_key', BALANCES, ['org_id', 'source_key'], { unique: true })
+  await createIndexIfNotExists(db, 'idx_attendance_leave_balances_user_type', BALANCES, ['org_id', 'user_id', 'leave_type_code'])
+  await createIndexIfNotExists(db, 'idx_attendance_leave_balances_active_expiry', BALANCES, ['org_id', 'status', 'expires_at'])
+
+  const eventsExists = await checkTableExists(db, EVENTS)
+  if (!eventsExists) {
+    await db.schema
+      .createTable(EVENTS)
+      .ifNotExists()
+      .addColumn('id', 'uuid', col => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('org_id', 'text', col => col.notNull().defaultTo(DEFAULT_ORG_ID))
+      .addColumn('user_id', 'text', col => col.notNull())
+      .addColumn('balance_id', 'uuid', col => col.notNull().references(`${BALANCES}.id`).onDelete('cascade'))
+      .addColumn('event_type', 'text', col => col.notNull())
+      .addColumn('delta_minutes', 'integer', col => col.notNull())
+      .addColumn('source_type', 'text')
+      .addColumn('source_id', 'text')
+      .addColumn('occurred_at', 'timestamptz', col => col.notNull().defaultTo(sql`now()`))
+      .addColumn('created_at', 'timestamptz', col => col.defaultTo(sql`now()`))
+      // events are the +/- audit truth (design-lock #2230): event_type enum + the locked sign per type
+      // (grant > 0; deduct/expire/revoke < 0). The sign check also forbids delta_minutes = 0.
+      .addCheckConstraint('chk_attendance_leave_balance_events_event_type', sql`event_type IN ('grant', 'deduct', 'expire', 'revoke')`)
+      .addCheckConstraint('chk_attendance_leave_balance_events_delta_sign', sql`(event_type = 'grant' AND delta_minutes > 0) OR (event_type IN ('deduct', 'expire', 'revoke') AND delta_minutes < 0)`)
+      .execute()
+  }
+  await createIndexIfNotExists(db, 'idx_attendance_leave_balance_events_balance', EVENTS, ['org_id', 'balance_id'])
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  // events first (FK references balances)
+  await db.schema.dropTable(EVENTS).ifExists().execute()
+  await db.schema.dropTable(BALANCES).ifExists().execute()
+}

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -2828,6 +2828,98 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('④ C1 leave-balance ledger — source_key uniqueness + not-null backstop + events FK (latent schema)', async () => {
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const pool = new Pool({ connectionString: dbUrl })
+    const runSuffix = Date.now().toString(36)
+    const orgId = 'default'
+    const userId = `c1-${runSuffix}`
+    const sourceKey = `overtime_conversion:c1-${runSuffix}`
+    let balanceId: string | undefined
+    try {
+      // A grant lot inserts.
+      const ins = await pool.query(
+        `INSERT INTO attendance_leave_balances
+           (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_id, source_key)
+         VALUES ($1, $2, 'comp_time', 480, 480, 'overtime_conversion', $3, $4) RETURNING id`,
+        [orgId, userId, `req-${runSuffix}`, sourceKey],
+      )
+      balanceId = ins.rows[0]?.id as string | undefined
+      expect(balanceId).toBeTruthy()
+
+      // (1) double-credit backstop: same (org_id, source_key) -> unique violation (23505).
+      let dupErr: { code?: string } | null = null
+      try {
+        await pool.query(
+          `INSERT INTO attendance_leave_balances
+             (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_key)
+           VALUES ($1, $2, 'comp_time', 60, 60, 'overtime_conversion', $3)`,
+          [orgId, userId, sourceKey],
+        )
+      } catch (e) { dupErr = e as { code?: string } }
+      expect(dupErr?.code).toBe('23505')
+
+      // (2) source_key is the backstop precisely because it is NOT NULL -> null rejected (23502).
+      let nullErr: { code?: string } | null = null
+      try {
+        await pool.query(
+          `INSERT INTO attendance_leave_balances
+             (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_key)
+           VALUES ($1, $2, 'comp_time', 60, 60, 'manual_grant', NULL)`,
+          [orgId, `${userId}-n`],
+        )
+      } catch (e) { nullErr = e as { code?: string } }
+      expect(nullErr?.code).toBe('23502')
+
+      // (3) events ledger row references the lot; a dangling balance_id -> FK violation (23503).
+      const ev = await pool.query(
+        `INSERT INTO attendance_leave_balance_events
+           (org_id, user_id, balance_id, event_type, delta_minutes, source_type, source_id)
+         VALUES ($1, $2, $3, 'grant', 480, 'overtime_conversion', $4) RETURNING id`,
+        [orgId, userId, balanceId, `req-${runSuffix}`],
+      )
+      expect(ev.rows[0]?.id).toBeTruthy()
+      let fkErr: { code?: string } | null = null
+      try {
+        await pool.query(
+          `INSERT INTO attendance_leave_balance_events
+             (org_id, user_id, balance_id, event_type, delta_minutes)
+           VALUES ($1, $2, '00000000-0000-4000-8000-000000000000', 'deduct', -60)`,
+          [orgId, userId],
+        )
+      } catch (e) { fkErr = e as { code?: string } }
+      expect(fkErr?.code).toBe('23503')
+
+      // (4) DB-level balance math + enum invariants (#2230) — every impossible balance is a 23514
+      // check_violation, so a future code bug can't persist one. Each insert is valid except the
+      // field under test (distinct user/source_key so unique/not-null don't fire first).
+      const rejects = async (text: string, params: unknown[], code: string, label: string) => {
+        let err: { code?: string } | null = null
+        try { await pool.query(text, params) } catch (e) { err = e as { code?: string } }
+        expect({ label, code: err?.code }).toEqual({ label, code })
+      }
+      const balanceInsert = `INSERT INTO attendance_leave_balances
+        (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_key, status)
+        VALUES ($1, $2, 'comp_time', $3, $4, 'manual_grant', $5, $6)`
+      await rejects(balanceInsert, [orgId, `${userId}-a`, 0, 0, `mk:${runSuffix}:a`, 'active'], '23514', 'amount_minutes must be > 0')
+      await rejects(balanceInsert, [orgId, `${userId}-b`, 10, -5, `mk:${runSuffix}:b`, 'active'], '23514', 'remaining_minutes must be >= 0')
+      await rejects(balanceInsert, [orgId, `${userId}-c`, 10, 20, `mk:${runSuffix}:c`, 'active'], '23514', 'remaining_minutes must be <= amount_minutes')
+      await rejects(balanceInsert, [orgId, `${userId}-d`, 10, 10, `mk:${runSuffix}:d`, 'bogus'], '23514', 'status must be a valid enum')
+
+      const eventInsert = `INSERT INTO attendance_leave_balance_events
+        (org_id, user_id, balance_id, event_type, delta_minutes) VALUES ($1, $2, $3, $4, $5)`
+      await rejects(eventInsert, [orgId, userId, balanceId, 'bogus', 10], '23514', 'event_type must be a valid enum')
+      await rejects(eventInsert, [orgId, userId, balanceId, 'grant', 0], '23514', 'delta_minutes <> 0 (grant)')
+      await rejects(eventInsert, [orgId, userId, balanceId, 'grant', -5], '23514', 'grant delta must be > 0')
+      await rejects(eventInsert, [orgId, userId, balanceId, 'deduct', 5], '23514', 'deduct delta must be < 0')
+    } finally {
+      await pool.query('DELETE FROM attendance_leave_balance_events WHERE user_id LIKE $1', [`c1-${runSuffix}%`]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_leave_balances WHERE user_id LIKE $1', [`c1-${runSuffix}%`]).catch(() => undefined)
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('rejects non-UUID shift references for rotation rules, including UUID-like shift names', async () => {
     if (!baseUrl) return
 

--- a/packages/core-backend/tests/unit/attendance-leave-balance-ledger-migration.test.ts
+++ b/packages/core-backend/tests/unit/attendance-leave-balance-ledger-migration.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { describe, expect, it } from 'vitest'
+
+// ④ C1 (design-lock #2230) — DB-free guard that the migration DEFINES the locked ledger invariants.
+// The real-DB constraint enforcement is covered by the attendance integration suite; this always-on
+// unit guard catches a future edit that drops the backstop or makes the events table optional.
+const MIGRATION = resolve(
+  __dirname,
+  '../../src/db/migrations/zzzz20260603120000_create_attendance_leave_balances.ts',
+)
+const src = readFileSync(MIGRATION, 'utf8')
+
+describe('④ C1 attendance leave-balance ledger migration', () => {
+  it('creates both the grant-lot ledger and the required events audit table', () => {
+    expect(src).toContain("'attendance_leave_balances'")
+    expect(src).toContain("'attendance_leave_balance_events'")
+    // down() drops events before balances (FK order)
+    expect(src).toMatch(/dropTable\(EVENTS\)[\s\S]*dropTable\(BALANCES\)/)
+  })
+
+  it('locks the double-credit backstop on source_key (NOT NULL + UNIQUE(org_id, source_key)), not source_id', () => {
+    expect(src).toMatch(/addColumn\('source_key', 'text', col => col\.notNull\(\)\)/)
+    // source_id stays a nullable back-link — explicitly NOT notNull
+    expect(src).toMatch(/addColumn\('source_id', 'text'\)/)
+    // the uniqueness is a unique index over (org_id, source_key)
+    expect(src).toMatch(/uq_attendance_leave_balances_org_source_key[\s\S]*\['org_id', 'source_key'\][\s\S]*unique: true/)
+  })
+
+  it('events ledger carries the +/- audit shape and cascades from its lot', () => {
+    expect(src).toContain("addColumn('balance_id'")
+    expect(src).toContain('${BALANCES}.id')
+    expect(src).toContain(".onDelete('cascade')")
+    for (const col of ['event_type', 'delta_minutes', 'occurred_at']) {
+      expect(src).toContain(`addColumn('${col}'`)
+    }
+  })
+
+  it('locks the balance math + enum invariants as DB CHECK constraints (#2230)', () => {
+    expect(src).toContain('amount_minutes > 0')
+    expect(src).toContain('remaining_minutes >= 0 AND remaining_minutes <= amount_minutes')
+    expect(src).toContain("status IN ('active', 'exhausted', 'expired', 'revoked')")
+    expect(src).toContain("event_type IN ('grant', 'deduct', 'expire', 'revoke')")
+    // grant > 0; deduct/expire/revoke < 0 (also forbids delta_minutes = 0)
+    expect(src).toContain("event_type = 'grant' AND delta_minutes > 0")
+    expect(src).toContain("event_type IN ('deduct', 'expire', 'revoke') AND delta_minutes < 0")
+  })
+})


### PR DESCRIPTION
**C1** of the comp-time/leave-expiry design-lock (**#2230**). **Latent schema only** — nothing reads or writes these tables yet; C2+ wire the OT-approval credit and expiry hooks.

## ⚠️ C0/C1 boundary (precondition, not postmortem)
- **Lands on main + validates on CI's ephemeral DB** (migrations run there).
- **NOT staging-validated by this PR.** Staging smoke is **blocked by C0** — the staging migration-ledger alignment (#2226 runbook) — and the runtime accounting (C2) waits on C0 too. This states the #2226 trap as a gate up front.

## Schema
Migration `zzzz20260603120000_create_attendance_leave_balances` (sorts after the current top `…20260530…`; references no other attendance table → clean fresh replay):
- **`attendance_leave_balances`** — grant-LOT ledger. **Double-credit backstop = `source_key` NOT NULL + `UNIQUE(org_id, source_key)` as a unique INDEX** (so C2 can `INSERT … ON CONFLICT (org_id, source_key) DO NOTHING`) — **not `source_id`** (a nullable back-link; a unique on it would let null manual/accrual grants double-credit, since Postgres allows many NULLs).
- **`attendance_leave_balance_events`** — **required** audit ledger (built here, not deferred): one +/- row per mutation, `balance_id` FK `ON DELETE CASCADE`.
- Idempotent (`checkTableExists` + `ifNotExists` + `createIndexIfNotExists`); `down()` drops events then balances.

## Tests
- **Real-DB** (attendance integration suite): the three locked failure modes by SQLSTATE — dup `(org_id, source_key)` → 23505, null `source_key` → 23502, dangling `balance_id` → 23503.
- **DB-free unit guard**: the migration defines the locked invariants (both tables, `source_key` NOT NULL, unique on `(org_id, source_key)`, events audit shape + cascade).

🤖 Generated with [Claude Code](https://claude.com/claude-code)