### PR TITLE
docs(multitable): tick A6-2b frontend LANDED in the A6 execution plan

### DIFF
--- a/docs/development/multitable-automation-a6-execution-plan-20260601.md
+++ b/docs/development/multitable-automation-a6-execution-plan-20260601.md
@@ -131,12 +131,13 @@ only missing link.
 
 ---
 
-## 2. A6-2 suspend/resume — ✅ LANDED 2026-06-03 (#2236 design-lock + #2237 impl)
+## 2. A6-2 suspend/resume — ✅ LANDED 2026-06-03 (#2236 design-lock + #2237 impl + #2245 frontend)
 
 > **✅ LANDED 2026-06-03 — PR #2237 (squash `c363a78db`); design-lock #2236.** Admin-gated v1, webhook-
 > first (delay/timer + worker/claim still deferred/red-lined). As-built detail + the 2 review rounds live
 > in `multitable-automation-a6-2-suspend-resume-{design,verification}-20260603.md` — **not re-derived
-> here**. Remaining sub-step = A6-2b frontend (separate opt-in). Original plan retained below for the record.
+> here**. A6-2b frontend (admin Resume UI + `wait_for_callback` editor) **landed 2026-06-03 — PR #2245
+> (squash `cee99c8e4`)**, frontend-only/no contract change. Original plan retained below for the record.
 
 - **Adds:** the `suspended` C1 status, a resume token, and an **external-event/webhook
   resume endpoint first**; delay/timer resume (and the durable scheduler + worker/claim


### PR DESCRIPTION
Minimal reconcile (same shape as #2239) of the A6 execution-plan §2 note now that **A6-2b frontend landed as #2245** (squash `cee99c8e4`).

## Change (1 file, +3/−2)
- §2 header: `… (#2236 design-lock + #2237 impl + #2245 frontend)`.
- §2 note: the stale `Remaining sub-step = A6-2b frontend (separate opt-in)` line → `A6-2b frontend (admin Resume UI + wait_for_callback editor) landed 2026-06-03 — PR #2245`, frontend-only/no contract change.

## Scope
- **Docs-only minimal reconcile** — no design re-derivation. A6-2 (suspend/resume) is now fully landed (runtime #2237 + frontend #2245).
- **A6-3 (branch/DAG) · A6-4 (BPMN) · A6-5 (approval-as-job) stay design-deferred + demand-gated.** The public webhook endpoint + token emitter remain a separate opt-in. Nothing here starts the next rung.

🤖 Generated with [Claude Code](https://claude.com/claude-code)