### PR TITLE
feat(attendance): add temporary shift admin draft form

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -7122,6 +7122,77 @@
                   {{ tr('Cancel edit', '取消编辑') }}
                 </button>
               </div>
+              <div class="attendance__admin-subsection" data-attendance-temporary-shift-card>
+                <h4>{{ tr('Temporary shift replacement', '临时替班') }}</h4>
+                <p class="attendance__field-hint">
+                  {{ tr('Create a one-day replacement draft for a published shift assignment. Publish the draft when it is ready to take effect.', '为已发布的班次分配创建单日替班草稿；确认后再发布生效。') }}
+                </p>
+                <div class="attendance__admin-grid">
+                  <label class="attendance__field" for="attendance-temporary-shift-replacement-assignment">
+                    <span>{{ tr('Published assignment to replace', '要替换的已发布分配') }}</span>
+                    <select
+                      id="attendance-temporary-shift-replacement-assignment"
+                      v-model="temporaryAssignmentForm.replacementAssignmentId"
+                      :disabled="temporaryReplacementAssignmentOptions.length === 0"
+                      @change="onTemporaryReplacementAssignmentChange"
+                    >
+                      <option value="" disabled>{{ tr('Select published assignment', '选择已发布分配') }}</option>
+                      <option
+                        v-for="item in temporaryReplacementAssignmentOptions"
+                        :key="item.assignment.id"
+                        :value="item.assignment.id"
+                      >
+                        {{ formatTemporaryReplacementAssignmentOption(item) }}
+                      </option>
+                    </select>
+                    <small v-if="temporaryReplacementAssignmentOptions.length === 0" class="attendance__field-hint">
+                      {{ tr('No published regular assignment is available to replace.', '暂无可替换的已发布常规分配。') }}
+                    </small>
+                  </label>
+                  <label class="attendance__field" for="attendance-temporary-shift-replacement-shift">
+                    <span>{{ tr('Replacement shift', '替换班次') }}</span>
+                    <select
+                      id="attendance-temporary-shift-replacement-shift"
+                      v-model="temporaryAssignmentForm.shiftId"
+                      :disabled="shifts.length === 0"
+                    >
+                      <option value="" disabled>{{ tr('Select shift', '选择班次') }}</option>
+                      <option v-for="shift in shifts" :key="shift.id" :value="shift.id">
+                        {{ shift.name }}
+                      </option>
+                    </select>
+                  </label>
+                  <label class="attendance__field" for="attendance-temporary-shift-work-date">
+                    <span>{{ tr('Work date', '工作日期') }}</span>
+                    <input
+                      id="attendance-temporary-shift-work-date"
+                      v-model="temporaryAssignmentForm.workDate"
+                      type="date"
+                      :min="selectedTemporaryReplacementAssignment?.assignment.startDate"
+                      :max="selectedTemporaryReplacementAssignment?.assignment.endDate || undefined"
+                    />
+                  </label>
+                  <label class="attendance__field" for="attendance-temporary-shift-reason">
+                    <span>{{ tr('Reason', '原因') }}</span>
+                    <textarea
+                      id="attendance-temporary-shift-reason"
+                      v-model="temporaryAssignmentForm.reason"
+                      rows="2"
+                      :placeholder="tr('Optional reason shown on the draft', '可选，显示在草稿中的原因')"
+                    ></textarea>
+                  </label>
+                </div>
+                <div class="attendance__admin-actions">
+                  <button
+                    class="attendance__btn attendance__btn--primary"
+                    :disabled="temporaryAssignmentSaving || temporaryReplacementAssignmentOptions.length === 0"
+                    data-attendance-temporary-shift-save-draft
+                    @click="saveTemporaryAssignmentDraft"
+                  >
+                    {{ temporaryAssignmentSaving ? tr('Saving...', '保存中...') : tr('Save temporary draft', '保存临时班次草稿') }}
+                  </button>
+                </div>
+              </div>
               <div class="attendance__admin-actions attendance__admin-actions--wrap" data-attendance-schedule-publication-controls>
                 <span class="attendance__field-hint">
                   {{ tr(`Selected drafts: ${selectedScheduleDraftCount}`, `已选草稿：${selectedScheduleDraftCount}`) }}
