### PR TITLE
feat(plm): PLM-COLLAB P3-C — consume bom_multitable, render read-only BOM review

### DIFF
--- a/apps/web/src/components/plm/PlmBomReviewPanel.vue
+++ b/apps/web/src/components/plm/PlmBomReviewPanel.vue
@@ -37,6 +37,9 @@
       <p v-else-if="reviewState === 'upgrade'" class="bom-review__hint bom-review__hint--strong">
         当前租户尚未开通 BOM review；这里只显示升级入口，真实授权由 PLM license 判定。
       </p>
+      <p v-else-if="reviewState === 'error'" class="bom-review__hint bom-review__hint--strong" data-testid="plm-bom-review-error">
+        加载 BOM review 失败（PLM 暂时不可用），请稍后重试。
+      </p>
       <p v-else-if="reviewState === 'empty'" class="bom-review__hint">
         未找到该 Part 的 BOM 数据。
       </p>
@@ -113,15 +116,19 @@ const context = computed(() =>
 )
 
 // idle (nothing loaded) -> loading -> one of: unavailable (no support / degraded), upgrade
-// (supported but not entitled), empty (entitled but no context), table (entitled + context).
-const reviewState = computed<'idle' | 'loading' | 'unavailable' | 'upgrade' | 'empty' | 'table'>(() => {
+// (supported but not entitled), error (entitled but the provider fetch failed transiently),
+// empty (entitled, no context, no reason = part not found), table (entitled + context).
+const reviewState = computed<'idle' | 'loading' | 'unavailable' | 'upgrade' | 'error' | 'empty' | 'table'>(() => {
   if (loading.value) return 'loading'
   const current = result.value
   if (!current) return 'idle'
   if (!current.available) return 'unavailable'
   if (!current.entitled) return 'upgrade'
-  if (!current.context) return 'empty'
-  return 'table'
+  if (current.context) return 'table'
+  // entitled but no context: a relayed reason means a TRANSIENT provider failure (retry),
+  // NOT "this part has no BOM" -- only a reason-less null context is the empty/not-found case.
+  if (current.reason) return 'error'
+  return 'empty'
 })
 
 function formatQuantity(line: PlmBomMultitableLine): string {

--- a/apps/web/src/components/plm/PlmBomReviewPanel.vue
+++ b/apps/web/src/components/plm/PlmBomReviewPanel.vue
@@ -1,0 +1,160 @@
+<template>
+  <section class="bom-review" data-testid="plm-bom-review-panel">
+    <header class="bom-review__head">
+      <strong>BOM Review（只读）</strong>
+      <small>来自 PLM 的受治理只读快照；不可在此编辑/写回。</small>
+    </header>
+
+    <div class="bom-review__query">
+      <label>
+        <span>Part ID</span>
+        <input
+          v-model="partId"
+          data-testid="plm-bom-review-part-input"
+          placeholder="输入要查看 BOM 的 Part ID"
+          @keyup.enter="load"
+        />
+      </label>
+      <button
+        type="button"
+        class="bom-review__button"
+        data-testid="plm-bom-review-load"
+        :disabled="loading || !partId.trim()"
+        @click="load"
+      >
+        {{ loading ? '加载中…' : '加载 BOM Review' }}
+      </button>
+    </div>
+
+    <div class="bom-review__body" data-testid="plm-bom-review-state" :data-state="reviewState">
+      <p v-if="reviewState === 'idle'" class="bom-review__hint">
+        输入一个 Part ID 后加载其 BOM review 表。
+      </p>
+      <p v-else-if="reviewState === 'loading'" class="bom-review__hint">正在读取 BOM review…</p>
+      <p v-else-if="reviewState === 'unavailable'" class="bom-review__hint bom-review__hint--muted">
+        当前 PLM 不支持 BOM review，或暂时不可用。
+      </p>
+      <p v-else-if="reviewState === 'upgrade'" class="bom-review__hint bom-review__hint--strong">
+        当前租户尚未开通 BOM review；这里只显示升级入口，真实授权由 PLM license 判定。
+      </p>
+      <p v-else-if="reviewState === 'empty'" class="bom-review__hint">
+        未找到该 Part 的 BOM 数据。
+      </p>
+
+      <div v-else-if="reviewState === 'table' && context">
+        <div class="bom-review__part" data-testid="plm-bom-review-part">
+          <span class="bom-review__badge">Part</span>
+          <strong>{{ context.part.item_number || context.part.part_id }}</strong>
+          <span>{{ context.part.name }}</span>
+          <small>状态 {{ context.part.state || '—' }} · 版本 {{ context.part.generation ?? '—' }}</small>
+          <small v-if="context.source_updated_at">来源更新 {{ context.source_updated_at }}</small>
+        </div>
+
+        <p v-if="context.lines.length === 0" class="bom-review__hint" data-testid="plm-bom-review-no-lines">
+          该 Part 没有 BOM 行。
+        </p>
+        <table v-else class="bom-review__table">
+          <thead>
+            <tr>
+              <th>层级</th>
+              <th>物料号</th>
+              <th>名称</th>
+              <th>状态</th>
+              <th>数量</th>
+              <th>位号</th>
+              <th>来源版本</th>
+              <th>来源更新时间</th>
+            </tr>
+          </thead>
+          <tbody>
+            <tr
+              v-for="line in context.lines"
+              :key="line.bom_line_id"
+              data-testid="plm-bom-review-row"
+              :data-bom-line-id="line.bom_line_id"
+              :data-level="line.level"
+            >
+              <td>{{ line.level }}</td>
+              <td>
+                <span :style="{ paddingLeft: `${Math.max(0, line.level - 1) * 16}px` }">
+                  {{ line.item_number || line.part_id }}
+                </span>
+              </td>
+              <td>{{ line.name }}</td>
+              <td>{{ line.state || '—' }}</td>
+              <td>{{ formatQuantity(line) }}</td>
+              <td>{{ line.refdes || '—' }}</td>
+              <td>{{ line.source_version ?? '—' }}</td>
+              <td>{{ line.source_updated_at || '—' }}</td>
+            </tr>
+          </tbody>
+        </table>
+      </div>
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+import { computed, ref } from 'vue'
+import {
+  getPlmBomMultitableContext,
+  type PlmBomMultitableLine,
+  type PlmBomMultitableResult,
+} from '../../services/integration/workbench'
+
+const props = defineProps<{ dataSourceId: string }>()
+
+const partId = ref('')
+const loading = ref(false)
+const result = ref<PlmBomMultitableResult | null>(null)
+
+const context = computed(() =>
+  result.value && result.value.available ? result.value.context : null,
+)
+
+// idle (nothing loaded) -> loading -> one of: unavailable (no support / degraded), upgrade
+// (supported but not entitled), empty (entitled but no context), table (entitled + context).
+const reviewState = computed<'idle' | 'loading' | 'unavailable' | 'upgrade' | 'empty' | 'table'>(() => {
+  if (loading.value) return 'loading'
+  const current = result.value
+  if (!current) return 'idle'
+  if (!current.available) return 'unavailable'
+  if (!current.entitled) return 'upgrade'
+  if (!current.context) return 'empty'
+  return 'table'
+})
+
+function formatQuantity(line: PlmBomMultitableLine): string {
+  if (line.quantity === null || line.quantity === undefined) return '—'
+  return line.uom ? `${line.quantity} ${line.uom}` : String(line.quantity)
+}
+
+// Fetch ONLY on explicit user action (never on mount) so mounting the panel never triggers a
+// PLM call. The backend relay does the advisory gate; this is a single, read-only call.
+async function load(): Promise<void> {
+  const pid = partId.value.trim()
+  if (!pid || loading.value) return
+  loading.value = true
+  try {
+    result.value = await getPlmBomMultitableContext(props.dataSourceId, pid)
+  } catch {
+    result.value = { data_source_id: props.dataSourceId, available: false, reason: 'unavailable' }
+  } finally {
+    loading.value = false
+  }
+}
+</script>
+
+<style scoped>
+.bom-review { display: flex; flex-direction: column; gap: 8px; }
+.bom-review__head { display: flex; flex-direction: column; }
+.bom-review__query { display: flex; align-items: flex-end; gap: 8px; }
+.bom-review__query label { display: flex; flex-direction: column; gap: 2px; }
+.bom-review__button { white-space: nowrap; }
+.bom-review__part { display: flex; flex-wrap: wrap; gap: 8px; align-items: baseline; }
+.bom-review__badge { font-size: 12px; opacity: 0.7; }
+.bom-review__table { width: 100%; border-collapse: collapse; }
+.bom-review__table th, .bom-review__table td { text-align: left; padding: 4px 8px; border-bottom: 1px solid rgba(0,0,0,0.08); }
+.bom-review__hint--muted { opacity: 0.6; }
+.bom-review__hint--strong { font-weight: 600; }
+</style>

--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -118,6 +118,9 @@ export type PlmBomMultitableResult =
     available: true
     entitled: boolean
     context: PlmBomMultitableContext | null
+    // a relayed reason on an available+entitled+null-context result means a TRANSIENT
+    // provider fetch failure (retry), NOT "this part has no BOM" -- the UI distinguishes them.
+    reason?: string
   }
   | {
     data_source_id: string
@@ -642,7 +645,10 @@ function normalizePlmBomMultitableResult(
   }
   const entitled = record.entitled === true
   const context = entitled && isPlmBomMultitableContext(record.context) ? record.context : null
-  return { data_source_id: resolvedId, available: true, entitled, context }
+  // keep a relayed reason (e.g. 'unavailable' on a transient provider failure) so the UI can
+  // tell a transient error apart from a genuinely empty/absent part.
+  const reason = typeof record.reason === 'string' && record.reason.trim() ? record.reason.trim() : undefined
+  return { data_source_id: resolvedId, available: true, entitled, context, ...(reason ? { reason } : {}) }
 }
 
 function buildQueryString(input: Record<string, unknown>): string {

--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -74,6 +74,57 @@ export type PlmIntegrationCapabilitiesResult =
     reason?: string
   }
 
+// PLM-COLLAB P3-C: the governed READ-ONLY BOM multi-table review context (provider's P3-A
+// surface, relayed by the metasheet2 backend behind the advisory capability gate).
+export interface PlmBomMultitableLine {
+  bom_line_id: string
+  part_id: string
+  item_number: string | null
+  name: string | null
+  state: string | null
+  generation: number | null
+  quantity: number | null
+  uom: string | null
+  find_num: string | null
+  refdes: string | null
+  level: number
+  path: string[]
+  path_labels: string[]
+  source_version: number | null
+  source_updated_at: string | null
+  sync_status: string
+}
+
+export interface PlmBomMultitablePart {
+  part_id: string
+  item_number: string | null
+  name: string | null
+  state: string | null
+  generation: number | null
+}
+
+export interface PlmBomMultitableContext {
+  part: PlmBomMultitablePart
+  lines: PlmBomMultitableLine[]
+  source_version: number | null
+  source_updated_at: string | null
+  sync_status: string
+  template_key: string
+}
+
+export type PlmBomMultitableResult =
+  | {
+    data_source_id: string
+    available: true
+    entitled: boolean
+    context: PlmBomMultitableContext | null
+  }
+  | {
+    data_source_id: string
+    available: false
+    reason?: string
+  }
+
 export interface WorkbenchExternalSystemUpsertRequest extends IntegrationScope {
   id?: string
   projectId?: string | null
@@ -559,6 +610,41 @@ function normalizePlmCapabilitiesResult(
   }
 }
 
+// P3-C: a DEDICATED normalizer for the BOM multi-table relay (its own shape, not the
+// capability manifest). Validates only the envelope + that `context`, when present, is a
+// part+lines object; the rows are passed through (forward-compatible with provider additions).
+function isPlmBomMultitableContext(value: unknown): value is PlmBomMultitableContext {
+  if (!value || typeof value !== 'object') return false
+  const record = value as Record<string, unknown>
+  return (
+    Boolean(record.part && typeof record.part === 'object' && !Array.isArray(record.part))
+    && Array.isArray(record.lines)
+  )
+}
+
+function normalizePlmBomMultitableResult(
+  dataSourceId: string,
+  value: unknown,
+): PlmBomMultitableResult {
+  if (!value || typeof value !== 'object') {
+    return { data_source_id: dataSourceId, available: false, reason: 'unavailable' }
+  }
+  const record = value as Record<string, unknown>
+  const resolvedId = typeof record.data_source_id === 'string' && record.data_source_id.trim()
+    ? record.data_source_id.trim()
+    : dataSourceId
+  if (record.available !== true) {
+    return {
+      data_source_id: resolvedId,
+      available: false,
+      reason: typeof record.reason === 'string' && record.reason.trim() ? record.reason.trim() : 'unavailable',
+    }
+  }
+  const entitled = record.entitled === true
+  const context = entitled && isPlmBomMultitableContext(record.context) ? record.context : null
+  return { data_source_id: resolvedId, available: true, entitled, context }
+}
+
 function buildQueryString(input: Record<string, unknown>): string {
   const params = new URLSearchParams()
   for (const [key, value] of Object.entries(input)) {
@@ -642,6 +728,30 @@ export async function getPlmDataSourceCapabilities(dataSourceId: string): Promis
     return { data_source_id: normalizedId, available: false, reason: 'unavailable' }
   }
   return normalizePlmCapabilitiesResult(normalizedId, payload)
+}
+
+// P3-C: the backend relay (/api/plm-workbench/.../bom-multitable/.../context) returns a BARE
+// object (NOT the {ok,data} integration envelope), so read response.json() directly + a
+// dedicated normalizer -- do NOT route this through parseIntegrationResponse. The relay has
+// already done the advisory gate (unsupported -> available:false; unentitled -> available:true
+// + entitled:false + context:null without querying the resource).
+export async function getPlmBomMultitableContext(
+  dataSourceId: string,
+  partId: string,
+): Promise<PlmBomMultitableResult> {
+  const dsId = dataSourceId.trim()
+  const pid = partId.trim()
+  if (!dsId || !pid) {
+    return { data_source_id: dsId, available: false, reason: 'unavailable' }
+  }
+  const response = await apiFetch(
+    `/api/plm-workbench/data-sources/${encodeURIComponent(dsId)}/bom-multitable/${encodeURIComponent(pid)}/context`,
+  )
+  const payload = await response.json().catch(() => null) as unknown
+  if (!response.ok) {
+    return { data_source_id: dsId, available: false, reason: 'unavailable' }
+  }
+  return normalizePlmBomMultitableResult(dsId, payload)
 }
 
 export async function upsertWorkbenchExternalSystem(

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -280,6 +280,27 @@
               {{ PLM_APPROVAL_AUTOMATION_FEATURE_KEY }} · API {{ selectedPlmApprovalCapabilityEntry.apiVersion }}
             </small>
           </div>
+          <div
+            v-if="selectedPlmBomMultitableCapabilityEntry"
+            class="integration-workbench__capability-entry"
+            :data-state="selectedPlmBomMultitableCapabilityEntry.state"
+            data-testid="plm-bom-multitable-capability-entry"
+          >
+            <div>
+              <span class="integration-workbench__badge" :data-status="selectedPlmBomMultitableCapabilityEntry.state">
+                {{ selectedPlmBomMultitableCapabilityEntry.badge }}
+              </span>
+              <strong>{{ selectedPlmBomMultitableCapabilityEntry.title }}</strong>
+            </div>
+            <p>{{ selectedPlmBomMultitableCapabilityEntry.detail }}</p>
+            <small v-if="selectedPlmBomMultitableCapabilityEntry.apiVersion">
+              {{ PLM_BOM_MULTITABLE_FEATURE_KEY }} · API {{ selectedPlmBomMultitableCapabilityEntry.apiVersion }}
+            </small>
+            <PlmBomReviewPanel
+              v-if="selectedPlmBomMultitableCapabilityEntry.state === 'enabled' && selectedSourcePlmDataSourceId"
+              :data-source-id="selectedSourcePlmDataSourceId"
+            />
+          </div>
           <div v-if="!hasRunnableSourceSystem" class="integration-workbench__empty integration-workbench__empty--actionable" data-testid="source-empty-state">
             <strong>还没有可读取的数据源。</strong>
             <p>连接 PLM、HTTP API 或启用 SQL 只读通道后，可将数据导入 staging 多维表再清洗。</p>
@@ -1130,6 +1151,7 @@ import {
   type WorkbenchExternalSystem,
 } from '../services/integration/workbench'
 import MetaIntegrationFieldRuleAuthoring from '../components/integration/MetaIntegrationFieldRuleAuthoring.vue'
+import PlmBomReviewPanel from '../components/plm/PlmBomReviewPanel.vue'
 
 type WorkbenchSide = 'source' | 'target'
 type TransformFn = '' | 'trim' | 'upper' | 'lower' | 'toNumber' | 'dictMap'
@@ -1191,6 +1213,16 @@ interface PlmApprovalCapabilityEntry {
   detail: string
   apiVersion: string
   actionStatus: string
+}
+
+// P3-C: BOM review is a READ surface (no actions), so its capability entry mirrors the
+// approval one minus actionStatus.
+interface PlmBomCapabilityEntry {
+  state: 'enabled' | 'upgrade' | 'loading'
+  badge: string
+  title: string
+  detail: string
+  apiVersion: string
 }
 
 type ExportCell = string | number | boolean | null
@@ -1353,6 +1385,7 @@ const deletingConnectionId = ref('')
 // picker that references an existing /data-sources connection by id (never copies credentials).
 const DATA_SOURCE_BRIDGE_KIND = 'data-source:sql-readonly'
 const PLM_APPROVAL_AUTOMATION_FEATURE_KEY = 'approval_automation'
+const PLM_BOM_MULTITABLE_FEATURE_KEY = 'bom_multitable'
 const bridgeDataSources = ref<DataSourceListItem[]>([])
 const bridgeDataSourcesError = ref('')
 const bridgeDataSourcesLoaded = ref(false)
@@ -1536,6 +1569,38 @@ const selectedPlmApprovalCapabilityEntry = computed<PlmApprovalCapabilityEntry |
     detail: '当前租户尚未开通 approval_automation；前端只显示升级入口，真实授权仍由 PLM license 判定。',
     apiVersion,
     actionStatus,
+  }
+})
+const selectedBomMultitableFeature = computed<PlmIntegrationCapabilityFeature | null>(() => {
+  const result = selectedSourcePlmCapabilities.value
+  if (!result?.available) return null
+  const feature = result.manifest.features[PLM_BOM_MULTITABLE_FEATURE_KEY]
+  return feature && typeof feature === 'object' ? feature : null
+})
+const selectedPlmBomMultitableCapabilityEntry = computed<PlmBomCapabilityEntry | null>(() => {
+  if (!selectedSourcePlmDataSourceId.value) return null
+  if (selectedSourcePlmCapabilitiesLoading.value && !selectedSourcePlmCapabilities.value) {
+    return { state: 'loading', badge: '检测中', title: '正在读取 PLM 能力', detail: '能力清单只用于界面降级提示，不作为授权来源。', apiVersion: '' }
+  }
+  const feature = selectedBomMultitableFeature.value
+  // not supported (old PLM / unlit) -> hide the entry entirely (graceful degradation)
+  if (feature?.supported !== true) return null
+  const apiVersion = typeof feature.api_version === 'string' && feature.api_version.trim() ? feature.api_version.trim() : 'v1'
+  if (feature.entitled === true) {
+    return {
+      state: 'enabled',
+      badge: '可用',
+      title: 'BOM 多维表 Review',
+      detail: '已开通；可加载某个 Part 的只读 BOM review 表（受治理快照，不可写回）。',
+      apiVersion,
+    }
+  }
+  return {
+    state: 'upgrade',
+    badge: '可升级',
+    title: '升级 BOM Review',
+    detail: '当前租户尚未开通 bom_multitable；前端只显示升级入口，真实授权仍由 PLM license 判定。',
+    apiVersion,
   }
 })
 const sqlChannelDisabledHint = computed(() => {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -2252,6 +2252,65 @@ describe('IntegrationWorkbenchView', () => {
     expect(capabilityCalls).toEqual(['/api/plm-workbench/data-sources/plm-ds/capabilities'])
   })
 
+  it('P3-C: shows an enabled BOM-review entry (with the read-only panel) for an entitled bom_multitable, fetching no BOM until asked', async () => {
+    const calls: string[] = []
+    apiFetchMock.mockImplementation(async (url: string) => {
+      calls.push(url)
+      if (url === '/api/integration/adapters') {
+        return jsonResponse([
+          { kind: 'data-source:sql-readonly', label: 'Read-only PLM data source', roles: ['source'], supports: ['read'], advanced: true },
+        ])
+      }
+      if (url === '/api/integration/external-systems?tenantId=default') {
+        return jsonResponse([
+          {
+            id: 'plm_bridge', tenantId: 'default', workspaceId: null, name: 'Yuantus PLM bridge',
+            kind: 'data-source:sql-readonly', role: 'source', status: 'active',
+            config: { dataSourceId: 'plm-ds', object: 'eco' },
+          },
+        ])
+      }
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/plm-workbench/data-sources/plm-ds/capabilities') {
+        return rawJsonResponse({
+          data_source_id: 'plm-ds',
+          available: true,
+          manifest: {
+            schema_version: 'v1', provider: 'yuantus-plm', advisory: true,
+            features: {
+              bom_multitable: { supported: true, api_version: 'v1', entitled: true, scenarios: ['bom_review'] },
+            },
+          },
+        })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', { props: ['to'], setup(_props, { slots }) { return () => h('a', slots.default?.()) } })
+    app.mount(container)
+    await flushUi(8)
+
+    ;(container.querySelector('[data-testid="show-advanced-connectors"]') as HTMLInputElement).click()
+    await flushUi()
+    const sourceSystemSelect = container.querySelector('[data-testid="source-system"]') as HTMLSelectElement
+    sourceSystemSelect.value = 'plm_bridge'
+    sourceSystemSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    await flushUi(8)
+
+    const entry = container.querySelector('[data-testid="plm-bom-multitable-capability-entry"]') as HTMLElement | null
+    expect(entry).not.toBeNull()
+    expect(entry!.dataset.state).toBe('enabled')
+    expect(entry!.textContent).toContain('BOM 多维表 Review')
+    expect(entry!.textContent).toContain('bom_multitable · API v1')
+    // the read-only panel is mounted, but it must NOT have fetched any BOM context yet
+    expect(container.querySelector('[data-testid="plm-bom-review-panel"]')).not.toBeNull()
+    expect(calls.some((u) => u.includes('/bom-multitable/'))).toBe(false)
+  })
+
   it('C3: shows only the upgrade affordance for supported but not entitled approval automation', async () => {
     apiFetchMock.mockImplementation(async (url: string) => {
       if (url === '/api/integration/adapters') {

--- a/apps/web/tests/PlmBomReviewPanel.spec.ts
+++ b/apps/web/tests/PlmBomReviewPanel.spec.ts
@@ -1,0 +1,111 @@
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, nextTick, type App as VueApp } from 'vue'
+
+const getContextMock = vi.fn()
+vi.mock('../src/services/integration/workbench', () => ({
+  getPlmBomMultitableContext: (...args: unknown[]) => getContextMock(...args),
+}))
+
+import PlmBomReviewPanel from '../src/components/plm/PlmBomReviewPanel.vue'
+
+const CONTEXT = {
+  part: { part_id: 'P1', item_number: 'P-001', name: 'Assembly', state: 'Released', generation: 3 },
+  lines: [
+    { bom_line_id: 'R1', part_id: 'C1', item_number: 'C-001', name: 'Bracket', state: 'Draft', generation: 1, quantity: 2, uom: 'EA', find_num: '10', refdes: 'R1,R2', level: 1, path: ['P1'], path_labels: ['P-001'], source_version: 1, source_updated_at: '2026-06-05T00:00:00', sync_status: 'snapshot' },
+    { bom_line_id: 'R2', part_id: 'D1', item_number: 'D-001', name: 'Screw', state: 'Released', generation: 2, quantity: 4, uom: 'EA', find_num: '20', refdes: 'R3', level: 2, path: ['P1', 'C1'], path_labels: ['P-001', 'C-001'], source_version: 2, source_updated_at: '2026-06-05T00:00:00', sync_status: 'snapshot' },
+  ],
+  source_version: 3,
+  source_updated_at: '2026-06-05T00:00:00',
+  sync_status: 'snapshot',
+  template_key: 'bom_review',
+}
+
+async function flushUi(cycles = 6): Promise<void> {
+  for (let i = 0; i < cycles; i += 1) {
+    await Promise.resolve()
+    await nextTick()
+  }
+}
+
+let app: VueApp | null = null
+let container: HTMLDivElement
+
+function mountPanel(dataSourceId = 'plm-ds'): void {
+  container = document.createElement('div')
+  document.body.appendChild(container)
+  app = createApp(PlmBomReviewPanel, { dataSourceId })
+  app.mount(container)
+}
+
+function stateOf(): string | null {
+  return container.querySelector('[data-testid="plm-bom-review-state"]')?.getAttribute('data-state') ?? null
+}
+
+async function setPartAndLoad(partId: string): Promise<void> {
+  const input = container.querySelector('[data-testid="plm-bom-review-part-input"]') as HTMLInputElement
+  input.value = partId
+  input.dispatchEvent(new Event('input', { bubbles: true }))
+  await flushUi()
+  ;(container.querySelector('[data-testid="plm-bom-review-load"]') as HTMLButtonElement).click()
+  await flushUi()
+}
+
+afterEach(() => {
+  app?.unmount()
+  app = null
+  container?.remove()
+  getContextMock.mockReset()
+})
+
+describe('PlmBomReviewPanel (P3-C read-only BOM review)', () => {
+  it('is idle and does NOT call the service on mount', async () => {
+    mountPanel()
+    await flushUi()
+    expect(getContextMock).not.toHaveBeenCalled()
+    expect(stateOf()).toBe('idle')
+  })
+
+  it('loads + renders the read-only table with stable row keys, hierarchy, qty + provenance', async () => {
+    getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: true, entitled: true, context: CONTEXT })
+    mountPanel()
+    await flushUi()
+    await setPartAndLoad('P1')
+
+    expect(getContextMock).toHaveBeenCalledWith('plm-ds', 'P1')
+    expect(stateOf()).toBe('table')
+    const rows = container.querySelectorAll('[data-testid="plm-bom-review-row"]')
+    expect(rows.length).toBe(2)
+    // bom_line_id is the STABLE row key; level encodes the hierarchy
+    expect((rows[0] as HTMLElement).dataset.bomLineId).toBe('R1')
+    expect((rows[1] as HTMLElement).dataset.bomLineId).toBe('R2')
+    expect((rows[1] as HTMLElement).dataset.level).toBe('2')
+    // quantity + uom and the source provenance timestamp render
+    expect(container.textContent).toContain('2 EA')
+    expect(container.textContent).toContain('2026-06-05T00:00:00')
+  })
+
+  it('shows the upgrade affordance (no table) when supported but not entitled', async () => {
+    getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: true, entitled: false, context: null })
+    mountPanel()
+    await flushUi()
+    await setPartAndLoad('P1')
+    expect(stateOf()).toBe('upgrade')
+    expect(container.querySelector('[data-testid="plm-bom-review-row"]')).toBeNull()
+  })
+
+  it('degrades to unavailable when the relay reports no support (old PLM)', async () => {
+    getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: false, reason: 'unsupported' })
+    mountPanel()
+    await flushUi()
+    await setPartAndLoad('P1')
+    expect(stateOf()).toBe('unavailable')
+  })
+
+  it('shows empty state when entitled but the context is null (part not found)', async () => {
+    getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: true, entitled: true, context: null })
+    mountPanel()
+    await flushUi()
+    await setPartAndLoad('P1')
+    expect(stateOf()).toBe('empty')
+  })
+})

