### PR TITLE
feat(data-factory): wire large-BOM checkpoint apply routes

### DIFF
--- a/docs/development/data-factory-plm-stock-preparation-large-bom-c4-route-verification-20260608.md
+++ b/docs/development/data-factory-plm-stock-preparation-large-bom-c4-route-verification-20260608.md
@@ -1,0 +1,53 @@
+# DF Large-BOM C4 Route Verification - 2026-06-08
+
+## Scope
+
+Wired the checkpoint apply writer into large-BOM table-action routes:
+
+- `POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs`
+- `GET /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs/:applyJobId`
+- `POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs/:applyJobId/run`
+
+The route layer creates an apply job from the server-side C3 plan artifact, exposes values-free public status, and runs one checkpoint apply chunk through a target-scoped records API.
+
+## Security Boundary
+
+- Apply-job creation requires integration write/admin permission.
+- Apply-job run requires integration write/admin permission.
+- The browser may not send source, target, sheetId, plan, payload, or record data.
+- The target sheet comes from the server-side action snapshot stored on the job.
+- The run route builds a target-scoped records API from the private apply job target before invoking the writer.
+- The route validates that an apply job belongs to the expansion job in the URL.
+
+## Still Out Of Scope
+
+- No UI.
+- No automatic scheduler/loop.
+- No production or batch rollout.
+- No PLM/external DB write.
+- No K3 write, Submit, Audit, or BOM write.
+
+## Verification
+
+Local verification:
+
+```text
+pnpm --filter plugin-integration-core test:http-routes
+pnpm --filter plugin-integration-core test:stock-preparation-large-bom-jobs
+pnpm --filter plugin-integration-core test:stock-preparation-apply-writer
+pnpm --filter plugin-integration-core test:stock-preparation-table-actions
+pnpm --filter plugin-integration-core test:stock-preparation-conflict-planner
+pnpm --filter plugin-integration-core test:stock-preparation-bom-expansion
+```
+
+Route test locks:
+
+- read-only users cannot create or run checkpoint apply jobs;
+- client-supplied target/sheet scope is rejected;
+- apply-job creation performs no target write;
+- apply-job run writes only through the configured target sheet;
+- public responses are values-free.
+
+## Next Gate
+
+Before production/batch rollout, this path still needs an entity-machine large-BOM validation run with values-free evidence and an operator-visible rollback/retry procedure.

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -2830,6 +2830,18 @@ async function testLargeBomBackgroundExpansionJobRoutes() {
     'large-BOM expansion job plan route registered',
   )
   assert.ok(
+    mount.registered.includes('POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs'),
+    'large-BOM checkpoint apply job start route registered',
+  )
+  assert.ok(
+    mount.registered.includes('GET /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs/:applyJobId'),
+    'large-BOM checkpoint apply job inspect route registered',
+  )
+  assert.ok(
+    mount.registered.includes('POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs/:applyJobId/run'),
+    'large-BOM checkpoint apply job run route registered',
+  )
+  assert.ok(
     mount.registered.includes('POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/cancel'),
     'large-BOM expansion job cancel route registered',
   )
