### PR TITLE
feat(multitable): v2-d-a backend — stacked-bar series (additive-only)

### DIFF
--- a/packages/core-backend/src/multitable/chart-aggregation-service.ts
+++ b/packages/core-backend/src/multitable/chart-aggregation-service.ts
@@ -7,6 +7,7 @@
  */
 
 import type { ChartConfig, ChartType, AggregationFunction } from './charts'
+import { ADDITIVE_AGGREGATIONS } from './charts'
 
 export interface ChartDataPoint {
   label: string
@@ -14,13 +15,26 @@ export interface ChartDataPoint {
   color?: string
 }
 
+/**
+ * v2-d stacked-bar series. `data` is dense and aligned POSITIONALLY to `ChartData.dataPoints`
+ * (same length, same order; `0` where a (category × series) cell has no rows). Present only for
+ * a bar chart with `seriesByFieldId` + a primary `groupByFieldId` + an additive aggregation.
+ */
+export interface ChartSeries {
+  name: string
+  data: number[]
+}
+
 export interface ChartData {
   chartId: string
   chartType: ChartType
   dataPoints: ChartDataPoint[]
+  /** v2-d: stacked series split. `dataPoints`/`total` are unchanged by its presence. */
+  series?: ChartSeries[]
   total?: number
   metadata?: {
     groupByField?: string
+    seriesByField?: string
     aggregationFunction?: string
     recordCount?: number
     restricted?: boolean
@@ -132,13 +146,47 @@ export class ChartAggregationService {
 
     const total = dataPoints.reduce((sum, dp) => sum + dp.value, 0)
 
+    // v2-d: stacked-bar series split. Built AFTER sort+limit, so it only covers the surviving
+    // categories in their final order (building before limit would leak limited-out categories).
+    // Additive-only (sum/count) + bar + groupBy-primary (no date axis) — the producer is the uniform
+    // safety net mirroring `assertSeriesConstraints`; any other combination omits `series`, so a
+    // misleading stack can never be produced even from a hand-crafted/persisted bad config.
+    const seriesByFieldId = chart.dataSource.seriesByFieldId
+    const dateGrouped = !!(chart.dataSource.dateFieldId && chart.dataSource.dateGrouping)
+    let series: ChartSeries[] | undefined
+    if (
+      chart.type === 'bar' &&
+      seriesByFieldId &&
+      chart.dataSource.groupByFieldId &&
+      !dateGrouped &&
+      ADDITIVE_AGGREGATIONS.has(aggFn)
+    ) {
+      const seriesNames: string[] = []
+      const byName = new Map<string, number[]>() // series name -> data[] aligned to dataPoints
+      dataPoints.forEach((dp, ci) => {
+        const subGroups = this.groupRecords(groups.get(dp.label) ?? [], seriesByFieldId)
+        for (const [name, subRecords] of subGroups) {
+          let arr = byName.get(name)
+          if (!arr) {
+            arr = new Array(dataPoints.length).fill(0)
+            byName.set(name, arr)
+            seriesNames.push(name)
+          }
+          arr[ci] = this.aggregate(subRecords.map((r) => r.data[aggFieldId ?? '']), aggFn)
+        }
+      })
+      series = seriesNames.map((name) => ({ name, data: byName.get(name) as number[] }))
+    }
+
     return {
       chartId: chart.id,
       chartType: chart.type,
       dataPoints,
+      ...(series ? { series } : {}),
       total,
       metadata: {
         groupByField: chart.dataSource.groupByFieldId ?? chart.dataSource.dateFieldId,
+        ...(series ? { seriesByField: seriesByFieldId } : {}),
         aggregationFunction: aggFn,
         recordCount: filtered.length,
       },

--- a/packages/core-backend/src/multitable/charts.ts
+++ b/packages/core-backend/src/multitable/charts.ts
@@ -15,6 +15,13 @@ export interface ChartDataSource {
   /** What to group by (X axis for bar/line, slices for pie) */
   groupByFieldId?: string
 
+  /**
+   * v2-d: split each `groupByFieldId` category into stacked series.
+   * Honored only for a `bar` chart with a primary `groupByFieldId` and an additive
+   * aggregation (sum/count) — see `assertSeriesConstraints`; inert / rejected otherwise.
+   */
+  seriesByFieldId?: string
+
   /** What to aggregate (Y axis for bar/line, values for pie) */
   aggregation: ChartAggregation
 
@@ -65,4 +72,37 @@ export interface ChartCreateInput {
   dataSource: ChartDataSource
   display?: ChartDisplayConfig
   createdBy?: string
+}
+
+/**
+ * v2-d §4: aggregations whose stacked-bar segment heights sum to a meaningful total
+ * (`Σ segments == the single-series bar`). `avg`/`min`/`max`/`count_distinct` are excluded —
+ * stacking them produces a misleading height (avg-of-avgs; cross-series double-counting).
+ */
+export const ADDITIVE_AGGREGATIONS: ReadonlySet<AggregationFunction> = new Set<AggregationFunction>([
+  'sum',
+  'count',
+])
+
+/**
+ * v2-d stacked-series (`seriesByFieldId`) constraints. No-op when unset; otherwise throws unless
+ * the chart is a `bar` with a primary `groupByFieldId` and an additive aggregation (sum/count).
+ *
+ * Enforced at EVERY input boundary (preview + persisted create/update) so the UI is never the sole
+ * guard; the producer (`ChartAggregationService.computeChartData`) mirrors the same combination and
+ * silently omits `series` for anything else, so a hand-crafted/persisted bad config still can't
+ * render a misleading stack.
+ */
+export function assertSeriesConstraints(dataSource: ChartDataSource | undefined, type: ChartType): void {
+  const seriesByFieldId = dataSource?.seriesByFieldId
+  if (!seriesByFieldId) return
+  if (type !== 'bar') {
+    throw new Error('seriesByFieldId (stacked series) is only supported for bar charts')
+  }
+  if (!dataSource?.groupByFieldId) {
+    throw new Error('seriesByFieldId requires groupByFieldId (a primary category axis)')
+  }
+  if (!ADDITIVE_AGGREGATIONS.has(dataSource.aggregation?.function)) {
+    throw new Error('seriesByFieldId (stacked series) requires a sum or count aggregation')
+  }
 }

--- a/packages/core-backend/src/routes/dashboard.ts
+++ b/packages/core-backend/src/routes/dashboard.ts
@@ -31,6 +31,7 @@ import { randomUUID } from 'crypto'
 import { poolManager } from '../integration/db/connection-pool'
 import type { MultitableCapabilities } from '../multitable/access'
 import type { AggregationFunction, ChartConfig, ChartCreateInput, ChartType } from '../multitable/charts'
+import { assertSeriesConstraints } from '../multitable/charts'
 import type { ChartData } from '../multitable/chart-aggregation-service'
 import { DashboardService } from '../multitable/dashboard-service'
 import type { MultitableField } from '../multitable/field-codecs'
@@ -150,6 +151,7 @@ function chartReferencedFieldIds(chart: ChartConfig): string[] {
   const ids = [
     source.aggregation.fieldId,
     source.groupByFieldId,
+    source.seriesByFieldId, // v2-d: a denied series field must restrict, not leak its values as series names
     source.dateFieldId,
     source.filterFieldId,
   ]
@@ -212,6 +214,7 @@ function buildPreviewChart(sheetId: string, userId: string, body: unknown): Char
   if (AGGREGATIONS_REQUIRING_FIELD.has(aggregationFunction as AggregationFunction) && !readString(aggregation.fieldId)) {
     throw new Error('value field is required for this aggregation')
   }
+  assertSeriesConstraints(source as ChartConfig['dataSource'], chartType as ChartType)
   const now = new Date().toISOString()
   return {
     id: `chart_preview_${randomUUID()}`,
@@ -250,6 +253,8 @@ export function dashboardRouter() {
     try {
       const auth = await requireSheetManageViews(req, res, req.params.sheetId)
       if (!auth) return
+      // v2-d: validate series constraints on the persisted path too — the UI is never the sole guard.
+      assertSeriesConstraints(req.body?.dataSource as ChartConfig['dataSource'] | undefined, req.body?.type as ChartType)
       const chart = await dashboardService.createChart(req.params.sheetId, {
         ...req.body,
         createdBy: auth.userId,
@@ -309,6 +314,12 @@ export function dashboardRouter() {
         res.status(404).json({ error: 'Chart not found' })
         return
       }
+      // v2-d: validate the EFFECTIVE config (updateChart shallow-merges `{...existing,...input}`),
+      // so a patch that introduces a series field or changes type/aggregation is checked.
+      assertSeriesConstraints(
+        (req.body?.dataSource ?? chart.dataSource) as ChartConfig['dataSource'],
+        (req.body?.type ?? chart.type) as ChartType,
+      )
       const updated = await dashboardService.updateChart(req.params.id, req.body)
       res.json(updated)
     } catch (err: unknown) {

--- a/packages/core-backend/tests/integration/multitable-dashboard-chart-authz.test.ts
+++ b/packages/core-backend/tests/integration/multitable-dashboard-chart-authz.test.ts
@@ -30,6 +30,7 @@ const FLD_VISIBLE = `fld_f0b_visible_${TS}`
 const FLD_SECRET = `fld_f0b_secret_${TS}`
 const CHART_ID = `chart_f0b_visible_${TS}`
 const CHART_SECRET_ID = `chart_f0b_secret_${TS}`
+const CHART_SERIES_SECRET_ID = `chart_f0b_series_secret_${TS}` // v2-d: seriesByFieldId points at the denied field
 const DASHBOARD_ID = `dash_f0b_${TS}`
 const USER_ID = `u_f0b_reader_${TS}`
 const USER_ID_DENIED = `u_f0b_denied_${TS}`
@@ -103,6 +104,12 @@ describeIfDatabase('F0b dashboard/chart authz + chart-data mask (real DB)', () =
     await insertChart(CHART_ID)
     await insertChart(CHART_SECRET_ID, {
       groupByFieldId: FLD_SECRET,
+      aggregation: { function: 'count' },
+    })
+    // v2-d: a stacked chart whose SERIES field is the denied one (primary groupBy is visible).
+    await insertChart(CHART_SERIES_SECRET_ID, {
+      groupByFieldId: FLD_VISIBLE,
+      seriesByFieldId: FLD_SECRET,
       aggregation: { function: 'count' },
     })
     await insertDashboard(DASHBOARD_ID)
@@ -258,6 +265,31 @@ describeIfDatabase('F0b dashboard/chart authz + chart-data mask (real DB)', () =
         recordCount: 0,
       },
     })
+    expect(JSON.stringify(denied.body)).not.toContain(SECRET_CANARY)
+  })
+
+  test('R9 (v2-d): a denied seriesByFieldId restricts chart data — the field values do not leak as series names', async () => {
+    // groupBy = visible bucket, seriesBy = the SECRET field → series names would be the secret values.
+    getDashboardService().setRecordProvider(async (sheetId: string) => {
+      if (sheetId !== SHEET_ID) return []
+      return [{ data: { [FLD_VISIBLE]: 'visible bucket', [FLD_SECRET]: SECRET_CANARY } }]
+    })
+
+    // Allowed reader: series IS computed → the secret value surfaces as a series name (proves the leak vector).
+    testUserId = USER_ID
+    testPerms = ['multitable:read']
+    const allowed = await chartData(CHART_SERIES_SECRET_ID)
+    expect(allowed.status).toBe(200)
+    expect(allowed.body.series?.some((s: { name?: string }) => s.name === SECRET_CANARY)).toBe(true)
+    expect(JSON.stringify(allowed.body)).toContain(SECRET_CANARY)
+
+    // Denied reader: restricted, no series, no leak.
+    testUserId = USER_ID_DENIED
+    testPerms = ['multitable:read']
+    const denied = await chartData(CHART_SERIES_SECRET_ID)
+    expect(denied.status).toBe(200)
+    expect(denied.body).toMatchObject({ chartId: CHART_SERIES_SECRET_ID, dataPoints: [], total: 0, metadata: { restricted: true } })
+    expect(denied.body.series).toBeUndefined()
     expect(JSON.stringify(denied.body)).not.toContain(SECRET_CANARY)
   })
 })

--- a/packages/core-backend/tests/integration/multitable-dashboard-preview-data.test.ts
+++ b/packages/core-backend/tests/integration/multitable-dashboard-preview-data.test.ts
@@ -23,6 +23,7 @@ const FLD_AMOUNT = `fld_biv2b2_amount_${TS}`
 const FLD_DATE = `fld_biv2b2_date_${TS}`
 const FLD_SECRET = `fld_biv2b2_secret_${TS}`
 const CHART_PARITY_ID = `chart_biv2b2_parity_${TS}`
+const CHART_STACKED_ID = `chart_biv2b2_stacked_${TS}` // v2-d: persisted stacked chart for preview parity
 const USER_ID = `u_biv2b2_reader_${TS}`
 const USER_DENIED = `u_biv2b2_denied_${TS}`
 
@@ -82,6 +83,19 @@ describeIfDatabase('Dashboard BI v2-b2 preview-data endpoint (real DB)', () => {
         SHEET_ID,
         asJson({ groupByFieldId: FLD_STATUS, aggregation: { function: 'sum', fieldId: FLD_AMOUNT } }),
         asJson({ title: 'Persisted parity chart' }),
+        USER_ID,
+      ],
+    )
+    await q(
+      `INSERT INTO multitable_charts (id, name, type, sheet_id, data_source, display, created_by)
+       VALUES ($1,$2,$3,$4,$5::jsonb,$6::jsonb,$7)`,
+      [
+        CHART_STACKED_ID,
+        'Persisted stacked chart',
+        'bar',
+        SHEET_ID,
+        asJson({ groupByFieldId: FLD_STATUS, seriesByFieldId: FLD_SECRET, aggregation: { function: 'sum', fieldId: FLD_AMOUNT } }),
+        asJson({ title: 'Persisted stacked chart' }),
         USER_ID,
       ],
     )
@@ -189,5 +203,46 @@ describeIfDatabase('Dashboard BI v2-b2 preview-data endpoint (real DB)', () => {
     })
     expect(date.status).toBe(400)
     expect(JSON.stringify(date.body)).toContain('date grouping')
+  })
+
+  test('P5 (v2-d): stacked preview emits dense aligned series and matches persisted stacked-chart data', async () => {
+    const persisted = await request(app).get(`/api/multitable/sheets/${SHEET_ID}/charts/${CHART_STACKED_ID}/data`)
+    expect(persisted.status).toBe(200)
+    expect(persisted.body.series).toBeDefined()
+
+    const res = await preview({
+      name: 'Unsaved stacked',
+      type: 'bar',
+      dataSource: { groupByFieldId: FLD_STATUS, seriesByFieldId: FLD_SECRET, aggregation: { function: 'sum', fieldId: FLD_AMOUNT } },
+      display: { title: 'Persisted stacked chart' },
+    })
+    expect(res.status).toBe(200)
+    // preview === saved (same engine + gate)
+    expect(normalizeChartData(res.body)).toEqual(normalizeChartData(persisted.body))
+    // dense + aligned + additive consistency (Σ segments === single-series bar)
+    const body = res.body
+    for (const s of body.series) expect(s.data).toHaveLength(body.dataPoints.length)
+    body.dataPoints.forEach((dp: { value: number }, j: number) => {
+      const col = body.series.reduce((acc: number, s: { data: number[] }) => acc + s.data[j], 0)
+      expect(col).toBe(dp.value)
+    })
+  })
+
+  test('P6 (v2-d): non-additive or non-bar series config is rejected with 400 (server-side, not UI-only)', async () => {
+    const avg = await preview({
+      name: 'avg stacked',
+      type: 'bar',
+      dataSource: { groupByFieldId: FLD_STATUS, seriesByFieldId: FLD_SECRET, aggregation: { function: 'avg', fieldId: FLD_AMOUNT } },
+    })
+    expect(avg.status).toBe(400)
+    expect(JSON.stringify(avg.body)).toContain('sum or count')
+
+    const line = await preview({
+      name: 'line stacked',
+      type: 'line',
+      dataSource: { groupByFieldId: FLD_STATUS, seriesByFieldId: FLD_SECRET, aggregation: { function: 'count' } },
+    })
+    expect(line.status).toBe(400)
+    expect(JSON.stringify(line.body)).toContain('bar charts')
   })
 })

--- a/packages/core-backend/tests/unit/chart-dashboard.test.ts
+++ b/packages/core-backend/tests/unit/chart-dashboard.test.ts
@@ -3,6 +3,7 @@ import { describe, it, expect, beforeEach, vi } from 'vitest'
 import { ChartAggregationService } from '../../src/multitable/chart-aggregation-service'
 import type { ChartData } from '../../src/multitable/chart-aggregation-service'
 import type { ChartConfig, ChartCreateInput } from '../../src/multitable/charts'
+import { assertSeriesConstraints } from '../../src/multitable/charts'
 
 // ── DB mock ──────────────────────────────────────────────────────────────────
 
@@ -787,5 +788,162 @@ describe('DashboardService', () => {
       expect(data.dataPoints[0].label).toBe('A')
       expect(data.dataPoints[0].value).toBe(60)
     })
+  })
+})
+
+// ---------------------------------------------------------------------------
+// v2-d — stacked-bar series split (seriesByFieldId)
+// ---------------------------------------------------------------------------
+
+describe('ChartAggregationService — v2-d stacked series', () => {
+  let service: ChartAggregationService
+  beforeEach(() => {
+    service = new ChartAggregationService()
+  })
+
+  // status × category over sampleRecords:
+  //   open  → A:[10,50], B:[20]   closed → A:[30], B:[40]
+  const stackedChart = (overrides: Partial<ChartConfig['dataSource']> = {}, type: ChartConfig['type'] = 'bar') =>
+    makeChart({
+      type,
+      dataSource: {
+        groupByFieldId: 'status',
+        seriesByFieldId: 'category',
+        aggregation: { function: 'count' },
+        ...overrides,
+      },
+    })
+
+  it('count: emits one series per seriesBy value, dense and positionally aligned to dataPoints', async () => {
+    const result = await service.computeChartData(stackedChart(), sampleRecords)
+    // dataPoints unchanged = single-dimension groupBy count
+    expect(result.dataPoints).toEqual([
+      { label: 'open', value: 3 },
+      { label: 'closed', value: 2 },
+    ])
+    expect(result.series).toBeDefined()
+    expect(result.series!.map((s) => s.name)).toEqual(['A', 'B'])
+    // aligned to [open, closed]
+    expect(result.series!.find((s) => s.name === 'A')!.data).toEqual([2, 1])
+    expect(result.series!.find((s) => s.name === 'B')!.data).toEqual([1, 1])
+    // dense: every series spans every category
+    for (const s of result.series!) expect(s.data).toHaveLength(result.dataPoints.length)
+    expect(result.metadata?.seriesByField).toBe('category')
+  })
+
+  it('additive consistency: Σ series[*].data[j] === dataPoints[j].value (sum)', async () => {
+    const result = await service.computeChartData(
+      stackedChart({ aggregation: { function: 'sum', fieldId: 'amount' } }),
+      sampleRecords,
+    )
+    expect(result.dataPoints).toEqual([
+      { label: 'open', value: 80 },
+      { label: 'closed', value: 70 },
+    ])
+    result.dataPoints.forEach((dp, j) => {
+      const colSum = result.series!.reduce((acc, s) => acc + s.data[j], 0)
+      expect(colSum).toBe(dp.value) // stack height == single-series bar
+    })
+  })
+
+  it('dense 0-fill: a series absent in a category contributes 0, not a gap', async () => {
+    const records = makeRecords([
+      { status: 'open', category: 'A' },
+      { status: 'open', category: 'C' }, // C only in "open"
+      { status: 'closed', category: 'A' },
+    ])
+    const result = await service.computeChartData(stackedChart(), records)
+    expect(result.dataPoints.map((d) => d.label)).toEqual(['open', 'closed'])
+    const c = result.series!.find((s) => s.name === 'C')!
+    expect(c.data).toEqual([1, 0]) // present in open, 0 in closed (not undefined / missing)
+  })
+
+  it('series is built AFTER limit — only surviving categories, aligned', async () => {
+    const records = makeRecords([
+      { status: 'open', category: 'A' },
+      { status: 'open', category: 'A' },
+      { status: 'closed', category: 'B' },
+      { status: 'pending', category: 'A' },
+    ])
+    // sort by value desc + limit 1 → only "open" (value 2) survives
+    const result = await service.computeChartData(
+      stackedChart({ sortBy: 'value', sortOrder: 'desc', limit: 1 }),
+      records,
+    )
+    expect(result.dataPoints).toHaveLength(1)
+    expect(result.dataPoints[0].label).toBe('open')
+    for (const s of result.series!) expect(s.data).toHaveLength(1)
+  })
+
+  it('inert: non-additive aggregation (avg) omits series, dataPoints still computed', async () => {
+    const result = await service.computeChartData(
+      stackedChart({ aggregation: { function: 'avg', fieldId: 'amount' } }),
+      sampleRecords,
+    )
+    expect(result.series).toBeUndefined()
+    expect(result.metadata?.seriesByField).toBeUndefined()
+    expect(result.dataPoints.find((d) => d.label === 'open')?.value).toBe(80 / 3)
+  })
+
+  it('inert: seriesByFieldId on a non-bar chart omits series', async () => {
+    for (const type of ['line', 'pie'] as const) {
+      const result = await service.computeChartData(stackedChart({}, type), sampleRecords)
+      expect(result.series).toBeUndefined()
+    }
+  })
+
+  it('inert: no series without a primary groupByFieldId (date-grouped or ungrouped)', async () => {
+    const dateGrouped = await service.computeChartData(
+      makeChart({
+        type: 'bar',
+        dataSource: {
+          dateFieldId: 'date',
+          dateGrouping: 'month',
+          seriesByFieldId: 'category',
+          aggregation: { function: 'count' },
+        },
+      }),
+      sampleRecords,
+    )
+    expect(dateGrouped.series).toBeUndefined()
+  })
+
+  it('absent seriesByFieldId ⇒ byte-identical to today (no series key)', async () => {
+    const result = await service.computeChartData(makeChart(), sampleRecords)
+    expect('series' in result).toBe(false)
+  })
+})
+
+describe('assertSeriesConstraints (v2-d input validation)', () => {
+  const ds = (over: Partial<ChartConfig['dataSource']> = {}): ChartConfig['dataSource'] => ({
+    groupByFieldId: 'g',
+    seriesByFieldId: 's',
+    aggregation: { function: 'sum', fieldId: 'amt' },
+    ...over,
+  })
+
+  it('no-op when seriesByFieldId unset', () => {
+    expect(() => assertSeriesConstraints({ groupByFieldId: 'g', aggregation: { function: 'avg' } }, 'line')).not.toThrow()
+    expect(() => assertSeriesConstraints(undefined, 'bar')).not.toThrow()
+  })
+
+  it('passes for bar + groupBy + sum/count', () => {
+    expect(() => assertSeriesConstraints(ds(), 'bar')).not.toThrow()
+    expect(() => assertSeriesConstraints(ds({ aggregation: { function: 'count' } }), 'bar')).not.toThrow()
+  })
+
+  it('throws for a non-bar chart', () => {
+    expect(() => assertSeriesConstraints(ds(), 'line')).toThrow(/bar charts/)
+    expect(() => assertSeriesConstraints(ds(), 'pie')).toThrow(/bar charts/)
+  })
+
+  it('throws without a primary groupByFieldId', () => {
+    expect(() => assertSeriesConstraints(ds({ groupByFieldId: undefined }), 'bar')).toThrow(/groupByFieldId/)
+  })
+
+  it('throws for a non-additive aggregation (avg/min/max/count_distinct)', () => {
+    for (const fn of ['avg', 'min', 'max', 'count_distinct'] as const) {
+      expect(() => assertSeriesConstraints(ds({ aggregation: { function: fn, fieldId: 'amt' } }), 'bar')).toThrow(/sum or count/)
+    }
   })
 })


