### PR TITLE
fix(integration): map dangling data-source bridge errors to 422

### DIFF
--- a/packages/core-backend/src/data-adapters/data-source-plugin-facade.ts
+++ b/packages/core-backend/src/data-adapters/data-source-plugin-facade.ts
@@ -38,6 +38,9 @@ export interface DataSourceReadOnlyFacade {
 }
 
 export const MISSING_PRINCIPAL_MESSAGE = 'data source read requires an owner principal (none provided)'
+export const DATA_SOURCE_PRINCIPAL_REQUIRED_CODE = 'DATA_SOURCE_PRINCIPAL_REQUIRED'
+export const DATA_SOURCE_NOT_FOUND_CODE = 'DATA_SOURCE_NOT_FOUND'
+export const DATA_SOURCE_NOT_READ_ONLY_CODE = 'DATA_SOURCE_NOT_READ_ONLY'
 
 export function writableSourceMessage(dataSourceId: string): string {
   return `data source '${dataSourceId}' is writable; the read-only bridge refuses a writable binding`
@@ -59,9 +62,20 @@ export function writableSourceMessage(dataSourceId: string): string {
  * re-raises that message **verbatim** (it adds a name/type only, never altering the message), so the
  * deleted-vs-not-mine cases stay indistinguishable to the caller.
  */
-export class DataSourceUnavailableError extends Error {
-  constructor(message: string) {
+export class DataSourceBridgeConfigError extends Error {
+  status = 422
+  code: string
+
+  constructor(code: string, message: string, name = 'DataSourceBridgeConfigError') {
     super(message)
+    this.name = name
+    this.code = code
+  }
+}
+
+export class DataSourceUnavailableError extends DataSourceBridgeConfigError {
+  constructor(message: string) {
+    super(DATA_SOURCE_NOT_FOUND_CODE, message)
     this.name = 'DataSourceUnavailableError'
   }
 }
@@ -70,7 +84,11 @@ function requirePrincipal(principal: string | undefined): string {
   // Fail-closed: a read MUST carry an owner principal. We deliberately do NOT fall back to a
   // default / system / tenant / admin identity — that would bypass per-source ownership.
   if (typeof principal !== 'string' || principal.trim() === '') {
-    throw new Error(MISSING_PRINCIPAL_MESSAGE)
+    throw new DataSourceBridgeConfigError(
+      DATA_SOURCE_PRINCIPAL_REQUIRED_CODE,
+      MISSING_PRINCIPAL_MESSAGE,
+      'DataSourcePrincipalRequiredError'
+    )
   }
   return principal
 }
@@ -104,7 +122,11 @@ export function createDataSourcePluginFacade(
     // writable data source fails closed here — on getSchema/getTableInfo/select/test alike, not only
     // when testConnection happens to run first. Checked before connecting (it is a config flag).
     if (!adapter.isReadOnly()) {
-      throw new Error(writableSourceMessage(dataSourceId))
+      throw new DataSourceBridgeConfigError(
+        DATA_SOURCE_NOT_READ_ONLY_CODE,
+        writableSourceMessage(dataSourceId),
+        'DataSourceNotReadOnlyError'
+      )
     }
     if (!adapter.isConnected()) {
       await manager.connectDataSource(dataSourceId)

--- a/packages/core-backend/tests/unit/data-source-plugin-facade.test.ts
+++ b/packages/core-backend/tests/unit/data-source-plugin-facade.test.ts
@@ -1,6 +1,14 @@
 import { describe, expect, it, vi } from 'vitest'
 
-import { createDataSourcePluginFacade, DataSourceUnavailableError, MISSING_PRINCIPAL_MESSAGE, writableSourceMessage } from '../../src/data-adapters/data-source-plugin-facade'
+import {
+  createDataSourcePluginFacade,
+  DATA_SOURCE_NOT_FOUND_CODE,
+  DATA_SOURCE_NOT_READ_ONLY_CODE,
+  DATA_SOURCE_PRINCIPAL_REQUIRED_CODE,
+  DataSourceUnavailableError,
+  MISSING_PRINCIPAL_MESSAGE,
+  writableSourceMessage,
+} from '../../src/data-adapters/data-source-plugin-facade'
 import type { DataSourceManager } from '../../src/data-adapters/DataSourceManager'
 
 interface AdapterStubOptions {
@@ -63,7 +71,11 @@ describe('createDataSourcePluginFacade', () => {
   it('fails closed on a missing principal and NEVER falls back (manager not even resolved)', async () => {
     const getManager = vi.fn(() => managerStub().manager)
     const facade = createDataSourcePluginFacade(getManager)
-    await expect(facade.select('pg', 't', { limit: 10 }, undefined)).rejects.toThrow(MISSING_PRINCIPAL_MESSAGE)
+    await expect(facade.select('pg', 't', { limit: 10 }, undefined)).rejects.toMatchObject({
+      status: 422,
+      code: DATA_SOURCE_PRINCIPAL_REQUIRED_CODE,
+      message: MISSING_PRINCIPAL_MESSAGE,
+    })
     await expect(facade.getSchema('pg', '   ')).rejects.toThrow(MISSING_PRINCIPAL_MESSAGE)
     await expect(facade.getTableInfo('pg', 'items', undefined)).rejects.toThrow(MISSING_PRINCIPAL_MESSAGE)
     await expect(facade.test('pg', undefined)).rejects.toThrow(MISSING_PRINCIPAL_MESSAGE)
@@ -88,6 +100,8 @@ describe('createDataSourcePluginFacade', () => {
     // message identical so a non-owner cannot distinguish "deleted" from "not yours".
     await expect(facade.getSchema('pg', 'intruder')).rejects.toMatchObject({
       name: 'DataSourceUnavailableError',
+      status: 422,
+      code: DATA_SOURCE_NOT_FOUND_CODE,
       message: "Data source with id 'pg' not found",
     })
     await expect(facade.getSchema('pg', 'intruder')).rejects.toBeInstanceOf(DataSourceUnavailableError)
@@ -102,6 +116,8 @@ describe('createDataSourcePluginFacade', () => {
     } as unknown as DataSourceManager))
     await expect(deleted.getSchema('pg', 'owner-1')).rejects.toMatchObject({
       name: 'DataSourceUnavailableError',
+      status: 422,
+      code: DATA_SOURCE_NOT_FOUND_CODE,
       message: "Data source with id 'pg' not found",
     })
   })
@@ -132,7 +148,11 @@ describe('createDataSourcePluginFacade', () => {
   it('fails closed on a WRITABLE source for EVERY read method (not just test) — read never performed', async () => {
     const m = managerStub({ adapter: adapterStub({ readOnly: false }) })
     const facade = createDataSourcePluginFacade(() => m.manager)
-    await expect(facade.test('pg', 'owner-1')).rejects.toThrow(writableSourceMessage('pg'))
+    await expect(facade.test('pg', 'owner-1')).rejects.toMatchObject({
+      status: 422,
+      code: DATA_SOURCE_NOT_READ_ONLY_CODE,
+      message: writableSourceMessage('pg'),
+    })
     await expect(facade.getSchema('pg', 'owner-1')).rejects.toThrow(writableSourceMessage('pg'))
     await expect(facade.getTableInfo('pg', 'items', 'owner-1')).rejects.toThrow(writableSourceMessage('pg'))
     await expect(facade.select('pg', 'items', { limit: 10 }, 'owner-1')).rejects.toThrow(writableSourceMessage('pg'))

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -1028,20 +1028,18 @@ async function testDiscoveryRoutesRejectUnknownSystem() {
 
 // #2205 legibility nit: a `data-source:sql-readonly` external system EXISTS, but its bound data
 // source (config.dataSourceId) is deleted / not-visible to the principal — so the host facade
-// (assertAccess / getDataSource) rejects with a uniform "not found" surfaced as the named
-// DataSourceUnavailableError. That is a CONFIG error, not a server crash: the objects/schema routes
-// must return a clean 4xx (422), NOT 500, and stay UNIFORM (no existence leak between
-// deleted-vs-not-mine). We mock the adapter's listObjects/getSchema to throw the SAME error shape the
-// real facade emits (an Error named 'DataSourceUnavailableError' with the verbatim manager message)
-// and drive the live route → inferHttpStatus mapping end-to-end.
+// (assertAccess / getDataSource) rejects with a uniform "not found". On the entity machine this
+// reached the plugin host as a plain Error (name='Error'), not the TS facade's named class, so the
+// route must classify the DATA SOURCE message itself: clean 422, NOT 500, and UNIFORM (no existence
+// leak between deleted-vs-not-mine).
 async function testBridgeDanglingDataSourceMapsTo4xxNot500() {
   // The exact uniform wording DataSourceManager.assertAccess + getDataSource throw — re-raised
   // verbatim by the facade wrapper; identical for "deleted" and "not yours" → no existence leak.
   const UNIFORM_NOT_FOUND = "Data source with id 'ds_gone' not found"
   const danglingError = () => {
-    const error = new Error(UNIFORM_NOT_FOUND)
-    error.name = 'DataSourceUnavailableError'
-    return error
+    // Deliberately plain Error: this is the actual runtime failure shape reported in #2250.
+    // A test that only throws a named DataSourceUnavailableError is a fixture, not a wire lock.
+    return new Error(UNIFORM_NOT_FOUND)
   }
 
   const { calls, services } = createMockServices({
@@ -1089,7 +1087,7 @@ async function testBridgeDanglingDataSourceMapsTo4xxNot500() {
   assert.notEqual(res.statusCode, 500, 'a dangling data-source binding is a config error, not a 500')
   assert.equal(res.statusCode, 422, 'objects route maps the dangling-source not-found to 422')
   assert.equal(res.body.ok, false)
-  assert.equal(res.body.error.code, 'DataSourceUnavailableError', 'distinct code (NOT ExternalSystemNotFoundError) — the system exists, its bound source does not')
+  assert.equal(res.body.error.code, 'DATA_SOURCE_NOT_FOUND', 'distinct code (NOT ExternalSystemNotFoundError) — the system exists, its bound source does not')
   // No-existence-leak: the message is the uniform "not found", unchanged from the facade — it does
   // not reveal whether the source was deleted or simply not owned by this principal.
   assert.equal(res.body.error.message, UNIFORM_NOT_FOUND, 'message stays the uniform not-found (no existence leak)')
@@ -1105,7 +1103,7 @@ async function testBridgeDanglingDataSourceMapsTo4xxNot500() {
   assert.notEqual(res.statusCode, 500, 'schema route also avoids 500 for a dangling source')
   assert.equal(res.statusCode, 422, 'schema route maps the dangling-source not-found to 422')
   assert.equal(res.body.ok, false)
-  assert.equal(res.body.error.code, 'DataSourceUnavailableError')
+  assert.equal(res.body.error.code, 'DATA_SOURCE_NOT_FOUND')
   assert.equal(res.body.error.message, UNIFORM_NOT_FOUND, 'schema route keeps the identical uniform message (no leak)')
   assert.ok(findCall(calls, 'getSchema'), 'schema route reached the adapter getSchema')
 }

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -75,7 +75,7 @@ function sendOk(res, data, status = 200) {
 
 function sendError(res, error) {
   const status = Number.isInteger(error.status) ? error.status : inferHttpStatus(error)
-  const code = error.code || error.name || 'INTERNAL_ERROR'
+  const code = inferErrorCode(error)
   const message = error.message || 'Internal server error'
   const details = error.details ? sanitizeIntegrationPayload(error.details) : undefined
   return sendJson(res, status, {
@@ -88,8 +88,31 @@ function sendError(res, error) {
   })
 }
 
+function inferDataSourceBridgeErrorCode(error) {
+  const code = error && error.code ? String(error.code) : ''
+  if (/^DATA_SOURCE_/.test(code)) return code
+  const message = error && error.message ? String(error.message) : ''
+  if (message === 'data source read requires an owner principal (none provided)') {
+    return 'DATA_SOURCE_PRINCIPAL_REQUIRED'
+  }
+  if (/^Data source with id '[^']+' not found$/.test(message)) {
+    return 'DATA_SOURCE_NOT_FOUND'
+  }
+  if (/^data source '[^']+' is writable; the read-only bridge refuses a writable binding$/.test(message)) {
+    return 'DATA_SOURCE_NOT_READ_ONLY'
+  }
+  return ''
+}
+
+function inferErrorCode(error) {
+  const dataSourceCode = inferDataSourceBridgeErrorCode(error)
+  if (dataSourceCode) return dataSourceCode
+  return error.code || error.name || 'INTERNAL_ERROR'
+}
+
 function inferHttpStatus(error) {
   const name = error && error.name ? String(error.name) : ''
+  if (inferDataSourceBridgeErrorCode(error)) return 422
   if (/NotFound/.test(name)) return 404
   if (/Conflict/.test(name)) return 409
   if (/Validation|Transform|Watermark|DeadLetter/.test(name)) return 400


### PR DESCRIPTION
## Summary

Fix the #2250 entity-machine regression where a `data-source:sql-readonly` external system with a dangling/stale `config.dataSourceId` still returned HTTP 500 (`code=Error`) on objects/schema discovery.

The first #2244 fix only proved the route mapping for a named `DataSourceUnavailableError` fixture. The entity machine showed the runtime can reach the plugin host as a plain `Error("Data source with id '...' not found")`, so the route must classify the data-source bridge config error by code/message too.

## Changes

- `data-source-plugin-facade.ts`
  - Adds explicit datasource bridge config codes:
    - `DATA_SOURCE_PRINCIPAL_REQUIRED`
    - `DATA_SOURCE_NOT_FOUND`
    - `DATA_SOURCE_NOT_READ_ONLY`
  - Throws 422-bearing domain errors for missing principal, dangling/not-visible source, and writable-source binding.
- `http-routes.cjs`
  - Maps datasource bridge config errors to HTTP 422 even when the error arrives as a plain `Error` with the uniform manager message.
  - Emits stable `DATA_SOURCE_*` error codes instead of falling back to `Error`.
- Tests updated so the route regression uses the actual #2250 failure shape: plain `Error`, not a named fixture.

## Verification

- `./node_modules/.bin/vitest run packages/core-backend/tests/unit/data-source-plugin-facade.test.ts` → 9/9 pass
- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs` → pass
- `./node_modules/.bin/tsc -p packages/core-backend/tsconfig.json --noEmit` → pass
- `git diff --check` → pass

## Boundaries

- Read-only bridge error classification only.
- No K3 Save / Submit / Audit / BOM / production write.
- No external DB write.
- No RBAC/auth change.

After merge/package, #2250 needs one more entity-machine smoke of `/external-systems/:id/objects` and `/external-systems/:id/schema` against a dangling `dataSourceId`; expected HTTP 422 + `DATA_SOURCE_NOT_FOUND`.
