### PR TITLE
feat(multitable): dashboard chart create editor

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -83,6 +83,23 @@ type ApiErrorPayload = {
   serverVersion?: number
 }
 
+type ChartConfigWire = Omit<ChartConfig, 'chartType' | 'displayConfig'> & {
+  type?: ChartConfig['chartType']
+  chartType?: ChartConfig['chartType']
+  display?: ChartConfig['displayConfig']
+  displayConfig?: ChartConfig['displayConfig']
+}
+
+type ChartCreateInputWire = Omit<ChartCreateInput, 'chartType' | 'displayConfig'> & {
+  type: ChartCreateInput['chartType']
+  display?: ChartCreateInput['displayConfig']
+}
+
+type ChartUpdateInputWire = Omit<Partial<ChartCreateInput>, 'chartType' | 'displayConfig'> & {
+  type?: ChartCreateInput['chartType']
+  display?: ChartCreateInput['displayConfig']
+}
+
 let globalApiErrorLocaleResolver: ApiErrorLocaleResolver | undefined
 
 export function setMultitableApiErrorLocaleResolver(
@@ -115,6 +132,34 @@ function qs(params: Record<string, string | number | boolean | undefined>): stri
     .filter(([, v]) => v !== undefined && v !== '')
     .map(([k, v]) => `${encodeURIComponent(k)}=${encodeURIComponent(String(v))}`)
   return entries.length ? `?${entries.join('&')}` : ''
+}
+
+function normalizeChartConfig(chart: ChartConfig | ChartConfigWire): ChartConfig {
+  const wire = chart as ChartConfigWire
+  const chartType = wire.chartType ?? wire.type ?? chart.chartType
+  return {
+    ...(chart as ChartConfig),
+    chartType: chartType as ChartConfig['chartType'],
+    displayConfig: wire.displayConfig ?? wire.display,
+  }
+}
+
+function toChartCreateWire(input: ChartCreateInput): ChartCreateInputWire {
+  const { chartType, displayConfig, ...rest } = input
+  return {
+    ...rest,
+    type: chartType,
+    display: displayConfig,
+  }
+}
+
+function toChartUpdateWire(input: Partial<ChartCreateInput>): ChartUpdateInputWire {
+  const { chartType, displayConfig, ...rest } = input
+  return {
+    ...rest,
+    ...(chartType ? { type: chartType } : {}),
+    ...(displayConfig ? { display: displayConfig } : {}),
+  }
 }
 
 async function parseJson<T>(res: Response, isZh = false): Promise<T> {
@@ -1633,17 +1678,17 @@ export class MultitableApiClient {
   // --- Charts ---
   async listCharts(sheetId: string): Promise<ChartConfig[]> {
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/charts`)
-    const data = await this.parseJson<{ charts: ChartConfig[] }>(res)
-    return Array.isArray(data?.charts) ? data.charts : []
+    const data = await this.parseJson<{ charts: Array<ChartConfig | ChartConfigWire> }>(res)
+    return Array.isArray(data?.charts) ? data.charts.map(normalizeChartConfig) : []
   }
 
   async createChart(sheetId: string, input: ChartCreateInput): Promise<ChartConfig> {
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/charts`, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(input),
+      body: JSON.stringify(toChartCreateWire(input)),
     })
-    return this.parseJson<ChartConfig>(res)
+    return normalizeChartConfig(await this.parseJson<ChartConfig | ChartConfigWire>(res))
   }
 
   async updateChart(sheetId: string, chartId: string, input: Partial<ChartCreateInput>): Promise<ChartConfig> {
@@ -1652,10 +1697,10 @@ export class MultitableApiClient {
       {
         method: 'PATCH',
         headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify(input),
+        body: JSON.stringify(toChartUpdateWire(input)),
       },
     )
-    return this.parseJson<ChartConfig>(res)
+    return normalizeChartConfig(await this.parseJson<ChartConfig | ChartConfigWire>(res))
   }
 
   async deleteChart(sheetId: string, chartId: string): Promise<void> {

--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -38,6 +38,13 @@
         >{{ viewRenderLabel('dashboard.rename', isZh) }}</button>
       </div>
       <div class="meta-dashboard__actions">
+        <button
+          class="meta-dashboard__btn meta-dashboard__btn--primary"
+          type="button"
+          data-action="create-chart"
+          :disabled="!activeDashboard"
+          @click="openCreateChart"
+        >{{ viewRenderLabel('dashboard.newChart', isZh) }}</button>
         <button class="meta-dashboard__btn" type="button" data-action="add-panel" @click="showAddPanel = true">{{ viewRenderLabel('dashboard.addPanel', isZh) }}</button>
         <button class="meta-dashboard__btn meta-dashboard__btn--primary" type="button" data-action="create-dashboard" @click="onCreateDashboard">{{ viewRenderLabel('dashboard.newDashboard', isZh) }}</button>
       </div>
@@ -111,20 +118,94 @@
         </div>
       </div>
     </div>
+
+    <!-- Create chart modal -->
+    <div v-if="showCreateChart" class="meta-dashboard__modal-overlay" @click.self="showCreateChart = false">
+      <form class="meta-dashboard__modal" data-modal="create-chart" @submit.prevent="onCreateChart">
+        <div class="meta-dashboard__modal-header">
+          <h4>{{ viewRenderLabel('dashboard.createChartTitle', isZh) }}</h4>
+          <button class="meta-dashboard__btn meta-dashboard__btn--icon" type="button" @click="showCreateChart = false">&times;</button>
+        </div>
+        <div class="meta-dashboard__modal-body">
+          <label class="meta-dashboard__field">
+            <span>{{ viewRenderLabel('dashboard.chartName', isZh) }}</span>
+            <input
+              v-model="chartDraft.name"
+              class="meta-dashboard__input"
+              type="text"
+              data-field="chart-name"
+            />
+          </label>
+          <label class="meta-dashboard__field">
+            <span>{{ viewRenderLabel('dashboard.chartType', isZh) }}</span>
+            <select v-model="chartDraft.chartType" class="meta-dashboard__select" data-field="chart-type">
+              <option value="bar">bar</option>
+              <option value="line">line</option>
+              <option value="pie">pie</option>
+              <option value="number">number</option>
+              <option value="table">table</option>
+            </select>
+          </label>
+          <label class="meta-dashboard__field">
+            <span>{{ viewRenderLabel('dashboard.groupBy', isZh) }}</span>
+            <select v-model="chartDraft.groupByFieldId" class="meta-dashboard__select" data-field="chart-group-by">
+              <option value="">{{ viewRenderLabel('common.chooseField', isZh) }}</option>
+              <option v-for="field in groupableFields" :key="field.id" :value="field.id">
+                {{ field.name }} · {{ fieldTypeLabel(field.type, isZh) }}
+              </option>
+            </select>
+            <small v-if="!groupableFields.length" class="meta-dashboard__hint">{{ viewRenderLabel('dashboard.noGroupableFields', isZh) }}</small>
+          </label>
+          <label class="meta-dashboard__field">
+            <span>{{ viewRenderLabel('dashboard.aggregation', isZh) }}</span>
+            <select v-model="chartDraft.aggregation" class="meta-dashboard__select" data-field="chart-aggregation">
+              <option value="count">count</option>
+              <option value="sum">sum</option>
+              <option value="avg">avg</option>
+              <option value="min">min</option>
+              <option value="max">max</option>
+            </select>
+          </label>
+          <label v-if="requiresValueField" class="meta-dashboard__field">
+            <span>{{ viewRenderLabel('dashboard.valueField', isZh) }}</span>
+            <select v-model="chartDraft.valueFieldId" class="meta-dashboard__select" data-field="chart-value-field">
+              <option value="">{{ viewRenderLabel('common.chooseField', isZh) }}</option>
+              <option v-for="field in numericFields" :key="field.id" :value="field.id">
+                {{ field.name }} · {{ fieldTypeLabel(field.type, isZh) }}
+              </option>
+            </select>
+            <small v-if="!numericFields.length" class="meta-dashboard__hint">{{ viewRenderLabel('dashboard.noNumericFields', isZh) }}</small>
+          </label>
+          <div v-if="createChartError" class="meta-dashboard__error" data-error="create-chart">{{ createChartError }}</div>
+        </div>
+        <div class="meta-dashboard__modal-footer">
+          <button class="meta-dashboard__btn" type="button" @click="showCreateChart = false">{{ viewRenderLabel('dashboard.cancel', isZh) }}</button>
+          <button
+            class="meta-dashboard__btn meta-dashboard__btn--primary"
+            type="submit"
+            data-action="submit-create-chart"
+            :disabled="createChartDisabled || creatingChart"
+          >{{ viewRenderLabel('dashboard.createChart', isZh) }}</button>
+        </div>
+      </form>
+    </div>
   </div>
 </template>
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick } from 'vue'
-import type { Dashboard, DashboardPanel, ChartConfig, ChartData } from '../types'
+import type { AggregationFunction, ChartType, Dashboard, DashboardPanel, ChartConfig, ChartData, MetaField, MetaFieldType } from '../types'
 import type { MultitableApiClient } from '../api/client'
 import MetaChartRenderer from './MetaChartRenderer.vue'
 import { useLocale } from '../../composables/useLocale'
 import { dashboardDefaultName, viewRenderLabel, viewSizeLabel } from '../utils/meta-view-render-labels'
