### PR TITLE
docs(workflow): lock completion plan for automation convergence

### DIFF
--- a/docs/development/multitable-automation-a6-3-branch-parallel-design-20260605.md
+++ b/docs/development/multitable-automation-a6-3-branch-parallel-design-20260605.md
@@ -1,8 +1,8 @@
 # Multitable Automation A6-3 Branch / Parallel DAG Design-Lock (2026-06-05)
 
-Status: **A6-3-0 design-lock / scope gate**
+Status: **A6-3 design-lock / scope gate; A6-3-1 + A6-3-2 landed**
 
-Runtime: **not started**
+Runtime: **A6-3-1 `condition_branch` exclusive runtime landed; A6-3-2 frontend/readability landed; A6-3-3 and parallel/join still gated**
 
 Grounded on: `origin/main@83801c668`
 Companions:
@@ -15,8 +15,15 @@ Companions:
 
 ## 0. Verdict
 
-A6-3 can be opened as the next automation-only capability rung, but **only as
-this docs-only design-lock first**. Runtime remains a separate explicit opt-in.
+> **2026-06-09 status refresh**: this design-lock originally froze the shape
+> before runtime. Since then, A6-3-1 landed via #2321, A6-3-2a editor landed
+> via #2339, and A6-3-2b runs readability landed via #2348. The remaining
+> design-lock boundaries still apply to A6-3-3 and parallel/join.
+
+A6-3 was opened as the next automation-only capability rung, but **only through
+this docs-only design-lock first**. A6-3-1 and A6-3-2 later landed by explicit
+opt-in; the remaining A6-3-3 and parallel/join work still requires a separate
+explicit opt-in.
 
 The first runtime slice must be **A6-3-1 `condition_branch` / exclusive branch
 v1**, not full parallel DAG. Parallel fan-out and join semantics are important,

--- a/docs/development/multitable-automation-a6-execution-plan-20260601.md
+++ b/docs/development/multitable-automation-a6-execution-plan-20260601.md
@@ -29,7 +29,8 @@ treatment **on purpose**:
 - **A6-3 … A6-5 ADD capability** (branch/parallel graph execution, modeling import,
   approval coupling). Their *shape* is undefined until a concrete use-case names it.
   A6-3's first runtime slice (A6-3-1 `condition_branch` / exclusive branch v1) **landed via #2321**;
-  parallel/join + A6-3-2 frontend + A6-3-3 stay deferred. A6-4/A6-5 remain plan-level only:
+  the A6-3-2 frontend/readability slice **landed via #2339 + #2348**; parallel/join +
+  A6-3-3 stay deferred. A6-4/A6-5 remain plan-level only:
   scope boundary, dependency order, gate posture, and a pointer to the test surface the
   A6-0 scout already enumerated.
 
@@ -154,7 +155,7 @@ only missing link.
   duplicate-resume idempotent/rejected, resume-after-completion rejected, invalid/expired
   token rejected without leak, later: survives process restart).
 
-## 3. A6-3 branch/parallel DAG — A6-3-1 condition_branch runtime ✅ LANDED (#2321); rest deferred
+## 3. A6-3 branch/parallel DAG — A6-3-1 runtime + A6-3-2 frontend/readability ✅ LANDED (#2321/#2339/#2348); rest deferred
 
 Design-lock: `multitable-automation-a6-3-branch-parallel-design-20260605.md`.
 
