### PR TITLE
feat(multitable): v2-d-b1 frontend — grouped bar render + barMode control

### DIFF
--- a/apps/web/src/multitable/components/MetaChartRenderer.vue
+++ b/apps/web/src/multitable/components/MetaChartRenderer.vue
@@ -22,9 +22,9 @@
             <span class="meta-chart__legend-value">{{ pt.value }}</span>
           </div>
         </div>
-        <!-- v2-d: stacked-bar legend over series names (colors map to the palette by series index). -->
+        <!-- v2-d: multi-series bar legend over series names (grouped or stacked; colors map to the palette by series index). -->
         <div
-          v-if="hasStackedSeries && displayConfig?.showLegend !== false"
+          v-if="hasSeriesLegend && displayConfig?.showLegend !== false"
           class="meta-chart__legend meta-chart__legend--inline"
           data-legend="series"
         >
@@ -93,7 +93,7 @@ const isEChartsType = computed(() =>
   || props.chartData.chartType === 'pie',
 )
 const isRestricted = computed(() => props.chartData.metadata?.restricted === true)
-const hasStackedSeries = computed(() =>
+const hasSeriesLegend = computed(() =>
   props.chartData.chartType === 'bar' && (props.chartData.series?.length ?? 0) > 0,
 )
 

--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -209,7 +209,7 @@
             </select>
             <small v-if="!numericFields.length" class="meta-dashboard__hint">{{ viewRenderLabel('dashboard.noNumericFields', isZh) }}</small>
           </label>
-          <!-- v2-d: stack-by (series) — only for a bar chart with an additive aggregation; needs a primary groupBy. -->
+          <!-- v2-d: series split — for any bar chart (grouped or stacked); needs a primary groupBy. -->
           <label v-if="seriesByAllowed" class="meta-dashboard__field">
             <span>{{ viewRenderLabel('dashboard.seriesBy', isZh) }}</span>
             <select
@@ -223,7 +223,16 @@
                 {{ field.name }} · {{ fieldTypeLabel(field.type, isZh) }}
               </option>
             </select>
-            <small class="meta-dashboard__hint" data-hint="series-stacked">{{ viewRenderLabel('dashboard.seriesByHint', isZh) }}</small>
+            <small class="meta-dashboard__hint" data-hint="series-split">{{ viewRenderLabel('dashboard.seriesByHint', isZh) }}</small>
+          </label>
+          <!-- v2-d-b1: series layout (stacked vs grouped). Stacked offered only for an additive aggregation. -->
+          <label v-if="barModeShown" class="meta-dashboard__field">
+            <span>{{ viewRenderLabel('dashboard.barMode', isZh) }}</span>
+            <select v-model="chartDraft.barMode" class="meta-dashboard__select" data-field="chart-bar-mode">
+              <option v-if="stackedAllowed" value="stacked">{{ viewRenderLabel('dashboard.barModeStacked', isZh) }}</option>
+              <option value="grouped">{{ viewRenderLabel('dashboard.barModeGrouped', isZh) }}</option>
+            </select>
+            <small v-if="!stackedAllowed" class="meta-dashboard__hint" data-hint="bar-mode-grouped-only">{{ viewRenderLabel('dashboard.barModeAdditiveOnly', isZh) }}</small>
           </label>
           <div v-if="createChartError" class="meta-dashboard__error" data-error="create-chart">{{ createChartError }}</div>
           <section class="meta-dashboard__preview" data-chart-preview="true">
@@ -325,8 +334,10 @@ const chartDraft = ref({
   valueFieldId: '',
   // v2-c: single-series render variant; only meaningful for pie ('donut') / line ('area').
   variant: '' as '' | 'donut' | 'area',
-  // v2-d: stacked-bar series split; only meaningful for bar + additive aggregation.
+  // v2-d: bar series split (groupBy × seriesBy); only meaningful for a bar chart.
   seriesByFieldId: '',
+  // v2-d-b1: bar series layout — 'stacked' (default) or 'grouped' (side-by-side, allows non-additive).
+  barMode: 'stacked' as 'stacked' | 'grouped',
 })
 
 const activeDashboard = computed(() => dashboards.value.find((d) => d.id === activeDashboardId.value) ?? dashboards.value[0] ?? null)
@@ -337,19 +348,26 @@ const chartFields = computed(() => filterPropertyVisibleFields(props.fields ?? [
 const groupableFields = computed(() => chartFields.value.filter((field) => GROUPABLE_FIELD_TYPES.has(field.type)))
 const numericFields = computed(() => chartFields.value.filter((field) => NUMERIC_FIELD_TYPES.has(field.type)))
 const requiresValueField = computed(() => AGGREGATIONS_REQUIRING_VALUE.has(chartDraft.value.aggregation))
-// v2-d: the stack-by picker is offered only for a bar chart with an additive aggregation and a
-// non-date-grouped primary axis (matches the backend producer + assertSeriesConstraints).
+// v2-d / v2-d-b1: the series-split picker is offered for any bar chart with a non-date-grouped
+// primary axis (grouped layout accepts any aggregation). Whether STACKED is a legal layout depends
+// on the aggregation being additive (sum/count) — see `stackedAllowed` + the producer/validator.
 const seriesByAllowed = computed(() =>
-  chartDraft.value.chartType === 'bar'
-  && ADDITIVE_AGGREGATIONS.has(chartDraft.value.aggregation)
-  && !editingDateGrouped.value,
+  chartDraft.value.chartType === 'bar' && !editingDateGrouped.value,
 )
-// Clear an inapplicable series field when the gating inputs change (type/aggregation/groupBy/date).
+const stackedAllowed = computed(() => ADDITIVE_AGGREGATIONS.has(chartDraft.value.aggregation))
+// The layout (barMode) control appears once a series field is chosen.
+const barModeShown = computed(() => seriesByAllowed.value && !!chartDraft.value.seriesByFieldId)
+// Clear an inapplicable series field, and fall back to grouped when stacked is illegal, whenever the
+// gating inputs change (type/aggregation/groupBy/date).
 watch(
   () => [chartDraft.value.chartType, chartDraft.value.aggregation, chartDraft.value.groupByFieldId, editingDateGrouped.value],
   () => {
     if (chartDraft.value.seriesByFieldId && !(seriesByAllowed.value && chartDraft.value.groupByFieldId)) {
       chartDraft.value.seriesByFieldId = ''
+    }
+    // v2-d-b1: stacked requires an additive aggregation; if it's no longer additive, fall back to grouped.
+    if (!stackedAllowed.value && chartDraft.value.barMode === 'stacked') {
+      chartDraft.value.barMode = 'grouped'
     }
   },
 )
@@ -380,6 +398,7 @@ function resetChartDraft() {
     valueFieldId: '',
     variant: '',
     seriesByFieldId: '',
+    barMode: 'stacked',
   }
   createChartError.value = ''
   resetChartPreview()
@@ -404,6 +423,7 @@ function openEditChart(chartId: string) {
     valueFieldId: cfg.dataSource.aggregation.fieldId ?? '',
     variant: cfg.displayConfig?.variant ?? '',
     seriesByFieldId: cfg.dataSource.seriesByFieldId ?? '',
+    barMode: cfg.displayConfig?.barMode ?? 'stacked',
   }
   createChartError.value = ''
   resetChartPreview()
@@ -514,13 +534,19 @@ function buildChartInput(base?: ChartConfig): ChartCreateInput {
   if (!editingDateGrouped.value) {
     dataSource.groupByFieldId = chartDraft.value.groupByFieldId
   }
-  // v2-d: stacked series only when bar + additive + a primary groupBy. Set explicitly (or delete the
-  // base value) so switching chartType/aggregation/groupBy clears a now-inapplicable series.
-  if (seriesByAllowed.value && chartDraft.value.groupByFieldId && chartDraft.value.seriesByFieldId) {
+  // v2-d: bar series split only when bar + a primary groupBy. Set explicitly (or delete the base
+  // value) so switching chartType/groupBy/date clears a now-inapplicable series.
+  const hasSeriesSplit = seriesByAllowed.value && !!chartDraft.value.groupByFieldId && !!chartDraft.value.seriesByFieldId
+  if (hasSeriesSplit) {
     dataSource.seriesByFieldId = chartDraft.value.seriesByFieldId
   } else {
     delete dataSource.seriesByFieldId
   }
+  // v2-d-b1: bar layout is meaningful only with a series split; stacked falls back to grouped for a
+  // non-additive aggregation (the server enforces the same). Explicit so a switch clears a base value.
+  const barMode: 'stacked' | 'grouped' | undefined = hasSeriesSplit
+    ? (stackedAllowed.value ? chartDraft.value.barMode : 'grouped')
+    : undefined
   // v2-c: a render variant is valid only for its matching chartType (donut→pie, area→line).
   // Resolve it explicitly so switching chartType clears a now-inapplicable variant carried by base.
   const variant: 'donut' | 'area' | undefined =
@@ -535,6 +561,7 @@ function buildChartInput(base?: ChartConfig): ChartCreateInput {
       ...(base?.displayConfig ?? {}),
       title: name,
       variant,
+      barMode,
     },
   }
 }

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -927,8 +927,9 @@ export interface ChartAggregation {
 export interface ChartDataSource {
   sheetId: string
   groupByFieldId?: string
-  // v2-d: split each groupBy category into stacked series. Honored only for a bar chart with a
-  // primary groupByFieldId + an additive aggregation (sum/count); inert/rejected otherwise.
+  // v2-d: split each groupBy category into bar series (grouped or stacked — see displayConfig.barMode).
+  // Honored only for a bar chart with a primary groupByFieldId; stacked mode additionally requires an
+  // additive aggregation (sum/count), grouped mode accepts any. Inert/rejected otherwise.
   seriesByFieldId?: string
   dateFieldId?: string
   dateGrouping?: 'day' | 'week' | 'month' | 'quarter' | 'year'
@@ -946,6 +947,9 @@ export interface ChartDisplayConfig {
   // v2-c single-series render variant: 'donut' (pie + inner radius) / 'area' (line + areaStyle).
   // Only honored for the matching chartType (pie/line); inert otherwise.
   variant?: 'donut' | 'area'
+  // v2-d-b1: bar series layout when seriesByFieldId is set. 'stacked' (default) | 'grouped'
+  // (side-by-side; allows non-additive aggregations). Inert unless seriesByFieldId is set on a bar chart.
+  barMode?: 'stacked' | 'grouped'
 }
 
 export interface ChartConfig {
@@ -972,7 +976,7 @@ export interface ChartDataPoint {
   color?: string
 }
 
-// v2-d: stacked-bar series. `data` is dense + aligned positionally to ChartData.dataPoints.
+// v2-d: a bar series (grouped or stacked). `data` is dense + aligned positionally to ChartData.dataPoints.
 export interface ChartSeries {
   name: string
   data: number[]
@@ -981,7 +985,8 @@ export interface ChartSeries {
 export interface ChartData {
   chartType: ChartType
   dataPoints: ChartDataPoint[]
-  // v2-d: present for a stacked bar chart; dataPoints/total are unaffected by its presence.
+  // v2-d: present for a bar chart with a series split (grouped or stacked); dataPoints/total are
+  // unaffected by its presence (in non-additive grouped mode, Σ series ≠ dataPoints).
   series?: ChartSeries[]
   total?: number
   metadata?: Record<string, unknown>

--- a/apps/web/src/multitable/utils/buildChartOption.ts
+++ b/apps/web/src/multitable/utils/buildChartOption.ts
@@ -77,21 +77,23 @@ export function buildChartOption(
 
   if (chartType === 'bar') {
     const horizontal = displayConfig?.orientation === 'horizontal'
-    // v2-d: stacked bar — one ECharts series per seriesByFieldId value, all on the same stack.
-    // Categories (xAxis) come from dataPoints; each series.data is dense + aligned to that order.
-    // colored by series (palette), not per-bar; values read via the HTML legend + axis tooltip.
-    const stacked = chartData.series
-    if (stacked && stacked.length > 0) {
+    // v2-d: multi-series bar — one ECharts series per seriesByFieldId value. Categories (xAxis) come
+    // from dataPoints; each series.data is dense + aligned to that order. Colored by series (palette),
+    // values read via the HTML legend + axis tooltip. v2-d-b1: barMode 'grouped' renders them
+    // side-by-side (no stack); default 'stacked' shares one stack.
+    const multiSeries = chartData.series
+    if (multiSeries && multiSeries.length > 0) {
+      const grouped = displayConfig?.barMode === 'grouped'
       return {
         ...base,
         tooltip: { trigger: 'axis' },
         grid,
         xAxis: horizontal ? valueAxis : categoryAxis,
         yAxis: horizontal ? categoryAxis : valueAxis,
-        series: stacked.map((s) => ({
+        series: multiSeries.map((s) => ({
           type: 'bar',
           name: s.name,
-          stack: 'total',
+          ...(grouped ? {} : { stack: 'total' }),
           label: { show: false },
           data: s.data,
         })),

--- a/apps/web/src/multitable/utils/meta-view-render-labels.ts
+++ b/apps/web/src/multitable/utils/meta-view-render-labels.ts
@@ -104,6 +104,10 @@ export type MetaViewRenderLabelKey =
   | 'dashboard.seriesBy'
   | 'dashboard.seriesByNone'
   | 'dashboard.seriesByHint'
+  | 'dashboard.barMode'
+  | 'dashboard.barModeStacked'
+  | 'dashboard.barModeGrouped'
+  | 'dashboard.barModeAdditiveOnly'
   | 'dashboard.noNumericFields'
   | 'dashboard.livePreview'
   | 'dashboard.previewFillRequired'
@@ -218,6 +222,10 @@ export const VIEW_RENDER_LABEL_KEYS: readonly MetaViewRenderLabelKey[] = [
   'dashboard.seriesBy',
   'dashboard.seriesByNone',
   'dashboard.seriesByHint',
+  'dashboard.barMode',
+  'dashboard.barModeStacked',
+  'dashboard.barModeGrouped',
+  'dashboard.barModeAdditiveOnly',
   'dashboard.noNumericFields',
   'dashboard.livePreview',
   'dashboard.previewFillRequired',
@@ -336,9 +344,13 @@ const LABELS: Record<MetaViewRenderLabelKey, { en: string; zh: string }> = {
   'dashboard.variantStandard': { en: 'Standard', zh: '标准' },
   'dashboard.variantDonut': { en: 'Donut', zh: '环形图' },
   'dashboard.variantArea': { en: 'Area', zh: '面积图' },
-  'dashboard.seriesBy': { en: 'Stack by (series)', zh: '堆叠分组（系列）' },
-  'dashboard.seriesByNone': { en: 'None (single bar)', zh: '不堆叠（单系列）' },
-  'dashboard.seriesByHint': { en: 'Splits each bar into stacked segments. Sum/count only.', zh: '将每根柱子拆成堆叠分段；仅支持求和/计数。' },
+  'dashboard.seriesBy': { en: 'Split by (series)', zh: '系列分组' },
+  'dashboard.seriesByNone': { en: 'None (single bar)', zh: '不分组（单系列）' },
+  'dashboard.seriesByHint': { en: 'Splits each bar by a second field (stacked or grouped — see layout below).', zh: '按第二个字段拆分每根柱子（堆叠或并排，见下方布局）。' },
+  'dashboard.barMode': { en: 'Series layout', zh: '系列布局' },
+  'dashboard.barModeStacked': { en: 'Stacked', zh: '堆叠' },
+  'dashboard.barModeGrouped': { en: 'Grouped (side by side)', zh: '并排分组' },
+  'dashboard.barModeAdditiveOnly': { en: 'Stacked needs a sum or count aggregation; using grouped.', zh: '堆叠需要求和或计数聚合；已改用并排分组。' },
   'dashboard.noNumericFields': { en: 'No readable numeric fields available.', zh: '没有可读取的数值字段。' },
   'dashboard.livePreview': { en: 'Live preview', zh: '实时预览' },
   'dashboard.previewFillRequired': { en: 'Complete the chart fields to preview.', zh: '填写完整图表字段后可预览。' },

--- a/apps/web/tests/multitable-build-chart-option.spec.ts
+++ b/apps/web/tests/multitable-build-chart-option.spec.ts
@@ -150,6 +150,18 @@ describe('buildChartOption', () => {
     expect(o.series.every((s: any) => s.stack === 'total')).toBe(true)
   })
 
+  it('v2-d-b1 grouped barMode: multi-series bar has NO stack (side-by-side)', () => {
+    const o = opt(buildChartOption(stackedBar(), { barMode: 'grouped' }))
+    expect(o.series).toHaveLength(2)
+    expect(o.series.map((s: any) => s.name)).toEqual(['A', 'B'])
+    expect(o.series.every((s: any) => s.stack === undefined)).toBe(true)
+  })
+
+  it('v2-d-b1 stacked barMode (default or explicit) keeps stack:total', () => {
+    expect(opt(buildChartOption(stackedBar())).series.every((s: any) => s.stack === 'total')).toBe(true)
+    expect(opt(buildChartOption(stackedBar(), { barMode: 'stacked' })).series.every((s: any) => s.stack === 'total')).toBe(true)
+  })
+
   it('no series ⇒ unchanged single-series bar (regression)', () => {
     const o = opt(buildChartOption(chart('bar', [{ label: 'A', value: 10 }, { label: 'B', value: 20 }])))
     expect(o.series).toHaveLength(1)

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -759,7 +759,9 @@ describe('MetaDashboardView', () => {
   const groupBySelectOf = (c: HTMLElement) => c.querySelector('[data-field="chart-group-by"]') as HTMLSelectElement
   const seriesSelectOf = (c: HTMLElement) => c.querySelector('[data-field="chart-series-by"]') as HTMLSelectElement | null
 
-  it('v2-d: series picker shows only for bar + additive aggregation (sum/count)', async () => {
+  const barModeSelectOf = (c: HTMLElement) => c.querySelector('[data-field="chart-bar-mode"]') as HTMLSelectElement | null
+
+  it('v2-d-b1: series picker shows for any bar chart; barMode appears once a series is chosen', async () => {
     const { client } = mockClient([fakeDashboard({ panels: [] })], [])
     const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
     await flushPromises()
@@ -767,15 +769,20 @@ describe('MetaDashboardView', () => {
     const typeSelect = typeSelectOf(container)
     const aggSelect = aggSelectOf(container)
 
-    expect(seriesSelectOf(container)).toBeTruthy()             // default bar + count → shown
+    // default bar + count: picker shown, but barMode hidden until a series is picked
+    expect(seriesSelectOf(container)).toBeTruthy()
+    expect(barModeSelectOf(container)).toBeNull()
+    await setSelect(seriesSelectOf(container)!, 'fld_amount')
+    // additive → barMode offers stacked + grouped
+    expect(Array.from(barModeSelectOf(container)!.options).map((o) => o.value)).toEqual(['stacked', 'grouped'])
+    // bar + avg (non-additive): picker STILL shown (grouped allows it); barMode offers grouped only
     await setSelect(aggSelect, 'avg')
-    expect(seriesSelectOf(container)).toBeNull()               // bar + avg → hidden
-    await setSelect(aggSelect, 'sum')
-    expect(seriesSelectOf(container)).toBeTruthy()             // bar + sum → shown
+    expect(seriesSelectOf(container)).toBeTruthy()
+    expect(Array.from(barModeSelectOf(container)!.options).map((o) => o.value)).toEqual(['grouped'])
+    // non-bar → both hidden
     await setSelect(typeSelect, 'line')
-    expect(seriesSelectOf(container)).toBeNull()               // non-bar → hidden
-    await setSelect(typeSelect, 'number')
     expect(seriesSelectOf(container)).toBeNull()
+    expect(barModeSelectOf(container)).toBeNull()
   })
 
   it('v2-d: series picker is disabled without a primary groupBy', async () => {
@@ -803,29 +810,32 @@ describe('MetaDashboardView', () => {
     const post = fetchFn.mock.calls.find(
       ([url, init]: [string, RequestInit?]) => init?.method === 'POST' && url.includes('/charts') && !url.includes('preview-data'),
     )
-    expect(JSON.parse(post![1].body as string).dataSource.seriesByFieldId).toBe('fld_amount')
+    const body = JSON.parse(post![1].body as string)
+    expect(body.dataSource.seriesByFieldId).toBe('fld_amount')
+    expect(body.display.barMode).toBe('stacked') // additive default
   })
 
-  it('v2-d: switching to a non-additive aggregation clears the series field', async () => {
+  it('v2-d-b1: switching to a non-additive aggregation keeps the series and forces grouped layout', async () => {
     const { client, fetchFn } = mockClient([fakeDashboard({ panels: [] })], [])
     const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
     await flushPromises()
     await openCreateForm(container)
     const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
     nameInput.value = 'Switcher'; nameInput.dispatchEvent(new Event('input')); await nextTick()
-    await setSelect(seriesSelectOf(container)!, 'fld_amount')
-    await setSelect(aggSelectOf(container), 'avg')             // non-additive → picker hidden + series cleared
+    await setSelect(seriesSelectOf(container)!, 'fld_amount')  // bar + count + series (stacked default)
+    await setSelect(aggSelectOf(container), 'avg')            // non-additive → series KEPT, layout forced grouped
     const valueSelect = container.querySelector('[data-field="chart-value-field"]') as HTMLSelectElement
-    await setSelect(valueSelect, 'fld_amount')                // avg requires a value field
+    await setSelect(valueSelect, 'fld_amount')               // avg requires a value field
     ;(container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement).click()
     await flushPromises()
 
     const post = fetchFn.mock.calls.find(
       ([url, init]: [string, RequestInit?]) => init?.method === 'POST' && url.includes('/charts') && !url.includes('preview-data'),
     )
-    const ds = JSON.parse(post![1].body as string).dataSource
-    expect(ds.aggregation.function).toBe('avg')
-    expect(ds.seriesByFieldId).toBeUndefined()
+    const body = JSON.parse(post![1].body as string)
+    expect(body.dataSource.aggregation.function).toBe('avg')
+    expect(body.dataSource.seriesByFieldId).toBe('fld_amount') // kept (grouped allows non-additive)
+    expect(body.display.barMode).toBe('grouped')               // forced — stacked is illegal for avg
   })
 
   it('v2-d: editing a stacked chart preserves seriesByFieldId on a name-only edit (round-trip)', async () => {
@@ -867,6 +877,53 @@ describe('MetaDashboardView', () => {
     expect(previewSpy).toHaveBeenLastCalledWith('sheet_1', expect.objectContaining({
       chartType: 'bar',
       dataSource: expect.objectContaining({ seriesByFieldId: 'fld_amount' }),
+    }))
+    vi.useRealTimers()
+  })
+
+  it('v2-d-b1: editing a grouped chart preserves display.barMode on a name-only edit (round-trip)', async () => {
+    const chart = fakeChart({
+      chartType: 'bar',
+      dataSource: { sheetId: 'sheet_1', groupByFieldId: 'fld_status', seriesByFieldId: 'fld_amount', aggregation: { function: 'count' } },
+      displayConfig: { title: 'Grouped chart', barMode: 'grouped' },
+    })
+    const { client, fetchFn } = mockClient([fakeDashboard()], [chart])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    ;(container.querySelector('[data-action="add-panel"]') as HTMLButtonElement).click()
+    await nextTick()
+    ;(container.querySelector(`[data-edit-chart="${chart.id}"]`) as HTMLButtonElement).click()
+    await nextTick()
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Renamed'; nameInput.dispatchEvent(new Event('input')); await nextTick()
+    ;(container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement).click()
+    await flushPromises()
+
+    const patch = fetchFn.mock.calls.find(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'PATCH' && url.includes(`/charts/${chart.id}`),
+    )
+    const body = JSON.parse(patch![1].body as string)
+    expect(body.display.barMode).toBe('grouped')               // preserved, not reset to stacked
+    expect(body.dataSource.seriesByFieldId).toBe('fld_amount')
+  })
+
+  it('v2-d-b1: live preview carries display.barMode', async () => {
+    const { client } = mockClient([fakeDashboard({ panels: [] })], [])
+    const previewSpy = vi.spyOn(client, 'previewChartData').mockResolvedValue({ chartType: 'bar', dataPoints: [{ label: 'A', value: 1 }] })
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    vi.useFakeTimers()
+    await openCreateForm(container)
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Preview grouped'; nameInput.dispatchEvent(new Event('input')); await nextTick()
+    await setSelect(seriesSelectOf(container)!, 'fld_amount')
+    await setSelect(barModeSelectOf(container)!, 'grouped')
+
+    await vi.advanceTimersByTimeAsync(300)
+    await nextTick()
+    expect(previewSpy).toHaveBeenLastCalledWith('sheet_1', expect.objectContaining({
+      chartType: 'bar',
+      displayConfig: expect.objectContaining({ barMode: 'grouped' }),
     }))
     vi.useRealTimers()
   })


### PR DESCRIPTION
Frontend half of **v2-d-b1** (grouped bar), on the merged backend (#2312). **b1 only**; b2/b3 untouched. Completes the b1 slice (barMode + conditional-additive + grouped render).

## Changes (frontend-only)
- **types** — `ChartDisplayConfig += barMode?: 'stacked' | 'grouped'` (mirror backend). Fixed the stale "stacked"-only wording on `seriesByFieldId` / `ChartSeries` / `series` (now "bar series, grouped or stacked") per review nit.
- **`buildChartOption`** — bar multi-series → **no `stack` when `barMode === 'grouped'`** (side-by-side); default/`'stacked'` keeps `stack:'total'`.
- **`MetaChartRenderer`** — `hasStackedSeries` → `hasSeriesLegend` (the legend covers grouped too).
- **`MetaDashboardView`** — series picker now offered for **any** bar aggregation (was additive-only), since grouped accepts non-additive; a **"Series layout" (barMode) control** appears once a series is chosen, offering *stacked* only when additive; a watcher **forces grouped** when the aggregation is non-additive; `buildChartInput` carries the effective `barMode` in `displayConfig` (create/edit/preview = one config; explicit so a switch clears a stale base). 4 zh/en labels + reworded `seriesByHint`.

## Tests
- `buildChartOption` **+2**: grouped → no stack; stacked default/explicit → `stack:'total'`.
- dashboard form: **2 v2-d-a tests updated** for the relaxed gating (picker shows for any agg; non-additive **keeps** series + **forces grouped**) + **2 new** (edit round-trip preserves `barMode`; preview carries `barMode`) + create asserts `barMode`.
- All 4 importer specs **77/77**; `vue-tsc -b` clean. (multitable web files are gated by type-check + tests, not the CI lint allowlist.)

Note: the backend `assertSeriesConstraints` error strings still say "stacked" — left for b2/b3 to rewrite when they revise that function, rather than churning it mid-arc.

🤖 Generated with [Claude Code](https://claude.com/claude-code)