### PR TITLE
fix(attendance): authenticate remote metrics scrape

### DIFF
--- a/.github/workflows/attendance-remote-metrics-prod.yml
+++ b/.github/workflows/attendance-remote-metrics-prod.yml
@@ -46,7 +46,11 @@ jobs:
       metrics_rc: ${{ steps.remote_metrics.outputs.metrics_rc }}
       metrics_reason: ${{ steps.remote_metrics.outputs.metrics_reason }}
       missing_metrics: ${{ steps.remote_metrics.outputs.missing_metrics }}
+      metrics_auth_configured: ${{ steps.remote_metrics.outputs.metrics_auth_configured }}
     steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
       - name: Remote metrics check (with host sync logs)
         id: remote_metrics
         continue-on-error: true
@@ -55,12 +59,18 @@ jobs:
           DEPLOY_USER: ${{ secrets.DEPLOY_USER }}
           DEPLOY_SSH_KEY_B64: ${{ secrets.DEPLOY_SSH_KEY_B64 }}
           DEPLOY_PATH: ${{ secrets.DEPLOY_PATH }}
+          DEPLOY_COMPOSE_FILE: ${{ secrets.DEPLOY_COMPOSE_FILE }}
+          METRICS_AUTH_HEADER_SECRET: ${{ secrets.METRICS_AUTH_HEADER }}
           DRILL_FAIL: ${{ github.event.inputs.drill_fail || 'false' }}
           SKIP_HOST_SYNC: ${{ github.event.inputs.skip_host_sync || 'false' }}
           METRICS_URL: ${{ github.event.inputs.metrics_url || 'http://127.0.0.1:8900/metrics/prom' }}
           MAX_TIME: ${{ github.event.inputs.max_time || '10' }}
         run: |
           set -euo pipefail
+          quote_for_remote() {
+            printf '%q' "$1"
+          }
+
           mkdir -p ~/.ssh
           printf '%s' "$DEPLOY_SSH_KEY_B64" | base64 -d > ~/.ssh/deploy_key
           chmod 600 ~/.ssh/deploy_key
@@ -74,14 +84,36 @@ jobs:
 
           mkdir -p output/metrics
           metrics_log="output/metrics/metrics.log"