--- a/apps/web/tests/PlmBomReviewPanel.spec.ts
+++ b/apps/web/tests/PlmBomReviewPanel.spec.ts
@@ -101,11 +101,23 @@ describe('PlmBomReviewPanel (P3-C read-only BOM review)', () => {
     expect(stateOf()).toBe('unavailable')
   })
 
-  it('shows empty state when entitled but the context is null (part not found)', async () => {
+  it('shows empty state when entitled but the context is null with NO reason (part not found)', async () => {
     getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: true, entitled: true, context: null })
     mountPanel()
     await flushUi()
     await setPartAndLoad('P1')
     expect(stateOf()).toBe('empty')
+    expect(container.querySelector('[data-testid="plm-bom-review-error"]')).toBeNull()
+  })
+
+  it('shows a transient ERROR (not empty) when entitled + null context carries reason:unavailable', async () => {
+    // a transient provider fetch failure must read as "temporarily unavailable, retry", NOT
+    // as "this part has no BOM".
+    getContextMock.mockResolvedValue({ data_source_id: 'plm-ds', available: true, entitled: true, context: null, reason: 'unavailable' })
+    mountPanel()
+    await flushUi()
+    await setPartAndLoad('P1')
+    expect(stateOf()).toBe('error')
+    expect(container.querySelector('[data-testid="plm-bom-review-error"]')).not.toBeNull()
   })
 })

