### PR TITLE
feat(multitable): dashboard chart edit/delete (BI v2-b1)

### DIFF
--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -114,6 +114,22 @@
           >
             <span>{{ chart.name }}</span>
             <span class="meta-dashboard__chart-type">{{ chart.chartType }}</span>
+            <span class="meta-dashboard__chart-option-actions">
+              <button
+                class="meta-dashboard__btn meta-dashboard__btn--icon"
+                type="button"
+                data-action="edit-chart"
+                :data-edit-chart="chart.id"
+                @click.stop="openEditChart(chart.id)"
+              >{{ viewRenderLabel('dashboard.editChart', isZh) }}</button>
+              <button
+                class="meta-dashboard__btn meta-dashboard__btn--icon meta-dashboard__btn--danger"
+                type="button"
+                data-action="delete-chart"
+                :data-delete-chart="chart.id"
+                @click.stop="onDeleteChart(chart.id)"
+              >{{ viewRenderLabel('dashboard.deleteChart', isZh) }}</button>
+            </span>
           </div>
         </div>
       </div>
@@ -121,9 +137,9 @@
 
     <!-- Create chart modal -->
     <div v-if="showCreateChart" class="meta-dashboard__modal-overlay" @click.self="showCreateChart = false">
-      <form class="meta-dashboard__modal" data-modal="create-chart" @submit.prevent="onCreateChart">
+      <form class="meta-dashboard__modal" data-modal="create-chart" @submit.prevent="onSubmitChart">
         <div class="meta-dashboard__modal-header">
-          <h4>{{ viewRenderLabel('dashboard.createChartTitle', isZh) }}</h4>
+          <h4>{{ viewRenderLabel(editingChartId ? 'dashboard.editChartTitle' : 'dashboard.createChartTitle', isZh) }}</h4>
           <button class="meta-dashboard__btn meta-dashboard__btn--icon" type="button" @click="showCreateChart = false">&times;</button>
         </div>
         <div class="meta-dashboard__modal-body">
@@ -185,7 +201,7 @@
             type="submit"
             data-action="submit-create-chart"
             :disabled="createChartDisabled || creatingChart"
-          >{{ viewRenderLabel('dashboard.createChart', isZh) }}</button>
+          >{{ viewRenderLabel(editingChartId ? 'dashboard.saveChart' : 'dashboard.createChart', isZh) }}</button>
         </div>
       </form>
     </div>
@@ -194,7 +210,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick } from 'vue'
-import type { AggregationFunction, ChartType, Dashboard, DashboardPanel, ChartConfig, ChartData, MetaField, MetaFieldType } from '../types'
+import type { AggregationFunction, ChartType, Dashboard, DashboardPanel, ChartConfig, ChartCreateInput, ChartData, MetaField, MetaFieldType } from '../types'
 import type { MultitableApiClient } from '../api/client'
 import MetaChartRenderer from './MetaChartRenderer.vue'
 import { useLocale } from '../../composables/useLocale'
@@ -217,6 +233,7 @@ const chartConfigMap = ref<Record<string, ChartConfig>>({})
 const activeDashboardId = ref<string>(props.dashboardId ?? '')
 const showAddPanel = ref(false)
 const showCreateChart = ref(false)
+const editingChartId = ref<string | null>(null)
 const creatingChart = ref(false)
 const createChartError = ref('')
 const editingName = ref(false)
@@ -284,7 +301,25 @@ function resetChartDraft() {
 }
 
 function openCreateChart() {
+  editingChartId.value = null
   resetChartDraft()
+  showCreateChart.value = true
+}
+
+// v2-b1: open the (reused) chart form pre-filled to EDIT an existing chart's config.
+function openEditChart(chartId: string) {
+  const cfg = chartConfigMap.value[chartId]
+  if (!cfg) return
+  editingChartId.value = chartId
+  chartDraft.value = {
+    name: cfg.name,
+    chartType: cfg.chartType,
+    groupByFieldId: cfg.dataSource.groupByFieldId ?? '',
+    aggregation: cfg.dataSource.aggregation.function,
+    valueFieldId: cfg.dataSource.aggregation.fieldId ?? '',
+  }
+  createChartError.value = ''
+  showAddPanel.value = false
   showCreateChart.value = true
 }
 