@@ -165,9 +166,15 @@ Design-lock: `multitable-automation-a6-3-branch-parallel-design-20260605.md`.
 > inside branches; **exclusive** first-match-or-`defaultBranch` selection; **C1 parent/selected-child/
 > downstream lineage** reusing the existing job plane (no 2nd status vocab). The real-DB lineage seam gates
 > in CI via the blocking `plugin-tests.yml` targeted step (`multitable-automation-jobs.test.ts`, alongside
-> automation-retry/suspend-resume). **Still deferred, each its own opt-in:** A6-3-2 `condition_branch`
-> frontend builder + admin-runs readability; A6-3-3 `wait_for_callback` / nested-`condition_branch` inside
-> branches; A6-3 parallel fan-out / join-all / join-any. Design-lock detail below retained for the record.
+> automation-retry/suspend-resume).
+>
+> **✅ A6-3-2 frontend/readability LANDED 2026-06-06 — #2339 (squash `960ea9315`) + #2348 (squash
+> `4b44f25c6`)**: the rule editor can author a minimal `condition_branch` config (flat branch
+> conditions, `update_record` / `send_notification` branch action subset, default branch, read-only
+> never-flatten guard for richer loaded shapes, `workflow_job_v1` auto-lock), and the admin runs detail
+> shows selected branch `label (key)` plus branch child jobs. **Still deferred, each its own opt-in:**
+> A6-3-3 `wait_for_callback` / nested-`condition_branch` inside branches; A6-3 parallel fan-out /
+> join-all / join-any. Design-lock detail below retained for the record.
 
 The design-lock pins the first runtime slice as **A6-3-1 `condition_branch` /
 exclusive branch v1**, not full parallel DAG. Parallel fan-out, join-all, and

--- a/docs/development/multitable-automation-run-governance-todo-20260527.md
+++ b/docs/development/multitable-automation-run-governance-todo-20260527.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-27
 Scope: multitable automation run governance + whole-execution retry only
