### PR TITLE
feat(attendance): S2-0 reserve `outdoor_approval` event source against client forgery

### DIFF
--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -26,7 +26,7 @@
     "test:unit": "vitest run tests/unit --reporter=dot",
     "test:integration": "vitest --config vitest.integration.config.ts run tests/integration --reporter=dot",
     "test:integration:after-sales": "vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot",
-    "test:integration:attendance": "vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts tests/integration/attendance-expiry-service.test.ts tests/integration/attendance-unscheduled-reminder.test.ts --reporter=dot",
+    "test:integration:attendance": "vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts tests/integration/attendance-expiry-service.test.ts tests/integration/attendance-unscheduled-reminder.test.ts tests/integration/attendance-outdoor-punch.test.ts --reporter=dot",
     "test:contract": "vitest run tests/contract --reporter=dot",
     "test:e2e:handoff": "npx playwright test --config tests/e2e/playwright.config.ts",
     "test:cache": "npm run build:cache && TEST_USE_DIST=true vitest --config vitest.cache.config.ts run --reporter=dot",

--- a/packages/core-backend/tests/integration/attendance-outdoor-punch.test.ts
+++ b/packages/core-backend/tests/integration/attendance-outdoor-punch.test.ts
@@ -343,4 +343,23 @@ describeDb('② S3 outdoor punch approval (real DB, route-level)', () => {
       await deleteOutdoorFlows()
     }
   })
+
+  it('S2-0: a client cannot forge the reserved source `outdoor_approval` on /punch', async () => {
+    await setOutdoor({ requireApproval: false }, false) // no outdoor approval, no geofence → plain punch path
+    const u = `out-resv-${Date.now().toString(36)}`
+    const t = await mintToken(u, 'attendance:read,attendance:write')
+    try {
+      // Forged reserved source → 422, nothing written (so it can never be mis-classified as approved outdoor).
+      const forged = await punch(t, { eventType: 'check_in', source: 'outdoor_approval', location: INSIDE })
+      expect(forged.status).toBe(422)
+      expect((forged.body as { error?: { code?: string } })?.error?.code).toBe('PUNCH_SOURCE_RESERVED')
+      expect((await counts(u)).events).toHaveLength(0)
+      // A normal source still punches fine (no over-block) and lands with its own source — never outdoor_approval.
+      const ok = await punch(t, { eventType: 'check_in', source: 'mobile', location: INSIDE })
+      expect(ok.status).toBe(200)
+      expect((await counts(u)).events.map((e) => e.source)).toEqual(['mobile'])
+    } finally {
+      await cleanupUser(u)
+    }
+  })
 })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -45,6 +45,11 @@ const REQUEST_TYPES = [
   // ② S3 外勤审批 (#2304): outdoor field-work punch that needs approval before it counts.
   'outdoor_punch',
 ]
+// ② S2-0 (#2325 design-lock): event sources that ONLY a trusted internal writer may set — never accepted
+// from a client. `outdoor_approval` is written solely by the S3 approval path and is the authoritative
+// internal/external classifier for the future S2 in/out merge; if /punch let a client forge it, a normal
+// punch would be counted as an approved outdoor punch. Any client-facing event writer must reject these.
+const RESERVED_EVENT_SOURCES = new Set(['outdoor_approval'])
 const ATTENDANCE_APPROVAL_WORKFLOW_KEY = 'attendance.request'
 const ATTENDANCE_APPROVAL_QUEUE_PERMISSIONS = ['attendance:approve', 'attendance:admin']
 const ATTENDANCE_SCHEDULE_GROUP_SOURCES = new Set(['manual', 'import', 'integration'])
@@ -18883,6 +18888,14 @@ module.exports = {
         const parsed = punchSchema.safeParse(req.body)
         if (!parsed.success) {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+
+        // ② S2-0 (#2325): `outdoor_approval` (and any reserved internal source) must NOT be settable by a
+        // client — only the S3 approval path may write it. Reject a forged source so it cannot be
+        // mis-classified as an approved outdoor punch (a normal /punch never legitimately uses it).
+        if (RESERVED_EVENT_SOURCES.has(String(parsed.data.source ?? '').trim())) {
+          res.status(422).json({ ok: false, error: { code: 'PUNCH_SOURCE_RESERVED', message: 'This punch source is reserved and cannot be set on a punch.' } })
           return
         }
 


### PR DESCRIPTION
## What & why

The S2 in/out-merge **design-lock** (#2325) classifies a punch as approved-outdoor by reading `event.source === 'outdoor_approval'` — a source written **solely** by the S3 approval path. But `/punch` accepts an arbitrary `source` (`punchSchema`'s `source: z.string().optional()`, written as `parsed.data.source ?? 'manual'`), so before this change a client could **forge** `source: 'outdoor_approval'` on a normal punch and have it mis-counted as an approved outdoor punch once S2 merge logic lands.

This is the **P1 finding** the design-lock recorded as **S2-0's hard prerequisite**: "small-but-hard runtime PR — plug the client-forgery hole, add a reverse test, then safely wire S2-1 merge logic."

## Change (13 LOC in the bundle)

- `const RESERVED_EVENT_SOURCES = new Set(['outdoor_approval'])` — sources only a trusted internal writer (the S3 approve branch) may set.
- In the `/punch` handler, **before `enforcePunchConstraints`**, reject a reserved source with `422 PUNCH_SOURCE_RESERVED`. Placing it before constraint enforcement makes the block **settings-independent** (fires regardless of outdoor/geofence config).

### Surface audit (why `/punch` is the only writer to guard)

`/punch` is the only client-facing `attendance_events` writer that takes an arbitrary `source`. The other event INSERTs set their own internal sources: S3 approve (`outdoor_approval`), generic adjustment (`request`). The `context.source` at the preview path is a **response shape, not an INSERT**. Import writes **records, not events**.

## Test (real-DB integration)

`attendance-outdoor-punch.test.ts` → `S2-0: a client cannot forge the reserved source \`outdoor_approval\` on /punch`:
- forged `outdoor_approval` punch → **422 `PUNCH_SOURCE_RESERVED`**, **no event written**;
- a legitimate `mobile` punch in the same setup → **200**, event recorded.

## Verification

- `node --check plugins/plugin-attendance/index.cjs` ✅
- attendance integration suite (real local PG): **100 passed**, outdoor-punch **10/10** incl. the new S2-0 test ✅
- `tsc --noEmit` (core-backend): **0 errors** ✅
- 0 commits behind `origin/main` at push.

## Scope / non-goals

Pure runtime guard + reverse test. **No** S2 merge logic (that is S2-1), no OpenAPI/dist change (the rejected `source` was never part of the request contract), no settings/UI change. Unblocks **S2-1** to trust `source` as the in/out classifier.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---

## Follow-up: align `test:integration:attendance` script with CI

Non-blocking drift surfaced in review: `plugin-tests.yml` runs **4** attendance integration specs but the local `test:integration:attendance` script listed only **3** — `attendance-outdoor-punch.test.ts` was added to CI in #2308 without being added to the convenience script, so a dev running it locally covered less than CI. Appended the missing spec; the script file list is now **identical to CI** (diff-verified) and `pnpm test:integration:attendance` runs all 4 (100 pass locally). Folded here as a distinct commit since this PR already centers on that test.
