### PR TITLE
docs(multitable): clean live refs to deleted dead sample view plugins (#2224 follow-up)

### DIFF
--- a/docs/multitable-view-compat-matrix.md
+++ b/docs/multitable-view-compat-matrix.md
@@ -14,8 +14,8 @@ No view uses `/api/views/:viewId/data` for multitable data.
 | Grid | `meta_views.config` JSON | No | `plugin-view-grid` (component only, no config provider) |
 | Form | `meta_views.config` JSON | No | None |
 | Kanban | `meta_views.config` JSON + `kanban_configs` table | Yes (legacy fallback in `views.ts`) | None |
-| Gallery | `meta_views.config` JSON + `gallery_configs` table | Yes | `plugin-view-gallery` (GalleryViewConfigProvider) |
-| Calendar | `meta_views.config` JSON + `calendar_configs` table | Yes | `plugin-view-calendar` (CalendarViewConfigProvider) |
+| Gallery | `meta_views.config` JSON + `gallery_configs` table | Yes | None (sample `plugin-view-gallery` removed in #2224 — it never loaded: no manifest) |
+| Calendar | `meta_views.config` JSON + `calendar_configs` table | Yes | None (sample `plugin-view-calendar` removed in #2224 — it never loaded: no manifest) |
 | Timeline | `meta_views.config` JSON | No | `plugin-view-gantt` (component only) |
 
 ## Field Rendering Consistency
@@ -50,11 +50,9 @@ The legacy bridge at `/api/views/:viewId/config` serves the old Univer spreadshe
 Multitable views do NOT depend on it for data fetching or rendering.
 It is relevant only for:
 - Kanban: reads `kanban_configs` table as fallback when no plugin provider is registered
-- Gallery: `plugin-view-gallery` registers a ViewConfigProvider
-- Calendar: `plugin-view-calendar` registers a ViewConfigProvider
+- Gallery / Calendar: the sample `plugin-view-gallery` / `plugin-view-calendar` provider plugins were **removed in #2224** (they never loaded — no manifest), so no plugin provider is registered for these; their config lives in `meta_views.config` + the `gallery_configs` / `calendar_configs` tables.
 
-Any changes to multitable view rendering do NOT need to regression-test the legacy bridge,
-unless the change also modifies the plugin view config providers.
+Any changes to multitable view rendering do NOT need to regression-test the legacy bridge.
 
 ## Conclusion
 

--- a/docs/verification-index.md
+++ b/docs/verification-index.md
@@ -781,12 +781,11 @@ Entry points:
   - Run: `pnpm --filter @metasheet/core-backend test:integration`
   - Report: `docs/verification-integration-2025-12-28.md`
 
-- Plugin integration (Kanban):
-  - Run: `SKIP_PLUGINS=false pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/kanban-plugin.test.ts tests/integration/kanban.mvp.api.test.ts tests/integration/plugins-api.contract.test.ts --reporter=dot`
-  - Report: `docs/verification-kanban-plugins-2025-12-28.md`
+- Plugin integration (Kanban): _sample `plugin-view-kanban` + its 3 fixture tests removed in #2224 — no longer runnable._
+  - Historical report: `docs/verification-kanban-plugins-2025-12-28.md`
 
 - Plugin scan suppression (non-plugin tests):
-  - Run: `SKIP_PLUGINS=false pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/rooms.basic.test.ts tests/integration/snapshot-protection.test.ts tests/integration/kanban-plugin.test.ts tests/integration/kanban.mvp.api.test.ts tests/integration/plugins-api.contract.test.ts --reporter=dot`
+  - Run: `SKIP_PLUGINS=false pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/rooms.basic.test.ts tests/integration/snapshot-protection.test.ts --reporter=dot` _(kanban-plugin/kanban.mvp.api/plugins-api.contract tests removed in #2224)_
   - Report: `docs/verification-plugin-scan-suppression-2025-12-28.md`
 
 - Editable demo smoke (Grid + Kanban drag/write-back):


### PR DESCRIPTION
Tiny docs-only follow-up to #2224 (which deleted `plugins/plugin-view-kanban`/`gallery`/`calendar` + their 3 dormant fixture tests). Trims the **two docs that still carried live (now-broken) references**; frozen historical archive docs are intentionally left as past-tense records.

- **`docs/verification-index.md`** — the "Plugin integration (Kanban)" run-command listed only the 3 deleted tests → replaced with a "removed in #2224, no longer runnable" note (keeps the historical-report pointer). The "Plugin scan suppression" run-command dropped the 3 deleted test paths (`rooms.basic` + `snapshot-protection` still run).
- **`docs/multitable-view-compat-matrix.md`** — the Gallery/Calendar "Plugin Provider" column + Legacy-Bridge notes attributed ViewConfigProviders to the deleted plugins → now "None (sample removed in #2224; never loaded — no manifest)".

Docs-only; no code/test/config change. Field-read-gate arc remains 12/12 + §3 change gate live; only the deferred `AllowedFieldIds` brand remains.

🤖 Generated with [Claude Code](https://claude.com/claude-code)