-Status: A0-A5 closed (2026-05-29); A6-1 COMPLETE end-to-end (runtime #2130 + enable-writer #2191 + admin UI toggle #2193, 2026-06) — rules can opt into the per-action WorkflowJob plane from the editor, no longer dormant; A6-2 suspend/resume backend (admin-gated v1, webhook/external resume) LANDED #2237 c363a78db (2026-06-03) + A6-2b frontend (admin Resume UI + `wait_for_callback` editor) LANDED #2245 cee99c8e4 (2026-06-04) + operator UAT PASS #2257 (2026-06-04) — A6-2 now closed end-to-end; delay/timer resume deferred; A6-3-1 `condition_branch` exclusive-branch runtime LANDED #2321 `127b29dd9` (2026-06-05; design-lock `multitable-automation-a6-3-branch-parallel-design-20260605.md`) — A6-3-2 frontend builder / A6-3-3 (wait/nesting in branches) / parallel fan-out·join still gated; A6-4..A6-5 remain frozen / demand-gated
+Status: A0-A5 closed (2026-05-29); A6-1 COMPLETE end-to-end (runtime #2130 + enable-writer #2191 + admin UI toggle #2193, 2026-06) — rules can opt into the per-action WorkflowJob plane from the editor, no longer dormant; A6-2 suspend/resume backend (admin-gated v1, webhook/external resume) LANDED #2237 c363a78db (2026-06-03) + A6-2b frontend (admin Resume UI + `wait_for_callback` editor) LANDED #2245 cee99c8e4 (2026-06-04) + operator UAT PASS #2257 (2026-06-04) — A6-2 now closed end-to-end; delay/timer resume deferred; A6-3-1 `condition_branch` exclusive-branch runtime LANDED #2321 `127b29dd9` (2026-06-05; design-lock `multitable-automation-a6-3-branch-parallel-design-20260605.md`) + A6-3-2a editor LANDED #2339 `960ea9315` + A6-3-2b admin-runs readability LANDED #2348 `4b44f25c6`; A6-3-3 (wait/nesting in branches) / parallel fan-out·join still gated; A6-4..A6-5 remain frozen / demand-gated
 Companion: multitable-automation-run-governance-development-20260527.md
 Depends on (landed): C1 contract workflow-job-contract.ts (#1889, read-boundary wired only); RFC #1885
 
@@ -27,8 +27,8 @@ The governance half and named A5 retry runtime are complete on `origin/main`:
 
 This closeout did NOT mark the convergence engine complete at the time. Current status:
 A6-1 and A6-2 are complete end-to-end; A6-3-1 `condition_branch` exclusive-branch runtime
-landed (#2321), with A6-3-2 frontend / A6-3-3 / parallel-join still gated; A6-4/A6-5 remain
-separate future unlocks.
+landed (#2321), and A6-3-2 frontend/runs readability landed (#2339 + #2348). A6-3-3 /
+parallel-join remain gated; A6-4/A6-5 remain separate future unlocks.
 
 ## Doctrine — Two Gates (definition of "not lopsided")
 
@@ -69,7 +69,8 @@ The K3 Stage-1 blanket lock is retired (#1993; #1792 = M1 one-record Material Sa
 - A4 / A5: completed by explicit opt-in (#2039 + #2047); retry UI,
   idempotency keys, and re-fetch-current-record context remain future opt-ins.
 - A6: A6-0/A6-3 design-locks are docs-only; A6-1/A6-2 + A6-3-1 `condition_branch` runtime
-  landed by explicit opt-in; A6-3-2/A6-3-3 + parallel-join and A6-4/A6-5 remain frozen / demand-gated.
+  + A6-3-2 frontend/readability landed by explicit opt-in; A6-3-3 + parallel-join and
+  A6-4/A6-5 remain frozen / demand-gated.
 
 ## Current Baseline
 
@@ -279,7 +280,14 @@ complete.
       executor) rejecting `wait_for_callback` / nested `condition_branch` in branches; exclusive
       first-match-or-`defaultBranch`; C1 parent/selected-child/downstream lineage (no 2nd status vocab).
       Real-DB lineage seam gates via the blocking `plugin-tests.yml` targeted step.
-- [ ] A6-3-2 `condition_branch` frontend builder + admin-runs readability — not started.
+- [x] A6-3-2a `condition_branch` frontend builder — LANDED #2339 `960ea9315`
+      (2026-06-06): form-based branch builder, flat per-branch conditions, `update_record` /
+      `send_notification` branch action subset, read-only never-flatten guard for richer loaded
+      shapes, branch-key validation, and `workflow_job_v1` auto-lock.
+- [x] A6-3-2b `condition_branch` admin-runs readability — LANDED #2348 `4b44f25c6`
+      (2026-06-06): selected branch shows `label (key)` when present, branch child jobs are
+      grouped via nested step keys, and raw branch-selection output is suppressed in favour of the
+      readable line.
 - [ ] A6-3-3 `wait_for_callback` / nested `condition_branch` inside branches — gated (forbidden in A6-3-1).
 - [ ] A6-3 parallel fan-out / join-all / join-any — gated (separate follow rungs after the exclusive slice).
 - [ ] A6-4 BPMN compile/preview adapter — not started.

--- a/docs/development/workflow-automation-completion-plan-20260609.md
+++ b/docs/development/workflow-automation-completion-plan-20260609.md
@@ -1,0 +1,162 @@
+# Workflow & Automation Completion Plan
+
+Date: 2026-06-09
+
+Grounded on: `origin/main@db6b128eeb35`
+
+Scope: MetaSheet2 workflow, approval, and multitable automation as one product
+target. This is a completion definition and execution ledger, not a sprint
+schedule.
+
+## 0. Decision
+
+We can make "workflow and workflow automation" the primary development goal,
+but completion must mean a bounded v1 product loop:
+
+1. **Multitable automation** is the execution substrate for record-triggered
+   side effects, retry, job provenance, suspend/resume, and simple branches.
+2. **Approval** remains the source of truth for approval templates, runtime
+   graphs, assignments, permissions, and approval task state.
+3. **Convergence** connects the two through explicit actions/events:
+   `start_approval`, approval completion events, and result backwrite.
+4. **Workflow Designer/BPMN** is a modeling and preview surface for this
+   substrate. It must not become a fourth production runtime in v1.
+
+This prevents the line from drifting into "build a generic BPMN platform" while
+still letting users test real workflow automation.
+
+## 1. Current Main State
+
+### 1.1 Multitable automation
+
+Current main already contains the governance and first convergence slices:
+
+| Area | Current status |
+|---|---|
+| Run governance A0-A5 | Landed: execution snapshots, redaction, runs API, admin UI, whole-execution retry, response redaction hardening. |
+| A6-1 WorkflowJob plane | Landed: `multitable_automation_jobs`, rule-level `execution_mode`, editor toggle, C1 job views. |
+| A6-2 suspend/resume | Landed end-to-end: `wait_for_callback`, `multitable_automation_suspensions`, admin resume route, editor config, admin runs resume UI, UAT recorded. |
+| A6-3-1 condition branch runtime | Landed: `condition_branch`, exclusive first-match/default branch, C1 parent/child/downstream lineage. |
+| A6-3-2 frontend and runs readability | Landed in code: editor builder in `MetaAutomationRuleEditor.vue` and `conditionBranchAuthoring.ts`; runs readability in `AutomationExecutionsView.vue`. |
+| Still missing | Branch-local wait/nesting, parallel fan-out/join, BPMN compile/preview mapping, approval-as-job bridge, public webhook token emitter. |
+
+### 1.2 Approval
+
+Current main already contains substantial approval product runtime:
+
+| Area | Current status |
+|---|---|
+| Template CRUD / publish | Existing backend endpoints create, update, publish, clone, list, and detail templates. |
+| Runtime graph freeze | `publishTemplate` builds and stores `approval_published_definitions.runtime_graph`. |
+| Dynamic assignee resolver | `ApprovalAssigneeResolver` supports `static_user`, `static_role`, `requester`, and `form_field_user`. |
+| Template authoring UI | Landed: `/approval-templates/new` and `/approval-templates/:id/edit`, fail-closed on unsupported rich graphs, preserves unsupported field metadata. |
+| Real DB authoring UAT guard | Landed integration test for create -> publish -> start -> resolve on real DB. |
+| Still missing | Deployed-browser smoke final verdict, field-visibility authoring UI, richer template constructs, trigger bindings, result backwrite, automation `start_approval`. |
+
+### 1.3 Workflow Designer / BPMN
+
+Workflow Designer has a BPMN draft/edit/deploy baseline and hub/catalog work,
+but it is not yet the unified workflow automation authoring layer.
+
+| Area | Current status |
+|---|---|
+| BPMN draft API | Existing draft save/load/update/deploy support. |
+| Designer hub/catalog | Existing list/template/team-view/hub improvements. |
+| Runtime positioning | Must stay modeling/preview first. v1 must not route production execution through a separate BPMN runtime. |
+| Still missing | Compile/preview adapter into automation/approval definitions, deterministic gap report, no-live-runtime guard. |
+
+## 2. Definition of Complete v1
+
+The v1 target is complete when an admin can build, run, inspect, and safely
+operate a practical business workflow using existing product surfaces:
+
+1. **Authoring**
+   - Approval templates can be created, edited, published, and used to start
+     approvals.
+   - Automation rules can express linear actions, wait/resume, and exclusive
+     condition branches from the UI.
+   - Unsupported richer shapes open read-only or fail closed; they are never
+     silently flattened.
+
+2. **Execution**
+   - Automation rules may opt into the C1 WorkflowJob plane.
+   - Per-action jobs persist with C1 status vocabulary and redacted outputs.
+   - Whole-execution retry uses current rule credentials plus stored trigger
+     event and requires explicit side-effect confirmation.
+   - Suspend/resume is admin-gated v1; public webhook emitter is a separate
+     later decision.
+
+3. **Cross-surface business closure**
+   - Automation can start an approval through an explicit `start_approval`
+     action.
+   - Approval completion emits an event contract consumed by automation.
+   - Approval result backwrite into multitable records is explicit, auditable,
+     and configured by mapping, not hidden side effects.
+
+4. **Designer**
+   - BPMN/workflow designer can compile-preview a constrained subset into the
+     automation/approval substrate.
+   - Unsupported BPMN nodes produce a gap report.
+   - Preview is side-effect-free and never starts live BPMN execution.
+
+5. **Operations**
+   - Admin runs view shows run/job detail, selected branch, suspended state,
+     retry provenance, and redacted snapshots.
+   - Real-DB integration tests cover every new seam.
+   - Operator UAT issues/runbooks exist for deployed-browser smoke where CI
+     cannot prove routing/auth/UI integration.
+
+## 3. Remaining Development Ledger
+
+| ID | Work | Status | Completion acceptance |
+|---|---|---|---|
+| W0 | Re-ground status docs against current main | This PR | Existing TODOs no longer say A6-3-2 is not started after #2339/#2348. |
+| W1 | Approval authoring deployed-browser smoke | Remaining UAT | Operator creates template -> publishes -> starts `/approvals/new/:templateId` -> confirms form-field approver resolution; unsupported rich template is read-only/save-disabled. |
+| W2 | Automation A6-3-3 branch-local wait/nesting | Not started; demand-gated | `wait_for_callback` can live inside selected branch with stable nested step cursor, rule-drift guard, resume tests, and no silent flattening in editor. |
+| W3 | Automation parallel fan-out + join-all | Not started; demand-gated | Parallel branches persist independent job lineage; join-all waits for all branches; failures and skipped branches are audited. |
+| W4 | Automation join-any / cancellation semantics | Not started; demand-gated after W3 | First completed branch continues; ignored/cancelled siblings are explicit in C1 jobs and audit. |
+| W5 | Approval completion event contract | Not started | `approval.approved/rejected/returned/cancelled` event payload is versioned, redacted, and tested without adding automation action yet. |
+| W6 | Automation `start_approval` action | Not started; after W5 design | Starts one approval instance from a published template, creates a waiting job, and resumes from W5 completion event. |
+| W7 | Approval result backwrite | Not started; after W5/W6 | Explicit mapping writes approved/rejected/returned result to multitable record fields with audit and permission checks. |
+| W8 | BPMN compile/preview adapter | Not started; after W3 minimum | Constrained BPMN subset compiles into automation/approval preview plus gap report; no live execution route. |
+| W9 | Public webhook resume token emitter | Not started; use-case gated | External consumer can receive a token/callback URL safely; auth, expiry, replay, and redaction are locked before public route. |
+| W10 | Field-visibility / richer approval authoring | Optional follow-up | Existing `visibilityRule` data can be authored, not only preserved; unsupported graph constructs remain fail-closed. |
+
+## 4. Recommended Next Slice
+
+The next implementation should be **W1 + W2 in that order**:
+
+1. **W1 approval authoring operator smoke** is the smallest remaining proof
+   gap. It does not add code unless smoke discovers a real issue.
+2. **W2 A6-3-3 branch-local wait/nesting** is the next meaningful automation
+   capability. It extends already-landed A6-2 and A6-3 without pulling in
+   approval coupling or BPMN.
+
+Do not jump straight to `start_approval` or BPMN before W2 and W5. Approval-as-
+job needs stable suspend/resume plus an approval completion event contract; BPMN
+gateway preview needs branch/parallel semantics to map to.
+
+## 5. Non-goals for v1
+
+- No generic JS/SQL/code node.
+- No arbitrary public webhook endpoint without emitter/auth/replay design.
+- No second status vocabulary outside C1.
+- No second run/audit store outside automation jobs + approval records.
+- No live BPMN production runtime for v1.
+- No silent flattening of unsupported approval or automation shapes.
+- No cross-surface coupling hidden behind "template save" or "record update";
+  bridge behavior must be explicit and reviewable.
+
+## 6. Tracker Maintenance Rule
+
+Every runtime slice that lands must update exactly one status source and, when
+needed, one verification/runbook:
+
+- Automation status source: `multitable-automation-run-governance-todo-20260527.md`.
+- Automation execution plan: `multitable-automation-a6-execution-plan-20260601.md`.
+- Approval authoring status source:
+  `approval-template-authoring-frontend-mvp-todo-20260604.md`.
+- Cross-surface completion source: this document.
+
+If code lands but the tracker still says "not started", the tracker is wrong
+and should be corrected before starting a new rung.


### PR DESCRIPTION
## Summary

- confirms workflow + workflow automation as a bounded v1 product target
- adds `workflow-automation-completion-plan-20260609.md` as the cross-surface completion ledger
- re-grounds stale A6 tracker text: A6-3-2a editor (#2339) and A6-3-2b runs readability (#2348) are landed, while A6-3-3 / parallel-join / BPMN preview / approval-as-job remain demand-gated

## Notes

This is intentionally docs-only. It does not start new runtime work. It defines the finish line first: automation job/run substrate, approval template/runtime source of truth, explicit approval automation bridge, and BPMN as compile/preview rather than a fourth live runtime.

## Verification

- `git diff --check`
- scoped grep for stale `A6-3-2 not started` tracker language
