### PR TITLE
fix(integration): 4xx not 500 for a dangling data-source binding on the bridge objects/schema routes

### DIFF
--- a/packages/core-backend/src/data-adapters/data-source-plugin-facade.ts
+++ b/packages/core-backend/src/data-adapters/data-source-plugin-facade.ts
@@ -43,6 +43,29 @@ export function writableSourceMessage(dataSourceId: string): string {
   return `data source '${dataSourceId}' is writable; the read-only bridge refuses a writable binding`
 }
 
+/**
+ * A bound data source is dangling / not visible to the principal — i.e. `assertAccess` or
+ * `getDataSource` rejected because the row was deleted OR is not owned by the caller. This is a
+ * **config** error (the external-system row points at a source that isn't there for this caller),
+ * not a server fault, so it must surface as a clean 4xx rather than a 500.
+ *
+ * It is a HTTP-agnostic *domain* error (it carries no status) — the integration plugin's central
+ * `inferHttpStatus` maps the name to 422 DATA_SOURCE_UNAVAILABLE. We deliberately do NOT name it
+ * `*NotFoundError`: the route URL's `:id` addresses the external system (which exists); a 404 there
+ * would falsely read as "no such external system" and collide with the genuine system-missing 404.
+ *
+ * **No-existence-leak invariant preserved.** `assertAccess` throws the SAME uniform "not found"
+ * wording for "deleted" and "not yours" so a non-owner cannot learn a source exists; this wrapper
+ * re-raises that message **verbatim** (it adds a name/type only, never altering the message), so the
+ * deleted-vs-not-mine cases stay indistinguishable to the caller.
+ */
+export class DataSourceUnavailableError extends Error {
+  constructor(message: string) {
+    super(message)
+    this.name = 'DataSourceUnavailableError'
+  }
+}
+
 function requirePrincipal(principal: string | undefined): string {
   // Fail-closed: a read MUST carry an owner principal. We deliberately do NOT fall back to a
   // default / system / tenant / admin identity — that would bypass per-source ownership.
@@ -64,9 +87,19 @@ export function createDataSourcePluginFacade(
   async function authorize(dataSourceId: string, principal: string | undefined) {
     const owner = requirePrincipal(principal)
     const manager = getManager()
-    // Throws the uniform "not found" on owner mismatch — no existence leak.
-    manager.assertAccess(dataSourceId, owner)
-    const adapter = manager.getDataSource(dataSourceId)
+    // A dangling / not-visible binding (deleted row OR owner mismatch) is a CONFIG error, not a
+    // server fault. assertAccess + getDataSource each have exactly one throw — the uniform
+    // "not found" — so wrap just these two and re-raise the message VERBATIM as a named domain
+    // error the integration host maps to a clean 4xx (422). Preserving the message keeps the
+    // deleted-vs-not-yours cases indistinguishable: no existence leak.
+    let adapter
+    try {
+      // Throws the uniform "not found" on owner mismatch — no existence leak.
+      manager.assertAccess(dataSourceId, owner)
+      adapter = manager.getDataSource(dataSourceId)
+    } catch (err) {
+      throw new DataSourceUnavailableError(err instanceof Error ? err.message : String(err))
+    }
     // Read-only-source guard at the choke point: EVERY read method routes through authorize, so a
     // writable data source fails closed here — on getSchema/getTableInfo/select/test alike, not only
     // when testConnection happens to run first. Checked before connecting (it is a config flag).

--- a/packages/core-backend/tests/unit/data-source-plugin-facade.test.ts
+++ b/packages/core-backend/tests/unit/data-source-plugin-facade.test.ts
@@ -1,6 +1,6 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { createDataSourcePluginFacade, MISSING_PRINCIPAL_MESSAGE, writableSourceMessage } from '../../src/data-adapters/data-source-plugin-facade'
+import { createDataSourcePluginFacade, DataSourceUnavailableError, MISSING_PRINCIPAL_MESSAGE, writableSourceMessage } from '../../src/data-adapters/data-source-plugin-facade'
 import type { DataSourceManager } from '../../src/data-adapters/DataSourceManager'
 
 interface AdapterStubOptions {
@@ -27,8 +27,10 @@ interface ManagerStubOptions {
 function managerStub(opts: ManagerStubOptions = {}) {
   const adapter = opts.adapter ?? adapterStub()
   const stub = {
+    // Mirror DataSourceManager's uniform not-found wording verbatim — the wrapper must re-raise it
+    // unchanged (no existence leak), so the test asserts against the real message shape.
     assertAccess: vi.fn((id: string, _owner: string | undefined) => {
-      if (opts.deny) throw new Error(`Data source '${id}' not found`)
+      if (opts.deny) throw new Error(`Data source with id '${id}' not found`)
     }),
     getDataSource: vi.fn(() => adapter),
     connectDataSource: vi.fn(async () => undefined),
@@ -74,6 +76,34 @@ describe('createDataSourcePluginFacade', () => {
     const facade = createDataSourcePluginFacade(() => m.manager)
     await expect(facade.getSchema('pg', 'intruder')).rejects.toThrow(/not found/)
     expect(m.stub.assertAccess).toHaveBeenCalledWith('pg', 'intruder')
+  })
+
+  it('re-raises a dangling / not-visible binding as a NAMED DataSourceUnavailableError with the message VERBATIM (no existence leak)', async () => {
+    // This pins the name the integration host's inferHttpStatus keys on to map 500→422. The CJS
+    // plugin route test fakes this error shape; if this name drifts, the route silently reverts to
+    // 500 while that fixture test stays green — so the contract is pinned HERE, against the real TS.
+    const m = managerStub({ deny: true })
+    const facade = createDataSourcePluginFacade(() => m.manager)
+    // assertAccess throws the uniform "not found"; the wrapper must add only a name, keeping the
+    // message identical so a non-owner cannot distinguish "deleted" from "not yours".
+    await expect(facade.getSchema('pg', 'intruder')).rejects.toMatchObject({
+      name: 'DataSourceUnavailableError',
+      message: "Data source with id 'pg' not found",
+    })
+    await expect(facade.getSchema('pg', 'intruder')).rejects.toBeInstanceOf(DataSourceUnavailableError)
+    // Same uniform surface from a deleted-source (getDataSource miss) — message stays identical.
+    const deleted = createDataSourcePluginFacade(() => ({
+      assertAccess: vi.fn(() => undefined),
+      getDataSource: vi.fn((id: string) => {
+        throw new Error(`Data source with id '${id}' not found`)
+      }),
+      connectDataSource: vi.fn(async () => undefined),
+      select: vi.fn(async () => ({ data: [], metadata: {} })),
+    } as unknown as DataSourceManager))
+    await expect(deleted.getSchema('pg', 'owner-1')).rejects.toMatchObject({
+      name: 'DataSourceUnavailableError',
+      message: "Data source with id 'pg' not found",
+    })
   })
 
   it('select authorizes then maps to manager.select with {limit, offset}', async () => {

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -1026,6 +1026,90 @@ async function testDiscoveryRoutesRejectUnknownSystem() {
   assert.equal(findCalls(calls, 'createAdapter').length, 0, 'unknown system schema lookup does not create an adapter')
 }
 
+// #2205 legibility nit: a `data-source:sql-readonly` external system EXISTS, but its bound data
+// source (config.dataSourceId) is deleted / not-visible to the principal — so the host facade
+// (assertAccess / getDataSource) rejects with a uniform "not found" surfaced as the named
+// DataSourceUnavailableError. That is a CONFIG error, not a server crash: the objects/schema routes
+// must return a clean 4xx (422), NOT 500, and stay UNIFORM (no existence leak between
+// deleted-vs-not-mine). We mock the adapter's listObjects/getSchema to throw the SAME error shape the
+// real facade emits (an Error named 'DataSourceUnavailableError' with the verbatim manager message)
+// and drive the live route → inferHttpStatus mapping end-to-end.
+async function testBridgeDanglingDataSourceMapsTo4xxNot500() {
+  // The exact uniform wording DataSourceManager.assertAccess + getDataSource throw — re-raised
+  // verbatim by the facade wrapper; identical for "deleted" and "not yours" → no existence leak.
+  const UNIFORM_NOT_FOUND = "Data source with id 'ds_gone' not found"
+  const danglingError = () => {
+    const error = new Error(UNIFORM_NOT_FOUND)
+    error.name = 'DataSourceUnavailableError'
+    return error
+  }
+
+  const { calls, services } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        calls.push(['getExternalSystemForAdapter', input])
+        return {
+          id: input.id,
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId,
+          name: 'Read-only SQL bridge',
+          kind: 'data-source:sql-readonly',
+          role: 'source',
+          // No documentTemplates: the schema route must NOT fall back to a template and mask the
+          // dangling-source 422 with a 200.
+          config: { dataSourceId: 'ds_gone' },
+        }
+      },
+    },
+    adapterRegistry: {
+      createAdapter(input, deps) {
+        calls.push(['createAdapter', input, deps])
+        return {
+          // Both discovery methods route through the host facade, which throws on a dangling bind.
+          async listObjects() {
+            calls.push(['listObjects'])
+            throw danglingError()
+          },
+          async getSchema(schemaInput) {
+            calls.push(['getSchema', schemaInput])
+            throw danglingError()
+          },
+        }
+      },
+    },
+  })
+  const { routes } = mountRoutes(services)
+
+  // objects route
+  let res = await invoke(routes, 'GET', '/api/integration/external-systems/:id/objects', {
+    user: READ_USER,
+    params: { id: 'sql_bridge_1' },
+    query: { workspaceId: 'workspace_1' },
+  })
+  assert.notEqual(res.statusCode, 500, 'a dangling data-source binding is a config error, not a 500')
+  assert.equal(res.statusCode, 422, 'objects route maps the dangling-source not-found to 422')
+  assert.equal(res.body.ok, false)
+  assert.equal(res.body.error.code, 'DataSourceUnavailableError', 'distinct code (NOT ExternalSystemNotFoundError) — the system exists, its bound source does not')
+  // No-existence-leak: the message is the uniform "not found", unchanged from the facade — it does
+  // not reveal whether the source was deleted or simply not owned by this principal.
+  assert.equal(res.body.error.message, UNIFORM_NOT_FOUND, 'message stays the uniform not-found (no existence leak)')
+  assert.ok(findCall(calls, 'listObjects'), 'objects route reached the adapter (the facade is where it failed)')
+
+  // schema route — same dangling source, same uniform 422 surface (no leak divergence)
+  calls.length = 0
+  res = await invoke(routes, 'GET', '/api/integration/external-systems/:id/schema', {
+    user: READ_USER,
+    params: { id: 'sql_bridge_1' },
+    query: { workspaceId: 'workspace_1', object: 'public.customers' },
+  })
+  assert.notEqual(res.statusCode, 500, 'schema route also avoids 500 for a dangling source')
+  assert.equal(res.statusCode, 422, 'schema route maps the dangling-source not-found to 422')
+  assert.equal(res.body.ok, false)
+  assert.equal(res.body.error.code, 'DataSourceUnavailableError')
+  assert.equal(res.body.error.message, UNIFORM_NOT_FOUND, 'schema route keeps the identical uniform message (no leak)')
+  assert.ok(findCall(calls, 'getSchema'), 'schema route reached the adapter getSchema')
+}
+
 async function testDocumentTemplateValidation() {
   const cases = [
     {
@@ -2222,6 +2306,7 @@ async function main() {
   await testDiscoveryRoutes()
   await testDiscoveryObjectsRouteDoesNotDefaultTruncateAdapterObjects()
   await testDiscoveryRoutesRejectUnknownSystem()
+  await testBridgeDanglingDataSourceMapsTo4xxNot500()
   await testDocumentTemplateValidation()
   await testPipelineRoutes()
   await testTemplatePreviewRoute()

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -93,7 +93,11 @@ function inferHttpStatus(error) {
   if (/NotFound/.test(name)) return 404
   if (/Conflict/.test(name)) return 409
   if (/Validation|Transform|Watermark|DeadLetter/.test(name)) return 400
-  if (/PipelineRunner/.test(name)) return 422
+  // A `data-source:sql-readonly` external system bound to a deleted / not-visible data source is a
+  // CONFIG error (its config.dataSourceId dangles), NOT a server fault — map to 422, not 500.
+  // Deliberately NOT 404: the route's `:id` addresses the external system (which exists), so a 404
+  // would falsely read as "no such external system" and collide with ExternalSystemNotFoundError.
+  if (/PipelineRunner|DataSourceUnavailable/.test(name)) return 422
   return 500
 }
 


### PR DESCRIPTION
## What & why

When a `data-source:sql-readonly` external system's `config.dataSourceId` points at a **deleted / not-visible** data source, the host facade (`packages/core-backend/src/data-adapters/data-source-plugin-facade.ts`) threw a plain `Error` via `manager.assertAccess` / `manager.getDataSource` (the uniform `Data source with id 'X' not found`). With name `Error`, the integration handler's `inferHttpStatus` fell through to **500**, so `GET /api/integration/external-systems/:id/objects` and `.../schema` read as a *server crash* for what is really a **config** error. In #2205 this cost the operator several confused rounds.

This maps that one failure to a clean **422 `DataSourceUnavailableError`** (code surfaced via the existing class-name-as-code convention, e.g. `ExternalSystemNotFoundError`).

## Approach (minimal, layering-respecting)

- **Facade (TS):** new HTTP-agnostic domain error `DataSourceUnavailableError`, wrapping **only** the `assertAccess` + `getDataSource` calls in `authorize()` (each has exactly one throw — the uniform not-found). `requirePrincipal`, the writable-source guard, and `connectDataSource` stay **outside** the wrap, untouched. The wrapper re-raises `err.message` **verbatim**.
- **Plugin (CJS):** one branch in the central `inferHttpStatus` (`DataSourceUnavailable` → 422), consistent with its existing `PipelineRunner`/`DeadLetter`/etc. branches. The facade carries **no** `.status` — the central mapper stays the only thing that knows HTTP.
- **No handler edits.** `externalSystemObjects` / `externalSystemSchema` are unchanged; the named error + central mapping does the work.

### Why 422, not 404
The route `:id` addresses the **external system**, which *exists* (`loadSystem` succeeded) — the dangling thing is a *referenced* resource. A 404 there would falsely read as "no such external system" (the exact #2205 misdirection) and would **collide** with the genuine `ExternalSystemNotFoundError` 404 on the same URL. 422 keeps the two causes legibly distinct by `code`.

### `externalSystemsTest` verified, not the bug
Its `adapter.testConnection()` is already inside a try/catch → `testConnectionErrorResult` → returns **200** with a failure result; it never 500s on a dangling source. Left untouched.

## No-existence-leak invariant — preserved
`assertAccess` deliberately throws the **same** uniform "not found" for "deleted" and "not yours" so a non-owner can't learn a source exists. The wrapper adds only a name/type and re-raises the message **verbatim** — message content, fail-closed behaviour, redaction, and read/select/write are all unchanged. **The HTTP status is the only thing that changed (500 → 422).** Both `objects` and `schema` keep the identical uniform message (asserted in the new tests).

## Tests
- **Facade vitest** (`tests/unit/data-source-plugin-facade.test.ts`): extended the not-found test to **pin `error.name === 'DataSourceUnavailableError'` and the verbatim message**, for both the owner-mismatch (`assertAccess`) and deleted (`getDataSource`) paths. This closes a wire-vs-fixture gap: the CJS route test *fakes* that error shape, so if the name ever drifts the route silently reverts to 500 — pinned here against the real TS. (9/9 pass.)
- **CJS route test** (`plugins/plugin-integration-core/__tests__/http-routes.test.cjs` → `testBridgeDanglingDataSourceMapsTo4xxNot500`, registered in `main()`): drives `objects` + `schema` on a `data-source:sql-readonly` system whose adapter `listObjects`/`getSchema` throw the same not-found-style error the facade emits; asserts **422 (and explicitly NOT 500)**, distinct `code`, and a **uniform, non-leaking** message. Mirrors the existing discovery-route tests.

All pass: `http-routes.test.cjs`, `data-source-sql-readonly-source-adapter.test.cjs`, `plugin-runtime-smoke.test.cjs` (plain node); `tsc --noEmit` on core-backend = 0 errors; facade vitest 9/9.

LEAVE-FOR-REVIEW — do not merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

> **Scope note:** this is scoped to the *dangling / not-visible* binding per the task. The adjacent **writable-binding** path in the same `authorize()` (`if (!adapter.isReadOnly()) throw new Error(writableSourceMessage(...))`) is *also* a config error that still returns 500 on these routes — a separate, similar legibility nit, intentionally **not** addressed here.