### PR TITLE
feat(multitable): v2-d-b3 backend — date-axis × series

### DIFF
--- a/packages/core-backend/src/multitable/chart-aggregation-service.ts
+++ b/packages/core-backend/src/multitable/chart-aggregation-service.ts
@@ -136,34 +136,46 @@ export class ChartAggregationService {
       dataPoints.push({ label, value })
     }
 
-    // Sort
-    dataPoints = this.sortDataPoints(dataPoints, chart.dataSource.sortBy, chart.dataSource.sortOrder)
+    // Sort. v2-d-b3: a date primary axis is ordered CHRONOLOGICALLY (bucket keys — day YYYY-MM-DD /
+    // week / month YYYY-MM / quarter YYYY-Qn / year — sort ascending lexically = chronologically) and
+    // IGNORES sortBy/sortOrder (which sort categories by label/value, meaningless for a time axis).
+    // Applies to ALL date-grouped charts (single- and multi-series), fixing the old encounter-order quirk.
+    const dateGrouped = !!(chart.dataSource.dateFieldId && chart.dataSource.dateGrouping)
+    if (dateGrouped) {
+      dataPoints.sort((a, b) => (a.label < b.label ? -1 : a.label > b.label ? 1 : 0))
+    } else {
+      dataPoints = this.sortDataPoints(dataPoints, chart.dataSource.sortBy, chart.dataSource.sortOrder)
+    }
 
-    // Limit
+    // Limit. v2-d-b3: in date mode `limit` selects the NEWEST N buckets, then renders them chronological
+    // ascending — slice(-limit) since dataPoints is already ascending (NOT slice(0,limit) = oldest N).
+    // groupBy/pie keep top-N after sortBy.
     if (chart.dataSource.limit && chart.dataSource.limit > 0) {
-      dataPoints = dataPoints.slice(0, chart.dataSource.limit)
+      dataPoints = dateGrouped
+        ? dataPoints.slice(-chart.dataSource.limit)
+        : dataPoints.slice(0, chart.dataSource.limit)
     }
 
     const total = dataPoints.reduce((sum, dp) => sum + dp.value, 0)
 
-    // v2-d: bar/line series split. Built AFTER sort+limit, so it only covers the surviving categories
-    // in their final order (building before limit would leak limited-out categories). Emitted for
-    // bar OR line (v2-d-b2) + seriesByFieldId + groupBy-primary (no date axis). Additive aggregation is
-    // required ONLY for a STACKED bar (its sum is the bar height); grouped bars (v2-d-b1) and lines are
-    // independent → any aggregation. The producer branches on type/`barMode` — not validation alone —
-    // so a persisted stacked+non-additive config still can't RENDER a misleading stack; it just omits
-    // series. Stacked vs grouped vs multi-line differ only at render; the series math is identical.
+    // v2-d: bar/line series split. Built AFTER sort+limit, so it only covers the surviving primary
+    // buckets in their final order (building before limit would leak limited-out buckets). Emitted for
+    // bar OR line (v2-d-b2) + seriesByFieldId + a primary axis = groupByFieldId OR a date axis (v2-d-b3).
+    // Additive aggregation is required ONLY for a STACKED bar (its sum is the bar height); grouped bars
+    // (v2-d-b1) and lines are independent → any aggregation. The producer branches on type/`barMode` — not
+    // validation alone — so a persisted stacked+non-additive config still can't RENDER a misleading stack;
+    // it just omits series. The series math is identical for a groupBy category or a date bucket (`groups`
+    // is keyed by the same label `dataPoints` carries, so `groups.get(dp.label)` works for both).
     const seriesByFieldId = chart.dataSource.seriesByFieldId
-    const dateGrouped = !!(chart.dataSource.dateFieldId && chart.dataSource.dateGrouping)
     const grouped = chart.display.barMode === 'grouped'
     const seriesType = chart.type === 'bar' || chart.type === 'line'
     const requiresAdditive = chart.type === 'bar' && !grouped // only a stacked bar
