### PR TITLE
docs(data-factory): design canonical stock target provisioning

### DIFF
--- a/docs/development/data-factory-plm-project-bom-c1b-target-provisioning-design-20260605.md
+++ b/docs/development/data-factory-plm-project-bom-c1b-target-provisioning-design-20260605.md
@@ -1,0 +1,222 @@
+# Data Factory #2253 C1b - canonical stock-preparation target provisioning design (2026-06-05)
+
+> **Design-first. No runtime in this slice.** This document responds to the
+> C5-3b entity-machine retest: the target-schema preflight works, but the onsite
+> stock-preparation table is not a canonical C1 target. C1b defines the safe
+> provisioning/binding path before another full C5 smoke. It adds no route, no
+> UI, no migration, no PLM read, no MetaSheet row write, and no K3 path.
+
+## Why
+
+C5-3b proved the correct failure mode for a partial explicit `target.fieldIdMap`:
+`TARGET_SCHEMA_INCOMPLETE` before any source read. The remaining target blocker
+is not a bug in that preflight. It is that the existing onsite stock-preparation
+table is a business/manual table and does not carry the canonical C1 PLM/system
+fields:
+
+- idempotency and lineage fields such as `idempotencyKey`, `parentSourceId`,
+  `path`, and `depth`;
+- refresh state fields such as `active`, `lastPlmRefreshRunId`,
+  `lastPlmRefreshAt`, `lastPlmRefreshDecision`, and
+  `lastPlmConflictSummary`;
+- PLM payload fields such as `componentSourceId`, `componentCode`,
+  `componentName`, `material`, `sourceVersion`, `rawQuantity`, and
+  `totalQuantity`.
+
+Retrofitting that table through a large deployment-env `fieldIdMap` is fragile:
+it couples the action to many physical field ids, hits Windows JSON escaping
+risks, and makes first-run validation harder. The safer v1 is a canonical target
+created or bound from the C1 manifest.
+
+## Product decision
+
+Use a canonical C1 stock-preparation target for the first full C5 smoke.
+
+The legacy `备料主表` may remain untouched or be migrated later through a
+separate import/migration slice. Full C5 smoke should not depend on a partial
+legacy table map.
+
+## Scope
+
+C1b defines a target readiness/provisioning contract:
+
+1. build a MetaSheet sheet/object structure from
+   `STOCK_PREPARATION_MAIN_TABLE_TEMPLATE`;
+2. create or bind a stock-preparation main table with all C1 fields;
+3. keep PLM/system fields and human-preserved fields classified exactly as the
+   C1 manifest says;
+4. produce a server-side table-action target binding that can omit
+   `target.fieldIdMap` because logical field ids match the canonical target;
+5. emit values-free readiness evidence.
+
+This slice does not define the runtime implementation yet. Implementation should
+be split into smaller follow-ups after this design is reviewed.
+
+## Boundaries
+
+C1b must not:
+
+- read PLM;
+- write MetaSheet **rows**;
+- run the C2 expander, C3 planner, or C4 writer;
+- call K3 Save / Submit / Audit / BOM;
+- write to any external database;
+- accept raw SQL or user-authored SQL;
+- expose source bindings, target sheet ids, field ids, credentials, or business
+  row values in issue evidence;
+- silently map a legacy business table with missing system fields.
+
+Creating table/field **metadata** is allowed only in the later implementation
+slice and only behind admin permission.
+
+## Target readiness modes
+
+| Mode | Meaning | C5 readiness |
+|---|---|---|
+| `canonical_existing` | Existing target has all canonical logical field ids. | Ready; `target.fieldIdMap` may be empty. |
+| `canonical_create` | Admin creates a new target from the C1 manifest. | Ready after creation succeeds. |
+| `explicit_complete_map` | Non-canonical target maps every PLM/system field and required human field intentionally. | Allowed, but not the preferred first-smoke path. |
+| `explicit_partial_map` | Non-canonical target maps only some fields. | Fail closed as `TARGET_SCHEMA_INCOMPLETE`. |
+| `legacy_business_table` | Existing business/manual table with no canonical system fields. | Not ready; do not run full C5 smoke. |
+
+The onsite recommendation selects `canonical_create` or `canonical_existing` for
+the first full smoke.
+
+## Required field contract
+
+The canonical target must include every field from
+`STOCK_PREPARATION_MAIN_TABLE_TEMPLATE`.
+
+PLM/system fields:
+
+- `projectNo`
+- `idempotencyKey`
+- `componentSourceId`
+- `parentSourceId`
+- `path`
+- `depth`
+- `componentCode`
+- `componentName`
+- `material`
+- `sourceVersion`
+- `rawQuantity`
+- `totalQuantity`
+- `active`
+- `lastPlmRefreshRunId`
+- `lastPlmRefreshAt`
+- `lastPlmRefreshDecision`
+- `lastPlmConflictSummary`
+
+Human-preserved fields:
+
+- `materialType`
+- `blankType`
+- `stockPreparationStatus`
+- `demandDate`
+- `leadTimeDays`
+- `notes`
+- `procurementReply`
+- `warehouseConfirmation`
+
+Implementation must use the manifest as the source of truth, not a duplicated
+field list. A test must fail if the runtime provisioning list drifts from the
+manifest.
+
+## Admin workflow
+
+The implementation should expose one of these admin-only flows:
+
+1. **Create canonical target**: create a new stock-preparation main table from
+   the C1 manifest and return a server-side target binding.
+2. **Bind existing canonical target**: validate an existing table has all
+   logical fields, then return the target binding.
+
+For v1, the browser should not edit PLM/system field ids, source bindings, C3
+plans, C4 payloads, or raw action JSON. If an admin UI is added, it should show
+readiness state and field presence, not expose private deployment config values.
+
+## Action config output
+
+The preferred canonical target config shape is:
+
+```json
+{
+  "target": {
+    "sheetId": "<server-owned-stock-preparation-sheet-id>",
+    "objectId": "plm_stock_preparation_main",
+    "keyField": "idempotencyKey",
+    "fieldIdMap": {}
+  }
+}
+```
+
+`fieldIdMap` stays empty because canonical logical field ids match the template.
+This avoids the large Windows deployment-env JSON map that failed in C5-3a.
+
+If an explicit map is still used, it must remain all-or-nothing for PLM/system
+fields and continue to pass C5-3b preflight.
+
+## Source gate stays separate
+
+C1b only solves the target side. Full C5 smoke still also needs a real PLM source
+bound as `data-source:sql-readonly`.
+
+If production must use the existing `bridge:legacy-sql-readonly` path, that is a
+separate source-design pivot. C1b must not silently widen C5 source kind support.
+
+## Relationship to C6 custom option sync
+
+The user-facing custom option button is supported as C6, not C1b.
+
+C1b creates/binds select fields such as `materialType`, `blankType`, and
+`stockPreparationStatus` with `optionSource` metadata. C6 later adds a controlled
+sync action that refreshes those field options from `config_info`.
+
+C6 must not be implemented by auto-creating new options during C5 apply. Apply
+uses the current target schema/options and fails or manual-confirms when values
+do not fit the configured contract.
+
+## Evidence
+
+Allowed issue evidence:
+
+- mode: `canonical_existing`, `canonical_create`, or failed mode;
+- field presence counts;
+- missing logical field ids;
+- ownership counts: PLM/system vs human-preserved;
+- option-source keys, not option values;
+- target readiness status.
+
+Forbidden issue evidence:
+
+- target sheet id;
+- physical field ids if considered private;
+- business row values;
+- PLM row values;
+- datasource ids, credentials, tokens, connection strings;
+- action config JSON carrying private bindings.
+
+## Implementation decomposition
+
+| Slice | Scope |
+|---|---|
+| C1b-0 | This design + TODO reconcile. Docs-only. |
+| C1b-1 | Backend manifest-to-target readiness/provisioning helper. Admin-only, metadata only, no rows. |
+| C1b-2 | Optional admin UI or runbook to create/bind the canonical target. No PLM read. |
+| C1b-3 | Entity-machine target readiness smoke: canonical target present and C5 action can be configured without explicit `fieldIdMap`. |
+
+C5 full smoke resumes only after C1b target readiness and the PLM source gate are
+both satisfied.
+
+## Acceptance locks for C1b implementation
+
+- Provisioning uses `STOCK_PREPARATION_MAIN_TABLE_TEMPLATE` as the only field
+  contract.
+- The helper never writes business rows.
+- Admin permission is required for create/bind.
+- Canonical target can omit `target.fieldIdMap`.
+- Non-canonical explicit maps still go through C5-3b completeness preflight.
+- Readiness errors are values-free.
+- C1b does not add Bridge source support.
+- C1b does not call PLM, K3, or external DB write paths.
+- C6 option sync remains a later separate opt-in.

