### PR TITLE
feat(data-factory): add stock-preparation action review UI

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -779,6 +779,100 @@ export interface IntegrationDeadLetterReplayResult {
   [key: string]: unknown
 }
 
+export interface IntegrationTableActionParameter {
+  id: string
+  label?: string
+  type?: string
+  required?: boolean
+  trim?: boolean
+  binding?: Record<string, unknown>
+}
+
+export interface IntegrationTableActionMetadata {
+  actionId: string
+  kind: string
+  label: string
+  configured: boolean
+  parameters: IntegrationTableActionParameter[]
+  permissions?: {
+    dryRun?: string
+    apply?: string
+  }
+  evidence?: Record<string, unknown>
+}
+
+export interface IntegrationTableActionDryRunResult {
+  action?: IntegrationTableActionMetadata
+  status: string
+  dryRunToken?: string | null
+  revision?: string
+  canApply?: boolean
+  counts?: Record<string, number>
+  evidence?: Record<string, unknown>
+}
+
+export interface IntegrationTableActionApplyResult {
+  action?: IntegrationTableActionMetadata
+  status: string
+  permission?: string
+  dryRunRevision?: string
+  apply?: Record<string, unknown>
+  evidence?: Record<string, unknown>
+}
+
+export interface IntegrationTableActionRequestPayload {
+  parameters: Record<string, unknown>
+  confirm?: {
+    dryRunToken?: string
+    acceptManualConfirmHold?: boolean
+  }
+}
+
+export async function listIntegrationTableActions(scope: IntegrationScope = {}): Promise<IntegrationTableActionMetadata[]> {
+  const query = buildQueryString({
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId,
+  })
+  const response = await apiFetch(`/api/integration/table-actions${query ? `?${query}` : ''}`)
+  const data = await parseIntegrationResponse<IntegrationTableActionMetadata[]>(response)
+  return Array.isArray(data) ? data : []
+}
+
+export async function dryRunIntegrationTableAction(
+  actionId: string,
+  payload: IntegrationScope & Pick<IntegrationTableActionRequestPayload, 'parameters'>,
+): Promise<IntegrationTableActionDryRunResult> {
+  const query = buildQueryString({
+    tenantId: payload.tenantId,
+    workspaceId: payload.workspaceId,
+  })
+  const response = await apiFetch(`/api/integration/table-actions/${encodeURIComponent(actionId)}/dry-run${query ? `?${query}` : ''}`, {
+    method: 'POST',
+    body: JSON.stringify({
+      parameters: payload.parameters,
+    }),
+  })
+  return parseIntegrationResponse<IntegrationTableActionDryRunResult>(response)
+}
+
+export async function applyIntegrationTableAction(
+  actionId: string,
+  payload: IntegrationScope & IntegrationTableActionRequestPayload,
+): Promise<IntegrationTableActionApplyResult> {
+  const query = buildQueryString({
+    tenantId: payload.tenantId,
+    workspaceId: payload.workspaceId,
+  })
+  const response = await apiFetch(`/api/integration/table-actions/${encodeURIComponent(actionId)}/apply${query ? `?${query}` : ''}`, {
+    method: 'POST',
+    body: JSON.stringify({
+      parameters: payload.parameters,
+      confirm: payload.confirm,
+    }),
+  })
+  return parseIntegrationResponse<IntegrationTableActionApplyResult>(response)
+}
+
 // Only 'open' letters are replayable — the server enforces the same, but the UI
 // must not even offer replay for replayed/discarded letters (a second live ERP
 // write). Keep this in lock-step with the backend guard in pipeline-runner.cjs.

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -670,6 +670,81 @@
         {{ dryRunEmptyPreviewNotice }}
       </div>
 
