### PR TITLE
feat(attendance): S3-2 outdoor approval admin config card (AttendanceView, default OFF)

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -2040,6 +2040,57 @@
                   {{ settingsLoading ? tr('Saving...', '保存中...') : tr('Save shift compliance', '保存排班合规') }}
                 </button>
               </div>
+
+              <div class="attendance__admin-subsection" data-admin-card="outdoor-approval">
+                <h4>{{ tr('Outdoor punch approval', '外勤打卡审批') }}</h4>
+                <p class="attendance__field-hint">
+                  {{ tr('When enabled, a punch outside the geofence (or marked as outdoor) needs approval before it counts as attendance. Default off = no change to punching.', '开启后，围栏外（或标记为外勤）的打卡需审批通过后才计入考勤。默认关闭＝不改变打卡行为。') }}
+                </p>
+                <label class="attendance__field attendance__field--checkbox" for="attendance-outdoor-require-approval">
+                  <span>{{ tr('Require approval for outdoor punches', '外勤打卡需审批') }}</span>
+                  <input
+                    id="attendance-outdoor-require-approval"
+                    v-model="outdoorForm.requireApproval"
+                    type="checkbox"
+                    data-outdoor="require-approval"
+                  />
+                </label>
+                <label class="attendance__field attendance__field--checkbox" for="attendance-outdoor-require-note">
+                  <span>{{ tr('Require a note on the outdoor punch', '外勤打卡需填写备注') }}</span>
+                  <input
+                    id="attendance-outdoor-require-note"
+                    v-model="outdoorForm.requireNote"
+                    type="checkbox"
+                    data-outdoor="require-note"
+                  />
+                </label>
+                <label class="attendance__field" for="attendance-outdoor-flow">
+                  <span>{{ tr('Approval flow', '审批流程') }}</span>
+                  <select
+                    id="attendance-outdoor-flow"
+                    v-model="outdoorForm.approvalFlowId"
+                    data-outdoor="approval-flow"
+                  >
+                    <option value="">{{ tr('Auto — use the single active outdoor flow', '自动——使用唯一启用的外勤审批流') }}</option>
+                    <option v-for="flow in outdoorApprovalFlowOptions" :key="flow.id" :value="flow.id">{{ flow.name }}</option>
+                    <option
+                      v-if="outdoorForm.approvalFlowId && !outdoorApprovalFlowOptions.some((f) => f.id === outdoorForm.approvalFlowId)"
+                      :value="outdoorForm.approvalFlowId"
+                    >{{ outdoorForm.approvalFlowId }}</option>
+                  </select>
+                </label>
+                <p v-if="outdoorApprovalFlowOptions.length === 0" class="attendance__field-hint">
+                  {{ tr('No active outdoor approval flow yet — create one under Approval Flows with request type outdoor_punch.', '尚无启用的外勤审批流——请在「审批流」中以请求类型 outdoor_punch 创建。') }}
+                </p>
+                <button
+                  class="attendance__btn attendance__btn--primary"
+                  :disabled="settingsLoading"
+                  data-outdoor="save"
+                  @click="saveOutdoorApproval"
+                >
+                  {{ settingsLoading ? tr('Saving...', '保存中...') : tr('Save outdoor approval', '保存外勤审批') }}
+                </button>
+              </div>
             </div>
 
             <div
@@ -7246,6 +7297,16 @@ interface AttendanceSettings {
     weeklyMaxMinutes?: number | null
     monthlyMaxMinutes?: number | null
   }
