### PR TITLE
fix(data-sources): complete MySQL schema discovery for DF bridge

### DIFF
--- a/packages/core-backend/src/data-adapters/MySQLAdapter.ts
+++ b/packages/core-backend/src/data-adapters/MySQLAdapter.ts
@@ -471,10 +471,10 @@ export class MySQLAdapter extends BaseDataAdapter {
         IS_NULLABLE as is_nullable,
         COLUMN_DEFAULT as column_default,
         CHARACTER_MAXIMUM_LENGTH as max_length,
-        NUMERIC_PRECISION as precision,
-        NUMERIC_SCALE as scale,
-        COLUMN_COMMENT as comment,
-        EXTRA as extra
+        NUMERIC_PRECISION as numeric_precision,
+        NUMERIC_SCALE as numeric_scale,
+        COLUMN_COMMENT as column_comment,
+        EXTRA as extra_info
       FROM information_schema.COLUMNS
       WHERE TABLE_SCHEMA = ?
         AND TABLE_NAME = ?
@@ -487,10 +487,10 @@ export class MySQLAdapter extends BaseDataAdapter {
       is_nullable: string
       column_default: string | null
       max_length: number | null
-      precision: number | null
-      scale: number | null
-      comment: string | null
-      extra: string
+      numeric_precision: number | null
+      numeric_scale: number | null
+      column_comment: string | null
+      extra_info: string
     }>(query, [database, table])
 
     return result.data.map(row => ({
@@ -498,8 +498,8 @@ export class MySQLAdapter extends BaseDataAdapter {
       type: this.formatColumnType(row),
       nullable: row.is_nullable === 'YES',
       defaultValue: row.column_default,
-      autoIncrement: row.extra.includes('auto_increment'),
-      comment: row.comment || undefined
+      autoIncrement: row.extra_info.includes('auto_increment'),
+      comment: row.column_comment || undefined
     }))
   }
 
@@ -603,17 +603,17 @@ export class MySQLAdapter extends BaseDataAdapter {
   private formatColumnType(column: {
     data_type: string
     max_length: number | null
-    precision: number | null
-    scale: number | null
+    numeric_precision: number | null
+    numeric_scale: number | null
   }): string {
     let type = column.data_type
 
     if (column.max_length && ['varchar', 'char'].includes(column.data_type)) {
       type += `(${column.max_length})`
-    } else if (column.precision && ['decimal', 'numeric'].includes(column.data_type)) {
-      type += `(${column.precision}`
-      if (column.scale) {
-        type += `,${column.scale}`
+    } else if (column.numeric_precision && ['decimal', 'numeric'].includes(column.data_type)) {
+      type += `(${column.numeric_precision}`
+      if (column.numeric_scale) {
+        type += `,${column.numeric_scale}`
       }
       type += ')'
     }

--- a/packages/core-backend/tests/unit/data-source-mysql-schema.test.ts
+++ b/packages/core-backend/tests/unit/data-source-mysql-schema.test.ts
@@ -1,0 +1,97 @@
+import { describe, expect, it } from 'vitest'
+
+import { MySQLAdapter } from '../../src/data-adapters/MySQLAdapter'
+import type { DataSourceConfig, QueryResult } from '../../src/data-adapters/BaseAdapter'
+
+const cfg: DataSourceConfig = {
+  id: 'mysql_schema_test',
+  name: 'mysql_schema_test',
+  type: 'mysql',
+  connection: { database: 'stockorder' },
+  options: { autoConnect: false },
+}
+
+class FakeMySQLAdapter extends MySQLAdapter {
+  queries: Array<{ sql: string; params?: unknown[] }> = []
+
+  override async query<T = Record<string, unknown>>(sql: string, params?: unknown[]): Promise<QueryResult<T>> {
+    this.queries.push({ sql, params })
+    return {
+      data: [
+        {
+          column_name: 'id',
+          data_type: 'int',
+          is_nullable: 'NO',
+          column_default: null,
+          max_length: null,
+          numeric_precision: 10,
+          numeric_scale: 0,
+          column_comment: 'primary key',
+          extra_info: 'auto_increment',
+        },
+        {
+          column_name: 'amount',
+          data_type: 'decimal',
+          is_nullable: 'YES',
+          column_default: null,
+          max_length: null,
+          numeric_precision: 12,
+          numeric_scale: 2,
+          column_comment: 'order amount',
+          extra_info: '',
+        },
+        {
+          column_name: 'sku',
+          data_type: 'varchar',
+          is_nullable: 'NO',
+          column_default: '',
+          max_length: 64,
+          numeric_precision: null,
+          numeric_scale: null,
+          column_comment: '',
+          extra_info: '',
+        },
+      ] as T[],
+    }
+  }
+}
+
+describe('MySQLAdapter schema metadata', () => {
+  it('uses non-reserved metadata aliases and maps returned column fields', async () => {
+    const adapter = new FakeMySQLAdapter(cfg)
+    const columns = await adapter.getColumns('stock_info', 'stockorder')
+
+    expect(adapter.queries).toHaveLength(1)
+    expect(adapter.queries[0].sql).toContain('NUMERIC_PRECISION as numeric_precision')
+    expect(adapter.queries[0].sql).toContain('NUMERIC_SCALE as numeric_scale')
+    expect(adapter.queries[0].sql).toContain('COLUMN_COMMENT as column_comment')
+    expect(adapter.queries[0].sql).not.toMatch(/\bas precision\b/i)
+    expect(adapter.queries[0].params).toEqual(['stockorder', 'stock_info'])
+    expect(columns).toEqual([
+      {
+        name: 'id',
+        type: 'int',
+        nullable: false,
+        defaultValue: null,
+        autoIncrement: true,
+        comment: 'primary key',
+      },
+      {
+        name: 'amount',
+        type: 'decimal(12,2)',
+        nullable: true,
+        defaultValue: null,
+        autoIncrement: false,
+        comment: 'order amount',
+      },
+      {
+        name: 'sku',
+        type: 'varchar(64)',
+        nullable: false,
+        defaultValue: '',
+        autoIncrement: false,
+        comment: undefined,
+      },
+    ])
+  })
+})

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -901,6 +901,47 @@ async function testDiscoveryRoutes() {
   assert.equal(missingObject.body.error.code, 'OBJECT_REQUIRED')
 }
 
+async function testDiscoveryObjectsRouteDoesNotDefaultTruncateAdapterObjects() {
+  const largeObjects = Array.from({ length: 109 }, (_, index) => ({
+    name: index === 87 ? 'stockorder.stock_info' : `stockorder.table_${String(index + 1).padStart(3, '0')}`,
+    label: `table ${index + 1}`,
+    operations: ['read'],
+    accessToken: index === 0 ? 'secret-token-should-not-leak' : undefined,
+  }))
+  const { services } = createMockServices({
+    adapterRegistry: {
+      createAdapter() {
+        return {
+          async listObjects() {
+            return largeObjects
+          },
+        }
+      },
+    },
+  })
+  const { routes } = mountRoutes(services)
+
+  const res = await invoke(routes, 'GET', '/api/integration/external-systems/:id/objects', {
+    user: READ_USER,
+    params: { id: 'mysql_bridge_1' },
+    query: { workspaceId: 'workspace_1' },
+  })
+
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.length, 109, 'object discovery returns the full metadata list, not the default 50-item redaction cap')
+  assert.ok(
+    res.body.data.some((object) => object.name === 'stockorder.stock_info'),
+    'business tables beyond the first 50 stay discoverable',
+  )
+  assert.equal(
+    res.body.data.some((object) => typeof object === 'string' && object.includes('more items truncated')),
+    false,
+    'object discovery does not include the default array truncation marker',
+  )
+  assert.equal(JSON.stringify(res.body).includes('secret-token-should-not-leak'), false, 'object metadata still runs through redaction')
+  assert.equal(res.body.data[0].accessToken, '[redacted]')
+}
+
 async function testDiscoveryRoutesRejectUnknownSystem() {
   const { calls, services } = createMockServices()
   services.externalSystemRegistry.getExternalSystemForAdapter = async (input) => {
@@ -2129,6 +2170,7 @@ async function main() {
   await testExternalSystemTestRequiresSavedSystem()
   await testExternalSystemTestRedactsAdapterResultSecrets()
   await testDiscoveryRoutes()
+  await testDiscoveryObjectsRouteDoesNotDefaultTruncateAdapterObjects()
   await testDiscoveryRoutesRejectUnknownSystem()
   await testDocumentTemplateValidation()
   await testPipelineRoutes()

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -32,6 +32,7 @@ const ROUTES = [
   ['GET', '/api/integration/dead-letters', 'deadLettersList'],
   ['POST', '/api/integration/dead-letters/:id/replay', 'deadLettersReplay'],
 ]
+const EXTERNAL_SYSTEM_OBJECTS_MAX_ITEMS = 1000
 const { sanitizeIntegrationPayload, scrubSecretStringValue } = require('./payload-redaction.cjs')
 const { getPath, setPath, transformRecord } = require('./transform-engine.cjs')
 // DF-T1-0/DF-T1: compose the no-write preview through the SAME K3 Save-body composer the
@@ -1057,10 +1058,13 @@ function createHandlers(services) {
         ? await adapter.listObjects()
         : []
       const documentTemplateObjects = listDocumentTemplates(system)
-      return sendOk(res, sanitizeIntegrationPayload([
+      const objects = [
         ...(Array.isArray(adapterObjects) ? adapterObjects : []),
         ...documentTemplateObjects,
-      ]))
+      ]
+      return sendOk(res, sanitizeIntegrationPayload(objects, {
+        maxArrayItems: EXTERNAL_SYSTEM_OBJECTS_MAX_ITEMS,
+      }))
     },
 
     async externalSystemSchema(req, res) {


### PR DESCRIPTION
## Summary

Follow-up for #2227 / #2205 entity-machine validation. MySQL readonly connectivity and guarded reads passed on the entity machine, but Data Factory consumption still had two blockers:

- MySQL column metadata came back empty on the adapter schema path for schema-qualified objects such as `stockorder.stock_info`.
- `/api/integration/external-systems/:id/objects` default-redacted the adapter object list at 50 items, hiding business tables after the first page even though the underlying data source schema listed 109 tables.

This PR fixes both without changing read/select/write behavior.

## Changes

- Use MySQL metadata aliases that avoid the reported reserved/compatibility issue:
  - `numeric_precision`, `numeric_scale`, `column_comment`, `extra_info`.
- Add a MySQL schema metadata unit test that locks the aliases and verifies mapped column output.
- Keep integration object discovery sanitized, but apply a route-local metadata cap (`1000`) instead of the global payload default (`50`).
- Add an integration route regression test with 109 adapter objects, including a business table beyond item 50 and a redacted secret-shaped field.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/data-source-mysql-schema.test.ts tests/unit/data-source-scope.test.ts tests/unit/data-source-identifier-quoting.test.ts --watch=false`
- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- `node plugins/plugin-integration-core/__tests__/data-source-sql-readonly-source-adapter.test.cjs`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`

Negative controls:

- Reverting `NUMERIC_PRECISION as numeric_precision` back to `as precision` fails the new MySQL schema test.
- Removing the route-local object-list cap makes the new route test return 51 items instead of 109, reproducing the entity-machine truncation.

## Boundaries

- Plugin/data-source only.
- Read-only behavior preserved.
- `read` / `select` untouched.
- No K3 / RBAC / auth changes.
- No C3/C6 runtime work.
