### PR TITLE
feat(plm-embed): single-use embed token (jti replay protection, B1)

### DIFF
--- a/packages/core-backend/src/auth/embed-jti-store.ts
+++ b/packages/core-backend/src/auth/embed-jti-store.ts
@@ -25,6 +25,7 @@ export class EmbedJtiStoreUnavailableError extends Error {
 /**
  * Hash the SCOPED key so a bare jti never lands in Redis, and a jti can only be consumed within the
  * exact (aud, feature_key, tenant_id, part_id) scope it was minted for (no cross-scope collision).
+ * The JSON array avoids delimiter ambiguity between adjacent scope fields.
  */
 export function embedJtiKey(scope: {
   aud: string
@@ -33,7 +34,7 @@ export function embedJtiKey(scope: {
   part_id: string
   jti: string
 }): string {
-  const material = [scope.aud, scope.feature_key, scope.tenant_id, scope.part_id, scope.jti].join('|')
+  const material = JSON.stringify([scope.aud, scope.feature_key, scope.tenant_id, scope.part_id, scope.jti])
   const digest = crypto.createHash('sha256').update(material).digest('hex')
   return `plm-embed:jti:${digest}`
 }

--- a/packages/core-backend/src/auth/embed-jti-store.ts
+++ b/packages/core-backend/src/auth/embed-jti-store.ts
@@ -1,0 +1,58 @@
+import crypto from 'node:crypto'
+import { getRedisClient } from '../db/redis'
+
+/**
+ * PLM-COLLAB P3-D2 slice B (B1): the shared single-use store for embed-token `jti` consumption.
+ *
+ * Backed by the shared Redis (cross-instance), so a replay of a still-valid embed token is rejected
+ * regardless of which instance handles it. There is deliberately NO in-memory fallback: a
+ * per-instance memory store would not stop a replay that lands on a different instance, which would
+ * defeat single-use. When the shared store is unavailable the consume throws and the caller MUST
+ * fail closed (503), never fail open.
+ *
+ * Operational caveat (inherited from db/redis.ts): getRedisClient() memoizes a *startup* connection
+ * failure as a permanent null, so if Redis is down at the first call the embed path stays
+ * fail-closed (503) until the process restarts. After a successful first connect, ioredis recovers
+ * from transient drops on its own (a drop just throws on the in-flight SET -> a single 503).
+ */
+export class EmbedJtiStoreUnavailableError extends Error {
+  constructor(message = 'embed jti store unavailable') {
+    super(message)
+    this.name = 'EmbedJtiStoreUnavailableError'
+  }
+}
+
+/**
+ * Hash the SCOPED key so a bare jti never lands in Redis, and a jti can only be consumed within the
+ * exact (aud, feature_key, tenant_id, part_id) scope it was minted for (no cross-scope collision).
+ */
+export function embedJtiKey(scope: {
+  aud: string
+  feature_key: string
+  tenant_id: string
+  part_id: string
+  jti: string
+}): string {
+  const material = [scope.aud, scope.feature_key, scope.tenant_id, scope.part_id, scope.jti].join('|')
+  const digest = crypto.createHash('sha256').update(material).digest('hex')
+  return `plm-embed:jti:${digest}`
+}
+
+/**
+ * Atomically consume the key. Returns true if it was newly consumed (first use), false if it was
+ * already present (a replay). Throws EmbedJtiStoreUnavailableError when the shared store is
+ * unavailable -- the caller fails closed.
+ */
+export async function consumeEmbedJti(key: string, ttlSeconds: number): Promise<boolean> {
+  const redis = await getRedisClient()
+  if (!redis) throw new EmbedJtiStoreUnavailableError()
+  const ttl = Math.max(1, Math.floor(ttlSeconds))
+  let result: string | null
+  try {
+    // SET key 1 EX <ttl> NX -> 'OK' when newly set (first use), null when the key already exists (replay)
+    result = await redis.set(key, '1', 'EX', ttl, 'NX')
+  } catch {
+    throw new EmbedJtiStoreUnavailableError('embed jti store consume failed')
+  }
+  return result === 'OK'
+}

--- a/packages/core-backend/src/routes/plm-embed.ts
+++ b/packages/core-backend/src/routes/plm-embed.ts
@@ -20,6 +20,7 @@ import { Router, type Request, type Response } from 'express'
 import { getDataSourceManager } from './data-sources'
 import { embedTokenAuth } from '../middleware/embed-token-auth'
 import { embedAllowedOrigins, embedDataSourceId, frameAncestorsValue } from '../auth/embed-config'
+import { consumeEmbedJti, embedJtiKey } from '../auth/embed-jti-store'
 import type { BomMultitableContextResult } from '../data-adapters/PLMAdapter'
 
 const BOM_FEATURE_KEY = 'bom_multitable'
@@ -97,6 +98,39 @@ export default function plmEmbedRouter(): Router {
       const servedTenantId = adapter.getEffectiveTenantId()
       if (!servedTenantId || claims.tenant_id !== servedTenantId) {
         return res.status(403).json({ ok: false, error: { code: 'EMBED_TENANT_MISMATCH', message: 'token tenant does not match the embed data source tenant' } })
+      }
+
+      // Single-use: atomically consume the token's jti against the SHARED store BEFORE querying, so a
+      // replay of a still-valid token cannot fetch data a second time. A jti is required (an absent
+      // jti cannot be tracked). The store being unavailable fails CLOSED (503) -- never fail open, and
+      // never a per-instance fallback. Cost (accepted): one data call per token; after the transient
+      // provider-failure degrade below, the parent must RE-MINT + re-post (a retry is NOT a re-call).
+      const jti = typeof claims.jti === 'string' ? claims.jti : ''
+      if (!jti) {
+        return res.status(401).json({ ok: false, error: { code: 'INVALID_EMBED_TOKEN', message: 'missing jti' } })
+      }
+      const now = Math.floor(Date.now() / 1000)
+      const ttl = Math.min(typeof claims.exp === 'number' ? claims.exp - now : 0, 600)
+      if (ttl < 1) {
+        return res.status(401).json({ ok: false, error: { code: 'INVALID_EMBED_TOKEN', message: 'token expired' } })
+      }
+      let firstUse: boolean
+      try {
+        firstUse = await consumeEmbedJti(
+          embedJtiKey({
+            aud: claims.aud ?? '',
+            feature_key: claims.feature_key ?? '',
+            tenant_id: claims.tenant_id ?? '',
+            part_id: claims.part_id,
+            jti,
+          }),
+          ttl,
+        )
+      } catch {
+        return res.status(503).json({ ok: false, error: { code: 'EMBED_UNAVAILABLE', message: 'embed replay store unavailable' } })
+      }
+      if (!firstUse) {
+        return res.status(401).json({ ok: false, error: { code: 'EMBED_TOKEN_REPLAYED', message: 'embed token already used' } })
       }
 
       const partId = claims.part_id // token-bound; never a request input

--- a/packages/core-backend/tests/unit/embed-jti-store.test.ts
+++ b/packages/core-backend/tests/unit/embed-jti-store.test.ts
@@ -1,0 +1,69 @@
+import { beforeEach, describe, expect, it, vi } from 'vitest'
+
+const getRedisClientMock = vi.fn()
+vi.mock('../../src/db/redis', () => ({
+  getRedisClient: (...args: unknown[]) => getRedisClientMock(...args),
+}))
+
+import { consumeEmbedJti, embedJtiKey, EmbedJtiStoreUnavailableError } from '../../src/auth/embed-jti-store'
+
+// A stateful Redis `SET key val EX ttl NX` fake: returns 'OK' the first time a key is set, and null
+// while it already exists. The replay result comes from the NX SEMANTICS, not from mockReturnValueOnce
+// -- so a regression that drops NX (and thus fail-opens) actually changes the test outcome.
+function makeRedis() {
+  const store = new Map<string, string>()
+  const set = vi.fn(async (key: string, val: string, _ex: string, _ttl: number, nx?: string) => {
+    if (nx === 'NX' && store.has(key)) return null
+    store.set(key, val)
+    return 'OK'
+  })
+  return { set }
+}
+
+describe('embedJtiKey', () => {
+  it('is deterministic, scoped, prefixed, and never leaks the bare jti', () => {
+    const scope = { aud: 'metasheet2.embed', feature_key: 'bom_multitable', tenant_id: 't1', part_id: 'P1', jti: 'jti-secret-123' }
+    const key = embedJtiKey(scope)
+    expect(key).toBe(embedJtiKey({ ...scope })) // deterministic
+    expect(key.startsWith('plm-embed:jti:')).toBe(true)
+    expect(key).not.toContain('jti-secret-123') // hashed -> no bare jti
+    // scope binding: changing any scope component changes the key
+    expect(embedJtiKey({ ...scope, jti: 'other' })).not.toBe(key)
+    expect(embedJtiKey({ ...scope, tenant_id: 't2' })).not.toBe(key)
+    expect(embedJtiKey({ ...scope, part_id: 'P2' })).not.toBe(key)
+    expect(embedJtiKey({ ...scope, feature_key: 'approval_automation' })).not.toBe(key)
+    expect(embedJtiKey({ ...scope, aud: 'other.embed' })).not.toBe(key)
+  })
+})
+
+describe('consumeEmbedJti', () => {
+  beforeEach(() => getRedisClientMock.mockReset())
+
+  it('SET NX EX -> true on first use, false on replay; pins the exact args incl. NX', async () => {
+    const redis = makeRedis()
+    getRedisClientMock.mockResolvedValue(redis)
+    const first = await consumeEmbedJti('k', 120)
+    expect(first).toBe(true)
+    // pin the args: dropping NX (or wrong EX/NX order) would silently fail-open replay protection
+    expect(redis.set).toHaveBeenCalledWith('k', '1', 'EX', 120, 'NX')
+    const second = await consumeEmbedJti('k', 120)
+    expect(second).toBe(false) // replay, produced by the NX semantics
+  })
+
+  it('floors a fractional ttl and never goes below 1 second', async () => {
+    const redis = makeRedis()
+    getRedisClientMock.mockResolvedValue(redis)
+    await consumeEmbedJti('k', 0.4)
+    expect(redis.set).toHaveBeenCalledWith('k', '1', 'EX', 1, 'NX')
+  })
+
+  it('throws (fail-closed) when the shared store is unavailable (null client)', async () => {
+    getRedisClientMock.mockResolvedValue(null)
+    await expect(consumeEmbedJti('k', 120)).rejects.toBeInstanceOf(EmbedJtiStoreUnavailableError)
+  })
+
+  it('throws (fail-closed) when the SET command itself throws', async () => {
+    getRedisClientMock.mockResolvedValue({ set: vi.fn().mockRejectedValue(new Error('redis down')) })
+    await expect(consumeEmbedJti('k', 120)).rejects.toBeInstanceOf(EmbedJtiStoreUnavailableError)
+  })
+})

--- a/packages/core-backend/tests/unit/embed-jti-store.test.ts
+++ b/packages/core-backend/tests/unit/embed-jti-store.test.ts
@@ -34,6 +34,25 @@ describe('embedJtiKey', () => {
     expect(embedJtiKey({ ...scope, feature_key: 'approval_automation' })).not.toBe(key)
     expect(embedJtiKey({ ...scope, aud: 'other.embed' })).not.toBe(key)
   })
+
+  it('does not collapse scopes that would collide under delimiter-joined material', () => {
+    const left = embedJtiKey({
+      aud: 'metasheet2.embed|bom_multitable',
+      feature_key: 'tenant-a',
+      tenant_id: 'part-1',
+      part_id: 'scope',
+      jti: 'jti-1',
+    })
+    const right = embedJtiKey({
+      aud: 'metasheet2.embed',
+      feature_key: 'bom_multitable|tenant-a',
+      tenant_id: 'part-1',
+      part_id: 'scope',
+      jti: 'jti-1',
+    })
+
+    expect(left).not.toBe(right)
+  })
 })
 
 describe('consumeEmbedJti', () => {

--- a/packages/core-backend/tests/unit/plm-embed-routes.test.ts
+++ b/packages/core-backend/tests/unit/plm-embed-routes.test.ts
@@ -6,6 +6,14 @@ import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
 // Controllable DataSourceManager mock.
 const dsMocks = vi.hoisted(() => ({ getDataSource: vi.fn() }))
 
+// Controllable single-use jti store. Default (set in beforeEach) is "first use" -> true, so the
+// existing happy-path tests keep reaching getBomMultitableContext; replay/unavailable are per-test.
+const jtiMocks = vi.hoisted(() => ({ consume: vi.fn() }))
+vi.mock('../../src/auth/embed-jti-store', () => ({
+  consumeEmbedJti: (...args: unknown[]) => jtiMocks.consume(...args),
+  embedJtiKey: (scope: { jti?: unknown }) => `plm-embed:jti:${String(scope.jti)}`,
+}))
+
 // Stub jwt-middleware's heavy deps so importing the REAL isWhitelisted is cheap. We do NOT mock
 // jwt-middleware itself -- we want the REAL whitelist (it must include /api/plm-embed/).
 vi.mock('../../src/db/sharding/tenant-context', () => ({ extractTenantFromHeaders: () => undefined }))
@@ -79,6 +87,8 @@ const URL = '/api/plm-embed/bom-review/context'
 describe('PLM embed relay (PLM-COLLAB-P3-D2)', () => {
   beforeEach(() => {
     dsMocks.getDataSource.mockReset()
+    jtiMocks.consume.mockReset()
+    jtiMocks.consume.mockResolvedValue(true) // default: first use; replay/unavailable overridden per test
     process.env.YUANTUS_EMBED_PUBLIC_KEY = PUB_B64
     process.env.YUANTUS_EMBED_KEY_ID = KID
     process.env.PLM_EMBED_AUDIENCE = AUD
@@ -244,5 +254,46 @@ describe('PLM embed relay (PLM-COLLAB-P3-D2)', () => {
     expect(res.status).toBe(403)
     expect(res.body.error.code).toBe('EMBED_TENANT_MISMATCH')
     expect(spy).not.toHaveBeenCalled()
+    // ordering: the jti is consumed only AFTER the tenant check passes -> a 403 here never consumes it
+    expect(jtiMocks.consume).not.toHaveBeenCalled()
+  })
+
+  // --- single-use jti consume (slice B / B1): consume AFTER all checks, BEFORE the BOM query ---
+
+  it('first use: consumes the (scoped) jti and serves -> 200', async () => {
+    const getBomMultitableContext = vi.fn().mockResolvedValue({ feature_key: 'bom_multitable', entitled: true, upgrade: { available: false }, context: CONTEXT })
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getBomMultitableContext }))
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint({ jti: 'j-abc' }))
+    expect(res.status).toBe(200)
+    expect(jtiMocks.consume).toHaveBeenCalledWith('plm-embed:jti:j-abc', expect.any(Number))
+    expect(getBomMultitableContext).toHaveBeenCalledWith('P1')
+  })
+
+  it('replay (jti already consumed) -> 401 EMBED_TOKEN_REPLAYED, BOM never queried', async () => {
+    jtiMocks.consume.mockResolvedValue(false)
+    const getBomMultitableContext = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getBomMultitableContext }))
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint())
+    expect(res.status).toBe(401)
+    expect(res.body.error.code).toBe('EMBED_TOKEN_REPLAYED')
+    expect(getBomMultitableContext).not.toHaveBeenCalled()
+  })
+
+  it('shared replay store unavailable -> 503 fail-closed, BOM never queried', async () => {
+    jtiMocks.consume.mockRejectedValue(new Error('redis down'))
+    const getBomMultitableContext = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getBomMultitableContext }))
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint())
+    expect(res.status).toBe(503)
+    expect(getBomMultitableContext).not.toHaveBeenCalled()
+  })
+
+  it('a token with no jti -> 401 (cannot be tracked for single-use)', async () => {
+    const getBomMultitableContext = vi.fn()
+    dsMocks.getDataSource.mockReturnValue(fullAdapter({ getBomMultitableContext }))
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint({ jti: undefined }))
+    expect(res.status).toBe(401)
+    expect(jtiMocks.consume).not.toHaveBeenCalled()
+    expect(getBomMultitableContext).not.toHaveBeenCalled()
   })
 })


