### PR TITLE
feat(data-factory): add stock target readiness routes

### DIFF
--- a/docs/development/data-factory-plm-project-bom-c1b-2-target-readiness-route-verification-20260605.md
+++ b/docs/development/data-factory-plm-project-bom-c1b-2-target-readiness-route-verification-20260605.md
@@ -1,0 +1,83 @@
+# Data Factory #2253 C1b-2 target readiness route verification (2026-06-05)
+
+## Scope
+
+C1b-2 exposes the C1b-1 canonical stock-preparation target helper through a
+narrow backend workflow:
+
+- `GET /api/integration/stock-preparation/target/readiness`
+- `POST /api/integration/stock-preparation/target/ensure`
+
+The routes are admin-only and use the C1 manifest as the target field contract.
+They inspect/bind/create table and field metadata only.
+
+## Boundaries
+
+This slice does **not** add:
+
+- frontend UI;
+- PLM reads;
+- MetaSheet business-row writes;
+- C2/C3/C4 execution;
+- K3 Save / Submit / Audit / BOM;
+- external database writes;
+- C6 custom option sync;
+- source gate changes.
+
+## Safety locks
+
+- Permission is derived from `requireAccess(req, 'admin')`; the browser cannot
+  supply `permission`.
+- Request fields are allowlisted to `tenantId`, `workspaceId`, `projectId`, and
+  `baseId`; `sheetId`, `fieldIdMap`, `target`, `source`, `plan`, and `payload`
+  are rejected before provisioning.
+- Missing targets can be created as metadata only through
+  `context.api.multitable.provisioning.ensureObject`.
+- Existing complete canonical targets bind without recreation.
+- Existing incomplete canonical targets fail closed as
+  `TARGET_SCHEMA_INCOMPLETE` and are not repaired in place.
+- `data.evidence` is values-free. `data.targetBinding` is private admin config
+  material and must not be pasted to issues/customer evidence.
+- The route never uses `context.api.multitable.records`.
+
+## Tests
+
+```bash
+pnpm --filter plugin-integration-core test:http-routes
+pnpm --filter plugin-integration-core test:stock-preparation-target-provisioning
+pnpm --filter plugin-integration-core test:stock-preparation-table-actions
+git diff --check
+```
+
+Expected focused output:
+
+```text
+http-routes: REST auth/list/upsert/run/dry-run/staging/replay tests passed
+stock-preparation-target-provisioning.test.cjs OK
+stock-preparation-table-actions.test.cjs OK
+```
+
+## Route assertions
+
+`http-routes.test.cjs` covers:
+
+- route registration for readiness and ensure;
+- write user cannot inspect/ensure; provisioning API is not called;
+- admin request with unsupported `sheetId` / `permission` fields returns
+  `STOCK_PREPARATION_TARGET_REQUEST_INVALID` before provisioning;
+- missing target readiness returns `canonical_missing` with values-free
+  evidence;
+- ensure creates the canonical descriptor and verifies manifest-derived fields;
+- ensure existing complete canonical target returns `canonical_existing` without
+  calling `ensureObject`;
+- incomplete existing target returns `TARGET_SCHEMA_INCOMPLETE`, hides the
+  sheet id, and is not repaired in place;
+- records API call count stays zero across readiness/ensure paths.
+
+## Remaining gates
+
+- C1b-3: entity-machine target readiness smoke using the runbook.
+- PLM source gate: real `data-source:sql-readonly` binding that satisfies C2
+  flat reads.
+- C5 full smoke: separate after target readiness and source gate pass.
+- C6: custom option sync remains a later opt-in.

--- a/docs/development/data-factory-plm-project-bom-c1b-target-provisioning-design-20260605.md
+++ b/docs/development/data-factory-plm-project-bom-c1b-target-provisioning-design-20260605.md
@@ -201,8 +201,8 @@ Forbidden issue evidence:
 | Slice | Scope |
 |---|---|
 | C1b-0 | This design + TODO reconcile. Docs-only. |
-| C1b-1 | Backend manifest-to-target readiness/provisioning helper. Admin-only, metadata only, no rows. |
-| C1b-2 | Optional admin UI or runbook to create/bind the canonical target. No PLM read. |
+| C1b-1 | Backend manifest-to-target readiness/provisioning helper. Admin-only, metadata only, no rows. Done in #2307. |
+| C1b-2 | Admin-only route/runbook to inspect or create/bind the canonical target. No PLM read. |
 | C1b-3 | Entity-machine target readiness smoke: canonical target present and C5 action can be configured without explicit `fieldIdMap`. |
 
 C5 full smoke resumes only after C1b target readiness and the PLM source gate are
