### PR TITLE
feat(data-factory): add durable plugin storage for large BOM jobs

### DIFF
--- a/docs/development/data-factory-plm-stock-preparation-large-bom-durable-storage-verification-20260610.md
+++ b/docs/development/data-factory-plm-stock-preparation-large-bom-durable-storage-verification-20260610.md
@@ -1,0 +1,94 @@
+# Data Factory PLM Stock Preparation Large-BOM Durable Storage Verification
+
+Date: 2026-06-10
+
+## Scope
+
+This slice closes the #2425 entity-machine stop rule where the C3/C4 route stack
+was present but `context.storage.durable` was `false`.
+
+Implemented boundary:
+
+- Reuse the existing host `plugin_kv` table as the durable plugin KV store.
+- Create `plugin_kv` when absent on fresh install paths, while reusing existing
+  `plugin_kv` on upgraded deployments.
+- Widen `plugin_kv.key` to `text` so fully-scoped Large-BOM keys fit.
+- Inject DB-backed `context.storage` only for `plugin-integration-core`.
+- Keep all other plugins on process-local memory storage.
+
+Not included:
+
+- No production or batch rollout.
+- No PLM write, external database write, raw SQL escape hatch, or K3 action.
+- No browser-controlled storage key/value path.
+- No multi-process checkpoint lease/CAS. That remains a production/batch
+  blocker; this slice only unblocks the durable-storage validation rerun.
+
+## Verification
+
+Commands:
+
+```bash
+pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-durable-storage.test.ts --watch=false
+pnpm --filter @metasheet/core-backend build
+pnpm --filter plugin-integration-core test:stock-preparation-large-bom-jobs
+pnpm --filter plugin-integration-core test:stock-preparation-table-actions
+pnpm --filter plugin-integration-core test:http-routes
+git diff --check
+```
+
+Results:
+
+- plugin durable storage unit tests: 8/8 passed.
+- core backend TypeScript build: passed.
+- Large-BOM job contract tests: passed.
+- stock-preparation table-action neighbor tests: passed.
+- integration-core HTTP route tests: passed.
+- diff whitespace check: passed.
+
+## Locked Behaviors
+
+- `plugin-integration-core` receives `storage.durable === true`.
+- Non-integration plugins keep `storage.durable === false` memory storage.
+- A job value written through one durable storage instance is readable through a
+  second instance backed by the same DB seam.
+- Storage is scoped by plugin name; same key in a different plugin cannot
+  cross-read.
+- Long scoped job keys greater than 255 characters persist through the storage
+  seam, with the migration creating `plugin_kv` when absent and widening
+  `plugin_kv.key` to `text`.
+- Backing-store failures become `PLUGIN_DURABLE_STORAGE_UNAVAILABLE` with
+  values-free details (`pluginName`, `operation`) instead of raw key/value/SQL.
+- Large-BOM route tests now start a job through one durable storage instance,
+  remount routes with a second instance backed by the same store, and run the job
+  from the second mount. This locks the #2425 class of failure at the route seam,
+  not only inside the storage helper.
+- Large-BOM route tests also cover durable-store failure responses and assert the
+  response omits project values, component values, backing SQL, and storage keys.
+
+## #2425 Rerun Expectation
+
+After package rebuild and deploy, the #2425 evidence should move from:
+
+```text
+durableStorage=false
+start.httpStatus=501
+errorCode=LARGE_BOM_JOB_STORE_UNAVAILABLE
+```
+
+to:
+
+```text
+durableStorage=true
+start.status=queued
+jobIdPresent=true
+```
+
+The validation still must remain values-free. Do not post raw job ids, project
+numbers, component codes/names, target sheet or field ids, idempotency keys, PLM
+rows, SQL, connection details, raw payload JSON, or stack traces.
+
+This is only the start-gate transition for #2425. The full #2425 validation
+still needs the subsequent run/plan/apply/idempotence evidence on the entity
+machine. Production/batch remains closed until that rerun passes and the separate
+rollout gate is satisfied.

