### PR TITLE
docs(data-factory): design duplicate held-group decisions

### DIFF
--- a/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
@@ -845,38 +845,87 @@ Acceptance locks:
 - No PLM write, external database write, K3 path, migration, package, or new
   policy execution beyond `keep_multiple_rows`.
 
-### 🟡 Duplicate-expanded-key D3 validation - #2340 sample keep-multiple closeout (PENDING - validation runbook)
+### ✅ Duplicate-expanded-key D3 validation - #2340 sample keep-multiple closeout (PARTIAL PASS - runbook #2373, package `929f133bd`)
 
 Gated on: D3 runtime (#2372) + explicit operator validation.
 
 Scope:
 
-- Validate the #2340 246-row sample against the landed `keep_multiple_rows`
-  resolver.
-- Confirm saved `table_scope` or selected `run_only` policies become active
-  only through fresh dry-run evidence.
-- Confirm resolved duplicate groups require explicit
+- Validated the #2340 246-row sample against the landed `keep_multiple_rows`
+  resolver using the D3 validation package
+  `metasheet-multitable-onprem-v2.5.0-d3-duplicate-validation-929f133bd`.
+- Confirmed a selected `run_only` policy became active only through fresh
+  post-policy dry-run evidence.
+- Confirmed resolved duplicate groups required explicit
   `acceptDuplicateResolution` acknowledgement before apply.
-- Confirm post-apply re-pull is idempotent: resolved duplicate rows become
-  `skip` or `update`, not another `add`.
-- Keep evidence values-free and never paste payload preview JSON or business
-  values.
+- Confirmed post-apply re-pull was idempotent: resolved duplicate rows became
+  existing rows, not another `add`.
+- Evidence remained values-free; no payload preview JSON or business values were
+  required.
 
 Acceptance locks:
 
-- A package containing #2372 or later is deployed before validation.
-- Pre-policy dry-run confirms already-written clean rows do not become new
-  `add` decisions.
-- Post-policy dry-run reports `resolvedGroupCount`, `resolvedRowCount`,
-  `heldGroupCount`, `heldReasonCounts`, and scope split
-  (`tableScopeResolvedGroupCount` / `runOnlyResolvedGroupCount`) before apply.
-- Apply without duplicate-resolution acknowledgement is blocked.
-- Apply after owner approval writes only resolved duplicate rows; unresolved
-  groups remain held.
-- Re-pull after apply reports `add=0` for the resolved set and no
-  `clean_to_collision_requires_review` for the resolved-key rows.
-- Any remaining held groups drive the next duplicate strategy decision; no
-  speculative runtime strategy starts from this validation PR.
+- The package containing #2372 was deployed on the entity machine before
+  validation.
+- Pre-policy dry-run confirmed already-written clean rows did not become new
+  `add` decisions:
+  `rowsExpanded=246`, `existingRows=190`,
+  `add/update/skip/inactive/manual_confirm=0/0/190/0/56`.
+- Post-policy dry-run reported the reviewed activation before apply:
+  `resolvedGroupCount=1`, `resolvedRowCount=2`, `heldGroupCount=27`,
+  `heldRowCount=54`, `heldReasonCounts=missing_stable_discriminator`,
+  `runOnlyResolvedGroupCount=1`, `tableScopeResolvedGroupCount=0`.
+- Apply without duplicate-resolution acknowledgement was blocked.
+- Apply after owner approval wrote only resolved duplicate rows:
+  `created/patched/failed/held=2/0/0/27`, `skipped=190`.
+- Re-pull after apply reported idempotence:
+  `existingRows=192`, `add/update/skip/manual_confirm=0/0/192/54`,
+  `rowErrors=0`.
+- The remaining 27 held groups drive the next duplicate strategy decision; no
+  speculative runtime strategy starts from the D3 validation closeout.
+- D3 is closed as a clean partial pass: resolvable groups passed; clean and
+  resolved rows are idempotent on re-pull; the remaining groups stay held
+  fail-closed.
+
+### 🟡 Duplicate-expanded-key D4 - held-group decision design (ACTIVE - #2343 follow-up)
+
+Gated on: D3 partial-pass evidence + #2343 explicit direction.
+
+Design doc:
+`docs/development/data-factory-plm-stock-preparation-duplicate-expanded-key-d4-held-group-decision-design-20260607.md`.
+
+Scope:
+
+- Decide the next strategy for the 27 remaining held groups from values-free
+  evidence, not speculation.
+- Anchor the decision in the legacy stock-preparation system behavior because
+  this track replaces that system.
+- Use D1/D3 diagnostics as decision inputs:
+  `heldReasonCounts`, rows-per-group distribution, same-parent vs cross-parent
+  shape when present, `quantityShapeCounts`, `stableDiscriminatorCounts`,
+  attribute-shape counts, and deterministic collision fingerprints.
+- Keep the remaining groups held fail-closed until a future implementation
+  slice is explicitly approved.
+
+Acceptance locks:
+
+- D4 is design-only. It must not change C2 expansion, C3 planner output, C4
+  apply behavior, idempotency-key generation, target writes, routes, UI,
+  migrations, package contents, or runtime policy execution.
+- The observed D3 held reason `missing_stable_discriminator` must not be forced
+  through `keep_multiple_rows`.
+- `merge_quantity` is not the default next policy. It is allowed only if legacy
+  behavior confirms that the same duplicate shape is additive demand and owner
+  review accepts the quantity semantics.
+- Unknown legacy behavior defaults to `source_correction_required` and no
+  Apply.
+- `select_representative` and `skip_selected` require explicit owner selection
+  and values-free evidence of skipped demand. No silent auto-pick or silent
+  drop.
+- Complete expansion is required before duplicate decisions are authoritative;
+  large-BOM bounded runs route back to #2342.
+- Any future executable policy requires a fresh dry-run, fresh token, reviewed
+  policy evidence, and explicit owner acknowledgement.
 
 ## Deferred tracks
 

--- a/docs/development/data-factory-plm-stock-preparation-duplicate-expanded-key-d4-held-group-decision-design-20260607.md
+++ b/docs/development/data-factory-plm-stock-preparation-duplicate-expanded-key-d4-held-group-decision-design-20260607.md
@@ -1,0 +1,227 @@
+# Data Factory PLM Stock Preparation Duplicate Expanded Key D4 Held-Group Decision Design - 2026-06-07
+
+## Purpose
+
+Define the D4 decision contract for the duplicate groups that remained held
+after D3 `keep_multiple_rows` validation on the #2340 sample.
+
+This is design-only input. It does not authorize runtime changes, Apply, K3
+write, PLM write, external database write, production rollout, checkpoint
+writer work, or any new duplicate policy execution.
+
+## Grounded Baseline
+
+D3 is a clean partial pass:
+
+- the #2340 sample expanded completely with `rowsExpanded=246`;
+- the already-written clean rows remained idempotent on re-pull;
+- one reviewed duplicate group resolved through `keep_multiple_rows`;
+- the resolved rows wrote once, then re-pulled as existing rows;
+- the remaining held groups stayed fail-closed.
+
+Values-free closeout shape:
+
+```text
+prePolicyDryRun:
+  rowsExpanded=246
+  existingRows=190
+  add/update/skip/inactive/manual_confirm=0/0/190/0/56
+
+postPolicyDryRun:
+  add/update/skip/inactive/manual_confirm=2/0/190/0/54
+  resolvedGroupCount=1
+  resolvedRowCount=2
+  heldGroupCount=27
+  heldRowCount=54
+  heldReasonCounts=missing_stable_discriminator
+  runOnlyResolvedGroupCount=1
+  tableScopeResolvedGroupCount=0
+
+apply:
+  status=partial
+  created/patched/failed/held=2/0/0/27
+  skipped=190
+
+rePull:
+  existingRows=192
+  add/update/skip/manual_confirm=0/0/192/54
+  resolvedGroupCount=1
+  resolvedRowCount=2
+  heldGroupCount=27
+  heldRowCount=54
+  heldReasonCounts=missing_stable_discriminator
+  rowErrors=0
+```
+
+Interpretation:
+
+- Dry-run decision counts are row-level. Held group counts are tracked
+  separately through `heldGroupCount`, so 27 held groups with 54 held rows
+  produce `manual_confirm=54`.
+- `keep_multiple_rows` is proven only for duplicate groups with a stable row
+  discriminator.
+- The remaining 27 groups are not resolvable multi-row cases under D3. Their
+  observed held reason is `missing_stable_discriminator`.
+- The remaining groups must not be forced through `keep_multiple_rows`.
+- No additional Apply should run until D4 diagnostics and an owner-approved
+  policy decision are complete.
+
+## D4 Decision Inputs
+
+D4 must decide from evidence, not from speculation.
+
+### 1. Legacy Stock-Preparation Behavior
+
+The legacy stock-preparation system is the source of truth for the duplicate
+shape because this track replaces that system.
+
+Before implementing a policy, confirm how the legacy system handles the same
+duplicate shape:
+
+- reject or report the duplicate;
+- deduplicate or keep one row;
+- merge quantity;
+- skip selected demand;
+- another explicit behavior.
+
+If legacy behavior cannot be confirmed, the default D4 posture is
+`source_correction_required` and no Apply.
+
+### 2. Existing Values-Free Diagnostics
+
+D4 should reuse the values-free D1/D3 diagnostics already available in the dry
+run evidence:
+
+- `heldGroupCount`;
+- `heldRowCount`;
+- `heldReasonCounts`;
+- rows-per-group distribution;
+- same-parent vs cross-parent shape counts when present;
+- `quantityShapeCounts` (`all_equal` vs `varied`);
+- `stableDiscriminatorCounts`;
+- attribute-shape counts when present;
+- deterministic collision fingerprints.
+
+These diagnostics identify which policy family is even safe to consider. They
+do not authorize a policy by themselves.
+
+### 3. Complete Expansion Requirement
+
+Duplicate diagnosis is authoritative only on a complete expansion. If a run is
+bounded by the large-BOM track (`largeBom=true`, `max_rows_exceeded`, or another
+scale halt), D4 must route back to #2342 before choosing a duplicate strategy
+for that sample.
+
+The #2340 validation sample had complete expansion, so its remaining
+`missing_stable_discriminator` held groups are valid D4 inputs.
+
+## Policy Decision Matrix
+
+### `source_correction_required`
+
+Default for:
+
+- missing legacy behavior;
+- `missing_stable_discriminator` groups where the legacy system rejects or
+  reports duplicates;
+- varied quantity groups where merging is not explicitly confirmed as the
+  legacy behavior;
+- any group where the source appears contradictory and no safe row identity can
+  be established.
+
+Effect:
+
+- keep the group held;
+- report a values-free reason that source correction is required;
+- do not write MetaSheet rows;
+- do not attempt to write or correct PLM.
+
+### `select_representative`
+
+Candidate only when:
+
+- the legacy system deduplicates or keeps one row for the same duplicate shape;
+- the owner supplies an explicit reviewed representative rule or selection;
+- skipped demand remains visible in values-free evidence as counts and
+  fingerprints.
+
+Locks:
+
+- never auto-pick the first row;
+- never infer representative choice from component code alone;
+- never hide which collision fingerprints were not written.
+
+### `skip_selected`
+
+Candidate only when:
+
+- the owner explicitly selects which duplicate demand is intentionally ignored;
+- the skipped demand is recorded in values-free evidence.
+
+Locks:
+
+- no silent drop;
+- no default skip;
+- no Apply without fresh dry-run evidence and explicit owner acknowledgement.
+
+### `merge_quantity`
+
+Not the default for the remaining 27 groups.
+
+Candidate only when:
+
+- legacy behavior confirms that the same duplicate shape is merged as additive
+  demand;
+- business semantics confirm that summing does not double-count
+  stock-preparation demand;
+- varied quantities receive explicit owner review.
+
+Locks:
+
+- varied quantity is not automatically mergeable;
+- merging must sum path quantities, not pick one row;
+- if the source-data shape suggests a conflict rather than additive demand,
+  default back to `source_correction_required`.
+
+### `keep_multiple_rows`
+
+Already covered by D3. It remains valid only when the duplicate group has a
+stable discriminator that can produce surgical, deterministic keys.
+
+For the remaining #2340 held groups, the observed reason is
+`missing_stable_discriminator`, so D4 must not choose `keep_multiple_rows`
+unless future evidence proves a stable discriminator exists for a specific
+group.
+
+## Acceptance Locks
+
+- D4 is a decision/design track only. It must not change C2 expansion, C3
+  planner output, C4 apply behavior, idempotency-key generation, target writes,
+  package contents, migrations, routes, or UI behavior.
+- Remaining held groups stay held fail-closed until a future implementation
+  slice is explicitly approved.
+- No additional Apply is authorized from D3 partial-pass evidence.
+- `merge_quantity` is not the default next policy for
+  `missing_stable_discriminator`.
+- Unknown legacy behavior defaults to `source_correction_required`.
+- `select_representative` and `skip_selected` require explicit owner selection
+  and values-free skipped-demand evidence.
+- Any future executable policy requires a fresh dry-run, fresh token, reviewed
+  policy evidence, and explicit owner acknowledgement.
+- Public evidence must not expose project number, component code/name/source
+  id, parent/path/idempotency key, raw PLM rows, target sheet id, field id,
+  payload JSON, raw SQL, credentials, tokens, or stack traces with business
+  values.
+
+## Future Slices
+
+D4 should lead to one or more separately opted implementation slices only after
+the legacy-system behavior and quantity-shape evidence are confirmed:
+
+- `source_correction_required` evidence/runtime handling;
+- `select_representative` or dedup/keep-one handling;
+- `skip_selected` handling;
+- `merge_quantity` handling, only if legacy behavior confirms additive demand;
+- additional runbook/operator validation.
+
+None of those slices are started by this design.


### PR DESCRIPTION
## Summary

Docs-only D4 held-group decision design for #2343 after the D3 keep-multiple validation partial pass.

- records the D3 closeout as a clean partial pass: 1 group / 2 rows resolved, 27 groups / 54 rows still held with `missing_stable_discriminator`
- adds a D4 design contract for the remaining held groups: anchor strategy choice in legacy stock-preparation behavior + values-free quantity-shape/held-reason diagnostics
- locks that `merge_quantity` is not the default, unknown legacy behavior defaults to `source_correction_required`, and no additional Apply/runtime behavior is authorized

## Boundaries

- docs-only
- no route/UI/runtime/apply changes
- no idempotency-key/planner behavior change
- no K3, PLM write, external DB write, migration, or package change

## Verification

- `git diff --cached --check`

Refs #2343
