### PR TITLE
feat(attendance): ④ C4-2 — expiry scheduler + expiresInDays grant wiring

### DIFF
--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -88,6 +88,12 @@ import {
   startApprovalSlaScheduler,
   stopApprovalSlaScheduler,
 } from './services/ApprovalSlaScheduler'
+import {
+  resolveAttendanceSchedulerIntervalMs,
+  resolveAttendanceSchedulerLeaderOptions,
+  startAttendanceScheduler,
+  stopAttendanceScheduler,
+} from './services/AttendanceScheduler'
 import { ApprovalBreachNotifier } from './services/ApprovalBreachNotifier'
 import {
   createApprovalBreachChannelsFromEnv,
@@ -1786,6 +1792,14 @@ export class MetaSheetServer {
       }
     })())
 
+    shutdownTasks.push((async () => {
+      try {
+        stopAttendanceScheduler()
+      } catch (err) {
+        this.logger.warn(`Attendance scheduler shutdown failed: ${err instanceof Error ? err.message : String(err)}`)
+      }
+    })())
+
     // 4. Destroy API Gateway resources (only if one was constructed during start()).
     shutdownTasks.push((async () => {
       try {
@@ -1952,6 +1966,20 @@ export class MetaSheetServer {
       this.logger.info('Approval SLA scheduler initialized')
     } catch (e) {
       this.logger.error('Approval SLA scheduler initialization failed; continuing in degraded mode', e as Error)
+    }
+
+    // ④ C4 — attendance comp-time expiry scheduler. Opt-in (ATTENDANCE_SCHEDULER_ENABLED=true, default
+    // OFF); returns null and no-ops when disabled. The expiry claim is idempotent + concurrency-safe on
+    // its own, so the optional Redis leader lock only sheds load.
+    try {
+      const attendanceLeaderOptions = await resolveAttendanceSchedulerLeaderOptions()
+      const scheduler = startAttendanceScheduler({
+        leaderOptions: attendanceLeaderOptions,
+        intervalMs: resolveAttendanceSchedulerIntervalMs(),
+      })
+      this.logger.info(scheduler ? 'Attendance scheduler initialized' : 'Attendance scheduler disabled (ATTENDANCE_SCHEDULER_ENABLED!=true)')
+    } catch (e) {
+      this.logger.error('Attendance scheduler initialization failed; continuing in degraded mode', e as Error)
     }
 
     // 加载插件并启动 HTTP 服务

--- a/packages/core-backend/src/services/AttendanceNotifier.ts
+++ b/packages/core-backend/src/services/AttendanceNotifier.ts
@@ -1,0 +1,84 @@
+/**
+ * ④ C4 — AttendanceNotifier scaffold (NO messages in C4).
+ *
+ * The seam ⑤/C5 reminders will use. C4 builds ONLY the scaffold: the channel interface, an env-gated
+ * factory that registers NOTHING by default (channel-env-gating discipline — a default-registered
+ * channel produces per-tick warn noise under at-least-once retry), and a no-op dispatch. C4's expiry job
+ * does not notify; the reminder job + concrete channels (DingTalk/email) arrive in C5, mirroring
+ * ApprovalBreachNotifier.
+ */
+
+import { Logger } from '../core/logger'
+
+export interface AttendanceNotificationMessage {
+  orgId: string
+  userId: string
+  kind: string
+  text: string
+}
+
+export interface AttendanceChannelResult {
+  ok: boolean
+  error?: string
+}
+
+export interface AttendanceNotificationChannel {
+  readonly name: string
+  send(message: AttendanceNotificationMessage): Promise<AttendanceChannelResult>
+}
+
+export interface AttendanceNotifierOptions {
+  channels?: AttendanceNotificationChannel[]
+  logger?: Logger
+}
+
+export interface AttendanceNotifyResult {
+  requested: number
+  sent: number
+  failed: number
+}
+
+export class AttendanceNotifier {
+  private readonly channels: AttendanceNotificationChannel[]
+  private readonly logger: Logger
+
+  constructor(options: AttendanceNotifierOptions = {}) {
+    this.channels = options.channels ?? []
+    this.logger = options.logger ?? new Logger('AttendanceNotifier')
+  }
+
+  get channelCount(): number {
+    return this.channels.length
+  }
+
+  /**
+   * Dispatch a batch of messages across every registered channel. With no channels (the C4 default)
+   * this is a no-op — sends nothing and logs nothing, so an at-least-once caller never produces per-tick
+   * warn noise. Never throws; a channel failure is isolated and counted.
+   */
+  async notify(messages: AttendanceNotificationMessage[]): Promise<AttendanceNotifyResult> {
+    const result: AttendanceNotifyResult = { requested: messages.length, sent: 0, failed: 0 }
+    if (this.channels.length === 0 || messages.length === 0) return result
+    for (const message of messages) {
+      for (const channel of this.channels) {
+        try {
+          const outcome = await channel.send(message)
+          if (outcome.ok) result.sent += 1
+          else result.failed += 1
+        } catch (error) {
+          result.failed += 1
+          this.logger.warn(`AttendanceNotifier channel ${channel.name} failed: ${error instanceof Error ? error.message : String(error)}`)
+        }
+      }
+    }
+    return result
+  }
+}
+
+/**
+ * Env-gated channel factory. C4 ships NO concrete channels — returns [] so nothing is registered by
+ * default (channel-env-gating discipline). C5 adds channels behind their own env flags.
+ */
+export function createAttendanceNotifierChannelsFromEnv(_env: NodeJS.ProcessEnv = process.env): AttendanceNotificationChannel[] {
+  return []
+}

--- a/packages/core-backend/src/services/AttendanceScheduler.ts
+++ b/packages/core-backend/src/services/AttendanceScheduler.ts
@@ -1,0 +1,290 @@
+/**
+ * ④ C4 — attendance comp-time expiry scheduler base.
+ *
+ * Mirrors ApprovalSlaScheduler: a periodic tick (default hourly) that runs the
+ * AttendanceExpiryService claim — flips `status='active' → 'expired'` on comp-time lots whose
+ * `expires_at` has passed and writes one `expire` event per transitioned lot. Single-process interval
+ * with a one-run guard; multi-instance fleets can opt into a Redis leader lock via
+ * ENABLE_ATTENDANCE_SCHEDULER_LEADER_LOCK=true. The expiry claim (AttendanceExpiryService) is itself
+ * idempotent and concurrency-safe (the `status='active'` predicate is the guard), so the leader lock is
+ * a LOAD optimisation only — never load-bearing for correctness.
+ *
+ * Default OFF: the scheduler starts only when ATTENDANCE_SCHEDULER_ENABLED=true. Until then, and until an
+ * org sets compTimeFromOvertime.expiresInDays (which makes grants stamp expires_at), expiry never runs.
+ *
+ * v1 wires only the expiry job. ⑤ unscheduled-reminder will reuse this base as a second job; the
+ * notification path lives in AttendanceNotifier (C5) — this scheduler sends nothing.
+ */
+
+import { randomBytes } from 'crypto'
+import { Logger } from '../core/logger'
+import { getRedisClient } from '../db/redis'
+import { RedisLeaderLock, type RedisLeaderLockClient } from '../multitable/redis-leader-lock'
+import {
+  getAttendanceExpiryService,
+  type AttendanceExpiryService,
+  type ExpiredCompTimeBalance,
+} from './AttendanceExpiryService'
+
+const DEFAULT_INTERVAL_MS = 60 * 60 * 1000
+const MIN_INTERVAL_MS = 5000
+const DEFAULT_LOCK_TTL_MS = 30_000
+
+export interface AttendanceSchedulerOptions {
+  expiryService?: AttendanceExpiryService
+  intervalMs?: number
+  leaderOptions?: AttendanceSchedulerLeaderOptions | null
+  runtime?: AttendanceSchedulerRuntimeOptions
+  logger?: Logger
+}
+
+export interface AttendanceSchedulerLeaderOptions {
+  leaderLock: RedisLeaderLock
+  lockKey?: string
+  ownerId: string
+  ttlMs?: number
+  renewIntervalMs?: number
+  retryIntervalMs?: number
+}
+
+export interface AttendanceSchedulerLeaderGauge {
+  labels(labels: { state: 'leader' | 'follower' | 'relinquished' }): { set(value: number): void }
+}
+
+export interface AttendanceSchedulerRuntimeOptions {
+  leaderStateGauge?: AttendanceSchedulerLeaderGauge
+}
+
+export class AttendanceScheduler {
+  private readonly logger: Logger
+  private readonly expiryService: AttendanceExpiryService
+  private readonly intervalMs: number
+  private readonly leaderOptions: AttendanceSchedulerLeaderOptions | null
+  private readonly lockKey: string
+  private readonly ttlMs: number
+  private readonly renewIntervalMs: number
+  private readonly retryIntervalMs: number
+  private readonly leaderStateGauge: AttendanceSchedulerLeaderGauge | null
+  private timer: NodeJS.Timeout | null = null
+  private renewalTimer: NodeJS.Timeout | null = null
+  private acquisitionTimer: NodeJS.Timeout | null = null
+  private running = false
+  private started = false
+  private isLeader = false
+  public readonly ready: Promise<void>
+
+  constructor(options: AttendanceSchedulerOptions = {}) {
+    this.expiryService = options.expiryService ?? getAttendanceExpiryService()
+    this.intervalMs = Math.max(MIN_INTERVAL_MS, options.intervalMs ?? DEFAULT_INTERVAL_MS)
+    this.leaderOptions = options.leaderOptions ?? null
+    this.lockKey = this.leaderOptions?.lockKey ?? 'attendance-scheduler:leader'
+    this.ttlMs = this.leaderOptions?.ttlMs ?? DEFAULT_LOCK_TTL_MS
+    this.renewIntervalMs = this.leaderOptions?.renewIntervalMs ?? Math.max(1_000, Math.floor(this.ttlMs / 3))
+    this.retryIntervalMs = this.leaderOptions?.retryIntervalMs ?? Math.max(1_000, Math.floor(this.ttlMs / 3))
+    this.leaderStateGauge = options.runtime?.leaderStateGauge ?? null
+    this.logger = options.logger ?? new Logger('AttendanceScheduler')
+    if (this.leaderOptions) {
+      this.setLeaderGauge('follower')
+      this.ready = this.attemptLeadership().catch((error) => {
+        this.isLeader = false
+        this.setLeaderGauge('follower')
+        this.logger.warn(`Attendance leader-lock acquisition failed: ${error instanceof Error ? error.message : String(error)}`)
+      })
+    } else {
+      this.isLeader = true
+      this.setLeaderGauge('leader')
+      this.ready = Promise.resolve()
+    }
+  }
+
+  start(): void {
+    if (this.started) return
+    this.started = true
+    this.ready.then(() => {
+      if (!this.started) return
+      if (this.isLeader) {
+        this.startTickLoop()
+      } else {
+        this.startAcquisitionRetryLoop()
+      }
+    }).catch((error) => {
+      this.logger.warn(`Attendance scheduler start skipped after leader-lock error: ${error instanceof Error ? error.message : String(error)}`)
+    })
+  }
+
+  stop(): void {
+    this.started = false
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+    if (this.renewalTimer) {
+      clearInterval(this.renewalTimer)
+      this.renewalTimer = null
+    }
+    if (this.acquisitionTimer) {
+      clearInterval(this.acquisitionTimer)
+      this.acquisitionTimer = null
+    }
+    if (this.leaderOptions && this.isLeader) {
+      const { leaderLock, ownerId } = this.leaderOptions
+      leaderLock.release(this.lockKey, ownerId).catch(() => {})
+      this.isLeader = false
+    }
+    this.setLeaderGauge('relinquished')
+    this.logger.info('Attendance scheduler stopped')
+  }
+
+  async tick(): Promise<ExpiredCompTimeBalance[]> {
+    if (!this.isLeader) return []
+    if (this.running) return []
+    this.running = true
+    try {
+      const expired = await this.expiryService.expireCompTimeBalances()
+      if (expired.length > 0) {
+        this.logger.info(`Comp-time lots expired: ${expired.length}`)
+      }
+      return expired
+    } catch (error) {
+      this.logger.error(`Attendance expiry tick failed: ${error instanceof Error ? error.message : String(error)}`)
+      return []
+    } finally {
+      this.running = false
+    }
+  }
+
+  get leader(): boolean {
+    return this.isLeader
+  }
+
+  private async attemptLeadership(): Promise<void> {
+    if (!this.leaderOptions) return
+    const { leaderLock, ownerId } = this.leaderOptions
+    const won = await leaderLock.acquire(this.lockKey, ownerId, this.ttlMs)
+    this.isLeader = won
+    if (won) {
+      this.logger.info(`Acquired attendance scheduler leader lock ${this.lockKey} (owner=${ownerId}, ttl=${this.ttlMs}ms)`)
+      this.setLeaderGauge('leader')
+      this.stopAcquisitionRetryLoop()
+      this.startRenewalLoop()
+      if (this.started) this.startTickLoop()
+    } else {
+      this.logger.info(`Did not acquire attendance scheduler leader lock ${this.lockKey}; operating as non-leader (owner=${ownerId})`)
+      this.setLeaderGauge('follower')
+    }
+  }
+
+  private setLeaderGauge(state: 'leader' | 'follower' | 'relinquished'): void {
+    if (!this.leaderStateGauge) return
+    try {
+      for (const candidate of ['leader', 'follower', 'relinquished'] as const) {
+        this.leaderStateGauge.labels({ state: candidate }).set(candidate === state ? 1 : 0)
+      }
+    } catch {
+      // Metrics failures must not break the scheduler.
+    }
+  }
+
+  private startTickLoop(): void {
+    if (!this.started || !this.isLeader || this.timer) return
+    this.logger.info(`Attendance scheduler starting with interval ${this.intervalMs}ms`)
+    this.timer = setInterval(() => { void this.tick() }, this.intervalMs)
+    if (typeof this.timer.unref === 'function') this.timer.unref()
+  }
+
+  private startAcquisitionRetryLoop(): void {
+    if (!this.leaderOptions || this.acquisitionTimer || this.isLeader) return
+    this.acquisitionTimer = setInterval(() => {
+      this.attemptLeadership().catch((error) => {
+        this.isLeader = false
+        this.setLeaderGauge('follower')
+        this.logger.warn(`Attendance leader-lock retry failed: ${error instanceof Error ? error.message : String(error)}`)
+      })
+    }, this.retryIntervalMs)
+    if (typeof this.acquisitionTimer.unref === 'function') this.acquisitionTimer.unref()
+  }
+
+  private stopAcquisitionRetryLoop(): void {
+    if (!this.acquisitionTimer) return
+    clearInterval(this.acquisitionTimer)
+    this.acquisitionTimer = null
+  }
+
+  private startRenewalLoop(): void {
+    if (!this.leaderOptions) return
+    if (this.renewalTimer) clearInterval(this.renewalTimer)
+    const { leaderLock, ownerId } = this.leaderOptions
+    this.renewalTimer = setInterval(() => {
+      leaderLock.renew(this.lockKey, ownerId, this.ttlMs).then(
+        (ok) => {
+          if (!ok) this.relinquishLeadership('renewal rejected')
+        },
+        (error) => {
+          this.logger.warn(`Attendance leader renewal error for ${this.lockKey}: ${error instanceof Error ? error.message : String(error)}`)
+          this.relinquishLeadership('renewal error')
+        },
+      )
+    }, this.renewIntervalMs)
+    if (typeof this.renewalTimer.unref === 'function') this.renewalTimer.unref()
+  }
+
+  private relinquishLeadership(reason: string): void {
+    if (!this.isLeader) return
+    this.logger.warn(`Relinquishing attendance scheduler leadership (${reason})`)
+    this.isLeader = false
+    this.setLeaderGauge('relinquished')
+    if (this.timer) {
+      clearInterval(this.timer)
+      this.timer = null
+    }
+    if (this.renewalTimer) {
+      clearInterval(this.renewalTimer)
+      this.renewalTimer = null
+    }
+    if (this.started) this.startAcquisitionRetryLoop()
+  }
+}
+
+let sharedScheduler: AttendanceScheduler | null = null
+
+/**
+ * Opt-in: starts the attendance scheduler only when ATTENDANCE_SCHEDULER_ENABLED=true (default OFF).
+ * Returns null when disabled or already started.
+ */
+export function startAttendanceScheduler(options: AttendanceSchedulerOptions = {}): AttendanceScheduler | null {
+  if (process.env.ATTENDANCE_SCHEDULER_ENABLED !== 'true') return null
+  if (sharedScheduler) return sharedScheduler
+  sharedScheduler = new AttendanceScheduler(options)
+  sharedScheduler.start()
+  return sharedScheduler
+}
+
+export function stopAttendanceScheduler(): void {
+  if (sharedScheduler) {
+    sharedScheduler.stop()
+    sharedScheduler = null
+  }
+}
+
+export async function resolveAttendanceSchedulerLeaderOptions(): Promise<AttendanceSchedulerLeaderOptions | null> {
+  if (process.env.ENABLE_ATTENDANCE_SCHEDULER_LEADER_LOCK !== 'true') return null
+  const redis = await getRedisClient()
+  if (!redis) return null
+  const ttlMs = Number(process.env.ATTENDANCE_SCHEDULER_LEADER_LOCK_TTL_MS) > 0
+    ? Number(process.env.ATTENDANCE_SCHEDULER_LEADER_LOCK_TTL_MS)
+    : DEFAULT_LOCK_TTL_MS
+  const retryIntervalMs = Number(process.env.ATTENDANCE_SCHEDULER_LEADER_LOCK_RETRY_MS) > 0
+    ? Number(process.env.ATTENDANCE_SCHEDULER_LEADER_LOCK_RETRY_MS)
+    : undefined
+  return {
+    leaderLock: new RedisLeaderLock({ client: redis as unknown as RedisLeaderLockClient }),
+    ownerId: `attendance-scheduler:${process.pid}:${randomBytes(4).toString('hex')}`,
+    ttlMs,
+    retryIntervalMs,
+  }
+}
+
+export function resolveAttendanceSchedulerIntervalMs(): number | undefined {
+  const raw = Number(process.env.ATTENDANCE_SCHEDULER_INTERVAL_MS)
+  return Number.isFinite(raw) && raw > 0 ? raw : undefined
+}

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -5,6 +5,8 @@ import net from 'net'
 import fs from 'fs/promises'
 import { Pool } from 'pg'
 import http from 'http'
+import { AttendanceExpiryService } from '../../src/services/AttendanceExpiryService'
+import { AttendanceScheduler } from '../../src/services/AttendanceScheduler'
 
 type HttpResponse = { status: number; body?: unknown; raw: string }
 
@@ -3021,7 +3023,7 @@ attendanceIntegrationDescribe(
       await pool.query('DELETE FROM attendance_leave_balance_events WHERE user_id = $1', [userId]).catch(() => undefined)
       await pool.query('DELETE FROM attendance_leave_balances WHERE user_id = $1', [userId]).catch(() => undefined)
       if (createdRequestIds.length > 0) {
-        await pool.query('DELETE FROM attendance_requests WHERE id = ANY($1::text[])', [createdRequestIds]).catch(() => undefined)
+        await pool.query('DELETE FROM attendance_requests WHERE id = ANY($1::uuid[])', [createdRequestIds]).catch(() => undefined)
       }
       if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS
       else process.env.RBAC_BYPASS = previousRbacBypass
@@ -3135,7 +3137,112 @@ attendanceIntegrationDescribe(
       await pool.query('DELETE FROM attendance_leave_balance_events WHERE user_id = ANY($1::text[])', [[uOk, uShort, uFifo]]).catch(() => undefined)
       await pool.query('DELETE FROM attendance_leave_balances WHERE user_id = ANY($1::text[])', [[uOk, uShort, uFifo]]).catch(() => undefined)
       if (createdRequestIds.length > 0) {
-        await pool.query('DELETE FROM attendance_requests WHERE id = ANY($1::text[])', [createdRequestIds]).catch(() => undefined)
+        await pool.query('DELETE FROM attendance_requests WHERE id = ANY($1::uuid[])', [createdRequestIds]).catch(() => undefined)
+      }
+      if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS
+      else process.env.RBAC_BYPASS = previousRbacBypass
+      await pool.end().catch(() => undefined)
+    }
+  })
+
+  it('④ C4 — grant stamps expires_at iff expiresInDays set; scheduler tick expires aged lots once (NULL/future survive)', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const runSuffix = Date.now().toString(36)
+    const userId = `attendance-c4wire-${runSuffix}`
+    const previousRbacBypass = process.env.RBAC_BYPASS
+    const pool = new Pool({ connectionString: dbUrl })
+    const scheduler = new AttendanceScheduler({
+      expiryService: new AttendanceExpiryService(async <T = unknown>(sql, params = []) => {
+        const result = await pool.query<T>(sql, params)
+        return { rows: result.rows, rowCount: result.rowCount }
+      }),
+    })
+    let token: string | undefined
+    let originalSettings: Record<string, unknown> = {}
+    const createdRequestIds: string[] = []
+    try {
+      process.env.RBAC_BYPASS = 'true'
+      const tokenRes = await requestJson(`${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`)
+      token = (tokenRes.body as { token?: string } | undefined)?.token
+      if (!token) return
+      const headers = { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }
+      const origRes = await requestJson(`${baseUrl}/api/attendance/settings`, { headers: { Authorization: `Bearer ${token}` } })
+      originalSettings = ((origRes.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
+
+      const otRuleRes = await requestJson(`${baseUrl}/api/attendance/overtime-rules`, { method: 'POST', headers, body: JSON.stringify({ name: `c4wire-ot-${runSuffix}`, minMinutes: 30 }) })
+      expect([201, 409]).toContain(otRuleRes.status)
+      let overtimeRuleId = (otRuleRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      if (!overtimeRuleId) {
+        const list = await requestJson(`${baseUrl}/api/attendance/overtime-rules`, { headers: { Authorization: `Bearer ${token}` } })
+        overtimeRuleId = ((list.body as { data?: { items?: { id?: string; name?: string }[] } } | undefined)?.data?.items ?? []).find(i => i.name === `c4wire-ot-${runSuffix}`)?.id
+      }
+      expect(overtimeRuleId).toBeTruthy()
+      const setCompTime = (body: Record<string, unknown>) => requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers, body: JSON.stringify({ compTimeFromOvertime: body }) })
+      const approveOvertime = async (workDate: string, minutes: number) => {
+        const create = await requestJson(`${baseUrl}/api/attendance/requests`, { method: 'POST', headers, body: JSON.stringify({ workDate, requestType: 'overtime', overtimeRuleId, minutes }) })
+        expect(create.status).toBe(201)
+        const id = (create.body as { data?: { request?: { id?: string } } } | undefined)?.data?.request?.id as string
+        createdRequestIds.push(id)
+        expect((await requestJson(`${baseUrl}/api/attendance/requests/${id}/approve`, { method: 'POST', headers, body: JSON.stringify({ comment: 'c4' }) })).status).toBe(200)
+        return id
+      }
+      const lotFor = async (otId: string) => (await pool.query(
+        `SELECT id, remaining_minutes, status, expires_at,
+                (expires_at - granted_at = interval '720 hours') AS exact_30d
+           FROM attendance_leave_balances WHERE org_id = 'default' AND source_key = $1`,
+        [`overtime_conversion:${otId}`],
+      )).rows[0] as { id: string; remaining_minutes: number; status: string; expires_at: string | null; exact_30d: boolean | null }
+      const expireEvents = async (balanceId: string) => (await pool.query(
+        `SELECT delta_minutes, source_type FROM attendance_leave_balance_events WHERE balance_id = $1 AND event_type = 'expire'`,
+        [balanceId],
+      )).rows as { delta_minutes: number; source_type: string }[]
+
+      // (1) enabled + expiresInDays=30 → grant stamps expires_at = granted_at + 30×24h (exact).
+      expect((await setCompTime({ enabled: true, expiresInDays: 30 })).status).toBe(200)
+      const otFuture = await approveOvertime('2026-09-25', 120)
+      const lotFuture = await lotFor(otFuture)
+      expect(lotFuture.status).toBe('active')
+      expect(lotFuture.expires_at).not.toBeNull()
+      expect(lotFuture.exact_30d).toBe(true) // expires_at - granted_at === 720h (DST-free fixed duration)
+
+      // (2) enabled + expiresInDays=null → grant keeps expires_at NULL (unchanged C2 behaviour).
+      expect((await setCompTime({ enabled: true, expiresInDays: null })).status).toBe(200)
+      const otNull = await approveOvertime('2026-09-26', 60)
+      const lotNull = await lotFor(otNull)
+      expect(lotNull.expires_at).toBeNull()
+
+      // (3) a scan with nothing of OURS past-due → our future + NULL lots both survive. The scan is
+      //     global (all orgs/users), so we assert OUR lots are absent from the result rather than the
+      //     whole result being empty — a stray past-due lot from another test must not flake this.
+      const tick3 = (await scheduler.tick()).map(r => r.balanceId)
+      expect(tick3).not.toContain(lotFuture.id)
+      expect(tick3).not.toContain(lotNull.id)
+      expect((await lotFor(otFuture)).status).toBe('active')
+      expect((await lotFor(otNull)).status).toBe('active')
+
+      // (4) age the future lot past its expiry, then tick → it expires once (remaining=0 + one expire event);
+      //     the NULL lot is still untouched.
+      await pool.query("UPDATE attendance_leave_balances SET expires_at = now() - interval '1 hour' WHERE id = $1", [lotFuture.id])
+      const firstTick = await scheduler.tick()
+      expect(firstTick.find(r => r.balanceId === lotFuture.id)).toEqual({ orgId: 'default', userId, balanceId: lotFuture.id, expiredMinutes: 120 })
+      expect(await lotFor(otFuture)).toMatchObject({ remaining_minutes: 0, status: 'expired' })
+      expect(await expireEvents(lotFuture.id)).toEqual([{ delta_minutes: -120, source_type: 'comp_time_expiry' }])
+      expect((await lotFor(otNull)).status).toBe('active')
+
+      // (5) repeat tick → our lot is not re-expired. Idempotency is proven by OUR expire-event count
+      //     staying 1 (user-scoped), not by the global scan being empty.
+      expect((await scheduler.tick()).map(r => r.balanceId)).not.toContain(lotFuture.id)
+      expect(await expireEvents(lotFuture.id)).toHaveLength(1)
+    } finally {
+      if (token && Object.keys(originalSettings).length > 0) {
+        await requestJson(`${baseUrl}/api/attendance/settings`, { method: 'PUT', headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' }, body: JSON.stringify(originalSettings) }).catch(() => undefined)
+      }
+      await pool.query('DELETE FROM attendance_leave_balance_events WHERE user_id = $1', [userId]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_leave_balances WHERE user_id = $1', [userId]).catch(() => undefined)
+      if (createdRequestIds.length > 0) {
+        await pool.query('DELETE FROM attendance_requests WHERE id = ANY($1::uuid[])', [createdRequestIds]).catch(() => undefined)
       }
       if (previousRbacBypass === undefined) delete process.env.RBAC_BYPASS
       else process.env.RBAC_BYPASS = previousRbacBypass
@@ -4707,7 +4814,7 @@ attendanceIntegrationDescribe(
             weeklyMaxMinutes: 2400,
             monthlyMaxMinutes: 9600,
           },
-          compTimeFromOvertime: { enabled: true },
+          compTimeFromOvertime: { enabled: true, expiresInDays: 45 },
         }),
       })
       expect(saveSettingsRes.status).toBe(200)
@@ -4734,7 +4841,7 @@ attendanceIntegrationDescribe(
         weeklyMaxMinutes: 2400,
         monthlyMaxMinutes: 9600,
       })
-      expect(reloaded?.compTimeFromOvertime).toEqual({ enabled: true })
+      expect(reloaded?.compTimeFromOvertime).toEqual({ enabled: true, expiresInDays: 45 })
 
       const futurePunchRes = await requestJson(`${baseUrl}/api/attendance/punch`, {
         method: 'POST',

--- a/packages/core-backend/tests/unit/attendance-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduler.test.ts
@@ -1,0 +1,85 @@
+import { afterEach, describe, expect, it } from 'vitest'
+
+import {
+  AttendanceScheduler,
+  startAttendanceScheduler,
+  stopAttendanceScheduler,
+} from '../../src/services/AttendanceScheduler'
+import type { AttendanceExpiryService, ExpiredCompTimeBalance } from '../../src/services/AttendanceExpiryService'
+import {
+  AttendanceNotifier,
+  createAttendanceNotifierChannelsFromEnv,
+} from '../../src/services/AttendanceNotifier'
+
+function fakeExpiryService(rows: ExpiredCompTimeBalance[], spy?: () => void): AttendanceExpiryService {
+  return {
+    async expireCompTimeBalances() {
+      spy?.()
+      return rows
+    },
+  } as unknown as AttendanceExpiryService
+}
+
+describe('AttendanceScheduler (④ C4)', () => {
+  afterEach(() => {
+    stopAttendanceScheduler()
+    delete process.env.ATTENDANCE_SCHEDULER_ENABLED
+  })
+
+  it('tick (single-process leader) runs the expiry service and returns its result', async () => {
+    let calls = 0
+    const expired: ExpiredCompTimeBalance[] = [
+      { orgId: 'default', userId: 'u1', balanceId: 'b1', expiredMinutes: 90 },
+    ]
+    const scheduler = new AttendanceScheduler({ expiryService: fakeExpiryService(expired, () => { calls += 1 }) })
+    expect(scheduler.leader).toBe(true) // no leaderOptions → single-process assumption
+    const result = await scheduler.tick()
+    expect(result).toEqual(expired)
+    expect(calls).toBe(1)
+  })
+
+  it('tick swallows expiry errors and returns [] (a bad scan never crashes the loop)', async () => {
+    const throwing = {
+      async expireCompTimeBalances() { throw new Error('boom') },
+    } as unknown as AttendanceExpiryService
+    const scheduler = new AttendanceScheduler({ expiryService: throwing })
+    await expect(scheduler.tick()).resolves.toEqual([])
+  })
+
+  it('startAttendanceScheduler is default OFF — returns null unless ATTENDANCE_SCHEDULER_ENABLED=true', () => {
+    delete process.env.ATTENDANCE_SCHEDULER_ENABLED
+    expect(startAttendanceScheduler({ expiryService: fakeExpiryService([]) })).toBeNull()
+
+    process.env.ATTENDANCE_SCHEDULER_ENABLED = 'true'
+    const scheduler = startAttendanceScheduler({ expiryService: fakeExpiryService([]) })
+    expect(scheduler).not.toBeNull()
+    // Idempotent: the shared instance is returned, not a second scheduler.
+    expect(startAttendanceScheduler({ expiryService: fakeExpiryService([]) })).toBe(scheduler)
+  })
+})
+
+describe('AttendanceNotifier scaffold (④ C4 — no messages)', () => {
+  it('registers no channels from env by default (channel-env-gating discipline)', () => {
+    expect(createAttendanceNotifierChannelsFromEnv({})).toEqual([])
+  })
+
+  it('notify with no channels is a silent no-op (no send, no throw, no warn noise)', async () => {
+    const notifier = new AttendanceNotifier()
+    expect(notifier.channelCount).toBe(0)
+    const result = await notifier.notify([{ orgId: 'default', userId: 'u1', kind: 'comp_time_expiry', text: 'x' }])
+    expect(result).toEqual({ requested: 1, sent: 0, failed: 0 })
+  })
+
+  it('dispatches across registered channels and isolates a failing one', async () => {
+    const calls: string[] = []
+    const notifier = new AttendanceNotifier({
+      channels: [
+        { name: 'ok', async send() { calls.push('ok'); return { ok: true } } },
+        { name: 'bad', async send() { calls.push('bad'); throw new Error('down') } },
+      ],
+    })
+    const result = await notifier.notify([{ orgId: 'default', userId: 'u1', kind: 'k', text: 't' }])
+    expect(result).toEqual({ requested: 1, sent: 1, failed: 1 })
+    expect(calls).toEqual(['ok', 'bad'])
+  })
+})

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -129,10 +129,13 @@ const DEFAULT_SETTINGS = {
     },
   },
   // ④ C2 (#2230 design-lock): overtime approval → comp-time (调休) leave grant.
-  // Opt-in; default OFF. v1 = 1:1 minutes, no expiry. The grant lot is written in the
-  // approval txn's final-approval branch (see resolveRequest); nothing accrues until enabled.
+  // Opt-in; default OFF. v1 = 1:1 minutes. The grant lot is written in the approval txn's
+  // final-approval branch (see resolveRequest); nothing accrues until enabled. ④ C4:
+  // expiresInDays (default null = no expiry) — when set, a grant stamps expires_at = granted_at +
+  // expiresInDays×24h and the AttendanceScheduler's expiry job (AttendanceExpiryService) reaps it.
   compTimeFromOvertime: {
     enabled: false,
+    expiresInDays: null,
   },
 }
 
@@ -10864,8 +10867,13 @@ function normalizeSettings(raw) {
 // default OFF. Only `enabled` is honoured (boolean); anything else falls back to the default.
 function normalizeCompTimeFromOvertimeSetting(raw) {
   const config = raw && typeof raw === 'object' ? raw : {}
+  // ④ C4: expiresInDays is a positive integer (validity in days) or null (no expiry). Anything
+  // else — 0, negative, non-numeric — normalizes to null so it can never shorten/garble expiry.
+  const expiresInDaysRaw = Number(config.expiresInDays)
+  const expiresInDays = Number.isInteger(expiresInDaysRaw) && expiresInDaysRaw > 0 ? expiresInDaysRaw : null
   return {
     enabled: typeof config.enabled === 'boolean' ? config.enabled : DEFAULT_SETTINGS.compTimeFromOvertime.enabled,
+    expiresInDays,
   }
 }
 
@@ -16434,9 +16442,11 @@ module.exports = {
           year: z.number().int().min(0).nullable().optional(),
         }).optional(),
       }).optional(),
-      // ④ C2 (#2230): overtime→comp-time opt-in. Only the boolean switch is settable here.
+      // ④ overtime→comp-time opt-in: the C2 enable switch + the C4 expiry validity (positive int days,
+      // or null = no expiry).
       compTimeFromOvertime: z.object({
         enabled: z.boolean().optional(),
+        expiresInDays: z.number().int().positive().nullable().optional(),
       }).optional(),
     })
 
