### PR TITLE
fix(attendance-approval): deep-link queue button to pending request

### DIFF
--- a/apps/web/src/views/approval/ApprovalCenterView.vue
+++ b/apps/web/src/views/approval/ApprovalCenterView.vue
@@ -381,6 +381,7 @@ const statusFilter = ref<ApprovalStatus | ''>('')
 const sourceSystemFilter = ref<'all' | 'platform' | 'plm'>('all')
 const currentPage = ref(1)
 const pageSize = ref(10)
+const attendanceRequestsSection = 'attendance-overview-requests'
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -460,14 +461,26 @@ function isAttendanceApproval(row: UnifiedApprovalDTO): boolean {
     || row.formSnapshot?.attendanceRequestId !== undefined
 }
 
+function attendanceRequestIdOf(row: UnifiedApprovalDTO): string | null {
+  const rawRequestId = row.formSnapshot?.attendanceRequestId
+  if (rawRequestId === undefined || rawRequestId === null) return null
+  const requestId = String(rawRequestId).trim()
+  return requestId ? requestId : null
+}
+
+function attendanceRequestQuery(row?: UnifiedApprovalDTO): Record<string, string> {
+  const query: Record<string, string> = { section: attendanceRequestsSection }
+  if (!row) return query
+  const requestId = attendanceRequestIdOf(row)
+  if (requestId) query.requestId = requestId
+  return query
+}
+
 function handleRowClick(row: UnifiedApprovalDTO) {
   if (isAttendanceApproval(row)) {
     router.push({
       name: 'attendance',
-      query: {
-        section: 'attendance-overview-requests',
-        requestId: String(row.formSnapshot?.attendanceRequestId ?? ''),
-      },
+      query: attendanceRequestQuery(row),
     })
     return
   }
@@ -475,9 +488,12 @@ function handleRowClick(row: UnifiedApprovalDTO) {
 }
 
 function openAttendanceApprovalQueue() {
+  const firstPendingAttendanceRequest = store.pendingApprovals.find(row =>
+    isAttendanceApproval(row) && attendanceRequestIdOf(row) !== null,
+  )
   router.push({
     name: 'attendance',
-    query: { section: 'attendance-overview-requests' },
+    query: attendanceRequestQuery(firstPendingAttendanceRequest),
   })
 }
 

--- a/apps/web/tests/approval-center.spec.ts
+++ b/apps/web/tests/approval-center.spec.ts
@@ -286,12 +286,46 @@ describe('ApprovalCenterView', () => {
     expect(container!.querySelector('[data-el-select]')).toBeTruthy()
   })
 
-  it('shows the attendance approval queue entry and routes to the attendance requests section', async () => {
+  it('routes the attendance approval queue entry to the first pending attendance request', async () => {
+    mockPendingApprovals.value = [
+      {
+        id: 'apv_attendance_1',
+        requestNo: 'ATT-100001',
+        title: '补卡申请',
+        status: 'pending',
+        requester: { name: '王五' },
+        createdAt: '2026-06-08T08:00:00Z',
+        workflowKey: 'attendance.request',
+        formSnapshot: { attendanceRequestId: 'request-att-1' },
+        assignments: [],
+      },
+    ]
+
     await mountView()
 
     const entry = container!.querySelector('[data-testid="attendance-approval-queue-entry"]')
     expect(entry?.textContent).toContain('考勤审批')
     expect(entry?.textContent).toContain('待处理考勤审批')
+
+    const button = Array.from(container!.querySelectorAll('button')).find(candidate =>
+      candidate.textContent?.includes('待处理考勤审批'),
+    )
+    expect(button).toBeTruthy()
+
+    button!.click()
+    await flushUi()
+
+    expect(pushSpy).toHaveBeenCalledWith({
+      name: 'attendance',
+      query: {
+        section: 'attendance-overview-requests',
+        requestId: 'request-att-1',
+      },
+    })
+  })
+
+  it('keeps the attendance approval queue entry fallback when no request id is available', async () => {
+    await mountView()
 
     const button = Array.from(container!.querySelectorAll('button')).find(candidate =>
       candidate.textContent?.includes('待处理考勤审批'),


### PR DESCRIPTION
## Summary
- close the remaining #2376 button-entry gap by routing `待处理考勤审批` to the first pending attendance request when a request id is available
- keep the previous section-only fallback when the pending queue has no request id
- share the attendance request query builder between row-click and queue-button routes

## Verification
- `pnpm install --frozen-lockfile` (temporary worktree dependency entrypoints)
- `pnpm --filter @metasheet/web exec vitest run tests/approval-center.spec.ts tests/approvalCenterUnreadBadge.spec.ts --watch=false`
- `pnpm --filter @metasheet/web type-check`
- `git diff --check`

Refs #2376
