### PR TITLE
docs(attendance): close out ④ C4 staging smoke

### DIFF
--- a/docs/development/attendance-comp-leave-c4-2-staging-smoke-runbook-20260604.md
+++ b/docs/development/attendance-comp-leave-c4-2-staging-smoke-runbook-20260604.md
@@ -1,10 +1,11 @@
 # ④ C4-2 staging smoke runbook + CI evidence (comp-time expiry scheduler)
 
 **Status:** C4-2 code is **merged** (#2274, merge commit `4b3108737`, on `origin/main`); CI is
-**fresh-green** and the attendance DB step genuinely ran the C4 spec (evidence §2). The **`④ C4 ✅`
-graduation is still gated on the staging C4 smoke below** — per the #2267 design-lock and #2230 governing
-("`④ C4 ✅` is gated on C4-2 + a staging C4 smoke"). This doc is that smoke, **prepared but not yet run**:
-it could not be executed from the dev sandbox (§3). It stays in `⬜` on the tracker until the smoke PASSES.
+**fresh-green** and the attendance DB step genuinely ran the C4 spec (evidence §2). The **staging C4 smoke
+PASSED on 2026-06-04** after deploying build `8701c46e00c68ed19c226e7206f5456866f6b8ba` to staging
+(`https://23.254.236.11/`) with `ATTENDANCE_SCHEDULER_ENABLED=true` and
+`ATTENDANCE_SCHEDULER_INTERVAL_MS=5000`. Per the #2267 design-lock and #2230 governing
+("`④ C4 ✅` is gated on C4-2 + a staging C4 smoke"), **④ C4 is now ✅**.
 
 Refs: #2274 (C4-2 impl), #2270 (C4-1 inert expiry fn), #2267 (C4 execution design-lock),
 #2230 (④ governing design-lock), #2226 (staging migration-align runbook — the hard prereq).
@@ -67,30 +68,45 @@ Other gates on #2274: `migration-replay`, `coverage`, `contracts (openapi/strict
 
 ---
 
-## 3. Why this smoke was NOT run from the dev sandbox (the blocker — report, don't force)
+## 3. Staging smoke result — PASS (2026-06-04)
 
-Three independent blockers, any one of which stops a sandbox-driven run:
+The previous network blocker was resolved by the new staging IP (`https://23.254.236.11/`). The smoke then ran
+against the live staging stack, not a local fixture:
 
-1. **Staging `:8082`/`:22` are not usable from the sandbox in the current route state.** Probed two ways:
-   a plain `curl http://142.171.239.56:8082/health` times out at HTTP `000`; and although `nc -z` to both
-   `:22` and `:8082` *succeeds* (TCP SYN-ACK), the application handshakes do **not** complete —
-   `curl :8082` still returns HTTP `000` and `ssh -i ~/.ssh/metasheet2_deploy mainuser@…` is
-   `Connection closed by …:22` before auth. "TCP-open but HTTP/SSH die at handshake" = the local route is
-   not going through the working **v2ray** path. The fix is `use-v2ray-142-ssh.command` (it
-   `sudo route delete`s the static host route so traffic uses v2ray, then SSH-tests) — that needs **sudo +
-   the operator's v2ray**, so the tunnel cannot be brought up from an unattended sandbox. (`github.com`
-   returns HTTP `200` from the same shell, so general outbound is fine — this is host-route-specific.)
-2. **Staging is not yet running C4-2.** Staging does not auto-mirror `main`; the last staging deploy was
-   `0fd25d3ed` (③ shift-compliance, 2026-06-03) — **before** C4-2 (`4b3108737`) merged on 2026-06-04. So a
-   deploy/image-bump is required first, and that is an owner-authorized live-infra action, not a sandbox one.
-3. **The smoke is not pure-HTTP** (unlike ③). `expiresInDays` minimum is **1 day** (fixed 24 h) and the
-   scheduler default tick is hourly — you cannot "grant then wait it out" inside a smoke window. The lot's
-   `expires_at` must be **aged in SQL** and the **deployed background scheduler** must be running on a short
-   interval. So the run needs **both** an HTTP path (grant) **and** psql on the staging DB (age + assert the
-   `expire` event) — i.e. an SSH session into staging, which is the owner's to drive.
+- Public health: `https://23.254.236.11/health` returned `healthy`.
+- SSH target: `mainuser@23.254.236.11` (`racknerd-0de8668`).
+- Staging repo / compose project: `/home/mainuser/metasheet2-dingtalk-staging` /
+  `metasheet2-dingtalk-staging`.
+- Migration state before smoke: `kysely_migration` count `177`; C1 tables
+  `attendance_leave_balances` / `attendance_leave_balance_events` present; C1 columns including `expires_at`,
+  `granted_at`, `remaining_minutes`, and `source_key` present.
+- Deployed build: `8701c46e00c68ed19c226e7206f5456866f6b8ba` (contains #2274).
+- Scheduler env in the staging backend: `ATTENDANCE_SCHEDULER_ENABLED=true`,
+  `ATTENDANCE_SCHEDULER_INTERVAL_MS=5000`.
+- Startup log evidence: `Attendance scheduler initialized` and
+  `Attendance scheduler starting with interval 5000ms`.
 
-Per the goal's guardrail ("如果 staging/migration/CI blocker 出现，停止并报告，不要扩大范围"): this is reported,
-not forced. The procedure below is ready to copy-paste once staging is deployed.
+Smoke output:
+
+```text
+PASS: backend build is 8701c46e
+ORIG_COMP={"enabled":false,"expiresInDays":null}
+PASS: enabled compTimeFromOvertime expiresInDays=30
+OT_RULE=f92ad711-1703-4da9-8e79-5fe7d76f8579
+OT_REQ=f1f5ace0-763e-44c4-bb70-be2fc589a0d7 source_key=overtime_conversion:f1f5ace0-763e-44c4-bb70-be2fc589a0d7
+PASS: 30d grant exact: lot=0b92579c-049a-4e49-a52e-df1baa6d3e85 remaining=120 exact_720h=true
+OT_NULL=430cfc0d-0f2d-4125-bd7b-77e11bb4eda7 source_key=overtime_conversion:430cfc0d-0f2d-4125-bd7b-77e11bb4eda7
+PASS: null-expiry control remains NULL
+PASS: background scheduler expired aged lot once: expired|0|1|-120:comp_time_expiry
+PASS: NULL lot survived scheduler scan
+PASS: repeat scheduler tick is idempotent
+PASS: cleanup residue=0 and settings restored
+C4_STAGING_SMOKE_PASS commit=8701c46e00c68ed19c226e7206f5456866f6b8ba lot=0b92579c-049a-4e49-a52e-df1baa6d3e85 ot=f1f5ace0-763e-44c4-bb70-be2fc589a0d7 null_ot=430cfc0d-0f2d-4125-bd7b-77e11bb4eda7
+```
+
+This closes the §2 caveat: CI already proved the expiry SQL + grant wiring; this staging run proves the
+deployed env-gated background scheduler path (`index.ts` startup → scheduler env → periodic tick →
+`AttendanceExpiryService`) end to end.
 
 ---
 
@@ -218,7 +234,7 @@ psql "$PGURL" -c "SELECT count(*) AS residue FROM attendance_leave_balances
 
 ---
 
-## 5. Pass criteria (all must hold) → only then flip `④ C4 ✅`
+## 5. Pass criteria (all held on 2026-06-04) → `④ C4 ✅`
 
 1. 4.3 `exact_30d = t` (grant stamps `granted_at + 720h`, DST-free).
 2. 4.4 null-expiry lot `expires_at = NULL` (no behaviour change when unset).
@@ -228,19 +244,17 @@ psql "$PGURL" -c "SELECT count(*) AS residue FROM attendance_leave_balances
 5. 4.6 second tick → still exactly one event (idempotent).
 6. 4.7 `residue = 0` and settings restored.
 
-On all-PASS: backfill the tracker rows `加班↔调休` / `假期过期管理` to `✅` with `#2274` + this smoke's
-evidence, and add a `回填（C4 closeout）` line. **Until then they stay `⬜`.**
+Tracker rows `加班↔调休` / `假期过期管理` were backfilled to `✅` with `#2274` + the smoke evidence above.
 
 ---
 
-## 6. Risks / deferred (carried into the report)
+## 6. Risks / deferred after C4 closeout
 
-- **R1 — background-scheduler wiring is only proven by this staging smoke.** CI proves the expiry SQL +
-  grant; it does not start the env-gated timer. If the smoke is skipped, the startup wiring
-  (`src/index.ts` → `startAttendanceScheduler` → `ATTENDANCE_SCHEDULER_ENABLED`) is unverified in a
-  deployed process. (Mitigated only by running §4.)
-- **R2 — staging migration state.** Assumes staging is migrated through C1–C3. If not, §4.0's pure-image-bump
-  assumption is false and the #2226 align + C1 DDL must land first (heavier blocker → STOP + report).
+- **R1 — background-scheduler wiring is now staging-proven.** The 2026-06-04 smoke closed the CI caveat by
+  proving startup wiring + env-gated periodic tick in a deployed process.
+- **R2 — staging migration state.** The 2026-06-04 pre-smoke check confirmed staging is migrated through
+  C1–C3 (`kysely_migration` count `177`, C1 tables/columns present). Future staging runs should still repeat
+  the same schema probe before treating C4-2 as a pure image bump.
 - **R3 — C5 not in scope.** No reminders, no notifier channels (scaffold only), no 未排班提醒. Deferred.
 - **R4 — leader lock untested here.** Single staging instance ⇒ `ENABLE_ATTENDANCE_SCHEDULER_LEADER_LOCK`
   left off; the load-shed path is unexercised on staging (correctness does not depend on it by design §2.2).

--- a/docs/development/attendance-comp-leave-c4-2-staging-smoke-runbook-20260604.md
+++ b/docs/development/attendance-comp-leave-c4-2-staging-smoke-runbook-20260604.md
@@ -1,0 +1,243 @@
+# ④ C4-2 staging smoke runbook + CI evidence (comp-time expiry scheduler)
+
+**Status:** C4-2 code is **merged** (#2274, merge commit `4b3108737`, on `origin/main`); CI is
+**fresh-green** and the attendance DB step genuinely ran the C4 spec (evidence §2). The **`④ C4 ✅`
+graduation is still gated on the staging C4 smoke below** — per the #2267 design-lock and #2230 governing
+("`④ C4 ✅` is gated on C4-2 + a staging C4 smoke"). This doc is that smoke, **prepared but not yet run**:
+it could not be executed from the dev sandbox (§3). It stays in `⬜` on the tracker until the smoke PASSES.
+
+Refs: #2274 (C4-2 impl), #2270 (C4-1 inert expiry fn), #2267 (C4 execution design-lock),
+#2230 (④ governing design-lock), #2226 (staging migration-align runbook — the hard prereq).
+
+---
+
+## 1. What merged (scope check — matches the locked C4-2 scope, no scope creep)
+
+`#2274` (6 files, +620/-10):
+
+- `packages/core-backend/src/services/AttendanceScheduler.ts` — env-gated (`ATTENDANCE_SCHEDULER_ENABLED`,
+  default OFF), `unref` interval tick + one-run guard, opt-in Redis leader lock
+  (`ENABLE_ATTENDANCE_SCHEDULER_LEADER_LOCK`, load-only — the expiry claim is self-guarding), interval via
+  `ATTENDANCE_SCHEDULER_INTERVAL_MS` (default 1h, floor 5s). Mirrors `ApprovalSlaScheduler`.
+- `packages/core-backend/src/services/AttendanceNotifier.ts` — **scaffold only**, registers **no** channels,
+  no-op dispatch (channel-env-gating discipline). No messages — reminders are C5.
+- `packages/core-backend/src/index.ts` — startup/shutdown wiring next to `startApprovalSlaScheduler`.
+- `plugins/plugin-attendance/index.cjs` — the C2 grant stamps `expires_at = granted_at + N×24h` (fixed
+  duration, SQL `now()`-computed) **iff** `compTimeFromOvertime.expiresInDays = N` (positive int) and
+  `enabled`; otherwise `expires_at = NULL` (C2 behaviour unchanged, no backfill).
+- `tests/unit/attendance-scheduler.test.ts` + `tests/integration/attendance-plugin.test.ts` — see §2.
+
+**No migration / no new DDL** in C4-2: `expires_at` is the C2 column, the ledger tables are C1 (#2231).
+This matters for staging: C4-2 is a **pure image bump** on top of an already-C1/C2/C3-migrated staging.
+
+---
+
+## 2. CI evidence — the attendance DB step really ran the C4 spec (not skipped)
+
+The matrix `test (18.x)` / `test (20.x)` jobs of **Plugin System Tests** (`plugin-tests.yml`) have a
+dedicated **`Run attendance integration tests`** step (NOT `|| true` — blocking) with a
+`: "${DATABASE_URL:?...}"` hard-guard and `ATTENDANCE_TEST_DATABASE_URL` pointed at a real postgres-14, so
+`attendance-plugin.test.ts` runs under `describe` (not `describe.skip`). Both node versions ran it.
+
+`#2274` run `26945820453`, job `test (20.x)` (`79498395042`) log:
+
+```
+✓ tests/integration/attendance-expiry-service.test.ts (1 test) 48ms
+✓ tests/integration/attendance-plugin.test.ts (88 tests) 7782ms
+  Test Files  2 passed (2)
+```
+
+The C4 assertions are these two cases, both green:
+
+- `attendance-plugin.test.ts:3148` — `it('④ C4 — grant stamps expires_at iff expiresInDays set; scheduler
+  tick expires aged lots once (NULL/future survive)')`: covers grant→`expires_at = granted_at + 720h`
+  (exact, `expiresInDays=30`), `expiresInDays=null → NULL`, future/NULL survive a scan, aged lot expires
+  once (`remaining=0` + one `expire` event `delta=-120, source_type=comp_time_expiry`), repeat tick =
+  no second event (idempotent).
+- `attendance-expiry-service.test.ts:17` (C4-1) — `it('expires active lots once and leaves NULL, future,
+  and spent lots untouched')`.
+
+> Caveat (honest): the CI test instantiates its **own** `AttendanceScheduler` + `AttendanceExpiryService`
+> against the test pool and calls `tick()` directly. It proves the **expiry state-flow + idempotency + the
+> grant wiring**. It does **not** exercise the **deployed env-gated background scheduler** (startup wiring →
+> `ATTENDANCE_SCHEDULER_ENABLED` → periodic tick). That gap is exactly what the staging smoke below closes.
+
+Other gates on #2274: `migration-replay`, `coverage`, `contracts (openapi/strict/dashboard)`, `e2e`,
+`after-sales integration`, `K3 WISE offline PoC`, `DingTalk P4 ops regression` — all pass.
+
+---
+
+## 3. Why this smoke was NOT run from the dev sandbox (the blocker — report, don't force)
+
+Three independent blockers, any one of which stops a sandbox-driven run:
+
+1. **Staging `:8082`/`:22` are not usable from the sandbox in the current route state.** Probed two ways:
+   a plain `curl http://142.171.239.56:8082/health` times out at HTTP `000`; and although `nc -z` to both
+   `:22` and `:8082` *succeeds* (TCP SYN-ACK), the application handshakes do **not** complete —
+   `curl :8082` still returns HTTP `000` and `ssh -i ~/.ssh/metasheet2_deploy mainuser@…` is
+   `Connection closed by …:22` before auth. "TCP-open but HTTP/SSH die at handshake" = the local route is
+   not going through the working **v2ray** path. The fix is `use-v2ray-142-ssh.command` (it
+   `sudo route delete`s the static host route so traffic uses v2ray, then SSH-tests) — that needs **sudo +
+   the operator's v2ray**, so the tunnel cannot be brought up from an unattended sandbox. (`github.com`
+   returns HTTP `200` from the same shell, so general outbound is fine — this is host-route-specific.)
+2. **Staging is not yet running C4-2.** Staging does not auto-mirror `main`; the last staging deploy was
+   `0fd25d3ed` (③ shift-compliance, 2026-06-03) — **before** C4-2 (`4b3108737`) merged on 2026-06-04. So a
+   deploy/image-bump is required first, and that is an owner-authorized live-infra action, not a sandbox one.
+3. **The smoke is not pure-HTTP** (unlike ③). `expiresInDays` minimum is **1 day** (fixed 24 h) and the
+   scheduler default tick is hourly — you cannot "grant then wait it out" inside a smoke window. The lot's
+   `expires_at` must be **aged in SQL** and the **deployed background scheduler** must be running on a short
+   interval. So the run needs **both** an HTTP path (grant) **and** psql on the staging DB (age + assert the
+   `expire` event) — i.e. an SSH session into staging, which is the owner's to drive.
+
+Per the goal's guardrail ("如果 staging/migration/CI blocker 出现，停止并报告，不要扩大范围"): this is reported,
+not forced. The procedure below is ready to copy-paste once staging is deployed.
+
+---
+
+## 4. Procedure (run from a host with the staging tunnel + psql on the staging DB)
+
+### 4.0 Deploy prerequisite (owner)
+
+Deploy `4b3108737` (or any later `main`) to staging `:8082` with the scheduler **on** and **fast**:
+
+```
+ATTENDANCE_SCHEDULER_ENABLED=true
+ATTENDANCE_SCHEDULER_INTERVAL_MS=5000        # 5 s floor — so the smoke doesn't wait an hour
+# (leave ENABLE_ATTENDANCE_SCHEDULER_LEADER_LOCK unset — single staging instance, not needed)
+```
+
+Because C4-2 adds **no DDL**, this is a pure image bump provided staging is already migrated through
+C1–C3 (the #2226 align + the C1 #2231 ledger DDL). If staging is **not** through C1–C3, that is a
+*different, heavier* blocker (run the #2226 align + C1 DDL first) — STOP and report it; do not improvise DDL.
+
+Set these once for the session (staging admin token = minted with the **staging** `JWT_SECRET`; a prod token
+401s on staging):
+
+```bash
+export BASE='http://127.0.0.1:8082'          # staging root via your tunnel
+export TOKEN='<staging-admin-jwt>'           # attendance:read,write,admin
+export PGURL='<staging-postgres-dsn>'        # reachable via the tunnel; psql "$PGURL" must connect
+export SUF="c4smoke-$(date +%s)"
+H=(-H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json')
+```
+
+### 4.1 Enable expiry + create an OT rule
+
+```bash
+curl -s "${H[@]}" -X PUT "$BASE/api/attendance/settings" \
+  -d '{"compTimeFromOvertime":{"enabled":true,"expiresInDays":30}}' | jq .
+# capture the original compTimeFromOvertime first if you want a clean restore:
+#   curl -s -H "Authorization: Bearer $TOKEN" "$BASE/api/attendance/settings" | jq '.data.compTimeFromOvertime'
+
+OT_RULE=$(curl -s "${H[@]}" -X POST "$BASE/api/attendance/overtime-rules" \
+  -d "{\"name\":\"$SUF-ot\",\"minMinutes\":30}" | jq -r '.data.id')
+echo "OT_RULE=$OT_RULE"
+```
+
+### 4.2 Grant a 30-day lot (OT request → approve = the C2 grant)
+
+```bash
+OT_REQ=$(curl -s "${H[@]}" -X POST "$BASE/api/attendance/requests" \
+  -d "{\"workDate\":\"2026-09-25\",\"requestType\":\"overtime\",\"overtimeRuleId\":\"$OT_RULE\",\"minutes\":120}" \
+  | jq -r '.data.request.id')
+curl -s "${H[@]}" -X POST "$BASE/api/attendance/requests/$OT_REQ/approve" -d '{"comment":"c4 smoke"}' | jq '.status? // .'
+echo "OT_REQ=$OT_REQ  source_key=overtime_conversion:$OT_REQ"
+```
+
+### 4.3 Assert the grant stamped `expires_at = granted_at + exactly 720 h`
+
+```bash
+psql "$PGURL" -c "SELECT id, user_id, status, remaining_minutes, expires_at,
+  (expires_at - granted_at = interval '720 hours') AS exact_30d
+  FROM attendance_leave_balances WHERE source_key = 'overtime_conversion:$OT_REQ';"
+```
+**PASS:** one row, `status=active`, `remaining_minutes=120`, `expires_at` NOT NULL, `exact_30d = t`.
+
+### 4.4 Null-expiry control — grant with `expiresInDays=null` keeps `expires_at` NULL
+
+```bash
+curl -s "${H[@]}" -X PUT "$BASE/api/attendance/settings" \
+  -d '{"compTimeFromOvertime":{"enabled":true,"expiresInDays":null}}' >/dev/null
+OT_NULL=$(curl -s "${H[@]}" -X POST "$BASE/api/attendance/requests" \
+  -d "{\"workDate\":\"2026-09-26\",\"requestType\":\"overtime\",\"overtimeRuleId\":\"$OT_RULE\",\"minutes\":60}" \
+  | jq -r '.data.request.id')
+curl -s "${H[@]}" -X POST "$BASE/api/attendance/requests/$OT_NULL/approve" -d '{"comment":"c4 null"}' >/dev/null
+psql "$PGURL" -c "SELECT expires_at FROM attendance_leave_balances WHERE source_key = 'overtime_conversion:$OT_NULL';"
+```
+**PASS:** `expires_at` is NULL.
+
+### 4.5 Age the 30-day lot past expiry, then let the **deployed scheduler** expire it
+
+```bash
+psql "$PGURL" -c "UPDATE attendance_leave_balances SET expires_at = now() - interval '1 hour'
+  WHERE source_key = 'overtime_conversion:$OT_REQ';"
+sleep 12     # > one ATTENDANCE_SCHEDULER_INTERVAL_MS (5 s) + margin; the background scheduler ticks
+psql "$PGURL" -c "SELECT b.status, b.remaining_minutes,
+    (SELECT count(*) FROM attendance_leave_balance_events e
+       WHERE e.balance_id = b.id AND e.event_type = 'expire') AS expire_events,
+    (SELECT string_agg(e.delta_minutes::text || ':' || e.source_type, ',')
+       FROM attendance_leave_balance_events e
+       WHERE e.balance_id = b.id AND e.event_type = 'expire') AS expire_detail
+  FROM attendance_leave_balances b WHERE b.source_key = 'overtime_conversion:$OT_REQ';"
+```
+**PASS:** `status=expired`, `remaining_minutes=0`, `expire_events=1`, `expire_detail = -120:comp_time_expiry`.
+Also re-check the null lot is **untouched**:
+```bash
+psql "$PGURL" -c "SELECT status FROM attendance_leave_balances WHERE source_key = 'overtime_conversion:$OT_NULL';"  # active
+```
+
+### 4.6 Idempotency — a second tick writes no second event
+
+```bash
+sleep 12     # another scheduler interval
+psql "$PGURL" -c "SELECT count(*) AS expire_events FROM attendance_leave_balance_events e
+  JOIN attendance_leave_balances b ON b.id = e.balance_id
+  WHERE b.source_key = 'overtime_conversion:$OT_REQ' AND e.event_type = 'expire';"
+```
+**PASS:** still `expire_events = 1`.
+
+### 4.7 Cleanup + residue assertion
+
+```bash
+psql "$PGURL" <<SQL
+DELETE FROM attendance_leave_balance_events
+  WHERE balance_id IN (SELECT id FROM attendance_leave_balances
+    WHERE source_key IN ('overtime_conversion:$OT_REQ','overtime_conversion:$OT_NULL'));
+DELETE FROM attendance_leave_balances
+  WHERE source_key IN ('overtime_conversion:$OT_REQ','overtime_conversion:$OT_NULL');
+DELETE FROM attendance_requests WHERE id = ANY (ARRAY['$OT_REQ','$OT_NULL']::uuid[]);
+SQL
+# restore the original compTimeFromOvertime setting (use the value captured in 4.1), then:
+psql "$PGURL" -c "SELECT count(*) AS residue FROM attendance_leave_balances
+  WHERE source_key IN ('overtime_conversion:$OT_REQ','overtime_conversion:$OT_NULL');"
+```
+**PASS:** `residue = 0`. Delete the `$SUF-ot` overtime rule too if your staging org should stay pristine.
+
+---
+
+## 5. Pass criteria (all must hold) → only then flip `④ C4 ✅`
+
+1. 4.3 `exact_30d = t` (grant stamps `granted_at + 720h`, DST-free).
+2. 4.4 null-expiry lot `expires_at = NULL` (no behaviour change when unset).
+3. 4.5 aged lot → `expired` + `remaining=0` + exactly one `-120:comp_time_expiry` event, **driven by the
+   deployed background scheduler** (closes the §2 caveat).
+4. 4.5 null lot survives the scan.
+5. 4.6 second tick → still exactly one event (idempotent).
+6. 4.7 `residue = 0` and settings restored.
+
+On all-PASS: backfill the tracker rows `加班↔调休` / `假期过期管理` to `✅` with `#2274` + this smoke's
+evidence, and add a `回填（C4 closeout）` line. **Until then they stay `⬜`.**
+
+---
+
+## 6. Risks / deferred (carried into the report)
+
+- **R1 — background-scheduler wiring is only proven by this staging smoke.** CI proves the expiry SQL +
+  grant; it does not start the env-gated timer. If the smoke is skipped, the startup wiring
+  (`src/index.ts` → `startAttendanceScheduler` → `ATTENDANCE_SCHEDULER_ENABLED`) is unverified in a
+  deployed process. (Mitigated only by running §4.)
+- **R2 — staging migration state.** Assumes staging is migrated through C1–C3. If not, §4.0's pure-image-bump
+  assumption is false and the #2226 align + C1 DDL must land first (heavier blocker → STOP + report).
+- **R3 — C5 not in scope.** No reminders, no notifier channels (scaffold only), no 未排班提醒. Deferred.
+- **R4 — leader lock untested here.** Single staging instance ⇒ `ENABLE_ATTENDANCE_SCHEDULER_LEADER_LOCK`
+  left off; the load-shed path is unexercised on staging (correctness does not depend on it by design §2.2).

--- a/docs/development/attendance-comp-leave-c4-2-staging-smoke-runbook-20260604.md
+++ b/docs/development/attendance-comp-leave-c4-2-staging-smoke-runbook-20260604.md
@@ -119,6 +119,9 @@ export TOKEN='<staging-admin-jwt>'           # attendance:read,write,admin
 export PGURL='<staging-postgres-dsn>'        # reachable via the tunnel; psql "$PGURL" must connect
 export SUF="c4smoke-$(date +%s)"
 H=(-H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json')
+ORIG_COMP_TIME=$(curl -s -H "Authorization: Bearer $TOKEN" "$BASE/api/attendance/settings" \
+  | jq -c '.data.compTimeFromOvertime // {"enabled":false,"expiresInDays":null}')
+echo "ORIG_COMP_TIME=$ORIG_COMP_TIME"
 ```
 
 ### 4.1 Enable expiry + create an OT rule
@@ -126,8 +129,6 @@ H=(-H "Authorization: Bearer $TOKEN" -H 'Content-Type: application/json')
 ```bash
 curl -s "${H[@]}" -X PUT "$BASE/api/attendance/settings" \
   -d '{"compTimeFromOvertime":{"enabled":true,"expiresInDays":30}}' | jq .
-# capture the original compTimeFromOvertime first if you want a clean restore:
-#   curl -s -H "Authorization: Bearer $TOKEN" "$BASE/api/attendance/settings" | jq '.data.compTimeFromOvertime'
 
 OT_RULE=$(curl -s "${H[@]}" -X POST "$BASE/api/attendance/overtime-rules" \
   -d "{\"name\":\"$SUF-ot\",\"minMinutes\":30}" | jq -r '.data.id')
@@ -207,11 +208,13 @@ DELETE FROM attendance_leave_balances
   WHERE source_key IN ('overtime_conversion:$OT_REQ','overtime_conversion:$OT_NULL');
 DELETE FROM attendance_requests WHERE id = ANY (ARRAY['$OT_REQ','$OT_NULL']::uuid[]);
 SQL
-# restore the original compTimeFromOvertime setting (use the value captured in 4.1), then:
+curl -s "${H[@]}" -X PUT "$BASE/api/attendance/settings" \
+  -d "$(jq -cn --argjson comp "$ORIG_COMP_TIME" '{compTimeFromOvertime:$comp}')" | jq '.data.compTimeFromOvertime'
+curl -s "${H[@]}" -X DELETE "$BASE/api/attendance/overtime-rules/$OT_RULE" | jq '.ok'
 psql "$PGURL" -c "SELECT count(*) AS residue FROM attendance_leave_balances
   WHERE source_key IN ('overtime_conversion:$OT_REQ','overtime_conversion:$OT_NULL');"
 ```
-**PASS:** `residue = 0`. Delete the `$SUF-ot` overtime rule too if your staging org should stay pristine.
+**PASS:** settings are restored, the temporary OT rule delete returns `true`, and `residue = 0`.
 
 ---
 

--- a/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
+++ b/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
@@ -24,7 +24,7 @@
 | 档 | 项 | 关键约束 |
 |---|---|---|
 | **MUST** | **排班合规引擎**（日/周/月工时 cap，**超限阻断保存**） | 钉钉最硬护城河。**MUST 口径 = 排班时阻断保存；warning-only 只算报表/预警红利，不算 MUST ✅**（避免实现方交 warning 充数）。**design-lock #2213（2026-06-02）**：新建 `shiftCompliance`（不并入 comprehensiveHours）/ 全 save 路径事务内投影 / 首版 block / 完成口径 = 日周月三粒度×全路径 |
-| | **未排班提醒**（提醒负责人/本人） | ⚠️ **不是小 feature**：attendance 无调度器、无事件→通知消费者（2026-06-01 verify 证伪"渠道已有"）→ 实为"**attendance scheduler + notifier 基座**"基础设施刀（镜像 `ApprovalSlaScheduler`，leader-elected + env 渠道 notifier）；与**假期过期提醒共建/复用同一基座**。估时 **2–3pd**（原 1–2pd 作废）；排序靠后（§3）。**未排班处理策略 → 归 ③ 打卡策略组，不在此单建** |
+| | **未排班提醒**（提醒负责人/本人） | ⚠️ **不是小 feature**：2026-06-01 verify 证伪"渠道已有"（attendance 当时无调度器、无事件→通知消费者）。截至 2026-06-04，**attendance scheduler 基座已由 ④ C4 建成并 staging-proven**（镜像 `ApprovalSlaScheduler`，leader-elected/env-gated），但未排班 reminder/notifier 业务逻辑仍未接；⑤ 复用该基座。**未排班处理策略 → 归 ③ 打卡策略组，不在此单建** |
 | | **排班修改窗**（可改 N 天内、超窗锁；钉钉默认 180） | 与合规引擎 + 历史数据可信度强绑；无它则报表不可信。实现量小、治理价值高 |
 | | **打卡策略组**（外勤审批 + 内外勤卡合并 + **未排班打卡策略**） | 三项同属 punch policy → 一个"**打卡策略配置基座**"design-lock（greenfield，0 现有字段）；抽屉已在只差配置写入；未排班"阻断/允许打卡"默认 **allow**（不回归） |
 | | **加班 ↔ 调休** | 假勤闭环 |
@@ -50,12 +50,12 @@
 | 综合工时（报表侧） | （已成，OUT 之外的红利） | ✅ | #1801 等（113 hits，`enforcement:'warn'`） |
 | 固定班 preview/apply + provenance + managed controls · 周矩阵展示 · 打卡只读抽屉 · HR 字段/onboarding/work-time drawer · FormulaEngine（仅差 4–5 函数） | （红利） | ✅ | 并行 session 两天内落地 |
 | 排班合规引擎（超出禁止保存） | MUST | ✅ | **完成 2026-06-03**：design-lock #2213 → S0 latent settings #2214 → S1 daily cap #2218 → S2 weekly/monthly explicit scheduled-load cap #2221；staging 联调 PASS 13/13（`/tmp/staging-shift-compliance-smoke-20260603.mjs` against `0fd25d3ed`）。日/周/月三粒度 × shift/rotation/fixed-apply 全 save 路径均运行时 block；`warn` 仍为惰性预留 |
-| 未排班提醒（= scheduler+notifier 基座刀） | MUST | ⬜ | **verify 2026-06-01 证伪"渠道已有"**：attendance 无调度器、无事件→通知消费者 → 镜像 `ApprovalSlaScheduler`+notifier；2–3pd；与假期过期提醒共建。处理策略已移入 ③ |
+| 未排班提醒（复用 attendance scheduler 基座） | MUST | ⬜ | **verify 2026-06-01 证伪"渠道已有"**；scheduler 基座已由 ④ C4 建成并 staging-proven，但未排班 reminder scan + notifier channels 未接。处理策略已移入 ③ |
 | 排班修改窗 | MUST | ✅ | #2197（squash `2d4808fe`，2026-06-02）：org-level `shiftEditPolicy` 入 attendance settings JSON（默认 `unrestricted`，无 DDL）+ shift/rotation assignment POST/PUT/DELETE 6 写路由显式 422 `SHIFT_EDIT_WINDOW_EXCEEDED`；PUT/DELETE 同看 existing start date + next start date 防历史绕窗；unit + CI real-DB attendance integration 绿 |
 | 外勤审批 | MUST | ⬜ | 0 |
 | 内外勤卡合并 | MUST | ⬜ | 0（打卡抽屉只读） |
-| 加班↔调休 | MUST | ⬜ | C0–C3 + C4-1(#2270 inert) + **C4-2 merged #2274**（`4b3108737`：expiry scheduler + `expiresInDays` grant 写 `expires_at` + notifier scaffold，**无 DDL**）。CI real-DB attendance step 真跑且绿（`④ C4` 用例在 `attendance-plugin.test.ts` 88-test 文件 + `attendance-expiry-service.test.ts`）。**staging C4 smoke 未跑 → 未 ✅**（runbook `attendance-comp-leave-c4-2-staging-smoke-runbook-20260604.md`；staging:8082 sandbox 不可达 + 未部署 C4-2 + 需 SSH+SQL aging，按"停止并报告"处置） |
-| 假期过期管理 | MUST | ⬜ | 同上 C4 子链：`expires_at` 写入 + 过期 state-flow + 调度基座 merge #2274 / CI 绿；**未 ✅**（gated on staging smoke，见 runbook） |
+| 加班↔调休 | MUST | ✅ | C0–C3 staging-validated + C4-1(#2270 inert) + **C4-2 #2274**（`4b3108737`：expiry scheduler + `expiresInDays` grant 写 `expires_at` + notifier scaffold，**无 DDL**）。CI real-DB attendance step 真跑且绿（`④ C4` 用例在 `attendance-plugin.test.ts` 88-test 文件 + `attendance-expiry-service.test.ts`）。**staging C4 smoke PASS 2026-06-04**：staging deploy `8701c46e00c68ed19c226e7206f5456866f6b8ba` on `https://23.254.236.11/`，scheduler env `ATTENDANCE_SCHEDULER_ENABLED=true` / interval `5000ms`，30d grant 精确 720h，后台 scheduler 过期 aged lot 一次且 repeat tick 幂等，NULL-expiry lot 保持 active，cleanup residue=0（见 runbook `attendance-comp-leave-c4-2-staging-smoke-runbook-20260604.md`） |
+| 假期过期管理 | MUST | ✅ | C4 子链已 staging-validated：`expires_at` 写入 + 过期 state-flow + env-gated `AttendanceScheduler` 调度基座均已证实；C5 通知/提醒仍按 #2230 作为后续扩展，不影响 C4 完成口径 |
 | 自动对班 | SHOULD | ⬜ | 0 |
 | 一天多班次 | SHOULD | ⬜ | 0 |
 | 排班发布/草稿 | SHOULD | ⬜ | 0 |
@@ -73,7 +73,7 @@
 ② **打卡策略组**（design-lock #2203）：S0 基座 ✅#2204 · S1 未排班打卡 ✅#2209 · **子序修正 → S1→S3→S2**（S2 内外勤合并依赖 S3 先建"外勤打卡"事实类型）· **S3 外勤 + S2 产品 2026-06-02 暂缓**（外勤=重刀/移动现场）→ 组在 S1 后暂停
 ③ **排班合规引擎**（✅ #2213/#2214/#2218/#2221 + staging 2026-06-03）：`shiftCompliance` 日/周/月 cap 已按 **explicit scheduled load** 口径在全部 save 路径运行时阻断；staging smoke 13/13 通过，③ 正式关闭
 ④ **加班调休 + 假期过期**（假勤闭环；假期过期提醒在此**首建** scheduler/notifier 基座）— **design-lock 已落**（`attendance-comp-leave-expiry-design-lock-20260603.md`，本 PR；owner 决策 2026-06-03 锁定）：余额=**grant-lot ledger**（`attendance_leave_balances`，非 mutable aggregate）+ **必需审计流水 `attendance_leave_balance_events`**（不可只改 remaining）· 入账=OT approve **transition** 幂等（**`source_key` NOT NULL + `UNIQUE(org,source_key)` 兜底**，不锁可空 source_id）· 撤销**首版不自动反冲但不静默错账** · 调度=**首建 `AttendanceScheduler`**（镜像 `ApprovalSlaScheduler`，leader-elected，⑤ 复用）。子链 C0 staging-align（**硬前置**）→C1 ledger DDL→C2 入账→C3 扣减→C4 过期+调度→C5 提醒+notifier，实现 PR 拆开。**比 ③ 重一档（有 DDL）。**
-⑤ **未排班提醒**（**复用 ④ 的 scheduler+notifier 基座**；镜像 `ApprovalSlaScheduler`）
+⑤ **未排班提醒**（**复用 ④ C4 已建成的 scheduler 基座**；补 scan + notifier channels）
 ⑥ **自动对班**（灰度门，feature-flag 默认关 → preview → 自动写）
 
 > **回填（2026-06-01 pre-flight 发现）**：原排序把"未排班提醒"列首，依据"渠道已有/最便宜"——**verify 证伪**（attendance 无调度器、无事件→通知消费者）。故改：**排班修改窗为首刀**（真·最便宜 + 治理高）；未排班提醒降级为后续"scheduler+notifier 基座"基础设施刀（2–3pd，与假期过期提醒共建）；未排班处理策略归 ③ 打卡策略组。
@@ -83,6 +83,8 @@
 > **回填（2026-06-02 合规引擎 design-lock）**：③ 排班合规引擎 design-lock 落地（`attendance-shift-compliance-engine-design-lock-20260602.md`，#2213）。owner 决策锁定：(1) 新建 `shiftCompliance`（日/周/月 maxMinutes + enforcement warn|block，**不并入** comprehensiveHours——save-time/planned/日周月 vs report/actual/月季年）；(2) 强制 = **全部** save 路径（shift POST/PUT `29445/29538` + rotation POST/PUT `21452` + fixed-apply `27818/9193`，DELETE 不拦）；(3) **首版只 block**，warn 预留惰性。**keystone**：投影**复用** `loadAttendanceComprehensivePlannedMinutesByUser`（`13163`，经 effective-calendar resolver，与 comprehensiveHours **同一套** planned-minutes 算法 → 零漂移），**事务内写后投影 → 超限 throw → rollback → 422**（PUT 排除自身自动成立）。切片 **S0 latent config → S1 daily → S2 weekly+monthly**（各 gated + 真 DB route-level 反向 integration）。**完成口径（partial-MUST bar）：③ 仅在 daily∧weekly∧monthly × 全路径 + 反向 integration + staging 全满足才 ✅；daily-only 的 S1 是切片不是"引擎完成"**（防 P2 式 warning/切片充数）。
 
 > **回填（2026-06-03 合规引擎 closeout）**：S0 ✅ #2214（`shiftCompliance` latent settings）· S1 ✅ #2218（daily cap，全部 save 路径）· S2 ✅ #2221（weekly/monthly cap，owner 决策 A：只统计 explicit scheduled load，排除默认兜底工作制 baseline）。staging 部署到 `0fd25d3ed` 后运行 `/tmp/staging-shift-compliance-smoke-20260603.mjs`：**PASS 13/13**。覆盖：(1) `shiftCompliance` PUT→GET round-trip；(2) weekly cap 2400 + 单个显式 540 分钟排班 → 201，证明默认 Mon–Fri baseline 不计入；(3) daily/weekly/monthly 超 cap → `422 SHIFT_COMPLIANCE_CAP_EXCEEDED` 且无 assignment 持久化；(4) fixed-schedule apply 批量路径超 cap → 422 且无 managed row。联调中发现 staging schema drift 并做最小 alignment：`attendance_groups.attendance_type` + `attendance_shift_assignments.producer_*`；这是 staging 环境补齐，不改变 ③ 完成口径，但后续应补正式 migration/ops 记录避免其它环境复现。
+
+> **回填（2026-06-04 C4 closeout）**：④ C4-2 #2274（`4b3108737`）已部署 staging build `8701c46e00c68ed19c226e7206f5456866f6b8ba`（`https://23.254.236.11/`），并以 `ATTENDANCE_SCHEDULER_ENABLED=true` / `ATTENDANCE_SCHEDULER_INTERVAL_MS=5000` 运行后台 scheduler。C4 staging smoke **PASS**：`compTimeFromOvertime.expiresInDays=30` 的 OT grant 写出 `expires_at - granted_at = interval '720 hours'`；`expiresInDays=null` 的 control lot 保持 `expires_at=NULL`；SQL aging 后由**部署态后台 scheduler**把 aged lot 过期为 `status=expired, remaining=0` 并写 exactly one `-120:comp_time_expiry` event；repeat tick 不重复；cleanup residue=0 且 settings restored。至此 ④ 的 C0/C1/C2/C3/C4 全部完成；C5 通知/提醒仍为后续扩展。
 
 > **⚠️ schema 成组迁移，别一刀一迁。** 首刀"排班修改窗"已按 #2197 路线**无 DDL 落地**：policy 先进 org-level attendance settings JSON（`shiftEditPolicy`），write-time 按受影响日期判窗。后续若要把排班合规（`shift_constraints`）、发布（`status`）、多班次（`slot`）、或持久锁窗（`locked_at`）落到 `attendance_shift_assignments`/`rule_sets`，这些 schema 变更再打一个协调 migration，再分层叠 service/UI（v1 阶段2 已是此意）。
 

--- a/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
+++ b/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
@@ -54,8 +54,8 @@
 | 排班修改窗 | MUST | ✅ | #2197（squash `2d4808fe`，2026-06-02）：org-level `shiftEditPolicy` 入 attendance settings JSON（默认 `unrestricted`，无 DDL）+ shift/rotation assignment POST/PUT/DELETE 6 写路由显式 422 `SHIFT_EDIT_WINDOW_EXCEEDED`；PUT/DELETE 同看 existing start date + next start date 防历史绕窗；unit + CI real-DB attendance integration 绿 |
 | 外勤审批 | MUST | ⬜ | 0 |
 | 内外勤卡合并 | MUST | ⬜ | 0（打卡抽屉只读） |
-| 加班↔调休 | MUST | ⬜ | 0 |
-| 假期过期管理 | MUST | ⬜ | 0 |
+| 加班↔调休 | MUST | ⬜ | C0–C3 + C4-1(#2270 inert) + **C4-2 merged #2274**（`4b3108737`：expiry scheduler + `expiresInDays` grant 写 `expires_at` + notifier scaffold，**无 DDL**）。CI real-DB attendance step 真跑且绿（`④ C4` 用例在 `attendance-plugin.test.ts` 88-test 文件 + `attendance-expiry-service.test.ts`）。**staging C4 smoke 未跑 → 未 ✅**（runbook `attendance-comp-leave-c4-2-staging-smoke-runbook-20260604.md`；staging:8082 sandbox 不可达 + 未部署 C4-2 + 需 SSH+SQL aging，按"停止并报告"处置） |
+| 假期过期管理 | MUST | ⬜ | 同上 C4 子链：`expires_at` 写入 + 过期 state-flow + 调度基座 merge #2274 / CI 绿；**未 ✅**（gated on staging smoke，见 runbook） |
 | 自动对班 | SHOULD | ⬜ | 0 |
 | 一天多班次 | SHOULD | ⬜ | 0 |
 | 排班发布/草稿 | SHOULD | ⬜ | 0 |


### PR DESCRIPTION
## What

Docs-only closeout for **#2274** (④ C4-2, merged `4b3108737`). Records the **passing staging C4 smoke** and backfills the ④ tracker rows `加班↔调休` / `假期过期管理` to `✅`.

## Staging evidence

- New staging endpoint verified: `https://23.254.236.11/health` → `healthy`.
- Deployed staging build: `8701c46e00c68ed19c226e7206f5456866f6b8ba` (contains #2274).
- Scheduler env: `ATTENDANCE_SCHEDULER_ENABLED=true`, `ATTENDANCE_SCHEDULER_INTERVAL_MS=5000`.
- Migration pre-check: `kysely_migration` count `177`; C1 ledger tables/columns present.
- Smoke result: `C4_STAGING_SMOKE_PASS` — 30d grant exact 720h, NULL-expiry lot untouched, deployed background scheduler expired the aged lot once, repeat tick idempotent, cleanup residue=0 and settings restored.

## Contents

- `docs/development/attendance-comp-leave-c4-2-staging-smoke-runbook-20260604.md` — keeps the reusable runbook and adds the 2026-06-04 PASS transcript/evidence.
- `docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md` — flips ④ rows to `✅` and records the C4 closeout evidence; notes that C5 notifications/reminders remain a separate follow-up.

Refs #2274 #2270 #2267 #2230 #2226