### PR TITLE
fix(multitable): preserve date-grouped chart edits

### DIFF
--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -164,13 +164,21 @@
           </label>
           <label class="meta-dashboard__field">
             <span>{{ viewRenderLabel('dashboard.groupBy', isZh) }}</span>
-            <select v-model="chartDraft.groupByFieldId" class="meta-dashboard__select" data-field="chart-group-by">
+            <select
+              v-model="chartDraft.groupByFieldId"
+              class="meta-dashboard__select"
+              data-field="chart-group-by"
+              :disabled="editingDateGrouped"
+            >
               <option value="">{{ viewRenderLabel('common.chooseField', isZh) }}</option>
               <option v-for="field in groupableFields" :key="field.id" :value="field.id">
                 {{ field.name }} · {{ fieldTypeLabel(field.type, isZh) }}
               </option>
             </select>
-            <small v-if="!groupableFields.length" class="meta-dashboard__hint">{{ viewRenderLabel('dashboard.noGroupableFields', isZh) }}</small>
+            <small v-if="editingDateGrouped" class="meta-dashboard__hint" data-hint="date-grouping-locked">
+              {{ viewRenderLabel('dashboard.dateGroupingLocked', isZh) }}
+            </small>
+            <small v-else-if="!groupableFields.length" class="meta-dashboard__hint">{{ viewRenderLabel('dashboard.noGroupableFields', isZh) }}</small>
           </label>
           <label class="meta-dashboard__field">
             <span>{{ viewRenderLabel('dashboard.aggregation', isZh) }}</span>
@@ -210,7 +218,7 @@
 
 <script setup lang="ts">
 import { ref, computed, watch, nextTick } from 'vue'
-import type { AggregationFunction, ChartType, Dashboard, DashboardPanel, ChartConfig, ChartCreateInput, ChartData, MetaField, MetaFieldType } from '../types'
+import type { AggregationFunction, ChartType, Dashboard, DashboardPanel, ChartConfig, ChartCreateInput, ChartData, ChartDataSource, MetaField, MetaFieldType } from '../types'
 import type { MultitableApiClient } from '../api/client'
 import MetaChartRenderer from './MetaChartRenderer.vue'
 import { useLocale } from '../../composables/useLocale'
@@ -267,6 +275,8 @@ const chartDraft = ref({
 })
 
 const activeDashboard = computed(() => dashboards.value.find((d) => d.id === activeDashboardId.value) ?? dashboards.value[0] ?? null)
+const editingChart = computed(() => editingChartId.value ? chartConfigMap.value[editingChartId.value] ?? null : null)
+const editingDateGrouped = computed(() => Boolean(editingChart.value?.dataSource.dateFieldId))
 
 const chartFields = computed(() => filterPropertyVisibleFields(props.fields ?? []))
 const groupableFields = computed(() => chartFields.value.filter((field) => GROUPABLE_FIELD_TYPES.has(field.type)))
