### PR TITLE
feat(data-factory): hold source-correction duplicate groups

### DIFF
--- a/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
@@ -887,7 +887,7 @@ Acceptance locks:
   resolved rows are idempotent on re-pull; the remaining groups stay held
   fail-closed.
 
-### 🟡 Duplicate-expanded-key D4 - held-group decision design (ACTIVE - #2343 follow-up)
+### ✅ Duplicate-expanded-key D4 - held-group decision design (DONE - #2343 follow-up)
 
 Gated on: D3 partial-pass evidence + #2343 explicit direction.
 
@@ -926,6 +926,37 @@ Acceptance locks:
   large-BOM bounded runs route back to #2342.
 - Any future executable policy requires a fresh dry-run, fresh token, reviewed
   policy evidence, and explicit owner acknowledgement.
+
+### 🟡 Duplicate-expanded-key D4-1 - source-correction held-only runtime (ACTIVE)
+
+Gated on: Duplicate D4 design + explicit opt-in.
+
+Scope:
+
+- Implement the conservative `source_correction_required` policy as a held-only
+  runtime reason for reviewed duplicate-expanded-key groups.
+- Keep affected duplicate groups as `manual_confirm` / held. They must not
+  produce `add`, `update`, `skip`, or `inactive` decisions.
+- Preserve D4's source-boundary posture: Data Factory reports that source
+  correction is required; it does not repair PLM/source data and does not make
+  held demand disappear.
+- Keep unimplemented strategies (`merge_quantity`, `select_representative`,
+  `skip_selected`) held as `unsupported_policy`.
+
+Acceptance locks:
+
+- No C2 expansion change, idempotency-key change, route, UI, migration,
+  package, PLM write, external database write, K3 path, or production rollout.
+- `source_correction_required` must distinguish itself from generic
+  `default_hold` / `unsupported_policy` in values-free evidence.
+- `source_correction_required` must never create, patch, skip, inactivate, or
+  delete target rows.
+- Applying a reviewed run that contains only source-correction duplicate groups
+  must report those groups as held and make zero records API write calls.
+- Public evidence must not expose project number, component code/name/source
+  id, parent/path/idempotency key, raw PLM rows, target sheet id, field id,
+  payload JSON, raw SQL, credentials, tokens, or stack traces with business
+  values.
 
 ### 🟡 Source snapshot diff gate C0 - PLM-BOM lifecycle design (ACTIVE - #2388)
 

--- a/docs/development/data-factory-plm-stock-preparation-duplicate-expanded-key-d4-source-correction-design-20260608.md
+++ b/docs/development/data-factory-plm-stock-preparation-duplicate-expanded-key-d4-source-correction-design-20260608.md
@@ -6,9 +6,11 @@ Define the design contract for `source_correction_required`, the conservative
 D4 policy candidate for duplicate-expanded-key groups that remain held with
 `missing_stable_discriminator`.
 
-This is design-only. It does not authorize runtime changes, another Apply,
-production rollout, checkpoint writer work, K3 write, PLM write, external
-database write, raw SQL, migration, route, UI, or package change.
+The D4-1 runtime slice implements only the held-only part of this contract:
+`source_correction_required` can be selected and reported as its own held
+reason. It still does not authorize another Apply, production rollout,
+checkpoint writer work, K3 write, PLM write, external database write, raw SQL,
+migration, route, UI, package change, or any source repair.
 
 ## Baseline
 
@@ -94,20 +96,20 @@ Forbidden evidence:
 - credentials, tokens, connection strings, raw SQL, or stack traces containing
   business values.
 
-## Future Runtime Contract
+## D4-1 Runtime Contract
 
-If this policy is implemented later, it must be held-only:
+This policy is held-only:
 
 - affected duplicate groups remain `manual_confirm` / held;
 - no `add`, `update`, `skip`, or `inactive` decision is produced for affected
   rows;
 - no target write is attempted for affected rows;
-- apply result, if other clean rows are allowed by existing gates, must report
+- apply result, if other clean rows are allowed by existing gates, reports
   the source-correction groups as held;
 - evidence must distinguish `source_correction_required` from generic
   `default_hold` so the operator understands the required next action.
 
-This future runtime contract must not weaken existing gates:
+This runtime contract must not weaken existing gates:
 
 - fresh dry-run required;
 - fresh token required;
@@ -129,21 +131,22 @@ Avoid wording that implies Data Factory can repair PLM/source data.
 
 ## Acceptance Locks
 
