### PR TITLE
feat(multitable): FOL-1 related-record downstream invalidation (realtime fan-out + Yjs read-side)

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -174,6 +174,7 @@ jobs:
             tests/integration/multitable-formula-over-lookup-view.test.ts \
             tests/integration/multitable-formula-over-lookup-create-view.test.ts \
             tests/integration/multitable-formula-over-lookup-afull-view.test.ts \
+            tests/integration/multitable-fol1-related-invalidation.test.ts \
             tests/integration/multitable-formula-dryrun.test.ts \
             tests/integration/multitable-records-read-field-mask.test.ts \
             tests/integration/multitable-readpath-search-filter-field-mask.test.ts \

--- a/packages/core-backend/src/multitable/record-write-service.ts
+++ b/packages/core-backend/src/multitable/record-write-service.ts
@@ -288,14 +288,17 @@ export interface RecordWriteHelpers {
    * one-hop formula propagation: related records whose lookup/rollup resolve to the edited
    * source sheet AND whose targetFieldId is in `changedFieldIds` get their formulas
    * recomputed + materialized. Returned `data` is masked per the related sheet's field-read
-   * gate (echo only — the recompute itself runs on the full hydrated row).
+   * gate (echo only — the recompute itself runs on the full hydrated row). FOL-1 (followups
+   * design 2026-06-10 §2.1): `affectedFieldIds` is per-record UNMASKED metadata (affected
+   * lookup/rollup + actually-recomputed formula ids) gating the related-sheet realtime
+   * fan-out + Yjs invalidation in Steps 4/6 below; it never reaches the HTTP echo.
    */
   computeDependentLookupRollupRecords: (
     query: QueryFn,
     sourceSheetId: string,
     updatedRecordIds: string[],
     changedFieldIds: string[],
-  ) => Promise<Array<{ sheetId: string; recordId: string; data: Record<string, unknown> }>>
+  ) => Promise<Array<{ sheetId: string; recordId: string; data: Record<string, unknown>; affectedFieldIds: string[] }>>
   /**
    * Recalculate `formula` fields for the given just-updated records when a
    * changed field has a dependent formula (per `formula_dependencies`). Returns
@@ -886,7 +889,53 @@ export class RecordWriteService {
         recordId: record.recordId,
         data: h.filterRecordDataByFieldIds(record.data, visiblePropertyFieldIds),
       }))
-    const crossSheetRelated = relatedRecords.filter((record) => record.sheetId !== sheetId)
+    const crossSheetRelated = relatedRecords
+      .filter((record) => record.sheetId !== sheetId)
+      // The HTTP echo keeps its exact pre-FOL-1 shape — `affectedFieldIds` is unmasked
+      // fan-out metadata, never part of the response contract.
+      .map((record) => ({ sheetId: record.sheetId, recordId: record.recordId, data: record.data }))
+
+    // FOL-1 (followups design 2026-06-10 §2.1): group the related records whose computed
+    // values this PATCH actually invalidated (non-empty UNMASKED affected metadata — the
+    // publish gate is the AFFECTED gate, NOT echo presence: the helper echoes every readable
+    // linked sheet, and broadcasting on echo would fan any edit out to all of them).
+    const affectedRelatedBySheet = new Map<string, { recordIds: string[]; fieldIds: Set<string> }>()
+    for (const record of relatedRecords) {
+      if (record.affectedFieldIds.length === 0) continue
+      let group = affectedRelatedBySheet.get(record.sheetId)
+      if (!group) {
+        group = { recordIds: [], fieldIds: new Set<string>() }
+        affectedRelatedBySheet.set(record.sheetId, group)
+      }
+      group.recordIds.push(record.recordId)
+      for (const fieldId of record.affectedFieldIds) group.fieldIds.add(fieldId)
+    }
+
+    // FOL-1 (§2.1 decision 5): the helper just materialized fresh formula values onto the
+    // affected related records, so any cached Y.Doc for them is now stale. Send their ids
+    // through the same post-commit seam as the source records (Step 3) — the Yjs hook is
+    // record-id keyed and itself skips `source === 'yjs-bridge'`, mirroring source-record
+    // behavior (the bridge additionally stubs the helper to [], a natural no-op).
+    if (this.postCommitHooks.length > 0 && affectedRelatedBySheet.size > 0) {
+      for (const [relatedSheetId, group] of affectedRelatedBySheet.entries()) {
+        const relatedContext: RecordPostCommitContext = {
+          recordIds: group.recordIds,
+          sheetId: relatedSheetId,
+          actorId,
+          source: input.source,
+        }
+        for (const hook of this.postCommitHooks) {
+          try {
+            await hook(relatedContext)
+          } catch (err) {
+            console.error(
+              `[record-write] Post-commit hook failed for related records ${relatedContext.recordIds.join(',')} — downstream state may be stale until the next successful sync:`,
+              err,
+            )
+          }
+        }
+      }
+    }
 
     // -----------------------------------------------------------------------
     // Step 4c: Formula field recalculation (field.property.expression-based).
@@ -982,13 +1031,33 @@ export class RecordWriteService {
             ...Object.fromEntries(
               (changesByRecord.get(update.recordId) ?? []).map((change) => [change.fieldId, change.value]),
             ),
-            // Materialized formula values so other clients merge the fresh value
-            // (applyRemoteRecordPatch does `{ ...data, ...patch }`) rather than
-            // keeping a stale formula after only the source field is patched.
+            // Recomputed formula values ride along for call-payload parity with fieldIds,
+            // but recordPatches NEVER reaches other clients: the shared publisher strips it
+            // before broadcast and the frontend deliberately consumes no values from
+            // realtime events — receivers refetch affected records under their own mask.
             ...(formulaByRecord.get(update.recordId) ?? {}),
           },
         })),
       })
+
+      // FOL-1 (§2.1): related-record invalidation fan-out — one event per AFFECTED related
+      // sheet, pure invalidation signal: fieldIds carry the UNMASKED affected ids (metadata,
+      // never values — an actor-masked echo key set would hide invalidations from readers who
+      // CAN see the field) and the call MUST NOT construct recordPatches. Cross-sheet events
+      // omit actorId (the editor made no local edit there, so their own other tabs must
+      // refetch too); the same-sheet self-link event carries it (the editor's tab already
+      // merged the response echo — actorId prevents a redundant self-GET). No cycle: these
+      // events only ever trigger reads on receivers, never a write path.
+      for (const [relatedSheetId, group] of affectedRelatedBySheet.entries()) {
+        publishMultitableSheetRealtime({
+          spreadsheetId: relatedSheetId,
+          ...(relatedSheetId === sheetId ? { actorId } : {}),
+          source: 'multitable',
+          kind: 'record-updated',
+          recordIds: group.recordIds,
+          fieldIds: [...group.fieldIds],
+        })
+      }
 
       // -------------------------------------------------------------------
       // Step 7: EventBus emit

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -1888,6 +1888,14 @@ type RelatedComputedRecord = {
   sheetId: string
   recordId: string
   data: Record<string, unknown>
+  /**
+   * FOL-1 (followups design 2026-06-10 §2.1): UNMASKED affected-field metadata — the
+   * lookup/rollup ids the edited source fields actually feed for THIS record, plus the
+   * formula ids actually recomputed. Drives the related-sheet realtime fan-out + Yjs
+   * invalidation gates in RecordWriteService; ids are metadata, never values. The masked
+   * `data` above stays the only thing surfaced in the HTTP echo.
+   */
+  affectedFieldIds: string[]
 }
 
 function mergeComputedRecords(
@@ -2053,13 +2061,18 @@ async function computeDependentLookupRollupRecords(
     }
 
     for (const row of rows) {
+      const recomputedFormulaData = formulaDataByRecord.get(row.id)
       results.push({
         sheetId,
         recordId: row.id,
         data: filterRecordDataByFieldIds(
-          { ...extractLookupRollupData(fields, row.data), ...(formulaDataByRecord.get(row.id) ?? {}) },
+          { ...extractLookupRollupData(fields, row.data), ...(recomputedFormulaData ?? {}) },
           allowedFieldIds,
         ),
+        affectedFieldIds: [
+          ...(affectedFieldIdsByRecord.get(row.id) ?? []),
+          ...Object.keys(recomputedFormulaData ?? {}),
+        ],
       })
     }
   }

