### PR TITLE
feat(attendance): add dormant auto shift auto-write config

### DIFF
--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -7213,6 +7213,7 @@ attendanceIntegrationDescribe(
           { autoShiftMatching: { mode: 'auto' } },
           { autoShiftMatching: { autoWrite: { lookaheadDays: 0 } } },
           { autoShiftMatching: { autoWrite: { lookaheadDays: 4 } } },
+          { autoShiftMatching: { autoWrite: { maxAssignmentsPerRun: 0 } } },
           { autoShiftMatching: { autoWrite: { maxAssignmentsPerRun: 101 } } },
           { autoShiftMatching: { autoWrite: { minConfidence: 'medium' } } },
         ]

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -7029,6 +7029,12 @@ attendanceIntegrationDescribe(
             mode: 'apply',
             maxToleranceMinutes: 90,
             minConfidenceToApply: 'medium',
+            autoWrite: {
+              enabled: true,
+              lookaheadDays: 3,
+              maxAssignmentsPerRun: 40,
+              minConfidence: 'high',
+            },
           },
         }),
       })
@@ -7067,6 +7073,12 @@ attendanceIntegrationDescribe(
         mode: 'apply',
         maxToleranceMinutes: 90,
         minConfidenceToApply: 'medium',
+        autoWrite: {
+          enabled: true,
+          lookaheadDays: 3,
+          maxAssignmentsPerRun: 40,
+          minConfidence: 'high',
+        },
       })
 
       const futurePunchRes = await requestJson(`${baseUrl}/api/attendance/punch`, {
@@ -7151,6 +7163,73 @@ attendanceIntegrationDescribe(
       expect(res.status).toBe(200)
       return ((res.body as { data?: Record<string, unknown> } | undefined)?.data ?? {}) as Record<string, unknown>
     }
+
+    it('round-trips dormant auto-write settings while keeping auto mode rejected', async () => {
+      if (!baseUrl) return
+      const runSuffix = Date.now().toString(36)
+      const adminToken = await getAdminToken(`attendance-autoshift-autowrite-admin-${runSuffix}`)
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+      const originalSettings = await loadSettingsForTest(adminToken)
+      try {
+        await saveAutoShiftSettings(adminToken, {
+          autoShiftMatching: {
+            enabled: true,
+            mode: 'apply',
+            maxToleranceMinutes: 30,
+            minConfidenceToApply: 'high',
+            autoWrite: {
+              enabled: true,
+              lookaheadDays: 3,
+              maxAssignmentsPerRun: 40,
+              minConfidence: 'high',
+            },
+          },
+        })
+
+        await saveAutoShiftSettings(adminToken, {
+          autoShiftMatching: {
+            autoWrite: {
+              lookaheadDays: 2,
+            },
+          },
+        })
+
+        const reloaded = await loadSettingsForTest(adminToken)
+        expect(reloaded.autoShiftMatching).toEqual({
+          enabled: true,
+          mode: 'apply',
+          maxToleranceMinutes: 30,
+          minConfidenceToApply: 'high',
+          autoWrite: {
+            enabled: true,
+            lookaheadDays: 2,
+            maxAssignmentsPerRun: 40,
+            minConfidence: 'high',
+          },
+        })
+
+        const invalidPayloads: Array<Record<string, unknown>> = [
+          { autoShiftMatching: { mode: 'auto' } },
+          { autoShiftMatching: { autoWrite: { lookaheadDays: 0 } } },
+          { autoShiftMatching: { autoWrite: { lookaheadDays: 4 } } },
+          { autoShiftMatching: { autoWrite: { maxAssignmentsPerRun: 101 } } },
+          { autoShiftMatching: { autoWrite: { minConfidence: 'medium' } } },
+        ]
+
+        for (const payload of invalidPayloads) {
+          const res = await requestJson(`${baseUrl}/api/attendance/settings`, {
+            method: 'PUT',
+            headers: { Authorization: `Bearer ${adminToken}`, 'Content-Type': 'application/json' },
+            body: JSON.stringify(payload),
+          })
+          expect(res.status, JSON.stringify({ payload, body: res.body })).toBe(400)
+          expect((res.body as { error?: { code?: string } } | undefined)?.error?.code).toBe('VALIDATION_ERROR')
+        }
+      } finally {
+        await saveAutoShiftSettings(adminToken, originalSettings).catch(() => undefined)
+      }
+    })
 
     async function createShiftForAutoShift(token: string, name: string, start: string, end: string): Promise<string> {
       if (!baseUrl) throw new Error('baseUrl missing')

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -163,6 +163,14 @@ const DEFAULT_SETTINGS = {
     mode: 'preview',
     maxToleranceMinutes: 120,
     minConfidenceToApply: 'high',
+    // A2-0 dormant shape only. The background writer stays unavailable until
+    // mode='auto' + the scheduler slice are wired.
+    autoWrite: {
+      enabled: false,
+      lookaheadDays: 1,
+      maxAssignmentsPerRun: 25,
+      minConfidence: 'high',
+    },
   },
 }
 
@@ -11530,11 +11538,17 @@ function normalizeSettings(raw) {
 
 function normalizeAutoShiftMatchingSetting(raw) {
   const config = raw && typeof raw === 'object' ? raw : {}
+  const autoWrite = config.autoWrite && typeof config.autoWrite === 'object' ? config.autoWrite : {}
   const modeRaw = typeof config.mode === 'string' ? config.mode.trim() : ''
   const minConfidenceRaw = typeof config.minConfidenceToApply === 'string'
     ? config.minConfidenceToApply.trim()
     : ''
+  const autoWriteMinConfidenceRaw = typeof autoWrite.minConfidence === 'string'
+    ? autoWrite.minConfidence.trim()
+    : ''
   const tolerance = Number(config.maxToleranceMinutes)
+  const lookaheadDays = Number(autoWrite.lookaheadDays)
+  const maxAssignmentsPerRun = Number(autoWrite.maxAssignmentsPerRun)
   return {
     enabled: typeof config.enabled === 'boolean' ? config.enabled : DEFAULT_SETTINGS.autoShiftMatching.enabled,
     // A1 exposes admin-selected apply. `auto` remains a future A2 slice and must not be accepted.
@@ -11545,6 +11559,20 @@ function normalizeAutoShiftMatchingSetting(raw) {
     minConfidenceToApply: ['high', 'medium', 'low'].includes(minConfidenceRaw)
       ? minConfidenceRaw
       : DEFAULT_SETTINGS.autoShiftMatching.minConfidenceToApply,
+    autoWrite: {
+      enabled: typeof autoWrite.enabled === 'boolean'
+        ? autoWrite.enabled
+        : DEFAULT_SETTINGS.autoShiftMatching.autoWrite.enabled,
+      lookaheadDays: Number.isInteger(lookaheadDays) && lookaheadDays >= 1 && lookaheadDays <= 3
+        ? lookaheadDays
+        : DEFAULT_SETTINGS.autoShiftMatching.autoWrite.lookaheadDays,
+      maxAssignmentsPerRun: Number.isInteger(maxAssignmentsPerRun) && maxAssignmentsPerRun >= 1 && maxAssignmentsPerRun <= 100
+        ? maxAssignmentsPerRun
+        : DEFAULT_SETTINGS.autoShiftMatching.autoWrite.maxAssignmentsPerRun,
+      minConfidence: autoWriteMinConfidenceRaw === 'high'
+        ? autoWriteMinConfidenceRaw
+        : DEFAULT_SETTINGS.autoShiftMatching.autoWrite.minConfidence,
+    },
   }
 }
 
@@ -11725,6 +11753,10 @@ function mergeSettings(base, update) {
     autoShiftMatching: {
       ...(base?.autoShiftMatching || {}),
       ...(update?.autoShiftMatching || {}),
+      autoWrite: {
+        ...(base?.autoShiftMatching?.autoWrite || {}),
+        ...(update?.autoShiftMatching?.autoWrite || {}),
+      },
     },
   })
 }
@@ -17784,6 +17816,12 @@ module.exports = {
         mode: z.enum(['preview', 'apply']).optional(),
         maxToleranceMinutes: z.number().int().positive().max(720).optional(),
         minConfidenceToApply: z.enum(['high', 'medium', 'low']).optional(),
+        autoWrite: z.object({
+          enabled: z.boolean().optional(),
+          lookaheadDays: z.number().int().min(1).max(3).optional(),
+          maxAssignmentsPerRun: z.number().int().positive().max(100).optional(),
+          minConfidence: z.literal('high').optional(),
+        }).optional(),
       }).optional(),
     })
 


### PR DESCRIPTION
## Summary
- add dormant `autoShiftMatching.autoWrite` settings shape for A2 automatic shift matching
- keep `mode='auto'` rejected until the scheduler/write slice lands
- deep-merge partial `autoWrite` updates so sibling keys are preserved

## Scope
- Backend settings schema/normalizer only; no scheduler, no auto-write runtime, no frontend, no OpenAPI surface.
- `autoWrite.minConfidence` is locked to `high`; `lookaheadDays` is bounded to 1..3; `maxAssignmentsPerRun` to 1..100.

## Verification
- `node --check plugins/plugin-attendance/index.cjs`
- `git diff --check`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend test:integration:attendance` (local runner starts, but all 122 integration tests skip because this worktree has no DB env; CI real-DB gate is required for wire execution)

## Notes
- This is A2-0 from `docs/development/attendance-auto-shift-a2-auto-write-design-lock-20260610.md`.
- A2-1/A2-2 scheduler and `mode='auto'` remain separate gated slices.
