### PR TITLE
feat(data-factory): support filtered SQL source reads (#2253)

### DIFF
--- a/docs/development/data-factory-plm-project-bom-c2-0-filtered-read-verification-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-c2-0-filtered-read-verification-20260604.md
@@ -1,0 +1,41 @@
+# Data Factory PLM project BOM C2-0 filtered-read bridge verification (2026-06-04)
+
+## Scope
+
+C2-0 for issue #2253. This is the small bridge prerequisite before the C2
+`projectNo -> PLM BOM` dry-run expansion helper.
+
+It makes `data-source:sql-readonly` support equality-filtered reads so C2 can
+perform flat, parameterized PLM lookups such as `FileCode = projectNo` and
+`parentId = componentSourceId`.
+
+It does not add the PLM BOM expansion helper, write MetaSheet rows, add UI,
+change K3, or add any raw SQL / join / stored procedure surface.
+
+## Locks
+
+- `read.filters` is converted to host facade `select(..., { where })`.
+- The host facade forwards `where` to `DataSourceManager.select`.
+- Filters are equality-only primitives: string / number / boolean / null.
+- Object-shaped operators and arrays fail closed before the facade read.
+- Existing offset pagination behavior is unchanged.
+- Owner-scope and read-only checks remain in the host facade choke point.
+
+## Verification
+
+Run:
+
+```bash
+pnpm --filter plugin-integration-core test:data-source-bridge
+pnpm --filter @metasheet/core-backend test:unit -- data-source-plugin-facade.test.ts
+git diff --check
+```
+
+Expected: all pass.
+
+## Next
+
+C2 remains a separate opt-in. It can use the #2253 candidate PLM relation
+descriptors to build app-side recursion over flat parameterized reads. If live
+PLM requires recursive CTE / stored procedure / vendor API / raw SQL, the track
+still pivots to a customer flat BOM view or deferred PLM adapter/API.

--- a/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
@@ -99,9 +99,27 @@ available in this repo. Instead, this slice turns the feasibility gate into a
 schema-only contract (`requires_customer_schema`) that C2 must satisfy before
 runtime can proceed.
 
-### 🔒 C2 - `projectNo -> PLM BOM` dry-run expansion helper
+### 🟡 C2-0 - Filtered readonly SQL bridge for PLM lookups (this PR)
 
 Gated on: C1 + explicit opt-in.
+
+Scope:
+
+- Thread `read.filters` through `data-source:sql-readonly` as structured
+  `where` filters.
+- Keep filters equality-only: string / number / boolean / null.
+- No raw SQL, joins, stored procedures, operator objects, arrays, UI, PLM BOM
+  expansion, MetaSheet write, or K3.
+
+Acceptance locks:
+
+- `FileCode` / parent-id filters reach `DataSourceManager.select(..., { where })`.
+- Invalid structured filters fail closed before any data-source read.
+- Existing offset pagination remains unchanged.
+
+### 🔒 C2 - `projectNo -> PLM BOM` dry-run expansion helper
+
+Gated on: C2-0 + confirmed customer PLM relation descriptors + explicit opt-in.
 
 Scope:
 
@@ -226,8 +244,10 @@ These are not blockers for C0, but they must be pinned before runtime:
 
 ## Sequencing rule
 
-C0 and C1 are complete. The next runtime slice is C2, but it remains locked
-until the customer PLM relation descriptors prove app-side recursion over flat
-parameterized readonly SQL reads, or the track pivots to a customer flat BOM
-view / deferred PLM adapter per the C0 feasibility gate. C2-C6 still require
-their predecessor to land and the owner to explicitly opt in.
+C0 and C1 are complete. The next bridge prerequisite is C2-0, which only enables
+equality-filtered `data-source:sql-readonly` reads. The C2 PLM BOM expansion
+runtime still remains locked until C2-0 lands and the customer PLM relation
+descriptors prove app-side recursion over flat parameterized readonly SQL reads,
+or the track pivots to a customer flat BOM view / deferred PLM adapter per the
+C0 feasibility gate. C2-C6 still require their predecessor to land and the owner
+to explicitly opt in.

--- a/packages/core-backend/src/data-adapters/data-source-plugin-facade.ts
+++ b/packages/core-backend/src/data-adapters/data-source-plugin-facade.ts
@@ -1,5 +1,5 @@
 import type { DataSourceManager } from './DataSourceManager'
-import type { DbValue, QueryResult, SchemaInfo, TableInfo } from './BaseAdapter'
+import type { DbValue, QueryOptions, QueryResult, SchemaInfo, TableInfo } from './BaseAdapter'
 
 /**
  * Narrow, READ-ONLY data-source surface handed to the integration plugin so the Data
@@ -32,7 +32,7 @@ export interface DataSourceReadOnlyFacade {
   select(
     dataSourceId: string,
     table: string,
-    options: { limit?: number; offset?: number },
+    options: Pick<QueryOptions, 'limit' | 'offset' | 'where'>,
     principal: string | undefined
   ): Promise<QueryResult<Record<string, DbValue>>>
 }
@@ -152,10 +152,14 @@ export function createDataSourcePluginFacade(
     async select(dataSourceId, table, options, principal) {
       const { manager } = await authorize(dataSourceId, principal)
       // manager.select enforces the A5 row caps and is read-only; no write path is reachable here.
-      return manager.select<Record<string, DbValue>>(dataSourceId, table, {
+      const queryOptions: QueryOptions = {
         limit: options.limit,
         offset: options.offset,
-      })
+      }
+      if (options.where && Object.keys(options.where).length > 0) {
+        queryOptions.where = options.where
+      }
+      return manager.select<Record<string, DbValue>>(dataSourceId, table, queryOptions)
     },
   }
 }

--- a/packages/core-backend/tests/unit/data-source-plugin-facade.test.ts
+++ b/packages/core-backend/tests/unit/data-source-plugin-facade.test.ts
@@ -131,6 +131,19 @@ describe('createDataSourcePluginFacade', () => {
     expect(res.data).toEqual([{ id: 1 }])
   })
 
+  it('select forwards where filters to DataSourceManager for parameterized readonly reads', async () => {
+    const m = managerStub()
+    const facade = createDataSourcePluginFacade(() => m.manager)
+    const where = { FileCode: 'P-001', parent_id: 'OBJ-7', active: true }
+    await facade.select('pg', 'DN_PDM_PathExAttrInfo', { limit: 100, offset: 0, where }, 'owner-1')
+    expect(m.stub.assertAccess).toHaveBeenCalledWith('pg', 'owner-1')
+    expect(m.stub.select).toHaveBeenCalledWith('pg', 'DN_PDM_PathExAttrInfo', {
+      limit: 100,
+      offset: 0,
+      where,
+    })
+  })
+
   it('connects the adapter when not already connected, before reading schema', async () => {
     const m = managerStub({ adapter: adapterStub({ connected: false }) })
     const facade = createDataSourcePluginFacade(() => m.manager)

--- a/plugins/plugin-integration-core/__tests__/data-source-sql-readonly-source-adapter.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/data-source-sql-readonly-source-adapter.test.cjs
@@ -92,6 +92,42 @@ async function main() {
     assert.equal(f.calls.select[0].table, 'public.items')
   }
 
+  // 4b. Equality filters are forwarded as `where`, enabling parameterized flat reads for
+  //     FileCode / parent-id lookups without raw SQL or full-table local filtering.
+  {
+    const f = fakeFacade()
+    const a = adapterWith(f, 'owner-42')
+    await a.read({
+      object: 'DN_PDM_PathExAttrInfo',
+      limit: 25,
+      cursor: '5',
+      filters: { FileCode: 'P-001', active: true, optional: null },
+    })
+    assert.deepEqual(f.calls.select[0].options, {
+      limit: 25,
+      offset: 5,
+      where: { FileCode: 'P-001', active: true, optional: null },
+    })
+  }
+
+  // 4c. Filters are equality-only primitives. Structured operators/arrays remain out of scope for
+  //     the readonly bridge; C2 gets parameterized equality reads, not a generic query surface.
+  {
+    const f = fakeFacade()
+    const a = adapterWith(f)
+    await assert.rejects(
+      () => a.read({ object: 'items', filters: { FileCode: { $like: 'P%' } } }),
+      /equality primitives only/,
+      'operator-shaped filter rejected',
+    )
+    await assert.rejects(
+      () => a.read({ object: 'items', filters: { FileCode: ['P-001'] } }),
+      /equality primitives only/,
+      'array filter rejected',
+    )
+    assert.equal(f.calls.select.length, 0, 'invalid filters fail before any facade read')
+  }
+
   // 5. Read-only-source guard now lives in the host facade and fires on EVERY read path: a facade
   //    that rejects a writable binding makes read / listObjects / getSchema / testConnection all fail
   //    closed — NOT only when testConnection() runs first (the dry-run/pipeline paths skip it).

--- a/plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/data-source-sql-readonly-source-adapter.cjs
@@ -42,6 +42,27 @@ function isPlainObject(value) {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
 }
 
+function hasOwnKeys(value) {
+  return isPlainObject(value) && Object.keys(value).length > 0
+}
+
+function normalizeEqualityFilters(filters = {}) {
+  if (!hasOwnKeys(filters)) return undefined
+  const out = {}
+  for (const [key, value] of Object.entries(filters)) {
+    if (typeof key !== 'string' || key.trim() === '') {
+      throw new AdapterValidationError('filters keys must be non-empty strings', { field: 'filters' })
+    }
+    if (value !== null && !['string', 'number', 'boolean'].includes(typeof value)) {
+      throw new AdapterValidationError('data-source:sql-readonly filters support equality primitives only', {
+        field: `filters.${key}`,
+      })
+    }
+    out[key] = value
+  }
+  return out
+}
+
 // Fail-closed guard: the host injects the read-only data-source facade as
 // `context.api.dataSources`. If it is absent (e.g. the plugin allowlist key drifted), surface a
 // clear error instead of a confusing `undefined` access. Mirrors the staging adapter's
@@ -156,10 +177,13 @@ function createDataSourceSqlReadonlySourceAdapter({ system, context, principal }
       const request = normalizeReadRequest(input)
       const api = getDataSourcesApi(context)
       const offset = parseOffsetCursor(request.cursor)
+      const selectOptions = { limit: request.limit, offset }
+      const where = normalizeEqualityFilters(request.filters)
+      if (where) selectOptions.where = where
       const result = await api.select(
         dataSourceId,
         request.object,
-        { limit: request.limit, offset },
+        selectOptions,
         principal
       )
       if (result && result.error) {


### PR DESCRIPTION
## Summary

C2-0 prerequisite for #2253. This makes `data-source:sql-readonly` capable of equality-filtered reads so C2 can perform flat, parameterized PLM lookups (`FileCode = projectNo`, parent-id lookups) instead of full-table reads followed by local filtering.

What changed:
- `data-source:sql-readonly.read({ filters })` now converts equality primitive filters into facade `select(..., { where })`
- the host read-only data-source facade forwards `where` into `DataSourceManager.select`
- filters are deliberately narrow: string / number / boolean / null only
- object-shaped operators and arrays fail closed before any facade read
- TODO + verification docs mark C2-0 as the bridge prerequisite before C2

Boundary:
- no PLM BOM expansion helper yet
- no MetaSheet writes
- no route/UI/migration
- no raw SQL / joins / stored procedures / user SQL
- no K3 Save / Submit / Audit / BOM

## Verification

Passed locally:

```bash
pnpm --filter plugin-integration-core test:data-source-bridge
pnpm --filter plugin-integration-core test:pipeline-runner
pnpm --filter @metasheet/core-backend exec vitest run tests/unit/data-source-plugin-facade.test.ts --reporter=dot
pnpm --filter @metasheet/core-backend build
git diff --check
```

Note: the core-backend single-file unit/build commands were run in the `/tmp` worktree with temporary symlinks to the already-installed main checkout `node_modules`; the symlinks were removed after the commands.

## Next

C2 remains a separate opt-in. It can use the #2253 candidate relation descriptors to build `projectNo -> PLM BOM` dry-run expansion over flat parameterized reads. If live PLM requires recursive CTE / stored procedure / vendor API / raw SQL, the track still pivots to a customer flat BOM view or deferred PLM adapter/API.