### PR TITLE
fix(data-factory): fail closed on incomplete stock target schema

### DIFF
--- a/docs/development/data-factory-plm-project-bom-c5-3b-target-schema-preflight-verification-20260605.md
+++ b/docs/development/data-factory-plm-project-bom-c5-3b-target-schema-preflight-verification-20260605.md
@@ -1,0 +1,100 @@
+# Data Factory PLM stock-preparation C5-3b target schema preflight verification (2026-06-05)
+
+## Scope
+
+C5-3b addresses the #2253 entity-machine smoke finding after C5-3a:
+
+- the action config can now be injected and reports `configured:true`;
+- dry-run reaches the C5 route;
+- but a temporary target binding pointed at an existing stock-preparation table
+  whose `target.fieldIdMap` omitted C5 PLM/system fields such as
+  `idempotencyKey`, `path`, `active`, and `lastPlmRefresh*`.
+
+This slice adds a values-free target config preflight. When an action uses an
+explicit `target.fieldIdMap`, it must map every `plm_system` field from the
+stock-preparation template. A partial explicit map fails closed with
+`TARGET_SCHEMA_INCOMPLETE` before any PLM source adapter is loaded.
+
+## Boundary
+
+This slice does not add:
+
+- support for `bridge:legacy-sql-readonly` as a C5 source kind;
+- PLM reads;
+- MetaSheet writes;
+- K3 Save / Submit / Audit / BOM;
+- migrations;
+- UI changes;
+- raw SQL;
+- permission model changes.
+
+The source contract remains `data-source:sql-readonly`. If the customer PLM can
+only be reached through Bridge Agent, that is a separate source-design pivot,
+not this hot path.
+
+## Behavior
+
+- Canonical C1 target tables may omit `target.fieldIdMap`; logical field ids are
+  used as-is, preserving the existing happy path.
+- Existing/non-canonical target tables that provide `target.fieldIdMap` are an
+  explicit physical-field binding and must map all PLM/system fields.
+- A missing PLM/system field returns `422 TARGET_SCHEMA_INCOMPLETE`.
+- Error details are values-free and omit source ids and target sheet ids. They
+  include only the target object id, field-map mode, required logical fields,
+  and missing logical fields.
+- The HTTP dry-run/apply routes run the target preflight before source adapter
+  creation, so a bad target binding cannot trigger a PLM read.
+- The helper APIs also run the same preflight, so direct unit/runtime calls
+  cannot bypass the route guard.
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter plugin-integration-core test:stock-preparation-table-actions
+pnpm --filter plugin-integration-core test:http-routes
+pnpm --filter plugin-integration-core test:stock-preparation-apply-writer
+pnpm --filter plugin-integration-core test
+git diff --check
+```
+
+Results:
+
+- `stock-preparation-table-actions.test.cjs`: passed.
+- `http-routes.test.cjs`: passed.
+- `stock-preparation-apply-writer.test.cjs`: passed.
+- `plugin-integration-core test`: passed after installing workspace
+  dependencies in the isolated worktree with
+  `pnpm install --frozen-lockfile --offline`; node_modules shim churn was
+  removed from the diff.
+- `git diff --check`: passed.
+
+## Test locks
+
+`plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs`
+locks the helper boundary:
+
+- incomplete explicit target field maps fail with
+  `TARGET_SCHEMA_INCOMPLETE`;
+- dry-run fails before PLM source reads;
+- apply fails before PLM source reads, target reads, target writes, or token
+  consumption;
+- the error reports missing logical field names without exposing the target
+  sheet id.
+
+`plugins/plugin-integration-core/__tests__/http-routes.test.cjs` locks the real
+wire boundary:
+
+- dry-run returns `422 TARGET_SCHEMA_INCOMPLETE`;
+- missing `idempotencyKey` / `path` are surfaced as values-free logical field
+  names;
+- `getExternalSystemForAdapter` and `createAdapter` are never called when the
+  target preflight fails;
+- the error does not expose the configured source binding or target sheet id.
+
+## Remaining gate
+
+After this slice lands, cut a refreshed on-prem package and rerun #2253 C5-3
+entity-machine smoke. The operator still needs to bind the PLM source as
+`data-source:sql-readonly` or explicitly pivot to a separate source design.

--- a/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
@@ -313,7 +313,7 @@ Acceptance locks:
 - Request-body wire test asserts dry-run/apply send no browser-supplied
   `sheetId`, source/target binding, C3 plan, or C4 payload.
 
-### 🟡 C5-3a - On-prem action config injection unblocker (this PR)
+### ✅ C5-3a - On-prem action config injection unblocker (DONE - PR #2293)
 
 Gated on: C5-1/C5-2 + entity-machine smoke finding + explicit opt-in.
 
@@ -342,9 +342,37 @@ Acceptance locks:
 - The deployment config path is scoped to `plugin-integration-core`; unrelated
   plugins do not receive the table-action config.
 
+### 🟡 C5-3b - Target schema/config preflight (this PR)
+
+Gated on: C5-3a entity-machine smoke finding + explicit opt-in.
+
+Scope:
+
+- Add a route/helper-level target config preflight for
+  `plm.stock-preparation.pull-bom.v1`.
+- When a deployment uses explicit `target.fieldIdMap`, require it to map every
+  PLM/system field from the C1 stock-preparation template.
+- Return a values-free `422 TARGET_SCHEMA_INCOMPLETE` before PLM source adapter
+  creation when the target binding is partial.
+- Keep canonical logical-id target tables working when `target.fieldIdMap` is
+  empty.
+- Keep the C5 source kind unchanged: `data-source:sql-readonly` only. Do not
+  widen this slice to `bridge:legacy-sql-readonly`.
+
+Acceptance locks:
+
+- Incomplete explicit target maps fail before PLM reads, target reads, target
+  writes, or dry-run token consumption.
+- HTTP dry-run fails before `getExternalSystemForAdapter` / `createAdapter`.
+- Error details expose logical field names only; no source external-system id,
+  target sheet id, PLM row value, or MetaSheet row value.
+- No PLM read, MetaSheet write, K3, UI, migration, raw SQL, or permission model
+  change.
+
 ### ⬜ C5-3 - Operator validation runbook / entity-machine smoke
 
-Gated on: C5-1/C5-2 + C5-3a package deployed + explicit opt-in.
+Gated on: C5-1/C5-2 + C5-3a package deployed + C5-3b package deployed +
+explicit opt-in.
 
 Scope:
 
@@ -405,16 +433,16 @@ operator checks stay in later validation slices:
 
 ## Sequencing rule
 
-C0, C1, C2-0, C2, C3, C4, C5-0, C5-1, and C5-2 are complete. C5-3a is the
-current entity-machine unblocker found during C5-3 smoke: the host must inject
-server-owned action config so the plugin can report the PLM action as
-`configured:true`.
+C0, C1, C2-0, C2, C3, C4, C5-0, C5-1, C5-2, and C5-3a are complete. C5-3b is
+the current entity-machine unblocker found during C5-3 smoke: an explicit
+target `fieldIdMap` must fail closed when it omits C5 PLM/system fields.
 
 1. C5-0 design locks the reusable parameterized action contract.
 2. C5-1 adds backend action routes and server-side recompute/apply wiring.
 3. C5-2 adds the workbench operator surface.
 4. C5-3a injects server-owned plugin action config for on-prem deployment.
-5. C5-3 validates the flow on an entity machine.
+5. C5-3b rejects incomplete target schema/config before any PLM read.
+6. C5-3 validates the flow on an entity machine.
 
 C6 option sync remains after C5. All later slices still require their
 predecessor to land and the owner to explicitly opt in. K3 Save / Submit /

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -2335,6 +2335,20 @@ function tableActionConfig() {
   }
 }
 
+function tableActionConfigWithIncompleteTargetFieldMap() {
+  return {
+    ...tableActionConfig(),
+    target: {
+      sheetId: 'sheet_stock_configured',
+      objectId: 'stockPreparationMain',
+      fieldIdMap: {
+        projectNo: 'fld_project_no',
+        componentSourceId: 'fld_component_source_id',
+      },
+    },
+  }
+}
+
 function tableActionPlmData() {
   return {
     DN_PDM_PathExAttrInfo: [{ FileCode: 'P-001', Parent_OBJ_ID: 'PATH-1' }],
@@ -2511,6 +2525,54 @@ async function testTableActionRoutes() {
   assert.equal(JSON.stringify(res.body.data.evidence).includes('A-001'), false, 'apply evidence hides component code')
 }
 
+async function testTableActionTargetPreflightBeforeSourceAdapter() {
+  const { calls, services } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        calls.push(['getExternalSystemForAdapter', input])
+        return {
+          id: input.id,
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId,
+          name: 'Readonly PLM SQL',
+          kind: 'data-source:sql-readonly',
+          role: 'source',
+        }
+      },
+    },
+    adapterRegistry: {
+      createAdapter(system, deps) {
+        calls.push(['createAdapter', system, deps])
+        return createTableActionSourceAdapter(tableActionPlmData(), calls)
+      },
+    },
+  })
+  const records = createTableActionRecordsApi()
+  const { routes } = mountRoutes(services, {
+    recordsApi: records.recordsApi,
+    config: {
+      stockPreparationTableActions: [tableActionConfigWithIncompleteTargetFieldMap()],
+    },
+  })
+
+  const res = await invoke(routes, 'POST', '/api/integration/table-actions/:actionId/dry-run', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID },
+    body: { parameters: { projectNo: 'P-001' } },
+  })
+  assert.equal(res.statusCode, 422)
+  assert.equal(res.body.error.code, 'TARGET_SCHEMA_INCOMPLETE')
+  assert.equal(res.body.error.details.fieldMapMode, 'explicit')
+  assert.ok(res.body.error.details.missingFields.includes('idempotencyKey'), 'missing idempotencyKey is reported')
+  assert.ok(res.body.error.details.missingFields.includes('path'), 'missing path is reported')
+  const errorText = JSON.stringify(res.body.error)
+  assert.equal(errorText.includes('sheet_stock_configured'), false, 'target sheetId is not exposed in target-schema error')
+  assert.equal(errorText.includes('plm_sql_source'), false, 'source binding is not exposed in target-schema error')
+  assert.equal(findCalls(calls, 'getExternalSystemForAdapter').length, 0, 'target preflight fails before loading the source system')
+  assert.equal(findCalls(calls, 'createAdapter').length, 0, 'target preflight fails before creating the source adapter')
+  assert.equal(records.calls.length, 0, 'target preflight fails before target reads')
+}
+
 async function testTableActionUnconfiguredFailsClosed() {
   const { routes } = mountRoutes(createMockServices().services)
   const res = await invoke(routes, 'POST', '/api/integration/table-actions/:actionId/dry-run', {
@@ -2525,6 +2587,7 @@ async function testTableActionUnconfiguredFailsClosed() {
 async function main() {
   await testUnauthenticatedWriteRequestIsRejected()
   await testTableActionRoutes()
+  await testTableActionTargetPreflightBeforeSourceAdapter()
   await testTableActionUnconfiguredFailsClosed()
   await testTemplatePreviewReferenceMappingResolution()
   await testTemplatePreviewLiveBulkRead()

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
@@ -186,6 +186,63 @@ async function testDryRunRequiresAllowlistedParametersAndStoresToken() {
   assert.equal(JSON.stringify(dryRun.evidence).includes('Assembly'), false, 'evidence hides component name')
 }
 
+async function testTargetFieldMapIncompleteFailsBeforeReads() {
+  const source = createSourceAdapter()
+  const records = createRecordsApi()
+  const storage = createMemoryStorage()
+  const action = baseAction({
+    target: {
+      sheetId: 'sheet_stock',
+      objectId: 'stockPreparationMain',
+      fieldIdMap: {
+        projectNo: 'fld_project_no',
+        componentSourceId: 'fld_component_source_id',
+      },
+    },
+  })
+
+  function assertTargetSchemaIncomplete(error) {
+    assert.equal(error.name, 'StockPreparationTableActionError')
+    assert.equal(error.status, 422)
+    assert.equal(error.code, 'TARGET_SCHEMA_INCOMPLETE')
+    assert.equal(error.details.fieldMapMode, 'explicit')
+    assert.equal(error.details.targetObjectId, 'stockPreparationMain')
+    assert.ok(error.details.missingFields.includes('idempotencyKey'), 'idempotencyKey is required')
+    assert.ok(error.details.missingFields.includes('path'), 'path is required')
+    assert.ok(error.details.missingFields.includes('lastPlmRefreshDecision'), 'refresh decision is required')
+    assert.equal(JSON.stringify(error.details).includes('sheet_stock'), false, 'error details do not expose sheetId')
+    return true
+  }
+
+  await assert.rejects(
+    () => dryRunStockPreparationAction({
+      action,
+      parameters: { projectNo: 'P-001' },
+      sourceAdapter: source.adapter,
+      recordsApi: records.recordsApi,
+      tokenStore: storage,
+    }),
+    assertTargetSchemaIncomplete,
+  )
+  assert.equal(source.calls.length, 0, 'dry-run target preflight fails before PLM source reads')
+  assert.equal(records.calls.length, 0, 'dry-run target preflight fails before target reads')
+
+  await assert.rejects(
+    () => applyStockPreparationAction({
+      action,
+      parameters: { projectNo: 'P-001' },
+      dryRunToken: 'not-used',
+      sourceAdapter: source.adapter,
+      recordsApi: records.recordsApi,
+      tokenStore: storage,
+      permission: 'write',
+    }),
+    assertTargetSchemaIncomplete,
+  )
+  assert.equal(source.calls.length, 0, 'apply target preflight fails before PLM source reads')
+  assert.equal(records.calls.length, 0, 'apply target preflight fails before target reads or writes')
+}
+
 async function testApplyRequiresTokenRecomputesAndScopesTarget() {
   const storage = createMemoryStorage()
   const source = createSourceAdapter()
@@ -312,6 +369,7 @@ async function testApplyDetectsDataShiftAndManualConfirmHold() {
 async function main() {
   await testRegistryListsConfiguredMetadataWithoutTargetSecrets()
   await testDryRunRequiresAllowlistedParametersAndStoresToken()
+  await testTargetFieldMapIncompleteFailsBeforeReads()
   await testApplyRequiresTokenRecomputesAndScopesTarget()
   await testApplyDetectsDataShiftAndManualConfirmHold()
 

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -57,6 +57,7 @@ const {
   PLM_STOCK_PREPARATION_ACTION_ID,
   StockPreparationTableActionError,
   applyStockPreparationAction,
+  assertStockPreparationTargetReady,
   createStockPreparationTableActionRegistry,
   dryRunStockPreparationAction,
 } = require('./stock-preparation-table-actions.cjs')
@@ -1243,7 +1244,7 @@ function createHandlers(services, options = {}) {
       requireAccess(req, 'read')
       const body = normalizeTableActionBody(requestBody(req))
       const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
-      const action = await tableActions.getTableAction(scopedInput(req, { actionId }))
+      const action = assertStockPreparationTargetReady(await tableActions.getTableAction(scopedInput(req, { actionId })))
       const sourceAdapter = await loadTableActionSourceAdapter(req, action)
       return sendOk(res, await dryRunStockPreparationAction({
         action,
@@ -1258,7 +1259,7 @@ function createHandlers(services, options = {}) {
       const user = requireAccess(req, 'write')
       const body = normalizeTableActionBody(requestBody(req))
       const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
-      const action = await tableActions.getTableAction(scopedInput(req, { actionId }))
+      const action = assertStockPreparationTargetReady(await tableActions.getTableAction(scopedInput(req, { actionId })))
       const sourceAdapter = await loadTableActionSourceAdapter(req, action)
       const confirm = isPlainObject(body.confirm) ? body.confirm : {}
       return sendOk(res, await applyStockPreparationAction({

--- a/plugins/plugin-integration-core/lib/stock-preparation-table-actions.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-table-actions.cjs
@@ -154,6 +154,40 @@ function normalizeStockPreparationActionConfig(input = {}) {
   }
 }
 
+function targetFieldMapHasExplicitBindings(fieldIdMap = {}) {
+  return Object.keys(fieldIdMap || {}).some((field) => optionalString(fieldIdMap[field]))
+}
+
+function plmSystemFieldIds(template) {
+  return template.fields
+    .filter((field) => field.ownership === 'plm_system')
+    .map((field) => field.id)
+}
+
+function assertTargetFieldMapCompleteness(action) {
+  if (!targetFieldMapHasExplicitBindings(action.target.fieldIdMap)) return
+  const requiredFields = plmSystemFieldIds(action.template)
+  const missingFields = requiredFields.filter((field) => !optionalString(action.target.fieldIdMap[field]))
+  if (missingFields.length === 0) return
+  throw new StockPreparationTableActionError(
+    422,
+    'TARGET_SCHEMA_INCOMPLETE',
+    'target.fieldIdMap is missing C5 PLM/system fields',
+    {
+      targetObjectId: action.target.objectId,
+      fieldMapMode: 'explicit',
+      missingFields,
+      requiredFields,
+    },
+  )
+}
+
+function assertStockPreparationTargetReady(input = {}) {
+  const action = normalizeStockPreparationActionConfig(input)
+  assertTargetFieldMapCompleteness(action)
+  return action
+}
+
 function publicActionMetadata(action) {
   const configured = Boolean(action && action.configured === true)
   return {
@@ -453,7 +487,7 @@ function evidenceForDryRun({ action, parameters, expansion, plan, revision, canA
 }
 
 async function dryRunStockPreparationAction(input = {}) {
-  const action = normalizeStockPreparationActionConfig(input.action)
+  const action = assertStockPreparationTargetReady(input.action)
   const parameters = normalizeActionParameters(input.parameters)
   const dryRun = await computeDryRun({
     action,
@@ -494,7 +528,7 @@ async function dryRunStockPreparationAction(input = {}) {
 }
 
 async function applyStockPreparationAction(input = {}) {
-  const action = normalizeStockPreparationActionConfig(input.action)
+  const action = assertStockPreparationTargetReady(input.action)
   const parameters = normalizeActionParameters(input.parameters)
   const dryRun = await computeDryRun({
     action,
@@ -551,6 +585,7 @@ module.exports = {
   TABLE_ACTION_KIND,
   StockPreparationTableActionError,
   applyStockPreparationAction,
+  assertStockPreparationTargetReady,
   createStockPreparationTableActionRegistry,
   createTargetScopedRecordsApi,
   dryRunStockPreparationAction,
@@ -562,8 +597,10 @@ module.exports = {
     consumeDryRunToken,
     createDryRunToken,
     hashJson,
+    plmSystemFieldIds,
     readExistingStockPreparationRows,
     stableStringify,
+    targetFieldMapHasExplicitBindings,
     unmapRecordFields,
   },
 }


### PR DESCRIPTION
## Summary

- Adds C5-3b target schema/config preflight for `plm.stock-preparation.pull-bom.v1`.
- If deployment config uses an explicit `target.fieldIdMap`, it must map every PLM/system field from the stock-preparation template.
- Fails closed with values-free `422 TARGET_SCHEMA_INCOMPLETE` before any PLM source adapter is loaded.
- Keeps `data-source:sql-readonly` as the only C5 source kind; no Bridge Agent widening in this slice.

## Verification

- `pnpm --filter plugin-integration-core test:stock-preparation-table-actions`
- `pnpm --filter plugin-integration-core test:http-routes`
- `pnpm --filter plugin-integration-core test:stock-preparation-apply-writer`
- `pnpm --filter plugin-integration-core test`
- `git diff --check`

## Boundaries

No PLM read/write, no MetaSheet write on bad target config, no K3, no UI, no migration, no raw SQL, no permission model change.