--- a/docs/development/data-factory-plm-project-bom-c5-3b-target-schema-preflight-verification-20260605.md
+++ b/docs/development/data-factory-plm-project-bom-c5-3b-target-schema-preflight-verification-20260605.md
@@ -93,8 +93,30 @@ wire boundary:
   target preflight fails;
 - the error does not expose the configured source binding or target sheet id.
 
+## Entity-machine retest closeout
+
+The refreshed package
+`metasheet-multitable-onprem-v2.5.0-plm-stock-c5-3b-17feef2f` was deployed on
+the entity machine and the C5-3b guard passed:
+
+- the temporary table-action config reached `configured:true`;
+- a partial explicit `target.fieldIdMap` returned HTTP `422` with
+  `TARGET_SCHEMA_INCOMPLETE`;
+- the error exposed logical schema metadata only;
+- the source-read log delta was `0`, proving the target preflight ran before any
+  PLM/data-source read;
+- no K3 Save / Submit / Audit / BOM, no MetaSheet apply/write, no external PLM
+  DB write, and no raw/user-authored SQL were executed.
+
+This closes the C5-3b code/package fix.
+
 ## Remaining gate
 
-After this slice lands, cut a refreshed on-prem package and rerun #2253 C5-3
-entity-machine smoke. The operator still needs to bind the PLM source as
-`data-source:sql-readonly` or explicitly pivot to a separate source design.
+Full C5 smoke still needs two gates:
+
+- target readiness: use a canonical C1 stock-preparation target or a complete
+  explicit `fieldIdMap`; C1b owns the preferred canonical target
+  provisioning/binding path;
+- source readiness: bind the real PLM source as `data-source:sql-readonly`, or
+  explicitly pivot to a separate source design if the Bridge Agent route is the
+  desired production path.

