### PR TITLE
feat(multitable): v2-d-b2 backend — multi-series line

### DIFF
--- a/packages/core-backend/src/multitable/chart-aggregation-service.ts
+++ b/packages/core-backend/src/multitable/chart-aggregation-service.ts
@@ -146,22 +146,25 @@ export class ChartAggregationService {
 
     const total = dataPoints.reduce((sum, dp) => sum + dp.value, 0)
 
-    // v2-d: bar series split. Built AFTER sort+limit, so it only covers the surviving categories in
-    // their final order (building before limit would leak limited-out categories). Emitted for
-    // bar + seriesByFieldId + groupBy-primary (no date axis) when EITHER barMode 'grouped' (v2-d-b1:
-    // side-by-side, any aggregation) OR an additive aggregation (stacked). The producer branches on
-    // `barMode` — not validation alone — so a persisted stacked+non-additive config still can't RENDER
-    // a misleading stack; it just omits series. Grouped vs stacked differ only at render.
+    // v2-d: bar/line series split. Built AFTER sort+limit, so it only covers the surviving categories
+    // in their final order (building before limit would leak limited-out categories). Emitted for
+    // bar OR line (v2-d-b2) + seriesByFieldId + groupBy-primary (no date axis). Additive aggregation is
+    // required ONLY for a STACKED bar (its sum is the bar height); grouped bars (v2-d-b1) and lines are
+    // independent → any aggregation. The producer branches on type/`barMode` — not validation alone —
+    // so a persisted stacked+non-additive config still can't RENDER a misleading stack; it just omits
+    // series. Stacked vs grouped vs multi-line differ only at render; the series math is identical.
     const seriesByFieldId = chart.dataSource.seriesByFieldId
     const dateGrouped = !!(chart.dataSource.dateFieldId && chart.dataSource.dateGrouping)
     const grouped = chart.display.barMode === 'grouped'
+    const seriesType = chart.type === 'bar' || chart.type === 'line'
+    const requiresAdditive = chart.type === 'bar' && !grouped // only a stacked bar
     let series: ChartSeries[] | undefined
     if (
-      chart.type === 'bar' &&
+      seriesType &&
       seriesByFieldId &&
       chart.dataSource.groupByFieldId &&
       !dateGrouped &&
-      (grouped || ADDITIVE_AGGREGATIONS.has(aggFn))
+      (!requiresAdditive || ADDITIVE_AGGREGATIONS.has(aggFn))
     ) {
       const seriesNames: string[] = []
       const byName = new Map<string, number[]>() // series name -> data[] aligned to dataPoints

--- a/packages/core-backend/src/multitable/charts.ts
+++ b/packages/core-backend/src/multitable/charts.ts
@@ -106,8 +106,9 @@ export function assertSeriesConstraints(
 ): void {
   const seriesByFieldId = dataSource?.seriesByFieldId
   if (!seriesByFieldId) return
-  if (type !== 'bar') {
-    throw new Error('seriesByFieldId (stacked series) is only supported for bar charts')
+  // v2-d-b2: bar and line carry a series split (line = overlaid lines, never stacked).
+  if (type !== 'bar' && type !== 'line') {
+    throw new Error('seriesByFieldId is only supported for bar and line charts')
   }
   if (!dataSource?.groupByFieldId) {
     throw new Error('seriesByFieldId requires groupByFieldId (a primary category axis)')
@@ -116,12 +117,12 @@ export function assertSeriesConstraints(
     // The producer gives date grouping precedence over groupByFieldId, so a series split is not
     // applied here — reject rather than silently produce a non-split chart (groupBy-primary only;
     // date-axis × series is deferred to v2-d-b3).
-    throw new Error('seriesByFieldId (stacked series) is not supported with date grouping')
+    throw new Error('seriesByFieldId is not supported with date grouping')
   }
-  // v2-d-b1: additive aggregation is required ONLY when the segments are STACKED (their sum is the
-  // bar height, which must be meaningful). Grouped (side-by-side) bars are independent → any
-  // aggregation is honest.
-  if (barMode !== 'grouped' && !ADDITIVE_AGGREGATIONS.has(dataSource.aggregation?.function)) {
+  // Additive aggregation is required ONLY for a STACKED bar — its segment heights must sum to a
+  // meaningful total. Grouped (side-by-side) bars are independent, and lines never stack, so both
+  // accept any aggregation. (v2-d-b1 = grouped relaxation; v2-d-b2 = line.)
+  if (type === 'bar' && barMode !== 'grouped' && !ADDITIVE_AGGREGATIONS.has(dataSource.aggregation?.function)) {
     throw new Error('stacked series require a sum or count aggregation (use barMode "grouped" for others)')
   }
 }

--- a/packages/core-backend/tests/integration/multitable-dashboard-preview-data.test.ts
+++ b/packages/core-backend/tests/integration/multitable-dashboard-preview-data.test.ts
@@ -228,7 +228,7 @@ describeIfDatabase('Dashboard BI v2-b2 preview-data endpoint (real DB)', () => {
     })
   })
 
-  test('P6 (v2-d): non-additive or non-bar series config is rejected with 400 (server-side, not UI-only)', async () => {
+  test('P6 (v2-d): a stacked bar with a non-additive aggregation is rejected with 400 (server-side, not UI-only)', async () => {
     const avg = await preview({
       name: 'avg stacked',
       type: 'bar',
@@ -237,13 +237,14 @@ describeIfDatabase('Dashboard BI v2-b2 preview-data endpoint (real DB)', () => {
     expect(avg.status).toBe(400)
     expect(JSON.stringify(avg.body)).toContain('sum or count')
 
-    const line = await preview({
-      name: 'line stacked',
-      type: 'line',
+    // series on a series-incompatible type (pie) → 400
+    const pie = await preview({
+      name: 'pie series',
+      type: 'pie',
       dataSource: { groupByFieldId: FLD_STATUS, seriesByFieldId: FLD_SECRET, aggregation: { function: 'count' } },
     })
-    expect(line.status).toBe(400)
-    expect(JSON.stringify(line.body)).toContain('bar charts')
+    expect(pie.status).toBe(400)
+    expect(JSON.stringify(pie.body)).toContain('bar and line')
   })
 
   test('P7 (v2-d-b1): grouped barMode accepts a non-additive aggregation and emits series', async () => {
@@ -256,5 +257,27 @@ describeIfDatabase('Dashboard BI v2-b2 preview-data endpoint (real DB)', () => {
     expect(res.status).toBe(200) // same config 400s when stacked (P6) — grouped relaxes additive-only
     expect(Array.isArray(res.body.series)).toBe(true)
     expect(res.body.series.length).toBeGreaterThan(0)
+  })
+
+  test('P8 (v2-d-b2): a multi-series line is accepted (any aggregation) and emits series', async () => {
+    const res = await preview({
+      name: 'multi line',
+      type: 'line',
+      dataSource: { groupByFieldId: FLD_STATUS, seriesByFieldId: FLD_SECRET, aggregation: { function: 'avg', fieldId: FLD_AMOUNT } },
+    })
+    expect(res.status).toBe(200) // line never stacks → non-additive is fine
+    expect(res.body.chartType).toBe('line')
+    expect(Array.isArray(res.body.series)).toBe(true)
+    expect(res.body.series.length).toBeGreaterThan(0)
+
+    // line + date grouping is still rejected (deferred to b3). groupBy present too, so the date check
+    // (not the groupBy-required check) is what fires.
+    const dated = await preview({
+      name: 'line date series',
+      type: 'line',
+      dataSource: { groupByFieldId: FLD_STATUS, dateFieldId: FLD_DATE, dateGrouping: 'month', seriesByFieldId: FLD_SECRET, aggregation: { function: 'count' } },
+    })
+    expect(dated.status).toBe(400)
+    expect(JSON.stringify(dated.body)).toContain('date grouping')
   })
 })

--- a/packages/core-backend/tests/unit/chart-dashboard.test.ts
+++ b/packages/core-backend/tests/unit/chart-dashboard.test.ts
@@ -885,11 +885,23 @@ describe('ChartAggregationService — v2-d stacked series', () => {
     expect(result.dataPoints.find((d) => d.label === 'open')?.value).toBe(80 / 3)
   })
 
-  it('inert: seriesByFieldId on a non-bar chart omits series', async () => {
-    for (const type of ['line', 'pie'] as const) {
+  it('inert: seriesByFieldId on a series-incompatible chart (pie/number/table) omits series', async () => {
+    for (const type of ['pie', 'number', 'table'] as const) {
       const result = await service.computeChartData(stackedChart({}, type), sampleRecords)
       expect(result.series).toBeUndefined()
     }
+  })
+
+  // v2-d-b2: line carries a series split (overlaid lines, no stack), any aggregation.
+  it('line: emits series (multi-line) for any aggregation', async () => {
+    const result = await service.computeChartData(
+      stackedChart({ aggregation: { function: 'avg', fieldId: 'amount' } }, 'line'),
+      sampleRecords,
+    )
+    expect(result.chartType).toBe('line')
+    expect(result.series).toBeDefined()
+    expect(result.series!.map((s) => s.name)).toEqual(['A', 'B'])
+    expect(result.series!.find((s) => s.name === 'A')!.data).toEqual([30, 30]) // avg per (status × category)
   })
 
   it('inert: no series without a primary groupByFieldId (date-grouped or ungrouped)', async () => {
@@ -951,9 +963,21 @@ describe('assertSeriesConstraints (v2-d input validation)', () => {
     expect(() => assertSeriesConstraints(ds({ aggregation: { function: 'count' } }), 'bar')).not.toThrow()
   })
 
-  it('throws for a non-bar chart', () => {
-    expect(() => assertSeriesConstraints(ds(), 'line')).toThrow(/bar charts/)
-    expect(() => assertSeriesConstraints(ds(), 'pie')).toThrow(/bar charts/)
+  it('throws for a series-incompatible chart type (pie/number/table)', () => {
+    for (const type of ['pie', 'number', 'table'] as const) {
+      expect(() => assertSeriesConstraints(ds(), type)).toThrow(/bar and line charts/)
+    }
+  })
+
+  // v2-d-b2: line accepts a series split with any aggregation (lines never stack).
+  it('line accepts any aggregation (no additive requirement)', () => {
+    for (const fn of ['avg', 'min', 'max', 'count_distinct', 'sum', 'count'] as const) {
+      expect(() => assertSeriesConstraints(ds({ aggregation: { function: fn, fieldId: 'amt' } }), 'line')).not.toThrow()
+    }
+  })
+
+  it('line + date grouping is still rejected (deferred to b3)', () => {
+    expect(() => assertSeriesConstraints(ds({ dateFieldId: 'd', dateGrouping: 'month' }), 'line')).toThrow(/date grouping/)
   })
 
   it('throws without a primary groupByFieldId', () => {


### PR DESCRIPTION
Second sub-slice of **v2-d-b** (design-lock #2310), **backend-first**, **b2 only**. Frontend (line series picker + multi-line render) follows separately; b3 (date×series) untouched.

## Changes
- **`assertSeriesConstraints`** — allows `line` (in addition to `bar`); the additive requirement now applies **only to a stacked bar** (lines never stack, grouped bars are independent → any aggregation). Still rejects pie/number/table (`"bar and line charts"`) and date grouping (deferred to b3).
- **Producer (`computeChartData`)** — emits `series[]` for `line` too (overlaid, no stack semantics). `requiresAdditive = bar && !grouped` only; series math unchanged; `dataPoints`/`total` stay single-dimension.

## Tests
- **unit**: line emits multi-series for any aggregation; validator (line accepts any agg / line+date still rejected / pie-number-table rejected); producer pie/number/table inert.
- **real-DB P8**: line+avg → 200 + series; line+date → 400. **P6 reframed**: stacked bar+avg → 400; pie+series → 400.
- Full backend unit **2776/2776**, dashboard real-DB **19/19**, tsc + eslint clean. No new security surface (`chartReferencedFieldIds` unchanged; line adds no new field reference).

🤖 Generated with [Claude Code](https://claude.com/claude-code)