### PR TITLE
docs(multitable): refresh chart series comments for v2-d-b (line/grouped/date)

### DIFF
--- a/packages/core-backend/src/multitable/chart-aggregation-service.ts
+++ b/packages/core-backend/src/multitable/chart-aggregation-service.ts
@@ -16,9 +16,10 @@ export interface ChartDataPoint {
 }
 
 /**
- * v2-d stacked-bar series. `data` is dense and aligned POSITIONALLY to `ChartData.dataPoints`
- * (same length, same order; `0` where a (category × series) cell has no rows). Present only for
- * a bar chart with `seriesByFieldId` + a primary `groupByFieldId` + an additive aggregation.
+ * v2-d bar/line series. `data` is dense and aligned POSITIONALLY to `ChartData.dataPoints` (same
+ * length, same order; `0` where a (bucket × series) cell has no rows). Present for a bar or line chart
+ * with `seriesByFieldId` + a primary axis (`groupByFieldId` or a date axis); a stacked bar additionally
+ * requires an additive aggregation, while grouped bar / multi-series line accept any aggregation.
  */
 export interface ChartSeries {
   name: string
@@ -29,7 +30,7 @@ export interface ChartData {
   chartId: string
   chartType: ChartType
   dataPoints: ChartDataPoint[]
-  /** v2-d: stacked series split. `dataPoints`/`total` are unchanged by its presence. */
+  /** v2-d: series split (stacked/grouped bar or multi-series line). `dataPoints`/`total` are unchanged by its presence. */
   series?: ChartSeries[]
   total?: number
   metadata?: {

--- a/packages/core-backend/src/multitable/charts.ts
+++ b/packages/core-backend/src/multitable/charts.ts
@@ -16,9 +16,11 @@ export interface ChartDataSource {
   groupByFieldId?: string
 
   /**
-   * v2-d: split each `groupByFieldId` category into stacked series.
-   * Honored only for a `bar` chart with a primary `groupByFieldId` and an additive
-   * aggregation (sum/count) — see `assertSeriesConstraints`; inert / rejected otherwise.
+   * v2-d: split each primary-axis bucket into series. Honored for a `bar` or `line` chart with a
+   * primary axis — either `groupByFieldId` or a date axis (`dateFieldId` + `dateGrouping`, v2-d-b3).
+   * A STACKED bar additionally requires an additive aggregation (sum/count); a grouped bar
+   * (`display.barMode='grouped'`, v2-d-b1) and a multi-series line (v2-d-b2) accept any aggregation.
+   * See `assertSeriesConstraints`; inert / rejected otherwise.
    */
   seriesByFieldId?: string
 
@@ -91,8 +93,10 @@ export const ADDITIVE_AGGREGATIONS: ReadonlySet<AggregationFunction> = new Set<A
 ])
 
 /**
- * v2-d stacked-series (`seriesByFieldId`) constraints. No-op when unset; otherwise throws unless
- * the chart is a `bar` with a primary `groupByFieldId` and an additive aggregation (sum/count).
+ * v2-d series (`seriesByFieldId`) constraints. No-op when unset; otherwise throws unless the chart is
+ * a `bar` or `line` with a primary axis — `groupByFieldId` OR a date axis (`dateFieldId` +
+ * `dateGrouping`, v2-d-b3). A STACKED bar (default `barMode`) additionally requires an additive
+ * aggregation (sum/count); a grouped bar (`barMode='grouped'`) and a line accept any aggregation.
  *
  * Enforced at EVERY input boundary (preview + persisted create/update) so the UI is never the sole
  * guard; the producer (`ChartAggregationService.computeChartData`) mirrors the same combination and


### PR DESCRIPTION
Comment-only cleanup (reviewer-flagged Low). After v2-d-b1/b2/b3, several comments still described the old **"bar + groupBy + additive/stacked"** model while runtime now supports **line** and a **date axis** as the primary, plus grouped/non-additive. Refreshed so they don't mislead the b3 frontend implementer:

- `ChartDataSource.seriesByFieldId` field doc (`charts.ts`)
- `assertSeriesConstraints` JSDoc (`charts.ts`)
- `ChartSeries` doc + `ChartData.series` doc (`chart-aggregation-service.ts`)

All now state: bar **or** line; primary axis = `groupByFieldId` **or** a date axis; a **stacked bar** requires an additive aggregation, while a **grouped bar / multi-series line** accept any.

**No behavior change** — comment-only diff (verified: no non-comment lines changed), `tsc --noEmit` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)