### PR TITLE
feat(multitable): numeric sort + range filters for currency/percent/rating (typed query Slice 1)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -170,6 +170,7 @@ jobs:
             tests/integration/multitable-permission-golden-d3d1.test.ts \
             tests/integration/multitable-permission-golden-d3d2.test.ts \
             tests/integration/multitable-view-aggregate.test.ts \
+            tests/integration/multitable-typed-query-numeric-view.test.ts \
             tests/integration/multitable-formula-dryrun.test.ts \
             tests/integration/multitable-records-read-field-mask.test.ts \
             tests/integration/multitable-readpath-search-filter-field-mask.test.ts \

--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -87,6 +87,20 @@ export function buildFilterInfo(
 
 // --- Operator map by field type ---
 
+// Numeric field types (number/currency/percent/rating) share one operator set so
+// the menu can't drift. Mirrors the backend isNumericQueryFieldType predicate
+// (univer-meta.ts). See docs/development/multitable-typed-query-polish-design-20260603.md.
+const NUMERIC_FILTER_OPERATORS: Array<{ value: string; label: string }> = [
+  { value: 'is', label: '=' },
+  { value: 'isNot', label: '≠' },
+  { value: 'greater', label: '>' },
+  { value: 'greaterEqual', label: '≥' },
+  { value: 'less', label: '<' },
+  { value: 'lessEqual', label: '≤' },
+  { value: 'isEmpty', label: 'is empty' },
+  { value: 'isNotEmpty', label: 'is not empty' },
+]
+
 export const FILTER_OPERATORS_BY_TYPE: Record<string, Array<{ value: string; label: string }>> = {
   string: [
     { value: 'is', label: 'is' },
@@ -120,16 +134,10 @@ export const FILTER_OPERATORS_BY_TYPE: Record<string, Array<{ value: string; lab
     { value: 'isEmpty', label: 'is empty' },
     { value: 'isNotEmpty', label: 'is not empty' },
   ],
-  number: [
-    { value: 'is', label: '=' },
-    { value: 'isNot', label: '\u2260' },
-    { value: 'greater', label: '>' },
-    { value: 'greaterEqual', label: '\u2265' },
-    { value: 'less', label: '<' },
-    { value: 'lessEqual', label: '\u2264' },
-    { value: 'isEmpty', label: 'is empty' },
-    { value: 'isNotEmpty', label: 'is not empty' },
-  ],
+  number: NUMERIC_FILTER_OPERATORS,
+  currency: NUMERIC_FILTER_OPERATORS,
+  percent: NUMERIC_FILTER_OPERATORS,
+  rating: NUMERIC_FILTER_OPERATORS,
   boolean: [
     { value: 'is', label: 'is' },
     { value: 'isNot', label: 'is not' },

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1457,7 +1457,19 @@ function parseMetaSortRules(sortInfo: unknown): MetaSortRule[] {
   return rules
 }
 
-function compareMetaSortValue(type: UniverMetaField['type'], valueA: unknown, valueB: unknown, desc: boolean): number {
+/**
+ * Numeric query semantics: these field types sort + range-filter as JS numbers
+ * via toComparableNumber. `date` is intentionally excluded — it has its own
+ * epoch branch (toEpoch). `rollup` is pre-normalized to `number` by callers
+ * (effectiveType), so it need not appear here. Shared by compareMetaSortValue
+ * (sort) and evaluateMetaFilterCondition (filter) so the two cannot drift.
+ * See docs/development/multitable-typed-query-polish-design-20260603.md.
+ */
+export function isNumericQueryFieldType(type: string): boolean {
+  return type === 'number' || type === 'currency' || type === 'percent' || type === 'rating'
+}
+
+export function compareMetaSortValue(type: UniverMetaField['type'], valueA: unknown, valueB: unknown, desc: boolean): number {
   const effectiveType = type === 'rollup' ? 'number' : type
   const aNull = isNullishSortValue(valueA)
   const bNull = isNullishSortValue(valueB)
@@ -1466,7 +1478,7 @@ function compareMetaSortValue(type: UniverMetaField['type'], valueA: unknown, va
   if (bNull) return -1
 
   let cmp = 0
-  if (effectiveType === 'number' || effectiveType === 'date') {
+  if (isNumericQueryFieldType(effectiveType) || effectiveType === 'date') {
     const toComparable = effectiveType === 'date' ? toEpoch : toComparableNumber
     const leftValue = toComparable(valueA)
     const rightValue = toComparable(valueB)
@@ -1911,7 +1923,7 @@ async function computeDependentLookupRollupRecords(
   return results
 }
 
-function evaluateMetaFilterCondition(
+export function evaluateMetaFilterCondition(
   type: UniverMetaField['type'],
   cellValue: unknown,
   condition: MetaFilterCondition,
@@ -1924,7 +1936,7 @@ function evaluateMetaFilterCondition(
   if (opNorm === 'isempty') return isNullishSortValue(cellValue)
   if (opNorm === 'isnotempty') return !isNullishSortValue(cellValue)
 
-  if (effectiveType === 'number' || effectiveType === 'date') {
+  if (isNumericQueryFieldType(effectiveType) || effectiveType === 'date') {
     const toComparable = effectiveType === 'date' ? toEpoch : toComparableNumber
     const left = toComparable(cellValue)
     const right = toComparable(value)
@@ -1935,6 +1947,11 @@ function evaluateMetaFilterCondition(
     if (opNorm === 'greaterequal' || opNorm === 'isgreaterequal') return left !== null && right !== null && left >= right
     if (opNorm === 'less' || opNorm === 'isless') return left !== null && right !== null && left < right
     if (opNorm === 'lessequal' || opNorm === 'islessequal') return left !== null && right !== null && left <= right
+    // Unrecognized operator on a numeric field → no-op (pre-existing catch-all). Accepted
+    // reclassification effect: a `contains`/`doesNotContain` filter persisted on currency/
+    // percent/rating BEFORE Slice 1 (when they fell back to the string operator set) now lands
+    // here and shows all rows. The operator menu no longer offers text ops for these types, so
+    // new filters can't reach this branch. See multitable-typed-query-polish-design-20260603.md.
     return true
   }
 

--- a/packages/core-backend/tests/integration/multitable-typed-query-numeric-view.test.ts
+++ b/packages/core-backend/tests/integration/multitable-typed-query-numeric-view.test.ts
@@ -1,0 +1,102 @@
+/**
+ * Slice 1 (typed query polish) real-DB wire proof. The unit matrix
+ * (tests/unit/multitable-typed-query-numeric.test.ts) proves the helpers; this
+ * proves a currency field's `type` actually reaches the in-memory comparator +
+ * filter evaluator through the real GET /view handler (wire-vs-fixture-drift
+ * guard), and that GET /view-aggregate agrees on the filtered set.
+ *
+ * Runs only with DATABASE_URL (describeIfDatabase) via the plugin-tests.yml step.
+ * See docs/development/multitable-typed-query-polish-design-20260603.md §7 (Bar B).
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const USER = `u_tqp_${TS}`
+const BASE_ID = `base_tqp_${TS}`
+const SHEET_ID = `sheet_tqp_${TS}`
+const FLD_CUR = `fld_cur_${TS}`
+const V_SORT = `v_sort_${TS}`
+const V_FILTER = `v_filter_${TS}`
+
+// Currency values chosen so lexicographic / localeCompare(numeric:true) ordering
+// would DIFFER from numeric: "1.5" vs "1.25" (frac runs 5 vs 25) and the negative -5.
+const VALUES = [10, 2, 1.5, 1.25, -5]
+const ASC = [-5, 1.25, 1.5, 2, 10]
+
+let app: Express
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+describeIfDatabase('multitable typed query — numeric currency over real /view (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: USER, roles: ['member'], perms: ['multitable:read'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [BASE_ID, 'TQP Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [SHEET_ID, BASE_ID, 'TQP Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_CUR, SHEET_ID, 'Amount', 'currency', JSON.stringify({ code: 'CNY', decimals: 2 }), 1])
+    for (let i = 0; i < VALUES.length; i++) {
+      await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+        [`rec_${TS}_${i}`, SHEET_ID, JSON.stringify({ [FLD_CUR]: VALUES[i] })])
+    }
+    // sort view: currency ascending
+    await q('INSERT INTO meta_views (id, sheet_id, name, type, hidden_field_ids, filter_info, sort_info, config) VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7::jsonb,$8::jsonb)',
+      [V_SORT, SHEET_ID, V_SORT, 'grid', '[]', JSON.stringify({ conjunction: 'and', conditions: [] }),
+        JSON.stringify({ rules: [{ fieldId: FLD_CUR, desc: false }] }), JSON.stringify({})])
+    // filter view: currency > 1.5 (+ a sum aggregation so view-aggregate has config)
+    await q('INSERT INTO meta_views (id, sheet_id, name, type, hidden_field_ids, filter_info, sort_info, config) VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7::jsonb,$8::jsonb)',
+      [V_FILTER, SHEET_ID, V_FILTER, 'grid', '[]',
+        JSON.stringify({ conjunction: 'and', conditions: [{ fieldId: FLD_CUR, operator: 'greater', value: 1.5 }] }),
+        JSON.stringify({ rules: [] }), JSON.stringify({ aggregations: { [FLD_CUR]: 'sum' } })])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('/view sorts currency by NUMERIC value (not lexicographic): incl. decimals + negative', async () => {
+    const res = await request(app).get(`/api/multitable/view?sheetId=${SHEET_ID}&viewId=${V_SORT}&limit=10&offset=0`)
+    expect(res.status).toBe(200)
+    const order = (res.body.data.rows as Array<{ data: Record<string, unknown> }>).map((r) => r.data[FLD_CUR])
+    expect(order).toEqual(ASC)
+  })
+
+  test('/view numeric sort holds ACROSS a page boundary (full-set sort, then paginate — not within-page only)', async () => {
+    // ASC = [-5, 1.25, 1.5, 2, 10]. Page size 3 must split it 3 + 2 in numeric order.
+    const p1 = await request(app).get(`/api/multitable/view?sheetId=${SHEET_ID}&viewId=${V_SORT}&limit=3&offset=0`)
+    const p2 = await request(app).get(`/api/multitable/view?sheetId=${SHEET_ID}&viewId=${V_SORT}&limit=3&offset=3`)
+    expect((p1.body.data.rows as Array<{ data: Record<string, unknown> }>).map((r) => r.data[FLD_CUR])).toEqual([-5, 1.25, 1.5])
+    expect((p2.body.data.rows as Array<{ data: Record<string, unknown> }>).map((r) => r.data[FLD_CUR])).toEqual([2, 10])
+  })
+
+  test('/view applies a currency `greater` range filter (was a silent no-op via the string branch)', async () => {
+    const res = await request(app).get(`/api/multitable/view?sheetId=${SHEET_ID}&viewId=${V_FILTER}&limit=10&offset=0`)
+    expect(res.status).toBe(200)
+    const vals = (res.body.data.rows as Array<{ data: Record<string, unknown> }>).map((r) => r.data[FLD_CUR]).sort((a: any, b: any) => a - b)
+    expect(vals).toEqual([2, 10]) // > 1.5 → only 2 and 10
+    expect(res.body.data.page.total).toBe(2)
+  })
+
+  test('PARITY: /view-aggregate agrees with /view on the currency-filtered set', async () => {
+    const viewRes = await request(app).get(`/api/multitable/view?sheetId=${SHEET_ID}&viewId=${V_FILTER}&limit=1&offset=0`)
+    const aggRes = await request(app).get(`/api/multitable/sheets/${SHEET_ID}/view-aggregate?viewId=${V_FILTER}`)
+    expect(aggRes.status).toBe(200)
+    expect(viewRes.body.data.page.total).toBe(2)
+    expect(aggRes.body.data.total).toBe(viewRes.body.data.page.total)
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-typed-query-numeric.test.ts
+++ b/packages/core-backend/tests/unit/multitable-typed-query-numeric.test.ts
@@ -1,0 +1,123 @@
+/**
+ * Slice 1 (typed query polish) unit matrix — proves currency/percent/rating are
+ * treated as NUMERIC (not text) by the shared predicate + the two in-memory query
+ * helpers, and that string-like types (url/email/phone) are unchanged.
+ *
+ * Pure functions, no DB. The real-`/view` wire proof lives in the DB-gated
+ * integration test (multitable-typed-query-numeric.int.test.ts) — both bars per
+ * docs/development/multitable-typed-query-polish-design-20260603.md §7.
+ */
+import { describe, expect, it } from 'vitest'
+
+import {
+  compareMetaSortValue,
+  evaluateMetaFilterCondition,
+  isNumericQueryFieldType,
+} from '../../src/routes/univer-meta'
+
+const cond = (operator: string, value?: unknown) => ({ fieldId: 'f', operator, value })
+const sortAsc = (type: any, arr: unknown[]) => [...arr].sort((a, b) => compareMetaSortValue(type, a, b, false))
+
+describe('isNumericQueryFieldType', () => {
+  it('is true for number/currency/percent/rating', () => {
+    for (const t of ['number', 'currency', 'percent', 'rating']) {
+      expect(isNumericQueryFieldType(t)).toBe(true)
+    }
+  })
+  it('is false for text/date/boolean/select and url/email/phone', () => {
+    for (const t of ['string', 'longText', 'url', 'email', 'phone', 'date', 'dateTime', 'boolean', 'select', 'link']) {
+      expect(isNumericQueryFieldType(t)).toBe(false)
+    }
+  })
+  it('is false for rollup (callers pre-normalize rollup → number; predicate need not list it)', () => {
+    expect(isNumericQueryFieldType('rollup')).toBe(false)
+  })
+})
+
+describe('compareMetaSortValue — numeric reclassification', () => {
+  // The exact case localeCompare(numeric:true) gets wrong: "1.5" vs "1.25" compares
+  // the fractional digit-runs 5 vs 25 → "1.5" < "1.25". And negatives ("-5") were punctuation.
+  it('currency sorts by numeric value incl. decimals + negatives (was lexicographic)', () => {
+    expect(sortAsc('currency', [10, 2, 1.5, 1.25, -5])).toEqual([-5, 1.25, 1.5, 2, 10])
+  })
+  it('currency sorts descending', () => {
+    expect([...[10, 2, 1.5, 1.25, -5]].sort((a, b) => compareMetaSortValue('currency', a, b, true)))
+      .toEqual([10, 2, 1.5, 1.25, -5])
+  })
+  it('percent sorts by numeric value (0.5 > 0.25, not the lexicographic reverse)', () => {
+    expect(sortAsc('percent', [0.5, 0.25, 0.05, 1])).toEqual([0.05, 0.25, 0.5, 1])
+  })
+  it('rating sorts numerically (was already fine for integers; still correct)', () => {
+    expect(sortAsc('rating', [3, 1, 5, 2])).toEqual([1, 2, 3, 5])
+  })
+  it('currency tolerates string-stored numbers (legacy/mixed storage)', () => {
+    expect(compareMetaSortValue('currency', '12.5', 2, false)).toBeGreaterThan(0) // 12.5 after 2
+  })
+  it('nulls sink last regardless of direction', () => {
+    expect(sortAsc('currency', [5, null, 2])).toEqual([2, 5, null])
+  })
+  // regressions: unchanged behavior for the existing branches
+  it('number unchanged (numeric)', () => {
+    expect(sortAsc('number', [10, 2, 1.5])).toEqual([1.5, 2, 10])
+  })
+  it('string unchanged (localeCompare numeric collation)', () => {
+    expect(sortAsc('string', ['10', '2', '1'])).toEqual(['1', '2', '10'])
+  })
+  it('date unchanged (epoch)', () => {
+    expect(sortAsc('date', ['2026-03-01', '2026-01-15', '2025-12-31']))
+      .toEqual(['2025-12-31', '2026-01-15', '2026-03-01'])
+  })
+})
+
+describe('evaluateMetaFilterCondition — numeric reclassification', () => {
+  it('currency range ops compare numerically (were silent no-ops via the string branch)', () => {
+    expect(evaluateMetaFilterCondition('currency', 2, cond('greater', 1.5))).toBe(true)
+    expect(evaluateMetaFilterCondition('currency', 1.25, cond('greater', 1.5))).toBe(false)
+    expect(evaluateMetaFilterCondition('currency', 1.5, cond('greater', 1.5))).toBe(false) // strict
+    expect(evaluateMetaFilterCondition('currency', 1.5, cond('greaterEqual', 1.5))).toBe(true)
+    expect(evaluateMetaFilterCondition('currency', 1.25, cond('less', 1.5))).toBe(true)
+    expect(evaluateMetaFilterCondition('currency', 2, cond('lessEqual', 2))).toBe(true)
+  })
+  it('currency equality is numeric (100.5 === "100.50", which string equality missed)', () => {
+    expect(evaluateMetaFilterCondition('currency', 100.5, cond('is', '100.50'))).toBe(true)
+    expect(evaluateMetaFilterCondition('currency', 100.5, cond('isNot', '100.50'))).toBe(false)
+  })
+  it('rating range ops now work (rating-specific gap: sort was fine, range was a no-op)', () => {
+    expect(evaluateMetaFilterCondition('rating', 3, cond('greaterEqual', 3))).toBe(true)
+    expect(evaluateMetaFilterCondition('rating', 2, cond('greaterEqual', 3))).toBe(false)
+  })
+  it('percent range ops compare numerically', () => {
+    expect(evaluateMetaFilterCondition('percent', 0.5, cond('greater', 0.25))).toBe(true)
+    expect(evaluateMetaFilterCondition('percent', 0.05, cond('greater', 0.25))).toBe(false)
+  })
+  it('isEmpty/isNotEmpty unchanged for numeric types', () => {
+    expect(evaluateMetaFilterCondition('currency', null, cond('isEmpty'))).toBe(true)
+    expect(evaluateMetaFilterCondition('currency', 0, cond('isNotEmpty'))).toBe(true)
+  })
+  it('ACCEPTED reclassification effect: a `contains` filter persisted on currency before Slice 1 now no-ops (shows all)', () => {
+    // The numeric branch has no text-operator case → catch-all returns true. The operator menu no
+    // longer offers `contains` for currency/percent/rating, so this only affects pre-Slice-1 views.
+    expect(evaluateMetaFilterCondition('currency', 7, cond('contains', '5'))).toBe(true)
+  })
+
+  // url/email/phone: deliberately NOT numeric — they keep the string operator family.
+  it('url/email/phone stay string-typed: contains + equality work', () => {
+    expect(evaluateMetaFilterCondition('url', 'https://Example.com/x', cond('contains', 'example'))).toBe(true)
+    expect(evaluateMetaFilterCondition('email', 'a@b.com', cond('is', 'A@B.com'))).toBe(true) // case-insensitive
+    expect(evaluateMetaFilterCondition('phone', '+86 138', cond('contains', '138'))).toBe(true)
+  })
+  it('url range op is an inert no-op (string branch default) — not meaningful, not numeric', () => {
+    // documents the intended boundary: a range operator on a text field returns true (no filtering),
+    // exactly as before; url/email/phone are intentionally excluded from isNumericQueryFieldType.
+    expect(evaluateMetaFilterCondition('url', 'https://a.com', cond('greater', 'https://b.com'))).toBe(true)
+  })
+
+  // regressions
+  it('number range ops unchanged', () => {
+    expect(evaluateMetaFilterCondition('number', 5, cond('greater', 3))).toBe(true)
+    expect(evaluateMetaFilterCondition('number', 2, cond('greater', 3))).toBe(false)
+  })
+  it('string contains unchanged', () => {
+    expect(evaluateMetaFilterCondition('string', 'hello world', cond('contains', 'world'))).toBe(true)
+  })
+})


### PR DESCRIPTION
Implements **Slice 1** of the typed-query-polish design-lock (#2238, `docs/development/multitable-typed-query-polish-design-20260603.md`).

## Problem

`currency`/`percent`/`rating` were misclassified as **text** in the in-memory grid query path (`GET /view` + `/view-aggregate`):
- sort fell to `localeCompare(numeric:true)` → decimal/negative **mis-sort** (`1.5` vs `1.25` compares `5` vs `25`);
- the frontend operator menu fell back to **string** ops, so `>`/`<` were never offered (and a hand-written range filter would silently no-op).

## Fix — one shared predicate + 3 call sites (per design §5.1)

- **`isNumericQueryFieldType(type)`** — `number/currency/percent/rating`. `date` keeps its own epoch branch; `rollup` is pre-normalized to `number` by callers. Shared by both helpers so they can't drift.
- **`compareMetaSortValue`** + **`evaluateMetaFilterCondition`** numeric-branch guards now use it. Both **exported** for direct unit tests.
- **frontend `FILTER_OPERATORS_BY_TYPE`** — `number/currency/percent/rating` reuse one `NUMERIC_FILTER_OPERATORS` list (numeric menu, matching the already-numeric input box). `url/email/phone` keep the string family (**unchanged** — correct reuse, design scope #3).

No new value shape → **field-read gate, redaction, OpenAPI, XLSX, `query-service.ts` SQL cursor path all untouched.** No migration.

## Accepted reclassification effect (was raised in review)

A `contains`/`doesNotContain` filter **persisted on currency/percent/rating before Slice 1** (when they fell back to string ops) now lands in the numeric branch's catch-all → **no-op (shows all rows)**, not an error. The operator menu no longer offers text ops for these types, so new filters can't reach it. Documented inline at the catch-all + encoded in a unit test. `is`/`isNot` survive (numeric equality is equal-or-better). Pure reclassification kept (catch-all not widened) so the change stays locally verifiable and within the design's safety story.

## Tests

- `tests/unit/multitable-typed-query-numeric.test.ts` — **22-case matrix** (sort incl. decimals/negatives; range/equality filters; rating range-gap close; url/email/phone stay string; the accepted contains-no-op; regressions). Runs in the normal test step. **22/22 green locally.**
- `tests/integration/multitable-typed-query-numeric-view.test.ts` — real-DB `/view` numeric sort, **cross-page-boundary** sort, currency `greater` range filter, and `/view-aggregate` parity. Added to the `plugin-tests.yml` real-DB runner list so it **actually executes** (not silent-skip).

Local: `tsc --noEmit` + `vue-tsc -b` green.

Slices 2 (`between`) and 3 (SQL `/records` parity) remain deferred (design §9).

🤖 Generated with [Claude Code](https://claude.com/claude-code)