-- Design-only: no runtime, route, UI, migration, package, C2 expansion, C3
-  planner, C4 apply, idempotency-key, K3, PLM write, or external DB write
-  change.
+- D4-1 only adds held-only evidence/runtime handling for
+  `source_correction_required`; it does not change routes, UI, migration,
+  package, C2 expansion, idempotency-key generation, K3, PLM write, or external
+  DB write behavior.
 - Unknown legacy behavior defaults to `source_correction_required`.
 - `source_correction_required` must keep demand visible as held evidence; it
   must never silently drop demand.
 - It must never create target rows.
 - It must never write PLM/source data.
 - It must never be treated as successful resolution of a duplicate group.
-- Future implementation must be a separate opt-in with tests proving held-only
-  behavior and values-free evidence.
+- Any further strategy implementation must be a separate opt-in with tests
+  proving its held/write behavior and values-free evidence.
 
-## Future Test Plan
+## Verification
 
-When implementation is explicitly approved, add tests for:
+Implementation is pinned by tests for:
 
 1. `missing_stable_discriminator` + unknown legacy behavior produces
    `source_correction_required` held evidence.
@@ -156,5 +159,12 @@ When implementation is explicitly approved, add tests for:
 6. Large-BOM bounded runs cannot use this policy to make duplicate evidence
    authoritative.
 
-None of these tests are added by this design slice because no runtime behavior
-is introduced here.
+Runtime coverage added in D4-1:
+
+- planner-level test: a selected `source_correction_required` policy remains
+  fail-closed and reports `heldReasonCounts.source_correction_required`;
+- planner-level test: `merge_quantity`, `select_representative`, and
+  `skip_selected` still remain held as `unsupported_policy`;
+- table-action test: a saved table-scope `source_correction_required` policy
+  dry-runs as held, applies with zero create/patch calls, and emits values-free
+  evidence.

--- a/docs/development/data-factory-plm-stock-preparation-duplicate-expanded-key-d4-source-correction-runtime-verification-20260608.md
+++ b/docs/development/data-factory-plm-stock-preparation-duplicate-expanded-key-d4-source-correction-runtime-verification-20260608.md
@@ -1,0 +1,69 @@
+# Data Factory PLM Stock Preparation Duplicate Expanded Key D4 Source Correction Runtime Verification - 2026-06-08
+
+## Scope
+
+D4-1 implements `source_correction_required` as a held-only runtime reason for
+reviewed duplicate-expanded-key groups.
+
+It does not implement `merge_quantity`, `select_representative`, or
+`skip_selected`. Those strategies remain held as `unsupported_policy`.
+
+## Behavior
+
+- A selected `source_correction_required` policy keeps the duplicate group
+  fail-closed as `manual_confirm` / held.
+- The conflict plan emits values-free evidence with
+  `heldReasonCounts.source_correction_required`.
+- A table-scoped `source_correction_required` policy can be persisted and
+  reviewed, but Apply writes nothing for the held duplicate group.
+- Applying a run that contains only the held source-correction group returns a
+  held result with zero `createRecord` and zero `patchRecord` calls.
+
+## Boundary
+
+- No C2 expansion change.
+- No idempotency-key change.
+- No route, UI, migration, package, or OpenAPI change.
+- No PLM write, external database write, K3 path, or production rollout.
+- No source repair. Data Factory only reports that source correction is
+  required.
+
+## Values-Free Evidence
+
+Public evidence may contain:
+
+- policy name;
+- scope;
+- counts;
+- deterministic collision fingerprints;
+- held reason tokens.
+
+It must not contain:
+
+- project number;
+- component code, component name, component source id, or material;
+- parent, path, source detail id, source line, sort line, or raw PLM row;
+- raw idempotency key or base key;
+- target sheet id or field id;
+- payload JSON, raw SQL, credentials, tokens, or stack traces with business
+  values.
+
+## Verification Commands
+
+```bash
+node plugins/plugin-integration-core/__tests__/stock-preparation-conflict-planner.test.cjs
+node plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
+```
+
+## Test Locks
+
+- `source_correction_required` is distinct from `default_hold` and
+  `unsupported_policy`.
+- `source_correction_required` does not produce `add`, `update`, `skip`, or
+  `inactive` decisions.
+- Unimplemented policies (`merge_quantity`, `select_representative`,
+  `skip_selected`) still remain held as `unsupported_policy`.
+- Saved table-scope `source_correction_required` policy keeps the group held
+  and makes no target records API write calls.
+- Evidence serialization does not include sensitive project/component/source
+  values from the fixtures.

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-conflict-planner.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-conflict-planner.test.cjs
@@ -614,6 +614,93 @@ function testKeepMultipleRowsWithoutStableDiscriminatorHolds() {
   assert.equal(resolution.heldReasonCounts.missing_stable_discriminator, 1)
 }
 
