### PR TITLE
feat(attendance): add auto shift matching preview

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -4815,6 +4815,12 @@ attendanceIntegrationDescribe(
             monthlyMaxMinutes: 9600,
           },
           compTimeFromOvertime: { enabled: true, expiresInDays: 45 },
+          autoShiftMatching: {
+            enabled: true,
+            mode: 'preview',
+            maxToleranceMinutes: 90,
+            minConfidenceToApply: 'medium',
+          },
         }),
       })
       expect(saveSettingsRes.status).toBe(200)
@@ -4832,6 +4838,7 @@ attendanceIntegrationDescribe(
           comprehensiveHours?: { capDefaults?: Record<string, number | null> }
           shiftCompliance?: Record<string, unknown>
           compTimeFromOvertime?: Record<string, unknown>
+          autoShiftMatching?: Record<string, unknown>
         }
       } | undefined)?.data
       expect(reloaded?.comprehensiveHours?.capDefaults).toEqual({ month: 10560, quarter: 31680, year: 126720 })
@@ -4842,6 +4849,12 @@ attendanceIntegrationDescribe(
         monthlyMaxMinutes: 9600,
       })
       expect(reloaded?.compTimeFromOvertime).toEqual({ enabled: true, expiresInDays: 45 })
+      expect(reloaded?.autoShiftMatching).toEqual({
+        enabled: true,
+        mode: 'preview',
+        maxToleranceMinutes: 90,
+        minConfidenceToApply: 'medium',
+      })
 
       const futurePunchRes = await requestJson(`${baseUrl}/api/attendance/punch`, {
         method: 'POST',
@@ -4894,6 +4907,287 @@ attendanceIntegrationDescribe(
         body: JSON.stringify(originalSettings),
       }).catch(() => undefined)
     }
