### PR TITLE
feat(data-factory): add large-BOM expansion job skeleton

### DIFF
--- a/docs/development/data-factory-plm-stock-preparation-large-bom-c3-job-skeleton-verification-20260608.md
+++ b/docs/development/data-factory-plm-stock-preparation-large-bom-c3-job-skeleton-verification-20260608.md
@@ -1,0 +1,88 @@
+# Data Factory #2342 - C3 large-BOM job skeleton verification (2026-06-08)
+
+## Scope
+
+This slice implements only the C3-1/C3-2 job skeleton for large-BOM background
+expansion:
+
+- durable job-store contract;
+- queued background expansion job creation;
+- values-free inspect response;
+- cancel transition for a queued job.
+
+It does not implement C3 checkpointed expansion, C3 authoritative artifacts,
+C4 checkpointed apply, PLM/external writes, K3 writes, source reads, target
+record reads, or MetaSheet row writes.
+
+## Runtime Contract
+
+Routes added:
+
+- `POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs`
+- `GET /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId`
+- `POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/cancel`
+
+The start route accepts only `{ parameters: { projectNo } }`. Browser-supplied
+source, target, read plan, SQL, caps, plan, payload, sheet id, field id, or
+token fields are rejected at the route boundary.
+
+Background expansion requires `context.storage.durable === true`. A regular
+memory store fails closed with `LARGE_BOM_JOB_STORE_UNAVAILABLE`, because it
+cannot satisfy resume semantics.
+
+The start/cancel paths require an authenticated principal. Missing `user.id` /
+`user.email` fails closed with `LARGE_BOM_JOB_PRINCIPAL_REQUIRED`; there is no
+system/admin/service fallback.
+
+## Values-Free Evidence
+
+Public job responses expose:
+
+- opaque `jobId`;
+- status and `largeBom=true`;
+- `projectNoPresent`;
+- progress counters;
+- source kind token;
+- values-free error/read-shape tokens.
+
+Public job responses do not expose:
+
+- project number;
+- principal;
+- source external system id;
+- target sheet id or field ids;
+- PLM rows;
+- target rows;
+- read filters or filter values;
+- raw SQL;
+- credentials, tokens, or connection strings.
+
+## Verification
+
+Commands run:
+
+```sh
+pnpm --filter plugin-integration-core test:stock-preparation-large-bom-jobs
+pnpm --filter plugin-integration-core test:http-routes
+```
+
+Assertions locked:
+
+- memory-only storage is rejected before source load, adapter creation, target
+  reads, or target writes;
+- durable storage permits a queued job;
+- inspect returns a values-free queued job;
+- read-only users cannot cancel;
+- cancel rejects browser-supplied scope fields;
+- cancel transitions the job to `cancelled` without making it authoritative;
+- helper-level lifecycle responses remain values-free even though private job
+  state stores the project parameter and principal for future worker resume.
+
+## Deferred
+
+The following remain separate gated slices:
+
+- C3-3 checkpointed expansion and resume;
+- C3-4 authoritative artifact/planner handoff;
+- C3-5 entity-machine validation;
+- C4 checkpointed apply.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -48,6 +48,13 @@ function createMemoryStorage() {
   }
 }
 
