### PR TITLE
[codex] fix unsupported lock_record action exposure

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -236,15 +236,14 @@
             <div class="meta-rule-editor__action-header">
               <span class="meta-rule-editor__action-num">{{ idx + 1 }}.</span>
               <select v-model="action.type" class="meta-rule-editor__select" @change="onDraftActionTypeChange(action)">
-                <option value="update_record">{{ automationActionTypeLabel('update_record', isZh) }}</option>
-                <option value="create_record">{{ automationActionTypeLabel('create_record', isZh) }}</option>
-                <option value="send_webhook">{{ automationActionTypeLabel('send_webhook', isZh) }}</option>
-                <option value="send_notification">{{ automationActionTypeLabel('send_notification', isZh) }}</option>
-                <option value="send_email">{{ automationActionTypeLabel('send_email', isZh) }}</option>
-                <option value="send_dingtalk_group_message">{{ automationActionTypeLabel('send_dingtalk_group_message', isZh) }}</option>
-                <option value="send_dingtalk_person_message">{{ automationActionTypeLabel('send_dingtalk_person_message', isZh) }}</option>
-                <option value="lock_record">{{ automationActionTypeLabel('lock_record', isZh) }}</option>
-                <option value="wait_for_callback">{{ automationActionTypeLabel('wait_for_callback', isZh) }}</option>
+                <option
+                  v-for="type in selectableActionTypes(action.type)"
+                  :key="type"
+                  :value="type"
+                  :disabled="isUnsupportedSelectableActionType(type)"
+                >
+                  {{ automationActionTypeLabel(type, isZh) }}
+                </option>
               </select>
               <div class="meta-rule-editor__action-btns">
                 <button v-if="idx > 0" class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="moveAction(idx, -1)" :title="automationLabel('editor.moveUpTitle', isZh)">&#x2191;</button>
@@ -1098,6 +1097,30 @@ const copiedPreviewKey = ref('')
 let personRecipientSuggestionLoadId = 0
 let copiedPreviewResetTimer: ReturnType<typeof setTimeout> | null = null
 const { isZh } = useLocale()
+
+const SUPPORTED_SELECTABLE_ACTION_TYPES: AutomationActionType[] = [
+  'update_record',
+  'create_record',
+  'send_webhook',
+  'send_notification',
+  'send_email',
+  'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
+  'wait_for_callback',
+]
+
+const UNSUPPORTED_SELECTABLE_ACTION_TYPES: AutomationActionType[] = ['lock_record']
+
+function isUnsupportedSelectableActionType(type: AutomationActionType): boolean {
+  return UNSUPPORTED_SELECTABLE_ACTION_TYPES.includes(type)
+}
+
+function selectableActionTypes(currentType: AutomationActionType): AutomationActionType[] {
+  if (isUnsupportedSelectableActionType(currentType)) {
+    return [...SUPPORTED_SELECTABLE_ACTION_TYPES, currentType]
+  }
+  return SUPPORTED_SELECTABLE_ACTION_TYPES
+}
 
 const formViews = computed(() => (props.views ?? []).filter((view) =>
   view.type === 'form' && (!view.sheetId || view.sheetId === props.sheetId),

--- a/apps/web/tests/multitable-automation-rule-editor.spec.ts
+++ b/apps/web/tests/multitable-automation-rule-editor.spec.ts
@@ -308,6 +308,43 @@ describe('MetaAutomationRuleEditor', () => {
       .toBe('记录 {{recordId}} 已变更。状态：{{record.status}}')
   })
 
+  it('does not offer unsupported lock_record actions for new automation rules', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    const actionValues = Array.from(actionSelect.options).map((option) => option.value)
+    expect(actionValues).toContain('update_record')
+    expect(actionValues).toContain('create_record')
+    expect(actionValues).toContain('send_webhook')
+    expect(actionValues).toContain('send_notification')
+    expect(actionValues).toContain('send_email')
+    expect(actionValues).toContain('send_dingtalk_group_message')
+    expect(actionValues).toContain('send_dingtalk_person_message')
+    expect(actionValues).toContain('wait_for_callback')
+    expect(actionValues).not.toContain('lock_record')
+  })
+
+  it('keeps existing lock_record actions visible but disabled for compatibility', async () => {
+    const { container } = mount({
+      visible: true,
+      sheetId: 'sheet_1',
+      fields,
+      rule: fakeRule({
+        actionType: 'lock_record',
+        actionConfig: { locked: true },
+        actions: [{ type: 'lock_record', config: { locked: true } }],
+      }),
+    })
+    await flushPromises()
+
+    const actionSelect = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+    const lockOption = Array.from(actionSelect.options).find((option) => option.value === 'lock_record')
+    expect(actionSelect.value).toBe('lock_record')
+    expect(lockOption).toBeTruthy()
+    expect(lockOption?.disabled).toBe(true)
+  })
+
   it('localizes test-run warning and confirm text while leaving runtime status messages raw', async () => {
     useLocale().setLocale('zh-CN')
     const tested = vi.fn()


### PR DESCRIPTION
## Summary

Closes #2277.

- Replace the advanced automation action dropdown's hard-coded options with a supported selectable action allowlist.
- Remove `lock_record` from new-rule selectable actions while keeping `wait_for_callback` available.
- Preserve compatibility for existing `lock_record` rules by rendering the current value as a disabled option instead of silently dropping the action context.
- Add UI specs for both the new-rule hidden state and existing-rule disabled compatibility state.

## Why

`lock_record` is visible in the multitable automation editor, but the current storage contract does not include the expected locked-record column/semantics. That makes the action appear supported while it fails at runtime. This PR chooses the conservative issue option: hide/disable it until the storage contract is deliberately implemented.

## Validation

- Passed: `apps/web` local Vitest direct run for `tests/multitable-automation-rule-editor.spec.ts` (94 tests passed).
- Passed: `git diff --check` for the touched files.
- Attempted: `vue-tsc -b`; currently blocked before this component by an existing Vite type-version mismatch in `vite.config.ts` (`vite@5` / `vite@7` plugin type incompatibility), not by this change.
