### PR TITLE
feat(web): PLM-COLLAB P3-D2 token-bound BOM-review embed (frontend)

### DIFF
--- a/apps/web/src/components/plm/PlmBomReviewPanel.vue
+++ b/apps/web/src/components/plm/PlmBomReviewPanel.vue
@@ -44,55 +44,7 @@
         未找到该 Part 的 BOM 数据。
       </p>
 
-      <div v-else-if="reviewState === 'table' && context">
-        <div class="bom-review__part" data-testid="plm-bom-review-part">
-          <span class="bom-review__badge">Part</span>
-          <strong>{{ context.part.item_number || context.part.part_id }}</strong>
-          <span>{{ context.part.name }}</span>
-          <small>状态 {{ context.part.state || '—' }} · 版本 {{ context.part.generation ?? '—' }}</small>
-          <small v-if="context.source_updated_at">来源更新 {{ context.source_updated_at }}</small>
-        </div>
-
-        <p v-if="context.lines.length === 0" class="bom-review__hint" data-testid="plm-bom-review-no-lines">
-          该 Part 没有 BOM 行。
-        </p>
-        <table v-else class="bom-review__table">
-          <thead>
-            <tr>
-              <th>层级</th>
-              <th>物料号</th>
-              <th>名称</th>
-              <th>状态</th>
-              <th>数量</th>
-              <th>位号</th>
-              <th>来源版本</th>
-              <th>来源更新时间</th>
-            </tr>
-          </thead>
-          <tbody>
-            <tr
-              v-for="line in context.lines"
-              :key="line.bom_line_id"
-              data-testid="plm-bom-review-row"
-              :data-bom-line-id="line.bom_line_id"
-              :data-level="line.level"
-            >
-              <td>{{ line.level }}</td>
-              <td>
-                <span :style="{ paddingLeft: `${Math.max(0, line.level - 1) * 16}px` }">
-                  {{ line.item_number || line.part_id }}
-                </span>
-              </td>
-              <td>{{ line.name }}</td>
-              <td>{{ line.state || '—' }}</td>
-              <td>{{ formatQuantity(line) }}</td>
-              <td>{{ line.refdes || '—' }}</td>
-              <td>{{ line.source_version ?? '—' }}</td>
-              <td>{{ line.source_updated_at || '—' }}</td>
-            </tr>
-          </tbody>
-        </table>
-      </div>
+      <PlmBomReviewTable v-else-if="reviewState === 'table' && context" :context="context" />
     </div>
   </section>
 </template>
@@ -101,9 +53,9 @@
 import { computed, ref } from 'vue'
 import {
   getPlmBomMultitableContext,
-  type PlmBomMultitableLine,
   type PlmBomMultitableResult,
 } from '../../services/integration/workbench'
+import PlmBomReviewTable from './PlmBomReviewTable.vue'
 
 const props = defineProps<{ dataSourceId: string }>()
 
@@ -131,11 +83,6 @@ const reviewState = computed<'idle' | 'loading' | 'unavailable' | 'upgrade' | 'e
   return 'empty'
 })
 