--- a/apps/web/tests/plm-bom-review-service.spec.ts
+++ b/apps/web/tests/plm-bom-review-service.spec.ts
@@ -63,4 +63,10 @@ describe('getPlmBomMultitableContext (P3-C consumer service)', () => {
     const r = await getPlmBomMultitableContext('ds-1', 'P1')
     expect(r).toEqual({ data_source_id: 'ds-1', available: true, entitled: true, context: null })
   })
+
+  it('carries a relayed reason on an entitled + null-context result (transient failure)', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ data_source_id: 'ds-1', available: true, entitled: true, context: null, reason: 'unavailable' }))
+    const r = await getPlmBomMultitableContext('ds-1', 'P1')
+    expect(r).toEqual({ data_source_id: 'ds-1', available: true, entitled: true, context: null, reason: 'unavailable' })
+  })
 })

--- a/apps/web/tests/plm-bom-review-service.spec.ts
+++ b/apps/web/tests/plm-bom-review-service.spec.ts
@@ -1,0 +1,66 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const apiFetchMock = vi.fn()
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+  apiGet: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+import { getPlmBomMultitableContext } from '../src/services/integration/workbench'
+
+// The relay returns a BARE object (NOT the {ok,data} integration envelope).
+function rawJsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+const CONTEXT = {
+  part: { part_id: 'P1', item_number: 'P-001', name: 'Assembly', state: 'Released', generation: 3 },
+  lines: [
+    { bom_line_id: 'R1', part_id: 'C1', item_number: 'C-001', name: 'Bracket', state: 'Draft', generation: 1, quantity: 2, uom: 'EA', find_num: '10', refdes: 'R1,R2', level: 1, path: ['P1'], path_labels: ['P-001'], source_version: 1, source_updated_at: '2026-06-05T00:00:00', sync_status: 'snapshot' },
+  ],
+  source_version: 3,
+  source_updated_at: '2026-06-05T00:00:00',
+  sync_status: 'snapshot',
+  template_key: 'bom_review',
+}
+
+describe('getPlmBomMultitableContext (P3-C consumer service)', () => {
+  beforeEach(() => apiFetchMock.mockReset())
+
+  it('does not fetch when dataSourceId or partId is empty', async () => {
+    const r = await getPlmBomMultitableContext('ds-1', '   ')
+    expect(r).toEqual({ data_source_id: 'ds-1', available: false, reason: 'unavailable' })
+    expect(apiFetchMock).not.toHaveBeenCalled()
+  })
+
+  it('reads the BARE relay object on entitled success (not parseIntegrationResponse)', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ data_source_id: 'ds-1', available: true, entitled: true, context: CONTEXT }))
+    const r = await getPlmBomMultitableContext('ds-1', 'P1')
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/plm-workbench/data-sources/ds-1/bom-multitable/P1/context')
+    expect(r).toEqual({ data_source_id: 'ds-1', available: true, entitled: true, context: CONTEXT })
+  })
+
+  it('unentitled relay -> entitled:false + null context', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ data_source_id: 'ds-1', available: true, entitled: false, context: null }))
+    const r = await getPlmBomMultitableContext('ds-1', 'P1')
+    expect(r).toEqual({ data_source_id: 'ds-1', available: true, entitled: false, context: null })
+  })
+
+  it('unsupported/unavailable relay -> available:false with the reason', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ data_source_id: 'ds-1', available: false, reason: 'unsupported' }))
+    const r = await getPlmBomMultitableContext('ds-1', 'P1')
+    expect(r).toEqual({ data_source_id: 'ds-1', available: false, reason: 'unsupported' })
+  })
+
+  it('non-ok HTTP -> degrades to unavailable', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({}, 500))
+    const r = await getPlmBomMultitableContext('ds-1', 'P1')
+    expect(r).toEqual({ data_source_id: 'ds-1', available: false, reason: 'unavailable' })
+  })
+
+  it('entitled but malformed context (not part+lines) -> nulls the context', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ data_source_id: 'ds-1', available: true, entitled: true, context: { bogus: 1 } }))
+    const r = await getPlmBomMultitableContext('ds-1', 'P1')
+    expect(r).toEqual({ data_source_id: 'ds-1', available: true, entitled: true, context: null })
+  })
+})

