### PR TITLE
feat(data-factory): resolve keep-multiple duplicate rows

### DIFF
--- a/apps/web/src/services/integration/workbench.ts
+++ b/apps/web/src/services/integration/workbench.ts
@@ -1019,6 +1019,7 @@ export interface IntegrationTableActionDryRunResult {
   evidence?: Record<string, unknown> & {
     plan?: {
       duplicateExpandedKeyDiagnostics?: Record<string, unknown>
+      duplicateExpandedKeyResolution?: Record<string, unknown>
       conflictPolicyReview?: Record<string, unknown>
       [key: string]: unknown
     }
@@ -1040,6 +1041,7 @@ export interface IntegrationTableActionRequestPayload {
   confirm?: {
     dryRunToken?: string
     acceptManualConfirmHold?: boolean
+    acceptDuplicateResolution?: boolean
   }
 }
 

--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -785,7 +785,7 @@
                 <strong>重复行分组待处理</strong>
                 <span class="integration-workbench__badge" data-status="warning">manual_confirm</span>
               </div>
-              <p>重复行不会被自动挑选、合并或写入；下方仅展示 values-free 分组诊断，策略应用仍需后续显式确认。</p>
+              <p>重复行策略只在 fresh dry-run evidence 中生效；已解决的分组仍需本次显式确认后才能 apply，未解决分组保持不写。</p>
               <div class="integration-workbench__metric-row">
                 <span v-for="metric in tableActionDuplicateMetrics" :key="metric.id">{{ metric.label }} {{ metric.value }}</span>
               </div>
@@ -793,7 +793,7 @@
                 policies: {{ tableActionDuplicatePolicies.join(', ') }}
               </p>
               <p class="integration-workbench__hint" data-testid="table-action-duplicate-policy-scope">
-                本表已保存策略 {{ tableActionStoredConflictPolicyCount }} 条；未选择时默认 hold。任何策略选择都不会自动写入重复行。
+                本表已保存策略 {{ tableActionStoredConflictPolicyCount }} 条；本次 dry-run 已解决 {{ tableActionResolvedDuplicateGroupCount }} 组，仍 hold {{ tableActionHeldDuplicateGroupCount }} 组；未选择时默认 hold。
               </p>
               <ul v-if="tableActionDuplicateGroups.length" class="integration-workbench__mini-list">
                 <li v-for="group in tableActionDuplicateGroups" :key="group.fingerprint">
@@ -813,7 +813,7 @@
                         </option>
                       </select>
                     </label>
-                    <span class="integration-workbench__hint">当前 {{ group.currentPolicy }} · {{ group.currentScope }} · 仍 held</span>
+                    <span class="integration-workbench__hint">当前 {{ group.currentPolicy }} · {{ group.currentScope }} · {{ group.resolutionLabel }}</span>
                     <button
                       type="button"
                       class="integration-workbench__button"
@@ -852,6 +852,10 @@
             <label v-if="tableActionManualConfirmCount > 0" class="integration-workbench__inline-check">
               <input v-model="tableActionAcceptManualConfirmHold" type="checkbox" data-testid="table-action-accept-manual-hold" />
               <span>确认 manual_confirm 行保持不写，只应用 clean add/update/inactive 决策。</span>
+            </label>
+            <label v-if="tableActionResolvedDuplicateGroupCount > 0" class="integration-workbench__inline-check">
+              <input v-model="tableActionAcceptDuplicateResolution" type="checkbox" data-testid="table-action-accept-duplicate-resolution" />
+              <span>确认已复核本次自动解决的重复分组，只应用 dry-run evidence 中列出的解决结果。</span>
             </label>
           </div>
           <div v-if="tableActionApplyResult" class="integration-workbench__table-action-review" data-testid="table-action-apply-result">
@@ -1286,6 +1290,7 @@ interface DuplicateExpandedGroupView {
   currentPolicy: string
   currentScope: string
   draftPolicy: string
+  resolutionLabel: string
 }
 
 interface ConnectionDraft {
@@ -1412,6 +1417,7 @@ const runningTableAction = ref<'dry-run' | 'apply' | ''>('')
 const tableActionDryRunResult = ref<IntegrationTableActionDryRunResult | null>(null)
 const tableActionApplyResult = ref<IntegrationTableActionApplyResult | null>(null)
 const tableActionAcceptManualConfirmHold = ref(false)
+const tableActionAcceptDuplicateResolution = ref(false)
 const tableActionDuplicatePolicyDrafts = ref<Record<string, string>>({})
 const tableActionDuplicateRunPolicies = ref<Record<string, string>>({})
 const tableActionTableScopePolicies = ref<IntegrationTableActionConflictPolicyResult | null>(null)
@@ -2043,6 +2049,31 @@ const tableActionConflictPolicySelections = computed(() => {
   }
   return out
 })
+const tableActionDuplicateResolution = computed(() => {
+  const resolution = tableActionPlanEvidence.value && isRecord(tableActionPlanEvidence.value.duplicateExpandedKeyResolution)
+    ? tableActionPlanEvidence.value.duplicateExpandedKeyResolution
+    : null
+  return resolution && resolution.conflictType === 'duplicate_expanded_key' ? resolution : null
+})
+const tableActionDuplicateResolutionSelections = computed(() => {
+  const resolution = tableActionDuplicateResolution.value
+  const out = new Map<string, { label: string }>()
+  const resolvedRows = Array.isArray(resolution?.resolvedPolicies) ? resolution.resolvedPolicies.filter(isRecord) : []
+  for (const row of resolvedRows) {
+    if (typeof row.fingerprint !== 'string') continue
+    const discriminator = typeof row.discriminator === 'string' ? row.discriminator : 'stable'
+    out.set(row.fingerprint, { label: `resolved · ${discriminator}` })
+  }
+  const heldRows = Array.isArray(resolution?.heldPolicies) ? resolution.heldPolicies.filter(isRecord) : []
+  for (const row of heldRows) {
+    if (typeof row.fingerprint !== 'string' || out.has(row.fingerprint)) continue
+    const reason = typeof row.reason === 'string' ? row.reason : 'held'
+    out.set(row.fingerprint, { label: `held · ${reason}` })
+  }
+  return out
+})
+const tableActionResolvedDuplicateGroupCount = computed(() => Number(tableActionDuplicateResolution.value?.resolvedGroupCount || 0))
+const tableActionHeldDuplicateGroupCount = computed(() => Number(tableActionDuplicateResolution.value?.heldGroupCount || 0))
 const tableActionStoredConflictPolicyCount = computed(() => Number(tableActionTableScopePolicies.value?.policyCount || 0))
 const tableActionDuplicateGroups = computed<DuplicateExpandedGroupView[]>(() => {
   const diagnostics = tableActionDuplicateDiagnostics.value
@@ -2065,6 +2096,7 @@ const tableActionDuplicateGroups = computed<DuplicateExpandedGroupView[]>(() => 
       currentPolicy: tableActionConflictPolicySelections.value.get(typeof group.fingerprint === 'string' ? group.fingerprint : '')?.policy || 'hold',
       currentScope: tableActionConflictPolicySelections.value.get(typeof group.fingerprint === 'string' ? group.fingerprint : '')?.scope || 'default',
       draftPolicy: tableActionDuplicatePolicyDrafts.value[typeof group.fingerprint === 'string' ? group.fingerprint : ''] || tableActionConflictPolicySelections.value.get(typeof group.fingerprint === 'string' ? group.fingerprint : '')?.policy || 'hold',
+      resolutionLabel: tableActionDuplicateResolutionSelections.value.get(typeof group.fingerprint === 'string' ? group.fingerprint : '')?.label || 'held · default_hold',
     }
   })
 })
