### PR TITLE
fix(attendance): harden multi-shift slot foundation rollout

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260609120000_add_attendance_shift_assignment_slot_index.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260609120000_add_attendance_shift_assignment_slot_index.ts
@@ -3,9 +3,7 @@ import { sql } from 'kysely'
 import {
   addColumnIfNotExists,
   checkTableExists,
-  createIndexIfNotExists,
   dropColumnIfExists,
-  dropIndexIfExists,
 } from './_patterns'
 
 const TABLE_NAME = 'attendance_shift_assignments'
@@ -23,15 +21,8 @@ export async function up(db: Kysely<unknown>): Promise<void> {
   await sql`
     ALTER TABLE attendance_shift_assignments
     ADD CONSTRAINT chk_attendance_shift_assignments_slot_index
-    CHECK (slot_index BETWEEN 0 AND 2)
+    CHECK (slot_index BETWEEN 0 AND 2) NOT VALID
   `.execute(db)
-
-  await createIndexIfNotExists(
-    db,
-    'idx_attendance_shift_assignments_user_slot_range',
-    TABLE_NAME,
-    ['org_id', 'user_id', 'slot_index', 'start_date'],
-  )
 }
 
 export async function down(db: Kysely<unknown>): Promise<void> {
@@ -39,6 +30,5 @@ export async function down(db: Kysely<unknown>): Promise<void> {
   if (!exists) return
 
   await sql`ALTER TABLE attendance_shift_assignments DROP CONSTRAINT IF EXISTS chk_attendance_shift_assignments_slot_index`.execute(db)
-  await dropIndexIfExists(db, 'idx_attendance_shift_assignments_user_slot_range')
   await dropColumnIfExists(db, TABLE_NAME, 'slot_index')
 }

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -1105,7 +1105,7 @@ export interface AttendanceShiftAssignmentsTable {
   org_id: string
   user_id: string
   shift_id: string
-  slot_index: number
+  slot_index: Generated<number>
   start_date: ColumnType<string, string | undefined, string>
   end_date: ColumnType<string | null, string | undefined, string | null>
   is_active: boolean

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -11410,7 +11410,7 @@ async function loadShiftAssignment(db, orgId, userId, workDate) {
   const targetOrg = orgId || DEFAULT_ORG_ID
   try {
     const rows = await db.query(
-      `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
+      `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.start_date, a.end_date, a.is_active,
               s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
               s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
               s.early_grace_minutes AS shift_early_grace_minutes, s.rounding_minutes AS shift_rounding_minutes,
@@ -11777,7 +11777,7 @@ async function loadShiftAssignmentMapForUsersRange(db, orgId, userIds, fromDate,
   if (!fromDate || !toDate) return new Map()
   try {
     const rows = await db.query(
-      `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
+      `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.start_date, a.end_date, a.is_active,
               s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
               s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
               s.early_grace_minutes AS shift_early_grace_minutes, s.rounding_minutes AS shift_rounding_minutes,
@@ -29918,7 +29918,7 @@ module.exports = {
               [orgId]
             ),
             db.query(
-              `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
+              `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.start_date, a.end_date, a.is_active,
                       s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
                       s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight,
                       s.late_grace_minutes AS shift_late_grace_minutes,
@@ -30742,7 +30742,7 @@ module.exports = {
             : buildAttendanceAssignmentViewSql(viewAccess.scopes, rowParams, 'a')
           rowParams.push(pageSize, offset)
           const rows = await db.query(
-            `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
+            `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.start_date, a.end_date, a.is_active,
                     s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
                     s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
                     s.early_grace_minutes AS shift_early_grace_minutes, s.rounding_minutes AS shift_rounding_minutes,


### PR DESCRIPTION
## Summary
- Follow-up to #2422 after review caught rollout hardening gaps.
- Stop selecting `a.slot_index` from legacy single-shift read paths in M0; `mapAssignmentRow` still returns `slotIndex: 0` via fallback, so code that lands before the DB migration does not silently turn existing assignments into "no assignment" through schema-error fallback.
- Change the Kysely type to `Generated<number>` so typed inserts can omit the defaulted column.
- Make the M0 DDL lighter: remove the regular lookup index from this latent slice and add the 0..2 CHECK as `NOT VALID`; M1 can add any production-safe lookup/indexing once runtime slot conflicts need it.

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`

## Notes
- This intentionally keeps #2422's API behavior unchanged: M0 still exposes default `slotIndex`/`slot_index` as `0`, and still does not accept slot writes.
