### PR TITLE
refactor(attendance): compose attendance scheduler jobs

### DIFF
--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -94,6 +94,7 @@ import {
   resolveAttendanceSchedulerIntervalMs,
   resolveAttendanceSchedulerLeaderOptions,
   resolveUnscheduledReminderJob,
+  registerAttendanceSchedulerJob,
   startAttendanceScheduler,
   stopAttendanceScheduler,
 } from './services/AttendanceScheduler'
@@ -199,6 +200,7 @@ export class MetaSheetServer {
   private pluginRouteRegistrationIdsByPlugin = new Map<string, Set<string>>()
   private pluginCommunicationNamespacesByPlugin = new Map<string, Set<string>>()
   private pluginCommunicationNamespaceOwners = new Map<string, string>()
+  private pluginAttendanceSchedulerUnregistersByPlugin = new Map<string, Set<() => void>>()
   private port: number
   private host?: string
   private portLocked: boolean
@@ -848,13 +850,39 @@ export class MetaSheetServer {
     return true
   }
 
+  private registerPluginAttendanceSchedulerJob(pluginName: string, job: { name?: string; run(): Promise<unknown> }): (() => void) | null {
+    const unregister = registerAttendanceSchedulerJob(job)
+    if (!unregister) return null
+
+    const unregisters = this.pluginAttendanceSchedulerUnregistersByPlugin.get(pluginName) ?? new Set<() => void>()
+    const wrappedUnregister = () => {
+      unregister()
+      unregisters.delete(wrappedUnregister)
+      if (unregisters.size === 0) {
+        this.pluginAttendanceSchedulerUnregistersByPlugin.delete(pluginName)
+      }
+    }
+    unregisters.add(wrappedUnregister)
+    this.pluginAttendanceSchedulerUnregistersByPlugin.set(pluginName, unregisters)
+    return wrappedUnregister
+  }
+
   private cleanupPluginRuntimeRegistrations(pluginName: string): void {
     this.removePluginRoutes(pluginName)
 
     const namespaces = this.pluginCommunicationNamespacesByPlugin.get(pluginName)
-    if (!namespaces) return
-    for (const namespace of Array.from(namespaces)) {
-      this.unregisterPluginCommunicationNamespace(pluginName, namespace)
+    if (namespaces) {
+      for (const namespace of Array.from(namespaces)) {
+        this.unregisterPluginCommunicationNamespace(pluginName, namespace)
+      }
+    }
+
+    const unregisters = this.pluginAttendanceSchedulerUnregistersByPlugin.get(pluginName)
+    if (unregisters) {
+      for (const unregister of Array.from(unregisters)) {
+        unregister()
+      }
+      this.pluginAttendanceSchedulerUnregistersByPlugin.delete(pluginName)
     }
   }
 
@@ -1578,6 +1606,9 @@ export class MetaSheetServer {
       core: pluginApiSurface,
       services: {
         notification: notificationService,
+        attendanceScheduler: {
+          registerJob: (job: { name?: string; run(): Promise<unknown> }) => this.registerPluginAttendanceSchedulerJob(pluginName, job),
+        },
         automationRegistry,
         rbacProvisioning,
         platformAppInstances,
@@ -2007,10 +2038,12 @@ export class MetaSheetServer {
     // OFF → null → expiry only).
     try {
       const attendanceLeaderOptions = await resolveAttendanceSchedulerLeaderOptions()
+      const unscheduledReminderJob = resolveUnscheduledReminderJob()
+      const attendanceSchedulerJobs = unscheduledReminderJob ? [unscheduledReminderJob] : []
       const scheduler = startAttendanceScheduler({
         leaderOptions: attendanceLeaderOptions,
         intervalMs: resolveAttendanceSchedulerIntervalMs(),
-        reminderJob: resolveUnscheduledReminderJob(),
+        jobs: attendanceSchedulerJobs,
       })
       this.logger.info(scheduler ? 'Attendance scheduler initialized' : 'Attendance scheduler disabled (ATTENDANCE_SCHEDULER_ENABLED!=true)')
     } catch (e) {

--- a/packages/core-backend/src/services/AttendanceScheduler.ts
+++ b/packages/core-backend/src/services/AttendanceScheduler.ts
@@ -12,9 +12,9 @@
  * Default OFF: the scheduler starts only when ATTENDANCE_SCHEDULER_ENABLED=true. Until then, and until an
  * org sets compTimeFromOvertime.expiresInDays (which makes grants stamp expires_at), expiry never runs.
  *
- * Jobs per cycle (each independently guarded, one failing never affects the other):
+ * Jobs per cycle (each independently guarded, one failing never affects the others):
  *   - the comp-time EXPIRY job (④ C4, always present);
- *   - the ⑤ UNSCHEDULED-REMINDER job, present only when ATTENDANCE_UNSCHEDULED_REMINDER_ENABLED=true.
+ *   - registered secondary jobs such as the ⑤ UNSCHEDULED-REMINDER job and future A2 auto-shift jobs.
  * Reuses THIS scheduler base — never a second scheduler. The notification path lives in AttendanceNotifier
  * (no channels by default ⇒ the scheduler sends nothing externally; ⑤'s reminder record is internal).
  */
@@ -36,13 +36,19 @@ const MIN_INTERVAL_MS = 5000
 const DEFAULT_LOCK_TTL_MS = 30_000
 
 /** A time-driven attendance job the scheduler runs each cycle (alongside expiry). */
-export interface AttendanceReminderJob {
+export interface AttendanceSchedulerJob {
+  name?: string
   run(): Promise<unknown>
 }
 
+// Backward-compatible alias for the ⑤ unscheduled-reminder job type.
+export type AttendanceReminderJob = AttendanceSchedulerJob
+
 export interface AttendanceSchedulerOptions {
   expiryService?: AttendanceExpiryService
-  /** ⑤ optional second job; null/undefined ⇒ scheduler runs expiry only (④ behaviour unchanged). */
+  /** Additional jobs that run after expiry. Each job is isolated from its siblings. */
+  jobs?: AttendanceSchedulerJob[]
+  /** ⑤ legacy optional second job; folded into `jobs` for compatibility. */
   reminderJob?: AttendanceReminderJob | null
   intervalMs?: number
   leaderOptions?: AttendanceSchedulerLeaderOptions | null
@@ -70,7 +76,7 @@ export interface AttendanceSchedulerRuntimeOptions {
 export class AttendanceScheduler {
   private readonly logger: Logger
   private readonly expiryService: AttendanceExpiryService
-  private readonly reminderJob: AttendanceReminderJob | null
+  private jobs: AttendanceSchedulerJob[]
   private readonly intervalMs: number
   private readonly leaderOptions: AttendanceSchedulerLeaderOptions | null
   private readonly lockKey: string
@@ -88,7 +94,8 @@ export class AttendanceScheduler {
 
   constructor(options: AttendanceSchedulerOptions = {}) {
     this.expiryService = options.expiryService ?? getAttendanceExpiryService()
-    this.reminderJob = options.reminderJob ?? null
+    this.jobs = [...(options.jobs ?? [])]
+    if (options.reminderJob) this.jobs.push(options.reminderJob)
     this.intervalMs = Math.max(MIN_INTERVAL_MS, options.intervalMs ?? DEFAULT_INTERVAL_MS)
     this.leaderOptions = options.leaderOptions ?? null
     this.lockKey = this.leaderOptions?.lockKey ?? 'attendance-scheduler:leader'
@@ -168,23 +175,37 @@ export class AttendanceScheduler {
   }
 
   /**
-   * One scheduler cycle = the expiry job, then the optional ⑤ reminder job. Each is independently
-   * try/caught so a failure in one never skips the other. `tick()` stays the public expiry entry point
-   * (signature/return unchanged → ④ tests untouched); the reminder runs only when wired AND on the leader.
+   * One scheduler cycle = the expiry job, then registered secondary jobs (⑤ reminder, A2 auto-shift,
+   * etc.). Each is independently try/caught so a failure in one never skips the rest. `tick()` stays the
+   * public expiry entry point (signature/return unchanged → ④ tests untouched); secondary jobs run only
+   * when registered AND on the leader.
    */
   async runCycle(): Promise<void> {
     await this.tick()
-    if (this.reminderJob && this.isLeader) {
+    if (!this.isLeader) return
+    for (const job of [...this.jobs]) {
       try {
-        await this.reminderJob.run()
+        await job.run()
       } catch (error) {
-        this.logger.error(`Attendance unscheduled-reminder job failed: ${error instanceof Error ? error.message : String(error)}`)
+        const name = job.name || 'unnamed'
+        this.logger.error(`Attendance scheduler job ${name} failed: ${error instanceof Error ? error.message : String(error)}`)
       }
     }
   }
 
   get leader(): boolean {
     return this.isLeader
+  }
+
+  registerJob(job: AttendanceSchedulerJob): () => void {
+    const name = typeof job.name === 'string' ? job.name.trim() : ''
+    if (name) {
+      this.jobs = this.jobs.filter(existing => existing.name !== name)
+    }
+    this.jobs.push(job)
+    return () => {
+      this.jobs = this.jobs.filter(existing => existing !== job)
+    }
   }
 
   private async attemptLeadership(): Promise<void> {
@@ -289,6 +310,14 @@ export function startAttendanceScheduler(options: AttendanceSchedulerOptions = {
   return sharedScheduler
 }
 
+export function getSharedAttendanceScheduler(): AttendanceScheduler | null {
+  return sharedScheduler
+}
+
+export function registerAttendanceSchedulerJob(job: AttendanceSchedulerJob): (() => void) | null {
+  return sharedScheduler?.registerJob(job) ?? null
+}
+
 export function stopAttendanceScheduler(): void {
   if (sharedScheduler) {
     sharedScheduler.stop()
@@ -326,11 +355,15 @@ export function resolveAttendanceSchedulerIntervalMs(): number | undefined {
  * dispatch record — no external send until a channel is configured (C5). Lookahead defaults to 1 day and
  * is clamped inside the service.
  */
-export function resolveUnscheduledReminderJob(): AttendanceReminderJob | null {
+export function resolveUnscheduledReminderJob(): AttendanceSchedulerJob | null {
   if (process.env.ATTENDANCE_UNSCHEDULED_REMINDER_ENABLED !== 'true') return null
   const notifier = new AttendanceNotifier({ channels: createAttendanceNotifierChannelsFromEnv() })
-  return new UnscheduledReminderService({
+  const service = new UnscheduledReminderService({
     notifier,
     lookaheadDays: Number(process.env.ATTENDANCE_UNSCHEDULED_REMINDER_LOOKAHEAD_DAYS),
   })
+  return {
+    name: 'unscheduled-reminder',
+    run: () => service.run(),
+  }
 }

--- a/packages/core-backend/src/types/plugin.ts
+++ b/packages/core-backend/src/types/plugin.ts
@@ -945,6 +945,9 @@ export interface PluginServices {
   queue: QueueService        // Queue service instance
   storage: StorageService      // Storage service instance
   scheduler: SchedulerService    // Scheduler service instance
+  attendanceScheduler?: {
+    registerJob(job: { name?: string; run(): Promise<unknown> }): (() => void) | null
+  }
   notification: NotificationService // Notification service instance
   automationRegistry: PluginAutomationRegistryService
   rbacProvisioning: PluginRbacProvisioningService

--- a/packages/core-backend/tests/unit/attendance-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduler.test.ts
@@ -1,7 +1,9 @@
-import { afterEach, describe, expect, it } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 
 import {
   AttendanceScheduler,
+  registerAttendanceSchedulerJob,
+  resolveUnscheduledReminderJob,
   startAttendanceScheduler,
   stopAttendanceScheduler,
 } from '../../src/services/AttendanceScheduler'
@@ -10,6 +12,7 @@ import {
   AttendanceNotifier,
   createAttendanceNotifierChannelsFromEnv,
 } from '../../src/services/AttendanceNotifier'
+import { UnscheduledReminderService } from '../../src/services/UnscheduledReminderService'
 
 function fakeExpiryService(rows: ExpiredCompTimeBalance[], spy?: () => void): AttendanceExpiryService {
   return {
@@ -24,6 +27,8 @@ describe('AttendanceScheduler (④ C4)', () => {
   afterEach(() => {
     stopAttendanceScheduler()
     delete process.env.ATTENDANCE_SCHEDULER_ENABLED
+    delete process.env.ATTENDANCE_UNSCHEDULED_REMINDER_ENABLED
+    vi.restoreAllMocks()
   })
 
   it('tick (single-process leader) runs the expiry service and returns its result', async () => {
@@ -55,6 +60,77 @@ describe('AttendanceScheduler (④ C4)', () => {
     expect(scheduler).not.toBeNull()
     // Idempotent: the shared instance is returned, not a second scheduler.
     expect(startAttendanceScheduler({ expiryService: fakeExpiryService([]) })).toBe(scheduler)
+  })
+
+  it('runCycle runs registered jobs after expiry and isolates a failing job', async () => {
+    const calls: string[] = []
+    const scheduler = new AttendanceScheduler({
+      expiryService: fakeExpiryService([], () => { calls.push('expiry') }),
+      jobs: [
+        { name: 'first', async run() { calls.push('first') } },
+        { name: 'bad', async run() { calls.push('bad'); throw new Error('down') } },
+        { name: 'second', async run() { calls.push('second') } },
+      ],
+    })
+
+    await scheduler.runCycle()
+
+    expect(calls).toEqual(['expiry', 'first', 'bad', 'second'])
+  })
+
+  it('supports dynamic shared-scheduler job registration and unregistering', async () => {
+    process.env.ATTENDANCE_SCHEDULER_ENABLED = 'true'
+    const calls: string[] = []
+    const scheduler = startAttendanceScheduler({ expiryService: fakeExpiryService([]), intervalMs: 999_999 })
+    expect(scheduler).not.toBeNull()
+
+    const unregister = registerAttendanceSchedulerJob({
+      name: 'dynamic',
+      async run() { calls.push('dynamic') },
+    })
+    expect(typeof unregister).toBe('function')
+
+    await scheduler!.runCycle()
+    expect(calls).toEqual(['dynamic'])
+
+    unregister?.()
+    await scheduler!.runCycle()
+    expect(calls).toEqual(['dynamic'])
+  })
+
+  it('replaces named jobs without letting stale unregister handles remove the replacement', async () => {
+    const calls: string[] = []
+    const scheduler = new AttendanceScheduler({ expiryService: fakeExpiryService([]) })
+    const unregisterOld = scheduler.registerJob({
+      name: 'replaceable',
+      async run() { calls.push('old') },
+    })
+    scheduler.registerJob({
+      name: 'replaceable',
+      async run() { calls.push('new') },
+    })
+    unregisterOld()
+
+    await scheduler.runCycle()
+
+    expect(calls).toEqual(['new'])
+  })
+
+  it('resolves the unscheduled reminder job with one stable service instance', async () => {
+    process.env.ATTENDANCE_UNSCHEDULED_REMINDER_ENABLED = 'true'
+    const instances = new Set<unknown>()
+    vi.spyOn(UnscheduledReminderService.prototype, 'run').mockImplementation(function (this: UnscheduledReminderService) {
+      instances.add(this)
+      return Promise.resolve({ targetDate: '2026-06-11', claimed: 0, dispatched: 0 })
+    })
+
+    const job = resolveUnscheduledReminderJob()
+    expect(job?.name).toBe('unscheduled-reminder')
+
+    await job?.run()
+    await job?.run()
+
+    expect(instances.size).toBe(1)
   })
 })
 

--- a/packages/core-backend/tests/unit/plugin-runtime-teardown.test.ts
+++ b/packages/core-backend/tests/unit/plugin-runtime-teardown.test.ts
@@ -1,6 +1,19 @@
-import { describe, expect, it, vi } from 'vitest'
+import { afterEach, describe, expect, it, vi } from 'vitest'
 import request from 'supertest'
 import { MetaSheetServer } from '../../src/index'
+import {
+  startAttendanceScheduler,
+  stopAttendanceScheduler,
+} from '../../src/services/AttendanceScheduler'
+import type { AttendanceExpiryService } from '../../src/services/AttendanceExpiryService'
+
+function fakeExpiryService(): AttendanceExpiryService {
+  return {
+    async expireCompTimeBalances() {
+      return []
+    },
+  } as unknown as AttendanceExpiryService
+}
 
 function installLoadedPlugin(server: MetaSheetServer, name: string, plugin: Record<string, unknown>) {
   const loader = (server as unknown as { pluginLoader: { loadedPlugins: Map<string, unknown> } }).pluginLoader
@@ -18,6 +31,11 @@ function installLoadedPlugin(server: MetaSheetServer, name: string, plugin: Reco
 }
 
 describe('MetaSheetServer plugin runtime teardown', () => {
+  afterEach(() => {
+    stopAttendanceScheduler()
+    delete process.env.ATTENDANCE_SCHEDULER_ENABLED
+  })
+
   it('disables plugin-owned routes and communication namespaces on deactivate, then allows clean reactivation', async () => {
     const server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
     const pluginName = 'plugin-runtime-teardown-probe'
@@ -98,6 +116,50 @@ describe('MetaSheetServer plugin runtime teardown', () => {
     await expect(request((server as any).app).get(routePath)).resolves.toMatchObject({
       status: 404,
     })
+  })
+
+  it('cleans plugin-owned attendance scheduler jobs on deactivate and failed activation', async () => {
+    process.env.ATTENDANCE_SCHEDULER_ENABLED = 'true'
+    const scheduler = startAttendanceScheduler({ expiryService: fakeExpiryService(), intervalMs: 999_999 })
+    expect(scheduler).not.toBeNull()
+
+    const server = new MetaSheetServer({ port: 0, host: '127.0.0.1', pluginDirs: [] })
+    const pluginName = 'plugin-runtime-scheduler-probe'
+    let calls = 0
+
+    installLoadedPlugin(server, pluginName, {
+      async activate(context: any) {
+        context.services.attendanceScheduler.registerJob({
+          name: `${pluginName}:job`,
+          async run() { calls += 1 },
+        })
+      },
+      deactivate: vi.fn(),
+    })
+
+    await (server as any).activatePluginByName(pluginName)
+    await scheduler!.runCycle()
+    expect(calls).toBe(1)
+
+    await (server as any).deactivatePluginByName(pluginName)
+    await scheduler!.runCycle()
+    expect(calls).toBe(1)
+
+    installLoadedPlugin(server, pluginName, {
+      async activate(context: any) {
+        context.services.attendanceScheduler.registerJob({
+          name: `${pluginName}:job`,
+          async run() { calls += 1 },
+        })
+        throw new Error('boom')
+      },
+      deactivate: vi.fn(),
+    })
+
+    const state = await (server as any).activatePluginByName(pluginName)
+    expect(state).toMatchObject({ status: 'failed', error: 'boom' })
+    await scheduler!.runCycle()
+    expect(calls).toBe(1)
   })
 
   it('rejects communication namespace collisions without deleting the original owner', async () => {


### PR DESCRIPTION
## Summary

A2-2a prerequisite slice for auto-shift auto-write: make the existing attendance scheduler a composite job host.

- Adds `AttendanceSchedulerJob` and `jobs[]` support while keeping `tick()` as the expiry-only public entry point.
- Runs secondary jobs after expiry, only on the leader, with per-job error isolation.
- Exposes `services.attendanceScheduler.registerJob(...)` to plugins through the existing plugin services surface.
- Keeps the ⑤ unscheduled-reminder job on the same scheduler base; no second scheduler.
- Adds unit coverage for job isolation, dynamic registration/unregistration, and stale unregister handles after named-job replacement.

## Scope boundaries

This is intentionally infrastructure-only:

- no `autoShiftMatching.mode='auto'` enablement;
- no auto-write assignment job;
- no DB migration or run-summary ledger;
- no frontend/OpenAPI changes;
- no attendance assignment writes.

## Verification

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-scheduler.test.ts --reporter=dot` → 9/9 pass
- `pnpm --filter @metasheet/core-backend build` → pass
- `pnpm --filter @metasheet/core-backend test:unit` → 224 files / 2870 tests pass
- `git diff --check` → pass

## Follow-up

A2-2b can register the plugin-local auto-shift write job against this scheduler surface, after its own run-ledger/system-actor decisions are locked.




## Subagent review

Gibbs reviewed the initial PR, found two P2s (plugin-owned scheduler job cleanup and unscheduled-reminder stable instance), and re-reviewed the updated head as APPROVE.