--- a/docs/development/data-factory-plm-project-bom-stock-preparation-design-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-stock-preparation-design-20260604.md
@@ -307,11 +307,12 @@ Each implementation slice is a separate explicit opt-in.
 |---|---|
 | C0 | Design + TODO docs only. No runtime. |
 | C1 | Stock-preparation table template / field model manifest. Schema-only; no PLM read, no write. |
+| C1b | Canonical stock-preparation target provisioning/binding. Metadata create/bind only; no PLM read and no business-row write. |
 | C2 | `projectNo -> PLM BOM` dry-run expansion helper. Recursive read + normalized rows; no MetaSheet write. |
 | C3 | Conflict planner. Computes `add/update/skip/inactive/manual_confirm`; preserves human fields; no write. |
 | C4 | Apply writer. Writes only the MetaSheet stock-preparation main table; records run id, decision, and conflict summary. |
 | C5 | Workbench UI action. Project number input, dry-run summary, apply confirmation; no K3. |
-| C6 | `config_info` option sync. Keeps select/dropdown options aligned for configured stock-preparation fields. |
+| C6 | `config_info` option sync. Keeps select/dropdown options aligned for configured stock-preparation fields through a controlled sync action. |
 
 Deferred:
 
@@ -337,4 +338,10 @@ Deferred:
 - Apply writes MetaSheet only; no external DB write and no K3 call.
 - Permissions separate dry-run read/source-read from apply write/admin.
 - Issue/customer evidence is values-free.
