### PR TITLE
fix(attendance): complete temporary shift staging paths

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -3,6 +3,7 @@ import type { MetaSheetServer } from '../../src/index'
 import * as path from 'path'
 import net from 'net'
 import fs from 'fs/promises'
+import { randomUUID } from 'crypto'
 import { Pool } from 'pg'
 import http from 'http'
 import { AttendanceExpiryService } from '../../src/services/AttendanceExpiryService'
@@ -3767,10 +3768,14 @@ attendanceIntegrationDescribe(
     const runSuffix = Date.now().toString(36)
     const adminUserId = `attendance-temp-shift-admin-${runSuffix}`
     const userId = `attendance-temp-shift-user-${runSuffix}`
+    const fixedUserId = `attendance-temp-shift-fixed-${runSuffix}`
     const workDate = '2026-08-03'
+    const fixedDate = '2026-08-04'
+    const staleTempDate = '2026-08-05'
     const pool = new Pool({ connectionString: dbUrl })
     let originalSettings: Record<string, unknown> = {}
     const shiftIds: string[] = []
+    let fixedGroupId: string | undefined
 
     const tokenRes = await requestJson(
       `${baseUrl}/api/auth/dev-token?userId=${encodeURIComponent(adminUserId)}&roles=admin&perms=attendance:read,attendance:write,attendance:admin`
@@ -3812,6 +3817,16 @@ attendanceIntegrationDescribe(
         headers,
         body: JSON.stringify({ assignmentIds: [assignmentId] }),
       })
+    }
+
+    async function loadEffectiveSlot(targetUserId: string, targetDate: string) {
+      const effectiveCalendarRes = await requestJson(
+        `${baseUrl}/api/attendance/effective-calendar?from=${targetDate}&to=${targetDate}&userId=${encodeURIComponent(targetUserId)}`,
+        { headers: { Authorization: `Bearer ${token}` } },
+      )
+      expect(effectiveCalendarRes.status, JSON.stringify(effectiveCalendarRes.body)).toBe(200)
+      const item = ((effectiveCalendarRes.body as { data?: { items?: Array<{ effective?: { slots?: Array<{ shiftId?: string; assignmentKind?: string; replaces?: { assignmentId?: string } }> } }> } } | undefined)?.data?.items ?? [])[0]
+      return item?.effective?.slots?.[0]
     }
 
     function tempDraftBody(replacementShiftId: string, replacementAssignmentId: string, overrides: Record<string, unknown> = {}) {
@@ -4040,6 +4055,115 @@ attendanceIntegrationDescribe(
       })
       expect(secondTempRes.status, JSON.stringify(secondTempRes.body)).toBe(409)
       expect((secondTempRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('ATTENDANCE_SCHEDULE_ASSIGNMENT_CONFLICT')
+
+      const fixedGroupRes = await requestJson(`${baseUrl}/api/attendance/groups`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({
+          name: `temp-shift-fixed-${runSuffix}`,
+          timezone: 'UTC',
+          attendanceType: 'fixed_shift',
+          description: 'temporary-shift fixed rebuild compatibility',
+        }),
+      })
+      expect(fixedGroupRes.status, JSON.stringify(fixedGroupRes.body)).toBe(200)
+      fixedGroupId = (fixedGroupRes.body as { data?: { id?: string } } | undefined)?.data?.id
+      expect(fixedGroupId).toBeTruthy()
+      if (!fixedGroupId) return
+      const fixedMemberRes = await requestJson(`${baseUrl}/api/attendance/groups/${fixedGroupId}/members`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ userIds: [fixedUserId] }),
+      })
+      expect(fixedMemberRes.status, JSON.stringify(fixedMemberRes.body)).toBe(200)
+      const fixedApplyRes = await requestJson(`${baseUrl}/api/attendance/groups/${fixedGroupId}/fixed-schedule/apply`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ shiftId: baseShiftId, startDate: fixedDate, endDate: fixedDate }),
+      })
+      expect(fixedApplyRes.status, JSON.stringify(fixedApplyRes.body)).toBe(201)
+      const fixedBaseRows = await pool.query(
+        `SELECT id
+           FROM attendance_shift_assignments
+          WHERE user_id = $1
+            AND start_date = $2::date
+            AND shift_id = $3
+            AND producer_type = 'attendance_group_fixed_schedule'
+            AND COALESCE(is_active, true) = true`,
+        [fixedUserId, fixedDate, baseShiftId],
+      )
+      const fixedBaseAssignmentId = fixedBaseRows.rows[0]?.id
+      expect(fixedBaseAssignmentId).toBeTruthy()
+      if (!fixedBaseAssignmentId) return
+      const fixedTempDraftRes = await requestJson(`${baseUrl}/api/attendance/schedule-drafts/assignments`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify(tempDraftBody(replacementShiftId, fixedBaseAssignmentId, {
+          userId: fixedUserId,
+          startDate: fixedDate,
+          endDate: fixedDate,
+          temporaryReason: 'fixed rebuild replacement',
+        })),
+      })
+      expect(fixedTempDraftRes.status, JSON.stringify(fixedTempDraftRes.body)).toBe(201)
+      const fixedTempDraftId = (fixedTempDraftRes.body as { data?: { assignment?: { id?: string } } } | undefined)?.data?.assignment?.id
+      expect(fixedTempDraftId).toBeTruthy()
+      if (!fixedTempDraftId) return
+      const publishFixedTempRes = await publish(fixedTempDraftId)
+      expect(publishFixedTempRes.status, JSON.stringify(publishFixedTempRes.body)).toBe(200)
+      expect(await loadEffectiveSlot(fixedUserId, fixedDate)).toMatchObject({
+        shiftId: replacementShiftId,
+        assignmentKind: 'temporary',
+        replaces: { assignmentId: fixedBaseAssignmentId },
+      })
+      const fixedRebuildRes = await requestJson(`${baseUrl}/api/attendance/groups/${fixedGroupId}/fixed-schedule/rebuild`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ shiftId: baseShiftId, startDate: fixedDate, endDate: fixedDate }),
+      })
+      expect(fixedRebuildRes.status, JSON.stringify(fixedRebuildRes.body)).toBe(200)
+      expect(await loadEffectiveSlot(fixedUserId, fixedDate)).toMatchObject({
+        shiftId: replacementShiftId,
+        assignmentKind: 'temporary',
+        replaces: { assignmentId: fixedBaseAssignmentId },
+      })
+
+      const staleApplyRes = await requestJson(`${baseUrl}/api/attendance/groups/${fixedGroupId}/fixed-schedule/apply`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ shiftId: baseShiftId, startDate: staleTempDate, endDate: staleTempDate }),
+      })
+      expect(staleApplyRes.status, JSON.stringify(staleApplyRes.body)).toBe(201)
+      await pool.query(
+        `INSERT INTO attendance_shift_assignments
+          (id, org_id, user_id, shift_id, slot_index, start_date, end_date, is_active, publish_status,
+           assignment_kind, temporary_mode, temporary_replaces_kind, temporary_replaces_assignment_id,
+           temporary_reason, temporary_created_by, temporary_created_at, locked_at)
+         VALUES ($1, 'default', $2, $3, 0, $4::date, $4::date, true, 'published',
+           'temporary', 'replace', 'shift', $5, 'stale unrelated temp overlay', $6, now(), now())`,
+        [randomUUID(), fixedUserId, replacementShiftId, staleTempDate, baseAssignment.id, adminUserId],
+      )
+      const staleRebuildRes = await requestJson(`${baseUrl}/api/attendance/groups/${fixedGroupId}/fixed-schedule/rebuild`, {
+        method: 'POST',
+        headers,
+        body: JSON.stringify({ shiftId: baseShiftId, startDate: staleTempDate, endDate: staleTempDate }),
+      })
+      expect(staleRebuildRes.status, JSON.stringify(staleRebuildRes.body)).toBe(409)
+      expect((staleRebuildRes.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('ATTENDANCE_GROUP_FIXED_SCHEDULE_BLOCKING_CONFLICT')
+
+      const deleteTempRes = await requestJson(`${baseUrl}/api/attendance/assignments/${tempDraft.id}`, {
+        method: 'DELETE',
+        headers,
+      })
+      expect(deleteTempRes.status, JSON.stringify(deleteTempRes.body)).toBe(200)
+      const inactiveTempRows = await pool.query(
+        'SELECT is_active FROM attendance_shift_assignments WHERE id = $1',
+        [tempDraft.id],
+      )
+      expect(inactiveTempRows.rows[0]?.is_active).toBe(false)
+      expect(await loadEffectiveSlot(userId, workDate)).toMatchObject({
+        shiftId: baseShiftId,
+      })
     } finally {
       if (Object.keys(originalSettings).length > 0) {
         await requestJson(`${baseUrl}/api/attendance/settings`, {
@@ -4048,7 +4172,11 @@ attendanceIntegrationDescribe(
           body: JSON.stringify(originalSettings),
         }).catch(() => undefined)
       }
-      await pool.query('DELETE FROM attendance_shift_assignments WHERE user_id = $1', [userId]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_shift_assignments WHERE user_id = ANY($1::text[])', [[userId, fixedUserId]]).catch(() => undefined)
+      if (fixedGroupId) {
+        await pool.query('DELETE FROM attendance_group_members WHERE group_id = $1', [fixedGroupId]).catch(() => undefined)
+        await pool.query('DELETE FROM attendance_groups WHERE id = $1', [fixedGroupId]).catch(() => undefined)
+      }
       if (shiftIds.length > 0) {
         await pool.query('DELETE FROM attendance_shifts WHERE id = ANY($1::uuid[])', [shiftIds]).catch(() => undefined)
       }

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -9253,6 +9253,32 @@ function mapAttendanceGroupFixedScheduleBlockingConflict(row, draft) {
   return mapped
 }
 
+function isTemporaryShiftOverlayRowForFixedScheduleDraft(row, draft, overlaps = []) {
+  if (!row || row.kind === 'rotation') return false
+  if (row.assignment_kind !== 'temporary') return false
+  if (row.temporary_mode !== 'replace') return false
+  if (row.temporary_replaces_kind !== 'shift') return false
+  const replacementAssignmentId = normalizeUuidString(row.temporary_replaces_assignment_id)
+  if (!replacementAssignmentId) return false
+  const rowStartDate = normalizeDateOnly(row.start_date) ?? row.start_date
+  const rowEndDate = normalizeAttendanceScheduleAssignmentEndDate(row.end_date) || rowStartDate
+  const draftStartDate = normalizeDateOnly(draft.startDate) ?? draft.startDate
+  const draftSlotIndex = normalizeAttendanceScheduleSlotIndex(draft.slotIndex, 0)
+  if (
+    String(row.user_id || '') !== String(draft.userId || '')
+    || normalizeAttendanceScheduleSlotIndex(row.slot_index, 0) !== draftSlotIndex
+    || rowStartDate > draftStartDate
+    || rowEndDate < draftStartDate
+  ) {
+    return false
+  }
+  return overlaps.some((candidate) =>
+    String(candidate?.id || '') === replacementAssignmentId
+    && candidate?.assignment_kind !== 'temporary'
+    && isExactAttendanceGroupFixedScheduleAssignment(candidate, draft)
+  )
+}
+
 async function acquireAttendanceScheduleAssignmentLocks(db, orgId, userIds) {
   const lockUserIds = Array.from(new Set(
     (Array.isArray(userIds) ? userIds : [])
@@ -9356,6 +9382,9 @@ async function buildAttendanceGroupFixedSchedulePlan(db, input, options = {}) {
             a.publish_status, a.publish_batch_id, a.publish_requested_at, a.publish_requested_by,
             a.published_at, a.published_by, a.locked_at, a.reopened_from_assignment_id,
             a.producer_type, a.producer_ref_id, a.producer_key, a.producer_run_id,
+            a.assignment_kind, a.temporary_mode, a.temporary_replaces_kind,
+            a.temporary_replaces_assignment_id, a.temporary_reason, a.temporary_created_by,
+            a.temporary_created_at,
             'shift'::text AS kind,
             s.work_start_time, s.work_end_time, s.is_overnight
        FROM attendance_shift_assignments a
@@ -9414,6 +9443,7 @@ async function buildAttendanceGroupFixedSchedulePlan(db, input, options = {}) {
     }
     const overlaps = overlapsByUserId.get(userId) ?? []
     const blockingRow = overlaps.find((row) => {
+      if (isTemporaryShiftOverlayRowForFixedScheduleDraft(row, draft, overlaps)) return false
       if (isExactAttendanceGroupFixedScheduleAssignment(row, draft)) return false
       if (multiShiftDay.enabled && row?.kind !== 'rotation') {
         const existingSlotIndex = normalizeAttendanceScheduleSlotIndex(row?.slot_index, 0)
@@ -32523,21 +32553,50 @@ module.exports = {
             return
           }
 
-          const existingPublishStatus = normalizeAttendanceSchedulePublishStatus(existingRows[0].publish_status)
-          if (!isAttendanceSchedulePublishedDirectlyMutable(existingRows[0])) {
+          const existing = existingRows[0]
+          const existingPublishStatus = normalizeAttendanceSchedulePublishStatus(existing.publish_status)
+          const isPublishedTemporaryAssignment = existing.assignment_kind === 'temporary' && existingPublishStatus === 'published'
+          if (!isPublishedTemporaryAssignment && !isAttendanceSchedulePublishedDirectlyMutable(existing)) {
             respondAttendanceSchedulePublishLocked(res, existingPublishStatus)
             return
           }
 
-          const windowAccess = await enforceShiftEditWindow(res, [existingRows[0].start_date])
+          const windowAccess = await enforceShiftEditWindow(res, [existing.start_date])
           if (!windowAccess) return
 
           const access = await assertAttendanceScheduleAssignmentDispatchAllowed(req, res, {
             orgId,
-            payload: existingRows[0],
+            payload: existing,
             actorAccess,
           })
           if (!access) return
+
+          if (isPublishedTemporaryAssignment) {
+            const result = await db.transaction(async (trx) => {
+              await acquireAttendanceScheduleAssignmentLock(trx, orgId, existing.user_id)
+              const rows = await trx.query(
+                `UPDATE attendance_shift_assignments
+                    SET is_active = false,
+                        updated_at = now()
+                  WHERE id = $1
+                    AND org_id = $2
+                    AND assignment_kind = 'temporary'
+                    AND COALESCE(publish_status, 'published') = 'published'
+                    AND COALESCE(is_active, true) = true
+                  RETURNING *`,
+                [assignmentId, orgId]
+              )
+              return rows[0] ? { row: rows[0] } : { missing: true }
+            })
+            if (result.missing) {
+              res.status(404).json({ ok: false, error: { code: 'NOT_FOUND', message: 'Assignment not found' } })
+              return
+            }
+            const assignment = mapAssignmentRow(result.row)
+            emitEvent('attendance.assignment.deleted', { orgId, assignmentId })
+            res.json({ ok: true, data: { id: assignmentId, assignment } })
+            return
+          }
 
           const rows = await db.query(
             `DELETE FROM attendance_shift_assignments

--- a/scripts/ops/staging-attendance-temporary-shift-t6-smoke.mjs
+++ b/scripts/ops/staging-attendance-temporary-shift-t6-smoke.mjs
@@ -161,11 +161,15 @@ async function effectiveItem(userId, date) {
 }
 
 function effectiveShiftId(item) {
-  return item?.effective?.shiftId || item?.effective?.shift_id || null
+  return item?.effective?.shiftId || item?.effective?.shift_id || slotShiftId(effectiveSlots(item)[0]) || null
 }
 
 function effectiveSlots(item) {
   return Array.isArray(item?.effective?.slots) ? item.effective.slots : []
+}
+
+function hasTemporarySlot(item) {
+  return effectiveSlots(item).some(slot => slot?.assignmentKind === 'temporary' || slot?.assignment_kind === 'temporary')
 }
 
 function slotShiftId(slot) {
@@ -280,14 +284,14 @@ async function main() {
 
   const baseAssignmentId = await createPublishedAssignment(USER, baseShiftId, WORK_DATE, addDays(WORK_DATE, 2))
   let item = await effectiveItem(USER, WORK_DATE)
-  ok(effectiveShiftId(item) === baseShiftId,
-    'before temp publish, effective-calendar returns the base assignment', item?.effective)
-  ok(!effectiveSlots(item).some(slot => slot?.assignmentKind === 'temporary' || slot?.assignment_kind === 'temporary'),
+  ok(item?.effective?.source === 'shift' && !hasTemporarySlot(item),
+    'before temp publish, effective-calendar returns the base shift schedule', item?.effective)
+  ok(!hasTemporarySlot(item),
     'before temp publish, no temporary slot is visible', effectiveSlots(item))
 
   const tempDraftId = await createTemporaryDraft(USER, replacementShiftId, baseAssignmentId, WORK_DATE, `${STAMP} one-day replacement`)
   item = await effectiveItem(USER, WORK_DATE)
-  ok(effectiveShiftId(item) === baseShiftId,
+  ok(item?.effective?.source === 'shift' && !hasTemporarySlot(item),
     'draft temporary assignment is invisible before publication', item?.effective)
 
   await publishAssignment(tempDraftId, 'temporary replacement draft')
@@ -305,7 +309,7 @@ async function main() {
 
   await deleteAssignment(tempDraftId, 'temporary replacement')
   item = await effectiveItem(USER, WORK_DATE)
-  ok(effectiveShiftId(item) === baseShiftId,
+  ok(item?.effective?.source === 'shift' && !hasTemporarySlot(item),
     'canceling the temporary row restores the base assignment', item?.effective)
 
   const fixedGroupId = await createFixedGroup(FIXED_USER)


### PR DESCRIPTION
## Summary
- allow published temporary shift assignments to be cancelled via the existing assignment DELETE path by soft-deactivating only temporary rows
- keep fixed-schedule rebuild from treating a temporary replacement overlay as a blocking conflict, preserving the overlay while rebuilding managed base rows
- update the T6 staging smoke helper to read effective shift ids from `effective.slots[]`, matching the deployed effective-calendar contract

## Why
The first T6 staging run against deploy `5edaf08b` reached the real runtime paths and found two implementation gaps plus one script contract mismatch:
- published temporary rows were locked against DELETE, so the smoke could not prove base restore after cancel
- fixed-schedule rebuild returned 409 on a temporary overlay even though the design requires fixed apply/rebuild to preserve temp rows
- effective-calendar exposes temporary/default single-shift replacement through `effective.slots[]`, not a top-level `effective.shiftId`

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `node --check scripts/ops/staging-attendance-temporary-shift-t6-smoke.mjs`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit`
- `pnpm --filter @metasheet/core-backend test:integration:attendance` (local DB unavailable, 119 skipped; CI real-DB is the gate)

## Scope
No schema/OpenAPI/frontend changes. Tracker remains pending until this lands, staging is redeployed, and the T6 smoke passes with residue=0.