### PR TITLE
feat(data-factory): add large-BOM expansion worker seam

### DIFF
--- a/docs/development/data-factory-plm-stock-preparation-large-bom-c3-worker-verification-20260608.md
+++ b/docs/development/data-factory-plm-stock-preparation-large-bom-c3-worker-verification-20260608.md
@@ -1,0 +1,113 @@
+# Data Factory #2342 - C3 background expansion worker verification (2026-06-08)
+
+## Scope
+
+This stacked slice builds on the C3 job skeleton and adds the first background
+expansion worker seam:
+
+- run a queued/running/paused/failed background expansion job;
+- read the PLM source through the configured source adapter;
+- seal a private expansion artifact on success;
+- mark scale/correctness failures as non-authoritative failed jobs;
+- keep public job evidence values-free.
+
+It is intentionally not the full checkpoint/frontier resume implementation.
+It provides the execution and artifact seam that the later C3 checkpoint slice
+can split into resumable chunks.
+
+## Boundaries
+
+Still out of scope:
+
+- route/UI worker trigger;
+- explicit frontier queue;
+- chunk checkpoint resume;
+- authoritative planner handoff;
+- C4 checkpointed apply;
+- MetaSheet target reads or writes;
+- PLM/external writes;
+- K3 writes.
+
+The worker only calls `sourceAdapter.read(...)`. It never receives or uses a
+records API and therefore cannot create or patch target rows.
+
+## Worker Behavior
+
+`runLargeBomBackgroundExpansionJob(...)`:
+
+- requires durable job storage;
+- requires a source adapter with `read()`;
+- refuses cancelled/expired jobs;
+- leaves completed jobs unchanged on retry;
+- transitions runnable jobs to `running` before source reads;
+- calls the existing app-side flat-read BOM expander;
+- stores full private artifact rows only when the expansion is valid;
+- seals an artifact revision derived from action snapshot, parameters,
+  principal, expansion summary, and expanded rows;
+- exposes only `artifactRevisionPresent`, not the artifact revision itself;
+- sets `status='failed'` and `authoritative=false` on bounded or hard failures.
+
+The C4 authoritative gate now requires all of:
+
+- `status='completed'`;
+- `authoritative=true`;
+- a sealed artifact revision.
+
+## Values-Free Evidence
+
+Public job evidence may include:
+
+- opaque job id;
+- status;
+- progress counters;
+- source kind token;
+- read object names;
+- error type tokens;
+- artifact-revision presence boolean.
+
+Public job evidence must not include:
+
+- project number;
+- request principal;
+- source binding id;
+- target sheet id or field ids;
+- component source ids;
+- component code/name/material;
+- path, parent, or idempotency keys;
+- raw PLM rows;
+- raw filters;
+- raw SQL;
+- credentials, tokens, or connection strings.
+
+## Verification
+
+Commands run:
+
+```sh
+pnpm --filter plugin-integration-core test:stock-preparation-large-bom-jobs
+pnpm --filter plugin-integration-core test:stock-preparation-bom-expansion
+pnpm --filter plugin-integration-core test:stock-preparation-table-actions
+pnpm --filter plugin-integration-core test:http-routes
+```
+
+Locked assertions:
+
+- completed background jobs become authoritative only with a sealed artifact
+  revision;
+- completed public projection is values-free and exposes only
+  `artifactRevisionPresent`;
+- the private artifact keeps the expanded rows for future planning;
+- source reads are equality-filtered flat reads and carry no SQL/query fields;
+- rerunning an already-completed job does not re-read the source and does not
+  append duplicate artifact rows;
+- scale budget failure stays non-authoritative and exposes values-free
+  `max_rows_exceeded` evidence.
+
+## Deferred
+
+Still gated:
+
+- C3 checkpoint/frontier resume with interruption tests;
+- C3 authoritative planner handoff;
+- C3 entity-machine validation;
+- C4 checkpointed apply writer and route/UI handoff.

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-large-bom-jobs.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-large-bom-jobs.test.cjs
@@ -13,6 +13,7 @@ const {
   isAuthoritativeLargeBomExpansion,
   loadLargeBomBackgroundExpansionJob,
   publicBackgroundExpansionJob,
+  runLargeBomBackgroundExpansionJob,
   summarizeLargeBomBackgroundExpansionJobForEvidence,
   summarizeLargeBomCheckpointApplyJobForEvidence,
 } = require(path.join(__dirname, '..', 'lib', 'stock-preparation-large-bom-jobs.cjs'))
