### PR TITLE
feat(plm-embed): allow REST tenant scope options

### DIFF
--- a/packages/core-backend/src/routes/data-sources.ts
+++ b/packages/core-backend/src/routes/data-sources.ts
@@ -23,6 +23,19 @@ import { DATA_SOURCE_DEFAULT_LIMIT, DATA_SOURCE_MAX_ROWS } from '../data-adapter
 // Zod schemas for request validation
 const ConnectionConfigSchema = z.record(z.union([z.string(), z.number(), z.boolean()]))
 
+const DataSourceOptionsSchema = z.object({
+  autoConnect: z.boolean().optional(),
+  timeout: z.number().optional(),
+  retryAttempts: z.number().optional(),
+  // Read-only is the default; set false to permit write SQL via /query.
+  readOnly: z.boolean().optional(),
+  // PLM/Yuantus per-source scope. PLMAdapter.connect() turns these into the
+  // actual x-tenant-id / x-org-id headers when no higher-precedence global/env
+  // scope or hand-set header is already serving the source.
+  tenantId: z.string().min(1).optional(),
+  orgId: z.string().min(1).optional()
+})
+
 const DataSourceCreateSchema = z.object({
   id: z.string().min(1, 'ID is required'),
   name: z.string().min(1, 'Name is required'),
@@ -30,13 +43,7 @@ const DataSourceCreateSchema = z.object({
     errorMap: () => ({ message: 'Unsupported data source type' })
   }),
   connection: ConnectionConfigSchema,
-  options: z.object({
-    autoConnect: z.boolean().optional(),
-    timeout: z.number().optional(),
-    retryAttempts: z.number().optional(),
-    // Read-only is the default; set false to permit write SQL via /query.
-    readOnly: z.boolean().optional()
-  }).optional(),
+  options: DataSourceOptionsSchema.optional(),
   credentials: z.object({
     username: z.string().optional(),
     password: z.string().optional(),
@@ -54,13 +61,7 @@ const DataSourceCreateSchema = z.object({
 const DataSourceUpdateSchema = z.object({
   name: z.string().min(1).optional(),
   connection: ConnectionConfigSchema.optional(),
-  options: z.object({
-    autoConnect: z.boolean().optional(),
-    timeout: z.number().optional(),
-    retryAttempts: z.number().optional(),
-    // Read-only is the default; set false to permit write SQL via /query.
-    readOnly: z.boolean().optional()
-  }).optional(),
+  options: DataSourceOptionsSchema.optional(),
   poolConfig: z.object({
     min: z.number().min(0).optional(),
     max: z.number().min(1).optional(),

--- a/packages/core-backend/tests/unit/data-source-readonly.test.ts
+++ b/packages/core-backend/tests/unit/data-source-readonly.test.ts
@@ -134,6 +134,39 @@ describe('data-sources PUT deep-merge (A-RO)', () => {
     expect(got.body.data.options).toMatchObject({ autoConnect: true, readOnly: false, timeout: 5 })
   })
 
+  it('persists per-source tenant scope option keys through create and partial update', async () => {
+    currentUser = admin('alice')
+    const create = await request(app)
+      .post('/api/data-sources')
+      .send({
+        id: 'plm-scope',
+        name: 'PLM scoped',
+        type: 'http',
+        connection: { baseURL: 'http://plm.example.test' },
+        options: { autoConnect: false, readOnly: true, tenantId: 'tenant-a', orgId: 'org-a' },
+      })
+    expect(create.status).toBe(201)
+    expect(create.body.data.options).toMatchObject({ tenantId: 'tenant-a', orgId: 'org-a' })
+
+    // This route-level test only locks REST persistence of the option keys. PLM
+    // embed reachability is locked by the real PLMAdapter tests; an HTTP source
+    // is not a PLM BOM adapter.
+    const put = await request(app)
+      .put('/api/data-sources/plm-scope')
+      .send({ options: { timeout: 10 } })
+    expect(put.status).toBe(200)
+
+    const got = await request(app).get('/api/data-sources/plm-scope')
+    expect(got.status).toBe(200)
+    expect(got.body.data.options).toMatchObject({
+      autoConnect: false,
+      readOnly: true,
+      tenantId: 'tenant-a',
+      orgId: 'org-a',
+      timeout: 10,
+    })
+  })
+
   it('a partial connection update preserves hidden security keys (P1 regression)', async () => {
     currentUser = admin('alice')
     // A source whose connection carries security-sensitive keys an edit UI does NOT surface.

--- a/packages/core-backend/tests/unit/plm-adapter-effective-tenant.test.ts
+++ b/packages/core-backend/tests/unit/plm-adapter-effective-tenant.test.ts
@@ -15,10 +15,16 @@ const logger = { info: vi.fn(), warn: vi.fn(), error: vi.fn(), debug: vi.fn() }
 
 function makeAdapter(opts: {
   globalTenant?: string
+  globalOrg?: string
   optionsTenant?: string
+  optionsOrg?: string
   connectionHeaders?: Record<string, string>
 }): PLMAdapter {
-  const get = vi.fn(async (key: string) => (key === 'plm.tenantId' ? opts.globalTenant : undefined))
+  const get = vi.fn(async (key: string) => {
+    if (key === 'plm.tenantId') return opts.globalTenant
+    if (key === 'plm.orgId') return opts.globalOrg
+    return undefined
+  })
   const configService = { get }
   const config = {
     id: 'plm-embed',
@@ -26,7 +32,10 @@ function makeAdapter(opts: {
     type: 'plm',
     // no URL -> mock mode -> connect() resolves the tenant + sets the x-tenant-id header then early-returns
     connection: { url: '', ...(opts.connectionHeaders ? { headers: opts.connectionHeaders } : {}) },
-    options: opts.optionsTenant ? { tenantId: opts.optionsTenant } : {},
+    options: {
+      ...(opts.optionsTenant ? { tenantId: opts.optionsTenant } : {}),
+      ...(opts.optionsOrg ? { orgId: opts.optionsOrg } : {}),
+    },
   }
   return new PLMAdapter(configService as never, logger as never, config as never)
 }
@@ -69,6 +78,16 @@ describe('PLMAdapter.getEffectiveTenantId (served tenant, full precedence)', () 
     const adapter = makeAdapter({ optionsTenant: 'tenant-a' })
     await adapter.connect()
     expect(adapter.getEffectiveTenantId()).toBe('tenant-a')
+  })
+
+  it('falls back to per-source options.tenantId/orgId and sends both PLM scope headers', async () => {
+    const adapter = makeAdapter({ optionsTenant: 'tenant-a', optionsOrg: 'org-a' })
+    await adapter.connect()
+    expect(adapter.getEffectiveTenantId()).toBe('tenant-a')
+    expect(((adapter as unknown as { config: { connection: { headers?: Record<string, string> } } }).config.connection.headers)).toMatchObject({
+      'x-tenant-id': 'tenant-a',
+      'x-org-id': 'org-a',
+    })
   })
 
   it('is undefined when no tenant is configured anywhere (the relay then fails closed)', async () => {

--- a/packages/core-backend/tests/unit/plm-embed-routes.test.ts
+++ b/packages/core-backend/tests/unit/plm-embed-routes.test.ts
@@ -258,6 +258,36 @@ describe('PLM embed relay (PLM-COLLAB-P3-D2)', () => {
     expect(jtiMocks.consume).not.toHaveBeenCalled()
   })
 
+  it('END-TO-END (real adapter): per-source options tenant/org serve the embed route when the token tenant matches', async () => {
+    for (const k of ['PLM_TENANT_ID', 'PLM_ORG_ID', 'PLM_BASE_URL', 'PLM_URL']) delete process.env[k]
+    const adapter = new PLMAdapter(
+      { get: async () => undefined } as never,
+      { info: vi.fn(), warn: vi.fn(), error: vi.fn() } as never,
+      {
+        id: DS_ID,
+        name: 'PLM',
+        type: 'plm',
+        connection: { url: '' },
+        options: { tenantId: 'tenant-a', orgId: 'org-a' },
+      } as never,
+    )
+    await adapter.connect() // no URL -> mock mode -> no network; options populate served tenant/org headers
+    const getBomMultitableContext = vi
+      .spyOn(adapter, 'getBomMultitableContext')
+      .mockResolvedValue({ feature_key: 'bom_multitable', entitled: true, upgrade: { available: false }, context: CONTEXT })
+    dsMocks.getDataSource.mockReturnValue(adapter)
+
+    const res = await request(buildApp()).get(URL).set('X-PLM-Embed-Token', mint({ tenant_id: 'tenant-a' }))
+
+    expect(res.status).toBe(200)
+    expect(getBomMultitableContext).toHaveBeenCalledWith('P1')
+    expect(adapter.getEffectiveTenantId()).toBe('tenant-a')
+    expect(((adapter as unknown as { config: { connection: { headers?: Record<string, string> } } }).config.connection.headers)).toMatchObject({
+      'x-tenant-id': 'tenant-a',
+      'x-org-id': 'org-a',
+    })
+  })
+
   // --- single-use jti consume (slice B / B1): consume AFTER all checks, BEFORE the BOM query ---
 
   it('first use: consumes the (scoped) jti and serves -> 200', async () => {


### PR DESCRIPTION
## Summary

Allows data-source REST create/update payloads to persist PLM/Yuantus per-source scope options:

- `options.tenantId`
- `options.orgId`

`PLMAdapter.connect()` already consumes these options as the fallback source for `x-tenant-id` / `x-org-id` when no higher-precedence global/env scope or hand-set served header exists. This PR opens the REST validation gate so the values can survive create/update and be available to the adapter.

## Why

The P3-D embed relay now validates embed-token `tenant_id` against the tenant actually served by the configured data source. This small slice removes one deployment-only ambiguity by letting the data-source record carry the tenant/org scope through REST persistence.

## Tests

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/data-source-readonly.test.ts tests/unit/plm-adapter-effective-tenant.test.ts --watch=false`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm exec eslint src/routes/data-sources.ts tests/unit/data-source-readonly.test.ts` from `packages/core-backend` cwd
  - Result: 0 errors; test file is ignored by package ESLint config.

## Boundaries

- No embed relay changes.
- No frontend/UI changes.
- No new data-source type registration.
- `SUPPORTED_DATA_SOURCE_TYPES` still does not publicly expose a `plm` type here; this is the REST/persistence step for scoped options, not the full UI productization of PLM source creation.
