### PR TITLE
feat(attendance): support multi-shift assignment slots

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -2355,6 +2355,243 @@ attendanceIntegrationDescribe(
     expect(invalidRangeError?.code).toBe('VALIDATION_ERROR')
   })
 
+  it('enforces multi-shift slot conflicts on manual assignment create and update', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const adminUserId = `attendance-multishift-admin-${runSuffix}`
+    const workDate = '2026-07-08'
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) return
+
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    }
+    const pool = new Pool({ connectionString: dbUrl })
+    let originalSettings: Record<string, unknown> = {}
+
+    async function saveSettings(patch: Record<string, unknown>) {
+      const res = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify(patch),
+      })
+      expect(res.status, JSON.stringify(res.body)).toBe(200)
+      return res
+    }
+
+    async function createShift(name: string, workStartTime: string, workEndTime: string): Promise<string> {
+      const shiftRes = await requestJson(`${baseUrl}/api/attendance/shifts`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name,
+          timezone: 'Asia/Shanghai',
+          workStartTime,
+          workEndTime,
+          workingDays: [1, 2, 3, 4, 5],
+        }),
+      })
+      expect(shiftRes.status, JSON.stringify(shiftRes.body)).toBe(201)
+      const shiftId = (shiftRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(shiftId).toBeTruthy()
+      if (!shiftId) throw new Error('missing shift id')
+      return shiftId
+    }
+
+    async function createAssignment(userId: string, shiftId: string, slotIndex?: number) {
+      const body: Record<string, unknown> = {
+        userId,
+        shiftId,
+        startDate: workDate,
+        endDate: workDate,
+        isActive: true,
+      }
+      if (slotIndex !== undefined) body.slotIndex = slotIndex
+      return requestJson(`${baseUrl}/api/attendance/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      })
+    }
+
+    function expectShiftAssignmentConflict(res: HttpResponse) {
+      expect(res.status).toBe(409)
+      const error = (res.body as { error?: { code?: string; details?: { conflictType?: string } } } | undefined)?.error
+      expect(error?.code).toBe('ATTENDANCE_SCHEDULE_ASSIGNMENT_CONFLICT')
+      expect(error?.details?.conflictType).toBe('shift_assignment_overlap')
+    }
+
+    try {
+      const settingsRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      expect(settingsRes.status).toBe(200)
+      originalSettings = ((settingsRes.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
+
+      const morningShiftId = await createShift(`Multi Shift Morning ${runSuffix}`, '08:00', '12:00')
+      const eveningShiftId = await createShift(`Multi Shift Evening ${runSuffix}`, '13:00', '17:00')
+      const overlapShiftId = await createShift(`Multi Shift Overlap ${runSuffix}`, '11:00', '15:00')
+
+      await saveSettings({
+        shiftEditPolicy: { mode: 'unrestricted', windowDays: 0 },
+        shiftCompliance: { enforcement: 'warn', dailyMaxMinutes: null, weeklyMaxMinutes: null, monthlyMaxMinutes: null },
+        multiShiftDay: { enabled: false, maxSlots: 3 },
+      })
+
+      const defaultOffUserId = `${adminUserId}-default-off`
+      const defaultOffBaseRes = await createAssignment(defaultOffUserId, morningShiftId, 0)
+      expect(defaultOffBaseRes.status).toBe(201)
+      const defaultOffSecondRes = await createAssignment(defaultOffUserId, eveningShiftId, 1)
+      expectShiftAssignmentConflict(defaultOffSecondRes)
+
+      await saveSettings({
+        multiShiftDay: { enabled: true, maxSlots: 3 },
+        shiftCompliance: { enforcement: 'warn', dailyMaxMinutes: null, weeklyMaxMinutes: null, monthlyMaxMinutes: null },
+      })
+
+      const multiSlotUserId = `${adminUserId}-enabled`
+      const morningAssignmentRes = await createAssignment(multiSlotUserId, morningShiftId, 0)
+      expect(morningAssignmentRes.status, JSON.stringify(morningAssignmentRes.body)).toBe(201)
+      const morningAssignment = (morningAssignmentRes.body as { data?: { assignment?: { id?: string; slotIndex?: number; slot_index?: number } } } | undefined)?.data?.assignment
+      expect(morningAssignment?.slotIndex).toBe(0)
+      expect(morningAssignment?.slot_index).toBe(0)
+      expect(morningAssignment?.id).toBeTruthy()
+
+      const eveningAssignmentRes = await createAssignment(multiSlotUserId, eveningShiftId, 1)
+      expect(eveningAssignmentRes.status, JSON.stringify(eveningAssignmentRes.body)).toBe(201)
+      const eveningAssignment = (eveningAssignmentRes.body as { data?: { assignment?: { id?: string; slotIndex?: number; slot_index?: number } } } | undefined)?.data?.assignment
+      expect(eveningAssignment?.slotIndex).toBe(1)
+      expect(eveningAssignment?.slot_index).toBe(1)
+      expect(eveningAssignment?.id).toBeTruthy()
+      if (!eveningAssignment?.id) return
+
+      const slotRows = await pool.query(
+        `SELECT slot_index
+           FROM attendance_shift_assignments
+          WHERE user_id = $1
+            AND start_date = $2::date
+            AND COALESCE(is_active, true) = true
+          ORDER BY slot_index ASC`,
+        [multiSlotUserId, workDate]
+      )
+      expect(slotRows.rows.map(row => Number(row.slot_index))).toEqual([0, 1])
+
+      expectShiftAssignmentConflict(await createAssignment(multiSlotUserId, eveningShiftId, 1))
+      expectShiftAssignmentConflict(await createAssignment(multiSlotUserId, overlapShiftId, 2))
+
+      const updateSlotRes = await requestJson(`${baseUrl}/api/attendance/assignments/${eveningAssignment.id}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ slotIndex: 2 }),
+      })
+      expect(updateSlotRes.status, JSON.stringify(updateSlotRes.body)).toBe(200)
+      const updatedAssignment = (updateSlotRes.body as { data?: { assignment?: { slotIndex?: number; slot_index?: number } } } | undefined)?.data?.assignment
+      expect(updatedAssignment?.slotIndex).toBe(2)
+      expect(updatedAssignment?.slot_index).toBe(2)
+
+      const listRes = await requestJson(`${baseUrl}/api/attendance/assignments?userId=${encodeURIComponent(multiSlotUserId)}`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      expect(listRes.status).toBe(200)
+      const listItems = (listRes.body as { data?: { items?: Array<{ assignment?: { id?: string; slotIndex?: number; slot_index?: number } }> } } | undefined)?.data?.items ?? []
+      const listedEveningAssignment = listItems.find(item => item.assignment?.id === eveningAssignment.id)?.assignment
+      expect(listedEveningAssignment?.slotIndex).toBe(2)
+      expect(listedEveningAssignment?.slot_index).toBe(2)
+
+      const updateToSameSlotRes = await requestJson(`${baseUrl}/api/attendance/assignments/${eveningAssignment.id}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ slotIndex: 0 }),
+      })
+      expectShiftAssignmentConflict(updateToSameSlotRes)
+
+      const rotationRuleRes = await requestJson(`${baseUrl}/api/attendance/rotation-rules`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name: `Multi Shift Rotation ${runSuffix}`,
+          timezone: 'Asia/Shanghai',
+          shiftSequence: [morningShiftId],
+          isActive: true,
+        }),
+      })
+      expect(rotationRuleRes.status).toBe(201)
+      const rotationRuleId = (rotationRuleRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(rotationRuleId).toBeTruthy()
+      if (!rotationRuleId) return
+
+      const rotationConflictRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          userId: multiSlotUserId,
+          rotationRuleId,
+          startDate: workDate,
+          endDate: workDate,
+          isActive: true,
+        }),
+      })
+      expect(rotationConflictRes.status).toBe(409)
+      const rotationError = (rotationConflictRes.body as { error?: { details?: { conflictType?: string; draftKind?: string; existingKind?: string } } } | undefined)?.error
+      expect(rotationError?.details?.conflictType).toBe('rotation_overrides_shift')
+      expect(rotationError?.details?.draftKind).toBe('rotation')
+      expect(rotationError?.details?.existingKind).toBe('shift')
+
+      const rotationFirstUserId = `${adminUserId}-rotation-first`
+      const rotationFirstRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          userId: rotationFirstUserId,
+          rotationRuleId,
+          startDate: workDate,
+          endDate: workDate,
+          isActive: true,
+        }),
+      })
+      expect(rotationFirstRes.status).toBe(201)
+      const directAfterRotationRes = await createAssignment(rotationFirstUserId, morningShiftId, 1)
+      expect(directAfterRotationRes.status).toBe(409)
+      const directAfterRotationError = (directAfterRotationRes.body as { error?: { details?: { conflictType?: string; draftKind?: string; existingKind?: string } } } | undefined)?.error
+      expect(directAfterRotationError?.details?.conflictType).toBe('rotation_overrides_shift')
+      expect(directAfterRotationError?.details?.draftKind).toBe('shift')
+      expect(directAfterRotationError?.details?.existingKind).toBe('rotation')
+
+      await saveSettings({ multiShiftDay: { enabled: true, maxSlots: 2 } })
+      const tooHighSlotRes = await createAssignment(`${adminUserId}-slot-too-high`, eveningShiftId, 2)
+      expect(tooHighSlotRes.status).toBe(400)
+      const tooHighError = (tooHighSlotRes.body as { error?: { code?: string; message?: string } } | undefined)?.error
+      expect(tooHighError?.code).toBe('VALIDATION_ERROR')
+      expect(String(tooHighError?.message || '')).toContain('slotIndex')
+    } finally {
+      if (Object.keys(originalSettings).length > 0) {
+        await requestJson(`${baseUrl}/api/attendance/settings`, {
+          method: 'PUT',
+          headers,
+          body: JSON.stringify({
+            shiftEditPolicy: originalSettings.shiftEditPolicy ?? { mode: 'unrestricted', windowDays: 0 },
+            shiftCompliance: originalSettings.shiftCompliance ?? {
+              enforcement: 'block',
+              dailyMaxMinutes: null,
+              weeklyMaxMinutes: null,
+              monthlyMaxMinutes: null,
+            },
+            multiShiftDay: originalSettings.multiShiftDay ?? { enabled: false, maxSlots: 3 },
+          }),
+        }).catch(() => undefined)
+      }
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('enforces schedule-edit windows on shift and rotation assignment writes', async () => {
     if (!baseUrl) return
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8633,6 +8633,7 @@ function normalizeAssignmentPayload(value) {
     ...payload,
     userId: firstDefinedValue(payload.userId, payload.user_id),
     shiftId: firstDefinedValue(payload.shiftId, payload.shift_id),
+    slotIndex: firstDefinedValue(payload.slotIndex, payload.slot_index),
     startDate: firstDefinedValue(payload.startDate, payload.start_date),
     endDate: firstDefinedValue(payload.endDate, payload.end_date),
     isActive: firstDefinedValue(payload.isActive, payload.is_active),
@@ -8812,6 +8813,50 @@ function resolveAttendanceScheduleAssignmentUpdateEndDate(payload, existingEndDa
   return normalizeAttendanceScheduleAssignmentEndDate(payload.endDate)
 }
 
+function normalizeAttendanceScheduleSlotIndex(value, fallback = 0) {
+  if (value === null || value === undefined || value === '') return fallback
+  const parsed = Number(value)
+  if (!Number.isInteger(parsed)) return fallback
+  return parsed
+}
+
+function resolveAttendanceScheduleAssignmentSlotIndex(settings, value, fallback = 0) {
+  const multiShiftDay = normalizeMultiShiftDaySetting(settings?.multiShiftDay)
+  const slotIndex = multiShiftDay.enabled
+    ? normalizeAttendanceScheduleSlotIndex(value, fallback)
+    : 0
+  if (multiShiftDay.enabled && (slotIndex < 0 || slotIndex >= multiShiftDay.maxSlots)) {
+    return {
+      ok: false,
+      status: 400,
+      code: 'VALIDATION_ERROR',
+      message: `slotIndex must be between 0 and ${multiShiftDay.maxSlots - 1}`,
+    }
+  }
+  return { ok: true, slotIndex, multiShiftDay }
+}
+
+function resolveAttendanceShiftWindowForSlotConflict(shift) {
+  if (!shift || typeof shift !== 'object') return null
+  const start = normalizeTimeString(shift.workStartTime ?? shift.work_start_time)
+  const end = normalizeTimeString(shift.workEndTime ?? shift.work_end_time)
+  if (!start || !end) return null
+  const isOvernight = resolveOvernightFlag(shift.isOvernight ?? shift.is_overnight, start, end)
+  if (isOvernight || start === end) return null
+  const startMinutes = parseTimeToMinutes(start, null)
+  const endMinutes = parseTimeToMinutes(end, null)
+  if (!Number.isFinite(startMinutes) || !Number.isFinite(endMinutes) || startMinutes >= endMinutes) return null
+  return { startMinutes, endMinutes }
+}
+
+function attendanceShiftWindowsOverlapForSlotConflict(leftShift, rightShift) {
+  const left = resolveAttendanceShiftWindowForSlotConflict(leftShift)
+  const right = resolveAttendanceShiftWindowForSlotConflict(rightShift)
+  // Overnight/invalid multi-slot comparisons are intentionally conservative for v1.
+  if (!left || !right) return true
+  return left.startMinutes < right.endMinutes && right.startMinutes < left.endMinutes
+}
+
 async function acquireAttendanceScheduleAssignmentLock(client, orgId, userId) {
   try {
     await client.query(
@@ -8878,20 +8923,45 @@ async function findAttendanceScheduleAssignmentConflict(db, draft) {
   const otherKindLabel = draft.kind === 'rotation' ? 'shift' : 'rotation'
   const baseParams = [draft.orgId, draft.userId, draftStartDate, overlapEndDate]
   const excludeClause = draft.excludeId ? 'AND id <> $5' : ''
-  const sameKindRows = await db.query(
-    `SELECT id, start_date, end_date, $${draft.excludeId ? 6 : 5}::text AS kind
-       FROM ${sameKindTable}
-      WHERE org_id = $1
-        AND user_id = $2
-        AND COALESCE(is_active, true) = true
-        AND start_date <= $4::date
-        AND COALESCE(end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
-        ${excludeClause}
-      ORDER BY start_date DESC, created_at DESC
-      LIMIT 1`,
-    draft.excludeId ? [...baseParams, draft.excludeId, sameKindLabel] : [...baseParams, sameKindLabel]
-  )
-  if (sameKindRows.length) return mapAttendanceScheduleAssignmentConflict(sameKindRows[0], draft)
+  const multiShiftConflictEnabled = draft.kind === 'shift' && draft.multiShiftEnabled === true
+  if (multiShiftConflictEnabled) {
+    const sameKindRows = await db.query(
+      `SELECT a.id, a.start_date, a.end_date, a.slot_index, $${draft.excludeId ? 6 : 5}::text AS kind,
+              s.work_start_time, s.work_end_time, s.is_overnight
+         FROM attendance_shift_assignments a
+         LEFT JOIN attendance_shifts s ON s.id = a.shift_id AND s.org_id = a.org_id
+        WHERE a.org_id = $1
+          AND a.user_id = $2
+          AND COALESCE(a.is_active, true) = true
+          AND a.start_date <= $4::date
+          AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
+          ${draft.excludeId ? 'AND a.id <> $5' : ''}
+        ORDER BY a.start_date DESC, a.created_at DESC`,
+      draft.excludeId ? [...baseParams, draft.excludeId, sameKindLabel] : [...baseParams, sameKindLabel]
+    )
+    const draftSlotIndex = normalizeAttendanceScheduleSlotIndex(draft.slotIndex, 0)
+    const conflictingSameKindRow = sameKindRows.find((row) => {
+      const existingSlotIndex = normalizeAttendanceScheduleSlotIndex(row.slot_index, 0)
+      if (existingSlotIndex === draftSlotIndex) return true
+      return attendanceShiftWindowsOverlapForSlotConflict(row, draft.shift)
+    })
+    if (conflictingSameKindRow) return mapAttendanceScheduleAssignmentConflict(conflictingSameKindRow, draft)
+  } else {
+    const sameKindRows = await db.query(
+      `SELECT id, start_date, end_date, $${draft.excludeId ? 6 : 5}::text AS kind
+         FROM ${sameKindTable}
+        WHERE org_id = $1
+          AND user_id = $2
+          AND COALESCE(is_active, true) = true
+          AND start_date <= $4::date
+          AND COALESCE(end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
+          ${excludeClause}
+        ORDER BY start_date DESC, created_at DESC
+        LIMIT 1`,
+      draft.excludeId ? [...baseParams, draft.excludeId, sameKindLabel] : [...baseParams, sameKindLabel]
+    )
+    if (sameKindRows.length) return mapAttendanceScheduleAssignmentConflict(sameKindRows[0], draft)
+  }
 
   const otherKindRows = await db.query(
     `SELECT id, start_date, end_date, $5::text AS kind
@@ -16980,6 +17050,7 @@ module.exports = {
     const assignmentCreateSchema = z.object({
       userId: z.string().min(1),
       shiftId: z.string().min(1),
+      slotIndex: z.number().int().min(0).max(2).optional(),
       startDate: z.string().min(1),
       endDate: z.string().nullable().optional(),
       isActive: z.boolean().optional(),
@@ -30742,7 +30813,7 @@ module.exports = {
             : buildAttendanceAssignmentViewSql(viewAccess.scopes, rowParams, 'a')
           rowParams.push(pageSize, offset)
           const rows = await db.query(
-            `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.start_date, a.end_date, a.is_active,
+            `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
                     s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
                     s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
                     s.early_grace_minutes AS shift_early_grace_minutes, s.rounding_minutes AS shift_rounding_minutes,
@@ -30822,6 +30893,13 @@ module.exports = {
             res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Shift not found' } })
             return
           }
+          const settings = await getSettings(db)
+          const slotResolution = resolveAttendanceScheduleAssignmentSlotIndex(settings, parsed.data.slotIndex, 0)
+          if (!slotResolution.ok) {
+            res.status(slotResolution.status).json({ ok: false, error: { code: slotResolution.code, message: slotResolution.message } })
+            return
+          }
+          payload.slotIndex = slotResolution.slotIndex
 
           const result = await db.transaction(async (trx) => {
             await acquireAttendanceScheduleAssignmentLock(trx, orgId, payload.userId)
@@ -30832,19 +30910,23 @@ module.exports = {
               startDate: payload.startDate,
               endDate: payload.endDate,
               isActive: payload.isActive,
+              slotIndex: payload.slotIndex,
+              multiShiftEnabled: slotResolution.multiShiftDay.enabled,
+              shift: shiftRows[0],
             })
             if (conflict) return { conflict }
 
             const rows = await trx.query(
               `INSERT INTO attendance_shift_assignments
-               (id, org_id, user_id, shift_id, start_date, end_date, is_active)
-               VALUES ($1, $2, $3, $4, $5, $6, $7)
+               (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8)
                RETURNING *`,
               [
                 randomUUID(),
                 orgId,
                 payload.userId,
                 payload.shiftId,
+                payload.slotIndex,
                 payload.startDate,
                 payload.endDate,
                 payload.isActive,
@@ -30959,6 +31041,17 @@ module.exports = {
             res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Shift not found' } })
             return
           }
+          const settings = await getSettings(db)
+          const slotResolution = resolveAttendanceScheduleAssignmentSlotIndex(
+            settings,
+            parsed.data.slotIndex,
+            normalizeAttendanceScheduleSlotIndex(existing.slot_index, 0)
+          )
+          if (!slotResolution.ok) {
+            res.status(slotResolution.status).json({ ok: false, error: { code: slotResolution.code, message: slotResolution.message } })
+            return
+          }
+          payload.slotIndex = slotResolution.slotIndex
 
           const result = await db.transaction(async (trx) => {
             await acquireAttendanceScheduleAssignmentLock(trx, orgId, payload.userId)
@@ -30969,6 +31062,9 @@ module.exports = {
               startDate: payload.startDate,
               endDate: payload.endDate,
               isActive: payload.isActive,
+              slotIndex: payload.slotIndex,
+              multiShiftEnabled: slotResolution.multiShiftDay.enabled,
+              shift: shiftRows[0],
               excludeId: assignmentId,
             })
             if (conflict) return { conflict }
@@ -30977,9 +31073,10 @@ module.exports = {
               `UPDATE attendance_shift_assignments
                SET user_id = $3,
                    shift_id = $4,
-                   start_date = $5,
-                   end_date = $6,
-                   is_active = $7,
+                   slot_index = $5,
+                   start_date = $6,
+                   end_date = $7,
+                   is_active = $8,
                    updated_at = now()
                WHERE id = $1 AND org_id = $2
                RETURNING *`,
@@ -30988,6 +31085,7 @@ module.exports = {
                 orgId,
                 payload.userId,
                 payload.shiftId,
+                payload.slotIndex,
                 payload.startDate,
                 payload.endDate,
                 payload.isActive,


### PR DESCRIPTION
## Summary

M1 for the locked one-day multi-shift design:

- accept `slotIndex` / `slot_index` on manual shift assignment POST/PUT;
- persist `attendance_shift_assignments.slot_index` for manual assignments;
- keep `multiShiftDay.enabled=false` on the legacy one-shift conflict path, coercing requested slots back to `0`;
- when `multiShiftDay.enabled=true`, allow different slots only when the referenced shift time windows do not overlap;
- keep same-slot overlaps rejected and keep rotation assignments mutually exclusive with direct shift slots;
- return non-zero slots through the assignments list read path.

Scope held to M1. This PR does **not** implement effective-calendar `slots[]`, planned-minutes summing, fixed-schedule/auto-shift multi-slot support, UI, or staging closeout.

## Verification

- `node --check plugins/plugin-attendance/index.cjs`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-scheduling-assignment-conflict.test.ts --reporter=dot` → 22/22
- Scratch PostgreSQL migrated with CI's migration exclude set, then:
  - `DATABASE_URL=... ATTENDANCE_TEST_DATABASE_URL=... pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "multi-shift slot conflicts" --reporter=dot` → 1 selected test passed
  - `DATABASE_URL=... ATTENDANCE_TEST_DATABASE_URL=... pnpm --filter @metasheet/core-backend run test:integration:attendance` → 4 files, 115/115 passed
- `pnpm --filter @metasheet/core-backend exec vitest run --reporter=dot` was attempted twice: one clean pass earlier (319 files; 3719 passed / 245 skipped), later rerun hit unrelated multitable/xlsx socket reset failures. The attendance DB gate above is the relevant hard gate for this slice.

## Review notes closed before PR

- Assignment list read now selects `a.slot_index`; test asserts a moved slot `2` round-trips through `GET /api/attendance/assignments`.
- Test covers both rotation directions: direct rows block rotation, and a pre-existing rotation blocks direct slot creation while multi-shift is enabled.
- Settings cache staleness is existing module-level attendance settings behavior; `/settings` PUT refreshes the current process cache, and this PR does not attempt a multi-instance cache-invalidation redesign.