+          token_fallback_log="output/metrics/metrics-token-fallback.log"
+
+          METRICS_AUTH_HEADER="${METRICS_AUTH_HEADER_SECRET:-}"
+          if [[ -z "$METRICS_AUTH_HEADER" ]]; then
+            set +e
+            metrics_token="$(METRICS_SCRAPE_TOKEN_RESOLVE_REQUIRED=false bash scripts/ops/resolve-metrics-scrape-token.sh 2> >(tee "$token_fallback_log" >&2))"
+            token_resolve_status=$?
+            set -e
+            if [[ "$token_resolve_status" != "0" ]]; then
+              echo "::warning::deploy-host metrics token fallback failed (exit ${token_resolve_status}); remote metrics check will continue without derived auth"
+            elif [[ -n "$metrics_token" ]]; then
+              echo "::add-mask::$metrics_token"
+              METRICS_AUTH_HEADER="Authorization: Bearer $metrics_token"
+            fi
+          fi
+          if [[ -n "$METRICS_AUTH_HEADER" ]]; then
+            echo "::add-mask::$METRICS_AUTH_HEADER"
+            echo "metrics_auth_configured=true" >> "$GITHUB_OUTPUT"
+          else
+            echo "metrics_auth_configured=false" >> "$GITHUB_OUTPUT"
+          fi
 
           remote_cmds=(
             "set -euo pipefail"
-            "DEPLOY_PATH=\"${DEPLOY_PATH}\""
-            "DRILL_FAIL=\"${DRILL_FAIL}\""
-            "SKIP_HOST_SYNC=\"${SKIP_HOST_SYNC}\""
-            "METRICS_URL=\"${METRICS_URL}\""
-            "MAX_TIME=\"${MAX_TIME}\""
+            "DEPLOY_PATH=$(quote_for_remote "${DEPLOY_PATH}")"
+            "DRILL_FAIL=$(quote_for_remote "${DRILL_FAIL}")"
+            "SKIP_HOST_SYNC=$(quote_for_remote "${SKIP_HOST_SYNC}")"
+            "METRICS_URL=$(quote_for_remote "${METRICS_URL}")"
+            "MAX_TIME=$(quote_for_remote "${MAX_TIME}")"
+            "METRICS_AUTH_HEADER=$(quote_for_remote "${METRICS_AUTH_HEADER}")"
             'if [[ "${DEPLOY_PATH}" == /* ]]; then'
               '  DEPLOY_REPO_PATH="${DEPLOY_PATH}"'
             'elif [[ "${DEPLOY_PATH}" == ~/* ]]; then'
@@ -129,7 +161,7 @@ jobs:
               '  metrics_rc="$host_sync_rc"'
             "else"
               "  set +e"
-              "  METRICS_URL=\"${METRICS_URL}\" MAX_TIME=\"${MAX_TIME}\" scripts/ops/attendance-check-metrics.sh"
+              '  METRICS_URL="${METRICS_URL}" MAX_TIME="${MAX_TIME}" METRICS_AUTH_HEADER="${METRICS_AUTH_HEADER}" scripts/ops/attendance-check-metrics.sh'
               '  metrics_rc=$?'
               "  set -e"
             "fi"
@@ -176,6 +208,7 @@ jobs:
           METRICS_RC: ${{ steps.remote_metrics.outputs.metrics_rc }}
           METRICS_REASON: ${{ steps.remote_metrics.outputs.metrics_reason }}
           MISSING_METRICS: ${{ steps.remote_metrics.outputs.missing_metrics }}
+          METRICS_AUTH_CONFIGURED: ${{ steps.remote_metrics.outputs.metrics_auth_configured }}
           METRICS_URL: ${{ github.event.inputs.metrics_url || 'http://127.0.0.1:8900/metrics/prom' }}
           MAX_TIME: ${{ github.event.inputs.max_time || '10' }}
           DRILL_FAIL: ${{ github.event.inputs.drill_fail || 'false' }}
@@ -216,6 +249,7 @@ jobs:
           echo "- Remote exit code: \`${METRICS_RC:-missing}\` (meaning: ${rc_meaning})" >> "$GITHUB_STEP_SUMMARY"
           echo "- Failure reason: \`${METRICS_REASON:-missing}\`" >> "$GITHUB_STEP_SUMMARY"
           echo "- Metrics URL: \`${METRICS_URL:-missing}\` (max_time=\`${MAX_TIME:-missing}\`s)" >> "$GITHUB_STEP_SUMMARY"
+          echo "- Metrics auth configured: \`${METRICS_AUTH_CONFIGURED:-missing}\`" >> "$GITHUB_STEP_SUMMARY"
           if [[ -n "${MISSING_METRICS:-}" ]]; then
             echo "- Missing metrics: \`${MISSING_METRICS}\`" >> "$GITHUB_STEP_SUMMARY"
           fi
@@ -366,6 +400,7 @@ jobs:
       METRICS_RC: ${{ needs.metrics.outputs.metrics_rc }}
       METRICS_REASON: ${{ needs.metrics.outputs.metrics_reason }}
       MISSING_METRICS: ${{ needs.metrics.outputs.missing_metrics }}
+      METRICS_AUTH_CONFIGURED: ${{ needs.metrics.outputs.metrics_auth_configured }}
       METRICS_URL: ${{ github.event.inputs.metrics_url || 'http://127.0.0.1:8900/metrics/prom' }}
       MAX_TIME: ${{ github.event.inputs.max_time || '10' }}
     steps:
@@ -379,6 +414,7 @@ jobs:
             const metricsRc = String(process.env.METRICS_RC || '').trim()
             const metricsReason = String(process.env.METRICS_REASON || '').trim()
             const missingMetrics = String(process.env.MISSING_METRICS || '').trim()
+            const metricsAuthConfigured = String(process.env.METRICS_AUTH_CONFIGURED || '').trim()
             const metricsUrl = String(process.env.METRICS_URL || '').trim()
             const maxTime = String(process.env.MAX_TIME || '').trim()
             const titleOverride = String(process.env.ISSUE_TITLE_OVERRIDE || '').trim()
@@ -401,7 +437,7 @@ jobs:
             const artifactName = `attendance-remote-metrics-prod-${context.runId}-${process.env.GITHUB_RUN_ATTEMPT || '1'}`
 
             const failed = metricsResult === 'failure'
-            const statusLine = `job: metrics=${metricsResult || 'unknown'} rc=${metricsRc || 'missing'} reason=${metricsReason || 'missing'} missing_metrics=${missingMetrics || 'none'} metrics_url=${metricsUrl || 'missing'} max_time=${maxTime || 'missing'} skip_host_sync=${skipHostSync || 'missing'}${drillFail ? ' (drill_fail=true)' : ''}`
+            const statusLine = `job: metrics=${metricsResult || 'unknown'} rc=${metricsRc || 'missing'} reason=${metricsReason || 'missing'} missing_metrics=${missingMetrics || 'none'} metrics_auth_configured=${metricsAuthConfigured || 'missing'} metrics_url=${metricsUrl || 'missing'} max_time=${maxTime || 'missing'} skip_host_sync=${skipHostSync || 'missing'}${drillFail ? ' (drill_fail=true)' : ''}`
 
             const body = [
               'Automated host metrics tracking issue (P1, no paging).',

--- a/scripts/ops/attendance-check-metrics.sh
+++ b/scripts/ops/attendance-check-metrics.sh
@@ -7,6 +7,8 @@ set -euo pipefail
 
 METRICS_URL="${METRICS_URL:-http://127.0.0.1:8900/metrics/prom}"
 MAX_TIME="${MAX_TIME:-10}"
+METRICS_AUTH_HEADER="${METRICS_AUTH_HEADER:-}"
+METRICS_SCRAPE_TOKEN="${METRICS_SCRAPE_TOKEN:-}"
 
 function die() {
   echo "[attendance-check-metrics] ERROR: $*" >&2
@@ -22,7 +24,16 @@ if ! command -v curl >/dev/null 2>&1; then
 fi
 
 info "Fetching: ${METRICS_URL}"
-raw="$(curl -fsS --max-time "$MAX_TIME" "$METRICS_URL")"
+curl_args=(-fsS --max-time "$MAX_TIME")
+if [[ -n "$METRICS_AUTH_HEADER" ]]; then
+  curl_args+=(-H "$METRICS_AUTH_HEADER")
+  info "Using metrics auth header"
+elif [[ -n "$METRICS_SCRAPE_TOKEN" ]]; then
+  curl_args+=(-H "x-metrics-token: $METRICS_SCRAPE_TOKEN")
+  info "Using metrics scrape token"
+fi
+
+raw="$(curl "${curl_args[@]}" "$METRICS_URL")"
 
 # Basic Prometheus sanity.
 if ! grep -qE '^# (HELP|TYPE) ' <<<"$raw"; then

--- a/scripts/ops/attendance-check-metrics.test.mjs
+++ b/scripts/ops/attendance-check-metrics.test.mjs
@@ -1,0 +1,101 @@
+import assert from 'node:assert/strict'
+import { chmodSync, mkdirSync, mkdtempSync, readFileSync, rmSync, writeFileSync } from 'node:fs'
+import { tmpdir } from 'node:os'
+import path from 'node:path'
+import { spawn } from 'node:child_process'
+import test from 'node:test'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+const scriptPath = path.join(repoRoot, 'scripts', 'ops', 'attendance-check-metrics.sh')
+
+const metricsFixture = [
+  '# HELP attendance_api_errors_total Total attendance API errors',
+  '# TYPE attendance_api_errors_total counter',
+  '# HELP attendance_rate_limited_total Total attendance rate-limited requests',
+  '# TYPE attendance_rate_limited_total counter',
+  '# HELP attendance_operation_requests_total Total attendance operation requests',
+  '# TYPE attendance_operation_requests_total counter',
+  '# HELP attendance_operation_latency_seconds Attendance operation latency',
+  '# TYPE attendance_operation_latency_seconds histogram',
+  '# HELP attendance_import_upload_bytes_total Total attendance upload bytes',
+  '# TYPE attendance_import_upload_bytes_total counter',
+  '# HELP attendance_import_upload_rows_total Total attendance upload rows',
+  '# TYPE attendance_import_upload_rows_total counter',
+].join('\n')
+
+function runCheck(env = {}) {
+  const tmp = mkdtempSync(path.join(tmpdir(), 'attendance-check-metrics-'))
+  const binDir = path.join(tmp, 'bin')
+  const argsPath = path.join(tmp, 'curl-args.txt')
+  mkdirSync(binDir)
+  const curlPath = path.join(binDir, 'curl')
+  writeFileSync(
+    curlPath,
+    `#!/usr/bin/env bash
+printf '%s\\n' "$@" > "$FAKE_CURL_ARGS_PATH"
+cat <<'EOF'
+${metricsFixture}
+EOF
+`,
+    'utf8',
+  )
+  chmodSync(curlPath, 0o755)
+
+  return new Promise((resolve, reject) => {
+    const child = spawn('bash', [scriptPath], {
+      stdio: ['ignore', 'pipe', 'pipe'],
+      env: {
+        PATH: `${binDir}:${process.env.PATH || ''}`,
+        HOME: process.env.HOME || '',
+        FAKE_CURL_ARGS_PATH: argsPath,
+        METRICS_URL: 'http://127.0.0.1:8900/metrics/prom',
+        ...env,
+      },
+    })
+    let stdout = ''
+    let stderr = ''
+    child.stdout.setEncoding('utf8')
+    child.stderr.setEncoding('utf8')
+    child.stdout.on('data', (chunk) => {
+      stdout += chunk
+    })
+    child.stderr.on('data', (chunk) => {
+      stderr += chunk
+    })
+    child.on('error', reject)
+    child.on('close', (status) => {
+      let args = ''
+      try {
+        args = readFileSync(argsPath, 'utf8')
+      } finally {
+        rmSync(tmp, { recursive: true, force: true })
+      }
+      resolve({ status, stdout, stderr, args })
+    })
+  })
+}
+
+test('attendance metrics check passes configured auth header to curl', async () => {
+  const result = await runCheck({
+    METRICS_AUTH_HEADER: 'Authorization: Bearer metrics-secret',
+    METRICS_SCRAPE_TOKEN: 'unused-token',
+  })
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stderr, /Using metrics auth header/)
+  assert.match(result.args, /^-H$/m)
+  assert.match(result.args, /^Authorization: Bearer metrics-secret$/m)
+  assert.doesNotMatch(result.args, /unused-token/)
+})
+
+test('attendance metrics check falls back to x-metrics-token when no auth header exists', async () => {
+  const result = await runCheck({
+    METRICS_SCRAPE_TOKEN: 'metrics-secret',
+  })
+
+  assert.equal(result.status, 0, result.stderr)
+  assert.match(result.stderr, /Using metrics scrape token/)
+  assert.match(result.args, /^-H$/m)
+  assert.match(result.args, /^x-metrics-token: metrics-secret$/m)
+})

--- a/scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
+++ b/scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs
@@ -62,3 +62,17 @@ test('regression workflow limits nightly artifact PR contents', () => {
   assert.doesNotMatch(raw, /add-paths:[\s\S]*node_modules/)
   assert.doesNotMatch(raw, /add-paths:[\s\S]*package\.json/)
 })
+
+test('attendance remote metrics reuses metrics scrape auth fallback', () => {
+  const raw = readWorkflow('.github/workflows/attendance-remote-metrics-prod.yml')
+
+  assert.match(raw, /uses: actions\/checkout@v4/)
+  assert.match(raw, /METRICS_AUTH_HEADER_SECRET:\s+\$\{\{\s*secrets\.METRICS_AUTH_HEADER\s*\}\}/)
+  assert.match(raw, /DEPLOY_COMPOSE_FILE:\s+\$\{\{\s*secrets\.DEPLOY_COMPOSE_FILE\s*\}\}/)
+  assert.match(raw, /METRICS_SCRAPE_TOKEN_RESOLVE_REQUIRED=false bash scripts\/ops\/resolve-metrics-scrape-token\.sh/)
+  assert.match(raw, /METRICS_AUTH_HEADER="Authorization: Bearer \$metrics_token"/)
+  assert.match(raw, /METRICS_AUTH_HEADER=\$\(quote_for_remote "\$\{METRICS_AUTH_HEADER\}"\)/)
+  assert.match(raw, /METRICS_AUTH_HEADER="\$\{METRICS_AUTH_HEADER\}" scripts\/ops\/attendance-check-metrics\.sh/)
+  assert.match(raw, /metrics_auth_configured/)
+  assert.doesNotMatch(raw, /ATTENDANCE_ADMIN_JWT/)
+})


### PR DESCRIPTION
## Summary
- allow `scripts/ops/attendance-check-metrics.sh` to send `METRICS_AUTH_HEADER`, falling back to `x-metrics-token` when `METRICS_SCRAPE_TOKEN` is provided
- update `Attendance Remote Metrics (Prod)` to reuse the existing deploy-host `METRICS_SCRAPE_TOKEN` resolver when `METRICS_AUTH_HEADER` is absent
- expose `metrics_auth_configured` in summaries/issues without printing secret material

Refs #273

## Verification
- `node --test scripts/ops/attendance-check-metrics.test.mjs scripts/ops/resolve-metrics-scrape-token.test.mjs scripts/ops/phase5-metrics-auth-fallback-workflow-contract.test.mjs`
- `git diff --check`
- `bash -n scripts/ops/attendance-check-metrics.sh`