### PR TITLE
feat(attendance): comp-time balance deduction on comp_time leave approval (④ C3)

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -3029,6 +3029,120 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('④ C3 — comp_time leave approval deducts balance FIFO; insufficient blocks (422) with no deduction; replay no double-deduct', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const runSuffix = Date.now().toString(36)
+    const uOk = `attendance-c3-ok-${runSuffix}`
+    const uShort = `attendance-c3-short-${runSuffix}`
+    const uFifo = `attendance-c3-fifo-${runSuffix}`
+    const previousRbacBypass = process.env.RBAC_BYPASS
+    const pool = new Pool({ connectionString: dbUrl })
+    const createdRequestIds: string[] = []
+    try {
+      process.env.RBAC_BYPASS = 'true'
+      const tokenFor = async (uid: string) => {
+        const r = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(uid)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`)
+        return (r.body as { token?: string } | undefined)?.token
+      }
+      const tokenOk = await tokenFor(uOk)
+      const tokenShort = await tokenFor(uShort)
+      const tokenFifo = await tokenFor(uFifo)
+      if (!tokenOk || !tokenShort || !tokenFifo) return
+      const hdr = (t: string) => ({ Authorization: `Bearer ${t}`, 'Content-Type': 'application/json' })
+
+      // comp_time leave type (explicit code='comp_time'); idempotent across reruns (409 -> look it up).
+      const ltRes = await requestJson(`${baseUrl}/api/attendance/leave-types`, { method: 'POST', headers: hdr(tokenOk), body: JSON.stringify({ code: 'comp_time', name: `Comp Time ${runSuffix}`, paid: false, requiresApproval: true }) })
+      expect([201, 409]).toContain(ltRes.status)
+      let leaveTypeId = (ltRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      if (!leaveTypeId) {
+        const list = await requestJson(`${baseUrl}/api/attendance/leave-types?isActive=true`, { headers: { Authorization: `Bearer ${tokenOk}` } })
+        const items = (list.body as { data?: { items?: { id?: string; code?: string }[] } } | undefined)?.data?.items ?? []
+        leaveTypeId = items.find(i => i.code === 'comp_time')?.id
+      }
+      expect(leaveTypeId).toBeTruthy()
+
+      const insertLot = async (userId: string, opts: { amount: number; remaining: number; expiresAt: string | null; grantedAt: string; tag: string }) => {
+        const r = await pool.query(
+          `INSERT INTO attendance_leave_balances
+             (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_key, status, granted_at, expires_at)
+           VALUES ('default', $1, 'comp_time', $2, $3, 'overtime_conversion', $4, 'active', $5, $6) RETURNING id`,
+          [userId, opts.amount, opts.remaining, `c3:${runSuffix}:${opts.tag}`, opts.grantedAt, opts.expiresAt],
+        )
+        return r.rows[0].id as string
+      }
+      const createLeave = async (token: string, workDate: string, minutes: number) => {
+        const r = await requestJson(`${baseUrl}/api/attendance/requests`, { method: 'POST', headers: hdr(token), body: JSON.stringify({ workDate, requestType: 'leave', leaveTypeId, minutes }) })
+        expect(r.status).toBe(201)
+        const id = (r.body as { data?: { request?: { id?: string } } } | undefined)?.data?.request?.id
+        expect(id).toBeTruthy()
+        createdRequestIds.push(id as string)
+        return id as string
+      }
+      const approve = (token: string, id: string) => requestJson(`${baseUrl}/api/attendance/requests/${id}/approve`, { method: 'POST', headers: hdr(token), body: JSON.stringify({ comment: 'ok' }) })
+      const lotRow = async (id: string) => (await pool.query('SELECT remaining_minutes, status FROM attendance_leave_balances WHERE id = $1', [id])).rows[0] as { remaining_minutes: number; status: string }
+      const deductEvents = async (reqId: string) => (await pool.query(
+        `SELECT balance_id, delta_minutes, event_type FROM attendance_leave_balance_events
+           WHERE source_type = 'comp_time_leave' AND source_id = $1 ORDER BY delta_minutes ASC`,
+        [reqId],
+      )).rows as { balance_id: string; delta_minutes: number; event_type: string }[]
+
+      // (a) sufficient → FIFO across two lots. Lot A expires sooner (consumed first); Lot B no-expiry.
+      const lotA = await insertLot(uOk, { amount: 120, remaining: 120, expiresAt: '2099-06-01', grantedAt: '2026-01-01', tag: 'A' })
+      const lotB = await insertLot(uOk, { amount: 120, remaining: 120, expiresAt: null, grantedAt: '2026-02-01', tag: 'B' })
+      const reqOk = await createLeave(tokenOk, '2026-09-10', 180)
+      expect((await approve(tokenOk, reqOk)).status).toBe(200)
+      expect(await lotRow(lotA)).toMatchObject({ remaining_minutes: 0, status: 'exhausted' })
+      expect(await lotRow(lotB)).toMatchObject({ remaining_minutes: 60, status: 'active' })
+      const evOk = await deductEvents(reqOk)
+      expect(evOk.map(e => ({ balance_id: e.balance_id, delta: Number(e.delta_minutes), type: e.event_type }))).toEqual([
+        { balance_id: lotA, delta: -120, type: 'deduct' }, // FIFO: soonest-expiry lot drained first
+        { balance_id: lotB, delta: -60, type: 'deduct' },
+      ])
+
+      // (c) replay: re-approving the resolved request is rejected; balance + events unchanged.
+      expect((await approve(tokenOk, reqOk)).status).toBe(400)
+      expect(await lotRow(lotA)).toMatchObject({ remaining_minutes: 0, status: 'exhausted' })
+      expect(await lotRow(lotB)).toMatchObject({ remaining_minutes: 60, status: 'active' })
+      expect(await deductEvents(reqOk)).toHaveLength(2)
+
+      // (b) insufficient → 422, approval blocked, request stays pending, balance untouched, no deduct event.
+      const lotShort = await insertLot(uShort, { amount: 60, remaining: 60, expiresAt: null, grantedAt: '2026-01-01', tag: 'S' })
+      const reqShort = await createLeave(tokenShort, '2026-09-11', 120)
+      const shortRes = await approve(tokenShort, reqShort)
+      expect(shortRes.status).toBe(422)
+      expect((shortRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('COMP_TIME_BALANCE_INSUFFICIENT')
+      const reqRow = (await pool.query('SELECT status FROM attendance_requests WHERE id = $1', [reqShort])).rows[0] as { status: string } | undefined
+      expect(reqRow?.status).toBe('pending')
+      expect(await lotRow(lotShort)).toMatchObject({ remaining_minutes: 60, status: 'active' })
+      expect(await deductEvents(reqShort)).toHaveLength(0)
+
+      // (d) FIFO tiebreak by granted_at among NULL-expiry lots — this is the ordering that actually
+      // fires in production today (every C2 grant has expires_at=NULL, so all lots fall in the
+      // NULLS-LAST bucket and only granted_at ASC discriminates). Older grant must drain first.
+      const lotOld = await insertLot(uFifo, { amount: 120, remaining: 120, expiresAt: null, grantedAt: '2026-01-01', tag: 'old' })
+      const lotNew = await insertLot(uFifo, { amount: 120, remaining: 120, expiresAt: null, grantedAt: '2026-02-01', tag: 'new' })
+      const reqFifo = await createLeave(tokenFifo, '2026-09-12', 180)
+      expect((await approve(tokenFifo, reqFifo)).status).toBe(200)
+      expect(await lotRow(lotOld)).toMatchObject({ remaining_minutes: 0, status: 'exhausted' })
+      expect(await lotRow(lotNew)).toMatchObject({ remaining_minutes: 60, status: 'active' })
+      expect((await deductEvents(reqFifo)).map(e => ({ balance_id: e.balance_id, delta: Number(e.delta_minutes) }))).toEqual([
+        { balance_id: lotOld, delta: -120 }, // oldest grant drained first
+        { balance_id: lotNew, delta: -60 },
+      ])
+    } finally {
+      await pool.query('DELETE FROM attendance_leave_balance_events WHERE user_id = ANY($1::text[])', [[uOk, uShort, uFifo]]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_leave_balances WHERE user_id = ANY($1::text[])', [[uOk, uShort, uFifo]]).catch(() => undefined)
+      if (createdRequestIds.length > 0) {
+        await pool.query('DELETE FROM attendance_requests WHERE id = ANY($1::text[])', [createdRequestIds]).catch(() => undefined)
+      }
+      if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS
+      else process.env.RBAC_BYPASS = previousRbacBypass
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('rejects non-UUID shift references for rotation rules, including UUID-like shift names', async () => {
     if (!baseUrl) return
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -13420,6 +13420,59 @@ function respondShiftComplianceCapExceeded(res, error) {
   return true
 }
 
+// ④ C3 (#2230 design-lock): deduct comp-time (调休) balance on a comp_time leave's final approval.
+// FIFO by soonest expiry then oldest grant, over active lots with remaining_minutes > 0. Runs entirely
+// inside the caller's approval txn: lots are SELECT … FOR UPDATE (no concurrent double-spend), each
+// touched lot's remaining_minutes is reduced (status → 'exhausted' at zero) and a 'deduct' event is
+// written (delta < 0, back-linked to the leave request for reconciliation). When the active balance is
+// short of the requested minutes the whole call throws → the approval txn rolls back → 422
+// COMP_TIME_BALANCE_INSUFFICIENT (no partial approval in v1). Idempotency comes from the pending→approved
+// transition guard: resolveRequest locks the request row FOR UPDATE and rejects re-approve before reaching
+// here, so a repeated approve never double-deducts.
+async function deductCompTimeBalance(trx, { orgId, userId, requestId, minutes }) {
+  const deductMinutes = Math.floor(Number(minutes) || 0)
+  if (deductMinutes <= 0) return { deducted: 0, lots: 0 }
+  const lots = (await trx.query(
+    `SELECT id, remaining_minutes, status
+       FROM attendance_leave_balances
+      WHERE org_id = $1 AND user_id = $2 AND leave_type_code = 'comp_time'
+        AND status = 'active' AND remaining_minutes > 0
+      ORDER BY expires_at ASC NULLS LAST, granted_at ASC
+      FOR UPDATE`,
+    [orgId, userId]
+  )).map((row) => ({ id: row.id, remaining: Number(row.remaining_minutes), status: row.status }))
+  const available = lots.reduce((sum, lot) => sum + lot.remaining, 0)
+  if (available < deductMinutes) {
+    throw new HttpError(
+      422,
+      'COMP_TIME_BALANCE_INSUFFICIENT',
+      `Comp-time balance insufficient: requested ${deductMinutes} min, available ${available} min`
+    )
+  }
+  let remaining = deductMinutes
+  let touched = 0
+  for (const lot of lots) {
+    if (remaining <= 0) break
+    const take = Math.min(lot.remaining, remaining)
+    const newRemaining = lot.remaining - take
+    await trx.query(
+      `UPDATE attendance_leave_balances
+          SET remaining_minutes = $1, status = $2, updated_at = now()
+        WHERE id = $3`,
+      [newRemaining, newRemaining === 0 ? 'exhausted' : lot.status, lot.id]
+    )
+    await trx.query(
+      `INSERT INTO attendance_leave_balance_events
+         (org_id, user_id, balance_id, event_type, delta_minutes, source_type, source_id)
+       VALUES ($1, $2, $3, 'deduct', $4, 'comp_time_leave', $5)`,
+      [orgId, userId, lot.id, -take, requestId]
+    )
+    remaining -= take
+    touched += 1
+  }
+  return { deducted: deductMinutes, lots: touched }
+}
+
 async function loadAttendanceComprehensiveActualMinutesByUser(db, orgId, userIds, period) {
   const actualMinutesByUser = new Map()
   const actualDetailsByUser = new Map()
@@ -20377,6 +20430,18 @@ module.exports = {
                   }
                 }
               }
+            }
+            // ④ C3 (#2230 design-lock): comp_time leave approval → deduct comp-time balance (FIFO).
+            // Same approval txn; an insufficient active balance throws → 422 + full rollback (the request
+            // stays pending — no partial approval). Only comp_time leave, identified by the request's
+            // persisted leaveType.code; the deduction amount is the request's metadata.minutes.
+            if (requestType === 'leave' && requestMetadata.leaveType?.code === 'comp_time') {
+              await deductCompTimeBalance(trx, {
+                orgId,
+                userId: requestRow.user_id,
+                requestId,
+                minutes: requestMetadata.minutes,
+              })
             }
             const baseRule = await loadDefaultRule(trx, orgId)
             const context = await resolveWorkContext({


### PR DESCRIPTION
## What

④ **C3** — when a **comp_time (调休) leave** request reaches final approval, **deduct** the requested minutes from the user's comp-time balance lots (granted by C2 #2252), **FIFO**. If the active balance is short, **block the approval** (422) — no partial approval in v1. Under design-lock #2230, on the C1 ledger (#2231).

## How

- New top-level `deductCompTimeBalance(trx, {orgId, userId, requestId, minutes})`:
  - `SELECT … FOR UPDATE` the active lots (`status='active' AND remaining_minutes>0`) `ORDER BY expires_at ASC NULLS LAST, granted_at ASC` (soonest-expiry first, oldest-grant tiebreak).
  - sum the active balance; if `< requested` → `throw HttpError(422, COMP_TIME_BALANCE_INSUFFICIENT)` → the **approval txn rolls back**, request stays `pending`.
  - otherwise draw FIFO across lots: reduce `remaining_minutes` (status → `'exhausted'` at zero) and write one `'deduct'` balance event per touched lot (`delta<0`, `source_type='comp_time_leave'`, `source_id=requestId` for reconciliation).
- Wired into `resolveRequest`'s `isFinalApproval` branch, gated on `request_type='leave'` **AND** the request's persisted `metadata.leaveType.code === 'comp_time'` — non-comp_time leave and every other request type are untouched (no regression). Deduction amount = the request's `metadata.minutes`.

### Idempotency
No extra backstop needed: `resolveRequest` locks the request row `FOR UPDATE` and rejects re-approve of a resolved request (status `!== 'pending'` → 400) **before** reaching the hook. Concurrent final-approves serialize on that row lock; the second 400s. Same transition-only guard as the C2 credit, and `resolveRequest` is the sole writer of `status='approved'`.

## Tests (real-DB integration, `attendance-plugin.test.ts`)

`④ C3` locks four cases:
- **(a) sufficient** → FIFO across two lots: soonest-expiry lot drained to `0`/`exhausted`, next lot partially; two ordered `deduct` events summing to the request minutes.
- **(d) granted_at tiebreak** → two **NULL-expiry** lots (the shape every C2 grant produces today) differing only by `granted_at`: oldest grant drains first. This is the ordering that actually fires in prod now; a mutation check (`ASC`→`DESC`) confirms the case fails without the correct sort key.
- **(b) insufficient** → `422 COMP_TIME_BALANCE_INSUFFICIENT`, request stays `pending`, balance untouched, no `deduct` event (proves the 422 rolls back the whole approval, not just the deduction).
- **(c) replay** → re-approve returns 400, balance + events unchanged (no double-deduct).

Verified locally against Postgres: full **87-test** attendance integration suite green.

## Scope / deferred
- v1 = block-on-insufficient (no partial approval), FIFO by expiry-then-grant. **C4** (expiry + leader-elected scheduler) → **C5** (unscheduled reminder + notifier) remain separate gated opt-ins under #2230.
- Revocation/auto-reversal of a deducted approval stays the explicitly-deferred slice in the design-lock (the `comp_time_leave` event back-link makes it reconcilable).

Refs #2230 (design-lock); builds on #2231 (C1 ledger) + #2252 (C2 credit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)