### PR TITLE
feat(attendance): add multi-shift slot foundation

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260609120000_add_attendance_shift_assignment_slot_index.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260609120000_add_attendance_shift_assignment_slot_index.ts
@@ -1,0 +1,44 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import {
+  addColumnIfNotExists,
+  checkTableExists,
+  createIndexIfNotExists,
+  dropColumnIfExists,
+  dropIndexIfExists,
+} from './_patterns'
+
+const TABLE_NAME = 'attendance_shift_assignments'
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, TABLE_NAME)
+  if (!exists) return
+
+  await addColumnIfNotExists(db, TABLE_NAME, 'slot_index', 'smallint', {
+    notNull: true,
+    defaultTo: 0,
+  })
+
+  await sql`ALTER TABLE attendance_shift_assignments DROP CONSTRAINT IF EXISTS chk_attendance_shift_assignments_slot_index`.execute(db)
+  await sql`
+    ALTER TABLE attendance_shift_assignments
+    ADD CONSTRAINT chk_attendance_shift_assignments_slot_index
+    CHECK (slot_index BETWEEN 0 AND 2)
+  `.execute(db)
+
+  await createIndexIfNotExists(
+    db,
+    'idx_attendance_shift_assignments_user_slot_range',
+    TABLE_NAME,
+    ['org_id', 'user_id', 'slot_index', 'start_date'],
+  )
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, TABLE_NAME)
+  if (!exists) return
+
+  await sql`ALTER TABLE attendance_shift_assignments DROP CONSTRAINT IF EXISTS chk_attendance_shift_assignments_slot_index`.execute(db)
+  await dropIndexIfExists(db, 'idx_attendance_shift_assignments_user_slot_range')
+  await dropColumnIfExists(db, TABLE_NAME, 'slot_index')
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1105,6 +1105,7 @@ export interface AttendanceShiftAssignmentsTable {
   org_id: string
   user_id: string
   shift_id: string
+  slot_index: number
   start_date: ColumnType<string, string | undefined, string>
   end_date: ColumnType<string | null, string | undefined, string | null>
   is_active: boolean

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -1864,8 +1864,29 @@ attendanceIntegrationDescribe(
     expect(assignmentRow?.assignment?.user_id).toBe(testUserId)
     expect(assignmentRow?.assignment?.shiftId).toBe(shiftId)
     expect(assignmentRow?.assignment?.shift_id).toBe(shiftId)
+    expect(assignmentRow?.assignment?.slotIndex).toBe(0)
+    expect(assignmentRow?.assignment?.slot_index).toBe(0)
     expect(assignmentRow?.shift?.workStartTime).toBe('08:30:00')
     expect(assignmentRow?.shift?.work_start_time).toBe('08:30:00')
+
+    const pool = new Pool({ connectionString: attendanceIntegrationDbUrl })
+    try {
+      const columnRes = await pool.query(
+        `SELECT column_name
+           FROM information_schema.columns
+          WHERE table_schema = current_schema()
+            AND table_name = 'attendance_shift_assignments'
+            AND column_name = 'slot_index'`
+      )
+      expect(columnRes.rowCount).toBe(1)
+      const persistedRes = await pool.query(
+        'SELECT slot_index FROM attendance_shift_assignments WHERE id = $1',
+        [assignmentId]
+      )
+      expect(Number(persistedRes.rows[0]?.slot_index)).toBe(0)
+    } finally {
+      await pool.end()
+    }
   })
 
   it('rejects unknown shift fields and overly long shift names on create and update', async () => {
@@ -4819,6 +4840,7 @@ attendanceIntegrationDescribe(
             weeklyMaxMinutes: 2400,
             monthlyMaxMinutes: 9600,
           },
+          multiShiftDay: { enabled: true, maxSlots: 3 },
           compTimeFromOvertime: { enabled: true, expiresInDays: 45 },
           autoShiftMatching: {
             enabled: true,
@@ -4842,6 +4864,7 @@ attendanceIntegrationDescribe(
         data?: {
           comprehensiveHours?: { capDefaults?: Record<string, number | null> }
           shiftCompliance?: Record<string, unknown>
+          multiShiftDay?: Record<string, unknown>
           compTimeFromOvertime?: Record<string, unknown>
           autoShiftMatching?: Record<string, unknown>
         }
@@ -4853,6 +4876,7 @@ attendanceIntegrationDescribe(
         weeklyMaxMinutes: 2400,
         monthlyMaxMinutes: 9600,
       })
+      expect(reloaded?.multiShiftDay).toEqual({ enabled: true, maxSlots: 3 })
       expect(reloaded?.compTimeFromOvertime).toEqual({ enabled: true, expiresInDays: 45 })
       expect(reloaded?.autoShiftMatching).toEqual({
         enabled: true,

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -123,6 +123,12 @@ const DEFAULT_SETTINGS = {
     merge: { internalWinsOnIn: false, externalWinsOnOut: false },
     outdoor: { requireApproval: false, requireNote: false, requirePhoto: false, approvalFlowId: '' },
   },
+  // 一天多班次 (multi-shift day) — latent M0 foundation. Default off preserves the
+  // current single-effective-assignment behaviour; M1 wires the slot conflict guard.
+  multiShiftDay: {
+    enabled: false,
+    maxSlots: 3,
+  },
   formula: {
     allowRawAliases: true,
   },
@@ -8181,6 +8187,8 @@ function mapAssignmentRow(row) {
     user_id: row.user_id,
     shiftId: row.shift_id,
     shift_id: row.shift_id,
+    slotIndex: Number.isFinite(Number(row.slot_index)) ? Number(row.slot_index) : 0,
+    slot_index: Number.isFinite(Number(row.slot_index)) ? Number(row.slot_index) : 0,
     startDate: normalizeDateOnly(row.start_date) ?? row.start_date,
     start_date: normalizeDateOnly(row.start_date) ?? row.start_date,
     endDate: normalizeDateOnly(row.end_date) ?? row.end_date ?? null,
@@ -10871,6 +10879,7 @@ function normalizeSettings(raw) {
     shiftEditPolicy: normalizeShiftEditPolicySetting(raw.shiftEditPolicy),
     shiftCompliance: normalizeShiftComplianceSetting(raw.shiftCompliance),
     punchPolicy: normalizePunchPolicySetting(raw.punchPolicy),
+    multiShiftDay: normalizeMultiShiftDaySetting(raw.multiShiftDay),
     formula: {
       allowRawAliases: parseBoolean(formula.allowRawAliases, DEFAULT_SETTINGS.formula.allowRawAliases),
     },
@@ -10897,6 +10906,17 @@ function normalizeAutoShiftMatchingSetting(raw) {
     minConfidenceToApply: ['high', 'medium', 'low'].includes(minConfidenceRaw)
       ? minConfidenceRaw
       : DEFAULT_SETTINGS.autoShiftMatching.minConfidenceToApply,
+  }
+}
+
+function normalizeMultiShiftDaySetting(raw) {
+  const config = raw && typeof raw === 'object' ? raw : {}
+  const maxSlotsRaw = Number(config.maxSlots)
+  return {
+    enabled: typeof config.enabled === 'boolean' ? config.enabled : DEFAULT_SETTINGS.multiShiftDay.enabled,
+    maxSlots: Number.isInteger(maxSlotsRaw) && maxSlotsRaw >= 1 && maxSlotsRaw <= 3
+      ? maxSlotsRaw
+      : DEFAULT_SETTINGS.multiShiftDay.maxSlots,
   }
 }
 
@@ -11033,6 +11053,10 @@ function mergeSettings(base, update) {
       unscheduled: { ...(base?.punchPolicy?.unscheduled || {}), ...(update?.punchPolicy?.unscheduled || {}) },
       merge: { ...(base?.punchPolicy?.merge || {}), ...(update?.punchPolicy?.merge || {}) },
       outdoor: { ...(base?.punchPolicy?.outdoor || {}), ...(update?.punchPolicy?.outdoor || {}) },
+    },
+    multiShiftDay: {
+      ...(base?.multiShiftDay || {}),
+      ...(update?.multiShiftDay || {}),
     },
     comprehensiveHours: {
       ...(base?.comprehensiveHours || {}),
@@ -11386,7 +11410,7 @@ async function loadShiftAssignment(db, orgId, userId, workDate) {
   const targetOrg = orgId || DEFAULT_ORG_ID
   try {
     const rows = await db.query(
-      `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.start_date, a.end_date, a.is_active,
+      `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
               s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
               s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
               s.early_grace_minutes AS shift_early_grace_minutes, s.rounding_minutes AS shift_rounding_minutes,
@@ -11753,7 +11777,7 @@ async function loadShiftAssignmentMapForUsersRange(db, orgId, userIds, fromDate,
   if (!fromDate || !toDate) return new Map()
   try {
     const rows = await db.query(
-      `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.start_date, a.end_date, a.is_active,
+      `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
               s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
               s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
               s.early_grace_minutes AS shift_early_grace_minutes, s.rounding_minutes AS shift_rounding_minutes,
@@ -16871,6 +16895,12 @@ module.exports = {
           requireNote: z.boolean().optional(),
           approvalFlowId: z.string().optional(),
         }).optional(),
+      }).optional(),
+      // Multi-shift day M0: latent org setting only. M1 wires assignment slot writes
+      // and conflict semantics; default false means no behaviour change.
+      multiShiftDay: z.object({
+        enabled: z.boolean().optional(),
+        maxSlots: z.number().int().min(1).max(3).optional(),
       }).optional(),
       formula: z.object({
         allowRawAliases: z.boolean().optional(),
@@ -29888,7 +29918,7 @@ module.exports = {
               [orgId]
             ),
             db.query(
-              `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.start_date, a.end_date, a.is_active,
+              `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
                       s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
                       s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight,
                       s.late_grace_minutes AS shift_late_grace_minutes,
@@ -30712,7 +30742,7 @@ module.exports = {
             : buildAttendanceAssignmentViewSql(viewAccess.scopes, rowParams, 'a')
           rowParams.push(pageSize, offset)
           const rows = await db.query(
-            `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.start_date, a.end_date, a.is_active,
+            `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
                     s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
                     s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
                     s.early_grace_minutes AS shift_early_grace_minutes, s.rounding_minutes AS shift_rounding_minutes,


### PR DESCRIPTION
## Summary
- Add the M0 multi-shift-day foundation: `attendance_shift_assignments.slot_index smallint NOT NULL DEFAULT 0` with a 0..2 CHECK and a supporting user/slot/range lookup index.
- Add latent org settings `multiShiftDay.{enabled,maxSlots}` (default `false/3`) and wire it through normalize/merge/settings PUT+GET.
- Expose `slotIndex`/`slot_index` on assignment response mapping and select the real column on read paths.

## Scope / boundary
- This is M0 only. It does **not** accept `slotIndex` on assignment POST/PUT and does **not** change conflict semantics; current single-assignment behavior stays intact.
- M1 will wire assignment `slotIndex` writes + same-slot/date-range and cross-slot time-window conflict guards.

## Migration batching pre-flight
- Checked `origin/main` before implementation: no existing `slot_index` column, no open matching attendance shift/slot PR, and adjacent hot-table DDL (`status` publish/draft, `locked_at`, shift constraints) still exists only as future tracker/design work.
- Because those adjacent schema changes are not ready to batch and `slot_index` is a replay-safe latent `NOT NULL DEFAULT 0` column, M0 ships this standalone with the decision recorded here.

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend test:integration:attendance` (local environment has no `DATABASE_URL`/`ATTENDANCE_TEST_DATABASE_URL`, so Vitest skipped all DB integration files; CI must provide the real-DB proof)

## Notes
- The integration spec was extended so the real DB gate checks the `slot_index` column exists, defaulted assignments persist `slot_index=0`, and the API returns both `slotIndex` and `slot_index` as `0`.