@@ -222,6 +222,24 @@ admin workflow or runbook:
   trusting returned physical field ids;
 - helper uses only `context.api.multitable.provisioning`; it does not use the
   records API and writes no business rows.
+
+## C1b-2 implementation note
+
+C1b-2 wires the helper through a narrow admin-only backend workflow, not a broad
+authoring UI:
+
+- `GET /api/integration/stock-preparation/target/readiness` inspects target
+  readiness only;
+- `POST /api/integration/stock-preparation/target/ensure` creates missing
+  canonical table/field metadata or binds an existing complete canonical target;
+- both routes derive permission from `requireAccess(req, 'admin')` and reject
+  client-supplied `permission`, `sheetId`, `target`, `fieldIdMap`, source
+  bindings, C3 plans, or C4 payloads;
+- responses separate private `targetBinding` from values-free `evidence`;
+- operator/customer evidence must copy only `data.evidence`, never
+  `data.targetBinding`;
+- C1b-2 still does not read PLM, use the records API, write business rows, call
+  K3, write an external database, or sync custom options.
 
 ## Acceptance locks for C1b implementation
 

--- a/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
@@ -131,7 +131,7 @@ Acceptance locks:
   `optionSource` metadata.
 - Issue evidence is values-free: field names/counts and readiness status only.
 
-### 🟡 C1b-1 - Canonical target provisioning helper (this PR)
+### ✅ C1b-1 - Canonical target provisioning helper (DONE - PR #2307, `61633c634`)
 
 Gated on: C1b-0 + explicit opt-in.
 
@@ -157,6 +157,36 @@ Acceptance locks:
   writes to an external database.
 - C1b-2 UI/runbook, C1b-3 entity-machine readiness smoke, and C6 option sync
   remain separate opt-ins.
+
+### 🟡 C1b-2 - Admin target readiness/provisioning workflow (this PR)
+
+Gated on: C1b-1 + explicit opt-in.
+
+Scope:
+
+- Expose a narrow admin-only backend workflow:
+  - `GET /api/integration/stock-preparation/target/readiness`
+  - `POST /api/integration/stock-preparation/target/ensure`
+- Derive admin permission from `requireAccess(req, 'admin')`; never accept
+  client-supplied permission, sheet id, field map, target config, PLM source, or
+  action payload.
+- Use the C1b-1 helper to inspect/bind/create only table/field metadata.
+- Return a private `targetBinding` for admin config and a separate values-free
+  `evidence` object for issue/customer evidence.
+- Add an operator runbook for entity-machine target readiness.
+
+Acceptance locks:
+
+- Non-admin users cannot inspect or ensure the target.
+- Unsupported client fields fail closed before provisioning.
+- Missing target creates canonical metadata only; no records API, PLM read, K3,
+  or external DB write.
+- Existing complete canonical target binds without recreating.
+- Existing incomplete canonical target fails closed as
+  `TARGET_SCHEMA_INCOMPLETE` and is not repaired in place.
+- Issue evidence must copy only `data.evidence`, never `data.targetBinding`.
+- C1b-3 entity-machine target readiness smoke, the PLM source gate, and C6
+  option sync remain separate opt-ins.
 
 ### ✅ C2-0 - Filtered readonly SQL bridge for PLM lookups (DONE - PR #2265, `2be099bd8`)
 