@@ -372,34 +407,98 @@ async function addPanelForChart(chartId: string) {
   }
 }
 
-async function onCreateChart() {
+// Build a chart create/update payload from the form. For EDIT, pass the existing config as `base`:
+// the server shallow-replaces dataSource/displayConfig with what we send ({ ...existing, ...input }),
+// so we OVERLAY onto the existing objects to PRESERVE fields this minimal form does not model —
+// displayConfig options (showLegend / colorScheme / showValues) and dataSource.filter / date-grouping.
+// The form owns only name / chartType / groupByFieldId / aggregation. (v2-b1 boundary: a date-grouped
+// chart keeps its date-grouping — full grouping-mode editing is a later slice.)
+function buildChartInput(base?: ChartConfig): ChartCreateInput {
+  const name = chartDraft.value.name.trim()
+  return {
+    name,
+    chartType: chartDraft.value.chartType,
+    dataSource: {
+      ...(base?.dataSource ?? {}),
+      sheetId: props.sheetId,
+      groupByFieldId: chartDraft.value.groupByFieldId,
+      aggregation: {
+        function: chartDraft.value.aggregation,
+        ...(requiresValueField.value ? { fieldId: chartDraft.value.valueFieldId } : {}),
+      },
+    },
+    displayConfig: {
+      ...(base?.displayConfig ?? {}),
+      title: name,
+    },
+  }
+}
+
+// v2-a create + v2-b1 edit share one form. editingChartId === null → create; else → update.
+async function onSubmitChart() {
   if (!props.client || createChartDisabled.value) return
+  const isEdit = editingChartId.value !== null
   creatingChart.value = true
   createChartError.value = ''
   try {
-    const chart = await props.client.createChart(props.sheetId, {
-      name: chartDraft.value.name.trim(),
-      chartType: chartDraft.value.chartType,
-      dataSource: {
-        sheetId: props.sheetId,
-        groupByFieldId: chartDraft.value.groupByFieldId,
-        aggregation: {
-          function: chartDraft.value.aggregation,
-          ...(requiresValueField.value ? { fieldId: chartDraft.value.valueFieldId } : {}),
-        },
-      },
-      displayConfig: {
-        title: chartDraft.value.name.trim(),
-      },
-    })
-    charts.value = [...charts.value, chart]
-    chartConfigMap.value[chart.id] = chart
-    showCreateChart.value = false
-    await addPanelForChart(chart.id)
+    if (isEdit) {
+      const chartId = editingChartId.value as string
+      // overlay onto the existing config so unmodeled fields survive the server's shallow replace
+      const input = buildChartInput(chartConfigMap.value[chartId])
+      const updated = await props.client.updateChart(props.sheetId, chartId, input)
+      charts.value = charts.value.map((c) => (c.id === chartId ? updated : c))
+      chartConfigMap.value[chartId] = updated
+      // v2-b1: re-pull chart data so any panel showing it re-renders with the new config
+      // (loadPanelData skips already-loaded charts, so refetch explicitly here).
+      try {
+        chartDataMap.value[chartId] = await props.client.getChartData(props.sheetId, chartId)
+      } catch {
+        delete chartDataMap.value[chartId]
+      }
+      showCreateChart.value = false
+      editingChartId.value = null
+    } else {
+      const chart = await props.client.createChart(props.sheetId, buildChartInput())
+      charts.value = [...charts.value, chart]
+      chartConfigMap.value[chart.id] = chart
+      showCreateChart.value = false
+      await addPanelForChart(chart.id)
+    }
   } catch {
-    createChartError.value = viewRenderLabel('dashboard.createChartError', isZh.value)
+    createChartError.value = viewRenderLabel(isEdit ? 'dashboard.editChartError' : 'dashboard.createChartError', isZh.value)
   } finally {
     creatingChart.value = false
+  }
+}
+
+// v2-b1: delete a chart (confirm), then prune any active-dashboard panels that referenced it
+// so the dashboard does not leave a dangling "loading" panel.
+async function onDeleteChart(chartId: string) {
+  if (!props.client) return
+  const message = viewRenderLabel('dashboard.deleteChartConfirm', isZh.value)
+  if (typeof window !== 'undefined' && typeof window.confirm === 'function' && !window.confirm(message)) return
+  try {
+    await props.client.deleteChart(props.sheetId, chartId)
+    charts.value = charts.value.filter((c) => c.id !== chartId)
+    delete chartConfigMap.value[chartId]
+    delete chartDataMap.value[chartId]
+    const db = activeDashboard.value
+    if (db && db.panels.some((p) => p.chartId === chartId)) {
+      const updated = db.panels.filter((p) => p.chartId !== chartId)
+      try {
+        const result = await props.client.updateDashboard(props.sheetId, db.id, { panels: updated })
+        const idx = dashboards.value.findIndex((d) => d.id === db.id)
+        if (idx >= 0) dashboards.value[idx] = result
+      } catch {
+        // skip
+      }
+    }
+    if (editingChartId.value === chartId) {
+      showCreateChart.value = false
+      editingChartId.value = null
+    }
+  } catch {
+    // skip
   }
 }
 

--- a/apps/web/src/multitable/utils/meta-view-render-labels.ts
+++ b/apps/web/src/multitable/utils/meta-view-render-labels.ts
@@ -98,6 +98,12 @@ export type MetaViewRenderLabelKey =
   | 'dashboard.noGroupableFields'
   | 'dashboard.noNumericFields'
   | 'dashboard.createChartError'
+  | 'dashboard.editChartTitle'
+  | 'dashboard.editChart'
+  | 'dashboard.saveChart'
+  | 'dashboard.deleteChart'
+  | 'dashboard.deleteChartConfirm'
+  | 'dashboard.editChartError'
   | 'chart.label'
   | 'chart.value'
   | 'chart.restrictedTitle'
@@ -193,6 +199,12 @@ export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'dashboard.noGroupableFields',
   'dashboard.noNumericFields',
   'dashboard.createChartError',
+  'dashboard.editChartTitle',
+  'dashboard.editChart',
+  'dashboard.saveChart',
+  'dashboard.deleteChart',
+  'dashboard.deleteChartConfirm',
+  'dashboard.editChartError',
   'chart.label',
   'chart.value',
   'chart.restrictedTitle',
@@ -292,6 +304,12 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
   'dashboard.noGroupableFields': { en: 'No readable groupable fields available.', zh: '没有可读取的可分组字段。' },
   'dashboard.noNumericFields': { en: 'No readable numeric fields available.', zh: '没有可读取的数值字段。' },
   'dashboard.createChartError': { en: 'Failed to create chart.', zh: '创建图表失败。' },
+  'dashboard.editChartTitle': { en: 'Edit chart', zh: '编辑图表' },
+  'dashboard.editChart': { en: 'Edit', zh: '编辑' },
+  'dashboard.saveChart': { en: 'Save chart', zh: '保存图表' },
+  'dashboard.deleteChart': { en: 'Delete', zh: '删除' },
+  'dashboard.deleteChartConfirm': { en: 'Delete this chart? Panels showing it will be removed.', zh: '删除此图表？引用它的面板将被移除。' },
+  'dashboard.editChartError': { en: 'Failed to save chart.', zh: '保存图表失败。' },
   'chart.label': { en: 'Label', zh: '标签' },
   'chart.value': { en: 'Value', zh: '值' },
   'chart.restrictedTitle': { en: 'Chart data restricted', zh: '图表数据受限' },

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -84,6 +84,14 @@ function mockClient(dashboards: Dashboard[] = [], charts: ChartConfig[] = [], ch
         display: body.display,
       })
     }