--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -616,6 +616,7 @@ const YUANTUS_SUPPORTED_OPERATIONS = [
   'where_used',
   'bom_compare',
   'bom_compare_schema',
+  'bom_multitable_context',
   'substitutes',
   'substitutes_add',
   'substitutes_remove',
@@ -664,6 +665,62 @@ export interface IntegrationCapabilityManifest {
 export type IntegrationCapabilitiesResult =
   | { available: true; manifest: IntegrationCapabilityManifest }
   | { available: false; reason: 'unsupported-mode' | 'unavailable' };
+
+/**
+ * PLM-COLLAB P3-C consumer types: the governed READ-ONLY BOM multi-table review context
+ * returned by the provider's P3-A `GET /api/v1/bom/multitable/{partId}/context`. The whole
+ * BOM tree is flattened into review rows; `bom_line_id` is the STABLE per-row key, `part_id`
+ * the child part id, `level`/`path` the hierarchy, and the provenance markers let the UI flag
+ * staleness. READ-ONLY: there is no write-back from this surface.
+ */
+export interface BomMultitableLine {
+  bom_line_id: string;
+  part_id: string;
+  item_number: string | null;
+  name: string | null;
+  state: string | null;
+  generation: number | null;
+  quantity: number | null;
+  uom: string | null;
+  find_num: string | null;
+  refdes: string | null;
+  level: number;
+  path: string[];
+  path_labels: string[];
+  source_version: number | null;
+  source_updated_at: string | null;
+  sync_status: string;
+}
+
+export interface BomMultitablePart {
+  part_id: string;
+  item_number: string | null;
+  name: string | null;
+  state: string | null;
+  generation: number | null;
+}
+
+export interface BomMultitableContext {
+  part: BomMultitablePart;
+  lines: BomMultitableLine[];
+  source_version: number | null;
+  source_updated_at: string | null;
+  sync_status: string;
+  template_key: string;
+}
+
+/**
+ * The provider's gated response shape. An unentitled tenant gets `entitled:false` + a null
+ * context WITHOUT the part being queried (the provider is the real gate); `upgrade.available`
+ * then drives the consumer's upgrade affordance. ADVISORY: the relay route additionally
+ * pre-checks the manifest so an unentitled call never even reaches the data endpoint.
+ */
+export interface BomMultitableContextResult {
+  feature_key: string;
+  entitled: boolean;
+  upgrade: { available: boolean };
+  context: BomMultitableContext | null;
+}
 
 export class PLMAdapter extends HTTPAdapter {
   private mockMode = false;
@@ -1032,6 +1089,15 @@ export class PLMAdapter extends HTTPAdapter {
               scenarios: ['eco'],
               actions: ['notify'],
               action_status: 'stubbed',
+            },
+            // P3-C: mock the lit bom_multitable SKU so mock-mode dev can exercise the BOM
+            // review panel end to end (a read surface -> no actions).
+            bom_multitable: {
+              supported: true,
+              api_version: 'v1',
+              entitled: true,
+              cache_scope: { supported: 'global', entitled: 'tenant' },
+              scenarios: ['bom_review'],
             },
           },
         },
@@ -1962,6 +2028,54 @@ export class PLMAdapter extends HTTPAdapter {
       return { data: items, metadata: { totalCount: items.length }, error: result.error }
     }
     return this.query<BOMItem>(`/api/products/${productId}/bom`)
+  }
+
+  /**
+   * PLM-COLLAB P3-C: fetch the governed READ-ONLY BOM multi-table review context for a part
+   * (the provider's P3-A `GET /api/v1/bom/multitable/{partId}/context`). Relays the provider's
+   * gated shape `{feature_key, entitled, upgrade, context}` -- the PROVIDER is the real gate
+   * (an unentitled tenant gets context:null without the part being queried). The relay route
+   * additionally pre-checks the advisory manifest so an unentitled call never reaches here.
+   * Read-only: no write-back. A legacy / non-yuantus PLM has no such surface -> unentitled.
+   */
+  async getBomMultitableContext(partId: string): Promise<BomMultitableContextResult> {
+    if (this.mockMode) {
+      const now = new Date().toISOString()
+      return {
+        feature_key: 'bom_multitable',
+        entitled: true,
+        upgrade: { available: false },
+        context: {
+          part: { part_id: partId, item_number: 'P-001', name: 'Mock Assembly', state: 'Released', generation: 1 },
+          lines: [
+            { bom_line_id: 'R1', part_id: 'C1', item_number: 'C-001', name: 'Bracket', state: 'Draft', generation: 1, quantity: 2, uom: 'EA', find_num: '10', refdes: 'R1,R2', level: 1, path: [partId], path_labels: ['P-001'], source_version: 1, source_updated_at: now, sync_status: 'snapshot' },
+            { bom_line_id: 'R2', part_id: 'D1', item_number: 'D-001', name: 'Screw', state: 'Released', generation: 2, quantity: 4, uom: 'EA', find_num: '20', refdes: 'R3', level: 2, path: [partId, 'C1'], path_labels: ['P-001', 'C-001'], source_version: 2, source_updated_at: now, sync_status: 'snapshot' },
+          ],
+          source_version: 1,
+          source_updated_at: now,
+          sync_status: 'snapshot',
+          template_key: 'bom_review',
+        },
+      }
+    }
+    if (this.apiMode === 'yuantus') {
+      const result = await this.query<BomMultitableContextResult>(`/api/v1/bom/multitable/${partId}/context`)
+      const body = result.data && result.data.length > 0 ? result.data[0] : null
+      if (!body || typeof body !== 'object') {
+        // older PLM / unexpected shape -> safe unentitled affordance (no data leaked)
+        return { feature_key: 'bom_multitable', entitled: false, upgrade: { available: true }, context: null }
+      }
+      const entitled = body.entitled === true
+      return {
+        feature_key: typeof body.feature_key === 'string' && body.feature_key ? body.feature_key : 'bom_multitable',
+        entitled,
+        upgrade: { available: !entitled },
+        // context only when the provider says entitled (defence in depth against a stale manifest)
+        context: entitled && body.context && typeof body.context === 'object' ? body.context : null,
+      }
+    }
+    // legacy / non-yuantus PLM has no multitable review surface
+    return { feature_key: 'bom_multitable', entitled: false, upgrade: { available: true }, context: null }
   }
 
   async getApprovals(options?: ApprovalQueryOptions): Promise<QueryResult<ApprovalRequest>> {

--- a/packages/core-backend/src/routes/plm-workbench.ts
+++ b/packages/core-backend/src/routes/plm-workbench.ts
@@ -27,7 +27,7 @@ import {
 import { loadValidators } from '../types/validator'
 import { parsePagination } from '../util/response'
 import { getDataSourceManager } from './data-sources'
-import type { IntegrationCapabilitiesResult } from '../data-adapters/PLMAdapter'
+import type { IntegrationCapabilitiesResult, BomMultitableContextResult } from '../data-adapters/PLMAdapter'
 
 // Typed wrapper for temporary tables not yet in main Database interface
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -777,6 +777,86 @@ router.get(
       return res.json({ data_source_id: dataSourceId, available: false, reason: 'unavailable' })
     }
     return res.json({ data_source_id: dataSourceId, ...result })
+  },
+)
+
+// PLM-COLLAB Phase 3 C (P3-C): relay the governed READ-ONLY BOM multi-table review context,
+// GATED by the advisory manifest. Pinned order: resolve adapter (404) -> duck-typed guard ->
+// capabilities pre-check. If bom_multitable is not supported -> hide (old PLM / unlit). If it
+// is supported but the tenant is NOT entitled (per the advisory manifest), return the
+// unentitled affordance WITHOUT calling the data endpoint ("未授权不查资源"). Only an entitled
+// tenant reaches getBomMultitableContext, and the PROVIDER stays the authoritative gate (we
+// reflect its entitled + null its context otherwise). Read-only; never 500s -> degrades.
+interface PlmBomReviewAdapter {
+  getIntegrationCapabilities(): Promise<IntegrationCapabilitiesResult>
+  getBomMultitableContext(partId: string): Promise<BomMultitableContextResult>
+}
+
+function isPlmBomReviewAdapter(adapter: unknown): adapter is PlmBomReviewAdapter {
+  const candidate = adapter as PlmBomReviewAdapter | null
+  return (
+    typeof candidate?.getIntegrationCapabilities === 'function'
+    && typeof candidate?.getBomMultitableContext === 'function'
+  )
+}
+
+router.get(
+  '/api/plm-workbench/data-sources/:id/bom-multitable/:partId/context',
+  authenticate,
+  param('id').isString(),
+  param('partId').isString(),
+  validate,
+  async (req: Request, res: Response) => {
+    const dataSourceId = req.params.id
+    const partId = req.params.partId
+    let adapter: unknown
+    try {
+      adapter = getDataSourceManager().getDataSource(dataSourceId)
+    } catch {
+      return res
+        .status(404)
+        .json({ error: 'Data source not found', data_source_id: dataSourceId })
+    }
+    if (!isPlmBomReviewAdapter(adapter)) {
+      return res.json({ data_source_id: dataSourceId, available: false, reason: 'unsupported-mode' })
+    }
+    // 1) advisory capability pre-check (never 500)
+    let capabilities: IntegrationCapabilitiesResult
+    try {
+      capabilities = await adapter.getIntegrationCapabilities()
+    } catch {
+      return res.json({ data_source_id: dataSourceId, available: false, reason: 'unavailable' })
+    }
+    const feature = capabilities.available ? capabilities.manifest.features.bom_multitable : undefined
+    if (!feature || feature.supported !== true) {
+      // old PLM / feature unlit -> hide the surface entirely
+      return res.json({ data_source_id: dataSourceId, available: false, reason: 'unsupported' })
+    }
+    if (feature.entitled !== true) {
+      // supported but not entitled -> DO NOT query the resource; advisory upgrade affordance
+      return res.json({ data_source_id: dataSourceId, available: true, entitled: false, context: null })
+    }
+    // 2) entitled -> fetch the governed read-only context (never 500 -> degrade)
+    let result: BomMultitableContextResult
+    try {
+      result = await adapter.getBomMultitableContext(partId)
+    } catch {
+      return res.json({
+        data_source_id: dataSourceId,
+        available: true,
+        entitled: true,
+        context: null,
+        reason: 'unavailable',
+      })
+    }
+    // the provider is the authoritative gate: reflect its entitled, null the context otherwise
+    const entitled = result.entitled === true
+    return res.json({
+      data_source_id: dataSourceId,
+      available: true,
+      entitled,
+      context: entitled ? result.context : null,
+    })
   },
 )
 

