### PR TITLE
docs(workflow): record approval and A6 trial evidence

### DIFF
--- a/docs/development/approval-template-authoring-frontend-mvp-todo-20260604.md
+++ b/docs/development/approval-template-authoring-frontend-mvp-todo-20260604.md
@@ -1,6 +1,6 @@
 # Approval Template Authoring Frontend MVP TODO - 2026-06-04
 
-Status: **Frontend MVP implemented in this branch; real-stack UAT pending**.
+Status: **Frontend MVP landed; deployed authoring -> publish -> start smoke passed (#2318/#2371/#2375)**.
 
 Canonical design: `docs/development/approval-template-authoring-frontend-mvp-design-20260604.md`.
 
@@ -23,7 +23,7 @@ This TODO covers only the frontend authoring MVP. It does not authorize approval
 | Linear approval graph builder | [x] implemented |
 | Publish UI | [x] implemented |
 | Frontend tests/typecheck | [x] passed |
-| Real-stack UAT | [ ] not started |
+| Real-stack UAT | [x] authoring -> publish -> start smoke passed (#2318/#2371/#2375); full approve-to-terminal smoke remains outside the authoring MVP gate |
 
 ## Implementation Tasks
 
@@ -118,18 +118,20 @@ This TODO covers only the frontend authoring MVP. It does not authorize approval
 - [x] Unsupported graph edit-safety spec: existing parallel/condition/add-sign/unknown graph cannot be saved through the linear builder.
 - [x] `form_field_user` guard spec.
 - [x] Attachment not-authorable spec.
-- [x] Existing `ApprovalNewView` compatibility path remains covered by approval permission/lifecycle specs; real-stack UAT remains pending.
+- [x] Existing `ApprovalNewView` compatibility path remains covered by approval permission/lifecycle specs; deployed-browser authoring -> start smoke passed (#2318/#2371).
 - [x] Typecheck.
 
 ### A9. UAT
 
-- [ ] Manager creates a simple two-field template.
-- [ ] Manager configures one approval step with static user or requester source.
-- [ ] Manager publishes template.
-- [ ] Writer starts approval from `/approval-templates`.
+- [x] Manager creates a simple template with a user field (#2318/#2371/#2375).
+- [x] Manager configures one approval step with `form_field_user` source (#2318/#2371/#2375).
+- [x] Manager publishes template (#2318/#2371/#2375).
+- [x] Writer starts approval from `/approvals/new/:templateId` (#2318/#2371/#2375).
+- [x] Submitted user field resolves to the expected active assignee (#2318/#2371/#2375).
+- [x] Unsupported complex template opens read-only / save-disabled with no silent flattening (#2318).
 - [ ] Actor approves.
 - [ ] Requester sees terminal state under `我发起的`.
-- [ ] Non-manager cannot enter authoring view.
+- [ ] Non-manager cannot enter authoring view in deployed UI.
 
 ## Explicitly Deferred
 

--- a/docs/development/multitable-automation-run-governance-todo-20260527.md
+++ b/docs/development/multitable-automation-run-governance-todo-20260527.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-27
 Scope: multitable automation run governance + whole-execution retry only
-Status: A0-A5 closed (2026-05-29); A6-1 COMPLETE end-to-end (runtime #2130 + enable-writer #2191 + admin UI toggle #2193, 2026-06) — rules can opt into the per-action WorkflowJob plane from the editor, no longer dormant; A6-2 suspend/resume backend (admin-gated v1, webhook/external resume) LANDED #2237 c363a78db (2026-06-03) + A6-2b frontend (admin Resume UI + `wait_for_callback` editor) LANDED #2245 cee99c8e4 (2026-06-04) + operator UAT PASS #2257 (2026-06-04) — A6-2 now closed end-to-end; delay/timer resume deferred; A6-3-1 `condition_branch` exclusive-branch runtime LANDED #2321 `127b29dd9` (2026-06-05; design-lock `multitable-automation-a6-3-branch-parallel-design-20260605.md`) + A6-3-2a editor LANDED #2339 `960ea9315` + A6-3-2b admin-runs readability LANDED #2348 `4b44f25c6`; A6-3-3 (wait/nesting in branches) / parallel fan-out·join still gated; A6-4..A6-5 remain frozen / demand-gated
+Status: A0-A5 closed (2026-05-29); A6-1 COMPLETE end-to-end (runtime #2130 + enable-writer #2191 + admin UI toggle #2193, 2026-06) — rules can opt into the per-action WorkflowJob plane from the editor, no longer dormant; A6-2 suspend/resume backend (admin-gated v1, webhook/external resume) LANDED #2237 c363a78db (2026-06-03) + A6-2b frontend (admin Resume UI + `wait_for_callback` editor) LANDED #2245 cee99c8e4 (2026-06-04) + operator UAT PASS #2257 (2026-06-04) — A6-2 now closed end-to-end; delay/timer resume deferred; A6-3-1 `condition_branch` exclusive-branch runtime LANDED #2321 `127b29dd9` (2026-06-05; design-lock `multitable-automation-a6-3-branch-parallel-design-20260605.md`) + A6-3-2a editor LANDED #2339 `960ea9315` + A6-3-2b admin-runs readability LANDED #2348 `4b44f25c6`; A6-3 v1 operator/API/UI trial PASS (#2367/#2371), with no current A6-3-3 unlock signal; A6-3-3 (wait/nesting in branches) / parallel fan-out·join still gated; A6-4..A6-5 remain frozen / demand-gated
 Companion: multitable-automation-run-governance-development-20260527.md
 Depends on (landed): C1 contract workflow-job-contract.ts (#1889, read-boundary wired only); RFC #1885
 
@@ -28,7 +28,9 @@ The governance half and named A5 retry runtime are complete on `origin/main`:
 This closeout did NOT mark the convergence engine complete at the time. Current status:
 A6-1 and A6-2 are complete end-to-end; A6-3-1 `condition_branch` exclusive-branch runtime
 landed (#2321), and A6-3-2 frontend/runs readability landed (#2339 + #2348). A6-3-3 /
-parallel-join remain gated; A6-4/A6-5 remain separate future unlocks.
+parallel-join remain gated; A6-4/A6-5 remain separate future unlocks. Later trial
+evidence (#2367/#2371) confirmed the A6-3 v1 surface is enough for the tested
+condition-branch flow and did not produce a branch-local wait/nesting demand.
 
 ## Doctrine — Two Gates (definition of "not lopsided")
 
@@ -288,7 +290,8 @@ complete.
       (2026-06-06): selected branch shows `label (key)` when present, branch child jobs are
       grouped via nested step keys, and raw branch-selection output is suppressed in favour of the
       readable line.
-- [ ] A6-3-3 `wait_for_callback` / nested `condition_branch` inside branches — gated (forbidden in A6-3-1).
+- [x] A6-3 v1 operator/API/UI trial — PASS #2367/#2371; no A6-3-3 demand surfaced.
+- [ ] A6-3-3 `wait_for_callback` / nested `condition_branch` inside branches — gated (forbidden in A6-3-1); open only for a named branch-local wait/nesting scenario.
 - [ ] A6-3 parallel fan-out / join-all / join-any — gated (separate follow rungs after the exclusive slice).
 - [ ] A6-4 BPMN compile/preview adapter — not started.
 - [ ] A6-5 approval-as-job bridge — not started.

--- a/docs/development/workflow-automation-completion-plan-20260609.md
+++ b/docs/development/workflow-automation-completion-plan-20260609.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-09
 
-Grounded on: `origin/main@db6b128eeb35`
+Grounded on: `origin/main@59c883c0e1e3`
 
 Scope: MetaSheet2 workflow, approval, and multitable automation as one product
 target. This is a completion definition and execution ledger, not a sprint
@@ -51,7 +51,8 @@ Current main already contains substantial approval product runtime:
 | Dynamic assignee resolver | `ApprovalAssigneeResolver` supports `static_user`, `static_role`, `requester`, and `form_field_user`. |
 | Template authoring UI | Landed: `/approval-templates/new` and `/approval-templates/:id/edit`, fail-closed on unsupported rich graphs, preserves unsupported field metadata. |
 | Real DB authoring UAT guard | Landed integration test for create -> publish -> start -> resolve on real DB. |
-| Still missing | Deployed-browser smoke final verdict, field-visibility authoring UI, richer template constructs, trigger bindings, result backwrite, automation `start_approval`. |
+| Deployed/browser UAT | Passed: #2318 and #2371 accepted UI-created template -> publish -> `/approvals/new/:templateId` -> `form_field_user` resolution, plus unsupported-template read-only/save-disabled safety. |
+| Still missing | Field-visibility authoring UI, richer template constructs, trigger bindings, result backwrite, automation `start_approval`. |
 
 ### 1.3 Workflow Designer / BPMN
 
@@ -111,8 +112,8 @@ operate a practical business workflow using existing product surfaces:
 | ID | Work | Status | Completion acceptance |
 |---|---|---|---|
 | W0 | Re-ground status docs against current main | This PR | Existing TODOs no longer say A6-3-2 is not started after #2339/#2348. |
-| W1 | Approval authoring deployed-browser smoke | Remaining UAT | Operator creates template -> publishes -> starts `/approvals/new/:templateId` -> confirms form-field approver resolution; unsupported rich template is read-only/save-disabled. |
-| W2 | Automation A6-3-3 branch-local wait/nesting | Not started; demand-gated | `wait_for_callback` can live inside selected branch with stable nested step cursor, rule-drift guard, resume tests, and no silent flattening in editor. |
+| W1 | Approval authoring deployed-browser smoke | Done | #2318 PASS accepted: UI-created template published, `/approvals/new/:templateId` started, submitted user field resolved to expected assignee, unsupported rich template was read-only/save-disabled. #2375/#2371 reconfirmed current deployment. |
+| W2 | Automation A6-3-3 branch-local wait/nesting | Not started; demand-gated; no current unlock | `wait_for_callback` can live inside selected branch with stable nested step cursor, rule-drift guard, resume tests, and no silent flattening in editor. #2367 trial found A6-3 v1 sufficient for the tested flow, so do not start W2 without a new named scenario. |
 | W3 | Automation parallel fan-out + join-all | Not started; demand-gated | Parallel branches persist independent job lineage; join-all waits for all branches; failures and skipped branches are audited. |
 | W4 | Automation join-any / cancellation semantics | Not started; demand-gated after W3 | First completed branch continues; ignored/cancelled siblings are explicit in C1 jobs and audit. |
 | W5 | Approval completion event contract | Not started | `approval.approved/rejected/returned/cancelled` event payload is versioned, redacted, and tested without adding automation action yet. |
@@ -124,16 +125,21 @@ operate a practical business workflow using existing product surfaces:
 
 ## 4. Recommended Next Slice
 
-The next implementation should be **W1 + W2 in that order**:
+The next implementation should be **W5: approval completion event contract
+scope-gate**.
 
-1. **W1 approval authoring operator smoke** is the smallest remaining proof
-   gap. It does not add code unless smoke discovers a real issue.
-2. **W2 A6-3-3 branch-local wait/nesting** is the next meaningful automation
-   capability. It extends already-landed A6-2 and A6-3 without pulling in
-   approval coupling or BPMN.
+Why:
 
-Do not jump straight to `start_approval` or BPMN before W2 and W5. Approval-as-
-job needs stable suspend/resume plus an approval completion event contract; BPMN
+1. **W1 is closed by issue evidence** (#2318 + #2371 + #2375).
+2. **W2 is intentionally held** because #2367 found no concrete
+   branch-internal wait/nesting demand for the current trial flow.
+3. The v1 completion gap is now cross-surface closure: automation cannot yet
+   start an approval, and approval completion cannot yet resume/update
+   automation. W5 is the smallest safe first step because it defines the event
+   contract without adding `start_approval` behavior yet.
+
+Do not jump straight to `start_approval` or BPMN before W5. Approval-as-job
+needs stable suspend/resume plus an approval completion event contract; BPMN
 gateway preview needs branch/parallel semantics to map to.
 
 ## 5. Non-goals for v1


### PR DESCRIPTION
## Summary

- mark approval template authoring deployed/browser smoke as passed based on #2318, #2371, and #2375 evidence
- record A6-3 v1 operator/API/UI trial evidence from #2367/#2371 and keep A6-3-3 demand-gated
- update the workflow completion plan recommendation from W1/W2 to W5 approval completion event contract scope-gate

## Verification

- git diff --check
- status-only docs update; no runtime code changed
