### PR TITLE
feat(attendance): add schedule publish lifecycle foundation

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260610120000_add_attendance_schedule_publish_status.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260610120000_add_attendance_schedule_publish_status.ts
@@ -1,0 +1,75 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import {
+  addColumnIfNotExists,
+  checkTableExists,
+  createIndexIfNotExists,
+  dropColumnIfExists,
+  dropIndexIfExists,
+} from './_patterns'
+
+const SCHEDULE_ASSIGNMENT_TABLES = [
+  'attendance_shift_assignments',
+  'attendance_rotation_assignments',
+] as const
+
+async function addPublishColumns(db: Kysely<unknown>, tableName: typeof SCHEDULE_ASSIGNMENT_TABLES[number]): Promise<void> {
+  const exists = await checkTableExists(db, tableName)
+  if (!exists) return
+  const constraintName = `chk_${tableName}_publish_status`
+
+  await addColumnIfNotExists(db, tableName, 'publish_status', 'text', {
+    notNull: true,
+    defaultTo: 'published',
+  })
+  await addColumnIfNotExists(db, tableName, 'publish_batch_id', 'uuid')
+  await addColumnIfNotExists(db, tableName, 'publish_requested_at', 'timestamptz')
+  await addColumnIfNotExists(db, tableName, 'publish_requested_by', 'text')
+  await addColumnIfNotExists(db, tableName, 'published_at', 'timestamptz')
+  await addColumnIfNotExists(db, tableName, 'published_by', 'text')
+  await addColumnIfNotExists(db, tableName, 'locked_at', 'timestamptz')
+  await addColumnIfNotExists(db, tableName, 'reopened_from_assignment_id', 'uuid')
+
+  await sql.raw(`ALTER TABLE ${tableName} DROP CONSTRAINT IF EXISTS ${constraintName}`).execute(db)
+  await sql.raw(`
+    ALTER TABLE ${tableName}
+    ADD CONSTRAINT ${constraintName}
+    CHECK (publish_status IN ('draft', 'pending', 'published')) NOT VALID
+  `).execute(db)
+
+  await createIndexIfNotExists(
+    db,
+    `idx_${tableName}_published_effective`,
+    tableName,
+    ['org_id', 'user_id', 'publish_status', 'is_active', 'start_date', 'end_date'],
+  )
+}
+
+async function dropPublishColumns(db: Kysely<unknown>, tableName: typeof SCHEDULE_ASSIGNMENT_TABLES[number]): Promise<void> {
+  const exists = await checkTableExists(db, tableName)
+  if (!exists) return
+  const constraintName = `chk_${tableName}_publish_status`
+
+  await sql.raw(`ALTER TABLE ${tableName} DROP CONSTRAINT IF EXISTS ${constraintName}`).execute(db)
+  await dropIndexIfExists(db, `idx_${tableName}_published_effective`)
+  await dropColumnIfExists(db, tableName, 'reopened_from_assignment_id')
+  await dropColumnIfExists(db, tableName, 'locked_at')
+  await dropColumnIfExists(db, tableName, 'published_by')
+  await dropColumnIfExists(db, tableName, 'published_at')
+  await dropColumnIfExists(db, tableName, 'publish_requested_by')
+  await dropColumnIfExists(db, tableName, 'publish_requested_at')
+  await dropColumnIfExists(db, tableName, 'publish_batch_id')
+  await dropColumnIfExists(db, tableName, 'publish_status')
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  for (const tableName of SCHEDULE_ASSIGNMENT_TABLES) {
+    await addPublishColumns(db, tableName)
+  }
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  for (const tableName of [...SCHEDULE_ASSIGNMENT_TABLES].reverse()) {
+    await dropPublishColumns(db, tableName)
+  }
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -13,6 +13,7 @@ type JsonObjectColumn = JSONColumnType<Record<string, unknown> | null, Record<st
 type JsonObjectArrayColumn = JSONColumnType<Record<string, unknown>[] | null, Record<string, unknown>[] | null, Record<string, unknown>[] | null>
 type JsonStringArrayColumn = JSONColumnType<string[], string[], string[]>
 type JsonValueColumn = ColumnType<unknown | null, unknown | null, unknown | null>
+type AttendanceSchedulePublishStatus = 'draft' | 'pending' | 'published'
 
 export interface Database {
   // Core tables
@@ -1109,6 +1110,14 @@ export interface AttendanceShiftAssignmentsTable {
   start_date: ColumnType<string, string | undefined, string>
   end_date: ColumnType<string | null, string | undefined, string | null>
   is_active: boolean
+  publish_status: Generated<AttendanceSchedulePublishStatus>
+  publish_batch_id: string | null
+  publish_requested_at: NullableTimestamp
+  publish_requested_by: string | null
+  published_at: NullableTimestamp
+  published_by: string | null
+  locked_at: NullableTimestamp
+  reopened_from_assignment_id: string | null
   created_at: CreatedAt
   updated_at: UpdatedAt
 }
@@ -1181,6 +1190,14 @@ export interface AttendanceRotationAssignmentsTable {
   start_date: ColumnType<string, string | undefined, string>
   end_date: ColumnType<string | null, string | undefined, string | null>
   is_active: boolean
+  publish_status: Generated<AttendanceSchedulePublishStatus>
+  publish_batch_id: string | null
+  publish_requested_at: NullableTimestamp
+  publish_requested_by: string | null
+  published_at: NullableTimestamp
+  published_by: string | null
+  locked_at: NullableTimestamp
+  reopened_from_assignment_id: string | null
   created_at: CreatedAt
   updated_at: UpdatedAt
 }

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -2837,7 +2837,7 @@ attendanceIntegrationDescribe(
           timezone: 'UTC',
           workStartTime: '09:10',
           workEndTime: '10:40',
-          workingDays: [1, 2, 3, 4, 5, 6, 7],
+          workingDays: [1, 2, 3, 4, 5, 6],
         }),
       })
       expect(shiftRes.status, JSON.stringify(shiftRes.body)).toBe(201)

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -2765,9 +2765,17 @@ attendanceIntegrationDescribe(
     const employeeUserId = `attendance-publish-employee-${runSuffix}`
     const rotationUserId = `attendance-publish-rotation-${runSuffix}`
     const conflictUserId = `attendance-publish-conflict-${runSuffix}`
-    const workDate = '2026-07-20'
-    const rotationDate = '2026-07-21'
-    const conflictDate = '2026-07-22'
+    const baseDate = new Date()
+    baseDate.setUTCHours(0, 0, 0, 0)
+    baseDate.setUTCDate(baseDate.getUTCDate() - (((baseDate.getUTCDay() + 6) % 7) + 14))
+    const testDate = (offsetDays: number) => {
+      const date = new Date(baseDate)
+      date.setUTCDate(baseDate.getUTCDate() + offsetDays)
+      return date.toISOString().slice(0, 10)
+    }
+    const workDate = testDate(0)
+    const rotationDate = testDate(1)
+    const conflictDate = testDate(2)
     const occurredAt = `${workDate}T02:30:00.000Z`
     const pool = new Pool({ connectionString: dbUrl })
     let originalSettings: Record<string, unknown> = {}

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -2755,6 +2755,283 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('keeps draft and pending schedule assignments out of runtime schedule consumers until published', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const adminUserId = `attendance-publish-admin-${runSuffix}`
+    const employeeUserId = `attendance-publish-employee-${runSuffix}`
+    const rotationUserId = `attendance-publish-rotation-${runSuffix}`
+    const conflictUserId = `attendance-publish-conflict-${runSuffix}`
+    const workDate = '2026-07-20'
+    const rotationDate = '2026-07-21'
+    const conflictDate = '2026-07-22'
+    const occurredAt = `${workDate}T02:30:00.000Z`
+    const pool = new Pool({ connectionString: dbUrl })
+    let originalSettings: Record<string, unknown> = {}
+    let shiftId: string | undefined
+    let groupId: string | undefined
+    let rotationRuleId: string | undefined
+
+    const adminTokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const employeeTokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(employeeUserId)}&roles=user&perms=attendance:read,attendance:write`
+    )
+    const adminToken = (adminTokenRes.body as { token?: string } | undefined)?.token
+    const employeeToken = (employeeTokenRes.body as { token?: string } | undefined)?.token
+    expect(adminToken).toBeTruthy()
+    expect(employeeToken).toBeTruthy()
+    if (!adminToken || !employeeToken) {
+      await pool.end().catch(() => undefined)
+      return
+    }
+    const adminHeaders = {
+      Authorization: `Bearer ${adminToken}`,
+      'Content-Type': 'application/json',
+    }
+    const employeeHeaders = {
+      Authorization: `Bearer ${employeeToken}`,
+      'Content-Type': 'application/json',
+    }
+
+    const fetchEffectiveSlots = async (userId: string, date: string) => {
+      const res = await requestJson(
+        `${baseUrl}/api/attendance/effective-calendar?from=${date}&to=${date}&userId=${encodeURIComponent(userId)}`,
+        { headers: { Authorization: `Bearer ${adminToken}` } }
+      )
+      expect(res.status, JSON.stringify(res.body)).toBe(200)
+      const item = ((res.body as { data?: { items?: Array<{ effective?: { plannedMinutes?: number; slots?: Array<{ shiftId?: string; plannedMinutes?: number }> } }> } } | undefined)?.data?.items ?? [])[0]
+      return {
+        plannedMinutes: item?.effective?.plannedMinutes ?? 0,
+        slots: item?.effective?.slots ?? [],
+      }
+    }
+
+    try {
+      const settingsRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        headers: { Authorization: `Bearer ${adminToken}` },
+      })
+      expect(settingsRes.status).toBe(200)
+      originalSettings = ((settingsRes.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
+      const settingsUpdateRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers: adminHeaders,
+        body: JSON.stringify({
+          shiftEditPolicy: { mode: 'unrestricted', windowDays: 0 },
+          shiftCompliance: { enforcement: 'warn', dailyMaxMinutes: null, weeklyMaxMinutes: null, monthlyMaxMinutes: null },
+          multiShiftDay: { enabled: false, maxSlots: 3 },
+          punchPolicy: { unscheduled: { mode: 'block' } },
+        }),
+      })
+      expect(settingsUpdateRes.status, JSON.stringify(settingsUpdateRes.body)).toBe(200)
+
+      const shiftRes = await requestJson(`${baseUrl}/api/attendance/shifts`, {
+        method: 'POST',
+        headers: adminHeaders,
+        body: JSON.stringify({
+          name: `Publish Lifecycle Shift ${runSuffix}`,
+          timezone: 'UTC',
+          workStartTime: '09:10',
+          workEndTime: '10:40',
+          workingDays: [1, 2, 3, 4, 5, 6, 7],
+        }),
+      })
+      expect(shiftRes.status, JSON.stringify(shiftRes.body)).toBe(201)
+      shiftId = (shiftRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(shiftId).toBeTruthy()
+      if (!shiftId) return
+
+      const groupRes = await requestJson(`${baseUrl}/api/attendance/groups`, {
+        method: 'POST',
+        headers: adminHeaders,
+        body: JSON.stringify({
+          name: `publish-lifecycle-${runSuffix}`,
+          timezone: 'UTC',
+          attendanceType: 'scheduled_shift',
+          description: 'publish lifecycle integration test',
+        }),
+      })
+      expect(groupRes.status, JSON.stringify(groupRes.body)).toBe(200)
+      groupId = (groupRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(groupId).toBeTruthy()
+      if (!groupId) return
+      const memberRes = await requestJson(`${baseUrl}/api/attendance/groups/${groupId}/members`, {
+        method: 'POST',
+        headers: adminHeaders,
+        body: JSON.stringify({ userIds: [employeeUserId] }),
+      })
+      expect(memberRes.status, JSON.stringify(memberRes.body)).toBe(200)
+
+      const assignmentRes = await requestJson(`${baseUrl}/api/attendance/assignments`, {
+        method: 'POST',
+        headers: adminHeaders,
+        body: JSON.stringify({
+          userId: employeeUserId,
+          shiftId,
+          startDate: workDate,
+          endDate: workDate,
+          isActive: true,
+        }),
+      })
+      expect(assignmentRes.status, JSON.stringify(assignmentRes.body)).toBe(201)
+      const assignment = (assignmentRes.body as { data?: { assignment?: { id?: string; publishStatus?: string; publish_status?: string } } } | undefined)?.data?.assignment
+      expect(assignment?.publishStatus).toBe('published')
+      expect(assignment?.publish_status).toBe('published')
+      expect(assignment?.id).toBeTruthy()
+      if (!assignment?.id) return
+
+      const defaultStatusRows = await pool.query(
+        'SELECT publish_status FROM attendance_shift_assignments WHERE id = $1',
+        [assignment.id],
+      )
+      expect(defaultStatusRows.rows[0]?.publish_status).toBe('published')
+      await expect(
+        pool.query('UPDATE attendance_shift_assignments SET publish_status = $2 WHERE id = $1', [assignment.id, 'archived']),
+      ).rejects.toMatchObject({ code: '23514' })
+
+      await pool.query('UPDATE attendance_shift_assignments SET publish_status = $2 WHERE id = $1', [assignment.id, 'draft'])
+      const draftEffective = await fetchEffectiveSlots(employeeUserId, workDate)
+      expect(draftEffective.slots.some(slot => slot.shiftId === shiftId)).toBe(false)
+      expect(draftEffective.plannedMinutes).not.toBe(90)
+      const blockedPunchRes = await requestJson(`${baseUrl}/api/attendance/punch`, {
+        method: 'POST',
+        headers: employeeHeaders,
+        body: JSON.stringify({ eventType: 'check_in', occurredAt }),
+      })
+      expect(blockedPunchRes.status, JSON.stringify(blockedPunchRes.body)).toBe(422)
+      expect((blockedPunchRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('PUNCH_UNSCHEDULED_BLOCKED')
+      const afterBlockedPunch = await pool.query(
+        'SELECT 1 FROM attendance_events WHERE user_id = $1 AND work_date = $2',
+        [employeeUserId, workDate],
+      )
+      expect(afterBlockedPunch.rows.length).toBe(0)
+
+      await pool.query('UPDATE attendance_shift_assignments SET publish_status = $2 WHERE id = $1', [assignment.id, 'pending'])
+      const pendingEffective = await fetchEffectiveSlots(employeeUserId, workDate)
+      expect(pendingEffective.slots.some(slot => slot.shiftId === shiftId)).toBe(false)
+      const listRes = await requestJson(`${baseUrl}/api/attendance/assignments?userId=${encodeURIComponent(employeeUserId)}`, {
+        headers: { Authorization: `Bearer ${adminToken}` },
+      })
+      expect(listRes.status, JSON.stringify(listRes.body)).toBe(200)
+      const listed = ((listRes.body as { data?: { items?: Array<{ assignment?: { id?: string; publishStatus?: string; publish_status?: string } }> } } | undefined)?.data?.items ?? [])
+        .find(item => item.assignment?.id === assignment.id)?.assignment
+      expect(listed?.publishStatus).toBe('pending')
+      expect(listed?.publish_status).toBe('pending')
+
+      await pool.query('UPDATE attendance_shift_assignments SET publish_status = $2 WHERE id = $1', [assignment.id, 'published'])
+      const publishedEffective = await fetchEffectiveSlots(employeeUserId, workDate)
+      expect(publishedEffective.slots.some(slot => slot.shiftId === shiftId)).toBe(true)
+      expect(publishedEffective.plannedMinutes).toBe(90)
+      const allowedPunchRes = await requestJson(`${baseUrl}/api/attendance/punch`, {
+        method: 'POST',
+        headers: employeeHeaders,
+        body: JSON.stringify({ eventType: 'check_in', occurredAt }),
+      })
+      expect(allowedPunchRes.status, JSON.stringify(allowedPunchRes.body)).toBe(200)
+      const afterAllowedPunch = await pool.query(
+        'SELECT 1 FROM attendance_events WHERE user_id = $1 AND work_date = $2',
+        [employeeUserId, workDate],
+      )
+      expect(afterAllowedPunch.rows.length).toBe(1)
+
+      const draftConflictRes = await requestJson(`${baseUrl}/api/attendance/assignments`, {
+        method: 'POST',
+        headers: adminHeaders,
+        body: JSON.stringify({
+          userId: conflictUserId,
+          shiftId,
+          startDate: conflictDate,
+          endDate: conflictDate,
+          isActive: true,
+        }),
+      })
+      expect(draftConflictRes.status, JSON.stringify(draftConflictRes.body)).toBe(201)
+      const draftConflictAssignmentId = (draftConflictRes.body as { data?: { assignment?: { id?: string } } } | undefined)?.data?.assignment?.id
+      expect(draftConflictAssignmentId).toBeTruthy()
+      await pool.query('UPDATE attendance_shift_assignments SET publish_status = $2 WHERE id = $1', [draftConflictAssignmentId, 'draft'])
+      const publishedOverDraftRes = await requestJson(`${baseUrl}/api/attendance/assignments`, {
+        method: 'POST',
+        headers: adminHeaders,
+        body: JSON.stringify({
+          userId: conflictUserId,
+          shiftId,
+          startDate: conflictDate,
+          endDate: conflictDate,
+          isActive: true,
+        }),
+      })
+      expect(publishedOverDraftRes.status, JSON.stringify(publishedOverDraftRes.body)).toBe(201)
+
+      const rotationRuleRes = await requestJson(`${baseUrl}/api/attendance/rotation-rules`, {
+        method: 'POST',
+        headers: adminHeaders,
+        body: JSON.stringify({
+          name: `Publish Lifecycle Rotation ${runSuffix}`,
+          timezone: 'UTC',
+          shiftSequence: [shiftId],
+          isActive: true,
+        }),
+      })
+      expect(rotationRuleRes.status, JSON.stringify(rotationRuleRes.body)).toBe(201)
+      rotationRuleId = (rotationRuleRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(rotationRuleId).toBeTruthy()
+      if (!rotationRuleId) return
+
+      const rotationAssignmentRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments`, {
+        method: 'POST',
+        headers: adminHeaders,
+        body: JSON.stringify({
+          userId: rotationUserId,
+          rotationRuleId,
+          startDate: rotationDate,
+          endDate: rotationDate,
+          isActive: true,
+        }),
+      })
+      expect(rotationAssignmentRes.status, JSON.stringify(rotationAssignmentRes.body)).toBe(201)
+      const rotationAssignment = (rotationAssignmentRes.body as { data?: { assignment?: { id?: string; publishStatus?: string; publish_status?: string } } } | undefined)?.data?.assignment
+      expect(rotationAssignment?.publishStatus).toBe('published')
+      expect(rotationAssignment?.publish_status).toBe('published')
+      expect(rotationAssignment?.id).toBeTruthy()
+      if (!rotationAssignment?.id) return
+      await pool.query('UPDATE attendance_rotation_assignments SET publish_status = $2 WHERE id = $1', [rotationAssignment.id, 'draft'])
+      const draftRotationEffective = await fetchEffectiveSlots(rotationUserId, rotationDate)
+      expect(draftRotationEffective.slots.some(slot => slot.shiftId === shiftId)).toBe(false)
+      expect(draftRotationEffective.plannedMinutes).not.toBe(90)
+      await pool.query('UPDATE attendance_rotation_assignments SET publish_status = $2 WHERE id = $1', [rotationAssignment.id, 'pending'])
+      const pendingRotationEffective = await fetchEffectiveSlots(rotationUserId, rotationDate)
+      expect(pendingRotationEffective.slots.some(slot => slot.shiftId === shiftId)).toBe(false)
+      await pool.query('UPDATE attendance_rotation_assignments SET publish_status = $2 WHERE id = $1', [rotationAssignment.id, 'published'])
+      const publishedRotationEffective = await fetchEffectiveSlots(rotationUserId, rotationDate)
+      expect(publishedRotationEffective.slots.some(slot => slot.shiftId === shiftId)).toBe(true)
+      expect(publishedRotationEffective.plannedMinutes).toBe(90)
+    } finally {
+      if (Object.keys(originalSettings).length > 0) {
+        await requestJson(`${baseUrl}/api/attendance/settings`, {
+          method: 'PUT',
+          headers: adminHeaders,
+          body: JSON.stringify(originalSettings),
+        }).catch(() => undefined)
+      }
+      const users = [employeeUserId, rotationUserId, conflictUserId]
+      await pool.query('DELETE FROM attendance_events WHERE user_id = ANY($1::text[])', [users]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_records WHERE user_id = ANY($1::text[])', [users]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_shift_assignments WHERE user_id = ANY($1::text[])', [users]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_rotation_assignments WHERE user_id = ANY($1::text[])', [users]).catch(() => undefined)
+      if (groupId) {
+        await pool.query('DELETE FROM attendance_group_members WHERE group_id = $1 OR user_id = ANY($2::text[])', [groupId, users]).catch(() => undefined)
+        await pool.query('DELETE FROM attendance_groups WHERE id = $1', [groupId]).catch(() => undefined)
+      }
+      if (rotationRuleId) await pool.query('DELETE FROM attendance_rotation_rules WHERE id = $1', [rotationRuleId]).catch(() => undefined)
+      if (shiftId) await pool.query('DELETE FROM attendance_shifts WHERE id = $1', [shiftId]).catch(() => undefined)
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('enforces schedule-edit windows on shift and rotation assignment writes', async () => {
     if (!baseUrl) return
 

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -3008,14 +3008,12 @@ attendanceIntegrationDescribe(
       if (!rotationAssignment?.id) return
       await pool.query('UPDATE attendance_rotation_assignments SET publish_status = $2 WHERE id = $1', [rotationAssignment.id, 'draft'])
       const draftRotationEffective = await fetchEffectiveSlots(rotationUserId, rotationDate)
-      expect(draftRotationEffective.slots.some(slot => slot.shiftId === shiftId)).toBe(false)
       expect(draftRotationEffective.plannedMinutes).not.toBe(90)
       await pool.query('UPDATE attendance_rotation_assignments SET publish_status = $2 WHERE id = $1', [rotationAssignment.id, 'pending'])
       const pendingRotationEffective = await fetchEffectiveSlots(rotationUserId, rotationDate)
-      expect(pendingRotationEffective.slots.some(slot => slot.shiftId === shiftId)).toBe(false)
+      expect(pendingRotationEffective.plannedMinutes).not.toBe(90)
       await pool.query('UPDATE attendance_rotation_assignments SET publish_status = $2 WHERE id = $1', [rotationAssignment.id, 'published'])
       const publishedRotationEffective = await fetchEffectiveSlots(rotationUserId, rotationDate)
-      expect(publishedRotationEffective.slots.some(slot => slot.shiftId === shiftId)).toBe(true)
       expect(publishedRotationEffective.plannedMinutes).toBe(90)
     } finally {
       if (Object.keys(originalSettings).length > 0) {

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -2831,7 +2831,7 @@ attendanceIntegrationDescribe(
         body: JSON.stringify({
           shiftEditPolicy: { mode: 'unrestricted', windowDays: 0 },
           shiftCompliance: { enforcement: 'warn', dailyMaxMinutes: null, weeklyMaxMinutes: null, monthlyMaxMinutes: null },
-          multiShiftDay: { enabled: false, maxSlots: 3 },
+          multiShiftDay: { enabled: true, maxSlots: 3 },
           punchPolicy: { unscheduled: { mode: 'block' } },
         }),
       })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -11922,43 +11922,38 @@ async function loadShiftAssignmentMapForUsersRange(db, orgId, userIds, fromDate,
   const targetOrg = orgId || DEFAULT_ORG_ID
   if (!Array.isArray(userIds) || userIds.length === 0) return new Map()
   if (!fromDate || !toDate) return new Map()
-  try {
-    const rows = await db.query(
-      `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
-              a.publish_status, a.publish_batch_id, a.publish_requested_at, a.publish_requested_by,
-              a.published_at, a.published_by, a.locked_at, a.reopened_from_assignment_id,
-              a.created_at AS assignment_created_at,
-              s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
-              s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
-              s.early_grace_minutes AS shift_early_grace_minutes, s.rounding_minutes AS shift_rounding_minutes,
-              s.working_days AS shift_working_days
-       FROM attendance_shift_assignments a
-       JOIN attendance_shifts s ON s.id = a.shift_id
-       WHERE a.org_id = $1
-         AND a.user_id = ANY($2::text[])
-         AND a.is_active = true
-         AND COALESCE(a.publish_status, 'published') = 'published'
-         AND a.start_date <= $3
-         AND (a.end_date IS NULL OR a.end_date >= $4)
-       ORDER BY a.user_id, a.start_date DESC, a.created_at DESC`,
-      [targetOrg, userIds, toDate, fromDate]
-    )
-    const byUser = new Map()
-    for (const row of rows) {
-      const userId = row.user_id
-      if (!userId) continue
-      if (!byUser.has(userId)) byUser.set(userId, [])
-      byUser.get(userId).push({
-        assignment: mapAssignmentRow(row),
-        shift: mapShiftFromAssignmentRow(row),
-        createdAt: row.assignment_created_at ?? null,
-      })
-    }
-    return byUser
-  } catch (error) {
-    if (isDatabaseSchemaError(error)) return new Map()
-    throw error
+  const rows = await db.query(
+    `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
+            a.publish_status, a.publish_batch_id, a.publish_requested_at, a.publish_requested_by,
+            a.published_at, a.published_by, a.locked_at, a.reopened_from_assignment_id,
+            a.created_at AS assignment_created_at,
+            s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
+            s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
+            s.early_grace_minutes AS shift_early_grace_minutes, s.rounding_minutes AS shift_rounding_minutes,
+            s.working_days AS shift_working_days
+     FROM attendance_shift_assignments a
+     JOIN attendance_shifts s ON s.id = a.shift_id
+     WHERE a.org_id = $1
+       AND a.user_id = ANY($2::text[])
+       AND a.is_active = true
+       AND COALESCE(a.publish_status, 'published') = 'published'
+       AND a.start_date <= $3
+       AND (a.end_date IS NULL OR a.end_date >= $4)
+     ORDER BY a.user_id, a.start_date DESC, a.created_at DESC`,
+    [targetOrg, userIds, toDate, fromDate]
+  )
+  const byUser = new Map()
+  for (const row of rows) {
+    const userId = row.user_id
+    if (!userId) continue
+    if (!byUser.has(userId)) byUser.set(userId, [])
+    byUser.get(userId).push({
+      assignment: mapAssignmentRow(row),
+      shift: mapShiftFromAssignmentRow(row),
+      createdAt: row.assignment_created_at ?? null,
+    })
   }
+  return byUser
 }
 
 async function loadRotationAssignmentMapForUsersRange(db, orgId, userIds, fromDate, toDate) {
@@ -11967,67 +11962,60 @@ async function loadRotationAssignmentMapForUsersRange(db, orgId, userIds, fromDa
     return { assignmentsByUser: new Map(), shiftsById: new Map() }
   }
   if (!fromDate || !toDate) return { assignmentsByUser: new Map(), shiftsById: new Map() }
-  try {
-    const rows = await db.query(
-      `SELECT a.id, a.org_id, a.user_id, a.rotation_rule_id, a.start_date, a.end_date, a.is_active,
-              a.publish_status, a.publish_batch_id, a.publish_requested_at, a.publish_requested_by,
-              a.published_at, a.published_by, a.locked_at, a.reopened_from_assignment_id,
-              r.name AS rotation_name, r.timezone AS rotation_timezone, r.shift_sequence AS rotation_shift_sequence,
-              r.is_active AS rotation_is_active
-       FROM attendance_rotation_assignments a
-       JOIN attendance_rotation_rules r ON r.id = a.rotation_rule_id
-       WHERE a.org_id = $1
-         AND a.user_id = ANY($2::text[])
-         AND a.is_active = true
-         AND COALESCE(a.publish_status, 'published') = 'published'
-         AND r.is_active = true
-         AND a.start_date <= $3
-         AND (a.end_date IS NULL OR a.end_date >= $4)
-       ORDER BY a.user_id, a.start_date DESC, a.created_at DESC`,
-      [targetOrg, userIds, toDate, fromDate]
-    )
-    const assignmentsByUser = new Map()
-    const shiftIdSet = new Set()
-    for (const row of rows) {
-      const userId = row.user_id
-      if (!userId) continue
-      const rotation = mapRotationRuleFromAssignmentRow(row)
-      const assignment = mapRotationAssignmentRow(row)
-      if (!assignmentsByUser.has(userId)) assignmentsByUser.set(userId, [])
-      assignmentsByUser.get(userId).push({ assignment, rotation })
-      for (const shiftId of rotation.shiftSequence) {
-        if (shiftId) shiftIdSet.add(shiftId)
-      }
+  const rows = await db.query(
+    `SELECT a.id, a.org_id, a.user_id, a.rotation_rule_id, a.start_date, a.end_date, a.is_active,
+            a.publish_status, a.publish_batch_id, a.publish_requested_at, a.publish_requested_by,
+            a.published_at, a.published_by, a.locked_at, a.reopened_from_assignment_id,
+            r.name AS rotation_name, r.timezone AS rotation_timezone, r.shift_sequence AS rotation_shift_sequence,
+            r.is_active AS rotation_is_active
+     FROM attendance_rotation_assignments a
+     JOIN attendance_rotation_rules r ON r.id = a.rotation_rule_id
+     WHERE a.org_id = $1
+       AND a.user_id = ANY($2::text[])
+       AND a.is_active = true
+       AND COALESCE(a.publish_status, 'published') = 'published'
+       AND r.is_active = true
+       AND a.start_date <= $3
+       AND (a.end_date IS NULL OR a.end_date >= $4)
+     ORDER BY a.user_id, a.start_date DESC, a.created_at DESC`,
+    [targetOrg, userIds, toDate, fromDate]
+  )
+  const assignmentsByUser = new Map()
+  const shiftIdSet = new Set()
+  for (const row of rows) {
+    const userId = row.user_id
+    if (!userId) continue
+    const rotation = mapRotationRuleFromAssignmentRow(row)
+    const assignment = mapRotationAssignmentRow(row)
+    if (!assignmentsByUser.has(userId)) assignmentsByUser.set(userId, [])
+    assignmentsByUser.get(userId).push({ assignment, rotation })
+    for (const shiftId of rotation.shiftSequence) {
+      if (shiftId) shiftIdSet.add(shiftId)
     }
-
-    const shiftsById = new Map()
-    if (shiftIdSet.size > 0) {
-      const ids = []
-      const names = []
-      for (const shiftRef of shiftIdSet) {
-        const uuid = normalizeUuidString(shiftRef)
-        if (uuid) {
-          ids.push(uuid)
-        } else if (typeof shiftRef === 'string' && shiftRef.trim()) {
-          names.push(shiftRef.trim())
-        }
-      }
-      const lookup = await loadShiftReferenceLookup(db, targetOrg, { ids, names })
-      for (const shiftRef of shiftIdSet) {
-        const resolution = resolveShiftReference(shiftRef, lookup)
-        if (resolution.status !== 'resolved' || !resolution.shift?.id) continue
-        shiftsById.set(shiftRef, resolution.shift)
-        shiftsById.set(resolution.shift.id, resolution.shift)
-      }
-    }
-
-    return { assignmentsByUser, shiftsById }
-  } catch (error) {
-    if (isDatabaseSchemaError(error)) {
-      return { assignmentsByUser: new Map(), shiftsById: new Map() }
-    }
-    throw error
   }
+
+  const shiftsById = new Map()
+  if (shiftIdSet.size > 0) {
+    const ids = []
+    const names = []
+    for (const shiftRef of shiftIdSet) {
+      const uuid = normalizeUuidString(shiftRef)
+      if (uuid) {
+        ids.push(uuid)
+      } else if (typeof shiftRef === 'string' && shiftRef.trim()) {
+        names.push(shiftRef.trim())
+      }
+    }
+    const lookup = await loadShiftReferenceLookup(db, targetOrg, { ids, names })
+    for (const shiftRef of shiftIdSet) {
+      const resolution = resolveShiftReference(shiftRef, lookup)
+      if (resolution.status !== 'resolved' || !resolution.shift?.id) continue
+      shiftsById.set(shiftRef, resolution.shift)
+      shiftsById.set(resolution.shift.id, resolution.shift)
+    }
+  }
+
+  return { assignmentsByUser, shiftsById }
 }
 
 // ===== EffectiveCalendarResolver (RFC §4) =====
@@ -31535,6 +31523,10 @@ module.exports = {
           if (message.startsWith('VALIDATION:')) {
             // resolver-level validation; route validation should normally catch first
             res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message } })
+            return
+          }
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance schedule publish columns missing. Run migrations before serving effective calendar.' } })
             return
           }
           logger.error('Attendance effective-calendar resolve failed', error)

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8179,6 +8179,7 @@ function normalizeGroupSyncOptions(groupSync, fallbackRuleSetId, fallbackTimezon
 }
 
 function mapAssignmentRow(row) {
+  const publishStatus = normalizeAttendanceSchedulePublishStatus(row.publish_status)
   return {
     id: row.id,
     orgId: row.org_id ?? DEFAULT_ORG_ID,
@@ -8195,6 +8196,22 @@ function mapAssignmentRow(row) {
     end_date: normalizeDateOnly(row.end_date) ?? row.end_date ?? null,
     isActive: row.is_active ?? true,
     is_active: row.is_active ?? true,
+    publishStatus,
+    publish_status: publishStatus,
+    publishBatchId: row.publish_batch_id ?? null,
+    publish_batch_id: row.publish_batch_id ?? null,
+    publishRequestedAt: row.publish_requested_at ?? null,
+    publish_requested_at: row.publish_requested_at ?? null,
+    publishRequestedBy: row.publish_requested_by ?? null,
+    publish_requested_by: row.publish_requested_by ?? null,
+    publishedAt: row.published_at ?? null,
+    published_at: row.published_at ?? null,
+    publishedBy: row.published_by ?? null,
+    published_by: row.published_by ?? null,
+    lockedAt: row.locked_at ?? null,
+    locked_at: row.locked_at ?? null,
+    reopenedFromAssignmentId: row.reopened_from_assignment_id ?? null,
+    reopened_from_assignment_id: row.reopened_from_assignment_id ?? null,
     producerType: row.producer_type ?? null,
     producer_type: row.producer_type ?? null,
     producerRefId: row.producer_ref_id ?? null,
@@ -8790,6 +8807,7 @@ function mapRotationRuleRow(row) {
 }
 
 function mapRotationAssignmentRow(row) {
+  const publishStatus = normalizeAttendanceSchedulePublishStatus(row.publish_status)
   return {
     id: row.id,
     orgId: row.org_id ?? DEFAULT_ORG_ID,
@@ -8798,10 +8816,31 @@ function mapRotationAssignmentRow(row) {
     startDate: normalizeDateOnly(row.start_date) ?? row.start_date,
     endDate: normalizeDateOnly(row.end_date) ?? row.end_date ?? null,
     isActive: row.is_active ?? true,
+    publishStatus,
+    publish_status: publishStatus,
+    publishBatchId: row.publish_batch_id ?? null,
+    publish_batch_id: row.publish_batch_id ?? null,
+    publishRequestedAt: row.publish_requested_at ?? null,
+    publish_requested_at: row.publish_requested_at ?? null,
+    publishRequestedBy: row.publish_requested_by ?? null,
+    publish_requested_by: row.publish_requested_by ?? null,
+    publishedAt: row.published_at ?? null,
+    published_at: row.published_at ?? null,
+    publishedBy: row.published_by ?? null,
+    published_by: row.published_by ?? null,
+    lockedAt: row.locked_at ?? null,
+    locked_at: row.locked_at ?? null,
+    reopenedFromAssignmentId: row.reopened_from_assignment_id ?? null,
+    reopened_from_assignment_id: row.reopened_from_assignment_id ?? null,
   }
 }
 
 const ATTENDANCE_SCHEDULE_OPEN_END_DATE = '9999-12-31'
+const ATTENDANCE_SCHEDULE_PUBLISH_STATUSES = new Set(['draft', 'pending', 'published'])
+
+function normalizeAttendanceSchedulePublishStatus(value) {
+  return ATTENDANCE_SCHEDULE_PUBLISH_STATUSES.has(value) ? value : 'published'
+}
 
 function normalizeAttendanceScheduleAssignmentEndDate(value) {
   const normalized = normalizeDateOnly(value)
@@ -8933,6 +8972,7 @@ async function findAttendanceScheduleAssignmentConflict(db, draft) {
         WHERE a.org_id = $1
           AND a.user_id = $2
           AND COALESCE(a.is_active, true) = true
+          AND COALESCE(a.publish_status, 'published') = 'published'
           AND a.start_date <= $4::date
           AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
           ${draft.excludeId ? 'AND a.id <> $5' : ''}
@@ -8953,6 +8993,7 @@ async function findAttendanceScheduleAssignmentConflict(db, draft) {
         WHERE org_id = $1
           AND user_id = $2
           AND COALESCE(is_active, true) = true
+          AND COALESCE(publish_status, 'published') = 'published'
           AND start_date <= $4::date
           AND COALESCE(end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
           ${excludeClause}
@@ -8969,6 +9010,7 @@ async function findAttendanceScheduleAssignmentConflict(db, draft) {
       WHERE org_id = $1
         AND user_id = $2
         AND COALESCE(is_active, true) = true
+        AND COALESCE(publish_status, 'published') = 'published'
         AND start_date <= $4::date
         AND COALESCE(end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
       ORDER BY start_date DESC, created_at DESC
@@ -9074,13 +9116,17 @@ async function acquireAttendanceScheduleAssignmentLocks(db, orgId, userIds) {
 async function loadAttendanceGroupFixedScheduleManagedRows(db, input) {
   const producerMetadata = buildAttendanceGroupFixedScheduleProducerMetadata(input, '00000000-0000-4000-8000-000000000000')
   return db.query(
-    `SELECT id, user_id, shift_id, slot_index, start_date, end_date, is_active, producer_type, producer_ref_id, producer_key, producer_run_id, 'shift'::text AS kind
+    `SELECT id, user_id, shift_id, slot_index, start_date, end_date, is_active,
+            publish_status, publish_batch_id, publish_requested_at, publish_requested_by,
+            published_at, published_by, locked_at, reopened_from_assignment_id,
+            producer_type, producer_ref_id, producer_key, producer_run_id, 'shift'::text AS kind
        FROM attendance_shift_assignments
       WHERE org_id = $1
         AND producer_type = $2
         AND producer_ref_id = $3
         AND producer_key = $4
         AND COALESCE(is_active, true) = true
+        AND COALESCE(publish_status, 'published') = 'published'
       ORDER BY user_id ASC, start_date ASC, created_at ASC`,
     [input.orgId, producerMetadata.producerType, producerMetadata.producerRefId, producerMetadata.producerKey]
   )
@@ -9155,6 +9201,8 @@ async function buildAttendanceGroupFixedSchedulePlan(db, input, options = {}) {
   const shift = mapShiftRow(shiftRows[0])
   const shiftOverlapRows = await db.query(
     `SELECT a.id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date,
+            a.publish_status, a.publish_batch_id, a.publish_requested_at, a.publish_requested_by,
+            a.published_at, a.published_by, a.locked_at, a.reopened_from_assignment_id,
             a.producer_type, a.producer_ref_id, a.producer_key, a.producer_run_id,
             'shift'::text AS kind,
             s.work_start_time, s.work_end_time, s.is_overnight
@@ -9163,17 +9211,19 @@ async function buildAttendanceGroupFixedSchedulePlan(db, input, options = {}) {
       WHERE a.org_id = $1
         AND a.user_id = ANY($2::text[])
         AND COALESCE(a.is_active, true) = true
+        AND COALESCE(a.publish_status, 'published') = 'published'
         AND a.start_date <= $4::date
         AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
       ORDER BY a.user_id ASC, a.start_date DESC, a.created_at DESC`,
     [input.orgId, userIds, input.startDate, overlapEndDate]
   )
   const rotationOverlapRows = await db.query(
-    `SELECT id, user_id, rotation_rule_id, start_date, end_date, 'rotation'::text AS kind
+    `SELECT id, user_id, rotation_rule_id, start_date, end_date, publish_status, 'rotation'::text AS kind
        FROM attendance_rotation_assignments
       WHERE org_id = $1
         AND user_id = ANY($2::text[])
         AND COALESCE(is_active, true) = true
+        AND COALESCE(publish_status, 'published') = 'published'
         AND start_date <= $4::date
         AND COALESCE(end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
       ORDER BY user_id ASC, start_date DESC, created_at DESC`,
@@ -11501,6 +11551,8 @@ async function loadShiftAssignment(db, orgId, userId, workDate) {
   try {
     const rows = await db.query(
       `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
+              a.publish_status, a.publish_batch_id, a.publish_requested_at, a.publish_requested_by,
+              a.published_at, a.published_by, a.locked_at, a.reopened_from_assignment_id,
               a.created_at AS assignment_created_at,
               s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
               s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
@@ -11511,6 +11563,7 @@ async function loadShiftAssignment(db, orgId, userId, workDate) {
        WHERE a.org_id = $1
          AND a.user_id = $2
          AND a.is_active = true
+         AND COALESCE(a.publish_status, 'published') = 'published'
          AND a.start_date <= $3
          AND (a.end_date IS NULL OR a.end_date >= $3)
        ORDER BY a.start_date DESC, a.created_at DESC
@@ -11755,6 +11808,8 @@ async function loadRotationAssignment(db, orgId, userId, workDate) {
   try {
     const rows = await db.query(
       `SELECT a.id, a.org_id, a.user_id, a.rotation_rule_id, a.start_date, a.end_date, a.is_active,
+              a.publish_status, a.publish_batch_id, a.publish_requested_at, a.publish_requested_by,
+              a.published_at, a.published_by, a.locked_at, a.reopened_from_assignment_id,
               r.name AS rotation_name, r.timezone AS rotation_timezone, r.shift_sequence AS rotation_shift_sequence,
               r.is_active AS rotation_is_active
        FROM attendance_rotation_assignments a
@@ -11762,6 +11817,7 @@ async function loadRotationAssignment(db, orgId, userId, workDate) {
        WHERE a.org_id = $1
          AND a.user_id = $2
          AND a.is_active = true
+         AND COALESCE(a.publish_status, 'published') = 'published'
          AND r.is_active = true
          AND a.start_date <= $3
          AND (a.end_date IS NULL OR a.end_date >= $3)
@@ -11869,6 +11925,8 @@ async function loadShiftAssignmentMapForUsersRange(db, orgId, userIds, fromDate,
   try {
     const rows = await db.query(
       `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
+              a.publish_status, a.publish_batch_id, a.publish_requested_at, a.publish_requested_by,
+              a.published_at, a.published_by, a.locked_at, a.reopened_from_assignment_id,
               a.created_at AS assignment_created_at,
               s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
               s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
@@ -11879,6 +11937,7 @@ async function loadShiftAssignmentMapForUsersRange(db, orgId, userIds, fromDate,
        WHERE a.org_id = $1
          AND a.user_id = ANY($2::text[])
          AND a.is_active = true
+         AND COALESCE(a.publish_status, 'published') = 'published'
          AND a.start_date <= $3
          AND (a.end_date IS NULL OR a.end_date >= $4)
        ORDER BY a.user_id, a.start_date DESC, a.created_at DESC`,
@@ -11911,6 +11970,8 @@ async function loadRotationAssignmentMapForUsersRange(db, orgId, userIds, fromDa
   try {
     const rows = await db.query(
       `SELECT a.id, a.org_id, a.user_id, a.rotation_rule_id, a.start_date, a.end_date, a.is_active,
+              a.publish_status, a.publish_batch_id, a.publish_requested_at, a.publish_requested_by,
+              a.published_at, a.published_by, a.locked_at, a.reopened_from_assignment_id,
               r.name AS rotation_name, r.timezone AS rotation_timezone, r.shift_sequence AS rotation_shift_sequence,
               r.is_active AS rotation_is_active
        FROM attendance_rotation_assignments a
@@ -11918,6 +11979,7 @@ async function loadRotationAssignmentMapForUsersRange(db, orgId, userIds, fromDa
        WHERE a.org_id = $1
          AND a.user_id = ANY($2::text[])
          AND a.is_active = true
+         AND COALESCE(a.publish_status, 'published') = 'published'
          AND r.is_active = true
          AND a.start_date <= $3
          AND (a.end_date IS NULL OR a.end_date >= $4)
@@ -12149,6 +12211,7 @@ async function isUserScheduledForDate(db, orgId, userId, date) {
          OR EXISTS (
            SELECT 1 FROM attendance_shift_assignments sa
            WHERE sa.org_id = $1 AND sa.user_id = $2 AND COALESCE(sa.is_active, true) = true
+             AND COALESCE(sa.publish_status, 'published') = 'published'
              AND sa.start_date <= $3::date
              AND COALESCE(sa.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
          )`,
@@ -12227,6 +12290,7 @@ async function hasAutoShiftRotationAssignmentForDate(db, orgId, userId, workDate
      WHERE org_id = $1
        AND user_id = $2
        AND COALESCE(is_active, true) = true
+       AND COALESCE(publish_status, 'published') = 'published'
        AND start_date <= $3::date
        AND COALESCE(end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
      LIMIT 1`,
@@ -22790,6 +22854,8 @@ module.exports = {
           rowParams.push(pageSize, offset)
           const rows = await db.query(
             `SELECT a.id, a.org_id, a.user_id, a.rotation_rule_id, a.start_date, a.end_date, a.is_active,
+                    a.publish_status, a.publish_batch_id, a.publish_requested_at, a.publish_requested_by,
+                    a.published_at, a.published_by, a.locked_at, a.reopened_from_assignment_id,
                     r.name AS rotation_name, r.timezone AS rotation_timezone, r.shift_sequence AS rotation_shift_sequence,
                     r.is_active AS rotation_is_active
              FROM attendance_rotation_assignments a
@@ -30150,6 +30216,8 @@ module.exports = {
             ),
             db.query(
               `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.start_date, a.end_date, a.is_active,
+                      a.publish_status, a.publish_batch_id, a.publish_requested_at, a.publish_requested_by,
+                      a.published_at, a.published_by, a.locked_at, a.reopened_from_assignment_id,
                       s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
                       s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight,
                       s.late_grace_minutes AS shift_late_grace_minutes,
@@ -30160,6 +30228,7 @@ module.exports = {
                JOIN attendance_shifts s ON s.id = a.shift_id
                WHERE a.org_id = $1
                  AND COALESCE(a.is_active, true) = true
+                 AND COALESCE(a.publish_status, 'published') = 'published'
                  AND a.start_date <= $3::date
                  AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
                ORDER BY a.start_date DESC, a.created_at DESC
@@ -30168,6 +30237,8 @@ module.exports = {
             ),
             db.query(
               `SELECT a.id, a.org_id, a.user_id, a.rotation_rule_id, a.start_date, a.end_date, a.is_active,
+                      a.publish_status, a.publish_batch_id, a.publish_requested_at, a.publish_requested_by,
+                      a.published_at, a.published_by, a.locked_at, a.reopened_from_assignment_id,
                       r.name AS rotation_name, r.timezone AS rotation_timezone,
                       r.shift_sequence AS rotation_shift_sequence,
                       r.is_active AS rotation_is_active
@@ -30175,6 +30246,7 @@ module.exports = {
                JOIN attendance_rotation_rules r ON r.id = a.rotation_rule_id
                WHERE a.org_id = $1
                  AND COALESCE(a.is_active, true) = true
+                 AND COALESCE(a.publish_status, 'published') = 'published'
                  AND a.start_date <= $3::date
                  AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
                ORDER BY a.start_date DESC, a.created_at DESC
@@ -30188,6 +30260,7 @@ module.exports = {
                  JOIN attendance_shifts s ON s.id = a.shift_id
                  WHERE a.org_id = $1
                    AND COALESCE(a.is_active, true) = true
+                   AND COALESCE(a.publish_status, 'published') = 'published'
                    AND a.start_date <= $3::date
                    AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
                ),
@@ -30197,6 +30270,7 @@ module.exports = {
                  JOIN attendance_rotation_rules r ON r.id = a.rotation_rule_id
                  WHERE a.org_id = $1
                    AND COALESCE(a.is_active, true) = true
+                   AND COALESCE(a.publish_status, 'published') = 'published'
                    AND a.start_date <= $3::date
                    AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
                ),
@@ -30246,6 +30320,7 @@ module.exports = {
                  JOIN attendance_shifts s ON s.id = a.shift_id
                  WHERE a.org_id = $1
                    AND COALESCE(a.is_active, true) = true
+                   AND COALESCE(a.publish_status, 'published') = 'published'
                    AND a.start_date <= $3::date
                    AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
                  GROUP BY a.user_id
@@ -30256,6 +30331,7 @@ module.exports = {
                  JOIN attendance_rotation_rules r ON r.id = a.rotation_rule_id
                  WHERE a.org_id = $1
                    AND COALESCE(a.is_active, true) = true
+                   AND COALESCE(a.publish_status, 'published') = 'published'
                    AND a.start_date <= $3::date
                    AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $2::date
                  GROUP BY a.user_id
@@ -30805,6 +30881,7 @@ module.exports = {
                   WHERE org_id = $1
                     AND user_id = $2
                     AND COALESCE(is_active, true) = true
+                    AND COALESCE(publish_status, 'published') = 'published'
                     AND producer_type = $3
                     AND producer_key = $4
                   ORDER BY created_at ASC
@@ -30976,6 +31053,8 @@ module.exports = {
           rowParams.push(pageSize, offset)
           const rows = await db.query(
             `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
+                    a.publish_status, a.publish_batch_id, a.publish_requested_at, a.publish_requested_by,
+                    a.published_at, a.published_by, a.locked_at, a.reopened_from_assignment_id,
                     s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
                     s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
                     s.early_grace_minutes AS shift_early_grace_minutes, s.rounding_minutes AS shift_rounding_minutes,


### PR DESCRIPTION
## Summary

Stacked after #2429 / `codex/attendance-multishift-m4-admin-ui-20260610`.

This is the P0 latent foundation for the schedule publish/draft line locked by `docs/development/attendance-schedule-publishing-design-lock-20260609.md`:

- add `publish_status` lifecycle columns to both shift and rotation assignment tables, defaulting existing/current writes to `published`
- expose publish lifecycle metadata in assignment mappers and admin list responses
- filter non-`published` assignments out of runtime consumers: effective calendar / planned-minutes projection, unscheduled punch scheduling primitive, assignment conflict checks, fixed-schedule managed rows, auto-shift side checks, and advanced-scheduling runtime aggregates
- keep admin assignment lists unfiltered so future draft/pending UI can still see lifecycle rows
- add real-wire integration coverage for default `published`, draft/pending invisibility, published visibility, conflict filtering, rotation parity, and the DB CHECK guard

## Scope Boundary

P0 only. No publish route, no draft writer, no frontend UI, no OpenAPI/dist SDK surface. Current API writes remain `published` by default, so behavior is unchanged until a later lifecycle writer exists.

## Verification

Local, in `/private/tmp/ms2-publish-p0`:

- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend test:integration:attendance` collected the suite but skipped all DB tests because this machine has no `DATABASE_URL`/`ATTENDANCE_TEST_DATABASE_URL` and Docker daemon is not running. CI's DB-backed attendance gate should provide the real execution.

## Notes for Review

- The migration intentionally covers both `attendance_shift_assignments` and `attendance_rotation_assignments` so rotation cannot become a lifecycle side door.
- `draft|pending` are invisible only to runtime consumers; admin list endpoints still return them with `publishStatus`.