+  })
+
+  describe('auto shift matching preview', () => {
+    const orgId = 'default'
+
+    async function getAdminToken(userId: string): Promise<string | undefined> {
+      if (!baseUrl) return undefined
+      const tokenRes = await requestJson(
+        `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(userId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+      )
+      return (tokenRes.body as { token?: string } | undefined)?.token
+    }
+
+    async function saveAutoShiftSettings(token: string, payload: Record<string, unknown>): Promise<void> {
+      if (!baseUrl) return
+      const res = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify(payload),
+      })
+      expect(res.status).toBe(200)
+    }
+
+    async function loadSettingsForTest(token: string): Promise<Record<string, unknown>> {
+      if (!baseUrl) return {}
+      const res = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      expect(res.status).toBe(200)
+      return ((res.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
+    }
+
+    async function createShiftForAutoShift(token: string, name: string, start: string, end: string): Promise<string> {
+      if (!baseUrl) throw new Error('baseUrl missing')
+      const res = await requestJson(`${baseUrl}/api/attendance/shifts`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({
+          name,
+          timezone: 'UTC',
+          workStartTime: start,
+          workEndTime: end,
+          workingDays: [0, 1, 2, 3, 4, 5, 6],
+        }),
+      })
+      expect(res.status).toBe(201)
+      const shiftId = (res.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(shiftId).toBeTruthy()
+      if (!shiftId) throw new Error('shift id missing')
+      return shiftId
+    }
+
+    async function createGroupForAutoShift(token: string, name: string, attendanceType: string, userId: string): Promise<string> {
+      if (!baseUrl) throw new Error('baseUrl missing')
+      const groupRes = await requestJson(`${baseUrl}/api/attendance/groups`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ name, timezone: 'UTC', attendanceType, description: 'auto-shift-preview-test' }),
+      })
+      expect(groupRes.status).toBe(200)
+      const groupId = (groupRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(groupId).toBeTruthy()
+      if (!groupId) throw new Error('group id missing')
+
+      const memberRes = await requestJson(`${baseUrl}/api/attendance/groups/${groupId}/members`, {
+        method: 'POST',
+        headers: { Authorization: `Bearer ${token}`, 'Content-Type': 'application/json' },
+        body: JSON.stringify({ userIds: [userId] }),
+      })
+      expect(memberRes.status).toBe(200)
+      return groupId
+    }
+
+    async function insertPunchEvent(pool: Pool, userId: string, workDate: string, eventType: 'check_in' | 'check_out', occurredAt: string): Promise<string> {
+      const eventId = randomUuidV4()
+      await pool.query(
+        `INSERT INTO attendance_events
+         (id, user_id, org_id, work_date, occurred_at, event_type, source, timezone, location, meta)
+         VALUES ($1, $2, $3, $4, $5, $6, 'integration-test', 'UTC', '{}'::jsonb, '{}'::jsonb)`,
+        [eventId, userId, orgId, workDate, occurredAt, eventType],
+      )
+      return eventId
+    }
+
+    it('returns disabled when either preview gate is off and writes no assignments', async () => {
+      if (!baseUrl) return
+      const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+      if (!dbUrl) return
+      const runSuffix = Date.now().toString(36)
+      const adminToken = await getAdminToken(`attendance-autoshift-disabled-admin-${runSuffix}`)
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+      const previousFlag = process.env.ATTENDANCE_AUTO_SHIFT_MATCHING_ENABLED
+      const originalSettings = await loadSettingsForTest(adminToken)
+      const pool = new Pool({ connectionString: dbUrl })
+      const userId = `attendance-autoshift-disabled-user-${runSuffix}`
+      try {
+        process.env.ATTENDANCE_AUTO_SHIFT_MATCHING_ENABLED = 'true'
+        await saveAutoShiftSettings(adminToken, { autoShiftMatching: { enabled: false, mode: 'preview' } })
+        const res = await requestJson(`${baseUrl}/api/attendance/auto-shift-matching/preview`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ from: '2026-06-10', userIds: [userId] }),
+        })
+        expect(res.status).toBe(403)
+        expect((res.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('AUTO_SHIFT_MATCHING_DISABLED')
+        const writes = await pool.query(
+          `SELECT
+             (SELECT COUNT(*)::int FROM attendance_shift_assignments WHERE org_id = $1 AND user_id = $2) AS shift_count,
+             (SELECT COUNT(*)::int FROM attendance_rotation_assignments WHERE org_id = $1 AND user_id = $2) AS rotation_count`,
+          [orgId, userId],
+        )
+        expect(writes.rows[0]).toMatchObject({ shift_count: 0, rotation_count: 0 })
+      } finally {
+        await saveAutoShiftSettings(adminToken, originalSettings).catch(() => undefined)
+        if (previousFlag === undefined) delete process.env.ATTENDANCE_AUTO_SHIFT_MATCHING_ENABLED
+        else process.env.ATTENDANCE_AUTO_SHIFT_MATCHING_ENABLED = previousFlag
+        await pool.end()
+      }
+    })
+
+    it('suggests a deterministic shift for an unscheduled scheduled-shift member without writing assignments', async () => {
+      if (!baseUrl) return
+      const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+      if (!dbUrl) return
+      const runSuffix = Date.now().toString(36)
+      const adminToken = await getAdminToken(`attendance-autoshift-happy-admin-${runSuffix}`)
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+      const previousFlag = process.env.ATTENDANCE_AUTO_SHIFT_MATCHING_ENABLED
+      const originalSettings = await loadSettingsForTest(adminToken)
+      const pool = new Pool({ connectionString: dbUrl })
+      const userId = `attendance-autoshift-happy-user-${runSuffix}`
+      const workDate = '2026-06-11'
+      const minuteOffset = Number.parseInt(runSuffix.slice(-2), 36) % 40
+      const startMinute = String(10 + minuteOffset).padStart(2, '0')
+      const endMinute = String(49 - minuteOffset).padStart(2, '0')
+      const shiftStart = `10:${startMinute}`
+      const shiftEnd = `17:${endMinute}`
+      const inAt = `10:${String(11 + minuteOffset).padStart(2, '0')}:00`
+      const outAt = `17:${String(48 - minuteOffset).padStart(2, '0')}:00`
+      try {
+        process.env.ATTENDANCE_AUTO_SHIFT_MATCHING_ENABLED = 'true'
+        await pool.query(
+          `DELETE FROM attendance_shifts
+           WHERE org_id = $1
+             AND (
+               name LIKE 'Auto Shift Match %'
+               OR name LIKE '000 Auto Shift Match %'
+               OR name LIKE 'Auto Shift Non Match %'
+             )`,
+          [orgId],
+        )
+        await saveAutoShiftSettings(adminToken, {
+          autoShiftMatching: {
+            enabled: true,
+            mode: 'preview',
+            maxToleranceMinutes: 20,
+            minConfidenceToApply: 'high',
+          },
+        })
+        await createGroupForAutoShift(adminToken, `autoshift-happy-${runSuffix}`, 'scheduled_shift', userId)
+        const matchingShiftId = await createShiftForAutoShift(adminToken, `000 Auto Shift Match ${runSuffix}`, shiftStart, shiftEnd)
+        await createShiftForAutoShift(adminToken, `Auto Shift Non Match ${runSuffix}`, '12:00', '20:00')
+        const inId = await insertPunchEvent(pool, userId, workDate, 'check_in', `${workDate}T${inAt}.000Z`)
+        const outId = await insertPunchEvent(pool, userId, workDate, 'check_out', `${workDate}T${outAt}.000Z`)
+
+        const res = await requestJson(`${baseUrl}/api/attendance/auto-shift-matching/preview`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({ from: workDate, to: workDate, userIds: [userId] }),
+        })
+        expect(res.status).toBe(200)
+        const data = (res.body as { data?: { items?: any[]; skipped?: any[] } } | undefined)?.data
+        expect(data?.items).toHaveLength(1)
+        expect(data?.items?.[0]).toMatchObject({
+          userId,
+          workDate,
+          candidateShiftId: matchingShiftId,
+          candidateShiftName: `000 Auto Shift Match ${runSuffix}`,
+          score: 2,
+          confidence: 'high',
+        })
+        expect(data?.items?.[0]?.evidence?.eventIds).toEqual([inId, outId])
+        expect(data?.skipped ?? []).toHaveLength(0)
+
+        const writes = await pool.query(
+          `SELECT
+             (SELECT COUNT(*)::int FROM attendance_shift_assignments WHERE org_id = $1 AND user_id = $2) AS shift_count,
+             (SELECT COUNT(*)::int FROM attendance_rotation_assignments WHERE org_id = $1 AND user_id = $2) AS rotation_count`,
+          [orgId, userId],
+        )
+        expect(writes.rows[0]).toMatchObject({ shift_count: 0, rotation_count: 0 })
+      } finally {
+        await saveAutoShiftSettings(adminToken, originalSettings).catch(() => undefined)
+        if (previousFlag === undefined) delete process.env.ATTENDANCE_AUTO_SHIFT_MATCHING_ENABLED
+        else process.env.ATTENDANCE_AUTO_SHIFT_MATCHING_ENABLED = previousFlag
+        await pool.end()
+      }
+    })
+
+    it('skips already-scheduled users, fixed/free groups, pending outdoor approvals, and out-of-tolerance punches', async () => {
+      if (!baseUrl) return
+      const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+      if (!dbUrl) return
+      const runSuffix = Date.now().toString(36)
+      const adminToken = await getAdminToken(`attendance-autoshift-skip-admin-${runSuffix}`)
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+      const previousFlag = process.env.ATTENDANCE_AUTO_SHIFT_MATCHING_ENABLED
+      const originalSettings = await loadSettingsForTest(adminToken)
+      const pool = new Pool({ connectionString: dbUrl })
+      const workDate = '2026-06-12'
+      const scheduledUserId = `attendance-autoshift-scheduled-${runSuffix}`
+      const fixedUserId = `attendance-autoshift-fixed-${runSuffix}`
+      const pendingOutdoorUserId = `attendance-autoshift-pending-outdoor-${runSuffix}`
+      const toleranceUserId = `attendance-autoshift-tolerance-${runSuffix}`
+      try {
+        process.env.ATTENDANCE_AUTO_SHIFT_MATCHING_ENABLED = 'true'
+        await saveAutoShiftSettings(adminToken, {
+          autoShiftMatching: {
+            enabled: true,
+            mode: 'preview',
+            maxToleranceMinutes: 30,
+            minConfidenceToApply: 'low',
+          },
+        })
+        const shiftId = await createShiftForAutoShift(adminToken, `Auto Shift Skip ${runSuffix}`, '09:00', '18:00')
+        await createGroupForAutoShift(adminToken, `autoshift-scheduled-${runSuffix}`, 'scheduled_shift', scheduledUserId)
+        await createGroupForAutoShift(adminToken, `autoshift-fixed-${runSuffix}`, 'fixed_shift', fixedUserId)
+        await createGroupForAutoShift(adminToken, `autoshift-pending-${runSuffix}`, 'scheduled_shift', pendingOutdoorUserId)
+        await createGroupForAutoShift(adminToken, `autoshift-tolerance-${runSuffix}`, 'scheduled_shift', toleranceUserId)
+
+        await pool.query(
+          `INSERT INTO attendance_shift_assignments
+           (id, org_id, user_id, shift_id, start_date, end_date, is_active)
+           VALUES ($1, $2, $3, $4, $5, $5, true)`,
+          [randomUuidV4(), orgId, scheduledUserId, shiftId, workDate],
+        )
+        await insertPunchEvent(pool, scheduledUserId, workDate, 'check_in', `${workDate}T09:02:00.000Z`)
+        await insertPunchEvent(pool, scheduledUserId, workDate, 'check_out', `${workDate}T18:01:00.000Z`)
+        await insertPunchEvent(pool, fixedUserId, workDate, 'check_in', `${workDate}T09:01:00.000Z`)
+        await pool.query(
+          `INSERT INTO attendance_requests
+           (id, user_id, org_id, work_date, request_type, requested_in_at, status, metadata)
+           VALUES ($1, $2, $3, $4, 'outdoor_punch', $5, 'pending', $6::jsonb)`,
+          [
+            randomUuidV4(),
+            pendingOutdoorUserId,
+            orgId,
+            workDate,
+            `${workDate}T09:00:00.000Z`,
+            JSON.stringify({ outdoorPunch: { eventType: 'check_in', occurredAt: `${workDate}T09:00:00.000Z`, workDate } }),
+          ],
+        )
+        await insertPunchEvent(pool, toleranceUserId, workDate, 'check_in', `${workDate}T03:00:00.000Z`)
+        await insertPunchEvent(pool, toleranceUserId, workDate, 'check_out', `${workDate}T04:00:00.000Z`)
+
+        const res = await requestJson(`${baseUrl}/api/attendance/auto-shift-matching/preview`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            from: workDate,
+            userIds: [scheduledUserId, fixedUserId, pendingOutdoorUserId, toleranceUserId],
+          }),
+        })
+        expect(res.status).toBe(200)
+        const data = (res.body as { data?: { items?: any[]; skipped?: Array<{ userId: string; reason: string }> } } | undefined)?.data
+        expect(data?.items ?? []).toHaveLength(0)
+        const reasonsByUser = new Map((data?.skipped ?? []).map((item) => [item.userId, item.reason]))
+        expect(reasonsByUser.get(scheduledUserId)).toBe('already_scheduled')
+        expect(reasonsByUser.get(fixedUserId)).toBe('not_scheduled_shift_group')
+        expect(reasonsByUser.get(pendingOutdoorUserId)).toBe('no_punch')
+        expect(reasonsByUser.get(toleranceUserId)).toBe('no_candidate_within_tolerance')
+      } finally {
+        await saveAutoShiftSettings(adminToken, originalSettings).catch(() => undefined)
+        if (previousFlag === undefined) delete process.env.ATTENDANCE_AUTO_SHIFT_MATCHING_ENABLED
+        else process.env.ATTENDANCE_AUTO_SHIFT_MATCHING_ENABLED = previousFlag
+        await pool.end()
+      }
+    })
   })
 
   it('supports request item lookup, update, and delete aliases for self-service follow-up', async () => {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -145,6 +145,14 @@ const DEFAULT_SETTINGS = {
     enabled: false,
     expiresInDays: null,
   },
+  // 自动对班 (auto shift matching) — preview-only A0 foundation. Requires BOTH the
+  // runtime env flag and this org setting before the read-only preview endpoint can run.
+  autoShiftMatching: {
+    enabled: false,
+    mode: 'preview',
+    maxToleranceMinutes: 120,
+    minConfidenceToApply: 'high',
+  },
 }
 
 const allowRbacDegradation = process.env.RBAC_OPTIONAL === '1'
@@ -10868,6 +10876,27 @@ function normalizeSettings(raw) {
     },
     comprehensiveHours: normalizeAttendanceComprehensiveHoursSettings(raw.comprehensiveHours),
     compTimeFromOvertime: normalizeCompTimeFromOvertimeSetting(raw.compTimeFromOvertime),
+    autoShiftMatching: normalizeAutoShiftMatchingSetting(raw.autoShiftMatching),
+  }
+}
+
+function normalizeAutoShiftMatchingSetting(raw) {
+  const config = raw && typeof raw === 'object' ? raw : {}
+  const modeRaw = typeof config.mode === 'string' ? config.mode.trim() : ''
+  const minConfidenceRaw = typeof config.minConfidenceToApply === 'string'
+    ? config.minConfidenceToApply.trim()
+    : ''
+  const tolerance = Number(config.maxToleranceMinutes)
+  return {
+    enabled: typeof config.enabled === 'boolean' ? config.enabled : DEFAULT_SETTINGS.autoShiftMatching.enabled,
+    // A0 is preview-only. apply / auto modes are future slices and must not silently become accepted.
+    mode: modeRaw === 'preview' ? 'preview' : DEFAULT_SETTINGS.autoShiftMatching.mode,
+    maxToleranceMinutes: Number.isFinite(tolerance) && tolerance > 0
+      ? Math.min(720, Math.floor(tolerance))
+      : DEFAULT_SETTINGS.autoShiftMatching.maxToleranceMinutes,
+    minConfidenceToApply: ['high', 'medium', 'low'].includes(minConfidenceRaw)
+      ? minConfidenceRaw
+      : DEFAULT_SETTINGS.autoShiftMatching.minConfidenceToApply,
   }
 }
 
@@ -11018,6 +11047,10 @@ function mergeSettings(base, update) {
     compTimeFromOvertime: {
       ...(base?.compTimeFromOvertime || {}),
       ...(update?.compTimeFromOvertime || {}),
+    },
+    autoShiftMatching: {
+      ...(base?.autoShiftMatching || {}),
+      ...(update?.autoShiftMatching || {}),
     },
   })
 }
@@ -12008,6 +12041,230 @@ async function isUserScheduledForDate(db, orgId, userId, date) {
   } catch (error) {
     if (isDatabaseSchemaError(error)) return true
     throw error
+  }
+}
+
+function isAutoShiftMatchingRuntimeEnabled() {
+  return parseBoolean(process.env.ATTENDANCE_AUTO_SHIFT_MATCHING_ENABLED, false)
+}
+
+function confidenceRank(value) {
+  if (value === 'high') return 3
+  if (value === 'medium') return 2
+  if (value === 'low') return 1
+  return 0
+}
+
+function enumerateAttendanceDateKeys(from, to) {
+  const start = normalizeDateOnly(from)
+  const end = normalizeDateOnly(to)
+  if (!start || !end || start > end) return []
+  const keys = []
+  const cursor = new Date(`${start}T00:00:00.000Z`)
+  const endTime = new Date(`${end}T00:00:00.000Z`).getTime()
+  while (cursor.getTime() <= endTime) {
+    keys.push(cursor.toISOString().slice(0, 10))
+    cursor.setUTCDate(cursor.getUTCDate() + 1)
+  }
+  return keys
+}
+
+async function loadAutoShiftTargetUserIds(db, orgId, input) {
+  const users = new Set()
+  for (const userId of normalizeStringArray(input.userIds)) {
+    users.add(userId)
+  }
+  const groupIds = normalizeStringArray(input.attendanceGroupIds)
+  if (groupIds.length > 0) {
+    const rows = await db.query(
+      `SELECT DISTINCT user_id
+       FROM attendance_group_members
+       WHERE org_id = $1
+         AND group_id = ANY($2::uuid[])
+       ORDER BY user_id ASC`,
+      [orgId, groupIds],
+    )
+    for (const row of rows) {
+      const userId = String(row.user_id ?? '').trim()
+      if (userId) users.add(userId)
+    }
+  }
+  return [...users].sort()
+}
+
+async function loadAutoShiftUserGroupTypes(db, orgId, userId) {
+  const rows = await db.query(
+    `SELECT g.attendance_type
+     FROM attendance_group_members m
+     JOIN attendance_groups g ON g.id = m.group_id AND g.org_id = m.org_id
+     WHERE m.org_id = $1 AND m.user_id = $2`,
+    [orgId, userId],
+  )
+  return rows.map((row) => normalizeAttendanceGroupType(row.attendance_type))
+}
+
+async function hasAutoShiftRotationAssignmentForDate(db, orgId, userId, workDate) {
+  const rows = await db.query(
+    `SELECT 1
+     FROM attendance_rotation_assignments
+     WHERE org_id = $1
+       AND user_id = $2
+       AND COALESCE(is_active, true) = true
+       AND start_date <= $3::date
+       AND COALESCE(end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
+     LIMIT 1`,
+    [orgId, userId, workDate],
+  )
+  return rows.length > 0
+}
+
+async function loadAutoShiftPunchEvents(db, orgId, userId, workDate) {
+  const rows = await db.query(
+    `SELECT id, event_type, occurred_at
+     FROM attendance_events
+     WHERE org_id = $1
+       AND user_id = $2
+       AND work_date = $3::date
+       AND event_type IN ('check_in', 'check_out')
+     ORDER BY occurred_at ASC, id ASC`,
+    [orgId, userId, workDate],
+  )
+  return rows
+    .map((row) => ({
+      id: row.id,
+      eventType: row.event_type,
+      occurredAt: row.occurred_at instanceof Date ? row.occurred_at : parseDateInput(row.occurred_at),
+    }))
+    .filter((row) => row.occurredAt instanceof Date && !Number.isNaN(row.occurredAt.getTime()))
+}
+
+async function loadAutoShiftCandidateShifts(db, orgId) {
+  const rows = await db.query(
+    `SELECT *
+     FROM attendance_shifts
+     WHERE org_id = $1
+     ORDER BY name ASC, created_at ASC, id ASC`,
+    [orgId],
+  )
+  return rows.map(mapShiftRow)
+}
+
+function scoreAutoShiftCandidate(shift, events, options) {
+  const maxToleranceMinutes = options?.maxToleranceMinutes ?? DEFAULT_SETTINGS.autoShiftMatching.maxToleranceMinutes
+  const startMinutes = parseTimeToMinutes(shift.workStartTime, null)
+  const endMinutes = parseTimeToMinutes(shift.workEndTime, null)
+  if (!Number.isFinite(startMinutes) || !Number.isFinite(endMinutes)) return null
+  if (shift.isOvernight || endMinutes <= startMinutes) return null
+
+  const checkIns = events.filter((event) => event.eventType === 'check_in')
+  const checkOuts = events.filter((event) => event.eventType === 'check_out')
+  const firstIn = checkIns[0] ?? null
+  const lastOut = checkOuts[checkOuts.length - 1] ?? null
+  const reasons = []
+  let score = 0
+  let compared = 0
+
+  if (firstIn) {
+    const delta = Math.abs(getZonedMinutes(firstIn.occurredAt, shift.timezone) - startMinutes)
+    score += delta
+    compared += 1
+    reasons.push(`check_in_delta:${delta}`)
+  } else {
+    score += 60
+    reasons.push('missing_check_in')
+  }
+
+  if (lastOut) {
+    const delta = Math.abs(getZonedMinutes(lastOut.occurredAt, shift.timezone) - endMinutes)
+    score += delta
+    compared += 1
+    reasons.push(`check_out_delta:${delta}`)
+  } else {
+    score += 60
+    reasons.push('missing_check_out')
+  }
+
+  if (compared === 0) return null
+  if (compared === 1) {
+    reasons.push('single_punch')
+  }
+  if (score > maxToleranceMinutes) return null
+
+  const confidence = compared === 2 && score <= 30
+    ? 'high'
+    : (score <= 90 ? 'medium' : 'low')
+  return {
+    candidateShiftId: shift.id,
+    candidateShiftName: shift.name,
+    score,
+    confidence,
+    reasons,
+    evidence: {
+      firstInAt: firstIn?.occurredAt?.toISOString() ?? null,
+      lastOutAt: lastOut?.occurredAt?.toISOString() ?? null,
+      eventIds: events.map((event) => event.id),
+    },
+  }
+}
+
+async function buildAutoShiftMatchingPreview(db, input) {
+  const orgId = input.orgId || DEFAULT_ORG_ID
+  const dates = enumerateAttendanceDateKeys(input.from, input.to)
+  const userIds = await loadAutoShiftTargetUserIds(db, orgId, input)
+  const maxToleranceMinutes = input.maxToleranceMinutes ?? DEFAULT_SETTINGS.autoShiftMatching.maxToleranceMinutes
+  const minConfidence = input.minConfidenceToApply ?? DEFAULT_SETTINGS.autoShiftMatching.minConfidenceToApply
+  const candidateShifts = await loadAutoShiftCandidateShifts(db, orgId)
+  const items = []
+  const skipped = []
+
+  for (const userId of userIds) {
+    const groupTypes = await loadAutoShiftUserGroupTypes(db, orgId, userId)
+    const allScheduledShift = groupTypes.length > 0 && groupTypes.every((type) => type === 'scheduled_shift')
+    for (const workDate of dates) {
+      if (!allScheduledShift) {
+        skipped.push({ userId, workDate, reason: 'not_scheduled_shift_group' })
+        continue
+      }
+
+      const hasExistingSchedule = await isUserScheduledForDate(db, orgId, userId, workDate)
+      if (hasExistingSchedule || await hasAutoShiftRotationAssignmentForDate(db, orgId, userId, workDate)) {
+        skipped.push({ userId, workDate, reason: 'already_scheduled' })
+        continue
+      }
+
+      const events = await loadAutoShiftPunchEvents(db, orgId, userId, workDate)
+      if (!events.length) {
+        skipped.push({ userId, workDate, reason: 'no_punch' })
+        continue
+      }
+
+      const scored = candidateShifts
+        .map((shift) => scoreAutoShiftCandidate(shift, events, { maxToleranceMinutes }))
+        .filter(Boolean)
+        .sort((a, b) => {
+          if (b.confidence !== a.confidence) return confidenceRank(b.confidence) - confidenceRank(a.confidence)
+          if (a.score !== b.score) return a.score - b.score
+          return String(a.candidateShiftName).localeCompare(String(b.candidateShiftName))
+        })
+      const winner = scored[0]
+      if (!winner) {
+        skipped.push({ userId, workDate, reason: 'no_candidate_within_tolerance' })
+        continue
+      }
+      if (confidenceRank(winner.confidence) < confidenceRank(minConfidence)) {
+        skipped.push({ userId, workDate, reason: 'candidate_below_confidence', candidateShiftId: winner.candidateShiftId, confidence: winner.confidence })
+        continue
+      }
+      items.push({ userId, workDate, ...winner })
+    }
+  }
+
+  return {
+    from: input.from,
+    to: input.to,
+    items,
+    skipped,
+    total: items.length,
   }
 }
 
@@ -16604,7 +16861,25 @@ module.exports = {
         enabled: z.boolean().optional(),
         expiresInDays: z.number().int().positive().nullable().optional(),
       }).optional(),
+      // 自动对班 A0 preview config. Runtime remains double-gated by
+      // ATTENDANCE_AUTO_SHIFT_MATCHING_ENABLED; apply/auto modes are future slices.
+      autoShiftMatching: z.object({
+        enabled: z.boolean().optional(),
+        mode: z.enum(['preview']).optional(),
+        maxToleranceMinutes: z.number().int().positive().max(720).optional(),
+        minConfidenceToApply: z.enum(['high', 'medium', 'low']).optional(),
+      }).optional(),
     })
+
+    const autoShiftMatchingPreviewSchema = z.object({
+      from: z.string().min(1),
+      to: z.string().optional(),
+      userIds: z.array(z.string().min(1)).optional(),
+      attendanceGroupIds: z.array(z.string().uuid()).optional(),
+      maxToleranceMinutes: z.number().int().positive().max(720).optional(),
+      minConfidenceToApply: z.enum(['high', 'medium', 'low']).optional(),
+      orgId: z.string().optional(),
+    }).strict()
 
     const punchSchema = z.object({
       eventType: z.enum(['check_in', 'check_out']),
@@ -30084,6 +30359,73 @@ module.exports = {
           }
           logger.error('Attendance shift delete failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete shift' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/auto-shift-matching/preview',
+      withPermission('attendance:admin', async (req, res) => {
+        const parsed = autoShiftMatchingPreviewSchema.safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+
+        const orgId = getOrgId(req)
+        const dateRange = resolveAttendanceDateRange(parsed.data.from, parsed.data.to ?? parsed.data.from, 0)
+        if (!dateRange.ok) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: dateRange.message } })
+          return
+        }
+        const dates = enumerateAttendanceDateKeys(dateRange.from, dateRange.to)
+        if (dates.length === 0 || dates.length > 31) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Preview range must be 1-31 days' } })
+          return
+        }
+        const hasUserTargets = normalizeStringArray(parsed.data.userIds).length > 0
+        const hasGroupTargets = normalizeStringArray(parsed.data.attendanceGroupIds).length > 0
+        if (!hasUserTargets && !hasGroupTargets) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'Preview requires userIds or attendanceGroupIds' } })
+          return
+        }
+
+        try {
+          const settings = await getSettings(db)
+          const autoShiftSettings = normalizeAutoShiftMatchingSetting(settings.autoShiftMatching)
+          if (
+            !isAutoShiftMatchingRuntimeEnabled()
+            || autoShiftSettings.enabled !== true
+            || autoShiftSettings.mode !== 'preview'
+          ) {
+            res.status(403).json({
+              ok: false,
+              error: {
+                code: 'AUTO_SHIFT_MATCHING_DISABLED',
+                message: 'Auto shift matching preview is disabled',
+              },
+            })
+            return
+          }
+
+          const preview = await buildAutoShiftMatchingPreview(db, {
+            orgId,
+            from: dateRange.from,
+            to: dateRange.to,
+            userIds: parsed.data.userIds,
+            attendanceGroupIds: parsed.data.attendanceGroupIds,
+            maxToleranceMinutes: parsed.data.maxToleranceMinutes ?? autoShiftSettings.maxToleranceMinutes,
+            minConfidenceToApply: parsed.data.minConfidenceToApply ?? autoShiftSettings.minConfidenceToApply,
+          })
+          res.json({ ok: true, data: preview })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance auto-shift preview tables missing' } })
+            return
+          }
+          logger.error('Attendance auto-shift matching preview failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to preview auto shift matching' } })
         }
       })
     )


### PR DESCRIPTION
## Summary
- Add A0 auto-shift matching org settings (`autoShiftMatching`) plus the runtime gate `ATTENDANCE_AUTO_SHIFT_MATCHING_ENABLED`.
- Add `POST /api/attendance/auto-shift-matching/preview` as a read-only preview endpoint: scheduled-shift-only eligibility, existing schedule/rotation coverage skip, real attendance_events evidence only, deterministic shift scoring, confidence/reasons/evidence output.
- Add real-DB integration coverage for disabled gate/no-write, deterministic suggestion/no assignment writes, already-scheduled skip, fixed/free skip, pending outdoor approval ignored, and out-of-tolerance skip.

## Boundaries
- A0 backend preview only; no UI, no apply, no automatic write, no DB table, no scheduler.
- Defaults are off; both runtime flag and org setting are required.
- A0-UI, A1 admin apply, and A2 auto-write remain separate gated slices per the design-lock.

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- `DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_test ATTENDANCE_TEST_DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_test pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts --reporter=dot -t "auto shift matching preview"` → 3/3 pass
- `DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_test ATTENDANCE_TEST_DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_test pnpm --filter @metasheet/core-backend test:integration:attendance` → 111/111 pass

## Local DB note
- Local verification used the existing `metasheet_test` DB with owner role `chouhua`. I applied pending migrations there and cleared stale `attendance.settings` pollution before the final full run; this was local-test-only, not staging/prod.
