### PR TITLE
fix(attendance-approval): make approval-center attendance items actionable

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -804,11 +804,21 @@
             </div>
             <div v-if="requests.length === 0" class="attendance__empty">{{ tr('No requests.', '暂无申请。') }}</div>
             <ul v-else class="attendance__request-list">
-              <li v-for="item in requests" :key="item.id" class="attendance__request-item">
+              <li
+                v-for="item in requests"
+                :key="item.id"
+                class="attendance__request-item"
+                :class="{ 'attendance__request-item--focused': isFocusedAttendanceRequest(item) }"
+                :data-attendance-request-id="item.id"
+                :data-attendance-request-focused="isFocusedAttendanceRequest(item) ? 'true' : undefined"
+              >
                 <div>
                   <strong>{{ item.work_date }}</strong> · {{ formatRequestType(item.request_type) }}
                   <span class="attendance__status-chip" :class="`attendance__status-chip--${item.status}`">
                     {{ formatStatus(item.status) }}
+                  </span>
+                  <span v-if="isFocusedAttendanceRequest(item)" class="attendance__status-chip attendance__status-chip--focus">
+                    {{ tr('Opened from Approval Center', '来自审批中心') }}
                   </span>
                 </div>
                 <div class="attendance__request-meta" v-if="item.metadata">
@@ -827,7 +837,13 @@
                   <span>{{ tr('Out', '出') }}: {{ formatDateTime(item.requested_out_at) }}</span>
                 </div>
                 <div class="attendance__request-actions" v-if="item.status === 'pending'">
-                  <button class="attendance__btn" @click="cancelRequest(item.id)">{{ tr('Cancel', '取消') }}</button>
+                  <button v-if="!isFocusedAttendanceRequest(item)" class="attendance__btn" @click="cancelRequest(item.id)">{{ tr('Cancel', '取消') }}</button>
+                  <template v-if="canReviewFocusedAttendanceRequest(item)">
+                    <button class="attendance__btn" @click="resolveRequest(item.id, 'approve')">{{ tr('Approve', '批准') }}</button>
+                    <button class="attendance__btn attendance__btn--danger" @click="resolveRequest(item.id, 'reject')">
+                      {{ tr('Reject', '驳回') }}
+                    </button>
+                  </template>
                 </div>
               </li>
             </ul>
@@ -6976,10 +6992,12 @@ const props = withDefaults(
   defineProps<{
     mode?: AttendancePageMode
     initialSectionId?: string
+    initialRequestId?: string
   }>(),
   {
     mode: 'overview',
     initialSectionId: '',
+    initialRequestId: '',
   }
 )
 
@@ -8105,6 +8123,7 @@ const recordTimelineById = ref<Record<string, AttendancePunchEvent[]>>({})
 const recordTimelineErrorById = ref<Record<string, string>>({})
 const recordTimelineSupported = ref<boolean | null>(null)
 const requests = ref<AttendanceRequest[]>([])
+const focusedAttendanceRequestId = computed(() => props.initialRequestId.trim())
 const anomalies = ref<AttendanceAnomaly[]>([])
 const anomaliesLoading = ref(false)
 const statusMessage = ref('')
