### PR TITLE
feat(automation): add A6-3 condition branch runtime

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260605130000_add_condition_branch_automation_action.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260605130000_add_condition_branch_automation_action.ts
@@ -1,0 +1,63 @@
+/**
+ * Migration: A6-3-1 — widen the automation action-type CHECK constraint to
+ * include `condition_branch` (exclusive branch v1).
+ *
+ * Keeps `chk_automation_action_type` aligned with the app-level
+ * `ALL_ACTION_TYPES`. NULL-safe: only the enum widens; no table or column is
+ * added in this slice.
+ */
+
+import { sql, type Kysely } from 'kysely'
+
+export const AUTOMATION_ACTION_TYPES_WITH_CONDITION_BRANCH = [
+  'notify',
+  'update_field',
+  'update_record',
+  'create_record',
+  'send_webhook',
+  'send_notification',
+  'send_email',
+  'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
+  'lock_record',
+  'wait_for_callback',
+  'condition_branch',
+] as const
+
+export const AUTOMATION_ACTION_TYPES_BEFORE_CONDITION_BRANCH = [
+  'notify',
+  'update_field',
+  'update_record',
+  'create_record',
+  'send_webhook',
+  'send_notification',
+  'send_email',
+  'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
+  'lock_record',
+  'wait_for_callback',
+] as const
+
+function quotedActions(actions: readonly string[]): string {
+  return actions.map((action) => `'${action}'`).join(', ')
+}
+
+async function replaceAutomationActionTypeConstraint(
+  db: Kysely<unknown>,
+  actions: readonly string[],
+): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_action_type`.execute(db)
+  await sql.raw(`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_action_type
+    CHECK (action_type IN (${quotedActions(actions)}))
+  `).execute(db)
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await replaceAutomationActionTypeConstraint(db, AUTOMATION_ACTION_TYPES_WITH_CONDITION_BRANCH)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await replaceAutomationActionTypeConstraint(db, AUTOMATION_ACTION_TYPES_BEFORE_CONDITION_BRANCH)
+}

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -13,6 +13,7 @@ export type AutomationActionType =
   | 'send_dingtalk_person_message'
   | 'lock_record'
   | 'wait_for_callback'
+  | 'condition_branch'
 
 export const ALL_ACTION_TYPES: AutomationActionType[] = [
   'update_record',
@@ -24,6 +25,7 @@ export const ALL_ACTION_TYPES: AutomationActionType[] = [
   'send_dingtalk_person_message',
   'lock_record',
   'wait_for_callback',
+  'condition_branch',
 ]
 
 /** Config shape for update_record */

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -479,17 +479,26 @@ export interface ActionJobLifecycle {
   /** Before any condition/action side effects — persist a visible parent execution row. */
   onExecutionStarted?(execution: AutomationExecution): Promise<void>
   /** Before the action's side effect runs — create the job as `running` (observable on crash). */
-  onStart(stepIndex: number, action: AutomationAction): Promise<void>
+  onStart(stepIndex: number, action: AutomationAction, meta?: ActionJobLifecycleMeta): Promise<void>
   /** After the action settled — update the job to resolved/failed. */
-  onSettled(stepIndex: number, action: AutomationAction, result: AutomationStepResult): Promise<void>
+  onSettled(stepIndex: number, action: AutomationAction, result: AutomationStepResult, meta?: ActionJobLifecycleMeta): Promise<void>
   /** A fail-stop-skipped action — record a terminal `skipped` job. */
-  onSkipped(stepIndex: number, action: AutomationAction): Promise<void>
+  onSkipped(stepIndex: number, action: AutomationAction, meta?: ActionJobLifecycleMeta): Promise<void>
   /**
    * A6-2: a `wait_for_callback` step in an opted-in rule — persist the suspension row
    * + a `suspended` C1 job, then the executor STOPS (the tail runs on admin resume).
    * Optional: legacy rules supply no lifecycle, so a legacy `wait_for_callback` fails closed (D7).
    */
   onSuspend?(stepIndex: number, action: AutomationAction): Promise<void>
+}
+
+export interface ActionJobLifecycleMeta {
+  /** Stable C1 step key. Defaults to the top-level step index. */
+  stepKey?: string
+  /** Deterministic job id. Defaults to `${executionId}:job:${stepIndex}`. */
+  jobId?: string
+  /** Explicit graph edge. Defaults to the previous top-level job. */
+  upstreamJobId?: string | null
 }
 
 /** Builds the per-execution job lifecycle once the executionId is known (service-supplied for opt-in rules). */
@@ -534,6 +543,7 @@ export interface AutomationStepResult {
 }
 
 export interface ExecutionContext {
+  executionId: string
   ruleId: string
   sheetId: string
   recordId: string
@@ -597,6 +607,7 @@ export class AutomationExecutor {
     // Build execution context from trigger event
     const payload = triggerEvent as Record<string, unknown>
     const context: ExecutionContext = {
+      executionId,
       ruleId: rule.id,
       sheetId: rule.sheetId,
       recordId: (payload?.recordId as string) ?? '',
@@ -713,8 +724,14 @@ export class AutomationExecutor {
     jobLifecycle?: ActionJobLifecycle,
     startIndex = 0,
   ): Promise<{ suspended: boolean }> {
+    let nextTopLevelUpstreamJobId: string | null | undefined
+
     for (let index = startIndex; index < actions.length; index++) {
       const action = actions[index]
+      const topLevelMeta = nextTopLevelUpstreamJobId !== undefined
+        ? { upstreamJobId: nextTopLevelUpstreamJobId }
+        : undefined
+      nextTopLevelUpstreamJobId = undefined
 
       // A6-2 suspend point: a `wait_for_callback` in an opted-in rule suspends here.
       if (action.type === 'wait_for_callback') {
@@ -737,67 +754,43 @@ export class AutomationExecutor {
         return { suspended: false }
       }
 
+      // A6-3-1 exclusive branch. It requires the persisted job plane so nested
+      // branch jobs can be observed as C1 jobs; legacy/off-path rules fail closed.
+      if (action.type === 'condition_branch') {
+        if (!jobLifecycle) {
+          results.push({
+            actionType: 'condition_branch',
+            status: 'failed',
+            error: 'condition_branch requires execution_mode workflow_job_v1',
+            durationMs: 0,
+          })
+          for (let i = index + 1; i < actions.length; i++) {
+            results.push({ actionType: actions[i].type, status: 'skipped', durationMs: 0 })
+          }
+          return { suspended: false }
+        }
+
+        await jobLifecycle.onStart(index, action, topLevelMeta)
+        const branchResult = await this.executeConditionBranch(index, action, context, jobLifecycle)
+        results.push(branchResult.result)
+        await jobLifecycle.onSettled(index, action, branchResult.result)
+
+        if (branchResult.result.status === 'failed') {
+          for (let i = index + 1; i < actions.length; i++) {
+            await jobLifecycle.onSkipped(i, actions[i])
+            results.push({ actionType: actions[i].type, status: 'skipped', durationMs: 0 })
+          }
+          break
+        }
+
+        nextTopLevelUpstreamJobId = branchResult.lastJobId
+        continue
+      }
+
       // A6-1 fail-closed: onStart runs BEFORE the inner try, so a job-create failure propagates
       // to execute()'s outer catch (execution fails) — and the action's side effect never runs.
-      if (jobLifecycle) await jobLifecycle.onStart(index, action)
-      const startMs = Date.now()
-      let result: AutomationStepResult
-
-      try {
-        switch (action.type) {
-          case 'update_record':
-            result = await this.executeUpdateRecord(action.config, context)
-            break
-          case 'create_record':
-            result = await this.executeCreateRecord(action.config, context)
-            break
-          case 'send_webhook':
-            result = await this.executeSendWebhook(action.config, context)
-            break
-          case 'send_notification':
-            result = await this.executeSendNotification(action.config, context)
-            break
-          case 'send_email':
-            result = await this.executeSendEmail(action.config as unknown as SendEmailConfig, context)
-            break
-          case 'send_dingtalk_group_message':
-            result = await this.executeSendDingTalkGroupMessage(action.config as unknown as SendDingTalkGroupMessageConfig, context)
-            break
-          case 'send_dingtalk_person_message':
-            result = await this.executeSendDingTalkPersonMessage(action.config as unknown as SendDingTalkPersonMessageConfig, context)
-            break
-          case 'lock_record':
-            result = await this.executeLockRecord(action.config, context)
-            break
-          default:
-            result = {
-              actionType: action.type,
-              status: 'failed',
-              error: `Unknown action type: ${action.type}`,
-            }
-        }
-      } catch (err) {
-        result = {
-          actionType: action.type,
-          status: 'failed',
-          error: err instanceof Error ? err.message : String(err),
-        }
-      }
-
-      result.durationMs = Date.now() - startMs
-
-      if (action.type === 'send_dingtalk_group_message' && result.status === 'failed') {
-        let failureAlert: Record<string, unknown>
-        try {
-          failureAlert = await this.notifyRuleCreatorOfDingTalkGroupFailure(result, context)
-        } catch (error) {
-          failureAlert = {
-            status: 'failed',
-            reason: redactDingTalkFailureAlertText(error instanceof Error ? error.message : String(error)),
-          }
-        }
-        result.output = mergeFailureAlertOutput(result.output, failureAlert)
-      }
+      if (jobLifecycle) await jobLifecycle.onStart(index, action, topLevelMeta)
+      const result = await this.executeSingleAction(action, context)
 
       results.push(result)
 
@@ -823,6 +816,228 @@ export class AutomationExecutor {
     }
 
     return { suspended: false }
+  }
+
+  private async executeConditionBranch(
+    stepIndex: number,
+    action: AutomationAction,
+    context: ExecutionContext,
+    jobLifecycle: ActionJobLifecycle,
+  ): Promise<{ result: AutomationStepResult; lastJobId: string }> {
+    const startMs = Date.now()
+    const parentJobId = `${context.executionId}:job:${stepIndex}`
+    const config = action.config as {
+      branches?: Array<{
+        key?: unknown
+        label?: unknown
+        conditions?: ConditionGroup
+        actions?: AutomationAction[]
+      }>
+      defaultBranch?: {
+        key?: unknown
+        label?: unknown
+        actions?: AutomationAction[]
+      } | null
+    }
+    const branches = Array.isArray(config.branches) ? config.branches : []
+    let selected: typeof branches[number] | null = null
+    let matched = false
+
+    try {
+      for (const branch of branches) {
+        if (branch.conditions && evaluateConditions(branch.conditions, context.recordData)) {
+          selected = branch
+          matched = true
+          break
+        }
+      }
+    } catch (error) {
+      return {
+        lastJobId: parentJobId,
+        result: {
+          actionType: 'condition_branch',
+          status: 'failed',
+          error: error instanceof Error ? error.message : String(error),
+          durationMs: Date.now() - startMs,
+        },
+      }
+    }
+
+    if (!selected && config.defaultBranch) {
+      selected = config.defaultBranch
+    }
+
+    const selectedBranchKey = typeof selected?.key === 'string' ? selected.key : null
+    const selectedBranchLabel = typeof selected?.label === 'string' ? selected.label : undefined
+    const branchActions = Array.isArray(selected?.actions) ? selected.actions : []
+    const output: Record<string, unknown> = {
+      selectedBranchKey,
+      matched,
+    }
+    if (selectedBranchLabel) output.selectedBranchLabel = selectedBranchLabel
+
+    if (!selected || branchActions.length === 0) {
+      return {
+        lastJobId: parentJobId,
+        result: {
+          actionType: 'condition_branch',
+          status: 'success',
+          output,
+          durationMs: Date.now() - startMs,
+        },
+      }
+    }
+
+    if (!selectedBranchKey) {
+      return {
+        lastJobId: parentJobId,
+        result: {
+          actionType: 'condition_branch',
+          status: 'failed',
+          error: 'condition_branch selected branch key is invalid',
+          output,
+          durationMs: Date.now() - startMs,
+        },
+      }
+    }
+
+    let upstreamJobId: string | null = parentJobId
+    let lastJobId = parentJobId
+    for (let actionIndex = 0; actionIndex < branchActions.length; actionIndex++) {
+      const branchAction = branchActions[actionIndex]
+      const stepKey = `${stepIndex}.branch.${selectedBranchKey}.${actionIndex}`
+      const jobId = `${context.executionId}:job:${stepIndex}:branch:${selectedBranchKey}:${actionIndex}`
+      const meta = { stepKey, jobId, upstreamJobId }
+
+      if (branchAction.type === 'wait_for_callback') {
+        const failed: AutomationStepResult = {
+          actionType: 'condition_branch',
+          status: 'failed',
+          error: 'wait_for_callback inside condition_branch is deferred to A6-3-3',
+          output,
+          durationMs: Date.now() - startMs,
+        }
+        return { result: failed, lastJobId }
+      }
+
+      if (branchAction.type === 'condition_branch') {
+        const failed: AutomationStepResult = {
+          actionType: 'condition_branch',
+          status: 'failed',
+          error: 'Nested condition_branch is not supported in A6-3-1',
+          output,
+          durationMs: Date.now() - startMs,
+        }
+        return { result: failed, lastJobId }
+      }
+
+      await jobLifecycle.onStart(stepIndex, branchAction, meta)
+      const branchActionResult = await this.executeSingleAction(branchAction, context)
+      await jobLifecycle.onSettled(stepIndex, branchAction, branchActionResult, meta)
+      lastJobId = jobId
+      upstreamJobId = jobId
+
+      if (branchActionResult.status === 'failed') {
+        for (let skippedIndex = actionIndex + 1; skippedIndex < branchActions.length; skippedIndex++) {
+          const skippedAction = branchActions[skippedIndex]
+          const skippedStepKey = `${stepIndex}.branch.${selectedBranchKey}.${skippedIndex}`
+          const skippedJobId = `${context.executionId}:job:${stepIndex}:branch:${selectedBranchKey}:${skippedIndex}`
+          await jobLifecycle.onSkipped(stepIndex, skippedAction, {
+            stepKey: skippedStepKey,
+            jobId: skippedJobId,
+            upstreamJobId,
+          })
+          upstreamJobId = skippedJobId
+          lastJobId = skippedJobId
+        }
+        return {
+          lastJobId,
+          result: {
+            actionType: 'condition_branch',
+            status: 'failed',
+            error: branchActionResult.error ?? `Branch action ${actionIndex} failed`,
+            output,
+            durationMs: Date.now() - startMs,
+          },
+        }
+      }
+    }
+
+    return {
+      lastJobId,
+      result: {
+        actionType: 'condition_branch',
+        status: 'success',
+        output,
+        durationMs: Date.now() - startMs,
+      },
+    }
+  }
+
+  private async executeSingleAction(
+    action: AutomationAction,
+    context: ExecutionContext,
+  ): Promise<AutomationStepResult> {
+    const startMs = Date.now()
+    let result: AutomationStepResult
+
+    try {
+      switch (action.type) {
+        case 'update_record':
+          result = await this.executeUpdateRecord(action.config, context)
+          break
+        case 'create_record':
+          result = await this.executeCreateRecord(action.config, context)
+          break
+        case 'send_webhook':
+          result = await this.executeSendWebhook(action.config, context)
+          break
+        case 'send_notification':
+          result = await this.executeSendNotification(action.config, context)
+          break
+        case 'send_email':
+          result = await this.executeSendEmail(action.config as unknown as SendEmailConfig, context)
+          break
+        case 'send_dingtalk_group_message':
+          result = await this.executeSendDingTalkGroupMessage(action.config as unknown as SendDingTalkGroupMessageConfig, context)
+          break
+        case 'send_dingtalk_person_message':
+          result = await this.executeSendDingTalkPersonMessage(action.config as unknown as SendDingTalkPersonMessageConfig, context)
+          break
+        case 'lock_record':
+          result = await this.executeLockRecord(action.config, context)
+          break
+        default:
+          result = {
+            actionType: action.type,
+            status: 'failed',
+            error: `Unknown action type: ${action.type}`,
+          }
+      }
+    } catch (err) {
+      result = {
+        actionType: action.type,
+        status: 'failed',
+        error: err instanceof Error ? err.message : String(err),
+      }
+    }
+
+    result.durationMs = Date.now() - startMs
+
+    if (action.type === 'send_dingtalk_group_message' && result.status === 'failed') {
+      let failureAlert: Record<string, unknown>
+      try {
+        failureAlert = await this.notifyRuleCreatorOfDingTalkGroupFailure(result, context)
+      } catch (error) {
+        failureAlert = {
+          status: 'failed',
+          reason: redactDingTalkFailureAlertText(error instanceof Error ? error.message : String(error)),
+        }
+      }
+      result.output = mergeFailureAlertOutput(result.output, failureAlert)
+    }
+
+    return result
   }
 
   private async notifyRuleCreatorOfDingTalkGroupFailure(

--- a/packages/core-backend/src/multitable/automation-job-service.ts
+++ b/packages/core-backend/src/multitable/automation-job-service.ts
@@ -18,7 +18,7 @@
 import { db } from '../db/db'
 import { toJsonValue } from '../db/type-helpers'
 import { legacyAutomationStatusToJobStatus, normalizeWorkflowJobStatus, type WorkflowJobStatus, type WorkflowJobSuspendReason } from './workflow-job-contract'
-import type { ActionJobLifecycle } from './automation-executor'
+import type { ActionJobLifecycle, ActionJobLifecycleMeta } from './automation-executor'
 import type { AutomationAction } from './automation-actions'
 import { redactString, redactValue } from './automation-log-redact'
 
@@ -35,12 +35,18 @@ export class AutomationJobService {
   lifecycleFor(executionId: string, rule: { id: string; sheetId?: string }): ActionJobLifecycle {
     // Deterministic id (no random) → idempotent shape, same `${exec}:<kind>:<i>` family as the
     // legacy step-view id (`${exec}:step:i`); jobs use `:job:`.
-    const jobId = (stepIndex: number): string => `${executionId}:job:${stepIndex}`
-    const upstream = (stepIndex: number): string | null => (stepIndex > 0 ? jobId(stepIndex - 1) : null)
+    const jobId = (stepIndex: number, meta?: ActionJobLifecycleMeta): string =>
+      meta?.jobId ?? `${executionId}:job:${stepIndex}`
+    const stepKey = (stepIndex: number, meta?: ActionJobLifecycleMeta): string =>
+      meta?.stepKey ?? String(stepIndex)
+    const upstream = (stepIndex: number, meta?: ActionJobLifecycleMeta): string | null =>
+      meta && Object.prototype.hasOwnProperty.call(meta, 'upstreamJobId')
+        ? meta.upstreamJobId ?? null
+        : stepIndex > 0 ? `${executionId}:job:${stepIndex - 1}` : null
 
     return {
-      onStart: async (stepIndex, action) => {
-        const id = jobId(stepIndex)
+      onStart: async (stepIndex, action, meta) => {
+        const id = jobId(stepIndex, meta)
         const now = new Date().toISOString()
         await db
           .insertInto('multitable_automation_jobs')
@@ -50,10 +56,10 @@ export class AutomationJobService {
             rule_id: rule.id,
             sheet_id: rule.sheetId ?? null,
             step_index: stepIndex,
-            step_key: String(stepIndex),
+            step_key: stepKey(stepIndex, meta),
             action_type: action.type,
             status: 'running', // C1 'running'
-            upstream_job_id: upstream(stepIndex),
+            upstream_job_id: upstream(stepIndex, meta),
             result: null,
             error: null,
             started_at: now,
@@ -63,7 +69,7 @@ export class AutomationJobService {
           })
           .execute()
       },
-      onSettled: async (stepIndex, _action, result) => {
+      onSettled: async (stepIndex, _action, result, meta) => {
         await db
           .updateTable('multitable_automation_jobs')
           .set({
@@ -75,24 +81,24 @@ export class AutomationJobService {
             duration_ms: result.durationMs ?? null,
             updated_at: new Date().toISOString() as never,
           })
-          .where('id', '=', jobId(stepIndex))
+          .where('id', '=', jobId(stepIndex, meta))
           .execute()
       },
-      onSkipped: async (stepIndex, action) => {
+      onSkipped: async (stepIndex, action, meta) => {
         // Fail-stop remainder — a terminal skipped job (created directly, never ran).
         const now = new Date().toISOString()
         await db
           .insertInto('multitable_automation_jobs')
           .values({
-            id: jobId(stepIndex),
+            id: jobId(stepIndex, meta),
             execution_id: executionId,
             rule_id: rule.id,
             sheet_id: rule.sheetId ?? null,
             step_index: stepIndex,
-            step_key: String(stepIndex),
+            step_key: stepKey(stepIndex, meta),
             action_type: action.type,
             status: 'skipped',
-            upstream_job_id: upstream(stepIndex),
+            upstream_job_id: upstream(stepIndex, meta),
             result: null,
             error: null,
             started_at: null,
@@ -165,6 +171,8 @@ export class AutomationJobService {
       .selectAll()
       .where('execution_id', '=', executionId)
       .orderBy('step_index', 'asc')
+      .orderBy('created_at', 'asc')
+      .orderBy('step_key', 'asc')
       .execute()
 
     // B1: a `suspended` job MUST carry its C1 suspend descriptor — the contract enforces

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -64,6 +64,8 @@ const VALID_ACTION_TYPES = new Set<string>([
   ...LEGACY_ACTION_TYPES,
   ...ALL_ACTION_TYPES,
 ])
+const CANONICAL_ACTION_TYPES = new Set<string>(ALL_ACTION_TYPES)
+const SAFE_BRANCH_KEY = /^[A-Za-z0-9_-]{1,64}$/
 
 // A6-1 opt-in (#2130 runtime): a rule may persist one C1 WorkflowJob row per action.
 // `null`/`'legacy'` both mean the legacy fire-and-forget path (no job rows); only
@@ -127,6 +129,119 @@ function parseConditionGroupInput(value: unknown): ConditionGroup {
     }
     throw error
   }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function validateActionObject(action: unknown, path: string): AutomationAction {
+  if (!isRecord(action)) {
+    throw new AutomationRuleValidationError(`${path} must be an object`)
+  }
+  if (typeof action.type !== 'string' || !CANONICAL_ACTION_TYPES.has(action.type)) {
+    throw new AutomationRuleValidationError(`${path}.type is invalid`)
+  }
+  const config = isRecord(action.config) ? action.config : {}
+  return { type: action.type as AutomationAction['type'], config }
+}
+
+function readBranchActions(value: unknown, path: string): AutomationAction[] {
+  if (value === undefined || value === null) return []
+  if (!Array.isArray(value)) {
+    throw new AutomationRuleValidationError(`${path} must be an array`)
+  }
+  return value.map((action, index) => validateActionObject(action, `${path}[${index}]`))
+}
+
+function validateConditionBranchConfig(config: unknown, path: string): AutomationAction[] {
+  if (!isRecord(config)) {
+    throw new AutomationRuleValidationError(`${path} must be an object`)
+  }
+  if (!Array.isArray(config.branches) || config.branches.length === 0) {
+    throw new AutomationRuleValidationError(`${path}.branches must be a non-empty array`)
+  }
+
+  const seen = new Set<string>()
+  const nestedActions: AutomationAction[] = []
+  for (const [index, branch] of config.branches.entries()) {
+    const branchPath = `${path}.branches[${index}]`
+    if (!isRecord(branch)) {
+      throw new AutomationRuleValidationError(`${branchPath} must be an object`)
+    }
+    if (typeof branch.key !== 'string' || !SAFE_BRANCH_KEY.test(branch.key)) {
+      throw new AutomationRuleValidationError(`${branchPath}.key must be a safe non-empty string`)
+    }
+    if (seen.has(branch.key)) {
+      throw new AutomationRuleValidationError(`${branchPath}.key must be unique`)
+    }
+    seen.add(branch.key)
+    parseConditionGroupInput(branch.conditions)
+    const actions = readBranchActions(branch.actions, `${branchPath}.actions`)
+    for (const nested of actions) {
+      if (nested.type === 'condition_branch') {
+        throw new AutomationRuleValidationError(`${branchPath}.actions cannot contain nested condition_branch in A6-3-1`)
+      }
+      if (nested.type === 'wait_for_callback') {
+        throw new AutomationRuleValidationError(`${branchPath}.actions cannot contain wait_for_callback until A6-3-3`)
+      }
+    }
+    nestedActions.push(...actions)
+  }
+
+  if (config.defaultBranch !== undefined && config.defaultBranch !== null) {
+    const defaultPath = `${path}.defaultBranch`
+    if (!isRecord(config.defaultBranch)) {
+      throw new AutomationRuleValidationError(`${defaultPath} must be an object`)
+    }
+    if (typeof config.defaultBranch.key !== 'string' || !SAFE_BRANCH_KEY.test(config.defaultBranch.key)) {
+      throw new AutomationRuleValidationError(`${defaultPath}.key must be a safe non-empty string`)
+    }
+    if (seen.has(config.defaultBranch.key)) {
+      throw new AutomationRuleValidationError(`${defaultPath}.key must be unique`)
+    }
+    const actions = readBranchActions(config.defaultBranch.actions, `${defaultPath}.actions`)
+    for (const nested of actions) {
+      if (nested.type === 'condition_branch') {
+        throw new AutomationRuleValidationError(`${defaultPath}.actions cannot contain nested condition_branch in A6-3-1`)
+      }
+      if (nested.type === 'wait_for_callback') {
+        throw new AutomationRuleValidationError(`${defaultPath}.actions cannot contain wait_for_callback until A6-3-3`)
+      }
+    }
+    nestedActions.push(...actions)
+  }
+
+  return nestedActions
+}
+
+function collectNestedAutomationActions(
+  actionType: string,
+  actionConfig: Record<string, unknown>,
+  actions: AutomationAction[] | null | undefined,
+  executionMode: string | null,
+): AutomationAction[] {
+  const collected: AutomationAction[] = []
+  const requiresWorkflowJobMode = actionType === 'condition_branch'
+
+  if (actionType === 'condition_branch') {
+    collected.push(...validateConditionBranchConfig(actionConfig, 'actionConfig'))
+  }
+
+  for (const [index, action] of (actions ?? []).entries()) {
+    const current = validateActionObject(action, `actions[${index}]`)
+    if (current.type === 'condition_branch') {
+      collected.push(...validateConditionBranchConfig(current.config, `actions[${index}].config`))
+    }
+    collected.push(current)
+  }
+
+  const hasBranch = requiresWorkflowJobMode || collected.some((action) => action.type === 'condition_branch')
+  if (hasBranch && executionMode !== 'workflow_job_v1') {
+    throw new AutomationRuleValidationError('condition_branch requires execution_mode workflow_job_v1')
+  }
+
+  return collected
 }
 
 /**
@@ -390,20 +505,20 @@ export class AutomationService {
     const actions = Array.isArray(normalizedDingTalkInputs.actions)
       ? normalizedDingTalkInputs.actions as AutomationAction[]
       : input.actions ?? null
-    const actionConfigValidationError = validateDingTalkAutomationActionConfigs(input.actionType, actionConfig, actions)
+    const executionMode = normalizeExecutionMode(input.executionMode)
+    const actionsForValidation = collectNestedAutomationActions(input.actionType, actionConfig, actions, executionMode)
+    const actionConfigValidationError = validateDingTalkAutomationActionConfigs(input.actionType, actionConfig, actionsForValidation)
     if (actionConfigValidationError) throw new AutomationRuleValidationError(actionConfigValidationError)
-    const sendEmailValidationError = validateSendEmailActionConfigs(input.actionType, actionConfig, actions)
+    const sendEmailValidationError = validateSendEmailActionConfigs(input.actionType, actionConfig, actionsForValidation)
     if (sendEmailValidationError) throw new AutomationRuleValidationError(sendEmailValidationError)
     const linkValidationError = await validateDingTalkAutomationLinks(
       this.queryFn,
       sheetId,
       input.actionType,
       actionConfig,
-      actions,
+      actionsForValidation,
     )
     if (linkValidationError) throw new AutomationRuleValidationError(linkValidationError)
-
-    const executionMode = normalizeExecutionMode(input.executionMode)
 
     const row = {
       id: ruleId,
@@ -486,9 +601,13 @@ export class AutomationService {
       throw new AutomationRuleValidationError(`Invalid action_type: ${input.actionType}`)
     }
     const updates: Record<string, unknown> = {}
-    const shouldValidateActions = input.actionType !== undefined || input.actionConfig !== undefined || input.actions !== undefined
+    const shouldValidateActions = input.actionType !== undefined
+      || input.actionConfig !== undefined
+      || input.actions !== undefined
+      || input.executionMode !== undefined
     let normalizedActionConfigForUpdate: Record<string, unknown> | undefined
     let normalizedActionsForUpdate: AutomationAction[] | null | undefined
+    let normalizedExecutionModeForUpdate: string | null | undefined
 
     if (shouldValidateActions) {
       const existing = await this.getRule(ruleId)
@@ -497,6 +616,9 @@ export class AutomationService {
       const nextActionType = input.actionType ?? existing.action_type
       const nextActionConfig = input.actionConfig ?? existing.action_config
       const nextActions = input.actions !== undefined ? input.actions : existing.actions ?? null
+      const nextExecutionMode = input.executionMode !== undefined
+        ? normalizeExecutionMode(input.executionMode)
+        : existing.execution_mode ?? null
       const normalizedDingTalkInputs = normalizeDingTalkAutomationActionInputs(nextActionType, nextActionConfig, nextActions)
       const normalizedNextActionConfig = normalizedDingTalkInputs.actionConfig && typeof normalizedDingTalkInputs.actionConfig === 'object'
         ? normalizedDingTalkInputs.actionConfig as Record<string, unknown>
@@ -504,16 +626,22 @@ export class AutomationService {
       const normalizedNextActions = Array.isArray(normalizedDingTalkInputs.actions)
         ? normalizedDingTalkInputs.actions as AutomationAction[]
         : nextActions
-      const actionConfigValidationError = validateDingTalkAutomationActionConfigs(
+      const actionsForValidation = collectNestedAutomationActions(
         nextActionType,
         normalizedNextActionConfig,
         normalizedNextActions,
+        nextExecutionMode,
+      )
+      const actionConfigValidationError = validateDingTalkAutomationActionConfigs(
+        nextActionType,
+        normalizedNextActionConfig,
+        actionsForValidation,
       )
       if (actionConfigValidationError) throw new AutomationRuleValidationError(actionConfigValidationError)
       const sendEmailValidationError = validateSendEmailActionConfigs(
         nextActionType,
         normalizedNextActionConfig,
-        normalizedNextActions,
+        actionsForValidation,
       )
       if (sendEmailValidationError) throw new AutomationRuleValidationError(sendEmailValidationError)
       const linkValidationError = await validateDingTalkAutomationLinks(
@@ -521,12 +649,13 @@ export class AutomationService {
         sheetId,
         nextActionType,
         normalizedNextActionConfig,
-        normalizedNextActions,
+        actionsForValidation,
       )
       if (linkValidationError) throw new AutomationRuleValidationError(linkValidationError)
 
       if (input.actionConfig !== undefined) normalizedActionConfigForUpdate = normalizedNextActionConfig
       if (input.actions !== undefined) normalizedActionsForUpdate = Array.isArray(input.actions) ? normalizedNextActions : null
+      if (input.executionMode !== undefined) normalizedExecutionModeForUpdate = nextExecutionMode
     }
 
     if (input.name !== undefined) updates.name = input.name
@@ -537,7 +666,7 @@ export class AutomationService {
     if (input.enabled !== undefined) updates.enabled = input.enabled
     if (input.conditions !== undefined) updates.conditions = input.conditions ? JSON.stringify(input.conditions) : null
     if (input.actions !== undefined) updates.actions = normalizedActionsForUpdate ? JSON.stringify(normalizedActionsForUpdate) : null
-    if (input.executionMode !== undefined) updates.execution_mode = normalizeExecutionMode(input.executionMode)
+    if (input.executionMode !== undefined) updates.execution_mode = normalizedExecutionModeForUpdate ?? normalizeExecutionMode(input.executionMode)
 
     if (Object.keys(updates).length === 0) return this.getRule(ruleId)
 
@@ -857,6 +986,7 @@ export class AutomationService {
     // Re-derived context (D4): current record data + stored (redacted) trigger event.
     const triggerEvent = suspension.triggerEvent ?? {}
     const context: ExecutionContext = {
+      executionId: execution.id,
       ruleId: execRule.id,
       sheetId: execRule.sheetId,
       recordId: suspension.recordId ?? '',

--- a/packages/core-backend/tests/integration/multitable-automation-jobs.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-jobs.test.ts
@@ -172,4 +172,148 @@ describeIfDatabase('multitable automation jobs (A6-1, real DB)', () => {
       }
     }
   })
+
+  test('A6-3-1 seam: condition_branch persists parent, selected child, and downstream C1 jobs', async () => {
+    const urls: string[] = []
+    const svc = new AutomationService(
+      new EventBus(),
+      db as never,
+      (async () => ({ rows: [], rowCount: 0 })) as never,
+      (async (url: string) => {
+        urls.push(url)
+        return new Response('OK', { status: 200 })
+      }) as never,
+    )
+    const sheetId = `sheet_branch_${TS}`
+    const branchAction = {
+      type: 'condition_branch',
+      config: {
+        branches: [
+          {
+            key: 'vip',
+            label: 'VIP',
+            conditions: { logic: 'and', conditions: [{ fieldId: 'tier', operator: 'equals', value: 'vip' }] },
+            actions: [{ type: 'send_webhook', config: { url: 'https://example.test/vip' } }],
+          },
+          {
+            key: 'standard',
+            conditions: { logic: 'and', conditions: [{ fieldId: 'tier', operator: 'equals', value: 'standard' }] },
+            actions: [{ type: 'send_webhook', config: { url: 'https://example.test/standard' } }],
+          },
+        ],
+      },
+    } as const
+    const execIds: string[] = []
+    const ruleIds: string[] = []
+    try {
+      const persisted = await svc.createRule(sheetId, {
+        name: 'A6-3 branch real DB',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'condition_branch',
+        actionConfig: branchAction.config,
+        actions: [branchAction],
+        executionMode: 'workflow_job_v1',
+        createdBy: 'u1',
+      })
+      ruleIds.push(persisted.id)
+      expect(persisted.action_type).toBe('condition_branch')
+      expect(persisted.execution_mode).toBe('workflow_job_v1')
+
+      const optIn = await svc.executeRule(
+        {
+          id: `atr_branch_in_${TS}`,
+          name: 'A6-3 branch opt-in',
+          sheetId,
+          trigger: { type: 'record.created', config: {} },
+          actions: [
+            branchAction,
+            { type: 'send_webhook', config: { url: 'https://example.test/after' } },
+          ],
+          enabled: true,
+          createdBy: 'u1',
+          createdAt: new Date(TS).toISOString(),
+          executionMode: 'workflow_job_v1',
+        } as never,
+        { sheetId, recordId: `rec_branch_${TS}`, data: { tier: 'vip' } },
+      )
+      execIds.push(optIn.id)
+      expect(optIn.status).toBe('success')
+      expect(optIn.steps[0]).toMatchObject({
+        actionType: 'condition_branch',
+        status: 'success',
+        output: { selectedBranchKey: 'vip', selectedBranchLabel: 'VIP', matched: true },
+      })
+      expect(urls).toEqual(['https://example.test/vip', 'https://example.test/after'])
+
+      const raw = await q(
+        `SELECT id, step_index, step_key, action_type, status, upstream_job_id
+           FROM multitable_automation_jobs
+          WHERE execution_id = $1
+          ORDER BY step_index ASC, step_key ASC`,
+        [optIn.id],
+      )
+      expect(raw.rows).toEqual([
+        {
+          id: `${optIn.id}:job:0`,
+          step_index: 0,
+          step_key: '0',
+          action_type: 'condition_branch',
+          status: 'resolved',
+          upstream_job_id: null,
+        },
+        {
+          id: `${optIn.id}:job:0:branch:vip:0`,
+          step_index: 0,
+          step_key: '0.branch.vip.0',
+          action_type: 'send_webhook',
+          status: 'resolved',
+          upstream_job_id: `${optIn.id}:job:0`,
+        },
+        {
+          id: `${optIn.id}:job:1`,
+          step_index: 1,
+          step_key: '1',
+          action_type: 'send_webhook',
+          status: 'resolved',
+          upstream_job_id: `${optIn.id}:job:0:branch:vip:0`,
+        },
+      ])
+      const views = await jobs.listByExecution(optIn.id)
+      expect(views.map((v) => [v.stepKey, v.status, v.upstreamJobId])).toEqual([
+        ['0', 'resolved', null],
+        ['0.branch.vip.0', 'resolved', `${optIn.id}:job:0`],
+        ['1', 'resolved', `${optIn.id}:job:0:branch:vip:0`],
+      ])
+
+      const legacy = await svc.executeRule(
+        {
+          id: `atr_branch_out_${TS}`,
+          name: 'A6-3 branch legacy',
+          sheetId,
+          trigger: { type: 'record.created', config: {} },
+          actions: [branchAction],
+          enabled: true,
+          createdBy: 'u1',
+          createdAt: new Date(TS).toISOString(),
+        } as never,
+        { sheetId, recordId: `rec_branch_${TS}`, data: { tier: 'vip' } },
+      )
+      execIds.push(legacy.id)
+      expect(legacy.status).toBe('failed')
+      const none = await q(
+        'SELECT count(*)::int AS n FROM multitable_automation_jobs WHERE execution_id = $1',
+        [legacy.id],
+      )
+      expect(none.rows[0].n).toBe(0)
+    } finally {
+      for (const id of execIds) {
+        await q('DELETE FROM multitable_automation_jobs WHERE execution_id = $1', [id])
+        await q('DELETE FROM multitable_automation_executions WHERE id = $1', [id])
+      }
+      for (const id of ruleIds) {
+        await q('DELETE FROM automation_rules WHERE id = $1', [id])
+      }
+    }
+  })
 })

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -2275,6 +2275,81 @@ describe('AutomationService — Rule CRUD', () => {
     expect(rule.execution_mode).toBe('workflow_job_v1')
   })
 
+  it('A6-3-1: createRule accepts condition_branch only with workflow_job_v1', async () => {
+    const action = {
+      type: 'condition_branch',
+      config: {
+        branches: [{
+          key: 'vip',
+          conditions: { logic: 'and', conditions: [{ fieldId: 'tier', operator: 'equals', value: 'vip' }] },
+          actions: [{ type: 'update_record', config: { fields: { status: 'vip' } } }],
+        }],
+        defaultBranch: {
+          key: 'fallback',
+          actions: [{ type: 'send_notification', config: { userIds: ['u1'], message: 'fallback' } }],
+        },
+      },
+    } as const
+
+    dbExecuteResults.push([])
+    const rule = await service.createRule('sheet_1', {
+      name: 'Branch rule',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'condition_branch',
+      actionConfig: action.config,
+      actions: [action],
+      executionMode: 'workflow_job_v1',
+      createdBy: 'user_1',
+    })
+
+    expect(rule.action_type).toBe('condition_branch')
+    expect(rule.actions).toEqual([action])
+    expect(rule.execution_mode).toBe('workflow_job_v1')
+
+    const promise = service.createRule('sheet_1', {
+      name: 'Branch rule legacy',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'condition_branch',
+      actionConfig: action.config,
+      actions: [action],
+      createdBy: 'user_1',
+    })
+    await expect(promise).rejects.toThrow('condition_branch requires execution_mode workflow_job_v1')
+  })
+
+  it('A6-3-1: createRule rejects wait_for_callback inside a condition_branch branch', async () => {
+    const promise = service.createRule('sheet_1', {
+      name: 'Nested wait branch',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'condition_branch',
+      actionConfig: {
+        branches: [{
+          key: 'needs_wait',
+          conditions: { logic: 'and', conditions: [{ fieldId: 'status', operator: 'equals', value: 'pending' }] },
+          actions: [{ type: 'wait_for_callback', config: {} }],
+        }],
+      },
+      actions: [{
+        type: 'condition_branch',
+        config: {
+          branches: [{
+            key: 'needs_wait',
+            conditions: { logic: 'and', conditions: [{ fieldId: 'status', operator: 'equals', value: 'pending' }] },
+            actions: [{ type: 'wait_for_callback', config: {} }],
+          }],
+        },
+      }],
+      executionMode: 'workflow_job_v1',
+      createdBy: 'user_1',
+    })
+
+    await expect(promise).rejects.toThrow('cannot contain wait_for_callback until A6-3-3')
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
   it('createRule normalizes legacy DingTalk title and content fields', async () => {
     dbExecuteResults.push([])
     const rule = await service.createRule('sheet_1', {
@@ -2554,6 +2629,30 @@ describe('AutomationService — Rule CRUD', () => {
     expect(rule?.execution_mode).toBe('workflow_job_v1')
   })
 
+  it('A6-3-1: updateRule rejects turning a condition_branch rule back to legacy', async () => {
+    const branchAction = {
+      type: 'condition_branch',
+      config: {
+        branches: [{
+          key: 'vip',
+          conditions: { logic: 'and', conditions: [{ fieldId: 'tier', operator: 'equals', value: 'vip' }] },
+          actions: [{ type: 'update_record', config: { fields: { status: 'vip' } } }],
+        }],
+      },
+    }
+    dbExecuteTakeFirstResults.push(makeRuleRow({
+      action_type: 'condition_branch',
+      action_config: branchAction.config,
+      actions: [branchAction],
+      execution_mode: 'workflow_job_v1',
+    }))
+
+    const promise = service.updateRule('atr_1', 'sheet_1', { executionMode: null })
+
+    await expect(promise).rejects.toThrow('condition_branch requires execution_mode workflow_job_v1')
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
   it('updateRule validates the merged state when only actionType changes to DingTalk', async () => {
     dbExecuteTakeFirstResults.push(makeRuleRow({
       action_type: 'notify',
@@ -2764,7 +2863,7 @@ describe('AutomationService — Rule CRUD', () => {
     ]) chain[m] = vi.fn(chainFn)
     chain.set = vi.fn((v: Record<string, unknown>) => { setPayloads.push(v); return chain })
     chain.execute = vi.fn(async () => [ruleRow])
-    chain.executeTakeFirst = vi.fn(async () => undefined)
+    chain.executeTakeFirst = vi.fn(async () => ruleRow)
     const localService = new AutomationService(
       new EventBus(),
       chain as never,
@@ -2981,6 +3080,133 @@ describe('AutomationExecutor — A6-1 job lifecycle hooks', () => {
     const execution = await executor.execute(rule, { recordId: 'r1', data: {}, sheetId: 'sheet_1' })
     expect(execution.status).toBe('success')
     expect(execution.steps).toHaveLength(1) // legacy steps unchanged; no jobs involved
+  })
+
+  it('A6-3-1: condition_branch selects one branch and wires nested C1 job metadata', async () => {
+    let executionId = ''
+    const events: Array<{
+      phase: string
+      index: number
+      type: string
+      status?: string
+      stepKey?: string
+      jobId?: string
+      upstreamJobId?: string | null
+    }> = []
+    const lifecycle = {
+      factory: (id: string) => {
+        executionId = id
+        return {
+          onStart: async (index: number, action: { type: string }, meta?: { stepKey?: string; jobId?: string; upstreamJobId?: string | null }) => {
+            events.push({ phase: 'start', index, type: action.type, ...meta })
+          },
+          onSettled: async (index: number, action: { type: string }, result: { status: string }, meta?: { stepKey?: string; jobId?: string; upstreamJobId?: string | null }) => {
+            events.push({ phase: 'settled', index, type: action.type, status: result.status, ...meta })
+          },
+          onSkipped: async (index: number, action: { type: string }, meta?: { stepKey?: string; jobId?: string; upstreamJobId?: string | null }) => {
+            events.push({ phase: 'skipped', index, type: action.type, ...meta })
+          },
+        }
+      },
+    }
+    const rule = createMockRule({
+      actions: [
+        {
+          type: 'condition_branch',
+          config: {
+            branches: [
+              {
+                key: 'vip',
+                label: 'VIP',
+                conditions: { logic: 'and', conditions: [{ fieldId: 'tier', operator: 'equals', value: 'vip' }] },
+                actions: [{ type: 'update_record', config: { fields: { status: 'vip' } } }],
+              },
+              {
+                key: 'standard',
+                conditions: { logic: 'and', conditions: [{ fieldId: 'tier', operator: 'equals', value: 'standard' }] },
+                actions: [{ type: 'send_webhook', config: { url: 'https://example.com/standard' } }],
+              },
+            ],
+          },
+        },
+        { type: 'send_webhook', config: { url: 'https://example.com/after' } },
+      ],
+    })
+
+    const execution = await executor.execute(rule, {
+      recordId: 'r1',
+      data: { tier: 'vip' },
+      sheetId: 'sheet_1',
+    }, lifecycle.factory)
+
+    expect(execution.status).toBe('success')
+    expect(execution.steps).toHaveLength(2)
+    expect(execution.steps[0]).toMatchObject({
+      actionType: 'condition_branch',
+      status: 'success',
+      output: { selectedBranchKey: 'vip', selectedBranchLabel: 'VIP', matched: true },
+    })
+    expect(events).toEqual([
+      { phase: 'start', index: 0, type: 'condition_branch' },
+      {
+        phase: 'start',
+        index: 0,
+        type: 'update_record',
+        stepKey: '0.branch.vip.0',
+        jobId: `${executionId}:job:0:branch:vip:0`,
+        upstreamJobId: `${executionId}:job:0`,
+      },
+      {
+        phase: 'settled',
+        index: 0,
+        type: 'update_record',
+        status: 'success',
+        stepKey: '0.branch.vip.0',
+        jobId: `${executionId}:job:0:branch:vip:0`,
+        upstreamJobId: `${executionId}:job:0`,
+      },
+      { phase: 'settled', index: 0, type: 'condition_branch', status: 'success' },
+      {
+        phase: 'start',
+        index: 1,
+        type: 'send_webhook',
+        upstreamJobId: `${executionId}:job:0:branch:vip:0`,
+      },
+      { phase: 'settled', index: 1, type: 'send_webhook', status: 'success' },
+    ])
+    expect(deps.fetchFn).toHaveBeenCalledTimes(1) // non-selected branch webhook did not run; only the after action did.
+  })
+
+  it('A6-3-1: condition_branch fails closed in legacy mode and skips later actions', async () => {
+    const rule = createMockRule({
+      actions: [
+        {
+          type: 'condition_branch',
+          config: {
+            branches: [{
+              key: 'vip',
+              conditions: { logic: 'and', conditions: [{ fieldId: 'tier', operator: 'equals', value: 'vip' }] },
+              actions: [{ type: 'update_record', config: { fields: { status: 'vip' } } }],
+            }],
+          },
+        },
+        { type: 'send_webhook', config: { url: 'https://example.com/after' } },
+      ],
+    })
+
+    const execution = await executor.execute(rule, { recordId: 'r1', data: { tier: 'vip' }, sheetId: 'sheet_1' })
+
+    expect(execution.status).toBe('failed')
+    expect(execution.steps).toEqual([
+      {
+        actionType: 'condition_branch',
+        status: 'failed',
+        error: 'condition_branch requires execution_mode workflow_job_v1',
+        durationMs: 0,
+      },
+      { actionType: 'send_webhook', status: 'skipped', durationMs: 0 },
+    ])
+    expect(deps.fetchFn).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/core-backend/tests/unit/condition-branch-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/condition-branch-automation-action-migration.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, it } from 'vitest'
+import { ALL_ACTION_TYPES } from '../../src/multitable/automation-actions'
+import {
+  AUTOMATION_ACTION_TYPES_BEFORE_CONDITION_BRANCH,
+  AUTOMATION_ACTION_TYPES_WITH_CONDITION_BRANCH,
+} from '../../src/db/migrations/zzzz20260605130000_add_condition_branch_automation_action'
+
+describe('condition_branch automation action migration (A6-3-1)', () => {
+  it('keeps the latest database action constraint in sync with app-level action types', () => {
+    // The LATEST chk_automation_action_type constraint must accept EVERY app action type.
+    for (const actionType of ALL_ACTION_TYPES) {
+      expect(AUTOMATION_ACTION_TYPES_WITH_CONDITION_BRANCH).toContain(actionType)
+    }
+  })
+
+  it('adds condition_branch on top of the prior wait_for_callback action set, and nothing else', () => {
+    expect(AUTOMATION_ACTION_TYPES_WITH_CONDITION_BRANCH).toContain('condition_branch')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_CONDITION_BRANCH).not.toContain('condition_branch')
+    expect(AUTOMATION_ACTION_TYPES_WITH_CONDITION_BRANCH.filter((a) => a !== 'condition_branch'))
+      .toEqual([...AUTOMATION_ACTION_TYPES_BEFORE_CONDITION_BRANCH])
+  })
+
+  it('rolls back only the condition_branch widening', () => {
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_CONDITION_BRANCH).not.toContain('condition_branch')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_CONDITION_BRANCH).toContain('wait_for_callback')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_CONDITION_BRANCH).toContain('lock_record')
+  })
+})

--- a/packages/core-backend/tests/unit/wait-for-callback-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/wait-for-callback-automation-action-migration.test.ts
@@ -1,19 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { ALL_ACTION_TYPES } from '../../src/multitable/automation-actions'
 import {
   AUTOMATION_ACTION_TYPES_BEFORE_WAIT_FOR_CALLBACK,
   AUTOMATION_ACTION_TYPES_WITH_WAIT_FOR_CALLBACK,
 } from '../../src/db/migrations/zzzz20260603140000_add_wait_for_callback_automation_action'
 
 describe('wait_for_callback automation action migration (A6-2)', () => {
-  it('keeps the database action constraint in sync with app-level action types', () => {
-    // The LATEST chk_automation_action_type constraint must accept EVERY app action type —
-    // adding an action type without widening the constraint would break inserts (this guards it).
-    for (const actionType of ALL_ACTION_TYPES) {
-      expect(AUTOMATION_ACTION_TYPES_WITH_WAIT_FOR_CALLBACK).toContain(actionType)
-    }
-  })
-
   it('adds wait_for_callback on top of the prior (send_email) action set, and nothing else', () => {
     expect(AUTOMATION_ACTION_TYPES_WITH_WAIT_FOR_CALLBACK).toContain('wait_for_callback')
     expect(AUTOMATION_ACTION_TYPES_BEFORE_WAIT_FOR_CALLBACK).not.toContain('wait_for_callback')


### PR DESCRIPTION
## Summary
- add the A6-3-1 `condition_branch` action type and widen the automation action CHECK constraint
- implement exclusive branch runtime for `workflow_job_v1` rules: parent branch job, selected child job chain, and downstream top-level upstream linkage
- add service validation so `condition_branch` requires `workflow_job_v1`, rejects nested `condition_branch`, and rejects `wait_for_callback` inside branches until A6-3-3

## Scope boundaries
- A6-3-1 only: exclusive branch v1
- no frontend builder in this PR
- no parallel/join DAG, no suspend inside branch, no BPMN runtime/adapter, no approval-as-job, no public webhook/emitter
- no new tables; migration only widens `automation_rules.chk_automation_action_type`

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts tests/unit/condition-branch-automation-action-migration.test.ts tests/unit/wait-for-callback-automation-action-migration.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/multitable-automation-service.test.ts tests/unit/automation-routes-wiring.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec eslint src/multitable/automation-actions.ts src/multitable/automation-executor.ts src/multitable/automation-job-service.ts src/multitable/automation-service.ts tests/unit/automation-v1.test.ts tests/integration/multitable-automation-jobs.test.ts tests/unit/condition-branch-automation-action-migration.test.ts tests/unit/wait-for-callback-automation-action-migration.test.ts` (source clean; test files are ignored by existing ESLint ignore pattern)

## Local DB note
- `tests/integration/multitable-automation-jobs.test.ts` skips without `DATABASE_URL`
- with the local `.env`, the configured `localhost:5432/metasheet_v2` schema is stale (`multitable_automation_jobs` missing; 86 pending migrations)
- I did not migrate that dev DB; creating an isolated temp DB was denied by local Postgres privileges
- the added real-DB seam is therefore intended to run in CI
