### PR TITLE
fix(multitable): re-trigger live preview on series/barMode/variant change

### DIFF
--- a/apps/web/src/multitable/components/MetaDashboardView.vue
+++ b/apps/web/src/multitable/components/MetaDashboardView.vue
@@ -760,6 +760,11 @@ watch(
     chartDraft.value.groupByFieldId,
     chartDraft.value.aggregation,
     chartDraft.value.valueFieldId,
+    // every field buildChartInput reads must re-trigger the preview, else the saved config diverges
+    // from what's shown: variant (v2-c), seriesByFieldId (v2-d), barMode (v2-d-b1).
+    chartDraft.value.variant,
+    chartDraft.value.seriesByFieldId,
+    chartDraft.value.barMode,
     editingDateGrouped.value,
   ],
   scheduleChartPreview,

--- a/apps/web/tests/multitable-dashboard-view.spec.ts
+++ b/apps/web/tests/multitable-dashboard-view.spec.ts
@@ -602,6 +602,35 @@ describe('MetaDashboardView', () => {
     expect(body.display.barMode).toBeUndefined()                // line → no barMode
   })
 
+  it('v2-d-b3: changing ONLY the series field on a date-grouped chart re-requests the live preview', async () => {
+    const chart = fakeChart({
+      chartType: 'line',
+      dataSource: { sheetId: 'sheet_1', dateFieldId: 'fld_date', dateGrouping: 'month', aggregation: { function: 'count' } },
+    })
+    const { client } = mockClient([fakeDashboard()], [chart])
+    const previewSpy = vi.spyOn(client, 'previewChartData').mockResolvedValue({ chartType: 'line', dataPoints: [{ label: '2026-01', value: 1 }] })
+    const { container } = mount({ sheetId: 'sheet_1', client, fields: chartFields })
+    await flushPromises()
+    vi.useFakeTimers()
+    ;(container.querySelector('[data-action="add-panel"]') as HTMLButtonElement).click()
+    await nextTick()
+    ;(container.querySelector(`[data-edit-chart="${chart.id}"]`) as HTMLButtonElement).click()
+    await nextTick()
+    await vi.advanceTimersByTimeAsync(300); await nextTick() // let the on-open preview settle
+    previewSpy.mockClear()
+
+    // change ONLY the series field — must re-trigger the debounced preview (the watcher-dep bug)
+    const series = container.querySelector('[data-field="chart-series-by"]') as HTMLSelectElement
+    series.value = 'fld_amount'; series.dispatchEvent(new Event('change')); await nextTick()
+    await vi.advanceTimersByTimeAsync(300); await nextTick()
+
+    expect(previewSpy).toHaveBeenCalledTimes(1)
+    expect(previewSpy).toHaveBeenLastCalledWith('sheet_1', expect.objectContaining({
+      dataSource: expect.objectContaining({ seriesByFieldId: 'fld_amount' }),
+    }))
+    vi.useRealTimers()
+  })
+
   it('deletes a chart from the chart list (after confirm) and prunes the panel that showed it', async () => {
     const chart = fakeChart()
     const confirmSpy = vi.spyOn(window, 'confirm').mockReturnValue(true)


### PR DESCRIPTION
**Reviewer-flagged Medium.** The dashboard live-preview watcher depended on `name`/`chartType`/`groupByFieldId`/`aggregation`/`valueFieldId`/`editingDateGrouped` — but **not** `variant` (v2-c), `seriesByFieldId` (v2-d), or `barMode` (v2-d-b1). So changing *only* one of those saved the new config but left the **preview stale** — most visible for **b3 date-axis × series** (editing a date-grouped chart to add a series field showed the old preview).

## Fix
Added `variant`, `seriesByFieldId`, `barMode` to the preview-trigger watcher's dependency list, so every field `buildChartInput` reads re-requests the debounced preview. One-line-ish change; no other behavior touched.

## Test
Open an existing date-grouped chart, change **only** `seriesByFieldId`, assert `previewChartData` is re-called with the new series (`dataSource.seriesByFieldId`). dashboard spec **34/34**, other importer specs 54/54, `vue-tsc -b` clean. Transitive-mounter sweep 8/10 — the 2 fails (timeline-config / workflow-designer) are **pre-existing** (stash-based verify-by-revert: identical on clean `origin/main`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)