### PR TITLE
docs(data-factory): design PLM project BOM stock-prep action (#2253)

### DIFF
--- a/docs/development/data-factory-plm-project-bom-stock-preparation-design-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-stock-preparation-design-20260604.md
@@ -1,0 +1,340 @@
+# Data Factory - PLM project BOM to stock-preparation tables - C0 design (2026-06-04)
+
+> **Design-first. No runtime in this slice.** This document locks the C0
+> contract for issue #2253: an operator enters one project number, Data Factory
+> reads a PLM BOM through an existing `data-source:sql-readonly` source, expands
+> it recursively, previews the stock-preparation changes, and later applies
+> those changes to MetaSheet tables only. C0 adds no route, no helper, no UI, no
+> migration, and no K3 write path.
+
+## Why
+
+The customer has a legacy production stock-preparation flow driven by a PLM
+project number. The product goal is not a generic SQL editor. It is a named
+business action:
+
+1. Read one project BOM by project number.
+2. Expand the recursive BOM into material demand rows.
+3. Compare those rows with an existing stock-preparation main table.
+4. Preserve human-entered planning fields while refreshing PLM/system fields.
+5. Apply the accepted plan to MetaSheet tables.
+
+This sits on top of the already shipped read-only SQL bridge. The bridge proves
+that Data Factory can read an owner-scoped SQL data source without copying
+credentials. This C0 defines the business action that consumes that bridge.
+
+## Relationship to the SQL bridge smoke
+
+The datasource bridge validation stream (#2250 / #2254 and follow-up packages)
+can continue in parallel. That stream proves the generic read-only SQL source is
+deployable and operator-usable. This #2253 track is downstream business logic:
+it consumes that source through a parameterized action and writes only MetaSheet
+stock-preparation rows after dry-run/planner acceptance. A bridge smoke failure
+blocks #2253 runtime, but it does not change this C0 business contract.
+
+## Scope boundary
+
+This track adds a **parameterized PLM BOM pull action**:
+
+```
+projectNo -> readonly PLM SQL read -> recursive BOM expansion -> dry-run plan
+          -> optional apply to MetaSheet stock-preparation main table
+```
+
+It does **NOT**:
+
+- expose raw SQL or user-authored SQL;
+- write to the PLM database or any external database;
+- call K3 Save / Submit / Audit / BOM;
+- unlock K3 multi-record or production write;
+- generate procurement and warehouse child tables in v1;
+- merge the PLM adapter/API track into this v1;
+- start background job runtime in C0.
+
+## Locked v1 answers from #2253
+
+| Topic | v1 decision |
+|---|---|
+| Source | `data-source:sql-readonly` / readonly SQL source only. PLM adapter/API is a later extension. |
+| Query shape | Parameterized `projectNo`; no raw SQL and no user-authored SQL. |
+| Match | Single project number, exact match on `FileCode`; no fuzzy, prefix, or batch match in v1. |
+| No hit | Dry-run returns `0 rows` plus a clear not-found summary. It does not create a project row. |
+| Identity | `projectNo + componentSourceId(OBJ_ID) + parentSourceId/path`. Same component under different parents remains a distinct row. |
+| Expansion | Recursive quantity multiplication; preserve raw quantity, total quantity, depth, and path. |
+| Guards | `maxDepth`, `maxRows`, and cycle guard fail closed. Oversized work must not block a sync request indefinitely. |
+| Target | v1 writes the stock-preparation main table only. Procurement/warehouse are views or later slices. |
+| Conflict default | Add missing rows, refresh PLM/system fields, preserve human fields, skip/mark duplicates, mark PLM-missing rows inactive, never delete by default. |
+| Conflict config | Default conflict strategy is configurable at project/table/pipeline scope; a run can override it later. |
+| Permissions | Dry-run uses Data Factory read/source-read; apply/write uses Data Factory write/admin. |
+| Boundary | MetaSheet write only. No K3 Save / Submit / Audit / BOM. |
+| Scale | Design for dozens to thousands of rows. Exceeding guard thresholds fails closed or moves to background/paged execution in a later slice. |
+
+## Source contract
+
+The action binds to an existing Integration external system of kind
+`data-source:sql-readonly`.
+
+Required source binding:
+
+```json
+{
+  "kind": "data-source:sql-readonly",
+  "role": "source",
+  "config": {
+    "dataSourceId": "ds_...",
+    "object": "plm_bom_or_view"
+  }
+}
+```
+
+The action must not receive credentials. The Integration row carries only the
+`dataSourceId` reference. Ownership and visibility stay enforced by the bridge:
+direct test/schema reads use the request user, and pipeline runs use
+`pipeline.createdBy`.
+
+The PLM read is a named, parameterized read plan. The exact PLM table/view and
+relationship columns are configured in C1/C2, but the action must only bind
+known fields. A free-form SQL textarea is explicitly out of scope.
+
+### Feasibility gate for C1/C2
+
+Because raw SQL is forbidden, recursive BOM expansion must be implemented
+app-side over flat, parameterized reads from the readonly SQL source. C1/C2 must
+confirm this is feasible before runtime starts. If the customer PLM exposes the
+needed BOM only through a recursive CTE, stored procedure, or vendor API call,
+v1 must pivot to either a customer-provided flat BOM view or the deferred PLM
+adapter/API track; it must not add a raw-SQL escape hatch.
+
+## Match and no-hit contract
+
+Input:
+
+```json
+{ "projectNo": "P2026-001" }
+```
+
+v1 matching:
+
+- trims the operator input;
+- rejects blank input;
+- filters PLM rows by exact `FileCode = projectNo`;
+- returns a not-found dry-run summary when no BOM root is found;
+- does not create a stock-preparation project/header row on not-found.
+
+No-hit evidence shape:
+
+```json
+{
+  "projectNoPresent": true,
+  "matchField": "FileCode",
+  "status": "not_found",
+  "rowsExpanded": 0,
+  "actions": {
+    "add": 0,
+    "update": 0,
+    "skip": 0,
+    "inactive": 0,
+    "manualConfirm": 0
+  }
+}
+```
+
+## Recursive BOM expansion contract
+
+The expansion output is a normalized logical row, not yet a MetaSheet write:
+
+| Field | Purpose |
+|---|---|
+| `projectNo` | Operator input / PLM `FileCode` match. |
+| `componentSourceId` | Stable PLM source id, expected `OBJ_ID` when available. |
+| `parentSourceId` | Parent PLM source id, null only for root/top-level rows. |
+| `path` | Stable path token chain for idempotency and traceability. |
+| `depth` | Recursive depth from the project/root BOM. |
+| `componentCode` | PLM component code/drawing number. |
+| `componentName` | PLM component name. |
+| `material` | PLM material field when available. |
+| `sourceVersion` | PLM system version, for example `SysVer` when available. |
+| `rawQuantity` | Quantity at the current BOM edge. |
+| `totalQuantity` | Multiplied quantity across the path. |
+| `active` | Planned active state; PLM-missing old rows become inactive, not deleted. |
+
+Rules:
+
+- Quantity multiplication is deterministic and numeric. Non-numeric required
+  quantity fails the row, not the whole batch, unless it prevents path identity.
+- Path/parent are part of the identity. The same component under two parents is
+  two stock-preparation rows.
+- Cycle guard fails closed. The expander must never loop indefinitely.
+- `maxDepth` and `maxRows` are hard guards. Crossing a guard returns a dry-run
+  failure with counts and the guard that fired. It must not silently truncate.
+- The action records enough lineage to support later DF-N provenance display.
+
+## Idempotency key
+
+The durable v1 key is:
+
+```text
+projectNo + componentSourceId + parentSourceId/path
+```
+
+Implementation detail may serialize this as a stable string, for example:
+
+```text
+projectNo=<projectNo>|component=<OBJ_ID>|parent=<parentId>|path=<path>
+```
+
+The key must not use component code alone. Component code can repeat, change, or
+appear under several parents.
+
+## Target table model
+
+v1 writes one MetaSheet stock-preparation main table. C1 defines the exact
+manifest, but the logical columns are:
+
+### PLM/system-owned fields
+
+- `projectNo`
+- `idempotencyKey`
+- `componentSourceId`
+- `parentSourceId`
+- `path`
+- `depth`
+- `componentCode`
+- `componentName`
+- `material`
+- `sourceVersion`
+- `rawQuantity`
+- `totalQuantity`
+- `active`
+- `lastPlmRefreshRunId`
+- `lastPlmRefreshAt`
+
+### Human-owned fields
+
+These are preserved by default during refresh:
+
+- `materialType`
+- `blankType`
+- `stockPreparationStatus`
+- `demandDate`
+- `leadTimeDays`
+- `notes`
+- `procurementReply`
+- `warehouseConfirmation`
+
+C1 must pin the exact whitelist. Any field not explicitly classified must fail
+closed during apply planning instead of being overwritten by accident.
+
+### Views instead of child tables in v1
+
+Procurement and warehouse surfaces are views or filtered layouts over the main
+table in v1. Separate procurement/warehouse child-table generation is deferred
+to a later explicit slice.
+
+## Conflict planner contract
+
+Dry-run computes decisions without writing:
+
+| Decision | Meaning |
+|---|---|
+| `add` | PLM row exists and no matching stock-preparation row exists. |
+| `update` | Matching row exists; PLM/system fields will refresh; human fields preserve. |
+| `skip` | Duplicate or unchanged row that needs no write under the default strategy. |
+| `inactive` | Existing row no longer appears in PLM; mark inactive, do not delete. |
+| `manual_confirm` | A critical conflict requires human review before apply. |
+
+Default conflict strategy:
+
+- add missing rows;
+- refresh only PLM/system-owned fields;
+- preserve human-owned fields;
+- skip or mark duplicate BOM rows instead of picking one silently;
+- mark PLM-missing existing rows inactive;
+- never delete by default;
+- record `runId`, `decision`, and `conflictSummary` for every applied row.
+
+Manual-confirm triggers are finalized in C3, but C0 reserves these classes:
+
+- same idempotency key but incompatible path/parent lineage;
+- component source id collision with different component identity;
+- non-numeric or negative quantity where quantity is required;
+- duplicate PLM rows where the default strategy cannot choose safely;
+- apply would overwrite a human-owned field.
+
+## Permissions
+
+| Operation | Permission posture |
+|---|---|
+| Dry-run | Data Factory read/source-read; source ownership enforced by the readonly SQL bridge. |
+| Apply | Data Factory write/admin; writes MetaSheet tables only. |
+| Evidence export | Read permission; values-free issue/customer evidence only. |
+
+There is no K3 permission path in this track. K3 Save / Submit / Audit / BOM
+remain unrelated scoped gates.
+
+## Evidence and redaction
+
+The live UI may show business values to authorized operators because the
+operator is working inside the tenant workspace. Issue/customer evidence must
+remain values-free:
+
+Allowed evidence:
+
+- project number presence, not the project number;
+- match field name (`FileCode`);
+- object/table names when not sensitive;
+- expanded row count;
+- max depth;
+- guard status;
+- action counts (`add/update/skip/inactive/manualConfirm`);
+- conflict types;
+- field names and ownership class (`plm_system` / `human_preserved`);
+- run id.
+
+Forbidden evidence:
+
+- connection secrets or connection strings;
+- raw SQL;
+- raw PLM rows;
+- raw stock-preparation row values;
+- full payload JSON if it carries business values.
+
+## Runtime decomposition
+
+Each implementation slice is a separate explicit opt-in.
+
+| Slice | Scope |
+|---|---|
+| C0 | Design + TODO docs only. No runtime. |
+| C1 | Stock-preparation table template / field model manifest. Schema-only; no PLM read, no write. |
+| C2 | `projectNo -> PLM BOM` dry-run expansion helper. Recursive read + normalized rows; no MetaSheet write. |
+| C3 | Conflict planner. Computes `add/update/skip/inactive/manual_confirm`; preserves human fields; no write. |
+| C4 | Apply writer. Writes only the MetaSheet stock-preparation main table; records run id, decision, and conflict summary. |
+| C5 | Workbench UI action. Project number input, dry-run summary, apply confirmation; no K3. |
+| C6 | `config_info` option sync. Keeps select/dropdown options aligned for configured stock-preparation fields. |
+
+Deferred:
+
+- PLM adapter/API source;
+- fuzzy/prefix/batch project matching;
+- procurement and warehouse child-table generation;
+- background/paged execution for very large BOMs;
+- C3 watermark/incremental SQL bridge implementation;
+- external database writes;
+- K3 Save / Submit / Audit / BOM.
+
+## Acceptance locks for future implementation
+
+- The PLM read uses `data-source:sql-readonly`; no raw SQL string is accepted.
+- `projectNo` is required and matches `FileCode` exactly in v1.
+- PLM no-hit returns dry-run `0 rows` and does not write a project/header row.
+- Idempotency includes project number, component source id, and parent/path.
+- Same component under different parents remains separate.
+- `maxDepth`, `maxRows`, and cycle guards fail closed with explicit evidence.
+- Dry-run reports add/update/skip/inactive/manual-confirm counts.
+- Human-owned fields are preserved by whitelist and never overwritten silently.
+- Missing PLM rows become inactive; apply does not delete by default.
+- Apply writes MetaSheet only; no external DB write and no K3 call.
+- Permissions separate dry-run read/source-read from apply write/admin.
+- Issue/customer evidence is values-free.
+- Each C1-C6 slice remains a separate PR-level opt-in.

--- a/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
@@ -1,0 +1,225 @@
+# Data Factory PLM project BOM -> stock-preparation - execution plan + gated TODO (2026-06-04)
+
+> Companion to
+> `data-factory-plm-project-bom-stock-preparation-design-20260604.md`.
+> This file is the trackable execution ladder for issue #2253. It is **not**
+> an authorization to implement runtime.
+>
+> Markers: ✅ done · ⬜ open / ready (still needs its own opt-in) · 🔒 gated
+> (blocked on a prior gate and a separate explicit opt-in).
+
+## Non-negotiables
+
+- No raw SQL and no user-authored SQL.
+- Source is `data-source:sql-readonly` in v1.
+- Project match is single `projectNo` exact on `FileCode`.
+- Apply writes MetaSheet stock-preparation main table only.
+- No external database write.
+- No K3 Save / Submit / Audit / BOM.
+- Human-owned fields preserve by default.
+- PLM-missing rows mark inactive; no default delete.
+- Issue/customer evidence stays values-free.
+- Every phase is a separate named opt-in; never auto-start the next slice.
+
+## Relationship to the datasource bridge track
+
+#2250 / #2254 datasource bridge smoke and packaging can continue in parallel.
+That track proves the generic SQL source is deployable. This #2253 ladder starts
+only the downstream business action that consumes the source. A bridge smoke
+regression blocks #2253 runtime, but it does not change the C0 design scope.
+
+## Current #2253 v1 boundary
+
+| Question | Locked answer |
+|---|---|
+| PLM source | `data-source:sql-readonly` / readonly SQL source. |
+| Query | Parameterized `projectNo`; no raw SQL. |
+| Match | Single exact `FileCode = projectNo`; no fuzzy/prefix/batch. |
+| No-hit | Dry-run `0 rows` + not-found summary; no project row write. |
+| Identity | `projectNo + componentSourceId(OBJ_ID) + parentSourceId/path`. |
+| Same component under different parent | Keep as separate BOM rows. |
+| Expansion | Recursive quantity multiplication; keep raw qty, total qty, depth, path. |
+| Guards | `maxDepth`, `maxRows`, cycle guard fail closed. |
+| Target | Stock-preparation main table only in v1. |
+| Procurement/warehouse | Views or later slices, not separate v1 tables. |
+| Conflict default | Add missing, refresh PLM/system fields, preserve human fields, skip/mark duplicates, inactive not delete. |
+| Permissions | Dry-run read/source-read; apply write/admin. |
+| Boundary | MetaSheet write only; no K3. |
+| Scale | Dozens to thousands of rows; threshold overflow fails closed or moves to later background/paged execution. |
+
+## Phase ladder
+
+### ⬜ C0 - Design + TODO (this PR)
+
+Docs-only.
+
+- [x] Lock v1 source/match/identity/target/conflict/permission boundaries from #2253.
+- [x] Define table model ownership classes: PLM/system-owned vs human-owned fields.
+- [x] Define recursive expansion contract and fail-closed guards.
+- [x] Define dry-run evidence shape and values-free issue evidence rule.
+- [x] Decompose implementation into C1-C6.
+- [ ] Review/accept C0 before any runtime starts.
+
+Definition of done:
+
+- Docs-only diff.
+- No runtime, route, migration, UI, package, or K3 change.
+- #2253 linked from the PR.
+
+### 🔒 C1 - Stock-preparation table template / field model manifest
+
+Gated on: C0 accepted + explicit opt-in.
+
+Scope:
+
+- Confirm the BOM-read feasibility gate: recursive BOM must be reachable
+  through flat, parameterized readonly SQL reads that the app can expand. If it
+  requires a recursive CTE, stored procedure, or vendor API, pause this v1 and
+  pivot to a customer-provided flat BOM view or the deferred PLM adapter/API
+  track.
+- Add schema-only manifest(s) for the stock-preparation main table.
+- Pin exact PLM/system-owned field list.
+- Pin exact human-owned preserve whitelist.
+- Define select/dropdown fields that later C6 syncs from `config_info`.
+- No PLM read.
+- No MetaSheet write.
+- No UI.
+
+Acceptance locks:
+
+- Field ownership is explicit; unclassified field = fail closed in later planner.
+- BOM-read feasibility is confirmed without raw SQL or stored-procedure calls.
+- Manifest contains idempotency key fields.
+- Manifest contains run/decision/conflict fields.
+- Procurement/warehouse stay views or deferred; no child-table generation.
+
+### 🔒 C2 - `projectNo -> PLM BOM` dry-run expansion helper
+
+Gated on: C1 + explicit opt-in.
+
+Scope:
+
+- Build a pure or service-layer helper that reads through `data-source:sql-readonly`.
+- Accept parameterized `projectNo`.
+- Match exact `FileCode`.
+- Expand recursive BOM rows into normalized logical rows.
+- No MetaSheet write.
+
+Acceptance locks:
+
+- Blank `projectNo` rejects.
+- No-hit returns `0 rows` + not-found summary.
+- Recursive quantity multiplication preserves raw quantity and total quantity.
+- Same component under different parents produces distinct rows.
+- Idempotency key includes project number, component source id, and parent/path.
+- `maxDepth`, `maxRows`, and cycle guard fail closed.
+- No raw SQL is accepted; read plan is configured/known.
+- Values-free dry-run summary can be emitted.
+
+### 🔒 C3 - Conflict planner
+
+Gated on: C2 + explicit opt-in.
+
+Scope:
+
+- Compare expanded rows with existing stock-preparation rows.
+- Compute decisions: `add`, `update`, `skip`, `inactive`, `manual_confirm`.
+- Preserve human-owned fields.
+- No write.
+
+Acceptance locks:
+
+- PLM/system fields refresh only in `add/update`.
+- Human-owned fields are preserved by whitelist.
+- Duplicate/conflicting rows never pick-first silently.
+- PLM-missing existing rows become `inactive`, not deleted.
+- Dry-run counts include add/update/skip/inactive/manual-confirm.
+- Planner output includes run id, decision, conflict summary shape for C4.
+
+### 🔒 C4 - Apply writer to stock-preparation main table
+
+Gated on: C3 + explicit opt-in.
+
+Scope:
+
+- Apply an accepted plan to the MetaSheet stock-preparation main table.
+- Use keyed create/patch by idempotency key.
+- Record run id, decision, and conflict summary.
+- No external database write.
+- No K3 write.
+
+Acceptance locks:
+
+- Apply requires Data Factory write/admin.
+- Apply writes only configured MetaSheet object(s).
+- Human-owned fields are not overwritten.
+- Inactive marking patches status/active fields; no delete.
+- Partial failure is reported with row-level decisions.
+- Re-running the same accepted plan is idempotent.
+
+### 🔒 C5 - Workbench UI action
+
+Gated on: C4 + explicit opt-in.
+
+Scope:
+
+- Add a named PLM project BOM stock-preparation action in the workbench.
+- Operator enters `projectNo`.
+- UI shows dry-run summary and conflict counts.
+- Apply confirmation calls C4 only when allowed.
+
+Acceptance locks:
+
+- No raw SQL textarea.
+- Dry-run and apply permissions are visibly separated.
+- Values shown in the tenant UI are not copied to issue evidence.
+- No K3 button/action is introduced.
+- No batch/multi-project mode in v1.
+
+### 🔒 C6 - `config_info` -> select/dropdown option sync
+
+Gated on: C5 + explicit opt-in.
+
+Scope:
+
+- Sync selected option sets used by stock-preparation fields.
+- Keep options aligned for fields such as material type / blank type / status.
+- This is MetaSheet configuration sync only.
+
+Acceptance locks:
+
+- No PLM write.
+- No K3 write.
+- Option evidence is values-free when posted to issues.
+- Missing/ambiguous option mapping fails closed.
+
+## Deferred tracks
+
+- PLM adapter/API source instead of readonly SQL.
+- Fuzzy/prefix/multi-project matching.
+- Procurement/warehouse child-table generation.
+- Background/paged execution for very large BOMs.
+- SQL bridge C3 watermark/incremental implementation.
+- External DB write.
+- K3 Save / Submit / Audit / BOM.
+
+## Open details to confirm in C1/C2
+
+These are not blockers for C0, but they must be pinned before runtime:
+
+- **Feasibility gate:** exact PLM table/view object and relation descriptors
+  must support app-side recursion over flat parameterized reads. If not, pivot
+  to a flat customer BOM view or deferred PLM adapter/API.
+- Exact PLM source id column when `OBJ_ID` is absent or aliased.
+- Exact parent/child relation columns.
+- Default `maxDepth` and `maxRows` values.
+- Exact stock-preparation field ids and labels.
+- Exact human-owned preserve whitelist.
+- Exact `config_info` option source and target fields.
+- Which critical conflicts require manual confirmation in v1.
+
+## Sequencing rule
+
+C0 must be reviewed before C1 starts. After C0, the next buildable slice is
+C1 (schema-only stock-preparation field model manifest). C2-C6 remain locked
+until their predecessor lands and the owner explicitly opts in.


### PR DESCRIPTION
## Summary

Docs-only C0 design for #2253: project-number PLM BOM pull into stock-preparation tables. This locks the v1 business action before runtime starts.

- source = `data-source:sql-readonly`, parameterized `projectNo`, no raw/user SQL
- match = single exact `FileCode`, no fuzzy/prefix/batch v1
- identity = `projectNo + componentSourceId(OBJ_ID) + parentSourceId/path`
- target = MetaSheet stock-preparation main table only; procurement/warehouse are views or later slices
- conflict default = add missing, refresh PLM/system fields, preserve human fields, duplicate skip/mark, inactive not delete
- permissions = dry-run read/source-read, apply write/admin
- boundary = no external DB write, no K3 Save/Submit/Audit/BOM

## Files

- `docs/development/data-factory-plm-project-bom-stock-preparation-design-20260604.md`
- `docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md`

## Verification

- `gh issue view 2253 --repo zensgit/metasheet2 --comments`
- `rg -n "#2253|data-source:sql-readonly|FileCode|OBJ_ID|maxDepth|maxRows|cycle|manual_confirm|config_info|No K3|raw SQL|C6" docs/development/data-factory-plm-project-bom-stock-preparation-*`
- `git diff --cached --check`

## Runtime boundary

No runtime, no route, no helper, no UI, no migration, no package, and no K3 change. C1-C6 remain gated and require separate opt-in after this C0 design is reviewed.

Closes no runtime issue by itself; prepares #2253 for implementation review.