### PR TITLE
feat(automation): A6-3-2a — condition_branch editor (frontend builder)

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -1212,14 +1212,8 @@ const SUPPORTED_SELECTABLE_ACTION_TYPES: AutomationActionType[] = [
   'condition_branch',
 ]
 
-// A6-3-2a: the minimal v1 set of action types authorable INSIDE a condition_branch branch.
-// Mirrors the backend (which forbids wait_for_callback + nested condition_branch in branches);
-// kept to simple-config types this slice can faithfully round-trip. Loaded branches whose actions
-// fall outside this set open read-only (never flattened) — see conditionBranchUnsupportedReason.
-const BRANCH_AUTHORABLE_ACTION_TYPES: AutomationActionType[] = [
-  'update_record',
-  'send_notification',
-]
+// A6-3-2a: BRANCH_AUTHORABLE_ACTION_TYPES (the v1 in-branch action subset) is imported from
+// ../utils/conditionBranchAuthoring — the single source of truth shared with the seam + tests.
 
 const UNSUPPORTED_SELECTABLE_ACTION_TYPES: AutomationActionType[] = ['lock_record']
 

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -1000,6 +1000,16 @@ import {
   automationTriggerConditionLabel,
   automationTriggerTypeLabel,
 } from '../utils/meta-automation-labels'
