### PR TITLE
feat(multitable): dashboard chart variants — donut + area [v2-c]

### DIFF
--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -154,12 +154,21 @@
           </label>
           <label class="meta-dashboard__field">
             <span>{{ viewRenderLabel('dashboard.chartType', isZh) }}</span>
-            <select v-model="chartDraft.chartType" class="meta-dashboard__select" data-field="chart-type">
+            <select v-model="chartDraft.chartType" class="meta-dashboard__select" data-field="chart-type" @change="chartDraft.variant = ''">
               <option value="bar">bar</option>
               <option value="line">line</option>
               <option value="pie">pie</option>
               <option value="number">number</option>
               <option value="table">table</option>
+            </select>
+          </label>
+          <!-- v2-c: single-series render variant; shown only for pie (donut) / line (area). -->
+          <label v-if="chartDraft.chartType === 'pie' || chartDraft.chartType === 'line'" class="meta-dashboard__field">
+            <span>{{ viewRenderLabel('dashboard.chartVariant', isZh) }}</span>
+            <select v-model="chartDraft.variant" class="meta-dashboard__select" data-field="chart-variant">
+              <option value="">{{ viewRenderLabel('dashboard.variantStandard', isZh) }}</option>
+              <option v-if="chartDraft.chartType === 'pie'" value="donut">{{ viewRenderLabel('dashboard.variantDonut', isZh) }}</option>
+              <option v-if="chartDraft.chartType === 'line'" value="area">{{ viewRenderLabel('dashboard.variantArea', isZh) }}</option>
             </select>
           </label>
           <label class="meta-dashboard__field">
@@ -296,6 +305,8 @@ const chartDraft = ref({
   groupByFieldId: '',
   aggregation: 'count' as AggregationFunction,
   valueFieldId: '',
+  // v2-c: single-series render variant; only meaningful for pie ('donut') / line ('area').
+  variant: '' as '' | 'donut' | 'area',
 })
 
 const activeDashboard = computed(() => dashboards.value.find((d) => d.id === activeDashboardId.value) ?? dashboards.value[0] ?? null)
@@ -331,6 +342,7 @@ function resetChartDraft() {
     groupByFieldId: groupableFields.value[0]?.id ?? '',
     aggregation: 'count',
     valueFieldId: '',
+    variant: '',
   }
   createChartError.value = ''
   resetChartPreview()
@@ -353,6 +365,7 @@ function openEditChart(chartId: string) {
     groupByFieldId: cfg.dataSource.groupByFieldId ?? '',
     aggregation: cfg.dataSource.aggregation.function,
     valueFieldId: cfg.dataSource.aggregation.fieldId ?? '',
+    variant: cfg.displayConfig?.variant ?? '',
   }
   createChartError.value = ''
   resetChartPreview()
