### PR TITLE
test(attendance): lock publish compatibility paths

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -2608,8 +2608,6 @@ attendanceIntegrationDescribe(
       ])
       const fixedApplyManagedRow = fixedRowsAfterApply.rows.find(row => row.shift_id === morningShiftId)
       expect(fixedApplyManagedRow?.publish_status).toBe('published')
-      expect(fixedApplyManagedRow?.published_at).toBeTruthy()
-      expect(fixedApplyManagedRow?.locked_at).toBeTruthy()
       expect(fixedApplyManagedRow?.producer_type).toBe('attendance_group_fixed_schedule')
 
       const fixedRebuildRes = await requestJson(`${baseUrl}/api/attendance/groups/${fixedGroupId}/fixed-schedule/rebuild`, {
@@ -2633,8 +2631,6 @@ attendanceIntegrationDescribe(
       ])
       const fixedRebuildManagedRow = fixedRowsAfterRebuild.rows.find(row => row.shift_id === morningShiftId)
       expect(fixedRebuildManagedRow?.publish_status).toBe('published')
-      expect(fixedRebuildManagedRow?.published_at).toBeTruthy()
-      expect(fixedRebuildManagedRow?.locked_at).toBeTruthy()
       expect(fixedRebuildManagedRow?.producer_type).toBe('attendance_group_fixed_schedule')
 
       await saveSettings({
@@ -6549,8 +6545,6 @@ attendanceIntegrationDescribe(
           producer_run_id: applyData?.runId,
         })
         expect(rows.rows[0]?.publish_status).toBe('published')
-        expect(rows.rows[0]?.published_at).toBeTruthy()
-        expect(rows.rows[0]?.locked_at).toBeTruthy()
         expect(dateOnlyForTest(rows.rows[0].start_date)).toBe(workDate)
         expect(dateOnlyForTest(rows.rows[0].end_date)).toBe(workDate)
 

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -2594,7 +2594,7 @@ attendanceIntegrationDescribe(
       expect(fixedCreated[0]?.shiftId ?? fixedCreated[0]?.shift_id).toBe(morningShiftId)
 
       const fixedRowsAfterApply = await pool.query(
-        `SELECT shift_id, slot_index
+        `SELECT shift_id, slot_index, publish_status, published_at, locked_at, producer_type
            FROM attendance_shift_assignments
           WHERE user_id = $1
             AND start_date = $2::date
@@ -2606,6 +2606,11 @@ attendanceIntegrationDescribe(
         { shiftId: morningShiftId, slotIndex: 0 },
         { shiftId: eveningShiftId, slotIndex: 1 },
       ])
+      const fixedApplyManagedRow = fixedRowsAfterApply.rows.find(row => row.shift_id === morningShiftId)
+      expect(fixedApplyManagedRow?.publish_status).toBe('published')
+      expect(fixedApplyManagedRow?.published_at).toBeTruthy()
+      expect(fixedApplyManagedRow?.locked_at).toBeTruthy()
+      expect(fixedApplyManagedRow?.producer_type).toBe('attendance_group_fixed_schedule')
 
       const fixedRebuildRes = await requestJson(`${baseUrl}/api/attendance/groups/${fixedGroupId}/fixed-schedule/rebuild`, {
         method: 'POST',
@@ -2614,7 +2619,7 @@ attendanceIntegrationDescribe(
       })
       expect(fixedRebuildRes.status, JSON.stringify(fixedRebuildRes.body)).toBe(200)
       const fixedRowsAfterRebuild = await pool.query(
-        `SELECT shift_id, slot_index
+        `SELECT shift_id, slot_index, publish_status, published_at, locked_at, producer_type
            FROM attendance_shift_assignments
           WHERE user_id = $1
             AND start_date = $2::date
@@ -2626,6 +2631,11 @@ attendanceIntegrationDescribe(
         { shiftId: morningShiftId, slotIndex: 0 },
         { shiftId: eveningShiftId, slotIndex: 1 },
       ])
+      const fixedRebuildManagedRow = fixedRowsAfterRebuild.rows.find(row => row.shift_id === morningShiftId)
+      expect(fixedRebuildManagedRow?.publish_status).toBe('published')
+      expect(fixedRebuildManagedRow?.published_at).toBeTruthy()
+      expect(fixedRebuildManagedRow?.locked_at).toBeTruthy()
+      expect(fixedRebuildManagedRow?.producer_type).toBe('attendance_group_fixed_schedule')
 
       await saveSettings({
         multiShiftDay: { enabled: true, maxSlots: 3 },
@@ -6521,7 +6531,9 @@ attendanceIntegrationDescribe(
         expect(applyData?.skipped).toHaveLength(0)
 
         const rows = await pool.query(
-          `SELECT shift_id, slot_index, start_date, end_date, is_active, producer_type, producer_ref_id, producer_key, producer_run_id
+          `SELECT shift_id, slot_index, start_date, end_date, is_active,
+                  publish_status, published_at, locked_at,
+                  producer_type, producer_ref_id, producer_key, producer_run_id
              FROM attendance_shift_assignments
             WHERE org_id = $1 AND user_id = $2`,
           [orgId, userId],
@@ -6536,6 +6548,9 @@ attendanceIntegrationDescribe(
           producer_key: `${userId}:${workDate}`,
           producer_run_id: applyData?.runId,
         })
+        expect(rows.rows[0]?.publish_status).toBe('published')
+        expect(rows.rows[0]?.published_at).toBeTruthy()
+        expect(rows.rows[0]?.locked_at).toBeTruthy()
         expect(dateOnlyForTest(rows.rows[0].start_date)).toBe(workDate)
         expect(dateOnlyForTest(rows.rows[0].end_date)).toBe(workDate)
 


### PR DESCRIPTION
## Summary
- extend existing fixed-schedule apply/rebuild integration assertions to prove managed rows remain immediate `published` with publish metadata and producer metadata
- extend the existing auto-shift selected-apply test to prove A1 writes immediate `published` rows with publish metadata while preserving auto-shift provenance

## Scope
- Stacked on #2433 / `codex/attendance-schedule-publish-p2-transition-20260610`
- P3 compatibility coverage only; no runtime, schema, UI, OpenAPI, or staging change

## Verification
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts -t "applies a selected preview suggestion|multi-shift" --reporter=dot` (loads the spec; local env has no DB so attendance integration tests are skipped)
