### PR TITLE
feat(multitable): FOL-2 dry-run preview hydration — expression-scoped lookup/rollup sampling

### DIFF
--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -6404,13 +6404,17 @@ export function univerMetaRouter(): Router {
       }
       if (!capabilities.canManageFields) return sendForbidden(res)
 
-      if (dryRunFormulaEngine.extractFieldReferences(expression).length > DRY_RUN_MAX_REFERENCED_FIELDS) {
+      const referencedFieldIds = dryRunFormulaEngine.extractFieldReferences(expression)
+      if (referencedFieldIds.length > DRY_RUN_MAX_REFERENCED_FIELDS) {
         return res.status(422).json({ ok: false, error: { code: 'DRYRUN_TOO_MANY_REFS', message: `Expression references more than ${DRY_RUN_MAX_REFERENCED_FIELDS} fields` } })
       }
       const fields = await loadFieldsForSheetShared(pool.query.bind(pool), sheetId)
 
-      // #5c: optional real-record sampling. RAW persisted data only (no applyLookupRollup) so the preview
-      // matches production recalc; lookup/rollup keys are absent in raw → existing missing_sample diagnostic.
+      // #5c + FOL-2: optional real-record sampling. Production recalc evaluates HYDRATED rows since
+      // A-min (#2247), so the sampled record hydrates its referenced lookup/rollup the same way —
+      // at the ROUTE layer only (the dry-run engine keeps its no-DB invariant). Order is
+      // hydrate → mask → manual override: a denied/hidden lookup key is dropped by the mask and
+      // still surfaces as missing_sample.
       let effectiveSampleValues: Record<string, unknown> = sampleValues
       if (recordId && recordReadAccess) {
         const userId = recordReadAccess.userId
@@ -6420,6 +6424,24 @@ export function univerMetaRouter(): Router {
             [recordId, sheetId],
           )
           const rawData = recordRes.rows.length > 0 ? normalizeJson(recordRes.rows[0].data) : {}
+          // FOL-2 hydration is EXPRESSION-SCOPED (design 2026-06-10 §3.1): only the lookup/rollup
+          // fields the expression references are passed to applyLookupRollup (its `fields` param
+          // consumes lookup/rollup entries only; link configs flow via `relationalLinkFields`),
+          // binding the per-preview cost to the expression — no computed ref → zero
+          // link/foreign-sheet reads. Requester-perspective (`req`): an unreadable foreign sheet
+          // hydrates a lookup to [] and a rollup to null, same as every read path.
+          const referencedIdSet = new Set(referencedFieldIds)
+          const referencedComputedFields = fields.filter(
+            (field) => (field.type === 'lookup' || field.type === 'rollup') && referencedIdSet.has(field.id),
+          )
+          if (referencedComputedFields.length > 0) {
+            const relationalLinkFields = fields
+              .map((f) => (f.type === 'link' ? { fieldId: f.id, cfg: parseLinkFieldConfig(f.property) } : null))
+              .filter((v): v is RelationalLinkField => !!v && !!v.cfg)
+            const row: UniverMetaRecord = { id: recordId, version: 0, data: rawData }
+            const linkValuesByRecord = await loadLinkValuesByRecord(pool.query.bind(pool), [recordId], relationalLinkFields)
+            await applyLookupRollup(req, pool.query.bind(pool), referencedComputedFields, [row], relationalLinkFields, linkValuesByRecord)
+          }
           // D3c field mask, sheet-scope (hiddenFieldIds: [] — display-consistency defer, see #5c design-lock §4).
           // scope.visible is the real field-read gate; a denied field is omitted → becomes missing_sample.
           const visibleFields = filterVisiblePropertyFields(fields)

--- a/packages/core-backend/tests/integration/multitable-formula-dryrun.test.ts
+++ b/packages/core-backend/tests/integration/multitable-formula-dryrun.test.ts
@@ -2,6 +2,12 @@
  * Real-DB integration test for the formula dry-run endpoint (#5a, design #1860):
  * POST /api/multitable/sheets/:sheetId/formula/dry-run.
  * Confirms the canManageFields gate, structural caps, and the happy path. Runs only with DATABASE_URL.
+ *
+ * FOL-2 (dry-run hydration, design 2026-06-10 §3): the recordId branch hydrates the lookup/rollup
+ * fields the expression references (requester-perspective, hydrate → mask → manual override), so
+ * the preview matches production recalc, which evaluates HYDRATED rows since A-min (#2247).
+ * D1-D7 below pin the joined-string substitution semantics (A2b) and the expression-scoped
+ * hydration cost (no computed ref → zero link/foreign-sheet reads).
  */
 import express, { type Express } from 'express'
 import request from 'supertest'
@@ -22,17 +28,58 @@ const FLD_A = `fld_dry_a_${TS}`
 const FLD_B = `fld_dry_b_${TS}`
 const FLD_SECRET = `fld_dry_secret_${TS}` // #5c: field the requesting user is denied (field_permissions.visible=false)
 const FLD_HIDDEN = `fld_dry_hidden_${TS}` // #5c: statically hidden field (property.hidden=true) — second mask channel
-const FLD_LOOKUP = `fld_dry_lookup_${TS}` // #5c: lookup field — never persisted in raw record data
+const FLD_LOOKUP = `fld_dry_lookup_${TS}` // #5c: lookup field — never persisted in raw record data (null cfg → hydrates to [])
 const REC_ID = `rec_dry_${TS}`
 const USER_ID = `u_dry_${TS}`
 const SECRET_CANARY = 'do-not-leak-canary' // #5c: proves a field_permissions-denied field never leaks
 const HIDDEN_CANARY = 'do-not-leak-hidden' // #5c: proves a property.hidden field never leaks
+
+// ── FOL-2 hydration fixtures: real foreign sheets + link + configured lookup/rollup ──
+const FOREIGN_A = `sheet_dry_fa_${TS}` // foreign sheet feeding the referenced lookup/rollup
+const FOREIGN_B = `sheet_dry_fb_${TS}` // foreign sheet feeding the UNREFERENCED lookup (D6 scoping)
+const FLD_FA_NUM = `fld_dry_fa_num_${TS}` // numeric lookup/rollup target (100)
+const FLD_FA_SECRET = `fld_dry_fa_secret_${TS}` // carries FOREIGN_CANARY — read only via FLD_LU_DENIED
+const FLD_FB_NUM = `fld_dry_fb_num_${TS}`
+const FLD_LINK_A = `fld_dry_link_a_${TS}`
+const FLD_LINK_B = `fld_dry_link_b_${TS}`
+const FLD_LU_A = `fld_dry_lu_a_${TS}` // configured lookup → FLD_FA_NUM
+const FLD_RU_A = `fld_dry_ru_a_${TS}` // sum rollup → FLD_FA_NUM
+const FLD_LU_B = `fld_dry_lu_b_${TS}` // configured lookup → FLD_FB_NUM; deliberately never referenced in D6
+const FLD_LU_DENIED = `fld_dry_lu_denied_${TS}` // lookup → FLD_FA_SECRET, field_permissions-denied for USER_ID
+const REC_FA1 = `rec_dry_fa1_${TS}`
+const REC_FB1 = `rec_dry_fb1_${TS}`
+const USER_LIMITED = `u_dry_limited_${TS}` // sheet-scoped grant on SHEET_ID only → both foreign sheets unreadable
+const FOREIGN_CANARY = 'do-not-leak-foreign-canary' // FOL-2 D3: hydrated-then-masked value must never leak
 
 let app: Express
 let testPerms: string[] = ['multitable:write'] // canManageFields requires multitable:write
 let testUserId: string = USER_ID // #5c: mutable so a test can drop the user to assert 401
 const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
 const post = (body: unknown) => request(app).post(`/api/multitable/sheets/${SHEET_ID}/formula/dry-run`).send(body as object)
+
+// FOL-2 D6/D7: capture every SQL statement issued while `fn` runs by patching the shared pool's
+// query method (the route re-binds pool.query per request, so the patch is picked up). Params are
+// flattened so ids inside text[] array params are matchable with a plain `includes`.
+type CapturedQuery = { sql: string; params: unknown[] }
+const captureQueries = async (fn: () => Promise<void>): Promise<CapturedQuery[]> => {
+  const pool = poolManager.get() as unknown as { query: (...args: unknown[]) => unknown }
+  const original = pool.query
+  const captured: CapturedQuery[] = []
+  pool.query = function (this: unknown, ...args: unknown[]) {
+    if (typeof args[0] === 'string') {
+      captured.push({ sql: args[0], params: Array.isArray(args[1]) ? (args[1] as unknown[]).flat(3) : [] })
+    }
+    return original.apply(this, args)
+  }
+  try {
+    await fn()
+  } finally {
+    pool.query = original
+  }
+  return captured
+}
+const touchesSheet = (queries: CapturedQuery[], sheetId: string) =>
+  queries.some((c) => c.params.includes(sheetId))
 
 describeIfDatabase('multitable formula dry-run (real DB)', () => {
   beforeAll(async () => {
@@ -55,13 +102,39 @@ describeIfDatabase('multitable formula dry-run (real DB)', () => {
     await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_ID, SHEET_ID, JSON.stringify({ [FLD_A]: 10, [FLD_B]: 20, [FLD_SECRET]: SECRET_CANARY, [FLD_HIDDEN]: HIDDEN_CANARY })])
     // Deny FLD_SECRET to the requesting user — the real D3c field-read deny gate (subject-scoped).
     await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_SECRET, 'user', USER_ID, false, false])
+
+    // ── FOL-2 hydration fixtures (design 2026-06-10 §3.2): the pre-FOL-2 FLD_LOOKUP has property
+    // {} (cfg parses to null → hydrates to []), so REAL foreign sheets + a link + configured
+    // lookup/rollup are needed to exercise actual value hydration.
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [FOREIGN_A, BASE_ID, 'Dry Foreign A'])
+    await q('INSERT INTO meta_sheets (id, base_id, name) VALUES ($1, $2, $3)', [FOREIGN_B, BASE_ID, 'Dry Foreign B'])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_FA_NUM, FOREIGN_A, 'FA Num', 'number', '{}', 1])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_FA_SECRET, FOREIGN_A, 'FA Secret', 'string', '{}', 2])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_FB_NUM, FOREIGN_B, 'FB Num', 'number', '{}', 1])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_FA1, FOREIGN_A, JSON.stringify({ [FLD_FA_NUM]: 100, [FLD_FA_SECRET]: FOREIGN_CANARY })])
+    await q('INSERT INTO meta_records (id, sheet_id, data, version) VALUES ($1,$2,$3::jsonb,1)', [REC_FB1, FOREIGN_B, JSON.stringify({ [FLD_FB_NUM]: 7 })])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LINK_A, SHEET_ID, 'Link A', 'link', JSON.stringify({ foreignSheetId: FOREIGN_A }), 6])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LINK_B, SHEET_ID, 'Link B', 'link', JSON.stringify({ foreignSheetId: FOREIGN_B }), 7])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LU_A, SHEET_ID, 'Lookup A', 'lookup', JSON.stringify({ linkFieldId: FLD_LINK_A, targetFieldId: FLD_FA_NUM, foreignSheetId: FOREIGN_A }), 8])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_RU_A, SHEET_ID, 'Rollup A', 'rollup', JSON.stringify({ linkFieldId: FLD_LINK_A, targetFieldId: FLD_FA_NUM, aggregation: 'sum', foreignSheetId: FOREIGN_A }), 9])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LU_B, SHEET_ID, 'Lookup B', 'lookup', JSON.stringify({ linkFieldId: FLD_LINK_B, targetFieldId: FLD_FB_NUM, foreignSheetId: FOREIGN_B }), 10])
+    await q('INSERT INTO meta_fields (id, sheet_id, name, type, property, "order") VALUES ($1,$2,$3,$4,$5::jsonb,$6)', [FLD_LU_DENIED, SHEET_ID, 'Lookup Denied', 'lookup', JSON.stringify({ linkFieldId: FLD_LINK_A, targetFieldId: FLD_FA_SECRET, foreignSheetId: FOREIGN_A }), 11])
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [FLD_LINK_A, REC_ID, REC_FA1])
+    await q('INSERT INTO meta_links (field_id, record_id, foreign_record_id) VALUES ($1,$2,$3)', [FLD_LINK_B, REC_ID, REC_FB1])
+    // D3: deny the configured lookup itself — hydrate → mask must drop the hydrated value.
+    await q('INSERT INTO field_permissions (sheet_id, field_id, subject_type, subject_id, visible, read_only) VALUES ($1,$2,$3,$4,$5,$6)', [SHEET_ID, FLD_LU_DENIED, 'user', USER_ID, false, false])
+    // D4/D4b: USER_LIMITED gets sheet-scoped write on SHEET_ID only (schema-write grant →
+    // canManageFields), no global perms and no grant on FOREIGN_A/B → foreign sheets unreadable.
+    await q('INSERT INTO spreadsheet_permissions (sheet_id, user_id, subject_type, subject_id, perm_code) VALUES ($1,$2,$3,$4,$5)', [SHEET_ID, USER_LIMITED, 'user', USER_LIMITED, 'spreadsheet:write'])
   })
 
   afterAll(async () => {
+    await q('DELETE FROM meta_links WHERE field_id = ANY($1::text[])', [[FLD_LINK_A, FLD_LINK_B]]).catch(() => {})
+    await q('DELETE FROM spreadsheet_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
     await q('DELETE FROM field_permissions WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
-    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
-    await q('DELETE FROM meta_fields WHERE sheet_id = $1', [SHEET_ID]).catch(() => {})
-    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET_ID]).catch(() => {})
+    await q('DELETE FROM meta_records WHERE sheet_id = ANY($1::text[])', [[SHEET_ID, FOREIGN_A, FOREIGN_B]]).catch(() => {})
+    await q('DELETE FROM meta_fields WHERE sheet_id = ANY($1::text[])', [[SHEET_ID, FOREIGN_A, FOREIGN_B]]).catch(() => {})
+    await q('DELETE FROM meta_sheets WHERE id = ANY($1::text[])', [[SHEET_ID, FOREIGN_A, FOREIGN_B]]).catch(() => {})
     await q('DELETE FROM meta_bases WHERE id = $1', [BASE_ID]).catch(() => {})
   })
 
