### PR TITLE
fix(automation): clarify required WorkflowJob helper copy

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -1833,7 +1833,7 @@ function removeDefaultBranch(action: DraftAction): void {
 
 function setExecutionMode(checked: boolean): void {
   // A6-1 opt-in: checkbox → the rule's persistent WorkflowJob mode (off = legacy/null).
-  // A6-2b: cannot turn it off while a wait_for_callback step is present.
+  // A6-2b/A6-3-2a: cannot turn it off while a required-job-mode action is present.
   if (requiresJobMode.value) {
     draft.value.executionMode = 'workflow_job_v1'
     return
@@ -2767,8 +2767,8 @@ function buildPayload(): Partial<AutomationRule> {
     actions,
     actionType: actions[0]?.type ?? 'update_record',
     actionConfig: actions[0]?.config ?? {},
-    // A6-2b: a wait_for_callback action forces workflow_job_v1 (backend fail-closes legacy waits) —
-    // enforced here so the payload is correct regardless of toggle state.
+    // A6-2b/A6-3-2a: required-job-mode actions force workflow_job_v1 (backend fail-closes
+    // legacy waits/branches) — enforced here so the payload is correct regardless of toggle state.
     executionMode: requiresJobMode.value ? 'workflow_job_v1' : d.executionMode,
   }
 }

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -565,8 +565,8 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
     zh: '开启后，本规则每个动作的运行都会保存为持久的 WorkflowJob 记录；关闭则使用默认的轻量日志。',
   },
   'editor.executionModeRequiredHint': {
-    en: 'Required and locked on: this rule has a "wait for callback" action, and suspend/resume needs the WorkflowJob record.',
-    zh: '已强制开启并锁定：本规则包含“等待回调”动作，挂起/恢复依赖 WorkflowJob 记录，无法关闭。',
+    en: 'Required and locked on: this rule has an action that requires durable WorkflowJob records (wait for callback or condition branch).',
+    zh: '已强制开启并锁定：本规则包含需要持久 WorkflowJob 记录的动作（等待回调或条件分支），无法关闭。',
   },
   'trigger.title': { en: 'Trigger', zh: '触发器' },
   'trigger.watchField': { en: 'Watch field', zh: '监听字段' },

--- a/apps/web/tests/meta-automation-labels.spec.ts
+++ b/apps/web/tests/meta-automation-labels.spec.ts
@@ -61,6 +61,13 @@ describe('meta-automation-labels', () => {
     expect(automationActionTypeLabel('future_action', true)).toBe('future_action')
   })
 
+  it('explains required WorkflowJob mode for both wait and branch actions', () => {
+    expect(automationLabel('editor.executionModeRequiredHint', false)).toContain('condition branch')
+    expect(automationLabel('editor.executionModeRequiredHint', false)).toContain('wait for callback')
+    expect(automationLabel('editor.executionModeRequiredHint', true)).toContain('条件分支')
+    expect(automationLabel('editor.executionModeRequiredHint', true)).toContain('等待回调')
+  })
+
   it('localizes trigger types, trigger conditions, and cron presets with raw fallbacks', () => {
     expect(automationTriggerTypeLabel('record.created', false)).toBe('When record created')
     expect(automationTriggerTypeLabel('record.created', true)).toBe('当记录创建时')


### PR DESCRIPTION
## Summary
- Update the automation editor required-WorkflowJob helper copy so it names both current required-job-mode actions: wait for callback and condition branch.
- Align nearby source comments with the shared required-job-mode gate.
- Add a label test to keep the helper copy from regressing to a single-action explanation.

## Verification
- pnpm install --frozen-lockfile
- pnpm --filter @metasheet/web exec vitest run tests/meta-automation-labels.spec.ts --watch=false
- pnpm --filter @metasheet/web type-check
- git diff --check

Refs #2353