### PR TITLE
feat(data-factory): show duplicate held reasons

### DIFF
--- a/apps/web/src/views/IntegrationWorkbenchView.vue
+++ b/apps/web/src/views/IntegrationWorkbenchView.vue
@@ -795,6 +795,9 @@
               <p class="integration-workbench__hint" data-testid="table-action-duplicate-policy-scope">
                 本表已保存策略 {{ tableActionStoredConflictPolicyCount }} 条；本次 dry-run 已解决 {{ tableActionResolvedDuplicateGroupCount }} 组，仍 hold {{ tableActionHeldDuplicateGroupCount }} 组；未选择时默认 hold。
               </p>
+              <div v-if="tableActionHeldReasonMetrics.length" class="integration-workbench__metric-row" data-testid="table-action-held-reason-summary">
+                <span v-for="metric in tableActionHeldReasonMetrics" :key="metric.id">heldReason {{ metric.label }} {{ metric.value }}</span>
+              </div>
               <ul v-if="tableActionDuplicateGroups.length" class="integration-workbench__mini-list">
                 <li v-for="group in tableActionDuplicateGroups" :key="group.fingerprint">
                   <div>
@@ -2074,6 +2077,14 @@ const tableActionDuplicateResolutionSelections = computed(() => {
 })
 const tableActionResolvedDuplicateGroupCount = computed(() => Number(tableActionDuplicateResolution.value?.resolvedGroupCount || 0))
 const tableActionHeldDuplicateGroupCount = computed(() => Number(tableActionDuplicateResolution.value?.heldGroupCount || 0))
+const tableActionHeldReasonMetrics = computed(() => {
+  const counts = tableActionDuplicateResolution.value?.heldReasonCounts
+  if (!isRecord(counts)) return []
+  return Object.entries(counts)
+    .filter(([reason, count]) => safeEvidenceToken(reason) && typeof count === 'number' && Number.isFinite(count) && count > 0)
+    .sort(([left], [right]) => left.localeCompare(right))
+    .map(([reason, count]) => ({ id: reason, label: reason, value: String(count) }))
+})
 const tableActionStoredConflictPolicyCount = computed(() => Number(tableActionTableScopePolicies.value?.policyCount || 0))
 const tableActionDuplicateGroups = computed<DuplicateExpandedGroupView[]>(() => {
   const diagnostics = tableActionDuplicateDiagnostics.value
@@ -2616,6 +2627,10 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 
 function numberMetric(value: unknown): string {
   return typeof value === 'number' && Number.isFinite(value) ? String(value) : ''
+}
+
+function safeEvidenceToken(value: unknown): value is string {
+  return typeof value === 'string' && /^[a-z][a-z0-9_]{0,80}$/i.test(value)
 }
 
 function isLargeBomBoundedTableActionResult(result: IntegrationTableActionDryRunResult | null): boolean {

--- a/apps/web/tests/IntegrationWorkbenchView.spec.ts
+++ b/apps/web/tests/IntegrationWorkbenchView.spec.ts
@@ -2710,6 +2710,38 @@ describe('IntegrationWorkbenchView', () => {
               counts: { add: 190, update: 0, skip: 190, inactive: 0, manual_confirm: 2 },
               conflictTypes: ['duplicate_expanded_key'],
               duplicateExpandedKeyDiagnostics: duplicateDiagnostics,
+              duplicateExpandedKeyResolution: {
+                conflictType: 'duplicate_expanded_key',
+                resolvedPolicy: 'keep_multiple_rows',
+                resolvedGroupCount: 0,
+                resolvedRowCount: 0,
+                heldGroupCount: 2,
+                heldRowCount: 4,
+                heldReasonCounts: {
+                  default_hold: 1,
+                  missing_stable_discriminator: 1,
+                  'unsafe-reason': 1,
+                },
+                resolvedPolicies: [],
+                heldPolicies: [
+                  {
+                    fingerprint: 'sha16:1111222233334444',
+                    policy: 'hold',
+                    scope: 'default',
+                    reason: 'missing_stable_discriminator',
+                    rowCount: 2,
+                    writeEffect: 'manual_confirm_held',
+                  },
+                  {
+                    fingerprint: 'sha16:aaaabbbbccccdddd',
+                    policy: 'hold',
+                    scope: 'default',
+                    reason: 'default_hold',
+                    rowCount: 2,
+                    writeEffect: 'manual_confirm_held',
+                  },
+                ],
+              },
             },
           },
         })
@@ -2752,6 +2784,9 @@ describe('IntegrationWorkbenchView', () => {
     expect(block).toContain('crossParent 1')
     expect(block).toContain('quantityVaried 1')
     expect(block).toContain('stableDiscriminator 2')
+    expect(block).toContain('heldReason default_hold 1')
+    expect(block).toContain('heldReason missing_stable_discriminator 1')
+    expect(block).not.toContain('heldReason unsafe-reason 1')
     expect(block).toContain('keep_multiple_rows')
     expect(block).toContain('merge_quantity')
     expect(block).toContain('skip_selected')


### PR DESCRIPTION
## Summary

Small evidence/UI enhancement for #2343 follow-up work.

- renders values-free `heldReasonCounts` in the duplicate-expanded-key review block
- keeps the display to safe snake_case reason tokens + counts only
- extends the existing IntegrationWorkbenchView spec to cover `default_hold` + `missing_stable_discriminator` and to prove an unsafe reason token is not rendered in the summary

## Boundaries

- frontend/evidence display only
- no backend route/runtime change
- no planner/apply/idempotency-key behavior change
- no K3, PLM write, external DB write, migration, or package change

## Verification

- `pnpm --filter @metasheet/web exec vitest run tests/IntegrationWorkbenchView.spec.ts --watch=false`
- `pnpm --filter @metasheet/web exec vue-tsc --noEmit`
- `pnpm --filter @metasheet/web exec eslint src/views/IntegrationWorkbenchView.vue --max-warnings=0`
- `git diff --check`

Note: running eslint on the full spec file still reports pre-existing router-link mock warnings; this slice did not modify those warnings.

Refs #2343
