### PR TITLE
feat(multitable): formula-over-lookup on create/submit/import (A-min-create)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -172,6 +172,7 @@ jobs:
             tests/integration/multitable-view-aggregate.test.ts \
             tests/integration/multitable-typed-query-numeric-view.test.ts \
             tests/integration/multitable-formula-over-lookup-view.test.ts \
+            tests/integration/multitable-formula-over-lookup-create-view.test.ts \
             tests/integration/multitable-formula-dryrun.test.ts \
             tests/integration/multitable-records-read-field-mask.test.ts \
             tests/integration/multitable-readpath-search-filter-field-mask.test.ts \

--- a/packages/core-backend/src/multitable/record-service.ts
+++ b/packages/core-backend/src/multitable/record-service.ts
@@ -389,7 +389,21 @@ function buildDirectValidationFields(rows: unknown[]) {
   })
 }
 
+/**
+ * Optional hook (A-min-create, design #2255) to compute a NEW record's same-record formula
+ * fields after insert + meta_links. Injected by the route layer with a req-bound implementation
+ * (hydrate lookup/rollup → recalculateRecordFromData); the service never learns req / RBAC /
+ * applyLookupRollup. Returns the recomputed formula values per record. Unset = current behavior.
+ */
+export type FormulaRecalcHook = (
+  query: QueryFn,
+  sheetId: string,
+  recordIds: string[],
+) => Promise<Array<{ recordId: string; data: Record<string, unknown> }>>
+
 export class RecordService {
+  private formulaRecalcHook?: FormulaRecalcHook
+
   constructor(
     private pool: ConnectionPool,
     private eventBus: EventBus,
@@ -398,6 +412,11 @@ export class RecordService {
 
   setPostCommitHooks(hooks: RecordPostCommitHook[]): void {
     this.postCommitHooks = [...hooks]
+  }
+
+  /** A-min-create: inject the route-supplied formula recalc hook (null clears it). */
+  setFormulaRecalcHook(hook: FormulaRecalcHook | null): void {
+    this.formulaRecalcHook = hook ?? undefined
   }
 
   setYjsInvalidator(invalidator: YjsInvalidator | null): void {
@@ -598,6 +617,24 @@ export class RecordService {
 
     const version = Number((recordRes.rows[0] as { version?: unknown } | undefined)?.version ?? 1)
 
+    // A-min-create (#2255): compute the new record's same-record formula fields (lookup/rollup
+    // hydrated) now that insert + meta_links are committed, and merge the formula values into the
+    // response echo. Persistence is done by the hook (recalculateRecordFromData writes formula keys
+    // only — lookups are NOT materialized). Best-effort: the record is already committed, so a
+    // recalc failure must not fail the create. Hook unset → unchanged behavior.
+    let responseData: Record<string, unknown> = patch
+    if (this.formulaRecalcHook) {
+      try {
+        const recomputed = await this.formulaRecalcHook(this.pool.query.bind(this.pool), sheetId, [recordId])
+        const formulaValues = recomputed.find((entry) => entry.recordId === recordId)?.data
+        if (formulaValues && Object.keys(formulaValues).length > 0) {
+          responseData = { ...patch, ...formulaValues }
+        }
+      } catch (err) {
+        console.error(`[record-service] formula recalc hook failed for ${recordId}:`, err)
+      }
+    }
+
     publishMultitableSheetRealtime({
       spreadsheetId: sheetId,
       actorId,
@@ -622,7 +659,7 @@ export class RecordService {
     return {
       recordId,
       version,
-      data: patch,
+      data: responseData,
     }
   }
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1676,6 +1676,60 @@ async function recalculateFormulaFields(
   return results
 }
 
+/**
+ * A-min-create (design #2255): compute a NEWLY created / submitted record's same-record formulas
+ * for the FIRST time, with lookup/rollup hydrated in-memory so a formula-over-lookup sees the
+ * actual value instead of the absent-on-reload `0`. Run only AFTER insert + meta_links exist.
+ * NO dependency gate — a fresh record computes ALL its formula fields once. Loads the record(s),
+ * hydrates via applyLookupRollup, then recalculateRecordFromData (writes back ONLY formula keys —
+ * lookup/rollup are NOT materialized). Same-record / same-sheet only (no foreign/related
+ * propagation — that is A-full, gated). Returns the recomputed formula values per record so the
+ * CALLER can surface them in echo/realtime under its own field-read mask. Route-layer: owns `req`
+ * + applyLookupRollup so the service layer never learns either. Reused by the createRecord hook
+ * (POST /records + import-xlsx) and the form-submit handler.
+ */
+async function recalcNewRecordFormulas(
+  req: Request,
+  query: QueryFn,
+  sheetId: string,
+  recordIds: string[],
+): Promise<Array<{ recordId: string; data: Record<string, unknown> }>> {
+  if (recordIds.length === 0) return []
+  const fields = await loadSheetFields({ query }, sheetId)
+  const formulaFieldIds = fields.filter((f) => f.type === 'formula').map((f) => f.id)
+  if (formulaFieldIds.length === 0) return []
+
+  const recordRes = await query(
+    'SELECT id, version, data FROM meta_records WHERE sheet_id = $1 AND id = ANY($2::text[])',
+    [sheetId, recordIds],
+  )
+  const rows = (recordRes.rows as any[]).map((r) => ({
+    id: String(r.id),
+    version: Number(r.version ?? 1),
+    data: normalizeJson(r.data),
+  })) as UniverMetaRecord[]
+  if (rows.length === 0) return []
+
+  const relationalLinkFields = fields
+    .map((f) => (f.type === 'link' ? { fieldId: f.id, cfg: parseLinkFieldConfig(f.property) } : null))
+    .filter((v): v is RelationalLinkField => !!v && !!v.cfg)
+  const linkValuesByRecord = await loadLinkValuesByRecord(query, recordIds, relationalLinkFields)
+  // Hydrate same-record lookup/rollup into row.data (perm-scoped foreign read inside).
+  await applyLookupRollup(req, query, fields, rows, relationalLinkFields, linkValuesByRecord)
+
+  const results: Array<{ recordId: string; data: Record<string, unknown> }> = []
+  for (const row of rows) {
+    const nextData = await multitableFormulaEngine.recalculateRecordFromData(query, sheetId, row.id, row.data, fields)
+    if (!nextData) continue
+    const formulaData: Record<string, unknown> = {}
+    for (const fieldId of formulaFieldIds) {
+      if (fieldId in nextData) formulaData[fieldId] = nextData[fieldId]
+    }
+    results.push({ recordId: row.id, data: formulaData })
+  }
+  return results
+}
+
 async function applyLookupRollup(
   req: Request,
   query: QueryFn,
@@ -5944,6 +5998,8 @@ export function univerMetaRouter(): Router {
 
         const built = buildXlsxImportRecords(parsed, columnMapping.mapping)
         const recordService = new RecordService(pool, eventBus)
+        // A-min-create (#2255): import-xlsx inherits create-time formula-over-lookup recalc via createRecord.
+        recordService.setFormulaRecalcHook((q, sid, ids) => recalcNewRecordFormulas(req, q, sid, ids))
         if (yjsInvalidator) {
           recordService.setPostCommitHooks([createYjsInvalidationPostCommitHook(yjsInvalidator)])
         }
@@ -7265,34 +7321,22 @@ export function univerMetaRouter(): Router {
           )
         : undefined
 
-      // Recalculate dependent formula fields after record update
+      // Recalculate the submitted record's formula fields (A-min-create #2255). Reuse the shared
+      // route helper: it hydrates same-record lookup/rollup FIRST so a formula-over-lookup computes
+      // against the actual value instead of the absent-on-reload `0`. NO dependency gate — the
+      // submitted record computes ALL its formulas once. Echo + realtime stay behind the D1 field
+      // mask (readableEchoFieldIds); `formulaEcho` carries the masked values into the broadcast.
+      const formulaEcho: Record<string, unknown> = {}
       try {
-        const changedFieldIds = Object.keys(patch)
-        if (changedFieldIds.length > 0) {
-          const depRes = await pool.query(
-            `SELECT DISTINCT field_id FROM formula_dependencies
-             WHERE (depends_on_field_id = ANY($1::text[]))
-               AND (depends_on_sheet_id IS NULL OR depends_on_sheet_id = $2)
-               AND sheet_id = $2`,
-            [changedFieldIds, view.sheetId],
-          )
-          if (depRes.rows.length > 0) {
-            const recalculated = await multitableFormulaEngine.recalculateRecord(
-              pool.query.bind(pool),
-              view.sheetId,
-              record.id,
-              fields,
-            )
-            if (recalculated) {
-              // Surface freshly materialized formula values in the response/broadcast.
-              // record.data was already filtered + link-merged above, so overlay only
-              // visible formula fields rather than replacing it (avoids clobbering the
-              // normalized link values).
-              for (const field of fields) {
-                if (field.type === 'formula' && field.id in recalculated && readableEchoFieldIds.has(field.id)) {
-                  record.data[field.id] = recalculated[field.id]
-                }
-              }
+        const recomputed = await recalcNewRecordFormulas(req, pool.query.bind(pool), view.sheetId, [record.id])
+        const formulaValues = recomputed.find((entry) => entry.recordId === record.id)?.data
+        if (formulaValues) {
+          // record.data was already filtered + link-merged above; overlay only the visible formula
+          // fields (avoids clobbering normalized link values, and never surfaces a masked field).
+          for (const field of fields) {
+            if (field.type === 'formula' && field.id in formulaValues && readableEchoFieldIds.has(field.id)) {
+              record.data[field.id] = formulaValues[field.id]
+              formulaEcho[field.id] = formulaValues[field.id]
             }
           }
         }
@@ -7318,11 +7362,11 @@ export function univerMetaRouter(): Router {
         kind: 'record-updated',
         recordId: record.id,
         recordIds: [record.id],
-        fieldIds: Object.keys(patch),
+        fieldIds: [...new Set([...Object.keys(patch), ...Object.keys(formulaEcho)])],
         recordPatches: [{
           recordId: record.id,
           version: record.version,
-          patch,
+          patch: { ...patch, ...formulaEcho },
         }],
       })
 
@@ -8263,6 +8307,8 @@ export function univerMetaRouter(): Router {
         return res.status(401).json({ error: 'Authentication required' })
       }
       const recordService = new RecordService(pool, eventBus)
+      // A-min-create (#2255): compute the new record's same-record formula-over-lookup on create.
+      recordService.setFormulaRecalcHook((q, sid, ids) => recalcNewRecordFormulas(req, q, sid, ids))
       const result = await recordService.createRecord({
         sheetId,
         capabilities,

--- a/packages/core-backend/tests/integration/multitable-formula-over-lookup-create-view.test.ts
+++ b/packages/core-backend/tests/integration/multitable-formula-over-lookup-create-view.test.ts
@@ -1,0 +1,143 @@
+/**
+ * A-min-create (design #2255) — real-DB wire proof for the three INSERT paths.
+ * A new/submitted/imported record's same-record link -> lookup -> formula now computes on its
+ * first appearance (hydrated), instead of being uncomputed (create) or computed against 0 (submit).
+ *
+ *  - C1: POST /records create        -> formula = actual lookup value (was uncomputed)
+ *  - C2: form-submit create          -> formula = actual value (was raw recalc -> 0)
+ *  - C3: import-xlsx (inherited)     -> imported record's formula = actual value
+ *  - N1: same-record boundary        -> creating one record does NOT recompute an unrelated record
+ *
+ * Runs only with DATABASE_URL (describeIfDatabase) via the plugin-tests.yml real-DB runner list.
+ * Numeric semantics inherited from A-min: single-value numeric lookup [5] -> `={lu}+1` = 6.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+import { buildXlsxBuffer, type XlsxModule } from '../../src/multitable/xlsx-service'
+
+const xlsx = (await import('xlsx')) as unknown as XlsxModule
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const USER = `u_folc_${TS}`
+const BASE_ID = `base_folc_${TS}`
+const FS = `sheet_folc_foreign_${TS}`
+const MS = `sheet_folc_main_${TS}`
+const FLD_FTARGET = `fld_ftarget_${TS}`
+const FLD_LINK = `fld_link_${TS}`
+const FLD_LU = `fld_lu_${TS}`
+const FLD_F = `fld_f_${TS}`
+const REC_FX = `rec_fx_${TS}` // ftarget = 5  -> formula 6 (C1, C2)
+const REC_FZ = `rec_fz_${TS}` // ftarget = 8  -> formula 9 (C3, isolates the imported record)
+const REC_B = `rec_b_${TS}` // pre-seeded unrelated record with a STALE formula (N1)
+const V_FORM = `v_form_${TS}`
+
+let app: Express
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const formulaOf = async (recordId: string) => {
+  const r = await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [recordId, MS])
+  const data = (r.rows as any[])[0]?.data
+  return (typeof data === 'string' ? JSON.parse(data) : data)?.[FLD_F]
+}
+
+describeIfDatabase('multitable formula-over-lookup on create/submit/import (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = { id: USER, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1, $2)', [BASE_ID, 'FoLC Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [FS, BASE_ID, 'Foreign'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [MS, BASE_ID, 'Main'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_FTARGET, FS, 'FTarget', 'number', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_FX, FS, JSON.stringify({ [FLD_FTARGET]: 5 })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_FZ, FS, JSON.stringify({ [FLD_FTARGET]: 8 })])
+
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_LINK, MS, 'Link', 'link', JSON.stringify({ foreignSheetId: FS }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_LU, MS, 'Lookup', 'lookup', JSON.stringify({ linkFieldId: FLD_LINK, targetFieldId: FLD_FTARGET, foreignSheetId: FS }), 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_F, MS, 'Formula', 'formula', JSON.stringify({ expression: `={${FLD_LU}}+1` }), 3])
+    await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,$4)', [MS, FLD_F, FLD_LU, MS])
+
+    // N1: an unrelated record with a stale formula value — must stay untouched by other records' create.
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_B, MS, JSON.stringify({ [FLD_F]: 999 })])
+
+    // form view for C2
+    await q('INSERT INTO meta_views (id, sheet_id, name, type, hidden_field_ids, filter_info, config) VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7::jsonb)',
+      [V_FORM, MS, V_FORM, 'form', '[]', JSON.stringify({ conjunction: 'and', conditions: [] }), JSON.stringify({})])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [MS]).catch(() => {})
+    await q('DELETE FROM formula_dependencies WHERE sheet_id = $1', [MS]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id = $1', [FLD_LINK]).catch(() => {})
+    await q('DELETE FROM meta_views WHERE sheet_id = $1', [MS]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[MS, FS]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('C1: POST /records create computes formula-over-lookup (was uncomputed on create)', async () => {
+    const res = await request(app).post('/api/multitable/records').send({ sheetId: MS, data: { [FLD_LINK]: [REC_FX] } })
+    expect(res.status).toBe(200)
+    const id = res.body.data.record.id
+    expect(res.body.data.record.data[FLD_F]).toBe(6) // echo carries fresh formula (masked; field visible)
+    expect(await formulaOf(id)).toBe(6) // DB-materialized, authoritative
+  })
+
+  test('N1 (boundary): creating a record does NOT recompute an unrelated record', async () => {
+    // REC_B was seeded with a stale 999 and is unrelated to C1's new record.
+    expect(await formulaOf(REC_B)).toBe(999) // untouched — create-recalc is scoped to the new record
+  })
+
+  test('C2: form-submit create computes against the ACTUAL lookup value (was raw recalc -> 0)', async () => {
+    const res = await request(app).post(`/api/multitable/views/${V_FORM}/submit`).send({ data: { [FLD_LINK]: [REC_FX] } })
+    expect(res.status).toBe(200)
+    expect(res.body.data.mode).toBe('create')
+    const id = res.body.data.record.id
+    expect(res.body.data.record.data[FLD_F]).toBe(6) // echo: 6 (hydrated), not 1 (raw -> lookup absent -> 0)
+    expect(await formulaOf(id)).toBe(6)
+  })
+
+  test('C3: import-xlsx inherits create-time formula-over-lookup recalc', async () => {
+    // minimal fixture: one row, the link column (header auto-maps to the link field by name) -> REC_FZ (ftarget 8) -> formula 9
+    const buffer = buildXlsxBuffer(xlsx, { sheetName: 'Rows', headers: ['Link'], rows: [[REC_FZ]] })
+    const res = await request(app).post(`/api/multitable/sheets/${MS}/import-xlsx`).attach('file', buffer, 'rows.xlsx')
+    expect(res.status).toBe(200)
+    expect(res.body.data.imported).toBe(1)
+    // the imported record is the only MS record whose formula resolves to 9 (REC_FZ.ftarget 8 + 1)
+    const r = await q(`SELECT data FROM meta_records WHERE sheet_id = $1 AND data ->> $2 = '9'`, [MS, FLD_F])
+    expect((r.rows as any[]).length).toBe(1)
+  })
+
+  test('MASK: a field_permissions-denied formula field is OMITTED from both create echoes (D1 mask preserved)', async () => {
+    // Deny FLD_F to this user. The formula still COMPUTES server-side (the record write is unchanged),
+    // but the fresh value must NOT appear in the create / form-submit echo. The form-submit realtime
+    // shares the SAME readableEchoFieldIds gate (formulaEcho is built in the same masked loop), so a
+    // denied field is omitted from the broadcast by construction.
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)',
+      [MS, FLD_F, 'user', USER, false, false])
+
+    const created = await request(app).post('/api/multitable/records').send({ sheetId: MS, data: { [FLD_LINK]: [REC_FX] } })
+    expect(created.status).toBe(200)
+    expect(created.body.data.record.data[FLD_F]).toBeUndefined() // POST /records echo: masked
+    expect(await formulaOf(created.body.data.record.id)).toBe(6) // but still computed in the DB
+
+    const submitted = await request(app).post(`/api/multitable/views/${V_FORM}/submit`).send({ data: { [FLD_LINK]: [REC_FX] } })
+    expect(submitted.status).toBe(200)
+    expect(submitted.body.data.record.data[FLD_F]).toBeUndefined() // form-submit echo: masked
+
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1 AND field_id = $2', [MS, FLD_F]).catch(() => {})
+  })
+})

--- a/packages/core-backend/tests/unit/record-service.test.ts
+++ b/packages/core-backend/tests/unit/record-service.test.ts
@@ -186,6 +186,48 @@ describe('RecordService', () => {
     )
   })
 
+  it('A-min-create: invokes the formula recalc hook once post-insert and merges formula values into the echo', async () => {
+    const service = new RecordService(pool, eventBus as any)
+    const hook = vi.fn(async (_q: unknown, _sid: string, ids: string[]) => [{ recordId: ids[0], data: { fld_total: 42 } }])
+    service.setFormulaRecalcHook(hook as any)
+
+    const result = await service.createRecord({
+      sheetId: 'sheet_ops',
+      data: { fld_title: 'Alpha' },
+      actorId: 'user_1',
+      capabilities: { ...fullCapabilities },
+    })
+
+    expect(hook).toHaveBeenCalledTimes(1)
+    expect(hook).toHaveBeenCalledWith(expect.any(Function), 'sheet_ops', [result.recordId])
+    // formula value merged into the response echo (route then applies the field-read mask)
+    expect(result.data).toEqual({ fld_title: 'Alpha', fld_total: 42 })
+  })
+
+  it('A-min-create: hook UNSET leaves create unchanged (no recalc, data = patch)', async () => {
+    const service = new RecordService(pool, eventBus as any)
+    const result = await service.createRecord({
+      sheetId: 'sheet_ops',
+      data: { fld_title: 'Alpha' },
+      actorId: 'user_1',
+      capabilities: { ...fullCapabilities },
+    })
+    expect(result.data).toEqual({ fld_title: 'Alpha' })
+  })
+
+  it('A-min-create: a hook failure does NOT fail the create (best-effort); echo falls back to patch', async () => {
+    const service = new RecordService(pool, eventBus as any)
+    service.setFormulaRecalcHook((async () => { throw new Error('boom') }) as any)
+    const result = await service.createRecord({
+      sheetId: 'sheet_ops',
+      data: { fld_title: 'Alpha' },
+      actorId: 'user_1',
+      capabilities: { ...fullCapabilities },
+    })
+    expect(result.recordId).toMatch(/^rec_/)
+    expect(result.data).toEqual({ fld_title: 'Alpha' }) // record committed; echo unmerged
+  })
+
   it('creates a record with normalized multiSelect values', async () => {
     pool = createMockPool({
       SELECT_FIELDS: {


### PR DESCRIPTION
Implements the create/submit/import sibling of A-min (#2247, PATCH path) per design #2255. A new/submitted/imported record's **same-record** `link → lookup → formula` now computes on its first appearance — against the actual lookup value instead of being uncomputed (create) or computed against `0` (form-submit). **NOT A-full** (no foreign-record propagation).

## Layering = service-hook injection (locked decision)

- `RecordService` gains an **optional** `setFormulaRecalcHook(hook)` (mirrors `setYjsInvalidator`). It never learns `req` / RBAC / `applyLookupRollup`. **Unset = current behavior.** `createRecord` invokes the hook **after insert + meta_links commit** and merges the returned formula values into the response echo; **best-effort** (a hook failure doesn't fail the already-committed create).
- New route-layer helper `recalcNewRecordFormulas(req, query, sheetId, recordIds)`: load row → `applyLookupRollup` (hydrate same-record lookup/rollup) → `recalculateRecordFromData` (writes back **only** formula keys; lookups **not** materialized). **No dependency gate** — a fresh record computes all its formulas once.
- **POST /records + import-xlsx** inject the hook (xlsx inherits via `createRecord`). **form-submit** calls the same helper directly (hand-written insert), replacing its raw `recalculateRecord`.

## Your two review points

1. **Hook unset = old behavior** — U1 unit tests: hook called once post-insert + merged; **unset → unchanged**; hook failure → create still succeeds. (Plus full backend `test:unit` 210/2716 green.)
2. **Form-submit echo/realtime get fresh formula, still behind the D1 mask** — the echo overlay and the realtime `formulaEcho` are built in the **same** `readableEchoFieldIds` masked loop. C2 proves fresh formula surfaces; the **MASK** test proves a `field_permissions`-denied formula field is **omitted** from both create echoes while still computed in the DB. Realtime shares the same gate by construction.

## Deliberate asymmetry (pre-empting the reviewer)

`createRecord`'s **realtime** intentionally does **not** carry the formula (only the route-masked response echo does) — the service layer lacks the per-actor field mask. **form-submit**'s realtime **does** carry the masked formula (the route has `readableEchoFieldIds`). Both echoes are masked.

## Tests (real-DB, added to plugin-tests.yml; validated locally green)

`multitable-formula-over-lookup-create-view.test.ts` (6): C1 POST /records=6, C2 form-submit=6 (hydrated, not raw→1), C3 import-xlsx inherited=9, N1 same-record boundary (unrelated record untouched), MASK (denied field omitted from both echoes). `record-service.test.ts` (+3 U1).

## Out of scope (gated)

A-full foreign-record propagation, multi-value lookup arithmetic (Option D), dry-run hydration, lookup materialization, migration, RBAC/auth. No `src/formula/engine.ts` change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)