### PR DESCRIPTION
**Backend slice of Dashboard BI v2-d-a (stacked bar)**, per design-lock #2291 (`docs/development/multitable-dashboard-bi-v2d-multiseries-design-20260604.md`). Backend-first per owner direction; the frontend (form series picker + `buildChartOption` stacked render) follows as a **separate opt-in**. No frontend in this PR.

## Changes
- **Types** — `ChartDataSource += seriesByFieldId?`; `ChartData += series?: ChartSeries[]` (`{name, data:number[]}`, dense + aligned **positionally** to the sorted+limited `dataPoints`). `dataPoints`/`total` unchanged.
- **Producer** (`computeChartData`) — after sort+limit, emits `series` **only** for `bar` + `seriesByFieldId` + primary `groupByFieldId` (no date axis) + additive aggregation (`sum`/`count`). Any other combination silently omits `series` — the uniform safety net both the live-data and preview routes inherit, so a hand-crafted/persisted bad config can never render a misleading stack.
- **🔴 Gate** — `chartReferencedFieldIds` += `seriesByFieldId`. A permission-denied series field now restricts (no leak of its distinct values as series names). One helper gates both routes.
- **Validation** — shared `assertSeriesConstraints` (in `charts.ts`) enforced at all three input boundaries: preview (`buildPreviewChart`) + persisted **create** + persisted **update** (validated on the *effective merged* config). 400, never UI-only.

## Tests (all green locally)
- **Unit 13** (`tests/unit/chart-dashboard.test.ts`): producer dense/aligned, additive `Σ series == dataPoints` consistency, 0-fill, built-after-limit, inert on non-additive/non-bar/no-groupBy/date-grouped, absent-series byte-identical; `assertSeriesConstraints` matrix.
- **Real-DB R9** (`multitable-dashboard-chart-authz.test.ts`): denied `seriesByFieldId` → `restricted`, no `series`, no canary leak — with an allowed user proving the provider *can* surface it (the leak vector).
- **Real-DB P5/P6** (`multitable-dashboard-preview-data.test.ts`): stacked preview ≡ persisted stacked-chart data (dense+aligned+consistency); non-additive/non-bar series → 400.
- Full backend unit **2758/2758**, dashboard real-DB **17/17**, `tsc --noEmit` clean. (Both integration files are already in the plugin-tests.yml real-DB list — no workflow change.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)