### PR TITLE
feat(multitable): dashboard chart live preview

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -185,6 +185,7 @@ jobs:
             tests/integration/multitable-link-summary-display-field-mask.test.ts \
             tests/integration/multitable-form-context-submit-field-mask.test.ts \
             tests/integration/multitable-dashboard-chart-authz.test.ts \
+            tests/integration/multitable-dashboard-preview-data.test.ts \
             tests/integration/multitable-write-echo-field-mask.test.ts \
             tests/integration/multitable-create-echo-field-mask.test.ts \
             tests/integration/multitable-cross-sheet-related-echo-mask.test.ts \

--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -1718,6 +1718,15 @@ export class MultitableApiClient {
     return this.parseJson<ChartData>(res)
   }
 
+  async previewChartData(sheetId: string, input: ChartCreateInput): Promise<ChartData> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/charts/preview-data`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(toChartCreateWire(input)),
+    })
+    return this.parseJson<ChartData>(res)
+  }
+
   // --- Dashboards ---
   async listDashboards(sheetId: string): Promise<Dashboard[]> {
     const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/dashboards`)

--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -201,6 +201,27 @@
             <small v-if="!numericFields.length" class="meta-dashboard__hint">{{ viewRenderLabel('dashboard.noNumericFields', isZh) }}</small>
           </label>
           <div v-if="createChartError" class="meta-dashboard__error" data-error="create-chart">{{ createChartError }}</div>
+          <section class="meta-dashboard__preview" data-chart-preview="true">
+            <div class="meta-dashboard__preview-title">{{ viewRenderLabel('dashboard.livePreview', isZh) }}</div>
+            <div v-if="createChartDisabled" class="meta-dashboard__preview-empty" data-chart-preview-empty="true">
+              {{ viewRenderLabel('dashboard.previewFillRequired', isZh) }}
+            </div>
+            <div v-else-if="previewLoading" class="meta-dashboard__panel-loading" data-chart-preview-loading="true">
+              {{ viewRenderLabel('dashboard.loadingPreview', isZh) }}
+            </div>
+            <div v-else-if="previewError" class="meta-dashboard__error" data-chart-preview-error="true">
+              {{ viewRenderLabel('dashboard.previewError', isZh) }}
+            </div>
+            <div v-else-if="previewChartData" class="meta-dashboard__preview-chart" data-chart-preview-result="true">
+              <MetaChartRenderer
+                :chart-data="previewChartData"
+                :display-config="previewDisplayConfig"
+              />
+            </div>
+            <div v-else class="meta-dashboard__preview-empty" data-chart-preview-empty="true">
+              {{ viewRenderLabel('dashboard.previewWaiting', isZh) }}
+            </div>
+          </section>
         </div>
         <div class="meta-dashboard__modal-footer">
           <button class="meta-dashboard__btn" type="button" @click="showCreateChart = false">{{ viewRenderLabel('dashboard.cancel', isZh) }}</button>
@@ -217,7 +238,7 @@
 </template>
 
 <script setup lang="ts">
-import { ref, computed, watch, nextTick } from 'vue'
+import { ref, computed, watch, nextTick, onBeforeUnmount } from 'vue'
 import type { AggregationFunction, ChartType, Dashboard, DashboardPanel, ChartConfig, ChartCreateInput, ChartData, ChartDataSource, MetaField, MetaFieldType } from '../types'
 import type { MultitableApiClient } from '../api/client'
 import MetaChartRenderer from './MetaChartRenderer.vue'
@@ -244,6 +265,9 @@ const showCreateChart = ref(false)
 const editingChartId = ref<string | null>(null)
 const creatingChart = ref(false)
 const createChartError = ref('')
+const previewChartData = ref<ChartData | null>(null)
+const previewLoading = ref(false)
+const previewError = ref('')
 const editingName = ref(false)
 const nameInput = ref('')
 const nameInputRef = ref<HTMLInputElement | null>(null)
@@ -289,6 +313,7 @@ const createChartDisabled = computed(() => {
   if (requiresValueField.value && !chartDraft.value.valueFieldId) return true
   return false
 })
