### PR TITLE
docs(multitable): record A6-2 operator UAT closeout

### DIFF
--- a/docs/development/multitable-automation-a6-2-suspend-resume-verification-20260603.md
+++ b/docs/development/multitable-automation-a6-2-suspend-resume-verification-20260603.md
@@ -1,7 +1,8 @@
 # A6-2 — suspend/resume runtime (admin-gated v1) — verification (2026-06-03)
 
 > Verifies the impl against the design-lock `multitable-automation-a6-2-suspend-resume-design-20260603.md`
-> (#2236). Backend-first; frontend (A6-2b) deferred. Built on a fresh worktree off `origin/main`.
+> (#2236). Initial backend-first verification was followed by A6-2b frontend and operator UAT closeout.
+> Built on a fresh worktree off `origin/main`.
 
 ## What shipped
 
@@ -32,7 +33,7 @@
   `resumed`, `initiatedBy` stamped · T3 double-resume → 409 · T4 unknown token → 404 · T5 legacy
   fail-closed (no suspension) · T6 trigger_event redacted · T7 rule-disabled → 409 (token NOT consumed) ·
   T8 rule-changed → 409 (D4b) · T9 record-missing → 404. **T1 also asserts the suspended READ path** —
-  `listByExecution` surfaces the descriptor-less `suspended` job view without throwing.
+  `listByExecution` surfaces a valid C1 `suspended` job view with the admin-detail suspend descriptor.
 - **No regressions:** A6-1 jobs real-DB **5/5**; action-type migration tests **6/6** (send_email delta +
   new wait_for_callback sync); `automation-runs-api` **24/24** (admin-gate count 3→4 confirms the resume
   route IS gated; **a suspended execution renders via the detail route** — 200, status `running`, suspended
@@ -87,10 +88,32 @@ Owner diff-review flagged 3 state-consistency / C1-contract blockers; all fixed 
   legacy steps and never carries it. Stale code comments updated to the real contract ("admin detail is
   the v1 token surface", not "never in the read plane / emitted on suspend").
 
+## Frontend + operator UAT closeout (2026-06-04)
+
+- **A6-2b frontend landed:** PR #2245 added the `wait_for_callback` rule-editor action,
+  auto-enables + locks `workflow_job_v1`, and exposes the admin Resume control from the
+  run detail view. PR #2248 reconciled the execution-plan tracker.
+- **Create/update reachability blocker fixed:** PR #2264 derived `AutomationService` action validation
+  from canonical `ALL_ACTION_TYPES`, closing the UI-save failure
+  `Invalid action_type: wait_for_callback`.
+- **Post-wait follow-up payload drift fixed:** PR #2272 makes UI-created `update_record`,
+  `create_record`, and `send_notification` follow-up actions emit the executor-shaped configs.
+- **Unsupported `lock_record` footgun removed:** PR #2278 hides `lock_record` from new advanced
+  action selections while its `meta_records.locked` storage contract is unsupported; existing
+  `lock_record` actions remain visible but disabled for compatibility.
+- **Operator UAT PASS:** issue #2257 was rerun against package
+  `metasheet-multitable-onprem-v2.5.0-a6-2-uat-followup-lock-gate-b37ff906`
+  (source `b37ff9066b4d1e78927393eb6317d2efefd2c1fe`). The values-free checklist verified
+  `wait_for_callback -> update_record` through the real UI: rule save, real record-created
+  trigger, suspended run detail with token, admin Resume, terminal `resolved`, both steps
+  resolved, and the target field updated. Negative guards passed for missing
+  `confirmSideEffects` (400), repeat resume (409), invalid token (404), and unauthenticated
+  admin execution API access (401).
+
 ## Red lines honored
 No delay/timer · no worker/claim · no branch/parallel · no BPMN · no approval-as-job · **no public
 endpoint / no token emitter** (admin-gated only) · no K3 / central RBAC / integration-core / contract.
 
 ## Remaining (separate opt-ins)
-A6-2b frontend (configure the action + surface suspended runs) · public webhook endpoint + token emitter
-(when a real consumer exists) · sequential-multi-wait stress · A6-3+ (branch / BPMN / approval-as-job).
+Public webhook endpoint + token emitter (when a real consumer exists) · delay/timer resume ·
+sequential-multi-wait stress · A6-3+ (branch / BPMN / approval-as-job).

--- a/docs/development/multitable-automation-a6-execution-plan-20260601.md
+++ b/docs/development/multitable-automation-a6-execution-plan-20260601.md
@@ -131,13 +131,15 @@ only missing link.
 
 ---
 
-## 2. A6-2 suspend/resume — ✅ LANDED 2026-06-03 (#2236 design-lock + #2237 impl + #2245 frontend)
+## 2. A6-2 suspend/resume — ✅ LANDED (#2236 design-lock + #2237 impl + #2245 frontend + #2257 UAT)
 
 > **✅ LANDED 2026-06-03 — PR #2237 (squash `c363a78db`); design-lock #2236.** Admin-gated v1, webhook-
 > first (delay/timer + worker/claim still deferred/red-lined). As-built detail + the 2 review rounds live
 > in `multitable-automation-a6-2-suspend-resume-{design,verification}-20260603.md` — **not re-derived
-> here**. A6-2b frontend (admin Resume UI + `wait_for_callback` editor) **landed 2026-06-03 — PR #2245
-> (squash `cee99c8e4`)**, frontend-only/no contract change. Original plan retained below for the record.
+> here**. A6-2b frontend (admin Resume UI + `wait_for_callback` editor) **landed 2026-06-04 — PR #2245
+> (squash `cee99c8e4`)**, frontend-only/no contract change. Operator UAT **PASS #2257** on the refreshed
+> package from `b37ff906` after #2264/#2272/#2278 cleared the save, follow-up-shape, and `lock_record`
+> footgun blockers. Original plan retained below for the record.
 
 - **Adds:** the `suspended` C1 status, a resume token, and an **external-event/webhook
   resume endpoint first**; delay/timer resume (and the durable scheduler + worker/claim

--- a/docs/development/multitable-automation-run-governance-todo-20260527.md
+++ b/docs/development/multitable-automation-run-governance-todo-20260527.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-27
 Scope: multitable automation run governance + whole-execution retry only
-Status: A0-A5 closed (2026-05-29); A6-1 COMPLETE end-to-end (runtime #2130 + enable-writer #2191 + admin UI toggle #2193, 2026-06) — rules can opt into the per-action WorkflowJob plane from the editor, no longer dormant; A6-2 suspend/resume backend (admin-gated v1, webhook/external resume) LANDED #2237 c363a78db (2026-06-03) + A6-2b frontend (admin Resume UI + `wait_for_callback` editor) LANDED #2245 cee99c8e4 (2026-06-04) — A6-2 now closed end-to-end; delay/timer resume deferred; A6-3..A6-5 remain frozen / demand-gated
+Status: A0-A5 closed (2026-05-29); A6-1 COMPLETE end-to-end (runtime #2130 + enable-writer #2191 + admin UI toggle #2193, 2026-06) — rules can opt into the per-action WorkflowJob plane from the editor, no longer dormant; A6-2 suspend/resume backend (admin-gated v1, webhook/external resume) LANDED #2237 c363a78db (2026-06-03) + A6-2b frontend (admin Resume UI + `wait_for_callback` editor) LANDED #2245 cee99c8e4 (2026-06-04) + operator UAT PASS #2257 (2026-06-04) — A6-2 now closed end-to-end; delay/timer resume deferred; A6-3..A6-5 remain frozen / demand-gated
 Companion: multitable-automation-run-governance-development-20260527.md
 Depends on (landed): C1 contract workflow-job-contract.ts (#1889, read-boundary wired only); RFC #1885
 
@@ -269,6 +269,7 @@ mark the convergence engine complete.
 - [x] A6-1 admin UI toggle (rule-editor checkbox) — LANDED #2193. **A6-1 COMPLETE end-to-end.**
 - [x] A6-2 suspend/resume runtime (backend, admin-gated v1; webhook/external resume) — LANDED #2237 c363a78db (2026-06-03).
 - [x] A6-2b suspend/resume frontend (admin Resume UI + `wait_for_callback` editor) — LANDED #2245 cee99c8e4 (2026-06-04). **A6-2 closed end-to-end.** delay/timer resume still deferred / demand-gated.
+- [x] A6-2 UI/operator UAT — PASS #2257 on package `metasheet-multitable-onprem-v2.5.0-a6-2-uat-followup-lock-gate-b37ff906`: `wait_for_callback -> update_record` saved through the UI, suspended, resumed from admin detail, reached terminal `resolved`, and passed the listed negative guards. UAT blockers cleared by #2264 (service validation), #2272 (executor-shaped follow-up configs), and #2278 (`lock_record` hidden/disabled while storage contract is unsupported).
 - [ ] A6-3 branch/parallel DAG runtime — not started.
 - [ ] A6-4 BPMN compile/preview adapter — not started.
 - [ ] A6-5 approval-as-job bridge — not started.


### PR DESCRIPTION
## Summary

- record the final #2257 A6-2 UI/operator UAT PASS against the refreshed `b37ff906` package
- reconcile A6-2 verification / execution-plan / TODO docs after #2245, #2264, #2272, and #2278
- remove stale wording that still treated A6-2b frontend as deferred

## Verification

- `git diff --check`

## Scope

Docs-only. No runtime, route, migration, frontend behavior, A6-3+, public webhook resume, token emitter, delay/timer, BPMN, or approval-as-job changes.