@@ -463,6 +476,12 @@ function buildChartInput(base?: ChartConfig): ChartCreateInput {
   if (!editingDateGrouped.value) {
     dataSource.groupByFieldId = chartDraft.value.groupByFieldId
   }
+  // v2-c: a render variant is valid only for its matching chartType (donut→pie, area→line).
+  // Resolve it explicitly so switching chartType clears a now-inapplicable variant carried by base.
+  const variant: 'donut' | 'area' | undefined =
+    chartDraft.value.chartType === 'pie' && chartDraft.value.variant === 'donut' ? 'donut'
+      : chartDraft.value.chartType === 'line' && chartDraft.value.variant === 'area' ? 'area'
+        : undefined
   return {
     name,
     chartType: chartDraft.value.chartType,
@@ -470,6 +489,7 @@ function buildChartInput(base?: ChartConfig): ChartCreateInput {
     displayConfig: {
       ...(base?.displayConfig ?? {}),
       title: name,
+      variant,
     },
   }
 }

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -940,6 +940,9 @@ export interface ChartDisplayConfig {
   prefix?: string
   suffix?: string
   orientation?: 'horizontal' | 'vertical'
+  // v2-c single-series render variant: 'donut' (pie + inner radius) / 'area' (line + areaStyle).
+  // Only honored for the matching chartType (pie/line); inert otherwise.
+  variant?: 'donut' | 'area'
 }
 
 export interface ChartConfig {

--- a/apps/web/src/multitable/utils/buildChartOption.ts
+++ b/apps/web/src/multitable/utils/buildChartOption.ts
@@ -52,7 +52,8 @@ export function buildChartOption(
       series: [
         {
           type: 'pie',
-          radius: '70%',
+          // v2-c: displayConfig.variant 'donut' renders the pie with an inner radius (a hole).
+          radius: displayConfig?.variant === 'donut' ? ['45%', '70%'] : '70%',
           // sectors stay label-less; value is shown by the renderer's HTML legend
           label: { show: false },
           data: dataPoints.map((p) => ({
@@ -104,6 +105,8 @@ export function buildChartOption(
       {
         type: 'line',
         label: { show: false },
+        // v2-c: displayConfig.variant 'area' fills the area under the line.
+        ...(displayConfig?.variant === 'area' ? { areaStyle: {} } : {}),
         data: seriesData,
       },
     ],

--- a/apps/web/src/multitable/utils/meta-view-render-labels.ts
+++ b/apps/web/src/multitable/utils/meta-view-render-labels.ts
@@ -97,6 +97,10 @@ export type MetaViewRenderLabelKey =
   | 'dashboard.cancel'
   | 'dashboard.noGroupableFields'
   | 'dashboard.dateGroupingLocked'
+  | 'dashboard.chartVariant'
+  | 'dashboard.variantStandard'
+  | 'dashboard.variantDonut'
+  | 'dashboard.variantArea'
   | 'dashboard.noNumericFields'
   | 'dashboard.livePreview'
   | 'dashboard.previewFillRequired'
@@ -204,6 +208,10 @@ export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'dashboard.cancel',
   'dashboard.noGroupableFields',
   'dashboard.dateGroupingLocked',
+  'dashboard.chartVariant',
+  'dashboard.variantStandard',
+  'dashboard.variantDonut',
+  'dashboard.variantArea',
   'dashboard.noNumericFields',
   'dashboard.livePreview',
   'dashboard.previewFillRequired',
@@ -318,6 +326,10 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
     en: 'Grouped by date; date grouping is preserved in this editor.',
     zh: '已按日期分组；此编辑器会保留现有日期分组。',
   },
+  'dashboard.chartVariant': { en: 'Chart style', zh: '图表样式' },
+  'dashboard.variantStandard': { en: 'Standard', zh: '标准' },
+  'dashboard.variantDonut': { en: 'Donut', zh: '环形图' },
+  'dashboard.variantArea': { en: 'Area', zh: '面积图' },
   'dashboard.noNumericFields': { en: 'No readable numeric fields available.', zh: '没有可读取的数值字段。' },
   'dashboard.livePreview': { en: 'Live preview', zh: '实时预览' },
   'dashboard.previewFillRequired': { en: 'Complete the chart fields to preview.', zh: '填写完整图表字段后可预览。' },

--- a/apps/web/tests/multitable-build-chart-option.spec.ts
+++ b/apps/web/tests/multitable-build-chart-option.spec.ts
@@ -90,4 +90,31 @@ describe('buildChartOption', () => {
     expect(o.series[0].data).toEqual([])
     expect(o.xAxis.data).toEqual([])
   })
+
+  // --- v2-c single-series render variants (displayConfig.variant) ---
+
+  it('donut: pie + variant "donut" uses an inner radius; plain pie keeps radius "70%" (regression)', () => {
+    const donut = opt(buildChartOption(chart('pie', [{ label: 'A', value: 1 }]), { variant: 'donut' }))
+    expect(Array.isArray(donut.series[0].radius)).toBe(true) // [inner, outer] hole
+    const plain = opt(buildChartOption(chart('pie', [{ label: 'A', value: 1 }])))
+    expect(plain.series[0].radius).toBe('70%')
+  })
+
+  it('area: line + variant "area" fills the area; plain line has no areaStyle (regression)', () => {
+    const area = opt(buildChartOption(chart('line', [{ label: 'A', value: 1 }]), { variant: 'area' }))
+    expect(area.series[0].areaStyle).toBeDefined()
+    const plain = opt(buildChartOption(chart('line', [{ label: 'A', value: 1 }])))
+    expect(plain.series[0].areaStyle).toBeUndefined()
+  })
+
+  it('variant is inert on non-matching types (donut only pies, area only lines)', () => {
+    const barDonut = opt(buildChartOption(chart('bar', [{ label: 'A', value: 1 }]), { variant: 'donut' }))
+    expect(barDonut.series[0].type).toBe('bar')
+    expect(barDonut.series[0].areaStyle).toBeUndefined()
+    const lineDonut = opt(buildChartOption(chart('line', [{ label: 'A', value: 1 }]), { variant: 'donut' }))
+    expect(lineDonut.series[0].areaStyle).toBeUndefined() // 'donut' does not area-fill a line
+    const pieArea = opt(buildChartOption(chart('pie', [{ label: 'A', value: 1 }]), { variant: 'area' }))
+    expect(pieArea.series[0].radius).toBe('70%') // 'area' does not donut-ify a pie
+    expect(buildChartOption(chart('number', [{ label: 'x', value: 1 }]), { variant: 'donut' })).toBeNull()
+  })
 })

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -615,4 +615,141 @@ describe('MetaDashboardView', () => {
     expect(delCalls.length).toBe(0)
     confirmSpy.mockRestore()
   })
+
+  // ---- v2-c: donut / area single-series render variants (displayConfig.variant) ----
+
+  const openCreateForm = async (container: HTMLElement) => {
+    ;(container.querySelector('[data-action="create-chart"]') as HTMLButtonElement).click()
+    await nextTick()
+  }
+  const setSelect = async (el: HTMLSelectElement, value: string) => {
+    el.value = value
+    el.dispatchEvent(new Event('change'))
+    await nextTick()
+  }
+  const typeSelectOf = (c: HTMLElement) => c.querySelector('[data-field="chart-type"]') as HTMLSelectElement
+  const variantSelectOf = (c: HTMLElement) => c.querySelector('[data-field="chart-variant"]') as HTMLSelectElement | null
+
+  it('v2-c: variant select shows only for pie/line and offers donut/area respectively', async () => {
+    const { client } = mockClient([fakeDashboard({ panels: [] })], [])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    await openCreateForm(container)
+    const typeSelect = typeSelectOf(container)
+
+    await setSelect(typeSelect, 'bar')
+    expect(variantSelectOf(container)).toBeNull()
+    await setSelect(typeSelect, 'pie')
+    expect(Array.from(variantSelectOf(container)!.options).map((o) => o.value)).toEqual(['', 'donut'])
+    await setSelect(typeSelect, 'line')
+    expect(Array.from(variantSelectOf(container)!.options).map((o) => o.value)).toEqual(['', 'area'])
+    await setSelect(typeSelect, 'number')
+    expect(variantSelectOf(container)).toBeNull()
+  })
+
+  it('v2-c: create carries displayConfig.variant (pie + donut)', async () => {
+    const { client, fetchFn } = mockClient([fakeDashboard({ panels: [] })], [])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    await openCreateForm(container)
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Donut'; nameInput.dispatchEvent(new Event('input')); await nextTick()
+    await setSelect(typeSelectOf(container), 'pie')
+    await setSelect(variantSelectOf(container)!, 'donut')
+    ;(container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const post = fetchFn.mock.calls.find(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'POST' && url.includes('/charts') && !url.includes('preview-data'),
+    )
+    const body = JSON.parse(post![1].body as string)
+    expect(body.type).toBe('pie')
+    expect(body.display.variant).toBe('donut') // wire maps displayConfig -> display
+  })
+
+  it('v2-c: switching chartType clears an inapplicable variant (donut -> bar drops it)', async () => {
+    const { client, fetchFn } = mockClient([fakeDashboard({ panels: [] })], [])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    await openCreateForm(container)
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Switcher'; nameInput.dispatchEvent(new Event('input')); await nextTick()
+    await setSelect(typeSelectOf(container), 'pie')
+    await setSelect(variantSelectOf(container)!, 'donut')
+    await setSelect(typeSelectOf(container), 'bar') // @change clears variant
+    ;(container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const post = fetchFn.mock.calls.find(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'POST' && url.includes('/charts') && !url.includes('preview-data'),
+    )
+    const body = JSON.parse(post![1].body as string)
+    expect(body.type).toBe('bar')
+    expect(body.display.variant).toBeUndefined()
+  })
+
+  it('v2-c: edit carries displayConfig.variant', async () => {
+    const chart = fakeChart({ chartType: 'pie' })
+    const { client, fetchFn } = mockClient([fakeDashboard()], [chart])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    ;(container.querySelector('[data-action="add-panel"]') as HTMLButtonElement).click()
+    await nextTick()
+    ;(container.querySelector(`[data-edit-chart="${chart.id}"]`) as HTMLButtonElement).click()
+    await nextTick()
+    await setSelect(variantSelectOf(container)!, 'donut')
+    ;(container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const patch = fetchFn.mock.calls.find(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'PATCH' && url.includes(`/charts/${chart.id}`),
+    )
+    expect(JSON.parse(patch![1].body as string).display.variant).toBe('donut')
+  })
+
+  it('v2-c: editing an existing donut chart preserves variant on a no-op (round-trip)', async () => {
+    // The v2-b1 config-loss trap: openEditChart must pre-fill the variant, else a
+    // name-only edit would drop it (buildChartInput always sets variant explicitly).
+    const chart = fakeChart({ chartType: 'pie', displayConfig: { title: 'Sales Chart', variant: 'donut' } })
+    const { client, fetchFn } = mockClient([fakeDashboard()], [chart])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    ;(container.querySelector('[data-action="add-panel"]') as HTMLButtonElement).click()
+    await nextTick()
+    ;(container.querySelector(`[data-edit-chart="${chart.id}"]`) as HTMLButtonElement).click()
+    await nextTick()
+    // change ONLY the name; never touch the variant select
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Renamed'; nameInput.dispatchEvent(new Event('input')); await nextTick()
+    ;(container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const patch = fetchFn.mock.calls.find(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'PATCH' && url.includes(`/charts/${chart.id}`),
+    )
+    const body = JSON.parse(patch![1].body as string)
+    expect(body.display.variant).toBe('donut') // preserved, not dropped
+    expect(body.name).toBe('Renamed')
+  })
+
+  it('v2-c: live preview carries displayConfig.variant (same config as save)', async () => {
+    const { client } = mockClient([fakeDashboard({ panels: [] })], [])
+    const previewSpy = vi.spyOn(client, 'previewChartData').mockResolvedValue({ chartType: 'pie', dataPoints: [{ label: 'A', value: 1 }] })
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    vi.useFakeTimers()
+    await openCreateForm(container)
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Preview donut'; nameInput.dispatchEvent(new Event('input')); await nextTick()
+    await setSelect(typeSelectOf(container), 'pie')
+    await setSelect(variantSelectOf(container)!, 'donut')
+
+    await vi.advanceTimersByTimeAsync(300)
+    await nextTick()
+    expect(previewSpy).toHaveBeenLastCalledWith('sheet_1', expect.objectContaining({
+      chartType: 'pie',
+      displayConfig: expect.objectContaining({ variant: 'donut' }),
+    }))
+    vi.useRealTimers()
+  })
 })


### PR DESCRIPTION
Implements **v2-c** of the Dashboard BI arc per the merged design-lock (`docs/development/multitable-dashboard-bi-v2c-variants-design-20260604.md`, #2289). Frontend-only; backend `ChartConfig`/`ChartData` untouched.

## Scope (locked — not re-opened)
- **donut** = `chartType: 'pie'` + `displayConfig.variant: 'donut'` → pie rendered with an inner radius (hole).
- **area** = `chartType: 'line'` + `displayConfig.variant: 'area'` → line gets `areaStyle`.
- `variant` is **inert** on any non-matching type (bar/number/table, and the wrong pairing like `area` on a pie).
- **stacked / multi-series deferred to v2-d** (would need the `ChartData → series[]` contract change).

## Changes
- `buildChartOption.ts` — pie reads `variant === 'donut'` for inner radius; line reads `variant === 'area'` for `areaStyle`. No-variant path unchanged.
- `types.ts` — `ChartDisplayConfig.variant?: 'donut' | 'area'` (only honored for the matching chartType).
- `MetaDashboardView.vue` — variant `<select>` shown only for pie/line (donut/area options); `chartType` `@change` clears an inapplicable variant; `buildChartInput` resolves an effective variant so create / edit / preview all carry the same `displayConfig`.
- `meta-view-render-labels.ts` — 4 zh/en labels (`dashboard.chartVariant` / `variantStandard` / `variantDonut` / `variantArea`).

## Verification
- `buildChartOption` unit: donut inner-radius, area `areaStyle`, **no-variant regression**, inert on non-matching types. (15/15)
- dashboard form spec: variant visibility (pie/line only), create / edit / **live-preview** carry `display.variant`, **clear-on-chartType-switch**. (22/22)
- `vue-tsc -b` clean.
- No backend / real-DB needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)