### PR TITLE
feat(multitable): show restricted chart data state

### DIFF
--- a/apps/web/src/multitable/components/MetaChartRenderer.vue
+++ b/apps/web/src/multitable/components/MetaChartRenderer.vue
@@ -2,8 +2,13 @@
   <div class="meta-chart" :data-chart-type="chartData.chartType">
     <div v-if="displayConfig?.title" class="meta-chart__title">{{ displayConfig.title }}</div>
 
+    <div v-if="isRestricted" class="meta-chart__restricted" data-chart-restricted="true">
+      <strong>{{ viewRenderLabel('chart.restrictedTitle', isZh) }}</strong>
+      <span>{{ viewRenderLabel('chart.restrictedHint', isZh) }}</span>
+    </div>
+
     <!-- bar / line / pie → ECharts canvas. Title + (pie) legend stay as HTML chrome. -->
-    <template v-if="isEChartsType">
+    <template v-else-if="isEChartsType">
       <div class="meta-chart__plot" :class="{ 'meta-chart__plot--pie': chartData.chartType === 'pie' }">
         <div ref="chartEl" class="meta-chart__echarts" data-chart-canvas="true"></div>
         <div
@@ -76,6 +81,7 @@ const isEChartsType = computed(() =>
   || props.chartData.chartType === 'line'
   || props.chartData.chartType === 'pie',
 )
