### PR TITLE
feat(attendance): add auto-shift auto-write run ledger

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260610140000_create_attendance_auto_shift_auto_write_ledger.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260610140000_create_attendance_auto_shift_auto_write_ledger.ts
@@ -1,0 +1,119 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists, createIndexIfNotExists } from './_patterns'
+
+const DEFAULT_ORG_ID = 'default'
+const RUNS = 'attendance_auto_shift_auto_write_runs'
+const ITEMS = 'attendance_auto_shift_auto_write_run_items'
+
+// A2-2 auto-shift auto-write ledger foundation. Dormant schema only: no scheduler job and no
+// assignment writes are wired here. The run table is the durable claim/audit parent; item rows record
+// the per-user/day outcome so a later rollback/cleanup can target producer_run_id precisely instead of
+// broad producer_type predicates.
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  const runsExists = await checkTableExists(db, RUNS)
+  if (!runsExists) {
+    await db.schema
+      .createTable(RUNS)
+      .ifNotExists()
+      .addColumn('id', 'uuid', col => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('org_id', 'text', col => col.notNull().defaultTo(DEFAULT_ORG_ID))
+      .addColumn('source', 'text', col => col.notNull().defaultTo('scheduler'))
+      .addColumn('status', 'text', col => col.notNull().defaultTo('running'))
+      .addColumn('target_from', 'date', col => col.notNull())
+      .addColumn('target_to', 'date', col => col.notNull())
+      .addColumn('config_snapshot', 'jsonb', col => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('scanned_count', 'integer', col => col.notNull().defaultTo(0))
+      .addColumn('candidate_count', 'integer', col => col.notNull().defaultTo(0))
+      .addColumn('applied_count', 'integer', col => col.notNull().defaultTo(0))
+      .addColumn('skipped_count', 'integer', col => col.notNull().defaultTo(0))
+      .addColumn('error_count', 'integer', col => col.notNull().defaultTo(0))
+      .addColumn('error_message', 'text')
+      .addColumn('started_at', 'timestamptz', col => col.notNull().defaultTo(sql`now()`))
+      .addColumn('finished_at', 'timestamptz')
+      .addColumn('created_at', 'timestamptz', col => col.notNull().defaultTo(sql`now()`))
+      .addCheckConstraint('chk_attendance_auto_shift_runs_status', sql`status IN ('running', 'succeeded', 'partial', 'failed')`)
+      .addCheckConstraint('chk_attendance_auto_shift_runs_source_nonempty', sql`source <> ''`)
+      .addCheckConstraint('chk_attendance_auto_shift_runs_window', sql`target_from <= target_to`)
+      .addCheckConstraint(
+        'chk_attendance_auto_shift_runs_finished_state',
+        sql`(status = 'running' AND finished_at IS NULL) OR (status <> 'running' AND finished_at IS NOT NULL)`,
+      )
+      .addCheckConstraint(
+        'chk_attendance_auto_shift_runs_counts_nonnegative',
+        sql`scanned_count >= 0 AND candidate_count >= 0 AND applied_count >= 0 AND skipped_count >= 0 AND error_count >= 0`,
+      )
+      .execute()
+  }
+
+  // Durable active-run claim: a later scheduler tick can INSERT a running row and let this partial
+  // unique index reject an overlapping in-flight run for the same org/source/window.
+  await createIndexIfNotExists(
+    db,
+    'uq_attendance_auto_shift_runs_active_window',
+    RUNS,
+    ['org_id', 'source', 'target_from', 'target_to'],
+    { unique: true, where: sql`status = 'running'` },
+  )
+  await createIndexIfNotExists(db, 'uq_attendance_auto_shift_runs_id_org', RUNS, ['id', 'org_id'], { unique: true })
+  await createIndexIfNotExists(db, 'idx_attendance_auto_shift_runs_org_started', RUNS, ['org_id', 'started_at'])
+  await createIndexIfNotExists(db, 'idx_attendance_auto_shift_runs_status', RUNS, ['org_id', 'status'])
+
+  const itemsExists = await checkTableExists(db, ITEMS)
+  if (!itemsExists) {
+    await db.schema
+      .createTable(ITEMS)
+      .ifNotExists()
+      .addColumn('id', 'uuid', col => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('run_id', 'uuid', col => col.notNull())
+      .addColumn('org_id', 'text', col => col.notNull().defaultTo(DEFAULT_ORG_ID))
+      .addColumn('user_id', 'text', col => col.notNull())
+      .addColumn('work_date', 'date', col => col.notNull())
+      .addColumn('candidate_shift_id', 'uuid')
+      .addColumn('confidence', 'text')
+      .addColumn('status', 'text', col => col.notNull())
+      .addColumn('reason', 'text')
+      .addColumn('assignment_id', 'uuid')
+      .addColumn('evidence_event_ids', 'jsonb', col => col.notNull().defaultTo(sql`'[]'::jsonb`))
+      .addColumn('error_message', 'text')
+      .addColumn('created_at', 'timestamptz', col => col.notNull().defaultTo(sql`now()`))
+      .addCheckConstraint('chk_attendance_auto_shift_run_items_status', sql`status IN ('applied', 'skipped', 'error')`)
+      .addCheckConstraint('chk_attendance_auto_shift_run_items_confidence', sql`confidence IS NULL OR confidence IN ('high', 'medium', 'low')`)
+      .addCheckConstraint('chk_attendance_auto_shift_run_items_evidence_array', sql`jsonb_typeof(evidence_event_ids) = 'array'`)
+      .addCheckConstraint('chk_attendance_auto_shift_run_items_assignment_state', sql`(status = 'applied') = (assignment_id IS NOT NULL)`)
+      .addCheckConstraint(
+        'chk_attendance_auto_shift_run_items_reason',
+        sql`status = 'applied' OR reason IS NOT NULL OR error_message IS NOT NULL`,
+      )
+      .execute()
+  }
+
+  await sql`ALTER TABLE attendance_auto_shift_auto_write_run_items DROP CONSTRAINT IF EXISTS fk_attendance_auto_shift_run_items_run_org`.execute(db)
+  await db.schema
+    .alterTable(ITEMS)
+    .addForeignKeyConstraint(
+      'fk_attendance_auto_shift_run_items_run_org',
+      ['run_id', 'org_id'],
+      RUNS,
+      ['id', 'org_id'],
+    )
+    .onDelete('cascade')
+    .execute()
+
+  await createIndexIfNotExists(
+    db,
+    'uq_attendance_auto_shift_run_items_user_day',
+    ITEMS,
+    ['run_id', 'user_id', 'work_date'],
+    { unique: true },
+  )
+  await createIndexIfNotExists(db, 'idx_attendance_auto_shift_run_items_user_day', ITEMS, ['org_id', 'user_id', 'work_date'])
+  await createIndexIfNotExists(db, 'idx_attendance_auto_shift_run_items_run_status', ITEMS, ['run_id', 'status'])
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable(ITEMS).ifExists().execute()
+  await db.schema.dropTable(RUNS).ifExists().execute()
+}

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -4777,6 +4777,95 @@ attendanceIntegrationDescribe(
     }
   })
 