+- C1b target create/bind uses the C1 manifest as the single field contract; a
+  full C5 smoke should prefer a canonical target over a large legacy-table
+  `fieldIdMap`.
+- C6 may expose a user-facing/admin-facing custom option sync action, but C5
+  apply must not auto-create unknown select/dropdown options while writing BOM
+  refresh rows.
 - Each C1-C6 slice remains a separate PR-level opt-in.

--- a/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
@@ -100,6 +100,37 @@ available in this repo. Instead, this slice turns the feasibility gate into a
 schema-only contract (`requires_customer_schema`) that C2 must satisfy before
 runtime can proceed.
 
+### 🟡 C1b - Canonical target provisioning / binding design (this PR)
+
+Gated on: C5-3b entity-machine finding + explicit opt-in.
+
+Scope:
+
+- Design the target readiness path discovered by the C5-3b onsite retest:
+  the existing onsite stock-preparation table is a business/manual table and is
+  not a canonical C1 target.
+- Prefer a canonical C1 target table over retrofitting a large explicit
+  deployment-env `fieldIdMap`.
+- Define create/bind modes for a stock-preparation main table that carries all
+  C1 PLM/system fields and human-preserved fields.
+- Keep this slice docs-only; no route, UI, table creation, PLM read, MetaSheet
+  row write, or K3 path.
+- Keep the PLM source gate separate: full C5 smoke still needs a real PLM source
+  registered/bound as `data-source:sql-readonly`, or a separate Bridge-source
+  design pivot.
+
+Acceptance locks:
+
+- The C1 manifest remains the single source of truth for target fields.
+- Canonical targets may omit `target.fieldIdMap`; logical field ids are used.
+- Legacy/non-canonical targets with partial explicit maps still fail as
+  `TARGET_SCHEMA_INCOMPLETE`.
+- Any create/bind implementation is admin-only and metadata-only; it writes no
+  business rows.
+- C6 custom option sync remains a later separate opt-in; C1b only carries
+  `optionSource` metadata.
+- Issue evidence is values-free: field names/counts and readiness status only.
+
 ### ✅ C2-0 - Filtered readonly SQL bridge for PLM lookups (DONE - PR #2265, `2be099bd8`)
 
 Gated on: C1 + explicit opt-in.
@@ -342,7 +373,7 @@ Acceptance locks:
 - The deployment config path is scoped to `plugin-integration-core`; unrelated
   plugins do not receive the table-action config.
 
-### 🟡 C5-3b - Target schema/config preflight (this PR)
+### ✅ C5-3b - Target schema/config preflight (DONE - PR #2298, `17feef2fa`)
 
 Gated on: C5-3a entity-machine smoke finding + explicit opt-in.
 
@@ -372,7 +403,8 @@ Acceptance locks:
 ### ⬜ C5-3 - Operator validation runbook / entity-machine smoke
 
 Gated on: C5-1/C5-2 + C5-3a package deployed + C5-3b package deployed +
-explicit opt-in.
+C1b target readiness + real PLM `data-source:sql-readonly` binding + explicit
+opt-in.
 
 Scope:
 
@@ -389,6 +421,19 @@ Acceptance locks:
 - External DB write remains not invoked.
 - Manual-confirm rows remain held.
 
