### PR TITLE
fix(data-factory): close stock source-gate smoke gaps

### DIFF
--- a/docs/development/data-factory-plm-project-bom-c5-3c-source-gate-smoke-fixes-verification-20260605.md
+++ b/docs/development/data-factory-plm-project-bom-c5-3c-source-gate-smoke-fixes-verification-20260605.md
@@ -1,0 +1,130 @@
+# Data Factory PLM stock-preparation C5-3c source-gate smoke fixes verification (2026-06-05)
+
+## Scope
+
+C5-3c addresses the #2253 entity-machine Bridge-source smoke finding after the
+`multitable-onprem-plm-stock-bridge-source-20260605-2d9281cdf` package:
+
+- deploy and explicit `bridge:legacy-sql-readonly` action config passed;
+- public table-action metadata stayed values-free;
+- the first dry-run with C1b canonical target binding failed with
+  `Unknown fieldId: projectNo`;
+- a manually reconstructed complete `fieldIdMap` reached C2 expansion, but the
+  first Bridge read failed with `read_failed` and insufficient values-free read
+  diagnostics.
+
+This slice fixes those two smoke blockers without opening writes.
+
+## Runtime changes
+
+- C1b canonical target readiness/ensure now returns a private
+  logical-to-physical `targetBinding.fieldIdMap` from
+  `multitable.provisioning.resolveFieldIds`.
+- The values-free readiness evidence reports only whether that map is empty; it
+  still does not expose sheet ids or physical field ids.
+- C5 existing-row reads now work with the canonical C1b binding because
+  `projectNo` filters are mapped to the physical target field id.
+- Bridge adapter read metadata now reports values-free filter diagnostics:
+  `filtersApplied` and `filterFields`.
+- C2 BOM expansion evidence now reports values-free `readDiagnostics` with
+  object name, filter field names, cursor presence, status, filters sent, adapter
+  source when available, row count, and error code.
+
+## Boundary
+
+This slice does not add:
+
+- MetaSheet apply/write;
+- PLM/external database write;
+- K3 Save / Submit / Audit / BOM;
+- raw SQL, joins, CTEs, stored procedures, or vendor API calls;
+- client-supplied target bindings;
+- source fallback between `data-source:sql-readonly` and
+  `bridge:legacy-sql-readonly`.
+
+## Verification
+
+Commands run:
+
+```bash
+pnpm --filter plugin-integration-core test:stock-preparation-target-provisioning
+pnpm --filter plugin-integration-core test:stock-preparation-table-actions
+pnpm --filter plugin-integration-core test:stock-preparation-bom-expansion
+node plugins/plugin-integration-core/__tests__/bridge-agent-readonly-adapter.test.cjs
+pnpm --filter plugin-integration-core test:http-routes
+pnpm --filter plugin-integration-core test
+git diff --check
+```
+
+Results:
+
+- `stock-preparation-target-provisioning.test.cjs`: passed.
+- `stock-preparation-table-actions.test.cjs`: passed.
+- `stock-preparation-bom-expansion.test.cjs`: passed.
+- `bridge-agent-readonly-adapter.test.cjs`: passed.
+- `http-routes.test.cjs`: passed.
+- `plugin-integration-core test`: passed after installing workspace
+  dependencies in the isolated worktree with `pnpm install --frozen-lockfile
+  --offline`; node_modules shim churn was removed from the diff.
+- `git diff --check`: passed.
+
+## Test locks
+
+`plugins/plugin-integration-core/__tests__/stock-preparation-target-provisioning.test.cjs`
+locks the C1b target binding:
+
+- existing canonical target binding returns the resolved logical-to-physical
+  field map;
+- create path returns the post-create resolved logical-to-physical field map;
+- readiness evidence marks the map non-empty without exposing the private sheet
+  id.
+
+`plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs`
+locks the C5 runtime use of that binding:
+
+- dry-run with a complete physical `fieldIdMap` reads existing target rows using
+  the physical project field;
+- dry-run evidence remains values-free.
+
+`plugins/plugin-integration-core/__tests__/stock-preparation-bom-expansion.test.cjs`
+locks the source-gate diagnostics:
+
+- successful reads expose `readDiagnostics[].filtersApplied=true` and filter
+  field names without exposing project values or row values;
+- read failures expose `readDiagnostics[].status=failed` and the adapter error
+  code without copying the error message or business values.
+
+`plugins/plugin-integration-core/__tests__/bridge-agent-readonly-adapter.test.cjs`
+locks the Bridge metadata:
+
+- filtered reads POST primitive equality filters to the Bridge Agent;
+- read metadata reports `filtersApplied=true` and sorted `filterFields`.
+
+`plugins/plugin-integration-core/__tests__/http-routes.test.cjs` locks the
+route-wire target binding:
+
+- target readiness/ensure routes return the resolved private field map in
+  `targetBinding`;
+- values-free readiness evidence marks the map non-empty without exposing the
+  private sheet id.
+
+## Entity-machine retest
+
+After this slice is packaged, rerun the #2253 source-gate smoke:
+
+1. Deploy the refreshed package.
+2. Configure the server-owned action source as `bridge:legacy-sql-readonly`.
+3. Use the C1b target readiness `targetBinding` directly; do not manually
+   reconstruct a field map from labels.
+4. Run dry-run for one `projectNo`.
+5. Capture values-free evidence only:
+   - source kind;
+   - projectNo present/not value;
+   - dry-run status and counts;
+   - expansion status/error types;
+   - `readDiagnostics` object names, filter field names, filters sent/applied,
+     status, and error code.
+
+Do not paste targetBinding, sheet ids, source ids, physical field ids, PLM row
+values, target row values, project values, raw SQL, connection strings, database
+credentials, or Bridge shared secrets.

