### PR TITLE
feat(approval): emit completion events for terminal approvals

### DIFF
--- a/packages/core-backend/src/services/ApprovalCompletionEvent.ts
+++ b/packages/core-backend/src/services/ApprovalCompletionEvent.ts
@@ -1,0 +1,131 @@
+import { Logger } from '../core/logger'
+import { eventBus } from '../integration/events/event-bus'
+
+const logger = new Logger('ApprovalCompletionEvent')
+
+export type ApprovalCompletionOutcome = 'approved' | 'rejected' | 'revoked' | 'cancelled'
+export type ApprovalCompletionEventType =
+  | 'approval.approved'
+  | 'approval.rejected'
+  | 'approval.revoked'
+  | 'approval.cancelled'
+
+export type ApprovalCompletionTransitionAction =
+  | 'approve'
+  | 'reject'
+  | 'revoke'
+  | 'jump'
+  | 'auto_approve'
+
+export interface ApprovalCompletionInstanceSnapshot {
+  id: string
+  request_no?: string | null
+  template_id?: string | null
+  template_version_id?: string | null
+  published_definition_id?: string | null
+  business_key?: string | null
+  workflow_key?: string | null
+  requester_snapshot?: unknown
+}
+
+export interface ApprovalCompletionActorSnapshot {
+  id: string
+  name?: string | null
+}
+
+export interface ApprovalCompletionTransitionSnapshot {
+  action: ApprovalCompletionTransitionAction
+  fromStatus: string | null
+  toStatus: ApprovalCompletionOutcome
+  fromVersion: number | null
+  toVersion: number
+  nodeKey: string | null
+}
+
+export interface ApprovalCompletionEventV1 {
+  version: 1
+  eventId: string
+  eventType: ApprovalCompletionEventType
+  occurredAt: string
+  source: 'approval-product'
+  approval: {
+    instanceId: string
+    requestNo: string | null
+    templateId: string | null
+    templateVersionId: string | null
+    publishedDefinitionId: string | null
+    businessKey: string | null
+    workflowKey: string | null
+  }
+  transition: ApprovalCompletionTransitionSnapshot
+  actor: {
+    id: string
+    name: string | null
+  } | null
+  requester: {
+    id: string | null
+  }
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function nullableString(value: unknown): string | null {
+  return typeof value === 'string' && value.trim().length > 0 ? value : null
+}
+
+export function approvalCompletionEventTypeForOutcome(
+  outcome: ApprovalCompletionOutcome,
+): ApprovalCompletionEventType {
+  return `approval.${outcome}` as ApprovalCompletionEventType
+}
+
+export function buildApprovalCompletionEvent(input: {
+  instance: ApprovalCompletionInstanceSnapshot
+  transition: ApprovalCompletionTransitionSnapshot
+  actor?: ApprovalCompletionActorSnapshot | null
+  occurredAt?: Date
+}): ApprovalCompletionEventV1 {
+  const eventType = approvalCompletionEventTypeForOutcome(input.transition.toStatus)
+  const requesterSnapshot = isRecord(input.instance.requester_snapshot)
+    ? input.instance.requester_snapshot
+    : {}
+
+  return {
+    version: 1,
+    eventId: `approval:${input.instance.id}:${input.transition.toVersion}:${eventType}`,
+    eventType,
+    occurredAt: (input.occurredAt ?? new Date()).toISOString(),
+    source: 'approval-product',
+    approval: {
+      instanceId: input.instance.id,
+      requestNo: nullableString(input.instance.request_no),
+      templateId: nullableString(input.instance.template_id),
+      templateVersionId: nullableString(input.instance.template_version_id),
+      publishedDefinitionId: nullableString(input.instance.published_definition_id),
+      businessKey: nullableString(input.instance.business_key),
+      workflowKey: nullableString(input.instance.workflow_key),
+    },
+    transition: input.transition,
+    actor: input.actor
+      ? {
+          id: input.actor.id,
+          name: nullableString(input.actor.name),
+        }
+      : null,
+    requester: {
+      id: nullableString(requesterSnapshot['id']),
+    },
+  }
+}
+
+export function emitApprovalCompletionEvent(event: ApprovalCompletionEventV1): void {
+  try {
+    eventBus.emit(event.eventType, event)
+  } catch (error) {
+    logger.warn(
+      `approval completion event ${event.eventId} failed: ${error instanceof Error ? error.message : String(error)}`,
+    )
+  }
+}

--- a/packages/core-backend/src/services/ApprovalProductService.ts
+++ b/packages/core-backend/src/services/ApprovalProductService.ts
@@ -46,6 +46,12 @@ import type {
 import { APPROVAL_ERROR_CODES } from './approval-bridge-types'
 import { ServiceError } from './ApprovalBridgeService'
 import { getApprovalMetricsService, type ApprovalMetricsService, type ApprovalTerminalState } from './ApprovalMetricsService'
+import {
+  buildApprovalCompletionEvent,
+  emitApprovalCompletionEvent,
+  type ApprovalCompletionEventV1,
+  type ApprovalCompletionTransitionSnapshot,
+} from './ApprovalCompletionEvent'
 import { Logger } from '../core/logger'
 import { eventBus } from '../integration/events/event-bus'
 
@@ -2513,6 +2519,7 @@ export class ApprovalProductService {
       instanceMetadata.parallelBranchStates = buildPersistableParallelState(initial.parallelState)
     }
 
+    let completionEvent: ApprovalCompletionEventV1 | null = null
     let client: ApprovalDbClient | null = null
     try {
       client = await pool.connect()
@@ -2569,6 +2576,30 @@ export class ApprovalProductService {
         },
       })
 
+      if (initial.status === 'approved') {
+        completionEvent = buildApprovalCompletionEvent({
+          instance: {
+            id: instanceId,
+            request_no: requestNo,
+            template_id: bundle.template.id,
+            template_version_id: bundle.version.id,
+            published_definition_id: bundle.publishedDefinition.id,
+            business_key: bundle.template.key,
+            workflow_key: 'approval-product-template',
+            requester_snapshot: requesterSnapshot,
+          },
+          transition: {
+            action: 'auto_approve',
+            fromStatus: null,
+            toStatus: 'approved',
+            fromVersion: null,
+            toVersion: 0,
+            nodeKey: null,
+          },
+          actor: null,
+        })
+      }
+
       await client.query('COMMIT')
     } catch (error) {
       await rollbackQuietly(client)
@@ -2596,6 +2627,9 @@ export class ApprovalProductService {
         })
       }
     })