### PR DESCRIPTION
## PLM-COLLAB P3-D2 slice B (B1) — embed token single-use / replay protection

Closes the **second `[~]`** from the P3-D closeout (#737): the embed token's `jti` was trackable but replayable within its TTL. Now a replay of a still-valid token is rejected. Backend-only; **B1** (consumer-side shared store, **no provider callback** — keeps Fork B offline).

### Design (owner-ratified, scope kept narrow)
- New `auth/embed-jti-store.ts`:
  - `embedJtiKey({aud,feature_key,tenant_id,part_id,jti})` → `plm-embed:jti:<sha256(scoped)>` — **hashed** (no bare jti in Redis) and **scope-bound** (a jti can only be consumed within its exact aud/feature/tenant/part scope).
  - `consumeEmbedJti(key, ttl)` → `getRedisClient()` + `SET key 1 EX ttl NX` → `true` on first use (`'OK'`), `false` on replay (`null`). Throws `EmbedJtiStoreUnavailableError` if the client is null or `SET` throws — **no in-memory fallback** (a per-instance memory store wouldn't stop a replay on another instance, defeating single-use).
- Relay `/api/plm-embed/bom-review/context` — **only** this route is guarded. After verify → feature → origin → **served-tenant** (slice A) all pass, and **before** `getBomMultitableContext`: require `jti` (else 401); `ttl = min(exp - now, 600)`; **atomically consume**:
  - throws → **503** (`EMBED_UNAVAILABLE`, fail-closed),
  - already consumed → **401 `EMBED_TOKEN_REPLAYED`**,
  - first use → proceed to the query.

### Cost (accepted) + the "retry" contract
- A token allows **one** data call. The consume happens **before** the query, so after the transient-provider-failure degrade (`200 {context:null, reason:'unavailable'}`) the **same token is spent** — the parent must **re-mint + re-post**, not re-call.
- ⚠️ **Flag for you:** the P3-D2 frontend currently renders that degrade as an `error`/"重试" state, which now implies an in-place retry that would 401-replay. The owner accepted the re-mint cost; this slice is backend-only, so I did **not** touch the frontend. **Should I open a tiny follow-up to change the embed `error` copy to "重新打开/重新载入" (re-mint), or leave it?** Your call.

### Operational note
- `getRedisClient()` (db/redis.ts) memoizes a **startup** connection failure as permanent null → the embed path stays **fail-closed (503)** until process restart if Redis is down at the first call. After a successful first connect, ioredis recovers from transient drops on its own (a drop is a single 503, not permanent).

### Tests (30 across the two specs)
- `embed-jti-store.test.ts`: key is deterministic/scoped/prefixed and **never leaks the bare jti**; consume **pins the exact `SET(key,'1','EX',ttl,'NX')` args** (a dropped NX = silent fail-open, so this is asserted) with a stateful NX-honoring fake (replay comes from the semantics); fractional-ttl floor ≥ 1; null client and throwing `SET` both **fail closed**.
- `plm-embed-routes.test.ts`: first-use consumes the scoped key → 200; **replay → 401 `EMBED_TOKEN_REPLAYED`**, BOM never queried; **store unavailable → 503**, never queried; no-jti → 401; and the **ordering** proof — a tenant-mismatch 403 never consumes the jti.

### Verification
- root `type-check` — green · `eslint` (changed src) — 0 errors · `vitest` — **30 passed**

**B2 (provider consume/revoke) deliberately not done** — it would pull the offline model back to an online handshake + Yuantus-side state/revocation + a cross-repo contract. B1 fixes the gap without expanding the surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