+    const hasPrimaryAxis = !!chart.dataSource.groupByFieldId || dateGrouped
     let series: ChartSeries[] | undefined
     if (
       seriesType &&
       seriesByFieldId &&
-      chart.dataSource.groupByFieldId &&
-      !dateGrouped &&
+      hasPrimaryAxis &&
       (!requiresAdditive || ADDITIVE_AGGREGATIONS.has(aggFn))
     ) {
       const seriesNames: string[] = []

--- a/packages/core-backend/src/multitable/charts.ts
+++ b/packages/core-backend/src/multitable/charts.ts
@@ -110,18 +110,16 @@ export function assertSeriesConstraints(
   if (type !== 'bar' && type !== 'line') {
     throw new Error('seriesByFieldId is only supported for bar and line charts')
   }
-  if (!dataSource?.groupByFieldId) {
-    throw new Error('seriesByFieldId requires groupByFieldId (a primary category axis)')
-  }
-  if (dataSource.dateFieldId && dataSource.dateGrouping) {
-    // The producer gives date grouping precedence over groupByFieldId, so a series split is not
-    // applied here — reject rather than silently produce a non-split chart (groupBy-primary only;
-    // date-axis × series is deferred to v2-d-b3).
-    throw new Error('seriesByFieldId is not supported with date grouping')
+  // v2-d-b3: the primary axis is groupByFieldId OR a date axis (dateFieldId + dateGrouping). One of
+  // them must be present; a date axis provides its own primary (groupByFieldId not required there).
+  const dateGrouped = Boolean(dataSource.dateFieldId && dataSource.dateGrouping)
+  if (!dataSource?.groupByFieldId && !dateGrouped) {
+    throw new Error('seriesByFieldId requires groupByFieldId or date grouping (a primary axis)')
   }
   // Additive aggregation is required ONLY for a STACKED bar — its segment heights must sum to a
   // meaningful total. Grouped (side-by-side) bars are independent, and lines never stack, so both
-  // accept any aggregation. (v2-d-b1 = grouped relaxation; v2-d-b2 = line.)
+  // accept any aggregation. This holds for a date axis too: a stacked bar over time still needs an
+  // additive aggregation. (v2-d-b1 = grouped relaxation; v2-d-b2 = line; v2-d-b3 = date axis.)
   if (type === 'bar' && barMode !== 'grouped' && !ADDITIVE_AGGREGATIONS.has(dataSource.aggregation?.function)) {
     throw new Error('stacked series require a sum or count aggregation (use barMode "grouped" for others)')
   }

--- a/packages/core-backend/tests/integration/multitable-dashboard-preview-data.test.ts
+++ b/packages/core-backend/tests/integration/multitable-dashboard-preview-data.test.ts
@@ -269,15 +269,34 @@ describeIfDatabase('Dashboard BI v2-b2 preview-data endpoint (real DB)', () => {
     expect(res.body.chartType).toBe('line')
     expect(Array.isArray(res.body.series)).toBe(true)
     expect(res.body.series.length).toBeGreaterThan(0)
+  })
 
-    // line + date grouping is still rejected (deferred to b3). groupBy present too, so the date check
-    // (not the groupBy-required check) is what fires.
-    const dated = await preview({
-      name: 'line date series',
+  test('P9 (v2-d-b3): a date-axis × series line is accepted — chronological buckets + dense series', async () => {
+    const res = await preview({
+      name: 'date series line',
       type: 'line',
-      dataSource: { groupByFieldId: FLD_STATUS, dateFieldId: FLD_DATE, dateGrouping: 'month', seriesByFieldId: FLD_SECRET, aggregation: { function: 'count' } },
+      // pure date axis (no groupByFieldId) + series → b3 lifts the date-grouping rejection
+      dataSource: { dateFieldId: FLD_DATE, dateGrouping: 'month', seriesByFieldId: FLD_SECRET, aggregation: { function: 'count' } },
     })
-    expect(dated.status).toBe(400)
-    expect(JSON.stringify(dated.body)).toContain('date grouping')
+    expect(res.status).toBe(200)
+    expect(res.body.chartType).toBe('line')
+    expect(res.body.dataPoints.map((p: { label: string }) => p.label)).toEqual(['2026-01', '2026-02']) // chronological
+    expect(Array.isArray(res.body.series)).toBe(true)
+    expect(res.body.series.length).toBeGreaterThan(0)
+    for (const s of res.body.series) expect(s.data).toHaveLength(res.body.dataPoints.length) // dense, aligned
+  })
+
+  test('P10 (v2-d-b3 security): a denied seriesByFieldId restricts even in date mode (no leak)', async () => {
+    testUserId = USER_DENIED
+    const res = await preview({
+      name: 'date denied series',
+      type: 'line',
+      dataSource: { dateFieldId: FLD_DATE, dateGrouping: 'month', seriesByFieldId: FLD_SECRET, aggregation: { function: 'count' } },
+    })
+    expect(res.status).toBe(200)
+    expect(res.body.metadata?.restricted).toBe(true)
+    expect(res.body.series).toBeUndefined()
+    expect(res.body.dataPoints).toEqual([])
+    expect(JSON.stringify(res.body)).not.toContain('secret-canary')
   })
 })

--- a/packages/core-backend/tests/unit/chart-dashboard.test.ts
+++ b/packages/core-backend/tests/unit/chart-dashboard.test.ts
@@ -904,20 +904,43 @@ describe('ChartAggregationService — v2-d stacked series', () => {
     expect(result.series!.find((s) => s.name === 'A')!.data).toEqual([30, 30]) // avg per (status × category)
   })
 
-  it('inert: no series without a primary groupByFieldId (date-grouped or ungrouped)', async () => {
-    const dateGrouped = await service.computeChartData(
-      makeChart({
-        type: 'bar',
-        dataSource: {
-          dateFieldId: 'date',
-          dateGrouping: 'month',
-          seriesByFieldId: 'category',
-          aggregation: { function: 'count' },
-        },
-      }),
+  it('inert: no series for an UNGROUPED chart (no groupBy, no date axis)', async () => {
+    const ungrouped = await service.computeChartData(
+      makeChart({ type: 'bar', dataSource: { seriesByFieldId: 'category', aggregation: { function: 'count' } } }),
       sampleRecords,
     )
-    expect(dateGrouped.series).toBeUndefined()
+    expect(ungrouped.series).toBeUndefined()
+  })
+
+  // v2-d-b3: date-axis × series — date buckets are the primary axis, ordered chronologically.
+  const dateSeriesChart = (over: Partial<ChartConfig['dataSource']> = {}) => makeChart({
+    type: 'line',
+    dataSource: { dateFieldId: 'date', dateGrouping: 'month', seriesByFieldId: 'category', aggregation: { function: 'count' }, ...over },
+  })
+
+  it('b3: date-grouped + seriesByFieldId emits series over chronological date buckets (dense, 0-filled)', async () => {
+    const result = await service.computeChartData(dateSeriesChart(), sampleRecords)
+    expect(result.dataPoints.map((d) => d.label)).toEqual(['2026-01', '2026-02', '2026-03', '2026-04']) // chronological, not encounter-order
+    expect(result.series).toBeDefined()
+    expect(result.series!.map((s) => s.name)).toEqual(['A', 'B'])
+    expect(result.series!.find((s) => s.name === 'A')!.data).toEqual([1, 1, 0, 1]) // 0-fill where A absent (2026-03)
+    expect(result.series!.find((s) => s.name === 'B')!.data).toEqual([1, 0, 1, 0])
+    for (const s of result.series!) expect(s.data).toHaveLength(result.dataPoints.length)
+  })
+
+  it('b3 §5.1: a single-series date chart orders chronologically, ignoring sortBy/sortOrder', async () => {
+    const result = await service.computeChartData(
+      makeChart({ type: 'line', dataSource: { dateFieldId: 'date', dateGrouping: 'month', aggregation: { function: 'count' }, sortBy: 'value', sortOrder: 'desc' } }),
+      sampleRecords,
+    )
+    expect(result.dataPoints.map((d) => d.label)).toEqual(['2026-01', '2026-02', '2026-03', '2026-04']) // sortBy:value desc ignored
+  })
+
+  it('b3 §5.3: limit selects the NEWEST N buckets, rendered ascending (not oldest N)', async () => {
+    const result = await service.computeChartData(dateSeriesChart({ limit: 2 }), sampleRecords)
+    expect(result.dataPoints.map((d) => d.label)).toEqual(['2026-03', '2026-04']) // latest 2, ascending — NOT 2026-01/02
+    for (const s of result.series!) expect(s.data).toHaveLength(2) // series aligned to the surviving newest buckets
+    expect(result.series!.find((s) => s.name === 'B')!.data).toEqual([1, 0]) // 2026-03 has B, 2026-04 does not
   })
 
   it('absent seriesByFieldId ⇒ byte-identical to today (no series key)', async () => {
@@ -976,8 +999,10 @@ describe('assertSeriesConstraints (v2-d input validation)', () => {
     }
   })
 
-  it('line + date grouping is still rejected (deferred to b3)', () => {
-    expect(() => assertSeriesConstraints(ds({ dateFieldId: 'd', dateGrouping: 'month' }), 'line')).toThrow(/date grouping/)
+  it('b3: line + date grouping is now allowed (date axis = primary)', () => {
+    expect(() => assertSeriesConstraints(ds({ dateFieldId: 'd', dateGrouping: 'month' }), 'line')).not.toThrow()
+    // date axis alone (no groupByFieldId) is a valid primary
+    expect(() => assertSeriesConstraints(ds({ groupByFieldId: undefined, dateFieldId: 'd', dateGrouping: 'month' }), 'line')).not.toThrow()
   })
 
   it('throws without a primary groupByFieldId', () => {
@@ -990,8 +1015,11 @@ describe('assertSeriesConstraints (v2-d input validation)', () => {
     }
   })
 
-  it('throws when combined with date grouping (matches the producer giving the date axis precedence)', () => {
-    expect(() => assertSeriesConstraints(ds({ dateFieldId: 'd', dateGrouping: 'month' }), 'bar')).toThrow(/date grouping/)
+  it('b3: a STACKED bar over a date axis still requires an additive aggregation (§2.2 holds for date too)', () => {
+    // stacked bar (default barMode) + date + non-additive → rejected
+    expect(() => assertSeriesConstraints(ds({ dateFieldId: 'd', dateGrouping: 'month', aggregation: { function: 'avg', fieldId: 'amt' } }), 'bar')).toThrow(/sum or count/)
+    // grouped bar over date with the same non-additive aggregation → allowed
+    expect(() => assertSeriesConstraints(ds({ dateFieldId: 'd', dateGrouping: 'month', aggregation: { function: 'avg', fieldId: 'amt' } }), 'bar', 'grouped')).not.toThrow()
   })
 
   // v2-d-b1: barMode 'grouped' relaxes the additive requirement (side-by-side bars are independent).


### PR DESCRIPTION
Third / final sub-slice of **v2-d-b** (design-lock #2310), **backend-first**, **b3 only**. Lifts v2-d-a's date-grouping rejection so a date axis can be split into series. Frontend (date-grouped series picker) follows separately.

## Changes
- **`assertSeriesConstraints`** — a date axis (`dateFieldId`+`dateGrouping`) is now a valid **primary axis** for a series split (line / grouped bar, any aggregation); `groupByFieldId` required only when *not* date-grouped. A **stacked bar over a date axis still requires an additive aggregation** (§2.2 holds).
- **Producer (`computeChartData`)**:
  - **§5.1** date-grouped charts order **chronologically** (bucket keys ascending), **ignoring `sortBy`/`sortOrder`** — applies to **all** date-grouped charts (fixes the old encounter-order quirk; full-suite regression clean).
  - **§5.3** in date mode `limit` selects the **newest N buckets** then renders ascending (`slice(-limit)`, **not** `slice(0,limit)`=oldest N).
  - series emit-guard: primary axis = `groupByFieldId` **or** date axis (drop `!dateGrouped`). The series math is identical (`groups` keyed by the same label `dataPoints` carries). **§5.2** dense 0-fill per existing bucket; missing buckets not synthesized (inherited single-series limitation, documented).

## Tests
- **unit**: date×series chronological + dense; single-series date chronological **ignoring `sortBy:value`**; **newest-N limit ascending** (5→latest in order); ungrouped inert; validator date-allowed + stacked-over-date-still-additive.
- **real-DB P9**: date×series line accepted (chronological + dense). **P10**: denied `seriesByFieldId` **restricts in date mode** (no leak). **P8 flipped** (line+date now 200, was 400).
- Full backend unit **2824/2824**, dashboard real-DB **21/21**, tsc + eslint clean. No new security surface (`chartReferencedFieldIds` already gates `seriesByFieldId` + `dateFieldId`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)