@@ -176,16 +249,20 @@ describeIfDatabase('multitable formula dry-run (real DB)', () => {
     expect(overridden.body.data.result).toBe(120) // manual override of A wins over the record's 10
   })
 
-  test('#5c T4: lookup-ref → missing_sample (RAW read, NOT materialized) — preview==production', async () => {
+  test('#5c T4 (flipped by FOL-2): null-cfg lookup-ref hydrates to [] — no missing_sample, "" substitution', async () => {
     testPerms = ['multitable:write']; testUserId = USER_ID
-    // FLD_LOOKUP is a known field on the sheet but absent from raw persisted data → must degrade
-    // to missing_sample, never a materialized lookup value (locks the raw-read decision).
+    // FLD_LOOKUP has property {} (cfg parses to null) → applyLookupRollup hydrates it to [],
+    // which substitutes as "" (joined-string A2b contract) → numeric coercion 0 in arithmetic.
+    // Pre-FOL-2 this asserted missing_sample (raw read); production recalc evaluates HYDRATED
+    // rows since A-min (#2247), so the preview hydrates too.
     const res = await post({ expression: `={${FLD_LOOKUP}}+1`, recordId: REC_ID })
     expect(res.status).toBe(200)
     const missing = res.body.data.diagnostics.find((d: { kind: string; fieldId?: string }) => d.kind === 'missing_sample' && d.fieldId === FLD_LOOKUP)
-    expect(missing).toBeDefined()
+    expect(missing).toBeUndefined() // hydrated (to []) — sampled, no longer missing
+    expect(res.body.data.success).toBe(true)
+    expect(res.body.data.result).toBe(1) // [] → "" → 0 + 1
     const unknown = res.body.data.diagnostics.find((d: { kind: string }) => d.kind === 'unknown_field')
-    expect(unknown).toBeUndefined() // it IS a known field, just not sampled — not unknown_field
+    expect(unknown).toBeUndefined() // it IS a known field — not unknown_field
   })
 
   test('#5c T5: no recordId → unchanged #5b manual-sample path (additive, not regressed)', async () => {
@@ -213,5 +290,128 @@ describeIfDatabase('multitable formula dry-run (real DB)', () => {
     const missing = res.body.data.diagnostics.find((d: { kind: string; fieldId?: string }) => d.kind === 'missing_sample' && d.fieldId === FLD_HIDDEN)
     expect(missing).toBeDefined()
     expect(JSON.stringify(res.body)).not.toContain(HIDDEN_CANARY)
+  })
+
+  // ───────────────────────── FOL-2: dry-run hydration (design 2026-06-10 §3) ─────────────────────────
+  // The recordId branch hydrates the lookup/rollup fields the expression references (requester-
+  // perspective, hydrate → mask → manual override). Expected values follow the engine's ACTUAL
+  // joined-string substitution (A2b, pinned in tests/unit/multitable-formula-over-lookup.test.ts):
+  // hydrated [100] → "100" (numeric coercion in arithmetic), [] → "" (bare → '', +1 → 1);
+  // a sum rollup hydrates to a number, an empty/unreadable one to null → '0' substitution.
+
+  test('FOL-2 D1: linked lookup ref hydrates — [100] → "100" joined-string → +1 = 101', async () => {
+    testPerms = ['multitable:write']; testUserId = USER_ID
+    const arith = await post({ expression: `={${FLD_LU_A}}+1`, recordId: REC_ID })
+    expect(arith.status).toBe(200)
+    expect(arith.body.data.success).toBe(true)
+    expect(arith.body.data.result).toBe(101)
+    expect(arith.body.data.resultType).toBe('number')
+    const missing = arith.body.data.diagnostics.find((d: { kind: string; fieldId?: string }) => d.kind === 'missing_sample' && d.fieldId === FLD_LU_A)
+    expect(missing).toBeUndefined()
+    // bare ref pins the joined-string substitution itself: [100] → "100" (a string, not 100)
+    const bare = await post({ expression: `={${FLD_LU_A}}`, recordId: REC_ID })
+    expect(bare.body.data.result).toBe('100')
+    expect(bare.body.data.resultType).toBe('string')
+  })
+
+  test('FOL-2 D2: rollup ref hydrates — sum over [100] → 100 → +1 = 101', async () => {
+    testPerms = ['multitable:write']; testUserId = USER_ID
+    const arith = await post({ expression: `={${FLD_RU_A}}+1`, recordId: REC_ID })
+    expect(arith.status).toBe(200)
+    expect(arith.body.data.success).toBe(true)
+    expect(arith.body.data.result).toBe(101)
+    const missing = arith.body.data.diagnostics.find((d: { kind: string; fieldId?: string }) => d.kind === 'missing_sample' && d.fieldId === FLD_RU_A)
+    expect(missing).toBeUndefined()
+    const bare = await post({ expression: `={${FLD_RU_A}}`, recordId: REC_ID })
+    expect(bare.body.data.result).toBe(100) // rollup hydrates to a scalar number — no array join
+    expect(bare.body.data.resultType).toBe('number')
+  })
+
+  test('FOL-2 D3: field_permissions-denied lookup stays missing_sample; hydrated foreign value never leaks (hydrate → mask order)', async () => {
+    testPerms = ['multitable:write']; testUserId = USER_ID
+    // FLD_LU_DENIED is a properly-configured lookup whose foreign target carries FOREIGN_CANARY;
+    // it hydrates (referenced) but the mask drops the key BEFORE the engine sees it.
+    const res = await post({ expression: `={${FLD_LU_DENIED}}`, recordId: REC_ID })
+    expect(res.status).toBe(200)
+    const missing = res.body.data.diagnostics.find((d: { kind: string; fieldId?: string }) => d.kind === 'missing_sample' && d.fieldId === FLD_LU_DENIED)
+    expect(missing).toBeDefined()
+    expect(JSON.stringify(res.body)).not.toContain(FOREIGN_CANARY)
+  })
+
+  test('FOL-2 D4: requester cannot read the foreign sheet — lookup hydrates to [] → "" substitution', async () => {
+    testPerms = []; testUserId = USER_LIMITED // sheet-scoped write on SHEET_ID only
+    const bare = await post({ expression: `={${FLD_LU_A}}`, recordId: REC_ID })
+    expect(bare.status).toBe(200)
+    expect(bare.body.data.success).toBe(true)
+    expect(bare.body.data.result).toBe('') // [] joins to "" — a string, not a missing sample
+    expect(bare.body.data.resultType).toBe('string')
+    const missing = bare.body.data.diagnostics.find((d: { kind: string; fieldId?: string }) => d.kind === 'missing_sample' && d.fieldId === FLD_LU_A)
+    expect(missing).toBeUndefined()
+    const arith = await post({ expression: `={${FLD_LU_A}}+1`, recordId: REC_ID })
+    expect(arith.body.data.result).toBe(1) // "" coerces to 0 in arithmetic
+    testPerms = ['multitable:write']; testUserId = USER_ID
+  })
+
+  test('FOL-2 D4b: requester cannot read the foreign sheet — rollup hydrates to null → \'0\' substitution (diverges from lookup)', async () => {
+    testPerms = []; testUserId = USER_LIMITED
+    const bare = await post({ expression: `={${FLD_RU_A}}`, recordId: REC_ID })
+    expect(bare.status).toBe(200)
+    expect(bare.body.data.success).toBe(true)
+    expect(bare.body.data.result).toBe(0) // null substitutes as '0' — not "" like a lookup
+    expect(bare.body.data.resultType).toBe('number')
+    const missing = bare.body.data.diagnostics.find((d: { kind: string; fieldId?: string }) => d.kind === 'missing_sample' && d.fieldId === FLD_RU_A)
+    expect(missing).toBeUndefined() // hydrated (to null) — sampled, no longer missing
+    const arith = await post({ expression: `={${FLD_RU_A}}+1`, recordId: REC_ID })
+    expect(arith.body.data.result).toBe(1)
+    testPerms = ['multitable:write']; testUserId = USER_ID
+  })
+
+  test('FOL-2 D5: manual sampleValues beat hydration; a masked lookup accepts a manual sample', async () => {
+    testPerms = ['multitable:write']; testUserId = USER_ID
+    // {...masked, ...sampleValues}: the manual 5 wins over the hydrated [100].
+    const overridden = await post({ expression: `={${FLD_LU_A}}+1`, recordId: REC_ID, sampleValues: { [FLD_LU_A]: 5 } })
+    expect(overridden.status).toBe(200)
+    expect(overridden.body.data.result).toBe(6)
+    // A manual sample for the MASKED lookup also evaluates — it is the caller's own data, not a leak.
+    const maskedManual = await post({ expression: `={${FLD_LU_DENIED}}+1`, recordId: REC_ID, sampleValues: { [FLD_LU_DENIED]: 5 } })
+    expect(maskedManual.body.data.result).toBe(6)
+    expect(JSON.stringify(maskedManual.body)).not.toContain(FOREIGN_CANARY)
+  })
+
+  test('FOL-2 D6: hydration is expression-scoped — no computed ref → zero link/foreign reads; unreferenced lookup\'s sheet never queried', async () => {
+    testPerms = ['multitable:write']; testUserId = USER_ID
+    // (a) expression references NO lookup/rollup → ZERO foreign-sheet queries, no meta_links read.
+    const plain = await captureQueries(async () => {
+      const res = await post({ expression: `={${FLD_A}}+{${FLD_B}}`, recordId: REC_ID })
+      expect(res.status).toBe(200)
+      expect(res.body.data.result).toBe(30)
+    })
+    expect(plain.length).toBeGreaterThan(0) // the capture hook is actually wired
+    expect(plain.some((c) => /meta_links/i.test(c.sql))).toBe(false)
+    expect(touchesSheet(plain, FOREIGN_A)).toBe(false)
+    expect(touchesSheet(plain, FOREIGN_B)).toBe(false)
+    // (b) referencing lookup A only → FOREIGN_A records are read, FOREIGN_B is never touched
+    // (FLD_LU_B exists and is linked, but the expression does not reference it).
+    const scoped = await captureQueries(async () => {
+      const res = await post({ expression: `={${FLD_LU_A}}+1`, recordId: REC_ID })
+      expect(res.status).toBe(200)
+      expect(res.body.data.result).toBe(101)
+    })
+    expect(scoped.some((c) => /FROM meta_records/.test(c.sql) && c.params.includes(FOREIGN_A))).toBe(true)
+    expect(touchesSheet(scoped, FOREIGN_B)).toBe(false)
+  })
+
+  test('FOL-2 D7: no recordId → #5b manual path unchanged (lookup ref stays missing_sample, zero hydration reads)', async () => {
+    testPerms = ['multitable:write']; testUserId = USER_ID
+    const captured = await captureQueries(async () => {
+      const res = await post({ expression: `={${FLD_LU_A}}+1` })
+      expect(res.status).toBe(200)
+      const missing = res.body.data.diagnostics.find((d: { kind: string; fieldId?: string }) => d.kind === 'missing_sample' && d.fieldId === FLD_LU_A)
+      expect(missing).toBeDefined()
+      expect(res.body.data.result).toBe(1) // absent → '0' substitution, exactly as before FOL-2
+    })
+    expect(captured.some((c) => /meta_links/i.test(c.sql))).toBe(false)
+    expect(touchesSheet(captured, FOREIGN_A)).toBe(false)
+    expect(touchesSheet(captured, FOREIGN_B)).toBe(false)
   })
 })


### PR DESCRIPTION
## Summary

Implements **FOL-2** per the design-lock in `multitable-formula-over-lookup-followups-development-plan-20260610.md` §3 (#2460): the formula dry-run preview's `recordId` sampling now hydrates lookup/rollup before masking, restoring preview ↔ production parity that inverted when A-min (#2247) made production recalc evaluate hydrated rows.

## Locked decisions implemented (all 7, zero deviations)

- **Route-level hydrate → mask → manual override**: existing `loadLinkValuesByRecord` + `applyLookupRollup(req, …)` before the unchanged #5c mask and `…sampleValues` precedence; `dryRunFormulaEngine` keeps its no-DB invariant (stub still throws on DB access).
- **Expression-scoped hydration**: only the lookup/rollup fields the expression references are passed to `applyLookupRollup` — no computed ref → zero link/foreign-sheet reads (D6 pins this with a query-capture spy + an unreferenced-but-linked decoy foreign sheet that must never be queried).
- **Joined-string substitution semantics pinned from engine ACTUAL behavior** (probed, then asserted): `[100]` → `"100"` → `+1` = 101; `[]` → `""` (+1 = 1, string); rollup `null` → `'0'`.
- **Actor-perspective hydration**: unreadable foreign sheet → lookup `[]` / rollup `null` (D4/D4b, sheet-scoped limited user), same as every read path.
- Stale #5c comment fixed ("RAW … matches production recalc" — rationale inverted since A-min).
- `#5b` no-recordId path pinned unchanged (D7); response shape unchanged.

## Tests (fail-first, suite already in the plugin-tests.yml runner)

- `multitable-formula-dryrun.test.ts` 20 → **26 tests**: D1/D2 (new foreign-sheet + meta_links + real lookup/sum-rollup fixtures), D3 (deny mask + canary, kept), D4/D4b (unreadable-foreign lookup vs rollup divergence), D5 (manual override beats hydration, incl. masked-lookup override), D6 (hydration scoping), D7 (no-recordId unchanged), plus the legacy T4 assertion flipped (null-cfg lookup → []-hydration).
- Fail-first: 6 RED pre-implementation (captured: `expected 1 to be 101`, missing_sample still present, etc.).
- Full verification: 26/26 + 15/15 adjacent FoL suites, 224 files / 2859 unit, `tsc --noEmit` clean.

## Review

Independent adversarial review: **APPROVE-WITH-NITS** (`/tmp/fol2-review-claude-20260610.md`). F1 addressed before this PR (comment mis-stated the link-fields mechanism; dead link-field spread removed — `applyLookupRollup`'s `fields` param consumes lookup/rollup entries only). F2 (hydration runs before the engine's unknown-field gate — cost-only, bounded by `DRY_RUN_MAX_REFERENCED_FIELDS`) accepted as documented.

Design-lock: #2460 · Chain: #2410 → #2450 → this (parallel lane with FOL-1).

🤖 Generated with [Claude Code](https://claude.com/claude-code)