+import { fieldTypeLabel } from '../utils/meta-core-labels'
+import { filterPropertyVisibleFields } from '../utils/field-permissions'
 
 const props = defineProps<{
   sheetId: string
   dashboardId?: string
+  fields?: MetaField[]
   client?: MultitableApiClient
 }>()
 
@@ -135,12 +216,52 @@ const chartDataMap = ref<Record<string, ChartData>>({})
 const chartConfigMap = ref<Record<string, ChartConfig>>({})
 const activeDashboardId = ref<string>(props.dashboardId ?? '')
 const showAddPanel = ref(false)
+const showCreateChart = ref(false)
+const creatingChart = ref(false)
+const createChartError = ref('')
 const editingName = ref(false)
 const nameInput = ref('')
 const nameInputRef = ref<HTMLInputElement | null>(null)
 const { isZh } = useLocale()
 
+const GROUPABLE_FIELD_TYPES = new Set<MetaFieldType>([
+  'string',
+  'number',
+  'currency',
+  'percent',
+  'rating',
+  'boolean',
+  'date',
+  'dateTime',
+  'formula',
+  'select',
+  'lookup',
+  'rollup',
+])
+const NUMERIC_FIELD_TYPES = new Set<MetaFieldType>(['number', 'currency', 'percent', 'rating', 'rollup'])
+const AGGREGATIONS_REQUIRING_VALUE = new Set<AggregationFunction>(['sum', 'avg', 'min', 'max'])
+
+const chartDraft = ref({
+  name: '',
+  chartType: 'bar' as ChartType,
+  groupByFieldId: '',
+  aggregation: 'count' as AggregationFunction,
+  valueFieldId: '',
+})
+
 const activeDashboard = computed(() => dashboards.value.find((d) => d.id === activeDashboardId.value) ?? dashboards.value[0] ?? null)
