### PR TITLE
fix(plm-embed): clarify re-mint flow after transient BOM embed failure

### DIFF
--- a/apps/web/src/services/integration/plmEmbed.ts
+++ b/apps/web/src/services/integration/plmEmbed.ts
@@ -71,8 +71,10 @@ export async function getPlmEmbedBomContext(token: string): Promise<PlmEmbedBomR
     const entitled = data.entitled === true
     // context is trusted only when entitled AND it validates as a part+lines object
     const context = entitled && isPlmBomMultitableContext(data.context) ? data.context : null
-    // a relayed reason on an entitled+null-context result means a TRANSIENT provider failure
-    // (retry), NOT "this part has no BOM" -- a reason-less null context is the empty/not-found case
+    // a relayed reason on an entitled+null-context result means a TRANSIENT provider failure after
+    // the single-use embed token may already be spent. The parent must re-mint/re-post (reopen or
+    // reload the embed), NOT re-call with the same token. A reason-less null context is the
+    // empty/not-found case.
     const reason = typeof data.reason === 'string' && data.reason.trim() ? data.reason.trim() : undefined
     return { available: true, entitled, context, ...(reason ? { reason } : {}) }
   } catch {

--- a/apps/web/src/views/PlmEmbedBomReviewView.vue
+++ b/apps/web/src/views/PlmEmbedBomReviewView.vue
@@ -20,7 +20,7 @@
         当前租户尚未开通 BOM review；真实授权由 PLM license 判定。
       </p>
       <p v-else-if="reviewState === 'error'" class="plm-embed-bom__hint plm-embed-bom__hint--strong" data-testid="plm-embed-bom-error">
-        加载 BOM review 失败（PLM 暂时不可用），请稍后重试。
+        加载 BOM review 失败（PLM 暂时不可用）。请从 PLM 重新打开此嵌入视图以重新授权。
       </p>
       <p v-else-if="reviewState === 'empty'" class="plm-embed-bom__hint">
         未找到该 Part 的 BOM 数据。
@@ -78,8 +78,9 @@ type EmbedReviewState =
 
 // not-configured (allowlist empty -> can never accept a token) -> awaiting-token -> loading ->
 // one of: unavailable (no support / degraded), upgrade (supported but not entitled), error
-// (entitled but the provider fetch failed transiently), empty (entitled, no context, no reason =
-// part not found), table (entitled + context).
+// (entitled but the provider fetch failed after the single-use token was spent; parent must re-mint
+// by reopening/reloading the embed), empty (entitled, no context, no reason = part not found), table
+// (entitled + context).
 const reviewState = computed<EmbedReviewState>(() => {
   if (!tokenReceived.value) {
     if (configReady.value && allowedOrigins.value.length === 0) return 'not-configured'

--- a/apps/web/tests/plm-embed-bom-review.spec.ts
+++ b/apps/web/tests/plm-embed-bom-review.spec.ts
@@ -204,6 +204,9 @@ describe('PlmEmbedBomReviewView — P3-D2 token-bound embed handshake', () => {
     postMessageFromParent(PLM_ORIGIN, tokenMessage())
     await flush()
     expect(state(root)).toBe('error')
+    const error = root.querySelector('[data-testid="plm-embed-bom-error"]')
+    expect(error?.textContent).toContain('重新打开此嵌入视图以重新授权')
+    expect(error?.textContent).not.toContain('重试')
   })
 
   it('shows the unavailable state when the relay reports the surface is unavailable', async () => {


### PR DESCRIPTION
## Summary
- Update the token-bound BOM review embed error copy to avoid suggesting an in-place retry after #2370 made embed tokens single-use.
- Clarify the service/view comments: a transient provider failure can spend the token, so the parent PLM page must re-mint/re-post by reopening or reloading the embed.
- Add a regression assertion so the embed error state mentions reauthorization and does not regress to "重试".

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/plm-embed-bom-review.spec.ts --watch=false
- pnpm --filter @metasheet/web type-check
- pnpm --filter @metasheet/web lint

## Scope
- Frontend UX copy only; no auth, token, relay, or route behavior changes.
