### PR TITLE
feat(data-adapters): PLM integration capability handshake client (C1)

### DIFF
--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -632,6 +632,39 @@ const YUANTUS_SUPPORTED_OPERATIONS = [
   'cad_review_update',
 ]
 
+/**
+ * PLM-COLLAB Phase 2.5 (Integration Handshake) consumer types: the advisory capability
+ * manifest returned by the provider's `GET /api/v1/integrations/capabilities`. ADVISORY
+ * ONLY -- used to decide UI degradation / entry display; NEVER an authorization decision
+ * (the PLM provider still enforces is_entitled at every feature endpoint).
+ */
+export interface IntegrationFeatureCapability {
+  supported: boolean;
+  api_version: string | null;
+  entitled: boolean;
+  cache_scope?: { supported?: string; entitled?: string };
+  scenarios?: string[];
+  actions?: string[];
+  action_status?: string;
+}
+
+export interface IntegrationCapabilityManifest {
+  schema_version: string;
+  provider: string;
+  advisory: boolean;
+  features: Record<string, IntegrationFeatureCapability>;
+}
+
+/**
+ * Result of querying the manifest. The handshake degrades gracefully: a legacy/non-yuantus
+ * PLM yields `unsupported-mode`, and an older PLM without the endpoint (404/error) yields
+ * `unavailable`. The consumer's safe default for both is to HIDE the automation entries
+ * rather than assume support.
+ */
+export type IntegrationCapabilitiesResult =
+  | { available: true; manifest: IntegrationCapabilityManifest }
+  | { available: false; reason: 'unsupported-mode' | 'unavailable' };
+
 export class PLMAdapter extends HTTPAdapter {
   private mockMode = false;
   private apiMode: PLMApiMode = 'legacy';
@@ -762,6 +795,10 @@ export class PLMAdapter extends HTTPAdapter {
 
     this.logger.info(`PLM Adapter connecting to ${this.config.connection.url}`);
     await super.connect();
+    // PLM-COLLAB P2.5: warm/refresh the integration capability cache after a real connect
+    // (fire-and-forget; refreshIntegrationCapabilities degrades gracefully and never throws,
+    // so this never blocks or fails connect).
+    void this.refreshIntegrationCapabilities();
   }
 
   private withTrailingSlash(path: string): string {
@@ -959,6 +996,92 @@ export class PLMAdapter extends HTTPAdapter {
     } catch (_err) {
       return this.testConnection()
     }
+  }
+
+  // PLM-COLLAB Phase 2.5 (Integration Handshake) consumer: advisory capability manifest.
+  private cachedIntegrationCapabilities: IntegrationCapabilitiesResult | null = null;
+
+  /**
+   * Fetch the PLM integration capability manifest so the UI can degrade gracefully
+   * (show/hide automation entries by supported/entitled). ADVISORY ONLY -- it never
+   * authorizes anything; the PLM still enforces entitlement at each feature endpoint.
+   *
+   * Successful results are cached on the instance (cleared on (re)connect via
+   * refreshIntegrationCapabilities). Failures are NOT cached, so a transient error or a
+   * just-upgraded PLM is retried on the next call. Graceful degradation (F1): a
+   * legacy/non-yuantus PLM -> `unsupported-mode`; a PLM without the endpoint (404/error)
+   * -> `unavailable`. The consumer's safe default for both is to HIDE the entries.
+   */
+  async getIntegrationCapabilities(): Promise<IntegrationCapabilitiesResult> {
+    if (this.cachedIntegrationCapabilities) {
+      return this.cachedIntegrationCapabilities;
+    }
+    if (this.mockMode) {
+      const mock: IntegrationCapabilitiesResult = {
+        available: true,
+        manifest: {
+          schema_version: 'v1',
+          provider: 'yuantus-plm',
+          advisory: true,
+          features: {
+            approval_automation: {
+              supported: true,
+              api_version: 'v1',
+              entitled: true,
+              cache_scope: { supported: 'global', entitled: 'tenant' },
+              scenarios: ['eco'],
+              actions: ['notify'],
+              action_status: 'stubbed',
+            },
+          },
+        },
+      };
+      this.cachedIntegrationCapabilities = mock;
+      return mock;
+    }
+    if (this.apiMode !== 'yuantus') {
+      return { available: false, reason: 'unsupported-mode' };
+    }
+    try {
+      const result = await this.query<IntegrationCapabilityManifest>(
+        '/api/v1/integrations/capabilities',
+      );
+      const manifest =
+        result.data && result.data.length > 0 ? result.data[0] : null;
+      // Top-level shape validation: confirm this really is the yuantus-plm advisory
+      // manifest, so a misconfigured proxy or an unrelated/old endpoint that happens to
+      // return JSON with a `features` key is not a false positive. schema_version is only
+      // required to be PRESENT (not exactly "v1"): the provider commits to additive-only
+      // schema evolution, so a v1 consumer must still accept a forward-compatible future
+      // version rather than degrade on it.
+      if (
+        !manifest ||
+        manifest.provider !== 'yuantus-plm' ||
+        manifest.advisory !== true ||
+        typeof manifest.schema_version !== 'string' ||
+        manifest.schema_version.length === 0 ||
+        !manifest.features ||
+        typeof manifest.features !== 'object'
+      ) {
+        return { available: false, reason: 'unavailable' };
+      }
+      const resolved: IntegrationCapabilitiesResult = { available: true, manifest };
+      this.cachedIntegrationCapabilities = resolved;
+      return resolved;
+    } catch (_err) {
+      // F1: older PLM / no endpoint / transient error -> advertise unavailable, do not
+      // cache (retry next call), never throw (the handshake must not break the consumer).
+      return { available: false, reason: 'unavailable' };
+    }
+  }
+
+  /**
+   * Clear the cached manifest and re-fetch. Called after (re)connect so a reconnect (or a
+   * PLM upgrade) refreshes the advertised capabilities. Never throws.
+   */
+  async refreshIntegrationCapabilities(): Promise<void> {
+    this.cachedIntegrationCapabilities = null;
+    await this.getIntegrationCapabilities();
   }
 
   async getProducts(options?: PLMQueryOptions): Promise<QueryResult<PLMProduct>> {

--- a/packages/core-backend/tests/unit/plm-adapter-capabilities.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-capabilities.test.ts
@@ -1,0 +1,136 @@
+import { describe, it, expect, vi } from 'vitest'
+import { PLMAdapter } from '../../src/data-adapters/PLMAdapter'
+
+const createAdapter = () => {
+  const configService = { get: vi.fn().mockResolvedValue(undefined) }
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+  const adapter = new PLMAdapter(configService as any, logger as any)
+  ;(adapter as any).apiMode = 'yuantus'
+  ;(adapter as any).mockMode = false
+  return adapter
+}
+
+const MANIFEST = {
+  schema_version: 'v1',
+  provider: 'yuantus-plm',
+  advisory: true,
+  features: {
+    approval_automation: {
+      supported: true,
+      api_version: 'v1',
+      entitled: true,
+      cache_scope: { supported: 'global', entitled: 'tenant' },
+      scenarios: ['eco'],
+      actions: ['notify'],
+      action_status: 'stubbed',
+    },
+    bom_multitable: {
+      supported: false,
+      api_version: null,
+      entitled: false,
+      cache_scope: { supported: 'global', entitled: 'tenant' },
+    },
+  },
+}
+
+describe('PLMAdapter integration capabilities (PLM-COLLAB P2.5 handshake)', () => {
+  it('returns the typed manifest in yuantus mode', async () => {
+    const adapter = createAdapter()
+    ;(adapter as any).query = vi.fn().mockResolvedValue({ data: [MANIFEST] })
+
+    const result = await adapter.getIntegrationCapabilities()
+
+    expect(result.available).toBe(true)
+    if (result.available) {
+      expect(result.manifest.advisory).toBe(true)
+      expect(result.manifest.features.approval_automation.supported).toBe(true)
+      expect(result.manifest.features.approval_automation.entitled).toBe(true)
+      expect(result.manifest.features.approval_automation.action_status).toBe('stubbed')
+      expect(result.manifest.features.bom_multitable.supported).toBe(false)
+    }
+  })
+
+  it('degrades to unavailable when the endpoint is absent (404/error)', async () => {
+    const adapter = createAdapter()
+    ;(adapter as any).query = vi
+      .fn()
+      .mockRejectedValue(new Error('Request failed with status code 404'))
+
+    const result = await adapter.getIntegrationCapabilities()
+
+    expect(result).toEqual({ available: false, reason: 'unavailable' })
+  })
+
+  it('degrades to unsupported-mode for a non-yuantus PLM without attempting a fetch', async () => {
+    const adapter = createAdapter()
+    ;(adapter as any).apiMode = 'legacy'
+    const queryMock = vi.fn()
+    ;(adapter as any).query = queryMock
+
+    const result = await adapter.getIntegrationCapabilities()
+
+    expect(result).toEqual({ available: false, reason: 'unsupported-mode' })
+    expect(queryMock).not.toHaveBeenCalled()
+  })
+
+  it('caches a successful manifest (a second call does not re-fetch)', async () => {
+    const adapter = createAdapter()
+    const queryMock = vi.fn().mockResolvedValue({ data: [MANIFEST] })
+    ;(adapter as any).query = queryMock
+
+    await adapter.getIntegrationCapabilities()
+    await adapter.getIntegrationCapabilities()
+
+    expect(queryMock).toHaveBeenCalledTimes(1)
+  })
+
+  it('refresh clears the cache and re-fetches', async () => {
+    const adapter = createAdapter()
+    const queryMock = vi.fn().mockResolvedValue({ data: [MANIFEST] })
+    ;(adapter as any).query = queryMock
+
+    await adapter.getIntegrationCapabilities()
+    await adapter.refreshIntegrationCapabilities()
+    await adapter.getIntegrationCapabilities()
+
+    expect(queryMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('does not cache a failure (retries on the next call)', async () => {
+    const adapter = createAdapter()
+    const queryMock = vi
+      .fn()
+      .mockRejectedValueOnce(new Error('boom'))
+      .mockResolvedValueOnce({ data: [MANIFEST] })
+    ;(adapter as any).query = queryMock
+
+    const first = await adapter.getIntegrationCapabilities()
+    const second = await adapter.getIntegrationCapabilities()
+
+    expect(first.available).toBe(false)
+    expect(second.available).toBe(true)
+    expect(queryMock).toHaveBeenCalledTimes(2)
+  })
+
+  it('rejects a false-positive response (wrong provider / not advisory) as unavailable', async () => {
+    const adapter = createAdapter()
+    ;(adapter as any).query = vi.fn().mockResolvedValue({
+      data: [{ provider: 'some-other-service', advisory: false, schema_version: 'v1', features: { x: {} } }],
+    })
+
+    const result = await adapter.getIntegrationCapabilities()
+
+    expect(result).toEqual({ available: false, reason: 'unavailable' })
+  })
+
+  it('accepts a forward-compatible future schema_version (additive evolution)', async () => {
+    const adapter = createAdapter()
+    ;(adapter as any).query = vi
+      .fn()
+      .mockResolvedValue({ data: [{ ...MANIFEST, schema_version: 'v2' }] })
+
+    const result = await adapter.getIntegrationCapabilities()
+
+    expect(result.available).toBe(true)
+  })
+})


### PR DESCRIPTION
## C1 — PLM integration capability handshake client (PLM-COLLAB Phase 2.5 consumer)

Starts closing the cross-repo loop for the PLM integration handshake on the MetaSheet
(consumer) side: `PLMAdapter.getIntegrationCapabilities()` queries the provider's advisory
manifest `GET /api/v1/integrations/capabilities` so the UI can degrade gracefully by
`supported` / `entitled` / `api_version` / `action_status`.

### Behavior
- **Advisory only (F3):** the manifest is a UI/degradation hint, NEVER an authorization
  decision — the PLM still enforces `is_entitled` at every feature endpoint.
- **Graceful degradation (F1):** legacy/non-yuantus mode → `unsupported-mode`; a PLM
  without the endpoint / 404 / network error → `unavailable`. The safe default for both is
  to HIDE automation entries (never assume support).
- **Caching (F2):** successful results are cached on the adapter instance; failures are NOT
  cached (retry next call). `refreshIntegrationCapabilities()` clears + re-fetches and is
  warmed fire-and-forget after a real connect.

### Scope
Adapter consumption + safe degradation + cache semantics only. No route (C2 follow-up), no
frontend UI (C3 follow-up), no pact change.

### Pact: intentionally no required interaction
C1 intentionally does not add a required pact interaction for
`/api/v1/integrations/capabilities`. The capability manifest is advisory/optional; old PLM
instances may not expose it. Consumer behavior is guarded by unit tests: success caches,
failure does not cache, unavailable/unsupported safely hides upgrade entries. Pact coverage
can be revisited only when we decide all supported PLM versions must expose this endpoint.

### Verification
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`: 0 errors.
- New `tests/unit/plm-adapter-capabilities.test.ts` (6 tests): typed manifest in yuantus mode;
  404/error → `unavailable`; non-yuantus → `unsupported-mode` (no fetch attempted); success
  caching; refresh re-fetch; no-cache-on-failure.
- Full backend unit suite: **2733 passed** (the fire-and-forget connect warm-up breaks nothing).
- ESLint clean on the changed source.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
