### PR TITLE
fix(automation): merge update_record JSONB patches once

### DIFF
--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -1163,23 +1163,16 @@ export class AutomationExecutor {
       return { actionType: 'update_record', status: 'failed', error: 'No fields specified' }
     }
 
-    // Build SET clause
-    const entries = Object.entries(fields)
-    const sets: string[] = []
-    const params: unknown[] = []
-    let idx = 1
-    for (const [key, val] of entries) {
-      sets.push(`data = jsonb_set(COALESCE(data, '{}'), $${idx}::text[], $${idx + 1}::jsonb)`)
-      params.push(`{${key}}`, JSON.stringify(val))
-      idx += 2
-    }
-    params.push(context.recordId, context.sheetId)
+    const patch = Object.fromEntries(Object.entries(fields))
 
     try {
       await this.deps.queryFn(
-        `UPDATE meta_records SET ${sets.join(', ')}, version = version + 1, updated_at = NOW()
-         WHERE id = $${idx} AND sheet_id = $${idx + 1}`,
-        params,
+        `UPDATE meta_records
+         SET data = COALESCE(data, '{}'::jsonb) || $1::jsonb,
+             version = version + 1,
+             updated_at = NOW()
+         WHERE id = $2 AND sheet_id = $3`,
+        [JSON.stringify(patch), context.recordId, context.sheetId],
       )
 
       // Emit event for chaining

--- a/packages/core-backend/tests/unit/multitable-automation-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-service.test.ts
@@ -220,7 +220,7 @@ describe('AutomationService', () => {
     it('runs update_record query and emits follow-up update event', async () => {
       const rule = createMockRule({
         action_type: 'update_record',
-        action_config: { fields: { target_field: 'auto_value' } },
+        action_config: { fields: { target_field: 'auto_value', second_field: 'next_value' } },
       })
       const query = createMockQuery([rule])
       service = new AutomationService(bus, createMockDb([rule]) as never, query)
@@ -234,16 +234,23 @@ describe('AutomationService', () => {
         actorId: 'user1',
       })
 
-      expect(query).toHaveBeenCalledWith(
-        expect.stringContaining('UPDATE meta_records SET'),
-        expect.arrayContaining(['{target_field}', JSON.stringify('auto_value'), 'rec1', 'sheet1']),
+      const updateCall = query.mock.calls.find(([sql]) =>
+        String(sql).includes('UPDATE meta_records') && String(sql).includes('SET data ='),
       )
+      expect(updateCall).toBeTruthy()
+      const [sql, params] = updateCall!
+      expect((String(sql).match(/\bdata\s*=/g) ?? [])).toHaveLength(1)
+      expect(params).toEqual([
+        JSON.stringify({ target_field: 'auto_value', second_field: 'next_value' }),
+        'rec1',
+        'sheet1',
+      ])
 
       // Should emit follow-up update event with incremented depth
       expect(emitSpy).toHaveBeenCalledWith('multitable.record.updated', expect.objectContaining({
         sheetId: 'sheet1',
         recordId: 'rec1',
-        changes: { target_field: 'auto_value' },
+        changes: { target_field: 'auto_value', second_field: 'next_value' },
         _automationDepth: 1,
       }))
     })


### PR DESCRIPTION
## Summary
- Fix `update_record` automation actions so multiple field updates write `meta_records.data` once with a JSONB patch.
- Add a regression assertion that multi-field update_record uses a single `data =` assignment and preserves emitted changes.

## Verification
- `corepack pnpm@10.24.0 --filter @metasheet/core-backend exec vitest run tests/unit/multitable-automation-service.test.ts --watch=false`
- `corepack pnpm@10.24.0 --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts --watch=false`
- `corepack pnpm@10.24.0 --filter @metasheet/web exec vitest run tests/conditionBranchAuthoring.spec.ts tests/conditionBranchEditor.spec.ts tests/conditionBranchRunsView.spec.ts --watch=false`

Refs #2353