+const previewDisplayConfig = computed(() => buildChartInput(editingChart.value ?? undefined).displayConfig)
 
 const sortedPanels = computed(() => {
   if (!activeDashboard.value) return []
@@ -308,6 +333,7 @@ function resetChartDraft() {
     valueFieldId: '',
   }
   createChartError.value = ''
+  resetChartPreview()
 }
 
 function openCreateChart() {
@@ -329,6 +355,7 @@ function openEditChart(chartId: string) {
     valueFieldId: cfg.dataSource.aggregation.fieldId ?? '',
   }
   createChartError.value = ''
+  resetChartPreview()
   showAddPanel.value = false
   showCreateChart.value = true
 }
@@ -444,6 +471,54 @@ function buildChartInput(base?: ChartConfig): ChartCreateInput {
       ...(base?.displayConfig ?? {}),
       title: name,
     },
+  }
+}
+
+let previewTimer: ReturnType<typeof setTimeout> | null = null
+let previewSeq = 0
+
+function clearPreviewTimer() {
+  if (previewTimer) {
+    clearTimeout(previewTimer)
+    previewTimer = null
+  }
+}
+
+function resetChartPreview() {
+  clearPreviewTimer()
+  previewSeq += 1
+  previewChartData.value = null
+  previewLoading.value = false
+  previewError.value = ''
+}
+
+function scheduleChartPreview() {
+  clearPreviewTimer()
+  if (!showCreateChart.value || !props.client || createChartDisabled.value) {
+    resetChartPreview()
+    return
+  }
+  previewError.value = ''
+  previewTimer = setTimeout(() => {
+    void runChartPreview()
+  }, 300)
+}
+
+async function runChartPreview() {
+  if (!props.client || createChartDisabled.value) return
+  const seq = ++previewSeq
+  previewLoading.value = true
+  previewError.value = ''
+  try {
+    const data = await props.client.previewChartData(props.sheetId, buildChartInput(editingChart.value ?? undefined))
+    if (seq !== previewSeq) return
+    previewChartData.value = data
+  } catch {
+    if (seq !== previewSeq) return
+    previewChartData.value = null
+    previewError.value = 'preview_failed'
+  } finally {
+    if (seq === previewSeq) previewLoading.value = false
   }
 }
 
@@ -578,6 +653,21 @@ watch(groupableFields, () => {
     chartDraft.value.groupByFieldId = groupableFields.value[0].id
   }
 })
+
+watch(
+  () => [
+    showCreateChart.value,
+    chartDraft.value.name,
+    chartDraft.value.chartType,
+    chartDraft.value.groupByFieldId,
+    chartDraft.value.aggregation,
+    chartDraft.value.valueFieldId,
+    editingDateGrouped.value,
+  ],
+  scheduleChartPreview,
+)
+
+onBeforeUnmount(resetChartPreview)
 </script>
 
 <style scoped>
