### PR TITLE
feat(data-factory): add large-BOM checkpoint apply writer

### DIFF
--- a/docs/development/data-factory-plm-stock-preparation-large-bom-c4-writer-verification-20260608.md
+++ b/docs/development/data-factory-plm-stock-preparation-large-bom-c4-writer-verification-20260608.md
@@ -1,0 +1,53 @@
+# DF Large-BOM C4 Checkpoint Apply Writer Verification - 2026-06-08
+
+## Scope
+
+Implemented the latent C4 checkpoint apply writer service for large-BOM jobs.
+
+- Creates a checkpoint apply job only from a completed authoritative C3 plan artifact.
+- Requires durable job storage, authenticated principal, and Data Factory `write` or `admin` permission.
+- Requires explicit manual-confirm acknowledgement when the C3 plan contains held rows.
+- Applies plan decisions in bounded chunks by reusing the existing C4 `applyStockPreparationPlan` writer.
+- Persists checkpoint progress after each chunk; retry remains safe because add decisions are idempotent find-then-patch.
+- Public projection is values-free: counts, status, revision-presence booleans, result status tokens, error-code tokens, and field-category tokens only.
+
+## Boundary
+
+Not included in this slice:
+
+- No route or UI.
+- No browser-supplied plan, target, sheet id, field id, or payload.
+- No PLM/source read.
+- No target read outside the injected MetaSheet records API used by the existing C4 writer.
+- No external DB write, K3 write, Submit, Audit, BOM, production rollout, or batch apply enablement.
+
+## Tests
+
+Local verification:
+
+```text
+pnpm --filter plugin-integration-core test:stock-preparation-large-bom-jobs
+pnpm --filter plugin-integration-core test:stock-preparation-apply-writer
+pnpm --filter plugin-integration-core test:stock-preparation-conflict-planner
+pnpm --filter plugin-integration-core test:stock-preparation-bom-expansion
+pnpm --filter plugin-integration-core test:http-routes
+```
+
+Covered cases:
+
+- durable storage is mandatory;
+- non-authoritative or missing C3 plan artifact is rejected;
+- read permission is rejected for apply;
+- manual-confirm rows require explicit acknowledgement before apply job creation;
+- chunked apply writes clean rows while holding manual-confirm rows;
+- public apply job summary stays values-free;
+- simulated checkpoint loss after a successful add does not create a duplicate row on retry.
+
+## Remaining Gated Work
+
+The next C4 slices still need separate review:
+
+- route/action wiring with server-side permission derivation;
+- records API scoping to the configured target sheet;
+- operator-facing progress and approval surface;
+- entity-machine large-BOM validation before any production/batch rollout.

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-large-bom-jobs.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-large-bom-jobs.test.cjs
@@ -224,6 +224,7 @@ async function seedPlannedLargeBomJob({
   const actionId = 'plm.stock-preparation.pull-bom.v1'
   const job = {
     jobId,
+    ...TEST_SCOPE,
     actionId,
     status: 'completed',
     authoritative: true,
@@ -268,8 +269,8 @@ async function seedPlannedLargeBomJob({
     createdAt: '2026-06-08T00:00:00.000Z',
     updatedAt: '2026-06-08T00:00:00.000Z',
   }
-  await storage.set(__internals.backgroundJobKey(actionId, jobId), job)
-  return { storage, actionId, jobId, job }
+  await storage.set(__internals.backgroundJobKey({ ...TEST_SCOPE, actionId, jobId }), job)
+  return { storage, ...TEST_SCOPE, actionId, jobId, job }
 }
 
 function plmData(overrides = {}) {
@@ -943,6 +944,7 @@ async function testCheckpointApplyRequiresDurablePlanPermissionAndManualAck() {
   const storageWithoutPlan = createStorage()
   await createLargeBomBackgroundExpansionJob({
     storage: storageWithoutPlan,
+    ...TEST_SCOPE,
     action: { actionId: 'plm.stock-preparation.pull-bom.v1', target: targetBinding() },
     parameters: { projectNo: 'PROJECT_VALUE_SHOULD_NOT_APPEAR' },
     principal: 'PRIVATE_TOKEN_SHOULD_NOT_APPEAR',
@@ -951,6 +953,7 @@ async function testCheckpointApplyRequiresDurablePlanPermissionAndManualAck() {
   await assert.rejects(
     () => createLargeBomCheckpointApplyJob({
       storage: storageWithoutPlan,
+      ...TEST_SCOPE,
       actionId: 'plm.stock-preparation.pull-bom.v1',
       jobId: 'job-no-plan',
       principal: 'user-1',
@@ -965,6 +968,7 @@ async function testCheckpointApplyRequiresDurablePlanPermissionAndManualAck() {
   await assert.rejects(
     () => createLargeBomCheckpointApplyJob({
       storage,
+      ...TEST_SCOPE,
       actionId,
       jobId,
       principal: 'user-1',
@@ -984,6 +988,7 @@ async function testCheckpointApplyRequiresDurablePlanPermissionAndManualAck() {
   await assert.rejects(
     () => createLargeBomCheckpointApplyJob({
       storage: seeded.storage,
+      ...TEST_SCOPE,
       actionId: seeded.actionId,
       jobId: seeded.jobId,
       principal: 'user-1',
@@ -1006,6 +1011,7 @@ async function testCheckpointApplyChunksPlanAndKeepsPublicEvidenceValuesFree() {
   const api = createTargetRecordsApi()
   const created = await createLargeBomCheckpointApplyJob({
     storage,
+    ...TEST_SCOPE,
     actionId,
     jobId,
     principal: 'user-1',
@@ -1021,19 +1027,21 @@ async function testCheckpointApplyChunksPlanAndKeepsPublicEvidenceValuesFree() {
 
   const first = await runLargeBomCheckpointApplyJobChunk({
     storage,
+    ...TEST_SCOPE,
     actionId,
     applyJobId: 'apply-job-chunks',
     recordsApi: api.recordsApi,
     maxDecisionsPerChunk: 1,
     now: () => '2026-06-08T00:02:00.000Z',
   })
-  assert.equal(first.status, 'running')
+  assert.equal(first.status, 'paused', 'completed non-terminal chunks are ready for the next explicit run')
   assert.equal(first.checkpoint.nextDecisionIndex, 1)
   assert.equal(first.counts.created, 1)
   assert.equal(api.rows.length, 1)
 
   const second = await runLargeBomCheckpointApplyJobChunk({
     storage,
+    ...TEST_SCOPE,
     actionId,
     applyJobId: 'apply-job-chunks',
     recordsApi: api.recordsApi,
@@ -1069,6 +1077,7 @@ async function testCheckpointApplyChunksPlanAndKeepsPublicEvidenceValuesFree() {
 
   const loaded = await loadLargeBomCheckpointApplyJob({
     storage,
+    ...TEST_SCOPE,
     actionId,
     applyJobId: 'apply-job-chunks',
   })
@@ -1079,6 +1088,7 @@ async function testCheckpointApplyMissingRecordsApiFailsBeforeRunning() {
   const { storage, actionId, jobId } = await seedPlannedLargeBomJob({ jobId: 'job-missing-records-api' })
   await createLargeBomCheckpointApplyJob({
     storage,
+    ...TEST_SCOPE,
     actionId,
     jobId,
     principal: 'user-1',
@@ -1089,6 +1099,7 @@ async function testCheckpointApplyMissingRecordsApiFailsBeforeRunning() {
   await assert.rejects(
     () => runLargeBomCheckpointApplyJobChunk({
       storage,
+      ...TEST_SCOPE,
       actionId,
       applyJobId: 'apply-job-missing-records-api',
       recordsApi: {},
@@ -1101,6 +1112,7 @@ async function testCheckpointApplyMissingRecordsApiFailsBeforeRunning() {
 
   const loaded = await loadLargeBomCheckpointApplyJob({
     storage,
+    ...TEST_SCOPE,
     actionId,
     applyJobId: 'apply-job-missing-records-api',
   })
@@ -1108,24 +1120,26 @@ async function testCheckpointApplyMissingRecordsApiFailsBeforeRunning() {
   assert.equal(loaded.checkpoint.nextDecisionIndex, 0, 'missing recordsApi does not advance the checkpoint')
 }
 
-async function testCheckpointApplyRetryDoesNotDuplicateAddAfterCheckpointLoss() {
+async function testCheckpointApplyRejectsConcurrentRunningChunk() {
   const key = 'PROJECT_VALUE_SHOULD_NOT_APPEAR::IDEMPOTENT-KEY'
   const plan = planWithDecisions([addDecision(key)])
-  const { storage, actionId, jobId } = await seedPlannedLargeBomJob({ plan, jobId: 'job-idempotent-apply' })
+  const { storage, actionId, jobId } = await seedPlannedLargeBomJob({ plan, jobId: 'job-concurrent-apply' })
   const api = createTargetRecordsApi()
   await createLargeBomCheckpointApplyJob({
     storage,
+    ...TEST_SCOPE,
     actionId,
     jobId,
     principal: 'user-1',
     permission: 'admin',
-    createApplyJobId: () => 'apply-job-idempotent',
+    createApplyJobId: () => 'apply-job-concurrent',
   })
 
   const first = await runLargeBomCheckpointApplyJobChunk({
     storage,
+    ...TEST_SCOPE,
     actionId,
-    applyJobId: 'apply-job-idempotent',
+    applyJobId: 'apply-job-concurrent',
     recordsApi: api.recordsApi,
     maxDecisionsPerChunk: 1,
   })
@@ -1133,7 +1147,7 @@ async function testCheckpointApplyRetryDoesNotDuplicateAddAfterCheckpointLoss() 
   assert.equal(first.counts.created, 1)
   assert.equal(api.rows.length, 1)
 
-  const applyKey = __internals.checkpointApplyJobKey(actionId, 'apply-job-idempotent')
+  const applyKey = __internals.checkpointApplyJobKey({ ...TEST_SCOPE, actionId, applyJobId: 'apply-job-concurrent' })
   const persisted = await storage.get(applyKey)
   persisted.status = 'running'
   persisted.checkpoint.nextDecisionIndex = 0
@@ -1152,20 +1166,31 @@ async function testCheckpointApplyRetryDoesNotDuplicateAddAfterCheckpointLoss() 
   }
   await storage.set(applyKey, persisted)
 
-  const retry = await runLargeBomCheckpointApplyJobChunk({
-    storage,
-    actionId,
-    applyJobId: 'apply-job-idempotent',
-    recordsApi: api.recordsApi,
-    maxDecisionsPerChunk: 1,
-  })
-  assert.equal(retry.status, 'succeeded')
-  assert.equal(retry.counts.created, 0, 'retry after checkpoint loss does not create another row')
-  assert.equal(retry.counts.updated, 1, 'idempotent add patches the already-created row')
-  assert.equal(api.rows.length, 1, 'checkpoint retry keeps a single target row')
+  await assert.rejects(
+    () => runLargeBomCheckpointApplyJobChunk({
+      storage,
+      ...TEST_SCOPE,
+      actionId,
+      applyJobId: 'apply-job-concurrent',
+      recordsApi: api.recordsApi,
+      maxDecisionsPerChunk: 1,
+    }),
+    (error) => error instanceof StockPreparationLargeBomJobError &&
+      error.code === 'LARGE_BOM_APPLY_RUN_IN_PROGRESS' &&
+      error.status === 409,
+  )
+  assert.equal(api.rows.length, 1, 'concurrent run rejection keeps a single target row')
   assert.equal(api.calls.filter((call) => call[0] === 'createRecord').length, 1)
-  assert.equal(api.calls.filter((call) => call[0] === 'patchRecord').length, 1)
-  assertValuesFree(publicCheckpointApplyJob(retry))
+  assert.equal(api.calls.filter((call) => call[0] === 'patchRecord').length, 0)
+
+  const loaded = await loadLargeBomCheckpointApplyJob({
+    storage,
+    ...TEST_SCOPE,
+    actionId,
+    applyJobId: 'apply-job-concurrent',
+  })
+  assert.equal(loaded.status, 'running', 'concurrent rejection does not mutate the in-flight job')
+  assertValuesFree(publicCheckpointApplyJob(loaded))
 }
 
 async function main() {
@@ -1186,7 +1211,7 @@ async function main() {
   await testCheckpointApplyRequiresDurablePlanPermissionAndManualAck()
   await testCheckpointApplyChunksPlanAndKeepsPublicEvidenceValuesFree()
   await testCheckpointApplyMissingRecordsApiFailsBeforeRunning()
-  await testCheckpointApplyRetryDoesNotDuplicateAddAfterCheckpointLoss()
+  await testCheckpointApplyRejectsConcurrentRunningChunk()
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-large-bom-jobs.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-large-bom-jobs.test.cjs
@@ -156,6 +156,36 @@ function createTargetRecordsApi({ existing = [] } = {}) {
   }
 }
 
+function createBlockingTargetRecordsApi({ existing = [] } = {}) {
+  const api = createTargetRecordsApi({ existing })
+  let enteredFirstCreate
+  let releaseFirstCreate
+  let firstCreateBlocked = false
+  const firstCreateEntered = new Promise((resolve) => {
+    enteredFirstCreate = resolve
+  })
+  const firstCreateReleased = new Promise((resolve) => {
+    releaseFirstCreate = resolve
+  })
+  return {
+    rows: api.rows,
+    calls: api.calls,
+    firstCreateEntered,
+    releaseFirstCreate,
+    recordsApi: {
+      ...api.recordsApi,
+      async createRecord(input = {}) {
+        if (!firstCreateBlocked) {
+          firstCreateBlocked = true
+          enteredFirstCreate()
+          await firstCreateReleased
+        }
+        return api.recordsApi.createRecord(input)
+      },
+    },
+  }
+}
+
 function targetBinding(overrides = {}) {
   return {
     sheetId: 'sheet_stock_preparation',
@@ -1120,6 +1150,53 @@ async function testCheckpointApplyMissingRecordsApiFailsBeforeRunning() {
   assert.equal(loaded.checkpoint.nextDecisionIndex, 0, 'missing recordsApi does not advance the checkpoint')
 }
 
+async function testCheckpointApplySingleFlightRejectsConcurrentQueuedRun() {
+  const plan = planWithDecisions([addDecision('PROJECT_VALUE_SHOULD_NOT_APPEAR::CONCURRENT-KEY')])
+  const { storage, actionId, jobId } = await seedPlannedLargeBomJob({ plan, jobId: 'job-single-flight-apply' })
+  const api = createBlockingTargetRecordsApi()
+  await createLargeBomCheckpointApplyJob({
+    storage,
+    ...TEST_SCOPE,
+    actionId,
+    jobId,
+    principal: 'user-1',
+    permission: 'admin',
+    createApplyJobId: () => 'apply-job-single-flight',
+  })
+
+  const firstRun = runLargeBomCheckpointApplyJobChunk({
+    storage,
+    ...TEST_SCOPE,
+    actionId,
+    applyJobId: 'apply-job-single-flight',
+    recordsApi: api.recordsApi,
+    maxDecisionsPerChunk: 1,
+  })
+  await api.firstCreateEntered
+
+  await assert.rejects(
+    () => runLargeBomCheckpointApplyJobChunk({
+      storage,
+      ...TEST_SCOPE,
+      actionId,
+      applyJobId: 'apply-job-single-flight',
+      recordsApi: api.recordsApi,
+      maxDecisionsPerChunk: 1,
+    }),
+    (error) => error instanceof StockPreparationLargeBomJobError &&
+      error.code === 'LARGE_BOM_APPLY_RUN_IN_PROGRESS' &&
+      error.status === 409,
+  )
+  assert.equal(api.rows.length, 0, 'second concurrent run is rejected while the first chunk is in flight')
+
+  api.releaseFirstCreate()
+  const completed = await firstRun
+  assert.equal(completed.status, 'succeeded')
+  assert.equal(completed.counts.created, 1)
+  assert.equal(api.rows.length, 1)
+  assert.equal(api.calls.filter((call) => call[0] === 'createRecord').length, 1)
+}
+
 async function testCheckpointApplyRejectsConcurrentRunningChunk() {
   const key = 'PROJECT_VALUE_SHOULD_NOT_APPEAR::IDEMPOTENT-KEY'
   const plan = planWithDecisions([addDecision(key)])
@@ -1211,6 +1288,7 @@ async function main() {
   await testCheckpointApplyRequiresDurablePlanPermissionAndManualAck()
   await testCheckpointApplyChunksPlanAndKeepsPublicEvidenceValuesFree()
   await testCheckpointApplyMissingRecordsApiFailsBeforeRunning()
+  await testCheckpointApplySingleFlightRejectsConcurrentQueuedRun()
   await testCheckpointApplyRejectsConcurrentRunningChunk()
 }
 

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-large-bom-jobs.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-large-bom-jobs.test.cjs
@@ -7,13 +7,18 @@ const {
   LARGE_BOM_BACKGROUND_EXPANSION_STATUSES,
   LARGE_BOM_CHECKPOINT_APPLY_STATUSES,
   StockPreparationLargeBomJobError,
+  __internals,
   assertAuthoritativeLargeBomExpansion,
   cancelLargeBomBackgroundExpansionJob,
   createLargeBomBackgroundExpansionJob,
+  createLargeBomCheckpointApplyJob,
   isAuthoritativeLargeBomExpansion,
   loadLargeBomBackgroundExpansionJob,
+  loadLargeBomCheckpointApplyJob,
   planLargeBomBackgroundExpansionJob,
   publicBackgroundExpansionJob,
+  publicCheckpointApplyJob,
+  runLargeBomCheckpointApplyJobChunk,
   runLargeBomBackgroundExpansionJob,
   summarizeLargeBomBackgroundExpansionJobForEvidence,
   summarizeLargeBomCheckpointApplyJobForEvidence,
@@ -106,6 +111,165 @@ function createSourceAdapter(data) {
       },
     },
   }
+}
+
+function createTargetRecordsApi({ existing = [] } = {}) {
+  const rows = existing.map((entry, index) => ({
+    id: entry.id || `target_${index + 1}`,
+    sheetId: entry.sheetId || 'sheet_stock_preparation',
+    version: entry.version || 1,
+    data: { ...(entry.data || entry) },
+  }))
+  const calls = []
+  return {
+    rows,
+    calls,
+    recordsApi: {
+      async queryRecords(input = {}) {
+        calls.push(['queryRecords', clone(input)])
+        return rows
+          .filter((row) => row.sheetId === input.sheetId)
+          .filter((row) => Object.entries(input.filters || {}).every(([field, expected]) => row.data[field] === expected))
+          .slice(input.offset || 0, (input.offset || 0) + (input.limit || 1000))
+          .map(clone)
+      },
+      async createRecord(input = {}) {
+        calls.push(['createRecord', clone(input)])
+        const record = {
+          id: `target_${rows.length + 1}`,
+          sheetId: input.sheetId,
+          version: 1,
+          data: { ...(input.data || {}) },
+        }
+        rows.push(record)
+        return clone(record)
+      },
+      async patchRecord(input = {}) {
+        calls.push(['patchRecord', clone(input)])
+        const row = rows.find((entry) => entry.sheetId === input.sheetId && entry.id === input.recordId)
+        if (!row) throw new Error(`record not found: ${input.recordId}`)
+        row.version += 1
+        row.data = { ...row.data, ...(input.changes || {}) }
+        return clone(row)
+      },
+    },
+  }
+}
+
+function targetBinding(overrides = {}) {
+  return {
+    sheetId: 'sheet_stock_preparation',
+    ...overrides,
+  }
+}
+
+function addDecision(key, overrides = {}) {
+  return {
+    decision: 'add',
+    idempotencyKey: key,
+    record: {
+      idempotencyKey: key,
+      projectNo: 'PROJECT_VALUE_SHOULD_NOT_APPEAR',
+      componentSourceId: overrides.componentSourceId || 'COMPONENT_VALUE_SHOULD_NOT_APPEAR',
+      parentSourceId: overrides.parentSourceId === undefined ? null : overrides.parentSourceId,
+      path: overrides.path || 'PATH_VALUE_SHOULD_NOT_APPEAR',
+      depth: overrides.depth || 0,
+      componentCode: overrides.componentCode || 'CODE_VALUE_SHOULD_NOT_APPEAR',
+      componentName: overrides.componentName || 'NAME_VALUE_SHOULD_NOT_APPEAR',
+      material: overrides.material || 'MATERIAL_VALUE_SHOULD_NOT_APPEAR',
+      sourceVersion: overrides.sourceVersion || 'V1',
+      rawQuantity: overrides.rawQuantity || 1,
+      totalQuantity: overrides.totalQuantity || 1,
+      active: true,
+      lastPlmRefreshRunId: 'run-large-bom-apply',
+      lastPlmRefreshAt: '2026-06-08T00:00:00.000Z',
+      lastPlmRefreshDecision: 'add',
+      lastPlmConflictSummary: '',
+    },
+    conflictSummary: { type: 'add_missing' },
+  }
+}
+
+function manualConfirmDecision(key) {
+  return {
+    decision: 'manual_confirm',
+    idempotencyKey: key,
+    conflictSummary: { type: 'source_correction_required' },
+    source: 'planner',
+  }
+}
+
+function planWithDecisions(decisions) {
+  return {
+    valid: true,
+    ok: decisions.every((decision) => decision.decision !== 'manual_confirm'),
+    counts: {
+      add: decisions.filter((decision) => decision.decision === 'add').length,
+      update: 0,
+      skip: 0,
+      inactive: 0,
+      manual_confirm: decisions.filter((decision) => decision.decision === 'manual_confirm').length,
+    },
+    decisions: decisions.map(clone),
+    plannedAt: '2026-06-08T00:00:00.000Z',
+  }
+}
+
+async function seedPlannedLargeBomJob({
+  storage = createStorage(),
+  jobId = 'job-apply-source-1',
+  plan = planWithDecisions([addDecision('PROJECT_VALUE_SHOULD_NOT_APPEAR::KEY-1')]),
+  target = targetBinding(),
+} = {}) {
+  const actionId = 'plm.stock-preparation.pull-bom.v1'
+  const job = {
+    jobId,
+    actionId,
+    status: 'completed',
+    authoritative: true,
+    projectNoPresent: true,
+    parameters: { projectNo: 'PROJECT_VALUE_SHOULD_NOT_APPEAR' },
+    principal: 'PRIVATE_TOKEN_SHOULD_NOT_APPEAR',
+    actionSnapshot: {
+      actionId,
+      source: { kind: 'data-source:sql-readonly', externalSystemId: 'SOURCE_BINDING_SHOULD_NOT_APPEAR' },
+      target,
+    },
+    sourceKind: 'data-source:sql-readonly',
+    artifactRevision: 'artifact-revision-1',
+    artifact: {
+      revision: 'artifact-revision-1',
+      status: 'expanded',
+      rows: [],
+      summary: {},
+      sealedAt: '2026-06-08T00:00:00.000Z',
+    },
+    planRevision: 'plan-revision-1',
+    planArtifact: {
+      revision: 'plan-revision-1',
+      artifactRevision: 'artifact-revision-1',
+      plan: clone(plan),
+      existingRowCount: 0,
+      plannedAt: plan.plannedAt,
+    },
+    progress: {
+      rowsExpanded: 0,
+      readCount: 0,
+      frontierRemaining: 0,
+      completedChunks: 1,
+    },
+    budgets: {},
+    evidence: {
+      sourceKind: 'data-source:sql-readonly',
+      readObjects: [],
+      errorTypes: [],
+      readDiagnosticShapePresent: false,
+    },
+    createdAt: '2026-06-08T00:00:00.000Z',
+    updatedAt: '2026-06-08T00:00:00.000Z',
+  }
+  await storage.set(__internals.backgroundJobKey(actionId, jobId), job)
+  return { storage, actionId, jobId, job }
 }
 
 function plmData(overrides = {}) {
@@ -762,6 +926,248 @@ async function testPlannerHandoffStoresValuesFreePlanEvidence() {
   assert.equal(loaded.planRevision, planned.planRevision, 'plan artifact is persisted on the job')
 }
 
+async function testCheckpointApplyRequiresDurablePlanPermissionAndManualAck() {
+  await assert.rejects(
+    () => createLargeBomCheckpointApplyJob({
+      storage: createStorage({ durable: false }),
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      jobId: 'missing',
+      principal: 'user-1',
+      permission: 'write',
+      createApplyJobId: () => 'apply-job-1',
+    }),
+    (error) => error instanceof StockPreparationLargeBomJobError &&
+      error.code === 'LARGE_BOM_JOB_STORE_UNAVAILABLE',
+  )
+
+  const storageWithoutPlan = createStorage()
+  await createLargeBomBackgroundExpansionJob({
+    storage: storageWithoutPlan,
+    action: { actionId: 'plm.stock-preparation.pull-bom.v1', target: targetBinding() },
+    parameters: { projectNo: 'PROJECT_VALUE_SHOULD_NOT_APPEAR' },
+    principal: 'PRIVATE_TOKEN_SHOULD_NOT_APPEAR',
+    createJobId: () => 'job-no-plan',
+  })
+  await assert.rejects(
+    () => createLargeBomCheckpointApplyJob({
+      storage: storageWithoutPlan,
+      actionId: 'plm.stock-preparation.pull-bom.v1',
+      jobId: 'job-no-plan',
+      principal: 'user-1',
+      permission: 'write',
+      createApplyJobId: () => 'apply-job-no-plan',
+    }),
+    (error) => error instanceof StockPreparationLargeBomJobError &&
+      error.code === 'LARGE_BOM_PLAN_ARTIFACT_NOT_AUTHORITATIVE',
+  )
+
+  const { storage, actionId, jobId } = await seedPlannedLargeBomJob()
+  await assert.rejects(
+    () => createLargeBomCheckpointApplyJob({
+      storage,
+      actionId,
+      jobId,
+      principal: 'user-1',
+      permission: 'read',
+      createApplyJobId: () => 'apply-job-read',
+    }),
+    (error) => error instanceof StockPreparationLargeBomJobError &&
+      error.code === 'LARGE_BOM_APPLY_PERMISSION_REQUIRED' &&
+      error.status === 403,
+  )
+
+  const manualPlan = planWithDecisions([
+    addDecision('PROJECT_VALUE_SHOULD_NOT_APPEAR::KEY-1'),
+    manualConfirmDecision('PROJECT_VALUE_SHOULD_NOT_APPEAR::HELD-1'),
+  ])
+  const seeded = await seedPlannedLargeBomJob({ plan: manualPlan, jobId: 'job-manual-ack' })
+  await assert.rejects(
+    () => createLargeBomCheckpointApplyJob({
+      storage: seeded.storage,
+      actionId: seeded.actionId,
+      jobId: seeded.jobId,
+      principal: 'user-1',
+      permission: 'write',
+      createApplyJobId: () => 'apply-job-needs-ack',
+    }),
+    (error) => error instanceof StockPreparationLargeBomJobError &&
+      error.code === 'LARGE_BOM_APPLY_MANUAL_CONFIRM_ACK_REQUIRED' &&
+      error.status === 409,
+  )
+}
+
+async function testCheckpointApplyChunksPlanAndKeepsPublicEvidenceValuesFree() {
+  const plan = planWithDecisions([
+    addDecision('PROJECT_VALUE_SHOULD_NOT_APPEAR::KEY-1', { componentSourceId: 'COMPONENT_VALUE_SHOULD_NOT_APPEAR' }),
+    manualConfirmDecision('PROJECT_VALUE_SHOULD_NOT_APPEAR::HELD-1'),
+    addDecision('PROJECT_VALUE_SHOULD_NOT_APPEAR::KEY-2', { componentSourceId: 'CHILD_VALUE_SHOULD_NOT_APPEAR' }),
+  ])
+  const { storage, actionId, jobId } = await seedPlannedLargeBomJob({ plan })
+  const api = createTargetRecordsApi()
+  const created = await createLargeBomCheckpointApplyJob({
+    storage,
+    actionId,
+    jobId,
+    principal: 'user-1',
+    permission: 'write',
+    acceptManualConfirmHold: true,
+    createApplyJobId: () => 'apply-job-chunks',
+    now: () => '2026-06-08T00:01:00.000Z',
+  })
+  assert.equal(created.status, 'queued')
+  assert.equal(created.totalDecisions, 3)
+  assert.equal(created.approval.principal, 'user-1', 'private apply job records the authenticated approver')
+  assert.equal(created.target.sheetId, 'sheet_stock_preparation', 'private apply job records server-configured target')
+
+  const first = await runLargeBomCheckpointApplyJobChunk({
+    storage,
+    actionId,
+    applyJobId: 'apply-job-chunks',
+    recordsApi: api.recordsApi,
+    maxDecisionsPerChunk: 1,
+    now: () => '2026-06-08T00:02:00.000Z',
+  })
+  assert.equal(first.status, 'running')
+  assert.equal(first.checkpoint.nextDecisionIndex, 1)
+  assert.equal(first.counts.created, 1)
+  assert.equal(api.rows.length, 1)
+
+  const second = await runLargeBomCheckpointApplyJobChunk({
+    storage,
+    actionId,
+    applyJobId: 'apply-job-chunks',
+    recordsApi: api.recordsApi,
+    maxDecisionsPerChunk: 2,
+    now: () => '2026-06-08T00:03:00.000Z',
+  })
+  assert.equal(second.status, 'partial', 'manual_confirm remains held while clean rows write')
+  assert.equal(second.checkpoint.nextDecisionIndex, 3)
+  assert.equal(second.counts.created, 2)
+  assert.equal(second.counts.held, 1)
+  assert.equal(second.counts.failed, 0)
+  assert.equal(api.rows.length, 2)
+  assert.equal(api.calls.filter((call) => call[0] === 'createRecord').length, 2)
+
+  const publicJob = publicCheckpointApplyJob(second)
+  assert.equal(publicJob.jobId, 'apply-job-chunks')
+  assert.equal(publicJob.status, 'partial')
+  assert.equal(publicJob.planRevisionPresent, true)
+  assert.equal(publicJob.targetRevisionPresent, true)
+  assert.equal(publicJob.approvalPresent, true)
+  assert.deepEqual(publicJob.counts, {
+    created: 2,
+    updated: 0,
+    inactive: 0,
+    skipped: 0,
+    held: 1,
+    failed: 0,
+  })
+  assert.ok(publicJob.evidence.resultStatuses.includes('created'))
+  assert.ok(publicJob.evidence.resultStatuses.includes('held'))
+  assert.ok(publicJob.evidence.fieldCategories.includes('plm_system'))
+  assertValuesFree(publicJob)
+
+  const loaded = await loadLargeBomCheckpointApplyJob({
+    storage,
+    actionId,
+    applyJobId: 'apply-job-chunks',
+  })
+  assert.equal(loaded.status, 'partial')
+}
+
+async function testCheckpointApplyMissingRecordsApiFailsBeforeRunning() {
+  const { storage, actionId, jobId } = await seedPlannedLargeBomJob({ jobId: 'job-missing-records-api' })
+  await createLargeBomCheckpointApplyJob({
+    storage,
+    actionId,
+    jobId,
+    principal: 'user-1',
+    permission: 'write',
+    createApplyJobId: () => 'apply-job-missing-records-api',
+  })
+
+  await assert.rejects(
+    () => runLargeBomCheckpointApplyJobChunk({
+      storage,
+      actionId,
+      applyJobId: 'apply-job-missing-records-api',
+      recordsApi: {},
+      maxDecisionsPerChunk: 1,
+    }),
+    (error) => error instanceof StockPreparationLargeBomJobError &&
+      error.code === 'LARGE_BOM_APPLY_RECORDS_API_UNAVAILABLE' &&
+      error.status === 501,
+  )
+
+  const loaded = await loadLargeBomCheckpointApplyJob({
+    storage,
+    actionId,
+    applyJobId: 'apply-job-missing-records-api',
+  })
+  assert.equal(loaded.status, 'queued', 'missing recordsApi fails before marking the job running')
+  assert.equal(loaded.checkpoint.nextDecisionIndex, 0, 'missing recordsApi does not advance the checkpoint')
+}
+
+async function testCheckpointApplyRetryDoesNotDuplicateAddAfterCheckpointLoss() {
+  const key = 'PROJECT_VALUE_SHOULD_NOT_APPEAR::IDEMPOTENT-KEY'
+  const plan = planWithDecisions([addDecision(key)])
+  const { storage, actionId, jobId } = await seedPlannedLargeBomJob({ plan, jobId: 'job-idempotent-apply' })
+  const api = createTargetRecordsApi()
+  await createLargeBomCheckpointApplyJob({
+    storage,
+    actionId,
+    jobId,
+    principal: 'user-1',
+    permission: 'admin',
+    createApplyJobId: () => 'apply-job-idempotent',
+  })
+
+  const first = await runLargeBomCheckpointApplyJobChunk({
+    storage,
+    actionId,
+    applyJobId: 'apply-job-idempotent',
+    recordsApi: api.recordsApi,
+    maxDecisionsPerChunk: 1,
+  })
+  assert.equal(first.status, 'succeeded')
+  assert.equal(first.counts.created, 1)
+  assert.equal(api.rows.length, 1)
+
+  const applyKey = __internals.checkpointApplyJobKey(actionId, 'apply-job-idempotent')
+  const persisted = await storage.get(applyKey)
+  persisted.status = 'running'
+  persisted.checkpoint.nextDecisionIndex = 0
+  persisted.counts = {
+    created: 0,
+    updated: 0,
+    inactive: 0,
+    skipped: 0,
+    held: 0,
+    failed: 0,
+  }
+  persisted.evidence = {
+    resultStatuses: [],
+    errorCodes: [],
+    fieldCategories: ['plm_system'],
+  }
+  await storage.set(applyKey, persisted)
+
+  const retry = await runLargeBomCheckpointApplyJobChunk({
+    storage,
+    actionId,
+    applyJobId: 'apply-job-idempotent',
+    recordsApi: api.recordsApi,
+    maxDecisionsPerChunk: 1,
+  })
+  assert.equal(retry.status, 'succeeded')
+  assert.equal(retry.counts.created, 0, 'retry after checkpoint loss does not create another row')
+  assert.equal(retry.counts.updated, 1, 'idempotent add patches the already-created row')
+  assert.equal(api.rows.length, 1, 'checkpoint retry keeps a single target row')
+  assert.equal(api.calls.filter((call) => call[0] === 'createRecord').length, 1)
+  assert.equal(api.calls.filter((call) => call[0] === 'patchRecord').length, 1)
+  assertValuesFree(publicCheckpointApplyJob(retry))
+}
+
 async function main() {
   testStatusEnumsArePinned()
   testBackgroundEvidenceIsValuesFreeProjection()
@@ -777,6 +1183,10 @@ async function main() {
   await testPlannerHandoffRequiresAuthoritativeArtifact()
   await testPlannerHandoffRejectsMalformedExistingRows()
   await testPlannerHandoffStoresValuesFreePlanEvidence()
+  await testCheckpointApplyRequiresDurablePlanPermissionAndManualAck()
+  await testCheckpointApplyChunksPlanAndKeepsPublicEvidenceValuesFree()
+  await testCheckpointApplyMissingRecordsApiFailsBeforeRunning()
+  await testCheckpointApplyRetryDoesNotDuplicateAddAfterCheckpointLoss()
 }
 
 main().catch((err) => {

--- a/plugins/plugin-integration-core/lib/stock-preparation-large-bom-jobs.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-large-bom-jobs.cjs
@@ -72,6 +72,7 @@ const APPLY_COUNT_FIELDS = Object.freeze([
 const LARGE_BOM_APPLY_PERMISSIONS = Object.freeze(['write', 'admin'])
 const LARGE_BOM_APPLY_DEFAULT_CHUNK_SIZE = 100
 const LARGE_BOM_APPLY_MAX_CHUNK_SIZE = 1000
+const activeCheckpointApplyRuns = new Set()
 
 class StockPreparationLargeBomJobError extends Error {
   constructor(code, message, details = {}, status = 422) {
@@ -776,20 +777,8 @@ function terminalApplyStatus(counts = {}) {
   return 'succeeded'
 }
 
-async function runLargeBomCheckpointApplyJobChunk(input = {}) {
-  const storage = ensureDurableJobStorage(input.storage)
-  const key = checkpointApplyJobKey({ ...input, applyJobId: input.applyJobId || input.jobId })
-  const job = await storage.get(key)
-  if (!job) {
-    throw new StockPreparationLargeBomJobError(
-      'LARGE_BOM_APPLY_JOB_NOT_FOUND',
-      'large-BOM checkpoint apply job was not found',
-      { applyJobIdPresent: Boolean(optionalString(input.applyJobId || input.jobId)) },
-      404,
-    )
-  }
-  if (['succeeded', 'partial'].includes(job.status)) return cloneJson(job)
-  if (job.status === 'running') {
+function acquireCheckpointApplyRun(key) {
+  if (activeCheckpointApplyRuns.has(key)) {
     throw new StockPreparationLargeBomJobError(
       'LARGE_BOM_APPLY_RUN_IN_PROGRESS',
       'large-BOM checkpoint apply job already has a running chunk',
@@ -797,61 +786,96 @@ async function runLargeBomCheckpointApplyJobChunk(input = {}) {
       409,
     )
   }
-  if (!['queued', 'paused', 'failed'].includes(job.status)) {
-    throw new StockPreparationLargeBomJobError(
-      'LARGE_BOM_APPLY_RUN_REJECTED',
-      'large-BOM checkpoint apply job cannot be run from this status',
-      { status: safeEvidenceToken(job.status, 'status') || undefined },
-      409,
-    )
+  activeCheckpointApplyRuns.add(key)
+  let released = false
+  return () => {
+    if (released) return
+    released = true
+    activeCheckpointApplyRuns.delete(key)
   }
-  const plan = isPlainObject(job.plan) && Array.isArray(job.plan.decisions) ? job.plan : null
-  if (!plan) {
-    throw new StockPreparationLargeBomJobError(
-      'LARGE_BOM_APPLY_PLAN_INVALID',
-      'large-BOM checkpoint apply job is missing a private conflict plan',
-      { planPresent: false },
-    )
-  }
-  const chunkSize = normalizeChunkSize(input.maxDecisionsPerChunk)
-  const recordsApi = requireCheckpointRecordsApi(input.recordsApi)
-  const start = nextDecisionIndex(job)
-  const decisions = plan.decisions
-  if (start >= decisions.length) {
-    job.status = terminalApplyStatus(job.counts)
+}
+
+async function runLargeBomCheckpointApplyJobChunk(input = {}) {
+  const storage = ensureDurableJobStorage(input.storage)
+  const key = checkpointApplyJobKey({ ...input, applyJobId: input.applyJobId || input.jobId })
+  const release = acquireCheckpointApplyRun(key)
+  try {
+    const job = await storage.get(key)
+    if (!job) {
+      throw new StockPreparationLargeBomJobError(
+        'LARGE_BOM_APPLY_JOB_NOT_FOUND',
+        'large-BOM checkpoint apply job was not found',
+        { applyJobIdPresent: Boolean(optionalString(input.applyJobId || input.jobId)) },
+        404,
+      )
+    }
+    if (['succeeded', 'partial'].includes(job.status)) return cloneJson(job)
+    if (job.status === 'running') {
+      throw new StockPreparationLargeBomJobError(
+        'LARGE_BOM_APPLY_RUN_IN_PROGRESS',
+        'large-BOM checkpoint apply job already has a running chunk',
+        { status: 'running' },
+        409,
+      )
+    }
+    if (!['queued', 'paused', 'failed'].includes(job.status)) {
+      throw new StockPreparationLargeBomJobError(
+        'LARGE_BOM_APPLY_RUN_REJECTED',
+        'large-BOM checkpoint apply job cannot be run from this status',
+        { status: safeEvidenceToken(job.status, 'status') || undefined },
+        409,
+      )
+    }
+    const plan = isPlainObject(job.plan) && Array.isArray(job.plan.decisions) ? job.plan : null
+    if (!plan) {
+      throw new StockPreparationLargeBomJobError(
+        'LARGE_BOM_APPLY_PLAN_INVALID',
+        'large-BOM checkpoint apply job is missing a private conflict plan',
+        { planPresent: false },
+      )
+    }
+    const chunkSize = normalizeChunkSize(input.maxDecisionsPerChunk)
+    const recordsApi = requireCheckpointRecordsApi(input.recordsApi)
+    const start = nextDecisionIndex(job)
+    const decisions = plan.decisions
+    if (start >= decisions.length) {
+      job.status = terminalApplyStatus(job.counts)
+      job.updatedAt = isoNow(typeof input.now === 'function' ? input.now() : undefined)
+      await storage.set(key, job)
+      return cloneJson(job)
+    }
+
+    const runningAt = isoNow(typeof input.now === 'function' ? input.now() : undefined)
+    job.status = 'running'
+    job.updatedAt = runningAt
+    await storage.set(key, job)
+
+    const end = Math.min(start + chunkSize, decisions.length)
+    const chunkPlan = {
+      ...plan,
+      decisions: decisions.slice(start, end).map(cloneJson),
+    }
+    const applyResult = await applyStockPreparationPlan({
+      permission: job.permission,
+      plan: chunkPlan,
+      target: job.target,
+      template: job.template,
+      recordsApi,
+    })
+
+    job.counts = mergeCounts(job.counts, applyResult.counts)
+    mergeApplyEvidence(job, applyResult)
+    job.checkpoint = {
+      nextDecisionIndex: end,
+      completedChunks: completedChunks(job) + 1,
+    }
+    job.status = end >= decisions.length ? terminalApplyStatus(job.counts) : 'paused'
     job.updatedAt = isoNow(typeof input.now === 'function' ? input.now() : undefined)
     await storage.set(key, job)
     return cloneJson(job)
+  } finally {
+    release()
   }
-
-  const runningAt = isoNow(typeof input.now === 'function' ? input.now() : undefined)
-  job.status = 'running'
-  job.updatedAt = runningAt
-  await storage.set(key, job)
-
-  const end = Math.min(start + chunkSize, decisions.length)
-  const chunkPlan = {
-    ...plan,
-    decisions: decisions.slice(start, end).map(cloneJson),
-  }
-  const applyResult = await applyStockPreparationPlan({
-    permission: job.permission,
-    plan: chunkPlan,
-    target: job.target,
-    template: job.template,
-    recordsApi,
-  })
-
-  job.counts = mergeCounts(job.counts, applyResult.counts)
-  mergeApplyEvidence(job, applyResult)
-  job.checkpoint = {
-    nextDecisionIndex: end,
-    completedChunks: completedChunks(job) + 1,
-  }
-  job.status = end >= decisions.length ? terminalApplyStatus(job.counts) : 'paused'
-  job.updatedAt = isoNow(typeof input.now === 'function' ? input.now() : undefined)
-  await storage.set(key, job)
-  return cloneJson(job)
 }
 
 async function planLargeBomBackgroundExpansionJob(input = {}) {

--- a/plugins/plugin-integration-core/lib/stock-preparation-large-bom-jobs.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-large-bom-jobs.cjs
@@ -248,9 +248,10 @@ function backgroundJobKey(input = {}) {
   return `stock-preparation:large-bom:background:${tenantId}:${workspaceId}:${safeActionId}:${safeJobId}`
 }
 
-function checkpointApplyJobKey(actionId, applyJobId) {
-  const safeActionId = safeEvidenceToken(actionId, 'actionId')
-  const safeApplyJobId = safeEvidenceToken(applyJobId, 'applyJobId')
+function checkpointApplyJobKey(input = {}) {
+  const { tenantId, workspaceId } = requiredJobScope(input)
+  const safeActionId = safeEvidenceToken(input.actionId, 'actionId')
+  const safeApplyJobId = safeEvidenceToken(input.applyJobId, 'applyJobId')
   if (!safeActionId || !safeApplyJobId) {
     throw new StockPreparationLargeBomJobError(
       'LARGE_BOM_APPLY_JOB_ID_INVALID',
@@ -258,7 +259,7 @@ function checkpointApplyJobKey(actionId, applyJobId) {
       { actionIdPresent: Boolean(safeActionId), applyJobIdPresent: Boolean(safeApplyJobId) },
     )
   }
-  return `stock-preparation:large-bom:apply:${safeActionId}:${safeApplyJobId}`
+  return `stock-preparation:large-bom:apply:${tenantId}:${workspaceId}:${safeActionId}:${safeApplyJobId}`
 }
 
 function requiredPrincipal(value) {
@@ -669,10 +670,12 @@ function requireCheckpointRecordsApi(recordsApi) {
 
 async function createLargeBomCheckpointApplyJob(input = {}) {
   const storage = ensureDurableJobStorage(input.storage)
+  const scope = requiredJobScope(input)
   const principal = requiredPrincipal(input.principal)
   const permission = requireApplyPermission(input.permission)
   const sourceJob = await loadLargeBomBackgroundExpansionJob({
     storage,
+    ...scope,
     actionId: input.actionId,
     jobId: input.jobId,
   })
@@ -698,6 +701,7 @@ async function createLargeBomCheckpointApplyJob(input = {}) {
   const now = isoNow(typeof input.now === 'function' ? input.now() : undefined)
   const job = {
     jobId: applyJobId,
+    ...scope,
     actionId: sourceJob.actionId,
     sourceJobId: sourceJob.jobId,
     status: 'queued',
@@ -730,13 +734,13 @@ async function createLargeBomCheckpointApplyJob(input = {}) {
     createdAt: now,
     updatedAt: now,
   }
-  await storage.set(checkpointApplyJobKey(sourceJob.actionId, applyJobId), job)
+  await storage.set(checkpointApplyJobKey({ ...scope, actionId: sourceJob.actionId, applyJobId }), job)
   return cloneJson(job)
 }
 
 async function loadLargeBomCheckpointApplyJob(input = {}) {
   const storage = ensureDurableJobStorage(input.storage)
-  const key = checkpointApplyJobKey(input.actionId, input.applyJobId || input.jobId)
+  const key = checkpointApplyJobKey({ ...input, applyJobId: input.applyJobId || input.jobId })
   const job = await storage.get(key)
   if (!job) {
     throw new StockPreparationLargeBomJobError(
@@ -774,7 +778,7 @@ function terminalApplyStatus(counts = {}) {
 
 async function runLargeBomCheckpointApplyJobChunk(input = {}) {
   const storage = ensureDurableJobStorage(input.storage)
-  const key = checkpointApplyJobKey(input.actionId, input.applyJobId || input.jobId)
+  const key = checkpointApplyJobKey({ ...input, applyJobId: input.applyJobId || input.jobId })
   const job = await storage.get(key)
   if (!job) {
     throw new StockPreparationLargeBomJobError(
@@ -785,7 +789,15 @@ async function runLargeBomCheckpointApplyJobChunk(input = {}) {
     )
   }
   if (['succeeded', 'partial'].includes(job.status)) return cloneJson(job)
-  if (!['queued', 'running', 'paused', 'failed'].includes(job.status)) {
+  if (job.status === 'running') {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_APPLY_RUN_IN_PROGRESS',
+      'large-BOM checkpoint apply job already has a running chunk',
+      { status: 'running' },
+      409,
+    )
+  }
+  if (!['queued', 'paused', 'failed'].includes(job.status)) {
     throw new StockPreparationLargeBomJobError(
       'LARGE_BOM_APPLY_RUN_REJECTED',
       'large-BOM checkpoint apply job cannot be run from this status',
@@ -836,7 +848,7 @@ async function runLargeBomCheckpointApplyJobChunk(input = {}) {
     nextDecisionIndex: end,
     completedChunks: completedChunks(job) + 1,
   }
-  job.status = end >= decisions.length ? terminalApplyStatus(job.counts) : 'running'
+  job.status = end >= decisions.length ? terminalApplyStatus(job.counts) : 'paused'
   job.updatedAt = isoNow(typeof input.now === 'function' ? input.now() : undefined)
   await storage.set(key, job)
   return cloneJson(job)

--- a/plugins/plugin-integration-core/lib/stock-preparation-large-bom-jobs.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-large-bom-jobs.cjs
@@ -18,6 +18,10 @@ const {
   planStockPreparationConflicts,
   summarizeConflictPlanForEvidence,
 } = require('./stock-preparation-conflict-planner.cjs')
+const {
+  applyStockPreparationPlan,
+  summarizeApplyResultForEvidence,
+} = require('./stock-preparation-apply-writer.cjs')
 
 const LARGE_BOM_BACKGROUND_EXPANSION_STATUSES = Object.freeze([
   'queued',
@@ -64,6 +68,10 @@ const APPLY_COUNT_FIELDS = Object.freeze([
   'held',
   'failed',
 ])
+
+const LARGE_BOM_APPLY_PERMISSIONS = Object.freeze(['write', 'admin'])
+const LARGE_BOM_APPLY_DEFAULT_CHUNK_SIZE = 100
+const LARGE_BOM_APPLY_MAX_CHUNK_SIZE = 1000
 
 class StockPreparationLargeBomJobError extends Error {
   constructor(code, message, details = {}, status = 422) {
@@ -187,6 +195,10 @@ function defaultJobId() {
   return `large-bom-expansion-${crypto.randomUUID()}`
 }
 
+function defaultApplyJobId() {
+  return `large-bom-apply-${crypto.randomUUID()}`
+}
+
 function ensureDurableJobStorage(storage) {
   if (!storage || storage.durable !== true) {
     throw new StockPreparationLargeBomJobError(
@@ -236,6 +248,19 @@ function backgroundJobKey(input = {}) {
   return `stock-preparation:large-bom:background:${tenantId}:${workspaceId}:${safeActionId}:${safeJobId}`
 }
 
+function checkpointApplyJobKey(actionId, applyJobId) {
+  const safeActionId = safeEvidenceToken(actionId, 'actionId')
+  const safeApplyJobId = safeEvidenceToken(applyJobId, 'applyJobId')
+  if (!safeActionId || !safeApplyJobId) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_APPLY_JOB_ID_INVALID',
+      'large-BOM checkpoint apply job id is required',
+      { actionIdPresent: Boolean(safeActionId), applyJobIdPresent: Boolean(safeApplyJobId) },
+    )
+  }
+  return `stock-preparation:large-bom:apply:${safeActionId}:${safeApplyJobId}`
+}
+
 function requiredPrincipal(value) {
   const principal = optionalString(value)
   if (!principal) {
@@ -252,6 +277,13 @@ function publicBackgroundExpansionJob(job) {
   return {
     jobId: safeEvidenceToken(job && job.jobId, 'jobId'),
     ...summarizeLargeBomBackgroundExpansionJobForEvidence(job),
+  }
+}
+
+function publicCheckpointApplyJob(job) {
+  return {
+    jobId: safeEvidenceToken(job && job.jobId, 'jobId'),
+    ...summarizeLargeBomCheckpointApplyJobForEvidence(job),
   }
 }
 
@@ -526,6 +558,290 @@ function largeBomPlanRevision({ job, plan, existingRows, conflictPolicyReview })
   })
 }
 
+function isAuthoritativeLargeBomPlan(job = {}) {
+  if (!isAuthoritativeLargeBomExpansion(job)) return false
+  const planArtifact = isPlainObject(job.planArtifact) ? job.planArtifact : {}
+  const plan = isPlainObject(planArtifact.plan) ? planArtifact.plan : {}
+  return Boolean(optionalString(job.planRevision || planArtifact.revision)) &&
+    Array.isArray(plan.decisions)
+}
+
+function assertAuthoritativeLargeBomPlan(job = {}) {
+  if (!isAuthoritativeLargeBomPlan(job)) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_PLAN_ARTIFACT_NOT_AUTHORITATIVE',
+      'large-BOM apply requires a completed authoritative conflict plan artifact',
+      {
+        status: isPlainObject(job) ? optionalString(job.status) || undefined : undefined,
+        authoritative: isPlainObject(job) ? job.authoritative === true : false,
+        artifactRevisionPresent: isPlainObject(job)
+          ? Boolean(optionalString(job.artifactRevision || (job.artifact && job.artifact.revision)))
+          : false,
+        planRevisionPresent: isPlainObject(job)
+          ? Boolean(optionalString(job.planRevision || (job.planArtifact && job.planArtifact.revision)))
+          : false,
+      },
+    )
+  }
+  return job
+}
+
+function requireApplyPermission(value) {
+  const permission = optionalString(value)
+  if (!LARGE_BOM_APPLY_PERMISSIONS.includes(permission)) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_APPLY_PERMISSION_REQUIRED',
+      'large-BOM checkpoint apply requires Data Factory write/admin permission',
+      { permission: permission || undefined },
+      403,
+    )
+  }
+  return permission
+}
+
+function normalizeChunkSize(value) {
+  if (value === undefined || value === null || value === '') return LARGE_BOM_APPLY_DEFAULT_CHUNK_SIZE
+  const parsed = nonNegativeInteger(value, 'maxDecisionsPerChunk')
+  if (parsed < 1 || parsed > LARGE_BOM_APPLY_MAX_CHUNK_SIZE) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_APPLY_CHUNK_SIZE_INVALID',
+      'large-BOM checkpoint apply chunk size is out of range',
+      { min: 1, max: LARGE_BOM_APPLY_MAX_CHUNK_SIZE },
+    )
+  }
+  return parsed
+}
+
+function emptyApplyCounts() {
+  return Object.fromEntries(APPLY_COUNT_FIELDS.map((field) => [field, 0]))
+}
+
+function mergeCounts(left = {}, right = {}) {
+  const out = emptyApplyCounts()
+  for (const field of APPLY_COUNT_FIELDS) {
+    out[field] = nonNegativeInteger(left[field], field) + nonNegativeInteger(right[field], field)
+  }
+  return out
+}
+
+function mergeTokenList(left = [], right = []) {
+  const out = []
+  for (const token of [...left, ...right]) {
+    if (typeof token === 'string' && token && !out.includes(token)) out.push(token)
+  }
+  return out.sort()
+}
+
+function countManualConfirmDecisions(plan = {}) {
+  return Array.isArray(plan.decisions)
+    ? plan.decisions.filter((decision) => decision && decision.decision === 'manual_confirm').length
+    : 0
+}
+
+function requireTargetSnapshot(job = {}) {
+  const target = job.actionSnapshot && job.actionSnapshot.target
+  if (!isPlainObject(target)) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_APPLY_TARGET_REQUIRED',
+      'large-BOM checkpoint apply requires a server-configured target binding',
+      { targetPresent: false },
+    )
+  }
+  return cloneJson(target)
+}
+
+function requireCheckpointRecordsApi(recordsApi) {
+  if (
+    !recordsApi ||
+    typeof recordsApi.queryRecords !== 'function' ||
+    typeof recordsApi.createRecord !== 'function' ||
+    typeof recordsApi.patchRecord !== 'function'
+  ) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_APPLY_RECORDS_API_UNAVAILABLE',
+      'large-BOM checkpoint apply requires queryRecords/createRecord/patchRecord records API',
+      { field: 'recordsApi' },
+      501,
+    )
+  }
+  return recordsApi
+}
+
+async function createLargeBomCheckpointApplyJob(input = {}) {
+  const storage = ensureDurableJobStorage(input.storage)
+  const principal = requiredPrincipal(input.principal)
+  const permission = requireApplyPermission(input.permission)
+  const sourceJob = await loadLargeBomBackgroundExpansionJob({
+    storage,
+    actionId: input.actionId,
+    jobId: input.jobId,
+  })
+  assertAuthoritativeLargeBomPlan(sourceJob)
+  const planArtifact = sourceJob.planArtifact
+  const plan = cloneJson(planArtifact.plan)
+  const manualConfirmCount = countManualConfirmDecisions(plan)
+  if (manualConfirmCount > 0 && input.acceptManualConfirmHold !== true) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_APPLY_MANUAL_CONFIRM_ACK_REQUIRED',
+      'large-BOM checkpoint apply requires explicit acknowledgement for held manual-confirm rows',
+      { manualConfirmCount },
+      409,
+    )
+  }
+  const target = requireTargetSnapshot(sourceJob)
+  const applyJobId = safeEvidenceToken(
+    (typeof input.createApplyJobId === 'function' ? input.createApplyJobId() : '') ||
+      optionalString(input.applyJobId) ||
+      defaultApplyJobId(),
+    'applyJobId',
+  )
+  const now = isoNow(typeof input.now === 'function' ? input.now() : undefined)
+  const job = {
+    jobId: applyJobId,
+    actionId: sourceJob.actionId,
+    sourceJobId: sourceJob.jobId,
+    status: 'queued',
+    planRevision: sourceJob.planRevision || planArtifact.revision,
+    targetRevision: hashJson(target),
+    approvalPresent: true,
+    approval: {
+      principal,
+      permission,
+      acceptManualConfirmHold: input.acceptManualConfirmHold === true,
+      approvedAt: now,
+    },
+    permission,
+    target,
+    template: sourceJob.actionSnapshot && sourceJob.actionSnapshot.template
+      ? cloneJson(sourceJob.actionSnapshot.template)
+      : undefined,
+    plan,
+    totalDecisions: Array.isArray(plan.decisions) ? plan.decisions.length : 0,
+    checkpoint: {
+      nextDecisionIndex: 0,
+      completedChunks: 0,
+    },
+    counts: emptyApplyCounts(),
+    evidence: {
+      resultStatuses: [],
+      errorCodes: [],
+      fieldCategories: ['plm_system'],
+    },
+    createdAt: now,
+    updatedAt: now,
+  }
+  await storage.set(checkpointApplyJobKey(sourceJob.actionId, applyJobId), job)
+  return cloneJson(job)
+}
+
+async function loadLargeBomCheckpointApplyJob(input = {}) {
+  const storage = ensureDurableJobStorage(input.storage)
+  const key = checkpointApplyJobKey(input.actionId, input.applyJobId || input.jobId)
+  const job = await storage.get(key)
+  if (!job) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_APPLY_JOB_NOT_FOUND',
+      'large-BOM checkpoint apply job was not found',
+      { applyJobIdPresent: Boolean(optionalString(input.applyJobId || input.jobId)) },
+      404,
+    )
+  }
+  return cloneJson(job)
+}
+
+function nextDecisionIndex(job = {}) {
+  return nonNegativeInteger(job.checkpoint && job.checkpoint.nextDecisionIndex, 'checkpoint.nextDecisionIndex')
+}
+
+function completedChunks(job = {}) {
+  return nonNegativeInteger(job.checkpoint && job.checkpoint.completedChunks, 'checkpoint.completedChunks')
+}
+
+function mergeApplyEvidence(job, applyResult) {
+  const publicResult = summarizeApplyResultForEvidence(applyResult)
+  const evidence = isPlainObject(job.evidence) ? job.evidence : {}
+  job.evidence = {
+    resultStatuses: mergeTokenList(evidence.resultStatuses, publicResult.resultStatuses),
+    errorCodes: mergeTokenList(evidence.errorCodes, publicResult.errorCodes),
+    fieldCategories: mergeTokenList(evidence.fieldCategories, ['plm_system']),
+  }
+}
+
+function terminalApplyStatus(counts = {}) {
+  if (nonNegativeInteger(counts.failed, 'failed') > 0 || nonNegativeInteger(counts.held, 'held') > 0) return 'partial'
+  return 'succeeded'
+}
+
+async function runLargeBomCheckpointApplyJobChunk(input = {}) {
+  const storage = ensureDurableJobStorage(input.storage)
+  const key = checkpointApplyJobKey(input.actionId, input.applyJobId || input.jobId)
+  const job = await storage.get(key)
+  if (!job) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_APPLY_JOB_NOT_FOUND',
+      'large-BOM checkpoint apply job was not found',
+      { applyJobIdPresent: Boolean(optionalString(input.applyJobId || input.jobId)) },
+      404,
+    )
+  }
+  if (['succeeded', 'partial'].includes(job.status)) return cloneJson(job)
+  if (!['queued', 'running', 'paused', 'failed'].includes(job.status)) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_APPLY_RUN_REJECTED',
+      'large-BOM checkpoint apply job cannot be run from this status',
+      { status: safeEvidenceToken(job.status, 'status') || undefined },
+      409,
+    )
+  }
+  const plan = isPlainObject(job.plan) && Array.isArray(job.plan.decisions) ? job.plan : null
+  if (!plan) {
+    throw new StockPreparationLargeBomJobError(
+      'LARGE_BOM_APPLY_PLAN_INVALID',
+      'large-BOM checkpoint apply job is missing a private conflict plan',
+      { planPresent: false },
+    )
+  }
+  const chunkSize = normalizeChunkSize(input.maxDecisionsPerChunk)
+  const recordsApi = requireCheckpointRecordsApi(input.recordsApi)
+  const start = nextDecisionIndex(job)
+  const decisions = plan.decisions
+  if (start >= decisions.length) {
+    job.status = terminalApplyStatus(job.counts)
+    job.updatedAt = isoNow(typeof input.now === 'function' ? input.now() : undefined)
+    await storage.set(key, job)
+    return cloneJson(job)
+  }
+
+  const runningAt = isoNow(typeof input.now === 'function' ? input.now() : undefined)
+  job.status = 'running'
+  job.updatedAt = runningAt
+  await storage.set(key, job)
+
+  const end = Math.min(start + chunkSize, decisions.length)
+  const chunkPlan = {
+    ...plan,
+    decisions: decisions.slice(start, end).map(cloneJson),
+  }
+  const applyResult = await applyStockPreparationPlan({
+    permission: job.permission,
+    plan: chunkPlan,
+    target: job.target,
+    template: job.template,
+    recordsApi,
+  })
+
+  job.counts = mergeCounts(job.counts, applyResult.counts)
+  mergeApplyEvidence(job, applyResult)
+  job.checkpoint = {
+    nextDecisionIndex: end,
+    completedChunks: completedChunks(job) + 1,
+  }
+  job.status = end >= decisions.length ? terminalApplyStatus(job.counts) : 'running'
+  job.updatedAt = isoNow(typeof input.now === 'function' ? input.now() : undefined)
+  await storage.set(key, job)
+  return cloneJson(job)
+}
+
 async function planLargeBomBackgroundExpansionJob(input = {}) {
   const storage = ensureDurableJobStorage(input.storage)
   const key = backgroundJobKey(input)
@@ -656,20 +972,29 @@ module.exports = {
   StockPreparationLargeBomJobError,
   cancelLargeBomBackgroundExpansionJob,
   createLargeBomBackgroundExpansionJob,
+  createLargeBomCheckpointApplyJob,
   loadLargeBomBackgroundExpansionJob,
+  loadLargeBomCheckpointApplyJob,
   planLargeBomBackgroundExpansionJob,
   publicBackgroundExpansionJob,
+  publicCheckpointApplyJob,
   runLargeBomBackgroundExpansionJob,
+  runLargeBomCheckpointApplyJobChunk,
   summarizeLargeBomBackgroundExpansionJobForEvidence,
   summarizeLargeBomCheckpointApplyJobForEvidence,
   isAuthoritativeLargeBomExpansion,
   assertAuthoritativeLargeBomExpansion,
+  isAuthoritativeLargeBomPlan,
+  assertAuthoritativeLargeBomPlan,
   __internals: {
     backgroundJobKey,
+    checkpointApplyJobKey,
     ensureDurableJobStorage,
     hashJson,
     safeEvidenceToken,
     safeTokenList,
     nonNegativeInteger,
+    normalizeChunkSize,
+    requireCheckpointRecordsApi,
   },
 }


### PR DESCRIPTION
## Summary

Adds the latent C4 checkpoint apply writer service for the large-BOM path.

- creates checkpoint apply jobs only from a completed authoritative C3 plan artifact;
- requires durable storage, authenticated principal, and Data Factory write/admin permission;
- requires explicit manual-confirm acknowledgement before apply job creation when held rows are present;
- applies plan decisions in bounded chunks by reusing the existing `applyStockPreparationPlan` writer;
- persists checkpoint progress and keeps retry safe through the existing idempotent add/find-then-patch behavior;
- exposes values-free public apply-job summaries only.

## Boundary

Still not wired to any route, UI, worker scheduler, production apply button, PLM read, external DB write, K3 write, Submit/Audit/BOM, or batch rollout. This is a service-layer C4 primitive stacked on #2396.

## Verification

```text
pnpm --filter plugin-integration-core test:stock-preparation-large-bom-jobs
pnpm --filter plugin-integration-core test:stock-preparation-apply-writer
pnpm --filter plugin-integration-core test:stock-preparation-conflict-planner
pnpm --filter plugin-integration-core test:stock-preparation-bom-expansion
pnpm --filter plugin-integration-core test:http-routes
git diff --check
```

Verification doc: `docs/development/data-factory-plm-stock-preparation-large-bom-c4-writer-verification-20260608.md`.

## Notes

The retry test simulates a write-after-success / checkpoint-lost window by resetting the checkpoint to the same decision after the target row already exists. The rerun patches the existing row and does not create a duplicate.