--- a/packages/core-backend/src/db/migrations/zzzz20260610140000_widen_plugin_kv_key.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260610140000_widen_plugin_kv_key.ts
@@ -1,0 +1,29 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+
+/**
+ * Large-BOM C3/C4 job keys include tenant/workspace/action/job scope. The
+ * existing plugin KV table is the right durable backing store, but its original
+ * varchar(255) key is too tight for these fully-scoped runtime keys. Some fresh
+ * install paths do not replay the legacy SQL plugin migration, so this migration
+ * also creates the host KV table when it is absent.
+ */
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`
+    CREATE TABLE IF NOT EXISTS plugin_kv (
+      plugin varchar(255) NOT NULL,
+      key text NOT NULL,
+      value jsonb,
+      created_at timestamptz NOT NULL DEFAULT now(),
+      updated_at timestamptz NOT NULL DEFAULT now(),
+      PRIMARY KEY (plugin, key)
+    )
+  `.execute(db)
+  await sql`ALTER TABLE plugin_kv ALTER COLUMN key TYPE text`.execute(db)
+  await sql`CREATE INDEX IF NOT EXISTS idx_plugin_kv_plugin ON plugin_kv(plugin)`.execute(db)
+  await sql`CREATE INDEX IF NOT EXISTS idx_plugin_kv_updated_at ON plugin_kv(updated_at)`.execute(db)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`ALTER TABLE IF EXISTS plugin_kv ALTER COLUMN key TYPE varchar(255)`.execute(db)
+}

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -132,6 +132,7 @@ import workflowRouter from './routes/workflow'
 import workflowDesignerRouter from './routes/workflow-designer'
 import plmWorkbenchRouter from './routes/plm-workbench'
 import plmEmbedRouter from './routes/plm-embed'
+import { createHostPluginStorage } from './plugins/plugin-durable-storage'
 import { univerMockRouter } from './routes/univer-mock'
 import { univerMetaRouter } from './routes/univer-meta'
 import { dashboardRouter } from './routes/dashboard'
@@ -1427,22 +1428,10 @@ export class MetaSheetServer {
           }),
         }
       : pluginBaseCoreApi
