### PR TITLE
feat(data-factory): show duplicate expanded key diagnostics

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -1016,7 +1016,12 @@ export interface IntegrationTableActionDryRunResult {
   revision?: string
   canApply?: boolean
   counts?: Record<string, number>
-  evidence?: Record<string, unknown>
+  evidence?: Record<string, unknown> & {
+    plan?: {
+      duplicateExpandedKeyDiagnostics?: Record<string, unknown>
+      [key: string]: unknown
+    }
+  }
 }
 
 export interface IntegrationTableActionApplyResult {

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -780,6 +780,24 @@
                 errorTypes: {{ tableActionBoundedErrorTypes.join(', ') }}
               </p>
             </div>
+            <div v-if="tableActionDuplicateDiagnostics" class="integration-workbench__bounded-preview" data-testid="table-action-duplicate-diagnostics">
+              <div>
+                <strong>重复行分组待处理</strong>
+                <span class="integration-workbench__badge" data-status="warning">manual_confirm</span>
+              </div>
+              <p>重复行不会被自动挑选、合并或写入；下方仅展示 values-free 分组诊断，策略应用仍需后续显式确认。</p>
+              <div class="integration-workbench__metric-row">
+                <span v-for="metric in tableActionDuplicateMetrics" :key="metric.id">{{ metric.label }} {{ metric.value }}</span>
+              </div>
+              <p v-if="tableActionDuplicatePolicies.length" class="integration-workbench__hint">
+                policies: {{ tableActionDuplicatePolicies.join(', ') }}
+              </p>
+              <ul v-if="tableActionDuplicateGroups.length" class="integration-workbench__mini-list">
+                <li v-for="group in tableActionDuplicateGroups" :key="group.fingerprint">
+                  #{{ group.ordinal }} {{ group.fingerprint }} · rows {{ group.rowCount }} · {{ group.parentShape }} · quantity {{ group.quantityShape }} · attrs {{ group.attributeShape }} · stable {{ group.stableDiscriminator }}
+                </li>
+              </ul>
+            </div>
             <p class="integration-workbench__hint" data-testid="table-action-token-state">
               {{ tableActionDryRunToken ? 'dry-run token 已签发；token 仅保存在当前页面内存，不展示、不复制到 evidence。' : '本次 dry-run 不可 apply；请处理失败项后重跑。' }}
             </p>
@@ -1204,6 +1222,16 @@ interface StagingObjectConfig {
 
 type ConnectionDraftRole = WorkbenchExternalSystem['role']
 type ConnectionDraftStatus = WorkbenchExternalSystem['status']
+
+interface DuplicateExpandedGroupView {
+  ordinal: string
+  fingerprint: string
+  rowCount: string
+  parentShape: string
+  quantityShape: string
+  attributeShape: string
+  stableDiscriminator: string
+}
 
 interface ConnectionDraft {
   id: string
@@ -1903,6 +1931,59 @@ const tableActionBoundedPreviewMetrics = computed(() => {
     { id: 'max-read-count', label: 'maxReadCount', value: numberMetric(preview.maxReadCount) },
     { id: 'max-elapsed-ms', label: 'maxElapsedMs', value: numberMetric(preview.maxElapsedMs) },
   ].filter((metric) => metric.value !== '')
+})
+const tableActionPlanEvidence = computed(() => {
+  const evidence = isRecord(tableActionDryRunResult.value?.evidence) ? tableActionDryRunResult.value?.evidence : null
+  return evidence && isRecord(evidence.plan) ? evidence.plan : null
+})
+const tableActionDuplicateDiagnostics = computed(() => {
+  const diagnostics = tableActionPlanEvidence.value && isRecord(tableActionPlanEvidence.value.duplicateExpandedKeyDiagnostics)
+    ? tableActionPlanEvidence.value.duplicateExpandedKeyDiagnostics
+    : null
+  if (!diagnostics || diagnostics.conflictType !== 'duplicate_expanded_key') return null
+  return diagnostics
+})
+const tableActionDuplicateMetrics = computed(() => {
+  const diagnostics = tableActionDuplicateDiagnostics.value
+  if (!diagnostics) return []
+  const parentCounts = isRecord(diagnostics.parentShapeCounts) ? diagnostics.parentShapeCounts : {}
+  const quantityCounts = isRecord(diagnostics.quantityShapeCounts) ? diagnostics.quantityShapeCounts : {}
+  const stableCounts = isRecord(diagnostics.stableDiscriminatorCounts) ? diagnostics.stableDiscriminatorCounts : {}
+  return [
+    { id: 'groups', label: 'groups', value: numberMetric(diagnostics.groupCount) },
+    { id: 'rows', label: 'rows', value: numberMetric(diagnostics.rowCount) },
+    { id: 'same-parent', label: 'sameParent', value: numberMetric(parentCounts.same_parent) },
+    { id: 'cross-parent', label: 'crossParent', value: numberMetric(parentCounts.cross_parent) },
+    { id: 'quantity-varied', label: 'quantityVaried', value: numberMetric(quantityCounts.varied) },
+    { id: 'stable', label: 'stableDiscriminator', value: numberMetric(stableCounts.any) },
+  ].filter((metric) => metric.value !== '')
+})
+const tableActionDuplicatePolicies = computed(() => {
+  const diagnostics = tableActionDuplicateDiagnostics.value
+  return Array.isArray(diagnostics?.allowedPolicies)
+    ? diagnostics.allowedPolicies.filter((policy): policy is string => typeof policy === 'string')
+    : []
+})
+const tableActionDuplicateGroups = computed<DuplicateExpandedGroupView[]>(() => {
+  const diagnostics = tableActionDuplicateDiagnostics.value
+  const groups = Array.isArray(diagnostics?.groups) ? diagnostics.groups.filter(isRecord) : []
+  return groups.slice(0, 8).map((group, index) => {
+    const stable = isRecord(group.stableDiscriminators) ? group.stableDiscriminators : {}
+    const stableLabels = [
+      stable.sourceDetail === true ? 'sourceDetail' : '',
+      stable.pathParent === true ? 'pathParent' : '',
+      stable.sortLine === true ? 'sortLine' : '',
+    ].filter(Boolean)
+    return {
+      ordinal: numberMetric(group.ordinal) || String(index + 1),
+      fingerprint: typeof group.fingerprint === 'string' ? group.fingerprint : `group-${index + 1}`,
+      rowCount: numberMetric(group.rowCount) || '0',
+      parentShape: typeof group.parentShape === 'string' ? group.parentShape : 'unknown',
+      quantityShape: typeof group.quantityShape === 'string' ? group.quantityShape : 'unknown',
+      attributeShape: typeof group.attributeShape === 'string' ? group.attributeShape : 'unknown',
+      stableDiscriminator: stableLabels.length ? stableLabels.join('+') : 'none',
+    }
+  })
 })
 const tableActionEvidenceText = computed(() => {
   const evidence = tableActionApplyResult.value?.evidence || tableActionDryRunResult.value?.evidence
@@ -3326,8 +3407,15 @@ async function dryRunTableAction(): Promise<void> {
     })
     tableActionDryRunResult.value = result
     const manualCount = Number(result.counts?.manual_confirm || 0)
+    const planEvidence = isRecord(result.evidence?.plan) ? result.evidence.plan : null
+    const duplicateDiagnostics = planEvidence && isRecord(planEvidence.duplicateExpandedKeyDiagnostics)
+      ? planEvidence.duplicateExpandedKeyDiagnostics
+      : null
+    const duplicateGroupCount = duplicateDiagnostics ? Number(duplicateDiagnostics.groupCount || 0) : 0
     const message = isLargeBomBoundedTableActionResult(result)
       ? '表动作 dry-run 返回大 BOM 有界预览；Apply 已阻塞，请走完整展开/后台通道。'
+      : duplicateGroupCount > 0
+      ? `表动作 dry-run 完成：${duplicateGroupCount} 个重复分组需要 review；重复行保持不写。`
       : manualCount > 0
       ? `表动作 dry-run 完成：${manualCount} 行需要人工确认，apply 会保持这些行不写。`
       : '表动作 dry-run 完成，可进入 apply 确认。'
@@ -3612,6 +3700,25 @@ watch([selectedTableActionId, tableActionProjectNo], () => {
 
 .integration-workbench__bounded-preview strong {
   color: #7c2d12;
+}
+
+.integration-workbench__mini-list {
+  display: grid;
+  gap: 6px;
+  margin: 0;
+  padding: 0;
+  list-style: none;
+}
+
+.integration-workbench__mini-list li {
+  padding: 8px;
+  border: 1px solid #f3d8bd;
+  border-radius: 6px;
+  background: #fffaf5;
+  color: #5b3417;
+  font-size: 12px;
+  line-height: 1.45;
+  overflow-wrap: anywhere;
 }
 
 .integration-workbench {
@@ -3975,6 +4082,11 @@ watch([selectedTableActionId, tableActionProjectNo], () => {
 .integration-workbench__badge[data-status="error"] {
   background: #fff0f0;
   color: #9b1c1c;
+}
+
+.integration-workbench__badge[data-status="warning"] {
+  background: #fff8e8;
+  color: #744600;
 }
 
 .integration-workbench__badge[data-status="enabled"] {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -2643,6 +2643,140 @@ describe('IntegrationWorkbenchView', () => {
     expect(applyBodies).toHaveLength(0)
   })
 
+  it('D1 duplicate-expanded-key: renders values-free grouped duplicate diagnostics', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:write']))
+    const applyBodies: Array<Record<string, unknown>> = []
+    const publicAction = {
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      kind: 'parameterized_table_action',
+      label: 'PLM project BOM -> stock preparation',
+      configured: true,
+      parameters: [{ id: 'projectNo', label: 'Project number', type: 'string', required: true }],
+      permissions: { dryRun: 'read', apply: 'write' },
+      evidence: { valuesFreeIssueEvidence: true },
+    }
+    const duplicateDiagnostics = {
+      conflictType: 'duplicate_expanded_key',
+      groupCount: 2,
+      rowCount: 4,
+      rowsPerGroup: [{ rowCount: 2, groups: 2 }],
+      parentShapeCounts: { same_parent: 1, cross_parent: 1 },
+      quantityShapeCounts: { all_equal: 1, varied: 1 },
+      attributeShapeCounts: { all_equal: 2 },
+      stableDiscriminatorCounts: { any: 2, sourceDetail: 1, pathParent: 1, sortLine: 1 },
+      defaultPolicy: 'hold',
+      allowedPolicies: ['hold', 'keep_multiple_rows', 'merge_quantity', 'skip_selected', 'source_correction_required'],
+      groups: [
+        {
+          ordinal: 1,
+          fingerprint: 'sha16:1111222233334444',
+          rowCount: 2,
+          parentShape: 'same_parent',
+          quantityShape: 'varied',
+          attributeShape: 'all_equal',
+          stableDiscriminators: { any: true, sortLine: true },
+        },
+        {
+          ordinal: 2,
+          fingerprint: 'sha16:aaaabbbbccccdddd',
+          rowCount: 2,
+          parentShape: 'cross_parent',
+          quantityShape: 'all_equal',
+          attributeShape: 'all_equal',
+          stableDiscriminators: { any: true, sourceDetail: true, pathParent: true },
+        },
+      ],
+    }
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([publicAction])
+      if (url === '/api/integration/table-actions/plm.stock-preparation.pull-bom.v1/dry-run?tenantId=default') {
+        return jsonResponse({
+          action: publicAction,
+          status: 'manual_confirm_required',
+          dryRunToken: 'duplicate-dry-token',
+          revision: 'dup-rev-1',
+          canApply: true,
+          counts: { add: 190, update: 0, skip: 190, inactive: 0, manual_confirm: 2 },
+          evidence: {
+            actionId: publicAction.actionId,
+            projectNoPresent: true,
+            dryRunRevision: 'dup-rev-1',
+            expansion: { status: 'expanded', rowsExpanded: 246, errorTypes: [] },
+            plan: {
+              counts: { add: 190, update: 0, skip: 190, inactive: 0, manual_confirm: 2 },
+              conflictTypes: ['duplicate_expanded_key'],
+              duplicateExpandedKeyDiagnostics: duplicateDiagnostics,
+            },
+          },
+        })
+      }
+      if (url === '/api/integration/table-actions/plm.stock-preparation.pull-bom.v1/apply?tenantId=default') {
+        applyBodies.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>)
+        return jsonResponse({ status: 'should-not-run' })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi(12)
+
+    const projectInput = container.querySelector('[data-testid="table-action-project-no"]') as HTMLInputElement
+    projectInput.value = 'P-DUP'
+    projectInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    ;(container.querySelector('[data-testid="table-action-dry-run"]') as HTMLButtonElement).click()
+    await flushUi(10)
+
+    const status = container.querySelector('.integration-workbench__status')?.textContent || ''
+    expect(status).toContain('2 个重复分组需要 review')
+    const block = container.querySelector('[data-testid="table-action-duplicate-diagnostics"]')?.textContent || ''
+    expect(block).toContain('重复行分组待处理')
+    expect(block).toContain('groups 2')
+    expect(block).toContain('rows 4')
+    expect(block).toContain('sameParent 1')
+    expect(block).toContain('crossParent 1')
+    expect(block).toContain('quantityVaried 1')
+    expect(block).toContain('stableDiscriminator 2')
+    expect(block).toContain('keep_multiple_rows')
+    expect(block).toContain('merge_quantity')
+    expect(block).toContain('skip_selected')
+    expect(block).toContain('sha16:1111222233334444')
+    expect(block).toContain('same_parent')
+    expect(block).toContain('cross_parent')
+    expect(block).not.toContain('P-DUP')
+    expect(block).not.toContain('PART-DUP')
+    expect(block).not.toContain('Secret Alloy')
+    expect(block).not.toContain('DETAIL-A')
+
+    const evidence = container.querySelector('[data-testid="table-action-evidence"]')?.textContent || ''
+    expect(evidence).toContain('duplicate_expanded_key')
+    expect(evidence).toContain('sha16:aaaabbbbccccdddd')
+    expect(evidence).not.toContain('P-DUP')
+    expect(evidence).not.toContain('PART-DUP')
+    expect(evidence).not.toContain('Secret Alloy')
+    expect(evidence).not.toContain('DETAIL-A')
+    expect(container.querySelector('[data-testid="table-action-panel"]')?.textContent).not.toContain('duplicate-dry-token')
+    const applyButton = container.querySelector('[data-testid="table-action-apply"]') as HTMLButtonElement
+    expect(applyButton.disabled).toBe(true)
+    applyButton.click()
+    await flushUi()
+    expect(applyBodies).toHaveLength(0)
+  })
+
   it('C2 large-BOM: renders bounded dry-run state as non-authoritative and blocks apply', async () => {
     localStorage.setItem('user_permissions', JSON.stringify(['integration:write']))
     const dryRunBodies: Array<Record<string, unknown>> = []

--- a/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
@@ -719,6 +719,53 @@ Acceptance locks:
 - Human-preserved fields are never written.
 - Row-level failures are values-free and do not erase clean-row progress.
 
+### ✅ Duplicate-expanded-key D0 - conflict strategy design (DONE - PR #2346, `14d6c2ca1`)
+
+Gated on: #2340 onsite held-duplicate evidence + explicit opt-in.
+
+Scope:
+
+- Design the generic conflict-strategy frame with `duplicate_expanded_key` as
+  the first supported conflict type.
+- Lock values-free duplicate-cause diagnostics before any policy choice.
+- Lock policy candidates: `hold`, `keep_multiple_rows`, `merge_quantity`,
+  `select_representative`, `skip_selected`, `source_correction_required`.
+- Lock policy scopes: `run_only` and `table_scope`; global/template defaults
+  remain deferred.
+- Lock no silent pick, no silent drop, no material-code-only identity, and
+  fresh dry-run/token before any future duplicate apply.
+- Lock #2342 dependency: duplicate evidence on large samples is authoritative
+  only after complete expansion.
+
+### 🟡 Duplicate-expanded-key D1 - grouped dry-run evidence/UI (ACTIVE - this PR)
+
+Gated on: Duplicate D0 + Large-BOM C1-C4 chain + explicit opt-in.
+
+Scope:
+
+- Extend C3 conflict-plan evidence with values-free
+  `duplicateExpandedKeyDiagnostics`.
+- Diagnose duplicate groups without exposing row values:
+  group count, rows-per-group distribution, same-parent vs cross-parent counts,
+  quantity-shape counts, attribute-shape counts, stable-discriminator counts,
+  deterministic collision fingerprints, and allowed policy names.
+- Render a grouped review block in the workbench dry-run panel.
+- Keep duplicate rows held as `manual_confirm`; no policy persistence and no
+  duplicate apply in D1.
+
+Acceptance locks:
+
+- No MetaSheet write, PLM write, external database write, K3, route change,
+  package, migration, policy persistence, or Apply unlock.
+- Public evidence never exposes project number, raw idempotency key, component
+  source id/code/name/material, parent id/path, source detail id, target values,
+  sheet id, field id, raw SQL, credentials, or tokens.
+- Collision fingerprints are deterministic and do not expose raw keys.
+- Default recommendation is `hold`.
+- `keep_multiple_rows`, `merge_quantity`, `select_representative`,
+  `skip_selected`, and `source_correction_required` are displayed as candidates
+  only; no writer infers or applies them.
+
 ## Deferred tracks
 
 - New project/sample C4 apply validation after separate explicit approval.

--- a/docs/development/data-factory-plm-stock-preparation-duplicate-expanded-key-d1-verification-20260606.md
+++ b/docs/development/data-factory-plm-stock-preparation-duplicate-expanded-key-d1-verification-20260606.md
@@ -1,0 +1,89 @@
+# Data Factory #2343 D1 - duplicate-expanded-key dry-run evidence/UI verification (2026-06-06)
+
+## Scope
+
+This slice implements the D1 review surface for `duplicate_expanded_key` rows.
+
+It remains read-only and dry-run-only:
+
+- no duplicate policy persistence;
+- no duplicate-row Apply;
+- no MetaSheet row write;
+- no PLM write;
+- no external database write;
+- no K3 path;
+- no route, migration, package, or production rollout change.
+
+## Backend evidence
+
+`summarizeConflictPlanForEvidence()` now includes
+`duplicateExpandedKeyDiagnostics` when the C3 planner finds duplicate expanded
+keys.
+
+The diagnostic is values-free and includes:
+
+- `conflictType='duplicate_expanded_key'`;
+- group count and duplicate-row count;
+- rows-per-group distribution;
+- same-parent / cross-parent / unknown parent-shape counts;
+- quantity-shape counts (`all_equal`, `varied`, `unknown`);
+- attribute-shape counts (`all_equal`, `varied`, `unknown`);
+- stable-discriminator counts (`sourceDetail`, `pathParent`, `sortLine`);
+- deterministic collision fingerprints;
+- default policy `hold`;
+- allowed policy names.
+
+It does not expose raw idempotency keys, project numbers, PLM source ids,
+component values, parent ids, paths, quantities, source detail ids, target row
+values, sheet ids, field ids, credentials, raw SQL, or tokens.
+
+## Workbench UI
+
+`IntegrationWorkbenchView` now renders a grouped duplicate review block when the
+dry-run evidence contains duplicate diagnostics:
+
+- title: `重复行分组待处理`;
+- manual-confirm badge;
+- values-free metrics;
+- policy candidate names;
+- per-group ordinal/fingerprint/shape summary.
+
+The UI does not add policy controls in D1. Duplicate rows remain held as
+`manual_confirm`. Existing clean-row apply behavior is unchanged: an operator
+can still explicitly accept that manual-confirm rows stay unwritten and apply
+clean add/update/inactive rows.
+
+## Verification
+
+Commands:
+
+```bash
+pnpm --filter plugin-integration-core test:stock-preparation-conflict-planner
+pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false
+pnpm --filter @metasheet/web type-check
+pnpm --filter @metasheet/web lint
+git diff --check
+```
+
+Covered assertions:
+
+- duplicate expanded rows still produce `manual_confirm`;
+- no duplicate group falls through to add/update/skip;
+- evidence includes grouped duplicate diagnostics;
+- diagnostics distinguish same-parent and cross-parent groups;
+- diagnostics include quantity-shape and stable-discriminator counts;
+- fingerprints are deterministic and do not expose raw keys;
+- evidence does not contain project number, raw collision keys, component ids,
+  component names, material, source detail ids, parent ids, or paths;
+- the workbench renders the grouped duplicate block from a real dry-run
+  response;
+- the workbench block and evidence do not render project/component/material
+  values or dry-run tokens;
+- Apply remains disabled until the existing manual-confirm-hold acknowledgement
+  is explicitly checked.
+
+## Remaining gates
+
+- D2: optional run/table-scoped policy persistence, owner/admin reviewed.
+- D3: apply explicitly resolved duplicate rows, if approved.
+- Entity-machine validation with values-free duplicate evidence.

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-conflict-planner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-conflict-planner.test.cjs
@@ -327,6 +327,99 @@ function testValuesFreeEvidence() {
   assert.ok(evidence.humanPreservedFields.includes('notes'), 'evidence may include field names')
 }
 
+function testDuplicateExpandedKeyDiagnosticsValuesFree() {
+  const sameParentA = row({
+    idempotencyKey: 'DUP-SAME-PARENT',
+    componentSourceId: 'PART-DUP-SAME-A',
+    parentSourceId: 'PARENT-SAME',
+    path: 'ROOT/PARENT-SAME/PART-DUP',
+    pathTokens: ['ROOT', 'PARENT-SAME', 'PART-DUP'],
+    componentCode: 'DUP-CODE',
+    componentName: 'Duplicate Widget',
+    material: 'Secret Alloy',
+    totalQuantity: 2,
+    sortLine: '10',
+  })
+  const sameParentB = {
+    ...sameParentA,
+    componentSourceId: 'PART-DUP-SAME-B',
+    totalQuantity: 3,
+    sortLine: '20',
+  }
+  const crossParentA = row({
+    idempotencyKey: 'DUP-CROSS-PARENT',
+    componentSourceId: 'PART-DUP-CROSS-A',
+    parentSourceId: 'PARENT-A',
+    path: 'ROOT/PARENT-A/PART-DUP',
+    pathTokens: ['ROOT', 'PARENT-A', 'PART-DUP'],
+    componentCode: 'CROSS-CODE',
+    componentName: 'Cross Parent Widget',
+    material: 'Cross Alloy',
+    totalQuantity: 5,
+    sourceDetailId: 'DETAIL-A',
+  })
+  const crossParentB = {
+    ...crossParentA,
+    componentSourceId: 'PART-DUP-CROSS-B',
+    parentSourceId: 'PARENT-B',
+    path: 'ROOT/PARENT-B/PART-DUP',
+    pathTokens: ['ROOT', 'PARENT-B', 'PART-DUP'],
+    sourceDetailId: 'DETAIL-B',
+  }
+
+  const plan = planStockPreparationConflicts({
+    expandedRows: [sameParentA, sameParentB, crossParentA, crossParentB],
+    existingRows: [],
+    runId: 'run-duplicate-diagnostics',
+    plannedAt: '2026-06-04T09:00:00.000Z',
+  })
+  const evidence = summarizeConflictPlanForEvidence(plan)
+  const diagnostics = evidence.duplicateExpandedKeyDiagnostics
+
+  assert.equal(plan.valid, false)
+  assert.equal(evidence.counts.manual_confirm, 2)
+  assert.equal(diagnostics.conflictType, 'duplicate_expanded_key')
+  assert.equal(diagnostics.groupCount, 2)
+  assert.equal(diagnostics.rowCount, 4)
+  assert.deepEqual(diagnostics.rowsPerGroup, [{ rowCount: 2, groups: 2 }])
+  assert.equal(diagnostics.parentShapeCounts.same_parent, 1)
+  assert.equal(diagnostics.parentShapeCounts.cross_parent, 1)
+  assert.equal(diagnostics.quantityShapeCounts.varied, 1)
+  assert.equal(diagnostics.quantityShapeCounts.all_equal, 1)
+  assert.equal(diagnostics.attributeShapeCounts.all_equal, 2)
+  assert.equal(diagnostics.stableDiscriminatorCounts.any, 2)
+  assert.equal(diagnostics.stableDiscriminatorCounts.pathParent, 1)
+  assert.equal(diagnostics.stableDiscriminatorCounts.sourceDetail, 1)
+  assert.equal(diagnostics.stableDiscriminatorCounts.sortLine, 1)
+  assert.deepEqual(diagnostics.allowedPolicies, [
+    'hold',
+    'keep_multiple_rows',
+    'merge_quantity',
+    'select_representative',
+    'skip_selected',
+    'source_correction_required',
+  ])
+  assert.equal(diagnostics.defaultPolicy, 'hold')
+  assert.equal(diagnostics.groups.length, 2)
+  assert.match(diagnostics.groups[0].fingerprint, /^sha16:[a-f0-9]{16}$/)
+  assert.equal(
+    __internals.stableFingerprint('DUP-SAME-PARENT'),
+    __internals.stableFingerprint('DUP-SAME-PARENT'),
+    'collision fingerprints are deterministic',
+  )
+
+  const text = JSON.stringify(evidence)
+  assert.ok(!text.includes('P-001'), 'evidence must not include project value')
+  assert.ok(!text.includes('DUP-SAME-PARENT'), 'evidence must not include raw collision key')
+  assert.ok(!text.includes('DUP-CROSS-PARENT'), 'evidence must not include raw collision key')
+  assert.ok(!text.includes('PART-DUP'), 'evidence must not include component source ids')
+  assert.ok(!text.includes('Duplicate Widget'), 'evidence must not include component names')
+  assert.ok(!text.includes('Secret Alloy'), 'evidence must not include material')
+  assert.ok(!text.includes('DETAIL-A'), 'evidence must not include source detail ids')
+  assert.ok(!text.includes('PARENT-A'), 'evidence must not include parent ids')
+  assert.ok(!text.includes('ROOT/PARENT'), 'evidence must not include paths')
+}
+
 function main() {
   testAddUpdateSkipInactive()
   testRowErrorsDoNotAbortGoodRows()
@@ -337,6 +430,7 @@ function main() {
   testTemplateTypeEquivalentValuesSkipAfterCreate()
   testTemplateNormalizationDoesNotHideRealIdentityOrLineageConflicts()
   testValuesFreeEvidence()
+  testDuplicateExpandedKeyDiagnosticsValuesFree()
 
   console.log('stock-preparation-conflict-planner.test.cjs OK')
 }

--- a/plugins/plugin-integration-core/lib/stock-preparation-conflict-planner.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-conflict-planner.cjs
@@ -6,6 +6,8 @@
 // decisions for a later C4 apply writer. No PLM read, MetaSheet write, route,
 // UI, external DB write, or K3 path.
 
+const crypto = require('node:crypto')
+
 const {
   HUMAN_PRESERVED_FIELD_IDS,
   STOCK_PREPARATION_MAIN_TABLE_TEMPLATE,
@@ -39,6 +41,28 @@ const IDENTITY_FIELD_IDS = Object.freeze([
   'componentName',
   'material',
   'sourceVersion',
+])
+
+const DUPLICATE_EXPANDED_KEY_POLICIES = Object.freeze([
+  'hold',
+  'keep_multiple_rows',
+  'merge_quantity',
+  'select_representative',
+  'skip_selected',
+  'source_correction_required',
+])
+
+const DUPLICATE_SOURCE_DETAIL_FIELDS = Object.freeze([
+  'sourceDetailId',
+  'detailSourceId',
+  'lineSourceId',
+  'bomDetailId',
+])
+
+const DUPLICATE_SORT_LINE_FIELDS = Object.freeze([
+  'sourceSortLine',
+  'sortLine',
+  'lineNo',
 ])
 
 class StockPreparationConflictPlannerError extends Error {
@@ -204,6 +228,154 @@ function valuesEqualForTemplateField(left, right, field) {
     normalizeComparableValueForField(left, field),
     normalizeComparableValueForField(right, field),
   )
+}
+
+function stableStringify(value) {
+  if (Array.isArray(value)) return `[${value.map((item) => stableStringify(item)).join(',')}]`
+  if (isPlainObject(value)) {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+function stableFingerprint(value) {
+  return `sha16:${crypto
+    .createHash('sha256')
+    .update('stock-preparation-duplicate-expanded-key-v1\0')
+    .update(String(value))
+    .digest('hex')
+    .slice(0, 16)}`
+}
+
+function firstPresent(row, fields) {
+  for (const field of fields) {
+    const value = row && row[field]
+    if (!isBlank(value)) return value
+  }
+  return undefined
+}
+
+function stableValue(value) {
+  return value === undefined ? null : value
+}
+
+function stableKey(value) {
+  return stableStringify(stableValue(value))
+}
+
+function parentContext(row) {
+  return {
+    parentSourceId: stableValue(row && row.parentSourceId),
+    path: stableValue(row && row.path),
+  }
+}
+
+function parentContextKey(row) {
+  return stableStringify(parentContext(row))
+}
+
+function hasParentContext(row) {
+  return !isBlank(row && row.parentSourceId) || !isBlank(row && row.path)
+}
+
+function allValuesPresent(rows, picker) {
+  return rows.every((row) => !isBlank(picker(row)))
+}
+
+function distinctCount(rows, picker) {
+  return new Set(rows.map((row) => stableKey(picker(row)))).size
+}
+
+function groupQuantityShape(rows) {
+  if (!allValuesPresent(rows, (row) => row && row.totalQuantity)) return 'unknown'
+  return distinctCount(rows, (row) => row.totalQuantity) <= 1 ? 'all_equal' : 'varied'
+}
+
+function groupAttributeShape(rows) {
+  const fields = ['componentCode', 'componentName', 'material', 'sourceVersion']
+  const presentFields = fields.filter((field) => rows.some((row) => !isBlank(row && row[field])))
+  if (presentFields.length === 0) return 'unknown'
+  return presentFields.every((field) => distinctCount(rows, (row) => row && row[field]) <= 1) ? 'all_equal' : 'varied'
+}
+
+function groupParentShape(rows) {
+  if (!rows.every(hasParentContext)) return 'unknown'
+  return distinctCount(rows, parentContextKey) <= 1 ? 'same_parent' : 'cross_parent'
+}
+
+function hasDistinctStableDiscriminator(rows, fields) {
+  if (!allValuesPresent(rows, (row) => firstPresent(row, fields))) return false
+  return distinctCount(rows, (row) => firstPresent(row, fields)) === rows.length
+}
+
+function duplicateExpandedGroupDiagnostic(key, rows, index) {
+  const parentShape = groupParentShape(rows)
+  const quantityShape = groupQuantityShape(rows)
+  const attributeShape = groupAttributeShape(rows)
+  const sourceDetail = hasDistinctStableDiscriminator(rows, DUPLICATE_SOURCE_DETAIL_FIELDS)
+  const sortLine = hasDistinctStableDiscriminator(rows, DUPLICATE_SORT_LINE_FIELDS)
+  const pathParent = parentShape === 'cross_parent'
+  return {
+    ordinal: index + 1,
+    fingerprint: stableFingerprint(key),
+    rowCount: rows.length,
+    parentShape,
+    quantityShape,
+    attributeShape,
+    stableDiscriminators: {
+      sourceDetail,
+      pathParent,
+      sortLine,
+      any: sourceDetail || pathParent || sortLine,
+    },
+    recommendedDefault: 'hold',
+    allowedPolicies: DUPLICATE_EXPANDED_KEY_POLICIES.slice(),
+  }
+}
+
+function increment(map, key) {
+  map.set(key, (map.get(key) || 0) + 1)
+}
+
+function sortedDistribution(map, keyName) {
+  return Array.from(map.entries())
+    .map(([key, count]) => ({ [keyName]: key, groups: count }))
+    .sort((left, right) => Number(left[keyName]) - Number(right[keyName]))
+}
+
+function shapeCounts(groups, field) {
+  const out = {}
+  for (const group of groups) out[group[field]] = (out[group[field]] || 0) + 1
+  return out
+}
+
+function duplicateExpandedKeyDiagnostics(groupedRows) {
+  const groups = []
+  const distribution = new Map()
+  for (const [key, rows] of groupedRows.entries()) {
+    if (rows.length <= 1) continue
+    increment(distribution, rows.length)
+    groups.push(duplicateExpandedGroupDiagnostic(key, rows, groups.length))
+  }
+  if (groups.length === 0) return undefined
+  return {
+    conflictType: 'duplicate_expanded_key',
+    groupCount: groups.length,
+    rowCount: groups.reduce((sum, group) => sum + group.rowCount, 0),
+    rowsPerGroup: sortedDistribution(distribution, 'rowCount'),
+    parentShapeCounts: shapeCounts(groups, 'parentShape'),
+    quantityShapeCounts: shapeCounts(groups, 'quantityShape'),
+    attributeShapeCounts: shapeCounts(groups, 'attributeShape'),
+    stableDiscriminatorCounts: {
+      any: groups.filter((group) => group.stableDiscriminators.any).length,
+      sourceDetail: groups.filter((group) => group.stableDiscriminators.sourceDetail).length,
+      pathParent: groups.filter((group) => group.stableDiscriminators.pathParent).length,
+      sortLine: groups.filter((group) => group.stableDiscriminators.sortLine).length,
+    },
+    defaultPolicy: 'hold',
+    allowedPolicies: DUPLICATE_EXPANDED_KEY_POLICIES.slice(),
+    groups,
+  }
 }
 
 function changedFields(nextRow, existingRow, fields, templateFields = new Map()) {
@@ -480,6 +652,7 @@ function planStockPreparationConflicts(input = {}) {
       humanPreservedFields: humanFields.slice(),
       plmSystemFields: plmFields.slice(),
       conflictTypes: Array.from(new Set(decisions.map((decision) => decision.conflictSummary && decision.conflictSummary.type).filter(Boolean))).sort(),
+      duplicateExpandedKeyDiagnostics: duplicateExpandedKeyDiagnostics(expanded.keyed),
     },
   }
 }
@@ -497,6 +670,9 @@ function summarizeConflictPlanForEvidence(plan = {}) {
     humanPreservedFields: Array.isArray(summary.humanPreservedFields) ? summary.humanPreservedFields.slice() : [],
     plmSystemFields: Array.isArray(summary.plmSystemFields) ? summary.plmSystemFields.slice() : [],
     conflictTypes: Array.isArray(summary.conflictTypes) ? summary.conflictTypes.slice() : [],
+    duplicateExpandedKeyDiagnostics: isPlainObject(summary.duplicateExpandedKeyDiagnostics)
+      ? JSON.parse(JSON.stringify(summary.duplicateExpandedKeyDiagnostics))
+      : undefined,
   }
 }
 
@@ -517,6 +693,7 @@ module.exports = {
     normalizeComparableValueForField,
     plmRefreshFieldIds,
     sameStringSet,
+    stableFingerprint,
     valuesEqual,
     valuesEqualForTemplateField,
   },


### PR DESCRIPTION
## Summary
Implements #2343 D1: values-free grouped duplicate-expanded-key diagnostics plus workbench display. This is stacked on #2365.

## What changed
- C3 planner evidence now includes duplicateExpandedKeyDiagnostics: group counts, rows-per-group distribution, parent/quantity/attribute shape counts, stable-discriminator counts, sha16 collision fingerprints, and allowed policy names.
- Workbench dry-run review renders the grouped duplicate block so operators can see why duplicate-expanded-key rows are held.
- TODO and verification docs updated.

## Boundaries
- No MetaSheet write, PLM write, external DB write, K3, route, migration, package, policy persistence, or Apply unlock.
- Duplicate rows remain manual_confirm and held; clean-row apply behavior is unchanged.

## Verification
- pnpm --filter plugin-integration-core test:stock-preparation-conflict-planner
- pnpm --filter plugin-integration-core test
- pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web lint
- git diff --check