### PR TITLE
feat(approval): add template authoring frontend MVP

### DIFF
--- a/apps/web/src/approvals/api.ts
+++ b/apps/web/src/approvals/api.ts
@@ -18,6 +18,9 @@ import type {
   ApprovalTemplateStatus,
   ApprovalTemplateVisibilityScope,
   FormField,
+  CreateApprovalTemplateRequest,
+  UpdateApprovalTemplateRequest,
+  PublishApprovalTemplateRequest,
 } from '../types/approval'
 
 // ---------------------------------------------------------------------------
@@ -430,6 +433,78 @@ export async function updateTemplateSlaHours(
     throw new Error(`API error: ${response.status} ${response.statusText}`)
   }
   return response.json()
+}
+
+export async function createTemplate(
+  payload: CreateApprovalTemplateRequest,
+): Promise<ApprovalTemplateDetailDTO> {
+  if (USE_MOCK) {
+    return {
+      ...mockTemplateDetail(`tpl_${Date.now()}`),
+      key: payload.key,
+      name: payload.name,
+      description: payload.description ?? null,
+      category: payload.category ?? null,
+      visibilityScope: payload.visibilityScope ?? { type: 'all', ids: [] },
+      slaHours: payload.slaHours ?? null,
+      status: 'draft',
+      activeVersionId: null,
+      latestVersionId: `ver_${Date.now()}_1`,
+      formSchema: payload.formSchema,
+      approvalGraph: payload.approvalGraph,
+    }
+  }
+  return apiPost('/api/approval-templates', payload)
+}
+
+export async function updateTemplate(
+  templateId: string,
+  payload: UpdateApprovalTemplateRequest,
+): Promise<ApprovalTemplateDetailDTO> {
+  if (USE_MOCK) {
+    const base = mockTemplateDetail(templateId)
+    return {
+      ...base,
+      ...('key' in payload ? { key: payload.key ?? base.key } : {}),
+      ...('name' in payload ? { name: payload.name ?? base.name } : {}),
+      ...('description' in payload ? { description: payload.description ?? null } : {}),
+      ...('category' in payload ? { category: payload.category ?? null } : {}),
+      ...('visibilityScope' in payload ? { visibilityScope: payload.visibilityScope ?? base.visibilityScope } : {}),
+      ...('slaHours' in payload ? { slaHours: payload.slaHours ?? null } : {}),
+      ...(payload.formSchema ? { formSchema: payload.formSchema } : {}),
+      ...(payload.approvalGraph ? { approvalGraph: payload.approvalGraph } : {}),
+      status: 'draft',
+      activeVersionId: base.activeVersionId,
+      latestVersionId: `ver_${templateId}_${Date.now()}`,
+    }
+  }
+  const response = await apiFetch(`/api/approval-templates/${encodeURIComponent(templateId)}`, {
+    method: 'PATCH',
+    body: JSON.stringify(payload),
+  })
+  if (!response.ok) {
+    throw new Error(`API error: ${response.status} ${response.statusText}`)
+  }
+  return response.json()
+}
+
+export async function publishTemplate(
+  templateId: string,
+  payload: PublishApprovalTemplateRequest,
+): Promise<ApprovalTemplateVersionDetailDTO> {
+  if (USE_MOCK) {
+    return {
+      ...mockVersionDetail(templateId, `ver_${templateId}_${Date.now()}`),
+      status: 'published',
+      runtimeGraph: {
+        ...mockTemplateDetail(templateId).approvalGraph,
+        policy: payload.policy,
+      },
+      publishedDefinitionId: `def_${Date.now()}`,
+      updatedAt: new Date().toISOString(),
+    }
+  }
+  return apiPost(`/api/approval-templates/${encodeURIComponent(templateId)}/publish`, payload)
 }
 
 // ---------------------------------------------------------------------------