+Current entity-machine state after C5-3b:
+
+- C5-3b target-schema preflight PASSed: partial explicit `fieldIdMap` returns
+  values-free `422 TARGET_SCHEMA_INCOMPLETE` before any source read.
+- Full C5 smoke remains blocked on target readiness and source binding, not on
+  the preflight code.
+- Target readiness: use a canonical C1 target table or a complete explicit
+  field map. The recommended next path is C1b canonical target
+  provisioning/binding.
+- Source readiness: bind the real PLM SQL Server source as
+  `data-source:sql-readonly`; `bridge:legacy-sql-readonly` support is a
+  separate source-design pivot, not a silent fallback.
+
 ### 🔒 C6 - `config_info` -> select/dropdown option sync
 
 Gated on: C5 + explicit opt-in.
@@ -397,6 +442,8 @@ Scope:
 
 - Sync selected option sets used by stock-preparation fields.
 - Keep options aligned for fields such as material type / blank type / status.
+- Support a controlled user-facing/admin-facing "sync options" action after the
+  target table exists.
 - This is MetaSheet configuration sync only.
 
 Acceptance locks:
@@ -405,6 +452,7 @@ Acceptance locks:
 - No K3 write.
 - Option evidence is values-free when posted to issues.
 - Missing/ambiguous option mapping fails closed.
+- C6 must not auto-create unknown options during C5 apply.
 
 ## Deferred tracks
 
@@ -433,18 +481,22 @@ operator checks stay in later validation slices:
 
 ## Sequencing rule
 
-C0, C1, C2-0, C2, C3, C4, C5-0, C5-1, C5-2, and C5-3a are complete. C5-3b is
-the current entity-machine unblocker found during C5-3 smoke: an explicit
-target `fieldIdMap` must fail closed when it omits C5 PLM/system fields.
+C0, C1, C2-0, C2, C3, C4, C5-0, C5-1, C5-2, C5-3a, and C5-3b are complete.
+C5-3b closed the target-schema fail-closed bug found during C5-3 smoke. The next
+target-side blocker is C1b canonical target provisioning/binding; the next
+source-side blocker is binding the real PLM source as `data-source:sql-readonly`
+or explicitly opening a Bridge-source design.
 
 1. C5-0 design locks the reusable parameterized action contract.
 2. C5-1 adds backend action routes and server-side recompute/apply wiring.
 3. C5-2 adds the workbench operator surface.
 4. C5-3a injects server-owned plugin action config for on-prem deployment.
 5. C5-3b rejects incomplete target schema/config before any PLM read.
-6. C5-3 validates the flow on an entity machine.
+6. C1b prepares a canonical target table/binding so full C5 smoke no longer
+   depends on a large explicit legacy `fieldIdMap`.
+7. C5-3 validates the flow on an entity machine.
 
-C6 option sync remains after C5. All later slices still require their
-predecessor to land and the owner to explicitly opt in. K3 Save / Submit /
-Audit / BOM, external database write, and multi-project/batch mode remain out
-of scope.
+C6 option sync remains after C1b/C5 target readiness. All later slices still
+require their predecessor to land and the owner to explicitly opt in. K3 Save /
+Submit / Audit / BOM, external database write, and multi-project/batch mode
+remain out of scope.


### PR DESCRIPTION
## Summary

Docs-only C1b-0 for #2253 after the C5-3b entity-machine retest.

This PR locks the next target-side path before full C5 smoke resumes:

- prefer a canonical C1 stock-preparation target over retrofitting the legacy business table with a large deployment-env `fieldIdMap`;
- define target readiness modes: canonical existing, canonical create, complete explicit map, partial explicit map, legacy business table;
- require the C1 manifest as the single source of truth for PLM/system + human-preserved fields;
- keep source readiness separate: the real PLM source must be bound as `data-source:sql-readonly`, or Bridge support must be a separate source-design pivot;
- clarify the custom option button path: C6 can add a controlled `config_info` option sync action, but C5 apply must not auto-create unknown options.

Also updates the C5-3b verification doc with the entity-machine PASS and remaining gates.

## Boundary

No runtime, route, UI, migration, PLM read, MetaSheet row write, external DB write, K3, package, or permission change.

## Verification

- `git diff --check`
