### PR TITLE
feat(automation): A6-3-2b — condition_branch readability in admin runs

### DIFF
--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -270,6 +270,9 @@ export type AutomationLabelKey =
   | 'runs.triggerEvent'
   | 'runs.ruleSnapshot'
   | 'runs.steps'
+  | 'runs.branchStep'
+  | 'runs.selectedBranch'
+  | 'runs.branchNoMatch'
   | 'runs.loadingDetail'
   | 'runs.resume'
   | 'runs.resumeConfirm'
@@ -499,6 +502,9 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'runs.triggerEvent',
   'runs.ruleSnapshot',
   'runs.steps',
+  'runs.branchStep',
+  'runs.selectedBranch',
+  'runs.branchNoMatch',
   'runs.loadingDetail',
   'runs.resume',
   'runs.resumeConfirm',
@@ -747,6 +753,9 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'runs.triggerEvent': { en: 'Trigger event', zh: '触发事件' },
   'runs.ruleSnapshot': { en: 'Rule snapshot', zh: '规则快照' },
   'runs.steps': { en: 'Steps', zh: '步骤' },
+  'runs.branchStep': { en: 'branch', zh: '分支' },
+  'runs.selectedBranch': { en: 'Selected branch:', zh: '命中分支：' },
+  'runs.branchNoMatch': { en: 'No branch matched (no default)', zh: '无分支命中（无默认分支）' },
   'runs.loadingDetail': { en: 'Loading detail…', zh: '加载详情…' },
   'runs.resume': { en: 'Resume', zh: '恢复执行' },
   'runs.resumeConfirm': {

--- a/apps/web/src/views/AutomationExecutionsView.vue
+++ b/apps/web/src/views/AutomationExecutionsView.vue
@@ -66,8 +66,12 @@
               v-for="step in detail.steps"
               :key="step.id"
               class="automation-runs__step"
+              :class="{ 'automation-runs__step--branch-child': branchChildStep(step.stepKey) }"
             >
               <span class="automation-runs__step-key">{{ step.stepKey }}</span>
+              <span v-if="branchChildStep(step.stepKey)" class="automation-runs__branch-child" data-field="branch-child">
+                ↳ {{ automationLabel('runs.branchStep', isZh) }} {{ branchChildStep(step.stepKey)?.branchKey }} · #{{ branchChildStep(step.stepKey)?.actionIndex }}
+              </span>
               <span class="automation-runs__badge automation-runs__badge--sm" :class="`automation-runs__badge--${step.status}`">
                 {{ automationStatusLabel(step.status, isZh) }}
               </span>
@@ -83,7 +87,11 @@
               <div v-if="step.error" class="automation-runs__step-error" data-field="step-error">
                 {{ summarizeStepError(step.error) }}
               </div>
-              <div v-if="step.result !== undefined && step.result !== null" class="automation-runs__step-output" data-field="step-output">
+              <div v-if="conditionBranchSelection(step)" class="automation-runs__branch-selection" data-field="branch-selection">
+                <template v-if="conditionBranchSelection(step)?.key">{{ automationLabel('runs.selectedBranch', isZh) }} {{ conditionBranchSelection(step)?.key }}</template>
+                <template v-else>{{ automationLabel('runs.branchNoMatch', isZh) }}</template>
+              </div>
+              <div v-if="step.result !== undefined && step.result !== null && !conditionBranchSelection(step)" class="automation-runs__step-output" data-field="step-output">
                 {{ summarizeStepOutput(step.result) }}
               </div>
             </div>
@@ -133,6 +141,22 @@ const detail = ref<AutomationRunView | null>(null)
 const detailLoading = ref(false)
 const resuming = ref<string | null>(null)
 const resumeError = ref<string | null>(null)
+
+// A6-3-2b (read-only): surface condition_branch lineage from the persisted C1 jobs.
+// Parent step's result carries { selectedBranchKey, matched }; nested branch-action jobs use a
+// `${stepIndex}.branch.${key}.${i}` stepKey. Pure readers over the existing run-view shape.
+function conditionBranchSelection(step: AutomationRunStepView): { key: string; matched: boolean } | null {
+  const r = step.result
+  if (r && typeof r === 'object' && !Array.isArray(r) && 'selectedBranchKey' in r) {
+    const key = (r as Record<string, unknown>).selectedBranchKey
+    return { key: typeof key === 'string' ? key : '', matched: Boolean((r as Record<string, unknown>).matched) }
+  }
+  return null
+}
+function branchChildStep(stepKey: string): { branchKey: string; actionIndex: string } | null {
+  const m = /\.branch\.([A-Za-z0-9_-]+)\.(\d+)$/.exec(stepKey)
+  return m ? { branchKey: m[1], actionIndex: m[2] } : null
+}
 
 async function loadData() {
   loading.value = true
@@ -277,6 +301,9 @@ if (isAdmin) void loadData()
 .automation-runs__detail-h { margin: 6px 0 2px; font-size: 12px; font-weight: 700; color: #475569; text-transform: uppercase; }
 .automation-runs__step { display: flex; align-items: center; gap: 8px; font-size: 12px; flex-wrap: wrap; }
 .automation-runs__step-key { font-weight: 700; color: #2563eb; }
+.automation-runs__step--branch-child { margin-left: 20px; border-left: 2px solid #e2e8f0; padding-left: 8px; }
+.automation-runs__branch-child { color: #64748b; font-size: 11px; }
+.automation-runs__branch-selection { width: 100%; padding: 4px 8px; background: #eff6ff; color: #1d4ed8; border-radius: 4px; font-size: 11px; font-weight: 600; }
 .automation-runs__step-error { width: 100%; padding: 4px 8px; background: #fef2f2; color: #dc2626; border-radius: 4px; font-size: 11px; }
 .automation-runs__step-output { width: 100%; padding: 4px 8px; background: #f8fafc; color: #475569; border-radius: 4px; font-size: 11px; word-break: break-all; }
 .automation-runs__json { width: 100%; margin: 0; padding: 8px; background: #f8fafc; color: #334155; border-radius: 6px; font-size: 11px; white-space: pre-wrap; word-break: break-all; max-height: 200px; overflow: auto; }

--- a/apps/web/src/views/AutomationExecutionsView.vue
+++ b/apps/web/src/views/AutomationExecutionsView.vue
@@ -88,7 +88,7 @@
                 {{ summarizeStepError(step.error) }}
               </div>
               <div v-if="conditionBranchSelection(step)" class="automation-runs__branch-selection" data-field="branch-selection">
-                <template v-if="conditionBranchSelection(step)?.key">{{ automationLabel('runs.selectedBranch', isZh) }} {{ conditionBranchSelection(step)?.key }}</template>
+                <template v-if="conditionBranchSelection(step)?.key">{{ automationLabel('runs.selectedBranch', isZh) }} {{ conditionBranchSelection(step)?.label ? `${conditionBranchSelection(step)?.label} (${conditionBranchSelection(step)?.key})` : conditionBranchSelection(step)?.key }}</template>
                 <template v-else>{{ automationLabel('runs.branchNoMatch', isZh) }}</template>
               </div>
               <div v-if="step.result !== undefined && step.result !== null && !conditionBranchSelection(step)" class="automation-runs__step-output" data-field="step-output">
@@ -145,11 +145,15 @@ const resumeError = ref<string | null>(null)
 // A6-3-2b (read-only): surface condition_branch lineage from the persisted C1 jobs.
 // Parent step's result carries { selectedBranchKey, matched }; nested branch-action jobs use a
 // `${stepIndex}.branch.${key}.${i}` stepKey. Pure readers over the existing run-view shape.
-function conditionBranchSelection(step: AutomationRunStepView): { key: string; matched: boolean } | null {
+function conditionBranchSelection(step: AutomationRunStepView): { key: string; label: string; matched: boolean } | null {
   const r = step.result
   if (r && typeof r === 'object' && !Array.isArray(r) && 'selectedBranchKey' in r) {
-    const key = (r as Record<string, unknown>).selectedBranchKey
-    return { key: typeof key === 'string' ? key : '', matched: Boolean((r as Record<string, unknown>).matched) }
+    const rec = r as Record<string, unknown>
+    return {
+      key: typeof rec.selectedBranchKey === 'string' ? rec.selectedBranchKey : '',
+      label: typeof rec.selectedBranchLabel === 'string' ? rec.selectedBranchLabel : '',
+      matched: Boolean(rec.matched),
+    }
   }
   return null
 }

--- a/apps/web/tests/conditionBranchRunsView.spec.ts
+++ b/apps/web/tests/conditionBranchRunsView.spec.ts
@@ -50,12 +50,12 @@ describe('A6-3-2b condition_branch runs readability', () => {
   it('shows the selected branch on the parent step + indents/labels the nested branch jobs', async () => {
     const c = await expand(detailWith([
       { id: 'axe_cb:step:0', executionId: 'axe_cb', stepKey: '0', status: 'resolved', upstreamJobId: null, result: { ok: true } },
-      { id: 'axe_cb:step:1', executionId: 'axe_cb', stepKey: '1', status: 'resolved', upstreamJobId: 'axe_cb:step:0', result: { selectedBranchKey: 'vip', matched: true } },
+      { id: 'axe_cb:step:1', executionId: 'axe_cb', stepKey: '1', status: 'resolved', upstreamJobId: 'axe_cb:step:0', result: { selectedBranchKey: 'vip', selectedBranchLabel: 'VIP tier', matched: true } },
       { id: 'axe_cb:step:1b', executionId: 'axe_cb', stepKey: '1.branch.vip.0', status: 'resolved', upstreamJobId: 'axe_cb:step:1', result: { updated: 1 } },
     ]))
     const sel = c.querySelector('[data-field="branch-selection"]')
     expect(sel).not.toBeNull()
-    expect(sel?.textContent ?? '').toContain('vip') // selected branch surfaced from result.selectedBranchKey
+    expect(sel?.textContent ?? '').toContain('VIP tier (vip)') // label (key) when selectedBranchLabel present
     const child = c.querySelector('[data-field="branch-child"]')
     expect(child).not.toBeNull()
     expect(child?.textContent ?? '').toContain('vip') // parsed from the nested stepKey

--- a/apps/web/tests/conditionBranchRunsView.spec.ts
+++ b/apps/web/tests/conditionBranchRunsView.spec.ts
@@ -1,0 +1,76 @@
+// A6-3-2b — condition_branch readability in the admin runs view (read-only).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import AutomationExecutionsView from '../src/views/AutomationExecutionsView.vue'
+import { useLocale } from '../src/composables/useLocale'
+import type { AutomationRunView } from '../src/multitable/types'
+
+let mockIsAdmin = true
+vi.mock('../src/composables/useAuth', () => ({ useAuth: () => ({ hasAdminAccess: () => mockIsAdmin }) }))
+
+async function settle() {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await nextTick()
+}
+
+const LIST = {
+  id: 'axe_cb', ruleId: 'rule-1', sheetId: 'sheet-a', status: 'resolved', statusLegacy: 'success',
+  triggeredBy: 'event', triggeredAt: '2026-06-06T00:00:00.000Z', finishedAt: '2026-06-06T00:00:01.000Z',
+  duration: 1, error: null, schemaVersion: 1, steps: [],
+}
+function detailWith(steps: unknown[]): AutomationRunView {
+  return { ...LIST, triggerEvent: { recordId: 'rec1' }, ruleSnapshot: { id: 'rule-1', name: 'Branch' }, steps } as AutomationRunView
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeClient(detail: AutomationRunView): any {
+  return { listAutomationRuns: vi.fn().mockResolvedValue([LIST]), getAutomationRun: vi.fn().mockResolvedValue(detail) }
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mount(client: any) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(AutomationExecutionsView, { client }) })
+  app.mount(container)
+  return { container, app }
+}
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mounted: { container: HTMLElement; app: any } | null = null
+beforeEach(() => { mockIsAdmin = true; useLocale().setLocale('en') })
+afterEach(() => { if (mounted) { mounted.app.unmount(); mounted.container.remove(); mounted = null } })
+
+async function expand(detail: AutomationRunView) {
+  mounted = mount(makeClient(detail))
+  await settle()
+  ;(mounted.container.querySelector('[data-run-id="axe_cb"]') as HTMLElement).click()
+  await settle()
+  return mounted.container
+}
+
+describe('A6-3-2b condition_branch runs readability', () => {
+  it('shows the selected branch on the parent step + indents/labels the nested branch jobs', async () => {
+    const c = await expand(detailWith([
+      { id: 'axe_cb:step:0', executionId: 'axe_cb', stepKey: '0', status: 'resolved', upstreamJobId: null, result: { ok: true } },
+      { id: 'axe_cb:step:1', executionId: 'axe_cb', stepKey: '1', status: 'resolved', upstreamJobId: 'axe_cb:step:0', result: { selectedBranchKey: 'vip', matched: true } },
+      { id: 'axe_cb:step:1b', executionId: 'axe_cb', stepKey: '1.branch.vip.0', status: 'resolved', upstreamJobId: 'axe_cb:step:1', result: { updated: 1 } },
+    ]))
+    const sel = c.querySelector('[data-field="branch-selection"]')
+    expect(sel).not.toBeNull()
+    expect(sel?.textContent ?? '').toContain('vip') // selected branch surfaced from result.selectedBranchKey
+    const child = c.querySelector('[data-field="branch-child"]')
+    expect(child).not.toBeNull()
+    expect(child?.textContent ?? '').toContain('vip') // parsed from the nested stepKey
+    expect(child?.textContent ?? '').toContain('#0')
+    expect(c.querySelector('.automation-runs__step--branch-child')).not.toBeNull() // indented
+  })
+
+  it('shows the no-match label when no branch was selected (no default) and suppresses the raw output', async () => {
+    const c = await expand(detailWith([
+      { id: 'axe_cb:step:0', executionId: 'axe_cb', stepKey: '0', status: 'resolved', upstreamJobId: null, result: { selectedBranchKey: null, matched: false } },
+    ]))
+    const sel = c.querySelector('[data-field="branch-selection"]')
+    expect(sel).not.toBeNull()
+    expect(sel?.textContent ?? '').toContain('No branch matched')
+    // the raw {selectedBranchKey:null,...} output is suppressed in favour of the branch-selection line
+    expect(c.querySelector('[data-field="step-output"]')).toBeNull()
+  })
+})


### PR DESCRIPTION
A6-3-2b: the §10 admin-runs-detail half of A6-3-2 — surface the `condition_branch` lineage in `AutomationExecutionsView` (read-only), consuming the C1 jobs A6-3-1 already persists. **Frontend-only, no backend/contract change.** (Editor half = #2339, merged.)

## What it shows
- The `condition_branch` **parent step** shows its **selected branch** (from `step.result.selectedBranchKey`), or a "No branch matched (no default)" line when none/​default — the raw `{selectedBranchKey,…}` output is suppressed in favour of it.
- **Nested branch-action jobs** (`stepKey = "${i}.branch.<key>.<n>"`) are **indented + labelled** `↳ branch <key> · #<n>`, parsed purely from the stepKey (the non-selected branches produce no jobs — exclusive — so only the taken path renders).

## Wire-vs-fixture check (done)
Verified the real data shape before building: the job-service maps the executor result's `output` → step `result` (`automation-job-service.ts:78`), so a parent's `result` carries `{selectedBranchKey, matched}` directly, and nested jobs carry the `.branch.` stepKeys. The view reads exactly that.

## Tests / verification
- `conditionBranchRunsView.spec.ts` (2): selected-branch surfaced + nested-child label/indent; no-match label + raw-output suppression.
- `vue-tsc -b` (the CI command) **0 errors**; existing `AutomationExecutionsView.spec.ts` green (no regression). 3 strict-zero `runs.*` labels added.

Read-only display; no new gated surface. A6-3-3 / parallel-join / A6-4 / A6-5 stay gated.

🤖 Generated with [Claude Code](https://claude.com/claude-code)