+function testSourceCorrectionRequiredHoldsWithExplicitReason() {
+  const duplicateKey = 'DUP-SOURCE-CORRECTION'
+  const duplicateA = row({
+    idempotencyKey: duplicateKey,
+    projectNo: 'PROJECT-LEAK',
+    componentSourceId: 'COMP-SOURCE-CORRECTION-A',
+    parentSourceId: 'PARENT-SOURCE-CORRECTION',
+    path: 'ROOT/PARENT-SOURCE-CORRECTION/COMP-SOURCE-CORRECTION',
+    pathTokens: ['ROOT', 'PARENT-SOURCE-CORRECTION', 'COMP-SOURCE-CORRECTION'],
+    componentCode: 'SOURCE-CORRECTION-CODE',
+    componentName: 'Source Correction Widget',
+    material: 'Source Correction Alloy',
+  })
+  const duplicateB = {
+    ...duplicateA,
+    componentSourceId: 'COMP-SOURCE-CORRECTION-B',
+  }
+
+  const plan = planStockPreparationConflicts({
+    expandedRows: [duplicateA, duplicateB],
+    existingRows: [],
+    duplicatePolicyReview: duplicatePolicyReviewFor(duplicateKey, 'source_correction_required', 'table_scope'),
+    runId: 'run-d4-source-correction',
+    plannedAt: '2026-06-08T09:00:00.000Z',
+  })
+
+  assert.equal(plan.valid, false, 'source correction keeps the plan fail-closed')
+  assert.equal(plan.counts.add, 0, 'source correction must not produce add decisions')
+  assert.equal(plan.counts.update, 0, 'source correction must not produce update decisions')
+  assert.equal(plan.counts.skip, 0, 'source correction must not produce skip decisions')
+  assert.equal(plan.counts.inactive, 0, 'source correction must not produce inactive decisions')
+  assert.equal(plan.counts.manual_confirm, 1)
+
+  const evidence = summarizeConflictPlanForEvidence(plan)
+  const resolution = evidence.duplicateExpandedKeyResolution
+  const held = resolution.heldPolicies[0]
+  assert.equal(resolution.heldGroupCount, 1)
+  assert.equal(resolution.heldRowCount, 2)
+  assert.equal(resolution.heldReasonCounts.source_correction_required, 1)
+  assert.equal(resolution.heldReasonCounts.unsupported_policy || 0, 0)
+  assert.equal(held.policy, 'source_correction_required')
+  assert.equal(held.reason, 'source_correction_required')
+  assert.equal(held.scope, 'table_scope')
+  assert.equal(held.rowCount, 2)
+
+  const text = JSON.stringify(resolution)
+  for (const sensitive of [
+    'PROJECT-LEAK',
+    duplicateKey,
+    'COMP-SOURCE-CORRECTION',
+    'PARENT-SOURCE-CORRECTION',
+    'ROOT/',
+    'SOURCE-CORRECTION-CODE',
+    'Source Correction Widget',
+    'Source Correction Alloy',
+  ]) {
+    assert.ok(!text.includes(sensitive), `source-correction evidence must not include ${sensitive}`)
+  }
+}
+
+function testUnimplementedDuplicatePoliciesRemainHeldAsUnsupported() {
+  for (const policy of ['merge_quantity', 'select_representative', 'skip_selected']) {
+    const duplicateKey = `DUP-${policy}`
+    const duplicateA = row({ idempotencyKey: duplicateKey, componentSourceId: `PART-${policy}` })
+    const duplicateB = { ...duplicateA }
+
+    const plan = planStockPreparationConflicts({
+      expandedRows: [duplicateA, duplicateB],
+      existingRows: [],
+      duplicatePolicyReview: duplicatePolicyReviewFor(duplicateKey, policy, 'run_only'),
+      runId: `run-${policy}`,
+      plannedAt: '2026-06-08T09:00:00.000Z',
+    })
+
+    assert.equal(plan.valid, false, `${policy} must remain fail-closed`)
+    assert.equal(plan.counts.add, 0, `${policy} must not produce add decisions`)
+    assert.equal(plan.counts.update, 0, `${policy} must not produce update decisions`)
+    assert.equal(plan.counts.skip, 0, `${policy} must not produce skip decisions`)
+    assert.equal(plan.counts.inactive, 0, `${policy} must not produce inactive decisions`)
+    assert.equal(plan.counts.manual_confirm, 1)
+    const resolution = summarizeConflictPlanForEvidence(plan).duplicateExpandedKeyResolution
+    assert.equal(resolution.heldReasonCounts.unsupported_policy, 1)
+    assert.equal(resolution.heldPolicies[0].policy, policy)
+    assert.equal(resolution.heldPolicies[0].reason, 'unsupported_policy')
+  }
+}
+
 function main() {
   testAddUpdateSkipInactive()
   testRowErrorsDoNotAbortGoodRows()
@@ -629,6 +716,8 @@ function main() {
   testDuplicateResolutionEvidenceValuesFree()
   testKeepMultipleRowsCleanToCollisionHolds()
   testKeepMultipleRowsWithoutStableDiscriminatorHolds()
+  testSourceCorrectionRequiredHoldsWithExplicitReason()
+  testUnimplementedDuplicatePoliciesRemainHeldAsUnsupported()
 
   console.log('stock-preparation-conflict-planner.test.cjs OK')
 }

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
@@ -570,6 +570,78 @@ async function testSavedKeepMultipleRowsPolicyRequiresFreshReviewAndAppliesResol
   assert.equal(repullResolution.heldReasonCounts.clean_to_collision_requires_review || 0, 0)
 }
 