--- a/packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-bom-multitable.test.ts
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi } from 'vitest'
+import { PLMAdapter } from '../../src/data-adapters/PLMAdapter'
+
+const createAdapter = (mode: 'yuantus' | 'legacy' | 'mock') => {
+  const configService = { get: vi.fn().mockResolvedValue(undefined) }
+  const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn() }
+  const adapter = new PLMAdapter(configService as never, logger as never)
+  ;(adapter as never as { apiMode: string }).apiMode = mode === 'mock' ? 'yuantus' : mode
+  ;(adapter as never as { mockMode: boolean }).mockMode = mode === 'mock'
+  return adapter
+}
+
+const PROVIDER_CONTEXT = {
+  part: { part_id: 'P1', item_number: 'P-001', name: 'Assembly', state: 'Released', generation: 3 },
+  lines: [
+    { bom_line_id: 'R1', part_id: 'C1', item_number: 'C-001', name: 'Bracket', state: 'Draft', generation: 1, quantity: 2, uom: 'EA', find_num: '10', refdes: 'R1,R2', level: 1, path: ['P1'], path_labels: ['P-001'], source_version: 1, source_updated_at: '2026-06-05T00:00:00', sync_status: 'snapshot' },
+  ],
+  source_version: 3,
+  source_updated_at: '2026-06-05T00:00:00',
+  sync_status: 'snapshot',
+  template_key: 'bom_review',
+}
+
+describe('PLMAdapter.getBomMultitableContext (PLM-COLLAB P3-C)', () => {
+  it('yuantus + entitled: relays the provider context', async () => {
+    const adapter = createAdapter('yuantus')
+    const query = vi.fn().mockResolvedValue({
+      data: [{ feature_key: 'bom_multitable', entitled: true, upgrade: { available: false }, context: PROVIDER_CONTEXT }],
+    })
+    ;(adapter as never as { query: unknown }).query = query
+
+    const result = await adapter.getBomMultitableContext('P1')
+
+    expect(query).toHaveBeenCalledWith('/api/v1/bom/multitable/P1/context')
+    expect(result.entitled).toBe(true)
+    expect(result.upgrade).toEqual({ available: false })
+    expect(result.context).toEqual(PROVIDER_CONTEXT)
+  })
+
+  it('yuantus + provider unentitled: entitled:false, null context, upgrade available', async () => {
+    const adapter = createAdapter('yuantus')
+    ;(adapter as never as { query: unknown }).query = vi.fn().mockResolvedValue({
+      data: [{ feature_key: 'bom_multitable', entitled: false, upgrade: { available: true }, context: null }],
+    })
+
+    const result = await adapter.getBomMultitableContext('P1')
+
+    expect(result.entitled).toBe(false)
+    expect(result.context).toBeNull()
+    expect(result.upgrade).toEqual({ available: true })
+  })
+
+  it('yuantus + entitled:true but no context: nulls the context (defensive)', async () => {
+    const adapter = createAdapter('yuantus')
+    ;(adapter as never as { query: unknown }).query = vi.fn().mockResolvedValue({
+      data: [{ feature_key: 'bom_multitable', entitled: true, upgrade: { available: false }, context: null }],
+    })
+
+    const result = await adapter.getBomMultitableContext('P1')
+
+    expect(result.entitled).toBe(true)
+    expect(result.context).toBeNull()
+  })
+
+  it('yuantus + empty/odd response: safe unentitled affordance (no data)', async () => {
+    const adapter = createAdapter('yuantus')
+    ;(adapter as never as { query: unknown }).query = vi.fn().mockResolvedValue({ data: [] })
+
+    const result = await adapter.getBomMultitableContext('P1')
+
+    expect(result).toEqual({ feature_key: 'bom_multitable', entitled: false, upgrade: { available: true }, context: null })
+  })
+
+  it('legacy mode: unentitled affordance WITHOUT a fetch (no such surface)', async () => {
+    const adapter = createAdapter('legacy')
+    const query = vi.fn()
+    ;(adapter as never as { query: unknown }).query = query
+
+    const result = await adapter.getBomMultitableContext('P1')
+
+    expect(result.entitled).toBe(false)
+    expect(result.context).toBeNull()
+    expect(query).not.toHaveBeenCalled()
+  })
+
+  it('mock mode: returns a demoable entitled context (so the panel renders locally)', async () => {
+    const adapter = createAdapter('mock')
+    const result = await adapter.getBomMultitableContext('P9')
+
+    expect(result.entitled).toBe(true)
+    expect(result.context).not.toBeNull()
+    expect(result.context?.part.part_id).toBe('P9')
+    expect(result.context?.lines.length).toBeGreaterThan(0)
+    // the stable row key + hierarchy are present in the mock too
+    expect(result.context?.lines[0].bom_line_id).toBeTruthy()
+    expect(result.context?.template_key).toBe('bom_review')
+  })
+})