+      <div class="integration-workbench__table-action" data-testid="table-action-panel">
+        <div class="integration-workbench__panel-head">
+          <div>
+            <h3>参数化表动作</h3>
+            <p>面向已由管理员配置的安全动作。浏览器只填写 allowlist 参数；来源、目标表和写入计划由服务端决定。</p>
+          </div>
+          <span class="integration-workbench__badge" data-testid="table-action-permission-note">dry-run=read · apply=write/admin</span>
+        </div>
+        <div v-if="tableActions.length === 0" class="integration-workbench__empty" data-testid="table-action-empty">
+          当前部署没有暴露表动作。
+        </div>
+        <template v-else>
+          <div class="integration-workbench__grid integration-workbench__grid--compact">
+            <label>
+              <span>动作</span>
+              <select v-model="selectedTableActionId" data-testid="table-action-id">
+                <option v-for="action in tableActions" :key="action.actionId" :value="action.actionId">
+                  {{ action.label }} · {{ action.configured ? '已配置' : '未配置' }}
+                </option>
+              </select>
+            </label>
+            <label>
+              <span>项目号 projectNo</span>
+              <input v-model="tableActionProjectNo" data-testid="table-action-project-no" placeholder="例如 P2026-001" />
+            </label>
+          </div>
+          <p class="integration-workbench__hint" data-testid="table-action-boundary">
+            不提供 raw SQL、source/object、sheetId、C3 plan 或 C4 payload 输入；apply 会用 dry-run token 触发服务端重新计算。
+          </p>
+          <div class="integration-workbench__actions">
+            <button
+              type="button"
+              class="integration-workbench__button"
+              data-testid="table-action-dry-run"
+              :disabled="!tableActionCanDryRun"
+              @click="dryRunTableAction"
+            >
+              {{ runningTableAction === 'dry-run' ? 'Dry-run 中' : 'Dry-run 表动作' }}
+            </button>
+            <button
+              type="button"
+              class="integration-workbench__button integration-workbench__button--danger"
+              data-testid="table-action-apply"
+              :disabled="!tableActionCanApply"
+              @click="applyTableAction"
+            >
+              {{ runningTableAction === 'apply' ? 'Apply 中' : 'Apply 到备料表' }}
+            </button>
+          </div>
+          <div v-if="tableActionDryRunResult" class="integration-workbench__table-action-review" data-testid="table-action-review">
+            <strong>{{ tableActionReviewSummary }}</strong>
+            <div class="integration-workbench__metric-row">
+              <span>add {{ tableActionCounts.add || 0 }}</span>
+              <span>update {{ tableActionCounts.update || 0 }}</span>
+              <span>skip {{ tableActionCounts.skip || 0 }}</span>
+              <span>inactive {{ tableActionCounts.inactive || 0 }}</span>
+              <span>manual {{ tableActionCounts.manual_confirm || 0 }}</span>
+            </div>
+            <p class="integration-workbench__hint" data-testid="table-action-token-state">
+              {{ tableActionDryRunToken ? 'dry-run token 已签发；token 仅保存在当前页面内存，不展示、不复制到 evidence。' : '本次 dry-run 不可 apply；请处理失败项后重跑。' }}
+            </p>
+            <label v-if="tableActionManualConfirmCount > 0" class="integration-workbench__inline-check">
+              <input v-model="tableActionAcceptManualConfirmHold" type="checkbox" data-testid="table-action-accept-manual-hold" />
+              <span>确认 manual_confirm 行保持不写，只应用 clean add/update/inactive 决策。</span>
+            </label>
+          </div>
+          <div v-if="tableActionApplyResult" class="integration-workbench__table-action-review" data-testid="table-action-apply-result">
+            <strong>apply {{ tableActionApplyResult.status }}</strong>
+            <p class="integration-workbench__hint">已消费 dry-run token；如需再次 apply，必须重新 dry-run。</p>
+          </div>
+          <pre v-if="tableActionEvidenceText" data-testid="table-action-evidence">{{ tableActionEvidenceText }}</pre>
+          <p class="integration-workbench__hint">Issue / 客户证据只粘贴 values-free summary counts、status、error code；不要粘贴 PLM 行、备料表值或 payload。</p>
+        </template>
+      </div>
+
       <div class="integration-workbench__export">
         <div>
           <strong>导出清洗结果</strong>