+const isRestricted = computed(() => props.chartData.metadata?.restricted === true)
 
 // Legend swatch fallback color — same palette as buildChartOption so canvas + HTML legend match.
 function defaultColor(idx: number): string {
@@ -102,6 +108,10 @@ function teardownChart(): void {
 }
 
 function renderChart(): void {
+  if (isRestricted.value) {
+    teardownChart()
+    return
+  }
   // non-chart type (number/table) → release any canvas instance + observer
   if (!isEChartsType.value) {
     teardownChart()
@@ -133,6 +143,23 @@ onBeforeUnmount(teardownChart)
   margin-bottom: 8px;
   text-align: center;
 }
+
+.meta-chart__restricted {
+  display: flex;
+  flex-direction: column;
+  align-items: center;
+  justify-content: center;
+  min-height: 160px;
+  gap: 6px;
+  padding: 24px 18px;
+  border: 1px dashed #cbd5e1;
+  border-radius: 12px;
+  background: #f8fafc;
+  text-align: center;
+}
+
+.meta-chart__restricted strong { color: #0f172a; font-size: 14px; }
+.meta-chart__restricted span { color: #64748b; font-size: 12px; }
 
 .meta-chart__plot { width: 100%; }
 .meta-chart__plot--pie { display: flex; align-items: flex-start; gap: 16px; }

--- a/apps/web/src/multitable/utils/meta-view-render-labels.ts
+++ b/apps/web/src/multitable/utils/meta-view-render-labels.ts
@@ -88,6 +88,8 @@ export type MetaViewRenderLabelKey =
   | 'dashboard.noCharts'
   | 'chart.label'
   | 'chart.value'
+  | 'chart.restrictedTitle'
+  | 'chart.restrictedHint'
 
 export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'common.loading',
@@ -169,6 +171,8 @@ export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'dashboard.noCharts',
   'chart.label',
   'chart.value',
+  'chart.restrictedTitle',
+  'chart.restrictedHint',
 ]
 
 const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
@@ -254,6 +258,11 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
   'dashboard.noCharts': { en: 'No charts available. Create a chart first.', zh: '暂无可用图表。请先创建一个图表。' },
   'chart.label': { en: 'Label', zh: '标签' },
   'chart.value': { en: 'Value', zh: '值' },
+  'chart.restrictedTitle': { en: 'Chart data restricted', zh: '图表数据受限' },
+  'chart.restrictedHint': {
+    en: 'This chart references fields you cannot read.',
+    zh: '此图表引用了你无权读取的字段。',
+  },
 }
 
 export function viewRenderLabel(key: MetaViewRenderLabelKey, isZh: boolean): string {

--- a/apps/web/tests/multitable-chart-renderer.spec.ts
+++ b/apps/web/tests/multitable-chart-renderer.spec.ts
@@ -75,6 +75,13 @@ const tableData: ChartData = {
   ],
 }
 
+const restrictedBarData: ChartData = {
+  chartType: 'bar',
+  dataPoints: [],
+  total: 0,
+  metadata: { restricted: true, recordCount: 0 },
+}
+
 describe('MetaChartRenderer', () => {
   // jsdom has no ResizeObserver — stub it so the renderer's resize wiring is exercisable.
   const realResizeObserver = (globalThis as unknown as { ResizeObserver?: unknown }).ResizeObserver
@@ -184,6 +191,28 @@ describe('MetaChartRenderer', () => {
     expect(affixes[1].textContent).toBe('USD')
   })
 
+  it('renders restricted chart data as a permission notice without initializing ECharts', async () => {
+    const { container } = mount({ chartData: restrictedBarData })
+    await flushPromises()
+
+    expect(container.querySelector('[data-chart-restricted]')).toBeTruthy()
+    expect(container.querySelector('[data-chart-canvas]')).toBeNull()
+    expect(container.textContent).toContain('Chart data restricted')
+    expect(container.textContent).toContain('fields you cannot read')
+    expect(mocks.init).not.toHaveBeenCalled()
+    expect(mocks.setOption).not.toHaveBeenCalled()
+  })
+
+  it('localizes the restricted chart notice', async () => {
+    useLocale().setLocale('zh-CN')
+    const { container } = mount({ chartData: restrictedBarData })
+    await flushPromises()
+
+    expect(container.querySelector('[data-chart-restricted]')).toBeTruthy()
+    expect(container.textContent).toContain('图表数据受限')
+    expect(container.textContent).toContain('无权读取')
+  })
+
   it('shows the HTML title from display config (single source, no ECharts title)', async () => {
     const config: ChartDisplayConfig = { title: 'Sales Overview' }
     const { container } = mount({ chartData: barData, displayConfig: config })
@@ -238,6 +267,18 @@ describe('MetaChartRenderer', () => {
     state.chartData = numberData
     await flushPromises()
     expect(mocks.dispose).toHaveBeenCalled()
+  })
+
+  it('disposes the canvas when switching bar → restricted', async () => {
+    const { container, state } = mountReactive({ chartData: barData })
+    await flushPromises()
+    expect(mocks.init).toHaveBeenCalledTimes(1)
+
+    state.chartData = restrictedBarData
+    await flushPromises()
+    expect(mocks.dispose).toHaveBeenCalled()
+    expect(container.querySelector('[data-chart-restricted]')).toBeTruthy()
+    expect(container.querySelector('[data-chart-canvas]')).toBeNull()
   })
 
   it('wires the resize observer to chart.resize()', async () => {

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -51,7 +51,7 @@ const fakeChartData: ChartData = {
   ],
 }
 
-function mockClient(dashboards: Dashboard[] = [], charts: ChartConfig[] = []) {
+function mockClient(dashboards: Dashboard[] = [], charts: ChartConfig[] = [], chartData: ChartData = fakeChartData) {
   const ok = (body: unknown) => new Response(JSON.stringify({ data: body }), { status: 200, headers: { 'Content-Type': 'application/json' } })
   const noContent = () => new Response(null, { status: 204 })
 
@@ -61,7 +61,7 @@ function mockClient(dashboards: Dashboard[] = [], charts: ChartConfig[] = []) {
       return ok({ dashboards })
     }
     if (method === 'GET' && url.includes('/charts') && url.includes('/data')) {
-      return ok(fakeChartData)
+      return ok(chartData)
     }
     if (method === 'GET' && url.includes('/charts')) {
       return ok({ charts })
@@ -115,6 +115,22 @@ describe('MetaDashboardView', () => {
     expect(grid).toBeTruthy()
     const panels = container.querySelectorAll('[data-panel-id]')
     expect(panels.length).toBe(1)
+  })
+
+  it('renders a restricted chart-data notice in a dashboard panel', async () => {
+    const restrictedData: ChartData = {
+      chartType: 'bar',
+      dataPoints: [],
+      total: 0,
+      metadata: { restricted: true, recordCount: 0 },
+    }
+    const { client } = mockClient([fakeDashboard()], [fakeChart()], restrictedData)
+    const { container } = mount({ sheetId: 'sheet_1', client })
+    await flushPromises()
+
+    expect(container.querySelector('[data-chart-restricted]')).toBeTruthy()
+    expect(container.textContent).toContain('Chart data restricted')
+    expect(container.textContent).toContain('fields you cannot read')
   })
 
   it('creates a new dashboard', async () => {


### PR DESCRIPTION
## Summary
- render `ChartData.metadata.restricted=true` as an explicit permission notice instead of an empty chart/table/number
- tear down and skip ECharts when chart data is restricted
- add typed EN/ZH labels and dashboard-panel coverage

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-chart-renderer.spec.ts tests/multitable-dashboard-view.spec.ts --watch=false` → 25 passed
- `pnpm --filter @metasheet/web exec vue-tsc -b` → clean

## Notes
- Frontend-only UX slice; no backend/RBAC/chart aggregation changes.
- The `pnpm install --frozen-lockfile --ignore-scripts` needed for this throwaway worktree produced tracked `node_modules` symlink churn in plugin/tool folders; those files are intentionally excluded from this PR.
