### PR TITLE
feat(plm): PLM-COLLAB-P3-D2 backend — offline-verify Yuantus embed token + dedicated relay

### DIFF
--- a/packages/core-backend/src/auth/embed-config.ts
+++ b/packages/core-backend/src/auth/embed-config.ts
@@ -1,0 +1,36 @@
+/**
+ * PLM-COLLAB-P3-D2 embed config. PLM_EMBED_ALLOWED_ORIGINS is the SINGLE source for all three
+ * origin layers (the backend embed_origin-claim check, the CSP frame-ancestors value served to
+ * the edge, and the frontend postMessage parent-origin allowlist) so they can't drift apart.
+ */
+
+/** CSV allowlist of embed origins; a literal '*' is DROPPED (never allow-all, mirrors the mint side). */
+export function embedAllowedOrigins(): string[] {
+  return (process.env.PLM_EMBED_ALLOWED_ORIGINS || '')
+    .split(',')
+    .map((s) => s.trim())
+    .filter((s) => s && s !== '*')
+}
+
+/** CSP frame-ancestors value. Fail CLOSED when unconfigured: 'none' (the iframe won't render). */
+export function frameAncestorsValue(): string {
+  const origins = embedAllowedOrigins()
+  return origins.length ? `frame-ancestors ${origins.join(' ')}` : "frame-ancestors 'none'"
+}
+
+/** kid -> base64 raw Ed25519 PUBLIC key (Yuantus distributes the public key by deploy config). */
+export function embedPublicKeysByKid(): Record<string, string> {
+  const pub = (process.env.YUANTUS_EMBED_PUBLIC_KEY || '').trim()
+  const kid = (process.env.YUANTUS_EMBED_KEY_ID || 'embed-1').trim()
+  return pub ? { [kid]: pub } : {}
+}
+
+/** The expected JWT `aud` (recipient SERVICE) for standard audience validation. */
+export function embedAudience(): string {
+  return (process.env.PLM_EMBED_AUDIENCE || 'metasheet2.embed').trim() || 'metasheet2.embed'
+}
+
+/** The SERVER-configured PLM data source the embed is bound to (NEVER taken from the request). */
+export function embedDataSourceId(): string {
+  return (process.env.PLM_EMBED_DATA_SOURCE_ID || '').trim()
+}