@@ -2112,7 +2144,8 @@ const tableActionCanApply = computed(() => Boolean(
   && runningTableAction.value === ''
   && tableActionConflictPolicyDirty.value === false
   && Object.keys(tableActionDuplicateRunPolicies.value).length === 0
-  && (tableActionManualConfirmCount.value === 0 || tableActionAcceptManualConfirmHold.value),
+  && (tableActionManualConfirmCount.value === 0 || tableActionAcceptManualConfirmHold.value)
+  && (tableActionResolvedDuplicateGroupCount.value === 0 || tableActionAcceptDuplicateResolution.value)
 ))
 const tableActionReviewSummary = computed(() => {
   if (!selectedTableAction.value) return '当前部署没有可用表动作。'
@@ -3446,6 +3479,7 @@ function resetTableActionReview(): void {
   tableActionDryRunResult.value = null
   tableActionApplyResult.value = null
   tableActionAcceptManualConfirmHold.value = false
+  tableActionAcceptDuplicateResolution.value = false
   tableActionDuplicatePolicyDrafts.value = {}
   tableActionDuplicateRunPolicies.value = {}
   tableActionConflictPolicySaving.value = ''
@@ -3603,6 +3637,7 @@ async function dryRunTableAction(): Promise<void> {
   tableActionDryRunResult.value = null
   tableActionApplyResult.value = null
   tableActionAcceptManualConfirmHold.value = false
+  tableActionAcceptDuplicateResolution.value = false
   try {
     const result = await dryRunIntegrationTableAction(action.actionId, {
       ...currentScope(),
@@ -3619,8 +3654,15 @@ async function dryRunTableAction(): Promise<void> {
       ? planEvidence.duplicateExpandedKeyDiagnostics
       : null
     const duplicateGroupCount = duplicateDiagnostics ? Number(duplicateDiagnostics.groupCount || 0) : 0
+    const resolution = planEvidence && isRecord(planEvidence.duplicateExpandedKeyResolution)
+      ? planEvidence.duplicateExpandedKeyResolution
+      : null
+    const resolvedDuplicateGroups = Number(resolution?.resolvedGroupCount || 0)
+    const heldDuplicateGroups = Number(resolution?.heldGroupCount || 0)
     const message = isLargeBomBoundedTableActionResult(result)
       ? '表动作 dry-run 返回大 BOM 有界预览；Apply 已阻塞，请走完整展开/后台通道。'
+      : resolvedDuplicateGroups > 0
+      ? `表动作 dry-run 完成：${resolvedDuplicateGroups} 个重复分组已按策略解决，${heldDuplicateGroups} 个仍 hold；请复核后确认 apply。`
       : duplicateGroupCount > 0
       ? `表动作 dry-run 完成：${duplicateGroupCount} 个重复分组需要 review；重复行保持不写。`
       : manualCount > 0
@@ -3657,11 +3699,13 @@ async function applyTableAction(): Promise<void> {
       confirm: {
         dryRunToken: tableActionDryRunToken.value,
         acceptManualConfirmHold: tableActionAcceptManualConfirmHold.value === true,
+        acceptDuplicateResolution: tableActionAcceptDuplicateResolution.value === true,
       },
     })
     tableActionApplyResult.value = result
     tableActionDryRunResult.value = null
     tableActionAcceptManualConfirmHold.value = false
+    tableActionAcceptDuplicateResolution.value = false
     setStatus(`表动作 apply 完成：${result.status}`, result.status === 'failed' ? 'error' : 'success')
   } catch (error) {
     setStatus(error instanceof Error ? error.message : String(error), 'error')

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -2566,6 +2566,7 @@ describe('IntegrationWorkbenchView', () => {
       confirm: {
         dryRunToken: 'dry-token-secret',
         acceptManualConfirmHold: true,
+        acceptDuplicateResolution: false,
       },
     })
     expect(applyBodies[0].body).not.toHaveProperty('sheetId')
@@ -2924,7 +2925,7 @@ describe('IntegrationWorkbenchView', () => {
     const block = container.querySelector('[data-testid="table-action-duplicate-diagnostics"]')?.textContent || ''
     expect(block).toContain('keep_multiple_rows')
     expect(block).toContain('run_only')
-    expect(block).toContain('仍 held')
+    expect(block).toContain('held')
     expect(block).not.toContain('P-DUP')
 
     select.value = 'merge_quantity'
@@ -2944,6 +2945,162 @@ describe('IntegrationWorkbenchView', () => {
       fingerprints: ['sha16:1111222233334444'],
     })
     expect(applyBodies).toHaveLength(0)
+  })
+
+  it('D3 duplicate-expanded-key: requires explicit acknowledgement before applying resolved duplicate groups', async () => {
+    localStorage.setItem('user_permissions', JSON.stringify(['integration:write']))
+    const applyBodies: Array<Record<string, unknown>> = []
+    const publicAction = {
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      kind: 'parameterized_table_action',
+      label: 'PLM project BOM -> stock preparation',
+      configured: true,
+      parameters: [{ id: 'projectNo', label: 'Project number', type: 'string', required: true }],
+      permissions: { dryRun: 'read', apply: 'write' },
+      evidence: { valuesFreeIssueEvidence: true },
+    }
+    const duplicateDiagnostics = {
+      conflictType: 'duplicate_expanded_key',
+      groupCount: 1,
+      rowCount: 2,
+      rowsPerGroup: [{ rowCount: 2, groups: 1 }],
+      parentShapeCounts: { same_parent: 1 },
+      quantityShapeCounts: { varied: 1 },
+      attributeShapeCounts: { all_equal: 1 },
+      stableDiscriminatorCounts: { any: 1, sortLine: 1 },
+      defaultPolicy: 'hold',
+      allowedPolicies: ['hold', 'keep_multiple_rows'],
+      groups: [{
+        ordinal: 1,
+        fingerprint: 'sha16:1111222233334444',
+        rowCount: 2,
+        parentShape: 'same_parent',
+        quantityShape: 'varied',
+        attributeShape: 'all_equal',
+        stableDiscriminators: { any: true, sortLine: true },
+      }],
+    }
+    apiFetchMock.mockImplementation(async (url: string, init?: RequestInit) => {
+      if (url === '/api/integration/adapters') return jsonResponse([])
+      if (url === '/api/integration/external-systems?tenantId=default') return jsonResponse([])
+      if (url === '/api/integration/staging/descriptors') return jsonResponse([])
+      if (url === '/api/integration/table-actions?tenantId=default') return jsonResponse([publicAction])
+      if (url === '/api/integration/table-actions/plm.stock-preparation.pull-bom.v1/conflict-policies?tenantId=default') {
+        return jsonResponse({
+          conflictType: 'duplicate_expanded_key',
+          scope: 'table_scope',
+          policyCount: 1,
+          policies: [{ fingerprint: 'sha16:1111222233334444', policy: 'keep_multiple_rows', scope: 'table_scope' }],
+        })
+      }
+      if (url === '/api/integration/table-actions/plm.stock-preparation.pull-bom.v1/dry-run?tenantId=default') {
+        return jsonResponse({
+          action: publicAction,
+          status: 'ready',
+          dryRunToken: 'resolved-duplicate-token',
+          revision: 'resolved-duplicate-rev',
+          canApply: true,
+          counts: { add: 2, update: 0, skip: 0, inactive: 0, manual_confirm: 0 },
+          evidence: {
+            actionId: publicAction.actionId,
+            projectNoPresent: true,
+            dryRunRevision: 'resolved-duplicate-rev',
+            expansion: { status: 'expanded', rowsExpanded: 2, errorTypes: [] },
+            plan: {
+              counts: { add: 2, update: 0, skip: 0, inactive: 0, manual_confirm: 0 },
+              conflictTypes: [],
+              duplicateExpandedKeyDiagnostics: duplicateDiagnostics,
+              conflictPolicyReview: {
+                conflictType: 'duplicate_expanded_key',
+                defaultPolicy: 'hold',
+                groupCount: 1,
+                configuredPolicyCount: 1,
+                policyCounts: { keep_multiple_rows: 1 },
+                scopeCounts: { table_scope: 1 },
+                selectedPolicies: [{
+                  fingerprint: 'sha16:1111222233334444',
+                  policy: 'keep_multiple_rows',
+                  scope: 'table_scope',
+                }],
+              },
+              duplicateExpandedKeyResolution: {
+                conflictType: 'duplicate_expanded_key',
+                resolvedPolicy: 'keep_multiple_rows',
+                resolvedGroupCount: 1,
+                resolvedRowCount: 2,
+                heldGroupCount: 0,
+                heldRowCount: 0,
+                tableScopeResolvedGroupCount: 1,
+                runOnlyResolvedGroupCount: 0,
+                heldReasonCounts: {},
+                resolvedPolicies: [{
+                  fingerprint: 'sha16:1111222233334444',
+                  policy: 'keep_multiple_rows',
+                  scope: 'table_scope',
+                  discriminator: 'sortLine',
+                  rowCount: 2,
+                  writeEffect: 'add_decisions',
+                }],
+              },
+            },
+          },
+        })
+      }
+      if (url === '/api/integration/table-actions/plm.stock-preparation.pull-bom.v1/apply?tenantId=default') {
+        applyBodies.push(JSON.parse(String(init?.body || '{}')) as Record<string, unknown>)
+        return jsonResponse({ status: 'succeeded', apply: { counts: { created: 2 } }, evidence: { actionId: publicAction.actionId } })
+      }
+      throw new Error(`unexpected URL ${url}`)
+    })
+
+    const View = (await import('../src/views/IntegrationWorkbenchView.vue')).default
+    container = document.createElement('div')
+    document.body.appendChild(container)
+    app = createApp(View as Component)
+    app.component('router-link', {
+      props: ['to'],
+      setup(_props, { slots }) {
+        return () => h('a', slots.default?.())
+      },
+    })
+    app.mount(container)
+    await flushUi(12)
+
+    const projectInput = container.querySelector('[data-testid="table-action-project-no"]') as HTMLInputElement
+    projectInput.value = 'P-DUP'
+    projectInput.dispatchEvent(new Event('input', { bubbles: true }))
+    await flushUi()
+
+    ;(container.querySelector('[data-testid="table-action-dry-run"]') as HTMLButtonElement).click()
+    await flushUi(10)
+
+    const block = container.querySelector('[data-testid="table-action-duplicate-diagnostics"]')?.textContent || ''
+    expect(block).toContain('本次 dry-run 已解决 1 组')
+    expect(block).toContain('当前 keep_multiple_rows · table_scope · resolved · sortLine')
+    expect(block).not.toContain('P-DUP')
+    const applyButton = container.querySelector('[data-testid="table-action-apply"]') as HTMLButtonElement
+    expect(applyButton.disabled).toBe(true)
+    ;(container.querySelector('[data-testid="table-action-accept-duplicate-resolution"]') as HTMLInputElement).click()
+    await flushUi()
+    expect(applyButton.disabled).toBe(false)
+    applyButton.click()
+    await flushUi(6)
+
+    expect(applyBodies).toHaveLength(1)
+    expect(applyBodies[0]).toEqual({
+      parameters: { projectNo: 'P-DUP' },
+      confirm: {
+        dryRunToken: 'resolved-duplicate-token',
+        acceptManualConfirmHold: false,
+        acceptDuplicateResolution: true,
+      },
+    })
+    expect(applyBodies[0]).not.toHaveProperty('sheetId')
+    expect(applyBodies[0]).not.toHaveProperty('source')
+    expect(applyBodies[0]).not.toHaveProperty('target')
+    expect(applyBodies[0]).not.toHaveProperty('plan')
+    expect(applyBodies[0]).not.toHaveProperty('payload')
+    expect(applyBodies[0]).not.toHaveProperty('conflictPolicyReview')
   })
 
   it('C2 large-BOM: renders bounded dry-run state as non-authoritative and blocks apply', async () => {

--- a/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
@@ -766,7 +766,7 @@ Acceptance locks:
   `skip_selected`, and `source_correction_required` are displayed as candidates
   only; no writer infers or applies them.
 
-### 🟡 Duplicate-expanded-key D2 - run/table-scoped policy review (ACTIVE - this PR)
+### ✅ Duplicate-expanded-key D2 - run/table-scoped policy review (DONE - PR #2368, `1bcbfdc97`)
 
 Gated on: Duplicate D1 + explicit opt-in.
 
@@ -800,6 +800,50 @@ Acceptance locks:
   approver identity, credentials, tokens, payloads, or raw SQL.
 - A pending run-only choice requires a fresh dry-run before Apply can be
   enabled.
+
+### 🟡 Duplicate-expanded-key D3 - keep-multiple resolver + reviewed apply (ACTIVE - this PR)
+
+Gated on: Duplicate D2 + explicit opt-in.
+
+Scope:
+
+- Implement the first executable duplicate policy: `keep_multiple_rows`.
+- Resolve only duplicate groups that have an explicit `keep_multiple_rows`
+  policy and a stable row discriminator.
+- Use surgical idempotency keys only for the resolved collision group rows.
+  Clean rows and already-written clean keys keep their original key.
+- Carry the default fail-closed posture forward: no policy, unsupported policy,
+  stale fingerprint, missing stable discriminator, duplicate existing target
+  key, or clean-to-collision transition all stay held.
+- Make previously saved `table_scope` policies become active only through a
+  fresh dry-run that explicitly reports the resolved group count before apply.
+- Require a fresh dry-run token and explicit duplicate-resolution
+  acknowledgement before applying any resolved duplicate groups.
+
+Acceptance locks:
+
+- `keep_multiple_rows` is the only policy that can change C3 decisions in D3.
+  `merge_quantity`, `select_representative`, `skip_selected`, and
+  `source_correction_required` remain review-only/held.
+- A stored `table_scope` policy must not silently activate. The next dry-run
+  must values-free report how many groups it resolves, split by table/run
+  scope, before Apply can proceed.
+- Surgical keys apply only to rows inside the resolved collision group.
+  Non-collision rows preserve their original `idempotencyKey`.
+- Clean-to-collision transitions default to hold. D3 must not silently re-key,
+  orphan, deactivate, or duplicate a row that was previously written under the
+  clean/base key.
+- Apply recomputes from the reviewed dry-run token. Run-only policy choices are
+  token-bound; table-scope policy changes after dry-run invalidate the token.
+- Resolved duplicate groups require an explicit apply acknowledgement; a token
+  alone is not enough.
+- Public evidence remains values-free: fingerprints, policies, scopes,
+  discriminator type, counts, and hold reasons only. It must not expose project
+  number, raw idempotency key, component values, parent/path values,
+  discriminator values, target sheet id, field id, credentials, tokens,
+  payloads, or raw SQL.
+- No PLM write, external database write, K3 path, migration, package, or new
+  policy execution beyond `keep_multiple_rows`.
 
 ## Deferred tracks
 

--- a/docs/development/data-factory-plm-stock-preparation-duplicate-expanded-key-d3-verification-20260607.md
+++ b/docs/development/data-factory-plm-stock-preparation-duplicate-expanded-key-d3-verification-20260607.md
@@ -1,0 +1,98 @@
+# Data Factory PLM Stock Preparation Duplicate Expanded Key D3 Verification - 2026-06-07
+
+## Scope
+
+D3 is the first executable duplicate-expanded-key policy slice.
+
+It implements `keep_multiple_rows` only. Other duplicate policies remain held:
+`merge_quantity`, `select_representative`, `skip_selected`, and
+`source_correction_required`.
+
+## Implementation
+
+- `plugins/plugin-integration-core/lib/stock-preparation-bom-expansion.cjs`
+  carries the configured PLM detail `sortField` into expanded rows as
+  `sortLine`, giving same-parent duplicate rows a stable discriminator when the
+  source schema provides one.
+- `plugins/plugin-integration-core/lib/stock-preparation-conflict-planner.cjs`
+  resolves only duplicate groups with:
+  - selected policy `keep_multiple_rows`;
+  - a stable discriminator (`sourceDetail`, `pathParent`, or `sortLine`);
+  - no existing row under the clean/base idempotency key.
+- Resolved duplicate rows become normal `add` decisions with surgical
+  discriminator keys. C4 still uses the existing add path
+  (find-then-patch/create); no new writer decision type is introduced.
+- `plugins/plugin-integration-core/lib/stock-preparation-table-actions.cjs`
+  binds the reviewed policy state into the dry-run revision:
+  - run-only policy choices are stored in the one-use dry-run token;
+  - table-scope policy changes after dry-run invalidate the token;
+  - resolved duplicate groups require `acceptDuplicateResolution=true`.
+  - public policy-review evidence reflects resolved groups as
+    `add_decisions_require_ack`, while held groups remain
+    `manual_confirm_held`.
+- `apps/web/src/views/IntegrationWorkbenchView.vue` shows resolved/held
+  duplicate group state and requires an explicit checkbox before Apply can send
+  a resolved-duplicate request.
+
+## Guardrails
+
+- Default remains fail-closed `hold`.
+- Clean-to-collision transitions hold by default. D3 does not silently re-key,
+  orphan, deactivate, or duplicate rows that were already written under the
+  clean/base idempotency key.
+- Surgical keys are applied only inside resolved collision groups. Non-collision
+  rows keep their original `idempotencyKey`.
+- Apply still rejects client-supplied C3 plans, C4 payloads, target scopes, and
+  `conflictPolicyReview`.
+- Public evidence is values-free: fingerprints, policy names, scopes,
+  discriminator type, counts, and hold reasons only. No project number, raw
+  idempotency key, component values, parent/path values, discriminator values,
+  target sheet id, field id, credential, token, payload, or raw SQL is exposed.
+- No PLM write, external database write, K3 path, migration, or package change.
+
+## Verification
+
+Commands run:
+
+```bash
+node plugins/plugin-integration-core/__tests__/stock-preparation-conflict-planner.test.cjs
+node plugins/plugin-integration-core/__tests__/stock-preparation-conflict-policies.test.cjs
+node plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
+node plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+pnpm --filter plugin-integration-core test
+pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false
+pnpm --filter @metasheet/web exec vue-tsc --noEmit
+```
+
+Results:
+
+- conflict planner suite: pass.
+- conflict policy suite: pass.
+- table action suite: pass.
+- HTTP route suite: pass.
+- plugin-integration-core full test script: pass.
+- Workbench spec: 29/29 pass.
+- Vue type-check: pass.
+
+## Negative Controls Locked By Tests
+
+- A saved table-scope `keep_multiple_rows` policy is explicitly reported as
+  active on the next dry-run before Apply can proceed.
+- Changing table-scope policy after dry-run invalidates the token.
+- Resolved duplicate groups cannot be applied without
+  `acceptDuplicateResolution=true`.
+- Run-only policy choices are token-bound; Apply does not accept
+  client-supplied `conflictPolicyReview`.
+- Clean-to-collision transitions stay held and do not mark the existing
+  base-key row inactive.
+- Missing stable discriminator stays held.
+- Public resolution evidence remains values-free.
+
+## Deferred
+
+The remaining duplicate policies are not implemented in D3:
+`merge_quantity`, `select_representative`, `skip_selected`, and
+`source_correction_required`.
+
+Large-BOM background expansion/checkpointed apply and production rollout remain
+separate explicit opt-ins.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -2772,8 +2772,8 @@ async function testTableActionConflictPolicyRoutes() {
   const duplicateData = {
     ...tableActionPlmData(),
     DN_PDM_OrderDetailInfo: [
-      { order_id: 'ORDER-1', part_id: 'PART-A', quantity: '2' },
-      { order_id: 'ORDER-1', part_id: 'PART-A', quantity: '3' },
+      { order_id: 'ORDER-1', part_id: 'PART-A', quantity: '2', sort_id: '10' },
+      { order_id: 'ORDER-1', part_id: 'PART-A', quantity: '3', sort_id: '20' },
     ],
   }
   const { services } = createMockServices({
@@ -2853,6 +2853,30 @@ async function testTableActionConflictPolicyRoutes() {
   assert.equal(res.body.data.policies[0].approvedByPresent, true)
   assert.equal(JSON.stringify(res.body.data).includes('sheet_stock_configured'), false, 'policy response hides target sheet id')
   assert.equal(JSON.stringify(res.body.data).includes('user_admin'), false, 'policy response hides approver identity')
+
+  res = await invoke(routes, 'POST', '/api/integration/table-actions/:actionId/dry-run', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID },
+    body: { parameters: { projectNo: 'P-001' } },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.status, 'ready', 'saved keep_multiple_rows policy resolves on the next fresh dry-run')
+  assert.equal(res.body.data.counts.add, 2)
+  assert.equal(res.body.data.counts.manual_confirm, 0)
+  assert.equal(res.body.data.evidence.plan.duplicateExpandedKeyResolution.resolvedGroupCount, 1)
+  assert.equal(res.body.data.evidence.plan.duplicateExpandedKeyResolution.tableScopeResolvedGroupCount, 1)
+  const resolvedToken = res.body.data.dryRunToken
+
+  res = await invoke(routes, 'POST', '/api/integration/table-actions/:actionId/apply', {
+    user: ADMIN_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID },
+    body: {
+      parameters: { projectNo: 'P-001' },
+      confirm: { dryRunToken: resolvedToken },
+    },
+  })
+  assert.equal(res.statusCode, 409)
+  assert.equal(res.body.error.code, 'TABLE_ACTION_DUPLICATE_RESOLUTION_REVIEW_REQUIRED', 'resolved duplicate groups need explicit apply acknowledgement')
 
   res = await invoke(routes, 'POST', '/api/integration/table-actions/:actionId/dry-run', {
     user: READ_USER,

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-conflict-planner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-conflict-planner.test.cjs
@@ -420,6 +420,107 @@ function testDuplicateExpandedKeyDiagnosticsValuesFree() {
   assert.ok(!text.includes('ROOT/PARENT'), 'evidence must not include paths')
 }
 
+function duplicatePolicyReviewFor(baseKey, policy = 'keep_multiple_rows', scope = 'table_scope') {
+  return {
+    conflictType: 'duplicate_expanded_key',
+    selectedPolicies: [{
+      fingerprint: __internals.stableFingerprint(baseKey),
+      policy,
+      scope,
+    }],
+  }
+}
+
+function testKeepMultipleRowsResolvesSurgically() {
+  const duplicateKey = 'DUP-CROSS-PARENT-KEY'
+  const duplicateA = row({
+    idempotencyKey: duplicateKey,
+    componentSourceId: 'PART-DUP-A',
+    parentSourceId: 'PARENT-A',
+    path: 'ROOT/PARENT-A/PART-DUP',
+    pathTokens: ['ROOT', 'PARENT-A', 'PART-DUP'],
+  })
+  const duplicateB = row({
+    ...duplicateA,
+    idempotencyKey: duplicateKey,
+    componentSourceId: 'PART-DUP-B',
+    parentSourceId: 'PARENT-B',
+    path: 'ROOT/PARENT-B/PART-DUP',
+    pathTokens: ['ROOT', 'PARENT-B', 'PART-DUP'],
+  })
+  const clean = row({ componentSourceId: 'PART-CLEAN', pathTokens: ['PART-CLEAN'] })
+
+  const plan = planStockPreparationConflicts({
+    expandedRows: [duplicateA, duplicateB, clean],
+    existingRows: [],
+    duplicatePolicyReview: duplicatePolicyReviewFor(duplicateKey, 'keep_multiple_rows', 'table_scope'),
+    runId: 'run-d3-resolve',
+    plannedAt: '2026-06-07T09:00:00.000Z',
+  })
+
+  assert.equal(plan.valid, true, 'resolved duplicate groups should not leave manual_confirm')
+  assert.equal(plan.counts.add, 3)
+  assert.equal(plan.counts.manual_confirm, 0)
+  const addKeys = byDecision(plan, DECISIONS.ADD).map((entry) => entry.idempotencyKey)
+  const duplicateKeys = addKeys.filter((key) => key.startsWith(`${duplicateKey}::duplicate:pathParent:`))
+  assert.equal(duplicateKeys.length, 2, 'only the duplicate group receives surgical discriminator keys')
+  assert.equal(new Set(duplicateKeys).size, 2, 'resolved duplicate keys are distinct')
+  assert.ok(addKeys.includes(clean.idempotencyKey), 'clean row keeps its original idempotency key')
+
+  const resolution = summarizeConflictPlanForEvidence(plan).duplicateExpandedKeyResolution
+  assert.equal(resolution.resolvedGroupCount, 1)
+  assert.equal(resolution.resolvedRowCount, 2)
+  assert.equal(resolution.tableScopeResolvedGroupCount, 1, 'saved table-scope policy activation is explicit')
+  assert.equal(resolution.heldGroupCount, 0)
+  assert.equal(resolution.resolvedPolicies[0].discriminator, 'pathParent')
+  const text = JSON.stringify(resolution)
+  assert.ok(!text.includes('PARENT-A'), 'resolution evidence hides parent values')
+  assert.ok(!text.includes('ROOT/PARENT'), 'resolution evidence hides paths')
+}
+
+function testKeepMultipleRowsCleanToCollisionHolds() {
+  const duplicateKey = 'DUP-CLEAN-TO-COLLISION'
+  const duplicateA = row({ idempotencyKey: duplicateKey, componentSourceId: 'PART-DUP-A', parentSourceId: 'PARENT-A', pathTokens: ['ROOT', 'PARENT-A', 'PART-DUP'] })
+  const duplicateB = row({ ...duplicateA, componentSourceId: 'PART-DUP-B', parentSourceId: 'PARENT-B', pathTokens: ['ROOT', 'PARENT-B', 'PART-DUP'] })
+
+  const plan = planStockPreparationConflicts({
+    expandedRows: [duplicateA, duplicateB],
+    existingRows: [{ ...duplicateA, idempotencyKey: duplicateKey, notes: 'already written clean row' }],
+    duplicatePolicyReview: duplicatePolicyReviewFor(duplicateKey, 'keep_multiple_rows', 'table_scope'),
+    runId: 'run-d3-clean-collision',
+    plannedAt: '2026-06-07T09:00:00.000Z',
+  })
+
+  assert.equal(plan.valid, false)
+  assert.equal(plan.counts.add, 0, 'clean-to-collision must not silently add re-keyed rows')
+  assert.equal(plan.counts.inactive, 0, 'clean-to-collision must not orphan the existing base-key row')
+  assert.equal(plan.counts.manual_confirm, 1)
+  const resolution = summarizeConflictPlanForEvidence(plan).duplicateExpandedKeyResolution
+  assert.equal(resolution.heldGroupCount, 1)
+  assert.equal(resolution.heldReasonCounts.clean_to_collision_requires_review, 1)
+}
+
+function testKeepMultipleRowsWithoutStableDiscriminatorHolds() {
+  const duplicateKey = 'DUP-NO-STABLE-DISCRIMINATOR'
+  const duplicateA = row({ idempotencyKey: duplicateKey, componentSourceId: 'PART-DUP', pathTokens: ['PART-DUP'] })
+  const duplicateB = { ...duplicateA }
+
+  const plan = planStockPreparationConflicts({
+    expandedRows: [duplicateA, duplicateB],
+    existingRows: [],
+    duplicatePolicyReview: duplicatePolicyReviewFor(duplicateKey, 'keep_multiple_rows', 'run_only'),
+    runId: 'run-d3-no-discriminator',
+    plannedAt: '2026-06-07T09:00:00.000Z',
+  })
+
+  assert.equal(plan.valid, false)
+  assert.equal(plan.counts.add, 0)
+  assert.equal(plan.counts.manual_confirm, 1)
+  const resolution = summarizeConflictPlanForEvidence(plan).duplicateExpandedKeyResolution
+  assert.equal(resolution.runOnlyResolvedGroupCount, 0)
+  assert.equal(resolution.heldReasonCounts.missing_stable_discriminator, 1)
+}
+
 function main() {
   testAddUpdateSkipInactive()
   testRowErrorsDoNotAbortGoodRows()
@@ -431,6 +532,9 @@ function main() {
   testTemplateNormalizationDoesNotHideRealIdentityOrLineageConflicts()
   testValuesFreeEvidence()
   testDuplicateExpandedKeyDiagnosticsValuesFree()
+  testKeepMultipleRowsResolvesSurgically()
+  testKeepMultipleRowsCleanToCollisionHolds()
+  testKeepMultipleRowsWithoutStableDiscriminatorHolds()
 
   console.log('stock-preparation-conflict-planner.test.cjs OK')
 }

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
@@ -20,7 +20,11 @@ const {
 } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-templates.cjs'))
 const {
   DECISIONS,
+  __internals: plannerInternals,
 } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-conflict-planner.cjs'))
+const {
+  saveTableScopeConflictPolicies,
+} = require(path.join(__dirname, '..', 'lib', 'stock-preparation-conflict-policies.cjs'))
 
 const PHYSICAL_FIELD_ID_MAP = Object.fromEntries(
   STOCK_PREPARATION_MAIN_TABLE_TEMPLATE.fields.map((field) => [field.id, `fld_${field.id}`]),
@@ -84,6 +88,25 @@ function childBomPlmData(overrides = {}) {
     DN_PDM_BomDetailsInfo: [{ bom_pid: 'BOM-A', part_id: 'PART-B', Bom_ExAttr1: '3' }],
     ...overrides,
   })
+}
+
+function duplicateRootPlmData(overrides = {}) {
+  return basePlmData({
+    DN_PDM_OrderDetailInfo: [
+      { order_id: 'ORDER-1', part_id: 'PART-A', quantity: '2', sort_id: '10' },
+      { order_id: 'ORDER-1', part_id: 'PART-A', quantity: '3', sort_id: '20' },
+    ],
+    ...overrides,
+  })
+}
+
+function rootPartFingerprint(projectNo = 'P-001', componentSourceId = 'PART-A') {
+  return plannerInternals.stableFingerprint(JSON.stringify({
+    projectNo,
+    componentSourceId,
+    parentSourceId: null,
+    path: [componentSourceId],
+  }))
 }
 
 function createSourceAdapter(data = basePlmData()) {
@@ -397,6 +420,155 @@ async function testApplyRequiresTokenRecomputesAndScopesTarget() {
   )
 }
 
+async function testSavedKeepMultipleRowsPolicyRequiresFreshReviewAndAppliesResolvedRows() {
+  const storage = createMemoryStorage()
+  const source = createSourceAdapter(duplicateRootPlmData())
+  const records = createRecordsApi()
+  const action = normalizeStockPreparationActionConfig(baseAction())
+  const fingerprint = rootPartFingerprint()
+
+  await saveTableScopeConflictPolicies({
+    action,
+    policyStore: storage,
+    approver: 'admin-user',
+    request: {
+      conflictType: 'duplicate_expanded_key',
+      policies: [{ fingerprint, policy: 'keep_multiple_rows' }],
+    },
+  })
+
+  const dryRun = await dryRunStockPreparationAction({
+    action,
+    parameters: { projectNo: 'P-001' },
+    sourceAdapter: source.adapter,
+    recordsApi: records.recordsApi,
+    tokenStore: storage,
+    policyStore: storage,
+    plannedAt: '2026-06-07T09:00:00.000Z',
+  })
+
+  assert.equal(dryRun.status, 'ready')
+  assert.equal(dryRun.counts.add, 2)
+  assert.equal(dryRun.counts.manual_confirm, 0)
+  assert.equal(typeof dryRun.dryRunToken, 'string')
+  const resolution = dryRun.evidence.plan.duplicateExpandedKeyResolution
+  assert.equal(resolution.resolvedGroupCount, 1)
+  assert.equal(resolution.resolvedRowCount, 2)
+  assert.equal(resolution.tableScopeResolvedGroupCount, 1, 'previously saved table-scope policy is explicitly shown as active')
+  assert.equal(resolution.resolvedPolicies[0].discriminator, 'sortLine')
+  assert.equal(dryRun.evidence.plan.conflictPolicyReview.writeEffect, 'add_decisions_require_ack')
+  assert.equal(dryRun.evidence.plan.conflictPolicyReview.selectedPolicies[0].scope, 'table_scope')
+  assert.equal(dryRun.evidence.plan.conflictPolicyReview.selectedPolicies[0].policy, 'keep_multiple_rows')
+  assert.equal(dryRun.evidence.plan.conflictPolicyReview.selectedPolicies[0].writeEffect, 'add_decisions_require_ack')
+  assert.equal(JSON.stringify(dryRun.evidence).includes('P-001'), false, 'duplicate resolution evidence hides project value')
+  assert.equal(JSON.stringify(dryRun.evidence).includes('sort_id'), false, 'duplicate resolution evidence hides source column internals')
+
+  await saveTableScopeConflictPolicies({
+    action,
+    policyStore: storage,
+    approver: 'admin-user',
+    request: {
+      conflictType: 'duplicate_expanded_key',
+      policies: [{ fingerprint, policy: 'hold' }],
+    },
+  })
+  await assert.rejects(
+    () => applyStockPreparationAction({
+      action,
+      parameters: { projectNo: 'P-001' },
+      dryRunToken: dryRun.dryRunToken,
+      sourceAdapter: source.adapter,
+      recordsApi: records.recordsApi,
+      tokenStore: storage,
+      policyStore: storage,
+      permission: 'write',
+      acceptDuplicateResolution: true,
+    }),
+    /does not match the current dry-run revision/,
+    'saved table-scope policy changes after review invalidate the dry-run token',
+  )
+
+  await saveTableScopeConflictPolicies({
+    action,
+    policyStore: storage,
+    approver: 'admin-user',
+    request: {
+      conflictType: 'duplicate_expanded_key',
+      policies: [{ fingerprint, policy: 'keep_multiple_rows' }],
+    },
+  })
+  const unacknowledgedDryRun = await dryRunStockPreparationAction({
+    action,
+    parameters: { projectNo: 'P-001' },
+    sourceAdapter: source.adapter,
+    recordsApi: records.recordsApi,
+    tokenStore: storage,
+    policyStore: storage,
+    plannedAt: '2026-06-07T09:00:30.000Z',
+  })
+  await assert.rejects(
+    () => applyStockPreparationAction({
+      action,
+      parameters: { projectNo: 'P-001' },
+      dryRunToken: unacknowledgedDryRun.dryRunToken,
+      sourceAdapter: source.adapter,
+      recordsApi: records.recordsApi,
+      tokenStore: storage,
+      policyStore: storage,
+      permission: 'write',
+    }),
+    /acceptDuplicateResolution=true/,
+    'resolved duplicate groups require explicit apply acknowledgement',
+  )
+
+  const reviewedDryRun = await dryRunStockPreparationAction({
+    action,
+    parameters: { projectNo: 'P-001' },
+    sourceAdapter: source.adapter,
+    recordsApi: records.recordsApi,
+    tokenStore: storage,
+    policyStore: storage,
+    plannedAt: '2026-06-07T09:01:00.000Z',
+  })
+  const result = await applyStockPreparationAction({
+    action,
+    parameters: { projectNo: 'P-001' },
+    dryRunToken: reviewedDryRun.dryRunToken,
+    sourceAdapter: source.adapter,
+    recordsApi: records.recordsApi,
+    tokenStore: storage,
+    policyStore: storage,
+    permission: 'write',
+    acceptDuplicateResolution: true,
+  })
+
+  assert.equal(result.status, 'succeeded')
+  assert.equal(result.apply.counts.created, 2)
+  const createCalls = records.calls.filter((call) => call[0] === 'createRecord')
+  assert.equal(createCalls.length, 2)
+  assert.equal(new Set(createCalls.map((call) => call[1].data.idempotencyKey)).size, 2)
+  assert.equal(createCalls.every((call) => String(call[1].data.idempotencyKey).includes('::duplicate:sortLine:')), true)
+  assert.equal(JSON.stringify(result.evidence).includes('P-001'), false, 'apply evidence hides project value')
+  assert.equal(JSON.stringify(result.evidence).includes('A-001'), false, 'apply evidence hides component code')
+
+  const repullDryRun = await dryRunStockPreparationAction({
+    action,
+    parameters: { projectNo: 'P-001' },
+    sourceAdapter: source.adapter,
+    recordsApi: records.recordsApi,
+    tokenStore: storage,
+    policyStore: storage,
+    plannedAt: '2026-06-07T09:02:00.000Z',
+  })
+  const repullResolution = repullDryRun.evidence.plan.duplicateExpandedKeyResolution
+  assert.equal(repullDryRun.status, 'ready')
+  assert.equal(repullDryRun.counts.add, 0, 'resolved duplicate rows re-pull by deterministic keys instead of adding again')
+  assert.equal(repullDryRun.counts.manual_confirm, 0, 'resolved-key rows are not misclassified as base-key clean-to-collision')
+  assert.equal(repullDryRun.counts.skip + repullDryRun.counts.update, 2, 're-pull reaches skip/update, not duplicate add')
+  assert.equal(repullResolution.resolvedGroupCount, 1)
+  assert.equal(repullResolution.heldReasonCounts.clean_to_collision_requires_review || 0, 0)
+}
+
 async function testLargeBomBoundedDryRunBlocksApplyToken() {
   const source = createSourceAdapter(childBomPlmData())
   const records = createRecordsApi()
@@ -642,6 +814,7 @@ async function main() {
   await testBridgeSourceKindRequiresExplicitMatchingReadPlanAndCanDryRun()
   await testTargetFieldMapIncompleteFailsBeforeReads()
   await testApplyRequiresTokenRecomputesAndScopesTarget()
+  await testSavedKeepMultipleRowsPolicyRequiresFreshReviewAndAppliesResolvedRows()
   await testLargeBomBoundedDryRunBlocksApplyToken()
   await testReadPageLimitBoundedDryRunAndDepthHardFailureStayDistinct()
   await testApplyNormalizesNumericPlmDisplayFieldsBeforeCreate()

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -1366,10 +1366,12 @@ function createHandlers(services, options = {}) {
         parameters: body.parameters,
         dryRunToken: confirm.dryRunToken,
         acceptManualConfirmHold: confirm.acceptManualConfirmHold === true,
+        acceptDuplicateResolution: confirm.acceptDuplicateResolution === true,
         permission: applyPermissionForUser(user),
         sourceAdapter,
         recordsApi: getMultitableRecordsApi(),
         tokenStore: context.storage,
+        policyStore: context.storage,
       }))
     },
 

--- a/plugins/plugin-integration-core/lib/stock-preparation-bom-expansion.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-bom-expansion.cjs
@@ -492,10 +492,10 @@ function makeSummary({ projectNoPresent, matchField, status, rowsExpanded, rootM
   return summary
 }
 
-function createRow({ projectNo, parentSourceId, pathTokens, depth, partRow, rawQuantity, totalQuantity, active }) {
+function createRow({ projectNo, parentSourceId, pathTokens, depth, partRow, rawQuantity, totalQuantity, active, sortLine }) {
   const componentSourceId = toKey(readField(partRow, 'OBJ_ID'))
   const path = makePath(pathTokens)
-  return {
+  const row = {
     projectNo,
     idempotencyKey: makeIdempotencyKey(projectNo, componentSourceId, parentSourceId, pathTokens),
     componentSourceId,
@@ -510,9 +510,11 @@ function createRow({ projectNo, parentSourceId, pathTokens, depth, partRow, rawQ
     totalQuantity,
     active,
   }
+  if (!isBlank(sortLine)) row.sortLine = sortLine
+  return row
 }
 
-function rowFromPart(plan, { projectNo, parentSourceId, pathTokens, depth, partRow, rawQuantity, totalQuantity, active }) {
+function rowFromPart(plan, { projectNo, parentSourceId, pathTokens, depth, partRow, rawQuantity, totalQuantity, active, sortLine }) {
   const componentSourceId = toKey(readField(partRow, plan.part.idField))
   if (componentSourceId === null) {
     return {
@@ -536,6 +538,7 @@ function rowFromPart(plan, { projectNo, parentSourceId, pathTokens, depth, partR
       rawQuantity,
       totalQuantity,
       active,
+      sortLine,
     }),
     componentSourceId,
     sourceVersion: normalizedPart.SysVer,
@@ -739,6 +742,7 @@ async function expandPlmProjectBom(input = {}) {
           rawQuantity: qty.value,
           totalQuantity: parentRow.totalQuantity * qty.value,
           active: true,
+          sortLine: plan.bomDetail.sortField ? readField(detail, plan.bomDetail.sortField) : undefined,
         })
         if (rowResult.error) {
           addRowError(rowResult.error)
@@ -805,6 +809,7 @@ async function expandPlmProjectBom(input = {}) {
             rawQuantity: qty.value,
             totalQuantity: qty.value,
             active: true,
+            sortLine: plan.orderDetail.sortField ? readField(detail, plan.orderDetail.sortField) : undefined,
           })
           if (rowResult.error) {
             addRowError(rowResult.error)

--- a/plugins/plugin-integration-core/lib/stock-preparation-conflict-planner.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-conflict-planner.cjs
@@ -378,6 +378,201 @@ function duplicateExpandedKeyDiagnostics(groupedRows) {
   }
 }
 
+function duplicateExpandedKeyDiagnosticsForRows(rows) {
+  return duplicateExpandedKeyDiagnostics(groupByKey(normalizeRows(rows, 'expandedRows')).keyed)
+}
+
+function duplicatePolicySelections(review) {
+  const selections = new Map()
+  const rows = isPlainObject(review) && Array.isArray(review.selectedPolicies)
+    ? review.selectedPolicies
+    : []
+  for (const row of rows) {
+    if (!isPlainObject(row)) continue
+    if (typeof row.fingerprint !== 'string' || typeof row.policy !== 'string') continue
+    selections.set(row.fingerprint, {
+      policy: row.policy,
+      scope: typeof row.scope === 'string' ? row.scope : 'default',
+    })
+  }
+  return selections
+}
+
+function duplicateGroupDiscriminator(rows) {
+  if (hasDistinctStableDiscriminator(rows, DUPLICATE_SOURCE_DETAIL_FIELDS)) {
+    return {
+      kind: 'sourceDetail',
+      valueForRow: (row) => firstPresent(row, DUPLICATE_SOURCE_DETAIL_FIELDS),
+    }
+  }
+  if (rows.every(hasParentContext) && distinctCount(rows, parentContextKey) === rows.length) {
+    return {
+      kind: 'pathParent',
+      valueForRow: parentContext,
+    }
+  }
+  if (hasDistinctStableDiscriminator(rows, DUPLICATE_SORT_LINE_FIELDS)) {
+    return {
+      kind: 'sortLine',
+      valueForRow: (row) => firstPresent(row, DUPLICATE_SORT_LINE_FIELDS),
+    }
+  }
+  return null
+}
+
+function duplicateResolvedKey(baseKey, groupFingerprint, discriminatorKind, discriminatorValue) {
+  const discriminatorHash = stableFingerprint(`${groupFingerprint}\0${discriminatorKind}\0${stableStringify(stableValue(discriminatorValue))}`)
+  return `${baseKey}::duplicate:${discriminatorKind}:${discriminatorHash}`
+}
+
+function emptyDuplicateResolutionSummary() {
+  return {
+    conflictType: 'duplicate_expanded_key',
+    resolvedPolicy: 'keep_multiple_rows',
+    resolvedGroupCount: 0,
+    resolvedRowCount: 0,
+    heldGroupCount: 0,
+    heldRowCount: 0,
+    tableScopeResolvedGroupCount: 0,
+    runOnlyResolvedGroupCount: 0,
+    heldReasonCounts: {},
+    resolvedPolicies: [],
+    heldPolicies: [],
+  }
+}
+
+function addHeldDuplicateResolution(summary, { fingerprint, rows, policy, scope, reason }) {
+  summary.heldGroupCount += 1
+  summary.heldRowCount += rows.length
+  summary.heldReasonCounts[reason] = (summary.heldReasonCounts[reason] || 0) + 1
+  summary.heldPolicies.push({
+    fingerprint,
+    policy,
+    scope,
+    reason,
+    rowCount: rows.length,
+  })
+}
+
+function addResolvedDuplicateResolution(summary, { fingerprint, rows, policy, scope, discriminatorKind }) {
+  summary.resolvedGroupCount += 1
+  summary.resolvedRowCount += rows.length
+  if (scope === 'table_scope') summary.tableScopeResolvedGroupCount += 1
+  if (scope === 'run_only') summary.runOnlyResolvedGroupCount += 1
+  summary.resolvedPolicies.push({
+    fingerprint,
+    policy,
+    scope,
+    discriminator: discriminatorKind,
+    rowCount: rows.length,
+    writeEffect: 'add_decisions',
+  })
+}
+
+function compactDuplicateResolutionSummary(summary) {
+  if (!summary || (summary.resolvedGroupCount === 0 && summary.heldGroupCount === 0)) return undefined
+  const out = {
+    conflictType: summary.conflictType,
+    resolvedPolicy: summary.resolvedPolicy,
+    resolvedGroupCount: summary.resolvedGroupCount,
+    resolvedRowCount: summary.resolvedRowCount,
+    heldGroupCount: summary.heldGroupCount,
+    heldRowCount: summary.heldRowCount,
+    tableScopeResolvedGroupCount: summary.tableScopeResolvedGroupCount,
+    runOnlyResolvedGroupCount: summary.runOnlyResolvedGroupCount,
+    heldReasonCounts: { ...summary.heldReasonCounts },
+  }
+  if (summary.resolvedPolicies.length) out.resolvedPolicies = summary.resolvedPolicies.map((row) => ({ ...row }))
+  if (summary.heldPolicies.length) out.heldPolicies = summary.heldPolicies.map((row) => ({ ...row }))
+  return out
+}
+
+function resolveDuplicateExpandedRows({ expandedKeyed, existingKeyed, duplicatePolicyReview }) {
+  const selections = duplicatePolicySelections(duplicatePolicyReview)
+  const keyed = new Map()
+  const duplicateExpandedKeys = new Set()
+  const resolution = emptyDuplicateResolutionSummary()
+
+  for (const [key, rows] of expandedKeyed.entries()) {
+    if (rows.length <= 1) {
+      keyed.set(key, rows)
+      continue
+    }
+
+    const fingerprint = stableFingerprint(key)
+    const selected = selections.get(fingerprint) || { policy: 'hold', scope: 'default' }
+    if (selected.policy !== 'keep_multiple_rows') {
+      duplicateExpandedKeys.add(key)
+      addHeldDuplicateResolution(resolution, {
+        fingerprint,
+        rows,
+        policy: selected.policy,
+        scope: selected.scope,
+        reason: selected.policy === 'hold' ? 'default_hold' : 'unsupported_policy',
+      })
+      continue
+    }
+
+    if (existingKeyed.has(key)) {
+      duplicateExpandedKeys.add(key)
+      addHeldDuplicateResolution(resolution, {
+        fingerprint,
+        rows,
+        policy: selected.policy,
+        scope: selected.scope,
+        reason: 'clean_to_collision_requires_review',
+      })
+      continue
+    }
+
+    const discriminator = duplicateGroupDiscriminator(rows)
+    if (!discriminator) {
+      duplicateExpandedKeys.add(key)
+      addHeldDuplicateResolution(resolution, {
+        fingerprint,
+        rows,
+        policy: selected.policy,
+        scope: selected.scope,
+        reason: 'missing_stable_discriminator',
+      })
+      continue
+    }
+
+    const resolvedRows = rows.map((row) => {
+      const discriminatorValue = discriminator.valueForRow(row)
+      const resolvedKey = duplicateResolvedKey(key, fingerprint, discriminator.kind, discriminatorValue)
+      return { ...row, idempotencyKey: resolvedKey }
+    })
+    const uniqueResolvedKeys = new Set(resolvedRows.map((row) => row.idempotencyKey))
+    if (uniqueResolvedKeys.size !== rows.length) {
+      duplicateExpandedKeys.add(key)
+      addHeldDuplicateResolution(resolution, {
+        fingerprint,
+        rows,
+        policy: selected.policy,
+        scope: selected.scope,
+        reason: 'non_unique_resolved_key',
+      })
+      continue
+    }
+
+    for (const row of resolvedRows) keyed.set(row.idempotencyKey, [row])
+    addResolvedDuplicateResolution(resolution, {
+      fingerprint,
+      rows,
+      policy: selected.policy,
+      scope: selected.scope,
+      discriminatorKind: discriminator.kind,
+    })
+  }
+
+  return {
+    keyed,
+    duplicateExpandedKeys,
+    resolution: compactDuplicateResolutionSummary(resolution),
+  }
+}
+
 function changedFields(nextRow, existingRow, fields, templateFields = new Map()) {
   return fields.filter((field) => !valuesEqualForTemplateField(nextRow[field], existingRow[field], templateFields.get(field)))
 }
@@ -522,6 +717,11 @@ function planStockPreparationConflicts(input = {}) {
 
   const expanded = groupByKey(expandedRows)
   const existing = groupByKey(existingRows)
+  const resolvedExpanded = resolveDuplicateExpandedRows({
+    expandedKeyed: expanded.keyed,
+    existingKeyed: existing.keyed,
+    duplicatePolicyReview: input.duplicatePolicyReview,
+  })
 
   for (const row of expanded.missing) {
     manualConfirm(decisions, counts, {
@@ -547,10 +747,10 @@ function planStockPreparationConflicts(input = {}) {
     })
   }
 
-  const duplicateExpandedKeys = new Set()
-  for (const [key, rows] of expanded.keyed.entries()) {
+  const duplicateExpandedKeys = resolvedExpanded.duplicateExpandedKeys
+  for (const key of duplicateExpandedKeys) {
+    const rows = expanded.keyed.get(key) || []
     if (rows.length > 1) {
-      duplicateExpandedKeys.add(key)
       manualConfirm(decisions, counts, {
         idempotencyKey: key,
         type: 'duplicate_expanded_key',
@@ -572,7 +772,7 @@ function planStockPreparationConflicts(input = {}) {
     }
   }
 
-  for (const [key, rows] of expanded.keyed.entries()) {
+  for (const [key, rows] of resolvedExpanded.keyed.entries()) {
     if (duplicateExpandedKeys.has(key) || duplicateExistingKeys.has(key)) continue
     const row = rows[0]
     const existingGroup = existing.keyed.get(key)
@@ -623,7 +823,7 @@ function planStockPreparationConflicts(input = {}) {
   }
 
   for (const [key, rows] of existing.keyed.entries()) {
-    if (expanded.keyed.has(key) || duplicateExistingKeys.has(key)) continue
+    if (expanded.keyed.has(key) || resolvedExpanded.keyed.has(key) || duplicateExistingKeys.has(key)) continue
     const existingRow = rows[0]
     if (existingRow.active === false) {
       addDecision(decisions, counts, {
@@ -653,6 +853,7 @@ function planStockPreparationConflicts(input = {}) {
       plmSystemFields: plmFields.slice(),
       conflictTypes: Array.from(new Set(decisions.map((decision) => decision.conflictSummary && decision.conflictSummary.type).filter(Boolean))).sort(),
       duplicateExpandedKeyDiagnostics: duplicateExpandedKeyDiagnostics(expanded.keyed),
+      duplicateExpandedKeyResolution: resolvedExpanded.resolution,
     },
   }
 }
@@ -673,6 +874,9 @@ function summarizeConflictPlanForEvidence(plan = {}) {
     duplicateExpandedKeyDiagnostics: isPlainObject(summary.duplicateExpandedKeyDiagnostics)
       ? JSON.parse(JSON.stringify(summary.duplicateExpandedKeyDiagnostics))
       : undefined,
+    duplicateExpandedKeyResolution: isPlainObject(summary.duplicateExpandedKeyResolution)
+      ? JSON.parse(JSON.stringify(summary.duplicateExpandedKeyResolution))
+      : undefined,
   }
 }
 
@@ -683,10 +887,14 @@ module.exports = {
   IDENTITY_FIELD_IDS,
   DUPLICATE_EXPANDED_KEY_POLICIES,
   StockPreparationConflictPlannerError,
+  duplicateExpandedKeyDiagnosticsForRows,
   planStockPreparationConflicts,
   summarizeConflictPlanForEvidence,
   __internals: {
     changedFields,
+    duplicateExpandedKeyDiagnosticsForRows,
+    duplicateGroupDiscriminator,
+    duplicateResolvedKey,
     fieldMapForTemplate,
     groupByKey,
     normalizeStrategy,

--- a/plugins/plugin-integration-core/lib/stock-preparation-conflict-policies.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-conflict-policies.cjs
@@ -1,8 +1,8 @@
 'use strict'
 
-// #2343 D2: duplicate-expanded-key policy review/persistence.
-// This module records operator/admin policy intent only. It never changes C3
-// planner decisions or C4 writes; duplicate rows stay manual_confirm held.
+// #2343 D2/D3: duplicate-expanded-key policy review/persistence.
+// This module records operator/admin policy intent only. The D3 planner decides
+// whether a reviewed policy can resolve rows; this module never writes.
 
 const crypto = require('node:crypto')
 

--- a/plugins/plugin-integration-core/lib/stock-preparation-table-actions.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-table-actions.cjs
@@ -15,6 +15,7 @@ const {
 } = require('./stock-preparation-bom-expansion.cjs')
 const {
   DECISIONS,
+  duplicateExpandedKeyDiagnosticsForRows,
   planStockPreparationConflicts,
   summarizeConflictPlanForEvidence,
 } = require('./stock-preparation-conflict-planner.cjs')
@@ -397,7 +398,7 @@ function emptyPlan() {
   }
 }
 
-function buildRevision({ action, parameters, expansion, existingRows }) {
+function buildRevision({ action, parameters, expansion, existingRows, conflictPolicyReview, plan }) {
   return hashJson({
     actionId: action.actionId,
     parameters,
@@ -413,7 +414,63 @@ function buildRevision({ action, parameters, expansion, existingRows }) {
       rowErrors: expansion.rowErrors,
     },
     existingRows,
+    conflictPolicyReview: conflictPolicyReview || null,
+    plan: plan
+      ? {
+          counts: plan.counts,
+          valid: plan.valid === true,
+          conflictTypes: plan.summary && plan.summary.conflictTypes,
+          duplicateExpandedKeyResolution: plan.summary && plan.summary.duplicateExpandedKeyResolution,
+        }
+      : null,
   })
+}
+
+function duplicateReviewEffectSummary(resolution) {
+  if (!isPlainObject(resolution) || resolution.conflictType !== 'duplicate_expanded_key') return null
+  const effects = new Map()
+  const resolved = Array.isArray(resolution.resolvedPolicies) ? resolution.resolvedPolicies : []
+  for (const row of resolved) {
+    if (isPlainObject(row) && typeof row.fingerprint === 'string') effects.set(row.fingerprint, 'add_decisions_require_ack')
+  }
+  const held = Array.isArray(resolution.heldPolicies) ? resolution.heldPolicies : []
+  for (const row of held) {
+    if (isPlainObject(row) && typeof row.fingerprint === 'string' && !effects.has(row.fingerprint)) {
+      effects.set(row.fingerprint, 'manual_confirm_held')
+    }
+  }
+  if (effects.size === 0) return null
+  return effects
+}
+
+function conflictPolicyReviewForEvidence(review, plan) {
+  if (!isPlainObject(review)) return review
+  const resolution = plan && plan.summary && plan.summary.duplicateExpandedKeyResolution
+  const effects = duplicateReviewEffectSummary(resolution)
+  if (!effects) return review
+  let resolvedCount = 0
+  let heldCount = 0
+  const selectedPolicies = Array.isArray(review.selectedPolicies)
+    ? review.selectedPolicies.map((row) => {
+        if (!isPlainObject(row) || typeof row.fingerprint !== 'string') return row
+        const writeEffect = effects.get(row.fingerprint)
+        if (!writeEffect) return { ...row }
+        if (writeEffect === 'add_decisions_require_ack') resolvedCount += 1
+        if (writeEffect === 'manual_confirm_held') heldCount += 1
+        return { ...row, writeEffect }
+      })
+    : review.selectedPolicies
+  let writeEffect = review.writeEffect
+  if (resolvedCount > 0 && heldCount > 0) {
+    writeEffect = 'mixed_duplicate_resolution'
+  } else if (resolvedCount > 0) {
+    writeEffect = 'add_decisions_require_ack'
+  }
+  return {
+    ...review,
+    writeEffect,
+    selectedPolicies,
+  }
 }
 
 function tokenStoreKey(token) {
@@ -454,13 +511,13 @@ async function consumeDryRunToken(tokenStore, token, expected) {
   if (!Number.isNaN(expiresAt) && expiresAt < Date.now()) {
     throw new StockPreparationTableActionError(409, 'TABLE_ACTION_DRY_RUN_TOKEN_INVALID', 'dryRunToken is expired')
   }
-  if (stored.actionId !== expected.actionId || stored.parametersHash !== expected.parametersHash || stored.revision !== expected.revision) {
+  if (stored.actionId !== expected.actionId || stored.parametersHash !== expected.parametersHash || (expected.revision && stored.revision !== expected.revision)) {
     throw new StockPreparationTableActionError(409, 'TABLE_ACTION_DRY_RUN_TOKEN_MISMATCH', 'dryRunToken does not match the current dry-run revision')
   }
   return stored
 }
 
-async function computeDryRun({ action, parameters, sourceAdapter, recordsApi, plannedAt, runId }) {
+async function computeDryRun({ action, parameters, sourceAdapter, recordsApi, plannedAt, runId, runOnlyReview, tableScopeReview }) {
   const expansion = await expandPlmProjectBom({
     sourceAdapter,
     projectNo: parameters.projectNo,
@@ -478,7 +535,12 @@ async function computeDryRun({ action, parameters, sourceAdapter, recordsApi, pl
     return { expansion, existingRows: [], plan: emptyPlan(), revision, canApply: false, hasGlobalErrors }
   }
   const existingRows = await readExistingStockPreparationRows(recordsApi, action.target, parameters.projectNo)
-  const revision = buildRevision({ action, parameters, expansion, existingRows })
+  const duplicateDiagnostics = duplicateExpandedKeyDiagnosticsForRows(expansion.rows)
+  const conflictPolicyReview = buildConflictPolicyReview({
+    diagnostics: duplicateDiagnostics,
+    runOnlyReview,
+    tableScopeReview,
+  })
   const plan = planStockPreparationConflicts({
     template: action.template,
     conflictStrategy: action.conflictStrategy,
@@ -487,7 +549,9 @@ async function computeDryRun({ action, parameters, sourceAdapter, recordsApi, pl
     rowErrors: expansion.rowErrors,
     runId: runId || `table-action:${action.actionId}`,
     plannedAt: plannedAt || new Date().toISOString(),
+    duplicatePolicyReview: conflictPolicyReview,
   })
+  const revision = buildRevision({ action, parameters, expansion, existingRows, conflictPolicyReview, plan })
   return {
     expansion,
     existingRows,
@@ -495,12 +559,13 @@ async function computeDryRun({ action, parameters, sourceAdapter, recordsApi, pl
     revision,
     canApply: !hasGlobalErrors,
     hasGlobalErrors,
+    conflictPolicyReview,
   }
 }
 
 function evidenceForDryRun({ action, parameters, expansion, plan, revision, canApply, conflictPolicyReview }) {
   const planEvidence = summarizeConflictPlanForEvidence(plan)
-  if (planEvidence && conflictPolicyReview) planEvidence.conflictPolicyReview = conflictPolicyReview
+  if (planEvidence && conflictPolicyReview) planEvidence.conflictPolicyReview = conflictPolicyReviewForEvidence(conflictPolicyReview, plan)
   return {
     actionId: action.actionId,
     projectNoPresent: Boolean(parameters.projectNo),
@@ -528,6 +593,9 @@ async function dryRunStockPreparationAction(input = {}) {
   const action = assertStockPreparationTargetReady(input.action)
   const parameters = normalizeActionParameters(input.parameters)
   const runOnlyReview = normalizeRunOnlyConflictPolicyReview(input.conflictPolicyReview)
+  const tableScopeReview = input.policyStore
+    ? await loadTableScopeConflictPolicies({ action, policyStore: input.policyStore })
+    : null
   const dryRun = await computeDryRun({
     action,
     parameters,
@@ -535,6 +603,8 @@ async function dryRunStockPreparationAction(input = {}) {
     recordsApi: input.recordsApi,
     plannedAt: input.plannedAt,
     runId: input.runId,
+    runOnlyReview,
+    tableScopeReview,
   })
   let dryRunToken = null
   if (dryRun.canApply) {
@@ -542,16 +612,9 @@ async function dryRunStockPreparationAction(input = {}) {
       actionId: action.actionId,
       parametersHash: hashJson(parameters),
       revision: dryRun.revision,
+      conflictPolicyReview: runOnlyReview,
     })
   }
-  const tableScopeReview = input.policyStore
-    ? await loadTableScopeConflictPolicies({ action, policyStore: input.policyStore })
-    : null
-  const conflictPolicyReview = buildConflictPolicyReview({
-    diagnostics: dryRun.plan.summary && dryRun.plan.summary.duplicateExpandedKeyDiagnostics,
-    runOnlyReview,
-    tableScopeReview,
-  })
   return {
     action: publicActionMetadata(action),
     status: dryRunStatus(dryRun),
@@ -568,7 +631,7 @@ async function dryRunStockPreparationAction(input = {}) {
       plan: dryRun.plan,
       revision: dryRun.revision,
       canApply: dryRun.canApply,
-      conflictPolicyReview,
+      conflictPolicyReview: dryRun.conflictPolicyReview,
     }),
   }
 }
@@ -576,6 +639,14 @@ async function dryRunStockPreparationAction(input = {}) {
 async function applyStockPreparationAction(input = {}) {
   const action = assertStockPreparationTargetReady(input.action)
   const parameters = normalizeActionParameters(input.parameters)
+  const tokenRecord = await consumeDryRunToken(input.tokenStore, input.dryRunToken, {
+    actionId: action.actionId,
+    parametersHash: hashJson(parameters),
+  })
+  const runOnlyReview = normalizeRunOnlyConflictPolicyReview(tokenRecord.conflictPolicyReview)
+  const tableScopeReview = input.policyStore
+    ? await loadTableScopeConflictPolicies({ action, policyStore: input.policyStore })
+    : null
   const dryRun = await computeDryRun({
     action,
     parameters,
@@ -583,17 +654,21 @@ async function applyStockPreparationAction(input = {}) {
     recordsApi: input.recordsApi,
     plannedAt: input.plannedAt,
     runId: input.runId,
+    runOnlyReview,
+    tableScopeReview,
   })
-  await consumeDryRunToken(input.tokenStore, input.dryRunToken, {
-    actionId: action.actionId,
-    parametersHash: hashJson(parameters),
-    revision: dryRun.revision,
-  })
+  if (tokenRecord.revision !== dryRun.revision) {
+    throw new StockPreparationTableActionError(409, 'TABLE_ACTION_DRY_RUN_TOKEN_MISMATCH', 'dryRunToken does not match the current dry-run revision')
+  }
   if (!dryRun.canApply) {
     throw new StockPreparationTableActionError(409, 'TABLE_ACTION_DRY_RUN_NOT_APPLYABLE', 'current dry-run is not applyable')
   }
   if (dryRun.plan.counts[DECISIONS.MANUAL_CONFIRM] > 0 && input.acceptManualConfirmHold !== true) {
     throw new StockPreparationTableActionError(409, 'TABLE_ACTION_MANUAL_CONFIRM_REQUIRED', 'manual-confirm rows require acceptManualConfirmHold=true')
+  }
+  const duplicateResolution = dryRun.plan.summary && dryRun.plan.summary.duplicateExpandedKeyResolution
+  if (duplicateResolution && Number(duplicateResolution.resolvedGroupCount || 0) > 0 && input.acceptDuplicateResolution !== true) {
+    throw new StockPreparationTableActionError(409, 'TABLE_ACTION_DUPLICATE_RESOLUTION_REVIEW_REQUIRED', 'resolved duplicate groups require acceptDuplicateResolution=true')
   }
   const applyResult = await applyStockPreparationPlan({
     permission: input.permission,
@@ -619,6 +694,7 @@ async function applyStockPreparationAction(input = {}) {
         plan: dryRun.plan,
         revision: dryRun.revision,
         canApply: dryRun.canApply,
+        conflictPolicyReview: dryRun.conflictPolicyReview,
       }),
       apply: summarizeApplyResultForEvidence(applyResult),
     },


### PR DESCRIPTION
## Summary

D3 for #2343: make the first duplicate-expanded-key policy executable.

- Implements `keep_multiple_rows` resolution for duplicate expanded-key groups when a reviewed policy and stable discriminator are both present.
- Uses surgical duplicate keys only for resolved collision-group rows; clean rows keep their original idempotency key.
- Keeps fail-closed defaults: no policy, unsupported policy, stale/missing discriminator, existing clean/base target key, and clean-to-collision transitions all stay held.
- Makes previously saved `table_scope` policies active only through fresh dry-run evidence showing resolved/held counts before apply.
- Requires a fresh dry-run token plus `acceptDuplicateResolution=true` before applying resolved duplicate groups.
- Updates the Workbench review UI to show resolved vs held duplicate groups and gate apply on explicit acknowledgement.

## Guardrails

- `keep_multiple_rows` is the only policy that changes C3 decisions in this PR.
- No PLM write, external database write, K3 path, migration, package, or new writer decision type.
- Public evidence stays values-free: fingerprints, policies, scopes, discriminator type, counts, and hold reasons only.
- Apply still rejects client-supplied plans/payloads/target scopes/conflictPolicyReview; run-only choices are token-bound.

## Verification

- `node plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs`
- `node plugins/plugin-integration-core/__tests__/stock-preparation-conflict-planner.test.cjs`
- `node plugins/plugin-integration-core/__tests__/http-routes.test.cjs`
- `pnpm --filter plugin-integration-core test`
- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm exec eslint apps/web/src/views/IntegrationWorkbenchView.vue apps/web/src/services/integration/workbench.ts --max-warnings=0`
- `git diff --check`