+
+const chartFields = computed(() => filterPropertyVisibleFields(props.fields ?? []))
+const groupableFields = computed(() => chartFields.value.filter((field) => GROUPABLE_FIELD_TYPES.has(field.type)))
+const numericFields = computed(() => chartFields.value.filter((field) => NUMERIC_FIELD_TYPES.has(field.type)))
+const requiresValueField = computed(() => AGGREGATIONS_REQUIRING_VALUE.has(chartDraft.value.aggregation))
+const createChartDisabled = computed(() => {
+  if (!activeDashboard.value) return true
+  if (!chartDraft.value.name.trim()) return true
+  if (!chartDraft.value.groupByFieldId) return true
+  if (requiresValueField.value && !chartDraft.value.valueFieldId) return true
+  return false
+})
 
 const sortedPanels = computed(() => {
   if (!activeDashboard.value) return []
@@ -149,6 +270,22 @@ const sortedPanels = computed(() => {
 
 function chartNameById(chartId: string): string {
   return chartConfigMap.value[chartId]?.name ?? chartId
+}
+
+function resetChartDraft() {
+  chartDraft.value = {
+    name: '',
+    chartType: 'bar',
+    groupByFieldId: groupableFields.value[0]?.id ?? '',
+    aggregation: 'count',
+    valueFieldId: '',
+  }
+  createChartError.value = ''
+}
+
+function openCreateChart() {
+  resetChartDraft()
+  showCreateChart.value = true
 }
 
 async function loadData() {
@@ -205,6 +342,11 @@ async function onCreateDashboard() {
 async function onAddPanel(chartId: string) {
   if (!props.client || !activeDashboard.value) return
   showAddPanel.value = false
+  await addPanelForChart(chartId)
+}
+
+async function addPanelForChart(chartId: string) {
+  if (!props.client || !activeDashboard.value) return
   const db = activeDashboard.value
   const newPanel: DashboardPanel = {
     id: `panel_${Date.now()}`,
@@ -227,6 +369,37 @@ async function onAddPanel(chartId: string) {
     }
   } catch {
     // skip
+  }
+}
+
+async function onCreateChart() {
+  if (!props.client || createChartDisabled.value) return
+  creatingChart.value = true
+  createChartError.value = ''
+  try {
+    const chart = await props.client.createChart(props.sheetId, {
+      name: chartDraft.value.name.trim(),
+      chartType: chartDraft.value.chartType,
+      dataSource: {
+        sheetId: props.sheetId,
+        groupByFieldId: chartDraft.value.groupByFieldId,
+        aggregation: {
+          function: chartDraft.value.aggregation,
+          ...(requiresValueField.value ? { fieldId: chartDraft.value.valueFieldId } : {}),
+        },
+      },
+      displayConfig: {
+        title: chartDraft.value.name.trim(),
+      },
+    })
+    charts.value = [...charts.value, chart]
+    chartConfigMap.value[chart.id] = chart
+    showCreateChart.value = false
+    await addPanelForChart(chart.id)
+  } catch {
+    createChartError.value = viewRenderLabel('dashboard.createChartError', isZh.value)
+  } finally {
+    creatingChart.value = false
   }
 }
 
@@ -286,6 +459,12 @@ watch(
   () => { void loadData() },
   { immediate: true },
 )
+
+watch(groupableFields, () => {
+  if (!chartDraft.value.groupByFieldId && groupableFields.value[0]) {
+    chartDraft.value.groupByFieldId = groupableFields.value[0].id
+  }
+})
 </script>
 
 <style scoped>
@@ -327,6 +506,7 @@ watch(
   cursor: pointer;
 }
 
+.meta-dashboard__btn:disabled { cursor: not-allowed; opacity: 0.55; }
 .meta-dashboard__btn--primary { border-color: #2563eb; background: #2563eb; color: #fff; }
 .meta-dashboard__btn--danger { border-color: #ef4444; color: #b91c1c; }
 .meta-dashboard__btn--sm { padding: 3px 8px; font-size: 11px; }
@@ -412,6 +592,35 @@ watch(
   flex-direction: column;
   gap: 6px;
 }
+
+.meta-dashboard__modal-footer {
+  display: flex;
+  align-items: center;
+  justify-content: flex-end;
+  gap: 8px;
+  padding: 12px 16px 14px;
+  border-top: 1px solid #e2e8f0;
+}
+
+.meta-dashboard__field {
+  display: flex;
+  flex-direction: column;
+  gap: 5px;
+  font-size: 12px;
+  font-weight: 600;
+  color: #334155;
+}
+
+.meta-dashboard__input {
+  border: 1px solid #cbd5e1;
+  border-radius: 8px;
+  padding: 7px 10px;
+  font-size: 13px;
+  color: #0f172a;
+}
+
+.meta-dashboard__hint { color: #94a3b8; font-weight: 400; }
+.meta-dashboard__error { color: #b91c1c; font-size: 12px; }
 
 .meta-dashboard__chart-option {
   display: flex;

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -919,11 +919,15 @@ export type ChartType = 'bar' | 'line' | 'pie' | 'number' | 'table'
 
 export type AggregationFunction = 'count' | 'sum' | 'avg' | 'min' | 'max' | 'count_distinct'
 
+export interface ChartAggregation {
+  function: AggregationFunction
+  fieldId?: string
+}
+
 export interface ChartDataSource {
   sheetId: string
-  fieldId: string
-  groupFieldId?: string
-  aggregation: AggregationFunction
+  groupByFieldId?: string
+  aggregation: ChartAggregation
 }
 
 export interface ChartDisplayConfig {

--- a/apps/web/src/multitable/utils/meta-view-render-labels.ts
+++ b/apps/web/src/multitable/utils/meta-view-render-labels.ts
@@ -86,6 +86,18 @@ export type MetaViewRenderLabelKey =
   | 'dashboard.loadingChart'
   | 'dashboard.addChartPanel'
   | 'dashboard.noCharts'
+  | 'dashboard.newChart'
+  | 'dashboard.createChartTitle'
+  | 'dashboard.chartName'
+  | 'dashboard.chartType'
+  | 'dashboard.groupBy'
+  | 'dashboard.aggregation'
+  | 'dashboard.valueField'
+  | 'dashboard.createChart'
+  | 'dashboard.cancel'
+  | 'dashboard.noGroupableFields'
+  | 'dashboard.noNumericFields'
+  | 'dashboard.createChartError'
   | 'chart.label'
   | 'chart.value'
   | 'chart.restrictedTitle'
@@ -169,6 +181,18 @@ export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'dashboard.loadingChart',
   'dashboard.addChartPanel',
   'dashboard.noCharts',
+  'dashboard.newChart',
+  'dashboard.createChartTitle',
+  'dashboard.chartName',
+  'dashboard.chartType',
+  'dashboard.groupBy',
+  'dashboard.aggregation',
+  'dashboard.valueField',
+  'dashboard.createChart',
+  'dashboard.cancel',
+  'dashboard.noGroupableFields',
+  'dashboard.noNumericFields',
+  'dashboard.createChartError',
   'chart.label',
   'chart.value',
   'chart.restrictedTitle',
@@ -256,6 +280,18 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
   'dashboard.loadingChart': { en: 'Loading chart...', zh: '正在加载图表...' },
   'dashboard.addChartPanel': { en: 'Add Chart Panel', zh: '添加图表面板' },
   'dashboard.noCharts': { en: 'No charts available. Create a chart first.', zh: '暂无可用图表。请先创建一个图表。' },
+  'dashboard.newChart': { en: '+ New Chart', zh: '+ 新建图表' },
+  'dashboard.createChartTitle': { en: 'Create chart', zh: '新建图表' },
+  'dashboard.chartName': { en: 'Chart name', zh: '图表名称' },
+  'dashboard.chartType': { en: 'Chart type', zh: '图表类型' },
+  'dashboard.groupBy': { en: 'Group by', zh: '分组字段' },
+  'dashboard.aggregation': { en: 'Aggregation', zh: '聚合方式' },
+  'dashboard.valueField': { en: 'Value field', zh: '数值字段' },
+  'dashboard.createChart': { en: 'Create chart', zh: '创建图表' },
+  'dashboard.cancel': { en: 'Cancel', zh: '取消' },
+  'dashboard.noGroupableFields': { en: 'No readable groupable fields available.', zh: '没有可读取的可分组字段。' },
+  'dashboard.noNumericFields': { en: 'No readable numeric fields available.', zh: '没有可读取的数值字段。' },
+  'dashboard.createChartError': { en: 'Failed to create chart.', zh: '创建图表失败。' },
   'chart.label': { en: 'Label', zh: '标签' },
   'chart.value': { en: 'Value', zh: '值' },
   'chart.restrictedTitle': { en: 'Chart data restricted', zh: '图表数据受限' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -130,6 +130,7 @@
         <MetaDashboardView
           v-if="showDashboardView"
           :sheet-id="workbench.activeSheetId.value"
+          :fields="scopedAllFields"
           :client="workbench.client"
         />
         <MetaFormView

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -17,7 +17,7 @@ vi.mock('echarts/renderers', () => ({ CanvasRenderer: {} }))
 
 import MetaDashboardView from '../src/multitable/components/MetaDashboardView.vue'
 import { MultitableApiClient } from '../src/multitable/api/client'
-import type { Dashboard, ChartConfig, ChartData } from '../src/multitable/types'
+import type { Dashboard, ChartConfig, ChartData, MetaField } from '../src/multitable/types'
 import { useLocale } from '../src/composables/useLocale'
 
 function fakeDashboard(overrides: Partial<Dashboard> = {}): Dashboard {
@@ -38,10 +38,17 @@ function fakeChart(overrides: Partial<ChartConfig> = {}): ChartConfig {
     sheetId: 'sheet_1',
     name: 'Sales Chart',
     chartType: 'bar',
-    dataSource: { sheetId: 'sheet_1', fieldId: 'fld_1', aggregation: 'count' },
+    dataSource: { sheetId: 'sheet_1', groupByFieldId: 'fld_status', aggregation: { function: 'count' } },
     ...overrides,
   }
 }
+
+const chartFields: MetaField[] = [
+  { id: 'fld_status', name: 'Status', type: 'select' },
+  { id: 'fld_amount', name: 'Amount', type: 'number' },
+  { id: 'fld_hidden', name: 'Hidden', type: 'string', property: { hidden: true } },
+  { id: 'fld_link', name: 'Link', type: 'link' },
+]
 
 const fakeChartData: ChartData = {
   chartType: 'bar',
@@ -65,6 +72,17 @@ function mockClient(dashboards: Dashboard[] = [], charts: ChartConfig[] = [], ch
     }
     if (method === 'GET' && url.includes('/charts')) {
       return ok({ charts })
+    }
+    if (method === 'POST' && url.includes('/charts')) {
+      const body = JSON.parse(init?.body as string)
+      return ok({
+        id: 'chart_new',
+        sheetId: 'sheet_1',
+        name: body.name,
+        type: body.type,
+        dataSource: body.dataSource,
+        display: body.display,
+      })
     }
     if (method === 'POST' && url.includes('/dashboards')) {
       const body = JSON.parse(init?.body as string)
@@ -170,6 +188,98 @@ describe('MetaDashboardView', () => {
       ([url, init]: [string, RequestInit?]) => url.includes('/dashboards/') && init?.method === 'PATCH',
     )
     expect(patchCalls.length).toBe(1)
+  })
+
+  it('creates a chart and adds it to the active dashboard panel list', async () => {
+    const dashboard = fakeDashboard({ panels: [] })
+    const { client, fetchFn } = mockClient([dashboard], [])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    const createChartBtn = container.querySelector('[data-action="create-chart"]') as HTMLButtonElement
+    createChartBtn.click()
+    await flushPromises()
+
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Revenue by status'
+    nameInput.dispatchEvent(new Event('input'))
+    const aggregationSelect = container.querySelector('[data-field="chart-aggregation"]') as HTMLSelectElement
+    aggregationSelect.value = 'sum'
+    aggregationSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+    const valueSelect = container.querySelector('[data-field="chart-value-field"]') as HTMLSelectElement
+    valueSelect.value = 'fld_amount'
+    valueSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    const submit = container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement
+    expect(submit.disabled).toBe(false)
+    submit.click()
+    await flushPromises()
+
+    const chartPosts = fetchFn.mock.calls.filter(
+      ([url, init]: [string, RequestInit?]) => url.includes('/charts') && init?.method === 'POST',
+    )
+    expect(chartPosts.length).toBe(1)
+    const chartBody = JSON.parse(chartPosts[0][1].body as string)
+    expect(chartBody).toMatchObject({
+      name: 'Revenue by status',
+      type: 'bar',
+      dataSource: {
+        sheetId: 'sheet_1',
+        groupByFieldId: 'fld_status',
+        aggregation: { function: 'sum', fieldId: 'fld_amount' },
+      },
+      display: { title: 'Revenue by status' },
+    })
+    expect(chartBody.chartType).toBeUndefined()
+
+    const dashboardPatches = fetchFn.mock.calls.filter(
+      ([url, init]: [string, RequestInit?]) => url.includes('/dashboards/') && init?.method === 'PATCH',
+    )
+    expect(dashboardPatches.length).toBe(1)
+    const dashboardBody = JSON.parse(dashboardPatches[0][1].body as string)
+    expect(dashboardBody.panels).toEqual([
+      expect.objectContaining({ chartId: 'chart_new', size: 'medium', order: 0 }),
+    ])
+    const dataLoads = fetchFn.mock.calls.filter(([url]: [string]) => url.includes('/charts/chart_new/data'))
+    expect(dataLoads.length).toBe(1)
+  })
+
+  it('offers only chart-compatible fields and blocks value aggregations without a numeric field', async () => {
+    const dashboard = fakeDashboard({ panels: [] })
+    const { client, fetchFn } = mockClient([dashboard], [])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields.filter((field) => field.id !== 'fld_amount') })
+    await flushPromises()
+
+    const createChartBtn = container.querySelector('[data-action="create-chart"]') as HTMLButtonElement
+    createChartBtn.click()
+    await flushPromises()
+
+    const groupSelect = container.querySelector('[data-field="chart-group-by"]') as HTMLSelectElement
+    const groupValues = Array.from(groupSelect.options).map((option) => option.value)
+    expect(groupValues).toContain('fld_status')
+    expect(groupValues).not.toContain('fld_hidden')
+    expect(groupValues).not.toContain('fld_link')
+
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Needs value'
+    nameInput.dispatchEvent(new Event('input'))
+    const aggregationSelect = container.querySelector('[data-field="chart-aggregation"]') as HTMLSelectElement
+    aggregationSelect.value = 'sum'
+    aggregationSelect.dispatchEvent(new Event('change'))
+    await flushPromises()
+
+    expect(container.textContent).toContain('No readable numeric fields available.')
+    const submit = container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement
+    expect(submit.disabled).toBe(true)
+    submit.click()
+    await flushPromises()
+
+    const chartPosts = fetchFn.mock.calls.filter(
+      ([url, init]: [string, RequestInit?]) => url.includes('/charts') && init?.method === 'POST',
+    )
+    expect(chartPosts.length).toBe(0)
   })
 
   it('can remove a panel', async () => {


### PR DESCRIPTION
## Summary
- add the Dashboard BI v2-a minimal chart-create editor: name, existing chart type, group-by field, aggregation, and numeric value field when required
- wire save through existing client.createChart, then auto-add the created chart as a dashboard panel and load it through the existing getChartData/render path
- normalize chart client wire shape (backend type/display <-> frontend chartType/displayConfig) so the existing backend CRUD contract works without backend changes

## Scope
- create-only; no edit/delete UI
- no live preview or unsaved-config data request
- no multi-series, new chart types, backend aggregation, RBAC/auth, or OpenAPI changes

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-dashboard-view.spec.ts tests/meta-view-render-labels.spec.ts --watch=false
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web build

## Notes
- S0 design-lock is #2273: v2-a is intentionally the minimal create -> persist -> render slice.