@@ -734,6 +824,18 @@ watch(groupableFields, () => {
 
 .meta-dashboard__hint { color: #94a3b8; font-weight: 400; }
 .meta-dashboard__error { color: #b91c1c; font-size: 12px; }
+
+.meta-dashboard__preview {
+  margin-top: 8px;
+  padding: 10px 12px;
+  border: 1px solid #e2e8f0;
+  border-radius: 10px;
+  background: #f8fafc;
+}
+
+.meta-dashboard__preview-title { font-size: 12px; font-weight: 700; color: #334155; margin-bottom: 8px; }
+.meta-dashboard__preview-empty { font-size: 12px; color: #94a3b8; }
+.meta-dashboard__preview-chart { background: #fff; border-radius: 8px; padding: 10px; }
 
 .meta-dashboard__chart-option {
   display: flex;

--- a/apps/web/src/multitable/utils/meta-view-render-labels.ts
+++ b/apps/web/src/multitable/utils/meta-view-render-labels.ts
@@ -98,6 +98,11 @@ export type MetaViewRenderLabelKey =
   | 'dashboard.noGroupableFields'
   | 'dashboard.dateGroupingLocked'
   | 'dashboard.noNumericFields'
+  | 'dashboard.livePreview'
+  | 'dashboard.previewFillRequired'
+  | 'dashboard.loadingPreview'
+  | 'dashboard.previewWaiting'
+  | 'dashboard.previewError'
   | 'dashboard.createChartError'
   | 'dashboard.editChartTitle'
   | 'dashboard.editChart'
@@ -200,6 +205,11 @@ export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'dashboard.noGroupableFields',
   'dashboard.dateGroupingLocked',
   'dashboard.noNumericFields',
+  'dashboard.livePreview',
+  'dashboard.previewFillRequired',
+  'dashboard.loadingPreview',
+  'dashboard.previewWaiting',
+  'dashboard.previewError',
   'dashboard.createChartError',
   'dashboard.editChartTitle',
   'dashboard.editChart',
@@ -309,6 +319,11 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
     zh: '已按日期分组；此编辑器会保留现有日期分组。',
   },
   'dashboard.noNumericFields': { en: 'No readable numeric fields available.', zh: '没有可读取的数值字段。' },
+  'dashboard.livePreview': { en: 'Live preview', zh: '实时预览' },
+  'dashboard.previewFillRequired': { en: 'Complete the chart fields to preview.', zh: '填写完整图表字段后可预览。' },
+  'dashboard.loadingPreview': { en: 'Loading preview...', zh: '正在加载预览...' },
+  'dashboard.previewWaiting': { en: 'Preview will appear here.', zh: '预览将显示在这里。' },
+  'dashboard.previewError': { en: 'Preview failed. Save is not blocked.', zh: '预览失败，不影响保存。' },
   'dashboard.createChartError': { en: 'Failed to create chart.', zh: '创建图表失败。' },
   'dashboard.editChartTitle': { en: 'Edit chart', zh: '编辑图表' },
   'dashboard.editChart': { en: 'Edit', zh: '编辑' },

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -5,6 +5,12 @@ function flushPromises() {
   return new Promise<void>((resolve) => setTimeout(resolve, 0)).then(() => nextTick())
 }
 
+async function settleMicrotasksAndRender() {
+  await Promise.resolve()
+  await Promise.resolve()
+  await nextTick()
+}
+
 // MetaDashboardView renders MetaChartRenderer, which now uses ECharts (needs a canvas absent in
 // jsdom) → mock the runtime entry points so the dashboard mounts cleanly.
 vi.mock('echarts/core', () => ({
@@ -120,6 +126,7 @@ function mount(props: Record<string, unknown>) {
 
 describe('MetaDashboardView', () => {
   afterEach(() => {
+    vi.useRealTimers()
     useLocale().setLocale('en')
     document.body.innerHTML = ''
     vi.restoreAllMocks()
@@ -253,6 +260,83 @@ describe('MetaDashboardView', () => {
     ])
     const dataLoads = fetchFn.mock.calls.filter(([url]: [string]) => url.includes('/charts/chart_new/data'))
     expect(dataLoads.length).toBe(1)
+  })
+
+  it('loads a debounced live preview without gating chart save', async () => {
+    const dashboard = fakeDashboard({ panels: [] })
+    const { client } = mockClient([dashboard], [])
+    const previewSpy = vi.spyOn(client, 'previewChartData').mockResolvedValue({
+      chartType: 'number',
+      dataPoints: [{ label: 'Preview total', value: 42 }],
+      total: 42,
+    })
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    vi.useFakeTimers()
+    ;(container.querySelector('[data-action="create-chart"]') as HTMLButtonElement).click()
+    await nextTick()
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Preview chart'
+    nameInput.dispatchEvent(new Event('input'))
+    await nextTick()
+
+    const submit = container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement
+    expect(submit.disabled).toBe(false)
+    expect(previewSpy).not.toHaveBeenCalled()
+
+    await vi.advanceTimersByTimeAsync(300)
+    await nextTick()
+
+    expect(previewSpy).toHaveBeenCalledTimes(1)
+    expect(previewSpy).toHaveBeenCalledWith('sheet_1', expect.objectContaining({
+      name: 'Preview chart',
+      dataSource: expect.objectContaining({ groupByFieldId: 'fld_status' }),
+    }))
+    const previewNumber = container.querySelector('[data-chart-preview-result] [data-chart="number"]')
+    expect(previewNumber?.textContent).toContain('42')
+    expect(submit.disabled).toBe(false)
+  })
+
+  it('drops stale live-preview responses when chart draft changes quickly', async () => {
+    const dashboard = fakeDashboard({ panels: [] })
+    const { client } = mockClient([dashboard], [])
+    const resolvers: Array<(value: ChartData) => void> = []
+    vi.spyOn(client, 'previewChartData').mockImplementation(() => new Promise((resolve) => {
+      resolvers.push(resolve)
+    }))
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+
+    vi.useFakeTimers()
+    ;(container.querySelector('[data-action="create-chart"]') as HTMLButtonElement).click()
+    await nextTick()
+    const typeSelect = container.querySelector('[data-field="chart-type"]') as HTMLSelectElement
+    typeSelect.value = 'number'
+    typeSelect.dispatchEvent(new Event('change'))
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'First preview'
+    nameInput.dispatchEvent(new Event('input'))
+    await nextTick()
+
+    await vi.advanceTimersByTimeAsync(300)
+    expect(resolvers).toHaveLength(1)
+
+    nameInput.value = 'Second preview'
+    nameInput.dispatchEvent(new Event('input'))
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(300)
+    expect(resolvers).toHaveLength(2)
+
+    resolvers[1]({ chartType: 'number', dataPoints: [{ label: 'new', value: 2 }], total: 2 })
+    await settleMicrotasksAndRender()
+    const previewNumber = () => container.querySelector('[data-chart-preview-result] [data-chart="number"]')?.textContent ?? ''
+    expect(previewNumber()).toContain('2')
+
+    resolvers[0]({ chartType: 'number', dataPoints: [{ label: 'old', value: 1 }], total: 1 })
+    await settleMicrotasksAndRender()
+    expect(previewNumber()).toContain('2')
+    expect(previewNumber()).not.toContain('1')
   })
 
   it('offers only chart-compatible fields and blocks value aggregations without a numeric field', async () => {

--- a/packages/core-backend/src/multitable/dashboard-service.ts
+++ b/packages/core-backend/src/multitable/dashboard-service.ts
@@ -235,6 +235,10 @@ export class DashboardService {
     const chart = await this.getChart(chartId)
     if (!chart) throw new Error(`Chart not found: ${chartId}`)
 
+    return this.computeChartDataForConfig(chart)
+  }
+
+  async computeChartDataForConfig(chart: ChartConfig): Promise<ChartData> {
     let records: Array<{ data: Record<string, unknown> }> = []
     if (this.recordProvider) {
       records = await this.recordProvider(chart.sheetId)

--- a/packages/core-backend/src/routes/dashboard.ts
+++ b/packages/core-backend/src/routes/dashboard.ts
@@ -27,9 +27,10 @@
 
 import type { Request, Response } from 'express'
 import { Router } from 'express'
+import { randomUUID } from 'crypto'
 import { poolManager } from '../integration/db/connection-pool'
 import type { MultitableCapabilities } from '../multitable/access'
-import type { ChartConfig } from '../multitable/charts'
+import type { AggregationFunction, ChartConfig, ChartCreateInput, ChartType } from '../multitable/charts'
 import type { ChartData } from '../multitable/chart-aggregation-service'
 import { DashboardService } from '../multitable/dashboard-service'
 import type { MultitableField } from '../multitable/field-codecs'
@@ -43,6 +44,10 @@ import {
 } from '../multitable/permission-service'
 
 const dashboardService = new DashboardService()
+const CHART_TYPES = new Set<ChartType>(['bar', 'line', 'pie', 'number', 'table'])
+const AGGREGATION_FUNCTIONS = new Set<AggregationFunction>(['count', 'sum', 'avg', 'min', 'max', 'count_distinct'])
+const AGGREGATIONS_REQUIRING_FIELD = new Set<AggregationFunction>(['sum', 'avg', 'min', 'max', 'count_distinct'])
+const DATE_GROUPINGS = new Set(['day', 'week', 'month', 'quarter', 'year'])
 
 /** Expose the shared service for tests or external wiring. */
 export function getDashboardService(): DashboardService {
@@ -168,6 +173,59 @@ function restrictedChartData(chart: ChartConfig): ChartData {
   }
 }
 
+function readString(value: unknown): string | undefined {
+  return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
+}
+
+function buildPreviewChart(sheetId: string, userId: string, body: unknown): ChartConfig {
+  const input = (body ?? {}) as Partial<ChartCreateInput> & {
+    chartType?: unknown
+    type?: unknown
+    displayConfig?: unknown
+    display?: unknown
+  }
+  const chartType = readString(input.type) ?? readString(input.chartType)
+  if (!chartType || !CHART_TYPES.has(chartType as ChartType)) {
+    throw new Error('Invalid chart type')
+  }
+  const source = input.dataSource
+  if (!source || typeof source !== 'object') {
+    throw new Error('dataSource is required')
+  }
+  const aggregation = (source as ChartConfig['dataSource']).aggregation
+  if (!aggregation || typeof aggregation !== 'object') {
+    throw new Error('aggregation is required')
+  }
+  const aggregationFunction = readString(aggregation.function)
+  if (!aggregationFunction || !AGGREGATION_FUNCTIONS.has(aggregationFunction as AggregationFunction)) {
+    throw new Error('Invalid aggregation function')
+  }
+  const dateFieldId = readString((source as ChartConfig['dataSource']).dateFieldId)
+  const dateGrouping = readString((source as ChartConfig['dataSource']).dateGrouping)
+  const groupByFieldId = readString((source as ChartConfig['dataSource']).groupByFieldId)
+  if (dateGrouping && !DATE_GROUPINGS.has(dateGrouping)) {
+    throw new Error('Invalid date grouping')
+  }
+  if ((!dateFieldId || !dateGrouping) && !groupByFieldId) {
+    throw new Error('groupByFieldId or date grouping is required')
+  }
+  if (AGGREGATIONS_REQUIRING_FIELD.has(aggregationFunction as AggregationFunction) && !readString(aggregation.fieldId)) {
+    throw new Error('value field is required for this aggregation')
+  }
+  const now = new Date().toISOString()
+  return {
+    id: `chart_preview_${randomUUID()}`,
+    name: readString(input.name) ?? 'Preview chart',
+    type: chartType as ChartType,
+    sheetId,
+    viewId: readString(input.viewId),
+    dataSource: source as ChartConfig['dataSource'],
+    display: (input.display ?? input.displayConfig ?? {}) as ChartConfig['display'],
+    createdBy: userId,
+    createdAt: now,
+  }
+}
+
 export function dashboardRouter() {
   const router = Router()
 
@@ -197,6 +255,29 @@ export function dashboardRouter() {
         createdBy: auth.userId,
       })
       res.status(201).json(chart)
+    } catch (err: unknown) {
+      res.status(400).json({ error: (err as Error).message })
+    }
+  })
+
+  /** POST /api/multitable/sheets/:sheetId/charts/preview-data — compute unsaved chart preview data */
+  router.post('/sheets/:sheetId/charts/preview-data', async (req: Request, res: Response) => {
+    try {
+      const auth = await requireSheetRead(req, res, req.params.sheetId)
+      if (!auth) return
+      const chart = buildPreviewChart(req.params.sheetId, auth.userId, req.body)
+      const allowedFieldIds = await loadAllowedFieldIds(
+        auth.query,
+        req.params.sheetId,
+        auth.userId,
+        auth.capabilities,
+      )
+      if (isChartDataRestricted(chart, allowedFieldIds)) {
+        res.json(restrictedChartData(chart))
+        return
+      }
+      const data = await dashboardService.computeChartDataForConfig(chart)
+      res.json(data)
     } catch (err: unknown) {
       res.status(400).json({ error: (err as Error).message })
     }

--- a/packages/core-backend/tests/integration/multitable-dashboard-preview-data.test.ts
+++ b/packages/core-backend/tests/integration/multitable-dashboard-preview-data.test.ts
@@ -1,0 +1,193 @@
+/**
+ * Real-DB integration test for Dashboard BI v2-b2 — inline chart preview data.
+ * Design-lock: docs/development/multitable-dashboard-bi-v2b2-preview-design-20260604.md (#2283).
+ *
+ * The preview endpoint must compute unsaved chart configs through the same engine and
+ * field gate as persisted chart data. It deliberately avoids /dashboard/query because
+ * that route has a narrower widget model and a different response shape.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { dashboardRouter, getDashboardService } from '../../src/routes/dashboard'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_biv2b2_${TS}`
+const SHEET_ID = `sheet_biv2b2_${TS}`
+const FLD_STATUS = `fld_biv2b2_status_${TS}`
+const FLD_AMOUNT = `fld_biv2b2_amount_${TS}`
+const FLD_DATE = `fld_biv2b2_date_${TS}`
+const FLD_SECRET = `fld_biv2b2_secret_${TS}`
+const CHART_PARITY_ID = `chart_biv2b2_parity_${TS}`
+const USER_ID = `u_biv2b2_reader_${TS}`
+const USER_DENIED = `u_biv2b2_denied_${TS}`
+
+let app: Express
+let testUserId = USER_ID
+let testPerms: string[] = ['multitable:read']
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+const asJson = (value: unknown) => JSON.stringify(value)
+
+const rows = [
+  { data: { [FLD_STATUS]: 'open', [FLD_AMOUNT]: 10, [FLD_DATE]: '2026-01-15', [FLD_SECRET]: 'secret-canary' } },
+  { data: { [FLD_STATUS]: 'open', [FLD_AMOUNT]: 20, [FLD_DATE]: '2026-01-20', [FLD_SECRET]: 'secret-canary' } },
+  { data: { [FLD_STATUS]: 'closed', [FLD_AMOUNT]: 30, [FLD_DATE]: '2026-02-10', [FLD_SECRET]: 'other' } },
+]
+
+function installUser(req: express.Request, _res: express.Response, next: express.NextFunction) {
+  ;(req as any).user = testUserId ? { id: testUserId, roles: [], perms: testPerms } : undefined
+  next()
+}
+
+function preview(payload: Record<string, unknown>) {
+  return request(app)
+    .post(`/api/multitable/sheets/${SHEET_ID}/charts/preview-data`)
+    .send(payload)
+}
+
+function normalizeChartData(data: Record<string, unknown>) {
+  const { chartId: _chartId, ...rest } = data
+  return rest
+}
+
+describeIfDatabase('Dashboard BI v2-b2 preview-data endpoint (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use(installUser)
+    app.use('/api/multitable', dashboardRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'BI v2-b2 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SHEET_ID, BASE_ID, 'BI v2-b2 Sheet'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_STATUS, SHEET_ID, 'Status', 'string', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_AMOUNT, SHEET_ID, 'Amount', 'number', '{}', 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_DATE, SHEET_ID, 'Date', 'date', '{}', 3])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_SECRET, SHEET_ID, 'Secret', 'string', '{}', 4])
+    await q(
+      'INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)',
+      [SHEET_ID, FLD_SECRET, 'user', USER_DENIED, false, false],
+    )
+    await q(
+      `INSERT INTO multitable_charts (id, name, type, sheet_id, data_source, display, created_by)
+       VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7)`,
+      [
+        CHART_PARITY_ID,
+        'Persisted parity chart',
+        'bar',
+        SHEET_ID,
+        asJson({ groupByFieldId: FLD_STATUS, aggregation: { function: 'sum', fieldId: FLD_AMOUNT } }),
+        asJson({ title: 'Persisted parity chart' }),
+        USER_ID,
+      ],
+    )
+  })
+
+  beforeEach(() => {
+    testUserId = USER_ID
+    testPerms = ['multitable:read']
+    getDashboardService().setRecordProvider(async (sheetId: string) => (sheetId === SHEET_ID ? rows : []))
+  })
+
+  afterAll(async () => {
+    getDashboardService().setRecordProvider(async () => [])
+    await q('DELETE FROM multitable_charts WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('P1: preview matches persisted chart data for equivalent config', async () => {
+    const persisted = await request(app).get(`/api/multitable/sheets/${SHEET_ID}/charts/${CHART_PARITY_ID}/data`)
+    expect(persisted.status).toBe(200)
+
+    const res = await preview({
+      name: 'Unsaved parity chart',
+      type: 'bar',
+      dataSource: { groupByFieldId: FLD_STATUS, aggregation: { function: 'sum', fieldId: FLD_AMOUNT } },
+      display: { title: 'Unsaved parity chart' },
+    })
+    expect(res.status).toBe(200)
+    expect(normalizeChartData(res.body)).toEqual(normalizeChartData(persisted.body))
+  })
+
+  test('P2: preview supports cases outside /dashboard/query (date grouping, number max, table max)', async () => {
+    const date = await preview({
+      name: 'By month',
+      type: 'line',
+      dataSource: { dateFieldId: FLD_DATE, dateGrouping: 'month', aggregation: { function: 'count' } },
+    })
+    expect(date.status).toBe(200)
+    expect(date.body.chartType).toBe('line')
+    expect(date.body.dataPoints.map((point: { label: string }) => point.label)).toContain('2026-01')
+
+    const number = await preview({
+      name: 'Max amount',
+      type: 'number',
+      dataSource: { groupByFieldId: FLD_STATUS, aggregation: { function: 'max', fieldId: FLD_AMOUNT } },
+    })
+    expect(number.status).toBe(200)
+    expect(number.body.chartType).toBe('number')
+    expect(number.body.total).toBe(30)
+
+    const table = await preview({
+      name: 'Table max',
+      type: 'table',
+      dataSource: { groupByFieldId: FLD_STATUS, aggregation: { function: 'max', fieldId: FLD_AMOUNT } },
+    })
+    expect(table.status).toBe(200)
+    expect(table.body.chartType).toBe('table')
+    expect(table.body.dataPoints).toEqual(expect.arrayContaining([
+      expect.objectContaining({ label: 'open', value: 20 }),
+      expect.objectContaining({ label: 'closed', value: 30 }),
+    ]))
+  })
+
+  test('P3: denied referenced field returns restricted state without computing records', async () => {
+    testUserId = USER_DENIED
+    const provider = vi.fn(async () => rows)
+    getDashboardService().setRecordProvider(provider)
+
+    const res = await preview({
+      name: 'Denied secret',
+      type: 'bar',
+      dataSource: { groupByFieldId: FLD_SECRET, aggregation: { function: 'count' } },
+    })
+    expect(res.status).toBe(200)
+    expect(res.body).toMatchObject({
+      chartType: 'bar',
+      dataPoints: [],
+      total: 0,
+      metadata: { restricted: true, recordCount: 0 },
+    })
+    expect(JSON.stringify(res.body)).not.toContain('secret-canary')
+    expect(provider).not.toHaveBeenCalled()
+  })
+
+  test('P4: invalid preview config returns 400 instead of computing a misleading chart', async () => {
+    const res = await preview({
+      name: 'Missing value',
+      type: 'bar',
+      dataSource: { groupByFieldId: FLD_STATUS, aggregation: { function: 'sum' } },
+    })
+    expect(res.status).toBe(400)
+    expect(JSON.stringify(res.body)).toContain('value field')
+
+    const date = await preview({
+      name: 'Invalid date grouping',
+      type: 'line',
+      dataSource: { dateFieldId: FLD_DATE, dateGrouping: 'decade', aggregation: { function: 'count' } },
+    })
+    expect(date.status).toBe(400)
+    expect(JSON.stringify(date.body)).toContain('date grouping')
+  })
+})


### PR DESCRIPTION
## Summary
- Add `POST /api/multitable/sheets/:sheetId/charts/preview-data` for inline chart preview data, using the same chart aggregation engine and field gate as persisted chart data.
- Add `client.previewChartData` and a debounced/stale-dropped live preview in the dashboard chart create/edit form.
- Wire the new real-DB preview test into `plugin-tests.yml`.

## Scope
- Implements Dashboard BI v2-b2 per #2283: Option B faithful preview.
- No persistence, no new aggregation logic, no RBAC/auth changes.
- `/dashboard/query` remains untouched.

## Verification
- `pnpm --filter @metasheet/web exec vitest run tests/multitable-dashboard-view.spec.ts tests/meta-view-render-labels.spec.ts --watch=false` (24/24)
- `DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_test pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-dashboard-preview-data.test.ts --reporter=dot` (5/5)
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/chart-dashboard.test.ts tests/unit/dashboard-routes-wiring.test.ts --reporter=dot` (56/56)
- `DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_test pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-dashboard-chart-authz.test.ts tests/integration/multitable-view-aggregate.test.ts --reporter=dot` (24/24)
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/multitable-egress-coverage-guard.test.ts --reporter=dot` (1/1)
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/web build`
- `git diff --check HEAD~1..HEAD`
