### PR TITLE
feat(attendance): add schedule draft CRUD foundation

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -3038,6 +3038,307 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('supports draft schedule CRUD through draft-aware routes without changing immediate published writes', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const adminUserId = `attendance-draft-crud-admin-${runSuffix}`
+    const shiftUserId = `attendance-draft-crud-shift-${runSuffix}`
+    const rotationUserId = `attendance-draft-crud-rotation-${runSuffix}`
+    const deleteUserId = `attendance-draft-crud-delete-${runSuffix}`
+    const workDate = '2026-07-23'
+    const rotationDate = '2026-07-24'
+    const pool = new Pool({ connectionString: dbUrl })
+    let originalSettings: Record<string, unknown> = {}
+    const shiftIds: string[] = []
+    const rotationRuleIds: string[] = []
+
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) {
+      await pool.end().catch(() => undefined)
+      return
+    }
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    }
+
+    async function createShift(name: string, workStartTime: string, workEndTime: string): Promise<string> {
+      const res = await requestJson(`${baseUrl}/api/attendance/shifts`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name,
+          timezone: 'UTC',
+          workStartTime,
+          workEndTime,
+          workingDays: [0, 1, 2, 3, 4, 5, 6],
+        }),
+      })
+      expect(res.status, JSON.stringify(res.body)).toBe(201)
+      const id = (res.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(id).toBeTruthy()
+      if (!id) throw new Error('missing shift id')
+      shiftIds.push(id)
+      return id
+    }
+
+    async function createRotationRule(name: string, shiftId: string): Promise<string> {
+      const res = await requestJson(`${baseUrl}/api/attendance/rotation-rules`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name,
+          timezone: 'UTC',
+          shiftSequence: [shiftId],
+          isActive: true,
+        }),
+      })
+      expect(res.status, JSON.stringify(res.body)).toBe(201)
+      const id = (res.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(id).toBeTruthy()
+      if (!id) throw new Error('missing rotation rule id')
+      rotationRuleIds.push(id)
+      return id
+    }
+
+    function expectPublishLocked(res: HttpResponse, status: string) {
+      expect(res.status, JSON.stringify(res.body)).toBe(422)
+      const error = (res.body as { error?: { code?: string; details?: { publishStatus?: string } } } | undefined)?.error
+      expect(error?.code).toBe('SCHEDULE_PUBLISH_LOCKED')
+      expect(error?.details?.publishStatus).toBe(status)
+    }
+
+    try {
+      const settingsRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      expect(settingsRes.status).toBe(200)
+      originalSettings = ((settingsRes.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
+      const settingsUpdateRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({
+          shiftEditPolicy: { mode: 'unrestricted', windowDays: 0 },
+          shiftCompliance: { enforcement: 'warn', dailyMaxMinutes: null, weeklyMaxMinutes: null, monthlyMaxMinutes: null },
+          multiShiftDay: { enabled: false, maxSlots: 3 },
+        }),
+      })
+      expect(settingsUpdateRes.status, JSON.stringify(settingsUpdateRes.body)).toBe(200)
+
+      const publishedShiftId = await createShift(`Draft CRUD Published ${runSuffix}`, '08:00', '09:00')
+      const draftShiftId = await createShift(`Draft CRUD Draft ${runSuffix}`, '10:00', '11:00')
+      const updatedDraftShiftId = await createShift(`Draft CRUD Updated ${runSuffix}`, '12:00', '13:00')
+
+      const publishedRes = await requestJson(`${baseUrl}/api/attendance/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          userId: shiftUserId,
+          shiftId: publishedShiftId,
+          startDate: workDate,
+          endDate: workDate,
+          isActive: true,
+        }),
+      })
+      expect(publishedRes.status, JSON.stringify(publishedRes.body)).toBe(201)
+      const publishedAssignment = (publishedRes.body as { data?: { assignment?: { id?: string; publishStatus?: string } } } | undefined)?.data?.assignment
+      expect(publishedAssignment?.publishStatus).toBe('published')
+      expect(publishedAssignment?.id).toBeTruthy()
+      if (!publishedAssignment?.id) return
+
+      const draftRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          userId: shiftUserId,
+          shiftId: draftShiftId,
+          startDate: workDate,
+          endDate: workDate,
+          isActive: true,
+        }),
+      })
+      expect(draftRes.status, JSON.stringify(draftRes.body)).toBe(201)
+      const draftAssignment = (draftRes.body as { data?: { assignment?: { id?: string; publishStatus?: string; publish_status?: string } } } | undefined)?.data?.assignment
+      expect(draftAssignment?.publishStatus).toBe('draft')
+      expect(draftAssignment?.publish_status).toBe('draft')
+      expect(draftAssignment?.id).toBeTruthy()
+      if (!draftAssignment?.id) return
+
+      const duplicateDraftRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          userId: shiftUserId,
+          shiftId: draftShiftId,
+          startDate: workDate,
+          endDate: workDate,
+          isActive: true,
+        }),
+      })
+      expect(duplicateDraftRes.status, JSON.stringify(duplicateDraftRes.body)).toBe(409)
+      expect((duplicateDraftRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('ATTENDANCE_SCHEDULE_ASSIGNMENT_CONFLICT')
+
+      const draftListRes = await requestJson(
+        `${baseUrl}/api/attendance/assignments?userId=${encodeURIComponent(shiftUserId)}&publishStatus=draft`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      )
+      expect(draftListRes.status, JSON.stringify(draftListRes.body)).toBe(200)
+      const draftListItems = (draftListRes.body as { data?: { items?: Array<{ assignment?: { id?: string; publishStatus?: string } }> } } | undefined)?.data?.items ?? []
+      expect(draftListItems.map(item => item.assignment?.id)).toContain(draftAssignment.id)
+      expect(draftListItems.every(item => item.assignment?.publishStatus === 'draft')).toBe(true)
+
+      const publishedListRes = await requestJson(
+        `${baseUrl}/api/attendance/assignments?userId=${encodeURIComponent(shiftUserId)}&publishStatus=published`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      )
+      expect(publishedListRes.status, JSON.stringify(publishedListRes.body)).toBe(200)
+      const publishedListItems = (publishedListRes.body as { data?: { items?: Array<{ assignment?: { id?: string; publishStatus?: string } }> } } | undefined)?.data?.items ?? []
+      expect(publishedListItems.map(item => item.assignment?.id)).toContain(publishedAssignment?.id)
+      expect(publishedListItems.map(item => item.assignment?.id)).not.toContain(draftAssignment.id)
+
+      const ordinaryDraftUpdateRes = await requestJson(`${baseUrl}/api/attendance/assignments/${draftAssignment.id}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ shiftId: updatedDraftShiftId }),
+      })
+      expectPublishLocked(ordinaryDraftUpdateRes, 'draft')
+
+      const ordinaryPublishedUpdateRes = await requestJson(`${baseUrl}/api/attendance/assignments/${publishedAssignment.id}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ shiftId: publishedShiftId }),
+      })
+      expect(ordinaryPublishedUpdateRes.status, JSON.stringify(ordinaryPublishedUpdateRes.body)).toBe(200)
+      expect((ordinaryPublishedUpdateRes.body as { data?: { assignment?: { publishStatus?: string } } } | undefined)?.data?.assignment?.publishStatus).toBe('published')
+
+      const draftUpdateRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/assignments/${draftAssignment.id}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ shiftId: updatedDraftShiftId }),
+      })
+      expect(draftUpdateRes.status, JSON.stringify(draftUpdateRes.body)).toBe(200)
+      const updatedDraftAssignment = (draftUpdateRes.body as { data?: { assignment?: { shiftId?: string; publishStatus?: string } } } | undefined)?.data?.assignment
+      expect(updatedDraftAssignment?.shiftId).toBe(updatedDraftShiftId)
+      expect(updatedDraftAssignment?.publishStatus).toBe('draft')
+
+      await pool.query('UPDATE attendance_shift_assignments SET publish_status = $2 WHERE id = $1', [draftAssignment.id, 'pending'])
+      const pendingDraftUpdateRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/assignments/${draftAssignment.id}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ shiftId: draftShiftId }),
+      })
+      expectPublishLocked(pendingDraftUpdateRes, 'pending')
+      const ordinaryPendingDeleteRes = await requestJson(`${baseUrl}/api/attendance/assignments/${draftAssignment.id}`, {
+        method: 'DELETE',
+        headers,
+      })
+      expectPublishLocked(ordinaryPendingDeleteRes, 'pending')
+
+      const deleteDraftRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          userId: deleteUserId,
+          shiftId: draftShiftId,
+          startDate: workDate,
+          endDate: workDate,
+          isActive: true,
+        }),
+      })
+      expect(deleteDraftRes.status, JSON.stringify(deleteDraftRes.body)).toBe(201)
+      const deleteDraftId = (deleteDraftRes.body as { data?: { assignment?: { id?: string } } } | undefined)?.data?.assignment?.id
+      expect(deleteDraftId).toBeTruthy()
+      if (!deleteDraftId) return
+      const ordinaryDraftDeleteRes = await requestJson(`${baseUrl}/api/attendance/assignments/${deleteDraftId}`, {
+        method: 'DELETE',
+        headers,
+      })
+      expectPublishLocked(ordinaryDraftDeleteRes, 'draft')
+      const draftDeleteRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/assignments/${deleteDraftId}`, {
+        method: 'DELETE',
+        headers,
+      })
+      expect(draftDeleteRes.status, JSON.stringify(draftDeleteRes.body)).toBe(200)
+      const deletedRows = await pool.query('SELECT 1 FROM attendance_shift_assignments WHERE id = $1', [deleteDraftId])
+      expect(deletedRows.rows.length).toBe(0)
+
+      const rotationRuleId = await createRotationRule(`Draft CRUD Rotation ${runSuffix}`, publishedShiftId)
+      const updatedRotationRuleId = await createRotationRule(`Draft CRUD Rotation Updated ${runSuffix}`, updatedDraftShiftId)
+      const rotationDraftRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/rotation-assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          userId: rotationUserId,
+          rotationRuleId,
+          startDate: rotationDate,
+          endDate: rotationDate,
+          isActive: true,
+        }),
+      })
+      expect(rotationDraftRes.status, JSON.stringify(rotationDraftRes.body)).toBe(201)
+      const rotationDraft = (rotationDraftRes.body as { data?: { assignment?: { id?: string; publishStatus?: string } } } | undefined)?.data?.assignment
+      expect(rotationDraft?.publishStatus).toBe('draft')
+      expect(rotationDraft?.id).toBeTruthy()
+      if (!rotationDraft?.id) return
+
+      const ordinaryRotationUpdateRes = await requestJson(`${baseUrl}/api/attendance/rotation-assignments/${rotationDraft.id}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ rotationRuleId: updatedRotationRuleId }),
+      })
+      expectPublishLocked(ordinaryRotationUpdateRes, 'draft')
+      const rotationDraftUpdateRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/rotation-assignments/${rotationDraft.id}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ rotationRuleId: updatedRotationRuleId }),
+      })
+      expect(rotationDraftUpdateRes.status, JSON.stringify(rotationDraftUpdateRes.body)).toBe(200)
+      expect((rotationDraftUpdateRes.body as { data?: { assignment?: { rotationRuleId?: string; publishStatus?: string } } } | undefined)?.data?.assignment?.rotationRuleId).toBe(updatedRotationRuleId)
+
+      const rotationDraftListRes = await requestJson(
+        `${baseUrl}/api/attendance/rotation-assignments?publishStatus=draft`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      )
+      expect(rotationDraftListRes.status, JSON.stringify(rotationDraftListRes.body)).toBe(200)
+      const rotationDraftListItems = (rotationDraftListRes.body as { data?: { items?: Array<{ assignment?: { id?: string; publishStatus?: string } }> } } | undefined)?.data?.items ?? []
+      expect(rotationDraftListItems.map(item => item.assignment?.id)).toContain(rotationDraft.id)
+      expect(rotationDraftListItems.every(item => item.assignment?.publishStatus === 'draft')).toBe(true)
+
+      const rotationDraftDeleteRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/rotation-assignments/${rotationDraft.id}`, {
+        method: 'DELETE',
+        headers,
+      })
+      expect(rotationDraftDeleteRes.status, JSON.stringify(rotationDraftDeleteRes.body)).toBe(200)
+      const deletedRotationRows = await pool.query('SELECT 1 FROM attendance_rotation_assignments WHERE id = $1', [rotationDraft.id])
+      expect(deletedRotationRows.rows.length).toBe(0)
+    } finally {
+      if (Object.keys(originalSettings).length > 0) {
+        await requestJson(`${baseUrl}/api/attendance/settings`, {
+          method: 'PUT',
+          headers,
+          body: JSON.stringify(originalSettings),
+        }).catch(() => undefined)
+      }
+      const users = [shiftUserId, rotationUserId, deleteUserId]
+      await pool.query('DELETE FROM attendance_shift_assignments WHERE user_id = ANY($1::text[])', [users]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_rotation_assignments WHERE user_id = ANY($1::text[])', [users]).catch(() => undefined)
+      if (rotationRuleIds.length > 0) {
+        await pool.query('DELETE FROM attendance_rotation_rules WHERE id = ANY($1::uuid[])', [rotationRuleIds]).catch(() => undefined)
+      }
+      if (shiftIds.length > 0) {
+        await pool.query('DELETE FROM attendance_shifts WHERE id = ANY($1::uuid[])', [shiftIds]).catch(() => undefined)
+      }
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('enforces schedule-edit windows on shift and rotation assignment writes', async () => {
     if (!baseUrl) return
 

--- a/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduling-assignment-conflict.test.ts
@@ -65,7 +65,8 @@ describe('attendance scheduling assignment conflict guard', () => {
     expect(crossKindConflict?.draftKind).toBe('shift')
     expect(crossKindConflict?.existingKind).toBe('rotation')
     expect(crossKindConflict?.existingEndDate).toBeNull()
-    expect(String(crossKindDb.query.mock.calls[0]?.[0] || '')).toContain('id <> $5')
+    expect(String(crossKindDb.query.mock.calls[0]?.[0] || '')).toContain('id <>')
+    expect(crossKindDb.query.mock.calls[0]?.[1]).toContain('shift-current')
     expect(String(crossKindDb.query.mock.calls[1]?.[0] || '')).toContain('attendance_rotation_assignments')
   })
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8654,6 +8654,7 @@ function normalizeAssignmentPayload(value) {
     startDate: firstDefinedValue(payload.startDate, payload.start_date),
     endDate: firstDefinedValue(payload.endDate, payload.end_date),
     isActive: firstDefinedValue(payload.isActive, payload.is_active),
+    publishStatus: firstDefinedValue(payload.publishStatus, payload.publish_status),
   }
 }
 
@@ -8743,6 +8744,7 @@ function normalizeRotationAssignmentPayload(value) {
     startDate: firstDefinedValue(payload.startDate, payload.start_date),
     endDate: firstDefinedValue(payload.endDate, payload.end_date),
     isActive: firstDefinedValue(payload.isActive, payload.is_active),
+    publishStatus: firstDefinedValue(payload.publishStatus, payload.publish_status),
   }
 }
 
@@ -8840,6 +8842,38 @@ const ATTENDANCE_SCHEDULE_PUBLISH_STATUSES = new Set(['draft', 'pending', 'publi
 
 function normalizeAttendanceSchedulePublishStatus(value) {
   return ATTENDANCE_SCHEDULE_PUBLISH_STATUSES.has(value) ? value : 'published'
+}
+
+function normalizeAttendanceSchedulePublishStatusFilter(value) {
+  if (value == null || value === '' || value === 'all') return null
+  return ATTENDANCE_SCHEDULE_PUBLISH_STATUSES.has(value) ? value : undefined
+}
+
+function isAttendanceScheduleDraftEditable(row) {
+  return normalizeAttendanceSchedulePublishStatus(row?.publish_status) === 'draft'
+}
+
+function respondAttendanceSchedulePublishLocked(res, status) {
+  res.status(422).json({
+    ok: false,
+    error: {
+      code: 'SCHEDULE_PUBLISH_LOCKED',
+      message: `Schedule assignment is ${status}; use the draft workflow for draft rows and publish/cancel workflow for pending or published rows.`,
+      details: { publishStatus: status },
+    },
+  })
+}
+
+async function loadAttendanceScheduleAssignmentPublishStatus(db, tableName, assignmentId, orgId) {
+  if (!['attendance_shift_assignments', 'attendance_rotation_assignments'].includes(tableName)) {
+    throw new Error(`Unsupported attendance schedule assignment table: ${tableName}`)
+  }
+  const rows = await db.query(
+    `SELECT publish_status FROM ${tableName} WHERE id = $1 AND org_id = $2`,
+    [assignmentId, orgId]
+  )
+  if (!rows.length) return null
+  return normalizeAttendanceSchedulePublishStatus(rows[0].publish_status)
 }
 
 function normalizeAttendanceScheduleAssignmentEndDate(value) {
@@ -8947,7 +8981,7 @@ function mapAttendanceScheduleAssignmentConflict(row, draft) {
   }
 }
 
-async function findAttendanceScheduleAssignmentConflict(db, draft) {
+async function findAttendanceScheduleAssignmentConflict(db, draft, options = {}) {
   if (draft.isActive === false) return null
   const draftStartDate = normalizeDateOnly(draft.startDate) ?? draft.startDate
   const draftEndDate = normalizeAttendanceScheduleAssignmentEndDate(draft.endDate)
@@ -8960,22 +8994,27 @@ async function findAttendanceScheduleAssignmentConflict(db, draft) {
     : 'attendance_rotation_assignments'
   const sameKindLabel = draft.kind
   const otherKindLabel = draft.kind === 'rotation' ? 'shift' : 'rotation'
-  const baseParams = [draft.orgId, draft.userId, draftStartDate, overlapEndDate]
-  const excludeClause = draft.excludeId ? 'AND id <> $5' : ''
+  const conflictPublishStatuses = normalizeStringArray(options.publishStatuses)
+    .map(status => normalizeAttendanceSchedulePublishStatusFilter(status))
+    .filter(Boolean)
+  const publishStatuses = conflictPublishStatuses.length > 0 ? conflictPublishStatuses : ['published']
+  const baseParams = [draft.orgId, draft.userId, draftStartDate, overlapEndDate, publishStatuses]
+  const labelParamIndex = draft.excludeId ? 7 : 6
+  const excludeClause = draft.excludeId ? 'AND id <> $6' : ''
   const multiShiftConflictEnabled = draft.kind === 'shift' && draft.multiShiftEnabled === true
   if (multiShiftConflictEnabled) {
     const sameKindRows = await db.query(
-      `SELECT a.id, a.start_date, a.end_date, a.slot_index, $${draft.excludeId ? 6 : 5}::text AS kind,
+      `SELECT a.id, a.start_date, a.end_date, a.slot_index, $${labelParamIndex}::text AS kind,
               s.work_start_time, s.work_end_time, s.is_overnight
          FROM attendance_shift_assignments a
          LEFT JOIN attendance_shifts s ON s.id = a.shift_id AND s.org_id = a.org_id
         WHERE a.org_id = $1
           AND a.user_id = $2
           AND COALESCE(a.is_active, true) = true
-          AND COALESCE(a.publish_status, 'published') = 'published'
+          AND COALESCE(a.publish_status, 'published') = ANY($5::text[])
           AND a.start_date <= $4::date
           AND COALESCE(a.end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
-          ${draft.excludeId ? 'AND a.id <> $5' : ''}
+          ${draft.excludeId ? 'AND a.id <> $6' : ''}
         ORDER BY a.start_date DESC, a.created_at DESC`,
       draft.excludeId ? [...baseParams, draft.excludeId, sameKindLabel] : [...baseParams, sameKindLabel]
     )
@@ -8988,12 +9027,12 @@ async function findAttendanceScheduleAssignmentConflict(db, draft) {
     if (conflictingSameKindRow) return mapAttendanceScheduleAssignmentConflict(conflictingSameKindRow, draft)
   } else {
     const sameKindRows = await db.query(
-      `SELECT id, start_date, end_date, $${draft.excludeId ? 6 : 5}::text AS kind
+      `SELECT id, start_date, end_date, $${labelParamIndex}::text AS kind
          FROM ${sameKindTable}
         WHERE org_id = $1
           AND user_id = $2
           AND COALESCE(is_active, true) = true
-          AND COALESCE(publish_status, 'published') = 'published'
+          AND COALESCE(publish_status, 'published') = ANY($5::text[])
           AND start_date <= $4::date
           AND COALESCE(end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
           ${excludeClause}
@@ -9005,12 +9044,12 @@ async function findAttendanceScheduleAssignmentConflict(db, draft) {
   }
 
   const otherKindRows = await db.query(
-    `SELECT id, start_date, end_date, $5::text AS kind
+    `SELECT id, start_date, end_date, $6::text AS kind
        FROM ${otherKindTable}
       WHERE org_id = $1
         AND user_id = $2
         AND COALESCE(is_active, true) = true
-        AND COALESCE(publish_status, 'published') = 'published'
+        AND COALESCE(publish_status, 'published') = ANY($5::text[])
         AND start_date <= $4::date
         AND COALESCE(end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
       ORDER BY start_date DESC, created_at DESC
@@ -22806,10 +22845,14 @@ module.exports = {
       async (req, res) => {
         const schema = z.object({
           orgId: z.string().optional(),
+          publishStatus: z.enum(['draft', 'pending', 'published', 'all']).optional(),
         })
 
         const parsed = schema.safeParse({
           orgId: typeof req.query.orgId === 'string' ? req.query.orgId : undefined,
+          publishStatus: typeof req.query.publishStatus === 'string'
+            ? req.query.publishStatus
+            : (typeof req.query.publish_status === 'string' ? req.query.publish_status : undefined),
         })
 
         if (!parsed.success) {
@@ -22819,23 +22862,34 @@ module.exports = {
 
         const { page, pageSize, offset } = parsePagination(req.query)
         const orgId = getOrgId(req)
+        const publishStatusFilter = normalizeAttendanceSchedulePublishStatusFilter(parsed.data.publishStatus)
         const viewAccess = await loadAttendanceSchedulerScopesForAction(req, res, { action: 'view' })
         if (!viewAccess) return
 
         try {
           const countParams = [orgId]
+          let countPublishStatusFilter = ''
+          if (publishStatusFilter) {
+            countParams.push(publishStatusFilter)
+            countPublishStatusFilter = `AND COALESCE(a.publish_status, 'published') = $${countParams.length}`
+          }
           const countScopeClause = viewAccess.access.fullAdmin
             ? ''
             : buildAttendanceAssignmentViewSql(viewAccess.scopes, countParams, 'a')
           const countRows = await db.query(
             `SELECT COUNT(*)::int AS total
              FROM attendance_rotation_assignments a
-             WHERE a.org_id = $1 ${countScopeClause}`,
+             WHERE a.org_id = $1 ${countPublishStatusFilter} ${countScopeClause}`,
             countParams
           )
           const total = Number(countRows[0]?.total ?? 0)
 
           const rowParams = [orgId]
+          let rowPublishStatusFilter = ''
+          if (publishStatusFilter) {
+            rowParams.push(publishStatusFilter)
+            rowPublishStatusFilter = `AND COALESCE(a.publish_status, 'published') = $${rowParams.length}`
+          }
           const rowScopeClause = viewAccess.access.fullAdmin
             ? ''
             : buildAttendanceAssignmentViewSql(viewAccess.scopes, rowParams, 'a')
@@ -22848,7 +22902,7 @@ module.exports = {
                     r.is_active AS rotation_is_active
              FROM attendance_rotation_assignments a
              JOIN attendance_rotation_rules r ON r.id = a.rotation_rule_id
-             WHERE a.org_id = $1 ${rowScopeClause}
+             WHERE a.org_id = $1 ${rowPublishStatusFilter} ${rowScopeClause}
              ORDER BY a.start_date DESC, a.created_at DESC
              LIMIT $${rowParams.length - 1} OFFSET $${rowParams.length}`,
             rowParams
@@ -22875,6 +22929,321 @@ module.exports = {
           }
           logger.error('Attendance rotation assignments query failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load rotation assignments' } })
+        }
+      }
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/schedule-drafts/rotation-assignments',
+      async (req, res) => {
+        const parsed = rotationAssignmentCreateSchema.safeParse(normalizeRotationAssignmentPayload(req.body))
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+
+        const orgId = getOrgId(req)
+        const rotationRuleId = normalizeUuidString(parsed.data.rotationRuleId)
+        if (!rotationRuleId) {
+          respondInvalidUuid(res, 'rotationRuleId')
+          return
+        }
+        const payload = {
+          userId: parsed.data.userId,
+          rotationRuleId,
+          startDate: parsed.data.startDate,
+          endDate: normalizeAttendanceScheduleAssignmentEndDate(parsed.data.endDate),
+          isActive: parsed.data.isActive ?? true,
+        }
+
+        if (payload.endDate && payload.endDate < payload.startDate) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'End date must be after start date' } })
+          return
+        }
+
+        try {
+          const windowAccess = await enforceShiftEditWindow(res, [payload.startDate])
+          if (!windowAccess) return
+
+          const access = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, { orgId, payload })
+          if (!access) return
+
+          const ruleRows = await db.query(
+            'SELECT * FROM attendance_rotation_rules WHERE id = $1 AND org_id = $2',
+            [payload.rotationRuleId, orgId]
+          )
+          if (!ruleRows.length) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Rotation rule not found' } })
+            return
+          }
+
+          const result = await db.transaction(async (trx) => {
+            await acquireAttendanceScheduleAssignmentLock(trx, orgId, payload.userId)
+            const conflict = await findAttendanceScheduleAssignmentConflict(trx, {
+              kind: 'rotation',
+              orgId,
+              userId: payload.userId,
+              startDate: payload.startDate,
+              endDate: payload.endDate,
+              isActive: payload.isActive,
+            }, { publishStatuses: ['draft', 'pending'] })
+            if (conflict) return { conflict }
+
+            const rows = await trx.query(
+              `INSERT INTO attendance_rotation_assignments
+               (id, org_id, user_id, rotation_rule_id, start_date, end_date, is_active, publish_status)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, 'draft')
+               RETURNING *`,
+              [
+                randomUUID(),
+                orgId,
+                payload.userId,
+                payload.rotationRuleId,
+                payload.startDate,
+                payload.endDate,
+                payload.isActive,
+              ]
+            )
+            return { row: rows[0] }
+          })
+
+          if (result.conflict) {
+            respondAttendanceScheduleAssignmentConflict(res, result.conflict)
+            return
+          }
+
+          const assignment = mapRotationAssignmentRow(result.row)
+          const rotation = mapRotationRuleRow(ruleRows[0])
+          res.status(201).json({ ok: true, data: { assignment, rotation } })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance draft rotation assignment creation failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create draft rotation assignment' } })
+        }
+      }
+    )
+
+    context.api.http.addRoute(
+      'PUT',
+      '/api/attendance/schedule-drafts/rotation-assignments/:id',
+      async (req, res) => {
+        const parsed = rotationAssignmentUpdateSchema.safeParse(normalizeRotationAssignmentPayload(req.body ?? {}))
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+
+        const orgId = getOrgId(req)
+        const assignmentId = normalizeUuidString(req.params.id)
+        if (!assignmentId) {
+          respondInvalidUuid(res)
+          return
+        }
+
+        try {
+          const actorAccess = await resolveAttendanceSchedulerScopeActor(req, res)
+          if (!actorAccess) return
+
+          const existingRows = await db.query(
+            'SELECT * FROM attendance_rotation_assignments WHERE id = $1 AND org_id = $2',
+            [assignmentId, orgId]
+          )
+          if (!existingRows.length) {
+            if (!actorAccess.fullAdmin) {
+              respondAttendanceSchedulerScopeForbidden(res)
+              return
+            }
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Rotation assignment not found' } })
+            return
+          }
+
+          const existing = existingRows[0]
+          const existingPublishStatus = normalizeAttendanceSchedulePublishStatus(existing.publish_status)
+          if (!isAttendanceScheduleDraftEditable(existing)) {
+            respondAttendanceSchedulePublishLocked(res, existingPublishStatus)
+            return
+          }
+          const nextRotationRuleId = parsed.data.rotationRuleId !== undefined
+            ? normalizeUuidString(parsed.data.rotationRuleId)
+            : existing.rotation_rule_id
+          if (!nextRotationRuleId) {
+            respondInvalidUuid(res, 'rotationRuleId')
+            return
+          }
+          const payload = {
+            userId: parsed.data.userId ?? existing.user_id,
+            rotationRuleId: nextRotationRuleId,
+            startDate: parsed.data.startDate ?? existing.start_date,
+            endDate: resolveAttendanceScheduleAssignmentUpdateEndDate(parsed.data, existing.end_date),
+            isActive: parsed.data.isActive ?? existing.is_active,
+          }
+
+          if (payload.endDate && payload.endDate < payload.startDate) {
+            res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'End date must be after start date' } })
+            return
+          }
+
+          const windowAccess = await enforceShiftEditWindow(res, [existing.start_date, payload.startDate])
+          if (!windowAccess) return
+
+          const existingAccess = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
+            orgId,
+            payload: existing,
+            actorAccess,
+          })
+          if (!existingAccess) return
+          const nextAccess = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
+            orgId,
+            payload,
+            actorAccess,
+          })
+          if (!nextAccess) return
+
+          const ruleRows = await db.query(
+            'SELECT * FROM attendance_rotation_rules WHERE id = $1 AND org_id = $2',
+            [payload.rotationRuleId, orgId]
+          )
+          if (!ruleRows.length) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Rotation rule not found' } })
+            return
+          }
+
+          const result = await db.transaction(async (trx) => {
+            await acquireAttendanceScheduleAssignmentLock(trx, orgId, payload.userId)
+            const conflict = await findAttendanceScheduleAssignmentConflict(trx, {
+              kind: 'rotation',
+              orgId,
+              userId: payload.userId,
+              startDate: payload.startDate,
+              endDate: payload.endDate,
+              isActive: payload.isActive,
+              excludeId: assignmentId,
+            }, { publishStatuses: ['draft', 'pending'] })
+            if (conflict) return { conflict }
+
+            const rows = await trx.query(
+              `UPDATE attendance_rotation_assignments
+               SET user_id = $3,
+                   rotation_rule_id = $4,
+                   start_date = $5,
+                   end_date = $6,
+                   is_active = $7,
+                   updated_at = now()
+               WHERE id = $1 AND org_id = $2 AND publish_status = 'draft'
+               RETURNING *`,
+              [
+                assignmentId,
+                orgId,
+                payload.userId,
+                payload.rotationRuleId,
+                payload.startDate,
+                payload.endDate,
+                payload.isActive,
+              ]
+            )
+            if (!rows.length) {
+              const publishStatus = await loadAttendanceScheduleAssignmentPublishStatus(trx, 'attendance_rotation_assignments', assignmentId, orgId)
+              return publishStatus ? { lockedPublishStatus: publishStatus } : { missing: true }
+            }
+            return { row: rows[0] }
+          })
+
+          if (result.lockedPublishStatus) {
+            respondAttendanceSchedulePublishLocked(res, result.lockedPublishStatus)
+            return
+          }
+          if (result.missing) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Rotation assignment not found' } })
+            return
+          }
+          if (result.conflict) {
+            respondAttendanceScheduleAssignmentConflict(res, result.conflict)
+            return
+          }
+
+          const assignment = mapRotationAssignmentRow(result.row)
+          const rotation = mapRotationRuleRow(ruleRows[0])
+          res.json({ ok: true, data: { assignment, rotation } })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance draft rotation assignment update failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to update draft rotation assignment' } })
+        }
+      }
+    )
+
+    context.api.http.addRoute(
+      'DELETE',
+      '/api/attendance/schedule-drafts/rotation-assignments/:id',
+      async (req, res) => {
+        const orgId = getOrgId(req)
+        const assignmentId = normalizeUuidString(req.params.id)
+        if (!assignmentId) {
+          respondInvalidUuid(res)
+          return
+        }
+
+        try {
+          const actorAccess = await resolveAttendanceSchedulerScopeActor(req, res)
+          if (!actorAccess) return
+
+          const existingRows = await db.query(
+            'SELECT * FROM attendance_rotation_assignments WHERE id = $1 AND org_id = $2',
+            [assignmentId, orgId]
+          )
+          if (!existingRows.length) {
+            if (!actorAccess.fullAdmin) {
+              respondAttendanceSchedulerScopeForbidden(res)
+              return
+            }
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Rotation assignment not found' } })
+            return
+          }
+
+          const existingPublishStatus = normalizeAttendanceSchedulePublishStatus(existingRows[0].publish_status)
+          if (!isAttendanceScheduleDraftEditable(existingRows[0])) {
+            respondAttendanceSchedulePublishLocked(res, existingPublishStatus)
+            return
+          }
+
+          const windowAccess = await enforceShiftEditWindow(res, [existingRows[0].start_date])
+          if (!windowAccess) return
+
+          const access = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
+            orgId,
+            payload: existingRows[0],
+            actorAccess,
+          })
+          if (!access) return
+
+          const rows = await db.query(
+            'DELETE FROM attendance_rotation_assignments WHERE id = $1 AND org_id = $2 AND publish_status = $3 RETURNING id',
+            [assignmentId, orgId, 'draft']
+          )
+          if (!rows.length) {
+            const publishStatus = await loadAttendanceScheduleAssignmentPublishStatus(db, 'attendance_rotation_assignments', assignmentId, orgId)
+            if (publishStatus) {
+              respondAttendanceSchedulePublishLocked(res, publishStatus)
+              return
+            }
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Draft rotation assignment not found' } })
+            return
+          }
+          res.json({ ok: true, data: { id: assignmentId } })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance draft rotation assignment delete failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete draft rotation assignment' } })
         }
       }
     )
@@ -23016,6 +23385,11 @@ module.exports = {
           }
 
           const existing = existingRows[0]
+          const existingPublishStatus = normalizeAttendanceSchedulePublishStatus(existing.publish_status)
+          if (existingPublishStatus !== 'published') {
+            respondAttendanceSchedulePublishLocked(res, existingPublishStatus)
+            return
+          }
           const nextRotationRuleId = parsed.data.rotationRuleId !== undefined
             ? normalizeUuidString(parsed.data.rotationRuleId)
             : existing.rotation_rule_id
@@ -23082,7 +23456,7 @@ module.exports = {
                    end_date = $6,
                    is_active = $7,
                    updated_at = now()
-               WHERE id = $1 AND org_id = $2
+               WHERE id = $1 AND org_id = $2 AND COALESCE(publish_status, 'published') = 'published'
                RETURNING *`,
               [
                 assignmentId,
@@ -23094,6 +23468,10 @@ module.exports = {
                 payload.isActive,
               ]
             )
+            if (!rows.length) {
+              const publishStatus = await loadAttendanceScheduleAssignmentPublishStatus(trx, 'attendance_rotation_assignments', assignmentId, orgId)
+              return publishStatus ? { lockedPublishStatus: publishStatus } : { missing: true }
+            }
             await enforceShiftComplianceCap(trx, {
               orgId,
               userId: payload.userId,
@@ -23103,6 +23481,14 @@ module.exports = {
             return { row: rows[0] }
           })
 
+          if (result.lockedPublishStatus) {
+            respondAttendanceSchedulePublishLocked(res, result.lockedPublishStatus)
+            return
+          }
+          if (result.missing) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Rotation assignment not found' } })
+            return
+          }
           if (result.conflict) {
             respondAttendanceScheduleAssignmentConflict(res, result.conflict)
             return
@@ -23152,6 +23538,12 @@ module.exports = {
             return
           }
 
+          const existingPublishStatus = normalizeAttendanceSchedulePublishStatus(existingRows[0].publish_status)
+          if (existingPublishStatus !== 'published') {
+            respondAttendanceSchedulePublishLocked(res, existingPublishStatus)
+            return
+          }
+
           const windowAccess = await enforceShiftEditWindow(res, [existingRows[0].start_date])
           if (!windowAccess) return
 
@@ -23163,10 +23555,17 @@ module.exports = {
           if (!access) return
 
           const rows = await db.query(
-            'DELETE FROM attendance_rotation_assignments WHERE id = $1 AND org_id = $2 RETURNING id',
+            `DELETE FROM attendance_rotation_assignments
+             WHERE id = $1 AND org_id = $2 AND COALESCE(publish_status, 'published') = 'published'
+             RETURNING id`,
             [assignmentId, orgId]
           )
           if (!rows.length) {
+            const publishStatus = await loadAttendanceScheduleAssignmentPublishStatus(db, 'attendance_rotation_assignments', assignmentId, orgId)
+            if (publishStatus) {
+              respondAttendanceSchedulePublishLocked(res, publishStatus)
+              return
+            }
             res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Rotation assignment not found' } })
             return
           }
@@ -30991,6 +31390,7 @@ module.exports = {
         const schema = z.object({
           orgId: z.string().optional(),
           userId: z.string().optional(),
+          publishStatus: z.enum(['draft', 'pending', 'published', 'all']).optional(),
         })
 
         const parsed = schema.safeParse({
@@ -30998,6 +31398,9 @@ module.exports = {
           userId: typeof req.query.userId === 'string'
             ? req.query.userId
             : (typeof req.query.user_id === 'string' ? req.query.user_id : undefined),
+          publishStatus: typeof req.query.publishStatus === 'string'
+            ? req.query.publishStatus
+            : (typeof req.query.publish_status === 'string' ? req.query.publish_status : undefined),
         })
 
         if (!parsed.success) {
@@ -31007,6 +31410,7 @@ module.exports = {
 
         const orgId = getOrgId(req)
         const { page, pageSize, offset } = parsePagination(req.query)
+        const publishStatusFilter = normalizeAttendanceSchedulePublishStatusFilter(parsed.data.publishStatus)
         const viewAccess = await loadAttendanceSchedulerScopesForAction(req, res, { action: 'view' })
         if (!viewAccess) return
 
@@ -31017,6 +31421,11 @@ module.exports = {
             countParams.push(parsed.data.userId)
             userFilter = `AND a.user_id = $${countParams.length}`
           }
+          let countPublishStatusFilter = ''
+          if (publishStatusFilter) {
+            countParams.push(publishStatusFilter)
+            countPublishStatusFilter = `AND COALESCE(a.publish_status, 'published') = $${countParams.length}`
+          }
           const countScopeClause = viewAccess.access.fullAdmin
             ? ''
             : buildAttendanceAssignmentViewSql(viewAccess.scopes, countParams, 'a')
@@ -31024,7 +31433,7 @@ module.exports = {
           const countRows = await db.query(
             `SELECT COUNT(*)::int AS total
              FROM attendance_shift_assignments a
-             WHERE a.org_id = $1 ${userFilter} ${countScopeClause}`,
+             WHERE a.org_id = $1 ${userFilter} ${countPublishStatusFilter} ${countScopeClause}`,
             countParams
           )
           const total = Number(countRows[0]?.total ?? 0)
@@ -31034,6 +31443,11 @@ module.exports = {
           if (parsed.data.userId) {
             rowParams.push(parsed.data.userId)
             rowUserFilter = `AND a.user_id = $${rowParams.length}`
+          }
+          let rowPublishStatusFilter = ''
+          if (publishStatusFilter) {
+            rowParams.push(publishStatusFilter)
+            rowPublishStatusFilter = `AND COALESCE(a.publish_status, 'published') = $${rowParams.length}`
           }
           const rowScopeClause = viewAccess.access.fullAdmin
             ? ''
@@ -31049,7 +31463,7 @@ module.exports = {
                     s.working_days AS shift_working_days
              FROM attendance_shift_assignments a
              JOIN attendance_shifts s ON s.id = a.shift_id
-             WHERE a.org_id = $1 ${rowUserFilter} ${rowScopeClause}
+             WHERE a.org_id = $1 ${rowUserFilter} ${rowPublishStatusFilter} ${rowScopeClause}
              ORDER BY a.start_date DESC, a.created_at DESC
              LIMIT $${rowParams.length - 1} OFFSET $${rowParams.length}`,
             rowParams
@@ -31074,6 +31488,348 @@ module.exports = {
           }
           logger.error('Attendance assignments query failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load assignments' } })
+        }
+      }
+    )
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/schedule-drafts/assignments',
+      async (req, res) => {
+        const parsed = assignmentCreateSchema.safeParse(normalizeAssignmentPayload(req.body))
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+
+        const orgId = getOrgId(req)
+        const shiftId = normalizeUuidString(parsed.data.shiftId)
+        if (!shiftId) {
+          respondInvalidUuid(res, 'shiftId')
+          return
+        }
+        const payload = {
+          userId: parsed.data.userId,
+          shiftId,
+          startDate: parsed.data.startDate,
+          endDate: normalizeAttendanceScheduleAssignmentEndDate(parsed.data.endDate),
+          isActive: parsed.data.isActive ?? true,
+        }
+
+        if (payload.endDate && payload.endDate < payload.startDate) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'End date must be after start date' } })
+          return
+        }
+
+        try {
+          const windowAccess = await enforceShiftEditWindow(res, [payload.startDate])
+          if (!windowAccess) return
+
+          const access = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, { orgId, payload })
+          if (!access) return
+
+          const shiftRows = await db.query(
+            'SELECT * FROM attendance_shifts WHERE id = $1 AND org_id = $2',
+            [payload.shiftId, orgId]
+          )
+          if (!shiftRows.length) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Shift not found' } })
+            return
+          }
+          const settings = await getSettings(db)
+          const slotResolution = resolveAttendanceScheduleAssignmentSlotIndex(settings, parsed.data.slotIndex, 0)
+          if (!slotResolution.ok) {
+            res.status(slotResolution.status).json({ ok: false, error: { code: slotResolution.code, message: slotResolution.message } })
+            return
+          }
+          payload.slotIndex = slotResolution.slotIndex
+
+          const result = await db.transaction(async (trx) => {
+            await acquireAttendanceScheduleAssignmentLock(trx, orgId, payload.userId)
+            const conflict = await findAttendanceScheduleAssignmentConflict(trx, {
+              kind: 'shift',
+              orgId,
+              userId: payload.userId,
+              startDate: payload.startDate,
+              endDate: payload.endDate,
+              isActive: payload.isActive,
+              slotIndex: payload.slotIndex,
+              multiShiftEnabled: slotResolution.multiShiftDay.enabled,
+              shift: shiftRows[0],
+            }, { publishStatuses: ['draft', 'pending'] })
+            if (conflict) return { conflict }
+
+            const rows = await trx.query(
+              `INSERT INTO attendance_shift_assignments
+               (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active, publish_status)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'draft')
+               RETURNING *`,
+              [
+                randomUUID(),
+                orgId,
+                payload.userId,
+                payload.shiftId,
+                payload.slotIndex,
+                payload.startDate,
+                payload.endDate,
+                payload.isActive,
+              ]
+            )
+            return { row: rows[0] }
+          })
+
+          if (result.conflict) {
+            respondAttendanceScheduleAssignmentConflict(res, result.conflict)
+            return
+          }
+
+          const assignment = mapAssignmentRow(result.row)
+          const shift = mapShiftRow(shiftRows[0])
+          res.status(201).json({ ok: true, data: { assignment, shift } })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance draft assignment creation failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to create draft assignment' } })
+        }
+      }
+    )
+
+    context.api.http.addRoute(
+      'PUT',
+      '/api/attendance/schedule-drafts/assignments/:id',
+      async (req, res) => {
+        const parsed = assignmentUpdateSchema.safeParse(normalizeAssignmentPayload(req.body ?? {}))
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+
+        const orgId = getOrgId(req)
+        const assignmentId = normalizeUuidString(req.params.id)
+        if (!assignmentId) {
+          respondInvalidUuid(res)
+          return
+        }
+
+        try {
+          const actorAccess = await resolveAttendanceSchedulerScopeActor(req, res)
+          if (!actorAccess) return
+
+          const existingRows = await db.query(
+            'SELECT * FROM attendance_shift_assignments WHERE id = $1 AND org_id = $2',
+            [assignmentId, orgId]
+          )
+          if (!existingRows.length) {
+            if (!actorAccess.fullAdmin) {
+              respondAttendanceSchedulerScopeForbidden(res)
+              return
+            }
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Assignment not found' } })
+            return
+          }
+
+          const existing = existingRows[0]
+          const existingPublishStatus = normalizeAttendanceSchedulePublishStatus(existing.publish_status)
+          if (!isAttendanceScheduleDraftEditable(existing)) {
+            respondAttendanceSchedulePublishLocked(res, existingPublishStatus)
+            return
+          }
+          const nextShiftId = parsed.data.shiftId !== undefined
+            ? normalizeUuidString(parsed.data.shiftId)
+            : existing.shift_id
+          if (!nextShiftId) {
+            respondInvalidUuid(res, 'shiftId')
+            return
+          }
+          const payload = {
+            userId: parsed.data.userId ?? existing.user_id,
+            shiftId: nextShiftId,
+            startDate: parsed.data.startDate ?? existing.start_date,
+            endDate: resolveAttendanceScheduleAssignmentUpdateEndDate(parsed.data, existing.end_date),
+            isActive: parsed.data.isActive ?? existing.is_active,
+          }
+
+          if (payload.endDate && payload.endDate < payload.startDate) {
+            res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'End date must be after start date' } })
+            return
+          }
+
+          const windowAccess = await enforceShiftEditWindow(res, [existing.start_date, payload.startDate])
+          if (!windowAccess) return
+
+          const existingAccess = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
+            orgId,
+            payload: existing,
+            actorAccess,
+          })
+          if (!existingAccess) return
+          const nextAccess = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
+            orgId,
+            payload,
+            actorAccess,
+          })
+          if (!nextAccess) return
+
+          const shiftRows = await db.query(
+            'SELECT * FROM attendance_shifts WHERE id = $1 AND org_id = $2',
+            [payload.shiftId, orgId]
+          )
+          if (!shiftRows.length) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Shift not found' } })
+            return
+          }
+          const settings = await getSettings(db)
+          const slotResolution = resolveAttendanceScheduleAssignmentSlotIndex(
+            settings,
+            parsed.data.slotIndex,
+            normalizeAttendanceScheduleSlotIndex(existing.slot_index, 0)
+          )
+          if (!slotResolution.ok) {
+            res.status(slotResolution.status).json({ ok: false, error: { code: slotResolution.code, message: slotResolution.message } })
+            return
+          }
+          payload.slotIndex = slotResolution.slotIndex
+
+          const result = await db.transaction(async (trx) => {
+            await acquireAttendanceScheduleAssignmentLock(trx, orgId, payload.userId)
+            const conflict = await findAttendanceScheduleAssignmentConflict(trx, {
+              kind: 'shift',
+              orgId,
+              userId: payload.userId,
+              startDate: payload.startDate,
+              endDate: payload.endDate,
+              isActive: payload.isActive,
+              slotIndex: payload.slotIndex,
+              multiShiftEnabled: slotResolution.multiShiftDay.enabled,
+              shift: shiftRows[0],
+              excludeId: assignmentId,
+            }, { publishStatuses: ['draft', 'pending'] })
+            if (conflict) return { conflict }
+
+            const rows = await trx.query(
+              `UPDATE attendance_shift_assignments
+               SET user_id = $3,
+                   shift_id = $4,
+                   slot_index = $5,
+                   start_date = $6,
+                   end_date = $7,
+                   is_active = $8,
+                   updated_at = now()
+               WHERE id = $1 AND org_id = $2 AND publish_status = 'draft'
+               RETURNING *`,
+              [
+                assignmentId,
+                orgId,
+                payload.userId,
+                payload.shiftId,
+                payload.slotIndex,
+                payload.startDate,
+                payload.endDate,
+                payload.isActive,
+              ]
+            )
+            if (!rows.length) {
+              const publishStatus = await loadAttendanceScheduleAssignmentPublishStatus(trx, 'attendance_shift_assignments', assignmentId, orgId)
+              return publishStatus ? { lockedPublishStatus: publishStatus } : { missing: true }
+            }
+            return { row: rows[0] }
+          })
+
+          if (result.lockedPublishStatus) {
+            respondAttendanceSchedulePublishLocked(res, result.lockedPublishStatus)
+            return
+          }
+          if (result.missing) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Assignment not found' } })
+            return
+          }
+          if (result.conflict) {
+            respondAttendanceScheduleAssignmentConflict(res, result.conflict)
+            return
+          }
+
+          const assignment = mapAssignmentRow(result.row)
+          const shift = mapShiftRow(shiftRows[0])
+          res.json({ ok: true, data: { assignment, shift } })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance draft assignment update failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to update draft assignment' } })
+        }
+      }
+    )
+
+    context.api.http.addRoute(
+      'DELETE',
+      '/api/attendance/schedule-drafts/assignments/:id',
+      async (req, res) => {
+        const orgId = getOrgId(req)
+        const assignmentId = normalizeUuidString(req.params.id)
+        if (!assignmentId) {
+          respondInvalidUuid(res)
+          return
+        }
+
+        try {
+          const actorAccess = await resolveAttendanceSchedulerScopeActor(req, res)
+          if (!actorAccess) return
+
+          const existingRows = await db.query(
+            'SELECT * FROM attendance_shift_assignments WHERE id = $1 AND org_id = $2',
+            [assignmentId, orgId]
+          )
+          if (!existingRows.length) {
+            if (!actorAccess.fullAdmin) {
+              respondAttendanceSchedulerScopeForbidden(res)
+              return
+            }
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Assignment not found' } })
+            return
+          }
+
+          const existingPublishStatus = normalizeAttendanceSchedulePublishStatus(existingRows[0].publish_status)
+          if (!isAttendanceScheduleDraftEditable(existingRows[0])) {
+            respondAttendanceSchedulePublishLocked(res, existingPublishStatus)
+            return
+          }
+
+          const windowAccess = await enforceShiftEditWindow(res, [existingRows[0].start_date])
+          if (!windowAccess) return
+
+          const access = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
+            orgId,
+            payload: existingRows[0],
+            actorAccess,
+          })
+          if (!access) return
+
+          const rows = await db.query(
+            'DELETE FROM attendance_shift_assignments WHERE id = $1 AND org_id = $2 AND publish_status = $3 RETURNING id',
+            [assignmentId, orgId, 'draft']
+          )
+          if (!rows.length) {
+            const publishStatus = await loadAttendanceScheduleAssignmentPublishStatus(db, 'attendance_shift_assignments', assignmentId, orgId)
+            if (publishStatus) {
+              respondAttendanceSchedulePublishLocked(res, publishStatus)
+              return
+            }
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Draft assignment not found' } })
+            return
+          }
+          res.json({ ok: true, data: { id: assignmentId } })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance draft assignment delete failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete draft assignment' } })
         }
       }
     )