+    if (method === 'PATCH' && url.includes('/charts/')) {
+      const body = JSON.parse(init?.body as string)
+      const chartId = url.split('/charts/')[1]
+      return ok({ id: chartId, sheetId: 'sheet_1', name: body.name, chartType: body.chartType, dataSource: body.dataSource, displayConfig: body.displayConfig })
+    }
+    if (method === 'DELETE' && url.includes('/charts/')) {
+      return noContent()
+    }
     if (method === 'POST' && url.includes('/dashboards')) {
       const body = JSON.parse(init?.body as string)
       return ok({ id: 'dash_new', sheetId: 'sheet_1', panels: [], ...body })
@@ -349,5 +357,134 @@ describe('MetaDashboardView', () => {
     expect(container.querySelectorAll('[aria-label]')).toHaveLength(0)
     expect(container.querySelectorAll('[title]')).toHaveLength(1)
     expect(container.querySelectorAll('[placeholder]')).toHaveLength(0)
+  })
+
+  // ---- v2-b1: edit / delete an existing chart from the chart list ----
+
+  it('edits an existing chart from the chart list (reuses the form) and re-pulls its data', async () => {
+    const chart = fakeChart()
+    const { client, fetchFn } = mockClient([fakeDashboard()], [chart])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    // open the chart list (add-panel modal) and click edit on the chart row
+    ;(container.querySelector('[data-action="add-panel"]') as HTMLButtonElement).click()
+    await nextTick()
+    const editBtn = container.querySelector(`[data-edit-chart="${chart.id}"]`) as HTMLButtonElement
+    expect(editBtn).toBeTruthy()
+    editBtn.click()
+    await nextTick()
+
+    // form is pre-filled from the existing chart config (reused create form, edit mode)
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    expect(nameInput.value).toBe('Sales Chart')
+    expect(container.querySelector('[data-modal="create-chart"]')?.textContent).toContain('Edit chart')
+
+    nameInput.value = 'Renamed Chart'
+    nameInput.dispatchEvent(new Event('input'))
+    await nextTick()
+    ;(container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    // updateChart → PATCH /charts/<id> with the edited config
+    const patchChart = fetchFn.mock.calls.filter(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'PATCH' && url.includes(`/charts/${chart.id}`),
+    )
+    expect(patchChart.length).toBe(1)
+    expect(JSON.parse(patchChart[0][1].body as string).name).toBe('Renamed Chart')
+
+    // its chart data is re-pulled (initial panel load + the post-edit refetch)
+    const dataLoads = fetchFn.mock.calls.filter(
+      ([url, init]: [string, RequestInit?]) => (init?.method ?? 'GET') === 'GET' && url.includes(`/charts/${chart.id}/data`),
+    )
+    expect(dataLoads.length).toBeGreaterThanOrEqual(2)
+
+    // edit path must NOT create a new chart
+    const chartPosts = fetchFn.mock.calls.filter(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'POST' && url.includes('/charts'),
+    )
+    expect(chartPosts.length).toBe(0)
+  })
+
+  it('edit preserves config the minimal form does not model (display options + dataSource extras)', async () => {
+    // The server shallow-replaces dataSource/displayConfig with the sent objects, so edit must
+    // overlay onto the existing config. Carry display options (typed) + a dataSource extra
+    // (filter — a backend runtime field absent from the frontend type) and assert both survive.
+    const chart = fakeChart({
+      displayConfig: { title: 'Sales Chart', showLegend: false, colorScheme: 'cool' },
+      dataSource: { sheetId: 'sheet_1', groupByFieldId: 'fld_status', aggregation: { function: 'count' }, filter: [{ fieldId: 'fld_status', operator: 'is', value: 'open' }] } as ChartConfig['dataSource'],
+    })
+    const { client, fetchFn } = mockClient([fakeDashboard()], [chart])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="add-panel"]') as HTMLButtonElement).click()
+    await nextTick()
+    ;(container.querySelector(`[data-edit-chart="${chart.id}"]`) as HTMLButtonElement).click()
+    await nextTick()
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Renamed'
+    nameInput.dispatchEvent(new Event('input'))
+    await nextTick()
+    ;(container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const patch = fetchFn.mock.calls.find(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'PATCH' && url.includes(`/charts/${chart.id}`),
+    )
+    const body = JSON.parse(patch![1].body as string)
+    // client maps displayConfig→`display` on the wire; the overlay must preserve unmodeled fields
+    expect(body.display.showLegend).toBe(false) // preserved (not in the form)
+    expect(body.display.colorScheme).toBe('cool') // preserved
+    expect(body.display.title).toBe('Renamed') // form owns the title
+    expect(body.dataSource.filter).toEqual([{ fieldId: 'fld_status', operator: 'is', value: 'open' }]) // preserved
+    expect(body.dataSource.groupByFieldId).toBe('fld_status') // form owns grouping
+  })
+
+  it('deletes a chart from the chart list (after confirm) and prunes the panel that showed it', async () => {
+    const chart = fakeChart()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)
+    const { client, fetchFn } = mockClient([fakeDashboard()], [chart])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="add-panel"]') as HTMLButtonElement).click()
+    await nextTick()
+    const delBtn = container.querySelector(`[data-delete-chart="${chart.id}"]`) as HTMLButtonElement
+    expect(delBtn).toBeTruthy()
+    delBtn.click()
+    await flushPromises()
+
+    const delCalls = fetchFn.mock.calls.filter(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'DELETE' && url.includes(`/charts/${chart.id}`),
+    )
+    expect(delCalls.length).toBe(1)
+
+    // the only panel referenced the deleted chart → pruned via updateDashboard
+    const patchDb = fetchFn.mock.calls.filter(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'PATCH' && url.includes('/dashboards/'),
+    )
+    expect(patchDb.length).toBe(1)
+    expect(JSON.parse(patchDb[0][1].body as string).panels).toEqual([])
+    confirmSpy.mockRestore()
+  })
+
+  it('does not delete a chart when confirm is declined', async () => {
+    const chart = fakeChart()
+    const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(false)
+    const { client, fetchFn } = mockClient([fakeDashboard()], [chart])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="add-panel"]') as HTMLButtonElement).click()
+    await nextTick()
+    ;(container.querySelector(`[data-delete-chart="${chart.id}"]`) as HTMLButtonElement).click()
+    await flushPromises()
+
+    const delCalls = fetchFn.mock.calls.filter(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'DELETE' && url.includes(`/charts/${chart.id}`),
+    )
+    expect(delCalls.length).toBe(0)
+    confirmSpy.mockRestore()
   })
 })


