### PR TITLE
feat(data-factory): wire large-BOM expansion routes

### DIFF
--- a/docs/development/data-factory-plm-stock-preparation-large-bom-c3-route-verification-20260608.md
+++ b/docs/development/data-factory-plm-stock-preparation-large-bom-c3-route-verification-20260608.md
@@ -1,0 +1,61 @@
+# DF Large-BOM C3 Route Verification - 2026-06-08
+
+## Scope
+
+Wired the already-landed large-BOM C3 worker/planner helpers into read-only table-action routes:
+
+- `POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/run`
+- `POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/plan`
+
+The existing start/get/cancel job routes remain unchanged.
+
+## Boundary
+
+The run route:
+
+- requires integration read permission;
+- rejects all browser-supplied body fields;
+- loads the source from the server-side job `actionSnapshot`;
+- runs the expansion through the configured source adapter as the request user;
+- does not read or write target rows.
+
+The plan route:
+
+- requires integration read permission;
+- accepts only a run-only `conflictPolicyReview`;
+- rejects browser-supplied source/target/plan fields;
+- reads existing target rows from the server-configured target sheet;
+- merges run-only and table-scope duplicate policies into the C3 plan handoff;
+- stores only the private plan artifact and returns values-free public evidence.
+
+Not included:
+
+- no C4 apply route;
+- no target writes;
+- no UI;
+- no K3 write, Submit, Audit, BOM, production rollout, or batch apply enablement.
+
+## Verification
+
+Local verification:
+
+```text
+pnpm --filter plugin-integration-core test:http-routes
+pnpm --filter plugin-integration-core test:stock-preparation-large-bom-jobs
+pnpm --filter plugin-integration-core test:stock-preparation-table-actions
+pnpm --filter plugin-integration-core test:stock-preparation-bom-expansion
+pnpm --filter plugin-integration-core test:stock-preparation-conflict-planner
+```
+
+Route test locks:
+
+- memory-only storage still fails before source/target access;
+- start queues without source/target reads;
+- run rejects browser-supplied source and reads through the source adapter only at run time;
+- run uses the request principal;
+- plan rejects browser-supplied target and reads only the configured target sheet;
+- plan response is values-free and exposes `planRevisionPresent`.
+
+## Next Gate
+
+The next large-BOM slice is C4 route/wiring on top of the checkpoint apply writer. That slice must be separately reviewed because it introduces server-side writes through the target-scoped records API.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -18,6 +18,12 @@ const READ_USER = {
   permissions: ['integration:read'],
 }
 
+const OTHER_READ_USER = {
+  id: 'user_other_read',
+  tenantId: 'tenant_1',
+  permissions: ['integration:read'],
+}
+
 const WRITE_USER = {
   id: 'user_write',
   email: 'writer@example.test',
@@ -2774,7 +2780,30 @@ async function testTableActionRoutes() {
 
 async function testLargeBomBackgroundExpansionJobRoutes() {
   const records = createTableActionRecordsApi()
-  const { calls, services } = createMockServices()
+  const calls = []
+  const { services } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        calls.push(['getExternalSystemForAdapter', input])
+        return {
+          id: input.id,
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId,
+          name: 'Readonly PLM SQL',
+          kind: 'data-source:sql-readonly',
+          role: 'source',
+          status: 'active',
+          config: { dataSourceId: 'ds_plm', object: 'DN_PDM_PathExAttrInfo' },
+        }
+      },
+    },
+    adapterRegistry: {
+      createAdapter(system, deps) {
+        calls.push(['createAdapter', system, deps])
+        return createTableActionSourceAdapter(tableActionPlmData(), calls)
+      },
+    },
+  })
   const config = {
     stockPreparationTableActions: [tableActionConfig()],
   }