+    if (completionEvent) {
+      emitApprovalCompletionEvent(completionEvent)
+    }
 
     const approval = await this.getApproval(instanceId)
     if (!approval) {
@@ -2612,6 +2646,7 @@ export class ApprovalProductService {
     if (!pool) throw new Error('Database not available')
 
     let jumpEvent: AdminJumpEventPayload | null = null
+    let completionEvent: ApprovalCompletionEventV1 | null = null
     let client: ApprovalDbClient | null = null
     try {
       client = await pool.connect()
@@ -2773,6 +2808,20 @@ export class ApprovalProductService {
       }, actor)
       await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents)
       await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
+      if (resolution.status === 'approved') {
+        completionEvent = this.buildCompletionEvent(
+          instance,
+          {
+            action: 'jump',
+            fromStatus: instance.status,
+            toStatus: 'approved',
+            fromVersion: instance.version,
+            toVersion: nextVersion,
+            nodeKey: instance.current_node_key,
+          },
+          { id: actor.userId, name: actor.userName || actor.userId },
+        )
+      }
       await client.query('COMMIT')
 
       jumpEvent = {
@@ -2799,6 +2848,9 @@ export class ApprovalProductService {
       client?.release()
     }
 
+    if (completionEvent) {
+      emitApprovalCompletionEvent(completionEvent)
+    }
     if (jumpEvent) {
       eventBus.emit('approval.admin_jumped', jumpEvent)
     }
@@ -2993,7 +3045,20 @@ export class ApprovalProductService {
           toVersion: nextVersion,
           metadata: { nodeKey: currentNodeKey },
         }, actor)
+        const completionEvent = this.buildCompletionEvent(
+          instance,
+          {
+            action: 'revoke',
+            fromStatus: instance.status,
+            toStatus: 'revoked',
+            fromVersion: instance.version,
+            toVersion: nextVersion,
+            nodeKey: currentNodeKey,
+          },
+          { id: actor.userId, name: actorName },
+        )
         await client.query('COMMIT')
+        emitApprovalCompletionEvent(completionEvent)
         this.emitTerminalMetric(id, 'revoked')
         return (await this.getApproval(id))!
       }
