### PR TITLE
feat(attendance): S2-2 in/out merge admin config card

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -2091,6 +2091,39 @@
                   {{ settingsLoading ? tr('Saving...', '保存中...') : tr('Save outdoor approval', '保存外勤审批') }}
                 </button>
               </div>
+
+              <div class="attendance__admin-subsection" data-admin-card="inout-merge">
+                <h4>{{ tr('In/out punch merge', '内外勤卡合并') }}</h4>
+                <p class="attendance__field-hint">
+                  {{ tr('When a day has both an internal punch and an approved outdoor punch, choose which one counts as the first-in (check-in) / last-out (check-out). Both off (default) = first-in stays the earliest punch and last-out the latest — no change to existing attendance.', '当某天同时存在内勤打卡与已审批的外勤打卡时，选择哪一张计为上班卡（签到）/下班卡（签退）。两项均关闭（默认）＝上班卡取最早打卡、下班卡取最晚打卡，不改变现有考勤。') }}
+                </p>
+                <label class="attendance__field attendance__field--checkbox" for="attendance-merge-internal-wins-on-in">
+                  <span>{{ tr('Use the internal punch for the first-in (check-in)', '上班卡以内勤打卡为准') }}</span>
+                  <input
+                    id="attendance-merge-internal-wins-on-in"
+                    v-model="mergeForm.internalWinsOnIn"
+                    type="checkbox"
+                    data-merge="internal-wins-on-in"
+                  />
+                </label>
+                <label class="attendance__field attendance__field--checkbox" for="attendance-merge-external-wins-on-out">
+                  <span>{{ tr('Use the outdoor punch for the last-out (check-out)', '下班卡以外勤打卡为准') }}</span>
+                  <input
+                    id="attendance-merge-external-wins-on-out"
+                    v-model="mergeForm.externalWinsOnOut"
+                    type="checkbox"
+                    data-merge="external-wins-on-out"
+                  />
+                </label>
+                <button
+                  class="attendance__btn attendance__btn--primary"
+                  :disabled="settingsLoading"
+                  data-merge="save"
+                  @click="saveInOutMerge"
+                >
+                  {{ settingsLoading ? tr('Saving...', '保存中...') : tr('Save in/out merge', '保存内外勤合并') }}
+                </button>
+              </div>
             </div>
 
             <div
@@ -7306,6 +7339,12 @@ interface AttendanceSettings {
       requirePhoto?: boolean
       approvalFlowId?: string
     }
+    // ② S2-2 in/out merge (backend #2333/#2336). Frontend type only — the admin card reads/writes these
+    // via PUT { punchPolicy: { merge: ... } }. Both default false ⇒ existing append behaviour (no change).
+    merge?: {
+      internalWinsOnIn?: boolean
+      externalWinsOnOut?: boolean
+    }
   }
 }
 