+async function testSavedSourceCorrectionPolicyKeepsDuplicateHeldAndWritesNothing() {
+  const storage = createMemoryStorage()
+  const source = createSourceAdapter(duplicateRootPlmData())
+  const records = createRecordsApi()
+  const action = normalizeStockPreparationActionConfig(baseAction())
+  const fingerprint = rootPartFingerprint()
+
+  await saveTableScopeConflictPolicies({
+    action,
+    policyStore: storage,
+    approver: 'admin-user',
+    request: {
+      conflictType: 'duplicate_expanded_key',
+      policies: [{ fingerprint, policy: 'source_correction_required' }],
+    },
+  })
+
+  const dryRun = await dryRunStockPreparationAction({
+    action,
+    parameters: { projectNo: 'P-001' },
+    sourceAdapter: source.adapter,
+    recordsApi: records.recordsApi,
+    tokenStore: storage,
+    policyStore: storage,
+    plannedAt: '2026-06-08T09:00:00.000Z',
+  })
+
+  assert.equal(dryRun.status, 'manual_confirm_required')
+  assert.equal(dryRun.counts.add, 0)
+  assert.equal(dryRun.counts.update, 0)
+  assert.equal(dryRun.counts.skip, 0)
+  assert.equal(dryRun.counts.inactive, 0)
+  assert.equal(dryRun.counts.manual_confirm, 1)
+  assert.equal(typeof dryRun.dryRunToken, 'string')
+
+  const resolution = dryRun.evidence.plan.duplicateExpandedKeyResolution
+  assert.equal(resolution.resolvedGroupCount, 0)
+  assert.equal(resolution.heldGroupCount, 1)
+  assert.equal(resolution.heldRowCount, 2)
+  assert.equal(resolution.heldReasonCounts.source_correction_required, 1)
+  assert.equal(resolution.heldReasonCounts.unsupported_policy || 0, 0)
+  assert.equal(resolution.heldPolicies[0].policy, 'source_correction_required')
+  assert.equal(resolution.heldPolicies[0].reason, 'source_correction_required')
+  assert.equal(dryRun.evidence.plan.conflictPolicyReview.writeEffect, 'manual_confirm_held')
+  assert.equal(dryRun.evidence.plan.conflictPolicyReview.selectedPolicies[0].writeEffect, 'manual_confirm_held')
+
+  const result = await applyStockPreparationAction({
+    action,
+    parameters: { projectNo: 'P-001' },
+    dryRunToken: dryRun.dryRunToken,
+    sourceAdapter: source.adapter,
+    recordsApi: records.recordsApi,
+    tokenStore: storage,
+    policyStore: storage,
+    permission: 'write',
+    acceptManualConfirmHold: true,
+  })
+
+  assert.equal(result.status, 'held')
+  assert.equal(result.apply.counts.created, 0)
+  assert.equal(result.apply.counts.updated, 0)
+  assert.equal(result.apply.counts.inactive, 0)
+  assert.equal(result.apply.counts.held, 1)
+  assert.equal(records.calls.some((call) => call[0] === 'createRecord'), false, 'source correction never creates target rows')
+  assert.equal(records.calls.some((call) => call[0] === 'patchRecord'), false, 'source correction never patches target rows')
+
+  const text = JSON.stringify({ dryRun: dryRun.evidence, apply: result.evidence })
+  for (const sensitive of ['P-001', 'PART-A', 'A-001', 'Assembly', 'sort_id', 'ORDER-1']) {
+    assert.equal(text.includes(sensitive), false, `source-correction evidence hides ${sensitive}`)
+  }
+}
+
 async function testLargeBomBoundedDryRunBlocksApplyToken() {
   const source = createSourceAdapter(childBomPlmData())
   const records = createRecordsApi()
@@ -866,6 +938,7 @@ async function main() {
   await testTargetFieldMapIncompleteFailsBeforeReads()
   await testApplyRequiresTokenRecomputesAndScopesTarget()
   await testSavedKeepMultipleRowsPolicyRequiresFreshReviewAndAppliesResolvedRows()
+  await testSavedSourceCorrectionPolicyKeepsDuplicateHeldAndWritesNothing()
   await testLargeBomBoundedDryRunBlocksApplyToken()
   await testLargeBomBoundedApplyRejectsMatchingTokenBeforeWrites()
   await testReadPageLimitBoundedDryRunAndDepthHardFailureStayDistinct()

--- a/plugins/plugin-integration-core/lib/stock-preparation-conflict-planner.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-conflict-planner.cjs
@@ -398,6 +398,12 @@ function duplicatePolicySelections(review) {
   return selections
 }
 
+function heldReasonForDuplicatePolicy(policy) {
+  if (policy === 'hold') return 'default_hold'
+  if (policy === 'source_correction_required') return 'source_correction_required'
+  return 'unsupported_policy'
+}
+
 function duplicateGroupDiscriminator(rows) {
   if (hasDistinctStableDiscriminator(rows, DUPLICATE_SOURCE_DETAIL_FIELDS)) {
     return {
@@ -508,7 +514,7 @@ function resolveDuplicateExpandedRows({ expandedKeyed, existingKeyed, duplicateP
         rows,
         policy: selected.policy,
         scope: selected.scope,
-        reason: selected.policy === 'hold' ? 'default_hold' : 'unsupported_policy',
+        reason: heldReasonForDuplicatePolicy(selected.policy),
       })
       continue
     }


### PR DESCRIPTION
## Summary

D4-1 implements the conservative `source_correction_required` duplicate-expanded-key policy as held-only runtime behavior.

- selected `source_correction_required` policies now report an explicit `source_correction_required` held reason instead of generic `unsupported_policy`
- affected duplicate groups stay fail-closed as held/manual-confirm and produce no add/update/skip/inactive decisions
- saved table-scope `source_correction_required` policies dry-run/apply as held with zero records API create/patch calls
- unimplemented policies (`merge_quantity`, `select_representative`, `skip_selected`) remain held as `unsupported_policy`
- docs/TODO updated to split D4 design from D4-1 runtime and record verification

## Boundary

- no C2 expansion change
- no idempotency-key change
- no route/UI/migration/package/OpenAPI change
- no PLM write, external DB write, K3 path, or production rollout
- no source repair; this only reports that source correction is required

## Verification

- `node plugins/plugin-integration-core/__tests__/stock-preparation-conflict-planner.test.cjs`
- `node plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs`
- `node plugins/plugin-integration-core/__tests__/stock-preparation-conflict-policies.test.cjs`
- `for f in $(rg --files plugins/plugin-integration-core/__tests__ | rg 'stock-preparation.*\\.test\\.cjs$'); do node "$f"; done`
- `git diff --cached --check`

Attempted `pnpm --filter plugin-integration-core test`, but this temporary worktree has no `node_modules`; the run stopped at `ERR_MODULE_NOT_FOUND: Cannot find package 'tsx'` in `host-loader-smoke.test.mjs` after `plugin-runtime-smoke` passed. No lockfile or dependency install was performed in this PR.
