### PR TITLE
fix(multitable): allow wait_for_callback in automation validation

### DIFF
--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -11,7 +11,7 @@ import {
   type ConditionGroup,
 } from './automation-conditions'
 import { AutomationExecutor, type AutomationRule as ExecutorRule, type AutomationExecution, type AutomationDeps, type ExecutionContext } from './automation-executor'
-import type { AutomationAction } from './automation-actions'
+import { ALL_ACTION_TYPES, type AutomationAction } from './automation-actions'
 import type { AutomationTrigger } from './automation-triggers'
 import {
   AutomationScheduler,
@@ -55,17 +55,14 @@ const VALID_TRIGGER_TYPES = new Set([
   'webhook.received',
 ])
 
-const VALID_ACTION_TYPES = new Set([
+const LEGACY_ACTION_TYPES = [
   'notify',
   'update_field',
-  'update_record',
-  'create_record',
-  'send_webhook',
-  'send_notification',
-  'send_email',
-  'send_dingtalk_group_message',
-  'send_dingtalk_person_message',
-  'lock_record',
+] as const
+
+const VALID_ACTION_TYPES = new Set<string>([
+  ...LEGACY_ACTION_TYPES,
+  ...ALL_ACTION_TYPES,
 ])
 
 // A6-1 opt-in (#2130 runtime): a rule may persist one C1 WorkflowJob row per action.

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -2257,6 +2257,24 @@ describe('AutomationService — Rule CRUD', () => {
     expect(rule.enabled).toBe(true)
   })
 
+  it('A6-2: createRule accepts wait_for_callback with workflow_job_v1', async () => {
+    dbExecuteResults.push([]) // for insertInto().execute()
+    const rule = await service.createRule('sheet_1', {
+      name: 'Wait rule',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'wait_for_callback',
+      actionConfig: {},
+      actions: [{ type: 'wait_for_callback', config: {} }],
+      executionMode: 'workflow_job_v1',
+      createdBy: 'user_1',
+    })
+
+    expect(rule.action_type).toBe('wait_for_callback')
+    expect(rule.actions).toEqual([{ type: 'wait_for_callback', config: {} }])
+    expect(rule.execution_mode).toBe('workflow_job_v1')
+  })
+
   it('createRule normalizes legacy DingTalk title and content fields', async () => {
     dbExecuteResults.push([])
     const rule = await service.createRule('sheet_1', {
@@ -2509,6 +2527,31 @@ describe('AutomationService — Rule CRUD', () => {
     expect(rule).not.toBeNull()
     expect(rule!.name).toBe('Updated')
     expect(queryFn).not.toHaveBeenCalled()
+  })
+
+  it('A6-2: updateRule accepts wait_for_callback with workflow_job_v1', async () => {
+    dbExecuteTakeFirstResults.push(makeRuleRow({
+      action_type: 'update_record',
+      action_config: { fields: { status: 'before' } },
+      actions: [{ type: 'update_record', config: { fields: { status: 'before' } } }],
+    }))
+    dbExecuteResults.push([makeRuleRow({
+      action_type: 'wait_for_callback',
+      action_config: {},
+      actions: [{ type: 'wait_for_callback', config: {} }],
+      execution_mode: 'workflow_job_v1',
+    })])
+
+    const rule = await service.updateRule('atr_1', 'sheet_1', {
+      actionType: 'wait_for_callback',
+      actionConfig: {},
+      actions: [{ type: 'wait_for_callback', config: {} }],
+      executionMode: 'workflow_job_v1',
+    })
+
+    expect(rule?.action_type).toBe('wait_for_callback')
+    expect(rule?.actions).toEqual([{ type: 'wait_for_callback', config: {} }])
+    expect(rule?.execution_mode).toBe('workflow_job_v1')
   })
 
   it('updateRule validates the merged state when only actionType changes to DingTalk', async () => {

--- a/packages/core-backend/tests/unit/multitable-automation-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-service.test.ts
@@ -349,6 +349,7 @@ import {
   preflightDingTalkAutomationUpdate,
   serializeAutomationRule,
 } from '../../src/multitable/automation-service'
+import { ALL_ACTION_TYPES } from '../../src/multitable/automation-actions'
 
 describe('M5 — Automation route helpers', () => {
   describe('serializeAutomationRule', () => {
@@ -498,6 +499,14 @@ describe('M5 — Automation route helpers', () => {
       ).toThrow(AutomationRuleValidationError)
     })
 
+    it('accepts every canonical automation action type (drift guard)', () => {
+      for (const actionType of ALL_ACTION_TYPES) {
+        expect(
+          parseCreateRuleInput({ triggerType: 'record.created', actionType }, null).actionType,
+        ).toBe(actionType)
+      }
+    })
+
     it('throws AutomationRuleValidationError for malformed condition payloads', () => {
       expect(() =>
         parseCreateRuleInput(
@@ -611,6 +620,12 @@ describe('M5 — Automation route helpers', () => {
     it('accepts the legacy `notify` and `update_field` action types', () => {
       expect(parseUpdateRuleInput({ actionType: 'notify' })?.actionType).toBe('notify')
       expect(parseUpdateRuleInput({ actionType: 'update_field' })?.actionType).toBe('update_field')
+    })
+
+    it('accepts every canonical automation action type (drift guard)', () => {
+      for (const actionType of ALL_ACTION_TYPES) {
+        expect(parseUpdateRuleInput({ actionType })?.actionType).toBe(actionType)
+      }
     })
 
     it('A6-1: forwards executionMode (incl. explicit null) as a touched field', () => {


### PR DESCRIPTION
## Summary

Fixes the #2257 A6-2 operator UAT save blocker:

- the frontend and DB migration already support `wait_for_callback`
- the A6-2 executor/runtime already supports `wait_for_callback`
- `AutomationService` still used a hand-written `VALID_ACTION_TYPES` set that omitted `wait_for_callback`

This PR derives service validation from canonical `ALL_ACTION_TYPES` plus the two legacy compatibility actions (`notify`, `update_field`) so the service boundary no longer drifts from the canonical action contract.

## Scope

- Backend validation + tests only
- No runtime behavior change
- No public webhook endpoint
- No resume token emitter
- No branch/DAG, BPMN, or approval-as-job work

## Tests

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-automation-service.test.ts tests/unit/automation-v1.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `git diff --check`

## UAT continuation

After merge + redeploy, continue #2257 from the Save step onward.