@@ -11073,6 +11112,13 @@ const outdoorForm = reactive({
   requireApproval: false,
   requireNote: false,
   approvalFlowId: '',
+})
+// ② S2-2 内外勤卡合并 (in/out merge) config card. Mirrors outdoorForm: saved via saveInOutMerge, which
+// PUTs ONLY { punchPolicy: { merge: ... } } so the backend per-key merge leaves unscheduled / outdoor
+// siblings untouched. Both keys default false ⇒ existing append derivation, no regression.
+const mergeForm = reactive({
+  internalWinsOnIn: false,
+  externalWinsOnOut: false,
 })
 // Real data source for the flow picker: the org's ACTIVE outdoor_punch approval flows (no fake picker).
 const outdoorApprovalFlowOptions = computed(() =>
@@ -16395,6 +16441,7 @@ async function loadSettings() {
     applySettingsToForm(data.data || {})
     applyShiftComplianceToForm(data.data || {})
     applyOutdoorToForm(data.data || {})
+    applyInOutMergeToForm(data.data || {})
   } catch (error: any) {
     attendanceSettings.value = null
     setStatusFromError(error, tr('Failed to load settings', '加载设置失败'), 'admin')
@@ -16418,6 +16465,12 @@ function applyOutdoorToForm(settings: AttendanceSettings) {
   outdoorForm.requireApproval = outdoor.requireApproval === true
   outdoorForm.requireNote = outdoor.requireNote === true
   outdoorForm.approvalFlowId = typeof outdoor.approvalFlowId === 'string' ? outdoor.approvalFlowId : ''
+}
+
+function applyInOutMergeToForm(settings: AttendanceSettings) {
+  const merge = settings.punchPolicy?.merge || {}
+  mergeForm.internalWinsOnIn = merge.internalWinsOnIn === true
+  mergeForm.externalWinsOnOut = merge.externalWinsOnOut === true
 }
 
 async function saveShiftCompliance() {
@@ -16493,6 +16546,42 @@ async function saveOutdoorApproval() {
     setStatus(tr('Outdoor approval updated.', '外勤审批已更新。'))
   } catch (error: any) {
     setStatusFromError(error, tr('Failed to save outdoor approval', '保存外勤审批失败'), 'save-settings')
+  } finally {
+    settingsLoading.value = false
+  }
+}
+
+async function saveInOutMerge() {
+  settingsLoading.value = true
+  try {
+    // PUT ONLY punchPolicy.merge — the backend 2-level merge preserves outdoor / unscheduled siblings.
+    // Both keys false ⇒ existing append derivation, no change. (Record-only import/override protection is a
+    // backend invariant that only engages when a key is on; it is not controlled by this card.)
+    const payload = {
+      punchPolicy: {
+        merge: {
+          internalWinsOnIn: mergeForm.internalWinsOnIn === true,
+          externalWinsOnOut: mergeForm.externalWinsOnOut === true,
+        },
+      },
+    }
+    const response = await apiFetchWithTimeout('/api/attendance/settings', {
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    }, ATTENDANCE_ADMIN_REQUEST_TIMEOUT_MS)
+    if (response.status === 403) {
+      adminForbidden.value = true
+      throw createForbiddenError()
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw createApiError(response, data, tr('Failed to save in/out merge', '保存内外勤合并失败'))
+    }
+    adminForbidden.value = false
+    applyInOutMergeToForm((data.data || payload) as AttendanceSettings)
+    setStatus(tr('In/out merge updated.', '内外勤合并已更新。'))
+  } catch (error: any) {
+    setStatusFromError(error, tr('Failed to save in/out merge', '保存内外勤合并失败'), 'save-settings')
   } finally {
     settingsLoading.value = false
   }

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -2115,6 +2115,56 @@ describe('Attendance admin regressions', () => {
     })
   })
 
+  it('loads punchPolicy.merge into the in/out merge card and PUTs ONLY { punchPolicy: { merge } }', async () => {
+    attendanceSettingsData = {
+      punchPolicy: { merge: { internalWinsOnIn: true, externalWinsOnOut: true } },
+    }
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(16)
+
+    const internalWinsOnIn = container!.querySelector<HTMLInputElement>('[data-merge="internal-wins-on-in"]')
+    const externalWinsOnOut = container!.querySelector<HTMLInputElement>('[data-merge="external-wins-on-out"]')
+    expect(Boolean(internalWinsOnIn && externalWinsOnOut)).toBe(true)
+    // load: persisted booleans → checkboxes (catches a missing applyInOutMergeToForm wire in the load flow).
+    expect(internalWinsOnIn!.checked).toBe(true)
+    expect(externalWinsOnOut!.checked).toBe(true)
+
+    const saveButton = container!.querySelector<HTMLButtonElement>('[data-merge="save"]')
+    expect(saveButton).toBeTruthy()
+    saveButton!.click()
+    await flushUi(6)
+
+    // EXACTLY { punchPolicy: { merge: { internalWinsOnIn, externalWinsOnOut } } }: no orgId, no sibling
+    // settings (outdoor / unscheduled ride the backend per-sub-key preserve). toEqual so any leak fails.
+    expect(lastSettingsPutBody()).toEqual({
+      punchPolicy: { merge: { internalWinsOnIn: true, externalWinsOnOut: true } },
+    })
+  })
+
+  it('toggles one merge key from off and PUTs the exact partial body (asymmetric, default-off)', async () => {
+    attendanceSettingsData = { punchPolicy: { merge: { internalWinsOnIn: false, externalWinsOnOut: false } } }
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(16)
+
+    const internalWinsOnIn = container!.querySelector<HTMLInputElement>('[data-merge="internal-wins-on-in"]')
+    const externalWinsOnOut = container!.querySelector<HTMLInputElement>('[data-merge="external-wins-on-out"]')
+    // default off = both unchecked (no regression to existing append behaviour)
+    expect(internalWinsOnIn!.checked).toBe(false)
+    expect(externalWinsOnOut!.checked).toBe(false)
+    internalWinsOnIn!.checked = true
+    internalWinsOnIn!.dispatchEvent(new Event('change'))
+    await flushUi(2)
+    container!.querySelector<HTMLButtonElement>('[data-merge="save"]')!.click()
+    await flushUi(6)
+
+    // one key on, one off — the body carries both keys explicitly with the chosen booleans.
+    expect(lastSettingsPutBody()).toEqual({
+      punchPolicy: { merge: { internalWinsOnIn: true, externalWinsOnOut: false } },
+    })
+  })
+
   it('enabling outdoor approval from off PUTs requireApproval/requireNote=true + auto (empty) flow', async () => {
     attendanceSettingsData = { punchPolicy: { outdoor: { requireApproval: false, requireNote: false, approvalFlowId: '' } } }
     app = createApp(AttendanceView, { mode: 'admin' })


### PR DESCRIPTION
## What & why

The **S2-2** frontend admin card exposing the two `punchPolicy.merge` keys landed by the S2-1 backend (#2333) and its record-only protection fix (#2336):
- **`internalWinsOnIn`** — first-in (check-in) takes the **internal** punch
- **`externalWinsOnOut`** — last-out (check-out) takes the **outdoor** punch

Mirrors the proven **S3-2 outdoor-approval card** pattern exactly. Frontend-only — the merge engine + its tests are already on main.

## Change

- `mergeForm` reactive + `applyInOutMergeToForm` (wired into the settings **load** flow alongside `applyOutdoorToForm`) + `saveInOutMerge` handler.
- Save PUTs **ONLY** `{ punchPolicy: { merge: { internalWinsOnIn, externalWinsOnOut } } }` — relying on the backend per-sub-key merge to preserve `outdoor` / `unscheduled` siblings (the same partial-PUT contract the outdoor card uses; that preserve is locked by the S2-1 backend round-trip test).
- **Two checkboxes + save**, no flow picker / no extra surface. Both keys default `false` ⇒ existing append derivation, **no regression**.

## Honest copy (`文案诚实`)

The card describes the **narrow trigger** (a day with both an internal *and* an approved outdoor punch), what each key does, and the default. It deliberately does **not** claim "imported/corrected times are never overwritten" — that record-only protection is a backend invariant that engages **only when a key is on** (decision A), not something this toggle controls. Claiming it unconditionally would be false in the default keys-off state.

## Tests (jsdom, mirror the outdoor card tests)

- load `punchPolicy.merge` → both checkboxes reflect persisted booleans (catches a missing load wire — a separate edit from the handler);
- save → exact `{ punchPolicy: { merge } }` body via `toEqual` (any sibling/`orgId` leak fails);
- toggle one key from off → exact asymmetric partial body `{ internalWinsOnIn: true, externalWinsOnOut: false }`.

## Verification

- `attendance-admin-regressions.spec.ts`: **61 passed** (59 + 2 new) ✅
- `vue-tsc` type-check: exit 0, 0 errors ✅
- `git diff --check`: clean ✅

## Scope / non-goals

Frontend-only. No backend change. No staging smoke yet (that's S2-3, a separate gated opt-in). After this lands, the two keys are admin-toggleable — and safe, since enabling them can't clobber import/override facts (#2336).

🤖 Generated with [Claude Code](https://claude.com/claude-code)