-function formatQuantity(line: PlmBomMultitableLine): string {
-  if (line.quantity === null || line.quantity === undefined) return '—'
-  return line.uom ? `${line.quantity} ${line.uom}` : String(line.quantity)
-}
-
 // Fetch ONLY on explicit user action (never on mount) so mounting the panel never triggers a
 // PLM call. The backend relay does the advisory gate; this is a single, read-only call.
 async function load(): Promise<void> {
@@ -158,10 +105,6 @@ async function load(): Promise<void> {
 .bom-review__query { display: flex; align-items: flex-end; gap: 8px; }
 .bom-review__query label { display: flex; flex-direction: column; gap: 2px; }
 .bom-review__button { white-space: nowrap; }
-.bom-review__part { display: flex; flex-wrap: wrap; gap: 8px; align-items: baseline; }
-.bom-review__badge { font-size: 12px; opacity: 0.7; }
-.bom-review__table { width: 100%; border-collapse: collapse; }
-.bom-review__table th, .bom-review__table td { text-align: left; padding: 4px 8px; border-bottom: 1px solid rgba(0,0,0,0.08); }
 .bom-review__hint--muted { opacity: 0.6; }
 .bom-review__hint--strong { font-weight: 600; }
 </style>

--- a/apps/web/src/components/plm/PlmBomReviewTable.vue
+++ b/apps/web/src/components/plm/PlmBomReviewTable.vue
@@ -1,0 +1,74 @@
+<template>
+  <div v-if="context">
+    <div class="bom-review__part" data-testid="plm-bom-review-part">
+      <span class="bom-review__badge">Part</span>
+      <strong>{{ context.part.item_number || context.part.part_id }}</strong>
+      <span>{{ context.part.name }}</span>
+      <small>状态 {{ context.part.state || '—' }} · 版本 {{ context.part.generation ?? '—' }}</small>
+      <small v-if="context.source_updated_at">来源更新 {{ context.source_updated_at }}</small>
+    </div>
+
+    <p v-if="context.lines.length === 0" class="bom-review__hint" data-testid="plm-bom-review-no-lines">
+      该 Part 没有 BOM 行。
+    </p>
+    <table v-else class="bom-review__table">
+      <thead>
+        <tr>
+          <th>层级</th>
+          <th>物料号</th>
+          <th>名称</th>
+          <th>状态</th>
+          <th>数量</th>
+          <th>位号</th>
+          <th>来源版本</th>
+          <th>来源更新时间</th>
+        </tr>
+      </thead>
+      <tbody>
+        <tr
+          v-for="line in context.lines"
+          :key="line.bom_line_id"
+          data-testid="plm-bom-review-row"
+          :data-bom-line-id="line.bom_line_id"
+          :data-level="line.level"
+        >
+          <td>{{ line.level }}</td>
+          <td>
+            <span :style="{ paddingLeft: `${Math.max(0, line.level - 1) * 16}px` }">
+              {{ line.item_number || line.part_id }}
+            </span>
+          </td>
+          <td>{{ line.name }}</td>
+          <td>{{ line.state || '—' }}</td>
+          <td>{{ formatQuantity(line) }}</td>
+          <td>{{ line.refdes || '—' }}</td>
+          <td>{{ line.source_version ?? '—' }}</td>
+          <td>{{ line.source_updated_at || '—' }}</td>
+        </tr>
+      </tbody>
+    </table>
+  </div>
+</template>
+
+<script setup lang="ts">
+// P3-D2: the read-only BOM review table, extracted from PlmBomReviewPanel so BOTH the standalone
+// panel (P3-C) and the embedded view (P3-D2) render the identical table.
+import { type PlmBomMultitableContext, type PlmBomMultitableLine } from '../../services/integration/workbench'
+
+// nullable so both call sites (panel + embed) can bind their `context | null` computed without a
+// non-null assertion; the root v-if guards the render and narrows context for the subtree.
+defineProps<{ context: PlmBomMultitableContext | null }>()
+
+function formatQuantity(line: PlmBomMultitableLine): string {
+  if (line.quantity === null || line.quantity === undefined) return '—'
+  return line.uom ? `${line.quantity} ${line.uom}` : String(line.quantity)
+}
+</script>
+
+<style scoped>
+.bom-review__part { display: flex; flex-wrap: wrap; gap: 8px; align-items: baseline; }
+.bom-review__badge { font-size: 12px; opacity: 0.7; }
+.bom-review__table { width: 100%; border-collapse: collapse; }
+.bom-review__table th, .bom-review__table td { text-align: left; padding: 4px 8px; border-bottom: 1px solid rgba(0,0,0,0.08); }
+.bom-review__hint { opacity: 0.8; }
+</style>

--- a/apps/web/src/multitable/views/MultitableEmbedHost.vue
+++ b/apps/web/src/multitable/views/MultitableEmbedHost.vue
@@ -128,18 +128,26 @@ onMounted(() => {
 })
 
 // --- postMessage API ---
+// Pinned to the first allowlisted parent that messages us, so outbound posts target a concrete
+// origin instead of '*'. See postToParent for the fallback when no inbound message has arrived yet.
+const parentOrigin = ref<string | null>(null)
+
 function isOriginAllowed(origin: string): boolean {
   if (!props.allowedOrigins?.length) {
     // Default to same-origin if no restriction specified
     try { return origin === window.location.origin } catch { return false }
   }
-  return props.allowedOrigins.includes(origin) || props.allowedOrigins.includes('*')
+  // Strict exact-match against the configured allowlist -- '*' is NOT a wildcard here.
+  return props.allowedOrigins.includes(origin)
 }
 
 function onMessage(event: MessageEvent) {
   if (!isOriginAllowed(event.origin)) return
   const data = event.data
   if (!data || typeof data !== 'object' || !data.type?.startsWith('mt:')) return
+  // pin the parent origin only after a well-formed mt: message, so an unrelated message from an
+  // allowlisted origin can't occupy the pin first
+  parentOrigin.value = event.origin
 
   switch (data.type) {
     case 'mt:navigate':
@@ -357,7 +365,15 @@ onBeforeRouteLeave(() => {
 
 function postToParent(payload: Record<string, unknown>) {
   try {
-    if (window.parent !== window) window.parent.postMessage(payload, '*')
+    if (window.parent === window) return
+    // Never post to '*'. Prefer the pinned parent origin (captured from the first allowlisted
+    // inbound message); else the single configured allowed origin; else fall back to this frame's
+    // own origin -- which a cross-origin parent will simply not receive, so nothing leaks.
+    const target =
+      parentOrigin.value
+      ?? props.allowedOrigins?.find((origin) => origin && origin !== '*')
+      ?? window.location.origin
+    window.parent.postMessage(payload, target)
   } catch { /* cross-origin guard */ }
 }
 

--- a/apps/web/src/router/appRoutes.ts
+++ b/apps/web/src/router/appRoutes.ts
@@ -160,6 +160,15 @@ export const appRoutes: RouteRecordRaw[] = [
     meta: { title: 'PLM Audit', titleZh: 'PLM 审计', requiresAuth: true, requiredFeature: 'plm' }
   },
   {
+    // PLM-COLLAB P3-D2: token-bound BOM-review embed. Bare page (no shell, no metasheet session) --
+    // it is authed by a PLM-minted embed token delivered via postMessage from an allowlisted parent,
+    // NOT by a metasheet session. Mirrors the public-form route's no-session meta.
+    path: '/plm-embed/bom-review',
+    name: 'plm-embed-bom-review',
+    component: () => import('../views/PlmEmbedBomReviewView.vue'),
+    meta: { title: 'BOM Review', titleZh: 'BOM 评审（嵌入）', hideNavbar: true, requiresAuth: false, skipShellBootstrap: true }
+  },
+  {
     path: '/settings',
     name: 'user-settings',
     component: () => import('../views/SessionCenterView.vue'),

--- a/apps/web/src/services/integration/plmEmbed.ts
+++ b/apps/web/src/services/integration/plmEmbed.ts
@@ -1,0 +1,81 @@
+// PLM-COLLAB P3-D2 (frontend): client for the token-bound BOM-review embed surface.
+//
+// Two endpoints, both under /api/plm-embed/ (NOT the /api/integration/* envelope helpers):
+//   GET /config                  -- PUBLIC. The single source of the parent-origin allowlist.
+//                                   The iframe MUST trust this over any URL parameter, and the
+//                                   backend never emits '*' (it is stripped server-side).
+//   GET /bom-review/context      -- requires the X-PLM-Embed-Token header. The part is bound to
+//                                   the token's part_id claim on the server; there is NO part
+//                                   input. The token travels ONLY in the header -- never the URL,
+//                                   never a log line.
+//
+// Both responses use the bare {ok,data} envelope. Any non-200 / malformed response degrades to an
+// "unavailable" result for the read-only viewer (the specific 401/403/503 codes are deliberately
+// not surfaced to the embedded reader -- it is a viewer, not an auth console).
+import { apiFetch } from '../../utils/api'
+import { isPlmBomMultitableContext, type PlmBomMultitableContext } from './workbench'
+
+export interface PlmEmbedConfig {
+  // exact-match allowlist of parent origins permitted to deliver the embed token (never '*')
+  allowedOrigins: string[]
+  // the CSP frame-ancestors directive value the edge layer should set on the embed HTML document
+  frameAncestors: string
+}
+
+export type PlmEmbedBomResult =
+  | { available: true; entitled: boolean; context: PlmBomMultitableContext | null; reason?: string }
+  | { available: false; reason?: string }
+
+const FAIL_CLOSED_CONFIG: PlmEmbedConfig = { allowedOrigins: [], frameAncestors: "frame-ancestors 'none'" }
+
+export async function getPlmEmbedConfig(): Promise<PlmEmbedConfig> {
+  try {
+    // This is a token-only, requiresAuth:false iframe. A 401/403 here must degrade to fail-closed,
+    // NOT trigger apiFetch's default handleUnauthorized (which clears the session and redirects the
+    // whole frame to /login).
+    const response = await apiFetch('/api/plm-embed/config', { suppressUnauthorizedRedirect: true })
+    const body = await response.json().catch(() => null)
+    if (response.ok && body && body.ok === true && body.data && typeof body.data === 'object') {
+      const data = body.data as Record<string, unknown>
+      const allowedOrigins = Array.isArray(data.allowed_origins)
+        ? data.allowed_origins.filter(
+            (origin: unknown): origin is string =>
+              typeof origin === 'string' && origin.length > 0 && origin !== '*',
+          )
+        : []
+      const frameAncestors =
+        typeof data.frame_ancestors === 'string' && data.frame_ancestors.trim()
+          ? data.frame_ancestors
+          : FAIL_CLOSED_CONFIG.frameAncestors
+      return { allowedOrigins, frameAncestors }
+    }
+  } catch {
+    /* fall through to fail-closed */
+  }
+  return { ...FAIL_CLOSED_CONFIG }
+}
+
+export async function getPlmEmbedBomContext(token: string): Promise<PlmEmbedBomResult> {
+  try {
+    const response = await apiFetch('/api/plm-embed/bom-review/context', {
+      headers: { 'X-PLM-Embed-Token': token },
+      // a 401 (invalid/expired token) or 403 (feature/origin mismatch) must show unavailable/error
+      // in the embed, never redirect the token-only iframe to the metasheet login page
+      suppressUnauthorizedRedirect: true,
+    })
+    const body = await response.json().catch(() => null)
+    if (!response.ok || !body || body.ok !== true || !body.data || typeof body.data !== 'object') {
+      return { available: false, reason: 'unavailable' }
+    }
+    const data = body.data as Record<string, unknown>
+    const entitled = data.entitled === true
+    // context is trusted only when entitled AND it validates as a part+lines object
+    const context = entitled && isPlmBomMultitableContext(data.context) ? data.context : null
+    // a relayed reason on an entitled+null-context result means a TRANSIENT provider failure
+    // (retry), NOT "this part has no BOM" -- a reason-less null context is the empty/not-found case
+    const reason = typeof data.reason === 'string' && data.reason.trim() ? data.reason.trim() : undefined
+    return { available: true, entitled, context, ...(reason ? { reason } : {}) }
+  } catch {
+    return { available: false, reason: 'unavailable' }
+  }
+}

--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -616,7 +616,7 @@ function normalizePlmCapabilitiesResult(
 // P3-C: a DEDICATED normalizer for the BOM multi-table relay (its own shape, not the
 // capability manifest). Validates only the envelope + that `context`, when present, is a
 // part+lines object; the rows are passed through (forward-compatible with provider additions).
-function isPlmBomMultitableContext(value: unknown): value is PlmBomMultitableContext {
+export function isPlmBomMultitableContext(value: unknown): value is PlmBomMultitableContext {
   if (!value || typeof value !== 'object') return false
   const record = value as Record<string, unknown>
   return (

--- a/apps/web/src/views/PlmEmbedBomReviewView.vue
+++ b/apps/web/src/views/PlmEmbedBomReviewView.vue
@@ -1,0 +1,162 @@
+<template>
+  <section class="plm-embed-bom" data-testid="plm-embed-bom-review">
+    <header class="plm-embed-bom__head">
+      <strong>BOM Review（只读）</strong>
+      <small>嵌入视图 · 来自 PLM 的受治理只读快照；不可在此编辑或写回。</small>
+    </header>
+
+    <div class="plm-embed-bom__body" data-testid="plm-embed-bom-state" :data-state="reviewState">
+      <p v-if="reviewState === 'not-configured'" class="plm-embed-bom__hint plm-embed-bom__hint--strong" data-testid="plm-embed-bom-not-configured">
+        嵌入未配置允许来源（fail-closed），无法接收 PLM 嵌入令牌。
+      </p>
+      <p v-else-if="reviewState === 'awaiting-token'" class="plm-embed-bom__hint" data-testid="plm-embed-bom-awaiting">
+        等待来自 PLM 的嵌入令牌…
+      </p>
+      <p v-else-if="reviewState === 'loading'" class="plm-embed-bom__hint">正在读取 BOM review…</p>
+      <p v-else-if="reviewState === 'unavailable'" class="plm-embed-bom__hint plm-embed-bom__hint--muted">
+        当前 PLM 不支持 BOM review，或暂时不可用。
+      </p>
+      <p v-else-if="reviewState === 'upgrade'" class="plm-embed-bom__hint plm-embed-bom__hint--strong">
+        当前租户尚未开通 BOM review；真实授权由 PLM license 判定。
+      </p>
+      <p v-else-if="reviewState === 'error'" class="plm-embed-bom__hint plm-embed-bom__hint--strong" data-testid="plm-embed-bom-error">
+        加载 BOM review 失败（PLM 暂时不可用），请稍后重试。
+      </p>
+      <p v-else-if="reviewState === 'empty'" class="plm-embed-bom__hint">
+        未找到该 Part 的 BOM 数据。
+      </p>
+
+      <PlmBomReviewTable v-else-if="reviewState === 'table' && context" :context="context" />
+    </div>
+  </section>
+</template>
+
+<script setup lang="ts">
+// PLM-COLLAB P3-D2 (frontend): the token-bound BOM-review embed page.
+//
+// Handshake (LISTEN-only; this page never posts to the parent, so there is no targetOrigin '*' to
+// leak through):
+//   1. fetch /api/plm-embed/config for the parent-origin allowlist -- the SINGLE source of truth,
+//      never a URL parameter, and never containing '*'.
+//   2. wait for the parent to postMessage the PLM-minted embed token. Accept it ONLY from an origin
+//      in the allowlist (strict exact match); pin that origin. An empty allowlist accepts nothing.
+//   3. call /api/plm-embed/bom-review/context with the token in the X-PLM-Embed-Token header. There
+//      is NO part input -- the part is bound to the token's part_id claim on the server.
+//   4. render the identical read-only table the standalone panel uses.
+import { computed, onBeforeUnmount, onMounted, ref } from 'vue'
+import {
+  getPlmEmbedBomContext,
+  getPlmEmbedConfig,
+  type PlmEmbedBomResult,
+} from '../services/integration/plmEmbed'
+import PlmBomReviewTable from '../components/plm/PlmBomReviewTable.vue'
+
+// the inbound postMessage envelope: { type: 'plm-embed:token', token: '<jwt>' }
+const EMBED_TOKEN_MESSAGE_TYPE = 'plm-embed:token'
+
+const configReady = ref(false)
+const allowedOrigins = ref<string[]>([])
+// pinned to the first allowlisted sender; kept for any future outbound use (none today)
+const parentOrigin = ref<string | null>(null)
+const tokenReceived = ref(false)
+const loading = ref(false)
+const result = ref<PlmEmbedBomResult | null>(null)
+// messages that arrive before the allowlist is known are buffered, then re-validated in order
+let pendingMessages: MessageEvent[] = []
+
+const context = computed(() => (result.value && result.value.available ? result.value.context : null))
+
+type EmbedReviewState =
+  | 'not-configured'
+  | 'awaiting-token'
+  | 'loading'
+  | 'unavailable'
+  | 'upgrade'
+  | 'error'
+  | 'empty'
+  | 'table'
+
+// not-configured (allowlist empty -> can never accept a token) -> awaiting-token -> loading ->
+// one of: unavailable (no support / degraded), upgrade (supported but not entitled), error
+// (entitled but the provider fetch failed transiently), empty (entitled, no context, no reason =
+// part not found), table (entitled + context).
+const reviewState = computed<EmbedReviewState>(() => {
+  if (!tokenReceived.value) {
+    if (configReady.value && allowedOrigins.value.length === 0) return 'not-configured'
+    return 'awaiting-token'
+  }
+  if (loading.value) return 'loading'
+  const current = result.value
+  if (!current) return 'loading'
+  if (!current.available) return 'unavailable'
+  if (!current.entitled) return 'upgrade'
+  if (current.context) return 'table'
+  if (current.reason) return 'error'
+  return 'empty'
+})
+
+function isOriginAllowed(origin: string): boolean {
+  // Single source = the server /config allowlist, which NEVER contains '*'. An empty list is
+  // fail-closed: nothing is accepted. Strict exact-match only -- no wildcard, no prefix.
+  return allowedOrigins.value.length > 0 && allowedOrigins.value.includes(origin)
+}
+
+async function consumeToken(origin: string, token: string): Promise<void> {
+  parentOrigin.value = origin // pin the trusted parent origin
+  tokenReceived.value = true
+  loading.value = true
+  try {
+    result.value = await getPlmEmbedBomContext(token)
+  } catch {
+    result.value = { available: false, reason: 'unavailable' }
+  } finally {
+    loading.value = false
+  }
+}
+
+function processMessage(event: MessageEvent): void {
+  if (tokenReceived.value) return // first valid token wins; ignore the rest
+  if (!isOriginAllowed(event.origin)) return // reject non-allowlisted origin (no '*')
+  // Only accept a token from the embedding parent. A real browser postMessage always sets
+  // event.source, so when present it must be window.parent; a different (allowlisted-origin but
+  // non-parent) window is rejected. Synthetic events with no source fall back to the origin gate.
+  if (event.source && event.source !== window.parent) return
+  const data = event.data
+  if (!data || typeof data !== 'object') return
+  if ((data as { type?: unknown }).type !== EMBED_TOKEN_MESSAGE_TYPE) return
+  const token = (data as { token?: unknown }).token
+  if (typeof token !== 'string' || !token) return
+  void consumeToken(event.origin, token)
+}
+
+function onMessage(event: MessageEvent): void {
+  if (!configReady.value) {
+    pendingMessages.push(event) // buffer until the allowlist is loaded
+    return
+  }
+  processMessage(event)
+}
+
+onMounted(async () => {
+  // Attach the listener FIRST so a token posted while /config is in flight is not missed.
+  window.addEventListener('message', onMessage)
+  const config = await getPlmEmbedConfig()
+  allowedOrigins.value = config.allowedOrigins
+  configReady.value = true
+  const buffered = pendingMessages
+  pendingMessages = []
+  for (const event of buffered) processMessage(event)
+})
+
+onBeforeUnmount(() => {
+  window.removeEventListener('message', onMessage)
+})
+</script>
+
+<style scoped>
+.plm-embed-bom { display: flex; flex-direction: column; gap: 8px; padding: 12px; }
+.plm-embed-bom__head { display: flex; flex-direction: column; }
+.plm-embed-bom__body { display: flex; flex-direction: column; gap: 8px; }
+.plm-embed-bom__hint--muted { opacity: 0.6; }
+.plm-embed-bom__hint--strong { font-weight: 600; }
+</style>

--- a/apps/web/tests/multitable-embed-host.spec.ts
+++ b/apps/web/tests/multitable-embed-host.spec.ts
@@ -869,3 +869,100 @@ describe('multitable embed host guards', () => {
     })
   })
 })
+
+// P3-D2: positive coverage for the two owner-named origin fixes -- the wildcard is no longer honored
+// on inbound, and outbound posts pin a concrete origin instead of '*'.
+describe('multitable embed host — origin hardening (P3-D2)', () => {
+  let originApp: VueApp<Element> | null = null
+  let originContainer: HTMLDivElement | null = null
+  let parentSpy: ReturnType<typeof vi.fn>
+  let savedParent: WindowProxy
+
+  beforeEach(() => {
+    confirmPageLeaveSpy.mockReset()
+    confirmPageLeaveSpy.mockReturnValue(true)
+    getEmbedHostStateSpy.mockReset()
+    getEmbedHostStateSpy.mockReturnValue({
+      currentContext: { baseId: 'b', sheetId: 's', viewId: 'v' },
+      hasBlockingState: false,
+      blockingReason: null,
+      hasUnsavedDrafts: false,
+      busy: false,
+      pendingContext: null,
+    })
+    requestExternalContextSyncSpy.mockReset()
+    requestExternalContextSyncSpy.mockImplementation(async (input) => ({
+      status: 'applied',
+      context: { baseId: input.baseId ?? '', sheetId: input.sheetId ?? '', viewId: input.viewId ?? '' },
+    }))
+    parentSpy = vi.fn()
+    savedParent = window.parent
+    Object.defineProperty(window, 'parent', { configurable: true, value: { postMessage: parentSpy } })
+  })
+
+  afterEach(() => {
+    if (originApp) originApp.unmount()
+    originApp = null
+    if (originContainer?.parentNode) originContainer.parentNode.removeChild(originContainer)
+    originContainer = null
+    Object.defineProperty(window, 'parent', { configurable: true, value: savedParent })
+  })
+
+  async function mountHostWithOrigins(allowedOrigins: string[]) {
+    originContainer = document.createElement('div')
+    document.body.appendChild(originContainer)
+    const HostWrap = defineComponent({
+      name: 'OriginHostWrap',
+      components: { MultitableEmbedHost },
+      setup() { return { allowedOrigins } },
+      template: `<MultitableEmbedHost base-id="b" sheet-id="s" view-id="v" :allowed-origins="allowedOrigins" />`,
+    })
+    const router = createRouter({
+      history: createMemoryHistory(),
+      routes: [{ path: '/', name: 'origin-root', component: HostWrap }],
+    })
+    originApp = createApp(defineComponent({ name: 'OriginRoot', render: () => h(RouterView) }))
+    originApp.use(router)
+    await router.push('/')
+    await router.isReady()
+    originApp.mount(originContainer)
+    await nextTick()
+  }
+
+  it('rejects an inbound message from a foreign origin even when allowedOrigins includes "*"', async () => {
+    await mountHostWithOrigins(['*'])
+    parentSpy.mockClear()
+    // the wildcard is no longer a pass -- a foreign origin is rejected, so the host never responds
+    window.dispatchEvent(new MessageEvent('message', {
+      origin: 'https://evil.example.com',
+      data: { type: 'mt:get-navigation-state', requestId: 'rEvil' },
+    }))
+    await nextTick()
+    await nextTick()
+    const responded = parentSpy.mock.calls.some(
+      ([payload]) => (payload as { type?: string })?.type === 'mt:navigation-state',
+    )
+    expect(responded).toBe(false)
+  })
+
+  it('pins outbound postMessage to the allowlisted parent origin and never targets "*"', async () => {
+    await mountHostWithOrigins(['https://plm.example.com'])
+    window.dispatchEvent(new MessageEvent('message', {
+      origin: 'https://plm.example.com',
+      data: { type: 'mt:get-navigation-state', requestId: 'rOk' },
+    }))
+    await vi.waitFor(() => {
+      expect(
+        parentSpy.mock.calls.some(([payload]) => (payload as { type?: string })?.type === 'mt:navigation-state'),
+      ).toBe(true)
+    })
+    // no outbound post -- mount-time or response -- ever targets '*'
+    for (const call of parentSpy.mock.calls) {
+      expect(call[1]).not.toBe('*')
+    }
+    const stateCall = parentSpy.mock.calls.find(
+      ([payload]) => (payload as { type?: string })?.type === 'mt:navigation-state',
+    )
+    expect(stateCall?.[1]).toBe('https://plm.example.com')
+  })
+})

--- a/apps/web/tests/plm-embed-bom-review.spec.ts
+++ b/apps/web/tests/plm-embed-bom-review.spec.ts
@@ -1,0 +1,217 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, type App as VueApp } from 'vue'
+
+// The embed page's only data dependencies are the two plm-embed service calls; mock them so the
+// tests drive the handshake/state machine directly.
+const getPlmEmbedConfigMock = vi.fn()
+const getPlmEmbedBomContextMock = vi.fn()
+vi.mock('../src/services/integration/plmEmbed', () => ({
+  getPlmEmbedConfig: (...args: unknown[]) => getPlmEmbedConfigMock(...args),
+  getPlmEmbedBomContext: (...args: unknown[]) => getPlmEmbedBomContextMock(...args),
+}))
+
+import PlmEmbedBomReviewView from '../src/views/PlmEmbedBomReviewView.vue'
+
+const PLM_ORIGIN = 'https://plm.example.com'
+const EVIL_ORIGIN = 'https://attacker.example.com'
+
+function flush(): Promise<void> {
+  return new Promise((resolve) => setTimeout(resolve, 0))
+}
+
+function sampleContext() {
+  return {
+    part: { part_id: 'P1', item_number: 'ITM-1', name: 'Widget', state: 'Released', generation: 2 },
+    source_updated_at: '2026-06-01T00:00:00Z',
+    lines: [
+      {
+        bom_line_id: 'L1',
+        level: 1,
+        part_id: 'C1',
+        item_number: 'ITM-C1',
+        name: 'Bolt',
+        state: 'Released',
+        quantity: 4,
+        uom: 'EA',
+        refdes: 'B1',
+        source_version: 3,
+        source_updated_at: '2026-06-01T00:00:00Z',
+      },
+    ],
+  }
+}
+
+describe('PlmEmbedBomReviewView — P3-D2 token-bound embed handshake', () => {
+  let app: VueApp<Element> | null = null
+  let container: HTMLDivElement | null = null
+
+  beforeEach(() => {
+    getPlmEmbedConfigMock.mockReset()
+    getPlmEmbedBomContextMock.mockReset()
+    // default: a single allowlisted PLM origin (never '*')
+    getPlmEmbedConfigMock.mockResolvedValue({
+      allowedOrigins: [PLM_ORIGIN],
+      frameAncestors: `frame-ancestors ${PLM_ORIGIN}`,
+    })
+    getPlmEmbedBomContextMock.mockResolvedValue({ available: true, entitled: true, context: sampleContext() })
+  })
+
+  afterEach(() => {
+    if (app) app.unmount()
+    app = null
+    if (container?.parentNode) container.parentNode.removeChild(container)
+    container = null
+  })
+
+  function mountView(): HTMLDivElement {
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(PlmEmbedBomReviewView)
+    app.mount(container)
+    return container
+  }
+
+  function postMessageFromParent(origin: string, data: unknown): void {
+    window.dispatchEvent(new MessageEvent('message', { origin, data }))
+  }
+
+  function tokenMessage(token = 'embed-token-abc'): { type: string; token: string } {
+    return { type: 'plm-embed:token', token }
+  }
+
+  function state(root: HTMLDivElement): string | null {
+    return root.querySelector('[data-testid="plm-embed-bom-state"]')?.getAttribute('data-state') ?? null
+  }
+
+  it('waits for a token after config loads and never shows a hand-input Part ID field', async () => {
+    const root = mountView()
+    await flush()
+    expect(state(root)).toBe('awaiting-token')
+    // token-bound: there must be NO part input anywhere in the embed surface
+    expect(root.querySelector('input')).toBeNull()
+    expect(root.querySelector('[data-testid="plm-bom-review-part-input"]')).toBeNull()
+    expect(getPlmEmbedBomContextMock).not.toHaveBeenCalled()
+  })
+
+  it('renders the read-only table for a token from an allowlisted origin (part comes from the token)', async () => {
+    const root = mountView()
+    await flush()
+    postMessageFromParent(PLM_ORIGIN, tokenMessage('embed-token-abc'))
+    await flush()
+    expect(state(root)).toBe('table')
+    expect(root.querySelector('[data-testid="plm-bom-review-row"]')).not.toBeNull()
+    // the context call is driven ONLY by the token — no part argument is passed
+    expect(getPlmEmbedBomContextMock).toHaveBeenCalledTimes(1)
+    expect(getPlmEmbedBomContextMock).toHaveBeenCalledWith('embed-token-abc')
+  })
+
+  it('rejects a token from a non-allowlisted origin (stays awaiting, never fetches)', async () => {
+    const root = mountView()
+    await flush()
+    postMessageFromParent(EVIL_ORIGIN, tokenMessage())
+    await flush()
+    expect(state(root)).toBe('awaiting-token')
+    expect(getPlmEmbedBomContextMock).not.toHaveBeenCalled()
+  })
+
+  it('rejects a token whose source window is not the parent, even from an allowlisted origin', async () => {
+    const root = mountView()
+    await flush()
+    const frame = document.createElement('iframe')
+    document.body.appendChild(frame)
+    // an allowlisted origin, but the message came from a window that is NOT window.parent
+    window.dispatchEvent(new MessageEvent('message', { origin: PLM_ORIGIN, data: tokenMessage(), source: frame.contentWindow }))
+    await flush()
+    expect(state(root)).toBe('awaiting-token')
+    expect(getPlmEmbedBomContextMock).not.toHaveBeenCalled()
+    frame.remove()
+  })
+
+  it('accepts a token explicitly sourced from window.parent', async () => {
+    const root = mountView()
+    await flush()
+    window.dispatchEvent(new MessageEvent('message', { origin: PLM_ORIGIN, data: tokenMessage('parent-tok'), source: window.parent }))
+    await flush()
+    expect(state(root)).toBe('table')
+    expect(getPlmEmbedBomContextMock).toHaveBeenCalledWith('parent-tok')
+  })
+
+  it('is fail-closed when the allowlist is empty: no origin can deliver a token', async () => {
+    getPlmEmbedConfigMock.mockResolvedValue({ allowedOrigins: [], frameAncestors: "frame-ancestors 'none'" })
+    const root = mountView()
+    await flush()
+    expect(state(root)).toBe('not-configured')
+    // even a message whose origin matches this frame is rejected when the allowlist is empty
+    postMessageFromParent(window.location.origin, tokenMessage())
+    await flush()
+    expect(state(root)).toBe('not-configured')
+    expect(getPlmEmbedBomContextMock).not.toHaveBeenCalled()
+  })
+
+  it('ignores non-token and malformed messages from an allowlisted origin', async () => {
+    const root = mountView()
+    await flush()
+    postMessageFromParent(PLM_ORIGIN, { type: 'something-else', token: 't' })
+    postMessageFromParent(PLM_ORIGIN, { type: 'plm-embed:token' }) // no token
+    postMessageFromParent(PLM_ORIGIN, 'not-an-object')
+    await flush()
+    expect(state(root)).toBe('awaiting-token')
+    expect(getPlmEmbedBomContextMock).not.toHaveBeenCalled()
+  })
+
+  it('honors only the first valid token (later tokens are ignored)', async () => {
+    mountView()
+    await flush()
+    postMessageFromParent(PLM_ORIGIN, tokenMessage('first'))
+    await flush()
+    postMessageFromParent(PLM_ORIGIN, tokenMessage('second'))
+    await flush()
+    expect(getPlmEmbedBomContextMock).toHaveBeenCalledTimes(1)
+    expect(getPlmEmbedBomContextMock).toHaveBeenCalledWith('first')
+  })
+
+  it('processes a token posted before /config resolves (buffered, then re-validated)', async () => {
+    let resolveConfig: (value: { allowedOrigins: string[]; frameAncestors: string }) => void = () => {}
+    getPlmEmbedConfigMock.mockReturnValue(
+      new Promise((resolve) => {
+        resolveConfig = resolve
+      }),
+    )
+    const root = mountView()
+    // token arrives while config is still in flight
+    postMessageFromParent(PLM_ORIGIN, tokenMessage('early'))
+    await flush()
+    expect(getPlmEmbedBomContextMock).not.toHaveBeenCalled() // allowlist not known yet
+    resolveConfig({ allowedOrigins: [PLM_ORIGIN], frameAncestors: `frame-ancestors ${PLM_ORIGIN}` })
+    await flush()
+    expect(getPlmEmbedBomContextMock).toHaveBeenCalledWith('early')
+    expect(state(root)).toBe('table')
+  })
+
+  it('shows the upgrade state when the tenant is not entitled', async () => {
+    getPlmEmbedBomContextMock.mockResolvedValue({ available: true, entitled: false, context: null })
+    const root = mountView()
+    await flush()
+    postMessageFromParent(PLM_ORIGIN, tokenMessage())
+    await flush()
+    expect(state(root)).toBe('upgrade')
+  })
+
+  it('shows the error state for an entitled+null-context result carrying a transient reason', async () => {
+    getPlmEmbedBomContextMock.mockResolvedValue({ available: true, entitled: true, context: null, reason: 'unavailable' })
+    const root = mountView()
+    await flush()
+    postMessageFromParent(PLM_ORIGIN, tokenMessage())
+    await flush()
+    expect(state(root)).toBe('error')
+  })
+
+  it('shows the unavailable state when the relay reports the surface is unavailable', async () => {
+    getPlmEmbedBomContextMock.mockResolvedValue({ available: false, reason: 'unavailable' })
+    const root = mountView()
+    await flush()
+    postMessageFromParent(PLM_ORIGIN, tokenMessage())
+    await flush()
+    expect(state(root)).toBe('unavailable')
+  })
+})

--- a/apps/web/tests/plm-embed-service.spec.ts
+++ b/apps/web/tests/plm-embed-service.spec.ts
@@ -1,0 +1,138 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+// Exercise the REAL plmEmbed service (the embed component spec mocks this module away, so without
+// this file the security-relevant parsing -- '*' stripping, fail-closed config, the {ok,data}
+// envelope, and the transient-reason-vs-empty distinction -- would run in zero tests).
+const apiFetchMock = vi.fn()
+vi.mock('../src/utils/api', () => ({
+  apiFetch: (...args: unknown[]) => apiFetchMock(...args),
+  apiGet: (...args: unknown[]) => apiFetchMock(...args),
+}))
+
+import { getPlmEmbedConfig, getPlmEmbedBomContext } from '../src/services/integration/plmEmbed'
+
+function rawJsonResponse(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), { status, headers: { 'Content-Type': 'application/json' } })
+}
+
+// identical shape to the P3-C service spec's fixture -- known to pass isPlmBomMultitableContext
+const CONTEXT = {
+  part: { part_id: 'P1', item_number: 'P-001', name: 'Assembly', state: 'Released', generation: 3 },
+  lines: [
+    { bom_line_id: 'R1', part_id: 'C1', item_number: 'C-001', name: 'Bracket', state: 'Draft', generation: 1, quantity: 2, uom: 'EA', find_num: '10', refdes: 'R1,R2', level: 1, path: ['P1'], path_labels: ['P-001'], source_version: 1, source_updated_at: '2026-06-05T00:00:00', sync_status: 'snapshot' },
+  ],
+  source_version: 3,
+  source_updated_at: '2026-06-05T00:00:00',
+  sync_status: 'snapshot',
+  template_key: 'bom_review',
+}
+
+describe('getPlmEmbedConfig (P3-D2 — single-source allowlist, fail-closed)', () => {
+  beforeEach(() => apiFetchMock.mockReset())
+
+  it('reads the allowlist + frame-ancestors from the {ok,data} envelope', async () => {
+    apiFetchMock.mockResolvedValue(
+      rawJsonResponse({ ok: true, data: { allowed_origins: ['https://plm.example.com'], frame_ancestors: 'frame-ancestors https://plm.example.com' } }),
+    )
+    const c = await getPlmEmbedConfig()
+    // token-only iframe: must opt out of apiFetch's 401/403 -> handleUnauthorized login redirect
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/plm-embed/config', { suppressUnauthorizedRedirect: true })
+    expect(c).toEqual({ allowedOrigins: ['https://plm.example.com'], frameAncestors: 'frame-ancestors https://plm.example.com' })
+  })
+
+  it("strips '*', empty, and non-string entries from allowed_origins", async () => {
+    apiFetchMock.mockResolvedValue(
+      rawJsonResponse({ ok: true, data: { allowed_origins: ['*', '', 'https://plm.example.com', 42], frame_ancestors: 'frame-ancestors *' } }),
+    )
+    const c = await getPlmEmbedConfig()
+    expect(c.allowedOrigins).toEqual(['https://plm.example.com'])
+  })
+
+  it('fails closed (empty allowlist + frame-ancestors none) on a non-ok response', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ ok: false }, 500))
+    const c = await getPlmEmbedConfig()
+    expect(c).toEqual({ allowedOrigins: [], frameAncestors: "frame-ancestors 'none'" })
+  })
+
+  it('fails closed on a malformed (no data) response', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ ok: true }))
+    const c = await getPlmEmbedConfig()
+    expect(c).toEqual({ allowedOrigins: [], frameAncestors: "frame-ancestors 'none'" })
+  })
+
+  it('fails closed when apiFetch throws', async () => {
+    apiFetchMock.mockRejectedValueOnce(new Error('network'))
+    const c = await getPlmEmbedConfig()
+    expect(c).toEqual({ allowedOrigins: [], frameAncestors: "frame-ancestors 'none'" })
+  })
+})
+
+describe('getPlmEmbedBomContext (P3-D2 — header-only token + envelope + transient-vs-empty)', () => {
+  beforeEach(() => apiFetchMock.mockReset())
+
+  it('sends the token ONLY in the X-PLM-Embed-Token header (never the URL) and suppresses the login redirect', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ ok: true, data: { available: true, entitled: true, context: CONTEXT, part_id: 'P1' } }))
+    await getPlmEmbedBomContext('tok-xyz')
+    expect(apiFetchMock).toHaveBeenCalledWith('/api/plm-embed/bom-review/context', {
+      headers: { 'X-PLM-Embed-Token': 'tok-xyz' },
+      // 401/403 must degrade in-place, not redirect the token-only iframe to /login
+      suppressUnauthorizedRedirect: true,
+    })
+    expect(apiFetchMock.mock.calls[0][0]).not.toContain('tok-xyz')
+  })
+
+  it('entitled + valid context -> available/entitled/context', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ ok: true, data: { available: true, entitled: true, context: CONTEXT, part_id: 'P1' } }))
+    const r = await getPlmEmbedBomContext('t')
+    expect(r).toEqual({ available: true, entitled: true, context: CONTEXT })
+  })
+
+  it('entitled:false -> upgrade shape (null context)', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ ok: true, data: { available: true, entitled: false, context: null, part_id: 'P1' } }))
+    const r = await getPlmEmbedBomContext('t')
+    expect(r).toEqual({ available: true, entitled: false, context: null })
+  })
+
+  it('entitled + null context + reason -> keeps reason (transient, not empty)', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ ok: true, data: { available: true, entitled: true, context: null, reason: 'unavailable', part_id: 'P1' } }))
+    const r = await getPlmEmbedBomContext('t')
+    expect(r).toEqual({ available: true, entitled: true, context: null, reason: 'unavailable' })
+  })
+
+  it('entitled + null context + NO reason -> no reason (empty/not-found)', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ ok: true, data: { available: true, entitled: true, context: null, part_id: 'P1' } }))
+    const r = await getPlmEmbedBomContext('t')
+    expect(r).toEqual({ available: true, entitled: true, context: null })
+    expect('reason' in r).toBe(false)
+  })
+
+  it('drops an entitled context that fails validation -> null context', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ ok: true, data: { available: true, entitled: true, context: { not: 'a-context' }, part_id: 'P1' } }))
+    const r = await getPlmEmbedBomContext('t')
+    expect(r).toEqual({ available: true, entitled: true, context: null })
+  })
+
+  it('does not trust a context when entitled is false even if one is present', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ ok: true, data: { available: true, entitled: false, context: CONTEXT, part_id: 'P1' } }))
+    const r = await getPlmEmbedBomContext('t')
+    expect(r).toEqual({ available: true, entitled: false, context: null })
+  })
+
+  it('non-200 (e.g. 401 invalid token) -> unavailable', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ ok: false, error: { code: 'INVALID_EMBED_TOKEN' } }, 401))
+    const r = await getPlmEmbedBomContext('t')
+    expect(r).toEqual({ available: false, reason: 'unavailable' })
+  })
+
+  it('malformed envelope -> unavailable', async () => {
+    apiFetchMock.mockResolvedValue(rawJsonResponse({ ok: true }))
+    const r = await getPlmEmbedBomContext('t')
+    expect(r).toEqual({ available: false, reason: 'unavailable' })
+  })
+
+  it('apiFetch throws -> unavailable', async () => {
+    apiFetchMock.mockRejectedValueOnce(new Error('network'))
+    const r = await getPlmEmbedBomContext('t')
+    expect(r).toEqual({ available: false, reason: 'unavailable' })
+  })
+})