--- a/plugins/plugin-integration-core/__tests__/bridge-agent-readonly-adapter.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/bridge-agent-readonly-adapter.test.cjs
@@ -169,13 +169,15 @@ async function main() {
   const cappedCall = calls.filter((call) => call.pathname === '/query/material').at(-1)
   assert.deepEqual(cappedCall.body, { limit: 20 }, 'adapter caps reads to Bridge Agent maxLimit before sending')
 
-  await adapter.read({ object: 'material', limit: 5, filters: { FNumber: 'MAT-001', active: true, optional: null } })
+  const filtered = await adapter.read({ object: 'material', limit: 5, filters: { FNumber: 'MAT-001', active: true, optional: null } })
   const filteredCall = calls.filter((call) => call.pathname === '/query/material').at(-1)
   assert.deepEqual(
     filteredCall.body,
     { limit: 5, filters: { FNumber: 'MAT-001', active: true, optional: null } },
     'adapter forwards primitive equality filters to the Bridge Agent',
   )
+  assert.equal(filtered.metadata.filtersApplied, true)
+  assert.deepEqual(filtered.metadata.filterFields, ['FNumber', 'active', 'optional'])
 
   await assert.rejects(
     () => adapter.read({ object: 'material', filters: { FNumber: { $like: 'MAT%' } } }),

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -8,6 +8,9 @@ const httpRoutes = require(HTTP_ROUTES_PATH)
 const { MAX_LIST_LIMIT } = httpRoutes
 const { PLM_STOCK_PREPARATION_ACTION_ID } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-table-actions.cjs'))
 const { STOCK_PREPARATION_MAIN_TABLE_TEMPLATE } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-templates.cjs'))
+const STOCK_PREPARATION_RESOLVED_FIELD_ID_MAP = Object.fromEntries(
+  STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.fields.map((field) => [field.id, `fld_${field.id}`]),
+)
 
 const READ_USER = {
   id: 'user_read',
@@ -2526,8 +2529,9 @@ async function testStockPreparationTargetProvisioningRoutes() {
     sheetId: 'sheet_stock_canonical_created',
     objectId: STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.objectId,
     keyField: 'idempotencyKey',
-    fieldIdMap: {},
+    fieldIdMap: STOCK_PREPARATION_RESOLVED_FIELD_ID_MAP,
   })
+  assert.equal(res.body.data.evidence.target.fieldIdMapEmpty, false)
   assert.equal(JSON.stringify(res.body.data.evidence).includes('sheet_stock_canonical_created'), false, 'ensure evidence hides sheet id')
   const ensureCall = findCalls(provisioning.calls, 'ensureObject')[0]
   assert.equal(ensureCall[1].projectId, 'tenant_1:integration-core')
@@ -2550,7 +2554,8 @@ async function testStockPreparationTargetProvisioningRoutes() {
   })
   assertOkResponse(res, 200)
   assert.equal(res.body.data.mode, 'canonical_existing')
-  assert.deepEqual(res.body.data.targetBinding.fieldIdMap, {})
+  assert.deepEqual(res.body.data.targetBinding.fieldIdMap, STOCK_PREPARATION_RESOLVED_FIELD_ID_MAP)
+  assert.equal(res.body.data.evidence.target.fieldIdMapEmpty, false)
   assert.equal(findCalls(existing.calls, 'ensureObject').length, 0, 'existing complete target is bound, not recreated')
   assert.equal(findCalls(existing.calls, 'findObjectSheet')[0][1].projectId, 'tenant_1:integration-core', 'default projectId is integration-core scoped')
 

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-bom-expansion.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-bom-expansion.test.cjs
@@ -38,6 +38,11 @@ function createAdapter(data) {
         records,
         nextCursor: records.length >= limit && offset + records.length < matches.length ? String(offset + records.length) : null,
         done: offset + records.length >= matches.length,
+        metadata: {
+          source: 'bridge:legacy-sql-readonly',
+          filtersApplied: true,
+          filterFields: Object.keys(input.filters || {}).sort(),
+        },
       }
     },
   }
