### PR TITLE
feat(data-factory): add large-BOM planner handoff

### DIFF
--- a/docs/development/data-factory-plm-stock-preparation-large-bom-c3-planner-handoff-verification-20260608.md
+++ b/docs/development/data-factory-plm-stock-preparation-large-bom-c3-planner-handoff-verification-20260608.md
@@ -1,0 +1,82 @@
+# Data Factory #2342 - C3 large-BOM planner handoff verification (2026-06-08)
+
+## Scope
+
+This stacked slice adds the read-only C3 planner handoff after a background
+expansion job completes:
+
+- load a completed authoritative expansion artifact;
+- combine its private expanded rows with caller-provided existing target rows;
+- reuse the existing C3 `planStockPreparationConflicts` planner;
+- store a private plan artifact and revision on the job;
+- expose values-free plan evidence through the public job projection.
+
+It does not add a route, UI, target records API read, target write, PLM write,
+K3 path, or C4 checkpointed apply.
+
+## Contract
+
+`planLargeBomBackgroundExpansionJob(...)` requires an authoritative artifact:
+
+- `status='completed'`;
+- `authoritative=true`;
+- sealed artifact revision present.
+
+Queued/running/failed/cancelled/expired jobs and completed jobs without a
+sealed artifact fail closed through `LARGE_BOM_ARTIFACT_NOT_AUTHORITATIVE`.
+
+The helper intentionally accepts `existingRows` as an explicit input. Future
+route/worker wiring must load those rows from the server-scoped configured
+target binding; browser-supplied target scope remains forbidden.
+
+## Values-Free Evidence
+
+The private job stores:
+
+- full plan decisions;
+- existing row count;
+- plan revision;
+- artifact revision linkage.
+
+The public job projection exposes:
+
+- `planRevisionPresent`;
+- values-free planner evidence: counts, row counts, conflict types, duplicate
+  diagnostics/resolution fingerprints and policy labels.
+
+Public evidence must not expose project numbers, component ids/codes/names,
+source ids, existing target values, target record ids, sheet ids, field ids,
+raw rows, raw payloads, credentials, or tokens.
+
+## Verification
+
+Commands run:
+
+```sh
+pnpm --filter plugin-integration-core test:stock-preparation-large-bom-jobs
+```
+
+Additional related suites to run before merge:
+
+```sh
+pnpm --filter plugin-integration-core test:stock-preparation-conflict-planner
+pnpm --filter plugin-integration-core test:stock-preparation-bom-expansion
+pnpm --filter plugin-integration-core test:http-routes
+```
+
+Locked assertions:
+
+- planner handoff refuses a non-authoritative job;
+- completed artifact produces a persisted private plan artifact;
+- public projection exposes `planRevisionPresent=true`;
+- public plan evidence is values-free;
+- no target read/write API is introduced in this slice.
+
+## Deferred
+
+Still gated:
+
+- server-side target existing-row load for large-BOM planning;
+- route/UI worker trigger;
+- explicit checkpoint/frontier resume;
+- C4 checkpointed apply.

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-large-bom-jobs.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-large-bom-jobs.test.cjs
@@ -12,6 +12,7 @@ const {
   createLargeBomBackgroundExpansionJob,
   isAuthoritativeLargeBomExpansion,
   loadLargeBomBackgroundExpansionJob,
+  planLargeBomBackgroundExpansionJob,
   publicBackgroundExpansionJob,
   runLargeBomBackgroundExpansionJob,
   summarizeLargeBomBackgroundExpansionJobForEvidence,
@@ -33,6 +34,7 @@ const RAW_MARKERS = Object.freeze([
   'CHILD_CODE_SHOULD_NOT_APPEAR',
   'CHILD_NAME_SHOULD_NOT_APPEAR',
   'CHILD_MATERIAL_SHOULD_NOT_APPEAR',
+  'EXISTING_TARGET_VALUE_SHOULD_NOT_APPEAR',
 ])
 
 function assertValuesFree(value) {
@@ -205,6 +207,7 @@ function testBackgroundEvidenceIsValuesFreeProjection() {
     largeBom: true,
     authoritative: false,
     artifactRevisionPresent: false,
+    planRevisionPresent: false,
     projectNoPresent: true,
     progress: {
       rowsExpanded: 1200,
@@ -429,6 +432,7 @@ async function testBackgroundJobLifecycleIsValuesFree() {
   const publicJob = publicBackgroundExpansionJob(job)
   assert.equal(publicJob.jobId, 'job-values-free-1')
   assert.equal(publicJob.artifactRevisionPresent, false)
+  assert.equal(publicJob.planRevisionPresent, false)
   assert.deepEqual(publicJob.progress, {
     rowsExpanded: 0,
     readCount: 0,
@@ -639,6 +643,125 @@ async function testBackgroundWorkerStoresFailedJobWhenErrorTokenIsUnsafe() {
   assert.deepEqual(loaded.evidence.errorTypes, ['read_failed'])
 }
 
+async function completedJobWithArtifact({ storage = createStorage(), jobId = 'job-plan-1' } = {}) {
+  const source = createSourceAdapter(plmData())
+  await createLargeBomBackgroundExpansionJob({
+    storage,
+    ...TEST_SCOPE,
+    action: {
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      source: { kind: 'data-source:sql-readonly', externalSystemId: 'SOURCE_BINDING_SHOULD_NOT_APPEAR' },
+      target: { sheetId: 'TARGET_RECORD_VALUE_SHOULD_NOT_APPEAR' },
+    },
+    parameters: { projectNo: 'PROJECT_VALUE_SHOULD_NOT_APPEAR' },
+    principal: 'PRIVATE_TOKEN_SHOULD_NOT_APPEAR',
+    createJobId: () => jobId,
+    now: () => '2026-06-08T00:00:00.000Z',
+  })
+  await runLargeBomBackgroundExpansionJob({
+    storage,
+    ...TEST_SCOPE,
+    actionId: 'plm.stock-preparation.pull-bom.v1',
+    jobId,
+    sourceAdapter: source.adapter,
+    now: () => '2026-06-08T00:01:00.000Z',
+  })
+  return { storage, jobId }
+}
+
+async function testPlannerHandoffRequiresAuthoritativeArtifact() {
+  const storage = createStorage()
+  await createLargeBomBackgroundExpansionJob({
+    storage,
+    ...TEST_SCOPE,
+    action: {
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      source: { kind: 'data-source:sql-readonly' },
+    },
+    parameters: { projectNo: 'PROJECT_VALUE_SHOULD_NOT_APPEAR' },
+    principal: 'PRIVATE_TOKEN_SHOULD_NOT_APPEAR',
+    createJobId: () => 'job-not-authoritative',
+  })
+
+  await assert.rejects(
+    () => planLargeBomBackgroundExpansionJob({
+      storage,
+      ...TEST_SCOPE,
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      jobId: 'job-not-authoritative',
+      existingRows: [],
+    }),
+    (error) => error instanceof StockPreparationLargeBomJobError &&
+      error.code === 'LARGE_BOM_ARTIFACT_NOT_AUTHORITATIVE',
+  )
+}
+
+async function testPlannerHandoffRejectsMalformedExistingRows() {
+  const { storage, jobId } = await completedJobWithArtifact({ jobId: 'job-bad-existing-row' })
+
+  await assert.rejects(
+    () => planLargeBomBackgroundExpansionJob({
+      storage,
+      ...TEST_SCOPE,
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      jobId,
+      existingRows: [null],
+    }),
+    (error) => error instanceof StockPreparationLargeBomJobError &&
+      error.code === 'LARGE_BOM_PLAN_EXISTING_ROWS_INVALID' &&
+      error.details.index === 0,
+  )
+
+  const loaded = await loadLargeBomBackgroundExpansionJob({
+    storage,
+    ...TEST_SCOPE,
+    actionId: 'plm.stock-preparation.pull-bom.v1',
+    jobId,
+  })
+  assert.equal(loaded.planRevision, undefined, 'malformed existingRows must not persist a plan')
+}
+
+async function testPlannerHandoffStoresValuesFreePlanEvidence() {
+  const { storage, jobId } = await completedJobWithArtifact()
+  const planned = await planLargeBomBackgroundExpansionJob({
+    storage,
+    ...TEST_SCOPE,
+    actionId: 'plm.stock-preparation.pull-bom.v1',
+    jobId,
+    existingRows: [{
+      idempotencyKey: 'EXISTING_TARGET_VALUE_SHOULD_NOT_APPEAR',
+      projectNo: 'PROJECT_VALUE_SHOULD_NOT_APPEAR',
+      componentSourceId: 'EXISTING_TARGET_VALUE_SHOULD_NOT_APPEAR',
+      componentName: 'EXISTING_TARGET_VALUE_SHOULD_NOT_APPEAR',
+      active: true,
+    }],
+    runId: 'large-bom-plan-run',
+    plannedAt: '2026-06-08T00:02:00.000Z',
+    now: () => '2026-06-08T00:03:00.000Z',
+  })
+
+  assert.equal(planned.status, 'completed')
+  assert.equal(planned.authoritative, true)
+  assert.equal(typeof planned.planRevision, 'string')
+  assert.equal(planned.planArtifact.plan.counts.add, 2, 'private plan keeps decisions for future C4')
+  assert.equal(planned.planArtifact.plan.counts.manual_confirm, 0)
+  assert.equal(planned.planArtifact.existingRowCount, 1)
+  const publicJob = publicBackgroundExpansionJob(planned)
+  assert.equal(publicJob.planRevisionPresent, true)
+  assert.equal(publicJob.evidence.plan.counts.add, 2)
+  assert.equal(publicJob.evidence.plan.expandedRows, 2)
+  assert.equal(publicJob.evidence.plan.existingRows, 1)
+  assertValuesFree(publicJob)
+
+  const loaded = await loadLargeBomBackgroundExpansionJob({
+    storage,
+    ...TEST_SCOPE,
+    actionId: 'plm.stock-preparation.pull-bom.v1',
+    jobId,
+  })
+  assert.equal(loaded.planRevision, planned.planRevision, 'plan artifact is persisted on the job')
+}
+
 async function main() {
   testStatusEnumsArePinned()
   testBackgroundEvidenceIsValuesFreeProjection()
@@ -651,6 +774,9 @@ async function main() {
   await testBackgroundWorkerCompletesAuthoritativeArtifactWithoutPublicValues()
   await testBackgroundWorkerFailsNonAuthoritativeOnScaleBudget()
   await testBackgroundWorkerStoresFailedJobWhenErrorTokenIsUnsafe()
+  await testPlannerHandoffRequiresAuthoritativeArtifact()
+  await testPlannerHandoffRejectsMalformedExistingRows()
+  await testPlannerHandoffStoresValuesFreePlanEvidence()
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/lib/stock-preparation-large-bom-jobs.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-large-bom-jobs.cjs
@@ -14,6 +14,10 @@ const {
   LARGE_BOM_BOUNDED_ERROR_TYPES,
   summarizeBomExpansionForEvidence,
 } = require('./stock-preparation-bom-expansion.cjs')
+const {
+  planStockPreparationConflicts,
+  summarizeConflictPlanForEvidence,
+} = require('./stock-preparation-conflict-planner.cjs')
 
 const LARGE_BOM_BACKGROUND_EXPANSION_STATUSES = Object.freeze([
   'queued',
@@ -486,6 +490,84 @@ async function runLargeBomBackgroundExpansionJob(input = {}) {
   return cloneJson(job)
 }
 
+function normalizeExistingRows(rows) {
+  if (rows === undefined || rows === null) return []
+  if (!Array.isArray(rows)) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_PLAN_EXISTING_ROWS_INVALID',
+      'existingRows must be an array',
+      { field: 'existingRows' },
+    )
+  }
+  for (let index = 0; index < rows.length; index += 1) {
+    if (!isPlainObject(rows[index])) {
+      throw new StockPreparationLargeBomJobError(
+        'LARGE_BOM_PLAN_EXISTING_ROWS_INVALID',
+        'existingRows entries must be objects',
+        { field: 'existingRows', index },
+      )
+    }
+  }
+  return rows.map(cloneJson)
+}
+
+function largeBomPlanRevision({ job, plan, existingRows, conflictPolicyReview }) {
+  return hashJson({
+    artifactRevision: job.artifactRevision || (job.artifact && job.artifact.revision),
+    existingRows,
+    conflictPolicyReview: conflictPolicyReview || null,
+    plan: {
+      valid: plan.valid === true,
+      counts: plan.counts || {},
+      conflictTypes: plan.summary && plan.summary.conflictTypes,
+      duplicateExpandedKeyDiagnostics: plan.summary && plan.summary.duplicateExpandedKeyDiagnostics,
+      duplicateExpandedKeyResolution: plan.summary && plan.summary.duplicateExpandedKeyResolution,
+    },
+  })
+}
+
+async function planLargeBomBackgroundExpansionJob(input = {}) {
+  const storage = ensureDurableJobStorage(input.storage)
+  const key = backgroundJobKey(input)
+  const job = await storage.get(key)
+  if (!job) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_JOB_NOT_FOUND',
+      'large-BOM background expansion job was not found',
+      { jobIdPresent: Boolean(optionalString(input.jobId)) },
+      404,
+    )
+  }
+  assertAuthoritativeLargeBomExpansion(job)
+  const artifact = isPlainObject(job.artifact) ? job.artifact : {}
+  const expandedRows = Array.isArray(artifact.rows) ? artifact.rows.map(cloneJson) : []
+  const existingRows = normalizeExistingRows(input.existingRows)
+  const conflictPolicyReview = isPlainObject(input.conflictPolicyReview) ? cloneJson(input.conflictPolicyReview) : undefined
+  const plan = planStockPreparationConflicts({
+    template: job.actionSnapshot && job.actionSnapshot.template,
+    conflictStrategy: job.actionSnapshot && job.actionSnapshot.conflictStrategy,
+    expandedRows,
+    existingRows,
+    rowErrors: [],
+    runId: input.runId || `large-bom:${job.jobId}`,
+    plannedAt: input.plannedAt,
+    duplicatePolicyReview: conflictPolicyReview,
+  })
+  const revision = largeBomPlanRevision({ job, plan, existingRows, conflictPolicyReview })
+  job.planRevision = revision
+  job.planArtifact = {
+    revision,
+    artifactRevision: job.artifactRevision || artifact.revision,
+    plan: cloneJson(plan),
+    existingRowCount: existingRows.length,
+    plannedAt: plan.plannedAt,
+  }
+  job.planEvidence = summarizeConflictPlanForEvidence(plan)
+  job.updatedAt = isoNow(typeof input.now === 'function' ? input.now() : undefined)
+  await storage.set(key, job)
+  return cloneJson(job)
+}
+
 function summarizeLargeBomBackgroundExpansionJobForEvidence(job = {}) {
   if (!isPlainObject(job)) {
     throw new StockPreparationLargeBomJobError(
@@ -497,6 +579,14 @@ function summarizeLargeBomBackgroundExpansionJobForEvidence(job = {}) {
   const evidence = isPlainObject(job.evidence) ? job.evidence : {}
   const status = normalizeStatus(job.status, LARGE_BOM_BACKGROUND_EXPANSION_STATUSES, 'status')
   const errorTypes = safeTokenList(evidence.errorTypes || job.errorTypes, 'errorTypes')
+  const publicEvidence = {
+    sourceKind: safeEvidenceToken(evidence.sourceKind || job.sourceKind, 'sourceKind') || undefined,
+    readObjects: safeTokenList(evidence.readObjects || job.readObjects, 'readObjects'),
+    errorTypes,
+    scaleErrorTypes: errorTypes.filter((errorType) => LARGE_BOM_BOUNDED_ERROR_TYPES.includes(errorType)),
+    readDiagnosticShapePresent: evidence.readDiagnosticShapePresent === true || job.readDiagnosticShapePresent === true,
+  }
+  if (isPlainObject(job.planEvidence)) publicEvidence.plan = cloneJson(job.planEvidence)
   return {
     jobIdPresent: Boolean(optionalString(job.jobId)),
     actionId: safeEvidenceToken(job.actionId, 'actionId') || undefined,
@@ -504,16 +594,11 @@ function summarizeLargeBomBackgroundExpansionJobForEvidence(job = {}) {
     largeBom: true,
     authoritative: status === 'completed' && job.authoritative === true,
     artifactRevisionPresent: Boolean(optionalString(job.artifactRevision || (job.artifact && job.artifact.revision))),
+    planRevisionPresent: Boolean(optionalString(job.planRevision || (job.planArtifact && job.planArtifact.revision))),
     projectNoPresent: job.projectNoPresent === true,
     progress: nonNegativeProjection(job.progress, BACKGROUND_PROGRESS_FIELDS),
     budgets: nonNegativeProjection(job.budgets, BACKGROUND_BUDGET_FIELDS),
-    evidence: {
-      sourceKind: safeEvidenceToken(evidence.sourceKind || job.sourceKind, 'sourceKind') || undefined,
-      readObjects: safeTokenList(evidence.readObjects || job.readObjects, 'readObjects'),
-      errorTypes,
-      scaleErrorTypes: errorTypes.filter((errorType) => LARGE_BOM_BOUNDED_ERROR_TYPES.includes(errorType)),
-      readDiagnosticShapePresent: evidence.readDiagnosticShapePresent === true || job.readDiagnosticShapePresent === true,
-    },
+    evidence: publicEvidence,
   }
 }
 
@@ -572,6 +657,7 @@ module.exports = {
   cancelLargeBomBackgroundExpansionJob,
   createLargeBomBackgroundExpansionJob,
   loadLargeBomBackgroundExpansionJob,
+  planLargeBomBackgroundExpansionJob,
   publicBackgroundExpansionJob,
   runLargeBomBackgroundExpansionJob,
   summarizeLargeBomBackgroundExpansionJobForEvidence,


### PR DESCRIPTION
## Summary

Stacked on #2394. Adds the read-only #2342 C3 planner handoff after a background expansion job completes.

This introduces `planLargeBomBackgroundExpansionJob(...)`:
- requires a completed authoritative expansion artifact;
- combines private expanded rows with caller-provided existing target rows;
- reuses the existing `planStockPreparationConflicts` C3 planner;
- stores a private plan artifact + revision on the job;
- exposes values-free plan evidence through the public job projection.

## Boundary

Still no route/UI, no target records API read, no target write, no PLM/external write, no K3, no C4 checkpointed apply.

The helper intentionally accepts `existingRows` as input. Future route/worker wiring must load those rows from the server-scoped configured target binding; browser-supplied target scope remains forbidden.

## Hardening

- Planner handoff refuses non-authoritative jobs through `LARGE_BOM_ARTIFACT_NOT_AUTHORITATIVE`.
- Public projection exposes `planRevisionPresent`, not the revision itself.
- Public plan evidence is the existing values-free planner evidence: counts, row counts, conflict types, duplicate diagnostics/resolution fingerprints and policy labels.

## Verification

Passed:

```sh
pnpm --filter plugin-integration-core test:stock-preparation-large-bom-jobs
pnpm --filter plugin-integration-core test:stock-preparation-conflict-planner
pnpm --filter plugin-integration-core test:stock-preparation-bom-expansion
pnpm --filter plugin-integration-core test:http-routes
```

Verification doc: `docs/development/data-factory-plm-stock-preparation-large-bom-c3-planner-handoff-verification-20260608.md`.
