### PR TITLE
feat(attendance): add temporary shift replace runtime

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -3759,6 +3759,303 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('creates replace-only temporary draft assignments and publishes them over an existing shift', async () => {
+    if (!baseUrl) return
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+
+    const runSuffix = Date.now().toString(36)
+    const adminUserId = `attendance-temp-shift-admin-${runSuffix}`
+    const userId = `attendance-temp-shift-user-${runSuffix}`
+    const workDate = '2026-08-03'
+    const pool = new Pool({ connectionString: dbUrl })
+    let originalSettings: Record<string, unknown> = {}
+    const shiftIds: string[] = []
+
+    const tokenRes = await requestJson(
+      `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
+    )
+    const token = (tokenRes.body as { token?: string } | undefined)?.token
+    expect(token).toBeTruthy()
+    if (!token) {
+      await pool.end().catch(() => undefined)
+      return
+    }
+    const headers = {
+      Authorization: `Bearer ${token}`,
+      'Content-Type': 'application/json',
+    }
+
+    async function createShift(name: string, workStartTime: string, workEndTime: string): Promise<string> {
+      const res = await requestJson(`${baseUrl}/api/attendance/shifts`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name,
+          timezone: 'UTC',
+          workStartTime,
+          workEndTime,
+          workingDays: [0, 1, 2, 3, 4, 5, 6],
+        }),
+      })
+      expect(res.status, JSON.stringify(res.body)).toBe(201)
+      const id = (res.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(id).toBeTruthy()
+      if (!id) throw new Error('missing shift id')
+      shiftIds.push(id)
+      return id
+    }
+
+    async function publish(assignmentId: string): Promise<HttpResponse> {
+      return requestJson(`${baseUrl}/api/attendance/schedule-publications`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ assignmentIds: [assignmentId] }),
+      })
+    }
+
+    function tempDraftBody(replacementShiftId: string, replacementAssignmentId: string, overrides: Record<string, unknown> = {}) {
+      return {
+        userId,
+        shiftId: replacementShiftId,
+        startDate: workDate,
+        endDate: workDate,
+        isActive: true,
+        assignmentKind: 'temporary',
+        temporaryMode: 'replace',
+        temporaryReplacesKind: 'shift',
+        temporaryReplacesAssignmentId: replacementAssignmentId,
+        temporaryReason: 'one-off onsite coverage',
+        ...overrides,
+      }
+    }
+
+    try {
+      const settingsRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        headers: { Authorization: `Bearer ${token}` },
+      })
+      expect(settingsRes.status).toBe(200)
+      originalSettings = ((settingsRes.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
+      const settingsUpdateRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({
+          shiftEditPolicy: { mode: 'unrestricted', windowDays: 0 },
+          shiftCompliance: { enforcement: 'warn', dailyMaxMinutes: null, weeklyMaxMinutes: null, monthlyMaxMinutes: null },
+          multiShiftDay: { enabled: false, maxSlots: 3 },
+        }),
+      })
+      expect(settingsUpdateRes.status, JSON.stringify(settingsUpdateRes.body)).toBe(200)
+
+      const baseShiftId = await createShift(`Temp Base ${runSuffix}`, '08:00', '16:00')
+      const replacementShiftId = await createShift(`Temp Replacement ${runSuffix}`, '10:00', '18:00')
+
+      const baseAssignmentRes = await requestJson(`${baseUrl}/api/attendance/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          userId,
+          shiftId: baseShiftId,
+          startDate: workDate,
+          endDate: workDate,
+          isActive: true,
+        }),
+      })
+      expect(baseAssignmentRes.status, JSON.stringify(baseAssignmentRes.body)).toBe(201)
+      const baseAssignment = (baseAssignmentRes.body as { data?: { assignment?: { id?: string; publishStatus?: string } } } | undefined)?.data?.assignment
+      expect(baseAssignment?.publishStatus).toBe('published')
+      expect(baseAssignment?.id).toBeTruthy()
+      if (!baseAssignment?.id) return
+
+      const directTempRes = await requestJson(`${baseUrl}/api/attendance/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(tempDraftBody(replacementShiftId, baseAssignment.id)),
+      })
+      expect(directTempRes.status, JSON.stringify(directTempRes.body)).toBe(422)
+      expect((directTempRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('TEMP_SHIFT_IMMEDIATE_ACTIVE_UNSUPPORTED')
+
+      const openEndedTempRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(tempDraftBody(replacementShiftId, baseAssignment.id, { endDate: null })),
+      })
+      expect(openEndedTempRes.status, JSON.stringify(openEndedTempRes.body)).toBe(422)
+      expect((openEndedTempRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('TEMP_SHIFT_RANGE_UNSUPPORTED')
+
+      const addModeTempRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(tempDraftBody(replacementShiftId, baseAssignment.id, { temporaryMode: 'add' })),
+      })
+      expect(addModeTempRes.status, JSON.stringify(addModeTempRes.body)).toBe(422)
+      expect((addModeTempRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('TEMP_SHIFT_ADD_MODE_DEFERRED')
+
+      const rotationReplaceRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(tempDraftBody(replacementShiftId, baseAssignment.id, { temporaryReplacesKind: 'rotation' })),
+      })
+      expect(rotationReplaceRes.status, JSON.stringify(rotationReplaceRes.body)).toBe(422)
+      expect((rotationReplaceRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('TEMP_SHIFT_ROTATION_REPLACEMENT_UNSUPPORTED')
+
+      const tempDraftRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(tempDraftBody(replacementShiftId, baseAssignment.id)),
+      })
+      expect(tempDraftRes.status, JSON.stringify(tempDraftRes.body)).toBe(201)
+      const tempDraft = (tempDraftRes.body as { data?: { assignment?: {
+        id?: string
+        assignmentKind?: string
+        temporaryMode?: string
+        temporaryReplacesAssignmentId?: string
+        publishStatus?: string
+      } } } | undefined)?.data?.assignment
+      expect(tempDraft?.publishStatus).toBe('draft')
+      expect(tempDraft?.assignmentKind).toBe('temporary')
+      expect(tempDraft?.temporaryMode).toBe('replace')
+      expect(tempDraft?.temporaryReplacesAssignmentId).toBe(baseAssignment.id)
+      expect(tempDraft?.id).toBeTruthy()
+      if (!tempDraft?.id) return
+
+      const tempEditRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/assignments/${tempDraft.id}`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({ shiftId: baseShiftId }),
+      })
+      expect(tempEditRes.status, JSON.stringify(tempEditRes.body)).toBe(422)
+      expect((tempEditRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('TEMP_SHIFT_EDIT_DEFERRED')
+
+      const publishTempRes = await publish(tempDraft.id)
+      expect(publishTempRes.status, JSON.stringify(publishTempRes.body)).toBe(200)
+      const publishedTemp = (publishTempRes.body as { data?: { assignments?: Array<{ id?: string; assignmentKind?: string; publishStatus?: string; temporaryReplacesAssignmentId?: string }> } } | undefined)?.data?.assignments?.[0]
+      expect(publishedTemp?.id).toBe(tempDraft.id)
+      expect(publishedTemp?.publishStatus).toBe('published')
+      expect(publishedTemp?.assignmentKind).toBe('temporary')
+      expect(publishedTemp?.temporaryReplacesAssignmentId).toBe(baseAssignment.id)
+
+      const persistedRows = await pool.query(
+        `SELECT id, assignment_kind, temporary_mode, temporary_replaces_kind,
+                temporary_replaces_assignment_id, temporary_reason, temporary_created_by,
+                publish_status, locked_at
+           FROM attendance_shift_assignments
+          WHERE id = ANY($1::uuid[])
+          ORDER BY assignment_kind ASC`,
+        [[baseAssignment.id, tempDraft.id]]
+      )
+      expect(persistedRows.rows).toHaveLength(2)
+      const persistedBase = persistedRows.rows.find(row => row.id === baseAssignment.id)
+      const persistedTemp = persistedRows.rows.find(row => row.id === tempDraft.id)
+      expect(persistedBase?.assignment_kind).toBe('regular')
+      expect(persistedTemp).toMatchObject({
+        assignment_kind: 'temporary',
+        temporary_mode: 'replace',
+        temporary_replaces_kind: 'shift',
+        temporary_replaces_assignment_id: baseAssignment.id,
+        temporary_reason: 'one-off onsite coverage',
+        temporary_created_by: adminUserId,
+        publish_status: 'published',
+      })
+      expect(persistedTemp?.locked_at).toBeTruthy()
+
+      const defaultPlannedPreviewRes = await requestJson(`${baseUrl}/api/attendance/comprehensive-hours/preview`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          metric: 'planned',
+          enforcement: 'warn',
+          capMinutes: 1000,
+          userId,
+          period: { type: 'custom_range', from: workDate, to: workDate },
+        }),
+      })
+      expect(defaultPlannedPreviewRes.status, JSON.stringify(defaultPlannedPreviewRes.body)).toBe(200)
+      const defaultPlannedRows = (defaultPlannedPreviewRes.body as { data?: { rows?: Array<{ userId?: string; minutes?: number; plannedMinutes?: number }> } } | undefined)?.data?.rows ?? []
+      expect(defaultPlannedRows).toHaveLength(1)
+      expect(defaultPlannedRows[0]?.userId).toBe(userId)
+      expect(defaultPlannedRows[0]?.minutes).toBe(480)
+      expect(defaultPlannedRows[0]?.plannedMinutes).toBe(480)
+
+      const singleShiftEffectiveCalendarRes = await requestJson(
+        `${baseUrl}/api/attendance/effective-calendar?from=${workDate}&to=${workDate}&userId=${encodeURIComponent(userId)}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      )
+      expect(singleShiftEffectiveCalendarRes.status, JSON.stringify(singleShiftEffectiveCalendarRes.body)).toBe(200)
+      const singleShiftEffectiveItem = ((singleShiftEffectiveCalendarRes.body as { data?: { items?: Array<{ effective?: { plannedMinutes?: number; slots?: Array<{ shiftId?: string; assignmentKind?: string; replaces?: { assignmentId?: string } }> } }> } } | undefined)?.data?.items ?? [])[0]
+      expect(singleShiftEffectiveItem?.effective?.plannedMinutes).toBe(480)
+      expect(singleShiftEffectiveItem?.effective?.slots).toHaveLength(1)
+      expect(singleShiftEffectiveItem?.effective?.slots?.[0]).toMatchObject({
+        shiftId: replacementShiftId,
+        assignmentKind: 'temporary',
+        replaces: { assignmentId: baseAssignment.id },
+      })
+
+      const multiShiftSettingsRes = await requestJson(`${baseUrl}/api/attendance/settings`, {
+        method: 'PUT',
+        headers,
+        body: JSON.stringify({
+          multiShiftDay: { enabled: true, maxSlots: 3 },
+          shiftCompliance: { enforcement: 'warn', dailyMaxMinutes: null, weeklyMaxMinutes: null, monthlyMaxMinutes: null },
+        }),
+      })
+      expect(multiShiftSettingsRes.status, JSON.stringify(multiShiftSettingsRes.body)).toBe(200)
+
+      const effectiveCalendarRes = await requestJson(
+        `${baseUrl}/api/attendance/effective-calendar?from=${workDate}&to=${workDate}&userId=${encodeURIComponent(userId)}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      )
+      expect(effectiveCalendarRes.status, JSON.stringify(effectiveCalendarRes.body)).toBe(200)
+      const effectiveItem = ((effectiveCalendarRes.body as { data?: { items?: Array<{ effective?: { plannedMinutes?: number; slots?: Array<{ shiftId?: string; assignmentKind?: string; replaces?: { assignmentId?: string } }> } }> } } | undefined)?.data?.items ?? [])[0]
+      expect(effectiveItem?.effective?.plannedMinutes).toBe(480)
+      expect(effectiveItem?.effective?.slots).toHaveLength(1)
+      expect(effectiveItem?.effective?.slots?.[0]).toMatchObject({
+        shiftId: replacementShiftId,
+        assignmentKind: 'temporary',
+        replaces: { assignmentId: baseAssignment.id },
+      })
+
+      const plannedPreviewRes = await requestJson(`${baseUrl}/api/attendance/comprehensive-hours/preview`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          metric: 'planned',
+          enforcement: 'warn',
+          capMinutes: 1000,
+          userId,
+          period: { type: 'custom_range', from: workDate, to: workDate },
+        }),
+      })
+      expect(plannedPreviewRes.status, JSON.stringify(plannedPreviewRes.body)).toBe(200)
+      const plannedRows = (plannedPreviewRes.body as { data?: { rows?: Array<{ userId?: string; minutes?: number; plannedMinutes?: number }> } } | undefined)?.data?.rows ?? []
+      expect(plannedRows).toHaveLength(1)
+      expect(plannedRows[0]?.userId).toBe(userId)
+      expect(plannedRows[0]?.minutes).toBe(480)
+      expect(plannedRows[0]?.plannedMinutes).toBe(480)
+
+      const secondTempRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(tempDraftBody(replacementShiftId, baseAssignment.id, { temporaryReason: 'second temp' })),
+      })
+      expect(secondTempRes.status, JSON.stringify(secondTempRes.body)).toBe(409)
+      expect((secondTempRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('ATTENDANCE_SCHEDULE_ASSIGNMENT_CONFLICT')
+    } finally {
+      if (Object.keys(originalSettings).length > 0) {
+        await requestJson(`${baseUrl}/api/attendance/settings`, {
+          method: 'PUT',
+          headers,
+          body: JSON.stringify(originalSettings),
+        }).catch(() => undefined)
+      }
+      await pool.query('DELETE FROM attendance_shift_assignments WHERE user_id = $1', [userId]).catch(() => undefined)
+      if (shiftIds.length > 0) {
+        await pool.query('DELETE FROM attendance_shifts WHERE id = ANY($1::uuid[])', [shiftIds]).catch(() => undefined)
+      }
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('enforces schedule-edit windows on shift and rotation assignment writes', async () => {
     if (!baseUrl) return
 

--- a/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
+++ b/packages/core-backend/tests/unit/attendance-uuid-validation-routes.test.ts
@@ -2519,8 +2519,8 @@ describe('attendance UUID route validation', () => {
       if (rbac !== undefined) return rbac
       if (sql.includes('SELECT * FROM attendance_shifts')) return [shiftRow()]
       if (sql.includes('pg_advisory_xact_lock')) return []
-      if (sql.includes('FROM attendance_shift_assignments') && sql.includes('LIMIT 1')) return []
-      if (sql.includes('FROM attendance_rotation_assignments') && sql.includes('LIMIT 1')) return []
+      if (sql.includes('FROM attendance_shift_assignments')) return []
+      if (sql.includes('FROM attendance_rotation_assignments')) return []
       if (sql.includes('INSERT INTO attendance_shift_assignments')) return [shiftAssignmentRow()]
       throw new Error(`unexpected query: ${sql}`)
     })
@@ -2548,8 +2548,8 @@ describe('attendance UUID route validation', () => {
       if (sql.includes('FROM attendance_scheduler_scopes')) return [schedulerScopeRow()]
       if (sql.includes('SELECT * FROM attendance_shifts')) return [shiftRow()]
       if (sql.includes('pg_advisory_xact_lock')) return []
-      if (sql.includes('FROM attendance_shift_assignments') && sql.includes('LIMIT 1')) return []
-      if (sql.includes('FROM attendance_rotation_assignments') && sql.includes('LIMIT 1')) return []
+      if (sql.includes('FROM attendance_shift_assignments')) return []
+      if (sql.includes('FROM attendance_rotation_assignments')) return []
       if (sql.includes('INSERT INTO attendance_shift_assignments')) return [shiftAssignmentRow()]
       throw new Error(`unexpected query: ${sql}`)
     })

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -8669,6 +8669,11 @@ function normalizeAssignmentPayload(value) {
     endDate: firstDefinedValue(payload.endDate, payload.end_date),
     isActive: firstDefinedValue(payload.isActive, payload.is_active),
     publishStatus: firstDefinedValue(payload.publishStatus, payload.publish_status),
+    assignmentKind: firstDefinedValue(payload.assignmentKind, payload.assignment_kind),
+    temporaryMode: firstDefinedValue(payload.temporaryMode, payload.temporary_mode),
+    temporaryReplacesKind: firstDefinedValue(payload.temporaryReplacesKind, payload.temporary_replaces_kind),
+    temporaryReplacesAssignmentId: firstDefinedValue(payload.temporaryReplacesAssignmentId, payload.temporary_replaces_assignment_id),
+    temporaryReason: firstDefinedValue(payload.temporaryReason, payload.temporary_reason),
   }
 }
 
@@ -8972,6 +8977,10 @@ function buildAttendanceSchedulePublishDraft(row, settings) {
     draft.slotIndex = normalizeAttendanceScheduleSlotIndex(row.slot_index, 0)
     draft.multiShiftEnabled = settings?.multiShiftDay?.enabled === true
     draft.shift = row
+    if (row.assignment_kind === 'temporary') {
+      draft.assignmentKind = 'temporary'
+      draft.temporaryReplacesAssignmentId = normalizeUuidString(row.temporary_replaces_assignment_id)
+    }
   }
   return draft
 }
@@ -9086,6 +9095,9 @@ async function findAttendanceScheduleAssignmentConflict(db, draft, options = {})
   const draftStartDate = normalizeDateOnly(draft.startDate) ?? draft.startDate
   const draftEndDate = normalizeAttendanceScheduleAssignmentEndDate(draft.endDate)
   const overlapEndDate = draftEndDate || ATTENDANCE_SCHEDULE_OPEN_END_DATE
+  const allowedOverlapAssignmentId = draft.assignmentKind === 'temporary'
+    ? normalizeUuidString(draft.temporaryReplacesAssignmentId)
+    : null
   const sameKindTable = draft.kind === 'rotation'
     ? 'attendance_rotation_assignments'
     : 'attendance_shift_assignments'
@@ -9120,6 +9132,7 @@ async function findAttendanceScheduleAssignmentConflict(db, draft, options = {})
     )
     const draftSlotIndex = normalizeAttendanceScheduleSlotIndex(draft.slotIndex, 0)
     const conflictingSameKindRow = sameKindRows.find((row) => {
+      if (allowedOverlapAssignmentId && row.id === allowedOverlapAssignmentId) return false
       const existingSlotIndex = normalizeAttendanceScheduleSlotIndex(row.slot_index, 0)
       if (existingSlotIndex === draftSlotIndex) return true
       return attendanceShiftWindowsOverlapForSlotConflict(row, draft.shift)
@@ -9136,11 +9149,11 @@ async function findAttendanceScheduleAssignmentConflict(db, draft, options = {})
           AND start_date <= $4::date
           AND COALESCE(end_date, DATE '${ATTENDANCE_SCHEDULE_OPEN_END_DATE}') >= $3::date
           ${excludeClause}
-        ORDER BY start_date DESC, created_at DESC
-        LIMIT 1`,
+        ORDER BY start_date DESC, created_at DESC`,
       draft.excludeId ? [...baseParams, draft.excludeId, sameKindLabel] : [...baseParams, sameKindLabel]
     )
-    if (sameKindRows.length) return mapAttendanceScheduleAssignmentConflict(sameKindRows[0], draft)
+    const conflictingSameKindRow = sameKindRows.find(row => !(allowedOverlapAssignmentId && row.id === allowedOverlapAssignmentId))
+    if (conflictingSameKindRow) return mapAttendanceScheduleAssignmentConflict(conflictingSameKindRow, draft)
   }
 
   const otherKindRows = await db.query(
@@ -11692,6 +11705,9 @@ async function loadShiftAssignment(db, orgId, userId, workDate) {
       `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
               a.publish_status, a.publish_batch_id, a.publish_requested_at, a.publish_requested_by,
               a.published_at, a.published_by, a.locked_at, a.reopened_from_assignment_id,
+              a.assignment_kind, a.temporary_mode, a.temporary_replaces_kind,
+              a.temporary_replaces_assignment_id, a.temporary_reason, a.temporary_created_by,
+              a.temporary_created_at,
               a.created_at AS assignment_created_at,
               s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
               s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
@@ -11705,7 +11721,8 @@ async function loadShiftAssignment(db, orgId, userId, workDate) {
          AND COALESCE(a.publish_status, 'published') = 'published'
          AND a.start_date <= $3
          AND (a.end_date IS NULL OR a.end_date >= $3)
-       ORDER BY a.start_date DESC, a.created_at DESC
+       ORDER BY CASE WHEN a.assignment_kind = 'temporary' AND a.start_date = $3 THEN 0 ELSE 1 END,
+                a.start_date DESC, a.created_at DESC
        LIMIT 1`,
       [targetOrg, userId, workDate]
     )
@@ -12065,6 +12082,9 @@ async function loadShiftAssignmentMapForUsersRange(db, orgId, userIds, fromDate,
     `SELECT a.id, a.org_id, a.user_id, a.shift_id, a.slot_index, a.start_date, a.end_date, a.is_active,
             a.publish_status, a.publish_batch_id, a.publish_requested_at, a.publish_requested_by,
             a.published_at, a.published_by, a.locked_at, a.reopened_from_assignment_id,
+            a.assignment_kind, a.temporary_mode, a.temporary_replaces_kind,
+            a.temporary_replaces_assignment_id, a.temporary_reason, a.temporary_created_by,
+            a.temporary_created_at,
             a.created_at AS assignment_created_at,
             s.name AS shift_name, s.timezone AS shift_timezone, s.work_start_time AS shift_work_start_time,
             s.work_end_time AS shift_work_end_time, s.is_overnight AS shift_is_overnight, s.late_grace_minutes AS shift_late_grace_minutes,
@@ -13082,7 +13102,8 @@ async function resolveEffectiveCalendar(db, args) {
     }
     if (effective.label) effectiveOut.label = effective.label
     if (effective.policyId) effectiveOut.policyId = effective.policyId
-    if (mode === 'userId' && multiShiftDay.enabled) {
+    const exposesTemporaryShiftSlot = directShiftSlots.some(entry => isTemporaryShiftAssignmentEntryForDate(entry, date))
+    if (mode === 'userId' && (multiShiftDay.enabled || exposesTemporaryShiftSlot)) {
       const dayWorkingOverride = holiday || policyWinner ? effective.isWorkingDay : null
       const slots = profileSource === 'shift'
         ? buildEffectiveCalendarShiftSlots(directShiftSlots, { workDate: date, dayWorkingOverride })
@@ -13138,6 +13159,28 @@ function compareShiftAssignmentSlotEntries(left, right) {
   return String(left?.assignment?.id ?? '').localeCompare(String(right?.assignment?.id ?? ''))
 }
 
+function isTemporaryShiftAssignmentEntryForDate(entry, workDate) {
+  const assignment = entry?.assignment
+  if (!assignment || assignment.assignmentKind !== 'temporary') return false
+  const startDate = assignment.startDate ?? assignment.start_date
+  return startDate === workDate
+}
+
+function applyTemporaryShiftOverlayToAssignmentEntries(entries, workDate) {
+  const temporarySlots = new Set()
+  for (const entry of entries) {
+    if (isTemporaryShiftAssignmentEntryForDate(entry, workDate)) {
+      temporarySlots.add(getShiftAssignmentEntrySlotIndex(entry))
+    }
+  }
+  if (temporarySlots.size === 0) return entries
+  return entries.filter((entry) => {
+    const slotIndex = getShiftAssignmentEntrySlotIndex(entry)
+    if (!temporarySlots.has(slotIndex)) return true
+    return isTemporaryShiftAssignmentEntryForDate(entry, workDate)
+  })
+}
+
 function resolveShiftAssignmentsFromPrefetch(entries, workDate, options = {}) {
   if (!Array.isArray(entries) || entries.length === 0) return []
   const matches = []
@@ -13148,9 +13191,10 @@ function resolveShiftAssignmentsFromPrefetch(entries, workDate, options = {}) {
     if (startDate <= workDate && (!endDate || endDate >= workDate)) matches.push(entry)
   }
   if (matches.length === 0) return []
+  const overlayMatches = applyTemporaryShiftOverlayToAssignmentEntries(matches, workDate)
   const multiShiftDay = normalizeMultiShiftDaySetting(options.multiShiftDay)
-  if (!multiShiftDay.enabled) return [matches[0]]
-  return matches.sort(compareShiftAssignmentSlotEntries)
+  if (!multiShiftDay.enabled) return [overlayMatches[0]]
+  return overlayMatches.sort(compareShiftAssignmentSlotEntries)
 }
 
 function resolveShiftAssignmentFromPrefetch(entries, workDate, options = {}) {
@@ -13182,7 +13226,7 @@ function buildEffectiveCalendarShiftSlots(entries, options = {}) {
       ? dayWorkingOverride
       : isShiftAssignmentEntryWorkingOnDate(entry, workDate)
     const plannedMinutes = isWorkingDay ? calculateAttendanceComprehensiveShiftPlannedMinutes(shift) : 0
-    slots.push({
+    const slot = {
       assignmentId: assignment.id,
       slotIndex: getShiftAssignmentEntrySlotIndex(entry),
       shiftId: shift.id ?? assignment.shiftId ?? assignment.shift_id ?? null,
@@ -13191,7 +13235,17 @@ function buildEffectiveCalendarShiftSlots(entries, options = {}) {
       workEndTime: shift.workEndTime ?? shift.work_end_time ?? null,
       timezone: shift.timezone ?? null,
       plannedMinutes,
-    })
+    }
+    if (assignment.assignmentKind === 'temporary') {
+      slot.assignmentKind = 'temporary'
+      slot.temporaryMode = assignment.temporaryMode ?? null
+      slot.temporaryReason = assignment.temporaryReason ?? null
+      slot.replaces = {
+        kind: assignment.temporaryReplacesKind ?? null,
+        assignmentId: assignment.temporaryReplacesAssignmentId ?? null,
+      }
+    }
+    slots.push(slot)
   }
   return slots
 }
@@ -17405,9 +17459,159 @@ module.exports = {
       startDate: z.string().min(1),
       endDate: z.string().nullable().optional(),
       isActive: z.boolean().optional(),
+      assignmentKind: z.string().optional(),
+      temporaryMode: z.string().optional(),
+      temporaryReplacesKind: z.string().optional(),
+      temporaryReplacesAssignmentId: z.string().nullable().optional(),
+      temporaryReason: z.string().trim().max(500).nullable().optional(),
       orgId: z.string().optional(),
     })
     const assignmentUpdateSchema = assignmentCreateSchema.partial()
+
+    function hasTemporaryAssignmentPayload(data = {}) {
+      return data.assignmentKind !== undefined ||
+        data.temporaryMode !== undefined ||
+        data.temporaryReplacesKind !== undefined ||
+        data.temporaryReplacesAssignmentId !== undefined ||
+        data.temporaryReason !== undefined
+    }
+
+    function buildTemporaryShiftRouteError(code, message, details = {}) {
+      return { code, message, details }
+    }
+
+    function respondTemporaryShiftRouteError(res, error) {
+      res.status(422).json({
+        ok: false,
+        error: {
+          code: error.code,
+          message: error.message,
+          details: error.details ?? {},
+        },
+      })
+    }
+
+    function normalizeTemporaryShiftCreatePayload(data, payload) {
+      if (!hasTemporaryAssignmentPayload(data)) return { ok: true, temporary: null }
+      if (data.assignmentKind !== 'temporary') {
+        return {
+          ok: false,
+          error: buildTemporaryShiftRouteError(
+            'TEMP_SHIFT_METADATA_REQUIRES_TEMPORARY',
+            'Temporary shift metadata requires assignmentKind=temporary.'
+          ),
+        }
+      }
+      if (data.temporaryMode === 'add') {
+        return {
+          ok: false,
+          error: buildTemporaryShiftRouteError(
+            'TEMP_SHIFT_ADD_MODE_DEFERRED',
+            'Adding a temporary extra shift is deferred until multi-shift add-mode is enabled.'
+          ),
+        }
+      }
+      if (data.temporaryMode !== 'replace') {
+        return {
+          ok: false,
+          error: buildTemporaryShiftRouteError(
+            'TEMP_SHIFT_REPLACE_MODE_REQUIRED',
+            'Temporary shift v1 only supports replace mode.'
+          ),
+        }
+      }
+      if (!payload.endDate || payload.endDate !== payload.startDate) {
+        return {
+          ok: false,
+          error: buildTemporaryShiftRouteError(
+            'TEMP_SHIFT_RANGE_UNSUPPORTED',
+            'Temporary shift v1 must target exactly one work date.'
+          ),
+        }
+      }
+      if (data.temporaryReplacesKind === 'rotation') {
+        return {
+          ok: false,
+          error: buildTemporaryShiftRouteError(
+            'TEMP_SHIFT_ROTATION_REPLACEMENT_UNSUPPORTED',
+            'Temporary shift replacement for rotation assignments is not supported in v1.'
+          ),
+        }
+      }
+      if (data.temporaryReplacesKind !== 'shift') {
+        return {
+          ok: false,
+          error: buildTemporaryShiftRouteError(
+            'TEMP_SHIFT_REPLACEMENT_REQUIRED',
+            'Temporary shift v1 requires temporaryReplacesKind=shift.'
+          ),
+        }
+      }
+      const replacementId = normalizeUuidString(data.temporaryReplacesAssignmentId)
+      if (!replacementId) {
+        return {
+          ok: false,
+          error: buildTemporaryShiftRouteError(
+            'TEMP_SHIFT_REPLACEMENT_REQUIRED',
+            'Temporary shift v1 requires a valid temporaryReplacesAssignmentId.'
+          ),
+        }
+      }
+      return {
+        ok: true,
+        temporary: {
+          assignmentKind: 'temporary',
+          temporaryMode: 'replace',
+          temporaryReplacesKind: 'shift',
+          temporaryReplacesAssignmentId: replacementId,
+          temporaryReason: data.temporaryReason ?? null,
+        },
+      }
+    }
+
+    async function validateTemporaryShiftReplacement(client, { orgId, payload, temporary }) {
+      if (!temporary) return { ok: true }
+      const rows = await client.query(
+        `SELECT *
+           FROM attendance_shift_assignments
+          WHERE id = $1
+            AND org_id = $2
+          FOR UPDATE`,
+        [temporary.temporaryReplacesAssignmentId, orgId]
+      )
+      const replacement = rows[0]
+      if (!replacement) {
+        return {
+          ok: false,
+          error: buildTemporaryShiftRouteError(
+            'TEMP_SHIFT_REPLACEMENT_NOT_FOUND',
+            'The assignment being replaced was not found.'
+          ),
+        }
+      }
+      const replacementPublishStatus = normalizeAttendanceSchedulePublishStatus(replacement.publish_status)
+      const replacementSlotIndex = normalizeAttendanceScheduleSlotIndex(replacement.slot_index, 0)
+      const replacementStartDate = normalizeDateOnly(replacement.start_date) ?? replacement.start_date
+      const replacementEndDate = normalizeAttendanceScheduleAssignmentEndDate(replacement.end_date) || ATTENDANCE_SCHEDULE_OPEN_END_DATE
+      if (
+        replacement.user_id !== payload.userId ||
+        replacementSlotIndex !== normalizeAttendanceScheduleSlotIndex(payload.slotIndex, 0) ||
+        replacementStartDate > payload.startDate ||
+        replacementEndDate < payload.startDate ||
+        replacement.is_active === false ||
+        replacementPublishStatus !== 'published' ||
+        replacement.assignment_kind === 'temporary'
+      ) {
+        return {
+          ok: false,
+          error: buildTemporaryShiftRouteError(
+            'TEMP_SHIFT_REPLACEMENT_MISMATCH',
+            'The assignment being replaced does not match the temporary shift target.'
+          ),
+        }
+      }
+      return { ok: true, replacement }
+    }
 
     const holidayCreateSchema = z.object({
       date: z.string().min(1),
@@ -31627,6 +31831,13 @@ module.exports = {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: 'End date must be after start date' } })
           return
         }
+        const temporaryResolution = normalizeTemporaryShiftCreatePayload(parsed.data, payload)
+        if (!temporaryResolution.ok) {
+          respondTemporaryShiftRouteError(res, temporaryResolution.error)
+          return
+        }
+        const temporary = temporaryResolution.temporary
+        const actorUserId = getUserId(req) || null
 
         try {
           const windowAccess = await enforceShiftEditWindow(res, [payload.startDate])
@@ -31653,6 +31864,8 @@ module.exports = {
 
           const result = await db.transaction(async (trx) => {
             await acquireAttendanceScheduleAssignmentLock(trx, orgId, payload.userId)
+            const replacementValidation = await validateTemporaryShiftReplacement(trx, { orgId, payload, temporary })
+            if (!replacementValidation.ok) return { temporaryError: replacementValidation.error }
             const conflict = await findAttendanceScheduleAssignmentConflict(trx, {
               kind: 'shift',
               orgId,
@@ -31663,13 +31876,17 @@ module.exports = {
               slotIndex: payload.slotIndex,
               multiShiftEnabled: slotResolution.multiShiftDay.enabled,
               shift: shiftRows[0],
-            }, { publishStatuses: ['draft', 'pending'] })
+              assignmentKind: temporary?.assignmentKind,
+              temporaryReplacesAssignmentId: temporary?.temporaryReplacesAssignmentId,
+            }, { publishStatuses: temporary ? ['draft', 'pending', 'published'] : ['draft', 'pending'] })
             if (conflict) return { conflict }
 
             const rows = await trx.query(
               `INSERT INTO attendance_shift_assignments
-               (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active, publish_status)
-               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'draft')
+               (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active, publish_status,
+                assignment_kind, temporary_mode, temporary_replaces_kind, temporary_replaces_assignment_id,
+                temporary_reason, temporary_created_by, temporary_created_at)
+               VALUES ($1, $2, $3, $4, $5, $6, $7, $8, 'draft', $9, $10, $11, $12, $13, $14, $15)
                RETURNING *`,
               [
                 randomUUID(),
@@ -31680,11 +31897,22 @@ module.exports = {
                 payload.startDate,
                 payload.endDate,
                 payload.isActive,
+                temporary?.assignmentKind ?? 'regular',
+                temporary?.temporaryMode ?? null,
+                temporary?.temporaryReplacesKind ?? null,
+                temporary?.temporaryReplacesAssignmentId ?? null,
+                temporary?.temporaryReason ?? null,
+                temporary ? actorUserId : null,
+                temporary ? new Date().toISOString() : null,
               ]
             )
             return { row: rows[0] }
           })
 
+          if (result.temporaryError) {
+            respondTemporaryShiftRouteError(res, result.temporaryError)
+            return
+          }
           if (result.conflict) {
             respondAttendanceScheduleAssignmentConflict(res, result.conflict)
             return
@@ -31713,6 +31941,13 @@ module.exports = {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
           return
         }
+        if (hasTemporaryAssignmentPayload(parsed.data)) {
+          respondTemporaryShiftRouteError(res, buildTemporaryShiftRouteError(
+            'TEMP_SHIFT_EDIT_DEFERRED',
+            'Editing temporary shift metadata is deferred to a follow-up slice.'
+          ))
+          return
+        }
 
         const orgId = getOrgId(req)
         const assignmentId = normalizeUuidString(req.params.id)
@@ -31739,6 +31974,13 @@ module.exports = {
           }
 
           const existing = existingRows[0]
+          if (existing.assignment_kind === 'temporary') {
+            respondTemporaryShiftRouteError(res, buildTemporaryShiftRouteError(
+              'TEMP_SHIFT_EDIT_DEFERRED',
+              'Editing temporary shift rows is deferred to a follow-up slice.'
+            ))
+            return
+          }
           const existingPublishStatus = normalizeAttendanceSchedulePublishStatus(existing.publish_status)
           if (!isAttendanceScheduleDraftEditable(existing)) {
             respondAttendanceSchedulePublishLocked(res, existingPublishStatus)
@@ -31950,6 +32192,13 @@ module.exports = {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
           return
         }
+        if (hasTemporaryAssignmentPayload(parsed.data)) {
+          respondTemporaryShiftRouteError(res, buildTemporaryShiftRouteError(
+            'TEMP_SHIFT_IMMEDIATE_ACTIVE_UNSUPPORTED',
+            'Temporary shifts must be created through the draft schedule workflow.'
+          ))
+          return
+        }
 
         const orgId = getOrgId(req)
         const shiftId = normalizeUuidString(parsed.data.shiftId)
@@ -32063,6 +32312,13 @@ module.exports = {
           res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: parsed.error.message } })
           return
         }
+        if (hasTemporaryAssignmentPayload(parsed.data)) {
+          respondTemporaryShiftRouteError(res, buildTemporaryShiftRouteError(
+            'TEMP_SHIFT_EDIT_DEFERRED',
+            'Editing temporary shift metadata is deferred to a follow-up slice.'
+          ))
+          return
+        }
 
         const orgId = getOrgId(req)
         const assignmentId = normalizeUuidString(req.params.id)
@@ -32089,6 +32345,13 @@ module.exports = {
           }
 
           const existing = existingRows[0]
+          if (existing.assignment_kind === 'temporary') {
+            respondTemporaryShiftRouteError(res, buildTemporaryShiftRouteError(
+              'TEMP_SHIFT_EDIT_DEFERRED',
+              'Editing temporary shift rows is deferred to a follow-up slice.'
+            ))
+            return
+          }
           const existingPublishStatus = normalizeAttendanceSchedulePublishStatus(existing.publish_status)
           if (!isAttendanceSchedulePublishedDirectlyMutable(existing)) {
             respondAttendanceSchedulePublishLocked(res, existingPublishStatus)
@@ -32379,6 +32642,28 @@ module.exports = {
 
     async function enforceAttendanceSchedulePublicationConflicts(client, row, settings) {
       const draft = buildAttendanceSchedulePublishDraft(row, settings)
+      if (draft.assignmentKind === 'temporary') {
+        const replacementValidation = await validateTemporaryShiftReplacement(client, {
+          orgId: row.org_id,
+          payload: {
+            userId: row.user_id,
+            startDate: draft.startDate,
+            endDate: draft.endDate,
+            slotIndex: draft.slotIndex,
+          },
+          temporary: {
+            temporaryReplacesAssignmentId: draft.temporaryReplacesAssignmentId,
+          },
+        })
+        if (!replacementValidation.ok) {
+          throwAttendanceSchedulePublishRouteError(
+            422,
+            replacementValidation.error.code,
+            replacementValidation.error.message,
+            replacementValidation.error.details
+          )
+        }
+      }
       const publishedConflict = await findAttendanceScheduleAssignmentConflict(client, draft, { publishStatuses: ['published'] })
       if (publishedConflict) {
         throwAttendanceSchedulePublishRouteError(


### PR DESCRIPTION
## Summary

Adds the temporary-shift replace runtime slice on top of the latent T0 schema.

- allows creating one-day temporary replacement rows through the schedule draft assignment route only
- rejects immediate-active temporary rows and deferred shapes (`add`, open-ended/multiday, rotation replacement, temp metadata edits)
- revalidates the replacement assignment during draft create and publish so stale or mismatched replacements cannot be published
- lets a temporary row overlap only the published assignment it replaces while still detecting unrelated published/pending/draft conflicts
- overlays temporary rows in the effective-calendar/planned-minutes resolver so a replaced base shift is not double-counted
- exposes temporary metadata in effective-calendar slots for the replaced assignment when multi-shift slots are surfaced, and on default single-shift days that contain a temporary replacement
- updates the UUID route unit mock to match the widened conflict SELECT shape (same behavior, no `LIMIT 1` assumption)

## Scope

This is backend/runtime only. It does not add the admin UI, staging closeout, tracker flip, fixed-apply diagnostics, or the future temporary add-mode/multiday/rotation paths.

## Verification

Local verification in `/private/tmp/ms2-temp-shift-runtime`:

- `node --check plugins/plugin-attendance/index.cjs`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-uuid-validation-routes.test.ts --reporter=dot` → 55/55
- `pnpm --filter @metasheet/core-backend test:integration:attendance -- --runInBand` *(collected the four gated attendance specs, but local DB is unavailable so 119 tests skipped; CI real Postgres is the true gate)*
- `git diff --check`

New real-DB coverage in `attendance-plugin.test.ts` covers direct temp reject, invalid draft shapes, draft create, edit reject, publish, DB metadata, default single-shift planned-preview no-double-count, default single-shift effective-calendar temporary metadata, multi-shift slot metadata, planned-minutes no double count, and second-temp conflict.