@@ -7186,6 +7257,20 @@
                         >
                           {{ assignmentSlotLabel(item.assignment) }}
                         </span>
+                        <span
+                          v-if="isTemporaryAssignment(item.assignment)"
+                          class="attendance__scheduler-scope-chip"
+                          data-attendance-assignment-temporary-marker
+                          :title="temporaryAssignmentReplacementId(item.assignment)"
+                        >
+                          {{ tr('Temporary', '临时') }}
+                        </span>
+                        <small
+                          v-if="temporaryAssignmentReason(item.assignment)"
+                          class="attendance__field-hint"
+                        >
+                          {{ temporaryAssignmentReason(item.assignment) }}
+                        </small>
                       </td>
                       <td>{{ item.assignment.startDate }}</td>
                       <td>{{ item.assignment.endDate || '--' }}</td>
@@ -8681,6 +8766,7 @@ const shiftLoading = ref(false)
 const shiftSaving = ref(false)
 const assignmentLoading = ref(false)
 const assignmentSaving = ref(false)
+const temporaryAssignmentSaving = ref(false)
 const holidayLoading = ref(false)
 const holidaySaving = ref(false)
 const reportLoading = ref(false)
@@ -11736,6 +11822,13 @@ const assignmentForm = reactive({
   endDate: '',
   isActive: true,
   slotIndex: 0,
+})
+
+const temporaryAssignmentForm = reactive({
+  replacementAssignmentId: '',
+  shiftId: '',
+  workDate: toDateInput(today),
+  reason: '',
 })
 
 const shiftAssignmentEffectiveCalendarChips = ref<CalendarEffectiveChip[]>([])
@@ -17072,6 +17165,69 @@ function assignmentSlotLabel(assignment: AttendanceAssignment): string {
   return tr(`Slot ${index}`, `槽位 ${index}`)
 }
 
