### PR TITLE
feat(multitable): v2-d-b2 frontend — multi-series line render + line series picker

### DIFF
--- a/apps/web/src/multitable/components/MetaChartRenderer.vue
+++ b/apps/web/src/multitable/components/MetaChartRenderer.vue
@@ -22,7 +22,7 @@
             <span class="meta-chart__legend-value">{{ pt.value }}</span>
           </div>
         </div>
-        <!-- v2-d: multi-series bar legend over series names (grouped or stacked; colors map to the palette by series index). -->
+        <!-- v2-d: multi-series legend over series names (bar grouped/stacked or multi-line; colors map to the palette by series index). -->
         <div
           v-if="hasSeriesLegend && displayConfig?.showLegend !== false"
           class="meta-chart__legend meta-chart__legend--inline"
@@ -94,7 +94,8 @@ const isEChartsType = computed(() =>
 )
 const isRestricted = computed(() => props.chartData.metadata?.restricted === true)
 const hasSeriesLegend = computed(() =>
-  props.chartData.chartType === 'bar' && (props.chartData.series?.length ?? 0) > 0,
+  (props.chartData.chartType === 'bar' || props.chartData.chartType === 'line')
+  && (props.chartData.series?.length ?? 0) > 0,
 )
 
 // Legend swatch fallback color — same palette as buildChartOption so canvas + HTML legend match.