+import {
+  type BranchActionDraft,
+  type BranchDraft,
+  type DefaultBranchDraft,
+  BRANCH_AUTHORABLE_ACTION_TYPES,
+  buildConditionBranchConfig,
+  conditionBranchUnsupportedReason,
+  parseConditionBranchDraft,
+  validateConditionBranchKeys,
+} from '../utils/conditionBranchAuthoring'
 
 interface FieldPair {
   fieldId: string
@@ -1031,6 +1041,11 @@ type DraftActionConfig = Record<string, unknown> & {
   publicFormViewId?: string
   internalViewId?: string
   locked?: boolean
+  // A6-3-2a condition_branch authoring (supported → editable draft; unsupported → read-only + original preserved)
+  branches?: BranchDraft[]
+  defaultBranch?: DefaultBranchDraft | null
+  branchUnsupportedReason?: string | null
+  branchOriginal?: Record<string, unknown> | null
 }
 
 interface DraftAction {
@@ -1541,6 +1556,16 @@ function emptyDraft(): Draft {
 }
 
 function draftConfigFromAction(type: AutomationActionType, config: Record<string, unknown>): DraftActionConfig {
+  if (type === 'condition_branch') {
+    const reason = conditionBranchUnsupportedReason(config)
+    if (reason) {
+      // A6-3-2a point #3: a loaded shape the v1 UI can't faithfully round-trip → read-only.
+      // Preserve the ORIGINAL config verbatim; buildPayload re-emits it unchanged — never flatten.
+      return { branchUnsupportedReason: reason, branchOriginal: config, branches: [], defaultBranch: null }
+    }
+    const parsed = parseConditionBranchDraft(config)
+    return { branches: parsed.branches, defaultBranch: parsed.defaultBranch, branchUnsupportedReason: null, branchOriginal: null }
+  }
   if (type === 'update_record') {
     const fields = isPlainRecord(config.fields)
       ? config.fields
@@ -1647,6 +1672,38 @@ const JOB_MODE_REQUIRING_ACTION_TYPES: AutomationActionType[] = ['wait_for_callb
 const requiresJobMode = computed(() =>
   draft.value.actions.some((a) => JOB_MODE_REQUIRING_ACTION_TYPES.includes(a.type)),
 )
+
+// A6-3-2a: empty drafts for a fresh condition_branch action.
+function createEmptyBranchActionDraft(): BranchActionDraft {
+  return { type: 'update_record', fieldUpdates: [] }
+}
+function createEmptyBranchDraft(index = 1): BranchDraft {
+  return { key: `branch_${index}`, label: '', conjunction: 'AND', conditions: [], actions: [createEmptyBranchActionDraft()] }
+}
+function createEmptyDefaultBranchDraft(): DefaultBranchDraft {
+  return { key: 'default', label: '', actions: [createEmptyBranchActionDraft()] }
+}
+
+// A6-3-2a read-only guard (point #3) + branch-key validation (point #1) over the draft's
+// condition_branch actions. Both feed canSave (block-save) and the template (alert).
+const conditionBranchReadOnlyReason = computed<string | null>(() => {
+  for (const a of draft.value.actions) {
+    if (a.type === 'condition_branch' && a.config.branchUnsupportedReason) return a.config.branchUnsupportedReason
+  }
+  return null
+})
+const conditionBranchKeyError = computed<string | null>(() => {
+  for (const a of draft.value.actions) {
+    if (a.type === 'condition_branch' && !a.config.branchUnsupportedReason) {
+      const err = validateConditionBranchKeys({
+        branches: a.config.branches ?? [],
+        defaultBranch: a.config.defaultBranch ?? null,
+      })
+      if (err) return err
+    }
+  }
+  return null
+})
 
 function setExecutionMode(checked: boolean): void {
   // A6-1 opt-in: checkbox → the rule's persistent WorkflowJob mode (off = legacy/null).
@@ -1764,6 +1821,8 @@ watch(
 const canSave = computed(() => {
   if (!draft.value.name.trim()) return false
   if (draft.value.actions.length < 1) return false
+  if (conditionBranchReadOnlyReason.value) return false // A6-3-2a point #3: never save a non-round-trippable loaded branch
+  if (conditionBranchKeyError.value) return false // A6-3-2a point #1: branch key safe/unique mirror
   if (!draft.value.conditions.conditions.every(areConditionsComplete)) return false
   for (const action of draft.value.actions) {
     if (action.type === 'send_dingtalk_group_message') {
@@ -2368,6 +2427,8 @@ function appendPersonTemplateToken(
 
 function defaultConfigForActionType(type: AutomationActionType): DraftActionConfig {
   switch (type) {
+    case 'condition_branch':
+      return { branches: [createEmptyBranchDraft(1)], defaultBranch: null, branchUnsupportedReason: null, branchOriginal: null }
     case 'update_record':
       return { fieldUpdates: [] }
     case 'create_record':
@@ -2453,6 +2514,20 @@ function buildPayload(): Partial<AutomationRule> {
     triggerConfig.cron = cronPreset.value
   }
   const actions = d.actions.map((action) => {
+    if (action.type === 'condition_branch') {
+      // A6-3-2a point #3: read-only (unsupported loaded shape) re-emits the preserved original
+      // verbatim — never flattened. (canSave blocks save here anyway; this is the defensive floor.)
+      if (action.config.branchUnsupportedReason && action.config.branchOriginal) {
+        return { type: action.type, config: action.config.branchOriginal }
+      }
+      return {
+        type: action.type,
+        config: buildConditionBranchConfig({
+          branches: action.config.branches ?? [],
+          defaultBranch: action.config.defaultBranch ?? null,
+        }),
+      }
+    }
     if (action.type === 'update_record') {
       return {
         type: action.type,

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -896,6 +896,93 @@
             <div v-if="action.type === 'wait_for_callback'" class="meta-rule-editor__action-config" data-action-config="wait_for_callback">
               <div class="meta-rule-editor__hint" data-field="wait-for-callback-hint">{{ automationLabel('actionConfig.waitForCallbackHint', isZh) }}</div>
             </div>
+
+            <!-- A6-3-2a condition_branch builder (form-based; no canvas / BPMN vocab per design-lock §10) -->
+            <div v-if="action.type === 'condition_branch'" class="meta-rule-editor__action-config" data-action-config="condition_branch">
+              <div v-if="action.config.branchUnsupportedReason" class="meta-rule-editor__alert" data-field="condition-branch-readonly">
+                {{ automationLabel('conditionBranch.readOnly', isZh) }}
+              </div>
+              <template v-else>
+                <div class="meta-rule-editor__hint">{{ automationLabel('conditionBranch.hint', isZh) }}</div>
+                <div v-for="(branch, bIdx) in action.config.branches" :key="bIdx" class="meta-rule-editor__branch" :data-branch-index="bIdx">
+                  <div class="meta-rule-editor__branch-header">
+                    <input v-model="branch.key" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.key', isZh)" data-field="branch-key" />
+                    <input v-model="branch.label" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.label', isZh)" data-field="branch-label" />
+                    <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" data-action="remove-branch" @click="removeBranch(action, bIdx)">&times;</button>
+                  </div>
+                  <div v-if="branch.conditions.length > 1" class="meta-rule-editor__conjunction">
+                    <button type="button" class="meta-rule-editor__toggle-btn" :class="{ 'meta-rule-editor__toggle-btn--active': branch.conjunction === 'AND' }" @click="branch.conjunction = 'AND'">{{ automationLabel('condition.and', isZh) }}</button>
+                    <button type="button" class="meta-rule-editor__toggle-btn" :class="{ 'meta-rule-editor__toggle-btn--active': branch.conjunction === 'OR' }" @click="branch.conjunction = 'OR'">{{ automationLabel('condition.or', isZh) }}</button>
+                  </div>
+                  <div v-for="(cond, cIdx) in branch.conditions" :key="cIdx" class="meta-rule-editor__condition-row" :data-branch-condition-index="cIdx">
+                    <select :value="cond.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm" @change="onConditionFieldChange(cond, ($event.target as HTMLSelectElement).value)">
+                      <option value="">{{ automationLabel('condition.selectField', isZh) }}</option>
+                      <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
+                    </select>
+                    <select :value="cond.operator" class="meta-rule-editor__select meta-rule-editor__select--sm" @change="onConditionOperatorChange(cond, ($event.target as HTMLSelectElement).value as ConditionOperator)">
+                      <option v-for="op in conditionOperatorsForField(cond.fieldId)" :key="op.value" :value="op.value">{{ automationConditionOperatorLabel(op.value, isZh) }}</option>
+                    </select>
+                    <input v-if="!isUnaryOperator(cond.operator)" v-model="cond.value" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('condition.selectValue', isZh)" />
+                    <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeBranchCondition(branch, cIdx)">&times;</button>
+                  </div>
+                  <button class="meta-rule-editor__btn" type="button" data-action="add-branch-condition" @click="addBranchCondition(branch)">{{ automationLabel('condition.addCondition', isZh) }}</button>
+                  <div v-for="(bAct, aIdx) in branch.actions" :key="aIdx" class="meta-rule-editor__branch-action" :data-branch-action-index="aIdx">
+                    <select v-model="bAct.type" class="meta-rule-editor__select meta-rule-editor__select--sm" @change="onBranchActionTypeChange(bAct)">
+                      <option v-for="t in BRANCH_AUTHORABLE_ACTION_TYPES" :key="t" :value="t">{{ automationActionTypeLabel(t, isZh) }}</option>
+                    </select>
+                    <template v-if="bAct.type === 'update_record'">
+                      <div v-for="(pair, pIdx) in bAct.fieldUpdates" :key="pIdx" class="meta-rule-editor__field-pair">
+                        <select v-model="pair.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm">
+                          <option value="">{{ automationLabel('condition.selectField', isZh) }}</option>
+                          <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
+                        </select>
+                        <input v-model="pair.value" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.value', isZh)" />
+                        <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeBranchFieldPair(bAct, pIdx)">&times;</button>
+                      </div>
+                      <button class="meta-rule-editor__btn" type="button" data-action="add-branch-field" @click="addBranchFieldPair(bAct)">{{ automationLabel('conditionBranch.addField', isZh) }}</button>
+                    </template>
+                    <template v-else-if="bAct.type === 'send_notification'">
+                      <input v-model="bAct.userId" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.userIds', isZh)" />
+                      <input v-model="bAct.message" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.message', isZh)" />
+                    </template>
+                    <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeBranchAction(branch, aIdx)">&times;</button>
+                  </div>
+                  <button class="meta-rule-editor__btn" type="button" data-action="add-branch-action" @click="addBranchAction(branch)">{{ automationLabel('conditionBranch.addAction', isZh) }}</button>
+                </div>
+                <button class="meta-rule-editor__btn" type="button" data-action="add-branch" @click="addBranch(action)">{{ automationLabel('conditionBranch.addBranch', isZh) }}</button>
+                <div v-if="action.config.defaultBranch" class="meta-rule-editor__branch" data-field="default-branch">
+                  <div class="meta-rule-editor__branch-header">
+                    <span class="meta-rule-editor__group-label">{{ automationLabel('conditionBranch.default', isZh) }}</span>
+                    <input v-model="action.config.defaultBranch.key" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.key', isZh)" data-field="default-branch-key" />
+                    <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" data-action="remove-default-branch" @click="removeDefaultBranch(action)">&times;</button>
+                  </div>
+                  <div v-for="(bAct, aIdx) in action.config.defaultBranch.actions" :key="aIdx" class="meta-rule-editor__branch-action">
+                    <select v-model="bAct.type" class="meta-rule-editor__select meta-rule-editor__select--sm" @change="onBranchActionTypeChange(bAct)">
+                      <option v-for="t in BRANCH_AUTHORABLE_ACTION_TYPES" :key="t" :value="t">{{ automationActionTypeLabel(t, isZh) }}</option>
+                    </select>
+                    <template v-if="bAct.type === 'update_record'">
+                      <div v-for="(pair, pIdx) in bAct.fieldUpdates" :key="pIdx" class="meta-rule-editor__field-pair">
+                        <select v-model="pair.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm">
+                          <option value="">{{ automationLabel('condition.selectField', isZh) }}</option>
+                          <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
+                        </select>
+                        <input v-model="pair.value" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.value', isZh)" />
+                        <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeBranchFieldPair(bAct, pIdx)">&times;</button>
+                      </div>
+                      <button class="meta-rule-editor__btn" type="button" @click="addBranchFieldPair(bAct)">{{ automationLabel('conditionBranch.addField', isZh) }}</button>
+                    </template>
+                    <template v-else-if="bAct.type === 'send_notification'">
+                      <input v-model="bAct.userId" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.userIds', isZh)" />
+                      <input v-model="bAct.message" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('conditionBranch.message', isZh)" />
+                    </template>
+                    <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeBranchAction(action.config.defaultBranch, aIdx)">&times;</button>
+                  </div>
+                  <button class="meta-rule-editor__btn" type="button" @click="addBranchAction(action.config.defaultBranch)">{{ automationLabel('conditionBranch.addAction', isZh) }}</button>
+                </div>
+                <button v-else class="meta-rule-editor__btn" type="button" data-action="add-default-branch" @click="addDefaultBranch(action)">{{ automationLabel('conditionBranch.addDefault', isZh) }}</button>
+                <div v-if="conditionBranchKeyError" class="meta-rule-editor__error" data-field="branch-key-error">{{ conditionBranchKeyError }}</div>
+              </template>
+            </div>
           </div>
           <button
             v-if="draft.actions.length < 3"
@@ -1704,6 +1791,51 @@ const conditionBranchKeyError = computed<string | null>(() => {
   }
   return null
 })
+
+// A6-3-2a branch-builder mutations (operate on the draft action's config in place; Vue deep-reactive).
+function addBranch(action: DraftAction): void {
+  const branches = action.config.branches ?? (action.config.branches = [])
+  branches.push(createEmptyBranchDraft(branches.length + 1))
+}
+function removeBranch(action: DraftAction, index: number): void {
+  action.config.branches?.splice(index, 1)
+}
+function addBranchCondition(branch: BranchDraft): void {
+  branch.conditions.push({ fieldId: '', operator: 'equals', value: '' })
+}
+function removeBranchCondition(branch: BranchDraft, index: number): void {
+  branch.conditions.splice(index, 1)
+}
+function addBranchAction(branch: BranchDraft | DefaultBranchDraft): void {
+  branch.actions.push(createEmptyBranchActionDraft())
+}
+function removeBranchAction(branch: BranchDraft | DefaultBranchDraft, index: number): void {
+  branch.actions.splice(index, 1)
+}
+function onBranchActionTypeChange(action: BranchActionDraft): void {
+  if (action.type === 'update_record') {
+    action.fieldUpdates = action.fieldUpdates ?? []
+    delete action.userId
+    delete action.message
+  } else {
+    action.userId = action.userId ?? ''
+    action.message = action.message ?? ''
+    delete action.fieldUpdates
+  }
+}
+function addBranchFieldPair(action: BranchActionDraft): void {
+  action.fieldUpdates = action.fieldUpdates ?? []
+  action.fieldUpdates.push({ fieldId: '', value: '' })
+}
+function removeBranchFieldPair(action: BranchActionDraft, index: number): void {
+  action.fieldUpdates?.splice(index, 1)
+}
+function addDefaultBranch(action: DraftAction): void {
+  action.config.defaultBranch = createEmptyDefaultBranchDraft()
+}
+function removeDefaultBranch(action: DraftAction): void {
+  action.config.defaultBranch = null
+}
 
 function setExecutionMode(checked: boolean): void {
   // A6-1 opt-in: checkbox → the rule's persistent WorkflowJob mode (off = legacy/null).

--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -1107,6 +1107,16 @@ const SUPPORTED_SELECTABLE_ACTION_TYPES: AutomationActionType[] = [
   'send_dingtalk_group_message',
   'send_dingtalk_person_message',
   'wait_for_callback',
+  'condition_branch',
+]
+
+// A6-3-2a: the minimal v1 set of action types authorable INSIDE a condition_branch branch.
+// Mirrors the backend (which forbids wait_for_callback + nested condition_branch in branches);
+// kept to simple-config types this slice can faithfully round-trip. Loaded branches whose actions
+// fall outside this set open read-only (never flattened) — see conditionBranchUnsupportedReason.
+const BRANCH_AUTHORABLE_ACTION_TYPES: AutomationActionType[] = [
+  'update_record',
+  'send_notification',
 ]
 
 const UNSUPPORTED_SELECTABLE_ACTION_TYPES: AutomationActionType[] = ['lock_record']
@@ -1629,10 +1639,14 @@ function draftFromRule(rule: AutomationRule): Draft {
 const draft = ref<Draft>(emptyDraft())
 const conditionEditorEntries = computed(() => collectConditionEditorEntries(draft.value.conditions.conditions))
 
-// A6-2b: a wait_for_callback action REQUIRES execution_mode 'workflow_job_v1' — the backend
-// fail-closes a legacy rule that contains a wait step. So whenever a wait action is present the
-// job-mode toggle is forced on (and disabled), and buildPayload enforces it regardless.
-const requiresJobMode = computed(() => draft.value.actions.some((a) => a.type === 'wait_for_callback'))
+// A6-2b/A6-3-2a: wait_for_callback AND condition_branch both REQUIRE execution_mode
+// 'workflow_job_v1' — the backend fail-closes a legacy rule that contains either. So whenever such
+// an action is present the job-mode toggle is forced on (and disabled), and buildPayload enforces it
+// regardless of toggle/loaded state.
+const JOB_MODE_REQUIRING_ACTION_TYPES: AutomationActionType[] = ['wait_for_callback', 'condition_branch']
+const requiresJobMode = computed(() =>
+  draft.value.actions.some((a) => JOB_MODE_REQUIRING_ACTION_TYPES.includes(a.type)),
+)
 
 function setExecutionMode(checked: boolean): void {
   // A6-1 opt-in: checkbox → the rule's persistent WorkflowJob mode (off = legacy/null).

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -780,6 +780,7 @@ export type AutomationActionType =
   | 'send_dingtalk_person_message'
   | 'lock_record'
   | 'wait_for_callback'
+  | 'condition_branch'
   // Legacy aliases
   | 'notify'
   | 'update_field'

--- a/apps/web/src/multitable/utils/conditionBranchAuthoring.ts
+++ b/apps/web/src/multitable/utils/conditionBranchAuthoring.ts
@@ -1,0 +1,227 @@
+// A6-3-2a — pure save/load seam for the `condition_branch` editor (contained; unit-testable).
+//
+// Invariant (the non-negotiable): a loaded `condition_branch` config is only ever EDITED when the v1
+// UI can faithfully round-trip it — `buildConditionBranchConfig(parseConditionBranchDraft(config))`
+// is semantically equal to `config`. Anything the v1 UI cannot represent losslessly
+// (nested condition groups, non-string `update_record` values, comma/whitespace-bearing `userIds`,
+// branch action types outside the simple subset, `wait_for_callback`/nested `condition_branch`)
+// returns a non-null `conditionBranchUnsupportedReason` → the editor opens read-only and never
+// flattens. Mirrors the backend `validateConditionBranchConfig` boundaries (SAFE_BRANCH_KEY,
+// no wait/nesting in branches).
+import type {
+  AutomationAction,
+  AutomationActionType,
+  AutomationCondition,
+} from '../types'
+
+// Mirror of backend automation-service.ts SAFE_BRANCH_KEY.
+export const SAFE_BRANCH_KEY = /^[A-Za-z0-9_-]{1,64}$/
+
+// The v1 subset of action types authorable INSIDE a branch (simple, round-trippable config).
+export const BRANCH_AUTHORABLE_ACTION_TYPES = ['update_record', 'send_notification'] as const
+export type BranchAuthorableActionType = (typeof BRANCH_AUTHORABLE_ACTION_TYPES)[number]
+
+export interface BranchActionDraft {
+  type: BranchAuthorableActionType
+  fieldUpdates?: Array<{ fieldId: string; value: string }> // update_record
+  userId?: string // send_notification (comma/space-joined)
+  message?: string // send_notification
+}
+export interface BranchDraft {
+  key: string
+  label: string
+  conjunction: 'AND' | 'OR'
+  conditions: AutomationCondition[] // flat only (reuses the rule-level condition-row handlers)
+  actions: BranchActionDraft[]
+}
+export interface DefaultBranchDraft {
+  key: string
+  label: string
+  actions: BranchActionDraft[]
+}
+export interface ConditionBranchDraft {
+  branches: BranchDraft[]
+  defaultBranch: DefaultBranchDraft | null
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+// ---- round-trip checks for the simple-action subset ----
+
+const UPDATE_RECORD_ALLOWED_KEYS = new Set(['fields'])
+function updateRecordRoundTrippable(config: unknown): boolean {
+  if (!isPlainRecord(config)) return false
+  // Extra keys can't be represented by the field-pair UI → not lossless.
+  if (Object.keys(config).some((k) => !UPDATE_RECORD_ALLOWED_KEYS.has(k))) return false
+  const fields = config.fields
+  if (fields === undefined) return true
+  if (!isPlainRecord(fields)) return false
+  // The UI edits values as strings; non-string values would be coerced (lossy).
+  return Object.values(fields).every((v) => typeof v === 'string')
+}
+
+const SEND_NOTIFICATION_ALLOWED_KEYS = new Set(['userIds', 'message'])
+const SIMPLE_USER_ID = /^[^\s,]+$/ // join(', ')/split round-trips only comma/whitespace-free tokens
+function sendNotificationRoundTrippable(config: unknown): boolean {
+  if (!isPlainRecord(config)) return false
+  if (Object.keys(config).some((k) => !SEND_NOTIFICATION_ALLOWED_KEYS.has(k))) return false
+  const userIds = config.userIds
+  if (userIds !== undefined) {
+    if (!Array.isArray(userIds)) return false
+    if (!userIds.every((u) => typeof u === 'string' && SIMPLE_USER_ID.test(u))) return false
+  }
+  if (config.message !== undefined && typeof config.message !== 'string') return false
+  return true
+}
+
+function branchActionRoundTrippable(action: unknown): boolean {
+  if (!isPlainRecord(action)) return false
+  if (action.type === 'update_record') return updateRecordRoundTrippable(action.config)
+  if (action.type === 'send_notification') return sendNotificationRoundTrippable(action.config)
+  // outside the subset (incl. wait_for_callback / nested condition_branch) → read-only
+  return false
+}
+
+function conditionGroupIsFlat(group: unknown): boolean {
+  if (group === undefined || group === null) return true
+  if (!isPlainRecord(group)) return false
+  const conditions = group.conditions
+  if (conditions === undefined) return true
+  if (!Array.isArray(conditions)) return false
+  // every child must be a flat AutomationCondition (no nested ConditionGroup)
+  return conditions.every(
+    (c) => isPlainRecord(c) && typeof c.fieldId === 'string' && !('conditions' in c),
+  )
+}
+
+/**
+ * Returns a human-readable reason the loaded `condition_branch` config cannot be faithfully edited
+ * by the v1 UI (→ read-only), or `null` if it round-trips losslessly (→ editable). PURE; never mutates.
+ */
+export function conditionBranchUnsupportedReason(config: unknown): string | null {
+  if (!isPlainRecord(config)) return null // empty / brand-new action → editable as fresh
+  const branches = config.branches
+  if (branches !== undefined && !Array.isArray(branches)) return 'branches must be an array'
+  for (const branch of Array.isArray(branches) ? branches : []) {
+    if (!isPlainRecord(branch)) return 'a branch is not an object'
+    if (!conditionGroupIsFlat(branch.conditions)) return 'a branch uses a nested condition group'
+    for (const action of Array.isArray(branch.actions) ? branch.actions : []) {
+      if (!branchActionRoundTrippable(action)) return 'a branch action is outside the v1 editable set'
+    }
+  }
+  const def = config.defaultBranch
+  if (def !== undefined && def !== null) {
+    if (!isPlainRecord(def)) return 'defaultBranch is not an object'
+    for (const action of Array.isArray(def.actions) ? def.actions : []) {
+      if (!branchActionRoundTrippable(action)) return 'a default-branch action is outside the v1 editable set'
+    }
+  }
+  return null
+}
+
+// ---- parse (load) / build (save) ----
+
+function actionToDraft(action: AutomationAction): BranchActionDraft {
+  if (action.type === 'update_record') {
+    const fields = isPlainRecord(action.config.fields) ? action.config.fields : {}
+    return {
+      type: 'update_record',
+      fieldUpdates: Object.entries(fields).map(([fieldId, value]) => ({ fieldId, value: String(value ?? '') })),
+    }
+  }
+  const userIds = Array.isArray(action.config.userIds) ? action.config.userIds : []
+  return {
+    type: 'send_notification',
+    userId: userIds.map((u) => String(u)).join(', '),
+    message: typeof action.config.message === 'string' ? action.config.message : '',
+  }
+}
+
+function draftToAction(action: BranchActionDraft): AutomationAction {
+  if (action.type === 'update_record') {
+    const fields: Record<string, string> = {}
+    for (const pair of action.fieldUpdates ?? []) {
+      const fieldId = pair.fieldId.trim()
+      if (fieldId) fields[fieldId] = pair.value
+    }
+    return { type: 'update_record', config: { fields } }
+  }
+  return {
+    type: 'send_notification',
+    config: {
+      userIds: (action.userId ?? '')
+        .split(/[\s,]+/)
+        .map((s) => s.trim())
+        .filter(Boolean),
+      message: (action.message ?? '').trim(),
+    },
+  }
+}
+
+/** Load an editable config into draft form. Only safe when `conditionBranchUnsupportedReason` is null. */
+export function parseConditionBranchDraft(config: Record<string, unknown>): ConditionBranchDraft {
+  const branches = (Array.isArray(config.branches) ? config.branches : []).map((raw): BranchDraft => {
+    const b = isPlainRecord(raw) ? raw : {}
+    const group = isPlainRecord(b.conditions) ? b.conditions : {}
+    const conjunction = group.conjunction === 'OR' || group.logic === 'or' ? 'OR' : 'AND'
+    return {
+      key: typeof b.key === 'string' ? b.key : '',
+      label: typeof b.label === 'string' ? b.label : '',
+      conjunction,
+      conditions: (Array.isArray(group.conditions) ? group.conditions : []) as AutomationCondition[],
+      actions: (Array.isArray(b.actions) ? b.actions : []).map((a) => actionToDraft(a as AutomationAction)),
+    }
+  })
+  const def = isPlainRecord(config.defaultBranch) ? config.defaultBranch : null
+  const defaultBranch: DefaultBranchDraft | null = def
+    ? {
+        key: typeof def.key === 'string' ? def.key : '',
+        label: typeof def.label === 'string' ? def.label : '',
+        actions: (Array.isArray(def.actions) ? def.actions : []).map((a) => actionToDraft(a as AutomationAction)),
+      }
+    : null
+  return { branches, defaultBranch }
+}
+
+/** Build the executor-shaped config from draft. `conjunction` is the canonical form (mirrors the rule editor). */
+export function buildConditionBranchConfig(draft: ConditionBranchDraft): Record<string, unknown> {
+  const branches = draft.branches.map((b) => ({
+    key: b.key.trim(),
+    ...(b.label.trim() ? { label: b.label.trim() } : {}),
+    conditions: { conjunction: b.conjunction, conditions: b.conditions },
+    actions: b.actions.map(draftToAction),
+  }))
+  const config: Record<string, unknown> = { branches }
+  if (draft.defaultBranch) {
+    config.defaultBranch = {
+      key: draft.defaultBranch.key.trim(),
+      ...(draft.defaultBranch.label.trim() ? { label: draft.defaultBranch.label.trim() } : {}),
+      actions: draft.defaultBranch.actions.map(draftToAction),
+    }
+  }
+  return config
+}
+
+/** Frontend mirror of the backend branch-key rules: safe, non-empty, unique (incl. default vs branches). */
+export function validateConditionBranchKeys(draft: ConditionBranchDraft): string | null {
+  if (draft.branches.length === 0) return 'at least one branch is required'
+  const seen = new Set<string>()
+  for (const branch of draft.branches) {
+    const key = branch.key.trim()
+    if (!SAFE_BRANCH_KEY.test(key)) return `branch key "${branch.key}" must be 1-64 of [A-Za-z0-9_-]`
+    if (seen.has(key)) return `branch key "${key}" must be unique`
+    seen.add(key)
+  }
+  if (draft.defaultBranch) {
+    const key = draft.defaultBranch.key.trim()
+    if (!SAFE_BRANCH_KEY.test(key)) return `default branch key "${draft.defaultBranch.key}" must be 1-64 of [A-Za-z0-9_-]`
+    if (seen.has(key)) return `default branch key "${key}" must be unique`
+  }
+  return null
+}
+
+export function isBranchAuthorableActionType(type: AutomationActionType): type is BranchAuthorableActionType {
+  return (BRANCH_AUTHORABLE_ACTION_TYPES as readonly string[]).includes(type)
+}

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -130,6 +130,18 @@ export type AutomationLabelKey =
   | 'actionConfig.emailBodyPlaceholder'
   | 'actionConfig.lockRecord'
   | 'actionConfig.waitForCallbackHint'
+  | 'conditionBranch.readOnly'
+  | 'conditionBranch.hint'
+  | 'conditionBranch.key'
+  | 'conditionBranch.label'
+  | 'conditionBranch.value'
+  | 'conditionBranch.userIds'
+  | 'conditionBranch.message'
+  | 'conditionBranch.addField'
+  | 'conditionBranch.addAction'
+  | 'conditionBranch.addBranch'
+  | 'conditionBranch.default'
+  | 'conditionBranch.addDefault'
   | 'testRun.warning'
   | 'testRun.confirmSuffix'
   | 'testRun.unsavedHint'
@@ -347,6 +359,18 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'actionConfig.emailBodyPlaceholder',
   'actionConfig.lockRecord',
   'actionConfig.waitForCallbackHint',
+  'conditionBranch.readOnly',
+  'conditionBranch.hint',
+  'conditionBranch.key',
+  'conditionBranch.label',
+  'conditionBranch.value',
+  'conditionBranch.userIds',
+  'conditionBranch.message',
+  'conditionBranch.addField',
+  'conditionBranch.addAction',
+  'conditionBranch.addBranch',
+  'conditionBranch.default',
+  'conditionBranch.addDefault',
   'testRun.warning',
   'testRun.confirmSuffix',
   'testRun.unsavedHint',
@@ -577,6 +601,24 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
     en: 'Suspends the run until an admin resumes it from the runs view. No parameters in v1 (no external webhook/timer).',
     zh: '挂起执行，直到管理员在运行视图中手动恢复。v1 无参数（暂无外部 webhook/定时器）。',
   },
+  'conditionBranch.readOnly': {
+    en: 'This branch rule uses constructs not editable in this version — read-only (save is disabled to avoid flattening it).',
+    zh: '该分支规则包含本版本不可编辑的结构 —— 只读（已禁用保存以避免压扁丢失）。',
+  },
+  'conditionBranch.hint': {
+    en: 'Run different action chains by condition: exactly one matching branch (or the default) runs. Branch actions are limited to update-record / send-notification in v1.',
+    zh: '按条件走不同动作链：仅命中其一分支（或默认分支）执行。v1 分支内动作限更新记录 / 发送通知。',
+  },
+  'conditionBranch.key': { en: 'Branch key', zh: '分支 key' },
+  'conditionBranch.label': { en: 'Label (optional)', zh: '标签（可选）' },
+  'conditionBranch.value': { en: 'Value', zh: '值' },
+  'conditionBranch.userIds': { en: 'User IDs (comma-separated)', zh: '用户 ID（逗号分隔）' },
+  'conditionBranch.message': { en: 'Message', zh: '消息' },
+  'conditionBranch.addField': { en: '+ Field', zh: '+ 字段' },
+  'conditionBranch.addAction': { en: '+ Action', zh: '+ 动作' },
+  'conditionBranch.addBranch': { en: '+ Branch', zh: '+ 分支' },
+  'conditionBranch.default': { en: 'Default branch (no condition)', zh: '默认分支（无条件）' },
+  'conditionBranch.addDefault': { en: '+ Default branch', zh: '+ 默认分支' },
   'testRun.warning': { en: 'Test Run executes the saved rule and can send real DingTalk messages to configured groups or users.', zh: '测试运行会执行已保存规则，并可能向已配置的钉钉群或用户发送真实消息。' },
   'testRun.confirmSuffix': { en: 'Unsaved changes are not included. Continue?', zh: '未保存的更改不会包含在内。是否继续？' },
   'testRun.unsavedHint': { en: 'Save this automation before running a test.', zh: '请先保存此自动化，再运行测试。' },

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -800,6 +800,8 @@ export function automationActionTypeLabel(type: AutomationActionType | (string &
       return isZh ? '锁定记录' : 'Lock record'
     case 'wait_for_callback':
       return isZh ? '等待回调（挂起）' : 'Wait for callback (suspend)'
+    case 'condition_branch':
+      return isZh ? '条件分支' : 'Condition branch'
     case 'update_field':
       return isZh ? '更新字段值' : 'Update field value'
     default:

--- a/apps/web/tests/conditionBranchAuthoring.spec.ts
+++ b/apps/web/tests/conditionBranchAuthoring.spec.ts
@@ -1,0 +1,129 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildConditionBranchConfig,
+  conditionBranchUnsupportedReason,
+  parseConditionBranchDraft,
+  validateConditionBranchKeys,
+} from '../src/multitable/utils/conditionBranchAuthoring'
+
+// A supported (v1-editable) condition_branch config: flat conditions, simple-subset actions.
+const SUPPORTED = {
+  branches: [
+    {
+      key: 'vip',
+      label: 'VIP tier',
+      conditions: { conjunction: 'AND', conditions: [{ fieldId: 'tier', operator: 'equals', value: 'vip' }] },
+      actions: [{ type: 'update_record', config: { fields: { status: 'done', note: 'vip' } } }],
+    },
+    {
+      key: 'bulk',
+      conditions: {
+        conjunction: 'OR',
+        conditions: [
+          { fieldId: 'qty', operator: 'gt', value: '100' },
+          { fieldId: 'flag', operator: 'is_empty' },
+        ],
+      },
+      actions: [{ type: 'send_notification', config: { userIds: ['u1', 'u2'], message: 'bulk' } }],
+    },
+  ],
+  defaultBranch: {
+    key: 'fallback',
+    actions: [{ type: 'update_record', config: { fields: { status: 'review' } } }],
+  },
+}
+
+describe('conditionBranchAuthoring — round-trip invariant (build∘parse = identity for supported)', () => {
+  it('round-trips a multi-branch + defaultBranch config losslessly', () => {
+    const draft = parseConditionBranchDraft(SUPPORTED)
+    expect(buildConditionBranchConfig(draft)).toEqual(SUPPORTED)
+  })
+
+  it('round-trips a minimal single-branch config', () => {
+    const cfg = {
+      branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [] }],
+    }
+    expect(buildConditionBranchConfig(parseConditionBranchDraft(cfg))).toEqual(cfg)
+  })
+
+  it('parses logic-form conjunction (semantic) and canonicalizes to conjunction on build', () => {
+    const cfg = {
+      branches: [{ key: 'a', conditions: { logic: 'or', conditions: [{ fieldId: 'x', operator: 'equals', value: '1' }] }, actions: [] }],
+    }
+    expect(conditionBranchUnsupportedReason(cfg)).toBeNull() // semantically representable
+    const built = buildConditionBranchConfig(parseConditionBranchDraft(cfg)) as any
+    expect(built.branches[0].conditions.conjunction).toBe('OR') // canonical form, meaning preserved
+  })
+})
+
+describe('conditionBranchUnsupportedReason — read-only guard (point #3: never flatten)', () => {
+  it('returns null for a supported config', () => {
+    expect(conditionBranchUnsupportedReason(SUPPORTED)).toBeNull()
+  })
+  it('returns null for an empty / brand-new action config', () => {
+    expect(conditionBranchUnsupportedReason({})).toBeNull()
+    expect(conditionBranchUnsupportedReason(undefined)).toBeNull()
+  })
+
+  const unsupported: Array<[string, unknown]> = [
+    ['nested condition group', {
+      branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [{ conjunction: 'OR', conditions: [{ fieldId: 'x', operator: 'equals', value: '1' }] }] }, actions: [] }],
+    }],
+    ['non-string update_record value (number)', {
+      branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [{ type: 'update_record', config: { fields: { amount: 5 } } }] }],
+    }],
+    ['update_record extra config key', {
+      branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [{ type: 'update_record', config: { fields: {}, sheetId: 's' } }] }],
+    }],
+    ['comma-bearing userId', {
+      branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [{ type: 'send_notification', config: { userIds: ['a,b'], message: 'm' } }] }],
+    }],
+    ['action type outside subset (create_record)', {
+      branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [{ type: 'create_record', config: { sheetId: 's', data: {} } }] }],
+    }],
+    ['wait_for_callback inside a branch', {
+      branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [{ type: 'wait_for_callback', config: {} }] }],
+    }],
+    ['nested condition_branch inside a branch', {
+      branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [{ type: 'condition_branch', config: { branches: [] } }] }],
+    }],
+    ['defaultBranch action outside subset', {
+      branches: [{ key: 'a', conditions: { conjunction: 'AND', conditions: [] }, actions: [] }],
+      defaultBranch: { key: 'd', actions: [{ type: 'send_email', config: {} }] },
+    }],
+    ['branches not an array', { branches: 'nope' }],
+  ]
+  it.each(unsupported)('flags %s as read-only', (_label, config) => {
+    expect(conditionBranchUnsupportedReason(config)).not.toBeNull()
+  })
+})
+
+describe('validateConditionBranchKeys — frontend mirror of backend (point #1)', () => {
+  const make = (branches: Array<{ key: string }>, def?: { key: string }) =>
+    ({
+      branches: branches.map((b) => ({ key: b.key, label: '', conjunction: 'AND' as const, conditions: [], actions: [] })),
+      defaultBranch: def ? { key: def.key, label: '', actions: [] } : null,
+    })
+
+  it('accepts safe, non-empty, unique keys', () => {
+    expect(validateConditionBranchKeys(make([{ key: 'a' }, { key: 'b' }], { key: 'def' }))).toBeNull()
+  })
+  it('rejects empty branch list', () => {
+    expect(validateConditionBranchKeys(make([]))).toContain('at least one')
+  })
+  it('rejects an unsafe key (whitespace)', () => {
+    expect(validateConditionBranchKeys(make([{ key: 'bad key' }]))).toContain('A-Za-z0-9_-')
+  })
+  it('rejects an empty key', () => {
+    expect(validateConditionBranchKeys(make([{ key: '' }]))).not.toBeNull()
+  })
+  it('rejects a >64-char key', () => {
+    expect(validateConditionBranchKeys(make([{ key: 'x'.repeat(65) }]))).not.toBeNull()
+  })
+  it('rejects duplicate branch keys', () => {
+    expect(validateConditionBranchKeys(make([{ key: 'a' }, { key: 'a' }]))).toContain('unique')
+  })
+  it('rejects a defaultBranch key colliding with a branch key', () => {
+    expect(validateConditionBranchKeys(make([{ key: 'a' }], { key: 'a' }))).toContain('unique')
+  })
+})

--- a/apps/web/tests/conditionBranchEditor.spec.ts
+++ b/apps/web/tests/conditionBranchEditor.spec.ts
@@ -1,0 +1,161 @@
+// A6-3-2a UI tests — condition_branch editor through the real component (create + edit + read-only + keys).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import MetaAutomationRuleEditor from '../src/multitable/components/MetaAutomationRuleEditor.vue'
+import { useLocale } from '../src/composables/useLocale'
+import type { AutomationRule } from '../src/multitable/types'
+
+function flush() {
+  return new Promise<void>((r) => setTimeout(r, 0)).then(() => nextTick())
+}
+
+const fields = [
+  { id: 'fld_1', name: 'Status', type: 'select', options: [{ value: 'done', label: 'Done' }] },
+  { id: 'fld_2', name: 'Name', type: 'string' },
+]
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(MetaAutomationRuleEditor, props) })
+  app.mount(container)
+  return { container, app }
+}
+
+function setInput(container: HTMLElement, selector: string, value: string) {
+  const el = container.querySelector(selector) as HTMLInputElement
+  el.value = value
+  el.dispatchEvent(new Event('input'))
+}
+function selectAction0(container: HTMLElement, type: string) {
+  const sel = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+  sel.value = type
+  sel.dispatchEvent(new Event('change'))
+}
+function ruleWithBranch(config: Record<string, unknown>): AutomationRule {
+  return {
+    id: 'rule_cb', sheetId: 'sheet_1', name: 'Branch rule', triggerType: 'record.created', triggerConfig: {},
+    actionType: 'condition_branch', actionConfig: config, enabled: true, executionMode: 'workflow_job_v1',
+    actions: [{ type: 'condition_branch', config }],
+  } as AutomationRule
+}
+
+beforeEach(() => useLocale().setLocale('en'))
+afterEach(() => { document.body.innerHTML = ''; vi.restoreAllMocks() })
+
+describe('A6-3-2a condition_branch editor', () => {
+  it('#2 auto-lock: selecting condition_branch forces workflow_job_v1 (toggle checked+disabled) and buildPayload enforces it on save', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flush()
+    setInput(container, '[data-field="name"]', 'Branch rule')
+    selectAction0(container, 'condition_branch')
+    await flush()
+    const toggle = container.querySelector('[data-field="executionMode"]') as HTMLInputElement
+    expect(toggle.checked).toBe(true)
+    expect(toggle.disabled).toBe(true)
+    const saveBtn = container.querySelector('[data-action="save"]') as HTMLButtonElement
+    expect(saveBtn.disabled).toBe(false) // default branch (branch_1) is valid
+    saveBtn.click()
+    await flush()
+    expect(saved).toHaveBeenCalledTimes(1)
+    expect(saved.mock.calls[0][0].executionMode).toBe('workflow_job_v1')
+    expect(saved.mock.calls[0][0].actions[0].type).toBe('condition_branch')
+  })
+
+  it('#4 create: a branch with a condition + update_record action saves the executor-shaped config', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flush()
+    setInput(container, '[data-field="name"]', 'Tier rule')
+    selectAction0(container, 'condition_branch')
+    await flush()
+    // branch_1: add a condition (Name = vip)
+    ;(container.querySelector('[data-branch-index="0"] [data-action="add-branch-condition"]') as HTMLButtonElement).click()
+    await flush()
+    const condRow = container.querySelector('[data-branch-index="0"] [data-branch-condition-index="0"]') as HTMLElement
+    const fieldSel = condRow.querySelector('select') as HTMLSelectElement
+    fieldSel.value = 'fld_2'; fieldSel.dispatchEvent(new Event('change'))
+    await flush()
+    const valInput = condRow.querySelector('input') as HTMLInputElement
+    valInput.value = 'vip'; valInput.dispatchEvent(new Event('input'))
+    // branch_1 action 0 (update_record default): add a field pair Status=done
+    ;(container.querySelector('[data-branch-index="0"] [data-action="add-branch-field"]') as HTMLButtonElement).click()
+    await flush()
+    const pair = container.querySelector('[data-branch-index="0"] .meta-rule-editor__field-pair') as HTMLElement
+    const pairField = pair.querySelector('select') as HTMLSelectElement
+    pairField.value = 'fld_1'; pairField.dispatchEvent(new Event('change'))
+    const pairVal = pair.querySelector('input') as HTMLInputElement
+    pairVal.value = 'done'; pairVal.dispatchEvent(new Event('input'))
+    await flush()
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flush()
+    const payload = saved.mock.calls[0][0]
+    const branch = payload.actions[0].config.branches[0]
+    expect(branch.key).toBe('branch_1')
+    expect(branch.conditions.conditions[0]).toMatchObject({ fieldId: 'fld_2', value: 'vip' })
+    expect(branch.actions).toEqual([{ type: 'update_record', config: { fields: { fld_1: 'done' } } }])
+  })
+
+  it('#4 edit: loads a supported condition_branch rule and round-trips it on save', async () => {
+    const config = {
+      branches: [{
+        key: 'vip',
+        conditions: { conjunction: 'AND', conditions: [{ fieldId: 'fld_2', operator: 'equals', value: 'vip' }] },
+        actions: [{ type: 'send_notification', config: { userIds: ['u1', 'u2'], message: 'hi' } }],
+      }],
+    }
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule: ruleWithBranch(config), onSave: saved })
+    await flush()
+    expect((container.querySelector('[data-branch-index="0"] [data-field="branch-key"]') as HTMLInputElement).value).toBe('vip')
+    expect(container.querySelector('[data-field="condition-branch-readonly"]')).toBeNull()
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flush()
+    expect(saved.mock.calls[0][0].actions[0].config).toEqual(config)
+  })
+
+  it('#3 read-only: an unsupported loaded branch (action outside subset) shows the banner and blocks save (never flattens)', async () => {
+    const config = {
+      branches: [{
+        key: 'a', conditions: { conjunction: 'AND', conditions: [] },
+        actions: [{ type: 'create_record', config: { sheetId: 's', data: {} } }], // outside subset
+      }],
+    }
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule: ruleWithBranch(config) })
+    await flush()
+    expect(container.querySelector('[data-field="condition-branch-readonly"]')).not.toBeNull()
+    expect((container.querySelector('[data-action="save"]') as HTMLButtonElement).disabled).toBe(true)
+    // no branch-builder rendered (read-only)
+    expect(container.querySelector('[data-action-config="condition_branch"] [data-branch-index="0"]')).toBeNull()
+  })
+
+  it('#1 key validation: a duplicate branch key blocks save and shows the error', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flush()
+    setInput(container, '[data-field="name"]', 'Dup')
+    selectAction0(container, 'condition_branch')
+    await flush()
+    ;(container.querySelector('[data-action-config="condition_branch"] [data-action="add-branch"]') as HTMLButtonElement).click()
+    await flush()
+    // set both branch keys to the same value
+    const keyInputs = container.querySelectorAll('[data-branch-index] [data-field="branch-key"]')
+    ;(keyInputs[1] as HTMLInputElement).value = 'branch_1'
+    ;(keyInputs[1] as HTMLInputElement).dispatchEvent(new Event('input'))
+    await flush()
+    expect(container.querySelector('[data-field="branch-key-error"]')).not.toBeNull()
+    expect((container.querySelector('[data-action="save"]') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('#4 branch→normal: switching the action off condition_branch unlocks the job-mode toggle', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flush()
+    setInput(container, '[data-field="name"]', 'Switch')
+    selectAction0(container, 'condition_branch')
+    await flush()
+    expect((container.querySelector('[data-field="executionMode"]') as HTMLInputElement).disabled).toBe(true)
+    selectAction0(container, 'update_record')
+    await flush()
+    expect((container.querySelector('[data-field="executionMode"]') as HTMLInputElement).disabled).toBe(false)
+  })
+})