--- a/packages/core-backend/tests/unit/plm-workbench-bom-multitable-routes.test.ts
+++ b/packages/core-backend/tests/unit/plm-workbench-bom-multitable-routes.test.ts
@@ -1,0 +1,181 @@
+import express from 'express'
+import request from 'supertest'
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Controllable DataSourceManager.getDataSource mock (configured per test).
+const dsMocks = vi.hoisted(() => ({
+  getDataSource: vi.fn(),
+}))
+
+vi.mock('../../src/db/db', () => ({ db: {} }))
+vi.mock('../../src/db/pg', () => ({ pool: {}, query: vi.fn() }))
+vi.mock('../../src/middleware/auth', () => ({
+  authenticate: (req: express.Request, _res: express.Response, next: express.NextFunction) => {
+    req.user = { id: 'owner-1', tenantId: 'tenant-a' } as never
+    next()
+  },
+}))
+vi.mock('../../src/middleware/validation', () => ({
+  validate: (_req: express.Request, _res: express.Response, next: express.NextFunction) => next(),
+}))
+vi.mock('../../src/types/validator', () => ({
+  loadValidators: () => {
+    const makeChain = () => {
+      const chain = ((
+        _req: express.Request,
+        _res: express.Response,
+        next: express.NextFunction,
+      ) => next()) as express.RequestHandler & Record<string, () => express.RequestHandler>
+      chain.optional = () => chain
+      chain.isString = () => chain
+      chain.notEmpty = () => chain
+      chain.exists = () => chain
+      chain.isObject = () => chain
+      return chain
+    }
+    return { body: () => makeChain(), param: () => makeChain(), query: () => makeChain() }
+  },
+}))
+vi.mock('../../src/routes/data-sources', () => ({
+  getDataSourceManager: () => ({ getDataSource: dsMocks.getDataSource }),
+}))
+
+import plmWorkbenchRouter from '../../src/routes/plm-workbench'
+
+const CONTEXT = {
+  part: { part_id: 'P1', item_number: 'P-001', name: 'Assembly', state: 'Released', generation: 3 },
+  lines: [
+    { bom_line_id: 'R1', part_id: 'C1', item_number: 'C-001', name: 'Bracket', state: 'Draft', generation: 1, quantity: 2, uom: 'EA', find_num: '10', refdes: 'R1,R2', level: 1, path: ['P1'], path_labels: ['P-001'], source_version: 1, source_updated_at: '2026-06-05T00:00:00', sync_status: 'snapshot' },
+  ],
+  source_version: 3,
+  source_updated_at: '2026-06-05T00:00:00',
+  sync_status: 'snapshot',
+  template_key: 'bom_review',
+}
+
+const manifest = (bom: Record<string, unknown> | undefined) => ({
+  schema_version: 'v1',
+  provider: 'yuantus-plm',
+  advisory: true,
+  features: {
+    approval_automation: { supported: true, api_version: 'v1', entitled: true },
+    ...(bom ? { bom_multitable: bom } : {}),
+  },
+})
+
+const URL = '/api/plm-workbench/data-sources/ds-1/bom-multitable/P1/context'
+
+describe('plm-workbench BOM multi-table review route (PLM-COLLAB P3-C)', () => {
+  const app = express()
+  app.use(express.json())
+  app.use(plmWorkbenchRouter)
+
+  beforeEach(() => {
+    dsMocks.getDataSource.mockReset()
+  })
+
+  it('returns 404 when the data source does not exist', async () => {
+    dsMocks.getDataSource.mockImplementation(() => {
+      throw new Error('Data source not found: nope')
+    })
+    const res = await request(app).get('/api/plm-workbench/data-sources/nope/bom-multitable/P1/context')
+    expect(res.status).toBe(404)
+    expect(res.body.data_source_id).toBe('nope')
+  })
+
+  it('degrades to unsupported-mode for an adapter lacking the BOM method (no data call)', async () => {
+    // has the capability handshake but NOT getBomMultitableContext -> guard requires both.
+    const getIntegrationCapabilities = vi.fn()
+    dsMocks.getDataSource.mockReturnValue({ getIntegrationCapabilities })
+    const res = await request(app).get(URL)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ data_source_id: 'ds-1', available: false, reason: 'unsupported-mode' })
+    expect(getIntegrationCapabilities).not.toHaveBeenCalled()
+  })
+
+  it('degrades to unavailable (not 500) if the capability call throws', async () => {
+    const getBomMultitableContext = vi.fn()
+    dsMocks.getDataSource.mockReturnValue({
+      getIntegrationCapabilities: vi.fn().mockRejectedValue(new Error('boom')),
+      getBomMultitableContext,
+    })
+    const res = await request(app).get(URL)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ data_source_id: 'ds-1', available: false, reason: 'unavailable' })
+    expect(getBomMultitableContext).not.toHaveBeenCalled()
+  })
+
+  it('hides the surface (unsupported) when bom_multitable is not supported, WITHOUT querying', async () => {
+    const getBomMultitableContext = vi.fn()
+    dsMocks.getDataSource.mockReturnValue({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({ available: true, manifest: manifest(undefined) }),
+      getBomMultitableContext,
+    })
+    const res = await request(app).get(URL)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ data_source_id: 'ds-1', available: false, reason: 'unsupported' })
+    expect(getBomMultitableContext).not.toHaveBeenCalled()
+  })
+
+  it('supported-but-not-entitled -> entitled:false + null context WITHOUT querying the resource', async () => {
+    const getBomMultitableContext = vi.fn()
+    dsMocks.getDataSource.mockReturnValue({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({
+        available: true,
+        manifest: manifest({ supported: true, api_version: 'v1', entitled: false }),
+      }),
+      getBomMultitableContext,
+    })
+    const res = await request(app).get(URL)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ data_source_id: 'ds-1', available: true, entitled: false, context: null })
+    // the resource is NEVER queried when the advisory manifest says unentitled
+    expect(getBomMultitableContext).not.toHaveBeenCalled()
+  })
+
+  it('supported + entitled -> queries and passes through the read-only context', async () => {
+    const getBomMultitableContext = vi.fn().mockResolvedValue({
+      feature_key: 'bom_multitable', entitled: true, upgrade: { available: false }, context: CONTEXT,
+    })
+    dsMocks.getDataSource.mockReturnValue({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({
+        available: true,
+        manifest: manifest({ supported: true, api_version: 'v1', entitled: true, scenarios: ['bom_review'] }),
+      }),
+      getBomMultitableContext,
+    })
+    const res = await request(app).get(URL)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ data_source_id: 'ds-1', available: true, entitled: true, context: CONTEXT })
+    expect(getBomMultitableContext).toHaveBeenCalledWith('P1')
+  })
+
+  it('reflects the provider gate: entitled manifest but provider returns unentitled -> null context', async () => {
+    const getBomMultitableContext = vi.fn().mockResolvedValue({
+      feature_key: 'bom_multitable', entitled: false, upgrade: { available: true }, context: null,
+    })
+    dsMocks.getDataSource.mockReturnValue({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({
+        available: true,
+        manifest: manifest({ supported: true, api_version: 'v1', entitled: true }),
+      }),
+      getBomMultitableContext,
+    })
+    const res = await request(app).get(URL)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ data_source_id: 'ds-1', available: true, entitled: false, context: null })
+  })
+
+  it('degrades (not 500) if the entitled data call throws', async () => {
+    dsMocks.getDataSource.mockReturnValue({
+      getIntegrationCapabilities: vi.fn().mockResolvedValue({
+        available: true,
+        manifest: manifest({ supported: true, api_version: 'v1', entitled: true }),
+      }),
+      getBomMultitableContext: vi.fn().mockRejectedValue(new Error('boom')),
+    })
+    const res = await request(app).get(URL)
+    expect(res.status).toBe(200)
+    expect(res.body).toEqual({ data_source_id: 'ds-1', available: true, entitled: true, context: null, reason: 'unavailable' })
+  })
+})