--- a/packages/core-backend/src/auth/embed-token-verify.ts
+++ b/packages/core-backend/src/auth/embed-token-verify.ts
@@ -1,0 +1,99 @@
+/**
+ * PLM-COLLAB-P3-D2: offline verification of a Yuantus-issued Ed25519 (EdDSA) embed token.
+ *
+ * The Yuantus deployment signs the token with its PRIVATE key (PLM-COLLAB-P3-D1); metasheet2
+ * verifies OFFLINE with the matching PUBLIC key (kid-addressed) and therefore can never mint.
+ * We verify the signature over the RECEIVED `header_b64.payload_b64` bytes (NEVER re-serialized
+ * claims — the classic JWT bug), then check aud / typ / exp / part_id. EdDSA over Ed25519 is
+ * verified via node:crypto (no jose dep): a raw 32-byte public key -> JWK -> KeyObject ->
+ * crypto.verify(null, ...). This is wire-compatible with the Python minter (cross-language
+ * vector test pins it).
+ */
+import crypto from 'node:crypto'
+
+export interface EmbedTokenClaims {
+  sub?: string
+  tenant_id?: string
+  org_id?: string
+  part_id: string
+  feature_key?: string
+  aud?: string
+  embed_origin?: string
+  exp?: number
+  iat?: number
+  jti?: string
+  typ?: string
+  [key: string]: unknown
+}
+
+export class EmbedTokenError extends Error {}
+
+function b64urlToBuf(s: string): Buffer {
+  return Buffer.from(s, 'base64url')
+}
+
+/** A raw base64 (standard) Ed25519 public key (32 bytes) -> a node KeyObject via JWK. */
+function loadEd25519PublicKey(rawB64: string): crypto.KeyObject {
+  const raw = Buffer.from(rawB64, 'base64')
+  return crypto.createPublicKey({
+    key: { kty: 'OKP', crv: 'Ed25519', x: raw.toString('base64url') },
+    format: 'jwk',
+  })
+}
+
+export interface VerifyEmbedTokenOptions {
+  publicKeysByKid: Record<string, string> // kid -> base64 raw Ed25519 public key
+  audience: string
+  now?: number // unix seconds; defaults to Date.now()/1000 (injectable for tests)
+  expectedTyp?: string // default "embed"
+}
+
+export function verifyEmbedToken(token: string, opts: VerifyEmbedTokenOptions): EmbedTokenClaims {
+  const parts = token.split('.')
+  if (parts.length !== 3) throw new EmbedTokenError('malformed token')
+  const [headerB64, payloadB64, sigB64] = parts
+
+  let header: Record<string, unknown>
+  let claims: EmbedTokenClaims
+  try {
+    header = JSON.parse(b64urlToBuf(headerB64).toString('utf8')) as Record<string, unknown>
+    claims = JSON.parse(b64urlToBuf(payloadB64).toString('utf8')) as EmbedTokenClaims
+  } catch {
+    throw new EmbedTokenError('invalid token encoding')
+  }
+
+  if (header.alg !== 'EdDSA') throw new EmbedTokenError('unsupported alg')
+  const kid = typeof header.kid === 'string' ? header.kid : ''
+  const pubB64 = kid ? opts.publicKeysByKid[kid] : undefined
+  if (!kid || !pubB64) throw new EmbedTokenError('unknown key id')
+
+  // verify over the RECEIVED header.payload bytes (never re-serialized)
+  const signingInput = Buffer.from(`${headerB64}.${payloadB64}`, 'ascii')
+  let key: crypto.KeyObject
+  try {
+    key = loadEd25519PublicKey(pubB64)
+  } catch {
+    throw new EmbedTokenError('invalid public key')
+  }
+  let ok = false
+  try {
+    ok = crypto.verify(null, signingInput, key, b64urlToBuf(sigB64))
+  } catch {
+    ok = false
+  }
+  if (!ok) throw new EmbedTokenError('invalid signature')
+
+  // claim checks (standard audience + embed type + REQUIRED expiry + required part binding)
+  if (claims.aud !== opts.audience) throw new EmbedTokenError('wrong audience')
+  if (claims.typ !== (opts.expectedTyp ?? 'embed')) throw new EmbedTokenError('wrong token type')
+  // exp MUST be a finite number -- a missing/non-numeric exp would make the token never expire,
+  // breaking the P3-D short-TTL contract.
+  if (typeof claims.exp !== 'number' || !Number.isFinite(claims.exp)) {
+    throw new EmbedTokenError('missing or invalid exp')
+  }
+  const now = opts.now ?? Math.floor(Date.now() / 1000)
+  if (now > claims.exp) throw new EmbedTokenError('token expired')
+  if (typeof claims.part_id !== 'string' || !claims.part_id) throw new EmbedTokenError('missing part_id')
+
+  return claims
+}