--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -351,12 +351,14 @@ const requiresValueField = computed(() => AGGREGATIONS_REQUIRING_VALUE.has(chart
 // v2-d / v2-d-b1: the series-split picker is offered for any bar chart with a non-date-grouped
 // primary axis (grouped layout accepts any aggregation). Whether STACKED is a legal layout depends
 // on the aggregation being additive (sum/count) — see `stackedAllowed` + the producer/validator.
+// v2-d-b2: line carries a series split too (overlaid lines). The series picker is offered for any
+// bar OR line chart with a non-date-grouped primary axis.
 const seriesByAllowed = computed(() =>
-  chartDraft.value.chartType === 'bar' && !editingDateGrouped.value,
+  (chartDraft.value.chartType === 'bar' || chartDraft.value.chartType === 'line') && !editingDateGrouped.value,
 )
 const stackedAllowed = computed(() => ADDITIVE_AGGREGATIONS.has(chartDraft.value.aggregation))
-// The layout (barMode) control appears once a series field is chosen.
-const barModeShown = computed(() => seriesByAllowed.value && !!chartDraft.value.seriesByFieldId)
+// The layout (barMode) control is bar-only (lines never stack/group); appears once a series is chosen.
+const barModeShown = computed(() => chartDraft.value.chartType === 'bar' && !!chartDraft.value.seriesByFieldId)
 // Clear an inapplicable series field, and fall back to grouped when stacked is illegal, whenever the
 // gating inputs change (type/aggregation/groupBy/date).
 watch(
@@ -534,17 +536,17 @@ function buildChartInput(base?: ChartConfig): ChartCreateInput {
   if (!editingDateGrouped.value) {
     dataSource.groupByFieldId = chartDraft.value.groupByFieldId
   }
-  // v2-d: bar series split only when bar + a primary groupBy. Set explicitly (or delete the base
-  // value) so switching chartType/groupBy/date clears a now-inapplicable series.
+  // v2-d / v2-d-b2: bar OR line series split, only with a primary groupBy. Set explicitly (or delete
+  // the base value) so switching chartType/groupBy/date clears a now-inapplicable series.
   const hasSeriesSplit = seriesByAllowed.value && !!chartDraft.value.groupByFieldId && !!chartDraft.value.seriesByFieldId
   if (hasSeriesSplit) {
     dataSource.seriesByFieldId = chartDraft.value.seriesByFieldId
   } else {
     delete dataSource.seriesByFieldId
   }
-  // v2-d-b1: bar layout is meaningful only with a series split; stacked falls back to grouped for a
+  // v2-d-b1: barMode is BAR-only (lines never stack/group); stacked falls back to grouped for a
   // non-additive aggregation (the server enforces the same). Explicit so a switch clears a base value.
-  const barMode: 'stacked' | 'grouped' | undefined = hasSeriesSplit
+  const barMode: 'stacked' | 'grouped' | undefined = (chartDraft.value.chartType === 'bar' && hasSeriesSplit)
     ? (stackedAllowed.value ? chartDraft.value.barMode : 'grouped')
     : undefined
   // v2-c: a render variant is valid only for its matching chartType (donut→pie, area→line).

--- a/apps/web/src/multitable/utils/buildChartOption.ts
+++ b/apps/web/src/multitable/utils/buildChartOption.ts
@@ -117,6 +117,27 @@ export function buildChartOption(
   }
 
   // line — category labels come from the x-axis; no per-point value labels (matches old SVG)
+  const area = displayConfig?.variant === 'area'
+  // v2-d-b2: multi-series line — one overlaid line per seriesByFieldId value (never stacked).
+  // Categories (xAxis) come from dataPoints; each series.data is dense + aligned to that order.
+  // The area variant is preserved: every line keeps its areaStyle.
+  const lineSeries = chartData.series
+  if (lineSeries && lineSeries.length > 0) {
+    return {
+      ...base,
+      tooltip: { trigger: 'axis' },
+      grid,
+      xAxis: categoryAxis,
+      yAxis: valueAxis,
+      series: lineSeries.map((s) => ({
+        type: 'line',
+        name: s.name,
+        label: { show: false },
+        ...(area ? { areaStyle: {} } : {}),
+        data: s.data,
+      })),
+    }
+  }
   return {
     ...base,
     tooltip: { trigger: 'axis' },
@@ -128,7 +149,7 @@ export function buildChartOption(
         type: 'line',
         label: { show: false },
         // v2-c: displayConfig.variant 'area' fills the area under the line.
-        ...(displayConfig?.variant === 'area' ? { areaStyle: {} } : {}),
+        ...(area ? { areaStyle: {} } : {}),
         data: seriesData,
       },
     ],

--- a/apps/web/tests/multitable-build-chart-option.spec.ts
+++ b/apps/web/tests/multitable-build-chart-option.spec.ts
@@ -175,13 +175,51 @@ describe('buildChartOption', () => {
     expect(o.series[0].stack).toBeUndefined()
   })
 
-  it('series is inert on non-bar types (line/pie ignore it)', () => {
-    const lineWithSeries = opt(buildChartOption({
-      chartType: 'line',
+  it('series is inert on pie (no native multi-series mapping)', () => {
+    // pie ignores series → null/HTML path (number/table also null). bar+line handle series (see below).
+    const pieWithSeries = opt(buildChartOption({
+      chartType: 'pie',
       dataPoints: [{ label: 'A', value: 1 }],
       series: [{ name: 'X', data: [1] }],
     }))
-    expect(lineWithSeries.series[0].type).toBe('line')
-    expect(lineWithSeries.series[0].stack).toBeUndefined()
+    expect(pieWithSeries.series[0].type).toBe('pie') // pie renders its dataPoints, not the series split
+  })
+
+  // --- v2-d-b2: multi-series line ---
+
+  const multiLine = (): ChartData => ({
+    chartType: 'line',
+    dataPoints: [{ label: 'Jan', value: 3 }, { label: 'Feb', value: 5 }],
+    series: [
+      { name: 'A', data: [2, 4] },
+      { name: 'B', data: [1, 1] },
+    ],
+  })
+
+  it('v2-d-b2 multi-line: one line series per chartData.series entry, no stack', () => {
+    const o = opt(buildChartOption(multiLine()))
+    expect(o.series).toHaveLength(2)
+    expect(o.series.map((s: any) => s.type)).toEqual(['line', 'line'])
+    expect(o.series.map((s: any) => s.name)).toEqual(['A', 'B'])
+    expect(o.series.every((s: any) => s.stack === undefined)).toBe(true) // lines never stack
+    expect(o.series[0].data).toEqual([2, 4])
+    expect(o.xAxis.data).toEqual(['Jan', 'Feb'])
+    expect(o.series.every((s: any) => s.areaStyle === undefined)).toBe(true) // no area variant
+  })
+
+  it('v2-d-b2 area + multi-line: EVERY line keeps areaStyle (area-variant compat preserved)', () => {
+    const o = opt(buildChartOption(multiLine(), { variant: 'area' }))
+    expect(o.series).toHaveLength(2)
+    expect(o.series.every((s: any) => s.type === 'line')).toBe(true)
+    expect(o.series.every((s: any) => s.areaStyle !== undefined)).toBe(true)
+    expect(o.series.every((s: any) => s.stack === undefined)).toBe(true)
+  })
+
+  it('v2-d-b2 no series ⇒ single line unchanged; area variant still honored (regression)', () => {
+    const plain = opt(buildChartOption(chart('line', [{ label: 'A', value: 1 }])))
+    expect(plain.series).toHaveLength(1)
+    expect(plain.series[0].areaStyle).toBeUndefined()
+    const area = opt(buildChartOption(chart('line', [{ label: 'A', value: 1 }]), { variant: 'area' }))
+    expect(area.series[0].areaStyle).toBeDefined()
   })
 })

--- a/apps/web/tests/multitable-chart-renderer.spec.ts
+++ b/apps/web/tests/multitable-chart-renderer.spec.ts
@@ -165,6 +165,37 @@ describe('MetaChartRenderer', () => {
     expect(container.querySelector('[data-legend]')).toBeNull()
   })
 
+  // v2-d: multi-series legend over series names (bar grouped/stacked) + v2-d-b2 (multi-line).
+  it('renders the multi-series legend (series names) for a bar series split', async () => {
+    const { container } = mount({
+      chartData: { chartType: 'bar', dataPoints: [{ label: 'X', value: 1 }], series: [{ name: 'A', data: [1] }, { name: 'B', data: [0] }] },
+    })
+    await flushPromises()
+    const legend = container.querySelector('[data-legend="series"]')
+    expect(legend).toBeTruthy()
+    expect(legend?.textContent).toContain('A')
+    expect(legend?.textContent).toContain('B')
+  })
+
+  it('v2-d-b2: renders the multi-series legend for a multi-line chart too', async () => {
+    const { container } = mount({
+      chartData: { chartType: 'line', dataPoints: [{ label: 'Jan', value: 1 }], series: [{ name: 'A', data: [1] }, { name: 'B', data: [2] }] },
+    })
+    await flushPromises()
+    const legend = container.querySelector('[data-legend="series"]')
+    expect(legend).toBeTruthy()
+    expect(legend?.textContent).toContain('A')
+  })
+
+  it('hides the multi-series legend when showLegend is false', async () => {
+    const { container } = mount({
+      chartData: { chartType: 'line', dataPoints: [{ label: 'Jan', value: 1 }], series: [{ name: 'A', data: [1] }] },
+      displayConfig: { showLegend: false },
+    })
+    await flushPromises()
+    expect(container.querySelector('[data-legend="series"]')).toBeNull()
+  })
+
   it('does NOT init ECharts for number/table (HTML-rendered)', async () => {
     const num = mount({ chartData: numberData })
     await flushPromises()

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -779,8 +779,12 @@ describe('MetaDashboardView', () => {
     await setSelect(aggSelect, 'avg')
     expect(seriesSelectOf(container)).toBeTruthy()
     expect(Array.from(barModeSelectOf(container)!.options).map((o) => o.value)).toEqual(['grouped'])
-    // non-bar → both hidden
+    // v2-d-b2: line shows the picker too, but NEVER the barMode control (lines don't stack/group)
     await setSelect(typeSelect, 'line')
+    expect(seriesSelectOf(container)).toBeTruthy()
+    expect(barModeSelectOf(container)).toBeNull()
+    // number → both hidden
+    await setSelect(typeSelect, 'number')
     expect(seriesSelectOf(container)).toBeNull()
     expect(barModeSelectOf(container)).toBeNull()
   })
@@ -926,5 +930,39 @@ describe('MetaDashboardView', () => {
       displayConfig: expect.objectContaining({ barMode: 'grouped' }),
     }))
     vi.useRealTimers()
+  })
+
+  it('v2-d-b2: a line chart carries dataSource.seriesByFieldId but no display.barMode (create + preview)', async () => {
+    const { client, fetchFn } = mockClient([fakeDashboard({ panels: [] })], [])
+    const previewSpy = vi.spyOn(client, 'previewChartData').mockResolvedValue({ chartType: 'line', dataPoints: [{ label: 'A', value: 1 }] })
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    vi.useFakeTimers()
+    await openCreateForm(container)
+    const nameInput = container.querySelector('[data-field="chart-name"]') as HTMLInputElement
+    nameInput.value = 'Multi line'; nameInput.dispatchEvent(new Event('input')); await nextTick()
+    await setSelect(typeSelectOf(container), 'line')
+    await setSelect(seriesSelectOf(container)!, 'fld_amount')   // line + series; barMode control not shown
+
+    // preview carries the series, no barMode
+    await vi.advanceTimersByTimeAsync(300); await nextTick()
+    expect(previewSpy).toHaveBeenLastCalledWith('sheet_1', expect.objectContaining({
+      chartType: 'line',
+      dataSource: expect.objectContaining({ seriesByFieldId: 'fld_amount' }),
+    }))
+    const previewArg = previewSpy.mock.calls.at(-1)![1] as { displayConfig?: { barMode?: unknown } }
+    expect(previewArg.displayConfig?.barMode).toBeUndefined()
+    vi.useRealTimers()
+
+    // create carries series, no barMode
+    ;(container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement).click()
+    await flushPromises()
+    const post = fetchFn.mock.calls.find(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'POST' && url.includes('/charts') && !url.includes('preview-data'),
+    )
+    const body = JSON.parse(post![1].body as string)
+    expect(body.type).toBe('line')
+    expect(body.dataSource.seriesByFieldId).toBe('fld_amount')
+    expect(body.display.barMode).toBeUndefined()
   })
 })


### PR DESCRIPTION
Frontend half of **v2-d-b2** (multi-series line), on the merged backend (#2316). **b2 only**; b3 untouched. Frontend-only.

## Changes (per the locked four points)
- **`buildChartOption`** — line branch renders `chartData.series` as **N overlaid lines (no stack)**; the **area variant is preserved** — every line keeps its `areaStyle` when `variant: 'area'`.
- **`MetaDashboardView`** — series picker now offered for `line` too (`seriesByAllowed = bar || line`); the **`barMode` control stays bar-only** (lines never stack/group); `buildChartInput` carries `seriesByFieldId` for line but **not** `barMode`.
- **`MetaChartRenderer`** — `hasSeriesLegend` relaxed to `bar || line` (multi-line legend), comment updated.

## Tests
- `buildChartOption`: multi-line (no stack) / **area + multi-line (each line keeps areaStyle)** / single-line regression; pie inert.
- dashboard form: line series create + preview carry `seriesByFieldId` with **no** `barMode`; the b1 visibility test updated (line shows the picker, no barMode control).
- `MetaChartRenderer`: multi-series legend for **bar + line** + hidden when `showLegend:false`.
- 4 importer specs **84/84**; `vue-tsc -b` clean.

## Transitive-mounter sweep + revert A/B (per request)
Ran all **10** specs that mount `MultitableWorkbench` (embeds the dashboard): **8 pass**. The 2 failures — `workbench-manager-flow > timeline config` and `workbench-view > workflow designer` — are **pre-existing env failures**, proven by **verify-by-revert**: with my `src/multitable/` reverted to `origin/main`, the same 2 fail identically. Not caused by this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)