@@ -3119,8 +3184,21 @@ export class ApprovalProductService {
           toVersion: nextVersion,
           metadata: { nodeKey: currentNodeKey },
         }, actor)
+        const completionEvent = this.buildCompletionEvent(
+          instance,
+          {
+            action: 'reject',
+            fromStatus: instance.status,
+            toStatus: 'rejected',
+            fromVersion: instance.version,
+            toVersion: nextVersion,
+            nodeKey: currentNodeKey,
+          },
+          { id: actor.userId, name: actorName },
+        )
         await client.query('COMMIT')
         this.emitNodeDecisionMetric(id, currentNodeKey, actor.userId)
+        emitApprovalCompletionEvent(completionEvent)
         this.emitTerminalMetric(id, 'rejected')
         return (await this.getApproval(id))!
       }
@@ -3383,13 +3461,28 @@ export class ApprovalProductService {
       }
       await this.insertAutoApprovalEvents(client, id, nextVersion, resolution.status, resolution.autoApprovalEvents)
       await this.insertCcEvents(client, id, nextVersion, resolution.status, resolution.ccEvents)
+      const completionEvent = resolution.status === 'approved'
+        ? this.buildCompletionEvent(
+            instance,
+            {
+              action: 'approve',
+              fromStatus: instance.status,
+              toStatus: 'approved',
+              fromVersion: instance.version,
+              toVersion: nextVersion,
+              nodeKey: currentNodeKey,
+            },
+            { id: actor.userId, name: actorName },
+          )
+        : null
 
       await client.query('COMMIT')
 
       // Wave 2 WP5 slice 1 — emit metrics after commit so rollback failures
       // never leave dangling breakdown entries. All hooks are guarded.
       this.emitNodeDecisionMetric(id, currentNodeKey, actor.userId)
-      if (resolution.status === 'approved') {
+      if (completionEvent) {
+        emitApprovalCompletionEvent(completionEvent)
         this.emitTerminalMetric(id, 'approved')
       } else if (resolution.currentNodeKey && resolution.currentNodeKey !== currentNodeKey) {
         this.emitNodeActivationMetric(id, resolution.currentNodeKey)
@@ -3441,6 +3534,18 @@ export class ApprovalProductService {
         terminalAt: new Date(),
       }),
     )
