### PR TITLE
feat(multitable): v2-d-a frontend — stacked-bar series picker + render

### DIFF
--- a/apps/web/src/multitable/components/MetaChartRenderer.vue
+++ b/apps/web/src/multitable/components/MetaChartRenderer.vue
@@ -22,6 +22,17 @@
             <span class="meta-chart__legend-value">{{ pt.value }}</span>
           </div>
         </div>
+        <!-- v2-d: stacked-bar legend over series names (colors map to the palette by series index). -->
+        <div
+          v-if="hasStackedSeries && displayConfig?.showLegend !== false"
+          class="meta-chart__legend meta-chart__legend--inline"
+          data-legend="series"
+        >
+          <div v-for="(s, idx) in chartData.series" :key="s.name" class="meta-chart__legend-item">
+            <span class="meta-chart__legend-swatch" :style="{ background: defaultColor(idx) }"></span>
+            <span class="meta-chart__legend-label">{{ s.name }}</span>
+          </div>
+        </div>
       </div>
     </template>
 
@@ -82,6 +93,9 @@ const isEChartsType = computed(() =>
   || props.chartData.chartType === 'pie',
 )
 const isRestricted = computed(() => props.chartData.metadata?.restricted === true)
+const hasStackedSeries = computed(() =>
+  props.chartData.chartType === 'bar' && (props.chartData.series?.length ?? 0) > 0,
+)
 
 // Legend swatch fallback color — same palette as buildChartOption so canvas + HTML legend match.
 function defaultColor(idx: number): string {
@@ -168,6 +182,7 @@ onBeforeUnmount(teardownChart)
 .meta-chart__echarts { width: 100%; height: 250px; }
 
 .meta-chart__legend { display: flex; flex-direction: column; gap: 4px; }
+.meta-chart__legend--inline { flex-direction: row; flex-wrap: wrap; gap: 12px; margin-top: 8px; }
 .meta-chart__legend-item { display: flex; align-items: center; gap: 6px; font-size: 12px; }
 .meta-chart__legend-swatch { width: 12px; height: 12px; border-radius: 3px; flex-shrink: 0; }
 .meta-chart__legend-label { color: #475569; }

--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -209,6 +209,22 @@
             </select>
             <small v-if="!numericFields.length" class="meta-dashboard__hint">{{ viewRenderLabel('dashboard.noNumericFields', isZh) }}</small>
           </label>
+          <!-- v2-d: stack-by (series) — only for a bar chart with an additive aggregation; needs a primary groupBy. -->
+          <label v-if="seriesByAllowed" class="meta-dashboard__field">
+            <span>{{ viewRenderLabel('dashboard.seriesBy', isZh) }}</span>
+            <select
+              v-model="chartDraft.seriesByFieldId"
+              class="meta-dashboard__select"
+              data-field="chart-series-by"
+              :disabled="!chartDraft.groupByFieldId"
+            >
+              <option value="">{{ viewRenderLabel('dashboard.seriesByNone', isZh) }}</option>
+              <option v-for="field in groupableFields" :key="field.id" :value="field.id">
+                {{ field.name }} · {{ fieldTypeLabel(field.type, isZh) }}
+              </option>
+            </select>
+            <small class="meta-dashboard__hint" data-hint="series-stacked">{{ viewRenderLabel('dashboard.seriesByHint', isZh) }}</small>
+          </label>
           <div v-if="createChartError" class="meta-dashboard__error" data-error="create-chart">{{ createChartError }}</div>
           <section class="meta-dashboard__preview" data-chart-preview="true">
             <div class="meta-dashboard__preview-title">{{ viewRenderLabel('dashboard.livePreview', isZh) }}</div>
@@ -298,6 +314,8 @@ const GROUPABLE_FIELD_TYPES = new Set<MetaFieldType>([
 ])
 const NUMERIC_FIELD_TYPES = new Set<MetaFieldType>(['number', 'currency', 'percent', 'rating', 'rollup'])
 const AGGREGATIONS_REQUIRING_VALUE = new Set<AggregationFunction>(['sum', 'avg', 'min', 'max'])
+// v2-d: only additive aggregations make a stacked total meaningful (Σ segments == the single bar).
+const ADDITIVE_AGGREGATIONS = new Set<AggregationFunction>(['sum', 'count'])
 
 const chartDraft = ref({
   name: '',
@@ -307,6 +325,8 @@ const chartDraft = ref({
   valueFieldId: '',
   // v2-c: single-series render variant; only meaningful for pie ('donut') / line ('area').
   variant: '' as '' | 'donut' | 'area',
+  // v2-d: stacked-bar series split; only meaningful for bar + additive aggregation.
+  seriesByFieldId: '',
 })
 
 const activeDashboard = computed(() => dashboards.value.find((d) => d.id === activeDashboardId.value) ?? dashboards.value[0] ?? null)
@@ -317,6 +337,22 @@ const chartFields = computed(() => filterPropertyVisibleFields(props.fields ?? [
 const groupableFields = computed(() => chartFields.value.filter((field) => GROUPABLE_FIELD_TYPES.has(field.type)))
 const numericFields = computed(() => chartFields.value.filter((field) => NUMERIC_FIELD_TYPES.has(field.type)))
 const requiresValueField = computed(() => AGGREGATIONS_REQUIRING_VALUE.has(chartDraft.value.aggregation))
+// v2-d: the stack-by picker is offered only for a bar chart with an additive aggregation and a
+// non-date-grouped primary axis (matches the backend producer + assertSeriesConstraints).
+const seriesByAllowed = computed(() =>
+  chartDraft.value.chartType === 'bar'
+  && ADDITIVE_AGGREGATIONS.has(chartDraft.value.aggregation)
+  && !editingDateGrouped.value,
+)
+// Clear an inapplicable series field when the gating inputs change (type/aggregation/groupBy/date).
+watch(
+  () => [chartDraft.value.chartType, chartDraft.value.aggregation, chartDraft.value.groupByFieldId, editingDateGrouped.value],
+  () => {
+    if (chartDraft.value.seriesByFieldId && !(seriesByAllowed.value && chartDraft.value.groupByFieldId)) {
+      chartDraft.value.seriesByFieldId = ''
+    }
+  },
+)
 const createChartDisabled = computed(() => {
   if (!activeDashboard.value) return true
   if (!chartDraft.value.name.trim()) return true
@@ -343,6 +379,7 @@ function resetChartDraft() {
     aggregation: 'count',
     valueFieldId: '',
     variant: '',
+    seriesByFieldId: '',
   }
   createChartError.value = ''
   resetChartPreview()
@@ -366,6 +403,7 @@ function openEditChart(chartId: string) {
     aggregation: cfg.dataSource.aggregation.function,
     valueFieldId: cfg.dataSource.aggregation.fieldId ?? '',
     variant: cfg.displayConfig?.variant ?? '',
+    seriesByFieldId: cfg.dataSource.seriesByFieldId ?? '',
   }
   createChartError.value = ''
   resetChartPreview()
@@ -475,6 +513,13 @@ function buildChartInput(base?: ChartConfig): ChartCreateInput {
   }
   if (!editingDateGrouped.value) {
     dataSource.groupByFieldId = chartDraft.value.groupByFieldId
+  }
+  // v2-d: stacked series only when bar + additive + a primary groupBy. Set explicitly (or delete the
+  // base value) so switching chartType/aggregation/groupBy clears a now-inapplicable series.
+  if (seriesByAllowed.value && chartDraft.value.groupByFieldId && chartDraft.value.seriesByFieldId) {
+    dataSource.seriesByFieldId = chartDraft.value.seriesByFieldId
+  } else {
+    delete dataSource.seriesByFieldId
   }
   // v2-c: a render variant is valid only for its matching chartType (donut→pie, area→line).
   // Resolve it explicitly so switching chartType clears a now-inapplicable variant carried by base.

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -927,6 +927,9 @@ export interface ChartAggregation {
 export interface ChartDataSource {
   sheetId: string
   groupByFieldId?: string
+  // v2-d: split each groupBy category into stacked series. Honored only for a bar chart with a
+  // primary groupByFieldId + an additive aggregation (sum/count); inert/rejected otherwise.
+  seriesByFieldId?: string
   dateFieldId?: string
   dateGrouping?: 'day' | 'week' | 'month' | 'quarter' | 'year'
   aggregation: ChartAggregation
@@ -969,9 +972,17 @@ export interface ChartDataPoint {
   color?: string
 }
 
+// v2-d: stacked-bar series. `data` is dense + aligned positionally to ChartData.dataPoints.
+export interface ChartSeries {
+  name: string
+  data: number[]
+}
+
 export interface ChartData {
   chartType: ChartType
   dataPoints: ChartDataPoint[]
+  // v2-d: present for a stacked bar chart; dataPoints/total are unaffected by its presence.
+  series?: ChartSeries[]
   total?: number
   metadata?: Record<string, unknown>
 }

--- a/apps/web/src/multitable/utils/buildChartOption.ts
+++ b/apps/web/src/multitable/utils/buildChartOption.ts
@@ -77,6 +77,26 @@ export function buildChartOption(
 
   if (chartType === 'bar') {
     const horizontal = displayConfig?.orientation === 'horizontal'
+    // v2-d: stacked bar — one ECharts series per seriesByFieldId value, all on the same stack.
+    // Categories (xAxis) come from dataPoints; each series.data is dense + aligned to that order.
+    // colored by series (palette), not per-bar; values read via the HTML legend + axis tooltip.
+    const stacked = chartData.series
+    if (stacked && stacked.length > 0) {
+      return {
+        ...base,
+        tooltip: { trigger: 'axis' },
+        grid,
+        xAxis: horizontal ? valueAxis : categoryAxis,
+        yAxis: horizontal ? categoryAxis : valueAxis,
+        series: stacked.map((s) => ({
+          type: 'bar',
+          name: s.name,
+          stack: 'total',
+          label: { show: false },
+          data: s.data,
+        })),
+      }
+    }
     return {
       ...base,
       tooltip: { trigger: 'axis' },

--- a/apps/web/src/multitable/utils/meta-view-render-labels.ts
+++ b/apps/web/src/multitable/utils/meta-view-render-labels.ts
@@ -101,6 +101,9 @@ export type MetaViewRenderLabelKey =
   | 'dashboard.variantStandard'
   | 'dashboard.variantDonut'
   | 'dashboard.variantArea'
+  | 'dashboard.seriesBy'
+  | 'dashboard.seriesByNone'
+  | 'dashboard.seriesByHint'
   | 'dashboard.noNumericFields'
   | 'dashboard.livePreview'
   | 'dashboard.previewFillRequired'
@@ -212,6 +215,9 @@ export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'dashboard.variantStandard',
   'dashboard.variantDonut',
   'dashboard.variantArea',
+  'dashboard.seriesBy',
+  'dashboard.seriesByNone',
+  'dashboard.seriesByHint',
   'dashboard.noNumericFields',
   'dashboard.livePreview',
   'dashboard.previewFillRequired',
@@ -330,6 +336,9 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
   'dashboard.variantStandard': { en: 'Standard', zh: '标准' },
   'dashboard.variantDonut': { en: 'Donut', zh: '环形图' },
   'dashboard.variantArea': { en: 'Area', zh: '面积图' },
+  'dashboard.seriesBy': { en: 'Stack by (series)', zh: '堆叠分组（系列）' },
+  'dashboard.seriesByNone': { en: 'None (single bar)', zh: '不堆叠（单系列）' },
+  'dashboard.seriesByHint': { en: 'Splits each bar into stacked segments. Sum/count only.', zh: '将每根柱子拆成堆叠分段；仅支持求和/计数。' },
   'dashboard.noNumericFields': { en: 'No readable numeric fields available.', zh: '没有可读取的数值字段。' },
   'dashboard.livePreview': { en: 'Live preview', zh: '实时预览' },
   'dashboard.previewFillRequired': { en: 'Complete the chart fields to preview.', zh: '填写完整图表字段后可预览。' },

--- a/apps/web/tests/multitable-build-chart-option.spec.ts
+++ b/apps/web/tests/multitable-build-chart-option.spec.ts
@@ -117,4 +117,59 @@ describe('buildChartOption', () => {
     expect(pieArea.series[0].radius).toBe('70%') // 'area' does not donut-ify a pie
     expect(buildChartOption(chart('number', [{ label: 'x', value: 1 }]), { variant: 'donut' })).toBeNull()
   })
+
+  // --- v2-d: stacked bar (chartData.series) ---
+
+  const stackedBar = (): ChartData => ({
+    chartType: 'bar',
+    dataPoints: [{ label: 'open', value: 3 }, { label: 'closed', value: 2 }],
+    series: [
+      { name: 'A', data: [2, 1] },
+      { name: 'B', data: [1, 1] },
+    ],
+  })
+
+  it('stacked bar: one ECharts bar series per chartData.series entry, all on the same stack', () => {
+    const o = opt(buildChartOption(stackedBar()))
+    expect(o.series).toHaveLength(2)
+    expect(o.series.map((s: any) => s.type)).toEqual(['bar', 'bar'])
+    expect(o.series.map((s: any) => s.name)).toEqual(['A', 'B'])
+    expect(o.series.every((s: any) => s.stack === 'total')).toBe(true)
+    expect(o.series[0].data).toEqual([2, 1])
+    expect(o.series[1].data).toEqual([1, 1])
+    // x-axis categories come from dataPoints (vertical bar)
+    expect(o.xAxis.type).toBe('category')
+    expect(o.xAxis.data).toEqual(['open', 'closed'])
+  })
+
+  it('stacked bar honors horizontal orientation (axes swap, stack preserved)', () => {
+    const o = opt(buildChartOption(stackedBar(), { orientation: 'horizontal' }))
+    expect(o.xAxis.type).toBe('value')
+    expect(o.yAxis.type).toBe('category')
+    expect(o.yAxis.data).toEqual(['open', 'closed'])
+    expect(o.series.every((s: any) => s.stack === 'total')).toBe(true)
+  })
+
+  it('no series ⇒ unchanged single-series bar (regression)', () => {
+    const o = opt(buildChartOption(chart('bar', [{ label: 'A', value: 10 }, { label: 'B', value: 20 }])))
+    expect(o.series).toHaveLength(1)
+    expect(o.series[0].stack).toBeUndefined()
+    expect(o.series[0].data.map((d: any) => d.value)).toEqual([10, 20])
+  })
+
+  it('empty series[] ⇒ falls back to single-series bar (not zero series)', () => {
+    const o = opt(buildChartOption({ chartType: 'bar', dataPoints: [{ label: 'A', value: 5 }], series: [] }))
+    expect(o.series).toHaveLength(1)
+    expect(o.series[0].stack).toBeUndefined()
+  })
+
+  it('series is inert on non-bar types (line/pie ignore it)', () => {
+    const lineWithSeries = opt(buildChartOption({
+      chartType: 'line',
+      dataPoints: [{ label: 'A', value: 1 }],
+      series: [{ name: 'X', data: [1] }],
+    }))
+    expect(lineWithSeries.series[0].type).toBe('line')
+    expect(lineWithSeries.series[0].stack).toBeUndefined()
+  })
 })

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -752,4 +752,122 @@ describe('MetaDashboardView', () => {
     }))
     vi.useRealTimers()
   })
+
+  // ---- v2-d: stacked-bar series picker (seriesByFieldId) ----
+
+  const aggSelectOf = (c: HTMLElement) => c.querySelector('[data-field="chart-aggregation"]') as HTMLSelectElement
+  const groupBySelectOf = (c: HTMLElement) => c.querySelector('[data-field="chart-group-by"]') as HTMLSelectElement
+  const seriesSelectOf = (c: HTMLElement) => c.querySelector('[data-field="chart-series-by"]') as HTMLSelectElement | null
+
+  it('v2-d: series picker shows only for bar + additive aggregation (sum/count)', async () => {
+    const { client } = mockClient([fakeDashboard({ panels: [] })], [])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    await openCreateForm(container)
+    const typeSelect = typeSelectOf(container)
+    const aggSelect = aggSelectOf(container)
+
+    expect(seriesSelectOf(container)).toBeTruthy()             // default bar + count → shown
+    await setSelect(aggSelect, 'avg')
+    expect(seriesSelectOf(container)).toBeNull()               // bar + avg → hidden
+    await setSelect(aggSelect, 'sum')
+    expect(seriesSelectOf(container)).toBeTruthy()             // bar + sum → shown
+    await setSelect(typeSelect, 'line')
+    expect(seriesSelectOf(container)).toBeNull()               // non-bar → hidden
+    await setSelect(typeSelect, 'number')
+    expect(seriesSelectOf(container)).toBeNull()
+  })
+
+  it('v2-d: series picker is disabled without a primary groupBy', async () => {
+    const { client } = mockClient([fakeDashboard({ panels: [] })], [])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    await openCreateForm(container)
+    expect(seriesSelectOf(container)!.disabled).toBe(false)    // groupBy defaults to first groupable field
+    await setSelect(groupBySelectOf(container), '')
+    expect(seriesSelectOf(container)!.disabled).toBe(true)
+  })
+
+  it('v2-d: create carries dataSource.seriesByFieldId', async () => {
+    const { client, fetchFn } = mockClient([fakeDashboard({ panels: [] })], [])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    await openCreateForm(container)
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Stacked'; nameInput.dispatchEvent(new Event('input')); await nextTick()
+    // bar + count (defaults), groupBy = fld_status (default), series = fld_amount
+    await setSelect(seriesSelectOf(container)!, 'fld_amount')
+    ;(container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const post = fetchFn.mock.calls.find(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'POST' && url.includes('/charts') && !url.includes('preview-data'),
+    )
+    expect(JSON.parse(post![1].body as string).dataSource.seriesByFieldId).toBe('fld_amount')
+  })
+
+  it('v2-d: switching to a non-additive aggregation clears the series field', async () => {
+    const { client, fetchFn } = mockClient([fakeDashboard({ panels: [] })], [])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    await openCreateForm(container)
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Switcher'; nameInput.dispatchEvent(new Event('input')); await nextTick()
+    await setSelect(seriesSelectOf(container)!, 'fld_amount')
+    await setSelect(aggSelectOf(container), 'avg')             // non-additive → picker hidden + series cleared
+    const valueSelect = container.querySelector('[data-field="chart-value-field"]') as HTMLSelectElement
+    await setSelect(valueSelect, 'fld_amount')                // avg requires a value field
+    ;(container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const post = fetchFn.mock.calls.find(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'POST' && url.includes('/charts') && !url.includes('preview-data'),
+    )
+    const ds = JSON.parse(post![1].body as string).dataSource
+    expect(ds.aggregation.function).toBe('avg')
+    expect(ds.seriesByFieldId).toBeUndefined()
+  })
+
+  it('v2-d: editing a stacked chart preserves seriesByFieldId on a name-only edit (round-trip)', async () => {
+    const chart = fakeChart({
+      chartType: 'bar',
+      dataSource: { sheetId: 'sheet_1', groupByFieldId: 'fld_status', seriesByFieldId: 'fld_amount', aggregation: { function: 'count' } },
+    })
+    const { client, fetchFn } = mockClient([fakeDashboard()], [chart])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    ;(container.querySelector('[data-action="add-panel"]') as HTMLButtonElement).click()
+    await nextTick()
+    ;(container.querySelector(`[data-edit-chart="${chart.id}"]`) as HTMLButtonElement).click()
+    await nextTick()
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Renamed'; nameInput.dispatchEvent(new Event('input')); await nextTick()
+    ;(container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const patch = fetchFn.mock.calls.find(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'PATCH' && url.includes(`/charts/${chart.id}`),
+    )
+    expect(JSON.parse(patch![1].body as string).dataSource.seriesByFieldId).toBe('fld_amount')
+  })
+
+  it('v2-d: live preview carries dataSource.seriesByFieldId', async () => {
+    const { client } = mockClient([fakeDashboard({ panels: [] })], [])
+    const previewSpy = vi.spyOn(client, 'previewChartData').mockResolvedValue({ chartType: 'bar', dataPoints: [{ label: 'A', value: 1 }] })
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    vi.useFakeTimers()
+    await openCreateForm(container)
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Preview stacked'; nameInput.dispatchEvent(new Event('input')); await nextTick()
+    await setSelect(seriesSelectOf(container)!, 'fld_amount')
+
+    await vi.advanceTimersByTimeAsync(300)
+    await nextTick()
+    expect(previewSpy).toHaveBeenLastCalledWith('sheet_1', expect.objectContaining({
+      chartType: 'bar',
+      dataSource: expect.objectContaining({ seriesByFieldId: 'fld_amount' }),
+    }))
+    vi.useRealTimers()
+  })
 })


### PR DESCRIPTION
**Frontend half of Dashboard BI v2-d-a (stacked bar)**, on the merged backend (#2297 + #2299). Per the design-lock #2291 and the owner's backend-first split — this is its own PR, **not** folded into anything.

## Changes (frontend-only)
- **types** — `ChartDataSource += seriesByFieldId?`; `ChartData += series?: ChartSeries[]` (mirrors the backend wire).
- **`buildChartOption`** — bar branch emits N stacked ECharts series (`stack:'total'`) from `chartData.series`; absent/empty `series` → unchanged single-series bar; inert on non-bar types.
- **`MetaChartRenderer`** — HTML legend over series names for stacked bar (swatch color = palette by series index, matching the canvas; gated by `showLegend`).
- **`MetaDashboardView`** — "Stack by (series)" picker shown **only** for `bar` + additive aggregation (sum/count), **disabled** without a primary groupBy, **cleared** when type/aggregation/groupBy change; carried in `buildChartInput.dataSource.seriesByFieldId` so **create/edit/preview share one config** (explicit set/delete so switching clears a stale base value).
- 3 zh/en labels.

## Tests
- `buildChartOption` unit **+5**: stacked → N series each `stack:'total'`; horizontal orientation; **no-series regression**; empty-`series[]` → single-series fallback; inert on non-bar. (20/20)
- dashboard form **+6**: picker visibility (bar+additive only); disabled-without-groupBy; create + live-preview carry `seriesByFieldId`; clear-on-aggregation-switch; **edit round-trip preserve** (the v2-b1 config-loss trap). (29/29)
- `vue-tsc -b` clean; `MetaChartRenderer` spec 17/17 unregressed. (multitable web files are gated by type-check + tests, not the CI lint allowlist.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)