### PR TITLE
feat(multitable): v2-d-b3 frontend — date-grouped chart series picker

### DIFF
--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -216,7 +216,7 @@
               v-model="chartDraft.seriesByFieldId"
               class="meta-dashboard__select"
               data-field="chart-series-by"
-              :disabled="!chartDraft.groupByFieldId"
+              :disabled="!hasPrimaryAxis"
             >
               <option value="">{{ viewRenderLabel('dashboard.seriesByNone', isZh) }}</option>
               <option v-for="field in groupableFields" :key="field.id" :value="field.id">
@@ -353,9 +353,13 @@ const requiresValueField = computed(() => AGGREGATIONS_REQUIRING_VALUE.has(chart
 // on the aggregation being additive (sum/count) — see `stackedAllowed` + the producer/validator.
 // v2-d-b2: line carries a series split too (overlaid lines). The series picker is offered for any
 // bar OR line chart with a non-date-grouped primary axis.
+// v2-d-b3: the series picker is offered for any bar/line chart — including a date-grouped chart, whose
+// date axis is the primary (groupByFieldId stays disabled there). `hasPrimaryAxis` gates the rest:
+// a series split needs a primary axis = a groupBy field OR an (edited) date axis.
 const seriesByAllowed = computed(() =>
-  (chartDraft.value.chartType === 'bar' || chartDraft.value.chartType === 'line') && !editingDateGrouped.value,
+  chartDraft.value.chartType === 'bar' || chartDraft.value.chartType === 'line',
 )
+const hasPrimaryAxis = computed(() => !!chartDraft.value.groupByFieldId || editingDateGrouped.value)
 const stackedAllowed = computed(() => ADDITIVE_AGGREGATIONS.has(chartDraft.value.aggregation))
 // The layout (barMode) control is bar-only (lines never stack/group); appears once a series is chosen.
 const barModeShown = computed(() => chartDraft.value.chartType === 'bar' && !!chartDraft.value.seriesByFieldId)
@@ -364,7 +368,7 @@ const barModeShown = computed(() => chartDraft.value.chartType === 'bar' && !!ch
 watch(
   () => [chartDraft.value.chartType, chartDraft.value.aggregation, chartDraft.value.groupByFieldId, editingDateGrouped.value],
   () => {
-    if (chartDraft.value.seriesByFieldId && !(seriesByAllowed.value && chartDraft.value.groupByFieldId)) {
+    if (chartDraft.value.seriesByFieldId && !(seriesByAllowed.value && hasPrimaryAxis.value)) {
       chartDraft.value.seriesByFieldId = ''
     }
     // v2-d-b1: stacked requires an additive aggregation; if it's no longer additive, fall back to grouped.
@@ -538,7 +542,7 @@ function buildChartInput(base?: ChartConfig): ChartCreateInput {
   }
   // v2-d / v2-d-b2: bar OR line series split, only with a primary groupBy. Set explicitly (or delete
   // the base value) so switching chartType/groupBy/date clears a now-inapplicable series.
-  const hasSeriesSplit = seriesByAllowed.value && !!chartDraft.value.groupByFieldId && !!chartDraft.value.seriesByFieldId
+  const hasSeriesSplit = seriesByAllowed.value && hasPrimaryAxis.value && !!chartDraft.value.seriesByFieldId
   if (hasSeriesSplit) {
     dataSource.seriesByFieldId = chartDraft.value.seriesByFieldId
   } else {

--- a/apps/web/tests/multitable-build-chart-option.spec.ts
+++ b/apps/web/tests/multitable-build-chart-option.spec.ts
@@ -222,4 +222,26 @@ describe('buildChartOption', () => {
     const area = opt(buildChartOption(chart('line', [{ label: 'A', value: 1 }]), { variant: 'area' }))
     expect(area.series[0].areaStyle).toBeDefined()
   })
+
+  // --- v2-d-b3: date-axis × series renders via the same series shape (render is date-agnostic) ---
+
+  it('v2-d-b3: a date-axis × series line renders overlaid lines with date buckets as the x-axis', () => {
+    const o = opt(buildChartOption({
+      chartType: 'line',
+      dataPoints: [{ label: '2026-01', value: 3 }, { label: '2026-02', value: 5 }],
+      series: [{ name: 'A', data: [2, 4] }, { name: 'B', data: [1, 1] }],
+    }))
+    expect(o.series).toHaveLength(2)
+    expect(o.series.every((s: any) => s.type === 'line' && s.stack === undefined)).toBe(true)
+    expect(o.xAxis.data).toEqual(['2026-01', '2026-02']) // date buckets are the x-axis categories
+  })
+
+  it('v2-d-b3: a date-axis × series area line keeps areaStyle on every line', () => {
+    const o = opt(buildChartOption({
+      chartType: 'line',
+      dataPoints: [{ label: '2026-01', value: 3 }, { label: '2026-02', value: 5 }],
+      series: [{ name: 'A', data: [2, 4] }, { name: 'B', data: [1, 1] }],
+    }, { variant: 'area' }))
+    expect(o.series.every((s: any) => s.areaStyle !== undefined && s.stack === undefined)).toBe(true)
+  })
 })

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -569,6 +569,39 @@ describe('MetaDashboardView', () => {
     expect(body.dataSource.groupByFieldId).toBeUndefined()
   })
 
+  it('v2-d-b3: editing a date-grouped chart exposes an enabled series picker; PATCH carries the series + preserves date grouping', async () => {
+    const chart = fakeChart({
+      chartType: 'line',
+      dataSource: { sheetId: 'sheet_1', dateFieldId: 'fld_date', dateGrouping: 'month', aggregation: { function: 'count' } },
+    })
+    const { client, fetchFn } = mockClient([fakeDashboard()], [chart])
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    ;(container.querySelector('[data-action="add-panel"]') as HTMLButtonElement).click()
+    await nextTick()
+    ;(container.querySelector(`[data-edit-chart="${chart.id}"]`) as HTMLButtonElement).click()
+    await nextTick()
+
+    // groupBy stays disabled (date is the primary), but the series picker is now SHOWN + ENABLED (b3)
+    expect((container.querySelector('[data-field="chart-group-by"]') as HTMLSelectElement).disabled).toBe(true)
+    const series = container.querySelector('[data-field="chart-series-by"]') as HTMLSelectElement
+    expect(series).toBeTruthy()
+    expect(series.disabled).toBe(false) // enabled because the date axis is the primary, even with no groupBy
+    series.value = 'fld_amount'; series.dispatchEvent(new Event('change')); await nextTick()
+
+    ;(container.querySelector('[data-action="submit-create-chart"]') as HTMLButtonElement).click()
+    await flushPromises()
+    const patch = fetchFn.mock.calls.find(
+      ([url, init]: [string, RequestInit?]) => init?.method === 'PATCH' && url.includes(`/charts/${chart.id}`),
+    )
+    const body = JSON.parse(patch![1].body as string)
+    expect(body.dataSource.seriesByFieldId).toBe('fld_amount') // series added on a date-grouped chart
+    expect(body.dataSource.dateFieldId).toBe('fld_date')        // date grouping preserved
+    expect(body.dataSource.dateGrouping).toBe('month')
+    expect(body.dataSource.groupByFieldId).toBeUndefined()      // no spurious groupBy
+    expect(body.display.barMode).toBeUndefined()                // line → no barMode
+  })
+
   it('deletes a chart from the chart list (after confirm) and prunes the panel that showed it', async () => {
     const chart = fakeChart()
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)


### PR DESCRIPTION
Frontend half of **v2-d-b3** (date-axis × series), on the merged backend (#2345). **b3 only — the last piece of the v2-d arc.** Form-gating only; `buildChartOption` already renders a date×series `ChartData` (same `{dataPoints, series}` shape), so **no render/contract change**.

## Change (`MetaDashboardView`)
- Series picker now offered for a **date-grouped** chart too (`seriesByAllowed` drops `!editingDateGrouped`).
- New `hasPrimaryAxis` (`groupByFieldId` **or** an edited date axis) gates the picker enabled-state, the clear-watcher, and `buildChartInput.hasSeriesSplit`. `barMode` stays bar-only; stacked still additive.
- Editing a date-grouped line/bar can add a series field, date grouping preserved.

## Tests
- form: edit date-grouped → series picker **enabled** → PATCH carries `seriesByFieldId` + preserves `dateFieldId`/`dateGrouping`, no spurious `groupByFieldId`, line→no `barMode`.
- `buildChartOption`: date×series line → overlaid lines, date buckets as x-axis; area keeps `areaStyle`.
- 4 importer specs **87/87**; `vue-tsc -b` clean. Transitive-mounter sweep **8/10** — the 2 fails (timeline-config / workflow-designer) are **pre-existing** (stash-based verify-by-revert: identical on clean `origin/main`).

No backend/contract change; synthetic missing-buckets / series-cap untouched.

🤖 Generated with [Claude Code](https://claude.com/claude-code)