### PR TITLE
fix(integration-web): enable Workbench run buttons for an existing pipeline ID (#2232)

### DIFF
--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -659,10 +659,10 @@
       </div>
 
       <div class="integration-workbench__actions">
-        <button type="button" class="integration-workbench__button" data-testid="run-dry-run" :disabled="runningPipeline !== '' || !canRunDryRun" @click="executePipeline(true)">
+        <button type="button" class="integration-workbench__button" data-testid="run-dry-run" :disabled="runningPipeline !== '' || !canRunPipeline" @click="executePipeline(true)">
           {{ runningPipeline === 'dry-run' ? 'Dry-run 中' : 'Dry-run' }}
         </button>
-        <button type="button" class="integration-workbench__button integration-workbench__button--danger" data-testid="run-save-only" :disabled="runningPipeline !== '' || !allowSaveOnlyRun || !canRunDryRun" @click="executePipeline(false)">
+        <button type="button" class="integration-workbench__button integration-workbench__button--danger" data-testid="run-save-only" :disabled="runningPipeline !== '' || !allowSaveOnlyRun || !canRunPipeline" @click="executePipeline(false)">
           {{ runningPipeline === 'run' ? '推送中' : 'Save-only 推送' }}
         </button>
       </div>
@@ -1527,7 +1527,11 @@ const dryRunReadinessItems = computed(() => [
     detail: savedPipelineId.value.trim() || 'Payload 预览通过不等于 pipeline dry-run；请先保存 pipeline。',
   },
 ])
