### PR TITLE
fix(multitable): reject seriesByFieldId + date grouping [v2-d-a follow-up]

### DIFF
--- a/packages/core-backend/src/multitable/chart-aggregation-service.ts
+++ b/packages/core-backend/src/multitable/chart-aggregation-service.ts
@@ -96,7 +96,7 @@ export class ChartAggregationService {
    * Compute chart data from a chart config + record set.
    */
   async computeChartData(chart: ChartConfig, records: RecordRow[]): Promise<ChartData> {
-    let filtered = this.filterRecords(records, chart.dataSource)
+    const filtered = this.filterRecords(records, chart.dataSource)
     const aggFn = chart.dataSource.aggregation.function
     const aggFieldId = chart.dataSource.aggregation.fieldId
 

--- a/packages/core-backend/src/multitable/charts.ts
+++ b/packages/core-backend/src/multitable/charts.ts
@@ -102,6 +102,12 @@ export function assertSeriesConstraints(dataSource: ChartDataSource | undefined,
   if (!dataSource?.groupByFieldId) {
     throw new Error('seriesByFieldId requires groupByFieldId (a primary category axis)')
   }
+  if (dataSource.dateFieldId && dataSource.dateGrouping) {
+    // The producer gives date grouping precedence over groupByFieldId, so a stacked split is not
+    // applied here — reject rather than silently produce a non-stacked chart (v2-d-a is groupBy-primary;
+    // date-axis × series is deferred to v2-d-b).
+    throw new Error('seriesByFieldId (stacked series) is not supported with date grouping')
+  }
   if (!ADDITIVE_AGGREGATIONS.has(dataSource.aggregation?.function)) {
     throw new Error('seriesByFieldId (stacked series) requires a sum or count aggregation')
   }

--- a/packages/core-backend/tests/unit/chart-dashboard.test.ts
+++ b/packages/core-backend/tests/unit/chart-dashboard.test.ts
@@ -946,4 +946,8 @@ describe('assertSeriesConstraints (v2-d input validation)', () => {
       expect(() => assertSeriesConstraints(ds({ aggregation: { function: fn, fieldId: 'amt' } }), 'bar')).toThrow(/sum or count/)
     }
   })
+
+  it('throws when combined with date grouping (matches the producer giving the date axis precedence)', () => {
+    expect(() => assertSeriesConstraints(ds({ dateFieldId: 'd', dateGrouping: 'month' }), 'bar')).toThrow(/date grouping/)
+  })
 })


### PR DESCRIPTION
Small follow-up hardening to the v2-d-a backend (#2297, merged). **No auto-merge — held for review.**

The merged PR landed via auto-merge while this polish (from an advisor pass) was being prepared, so it didn't make it into #2297.

## Change
- `assertSeriesConstraints` now **rejects `seriesByFieldId` combined with date grouping** (`dateFieldId` + `dateGrouping`). The producer gives the date axis precedence over `groupByFieldId` and silently omits the series, so such a config *validated OK yet produced a non-stacked chart*. Rejecting it makes validation match the producer's actual behavior (v2-d-a is groupBy-primary; date-axis × series is deferred to v2-d-b). Degrades safely either way — this is completeness, not a bug fix.
- `let` → `const` cleanup in `computeChartData` (`filtered` is never reassigned).

## Tests
- +1 validator unit case (`seriesByFieldId` + date grouping → throws). `chart-dashboard` **63/63**, eslint clean, `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)