### PR TITLE
fix(data-factory): expose values-free C4 apply diagnostics

### DIFF
--- a/plugins/plugin-integration-core/__tests__/stock-preparation-apply-writer.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-apply-writer.test.cjs
@@ -86,6 +86,28 @@ function createRecordsApi({ existing = [] } = {}) {
   }
 }
 
+function createFailingCreateRecordsApi({ error, queryError = null } = {}) {
+  const calls = []
+  return {
+    calls,
+    recordsApi: {
+      async queryRecords(input) {
+        calls.push(['queryRecords', input])
+        if (queryError) throw queryError
+        return []
+      },
+      async createRecord(input) {
+        calls.push(['createRecord', input])
+        throw error || new Error('create failed for P-001 / PART-A / SECRET-OPTION')
+      },
+      async patchRecord(input) {
+        calls.push(['patchRecord', input])
+        throw new Error(`unexpected patch for ${input.recordId}`)
+      },
+    },
+  }
+}
+
 function target(overrides = {}) {
   return {
     sheetId: 'sheet_stock_preparation',
@@ -232,8 +254,99 @@ async function testPermissionAndHumanFieldGuards() {
     recordsApi: api.recordsApi,
   })
   assert.equal(result.counts.failed, 1)
-  assert.equal(result.errors[0].code, 'StockPreparationApplyWriterError')
+  assert.equal(result.errors[0].code, 'target_record_validation_failed')
   assert.equal(api.calls.length, 0, 'human-field guard fails before query/create')
+}
+
+async function testPlainCreateErrorsBecomeTypedValuesFreeDiagnostics() {
+  const api = createFailingCreateRecordsApi({
+    error: new Error('Invalid select option for fld_materialType: PART-A / P-001 / SECRET-OPTION'),
+  })
+
+  const result = await applyStockPreparationPlan({
+    permission: 'write',
+    plan: {
+      decisions: [{
+        decision: DECISIONS.ADD,
+        idempotencyKey: 'key-create-fail',
+        record: {
+          idempotencyKey: 'key-create-fail',
+          projectNo: 'P-001',
+          componentSourceId: 'PART-A',
+          path: '["PART-A"]',
+          active: true,
+        },
+      }],
+    },
+    target: target(),
+    recordsApi: api.recordsApi,
+  })
+
+  assert.equal(result.status, 'failed')
+  assert.equal(result.counts.failed, 1)
+  assert.equal(result.errors[0].code, 'select_option_not_found')
+  assert.equal(result.errors[0].operation, 'createRecord')
+  assert.equal(result.errors[0].message, 'create target row failed: select_option_not_found')
+  assert.equal(api.calls.some((call) => call[0] === 'createRecord'), true, 'create path was exercised')
+
+  const evidence = summarizeApplyResultForEvidence(result)
+  assert.deepEqual(evidence.errorCodes, ['select_option_not_found'])
+  assert.deepEqual(evidence.errorSummaries, [{
+    code: 'select_option_not_found',
+    count: 1,
+    decisions: [DECISIONS.ADD],
+    operations: ['createRecord'],
+  }])
+  const text = JSON.stringify({ result, evidence })
+  assert.equal(text.includes('SECRET-OPTION'), false, 'diagnostics must not expose option values')
+  assert.equal(text.includes('PART-A / P-001'), false, 'diagnostics must not expose row/project values')
+  assert.equal(text.includes('Invalid select option for'), false, 'raw error message must not be surfaced')
+  assert.equal(text.includes('"Error"'), false, 'plain Error must not remain the only diagnostic code')
+}
+
+async function testPlainQueryErrorsBecomeTypedValuesFreeDiagnostics() {
+  const api = createFailingCreateRecordsApi({
+    queryError: new Error('Unknown field fld_idempotency_key for project P-001 / component PART-A'),
+  })
+
+  const result = await applyStockPreparationPlan({
+    permission: 'write',
+    plan: {
+      decisions: [{
+        decision: DECISIONS.ADD,
+        idempotencyKey: 'key-query-fail',
+        record: {
+          idempotencyKey: 'key-query-fail',
+          projectNo: 'P-001',
+          componentSourceId: 'PART-A',
+          path: '["PART-A"]',
+          active: true,
+        },
+      }],
+    },
+    target: target(),
+    recordsApi: api.recordsApi,
+  })
+
+  assert.equal(result.status, 'failed')
+  assert.equal(result.counts.failed, 1)
+  assert.equal(result.errors[0].code, 'field_mapping_failed')
+  assert.equal(result.errors[0].operation, 'queryRecords')
+  assert.equal(result.errors[0].message, 'query target rows failed: field_mapping_failed')
+  assert.equal(api.calls.some((call) => call[0] === 'createRecord'), false, 'query failure blocks create')
+
+  const evidence = summarizeApplyResultForEvidence(result)
+  assert.deepEqual(evidence.errorCodes, ['field_mapping_failed'])
+  assert.deepEqual(evidence.errorSummaries, [{
+    code: 'field_mapping_failed',
+    count: 1,
+    decisions: [DECISIONS.ADD],
+    operations: ['queryRecords'],
+  }])
+  const text = JSON.stringify({ result, evidence })
+  assert.equal(text.includes('P-001'), false, 'diagnostics must not expose project values')
+  assert.equal(text.includes('PART-A'), false, 'diagnostics must not expose component values')
+  assert.equal(text.includes('Unknown field'), false, 'raw query error message must not be surfaced')
 }
 
 async function testFieldIdMapAndDuplicateTargetKey() {
@@ -293,6 +406,8 @@ async function main() {
   await testRerunIsIdempotentForAddDecision()
   await testUpdateAndInactiveNeverCreateMissingTargets()
   await testPermissionAndHumanFieldGuards()
+  await testPlainCreateErrorsBecomeTypedValuesFreeDiagnostics()
+  await testPlainQueryErrorsBecomeTypedValuesFreeDiagnostics()
   await testFieldIdMapAndDuplicateTargetKey()
   testInternals()
 

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
@@ -18,6 +18,9 @@ const {
 const {
   STOCK_PREPARATION_MAIN_TABLE_TEMPLATE,
 } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-templates.cjs'))
+const {
+  DECISIONS,
+} = require(path.join(__dirname, '..', 'lib', 'stock-preparation-conflict-planner.cjs'))
 
 const PHYSICAL_FIELD_ID_MAP = Object.fromEntries(
   STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.fields.map((field) => [field.id, `fld_${field.id}`]),
@@ -97,7 +100,7 @@ function createSourceAdapter(data = basePlmData()) {
   }
 }
 
-function createRecordsApi({ existing = [] } = {}) {
+function createRecordsApi({ existing = [], failCreateWith = null } = {}) {
   const rows = existing.map((entry, index) => ({
     id: entry.id || `rec_${index + 1}`,
     sheetId: entry.sheetId || 'sheet_stock',
@@ -119,6 +122,7 @@ function createRecordsApi({ existing = [] } = {}) {
       },
       async createRecord(input = {}) {
         calls.push(['createRecord', clone(input)])
+        if (failCreateWith) throw failCreateWith
         const record = {
           id: `rec_${rows.length + 1}`,
           sheetId: input.sheetId,
@@ -381,6 +385,49 @@ async function testApplyRequiresTokenRecomputesAndScopesTarget() {
   )
 }
 
+async function testApplySurfacesTypedValuesFreeRowFailureDiagnostics() {
+  const storage = createMemoryStorage()
+  const source = createSourceAdapter()
+  const records = createRecordsApi({
+    failCreateWith: new Error('Invalid select option for fld_material_type: P-001 PART-A secret-label'),
+  })
+  const action = baseAction()
+
+  const dryRun = await dryRunStockPreparationAction({
+    action,
+    parameters: { projectNo: 'P-001' },
+    sourceAdapter: source.adapter,
+    recordsApi: records.recordsApi,
+    tokenStore: storage,
+    plannedAt: '2026-06-04T09:00:00.000Z',
+  })
+
+  const result = await applyStockPreparationAction({
+    action,
+    parameters: { projectNo: 'P-001' },
+    dryRunToken: dryRun.dryRunToken,
+    sourceAdapter: source.adapter,
+    recordsApi: records.recordsApi,
+    tokenStore: storage,
+    permission: 'admin',
+  })
+
+  assert.equal(result.status, 'failed')
+  assert.equal(result.apply.counts.failed, 1)
+  assert.deepEqual(result.apply.errorCodes, ['select_option_not_found'])
+  assert.deepEqual(result.apply.errorSummaries, [{
+    code: 'select_option_not_found',
+    count: 1,
+    decisions: [DECISIONS.ADD],
+    operations: ['createRecord'],
+  }])
+  assert.equal(JSON.stringify(result.evidence).includes('P-001'), false, 'apply evidence hides project value')
+  assert.equal(JSON.stringify(result.evidence).includes('PART-A'), false, 'apply evidence hides component value')
+  assert.equal(JSON.stringify(result.evidence).includes('secret-label'), false, 'apply evidence hides option labels')
+  assert.equal(JSON.stringify(result.evidence).includes('Invalid select option'), false, 'apply evidence hides raw error message')
+  assert.equal(JSON.stringify(result.apply).includes('"Error"'), false, 'plain Error is not the response diagnostic')
+}
+
 async function testApplyDetectsDataShiftAndManualConfirmHold() {
   const storage = createMemoryStorage()
   const originalSource = createSourceAdapter()
@@ -450,6 +497,7 @@ async function main() {
   await testBridgeSourceKindRequiresExplicitMatchingReadPlanAndCanDryRun()
   await testTargetFieldMapIncompleteFailsBeforeReads()
   await testApplyRequiresTokenRecomputesAndScopesTarget()
+  await testApplySurfacesTypedValuesFreeRowFailureDiagnostics()
   await testApplyDetectsDataShiftAndManualConfirmHold()
 
   console.log('stock-preparation-table-actions.test.cjs OK')

--- a/plugins/plugin-integration-core/lib/stock-preparation-apply-writer.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-apply-writer.cjs
@@ -13,6 +13,18 @@ const {
 const { DECISIONS } = require('./stock-preparation-conflict-planner.cjs')
 
 const APPLY_PERMISSIONS = Object.freeze(['write', 'admin'])
+const KNOWN_TARGET_WRITE_ERROR_CODES = Object.freeze(new Set([
+  'create_record_failed',
+  'duplicate_target_key',
+  'field_mapping_failed',
+  'missing_required_field',
+  'patch_record_failed',
+  'select_option_not_found',
+  'target_record_validation_failed',
+  'target_row_not_found',
+  'target_scope_violation',
+  'unsupported_decision',
+]))
 
 class StockPreparationApplyWriterError extends Error {
   constructor(message, details = {}) {
@@ -130,12 +142,12 @@ function assertNoHumanFields(payload, context, humanFields = HUMAN_PRESERVED_FIE
 
 async function findExistingRecord(recordsApi, target, key) {
   const physicalKey = mapFieldName(target.keyField, target.fieldIdMap)
-  const records = await recordsApi.queryRecords({
+  const records = await callRecordsApi('queryRecords', () => recordsApi.queryRecords({
     sheetId: target.sheetId,
     filters: { [physicalKey]: key },
     limit: 2,
     offset: 0,
-  })
+  }))
   if (!Array.isArray(records)) {
     throw new StockPreparationApplyWriterError('queryRecords must return an array', { field: 'recordsApi.queryRecords' })
   }
@@ -154,6 +166,92 @@ function copyPayload(value, field) {
   return { ...value }
 }
 
+function errorName(error) {
+  return typeof (error && error.name) === 'string' && error.name.trim()
+    ? error.name.trim()
+    : ''
+}
+
+function errorRawCode(error) {
+  return typeof (error && error.code) === 'string' && error.code.trim()
+    ? error.code.trim()
+    : ''
+}
+
+function errorMessage(error) {
+  return typeof (error && error.message) === 'string'
+    ? error.message
+    : String(error || '')
+}
+
+function messageMatches(error, pattern) {
+  return pattern.test(errorMessage(error))
+}
+
+function classifyTargetWriteError(error, operation = 'apply') {
+  const detailsCode = typeof (error && error.details && error.details.code) === 'string'
+    ? error.details.code
+    : ''
+  if (KNOWN_TARGET_WRITE_ERROR_CODES.has(detailsCode)) return detailsCode
+
+  const rawCode = errorRawCode(error)
+  if (rawCode === 'FIELD_READONLY' || rawCode === 'FIELD_HIDDEN' || rawCode === 'TARGET_SCOPE_VIOLATION') {
+    return 'target_scope_violation'
+  }
+  if (rawCode === 'VALIDATION_ERROR') {
+    if (messageMatches(error, /invalid (multi-)?select option/i)) return 'select_option_not_found'
+    return 'target_record_validation_failed'
+  }
+
+  const name = errorName(error)
+  if (name === 'StockPreparationApplyWriterError') return 'target_record_validation_failed'
+  if (name === 'RecordNotFoundError' || name === 'MultitableRecordNotFoundError') return 'target_scope_violation'
+  if (name === 'RecordValidationError' || name === 'MultitableRecordValidationError' || name === 'RecordValidationFailedError') {
+    if (messageMatches(error, /invalid (multi-)?select option/i)) return 'select_option_not_found'
+    return 'target_record_validation_failed'
+  }
+  if (name === 'RecordPatchFieldValidationError') {
+    if (messageMatches(error, /select/i)) return 'select_option_not_found'
+    return 'target_record_validation_failed'
+  }
+
+  if (messageMatches(error, /unknown field(id)?/i)) return 'field_mapping_failed'
+  if (messageMatches(error, /invalid (multi-)?select option/i)) return 'select_option_not_found'
+  if (messageMatches(error, /required/i)) return 'missing_required_field'
+  if (messageMatches(error, /insufficient permissions|scope violation|not allowed|readonly|hidden/i)) return 'target_scope_violation'
+  if (messageMatches(error, /validation failed|value must|field is|must be/i)) return 'target_record_validation_failed'
+
+  return operation === 'patchRecord' ? 'patch_record_failed' : 'create_record_failed'
+}
+
+function sanitizeTargetWriteMessage(code, operation = 'apply') {
+  const action = operation === 'patchRecord'
+    ? 'patch target row'
+    : operation === 'createRecord'
+      ? 'create target row'
+      : operation === 'queryRecords'
+        ? 'query target rows'
+        : 'apply target row'
+  return `${action} failed: ${code}`
+}
+
+function wrapTargetWriteError(error, operation) {
+  if (error instanceof StockPreparationApplyWriterError) return error
+  const code = classifyTargetWriteError(error, operation)
+  return new StockPreparationApplyWriterError(sanitizeTargetWriteMessage(code, operation), {
+    code,
+    operation,
+  })
+}
+
+async function callRecordsApi(operation, callback) {
+  try {
+    return await callback()
+  } catch (error) {
+    throw wrapTargetWriteError(error, operation)
+  }
+}
+
 async function applyAddDecision({ recordsApi, target, decision, humanFields }) {
   const key = decisionKey(decision, target)
   const record = copyPayload(decision.record, 'decision.record')
@@ -162,18 +260,18 @@ async function applyAddDecision({ recordsApi, target, decision, humanFields }) {
 
   const existing = await findExistingRecord(recordsApi, target, key)
   if (existing && existing.id) {
-    const updated = await recordsApi.patchRecord({
+    const updated = await callRecordsApi('patchRecord', () => recordsApi.patchRecord({
       sheetId: target.sheetId,
       recordId: existing.id,
       changes: mapRecordFields(record, target.fieldIdMap),
-    })
+    }))
     return { status: 'updated', recordId: updated && updated.id ? updated.id : existing.id }
   }
 
-  const created = await recordsApi.createRecord({
+  const created = await callRecordsApi('createRecord', () => recordsApi.createRecord({
     sheetId: target.sheetId,
     data: mapRecordFields(record, target.fieldIdMap),
-  })
+  }))
   return { status: 'created', recordId: created && created.id }
 }
 
@@ -190,11 +288,11 @@ async function applyPatchDecision({ recordsApi, target, decision, humanFields })
     })
   }
 
-  const updated = await recordsApi.patchRecord({
+  const updated = await callRecordsApi('patchRecord', () => recordsApi.patchRecord({
     sheetId: target.sheetId,
     recordId: existing.id,
     changes: mapRecordFields(patch, target.fieldIdMap),
-  })
+  }))
   return { status: 'updated', recordId: updated && updated.id ? updated.id : existing.id }
 }
 
@@ -208,9 +306,38 @@ function incrementCounts(counts, decision, status) {
 function errorCode(error) {
   return error && error.details && error.details.code
     ? error.details.code
-    : error && error.name
-      ? error.name
-      : 'apply_failed'
+    : classifyTargetWriteError(error)
+}
+
+function errorOperation(error) {
+  return typeof (error && error.details && error.details.operation) === 'string'
+    ? error.details.operation
+    : null
+}
+
+function summarizeApplyErrors(errors = []) {
+  const byCode = new Map()
+  for (const entry of errors) {
+    const code = optionalString(entry && entry.code) || 'apply_failed'
+    const summary = byCode.get(code) || {
+      code,
+      count: 0,
+      decisions: new Set(),
+      operations: new Set(),
+    }
+    summary.count += 1
+    if (entry && entry.decision) summary.decisions.add(entry.decision)
+    if (entry && entry.operation) summary.operations.add(entry.operation)
+    byCode.set(code, summary)
+  }
+  return Array.from(byCode.values())
+    .map((entry) => ({
+      code: entry.code,
+      count: entry.count,
+      decisions: Array.from(entry.decisions).sort(),
+      operations: Array.from(entry.operations).sort(),
+    }))
+    .sort((left, right) => left.code.localeCompare(right.code))
 }
 
 function applyStatus(counts, written) {
@@ -269,11 +396,13 @@ async function applyStockPreparationPlan(input = {}) {
     } catch (error) {
       counts.failed += 1
       const code = errorCode(error)
+      const operation = errorOperation(error)
       errors.push({
         index,
         decision: decision.decision || null,
         code,
-        message: error && error.message ? error.message : String(error),
+        operation,
+        message: sanitizeTargetWriteMessage(code, operation),
       })
       results.push({
         index,
@@ -303,6 +432,7 @@ async function applyStockPreparationPlan(input = {}) {
 }
 
 function summarizeApplyResultForEvidence(result = {}) {
+  const errors = Array.isArray(result.errors) ? result.errors : []
   return {
     ok: result.ok === true,
     status: optionalString(result.status) || 'unknown',
@@ -311,9 +441,8 @@ function summarizeApplyResultForEvidence(result = {}) {
     resultStatuses: Array.isArray(result.results)
       ? Array.from(new Set(result.results.map((entry) => entry.status).filter(Boolean))).sort()
       : [],
-    errorCodes: Array.isArray(result.errors)
-      ? Array.from(new Set(result.errors.map((entry) => entry.code).filter(Boolean))).sort()
-      : [],
+    errorCodes: Array.from(new Set(errors.map((entry) => entry.code).filter(Boolean))).sort(),
+    errorSummaries: summarizeApplyErrors(errors),
   }
 }
 
@@ -327,8 +456,10 @@ module.exports = {
     decisionKey,
     findExistingRecord,
     applyStatus,
+    classifyTargetWriteError,
     mapRecordFields,
     normalizeTarget,
     requireApplyPermission,
+    summarizeApplyErrors,
   },
 }


### PR DESCRIPTION
## Summary
- classify C4 stock-preparation row write failures into stable values-free codes instead of surfacing plain `Error`
- include sanitized `errorCodes` and grouped `errorSummaries` in apply evidence, with decision/operation counts only
- wrap target query/create/patch calls so query-stage field-mapping failures and create-stage select-option failures are distinguishable

## Safety / boundaries
- no C4 retry or entity-machine apply is run by this PR
- no PLM write, external DB write, K3 action, UI, route, migration, RBAC, or auth change
- raw target write messages are not surfaced; tests assert project/component/option values stay out of diagnostics

## Verification
- `node plugins/plugin-integration-core/__tests__/stock-preparation-apply-writer.test.cjs`
- `node plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs`
- `pnpm --filter plugin-integration-core test`
- `git diff --check`

Closes no issue directly; supports the #2253 C4 apply gate diagnosis after the first failed apply attempt.