@@ -24,6 +25,14 @@ const RAW_MARKERS = Object.freeze([
   'PATH_VALUE_SHOULD_NOT_APPEAR',
   'TARGET_RECORD_VALUE_SHOULD_NOT_APPEAR',
   'PRIVATE_TOKEN_SHOULD_NOT_APPEAR',
+  'SOURCE_BINDING_SHOULD_NOT_APPEAR',
+  'CODE_VALUE_SHOULD_NOT_APPEAR',
+  'NAME_VALUE_SHOULD_NOT_APPEAR',
+  'MATERIAL_VALUE_SHOULD_NOT_APPEAR',
+  'CHILD_VALUE_SHOULD_NOT_APPEAR',
+  'CHILD_CODE_SHOULD_NOT_APPEAR',
+  'CHILD_NAME_SHOULD_NOT_APPEAR',
+  'CHILD_MATERIAL_SHOULD_NOT_APPEAR',
 ])
 
 function assertValuesFree(value) {
@@ -63,6 +72,67 @@ const TEST_SCOPE = Object.freeze({
   tenantId: 'tenant-1',
   workspaceId: 'workspace-1',
 })
+
+function clone(value) {
+  return JSON.parse(JSON.stringify(value))
+}
+
+function createSourceAdapter(data) {
+  const calls = []
+  return {
+    calls,
+    adapter: {
+      async read(input = {}) {
+        calls.push(clone(input))
+        const rows = Array.isArray(data[input.object]) ? data[input.object] : []
+        const matches = rows.filter((row) =>
+          Object.entries(input.filters || {}).every(([field, expected]) => row[field] === expected),
+        )
+        const offset = input.cursor ? Number(input.cursor) : 0
+        const limit = input.limit || 1000
+        const records = matches.slice(offset, offset + limit).map(clone)
+        return {
+          records,
+          done: offset + records.length >= matches.length,
+          nextCursor: offset + records.length < matches.length ? String(offset + records.length) : null,
+          metadata: {
+            source: 'data-source:sql-readonly',
+            filtersApplied: true,
+            filterFields: Object.keys(input.filters || {}).sort(),
+          },
+        }
+      },
+    },
+  }
+}
+
+function plmData(overrides = {}) {
+  return {
+    DN_PDM_PathExAttrInfo: [{ FileCode: 'PROJECT_VALUE_SHOULD_NOT_APPEAR', Parent_OBJ_ID: 'PATH-1' }],
+    DN_PDM_PathInfo: [{ OBJ_ID: 'PATH-1' }],
+    DN_PDM_OrderHeadInfo: [{ OBJ_ID: 'ORDER-1', path_id: 'PATH-1' }],
+    DN_PDM_OrderDetailInfo: [{ order_id: 'ORDER-1', part_id: 'COMPONENT_VALUE_SHOULD_NOT_APPEAR', quantity: '2', sort_id: 1 }],
+    DN_PDM_PartLibraryInfo: [
+      {
+        OBJ_ID: 'COMPONENT_VALUE_SHOULD_NOT_APPEAR',
+        IdentityNo: 'CODE_VALUE_SHOULD_NOT_APPEAR',
+        IdentityName: 'NAME_VALUE_SHOULD_NOT_APPEAR',
+        Material: 'MATERIAL_VALUE_SHOULD_NOT_APPEAR',
+        SysVer: 'V1',
+      },
+      {
+        OBJ_ID: 'CHILD_VALUE_SHOULD_NOT_APPEAR',
+        IdentityNo: 'CHILD_CODE_SHOULD_NOT_APPEAR',
+        IdentityName: 'CHILD_NAME_SHOULD_NOT_APPEAR',
+        Material: 'CHILD_MATERIAL_SHOULD_NOT_APPEAR',
+        SysVer: 'V1',
+      },
+    ],
+    DN_PDM_BomHeadInfo: [{ part_id: 'COMPONENT_VALUE_SHOULD_NOT_APPEAR', bom_id: 'BOM-1', SysVer: 'V1', bom_able: true }],
+    DN_PDM_BomDetailsInfo: [{ bom_pid: 'BOM-1', part_id: 'CHILD_VALUE_SHOULD_NOT_APPEAR', Bom_ExAttr1: '3', sort_id: 2 }],
+    ...overrides,
+  }
+}
 
 function testStatusEnumsArePinned() {
   assert.deepEqual(LARGE_BOM_BACKGROUND_EXPANSION_STATUSES, [
@@ -134,6 +204,7 @@ function testBackgroundEvidenceIsValuesFreeProjection() {
     status: 'running',
     largeBom: true,
     authoritative: false,
+    artifactRevisionPresent: false,
     projectNoPresent: true,
     progress: {
       rowsExpanded: 1200,
@@ -190,10 +261,15 @@ function testAuthoritativeExpansionGate() {
     () => assertAuthoritativeLargeBomExpansion({ status: 'running', authoritative: false }),
     'LARGE_BOM_ARTIFACT_NOT_AUTHORITATIVE',
   )
-  assert.deepEqual(running.details, { status: 'running', authoritative: false })
+  assert.deepEqual(running.details, { status: 'running', authoritative: false, artifactRevisionPresent: false })
 
   assertLargeBomJobError(
     () => assertAuthoritativeLargeBomExpansion({ status: 'completed', authoritative: false }),
+    'LARGE_BOM_ARTIFACT_NOT_AUTHORITATIVE',
+  )
+  assert.equal(isAuthoritativeLargeBomExpansion({ status: 'completed', authoritative: true }), false)
+  assertLargeBomJobError(
+    () => assertAuthoritativeLargeBomExpansion({ status: 'completed', authoritative: true }),
     'LARGE_BOM_ARTIFACT_NOT_AUTHORITATIVE',
   )
 }
@@ -352,6 +428,7 @@ async function testBackgroundJobLifecycleIsValuesFree() {
 
   const publicJob = publicBackgroundExpansionJob(job)
   assert.equal(publicJob.jobId, 'job-values-free-1')
+  assert.equal(publicJob.artifactRevisionPresent, false)
   assert.deepEqual(publicJob.progress, {
     rowsExpanded: 0,
     readCount: 0,
@@ -421,6 +498,147 @@ async function testBackgroundJobLifecycleIsValuesFree() {
   )
 }
 
+async function testBackgroundWorkerCompletesAuthoritativeArtifactWithoutPublicValues() {
+  const storage = createStorage()
+  const source = createSourceAdapter(plmData())
+  await createLargeBomBackgroundExpansionJob({
+    storage,
+    ...TEST_SCOPE,
+    action: {
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      source: { kind: 'data-source:sql-readonly', externalSystemId: 'SOURCE_BINDING_SHOULD_NOT_APPEAR' },
+      target: { sheetId: 'TARGET_RECORD_VALUE_SHOULD_NOT_APPEAR' },
+    },
+    parameters: { projectNo: 'PROJECT_VALUE_SHOULD_NOT_APPEAR' },
+    principal: 'PRIVATE_TOKEN_SHOULD_NOT_APPEAR',
+    createJobId: () => 'job-complete-1',
+    now: () => '2026-06-08T00:00:00.000Z',
+  })
+
+  const completed = await runLargeBomBackgroundExpansionJob({
+    storage,
+    ...TEST_SCOPE,
+    actionId: 'plm.stock-preparation.pull-bom.v1',
+    jobId: 'job-complete-1',
+    sourceAdapter: source.adapter,
+    now: () => '2026-06-08T00:01:00.000Z',
+  })
+
+  assert.equal(completed.status, 'completed')
+  assert.equal(completed.authoritative, true)
+  assert.equal(typeof completed.artifactRevision, 'string')
+  assert.equal(completed.artifact.rows.length, 2, 'private artifact keeps full expanded rows for future planning')
+  assert.equal(completed.artifact.rows[1].totalQuantity, 6)
+  assert.equal(source.calls.length > 0, true, 'worker reads through the source adapter')
+  assert.equal(source.calls.every((call) => call.filters && Object.keys(call.filters).length > 0), true, 'worker uses equality-filtered flat reads')
+  assert.equal(source.calls.every((call) => !('sql' in call) && !('rawSql' in call) && !('query' in call)), true, 'worker never sends raw SQL')
+
+  const publicJob = publicBackgroundExpansionJob(completed)
+  assert.equal(publicJob.status, 'completed')
+  assert.equal(publicJob.authoritative, true)
+  assert.equal(publicJob.artifactRevisionPresent, true)
+  assert.equal(publicJob.progress.rowsExpanded, 2)
+  assert.equal(publicJob.progress.completedChunks, 1)
+  assert.equal(publicJob.evidence.sourceKind, 'data-source:sql-readonly')
+  assert.ok(publicJob.evidence.readObjects.includes('DN_PDM_PathExAttrInfo'))
+  assertValuesFree(publicJob)
+
+  const callCountAfterCompletion = source.calls.length
+  const rerun = await runLargeBomBackgroundExpansionJob({
+    storage,
+    ...TEST_SCOPE,
+    actionId: 'plm.stock-preparation.pull-bom.v1',
+    jobId: 'job-complete-1',
+    sourceAdapter: source.adapter,
+    now: () => '2026-06-08T00:02:00.000Z',
+  })
+  assert.equal(rerun.status, 'completed')
+  assert.equal(rerun.artifactRevision, completed.artifactRevision, 'completed job retry keeps the same artifact revision')
+  assert.equal(rerun.artifact.rows.length, 2, 'completed job retry does not append duplicate artifact rows')
+  assert.equal(source.calls.length, callCountAfterCompletion, 'completed job retry does not re-read source')
+}
+
+async function testBackgroundWorkerFailsNonAuthoritativeOnScaleBudget() {
+  const storage = createStorage()
+  const source = createSourceAdapter(plmData())
+  await createLargeBomBackgroundExpansionJob({
+    storage,
+    ...TEST_SCOPE,
+    action: {
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      source: { kind: 'data-source:sql-readonly' },
+    },
+    parameters: { projectNo: 'PROJECT_VALUE_SHOULD_NOT_APPEAR' },
+    principal: 'PRIVATE_TOKEN_SHOULD_NOT_APPEAR',
+    createJobId: () => 'job-failed-1',
+    now: () => '2026-06-08T00:00:00.000Z',
+  })
+
+  const failed = await runLargeBomBackgroundExpansionJob({
+    storage,
+    ...TEST_SCOPE,
+    actionId: 'plm.stock-preparation.pull-bom.v1',
+    jobId: 'job-failed-1',
+    sourceAdapter: source.adapter,
+    expansionOptions: { maxRows: 1 },
+    now: () => '2026-06-08T00:01:00.000Z',
+  })
+
+  assert.equal(failed.status, 'failed')
+  assert.equal(failed.authoritative, false)
+  assert.equal(failed.artifact, undefined)
+  const publicJob = publicBackgroundExpansionJob(failed)
+  assert.equal(publicJob.authoritative, false)
+  assert.equal(publicJob.artifactRevisionPresent, false)
+  assert.ok(publicJob.evidence.errorTypes.includes('max_rows_exceeded'))
+  assert.ok(publicJob.evidence.scaleErrorTypes.includes('max_rows_exceeded'))
+  assertValuesFree(publicJob)
+}
+
+async function testBackgroundWorkerStoresFailedJobWhenErrorTokenIsUnsafe() {
+  const storage = createStorage()
+  await createLargeBomBackgroundExpansionJob({
+    storage,
+    ...TEST_SCOPE,
+    action: {
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      source: { kind: 'data-source:sql-readonly' },
+    },
+    parameters: { projectNo: 'PROJECT_VALUE_SHOULD_NOT_APPEAR' },
+    principal: 'PRIVATE_TOKEN_SHOULD_NOT_APPEAR',
+    createJobId: () => 'job-unsafe-error-1',
+    now: () => '2026-06-08T00:00:00.000Z',
+  })
+
+  const failed = await runLargeBomBackgroundExpansionJob({
+    storage,
+    ...TEST_SCOPE,
+    actionId: 'plm.stock-preparation.pull-bom.v1',
+    jobId: 'job-unsafe-error-1',
+    sourceAdapter: {
+      async read() {
+        const error = new Error('PROJECT_VALUE_SHOULD_NOT_APPEAR and COMPONENT_VALUE_SHOULD_NOT_APPEAR')
+        error.code = 'unsafe token with PROJECT_VALUE_SHOULD_NOT_APPEAR'
+        throw error
+      },
+    },
+    now: () => '2026-06-08T00:01:00.000Z',
+  })
+
+  assert.equal(failed.status, 'failed')
+  assert.deepEqual(failed.evidence.errorTypes, ['read_failed'])
+  assertValuesFree(publicBackgroundExpansionJob(failed))
+
+  const loaded = await loadLargeBomBackgroundExpansionJob({
+    storage,
+    ...TEST_SCOPE,
+    actionId: 'plm.stock-preparation.pull-bom.v1',
+    jobId: 'job-unsafe-error-1',
+  })
+  assert.equal(loaded.status, 'failed')
+  assert.deepEqual(loaded.evidence.errorTypes, ['read_failed'])
+}
+
 async function main() {
   testStatusEnumsArePinned()
   testBackgroundEvidenceIsValuesFreeProjection()
@@ -430,6 +648,9 @@ async function main() {
   testInvalidStatusAndCountsFailClosed()
   await testBackgroundJobStoreRequiresDurableStorageAndPrincipal()
   await testBackgroundJobLifecycleIsValuesFree()
+  await testBackgroundWorkerCompletesAuthoritativeArtifactWithoutPublicValues()
+  await testBackgroundWorkerFailsNonAuthoritativeOnScaleBudget()
+  await testBackgroundWorkerStoresFailedJobWhenErrorTokenIsUnsafe()
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/lib/stock-preparation-large-bom-jobs.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-large-bom-jobs.cjs
@@ -4,13 +4,15 @@ const crypto = require('node:crypto')
 
 // #2342 C3/C4 large-BOM job contract.
 // This module owns the route-facing job store/projection helpers while
-// intentionally leaving worker execution, dry-run composition, and apply to
-// later slices. It defines values-free status/evidence helpers so future
-// background expansion and checkpointed apply slices have a narrow contract.
+// intentionally leaving dry-run composition and apply to later slices. The
+// worker seam below produces the sealed expansion artifact used by those
+// later slices while keeping public evidence values-free.
 
 const { scrubSecretStringValue } = require('./payload-redaction.cjs')
 const {
+  expandPlmProjectBom,
   LARGE_BOM_BOUNDED_ERROR_TYPES,
+  summarizeBomExpansionForEvidence,
 } = require('./stock-preparation-bom-expansion.cjs')
 
 const LARGE_BOM_BACKGROUND_EXPANSION_STATUSES = Object.freeze([
@@ -151,6 +153,18 @@ function normalizeStatus(value, allowed, field) {
 
 function cloneJson(value) {
   return value === undefined ? undefined : JSON.parse(JSON.stringify(value))
+}
+
+function stableStringify(value) {
+  if (Array.isArray(value)) return `[${value.map((item) => stableStringify(item)).join(',')}]`
+  if (isPlainObject(value)) {
+    return `{${Object.keys(value).sort().map((key) => `${JSON.stringify(key)}:${stableStringify(value[key])}`).join(',')}}`
+  }
+  return JSON.stringify(value)
+}
+
+function hashJson(value) {
+  return crypto.createHash('sha256').update(stableStringify(value)).digest('hex')
 }
 
 function isoNow(now = new Date()) {
@@ -329,6 +343,149 @@ async function cancelLargeBomBackgroundExpansionJob(input = {}) {
   return cloneJson(job)
 }
 
+function requireSourceAdapter(adapter) {
+  if (!adapter || typeof adapter.read !== 'function') {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_JOB_SOURCE_ADAPTER_UNAVAILABLE',
+      'large-BOM background expansion requires a source adapter with read()',
+      {},
+      501,
+    )
+  }
+  return adapter
+}
+
+function expansionArtifactRevision({ job, expansion }) {
+  return hashJson({
+    action: job.actionSnapshot || { actionId: job.actionId },
+    parameters: job.parameters || {},
+    principal: job.principal,
+    expansion: {
+      rows: Array.isArray(expansion.rows) ? expansion.rows : [],
+      summary: expansion.summary || {},
+    },
+  })
+}
+
+function updateJobFromExpansion(job, expansion, now) {
+  const evidence = summarizeBomExpansionForEvidence(expansion)
+  const progress = {
+    rowsExpanded: Number(evidence.rowsExpanded || 0),
+    readCount: Number(evidence.readCount || 0),
+    frontierRemaining: 0,
+    completedChunks: expansion.valid === true ? 1 : 0,
+  }
+  const budgets = {
+    maxRows: evidence.maxRows,
+    maxPages: evidence.maxPages,
+    maxReadCount: evidence.maxReadCount,
+    maxElapsedMs: evidence.maxElapsedMs,
+    maxDepth: evidence.maxDepth,
+    maxArtifactChunks: 1,
+  }
+  for (const key of Object.keys(budgets)) {
+    if (budgets[key] === undefined || budgets[key] === null || budgets[key] === '') delete budgets[key]
+  }
+  job.progress = progress
+  job.budgets = budgets
+  job.evidence = {
+    sourceKind: job.sourceKind,
+    readObjects: evidence.readObjects || [],
+    errorTypes: evidence.errorTypes || [],
+    readDiagnosticShapePresent: Array.isArray(evidence.readDiagnostics) && evidence.readDiagnostics.length > 0,
+  }
+  job.updatedAt = now
+  if (expansion.valid === true) {
+    const revision = expansionArtifactRevision({ job, expansion })
+    job.status = 'completed'
+    job.authoritative = true
+    job.artifactRevision = revision
+    job.artifact = {
+      revision,
+      status: expansion.status,
+      rows: cloneJson(expansion.rows || []),
+      summary: cloneJson(expansion.summary || {}),
+      sealedAt: now,
+    }
+    return
+  }
+  job.status = 'failed'
+  job.authoritative = false
+  delete job.artifactRevision
+  delete job.artifact
+}
+
+function safeErrorType(error) {
+  try {
+    return safeEvidenceToken(error && (error.code || error.name), 'errorType') || 'read_failed'
+  } catch {
+    return 'read_failed'
+  }
+}
+
+async function runLargeBomBackgroundExpansionJob(input = {}) {
+  const storage = ensureDurableJobStorage(input.storage)
+  const sourceAdapter = requireSourceAdapter(input.sourceAdapter)
+  const key = backgroundJobKey(input)
+  const job = await storage.get(key)
+  if (!job) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_JOB_NOT_FOUND',
+      'large-BOM background expansion job was not found',
+      { jobIdPresent: Boolean(optionalString(input.jobId)) },
+      404,
+    )
+  }
+  if (job.status === 'completed') return cloneJson(job)
+  if (!['queued', 'running', 'paused', 'failed'].includes(job.status)) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_JOB_RUN_REJECTED',
+      'large-BOM background expansion job cannot be run from this status',
+      { status: safeEvidenceToken(job.status, 'status') || undefined },
+      409,
+    )
+  }
+  requiredPrincipal(job.principal)
+  const runningAt = isoNow(typeof input.now === 'function' ? input.now() : undefined)
+  job.status = 'running'
+  job.authoritative = false
+  job.updatedAt = runningAt
+  await storage.set(key, job)
+
+  let expansion
+  try {
+    expansion = await expandPlmProjectBom({
+      sourceAdapter,
+      projectNo: job.parameters && job.parameters.projectNo,
+      ...(isPlainObject(input.expansionOptions) ? input.expansionOptions : {}),
+    })
+  } catch (error) {
+    const failedAt = isoNow(typeof input.now === 'function' ? input.now() : undefined)
+    job.status = 'failed'
+    job.authoritative = false
+    job.progress = {
+      rowsExpanded: 0,
+      readCount: 0,
+      frontierRemaining: 0,
+      completedChunks: 0,
+    }
+    job.evidence = {
+      sourceKind: job.sourceKind,
+      readObjects: [],
+      errorTypes: [safeErrorType(error)],
+      readDiagnosticShapePresent: false,
+    }
+    job.updatedAt = failedAt
+    await storage.set(key, job)
+    return cloneJson(job)
+  }
+
+  const completedAt = isoNow(typeof input.now === 'function' ? input.now() : undefined)
+  updateJobFromExpansion(job, expansion, completedAt)
+  await storage.set(key, job)
+  return cloneJson(job)
+}
+
 function summarizeLargeBomBackgroundExpansionJobForEvidence(job = {}) {
   if (!isPlainObject(job)) {
     throw new StockPreparationLargeBomJobError(
@@ -346,6 +503,7 @@ function summarizeLargeBomBackgroundExpansionJobForEvidence(job = {}) {
     status,
     largeBom: true,
     authoritative: status === 'completed' && job.authoritative === true,
+    artifactRevisionPresent: Boolean(optionalString(job.artifactRevision || (job.artifact && job.artifact.revision))),
     projectNoPresent: job.projectNoPresent === true,
     progress: nonNegativeProjection(job.progress, BACKGROUND_PROGRESS_FIELDS),
     budgets: nonNegativeProjection(job.budgets, BACKGROUND_BUDGET_FIELDS),
@@ -361,7 +519,9 @@ function summarizeLargeBomBackgroundExpansionJobForEvidence(job = {}) {
 
 function isAuthoritativeLargeBomExpansion(job = {}) {
   if (!isPlainObject(job)) return false
-  return job.status === 'completed' && job.authoritative === true
+  return job.status === 'completed' &&
+    job.authoritative === true &&
+    Boolean(optionalString(job.artifactRevision || (job.artifact && job.artifact.revision)))
 }
 
 function assertAuthoritativeLargeBomExpansion(job = {}) {
@@ -372,6 +532,9 @@ function assertAuthoritativeLargeBomExpansion(job = {}) {
       {
         status: isPlainObject(job) ? optionalString(job.status) || undefined : undefined,
         authoritative: isPlainObject(job) ? job.authoritative === true : false,
+        artifactRevisionPresent: isPlainObject(job)
+          ? Boolean(optionalString(job.artifactRevision || (job.artifact && job.artifact.revision)))
+          : false,
       },
     )
   }
@@ -410,6 +573,7 @@ module.exports = {
   createLargeBomBackgroundExpansionJob,
   loadLargeBomBackgroundExpansionJob,
   publicBackgroundExpansionJob,
+  runLargeBomBackgroundExpansionJob,
   summarizeLargeBomBackgroundExpansionJobForEvidence,
   summarizeLargeBomCheckpointApplyJobForEvidence,
   isAuthoritativeLargeBomExpansion,
@@ -417,6 +581,7 @@ module.exports = {
   __internals: {
     backgroundJobKey,
     ensureDurableJobStorage,
+    hashJson,
     safeEvidenceToken,
     safeTokenList,
     nonNegativeInteger,


### PR DESCRIPTION
## Summary

Stacked on #2393. Adds the first #2342 C3 background expansion worker seam.

This introduces `runLargeBomBackgroundExpansionJob(...)` in the large-BOM job helper:
- transitions runnable jobs to `running`;
- reads PLM through the provided source adapter using the existing app-side flat-read BOM expander;
- seals a private expansion artifact on valid completion;
- marks scale/correctness failures as non-authoritative `failed` jobs;
- exposes only values-free public evidence (`artifactRevisionPresent`, counts, status, source kind, read object/error tokens).

## Important Boundary

This is intentionally **not** the full checkpoint/frontier-resume implementation yet. It creates the worker + artifact seam for C3, but keeps explicit checkpoint resume as a later C3 slice.

Still out of scope:
- route/UI worker trigger;
- explicit frontier queue;
- chunk checkpoint resume;
- planner handoff;
- C4 checkpointed apply;
- target records read/write;
- PLM/external writes;
- K3 writes.

## Hardening

- C4 authoritative gate now requires `completed + authoritative + sealed artifact revision`.
- Completed job retry is idempotent: it returns the sealed artifact as-is, does not re-read source, and does not append duplicate artifact rows.
- Scale budget failure stays non-authoritative and exposes values-free bounded error evidence.

## Verification

Passed:

```sh
pnpm --filter plugin-integration-core test:stock-preparation-large-bom-jobs
pnpm --filter plugin-integration-core test:stock-preparation-bom-expansion
pnpm --filter plugin-integration-core test:stock-preparation-table-actions
pnpm --filter plugin-integration-core test:http-routes
```

Verification doc: `docs/development/data-factory-plm-stock-preparation-large-bom-c3-worker-verification-20260608.md`.