+  }
+
+  private buildCompletionEvent(
+    instance: ApprovalInstanceRow,
+    transition: ApprovalCompletionTransitionSnapshot,
+    actor: { id: string; name?: string | null } | null,
+  ): ApprovalCompletionEventV1 {
+    return buildApprovalCompletionEvent({
+      instance,
+      transition,
+      actor,
+    })
   }
 
   async getApproval(id: string): Promise<UnifiedApprovalDTO | null> {

--- a/packages/core-backend/tests/unit/approval-completion-event.test.ts
+++ b/packages/core-backend/tests/unit/approval-completion-event.test.ts
@@ -1,0 +1,162 @@
+import { describe, expect, it, vi } from 'vitest'
+
+import {
+  approvalCompletionEventTypeForOutcome,
+  buildApprovalCompletionEvent,
+  emitApprovalCompletionEvent,
+} from '../../src/services/ApprovalCompletionEvent'
+import { eventBus } from '../../src/integration/events/event-bus'
+
+describe('ApprovalCompletionEvent', () => {
+  it('maps terminal outcomes to stable completion event types', () => {
+    expect(approvalCompletionEventTypeForOutcome('approved')).toBe('approval.approved')
+    expect(approvalCompletionEventTypeForOutcome('rejected')).toBe('approval.rejected')
+    expect(approvalCompletionEventTypeForOutcome('revoked')).toBe('approval.revoked')
+    expect(approvalCompletionEventTypeForOutcome('cancelled')).toBe('approval.cancelled')
+  })
+
+  it('builds a minimal v1 payload with stable identifiers and requester id only', () => {
+    const event = buildApprovalCompletionEvent({
+      occurredAt: new Date('2026-06-09T12:00:00.000Z'),
+      instance: {
+        id: 'apr-1',
+        request_no: 'AP-100001',
+        template_id: 'tpl-1',
+        template_version_id: 'ver-1',
+        published_definition_id: 'pub-1',
+        business_key: 'travel-request',
+        workflow_key: 'approval-product-template',
+        requester_snapshot: {
+          id: 'requester-1',
+          name: 'Requester One',
+          email: 'requester@example.test',
+          department: 'Finance',
+        },
+      },
+      transition: {
+        action: 'approve',
+        fromStatus: 'pending',
+        toStatus: 'approved',
+        fromVersion: 2,
+        toVersion: 3,
+        nodeKey: 'approval_1',
+      },
+      actor: {
+        id: 'manager-1',
+        name: 'Manager One',
+      },
+    })
+
+    expect(event).toEqual({
+      version: 1,
+      eventId: 'approval:apr-1:3:approval.approved',
+      eventType: 'approval.approved',
+      occurredAt: '2026-06-09T12:00:00.000Z',
+      source: 'approval-product',
+      approval: {
+        instanceId: 'apr-1',
+        requestNo: 'AP-100001',
+        templateId: 'tpl-1',
+        templateVersionId: 'ver-1',
+        publishedDefinitionId: 'pub-1',
+        businessKey: 'travel-request',
+        workflowKey: 'approval-product-template',
+      },
+      transition: {
+        action: 'approve',
+        fromStatus: 'pending',
+        toStatus: 'approved',
+        fromVersion: 2,
+        toVersion: 3,
+        nodeKey: 'approval_1',
+      },
+      actor: {
+        id: 'manager-1',
+        name: 'Manager One',
+      },
+      requester: {
+        id: 'requester-1',
+      },
+    })
+
+    const serialized = JSON.stringify(event)
+    expect(serialized).not.toContain('requester@example.test')
+    expect(serialized).not.toContain('Finance')
+  })
+
+  it('omits form, comment, and request transport data from rejected events', () => {
+    const event = buildApprovalCompletionEvent({
+      instance: {
+        id: 'apr-sensitive',
+        request_no: 'AP-100002',
+        template_id: 'tpl-sensitive',
+        template_version_id: 'ver-sensitive',
+        published_definition_id: 'pub-sensitive',
+        business_key: 'sensitive-business',
+        workflow_key: 'approval-product-template',
+        requester_snapshot: {
+          id: 'requester-2',
+          email: 'private@example.test',
+        },
+        // Extra fields can exist on row-shaped objects at runtime; the event
+        // builder intentionally reads only its minimal allowlist.
+        form_snapshot: {
+          salary: 900000,
+          token: 'secret-token',
+        },
+        comment: 'contains private rejection notes',
+        ip: '203.0.113.55',
+        user_agent: 'SensitiveBrowser/1.0',
+      } as never,
+      transition: {
+        action: 'reject',
+        fromStatus: 'pending',
+        toStatus: 'rejected',
+        fromVersion: 4,
+        toVersion: 5,
+        nodeKey: 'approval_2',
+      },
+      actor: {
+        id: 'manager-2',
+        name: null,
+      },
+      occurredAt: new Date('2026-06-09T12:01:00.000Z'),
+    })
+
+    expect(event.eventType).toBe('approval.rejected')
+    expect(event.eventId).toBe('approval:apr-sensitive:5:approval.rejected')
+    expect(event.actor).toEqual({ id: 'manager-2', name: null })
+    expect(event.requester).toEqual({ id: 'requester-2' })
+    const serialized = JSON.stringify(event)
+    expect(serialized).not.toContain('private@example.test')
+    expect(serialized).not.toContain('secret-token')
+    expect(serialized).not.toContain('private rejection notes')
+    expect(serialized).not.toContain('203.0.113.55')
+    expect(serialized).not.toContain('SensitiveBrowser')
+  })
+
+  it('guards listener failures so approval flows can continue after commit', () => {
+    const emitSpy = vi.spyOn(eventBus, 'emit').mockImplementation(() => {
+      throw new Error('listener failed')
+    })
+
+    expect(() => emitApprovalCompletionEvent(buildApprovalCompletionEvent({
+      instance: { id: 'apr-guarded' },
+      transition: {
+        action: 'revoke',
+        fromStatus: 'pending',
+        toStatus: 'revoked',
+        fromVersion: 8,
+        toVersion: 9,
+        nodeKey: 'approval_1',
+      },
+    }))).not.toThrow()
+
+    expect(emitSpy).toHaveBeenCalledWith(
+      'approval.revoked',
+      expect.objectContaining({
+        eventId: 'approval:apr-guarded:9:approval.revoked',
+      }),
+    )
+  })
+})

--- a/packages/core-backend/tests/unit/approval-product-service.test.ts
+++ b/packages/core-backend/tests/unit/approval-product-service.test.ts
@@ -12,9 +12,24 @@ const pgState = vi.hoisted(() => ({
   },
 }))
 
