### PR TITLE
fix(data-factory): normalize stock planner comparisons

### DIFF
--- a/plugins/plugin-integration-core/__tests__/stock-preparation-conflict-planner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-conflict-planner.test.cjs
@@ -230,6 +230,83 @@ function testPrimitiveValueComparisonFastPath() {
   assert.equal(__internals.valuesEqual(['a'], ['a']), true, 'array fallback keeps structural comparison')
 }
 
+function testTemplateTypeEquivalentValuesSkipAfterCreate() {
+  const expanded = row({
+    componentSourceId: 'PART-TYPE',
+    parentSourceId: 0,
+    pathTokens: ['ROOT', 'PART-TYPE'],
+    depth: '1',
+    componentCode: 1001,
+    componentName: 2002,
+    material: 3003,
+    sourceVersion: 7,
+    rawQuantity: '2',
+    totalQuantity: '6',
+    active: 'true',
+  })
+  const existing = {
+    ...expanded,
+    parentSourceId: '0',
+    depth: 1,
+    componentCode: '1001',
+    componentName: '2002',
+    material: '3003',
+    sourceVersion: '7',
+    rawQuantity: 2,
+    totalQuantity: 6,
+    active: true,
+    lastPlmRefreshDecision: DECISIONS.ADD,
+  }
+
+  const plan = planStockPreparationConflicts({
+    expandedRows: [expanded],
+    existingRows: [existing],
+    runId: 'run-type',
+    plannedAt: '2026-06-04T09:00:00.000Z',
+  })
+
+  assert.equal(plan.valid, true, 'type-only drift must not force manual confirmation')
+  assert.deepEqual(plan.counts, {
+    add: 0,
+    update: 0,
+    skip: 1,
+    inactive: 0,
+    manual_confirm: 0,
+  })
+  assert.deepEqual(byDecision(plan, DECISIONS.SKIP).map((entry) => entry.conflictSummary.type), ['unchanged'])
+}
+
+function testTemplateNormalizationDoesNotHideRealIdentityOrLineageConflicts() {
+  const identityNext = row({
+    componentSourceId: 'PART-REAL-ID',
+    pathTokens: ['PART-REAL-ID'],
+    componentCode: 1001,
+  })
+  const lineageNext = row({
+    componentSourceId: 'PART-REAL-LINE',
+    parentSourceId: 0,
+    pathTokens: ['ROOT', 'PART-REAL-LINE'],
+  })
+
+  const plan = planStockPreparationConflicts({
+    expandedRows: [identityNext, lineageNext],
+    existingRows: [
+      { ...identityNext, componentCode: '1002' },
+      { ...lineageNext, parentSourceId: '1' },
+    ],
+    runId: 'run-real-conflict',
+    plannedAt: '2026-06-04T09:00:00.000Z',
+  })
+
+  assert.equal(plan.valid, false)
+  assert.deepEqual(
+    byDecision(plan, DECISIONS.MANUAL_CONFIRM).map((entry) => entry.conflictSummary.type).sort(),
+    ['component_identity_conflict', 'lineage_mismatch'],
+  )
+  assert.equal(plan.counts.add, 0, 'real conflicts must not fall through to add')
+  assert.equal(plan.counts.update, 0, 'real conflicts must not fall through to update')
+}
+
 function testValuesFreeEvidence() {
   const expanded = row({ componentSourceId: 'PART-SECRET', componentName: 'Widget Name', material: 'Copper' })
   const plan = planStockPreparationConflicts({
@@ -257,6 +334,8 @@ function main() {
   testMissingKeysAndStrategyGuards()
   testHumanFieldWhitelistOrderIndependent()
   testPrimitiveValueComparisonFastPath()
+  testTemplateTypeEquivalentValuesSkipAfterCreate()
+  testTemplateNormalizationDoesNotHideRealIdentityOrLineageConflicts()
   testValuesFreeEvidence()
 
   console.log('stock-preparation-conflict-planner.test.cjs OK')

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
@@ -428,6 +428,20 @@ async function testApplyNormalizesNumericPlmDisplayFieldsBeforeCreate() {
   assert.equal(typeof createCall[1].data.totalQuantity, 'number')
   assert.equal(createCall[1].data.active, true)
   assert.equal(JSON.stringify(result.evidence).includes('1001'), false, 'apply evidence hides component code value')
+
+  const followUp = await dryRunStockPreparationAction({
+    action,
+    parameters: { projectNo: 'P-001' },
+    sourceAdapter: source.adapter,
+    recordsApi: records.recordsApi,
+    tokenStore: storage,
+    plannedAt: '2026-06-04T10:00:00.000Z',
+  })
+
+  assert.equal(followUp.status, 'ready', 'post-create dry-run should not require manual confirmation for type-only drift')
+  assert.equal(followUp.counts.add, 0, 'post-create dry-run must not duplicate-add')
+  assert.equal(followUp.counts.manual_confirm, 0, 'type-normalized existing rows must not be held')
+  assert.equal(followUp.counts.skip, 1, 'unchanged post-create row skips cleanly')
 }
 
 async function testApplySurfacesTypedValuesFreeRowFailureDiagnostics() {

--- a/plugins/plugin-integration-core/lib/stock-preparation-conflict-planner.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-conflict-planner.cjs
@@ -131,6 +131,10 @@ function plmRefreshFieldIds(template) {
   return fieldIdsByOwnership(template, 'plm_system').filter((id) => !RUN_FIELD_IDS.includes(id))
 }
 
+function fieldMapForTemplate(template) {
+  return new Map((template.fields || []).map((field) => [field.id, field]))
+}
+
 function keyOf(row) {
   return isPlainObject(row) && typeof row.idempotencyKey === 'string' && row.idempotencyKey.trim() !== ''
     ? row.idempotencyKey
@@ -169,8 +173,41 @@ function valuesEqual(left, right) {
   return JSON.stringify(normalizedLeft) === JSON.stringify(normalizedRight)
 }
 
-function changedFields(nextRow, existingRow, fields) {
-  return fields.filter((field) => !valuesEqual(nextRow[field], existingRow[field]))
+function normalizeComparableValueForField(value, field) {
+  const normalized = comparableValue(value)
+  if (normalized === null || !field || !field.type) return normalized
+  if (field.type === 'string' || field.type === 'date' || field.type === 'select') {
+    if (typeof normalized === 'number' || typeof normalized === 'boolean') return String(normalized)
+    return normalized
+  }
+  if (field.type === 'number') {
+    if (typeof normalized === 'number' && Number.isFinite(normalized)) return normalized
+    if (typeof normalized === 'string' && normalized.trim()) {
+      const parsed = Number(normalized)
+      if (Number.isFinite(parsed)) return parsed
+    }
+    return normalized
+  }
+  if (field.type === 'boolean') {
+    if (typeof normalized === 'boolean') return normalized
+    if (typeof normalized === 'string') {
+      const lowered = normalized.trim().toLowerCase()
+      if (lowered === 'true') return true
+      if (lowered === 'false') return false
+    }
+  }
+  return normalized
+}
+
+function valuesEqualForTemplateField(left, right, field) {
+  return valuesEqual(
+    normalizeComparableValueForField(left, field),
+    normalizeComparableValueForField(right, field),
+  )
+}
+
+function changedFields(nextRow, existingRow, fields, templateFields = new Map()) {
+  return fields.filter((field) => !valuesEqualForTemplateField(nextRow[field], existingRow[field], templateFields.get(field)))
 }
 
 function pickFields(row, fields) {
@@ -301,6 +338,7 @@ function planStockPreparationConflicts(input = {}) {
     })
   }
   const plmFields = plmRefreshFieldIds(template)
+  const templateFields = fieldMapForTemplate(template)
   const counts = {
     [DECISIONS.ADD]: 0,
     [DECISIONS.UPDATE]: 0,
@@ -380,7 +418,7 @@ function planStockPreparationConflicts(input = {}) {
       continue
     }
 
-    const lineageChanges = changedFields(row, existingRow, LINEAGE_FIELD_IDS)
+    const lineageChanges = changedFields(row, existingRow, LINEAGE_FIELD_IDS, templateFields)
     if (lineageChanges.length > 0) {
       manualConfirm(decisions, counts, {
         idempotencyKey: key,
@@ -392,7 +430,7 @@ function planStockPreparationConflicts(input = {}) {
       continue
     }
 
-    const identityChanges = changedFields(row, existingRow, IDENTITY_FIELD_IDS)
+    const identityChanges = changedFields(row, existingRow, IDENTITY_FIELD_IDS, templateFields)
     if (identityChanges.length > 0) {
       manualConfirm(decisions, counts, {
         idempotencyKey: key,
@@ -404,7 +442,7 @@ function planStockPreparationConflicts(input = {}) {
       continue
     }
 
-    const refreshChanges = strategy.refreshPlmSystemFields ? changedFields(row, existingRow, plmFields) : []
+    const refreshChanges = strategy.refreshPlmSystemFields ? changedFields(row, existingRow, plmFields, templateFields) : []
     if (refreshChanges.length === 0) {
       addDecision(decisions, counts, makeSkipDecision(row))
       continue
@@ -472,11 +510,14 @@ module.exports = {
   summarizeConflictPlanForEvidence,
   __internals: {
     changedFields,
+    fieldMapForTemplate,
     groupByKey,
     normalizeStrategy,
     normalizeIsoTime,
+    normalizeComparableValueForField,
     plmRefreshFieldIds,
     sameStringSet,
     valuesEqual,
+    valuesEqualForTemplateField,
   },
 }


### PR DESCRIPTION
## Summary
- normalize C3 stock-preparation changed-field comparisons through the target stock-preparation template types
- keep the existing primitive `valuesEqual()` semantics type-sensitive; only the planner's field-aware comparison path normalizes values
- add pure planner and table-action regression tests for the post-create re-pull shape exposed by #2253

## Why
The onsite typefix package confirmed C4 Apply-only succeeds and creates 44 rows, and readback works. The follow-up dry-run no longer duplicate-adds (`add=0`), but it still returns `manual_confirm=44`.

Current C3 compares raw PLM expansion values against C4-normalized target row values with type-sensitive equality. For fields declared as strings in the stock-preparation template, a PLM numeric display value and the stored string value are logically equivalent but currently look like identity/lineage drift.

## What changed
- C3 builds a template field map and compares lineage, identity, and PLM/system refresh fields via field-aware comparable normalization.
- String/date/select fields stringify primitive number/boolean values for comparison.
- Number fields compare numeric strings and numbers as equivalent when finite.
- Boolean fields compare `true`/`false` strings and booleans as equivalent.
- Object/array or otherwise uncoercible values are not flattened; real mismatches still fail closed.

## Tests
- Type-only post-create drift now plans clean `skip`, not `manual_confirm`.
- Real lineage/identity changes still produce `lineage_mismatch` / `component_identity_conflict` manual confirmation.
- C5 table-action flow: apply creates a row from numeric PLM display fields, then a follow-up dry-run returns `add=0`, `manual_confirm=0`, `skip=1`.

## Boundaries
- no C4 Apply retry
- no package/release in this PR
- no PLM write, external DB write, K3 write, route/UI/migration/RBAC/auth change
- evidence remains values-free

## Verification
- `node plugins/plugin-integration-core/__tests__/stock-preparation-conflict-planner.test.cjs`
- `node plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs`
- `pnpm --filter plugin-integration-core test`
- `git diff --check`