@@ -275,7 +285,7 @@ const requiresValueField = computed(() => AGGREGATIONS_REQUIRING_VALUE.has(chart
 const createChartDisabled = computed(() => {
   if (!activeDashboard.value) return true
   if (!chartDraft.value.name.trim()) return true
-  if (!chartDraft.value.groupByFieldId) return true
+  if (!editingDateGrouped.value && !chartDraft.value.groupByFieldId) return true
   if (requiresValueField.value && !chartDraft.value.valueFieldId) return true
   return false
 })
@@ -415,18 +425,21 @@ async function addPanelForChart(chartId: string) {
 // chart keeps its date-grouping — full grouping-mode editing is a later slice.)
 function buildChartInput(base?: ChartConfig): ChartCreateInput {
   const name = chartDraft.value.name.trim()
+  const dataSource: ChartDataSource = {
+    ...(base?.dataSource ?? {}),
+    sheetId: props.sheetId,
+    aggregation: {
+      function: chartDraft.value.aggregation,
+      ...(requiresValueField.value ? { fieldId: chartDraft.value.valueFieldId } : {}),
+    },
+  }
+  if (!editingDateGrouped.value) {
+    dataSource.groupByFieldId = chartDraft.value.groupByFieldId
+  }
   return {
     name,
     chartType: chartDraft.value.chartType,
-    dataSource: {
-      ...(base?.dataSource ?? {}),
-      sheetId: props.sheetId,
-      groupByFieldId: chartDraft.value.groupByFieldId,
-      aggregation: {
-        function: chartDraft.value.aggregation,
-        ...(requiresValueField.value ? { fieldId: chartDraft.value.valueFieldId } : {}),
-      },
-    },
+    dataSource,
     displayConfig: {
       ...(base?.displayConfig ?? {}),
       title: name,
@@ -560,6 +573,7 @@ watch(
 )
 
 watch(groupableFields, () => {
+  if (editingDateGrouped.value) return
   if (!chartDraft.value.groupByFieldId && groupableFields.value[0]) {
     chartDraft.value.groupByFieldId = groupableFields.value[0].id
   }

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -927,6 +927,8 @@ export interface ChartAggregation {
 export interface ChartDataSource {
   sheetId: string
   groupByFieldId?: string
+  dateFieldId?: string
+  dateGrouping?: 'day' | 'week' | 'month' | 'quarter' | 'year'
   aggregation: ChartAggregation
 }
 

--- a/apps/web/src/multitable/utils/meta-view-render-labels.ts
+++ b/apps/web/src/multitable/utils/meta-view-render-labels.ts
@@ -96,6 +96,7 @@ export type MetaViewRenderLabelKey =
   | 'dashboard.createChart'
   | 'dashboard.cancel'
   | 'dashboard.noGroupableFields'
+  | 'dashboard.dateGroupingLocked'
   | 'dashboard.noNumericFields'
   | 'dashboard.createChartError'
   | 'dashboard.editChartTitle'
@@ -197,6 +198,7 @@ export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'dashboard.createChart',
   'dashboard.cancel',
   'dashboard.noGroupableFields',
+  'dashboard.dateGroupingLocked',
   'dashboard.noNumericFields',
   'dashboard.createChartError',
   'dashboard.editChartTitle',
@@ -302,6 +304,10 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
   'dashboard.createChart': { en: 'Create chart', zh: '创建图表' },
   'dashboard.cancel': { en: 'Cancel', zh: '取消' },
   'dashboard.noGroupableFields': { en: 'No readable groupable fields available.', zh: '没有可读取的可分组字段。' },
+  'dashboard.dateGroupingLocked': {
+    en: 'Grouped by date; date grouping is preserved in this editor.',
+    zh: '已按日期分组；此编辑器会保留现有日期分组。',
+  },
   'dashboard.noNumericFields': { en: 'No readable numeric fields available.', zh: '没有可读取的数值字段。' },
   'dashboard.createChartError': { en: 'Failed to create chart.', zh: '创建图表失败。' },
   'dashboard.editChartTitle': { en: 'Edit chart', zh: '编辑图表' },

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -46,6 +46,7 @@ function fakeChart(overrides: Partial<ChartConfig> = {}): ChartConfig {
 const chartFields: MetaField[] = [
   { id: 'fld_status', name: 'Status', type: 'select' },
   { id: 'fld_amount', name: 'Amount', type: 'number' },
+  { id: 'fld_date', name: 'Created', type: 'date' },
   { id: 'fld_hidden', name: 'Hidden', type: 'string', property: { hidden: true } },
   { id: 'fld_link', name: 'Link', type: 'link' },
 ]
@@ -439,6 +440,49 @@ describe('MetaDashboardView', () => {
     expect(body.display.title).toBe('Renamed') // form owns the title
     expect(body.dataSource.filter).toEqual([{ fieldId: 'fld_status', operator: 'is', value: 'open' }]) // preserved
     expect(body.dataSource.groupByFieldId).toBe('fld_status') // form owns grouping
+  })
+
+  it('edits a date-grouped chart without requiring a group field and preserves date grouping', async () => {
+    const chart = fakeChart({
+      dataSource: {
+        sheetId: 'sheet_1',
+        dateFieldId: 'fld_date',
+        dateGrouping: 'month',
+        aggregation: { function: 'count' },
+      },
+    })
+    const { client, fetchFn } = mockClient([fakeDashboard()], [chart])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    ;(container.querySelector('[data-action="add-panel"]') as HTMLButtonElement).click()
+    await nextTick()
+    ;(container.querySelector(`[data-edit-chart="${chart.id}"]`) as HTMLButtonElement).click()
+    await nextTick()
+
+    const groupSelect = container.querySelector('[data-field="chart-group-by"]') as HTMLSelectElement
+    expect(groupSelect.disabled).toBe(true)
+    expect(groupSelect.value).toBe('')
+    expect(container.querySelector('[data-hint="date-grouping-locked"]')?.textContent).toContain('Grouped by date')
+
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Renamed date chart'
+    nameInput.dispatchEvent(new Event('input'))
+    await nextTick()
+
+    const submit = container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement
+    expect(submit.disabled).toBe(false)
+    submit.click()
+    await flushPromises()
+
+    const patch = fetchFn.mock.calls.find(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'PATCH' && url.includes(`/charts/${chart.id}`),
+    )
+    const body = JSON.parse(patch![1].body as string)
+    expect(body.name).toBe('Renamed date chart')
+    expect(body.dataSource.dateFieldId).toBe('fld_date')
+    expect(body.dataSource.dateGrouping).toBe('month')
+    expect(body.dataSource.groupByFieldId).toBeUndefined()
   })
 
   it('deletes a chart from the chart list (after confirm) and prunes the panel that showed it', async () => {


### PR DESCRIPTION
## Summary
- allow editing existing date-grouped dashboard charts without requiring an arbitrary group field
- model chart dataSource date grouping on the frontend and keep date grouping read-only/preserved in the minimal editor
- add a localized hint and a regression spec for the date-grouped edit path

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/multitable-dashboard-view.spec.ts tests/meta-view-render-labels.spec.ts --watch=false
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web build