--- a/packages/core-backend/tests/integration/multitable-fol1-related-invalidation.test.ts
+++ b/packages/core-backend/tests/integration/multitable-fol1-related-invalidation.test.ts
@@ -1,0 +1,342 @@
+/**
+ * FOL-1 (formula-over-lookup followups design 2026-06-10 §2) — related-record downstream
+ * invalidation, real-DB wire proof at the realtime broadcast layer.
+ *
+ * A-full (#2450) materializes formulas onto RELATED records, but Step 6 only published for
+ * the edited source sheet — related-table watchers got zero signal. FOL-1 adds a pure
+ * invalidation fan-out (no new event kind, no values, no recordPatches) gated on the
+ * AFFECTED set (the #2450 F1 dependency-gate result), NOT on echo presence:
+ *  - R1: foreign target edit → ONE `record-updated` on the related sheet; recordIds = only
+ *    the affected related records (echo-only linked records excluded); fieldIds = UNMASKED
+ *    affected lookup + recomputed formula ids — proven with a field_permissions-denied
+ *    actor: the denied formula id is absent from the echo but PRESENT in fieldIds; the
+ *    cross-sheet event omits actorId and the broadcast carries no recordPatches/values.
+ *  - R2: same-sheet self-link → a SECOND event on the source sheet for the related record,
+ *    WITH actorId (the editor's tab already merged the response echo; no redundant GET).
+ *  - R3: a related sheet the actor cannot read is skipped by the helper → zero events.
+ *  - R4: unrelated-field edit (AF3 scenario) → related sheets get ZERO events even though
+ *    the helper still echoes the linked records (publish gate = affected gate).
+ *  - R5: main-event regression — the source-sheet publish keeps its exact pre-FOL-1 shape.
+ *
+ * R6/R7 (Yjs bridge no-op + read-side invalidator plumbing) are unit-level in
+ * tests/unit/record-write-service.test.ts. Assertion layer here = eventBus spy on the
+ * shared singleton (same channel as multitable-sheet-realtime.api.test.ts — CollabService
+ * forwards verbatim, covered elsewhere) + AF-suite-style DB-level materialization asserts.
+ *
+ * Runs only with DATABASE_URL (describeIfDatabase) via the plugin-tests.yml real-DB runner list.
+ */
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { afterAll, beforeAll, beforeEach, describe, expect, test, vi, type MockInstance } from 'vitest'
+
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { eventBus } from '../../src/integration/events/event-bus'
+import { univerMetaRouter } from '../../src/routes/univer-meta'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE_ID = `base_fol1_${TS}`
+const FS = `sheet_fol1_foreign_${TS}` // foreign/source sheet (edited throughout R1/R3/R4/R5)
+const MS = `sheet_fol1_main_${TS}` // related: link + lookup + formula (deny-masked field for R1)
+const NS = `sheet_fol1_noread_${TS}` // related: unreadable to USER_LIMITED (R3)
+const SS = `sheet_fol1_self_${TS}` // self-link sheet (R2)
+
+const FLD_FTARGET = `fld_fol1_ftarget_${TS}`
+const FLD_FNOISE = `fld_fol1_fnoise_${TS}`
+const FLD_M_LINK = `fld_fol1_m_link_${TS}`
+const FLD_M_LINKB = `fld_fol1_m_linkb_${TS}` // second link -> FS with NO lookup over it (echo-only lane)
+const FLD_M_LU = `fld_fol1_m_lu_${TS}`
+const FLD_M_F = `fld_fol1_m_f_${TS}` // deny-masked for USER_DENY — must STILL appear in fieldIds
+const FLD_N_LINK = `fld_fol1_n_link_${TS}`
+const FLD_N_LU = `fld_fol1_n_lu_${TS}`
+const FLD_N_F = `fld_fol1_n_f_${TS}`
+const FLD_S_TARGET = `fld_fol1_s_target_${TS}`
+const FLD_S_LINK = `fld_fol1_s_link_${TS}`
+const FLD_S_LU = `fld_fol1_s_lu_${TS}`
+const FLD_S_F = `fld_fol1_s_f_${TS}`
+
+const REC_F1 = `rec_fol1_f1_${TS}` // target = 9, the record edited throughout
+const REC_M1 = `rec_fol1_m1_${TS}` // linked to F1 via FLD_M_LINK → affected on target edits
+const REC_M2 = `rec_fol1_m2_${TS}` // linked to F1 ONLY via FLD_M_LINKB → echoed but never affected
+const REC_N1 = `rec_fol1_n1_${TS}`
+const REC_S1 = `rec_fol1_s1_${TS}` // self-link source (edited in R2)
+const REC_S2 = `rec_fol1_s2_${TS}` // links to S1 → the same-sheet related record
+
+const USER_FULL = `u_fol1_full_${TS}` // global multitable read+write
+const USER_DENY = `u_fol1_deny_${TS}` // global perms, but M's formula field is deny-masked (R1)
+const USER_LIMITED = `u_fol1_limited_${TS}` // sheet-scoped: F + M only (N unreadable, R3)
+
+let app: Express
+let publishSpy: MockInstance
+let currentUser: { id: string; roles: string[]; perms: string[] } = {
+  id: USER_FULL,
+  roles: ['member'],
+  perms: ['multitable:read', 'multitable:write'],
+}
+
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+const readField = async (recordId: string, sheetId: string, fieldId: string) => {
+  const r = await q('SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2', [recordId, sheetId])
+  const data = (r.rows as Array<{ data: unknown }>)[0]?.data
+  const parsed = typeof data === 'string' ? JSON.parse(data) : data
+  return (parsed as Record<string, unknown> | undefined)?.[fieldId]
+}
+
+type RealtimeBroadcast = {
+  spreadsheetId: string
+  actorId?: string | null
+  source: string
+  kind: string
+  recordId?: string
+  recordIds?: string[]
+  fieldIds?: string[]
+}
+
+/** All `spreadsheet.cell.updated` broadcasts for a sheet since the last mockClear(). */
+const sheetEvents = (sheetId: string): RealtimeBroadcast[] =>
+  publishSpy.mock.calls
+    .filter((call) => call[0] === 'spreadsheet.cell.updated' && (call[1] as RealtimeBroadcast | undefined)?.spreadsheetId === sheetId)
+    .map((call) => call[1] as RealtimeBroadcast)
+
+const patchRecord = (sheetId: string, recordId: string, fieldId: string, value: unknown) =>
+  request(app).post('/api/multitable/patch').send({
+    sheetId,
+    changes: [{ recordId, fieldId, value }],
+  })
+
+const related = (body: { data?: { relatedRecords?: Array<{ sheetId: string; recordId: string; data: Record<string, unknown> }> } }, sheetId: string, recordId: string) =>
+  body.data?.relatedRecords?.find((r) => r.sheetId === sheetId && r.recordId === recordId)
+
+describeIfDatabase('multitable FOL-1 related-record downstream invalidation (real DB)', () => {
+  beforeAll(async () => {
+    app = express()
+    app.use(express.json())
+    app.use((req, _res, next) => { ;(req as any).user = currentUser; next() })
+    app.use('/api/multitable', univerMetaRouter())
+
+    // Spy on the shared singleton AFTER router setup; calls through so any real
+    // subscriber behavior stays intact — we only observe the broadcast payloads.
+    publishSpy = vi.spyOn(eventBus, 'publish')
+
+    await q('INSERT INTO meta_bases (id, name) VALUES ($1,$2)', [BASE_ID, 'FOL-1 Base'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [FS, BASE_ID, 'Foreign'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [MS, BASE_ID, 'Main Lookup'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [NS, BASE_ID, 'No Read'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1,$2,$3)', [SS, BASE_ID, 'Self Link'])
+
+    // foreign sheet: numeric target + an unrelated noise field
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_FTARGET, FS, 'FTarget', 'number', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_FNOISE, FS, 'FNoise', 'string', '{}', 2])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_F1, FS, JSON.stringify({ [FLD_FTARGET]: 9, [FLD_FNOISE]: 'x' })])
+
+    // M: link -> FS, lookup(FTarget), formula = {lookup}+1 — formula seeded STALE (6).
+    // PLUS a second link field (NO lookup attached): M2 links to F1 only through it, so M2
+    // is always part of the helper echo but never part of the affected set.
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_M_LINK, MS, 'Link', 'link', JSON.stringify({ foreignSheetId: FS }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_M_LU, MS, 'Lookup', 'lookup', JSON.stringify({ linkFieldId: FLD_M_LINK, targetFieldId: FLD_FTARGET, foreignSheetId: FS }), 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_M_F, MS, 'Formula', 'formula', JSON.stringify({ expression: `={${FLD_M_LU}}+1` }), 3])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_M_LINKB, MS, 'Link B', 'link', JSON.stringify({ foreignSheetId: FS }), 4])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_M1, MS, JSON.stringify({ [FLD_M_F]: 6 })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_M2, MS, JSON.stringify({})])
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [FLD_M_LINK, REC_M1, REC_F1])
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [FLD_M_LINKB, REC_M2, REC_F1])
+    await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,$4)',
+      [MS, FLD_M_F, FLD_M_LU, MS])
+
+    // N: same shape — unreadable to USER_LIMITED (R3); formula seeded STALE (6)
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_N_LINK, NS, 'Link', 'link', JSON.stringify({ foreignSheetId: FS }), 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_N_LU, NS, 'Lookup', 'lookup', JSON.stringify({ linkFieldId: FLD_N_LINK, targetFieldId: FLD_FTARGET, foreignSheetId: FS }), 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_N_F, NS, 'Formula', 'formula', JSON.stringify({ expression: `={${FLD_N_LU}}+1` }), 3])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_N1, NS, JSON.stringify({ [FLD_N_F]: 6 })])
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [FLD_N_LINK, REC_N1, REC_F1])
+    await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,$4)',
+      [NS, FLD_N_F, FLD_N_LU, NS])
+
+    // S: SELF-link sheet (R2) — S2 links to S1; lookup(S_TARGET) + formula seeded STALE (6)
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_S_TARGET, SS, 'STarget', 'number', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_S_LINK, SS, 'SLink', 'link', JSON.stringify({ foreignSheetId: SS }), 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_S_LU, SS, 'SLookup', 'lookup', JSON.stringify({ linkFieldId: FLD_S_LINK, targetFieldId: FLD_S_TARGET, foreignSheetId: SS }), 3])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)',
+      [FLD_S_F, SS, 'SFormula', 'formula', JSON.stringify({ expression: `={${FLD_S_LU}}+1` }), 4])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_S1, SS, JSON.stringify({ [FLD_S_TARGET]: 5 })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)',
+      [REC_S2, SS, JSON.stringify({ [FLD_S_F]: 6 })])
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [FLD_S_LINK, REC_S2, REC_S1])
+    await q('INSERT INTO formula_dependencies (sheet_id, field_id, depends_on_field_id, depends_on_sheet_id) VALUES ($1,$2,$3,$4)',
+      [SS, FLD_S_F, FLD_S_LU, SS])
+
+    // USER_LIMITED: sheet-scoped write on F (the edit) + M (readable related sheet); no grant
+    // on N and no global multitable perms → N is an unreadable related sheet (R3).
+    await q('INSERT INTO spreadsheet_permissions(sheet_id, user_id, subject_type, subject_id, perm_code) VALUES ($1,$2,$3,$4,$5)',
+      [FS, USER_LIMITED, 'user', USER_LIMITED, 'spreadsheet:write'])
+    await q('INSERT INTO spreadsheet_permissions(sheet_id, user_id, subject_type, subject_id, perm_code) VALUES ($1,$2,$3,$4,$5)',
+      [MS, USER_LIMITED, 'user', USER_LIMITED, 'spreadsheet:write'])
+
+    // USER_DENY: layer-3 field deny on M's formula field only (R1 unmasked-fieldIds proof).
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)',
+      [MS, FLD_M_F, 'user', USER_DENY, false, false])
+  })
+
+  beforeEach(() => {
+    publishSpy.mockClear()
+  })
+
+  afterAll(async () => {
+    publishSpy.mockRestore()
+    await q('DELETE FROM formula_dependencies WHERE sheet_id = ANY($1::text[])', [[MS, NS, SS]]).catch(() => {})
+    await q('DELETE FROM meta_links WHERE field_id = ANY($1::text[])', [[FLD_M_LINK, FLD_M_LINKB, FLD_N_LINK, FLD_S_LINK]]).catch(() => {})
+    await q('DELETE FROM field_permissions WHERE sheet_id = ANY($1::text[])', [[FS, MS, NS, SS]]).catch(() => {})
+    await q('DELETE FROM spreadsheet_permissions WHERE sheet_id = ANY($1::text[])', [[FS, MS, NS, SS]]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[FS, MS, NS, SS]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[FS, MS, NS, SS]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[FS, MS, NS, SS]]).catch(() => {})
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
+  })
+
+  test('sentinel: DATABASE_URL set', () => { expect(process.env.DATABASE_URL).toBeTruthy() })
+
+  test('R4: unrelated-field edit → zero related events despite the helper echo (publish gate = affected gate)', async () => {
+    currentUser = { id: USER_FULL, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
+    const res = await patchRecord(FS, REC_F1, FLD_FNOISE, 'y')
+    expect(res.status, JSON.stringify(res.body)).toBe(200)
+
+    // The cross-sheet echo still carries the linked records for a full-perm actor…
+    expect(related(res.body, MS, REC_M1)).toBeDefined()
+    // …but no related sheet receives an event: echo presence is NOT the publish gate.
+    expect(sheetEvents(MS)).toHaveLength(0)
+    expect(sheetEvents(NS)).toHaveLength(0)
+    expect(sheetEvents(SS)).toHaveLength(0)
+    // The source-sheet main event is unaffected.
+    const fsEvents = sheetEvents(FS)
+    expect(fsEvents).toHaveLength(1)
+    expect(fsEvents[0]).toMatchObject({ kind: 'record-updated', recordIds: [REC_F1], fieldIds: [FLD_FNOISE] })
+    // Stale seeds survive (no recompute happened).
+    expect(await readField(REC_M1, MS, FLD_M_F)).toBe(6)
+    expect(await readField(REC_N1, NS, FLD_N_F)).toBe(6)
+  })
+
+  test('R3: a related sheet the actor cannot read gets zero events (readable one still publishes)', async () => {
+    currentUser = { id: USER_LIMITED, roles: ['member'], perms: ['comments:write'] }
+    const res = await patchRecord(FS, REC_F1, FLD_FTARGET, 50)
+    expect(res.status, JSON.stringify(res.body)).toBe(200)
+
+    // N is unreadable to USER_LIMITED → helper skips it → no materialization, no event.
+    expect(sheetEvents(NS)).toHaveLength(0)
+    expect(await readField(REC_N1, NS, FLD_N_F)).toBe(6)
+
+    // M is readable → recomputed ([50] → 51) and exactly one invalidation event fans out.
+    expect(await readField(REC_M1, MS, FLD_M_F)).toBe(51)
+    const msEvents = sheetEvents(MS)
+    expect(msEvents).toHaveLength(1)
+    expect(msEvents[0].recordIds).toEqual([REC_M1])
+  })
+
+  test('R1: cross-sheet fan-out — affected recordIds only, UNMASKED fieldIds, no actorId, no recordPatches/values', async () => {
+    currentUser = { id: USER_DENY, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
+    const res = await patchRecord(FS, REC_F1, FLD_FTARGET, 100)
+    expect(res.status, JSON.stringify(res.body)).toBe(200)
+
+    // DB: related formulas materialized ([100] → 101) — reader-agnostic recompute.
+    expect(await readField(REC_M1, MS, FLD_M_F)).toBe(101)
+    expect(await readField(REC_N1, NS, FLD_N_F)).toBe(101)
+
+    // Exactly ONE event on the related sheet M.
+    const msEvents = sheetEvents(MS)
+    expect(msEvents).toHaveLength(1)
+    const msEvent = msEvents[0]
+    expect(msEvent.kind).toBe('record-updated')
+    expect(msEvent.source).toBe('multitable')
+    // recordIds = the AFFECTED related records only: M2 is linked to F1 (and echoed) through
+    // a link field with no lookup over it, so it must NOT be in the invalidation signal.
+    expect(msEvent.recordIds).toEqual([REC_M1])
+    // UNMASKED proof: USER_DENY cannot read FLD_M_F (echo masks it below), yet the
+    // invalidation metadata still carries the affected lookup AND the recomputed formula id.
+    expect([...(msEvent.fieldIds ?? [])].sort()).toEqual([FLD_M_F, FLD_M_LU].sort())
+    // Cross-sheet events omit actorId (the editor has no local edit on M; their other tabs
+    // must refetch too) and the broadcast never carries patches or values: pin the payload's
+    // EXACT key set — metadata-only, no value-bearing key can exist. (A stringify-not-contains
+    // value check would be flaky here: TS-stamped fixture ids can embed the patched number.)
+    expect(Object.keys(msEvent).sort()).toEqual(['fieldIds', 'kind', 'recordIds', 'source', 'spreadsheetId'])
+    // …while the HTTP echo for the same record stays masked (fieldIds ≠ echo keys) and the
+    // wire echo carries no fan-out metadata (exact key set, wire-vs-fixture discipline).
+    const m = related(res.body, MS, REC_M1)
+    expect(m).toBeDefined()
+    expect(Object.keys(m!).sort()).toEqual(['data', 'recordId', 'sheetId'])
+    expect(m!.data[FLD_M_LU]).toEqual([100])
+    expect(m!.data[FLD_M_F]).toBeUndefined()
+
+    // N (readable to this actor, no deny) fans out too.
+    const nsEvents = sheetEvents(NS)
+    expect(nsEvents).toHaveLength(1)
+    expect(nsEvents[0].recordIds).toEqual([REC_N1])
+    expect([...(nsEvents[0].fieldIds ?? [])].sort()).toEqual([FLD_N_F, FLD_N_LU].sort())
+    expect(nsEvents[0]).not.toHaveProperty('actorId')
+  })
+
+  test('R5: main-event regression — the source-sheet publish keeps its exact pre-FOL-1 shape', async () => {
+    currentUser = { id: USER_FULL, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
+    const res = await patchRecord(FS, REC_F1, FLD_FTARGET, 60)
+    expect(res.status, JSON.stringify(res.body)).toBe(200)
+
+    const fsEvents = sheetEvents(FS)
+    expect(fsEvents).toHaveLength(1)
+    // Exact shape: actorId carried, no recordPatches (publisher strips), no extra keys.
+    expect(fsEvents[0]).toEqual({
+      spreadsheetId: FS,
+      actorId: USER_FULL,
+      source: 'multitable',
+      kind: 'record-updated',
+      recordIds: [REC_F1],
+      fieldIds: [FLD_FTARGET],
+    })
+  })
+
+  test('R2: same-sheet self-link → a SECOND source-sheet event for the related record, WITH actorId', async () => {
+    currentUser = { id: USER_FULL, roles: ['member'], perms: ['multitable:read', 'multitable:write'] }
+    const res = await patchRecord(SS, REC_S1, FLD_S_TARGET, 10)
+    expect(res.status, JSON.stringify(res.body)).toBe(200)
+
+    // The same-sheet related formula materialized: lookup [10] → 11.
+    expect(await readField(REC_S2, SS, FLD_S_F)).toBe(11)
+
+    const ssEvents = sheetEvents(SS)
+    expect(ssEvents).toHaveLength(2)
+    const mainEvent = ssEvents.find((e) => e.recordIds?.includes(REC_S1))
+    const relatedEvent = ssEvents.find((e) => e.recordIds?.includes(REC_S2))
+    expect(mainEvent).toEqual({
+      spreadsheetId: SS,
+      actorId: USER_FULL,
+      source: 'multitable',
+      kind: 'record-updated',
+      recordIds: [REC_S1],
+      fieldIds: [FLD_S_TARGET],
+    })
+    // The self-link fan-out CARRIES actorId: the editor's own tab already merged the fresh
+    // values from the PATCH response echo, so it must self-skip instead of re-GETting.
+    expect(relatedEvent).toBeDefined()
+    expect(relatedEvent!.actorId).toBe(USER_FULL)
+    expect(relatedEvent!.kind).toBe('record-updated')
+    expect(relatedEvent!.recordIds).toEqual([REC_S2])
+    expect([...(relatedEvent!.fieldIds ?? [])].sort()).toEqual([FLD_S_F, FLD_S_LU].sort())
+    expect(relatedEvent).not.toHaveProperty('recordPatches')
+  })
+})

--- a/packages/core-backend/tests/unit/record-write-service.test.ts
+++ b/packages/core-backend/tests/unit/record-write-service.test.ts
@@ -260,8 +260,9 @@ describe('RecordWriteService', () => {
         expect.objectContaining({ recordId: 'rec1', data: expect.objectContaining({ fld_total: 42 }) }),
       ]),
     )