### PR DESCRIPTION
## PLM-COLLAB P3-D2 — token-bound BOM-review embed (frontend)

Consumer-side embed surface that consumes the **offline-verified PLM embed token** landed in the backend slice (#2341, minted by Yuantus P3-D1). Frontend-only; the backend (`/api/plm-embed/config`, `/api/plm-embed/bom-review/context`, offline EdDSA verify) is already on `main`.

### What this adds
- **`PlmEmbedBomReviewView`** — a bare, no-session embed page (route `/plm-embed/bom-review`, meta mirrors the public-form route: `requiresAuth:false`, `skipShellBootstrap:true`, `hideNavbar:true`). Flow:
  1. fetch `/api/plm-embed/config` for the parent-origin allowlist — the **single source of truth**, never a URL parameter, never `'*'`;
  2. listen for the PLM-minted token via `postMessage`, accepted **only** from an allowlisted origin (strict exact-match; **fail-closed** when the allowlist is empty);
  3. call `/api/plm-embed/bom-review/context` with the token in the **`X-PLM-Embed-Token` header** — the part is bound to the token's `part_id` claim, so there is **no hand-input Part ID**;
  4. render the read-only table.
- **`PlmBomReviewTable`** — the read-only table extracted from `PlmBomReviewPanel` so the standalone panel (P3-C) and the embed render identical markup.
- **`MultitableEmbedHost` hardening** (the two owner-named fixes): `isOriginAllowed` no longer treats `'*'` as a wildcard; `postToParent` pins the captured/configured parent origin instead of `'*'`.
- `plmEmbed` service (config + token-bound context fetch via `apiFetch`), embed route, tests.

### Security posture
- **Listen-only** embed page → it never posts to the parent, so there is no outbound `targetOrigin '*'` to leak.
- Token accepted only from an **allowlisted origin** AND, when a source is present, only from **`window.parent`** (`event.source` check).
- Token travels **only** in the `X-PLM-Embed-Token` header — never the URL, never a log line.
- Part is **token-bound** (`part_id` claim); the embed UI has no Part ID input.
- Allowlist is single-source (`/config`), exact-match, **fail-closed** on empty / on any fetch failure.
- Both embed calls pass **`suppressUnauthorizedRedirect`** → a 401 (bad/expired token) or 403 (feature/origin mismatch) degrades to unavailable/error **in-place**, never clearing the session or redirecting the token-only iframe to `/login`.

### Review fixes (from #2347 review)
- **[P1] base hygiene:** rebased onto current `origin/main`; `origin/main..HEAD` is exactly the 10 files of this slice (no stray doc).
- **[P1] 401/403 no longer redirects the iframe to login:** `suppressUnauthorizedRedirect: true` on both `/api/plm-embed/*` calls, asserted in the service spec.
- **[P2] source tightening:** embed page rejects a token whose `event.source` is not `window.parent`; `MultitableEmbedHost` pins the parent origin only after a well-formed `mt:` message.

**CSP:** this PR does **not** claim "CSP enforced." `frame-ancestors` must sit on the embed HTML document, which Express does not serve — it is an edge-layer header. `/config` exposes the directive value (fail-closed `'none'`) for that edge layer. The **code-enforced** controls here are: server-side token verify (backend), the `embed_origin` allowlist, and the frontend postMessage origin pin.

### Parent-side contract (Yuantus side, not this slice)
The PLM parent must post the token **after iframe load (with retry)**. The embed buffers a token that races `/config`, but it does **not** buffer one posted before its `message` listener attaches (a deliberate consequence of the listen-only / no-`'*'` choice).

### Verification
- `pnpm type-check` (vue-tsc) — green
- `pnpm lint` — green
- `pnpm vitest` — **80 passed** across the 6 touched specs, incl. embed handshake states, origin rejection, token-bound part, no hand-input Part ID, extraction regression, **positive coverage** for both `MultitableEmbedHost` origin fixes, and a **service-layer spec** running the real `plmEmbed` code ('*' stripping, fail-closed config, `{ok,data}` envelope, header-only token, transient-reason-vs-empty).

### Behavior note (intended, per the "remove '*'" mandate)
`postToParent`'s default-case `targetOrigin` changes from `'*'` to `window.location.origin`. A consumer embedding `MultitableEmbedHost` cross-origin **without** setting `allowedOrigins` was already unable to receive inbound messages (the empty-allowlist default is same-origin), so outbound is now simply consistent with that; any real cross-origin embed must set `allowedOrigins`, and then posts pin to it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
