### PR TITLE
feat(data-factory): show bounded large-BOM dry-runs

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -1000,6 +1000,18 @@ export interface IntegrationTableActionMetadata {
 export interface IntegrationTableActionDryRunResult {
   action?: IntegrationTableActionMetadata
   status: string
+  largeBom?: boolean
+  boundedPreview?: {
+    complete?: boolean
+    authoritative?: boolean
+    rowsExpanded?: number
+    readCount?: number
+    maxRows?: number
+    maxPages?: number
+    maxReadCount?: number
+    maxElapsedMs?: number
+    errorTypes?: string[]
+  }
   dryRunToken?: string | null
   revision?: string
   canApply?: boolean

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -767,6 +767,19 @@
               <span>inactive {{ tableActionCounts.inactive || 0 }}</span>
               <span>manual {{ tableActionCounts.manual_confirm || 0 }}</span>
             </div>
+            <div v-if="tableActionLargeBomBounded" class="integration-workbench__bounded-preview" data-testid="table-action-large-bom-bounded">
+              <div>
+                <strong>大 BOM 有界预览</strong>
+                <span class="integration-workbench__badge" data-status="error">Apply blocked</span>
+              </div>
+              <p>本次只展开了有界子集，冲突/重复计数不是完整计划；不会签发 dry-run token。</p>
+              <div class="integration-workbench__metric-row">
+                <span v-for="metric in tableActionBoundedPreviewMetrics" :key="metric.id">{{ metric.label }} {{ metric.value }}</span>
+              </div>
+              <p v-if="tableActionBoundedErrorTypes.length" class="integration-workbench__hint">
+                errorTypes: {{ tableActionBoundedErrorTypes.join(', ') }}
+              </p>
+            </div>
             <p class="integration-workbench__hint" data-testid="table-action-token-state">
               {{ tableActionDryRunToken ? 'dry-run token 已签发；token 仅保存在当前页面内存，不展示、不复制到 evidence。' : '本次 dry-run 不可 apply；请处理失败项后重跑。' }}
             </p>
@@ -1863,6 +1876,34 @@ const selectedTableAction = computed(() => tableActions.value.find((action) => a
 const tableActionCounts = computed(() => tableActionDryRunResult.value?.counts || {})
 const tableActionManualConfirmCount = computed(() => Number(tableActionCounts.value.manual_confirm || 0))
 const tableActionDryRunToken = computed(() => tableActionDryRunResult.value?.dryRunToken || '')
+const tableActionLargeBomBounded = computed(() => isLargeBomBoundedTableActionResult(tableActionDryRunResult.value))
+const tableActionBoundedPreview = computed(() => {
+  const result = tableActionDryRunResult.value
+  if (!result) return null
+  if (isRecord(result.boundedPreview)) return result.boundedPreview
+  const evidence = isRecord(result.evidence) ? result.evidence : null
+  const expansion = evidence && isRecord(evidence.expansion) ? evidence.expansion : null
+  return expansion && isRecord(expansion.boundedPreview) ? expansion.boundedPreview : null
+})
+const tableActionBoundedErrorTypes = computed(() => {
+  const preview = tableActionBoundedPreview.value
+  if (Array.isArray(preview?.errorTypes)) return preview.errorTypes.filter((entry): entry is string => typeof entry === 'string')
+  const evidence = isRecord(tableActionDryRunResult.value?.evidence) ? tableActionDryRunResult.value?.evidence : null
+  const expansion = evidence && isRecord(evidence.expansion) ? evidence.expansion : null
+  return Array.isArray(expansion?.errorTypes) ? expansion.errorTypes.filter((entry): entry is string => typeof entry === 'string') : []
+})
+const tableActionBoundedPreviewMetrics = computed(() => {
+  const preview = tableActionBoundedPreview.value
+  if (!preview) return []
+  return [
+    { id: 'rows-expanded', label: 'rows', value: numberMetric(preview.rowsExpanded) },
+    { id: 'read-count', label: 'reads', value: numberMetric(preview.readCount) },
+    { id: 'max-rows', label: 'maxRows', value: numberMetric(preview.maxRows) },
+    { id: 'max-pages', label: 'maxPages', value: numberMetric(preview.maxPages) },
+    { id: 'max-read-count', label: 'maxReadCount', value: numberMetric(preview.maxReadCount) },
+    { id: 'max-elapsed-ms', label: 'maxElapsedMs', value: numberMetric(preview.maxElapsedMs) },
+  ].filter((metric) => metric.value !== '')
+})
 const tableActionEvidenceText = computed(() => {
   const evidence = tableActionApplyResult.value?.evidence || tableActionDryRunResult.value?.evidence
   return evidence ? JSON.stringify(evidence, null, 2) : ''
@@ -1913,6 +1954,11 @@ const tableActionReviewSummary = computed(() => {
   if (!tableActionDryRunResult.value) return '输入项目号后先 dry-run；apply 必须使用本次 dry-run token，并由服务端重新计算计划。'
   const status = tableActionDryRunResult.value.status || 'unknown'
   const counts = tableActionCounts.value
+  if (tableActionLargeBomBounded.value) {
+    const rows = numberMetric(tableActionBoundedPreview.value?.rowsExpanded) || '0'
+    const reads = numberMetric(tableActionBoundedPreview.value?.readCount) || '0'
+    return `dry-run ${status} · bounded rows ${rows} / reads ${reads} · Apply blocked`
+  }
   return `dry-run ${status} · add ${counts.add || 0} / update ${counts.update || 0} / skip ${counts.skip || 0} / inactive ${counts.inactive || 0} / manual ${counts.manual_confirm || 0}`
 })
 
@@ -2367,6 +2413,18 @@ function normalizeStagingOpenTargets(result: IntegrationStagingInstallResult): I
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return Boolean(value && typeof value === 'object' && !Array.isArray(value))
+}
+
+function numberMetric(value: unknown): string {
+  return typeof value === 'number' && Number.isFinite(value) ? String(value) : ''
+}
+
+function isLargeBomBoundedTableActionResult(result: IntegrationTableActionDryRunResult | null): boolean {
+  if (!result) return false
+  if (result.largeBom === true || result.status === 'large_bom_bounded') return true
+  const evidence = isRecord(result.evidence) ? result.evidence : null
+  const expansion = evidence && isRecord(evidence.expansion) ? evidence.expansion : null
+  return expansion?.largeBom === true
 }
 
 const SECRET_EXPORT_KEY_PATTERN = /(^|[._-])(password|passwd|pwd|token|access[_-]?token|refresh[_-]?token|id[_-]?token|session[_-]?id|api[_-]?key|secret|signature|sign|auth|authorization)([._-]|$)/i
@@ -3268,7 +3326,9 @@ async function dryRunTableAction(): Promise<void> {
     })
     tableActionDryRunResult.value = result
     const manualCount = Number(result.counts?.manual_confirm || 0)
-    const message = manualCount > 0
+    const message = isLargeBomBoundedTableActionResult(result)
+      ? '表动作 dry-run 返回大 BOM 有界预览；Apply 已阻塞，请走完整展开/后台通道。'
+      : manualCount > 0
       ? `表动作 dry-run 完成：${manualCount} 行需要人工确认，apply 会保持这些行不写。`
       : '表动作 dry-run 完成，可进入 apply 确认。'
     setStatus(message, result.canApply ? 'success' : 'error')
@@ -3532,6 +3592,26 @@ watch([selectedTableActionId, tableActionProjectNo], () => {
   display: flex;
   flex-direction: column;
   gap: 8px;
+}
+
+.integration-workbench__bounded-preview {
+  display: grid;
+  gap: 8px;
+  padding: 10px;
+  border: 1px solid #f3c8a8;
+  border-radius: 6px;
+  background: #fff7ed;
+}
+
+.integration-workbench__bounded-preview > div:first-child {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  flex-wrap: wrap;
+}
+
+.integration-workbench__bounded-preview strong {
+  color: #7c2d12;
 }
 
 .integration-workbench {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -2643,6 +2643,123 @@ describe('IntegrationWorkbenchView', () => {
     expect(applyBodies).toHaveLength(0)
   })
 
+  it('C2 large-BOM: renders bounded dry-run state as non-authoritative and blocks apply', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:write']))
+    const dryRunBodies: Array<Record<string, unknown>> = []
+    const applyBodies: Array<Record<string, unknown>> = []
+    const publicAction = {
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      kind: 'parameterized_table_action',
+      label: 'PLM project BOM -> stock preparation',
+      configured: true,
+      parameters: [{ id: 'projectNo', label: 'Project number', type: 'string', required: true }],
+      permissions: { dryRun: 'read', apply: 'write' },
+      evidence: { valuesFreeIssueEvidence: true },
+    }
+    const boundedPreview = {
+      complete: false,
+      authoritative: false,
+      rowsExpanded: 500,
+      readCount: 1068,
+      maxRows: 500,
+      maxPages: 100,
+      maxReadCount: 1200,
+      errorTypes: ['max_rows_exceeded'],
+    }
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([publicAction])
+      if (url === '/api/integration/table-actions/plm.stock-preparation.pull-bom.v1/dry-run?tenantId=default') {
+        const body = JSON.parse(String(init?.body || '{}')) as Record<string, unknown>
+        dryRunBodies.push(body)
+        return jsonResponse({
+          action: publicAction,
+          status: 'large_bom_bounded',
+          largeBom: true,
+          boundedPreview,
+          dryRunToken: null,
+          revision: 'large-rev-1',
+          canApply: false,
+          counts: { add: 190, update: 0, skip: 0, inactive: 0, manual_confirm: 28 },
+          evidence: {
+            actionId: publicAction.actionId,
+            projectNoPresent: true,
+            dryRunRevision: 'large-rev-1',
+            expansion: {
+              status: 'failed',
+              largeBom: true,
+              boundedPreview,
+              rowsExpanded: 500,
+              readCount: 1068,
+              errorTypes: ['max_rows_exceeded'],
+            },
+            plan: {
+              counts: { add: 190, update: 0, skip: 0, inactive: 0, manual_confirm: 28 },
+              authoritative: false,
+            },
+          },
+        })
+      }
+      if (url === '/api/integration/table-actions/plm.stock-preparation.pull-bom.v1/apply?tenantId=default') {
+        applyBodies.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>)
+        return jsonResponse({ status: 'should-not-run' })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi(12)
+
+    const projectInput = container.querySelector('[data-testid="table-action-project-no"]') as HTMLInputElement
+    projectInput.value = 'P-LARGE'
+    projectInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    ;(container.querySelector('[data-testid="table-action-dry-run"]') as HTMLButtonElement).click()
+    await flushUi(10)
+
+    expect(dryRunBodies).toHaveLength(1)
+    expect(dryRunBodies[0]).toEqual({ parameters: { projectNo: 'P-LARGE' } })
+    const review = container.querySelector('[data-testid="table-action-review"]')?.textContent || ''
+    expect(review).toContain('large_bom_bounded')
+    expect(review).toContain('bounded rows 500')
+    expect(review).toContain('reads 1068')
+    const bounded = container.querySelector('[data-testid="table-action-large-bom-bounded"]')?.textContent || ''
+    expect(bounded).toContain('大 BOM 有界预览')
+    expect(bounded).toContain('Apply blocked')
+    expect(bounded).toContain('rows 500')
+    expect(bounded).toContain('reads 1068')
+    expect(bounded).toContain('maxRows 500')
+    expect(bounded).toContain('maxPages 100')
+    expect(bounded).toContain('maxReadCount 1200')
+    expect(bounded).toContain('max_rows_exceeded')
+    expect(container.querySelector('[data-testid="table-action-token-state"]')?.textContent).toContain('不可 apply')
+    const status = container.querySelector('.integration-workbench__status')?.textContent || ''
+    expect(status).toContain('大 BOM 有界预览')
+    const applyButton = container.querySelector('[data-testid="table-action-apply"]') as HTMLButtonElement
+    expect(applyButton.disabled).toBe(true)
+    applyButton.click()
+    await flushUi()
+    expect(applyBodies).toHaveLength(0)
+    const evidence = container.querySelector('[data-testid="table-action-evidence"]')?.textContent || ''
+    expect(evidence).toContain('max_rows_exceeded')
+    expect(evidence).not.toContain('P-LARGE')
+    expect(evidence).not.toContain('PART-')
+    expect(evidence).not.toContain('dry-token')
+  })
+
   it('C6: lets admins sync stock-preparation options and predefined action bindings without client scope or payload fields', async () => {
     localStorage.setItem('user_permissions', JSON.stringify(['integration:admin']))
     const syncBodies: Array<Record<string, unknown>> = []

--- a/docs/development/data-factory-plm-stock-preparation-large-bom-c2-ui-verification-20260606.md
+++ b/docs/development/data-factory-plm-stock-preparation-large-bom-c2-ui-verification-20260606.md
@@ -1,0 +1,81 @@
+# Data Factory #2342 C2 - large-BOM bounded UI verification (2026-06-06)
+
+## Scope
+
+This slice adds the operator-facing display for the C1 bounded large-BOM dry-run
+state in `IntegrationWorkbenchView`.
+
+It is intentionally UI-only:
+
+- no backend route change;
+- no C2/C3/C4 helper change;
+- no background full-expansion worker;
+- no checkpointed writer;
+- no MetaSheet row write;
+- no PLM/external database write;
+- no K3 path.
+
+This PR is stacked on the C1 bounded-readiness branch because it consumes the C1
+response shape.
+
+## UI behavior
+
+When a table action dry-run returns `status='large_bom_bounded'` or
+`largeBom=true`, the workbench now shows a dedicated bounded-preview block:
+
+- `大 BOM 有界预览`
+- Apply blocked badge
+- bounded metrics: rows expanded, read count, and configured cap fields when
+  present (`maxRows`, `maxPages`, `maxReadCount`, `maxElapsedMs`)
+- error types, values-free
+- clear statement that the preview is not authoritative and no dry-run token is
+  issued
+
+The regular Apply button remains disabled because the existing apply gate still
+requires all of:
+
+- `canApply === true`
+- a server dry-run token
+- integration write permission
+- manual-confirm acknowledgement when needed
+
+C2 does not add any browser-controlled cap or Apply mode.
+
+## Values-free boundary
+
+The UI can show tenant-visible values in other existing workbench surfaces, but
+the new bounded block displays only values-free counters and error types.
+
+The copied evidence still comes from the server `evidence` object. Tests assert
+that it does not render the project value, component id, or dry-run token.
+
+## Verification
+
+Commands:
+
+```bash
+pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false
+pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/web lint
+git diff --check
+```
+
+Covered assertions:
+
+- clicking the real table-action dry-run button with a mocked
+  `large_bom_bounded` response renders the bounded block;
+- the review summary shows bounded rows/read attempts;
+- cap metrics and `max_rows_exceeded` render as values-free diagnostics;
+- Apply is disabled and clicking it sends no request;
+- the status message says bounded preview / Apply blocked, not "ready to apply";
+- no dry-run token is shown;
+- evidence does not include the project value, component id, or token.
+
+## Remaining gates
+
+- C3: background full-expansion design.
+- C4: checkpointed large apply design.
+- C5: entity-machine validation with values-free evidence.
+
+#2343 D1 duplicate handling remains behind the large-sample complete-expansion
+decision, because bounded/subset duplicate counts are not authoritative.


### PR DESCRIPTION
## What changed

Implements #2342 C2 UI display for the bounded large-BOM state produced by C1.

This PR is stacked on #2361 / `codex/df-large-bom-c1-readiness-20260606` so the diff stays focused on the UI slice.

- Extends the table-action dry-run result type with `largeBom` and `boundedPreview`.
- Shows a dedicated `大 BOM 有界预览` block in the workbench when dry-run returns `status='large_bom_bounded'` or `largeBom=true`.
- Displays values-free bounded metrics: rows, reads, maxRows, maxPages, maxReadCount, maxElapsedMs, and errorTypes.
- Keeps Apply disabled through the existing `canApply && dryRunToken && write permission` gate.
- Fixes the dry-run status message so bounded large-BOM states do not say "ready to apply".

## Boundary

UI-only. No backend route change, no background worker, no checkpoint writer, no MetaSheet row write, no PLM/external DB write, no K3, no browser-controlled cap or Apply mode.

C3 remains next: background full-expansion design. C4 checkpointed apply design remains separate after C3.

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false`
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/web lint`
- `git diff --check`
- Browser smoke: dev server opened `/integrations/workbench`; app routed to login as expected, so the bounded state itself is covered by the component test rather than unauthenticated browser state.

Verification doc: `docs/development/data-factory-plm-stock-preparation-large-bom-c2-ui-verification-20260606.md`.

Advances #2342 C2; depends on #2361.