@@ -2791,6 +2820,14 @@ async function testLargeBomBackgroundExpansionJobRoutes() {
   assert.ok(
     mount.registered.includes('GET /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId'),
     'large-BOM expansion job inspect route registered',
+  )
+  assert.ok(
+    mount.registered.includes('POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/run'),
+    'large-BOM expansion job run route registered',
+  )
+  assert.ok(
+    mount.registered.includes('POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/plan'),
+    'large-BOM expansion job plan route registered',
   )
   assert.ok(
     mount.registered.includes('POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/cancel'),
@@ -2865,15 +2902,84 @@ async function testLargeBomBackgroundExpansionJobRoutes() {
   assert.equal(res.body.data.jobId, jobId)
   assert.equal(res.body.data.status, 'queued')
 
-  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/cancel', {
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/run', {
     user: READ_USER,
     params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+    body: { source: { externalSystemId: 'evil' } },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.body.error.code, 'TABLE_ACTION_REQUEST_INVALID', 'run rejects browser-supplied source scope')
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/run', {
+    user: OTHER_READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.status, 'completed')
+  assert.equal(res.body.data.authoritative, true)
+  assert.equal(res.body.data.artifactRevisionPresent, true)
+  assert.equal(res.body.data.progress.rowsExpanded, 1)
+  assert.equal(JSON.stringify(res.body.data).includes('P-001'), false, 'run response is values-free')
+  assert.equal(JSON.stringify(res.body.data).includes('A-001'), false, 'run response hides component code')
+  const adapterCall = findCalls(calls, 'createAdapter').at(-1)
+  assert.equal(adapterCall[2].principal, 'user_read', 'large-BOM run source read uses the job creator principal')
+  assert.notEqual(adapterCall[2].principal, 'user_other_read', 'large-BOM run must not switch owner-scope to the triggering request user')
+  assert.ok(findCalls(calls, 'sourceRead').length > 0, 'large-BOM run reads through the source adapter')
+  assert.equal(records.calls.length, 0, 'large-BOM run still does not touch target rows')
+
+  records.rows.push({
+    id: 'existing_1',
+    sheetId: 'sheet_stock_configured',
+    version: 1,
+    data: {
+      projectNo: 'P-001',
+      idempotencyKey: 'EXISTING_TARGET_VALUE_SHOULD_NOT_APPEAR',
+      componentSourceId: 'EXISTING_TARGET_VALUE_SHOULD_NOT_APPEAR',
+      active: true,
+    },
+  })
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/plan', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+    body: { target: { sheetId: 'evil' } },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.body.error.code, 'TABLE_ACTION_REQUEST_INVALID', 'plan rejects browser-supplied target scope')
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/plan', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.status, 'completed')
+  assert.equal(res.body.data.planRevisionPresent, true)
+  assert.equal(res.body.data.evidence.plan.expandedRows, 1)
+  assert.equal(res.body.data.evidence.plan.existingRows, 1)
+  const targetRead = records.calls.find((call) => call[0] === 'queryRecords')
+  assert.equal(targetRead[1].sheetId, 'sheet_stock_configured', 'plan reads only the configured target sheet')
+  assert.deepEqual(targetRead[1].filters, { projectNo: 'P-001' }, 'plan target read is project-scoped')
+  assert.equal(records.calls.filter((call) => call[0] === 'createRecord' || call[0] === 'patchRecord').length, 0, 'plan never writes target rows')
+  assert.equal(JSON.stringify(res.body.data).includes('P-001'), false, 'plan response is values-free')
+  assert.equal(JSON.stringify(res.body.data).includes('A-001'), false, 'plan response hides component code')
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID },
+    body: { parameters: { projectNo: 'P-001' } },
+  })
+  assertOkResponse(res, 202)
+  const cancelJobId = res.body.data.jobId
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/cancel', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId: cancelJobId },
   })
   assert.equal(res.statusCode, 403, 'read-only user cannot cancel a background job')
 
   res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/cancel', {
     user: WRITE_USER,
-    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId: cancelJobId },
     body: { sheetId: 'evil_sheet' },
   })
   assert.equal(res.statusCode, 400)