--- a/packages/core-backend/src/auth/jwt-middleware.ts
+++ b/packages/core-backend/src/auth/jwt-middleware.ts
@@ -20,7 +20,11 @@ const AUTH_WHITELIST = [
   '/api/v2/rpc-test',
   '/internal/metrics',
   '/api/cache-test',
-  '/api/permissions/health'
+  '/api/permissions/health',
+  // PLM-COLLAB-P3-D2: embed routes are authenticated by the EdDSA embed token (embedTokenAuth),
+  // NOT the session JWT, so they must bypass the global session gate. embedTokenAuth is their
+  // sole auth; /api/plm-embed/config is intentionally public (it only serves the origin allowlist).
+  '/api/plm-embed/'
 ]
 
 const PASSWORD_CHANGE_WHITELIST = [

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -130,6 +130,7 @@ import { PluginRuntimeSecurityService } from './security/plugin-runtime-security
 import workflowRouter from './routes/workflow'
 import workflowDesignerRouter from './routes/workflow-designer'
 import plmWorkbenchRouter from './routes/plm-workbench'
+import plmEmbedRouter from './routes/plm-embed'
 import { univerMockRouter } from './routes/univer-mock'
 import { univerMetaRouter } from './routes/univer-meta'
 import { dashboardRouter } from './routes/dashboard'
@@ -1017,8 +1018,10 @@ export class MetaSheetServer {
     const plmEnabled = isPlmEnabled(process.env.PRODUCT_MODE, process.env.ENABLE_PLM)
     if (plmEnabled) {
       this.app.use(plmWorkbenchRouter)
+      this.app.use(plmEmbedRouter())
     } else {
       this.app.use('/api/plm-workbench', disabledFeatureHandler('PLM workbench is disabled in this deployment'))
+      this.app.use('/api/plm-embed', disabledFeatureHandler('PLM embed is disabled in this deployment'))
       this.app.use('/api/federation/plm', disabledFeatureHandler('PLM federation APIs are disabled in this deployment'))
       this.app.use('/api/federation/import/plm', disabledFeatureHandler('PLM import APIs are disabled in this deployment'))
     }

--- a/packages/core-backend/src/middleware/embed-token-auth.ts
+++ b/packages/core-backend/src/middleware/embed-token-auth.ts
@@ -1,0 +1,42 @@
+/**
+ * PLM-COLLAB-P3-D2: authenticate an embed request by its `X-PLM-Embed-Token` header (a Yuantus
+ * EdDSA embed JWT), verified OFFLINE with the Yuantus public key. A custom header (NOT
+ * `Authorization: Bearer`) so it never collides with the session-JWT path. The embed routes are
+ * whitelisted from the global session-JWT gate so THIS is their sole auth.
+ *
+ * Failure modes: no token -> 401; no Yuantus public key configured -> 503 (fail-closed, the
+ * embed is simply unavailable, NOT a 401); bad/expired/wrong-aud/wrong-type token -> 401.
+ */
+import type { Request, Response, NextFunction } from 'express'
+import { verifyEmbedToken, type EmbedTokenClaims } from '../auth/embed-token-verify'
+import { embedAudience, embedPublicKeysByKid } from '../auth/embed-config'
+
+declare global {
+  // eslint-disable-next-line @typescript-eslint/no-namespace
+  namespace Express {
+    interface Request {
+      embedToken?: EmbedTokenClaims
+    }
+  }
+}
+
+export function embedTokenAuth(req: Request, res: Response, next: NextFunction): void {
+  const raw = req.headers['x-plm-embed-token']
+  const token = (Array.isArray(raw) ? raw[0] : raw)?.trim()
+  if (!token) {
+    res.status(401).json({ ok: false, error: { code: 'EMBED_TOKEN_REQUIRED', message: 'embed token required' } })
+    return
+  }
+  const publicKeys = embedPublicKeysByKid()
+  if (Object.keys(publicKeys).length === 0) {
+    res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed verification not configured' } })
+    return
+  }
+  try {
+    req.embedToken = verifyEmbedToken(token, { publicKeysByKid: publicKeys, audience: embedAudience() })
+  } catch {
+    res.status(401).json({ ok: false, error: { code: 'INVALID_EMBED_TOKEN', message: 'invalid embed token' } })
+    return
+  }
+  next()
+}

--- a/packages/core-backend/src/routes/plm-embed.ts
+++ b/packages/core-backend/src/routes/plm-embed.ts
@@ -1,0 +1,92 @@
+/**
+ * PLM-COLLAB-P3-D2: the DEDICATED embed relay (NOT the P3-C `/api/plm-workbench/...` route,
+ * which is session-JWT gated). These paths are whitelisted from the global session gate and
+ * authenticated solely by `embedTokenAuth` (the EdDSA embed token).
+ *
+ * Hard rules (owner-ratified):
+ * - The data source is SERVER-configured (`PLM_EMBED_DATA_SOURCE_ID`), NEVER taken from the
+ *   request — `DataSourceManager.getDataSource()` does no owner check and the embed token has
+ *   no metasheet user identity, so an iframe must not be able to point at an arbitrary source.
+ * - The part is the token-bound `part_id` claim, NEVER a request input.
+ * - `embed_origin` must be in the allowlist (defence in depth on top of the edge CSP).
+ * - Read-only; never 500s -> degrades.
+ *
+ * CSP frame-ancestors is computed here (fail-closed 'none' when unconfigured) and exposed via
+ * `/config`; the actual `Content-Security-Policy` header on the embed HTML document is applied
+ * at the deploy edge (Express does not serve the SPA HTML). The code-enforced controls are the
+ * token verification + the embed_origin allowlist + the frontend postMessage origin pin.
+ */
+import { Router, type Request, type Response } from 'express'
+import { getDataSourceManager } from './data-sources'
+import { embedTokenAuth } from '../middleware/embed-token-auth'
+import { embedAllowedOrigins, embedDataSourceId, frameAncestorsValue } from '../auth/embed-config'
+import type { BomMultitableContextResult } from '../data-adapters/PLMAdapter'
+
+const BOM_FEATURE_KEY = 'bom_multitable'
+
+interface PlmBomAdapter {
+  getBomMultitableContext(partId: string): Promise<BomMultitableContextResult>
+}
+function isPlmBomAdapter(adapter: unknown): adapter is PlmBomAdapter {
+  return typeof (adapter as PlmBomAdapter | null)?.getBomMultitableContext === 'function'
+}
+
+export default function plmEmbedRouter(): Router {
+  const router = Router()
+
+  // Public config the embed iframe fetches to learn its parent-origin allowlist (single source:
+  // PLM_EMBED_ALLOWED_ORIGINS) + the frame-ancestors value the deploy edge should apply. NOT
+  // derived from the iframe URL, so an attacker can't widen the allowlist.
+  router.get('/api/plm-embed/config', (_req: Request, res: Response) => {
+    res.json({
+      ok: true,
+      data: { allowed_origins: embedAllowedOrigins(), frame_ancestors: frameAncestorsValue() },
+    })
+  })
+
+  // The gated embed data route. Bound to the configured source + the token's part.
+  router.get(
+    '/api/plm-embed/bom-review/context',
+    embedTokenAuth,
+    async (req: Request, res: Response) => {
+      const claims = req.embedToken!
+      // the embed token must be scoped to THIS feature: a same-audience/typ embed token minted
+      // for another PLM feature must NOT be accepted by the BOM review relay.
+      if (claims.feature_key !== BOM_FEATURE_KEY) {
+        return res.status(403).json({ ok: false, error: { code: 'EMBED_FEATURE_MISMATCH', message: 'token not scoped to bom_multitable' } })
+      }
+      const origin = typeof claims.embed_origin === 'string' ? claims.embed_origin : ''
+      if (!origin || !embedAllowedOrigins().includes(origin)) {
+        return res.status(403).json({ ok: false, error: { code: 'EMBED_ORIGIN_NOT_ALLOWED', message: 'embed origin not allowed' } })
+      }
+
+      const dataSourceId = embedDataSourceId()
+      if (!dataSourceId) {
+        return res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed data source not configured' } })
+      }
+
+      let adapter: unknown
+      try {
+        adapter = getDataSourceManager().getDataSource(dataSourceId)
+      } catch {
+        return res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed data source unavailable' } })
+      }
+      if (!isPlmBomAdapter(adapter)) {
+        return res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed data source unsupported' } })
+      }
+
+      const partId = claims.part_id // token-bound; never a request input
+      let result: BomMultitableContextResult
+      try {
+        result = await adapter.getBomMultitableContext(partId)
+      } catch {
+        // never 500 -> degrade (transient provider failure)
+        return res.json({ ok: true, data: { available: true, entitled: true, context: null, reason: 'unavailable', part_id: partId } })
+      }
+      const entitled = result.entitled === true
+      return res.json({ ok: true, data: { available: true, entitled, context: entitled ? result.context : null, part_id: partId } })
+    },
+  )
+
+  return router
+}

--- a/packages/core-backend/tests/unit/embed-token-verify.test.ts
+++ b/packages/core-backend/tests/unit/embed-token-verify.test.ts
@@ -1,0 +1,63 @@
+import { describe, it, expect } from 'vitest'
+import { verifyEmbedToken, EmbedTokenError } from '../../src/auth/embed-token-verify'
+
+// CROSS-LANGUAGE VECTOR: this token + public key were produced by the REAL Yuantus P3-D1 Python
+// minter (`yuantus.security.auth.jwt.encode_eddsa`) with a fixed 32-byte seed. Verifying it here
+// proves node:crypto accepts a Python-signed Ed25519 JWT (sorted-keys compact JSON, unpadded
+// base64url, signature over `header_b64.payload_b64`) — a node↔node roundtrip would NOT.
+const PUB = 'A6EHv/POEL4dcN0Y50vAmWfk1jCbpQ1fHdyGZBJVMbg='
+const KID = 'embed-1'
+const TOKEN =
+  'eyJhbGciOiJFZERTQSIsImtpZCI6ImVtYmVkLTEiLCJ0eXAiOiJKV1QifQ' +
+  '.eyJhdWQiOiJtZXRhc2hlZXQyLmVtYmVkIiwiZW1iZWRfb3JpZ2luIjoiaHR0cHM6Ly9wbG0uZXhhbXBsZS5jb20iLCJleHAiOjE3NTAwMDAxMjAsImZlYXR1cmVfa2V5IjoiYm9tX211bHRpdGFibGUiLCJpYXQiOjE3NTAwMDAwMDAsImp0aSI6InRlc3QtanRpLTEyMyIsIm9yZ19pZCI6ImFjbWUiLCJwYXJ0X2lkIjoiUDEiLCJzdWIiOiI3IiwidGVuYW50X2lkIjoiZGVmYXVsdCIsInR5cCI6ImVtYmVkIn0' +
+  '.LoRjz4keK-gF3fwBpyv4v2geru0cQsKe_75Mn4mRyo_lhyy9LC2X5EpE0ebaYqJF6bDw8XfwoBvkjK0PMEtwCw'
+const KEYS = { [KID]: PUB }
+const AUD = 'metasheet2.embed'
+const NOW = 1750000050 // before exp (1750000120)
+
+describe('verifyEmbedToken (P3-D2 cross-language EdDSA offline verify)', () => {
+  it('verifies a token minted by the REAL Yuantus Python minter and returns the claims', () => {
+    const claims = verifyEmbedToken(TOKEN, { publicKeysByKid: KEYS, audience: AUD, now: NOW })
+    expect(claims.part_id).toBe('P1')
+    expect(claims.aud).toBe(AUD)
+    expect(claims.typ).toBe('embed')
+    expect(claims.embed_origin).toBe('https://plm.example.com')
+    expect(claims.tenant_id).toBe('default')
+    expect(claims.feature_key).toBe('bom_multitable')
+  })
+
+  it('rejects a wrong audience', () => {
+    expect(() => verifyEmbedToken(TOKEN, { publicKeysByKid: KEYS, audience: 'someone.else', now: NOW })).toThrow(EmbedTokenError)
+  })
+
+  it('rejects an expired token', () => {
+    expect(() => verifyEmbedToken(TOKEN, { publicKeysByKid: KEYS, audience: AUD, now: 1750009999 })).toThrow(/expired/)
+  })
+
+  it('rejects an unknown kid', () => {
+    expect(() => verifyEmbedToken(TOKEN, { publicKeysByKid: { 'other-kid': PUB }, audience: AUD, now: NOW })).toThrow(/key id/)
+  })
+
+  it('rejects a tampered signature', () => {
+    const [h, p] = TOKEN.split('.')
+    const tampered = `${h}.${p}.${'A'.repeat(86)}`
+    expect(() => verifyEmbedToken(tampered, { publicKeysByKid: KEYS, audience: AUD, now: NOW })).toThrow(/signature/)
+  })
+
+  it('rejects a swapped payload (signature is over the RECEIVED bytes, not re-serialized claims)', () => {
+    const [h, , s] = TOKEN.split('.')
+    const evilPayload = Buffer.from(
+      JSON.stringify({ aud: AUD, typ: 'embed', part_id: 'HACKED', exp: 9999999999 }),
+    ).toString('base64url')
+    const tampered = `${h}.${evilPayload}.${s}`
+    expect(() => verifyEmbedToken(tampered, { publicKeysByKid: KEYS, audience: AUD, now: NOW })).toThrow(/signature/)
+  })
+
+  it('rejects a wrong typ', () => {
+    expect(() => verifyEmbedToken(TOKEN, { publicKeysByKid: KEYS, audience: AUD, now: NOW, expectedTyp: 'auth' })).toThrow(/token type/)
+  })
+
+  it('rejects a malformed token', () => {
+    expect(() => verifyEmbedToken('not.a.jwt.token', { publicKeysByKid: KEYS, audience: AUD, now: NOW })).toThrow(EmbedTokenError)
+  })
+})

--- a/packages/core-backend/tests/unit/plm-embed-routes.test.ts
+++ b/packages/core-backend/tests/unit/plm-embed-routes.test.ts
@@ -1,0 +1,168 @@
+import crypto from 'node:crypto'
+import express from 'express'
+import request from 'supertest'
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Controllable DataSourceManager mock.
+const dsMocks = vi.hoisted(() => ({ getDataSource: vi.fn() }))
+
+// Stub jwt-middleware's heavy deps so importing the REAL isWhitelisted is cheap. We do NOT mock
+// jwt-middleware itself -- we want the REAL whitelist (it must include /api/plm-embed/).
+vi.mock('../../src/db/sharding/tenant-context', () => ({ extractTenantFromHeaders: () => undefined }))
+vi.mock('../../src/metrics/metrics', () => ({ metrics: new Proxy({}, { get: () => ({ inc: () => {} }) }) }))
+vi.mock('../../src/auth/AuthService', () => ({ authService: {} }))
+vi.mock('../../src/routes/data-sources', () => ({
+  getDataSourceManager: () => ({ getDataSource: dsMocks.getDataSource }),
+}))
+
+import { isWhitelisted } from '../../src/auth/jwt-middleware'
+import plmEmbedRouter from '../../src/routes/plm-embed'
+
+const KID = 'embed-1'
+const AUD = 'metasheet2.embed'
+const ORIGIN = 'https://plm.example.com'
+const DS_ID = 'plm-ds'
+
+// A node-side Ed25519 minter that mirrors the Yuantus wire format (sign over header_b64.payload_b64,
+// unpadded base64url). Cross-language correctness vs the Python minter is proven separately in
+// embed-token-verify.test.ts; here we need freshly-minted, non-expired tokens to drive the route.
+const { publicKey, privateKey } = crypto.generateKeyPairSync('ed25519')
+const PUB_B64 = Buffer.from((publicKey.export({ format: 'jwk' }) as { x: string }).x, 'base64url').toString('base64')
+
+function mint(overrides: Record<string, unknown> = {}, kid = KID): string {
+  const now = Math.floor(Date.now() / 1000)
+  const claims = { sub: '7', tenant_id: 'default', part_id: 'P1', feature_key: 'bom_multitable', aud: AUD, embed_origin: ORIGIN, iat: now, exp: now + 120, jti: 'j1', typ: 'embed', ...overrides }
+  const header = Buffer.from(JSON.stringify({ alg: 'EdDSA', typ: 'JWT', kid })).toString('base64url')
+  const payload = Buffer.from(JSON.stringify(claims)).toString('base64url')
+  const sig = crypto.sign(null, Buffer.from(`${header}.${payload}`, 'ascii'), privateKey).toString('base64url')
+  return `${header}.${payload}.${sig}`
+}
+
+const CONTEXT = { part: { part_id: 'P1', item_number: 'P-001', name: 'A', state: 'Released', generation: 3 }, lines: [], source_version: 3, source_updated_at: '2026', sync_status: 'snapshot', template_key: 'bom_review' }
+
+function buildApp() {
+  const app = express()
+  app.use(express.json())
+  // Reproduce the REAL global gate (index.ts:927): whitelisted -> through; else /api/* needs the
+  // session JWT (stood in here by a 401, exactly what jwtAuthMiddleware does on a missing token).
+  app.use((req, res, next) => {
+    if (isWhitelisted(req.path)) return next()
+    if (req.path.startsWith('/api/')) return res.status(401).json({ ok: false, error: { code: 'UNAUTHORIZED' } })
+    return next()
+  })
+  app.use(plmEmbedRouter())
+  return app
+}
+
+const URL = '/api/plm-embed/bom-review/context'
+
+describe('PLM embed relay (PLM-COLLAB-P3-D2)', () => {
+  beforeEach(() => {
+    dsMocks.getDataSource.mockReset()
+    process.env.YUANTUS_EMBED_PUBLIC_KEY = PUB_B64
+    process.env.YUANTUS_EMBED_KEY_ID = KID
+    process.env.PLM_EMBED_AUDIENCE = AUD
+    process.env.PLM_EMBED_ALLOWED_ORIGINS = ORIGIN
+    process.env.PLM_EMBED_DATA_SOURCE_ID = DS_ID
+  })
+  afterEach(() => {
+    for (const k of ['YUANTUS_EMBED_PUBLIC_KEY', 'YUANTUS_EMBED_KEY_ID', 'PLM_EMBED_AUDIENCE', 'PLM_EMBED_ALLOWED_ORIGINS', 'PLM_EMBED_DATA_SOURCE_ID']) delete process.env[k]
+  })
+
+  it('the embed path is whitelisted from the global session gate (else it would 401 before embedTokenAuth)', () => {
+    expect(isWhitelisted('/api/plm-embed/bom-review/context')).toBe(true)
+    expect(isWhitelisted('/api/plm-embed/config')).toBe(true)
+    expect(isWhitelisted('/api/other/thing')).toBe(false)
+  })
+
+  it('REAL CHAIN: an embed-token-only request (no session Bearer) reaches the route -> 200', async () => {
+    const getBomMultitableContext = vi.fn().mockResolvedValue({ feature_key: 'bom_multitable', entitled: true, upgrade: { available: false }, context: CONTEXT })
+    dsMocks.getDataSource.mockReturnValue({ getBomMultitableContext })
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint())
+    expect(res.status).toBe(200)
+    expect(res.body.data.entitled).toBe(true)
+    expect(res.body.data.context).toEqual(CONTEXT)
+    expect(res.body.data.part_id).toBe('P1')
+    // part is TOKEN-BOUND: the adapter was called with the claim's part, not any request input
+    expect(getBomMultitableContext).toHaveBeenCalledWith('P1')
+  })
+
+  it('a non-whitelisted /api/* path with no session is 401 (proves the stand-in gate is real)', async () => {
+    const res = await request(buildApp()).get('/api/other/thing')
+    expect(res.status).toBe(401)
+  })
+
+  it('no embed token -> 401', async () => {
+    const res = await request(buildApp()).get(URL)
+    expect(res.status).toBe(401)
+  })
+
+  it('invalid embed token -> 401', async () => {
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', 'not.a.valid.jwt')
+    expect(res.status).toBe(401)
+  })
+
+  it('no Yuantus public key configured -> 503 fail-closed (not 401)', async () => {
+    delete process.env.YUANTUS_EMBED_PUBLIC_KEY
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint())
+    expect(res.status).toBe(503)
+  })
+
+  it('embed_origin not in the allowlist -> 403', async () => {
+    dsMocks.getDataSource.mockReturnValue({ getBomMultitableContext: vi.fn() })
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint({ embed_origin: 'https://evil.example.com' }))
+    expect(res.status).toBe(403)
+  })
+
+  it('a token scoped to a DIFFERENT feature -> 403 (must be bom_multitable)', async () => {
+    const getBomMultitableContext = vi.fn()
+    dsMocks.getDataSource.mockReturnValue({ getBomMultitableContext })
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint({ feature_key: 'approval_automation' }))
+    expect(res.status).toBe(403)
+    expect(getBomMultitableContext).not.toHaveBeenCalled()
+  })
+
+  it('a token with NO exp -> 401 (exp is required; never mint a non-expiring token)', async () => {
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint({ exp: undefined }))
+    expect(res.status).toBe(401)
+  })
+
+  it('a token with a non-numeric exp -> 401', async () => {
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint({ exp: 'soon' }))
+    expect(res.status).toBe(401)
+  })
+
+  it('data source not configured -> 503', async () => {
+    delete process.env.PLM_EMBED_DATA_SOURCE_ID
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint())
+    expect(res.status).toBe(503)
+  })
+
+  it('provider throws -> degrades (context:null), never 500', async () => {
+    dsMocks.getDataSource.mockReturnValue({ getBomMultitableContext: vi.fn().mockRejectedValue(new Error('boom')) })
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint())
+    expect(res.status).toBe(200)
+    expect(res.body.data.context).toBeNull()
+    expect(res.body.data.reason).toBe('unavailable')
+  })
+
+  it('/config serves the single-source allowlist + frame-ancestors (public, no token)', async () => {
+    const res = await request(buildApp()).get('/api/plm-embed/config')
+    expect(res.status).toBe(200)
+    expect(res.body.data.allowed_origins).toEqual([ORIGIN])
+    expect(res.body.data.frame_ancestors).toBe(`frame-ancestors ${ORIGIN}`)
+  })
+
+  it('/config frame-ancestors fails CLOSED to none when unconfigured', async () => {
+    delete process.env.PLM_EMBED_ALLOWED_ORIGINS
+    const res = await request(buildApp()).get('/api/plm-embed/config')
+    expect(res.body.data.allowed_origins).toEqual([])
+    expect(res.body.data.frame_ancestors).toBe("frame-ancestors 'none'")
+  })
+
+  it('a literal * in the allowlist is dropped (never allow-all)', async () => {
+    process.env.PLM_EMBED_ALLOWED_ORIGINS = '*'
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint())
+    expect(res.status).toBe(403) // origin no longer matches an empty allowlist
+  })
+})