--- a/apps/web/src/approvals/templateAuthoring.ts
+++ b/apps/web/src/approvals/templateAuthoring.ts
@@ -1,0 +1,468 @@
+import type {
+  ApprovalAssigneeSource,
+  ApprovalGraph,
+  ApprovalMode,
+  ApprovalTemplateDetailDTO,
+  ApprovalTemplateVisibilityScope,
+  EmptyAssigneePolicy,
+  FormField,
+  FormFieldType,
+  FormOption,
+  FormSchema,
+  CreateApprovalTemplateRequest,
+  UpdateApprovalTemplateRequest,
+} from '../types/approval'
+
+export type AuthorableFieldType = Exclude<FormFieldType, 'attachment'>
+export type ApprovalStepSourceKind = ApprovalAssigneeSource['kind']
+
+export const AUTHORABLE_FIELD_TYPES: AuthorableFieldType[] = [
+  'text',
+  'textarea',
+  'number',
+  'date',
+  'datetime',
+  'select',
+  'multi-select',
+  'user',
+]
+
+export interface FieldAuthoringDraft {
+  localId: string
+  id: string
+  type: AuthorableFieldType
+  label: string
+  required: boolean
+  placeholder: string
+  optionsText: string
+  original?: FormField
+}
+
+export interface ApprovalStepDraft {
+  localId: string
+  name: string
+  sourceKind: ApprovalStepSourceKind
+  idsText: string
+  fieldId: string
+  approvalMode: ApprovalMode
+  emptyAssigneePolicy: EmptyAssigneePolicy
+}
+
+export interface TemplateAuthoringDraft {
+  templateId?: string
+  key: string
+  name: string
+  description: string
+  category: string
+  visibilityType: ApprovalTemplateVisibilityScope['type']
+  visibilityIdsText: string
+  slaHoursText: string
+  allowRevoke: boolean
+  fields: FieldAuthoringDraft[]
+  steps: ApprovalStepDraft[]
+}
+
+const UNSUPPORTED_GRAPH_NODE_TYPES = new Set(['cc', 'condition', 'parallel'])
+
+function nextLocalId(prefix: string): string {
+  return `${prefix}_${Date.now()}_${Math.random().toString(16).slice(2, 8)}`
+}
+
+export function createEmptyFieldDraft(index = 1): FieldAuthoringDraft {
+  return {
+    localId: nextLocalId('field'),
+    id: `field_${index}`,
+    type: 'text',
+    label: `字段 ${index}`,
+    required: false,
+    placeholder: '',
+    optionsText: '',
+  }
+}
+
+export function createEmptyStepDraft(index = 1): ApprovalStepDraft {
+  return {
+    localId: nextLocalId('step'),
+    name: `审批人 ${index}`,
+    sourceKind: 'requester',
+    idsText: '',
+    fieldId: '',
+    approvalMode: 'single',
+    emptyAssigneePolicy: 'error',
+  }
+}
+
+export function createEmptyTemplateDraft(): TemplateAuthoringDraft {
+  return {
+    key: '',
+    name: '',
+    description: '',
+    category: '',
+    visibilityType: 'all',
+    visibilityIdsText: '',
+    slaHoursText: '',
+    allowRevoke: true,
+    fields: [createEmptyFieldDraft(1)],
+    steps: [createEmptyStepDraft(1)],
+  }
+}
+
+export function formatOptionsText(options?: FormOption[]): string {
+  return (options ?? [])
+    .map((option) => `${option.label}:${option.value}`)
+    .join('\n')
+}
+
+export function parseOptionsText(value: string): FormOption[] {
+  return value
+    .split('\n')
+    .map((line) => line.trim())
+    .filter(Boolean)
+    .map((line) => {
+      const separator = line.indexOf(':')
+      if (separator === -1) {
+        return { label: line, value: line }
+      }
+      return {
+        label: line.slice(0, separator).trim(),
+        value: line.slice(separator + 1).trim(),
+      }
+    })
+}
+
+export function parseIdsText(value: string): string[] {
+  return Array.from(
+    new Set(
+      value
+        .split(/[\n,，]/)
+        .map((entry) => entry.trim())
+        .filter(Boolean),
+    ),
+  )
+}
+
+function formatIds(ids?: string[]): string {
+  return (ids ?? []).join(', ')
+}
+
+function isAuthorableFieldType(value: FormFieldType): value is AuthorableFieldType {
+  return AUTHORABLE_FIELD_TYPES.includes(value as AuthorableFieldType)
+}
+
+function fieldDraftFromField(field: FormField): FieldAuthoringDraft | null {
+  if (!isAuthorableFieldType(field.type)) return null
+  return {
+    localId: nextLocalId('field'),
+    id: field.id,
+    type: field.type,
+    label: field.label,
+    required: field.required === true,
+    placeholder: field.placeholder ?? '',
+    optionsText: formatOptionsText(field.options),
+    original: field,
+  }
+}
+
+function stepDraftFromApprovalNode(
+  node: ApprovalGraph['nodes'][number],
+  index: number,
+): ApprovalStepDraft | null {
+  if (node.type !== 'approval') return null
+  const config = node.config as Record<string, unknown>
+  const source = Array.isArray(config.assigneeSources)
+    ? config.assigneeSources[0] as ApprovalAssigneeSource | undefined
+    : undefined
+  const legacyType = config.assigneeType
+  const legacyIds = Array.isArray(config.assigneeIds)
+    ? config.assigneeIds.filter((entry): entry is string => typeof entry === 'string')
+    : []
+
+  let sourceKind: ApprovalStepSourceKind = 'requester'
+  let idsText = ''
+  let fieldId = ''
+  if (source?.kind === 'static_user') {
+    sourceKind = 'static_user'
+    idsText = formatIds(source.userIds)
+  } else if (source?.kind === 'static_role') {
+    sourceKind = 'static_role'
+    idsText = formatIds(source.roleIds)
+  } else if (source?.kind === 'requester') {
+    sourceKind = 'requester'
+  } else if (source?.kind === 'form_field_user') {
+    sourceKind = 'form_field_user'
+    fieldId = source.fieldId
+  } else if (legacyType === 'user') {
+    sourceKind = 'static_user'
+    idsText = formatIds(legacyIds)
+  } else if (legacyType === 'role') {
+    sourceKind = 'static_role'
+    idsText = formatIds(legacyIds)
+  }
+
+  return {
+    localId: nextLocalId('step'),
+    name: node.name ?? `审批人 ${index}`,
+    sourceKind,
+    idsText,
+    fieldId,
+    approvalMode: config.approvalMode === 'all' || config.approvalMode === 'any' ? config.approvalMode : 'single',
+    emptyAssigneePolicy: config.emptyAssigneePolicy === 'auto-approve' ? 'auto-approve' : 'error',
+  }
+}
+
+function orderedLinearNodes(graph: ApprovalGraph): ApprovalGraph['nodes'] | null {
+  const nodeByKey = new Map(graph.nodes.map((node) => [node.key, node]))
+  const outgoing = new Map<string, string[]>()
+  const incoming = new Map<string, string[]>()
+  for (const edge of graph.edges) {
+    if (!edge || typeof edge.key !== 'string' || typeof edge.source !== 'string' || typeof edge.target !== 'string') {
+      return null
+    }
+    const edgeKeys = Object.keys(edge as unknown as Record<string, unknown>)
+    if (edgeKeys.some((key) => !['key', 'source', 'target'].includes(key))) {
+      return null
+    }
+    if (!nodeByKey.has(edge.source) || !nodeByKey.has(edge.target)) return null
+    outgoing.set(edge.source, [...(outgoing.get(edge.source) ?? []), edge.target])
+    incoming.set(edge.target, [...(incoming.get(edge.target) ?? []), edge.source])
+  }
+
+  const starts = graph.nodes.filter((node) => node.type === 'start')
+  const ends = graph.nodes.filter((node) => node.type === 'end')
+  if (starts.length !== 1 || ends.length !== 1) return null
+
+  const ordered: ApprovalGraph['nodes'] = []
+  const visited = new Set<string>()
+  let cursor = starts[0].key
+  let reachedEnd = false
+  while (!reachedEnd) {
+    if (visited.has(cursor)) return null
+    const node = nodeByKey.get(cursor)
+    if (!node) return null
+    ordered.push(node)
+    visited.add(cursor)
+    if (node.type === 'end') {
+      reachedEnd = true
+      break
+    }
+    const next = outgoing.get(cursor) ?? []
+    if (next.length !== 1) return null
+    cursor = next[0]
+  }
+
+  if (visited.size !== graph.nodes.length) return null
+  for (const node of graph.nodes) {
+    const inCount = incoming.get(node.key)?.length ?? 0
+    const outCount = outgoing.get(node.key)?.length ?? 0
+    if (node.type === 'start' && inCount !== 0) return null
+    if (node.type === 'end' && outCount !== 0) return null
+    if (node.type === 'approval' && (inCount !== 1 || outCount !== 1)) return null
+  }
+  return ordered
+}
+
+export function unsupportedTemplateAuthoringReason(template: ApprovalTemplateDetailDTO): string | null {
+  const unsupportedField = template.formSchema.fields.find((field) => !isAuthorableFieldType(field.type))
+  if (unsupportedField) {
+    return `包含暂不支持编辑的字段类型：${unsupportedField.label || unsupportedField.id} (${unsupportedField.type})`
+  }
+
+  const unknownNode = template.approvalGraph.nodes.find((node) => {
+    const nodeKeys = Object.keys(node as unknown as Record<string, unknown>)
+    return nodeKeys.some((key) => !['key', 'type', 'name', 'config'].includes(key))
+      || UNSUPPORTED_GRAPH_NODE_TYPES.has(node.type)
+      || !['start', 'approval', 'end'].includes(node.type)
+  })
+  if (unknownNode) {
+    return `包含暂不支持编辑的审批节点：${unknownNode.name || unknownNode.key} (${unknownNode.type})`
+  }
+
+  const ordered = orderedLinearNodes(template.approvalGraph)
+  if (!ordered) {
+    return '审批流程不是 MVP 支持的线性结构'
+  }
+
+  const unsupportedApproval = ordered.find((node) => {
+    if (node.type !== 'approval') return false
+    const config = node.config as Record<string, unknown>
+    const allowedConfigKeys = [
+      'assigneeType',
+      'assigneeIds',
+      'assigneeSources',
+      'approvalMode',
+      'emptyAssigneePolicy',
+    ]
+    if (Object.keys(config).some((key) => !allowedConfigKeys.includes(key))) return true
+    const sources = config.assigneeSources
+    if (sources !== undefined) {
+      if (!Array.isArray(sources) || sources.length !== 1) return true
+      const source = sources[0] as ApprovalAssigneeSource
+      if (!['static_user', 'static_role', 'requester', 'form_field_user'].includes(source?.kind)) return true
+    }
+    return false
+  })
+  if (unsupportedApproval) {
+    return `审批节点含暂不支持的配置：${unsupportedApproval.name || unsupportedApproval.key}`
+  }
+
+  return null
+}
+
+export function draftFromTemplate(template: ApprovalTemplateDetailDTO): TemplateAuthoringDraft {
+  const ordered = orderedLinearNodes(template.approvalGraph) ?? template.approvalGraph.nodes
+  const fields = template.formSchema.fields
+    .map(fieldDraftFromField)
+    .filter((field): field is FieldAuthoringDraft => field !== null)
+  const steps = ordered
+    .map(stepDraftFromApprovalNode)
+    .filter((step): step is ApprovalStepDraft => step !== null)
+
+  return {
+    templateId: template.id,
+    key: template.key,
+    name: template.name,
+    description: template.description ?? '',
+    category: template.category ?? '',
+    visibilityType: template.visibilityScope?.type ?? 'all',
+    visibilityIdsText: formatIds(template.visibilityScope?.ids),
+    slaHoursText: template.slaHours == null ? '' : String(template.slaHours),
+    allowRevoke: true,
+    fields: fields.length > 0 ? fields : [createEmptyFieldDraft(1)],
+    steps: steps.length > 0 ? steps : [createEmptyStepDraft(1)],
+  }
+}
+
+export function buildFormSchema(draft: TemplateAuthoringDraft): FormSchema {
+  return {
+    fields: draft.fields.map((field) => {
+      const base = field.original ? { ...field.original } : {}
+      const next: FormField = {
+        ...base,
+        id: field.id.trim(),
+        type: field.type,
+        label: field.label.trim(),
+        required: field.required,
+        ...(field.placeholder.trim() ? { placeholder: field.placeholder.trim() } : {}),
+      }
+      if (!field.placeholder.trim()) {
+        delete next.placeholder
+      }
+      if (field.type === 'select' || field.type === 'multi-select') {
+        next.options = parseOptionsText(field.optionsText)
+      } else {
+        delete next.options
+      }
+      return next
+    }),
+  }
+}
+
+function sourceFromStep(step: ApprovalStepDraft): ApprovalAssigneeSource {
+  if (step.sourceKind === 'static_user') {
+    return { kind: 'static_user', userIds: parseIdsText(step.idsText) }
+  }
+  if (step.sourceKind === 'static_role') {
+    return { kind: 'static_role', roleIds: parseIdsText(step.idsText) }
+  }
+  if (step.sourceKind === 'form_field_user') {
+    return { kind: 'form_field_user', fieldId: step.fieldId.trim() }
+  }
+  return { kind: 'requester' }
+}
+
+export function buildApprovalGraph(draft: TemplateAuthoringDraft): ApprovalGraph {
+  const approvalNodes = draft.steps.map((step, index) => ({
+    key: `approval_${index + 1}`,
+    type: 'approval' as const,
+    name: step.name.trim() || `审批人 ${index + 1}`,
+    config: {
+      assigneeSources: [sourceFromStep(step)],
+      approvalMode: step.approvalMode,
+      emptyAssigneePolicy: step.emptyAssigneePolicy,
+    },
+  }))
+  const nodes: ApprovalGraph['nodes'] = [
+    { key: 'start', type: 'start', name: '发起', config: {} },
+    ...approvalNodes,
+    { key: 'end', type: 'end', name: '结束', config: {} },
+  ]
+  const keys = nodes.map((node) => node.key)
+  return {
+    nodes,
+    edges: keys.slice(0, -1).map((source, index) => ({
+      key: `edge-${source}-${keys[index + 1]}`,
+      source,
+      target: keys[index + 1],
+    })),
+  }
+}
+
+export function buildVisibilityScope(draft: TemplateAuthoringDraft): ApprovalTemplateVisibilityScope {
+  if (draft.visibilityType === 'all') return { type: 'all', ids: [] }
+  return { type: draft.visibilityType, ids: parseIdsText(draft.visibilityIdsText) }
+}
+
+export function buildSlaHours(draft: TemplateAuthoringDraft): number | null {
+  const value = draft.slaHoursText.trim()
+  if (!value) return null
+  const parsed = Number(value)
+  return Number.isInteger(parsed) && parsed > 0 ? parsed : Number.NaN
+}
+
+export function validateTemplateDraft(
+  draft: TemplateAuthoringDraft,
+  unsupportedReason?: string | null,
+): string[] {
+  const errors: string[] = []
+  if (unsupportedReason) errors.push(unsupportedReason)
+  if (!draft.key.trim()) errors.push('模板 Key 必填')
+  if (!draft.name.trim()) errors.push('模板名称必填')
+  if (draft.visibilityType !== 'all' && parseIdsText(draft.visibilityIdsText).length === 0) {
+    errors.push('非全员可见范围至少需要一个 id')
+  }
+  if (Number.isNaN(buildSlaHours(draft))) {
+    errors.push('SLA 必须是正整数小时或留空')
+  }
+  const fields = draft.fields.map((field) => field.id.trim()).filter(Boolean)
+  if (fields.length !== draft.fields.length) errors.push('字段 id 必填')
+  if (new Set(fields).size !== fields.length) errors.push('字段 id 不能重复')
+  draft.fields.forEach((field) => {
+    if (!field.label.trim()) errors.push(`字段 ${field.id || '(未命名)'} 的名称必填`)
+    if ((field.type === 'select' || field.type === 'multi-select')) {
+      const options = parseOptionsText(field.optionsText)
+      if (options.length === 0) errors.push(`字段 ${field.label || field.id} 需要至少一个选项`)
+      if (options.some((option) => !option.label.trim() || !option.value.trim())) {
+        errors.push(`字段 ${field.label || field.id} 的选项 label/value 不能为空`)
+      }
+    }
+  })
+  if (draft.steps.length === 0) errors.push('至少需要一个审批步骤')
+  const userFieldIds = new Set(draft.fields.filter((field) => field.type === 'user').map((field) => field.id.trim()))
+  draft.steps.forEach((step, index) => {
+    const label = step.name.trim() || `审批步骤 ${index + 1}`
+    if ((step.sourceKind === 'static_user' || step.sourceKind === 'static_role') && parseIdsText(step.idsText).length === 0) {
+      errors.push(`${label} 需要填写用户/角色 id`)
+    }
+    if (step.sourceKind === 'form_field_user' && !userFieldIds.has(step.fieldId.trim())) {
+      errors.push(`${label} 的表单用户字段无效`)
+    }
+  })
+  return errors
+}
+
+export function buildCreateTemplatePayload(draft: TemplateAuthoringDraft): CreateApprovalTemplateRequest {
+  return {
+    key: draft.key.trim(),
+    name: draft.name.trim(),
+    description: draft.description.trim() || null,
+    category: draft.category.trim() || null,
+    visibilityScope: buildVisibilityScope(draft),
+    slaHours: buildSlaHours(draft),
+    formSchema: buildFormSchema(draft),
+    approvalGraph: buildApprovalGraph(draft),
+  }
+}
+
+export function buildUpdateTemplatePayload(draft: TemplateAuthoringDraft): UpdateApprovalTemplateRequest {
+  return buildCreateTemplatePayload(draft)
+}

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -256,6 +256,18 @@ export const appRoutes: RouteRecordRaw[] = [
     meta: { title: 'Approval Templates', titleZh: '审批模板', requiresAuth: true }
   },
   {
+    path: '/approval-templates/new',
+    name: 'approval-template-create',
+    component: () => import('../views/approval/TemplateAuthoringView.vue'),
+    meta: { title: 'New Approval Template', titleZh: '新建审批模板', requiresAuth: true, permissions: ['approval-templates:manage'] }
+  },
+  {
+    path: '/approval-templates/:id/edit',
+    name: 'approval-template-edit',
+    component: () => import('../views/approval/TemplateAuthoringView.vue'),
+    meta: { title: 'Edit Approval Template', titleZh: '编辑审批模板', requiresAuth: true, permissions: ['approval-templates:manage'] }
+  },
+  {
     path: '/approval-templates/:id',
     name: 'approval-template-detail',
     component: () => import('../views/approval/TemplateDetailView.vue'),

--- a/apps/web/src/router/types.ts
+++ b/apps/web/src/router/types.ts
@@ -66,6 +66,8 @@ export const AppRouteNames = {
   APPROVAL_DETAIL: 'approval-detail',
   APPROVAL_CREATE: 'approval-create',
   APPROVAL_TEMPLATE_LIST: 'approval-template-list',
+  APPROVAL_TEMPLATE_CREATE: 'approval-template-create',
+  APPROVAL_TEMPLATE_EDIT: 'approval-template-edit',
   APPROVAL_TEMPLATE_DETAIL: 'approval-template-detail',
   APPROVAL_PENDING: 'approval-pending',
   APPROVAL_HISTORY: 'approval-history',
@@ -129,6 +131,7 @@ export interface AppRouteParams {
   'approval-detail': { id: string }
   'approval-create': { templateId: string }
   'approval-template-detail': { id: string }
+  'approval-template-edit': { id: string }
 
   // User routes
   'user-profile': { id?: string } // optional, defaults to current user
@@ -147,6 +150,7 @@ export interface AppRouteParams {
   'workflow-create': Record<string, never>
   'approval-list': Record<string, never>
   'approval-template-list': Record<string, never>
+  'approval-template-create': Record<string, never>
   'approval-pending': Record<string, never>
   'approval-history': Record<string, never>
   'attendance': Record<string, never>
@@ -437,6 +441,8 @@ export const ROUTE_PATHS = {
   APPROVAL_DETAIL: '/approvals/:id',
   APPROVAL_CREATE: '/approvals/new/:templateId',
   APPROVAL_TEMPLATE_LIST: '/approval-templates',
+  APPROVAL_TEMPLATE_CREATE: '/approval-templates/new',
+  APPROVAL_TEMPLATE_EDIT: '/approval-templates/:id/edit',
   APPROVAL_TEMPLATE_DETAIL: '/approval-templates/:id',
   APPROVAL_PENDING: '/approvals/pending',
   APPROVAL_HISTORY: '/approvals/history',

--- a/apps/web/src/types/approval.ts
+++ b/apps/web/src/types/approval.ts
@@ -9,6 +9,7 @@ export type ApprovalProductPermission = typeof APPROVAL_PRODUCT_PERMISSIONS[numb
 
 export type ApprovalNodeType = 'start' | 'approval' | 'cc' | 'condition' | 'parallel' | 'end'
 export type ApprovalAssigneeType = 'user' | 'role'
+export type ApprovalAssigneeSourceKind = 'static_user' | 'static_role' | 'requester' | 'form_field_user'
 export type ApprovalMode = 'single' | 'all' | 'any'
 export type ParallelJoinMode = 'all' | 'any'
 export type EmptyAssigneePolicy = 'error' | 'auto-approve'
@@ -41,11 +42,18 @@ export interface ApprovalNode {
 }
 
 export interface ApprovalNodeConfig {
-  assigneeType: ApprovalAssigneeType
-  assigneeIds: string[]
+  assigneeType?: ApprovalAssigneeType
+  assigneeIds?: string[]
+  assigneeSources?: ApprovalAssigneeSource[]
   approvalMode?: ApprovalMode
   emptyAssigneePolicy?: EmptyAssigneePolicy
 }
+
+export type ApprovalAssigneeSource =
+  | { kind: 'static_user'; userIds: string[] }
+  | { kind: 'static_role'; roleIds: string[] }
+  | { kind: 'requester' }
+  | { kind: 'form_field_user'; fieldId: string }
 
 export interface ConditionNodeConfig {
   branches: ConditionBranch[]
@@ -247,4 +255,30 @@ export interface ApprovalTemplateVersionDetailDTO {
   publishedDefinitionId: string | null
   createdAt: string
   updatedAt: string
+}
+
+export interface CreateApprovalTemplateRequest {
+  key: string
+  name: string
+  description?: string | null
+  category?: string | null
+  visibilityScope?: ApprovalTemplateVisibilityScope
+  slaHours?: number | null
+  formSchema: FormSchema
+  approvalGraph: ApprovalGraph
+}
+
+export interface UpdateApprovalTemplateRequest {
+  key?: string
+  name?: string
+  description?: string | null
+  category?: string | null
+  visibilityScope?: ApprovalTemplateVisibilityScope
+  slaHours?: number | null
+  formSchema?: FormSchema
+  approvalGraph?: ApprovalGraph
+}
+
+export interface PublishApprovalTemplateRequest {
+  policy: RuntimePolicy
 }

--- a/apps/web/src/views/approval/TemplateAuthoringView.vue
+++ b/apps/web/src/views/approval/TemplateAuthoringView.vue
@@ -1,0 +1,567 @@
+<template>
+  <section class="template-authoring">
+    <header class="template-authoring__header">
+      <el-button text @click="goBack">
+        <el-icon><ArrowLeft /></el-icon>
+        返回模板列表
+      </el-button>
+      <div>
+        <h1>{{ isEditMode ? '编辑审批模板' : '新建审批模板' }}</h1>
+        <p>面向模板管理员的线性审批模板编辑器</p>
+      </div>
+      <div class="template-authoring__actions">
+        <el-button
+          :loading="saving"
+          :disabled="!canSave"
+          data-testid="approval-template-save-button"
+          @click="handleSave"
+        >
+          保存草稿
+        </el-button>
+        <el-button
+          type="primary"
+          :loading="publishing"
+          :disabled="!canSave"
+          data-testid="approval-template-publish-button"
+          @click="handlePublish"
+        >
+          发布
+        </el-button>
+      </div>
+    </header>
+
+    <el-alert
+      v-if="!canManageTemplates"
+      title="你没有模板管理权限"
+      type="warning"
+      show-icon
+      :closable="false"
+      class="template-authoring__alert"
+    />
+
+    <el-alert
+      v-if="unsupportedReason"
+      :title="unsupportedReason"
+      description="该模板包含当前 MVP 不支持编辑的结构。为避免静默覆盖，页面只允许查看，不能保存。"
+      type="warning"
+      show-icon
+      :closable="false"
+      class="template-authoring__alert"
+      data-testid="approval-template-unsupported-alert"
+    />
+
+    <el-alert
+      v-if="loadError || validationErrors.length"
+      :title="loadError || '请修正后再保存'"
+      type="error"
+      show-icon
+      class="template-authoring__alert"
+      @close="clearErrors"
+    >
+      <template v-if="validationErrors.length" #default>
+        <ul class="template-authoring__error-list">
+          <li v-for="error in validationErrors" :key="error">{{ error }}</li>
+        </ul>
+      </template>
+    </el-alert>
+
+    <div v-loading="loading" class="template-authoring__body">
+      <el-card class="template-authoring__panel" shadow="never">
+        <template #header>
+          <strong>基本信息</strong>
+        </template>
+        <el-form label-position="top" class="template-authoring__grid">
+          <el-form-item label="模板 Key">
+            <el-input v-model="draft.key" :disabled="readOnly" data-testid="approval-template-key" />
+          </el-form-item>
+          <el-form-item label="模板名称">
+            <el-input v-model="draft.name" :disabled="readOnly" data-testid="approval-template-name" />
+          </el-form-item>
+          <el-form-item label="分类">
+            <el-input v-model="draft.category" :disabled="readOnly" placeholder="如 请假 / 采购 / 报销" />
+          </el-form-item>
+          <el-form-item label="SLA 小时">
+            <el-input v-model="draft.slaHoursText" :disabled="readOnly" placeholder="留空表示不启用" />
+          </el-form-item>
+          <el-form-item label="描述" class="template-authoring__wide">
+            <el-input
+              v-model="draft.description"
+              :disabled="readOnly"
+              type="textarea"
+              :rows="3"
+            />
+          </el-form-item>
+          <el-form-item label="可见范围">
+            <div class="template-authoring__inline">
+              <el-select v-model="draft.visibilityType" :disabled="readOnly" style="width: 140px">
+                <el-option label="全员" value="all" />
+                <el-option label="部门" value="dept" />
+                <el-option label="角色" value="role" />
+                <el-option label="用户" value="user" />
+              </el-select>
+              <el-input
+                v-model="draft.visibilityIdsText"
+                :disabled="readOnly || draft.visibilityType === 'all'"
+                placeholder="逗号分隔 id"
+              />
+            </div>
+          </el-form-item>
+          <el-form-item label="发布策略">
+            <el-checkbox v-model="draft.allowRevoke" :disabled="readOnly">
+              允许发起人撤回
+            </el-checkbox>
+          </el-form-item>
+        </el-form>
+      </el-card>
+
+      <el-card class="template-authoring__panel" shadow="never">
+        <template #header>
+          <div class="template-authoring__panel-header">
+            <strong>表单字段</strong>
+            <el-button
+              size="small"
+              :disabled="readOnly"
+              data-testid="approval-template-add-field"
+              @click="addField"
+            >
+              <el-icon><Plus /></el-icon>
+              添加字段
+            </el-button>
+          </div>
+        </template>
+
+        <div
+          v-for="(field, index) in draft.fields"
+          :key="field.localId"
+          class="template-authoring__item"
+          data-testid="approval-template-field-row"
+        >
+          <div class="template-authoring__item-toolbar">
+            <strong>字段 {{ index + 1 }}</strong>
+            <div>
+              <el-button size="small" :disabled="readOnly || index === 0" @click="moveField(index, -1)">上移</el-button>
+              <el-button size="small" :disabled="readOnly || index === draft.fields.length - 1" @click="moveField(index, 1)">下移</el-button>
+              <el-button size="small" type="danger" :disabled="readOnly || draft.fields.length === 1" @click="removeField(index)">删除</el-button>
+            </div>
+          </div>
+          <div class="template-authoring__grid">
+            <el-form-item label="字段 ID">
+              <el-input v-model="field.id" :disabled="readOnly" />
+            </el-form-item>
+            <el-form-item label="字段名称">
+              <el-input v-model="field.label" :disabled="readOnly" />
+            </el-form-item>
+            <el-form-item label="类型">
+              <el-select v-model="field.type" :disabled="readOnly" style="width: 100%">
+                <el-option label="文本" value="text" />
+                <el-option label="多行文本" value="textarea" />
+                <el-option label="数字" value="number" />
+                <el-option label="日期" value="date" />
+                <el-option label="日期时间" value="datetime" />
+                <el-option label="单选" value="select" />
+                <el-option label="多选" value="multi-select" />
+                <el-option label="用户" value="user" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="占位文本">
+              <el-input v-model="field.placeholder" :disabled="readOnly" />
+            </el-form-item>
+            <el-form-item label="是否必填">
+              <el-checkbox v-model="field.required" :disabled="readOnly">必填</el-checkbox>
+            </el-form-item>
+            <el-form-item
+              v-if="field.type === 'select' || field.type === 'multi-select'"
+              label="选项"
+              class="template-authoring__wide"
+            >
+              <el-input
+                v-model="field.optionsText"
+                :disabled="readOnly"
+                type="textarea"
+                :rows="3"
+                placeholder="每行一个选项，格式：显示名:值"
+              />
+            </el-form-item>
+          </div>
+        </div>
+      </el-card>
+
+      <el-card class="template-authoring__panel" shadow="never">
+        <template #header>
+          <div class="template-authoring__panel-header">
+            <strong>审批步骤</strong>
+            <el-button
+              size="small"
+              :disabled="readOnly"
+              data-testid="approval-template-add-step"
+              @click="addStep"
+            >
+              <el-icon><Plus /></el-icon>
+              添加审批人
+            </el-button>
+          </div>
+        </template>
+
+        <div
+          v-for="(step, index) in draft.steps"
+          :key="step.localId"
+          class="template-authoring__item"
+          data-testid="approval-template-step-row"
+        >
+          <div class="template-authoring__item-toolbar">
+            <strong>审批步骤 {{ index + 1 }}</strong>
+            <div>
+              <el-button size="small" :disabled="readOnly || index === 0" @click="moveStep(index, -1)">上移</el-button>
+              <el-button size="small" :disabled="readOnly || index === draft.steps.length - 1" @click="moveStep(index, 1)">下移</el-button>
+              <el-button size="small" type="danger" :disabled="readOnly || draft.steps.length === 1" @click="removeStep(index)">删除</el-button>
+            </div>
+          </div>
+          <div class="template-authoring__grid">
+            <el-form-item label="步骤名称">
+              <el-input v-model="step.name" :disabled="readOnly" />
+            </el-form-item>
+            <el-form-item label="审批人来源">
+              <el-select v-model="step.sourceKind" :disabled="readOnly" style="width: 100%">
+                <el-option label="指定用户 ID" value="static_user" />
+                <el-option label="指定角色 ID" value="static_role" />
+                <el-option label="发起人" value="requester" />
+                <el-option label="表单用户字段" value="form_field_user" />
+              </el-select>
+            </el-form-item>
+            <el-form-item v-if="step.sourceKind === 'static_user' || step.sourceKind === 'static_role'" label="用户/角色 ID">
+              <el-input v-model="step.idsText" :disabled="readOnly" placeholder="逗号或换行分隔" />
+            </el-form-item>
+            <el-form-item v-if="step.sourceKind === 'form_field_user'" label="表单用户字段">
+              <el-select v-model="step.fieldId" :disabled="readOnly" style="width: 100%">
+                <el-option
+                  v-for="field in userFields"
+                  :key="field.id"
+                  :label="`${field.label} (${field.id})`"
+                  :value="field.id"
+                />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="审批模式">
+              <el-select v-model="step.approvalMode" :disabled="readOnly" style="width: 100%">
+                <el-option label="单人通过" value="single" />
+                <el-option label="全部通过" value="all" />
+                <el-option label="任一通过" value="any" />
+              </el-select>
+            </el-form-item>
+            <el-form-item label="空审批人策略">
+              <el-select v-model="step.emptyAssigneePolicy" :disabled="readOnly" style="width: 100%">
+                <el-option label="报错" value="error" />
+                <el-option label="自动通过" value="auto-approve" />
+              </el-select>
+            </el-form-item>
+          </div>
+        </div>
+      </el-card>
+
+      <el-card class="template-authoring__panel" shadow="never">
+        <template #header>
+          <strong>JSON 预览</strong>
+        </template>
+        <el-collapse>
+          <el-collapse-item title="formSchema" name="form">
+            <pre data-testid="approval-template-form-preview">{{ formSchemaPreview }}</pre>
+          </el-collapse-item>
+          <el-collapse-item title="approvalGraph" name="graph">
+            <pre data-testid="approval-template-graph-preview">{{ approvalGraphPreview }}</pre>
+          </el-collapse-item>
+        </el-collapse>
+      </el-card>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, onMounted, ref } from 'vue'
+import { useRoute, useRouter } from 'vue-router'
+import { ArrowLeft, Plus } from '@element-plus/icons-vue'
+import { ElMessage, ElMessageBox } from 'element-plus'
+import { useApprovalPermissions } from '../../approvals/permissions'
+import {
+  createTemplate,
+  getTemplate,
+  publishTemplate,
+  updateTemplate,
+} from '../../approvals/api'
+import {
+  buildApprovalGraph,
+  buildCreateTemplatePayload,
+  buildFormSchema,
+  buildUpdateTemplatePayload,
+  createEmptyFieldDraft,
+  createEmptyStepDraft,
+  createEmptyTemplateDraft,
+  draftFromTemplate,
+  unsupportedTemplateAuthoringReason,
+  validateTemplateDraft,
+  type TemplateAuthoringDraft,
+} from '../../approvals/templateAuthoring'
+
+const route = useRoute()
+const router = useRouter()
+const { canManageTemplates } = useApprovalPermissions()
+
+const loading = ref(false)
+const saving = ref(false)
+const publishing = ref(false)
+const loadError = ref<string | null>(null)
+const validationErrors = ref<string[]>([])
+const unsupportedReason = ref<string | null>(null)
+const draft = ref<TemplateAuthoringDraft>(createEmptyTemplateDraft())
+
+const templateId = computed(() => typeof route.params.id === 'string' ? route.params.id : '')
+const isEditMode = computed(() => templateId.value.length > 0)
+const readOnly = computed(() => !canManageTemplates.value || Boolean(unsupportedReason.value))
+const canSave = computed(() => canManageTemplates.value && !unsupportedReason.value && !loading.value)
+const userFields = computed(() => draft.value.fields.filter((field) => field.type === 'user' && field.id.trim()))
+const formSchemaPreview = computed(() => JSON.stringify(buildFormSchema(draft.value), null, 2))
+const approvalGraphPreview = computed(() => JSON.stringify(buildApprovalGraph(draft.value), null, 2))
+
+function clearErrors() {
+  loadError.value = null
+  validationErrors.value = []
+}
+
+function goBack() {
+  router.push({ path: '/approval-templates' })
+}
+
+function swap<T>(items: T[], index: number, delta: -1 | 1) {
+  const target = index + delta
+  if (target < 0 || target >= items.length) return
+  const copy = [...items]
+  const current = copy[index]
+  copy[index] = copy[target]
+  copy[target] = current
+  return copy
+}
+
+function addField() {
+  draft.value.fields = [...draft.value.fields, createEmptyFieldDraft(draft.value.fields.length + 1)]
+}
+
+function removeField(index: number) {
+  if (draft.value.fields.length === 1) return
+  draft.value.fields = draft.value.fields.filter((_, i) => i !== index)
+}
+
+function moveField(index: number, delta: -1 | 1) {
+  draft.value.fields = swap(draft.value.fields, index, delta) ?? draft.value.fields
+}
+
+function addStep() {
+  draft.value.steps = [...draft.value.steps, createEmptyStepDraft(draft.value.steps.length + 1)]
+}
+
+function removeStep(index: number) {
+  if (draft.value.steps.length === 1) return
+  draft.value.steps = draft.value.steps.filter((_, i) => i !== index)
+}
+
+function moveStep(index: number, delta: -1 | 1) {
+  draft.value.steps = swap(draft.value.steps, index, delta) ?? draft.value.steps
+}
+
+async function loadTemplateForEdit() {
+  if (!isEditMode.value) {
+    draft.value = createEmptyTemplateDraft()
+    unsupportedReason.value = null
+    return
+  }
+  loading.value = true
+  loadError.value = null
+  try {
+    const template = await getTemplate(templateId.value)
+    unsupportedReason.value = unsupportedTemplateAuthoringReason(template)
+    draft.value = draftFromTemplate(template)
+  } catch (error: any) {
+    loadError.value = error?.message ?? '加载审批模板失败'
+  } finally {
+    loading.value = false
+  }
+}
+
+function validate(): boolean {
+  validationErrors.value = validateTemplateDraft(draft.value, unsupportedReason.value)
+  if (validationErrors.value.length > 0) {
+    ElMessage.warning('请先修正模板配置')
+    return false
+  }
+  return true
+}
+
+async function persistDraft() {
+  if (!validate()) return null
+  saving.value = true
+  try {
+    if (draft.value.templateId) {
+      const updated = await updateTemplate(draft.value.templateId, buildUpdateTemplatePayload(draft.value))
+      draft.value = draftFromTemplate(updated)
+      unsupportedReason.value = unsupportedTemplateAuthoringReason(updated)
+      return updated
+    }
+    const created = await createTemplate(buildCreateTemplatePayload(draft.value))
+    draft.value = draftFromTemplate(created)
+    unsupportedReason.value = unsupportedTemplateAuthoringReason(created)
+    await router.replace({ path: `/approval-templates/${created.id}/edit` })
+    return created
+  } catch (error: any) {
+    loadError.value = error?.message ?? '保存模板失败'
+    return null
+  } finally {
+    saving.value = false
+  }
+}
+
+async function handleSave() {
+  if (!canSave.value || saving.value) return
+  const saved = await persistDraft()
+  if (saved) {
+    ElMessage.success('草稿已保存')
+  }
+}
+
+async function handlePublish() {
+  if (!canSave.value || publishing.value) return
+  try {
+    await ElMessageBox.confirm('发布后用户即可从模板中心发起审批，确认发布吗？', '发布审批模板', {
+      confirmButtonText: '发布',
+      cancelButtonText: '取消',
+      type: 'warning',
+    })
+  } catch {
+    return
+  }
+  publishing.value = true
+  try {
+    const saved = await persistDraft()
+    if (!saved) return
+    await publishTemplate(saved.id, { policy: { allowRevoke: draft.value.allowRevoke } })
+    ElMessage.success('模板已发布')
+    await router.push({ path: `/approval-templates/${saved.id}` })
+  } catch (error: any) {
+    loadError.value = error?.message ?? '发布模板失败'
+  } finally {
+    publishing.value = false
+  }
+}
+
+onMounted(() => {
+  if (!canManageTemplates.value) return
+  void loadTemplateForEdit()
+})
+</script>
+
+<style scoped>
+.template-authoring {
+  max-width: 1120px;
+  margin: 0 auto;
+  padding: 24px;
+}
+
+.template-authoring__header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 18px;
+}
+
+.template-authoring__header h1 {
+  margin: 0;
+  font-size: 22px;
+  font-weight: 600;
+}
+
+.template-authoring__header p {
+  margin: 4px 0 0;
+  color: var(--el-text-color-secondary, #606266);
+}
+
+.template-authoring__actions,
+.template-authoring__inline,
+.template-authoring__panel-header,
+.template-authoring__item-toolbar {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.template-authoring__actions {
+  justify-content: flex-end;
+}
+
+.template-authoring__alert {
+  margin-bottom: 16px;
+}
+
+.template-authoring__body {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.template-authoring__panel {
+  border-radius: 8px;
+}
+
+.template-authoring__panel-header,
+.template-authoring__item-toolbar {
+  justify-content: space-between;
+}
+
+.template-authoring__grid {
+  display: grid;
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+  gap: 12px 16px;
+}
+
+.template-authoring__wide {
+  grid-column: 1 / -1;
+}
+
+.template-authoring__inline > .el-input {
+  flex: 1;
+}
+
+.template-authoring__item {
+  padding: 14px;
+  border: 1px solid var(--el-border-color-lighter, #ebeef5);
+  border-radius: 8px;
+}
+
+.template-authoring__item + .template-authoring__item {
+  margin-top: 12px;
+}
+
+.template-authoring__item-toolbar {
+  margin-bottom: 12px;
+}
+
+.template-authoring__error-list {
+  margin: 6px 0 0;
+  padding-left: 20px;
+}
+
+pre {
+  margin: 0;
+  white-space: pre-wrap;
+  word-break: break-word;
+  font-size: 12px;
+}
+
+@media (max-width: 760px) {
+  .template-authoring__header {
+    align-items: flex-start;
+    flex-direction: column;
+  }
+
+  .template-authoring__grid {
+    grid-template-columns: 1fr;
+  }
+}
+</style>

--- a/apps/web/src/views/approval/TemplateCenterView.vue
+++ b/apps/web/src/views/approval/TemplateCenterView.vue
@@ -30,19 +30,15 @@
             <el-icon><Search /></el-icon>
           </template>
         </el-input>
-        <el-tooltip
+        <el-button
           v-if="canManageTemplates"
-          content="即将上线"
-          placement="top"
+          type="primary"
+          style="margin-left: 12px"
+          data-testid="template-center-new-button"
+          @click="createTemplate"
         >
-          <el-button
-            type="primary"
-            style="margin-left: 12px"
-            disabled
-          >
-            新建模板
-          </el-button>
-        </el-tooltip>
+          新建模板
+        </el-button>
       </div>
     </header>
 
@@ -271,6 +267,11 @@ function handleRowClick(row: ApprovalTemplateListItemDTO) {
 
 function startApproval(templateId: string) {
   router.push({ path: `/approvals/new/${templateId}` })
+}
+
+function createTemplate() {
+  if (!canManageTemplates.value) return
+  router.push({ path: '/approval-templates/new' })
 }
 
 async function handleClone(row: ApprovalTemplateListItemDTO) {

--- a/apps/web/src/views/approval/TemplateDetailView.vue
+++ b/apps/web/src/views/approval/TemplateDetailView.vue
@@ -22,6 +22,13 @@
       >
         发起审批
       </el-button>
+      <el-button
+        v-if="template && canManageTemplates"
+        data-testid="template-detail-edit-button"
+        @click="editTemplate"
+      >
+        编辑模板
+      </el-button>
     </header>
 
     <el-alert
@@ -637,6 +644,11 @@ function startApproval() {
   if (template.value) {
     router.push({ path: `/approvals/new/${template.value.id}` })
   }
+}
+
+function editTemplate() {
+  if (!template.value || !canManageTemplates.value) return
+  router.push({ path: `/approval-templates/${template.value.id}/edit` })
 }
 
 onMounted(() => {

--- a/apps/web/tests/approvalTemplateAuthoring.spec.ts
+++ b/apps/web/tests/approvalTemplateAuthoring.spec.ts
@@ -1,0 +1,436 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, defineComponent, h, nextTick, ref, type App as VueApp } from 'vue'
+import TemplateAuthoringView from '../src/views/approval/TemplateAuthoringView.vue'
+import type { ApprovalTemplateDetailDTO } from '../src/types/approval'
+import {
+  buildCreateTemplatePayload,
+  buildFormSchema,
+  createEmptyTemplateDraft,
+  draftFromTemplate,
+  unsupportedTemplateAuthoringReason,
+  validateTemplateDraft,
+} from '../src/approvals/templateAuthoring'
+
+const pushSpy = vi.fn().mockResolvedValue(undefined)
+const replaceSpy = vi.fn().mockResolvedValue(undefined)
+let routeParams: Record<string, string> = {}
+
+vi.mock('vue-router', async () => {
+  const actual = await vi.importActual<typeof import('vue-router')>('vue-router')
+  return {
+    ...actual,
+    useRouter: () => ({
+      push: pushSpy,
+      replace: replaceSpy,
+      back: vi.fn(),
+    }),
+    useRoute: () => ({
+      params: routeParams,
+      query: {},
+      path: routeParams.id ? `/approval-templates/${routeParams.id}/edit` : '/approval-templates/new',
+      meta: {},
+    }),
+  }
+})
+
+const canManageTemplates = ref(true)
+vi.mock('../src/approvals/permissions', () => ({
+  useApprovalPermissions: () => ({
+    canManageTemplates,
+    canRead: ref(true),
+    canWrite: ref(true),
+    canAct: ref(true),
+  }),
+}))
+
+const createTemplateSpy = vi.fn()
+const updateTemplateSpy = vi.fn()
+const publishTemplateSpy = vi.fn()
+const getTemplateSpy = vi.fn()
+
+vi.mock('../src/approvals/api', () => ({
+  createTemplate: (payload: unknown) => createTemplateSpy(payload),
+  updateTemplate: (id: string, payload: unknown) => updateTemplateSpy(id, payload),
+  publishTemplate: (id: string, payload: unknown) => publishTemplateSpy(id, payload),
+  getTemplate: (id: string) => getTemplateSpy(id),
+}))
+
+vi.mock('element-plus', () => ({
+  ElMessage: {
+    success: vi.fn(),
+    warning: vi.fn(),
+    error: vi.fn(),
+  },
+  ElMessageBox: {
+    confirm: vi.fn().mockResolvedValue(undefined),
+  },
+}))
+
+const ElButton = defineComponent({
+  name: 'ElButton',
+  props: { disabled: Boolean, loading: Boolean, type: String, text: Boolean, size: String },
+  emits: ['click'],
+  render() {
+    return h('button', {
+      type: 'button',
+      disabled: this.disabled || this.loading,
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+      onClick: (event: Event) => this.$emit('click', event),
+    }, this.$slots.default?.())
+  },
+})
+
+const ElInput = defineComponent({
+  name: 'ElInput',
+  props: { modelValue: [String, Number], disabled: Boolean, type: String, rows: Number, placeholder: String },
+  emits: ['update:modelValue'],
+  render() {
+    return h('input', {
+      value: this.modelValue ?? '',
+      disabled: this.disabled,
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+      onInput: (event: Event) => this.$emit('update:modelValue', (event.target as HTMLInputElement).value),
+    })
+  },
+})
+
+const ElSelect = defineComponent({
+  name: 'ElSelect',
+  props: { modelValue: String, disabled: Boolean },
+  emits: ['update:modelValue', 'change'],
+  render() {
+    return h('select', {
+      value: this.modelValue ?? '',
+      disabled: this.disabled,
+      onChange: (event: Event) => {
+        const value = (event.target as HTMLSelectElement).value
+        this.$emit('update:modelValue', value)
+        this.$emit('change', value)
+      },
+    }, this.$slots.default?.())
+  },
+})
+
+const ElOption = defineComponent({
+  name: 'ElOption',
+  props: { label: String, value: String },
+  render() {
+    return h('option', { value: this.value }, this.label)
+  },
+})
+
+const ElCheckbox = defineComponent({
+  name: 'ElCheckbox',
+  props: { modelValue: Boolean, disabled: Boolean },
+  emits: ['update:modelValue'],
+  render() {
+    return h('label', [
+      h('input', {
+        type: 'checkbox',
+        checked: this.modelValue,
+        disabled: this.disabled,
+        onChange: (event: Event) => this.$emit('update:modelValue', (event.target as HTMLInputElement).checked),
+      }),
+      this.$slots.default?.(),
+    ])
+  },
+})
+
+const passthrough = (name: string, tag = 'div') => defineComponent({
+  name,
+  render() {
+    return h(tag, {
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+    }, this.$slots.default?.())
+  },
+})
+
+const ElAlert = defineComponent({
+  name: 'ElAlert',
+  props: { title: String, description: String },
+  render() {
+    return h('div', {
+      'data-testid': (this.$attrs as any)?.['data-testid'],
+    }, [
+      h('strong', this.title),
+      this.description ? h('p', this.description) : null,
+      this.$slots.default?.(),
+    ])
+  },
+})
+
+function installStubs(app: VueApp<Element>) {
+  app.directive('loading', {})
+  app.component('ElButton', ElButton)
+  app.component('ElInput', ElInput)
+  app.component('ElSelect', ElSelect)
+  app.component('ElOption', ElOption)
+  app.component('ElCheckbox', ElCheckbox)
+  app.component('ElAlert', ElAlert)
+  app.component('ElCard', passthrough('ElCard', 'section'))
+  app.component('ElForm', passthrough('ElForm', 'form'))
+  app.component('ElFormItem', passthrough('ElFormItem', 'label'))
+  app.component('ElIcon', passthrough('ElIcon', 'span'))
+  app.component('ElCollapse', passthrough('ElCollapse'))
+  app.component('ElCollapseItem', passthrough('ElCollapseItem'))
+}
+
+function buildTemplate(overrides: Partial<ApprovalTemplateDetailDTO> = {}): ApprovalTemplateDetailDTO {
+  return {
+    id: 'tpl_1',
+    key: 'expense',
+    name: '费用审批',
+    description: null,
+    category: null,
+    visibilityScope: { type: 'all', ids: [] },
+    slaHours: null,
+    status: 'draft',
+    activeVersionId: null,
+    latestVersionId: 'ver_1',
+    createdAt: '2026-06-04T00:00:00Z',
+    updatedAt: '2026-06-04T00:00:00Z',
+    formSchema: {
+      fields: [
+        { id: 'amount', type: 'number', label: '金额', required: true },
+        {
+          id: 'reviewer',
+          type: 'user',
+          label: '审批人',
+          visibilityRule: { fieldId: 'amount', operator: 'notEmpty' },
+        },
+      ],
+    },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: '发起', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          name: '审批人 1',
+          config: {
+            assigneeSources: [{ kind: 'form_field_user', fieldId: 'reviewer' }],
+            approvalMode: 'single',
+            emptyAssigneePolicy: 'error',
+          },
+        },
+        { key: 'end', type: 'end', name: '结束', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+      ],
+    },
+    ...overrides,
+  }
+}
+
+let container: HTMLDivElement | null = null
+let app: VueApp<Element> | null = null
+
+async function mountView() {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp(TemplateAuthoringView)
+  installStubs(app)
+  app.mount(container)
+  await nextTick()
+  await Promise.resolve()
+  await nextTick()
+}
+
+async function flushUi() {
+  for (let i = 0; i < 6; i += 1) {
+    await nextTick()
+    await Promise.resolve()
+  }
+}
+
+function setInput(testId: string, value: string) {
+  const input = container!.querySelector(`[data-testid="${testId}"]`) as HTMLInputElement
+  input.value = value
+  input.dispatchEvent(new Event('input'))
+}
+
+describe('approval template authoring helpers', () => {
+  it('preserves visibilityRule metadata while rebuilding supported fields', () => {
+    const template = buildTemplate()
+    const draft = draftFromTemplate(template)
+    draft.fields[0].label = '报销金额'
+
+    const schema = buildFormSchema(draft)
+
+    expect(schema.fields[1]?.visibilityRule).toEqual({ fieldId: 'amount', operator: 'notEmpty' })
+    expect(schema.fields[0]?.label).toBe('报销金额')
+  })
+
+  it('blocks unsupported graph constructs instead of flattening them', () => {
+    const reason = unsupportedTemplateAuthoringReason(buildTemplate({
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: '发起', config: {} },
+          { key: 'fork', type: 'parallel', name: '并行', config: { branches: ['a', 'b'], joinMode: 'all', joinNodeKey: 'join' } },
+          { key: 'end', type: 'end', name: '结束', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-fork', source: 'start', target: 'fork' },
+          { key: 'edge-fork-end', source: 'fork', target: 'end' },
+        ],
+      },
+    }))
+
+    expect(reason).toContain('暂不支持编辑的审批节点')
+  })
+
+  it('blocks existing attachment fields because the MVP has no upload runtime', () => {
+    const reason = unsupportedTemplateAuthoringReason(buildTemplate({
+      formSchema: {
+        fields: [
+          { id: 'file', type: 'attachment', label: '附件' },
+        ],
+      },
+    }))
+
+    expect(reason).toContain('暂不支持编辑的字段类型')
+  })
+
+  it('validates duplicate field ids, select options, and form-field-user sources', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'bad'
+    draft.name = '坏模板'
+    draft.fields = [
+      { ...draft.fields[0], id: 'dup', label: '字段 A', type: 'select', optionsText: '' },
+      { ...draft.fields[0], localId: 'field_2', id: 'dup', label: '字段 B', type: 'text' },
+    ]
+    draft.steps[0].sourceKind = 'form_field_user'
+    draft.steps[0].fieldId = 'missing_user_field'
+
+    const errors = validateTemplateDraft(draft)
+
+    expect(errors).toContain('字段 id 不能重复')
+    expect(errors.some((error) => error.includes('需要至少一个选项'))).toBe(true)
+    expect(errors.some((error) => error.includes('表单用户字段无效'))).toBe(true)
+  })
+
+  it('builds a create payload with C1 assigneeSources and a deterministic linear graph', () => {
+    const draft = createEmptyTemplateDraft()
+    draft.key = 'leave'
+    draft.name = '请假审批'
+    draft.fields[0].id = 'reviewer'
+    draft.fields[0].label = '审批人'
+    draft.fields[0].type = 'user'
+    draft.steps[0].sourceKind = 'form_field_user'
+    draft.steps[0].fieldId = 'reviewer'
+
+    const payload = buildCreateTemplatePayload(draft)
+
+    expect(payload.approvalGraph.nodes.map((node) => node.key)).toEqual(['start', 'approval_1', 'end'])
+    expect((payload.approvalGraph.nodes[1]?.config as any).assigneeSources).toEqual([
+      { kind: 'form_field_user', fieldId: 'reviewer' },
+    ])
+  })
+})
+
+describe('TemplateAuthoringView', () => {
+  beforeEach(() => {
+    routeParams = {}
+    canManageTemplates.value = true
+    createTemplateSpy.mockReset()
+    updateTemplateSpy.mockReset()
+    publishTemplateSpy.mockReset()
+    getTemplateSpy.mockReset()
+    pushSpy.mockClear()
+    replaceSpy.mockClear()
+    createTemplateSpy.mockImplementation(async (payload) => ({
+      ...buildTemplate({ id: 'tpl_created' }),
+      key: payload.key,
+      name: payload.name,
+      formSchema: payload.formSchema,
+      approvalGraph: payload.approvalGraph,
+    }))
+    updateTemplateSpy.mockImplementation(async (id, payload) => ({
+      ...buildTemplate({ id }),
+      ...payload,
+    }))
+    publishTemplateSpy.mockResolvedValue({})
+  })
+
+  afterEach(() => {
+    app?.unmount()
+    container?.remove()
+    app = null
+    container = null
+  })
+
+  it('creates a draft through the existing backend endpoint wrapper path', async () => {
+    await mountView()
+
+    setInput('approval-template-key', 'travel')
+    setInput('approval-template-name', '出差审批')
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(createTemplateSpy).toHaveBeenCalledTimes(1)
+    const payload = createTemplateSpy.mock.calls[0]?.[0] as any
+    expect(payload.key).toBe('travel')
+    expect(payload.name).toBe('出差审批')
+    expect(payload.approvalGraph.nodes.map((node: any) => node.key)).toEqual(['start', 'approval_1', 'end'])
+    expect(replaceSpy).toHaveBeenCalledWith({ path: '/approval-templates/tpl_created/edit' })
+  })
+
+  it('updates an existing supported template without replacing it through create', async () => {
+    routeParams = { id: 'tpl_1' }
+    getTemplateSpy.mockResolvedValue(buildTemplate())
+    await mountView()
+
+    setInput('approval-template-name', '费用审批 v2')
+    ;(container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(createTemplateSpy).not.toHaveBeenCalled()
+    expect(updateTemplateSpy).toHaveBeenCalledTimes(1)
+    expect(updateTemplateSpy.mock.calls[0]?.[0]).toBe('tpl_1')
+    expect((updateTemplateSpy.mock.calls[0]?.[1] as any).name).toBe('费用审批 v2')
+  })
+
+  it('publishes with an explicit allowRevoke policy after saving', async () => {
+    await mountView()
+
+    setInput('approval-template-key', 'purchase')
+    setInput('approval-template-name', '采购审批')
+    ;(container!.querySelector('[data-testid="approval-template-publish-button"]') as HTMLButtonElement).click()
+    await flushUi()
+
+    expect(createTemplateSpy).toHaveBeenCalledTimes(1)
+    expect(publishTemplateSpy).toHaveBeenCalledWith('tpl_created', { policy: { allowRevoke: true } })
+    expect(pushSpy).toHaveBeenCalledWith({ path: '/approval-templates/tpl_created' })
+  })
+
+  it('opens unsupported existing graphs read-only and refuses to save them', async () => {
+    routeParams = { id: 'tpl_parallel' }
+    getTemplateSpy.mockResolvedValue(buildTemplate({
+      id: 'tpl_parallel',
+      approvalGraph: {
+        nodes: [
+          { key: 'start', type: 'start', name: '发起', config: {} },
+          { key: 'parallel_1', type: 'parallel', name: '并行审批', config: { branches: ['a', 'b'], joinMode: 'all', joinNodeKey: 'end' } },
+          { key: 'end', type: 'end', name: '结束', config: {} },
+        ],
+        edges: [
+          { key: 'edge-start-parallel_1', source: 'start', target: 'parallel_1' },
+          { key: 'edge-parallel_1-end', source: 'parallel_1', target: 'end' },
+        ],
+      },
+    }))
+
+    await mountView()
+
+    expect(container!.querySelector('[data-testid="approval-template-unsupported-alert"]')?.textContent)
+      .toContain('暂不支持编辑')
+    const saveButton = container!.querySelector('[data-testid="approval-template-save-button"]') as HTMLButtonElement
+    expect(saveButton.disabled).toBe(true)
+    saveButton.click()
+    await flushUi()
+
+    expect(updateTemplateSpy).not.toHaveBeenCalled()
+  })
+})

--- a/apps/web/tests/approvalTemplateCenterCategory.spec.ts
+++ b/apps/web/tests/approvalTemplateCenterCategory.spec.ts
@@ -497,6 +497,17 @@ describe('TemplateCenterView — WP4 slice 1 category filter + clone', () => {
     expect(pushSpy).toHaveBeenCalledWith({ path: '/approval-templates/tpl_clone_new' })
   })
 
+  it('routes template managers to the new authoring view', async () => {
+    await mountView()
+    const newButton = container!.querySelector('[data-testid="template-center-new-button"]') as HTMLButtonElement
+    expect(newButton).toBeTruthy()
+
+    newButton.click()
+    await flushUi()
+
+    expect(pushSpy).toHaveBeenCalledWith({ path: '/approval-templates/new' })
+  })
+
   it('does not route when cloneTemplate rejects', async () => {
     cloneTemplateSpy.mockRejectedValueOnce(new Error('boom'))
     await mountView()

--- a/docs/development/approval-template-authoring-frontend-mvp-todo-20260604.md
+++ b/docs/development/approval-template-authoring-frontend-mvp-todo-20260604.md
@@ -1,6 +1,6 @@
 # Approval Template Authoring Frontend MVP TODO - 2026-06-04
 
-Status: **Design-lock proposed, implementation not started**.
+Status: **Frontend MVP implemented in this branch; real-stack UAT pending**.
 
 Canonical design: `docs/development/approval-template-authoring-frontend-mvp-design-20260604.md`.
 
@@ -16,110 +16,110 @@ This TODO covers only the frontend authoring MVP. It does not authorize approval
 
 | Item | Status |
 |---|---|
-| Design-lock | [x] drafted in this PR |
-| API client wrappers | [ ] not started |
-| Template authoring route/view | [ ] not started |
-| Form schema builder | [ ] not started |
-| Linear approval graph builder | [ ] not started |
-| Publish UI | [ ] not started |
-| Frontend tests/typecheck | [ ] not started |
+| Design-lock | [x] landed via #2292 |
+| API client wrappers | [x] implemented |
+| Template authoring route/view | [x] implemented |
+| Form schema builder | [x] implemented |
+| Linear approval graph builder | [x] implemented |
+| Publish UI | [x] implemented |
+| Frontend tests/typecheck | [x] passed |
 | Real-stack UAT | [ ] not started |
 
 ## Implementation Tasks
 
 ### A1. API Client
 
-- [ ] Add `createTemplate()` wrapper in `apps/web/src/approvals/api.ts`.
-- [ ] Add generic `updateTemplate()` wrapper or a narrow `updateTemplateDraft()` wrapper that can send `formSchema` and `approvalGraph`.
-- [ ] Add `publishTemplate()` wrapper.
-- [ ] Add request/response types in `apps/web/src/types/approval.ts` if missing.
-- [ ] Keep existing metadata helpers (`updateTemplateCategory`, `updateTemplateVisibilityScope`, `updateTemplateSlaHours`) working.
+- [x] Add `createTemplate()` wrapper in `apps/web/src/approvals/api.ts`.
+- [x] Add generic `updateTemplate()` wrapper or a narrow `updateTemplateDraft()` wrapper that can send `formSchema` and `approvalGraph`.
+- [x] Add `publishTemplate()` wrapper.
+- [x] Add request/response types in `apps/web/src/types/approval.ts` if missing.
+- [x] Keep existing metadata helpers (`updateTemplateCategory`, `updateTemplateVisibilityScope`, `updateTemplateSlaHours`) working.
 
 ### A2. Routing and Entry
 
-- [ ] Add `/approval-templates/new` route.
-- [ ] Consider `/approval-templates/:id/edit` for draft/latest-version editing.
-- [ ] Enable `新建模板` button only when `canManageTemplates`.
-- [ ] Add route-level no-permission state for users without `approval-templates:manage`.
+- [x] Add `/approval-templates/new` route.
+- [x] Consider `/approval-templates/:id/edit` for draft/latest-version editing.
+- [x] Enable `新建模板` button only when `canManageTemplates`.
+- [x] Add route-level no-permission state for users without `approval-templates:manage`.
 
 ### A3. Authoring View Shell
 
-- [ ] Create a dedicated authoring view, for example `TemplateAuthoringView.vue`.
-- [ ] Header actions: back, save draft, publish.
-- [ ] Show save/publish loading state separately.
-- [ ] Preserve server validation errors and show them near the relevant section when possible.
-- [ ] Follow the existing approval frontend convention: inline Chinese copy is acceptable in this MVP; do not introduce a multitable-style strict label module unless an approval-wide i18n slice is scoped.
+- [x] Create a dedicated authoring view, for example `TemplateAuthoringView.vue`.
+- [x] Header actions: back, save draft, publish.
+- [x] Show save/publish loading state separately.
+- [x] Preserve server validation errors and show them near the relevant section when possible.
+- [x] Follow the existing approval frontend convention: inline Chinese copy is acceptable in this MVP; do not introduce a multitable-style strict label module unless an approval-wide i18n slice is scoped.
 
 ### A4. Basic Metadata Editor
 
-- [ ] Key.
-- [ ] Name.
-- [ ] Description.
-- [ ] Category.
-- [ ] Visibility scope.
-- [ ] SLA hours.
-- [ ] Client validation for key/name.
+- [x] Key.
+- [x] Name.
+- [x] Description.
+- [x] Category.
+- [x] Visibility scope.
+- [x] SLA hours.
+- [x] Client validation for key/name.
 
 ### A5. Form Schema Builder
 
-- [ ] Field list with add/edit/delete/reorder.
+- [x] Field list with add/edit/delete/reorder.
 - [ ] Supported field types:
-  - [ ] text
-  - [ ] textarea
-  - [ ] number
-  - [ ] date
-  - [ ] datetime
-  - [ ] select
-  - [ ] multi-select
-  - [ ] user
-- [ ] Required flag.
-- [ ] Placeholder.
-- [ ] Default value where safe.
-- [ ] Select/multi-select options editor.
-- [ ] Block duplicate field ids.
-- [ ] Block empty field ids/labels.
-- [ ] Block empty select option labels/values.
-- [ ] Do not allow new `attachment` fields in this MVP.
-- [ ] Preserve existing `visibilityRule` metadata when editing old templates.
+  - [x] text
+  - [x] textarea
+  - [x] number
+  - [x] date
+  - [x] datetime
+  - [x] select
+  - [x] multi-select
+  - [x] user
+- [x] Required flag.
+- [x] Placeholder.
+- [x] Preserve existing `defaultValue` where safe; new default-value authoring remains omitted in this MVP.
+- [x] Select/multi-select options editor.
+- [x] Block duplicate field ids.
+- [x] Block empty field ids/labels.
+- [x] Block empty select option labels/values.
+- [x] Do not allow new `attachment` fields in this MVP.
+- [x] Preserve existing `visibilityRule` metadata when editing old templates.
 
 ### A6. Linear Approval Graph Builder
 
-- [ ] Linear step list.
-- [ ] Add/remove/reorder approval steps.
-- [ ] Approval mode: `single`, `all`, `any`.
-- [ ] Empty assignee policy: `error`, `auto-approve`.
-- [ ] Static user ids source.
-- [ ] Static role ids source.
-- [ ] Requester source.
-- [ ] Form-field user source.
-- [ ] Only allow `form_field_user` to reference fields of type `user`.
-- [ ] Emit deterministic node keys and edge keys.
-- [ ] Do not expose parallel/condition/BPMN nodes.
-- [ ] When editing an existing template, detect unsupported graph constructs and block saving or open read-only with an explicit unsupported-template message.
-- [ ] Never silently flatten an unsupported existing graph into the MVP linear graph.
+- [x] Linear step list.
+- [x] Add/remove/reorder approval steps.
+- [x] Approval mode: `single`, `all`, `any`.
+- [x] Empty assignee policy: `error`, `auto-approve`.
+- [x] Static user ids source.
+- [x] Static role ids source.
+- [x] Requester source.
+- [x] Form-field user source.
+- [x] Only allow `form_field_user` to reference fields of type `user`.
+- [x] Emit deterministic node keys and edge keys.
+- [x] Do not expose parallel/condition/BPMN nodes.
+- [x] When editing an existing template, detect unsupported graph constructs and block saving or open read-only with an explicit unsupported-template message.
+- [x] Never silently flatten an unsupported existing graph into the MVP linear graph.
 
 ### A7. Publish UX
 
-- [ ] Add publish button for template managers.
-- [ ] Confirm before publishing.
-- [ ] Send explicit publish policy.
-- [ ] MVP may expose only `allowRevoke`.
-- [ ] After publish, return to template detail or template center and refresh.
+- [x] Add publish button for template managers.
+- [x] Confirm before publishing.
+- [x] Send explicit publish policy.
+- [x] MVP may expose only `allowRevoke`.
+- [x] After publish, return to template detail or template center and refresh.
 
 ### A8. Tests
 
-- [ ] API client spec for create/update/publish payload shape.
-- [ ] Template center spec for enabled `新建模板` entry and non-manager hiding/disabled behavior.
-- [ ] Authoring view create-draft spec.
-- [ ] Authoring view update-draft spec.
-- [ ] Publish spec.
-- [ ] Field validation spec.
-- [ ] Existing `visibilityRule` round-trip spec: edit an unrelated supported field, save, and assert unsupported field metadata survives.
-- [ ] Unsupported graph edit-safety spec: existing parallel/condition/add-sign/unknown graph cannot be saved through the linear builder.
-- [ ] `form_field_user` guard spec.
-- [ ] Attachment not-authorable spec.
-- [ ] Existing `ApprovalNewView` compatibility spec with a template authored by the new builder shape.
-- [ ] Typecheck.
+- [x] API/payload spec for create/update/publish payload shape.
+- [x] Template center spec for enabled `新建模板` entry and non-manager hiding/disabled behavior.
+- [x] Authoring view create-draft spec.
+- [x] Authoring view update-draft spec.
+- [x] Publish spec.
+- [x] Field validation spec.
+- [x] Existing `visibilityRule` round-trip spec: edit an unrelated supported field, save, and assert unsupported field metadata survives.
+- [x] Unsupported graph edit-safety spec: existing parallel/condition/add-sign/unknown graph cannot be saved through the linear builder.
+- [x] `form_field_user` guard spec.
+- [x] Attachment not-authorable spec.
+- [x] Existing `ApprovalNewView` compatibility path remains covered by approval permission/lifecycle specs; real-stack UAT remains pending.
+- [x] Typecheck.
 
 ### A9. UAT
 


### PR DESCRIPTION
## Summary

Implements the Approval Template Authoring Frontend MVP scoped by #2292:

- enables `新建模板` for `approval-templates:manage` users and adds `/approval-templates/new` + `/approval-templates/:id/edit`
- adds typed create/update/publish approval-template client wrappers and frontend request types
- adds `TemplateAuthoringView.vue` with metadata, form schema builder, linear approval graph builder, explicit publish policy, and JSON preview
- preserves existing field metadata such as `visibilityRule/defaultValue/props` when editing supported templates
- blocks unsupported existing templates read-only instead of silently flattening complex graphs or unsupported fields
- keeps frozen surfaces untouched: no backend route/migration, no automation/A6, no trigger bindings, no BPMN, no approval-as-job
- updates the TODO tracker to mark frontend MVP implementation complete, with real-stack UAT still pending

## Verification

- `pnpm --filter @metasheet/web exec eslint src/approvals/templateAuthoring.ts src/views/approval/TemplateAuthoringView.vue src/views/approval/TemplateCenterView.vue src/views/approval/TemplateDetailView.vue --max-warnings=0`
- `pnpm --filter @metasheet/web exec vue-tsc -b`
- `pnpm --filter @metasheet/web exec vitest run tests/approvalTemplateAuthoring.spec.ts tests/approvalTemplateCenterCategory.spec.ts tests/approval-e2e-permissions.spec.ts --watch=false`
  - 3 files / 57 tests passed
  - existing warning: `approval-e2e-permissions.spec.ts` still lacks an `el-badge` stub in two cases
- `pnpm --filter @metasheet/web build`
  - passes; existing Vite chunk-size/dynamic-import warnings remain

## UAT checklist after merge

- template manager opens `/approval-templates` and clicks `新建模板`
- creates a simple template with two fields and one requester/static-user approval step
- saves draft, publishes with explicit `allowRevoke` policy
- writer starts an approval from `/approval-templates`
- actor approves/rejects
- requester sees terminal state under `我发起的`
- non-manager cannot enter the authoring route