+function createDurableMemoryStorage() {
+  return {
+    ...createMemoryStorage(),
+    durable: true,
+  }
+}
+
 function createMockContext(options = {}) {
   const routes = new Map()
   const records = options.recordsApi || {
@@ -2765,6 +2772,122 @@ async function testTableActionRoutes() {
   assert.equal(JSON.stringify(res.body.data.evidence).includes('A-001'), false, 'apply evidence hides component code')
 }
 
+async function testLargeBomBackgroundExpansionJobRoutes() {
+  const records = createTableActionRecordsApi()
+  const { calls, services } = createMockServices()
+  const config = {
+    stockPreparationTableActions: [tableActionConfig()],
+  }
+  let mount = mountRoutes(services, {
+    recordsApi: records.recordsApi,
+    storage: createMemoryStorage(),
+    config,
+  })
+
+  assert.ok(
+    mount.registered.includes('POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs'),
+    'large-BOM expansion job start route registered',
+  )
+  assert.ok(
+    mount.registered.includes('GET /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId'),
+    'large-BOM expansion job inspect route registered',
+  )
+  assert.ok(
+    mount.registered.includes('POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/cancel'),
+    'large-BOM expansion job cancel route registered',
+  )
+
+  let res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID },
+    body: { parameters: { projectNo: 'P-001' } },
+  })
+  assert.equal(res.statusCode, 501)
+  assert.equal(res.body.error.code, 'LARGE_BOM_JOB_STORE_UNAVAILABLE', 'memory-only storage is rejected for background expansion')
+  assert.equal(findCalls(calls, 'getExternalSystemForAdapter').length, 0, 'missing durable store fails before source load')
+  assert.equal(findCalls(calls, 'createAdapter').length, 0, 'missing durable store fails before adapter creation')
+  assert.equal(records.calls.length, 0, 'missing durable store fails before target reads/writes')
+
+  const storage = createDurableMemoryStorage()
+  mount = mountRoutes(services, {
+    recordsApi: records.recordsApi,
+    storage,
+    config,
+  })
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID },
+    body: {
+      parameters: { projectNo: 'P-001' },
+      source: { externalSystemId: 'evil' },
+    },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.body.error.code, 'TABLE_ACTION_REQUEST_INVALID', 'browser-supplied source is rejected')
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs', {
+    user: { tenantId: 'tenant_1', permissions: ['integration:read'] },
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID },
+    body: { parameters: { projectNo: 'P-001' } },
+  })
+  assert.equal(res.statusCode, 422)
+  assert.equal(res.body.error.code, 'LARGE_BOM_JOB_PRINCIPAL_REQUIRED', 'missing principal fails closed without fallback')
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID },
+    body: { parameters: { projectNo: 'P-001' } },
+  })
+  assertOkResponse(res, 202)
+  assert.equal(res.body.data.status, 'queued')
+  assert.equal(res.body.data.largeBom, true)
+  assert.equal(res.body.data.authoritative, false)
+  assert.equal(res.body.data.projectNoPresent, true)
+  assert.equal(res.body.data.jobIdPresent, true)
+  assert.equal(typeof res.body.data.jobId, 'string')
+  assert.equal(res.body.data.evidence.sourceKind, 'data-source:sql-readonly')
+  const responseText = JSON.stringify(res.body.data)
+  assert.equal(responseText.includes('P-001'), false, 'job start response is values-free')
+  assert.equal(responseText.includes('user_read'), false, 'job start response hides principal')
+  assert.equal(responseText.includes('sheet_stock_configured'), false, 'job start response hides target sheet')
+  assert.equal(responseText.includes('plm_sql_source'), false, 'job start response hides source binding')
+  assert.equal(findCalls(calls, 'getExternalSystemForAdapter').length, 0, 'job start does not load source system')
+  assert.equal(findCalls(calls, 'createAdapter').length, 0, 'job start does not create source adapter')
+  assert.equal(records.calls.length, 0, 'job start does not read or write target rows')
+  const jobId = res.body.data.jobId
+
+  res = await invoke(mount.routes, 'GET', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.jobId, jobId)
+  assert.equal(res.body.data.status, 'queued')
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/cancel', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+  })
+  assert.equal(res.statusCode, 403, 'read-only user cannot cancel a background job')
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/cancel', {
+    user: WRITE_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+    body: { sheetId: 'evil_sheet' },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.body.error.code, 'TABLE_ACTION_REQUEST_INVALID', 'cancel rejects browser-supplied scope')
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/cancel', {
+    user: WRITE_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.status, 'cancelled')
+  assert.equal(res.body.data.authoritative, false)
+}
+
 async function testTableActionConflictPolicyRoutes() {
   const calls = []
   const adapterCalls = []
@@ -3095,6 +3218,7 @@ async function main() {
   await testStockPreparationTargetProvisioningRoutes()
   await testStockPreparationOptionSyncRoute()
   await testTableActionRoutes()
+  await testLargeBomBackgroundExpansionJobRoutes()
   await testTableActionConflictPolicyRoutes()
   await testTableActionRoutesSupportExplicitBridgeSource()
   await testTableActionTargetPreflightBeforeSourceAdapter()

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-large-bom-jobs.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-large-bom-jobs.test.cjs
@@ -8,7 +8,11 @@ const {
   LARGE_BOM_CHECKPOINT_APPLY_STATUSES,
   StockPreparationLargeBomJobError,
   assertAuthoritativeLargeBomExpansion,
+  cancelLargeBomBackgroundExpansionJob,
+  createLargeBomBackgroundExpansionJob,
   isAuthoritativeLargeBomExpansion,
+  loadLargeBomBackgroundExpansionJob,
+  publicBackgroundExpansionJob,
   summarizeLargeBomBackgroundExpansionJobForEvidence,
   summarizeLargeBomCheckpointApplyJobForEvidence,
 } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-large-bom-jobs.cjs'))
@@ -39,6 +43,20 @@ function assertLargeBomJobError(fn, code) {
   assert.ok(err instanceof StockPreparationLargeBomJobError, `expected ${code}`)
   assert.equal(err.code, code)
   return err
+}
+
+function createStorage({ durable = true } = {}) {
+  const map = new Map()
+  return {
+    durable,
+    map,
+    async get(key) {
+      return map.get(key) || null
+    },
+    async set(key, value) {
+      map.set(key, JSON.parse(JSON.stringify(value)))
+    },
+  }
 }
 
 function testStatusEnumsArePinned() {
@@ -262,13 +280,109 @@ function testInvalidStatusAndCountsFailClosed() {
   assert.equal(numericString.counts.created, 5)
 }
 
-function main() {
+async function testBackgroundJobStoreRequiresDurableStorageAndPrincipal() {
+  await assert.rejects(
+    () => createLargeBomBackgroundExpansionJob({
+      storage: createStorage({ durable: false }),
+      action: { actionId: 'plm.stock-preparation.pull-bom.v1' },
+      parameters: { projectNo: 'PROJECT_VALUE_SHOULD_NOT_APPEAR' },
+      principal: 'user-1',
+      createJobId: () => 'job-1',
+    }),
+    (error) => error instanceof StockPreparationLargeBomJobError &&
+      error.code === 'LARGE_BOM_JOB_STORE_UNAVAILABLE' &&
+      error.status === 501,
+  )
+
+  await assert.rejects(
+    () => createLargeBomBackgroundExpansionJob({
+      storage: createStorage(),
+      action: { actionId: 'plm.stock-preparation.pull-bom.v1' },
+      parameters: { projectNo: 'PROJECT_VALUE_SHOULD_NOT_APPEAR' },
+      principal: '',
+      createJobId: () => 'job-1',
+    }),
+    (error) => error instanceof StockPreparationLargeBomJobError &&
+      error.code === 'LARGE_BOM_JOB_PRINCIPAL_REQUIRED',
+  )
+}
+
+async function testBackgroundJobLifecycleIsValuesFree() {
+  const storage = createStorage()
+  const job = await createLargeBomBackgroundExpansionJob({
+    storage,
+    action: {
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      source: { kind: 'data-source:sql-readonly' },
+      target: { sheetId: 'TARGET_RECORD_VALUE_SHOULD_NOT_APPEAR' },
+    },
+    parameters: { projectNo: 'PROJECT_VALUE_SHOULD_NOT_APPEAR' },
+    principal: 'PRIVATE_TOKEN_SHOULD_NOT_APPEAR',
+    createJobId: () => 'job-values-free-1',
+    now: () => '2026-06-08T00:00:00.000Z',
+  })
+
+  assert.equal(job.status, 'queued')
+  assert.equal(job.authoritative, false)
+  assert.equal(job.parameters.projectNo, 'PROJECT_VALUE_SHOULD_NOT_APPEAR', 'private job keeps operator parameter for future worker resume')
+  assert.equal(job.principal, 'PRIVATE_TOKEN_SHOULD_NOT_APPEAR', 'private job captures request principal for future source reads')
+  assert.equal(job.actionSnapshot.target.sheetId, 'TARGET_RECORD_VALUE_SHOULD_NOT_APPEAR', 'private job captures the server-side action config for future worker resume')
+
+  const publicJob = publicBackgroundExpansionJob(job)
+  assert.equal(publicJob.jobId, 'job-values-free-1')
+  assert.deepEqual(publicJob.progress, {
+    rowsExpanded: 0,
+    readCount: 0,
+    frontierRemaining: 0,
+    completedChunks: 0,
+  })
+  assert.equal(publicJob.projectNoPresent, true)
+  assert.equal(publicJob.evidence.sourceKind, 'data-source:sql-readonly')
+  assertValuesFree(publicJob)
+
+  const loaded = await loadLargeBomBackgroundExpansionJob({
+    storage,
+    actionId: 'plm.stock-preparation.pull-bom.v1',
+    jobId: 'job-values-free-1',
+  })
+  assert.deepEqual(loaded, job)
+
+  const cancelled = await cancelLargeBomBackgroundExpansionJob({
+    storage,
+    actionId: 'plm.stock-preparation.pull-bom.v1',
+    jobId: 'job-values-free-1',
+    principal: 'user-1',
+    now: () => '2026-06-08T00:01:00.000Z',
+  })
+  assert.equal(cancelled.status, 'cancelled')
+  assert.equal(cancelled.authoritative, false)
+  assertValuesFree(publicBackgroundExpansionJob(cancelled))
+
+  await assert.rejects(
+    () => loadLargeBomBackgroundExpansionJob({
+      storage,
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      jobId: 'missing-job',
+    }),
+    (error) => error instanceof StockPreparationLargeBomJobError &&
+      error.code === 'LARGE_BOM_JOB_NOT_FOUND' &&
+      error.status === 404,
+  )
+}
+
+async function main() {
   testStatusEnumsArePinned()
   testBackgroundEvidenceIsValuesFreeProjection()
   testBackgroundEvidenceRejectsUnsafeTokens()
   testAuthoritativeExpansionGate()
   testCheckpointApplyEvidenceIsValuesFreeProjection()
   testInvalidStatusAndCountsFailClosed()
+  await testBackgroundJobStoreRequiresDurableStorageAndPrincipal()
+  await testBackgroundJobLifecycleIsValuesFree()
 }
 
-main()
+main().catch((err) => {
+  console.error('stock-preparation-large-bom-jobs FAILED')
+  console.error(err)
+  process.exit(1)
+})

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-large-bom-jobs.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-large-bom-jobs.test.cjs
@@ -59,6 +59,11 @@ function createStorage({ durable = true } = {}) {
   }
 }
 
+const TEST_SCOPE = Object.freeze({
+  tenantId: 'tenant-1',
+  workspaceId: 'workspace-1',
+})
+
 function testStatusEnumsArePinned() {
   assert.deepEqual(LARGE_BOM_BACKGROUND_EXPANSION_STATUSES, [
     'queued',
@@ -284,6 +289,7 @@ async function testBackgroundJobStoreRequiresDurableStorageAndPrincipal() {
   await assert.rejects(
     () => createLargeBomBackgroundExpansionJob({
       storage: createStorage({ durable: false }),
+      ...TEST_SCOPE,
       action: { actionId: 'plm.stock-preparation.pull-bom.v1' },
       parameters: { projectNo: 'PROJECT_VALUE_SHOULD_NOT_APPEAR' },
       principal: 'user-1',
@@ -297,6 +303,7 @@ async function testBackgroundJobStoreRequiresDurableStorageAndPrincipal() {
   await assert.rejects(
     () => createLargeBomBackgroundExpansionJob({
       storage: createStorage(),
+      ...TEST_SCOPE,
       action: { actionId: 'plm.stock-preparation.pull-bom.v1' },
       parameters: { projectNo: 'PROJECT_VALUE_SHOULD_NOT_APPEAR' },
       principal: '',
@@ -305,12 +312,27 @@ async function testBackgroundJobStoreRequiresDurableStorageAndPrincipal() {
     (error) => error instanceof StockPreparationLargeBomJobError &&
       error.code === 'LARGE_BOM_JOB_PRINCIPAL_REQUIRED',
   )
+
+  await assert.rejects(
+    () => createLargeBomBackgroundExpansionJob({
+      storage: createStorage(),
+      tenantId: 'tenant-1',
+      action: { actionId: 'plm.stock-preparation.pull-bom.v1' },
+      parameters: { projectNo: 'PROJECT_VALUE_SHOULD_NOT_APPEAR' },
+      principal: 'user-1',
+      createJobId: () => 'job-1',
+    }),
+    (error) => error instanceof StockPreparationLargeBomJobError &&
+      error.code === 'LARGE_BOM_JOB_SCOPE_REQUIRED' &&
+      error.details.workspaceIdPresent === false,
+  )
 }
 
 async function testBackgroundJobLifecycleIsValuesFree() {
   const storage = createStorage()
   const job = await createLargeBomBackgroundExpansionJob({
     storage,
+    ...TEST_SCOPE,
     action: {
       actionId: 'plm.stock-preparation.pull-bom.v1',
       source: { kind: 'data-source:sql-readonly' },
@@ -342,13 +364,41 @@ async function testBackgroundJobLifecycleIsValuesFree() {
 
   const loaded = await loadLargeBomBackgroundExpansionJob({
     storage,
+    ...TEST_SCOPE,
     actionId: 'plm.stock-preparation.pull-bom.v1',
     jobId: 'job-values-free-1',
   })
   assert.deepEqual(loaded, job)
 
+  await assert.rejects(
+    () => loadLargeBomBackgroundExpansionJob({
+      storage,
+      tenantId: 'tenant-2',
+      workspaceId: 'workspace-1',
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      jobId: 'job-values-free-1',
+    }),
+    (error) => error instanceof StockPreparationLargeBomJobError &&
+      error.code === 'LARGE_BOM_JOB_NOT_FOUND' &&
+      error.status === 404,
+  )
+
+  await assert.rejects(
+    () => loadLargeBomBackgroundExpansionJob({
+      storage,
+      tenantId: 'tenant-1',
+      workspaceId: 'workspace-2',
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      jobId: 'job-values-free-1',
+    }),
+    (error) => error instanceof StockPreparationLargeBomJobError &&
+      error.code === 'LARGE_BOM_JOB_NOT_FOUND' &&
+      error.status === 404,
+  )
+
   const cancelled = await cancelLargeBomBackgroundExpansionJob({
     storage,
+    ...TEST_SCOPE,
     actionId: 'plm.stock-preparation.pull-bom.v1',
     jobId: 'job-values-free-1',
     principal: 'user-1',
@@ -361,6 +411,7 @@ async function testBackgroundJobLifecycleIsValuesFree() {
   await assert.rejects(
     () => loadLargeBomBackgroundExpansionJob({
       storage,
+      ...TEST_SCOPE,
       actionId: 'plm.stock-preparation.pull-bom.v1',
       jobId: 'missing-job',
     }),

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -26,6 +26,9 @@ const ROUTES = [
   ['GET', '/api/integration/table-actions', 'tableActionsList'],
   ['POST', '/api/integration/table-actions/:actionId/dry-run', 'tableActionDryRun'],
   ['POST', '/api/integration/table-actions/:actionId/apply', 'tableActionApply'],
+  ['POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs', 'tableActionLargeBomExpansionJobStart'],
+  ['GET', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId', 'tableActionLargeBomExpansionJobGet'],
+  ['POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/cancel', 'tableActionLargeBomExpansionJobCancel'],
   ['GET', '/api/integration/table-actions/:actionId/conflict-policies', 'tableActionConflictPoliciesList'],
   ['PUT', '/api/integration/table-actions/:actionId/conflict-policies', 'tableActionConflictPoliciesSave'],
   ['DELETE', '/api/integration/table-actions/:actionId/conflict-policies', 'tableActionConflictPoliciesDelete'],
@@ -66,7 +69,14 @@ const {
   assertStockPreparationTargetReady,
   createStockPreparationTableActionRegistry,
   dryRunStockPreparationAction,
+  normalizeActionParameters,
 } = require('./stock-preparation-table-actions.cjs')
+const {
+  cancelLargeBomBackgroundExpansionJob,
+  createLargeBomBackgroundExpansionJob,
+  loadLargeBomBackgroundExpansionJob,
+  publicBackgroundExpansionJob,
+} = require('./stock-preparation-large-bom-jobs.cjs')
 const {
   deleteTableScopeConflictPolicies,
   loadTableScopeConflictPolicies,
@@ -327,6 +337,8 @@ function publicRunInput(body = {}) {
 
 const VALID_TABLE_ACTION_DRY_RUN_BODY_KEYS = new Set(['parameters', 'conflictPolicyReview'])
 const VALID_TABLE_ACTION_APPLY_BODY_KEYS = new Set(['parameters', 'confirm'])
+const VALID_TABLE_ACTION_LARGE_BOM_START_BODY_KEYS = new Set(['parameters'])
+const VALID_EMPTY_REQUEST_KEYS = new Set()
 const VALID_STOCK_PREPARATION_TARGET_REQUEST_KEYS = new Set(['tenantId', 'workspaceId', 'projectId', 'baseId'])
 const VALID_STOCK_PREPARATION_OPTION_SYNC_REQUEST_KEYS = new Set([
   'tenantId',
@@ -1373,6 +1385,47 @@ function createHandlers(services, options = {}) {
         tokenStore: context.storage,
         policyStore: context.storage,
       }))
+    },
+
+    async tableActionLargeBomExpansionJobStart(req, res) {
+      requireAccess(req, 'read')
+      const body = normalizeTableActionBody(requestBody(req), VALID_TABLE_ACTION_LARGE_BOM_START_BODY_KEYS)
+      const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
+      const action = assertStockPreparationTargetReady(await tableActions.getTableAction(scopedInput(req, { actionId })))
+      const parameters = normalizeActionParameters(body.parameters)
+      const job = await createLargeBomBackgroundExpansionJob({
+        storage: context.storage,
+        action,
+        parameters,
+        principal: requestPrincipal(req),
+      })
+      return sendOk(res, publicBackgroundExpansionJob(job), 202)
+    },
+
+    async tableActionLargeBomExpansionJobGet(req, res) {
+      requireAccess(req, 'read')
+      const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
+      assertStockPreparationTargetReady(await tableActions.getTableAction(scopedInput(req, { actionId })))
+      const job = await loadLargeBomBackgroundExpansionJob({
+        storage: context.storage,
+        actionId,
+        jobId: firstString(requestParams(req).jobId),
+      })
+      return sendOk(res, publicBackgroundExpansionJob(job))
+    },
+
+    async tableActionLargeBomExpansionJobCancel(req, res) {
+      requireAccess(req, 'write')
+      normalizeTableActionBody(requestBody(req), VALID_EMPTY_REQUEST_KEYS)
+      const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
+      assertStockPreparationTargetReady(await tableActions.getTableAction(scopedInput(req, { actionId })))
+      const job = await cancelLargeBomBackgroundExpansionJob({
+        storage: context.storage,
+        actionId,
+        jobId: firstString(requestParams(req).jobId),
+        principal: requestPrincipal(req),
+      })
+      return sendOk(res, publicBackgroundExpansionJob(job))
     },
 
     async tableActionConflictPoliciesList(req, res) {

--- a/plugins/plugin-integration-core/lib/stock-preparation-large-bom-jobs.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-large-bom-jobs.cjs
@@ -191,9 +191,23 @@ function ensureDurableJobStorage(storage) {
   return storage
 }
 
-function backgroundJobKey(actionId, jobId) {
-  const safeActionId = safeEvidenceToken(actionId, 'actionId')
-  const safeJobId = safeEvidenceToken(jobId, 'jobId')
+function requiredJobScope(input = {}) {
+  const tenantId = safeEvidenceToken(input.tenantId, 'tenantId')
+  const workspaceId = safeEvidenceToken(input.workspaceId, 'workspaceId')
+  if (!tenantId || !workspaceId) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_JOB_SCOPE_REQUIRED',
+      'large-BOM job scope is required',
+      { tenantIdPresent: Boolean(tenantId), workspaceIdPresent: Boolean(workspaceId) },
+    )
+  }
+  return { tenantId, workspaceId }
+}
+
+function backgroundJobKey(input = {}) {
+  const { tenantId, workspaceId } = requiredJobScope(input)
+  const safeActionId = safeEvidenceToken(input.actionId, 'actionId')
+  const safeJobId = safeEvidenceToken(input.jobId, 'jobId')
   if (!safeActionId || !safeJobId) {
     throw new StockPreparationLargeBomJobError(
       'LARGE_BOM_JOB_ID_INVALID',
@@ -201,7 +215,7 @@ function backgroundJobKey(actionId, jobId) {
       { actionIdPresent: Boolean(safeActionId), jobIdPresent: Boolean(safeJobId) },
     )
   }
-  return `stock-preparation:large-bom:background:${safeActionId}:${safeJobId}`
+  return `stock-preparation:large-bom:background:${tenantId}:${workspaceId}:${safeActionId}:${safeJobId}`
 }
 
 function requiredPrincipal(value) {
@@ -225,6 +239,7 @@ function publicBackgroundExpansionJob(job) {
 
 async function createLargeBomBackgroundExpansionJob(input = {}) {
   const storage = ensureDurableJobStorage(input.storage)
+  const scope = requiredJobScope(input)
   const principal = requiredPrincipal(input.principal)
   const action = isPlainObject(input.action) ? input.action : {}
   const actionId = safeEvidenceToken(action.actionId || input.actionId, 'actionId')
@@ -240,6 +255,7 @@ async function createLargeBomBackgroundExpansionJob(input = {}) {
   const now = isoNow(typeof input.now === 'function' ? input.now() : undefined)
   const job = {
     jobId,
+    ...scope,
     actionId,
     status: 'queued',
     authoritative: false,
@@ -264,13 +280,13 @@ async function createLargeBomBackgroundExpansionJob(input = {}) {
     createdAt: now,
     updatedAt: now,
   }
-  await storage.set(backgroundJobKey(actionId, jobId), job)
+  await storage.set(backgroundJobKey({ ...scope, actionId, jobId }), job)
   return cloneJson(job)
 }
 
 async function loadLargeBomBackgroundExpansionJob(input = {}) {
   const storage = ensureDurableJobStorage(input.storage)
-  const key = backgroundJobKey(input.actionId, input.jobId)
+  const key = backgroundJobKey(input)
   const job = await storage.get(key)
   if (!job) {
     throw new StockPreparationLargeBomJobError(
@@ -286,7 +302,7 @@ async function loadLargeBomBackgroundExpansionJob(input = {}) {
 async function cancelLargeBomBackgroundExpansionJob(input = {}) {
   const storage = ensureDurableJobStorage(input.storage)
   requiredPrincipal(input.principal)
-  const key = backgroundJobKey(input.actionId, input.jobId)
+  const key = backgroundJobKey(input)
   const job = await storage.get(key)
   if (!job) {
     throw new StockPreparationLargeBomJobError(

--- a/plugins/plugin-integration-core/lib/stock-preparation-large-bom-jobs.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-large-bom-jobs.cjs
@@ -1,9 +1,12 @@
 'use strict'
 
-// #2342 C3/C4 latent large-BOM job contract.
-// This module is intentionally not wired to routes, workers, dry-run, or apply.
-// It defines values-free status/evidence helpers so future background expansion
-// and checkpointed apply slices have a narrow contract to build against.
+const crypto = require('node:crypto')
+
+// #2342 C3/C4 large-BOM job contract.
+// This module owns the route-facing job store/projection helpers while
+// intentionally leaving worker execution, dry-run composition, and apply to
+// later slices. It defines values-free status/evidence helpers so future
+// background expansion and checkpointed apply slices have a narrow contract.
 
 const { scrubSecretStringValue } = require('./payload-redaction.cjs')
 const {
@@ -57,11 +60,11 @@ const APPLY_COUNT_FIELDS = Object.freeze([
 ])
 
 class StockPreparationLargeBomJobError extends Error {
-  constructor(code, message, details = {}) {
+  constructor(code, message, details = {}, status = 422) {
     super(message)
     this.name = 'StockPreparationLargeBomJobError'
     this.code = code
-    this.status = 422
+    this.status = status
     this.details = details
   }
 }
@@ -146,6 +149,170 @@ function normalizeStatus(value, allowed, field) {
   return status
 }
 
+function cloneJson(value) {
+  return value === undefined ? undefined : JSON.parse(JSON.stringify(value))
+}
+
+function isoNow(now = new Date()) {
+  const date = now instanceof Date ? now : new Date(now)
+  if (!Number.isFinite(date.getTime())) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_JOB_TIMESTAMP_INVALID',
+      'job timestamp is invalid',
+      {},
+    )
+  }
+  return date.toISOString()
+}
+
+function defaultJobId() {
+  return `large-bom-expansion-${crypto.randomUUID()}`
+}
+
+function ensureDurableJobStorage(storage) {
+  if (!storage || storage.durable !== true) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_JOB_STORE_UNAVAILABLE',
+      'large-BOM background expansion requires durable job storage',
+      { durable: false },
+      501,
+    )
+  }
+  for (const method of ['get', 'set']) {
+    if (typeof storage[method] !== 'function') {
+      throw new StockPreparationLargeBomJobError(
+        'LARGE_BOM_JOB_STORE_UNAVAILABLE',
+        `large-BOM job storage is missing ${method}`,
+        { method },
+        501,
+      )
+    }
+  }
+  return storage
+}
+
+function backgroundJobKey(actionId, jobId) {
+  const safeActionId = safeEvidenceToken(actionId, 'actionId')
+  const safeJobId = safeEvidenceToken(jobId, 'jobId')
+  if (!safeActionId || !safeJobId) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_JOB_ID_INVALID',
+      'large-BOM job id is required',
+      { actionIdPresent: Boolean(safeActionId), jobIdPresent: Boolean(safeJobId) },
+    )
+  }
+  return `stock-preparation:large-bom:background:${safeActionId}:${safeJobId}`
+}
+
+function requiredPrincipal(value) {
+  const principal = optionalString(value)
+  if (!principal) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_JOB_PRINCIPAL_REQUIRED',
+      'large-BOM background expansion requires an authenticated principal',
+      {},
+    )
+  }
+  return principal
+}
+
+function publicBackgroundExpansionJob(job) {
+  return {
+    jobId: safeEvidenceToken(job && job.jobId, 'jobId'),
+    ...summarizeLargeBomBackgroundExpansionJobForEvidence(job),
+  }
+}
+
+async function createLargeBomBackgroundExpansionJob(input = {}) {
+  const storage = ensureDurableJobStorage(input.storage)
+  const principal = requiredPrincipal(input.principal)
+  const action = isPlainObject(input.action) ? input.action : {}
+  const actionId = safeEvidenceToken(action.actionId || input.actionId, 'actionId')
+  if (!actionId) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_JOB_ACTION_INVALID',
+      'large-BOM job actionId is required',
+      { actionIdPresent: false },
+    )
+  }
+  const parameters = isPlainObject(input.parameters) ? cloneJson(input.parameters) : {}
+  const jobId = safeEvidenceToken((typeof input.createJobId === 'function' ? input.createJobId() : '') || defaultJobId(), 'jobId')
+  const now = isoNow(typeof input.now === 'function' ? input.now() : undefined)
+  const job = {
+    jobId,
+    actionId,
+    status: 'queued',
+    authoritative: false,
+    projectNoPresent: optionalString(parameters.projectNo) !== '',
+    parameters,
+    principal,
+    actionSnapshot: cloneJson(action),
+    sourceKind: safeEvidenceToken(action.source && action.source.kind, 'sourceKind') || undefined,
+    progress: {
+      rowsExpanded: 0,
+      readCount: 0,
+      frontierRemaining: 0,
+      completedChunks: 0,
+    },
+    budgets: {},
+    evidence: {
+      sourceKind: safeEvidenceToken(action.source && action.source.kind, 'sourceKind') || undefined,
+      readObjects: [],
+      errorTypes: [],
+      readDiagnosticShapePresent: false,
+    },
+    createdAt: now,
+    updatedAt: now,
+  }
+  await storage.set(backgroundJobKey(actionId, jobId), job)
+  return cloneJson(job)
+}
+
+async function loadLargeBomBackgroundExpansionJob(input = {}) {
+  const storage = ensureDurableJobStorage(input.storage)
+  const key = backgroundJobKey(input.actionId, input.jobId)
+  const job = await storage.get(key)
+  if (!job) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_JOB_NOT_FOUND',
+      'large-BOM background expansion job was not found',
+      { jobIdPresent: Boolean(optionalString(input.jobId)) },
+      404,
+    )
+  }
+  return cloneJson(job)
+}
+
+async function cancelLargeBomBackgroundExpansionJob(input = {}) {
+  const storage = ensureDurableJobStorage(input.storage)
+  requiredPrincipal(input.principal)
+  const key = backgroundJobKey(input.actionId, input.jobId)
+  const job = await storage.get(key)
+  if (!job) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_JOB_NOT_FOUND',
+      'large-BOM background expansion job was not found',
+      { jobIdPresent: Boolean(optionalString(input.jobId)) },
+      404,
+    )
+  }
+  if (job.status === 'completed') {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_JOB_CANCEL_REJECTED',
+      'completed large-BOM background expansion job cannot be cancelled',
+      { status: 'completed' },
+      409,
+    )
+  }
+  if (!['cancelled', 'failed', 'expired'].includes(job.status)) {
+    job.status = 'cancelled'
+    job.authoritative = false
+    job.updatedAt = isoNow(typeof input.now === 'function' ? input.now() : undefined)
+    await storage.set(key, job)
+  }
+  return cloneJson(job)
+}
+
 function summarizeLargeBomBackgroundExpansionJobForEvidence(job = {}) {
   if (!isPlainObject(job)) {
     throw new StockPreparationLargeBomJobError(
@@ -223,11 +390,17 @@ module.exports = {
   LARGE_BOM_BACKGROUND_EXPANSION_STATUSES,
   LARGE_BOM_CHECKPOINT_APPLY_STATUSES,
   StockPreparationLargeBomJobError,
+  cancelLargeBomBackgroundExpansionJob,
+  createLargeBomBackgroundExpansionJob,
+  loadLargeBomBackgroundExpansionJob,
+  publicBackgroundExpansionJob,
   summarizeLargeBomBackgroundExpansionJobForEvidence,
   summarizeLargeBomCheckpointApplyJobForEvidence,
   isAuthoritativeLargeBomExpansion,
   assertAuthoritativeLargeBomExpansion,
   __internals: {
+    backgroundJobKey,
+    ensureDurableJobStorage,
     safeEvidenceToken,
     safeTokenList,
     nonNegativeInteger,


### PR DESCRIPTION
## Summary

Adds the #2342 C3-1/C3-2 background expansion job skeleton for PLM stock-preparation large BOMs.

This introduces:
- durable job-store gate (`context.storage.durable === true`) for large-BOM background expansion jobs;
- queued job creation with private principal + server-side action snapshot for future worker resume;
- values-free public job projection;
- start / inspect / cancel REST routes under table actions.

## Boundaries Held

- No C3 checkpointed expansion worker.
- No authoritative artifact.
- No C4 checkpointed apply.
- No source adapter read.
- No target records read/write.
- No PLM/external write, K3 write, raw SQL, or browser-supplied source/target/caps/plan/payload.
- Memory-only job storage fails closed.
- Missing authenticated principal fails closed; no system/admin/service fallback.

## Verification

Passed:

```sh
pnpm --filter plugin-integration-core test:stock-preparation-large-bom-jobs
pnpm --filter plugin-integration-core test:http-routes
pnpm --filter plugin-integration-core test:stock-preparation-table-actions
git diff --check
```

Not run to completion locally:

```sh
pnpm --filter plugin-integration-core test
```

The full plugin script stopped in this clean worktree before changed-code tests because `node --import tsx __tests__/host-loader-smoke.test.mjs` could not resolve `tsx`; pnpm also reported this worktree has no `node_modules`. CI should run this in a normal install environment.

## Notes

Verification doc: `docs/development/data-factory-plm-stock-preparation-large-bom-c3-job-skeleton-verification-20260608.md`.