-    // Other clients: the formula field id is in fieldIds AND its value is in the
-    // realtime record patch, so applyRemoteRecordPatch merges fresh (no stale formula).
+    // Other clients: the formula field id is in fieldIds so receivers refetch the record
+    // under their own mask. recordPatches is pinned at the CALL payload level only — the
+    // publisher strips it before broadcast; no value ever reaches the wire.
     const realtimePayload = mockPublish.mock.calls[0][0] as {
       fieldIds: string[]
       recordPatches: Array<{ recordId: string; patch: Record<string, unknown> }>
@@ -953,6 +954,151 @@ describe('RecordWriteService', () => {
       expect(result.updated).toHaveLength(1)
       expect(failing).toHaveBeenCalledOnce()
       expect(succeeding).toHaveBeenCalledOnce()
+    })
+  })
+
+  // -------------------------------------------------------------------------
+  // FOL-1 — related-record downstream invalidation
+  // (followups design 2026-06-10 §2: realtime fan-out + Yjs read-side)
+  // -------------------------------------------------------------------------
+  describe('FOL-1 related-record downstream invalidation', () => {
+    // Helper return shape per FOL-1: per-record UNMASKED `affectedFieldIds` metadata
+    // (affected lookup/rollup + actually-recomputed formula ids). Records with an empty
+    // affected set are echo-only — linked but untouched by this edit.
+    const relatedHelperResult = [
+      { sheetId: 'sheet2', recordId: 'rel_a', data: { fld_lu: [7] }, affectedFieldIds: ['fld_lu', 'fld_f'] },
+      { sheetId: 'sheet2', recordId: 'rel_b', data: { fld_lu: [] }, affectedFieldIds: [] },
+      { sheetId: 'sheet1', recordId: 'rel_self', data: { fld_self_lu: [7] }, affectedFieldIds: ['fld_self_lu'] },
+      { sheetId: 'sheet3', recordId: 'rel_echo_only', data: { fld_other: null }, affectedFieldIds: [] },
+    ]
+
+    it('publishes one invalidation event per AFFECTED related sheet — affected gate, not echo presence', async () => {
+      helpers = createMockHelpers({
+        computeDependentLookupRollupRecords: vi.fn().mockResolvedValue(relatedHelperResult),
+      })
+      const service = new RecordWriteService(pool, eventBus as any, helpers)
+
+      await service.patchRecords(buildTestInput())
+
+      const payloads = mockPublish.mock.calls.map((call) => call[0] as Record<string, unknown>)
+      // Main + sheet2 fan-out + same-sheet (self-link) fan-out; sheet3 has no affected
+      // record → ZERO events for it despite its echo entry.
+      expect(payloads).toHaveLength(3)
+      expect(payloads.filter((p) => p.spreadsheetId === 'sheet3')).toHaveLength(0)
+
+      // Main publish unchanged (R5 pin): still carries actorId + the recordPatches arg
+      // (stripped by the publisher before broadcast).
+      expect(payloads[0]).toMatchObject({
+        spreadsheetId: 'sheet1',
+        actorId: 'user1',
+        kind: 'record-updated',
+        recordIds: ['rec1'],
+      })
+      expect(payloads[0]).toHaveProperty('recordPatches')
+
+      // Cross-sheet fan-out: affected record only (rel_b excluded), UNMASKED affected ids,
+      // NO actorId key, NO recordPatches key — exact equality locks the whole call shape.
+      const sheet2Payload = payloads.find((p) => p.spreadsheetId === 'sheet2')
+      expect(sheet2Payload).toEqual({
+        spreadsheetId: 'sheet2',
+        source: 'multitable',
+        kind: 'record-updated',
+        recordIds: ['rel_a'],
+        fieldIds: ['fld_lu', 'fld_f'],
+      })
+
+      // Same-sheet self-link fan-out: a SECOND sheet1 event, WITH actorId (the editor's
+      // tab already merged the response echo — actorId prevents a redundant self-GET).
+      const selfPayload = payloads.find((p) => p.spreadsheetId === 'sheet1' && p !== payloads[0])
+      expect(selfPayload).toEqual({
+        spreadsheetId: 'sheet1',
+        actorId: 'user1',
+        source: 'multitable',
+        kind: 'record-updated',
+        recordIds: ['rel_self'],
+        fieldIds: ['fld_self_lu'],
+      })
+    })
+
+    it('R7: rest-source patch sends AFFECTED related record ids to the Yjs invalidator', async () => {
+      const invalidator = vi.fn().mockResolvedValue(undefined)
+      // buildTestInput() deliberately leaves `source` undefined — production-faithful: the REST
+      // PATCH route passes no source, and the hook gate skips only on source === 'yjs-bridge'.
+      helpers = createMockHelpers({
+        computeDependentLookupRollupRecords: vi.fn().mockResolvedValue(relatedHelperResult),
+      })
+      const service = new RecordWriteService(pool, eventBus as any, helpers, [
+        createYjsInvalidationPostCommitHook(invalidator),
+      ])
+
+      await service.patchRecords(buildTestInput())
+
+      const invalidated = invalidator.mock.calls.map((call) => call[0] as string[])
+      // First call = source records (Step 3, unchanged); the related ids follow per sheet.
+      expect(invalidated[0]).toEqual(['rec1'])
+      const relatedInvalidated = invalidated.slice(1).flat()
+      expect(relatedInvalidated.sort()).toEqual(['rel_a', 'rel_self'])
+      // Echo-only records (empty affected set) never reach the invalidator.
+      expect(relatedInvalidated).not.toContain('rel_b')
+      expect(relatedInvalidated).not.toContain('rel_echo_only')
+    })
+
+    it('R7: yjs-bridge source never reaches the invalidator — neither source nor related ids', async () => {
+      const invalidator = vi.fn().mockResolvedValue(undefined)
+      helpers = createMockHelpers({
+        computeDependentLookupRollupRecords: vi.fn().mockResolvedValue(relatedHelperResult),
+      })
+      const service = new RecordWriteService(pool, eventBus as any, helpers, [
+        createYjsInvalidationPostCommitHook(invalidator),
+      ])
+
+      await service.patchRecords(buildTestInput({ source: 'yjs-bridge' }))
+
+      expect(invalidator).not.toHaveBeenCalled()
+    })
+
+    it('R6: yjs-bridge stub path (helper → []) — zero fan-out, zero related Yjs invalidation', async () => {
+      const invalidator = vi.fn().mockResolvedValue(undefined)
+      // Default mock helper mirrors the index.ts bridge stub: async () => [].
+      const service = new RecordWriteService(pool, eventBus as any, helpers, [
+        createYjsInvalidationPostCommitHook(invalidator),
+      ])
+
+      await service.patchRecords(buildTestInput({ source: 'yjs-bridge' }))
+
+      expect(mockPublish).toHaveBeenCalledTimes(1) // main publish only
+      expect(invalidator).not.toHaveBeenCalled()
+    })
+
+    it('keeps the patch + fan-out resilient when a related post-commit hook throws', async () => {
+      const invalidator = vi.fn().mockRejectedValue(new Error('purge failed'))
+      helpers = createMockHelpers({
+        computeDependentLookupRollupRecords: vi.fn().mockResolvedValue(relatedHelperResult),
+      })
+      const service = new RecordWriteService(pool, eventBus as any, helpers, [
+        createYjsInvalidationPostCommitHook(invalidator),
+      ])
+
+      const result = await service.patchRecords(buildTestInput())
+
+      expect(result.updated).toHaveLength(1)
+      expect(mockPublish.mock.calls.length).toBe(3) // main + 2 fan-out events still publish
+    })
+
+    it('strips the fan-out metadata from the HTTP relatedRecords echo', async () => {
+      helpers = createMockHelpers({
+        computeDependentLookupRollupRecords: vi.fn().mockResolvedValue(relatedHelperResult),
+      })
+      const service = new RecordWriteService(pool, eventBus as any, helpers)
+
+      const result = await service.patchRecords(buildTestInput())
+
+      // Cross-sheet echo keeps its exact pre-FOL-1 shape: `affectedFieldIds` is internal
+      // fan-out metadata (unmasked ids), never part of the response contract.
+      expect(result.relatedRecords).toBeDefined()
+      for (const record of result.relatedRecords!) {
+        expect(Object.keys(record).sort()).toEqual(['data', 'recordId', 'sheetId'])
+      }
     })
   })
 })