@@ -11778,6 +11797,14 @@ function requestDecisionCommentLabel(item: AttendanceRequest): string {
   return String(item.status || '').toLowerCase() === 'rejected'
     ? tr('Rejection note', '驳回说明')
     : tr('Decision note', '审批说明')
+}
+
+function isFocusedAttendanceRequest(item: AttendanceRequest): boolean {
+  return Boolean(focusedAttendanceRequestId.value && item.id === focusedAttendanceRequestId.value)
+}
+
+function canReviewFocusedAttendanceRequest(item: AttendanceRequest): boolean {
+  return isFocusedAttendanceRequest(item) && String(item.status || '').toLowerCase() === 'pending'
 }
 
 function requestTypeCtaLabel(value: string): string {
@@ -15811,7 +15838,35 @@ async function loadRequests() {
   if (!response.ok || !data.ok) {
     throw new Error(readErrorMessage(data, tr('Failed to load requests', '加载申请失败')))
   }
-  requests.value = data.data.items
+  const loadedRequests = Array.isArray(data.data.items) ? data.data.items as AttendanceRequest[] : []
+  const focusedRequest = await loadFocusedAttendanceRequestBestEffort()
+  requests.value = focusedRequest
+    ? [focusedRequest, ...loadedRequests.filter(item => item.id !== focusedRequest.id)]
+    : loadedRequests
+}
+
+async function loadFocusedAttendanceRequestBestEffort(): Promise<AttendanceRequest | null> {
+  try {
+    return await loadFocusedAttendanceRequest()
+  } catch (error) {
+    setStatus(
+      readErrorMessage(error, tr('Focused attendance request is unavailable.', '待处理考勤申请不可用。')),
+      'error',
+    )
+    return null
+  }
+}
+
+async function loadFocusedAttendanceRequest(): Promise<AttendanceRequest | null> {
+  const requestId = focusedAttendanceRequestId.value
+  if (!requestId) return null
+
+  const response = await apiFetch(`/api/attendance/requests/${encodeURIComponent(requestId)}`)
+  const data = await response.json()
+  if (!response.ok || !data.ok) {
+    throw new Error(readErrorMessage(data, tr('Failed to load focused request', '加载待处理申请失败')))
+  }
+  return data.data?.request ?? null
 }
 
 async function loadAnomalies() {
@@ -19825,11 +19880,26 @@ watch(recordStatusBreakdown, (items) => {
 }, { immediate: true })
 
 watch(
-  () => [props.initialSectionId, showAdmin.value, showOverview.value, showReports.value, adminForbidden.value, attendancePluginActive.value] as const,
+  () => [props.initialSectionId, props.initialRequestId, showAdmin.value, showOverview.value, showReports.value, adminForbidden.value, attendancePluginActive.value] as const,
   () => {
     void focusInitialAttendanceSection()
   },
   { immediate: true },
+)
+
+watch(
+  () => props.initialRequestId,
+  () => {
+    if (!attendancePluginActive.value || !showOverview.value) return
+    void loadRequests().catch((error) => {
+      setStatusFromErrorWithContext(
+        error,
+        tr('Failed to load focused request', '加载待处理申请失败'),
+        requestTimezoneContextHint.value,
+        'refresh',
+      )
+    })
+  },
 )
 
 watch(attendanceGroupMemberGroupId, () => {
@@ -20634,6 +20704,11 @@ const holidaySectionBindings = {
   gap: 6px;
 }
 
+.attendance__request-item--focused {
+  border-color: #1976d2;
+  background: #f5f9ff;
+}
+
 .attendance__request-meta {
   display: flex;
   gap: 12px;
@@ -20674,6 +20749,11 @@ const holidaySectionBindings = {
 .attendance__status-chip--pending {
   background: #fff3e0;
   color: #ef6c00;
+}
+
+.attendance__status-chip--focus {
+  background: #e3f2fd;
+  color: #1565c0;
 }
 
 .attendance__status-chip--approved {

--- a/apps/web/src/views/attendance/AttendanceExperienceView.vue
+++ b/apps/web/src/views/attendance/AttendanceExperienceView.vue
@@ -126,6 +126,11 @@ const overviewInitialSectionId = computed(() => {
   return section === 'attendance-overview-requests' ? section : ''
 })
 
+const overviewInitialRequestId = computed(() => {
+  const requestId = Array.isArray(route.query.requestId) ? route.query.requestId[0] : route.query.requestId
+  return typeof requestId === 'string' ? requestId.trim() : ''
+})
+
 const adminInitialSectionId = computed(() => {
   const section = Array.isArray(route.query.section) ? route.query.section[0] : route.query.section
   return typeof section === 'string' && section.startsWith('attendance-admin-') ? section : ''
@@ -159,7 +164,10 @@ const activeView = computed(() => {
       return {
         component: AttendanceOverview,
         key: 'attendance-overview',
-        props: { initialSectionId: overviewInitialSectionId.value },
+        props: {
+          initialSectionId: overviewInitialSectionId.value,
+          initialRequestId: overviewInitialRequestId.value,
+        },
       }
     case 'reports':
       return {
@@ -189,6 +197,7 @@ const activeView = computed(() => {
         props: { canDesign: canAccessWorkflow.value },
       }
   }
+  return null
 })
 
 function updateMobileState(): void {

--- a/apps/web/src/views/attendance/AttendanceOverview.vue
+++ b/apps/web/src/views/attendance/AttendanceOverview.vue
@@ -1,5 +1,9 @@
 <template>
-  <AttendanceView mode="overview" :initial-section-id="initialSectionId" />
+  <AttendanceView
+    mode="overview"
+    :initial-section-id="initialSectionId"
+    :initial-request-id="initialRequestId"
+  />
 </template>
 
 <script setup lang="ts">
@@ -7,7 +11,9 @@ import AttendanceView from '../AttendanceView.vue'
 
 withDefaults(defineProps<{
   initialSectionId?: string
+  initialRequestId?: string
 }>(), {
   initialSectionId: '',
+  initialRequestId: '',
 })
 </script>

--- a/apps/web/tests/attendance-experience-entrypoints.spec.ts
+++ b/apps/web/tests/attendance-experience-entrypoints.spec.ts
@@ -44,8 +44,12 @@ vi.mock('../src/views/attendance/AttendanceOverview.vue', () => ({
         type: String,
         default: '',
       },
+      initialRequestId: {
+        type: String,
+        default: '',
+      },
     },
-    template: '<div data-view="overview" :data-section="initialSectionId"></div>',
+    template: '<div data-view="overview" :data-section="initialSectionId" :data-request-id="initialRequestId"></div>',
   }),
 }))
 
@@ -146,7 +150,7 @@ describe('Attendance experience entrypoints', () => {
   })
 
   it('routes the attendance approval queue shortcut into the overview requests section', async () => {
-    routeState.query = { section: 'attendance-overview-requests' }
+    routeState.query = { section: 'attendance-overview-requests', requestId: 'request-123' }
 
     app = createApp(AttendanceExperienceView)
     app.mount(container!)
@@ -155,6 +159,7 @@ describe('Attendance experience entrypoints', () => {
     const overviewView = container!.querySelector<HTMLElement>('[data-view="overview"]')
     expect(overviewView).toBeTruthy()
     expect(overviewView?.dataset.section).toBe('attendance-overview-requests')
+    expect(overviewView?.dataset.requestId).toBe('request-123')
   })
 
   it('routes the reports entrypoint into a dedicated reports view', async () => {

--- a/apps/web/tests/attendance-selfservice-dashboard.spec.ts
+++ b/apps/web/tests/attendance-selfservice-dashboard.spec.ts
@@ -106,6 +106,29 @@ function installOverviewMock(): void {
         },
       })
     }
+    if (url.endsWith('/api/attendance/requests/request-focused')) {
+      return jsonResponse(200, {
+        ok: true,
+        data: {
+          request: {
+            id: 'request-focused',
+            work_date: '2026-04-16',
+            request_type: 'time_correction',
+            requested_in_at: '2026-04-16T09:05:00+08:00',
+            requested_out_at: '2026-04-16T18:02:00+08:00',
+            reason: 'Approval-center pending item',
+            status: 'pending',
+            metadata: {},
+          },
+        },
+      })
+    }
+    if (url.endsWith('/api/attendance/requests/request-missing')) {
+      return jsonResponse(404, {
+        ok: false,
+        error: { message: 'Focused request is no longer available.' },
+      })
+    }
     if (url.includes('/api/attendance/requests?')) {
       return jsonResponse(200, {
         ok: true,
@@ -223,6 +246,12 @@ function installOverviewMock(): void {
     }
     if (url.includes('/api/attendance/overtime-rules')) {
       return jsonResponse(200, { ok: true, data: { items: [{ id: 'ot-default', name: 'Standard Overtime' }] } })
+    }
+    if (
+      url.includes('/api/attendance/requests/request-focused/approve')
+      || url.includes('/api/attendance/requests/request-focused/reject')
+    ) {
+      return jsonResponse(200, { ok: true, data: { requestId: 'request-focused', status: 'approved' } })
     }
 
     return jsonResponse(200, { ok: true, data: { items: [], total: 0 } })
@@ -435,6 +464,84 @@ describe('Attendance self-service dashboard', () => {
     expect(vi.mocked(apiFetch).mock.calls.some(call =>
       /\/api\/attendance\/requests\/request-pending\/(?:approve|reject)/.test(String(call[0]))
     )).toBe(false)
+  })
+
+  it('opens a focused attendance approval request from approval center and exposes review actions', async () => {
+    app = createApp(AttendanceView, {
+      mode: 'overview',
+      initialSectionId: 'attendance-overview-requests',
+      initialRequestId: 'request-focused',
+    })
+    app.mount(container!)
+    await flushUi(12)
+
+    expect(vi.mocked(apiFetch).mock.calls.some(call =>
+      String(call[0]).endsWith('/api/attendance/requests/request-focused'),
+    )).toBe(true)
+
+    const focusedItem = container!.querySelector<HTMLElement>('[data-attendance-request-id="request-focused"]')
+    expect(focusedItem).toBeTruthy()
+    expect(focusedItem?.dataset.attendanceRequestFocused).toBe('true')
+    expect(focusedItem?.textContent).toContain('Opened from Approval Center')
+    expect(focusedItem?.textContent).toContain('Time correction')
+    expect(focusedItem?.textContent).toContain('Approval-center pending item')
+    expect(focusedItem?.textContent).toContain('Approve')
+    expect(focusedItem?.textContent).toContain('Reject')
+
+    findButton(container!, 'Approve').click()
+    await flushUi(12)
+
+    expect(vi.mocked(apiFetch).mock.calls.some(call =>
+      String(call[0]).includes('/api/attendance/requests/request-focused/approve'),
+    )).toBe(true)
+  })
+
+  it('keeps the request list available when the focused approval request cannot be loaded', async () => {
+    app = createApp(AttendanceView, {
+      mode: 'overview',
+      initialSectionId: 'attendance-overview-requests',
+      initialRequestId: 'request-missing',
+    })
+    app.mount(container!)
+    await flushUi(12)
+
+    expect(vi.mocked(apiFetch).mock.calls.some(call =>
+      String(call[0]).endsWith('/api/attendance/requests/request-missing'),
+    )).toBe(true)
+
+    expect(container!.textContent).toContain('Focused request is no longer available.')
+    expect(container!.textContent).toContain('Family medical appointment')
+    expect(container!.querySelector('[data-attendance-request-focused="true"]')).toBeNull()
+  })
+
+  it('keeps focused attendance rejection comment required before calling the API', async () => {
+    const promptSpy = vi.spyOn(window, 'prompt').mockReturnValueOnce('').mockReturnValueOnce('Need evidence')
+
+    app = createApp(AttendanceView, {
+      mode: 'overview',
+      initialSectionId: 'attendance-overview-requests',
+      initialRequestId: 'request-focused',
+    })
+    app.mount(container!)
+    await flushUi(12)
+
+    findButton(container!, 'Reject').click()
+    await flushUi(4)
+
+    expect(vi.mocked(apiFetch).mock.calls.some(call =>
+      String(call[0]).includes('/api/attendance/requests/request-focused/reject'),
+    )).toBe(false)
+    expect(container!.textContent).toContain('Rejection reason is required.')
+
+    findButton(container!, 'Reject').click()
+    await flushUi(12)
+
+    const rejectCall = vi.mocked(apiFetch).mock.calls.find(call =>
+      String(call[0]).includes('/api/attendance/requests/request-focused/reject'),
+    )
+    expect(rejectCall).toBeTruthy()
+    expect(JSON.parse(String(rejectCall?.[1]?.body ?? '{}'))).toEqual({ comment: 'Need evidence' })
+    promptSpy.mockRestore()
   })
 
   it('prefills the request form from quick actions without leaving overview', async () => {

--- a/apps/web/tests/attendance-surface-modes.spec.ts
+++ b/apps/web/tests/attendance-surface-modes.spec.ts
@@ -14,8 +14,12 @@ vi.mock('../src/views/AttendanceView.vue', () => ({
         type: String,
         default: '',
       },
+      initialRequestId: {
+        type: String,
+        default: '',
+      },
     },
-    template: '<div :data-mode="mode" :data-section="initialSectionId"></div>',
+    template: '<div :data-mode="mode" :data-section="initialSectionId" :data-request-id="initialRequestId"></div>',
   }),
 }))
 
@@ -47,6 +51,7 @@ describe('Attendance surface wrappers', () => {
     const surface = container.querySelector<HTMLElement>('[data-mode="overview"]')
     expect(surface).toBeTruthy()
     expect(surface?.dataset.section).toBe('attendance-overview-requests')
+    expect(surface?.dataset.requestId).toBe('')
   })
 
   it('keeps reports routed through the dedicated reports shell mode', async () => {


### PR DESCRIPTION
## Summary

Fixes #2360.

Approval Center already routes attendance pending items with `requestId`, but the Attendance page ignored that query and only loaded the current user's own request list. This made bridged attendance approvals visible but not actionable.

This PR wires the existing route into the attendance request center:

- forwards `requestId` from `AttendanceExperienceView` / `AttendanceOverview` into `AttendanceView`
- loads the focused request through the existing safe single-item endpoint `GET /api/attendance/requests/:id`
- pins the focused row at the top, highlights it as opened from Approval Center, and exposes approve/reject actions for pending focused requests
- preserves the existing self-service cancel behavior for ordinary pending requests
- keeps rejection-comment validation before calling the reject endpoint

No backend route or permission change: it reuses the existing attendance request access checks and approve/reject endpoints.

## Verification

```bash
pnpm --filter @metasheet/web exec vitest run tests/attendance-experience-entrypoints.spec.ts tests/attendance-surface-modes.spec.ts tests/attendance-selfservice-dashboard.spec.ts --watch=false
pnpm --filter @metasheet/web type-check
git diff --check
pnpm --filter @metasheet/web exec eslint src/views/attendance/AttendanceExperienceView.vue src/views/attendance/AttendanceOverview.vue tests/attendance-experience-entrypoints.spec.ts tests/attendance-surface-modes.spec.ts tests/attendance-selfservice-dashboard.spec.ts
```

Targeted eslint exits 0; it reports existing `vue/one-component-per-file` warnings in test mocks only.
