### PR TITLE
feat(data-factory): surface bounded large-BOM dry-runs

### DIFF
--- a/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
@@ -571,7 +571,7 @@ Acceptance locks:
   unknown action ids fail closed.
 - Admin-only route/UI. Read/write non-admin users cannot sync options.
 
-### 🟡 Large-BOM C0 - strategy design for #2342 (ACTIVE - this PR)
+### ✅ Large-BOM C0 - strategy design for #2342 (DONE - PR #2351, `b7998d73d`)
 
 Gated on: #2340 large-sample dry-run evidence + explicit opt-in.
 
@@ -602,14 +602,41 @@ Acceptance locks:
 - #2343 D1 remains ready but should run after #2342 C0 for large samples,
   because complete expansion is upstream of authoritative duplicate analysis.
 
-Planned follow-up slices after C0 review:
+### 🟡 Large-BOM C1 - bounded dry-run readiness shape (ACTIVE - this PR)
 
-1. C1 bounded dry-run readiness shape (`largeBom=true`, no token, Apply
-   disabled).
-2. C2 operator UI affordance for summary-first bounded review.
-3. C3 background full-expansion design.
-4. C4 checkpointed apply writer design.
-5. C5 entity-machine validation with values-free evidence.
+Gated on: Large-BOM C0 accepted + explicit opt-in.
+
+Scope:
+
+- Preserve sync dry-run as bounded and read-only.
+- Surface scale-class caps as a values-free bounded state:
+  `status='large_bom_bounded'`, `largeBom=true`, `boundedPreview.complete=false`.
+- Keep Apply blocked: `canApply=false`, no dry-run token, no MetaSheet row
+  write.
+- Treat only scale caps as large-BOM bounded:
+  `max_rows_exceeded`, `read_page_limit_exceeded`, `read_count_exceeded`, and
+  `read_time_limit_exceeded`.
+- Preserve hard failures as hard failures: `max_depth_exceeded`, cycles, source
+  read failures, invalid rows, and other correctness errors must not be
+  relabeled as large BOM.
+- Keep issue/customer evidence values-free: counts, cap fields, read diagnostics,
+  and error types only.
+
+Acceptance locks:
+
+- `largeBom=true` always blocks Apply.
+- No dry-run token is issued for bounded large-BOM states.
+- C3 counts over bounded rows are subset/non-authoritative.
+- Browser input cannot raise caps or choose Apply mode.
+- No UI, route shape redesign, background job, checkpoint writer, package,
+  PLM write, external database write, K3, or production rollout.
+
+Planned follow-up slices after C1 review:
+
+1. C2 operator UI affordance for summary-first bounded review.
+2. C3 background full-expansion design.
+3. C4 checkpointed apply writer design.
+4. C5 entity-machine validation with values-free evidence.
 
 ## Deferred tracks
 
@@ -618,8 +645,8 @@ Planned follow-up slices after C0 review:
 - PLM adapter/API source instead of readonly SQL.
 - Fuzzy/prefix/multi-project matching.
 - Procurement/warehouse child-table generation.
-- Large-BOM runtime beyond C0: bounded-readiness implementation, UI affordance,
-  background full expansion, and checkpointed apply remain separate opt-ins.
+- Large-BOM runtime beyond C1: UI affordance, background full expansion, and
+  checkpointed apply remain separate opt-ins.
 - SQL bridge C3 watermark/incremental implementation.
 - External DB write.
 - K3 Save / Submit / Audit / BOM.