--- a/docs/operations/data-factory-plm-stock-preparation-target-readiness-runbook-20260605.md
+++ b/docs/operations/data-factory-plm-stock-preparation-target-readiness-runbook-20260605.md
@@ -1,0 +1,116 @@
+# Data Factory PLM stock-preparation target readiness runbook (C1b-2)
+
+Use this runbook on the entity machine before resuming the #2253 full C5 smoke.
+C1b-2 prepares the **target table metadata** only. It does not read PLM, write
+business rows, apply a plan, call K3, write an external database, or sync custom
+options.
+
+## Preconditions
+
+- You are signed in as an integration admin.
+- The deployed package includes #2307 and the C1b-2 route slice.
+- You know the tenant context. If no `projectId` is supplied, the backend uses
+  the plugin-scoped default `<tenantId>:integration-core`.
+
+## 1. Check readiness
+
+Call:
+
+```http
+GET /api/integration/stock-preparation/target/readiness?tenantId=<tenant>&projectId=<tenant>:integration-core
+```
+
+Expected not-yet-created shape:
+
+```json
+{
+  "ok": true,
+  "data": {
+    "ready": false,
+    "mode": "canonical_missing",
+    "targetBinding": null,
+    "evidence": {
+      "status": "missing",
+      "mode": "canonical_missing",
+      "fieldMapMode": "canonical",
+      "missingFields": ["... logical field ids only ..."]
+    }
+  }
+}
+```
+
+## 2. Create or bind the canonical target
+
+Call:
+
+```http
+POST /api/integration/stock-preparation/target/ensure
+```
+
+Body:
+
+```json
+{
+  "tenantId": "<tenant>",
+  "projectId": "<tenant>:integration-core",
+  "baseId": "<optional-base-id>"
+}
+```
+
+Successful create returns HTTP `201` and `mode: canonical_create`. Successful
+bind of an existing complete canonical target returns HTTP `200` and
+`mode: canonical_existing`.
+
+## 3. Evidence rule
+
+The response has two distinct sections:
+
+- `data.targetBinding`: private admin config material. It may include
+  `sheetId`. Do **not** paste this to issues/customer evidence.
+- `data.evidence`: values-free readiness evidence. This is the only section
+  allowed in #2253/customer evidence.
+
+Allowed evidence fields:
+
+- `status`
+- `mode`
+- `objectId`
+- `fieldMapMode`
+- `keyField`
+- `fieldCounts`
+- `missingFields`
+- `optionSources`
+- `target.fieldIdMapEmpty`
+
+Forbidden evidence:
+
+- `targetBinding`
+- target sheet id
+- physical field ids
+- datasource ids
+- credentials/tokens/connection strings
+- PLM row values
+- stock-preparation row values
+- action config JSON
+
+## 4. Fail-closed cases
+
+- Non-admin user -> HTTP `403`; no provisioning call.
+- Unsupported request fields such as `sheetId`, `fieldIdMap`, `target`,
+  `source`, `permission`, `plan`, or `payload` -> HTTP `400`; no provisioning
+  call.
+- Existing canonical object with missing logical fields -> HTTP `422`
+  `TARGET_SCHEMA_INCOMPLETE`; it is **not** repaired in place.
+
+## 5. Pass condition for C1b-3
+
+C1b-3 may start only when readiness evidence shows:
+
+- `ready: true`
+- `mode: canonical_create` or `canonical_existing`
+- `evidence.status: ready`
+- `evidence.missingFields: []`
+- `evidence.target.fieldIdMapEmpty: true`
+
+Full C5 smoke still also requires the separate PLM source gate: a real
+`data-source:sql-readonly` PLM binding that satisfies the C2 flat-read contract.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -7,6 +7,7 @@ const HTTP_ROUTES_PATH = path.join(__dirname, '..', 'lib', 'http-routes.cjs')
 const httpRoutes = require(HTTP_ROUTES_PATH)
 const { MAX_LIST_LIMIT } = httpRoutes
 const { PLM_STOCK_PREPARATION_ACTION_ID } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-table-actions.cjs'))