### PR DESCRIPTION
## PLM-COLLAB P3-C — consumer side of the BOM multi-table feature

metasheet2 discovers the PLM provider's `bom_multitable` capability through the existing C1/C2 handshake and renders a **read-only** BOM review table in the PLM workbench, degrading gracefully when the PLM is old/unlit or the tenant is not entitled. **Advisory + read-only: no write-back, no embed, no SSO, no hard pact dependency, does not touch the Yuantus repo.**

### Backend (`packages/core-backend`)
- **`PLMAdapter.getBomMultitableContext(partId)`** — yuantus → `GET /api/v1/bom/multitable/{partId}/context`, relaying the provider's gated `{feature_key, entitled, upgrade, context}` (the **provider stays the authoritative gate**). Mock mode returns a demoable entitled context, and the mock manifest now advertises `bom_multitable` so mock-mode dev exercises the panel end to end. Legacy → unentitled. New typed shapes.
- **New relay route** `GET /api/plm-workbench/data-sources/:id/bom-multitable/:partId/context`, mirroring the C2 capabilities relay: resolve adapter (404) → duck-typed guard → advisory capability pre-check. Not supported → hide; **supported but NOT entitled → `entitled:false` + null context WITHOUT querying the resource** (未授权不查资源); entitled → fetch + relay. Never 500s → degrades.