### PR DESCRIPTION
v2-b1 of the Dashboard BI v2 arc (S0 #2273, v2-a create editor #2276). Closes the authoring loop: a created chart can now be **edited** and **deleted** in-product. Frontend-only; reuses the existing `ChartConfig` CRUD client + the field-visibility gate.

## Edit
Reuses the v2-a create form as a create/edit form (`editingChartId`). An **Edit** action on each chart-list row opens the form pre-filled from the chart's config; submit calls the existing `client.updateChart`, then **re-pulls** the chart's data (`getChartData`) so any panel showing it re-renders (`loadPanelData` skips already-loaded charts → explicit refetch).

**Config preservation (raised in review):** the server `updateChart` does `{ ...existing, ...input }` (shallow top-level replace), so edit **overlays** the form fields onto the existing config (`buildChartInput(base)`) — fields the minimal form does not model (`display` options `showLegend`/`colorScheme`/`showValues`, `dataSource.filter`, date-grouping) **survive** instead of being silently reset. The form owns only name / chartType / groupBy / aggregation. Tested explicitly.

## Delete
A **Delete** action confirms (`window.confirm`), calls `client.deleteChart`, then prunes any **active-dashboard** panels referencing the deleted chart (`updateDashboard`) so no dangling "loading" panel is left.

## Conscious limitations (v2-b1 minimal)
- Panels in **other** dashboards referencing a deleted chart are not pruned — documented; cheap follow-up.
- A **date-grouped** chart keeps its date-grouping on edit (the form expresses field-grouping) — full grouping-mode editing is a later slice.
- Native `window.confirm` for delete (minimal slice).

## Scope held to the locked boundary
NO live preview (→ v2-b2), NO multi-series, NO new chart types, NO backend/RBAC/aggregation change. Create path unchanged.

## Tests
`multitable-dashboard-view.spec.ts` **+4** (edit reuses form + `updateChart` + refetch; edit **preserves** unmodeled display options + `dataSource.filter` through the wire; delete after confirm + panel prune; delete declined = no-op). **14/14** in-file green, `vue-tsc -b` clean. Full web suite: **+4 passing, 0 new failures** — the 16 pre-existing local-env failures (timezone/date/session/realtime) are identical with/without this change (verified by revert), green in CI.

🤖 Generated with [Claude Code](https://claude.com/claude-code)