-const canRunDryRun = computed(() => dryRunReadinessItems.value.every((item) => item.ready))
+// The dry-run / save-only run buttons drive executePipeline(), which only needs a saved (or pasted)
+// pipeline ID — the pipeline already holds target/mapping/idempotency server-side. So the run gate is
+// decoupled from the full BUILD checklist (dryRunReadinessItems, kept as authoring guidance): an operator
+// re-running an existing pipeline by pasting its ID must not be blocked by an unfilled builder. See #2232.
+const canRunPipeline = computed(() => savedPipelineId.value.trim() !== '')
 const dryRunBlockedSummary = computed(() => {
   const missing = dryRunReadinessItems.value.filter((item) => !item.ready)
   if (missing.length === 0) return '已满足 dry-run 前置条件。Dry-run 只生成 preview，不写外部系统。'

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -1107,6 +1107,81 @@ describe('IntegrationWorkbenchView', () => {
     expect((container.querySelector('[data-testid="run-dry-run"]') as HTMLButtonElement).disabled).toBe(true)
   })
 
+  it('#2232: enables the run buttons for a pasted existing pipeline ID even when the build checklist is incomplete', async () => {
+    apiFetchMock.mockImplementation(async (url: string) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'http', label: 'HTTP API', roles: ['source', 'target'], supports: ['read', 'upsert'], advanced: false },
+          { kind: 'erp:k3-wise-webapi', label: 'K3 WISE WebAPI', roles: ['target'], supports: ['upsert'], advanced: false },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') {
+        return jsonResponse([
+          { id: 'plm_1', tenantId: 'default', workspaceId: null, name: 'PLM Source', kind: 'http', role: 'source', status: 'active' },
+        ])
+      }
+      if (url === '/api/integration/staging/descriptors') {
+        return jsonResponse([])
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi()
+
+    // Mirror the #2205 re-run flow: a source is selected (mid-build, NOT a blank form), but the rest of the
+    // build checklist (target system/object, mapping rules, idempotency fields) is intentionally left unset.
+    const sourceSystemSelect = container.querySelector('[data-testid="source-system"]') as HTMLSelectElement
+    sourceSystemSelect.value = 'plm_1'
+    sourceSystemSelect.dispatchEvent(new Event('change'))
+    await flushUi()
+
+    const runDryRunButton = container.querySelector('[data-testid="run-dry-run"]') as HTMLButtonElement
+    const pipelineIdInput = container.querySelector('[data-testid="pipeline-id"]') as HTMLInputElement
+
+    // The BUILD checklist is genuinely incomplete (this is what makes the test discriminate against the old
+    // full-checklist gate), yet without a pipeline ID the run buttons stay disabled.
+    expect(container.querySelector('[data-testid="dry-run-readiness-summary"]')?.textContent).toContain('还缺')
+    const unreadyBefore = Array.from(container.querySelectorAll('[data-testid="pipeline-readiness"] li[data-ready="false"]'))
+    expect(unreadyBefore.length).toBeGreaterThan(0)
+    expect(runDryRunButton.disabled).toBe(true)
+
+    // Paste an existing pipeline ID (server already holds its target/mapping/idempotency) → run-dry-run enables
+    // even though the build checklist is still incomplete.
+    pipelineIdInput.value = '485b1a40-0000-0000-0000-000000002205'
+    pipelineIdInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    expect(container.querySelector('[data-testid="dry-run-readiness-summary"]')?.textContent).toContain('还缺')
+    expect(runDryRunButton.disabled).toBe(false)
+
+    // The danger save-only run button gates additionally on the explicit allow-toggle, but the pipeline-ID gate
+    // is likewise decoupled from the build checklist: ticking allow enables it.
+    const runSaveOnlyButton = container.querySelector('[data-testid="run-save-only"]') as HTMLButtonElement
+    expect(runSaveOnlyButton.disabled).toBe(true)
+    ;(container.querySelector('[data-testid="allow-save-only-run"]') as HTMLInputElement).click()
+    await flushUi()
+    expect(runSaveOnlyButton.disabled).toBe(false)
+
+    // Clearing the pipeline ID re-disables both run buttons (empty ID → no run target).
+    pipelineIdInput.value = '   '
+    pipelineIdInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+    expect(runDryRunButton.disabled).toBe(true)
+    expect(runSaveOnlyButton.disabled).toBe(true)
+  })
+
   it('marks SQL Server source option as disabled when queryExecutor is missing', async () => {
     apiFetchMock.mockImplementation(async (url: string) => {
       if (url === '/api/integration/adapters') {


### PR DESCRIPTION
Fixes #2232.

## The bug
In the Data Factory Workbench (`apps/web/src/views/IntegrationWorkbenchView.vue`), the **run** buttons — `run-dry-run` and `run-save-only` — were gated on `canRunDryRun`, i.e. the full ~8-item **BUILD** checklist (`dryRunReadinessItems`: source-system active, source-object, target-system active, target-object, source/target pairing, mapping rules, idempotency fields, pipeline-id).

But a run goes through `executePipeline()`, whose run payload (`currentScope()` + run-mode + sampleLimit) requires **only a non-empty `savedPipelineId`** — the pipeline already holds its target/mapping/idempotency **server-side**. So when an operator pastes an existing pipeline ID into the `pipeline-id` input to re-run it (the #2205 flow, pipeline `485b1a40-…`) without re-filling the UI builder, the run buttons stayed disabled even though the dry-run works at the API level (entity-machine 200, rowsRead=16). The operator had to hack the `disabled` attribute to test.

## The fix
Decouple the **RUN** gate from the **BUILD** checklist:
- New computed `canRunPipeline = savedPipelineId.value.trim() !== ''`.
- Both run buttons (`run-dry-run`, `run-save-only`) now use `canRunPipeline` instead of `canRunDryRun`, keeping their existing `runningPipeline !== ''` and `allowSaveOnlyRun` guards.
- `dryRunReadinessItems` panel + `dryRunBlockedSummary` are **retained as build/authoring guidance** — only removed as the run-button gate. The now-orphaned `canRunDryRun` computed is dropped.

### save-pipeline judgment call
`save-pipeline` (`canSavePipeline`) is **intentionally left untouched**. `savePipeline` upserts a pipeline **definition** from the UI fields, and its `savePipelineReadinessItems` gate maps 1:1 onto `buildPipelinePayload`'s required-field throws (source/target system+object, pairing, mapping, idempotency) — so that gate is legitimate, not part of this bug.

## Acceptance (#2232)
Extended `apps/web/tests/IntegrationWorkbenchView.spec.ts` with a test that mirrors the #2205 re-run flow:
- A source is selected (mid-build) but the build checklist is **incomplete** (readiness summary still shows `还缺`).
- Pasting a valid existing pipeline ID → `run-dry-run` becomes **ENABLED**; ticking the allow-toggle enables `run-save-only`.
- Clearing the pipeline ID → both run buttons go **disabled** again.

The test was verified to be discriminating: it **fails** against the old full-checklist gate (`run-dry-run` stays disabled) and **passes** with the fix.

## Checks
- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts` → **18 passed**.
- `pnpm --filter @metasheet/web run type-check` → **clean (exit 0)**.

Frontend-only (`apps/web`). No backend / plugin / K3 / RBAC / auth changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)