### PR TITLE
feat(attendance): project multi-shift effective minutes

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -2452,6 +2452,15 @@ attendanceIntegrationDescribe(
       const defaultOffSecondRes = await createAssignment(defaultOffUserId, eveningShiftId, 1)
       expectShiftAssignmentConflict(defaultOffSecondRes)
 
+      const defaultOffEffectiveCalendarRes = await requestJson(
+        `${baseUrl}/api/attendance/effective-calendar?from=${workDate}&to=${workDate}&userId=${encodeURIComponent(defaultOffUserId)}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      expect(defaultOffEffectiveCalendarRes.status, JSON.stringify(defaultOffEffectiveCalendarRes.body)).toBe(200)
+      const defaultOffItem = ((defaultOffEffectiveCalendarRes.body as { data?: { items?: Array<{ effective?: { plannedMinutes?: number; slots?: unknown[] } }> } } | undefined)?.data?.items ?? [])[0]
+      expect(defaultOffItem?.effective?.plannedMinutes).toBeUndefined()
+      expect(defaultOffItem?.effective?.slots).toBeUndefined()
+
       await saveSettings({
         multiShiftDay: { enabled: true, maxSlots: 3 },
         shiftCompliance: { enforcement: 'warn', dailyMaxMinutes: null, weeklyMaxMinutes: null, monthlyMaxMinutes: null },

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -2387,7 +2387,7 @@ attendanceIntegrationDescribe(
       return res
     }
 
-    async function createShift(name: string, workStartTime: string, workEndTime: string): Promise<string> {
+    async function createShift(name: string, workStartTime: string, workEndTime: string, workingDays: number[] = [1, 2, 3, 4, 5]): Promise<string> {
       const shiftRes = await requestJson(`${baseUrl}/api/attendance/shifts`, {
         method: 'POST',
         headers,
@@ -2396,7 +2396,7 @@ attendanceIntegrationDescribe(
           timezone: 'Asia/Shanghai',
           workStartTime,
           workEndTime,
-          workingDays: [1, 2, 3, 4, 5],
+          workingDays,
         }),
       })
       expect(shiftRes.status, JSON.stringify(shiftRes.body)).toBe(201)
@@ -2406,12 +2406,12 @@ attendanceIntegrationDescribe(
       return shiftId
     }
 
-    async function createAssignment(userId: string, shiftId: string, slotIndex?: number) {
+    async function createAssignment(userId: string, shiftId: string, slotIndex?: number, date: string = workDate) {
       const body: Record<string, unknown> = {
         userId,
         shiftId,
-        startDate: workDate,
-        endDate: workDate,
+        startDate: date,
+        endDate: date,
         isActive: true,
       }
       if (slotIndex !== undefined) body.slotIndex = slotIndex
@@ -2483,6 +2483,91 @@ attendanceIntegrationDescribe(
         [multiSlotUserId, workDate]
       )
       expect(slotRows.rows.map(row => Number(row.slot_index))).toEqual([0, 1])
+
+      const effectiveCalendarRes = await requestJson(
+        `${baseUrl}/api/attendance/effective-calendar?from=${workDate}&to=${workDate}&userId=${encodeURIComponent(multiSlotUserId)}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      expect(effectiveCalendarRes.status, JSON.stringify(effectiveCalendarRes.body)).toBe(200)
+      const effectiveItems = (effectiveCalendarRes.body as { data?: { items?: Array<{ effective?: { plannedMinutes?: number; slots?: Array<{ slotIndex?: number; shiftId?: string; plannedMinutes?: number }> } }> } } | undefined)?.data?.items ?? []
+      expect(effectiveItems).toHaveLength(1)
+      const effectiveSlots = effectiveItems[0]?.effective?.slots ?? []
+      expect(effectiveSlots.map(slot => slot.slotIndex)).toEqual([0, 1])
+      expect(effectiveSlots.map(slot => slot.shiftId)).toEqual([morningShiftId, eveningShiftId])
+      expect(effectiveSlots.map(slot => slot.plannedMinutes)).toEqual([240, 240])
+      expect(effectiveItems[0]?.effective?.plannedMinutes).toBe(480)
+
+      const comprehensivePreviewRes = await requestJson(`${baseUrl}/api/attendance/comprehensive-hours/preview`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          metric: 'planned',
+          enforcement: 'warn',
+          capMinutes: 1000,
+          userId: multiSlotUserId,
+          period: { type: 'custom_range', from: workDate, to: workDate },
+        }),
+      })
+      expect(comprehensivePreviewRes.status, JSON.stringify(comprehensivePreviewRes.body)).toBe(200)
+      const comprehensiveRows = (comprehensivePreviewRes.body as { data?: { rows?: Array<{ userId?: string; minutes?: number; plannedMinutes?: number }> } } | undefined)?.data?.rows ?? []
+      expect(comprehensiveRows).toHaveLength(1)
+      expect(comprehensiveRows[0]?.userId).toBe(multiSlotUserId)
+      expect(comprehensiveRows[0]?.minutes).toBe(480)
+      expect(comprehensiveRows[0]?.plannedMinutes).toBe(480)
+
+      const saturdayDate = '2026-07-11'
+      const weekdayOnlyShiftId = await createShift(`Multi Shift Weekday Only ${runSuffix}`, '08:00', '12:00', [1, 2, 3, 4, 5])
+      const saturdayOnlyShiftId = await createShift(`Multi Shift Saturday Only ${runSuffix}`, '13:00', '17:00', [6])
+      const mixedWorkingDaysUserId = `${adminUserId}-mixed-days`
+      expect((await createAssignment(mixedWorkingDaysUserId, weekdayOnlyShiftId, 0, saturdayDate)).status).toBe(201)
+      expect((await createAssignment(mixedWorkingDaysUserId, saturdayOnlyShiftId, 1, saturdayDate)).status).toBe(201)
+
+      const mixedEffectiveCalendarRes = await requestJson(
+        `${baseUrl}/api/attendance/effective-calendar?from=${saturdayDate}&to=${saturdayDate}&userId=${encodeURIComponent(mixedWorkingDaysUserId)}`,
+        { headers: { Authorization: `Bearer ${token}` } }
+      )
+      expect(mixedEffectiveCalendarRes.status, JSON.stringify(mixedEffectiveCalendarRes.body)).toBe(200)
+      const mixedItem = ((mixedEffectiveCalendarRes.body as { data?: { items?: Array<{ effective?: { isWorkingDay?: boolean; plannedMinutes?: number; slots?: Array<{ slotIndex?: number; plannedMinutes?: number }> } }> } } | undefined)?.data?.items ?? [])[0]
+      expect(mixedItem?.effective?.isWorkingDay).toBe(true)
+      expect(mixedItem?.effective?.slots?.map(slot => slot.slotIndex)).toEqual([0, 1])
+      expect(mixedItem?.effective?.slots?.map(slot => slot.plannedMinutes)).toEqual([0, 240])
+      expect(mixedItem?.effective?.plannedMinutes).toBe(240)
+
+      const mixedComprehensivePreviewRes = await requestJson(`${baseUrl}/api/attendance/comprehensive-hours/preview`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          metric: 'planned',
+          enforcement: 'warn',
+          capMinutes: 1000,
+          userId: mixedWorkingDaysUserId,
+          period: { type: 'custom_range', from: saturdayDate, to: saturdayDate },
+        }),
+      })
+      expect(mixedComprehensivePreviewRes.status, JSON.stringify(mixedComprehensivePreviewRes.body)).toBe(200)
+      const mixedComprehensiveRows = (mixedComprehensivePreviewRes.body as { data?: { rows?: Array<{ minutes?: number; plannedMinutes?: number }> } } | undefined)?.data?.rows ?? []
+      expect(mixedComprehensiveRows[0]?.minutes).toBe(240)
+      expect(mixedComprehensiveRows[0]?.plannedMinutes).toBe(240)
+
+      await saveSettings({
+        multiShiftDay: { enabled: true, maxSlots: 3 },
+        shiftCompliance: { enforcement: 'block', dailyMaxMinutes: 300, weeklyMaxMinutes: null, monthlyMaxMinutes: null },
+      })
+      const dailyCapRes = await requestJson(`${baseUrl}/api/attendance/assignments/${eveningAssignment.id}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ slotIndex: 2 }),
+      })
+      expect(dailyCapRes.status, JSON.stringify(dailyCapRes.body)).toBe(422)
+      const dailyCapError = (dailyCapRes.body as { error?: { code?: string; granularity?: string; projectedMinutes?: number } } | undefined)?.error
+      expect(dailyCapError?.code).toBe('SHIFT_COMPLIANCE_CAP_EXCEEDED')
+      expect(dailyCapError?.granularity).toBe('daily')
+      expect(dailyCapError?.projectedMinutes).toBe(480)
+
+      await saveSettings({
+        multiShiftDay: { enabled: true, maxSlots: 3 },
+        shiftCompliance: { enforcement: 'warn', dailyMaxMinutes: null, weeklyMaxMinutes: null, monthlyMaxMinutes: null },
+      })
 
       expectShiftAssignmentConflict(await createAssignment(multiSlotUserId, eveningShiftId, 1))
       expectShiftAssignmentConflict(await createAssignment(multiSlotUserId, overlapShiftId, 2))

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -11480,7 +11480,8 @@ async function loadShiftAssignment(db, orgId, userId, workDate) {
   const targetOrg = orgId || DEFAULT_ORG_ID
   try {
     const rows = await db.query(
-      `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.start_date, a.end_date, a.is_active,
+      `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
+              a.created_at AS assignment_created_at,
               s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
               s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
               s.early_grace_minutes AS shift_early_grace_minutes, s.rounding_minutes AS shift_rounding_minutes,
@@ -11847,7 +11848,8 @@ async function loadShiftAssignmentMapForUsersRange(db, orgId, userIds, fromDate,
   if (!fromDate || !toDate) return new Map()
   try {
     const rows = await db.query(
-      `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.start_date, a.end_date, a.is_active,
+      `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
+              a.created_at AS assignment_created_at,
               s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
               s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
               s.early_grace_minutes AS shift_early_grace_minutes, s.rounding_minutes AS shift_rounding_minutes,
@@ -11870,6 +11872,7 @@ async function loadShiftAssignmentMapForUsersRange(db, orgId, userIds, fromDate,
       byUser.get(userId).push({
         assignment: mapAssignmentRow(row),
         shift: mapShiftFromAssignmentRow(row),
+        createdAt: row.assignment_created_at ?? null,
       })
     }
     return byUser
@@ -12678,15 +12681,16 @@ async function resolveEffectiveCalendar(db, args) {
   else if (args.groupId) mode = 'groupId'
   else mode = 'orgOnly'
 
+  const settings = await getSettings(db)
   let calendarPolicyOverrides
   if (Array.isArray(args.calendarPolicyOverrides)) {
     calendarPolicyOverrides = normalizeCalendarPolicyOverrides(args.calendarPolicyOverrides)
   } else {
-    const settings = await getSettings(db)
     calendarPolicyOverrides = Array.isArray(settings?.calendarPolicy?.overrides)
       ? settings.calendarPolicy.overrides
       : []
   }
+  const multiShiftDay = normalizeMultiShiftDaySetting(settings?.multiShiftDay)
   const defaultRule = await loadDefaultRule(db, orgId)
   const dates = enumerateAttendanceCalendarDateRange(from, to)
   const holidaysByDate = await loadHolidayMapByDates(db, orgId, dates)
@@ -12736,7 +12740,7 @@ async function resolveEffectiveCalendar(db, args) {
   if (mode === 'userId') {
     const firstDate = dates[0] ?? from
     const rotationInfo = resolveRotationInfoFromPrefetch(rotationByUser.get(args.userId), firstDate, rotationShiftsById)
-    const shiftInfo = resolveShiftAssignmentFromPrefetch(shiftAssignmentsByUser.get(args.userId), firstDate)
+    const shiftInfo = resolveShiftAssignmentFromPrefetch(shiftAssignmentsByUser.get(args.userId), firstDate, { multiShiftDay })
     firstDateRotation = rotationInfo?.rotation ?? null
     firstDateShift = rotationInfo?.shift ?? shiftInfo?.shift ?? null
   }
@@ -12772,16 +12776,21 @@ async function resolveEffectiveCalendar(db, args) {
     const weekday = getWeekdayFromDateKey(date)
     let profileSource = 'rule'
     let profile = groupRule ?? defaultRule
+    let directShiftSlots = []
 
     if (mode === 'userId') {
       const rotationInfo = resolveRotationInfoFromPrefetch(rotationByUser.get(args.userId), date, rotationShiftsById)
-      const shiftInfo = resolveShiftAssignmentFromPrefetch(shiftAssignmentsByUser.get(args.userId), date)
+      const shiftSlots = !rotationInfo?.shift
+        ? resolveShiftAssignmentsFromPrefetch(shiftAssignmentsByUser.get(args.userId), date, { multiShiftDay })
+        : []
+      const shiftInfo = shiftSlots.length > 0 ? shiftSlots[0] : null
       if (rotationInfo?.shift) {
         profile = rotationInfo.shift
         profileSource = 'rotation'
       } else if (shiftInfo?.shift) {
         profile = shiftInfo.shift
         profileSource = 'shift'
+        directShiftSlots = shiftSlots
       }
     }
 
@@ -12799,6 +12808,9 @@ async function resolveEffectiveCalendar(db, args) {
       })
     } else {
       base = buildCalendarBaseFromProfile(profile, weekday, profileSource)
+      if (profileSource === 'shift' && directShiftSlots.length > 0) {
+        base.isWorkingDay = directShiftSlots.some((entry) => isShiftAssignmentEntryWorkingOnDate(entry, date))
+      }
       layers.push({
         kind: 'base_rule',
         source: profileSource,
@@ -12859,6 +12871,16 @@ async function resolveEffectiveCalendar(db, args) {
     }
     if (effective.label) effectiveOut.label = effective.label
     if (effective.policyId) effectiveOut.policyId = effective.policyId
+    if (mode === 'userId') {
+      const dayWorkingOverride = holiday || policyWinner ? effective.isWorkingDay : null
+      const slots = profileSource === 'shift'
+        ? buildEffectiveCalendarShiftSlots(directShiftSlots, { workDate: date, dayWorkingOverride })
+        : []
+      effectiveOut.plannedMinutes = slots.length > 0
+        ? sumEffectiveCalendarShiftSlotMinutes(slots)
+        : (effective.isWorkingDay ? calculateAttendanceComprehensiveShiftPlannedMinutes(profile) : 0)
+      if (slots.length > 0) effectiveOut.slots = slots
+    }
 
     return {
       date,
@@ -12878,15 +12900,96 @@ async function resolveEffectiveCalendar(db, args) {
   }
 }
 
-function resolveShiftAssignmentFromPrefetch(entries, workDate) {
-  if (!Array.isArray(entries) || entries.length === 0) return null
+function getShiftAssignmentEntrySlotIndex(entry) {
+  return normalizeAttendanceScheduleSlotIndex(entry?.assignment?.slotIndex ?? entry?.assignment?.slot_index, 0)
+}
+
+function getShiftAssignmentEntryStartMinutes(entry) {
+  const startTime = normalizeTimeString(entry?.shift?.workStartTime ?? entry?.shift?.work_start_time)
+  const minutes = parseTimeToMinutes(startTime, null)
+  return Number.isFinite(minutes) ? minutes : Number.MAX_SAFE_INTEGER
+}
+
+function getShiftAssignmentEntryCreatedAtMs(entry) {
+  const value = entry?.createdAt ?? entry?.assignment?.createdAt ?? entry?.assignment?.created_at
+  if (!value) return Number.MAX_SAFE_INTEGER
+  const ms = new Date(value).getTime()
+  return Number.isFinite(ms) ? ms : Number.MAX_SAFE_INTEGER
+}
+
+function compareShiftAssignmentSlotEntries(left, right) {
+  const slotDiff = getShiftAssignmentEntrySlotIndex(left) - getShiftAssignmentEntrySlotIndex(right)
+  if (slotDiff !== 0) return slotDiff
+  const startDiff = getShiftAssignmentEntryStartMinutes(left) - getShiftAssignmentEntryStartMinutes(right)
+  if (startDiff !== 0) return startDiff
+  const createdDiff = getShiftAssignmentEntryCreatedAtMs(left) - getShiftAssignmentEntryCreatedAtMs(right)
+  if (createdDiff !== 0) return createdDiff
+  return String(left?.assignment?.id ?? '').localeCompare(String(right?.assignment?.id ?? ''))
+}
+
+function resolveShiftAssignmentsFromPrefetch(entries, workDate, options = {}) {
+  if (!Array.isArray(entries) || entries.length === 0) return []
+  const matches = []
   for (const entry of entries) {
     const startDate = entry?.assignment?.startDate
     const endDate = entry?.assignment?.endDate
     if (!startDate) continue
-    if (startDate <= workDate && (!endDate || endDate >= workDate)) return entry
+    if (startDate <= workDate && (!endDate || endDate >= workDate)) matches.push(entry)
   }
-  return null
+  if (matches.length === 0) return []
+  const multiShiftDay = normalizeMultiShiftDaySetting(options.multiShiftDay)
+  if (!multiShiftDay.enabled) return [matches[0]]
+  return matches.sort(compareShiftAssignmentSlotEntries)
+}
+
+function resolveShiftAssignmentFromPrefetch(entries, workDate, options = {}) {
+  const slots = resolveShiftAssignmentsFromPrefetch(entries, workDate, options)
+  return Array.isArray(slots) && slots.length > 0 ? slots[0] : null
+}
+
+function isAttendanceProfileWorkingOnDate(profile, workDate) {
+  const date = normalizeDateOnly(workDate)
+  const weekday = date ? getWeekdayFromDateKey(date) : null
+  return weekday != null && Array.isArray(profile?.workingDays) && profile.workingDays.includes(weekday)
+}
+
+function isShiftAssignmentEntryWorkingOnDate(entry, workDate) {
+  return isAttendanceProfileWorkingOnDate(entry?.shift, workDate)
+}
+
+function buildEffectiveCalendarShiftSlots(entries, options = {}) {
+  const slots = []
+  const dayWorkingOverride = typeof options.dayWorkingOverride === 'boolean'
+    ? options.dayWorkingOverride
+    : null
+  const workDate = normalizeDateOnly(options.workDate)
+  for (const entry of Array.isArray(entries) ? entries : []) {
+    const assignment = entry?.assignment
+    const shift = entry?.shift
+    if (!assignment || !shift) continue
+    const isWorkingDay = dayWorkingOverride !== null
+      ? dayWorkingOverride
+      : isShiftAssignmentEntryWorkingOnDate(entry, workDate)
+    const plannedMinutes = isWorkingDay ? calculateAttendanceComprehensiveShiftPlannedMinutes(shift) : 0
+    slots.push({
+      assignmentId: assignment.id,
+      slotIndex: getShiftAssignmentEntrySlotIndex(entry),
+      shiftId: shift.id ?? assignment.shiftId ?? assignment.shift_id ?? null,
+      shiftName: shift.name ?? null,
+      workStartTime: shift.workStartTime ?? shift.work_start_time ?? null,
+      workEndTime: shift.workEndTime ?? shift.work_end_time ?? null,
+      timezone: shift.timezone ?? null,
+      plannedMinutes,
+    })
+  }
+  return slots
+}
+
+function sumEffectiveCalendarShiftSlotMinutes(slots) {
+  return (Array.isArray(slots) ? slots : []).reduce((total, slot) => {
+    const minutes = Number(slot?.plannedMinutes ?? slot?.planned_minutes ?? 0)
+    return total + (Number.isFinite(minutes) ? Math.max(0, Math.floor(minutes)) : 0)
+  }, 0)
 }
 
 function resolveRotationInfoFromPrefetch(entries, workDate, shiftsById) {
@@ -12919,12 +13022,18 @@ function resolveWorkContextFromPrefetch(options) {
   const rotationInfo = userId
     ? resolveRotationInfoFromPrefetch(prefetched.rotationAssignmentsByUser?.get(userId), workDate, prefetched.rotationShiftsById)
     : null
-  const assignmentInfo = userId
-    ? resolveShiftAssignmentFromPrefetch(prefetched.shiftAssignmentsByUser?.get(userId), workDate)
+  const multiShiftDay = normalizeMultiShiftDaySetting(prefetched.multiShiftDay)
+  const assignmentSlots = userId && !rotationInfo
+    ? resolveShiftAssignmentsFromPrefetch(prefetched.shiftAssignmentsByUser?.get(userId), workDate, { multiShiftDay })
+    : []
+  const assignmentInfo = assignmentSlots.length > 0
+    ? assignmentSlots[0]
     : null
   const profile = rotationInfo?.shift ?? assignmentInfo?.shift ?? defaultRule
   const weekday = getWeekdayFromDateKey(workDate)
-  let isWorkingDay = profile.workingDays.includes(weekday)
+  let isWorkingDay = assignmentSlots.length > 0
+    ? assignmentSlots.some((entry) => isShiftAssignmentEntryWorkingOnDate(entry, workDate))
+    : profile.workingDays.includes(weekday)
   if (holiday) {
     isWorkingDay = holiday.isWorkingDay === true
   }
@@ -12952,6 +13061,14 @@ function resolveWorkContextFromPrefetch(options) {
       dateKey: workDate,
       mode: 'userId',
     })
+  }
+  if (!rotationInfo && assignmentSlots.length > 0) {
+    const dayWorkingOverride = holiday || context.policySource ? context.isWorkingDay : null
+    const slots = buildEffectiveCalendarShiftSlots(assignmentSlots, { workDate, dayWorkingOverride })
+    context.slots = slots
+    context.plannedMinutes = sumEffectiveCalendarShiftSlotMinutes(slots)
+  } else {
+    context.plannedMinutes = context.isWorkingDay ? calculateAttendanceComprehensiveShiftPlannedMinutes(context.rule) : 0
   }
   return context
 }
@@ -12982,6 +13099,7 @@ async function buildWorkContextPrefetch(db, options) {
         // policy applies) rather than triggering the "old fixture"
         // no-op branch unexpectedly.
         calendarPolicy: { overrides: [] },
+        multiShiftDay: normalizeMultiShiftDaySetting(),
         scopeContextByUser: new Map(),
       },
     }
@@ -13012,6 +13130,7 @@ async function buildWorkContextPrefetch(db, options) {
       rotationAssignmentsByUser: rotationPrefetch.assignmentsByUser,
       rotationShiftsById: rotationPrefetch.shiftsById,
       calendarPolicy: { overrides: calendarOverrides },
+      multiShiftDay: normalizeMultiShiftDaySetting(settings?.multiShiftDay),
       scopeContextByUser,
     },
   }
@@ -13204,6 +13323,20 @@ function isAttendanceComprehensiveDayWorking(day, profile) {
   return weekday != null && Array.isArray(profile?.workingDays) && profile.workingDays.includes(weekday)
 }
 
+function calculateAttendancePlannedMinutesFromWorkContext(context, fallbackProfile) {
+  if (!context) return 0
+  const explicitMinutes = normalizeAttendanceComprehensiveOptionalMinutes(
+    context.plannedMinutes,
+    context.planned_minutes,
+  )
+  if (explicitMinutes !== null) return explicitMinutes
+  if (Array.isArray(context.slots) && context.slots.length > 0) {
+    return sumEffectiveCalendarShiftSlotMinutes(context.slots)
+  }
+  const profile = context.rule && typeof context.rule === 'object' ? context.rule : fallbackProfile ?? DEFAULT_RULE
+  return context.isWorkingDay ? calculateAttendanceComprehensiveShiftPlannedMinutes(profile) : 0
+}
+
 function buildAttendanceComprehensivePlannedMinutesFromDays(days, options = {}) {
   const fallbackProfile = options.defaultRule ?? options.fallbackProfile ?? DEFAULT_RULE
   const items = []
@@ -13212,7 +13345,14 @@ function buildAttendanceComprehensivePlannedMinutesFromDays(days, options = {}) 
     const date = normalizeDateOnly(day?.date ?? day?.workDate ?? day?.work_date)
     const profile = resolveAttendanceComprehensiveDayProfile(day, fallbackProfile)
     const isWorkingDay = isAttendanceComprehensiveDayWorking(day, profile)
-    const explicitMinutes = normalizeAttendanceComprehensiveOptionalMinutes(day?.plannedMinutes, day?.planned_minutes)
+    const explicitMinutes = normalizeAttendanceComprehensiveOptionalMinutes(
+      day?.plannedMinutes,
+      day?.planned_minutes,
+      day?.effective?.plannedMinutes,
+      day?.effective?.planned_minutes,
+      day?.resolvedContext?.plannedMinutes,
+      day?.resolvedContext?.planned_minutes,
+    )
     const minutes = isWorkingDay
       ? explicitMinutes !== null
         ? explicitMinutes
@@ -13740,7 +13880,7 @@ async function projectExplicitScheduledMinutesByUser(db, orgId, userId, from, to
     // shift assignments too). Use the raw assignment refs — not `context.source` — so the calendarPolicy
     // override layer (which runs after `source` is set) can't flip the classification.
     if (!context || (!context.assignment && !context.rotationAssignment)) continue
-    const minutes = context.isWorkingDay ? calculateAttendanceComprehensiveShiftPlannedMinutes(context.rule) : 0
+    const minutes = calculateAttendancePlannedMinutesFromWorkContext(context, defaultRule)
     items.push({ date, plannedMinutes: minutes })
     total += minutes
   }

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -12871,7 +12871,7 @@ async function resolveEffectiveCalendar(db, args) {
     }
     if (effective.label) effectiveOut.label = effective.label
     if (effective.policyId) effectiveOut.policyId = effective.policyId
-    if (mode === 'userId') {
+    if (mode === 'userId' && multiShiftDay.enabled) {
       const dayWorkingOverride = holiday || policyWinner ? effective.isWorkingDay : null
       const slots = profileSource === 'shift'
         ? buildEffectiveCalendarShiftSlots(directShiftSlots, { workDate: date, dayWorkingOverride })


### PR DESCRIPTION
## Stack

Draft stacked PR. Do not merge before parent PR #2426 (`codex/attendance-multishift-m1-conflict-20260610`) lands.

Base: `codex/attendance-multishift-m1-conflict-20260610`
Head: `codex/attendance-multishift-m2-effective-calendar-20260610`

## Scope

M2 for the multi-shift-day design-lock:

- effective-calendar returns direct-shift `effective.slots[]` when `multiShiftDay.enabled=true`;
- `effective.plannedMinutes` sums all same-day direct slots;
- comprehensive-hours planned previews and shift-compliance cap projection reuse the same multi-slot planned-minute path;
- default-off behavior remains single assignment / existing shape compatible.

No UI, producer-path compatibility, or staging closeout in this slice.

## Verification

Local verification already run on the stacked branch:

- `node --check plugins/plugin-attendance/index.cjs`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/attendance-comprehensive-hours-control.test.ts tests/unit/attendance-scheduling-assignment-conflict.test.ts --reporter=dot` => 66/66
- real-DB targeted `attendance-plugin.test.ts -t "multi-shift slot conflicts"` => 1/1
- fresh-DB `pnpm --filter @metasheet/core-backend run test:integration:attendance` => 4 files / 115 tests

## Review

- Kant read-only review: APPROVE.
- Bernoulli found a P1 in the first implementation (per-slot working-days gating); fixed by applying working-days per slot while keeping holiday/calendar-policy override day-level. Bernoulli re-review: APPROVE.
