### PR TITLE
feat(attendance): keep producer schedules single-slot

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -2558,6 +2558,75 @@ attendanceIntegrationDescribe(
       expect(mixedComprehensiveRows[0]?.minutes).toBe(240)
       expect(mixedComprehensiveRows[0]?.plannedMinutes).toBe(240)
 
+      const fixedApplyUserId = `${adminUserId}-fixed-apply`
+      expect((await createAssignment(fixedApplyUserId, eveningShiftId, 1)).status).toBe(201)
+      const fixedGroupRes = await requestJson(`${baseUrl}/api/attendance/groups`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name: `multi-shift-fixed-${runSuffix}`,
+          timezone: 'Asia/Shanghai',
+          attendanceType: 'fixed_shift',
+          description: 'multi-shift fixed apply compatibility',
+        }),
+      })
+      expect(fixedGroupRes.status, JSON.stringify(fixedGroupRes.body)).toBe(200)
+      const fixedGroupId = (fixedGroupRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(fixedGroupId).toBeTruthy()
+      if (!fixedGroupId) return
+      const fixedMemberRes = await requestJson(`${baseUrl}/api/attendance/groups/${fixedGroupId}/members`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ userIds: [fixedApplyUserId] }),
+      })
+      expect(fixedMemberRes.status, JSON.stringify(fixedMemberRes.body)).toBe(200)
+
+      const fixedApplyRes = await requestJson(`${baseUrl}/api/attendance/groups/${fixedGroupId}/fixed-schedule/apply`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ shiftId: morningShiftId, startDate: workDate, endDate: workDate }),
+      })
+      expect(fixedApplyRes.status, JSON.stringify(fixedApplyRes.body)).toBe(201)
+      const fixedCreated = (fixedApplyRes.body as { data?: { created?: Array<{ slotIndex?: number; slot_index?: number; shiftId?: string; shift_id?: string }> } } | undefined)?.data?.created ?? []
+      expect(fixedCreated).toHaveLength(1)
+      expect(fixedCreated[0]?.slotIndex).toBe(0)
+      expect(fixedCreated[0]?.slot_index).toBe(0)
+      expect(fixedCreated[0]?.shiftId ?? fixedCreated[0]?.shift_id).toBe(morningShiftId)
+
+      const fixedRowsAfterApply = await pool.query(
+        `SELECT shift_id, slot_index
+           FROM attendance_shift_assignments
+          WHERE user_id = $1
+            AND start_date = $2::date
+            AND COALESCE(is_active, true) = true
+          ORDER BY slot_index ASC`,
+        [fixedApplyUserId, workDate],
+      )
+      expect(fixedRowsAfterApply.rows.map(row => ({ shiftId: row.shift_id, slotIndex: Number(row.slot_index) }))).toEqual([
+        { shiftId: morningShiftId, slotIndex: 0 },
+        { shiftId: eveningShiftId, slotIndex: 1 },
+      ])
+
+      const fixedRebuildRes = await requestJson(`${baseUrl}/api/attendance/groups/${fixedGroupId}/fixed-schedule/rebuild`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ shiftId: morningShiftId, startDate: workDate, endDate: workDate }),
+      })
+      expect(fixedRebuildRes.status, JSON.stringify(fixedRebuildRes.body)).toBe(200)
+      const fixedRowsAfterRebuild = await pool.query(
+        `SELECT shift_id, slot_index
+           FROM attendance_shift_assignments
+          WHERE user_id = $1
+            AND start_date = $2::date
+            AND COALESCE(is_active, true) = true
+          ORDER BY slot_index ASC`,
+        [fixedApplyUserId, workDate],
+      )
+      expect(fixedRowsAfterRebuild.rows.map(row => ({ shiftId: row.shift_id, slotIndex: Number(row.slot_index) }))).toEqual([
+        { shiftId: morningShiftId, slotIndex: 0 },
+        { shiftId: eveningShiftId, slotIndex: 1 },
+      ])
+
       await saveSettings({
         multiShiftDay: { enabled: true, maxSlots: 3 },
         shiftCompliance: { enforcement: 'block', dailyMaxMinutes: 300, weeklyMaxMinutes: null, monthlyMaxMinutes: null },
@@ -5611,7 +5680,7 @@ attendanceIntegrationDescribe(
         expect(applyData?.skipped).toHaveLength(0)
 
         const rows = await pool.query(
-          `SELECT shift_id, start_date, end_date, is_active, producer_type, producer_ref_id, producer_key, producer_run_id
+          `SELECT shift_id, slot_index, start_date, end_date, is_active, producer_type, producer_ref_id, producer_key, producer_run_id
              FROM attendance_shift_assignments
             WHERE org_id = $1 AND user_id = $2`,
           [orgId, userId],
@@ -5619,6 +5688,7 @@ attendanceIntegrationDescribe(
         expect(rows.rows).toHaveLength(1)
         expect(rows.rows[0]).toMatchObject({
           shift_id: candidateShiftId,
+          slot_index: 0,
           is_active: true,
           producer_type: 'auto_shift_match',
           producer_ref_id: applyData?.runId,
@@ -5642,6 +5712,52 @@ attendanceIntegrationDescribe(
           [orgId, userId],
         )
         expect(Number(countRows.rows[0]?.count ?? 0)).toBe(1)
+
+        await saveAutoShiftSettings(adminToken, {
+          multiShiftDay: { enabled: true, maxSlots: 3 },
+          autoShiftMatching: {
+            enabled: true,
+            mode: 'apply',
+            maxToleranceMinutes: 30,
+            minConfidenceToApply: 'high',
+          },
+        })
+        const blockedUserId = `attendance-autoshift-slot1-user-${runSuffix}`
+        await createGroupForAutoShift(adminToken, `autoshift-slot1-${runSuffix}`, 'scheduled_shift', blockedUserId)
+        await pool.query(
+          `INSERT INTO attendance_shift_assignments
+           (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active)
+           VALUES ($1, $2, $3, $4, 1, $5, $5, true)`,
+          [randomUuidV4(), orgId, blockedUserId, candidateShiftId, workDate],
+        )
+        const blockedApplyRes = await requestJson(`${baseUrl}/api/attendance/auto-shift-matching/apply`, {
+          method: 'POST',
+          headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            items: [
+              {
+                userId: blockedUserId,
+                workDate,
+                candidateShiftId,
+                evidence: { eventIds: [`blocked-evidence-${runSuffix}`] },
+              },
+            ],
+          }),
+        })
+        expect(blockedApplyRes.status).toBe(200)
+        const blockedApplyData = (blockedApplyRes.body as { data?: { applied?: any[]; skipped?: any[] } } | undefined)?.data
+        expect(blockedApplyData?.applied).toHaveLength(0)
+        expect(blockedApplyData?.skipped?.[0]).toMatchObject({ userId: blockedUserId, workDate, candidateShiftId, reason: 'already_scheduled' })
+        const blockedRows = await pool.query(
+          `SELECT slot_index, producer_type
+             FROM attendance_shift_assignments
+            WHERE org_id = $1 AND user_id = $2 AND start_date = $3::date
+            ORDER BY slot_index ASC`,
+          [orgId, blockedUserId, workDate],
+        )
+        expect(blockedRows.rows.map(row => ({ slotIndex: Number(row.slot_index), producerType: row.producer_type ?? null }))).toEqual([
+          { slotIndex: 1, producerType: null },
+        ])
       } finally {
         await saveAutoShiftSettings(adminToken, originalSettings).catch(() => undefined)
         if (previousFlag === undefined) delete process.env.ATTENDANCE_AUTO_SHIFT_MATCHING_ENABLED

--- a/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
@@ -334,6 +334,7 @@ describe('attendance scheduling assignment conflict guard', () => {
           { user_id: 'user-shift-conflict' },
           { user_id: 'user-rotation-conflict' },
         ])
+        .mockResolvedValueOnce([])
         .mockResolvedValueOnce([
           {
             id: 'assignment-skip',

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -9037,6 +9037,7 @@ function mapAttendanceGroupFixedScheduleSkipped(row, draft, producerKey) {
 function isExactAttendanceGroupFixedScheduleAssignment(row, draft) {
   return row?.kind !== 'rotation'
     && String(row?.shift_id || '') === String(draft.shiftId || '')
+    && normalizeAttendanceScheduleSlotIndex(row?.slot_index, 0) === normalizeAttendanceScheduleSlotIndex(draft.slotIndex, 0)
     && (normalizeDateOnly(row?.start_date) ?? row?.start_date) === draft.startDate
     && normalizeAttendanceScheduleAssignmentEndDate(row?.end_date) === normalizeAttendanceScheduleAssignmentEndDate(draft.endDate)
 }
@@ -9073,7 +9074,7 @@ async function acquireAttendanceScheduleAssignmentLocks(db, orgId, userIds) {
 async function loadAttendanceGroupFixedScheduleManagedRows(db, input) {
   const producerMetadata = buildAttendanceGroupFixedScheduleProducerMetadata(input, '00000000-0000-4000-8000-000000000000')
   return db.query(
-    `SELECT id, user_id, shift_id, start_date, end_date, is_active, producer_type, producer_ref_id, producer_key, producer_run_id, 'shift'::text AS kind
+    `SELECT id, user_id, shift_id, slot_index, start_date, end_date, is_active, producer_type, producer_ref_id, producer_key, producer_run_id, 'shift'::text AS kind
        FROM attendance_shift_assignments
       WHERE org_id = $1
         AND producer_type = $2
@@ -9149,15 +9150,22 @@ async function buildAttendanceGroupFixedSchedulePlan(db, input, options = {}) {
 
   const producerKey = buildAttendanceGroupFixedScheduleProducerKey(input)
   const overlapEndDate = normalizeAttendanceScheduleAssignmentEndDate(input.endDate) || ATTENDANCE_SCHEDULE_OPEN_END_DATE
+  const settings = await getSettings(db).catch(() => null)
+  const multiShiftDay = normalizeMultiShiftDaySetting(settings?.multiShiftDay)
+  const shift = mapShiftRow(shiftRows[0])
   const shiftOverlapRows = await db.query(
-    `SELECT id, user_id, shift_id, start_date, end_date, producer_type, producer_ref_id, producer_key, producer_run_id, 'shift'::text AS kind
-       FROM attendance_shift_assignments
-      WHERE org_id = $1
-        AND user_id = ANY($2::text[])
-        AND COALESCE(is_active, true) = true
-        AND start_date <= $4::date
-        AND COALESCE(end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
-      ORDER BY user_id ASC, start_date DESC, created_at DESC`,
+    `SELECT a.id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date,
+            a.producer_type, a.producer_ref_id, a.producer_key, a.producer_run_id,
+            'shift'::text AS kind,
+            s.work_start_time, s.work_end_time, s.is_overnight
+       FROM attendance_shift_assignments a
+       LEFT JOIN attendance_shifts s ON s.id = a.shift_id AND s.org_id = a.org_id
+      WHERE a.org_id = $1
+        AND a.user_id = ANY($2::text[])
+        AND COALESCE(a.is_active, true) = true
+        AND a.start_date <= $4::date
+        AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
+      ORDER BY a.user_id ASC, a.start_date DESC, a.created_at DESC`,
     [input.orgId, userIds, input.startDate, overlapEndDate]
   )
   const rotationOverlapRows = await db.query(
@@ -9197,10 +9205,22 @@ async function buildAttendanceGroupFixedSchedulePlan(db, input, options = {}) {
       shiftId: input.shiftId,
       startDate: input.startDate,
       endDate: input.endDate ?? null,
+      slotIndex: 0,
+      multiShiftEnabled: multiShiftDay.enabled,
+      shift,
       isActive: true,
     }
     const overlaps = overlapsByUserId.get(userId) ?? []
-    const blockingRow = overlaps.find(row => !isExactAttendanceGroupFixedScheduleAssignment(row, draft))
+    const blockingRow = overlaps.find((row) => {
+      if (isExactAttendanceGroupFixedScheduleAssignment(row, draft)) return false
+      if (multiShiftDay.enabled && row?.kind !== 'rotation') {
+        const existingSlotIndex = normalizeAttendanceScheduleSlotIndex(row?.slot_index, 0)
+        if (existingSlotIndex !== 0 && !attendanceShiftWindowsOverlapForSlotConflict(row, shift)) {
+          return false
+        }
+      }
+      return true
+    })
     if (blockingRow) {
       const conflict = mapAttendanceGroupFixedScheduleBlockingConflict(blockingRow, draft)
       if (conflict) blockingConflicts.push(conflict)
@@ -9250,8 +9270,8 @@ async function insertAttendanceGroupFixedScheduleAssignments(db, input, items, p
   for (const item of items) {
     const rows = await db.query(
       `INSERT INTO attendance_shift_assignments
-       (id, org_id, user_id, shift_id, start_date, end_date, is_active, producer_type, producer_ref_id, producer_key, producer_run_id)
-       VALUES ($1, $2, $3, $4, $5, $6, true, $7, $8, $9, $10)
+       (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active, producer_type, producer_ref_id, producer_key, producer_run_id)
+       VALUES ($1, $2, $3, $4, 0, $5, $6, true, $7, $8, $9, $10)
        RETURNING *`,
       [
         randomUUID(),
@@ -30802,6 +30822,8 @@ module.exports = {
                 userId: item.userId,
                 startDate: item.workDate,
                 endDate: item.workDate,
+                slotIndex: 0,
+                multiShiftEnabled: false,
                 isActive: true,
               })
               if (conflict) {
@@ -30841,8 +30863,8 @@ module.exports = {
 
               const assignmentRows = await trx.query(
                 `INSERT INTO attendance_shift_assignments
-                 (id, org_id, user_id, shift_id, start_date, end_date, is_active, producer_type, producer_ref_id, producer_key, producer_run_id)
-                 VALUES ($1, $2, $3, $4, $5, $5, true, $6, $7, $8, $7)
+                 (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active, producer_type, producer_ref_id, producer_key, producer_run_id)
+                 VALUES ($1, $2, $3, $4, 0, $5, $5, true, $6, $7, $8, $7)
                  RETURNING *`,
                 [
                   randomUUID(),


### PR DESCRIPTION
## Stack

Draft stacked PR. Do not merge before parent M2 lands.

Base: `codex/attendance-multishift-m2-effective-calendar-20260610`
Head: `codex/attendance-multishift-m3-producer-guards-20260610`

## Scope

M3 for the multi-shift-day design-lock:

- fixed-schedule apply/rebuild writes and manages only `slotIndex=0`;
- fixed-schedule rebuild does not delete/overwrite an existing compatible non-zero slot;
- fixed-schedule still blocks same-slot, overlapping-shift, and rotation conflicts;
- auto-shift A1 stays single-slot: it writes `slot_index=0` and skips `already_scheduled` when any active direct/rotation assignment covers the user/day;
- no UI, staging, or broader producer redesign in this slice.

## Verification

Local verification already run on the stacked branch:

- `node --check plugins/plugin-attendance/index.cjs`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/attendance-comprehensive-hours-control.test.ts tests/unit/attendance-scheduling-assignment-conflict.test.ts --reporter=dot` => 66/66
- real-DB targeted `attendance-plugin.test.ts -t "multi-shift slot conflicts"` => 1/1
- fresh-DB `pnpm --filter @metasheet/core-backend run test:integration:attendance` => 4 files / 115 tests

## Review

Kant read-only review: APPROVE, no P1/P2 findings.