+function assignmentKind(assignment: AttendanceAssignment): 'regular' | 'temporary' {
+  return (assignment.assignmentKind ?? assignment.assignment_kind) === 'temporary' ? 'temporary' : 'regular'
+}
+
+function isTemporaryAssignment(assignment: AttendanceAssignment): boolean {
+  return assignmentKind(assignment) === 'temporary'
+}
+
+function temporaryAssignmentReason(assignment: AttendanceAssignment): string {
+  return String(assignment.temporaryReason ?? assignment.temporary_reason ?? '').trim()
+}
+
+function temporaryAssignmentReplacementId(assignment: AttendanceAssignment): string {
+  return String(assignment.temporaryReplacesAssignmentId ?? assignment.temporary_replaces_assignment_id ?? '').trim()
+}
+
+function assignmentDateRangeLabel(assignment: Pick<AttendanceAssignment, 'startDate' | 'endDate'>): string {
+  return assignment.endDate ? `${assignment.startDate} - ${assignment.endDate}` : assignment.startDate
+}
+
+function formatTemporaryReplacementAssignmentOption(item: AttendanceAssignmentItem): string {
+  const userLabel = attendanceAssignmentUserPrimaryLabel(item.assignment.userId) || item.assignment.userId
+  return `${userLabel} · ${item.shift.name} · ${assignmentDateRangeLabel(item.assignment)} · ${assignmentSlotLabel(item.assignment)}`
+}
+
+const temporaryReplacementAssignmentOptions = computed(() =>
+  assignments.value.filter((item) =>
+    assignmentPublishStatus(item.assignment) === 'published'
+    && item.assignment.isActive !== false
+    && assignmentKind(item.assignment) === 'regular',
+  ),
+)
+
+const selectedTemporaryReplacementAssignment = computed(() =>
+  temporaryReplacementAssignmentOptions.value.find((item) => item.assignment.id === temporaryAssignmentForm.replacementAssignmentId) ?? null,
+)
+
+function applyTemporaryReplacementDefaults(item: AttendanceAssignmentItem | null): void {
+  if (!item) return
+  temporaryAssignmentForm.workDate = item.assignment.startDate
+  if (!temporaryAssignmentForm.shiftId && shifts.value.length > 0) {
+    temporaryAssignmentForm.shiftId = shifts.value[0]?.id ?? ''
+  }
+}
+
+function onTemporaryReplacementAssignmentChange(): void {
+  applyTemporaryReplacementDefaults(selectedTemporaryReplacementAssignment.value)
+}
+
+function isTemporaryAssignmentWorkDateInRange(assignment: AttendanceAssignment, workDate: string): boolean {
+  if (workDate < assignment.startDate) return false
+  if (assignment.endDate && workDate > assignment.endDate) return false
+  return true
+}
+
+watch(temporaryReplacementAssignmentOptions, (options) => {
+  if (temporaryAssignmentForm.replacementAssignmentId && options.some((item) => item.assignment.id === temporaryAssignmentForm.replacementAssignmentId)) {
+    return
+  }
+  temporaryAssignmentForm.replacementAssignmentId = options[0]?.assignment.id ?? ''
+  applyTemporaryReplacementDefaults(options[0] ?? null)
+}, { immediate: true })
+
 function normalizeAssignmentPublishStatus(value: unknown): AttendanceSchedulePublishStatus {
   if (value === 'draft' || value === 'pending' || value === 'published') return value
   return 'published'
@@ -18536,6 +18692,9 @@ async function loadShifts() {
     if (!assignmentForm.shiftId && shifts.value.length > 0) {
       assignmentForm.shiftId = shifts.value[0].id
     }
+    if (!temporaryAssignmentForm.shiftId && shifts.value.length > 0) {
+      temporaryAssignmentForm.shiftId = shifts.value[0].id
+    }
     if (!attendanceGroupFixedSchedulePreviewForm.shiftId && shifts.value.length > 0) {
       attendanceGroupFixedSchedulePreviewForm.shiftId = shifts.value[0].id
     }
@@ -18617,6 +18776,14 @@ function resetAssignmentForm() {
   assignmentForm.endDate = ''
   assignmentForm.isActive = true
   assignmentForm.slotIndex = 0
+}
+
+function resetTemporaryAssignmentForm() {
+  const firstReplacement = temporaryReplacementAssignmentOptions.value[0] ?? null
+  temporaryAssignmentForm.replacementAssignmentId = firstReplacement?.assignment.id ?? ''
+  temporaryAssignmentForm.shiftId = shifts.value[0]?.id ?? ''
+  temporaryAssignmentForm.workDate = firstReplacement?.assignment.startDate ?? toDateInput(today)
+  temporaryAssignmentForm.reason = ''
 }
 
 function editAssignment(item: AttendanceAssignmentItem) {
@@ -18721,6 +18888,61 @@ async function saveAssignment(options: { asDraft?: boolean } = {}) {
     setStatus(readErrorMessage(error, tr('Failed to save assignment', '保存分配失败')), 'error')
   } finally {
     assignmentSaving.value = false
+  }
+}
+
+async function saveTemporaryAssignmentDraft() {
+  temporaryAssignmentSaving.value = true
+  try {
+    const replacement = selectedTemporaryReplacementAssignment.value
+    if (!replacement) {
+      throw new Error(tr('Select a published assignment to replace', '请选择一个已发布的排班分配作为替换目标'))
+    }
+    if (!temporaryAssignmentForm.shiftId) {
+      throw new Error(tr('Replacement shift is required', '替换班次为必选项'))
+    }
+    const workDate = temporaryAssignmentForm.workDate.trim()
+    if (!workDate) {
+      throw new Error(tr('Work date is required', '工作日期为必填项'))
+    }
+    if (!isTemporaryAssignmentWorkDateInRange(replacement.assignment, workDate)) {
+      throw new Error(tr('Work date must fall within the selected assignment range', '工作日期必须在所选分配的日期范围内'))
+    }
+    const reason = temporaryAssignmentForm.reason.trim()
+    const payload = {
+      userId: replacement.assignment.userId,
+      shiftId: temporaryAssignmentForm.shiftId,
+      startDate: workDate,
+      endDate: workDate,
+      isActive: true,
+      slotIndex: assignmentSlotIndex(replacement.assignment),
+      assignmentKind: 'temporary',
+      temporaryMode: 'replace',
+      temporaryReplacesKind: 'shift',
+      temporaryReplacesAssignmentId: replacement.assignment.id,
+      temporaryReason: reason.length > 0 ? reason : null,
+      orgId: normalizedOrgId(),
+    }
+    const response = await apiFetch('/api/attendance/schedule-drafts/assignments', {
+      method: 'POST',
+      body: JSON.stringify(payload),
+    })
+    if (response.status === 403) {
+      adminForbidden.value = true
+      throw new Error(tr('Admin permissions required', '需要管理员权限'))
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to save temporary shift draft', '保存临时班次草稿失败')))
+    }
+    adminForbidden.value = false
+    await loadAssignments()
+    resetTemporaryAssignmentForm()
+    setStatus(tr('Temporary shift draft saved.', '临时班次草稿已保存。'))
+  } catch (error: any) {
+    setStatus(readErrorMessage(error, tr('Failed to save temporary shift draft', '保存临时班次草稿失败')), 'error')
+  } finally {
+    temporaryAssignmentSaving.value = false
   }
 }
 

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -4106,6 +4106,244 @@ describe('Attendance admin regressions', () => {
     expect(container!.textContent).toContain('Assignment draft saved.')
   })
 
+  it('saves a temporary shift replacement draft from a published regular assignment', async () => {
+    const draftBodies: unknown[] = []
+    const baseShift = {
+      id: 'shift-base',
+      name: 'Base shift',
+      timezone: 'UTC',
+      workStartTime: '09:00',
+      workEndTime: '18:00',
+      isOvernight: false,
+      lateGraceMinutes: 10,
+      earlyGraceMinutes: 10,
+      roundingMinutes: 5,
+      workingDays: [1, 2, 3, 4, 5],
+    }
+    const temporaryShift = {
+      ...baseShift,
+      id: 'shift-temp',
+      name: 'Temporary shift',
+      workStartTime: '10:00',
+      workEndTime: '19:00',
+    }
+    const assignmentItems = [
+      {
+        assignment: {
+          id: 'assignment-base',
+          userId: 'user-temp',
+          shiftId: 'shift-base',
+          startDate: '2026-06-15',
+          endDate: '2026-06-20',
+          isActive: true,
+          slotIndex: 0,
+          publishStatus: 'published',
+          assignmentKind: 'regular',
+        },
+        shift: baseShift,
+      },
+      {
+        assignment: {
+          id: 'assignment-draft',
+          userId: 'user-draft',
+          shiftId: 'shift-base',
+          startDate: '2026-06-15',
+          endDate: null,
+          isActive: true,
+          slotIndex: 0,
+          publishStatus: 'draft',
+          assignmentKind: 'regular',
+        },
+        shift: baseShift,
+      },
+      {
+        assignment: {
+          id: 'assignment-existing-temp',
+          userId: 'user-temp',
+          shiftId: 'shift-temp',
+          startDate: '2026-06-16',
+          endDate: '2026-06-16',
+          isActive: true,
+          slotIndex: 0,
+          publishStatus: 'published',
+          assignmentKind: 'temporary',
+          temporaryMode: 'replace',
+          temporaryReplacesKind: 'shift',
+          temporaryReplacesAssignmentId: 'assignment-base',
+          temporaryReason: 'existing coverage',
+        },
+        shift: temporaryShift,
+      },
+    ]
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      const method = String(init?.method || 'GET').toUpperCase()
+      if (url.includes('/api/attendance/shifts')) {
+        return jsonResponse(200, { ok: true, data: { items: [baseShift, temporaryShift] } })
+      }
+      if (url === '/api/attendance/schedule-drafts/assignments' && method === 'POST') {
+        draftBodies.push(JSON.parse(String(init?.body || '{}')))
+        return jsonResponse(201, {
+          ok: true,
+          data: {
+            assignment: {
+              id: 'assignment-temp-draft',
+              userId: 'user-temp',
+              shiftId: 'shift-temp',
+              startDate: '2026-06-16',
+              endDate: '2026-06-16',
+              isActive: true,
+              slotIndex: 0,
+              publishStatus: 'draft',
+              assignmentKind: 'temporary',
+              temporaryMode: 'replace',
+              temporaryReplacesKind: 'shift',
+              temporaryReplacesAssignmentId: 'assignment-base',
+              temporaryReason: 'one-day coverage',
+            },
+          },
+        })
+      }
+      if (url === '/api/attendance/assignments' && method === 'POST') {
+        return jsonResponse(500, { ok: false, error: { code: 'UNEXPECTED_IMMEDIATE_SAVE', message: 'temporary draft should not call immediate save' } })
+      }
+      if (url.includes('/api/attendance/comprehensive-hours/preview')) {
+        return jsonResponse(500, { ok: false, error: { code: 'UNEXPECTED_PREVIEW', message: 'temporary draft should not preview' } })
+      }
+      if (url.includes('/api/attendance/assignments')) {
+        return jsonResponse(200, { ok: true, data: { items: assignmentItems } })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-assignments"]')!.click()
+    await flushUi(2)
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')!
+    const replacementSelect = section.querySelector<HTMLSelectElement>('#attendance-temporary-shift-replacement-assignment')!
+    expect(replacementSelect).toBeTruthy()
+    expect(Array.from(replacementSelect.options).map(option => option.value)).toEqual(['', 'assignment-base'])
+    expect(section.querySelector('[data-attendance-assignment-temporary-marker]')?.textContent).toContain('Temporary')
+
+    replacementSelect.value = 'assignment-base'
+    replacementSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    const shiftSelect = section.querySelector<HTMLSelectElement>('#attendance-temporary-shift-replacement-shift')!
+    shiftSelect.value = 'shift-temp'
+    shiftSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(section, '#attendance-temporary-shift-work-date', '2026-06-16')
+    setInput(section, '#attendance-temporary-shift-reason', 'one-day coverage')
+    await flushUi(2)
+
+    section.querySelector<HTMLButtonElement>('[data-attendance-temporary-shift-save-draft]')!.click()
+    await flushUi(8)
+
+    expect(draftBodies).toEqual([
+      {
+        userId: 'user-temp',
+        shiftId: 'shift-temp',
+        startDate: '2026-06-16',
+        endDate: '2026-06-16',
+        isActive: true,
+        slotIndex: 0,
+        assignmentKind: 'temporary',
+        temporaryMode: 'replace',
+        temporaryReplacesKind: 'shift',
+        temporaryReplacesAssignmentId: 'assignment-base',
+        temporaryReason: 'one-day coverage',
+      },
+    ])
+    expect(vi.mocked(apiFetch).mock.calls.some(([input]) =>
+      String(input).includes('/api/attendance/comprehensive-hours/preview')
+    )).toBe(false)
+    expect(vi.mocked(apiFetch).mock.calls.some(([input, init]) =>
+      String(input) === '/api/attendance/assignments' && init?.method === 'POST'
+    )).toBe(false)
+    expect(container!.textContent).toContain('Temporary shift draft saved.')
+  })
+
+  it('does not post a temporary shift draft outside the replaced assignment date range', async () => {
+    const draftBodies: unknown[] = []
+    const baseShift = {
+      id: 'shift-base',
+      name: 'Base shift',
+      timezone: 'UTC',
+      workStartTime: '09:00',
+      workEndTime: '18:00',
+      isOvernight: false,
+      lateGraceMinutes: 10,
+      earlyGraceMinutes: 10,
+      roundingMinutes: 5,
+      workingDays: [1, 2, 3, 4, 5],
+    }
+    const temporaryShift = {
+      ...baseShift,
+      id: 'shift-temp',
+      name: 'Temporary shift',
+      workStartTime: '10:00',
+      workEndTime: '19:00',
+    }
+    vi.mocked(apiFetch).mockImplementation(async (input, init) => {
+      const url = typeof input === 'string' ? input : input.url
+      const method = String(init?.method || 'GET').toUpperCase()
+      if (url.includes('/api/attendance/shifts')) {
+        return jsonResponse(200, { ok: true, data: { items: [baseShift, temporaryShift] } })
+      }
+      if (url === '/api/attendance/schedule-drafts/assignments' && method === 'POST') {
+        draftBodies.push(JSON.parse(String(init?.body || '{}')))
+        return jsonResponse(500, { ok: false, error: { code: 'UNEXPECTED_POST', message: 'out-of-range work date should not post' } })
+      }
+      if (url.includes('/api/attendance/assignments')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: {
+            items: [
+              {
+                assignment: {
+                  id: 'assignment-base',
+                  userId: 'user-temp',
+                  shiftId: 'shift-base',
+                  startDate: '2026-06-15',
+                  endDate: '2026-06-20',
+                  isActive: true,
+                  slotIndex: 0,
+                  publishStatus: 'published',
+                  assignmentKind: 'regular',
+                },
+                shift: baseShift,
+              },
+            ],
+          },
+        })
+      }
+      return emptyAttendanceResponse()
+    })
+
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(8)
+
+    container!.querySelector<HTMLButtonElement>('[data-admin-anchor="attendance-admin-assignments"]')!.click()
+    await flushUi(2)
+    const section = container!.querySelector<HTMLElement>('#attendance-admin-assignments')!
+    const workDateInput = section.querySelector<HTMLInputElement>('#attendance-temporary-shift-work-date')!
+    expect(workDateInput.min).toBe('2026-06-15')
+    expect(workDateInput.max).toBe('2026-06-20')
+    const shiftSelect = section.querySelector<HTMLSelectElement>('#attendance-temporary-shift-replacement-shift')!
+    shiftSelect.value = 'shift-temp'
+    shiftSelect.dispatchEvent(new Event('change', { bubbles: true }))
+    setInput(section, '#attendance-temporary-shift-work-date', '2026-06-21')
+    await flushUi(2)
+
+    section.querySelector<HTMLButtonElement>('[data-attendance-temporary-shift-save-draft]')!.click()
+    await flushUi(4)
+
+    expect(draftBodies).toEqual([])
+    expect(container!.textContent).toContain('Work date must fall within the selected assignment range')
+  })
+
   it('publishes selected direct and rotation schedule drafts with an exact request body', async () => {
     const publicationBodies: unknown[] = []
     vi.mocked(apiFetch).mockImplementation(async (input, init) => {


### PR DESCRIPTION
## Summary
- add a Temporary shift replacement card in the real AttendanceView assignments section
- create replace-only temporary shift drafts through /api/attendance/schedule-drafts/assignments
- mark temporary assignments in the assignment table and filter replacement targets to published regular assignments only

## Verification
- pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts -t "temporary shift" --watch=false
- pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts tests/attendance-admin-anchor-nav.spec.ts --watch=false
- pnpm --filter @metasheet/web exec vue-tsc -b
- git diff --check

## Scope
- Frontend-only T5 admin UI over the #2439 temporary shift runtime
- Does not change backend, DB, OpenAPI, or tracker status
- Staging smoke / tracker flip remain separate gated follow-up