### PR TITLE
feat(web): A6-2b — suspend/resume frontend (wait_for_callback config + admin resume)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1598,6 +1598,22 @@ export class MultitableApiClient {
     return this.parseJson<AutomationRunView>(res)
   }
 
+  /**
+   * A6-2: resume a suspended execution (admin-only; re-runs the remaining actions' side effects).
+   * The single-use `resumeToken` comes from the suspended step's C1 descriptor in the run detail.
+   * `confirmSideEffects:true` is always sent (the UI confirm-gates this call). parseJson throws an
+   * Error with `.code` (NOT_FOUND / ALREADY_RESUMED / RULE_CHANGED / RULE_MISSING_OR_DISABLED /
+   * RECORD_GONE) so the caller can map it to an inline message rather than a generic toast.
+   */
+  async resumeAutomation(resumeToken: string): Promise<AutomationRunView> {
+    const res = await this.fetch('/api/multitable/automation/resume', {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ resumeToken, confirmSideEffects: true }),
+    })
+    return this.parseJson<AutomationRunView>(res)
+  }
+
   async getAutomationDingTalkPersonDeliveries(sheetId: string, ruleId: string, limit?: number): Promise<DingTalkPersonDelivery[]> {
     const res = await this.fetch(
       `/api/multitable/sheets/${encodeURIComponent(sheetId)}/automations/${encodeURIComponent(ruleId)}/dingtalk-person-deliveries${qs({ limit })}`,

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -243,6 +243,7 @@
                 <option value="send_dingtalk_group_message">{{ automationActionTypeLabel('send_dingtalk_group_message', isZh) }}</option>
                 <option value="send_dingtalk_person_message">{{ automationActionTypeLabel('send_dingtalk_person_message', isZh) }}</option>
                 <option value="lock_record">{{ automationActionTypeLabel('lock_record', isZh) }}</option>
+                <option value="wait_for_callback">{{ automationActionTypeLabel('wait_for_callback', isZh) }}</option>
               </select>
               <div class="meta-rule-editor__action-btns">
                 <button v-if="idx > 0" class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="moveAction(idx, -1)" :title="automationLabel('editor.moveUpTitle', isZh)">&#x2191;</button>
@@ -888,6 +889,12 @@
                 <input type="checkbox" v-model="action.config.locked" />
                 {{ automationLabel('actionConfig.lockRecord', isZh) }}
               </label>
+            </div>
+
+            <!-- wait_for_callback config (A6-2: info-only, ZERO params — the suspend point; no
+                 webhook-URL / timer / manual-task fields. An admin resumes from the runs detail.) -->
+            <div v-if="action.type === 'wait_for_callback'" class="meta-rule-editor__action-config" data-action-config="wait_for_callback">
+              <div class="meta-rule-editor__hint" data-field="wait-for-callback-hint">{{ automationLabel('actionConfig.waitForCallbackHint', isZh) }}</div>
             </div>
           </div>
           <button
@@ -2295,6 +2302,8 @@ function defaultConfigForActionType(type: AutomationActionType): DraftActionConf
       }
     case 'lock_record':
       return { locked: true }
+    case 'wait_for_callback':
+      return {} // A6-2: zero-param suspend point (no webhook-URL/timer/manual-task fields)
     default:
       return {}
   }

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -17,13 +17,14 @@
         <label class="meta-rule-editor__label" data-field="executionModeToggle">
           <input
             type="checkbox"
-            :checked="draft.executionMode === 'workflow_job_v1'"
+            :checked="draft.executionMode === 'workflow_job_v1' || requiresJobMode"
+            :disabled="requiresJobMode"
             data-field="executionMode"
             @change="setExecutionMode(($event.target as HTMLInputElement).checked)"
           />
           {{ automationLabel('editor.executionModeLabel', isZh) }}
         </label>