@@ -20411,13 +20421,19 @@ module.exports = {
                 const amountMinutes = Math.floor(Number(requestMetadata.minutes) || 0)
                 if (amountMinutes > 0) {
                   const compTimeSourceKey = `overtime_conversion:${requestId}`
+                  // ④ C4 (#2267): when expiresInDays is configured (positive int), stamp the grant with
+                  // expires_at = granted_at + N×24h — a FIXED 24h-per-day duration, computed in SQL from
+                  // the statement's now() (granted_at also defaults to now() → exact). null = no expiry
+                  // (unchanged C2 behaviour). The AttendanceExpiryService (C4-1) reaps these.
+                  const expiresInDays = compTimeSettings.compTimeFromOvertime.expiresInDays ?? null
                   const lotRows = await trx.query(
                     `INSERT INTO attendance_leave_balances
-                       (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_id, source_key, status)
-                     VALUES ($1, $2, 'comp_time', $3, $3, 'overtime_conversion', $4, $5, 'active')
+                       (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_id, source_key, status, expires_at)
+                     VALUES ($1, $2, 'comp_time', $3, $3, 'overtime_conversion', $4, $5, 'active',
+                             CASE WHEN $6::int IS NULL THEN NULL ELSE now() + ($6::int * interval '24 hours') END)
                      ON CONFLICT (org_id, source_key) DO NOTHING
                      RETURNING id`,
-                    [orgId, requestRow.user_id, amountMinutes, requestId, compTimeSourceKey]
+                    [orgId, requestRow.user_id, amountMinutes, requestId, compTimeSourceKey, expiresInDays]
                   )
                   const newLotId = lotRows[0]?.id
                   if (newLotId) {


### PR DESCRIPTION
## What

④ **C4-2** — turns comp-time **expiry** on, end-to-end and in **one slice** (no writer-before-expirer window). Builds on C4-1's `AttendanceExpiryService` (#2270); governed by the #2267 design-lock.

Chain: C0 align · C1 ledger (#2231) · C2 credit (#2252) · C3 deduction (#2261) · C4-1 expiry function (#2270, inert) · **C4-2 = this**.

## How (the locked completion criteria)

- **Default OFF** — `compTimeFromOvertime.expiresInDays` defaults `null`: C2 behaviour unchanged, grant still writes `expires_at = NULL`. No backfill of existing NULL lots.
- **Enabled** — when `expiresInDays = N` (positive int), the C2 grant stamps `expires_at = granted_at + N * interval '24 hours'` — a **fixed** 24h-per-day duration (DST/tz-independent), computed in SQL from the statement's `now()` (and `granted_at` defaults to `now()`, so the two are exact).
- **Scheduler default OFF, leader-lock load-only** — `AttendanceScheduler` (core-backend/src/services, mirrors `ApprovalSlaScheduler`): interval tick + run-guard + `unref` timers; starts **only** when `ATTENDANCE_SCHEDULER_ENABLED=true`; opt-in Redis leader lock (`ENABLE_ATTENDANCE_SCHEDULER_LEADER_LOCK`) that only sheds load — the expiry claim is idempotent on its own, so correctness never depends on the lock. Wired into startup + shutdown.
- **Expiry idempotency** stays C4-1's atomic `status='active'` claim (unchanged) — a repeat tick writes no second event.
- **Notifier = scaffold only, no messages** — `AttendanceNotifier` with an env factory that registers **no** channels (channel-env-gating discipline) and a no-op dispatch. Reminders are C5.

## Tests
- **unit** (no DB): scheduler tick runs the expiry service + returns its result, swallows a scan error, is default-OFF + singleton; notifier no-op with no channels + isolates a failing channel.
- **real-DB integration** (`attendance-plugin.test.ts`): `expiresInDays=30` → the grant's `expires_at - granted_at` is **exactly 720h**; `expiresInDays=null` → `NULL`; a scheduler tick with nothing past-due leaves our future + NULL lots alone; aging a lot past expiry → one tick expires it (`remaining=0` + one `expire` event) and a repeat tick writes no second event; settings round-trip locks `expiresInDays` survives the wire. Test assertions are **user-scoped** (the expiry scan is global, so membership/event-count, not `toEqual([])`).
- Folded the deferred **`::text[]`→`::uuid[]`** cleanup fix in the C2/C3 `finally` blocks (`attendance_requests.id` is `uuid`).

Verified locally: `tsc` clean (my files), `pnpm lint` clean, **6 unit + 89 integration** green.

## Graduation
**"④ C4 ✅" is gated on a staging C4 smoke** (deploy → enable `expiresInDays` → grant → age/scan → expired+event → re-scan idempotent), not on this merge.

Refs #2267 (design-lock), #2270 (C4-1), #2230 (governing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)