@@ -31226,6 +31982,11 @@ module.exports = {
           }
 
           const existing = existingRows[0]
+          const existingPublishStatus = normalizeAttendanceSchedulePublishStatus(existing.publish_status)
+          if (existingPublishStatus !== 'published') {
+            respondAttendanceSchedulePublishLocked(res, existingPublishStatus)
+            return
+          }
           const nextShiftId = parsed.data.shiftId !== undefined
             ? normalizeUuidString(parsed.data.shiftId)
             : existing.shift_id
@@ -31307,7 +32068,7 @@ module.exports = {
                    end_date = $7,
                    is_active = $8,
                    updated_at = now()
-               WHERE id = $1 AND org_id = $2
+               WHERE id = $1 AND org_id = $2 AND COALESCE(publish_status, 'published') = 'published'
                RETURNING *`,
               [
                 assignmentId,
@@ -31320,6 +32081,10 @@ module.exports = {
                 payload.isActive,
               ]
             )
+            if (!rows.length) {
+              const publishStatus = await loadAttendanceScheduleAssignmentPublishStatus(trx, 'attendance_shift_assignments', assignmentId, orgId)
+              return publishStatus ? { lockedPublishStatus: publishStatus } : { missing: true }
+            }
             await enforceShiftComplianceCap(trx, {
               orgId,
               userId: payload.userId,
@@ -31329,6 +32094,14 @@ module.exports = {
             return { row: rows[0] }
           })
 
+          if (result.lockedPublishStatus) {
+            respondAttendanceSchedulePublishLocked(res, result.lockedPublishStatus)
+            return
+          }
+          if (result.missing) {
+            res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Assignment not found' } })
+            return
+          }
           if (result.conflict) {
             respondAttendanceScheduleAssignmentConflict(res, result.conflict)
             return
@@ -31378,6 +32151,12 @@ module.exports = {
             return
           }
 
+          const existingPublishStatus = normalizeAttendanceSchedulePublishStatus(existingRows[0].publish_status)
+          if (existingPublishStatus !== 'published') {
+            respondAttendanceSchedulePublishLocked(res, existingPublishStatus)
+            return
+          }
+
           const windowAccess = await enforceShiftEditWindow(res, [existingRows[0].start_date])
           if (!windowAccess) return
 
@@ -31389,10 +32168,17 @@ module.exports = {
           if (!access) return
 
           const rows = await db.query(
-            'DELETE FROM attendance_shift_assignments WHERE id = $1 AND org_id = $2 RETURNING id',
+            `DELETE FROM attendance_shift_assignments
+             WHERE id = $1 AND org_id = $2 AND COALESCE(publish_status, 'published') = 'published'
+             RETURNING id`,
             [assignmentId, orgId]
           )
           if (!rows.length) {
+            const publishStatus = await loadAttendanceScheduleAssignmentPublishStatus(db, 'attendance_shift_assignments', assignmentId, orgId)
+            if (publishStatus) {
+              respondAttendanceSchedulePublishLocked(res, publishStatus)
+              return
+            }
             res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Assignment not found' } })
             return
           }


### PR DESCRIPTION
## Summary
- add draft-aware schedule assignment routes for direct shifts and rotation assignments under `/api/attendance/schedule-drafts/*`
- add `publishStatus`/`publish_status` filters to admin assignment list endpoints while leaving default list behavior broad
- keep ordinary assignment creates immediately `published`, and guard ordinary update/delete plus draft update/delete with final status predicates to avoid draft/pending write-through

## Scope
- Stacked on #2430 / `codex/attendance-schedule-publish-p0-lifecycle-20260610`
- P1 only: draft CRUD foundation + admin list filters
- Not included: publish transaction/preflight, publish UI, OpenAPI/SDK surface, staging smoke

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "supports draft schedule CRUD" --reporter=dot` (loads the spec; local env has no DB so attendance integration tests are skipped)

## Review notes
- Subagent read-only review caught and re-checked: fixed invalid `workingDays` fixture and added final mutation status predicates for draft/published routes; re-review reported no P1/P2 findings.
- An earlier `pnpm test:integration -- --run ...` command was too broad for this repo script and ran unrelated integration suites without a local DB; that failure is not a P1 validation signal for this slice.
