### PR TITLE
fix(data-factory): harden stock-preparation planner checks

### DIFF
--- a/plugins/plugin-integration-core/__tests__/stock-preparation-conflict-planner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-conflict-planner.test.cjs
@@ -11,9 +11,14 @@ const path = require('node:path')
 const {
   DECISIONS,
   StockPreparationConflictPlannerError,
+  __internals,
   planStockPreparationConflicts,
   summarizeConflictPlanForEvidence,
 } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-conflict-planner.cjs'))
+
+const {
+  STOCK_PREPARATION_MAIN_TABLE_TEMPLATE,
+} = require(path.join(__dirname, '..', 'lib', 'stock-preparation-templates.cjs'))
 
 function row(overrides = {}) {
   const componentSourceId = overrides.componentSourceId || 'PART-A'
@@ -50,6 +55,10 @@ function assertNoHumanFields(payload, message) {
   for (const field of ['materialType', 'blankType', 'stockPreparationStatus', 'demandDate', 'leadTimeDays', 'notes', 'procurementReply', 'warehouseConfirmation']) {
     assert.equal(Object.prototype.hasOwnProperty.call(payload, field), false, `${message}: ${field} must not be present`)
   }
+}
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value))
 }
 
 function testAddUpdateSkipInactive() {
@@ -180,6 +189,45 @@ function testMissingKeysAndStrategyGuards() {
     StockPreparationConflictPlannerError,
     'delete missing rows rejected',
   )
+  assert.throws(
+    () => planStockPreparationConflicts({ expandedRows: [], existingRows: [], plannedAt: 'not-a-date' }),
+    StockPreparationConflictPlannerError,
+    'invalid plannedAt string rejected',
+  )
+  const plannedAtPlan = planStockPreparationConflicts({
+    expandedRows: [],
+    existingRows: [],
+    plannedAt: '2026-06-04T09:00:00Z',
+  })
+  assert.equal(plannedAtPlan.plannedAt, '2026-06-04T09:00:00.000Z', 'valid plannedAt string is normalized')
+}
+
+function testHumanFieldWhitelistOrderIndependent() {
+  const template = clone(STOCK_PREPARATION_MAIN_TABLE_TEMPLATE)
+  const humanFields = template.fields.filter((field) => field.ownership === 'human_preserved').reverse()
+  const systemFields = template.fields.filter((field) => field.ownership !== 'human_preserved')
+  template.fields = [...humanFields, ...systemFields]
+
+  const plan = planStockPreparationConflicts({
+    template,
+    expandedRows: [row({ componentSourceId: 'PART-ORDER', pathTokens: ['PART-ORDER'] })],
+    existingRows: [],
+    runId: 'run-order',
+    plannedAt: '2026-06-04T09:00:00.000Z',
+  })
+
+  assert.equal(plan.valid, true)
+  assert.equal(plan.counts.add, 1, 'same human field set is accepted even when template order changes')
+  assert.equal(__internals.sameStringSet(['a', 'b', 'c'], ['a', 'a', 'b']), false, 'duplicate right-side entries are not set-equal')
+}
+
+function testPrimitiveValueComparisonFastPath() {
+  assert.equal(__internals.valuesEqual(undefined, null), true, 'undefined and null retain legacy equivalence')
+  assert.equal(__internals.valuesEqual(1, 1), true)
+  assert.equal(__internals.valuesEqual(1, '1'), false, 'primitive comparisons stay type-sensitive')
+  assert.equal(__internals.valuesEqual(true, false), false)
+  assert.equal(__internals.valuesEqual({ a: 1 }, { a: 1 }), true, 'object fallback keeps structural comparison')
+  assert.equal(__internals.valuesEqual(['a'], ['a']), true, 'array fallback keeps structural comparison')
 }
 
 function testValuesFreeEvidence() {
@@ -207,6 +255,8 @@ function main() {
   testRowErrorsDoNotAbortGoodRows()
   testDuplicatesAndConflictsFailClosed()
   testMissingKeysAndStrategyGuards()
+  testHumanFieldWhitelistOrderIndependent()
+  testPrimitiveValueComparisonFastPath()
   testValuesFreeEvidence()
 
   console.log('stock-preparation-conflict-planner.test.cjs OK')

--- a/plugins/plugin-integration-core/lib/stock-preparation-conflict-planner.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-conflict-planner.cjs
@@ -82,7 +82,13 @@ function normalizeIsoTime(value) {
     return new Date().toISOString()
   }
   if (value instanceof Date && !Number.isNaN(value.getTime())) return value.toISOString()
-  if (typeof value === 'string' && value.trim() !== '') return value.trim()
+  if (typeof value === 'string') {
+    const trimmed = value.trim()
+    if (trimmed !== '') {
+      const timestamp = Date.parse(trimmed)
+      if (!Number.isNaN(timestamp)) return new Date(timestamp).toISOString()
+    }
+  }
   throw new StockPreparationConflictPlannerError('plannedAt must be an ISO string or Date', { field: 'plannedAt' })
 }
 
@@ -147,8 +153,20 @@ function groupByKey(rows) {
   return { keyed, missing }
 }
 
+function comparableValue(value) {
+  return value === undefined ? null : value
+}
+
+function isPrimitiveComparable(value) {
+  return value === null || ['string', 'number', 'boolean'].includes(typeof value)
+}
+
 function valuesEqual(left, right) {
-  return JSON.stringify(left === undefined ? null : left) === JSON.stringify(right === undefined ? null : right)
+  const normalizedLeft = comparableValue(left)
+  const normalizedRight = comparableValue(right)
+  if (normalizedLeft === normalizedRight) return true
+  if (isPrimitiveComparable(normalizedLeft) && isPrimitiveComparable(normalizedRight)) return false
+  return JSON.stringify(normalizedLeft) === JSON.stringify(normalizedRight)
 }
 
 function changedFields(nextRow, existingRow, fields) {
@@ -172,6 +190,15 @@ function assertNoHumanFields(payload, humanFields, context) {
       })
     }
   }