-    const storageCache = new Map<string, unknown>()
-    const storage: PluginStorage = {
-      async get<T = unknown>(key: string): Promise<T | null> {
-        if (!storageCache.has(key)) return null
-        return storageCache.get(key) as T
-      },
-      async set<T = unknown>(key: string, value: T): Promise<void> {
-        storageCache.set(key, value)
-      },
-      async delete(key: string): Promise<void> {
-        storageCache.delete(key)
-      },
-      async list(): Promise<string[]> {
-        return Array.from(storageCache.keys())
-      },
-    }
+    const storage: PluginStorage = createHostPluginStorage({
+      pluginName,
+      query: (sql, params) => poolManager.get().query(sql, params),
+    })
     const pluginApis = this.pluginApis
     const eventBus = this.eventBus
     const automationRegistry = {

--- a/packages/core-backend/src/plugins/plugin-durable-storage.ts
+++ b/packages/core-backend/src/plugins/plugin-durable-storage.ts
@@ -1,0 +1,153 @@
+import type { QueryResult } from 'pg'
+import type { PluginStorage } from '../types/plugin'
+
+export type PluginStorageQuery = (sql: string, params?: unknown[]) => Promise<Pick<QueryResult, 'rows'>>
+
+interface DurableStorageOptions {
+  pluginName: string
+  query: PluginStorageQuery
+}
+
+interface HostPluginStorageOptions {
+  pluginName: string
+  query: PluginStorageQuery
+}
+
+export interface DurablePluginStorage extends PluginStorage {
+  durable: true
+}
+
+export interface MemoryPluginStorage extends PluginStorage {
+  durable: false
+}
+
+export class PluginDurableStorageError extends Error {
+  code = 'PLUGIN_DURABLE_STORAGE_UNAVAILABLE'
+  status = 501
+  details: { pluginName: string; operation: string }
+
+  constructor(pluginName: string, operation: string, cause?: unknown) {
+    super('plugin durable storage is unavailable')
+    this.name = 'PluginDurableStorageError'
+    this.details = { pluginName, operation }
+    if (cause !== undefined) {
+      this.cause = cause
+    }
+  }
+}
+
+function normalizeStorageKey(key: string): string {
+  if (typeof key !== 'string' || key.trim() === '') {
+    throw new Error('plugin storage key is required')
+  }
+  return key
+}
+
+function serializeStorageValue(value: unknown): string {
+  if (value === undefined) {
+    throw new Error('plugin storage value must be JSON-serializable')
+  }
+  return JSON.stringify(value)
+}
+
+async function runStorageQuery(
+  pluginName: string,
+  operation: string,
+  query: PluginStorageQuery,
+  sql: string,
+  params?: unknown[],
+): Promise<Pick<QueryResult, 'rows'>> {
+  try {
+    return await query(sql, params)
+  } catch (error) {
+    throw new PluginDurableStorageError(pluginName, operation, error)
+  }
+}
+
+export function createMemoryPluginStorage(): MemoryPluginStorage {
+  const storageCache = new Map<string, unknown>()
+  return {
+    durable: false,
+    async get<T = unknown>(key: string): Promise<T | null> {
+      const storageKey = normalizeStorageKey(key)
+      if (!storageCache.has(storageKey)) return null
+      return storageCache.get(storageKey) as T
+    },
+    async set<T = unknown>(key: string, value: T): Promise<void> {
+      storageCache.set(normalizeStorageKey(key), value)
+    },
+    async delete(key: string): Promise<void> {
+      storageCache.delete(normalizeStorageKey(key))
+    },
+    async list(): Promise<string[]> {
+      return Array.from(storageCache.keys()).sort()
+    },
+  }
+}
+
+export function createPluginDurableStorage(options: DurableStorageOptions): DurablePluginStorage {
+  const pluginName = normalizeStorageKey(options.pluginName)
+  const query = options.query
+
+  return {
+    durable: true,
+    async get<T = unknown>(key: string): Promise<T | null> {
+      const storageKey = normalizeStorageKey(key)
+      const result = await runStorageQuery(
+        pluginName,
+        'get',
+        query,
+        `SELECT value
+           FROM plugin_kv
+          WHERE plugin = $1 AND key = $2`,
+        [pluginName, storageKey],
+      )
+      if (result.rows.length === 0) return null
+      return (result.rows[0] as { value: T }).value
+    },
+    async set<T = unknown>(key: string, value: T): Promise<void> {
+      const storageKey = normalizeStorageKey(key)
+      const serialized = serializeStorageValue(value)
+      await runStorageQuery(
+        pluginName,
+        'set',
+        query,
+        `INSERT INTO plugin_kv (plugin, key, value, updated_at)
+         VALUES ($1, $2, $3::jsonb, now())
+         ON CONFLICT (plugin, key)
+         DO UPDATE SET value = EXCLUDED.value, updated_at = now()`,
+        [pluginName, storageKey, serialized],
+      )
+    },
+    async delete(key: string): Promise<void> {
+      await runStorageQuery(
+        pluginName,
+        'delete',
+        query,
+        `DELETE FROM plugin_kv
+          WHERE plugin = $1 AND key = $2`,
+        [pluginName, normalizeStorageKey(key)],
+      )
+    },
+    async list(): Promise<string[]> {
+      const result = await runStorageQuery(
+        pluginName,
+        'list',
+        query,
+        `SELECT key
+           FROM plugin_kv
+          WHERE plugin = $1
+          ORDER BY key ASC`,
+        [pluginName],
+      )
+      return result.rows.map((row) => String((row as { key: string }).key))
+    },
+  }
+}
+
+export function createHostPluginStorage(options: HostPluginStorageOptions): PluginStorage {
+  if (options.pluginName === 'plugin-integration-core') {
+    return createPluginDurableStorage(options)
+  }
+  return createMemoryPluginStorage()
+}

--- a/packages/core-backend/src/plugins/types.ts
+++ b/packages/core-backend/src/plugins/types.ts
@@ -166,6 +166,7 @@ export interface PluginEvents {
 }
 
 export interface PluginStorage {
+  durable?: boolean
   get: (key: string) => Promise<unknown>
   set: (key: string, value: unknown) => Promise<void>
   delete: (key: string) => Promise<void>

--- a/packages/core-backend/src/types/plugin.ts
+++ b/packages/core-backend/src/types/plugin.ts
@@ -895,6 +895,7 @@ export interface PluginCommunication {
  * 插件存储接口
  */
 export interface PluginStorage {
+  durable?: boolean
   get<T = unknown>(key: string): Promise<T | null>
   set<T = unknown>(key: string, value: T): Promise<void>
   delete(key: string): Promise<void>

--- a/packages/core-backend/tests/unit/plugin-durable-storage.test.ts
+++ b/packages/core-backend/tests/unit/plugin-durable-storage.test.ts
@@ -1,0 +1,186 @@
+import { describe, expect, it } from 'vitest'
+import { readFile } from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import {
+  createHostPluginStorage,
+  createMemoryPluginStorage,
+  createPluginDurableStorage,
+  PluginDurableStorageError,
+  type PluginStorageQuery,
+} from '../../src/plugins/plugin-durable-storage'
+
+function createFakeQuery(): { query: PluginStorageQuery; calls: Array<{ sql: string; params?: unknown[] }> } {
+  const rows = new Map<string, unknown>()
+  const calls: Array<{ sql: string; params?: unknown[] }> = []
+  const storageKey = (pluginName: unknown, key: unknown) => `${String(pluginName)}\0${String(key)}`
+
+  return {
+    calls,
+    async query(sql: string, params?: unknown[]) {
+      calls.push({ sql, params })
+      if (sql.includes('INSERT INTO plugin_kv')) {
+        const [pluginName, key, value] = params ?? []
+        rows.set(storageKey(pluginName, key), JSON.parse(String(value)))
+        return { rows: [] }
+      }
+      if (sql.includes('SELECT value')) {
+        const [pluginName, key] = params ?? []
+        const found = rows.get(storageKey(pluginName, key))
+        return { rows: found === undefined ? [] : [{ value: found }] }
+      }
+      if (sql.includes('DELETE FROM plugin_kv')) {
+        const [pluginName, key] = params ?? []
+        rows.delete(storageKey(pluginName, key))
+        return { rows: [] }
+      }
+      if (sql.includes('SELECT key')) {
+        const [pluginName] = params ?? []
+        const prefix = `${String(pluginName)}\0`
+        const keys = Array.from(rows.keys())
+          .filter((key) => key.startsWith(prefix))
+          .map((key) => ({ key: key.slice(prefix.length) }))
+          .sort((left, right) => left.key.localeCompare(right.key))
+        return { rows: keys }
+      }
+      throw new Error(`unexpected SQL: ${sql}`)
+    },
+  }
+}
+
+describe('plugin durable storage', () => {
+  it('persists plugin-integration-core storage across instances', async () => {
+    const db = createFakeQuery()
+    const first = createPluginDurableStorage({ pluginName: 'plugin-integration-core', query: db.query })
+    const second = createPluginDurableStorage({ pluginName: 'plugin-integration-core', query: db.query })
+
+    expect(first.durable).toBe(true)
+
+    await first.set('tenant-a/workspace-a/action-a/job-1', {
+      public: { status: 'running', counts: { rowsExpanded: 44 } },
+      private: { rows: [{ sourceCode: 'kept-private' }] },
+    })
+
+    await expect(second.get('tenant-a/workspace-a/action-a/job-1')).resolves.toEqual({
+      public: { status: 'running', counts: { rowsExpanded: 44 } },
+      private: { rows: [{ sourceCode: 'kept-private' }] },
+    })
+
+    expect(db.calls[0].params).toEqual([
+      'plugin-integration-core',
+      'tenant-a/workspace-a/action-a/job-1',
+      JSON.stringify({
+        public: { status: 'running', counts: { rowsExpanded: 44 } },
+        private: { rows: [{ sourceCode: 'kept-private' }] },
+      }),
+    ])
+  })
+
+  it('stores scoped large-BOM keys longer than the legacy varchar(255) limit', async () => {
+    const db = createFakeQuery()
+    const storage = createPluginDurableStorage({ pluginName: 'plugin-integration-core', query: db.query })
+    const longKey = [
+      'integration:large-bom:background',
+      `tenant-${'t'.repeat(80)}`,
+      `workspace-${'w'.repeat(80)}`,
+      `action-${'a'.repeat(80)}`,
+      `job-${'j'.repeat(80)}`,
+    ].join(':')
+
+    expect(longKey.length).toBeGreaterThan(255)
+
+    await storage.set(longKey, { status: 'queued' })
+    await expect(storage.get(longKey)).resolves.toEqual({ status: 'queued' })
+  })
+
+  it('scopes list/get/delete by plugin name', async () => {
+    const db = createFakeQuery()
+    const integration = createPluginDurableStorage({ pluginName: 'plugin-integration-core', query: db.query })
+    const other = createPluginDurableStorage({ pluginName: 'plugin-other', query: db.query })
+
+    await integration.set('same-key', { owner: 'integration' })
+    await other.set('same-key', { owner: 'other' })
+    await integration.set('b-key', { ok: true })
+
+    await expect(integration.get('same-key')).resolves.toEqual({ owner: 'integration' })
+    await expect(other.get('same-key')).resolves.toEqual({ owner: 'other' })
+    await expect(integration.list()).resolves.toEqual(['b-key', 'same-key'])
+
+    await integration.delete('same-key')
+
+    await expect(integration.get('same-key')).resolves.toBeNull()
+    await expect(other.get('same-key')).resolves.toEqual({ owner: 'other' })
+  })
+
+  it('keeps non-integration plugins on non-durable memory storage', async () => {
+    const db = createFakeQuery()
+    const storage = createHostPluginStorage({ pluginName: 'plugin-attendance', query: db.query })
+
+    expect(storage.durable).toBe(false)
+
+    await storage.set('k', { v: 1 })
+    await expect(storage.get('k')).resolves.toEqual({ v: 1 })
+    expect(db.calls).toEqual([])
+  })
+
+  it('injects durable storage only for plugin-integration-core', async () => {
+    const db = createFakeQuery()
+    const storage = createHostPluginStorage({ pluginName: 'plugin-integration-core', query: db.query })
+
+    expect(storage.durable).toBe(true)
+
+    await storage.set('large-bom/job', { status: 'queued' })
+    await expect(storage.get('large-bom/job')).resolves.toEqual({ status: 'queued' })
+    expect(db.calls.length).toBeGreaterThan(0)
+  })
+
+  it('keeps memory storage process-local and explicitly non-durable', async () => {
+    const first = createMemoryPluginStorage()
+    const second = createMemoryPluginStorage()
+
+    expect(first.durable).toBe(false)
+
+    await first.set('k', { v: 1 })
+    await expect(first.get('k')).resolves.toEqual({ v: 1 })
+    await expect(second.get('k')).resolves.toBeNull()
+  })
+
+  it('wraps backing-store failures without exposing key or value details', async () => {
+    const storage = createPluginDurableStorage({
+      pluginName: 'plugin-integration-core',
+      async query() {
+        throw new Error('relation "plugin_kv" does not exist for project P-001 and component PART-A')
+      },
+    })
+
+    await expect(storage.get('tenant/workspace/action/job/P-001/PART-A')).rejects.toMatchObject({
+      name: 'PluginDurableStorageError',
+      code: 'PLUGIN_DURABLE_STORAGE_UNAVAILABLE',
+      status: 501,
+      details: {
+        pluginName: 'plugin-integration-core',
+        operation: 'get',
+      },
+    } satisfies Partial<PluginDurableStorageError>)
+    await expect(storage.get('tenant/workspace/action/job/P-001/PART-A')).rejects.not.toMatchObject({
+      details: expect.objectContaining({
+        key: expect.anything(),
+      }),
+    })
+  })
+
+  it('widens plugin_kv keys for scoped large-BOM job ids', async () => {
+    const currentFile = fileURLToPath(import.meta.url)
+    const migrationPath = path.resolve(
+      path.dirname(currentFile),
+      '../../src/db/migrations/zzzz20260610140000_widen_plugin_kv_key.ts',
+    )
+
+    const source = await readFile(migrationPath, 'utf8')
+
+    expect(source).toContain('CREATE TABLE IF NOT EXISTS plugin_kv')
+    expect(source).toContain('ALTER TABLE plugin_kv ALTER COLUMN key TYPE text')
+    expect(source).toContain('CREATE INDEX IF NOT EXISTS idx_plugin_kv_plugin')
+    expect(source).toContain('ALTER TABLE IF EXISTS plugin_kv ALTER COLUMN key TYPE varchar(255)')
+  })
+})

--- a/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
+++ b/plugins/plugin-integration-core/__tests__/http-routes.test.cjs
@@ -61,6 +61,56 @@ function createDurableMemoryStorage() {
   }
 }
 
+function createSharedDurableStorage(backing = new Map()) {
+  return {
+    durable: true,
+    backing,
+    async get(key) {
+      if (!backing.has(key)) return null
+      return clone(backing.get(key))
+    },
+    async set(key, value) {
+      backing.set(key, clone(value))
+    },
+    async delete(key) {
+      backing.delete(key)
+    },
+    async list() {
+      return Array.from(backing.keys()).sort()
+    },
+  }
+}
+
+function createFailingDurableStorage(operation = 'set') {
+  return {
+    durable: true,
+    async get() {
+      if (operation === 'get') throw createDurableStorageFailure('get')
+      return null
+    },
+    async set() {
+      if (operation === 'set') throw createDurableStorageFailure('set')
+    },
+    async delete() {},
+    async list() {
+      return []
+    },
+  }
+}
+
+function createDurableStorageFailure(operation) {
+  const error = new Error('plugin durable storage is unavailable')
+  error.name = 'PluginDurableStorageError'
+  error.code = 'PLUGIN_DURABLE_STORAGE_UNAVAILABLE'
+  error.status = 501
+  error.details = {
+    pluginName: 'plugin-integration-core',
+    operation,
+  }
+  error.cause = new Error('INSERT failed for key P-001/PART-A')
+  return error
+}
+
 function createMockContext(options = {}) {
   const routes = new Map()
   const records = options.recordsApi || {
@@ -3100,6 +3150,104 @@ async function testLargeBomBackgroundExpansionJobRoutes() {
   assert.equal(res.body.data.authoritative, false)
 }
 
+async function testLargeBomBackgroundExpansionJobsSurviveDurableRouteRemount() {
+  const calls = []
+  const records = createTableActionRecordsApi()
+  const { services } = createMockServices({
+    externalSystemRegistry: {
+      async getExternalSystemForAdapter(input) {
+        calls.push(['getExternalSystemForAdapter', input])
+        return {
+          id: input.id,
+          tenantId: input.tenantId,
+          workspaceId: input.workspaceId,
+          name: 'Readonly PLM SQL',
+          kind: 'data-source:sql-readonly',
+          role: 'source',
+          status: 'active',
+          config: { dataSourceId: 'ds_plm', object: 'DN_PDM_PathExAttrInfo' },
+        }
+      },
+    },
+    adapterRegistry: {
+      createAdapter(system, deps) {
+        calls.push(['createAdapter', system, deps])
+        return createTableActionSourceAdapter(tableActionPlmData(), calls)
+      },
+    },
+  })
+  const backing = new Map()
+  const config = {
+    stockPreparationTableActions: [tableActionConfig()],
+  }
+
+  const firstMount = mountRoutes(services, {
+    recordsApi: records.recordsApi,
+    storage: createSharedDurableStorage(backing),
+    config,
+  })
+  let res = await invoke(firstMount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID },
+    body: { parameters: { projectNo: 'P-001' } },
+  })
+  assertOkResponse(res, 202)
+  const jobId = res.body.data.jobId
+
+  const secondMount = mountRoutes(services, {
+    recordsApi: records.recordsApi,
+    storage: createSharedDurableStorage(backing),
+    config,
+  })
+  res = await invoke(secondMount.routes, 'GET', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.status, 'queued', 'second route mount reads the job from durable backing storage')
+
+  res = await invoke(secondMount.routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs/:jobId/run', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID, jobId },
+  })
+  assertOkResponse(res, 200)
+  assert.equal(res.body.data.status, 'completed')
+  assert.equal(res.body.data.progress.rowsExpanded, 1)
+  assert.ok(findCalls(calls, 'sourceRead').length > 0, 'remounted route runs the real source read path')
+  assert.equal(records.calls.length, 0, 'background expansion still does not touch target rows')
+}
+
+async function testLargeBomDurableStorageFailureIsValuesFree() {
+  const records = createTableActionRecordsApi()
+  const { calls, services } = createMockServices()
+  const { routes } = mountRoutes(services, {
+    recordsApi: records.recordsApi,
+    storage: createFailingDurableStorage('set'),
+    config: {
+      stockPreparationTableActions: [tableActionConfig()],
+    },
+  })
+
+  const res = await invoke(routes, 'POST', '/api/integration/table-actions/:actionId/large-bom/expansion-jobs', {
+    user: READ_USER,
+    params: { actionId: PLM_STOCK_PREPARATION_ACTION_ID },
+    body: { parameters: { projectNo: 'P-001' } },
+  })
+
+  assert.equal(res.statusCode, 501)
+  assert.equal(res.body.error.code, 'PLUGIN_DURABLE_STORAGE_UNAVAILABLE')
+  assert.equal(res.body.error.details.pluginName, 'plugin-integration-core')
+  assert.equal(res.body.error.details.operation, 'set')
+  assert.deepEqual(Object.keys(res.body.error.details).sort(), ['operation', 'pluginName'])
+  const responseText = JSON.stringify(res.body.error)
+  assert.equal(responseText.includes('P-001'), false, 'durable storage failure hides project values')
+  assert.equal(responseText.includes('PART-A'), false, 'durable storage failure hides component values')
+  assert.equal(responseText.includes('INSERT'), false, 'durable storage failure hides backing SQL')
+  assert.equal(responseText.includes('stock-preparation:large-bom'), false, 'durable storage failure hides storage keys')
+  assert.equal(calls.length, 0, 'durable storage failure fails before source adapter work')
+  assert.equal(records.calls.length, 0, 'durable storage failure fails before target reads/writes')
+}
+
 async function testTableActionConflictPolicyRoutes() {
   const calls = []
   const adapterCalls = []
@@ -3431,6 +3579,8 @@ async function main() {
   await testStockPreparationOptionSyncRoute()
   await testTableActionRoutes()
   await testLargeBomBackgroundExpansionJobRoutes()
+  await testLargeBomBackgroundExpansionJobsSurviveDurableRouteRemount()
+  await testLargeBomDurableStorageFailureIsValuesFree()
   await testTableActionConflictPolicyRoutes()
   await testTableActionRoutesSupportExplicitBridgeSource()
   await testTableActionTargetPreflightBeforeSourceAdapter()


### PR DESCRIPTION
## Summary

Closes the #2425 durable-storage start gate for Large-BOM C3/C4 jobs.

- Reuse the existing host `plugin_kv` table as durable plugin storage for `plugin-integration-core`.
- Widen `plugin_kv.key` from `varchar(255)` to `text` so fully scoped Large-BOM job keys fit.
- Keep non-integration plugins on process-local memory storage.
- Add route-level coverage that a Large-BOM job started through one durable storage instance survives a route remount and can run from a second instance.
- Add values-free durable-store failure coverage.

## Boundaries

- No production/batch rollout.
- No PLM write, external DB write, raw SQL escape hatch, or K3 action.
- No browser-controlled storage key/value path.
- No multi-process checkpoint lease/CAS; that remains a production/batch blocker.
- #2425 still needs entity-machine rerun evidence for run/plan/apply/idempotence after this lands and is packaged.

## Verification

- `pnpm --filter plugin-integration-core test:http-routes`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/plugin-durable-storage.test.ts --watch=false`
- `pnpm --filter plugin-integration-core test:stock-preparation-large-bom-jobs`
- `pnpm --filter plugin-integration-core test:stock-preparation-table-actions`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`

Note: `pnpm --filter @metasheet/core-backend lint` is not available in this package (`ERR_PNPM_RECURSIVE_RUN_NO_SCRIPT`).

## Review

Subagent read-only review: APPROVE, no P1/P2 findings. It verified the host injection, `plugin_kv` reuse/key widening, values-free failure behavior, and production/batch boundary.
