### PR TITLE
feat(attendance): add schedule publish transition

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -3339,6 +3339,263 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('publishes draft schedule assignments transactionally with preflight, conflict, and compliance rollback', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const adminUserId = `attendance-publish-admin-${runSuffix}`
+    const publishUserId = `attendance-publish-user-${runSuffix}`
+    const rotationUserId = `attendance-publish-rotation-${runSuffix}`
+    const conflictUserId = `attendance-publish-conflict-${runSuffix}`
+    const complianceUserId = `attendance-publish-cap-${runSuffix}`
+    const workDate = '2026-07-27'
+    const rotationDate = '2026-07-28'
+    const conflictDate = '2026-07-29'
+    const complianceDate = '2026-07-30'
+    const pool = new Pool({ connectionString: dbUrl })
+    let originalSettings: Record<string, unknown> = {}
+    const shiftIds: string[] = []
+    const rotationRuleIds: string[] = []
+
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) {
+      await pool.end().catch(() => undefined)
+      return
+    }
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    }
+
+    async function createShift(name: string, workStartTime: string, workEndTime: string): Promise<string> {
+      const res = await requestJson(`${baseUrl}/api/attendance/shifts`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name,
+          timezone: 'UTC',
+          workStartTime,
+          workEndTime,
+          workingDays: [0, 1, 2, 3, 4, 5, 6],
+        }),
+      })
+      expect(res.status, JSON.stringify(res.body)).toBe(201)
+      const id = (res.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(id).toBeTruthy()
+      if (!id) throw new Error('missing shift id')
+      shiftIds.push(id)
+      return id
+    }
+
+    async function createRotationRule(name: string, shiftId: string): Promise<string> {
+      const res = await requestJson(`${baseUrl}/api/attendance/rotation-rules`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name,
+          timezone: 'UTC',
+          shiftSequence: [shiftId],
+          isActive: true,
+        }),
+      })
+      expect(res.status, JSON.stringify(res.body)).toBe(201)
+      const id = (res.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(id).toBeTruthy()
+      if (!id) throw new Error('missing rotation rule id')
+      rotationRuleIds.push(id)
+      return id
+    }
+
+    async function createDraftAssignment(userId: string, shiftId: string, date: string): Promise<string> {
+      const res = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ userId, shiftId, startDate: date, endDate: date, isActive: true }),
+      })
+      expect(res.status, JSON.stringify(res.body)).toBe(201)
+      const id = (res.body as { data?: { assignment?: { id?: string } } } | undefined)?.data?.assignment?.id
+      expect(id).toBeTruthy()
+      if (!id) throw new Error('missing draft assignment id')
+      return id
+    }
+
+    async function publish(body: Record<string, unknown>): Promise<HttpResponse> {
+      return requestJson(`${baseUrl}/api/attendance/schedule-publications`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(body),
+      })
+    }
+
+    try {
+      const settingsRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      expect(settingsRes.status).toBe(200)
+      originalSettings = ((settingsRes.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
+      const settingsUpdateRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({
+          shiftEditPolicy: { mode: 'unrestricted', windowDays: 0 },
+          shiftCompliance: { enforcement: 'warn', dailyMaxMinutes: null, weeklyMaxMinutes: null, monthlyMaxMinutes: null },
+          multiShiftDay: { enabled: false, maxSlots: 3 },
+        }),
+      })
+      expect(settingsUpdateRes.status, JSON.stringify(settingsUpdateRes.body)).toBe(200)
+
+      const oneHourShiftId = await createShift(`Publish One Hour ${runSuffix}`, '08:00', '09:00')
+      const twoHourShiftId = await createShift(`Publish Two Hour ${runSuffix}`, '10:00', '12:00')
+      const capShiftId = await createShift(`Publish Cap ${runSuffix}`, '13:00', '15:00')
+      const publishDraftId = await createDraftAssignment(publishUserId, oneHourShiftId, workDate)
+
+      const preflightRes = await publish({ assignmentIds: [publishDraftId], preflightOnly: true })
+      expect(preflightRes.status, JSON.stringify(preflightRes.body)).toBe(200)
+      const preflightData = (preflightRes.body as { data?: { preflightOnly?: boolean; totalPublished?: number; assignments?: Array<{ id?: string; publishStatus?: string }> } } | undefined)?.data
+      expect(preflightData?.preflightOnly).toBe(true)
+      expect(preflightData?.totalPublished).toBe(1)
+      expect(preflightData?.assignments?.[0]?.publishStatus).toBe('published')
+      const preflightPersisted = await pool.query(
+        `SELECT publish_status, publish_batch_id, publish_requested_at, publish_requested_by,
+                published_at, published_by, locked_at
+           FROM attendance_shift_assignments
+          WHERE id = $1`,
+        [publishDraftId],
+      )
+      expect(preflightPersisted.rows[0]?.publish_status).toBe('draft')
+      expect(preflightPersisted.rows[0]?.publish_batch_id).toBeNull()
+      expect(preflightPersisted.rows[0]?.publish_requested_at).toBeNull()
+      expect(preflightPersisted.rows[0]?.publish_requested_by).toBeNull()
+      expect(preflightPersisted.rows[0]?.published_at).toBeNull()
+      expect(preflightPersisted.rows[0]?.published_by).toBeNull()
+      expect(preflightPersisted.rows[0]?.locked_at).toBeNull()
+
+      const rotationRuleId = await createRotationRule(`Publish Rotation ${runSuffix}`, oneHourShiftId)
+      const rotationDraftRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/rotation-assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          userId: rotationUserId,
+          rotationRuleId,
+          startDate: rotationDate,
+          endDate: rotationDate,
+          isActive: true,
+        }),
+      })
+      expect(rotationDraftRes.status, JSON.stringify(rotationDraftRes.body)).toBe(201)
+      const rotationDraftId = (rotationDraftRes.body as { data?: { assignment?: { id?: string } } } | undefined)?.data?.assignment?.id
+      expect(rotationDraftId).toBeTruthy()
+      if (!rotationDraftId) return
+
+      const publishRes = await publish({ assignmentIds: [publishDraftId], rotationAssignmentIds: [rotationDraftId] })
+      expect(publishRes.status, JSON.stringify(publishRes.body)).toBe(200)
+      const publishData = (publishRes.body as { data?: { publishBatchId?: string; preflightOnly?: boolean; totalPublished?: number; assignments?: Array<{ id?: string; publishStatus?: string }>; rotationAssignments?: Array<{ id?: string; publishStatus?: string }> } } | undefined)?.data
+      expect(publishData?.preflightOnly).toBe(false)
+      expect(publishData?.publishBatchId).toBeTruthy()
+      expect(publishData?.totalPublished).toBe(2)
+      expect(publishData?.assignments?.[0]?.publishStatus).toBe('published')
+      expect(publishData?.rotationAssignments?.[0]?.publishStatus).toBe('published')
+      const publishedRows = await pool.query(
+        `SELECT id, publish_status, publish_batch_id, publish_requested_at, publish_requested_by,
+                published_at, published_by, locked_at
+           FROM attendance_shift_assignments
+          WHERE id = $1
+         UNION ALL
+         SELECT id, publish_status, publish_batch_id, publish_requested_at, publish_requested_by,
+                published_at, published_by, locked_at
+           FROM attendance_rotation_assignments
+          WHERE id = $2`,
+        [publishDraftId, rotationDraftId],
+      )
+      expect(publishedRows.rows).toHaveLength(2)
+      for (const row of publishedRows.rows) {
+        expect(row.publish_status).toBe('published')
+        expect(row.publish_batch_id).toBe(publishData?.publishBatchId)
+        expect(row.publish_requested_at).toBeTruthy()
+        expect(row.publish_requested_by).toBe(adminUserId)
+        expect(row.published_at).toBeTruthy()
+        expect(row.published_by).toBe(adminUserId)
+        expect(row.locked_at).toBeTruthy()
+      }
+      const lockedPublishedUpdateRes = await requestJson(`${baseUrl}/api/attendance/assignments/${publishDraftId}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ shiftId: twoHourShiftId }),
+      })
+      expect(lockedPublishedUpdateRes.status, JSON.stringify(lockedPublishedUpdateRes.body)).toBe(422)
+      expect((lockedPublishedUpdateRes.body as { error?: { code?: string; details?: { publishStatus?: string } } } | undefined)?.error?.code).toBe('SCHEDULE_PUBLISH_LOCKED')
+      expect((lockedPublishedUpdateRes.body as { error?: { code?: string; details?: { publishStatus?: string } } } | undefined)?.error?.details?.publishStatus).toBe('published')
+
+      const conflictPublishedRes = await requestJson(`${baseUrl}/api/attendance/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          userId: conflictUserId,
+          shiftId: oneHourShiftId,
+          startDate: conflictDate,
+          endDate: conflictDate,
+          isActive: true,
+        }),
+      })
+      expect(conflictPublishedRes.status, JSON.stringify(conflictPublishedRes.body)).toBe(201)
+      const conflictDraftId = await createDraftAssignment(conflictUserId, twoHourShiftId, conflictDate)
+      const conflictPublishRes = await publish({ assignmentIds: [conflictDraftId] })
+      expect(conflictPublishRes.status, JSON.stringify(conflictPublishRes.body)).toBe(409)
+      expect((conflictPublishRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SCHEDULE_PUBLISH_CONFLICT')
+      const conflictDraftRow = await pool.query(
+        'SELECT publish_status, publish_batch_id, published_at FROM attendance_shift_assignments WHERE id = $1',
+        [conflictDraftId],
+      )
+      expect(conflictDraftRow.rows[0]?.publish_status).toBe('draft')
+      expect(conflictDraftRow.rows[0]?.publish_batch_id).toBeNull()
+      expect(conflictDraftRow.rows[0]?.published_at).toBeNull()
+
+      const capSettingsRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({
+          shiftCompliance: { enforcement: 'block', dailyMaxMinutes: 30, weeklyMaxMinutes: null, monthlyMaxMinutes: null },
+        }),
+      })
+      expect(capSettingsRes.status, JSON.stringify(capSettingsRes.body)).toBe(200)
+      const capDraftId = await createDraftAssignment(complianceUserId, capShiftId, complianceDate)
+      const capPublishRes = await publish({ assignmentIds: [capDraftId] })
+      expect(capPublishRes.status, JSON.stringify(capPublishRes.body)).toBe(422)
+      expect((capPublishRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('SHIFT_COMPLIANCE_CAP_EXCEEDED')
+      const capDraftRow = await pool.query(
+        'SELECT publish_status, publish_batch_id, published_at FROM attendance_shift_assignments WHERE id = $1',
+        [capDraftId],
+      )
+      expect(capDraftRow.rows[0]?.publish_status).toBe('draft')
+      expect(capDraftRow.rows[0]?.publish_batch_id).toBeNull()
+      expect(capDraftRow.rows[0]?.published_at).toBeNull()
+    } finally {
+      if (Object.keys(originalSettings).length > 0) {
+        await requestJson(`${baseUrl}/api/attendance/settings`, {
+          method: 'PUT',
+          headers,
+          body: JSON.stringify(originalSettings),
+        }).catch(() => undefined)
+      }
+      const users = [publishUserId, rotationUserId, conflictUserId, complianceUserId]
+      await pool.query('DELETE FROM attendance_shift_assignments WHERE user_id = ANY($1::text[])', [users]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_rotation_assignments WHERE user_id = ANY($1::text[])', [users]).catch(() => undefined)
+      if (rotationRuleIds.length > 0) {
+        await pool.query('DELETE FROM attendance_rotation_rules WHERE id = ANY($1::uuid[])', [rotationRuleIds]).catch(() => undefined)
+      }
+      if (shiftIds.length > 0) {
+        await pool.query('DELETE FROM attendance_shifts WHERE id = ANY($1::uuid[])', [shiftIds]).catch(() => undefined)
+      }
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('enforces schedule-edit windows on shift and rotation assignment writes', async () => {
     if (!baseUrl) return
 

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8853,6 +8853,10 @@ function isAttendanceScheduleDraftEditable(row) {
   return normalizeAttendanceSchedulePublishStatus(row?.publish_status) === 'draft'
 }
 
+function isAttendanceSchedulePublishedDirectlyMutable(row) {
+  return normalizeAttendanceSchedulePublishStatus(row?.publish_status) === 'published' && row?.locked_at == null
+}
+
 function respondAttendanceSchedulePublishLocked(res, status) {
   res.status(422).json({
     ok: false,
@@ -8874,6 +8878,88 @@ async function loadAttendanceScheduleAssignmentPublishStatus(db, tableName, assi
   )
   if (!rows.length) return null
   return normalizeAttendanceSchedulePublishStatus(rows[0].publish_status)
+}
+
+class AttendanceSchedulePublishRouteError extends Error {
+  constructor(status, code, message, details = {}) {
+    super(message)
+    this.name = 'AttendanceSchedulePublishRouteError'
+    this.status = status
+    this.code = code
+    this.details = details
+  }
+}
+
+class AttendanceSchedulePublishPreflightComplete extends Error {
+  constructor(result) {
+    super('Attendance schedule publish preflight complete')
+    this.name = 'AttendanceSchedulePublishPreflightComplete'
+    this.result = result
+  }
+}
+
+function respondAttendanceSchedulePublishRouteError(res, error) {
+  if (!(error instanceof AttendanceSchedulePublishRouteError)) return false
+  res.status(error.status).json({
+    ok: false,
+    error: {
+      code: error.code,
+      message: error.message,
+      details: error.details,
+    },
+  })
+  return true
+}
+
+function throwAttendanceSchedulePublishRouteError(status, code, message, details = {}) {
+  throw new AttendanceSchedulePublishRouteError(status, code, message, details)
+}
+
+function normalizeAttendanceSchedulePublicationIds(value) {
+  const ids = []
+  const invalid = []
+  for (const raw of Array.isArray(value) ? value : []) {
+    const id = normalizeUuidString(raw)
+    if (id) {
+      ids.push(id)
+    } else {
+      invalid.push(raw)
+    }
+  }
+  return { ids: Array.from(new Set(ids)).sort(), invalid }
+}
+
+function attendanceSchedulePublishSnapshot(row) {
+  return [
+    row.kind,
+    row.id,
+    row.user_id,
+    row.shift_id ?? row.rotation_rule_id ?? '',
+    normalizeAttendanceScheduleSlotIndex(row.slot_index, 0),
+    normalizeDateOnly(row.start_date) ?? row.start_date ?? '',
+    normalizeAttendanceScheduleAssignmentEndDate(row.end_date) ?? '',
+    row.is_active === false ? 'false' : 'true',
+    row.updated_at ? new Date(row.updated_at).toISOString() : '',
+  ].join('|')
+}
+
+function buildAttendanceSchedulePublishDraft(row, settings) {
+  const kind = row.kind === 'rotation' ? 'rotation' : 'shift'
+  const draft = {
+    kind,
+    orgId: row.org_id,
+    userId: row.user_id,
+    startDate: normalizeDateOnly(row.start_date) ?? row.start_date,
+    endDate: normalizeAttendanceScheduleAssignmentEndDate(row.end_date),
+    isActive: row.is_active,
+    excludeId: row.id,
+  }
+  if (kind === 'shift') {
+    draft.slotIndex = normalizeAttendanceScheduleSlotIndex(row.slot_index, 0)
+    draft.multiShiftEnabled = settings?.multiShiftDay?.enabled === true
+    draft.shift = row
+  }
+  return draft
 }
 
 function normalizeAttendanceScheduleAssignmentEndDate(value) {
@@ -23386,7 +23472,7 @@ module.exports = {
 
           const existing = existingRows[0]
           const existingPublishStatus = normalizeAttendanceSchedulePublishStatus(existing.publish_status)
-          if (existingPublishStatus !== 'published') {
+          if (!isAttendanceSchedulePublishedDirectlyMutable(existing)) {
             respondAttendanceSchedulePublishLocked(res, existingPublishStatus)
             return
           }
@@ -23456,7 +23542,9 @@ module.exports = {
                    end_date = $6,
                    is_active = $7,
                    updated_at = now()
-               WHERE id = $1 AND org_id = $2 AND COALESCE(publish_status, 'published') = 'published'
+               WHERE id = $1 AND org_id = $2
+                 AND COALESCE(publish_status, 'published') = 'published'
+                 AND locked_at IS NULL
                RETURNING *`,
               [
                 assignmentId,
@@ -23539,7 +23627,7 @@ module.exports = {
           }
 
           const existingPublishStatus = normalizeAttendanceSchedulePublishStatus(existingRows[0].publish_status)
-          if (existingPublishStatus !== 'published') {
+          if (!isAttendanceSchedulePublishedDirectlyMutable(existingRows[0])) {
             respondAttendanceSchedulePublishLocked(res, existingPublishStatus)
             return
           }
@@ -23556,7 +23644,9 @@ module.exports = {
 
           const rows = await db.query(
             `DELETE FROM attendance_rotation_assignments
-             WHERE id = $1 AND org_id = $2 AND COALESCE(publish_status, 'published') = 'published'
+             WHERE id = $1 AND org_id = $2
+               AND COALESCE(publish_status, 'published') = 'published'
+               AND locked_at IS NULL
              RETURNING id`,
             [assignmentId, orgId]
           )
@@ -31983,7 +32073,7 @@ module.exports = {
 
           const existing = existingRows[0]
           const existingPublishStatus = normalizeAttendanceSchedulePublishStatus(existing.publish_status)
-          if (existingPublishStatus !== 'published') {
+          if (!isAttendanceSchedulePublishedDirectlyMutable(existing)) {
             respondAttendanceSchedulePublishLocked(res, existingPublishStatus)
             return
           }
@@ -32068,7 +32158,9 @@ module.exports = {
                    end_date = $7,
                    is_active = $8,
                    updated_at = now()
-               WHERE id = $1 AND org_id = $2 AND COALESCE(publish_status, 'published') = 'published'
+               WHERE id = $1 AND org_id = $2
+                 AND COALESCE(publish_status, 'published') = 'published'
+                 AND locked_at IS NULL
                RETURNING *`,
               [
                 assignmentId,
@@ -32152,7 +32244,7 @@ module.exports = {
           }
 
           const existingPublishStatus = normalizeAttendanceSchedulePublishStatus(existingRows[0].publish_status)
-          if (existingPublishStatus !== 'published') {
+          if (!isAttendanceSchedulePublishedDirectlyMutable(existingRows[0])) {
             respondAttendanceSchedulePublishLocked(res, existingPublishStatus)
             return
           }
@@ -32169,7 +32261,9 @@ module.exports = {
 
           const rows = await db.query(
             `DELETE FROM attendance_shift_assignments
-             WHERE id = $1 AND org_id = $2 AND COALESCE(publish_status, 'published') = 'published'
+             WHERE id = $1 AND org_id = $2
+               AND COALESCE(publish_status, 'published') = 'published'
+               AND locked_at IS NULL
              RETURNING id`,
             [assignmentId, orgId]
           )
@@ -32191,6 +32285,313 @@ module.exports = {
           }
           logger.error('Attendance assignment delete failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete assignment' } })
+        }
+      }
+    )
+
+    const schedulePublicationSchema = z.object({
+      assignmentIds: z.array(z.string().min(1)).optional(),
+      rotationAssignmentIds: z.array(z.string().min(1)).optional(),
+      preflightOnly: z.boolean().optional(),
+    }).strict()
+
+    async function loadAttendanceSchedulePublicationRows(client, orgId, assignmentIds, rotationAssignmentIds, options = {}) {
+      const forUpdate = options.forUpdate === true
+      const rows = []
+      if (assignmentIds.length) {
+        const shiftRows = await client.query(
+          `SELECT a.*, 'shift'::text AS kind,
+                  s.work_start_time, s.work_end_time, s.is_overnight
+             FROM attendance_shift_assignments a
+             LEFT JOIN attendance_shifts s ON s.id = a.shift_id AND s.org_id = a.org_id
+            WHERE a.org_id = $1
+              AND a.id = ANY($2::uuid[])
+            ${forUpdate ? 'FOR UPDATE OF a' : ''}`,
+          [orgId, assignmentIds]
+        )
+        rows.push(...shiftRows)
+      }
+      if (rotationAssignmentIds.length) {
+        const rotationRows = await client.query(
+          `SELECT a.*, 'rotation'::text AS kind
+             FROM attendance_rotation_assignments a
+            WHERE a.org_id = $1
+              AND a.id = ANY($2::uuid[])
+            ${forUpdate ? 'FOR UPDATE OF a' : ''}`,
+          [orgId, rotationAssignmentIds]
+        )
+        rows.push(...rotationRows)
+      }
+      return rows
+    }
+
+    function assertAttendanceSchedulePublicationTargets(res, rows, requestedKeys) {
+      const foundKeys = new Set(rows.map(row => `${row.kind}:${row.id}`))
+      const missingKeys = requestedKeys.filter(key => !foundKeys.has(key))
+      if (missingKeys.length) {
+        res.status(404).json({
+          ok: false,
+          error: {
+            code: 'NOT_FOUND',
+            message: 'One or more draft assignments were not found',
+            details: { missing: missingKeys },
+          },
+        })
+        return false
+      }
+      for (const row of rows) {
+        const publishStatus = normalizeAttendanceSchedulePublishStatus(row.publish_status)
+        if (publishStatus === 'published') {
+          res.status(409).json({
+            ok: false,
+            error: {
+              code: 'SCHEDULE_PUBLISH_ALREADY_PUBLISHED',
+              message: 'One or more target assignments are already published',
+              details: { id: row.id, kind: row.kind, publishStatus },
+            },
+          })
+          return false
+        }
+        if (publishStatus !== 'draft') {
+          respondAttendanceSchedulePublishLocked(res, publishStatus)
+          return false
+        }
+      }
+      return true
+    }
+
+    async function enforceAttendanceSchedulePublicationConflicts(client, row, settings) {
+      const draft = buildAttendanceSchedulePublishDraft(row, settings)
+      const publishedConflict = await findAttendanceScheduleAssignmentConflict(client, draft, { publishStatuses: ['published'] })
+      if (publishedConflict) {
+        throwAttendanceSchedulePublishRouteError(
+          409,
+          'SCHEDULE_PUBLISH_CONFLICT',
+          getAttendanceScheduleAssignmentConflictMessage(publishedConflict),
+          { conflict: publishedConflict }
+        )
+      }
+      const pendingConflict = await findAttendanceScheduleAssignmentConflict(client, draft, { publishStatuses: ['pending'] })
+      if (pendingConflict) {
+        throwAttendanceSchedulePublishRouteError(
+          409,
+          'SCHEDULE_PUBLISH_PENDING_CONFLICT',
+          getAttendanceScheduleAssignmentConflictMessage(pendingConflict),
+          { conflict: pendingConflict }
+        )
+      }
+    }
+
+    context.api.http.addRoute(
+      'POST',
+      '/api/attendance/schedule-publications',
+      async (req, res) => {
+        const parsed = schedulePublicationSchema.safeParse(req.body ?? {})
+        if (!parsed.success) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
+          return
+        }
+
+        const assignmentIdResult = normalizeAttendanceSchedulePublicationIds(parsed.data.assignmentIds)
+        const rotationAssignmentIdResult = normalizeAttendanceSchedulePublicationIds(parsed.data.rotationAssignmentIds)
+        if (assignmentIdResult.invalid.length || rotationAssignmentIdResult.invalid.length) {
+          res.status(400).json({
+            ok: false,
+            error: {
+              code: 'VALIDATION_ERROR',
+              message: 'Invalid schedule assignment id',
+              details: {
+                assignmentIds: assignmentIdResult.invalid,
+                rotationAssignmentIds: rotationAssignmentIdResult.invalid,
+              },
+            },
+          })
+          return
+        }
+
+        const assignmentIds = assignmentIdResult.ids
+        const rotationAssignmentIds = rotationAssignmentIdResult.ids
+        if (!assignmentIds.length && !rotationAssignmentIds.length) {
+          res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'At least one assignment id is required' } })
+          return
+        }
+
+        const orgId = getOrgId(req)
+        const actorUserId = getUserId(req) || null
+        const preflightOnly = parsed.data.preflightOnly === true
+        const requestedKeys = [
+          ...assignmentIds.map(id => `shift:${id}`),
+          ...rotationAssignmentIds.map(id => `rotation:${id}`),
+        ].sort()
+
+        try {
+          const actorAccess = await resolveAttendanceSchedulerScopeActor(req, res)
+          if (!actorAccess) return
+
+          const initialRows = await loadAttendanceSchedulePublicationRows(db, orgId, assignmentIds, rotationAssignmentIds)
+          if (!assertAttendanceSchedulePublicationTargets(res, initialRows, requestedKeys)) return
+
+          const affectedDates = []
+          for (const row of initialRows) {
+            affectedDates.push(row.start_date)
+            if (row.end_date) affectedDates.push(row.end_date)
+            const access = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
+              orgId,
+              payload: row,
+              actorAccess,
+            })
+            if (!access) return
+          }
+
+          const windowAccess = await enforceShiftEditWindow(res, affectedDates)
+          if (!windowAccess) return
+
+          const initialSnapshots = new Map(initialRows.map(row => [`${row.kind}:${row.id}`, attendanceSchedulePublishSnapshot(row)]))
+          const result = await db.transaction(async (trx) => {
+            await acquireAttendanceScheduleAssignmentLocks(trx, orgId, initialRows.map(row => row.user_id))
+            const settings = await getSettings(trx)
+            const lockedRows = await loadAttendanceSchedulePublicationRows(trx, orgId, assignmentIds, rotationAssignmentIds, { forUpdate: true })
+            const lockedKeys = new Set(lockedRows.map(row => `${row.kind}:${row.id}`))
+            const missingKeys = requestedKeys.filter(key => !lockedKeys.has(key))
+            if (missingKeys.length) {
+              throwAttendanceSchedulePublishRouteError(404, 'NOT_FOUND', 'One or more draft assignments were not found', { missing: missingKeys })
+            }
+
+            for (const row of lockedRows) {
+              const key = `${row.kind}:${row.id}`
+              const publishStatus = normalizeAttendanceSchedulePublishStatus(row.publish_status)
+              if (publishStatus !== 'draft' || initialSnapshots.get(key) !== attendanceSchedulePublishSnapshot(row)) {
+                throwAttendanceSchedulePublishRouteError(
+                  409,
+                  'SCHEDULE_PUBLISH_STALE_DRAFT',
+                  'One or more draft assignments changed before publication',
+                  { id: row.id, kind: row.kind, publishStatus }
+                )
+              }
+            }
+
+            for (const row of lockedRows) {
+              await enforceAttendanceSchedulePublicationConflicts(trx, row, settings)
+            }
+
+            const publishBatchId = randomUUID()
+            if (assignmentIds.length) {
+              await trx.query(
+                `UPDATE attendance_shift_assignments
+                    SET publish_status = 'pending',
+                        publish_batch_id = $3,
+                        publish_requested_at = now(),
+                        publish_requested_by = $4,
+                        updated_at = now()
+                  WHERE org_id = $1
+                    AND id = ANY($2::uuid[])
+                    AND publish_status = 'draft'`,
+                [orgId, assignmentIds, publishBatchId, actorUserId]
+              )
+            }
+            if (rotationAssignmentIds.length) {
+              await trx.query(
+                `UPDATE attendance_rotation_assignments
+                    SET publish_status = 'pending',
+                        publish_batch_id = $3,
+                        publish_requested_at = now(),
+                        publish_requested_by = $4,
+                        updated_at = now()
+                  WHERE org_id = $1
+                    AND id = ANY($2::uuid[])
+                    AND publish_status = 'draft'`,
+                [orgId, rotationAssignmentIds, publishBatchId, actorUserId]
+              )
+            }
+
+            const publishedShiftRows = assignmentIds.length
+              ? await trx.query(
+                `UPDATE attendance_shift_assignments
+                    SET publish_status = 'published',
+                        published_at = now(),
+                        published_by = $4,
+                        locked_at = now(),
+                        updated_at = now()
+                  WHERE org_id = $1
+                    AND id = ANY($2::uuid[])
+                    AND publish_status = 'pending'
+                    AND publish_batch_id = $3
+                  RETURNING *`,
+                [orgId, assignmentIds, publishBatchId, actorUserId]
+              )
+              : []
+            const publishedRotationRows = rotationAssignmentIds.length
+              ? await trx.query(
+                `UPDATE attendance_rotation_assignments
+                    SET publish_status = 'published',
+                        published_at = now(),
+                        published_by = $4,
+                        locked_at = now(),
+                        updated_at = now()
+                  WHERE org_id = $1
+                    AND id = ANY($2::uuid[])
+                    AND publish_status = 'pending'
+                    AND publish_batch_id = $3
+                  RETURNING *`,
+                [orgId, rotationAssignmentIds, publishBatchId, actorUserId]
+              )
+              : []
+
+            if (publishedShiftRows.length !== assignmentIds.length || publishedRotationRows.length !== rotationAssignmentIds.length) {
+              throwAttendanceSchedulePublishRouteError(
+                409,
+                'SCHEDULE_PUBLISH_STALE_DRAFT',
+                'One or more draft assignments changed before publication',
+                {
+                  expectedAssignments: assignmentIds.length,
+                  publishedAssignments: publishedShiftRows.length,
+                  expectedRotationAssignments: rotationAssignmentIds.length,
+                  publishedRotationAssignments: publishedRotationRows.length,
+                }
+              )
+            }
+
+            for (const row of [...publishedShiftRows, ...publishedRotationRows]) {
+              await enforceShiftComplianceCap(trx, {
+                orgId,
+                userId: row.user_id,
+                fromDate: row.start_date,
+                toDate: row.end_date,
+              })
+            }
+
+            const data = {
+              publishBatchId,
+              preflightOnly,
+              assignments: publishedShiftRows.map(mapAssignmentRow),
+              rotationAssignments: publishedRotationRows.map(mapRotationAssignmentRow),
+              totalPublished: publishedShiftRows.length + publishedRotationRows.length,
+            }
+            if (preflightOnly) throw new AttendanceSchedulePublishPreflightComplete(data)
+            return data
+          })
+
+          emitEvent('attendance.schedulePublication.published', {
+            orgId,
+            publishBatchId: result.publishBatchId,
+            assignmentIds,
+            rotationAssignmentIds,
+            totalPublished: result.totalPublished,
+          })
+          res.json({ ok: true, data: result })
+        } catch (error) {
+          if (error instanceof AttendanceSchedulePublishPreflightComplete) {
+            res.json({ ok: true, data: error.result })
+            return
+          }
+          if (respondAttendanceSchedulePublishRouteError(res, error)) return
+          if (respondShiftComplianceCapExceeded(res, error)) return
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance tables missing' } })
+            return
+          }
+          logger.error('Attendance schedule publication failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to publish schedule assignments' } })
         }
       }
     )