### PR DESCRIPTION
## PLM-COLLAB-P3-D2 (backend) — offline-verify the Yuantus embed token

The **backend half** of P3-D2 (consumer offline-verify, Fork B): metasheet2 verifies the Yuantus P3-D1 Ed25519 embed token OFFLINE with the public key and serves a dedicated, token-bound BOM-review relay. The **frontend** (embed page + secure postMessage handshake + the MultitableEmbedHost origin pin) is a follow-up slice. Read-only; no token exchange; does not change session auth.

### What it does
- **`embed-token-verify.ts`** — EdDSA verify via **`node:crypto`** (no `jose` dep): raw pubkey → JWK → KeyObject → `crypto.verify(null, signingInput, key, sig)`, over the **received `header.payload` bytes** (never re-serialized — the classic JWT bug). Enforces `aud` (service audience) · `typ:"embed"` · **`exp` is a required finite number** · `part_id`. Cross-language correctness is pinned against a token actually minted by the **Yuantus Python minter** (a node↔node roundtrip wouldn't prove it).
- **`embed-token-auth.ts`** — authenticates by the **`X-PLM-Embed-Token`** header (custom, not `Authorization: Bearer`, so it never collides with the session JWT). No token → 401; **no Yuantus public key configured → 503 fail-closed**; bad/expired/wrong-aud token → 401.
- **`jwt-middleware.ts`** — `/api/plm-embed/` added to `AUTH_WHITELIST` so the **global session gate does NOT 401 embed requests** before `embedTokenAuth` runs. Pinned by a **real-middleware-chain test** (the failure a router-in-isolation test is blind to).
- **`plm-embed.ts`** (PLM-feature-gated) — `GET /api/plm-embed/bom-review/context` (gated): **data source = server-config `PLM_EMBED_DATA_SOURCE_ID`, never from the request**; **part = the token's `part_id`, never a request input**; the token must be **scoped to `feature_key === "bom_multitable"`** (else 403); `embed_origin` must be in the allowlist (else 403); never 500s → degrades. Plus `GET /api/plm-embed/config` (public — serves the single-source origin allowlist + the fail-closed `frame-ancestors` value).
- **`embed-config.ts`** — `PLM_EMBED_ALLOWED_ORIGINS` is the **single source** for the three origin layers (the `embed_origin` check, the CSP value, the frontend allowlist); a literal `'*'` is dropped.

### CSP scope (honest boundary)
This backend **computes** the `frame-ancestors` value (fail-closed `'none'` when unconfigured) and **exposes it via `/config`**. It does **NOT** set the `Content-Security-Policy` header on the embed HTML document — Express does not serve the SPA HTML, so the header is applied at the deploy edge (nginx/CDN), owner-ratified. The **code-enforced** controls are the token verification + the `embed_origin` allowlist + (next slice) the frontend postMessage origin pin.

### Tests
23 backend tests green: the cross-language Python-minted vector + wrong-aud/expired/**missing-or-non-numeric-exp**/tampered-sig/swapped-payload/unknown-kid/wrong-typ; the real-chain auth reachability (embed-token-only → 200) + no-token/invalid → 401, no-pubkey/no-datasource → 503, **wrong-feature → 403**, origin-mismatch → 403, part token-bound, provider-degrade, `/config` single-source + fail-closed, `'*'` dropped. `tsc` clean; rebased onto latest `main` (diff is exactly the 8 backend files).

Frontend (token-bound BOM-review embed page + postMessage handshake + origin pin) follows in its own slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)