### PR DESCRIPTION
A6-3-2a: the frontend authoring UI for the `condition_branch` runtime landed in #2321. **Frontend-only — consumes the landed A6-3-1 contract, no backend/contract change.** Follows A6-3 design-lock §10 (editor half; the runs-detail readability is **A6-3-2b**, a separate follow-up).

## Design: seam-first, read-only-never-flatten
The save/load contract is a **pure, unit-testable module** (`conditionBranchAuthoring.ts`) with an explicit invariant — a loaded config is only edited when it round-trips losslessly; anything else opens **read-only** and is re-emitted verbatim, **never flattened**. The SFC threads it through `draftConfigFromAction`/`buildPayload`/`canSave`. No refactor of the shared `draft.conditions`/`draft.actions` builders (contained, per the agreed blast-radius call).

## §10 acceptance (editor half)
- ✅ minimal `condition_branch` editor block (form-based branch list + flat conditions + subset actions + `defaultBranch`)
- ✅ force/lock `workflow_job_v1` when a `condition_branch` is present (the #2245 precedent)
- ✅ **no canvas editor**, **no BPMN/gateway vocabulary**
- ↪️ "display branch parent + selected branch jobs in admin runs detail" = **A6-3-2b** (separate)

## The 4 owner acceptance points (all covered, contract + UI)
1. **branch-key validation mirrors backend** — `validateConditionBranchKeys` (SAFE_BRANCH_KEY + non-empty + unique incl. `defaultBranch` vs branches) → blocks save + inline error. (7 contract + 1 UI test)
2. **auto-lock enforced in `buildPayload`** — `requiresJobMode` includes `condition_branch`; `buildPayload` forces `executionMode:'workflow_job_v1'` regardless of toggle/loaded state. (UI test #2)
3. **loaded richer shape → block-save read-only, never flatten** — nested condition groups · non-string `update_record` values · comma-bearing `userIds` · branch actions outside the subset · `wait_for_callback`/nested `condition_branch` in a branch → read-only banner + save disabled + original re-emitted verbatim. (11 contract + 1 UI test)
4. **create + edit both paths tested** — new authoring; load-supported → round-trip; branch-action→normal-action `executionMode` behavior; `draftConfigFromAction` ↔ `buildPayload` both directions locked. (round-trip contract + 3 UI tests)

## Minimal boundary (stated, per the agreed "decide minimal + disclose")
v1 authors **flat** per-branch conditions and the **`update_record` / `send_notification`** action subset. Nested condition groups, richer per-branch action config, and other branch action types are **not authored** here — a loaded rule using them opens **read-only** (never flattened), to be widened in a later slice.

## Verification (local, worktree red-green)
- **121 tests green**: 94 existing editor spec (no regression) + **21** seam contract tests (round-trip / read-only / keys) + **6** UI tests (the 4 points + branch→normal).
- `vue-tsc --noEmit` **0 errors**.
- (Frontend-only; runs in the web vitest job. No backend/contract/migration touched.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)