@@ -2979,6 +2991,76 @@ async function testLargeBomBackgroundExpansionJobRoutes() {
   assert.equal(records.calls.filter((call) => call[0] === 'createRecord' || call[0] === 'patchRecord').length, 0, 'plan never writes target rows')
   assert.equal(JSON.stringify(res.body.data).includes('P-001'), false, 'plan response is values-free')
   assert.equal(JSON.stringify(res.body.data).includes('A-001'), false, 'plan response hides component code')
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+    body: { confirm: {} },
+  })
+  assert.equal(res.statusCode, 403, 'read-only user cannot create a checkpoint apply job')
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs', {
+    user: WRITE_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+    body: { target: { sheetId: 'evil_sheet' } },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.body.error.code, 'TABLE_ACTION_REQUEST_INVALID', 'apply-job start rejects browser-supplied target')
+
+  const writesBeforeApplyJobStart = records.calls.filter((call) => call[0] === 'createRecord' || call[0] === 'patchRecord').length
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs', {
+    user: WRITE_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+    body: { confirm: {} },
+  })
+  assertOkResponse(res, 202)
+  assert.equal(res.body.data.status, 'queued')
+  assert.equal(res.body.data.planRevisionPresent, true)
+  assert.equal(res.body.data.targetRevisionPresent, true)
+  assert.equal(res.body.data.approvalPresent, true)
+  assert.equal(typeof res.body.data.jobId, 'string')
+  assert.equal(records.calls.filter((call) => call[0] === 'createRecord' || call[0] === 'patchRecord').length, writesBeforeApplyJobStart, 'apply-job start does not write target rows')
+  assert.equal(JSON.stringify(res.body.data).includes('P-001'), false, 'apply-job start response is values-free')
+  assert.equal(JSON.stringify(res.body.data).includes('sheet_stock_configured'), false, 'apply-job start hides target sheet')
+  const applyJobId = res.body.data.jobId
+
+  res = await invoke(mount.routes, 'GET', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs/:applyJobId', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId, applyJobId },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.jobId, applyJobId)
+  assert.equal(res.body.data.status, 'queued')
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs/:applyJobId/run', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId, applyJobId },
+  })
+  assert.equal(res.statusCode, 403, 'read-only user cannot run checkpoint apply')
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs/:applyJobId/run', {
+    user: WRITE_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId, applyJobId },
+    body: { sheetId: 'evil_sheet' },
+  })
+  assert.equal(res.statusCode, 400)
+  assert.equal(res.body.error.code, 'TABLE_ACTION_REQUEST_INVALID', 'apply-job run rejects browser-supplied sheet scope')
+
+  res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs/:applyJobId/run', {
+    user: WRITE_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId, applyJobId },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.status, 'succeeded')
+  assert.equal(res.body.data.counts.created, 1)
+  assert.equal(res.body.data.counts.inactive, 1)
+  assert.equal(res.body.data.counts.failed, 0)
+  const applyCreate = records.calls.find((call) => call[0] === 'createRecord')
+  const applyPatch = records.calls.find((call) => call[0] === 'patchRecord')
+  assert.equal(applyCreate[1].sheetId, 'sheet_stock_configured', 'checkpoint apply creates only on the configured target sheet')
+  assert.equal(applyPatch[1].sheetId, 'sheet_stock_configured', 'checkpoint apply patches only on the configured target sheet')
+  assert.equal(JSON.stringify(res.body.data).includes('P-001'), false, 'checkpoint apply response is values-free')
+  assert.equal(JSON.stringify(res.body.data).includes('A-001'), false, 'checkpoint apply response hides component code')
 
   res = await invoke(mount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs', {
     user: READ_USER,

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -3025,6 +3025,13 @@ async function testLargeBomBackgroundExpansionJobRoutes() {
   const applyJobId = res.body.data.jobId
 
   res = await invoke(mount.routes, 'GET', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs/:applyJobId', {
+    user: { id: 'user_cross_tenant', tenantId: 'tenant_2', permissions: ['integration:read'] },
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId, applyJobId },
+  })
+  assert.equal(res.statusCode, 404)
+  assert.equal(res.body.error.code, 'LARGE_BOM_APPLY_JOB_NOT_FOUND', 'known applyJobId is tenant-scoped')
+
+  res = await invoke(mount.routes, 'GET', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs/:applyJobId', {
     user: READ_USER,
     params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId, applyJobId },
   })

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -30,6 +30,9 @@ const ROUTES = [
   ['GET', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId', 'tableActionLargeBomExpansionJobGet'],
   ['POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/run', 'tableActionLargeBomExpansionJobRun'],
   ['POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/plan', 'tableActionLargeBomExpansionJobPlan'],
+  ['POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs', 'tableActionLargeBomApplyJobStart'],
+  ['GET', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs/:applyJobId', 'tableActionLargeBomApplyJobGet'],
+  ['POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs/:applyJobId/run', 'tableActionLargeBomApplyJobRun'],
   ['POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/cancel', 'tableActionLargeBomExpansionJobCancel'],
   ['GET', '/api/integration/table-actions/:actionId/conflict-policies', 'tableActionConflictPoliciesList'],
   ['PUT', '/api/integration/table-actions/:actionId/conflict-policies', 'tableActionConflictPoliciesSave'],
@@ -71,6 +74,7 @@ const {
   applyStockPreparationAction,
   assertStockPreparationTargetReady,
   createStockPreparationTableActionRegistry,
+  createTargetScopedRecordsApi,
   dryRunStockPreparationAction,
   normalizeActionParameters,
 } = require('./stock-preparation-table-actions.cjs')
@@ -78,9 +82,13 @@ const {
   assertAuthoritativeLargeBomExpansion,
   cancelLargeBomBackgroundExpansionJob,
   createLargeBomBackgroundExpansionJob,
+  createLargeBomCheckpointApplyJob,
   loadLargeBomBackgroundExpansionJob,
+  loadLargeBomCheckpointApplyJob,
   planLargeBomBackgroundExpansionJob,
   publicBackgroundExpansionJob,
+  publicCheckpointApplyJob,
+  runLargeBomCheckpointApplyJobChunk,
   runLargeBomBackgroundExpansionJob,
 } = require('./stock-preparation-large-bom-jobs.cjs')
 const {
@@ -358,6 +366,7 @@ const VALID_TABLE_ACTION_DRY_RUN_BODY_KEYS = new Set(['parameters', 'conflictPol
 const VALID_TABLE_ACTION_APPLY_BODY_KEYS = new Set(['parameters', 'confirm'])
 const VALID_TABLE_ACTION_LARGE_BOM_START_BODY_KEYS = new Set(['parameters'])
 const VALID_TABLE_ACTION_LARGE_BOM_PLAN_BODY_KEYS = new Set(['conflictPolicyReview'])
+const VALID_TABLE_ACTION_LARGE_BOM_APPLY_START_BODY_KEYS = new Set(['confirm'])
 const VALID_EMPTY_REQUEST_KEYS = new Set()
 const VALID_STOCK_PREPARATION_TARGET_REQUEST_KEYS = new Set(['tenantId', 'workspaceId', 'projectId', 'baseId'])
 const VALID_STOCK_PREPARATION_OPTION_SYNC_REQUEST_KEYS = new Set([
@@ -463,6 +472,14 @@ function largeBomExpansionOptionsForAction(action = {}) {
     if (options[key] === undefined || options[key] === null || options[key] === '') delete options[key]
   }
   return options
+}
+
+function assertApplyJobMatchesExpansion(applyJob, jobId) {
+  if (firstString(applyJob && applyJob.sourceJobId) === firstString(jobId)) return applyJob
+  throw new HttpRouteError(404, 'LARGE_BOM_APPLY_JOB_NOT_FOUND', 'large-BOM checkpoint apply job was not found', {
+    applyJobIdPresent: Boolean(firstString(applyJob && applyJob.jobId)),
+    sourceJobIdPresent: Boolean(firstString(jobId)),
+  })
 }
 
 function redactDeadLetter(deadLetter, fullPayload = false) {
@@ -1523,6 +1540,60 @@ function createHandlers(services, options = {}) {
         conflictPolicyReview,
       })
       return sendOk(res, publicBackgroundExpansionJob(planned))
+    },
+
+    async tableActionLargeBomApplyJobStart(req, res) {
+      const user = requireAccess(req, 'write')
+      const body = normalizeTableActionBody(requestBody(req), VALID_TABLE_ACTION_LARGE_BOM_APPLY_START_BODY_KEYS)
+      const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
+      const jobId = firstString(requestParams(req).jobId)
+      assertStockPreparationTargetReady(await tableActions.getTableAction(scopedInput(req, { actionId })))
+      const confirm = isPlainObject(body.confirm) ? body.confirm : {}
+      const job = await createLargeBomCheckpointApplyJob({
+        storage: context.storage,
+        actionId,
+        jobId,
+        principal: requestPrincipal(req),
+        permission: applyPermissionForUser(user),
+        acceptManualConfirmHold: confirm.acceptManualConfirmHold === true,
+      })
+      return sendOk(res, publicCheckpointApplyJob(job), 202)
+    },
+
+    async tableActionLargeBomApplyJobGet(req, res) {
+      requireAccess(req, 'read')
+      const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
+      const jobId = firstString(requestParams(req).jobId)
+      assertStockPreparationTargetReady(await tableActions.getTableAction(scopedInput(req, { actionId })))
+      const job = await loadLargeBomCheckpointApplyJob({
+        storage: context.storage,
+        actionId,
+        applyJobId: firstString(requestParams(req).applyJobId),
+      })
+      assertApplyJobMatchesExpansion(job, jobId)
+      return sendOk(res, publicCheckpointApplyJob(job))
+    },
+
+    async tableActionLargeBomApplyJobRun(req, res) {
+      requireAccess(req, 'write')
+      normalizeTableActionBody(requestBody(req), VALID_EMPTY_REQUEST_KEYS)
+      const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
+      const jobId = firstString(requestParams(req).jobId)
+      assertStockPreparationTargetReady(await tableActions.getTableAction(scopedInput(req, { actionId })))
+      const pendingJob = await loadLargeBomCheckpointApplyJob({
+        storage: context.storage,
+        actionId,
+        applyJobId: firstString(requestParams(req).applyJobId),
+      })
+      assertApplyJobMatchesExpansion(pendingJob, jobId)
+      const scopedRecordsApi = createTargetScopedRecordsApi(getMultitableRecordsApi(), pendingJob.target)
+      const job = await runLargeBomCheckpointApplyJobChunk({
+        storage: context.storage,
+        actionId,
+        applyJobId: pendingJob.jobId,
+        recordsApi: scopedRecordsApi,
+      })
+      return sendOk(res, publicCheckpointApplyJob(job))
     },
 
     async tableActionLargeBomExpansionJobCancel(req, res) {

--- a/plugins/plugin-integration-core/lib/http-routes.cjs
+++ b/plugins/plugin-integration-core/lib/http-routes.cjs
@@ -1547,10 +1547,12 @@ function createHandlers(services, options = {}) {
       const body = normalizeTableActionBody(requestBody(req), VALID_TABLE_ACTION_LARGE_BOM_APPLY_START_BODY_KEYS)
       const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
       const jobId = firstString(requestParams(req).jobId)
+      const routeScope = largeBomJobScope(req, { actionId })
       assertStockPreparationTargetReady(await tableActions.getTableAction(scopedInput(req, { actionId })))
       const confirm = isPlainObject(body.confirm) ? body.confirm : {}
       const job = await createLargeBomCheckpointApplyJob({
         storage: context.storage,
+        ...routeScope,
         actionId,
         jobId,
         principal: requestPrincipal(req),
@@ -1564,9 +1566,11 @@ function createHandlers(services, options = {}) {
       requireAccess(req, 'read')
       const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
       const jobId = firstString(requestParams(req).jobId)
+      const routeScope = largeBomJobScope(req, { actionId })
       assertStockPreparationTargetReady(await tableActions.getTableAction(scopedInput(req, { actionId })))
       const job = await loadLargeBomCheckpointApplyJob({
         storage: context.storage,
+        ...routeScope,
         actionId,
         applyJobId: firstString(requestParams(req).applyJobId),
       })
@@ -1579,9 +1583,11 @@ function createHandlers(services, options = {}) {
       normalizeTableActionBody(requestBody(req), VALID_EMPTY_REQUEST_KEYS)
       const actionId = firstString(requestParams(req).actionId) || PLM_STOCK_PREPARATION_ACTION_ID
       const jobId = firstString(requestParams(req).jobId)
+      const routeScope = largeBomJobScope(req, { actionId })
       assertStockPreparationTargetReady(await tableActions.getTableAction(scopedInput(req, { actionId })))
       const pendingJob = await loadLargeBomCheckpointApplyJob({
         storage: context.storage,
+        ...routeScope,
         actionId,
         applyJobId: firstString(requestParams(req).applyJobId),
       })
@@ -1589,6 +1595,7 @@ function createHandlers(services, options = {}) {
       const scopedRecordsApi = createTargetScopedRecordsApi(getMultitableRecordsApi(), pendingJob.target)
       const job = await runLargeBomCheckpointApplyJobChunk({
         storage: context.storage,
+        ...routeScope,
         actionId,
         applyJobId: pendingJob.jobId,
         recordsApi: scopedRecordsApi,


### PR DESCRIPTION
## Summary

Wires the C4 checkpoint apply writer into large-BOM table-action routes:

- `POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs`
- `GET /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs/:applyJobId`
- `POST /api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/apply-jobs/:applyJobId/run`

What changes:

- apply-job creation consumes the server-side C3 plan artifact and requires write/admin permission;
- apply-job run requires write/admin permission and uses a target-scoped records API built from the private apply job target;
- route rejects client-supplied source/target/sheet/plan/payload fields;
- public responses stay values-free.

## Boundary

No UI, no automatic scheduler/loop, no production/batch rollout, no external DB write, no K3 write, no Submit/Audit/BOM. This is a route wiring slice stacked on #2397.

## Verification

```text
pnpm --filter plugin-integration-core test:http-routes
pnpm --filter plugin-integration-core test:stock-preparation-large-bom-jobs
pnpm --filter plugin-integration-core test:stock-preparation-apply-writer
pnpm --filter plugin-integration-core test:stock-preparation-table-actions
pnpm --filter plugin-integration-core test:stock-preparation-conflict-planner
pnpm --filter plugin-integration-core test:stock-preparation-bom-expansion
git diff --check
```

Verification doc: `docs/development/data-factory-plm-stock-preparation-large-bom-c4-route-verification-20260608.md`.

## Notes

This makes the large-BOM C3/C4 route chain testable end-to-end in the plugin route layer, but production/batch rollout remains gated on entity-machine validation with values-free evidence and an operator-visible retry/rollback procedure.
