### PR TITLE
fix(multitable): emit executor-shaped automation action configs

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -1508,6 +1508,43 @@ function emptyDraft(): Draft {
 }
 
 function draftConfigFromAction(type: AutomationActionType, config: Record<string, unknown>): DraftActionConfig {
+  if (type === 'update_record') {
+    const fields = isPlainRecord(config.fields)
+      ? config.fields
+      : isPlainRecord(config.fieldUpdates)
+        ? config.fieldUpdates
+        : {}
+    const fieldUpdates = Array.isArray(config.fieldUpdates)
+      ? config.fieldUpdates
+      : Object.entries(fields).map(([fieldId, value]) => ({ fieldId, value: String(value ?? '') }))
+    return { ...config, fieldUpdates }
+  }
+  if (type === 'create_record') {
+    const data = isPlainRecord(config.data)
+      ? config.data
+      : isPlainRecord(config.fieldValues)
+        ? config.fieldValues
+        : {}
+    const fieldValues = Array.isArray(config.fieldValues)
+      ? config.fieldValues
+      : Object.entries(data).map(([fieldId, value]) => ({ fieldId, value: String(value ?? '') }))
+    return {
+      ...config,
+      targetSheetId: typeof config.sheetId === 'string' ? config.sheetId : typeof config.targetSheetId === 'string' ? config.targetSheetId : '',
+      fieldValues,
+    }
+  }
+  if (type === 'send_notification') {
+    return {
+      ...config,
+      userId: Array.isArray(config.userIds)
+        ? config.userIds.join(', ')
+        : typeof config.userId === 'string'
+          ? config.userId
+          : '',
+      message: typeof config.message === 'string' ? config.message : '',
+    }
+  }
   if (type === 'send_dingtalk_group_message') {
     return {
       ...config,
@@ -1760,6 +1797,22 @@ function parseUserIdsText(value: unknown): string[] {
     .split(/[\n,]+/)
     .map((entry) => entry.trim())
     .filter(Boolean)
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+function fieldPairsToRecord(value: unknown): Record<string, unknown> {
+  if (!Array.isArray(value)) return {}
+  const fields: Record<string, unknown> = {}
+  for (const pair of value) {
+    if (!isPlainRecord(pair)) continue
+    const fieldId = typeof pair.fieldId === 'string' ? pair.fieldId.trim() : ''
+    if (!fieldId) continue
+    fields[fieldId] = pair.value ?? ''
+  }
+  return fields
 }
 
 function parseGroupDestinationIds(value: unknown): string[] {
@@ -2363,6 +2416,34 @@ function buildPayload(): Partial<AutomationRule> {
     triggerConfig.cron = cronPreset.value
   }
   const actions = d.actions.map((action) => {
+    if (action.type === 'update_record') {
+      return {
+        type: action.type,
+        config: {
+          fields: fieldPairsToRecord(action.config.fieldUpdates),
+        },
+      }
+    }
+    if (action.type === 'create_record') {
+      return {
+        type: action.type,
+        config: {
+          sheetId: typeof action.config.targetSheetId === 'string' && action.config.targetSheetId.trim()
+            ? action.config.targetSheetId.trim()
+            : undefined,
+          data: fieldPairsToRecord(action.config.fieldValues),
+        },
+      }
+    }
+    if (action.type === 'send_notification') {
+      return {
+        type: action.type,
+        config: {
+          userIds: parseUserIdsText(action.config.userId),
+          message: typeof action.config.message === 'string' ? action.config.message.trim() : '',
+        },
+      }
+    }
     if (action.type === 'send_dingtalk_group_message') {
       const destinationIds = parseGroupDestinationIds(action.config.destinationIds ?? action.config.destinationId)
       const destinationIdFieldPaths = parseRecipientFieldPathsText(action.config.destinationFieldPath)

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -1541,6 +1541,160 @@ describe('MetaAutomationRuleEditor', () => {
     })
   })
 
+  it('emits executor-shaped update_record config for UI-created post-wait follow-up actions', async () => {
+    const saved = vi.fn()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Wait then update'
+    nameInput.dispatchEvent(new Event('input'))
+
+    const firstActionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    firstActionSelect.value = 'wait_for_callback'
+    firstActionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="add-action"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const followUpRow = container.querySelector('[data-action-index="1"]') as HTMLElement
+    ;(followUpRow.querySelector('.meta-rule-editor__action-config .meta-rule-editor__btn') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const fieldSelect = followUpRow.querySelector('.meta-rule-editor__field-pair select') as HTMLSelectElement
+    fieldSelect.value = 'fld_1'
+    fieldSelect.dispatchEvent(new Event('change'))
+    const valueInput = followUpRow.querySelector('.meta-rule-editor__field-pair input') as HTMLInputElement
+    valueInput.value = 'Done'
+    valueInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.executionMode).toBe('workflow_job_v1')
+    expect(payload.actions).toEqual([
+      { type: 'wait_for_callback', config: {} },
+      { type: 'update_record', config: { fields: { fld_1: 'Done' } } },
+    ])
+    expect(payload.actionType).toBe('wait_for_callback')
+    expect(payload.actionConfig).toEqual({})
+  })
+
+  it('emits executor-shaped create_record config for UI-created post-wait follow-up actions', async () => {
+    const saved = vi.fn()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Wait then create'
+    nameInput.dispatchEvent(new Event('input'))
+
+    const firstActionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    firstActionSelect.value = 'wait_for_callback'
+    firstActionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="add-action"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const followUpRow = container.querySelector('[data-action-index="1"]') as HTMLElement
+    const followUpSelect = followUpRow.querySelector('.meta-rule-editor__action-header select') as HTMLSelectElement
+    followUpSelect.value = 'create_record'
+    followUpSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const targetSheetInput = followUpRow.querySelector('.meta-rule-editor__action-config > input') as HTMLInputElement
+    targetSheetInput.value = 'sheet_target'
+    targetSheetInput.dispatchEvent(new Event('input'))
+    ;(followUpRow.querySelector('.meta-rule-editor__action-config .meta-rule-editor__btn') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const [fieldInput, valueInput] = Array.from(followUpRow.querySelectorAll('.meta-rule-editor__field-pair input')) as HTMLInputElement[]
+    fieldInput.value = 'fld_status'
+    fieldInput.dispatchEvent(new Event('input'))
+    valueInput.value = 'New'
+    valueInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.executionMode).toBe('workflow_job_v1')
+    expect(payload.actions).toEqual([
+      { type: 'wait_for_callback', config: {} },
+      { type: 'create_record', config: { sheetId: 'sheet_target', data: { fld_status: 'New' } } },
+    ])
+  })
+
+  it('emits executor-shaped send_notification config for UI-created post-wait follow-up actions', async () => {
+    const saved = vi.fn()
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      onSave: saved,
+    })
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="name"]') as HTMLInputElement
+    nameInput.value = 'Wait then notify'
+    nameInput.dispatchEvent(new Event('input'))
+
+    const firstActionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    firstActionSelect.value = 'wait_for_callback'
+    firstActionSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="add-action"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const followUpRow = container.querySelector('[data-action-index="1"]') as HTMLElement
+    const followUpSelect = followUpRow.querySelector('.meta-rule-editor__action-header select') as HTMLSelectElement
+    followUpSelect.value = 'send_notification'
+    followUpSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const [userInput, messageInput] = Array.from(followUpRow.querySelectorAll('input, textarea')) as Array<HTMLInputElement | HTMLTextAreaElement>
+    userInput.value = 'user_1, user_2'
+    userInput.dispatchEvent(new Event('input'))
+    messageInput.value = 'Resume completed'
+    messageInput.dispatchEvent(new Event('input'))
+    await flushPromises()
+
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false)
+    saveBtn.click()
+    await flushPromises()
+
+    expect(saved).toHaveBeenCalledTimes(1)
+    const payload = saved.mock.calls[0][0]
+    expect(payload.executionMode).toBe('workflow_job_v1')
+    expect(payload.actions).toEqual([
+      { type: 'wait_for_callback', config: {} },
+      { type: 'send_notification', config: { userIds: ['user_1', 'user_2'], message: 'Resume completed' } },
+    ])
+  })
+
   it('keeps save disabled for incomplete send_email action', async () => {
     const saved = vi.fn()
     const { container } = mount({


### PR DESCRIPTION
## Summary

Fixes the #2257 post-redeploy A6-2 UAT blocker where UI-created follow-up actions after `wait_for_callback` saved draft-only config shapes that the executor cannot run.

This PR keeps scope to the advanced automation editor payload contract:

- `update_record`: converts UI `fieldUpdates[]` into executor `config.fields`
- `create_record`: converts UI `targetSheetId`/`fieldValues[]` into executor `config.sheetId`/`config.data`
- `send_notification`: converts UI user id text into executor `config.userIds[]`
- preserves load-back mapping from persisted executor-shaped configs into editable draft fields

## Boundary

- No A6-3/A6-4/A6-5 behavior.
- No suspend/resume runtime change.
- No public webhook resume or token emitter.
- Does not fix `lock_record`: that action still depends on a separate backend storage/schema contract (`meta_records.locked`) and should be handled as its own issue/PR, not mixed into this UI payload hotfix.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/multitable-automation-rule-editor.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vue-tsc -b --pretty false`
- `git diff --check`

Note: targeted ESLint on this existing Vue file still reports pre-existing errors (`vue/valid-v-for`, unused import/function) unrelated to this diff; no new lint cleanup is included here.

Closes the follow-up-action contract portion of #2257 after #2264.