+const completionEventState = vi.hoisted(() => ({
+  emitApprovalCompletionEvent: vi.fn(),
+}))
+
 vi.mock('../../src/db/pg', () => ({
   pool: pgState.pool,
 }))
+
+vi.mock('../../src/services/ApprovalCompletionEvent', async () => {
+  const actual = await vi.importActual<typeof import('../../src/services/ApprovalCompletionEvent')>(
+    '../../src/services/ApprovalCompletionEvent',
+  )
+
+  return {
+    ...actual,
+    emitApprovalCompletionEvent: completionEventState.emitApprovalCompletionEvent,
+  }
+})
 
 function normalize(sql: string): string {
   return sql.replace(/\s+/g, ' ').trim()
@@ -197,6 +212,7 @@ describe('ApprovalProductService', () => {
     pgState.client.query.mockReset()
     pgState.client.release.mockReset()
     pgState.pool.connect.mockResolvedValue(pgState.client)
+    completionEventState.emitApprovalCompletionEvent.mockReset()
   })
 
   it('blocks revoke when the published runtime policy disables it', async () => {
@@ -345,6 +361,163 @@ describe('ApprovalProductService', () => {
       })
 
     expect(pgState.client.release).toHaveBeenCalledTimes(1)
+  })
+
+  it('emits a completion event when the requester revokes an approval', async () => {
+    const runtimeGraph = buildRuntimeGraph()
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return { rows: [buildInstanceRow()], rowCount: 1 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date('2026-04-11T00:00:00.000Z'),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT COUNT(*)::text AS count')) {
+        return { rows: [{ count: '0' }], rowCount: 1 }
+      }
+      if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith("UPDATE approval_instances SET status = 'revoked'")) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      status: 'revoked',
+      currentNodeKey: null,
+      assignments: [],
+    }))
+
+    const result = await service.dispatchAction(
+      'apr-1',
+      { action: 'revoke', comment: 'cancel request' },
+      { userId: 'user-1' },
+    )
+
+    expect(result.status).toBe('revoked')
+    expect(completionEventState.emitApprovalCompletionEvent).toHaveBeenCalledTimes(1)
+    expect(completionEventState.emitApprovalCompletionEvent).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'approval.revoked',
+      transition: expect.objectContaining({
+        action: 'revoke',
+        fromStatus: 'pending',
+        toStatus: 'revoked',
+        fromVersion: 2,
+        toVersion: 3,
+        nodeKey: 'approval_1',
+      }),
+      actor: { id: 'user-1', name: 'user-1' },
+      requester: { id: 'user-1' },
+    }))
+  })
+
+  it('emits a completion event when an approver rejects an approval', async () => {
+    const runtimeGraph = buildRuntimeGraph()
+
+    pgState.client.query.mockImplementation(async (sql: string) => {
+      const statement = normalize(sql)
+      if (statement === 'BEGIN' || statement === 'COMMIT' || statement === 'ROLLBACK') {
+        return { rows: [], rowCount: 0 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_instances WHERE id = $1')) {
+        return { rows: [buildInstanceRow()], rowCount: 1 }
+      }
+      if (statement.startsWith('SELECT * FROM approval_published_definitions WHERE id = $1')) {
+        return {
+          rows: [{
+            id: 'pub-1',
+            template_id: 'tpl-1',
+            template_version_id: 'ver-1',
+            runtime_graph: runtimeGraph,
+            is_active: true,
+            published_at: new Date('2026-04-11T00:00:00.000Z'),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('SELECT * FROM approval_assignments WHERE instance_id = $1')) {
+        return {
+          rows: [{
+            id: 'asg-manager-1',
+            instance_id: 'apr-1',
+            assignment_type: 'user',
+            assignee_id: 'manager-1',
+            source_step: 1,
+            node_key: 'approval_1',
+            is_active: true,
+            metadata: {},
+            created_at: new Date('2026-04-11T00:00:00.000Z'),
+            updated_at: new Date('2026-04-11T00:00:00.000Z'),
+          }],
+          rowCount: 1,
+        }
+      }
+      if (statement.startsWith('UPDATE approval_assignments SET is_active = FALSE')) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith("UPDATE approval_instances SET status = 'rejected'")) {
+        return { rows: [], rowCount: 1 }
+      }
+      if (statement.startsWith('INSERT INTO approval_records')) {
+        return { rows: [], rowCount: 1 }
+      }
+      throw new Error(`Unhandled query: ${statement}`)
+    })
+
+    const { ApprovalProductService } = await import('../../src/services/ApprovalProductService')
+    const service = new ApprovalProductService(buildNoopMetrics() as never)
+    vi.spyOn(service, 'getApproval').mockResolvedValue(buildApprovalDto({
+      status: 'rejected',
+      currentNodeKey: null,
+      assignments: [],
+    }))
+
+    const result = await service.dispatchAction(
+      'apr-1',
+      { action: 'reject', comment: 'insufficient evidence' },
+      { userId: 'manager-1', userName: 'Manager One' },
+    )
+
+    expect(result.status).toBe('rejected')
+    expect(completionEventState.emitApprovalCompletionEvent).toHaveBeenCalledTimes(1)
+    expect(completionEventState.emitApprovalCompletionEvent).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'approval.rejected',
+      transition: expect.objectContaining({
+        action: 'reject',
+        fromStatus: 'pending',
+        toStatus: 'rejected',
+        fromVersion: 2,
+        toVersion: 3,
+        nodeKey: 'approval_1',
+      }),
+      actor: { id: 'manager-1', name: 'Manager One' },
+      requester: { id: 'user-1' },
+    }))
   })
 
   it('rejects return targets that are not previously visited approval nodes', async () => {
@@ -554,6 +727,7 @@ describe('ApprovalProductService', () => {
       targetNodeKey: 'approval_1',
       nextNodeKey: 'approval_1',
     })
+    expect(completionEventState.emitApprovalCompletionEvent).not.toHaveBeenCalled()
     expect(pgState.client.release).toHaveBeenCalledTimes(1)
   })
 