### PR DESCRIPTION
## Summary

Implements **FOL-1** per the design-lock in `multitable-formula-over-lookup-followups-development-plan-20260610.md` §2 (#2460): after A-full (#2450) materializes formula values on RELATED records, the two downstream consumers that stayed stale now get invalidated:

1. **Realtime fan-out** — one invalidation event per affected related sheet (existing `record-updated` kind, zero values on the wire).
2. **Yjs read-side** — affected related record ids reach the existing Yjs invalidator (record-id-keyed, verified through `yjsBridge.cancelPending → yjsSyncService.invalidateDocs → yjsWsAdapter.notifyInvalidated`).

## Locked decisions implemented (all 9, zero deviations)

- **Publish gate = affected gate, NOT echo-gated**: a related sheet publishes only when ≥1 record there has a non-empty affected set (the #2450 F1 dependency-gate); echo-only linked records are excluded from `recordIds` (pinned by fixture record M2).
- **UNMASKED fieldIds metadata**: helper returns per-record `affectedFieldIds` (affected lookup/rollup + actually-recomputed formula ids); proven with a field_permissions-denied actor whose echo masks the formula key while the event still carries it. Metadata is **stripped from the HTTP echo** (exact key-set pins at both unit and wire level) so the response is byte-identical to pre-FOL-1.
- **actorId split**: cross-sheet events omit the key entirely (editor's other tabs must refetch); same-sheet self-link event carries it (actor's own tab already merged the PATCH echo).
- **No recordPatches in fan-out**; broadcast payload's exact key set pinned (`fieldIds/kind/recordIds/source/spreadsheetId`).
- **Yjs**: related ids flow through `createYjsInvalidationPostCommitHook` per related sheet; `source==='yjs-bridge'` skips (bridge's stubbed helper keeps collab path a natural no-op; widened seam type stays stub-assignable).
- Stale value-push comment at RWS Step 6 corrected (claimed `recordPatches`/`applyRemoteRecordPatch` flow that the publisher strips and the frontend never applies).

## Tests (fail-first, real-DB suite wired into plugin-tests.yml)

- NEW `multitable-fol1-related-invalidation.test.ts`: R1–R5 (fan-out + unmasked proof + actorId split + zero-event gates + main-event regression), 6/6.
- `record-write-service.test.ts`: +6 unit cases (per-sheet publish, R6 bridge stub, R7 invalidator both sources, hook-failure resilience, echo metadata strip).
- Fail-first evidence: R1/R2/R3 + 4 unit cases ran RED pre-implementation (captured in the workflow log); R4/R5/R6 are regression pins that were green by design.
- Full verification: 27/27 affected integration (incl. AF/A-min/create/echo-mask/realtime suites), 224 files / 2865 unit, `tsc --noEmit` clean.

## Review

Independent adversarial review: **APPROVE-WITH-NITS** (`/tmp/fol1-review-claude-20260610.md`). All three findings addressed before this PR: timestamp-flake assertion replaced with exact key-set pin, wire-level echo key pin added, R7 source-semantics comment added.

Design-lock: #2460 · Chain: #2410 → #2450 → this.

🤖 Generated with [Claude Code](https://claude.com/claude-code)