### PR TITLE
fix(data-factory): fail closed on missing child BOM

### DIFF
--- a/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
+++ b/docs/development/data-factory-plm-project-bom-stock-preparation-execution-plan-todo-20260604.md
@@ -927,7 +927,7 @@ Acceptance locks:
 - Any future executable policy requires a fresh dry-run, fresh token, reviewed
   policy evidence, and explicit owner acknowledgement.
 
-### 🟡 Duplicate-expanded-key D4-1 - source-correction held-only runtime (ACTIVE)
+### ✅ Duplicate-expanded-key D4-1 - source-correction held-only runtime (DONE - PR #2391, `366985cdc`)
 
 Gated on: Duplicate D4 design + explicit opt-in.
 
@@ -958,7 +958,7 @@ Acceptance locks:
   payload JSON, raw SQL, credentials, tokens, or stack traces with business
   values.
 
-### 🟡 Source snapshot diff gate C0 - PLM-BOM lifecycle design (ACTIVE - #2388)
+### ✅ Source snapshot diff gate C0 - PLM-BOM lifecycle design (DONE - PR #2402, `fc6d462f3`)
 
 Gated on: #2388 explicit direction + no runtime opt-in.
 
@@ -999,6 +999,30 @@ Acceptance locks:
   implementation slices.
 - Public evidence remains values-free.
 - Full cross-source generalization waits for a second real source.
+
+### 🟡 Source snapshot diff gate C0a - minimal missing-child BOM guard (ACTIVE)
+
+Gated on: #2402 C0 accepted semantics + #2342 runtime stack re-review.
+
+Scope:
+
+- Add the minimal fail-closed guard required before large-BOM background
+  expansion can become authoritative: an active BOM head with no BOM details is
+  source-incomplete and emits `missing_child_bom`.
+- Preserve normal explicit-leaf behavior where no active BOM head exists.
+- Keep the guard in existing app-side flat-read expansion; do not add raw SQL,
+  stored procedures, PLM writes, MetaSheet writes, routes, UI, migrations, K3,
+  or production rollout.
+
+Acceptance locks:
+
+- `missing_child_bom` makes the expansion invalid / not applyable.
+- `missing_child_bom` is not relabeled as a scale-bounded large-BOM condition.
+- Public evidence exposes only the held reason token and counts; it must not
+  include project number, component id/code/name, BOM id, raw PLM rows, target
+  sheet id, field id, raw SQL, credentials, tokens, or value-bearing stack
+  traces.
+- #2393-#2401 large-BOM runtime must rebase onto this guard before merge.
 
 ## Deferred tracks
 

