### PR TITLE
feat(multitable): same-record formula-over-lookup (A-min)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -171,6 +171,7 @@ jobs:
             tests/integration/multitable-permission-golden-d3d2.test.ts \
             tests/integration/multitable-view-aggregate.test.ts \
             tests/integration/multitable-typed-query-numeric-view.test.ts \
+            tests/integration/multitable-formula-over-lookup-view.test.ts \
             tests/integration/multitable-formula-dryrun.test.ts \
             tests/integration/multitable-records-read-field-mask.test.ts \
             tests/integration/multitable-readpath-search-filter-field-mask.test.ts \

--- a/packages/core-backend/src/multitable/formula-engine.ts
+++ b/packages/core-backend/src/multitable/formula-engine.ts
@@ -244,7 +244,10 @@ export class MultitableFormulaEngine {
 
   /**
    * Recalculate all formula fields for a given record.
-   * Loads the record, finds formula fields, evaluates them, and writes computed values back.
+   * Loads the record (raw) and delegates to recalculateRecordFromData. Use this for callers
+   * without an already-hydrated row (e.g. form-submit). The PATCH write-path uses
+   * recalculateRecordFromData directly with a row whose lookup/rollup values were hydrated
+   * in-memory, so formula-over-lookup sees the actual lookup value (A-min, design #2246).
    */
   async recalculateRecord(
     query: MultitableRecordsQueryFn,
@@ -263,6 +266,30 @@ export class MultitableFormulaEngine {
       const data: Record<string, unknown> =
         typeof row.data === 'string' ? JSON.parse(row.data) : (row.data ?? {})
 
+      return await this.recalculateRecordFromData(query, sheetId, recordId, data, fields)
+    } catch (error) {
+      logger.error('recalculateRecord failed:', error as Error)
+      return null
+    }
+  }
+
+  /**
+   * Evaluate + materialize a record's formula fields against PROVIDED `data` (no DB reload).
+   * The write-path recalc passes a row whose lookup/rollup values were already hydrated
+   * in-memory (via applyLookupRollup) so formulas reference the actual lookup value instead of
+   * the absent-on-reload `undefined → '0'` (A-min, design #2246). Only formula keys are written
+   * back (`data || $keys`) — lookup/rollup values are NOT materialized. Note: a scalar-array
+   * lookup reaches `evaluateField` as a joined string literal per the existing A2b contract;
+   * exact numeric arithmetic over lookups is Option D (parser), out of A-min scope.
+   */
+  async recalculateRecordFromData(
+    query: MultitableRecordsQueryFn,
+    sheetId: string,
+    recordId: string,
+    data: Record<string, unknown>,
+    fields: MultitableField[],
+  ): Promise<Record<string, unknown> | null> {
+    try {
       // Resolve each formula field's expression. Field-defined formulas store the
       // expression in `field.property.expression` (the authoring surface + the
       // source `formula_dependencies` is built from). Fall back to a legacy `=…`
@@ -309,7 +336,7 @@ export class MultitableFormulaEngine {
       )
       return { ...data, ...updates }
     } catch (error) {
-      logger.error('recalculateRecord failed:', error as Error)
+      logger.error('recalculateRecordFromData failed:', error as Error)
       return null
     }
   }

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -300,6 +300,9 @@ export interface RecordWriteHelpers {
     fields: UniverMetaField[],
     updatedRecordIds: string[],
     changedFieldIds: string[],
+    // A-min (design #2246): optional pre-hydrated row data per record (lookup/rollup resolved
+    // in-memory) so formula-over-lookup evals against the actual value. Absent → raw reload.
+    hydratedDataByRecord?: Map<string, Record<string, unknown>>,
   ) => Promise<Array<{ recordId: string; data: Record<string, unknown> }>>
   loadLinkValuesByRecord: (
     query: QueryFn,
@@ -795,6 +798,9 @@ export class RecordWriteService {
     // -----------------------------------------------------------------------
     let computedRecords: Array<{ recordId: string; data: Record<string, unknown> }> | undefined
     let updatedRowsForSummaries: UniverMetaRecord[] = []
+    // A-min (design #2246): full hydrated row data (lookup/rollup resolved in-memory) for the
+    // updated records, captured in Step 4 and fed into the Step 4c formula recalc.
+    let hydratedDataByRecord: Map<string, Record<string, unknown>> | undefined
     const computedFieldIds = visiblePropertyFields.filter((f) => f.type === 'lookup' || f.type === 'rollup')
 
     if (updates.length > 0 && (computedFieldIds.length > 0 || attachmentFields.length > 0)) {
@@ -827,6 +833,11 @@ export class RecordWriteService {
         relationalLinkFields,
         linkValuesByRecord,
       )
+
+      // A-min: snapshot the FULL hydrated data BEFORE the visibility filter below mutates
+      // row.data — the formula recalc (Step 4c) evals against this so a formula referencing a
+      // lookup sees the actual lookup value instead of the absent-on-reload `undefined → '0'`.
+      hydratedDataByRecord = new Map(rows.map((row) => [row.id, { ...row.data }]))
 
       for (const row of rows) {
         row.data = h.filterRecordDataByFieldIds(row.data, visiblePropertyFieldIds)
@@ -880,6 +891,7 @@ export class RecordWriteService {
               fields,
               updates.map((update) => update.recordId),
               changedFieldIds,
+              hydratedDataByRecord,
             )
           ).map((record) => ({
             recordId: record.recordId,

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1624,24 +1624,48 @@ async function recalculateFormulaFields(
   fields: UniverMetaField[],
   updatedRecordIds: string[],
   changedFieldIds: string[],
+  // A-min (design #2246): per-record rows whose lookup/rollup were already hydrated in-memory
+  // (write-path Step 4). When provided, eval formulas against the hydrated data so a
+  // formula-over-lookup sees the actual lookup value instead of the absent-on-reload `0`.
+  // Same-record / same-sheet only; absent → raw reload (unchanged for form-submit).
+  hydratedDataByRecord?: Map<string, Record<string, unknown>>,
 ): Promise<Array<{ recordId: string; data: Record<string, unknown> }>> {
   if (updatedRecordIds.length === 0 || changedFieldIds.length === 0) return []
   const formulaFieldIds = fields.filter((f) => f.type === 'formula').map((f) => f.id)
   if (formulaFieldIds.length === 0) return []
 
-  // Gate: only recompute when a changed field actually feeds a formula here.
+  // A-min trigger: a lookup/rollup's value changes when its underlying LINK field is edited, but
+  // changedFieldIds carries the link id, not the derived lookup id — so the dependency gate
+  // (formula → lookup) would miss. Expand the changed set with the SAME-RECORD lookup/rollup ids
+  // whose linkFieldId is in changedFieldIds. This stays bounded to updatedRecordIds (the patched
+  // records) → it never reaches foreign/related records' formulas (that is A-full, gated).
+  const changedSet = new Set(changedFieldIds)
+  const effectiveChangedFieldIds = [...changedSet]
+  for (const field of fields) {
+    if (field.type !== 'lookup' && field.type !== 'rollup') continue
+    if (changedSet.has(field.id)) continue
+    const cfg = field.type === 'lookup' ? parseLookupFieldConfig(field.property) : parseRollupFieldConfig(field.property)
+    if (cfg && changedSet.has(cfg.linkFieldId)) {
+      effectiveChangedFieldIds.push(field.id)
+    }
+  }
+
+  // Gate: only recompute when a changed (or dependent-lookup) field actually feeds a formula here.
   const depRes = await query(
     `SELECT DISTINCT field_id FROM formula_dependencies
      WHERE depends_on_field_id = ANY($1::text[])
        AND (depends_on_sheet_id IS NULL OR depends_on_sheet_id = $2)
        AND sheet_id = $2`,
-    [changedFieldIds, sheetId],
+    [effectiveChangedFieldIds, sheetId],
   )
   if (depRes.rows.length === 0) return []
 
   const results: Array<{ recordId: string; data: Record<string, unknown> }> = []
   for (const recordId of updatedRecordIds) {
-    const nextData = await multitableFormulaEngine.recalculateRecord(query, sheetId, recordId, fields)
+    const hydrated = hydratedDataByRecord?.get(recordId)
+    const nextData = hydrated
+      ? await multitableFormulaEngine.recalculateRecordFromData(query, sheetId, recordId, hydrated, fields)
+      : await multitableFormulaEngine.recalculateRecord(query, sheetId, recordId, fields)
     if (!nextData) continue
     const formulaData: Record<string, unknown> = {}
     for (const fieldId of formulaFieldIds) {

--- a/packages/core-backend/tests/integration/multitable-formula-over-lookup-view.test.ts
+++ b/packages/core-backend/tests/integration/multitable-formula-over-lookup-view.test.ts
@@ -1,0 +1,114 @@
+/**
+ * A-min (formula-over-lookup, design #2246) — real-DB wire proof.
+ *
+ * Proves the headline fix through the actual PATCH write path, and proves A-min did NOT silently
+ * grow into A-full (foreign-record propagation):
+ *  - T1/T2 (positive, same-record): editing a record's LINK field re-runs that record's formula
+ *    AND it computes against the ACTUAL hydrated lookup value (not stale, not absent→0).
+ *  - T4a (negative, foreign record in a SEPARATE sheet): editing the foreign record's target does
+ *    NOT re-run the related record's formula — the same-record boundary is enforced, not assumed.
+ *
+ * Runs only with DATABASE_URL (describeIfDatabase) via the plugin-tests.yml real-DB runner list.
+ * Numeric semantics observed in tests/unit/multitable-formula-over-lookup.test.ts: a single-value
+ * numeric lookup [9] hydrates and `={lu}+1` evaluates to 10 (the base engine coerces the scalar
+ * join numerically); absent → 1. So 10 vs 6 (no re-run) vs 1 (value-source=0) are all distinct.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const USER = `u_fol_${TS}`
+const BASE_ID = `base_fol_${TS}`
+const FS = `sheet_fol_foreign_${TS}` // foreign sheet (separate from the main sheet)
+const MS = `sheet_fol_main_${TS}` // main sheet (link + lookup + formula)
+const FLD_FTARGET = `fld_ftarget_${TS}`
+const FLD_LINK = `fld_link_${TS}`
+const FLD_LU = `fld_lu_${TS}`
+const FLD_F = `fld_f_${TS}`
+const REC_FX = `rec_fx_${TS}` // foreign target = 5
+const REC_FY = `rec_fy_${TS}` // foreign target = 9
+const REC_M = `rec_m_${TS}` // main record, seeded linked to REC_FX with a STALE formula (6)
+
+let app: Express
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const readFormula = async (recordId: string, sheetId: string) => {
+  const r = await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [recordId, sheetId])
+  const data = (r.rows as any[])[0]?.data
+  const parsed = typeof data === 'string' ? JSON.parse(data) : data
+  return parsed?.[FLD_F]
+}
+
+describeIfDatabase('multitable formula-over-lookup A-min (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: USER, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [BASE_ID, 'FoL Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [FS, BASE_ID, 'Foreign Sheet'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [MS, BASE_ID, 'Main Sheet'])
+
+    // foreign sheet: one numeric target field + two records (5, 9)
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_FTARGET, FS, 'FTarget', 'number', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_FX, FS, JSON.stringify({ [FLD_FTARGET]: 5 })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_FY, FS, JSON.stringify({ [FLD_FTARGET]: 9 })])
+
+    // main sheet: link -> FS, lookup (link -> FS.FTarget), formula = {lookup}+1
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_LINK, MS, 'Link', 'link', JSON.stringify({ foreignSheetId: FS }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_LU, MS, 'Lookup', 'lookup', JSON.stringify({ linkFieldId: FLD_LINK, targetFieldId: FLD_FTARGET, foreignSheetId: FS }), 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_F, MS, 'Formula', 'formula', JSON.stringify({ expression: `={${FLD_LU}}+1` }), 3])
+
+    // main record: seeded with a STALE formula value (6, as if computed for the REC_FX link) +
+    // an existing link to REC_FX, and the formula→lookup dependency edge.
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_M, MS, JSON.stringify({ [FLD_F]: 6 })])
+    await q('INSERT INTO meta_links (id, field_id, record_id, foreign_record_id) VALUES ($1,$2,$3,$4)', [`lnk_${TS}`, FLD_LINK, REC_M, REC_FX])
+    await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,$4)', [MS, FLD_F, FLD_LU, MS])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM formula_dependencies WHERE sheet_id = $1', [MS]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE record_id = $1', [REC_M]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('T1/T2: same-record link edit re-runs the formula against the ACTUAL hydrated lookup value', async () => {
+    // Re-point REC_M's link from REC_FX(5) to REC_FY(9). The formula = {lookup}+1 must re-run
+    // (trigger) and compute against the new lookup value 9 (value-source) → 10.
+    // 10 distinguishes from 6 (no re-run / stale) and from 1 (re-ran but lookup absent → 0).
+    const res = await request(app).post('/api/multitable/patch').send({
+      sheetId: MS,
+      changes: [{ recordId: REC_M, fieldId: FLD_LINK, value: [REC_FY], expectedVersion: 1 }],
+    })
+    expect(res.status).toBe(200)
+    expect(await readFormula(REC_M, MS)).toBe(10) // DB-materialized, authoritative
+  })
+
+  test('T4a (negative): editing the FOREIGN record does NOT re-run the related formula (A-min ≠ A-full)', async () => {
+    // After T1, REC_M.formula = 10 (lookup = REC_FY.FTarget = 9). Now edit the FOREIGN record
+    // REC_FY.FTarget 9 → 100 on the SEPARATE foreign sheet. Under A-min, REC_M's formula must
+    // stay 10 (foreign-record propagation is A-full, deliberately NOT implemented). If it became
+    // 101 the slice silently grew into A-full.
+    const res = await request(app).post('/api/multitable/patch').send({
+      sheetId: FS,
+      changes: [{ recordId: REC_FY, fieldId: FLD_FTARGET, value: 100, expectedVersion: 1 }],
+    })
+    expect(res.status).toBe(200)
+    expect(await readFormula(REC_M, MS)).toBe(10) // unchanged — same-record boundary enforced
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-formula-over-lookup.test.ts
+++ b/packages/core-backend/tests/unit/multitable-formula-over-lookup.test.ts
@@ -1,0 +1,88 @@
+/**
+ * A-min (formula-over-lookup, design #2246) — value-source unit coverage.
+ *
+ * Proves the multitable wrapper evaluates a formula against a row whose lookup value is PRESENT
+ * (hydrated) — yielding the actual value, not the absent-on-reload `undefined → '0'` — and that
+ * recalculateRecordFromData writes back ONLY formula keys (lookup/rollup are NOT materialized).
+ * The same-record TRIGGER + the real wire are covered in the real-DB integration test
+ * (tests/integration/multitable-formula-over-lookup-view.test.ts).
+ *
+ * NOTE on numeric semantics (observed, not assumed): a single-value scalar lookup hydrates as an
+ * array (e.g. [5]); evaluateField joins a scalar array into a string literal ("5"), and the frozen
+ * base engine coerces it numerically in arithmetic — so `={LU}+1` over [5] = 6, `={LU}*2` = 10.
+ * A bare `={LU}` yields the value-as-string ("5"/"beta"); a multi-value lookup joins to a string
+ * ("5,7"). Correct numeric arithmetic over MULTI-value lookups is Option D (parser), out of A-min.
+ */
+import { describe, expect, it, vi } from 'vitest'
+
+import { MultitableFormulaEngine } from '../../src/multitable/formula-engine'
+
+const fields = [
+  { id: 'fld_lu', name: 'LU', type: 'lookup' as const },
+  { id: 'fld_f', name: 'F', type: 'formula' as const },
+]
+
+describe('A-min value source: evaluateField over a hydrated (array-valued) lookup', () => {
+  const eng = new MultitableFormulaEngine()
+
+  it('single-value numeric lookup is numerically usable in arithmetic (was: computes against 0)', async () => {
+    expect(await eng.evaluateField('={fld_lu}+1', { fld_lu: [5] } as any, fields as any)).toBe(6)
+    expect(await eng.evaluateField('={fld_lu}*2', { fld_lu: [5] } as any, fields as any)).toBe(10)
+  })
+
+  it('absent lookup (the pre-fix bug) computes against 0', async () => {
+    expect(await eng.evaluateField('={fld_lu}+1', {} as any, fields as any)).toBe(1)
+    expect(await eng.evaluateField('={fld_lu}', {} as any, fields as any)).toBe(0)
+  })
+
+  it('bare lookup reaches eval as its value-as-string (string + numeric)', async () => {
+    expect(await eng.evaluateField('={fld_lu}', { fld_lu: ['beta'] } as any, fields as any)).toBe('beta')
+    expect(await eng.evaluateField('={fld_lu}', { fld_lu: [5] } as any, fields as any)).toBe('5')
+  })
+
+  it('multi-value scalar lookup joins to a string (no arithmetic; Option-D territory)', async () => {
+    expect(await eng.evaluateField('={fld_lu}', { fld_lu: [5, 7] } as any, fields as any)).toBe('5,7')
+  })
+
+  it('object-valued lookup → #VALUE! (A2b), never a fake join or 0', async () => {
+    expect(await eng.evaluateField('={fld_lu}', { fld_lu: [{ a: 1 }] } as any, fields as any)).toBe('#VALUE!')
+  })
+
+  it('rollup hydrates as a scalar number (cleaner than lookup) and is numerically usable', async () => {
+    // rollup aggregates to a number|null, so no array-join — `={ru}+1` over 5 = 6 directly.
+    const rfields = [{ id: 'fld_ru', name: 'RU', type: 'rollup' as const }, ...fields]
+    expect(await eng.evaluateField('={fld_ru}+1', { fld_ru: 5 } as any, rfields as any)).toBe(6)
+    expect(await eng.evaluateField('={fld_ru}', { fld_ru: 5 } as any, rfields as any)).toBe(5)
+  })
+})
+
+describe('A-min value source: recalculateRecordFromData evals against PROVIDED hydrated data', () => {
+  it('computes the formula from the hydrated lookup and writes back ONLY formula keys', async () => {
+    const calls: Array<{ sql: string; params: unknown[] }> = []
+    const query = vi.fn(async (sql: string, params?: unknown[]) => {
+      calls.push({ sql, params: params ?? [] })
+      return { rows: [], rowCount: 1 }
+    })
+    const eng = new MultitableFormulaEngine()
+    const ffields = [
+      { id: 'fld_lu', name: 'LU', type: 'lookup' as const },
+      { id: 'fld_f', name: 'F', type: 'formula' as const, property: { expression: '={fld_lu}+1' } },
+    ]
+    // hydrated row: lookup already resolved in-memory (the write-path Step-4 snapshot)
+    const hydrated = { fld_lu: [5] }
+
+    const next = await eng.recalculateRecordFromData(query as any, 'sheet_1', 'rec_1', hydrated as any, ffields as any)
+
+    // returns the formula computed from the hydrated lookup (6 = 5 + 1), not 1 (absent→0)
+    expect(next).toMatchObject({ fld_f: 6 })
+
+    // exactly one UPDATE, merging ONLY the formula key — lookup value is NOT materialized
+    const update = calls.find((c) => /UPDATE meta_records/.test(c.sql))
+    expect(update).toBeTruthy()
+    const writtenBack = JSON.parse(String(update!.params[0]))
+    expect(writtenBack).toEqual({ fld_f: 6 })
+    expect('fld_lu' in writtenBack).toBe(false) // lookup NOT persisted
+    // no SELECT reload — recalculateRecordFromData evaluates against the provided data
+    expect(calls.some((c) => /SELECT/.test(c.sql))).toBe(false)
+  })
+})

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -244,12 +244,15 @@ describe('RecordWriteService', () => {
     const result = await service.patchRecords(input)
 
     // Helper is invoked with the changed field ids so it can gate on formula_dependencies.
+    // 6th arg = hydratedDataByRecord (A-min): undefined here since this sheet has no lookup/rollup
+    // fields, so the write-path Step-4 hydration block does not run.
     expect(recalculateFormulaFields).toHaveBeenCalledWith(
       expect.any(Function),
       'sheet1',
       fields,
       ['rec1'],
       ['fld_name'],
+      undefined,
     )
     // Editing client: the computed formula value rides back in the response records.
     expect(result.records).toEqual(


### PR DESCRIPTION
Implements **Slice 1 / A-min** of the formula-over-lookup design-lock (#2246). A formula referencing a lookup/rollup now recomputes correctly when the **same record's** link is edited — against the actual lookup value instead of the absent-on-reload `undefined → '0'`.

## Two layers (both same-record / same-sheet only)

- **Value source:** the write path already hydrates the updated rows' lookup/rollup in-memory (Step 4, `applyLookupRollup`). Capture that hydrated row and feed it into the formula recalc instead of reloading raw. New wrapper method `recalculateRecordFromData(data)` evaluates against provided data; `recalculateRecord` = load-raw → delegate (form-submit/create callers unchanged). **Only formula keys are written back — lookup/rollup are NOT materialized.**
- **Trigger:** a lookup's value changes when its underlying **link** field is edited, but `changedFieldIds` carries the link id, not the derived lookup id, so the `formula → lookup` gate missed. `recalculateFormulaFields` now expands the changed set with the same-record lookup/rollup ids whose `linkFieldId` changed — **bounded to `updatedRecordIds`, so it never reaches foreign/related records.**

## Honest, qualified scope (not "formula-over-lookup fixed")

- ✅ **Numeric-correct for the single-value case** (observed in the unit test, not assumed): `={lu}+1`=6, `={lu}*2`=10 (the base engine coerces the scalar-join string numerically); bare `={lu}` = value-as-string; rollup hydrates as a clean number.
- ⚠️ **PATCH-path only.** Form-submit and create still recalc raw → a formula-over-lookup there computes against `0` until the record's first grid PATCH. Documented boundary; closing it is a separate slice.
- 🔒 **Deferred by design:** foreign-record → related-record propagation (**A-full / bounded C2a**), correct multi-value-lookup arithmetic (joins to a string today — **Option D** parser), lookup materialization, dry-run hydration.

## Frozen / boundary

No `src/formula/engine.ts` change (only the multitable wrapper + recalc orchestration), no RBAC/auth, no storage migration, no new field-permission gate. Per design §5/§6.

## Tests

- `tests/unit/multitable-formula-over-lookup.test.ts` (7) — value-source numeric semantics (single/multi/object/absent), rollup, and `recalculateRecordFromData` writes back **only** formula keys (no lookup materialization).
- `tests/integration/multitable-formula-over-lookup-view.test.ts` (3, real-DB; added to the `plugin-tests.yml` runner list so it actually runs) — **T1/T2** positive same-record (link edit re-runs formula to `10` = actual lookup `9` + 1; distinguishes from `6` no-re-run and `1` value-source-broken) + **T4a NEGATIVE** foreign-record-in-a-**separate-sheet** (formula stays `10`; proves A-min did not grow into A-full). **Validated locally green against a real DB.**
- Full backend `test:unit` green locally (210 files / 2713 tests).

🤖 Generated with [Claude Code](https://claude.com/claude-code)