### PR TITLE
feat(multitable): formula-over-lookup A-full — one-hop foreign-record propagation

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -173,6 +173,7 @@ jobs:
             tests/integration/multitable-typed-query-numeric-view.test.ts \
             tests/integration/multitable-formula-over-lookup-view.test.ts \
             tests/integration/multitable-formula-over-lookup-create-view.test.ts \
+            tests/integration/multitable-formula-over-lookup-afull-view.test.ts \
             tests/integration/multitable-formula-dryrun.test.ts \
             tests/integration/multitable-records-read-field-mask.test.ts \
             tests/integration/multitable-readpath-search-filter-field-mask.test.ts \

--- a/packages/core-backend/src/multitable/formula-engine.ts
+++ b/packages/core-backend/src/multitable/formula-engine.ts
@@ -254,6 +254,7 @@ export class MultitableFormulaEngine {
     sheetId: string,
     recordId: string,
     fields: MultitableField[],
+    onlyFormulaFieldIds?: ReadonlySet<string>,
   ): Promise<Record<string, unknown> | null> {
     try {
       const recordRes = await query(
@@ -266,7 +267,7 @@ export class MultitableFormulaEngine {
       const data: Record<string, unknown> =
         typeof row.data === 'string' ? JSON.parse(row.data) : (row.data ?? {})
 
-      return await this.recalculateRecordFromData(query, sheetId, recordId, data, fields)
+      return await this.recalculateRecordFromData(query, sheetId, recordId, data, fields, onlyFormulaFieldIds)
     } catch (error) {
       logger.error('recalculateRecord failed:', error as Error)
       return null
@@ -281,6 +282,12 @@ export class MultitableFormulaEngine {
    * back (`data || $keys`) — lookup/rollup values are NOT materialized. Note: a scalar-array
    * lookup reaches `evaluateField` as a joined string literal per the existing A2b contract;
    * exact numeric arithmetic over lookups is Option D (parser), out of A-min scope.
+   *
+   * `onlyFormulaFieldIds` restricts evaluation + materialization to those formula fields.
+   * The dependency-gated write paths (A-min/A-full) MUST pass it: hydration is actor-scoped
+   * (an unreadable foreign sheet hydrates a lookup to []), so re-evaluating a formula whose
+   * inputs did NOT change can clobber a correct stored value with a permission-degraded one.
+   * Absent → all formula fields (first computation on create/submit/import, design #2255).
    */
   async recalculateRecordFromData(
     query: MultitableRecordsQueryFn,
@@ -288,6 +295,7 @@ export class MultitableFormulaEngine {
     recordId: string,
     data: Record<string, unknown>,
     fields: MultitableField[],
+    onlyFormulaFieldIds?: ReadonlySet<string>,
   ): Promise<Record<string, unknown> | null> {
     try {
       // Resolve each formula field's expression. Field-defined formulas store the
@@ -297,6 +305,7 @@ export class MultitableFormulaEngine {
       // writes still compute.
       const formulaTargets = fields.flatMap((field) => {
         if (field.type !== 'formula') return []
+        if (onlyFormulaFieldIds && !onlyFormulaFieldIds.has(field.id)) return []
         const property = field.property as Record<string, unknown> | undefined
         // The legacy data-string fallback applies ONLY when the field has no
         // `expression` property key at all (older records). If the key is present

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -283,9 +283,18 @@ export interface RecordWriteHelpers {
     relationalLinkFields: RelationalLinkField[],
     linkValuesByRecord: Map<string, Map<string, string[]>>,
   ) => Promise<void>
+  /**
+   * Recompute related (linked) records' lookup/rollup echoes — and, A-full (design #2410),
+   * one-hop formula propagation: related records whose lookup/rollup resolve to the edited
+   * source sheet AND whose targetFieldId is in `changedFieldIds` get their formulas
+   * recomputed + materialized. Returned `data` is masked per the related sheet's field-read
+   * gate (echo only — the recompute itself runs on the full hydrated row).
+   */
   computeDependentLookupRollupRecords: (
     query: QueryFn,
+    sourceSheetId: string,
     updatedRecordIds: string[],
+    changedFieldIds: string[],
   ) => Promise<Array<{ sheetId: string; recordId: string; data: Record<string, unknown> }>>
   /**
    * Recalculate `formula` fields for the given just-updated records when a
@@ -852,13 +861,22 @@ export class RecordWriteService {
     }
 
     // -----------------------------------------------------------------------
-    // Step 4: Related record recomputation (cross-sheet)
+    // Step 4: Related record recomputation (cross-sheet). A-full (design #2410):
+    // the helper also propagates this PATCH one hop into the related records'
+    // formulas, gated by the source sheet + changed field ids below.
     // -----------------------------------------------------------------------
+    const changedFieldIds = [
+      ...new Set(
+        Array.from(changesByRecord.values()).flatMap((changes) => changes.map((change) => change.fieldId)),
+      ),
+    ]
     const relatedRecords =
       updates.length > 0
         ? await h.computeDependentLookupRollupRecords(
             this.pool.query.bind(this.pool),
+            sheetId,
             updates.map((u) => u.recordId),
+            changedFieldIds,
           )
         : []
 
@@ -877,11 +895,6 @@ export class RecordWriteService {
     // surface in the response + realtime patch so the editing client AND other
     // clients refresh after a source field changes via this write path.
     // -----------------------------------------------------------------------
-    const changedFieldIds = [
-      ...new Set(
-        Array.from(changesByRecord.values()).flatMap((changes) => changes.map((change) => change.fieldId)),
-      ),
-    ]
     const formulaRecords =
       updates.length > 0
         ? (

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1616,7 +1616,10 @@ async function loadLinkValuesByRecord(
  * (which sources the expression from `field.property.expression`) and returns the
  * recomputed formula-field values per record so the write path can surface them
  * in the response + realtime patch. Returns `[]` when no formula depends on the
- * change. Intra-sheet / intra-record only — no cross-sheet read, no perm gate.
+ * change. Only the DEPENDENT formulas are re-evaluated/persisted (the dep-gate
+ * result doubles as the engine allowlist) — formulas with unchanged inputs keep
+ * their stored value, since actor-scoped hydration could otherwise clobber them.
+ * Intra-sheet / intra-record only — no cross-sheet read, no perm gate.
  */
 async function recalculateFormulaFields(
   query: QueryFn,
@@ -1651,6 +1654,9 @@ async function recalculateFormulaFields(
   }
 
   // Gate: only recompute when a changed (or dependent-lookup) field actually feeds a formula here.
+  // The returned field ids are ALSO the recompute allowlist (F1, review of #2450): hydration is
+  // actor-scoped, so a formula whose inputs did not change must not be re-evaluated — it could
+  // be clobbered with a permission-degraded value (unreadable foreign sheet → lookup []).
   const depRes = await query(
     `SELECT DISTINCT field_id FROM formula_dependencies
      WHERE depends_on_field_id = ANY($1::text[])
@@ -1659,16 +1665,21 @@ async function recalculateFormulaFields(
     [effectiveChangedFieldIds, sheetId],
   )
   if (depRes.rows.length === 0) return []
+  const formulaFieldIdSet = new Set(formulaFieldIds)
+  const dependentFormulaFieldIds = new Set(
+    (depRes.rows as any[]).map((row) => String(row.field_id)).filter((id) => formulaFieldIdSet.has(id)),
+  )
+  if (dependentFormulaFieldIds.size === 0) return []
 
   const results: Array<{ recordId: string; data: Record<string, unknown> }> = []
   for (const recordId of updatedRecordIds) {
     const hydrated = hydratedDataByRecord?.get(recordId)
     const nextData = hydrated
-      ? await multitableFormulaEngine.recalculateRecordFromData(query, sheetId, recordId, hydrated, fields)
-      : await multitableFormulaEngine.recalculateRecord(query, sheetId, recordId, fields)
+      ? await multitableFormulaEngine.recalculateRecordFromData(query, sheetId, recordId, hydrated, fields, dependentFormulaFieldIds)
+      : await multitableFormulaEngine.recalculateRecord(query, sheetId, recordId, fields, dependentFormulaFieldIds)
     if (!nextData) continue
     const formulaData: Record<string, unknown> = {}
-    for (const fieldId of formulaFieldIds) {
+    for (const fieldId of dependentFormulaFieldIds) {
       if (fieldId in nextData) formulaData[fieldId] = nextData[fieldId]
     }
     results.push({ recordId, data: formulaData })
@@ -8520,11 +8531,12 @@ export function univerMetaRouter(): Router {
 
       const fields = (fieldRes.rows as any[]).map(serializeFieldRow)
       const visiblePropertyFields = filterVisiblePropertyFields(fields)
-      // F3 (#2106 §3 F3): RecordWriteService uses these ONLY for the read-back echo (it masks record / related /
-      // formula data + summaries at record-write-service.ts:828/854/882/914/929), so narrow them to the
-      // layer-2 ∧ layer-3 readable set — a field_permissions-denied value must not be echoed. fieldById (the
-      // write gate, below) stays from ALL fields, so a write-only-no-read field remains writable. (crossSheetRelated
-      // @record-write-service.ts:985 is returned UNMASKED — a separate finding, see the verification doc.)
+      // F3 (#2106 §3 F3): RecordWriteService uses these ONLY for the read-back echo (it masks record /
+      // related / formula data + summaries inside patchRecords), so narrow them to the layer-2 ∧ layer-3
+      // readable set — a field_permissions-denied value must not be echoed. fieldById (the write gate,
+      // below) stays from ALL fields, so a write-only-no-read field remains writable. crossSheetRelated
+      // is masked per related sheet inside computeDependentLookupRollupRecords (locked by the
+      // multitable-cross-sheet-related-echo-mask suite).
       const echoFieldScopeMap = access.userId ? await loadFieldPermissionScopeMap(pool.query.bind(pool), sheetId, access.userId) : new Map()
       const echoFieldPermissions = deriveFieldPermissions(visiblePropertyFields, capabilities, { hiddenFieldIds: [], fieldScopeMap: echoFieldScopeMap })
       const readableEchoFields = visiblePropertyFields.filter((field) => echoFieldPermissions[field.id]?.visible !== false)

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1907,7 +1907,11 @@ function mergeComputedRecords(
 async function computeDependentLookupRollupRecords(
   req: Request,
   query: QueryFn,
+  // A-full (design #2410): the edited (source) sheet + its changed field ids gate which related
+  // lookup/rollup fields count as "affected" for the one-hop formula recompute below.
+  sourceSheetId: string,
   updatedRecordIds: string[],
+  changedFieldIds: string[],
 ): Promise<RelatedComputedRecord[]> {
   if (updatedRecordIds.length === 0) return []
 
@@ -1989,11 +1993,62 @@ async function computeDependentLookupRollupRecords(
 
     await applyLookupRollup(req, query, fields, rows, relationalLinkFields, linkValuesByRecord)
 
+    // A-full (design #2410): one-hop formula recompute on the related records. A related
+    // lookup/rollup is "affected" only when it resolves to the edited source sheet, its
+    // targetFieldId is one of the changed source fields, AND the record actually links to one
+    // of the edited source records via that field's linkFieldId — an unrelated edit on the
+    // foreign record must not rewrite formulas just because the record is linked (§3.3).
+    const changedSourceFieldIds = new Set(changedFieldIds)
+    const updatedSourceRecordIds = new Set(updatedRecordIds)
+    const linkConfigById = new Map(relationalLinkFields.map(({ fieldId, cfg }) => [fieldId, cfg]))
+    const affectedFieldIdsByRecord = new Map<string, Set<string>>()
+    for (const field of fields) {
+      if (field.type !== 'lookup' && field.type !== 'rollup') continue
+      const cfg = field.type === 'lookup' ? parseLookupFieldConfig(field.property) : parseRollupFieldConfig(field.property)
+      if (!cfg) continue
+      const foreignSheetId = cfg.foreignSheetId ?? linkConfigById.get(cfg.linkFieldId)?.foreignSheetId
+      if (foreignSheetId !== sourceSheetId) continue
+      if (!changedSourceFieldIds.has(cfg.targetFieldId)) continue
+      for (const row of rows) {
+        const linkedIds =
+          linkValuesByRecord.get(row.id)?.get(cfg.linkFieldId) ?? normalizeLinkIds(row.data[cfg.linkFieldId])
+        if (!linkedIds.some((id) => updatedSourceRecordIds.has(id))) continue
+        const set = affectedFieldIdsByRecord.get(row.id) ?? new Set<string>()
+        set.add(field.id)
+        affectedFieldIdsByRecord.set(row.id, set)
+      }
+    }
+
+    let formulaDataByRecord = new Map<string, Record<string, unknown>>()
+    if (affectedFieldIdsByRecord.size > 0) {
+      const affectedComputedFieldIds = new Set<string>()
+      for (const set of affectedFieldIdsByRecord.values()) {
+        for (const id of set) affectedComputedFieldIds.add(id)
+      }
+      // Formula eval consumes the FULL hydrated row (row.data after applyLookupRollup), never
+      // the permission-masked echo patch built below — recompute stays reader-agnostic (§3.2).
+      // recalculateRecordFromData materializes ONLY formula keys; lookup/rollup remain
+      // computed-on-read. One hop only: results never re-enter this propagation.
+      const hydratedDataByRecord = new Map(rows.map((row) => [row.id, row.data]))
+      const formulaRecords = await recalculateFormulaFields(
+        query,
+        sheetId,
+        fields,
+        Array.from(affectedFieldIdsByRecord.keys()),
+        Array.from(affectedComputedFieldIds),
+        hydratedDataByRecord,
+      )
+      formulaDataByRecord = new Map(formulaRecords.map((record) => [record.recordId, record.data]))
+    }
+
     for (const row of rows) {
       results.push({
         sheetId,
         recordId: row.id,
-        data: filterRecordDataByFieldIds(extractLookupRollupData(fields, row.data), allowedFieldIds),
+        data: filterRecordDataByFieldIds(
+          { ...extractLookupRollupData(fields, row.data), ...(formulaDataByRecord.get(row.id) ?? {}) },
+          allowedFieldIds,
+        ),
       })
     }
   }
@@ -8499,7 +8554,8 @@ export function univerMetaRouter(): Router {
         serializeLinkSummaryMap,
         serializeAttachmentSummaryMap,
         applyLookupRollup: (q, f, rows, rl, lv) => applyLookupRollup(req, q, f, rows, rl, lv),
-        computeDependentLookupRollupRecords: (q, ids) => computeDependentLookupRollupRecords(req, q, ids),
+        computeDependentLookupRollupRecords: (q, sourceSheetId, ids, changed) =>
+          computeDependentLookupRollupRecords(req, q, sourceSheetId, ids, changed),
         recalculateFormulaFields,
         loadLinkValuesByRecord,
         buildLinkSummaries: (q, rows, rl, lv) => buildLinkSummaries(req, q, rows, rl, lv),

--- a/packages/core-backend/tests/integration/multitable-formula-over-lookup-afull-view.test.ts
+++ b/packages/core-backend/tests/integration/multitable-formula-over-lookup-afull-view.test.ts
@@ -19,6 +19,13 @@
  * .test.ts; AF8 (no diff to src/formula/engine.ts / no migrations / no RBAC) is a static PR
  * boundary, not a runtime assertion.
  *
+ * F1 guard (independent review of #2450): recompute must be restricted to the formulas the
+ * dependency gate actually returns. M carries a SECOND, independent chain
+ * (lu2 -> sheet G, f2 = {lu2}+1, seeded CORRECT at 8). A foreign edit on F must never rewrite
+ * f2 — neither for an actor who cannot read G (pre-fix: actor-scoped hydration emptied lu2 and
+ * persistently clobbered f2 to 1) nor for a full-perm actor (f2 simply does not depend on the
+ * affected lookup).
+ *
  * Stale seeding: related formulas are seeded as 6 (≠ current-value recompute results) so a
  * blind recompute (AF3) and a skipped recompute (AF4) are both distinguishable from a correct
  * one. Numeric semantics per A-min: lookup [9] + `={lu}+1` → 10; sum-rollup 9 + 1 → 10.
@@ -41,11 +48,17 @@ const MS = `sheet_afull_main_${TS}` // related: link + lookup + formula (readabl
 const RS = `sheet_afull_rollup_${TS}` // related: link + rollup + formula (AF5)
 const NS = `sheet_afull_noread_${TS}` // related: link + lookup + formula (unreadable in AF4)
 
+const GS = `sheet_afull_other_${TS}` // second foreign sheet feeding M's INDEPENDENT chain (F1 guard)
+
 const FLD_FTARGET = `fld_afull_ftarget_${TS}`
 const FLD_FNOISE = `fld_afull_fnoise_${TS}`
+const FLD_GVAL = `fld_afull_gval_${TS}`
 const FLD_M_LINK = `fld_afull_m_link_${TS}`
 const FLD_M_LU = `fld_afull_m_lu_${TS}`
 const FLD_M_F = `fld_afull_m_f_${TS}`
+const FLD_M_LINK2 = `fld_afull_m_link2_${TS}` // link -> GS (independent chain)
+const FLD_M_LU2 = `fld_afull_m_lu2_${TS}` // lookup(GVal)
+const FLD_M_F2 = `fld_afull_m_f2_${TS}` // formula = {lu2}+1, seeded CORRECT — must never be rewritten here
 const FLD_R_LINK = `fld_afull_r_link_${TS}`
 const FLD_R_RU = `fld_afull_r_ru_${TS}`
 const FLD_R_F = `fld_afull_r_f_${TS}`
@@ -55,6 +68,7 @@ const FLD_N_F = `fld_afull_n_f_${TS}`
 
 const REC_F1 = `rec_afull_f1_${TS}` // target = 9, the record edited throughout
 const REC_F2 = `rec_afull_f2_${TS}` // target = 200, AF6 same-record re-link target
+const REC_G1 = `rec_afull_g1_${TS}` // gval = 7 — never edited in this file
 const REC_M1 = `rec_afull_m1_${TS}`
 const REC_R1 = `rec_afull_r1_${TS}`
 const REC_N1 = `rec_afull_n1_${TS}`
@@ -100,6 +114,7 @@ describeIfDatabase('multitable formula-over-lookup A-full (real DB)', () => {
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [MS, BASE_ID, 'Main Lookup'])
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [RS, BASE_ID, 'Rollup'])
     await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [NS, BASE_ID, 'No Read'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [GS, BASE_ID, 'Other Foreign'])
 
     // foreign sheet: numeric target + an unrelated noise field
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
@@ -111,18 +126,35 @@ describeIfDatabase('multitable formula-over-lookup A-full (real DB)', () => {
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
       [REC_F2, FS, JSON.stringify({ [FLD_FTARGET]: 200 })])
 
+    // second foreign sheet G: numeric value — feeds M's independent chain, never edited here
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_GVAL, GS, 'GVal', 'number', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_G1, GS, JSON.stringify({ [FLD_GVAL]: 7 })])
+
     // M: link -> FS, lookup(FTarget), formula = {lookup}+1 — seeded STALE (6)
+    // PLUS an INDEPENDENT chain (F1 guard): link2 -> GS, lu2 = lookup(GVal), f2 = {lu2}+1 —
+    // seeded CORRECT (7+1 = 8). Nothing in this file edits G, so f2 must remain 8 throughout.
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
       [FLD_M_LINK, MS, 'Link', 'link', JSON.stringify({ foreignSheetId: FS }), 1])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
       [FLD_M_LU, MS, 'Lookup', 'lookup', JSON.stringify({ linkFieldId: FLD_M_LINK, targetFieldId: FLD_FTARGET, foreignSheetId: FS }), 2])
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
       [FLD_M_F, MS, 'Formula', 'formula', JSON.stringify({ expression: `={${FLD_M_LU}}+1` }), 3])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_M_LINK2, MS, 'Link G', 'link', JSON.stringify({ foreignSheetId: GS }), 4])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_M_LU2, MS, 'Lookup G', 'lookup', JSON.stringify({ linkFieldId: FLD_M_LINK2, targetFieldId: FLD_GVAL, foreignSheetId: GS }), 5])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_M_F2, MS, 'Formula G', 'formula', JSON.stringify({ expression: `={${FLD_M_LU2}}+1` }), 6])
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
-      [REC_M1, MS, JSON.stringify({ [FLD_M_F]: 6 })])
+      [REC_M1, MS, JSON.stringify({ [FLD_M_F]: 6, [FLD_M_F2]: 8 })])
     await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [FLD_M_LINK, REC_M1, REC_F1])
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [FLD_M_LINK2, REC_M1, REC_G1])
     await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,$4)',
       [MS, FLD_M_F, FLD_M_LU, MS])
+    await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,$4)',
+      [MS, FLD_M_F2, FLD_M_LU2, MS])
 
     // R: link -> FS, rollup sum(FTarget), formula = {rollup}+1 — seeded STALE (6)
     await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
@@ -164,12 +196,12 @@ describeIfDatabase('multitable formula-over-lookup A-full (real DB)', () => {
 
   afterAll(async () => {
     await q('DELETE FROM formula_dependencies WHERE sheet_id = ANY($1::text[])', [[MS, RS, NS]]).catch(() => {})
-    await q('DELETE FROM meta_links WHERE field_id = ANY($1::text[])', [[FLD_M_LINK, FLD_R_LINK, FLD_N_LINK]]).catch(() => {})
-    await q('DELETE FROM field_permissions WHERE sheet_id = ANY($1::text[])', [[FS, MS, RS, NS]]).catch(() => {})
-    await q('DELETE FROM spreadsheet_permissions WHERE sheet_id = ANY($1::text[])', [[FS, MS, RS, NS]]).catch(() => {})
-    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[FS, MS, RS, NS]]).catch(() => {})
-    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[FS, MS, RS, NS]]).catch(() => {})
-    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[FS, MS, RS, NS]]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id = ANY($1::text[])', [[FLD_M_LINK, FLD_M_LINK2, FLD_R_LINK, FLD_N_LINK]]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = ANY($1::text[])', [[FS, MS, RS, NS, GS]]).catch(() => {})
+    await q('DELETE FROM spreadsheet_permissions WHERE sheet_id = ANY($1::text[])', [[FS, MS, RS, NS, GS]]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[FS, MS, RS, NS, GS]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[FS, MS, RS, NS, GS]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[FS, MS, RS, NS, GS]]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
   })
 
@@ -183,17 +215,22 @@ describeIfDatabase('multitable formula-over-lookup A-full (real DB)', () => {
     expect(await readField(REC_M1, MS, FLD_M_F)).toBe(6)
     expect(await readField(REC_R1, RS, FLD_R_F)).toBe(6)
     expect(await readField(REC_N1, NS, FLD_N_F)).toBe(6)
-    // The related echo (if present) must not carry a formula key either.
+    // The related echo always carries M for a full-perm actor; it must not carry a formula key.
     const m = related(res.body, MS, REC_M1)
-    if (m) expect(m.data[FLD_M_F]).toBeUndefined()
+    expect(m).toBeDefined()
+    expect(m.data[FLD_M_F]).toBeUndefined()
   })
 
-  test('AF4: readable related sheet recomputes, unreadable related sheets are skipped', async () => {
+  test('AF4: readable related sheet recomputes, unreadable related sheets are skipped + unrelated formula untouched (F1 guard)', async () => {
     currentUser = { id: USER_LIMITED, roles: ['member'], perms: ['comments:write'] }
     const res = await patchForeign(FLD_FTARGET, 50)
     expect(res.status, JSON.stringify(res.body)).toBe(200)
     // M is readable to USER_LIMITED → its formula recomputes: lookup [50] → 51.
     expect(await readField(REC_M1, MS, FLD_M_F)).toBe(51)
+    // F1 guard (the exact review repro): USER_LIMITED cannot read G, so lu2 hydrates to [] for
+    // this actor — but f2 does not depend on the affected lookup, so it must NOT be re-evaluated.
+    // Pre-fix this clobbered the correct 8 to 1 (empty lookup → 0 → +1).
+    expect(await readField(REC_M1, MS, FLD_M_F2)).toBe(8)
     // N and R are unreadable to USER_LIMITED → skipped under the related-recompute boundary:
     // formulas stay stale (6) and the sheets do not appear in the response at all.
     expect(await readField(REC_N1, NS, FLD_N_F)).toBe(6)
@@ -217,11 +254,18 @@ describeIfDatabase('multitable formula-over-lookup A-full (real DB)', () => {
     // N readable for this actor → catches up too.
     expect(await readField(REC_N1, NS, FLD_N_F)).toBe(101)
 
+    // F1 guard (allowlist, not permission luck): USER_MASKED CAN read G, yet f2 still must not
+    // be rewritten — it does not depend on the affected lookup, so the dependency gate excludes
+    // it from recompute entirely.
+    expect(await readField(REC_M1, MS, FLD_M_F2)).toBe(8)
+
     // AF2: the related echo for M carries the visible lookup but NOT the denied formula field.
     const m = related(res.body, MS, REC_M1)
     expect(m).toBeDefined()
     expect(m.data[FLD_M_LU]).toEqual([100])
     expect(m.data[FLD_M_F]).toBeUndefined()
+    // The unrecomputed f2 must not ride along in the formula echo either.
+    expect(m.data[FLD_M_F2]).toBeUndefined()
 
     // Positive echo control: R's formula field has no deny row → fresh value present in echo.
     const r = related(res.body, RS, REC_R1)
@@ -239,5 +283,7 @@ describeIfDatabase('multitable formula-over-lookup A-full (real DB)', () => {
     expect(res.status, JSON.stringify(res.body)).toBe(200)
     // Same-record A-min path: lookup now [200] → formula 201, exactly as before A-full.
     expect(await readField(REC_M1, MS, FLD_M_F)).toBe(201)
+    // F1 guard on the A-min path too: the link edit affects only lu1's chain; f2 stays put.
+    expect(await readField(REC_M1, MS, FLD_M_F2)).toBe(8)
   })
 })

--- a/packages/core-backend/tests/integration/multitable-formula-over-lookup-afull-view.test.ts
+++ b/packages/core-backend/tests/integration/multitable-formula-over-lookup-afull-view.test.ts
@@ -1,0 +1,243 @@
+/**
+ * A-full (formula-over-lookup foreign-record propagation, design #2410) — real-DB wire proof.
+ *
+ * Proves the bounded one-hop propagation through the actual PATCH write path:
+ * editing a FOREIGN record's target field recomputes (and materializes) the formulas of the
+ * related records whose lookup/rollup values changed — and ONLY those:
+ *  - AF1: foreign target edit → related formula materialized fresh (flips A-min's T4a negative).
+ *  - AF2: response echo masks the related formula per the related sheet's field-read gate,
+ *    while the DB materialization stays reader-agnostic (full hydrated row, design §3.2).
+ *  - AF3: editing an UNRELATED field on the foreign record does NOT rewrite the related
+ *    formula — the affected-computed-id gate is target-field-aware (design §3.3).
+ *  - AF4: per-related-sheet readability boundary — a sheet the actor cannot read is skipped
+ *    (formula stays stale there), a readable one recomputes (design §3.4).
+ *  - AF5: rollup-backed formulas recompute from the hydrated rollup value.
+ *  - AF6: A-min same-record regression — a link edit on the related record itself still
+ *    recomputes through the A-min path exactly as before.
+ *
+ * AF7 (create/submit/import regression) stays in multitable-formula-over-lookup-create-view
+ * .test.ts; AF8 (no diff to src/formula/engine.ts / no migrations / no RBAC) is a static PR
+ * boundary, not a runtime assertion.
+ *
+ * Stale seeding: related formulas are seeded as 6 (≠ current-value recompute results) so a
+ * blind recompute (AF3) and a skipped recompute (AF4) are both distinguishable from a correct
+ * one. Numeric semantics per A-min: lookup [9] + `={lu}+1` → 10; sum-rollup 9 + 1 → 10.
+ *
+ * Runs only with DATABASE_URL (describeIfDatabase) via the plugin-tests.yml real-DB runner list.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, describe, expect, test } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_afull_${TS}`
+const FS = `sheet_afull_foreign_${TS}` // foreign/source sheet
+const MS = `sheet_afull_main_${TS}` // related: link + lookup + formula (readable in AF4)
+const RS = `sheet_afull_rollup_${TS}` // related: link + rollup + formula (AF5)
+const NS = `sheet_afull_noread_${TS}` // related: link + lookup + formula (unreadable in AF4)
+
+const FLD_FTARGET = `fld_afull_ftarget_${TS}`
+const FLD_FNOISE = `fld_afull_fnoise_${TS}`
+const FLD_M_LINK = `fld_afull_m_link_${TS}`
+const FLD_M_LU = `fld_afull_m_lu_${TS}`
+const FLD_M_F = `fld_afull_m_f_${TS}`
+const FLD_R_LINK = `fld_afull_r_link_${TS}`
+const FLD_R_RU = `fld_afull_r_ru_${TS}`
+const FLD_R_F = `fld_afull_r_f_${TS}`
+const FLD_N_LINK = `fld_afull_n_link_${TS}`
+const FLD_N_LU = `fld_afull_n_lu_${TS}`
+const FLD_N_F = `fld_afull_n_f_${TS}`
+
+const REC_F1 = `rec_afull_f1_${TS}` // target = 9, the record edited throughout
+const REC_F2 = `rec_afull_f2_${TS}` // target = 200, AF6 same-record re-link target
+const REC_M1 = `rec_afull_m1_${TS}`
+const REC_R1 = `rec_afull_r1_${TS}`
+const REC_N1 = `rec_afull_n1_${TS}`
+
+const USER_FULL = `u_afull_full_${TS}` // global multitable read+write
+const USER_LIMITED = `u_afull_limited_${TS}` // sheet-scoped: F + M only (N, R unreadable)
+const USER_MASKED = `u_afull_masked_${TS}` // global perms, but M's formula field is deny-masked
+
+let app: Express
+let currentUser: { id: string; roles: string[]; perms: string[] } = {
+  id: USER_FULL,
+  roles: ['member'],
+  perms: ['multitable:read', 'multitable:write'],
+}
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+const readField = async (recordId: string, sheetId: string, fieldId: string) => {
+  const r = await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [recordId, sheetId])
+  const data = (r.rows as any[])[0]?.data
+  const parsed = typeof data === 'string' ? JSON.parse(data) : data
+  return parsed?.[fieldId]
+}
+
+const patchForeign = (fieldId: string, value: unknown) =>
+  request(app).post('/api/multitable/patch').send({
+    sheetId: FS,
+    changes: [{ recordId: REC_F1, fieldId, value }],
+  })
+
+const related = (body: any, sheetId: string, recordId: string) =>
+  body.data?.relatedRecords?.find((r: { sheetId: string; recordId: string }) => r.sheetId === sheetId && r.recordId === recordId)
+
+describeIfDatabase('multitable formula-over-lookup A-full (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = currentUser; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'A-full Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [FS, BASE_ID, 'Foreign'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [MS, BASE_ID, 'Main Lookup'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [RS, BASE_ID, 'Rollup'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [NS, BASE_ID, 'No Read'])
+
+    // foreign sheet: numeric target + an unrelated noise field
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_FTARGET, FS, 'FTarget', 'number', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_FNOISE, FS, 'FNoise', 'string', '{}', 2])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_F1, FS, JSON.stringify({ [FLD_FTARGET]: 9, [FLD_FNOISE]: 'x' })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_F2, FS, JSON.stringify({ [FLD_FTARGET]: 200 })])
+
+    // M: link -> FS, lookup(FTarget), formula = {lookup}+1 — seeded STALE (6)
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_M_LINK, MS, 'Link', 'link', JSON.stringify({ foreignSheetId: FS }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_M_LU, MS, 'Lookup', 'lookup', JSON.stringify({ linkFieldId: FLD_M_LINK, targetFieldId: FLD_FTARGET, foreignSheetId: FS }), 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_M_F, MS, 'Formula', 'formula', JSON.stringify({ expression: `={${FLD_M_LU}}+1` }), 3])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_M1, MS, JSON.stringify({ [FLD_M_F]: 6 })])
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [FLD_M_LINK, REC_M1, REC_F1])
+    await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,$4)',
+      [MS, FLD_M_F, FLD_M_LU, MS])
+
+    // R: link -> FS, rollup sum(FTarget), formula = {rollup}+1 — seeded STALE (6)
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_R_LINK, RS, 'Link', 'link', JSON.stringify({ foreignSheetId: FS }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_R_RU, RS, 'Rollup', 'rollup', JSON.stringify({ linkFieldId: FLD_R_LINK, targetFieldId: FLD_FTARGET, foreignSheetId: FS, aggregation: 'sum' }), 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_R_F, RS, 'Formula', 'formula', JSON.stringify({ expression: `={${FLD_R_RU}}+1` }), 3])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_R1, RS, JSON.stringify({ [FLD_R_F]: 6 })])
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [FLD_R_LINK, REC_R1, REC_F1])
+    await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,$4)',
+      [RS, FLD_R_F, FLD_R_RU, RS])
+
+    // N: link -> FS, lookup(FTarget), formula — seeded STALE (6); unreadable to USER_LIMITED
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_N_LINK, NS, 'Link', 'link', JSON.stringify({ foreignSheetId: FS }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_N_LU, NS, 'Lookup', 'lookup', JSON.stringify({ linkFieldId: FLD_N_LINK, targetFieldId: FLD_FTARGET, foreignSheetId: FS }), 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_N_F, NS, 'Formula', 'formula', JSON.stringify({ expression: `={${FLD_N_LU}}+1` }), 3])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_N1, NS, JSON.stringify({ [FLD_N_F]: 6 })])
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [FLD_N_LINK, REC_N1, REC_F1])
+    await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,$4)',
+      [NS, FLD_N_F, FLD_N_LU, NS])
+
+    // USER_LIMITED: sheet-scoped write on F (the edit) + M (the readable related sheet); no
+    // grant on N/R and no global multitable perms → N and R are unreadable related sheets.
+    await q('INSERT INTO spreadsheet_permissions(sheet_id, user_id, subject_type, subject_id, perm_code) VALUES ($1,$2,$3,$4,$5)',
+      [FS, USER_LIMITED, 'user', USER_LIMITED, 'spreadsheet:write'])
+    await q('INSERT INTO spreadsheet_permissions(sheet_id, user_id, subject_type, subject_id, perm_code) VALUES ($1,$2,$3,$4,$5)',
+      [MS, USER_LIMITED, 'user', USER_LIMITED, 'spreadsheet:write'])
+
+    // USER_MASKED: layer-3 field deny on M's formula field only.
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)',
+      [MS, FLD_M_F, 'user', USER_MASKED, false, false])
+  })
+
+  afterAll(async () => {
+    await q('DELETE FROM formula_dependencies WHERE sheet_id = ANY($1::text[])', [[MS, RS, NS]]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id = ANY($1::text[])', [[FLD_M_LINK, FLD_R_LINK, FLD_N_LINK]]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = ANY($1::text[])', [[FS, MS, RS, NS]]).catch(() => {})
+    await q('DELETE FROM spreadsheet_permissions WHERE sheet_id = ANY($1::text[])', [[FS, MS, RS, NS]]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[FS, MS, RS, NS]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[FS, MS, RS, NS]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[FS, MS, RS, NS]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('AF3: editing an UNRELATED foreign field does not rewrite related formulas (target-field-aware gate)', async () => {
+    currentUser = { id: USER_FULL, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
+    const res = await patchForeign(FLD_FNOISE, 'y')
+    expect(res.status, JSON.stringify(res.body)).toBe(200)
+    // Stale seeds must survive untouched: a blind recompute would have produced 10 (9+1).
+    expect(await readField(REC_M1, MS, FLD_M_F)).toBe(6)
+    expect(await readField(REC_R1, RS, FLD_R_F)).toBe(6)
+    expect(await readField(REC_N1, NS, FLD_N_F)).toBe(6)
+    // The related echo (if present) must not carry a formula key either.
+    const m = related(res.body, MS, REC_M1)
+    if (m) expect(m.data[FLD_M_F]).toBeUndefined()
+  })
+
+  test('AF4: readable related sheet recomputes, unreadable related sheets are skipped', async () => {
+    currentUser = { id: USER_LIMITED, roles: ['member'], perms: ['comments:write'] }
+    const res = await patchForeign(FLD_FTARGET, 50)
+    expect(res.status, JSON.stringify(res.body)).toBe(200)
+    // M is readable to USER_LIMITED → its formula recomputes: lookup [50] → 51.
+    expect(await readField(REC_M1, MS, FLD_M_F)).toBe(51)
+    // N and R are unreadable to USER_LIMITED → skipped under the related-recompute boundary:
+    // formulas stay stale (6) and the sheets do not appear in the response at all.
+    expect(await readField(REC_N1, NS, FLD_N_F)).toBe(6)
+    expect(await readField(REC_R1, RS, FLD_R_F)).toBe(6)
+    expect(related(res.body, NS, REC_N1)).toBeUndefined()
+    expect(related(res.body, RS, REC_R1)).toBeUndefined()
+  })
+
+  test('AF1/AF2/AF5: foreign target edit materializes related formulas; echo is field-read masked', async () => {
+    currentUser = { id: USER_MASKED, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
+    const res = await patchForeign(FLD_FTARGET, 100)
+    expect(res.status, JSON.stringify(res.body)).toBe(200)
+
+    // AF1 (headline, flips A-min T4a): related lookup-backed formula materialized: [100] → 101.
+    // Reader-agnostic: USER_MASKED cannot SEE FLD_M_F, but the DB recompute uses the full
+    // hydrated row, not the actor's echo mask (design §3.2).
+    expect(await readField(REC_M1, MS, FLD_M_F)).toBe(101)
+
+    // AF5: rollup-backed formula recomputes from the hydrated rollup: sum(100)+1 → 101.
+    expect(await readField(REC_R1, RS, FLD_R_F)).toBe(101)
+    // N readable for this actor → catches up too.
+    expect(await readField(REC_N1, NS, FLD_N_F)).toBe(101)
+
+    // AF2: the related echo for M carries the visible lookup but NOT the denied formula field.
+    const m = related(res.body, MS, REC_M1)
+    expect(m).toBeDefined()
+    expect(m.data[FLD_M_LU]).toEqual([100])
+    expect(m.data[FLD_M_F]).toBeUndefined()
+
+    // Positive echo control: R's formula field has no deny row → fresh value present in echo.
+    const r = related(res.body, RS, REC_R1)
+    expect(r).toBeDefined()
+    expect(r.data[FLD_R_RU]).toBe(100)
+    expect(r.data[FLD_R_F]).toBe(101)
+  })
+
+  test('AF6: A-min same-record regression — link edit on the related record still recomputes', async () => {
+    currentUser = { id: USER_FULL, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
+    const res = await request(app).post('/api/multitable/patch').send({
+      sheetId: MS,
+      changes: [{ recordId: REC_M1, fieldId: FLD_M_LINK, value: [REC_F2] }],
+    })
+    expect(res.status, JSON.stringify(res.body)).toBe(200)
+    // Same-record A-min path: lookup now [200] → formula 201, exactly as before A-full.
+    expect(await readField(REC_M1, MS, FLD_M_F)).toBe(201)
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-formula-over-lookup-afull-view.test.ts
+++ b/packages/core-backend/tests/integration/multitable-formula-over-lookup-afull-view.test.ts
@@ -286,4 +286,21 @@ describeIfDatabase('multitable formula-over-lookup A-full (real DB)', () => {
     // F1 guard on the A-min path too: the link edit affects only lu1's chain; f2 stays put.
     expect(await readField(REC_M1, MS, FLD_M_F2)).toBe(8)
   })
+
+  test('AF6b: A-min F1 guard is DISCRIMINATING — limited actor link edit cannot clobber the G-chain', async () => {
+    // AF6 used USER_FULL, for whom a pre-fix all-formula recompute was value-idempotent (G readable
+    // → f2 re-evaluates to the same 8). This variant is the airtight pin: USER_LIMITED (write on M,
+    // NOTHING on G) edits M's link directly. Pre-fix, the A-min recompute would hydrate lu2 to []
+    // for this actor and clobber f2 to 1; with the dependency allowlist f2 is not re-evaluated.
+    currentUser = { id: USER_LIMITED, roles: ['member'], perms: ['comments:write'] }
+    const res = await request(app).post('/api/multitable/patch').send({
+      sheetId: MS,
+      changes: [{ recordId: REC_M1, fieldId: FLD_M_LINK, value: [REC_F1] }],
+    })
+    expect(res.status, JSON.stringify(res.body)).toBe(200)
+    // Re-linked back to F1 (target = 100 since AF1) → f1 recomputes through A-min: [100] → 101.
+    expect(await readField(REC_M1, MS, FLD_M_F)).toBe(101)
+    // The independent G-chain survives a limited-actor same-record edit untouched.
+    expect(await readField(REC_M1, MS, FLD_M_F2)).toBe(8)
+  })
 })

--- a/packages/core-backend/tests/integration/multitable-formula-over-lookup-view.test.ts
+++ b/packages/core-backend/tests/integration/multitable-formula-over-lookup-view.test.ts
@@ -1,12 +1,13 @@
 /**
  * A-min (formula-over-lookup, design #2246) — real-DB wire proof.
  *
- * Proves the headline fix through the actual PATCH write path, and proves A-min did NOT silently
- * grow into A-full (foreign-record propagation):
+ * Proves the headline fix through the actual PATCH write path:
  *  - T1/T2 (positive, same-record): editing a record's LINK field re-runs that record's formula
  *    AND it computes against the ACTUAL hydrated lookup value (not stale, not absent→0).
- *  - T4a (negative, foreign record in a SEPARATE sheet): editing the foreign record's target does
- *    NOT re-run the related record's formula — the same-record boundary is enforced, not assumed.
+ *  - T4a (positive since A-full, design #2410): editing the foreign record's target DOES
+ *    recompute the related record's formula — the one-hop propagation that was the A-min-era
+ *    negative boundary. The full A-full matrix lives in
+ *    multitable-formula-over-lookup-afull-view.test.ts.
  *
  * Runs only with DATABASE_URL (describeIfDatabase) via the plugin-tests.yml real-DB runner list.
  * Numeric semantics observed in tests/unit/multitable-formula-over-lookup.test.ts: a single-value
@@ -99,16 +100,17 @@ describeIfDatabase('multitable formula-over-lookup A-min (real DB)', () => {
     expect(await readFormula(REC_M, MS)).toBe(10) // DB-materialized, authoritative
   })
 
-  test('T4a (negative): editing the FOREIGN record does NOT re-run the related formula (A-min ≠ A-full)', async () => {
+  test('T4a (flipped by A-full #2410): editing the FOREIGN record DOES recompute the related formula', async () => {
     // After T1, REC_M.formula = 10 (lookup = REC_FY.FTarget = 9). Now edit the FOREIGN record
-    // REC_FY.FTarget 9 → 100 on the SEPARATE foreign sheet. Under A-min, REC_M's formula must
-    // stay 10 (foreign-record propagation is A-full, deliberately NOT implemented). If it became
-    // 101 the slice silently grew into A-full.
+    // REC_FY.FTarget 9 → 100 on the SEPARATE foreign sheet. Under A-full's bounded one-hop
+    // propagation the related record's lookup-backed formula recomputes: [100] + 1 → 101.
+    // (Until #2410's implementation this was the locked NEGATIVE asserting 10 — A-min's
+    // deliberate same-record boundary. The flip is the A-full headline.)
     const res = await request(app).post('/api/multitable/patch').send({
       sheetId: FS,
       changes: [{ recordId: REC_FY, fieldId: FLD_FTARGET, value: 100, expectedVersion: 1 }],
     })
     expect(res.status).toBe(200)
-    expect(await readFormula(REC_M, MS)).toBe(10) // unchanged — same-record boundary enforced
+    expect(await readFormula(REC_M, MS)).toBe(101) // one-hop foreign propagation materialized
   })
 })

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -847,6 +847,14 @@ describe('RecordWriteService', () => {
 
       expect(invalidator).toHaveBeenCalledOnce()
       expect(helpers.computeDependentLookupRollupRecords).toHaveBeenCalledOnce()
+      // A-full plumbing (design #2410): the helper receives the edited (source) sheet and the
+      // PATCH-level changed field ids so it can gate related-formula recompute.
+      expect(helpers.computeDependentLookupRollupRecords).toHaveBeenCalledWith(
+        expect.any(Function),
+        'sheet1',
+        ['rec1'],
+        ['fld_name'],
+      )
       expect(invalidator.mock.invocationCallOrder[0]).toBeLessThan(
         vi.mocked(helpers.computeDependentLookupRollupRecords).mock.invocationCallOrder[0],
       )


### PR DESCRIPTION
## Summary

Implements the **A-full** slice locked by the design-lock PR #2410
(`docs/development/multitable-formula-over-lookup-afull-design-20260609.md`): when a **foreign
record's target field** changes, related records whose `lookup`/`rollup` values change now get
their own **formula fields recomputed and materialized** — flipping A-min's T4a locked negative
into the A-full positive, exactly as the design predicted.

## Implementation (per design §2/§3)

- **No new graph engine** — extends the existing `computeDependentLookupRollupRecords()` seam
  (`univer-meta.ts`). New params: `sourceSheetId` + `changedFieldIds`.
- **Target-field-aware affected gate (§3.3)**: a related lookup/rollup counts as affected only
  when (a) it resolves to the edited source sheet, (b) its `targetFieldId` is among the changed
  source fields, and (c) the record links to an edited source record via that field's
  `linkFieldId`. Unrelated edits on a linked foreign record are a no-op.
- **Full hydrated row for eval, masked patch only for echo (§3.2)**: formula recompute consumes
  `row.data` after `applyLookupRollup()` — never the permission-filtered echo patch — so
  materialization stays reader-agnostic, matching A-min.
- **Persist formula keys only**: via existing `recalculateRecordFromData()` (`data || $patch`,
  no version bump). Lookup/rollup remain computed-on-read, never materialized.
- **Boundary preserved (§3.4/§3.5)**: unreadable related sheets skipped (unchanged behavior);
  no new cross-sheet realtime fan-out; response shape (`records`/`relatedRecords`) unchanged,
  now carrying fresh formula keys under the related sheet's `allowedFieldIds` mask.
- **One hop only**: `foreign source field → related lookup/rollup → related formula`. No
  recursion, no formula→formula (A2-defense untouched).

`RecordWriteService` change is plumbing-only: passes `sheetId` + `changedFieldIds` into the
helper (computation moved above Step 4, deduplicated from Step 4c).

## Test matrix (real-DB, fail-first, wired into plugin-tests.yml)

New `multitable-formula-over-lookup-afull-view.test.ts`:

| # | Assertion | Pre-impl |
|---|---|---|
| AF1 | foreign target edit materializes related lookup-backed formula (10→101 shape) | ❌ red |
| AF2 | echo masks denied formula field; DB recompute reader-agnostic | ❌ red |
| AF3 | unrelated foreign-field edit does NOT rewrite formulas (stale seed survives) | ✅ guard |
| AF4 | readable related sheet recomputes; unreadable sheets skipped + stay stale | ❌ red |
| AF5 | rollup-backed formula recomputes from hydrated rollup | ❌ red |
| AF6 | A-min same-record link edit regression | ✅ guard |

- **A-min T4a flipped** in `multitable-formula-over-lookup-view.test.ts` (stale 10 → fresh 101).
- AF7: existing `multitable-formula-over-lookup-create-view.test.ts` untouched, still green.
- AF8 (static boundary): no diff to `src/formula/engine.ts`, no migrations, no central RBAC/auth,
  no frontend, no realtime changes — diff is 2 runtime files + 2 test files + CI list.

## Verification (local, real DB)

- AF suite + A-min + create + cross-sheet echo-mask + write-echo-mask: **23/23 pass**
- Backend unit suite: **222 files / 2847 pass**
- `tsc --noEmit`: clean; `git diff --check`: clean

Design-lock: #2410

🤖 Generated with [Claude Code](https://claude.com/claude-code)