### PR TITLE
feat(data-factory): inject stock action plugin config

### DIFF
--- a/docs/development/data-factory-plm-project-bom-c5-3a-action-config-injection-verification-20260605.md
+++ b/docs/development/data-factory-plm-project-bom-c5-3a-action-config-injection-verification-20260605.md
@@ -1,0 +1,114 @@
+# Data Factory PLM stock-preparation C5-3a action config injection verification (2026-06-05)
+
+## Scope
+
+C5-3a fixes the entity-machine C5-3 blocker found in #2253: the
+`plugin-integration-core` table-action routes were implemented, but the host
+created the plugin context with `config: {}`. As a result,
+`GET /api/integration/table-actions` correctly returned `configured:false`
+because no server-owned action config could reach the plugin.
+
+This slice adds a narrow deployment-time config ingestion path for
+`plugin-integration-core` only:
+
+- `INTEGRATION_CORE_STOCK_PREPARATION_TABLE_ACTIONS_JSON` ->
+  `context.config.stockPreparationTableActions`;
+- `INTEGRATION_CORE_TABLE_ACTIONS_JSON` -> `context.config.tableActions`.
+
+Both values must be valid JSON arrays or objects. Invalid JSON or primitive
+JSON fails closed at startup instead of silently starting with empty config.
+
+## Boundary
+
+This slice does not add:
+
+- UI changes;
+- PLM reads;
+- MetaSheet writes;
+- K3 Save / Submit / Audit / BOM;
+- migrations;
+- raw SQL;
+- permission model changes;
+- datasource credentials in the integration plugin config.
+
+The table-action config remains server-side/admin-owned. Public action metadata
+is still values-free and does not expose source system ids or target sheet ids.
+
+## Non-secret deployment shape
+
+The stock-preparation action JSON may carry IDs and field maps needed to bind
+the already-reviewed C5 action, for example:
+
+```json
+[
+  {
+    "actionId": "plm.stock-preparation.pull-bom.v1",
+    "source": {
+      "kind": "data-source:sql-readonly",
+      "externalSystemId": "integration_external_system_id_for_plm_sql",
+      "readPlan": {}
+    },
+    "target": {
+      "sheetId": "stock_preparation_sheet_id",
+      "objectId": "stockPreparationMain",
+      "fieldIdMap": {}
+    },
+    "limits": {
+      "maxDepth": 8,
+      "maxRows": 5000
+    }
+  }
+]
+```
+
+`source.externalSystemId` is the Integration external-system id whose kind is
+`data-source:sql-readonly`; it is not the raw datasource id and it must not
+contain database credentials.
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-runtime-config.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter plugin-integration-core test:http-routes
+git diff --check
+```
+
+Results:
+
+- `plugin-runtime-config.test.ts`: 5/5 passed.
+- `@metasheet/core-backend build`: passed.
+- `plugin-integration-core test:http-routes`: passed.
+- `git diff --check`: passed.
+
+## Test locks
+
+`packages/core-backend/tests/unit/plugin-runtime-config.test.ts` locks the host
+ingestion path:
+
+- unrelated plugins receive `{}` and do not parse integration env;
+- `plugin-integration-core` receives both stock-specific and generic
+  table-action config;
+- invalid JSON rejects;
+- primitive JSON rejects.
+
+`plugins/plugin-integration-core/__tests__/http-routes.test.cjs` remains the
+consumer lock:
+
+- configured action metadata reports `configured:true`;
+- public metadata does not expose the configured target sheet id;
+- public metadata does not expose the configured source external-system id;
+- unconfigured action remains fail-closed.
+
+## Remaining gate
+
+After this slice lands, cut a refreshed on-prem package and rerun #2253 C5-3
+entity-machine smoke. The operator should confirm:
+
+- `GET /api/integration/table-actions?tenantId=default` reports
+  `configured:true` for `plm.stock-preparation.pull-bom.v1`;
+- dry-run remains read-only and values-free in issue evidence;
+- apply is executed only if explicitly approved for the configured
+  stock-preparation target.

--- a/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
@@ -248,9 +248,9 @@ Acceptance locks:
 - Dry-run/read and apply/write permissions are separated.
 - Issue/customer evidence stays values-free.
 
-### 🟡 C5-1 - Backend parameterized action routes (this PR)
+### ✅ C5-1 - Backend parameterized action routes (DONE - PR #2284)
 
-Gated on: C5-0 accepted + explicit opt-in.
+Gated on: C5-0 accepted + explicit opt-in. Done in #2284.
 
 Scope:
 
@@ -282,9 +282,9 @@ Acceptance locks:
 - Manual-confirm rows are held while clean rows can still apply.
 - Values-free summary is available for issue evidence.
 
-### 🟡 C5-2 - Workbench parameterized action UI (this PR)
+### ✅ C5-2 - Workbench parameterized action UI (DONE - PR #2288)
 
-Gated on: C5-1 + explicit opt-in.
+Gated on: C5-1 + explicit opt-in. Done in #2288.
 
 Scope:
 
@@ -313,9 +313,38 @@ Acceptance locks:
 - Request-body wire test asserts dry-run/apply send no browser-supplied
   `sheetId`, source/target binding, C3 plan, or C4 payload.
 
-### ⬜ C5-3 - Operator validation runbook
+### 🟡 C5-3a - On-prem action config injection unblocker (this PR)
 
-Gated on: C5-1/C5-2 + explicit opt-in.
+Gated on: C5-1/C5-2 + entity-machine smoke finding + explicit opt-in.
+
+Scope:
+
+- Inject server-owned `plugin-integration-core` table-action config into the
+  plugin host context from deployment environment JSON.
+- Keep the PLM action config non-secret: it may contain the integration
+  external-system id, readonly SQL object/read-plan references, target stock
+  sheet id/object id, field maps, and limits; it must not contain datasource
+  credentials or raw PLM/customer row values.
+- Preserve C5's server-side action ownership: the browser still receives only
+  public action metadata and never receives source bindings or target sheet ids.
+- No PLM read, MetaSheet write, UI, K3, migration, raw SQL, or permission model
+  change.
+
+Acceptance locks:
+
+- Without configured action JSON, `GET /api/integration/table-actions` remains
+  fail-closed with `configured:false`.
+- With valid server-side action JSON, the existing route consumer exposes the
+  action as `configured:true` while redacting source/target bindings from public
+  metadata.
+- Invalid JSON or non-object/non-array config fails closed at plugin host
+  startup; no silent empty config.
+- The deployment config path is scoped to `plugin-integration-core`; unrelated
+  plugins do not receive the table-action config.
+
+### ⬜ C5-3 - Operator validation runbook / entity-machine smoke
+
+Gated on: C5-1/C5-2 + C5-3a package deployed + explicit opt-in.
 
 Scope:
 
@@ -376,13 +405,16 @@ operator checks stay in later validation slices:
 
 ## Sequencing rule
 
-C0, C1, C2-0, C2, C3, and C4 are complete. The next step is C5, but it is split
-because it crosses from latent helpers into operator-triggered writes:
+C0, C1, C2-0, C2, C3, C4, C5-0, C5-1, and C5-2 are complete. C5-3a is the
+current entity-machine unblocker found during C5-3 smoke: the host must inject
+server-owned action config so the plugin can report the PLM action as
+`configured:true`.
 
 1. C5-0 design locks the reusable parameterized action contract.
 2. C5-1 adds backend action routes and server-side recompute/apply wiring.
 3. C5-2 adds the workbench operator surface.
-4. C5-3 validates the flow on an entity machine.
+4. C5-3a injects server-owned plugin action config for on-prem deployment.
+5. C5-3 validates the flow on an entity machine.
 
 C6 option sync remains after C5. All later slices still require their
 predecessor to land and the owner to explicitly opt in. K3 Save / Submit /

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -156,6 +156,7 @@ import { cacheRegistry } from '../core/cache/CacheRegistry'
 import { loadObservabilityConfig } from './config/observability'
 import { initObservability } from './observability/otel'
 import { isPlmEnabled } from './config/product-mode'
+import { resolvePluginRuntimeConfig } from './plugin-runtime-config'
 
 type PluginRuntimeState = {
   status: 'active' | 'inactive' | 'failed'
@@ -1552,7 +1553,7 @@ export class MetaSheetServer {
         security: this.pluginRuntimeSecurityService,
       } as unknown as import('./types/plugin').PluginServices,
       storage,
-      config: {},
+      config: resolvePluginRuntimeConfig(manifest.name),
       communication,
       logger: new Logger(`Plugin:${manifest.name}`),
     }

--- a/packages/core-backend/src/plugin-runtime-config.ts
+++ b/packages/core-backend/src/plugin-runtime-config.ts
@@ -1,0 +1,41 @@
+const INTEGRATION_CORE_PLUGIN_NAME = 'plugin-integration-core'
+const INTEGRATION_CORE_STOCK_ACTIONS_ENV = 'INTEGRATION_CORE_STOCK_PREPARATION_TABLE_ACTIONS_JSON'
+const INTEGRATION_CORE_TABLE_ACTIONS_ENV = 'INTEGRATION_CORE_TABLE_ACTIONS_JSON'
+
+function parsePluginJsonEnv(env: NodeJS.ProcessEnv, key: string): unknown {
+  const raw = env[key]
+  if (typeof raw !== 'string' || raw.trim().length === 0) return undefined
+  try {
+    return JSON.parse(raw)
+  } catch {
+    throw new Error(`${key} must be valid JSON`)
+  }
+}
+
+function assertPluginActionConfigShape(value: unknown, key: string): unknown {
+  if (value === undefined) return undefined
+  if (Array.isArray(value)) return value
+  if (value && typeof value === 'object') return value
+  throw new Error(`${key} must be a JSON array or object`)
+}
+
+export function resolvePluginRuntimeConfig(
+  manifestName: string,
+  env: NodeJS.ProcessEnv = process.env
+): Record<string, unknown> {
+  if (manifestName !== INTEGRATION_CORE_PLUGIN_NAME) return {}
+
+  const stockPreparationTableActions = assertPluginActionConfigShape(
+    parsePluginJsonEnv(env, INTEGRATION_CORE_STOCK_ACTIONS_ENV),
+    INTEGRATION_CORE_STOCK_ACTIONS_ENV
+  )
+  const tableActions = assertPluginActionConfigShape(
+    parsePluginJsonEnv(env, INTEGRATION_CORE_TABLE_ACTIONS_ENV),
+    INTEGRATION_CORE_TABLE_ACTIONS_ENV
+  )
+
+  return {
+    ...(tableActions !== undefined ? { tableActions } : {}),
+    ...(stockPreparationTableActions !== undefined ? { stockPreparationTableActions } : {}),
+  }
+}

--- a/packages/core-backend/tests/unit/plugin-runtime-config.test.ts
+++ b/packages/core-backend/tests/unit/plugin-runtime-config.test.ts
@@ -1,0 +1,58 @@
+import { describe, expect, it } from 'vitest'
+import { resolvePluginRuntimeConfig } from '../../src/plugin-runtime-config'
+
+describe('plugin runtime config resolution', () => {
+  it('keeps non-integration plugins unconfigured', () => {
+    const config = resolvePluginRuntimeConfig('plugin-view-kanban', {
+      INTEGRATION_CORE_STOCK_PREPARATION_TABLE_ACTIONS_JSON: '[{"actionId":"plm.stock-preparation.pull-bom.v1"}]',
+    })
+
+    expect(config).toEqual({})
+  })
+
+  it('does not parse table-action env for unrelated plugins', () => {
+    expect(resolvePluginRuntimeConfig('plugin-view-kanban', {
+      INTEGRATION_CORE_STOCK_PREPARATION_TABLE_ACTIONS_JSON: '{not-json',
+    })).toEqual({})
+  })
+
+  it('injects table-action config only into plugin-integration-core', () => {
+    const stockAction = {
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      source: {
+        kind: 'data-source:sql-readonly',
+        externalSystemId: 'ext_plm_sql',
+      },
+      target: {
+        sheetId: 'sheet_stock',
+      },
+    }
+    const genericAction = {
+      actionId: 'custom.lookup.v1',
+      source: { externalSystemId: 'ext_lookup' },
+      target: { sheetId: 'sheet_lookup' },
+    }
+
+    const config = resolvePluginRuntimeConfig('plugin-integration-core', {
+      INTEGRATION_CORE_STOCK_PREPARATION_TABLE_ACTIONS_JSON: JSON.stringify([stockAction]),
+      INTEGRATION_CORE_TABLE_ACTIONS_JSON: JSON.stringify({ lookup: genericAction }),
+    })
+
+    expect(config).toEqual({
+      stockPreparationTableActions: [stockAction],
+      tableActions: { lookup: genericAction },
+    })
+  })
+
+  it('fails closed on invalid JSON', () => {
+    expect(() => resolvePluginRuntimeConfig('plugin-integration-core', {
+      INTEGRATION_CORE_STOCK_PREPARATION_TABLE_ACTIONS_JSON: '{not-json',
+    })).toThrow('INTEGRATION_CORE_STOCK_PREPARATION_TABLE_ACTIONS_JSON must be valid JSON')
+  })
+
+  it('fails closed when table-action env is not an array or object', () => {
+    expect(() => resolvePluginRuntimeConfig('plugin-integration-core', {
+      INTEGRATION_CORE_TABLE_ACTIONS_JSON: '"not-an-action-list"',
+    })).toThrow('INTEGRATION_CORE_TABLE_ACTIONS_JSON must be a JSON array or object')
+  })
+})


### PR DESCRIPTION
## Summary
- add a narrow plugin-runtime config resolver for `plugin-integration-core`
- inject `INTEGRATION_CORE_STOCK_PREPARATION_TABLE_ACTIONS_JSON` into `context.config.stockPreparationTableActions` and `INTEGRATION_CORE_TABLE_ACTIONS_JSON` into `context.config.tableActions`
- fail closed on invalid JSON / primitive config, and keep unrelated plugins unconfigured
- add C5-3a verification docs and update the #2253 TODO ladder

## Why
#2253 entity-machine C5-3 reached the UI, but `GET /api/integration/table-actions` returned `configured:false`. Code inspection showed the host always created the integration plugin context with `config: {}`, so there was no supported deployment path for the server-owned stock-preparation action config.

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-runtime-config.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter plugin-integration-core test:http-routes`
- `git diff --check`

## Boundaries
- no UI changes
- no PLM read
- no MetaSheet write
- no K3 Save / Submit / Audit / BOM
- no migration / raw SQL / permission-model change
- no datasource credentials in the plugin config

Closes no issue; unblocks #2253 C5-3 package re-test after merge.