### PR TITLE
feat(plm-embed): cross-check embed token tenant against the served data-source tenant (P3-D2 slice A)

### DIFF
--- a/packages/core-backend/src/data-adapters/PLMAdapter.ts
+++ b/packages/core-backend/src/data-adapters/PLMAdapter.ts
@@ -752,6 +752,30 @@ export class PLMAdapter extends HTTPAdapter {
     });
   }
 
+  /**
+   * The tenant ACTUALLY sent on data requests: the `x-tenant-id` on config.connection.headers after
+   * connect(), read CASE-INSENSITIVELY. This is the source of truth -- HTTPAdapter sends
+   * connection.headers verbatim, and applyTenantOrgHeaders does NOT overwrite a hand-set header, so a
+   * hand-set value is what is served (even if a higher-precedence config value differs). Reading the
+   * final header -- not the precedence const -- is what makes the embed tenant cross-check sound.
+   *
+   * Returns undefined when no x-tenant-id is set, OR when multiple x-tenant-id casings disagree (an
+   * ambiguous/misconfigured source) -- so the relay fails closed. Callers MUST connect() first.
+   */
+  getEffectiveTenantId(): string | undefined {
+    const headers = this.config.connection.headers as Record<string, unknown> | undefined
+    if (!headers) return undefined
+    const distinct = Array.from(
+      new Set(
+        Object.keys(headers)
+          .filter((key) => key.toLowerCase() === 'x-tenant-id')
+          .map((key) => headers[key])
+          .filter((value): value is string => typeof value === 'string' && value.length > 0),
+      ),
+    )
+    return distinct.length === 1 ? distinct[0] : undefined
+  }
+
   async connect(): Promise<void> {
     const envBaseUrl = process.env.PLM_BASE_URL || process.env.PLM_URL
     const envToken = process.env.PLM_API_TOKEN || process.env.PLM_AUTH_TOKEN || process.env.PLM_TOKEN
@@ -804,16 +828,17 @@ export class PLMAdapter extends HTTPAdapter {
     }
 
     this.mockMode = isMock;
+    // Resolve the EFFECTIVE tenant/org once (the values actually sent as x-tenant-id / x-org-id):
+    // configService plm.tenantId -> PLM_TENANT_ID env -> per-source config.options.tenantId.
+    const effectiveTenantId = tenantId || (typeof this.config.options?.tenantId === 'string' ? this.config.options.tenantId : undefined)
+    const effectiveOrgId = orgId || (typeof this.config.options?.orgId === 'string' ? this.config.options.orgId : undefined)
     this.apiMode = this.resolveApiMode(
       apiMode || (typeof this.config.options?.apiMode === 'string' ? this.config.options.apiMode : undefined),
       this.config.connection.headers as Record<string, string> | undefined,
-      tenantId || (typeof this.config.options?.tenantId === 'string' ? this.config.options.tenantId : undefined),
-      orgId || (typeof this.config.options?.orgId === 'string' ? this.config.options.orgId : undefined)
+      effectiveTenantId,
+      effectiveOrgId
     );
-    this.applyTenantOrgHeaders(
-      tenantId || (typeof this.config.options?.tenantId === 'string' ? this.config.options.tenantId : undefined),
-      orgId || (typeof this.config.options?.orgId === 'string' ? this.config.options.orgId : undefined)
-    );
+    this.applyTenantOrgHeaders(effectiveTenantId, effectiveOrgId);
     this.yuantusCredentials = username && password
       ? { username, password, tenantId: tenantId || undefined, orgId: orgId || undefined }
       : null;

--- a/packages/core-backend/src/routes/plm-embed.ts
+++ b/packages/core-backend/src/routes/plm-embed.ts
@@ -26,9 +26,17 @@ const BOM_FEATURE_KEY = 'bom_multitable'
 
 interface PlmBomAdapter {
   getBomMultitableContext(partId: string): Promise<BomMultitableContextResult>
+  // the tenant actually served (x-tenant-id), used to cross-check the embed token's tenant_id
+  getEffectiveTenantId(): string | undefined
+  isConnected(): boolean
+  connect(): Promise<void>
 }
 function isPlmBomAdapter(adapter: unknown): adapter is PlmBomAdapter {
-  return typeof (adapter as PlmBomAdapter | null)?.getBomMultitableContext === 'function'
+  const a = adapter as Partial<PlmBomAdapter> | null
+  return typeof a?.getBomMultitableContext === 'function'
+    && typeof a?.getEffectiveTenantId === 'function'
+    && typeof a?.isConnected === 'function'
+    && typeof a?.connect === 'function'
 }
 
 export default function plmEmbedRouter(): Router {
@@ -73,6 +81,22 @@ export default function plmEmbedRouter(): Router {
       }
       if (!isPlmBomAdapter(adapter)) {
         return res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed data source unsupported' } })
+      }
+
+      // Ensure the adapter is connected so its effective tenant (resolved in connect()) is readable.
+      try {
+        if (!adapter.isConnected()) await adapter.connect()
+      } catch {
+        return res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed data source unavailable' } })
+      }
+      // Cross-check the token's tenant against the tenant whose data is ACTUALLY served (the
+      // x-tenant-id the adapter sends), BEFORE querying BOM context. Fail-closed: a missing or
+      // mismatched served tenant -> 403, and the resource is NEVER queried (no cross-tenant fetch).
+      // Comparing against the served tenant -- not a lower-precedence config fallback that the
+      // resolution chain can override -- is what makes this sound (avoids false closure).
+      const servedTenantId = adapter.getEffectiveTenantId()
+      if (!servedTenantId || claims.tenant_id !== servedTenantId) {
+        return res.status(403).json({ ok: false, error: { code: 'EMBED_TENANT_MISMATCH', message: 'token tenant does not match the embed data source tenant' } })
       }
 
       const partId = claims.part_id // token-bound; never a request input

--- a/packages/core-backend/tests/unit/plm-adapter-effective-tenant.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-effective-tenant.test.ts
@@ -1,0 +1,96 @@
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { PLMAdapter } from '../../src/data-adapters/PLMAdapter'
+
+// PLM-COLLAB P3-D2 (slice A): getEffectiveTenantId() must return the tenant the adapter ACTUALLY
+// serves -- the `x-tenant-id` on connection.headers after connect(), read case-insensitively, since
+// HTTPAdapter sends connection.headers verbatim. The precedence
+//   configService('plm.tenantId')  ->  PLM_TENANT_ID (env)  ->  config.options.tenantId
+// populates that header, but a HAND-SET connection x-tenant-id is NOT overwritten and wins. The
+// embed relay cross-checks the embed token against this, so returning anything other than the actual
+// served header would be FALSE CLOSURE (validate a tenant-A token while the adapter serves tenant-B).
+//
+// We exercise the real connect(): with no URL the adapter enters MOCK mode and connect() resolves the
+// tenant, sets the header, and early-returns BEFORE any network call -- so this is a pure unit test.
+const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
+
+function makeAdapter(opts: {
+  globalTenant?: string
+  optionsTenant?: string
+  connectionHeaders?: Record<string, string>
+}): PLMAdapter {
+  const get = vi.fn(async (key: string) => (key === 'plm.tenantId' ? opts.globalTenant : undefined))
+  const configService = { get }
+  const config = {
+    id: 'plm-embed',
+    name: 'PLM',
+    type: 'plm',
+    // no URL -> mock mode -> connect() resolves the tenant + sets the x-tenant-id header then early-returns
+    connection: { url: '', ...(opts.connectionHeaders ? { headers: opts.connectionHeaders } : {}) },
+    options: opts.optionsTenant ? { tenantId: opts.optionsTenant } : {},
+  }
+  return new PLMAdapter(configService as never, logger as never, config as never)
+}
+
+describe('PLMAdapter.getEffectiveTenantId (served tenant, full precedence)', () => {
+  const saved: Record<string, string | undefined> = {}
+  beforeEach(() => {
+    for (const k of ['PLM_TENANT_ID', 'PLM_BASE_URL', 'PLM_URL', 'PLM_USERNAME', 'PLM_PASSWORD']) {
+      saved[k] = process.env[k]
+      delete process.env[k]
+    }
+  })
+  afterEach(() => {
+    for (const k of Object.keys(saved)) {
+      if (saved[k] === undefined) delete process.env[k]
+      else process.env[k] = saved[k]
+    }
+  })
+
+  it('is undefined before connect()', () => {
+    const adapter = makeAdapter({ optionsTenant: 'tenant-a' })
+    expect(adapter.getEffectiveTenantId()).toBeUndefined()
+  })
+
+  it('global configService plm.tenantId WINS over per-source options (the served tenant) — false-closure guard', async () => {
+    const adapter = makeAdapter({ globalTenant: 'tenant-b', optionsTenant: 'tenant-a' })
+    await adapter.connect()
+    // the adapter sends x-tenant-id: tenant-b; validating against options (tenant-a) would be false closure
+    expect(adapter.getEffectiveTenantId()).toBe('tenant-b')
+  })
+
+  it('PLM_TENANT_ID env beats per-source options when no global config', async () => {
+    process.env.PLM_TENANT_ID = 'tenant-env'
+    const adapter = makeAdapter({ optionsTenant: 'tenant-a' })
+    await adapter.connect()
+    expect(adapter.getEffectiveTenantId()).toBe('tenant-env')
+  })
+
+  it('falls back to per-source options.tenantId when neither global config nor env is set', async () => {
+    const adapter = makeAdapter({ optionsTenant: 'tenant-a' })
+    await adapter.connect()
+    expect(adapter.getEffectiveTenantId()).toBe('tenant-a')
+  })
+
+  it('is undefined when no tenant is configured anywhere (the relay then fails closed)', async () => {
+    const adapter = makeAdapter({})
+    await adapter.connect()
+    expect(adapter.getEffectiveTenantId()).toBeUndefined()
+  })
+
+  it('a hand-set connection x-tenant-id IS the served tenant; a higher-precedence config does NOT override it', async () => {
+    // applyTenantOrgHeaders does not overwrite a pre-set header, and HTTPAdapter sends it verbatim,
+    // so the data request serves tenant-a even though global config says tenant-b. getEffectiveTenantId
+    // must return tenant-a (the served value) -- returning tenant-b would be false closure.
+    const adapter = makeAdapter({ globalTenant: 'tenant-b', connectionHeaders: { 'x-tenant-id': 'tenant-a' } })
+    await adapter.connect()
+    expect(adapter.getEffectiveTenantId()).toBe('tenant-a')
+  })
+
+  it('disagreeing x-tenant-id header casings -> undefined (ambiguous served tenant; the relay fails closed)', async () => {
+    // hand-set 'X-Tenant-Id'=tenant-a; applyTenantOrgHeaders adds lowercase 'x-tenant-id'=tenant-b ->
+    // two casings disagree -> the served tenant is ambiguous -> undefined.
+    const adapter = makeAdapter({ globalTenant: 'tenant-b', connectionHeaders: { 'X-Tenant-Id': 'tenant-a' } })
+    await adapter.connect()
+    expect(adapter.getEffectiveTenantId()).toBeUndefined()
+  })
+})

--- a/packages/core-backend/tests/unit/plm-embed-routes.test.ts
+++ b/packages/core-backend/tests/unit/plm-embed-routes.test.ts
@@ -17,6 +17,7 @@ vi.mock('../../src/routes/data-sources', () => ({
 
 import { isWhitelisted } from '../../src/auth/jwt-middleware'
 import plmEmbedRouter from '../../src/routes/plm-embed'
+import { PLMAdapter } from '../../src/data-adapters/PLMAdapter'
 
 const KID = 'embed-1'
 const AUD = 'metasheet2.embed'
@@ -39,6 +40,25 @@ function mint(overrides: Record<string, unknown> = {}, kid = KID): string {
 }
 
 const CONTEXT = { part: { part_id: 'P1', item_number: 'P-001', name: 'A', state: 'Released', generation: 3 }, lines: [], source_version: 3, source_updated_at: '2026', sync_status: 'snapshot', template_key: 'bom_review' }
+
+// A COMPLETE PlmBomAdapter mock: the relay's duck-type now also requires the tenant/connect surface
+// (getEffectiveTenantId/isConnected/connect). Default served tenant = 'default' to match the default
+// minted token's tenant_id, so existing happy-path tests keep passing the cross-check.
+function fullAdapter(opts: {
+  getBomMultitableContext?: ReturnType<typeof vi.fn>
+  tenant?: string | undefined
+  connected?: boolean
+  connect?: ReturnType<typeof vi.fn>
+} = {}) {
+  return {
+    getBomMultitableContext:
+      opts.getBomMultitableContext ??
+      vi.fn().mockResolvedValue({ feature_key: 'bom_multitable', entitled: true, upgrade: { available: false }, context: CONTEXT }),
+    getEffectiveTenantId: () => ('tenant' in opts ? opts.tenant : 'default'),
+    isConnected: () => opts.connected ?? true,
+    connect: opts.connect ?? vi.fn().mockResolvedValue(undefined),
+  }
+}
 
 function buildApp() {
   const app = express()
@@ -77,7 +97,7 @@ describe('PLM embed relay (PLM-COLLAB-P3-D2)', () => {
 
   it('REAL CHAIN: an embed-token-only request (no session Bearer) reaches the route -> 200', async () => {
     const getBomMultitableContext = vi.fn().mockResolvedValue({ feature_key: 'bom_multitable', entitled: true, upgrade: { available: false }, context: CONTEXT })
-    dsMocks.getDataSource.mockReturnValue({ getBomMultitableContext })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getBomMultitableContext }))
     const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint())
     expect(res.status).toBe(200)
     expect(res.body.data.entitled).toBe(true)
@@ -139,7 +159,7 @@ describe('PLM embed relay (PLM-COLLAB-P3-D2)', () => {
   })
 
   it('provider throws -> degrades (context:null), never 500', async () => {
-    dsMocks.getDataSource.mockReturnValue({ getBomMultitableContext: vi.fn().mockRejectedValue(new Error('boom')) })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getBomMultitableContext: vi.fn().mockRejectedValue(new Error('boom')) }))
     const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint())
     expect(res.status).toBe(200)
     expect(res.body.data.context).toBeNull()
@@ -164,5 +184,65 @@ describe('PLM embed relay (PLM-COLLAB-P3-D2)', () => {
     process.env.PLM_EMBED_ALLOWED_ORIGINS = '*'
     const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint())
     expect(res.status).toBe(403) // origin no longer matches an empty allowlist
+  })
+
+  // --- tenant cross-check (slice A): claims.tenant_id must equal the tenant actually served ---
+
+  it('token tenant matches the served (effective) tenant -> 200', async () => {
+    const getBomMultitableContext = vi.fn().mockResolvedValue({ feature_key: 'bom_multitable', entitled: true, upgrade: { available: false }, context: CONTEXT })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getBomMultitableContext, tenant: 'tenant-b' }))
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint({ tenant_id: 'tenant-b' }))
+    expect(res.status).toBe(200)
+    expect(getBomMultitableContext).toHaveBeenCalledWith('P1')
+  })
+
+  it('FALSE-CLOSURE GUARD: served tenant B (e.g. global wins over options A) but token tenant A -> 403, BOM never queried', async () => {
+    const getBomMultitableContext = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getBomMultitableContext, tenant: 'tenant-b' }))
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint({ tenant_id: 'tenant-a' }))
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('EMBED_TENANT_MISMATCH')
+    expect(getBomMultitableContext).not.toHaveBeenCalled()
+  })
+
+  it('absent served tenant -> 403 fail-closed, BOM never queried', async () => {
+    const getBomMultitableContext = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getBomMultitableContext, tenant: undefined }))
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint())
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('EMBED_TENANT_MISMATCH')
+    expect(getBomMultitableContext).not.toHaveBeenCalled()
+  })
+
+  it('an unconnected adapter is connected before its tenant is read', async () => {
+    const connect = vi.fn().mockResolvedValue(undefined)
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ connected: false, connect }))
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint())
+    expect(connect).toHaveBeenCalled()
+    expect(res.status).toBe(200)
+  })
+
+  it('an adapter missing the tenant/connect surface -> 503 (stricter duck-type)', async () => {
+    dsMocks.getDataSource.mockReturnValue({ getBomMultitableContext: vi.fn() })
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint())
+    expect(res.status).toBe(503)
+  })
+
+  it('END-TO-END (real adapter): global tenant B but a hand-set connection x-tenant-id A, token B -> 403, BOM never queried', async () => {
+    for (const k of ['PLM_TENANT_ID', 'PLM_BASE_URL', 'PLM_URL']) delete process.env[k]
+    // global config says tenant-b, but the data source hand-sets x-tenant-id: tenant-a (served value)
+    const adapter = new PLMAdapter(
+      { get: async (key: string) => (key === 'plm.tenantId' ? 'tenant-b' : undefined) } as never,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+      { id: DS_ID, name: 'PLM', type: 'plm', connection: { url: '', headers: { 'x-tenant-id': 'tenant-a' } } } as never,
+    )
+    await adapter.connect() // no URL -> mock mode -> no network; serves x-tenant-id: tenant-a
+    const spy = vi.spyOn(adapter, 'getBomMultitableContext')
+    dsMocks.getDataSource.mockReturnValue(adapter)
+    // a token for tenant-b must NOT be able to read tenant-a's served data
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint({ tenant_id: 'tenant-b' }))
+    expect(res.status).toBe(403)
+    expect(res.body.error.code).toBe('EMBED_TENANT_MISMATCH')
+    expect(spy).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## PLM-COLLAB P3-D2 slice A — embed token tenant ↔ served data-source tenant cross-check

Closes the **first partial** from the P3-D closeout (#737): the embed relay now binds the token's tenant to the tenant whose data is **actually served**, instead of leaving the alignment to deployment config. Backend-only.

### Model — R1 (compare against the EFFECTIVE served tenant, not a fallback)
Per the agreed reasoning: A's goal is "token tenant === the tenant actually served", so the only sound comparand is the tenant the adapter actually puts on `x-tenant-id` — comparing against the lowest-precedence `config.options.tenantId` would be **false closure** (validate a tenant-A token while the chain serves tenant-B data).

- **`PLMAdapter.getEffectiveTenantId()`** — returns the tenant **actually sent on data requests**: the `x-tenant-id` on `connection.headers` after `connect()`, read **case-insensitively** (HTTPAdapter sends `connection.headers` verbatim). The precedence `configService('plm.tenantId')` → `PLM_TENANT_ID` (env) → `config.options.tenantId` *populates* that header, but a **hand-set** `x-tenant-id` is not overwritten and is the served value. Disagreeing casings → `undefined` (ambiguous → fail-closed). This is the **structural** fix for the false-closure edge: the check compares the literal served header, not a precedence const that a hand-set header could diverge from.
- **`/api/plm-embed/bom-review/context` order:** `verify token → resolve configured data source → ensure/connect adapter → read served tenant → claims.tenant_id === served tenant → getBomMultitableContext`. A missing/ambiguous/mismatched served tenant is **fail-closed (403 `EMBED_TENANT_MISMATCH`)** and the BOM context is **never queried** (no cross-tenant fetch).

### Tests
- **Adapter** (`plm-adapter-effective-tenant.test.ts`): precedence (global config / env beat options) populates the served header; **a hand-set `connection.headers['x-tenant-id']` wins over a higher-precedence config** (returns the served value, not the config one); disagreeing casings → `undefined`; absent → `undefined`.
- **Relay** (`plm-embed-routes.test.ts`): match → 200; false-closure guard (served B + token A → 403, never queried); absent served tenant → 403; unconnected adapter is connected first; stricter duck-type → 503; **END-TO-END with a real `PLMAdapter`** — global config tenant B but a hand-set `connection x-tenant-id` A + token B → 403, BOM never queried.

### Deployment note
- The cross-check validates the **served `x-tenant-id`** (`connection.headers` after `connect()`).
- A **per-source** tenant (distinct from the global) currently requires **direct/internal `DataSourceConfig` construction**. The data-sources **REST/UI schema accepts neither path**: `connection` is a flat `z.record(string|number|boolean)` (a nested `connection.headers` object is rejected), and `options` is a closed object that strips `options.tenantId`. So a **REST-created** embed source inherits the **global** `configService('plm.tenantId')` / `PLM_TENANT_ID` tenant (which `connect()` writes into the header).
- Keep the served tenant **unambiguous**: don't let a global `plm.tenantId` silently stand in for a real per-source tenant, and don't set **disagreeing `x-tenant-id` casings** (→ fail-closed).
- Supporting per-source tenants via REST/UI (widening `ConnectionConfigSchema`/`options`) is a **future schema extension**, not part of this slice.

### Review fixes (round 2, from #2356 review)
- **[P1] base-race** — rebased onto current `origin/main`; `origin/main..HEAD` is exactly the 4 files of this slice.
- **[P1] getter now structurally sound** — `getEffectiveTenantId()` reads the actual served `x-tenant-id` header (case-insensitive) instead of the precedence const, so a hand-set conflicting header can no longer slip a token past the check. The PR-body caveat from round 1 is replaced by this code fix + the real-adapter end-to-end test.
- **[P2] config-path accuracy** — corrected: the data-sources REST/UI schema persists **neither** `options.tenantId` (closed `options`) **nor** a nested `connection.headers` (`ConnectionConfigSchema` is a flat `z.record(string|number|boolean)`). A per-source tenant is a direct/internal-construction path today; a REST-created source inherits the global tenant. Documented as such; widening the schema is deferred (out of this slice). No schema change.

### Verification
- root `type-check` — green
- `eslint` (changed src) — 0 errors
- `vitest` — **28 passed** across the two touched specs

Follow-up (separate slice, not here): **B** — jti single-use / revocation (shared-store seen-jti, no provider callback), the second `[~]` from #737.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