+  // ② S3 punch-policy outdoor approval (backend #2308). Frontend type only — the admin card reads/writes
+  // these via PUT { punchPolicy: { outdoor: ... } }. requirePhoto stays latent (no UI in S3-2).
+  punchPolicy?: {
+    outdoor?: {
+      requireApproval?: boolean
+      requireNote?: boolean
+      requirePhoto?: boolean
+      approvalFlowId?: string
+    }
+  }
 }
 
 interface HolidayPolicyOverride {
@@ -11004,6 +11065,19 @@ const shiftComplianceForm = reactive({
   weeklyMaxMinutes: '',
   monthlyMaxMinutes: '',
 })
+
+// ② S3-2 外勤打卡审批 (outdoor approval) config card. Mirrors shiftComplianceForm: saved via
+// saveOutdoorApproval, which PUTs ONLY { punchPolicy: { outdoor: ... } } so the backend per-key merge
+// leaves unscheduled / merge / the latent requirePhoto untouched. requireApproval=false ⇒ no regression.
+const outdoorForm = reactive({
+  requireApproval: false,
+  requireNote: false,
+  approvalFlowId: '',
+})
+// Real data source for the flow picker: the org's ACTIVE outdoor_punch approval flows (no fake picker).
+const outdoorApprovalFlowOptions = computed(() =>
+  approvalFlows.value.filter((flow) => flow.requestType === 'outdoor_punch' && flow.isActive),
+)
 
 const calendarPolicyOverrideDiagnostics = computed(() => buildCalendarPolicyOverrideDiagnostics(settingsForm.calendarPolicyOverrides))
 const calendarPolicyPreviewDraftOverrides = computed(() => calendarPolicyOverridesFromForm(settingsForm.calendarPolicyOverrides))
@@ -16320,6 +16394,7 @@ async function loadSettings() {
     attendanceSettings.value = (data.data as AttendanceSettings | null) ?? null
     applySettingsToForm(data.data || {})
     applyShiftComplianceToForm(data.data || {})
+    applyOutdoorToForm(data.data || {})
   } catch (error: any) {
     attendanceSettings.value = null
     setStatusFromError(error, tr('Failed to load settings', '加载设置失败'), 'admin')
@@ -16336,6 +16411,13 @@ function applyShiftComplianceToForm(settings: AttendanceSettings) {
   shiftComplianceForm.dailyMaxMinutes = capStr(sc.dailyMaxMinutes)
   shiftComplianceForm.weeklyMaxMinutes = capStr(sc.weeklyMaxMinutes)
   shiftComplianceForm.monthlyMaxMinutes = capStr(sc.monthlyMaxMinutes)
+}
+
+function applyOutdoorToForm(settings: AttendanceSettings) {
+  const outdoor = settings.punchPolicy?.outdoor || {}
+  outdoorForm.requireApproval = outdoor.requireApproval === true
+  outdoorForm.requireNote = outdoor.requireNote === true
+  outdoorForm.approvalFlowId = typeof outdoor.approvalFlowId === 'string' ? outdoor.approvalFlowId : ''
 }
 
 async function saveShiftCompliance() {
@@ -16375,6 +16457,42 @@ async function saveShiftCompliance() {
     setStatus(tr('Shift compliance updated.', '排班合规已更新。'))
   } catch (error: any) {
     setStatusFromError(error, tr('Failed to save shift compliance', '保存排班合规失败'), 'save-settings')
+  } finally {
+    settingsLoading.value = false
+  }
+}
+
+async function saveOutdoorApproval() {
+  settingsLoading.value = true
+  try {
+    // PUT ONLY punchPolicy.outdoor — the backend 2-level merge preserves unscheduled / merge siblings and
+    // the latent requirePhoto (not sent here). requireApproval=false ⇒ no change to existing punching.
+    const payload = {
+      punchPolicy: {
+        outdoor: {
+          requireApproval: outdoorForm.requireApproval === true,
+          requireNote: outdoorForm.requireNote === true,
+          approvalFlowId: String(outdoorForm.approvalFlowId || '').trim(),
+        },
+      },
+    }
+    const response = await apiFetchWithTimeout('/api/attendance/settings', {
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    }, ATTENDANCE_ADMIN_REQUEST_TIMEOUT_MS)
+    if (response.status === 403) {
+      adminForbidden.value = true
+      throw createForbiddenError()
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw createApiError(response, data, tr('Failed to save outdoor approval', '保存外勤审批失败'))
+    }
+    adminForbidden.value = false
+    applyOutdoorToForm((data.data || payload) as AttendanceSettings)
+    setStatus(tr('Outdoor approval updated.', '外勤审批已更新。'))
+  } catch (error: any) {
+    setStatusFromError(error, tr('Failed to save outdoor approval', '保存外勤审批失败'), 'save-settings')
   } finally {
     settingsLoading.value = false
   }

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -114,12 +114,14 @@ describe('Attendance admin regressions', () => {
   let attendanceSettingsData: Record<string, unknown> | null = null
   let attendanceSettingsFail = false
   let attendanceSettingsSaveData: Record<string, unknown> | null = null
+  let attendanceApprovalFlowsData: unknown[] | null = null
 
   beforeEach(() => {
     vi.clearAllMocks()
     attendanceSettingsData = null
     attendanceSettingsFail = false
     attendanceSettingsSaveData = null
+    attendanceApprovalFlowsData = null
     exportReportFieldFingerprint = 'records-unit-test-fingerprint'
     exportReportFieldCodes = 'work_date,employee_name'
     exportReportFieldCount = '2'
@@ -593,6 +595,12 @@ describe('Attendance admin regressions', () => {
           return jsonResponse(500, { ok: false, error: { code: 'INTERNAL_ERROR', message: 'settings unavailable' } })
         }
         return jsonResponse(200, { ok: true, data: attendanceSettingsData ?? {} })
+      }
+      if (url.includes('/api/attendance/approval-flows')
+        && String((init as { method?: string } | undefined)?.method || 'GET').toUpperCase() === 'GET') {
+        // Default [] keeps existing behaviour (loadApprovalFlows reads data.data.items || []); the outdoor
+        // flow-select test seeds this to assert the active-outdoor_punch filter.
+        return jsonResponse(200, { ok: true, data: { items: attendanceApprovalFlowsData ?? [] } })
       }
       if (url.includes('/api/attendance/scheduler-scopes')) {
         return jsonResponse(200, {
@@ -2145,6 +2153,34 @@ describe('Attendance admin regressions', () => {
 
     expect(lastSettingsPutBody()).toEqual({
       punchPolicy: { outdoor: { requireApproval: false, requireNote: false, approvalFlowId: '' } },
+    })
+  })
+
+  it('the approval-flow select lists ONLY active outdoor_punch flows and saves the chosen id', async () => {
+    attendanceApprovalFlowsData = [
+      { id: 'flow-out-active', name: 'Outdoor Active', requestType: 'outdoor_punch', isActive: true, steps: [] },
+      { id: 'flow-out-inactive', name: 'Outdoor Inactive', requestType: 'outdoor_punch', isActive: false, steps: [] },
+      { id: 'flow-leave', name: 'Leave Flow', requestType: 'leave', isActive: true, steps: [] },
+    ]
+    attendanceSettingsData = { punchPolicy: { outdoor: { requireApproval: true, requireNote: false, approvalFlowId: '' } } }
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(16)
+
+    const flow = container!.querySelector<HTMLSelectElement>('[data-outdoor="approval-flow"]')
+    expect(flow).toBeTruthy()
+    // The select offers '' (auto) + ONLY the active outdoor_punch flow — the inactive outdoor flow and the
+    // non-outdoor (leave) flow are filtered out by outdoorApprovalFlowOptions.
+    expect(Array.from(flow!.querySelectorAll('option')).map((o) => o.value)).toEqual(['', 'flow-out-active'])
+
+    // Choose the active outdoor flow and save → the chosen id is in the PUT body.
+    flow!.value = 'flow-out-active'
+    flow!.dispatchEvent(new Event('change'))
+    await flushUi(2)
+    container!.querySelector<HTMLButtonElement>('[data-outdoor="save"]')!.click()
+    await flushUi(6)
+    expect(lastSettingsPutBody()).toEqual({
+      punchPolicy: { outdoor: { requireApproval: true, requireNote: false, approvalFlowId: 'flow-out-active' } },
     })
   })
 

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -2068,6 +2068,86 @@ describe('Attendance admin regressions', () => {
     })
   })
 
+  // ② S3-2 外勤打卡审批 (outdoor approval) admin config card.
+  const lastSettingsPutBody = (): unknown => {
+    const puts = vi.mocked(apiFetch).mock.calls.filter(([url, init]) =>
+      String(url).includes('/api/attendance/settings')
+      && String((init as { method?: string } | undefined)?.method || 'GET').toUpperCase() === 'PUT')
+    expect(puts).toHaveLength(1)
+    return JSON.parse(String((puts[0][1] as { body?: string } | undefined)?.body || '{}'))
+  }
+
+  it('loads punchPolicy.outdoor into the card and PUTs ONLY { punchPolicy: { outdoor } } (flow id round-trips)', async () => {
+    attendanceSettingsData = {
+      punchPolicy: { outdoor: { requireApproval: true, requireNote: true, requirePhoto: false, approvalFlowId: 'flow-out-7' } },
+    }
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(16)
+
+    const requireApproval = container!.querySelector<HTMLInputElement>('[data-outdoor="require-approval"]')
+    const requireNote = container!.querySelector<HTMLInputElement>('[data-outdoor="require-note"]')
+    const flow = container!.querySelector<HTMLSelectElement>('[data-outdoor="approval-flow"]')
+    expect(Boolean(requireApproval && requireNote && flow)).toBe(true)
+    // load: booleans → checkboxes; the saved flow id round-trips via the preserve-option even when it is not
+    // in the active-flow list (so a previously-saved flow is never silently reset to '').
+    expect(requireApproval!.checked).toBe(true)
+    expect(requireNote!.checked).toBe(true)
+    expect(flow!.value).toBe('flow-out-7')
+
+    const saveButton = container!.querySelector<HTMLButtonElement>('[data-outdoor="save"]')
+    expect(saveButton).toBeTruthy()
+    saveButton!.click()
+    await flushUi(6)
+
+    // EXACTLY { punchPolicy: { outdoor: { requireApproval, requireNote, approvalFlowId } } }: no requirePhoto,
+    // no orgId, no sibling settings. toEqual (not toMatchObject) so any leak fails.
+    expect(lastSettingsPutBody()).toEqual({
+      punchPolicy: { outdoor: { requireApproval: true, requireNote: true, approvalFlowId: 'flow-out-7' } },
+    })
+  })
+
+  it('enabling outdoor approval from off PUTs requireApproval/requireNote=true + auto (empty) flow', async () => {
+    attendanceSettingsData = { punchPolicy: { outdoor: { requireApproval: false, requireNote: false, approvalFlowId: '' } } }
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(16)
+
+    const requireApproval = container!.querySelector<HTMLInputElement>('[data-outdoor="require-approval"]')
+    const requireNote = container!.querySelector<HTMLInputElement>('[data-outdoor="require-note"]')
+    expect(requireApproval!.checked).toBe(false)
+    requireApproval!.checked = true
+    requireApproval!.dispatchEvent(new Event('change'))
+    requireNote!.checked = true
+    requireNote!.dispatchEvent(new Event('change'))
+    await flushUi(2)
+    container!.querySelector<HTMLButtonElement>('[data-outdoor="save"]')!.click()
+    await flushUi(6)
+
+    expect(lastSettingsPutBody()).toEqual({
+      punchPolicy: { outdoor: { requireApproval: true, requireNote: true, approvalFlowId: '' } },
+    })
+  })
+
+  it('disabling requireApproval PUTs requireApproval=false (default-off, no regression)', async () => {
+    attendanceSettingsData = { punchPolicy: { outdoor: { requireApproval: true, requireNote: false, approvalFlowId: '' } } }
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(16)
+
+    const requireApproval = container!.querySelector<HTMLInputElement>('[data-outdoor="require-approval"]')
+    expect(requireApproval!.checked).toBe(true)
+    requireApproval!.checked = false
+    requireApproval!.dispatchEvent(new Event('change'))
+    await flushUi(2)
+    container!.querySelector<HTMLButtonElement>('[data-outdoor="save"]')!.click()
+    await flushUi(6)
+
+    expect(lastSettingsPutBody()).toEqual({
+      punchPolicy: { outdoor: { requireApproval: false, requireNote: false, approvalFlowId: '' } },
+    })
+  })
+
   it('keeps the group punch-method card read-only with only an Open drawer action', async () => {
     const card = await openAttendanceGroupPunchCard()
     // PM4: no inputs/toggles/save controls inside the punch card


### PR DESCRIPTION
## What

**S3-2 — the outdoor-approval admin config card.** The admin-UX follow-up to the merged S3 backend runtime (#2308). Adds an org-level config card to the **real** `AttendanceView.vue` settings section (not the unwired `useAttendanceAdminConfig` composable). **Frontend only — no backend / DB / OpenAPI / dist-sdk changes.**

## How

- Card exposes **`punchPolicy.outdoor.{requireApproval, requireNote, approvalFlowId}`** — clones the `shiftCompliance` caps-card pattern (reactive form + load + save). `requirePhoto` stays **latent — no UI**.
- **`saveOutdoorApproval` PUTs ONLY `{ punchPolicy: { outdoor: {...} } }`** (those 3 fields, no `requirePhoto`), so the backend per-key 2-level merge leaves `unscheduled` / `merge` / `requirePhoto` untouched. `requireApproval=false` ⇒ no change to existing punching (**no regression**).
- **`approvalFlowId` is a real `<select>`** populated from the org's **ACTIVE `outdoor_punch` approval flows** (`approvalFlows` filtered by `requestType==='outdoor_punch' && isActive`) — no fake picker. A saved id not in the active list is preserved via a fallback `<option>` so it **round-trips** (never silently reset to `''`); `""` = auto (the backend requires a unique active flow). An empty-list hint points admins to **Approval Flows** (request type `outdoor_punch`).
- **Honest admin-config copy only** — no claim of mobile outdoor UX / photo proof / in-out merge.

## Tests / verification

`apps/web/tests/attendance-admin-regressions.spec.ts` (real mount of `AttendanceView`, `toEqual`-locked PUT body = ONLY `{ punchPolicy: { outdoor } }`, no `orgId`/no sibling settings):
1. load + round-trip (incl. flow id via the preserve-option),
2. enable-from-off → `requireApproval`/`requireNote` true + auto flow,
3. disable → `requireApproval` false.

- **Gated by `attendance-web-guard`**: both `apps/web/src/views/AttendanceView.vue` and `attendance-admin-regressions.spec.ts` are in that workflow's `paths`, so this diff triggers it and the new spec runs in CI (not skip-when-unreachable).
- **Locally:** the 2 gated specs **88/88** (3 new + no regression) + `vue-tsc -b` **0 errors**. **Honesty note:** I ran exactly what the gate runs (the 2 guard specs + type-check); the **full web vitest suite was NOT run** (it's not in the gate). The edits are additive (new computed/reactive/template option + a frontend-type field), but I'm not claiming broader-than-gated coverage.

## Scope / deferred (NOT this PR)

移动端外勤体验 (mobile outdoor punch UX) · S2 in/out merge · C5 external notification channels · `requirePhoto` / photo-attachment proof · dist-sdk SDK types.

**Tracker is NOT re-flipped** — S3 is already ✅ on the runtime (staging-proven, #2319); this is the admin-UX follow-up.

Refs #2304 #2308

🤖 Generated with [Claude Code](https://claude.com/claude-code)
