### PR TITLE
docs(multitable): tick A6-2 suspend/resume LANDED in the A6 execution plan

### DIFF
--- a/docs/development/multitable-automation-a6-execution-plan-20260601.md
+++ b/docs/development/multitable-automation-a6-execution-plan-20260601.md
@@ -131,7 +131,12 @@ only missing link.
 
 ---
 
-## 2. A6-2 suspend/resume — PLAN-LEVEL (design deferred to its scout)
+## 2. A6-2 suspend/resume — ✅ LANDED 2026-06-03 (#2236 design-lock + #2237 impl)
+
+> **✅ LANDED 2026-06-03 — PR #2237 (squash `c363a78db`); design-lock #2236.** Admin-gated v1, webhook-
+> first (delay/timer + worker/claim still deferred/red-lined). As-built detail + the 2 review rounds live
+> in `multitable-automation-a6-2-suspend-resume-{design,verification}-20260603.md` — **not re-derived
+> here**. Remaining sub-step = A6-2b frontend (separate opt-in). Original plan retained below for the record.
 
 - **Adds:** the `suspended` C1 status, a resume token, and an **external-event/webhook
   resume endpoint first**; delay/timer resume (and the durable scheduler + worker/claim
@@ -207,5 +212,6 @@ only missing link.
 - Docs-only.
 - References the TODO checklist for status (does not re-derive or duplicate it) and the
   A6-0/A6-1 scouts for test surface and runtime rationale.
-- Only A6-1 enable-writer is build-ready; A6-2 … A6-5 remain design-deferred and
-  demand-gated, with no schema/mechanics designed here.
+- A6-1 enable-writer **landed** (#2130/#2191/#2193) and A6-2 suspend/resume **landed**
+  2026-06-03 (#2236 design-lock + #2237 impl, admin-gated v1); A6-3 … A6-5 remain
+  design-deferred and demand-gated, with no schema/mechanics designed here.


### PR DESCRIPTION
Updates the A6 execution-plan/TODO tracker to match main now that **A6-2 suspend/resume landed** (#2236 design-lock + #2237 impl, admin-gated v1, squash `c363a78db`).

- **§2 A6-2:** PLAN-LEVEL → **✅ LANDED**, with the as-built summary (out-of-band D2 — legacy execution stays `running`; `wait_for_callback` suspends; admin-gated `POST /automation/resume` re-derives + action-fingerprint rule-drift guard + single-use token claim; token **admin-detail-only**; webhook-first, delay/timer + worker still deferred; real-DB T1–T10). Original plan text retained for the record.
- **Closing summary:** A6-1 + A6-2 landed; **A6-3** (branch/parallel DAG) · **A6-4** (BPMN compile/preview, never runtime) · **A6-5** (approval-as-job) remain design-deferred + demand-gated.

Docs-only; no code/contract change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
