### PR TITLE
feat(multitable): v2-d-b1 backend — grouped bar mode (barMode + conditional-additive)

### DIFF
--- a/packages/core-backend/src/multitable/chart-aggregation-service.ts
+++ b/packages/core-backend/src/multitable/chart-aggregation-service.ts
@@ -146,20 +146,22 @@ export class ChartAggregationService {
 
     const total = dataPoints.reduce((sum, dp) => sum + dp.value, 0)
 
-    // v2-d: stacked-bar series split. Built AFTER sort+limit, so it only covers the surviving
-    // categories in their final order (building before limit would leak limited-out categories).
-    // Additive-only (sum/count) + bar + groupBy-primary (no date axis) — the producer is the uniform
-    // safety net mirroring `assertSeriesConstraints`; any other combination omits `series`, so a
-    // misleading stack can never be produced even from a hand-crafted/persisted bad config.
+    // v2-d: bar series split. Built AFTER sort+limit, so it only covers the surviving categories in
+    // their final order (building before limit would leak limited-out categories). Emitted for
+    // bar + seriesByFieldId + groupBy-primary (no date axis) when EITHER barMode 'grouped' (v2-d-b1:
+    // side-by-side, any aggregation) OR an additive aggregation (stacked). The producer branches on
+    // `barMode` — not validation alone — so a persisted stacked+non-additive config still can't RENDER
+    // a misleading stack; it just omits series. Grouped vs stacked differ only at render.
     const seriesByFieldId = chart.dataSource.seriesByFieldId
     const dateGrouped = !!(chart.dataSource.dateFieldId && chart.dataSource.dateGrouping)
+    const grouped = chart.display.barMode === 'grouped'
     let series: ChartSeries[] | undefined
     if (
       chart.type === 'bar' &&
       seriesByFieldId &&
       chart.dataSource.groupByFieldId &&
       !dateGrouped &&
-      ADDITIVE_AGGREGATIONS.has(aggFn)
+      (grouped || ADDITIVE_AGGREGATIONS.has(aggFn))
     ) {
       const seriesNames: string[] = []
       const byName = new Map<string, number[]>() // series name -> data[] aligned to dataPoints

--- a/packages/core-backend/src/multitable/charts.ts
+++ b/packages/core-backend/src/multitable/charts.ts
@@ -50,6 +50,12 @@ export interface ChartDisplayConfig {
   /** For number chart */
   prefix?: string
   suffix?: string
+  /**
+   * v2-d-b1: bar series layout when `seriesByFieldId` is set. 'stacked' (default) sums segments
+   * into one bar; 'grouped' renders them side-by-side (and, being independent, allows non-additive
+   * aggregations). Inert unless `seriesByFieldId` is set on a bar chart.
+   */
+  barMode?: 'stacked' | 'grouped'
 }
 
 export interface ChartConfig {
@@ -93,7 +99,11 @@ export const ADDITIVE_AGGREGATIONS: ReadonlySet<AggregationFunction> = new Set<A
  * silently omits `series` for anything else, so a hand-crafted/persisted bad config still can't
  * render a misleading stack.
  */
-export function assertSeriesConstraints(dataSource: ChartDataSource | undefined, type: ChartType): void {
+export function assertSeriesConstraints(
+  dataSource: ChartDataSource | undefined,
+  type: ChartType,
+  barMode?: ChartDisplayConfig['barMode'],
+): void {
   const seriesByFieldId = dataSource?.seriesByFieldId
   if (!seriesByFieldId) return
   if (type !== 'bar') {
@@ -103,12 +113,15 @@ export function assertSeriesConstraints(dataSource: ChartDataSource | undefined,
     throw new Error('seriesByFieldId requires groupByFieldId (a primary category axis)')
   }
   if (dataSource.dateFieldId && dataSource.dateGrouping) {
-    // The producer gives date grouping precedence over groupByFieldId, so a stacked split is not
-    // applied here — reject rather than silently produce a non-stacked chart (v2-d-a is groupBy-primary;
-    // date-axis × series is deferred to v2-d-b).
+    // The producer gives date grouping precedence over groupByFieldId, so a series split is not
+    // applied here — reject rather than silently produce a non-split chart (groupBy-primary only;
+    // date-axis × series is deferred to v2-d-b3).
     throw new Error('seriesByFieldId (stacked series) is not supported with date grouping')
   }
-  if (!ADDITIVE_AGGREGATIONS.has(dataSource.aggregation?.function)) {
-    throw new Error('seriesByFieldId (stacked series) requires a sum or count aggregation')
+  // v2-d-b1: additive aggregation is required ONLY when the segments are STACKED (their sum is the
+  // bar height, which must be meaningful). Grouped (side-by-side) bars are independent → any
+  // aggregation is honest.
+  if (barMode !== 'grouped' && !ADDITIVE_AGGREGATIONS.has(dataSource.aggregation?.function)) {
+    throw new Error('stacked series require a sum or count aggregation (use barMode "grouped" for others)')
   }
 }

--- a/packages/core-backend/src/routes/dashboard.ts
+++ b/packages/core-backend/src/routes/dashboard.ts
@@ -175,6 +175,12 @@ function restrictedChartData(chart: ChartConfig): ChartData {
   }
 }
 
+// v2-d-b1: sanitize barMode off a loosely-typed display object (unknown values → undefined = stacked).
+function readBarMode(display: unknown): 'stacked' | 'grouped' | undefined {
+  const mode = (display as { barMode?: unknown } | null | undefined)?.barMode
+  return mode === 'grouped' || mode === 'stacked' ? mode : undefined
+}
+
 function readString(value: unknown): string | undefined {
   return typeof value === 'string' && value.trim().length > 0 ? value.trim() : undefined
 }
@@ -214,7 +220,7 @@ function buildPreviewChart(sheetId: string, userId: string, body: unknown): Char
   if (AGGREGATIONS_REQUIRING_FIELD.has(aggregationFunction as AggregationFunction) && !readString(aggregation.fieldId)) {
     throw new Error('value field is required for this aggregation')
   }
-  assertSeriesConstraints(source as ChartConfig['dataSource'], chartType as ChartType)
+  assertSeriesConstraints(source as ChartConfig['dataSource'], chartType as ChartType, readBarMode(input.display ?? input.displayConfig))
   const now = new Date().toISOString()
   return {
     id: `chart_preview_${randomUUID()}`,
@@ -254,7 +260,7 @@ export function dashboardRouter() {
       const auth = await requireSheetManageViews(req, res, req.params.sheetId)
       if (!auth) return
       // v2-d: validate series constraints on the persisted path too — the UI is never the sole guard.
-      assertSeriesConstraints(req.body?.dataSource as ChartConfig['dataSource'] | undefined, req.body?.type as ChartType)
+      assertSeriesConstraints(req.body?.dataSource as ChartConfig['dataSource'] | undefined, req.body?.type as ChartType, readBarMode(req.body?.display))
       const chart = await dashboardService.createChart(req.params.sheetId, {
         ...req.body,
         createdBy: auth.userId,
@@ -319,6 +325,7 @@ export function dashboardRouter() {
       assertSeriesConstraints(
         (req.body?.dataSource ?? chart.dataSource) as ChartConfig['dataSource'],
         (req.body?.type ?? chart.type) as ChartType,
+        readBarMode(req.body?.display ?? chart.display),
       )
       const updated = await dashboardService.updateChart(req.params.id, req.body)
       res.json(updated)

--- a/packages/core-backend/tests/integration/multitable-dashboard-preview-data.test.ts
+++ b/packages/core-backend/tests/integration/multitable-dashboard-preview-data.test.ts
@@ -245,4 +245,16 @@ describeIfDatabase('Dashboard BI v2-b2 preview-data endpoint (real DB)', () => {
     expect(line.status).toBe(400)
     expect(JSON.stringify(line.body)).toContain('bar charts')
   })
+
+  test('P7 (v2-d-b1): grouped barMode accepts a non-additive aggregation and emits series', async () => {
+    const res = await preview({
+      name: 'grouped avg',
+      type: 'bar',
+      dataSource: { groupByFieldId: FLD_STATUS, seriesByFieldId: FLD_SECRET, aggregation: { function: 'avg', fieldId: FLD_AMOUNT } },
+      display: { barMode: 'grouped' },
+    })
+    expect(res.status).toBe(200) // same config 400s when stacked (P6) — grouped relaxes additive-only
+    expect(Array.isArray(res.body.series)).toBe(true)
+    expect(res.body.series.length).toBeGreaterThan(0)
+  })
 })

--- a/packages/core-backend/tests/unit/chart-dashboard.test.ts
+++ b/packages/core-backend/tests/unit/chart-dashboard.test.ts
@@ -912,6 +912,25 @@ describe('ChartAggregationService — v2-d stacked series', () => {
     const result = await service.computeChartData(makeChart(), sampleRecords)
     expect('series' in result).toBe(false)
   })
+
+  // v2-d-b1: grouped barMode emits series for NON-additive aggregations (independent side-by-side bars).
+  it('grouped barMode: emits series for a non-additive aggregation (avg)', async () => {
+    const result = await service.computeChartData(
+      makeChart({
+        type: 'bar',
+        display: { barMode: 'grouped' },
+        dataSource: { groupByFieldId: 'status', seriesByFieldId: 'category', aggregation: { function: 'avg', fieldId: 'amount' } },
+      }),
+      sampleRecords,
+    )
+    expect(result.series).toBeDefined()
+    expect(result.series!.map((s) => s.name)).toEqual(['A', 'B'])
+    // avg per (status × category): open/A = avg(10,50) = 30 ; series A aligned to [open, closed]
+    expect(result.series!.find((s) => s.name === 'A')!.data).toEqual([30, 30])
+    expect(result.series!.find((s) => s.name === 'B')!.data).toEqual([20, 40])
+    // grouped is NOT additive — Σ series ≠ dataPoints (the single-dimension avg)
+    expect(result.dataPoints.find((d) => d.label === 'open')?.value).toBeCloseTo(80 / 3)
+  })
 })
 
 describe('assertSeriesConstraints (v2-d input validation)', () => {
@@ -949,5 +968,21 @@ describe('assertSeriesConstraints (v2-d input validation)', () => {
 
   it('throws when combined with date grouping (matches the producer giving the date axis precedence)', () => {
     expect(() => assertSeriesConstraints(ds({ dateFieldId: 'd', dateGrouping: 'month' }), 'bar')).toThrow(/date grouping/)
+  })
+
+  // v2-d-b1: barMode 'grouped' relaxes the additive requirement (side-by-side bars are independent).
+  it('grouped barMode allows any aggregation', () => {
+    for (const fn of ['avg', 'min', 'max', 'count_distinct'] as const) {
+      expect(() => assertSeriesConstraints(ds({ aggregation: { function: fn, fieldId: 'amt' } }), 'bar', 'grouped')).not.toThrow()
+    }
+  })
+
+  it("stacked barMode (or unset) still requires additive", () => {
+    expect(() => assertSeriesConstraints(ds({ aggregation: { function: 'avg', fieldId: 'amt' } }), 'bar', 'stacked')).toThrow(/sum or count/)
+    expect(() => assertSeriesConstraints(ds({ aggregation: { function: 'avg', fieldId: 'amt' } }), 'bar')).toThrow(/sum or count/)
+  })
+
+  it('barMode is inert without seriesByFieldId (no error)', () => {
+    expect(() => assertSeriesConstraints({ groupByFieldId: 'g', aggregation: { function: 'avg' } }, 'bar', 'grouped')).not.toThrow()
   })
 })


### PR DESCRIPTION
First sub-slice of **v2-d-b** (design-lock #2310), **backend-first**, **b1 only** per owner direction. Frontend (barMode control + grouped render) follows as a separate opt-in; b2/b3 untouched.

## Changes
- **`ChartDisplayConfig += barMode?: 'stacked' | 'grouped'`** — default `'stacked'` = v2-d-a behavior (backward-compatible, no migration).
- **`assertSeriesConstraints` gains `barMode`** — additive (sum/count) required **only when stacked** (`barMode !== 'grouped'`); grouped accepts any aggregation. Threaded through all three input boundaries (preview `buildPreviewChart` + persisted create + persisted update on the *effective* display, via a `readBarMode` sanitizer).
- **Producer (`computeChartData`) branches on `chart.display.barMode`** — emits series for grouped+non-additive too. This preserves the v2-d-a safety-net invariant: a persisted `stacked + non-additive` config still omits series, so it can never *render* a misleading stack. The series math is unchanged (grouped vs stacked differ only at render — that's the frontend slice).

## Tests
- **unit +4**: producer grouped+avg → emits series (`Σ series ≠ dataPoints`, the non-additive case); validator grouped-allows-any-aggregation / stacked-still-requires-additive / barMode-inert-without-series.
- **real-DB P7**: grouped+avg → `200` + series — the same config that `400`s when stacked (P6).
- Full backend unit **2773/2773**, dashboard real-DB **18/18**, `tsc` + eslint clean. No new security surface (`chartReferencedFieldIds` unchanged; barMode display-only) — existing R9 denied-series→restricted still passes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)