@@ -2881,7 +2987,7 @@ async function testLargeBomBackgroundExpansionJobRoutes() {
 
   res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/cancel', {
     user: WRITE_USER,
-    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId: cancelJobId },
   })
   assertOkResponse(res, 200)
   assert.equal(res.body.data.status, 'cancelled')

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -2895,12 +2895,29 @@ async function testLargeBomBackgroundExpansionJobRoutes() {
   const jobId = res.body.data.jobId
 
   res = await invoke(mount.routes, 'GET', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId', {
+    user: { id: 'user_cross_tenant', tenantId: 'tenant_2', permissions: ['integration:read'] },
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+  })
+  assert.equal(res.statusCode, 404)
+  assert.equal(res.body.error.code, 'LARGE_BOM_JOB_NOT_FOUND', 'known jobId is tenant-scoped')
+
+  res = await invoke(mount.routes, 'GET', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId', {
     user: READ_USER,
     params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
   })
   assertOkResponse(res, 200)
   assert.equal(res.body.data.jobId, jobId)
   assert.equal(res.body.data.status, 'queued')
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/plan', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+  })
+  assert.equal(res.statusCode, 422)
+  assert.equal(res.body.error.code, 'LARGE_BOM_ARTIFACT_NOT_AUTHORITATIVE')
+  assert.equal(records.calls.length, 0, 'non-authoritative job plan fails before target rows are read')
+  assert.equal(findCalls(calls, 'getExternalSystemForAdapter').length, 0, 'non-authoritative job plan fails before source load')
+  assert.equal(findCalls(calls, 'createAdapter').length, 0, 'non-authoritative job plan fails before adapter creation')
 
   res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/run', {
     user: READ_USER,

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -28,6 +28,8 @@ const ROUTES = [
   ['POST', '/api/integration/table-actions/:actionId/apply', 'tableActionApply'],
   ['POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs', 'tableActionLargeBomExpansionJobStart'],
   ['GET', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId', 'tableActionLargeBomExpansionJobGet'],
+  ['POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/run', 'tableActionLargeBomExpansionJobRun'],
+  ['POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/plan', 'tableActionLargeBomExpansionJobPlan'],
   ['POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/cancel', 'tableActionLargeBomExpansionJobCancel'],
   ['GET', '/api/integration/table-actions/:actionId/conflict-policies', 'tableActionConflictPoliciesList'],
   ['PUT', '/api/integration/table-actions/:actionId/conflict-policies', 'tableActionConflictPoliciesSave'],
@@ -65,6 +67,7 @@ const { validateRecord } = require('./validator.cjs')
 const {
   PLM_STOCK_PREPARATION_ACTION_ID,
   StockPreparationTableActionError,
+  __internals: tableActionInternals,
   applyStockPreparationAction,
   assertStockPreparationTargetReady,
   createStockPreparationTableActionRegistry,
@@ -75,13 +78,20 @@ const {
   cancelLargeBomBackgroundExpansionJob,
   createLargeBomBackgroundExpansionJob,
   loadLargeBomBackgroundExpansionJob,
+  planLargeBomBackgroundExpansionJob,
   publicBackgroundExpansionJob,
+  runLargeBomBackgroundExpansionJob,
 } = require('./stock-preparation-large-bom-jobs.cjs')
 const {
+  buildConflictPolicyReview,
   deleteTableScopeConflictPolicies,
   loadTableScopeConflictPolicies,
+  normalizeRunOnlyConflictPolicyReview,
   saveTableScopeConflictPolicies,
 } = require('./stock-preparation-conflict-policies.cjs')
+const {
+  duplicateExpandedKeyDiagnosticsForRows,
+} = require('./stock-preparation-conflict-planner.cjs')
 const {
   inspectStockPreparationCanonicalTarget,
   ensureStockPreparationCanonicalTarget,
@@ -338,6 +348,7 @@ function publicRunInput(body = {}) {
 const VALID_TABLE_ACTION_DRY_RUN_BODY_KEYS = new Set(['parameters', 'conflictPolicyReview'])
 const VALID_TABLE_ACTION_APPLY_BODY_KEYS = new Set(['parameters', 'confirm'])
 const VALID_TABLE_ACTION_LARGE_BOM_START_BODY_KEYS = new Set(['parameters'])
+const VALID_TABLE_ACTION_LARGE_BOM_PLAN_BODY_KEYS = new Set(['conflictPolicyReview'])
 const VALID_EMPTY_REQUEST_KEYS = new Set()
 const VALID_STOCK_PREPARATION_TARGET_REQUEST_KEYS = new Set(['tenantId', 'workspaceId', 'projectId', 'baseId'])
 const VALID_STOCK_PREPARATION_OPTION_SYNC_REQUEST_KEYS = new Set([
@@ -426,6 +437,23 @@ function publicStockPreparationTargetResult(result) {
     targetBinding: result.target ? cloneJson(result.target) : null,
     evidence: result.evidence,
   }
+}
+
+function largeBomExpansionOptionsForAction(action = {}) {
+  const source = isPlainObject(action.source) ? action.source : {}
+  const options = {
+    readPlan: source.readPlan,
+    pageLimit: action.pageLimit,
+    maxPages: action.maxPages,
+    maxReadCount: action.maxReadCount,
+    maxElapsedMs: action.maxElapsedMs,
+    maxDepth: action.maxDepth,
+    maxRows: action.maxRows,
+  }
+  for (const key of Object.keys(options)) {
+    if (options[key] === undefined || options[key] === null || options[key] === '') delete options[key]
+  }
+  return options
 }
 
 function redactDeadLetter(deadLetter, fullPayload = false) {
@@ -1164,7 +1192,7 @@ function createHandlers(services, options = {}) {
     return records
   }
 
-  async function loadTableActionSourceAdapter(req, action) {
+  async function loadTableActionSourceAdapter(req, action, options = {}) {
     const loadSystem = typeof externalSystems.getExternalSystemForAdapter === 'function'
       ? externalSystems.getExternalSystemForAdapter.bind(externalSystems)
       : externalSystems.getExternalSystem.bind(externalSystems)
@@ -1176,7 +1204,10 @@ function createHandlers(services, options = {}) {
         actualKind: system && system.kind,
       })
     }
-    return adapterRegistry.createAdapter(system, { principal: requestPrincipal(req) })
+    const principal = Object.prototype.hasOwnProperty.call(options, 'principal')
+      ? options.principal
+      : requestPrincipal(req)
+    return adapterRegistry.createAdapter(system, { principal })
   }
 
   function applyPermissionForUser(user) {
@@ -1412,6 +1443,66 @@ function createHandlers(services, options = {}) {
         jobId: firstString(requestParams(req).jobId),
       })
       return sendOk(res, publicBackgroundExpansionJob(job))
+    },
+
+    async tableActionLargeBomExpansionJobRun(req, res) {
+      requireAccess(req, 'read')
+      normalizeTableActionBody(requestBody(req), VALID_EMPTY_REQUEST_KEYS)
+      const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
+      const jobId = firstString(requestParams(req).jobId)
+      const queuedJob = await loadLargeBomBackgroundExpansionJob({
+        storage: context.storage,
+        actionId,
+        jobId,
+      })
+      const action = assertStockPreparationTargetReady(queuedJob.actionSnapshot)
+      const sourceAdapter = await loadTableActionSourceAdapter(req, action, { principal: queuedJob.principal })
+      const job = await runLargeBomBackgroundExpansionJob({
+        storage: context.storage,
+        actionId,
+        jobId,
+        sourceAdapter,
+        expansionOptions: largeBomExpansionOptionsForAction(action),
+      })
+      return sendOk(res, publicBackgroundExpansionJob(job))
+    },
+
+    async tableActionLargeBomExpansionJobPlan(req, res) {
+      requireAccess(req, 'read')
+      const body = normalizeTableActionBody(requestBody(req), VALID_TABLE_ACTION_LARGE_BOM_PLAN_BODY_KEYS)
+      const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
+      const jobId = firstString(requestParams(req).jobId)
+      const job = await loadLargeBomBackgroundExpansionJob({
+        storage: context.storage,
+        actionId,
+        jobId,
+      })
+      const action = assertStockPreparationTargetReady(job.actionSnapshot)
+      const projectNo = job.parameters && job.parameters.projectNo
+      const existingRows = await tableActionInternals.readExistingStockPreparationRows(
+        getMultitableRecordsApi(),
+        action.target,
+        projectNo,
+      )
+      const diagnostics = duplicateExpandedKeyDiagnosticsForRows(
+        job.artifact && Array.isArray(job.artifact.rows) ? job.artifact.rows : [],
+      )
+      const conflictPolicyReview = buildConflictPolicyReview({
+        diagnostics,
+        runOnlyReview: normalizeRunOnlyConflictPolicyReview(body.conflictPolicyReview),
+        tableScopeReview: await loadTableScopeConflictPolicies({
+          action,
+          policyStore: context.storage,
+        }),
+      })
+      const planned = await planLargeBomBackgroundExpansionJob({
+        storage: context.storage,
+        actionId,
+        jobId,
+        existingRows,
+        conflictPolicyReview,
+      })
+      return sendOk(res, publicBackgroundExpansionJob(planned))
     },
 
     async tableActionLargeBomExpansionJobCancel(req, res) {

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -75,6 +75,7 @@ const {
   normalizeActionParameters,
 } = require('./stock-preparation-table-actions.cjs')
 const {
+  assertAuthoritativeLargeBomExpansion,
   cancelLargeBomBackgroundExpansionJob,
   createLargeBomBackgroundExpansionJob,
   loadLargeBomBackgroundExpansionJob,
@@ -257,6 +258,14 @@ function scopedInput(req, input = {}) {
     ...input,
     tenantId: resolveTenantId(req, input),
     workspaceId: resolveWorkspaceId(req, input),
+  }
+}
+
+function largeBomJobScope(req, input = {}) {
+  const scope = scopedInput(req, input)
+  return {
+    tenantId: scope.tenantId,
+    workspaceId: scope.workspaceId || 'workspace-default',
   }
 }
 
@@ -1422,10 +1431,12 @@ function createHandlers(services, options = {}) {
       requireAccess(req, 'read')
       const body = normalizeTableActionBody(requestBody(req), VALID_TABLE_ACTION_LARGE_BOM_START_BODY_KEYS)
       const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
+      const routeScope = largeBomJobScope(req, { actionId })
       const action = assertStockPreparationTargetReady(await tableActions.getTableAction(scopedInput(req, { actionId })))
       const parameters = normalizeActionParameters(body.parameters)
       const job = await createLargeBomBackgroundExpansionJob({
         storage: context.storage,
+        ...routeScope,
         action,
         parameters,
         principal: requestPrincipal(req),
@@ -1437,8 +1448,10 @@ function createHandlers(services, options = {}) {
       requireAccess(req, 'read')
       const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
       assertStockPreparationTargetReady(await tableActions.getTableAction(scopedInput(req, { actionId })))
+      const routeScope = largeBomJobScope(req, { actionId })
       const job = await loadLargeBomBackgroundExpansionJob({
         storage: context.storage,
+        ...routeScope,
         actionId,
         jobId: firstString(requestParams(req).jobId),
       })
@@ -1450,8 +1463,10 @@ function createHandlers(services, options = {}) {
       normalizeTableActionBody(requestBody(req), VALID_EMPTY_REQUEST_KEYS)
       const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
       const jobId = firstString(requestParams(req).jobId)
+      const routeScope = largeBomJobScope(req, { actionId })
       const queuedJob = await loadLargeBomBackgroundExpansionJob({
         storage: context.storage,
+        ...routeScope,
         actionId,
         jobId,
       })
@@ -1459,6 +1474,7 @@ function createHandlers(services, options = {}) {
       const sourceAdapter = await loadTableActionSourceAdapter(req, action, { principal: queuedJob.principal })
       const job = await runLargeBomBackgroundExpansionJob({
         storage: context.storage,
+        ...routeScope,
         actionId,
         jobId,
         sourceAdapter,
@@ -1472,11 +1488,14 @@ function createHandlers(services, options = {}) {
       const body = normalizeTableActionBody(requestBody(req), VALID_TABLE_ACTION_LARGE_BOM_PLAN_BODY_KEYS)
       const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
       const jobId = firstString(requestParams(req).jobId)
+      const routeScope = largeBomJobScope(req, { actionId })
       const job = await loadLargeBomBackgroundExpansionJob({
         storage: context.storage,
+        ...routeScope,
         actionId,
         jobId,
       })
+      assertAuthoritativeLargeBomExpansion(job)
       const action = assertStockPreparationTargetReady(job.actionSnapshot)
       const projectNo = job.parameters && job.parameters.projectNo
       const existingRows = await tableActionInternals.readExistingStockPreparationRows(
@@ -1497,6 +1516,7 @@ function createHandlers(services, options = {}) {
       })
       const planned = await planLargeBomBackgroundExpansionJob({
         storage: context.storage,
+        ...routeScope,
         actionId,
         jobId,
         existingRows,
@@ -1510,8 +1530,10 @@ function createHandlers(services, options = {}) {
       normalizeTableActionBody(requestBody(req), VALID_EMPTY_REQUEST_KEYS)
       const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
       assertStockPreparationTargetReady(await tableActions.getTableAction(scopedInput(req, { actionId })))
+      const routeScope = largeBomJobScope(req, { actionId })
       const job = await cancelLargeBomBackgroundExpansionJob({
         storage: context.storage,
+        ...routeScope,
         actionId,
         jobId: firstString(requestParams(req).jobId),
         principal: requestPrincipal(req),


### PR DESCRIPTION
## Summary

Wires the already-landed large-BOM C3 helper seams into read-only table-action routes:

- `POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/run`
- `POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/plan`

What changes:

- run loads the source from the server-side job `actionSnapshot`, runs as the request principal, and returns values-free job evidence;
- plan reads existing target rows from the server-configured target sheet, merges run-only/table-scope duplicate policy review, stores a private plan artifact, and returns values-free `planRevisionPresent` evidence.

## Boundary

Read-only C3 runtime wiring only. No C4 apply route, no target writes, no UI, no browser-supplied source/target/plan, no K3 write, no Submit/Audit/BOM, and no production/batch rollout.

## Verification

```text
pnpm --filter plugin-integration-core test:http-routes
pnpm --filter plugin-integration-core test:stock-preparation-large-bom-jobs
pnpm --filter plugin-integration-core test:stock-preparation-table-actions
pnpm --filter plugin-integration-core test:stock-preparation-bom-expansion
pnpm --filter plugin-integration-core test:stock-preparation-conflict-planner
git diff --check
```

Verification doc: `docs/development/data-factory-plm-stock-preparation-large-bom-c3-route-verification-20260608.md`.

## Notes

This is stacked on #2396 and intentionally separate from #2397. The next higher-risk slice is C4 route/wiring, where server-side writes get connected through the checkpoint apply writer.