--- a/docs/development/data-factory-plm-stock-preparation-large-bom-c1-bounded-readiness-verification-20260606.md
+++ b/docs/development/data-factory-plm-stock-preparation-large-bom-c1-bounded-readiness-verification-20260606.md
@@ -1,0 +1,113 @@
+# Data Factory #2342 C1 - large-BOM bounded readiness verification (2026-06-06)
+
+## Scope
+
+This slice implements the C1 runtime readiness shape from
+`data-factory-plm-stock-preparation-large-bom-c0-design-20260606.md`.
+
+It changes only the PLM stock-preparation table-action dry-run path:
+
+- scale caps become an explicit bounded readiness state;
+- Apply remains blocked;
+- no dry-run token is issued;
+- evidence stays values-free.
+
+No UI, route redesign, background worker, checkpoint writer, package change,
+MetaSheet row write, PLM write, external database write, K3 path, or production
+rollout is included.
+
+## Runtime shape
+
+When expansion hits a scale-class cap, dry-run now returns:
+
+```json
+{
+  "status": "large_bom_bounded",
+  "largeBom": true,
+  "canApply": false,
+  "dryRunToken": null,
+  "boundedPreview": {
+    "complete": false,
+    "authoritative": false,
+    "rowsExpanded": 500,
+    "readCount": 1068,
+    "errorTypes": ["max_rows_exceeded"]
+  }
+}
+```
+
+The exact counts vary by run. The important invariants are:
+
+- `largeBom=true` means the plan is not authoritative.
+- `canApply=false` is mandatory.
+- `dryRunToken` is absent/null.
+- C3 counts are bounded/subset counts only.
+- issue/customer evidence must copy only the values-free evidence object, never
+  row payloads or tenant-visible preview values.
+
+## Scale caps
+
+C1 treats these error types as bounded large-BOM scale failures:
+
+- `max_rows_exceeded`
+- `read_page_limit_exceeded`
+- `read_count_exceeded`
+- `read_time_limit_exceeded`
+
+`read_page_limit_exceeded` is preserved from the read helper instead of being
+collapsed into `read_failed`. This matters because a wide object exceeding page
+budget is a scale condition, while a driver/query failure is a source failure.
+
+The helper also accepts server-side `maxReadCount` and `maxElapsedMs` options.
+They are not browser-controlled and do not unlock Apply.
+
+## Hard failures stay hard
+
+These are not converted into `largeBom=true`:
+
+- `max_depth_exceeded`
+- `cycle_detected`
+- `read_failed`
+- invalid quantities or other row-level correctness issues
+- mixed scale + hard global errors
+- mixed scale + row-level correctness errors
+
+That keeps runaway/correctness/source failures distinct from bounded scale
+diagnostics.
+
+## Verification
+
+Commands:
+
+```bash
+pnpm --filter plugin-integration-core test:stock-preparation-bom-expansion
+pnpm --filter plugin-integration-core test:stock-preparation-table-actions
+pnpm --filter plugin-integration-core test
+```
+
+Covered assertions:
+
+- `max_rows_exceeded` dry-run returns `status='large_bom_bounded'`,
+  `largeBom=true`, `canApply=false`, `dryRunToken=null`, and stores no token.
+- `read_page_limit_exceeded` is preserved as a bounded scale error and reported
+  through `boundedPreview.errorTypes`.
+- `maxReadCount` produces `read_count_exceeded` with values-free diagnostics.
+- `maxElapsedMs` produces `read_time_limit_exceeded` with values-free
+  diagnostics.
+- `max_depth_exceeded` remains `status='failed'` and `largeBom=false`.
+- a scale cap mixed with a row-level correctness error remains
+  `largeBom=false` and does not expose `boundedPreview`.
+- evidence does not contain project number, component source id, component
+  display value, PLM path id, dry-run token, sheet id, field id, raw SQL, or
+  secret material.
+
+## Remaining gates
+
+- C2: UI display for summary-first bounded review.
+- C3: background full-expansion design.
+- C4: checkpointed large apply design.
+- C5: entity-machine validation with values-free evidence.
+
+Duplicate handling for large samples (#2343 D1) should wait until full expansion
+is available for those large samples, because bounded/subset duplicate counts are
+not authoritative.

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-bom-expansion.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-bom-expansion.test.cjs
@@ -226,6 +226,90 @@ async function testFailClosedGuards() {
   }
 }
 