@@ -942,13 +1017,16 @@
 
 <script setup lang="ts">
 import { computed, onMounted, reactive, ref, watch } from 'vue'
+import { useAuth } from '../composables/useAuth'
 import { buildXlsxBuffer } from '../multitable/import/xlsx-mapping'
 import { listDataSources } from '../data-sources/api'
 import type { DataSourceListItem } from '../data-sources/types'
 import {
   canReadFromSystem,
   canWriteToSystem,
+  applyIntegrationTableAction,
   deleteWorkbenchExternalSystem,
+  dryRunIntegrationTableAction,
   getDefaultIntegrationScope,
   isIntegrationScopedProjectId,
   normalizeIntegrationProjectId,
@@ -959,6 +1037,7 @@ import {
   listIntegrationPipelineRuns,
   listIntegrationProvenanceByRow,
   listIntegrationStagingDescriptors,
+  listIntegrationTableActions,
   listExternalSystemObjects,
   listIntegrationAdapters,
   listWorkbenchExternalSystems,
@@ -987,6 +1066,9 @@ import {
   type IntegrationSystemObject,
   type IntegrationFieldRule,
   type IntegrationReferenceMappingSource,
+  type IntegrationTableActionApplyResult,
+  type IntegrationTableActionDryRunResult,
+  type IntegrationTableActionMetadata,
   type IntegrationTemplatePreviewRequest,
   type WorkbenchExternalSystem,
 } from '../services/integration/workbench'
@@ -1054,6 +1136,7 @@ const flowSteps = [
   { title: '3. 多维表清洗', description: '业务人员在表格里修正、审核、补字段' },
   { title: '4. Dry-run / 推送', description: '预览 payload 后导出或 Save-only 写回' },
 ]
+const auth = useAuth()
 
 const stagingDatasetCopy: Record<string, { area: string; name: string; description: string }> = {
   plm_raw_items: {
@@ -1128,6 +1211,13 @@ const previewText = ref('尚未生成预览')
 const previewProvenance = ref<ReturnType<typeof summarizeFieldProvenance>>(null)
 const pipelineResultText = ref('尚未执行')
 const lastDryRunResult = ref<IntegrationPipelineRunResult | null>(null)
+const tableActions = ref<IntegrationTableActionMetadata[]>([])
+const selectedTableActionId = ref('')
+const tableActionProjectNo = ref('')
+const runningTableAction = ref<'dry-run' | 'apply' | ''>('')
+const tableActionDryRunResult = ref<IntegrationTableActionDryRunResult | null>(null)
+const tableActionApplyResult = ref<IntegrationTableActionApplyResult | null>(null)
+const tableActionAcceptManualConfirmHold = ref(false)
 const pipelineRuns = ref<IntegrationPipelineRun[]>([])
 const deadLetters = ref<IntegrationDeadLetter[]>([])
 const expandedRunIds = ref<Set<string>>(new Set())
@@ -1536,6 +1626,37 @@ const dryRunBlockedSummary = computed(() => {
   const missing = dryRunReadinessItems.value.filter((item) => !item.ready)
   if (missing.length === 0) return '已满足 dry-run 前置条件。Dry-run 只生成 preview，不写外部系统。'
   return `还缺 ${missing.length} 项：${missing.map((item) => item.label).join('、')}`
+})
+const configuredTableActions = computed(() => tableActions.value.filter((action) => action.configured === true))
+const selectedTableAction = computed(() => tableActions.value.find((action) => action.actionId === selectedTableActionId.value) || configuredTableActions.value[0] || tableActions.value[0] || null)
+const tableActionCounts = computed(() => tableActionDryRunResult.value?.counts || {})
+const tableActionManualConfirmCount = computed(() => Number(tableActionCounts.value.manual_confirm || 0))
+const tableActionDryRunToken = computed(() => tableActionDryRunResult.value?.dryRunToken || '')
+const tableActionEvidenceText = computed(() => {
+  const evidence = tableActionApplyResult.value?.evidence || tableActionDryRunResult.value?.evidence
+  return evidence ? JSON.stringify(evidence, null, 2) : ''
+})
+const tableActionCanDryRun = computed(() => Boolean(
+  selectedTableAction.value?.configured
+  && tableActionProjectNo.value.trim()
+  && runningTableAction.value === '',
+))
+const tableActionCanApply = computed(() => Boolean(
+  selectedTableAction.value?.configured
+  && tableActionProjectNo.value.trim()
+  && tableActionDryRunResult.value?.canApply === true
+  && tableActionDryRunToken.value
+  && auth.hasPermission('integration:write')
+  && runningTableAction.value === ''
+  && (tableActionManualConfirmCount.value === 0 || tableActionAcceptManualConfirmHold.value),
+))
+const tableActionReviewSummary = computed(() => {
+  if (!selectedTableAction.value) return '当前部署没有可用表动作。'
+  if (!selectedTableAction.value.configured) return '该动作尚未由管理员配置源/目标绑定，不能运行。'
+  if (!tableActionDryRunResult.value) return '输入项目号后先 dry-run；apply 必须使用本次 dry-run token，并由服务端重新计算计划。'
+  const status = tableActionDryRunResult.value.status || 'unknown'
+  const counts = tableActionCounts.value
+  return `dry-run ${status} · add ${counts.add || 0} / update ${counts.update || 0} / skip ${counts.skip || 0} / inactive ${counts.inactive || 0} / manual ${counts.manual_confirm || 0}`
 })
 
 function setStatus(message: string, kind: 'success' | 'error' | 'idle' = 'idle'): void {
@@ -2144,8 +2265,22 @@ async function refreshBootstrap(): Promise<void> {
     normalizeSystemSelections()
     if (!stagingSheetId.value) stagingSheetId.value = descriptorList.find((descriptor) => descriptor.id === 'standard_materials')?.id || descriptorList[0]?.id || ''
     setStatus(`已加载 ${systemList.length} 个连接、${adapterList.length} 个适配器和 ${descriptorList.length} 个 staging 表`, 'success')
+    void refreshTableActions(resolvedScope)
   } catch (error) {
     setStatus(error instanceof Error ? error.message : String(error), 'error')
+  }
+}
+
+async function refreshTableActions(resolvedScope = currentScope()): Promise<void> {
+  try {
+    const actionList = await listIntegrationTableActions(resolvedScope)
+    tableActions.value = actionList
+    if (!selectedTableActionId.value) {
+      selectedTableActionId.value = actionList.find((action) => action.configured)?.actionId || actionList[0]?.actionId || ''
+    }
+  } catch {
+    tableActions.value = []
+    selectedTableActionId.value = ''
   }
 }
 
@@ -2810,6 +2945,82 @@ async function executePipeline(dryRun: boolean): Promise<void> {
   }
 }
 
+function resetTableActionReview(): void {
+  tableActionDryRunResult.value = null
+  tableActionApplyResult.value = null
+  tableActionAcceptManualConfirmHold.value = false
+}
+
+function buildTableActionParameters(): Record<string, unknown> {
+  const projectNo = tableActionProjectNo.value.trim()
+  if (!projectNo) throw new Error('请填写项目号 projectNo')
+  return { projectNo }
+}
+
+async function dryRunTableAction(): Promise<void> {
+  const action = selectedTableAction.value
+  if (!action?.configured) {
+    setStatus('表动作尚未由管理员配置，不能 dry-run。', 'error')
+    return
+  }
+  runningTableAction.value = 'dry-run'
+  tableActionDryRunResult.value = null
+  tableActionApplyResult.value = null
+  tableActionAcceptManualConfirmHold.value = false
+  try {
+    const result = await dryRunIntegrationTableAction(action.actionId, {
+      ...currentScope(),
+      parameters: buildTableActionParameters(),
+    })
+    tableActionDryRunResult.value = result
+    const manualCount = Number(result.counts?.manual_confirm || 0)
+    const message = manualCount > 0
+      ? `表动作 dry-run 完成：${manualCount} 行需要人工确认，apply 会保持这些行不写。`
+      : '表动作 dry-run 完成，可进入 apply 确认。'
+    setStatus(message, result.canApply ? 'success' : 'error')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  } finally {
+    runningTableAction.value = ''
+  }
+}
+
+async function applyTableAction(): Promise<void> {
+  const action = selectedTableAction.value
+  if (!action?.configured) {
+    setStatus('表动作尚未由管理员配置，不能 apply。', 'error')
+    return
+  }
+  if (!auth.hasPermission('integration:write')) {
+    setStatus('当前用户只有 dry-run 读取权限，不能 apply 到备料表。', 'error')
+    return
+  }
+  if (!tableActionDryRunToken.value) {
+    setStatus('请先执行 dry-run；apply 必须使用服务端返回的一次性 dry-run token。', 'error')
+    return
+  }
+  runningTableAction.value = 'apply'
+  tableActionApplyResult.value = null
+  try {
+    const result = await applyIntegrationTableAction(action.actionId, {
+      ...currentScope(),
+      parameters: buildTableActionParameters(),
+      confirm: {
+        dryRunToken: tableActionDryRunToken.value,
+        acceptManualConfirmHold: tableActionAcceptManualConfirmHold.value === true,
+      },
+    })
+    tableActionApplyResult.value = result
+    tableActionDryRunResult.value = null
+    tableActionAcceptManualConfirmHold.value = false
+    setStatus(`表动作 apply 完成：${result.status}`, result.status === 'failed' ? 'error' : 'success')
+  } catch (error) {
+    setStatus(error instanceof Error ? error.message : String(error), 'error')
+  } finally {
+    runningTableAction.value = ''
+  }
+}
+
 const PROVENANCE_SOURCE_LABELS: Record<string, string> = {
   staging: '暂存源',
   template: '模板',
@@ -2931,6 +3142,10 @@ onMounted(() => {
 watch(showAdvancedConnectors, () => {
   normalizeSystemSelections()
 })
+
+watch([selectedTableActionId, tableActionProjectNo], () => {
+  resetTableActionReview()
+})
 </script>
 
 <style scoped>
@@ -2967,6 +3182,30 @@ watch(showAdvancedConnectors, () => {
   font-size: 12px;
   background: #eef2ff;
   color: #3730a3;
+}
+
+.integration-workbench__table-action {
+  margin: 16px 0;
+  padding: 14px;
+  border: 1px solid #d8e0e8;
+  border-radius: 8px;
+  background: #f8fbff;
+}
+
+.integration-workbench__table-action h3 {
+  margin: 0 0 4px;
+  font-size: 16px;
+}
+
+.integration-workbench__table-action p {
+  margin: 0;
+}
+
+.integration-workbench__table-action-review {
+  margin-top: 12px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
 }
 
 .integration-workbench {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -2163,4 +2163,199 @@ describe('IntegrationWorkbenchView', () => {
     await flushUi()
     expect((container.querySelector('[data-testid="save-connection-draft"]') as HTMLButtonElement).disabled).toBe(false)
   })
+
+  it('C5-2: runs a configured table action via dry-run token without client-supplied plan or sheet scope', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:write']))
+    const dryRunBodies: Array<{ url: string; body: Record<string, unknown> }> = []
+    const applyBodies: Array<{ url: string; body: Record<string, unknown> }> = []
+    const publicAction = {
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      kind: 'parameterized_table_action',
+      label: 'PLM project BOM -> stock preparation',
+      configured: true,
+      parameters: [{
+        id: 'projectNo',
+        label: 'Project number',
+        type: 'string',
+        required: true,
+        trim: true,
+        binding: { type: 'equality_filter', field: 'FileCode' },
+      }],
+      permissions: { dryRun: 'read', apply: 'write' },
+      evidence: { valuesFreeIssueEvidence: true },
+    }
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'http', label: 'HTTP API', roles: ['source'], supports: ['read'], advanced: false },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([publicAction])
+      if (url === '/api/integration/table-actions/plm.stock-preparation.pull-bom.v1/dry-run?tenantId=default') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        dryRunBodies.push({ url, body })
+        return jsonResponse({
+          action: publicAction,
+          status: 'manual_confirm_required',
+          dryRunToken: 'dry-token-secret',
+          revision: 'rev-1',
+          canApply: true,
+          counts: { add: 1, update: 2, skip: 3, inactive: 1, manual_confirm: 1 },
+          evidence: {
+            actionId: publicAction.actionId,
+            projectNoPresent: true,
+            dryRunRevision: 'rev-1',
+            expansion: { status: 'expanded', rows: 4, errorTypes: [] },
+            plan: { counts: { add: 1, update: 2, skip: 3, inactive: 1, manual_confirm: 1 }, errorTypes: [] },
+          },
+        })
+      }
+      if (url === '/api/integration/table-actions/plm.stock-preparation.pull-bom.v1/apply?tenantId=default') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        applyBodies.push({ url, body })
+        return jsonResponse({
+          action: publicAction,
+          status: 'partial',
+          permission: 'write',
+          dryRunRevision: 'rev-1',
+          apply: { status: 'partial', created: 1, patched: 2, skipped: 3, manualConfirmHeld: 1 },
+          evidence: {
+            actionId: publicAction.actionId,
+            projectNoPresent: true,
+            dryRunRevision: 'rev-1',
+            apply: { status: 'partial', errorCodes: [] },
+          },
+        })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi(12)
+
+    expect(container.querySelector('[data-testid="table-action-panel"]')?.textContent).toContain('PLM project BOM -> stock preparation')
+    expect(container.querySelector('[data-testid="table-action-boundary"]')?.textContent).toContain('不提供 raw SQL')
+    expect((container.querySelector('[data-testid="table-action-dry-run"]') as HTMLButtonElement).disabled).toBe(true)
+
+    const projectInput = container.querySelector('[data-testid="table-action-project-no"]') as HTMLInputElement
+    projectInput.value = 'P-001'
+    projectInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    ;(container.querySelector('[data-testid="table-action-dry-run"]') as HTMLButtonElement).click()
+    await flushUi(10)
+    expect(dryRunBodies).toHaveLength(1)
+    expect(dryRunBodies[0].body).toEqual({
+      parameters: { projectNo: 'P-001' },
+    })
+    expect(dryRunBodies[0].body).not.toHaveProperty('sheetId')
+    expect(dryRunBodies[0].body).not.toHaveProperty('source')
+    expect(dryRunBodies[0].body).not.toHaveProperty('target')
+    expect(dryRunBodies[0].body).not.toHaveProperty('plan')
+    expect(dryRunBodies[0].body).not.toHaveProperty('payload')
+    expect(container.querySelector('[data-testid="table-action-review"]')?.textContent).toContain('manual 1')
+    expect(container.querySelector('[data-testid="table-action-token-state"]')?.textContent).toContain('token 已签发')
+    expect(container.querySelector('[data-testid="table-action-panel"]')?.textContent).not.toContain('dry-token-secret')
+    expect((container.querySelector('[data-testid="table-action-apply"]') as HTMLButtonElement).disabled).toBe(true)
+
+    ;(container.querySelector('[data-testid="table-action-accept-manual-hold"]') as HTMLInputElement).click()
+    await flushUi()
+    expect((container.querySelector('[data-testid="table-action-apply"]') as HTMLButtonElement).disabled).toBe(false)
+    ;(container.querySelector('[data-testid="table-action-apply"]') as HTMLButtonElement).click()
+    await flushUi(10)
+
+    expect(applyBodies).toHaveLength(1)
+    expect(applyBodies[0].body).toEqual({
+      parameters: { projectNo: 'P-001' },
+      confirm: {
+        dryRunToken: 'dry-token-secret',
+        acceptManualConfirmHold: true,
+      },
+    })
+    expect(applyBodies[0].body).not.toHaveProperty('sheetId')
+    expect(applyBodies[0].body).not.toHaveProperty('source')
+    expect(applyBodies[0].body).not.toHaveProperty('target')
+    expect(applyBodies[0].body).not.toHaveProperty('plan')
+    expect(applyBodies[0].body).not.toHaveProperty('payload')
+    expect(container.querySelector('[data-testid="table-action-apply-result"]')?.textContent).toContain('apply partial')
+    expect(container.querySelector('[data-testid="table-action-evidence"]')?.textContent).not.toContain('P-001')
+    expect(container.querySelector('[data-testid="table-action-evidence"]')?.textContent).not.toContain('dry-token-secret')
+  })
+
+  it('C5-2: keeps apply disabled for read-only users after a successful dry-run', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:read']))
+    const applyBodies: Array<Record<string, unknown>> = []
+    const publicAction = {
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      kind: 'parameterized_table_action',
+      label: 'PLM project BOM -> stock preparation',
+      configured: true,
+      parameters: [{ id: 'projectNo', label: 'Project number', type: 'string', required: true }],
+      permissions: { dryRun: 'read', apply: 'write' },
+      evidence: { valuesFreeIssueEvidence: true },
+    }
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([publicAction])
+      if (url === '/api/integration/table-actions/plm.stock-preparation.pull-bom.v1/dry-run?tenantId=default') {
+        return jsonResponse({
+          action: publicAction,
+          status: 'ready',
+          dryRunToken: 'read-only-dry-token',
+          revision: 'rev-read-only',
+          canApply: true,
+          counts: { add: 1, update: 0, skip: 0, inactive: 0, manual_confirm: 0 },
+          evidence: { actionId: publicAction.actionId, projectNoPresent: true, dryRunRevision: 'rev-read-only' },
+        })
+      }
+      if (url === '/api/integration/table-actions/plm.stock-preparation.pull-bom.v1/apply?tenantId=default') {
+        applyBodies.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>)
+        return jsonResponse({ status: 'succeeded' })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi(12)
+
+    const projectInput = container.querySelector('[data-testid="table-action-project-no"]') as HTMLInputElement
+    projectInput.value = 'P-READ'
+    projectInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    ;(container.querySelector('[data-testid="table-action-dry-run"]') as HTMLButtonElement).click()
+    await flushUi(10)
+
+    expect(container.querySelector('[data-testid="table-action-review"]')?.textContent).toContain('add 1')
+    expect(container.querySelector('[data-testid="table-action-token-state"]')?.textContent).toContain('token 已签发')
+    const applyButton = container.querySelector('[data-testid="table-action-apply"]') as HTMLButtonElement
+    expect(applyButton.disabled).toBe(true)
+    applyButton.click()
+    await flushUi()
+    expect(applyBodies).toHaveLength(0)
+  })
 })

--- a/docs/development/data-factory-plm-project-bom-c5-2-workbench-action-ui-verification-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-c5-2-workbench-action-ui-verification-20260604.md
@@ -1,0 +1,70 @@
+# Data Factory PLM stock-preparation C5-2 workbench action UI verification (2026-06-04)
+
+## Scope
+
+C5-2 wires the already-merged C5-1 table-action routes into the Data Factory
+workbench UI.
+
+The operator can:
+
+- select the configured `plm.stock-preparation.pull-bom.v1` action;
+- enter the allowlisted `projectNo` parameter;
+- run a dry-run;
+- review status/counts and values-free evidence;
+- apply only with the server-issued dry-run token and explicit confirmation when
+  `manual_confirm` rows are held.
+
+## Boundary
+
+This slice is frontend/service wiring only.
+
+It does not add:
+
+- raw SQL input;
+- source/object/read-plan editing;
+- browser-supplied `sheetId`;
+- browser-supplied C3 plan or C4 payload;
+- K3 Save / Submit / Audit / BOM action;
+- batch or multi-project mode.
+
+The action config remains server-side/admin-owned. The browser sends only
+`parameters` and, for apply, `confirm`.
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false
+pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/web lint
+git diff --check
+```
+
+Results:
+
+- `IntegrationWorkbenchView.spec.ts`: 19/19 passed.
+- `vue-tsc -b`: passed.
+- Existing web lint script: passed.
+- `git diff --check`: passed.
+
+## Test Locks
+
+`apps/web/tests/IntegrationWorkbenchView.spec.ts` locks the C5-2 request body:
+
+- dry-run sends `{ parameters: { projectNo } }`;
+- apply sends `{ parameters: { projectNo }, confirm: { dryRunToken,
+  acceptManualConfirmHold } }`;
+- both requests are asserted to omit `sheetId`, `source`, `target`, `plan`, and
+  `payload`;
+- apply stays disabled until a dry-run token exists;
+- `manual_confirm` rows require explicit hold confirmation before apply;
+- the dry-run token is used by the request but is not rendered into the panel;
+- evidence remains values-free and does not contain the project number or token.
+
+## Remaining Gate
+
+C5-3 remains a separate opt-in: an operator validation runbook / entity-machine
+smoke for one project dry-run and, only with explicit approval, one apply to the
+configured MetaSheet stock-preparation main table.
+

--- a/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
@@ -282,17 +282,18 @@ Acceptance locks:
 - Manual-confirm rows are held while clean rows can still apply.
 - Values-free summary is available for issue evidence.
 
-### ⬜ C5-2 - Workbench parameterized action UI
+### 🟡 C5-2 - Workbench parameterized action UI (this PR)
 
 Gated on: C5-1 + explicit opt-in.
 
 Scope:
 
-- Add a reusable parameterized table action in the workbench, with the PLM
+- Add a reusable parameterized table action panel in the workbench, with the PLM
   project BOM pull as the first configured action instance.
-- Operator enters `projectNo`.
-- UI shows dry-run summary and conflict counts.
-- Apply confirmation calls C4 only when allowed.
+- Operator enters only `projectNo`.
+- UI shows dry-run status, conflict counts, a token-present state, and
+  values-free evidence.
+- Apply confirmation uses the dry-run token and calls C4 only when allowed.
 
 Acceptance locks:
 
@@ -309,6 +310,8 @@ Acceptance locks:
 - Values shown in the tenant UI are not copied to issue evidence.
 - No K3 button/action is introduced.
 - No batch/multi-project mode in v1.
+- Request-body wire test asserts dry-run/apply send no browser-supplied
+  `sheetId`, source/target binding, C3 plan, or C4 payload.
 
 ### ⬜ C5-3 - Operator validation runbook
 


### PR DESCRIPTION
## Summary

C5-2 for #2253: wire the C5-1 stock-preparation table-action routes into the Data Factory workbench UI.

Operators can now:

- load server-public table action metadata;
- enter the allowlisted `projectNo` parameter;
- run `dry-run` for `plm.stock-preparation.pull-bom.v1`;
- review status/counts and values-free evidence;
- apply only with the server-issued dry-run token, with explicit confirmation when `manual_confirm` rows are held.

## Safety Boundary

Held:

- no raw SQL textarea;
- no browser-supplied source/object/read-plan binding;
- no browser-supplied `sheetId`;
- no browser-supplied C3 plan or C4 payload;
- no K3 Save / Submit / Audit / BOM action;
- no batch or multi-project mode;
- dry-run and apply permissions are visibly separated;
- dry-run token is stored only in page state and not rendered/copied to evidence.

The workbench sends only:

- dry-run: `{ parameters: { projectNo } }`;
- apply: `{ parameters: { projectNo }, confirm: { dryRunToken, acceptManualConfirmHold } }`.

## Verification

Ran:

```bash
pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false
pnpm --filter @metasheet/web type-check
pnpm --filter @metasheet/web lint
git diff --check
```

Results:

- `IntegrationWorkbenchView.spec.ts`: 19/19 passed.
- `vue-tsc -b`: passed.
- Existing web lint script: passed.
- `git diff --check`: passed.

Note: a direct ad-hoc eslint over `IntegrationWorkbenchView.spec.ts` still reports the repo's existing test-file warnings (`router-link` casing / multi-component test stubs). The official web lint target remains green.

## Next Gate

C5-3 remains separate: operator validation / entity-machine smoke for one project dry-run and, only with explicit approval, one apply to the configured MetaSheet stock-preparation main table.