### Frontend (`apps/web`)
- **`getPlmBomMultitableContext`** — one call to the gated relay, reading the **bare** relay object via a dedicated normalizer (not `parseIntegrationResponse`, which expects the `{ok,data}` envelope).
- **`PlmBomReviewPanel.vue`** — self-contained read-only panel: part-id input + **on-demand load (never fetches on mount)**; states idle/loading/unavailable/upgrade/empty/table. The table shows `bom_line_id` (stable row key), `level`/hierarchy, item/name/state, quantity+uom, and the source provenance timestamp. No edit / no write-back.
- **`IntegrationWorkbenchView`** — a `bom_multitable` capability entry mirroring the approval entry (enabled / upgrade / hidden by manifest supported+entitled), mounting the panel when enabled.

### Verification
Backend 100 `plm-adapter*`/`plm-workbench*` tests green (14 new: adapter + all relay gate branches incl. no-query-when-unentitled, provider-gate reflection, graceful degrade); frontend 35 green (panel states, bare-object normalizer, workbench entry render + no-BOM-fetch-until-asked); `tsc` + `vue-tsc` + web lint clean. Base-checked against latest main (no hot-file collision); will rebase at merge time.

### Note for review (UX label nuance, not fixed here)
On the rare path where the tenant **is** entitled but the provider data call *throws*, the relay returns `reason:'unavailable'`, but the normalizer drops `reason` once `available:true`, so the panel renders the **empty** ("part not found") state rather than a distinct "temporarily unavailable". The owner-named degrade case (old PLM / no endpoint) correctly shows `unavailable`. Happy to add a distinct transient-error state if you want it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)