### PR TITLE
docs(automation): lock A6-3 branch DAG scope

### DIFF
--- a/docs/development/multitable-automation-a6-3-branch-parallel-design-20260605.md
+++ b/docs/development/multitable-automation-a6-3-branch-parallel-design-20260605.md
@@ -1,0 +1,358 @@
+# Multitable Automation A6-3 Branch / Parallel DAG Design-Lock (2026-06-05)
+
+Status: **A6-3-0 design-lock / scope gate**
+
+Runtime: **not started**
+
+Grounded on: `origin/main@83801c668`
+Companions:
+
+- `docs/development/multitable-automation-a6-convergence-scout-20260529.md`
+- `docs/development/multitable-automation-a6-execution-plan-20260601.md`
+- `docs/development/multitable-automation-a6-2-suspend-resume-design-20260603.md`
+- `docs/development/multitable-automation-a6-2-suspend-resume-verification-20260603.md`
+- `docs/development/multitable-automation-run-governance-todo-20260527.md`
+
+## 0. Verdict
+
+A6-3 can be opened as the next automation-only capability rung, but **only as
+this docs-only design-lock first**. Runtime remains a separate explicit opt-in.
+
+The first runtime slice must be **A6-3-1 `condition_branch` / exclusive branch
+v1**, not full parallel DAG. Parallel fan-out and join semantics are important,
+but they are a larger executor rewrite and should land after the branch
+representation, C1 job view, and skip semantics are proven on real Postgres.
+
+This slice must not pull in approval, BPMN, attendance, data-factory, K3, public
+webhooks, or a new workflow designer runtime. It is automation-only.
+
+## 1. Current Code Grounding
+
+The current runtime has enough foundation for A6-3, but it is still linear:
+
+- `AutomationExecutor.executeActions()` runs `rule.actions` by array index,
+  sequentially, and stops after the first failed action.
+- `wait_for_callback` is the only non-linear-ish step today. It suspends in
+  opted-in `workflow_job_v1` rules and resumes from `suspendIndex + 1`.
+- `AutomationJobService.lifecycleFor()` writes deterministic job ids as
+  `${executionId}:job:${stepIndex}` and uses `upstream_job_id` as the previous
+  step's job id. That is currently a linear chain.
+- `AutomationJobService.listByExecution()` returns C1 WorkflowJob views and
+  hydrates suspend descriptors for `suspended` jobs.
+- `workflow-job-contract.ts` already has the needed C1 vocabulary:
+  `queued/running/suspended/resolved/failed/skipped/rejected/errored`.
+- `automation-conditions.ts` already supplies the condition evaluator used by
+  rule-level filters. A6-3 should reuse it for branch predicates.
+- A2/A3 admin runs detail already prefers persisted jobs when present. A6-3
+  should extend that job plane rather than adding a second observability plane.
+
+## 2. Hard Boundaries
+
+A6-3-0 / A6-3-1 must not:
+
+- add approval trigger bindings, approval result backwrite, `start_approval`, or
+  approval completion events;
+- add BPMN parse/compile/live execution;
+- add public webhook endpoints or token emitters;
+- add delay/timer resume, worker queues, or scheduler ownership changes;
+- touch attendance, K3, data-factory, PLM, or approval-center runtime;
+- change default behavior of existing legacy rules;
+- invent statuses outside C1;
+- persist unredacted branch inputs/results;
+- introduce a new `workflow_*` runtime table outside the automation job plane.
+
+## 3. Decomposition
+
+### A6-3-0 — Design-lock (this PR)
+
+Docs-only. Defines the staged shape and test bar. No runtime.
+
+### A6-3-1 — `condition_branch` / exclusive branch v1
+
+Goal: allow one automation rule to choose exactly one branch based on
+conditions, then run that branch's actions and continue to the next linear step.
+
+This is the first useful non-linear behavior and the smallest safe runtime
+step.
+
+### A6-3-2 — Branch editor + runs-detail visibility
+
+Frontend support for the branch node and clearer admin run detail display.
+This can be stacked after A6-3-1 or merged in the same runtime wave only if the
+backend contract is already locked and tests are green.
+
+### A6-3-3 — Branch-local suspend/resume cursor
+
+Allow `wait_for_callback` inside a selected branch. This is not part of
+A6-3-1 because current A6-2 stores `step_index` as a top-level integer cursor;
+nested branch resume needs a stable `step_key` / branch cursor and a rule-drift
+fingerprint for that nested path. Keep this as a separate sub-rung so exclusive
+branch v1 does not smuggle in a suspension schema change.
+
+### A6-3-4 — Parallel fan-out + `join_all`
+
+Run multiple branches independently and continue only after all selected
+branches finish. This is a separate runtime opt-in after exclusive branch v1.
+
+### A6-3-5 — `join_any` / cancellation semantics
+
+Only after `join_all` is stable. `join_any` needs explicit audit for ignored or
+cancelled sibling branches, so it should not be bundled into the first parallel
+slice.
+
+## 4. A6-3-1 Shape
+
+### 4.1 Action type
+
+Add a new canonical action type:
+
+```ts
+condition_branch
+```
+
+Its config should be the only new runtime shape in A6-3-1:
+
+```ts
+type ConditionBranchConfig = {
+  branches: Array<{
+    key: string
+    label?: string
+    conditions: ConditionGroup
+    actions: AutomationAction[]
+  }>
+  defaultBranch?: {
+    key: string
+    label?: string
+    actions: AutomationAction[]
+  } | null
+}
+```
+
+Rules:
+
+- Branch keys are stable non-empty strings and unique within the node.
+- Branch conditions are evaluated in array order.
+- The first matching branch wins.
+- If no branch matches and `defaultBranch` exists, run it.
+- If no branch matches and there is no default, the branch node resolves with no
+  branch actions and is treated as a successful no-op with explicit output
+  `{ selectedBranchKey: null }`.
+- Only branch actions run; non-selected branch actions are represented as
+  skipped jobs only if the branch action is opted into persisted jobs and the
+  implementation can do so without fabricating side effects. If that cannot be
+  represented cleanly in A6-3-1, non-selected branch internals stay absent and
+  the parent branch job records the selected branch.
+
+### 4.2 Execution semantics
+
+For an opted-in `workflow_job_v1` rule:
+
+1. The `condition_branch` parent job starts as `running`.
+2. Conditions evaluate against the same `context.recordData` used by existing
+   rule conditions.
+3. The selected branch actions run sequentially with the same fail-stop
+   semantics as top-level actions.
+4. If a selected branch action fails, the parent branch job settles `failed` and
+   the top-level execution fails; later top-level actions are skipped.
+5. A6-3-1 rejects `wait_for_callback` inside branch actions. Branch-local
+   suspend/resume is A6-3-3 because it needs a nested resume cursor rather than
+   the current A6-2 top-level `step_index` integer.
+
+For a legacy / opt-out rule:
+
+- A6-3-1 should fail closed rather than silently emulate branches without the
+  persisted job plane. A `condition_branch` action in a legacy rule returns a
+  failed step explaining that it requires `execution_mode='workflow_job_v1'`,
+  and remaining actions are skipped.
+
+This mirrors the `wait_for_callback` precedent.
+
+### 4.3 Job identity
+
+A6-1 currently uses numeric `step_key` values (`"0"`, `"1"`, ...). A6-3-1
+needs stable nested keys without a new table:
+
+- Top-level job id remains `${executionId}:job:${stepIndex}`.
+- Top-level branch parent `step_key` remains the top-level index, e.g. `"2"`.
+- Selected branch child jobs use a nested step key:
+
+```text
+2.branch.<branchKey>.<actionIndex>
+```
+
+and deterministic ids:
+
+```text
+${executionId}:job:2:branch:${branchKey}:${actionIndex}
+```
+
+`upstream_job_id`:
+
+- The branch parent upstream is the previous top-level job.
+- The first selected branch child upstream is the branch parent job.
+- Later selected branch children upstream to the previous child.
+- The next top-level job upstreams to the last selected branch child, or to the
+  branch parent if no branch action ran.
+
+This keeps A2/A3 on the existing C1 job list shape while making the graph
+visible.
+
+### 4.4 Read view
+
+A2/A3 must not invent a separate branch model for A6-3-1. The persisted jobs
+list remains the source:
+
+- Branch parent job `result` includes:
+
+```json
+{
+  "selectedBranchKey": "manager",
+  "selectedBranchLabel": "Manager approval",
+  "matched": true
+}
+```
+
+- No secrets are stored; result goes through A1 `redactValue`.
+- A3 can render indentation from `stepKey` later, but backend contract does not
+  depend on the frontend.
+
+## 5. Parallel Shape (A6-3-4, Not A6-3-1)
+
+Parallel fan-out is deferred. When opened, it should add a separate action type:
+
+```ts
+parallel_branch
+```
+
+Expected config:
+
+```ts
+type ParallelBranchConfig = {
+  branches: Array<{
+    key: string
+    label?: string
+    actions: AutomationAction[]
+  }>
+  joinMode: 'all'
+}
+```
+
+`join_any` is explicitly not part of the first parallel runtime. `join_all`
+means:
+
+- every branch runs;
+- all branch results must be terminal before the parent resolves;
+- any failed branch fails the parent and execution;
+- successful branches still keep their results for audit.
+
+Even if the implementation is inline rather than worker-parallel in v1, the job
+graph must represent the fan-out/fan-in shape. Do not call it "parallel" if the
+job graph cannot show independent branches.
+
+## 6. Data / Migration Posture
+
+A6-3-1 should try to avoid a new table. Preferred minimal path:
+
+- widen `automation_rules` action type CHECK for `condition_branch`;
+- keep `multitable_automation_jobs` table;
+- use existing `step_key` and `upstream_job_id` for graph shape;
+- optionally add nullable columns only if the runtime scout proves they are
+  required:
+  - `parent_job_id TEXT NULL`
+  - `branch_key TEXT NULL`
+  - `branch_index INT NULL`
+
+If optional columns are added, they must be nullable and only populated for
+opted-in A6-3 jobs. Existing rows remain valid.
+
+The runtime scout must answer whether nested `step_key` is sufficient before any
+migration is written.
+
+## 7. Failure Semantics
+
+A6-3-1 inherits current fail-stop behavior:
+
+- condition evaluation error -> parent branch job `failed`, execution `failed`;
+- selected branch action failure -> that action job `failed`, parent branch job
+  `failed`, execution `failed`;
+- top-level actions after a failed branch are `skipped`;
+- no-match-without-default -> parent branch job `resolved` with
+  `selectedBranchKey: null`, execution continues;
+- `wait_for_callback` nested inside a branch config -> reject at rule save in
+  A6-3-1;
+- invalid branch config at rule save -> reject; do not wait until runtime.
+
+The branch parent job should not be marked `resolved` until its selected branch
+tail is finished. A6-3-1 has no branch-local suspension, so a selected branch is
+terminal in the same execution call.
+
+## 8. Validation Requirements
+
+Service-level validation is mandatory. Route-level validation alone is not
+enough because direct service callers exist.
+
+Validate:
+
+- action type exists in `ALL_ACTION_TYPES`;
+- `condition_branch.config.branches` is a non-empty array;
+- every branch key is unique and safe for deterministic ids;
+- every branch condition normalizes through `normalizeConditionGroupInput`;
+- every branch action type is in `ALL_ACTION_TYPES`;
+- nested branch action configs pass the same action-specific validation used for
+  top-level `actions`;
+- no branch contains `condition_branch` recursively in A6-3-1;
+- no branch contains `wait_for_callback` in A6-3-1.
+
+This closes the class of issue where top-level `actionType` is validated but
+`actions[]` / nested actions drift.
+
+## 9. Test Surface for A6-3-1
+
+Minimum runtime PR tests:
+
+1. Rule create/update accepts valid `condition_branch` only with
+   `executionMode: 'workflow_job_v1'`.
+2. Legacy/off-path `condition_branch` fails closed and writes no branch jobs.
+3. First matching branch wins; later matching branches are not executed.
+4. Default branch runs when no branch matches.
+5. No-match/no-default resolves no-op and continues.
+6. Selected branch action failure fails execution and skips later top-level
+   actions.
+7. Top-level action after successful branch receives upstream from the last
+   selected branch child.
+8. Branch config containing `wait_for_callback` is rejected at save time in
+   A6-3-1.
+9. Non-selected branch side effects do not run.
+10. A2 detail returns C1-normalized job views for nested branch jobs.
+11. Redaction applies to branch job result/error.
+12. Real Postgres integration: opt-in rule trigger -> branch jobs -> admin runs
+    detail; opt-out rule -> no jobs / fail-closed.
+
+## 10. Frontend Posture
+
+Frontend should follow backend, not lead it.
+
+First acceptable frontend slice:
+
+- add a minimal `condition_branch` editor block;
+- force / lock `workflow_job_v1` when the action is present, matching the
+  `wait_for_callback` precedent;
+- display branch parent and selected branch jobs in the admin runs detail;
+- do not add a canvas editor;
+- do not introduce BPMN language or gateway vocabulary yet.
+
+## 11. Acceptance for This Design-Lock
+
+- Docs-only diff.
+- Creates this A6-3 design-lock.
+- Updates tracker pointers only.
+- No runtime, migration, route, UI, OpenAPI, or test changes.
+- States that A6-3 runtime still requires a separate explicit owner opt-in.
+
+## 12. Recommended Next Opt-In Phrase
+
+If accepted, the runtime unlock should be explicit:
+
+> Start A6-3-1 condition_branch runtime v1 only: opt-in
+> `workflow_job_v1`, exclusive branch, no parallel, no BPMN, no approval bridge,
+> real Postgres tests.