--- a/docs/development/data-factory-plm-stock-preparation-missing-child-bom-guard-verification-20260609.md
+++ b/docs/development/data-factory-plm-stock-preparation-missing-child-bom-guard-verification-20260609.md
@@ -1,0 +1,59 @@
+# Data Factory PLM stock-preparation missing-child BOM guard verification
+
+Date: 2026-06-09
+
+## Scope
+
+This slice implements the minimal fail-closed guard required after #2402 before
+the #2342 large-BOM runtime stack can produce authoritative expansion artifacts.
+
+It changes the existing PLM BOM expansion helper only:
+
+- active BOM head + zero BOM detail rows => `missing_child_bom`;
+- the expansion becomes invalid / not applyable;
+- the error is treated as source-incomplete, not as scale-bounded large-BOM;
+- normal explicit-leaf behavior is preserved when there is no active BOM head.
+
+No route, UI, migration, package, MetaSheet write, PLM write, external database
+write, K3 path, raw SQL, stored procedure, production rollout, or checkpoint
+writer behavior is added.
+
+## Why
+
+#2402 locked the source snapshot/diff semantics:
+
+```text
+childless component + explicit leaf signal -> complete leaf
+childless component + explicit assembly/has-BOM signal -> missing_child_bom held
+childless component + no usable signal -> held, not complete leaf
+```
+
+In the current read plan, an active BOM head is the available source-side
+has-BOM signal. Before this slice, an active head with no detail rows silently
+looked like a complete leaf. That would let a background large-BOM expansion
+produce authoritative-looking artifacts for an incomplete assembly.
+
+## Verification Commands
+
+```bash
+node plugins/plugin-integration-core/__tests__/stock-preparation-bom-expansion.test.cjs
+node plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
+git diff --check
+git diff --check origin/main...HEAD
+```
+
+## Test Coverage
+
+The expansion test now covers:
+
+- active BOM head with no details returns `valid:false` / `status:'failed'`;
+- `rowErrors` contains `missing_child_bom`;
+- public evidence exposes `errorTypes:['missing_child_bom']`;
+- `largeBom:false`, so source incompleteness is not mislabeled as a scale cap;
+- public evidence does not contain the sample project, component, or BOM id.
+
+## Boundary Result
+
+The guard is a prerequisite for re-reviewing #2393-#2401. It does not by itself
+complete #2388 runtime, large-BOM background execution, checkpointed apply, or
+production rollout.

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-bom-expansion.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-bom-expansion.test.cjs
@@ -186,6 +186,27 @@ async function testFailClosedGuards() {
   }
 
   {
+    const { adapter } = createAdapter(baseData({
+      DN_PDM_BomDetailsInfo: [],
+    }))
+    const result = await expandPlmProjectBom({ sourceAdapter: adapter, projectNo: 'P-001' })
+    const evidence = summarizeBomExpansionForEvidence(result)
+    const text = JSON.stringify(evidence)
+
+    assert.equal(result.valid, false)
+    assert.equal(result.status, 'failed')
+    assert.ok(
+      result.rowErrors.some((error) => error.type === 'missing_child_bom' && error.field === 'bom_pid'),
+      'active BOM head with no details is held as missing_child_bom, not guessed as a complete leaf',
+    )
+    assert.deepEqual(evidence.errorTypes, ['missing_child_bom'])
+    assert.equal(evidence.largeBom, false, 'source-incomplete child BOM is not relabeled as a scale-bounded large BOM')
+    assert.equal(text.includes('P-001'), false, 'missing child BOM evidence hides project value')
+    assert.equal(text.includes('PART-A'), false, 'missing child BOM evidence hides component source id')
+    assert.equal(text.includes('BOM-A'), false, 'missing child BOM evidence hides BOM id')
+  }
+
+  {
     const { adapter } = createAdapter(baseData())
     const result = await expandPlmProjectBom({ sourceAdapter: adapter, projectNo: 'P-001', maxRows: 1 })
     assert.equal(result.valid, false)

--- a/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
@@ -720,6 +720,63 @@ async function testLargeBomBoundedApplyRejectsMatchingTokenBeforeWrites() {
   assert.deepEqual([...storage.map.keys()], [], 'token is consumed once even when the recomputed dry-run is not applyable')
 }
 
+async function testMissingChildBomDryRunBlocksApplyTokenAndWrites() {
+  const records = createRecordsApi()
+  const storage = createMemoryStorage()
+  const action = baseAction()
+  const parameters = { projectNo: 'P-001' }
+  const plannedAt = '2026-06-04T09:00:00.000Z'
+  const missingChildData = childBomPlmData({ DN_PDM_BomDetailsInfo: [] })
+
+  const dryRun = await dryRunStockPreparationAction({
+    action,
+    parameters,
+    sourceAdapter: createSourceAdapter(missingChildData).adapter,
+    recordsApi: records.recordsApi,
+    tokenStore: storage,
+    plannedAt,
+  })
+
+  assert.equal(dryRun.status, 'failed')
+  assert.equal(dryRun.largeBom, false)
+  assert.equal(dryRun.canApply, false)
+  assert.equal(dryRun.dryRunToken, null, 'incomplete assembly must not issue an apply token')
+  assert.equal(dryRun.counts.manual_confirm > 0, true, 'row is still visible as a held planning issue')
+  assert.equal(dryRun.evidence.expansion.errorTypes.includes('missing_child_bom'), true)
+  assert.deepEqual([...storage.map.keys()], [], 'incomplete assembly dry-run stores no token')
+  assert.equal(JSON.stringify(dryRun.evidence).includes('P-001'), false, 'incomplete assembly evidence hides project value')
+  assert.equal(JSON.stringify(dryRun.evidence).includes('BOM-A'), false, 'incomplete assembly evidence hides BOM ids')
+
+  const forgedMatchingToken = await tableActionInternals.createDryRunToken(storage, {
+    actionId: action.actionId,
+    parametersHash: tableActionInternals.hashJson(parameters),
+    revision: dryRun.revision,
+    conflictPolicyReview: null,
+  })
+
+  await assert.rejects(
+    () => applyStockPreparationAction({
+      action,
+      parameters,
+      dryRunToken: forgedMatchingToken,
+      sourceAdapter: createSourceAdapter(missingChildData).adapter,
+      recordsApi: records.recordsApi,
+      tokenStore: storage,
+      permission: 'write',
+      plannedAt,
+      acceptManualConfirmHold: true,
+    }),
+    (error) => {
+      assert.equal(error.code, 'TABLE_ACTION_DRY_RUN_NOT_APPLYABLE')
+      return true
+    },
+    'incomplete assembly remains non-applyable even when manual-confirm hold is accepted',
+  )
+
+  const writeCalls = records.calls.filter((call) => call[0] === 'createRecord' || call[0] === 'patchRecord')
+  assert.equal(writeCalls.length, 0, 'incomplete assembly apply rejection must happen before any target write')
+}
+
 async function testReadPageLimitBoundedDryRunAndDepthHardFailureStayDistinct() {
   const records = createRecordsApi()
 
@@ -941,6 +998,7 @@ async function main() {
   await testSavedSourceCorrectionPolicyKeepsDuplicateHeldAndWritesNothing()
   await testLargeBomBoundedDryRunBlocksApplyToken()
   await testLargeBomBoundedApplyRejectsMatchingTokenBeforeWrites()
+  await testMissingChildBomDryRunBlocksApplyTokenAndWrites()
   await testReadPageLimitBoundedDryRunAndDepthHardFailureStayDistinct()
   await testApplyNormalizesNumericPlmDisplayFieldsBeforeCreate()
   await testApplySurfacesTypedValuesFreeRowFailureDiagnostics()

--- a/plugins/plugin-integration-core/lib/stock-preparation-bom-expansion.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-bom-expansion.cjs
@@ -710,6 +710,14 @@ async function expandPlmProjectBom(input = {}) {
         addReadError(err, plan.bomDetail.object)
         return
       }
+      if (details.length === 0) {
+        addRowError({
+          type: 'missing_child_bom',
+          field: plan.bomDetail.bomParentField,
+          depth: nextDepth,
+        })
+        continue
+      }
       for (const detail of details) {
         if (errors.length > 0) return
         const childSourceId = toKey(readField(detail, plan.bomDetail.componentIdField))

--- a/plugins/plugin-integration-core/lib/stock-preparation-table-actions.cjs
+++ b/plugins/plugin-integration-core/lib/stock-preparation-table-actions.cjs
@@ -39,6 +39,7 @@ const DRY_RUN_TOKEN_PREFIX = 'integration:table-action:dry-run-token:'
 const DEFAULT_DRY_RUN_TOKEN_TTL_MS = 30 * 60 * 1000
 const DEFAULT_EXISTING_ROWS_PAGE_LIMIT = 1000
 const DEFAULT_EXISTING_ROWS_MAX_PAGES = 100
+const HARD_APPLY_BLOCKING_ROW_ERROR_TYPES = new Set(['missing_child_bom'])
 
 class StockPreparationTableActionError extends Error {
   constructor(status, code, message, details = {}) {
@@ -530,6 +531,7 @@ async function computeDryRun({ action, parameters, sourceAdapter, recordsApi, pl
     maxRows: action.maxRows,
   })
   const hasGlobalErrors = Array.isArray(expansion.errors) && expansion.errors.length > 0
+  const hasHardRowErrors = hasHardApplyBlockingRowErrors(expansion)
   if (expansion.status === 'not_found') {
     const revision = buildRevision({ action, parameters, expansion, existingRows: [] })
     return { expansion, existingRows: [], plan: emptyPlan(), revision, canApply: false, hasGlobalErrors }
@@ -557,7 +559,7 @@ async function computeDryRun({ action, parameters, sourceAdapter, recordsApi, pl
     existingRows,
     plan,
     revision,
-    canApply: !hasGlobalErrors,
+    canApply: !hasGlobalErrors && !hasHardRowErrors,
     hasGlobalErrors,
     conflictPolicyReview,
   }
@@ -587,6 +589,11 @@ function dryRunStatus(dryRun) {
   if (isLargeBomBoundedExpansion(dryRun.expansion)) return 'large_bom_bounded'
   if (dryRun.canApply) return dryRun.plan.valid ? 'ready' : 'manual_confirm_required'
   return 'failed'
+}
+
+function hasHardApplyBlockingRowErrors(expansion) {
+  const rowErrors = Array.isArray(expansion && expansion.rowErrors) ? expansion.rowErrors : []
+  return rowErrors.some((entry) => isPlainObject(entry) && HARD_APPLY_BLOCKING_ROW_ERROR_TYPES.has(entry.type))
 }
 
 async function dryRunStockPreparationAction(input = {}) {


### PR DESCRIPTION
## Summary

Adds the minimal `missing_child_bom` fail-closed guard required after #2402 before the #2342 large-BOM runtime stack can be re-reviewed:

- active BOM head + zero BOM detail rows now produces `rowErrors[].type='missing_child_bom'`;
- the expansion becomes `valid:false` / `status:'failed'`;
- evidence exposes only the values-free `missing_child_bom` token;
- the condition is not relabeled as scale-bounded `largeBom`.

This uses the existing active BOM head as the explicit source-side has-BOM signal. No active head still preserves the existing leaf behavior.

## Boundaries

No route, UI, migration, package, MetaSheet write, PLM write, external database write, K3 path, raw SQL, stored procedure, production rollout, large-BOM job wiring, or checkpoint writer change.

This PR does not complete #2388 runtime or #2342 runtime. It is a prerequisite guard so #2393-#2401 can rebase and be reviewed against the settled #2402 semantics.

## Verification

```bash
node plugins/plugin-integration-core/__tests__/stock-preparation-bom-expansion.test.cjs
node plugins/plugin-integration-core/__tests__/stock-preparation-table-actions.test.cjs
git diff --check
git diff --check origin/main...HEAD
```