### PR DESCRIPTION
## Summary
- add `POST /api/attendance/schedule-publications` for bounded draft publication across direct shift and rotation assignments
- run the publish flow with stable per-user locks, stale-draft checks, published/pending conflict checks, pending→published metadata, and shift-compliance enforcement before commit
- support `preflightOnly=true` through the same mutation/compliance path with transaction rollback, and lock P2-published schedule facts from ordinary PUT/DELETE while keeping legacy/immediate published rows mutable

## Scope
- Stacked on #2432 / `codex/attendance-schedule-publish-p1-draft-crud-20260610`
- P2 backend transition only
- Not included: frontend publish UI, OpenAPI/SDK surface, fixed draft mode, staging smoke

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "publishes draft schedule assignments" --reporter=dot` (loads the spec; local env has no DB so attendance integration tests are skipped)

## Test coverage added
- preflight returns publish-shaped output but leaves all publish metadata null and row status draft
- real publish flips direct + rotation rows with shared batch id, requested/published actor metadata, and locked schedule facts
- ordinary PUT on a P2-published row returns `SCHEDULE_PUBLISH_LOCKED`
- published conflict returns `SCHEDULE_PUBLISH_CONFLICT` and leaves draft rows unchanged
- compliance cap failure returns `SHIFT_COMPLIANCE_CAP_EXCEEDED` and rolls the row back to draft/no metadata

## Review notes
- Subagent read-only review reported no P1/P2 findings. I folded in two P3 test-strength improvements: full preflight metadata leakage assertions, and exact shared batch/actor metadata assertions.