--- a/docs/development/multitable-automation-a6-execution-plan-20260601.md
+++ b/docs/development/multitable-automation-a6-execution-plan-20260601.md
@@ -19,19 +19,19 @@
 The remaining ladder splits cleanly into two kinds of work, and they get different
 treatment **on purpose**:
 
-- **A6-1 enable-writer EXPOSES capability that already exists.** The persistent
-  WorkflowJob runtime landed in #2130 but is DORMANT — `execution_mode` is read by the
-  executor (`persistJobs = rule.executionMode === 'workflow_job_v1'`) but cannot be set
-  through the rule create/update API, so in production no rule can opt in. Finishing that
-  wiring adds **no new engine semantics**. Its shape is fully known, so it is planned
-  **deep** below (this section doubles as its scout).
-- **A6-2 … A6-5 ADD capability** (durable wait, graph execution, modeling import,
-  approval coupling). Their *shape* is undefined until a concrete use-case names it
-  (webhook-resume vs timer-resume; join-all vs join-any; the approval-completion
-  contract). Designing them before that is premature engineering. They are planned
-  **plan-level only**: scope boundary, dependency order, gate posture, and a pointer to
-  the test surface the A6-0 scout already enumerated. Detailed design is deferred to each
-  rung's own scout, written when its use-case is named.
+- **A6-1 enable-writer was the deep-planned slice because it only exposed capability
+  that already existed.** That path is now complete end-to-end (#2130 runtime + #2191
+  enable-writer + #2193 admin UI toggle). The deep section below is retained as the
+  historical implementation plan and acceptance record, not as remaining work.
+- **A6-2 has also landed end-to-end** (#2236 design-lock + #2237 backend + #2245
+  frontend + #2257 UAT). Delay/timer resume remains separate because it forces durable
+  scheduler/worker/leader semantics.
+- **A6-3 … A6-5 ADD capability** (branch/parallel graph execution, modeling import,
+  approval coupling). Their *shape* is undefined until a concrete use-case names it.
+  A6-3 now has its docs-only design-lock, with the first runtime slice pinned to
+  `condition_branch` / exclusive branch v1. A6-4/A6-5 remain plan-level only:
+  scope boundary, dependency order, gate posture, and a pointer to the test surface the
+  A6-0 scout already enumerated.
 
 Dependency order is fixed (each rung is the next one's floor):
 **A6-1 enable-writer → A6-2 suspend/resume → A6-3 branch/parallel DAG → A6-4 BPMN
@@ -115,9 +115,9 @@ only missing link.
 
 ### 1.6 Gate posture & acceptance
 
-- **Gate:** lowest on the ladder. Demand = owner asking to advance + a built-but-dormant
-  runtime that is otherwise dead code. No third-party use-case required to finish wiring
-  something already shipped.
+- **Gate:** lowest on the ladder. Demand = owner asking to advance + an already-built
+  runtime on-switch that was otherwise dead code. No third-party use-case required to
+  finish wiring something already shipped.
 - **Acceptance:** an opted-in rule persists jobs end-to-end through the real wire; a
   non-opted rule is byte-for-byte unchanged; invalid mode rejected; governance (A1
   redaction, A2 read boundary, fail-closed) inherited unchanged.
@@ -154,7 +154,14 @@ only missing link.
   duplicate-resume idempotent/rejected, resume-after-completion rejected, invalid/expired
   token rejected without leak, later: survives process restart).
 
-## 3. A6-3 branch/parallel DAG — PLAN-LEVEL (design deferred to its scout)
+## 3. A6-3 branch/parallel DAG — DESIGN-LOCK OPENED (#A6-3-0; runtime still deferred)
+
+Design-lock: `multitable-automation-a6-3-branch-parallel-design-20260605.md`.
+
+The design-lock pins the first runtime slice as **A6-3-1 `condition_branch` /
+exclusive branch v1**, not full parallel DAG. Parallel fan-out, join-all, and
+join-any stay separate follow rungs. Runtime still requires a named owner
+opt-in; this plan line does not authorize code.
 
 - **Adds:** graph fields (upstream/downstream edges, branch discriminator, join mode,
   branch result aggregation) and generalizes the linear executor into a DAG. This is the

--- a/docs/development/multitable-automation-run-governance-todo-20260527.md
+++ b/docs/development/multitable-automation-run-governance-todo-20260527.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-27
 Scope: multitable automation run governance + whole-execution retry only
-Status: A0-A5 closed (2026-05-29); A6-1 COMPLETE end-to-end (runtime #2130 + enable-writer #2191 + admin UI toggle #2193, 2026-06) — rules can opt into the per-action WorkflowJob plane from the editor, no longer dormant; A6-2 suspend/resume backend (admin-gated v1, webhook/external resume) LANDED #2237 c363a78db (2026-06-03) + A6-2b frontend (admin Resume UI + `wait_for_callback` editor) LANDED #2245 cee99c8e4 (2026-06-04) + operator UAT PASS #2257 (2026-06-04) — A6-2 now closed end-to-end; delay/timer resume deferred; A6-3..A6-5 remain frozen / demand-gated
+Status: A0-A5 closed (2026-05-29); A6-1 COMPLETE end-to-end (runtime #2130 + enable-writer #2191 + admin UI toggle #2193, 2026-06) — rules can opt into the per-action WorkflowJob plane from the editor, no longer dormant; A6-2 suspend/resume backend (admin-gated v1, webhook/external resume) LANDED #2237 c363a78db (2026-06-03) + A6-2b frontend (admin Resume UI + `wait_for_callback` editor) LANDED #2245 cee99c8e4 (2026-06-04) + operator UAT PASS #2257 (2026-06-04) — A6-2 now closed end-to-end; delay/timer resume deferred; A6-3 design-lock opened (`multitable-automation-a6-3-branch-parallel-design-20260605.md`), runtime still not started; A6-4..A6-5 remain frozen / demand-gated
 Companion: multitable-automation-run-governance-development-20260527.md
 Depends on (landed): C1 contract workflow-job-contract.ts (#1889, read-boundary wired only); RFC #1885
 
@@ -21,14 +21,13 @@ The governance half and named A5 retry runtime are complete on `origin/main`:
 - A6-0 convergence scout + A6-1 runtime scout: docs-only planning artifacts.
 - A6-1 persistent `WorkflowJob` runtime: LANDED #2130 (2026-05-30) — opt-in linear
   job plane (new `multitable_automation_jobs`, rule-level `execution_mode`, fail-closed,
-  A1-redaction reuse, A2 detail prefer-jobs). **DORMANT**: createRule/updateRule do not
-  accept `execution_mode`, so no rule is opt-in-able via the API (DB/fixture only) →
-  existing rules unaffected.
+  A1-redaction reuse, A2 detail prefer-jobs). Historical note: this runtime initially
+  landed **DORMANT** because createRule/updateRule did not accept `execution_mode`; that
+  dormant state was later closed by #2191 enable-writer + #2193 admin UI toggle.
 
-This closeout does NOT mark the convergence engine complete. A6-1 runtime landed but is
-dormant; the rest remains frozen / demand-gated: A6-1 enable-writer (API/UI to set
-`execution_mode`), suspend/resume, branch/parallel, BPMN adapter, and approval-as-job are
-still separate future unlocks.
+This closeout did NOT mark the convergence engine complete at the time. Current status:
+A6-1 and A6-2 are now complete end-to-end; A6-3 only has a docs-only design-lock opened,
+and A6-4/A6-5 remain separate future unlocks.
 
 ## Doctrine — Two Gates (definition of "not lopsided")
 
@@ -42,20 +41,21 @@ still separate future unlocks.
   its own status vocabulary.
 
 This line is the governance half. The capability half (convergence engine) is a
-frozen, demand-gated separate track (see A6 + RFC #1885 + contract #1889).
+separate demand-gated track (see A6 + RFC #1885 + contract #1889).
 
 ## Scope Boundary
 
-This line improves automation execution observability, and aligns its data model
-with the landed C1 WorkflowJob contract (#1889) by boundary mapping — NOT by
-changing storage and NOT by persisting jobs.
+The original governance-half line improves automation execution observability, and aligns
+its data model with the landed C1 WorkflowJob contract (#1889) by boundary mapping — NOT
+by changing storage and NOT by persisting jobs. Later A6 runtime slices are separate,
+explicit opt-ins and are tracked below.
 
-It does not unlock:
+By itself, the governance-half line did not unlock:
 
 - approval_trigger_bindings / approval result backwrite / automation start_approval
 - approval completion event bridge
-- persistent automation_jobs runtime
-- suspend/resume, branch/parallel, cross-engine orchestration
+- persistent automation_jobs runtime (later A6-1 opt-in)
+- suspend/resume (later A6-2 opt-in), branch/parallel, cross-engine orchestration
 - Workflow Designer / BPMN live execution mapping
 
 The K3 Stage-1 blanket lock is retired (#1993; #1792 = M1 one-record Material Save-only PASS) — replaced by post-GATE scoped gates (see `k3-post-gate-scoped-governance-20260528.md`). This does NOT open the capability half: each item above still requires a separate named unlock / demand gate.
@@ -67,7 +67,8 @@ The K3 Stage-1 blanket lock is retired (#1993; #1792 = M1 one-record Material Sa
   (explicit opt-in; not "read-only so no review needed").
 - A4 / A5: completed by explicit opt-in (#2039 + #2047); retry UI,
   idempotency keys, and re-fetch-current-record context remain future opt-ins.
-- A6: docs only; all runtime frozen / demand-gated.
+- A6: A6-0/A6-3 design-locks are docs-only; A6-1 and A6-2 runtime/frontend slices
+  landed by explicit opt-in; A6-3 runtime and A6-4/A6-5 remain frozen / demand-gated.
 
 ## Current Baseline
 
@@ -81,9 +82,9 @@ Already present before this line:
 - frontend redacted support packet utility
 - scheduler leader lock for in-memory timers
 - DingTalk-specific redactor in executor (redactDingTalkFailureAlertText) — to be CONSOLIDATED, not extended
-- C1 WorkflowJob contract (workflow-job-contract.ts, #1889) — LANDED, wired only
-  at the A2 read boundary; not runtime-wired into the executor
-  (WorkflowJobStatus 8-state; legacyAutomationStatusToJobStatus: success->resolved, rest identity)
+- C1 WorkflowJob contract (workflow-job-contract.ts, #1889) — LANDED. Initially wired
+  only at the A2 read boundary; now also used by A6-1 persisted jobs and A6-2 suspended
+  job/resume surfaces.
 
 Completed by this governance-half line:
 
@@ -247,21 +248,23 @@ Acceptance:
 - [x] Retry rejects missing / empty / invalid trigger events without loading rule or executing actions.
 - [x] Retry response and `/test` response never serialize raw in-memory ruleSnapshot / steps.
 
-### A6 — Capability-half Bridge  (lock: A6-0 design only; runtime frozen / demand-gated)
+### A6 — Capability-half Bridge  (A6-0 historical scope gate + current checklist)
 
-Checklist status below records the docs-only A6-0 scout/scope gate. It does NOT
-mark the convergence engine complete.
+Checklist status below starts with the docs-only A6-0 scout/scope gate, then records
+later A6-1/A6-2 completions and the current A6-3 design-lock. A6 is still not fully
+complete.
 
 - [x] A6-0 docs-only scout/scope gate recorded in
       `multitable-automation-a6-convergence-scout-20260529.md`.
-- [x] Runtime remains frozen / demand-gated; this milestone is not complete.
+- [x] At A6-0 time, runtime remained frozen / demand-gated; that milestone did not
+      authorize implementation.
 - [x] Record convergence sequence: persist job -> suspend/resume [webhook before delay]
       -> branch/parallel -> BPMN compile/preview adapter -> approval-as-job.
 - [x] Each step references a concrete integration use-case before unlock (demand gate).
 - [x] Graph fields (upstreamStepKey/branchIndex) introduced in A6-3, not in A1/A5.
 - [x] Governance inheritance: any capability reuses this line's
       run/job/status/provenance/redaction/replay substrate (no second-class layer).
-- [x] No runtime in this milestone.
+- [x] No runtime in the A6-0 milestone.
 - [x] A6-1 persistent WorkflowJob runtime scout recorded in
       `multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md`.
 - [x] A6-1 persistent WorkflowJob runtime — LANDED #2130.
@@ -270,6 +273,9 @@ mark the convergence engine complete.
 - [x] A6-2 suspend/resume runtime (backend, admin-gated v1; webhook/external resume) — LANDED #2237 c363a78db (2026-06-03).
 - [x] A6-2b suspend/resume frontend (admin Resume UI + `wait_for_callback` editor) — LANDED #2245 cee99c8e4 (2026-06-04). **A6-2 closed end-to-end.** delay/timer resume still deferred / demand-gated.
 - [x] A6-2 UI/operator UAT — PASS #2257 on package `metasheet-multitable-onprem-v2.5.0-a6-2-uat-followup-lock-gate-b37ff906`: `wait_for_callback -> update_record` saved through the UI, suspended, resumed from admin detail, reached terminal `resolved`, and passed the listed negative guards. UAT blockers cleared by #2264 (service validation), #2272 (executor-shaped follow-up configs), and #2278 (`lock_record` hidden/disabled while storage contract is unsupported).
-- [ ] A6-3 branch/parallel DAG runtime — not started.
+- [ ] A6-3 branch/parallel DAG runtime — design-lock opened in
+      `multitable-automation-a6-3-branch-parallel-design-20260605.md`;
+      runtime not started. First runtime slice is explicitly
+      `condition_branch` / exclusive branch v1 only.
 - [ ] A6-4 BPMN compile/preview adapter — not started.
 - [ ] A6-5 approval-as-job bridge — not started.

--- a/docs/development/run-governance-forward-plan-20260528.md
+++ b/docs/development/run-governance-forward-plan-20260528.md
@@ -1,8 +1,9 @@
 # 运行治理 / 收敛引擎线 — 前向开发安排（需求闸账本 · 2026-05-28）
 
 > 类型：**前向开发安排（forward plan）**，非开工清单。
-> **2026-05-29 update**：A4 retry scope-gate (#2039) + A5 whole-execution retry runtime (#2047) 已按具名 opt-in 落地；`/test` + retry HTTP serialization redaction/fail-open hardening 已由 #2051/#2053 闭合。A6-0 docs-only scout 已记录在 `multitable-automation-a6-convergence-scout-20260529.md`；A6 runtime 仍 frozen / demand-gated。
-> **2026-05-30 update**：A6-1 persistent `WorkflowJob` runtime scout（`…-a6-1-workflowjob-runtime-scout-20260530.md`）+ **runtime 已落地（#2130，verification `…-a6-1-workflowjob-runtime-verification-20260530.md`）**：opt-in `workflow_job_v1` 规则 inline 写 C1 job（fail-closed、A1 redaction 复用、A2 detail prefer-jobs）。**但 DORMANT** —— API/UI enable 路径 deferred（createRule/updateRule 不接 `execution_mode`），现有规则零影响。剩余 A6-1 enable-writer + A6-2..A6-5 仍 demand-gated。
+> **2026-05-29 update（historical; superseded below）**：A4 retry scope-gate (#2039) + A5 whole-execution retry runtime (#2047) 已按具名 opt-in 落地；`/test` + retry HTTP serialization redaction/fail-open hardening 已由 #2051/#2053 闭合。A6-0 docs-only scout 已记录在 `multitable-automation-a6-convergence-scout-20260529.md`；当时 A6 runtime 仍 frozen / demand-gated。
+> **2026-05-30 update（historical; superseded below）**：A6-1 persistent `WorkflowJob` runtime scout（`…-a6-1-workflowjob-runtime-scout-20260530.md`）+ **runtime 已落地（#2130，verification `…-a6-1-workflowjob-runtime-verification-20260530.md`）**：opt-in `workflow_job_v1` 规则 inline 写 C1 job（fail-closed、A1 redaction 复用、A2 detail prefer-jobs）。当时 **DORMANT** —— API/UI enable 路径 deferred（createRule/updateRule 不接 `execution_mode`），现有规则零影响。该 dormant 状态已由 #2191/#2193 关闭。
+> **2026-06-05 update**：A6-1 已 end-to-end 完成（runtime #2130 + enable-writer #2191 + admin UI toggle #2193）；A6-2 suspend/resume 已 end-to-end 完成（design #2236 + runtime #2237 + frontend #2245 + UAT #2257）。A6-3 branch/parallel DAG 现只打开 docs-only design-lock（`multitable-automation-a6-3-branch-parallel-design-20260605.md`）；A6-3 runtime、A6-4、A6-5 仍 demand-gated。
 > 配套（已收口）：`multitable-automation-run-governance-development-20260527.md` + `-todo-20260527.md`（#1987 固化）。
 > 上游契约：C1 `workflow-job-contract.ts`（#1889，landed）· 收敛 RFC #1885。
 > 锁：**K3 Stage-1 blanket 锁已退役（#1993；#1792 = M1 单条 Material Save-only PASS）→ 改用 post-GATE scoped gates（见 `k3-post-gate-scoped-governance-20260528.md`）**。这不改变本线纪律：**治理半（A0–A3）属于内核治理 / observability，已关闭**；**能力半（A4–A6）仍各受需求闸 / 独立具名 opt-in**（本线天然为 multitable 内核范畴，不依赖 integration-core / RBAC / auth），除非对应 scout 明确授权。
@@ -17,9 +18,9 @@
 |---|---|---|---|
 | **治理半**（observability：快照→脱敏→只读 API→admin UI→可达） | 运行可观测/可审计/可诊断 | **✅ 100% + 文档固化** | 否 —— 已关闭，不重开 |
 | **Retry 能力薄片**（A4/A5：whole-execution retry） | 失败/跳过 run 可由 admin 显式确认后整 run 重跑 | **✅ 100% for A5 v1** | 否 —— 已关闭；UI/idempotency/record-refresh 另需 opt-in |
-| **收敛引擎能力半**（A6：persistent jobs / suspend/resume / branch / DAG / approval-as-job） | automation+approval 统一到 WorkflowJob 引擎 | **🟡 A6-1 持久 WorkflowJob runtime 已落地（#2130，2026-05-30）但 DORMANT** —— enable 路径 deferred（createRule/updateRule 不接 execution_mode；只能 DB/fixture 开）；**A6-1 enable-writer + A6-2..A6-5（suspend/branch/DAG/approval-as-job）未建** | 否 —— **A6-1 已落但 dormant；其余受需求闸，未触发即过早工程** |
+| **收敛引擎能力半**（A6：persistent jobs / suspend/resume / branch / DAG / approval-as-job） | automation+approval 统一到 WorkflowJob 引擎 | **🟡 A6-1 + A6-2 已完成**；A6-3 branch/parallel DAG 只打开 design-lock，runtime 未启动；A6-4/A6-5 未启动 | 否 —— **A6-3 runtime 仍需具名 opt-in；A6-4/A6-5 受需求闸** |
 
-> **grounded 2026-05-30**：`/retry` 路由实现 A5 whole-execution retry；**A6-1 persist-job runtime 已存在**（#2130：`multitable_automation_jobs` 表 + `AutomationJobService` + rule-level `execution_mode` opt-in + A2 detail prefer-jobs），对 opted-in `workflow_job_v1` 规则 inline 写 C1 job（fail-closed），但 **DORMANT**（enable 路径 deferred）。C1 契约现既被 A2 读边界用作状态映射、也被 A6-1 job 持久化引用。**仍无** suspend/resume、branch/parallel、BPMN、approval-as-job runtime。
+> **grounded 2026-06-05**：`/retry` 路由实现 A5 whole-execution retry；A6-1 persist-job runtime 已生产可达（#2130/#2191/#2193）；A6-2 suspend/resume 已生产可达（#2237/#2245，admin-gated v1，operator UAT #2257）。C1 契约现被 A2 读边界、A6-1 job 持久化、A6-2 suspended job/resume 使用。**仍无** branch/parallel runtime、BPMN adapter、approval-as-job bridge。
 
 **所以"接下去的开发安排" = 触发条件账本 + 不自动推进纪律，不是任务队列。**
 
@@ -63,17 +64,19 @@
 - **健壮性闭合**：`/test` 与 retry 的 HTTP serialization invariant 已闭合；log-read failure uses safe fallback, not 500.
 - **锁姿态**：本 A5 v1 closed。后续 retry UI / idempotency / live-record-context 都是新 opt-in，不属于本 closed slice。
 
-### A6 — 收敛引擎 🔒 frozen / 需求驱动
+### A6 — 收敛引擎（已落 A6-1/A6-2；剩余需求驱动）
 依赖序：**持久 WorkflowJob runtime → suspend/resume（先 webhook 后 delay）→ branch/parallel（DAG）→ BPMN compile/preview adapter → approval-as-job**。
 - **执行细节（per-rung 最小改动集 / 测试面 / gate）**：见 `multitable-automation-a6-execution-plan-20260601.md`；A6-1 enable-writer 在该文档已 deep-scout（build-ready），A6-2..A6-5 仅 plan-level（设计待各自 scout 在用例点名时再写）。状态仍以 `…-todo-20260527.md` 清单为准。
 - **A6-0 scout**：`multitable-automation-a6-convergence-scout-20260529.md` 只记录边界/顺序/测试面；它不是 runtime unlock。
 - **A6-1 scout**：`multitable-automation-a6-1-workflowjob-runtime-scout-20260530.md` 已回答第一片 runtime 的七个设计问题。
 - **✅ A6-1 COMPLETE end-to-end（2026-06，不再 dormant）**：runtime **#2130**（`multitable_automation_jobs` 表 + rule-level `execution_mode` + inline linear job persistence fail-closed + A1 redaction 复用 + A2 detail prefer-jobs/legacy-fallback）+ **enable-writer #2191**（createRule/updateRule 接 `execution_mode`，service 层 enum 严格校验）+ **admin UI toggle #2193**（规则编辑器复选框，默认关）。净效果：管理员勾选规则 → 该规则每个动作持久化为 C1 WorkflowJob，A2/A3 可见。验收 runbook：`multitable-automation-a6-1-acceptance-runbook-20260602.md`。状态以 `…-todo-20260527.md` 为准。
-- **剩余依赖序（未建，各需具名 opt-in）**：**A6-2 suspend/resume**（**先 webhook/external resume，不是 delay timer** —— webhook 不要求先建持久调度器；delay 逼出 timer/worker/leader，复杂度高一档）→ **A6-3 branch/parallel DAG** → **A6-4 BPMN compile/preview** → **A6-5 approval-as-job**。触发须点名具体用例（"某 step 等外部回调再继续" / "人工确认后 resume" / A3 runs view 看到真实失败-等待需要 step-level continue），"继续自动化"不够。
+- **✅ A6-2 COMPLETE end-to-end（2026-06）**：design-lock #2236 + backend runtime #2237 + frontend #2245 + operator UAT #2257。Admin-gated v1，`wait_for_callback` + single-use token resume；delay/timer/public emitter 仍 deferred。
+- **A6-3 design-lock opened（2026-06-05）**：`multitable-automation-a6-3-branch-parallel-design-20260605.md`。First runtime slice is `condition_branch` / exclusive branch v1 only; runtime not started.
+- **剩余依赖序（未建，各需具名 opt-in）**：**A6-3 runtime**（先 exclusive branch，不是 parallel）→ **A6-4 BPMN compile/preview** → **A6-5 approval-as-job**。触发须点名具体用例（"按记录字段走不同动作分支" / "需要并行 fan-out + join" / "BPMN 只做 compile-preview" / "approval-as-job 需要审批完成事件桥"），"继续自动化"不够。
 - **触发信号**：某个**集成/DF 流水线真的需要 human-in-the-loop**（"导入→清洗→**等人工审批**→导出"= suspend + approval-as-job）或按记录分支；**且本就在 K3 GATE 下游**。
 - **治理继承硬契约**：A6 任一能力落地必须**复用本线的 run/job/status/provenance/redaction 底座**，不得新建二等可观测层。
 - **BPMN 永久定位**：compile/preview adapter（编译成 auto/approval 定义），**永不自己执行**（否则第四套状态孤岛）。
-- **锁姿态**：🔒🔒 全 frozen。approval-as-job 排最后（最高价值+最高风险，completion-event-contract 先行）。
+- **锁姿态**：A6-3 runtime、A6-4、A6-5 仍 frozen / demand-gated。approval-as-job 排最后（最高价值+最高风险，completion-event-contract 先行）。
 
 ---
 
@@ -117,4 +120,4 @@
 
 ## 8. 一句话排期
 
-**治理半已完成、A5 whole-execution retry v1 已完成、A6-0/A6-1 scout 已记录、文档固化后不重开。A6 收敛引擎 runtime 仍 frozen / demand-gated。** 近期"开发安排"实质是：**本 session 待命做点名 review；A5 的运行效果用于判断是否需要 retry UI / idempotency / A6；A6 本就排在 K3/DF 成熟需求下游。** 触发出现 → 走 §7 流程。无触发 → 不动，这就是正确的安排。
+**治理半已完成、A5 whole-execution retry v1 已完成、A6-1/A6-2 已 end-to-end 落地；A6-3 runtime、A6-4、A6-5 仍 demand-gated。** 近期"开发安排"实质是：**本 session 待命做点名 review；A5/A6-2 的运行效果用于判断是否需要 branch/parallel / BPMN / approval-as-job；A6 仍排在成熟 DF/automation 编排需求下游。** 触发出现 → 走 §7 流程。无触发 → 不动，这就是正确的安排。


### PR DESCRIPTION
## Summary
- add the A6-3 branch/parallel DAG design-lock as a docs-only scope gate
- pin the first runtime slice to `condition_branch` / exclusive branch v1 only
- reconcile A6 trackers so A6-1 and A6-2 read as complete while A6-3 runtime, A6-4, and A6-5 remain demand-gated

## Scope
- docs-only: no runtime, migration, route, UI, OpenAPI, or test changes
- no approval trigger bindings, no `start_approval`, no BPMN live execution, no public webhook emitter, no K3/DF/attendance changes
- branch-local `wait_for_callback`, parallel fan-out, `join_any`, BPMN compile/preview, and approval-as-job remain separate opt-ins

## Design Notes
- A6-3-1 is exclusive branch v1: first matching branch wins, optional default branch, no recursive branches, no nested `wait_for_callback`
- persisted C1 job plane remains the observability source; branch parent/child jobs use deterministic nested `step_key` values
- runtime PR must prove rule validation, fail-closed legacy behavior, redaction, C1 normalized read view, and real Postgres branch execution

## Verification
- `git diff --cached --check`
- `git diff origin/main...HEAD --check`
- consistency scan for stale A6-1 dormant / A6-2 not-built wording

Grounded on latest main after rebase: `61b13a95b`.