### PR TITLE
feat(attendance): S2-1 apply in/out merge punch policy

### DIFF
--- a/packages/core-backend/tests/integration/attendance-outdoor-punch.test.ts
+++ b/packages/core-backend/tests/integration/attendance-outdoor-punch.test.ts
@@ -3,6 +3,7 @@ import type { MetaSheetServer } from '../../src/index'
 import * as path from 'path'
 import net from 'net'
 import http from 'http'
+import { randomUUID } from 'crypto'
 import { Pool } from 'pg'
 
 // ② 打卡策略组 S3 外勤审批 — route-level real-DB integration (design-lock
@@ -90,6 +91,8 @@ describeDb('② S3 outdoor punch approval (real DB, route-level)', () => {
   // value left by a previous test never leaks through mergeSettings into this test's policy.
   const setOutdoor = (outdoor: Record<string, unknown> | null, withFence = true) =>
     putSettings({ geoFence: withFence ? FENCE : null, punchPolicy: outdoor ? { outdoor: { requireApproval: false, requireNote: false, approvalFlowId: '', ...outdoor } } : {} })
+  const setMerge = (merge: Record<string, unknown>) =>
+    putSettings({ punchPolicy: { merge: { internalWinsOnIn: false, externalWinsOnOut: false, ...merge } } })
 
   async function counts(userId: string) {
     const ev = (await pool.query(`SELECT event_type, source FROM attendance_events WHERE user_id = $1`, [userId])).rows as { event_type: string; source: string }[]
@@ -98,6 +101,25 @@ describeDb('② S3 outdoor punch approval (real DB, route-level)', () => {
     const reqs = (await pool.query(`SELECT status, metadata -> 'outdoorPunch' ->> 'eventType' AS event_type FROM attendance_requests WHERE user_id = $1 AND request_type = 'outdoor_punch'`, [userId])).rows as { status: string; event_type: string }[]
     return { events: ev, records: rec, recRow, outdoorReqs: reqs }
   }
+  async function recordFor(userId: string, workDate: string) {
+    return (await pool.query(
+      `SELECT first_in_at, last_out_at, work_minutes, status
+       FROM attendance_records
+       WHERE user_id = $1 AND work_date = $2 AND org_id = $3
+       LIMIT 1`,
+      [userId, workDate, ORG]
+    )).rows[0] ?? null
+  }
+  async function eventRows(userId: string, workDate: string) {
+    return (await pool.query(
+      `SELECT event_type, source, occurred_at
+       FROM attendance_events
+       WHERE user_id = $1 AND work_date = $2 AND org_id = $3
+       ORDER BY occurred_at ASC, event_type ASC`,
+      [userId, workDate, ORG]
+    )).rows as { event_type: string; source: string; occurred_at: Date }[]
+  }
+  const iso = (value: unknown) => new Date(value as string | number | Date).toISOString()
   async function cleanupUser(userId: string) {
     await pool.query(`DELETE FROM approval_instances WHERE business_key IN (SELECT 'attendance-request:' || id FROM attendance_requests WHERE user_id = $1)`, [userId]).catch(() => undefined)
     await pool.query(`DELETE FROM attendance_requests WHERE user_id = $1`, [userId]).catch(() => undefined)
@@ -277,21 +299,27 @@ describeDb('② S3 outdoor punch approval (real DB, route-level)', () => {
     }
   })
 
-  it('settings wire: PUT→GET round-trip for punchPolicy.outdoor; partial update preserves unscheduled & merge', async () => {
+  it('settings wire: PUT→GET round-trip for punchPolicy.outdoor/merge; partial update preserves siblings', async () => {
     const flowId = await createOutdoorFlow()
-    await setOutdoor({ requireApproval: true, requireNote: true, approvalFlowId: flowId })
+    await putSettings({
+      punchPolicy: {
+        merge: { internalWinsOnIn: true, externalWinsOnOut: true },
+        outdoor: { requireApproval: true, requireNote: true, approvalFlowId: flowId },
+      },
+    })
     const got = await getSettings()
-    const outdoor = (got.body as { data?: { punchPolicy?: { outdoor?: Record<string, unknown> } } })?.data?.punchPolicy?.outdoor
-    expect(outdoor).toMatchObject({ requireApproval: true, requireNote: true, approvalFlowId: flowId })
+    const pp = (got.body as { data?: { punchPolicy?: { outdoor?: Record<string, unknown>; merge?: Record<string, unknown> } } })?.data?.punchPolicy
+    expect(pp?.outdoor).toMatchObject({ requireApproval: true, requireNote: true, approvalFlowId: flowId })
+    expect(pp?.merge).toMatchObject({ internalWinsOnIn: true, externalWinsOnOut: true })
     // partial update of a sibling (unscheduled) must not clear outdoor
     await putSettings({ punchPolicy: { unscheduled: { mode: 'block' } } })
     const got2 = await getSettings()
-    const pp2 = (got2.body as { data?: { punchPolicy?: { outdoor?: Record<string, unknown>; unscheduled?: { mode?: string }; merge?: unknown } } })?.data?.punchPolicy
+    const pp2 = (got2.body as { data?: { punchPolicy?: { outdoor?: Record<string, unknown>; unscheduled?: { mode?: string }; merge?: Record<string, unknown> } } })?.data?.punchPolicy
     expect(pp2?.unscheduled?.mode).toBe('block')
     expect(pp2?.outdoor).toMatchObject({ requireApproval: true, requireNote: true, approvalFlowId: flowId }) // preserved
-    expect(pp2?.merge).toBeDefined() // sibling preserved
+    expect(pp2?.merge).toMatchObject({ internalWinsOnIn: true, externalWinsOnOut: true }) // sibling preserved
     // restore unscheduled
-    await putSettings({ punchPolicy: { unscheduled: { mode: 'allow' } } })
+    await putSettings({ punchPolicy: { unscheduled: { mode: 'allow' }, merge: { internalWinsOnIn: false, externalWinsOnOut: false } } })
   })
 
   it('P1: generic /requests API cannot create or update an outdoor_punch (must go through /punch)', async () => {
@@ -359,6 +387,84 @@ describeDb('② S3 outdoor punch approval (real DB, route-level)', () => {
       expect(ok.status).toBe(200)
       expect((await counts(u)).events.map((e) => e.source)).toEqual(['mobile'])
     } finally {
+      await cleanupUser(u)
+    }
+  })
+
+  it('S2-1: merge policy independently picks internal check-in and outdoor check-out without rewriting events', async () => {
+    await createOutdoorFlow()
+    await setMerge({ internalWinsOnIn: true, externalWinsOnOut: true })
+    await setOutdoor({ requireApproval: true, requireNote: false, approvalFlowId: '' }, false)
+    const u = `out-merge-${Date.now().toString(36)}`
+    const workDate = '2026-06-05'
+    const outdoorInAt = `${workDate}T08:50:00.000Z`
+    const internalInAt = `${workDate}T09:05:00.000Z`
+    const outdoorOutAt = `${workDate}T18:30:00.000Z`
+    const internalOutAt = `${workDate}T19:00:00.000Z`
+    const t = await mintToken(u, 'attendance:read,attendance:write')
+    try {
+      const outdoorIn = await punch(t, { eventType: 'check_in', occurredAt: outdoorInAt, location: INSIDE, meta: { outdoor: true, note: 'client morning' } })
+      const outdoorOut = await punch(t, { eventType: 'check_out', occurredAt: outdoorOutAt, location: INSIDE, meta: { outdoor: true, note: 'client evening' } })
+      expect(outdoorIn.status).toBe(202)
+      expect(outdoorOut.status).toBe(202)
+      const internalIn = await punch(t, { eventType: 'check_in', occurredAt: internalInAt, source: 'mobile', location: INSIDE })
+      const internalOut = await punch(t, { eventType: 'check_out', occurredAt: internalOutAt, source: 'mobile', location: INSIDE })
+      expect(internalIn.status).toBe(200)
+      expect(internalOut.status).toBe(200)
+
+      const reqIn = (outdoorIn.body as { data?: { request?: { id?: string } } })?.data?.request?.id as string
+      const reqOut = (outdoorOut.body as { data?: { request?: { id?: string } } })?.data?.request?.id as string
+      expect((await approve(reqIn)).status).toBe(200)
+      expect((await approve(reqOut)).status).toBe(200)
+
+      const record = await recordFor(u, workDate)
+      expect(iso(record.first_in_at)).toBe(internalInAt)
+      expect(iso(record.last_out_at)).toBe(outdoorOutAt)
+      expect((await eventRows(u, workDate)).map((row) => `${row.event_type}:${row.source}:${iso(row.occurred_at)}`)).toEqual([
+        `check_in:outdoor_approval:${outdoorInAt}`,
+        `check_in:mobile:${internalInAt}`,
+        `check_out:outdoor_approval:${outdoorOutAt}`,
+        `check_out:mobile:${internalOutAt}`,
+      ])
+    } finally {
+      await setMerge({ internalWinsOnIn: false, externalWinsOnOut: false }).catch(() => undefined)
+      await cleanupUser(u)
+    }
+  })
+
+  it('S2-1: protected record-only first-in survives later mixed internal/outdoor punch recompute', async () => {
+    await setMerge({ internalWinsOnIn: true, externalWinsOnOut: false })
+    await setOutdoor({ requireApproval: false }, false)
+    const u = `out-protect-${Date.now().toString(36)}`
+    const workDate = '2026-06-04'
+    const protectedFirst = `${workDate}T10:00:00.000Z`
+    const outdoorInAt = `${workDate}T08:50:00.000Z`
+    const internalInAt = `${workDate}T09:05:00.000Z`
+    const t = await mintToken(u, 'attendance:read,attendance:write')
+    try {
+      await pool.query(
+        `INSERT INTO attendance_records
+         (id, user_id, org_id, work_date, timezone, first_in_at, last_out_at, work_minutes, late_minutes, early_leave_minutes, status, is_workday, meta, source_batch_id, created_at, updated_at)
+         VALUES ($1, $2, $3, $4, 'UTC', $5, NULL, 0, 0, 0, 'adjusted', true, $6::jsonb, NULL, now(), now())`,
+        [randomUUID(), u, ORG, workDate, protectedFirst, JSON.stringify({ source: 'override-protected' })]
+      )
+      await pool.query(
+        `INSERT INTO attendance_events
+         (id, user_id, org_id, work_date, occurred_at, event_type, source, timezone, location, meta)
+         VALUES ($1, $2, $3, $4, $5, 'check_in', 'outdoor_approval', 'UTC', '{}'::jsonb, '{}'::jsonb)`,
+        [randomUUID(), u, ORG, workDate, outdoorInAt]
+      )
+
+      const internal = await punch(t, { eventType: 'check_in', occurredAt: internalInAt, source: 'mobile', location: INSIDE })
+      expect(internal.status).toBe(200)
+      const record = await recordFor(u, workDate)
+      expect(iso(record.first_in_at)).toBe(protectedFirst)
+      expect((await eventRows(u, workDate)).map((row) => `${row.event_type}:${row.source}:${iso(row.occurred_at)}`)).toEqual([
+        `check_in:outdoor_approval:${outdoorInAt}`,
+        `check_in:mobile:${internalInAt}`,
+      ])
+    } finally {
+      await setMerge({ internalWinsOnIn: false, externalWinsOnOut: false }).catch(() => undefined)
       await cleanupUser(u)
     }
   })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -45,11 +45,12 @@ const REQUEST_TYPES = [
   // ② S3 外勤审批 (#2304): outdoor field-work punch that needs approval before it counts.
   'outdoor_punch',
 ]
+const OUTDOOR_APPROVAL_EVENT_SOURCE = 'outdoor_approval'
 // ② S2-0 (#2325 design-lock): event sources that ONLY a trusted internal writer may set — never accepted
 // from a client. `outdoor_approval` is written solely by the S3 approval path and is the authoritative
-// internal/external classifier for the future S2 in/out merge; if /punch let a client forge it, a normal
+// internal/external classifier for the S2 in/out merge; if /punch let a client forge it, a normal
 // punch would be counted as an approved outdoor punch. Any client-facing event writer must reject these.
-const RESERVED_EVENT_SOURCES = new Set(['outdoor_approval'])
+const RESERVED_EVENT_SOURCES = new Set([OUTDOOR_APPROVAL_EVENT_SOURCE])
 const ATTENDANCE_APPROVAL_WORKFLOW_KEY = 'attendance.request'
 const ATTENDANCE_APPROVAL_QUEUE_PERMISSIONS = ['attendance:approve', 'attendance:admin']
 const ATTENDANCE_SCHEDULE_GROUP_SOURCES = new Set(['manual', 'import', 'integration'])
@@ -114,9 +115,9 @@ const DEFAULT_SETTINGS = {
     weeklyMaxMinutes: null,
     monthlyMaxMinutes: null,
   },
-  // 打卡策略组 (punch-policy group) — LATENT foundation (design-lock #2203 / S0). NOTHING reads this
-  // yet; each enforcement slice wires + exposes its own field (S1 unscheduled-punch / S2 in-out merge /
-  // S3 outdoor approval). All defaults = current behaviour (no regression).
+  // 打卡策略组 (punch-policy group) — shared foundation (design-lock #2203 / S0). Each enforcement
+  // slice wires + exposes its own field (S1 unscheduled-punch / S2 in-out merge / S3 outdoor approval).
+  // All defaults = current behaviour (no regression).
   punchPolicy: {
     unscheduled: { mode: 'allow' },
     merge: { internalWinsOnIn: false, externalWinsOnOut: false },
@@ -13735,6 +13736,131 @@ async function applyImportHeavyTransactionTimeout(client) {
   if (client) client.__attendanceImportStatementTimeoutMs = normalized
 }
 
+async function loadAttendanceRecordForUpdate(client, { userId, workDate, orgId }) {
+  const rows = await client.query(
+    'SELECT * FROM attendance_records WHERE user_id = $1 AND work_date = $2 AND org_id = $3 FOR UPDATE',
+    [userId, workDate, orgId]
+  )
+  return rows[0] ?? null
+}
+
+function attendanceTimeMs(value) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  const time = date.getTime()
+  return Number.isFinite(time) ? time : null
+}
+
+function cloneAttendanceDate(value) {
+  const time = attendanceTimeMs(value)
+  return time == null ? null : new Date(time)
+}
+
+function pickEarliestAttendanceEvent(events) {
+  let selected = null
+  for (const event of events) {
+    const time = attendanceTimeMs(event.occurred_at)
+    if (time == null) continue
+    if (!selected || time < selected.time) selected = { time, value: new Date(time) }
+  }
+  return selected?.value ?? null
+}
+
+function pickLatestAttendanceEvent(events) {
+  let selected = null
+  for (const event of events) {
+    const time = attendanceTimeMs(event.occurred_at)
+    if (time == null) continue
+    if (!selected || time > selected.time) selected = { time, value: new Date(time) }
+  }
+  return selected?.value ?? null
+}
+
+function protectedRecordTime(previousValue, eventsForSide) {
+  const previousTime = attendanceTimeMs(previousValue)
+  if (previousTime == null) return null
+  const representedByEvent = eventsForSide.some(event => attendanceTimeMs(event.occurred_at) === previousTime)
+  return representedByEvent ? null : new Date(previousTime)
+}
+
+function sameAttendanceInstant(a, b) {
+  const left = attendanceTimeMs(a)
+  const right = attendanceTimeMs(b)
+  return left === right
+}
+
+async function applyAttendanceInOutMergePolicy(options) {
+  const {
+    client,
+    userId,
+    orgId,
+    workDate,
+    timezone,
+    rule,
+    isWorkday,
+    settings,
+    record,
+    protectedRecord,
+  } = options
+  const mergePolicy = settings?.punchPolicy?.merge ?? DEFAULT_SETTINGS.punchPolicy.merge
+  const internalWinsOnIn = mergePolicy.internalWinsOnIn === true
+  const externalWinsOnOut = mergePolicy.externalWinsOnOut === true
+  if (!internalWinsOnIn && !externalWinsOnOut) return record
+  if (!record) return record
+
+  const events = await client.query(
+    `SELECT event_type, source, occurred_at
+     FROM attendance_events
+     WHERE user_id = $1
+       AND org_id = $2
+       AND work_date = $3
+       AND event_type IN ('check_in', 'check_out')
+     ORDER BY occurred_at ASC, id ASC`,
+    [userId, orgId, workDate]
+  )
+  const checkIns = events.filter(event => event.event_type === 'check_in')
+  const checkOuts = events.filter(event => event.event_type === 'check_out')
+  const internalIns = checkIns.filter(event => event.source !== OUTDOOR_APPROVAL_EVENT_SOURCE)
+  const outdoorIns = checkIns.filter(event => event.source === OUTDOOR_APPROVAL_EVENT_SOURCE)
+  const internalOuts = checkOuts.filter(event => event.source !== OUTDOOR_APPROVAL_EVENT_SOURCE)
+  const outdoorOuts = checkOuts.filter(event => event.source === OUTDOOR_APPROVAL_EVENT_SOURCE)
+
+  let nextFirstInAt = cloneAttendanceDate(record.first_in_at)
+  let nextLastOutAt = cloneAttendanceDate(record.last_out_at)
+
+  if (internalWinsOnIn && internalIns.length > 0 && outdoorIns.length > 0) {
+    nextFirstInAt = protectedRecordTime(protectedRecord?.first_in_at, checkIns)
+      ?? pickEarliestAttendanceEvent(internalIns)
+      ?? nextFirstInAt
+  }
+  if (externalWinsOnOut && internalOuts.length > 0 && outdoorOuts.length > 0) {
+    nextLastOutAt = protectedRecordTime(protectedRecord?.last_out_at, checkOuts)
+      ?? pickLatestAttendanceEvent(outdoorOuts)
+      ?? nextLastOutAt
+  }
+
+  if (sameAttendanceInstant(nextFirstInAt, record.first_in_at) && sameAttendanceInstant(nextLastOutAt, record.last_out_at)) {
+    return record
+  }
+
+  const approvedMinutes = await loadApprovedMinutes(client, orgId, userId, workDate)
+  return upsertAttendanceRecord({
+    userId,
+    orgId,
+    workDate,
+    timezone,
+    rule,
+    updateFirstInAt: nextFirstInAt,
+    updateLastOutAt: nextLastOutAt,
+    mode: 'override',
+    isWorkday,
+    leaveMinutes: approvedMinutes.leaveMinutes,
+    overtimeMinutes: approvedMinutes.overtimeMinutes,
+    existingRow: record,
+    client,
+  })
+}
+
 async function upsertAttendanceRecord(options) {
   const {
     userId,
@@ -13758,12 +13884,8 @@ async function upsertAttendanceRecord(options) {
 
   // Allow callers to prefetch + lock rows in bulk (performance) while keeping
   // this helper backwards compatible.
-  const existing = existingRow
-    ? [existingRow]
-    : await client.query(
-        'SELECT * FROM attendance_records WHERE user_id = $1 AND work_date = $2 AND org_id = $3 FOR UPDATE',
-        [userId, workDate, orgId]
-      )
+  const loadedExistingRow = existingRow ?? await loadAttendanceRecordForUpdate(client, { userId, workDate, orgId })
+  const existing = loadedExistingRow ? [loadedExistingRow] : []
 
   const values = computeAttendanceRecordUpsertValues({
     existingRow: existing[0] ?? null,
@@ -16438,13 +16560,17 @@ module.exports = {
         weeklyMaxMinutes: z.number().int().positive().nullable().optional(),
         monthlyMaxMinutes: z.number().int().positive().nullable().optional(),
       }).optional(),
-      // Punch-policy group (#2203). S1 exposes unscheduled.mode = allow|block. S3 (#2304) exposes the
-      // outdoor approval controls — requireApproval / requireNote / approvalFlowId only. requirePhoto stays
-      // latent (normalized but NOT wire-settable until an attachment/photo contract exists — no fake
-      // security). `merge` is still added by its own slice (S2).
+      // Punch-policy group (#2203). S1 exposes unscheduled.mode = allow|block. S2 exposes merge
+      // controls for in/out card selection. S3 (#2304) exposes the outdoor approval controls —
+      // requireApproval / requireNote / approvalFlowId only. requirePhoto stays latent (normalized but
+      // NOT wire-settable until an attachment/photo contract exists — no fake security).
       punchPolicy: z.object({
         unscheduled: z.object({
           mode: z.enum(['allow', 'block']).optional(),
+        }).optional(),
+        merge: z.object({
+          internalWinsOnIn: z.boolean().optional(),
+          externalWinsOnOut: z.boolean().optional(),
         }).optional(),
         outdoor: z.object({
           requireApproval: z.boolean().optional(),
@@ -19097,7 +19223,8 @@ module.exports = {
               ]
             )
 
-            const record = await upsertAttendanceRecord({
+            const protectedRecord = await loadAttendanceRecordForUpdate(trx, { userId, orgId, workDate })
+            let record = await upsertAttendanceRecord({
               userId,
               orgId,
               workDate,
@@ -19109,7 +19236,20 @@ module.exports = {
               isWorkday: context.isWorkingDay,
               leaveMinutes: 0,
               overtimeMinutes: 0,
+              existingRow: protectedRecord,
               client: trx,
+            })
+            record = await applyAttendanceInOutMergePolicy({
+              client: trx,
+              userId,
+              orgId,
+              workDate,
+              timezone,
+              rule: { ...context.rule, timezone },
+              isWorkday: context.isWorkingDay,
+              settings: punchPolicySettings,
+              record,
+              protectedRecord,
             })
 
             return { event: event[0], record }
@@ -20679,12 +20819,17 @@ module.exports = {
                   requestRow.work_date,
                   outdoorOccurredAt,
                   outdoorEventType,
-                  'outdoor_approval',
+                  OUTDOOR_APPROVAL_EVENT_SOURCE,
                   timezone,
                   JSON.stringify(op.location ?? {}),
                   JSON.stringify({ requestId, requestType: 'outdoor_punch', outdoor: true }),
                 ]
               )
+              const protectedRecord = await loadAttendanceRecordForUpdate(trx, {
+                userId: requestRow.user_id,
+                orgId,
+                workDate: requestRow.work_date,
+              })
               record = await upsertAttendanceRecord({
                 userId: requestRow.user_id,
                 orgId,
@@ -20697,7 +20842,20 @@ module.exports = {
                 isWorkday: context.isWorkingDay,
                 leaveMinutes: 0,
                 overtimeMinutes: 0,
+                existingRow: protectedRecord,
                 client: trx,
+              })
+              record = await applyAttendanceInOutMergePolicy({
+                client: trx,
+                userId: requestRow.user_id,
+                orgId,
+                workDate: requestRow.work_date,
+                timezone,
+                rule: { ...context.rule, timezone },
+                isWorkday: context.isWorkingDay,
+                settings: await getSettings(trx),
+                record,
+                protectedRecord,
               })
             }
 


### PR DESCRIPTION
## Summary
- Exposes `punchPolicy.merge.{internalWinsOnIn, externalWinsOnOut}` through attendance settings.
- Applies the S2 in/out merge policy after real check events land on the two trusted write paths: normal `/punch` and approved `outdoor_punch`.
- Preserves record-only facts by locking the pre-write record and treating non-event first/last values as protected candidates; S2 recompute only intervenes when the corresponding key is enabled and internal/outdoor events coexist for that side.
- Keeps raw `attendance_events` immutable and continues to use `source=outdoor_approval` as the now-reserved classifier from S2-0.

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend build`
- fresh local Postgres DB migrated from scratch, then `pnpm --filter @metasheet/core-backend test:integration:attendance` → 4 files / 102 tests passed

## Scope / deferred
- Backend only. No frontend admin card in this PR.
- No staging smoke and no tracker ✅ flip here; S2-2 frontend card and S2-3 reverse/staging closeout remain separate opt-ins.