+  it('A2 auto-shift auto-write ledger — active-run claim and item invariants are DB-enforced (latent schema)', async () => {
+    const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+    if (!dbUrl) return
+    const pool = new Pool({ connectionString: dbUrl })
+    const runSuffix = Date.now().toString(36)
+    const orgId = `a2-ledger-${runSuffix}`
+    const userId = `a2-user-${runSuffix}`
+    const targetFrom = '2026-06-15'
+    const targetTo = '2026-06-16'
+    let runId: string | undefined
+    const rejects = async (text: string, params: unknown[], code: string, label: string) => {
+      let err: { code?: string } | null = null
+      try { await pool.query(text, params) } catch (e) { err = e as { code?: string } }
+      expect({ label, code: err?.code }).toEqual({ label, code })
+    }
+    try {
+      await requireAttendanceTable(pool, 'attendance_auto_shift_auto_write_runs')
+      await requireAttendanceTable(pool, 'attendance_auto_shift_auto_write_run_items')
+
+      const runInsert = `INSERT INTO attendance_auto_shift_auto_write_runs
+        (org_id, source, status, target_from, target_to, config_snapshot)
+        VALUES ($1, 'scheduler', 'running', $2, $3, '{"autoWrite":{"enabled":true}}'::jsonb)
+        RETURNING id`
+      const insertedRun = await pool.query(runInsert, [orgId, targetFrom, targetTo])
+      runId = insertedRun.rows[0]?.id as string | undefined
+      expect(runId).toBeTruthy()
+
+      // The partial UNIQUE claim prevents a second in-flight scheduler run for the same org/source/window.
+      await rejects(runInsert, [orgId, targetFrom, targetTo], '23505', 'duplicate running window must be rejected')
+
+      // The same window can be represented after the prior run is terminal; the active claim is running-only.
+      const finishedRun = await pool.query(
+        `INSERT INTO attendance_auto_shift_auto_write_runs
+           (org_id, source, status, target_from, target_to, config_snapshot, finished_at)
+         VALUES ($1, 'scheduler', 'succeeded', $2, $3, '{}'::jsonb, now())
+         RETURNING id`,
+        [orgId, targetFrom, targetTo],
+      )
+      expect(finishedRun.rows[0]?.id).toBeTruthy()
+
+      const itemInsert = `INSERT INTO attendance_auto_shift_auto_write_run_items
+        (run_id, org_id, user_id, work_date, candidate_shift_id, confidence, status, assignment_id, evidence_event_ids)
+        VALUES ($1, $2, $3, $4, '00000000-0000-4000-8000-000000000111', 'high', 'applied',
+                '00000000-0000-4000-8000-000000000222', '[]'::jsonb)
+        RETURNING id`
+      const item = await pool.query(itemInsert, [runId, orgId, userId, targetFrom])
+      expect(item.rows[0]?.id).toBeTruthy()
+      await rejects(itemInsert, [runId, orgId, userId, targetFrom], '23505', 'duplicate item user/day must be rejected')
+
+      await rejects(
+        `INSERT INTO attendance_auto_shift_auto_write_run_items
+           (run_id, org_id, user_id, work_date, status, reason)
+         VALUES ('00000000-0000-4000-8000-000000000333', $1, $2, $3, 'skipped', 'no candidate')`,
+        [orgId, `${userId}-fk`, targetFrom],
+        '23503',
+        'run_id must reference a real run',
+      )
+      await rejects(
+        `INSERT INTO attendance_auto_shift_auto_write_run_items
+           (run_id, org_id, user_id, work_date, status, reason)
+         VALUES ($1, $2, $3, $4, 'skipped', 'wrong tenant')`,
+        [runId, `${orgId}-other`, `${userId}-tenant`, targetFrom],
+        '23503',
+        'item org_id must match parent run org_id',
+      )
+
+      const badRunInsert = `INSERT INTO attendance_auto_shift_auto_write_runs
+        (org_id, source, status, target_from, target_to, config_snapshot, scanned_count, finished_at)
+        VALUES ($1, $2, $3, $4, $5, '{}'::jsonb, $6, $7)`
+      await rejects(badRunInsert, [orgId, 'scheduler-bad-status', 'bogus', targetFrom, targetTo, 0, new Date()], '23514', 'run status enum must be valid')
+      await rejects(badRunInsert, [orgId, 'scheduler-bad-window', 'running', targetTo, targetFrom, 0, null], '23514', 'target window must be ordered')
+      await rejects(badRunInsert, [orgId, 'scheduler-bad-count', 'running', targetFrom, targetTo, -1, null], '23514', 'run counts must be nonnegative')
+      await rejects(badRunInsert, [orgId, 'scheduler-bad-finished', 'succeeded', targetFrom, targetTo, 0, null], '23514', 'terminal run must have finished_at')
+
+      const badItemInsert = `INSERT INTO attendance_auto_shift_auto_write_run_items
+        (run_id, org_id, user_id, work_date, confidence, status, assignment_id, evidence_event_ids, reason, error_message)
+        VALUES ($1, $2, $3, $4, $5, $6, $7, $8::jsonb, $9, $10)`
+      await rejects(badItemInsert, [runId, orgId, `${userId}-a`, targetTo, 'none', 'skipped', null, '[]', 'low confidence', null], '23514', 'confidence enum must be valid')
+      await rejects(badItemInsert, [runId, orgId, `${userId}-b`, targetTo, 'high', 'bogus', null, '[]', 'low confidence', null], '23514', 'item status enum must be valid')
+      await rejects(badItemInsert, [runId, orgId, `${userId}-c`, targetTo, 'high', 'applied', null, '[]', null, null], '23514', 'applied item must carry assignment_id')
+      await rejects(badItemInsert, [runId, orgId, `${userId}-d`, targetTo, 'high', 'skipped', null, '{}', 'low confidence', null], '23514', 'evidence_event_ids must be an array')
+      await rejects(badItemInsert, [runId, orgId, `${userId}-e`, targetTo, 'high', 'skipped', null, '[]', null, null], '23514', 'skipped/error item must explain the outcome')
+      await rejects(badItemInsert, [runId, orgId, `${userId}-f`, targetTo, 'high', 'skipped', '00000000-0000-4000-8000-000000000444', '[]', 'no write', null], '23514', 'skipped item must not carry assignment_id')
+    } finally {
+      await pool.query('DELETE FROM attendance_auto_shift_auto_write_runs WHERE org_id = $1', [orgId]).catch(() => undefined)
+      await pool.end().catch(() => undefined)
+    }
+  })
+
   it('④ C2 — overtime approval credits a comp-time grant lot (opt-in OFF=no credit; ON=lot+event; replay no double-credit)', async () => {
     if (!baseUrl) return
     const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL

--- a/packages/core-backend/tests/unit/attendance-auto-shift-auto-write-ledger-migration.test.ts
+++ b/packages/core-backend/tests/unit/attendance-auto-shift-auto-write-ledger-migration.test.ts
@@ -1,0 +1,48 @@
+import { readFileSync } from 'fs'
+import { resolve } from 'path'
+import { describe, expect, it } from 'vitest'
+
+const MIGRATION = resolve(
+  __dirname,
+  '../../src/db/migrations/zzzz20260610140000_create_attendance_auto_shift_auto_write_ledger.ts',
+)
+const src = readFileSync(MIGRATION, 'utf8')
+
+describe('A2 auto-shift auto-write run ledger migration', () => {
+  it('creates the dormant run parent and per-item audit tables', () => {
+    expect(src).toContain("'attendance_auto_shift_auto_write_runs'")
+    expect(src).toContain("'attendance_auto_shift_auto_write_run_items'")
+    expect(src).toMatch(/dropTable\(ITEMS\)[\s\S]*dropTable\(RUNS\)/)
+  })
+
+  it('locks the active-run claim as a partial unique index over org/source/window', () => {
+    expect(src).toMatch(/uq_attendance_auto_shift_runs_active_window[\s\S]*\['org_id', 'source', 'target_from', 'target_to'\][\s\S]*unique: true/)
+    expect(src).toContain("where: sql`status = 'running'`")
+  })
+
+  it('keeps run state well-formed with DB CHECK constraints', () => {
+    expect(src).toContain("status IN ('running', 'succeeded', 'partial', 'failed')")
+    expect(src).toContain("source <> ''")
+    expect(src).toContain('target_from <= target_to')
+    expect(src).toContain("(status = 'running' AND finished_at IS NULL) OR (status <> 'running' AND finished_at IS NOT NULL)")
+    expect(src).toContain('scanned_count >= 0 AND candidate_count >= 0 AND applied_count >= 0 AND skipped_count >= 0 AND error_count >= 0')
+  })
+
+  it('links each item to its run and de-duplicates user/day outcomes inside a run', () => {
+    expect(src).toContain("addColumn('run_id'")
+    expect(src).toMatch(/uq_attendance_auto_shift_runs_id_org[\s\S]*\['id', 'org_id'\][\s\S]*unique: true/)
+    expect(src).toContain("'fk_attendance_auto_shift_run_items_run_org'")
+    expect(src).toContain("['run_id', 'org_id']")
+    expect(src).toContain("['id', 'org_id']")
+    expect(src).toContain(".onDelete('cascade')")
+    expect(src).toMatch(/uq_attendance_auto_shift_run_items_user_day[\s\S]*\['run_id', 'user_id', 'work_date'\][\s\S]*unique: true/)
+  })
+
+  it('locks item outcome invariants for later rollback and audit semantics', () => {
+    expect(src).toContain("status IN ('applied', 'skipped', 'error')")
+    expect(src).toContain("confidence IS NULL OR confidence IN ('high', 'medium', 'low')")
+    expect(src).toContain("jsonb_typeof(evidence_event_ids) = 'array'")
+    expect(src).toContain("(status = 'applied') = (assignment_id IS NOT NULL)")
+    expect(src).toContain("status = 'applied' OR reason IS NOT NULL OR error_message IS NOT NULL")
+  })
+})


### PR DESCRIPTION
## Summary
- Add dormant A2 auto-shift auto-write run ledger tables: `attendance_auto_shift_auto_write_runs` and `attendance_auto_shift_auto_write_run_items`.
- Lock DB-level invariants for active-run claiming, run state/counts, item status/confidence/evidence shape, and per-run user/day de-dupe.
- Add always-on migration source guard plus a real-DB attendance integration test for the ledger constraints.

## Scope
- Dormant schema foundation only.
- Does not register a scheduler job, enable `mode: auto`, or write `attendance_shift_assignments`.
- Runtime auto-write remains a later A2 slice that will use this ledger for claim/audit/rollback targeting.

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/attendance-auto-shift-auto-write-ledger-migration.test.ts --reporter=dot`
- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend test:integration:attendance` (local DB env absent: 4 files / 123 tests skipped; PR CI should run the real Postgres attendance gate)
- `git diff --check`