+const { STOCK_PREPARATION_MAIN_TABLE_TEMPLATE } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-templates.cjs'))
 
 const READ_USER = {
   id: 'user_read',
@@ -51,6 +52,11 @@ function createMockContext(options = {}) {
     async createRecord() { throw new Error('createRecord not configured in test context') },
     async patchRecord() { throw new Error('patchRecord not configured in test context') },
   }
+  const provisioning = options.provisioningApi || {
+    async findObjectSheet() { return null },
+    async resolveFieldIds() { return {} },
+    async ensureObject() { throw new Error('ensureObject not configured in test context') },
+  }
 
   return {
     context: {
@@ -64,6 +70,7 @@ function createMockContext(options = {}) {
           },
         },
         multitable: {
+          provisioning,
           records,
         },
       },
@@ -2416,6 +2423,149 @@ function createTableActionRecordsApi() {
   return { rows, calls, recordsApi }
 }
 
+function createStockPreparationTargetProvisioningApi({
+  sheetExists = false,
+  missingFields = [],
+} = {}) {
+  const calls = []
+  let sheet = sheetExists
+    ? { id: 'sheet_stock_canonical_private', baseId: 'base_stock', name: 'PLM Stock Preparation Main', description: null }
+    : null
+  let missing = new Set(missingFields)
+  const api = {
+    async findObjectSheet(input) {
+      calls.push(['findObjectSheet', clone(input)])
+      return sheet ? clone(sheet) : null
+    },
+    async resolveFieldIds(input) {
+      calls.push(['resolveFieldIds', clone(input)])
+      const out = {}
+      for (const fieldId of input.fieldIds || []) {
+        if (!missing.has(fieldId)) out[fieldId] = `fld_${fieldId}`
+      }
+      return out
+    },
+    async ensureObject(input) {
+      calls.push(['ensureObject', clone(input)])
+      sheet = { id: 'sheet_stock_canonical_created', baseId: input.baseId || 'base_default', name: input.descriptor.name, description: input.descriptor.description || null }
+      missing = new Set()
+      return {
+        baseId: sheet.baseId,
+        sheet: clone(sheet),
+        fields: input.descriptor.fields.map((field, index) => ({
+          id: `physical_${index}_${field.id}`,
+          sheetId: sheet.id,
+          name: field.name,
+          type: field.type,
+          property: field.property || {},
+          order: index,
+        })),
+      }
+    },
+  }
+  return { api, calls }
+}
+
+async function testStockPreparationTargetProvisioningRoutes() {
+  const provisioning = createStockPreparationTargetProvisioningApi()
+  const records = createTableActionRecordsApi()
+  const { routes, registered } = mountRoutes(createMockServices().services, {
+    provisioningApi: provisioning.api,
+    recordsApi: records.recordsApi,
+  })
+
+  assert.ok(
+    registered.includes('GET /api/integration/stock-preparation/target/readiness'),
+    'stock-preparation target readiness route registered',
+  )
+  assert.ok(
+    registered.includes('POST /api/integration/stock-preparation/target/ensure'),
+    'stock-preparation target ensure route registered',
+  )
+
+  let res = await invoke(routes, 'GET', '/api/integration/stock-preparation/target/readiness', {
+    user: WRITE_USER,
+    query: { projectId: 'tenant_1:integration-core' },
+  })
+  assert.equal(res.statusCode, 403, 'write user cannot inspect target readiness')
+  assert.equal(provisioning.calls.length, 0, 'non-admin request does not reach provisioning API')
+
+  res = await invoke(routes, 'POST', '/api/integration/stock-preparation/target/ensure', {
+    user: ADMIN_USER,
+    body: { projectId: 'tenant_1:integration-core', sheetId: 'evil_sheet', permission: 'admin' },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.body.error.code, 'STOCK_PREPARATION_TARGET_REQUEST_INVALID')
+  assert.equal(provisioning.calls.length, 0, 'client-supplied sheetId/permission is rejected before provisioning')
+
+  res = await invoke(routes, 'GET', '/api/integration/stock-preparation/target/readiness', {
+    user: ADMIN_USER,
+    query: { projectId: 'tenant_1:integration-core' },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.ready, false)
+  assert.equal(res.body.data.mode, 'canonical_missing')
+  assert.equal(res.body.data.targetBinding, null)
+  assert.equal(res.body.data.evidence.status, 'missing')
+  assert.equal(res.body.data.evidence.missingFields.length, STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.fields.length)
+  assert.equal(JSON.stringify(res.body.data.evidence).includes('sheet_stock'), false, 'readiness evidence hides sheet id')
+  assert.equal(records.calls.length, 0, 'readiness route never uses records API')
+
+  res = await invoke(routes, 'POST', '/api/integration/stock-preparation/target/ensure', {
+    user: ADMIN_USER,
+    body: { projectId: 'tenant_1:integration-core', baseId: 'base_stock' },
+  })
+  assertOkResponse(res, 201)
+  assert.equal(res.body.data.ready, true)
+  assert.equal(res.body.data.mode, 'canonical_create')
+  assert.deepEqual(res.body.data.targetBinding, {
+    sheetId: 'sheet_stock_canonical_created',
+    objectId: STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.objectId,
+    keyField: 'idempotencyKey',
+    fieldIdMap: {},
+  })
+  assert.equal(JSON.stringify(res.body.data.evidence).includes('sheet_stock_canonical_created'), false, 'ensure evidence hides sheet id')
+  const ensureCall = findCalls(provisioning.calls, 'ensureObject')[0]
+  assert.equal(ensureCall[1].projectId, 'tenant_1:integration-core')
+  assert.equal(ensureCall[1].baseId, 'base_stock')
+  assert.deepEqual(
+    ensureCall[1].descriptor.fields.map((field) => field.id),
+    STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.fields.map((field) => field.id),
+    'ensure descriptor is manifest-derived',
+  )
+  assert.equal(records.calls.length, 0, 'ensure route never uses records API')
+
+  const existing = createStockPreparationTargetProvisioningApi({ sheetExists: true })
+  const existingMount = mountRoutes(createMockServices().services, {
+    provisioningApi: existing.api,
+    recordsApi: createTableActionRecordsApi().recordsApi,
+  })
+  res = await invoke(existingMount.routes, 'POST', '/api/integration/stock-preparation/target/ensure', {
+    user: ADMIN_USER,
+    body: { workspaceId: 'workspace_1' },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.mode, 'canonical_existing')
+  assert.deepEqual(res.body.data.targetBinding.fieldIdMap, {})
+  assert.equal(findCalls(existing.calls, 'ensureObject').length, 0, 'existing complete target is bound, not recreated')
+  assert.equal(findCalls(existing.calls, 'findObjectSheet')[0][1].projectId, 'tenant_1:integration-core', 'default projectId is integration-core scoped')
+
+  const incomplete = createStockPreparationTargetProvisioningApi({ sheetExists: true, missingFields: ['path'] })
+  const incompleteMount = mountRoutes(createMockServices().services, {
+    provisioningApi: incomplete.api,
+    recordsApi: createTableActionRecordsApi().recordsApi,
+  })
+  res = await invoke(incompleteMount.routes, 'POST', '/api/integration/stock-preparation/target/ensure', {
+    user: ADMIN_USER,
+    body: { projectId: 'tenant_1:integration-core' },
+  })
+  assert.equal(res.statusCode, 422)
+  assert.equal(res.body.error.code, 'TARGET_SCHEMA_INCOMPLETE')
+  assert.deepEqual(res.body.error.details.missingFields, ['path'])
+  assert.equal(JSON.stringify(res.body.error).includes('sheet_stock_canonical_private'), false, 'incomplete error hides sheet id')
+  assert.equal(findCalls(incomplete.calls, 'ensureObject').length, 0, 'incomplete existing target is not repaired in place')
+}
+
 async function testTableActionRoutes() {
   const adapterCalls = []
   const records = createTableActionRecordsApi()
@@ -2586,6 +2736,7 @@ async function testTableActionUnconfiguredFailsClosed() {
 
 async function main() {
   await testUnauthenticatedWriteRequestIsRejected()
+  await testStockPreparationTargetProvisioningRoutes()
   await testTableActionRoutes()
   await testTableActionTargetPreflightBeforeSourceAdapter()
   await testTableActionUnconfiguredFailsClosed()

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -26,6 +26,8 @@ const ROUTES = [
   ['GET', '/api/integration/table-actions', 'tableActionsList'],
   ['POST', '/api/integration/table-actions/:actionId/dry-run', 'tableActionDryRun'],
   ['POST', '/api/integration/table-actions/:actionId/apply', 'tableActionApply'],
+  ['GET', '/api/integration/stock-preparation/target/readiness', 'stockPreparationTargetReadiness'],
+  ['POST', '/api/integration/stock-preparation/target/ensure', 'stockPreparationTargetEnsure'],
   ['POST', '/api/integration/templates/preview', 'templatesPreview'],
   ['POST', '/api/integration/templates/derive', 'templatesDerive'],
   ['GET', '/api/integration/staging/descriptors', 'stagingDescriptors'],
@@ -61,6 +63,10 @@ const {
   createStockPreparationTableActionRegistry,
   dryRunStockPreparationAction,
 } = require('./stock-preparation-table-actions.cjs')
+const {
+  inspectStockPreparationCanonicalTarget,
+  ensureStockPreparationCanonicalTarget,
+} = require('./stock-preparation-target-provisioning.cjs')
 
 class HttpRouteError extends Error {
   constructor(status, code, message, details = {}) {
@@ -306,6 +312,7 @@ function publicRunInput(body = {}) {
 }
 
 const VALID_TABLE_ACTION_BODY_KEYS = new Set(['parameters', 'confirm'])
+const VALID_STOCK_PREPARATION_TARGET_REQUEST_KEYS = new Set(['tenantId', 'workspaceId', 'projectId', 'baseId'])
 
 function normalizeTableActionBody(body = {}) {
   if (!isPlainObject(body)) {
@@ -317,6 +324,44 @@ function normalizeTableActionBody(body = {}) {
     }
   }
   return body
+}
+
+function normalizeStockPreparationTargetRequest(input = {}) {
+  if (!isPlainObject(input)) {
+    throw new HttpRouteError(400, 'STOCK_PREPARATION_TARGET_REQUEST_INVALID', 'request must be an object')
+  }
+  for (const key of Object.keys(input)) {
+    if (!VALID_STOCK_PREPARATION_TARGET_REQUEST_KEYS.has(key)) {
+      throw new HttpRouteError(400, 'STOCK_PREPARATION_TARGET_REQUEST_INVALID', `unsupported request field: ${key}`, { field: key })
+    }
+  }
+  return {
+    tenantId: firstString(input.tenantId),
+    workspaceId: firstString(input.workspaceId),
+    projectId: firstString(input.projectId),
+    baseId: firstString(input.baseId),
+  }
+}
+
+function stockPreparationTargetInput(req, rawInput = {}) {
+  const input = normalizeStockPreparationTargetRequest(rawInput)
+  const tenantId = resolveTenantId(req, input)
+  const projectId = resolveIntegrationStagingProjectId(tenantId, input.projectId)
+  return {
+    tenantId,
+    workspaceId: input.workspaceId,
+    projectId,
+    baseId: input.baseId,
+  }
+}
+
+function publicStockPreparationTargetResult(result) {
+  return {
+    ready: result.ready === true,
+    mode: result.mode,
+    targetBinding: result.target ? cloneJson(result.target) : null,
+    evidence: result.evidence,
+  }
 }
 
 function redactDeadLetter(deadLetter, fullPayload = false) {
@@ -1272,6 +1317,29 @@ function createHandlers(services, options = {}) {
         recordsApi: getMultitableRecordsApi(),
         tokenStore: context.storage,
       }))
+    },
+
+    async stockPreparationTargetReadiness(req, res) {
+      requireAccess(req, 'admin')
+      const input = stockPreparationTargetInput(req, requestQuery(req))
+      const result = await inspectStockPreparationCanonicalTarget({
+        context,
+        projectId: input.projectId,
+        permission: 'admin',
+      })
+      return sendOk(res, publicStockPreparationTargetResult(result))
+    },
+
+    async stockPreparationTargetEnsure(req, res) {
+      requireAccess(req, 'admin')
+      const input = stockPreparationTargetInput(req, requestBody(req))
+      const result = await ensureStockPreparationCanonicalTarget({
+        context,
+        projectId: input.projectId,
+        baseId: input.baseId,
+        permission: 'admin',
+      })
+      return sendOk(res, publicStockPreparationTargetResult(result), result.mode === 'canonical_create' ? 201 : 200)
     },
 
     async templatesPreview(req, res) {


### PR DESCRIPTION
## Summary

Adds #2253 C1b-2: an admin-only backend workflow to inspect or create/bind the canonical PLM stock-preparation target.

Routes:

- `GET /api/integration/stock-preparation/target/readiness`
- `POST /api/integration/stock-preparation/target/ensure`

What it does:

- derives permission from `requireAccess(req, 'admin')`; never from client input
- rejects client-supplied `sheetId`, `permission`, `target`, `fieldIdMap`, source bindings, plans, or payloads before provisioning
- calls the C1b-1 helper to inspect/bind/create table + field metadata only
- returns private `targetBinding` for admin config and separate values-free `evidence` for issue/customer evidence
- adds an operator runbook for entity-machine target readiness

## Boundaries

- no frontend UI
- no PLM read
- no MetaSheet business-row write; route never uses records API
- no C2/C3/C4 execution
- no K3 Save / Submit / Audit / BOM
- no external database write
- no C6 custom option sync
- no PLM source gate change

## Verification

```bash
pnpm --filter plugin-integration-core test:http-routes
pnpm --filter plugin-integration-core test:stock-preparation-target-provisioning
pnpm --filter plugin-integration-core test:stock-preparation-table-actions
git diff --check
pnpm --filter plugin-integration-core test
```

All passed locally. Full plugin test required `pnpm install --frozen-lockfile` in the temp worktree to provide `tsx`; lockfile stayed unchanged and node_modules noise was restored before commit.

## Next gated slices

- C1b-3: entity-machine target readiness smoke using the new runbook
- PLM source gate: real `data-source:sql-readonly` PLM binding satisfying C2 flat reads
- C5 full smoke only after target readiness + source gate pass
- C6 custom option sync remains separate