-        <div class="meta-rule-editor__hint" data-field="executionModeHint">{{ automationLabel('editor.executionModeHint', isZh) }}</div>
+        <div class="meta-rule-editor__hint" data-field="executionModeHint">{{ requiresJobMode ? automationLabel('editor.executionModeRequiredHint', isZh) : automationLabel('editor.executionModeHint', isZh) }}</div>
 
         <!-- 1. Trigger selector -->
         <section class="meta-rule-editor__section">
@@ -1568,8 +1569,18 @@ function draftFromRule(rule: AutomationRule): Draft {
 const draft = ref<Draft>(emptyDraft())
 const conditionEditorEntries = computed(() => collectConditionEditorEntries(draft.value.conditions.conditions))
 
+// A6-2b: a wait_for_callback action REQUIRES execution_mode 'workflow_job_v1' — the backend
+// fail-closes a legacy rule that contains a wait step. So whenever a wait action is present the
+// job-mode toggle is forced on (and disabled), and buildPayload enforces it regardless.
+const requiresJobMode = computed(() => draft.value.actions.some((a) => a.type === 'wait_for_callback'))
+
 function setExecutionMode(checked: boolean): void {
   // A6-1 opt-in: checkbox → the rule's persistent WorkflowJob mode (off = legacy/null).
+  // A6-2b: cannot turn it off while a wait_for_callback step is present.
+  if (requiresJobMode.value) {
+    draft.value.executionMode = 'workflow_job_v1'
+    return
+  }
   draft.value.executionMode = checked ? 'workflow_job_v1' : null
 }
 
@@ -2311,6 +2322,9 @@ function defaultConfigForActionType(type: AutomationActionType): DraftActionConf
 
 function onDraftActionTypeChange(action: DraftAction) {
   action.config = defaultConfigForActionType(action.type)
+  // A6-2b: selecting wait_for_callback auto-enables the REQUIRED job mode (the backend fail-closes a
+  // legacy rule containing a wait step) — so the UI can't create a "suspends" rule that fails at runtime.
+  if (action.type === 'wait_for_callback') draft.value.executionMode = 'workflow_job_v1'
 }
 
 function removeAction(idx: number) {
@@ -2434,7 +2448,9 @@ function buildPayload(): Partial<AutomationRule> {
     actions,
     actionType: actions[0]?.type ?? 'update_record',
     actionConfig: actions[0]?.config ?? {},
-    executionMode: d.executionMode,
+    // A6-2b: a wait_for_callback action forces workflow_job_v1 (backend fail-closes legacy waits) —
+    // enforced here so the payload is correct regardless of toggle state.
+    executionMode: requiresJobMode.value ? 'workflow_job_v1' : d.executionMode,
   }
 }
 

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -779,6 +779,7 @@ export type AutomationActionType =
   | 'send_dingtalk_group_message'
   | 'send_dingtalk_person_message'
   | 'lock_record'
+  | 'wait_for_callback'
   // Legacy aliases
   | 'notify'
   | 'update_field'
@@ -872,6 +873,9 @@ export interface AutomationRunStepView {
   upstreamJobId: string | null
   result?: unknown
   error?: string
+  /** A6-2: present iff status === 'suspended' — the C1 suspend descriptor. The resume token is
+   * admin-detail-only (the runs detail uses it for the Resume action; never shown in the list). */
+  suspend?: { reason: string; resumeToken: string }
 }
 
 /**

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -93,6 +93,7 @@ export type AutomationLabelKey =
   | 'editor.removeActionTitle'
   | 'editor.executionModeLabel'
   | 'editor.executionModeHint'
+  | 'editor.executionModeRequiredHint'
   | 'trigger.title'
   | 'trigger.watchField'
   | 'trigger.selectField'
@@ -309,6 +310,7 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'editor.removeActionTitle',
   'editor.executionModeLabel',
   'editor.executionModeHint',
+  'editor.executionModeRequiredHint',
   'trigger.title',
   'trigger.watchField',
   'trigger.selectField',
@@ -531,6 +533,10 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'editor.executionModeHint': {
     en: 'When on, each action run for this rule is saved as a durable WorkflowJob record. Leave off for the default lightweight log.',
     zh: '开启后，本规则每个动作的运行都会保存为持久的 WorkflowJob 记录；关闭则使用默认的轻量日志。',
+  },
+  'editor.executionModeRequiredHint': {
+    en: 'Required and locked on: this rule has a "wait for callback" action, and suspend/resume needs the WorkflowJob record.',
+    zh: '已强制开启并锁定：本规则包含“等待回调”动作，挂起/恢复依赖 WorkflowJob 记录，无法关闭。',
   },
   'trigger.title': { en: 'Trigger', zh: '触发器' },
   'trigger.watchField': { en: 'Watch field', zh: '监听字段' },

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -128,6 +128,7 @@ export type AutomationLabelKey =
   | 'actionConfig.bodyTemplate'
   | 'actionConfig.emailBodyPlaceholder'
   | 'actionConfig.lockRecord'
+  | 'actionConfig.waitForCallbackHint'
   | 'testRun.warning'
   | 'testRun.confirmSuffix'
   | 'testRun.unsavedHint'
@@ -257,6 +258,14 @@ export type AutomationLabelKey =
   | 'runs.ruleSnapshot'
   | 'runs.steps'
   | 'runs.loadingDetail'
+  | 'runs.resume'
+  | 'runs.resumeConfirm'
+  | 'runs.resumeError.notFound'
+  | 'runs.resumeError.alreadyResumed'
+  | 'runs.resumeError.ruleChanged'
+  | 'runs.resumeError.ruleMissingOrDisabled'
+  | 'runs.resumeError.recordGone'
+  | 'runs.resumeError.generic'
 
 export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'log.title',
@@ -335,6 +344,7 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'actionConfig.bodyTemplate',
   'actionConfig.emailBodyPlaceholder',
   'actionConfig.lockRecord',
+  'actionConfig.waitForCallbackHint',
   'testRun.warning',
   'testRun.confirmSuffix',
   'testRun.unsavedHint',
@@ -464,6 +474,14 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'runs.ruleSnapshot',
   'runs.steps',
   'runs.loadingDetail',
+  'runs.resume',
+  'runs.resumeConfirm',
+  'runs.resumeError.notFound',
+  'runs.resumeError.alreadyResumed',
+  'runs.resumeError.ruleChanged',
+  'runs.resumeError.ruleMissingOrDisabled',
+  'runs.resumeError.recordGone',
+  'runs.resumeError.generic',
 ]
 
 const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
@@ -549,6 +567,10 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'actionConfig.bodyTemplate': { en: 'Body template', zh: '正文模板' },
   'actionConfig.emailBodyPlaceholder': { en: 'Record {{recordId}} changed. Status: {{record.status}}', zh: '记录 {{recordId}} 已变更。状态：{{record.status}}' },
   'actionConfig.lockRecord': { en: 'Lock record', zh: '锁定记录' },
+  'actionConfig.waitForCallbackHint': {
+    en: 'Suspends the run until an admin resumes it from the runs view. No parameters in v1 (no external webhook/timer).',
+    zh: '挂起执行，直到管理员在运行视图中手动恢复。v1 无参数（暂无外部 webhook/定时器）。',
+  },
   'testRun.warning': { en: 'Test Run executes the saved rule and can send real DingTalk messages to configured groups or users.', zh: '测试运行会执行已保存规则，并可能向已配置的钉钉群或用户发送真实消息。' },
   'testRun.confirmSuffix': { en: 'Unsaved changes are not included. Continue?', zh: '未保存的更改不会包含在内。是否继续？' },
   'testRun.unsavedHint': { en: 'Save this automation before running a test.', zh: '请先保存此自动化，再运行测试。' },
@@ -678,6 +700,17 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'runs.ruleSnapshot': { en: 'Rule snapshot', zh: '规则快照' },
   'runs.steps': { en: 'Steps', zh: '步骤' },
   'runs.loadingDetail': { en: 'Loading detail…', zh: '加载详情…' },
+  'runs.resume': { en: 'Resume', zh: '恢复执行' },
+  'runs.resumeConfirm': {
+    en: 'Resume this run? It continues the remaining actions and may cause external side effects.',
+    zh: '恢复这条执行？将继续执行剩余动作，可能产生外部副作用。',
+  },
+  'runs.resumeError.notFound': { en: 'Resume token not found.', zh: '恢复令牌不存在。' },
+  'runs.resumeError.alreadyResumed': { en: 'This run was already resumed.', zh: '该执行已被恢复。' },
+  'runs.resumeError.ruleChanged': { en: 'The rule changed since it was suspended; cannot resume safely.', zh: '规则在挂起后已变更，无法安全恢复。' },
+  'runs.resumeError.ruleMissingOrDisabled': { en: 'The rule is missing or disabled; cannot resume.', zh: '规则缺失或已停用，无法恢复。' },
+  'runs.resumeError.recordGone': { en: 'The record no longer exists; cannot resume.', zh: '记录已不存在，无法恢复。' },
+  'runs.resumeError.generic': { en: 'Resume failed.', zh: '恢复失败。' },
 }
 
 export function automationLabel(key: AutomationLabelKey, isZh: boolean): string {
@@ -717,6 +750,8 @@ export function automationActionTypeLabel(type: AutomationActionType | (string &
       return isZh ? '发送钉钉个人消息' : 'Send DingTalk person message'
     case 'lock_record':
       return isZh ? '锁定记录' : 'Lock record'
+    case 'wait_for_callback':
+      return isZh ? '等待回调（挂起）' : 'Wait for callback (suspend)'
     case 'update_field':
       return isZh ? '更新字段值' : 'Update field value'
     default:

--- a/apps/web/src/views/AutomationExecutionsView.vue
+++ b/apps/web/src/views/AutomationExecutionsView.vue
@@ -71,6 +71,15 @@
               <span class="automation-runs__badge automation-runs__badge--sm" :class="`automation-runs__badge--${step.status}`">
                 {{ automationStatusLabel(step.status, isZh) }}
               </span>
+              <!-- A6-2: resume a suspended step (admin detail only; token used internally, never shown). -->
+              <button
+                v-if="step.status === 'suspended' && step.suspend?.resumeToken"
+                class="automation-runs__btn automation-runs__btn--sm"
+                type="button"
+                data-action="resume"
+                :disabled="resuming === step.id"
+                @click.stop="resumeStep(step)"
+              >{{ automationLabel('runs.resume', isZh) }}</button>
               <div v-if="step.error" class="automation-runs__step-error" data-field="step-error">
                 {{ summarizeStepError(step.error) }}
               </div>
@@ -78,6 +87,9 @@
                 {{ summarizeStepOutput(step.result) }}
               </div>
             </div>
+
+            <!-- A6-2: resume failures map the discriminated code to an INLINE message (never a generic toast). -->
+            <div v-if="resumeError" class="automation-runs__step-error" data-field="resume-error" role="alert">{{ resumeError }}</div>
 
             <h2 class="automation-runs__detail-h">{{ automationLabel('runs.triggerEvent', isZh) }}</h2>
             <pre class="automation-runs__json" data-field="trigger-event">{{ jsonView(detail.triggerEvent) }}</pre>
@@ -95,8 +107,8 @@ import { ref } from 'vue'
 import { useLocale } from '../composables/useLocale'
 import { useAuth } from '../composables/useAuth'
 import { multitableClient, type MultitableApiClient } from '../multitable/api/client'
-import type { AutomationRunView, WorkflowJobStatus } from '../multitable/types'
-import { automationLabel, automationStatusLabel } from '../multitable/utils/meta-automation-labels'
+import type { AutomationRunView, AutomationRunStepView, WorkflowJobStatus } from '../multitable/types'
+import { automationLabel, automationStatusLabel, type AutomationLabelKey } from '../multitable/utils/meta-automation-labels'
 import { redactString, redactValue, summarizeStepError, summarizeStepOutput } from '../multitable/utils/automation-log-redact'
 
 const props = defineProps<{ client?: MultitableApiClient }>()
@@ -119,6 +131,8 @@ const sheetFilter = ref('')
 const expandedId = ref<string | null>(null)
 const detail = ref<AutomationRunView | null>(null)
 const detailLoading = ref(false)
+const resuming = ref<string | null>(null)
+const resumeError = ref<string | null>(null)
 
 async function loadData() {
   loading.value = true
@@ -141,6 +155,7 @@ async function loadData() {
 }
 
 async function toggleExpand(id: string) {
+  resumeError.value = null
   if (expandedId.value === id) {
     expandedId.value = null
     detail.value = null
@@ -165,6 +180,46 @@ async function toggleExpand(id: string) {
     expandedId.value = null // detail failed for the still-current row → collapse
   }
   detailLoading.value = false
+}
+
+const RESUME_ERROR_LABELS: Record<string, AutomationLabelKey> = {
+  NOT_FOUND: 'runs.resumeError.notFound',
+  ALREADY_RESUMED: 'runs.resumeError.alreadyResumed',
+  RULE_CHANGED: 'runs.resumeError.ruleChanged',
+  RULE_MISSING_OR_DISABLED: 'runs.resumeError.ruleMissingOrDisabled',
+  RECORD_GONE: 'runs.resumeError.recordGone',
+}
+
+/** Map the resume endpoint's discriminated code → an inline localized message (never a generic toast). */
+function mapResumeError(err: unknown): string {
+  const code = (err as { code?: string })?.code
+  if (code && RESUME_ERROR_LABELS[code]) return automationLabel(RESUME_ERROR_LABELS[code], isZh.value)
+  const msg = err instanceof Error ? err.message : String(err)
+  return redactString(msg) || automationLabel('runs.resumeError.generic', isZh.value)
+}
+
+/**
+ * A6-2: resume a suspended step. Confirm-gated (the remaining actions re-run, with possible external
+ * side effects — same mental model as A5 retry's confirmSideEffects). The token is used internally and
+ * never displayed. On success the run detail reloads in place; on failure the code maps to INLINE error.
+ */
+async function resumeStep(step: AutomationRunStepView) {
+  if (resuming.value || !step.suspend?.resumeToken) return
+  if (!window.confirm(automationLabel('runs.resumeConfirm', isZh.value))) return
+  const runId = expandedId.value
+  resumeError.value = null
+  resuming.value = step.id
+  try {
+    await client.resumeAutomation(step.suspend.resumeToken)
+    if (runId && expandedId.value === runId) {
+      const refreshed = await client.getAutomationRun(runId).catch(() => null)
+      if (expandedId.value === runId && refreshed) detail.value = refreshed
+    }
+  } catch (err) {
+    resumeError.value = mapResumeError(err)
+  } finally {
+    resuming.value = null
+  }
 }
 
 function formatTime(ts: string): string {

--- a/apps/web/tests/AutomationExecutionsView.spec.ts
+++ b/apps/web/tests/AutomationExecutionsView.spec.ts
@@ -32,6 +32,22 @@ const RUN_DETAIL: AutomationRunView = {
   ruleSnapshot: { id: 'rule-1', name: 'Notify' },
 }
 
+// A6-2: a suspended run — legacy status stays `running` (D2); the C1 job step carries the suspend
+// descriptor with the resume token (admin-detail-only; used by the Resume button, never displayed).
+const SUSPENDED_TOKEN = 'rt_secret_should_not_render_123'
+const SUSPENDED_LIST: AutomationRunView = {
+  ...RUN_LIST, id: 'axe_s', status: 'running', statusLegacy: 'running', finishedAt: null,
+}
+const SUSPENDED_DETAIL: AutomationRunView = {
+  ...SUSPENDED_LIST,
+  triggerEvent: { recordId: 'recS' },
+  ruleSnapshot: { id: 'rule-1', name: 'Notify' },
+  steps: [
+    { id: 'axe_s:step:0', executionId: 'axe_s', stepKey: '0', status: 'resolved', upstreamJobId: null, result: {} },
+    { id: 'axe_s:step:1', executionId: 'axe_s', stepKey: '1', status: 'suspended', upstreamJobId: 'axe_s:step:0', suspend: { reason: 'external_event', resumeToken: SUSPENDED_TOKEN } },
+  ],
+}
+
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
 function makeClient(over: Record<string, any> = {}): any {
   return {
@@ -82,13 +98,17 @@ describe('AutomationExecutionsView (A3 admin runs view)', () => {
     expect(mounted.container.textContent ?? '').toContain('resolved')
   })
 
-  it('shows the admin-only notice and does NOT call the API when not admin', async () => {
+  it('shows the admin-only notice and does NOT call the API (list/detail/resume) when not admin', async () => {
     mockIsAdmin = false
-    const client = makeClient()
+    const client = makeClient({ resumeAutomation: vi.fn() })
     mounted = mount(client)
     await nextTick()
     expect(mounted.container.querySelector('[data-denied="true"]')).not.toBeNull()
     expect(client.listAutomationRuns).not.toHaveBeenCalled()
+    expect(client.getAutomationRun).not.toHaveBeenCalled()
+    // A6-2: no admin surface for a non-admin → resume is unreachable + never requested.
+    expect(client.resumeAutomation).not.toHaveBeenCalled()
+    expect(mounted.container.querySelector('[data-action="resume"]')).toBeNull()
   })
 
   it('expanding a run fetches detail and renders C1 steps + redacted snapshot', async () => {
@@ -146,5 +166,66 @@ describe('AutomationExecutionsView (A3 admin runs view)', () => {
     const trigger = mounted.container.querySelector('[data-field="trigger-event"]')?.textContent ?? ''
     expect(trigger).toContain('recB')
     expect(trigger).not.toContain('recA')
+  })
+
+  it('A6-2: a suspended step shows a confirm-gated Resume → resumeAutomation(token) + reloads detail; token never rendered', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const client = makeClient({
+      listAutomationRuns: vi.fn().mockResolvedValue([SUSPENDED_LIST]),
+      getAutomationRun: vi.fn().mockResolvedValue(SUSPENDED_DETAIL),
+      resumeAutomation: vi.fn().mockResolvedValue({ ...SUSPENDED_DETAIL, status: 'resolved', statusLegacy: 'success' }),
+    })
+    mounted = mount(client)
+    await settle()
+    expect(mounted.container.textContent ?? '').not.toContain(SUSPENDED_TOKEN) // list view: no token
+    ;(mounted.container.querySelector('[data-run-id="axe_s"]') as HTMLElement).click()
+    await settle()
+    const resumeBtn = mounted.container.querySelector('[data-action="resume"]') as HTMLElement
+    expect(resumeBtn).not.toBeNull()
+    expect(mounted.container.textContent ?? '').not.toContain(SUSPENDED_TOKEN) // detail: token used internally, not shown
+    resumeBtn.click()
+    await settle()
+    expect(confirmSpy).toHaveBeenCalled() // confirm-gated (side-effects warning)
+    expect(client.resumeAutomation).toHaveBeenCalledWith(SUSPENDED_TOKEN)
+    expect(client.getAutomationRun).toHaveBeenCalledTimes(2) // expand + post-resume reload
+    confirmSpy.mockRestore()
+  })
+
+  it('A6-2: cancelling the resume confirm does NOT call resumeAutomation', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const client = makeClient({
+      listAutomationRuns: vi.fn().mockResolvedValue([SUSPENDED_LIST]),
+      getAutomationRun: vi.fn().mockResolvedValue(SUSPENDED_DETAIL),
+      resumeAutomation: vi.fn(),
+    })
+    mounted = mount(client)
+    await settle()
+    ;(mounted.container.querySelector('[data-run-id="axe_s"]') as HTMLElement).click()
+    await settle()
+    ;(mounted.container.querySelector('[data-action="resume"]') as HTMLElement).click()
+    await settle()
+    expect(confirmSpy).toHaveBeenCalled()
+    expect(client.resumeAutomation).not.toHaveBeenCalled()
+    confirmSpy.mockRestore()
+  })
+
+  it('A6-2: a discriminated resume error (409 RULE_CHANGED) maps to an INLINE message, not a toast', async () => {
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const err = Object.assign(new Error('x'), { code: 'RULE_CHANGED' })
+    const client = makeClient({
+      listAutomationRuns: vi.fn().mockResolvedValue([SUSPENDED_LIST]),
+      getAutomationRun: vi.fn().mockResolvedValue(SUSPENDED_DETAIL),
+      resumeAutomation: vi.fn().mockRejectedValue(err),
+    })
+    mounted = mount(client)
+    await settle()
+    ;(mounted.container.querySelector('[data-run-id="axe_s"]') as HTMLElement).click()
+    await settle()
+    ;(mounted.container.querySelector('[data-action="resume"]') as HTMLElement).click()
+    await settle()
+    const inline = mounted.container.querySelector('[data-field="resume-error"]')
+    expect(inline).not.toBeNull()
+    expect(inline?.textContent ?? '').toContain('changed') // RULE_CHANGED → localized inline message
+    confirmSpy.mockRestore()
   })
 })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -564,6 +564,34 @@ describe('MetaAutomationRuleEditor', () => {
     expect(saved.mock.calls[0][0].executionMode).toBeNull()
   })
 
+  it('A6-2b: wait_for_callback is selectable with INFO-ONLY config (zero params) and serializes {type, config:{}}', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'wait rule'
+    nameInput.dispatchEvent(new Event('input'))
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    expect(Array.from(actionSelect.options).map((o) => o.value)).toContain('wait_for_callback')
+    actionSelect.value = 'wait_for_callback'
+    actionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    // Info-only: the hint renders and there are ZERO param inputs (no webhook-URL/timer/manual-task fields).
+    const cfg = container.querySelector('[data-action-config="wait_for_callback"]') as HTMLElement
+    expect(cfg).not.toBeNull()
+    expect(container.querySelector('[data-field="wait-for-callback-hint"]')).not.toBeNull()
+    expect(cfg.querySelectorAll('input, textarea, select').length).toBe(0)
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].actions).toEqual([{ type: 'wait_for_callback', config: {} }])
+  })
+
   it('serializes numeric condition values as numbers', async () => {
     const saved = vi.fn()
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -564,7 +564,7 @@ describe('MetaAutomationRuleEditor', () => {
     expect(saved.mock.calls[0][0].executionMode).toBeNull()
   })
 
-  it('A6-2b: wait_for_callback is selectable with INFO-ONLY config (zero params) and serializes {type, config:{}}', async () => {
+  it('A6-2b: wait_for_callback is info-only (zero params), AUTO-ENABLES + LOCKS workflow_job_v1, and saves both', async () => {
     const saved = vi.fn()
     const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
     await flushPromises()
@@ -572,6 +572,9 @@ describe('MetaAutomationRuleEditor', () => {
     const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
     nameInput.value = 'wait rule'
     nameInput.dispatchEvent(new Event('input'))
+
+    const toggle = container.querySelector('[data-field="executionMode"]') as HTMLInputElement
+    expect(toggle.checked).toBe(false) // off by default
 
     const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
     expect(Array.from(actionSelect.options).map((o) => o.value)).toContain('wait_for_callback')
@@ -585,11 +588,39 @@ describe('MetaAutomationRuleEditor', () => {
     expect(container.querySelector('[data-field="wait-for-callback-hint"]')).not.toBeNull()
     expect(cfg.querySelectorAll('input, textarea, select').length).toBe(0)
 
+    // BLOCKING FIX: selecting wait_for_callback auto-enables AND LOCKS workflow_job_v1 (can't turn it off
+    // into the runtime-fail-closed state).
+    expect(toggle.checked).toBe(true)
+    expect(toggle.disabled).toBe(true)
+
     ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
     await flushPromises()
 
     expect(saved).toHaveBeenCalledTimes(1)
     expect(saved.mock.calls[0][0].actions).toEqual([{ type: 'wait_for_callback', config: {} }])
+    expect(saved.mock.calls[0][0].executionMode).toBe('workflow_job_v1') // never a legacy wait_for_callback rule
+  })
+
+  it('A6-2b: a loaded wait_for_callback rule with null executionMode is force-corrected to workflow_job_v1 on save', async () => {
+    const saved = vi.fn()
+    const rule: AutomationRule = {
+      id: 'atr_w', sheetId: 'sheet_1', name: 'legacy wait', triggerType: 'record.created',
+      triggerConfig: {}, actionType: 'wait_for_callback', actionConfig: {}, enabled: true,
+      actions: [{ type: 'wait_for_callback', config: {} }],
+      executionMode: null, // inconsistent: a wait step but legacy mode
+    }
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule, onSave: saved })
+    await flushPromises()
+
+    const toggle = container.querySelector('[data-field="executionMode"]') as HTMLInputElement
+    expect(toggle.checked).toBe(true) // forced on
+    expect(toggle.disabled).toBe(true) // locked
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].executionMode).toBe('workflow_job_v1') // enforced by buildPayload, not null
   })
 
   it('serializes numeric condition values as numbers', async () => {


### PR DESCRIPTION
A6-2b — the frontend that makes the landed A6-2 suspend/resume runtime **operable from the UI** (admin-gated v1). Follows #2237 (backend) + design-lock #2236. **Frontend-only; no backend/contract change.** Not a new engine capability — it closes the A6-2 admin loop.

## What it does
- **Rule editor:** `wait_for_callback` is a selectable action with an **info-only config (zero params** — no webhook-URL / timer / manual-task fields). A `[update, wait, update]` rule is buildable within the existing max-3-actions UI.
- **Admin runs detail:** a suspended step shows a **Resume** action — **confirm-gated** ("continues the remaining actions and may cause external side effects", same mental model as A5 retry's `confirmSideEffects`), which calls `POST /automation/resume` and reloads the detail in place. The discriminated codes (`404 NOT_FOUND`, `409 ALREADY_RESUMED / RULE_CHANGED / RULE_MISSING_OR_DISABLED / RECORD_GONE`) map to **inline** errors — never a generic toast.

## Token surface (per owner)
**Admin-detail-only, never displayed.** The list route uses legacy steps (no token); the detail's Resume button uses the suspended step's `suspend.resumeToken` **internally** and never renders it. (The masked `rt_••••`+copy chip is deferred — no external emitter in v1, so there's no need to hand the token out.)

## Acceptance points (the 4 pinned)
1. Editor: `wait_for_callback` selectable, config info-only, **zero params**. ✅
2. Resume only in admin **detail**; list fetches/shows **no token, no resume**. ✅
3. Error mapping: all 404/409 codes → **inline** error. ✅
4. **Non-admin** doesn't fetch detail / resume (extends the existing admin-gate spec). ✅

## Tests (frontend, vitest)
- **Editor spec:** `wait_for_callback` selectable + info-only (0 param inputs) + serializes `{ type, config:{} }`.
- **Runs-view spec:** suspended step → confirm-gated Resume → `resumeAutomation(token)` + reload + **token never rendered**; cancel → no resume; `409 RULE_CHANGED` → inline message; non-admin → no list/detail/resume.
- **Labels-sync spec** passes (union/KEYS/values in sync). `vue-tsc -b` clean.
- Full web suite: only pre-existing **env flakes** fail (timezone date / localStorage bucket / designer-wiring) — none reference any A6-2b symbol; the date one passes under `TZ=UTC`.

A6-3 (branch/DAG) · A6-4 (BPMN) · A6-5 (approval-as-job) remain demand-gated; the public webhook endpoint + token emitter remain a separate opt-in.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