@@ -690,6 +864,7 @@ describe('ApprovalProductService', () => {
       aggregateComplete: false,
       remainingAssignments: 1,
     })
+    expect(completionEventState.emitApprovalCompletionEvent).not.toHaveBeenCalled()
     expect(pgState.client.release).toHaveBeenCalledTimes(1)
   })
 
@@ -1268,6 +1443,28 @@ describe('ApprovalProductService', () => {
         terminalState: 'approved',
       }))
     })
+
+    expect(completionEventState.emitApprovalCompletionEvent).toHaveBeenCalledTimes(1)
+    expect(completionEventState.emitApprovalCompletionEvent).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'approval.approved',
+      approval: expect.objectContaining({
+        templateId: 'tpl-1',
+        templateVersionId: 'ver-1',
+        publishedDefinitionId: 'pub-1',
+        businessKey: 'auto',
+        workflowKey: 'approval-product-template',
+      }),
+      transition: expect.objectContaining({
+        action: 'auto_approve',
+        fromStatus: null,
+        toStatus: 'approved',
+        fromVersion: null,
+        toVersion: 0,
+        nodeKey: null,
+      }),
+      actor: null,
+      requester: { id: 'user-1' },
+    }))
   })
 
   it('creates new approvals from the currently active published definition', async () => {
@@ -2349,6 +2546,27 @@ describe('ApprovalProductService', () => {
     const updateCall = pgState.client.query.mock.calls.find(([sql]) =>
       normalize(sql as string).startsWith('UPDATE approval_instances SET status = $2'))
     expect(updateCall?.[1]).toEqual(['apr-1', 'approved', 3, null, 3, 3])
+    expect(completionEventState.emitApprovalCompletionEvent).toHaveBeenCalledTimes(1)
+    expect(completionEventState.emitApprovalCompletionEvent).toHaveBeenCalledWith(expect.objectContaining({
+      eventType: 'approval.approved',
+      approval: expect.objectContaining({
+        instanceId: 'apr-1',
+        requestNo: 'AP-100001',
+        templateId: 'tpl-1',
+        templateVersionId: 'ver-1',
+        publishedDefinitionId: 'pub-1',
+      }),
+      transition: expect.objectContaining({
+        action: 'approve',
+        fromStatus: 'pending',
+        toStatus: 'approved',
+        fromVersion: 2,
+        toVersion: 3,
+        nodeKey: 'approval_a',
+      }),
+      actor: { id: 'manager-1', name: 'manager-1' },
+      requester: { id: 'user-1' },
+    }))
 
     const autoRecordCalls = pgState.client.query.mock.calls
       .filter(([sql, params]) =>


### PR DESCRIPTION
## Summary
- add a typed approval completion event v1 builder for approved/rejected/revoked/cancelled outcomes
- emit guarded post-commit completion events from terminal approval paths: auto-approved create, approve, reject, revoke, and terminal admin jump cascades
- keep W6 explicitly out of scope: no automation consumer, no trigger binding, no start_approval action, no persistence table

## Event boundary
- event types: approval.approved / approval.rejected / approval.revoked / approval.cancelled
- payload allowlist: approval ids/keys, transition metadata, actor id/name, requester id only
- intentionally excludes form snapshot, comments, email, IP, user-agent, and transport data
- listener failures are log-and-swallow after commit, so approval flows continue

## Verification
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/core-backend exec vitest run tests/unit/approval-completion-event.test.ts tests/unit/approval-product-service.test.ts --watch=false
- pnpm exec eslint src/services/ApprovalCompletionEvent.ts src/services/ApprovalProductService.ts tests/unit/approval-completion-event.test.ts tests/unit/approval-product-service.test.ts (from packages/core-backend; source files clean, test files ignored by existing pattern)
- git diff --check

## Notes
- The guarded listener-failure unit test intentionally logs one warning while asserting the approval flow does not throw.