+async function testScaleLimitsRemainDiagnosableAndValuesFree() {
+  {
+    const { adapter } = createAdapter(baseData({
+      DN_PDM_PathExAttrInfo: [
+        { FileCode: 'P-001', Parent_OBJ_ID: 'PATH-1' },
+        { FileCode: 'P-001', Parent_OBJ_ID: 'PATH-2' },
+      ],
+    }))
+    const result = await expandPlmProjectBom({
+      sourceAdapter: adapter,
+      projectNo: 'P-001',
+      pageLimit: 1,
+      maxPages: 1,
+    })
+    const evidence = summarizeBomExpansionForEvidence(result)
+
+    assert.equal(result.valid, false)
+    assert.deepEqual(evidence.errorTypes, ['read_page_limit_exceeded'])
+    assert.equal(evidence.largeBom, true)
+    assert.deepEqual(evidence.boundedPreview.errorTypes, ['read_page_limit_exceeded'])
+    assert.equal(evidence.boundedPreview.complete, false)
+    assert.equal(evidence.boundedPreview.authoritative, false)
+    assert.equal(evidence.boundedPreview.maxPages, 1)
+    assert.equal(JSON.stringify(evidence).includes('PATH-'), false, 'page-limit evidence hides PLM row values')
+  }
+
+  {
+    const { adapter } = createAdapter(baseData())
+    const result = await expandPlmProjectBom({
+      sourceAdapter: adapter,
+      projectNo: 'P-001',
+      maxReadCount: 1,
+    })
+    const evidence = summarizeBomExpansionForEvidence(result)
+
+    assert.equal(result.valid, false)
+    assert.deepEqual(evidence.errorTypes, ['read_count_exceeded'])
+    assert.equal(evidence.readCount, 1)
+    assert.equal(evidence.largeBom, true)
+    assert.equal(evidence.boundedPreview.maxReadCount, 1)
+  }
+
+  {
+    const { adapter } = createAdapter(baseData())
+    const result = await expandPlmProjectBom({
+      sourceAdapter: adapter,
+      projectNo: 'P-001',
+      maxElapsedMs: 1,
+      startedAtMs: 0,
+      now: () => 2,
+    })
+    const evidence = summarizeBomExpansionForEvidence(result)
+
+    assert.equal(result.valid, false)
+    assert.deepEqual(evidence.errorTypes, ['read_time_limit_exceeded'])
+    assert.equal(evidence.readCount, 0)
+    assert.equal(evidence.largeBom, true)
+    assert.equal(evidence.boundedPreview.maxElapsedMs, 1)
+  }
+
+  {
+    const { adapter } = createAdapter(baseData({
+      DN_PDM_OrderDetailInfo: [
+        { order_id: 'ORDER-1', part_id: 'PART-BAD', quantity: 'not-a-number' },
+        { order_id: 'ORDER-1', part_id: 'PART-A', quantity: '1' },
+        { order_id: 'ORDER-1', part_id: 'PART-B', quantity: '1' },
+      ],
+      DN_PDM_PartLibraryInfo: [
+        { OBJ_ID: 'PART-A', IdentityNo: 'A-001', IdentityName: 'Assembly', Material: 'Steel', SysVer: 'V1' },
+        { OBJ_ID: 'PART-B', IdentityNo: 'B-001', IdentityName: 'Bolt', Material: 'Iron', SysVer: 'V1' },
+      ],
+      DN_PDM_BomHeadInfo: [],
+      DN_PDM_BomDetailsInfo: [],
+    }))
+    const result = await expandPlmProjectBom({ sourceAdapter: adapter, projectNo: 'P-001', maxRows: 1 })
+    const evidence = summarizeBomExpansionForEvidence(result)
+
+    assert.equal(result.valid, false)
+    assert.deepEqual(evidence.errorTypes, ['invalid_quantity', 'max_rows_exceeded'])
+    assert.equal(evidence.largeBom, false, 'row-level correctness errors are not relabeled as bounded large BOM')
+    assert.equal(evidence.boundedPreview, undefined)
+  }
+}
+
 function testReadPlanValidation() {
   const plan = clone(PLM_STOCK_PREPARATION_BOM_READ_PLAN)
   assert.equal(normalizeStockPreparationBomReadPlan(plan).matchField, 'FileCode')
@@ -263,6 +347,7 @@ async function main() {
   await testNoHit()
   await testSameComponentUnderDifferentParentsStaysDistinct()
   await testFailClosedGuards()
+  await testScaleLimitsRemainDiagnosableAndValuesFree()
   testReadPlanValidation()
 
   console.log('stock-preparation-bom-expansion.test.cjs OK')

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
@@ -74,6 +74,18 @@ function basePlmData(overrides = {}) {
   }
 }
 
+function childBomPlmData(overrides = {}) {
+  return basePlmData({
+    DN_PDM_PartLibraryInfo: [
+      { OBJ_ID: 'PART-A', IdentityNo: 'A-001', IdentityName: 'Assembly', Material: 'Steel', SysVer: 'V1' },
+      { OBJ_ID: 'PART-B', IdentityNo: 'B-001', IdentityName: 'Bolt', Material: 'Iron', SysVer: 'V1' },
+    ],
+    DN_PDM_BomHeadInfo: [{ part_id: 'PART-A', bom_id: 'BOM-A', SysVer: 'V1', bom_able: true }],
+    DN_PDM_BomDetailsInfo: [{ bom_pid: 'BOM-A', part_id: 'PART-B', Bom_ExAttr1: '3' }],
+    ...overrides,
+  })
+}
+
 function createSourceAdapter(data = basePlmData()) {
   const calls = []
   return {
@@ -385,6 +397,80 @@ async function testApplyRequiresTokenRecomputesAndScopesTarget() {
   )
 }
 
+async function testLargeBomBoundedDryRunBlocksApplyToken() {
+  const source = createSourceAdapter(childBomPlmData())
+  const records = createRecordsApi()
+  const storage = createMemoryStorage()
+
+  const dryRun = await dryRunStockPreparationAction({
+    action: baseAction({ maxRows: 1 }),
+    parameters: { projectNo: 'P-001' },
+    sourceAdapter: source.adapter,
+    recordsApi: records.recordsApi,
+    tokenStore: storage,
+    plannedAt: '2026-06-04T09:00:00.000Z',
+  })
+
+  assert.equal(dryRun.status, 'large_bom_bounded')
+  assert.equal(dryRun.largeBom, true)
+  assert.equal(dryRun.canApply, false)
+  assert.equal(dryRun.dryRunToken, null, 'bounded large-BOM dry-run must not issue an apply token')
+  assert.deepEqual([...storage.map.keys()], [], 'bounded large-BOM dry-run stores no token')
+  assert.deepEqual(dryRun.boundedPreview.errorTypes, ['max_rows_exceeded'])
+  assert.equal(dryRun.boundedPreview.complete, false)
+  assert.equal(dryRun.boundedPreview.authoritative, false)
+  assert.equal(dryRun.evidence.expansion.largeBom, true)
+  assert.deepEqual(dryRun.evidence.expansion.boundedPreview.errorTypes, ['max_rows_exceeded'])
+  assert.equal(JSON.stringify(dryRun.evidence).includes('P-001'), false, 'bounded evidence hides project value')
+  assert.equal(JSON.stringify(dryRun.evidence).includes('PART-B'), false, 'bounded evidence hides component source id')
+}
+
+async function testReadPageLimitBoundedDryRunAndDepthHardFailureStayDistinct() {
+  const records = createRecordsApi()
+
+  {
+    const source = createSourceAdapter(basePlmData({
+      DN_PDM_PathExAttrInfo: [
+        { FileCode: 'P-001', Parent_OBJ_ID: 'PATH-1' },
+        { FileCode: 'P-001', Parent_OBJ_ID: 'PATH-2' },
+      ],
+    }))
+    const dryRun = await dryRunStockPreparationAction({
+      action: baseAction({ pageLimit: 1, maxPages: 1 }),
+      parameters: { projectNo: 'P-001' },
+      sourceAdapter: source.adapter,
+      recordsApi: records.recordsApi,
+      tokenStore: createMemoryStorage(),
+      plannedAt: '2026-06-04T09:00:00.000Z',
+    })
+
+    assert.equal(dryRun.status, 'large_bom_bounded')
+    assert.equal(dryRun.largeBom, true)
+    assert.equal(dryRun.canApply, false)
+    assert.equal(dryRun.dryRunToken, null)
+    assert.deepEqual(dryRun.boundedPreview.errorTypes, ['read_page_limit_exceeded'])
+    assert.equal(dryRun.boundedPreview.maxPages, 1)
+  }
+
+  {
+    const source = createSourceAdapter(childBomPlmData())
+    const dryRun = await dryRunStockPreparationAction({
+      action: baseAction({ maxDepth: 0 }),
+      parameters: { projectNo: 'P-001' },
+      sourceAdapter: source.adapter,
+      recordsApi: records.recordsApi,
+      tokenStore: createMemoryStorage(),
+      plannedAt: '2026-06-04T09:00:00.000Z',
+    })
+
+    assert.equal(dryRun.status, 'failed')
+    assert.equal(dryRun.largeBom, false)
+    assert.equal(dryRun.canApply, false)
+    assert.equal(dryRun.dryRunToken, null)
+    assert.equal(dryRun.evidence.expansion.errorTypes.includes('max_depth_exceeded'), true)
+  }
+}
+
 async function testApplyNormalizesNumericPlmDisplayFieldsBeforeCreate() {
   const storage = createMemoryStorage()
   const source = createSourceAdapter(basePlmData({
@@ -556,6 +642,8 @@ async function main() {
   await testBridgeSourceKindRequiresExplicitMatchingReadPlanAndCanDryRun()
   await testTargetFieldMapIncompleteFailsBeforeReads()
   await testApplyRequiresTokenRecomputesAndScopesTarget()
+  await testLargeBomBoundedDryRunBlocksApplyToken()
+  await testReadPageLimitBoundedDryRunAndDepthHardFailureStayDistinct()
   await testApplyNormalizesNumericPlmDisplayFieldsBeforeCreate()
   await testApplySurfacesTypedValuesFreeRowFailureDiagnostics()
   await testApplyDetectsDataShiftAndManualConfirmHold()

--- a/plugins/plugin-integration-core/lib/stock-preparation-bom-expansion.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-bom-expansion.cjs
@@ -12,6 +12,12 @@ const DEFAULT_PAGE_LIMIT = 1000
 const DEFAULT_MAX_PAGES = 100
 const DEFAULT_MAX_DEPTH = 20
 const DEFAULT_MAX_ROWS = 10000
+const LARGE_BOM_BOUNDED_ERROR_TYPES = Object.freeze([
+  'max_rows_exceeded',
+  'read_page_limit_exceeded',
+  'read_count_exceeded',
+  'read_time_limit_exceeded',
+])
 const STOCK_PREPARATION_BOM_SOURCE_KINDS = Object.freeze([
   'data-source:sql-readonly',
   'bridge:legacy-sql-readonly',
@@ -119,6 +125,11 @@ function positiveInteger(input, field, defaultValue) {
     throw new StockPreparationBomExpansionError(`${field} must be a positive integer`, { field, value: input })
   }
   return value
+}
+
+function optionalPositiveInteger(input, field) {
+  if (input === undefined || input === null || input === '') return undefined
+  return positiveInteger(input, field, undefined)
 }
 
 function nonNegativeInteger(input, field, defaultValue) {
@@ -250,6 +261,47 @@ function normalizeFilters(filters) {
   return out
 }
 
+function isLargeBomBoundedErrorType(type) {
+  return LARGE_BOM_BOUNDED_ERROR_TYPES.includes(type)
+}
+
+function isReadLimitError(error) {
+  return Boolean(
+    error &&
+    error.name === 'StockPreparationBomExpansionError' &&
+    error.details &&
+    isLargeBomBoundedErrorType(error.details.code),
+  )
+}
+
+function readLimitErrorDetails(error, fallbackObject) {
+  if (!isReadLimitError(error)) return null
+  const details = error.details || {}
+  const { code, ...rest } = details
+  return {
+    type: code,
+    ...(fallbackObject && !rest.object ? { object: fallbackObject } : {}),
+    ...rest,
+  }
+}
+
+function assertReadBudget(options, readStats, object) {
+  if (options.maxReadCount !== undefined && readStats.length >= options.maxReadCount) {
+    throw new StockPreparationBomExpansionError('PLM read exceeded maxReadCount', {
+      code: 'read_count_exceeded',
+      object,
+      maxReadCount: options.maxReadCount,
+    })
+  }
+  if (options.maxElapsedMs !== undefined && options.now() - options.startedAtMs > options.maxElapsedMs) {
+    throw new StockPreparationBomExpansionError('PLM read exceeded maxElapsedMs', {
+      code: 'read_time_limit_exceeded',
+      object,
+      maxElapsedMs: options.maxElapsedMs,
+    })
+  }
+}
+
 async function readAll(adapter, object, filters, options, readStats) {
   const normalizedFilters = normalizeFilters(filters)
   const rows = []
@@ -262,6 +314,7 @@ async function readAll(adapter, object, filters, options, readStats) {
         maxPages: options.maxPages,
       })
     }
+    assertReadBudget(options, readStats, object)
     const input = { object, filters: normalizedFilters, limit: options.pageLimit }
     if (cursor) input.cursor = cursor
     const stat = {
@@ -383,7 +436,33 @@ function readDiagnostic(entry = {}) {
   return diagnostic
 }
 
-function makeSummary({ projectNoPresent, matchField, status, rowsExpanded, rootMatches, maxDepth, maxRows, readStats, errors, rowErrors }) {
+function scaleErrorTypes(errors = []) {
+  return Array.from(new Set(errors.map((entry) => entry.type).filter(isLargeBomBoundedErrorType))).sort()
+}
+
+function isLargeBomBoundedExpansion(result = {}) {
+  const errors = Array.isArray(result.errors) ? result.errors : []
+  const rowErrors = Array.isArray(result.rowErrors) ? result.rowErrors : []
+  return errors.length > 0 && rowErrors.length === 0 && errors.every((entry) => isLargeBomBoundedErrorType(entry.type))
+}
+
+function boundedPreviewSummary(summary = {}, errorTypes = []) {
+  if (errorTypes.length === 0) return undefined
+  const out = {
+    complete: false,
+    authoritative: false,
+    rowsExpanded: Number(summary.rowsExpanded || 0),
+    readCount: Number(summary.readCount || 0),
+    errorTypes: errorTypes.slice(),
+  }
+  if (summary.maxRows !== undefined) out.maxRows = summary.maxRows
+  if (summary.maxPages !== undefined) out.maxPages = summary.maxPages
+  if (summary.maxReadCount !== undefined) out.maxReadCount = summary.maxReadCount
+  if (summary.maxElapsedMs !== undefined) out.maxElapsedMs = summary.maxElapsedMs
+  return out
+}
+
+function makeSummary({ projectNoPresent, matchField, status, rowsExpanded, rootMatches, maxDepth, maxRows, maxPages, maxReadCount, maxElapsedMs, readStats, errors, rowErrors }) {
   const summary = {
     projectNoPresent,
     matchField,
@@ -392,6 +471,9 @@ function makeSummary({ projectNoPresent, matchField, status, rowsExpanded, rootM
     rootMatches,
     maxDepth,
     maxRows,
+    maxPages,
+    maxReadCount,
+    maxElapsedMs,
     readObjects: Array.from(new Set(readStats.map((entry) => entry.object))).sort(),
     readCount: readStats.length,
     readDiagnostics: readStats.map(readDiagnostic),
@@ -460,7 +542,7 @@ function rowFromPart(plan, { projectNo, parentSourceId, pathTokens, depth, partR
   }
 }
 
-function failureResult({ projectNoPresent, matchField, status = 'failed', rows, errors, rowErrors, readStats, rootMatches, maxDepth, maxRows }) {
+function failureResult({ projectNoPresent, matchField, status = 'failed', rows, errors, rowErrors, readStats, rootMatches, maxDepth, maxRows, maxPages, maxReadCount, maxElapsedMs }) {
   return {
     valid: false,
     status,
@@ -475,6 +557,9 @@ function failureResult({ projectNoPresent, matchField, status = 'failed', rows, 
       rootMatches,
       maxDepth,
       maxRows,
+      maxPages,
+      maxReadCount,
+      maxElapsedMs,
       readStats,
       errors,
       rowErrors,
@@ -494,6 +579,10 @@ async function expandPlmProjectBom(input = {}) {
     maxPages: positiveInteger(input.maxPages, 'maxPages', DEFAULT_MAX_PAGES),
     maxDepth: nonNegativeInteger(input.maxDepth, 'maxDepth', DEFAULT_MAX_DEPTH),
     maxRows: positiveInteger(input.maxRows, 'maxRows', DEFAULT_MAX_ROWS),
+    maxReadCount: optionalPositiveInteger(input.maxReadCount, 'maxReadCount'),
+    maxElapsedMs: optionalPositiveInteger(input.maxElapsedMs, 'maxElapsedMs'),
+    startedAtMs: Number.isFinite(input.startedAtMs) ? Number(input.startedAtMs) : Date.now(),
+    now: typeof input.now === 'function' ? input.now : Date.now,
   }
   const readStats = []
   const errors = []
@@ -503,6 +592,14 @@ async function expandPlmProjectBom(input = {}) {
   const read = (object, filters) => readAll(sourceAdapter, object, filters, options, readStats)
   const addGlobalError = (type, details = {}) => {
     errors.push({ type, ...details })
+  }
+  const addReadError = (err, object) => {
+    const bounded = readLimitErrorDetails(err, object)
+    if (bounded) {
+      addGlobalError(bounded.type, bounded)
+      return
+    }
+    addGlobalError('read_failed', { object, message: err && err.message })
   }
   const addRowError = (error) => {
     rowErrors.push(error)
@@ -520,7 +617,7 @@ async function expandPlmProjectBom(input = {}) {
   try {
     pathMatches = await read(plan.pathExAttr.object, { [plan.pathExAttr.matchField]: projectNo })
   } catch (err) {
-    addGlobalError('read_failed', { object: plan.pathExAttr.object, message: err && err.message })
+    addReadError(err, plan.pathExAttr.object)
     return failureResult({
       projectNoPresent: true,
       matchField: plan.matchField,
@@ -531,6 +628,9 @@ async function expandPlmProjectBom(input = {}) {
       rootMatches: 0,
       maxDepth: options.maxDepth,
       maxRows: options.maxRows,
+      maxPages: options.maxPages,
+      maxReadCount: options.maxReadCount,
+      maxElapsedMs: options.maxElapsedMs,
     })
   }
 
@@ -549,6 +649,9 @@ async function expandPlmProjectBom(input = {}) {
         rootMatches: 0,
         maxDepth: options.maxDepth,
         maxRows: options.maxRows,
+        maxPages: options.maxPages,
+        maxReadCount: options.maxReadCount,
+        maxElapsedMs: options.maxElapsedMs,
         readStats,
         errors: [],
         rowErrors: [],
@@ -583,7 +686,7 @@ async function expandPlmProjectBom(input = {}) {
     try {
       heads = (await read(plan.bomHead.object, headFilters)).filter((head) => isActiveBomHead(head, plan.bomHead.activeField))
     } catch (err) {
-      addGlobalError('read_failed', { object: plan.bomHead.object, message: err && err.message })
+      addReadError(err, plan.bomHead.object)
       return
     }
     if (nextDepth > options.maxDepth && heads.length > 0) {
@@ -601,7 +704,7 @@ async function expandPlmProjectBom(input = {}) {
       try {
         details = await read(plan.bomDetail.object, { [plan.bomDetail.bomParentField]: bomId })
       } catch (err) {
-        addGlobalError('read_failed', { object: plan.bomDetail.object, message: err && err.message })
+        addReadError(err, plan.bomDetail.object)
         return
       }
       for (const detail of details) {
@@ -713,7 +816,9 @@ async function expandPlmProjectBom(input = {}) {
       }
     }
   } catch (err) {
-    addGlobalError('read_failed', { message: err && err.message })
+    const bounded = readLimitErrorDetails(err)
+    if (bounded) addGlobalError(bounded.type, bounded)
+    else addGlobalError('read_failed', { message: err && err.message })
   }
 
   const status = errors.length > 0 || rowErrors.length > 0 ? 'failed' : 'expanded'
@@ -731,6 +836,9 @@ async function expandPlmProjectBom(input = {}) {
       rootMatches: pathMatches.length,
       maxDepth: options.maxDepth,
       maxRows: options.maxRows,
+      maxPages: options.maxPages,
+      maxReadCount: options.maxReadCount,
+      maxElapsedMs: options.maxElapsedMs,
       readStats,
       errors,
       rowErrors,
@@ -749,10 +857,15 @@ function summarizeBomExpansionForEvidence(result = {}) {
     rootMatches: Number(summary.rootMatches || 0),
     maxDepth: summary.maxDepth,
     maxRows: summary.maxRows,
+    maxPages: summary.maxPages,
+    maxReadCount: summary.maxReadCount,
+    maxElapsedMs: summary.maxElapsedMs,
     readObjects: Array.isArray(summary.readObjects) ? summary.readObjects.slice() : [],
     readCount: Number(summary.readCount || 0),
     readDiagnostics: Array.isArray(summary.readDiagnostics) ? summary.readDiagnostics.map(readDiagnostic) : [],
     errorTypes: Array.isArray(summary.errorTypes) ? summary.errorTypes.slice() : [],
+    largeBom: isLargeBomBoundedExpansion(result),
+    boundedPreview: isLargeBomBoundedExpansion(result) ? boundedPreviewSummary(summary, scaleErrorTypes(result.errors)) : undefined,
     actions: isPlainObject(summary.actions) ? { ...summary.actions } : undefined,
   }
 }
@@ -762,12 +875,14 @@ module.exports = {
   DEFAULT_MAX_PAGES,
   DEFAULT_MAX_DEPTH,
   DEFAULT_MAX_ROWS,
+  LARGE_BOM_BOUNDED_ERROR_TYPES,
   FORBIDDEN_PLAN_KEYS,
   PLM_STOCK_PREPARATION_BOM_READ_PLAN,
   STOCK_PREPARATION_BOM_SOURCE_KINDS,
   StockPreparationBomExpansionError,
   normalizeStockPreparationBomReadPlan,
   expandPlmProjectBom,
+  isLargeBomBoundedExpansion,
   summarizeBomExpansionForEvidence,
   __internals: {
     isBlank,

--- a/plugins/plugin-integration-core/lib/stock-preparation-table-actions.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-table-actions.cjs
@@ -10,6 +10,7 @@ const {
   PLM_STOCK_PREPARATION_BOM_READ_PLAN,
   STOCK_PREPARATION_BOM_SOURCE_KINDS,
   expandPlmProjectBom,
+  isLargeBomBoundedExpansion,
   summarizeBomExpansionForEvidence,
 } = require('./stock-preparation-bom-expansion.cjs')
 const {
@@ -162,6 +163,8 @@ function normalizeStockPreparationActionConfig(input = {}) {
     conflictStrategy: isPlainObject(input.conflictStrategy) ? cloneJson(input.conflictStrategy) : {},
     pageLimit: positiveInteger(input.pageLimit, 'pageLimit', undefined),
     maxPages: positiveInteger(input.maxPages, 'maxPages', undefined),
+    maxReadCount: positiveInteger(input.maxReadCount, 'maxReadCount', undefined),
+    maxElapsedMs: positiveInteger(input.maxElapsedMs, 'maxElapsedMs', undefined),
     maxDepth: input.maxDepth,
     maxRows: input.maxRows,
   }
@@ -459,6 +462,8 @@ async function computeDryRun({ action, parameters, sourceAdapter, recordsApi, pl
     readPlan: action.source.readPlan,
     pageLimit: action.pageLimit,
     maxPages: action.maxPages,
+    maxReadCount: action.maxReadCount,
+    maxElapsedMs: action.maxElapsedMs,
     maxDepth: action.maxDepth,
     maxRows: action.maxRows,
   })
@@ -499,6 +504,19 @@ function evidenceForDryRun({ action, parameters, expansion, plan, revision, canA
   }
 }
 
+function largeBomBoundedPreview(expansion) {
+  if (!isLargeBomBoundedExpansion(expansion)) return undefined
+  const evidence = summarizeBomExpansionForEvidence(expansion)
+  return evidence.boundedPreview
+}
+
+function dryRunStatus(dryRun) {
+  if (dryRun.expansion.status === 'not_found') return 'not_found'
+  if (isLargeBomBoundedExpansion(dryRun.expansion)) return 'large_bom_bounded'
+  if (dryRun.canApply) return dryRun.plan.valid ? 'ready' : 'manual_confirm_required'
+  return 'failed'
+}
+
 async function dryRunStockPreparationAction(input = {}) {
   const action = assertStockPreparationTargetReady(input.action)
   const parameters = normalizeActionParameters(input.parameters)
@@ -520,11 +538,9 @@ async function dryRunStockPreparationAction(input = {}) {
   }
   return {
     action: publicActionMetadata(action),
-    status: dryRun.expansion.status === 'not_found'
-      ? 'not_found'
-      : dryRun.canApply
-        ? (dryRun.plan.valid ? 'ready' : 'manual_confirm_required')
-        : 'failed',
+    status: dryRunStatus(dryRun),
+    largeBom: isLargeBomBoundedExpansion(dryRun.expansion),
+    boundedPreview: largeBomBoundedPreview(dryRun.expansion),
     dryRunToken,
     revision: dryRun.revision,
     canApply: dryRun.canApply,


### PR DESCRIPTION
## What changed

Implements #2342 C1 bounded dry-run readiness for the PLM stock-preparation table action.

- Preserves scale-class read caps as explicit bounded large-BOM evidence instead of opaque `failed` only:
  - `max_rows_exceeded`
  - `read_page_limit_exceeded`
  - `read_count_exceeded`
  - `read_time_limit_exceeded`
- Dry-run now returns `status: 'large_bom_bounded'`, `largeBom: true`, and a values-free `boundedPreview` when the expansion is bounded only by scale caps.
- Apply remains blocked: `canApply: false`, `dryRunToken: null`, and no token is written.
- Hard/correctness failures stay hard: max depth, cycles, read failures, row-level errors, and mixed row-error + scale states are not relabeled as large BOM.
- Adds server-side `maxReadCount` / `maxElapsedMs` budgets; browser input still cannot raise caps or choose apply mode.
- Updates the #2253 TODO to mark #2351 C0 done and C1 active, with C2/C3/C4/C5 still gated.

## Boundary

Backend/runtime only. No UI affordance yet, no route redesign, no background worker, no checkpoint writer, no package change, no MetaSheet row write, no PLM/external DB write, no K3.

C2 remains the next separate opt-in: UI display for the bounded large-BOM state. Until C2, the response and apply gate are correct, but the dedicated operator presentation is not in this PR.

## Verification

- `pnpm --filter plugin-integration-core test:stock-preparation-bom-expansion`
- `pnpm --filter plugin-integration-core test:stock-preparation-table-actions`
- `pnpm --filter plugin-integration-core test`
- `git diff --check`

Verification doc: `docs/development/data-factory-plm-stock-preparation-large-bom-c1-bounded-readiness-verification-20260606.md`.

Closes no issue; advances #2342 C1.