@@ -89,9 +94,41 @@ async function testSuccessfulExpansion() {
   const evidenceJson = JSON.stringify(evidence)
   assert.equal(evidence.valid, true)
   assert.equal(evidence.rowsExpanded, 2)
+  assert.ok(evidence.readDiagnostics.some((entry) =>
+    entry.object === 'DN_PDM_PathExAttrInfo' &&
+    entry.status === 'ok' &&
+    entry.filtersApplied === true &&
+    entry.filterFields.includes('FileCode'),
+  ), 'values-free evidence exposes Bridge filtered-read diagnostics')
   assert.ok(!evidenceJson.includes('P-001'), 'evidence hides project value')
   assert.ok(!evidenceJson.includes('PART-A'), 'evidence hides component source ids')
   assert.ok(!evidenceJson.includes('Assembly'), 'evidence hides component names')
+}
+
+async function testReadFailureDiagnosticsAreValuesFree() {
+  const adapter = {
+    async read() {
+      const error = new Error('driver failure for P-001 and PART-A')
+      error.code = 'BRIDGE_DB_QUERY_FAILED'
+      throw error
+    },
+  }
+  const result = await expandPlmProjectBom({ sourceAdapter: adapter, projectNo: 'P-001' })
+  const evidence = summarizeBomExpansionForEvidence(result)
+  const text = JSON.stringify(evidence)
+
+  assert.equal(evidence.valid, false)
+  assert.deepEqual(evidence.errorTypes, ['read_failed'])
+  assert.deepEqual(evidence.readDiagnostics, [{
+    object: 'DN_PDM_PathExAttrInfo',
+    filterFields: ['FileCode'],
+    cursor: null,
+    status: 'failed',
+    filtersSent: true,
+    errorCode: 'BRIDGE_DB_QUERY_FAILED',
+  }])
+  assert.equal(text.includes('P-001'), false, 'read failure evidence hides project value')
+  assert.equal(text.includes('PART-A'), false, 'read failure evidence hides error-message row values')
 }
 
 async function testNoHit() {
@@ -222,6 +259,7 @@ function testReadPlanValidation() {
 
 async function main() {
   await testSuccessfulExpansion()
+  await testReadFailureDiagnosticsAreValuesFree()
   await testNoHit()
   await testSameComponentUnderDifferentParentsStaysDistinct()
   await testFailClosedGuards()

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
@@ -15,6 +15,13 @@ const {
   dryRunStockPreparationAction,
   normalizeStockPreparationActionConfig,
 } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-table-actions.cjs'))
+const {
+  STOCK_PREPARATION_MAIN_TABLE_TEMPLATE,
+} = require(path.join(__dirname, '..', 'lib', 'stock-preparation-templates.cjs'))
+
+const PHYSICAL_FIELD_ID_MAP = Object.fromEntries(
+  STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.fields.map((field) => [field.id, `fld_${field.id}`]),
+)
 
 function clone(value) {
   return JSON.parse(JSON.stringify(value))
@@ -185,6 +192,35 @@ async function testDryRunRequiresAllowlistedParametersAndStoresToken() {
   assert.deepEqual(records.calls[0][1].filters, { projectNo: 'P-001' }, 'existing-row read filters to one project')
   assert.equal(JSON.stringify(dryRun.evidence).includes('P-001'), false, 'evidence hides project value')
   assert.equal(JSON.stringify(dryRun.evidence).includes('Assembly'), false, 'evidence hides component name')
+}
+
+async function testDryRunUsesPhysicalTargetFieldMapForExistingRowFilter() {
+  const source = createSourceAdapter()
+  const records = createRecordsApi()
+  const storage = createMemoryStorage()
+
+  const dryRun = await dryRunStockPreparationAction({
+    action: baseAction({
+      target: {
+        sheetId: 'sheet_stock',
+        objectId: 'stockPreparationMain',
+        fieldIdMap: PHYSICAL_FIELD_ID_MAP,
+      },
+    }),
+    parameters: { projectNo: 'P-001' },
+    sourceAdapter: source.adapter,
+    recordsApi: records.recordsApi,
+    tokenStore: storage,
+    plannedAt: '2026-06-04T09:00:00.000Z',
+  })
+
+  assert.equal(dryRun.status, 'ready')
+  assert.deepEqual(
+    records.calls[0][1].filters,
+    { fld_projectNo: 'P-001' },
+    'canonical target bindings with physical ids filter existing rows by the physical project field',
+  )
+  assert.equal(JSON.stringify(dryRun.evidence).includes('P-001'), false, 'field-map dry-run evidence hides project value')
 }
 
 async function testBridgeSourceKindRequiresExplicitMatchingReadPlanAndCanDryRun() {
@@ -410,6 +446,7 @@ async function testApplyDetectsDataShiftAndManualConfirmHold() {
 async function main() {
   await testRegistryListsConfiguredMetadataWithoutTargetSecrets()
   await testDryRunRequiresAllowlistedParametersAndStoresToken()
+  await testDryRunUsesPhysicalTargetFieldMapForExistingRowFilter()
   await testBridgeSourceKindRequiresExplicitMatchingReadPlanAndCanDryRun()
   await testTargetFieldMapIncompleteFailsBeforeReads()
   await testApplyRequiresTokenRecomputesAndScopesTarget()

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-target-provisioning.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-target-provisioning.test.cjs
@@ -19,6 +19,7 @@ const {
 } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-target-provisioning.cjs'))
 
 const LOGICAL_FIELD_IDS = STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.fields.map((field) => field.id)
+const RESOLVED_FIELD_ID_MAP = Object.fromEntries(LOGICAL_FIELD_IDS.map((fieldId) => [fieldId, `fld_${fieldId}`]))
 
 function createContext({
   sheetExists = false,
@@ -184,7 +185,9 @@ async function main() {
   )
   assert.equal(permissionCalls.findObjectSheet.length, 0, 'permission failure happens before provisioning reads')
 
-  // Existing canonical target can be bound with empty fieldIdMap.
+  // Existing canonical target binds resolved logical -> physical fields. The
+  // entity-machine C5 smoke proved that an empty fieldIdMap is not enough when
+  // the records API physical field ids differ from the C1 logical ids.
   const { context: bindCtx, calls: bindCalls } = createContext({ sheetExists: true })
   const bound = await ensureStockPreparationCanonicalTarget({
     context: bindCtx,
@@ -197,10 +200,11 @@ async function main() {
     sheetId: 'sheet_private_stock_target',
     objectId: STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.objectId,
     keyField: 'idempotencyKey',
-    fieldIdMap: {},
+    fieldIdMap: RESOLVED_FIELD_ID_MAP,
   })
   assert.equal(bound.evidence.mode, 'canonical_existing')
   assert.deepEqual(bound.evidence.missingFields, [])
+  assert.equal(bound.evidence.target.fieldIdMapEmpty, false)
   assert.equal(bindCalls.findObjectSheet.length, 1)
   assert.equal(bindCalls.resolveFieldIds.length, 1)
   assert.equal(bindCalls.ensureObject.length, 0, 'existing target bind does not create/repair')
@@ -249,8 +253,9 @@ async function main() {
     sheetId: 'sheet_created_stock_target',
     objectId: STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.objectId,
     keyField: 'idempotencyKey',
-    fieldIdMap: {},
+    fieldIdMap: RESOLVED_FIELD_ID_MAP,
   })
+  assert.equal(created.evidence.target.fieldIdMapEmpty, false)
   assert.equal(createCalls.findObjectSheet.length, 1)
   assert.equal(createCalls.ensureObject.length, 1)
   assert.equal(createCalls.ensureObject[0].descriptor.id, STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.objectId)

--- a/plugins/plugin-integration-core/lib/adapters/bridge-agent-readonly-adapter.cjs
+++ b/plugins/plugin-integration-core/lib/adapters/bridge-agent-readonly-adapter.cjs
@@ -421,6 +421,8 @@ function createBridgeAgentReadonlyAdapter({ system, fetchImpl = globalThis.fetch
         limit,
         count: records.length,
         source: 'bridge:legacy-sql-readonly',
+        filtersApplied: Boolean(filters),
+        filterFields: filters ? Object.keys(filters).sort() : [],
       },
     })
   }

--- a/plugins/plugin-integration-core/lib/stock-preparation-bom-expansion.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-bom-expansion.cjs
@@ -264,9 +264,30 @@ async function readAll(adapter, object, filters, options, readStats) {
     }
     const input = { object, filters: normalizedFilters, limit: options.pageLimit }
     if (cursor) input.cursor = cursor
-    readStats.push({ object, filterFields: Object.keys(normalizedFilters).sort(), cursor: cursor || null })
-    const result = await adapter.read(input)
+    const stat = {
+      object,
+      filterFields: Object.keys(normalizedFilters).sort(),
+      cursor: cursor || null,
+      status: 'attempted',
+      filtersSent: true,
+    }
+    readStats.push(stat)
+    let result
+    try {
+      result = await adapter.read(input)
+      stat.status = 'ok'
+    } catch (error) {
+      stat.status = 'failed'
+      stat.errorCode = safeErrorCode(error)
+      throw error
+    }
+    if (isPlainObject(result) && isPlainObject(result.metadata)) {
+      stat.source = typeof result.metadata.source === 'string' ? result.metadata.source : undefined
+      stat.filtersApplied = result.metadata.filtersApplied
+      if (Array.isArray(result.metadata.filterFields)) stat.filterFields = result.metadata.filterFields.slice().sort()
+    }
     const records = isPlainObject(result) && Array.isArray(result.records) ? result.records : []
+    stat.count = records.length
     for (const record of records) {
       if (isPlainObject(record)) rows.push(record)
     }
@@ -340,6 +361,28 @@ function makeActions(rowsExpanded) {
   }
 }
 
+function safeErrorCode(error) {
+  if (!error) return undefined
+  if (typeof error.code === 'string' && error.code.trim()) return error.code.trim()
+  if (typeof error.name === 'string' && error.name.trim()) return error.name.trim()
+  return undefined
+}
+
+function readDiagnostic(entry = {}) {
+  const diagnostic = {
+    object: entry.object,
+    filterFields: Array.isArray(entry.filterFields) ? entry.filterFields.slice().sort() : [],
+    cursor: entry.cursor || null,
+    status: entry.status || 'attempted',
+  }
+  if (entry.filtersSent !== undefined) diagnostic.filtersSent = entry.filtersSent === true
+  if (entry.source) diagnostic.source = entry.source
+  if (entry.filtersApplied !== undefined) diagnostic.filtersApplied = entry.filtersApplied === true
+  if (Number.isInteger(entry.count)) diagnostic.count = entry.count
+  if (entry.errorCode) diagnostic.errorCode = entry.errorCode
+  return diagnostic
+}
+
 function makeSummary({ projectNoPresent, matchField, status, rowsExpanded, rootMatches, maxDepth, maxRows, readStats, errors, rowErrors }) {
   const summary = {
     projectNoPresent,
@@ -351,6 +394,7 @@ function makeSummary({ projectNoPresent, matchField, status, rowsExpanded, rootM
     maxRows,
     readObjects: Array.from(new Set(readStats.map((entry) => entry.object))).sort(),
     readCount: readStats.length,
+    readDiagnostics: readStats.map(readDiagnostic),
     errorTypes: Array.from(new Set([...(errors || []), ...(rowErrors || [])].map((entry) => entry.type || entry.code).filter(Boolean))).sort(),
     actions: makeActions(status === 'expanded' ? rowsExpanded : 0),
   }
@@ -707,6 +751,7 @@ function summarizeBomExpansionForEvidence(result = {}) {
     maxRows: summary.maxRows,
     readObjects: Array.isArray(summary.readObjects) ? summary.readObjects.slice() : [],
     readCount: Number(summary.readCount || 0),
+    readDiagnostics: Array.isArray(summary.readDiagnostics) ? summary.readDiagnostics.map(readDiagnostic) : [],
     errorTypes: Array.isArray(summary.errorTypes) ? summary.errorTypes.slice() : [],
     actions: isPlainObject(summary.actions) ? { ...summary.actions } : undefined,
   }

--- a/plugins/plugin-integration-core/lib/stock-preparation-target-provisioning.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-target-provisioning.cjs
@@ -124,12 +124,12 @@ function buildStockPreparationTargetDescriptor(input = {}) {
   }
 }
 
-function buildCanonicalTargetBinding({ sheetId, objectId }) {
+function buildCanonicalTargetBinding({ sheetId, objectId, fieldIdMap = {} }) {
   return {
     sheetId,
     objectId,
     keyField: CANONICAL_KEY_FIELD,
-    fieldIdMap: {},
+    fieldIdMap,
   }
 }
 
@@ -158,7 +158,7 @@ function summarizeStockPreparationTargetReadiness(input = {}) {
     target: {
       objectId: template.objectId,
       keyField: CANONICAL_KEY_FIELD,
-      fieldIdMapEmpty: true,
+      fieldIdMapEmpty: input.fieldIdMapEmpty !== false,
     },
   }
 }
@@ -209,12 +209,13 @@ async function inspectStockPreparationCanonicalTarget(input = {}) {
   return {
     ready: true,
     mode: 'canonical_existing',
-    target: buildCanonicalTargetBinding({ sheetId: sheet.id, objectId: template.objectId }),
+    target: buildCanonicalTargetBinding({ sheetId: sheet.id, objectId: template.objectId, fieldIdMap: resolved }),
     evidence: summarizeStockPreparationTargetReadiness({
       template,
       mode: 'canonical_existing',
       status: 'ready',
       missingFields: [],
+      fieldIdMapEmpty: false,
     }),
   }
 }
@@ -273,12 +274,13 @@ async function ensureStockPreparationCanonicalTarget(input = {}) {
   return {
     ready: true,
     mode: 'canonical_create',
-    target: buildCanonicalTargetBinding({ sheetId: ensured.sheet.id, objectId: template.objectId }),
+    target: buildCanonicalTargetBinding({ sheetId: ensured.sheet.id, objectId: template.objectId, fieldIdMap: resolvedAfterCreate }),
     evidence: summarizeStockPreparationTargetReadiness({
       template,
       mode: 'canonical_create',
       status: 'ready',
       missingFields: [],
+      fieldIdMapEmpty: false,
     }),
   }
 }


### PR DESCRIPTION
## Summary

Closes the two #2253 entity-machine source-gate smoke gaps found after deploying `multitable-onprem-plm-stock-bridge-source-20260605-2d9281cdf`:

- C1b canonical target binding now returns the resolved logical-to-physical `fieldIdMap` from `multitable.provisioning.resolveFieldIds`, so C5 existing-row filters no longer send logical `projectNo` to a target whose physical field ids differ.
- Bridge/C2 dry-run evidence now includes values-free read diagnostics (`filtersSent`, `filtersApplied` when available, filter field names, read status, adapter source, error code), so the next entity-machine run can distinguish request wiring from Bridge/schema/read failures.

## Boundaries

- No MetaSheet apply/write.
- No PLM/external database write.
- No K3 Save / Submit / Audit / BOM.
- No raw SQL, joins, CTEs, stored procedures, or vendor API.
- No source fallback between `data-source:sql-readonly` and `bridge:legacy-sql-readonly`.
- Target binding remains private; issue evidence should still copy values-free evidence only.

## Verification

```bash
pnpm --filter plugin-integration-core test:stock-preparation-target-provisioning
pnpm --filter plugin-integration-core test:stock-preparation-table-actions
pnpm --filter plugin-integration-core test:stock-preparation-bom-expansion
node plugins/plugin-integration-core/__tests__/bridge-agent-readonly-adapter.test.cjs
pnpm --filter plugin-integration-core test:http-routes
pnpm install --frozen-lockfile --offline
pnpm --filter plugin-integration-core test
git diff --check
```

All passed. `pnpm install --frozen-lockfile --offline` was needed only to create workspace dependency links in the isolated worktree; node_modules shim churn was removed from the diff.

## Entity-machine retest target

After merge + package, rerun #2253 source-gate smoke with the C1b target readiness `targetBinding` directly, no manually reconstructed label map. Evidence should remain values-free: source kind, projectNo presence, dry-run status/counts/error codes, and `readDiagnostics` object/filter fields/status/errorCode. Do not paste targetBinding, sheet ids, source ids, physical field ids, SQL text, credentials, Bridge shared secret, project values, PLM row values, or target row values.