+}
+
+function sameStringSet(left, right) {
+  if (!Array.isArray(left) || !Array.isArray(right) || left.length !== right.length) return false
+  const leftSet = new Set(left)
+  if (leftSet.size !== left.length) return false
+  const rightSet = new Set(right)
+  if (rightSet.size !== right.length) return false
+  return right.every((value) => leftSet.has(value))
 }
 
 function runPatch(runId, plannedAt, decision, conflictSummary = '') {
@@ -268,7 +295,7 @@ function planStockPreparationConflicts(input = {}) {
 
   const humanFields = HUMAN_PRESERVED_FIELD_IDS.slice()
   const templateHumanFields = fieldIdsByOwnership(template, 'human_preserved')
-  if (JSON.stringify(humanFields) !== JSON.stringify(templateHumanFields)) {
+  if (!sameStringSet(humanFields, templateHumanFields)) {
     throw new StockPreparationConflictPlannerError('human field whitelist drifted from template', {
       field: 'template.fields',
     })
@@ -447,7 +474,9 @@ module.exports = {
     changedFields,
     groupByKey,
     normalizeStrategy,
+    normalizeIsoTime,
     plmRefreshFieldIds,
+    sameStringSet,
     valuesEqual,
   },
 }


### PR DESCRIPTION
## Summary

Follow-up to #2269 / Gemini review. This hardens the pure stock-preparation conflict planner without changing runtime scope:

- validate `plannedAt` string inputs instead of accepting any non-empty string;
- compare the human-preserved field whitelist as a set, so template field order does not create false drift;
- add a primitive fast path for `valuesEqual` while preserving the existing null/undefined equivalence and object/array fallback behavior.

## Verification

- `pnpm --filter plugin-integration-core test:stock-preparation-conflict-planner`
- `pnpm --filter plugin-integration-core test:stock-preparation-templates`
- `pnpm --filter plugin-integration-core test`
- `git diff --check`

## Boundaries

Pure helper + unit test only. No route/UI/migration/DB/PLM read/MetaSheet write/K3 touch.
