### PR TITLE
feat(multitable): add start approval automation bridge

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -196,6 +196,7 @@ jobs:
             tests/integration/multitable-automation-retry.test.ts \
             tests/integration/multitable-automation-jobs.test.ts \
             tests/integration/multitable-automation-suspend-resume.test.ts \
+            tests/integration/multitable-automation-start-approval.test.ts \
             --reporter=dot
 
       - name: Start core backend (background)

--- a/packages/core-backend/src/db/migrations/zzzz20260610150000_create_automation_approval_bridges.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260610150000_create_automation_approval_bridges.ts
@@ -74,7 +74,7 @@ export async function up(db: Kysely<unknown>): Promise<void> {
         approval_request_no TEXT,
         approval_template_id TEXT NOT NULL,
         approval_published_definition_id TEXT,
-        idempotency_key TEXT NOT NULL UNIQUE,
+        idempotency_key TEXT NOT NULL,
         status TEXT NOT NULL DEFAULT 'pending',
         outcome TEXT,
         action_fingerprint JSONB NOT NULL,
@@ -104,6 +104,16 @@ export async function up(db: Kysely<unknown>): Promise<void> {
         WHERE approval_instance_id IS NOT NULL
     `.execute(db)
   }
+
+  await sql`
+    ALTER TABLE multitable_automation_approval_bridges
+    DROP CONSTRAINT IF EXISTS multitable_automation_approval_bridges_idempotency_key_key
+  `.execute(db)
+  await sql`
+    CREATE UNIQUE INDEX IF NOT EXISTS uniq_mt_auto_approval_bridges_active_idempotency
+      ON multitable_automation_approval_bridges (idempotency_key)
+      WHERE status <> 'failed' OR approval_instance_id IS NOT NULL
+  `.execute(db)
 
   await sql`
     ALTER TABLE multitable_automation_approval_bridges

--- a/packages/core-backend/src/db/migrations/zzzz20260610150000_create_automation_approval_bridges.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260610150000_create_automation_approval_bridges.ts
@@ -1,0 +1,142 @@
+/**
+ * Migration: W6-1 — automation start_approval bridge
+ *
+ * Purpose: persist the durable linkage between one automation action job and
+ * one approval-product instance. Completion is driven by W5 approval terminal
+ * events, not by an admin resume token.
+ * Tables: multitable_automation_approval_bridges (new) and action-type CHECK widen.
+ * Breaking: No — new table plus additive action enum.
+ */
+
+import { sql, type Kysely } from 'kysely'
+import { checkTableExists } from './_patterns'
+
+export const AUTOMATION_ACTION_TYPES_WITH_START_APPROVAL = [
+  'notify',
+  'update_field',
+  'update_record',
+  'create_record',
+  'send_webhook',
+  'send_notification',
+  'send_email',
+  'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
+  'lock_record',
+  'wait_for_callback',
+  'condition_branch',
+  'start_approval',
+] as const
+
+export const AUTOMATION_ACTION_TYPES_BEFORE_START_APPROVAL = [
+  'notify',
+  'update_field',
+  'update_record',
+  'create_record',
+  'send_webhook',
+  'send_notification',
+  'send_email',
+  'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
+  'lock_record',
+  'wait_for_callback',
+  'condition_branch',
+] as const
+
+function quotedActions(actions: readonly string[]): string {
+  return actions.map((action) => `'${action}'`).join(', ')
+}
+
+async function replaceAutomationActionTypeConstraint(
+  db: Kysely<unknown>,
+  actions: readonly string[],
+): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_action_type`.execute(db)
+  await sql.raw(`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_action_type
+    CHECK (action_type IN (${quotedActions(actions)}))
+  `).execute(db)
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  const exists = await checkTableExists(db, 'multitable_automation_approval_bridges')
+  if (!exists) {
+    await sql`
+      CREATE TABLE IF NOT EXISTS multitable_automation_approval_bridges (
+        id TEXT PRIMARY KEY,
+        execution_id TEXT NOT NULL,
+        root_execution_id TEXT NOT NULL,
+        rule_id TEXT NOT NULL,
+        sheet_id TEXT,
+        record_id TEXT,
+        step_index INTEGER NOT NULL,
+        approval_instance_id TEXT,
+        approval_request_no TEXT,
+        approval_template_id TEXT NOT NULL,
+        approval_published_definition_id TEXT,
+        idempotency_key TEXT NOT NULL UNIQUE,
+        status TEXT NOT NULL DEFAULT 'pending',
+        outcome TEXT,
+        action_fingerprint JSONB NOT NULL,
+        trigger_event JSONB,
+        created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+        completed_at TIMESTAMPTZ,
+        resumed_at TIMESTAMPTZ
+      )
+    `.execute(db)
+
+    await sql`
+      CREATE INDEX IF NOT EXISTS idx_mt_auto_approval_bridges_execution_id
+        ON multitable_automation_approval_bridges (execution_id)
+    `.execute(db)
+    await sql`
+      CREATE INDEX IF NOT EXISTS idx_mt_auto_approval_bridges_root_step
+        ON multitable_automation_approval_bridges (root_execution_id, step_index, approval_template_id)
+    `.execute(db)
+    await sql`
+      CREATE INDEX IF NOT EXISTS idx_mt_auto_approval_bridges_pending_approval
+        ON multitable_automation_approval_bridges (approval_instance_id)
+        WHERE status = 'pending'
+    `.execute(db)
+    await sql`
+      CREATE UNIQUE INDEX IF NOT EXISTS uniq_mt_auto_approval_bridges_approval_instance
+        ON multitable_automation_approval_bridges (approval_instance_id)
+        WHERE approval_instance_id IS NOT NULL
+    `.execute(db)
+  }
+
+  await sql`
+    ALTER TABLE multitable_automation_approval_bridges
+    DROP CONSTRAINT IF EXISTS chk_mt_auto_approval_bridge_status
+  `.execute(db)
+  await sql`
+    ALTER TABLE multitable_automation_approval_bridges
+    ADD CONSTRAINT chk_mt_auto_approval_bridge_status
+    CHECK (status IN ('creating', 'pending', 'resumed', 'failed'))
+  `.execute(db)
+  await sql`
+    ALTER TABLE multitable_automation_approval_bridges
+    DROP CONSTRAINT IF EXISTS chk_mt_auto_approval_bridge_outcome
+  `.execute(db)
+  await sql`
+    ALTER TABLE multitable_automation_approval_bridges
+    ADD CONSTRAINT chk_mt_auto_approval_bridge_outcome
+    CHECK (outcome IS NULL OR outcome IN ('approved', 'rejected', 'revoked', 'cancelled'))
+  `.execute(db)
+  await sql`
+    ALTER TABLE multitable_automation_approval_bridges
+    DROP CONSTRAINT IF EXISTS chk_mt_auto_approval_bridge_claimable_has_approval
+  `.execute(db)
+  await sql`
+    ALTER TABLE multitable_automation_approval_bridges
+    ADD CONSTRAINT chk_mt_auto_approval_bridge_claimable_has_approval
+    CHECK (status NOT IN ('pending', 'resumed') OR approval_instance_id IS NOT NULL)
+  `.execute(db)
+
+  await replaceAutomationActionTypeConstraint(db, AUTOMATION_ACTION_TYPES_WITH_START_APPROVAL)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await sql`DROP TABLE IF EXISTS multitable_automation_approval_bridges`.execute(db)
+  await replaceAutomationActionTypeConstraint(db, AUTOMATION_ACTION_TYPES_BEFORE_START_APPROVAL)
+}

--- a/packages/core-backend/src/db/types.ts
+++ b/packages/core-backend/src/db/types.ts
@@ -112,6 +112,7 @@ export interface Database {
   automation_rules: AutomationRulesTable
   multitable_automation_jobs: MultitableAutomationJobsTable
   multitable_automation_suspensions: MultitableAutomationSuspensionsTable
+  multitable_automation_approval_bridges: MultitableAutomationApprovalBridgesTable
   multitable_automation_executions: MultitableAutomationExecutionsTable
   multitable_charts: MultitableChartsTable
   multitable_dashboards: MultitableDashboardsTable
@@ -1311,6 +1312,29 @@ export interface MultitableAutomationSuspensionsTable {
   trigger_event: JsonValueColumn
   status: string
   created_at: CreatedAt
+  resumed_at: Date | string | null
+}
+
+/** W6-1 start_approval bridge — approval completion resumes an automation job. */
+export interface MultitableAutomationApprovalBridgesTable {
+  id: string
+  execution_id: string
+  root_execution_id: string
+  rule_id: string
+  sheet_id: string | null
+  record_id: string | null
+  step_index: number
+  approval_instance_id: string | null
+  approval_request_no: string | null
+  approval_template_id: string
+  approval_published_definition_id: string | null
+  idempotency_key: string
+  status: string
+  outcome: string | null
+  action_fingerprint: JsonValueColumn
+  trigger_event: JsonValueColumn
+  created_at: CreatedAt
+  completed_at: Date | string | null
   resumed_at: Date | string | null
 }
 

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -14,6 +14,7 @@ export type AutomationActionType =
   | 'lock_record'
   | 'wait_for_callback'
   | 'condition_branch'
+  | 'start_approval'
 
 export const ALL_ACTION_TYPES: AutomationActionType[] = [
   'update_record',
@@ -26,6 +27,7 @@ export const ALL_ACTION_TYPES: AutomationActionType[] = [
   'lock_record',
   'wait_for_callback',
   'condition_branch',
+  'start_approval',
 ]
 
 /** Config shape for update_record */
@@ -102,6 +104,21 @@ export interface LockRecordConfig {
  */
 export interface WaitForCallbackConfig {
   reason?: 'external_event'
+}
+
+/**
+ * Config shape for start_approval (W6-1 approval bridge).
+ *
+ * v1 creates one approval instance from a published approval template, suspends
+ * the automation job, and resumes from W5 approval completion events. Form data
+ * is explicit mapping only; result backwrite is intentionally absent.
+ */
+export interface StartApprovalConfig {
+  templateId: string
+  formDataMapping: Record<string, string>
+  requester?: {
+    mode?: 'trigger_actor' | 'rule_creator'
+  }
 }
 
 export interface AutomationAction {

--- a/packages/core-backend/src/multitable/automation-approval-bridge-service.ts
+++ b/packages/core-backend/src/multitable/automation-approval-bridge-service.ts
@@ -155,7 +155,7 @@ export class AutomationApprovalBridgeService {
     private readonly approvalProductService: ApprovalProductService = new ApprovalProductService(),
   ) {}
 
-  async hasBridgeForAnyExecution(executionIds: string[]): Promise<boolean> {
+  async hasCreatedApprovalForAnyExecution(executionIds: string[]): Promise<boolean> {
     const ids = Array.from(new Set(executionIds.filter(Boolean)))
     if (ids.length === 0) return false
     const row = await db
@@ -165,6 +165,7 @@ export class AutomationApprovalBridgeService {
         eb('execution_id', 'in', ids),
         eb('root_execution_id', 'in', ids),
       ]))
+      .where('approval_instance_id', 'is not', null)
       .executeTakeFirst()
     return row != null
   }
@@ -182,8 +183,12 @@ export class AutomationApprovalBridgeService {
 
     const existing = await db
       .selectFrom('multitable_automation_approval_bridges')
-      .select(['id', 'approval_instance_id'])
+      .select(['id', 'approval_instance_id', 'status'])
       .where('idempotency_key', '=', idempotencyKey)
+      .where((eb) => eb.or([
+        eb('status', '<>', 'failed'),
+        eb('approval_instance_id', 'is not', null),
+      ]))
       .executeTakeFirst()
     if (existing) {
       throw new ServiceError('start_approval already created an approval for this execution step', 409, 'START_APPROVAL_DUPLICATE')

--- a/packages/core-backend/src/multitable/automation-approval-bridge-service.ts
+++ b/packages/core-backend/src/multitable/automation-approval-bridge-service.ts
@@ -14,7 +14,8 @@ import { ServiceError } from '../services/ApprovalBridgeService'
 import { ApprovalProductService } from '../services/ApprovalProductService'
 import type { ApprovalCompletionEventV1, ApprovalCompletionOutcome } from '../services/ApprovalCompletionEvent'
 import type { UnifiedApprovalDTO } from '../services/approval-bridge-types'
-import { isAdmin, listUserPermissions, userHasPermission } from '../rbac/service'
+import { isAdmin } from '../rbac/service'
+import { filterPermissionCodesByNamespaceAdmission } from '../rbac/namespace-admission'
 import { redactValue } from './automation-log-redact'
 import { AutomationJobService } from './automation-job-service'
 import { computeActionFingerprint, type ActionFingerprint } from './automation-suspension-service'
@@ -93,6 +94,26 @@ function hasPermissionCode(permissionCodes: string[], permissionCode: string): b
   if (permissionCodes.includes(permissionCode) || permissionCodes.includes('*:*')) return true
   const resource = permissionCode.split(':')[0]
   return resource ? permissionCodes.includes(`${resource}:*`) : false
+}
+
+async function listRbacPermissionCodes(userId: string): Promise<string[]> {
+  const result = await query<{ code: string }>(
+    `SELECT DISTINCT permission_code AS code FROM (
+       SELECT up.permission_code
+         FROM user_permissions up
+        WHERE up.user_id = $1
+       UNION ALL
+       SELECT rp.permission_code
+         FROM user_roles ur
+         JOIN role_permissions rp ON rp.role_id = ur.role_id
+        WHERE ur.user_id = $1
+     ) t`,
+    [userId],
+  )
+  return filterPermissionCodesByNamespaceAdmission(
+    userId,
+    result.rows.map((row) => row.code),
+  )
 }
 
 function rootIdFor(execution: Pick<AutomationExecution, 'id' | 'rerunOfExecutionId'> & { rootExecutionId?: string }): string {
@@ -353,11 +374,10 @@ export class AutomationApprovalBridgeService {
       throw new ServiceError('start_approval requester user not found or inactive', 404, 'START_APPROVAL_REQUESTER_NOT_FOUND')
     }
 
-    const permissions = await listUserPermissions(userId)
+    const permissions = await listRbacPermissionCodes(userId)
     const roles = await this.loadUserRoles(userId, user.role)
     const allowed = await isAdmin(userId)
       || hasPermissionCode(permissions, 'approvals:write')
-      || await userHasPermission(userId, 'approvals:write')
     if (!allowed) {
       throw new ServiceError('start_approval requester lacks approvals:write', 403, 'START_APPROVAL_PERMISSION_DENIED')
     }

--- a/packages/core-backend/src/multitable/automation-approval-bridge-service.ts
+++ b/packages/core-backend/src/multitable/automation-approval-bridge-service.ts
@@ -1,0 +1,410 @@
+/**
+ * Automation Approval Bridge Service — W6-1 start_approval runtime.
+ *
+ * Owns the durable linkage between one automation job and one approval-product
+ * instance. It deliberately does not execute the automation tail; AutomationService
+ * claims bridge completion and calls AutomationExecutor.continueExecution().
+ */
+
+import { randomUUID } from 'crypto'
+import { db } from '../db/db'
+import { query } from '../db/pg'
+import { toJsonValue } from '../db/type-helpers'
+import { ServiceError } from '../services/ApprovalBridgeService'
+import { ApprovalProductService } from '../services/ApprovalProductService'
+import type { ApprovalCompletionEventV1, ApprovalCompletionOutcome } from '../services/ApprovalCompletionEvent'
+import type { UnifiedApprovalDTO } from '../services/approval-bridge-types'
+import { isAdmin, listUserPermissions, userHasPermission } from '../rbac/service'
+import { redactValue } from './automation-log-redact'
+import { AutomationJobService } from './automation-job-service'
+import { computeActionFingerprint, type ActionFingerprint } from './automation-suspension-service'
+import {
+  lookupTemplateValue,
+  renderAutomationTemplate,
+  type AutomationExecution,
+  type AutomationStepResult,
+  type ExecutionContext,
+} from './automation-executor'
+import type { AutomationAction, StartApprovalConfig } from './automation-actions'
+
+type BridgeStatus = 'creating' | 'pending' | 'resumed' | 'failed'
+
+export interface AutomationApprovalBridgeRow {
+  id: string
+  executionId: string
+  rootExecutionId: string
+  ruleId: string
+  sheetId: string | null
+  recordId: string | null
+  stepIndex: number
+  approvalInstanceId: string | null
+  approvalRequestNo: string | null
+  approvalTemplateId: string
+  approvalPublishedDefinitionId: string | null
+  idempotencyKey: string
+  status: BridgeStatus
+  outcome: string | null
+  actionFingerprint: ActionFingerprint
+  triggerEvent: unknown
+}
+
+export interface StartApprovalBridgeResult {
+  suspended: boolean
+  result?: AutomationStepResult
+  approval: Pick<UnifiedApprovalDTO, 'id' | 'requestNo' | 'templateId' | 'publishedDefinitionId' | 'status'>
+}
+
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
+
+function normalizeString(value: unknown): string {
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function normalizeStartApprovalConfig(config: Record<string, unknown>): StartApprovalConfig {
+  const templateId = normalizeString(config.templateId)
+  if (!templateId) {
+    throw new ServiceError('start_approval.templateId is required', 400, 'VALIDATION_ERROR')
+  }
+  const rawMapping = isRecord(config.formDataMapping) ? config.formDataMapping : null
+  if (!rawMapping || Object.keys(rawMapping).length === 0) {
+    throw new ServiceError('start_approval.formDataMapping is required', 400, 'VALIDATION_ERROR')
+  }
+  const formDataMapping: Record<string, string> = {}
+  for (const [key, value] of Object.entries(rawMapping)) {
+    const fieldId = key.trim()
+    const expression = normalizeString(value)
+    if (!fieldId || !expression) {
+      throw new ServiceError('start_approval.formDataMapping entries must be non-empty strings', 400, 'VALIDATION_ERROR')
+    }
+    formDataMapping[fieldId] = expression
+  }
+  const requesterRaw = isRecord(config.requester) ? config.requester : undefined
+  const mode = requesterRaw?.mode === 'rule_creator' ? 'rule_creator' : 'trigger_actor'
+  return {
+    templateId,
+    formDataMapping,
+    requester: { mode },
+  }
+}
+
+function hasPermissionCode(permissionCodes: string[], permissionCode: string): boolean {
+  if (permissionCodes.includes(permissionCode) || permissionCodes.includes('*:*')) return true
+  const resource = permissionCode.split(':')[0]
+  return resource ? permissionCodes.includes(`${resource}:*`) : false
+}
+
+function rootIdFor(execution: Pick<AutomationExecution, 'id' | 'rerunOfExecutionId'> & { rootExecutionId?: string }): string {
+  return execution.rootExecutionId || execution.rerunOfExecutionId || execution.id
+}
+
+function buildTemplateData(context: ExecutionContext): Record<string, unknown> {
+  return {
+    ...context.recordData,
+    record: context.recordData,
+    trigger: context.triggerEvent,
+    sheetId: context.sheetId,
+    recordId: context.recordId,
+    actorId: context.actorId,
+    ruleId: context.ruleId,
+    executionId: context.executionId,
+  }
+}
+
+function renderMappedValue(expression: string, data: Record<string, unknown>): unknown {
+  if (expression.includes('{{')) return renderAutomationTemplate(expression, data)
+  const lookedUp = lookupTemplateValue(expression, data)
+  return lookedUp === undefined ? '' : lookedUp
+}
+
+function buildFormData(mapping: Record<string, string>, context: ExecutionContext): Record<string, unknown> {
+  const data = buildTemplateData(context)
+  return Object.fromEntries(
+    Object.entries(mapping).map(([fieldId, expression]) => [fieldId, renderMappedValue(expression, data)]),
+  )
+}
+
+function isTerminalApprovalStatus(status: string): status is ApprovalCompletionOutcome {
+  return status === 'approved' || status === 'rejected' || status === 'revoked' || status === 'cancelled'
+}
+
+function stepResultForApproval(approval: Pick<UnifiedApprovalDTO, 'id' | 'requestNo' | 'templateId' | 'publishedDefinitionId' | 'status'>): AutomationStepResult {
+  const output = {
+    approvalInstanceId: approval.id,
+    requestNo: approval.requestNo ?? null,
+    templateId: approval.templateId ?? null,
+    publishedDefinitionId: approval.publishedDefinitionId ?? null,
+    outcome: approval.status,
+  }
+  if (approval.status === 'approved') {
+    return { actionType: 'start_approval', status: 'success', output, durationMs: 0 }
+  }
+  return {
+    actionType: 'start_approval',
+    status: 'failed',
+    output,
+    error: `Approval completed with ${approval.status}`,
+    durationMs: 0,
+  }
+}
+
+export class AutomationApprovalBridgeService {
+  constructor(
+    private readonly jobService: AutomationJobService,
+    private readonly approvalProductService: ApprovalProductService = new ApprovalProductService(),
+  ) {}
+
+  async hasBridgeForAnyExecution(executionIds: string[]): Promise<boolean> {
+    const ids = Array.from(new Set(executionIds.filter(Boolean)))
+    if (ids.length === 0) return false
+    const row = await db
+      .selectFrom('multitable_automation_approval_bridges')
+      .select('id')
+      .where((eb) => eb.or([
+        eb('execution_id', 'in', ids),
+        eb('root_execution_id', 'in', ids),
+      ]))
+      .executeTakeFirst()
+    return row != null
+  }
+
+  async startApproval(input: {
+    execution: Pick<AutomationExecution, 'id' | 'rerunOfExecutionId'> & { rootExecutionId?: string }
+    rule: { id: string; sheetId?: string; actions: ReadonlyArray<AutomationAction>; createdBy?: string }
+    context: ExecutionContext
+    stepIndex: number
+    action: AutomationAction
+  }): Promise<StartApprovalBridgeResult> {
+    const config = normalizeStartApprovalConfig(input.action.config)
+    const rootExecutionId = rootIdFor(input.execution)
+    const idempotencyKey = `start_approval:${rootExecutionId}:${input.stepIndex}:${config.templateId}`
+
+    const existing = await db
+      .selectFrom('multitable_automation_approval_bridges')
+      .select(['id', 'approval_instance_id'])
+      .where('idempotency_key', '=', idempotencyKey)
+      .executeTakeFirst()
+    if (existing) {
+      throw new ServiceError('start_approval already created an approval for this execution step', 409, 'START_APPROVAL_DUPLICATE')
+    }
+
+    const actor = await this.loadAuthorizedActor(config, input.context, input.rule.createdBy ?? '')
+    const formData = buildFormData(config.formDataMapping, input.context)
+    const bridgeId = `aab_${randomUUID()}`
+    const fingerprint = computeActionFingerprint(input.rule.actions)
+
+    await db
+      .insertInto('multitable_automation_approval_bridges')
+      .values({
+        id: bridgeId,
+        execution_id: input.execution.id,
+        root_execution_id: rootExecutionId,
+        rule_id: input.rule.id,
+        sheet_id: input.rule.sheetId ?? null,
+        record_id: input.context.recordId || null,
+        step_index: input.stepIndex,
+        approval_instance_id: null,
+        approval_request_no: null,
+        approval_template_id: config.templateId,
+        approval_published_definition_id: null,
+        idempotency_key: idempotencyKey,
+        status: 'creating',
+        outcome: null,
+        action_fingerprint: toJsonValue(fingerprint) as never,
+        trigger_event: input.context.triggerEvent == null ? null : (toJsonValue(redactValue(input.context.triggerEvent)) as never),
+      })
+      .execute()
+
+    let approval: UnifiedApprovalDTO
+    try {
+      approval = await this.approvalProductService.createApproval(
+        { templateId: config.templateId, formData },
+        actor,
+      )
+    } catch (error) {
+      await this.markBridgeFailed(bridgeId)
+      throw error
+    }
+
+    const terminal = isTerminalApprovalStatus(approval.status)
+    const result = terminal ? stepResultForApproval(approval) : undefined
+
+    await db
+      .updateTable('multitable_automation_approval_bridges')
+      .set({
+        approval_instance_id: approval.id,
+        approval_request_no: approval.requestNo ?? null,
+        approval_published_definition_id: approval.publishedDefinitionId ?? null,
+        status: terminal ? 'resumed' : 'pending',
+        outcome: terminal ? approval.status : null,
+        completed_at: terminal ? new Date().toISOString() : null,
+        resumed_at: terminal ? new Date().toISOString() : null,
+      } as never)
+      .where('id', '=', bridgeId)
+      .execute()
+
+    try {
+      await db.transaction().execute(async (trx) => {
+        if (terminal && result) {
+          await this.jobService.writeSettledJob(
+            input.execution.id,
+            { id: input.rule.id, sheetId: input.rule.sheetId },
+            input.stepIndex,
+            input.action,
+            result,
+            trx,
+          )
+        } else {
+          await this.jobService.writeSuspendedJob(
+            input.execution.id,
+            { id: input.rule.id, sheetId: input.rule.sheetId },
+            input.stepIndex,
+            input.action,
+            trx,
+          )
+        }
+      })
+    } catch (error) {
+      await this.markBridgeFailed(bridgeId)
+      throw error
+    }
+
+    return {
+      suspended: !terminal,
+      ...(result ? { result } : {}),
+      approval: {
+        id: approval.id,
+        requestNo: approval.requestNo,
+        templateId: approval.templateId,
+        publishedDefinitionId: approval.publishedDefinitionId,
+        status: approval.status,
+      },
+    }
+  }
+
+  async claimCompletion(event: ApprovalCompletionEventV1): Promise<AutomationApprovalBridgeRow | null> {
+    const approvalId = event.approval.instanceId
+    const claimed = await db
+      .updateTable('multitable_automation_approval_bridges')
+      .set({
+        status: 'resumed',
+        outcome: event.transition.toStatus,
+        completed_at: event.occurredAt,
+        resumed_at: new Date().toISOString(),
+      } as never)
+      .where('approval_instance_id', '=', approvalId)
+      .where('status', '=', 'pending')
+      .returningAll()
+      .executeTakeFirst()
+    return claimed ? this.mapRow(claimed as Record<string, unknown>) : null
+  }
+
+  private async markBridgeFailed(id: string): Promise<void> {
+    await db
+      .updateTable('multitable_automation_approval_bridges')
+      .set({ status: 'failed' } as never)
+      .where('id', '=', id)
+      .execute()
+  }
+
+  private async loadAuthorizedActor(
+    config: StartApprovalConfig,
+    context: ExecutionContext,
+    ruleCreatedBy: string,
+  ): Promise<{
+    userId: string
+    userName?: string
+    email?: string
+    department?: string
+    departmentIds?: string[]
+    roles?: string[]
+    permissions?: string[]
+  }> {
+    const preferred = config.requester?.mode === 'rule_creator'
+      ? ruleCreatedBy
+      : (context.actorId || ruleCreatedBy)
+    const userId = normalizeString(preferred)
+    if (!userId) {
+      throw new ServiceError('start_approval requester could not be resolved', 400, 'START_APPROVAL_REQUESTER_REQUIRED')
+    }
+
+    const userResult = await query<{
+      id: string
+      email: string | null
+      username: string | null
+      name: string | null
+      role: string | null
+      is_active: boolean | null
+    }>(
+      `SELECT id, email, username, name, role, is_active
+         FROM users
+        WHERE id = $1
+        LIMIT 1`,
+      [userId],
+    )
+    const user = userResult.rows[0]
+    if (!user || user.is_active === false) {
+      throw new ServiceError('start_approval requester user not found or inactive', 404, 'START_APPROVAL_REQUESTER_NOT_FOUND')
+    }
+
+    const permissions = await listUserPermissions(userId)
+    const roles = await this.loadUserRoles(userId, user.role)
+    const allowed = await isAdmin(userId)
+      || hasPermissionCode(permissions, 'approvals:write')
+      || await userHasPermission(userId, 'approvals:write')
+    if (!allowed) {
+      throw new ServiceError('start_approval requester lacks approvals:write', 403, 'START_APPROVAL_PERMISSION_DENIED')
+    }
+
+    return {
+      userId,
+      userName: user.name ?? user.username ?? user.email ?? userId,
+      email: user.email ?? undefined,
+      roles,
+      permissions,
+    }
+  }
+
+  private async loadUserRoles(userId: string, legacyRole: string | null): Promise<string[]> {
+    const roles = new Set<string>()
+    if (legacyRole && legacyRole.trim()) roles.add(legacyRole.trim())
+    try {
+      const result = await query<{ role_id: string }>(
+        `SELECT role_id FROM user_roles WHERE user_id = $1`,
+        [userId],
+      )
+      for (const row of result.rows) {
+        if (row.role_id && row.role_id.trim()) roles.add(row.role_id.trim())
+      }
+    } catch {
+      // Older/degraded deployments may not have user_roles; legacy users.role still applies.
+    }
+    return Array.from(roles)
+  }
+
+  private mapRow(row: Record<string, unknown>): AutomationApprovalBridgeRow {
+    const fpRaw = typeof row.action_fingerprint === 'string'
+      ? JSON.parse(row.action_fingerprint)
+      : (row.action_fingerprint ?? {})
+    const fp = (fpRaw && typeof fpRaw === 'object' ? fpRaw : {}) as Record<string, unknown>
+    return {
+      id: row.id as string,
+      executionId: row.execution_id as string,
+      rootExecutionId: row.root_execution_id as string,
+      ruleId: row.rule_id as string,
+      sheetId: (row.sheet_id as string) ?? null,
+      recordId: (row.record_id as string) ?? null,
+      stepIndex: Number(row.step_index),
+      approvalInstanceId: (row.approval_instance_id as string) ?? null,
+      approvalRequestNo: (row.approval_request_no as string) ?? null,
+      approvalTemplateId: row.approval_template_id as string,
+      approvalPublishedDefinitionId: (row.approval_published_definition_id as string) ?? null,
+      idempotencyKey: row.idempotency_key as string,
+      status: row.status as BridgeStatus,
+      outcome: (row.outcome as string) ?? null,
+      actionFingerprint: { count: Number(fp.count ?? 0), hash: String(fp.hash ?? '') },
+      triggerEvent: typeof row.trigger_event === 'string' ? JSON.parse(row.trigger_event) : (row.trigger_event ?? null),
+    }
+  }
+}

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -44,7 +44,7 @@ function readJsonSafely(response: Response): Promise<unknown> {
   return response.json().catch(() => null)
 }
 
-function lookupTemplateValue(path: string, data: Record<string, unknown>): unknown {
+export function lookupTemplateValue(path: string, data: Record<string, unknown>): unknown {
   const segments = path.split('.').filter(Boolean)
   let current: unknown = data
   for (const segment of segments) {
@@ -54,7 +54,7 @@ function lookupTemplateValue(path: string, data: Record<string, unknown>): unkno
   return current
 }
 
-function renderTemplateValue(value: unknown): string {
+export function renderTemplateValue(value: unknown): string {
   if (value === null || value === undefined) return ''
   if (typeof value === 'string') return value
   if (typeof value === 'number' || typeof value === 'boolean') return String(value)
@@ -65,7 +65,7 @@ function renderTemplateValue(value: unknown): string {
   }
 }
 
-function renderAutomationTemplate(template: string, data: Record<string, unknown>): string {
+export function renderAutomationTemplate(template: string, data: Record<string, unknown>): string {
   return template.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (_match, key: string) =>
     renderTemplateValue(lookupTemplateValue(key, data)),
   )
@@ -490,6 +490,15 @@ export interface ActionJobLifecycle {
    * Optional: legacy rules supply no lifecycle, so a legacy `wait_for_callback` fails closed (D7).
    */
   onSuspend?(stepIndex: number, action: AutomationAction): Promise<void>
+  /**
+   * W6-1: `start_approval` in an opted-in rule — create one approval, persist the
+   * approval bridge + a `suspended` C1 job, then STOP. Completion resumes from W5.
+   */
+  onStartApproval?(
+    stepIndex: number,
+    action: AutomationAction,
+    context: ExecutionContext,
+  ): Promise<{ suspended: boolean; result?: AutomationStepResult }>
 }
 
 export interface ActionJobLifecycleMeta {
@@ -674,6 +683,7 @@ export class AutomationExecutor {
     context: ExecutionContext,
     suspendIndex: number,
     jobLifecycle?: ActionJobLifecycle,
+    settledStepResult?: AutomationStepResult,
   ): Promise<AutomationExecution> {
     const startTime = Date.now()
     execution.status = 'running'
@@ -684,7 +694,11 @@ export class AutomationExecutor {
       // bridge in onSettled). If this settle throws (e.g. a DB error), it now fails the execution
       // terminally below — NOT a bubbled 500 that leaves the token consumed and the tail unrun.
       const waitAction = rule.actions[suspendIndex]
-      const waitResult: AutomationStepResult = { actionType: 'wait_for_callback', status: 'success', durationMs: 0 }
+      const waitResult: AutomationStepResult = settledStepResult ?? {
+        actionType: waitAction.type,
+        status: 'success',
+        durationMs: 0,
+      }
       execution.steps.push(waitResult)
       if (jobLifecycle) await jobLifecycle.onSettled(suspendIndex, waitAction, waitResult)
 
@@ -746,6 +760,38 @@ export class AutomationExecutor {
           actionType: 'wait_for_callback',
           status: 'failed',
           error: 'wait_for_callback requires execution_mode workflow_job_v1',
+          durationMs: 0,
+        })
+        for (let i = index + 1; i < actions.length; i++) {
+          results.push({ actionType: actions[i].type, status: 'skipped', durationMs: 0 })
+        }
+        return { suspended: false }
+      }
+
+      // W6-1 approval bridge. The completion event, not an admin token, resumes the tail.
+      if (action.type === 'start_approval') {
+        if (jobLifecycle?.onStartApproval) {
+          const approvalResult = await jobLifecycle.onStartApproval(index, action, context)
+          if (approvalResult.suspended) return { suspended: true }
+          const result = approvalResult.result ?? {
+            actionType: 'start_approval',
+            status: 'success',
+            durationMs: 0,
+          }
+          results.push(result)
+          if (result.status === 'failed') {
+            for (let i = index + 1; i < actions.length; i++) {
+              await jobLifecycle.onSkipped(i, actions[i])
+              results.push({ actionType: actions[i].type, status: 'skipped', durationMs: 0 })
+            }
+            break
+          }
+          continue
+        }
+        results.push({
+          actionType: 'start_approval',
+          status: 'failed',
+          error: 'start_approval requires execution_mode workflow_job_v1',
           durationMs: 0,
         })
         for (let i = index + 1; i < actions.length; i++) {
@@ -1006,6 +1052,13 @@ export class AutomationExecutor {
           break
         case 'lock_record':
           result = await this.executeLockRecord(action.config, context)
+          break
+        case 'start_approval':
+          result = {
+            actionType: 'start_approval',
+            status: 'failed',
+            error: 'start_approval requires execution_mode workflow_job_v1',
+          }
           break
         default:
           result = {

--- a/packages/core-backend/src/multitable/automation-job-service.ts
+++ b/packages/core-backend/src/multitable/automation-job-service.ts
@@ -235,7 +235,7 @@ export class AutomationJobService {
         .selectFrom('multitable_automation_approval_bridges')
         .select(['step_index', 'approval_instance_id'])
         .where('execution_id', '=', executionId)
-        .where('status', '=', 'pending')
+        .where('approval_instance_id', 'is not', null)
         .orderBy('created_at', 'asc')
         .execute()
       for (const bridge of approvalBridges) {

--- a/packages/core-backend/src/multitable/automation-job-service.ts
+++ b/packages/core-backend/src/multitable/automation-job-service.ts
@@ -150,6 +150,38 @@ export class AutomationJobService {
       .execute()
   }
 
+  /** Write a terminal job row directly for bridge actions that complete synchronously. */
+  async writeSettledJob(
+    executionId: string,
+    rule: { id: string; sheetId?: string },
+    stepIndex: number,
+    action: AutomationAction,
+    result: { status: 'success' | 'failed' | 'skipped'; output?: unknown; error?: string; durationMs?: number },
+    executor: typeof db = db,
+  ): Promise<void> {
+    const now = new Date().toISOString()
+    await executor
+      .insertInto('multitable_automation_jobs')
+      .values({
+        id: `${executionId}:job:${stepIndex}`,
+        execution_id: executionId,
+        rule_id: rule.id,
+        sheet_id: rule.sheetId ?? null,
+        step_index: stepIndex,
+        step_key: String(stepIndex),
+        action_type: action.type,
+        status: legacyAutomationStatusToJobStatus(result.status),
+        upstream_job_id: stepIndex > 0 ? `${executionId}:job:${stepIndex - 1}` : null,
+        result: result.output == null ? null : (toJsonValue(redactValue(result.output)) as never),
+        error: result.error != null ? redactString(result.error) : null,
+        started_at: now,
+        finished_at: now,
+        duration_ms: result.durationMs ?? null,
+        schema_version: JOB_SCHEMA_VERSION,
+      })
+      .execute()
+  }
+
   /**
    * Read persisted jobs for an execution as C1 WorkflowJob views, ordered by step.
    * Returns [] when the execution has no jobs (legacy execution → caller falls back
@@ -197,6 +229,19 @@ export class AutomationJobService {
         suspendByStep.set(Number(s.step_index), {
           reason: s.reason as WorkflowJobSuspendReason,
           resumeToken: s.resume_token as string,
+        })
+      }
+      const approvalBridges = await db
+        .selectFrom('multitable_automation_approval_bridges')
+        .select(['step_index', 'approval_instance_id'])
+        .where('execution_id', '=', executionId)
+        .where('status', '=', 'pending')
+        .orderBy('created_at', 'asc')
+        .execute()
+      for (const bridge of approvalBridges) {
+        suspendByStep.set(Number(bridge.step_index), {
+          reason: 'manual_task',
+          resumeToken: bridge.approval_instance_id as string,
         })
       }
     }

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -10,7 +10,7 @@ import {
   type AutomationConditionField,
   type ConditionGroup,
 } from './automation-conditions'
-import { AutomationExecutor, type AutomationRule as ExecutorRule, type AutomationExecution, type AutomationDeps, type ExecutionContext } from './automation-executor'
+import { AutomationExecutor, type AutomationRule as ExecutorRule, type AutomationExecution, type AutomationDeps, type ExecutionContext, type ActionJobLifecycle, type AutomationStepResult } from './automation-executor'
 import { ALL_ACTION_TYPES, type AutomationAction } from './automation-actions'
 import type { AutomationTrigger } from './automation-triggers'
 import {
@@ -24,6 +24,8 @@ import { randomBytes } from 'crypto'
 import { AutomationLogService } from './automation-log-service'
 import { AutomationJobService } from './automation-job-service'
 import { AutomationSuspensionService, computeActionFingerprint } from './automation-suspension-service'
+import { AutomationApprovalBridgeService, type AutomationApprovalBridgeRow } from './automation-approval-bridge-service'
+import type { ApprovalCompletionEventV1 } from '../services/ApprovalCompletionEvent'
 import {
   normalizeDingTalkAutomationActionInputs,
   validateDingTalkAutomationActionConfigs,
@@ -120,6 +122,43 @@ function validateSendEmailActionConfigs(
   return null
 }
 
+function validateStartApprovalConfig(config: Record<string, unknown>, path: string): string | null {
+  const templateId = typeof config.templateId === 'string' ? config.templateId.trim() : ''
+  if (!templateId) return `${path}.templateId is required`
+  const mapping = isRecord(config.formDataMapping) ? config.formDataMapping : null
+  if (!mapping || Object.keys(mapping).length === 0) return `${path}.formDataMapping is required`
+  for (const [key, value] of Object.entries(mapping)) {
+    if (!key.trim() || typeof value !== 'string' || value.trim().length === 0) {
+      return `${path}.formDataMapping entries must be non-empty strings`
+    }
+  }
+  if (config.requester !== undefined) {
+    if (!isRecord(config.requester)) return `${path}.requester must be an object`
+    const mode = config.requester.mode
+    if (mode !== undefined && mode !== 'trigger_actor' && mode !== 'rule_creator') {
+      return `${path}.requester.mode must be trigger_actor or rule_creator`
+    }
+  }
+  return null
+}
+
+function validateStartApprovalActionConfigs(
+  actionType: string,
+  actionConfig: Record<string, unknown>,
+  actions: AutomationAction[] | null | undefined,
+): string | null {
+  if (actionType === 'start_approval') {
+    const error = validateStartApprovalConfig(actionConfig, 'actionConfig')
+    if (error) return error
+  }
+  for (const [index, action] of (actions ?? []).entries()) {
+    if (action.type !== 'start_approval') continue
+    const error = validateStartApprovalConfig(action.config, `actions[${index}].config`)
+    if (error) return error
+  }
+  return null
+}
+
 function parseConditionGroupInput(value: unknown): ConditionGroup {
   try {
     return normalizeConditionGroupInput(value)
@@ -185,6 +224,9 @@ function validateConditionBranchConfig(config: unknown, path: string): Automatio
       if (nested.type === 'wait_for_callback') {
         throw new AutomationRuleValidationError(`${branchPath}.actions cannot contain wait_for_callback until A6-3-3`)
       }
+      if (nested.type === 'start_approval') {
+        throw new AutomationRuleValidationError(`${branchPath}.actions cannot contain start_approval until A6-3-3`)
+      }
     }
     nestedActions.push(...actions)
   }
@@ -208,6 +250,9 @@ function validateConditionBranchConfig(config: unknown, path: string): Automatio
       if (nested.type === 'wait_for_callback') {
         throw new AutomationRuleValidationError(`${defaultPath}.actions cannot contain wait_for_callback until A6-3-3`)
       }
+      if (nested.type === 'start_approval') {
+        throw new AutomationRuleValidationError(`${defaultPath}.actions cannot contain start_approval until A6-3-3`)
+      }
     }
     nestedActions.push(...actions)
   }
@@ -222,7 +267,7 @@ function collectNestedAutomationActions(
   executionMode: string | null,
 ): AutomationAction[] {
   const collected: AutomationAction[] = []
-  const requiresWorkflowJobMode = actionType === 'condition_branch'
+  const requiresWorkflowJobMode = actionType === 'condition_branch' || actionType === 'start_approval'
 
   if (actionType === 'condition_branch') {
     collected.push(...validateConditionBranchConfig(actionConfig, 'actionConfig'))
@@ -236,9 +281,10 @@ function collectNestedAutomationActions(
     collected.push(current)
   }
 
-  const hasBranch = requiresWorkflowJobMode || collected.some((action) => action.type === 'condition_branch')
-  if (hasBranch && executionMode !== 'workflow_job_v1') {
-    throw new AutomationRuleValidationError('condition_branch requires execution_mode workflow_job_v1')
+  const hasWorkflowAction = requiresWorkflowJobMode
+    || collected.some((action) => action.type === 'condition_branch' || action.type === 'start_approval')
+  if (hasWorkflowAction && executionMode !== 'workflow_job_v1') {
+    throw new AutomationRuleValidationError('condition_branch/start_approval requires execution_mode workflow_job_v1')
   }
 
   return collected
@@ -409,6 +455,7 @@ export class AutomationService {
   private logService: AutomationLogService
   private jobService: AutomationJobService
   private suspensionService: AutomationSuspensionService
+  private approvalBridgeService: AutomationApprovalBridgeService
   /** Kept for backward-compat with raw SQL in executor actions */
   private queryFn: AutomationQueryFn
 
@@ -435,6 +482,7 @@ export class AutomationService {
     this.logService = new AutomationLogService()
     this.jobService = new AutomationJobService()
     this.suspensionService = new AutomationSuspensionService(this.jobService)
+    this.approvalBridgeService = new AutomationApprovalBridgeService(this.jobService)
     this.scheduler = new AutomationScheduler(
       async (rule) => {
         await this.executeRule(rule, { _triggeredBy: 'schedule' })
@@ -477,6 +525,18 @@ export class AutomationService {
       this.subscriptionIds.push(id)
     }
 
+    for (const eventType of ['approval.approved', 'approval.rejected', 'approval.revoked', 'approval.cancelled']) {
+      const id = this.eventBus.subscribe<ApprovalCompletionEventV1>(
+        eventType,
+        (payload) => {
+          this.handleApprovalCompletionEvent(payload).catch((err) => {
+            logger.error(`Automation approval bridge handler error for ${eventType}`, err instanceof Error ? err : undefined)
+          })
+        },
+      )
+      this.subscriptionIds.push(id)
+    }
+
     logger.info('AutomationService initialized (V1)')
   }
 
@@ -511,6 +571,8 @@ export class AutomationService {
     if (actionConfigValidationError) throw new AutomationRuleValidationError(actionConfigValidationError)
     const sendEmailValidationError = validateSendEmailActionConfigs(input.actionType, actionConfig, actionsForValidation)
     if (sendEmailValidationError) throw new AutomationRuleValidationError(sendEmailValidationError)
+    const startApprovalValidationError = validateStartApprovalActionConfigs(input.actionType, actionConfig, actionsForValidation)
+    if (startApprovalValidationError) throw new AutomationRuleValidationError(startApprovalValidationError)
     const linkValidationError = await validateDingTalkAutomationLinks(
       this.queryFn,
       sheetId,
@@ -644,6 +706,12 @@ export class AutomationService {
         actionsForValidation,
       )
       if (sendEmailValidationError) throw new AutomationRuleValidationError(sendEmailValidationError)
+      const startApprovalValidationError = validateStartApprovalActionConfigs(
+        nextActionType,
+        normalizedNextActionConfig,
+        actionsForValidation,
+      )
+      if (startApprovalValidationError) throw new AutomationRuleValidationError(startApprovalValidationError)
       const linkValidationError = await validateDingTalkAutomationLinks(
         this.queryFn,
         sheetId,
@@ -839,29 +907,14 @@ export class AutomationService {
   async executeRule(
     rule: ExecutorRule,
     triggerEvent: unknown,
-    retryMeta?: { rerunOfExecutionId: string; initiatedBy: string },
+    retryMeta?: { rerunOfExecutionId: string; initiatedBy: string; rootExecutionId?: string },
   ): Promise<AutomationExecution> {
     const persistJobs = rule.executionMode === 'workflow_job_v1'
     // A6-1: ONLY opted-in rules ('workflow_job_v1') get a per-action job lifecycle. Legacy rules
     // pass no factory → executor writes zero job rows (opt-out path is byte-identical to today).
     // This is the single place the path is chosen, so a retry of an opt-in rule also writes jobs.
     const jobLifecycleFactory = persistJobs
-      ? (executionId: string) => ({
-          onExecutionStarted: (execution: AutomationExecution) => this.logService.record(execution),
-          ...this.jobService.lifecycleFor(executionId, { id: rule.id, sheetId: rule.sheetId }),
-          // A6-2: a wait_for_callback step persists the suspension + suspended job, then the executor stops.
-          onSuspend: (stepIndex: number, action: AutomationAction): Promise<void> =>
-            this.suspensionService
-              .create({
-                executionId,
-                rule: { id: rule.id, sheetId: rule.sheetId, actions: rule.actions },
-                recordId: ((triggerEvent as Record<string, unknown>)?.recordId as string) ?? '',
-                triggerEvent,
-                stepIndex,
-                action,
-              })
-              .then(() => undefined),
-        })
+      ? (executionId: string) => this.buildJobLifecycle(executionId, rule, triggerEvent, retryMeta?.rootExecutionId)
       : undefined
     const execution = await this.executor.execute(rule, triggerEvent, jobLifecycleFactory)
     if (retryMeta) {
@@ -879,6 +932,43 @@ export class AutomationService {
       logger.error('Automation execution log persistence failed', err instanceof Error ? err : undefined)
     }
     return execution
+  }
+
+  private buildJobLifecycle(
+    executionId: string,
+    rule: ExecutorRule,
+    triggerEvent: unknown,
+    rootExecutionId?: string,
+  ): ActionJobLifecycle {
+    return {
+      onExecutionStarted: (execution: AutomationExecution) => this.logService.record(execution),
+      ...this.jobService.lifecycleFor(executionId, { id: rule.id, sheetId: rule.sheetId }),
+      // A6-2: a wait_for_callback step persists the suspension + suspended job, then the executor stops.
+      onSuspend: (stepIndex: number, action: AutomationAction): Promise<void> =>
+        this.suspensionService
+          .create({
+            executionId,
+            rule: { id: rule.id, sheetId: rule.sheetId, actions: rule.actions },
+            recordId: ((triggerEvent as Record<string, unknown>)?.recordId as string) ?? '',
+            triggerEvent,
+            stepIndex,
+            action,
+          })
+          .then(() => undefined),
+      // W6-1: create one approval, then either suspend pending completion or continue immediately
+      // if the approval auto-completed during createApproval().
+      onStartApproval: async (stepIndex: number, action: AutomationAction, context: ExecutionContext) => {
+        const result = await this.approvalBridgeService.startApproval({
+          execution: { id: executionId, rootExecutionId },
+          rule: { id: rule.id, sheetId: rule.sheetId, actions: rule.actions, createdBy: rule.createdBy },
+          context,
+          stepIndex,
+          action,
+        })
+        if (result.suspended) return { suspended: true }
+        return { suspended: false, result: result.result }
+      },
+    }
   }
 
   /**
@@ -914,6 +1004,15 @@ export class AutomationService {
       // Fail closed (A4-D7): null/undefined, array, or empty `{}` cannot rebuild context.
       return { status: 409, code: 'MISSING_TRIGGER_EVENT', message: 'Original execution has no usable stored trigger event to retry' }
     }
+    const lineageIds = await this.collectExecutionLineageIds(original)
+    const rootExecutionId = lineageIds.at(-1) ?? original.id
+    if (await this.approvalBridgeService.hasBridgeForAnyExecution(lineageIds)) {
+      return {
+        status: 409,
+        code: 'START_APPROVAL_ALREADY_CREATED',
+        message: 'Executions that already created an approval cannot be whole-execution retried in W6-1',
+      }
+    }
     const rule = await this.getRule(original.ruleId)
     if (!rule || !rule.enabled) {
       return { status: 409, code: 'RULE_MISSING_OR_DISABLED', message: `Rule ${original.ruleId} is missing or disabled; cannot retry` }
@@ -922,8 +1021,24 @@ export class AutomationService {
     const execution = await this.executeRule(execRule, original.triggerEvent, {
       rerunOfExecutionId: original.id,
       initiatedBy,
+      rootExecutionId,
     })
     return { execution }
+  }
+
+  private async collectExecutionLineageIds(execution: AutomationExecution): Promise<string[]> {
+    const ids: string[] = []
+    const seen = new Set<string>()
+    let current: AutomationExecution | null = execution
+    for (let depth = 0; current && depth < 16; depth++) {
+      if (seen.has(current.id)) break
+      seen.add(current.id)
+      ids.push(current.id)
+      const parentId = current.rerunOfExecutionId
+      if (!parentId || seen.has(parentId)) break
+      current = await this.logService.getById(parentId)
+    }
+    return ids
   }
 
   /**
@@ -995,21 +1110,9 @@ export class AutomationService {
       actorId: ((triggerEvent as Record<string, unknown>)?.actorId as string) ?? null,
       triggerEvent,
     }
-    const jobLifecycle = {
-      ...this.jobService.lifecycleFor(execution.id, { id: execRule.id, sheetId: execRule.sheetId }),
-      // A sequential second wait in the tail suspends again (new suspension row).
-      onSuspend: (stepIndex: number, action: AutomationAction): Promise<void> =>
-        this.suspensionService
-          .create({
-            executionId: execution.id,
-            rule: { id: execRule.id, sheetId: execRule.sheetId, actions: execRule.actions },
-            recordId: suspension.recordId ?? '',
-            triggerEvent,
-            stepIndex,
-            action,
-          })
-          .then(() => undefined),
-    }
+    const lineageIds = await this.collectExecutionLineageIds(execution)
+    const rootExecutionId = lineageIds.at(-1) ?? execution.id
+    const jobLifecycle = this.buildJobLifecycle(execution.id, execRule, triggerEvent, rootExecutionId)
     const continued = await this.executor.continueExecution(execution, execRule, context, suspension.stepIndex, jobLifecycle)
     try {
       await this.logService.updateRecordedExecution(continued)
@@ -1017,6 +1120,130 @@ export class AutomationService {
       logger.error('Resume execution log persistence failed', err instanceof Error ? err : undefined)
     }
     return { execution: continued }
+  }
+
+  async handleApprovalCompletionEvent(event: ApprovalCompletionEventV1): Promise<void> {
+    if (event.version !== 1 || event.source !== 'approval-product') return
+    if (!['approval.approved', 'approval.rejected', 'approval.revoked', 'approval.cancelled'].includes(event.eventType)) return
+
+    const bridge = await this.approvalBridgeService.claimCompletion(event)
+    if (!bridge) return
+
+    const execution = await this.logService.getById(bridge.executionId)
+    if (!execution) {
+      logger.error(`start_approval bridge ${bridge.id} references missing execution ${bridge.executionId}`)
+      return
+    }
+
+    const rule = await this.getRule(bridge.ruleId)
+    if (!rule || !rule.enabled) {
+      await this.failApprovalBridgeExecution(execution, bridge, `Rule ${bridge.ruleId} is missing or disabled; cannot resume approval bridge`)
+      return
+    }
+    const execRule = toExecutorRule(rule)
+    const currentFp = computeActionFingerprint(execRule.actions)
+    if (currentFp.count !== bridge.actionFingerprint.count || currentFp.hash !== bridge.actionFingerprint.hash) {
+      await this.failApprovalBridgeExecution(execution, bridge, 'Rule actions changed since start_approval suspended; cannot resume safely')
+      return
+    }
+
+    const result = this.approvalCompletionStepResult(event)
+    if (event.transition.toStatus !== 'approved') {
+      await this.failApprovalBridgeExecution(execution, bridge, result.error ?? `Approval completed with ${event.transition.toStatus}`, result)
+      return
+    }
+
+    let recordData: Record<string, unknown> = {}
+    if (bridge.recordId) {
+      const rec = await this.queryFn(
+        `SELECT data FROM meta_records WHERE id = $1 AND sheet_id = $2`,
+        [bridge.recordId, bridge.sheetId ?? execRule.sheetId],
+      )
+      const row = (rec.rows[0] ?? null) as { data?: Record<string, unknown> } | null
+      if (!row) {
+        await this.failApprovalBridgeExecution(execution, bridge, 'Record no longer exists; cannot resume approval bridge')
+        return
+      }
+      recordData = (row.data as Record<string, unknown>) ?? {}
+    }
+
+    const triggerEvent = bridge.triggerEvent ?? {}
+    const context: ExecutionContext = {
+      executionId: execution.id,
+      ruleId: execRule.id,
+      sheetId: execRule.sheetId,
+      recordId: bridge.recordId ?? '',
+      recordData,
+      ruleCreatedBy: execRule.createdBy,
+      actorId: event.actor?.id ?? event.requester.id ?? null,
+      triggerEvent,
+    }
+    const continued = await this.executor.continueExecution(
+      execution,
+      execRule,
+      context,
+      bridge.stepIndex,
+      this.buildJobLifecycle(execution.id, execRule, triggerEvent, bridge.rootExecutionId),
+      result,
+    )
+    try {
+      await this.logService.updateRecordedExecution(continued)
+    } catch (err) {
+      logger.error('Approval bridge execution log persistence failed', err instanceof Error ? err : undefined)
+    }
+  }
+
+  private approvalCompletionStepResult(event: ApprovalCompletionEventV1): AutomationStepResult {
+    const output = {
+      approvalInstanceId: event.approval.instanceId,
+      requestNo: event.approval.requestNo,
+      templateId: event.approval.templateId,
+      publishedDefinitionId: event.approval.publishedDefinitionId,
+      outcome: event.transition.toStatus,
+      eventId: event.eventId,
+    }
+    if (event.transition.toStatus === 'approved') {
+      return { actionType: 'start_approval', status: 'success', output, durationMs: 0 }
+    }
+    return {
+      actionType: 'start_approval',
+      status: 'failed',
+      output,
+      error: `Approval completed with ${event.transition.toStatus}`,
+      durationMs: 0,
+    }
+  }
+
+  private async failApprovalBridgeExecution(
+    execution: AutomationExecution,
+    bridge: AutomationApprovalBridgeRow,
+    message: string,
+    result?: AutomationStepResult,
+  ): Promise<void> {
+    const rule = await this.getRule(bridge.ruleId)
+    const execRule = rule ? toExecutorRule(rule) : null
+    const action = execRule?.actions[bridge.stepIndex] ?? { type: 'start_approval', config: {} } as AutomationAction
+    const failedResult = result ?? {
+      actionType: 'start_approval',
+      status: 'failed',
+      error: message,
+      durationMs: 0,
+    }
+    execution.status = 'failed'
+    execution.error = failedResult.error ?? message
+    execution.steps.push(failedResult)
+    execution.finishedAt = new Date().toISOString()
+    try {
+      await this.jobService.lifecycleFor(execution.id, { id: bridge.ruleId, sheetId: bridge.sheetId ?? undefined })
+        .onSettled(bridge.stepIndex, action, failedResult)
+    } catch (err) {
+      logger.error('Approval bridge job settle failed', err instanceof Error ? err : undefined)
+    }
+    try {
+      await this.logService.updateRecordedExecution(execution)
+    } catch (err) {
+      logger.error('Approval bridge failed-execution persistence failed', err instanceof Error ? err : undefined)
+    }
   }
 
   /**

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -1006,7 +1006,7 @@ export class AutomationService {
     }
     const lineageIds = await this.collectExecutionLineageIds(original)
     const rootExecutionId = lineageIds.at(-1) ?? original.id
-    if (await this.approvalBridgeService.hasBridgeForAnyExecution(lineageIds)) {
+    if (await this.approvalBridgeService.hasCreatedApprovalForAnyExecution(lineageIds)) {
       return {
         status: 409,
         code: 'START_APPROVAL_ALREADY_CREATED',
@@ -1232,10 +1232,17 @@ export class AutomationService {
     execution.status = 'failed'
     execution.error = failedResult.error ?? message
     execution.steps.push(failedResult)
+    const skippedTail = execRule?.actions.slice(bridge.stepIndex + 1) ?? []
+    for (const action of skippedTail) {
+      execution.steps.push({ actionType: action.type, status: 'skipped', durationMs: 0 })
+    }
     execution.finishedAt = new Date().toISOString()
+    const lifecycle = this.jobService.lifecycleFor(execution.id, { id: bridge.ruleId, sheetId: bridge.sheetId ?? undefined })
     try {
-      await this.jobService.lifecycleFor(execution.id, { id: bridge.ruleId, sheetId: bridge.sheetId ?? undefined })
-        .onSettled(bridge.stepIndex, action, failedResult)
+      await lifecycle.onSettled(bridge.stepIndex, action, failedResult)
+      for (let offset = 0; offset < skippedTail.length; offset++) {
+        await lifecycle.onSkipped(bridge.stepIndex + 1 + offset, skippedTail[offset])
+      }
     } catch (err) {
       logger.error('Approval bridge job settle failed', err instanceof Error ? err : undefined)
     }

--- a/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
@@ -405,11 +405,15 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
       expect(approvalAfterAction.status).toBe('rejected')
 
       const failed = await waitForExecutionStatus(svc, execution.id, 'failed')
-      expect(failed.steps).toHaveLength(1)
+      expect(failed.steps).toHaveLength(2)
       expect(failed.steps[0]).toMatchObject({
         actionType: 'start_approval',
         status: 'failed',
         error: 'Approval completed with rejected',
+      })
+      expect(failed.steps[1]).toMatchObject({
+        actionType: 'send_webhook',
+        status: 'skipped',
       })
       expect(calls).toEqual([])
 
@@ -420,9 +424,89 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
       expect(finalBridge.rows[0]).toMatchObject({ status: 'resumed', outcome: 'rejected' })
 
       const jobs = await svc.jobs.listByExecution(execution.id)
-      expect(jobs).toHaveLength(1)
+      expect(jobs).toHaveLength(2)
       expect(jobs[0]).toMatchObject({ status: 'failed', error: 'Approval completed with rejected' })
-      expect(() => normalizeWorkflowJob(jobs[0])).not.toThrow()
+      expect(jobs[1]).toMatchObject({ status: 'skipped' })
+      jobs.forEach((job) => expect(() => normalizeWorkflowJob(job)).not.toThrow())
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  test('retry is allowed after createApproval fails before any approval instance exists', async () => {
+    const svc = makeAutomationService()
+    try {
+      const missingTemplateId = `00000000-0000-4000-8000-${String(TS).slice(-12).padStart(12, '0')}`
+      const created = await svc.createRule(SHEET, {
+        name: 'W6 missing approval template',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'start_approval',
+        actionConfig: {
+          templateId: missingTemplateId,
+          formDataMapping: { summary: 'Record {{record.title}} needs approval' },
+          requester: { mode: 'trigger_actor' },
+        },
+        actions: [
+          {
+            type: 'start_approval',
+            config: {
+              templateId: missingTemplateId,
+              formDataMapping: { summary: 'Record {{record.title}} needs approval' },
+              requester: { mode: 'trigger_actor' },
+            },
+          },
+          { type: 'send_webhook', config: { url: 'https://example.test/w6-missing-template-tail' } },
+        ] as never,
+        executionMode: 'workflow_job_v1',
+        createdBy: REQUESTER,
+      })
+      ruleIds.push(created.id)
+      await seedSheetRecord('Missing template')
+
+      const execution = await svc.executeRule({
+        id: created.id,
+        name: 'W6 missing approval template',
+        sheetId: SHEET,
+        trigger: { type: 'record.created', config: {} },
+        actions: created.actions,
+        enabled: true,
+        createdBy: REQUESTER,
+        createdAt: new Date(TS).toISOString(),
+        executionMode: 'workflow_job_v1',
+      } as never, {
+        sheetId: SHEET,
+        recordId: RECORD,
+        data: { title: 'Missing template' },
+        actorId: REQUESTER,
+      })
+      executionIds.push(execution.id)
+      expect(execution.status).toBe('failed')
+
+      const failedBridge = await q(
+        `SELECT status, approval_instance_id, idempotency_key
+           FROM multitable_automation_approval_bridges
+          WHERE execution_id = $1`,
+        [execution.id],
+      )
+      expect(failedBridge.rows).toHaveLength(1)
+      expect(failedBridge.rows[0]).toMatchObject({ status: 'failed', approval_instance_id: null })
+
+      const retry = await svc.retryExecution(execution.id, REQUESTER)
+      expect('execution' in retry).toBe(true)
+      if (!('execution' in retry)) throw new Error(`retry was rejected: ${JSON.stringify(retry)}`)
+      executionIds.push(retry.execution.id)
+      expect(retry.execution.status).toBe('failed')
+
+      const retryBridge = await q(
+        `SELECT status, approval_instance_id, idempotency_key
+           FROM multitable_automation_approval_bridges
+          WHERE execution_id = $1`,
+        [retry.execution.id],
+      )
+      expect(retryBridge.rows).toHaveLength(1)
+      expect(retryBridge.rows[0]).toMatchObject({ status: 'failed', approval_instance_id: null })
+      expect(retryBridge.rows[0].idempotency_key).toBe(failedBridge.rows[0].idempotency_key)
     } finally {
       svc.shutdown()
     }

--- a/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
@@ -1,0 +1,777 @@
+/**
+ * Real-DB W6-1 start_approval seam.
+ *
+ * Drives the actual chain:
+ * AutomationService.executeRule(start_approval) -> ApprovalProductService.createApproval
+ * -> bridge row + suspended C1 job -> ApprovalProductService.dispatchAction(approve)
+ * -> approval completion event -> AutomationService continues the tail.
+ *
+ * This is intentionally real Postgres + real approval compile/runtime. It proves the two
+ * runtimes are wired through the shared event bus and the durable bridge table, not merely
+ * through hand-built fixtures.
+ */
+import { afterAll, beforeAll, describe, expect, test, vi } from 'vitest'
+
+import { db } from '../../src/db/db'
+import { eventBus } from '../../src/integration/events/event-bus'
+import { poolManager } from '../../src/integration/db/connection-pool'
+import { AutomationService } from '../../src/multitable/automation-service'
+import { normalizeWorkflowJob } from '../../src/multitable/workflow-job-contract'
+import { ApprovalProductService } from '../../src/services/ApprovalProductService'
+import { ensureApprovalSchemaReady } from '../helpers/approval-schema-bootstrap'
+
+const describeIfDatabase = process.env.DATABASE_URL ? describe : describe.skip
+
+const TS = Date.now()
+const BASE = `base_w6_start_${TS}`
+const SHEET = `sheet_w6_start_${TS}`
+const RECORD = `rec_w6_${TS}`
+const REQUESTER = `w6_requester_${TS}`
+const APPROVER = `w6_approver_${TS}`
+const NO_APPROVAL_PERMISSION = `w6_no_approval_${TS}`
+const q = (sql: string, params?: unknown[]) => poolManager.get().query(sql, params)
+
+const executionIds: string[] = []
+const ruleIds: string[] = []
+const templateIds: string[] = []
+const approvalIds: string[] = []
+let templateSeq = 0
+
+function makeAutomationService(fetchFn?: typeof fetch): AutomationService {
+  const svc = new AutomationService(eventBus, db as never, q as never, fetchFn as never)
+  svc.init()
+  return svc
+}
+
+async function seedUsers(): Promise<void> {
+  await q(
+    `INSERT INTO permissions (code, name, description)
+     VALUES ('approvals:write', 'Approvals Write', 'Start approvals from automation tests')
+     ON CONFLICT (code) DO NOTHING`,
+  )
+  for (const [id, email] of [
+    [REQUESTER, `${REQUESTER}@example.test`],
+    [APPROVER, `${APPROVER}@example.test`],
+    [NO_APPROVAL_PERMISSION, `${NO_APPROVAL_PERMISSION}@example.test`],
+  ]) {
+    await q(
+      `INSERT INTO users (id, email, name, password_hash, role, permissions, is_active, is_admin)
+       VALUES ($1, $2, $1, 'x', 'user', '[]'::jsonb, TRUE, FALSE)
+       ON CONFLICT (id) DO UPDATE
+          SET is_active = TRUE,
+              email = EXCLUDED.email,
+              name = EXCLUDED.name`,
+      [id, email],
+    )
+  }
+  await q(
+    `INSERT INTO user_permissions (user_id, permission_code)
+     VALUES ($1, 'approvals:write')
+     ON CONFLICT DO NOTHING`,
+    [REQUESTER],
+  )
+}
+
+function approvalTemplateRequest() {
+  templateSeq += 1
+  return {
+    key: `w6-start-${TS}-${templateSeq}`,
+    name: 'W6 Start Approval',
+    visibilityScope: { type: 'all', ids: [] },
+    formSchema: {
+      fields: [
+        { id: 'summary', type: 'text', label: 'Summary', required: true },
+      ],
+    },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: 'Start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          name: 'Approver',
+          config: {
+            assigneeSources: [{ kind: 'static_user', userIds: [APPROVER] }],
+            approvalMode: 'single',
+            emptyAssigneePolicy: 'error',
+          },
+        },
+        { key: 'end', type: 'end', name: 'End', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+      ],
+    },
+  }
+}
+
+function autoApproveTemplateRequest() {
+  templateSeq += 1
+  return {
+    key: `w6-auto-${TS}-${templateSeq}`,
+    name: 'W6 Auto Approval',
+    visibilityScope: { type: 'all', ids: [] },
+    formSchema: {
+      fields: [
+        { id: 'summary', type: 'text', label: 'Summary', required: true },
+      ],
+    },
+    approvalGraph: {
+      nodes: [
+        { key: 'start', type: 'start', name: 'Start', config: {} },
+        {
+          key: 'approval_1',
+          type: 'approval',
+          name: 'Auto',
+          config: {
+            assigneeSources: [{ kind: 'requester' }],
+            approvalMode: 'single',
+            emptyAssigneePolicy: 'error',
+          },
+        },
+        { key: 'end', type: 'end', name: 'End', config: {} },
+      ],
+      edges: [
+        { key: 'edge-start-approval_1', source: 'start', target: 'approval_1' },
+        { key: 'edge-approval_1-end', source: 'approval_1', target: 'end' },
+      ],
+    },
+  }
+}
+
+async function createPublishedTemplate(
+  request: Record<string, unknown> = approvalTemplateRequest(),
+  policy: Record<string, unknown> = { allowRevoke: true },
+): Promise<string> {
+  const approvals = new ApprovalProductService()
+  const template = await approvals.createTemplate(request as never)
+  templateIds.push(template.id)
+  await approvals.publishTemplate(template.id, { policy } as never)
+  return template.id
+}
+
+async function createStartApprovalRule(svc: AutomationService, templateId: string): Promise<string> {
+  const startApproval = {
+    type: 'start_approval',
+    config: {
+      templateId,
+      formDataMapping: {
+        summary: 'Record {{record.title}} needs approval',
+      },
+      requester: { mode: 'trigger_actor' },
+    },
+  } as const
+  const created = await svc.createRule(SHEET, {
+    name: 'W6 start approval',
+    triggerType: 'record.created',
+    triggerConfig: {},
+    actionType: 'start_approval',
+    actionConfig: startApproval.config,
+    actions: [
+      startApproval,
+      { type: 'send_webhook', config: { url: 'https://example.test/w6-tail' } },
+    ] as never,
+    executionMode: 'workflow_job_v1',
+    createdBy: REQUESTER,
+  })
+  ruleIds.push(created.id)
+  return created.id
+}
+
+async function seedSheetRecord(title: string): Promise<void> {
+  await q(
+    `INSERT INTO meta_bases (id, name)
+     VALUES ($1, $2)
+     ON CONFLICT (id) DO NOTHING`,
+    [BASE, 'W6 Base'],
+  )
+  await q(
+    `INSERT INTO meta_sheets (id, base_id, name)
+     VALUES ($1, $2, $3)
+     ON CONFLICT (id) DO NOTHING`,
+    [SHEET, BASE, 'W6 Sheet'],
+  )
+  await q(
+    `INSERT INTO meta_records (id, sheet_id, data, version, created_by)
+     VALUES ($1, $2, $3::jsonb, 1, $4)
+     ON CONFLICT (id) DO UPDATE
+        SET data = EXCLUDED.data,
+            updated_at = NOW()`,
+    [RECORD, SHEET, JSON.stringify({ title }), REQUESTER],
+  )
+}
+
+async function waitForExecutionStatus(svc: AutomationService, id: string, status: string) {
+  await vi.waitFor(async () => {
+    const execution = await svc.logs.getById(id)
+    expect(execution?.status, JSON.stringify(execution)).toBe(status)
+  }, { timeout: 5000, interval: 50 })
+  return (await svc.logs.getById(id))!
+}
+
+describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)', () => {
+  beforeAll(async () => {
+    await ensureApprovalSchemaReady()
+    await seedUsers()
+  })
+
+  afterAll(async () => {
+    for (const id of executionIds) {
+      await q('DELETE FROM multitable_automation_approval_bridges WHERE execution_id = $1', [id])
+      await q('DELETE FROM multitable_automation_suspensions WHERE execution_id = $1', [id])
+      await q('DELETE FROM multitable_automation_jobs WHERE execution_id = $1', [id])
+      await q('DELETE FROM multitable_automation_executions WHERE id = $1', [id])
+    }
+    for (const id of approvalIds) {
+      await q('DELETE FROM approval_records WHERE instance_id = $1', [id])
+      await q('DELETE FROM approval_assignments WHERE instance_id = $1', [id])
+      await q('DELETE FROM approval_instances WHERE id = $1', [id])
+    }
+    for (const id of ruleIds) {
+      await q('DELETE FROM automation_rules WHERE id = $1', [id])
+    }
+    await q('DELETE FROM meta_records WHERE sheet_id = $1', [SHEET])
+    await q('DELETE FROM meta_sheets WHERE id = $1', [SHEET])
+    await q('DELETE FROM meta_bases WHERE id = $1', [BASE])
+    for (const id of templateIds) {
+      await q('DELETE FROM approval_published_definitions WHERE template_id = $1::uuid', [id])
+      await q('DELETE FROM approval_template_versions WHERE template_id = $1::uuid', [id])
+      await q('DELETE FROM approval_templates WHERE id = $1::uuid', [id])
+    }
+    await q('DELETE FROM user_permissions WHERE user_id = ANY($1::text[])', [[REQUESTER, APPROVER]])
+    await q('DELETE FROM users WHERE id = ANY($1::text[])', [[REQUESTER, APPROVER, NO_APPROVAL_PERMISSION]])
+  })
+
+  test('sentinel: DATABASE_URL set', () => {
+    expect(process.env.DATABASE_URL).toBeTruthy()
+  })
+
+  test('pending approval suspends the job, then approval.approved resumes the automation tail', async () => {
+    const calls: string[] = []
+    const svc = makeAutomationService((async (url: string) => {
+      calls.push(url)
+      return new Response('OK', { status: 200 })
+    }) as never)
+    try {
+      const templateId = await createPublishedTemplate()
+      const ruleId = await createStartApprovalRule(svc, templateId)
+      await seedSheetRecord('Q4 plan')
+      const execRule = {
+        id: ruleId,
+        name: 'W6 start approval',
+        sheetId: SHEET,
+        trigger: { type: 'record.created', config: {} },
+        actions: [
+          {
+            type: 'start_approval',
+            config: {
+              templateId,
+              formDataMapping: { summary: 'Record {{record.title}} needs approval' },
+              requester: { mode: 'trigger_actor' },
+            },
+          },
+          { type: 'send_webhook', config: { url: 'https://example.test/w6-tail' } },
+        ],
+        enabled: true,
+        createdBy: REQUESTER,
+        createdAt: new Date(TS).toISOString(),
+        executionMode: 'workflow_job_v1',
+      }
+
+      const execution = await svc.executeRule(execRule as never, {
+        sheetId: SHEET,
+        recordId: RECORD,
+        data: { title: 'Q4 plan' },
+        actorId: REQUESTER,
+      })
+      executionIds.push(execution.id)
+
+      expect(execution.status).toBe('running')
+      expect(execution.steps).toEqual([])
+      expect(calls).toEqual([])
+
+      const bridge = await q(
+        `SELECT status, approval_instance_id, approval_template_id, step_index, trigger_event
+           FROM multitable_automation_approval_bridges
+          WHERE execution_id = $1`,
+        [execution.id],
+      )
+      expect(bridge.rows).toHaveLength(1)
+      expect(bridge.rows[0].status).toBe('pending')
+      expect(bridge.rows[0].approval_instance_id).toBeTruthy()
+      expect(bridge.rows[0].approval_template_id).toBe(templateId)
+      expect(bridge.rows[0].step_index).toBe(0)
+      expect(JSON.stringify(bridge.rows[0].trigger_event)).toContain('Q4 plan')
+      approvalIds.push(bridge.rows[0].approval_instance_id)
+
+      const jobs = await svc.jobs.listByExecution(execution.id)
+      expect(jobs).toHaveLength(1)
+      expect(jobs[0]).toMatchObject({
+        status: 'suspended',
+        stepKey: '0',
+        suspend: { reason: 'manual_task', resumeToken: bridge.rows[0].approval_instance_id },
+      })
+      expect(() => normalizeWorkflowJob(jobs[0])).not.toThrow()
+
+      const approvals = new ApprovalProductService()
+      const approvalAfterAction = await approvals.dispatchAction(
+        bridge.rows[0].approval_instance_id,
+        { action: 'approve', comment: 'go' },
+        { userId: APPROVER, userName: APPROVER },
+      )
+      expect(approvalAfterAction.status).toBe('approved')
+
+      const resumed = await waitForExecutionStatus(svc, execution.id, 'success')
+      expect(resumed.steps.map((step) => [step.actionType, step.status])).toEqual([
+        ['start_approval', 'success'],
+        ['send_webhook', 'success'],
+      ])
+      expect(resumed.steps[0].output).toMatchObject({
+        approvalInstanceId: bridge.rows[0].approval_instance_id,
+        outcome: 'approved',
+      })
+      expect(calls).toEqual(['https://example.test/w6-tail'])
+
+      const finalBridge = await q(
+        'SELECT status, outcome, resumed_at FROM multitable_automation_approval_bridges WHERE execution_id = $1',
+        [execution.id],
+      )
+      expect(finalBridge.rows[0]).toMatchObject({ status: 'resumed', outcome: 'approved' })
+      expect(finalBridge.rows[0].resumed_at).toBeTruthy()
+
+      const finalJobs = await svc.jobs.listByExecution(execution.id)
+      expect(finalJobs.map((job) => job.status)).toEqual(['resolved', 'resolved'])
+      expect(finalJobs[0].result).toMatchObject({ outcome: 'approved' })
+      finalJobs.forEach((job) => expect(() => normalizeWorkflowJob(job)).not.toThrow())
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  test('rejected approval fails the automation and does not run the tail', async () => {
+    const calls: string[] = []
+    const svc = makeAutomationService((async (url: string) => {
+      calls.push(url)
+      return new Response('OK', { status: 200 })
+    }) as never)
+    try {
+      const templateId = await createPublishedTemplate()
+      const ruleId = await createStartApprovalRule(svc, templateId)
+      await seedSheetRecord('Rejected path')
+      const execRule = {
+        id: ruleId,
+        name: 'W6 rejected approval',
+        sheetId: SHEET,
+        trigger: { type: 'record.created', config: {} },
+        actions: [
+          {
+            type: 'start_approval',
+            config: {
+              templateId,
+              formDataMapping: { summary: 'Record {{record.title}} needs approval' },
+              requester: { mode: 'trigger_actor' },
+            },
+          },
+          { type: 'send_webhook', config: { url: 'https://example.test/w6-rejected-tail' } },
+        ],
+        enabled: true,
+        createdBy: REQUESTER,
+        createdAt: new Date(TS).toISOString(),
+        executionMode: 'workflow_job_v1',
+      }
+
+      const execution = await svc.executeRule(execRule as never, {
+        sheetId: SHEET,
+        recordId: RECORD,
+        data: { title: 'Rejected path' },
+        actorId: REQUESTER,
+      })
+      executionIds.push(execution.id)
+      const bridge = await q(
+        `SELECT approval_instance_id
+           FROM multitable_automation_approval_bridges
+          WHERE execution_id = $1`,
+        [execution.id],
+      )
+      approvalIds.push(bridge.rows[0].approval_instance_id)
+
+      const approvals = new ApprovalProductService()
+      const approvalAfterAction = await approvals.dispatchAction(
+        bridge.rows[0].approval_instance_id,
+        { action: 'reject', comment: 'no' },
+        { userId: APPROVER, userName: APPROVER },
+      )
+      expect(approvalAfterAction.status).toBe('rejected')
+
+      const failed = await waitForExecutionStatus(svc, execution.id, 'failed')
+      expect(failed.steps).toHaveLength(1)
+      expect(failed.steps[0]).toMatchObject({
+        actionType: 'start_approval',
+        status: 'failed',
+        error: 'Approval completed with rejected',
+      })
+      expect(calls).toEqual([])
+
+      const finalBridge = await q(
+        'SELECT status, outcome FROM multitable_automation_approval_bridges WHERE execution_id = $1',
+        [execution.id],
+      )
+      expect(finalBridge.rows[0]).toMatchObject({ status: 'resumed', outcome: 'rejected' })
+
+      const jobs = await svc.jobs.listByExecution(execution.id)
+      expect(jobs).toHaveLength(1)
+      expect(jobs[0]).toMatchObject({ status: 'failed', error: 'Approval completed with rejected' })
+      expect(() => normalizeWorkflowJob(jobs[0])).not.toThrow()
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  test('retry lineage guard blocks re-running a root after a child retry creates an approval', async () => {
+    const svc = makeAutomationService()
+    try {
+      const templateId = await createPublishedTemplate()
+      const ruleId = await createStartApprovalRule(svc, templateId)
+      await seedSheetRecord('Retry root')
+      const rootId = `axe_w6_root_${TS}`
+      await svc.logs.record({
+        id: rootId,
+        ruleId,
+        triggeredBy: 'event',
+        triggeredAt: new Date().toISOString(),
+        status: 'failed',
+        steps: [{ actionType: 'send_webhook', status: 'failed', error: 'seed failure', durationMs: 1 }],
+        error: 'seed failure',
+        sheetId: SHEET,
+        triggerEvent: {
+          sheetId: SHEET,
+          recordId: RECORD,
+          data: { title: 'Retry root' },
+          actorId: REQUESTER,
+        },
+      })
+      executionIds.push(rootId)
+
+      const firstRetry = await svc.retryExecution(rootId, REQUESTER)
+      expect('execution' in firstRetry).toBe(true)
+      if (!('execution' in firstRetry)) throw new Error('retry did not create execution')
+      executionIds.push(firstRetry.execution.id)
+      expect(firstRetry.execution.status).toBe('running')
+
+      const bridge = await q(
+        `SELECT root_execution_id, approval_instance_id
+           FROM multitable_automation_approval_bridges
+          WHERE execution_id = $1`,
+        [firstRetry.execution.id],
+      )
+      expect(bridge.rows).toHaveLength(1)
+      expect(bridge.rows[0].root_execution_id).toBe(rootId)
+      approvalIds.push(bridge.rows[0].approval_instance_id)
+
+      const secondRetry = await svc.retryExecution(rootId, REQUESTER)
+      expect(secondRetry).toMatchObject({
+        status: 409,
+        code: 'START_APPROVAL_ALREADY_CREATED',
+      })
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  test('requester without approvals:write fails closed before creating approval or bridge rows', async () => {
+    const calls: string[] = []
+    const svc = makeAutomationService((async (url: string) => {
+      calls.push(url)
+      return new Response('OK', { status: 200 })
+    }) as never)
+    try {
+      const templateId = await createPublishedTemplate()
+      const ruleId = await createStartApprovalRule(svc, templateId)
+      await seedSheetRecord('No approval permission')
+      const execRule = {
+        id: ruleId,
+        name: 'W6 permission denied',
+        sheetId: SHEET,
+        trigger: { type: 'record.created', config: {} },
+        actions: [
+          {
+            type: 'start_approval',
+            config: {
+              templateId,
+              formDataMapping: { summary: 'Record {{record.title}} needs approval' },
+              requester: { mode: 'trigger_actor' },
+            },
+          },
+          { type: 'send_webhook', config: { url: 'https://example.test/w6-denied-tail' } },
+        ],
+        enabled: true,
+        createdBy: REQUESTER,
+        createdAt: new Date(TS).toISOString(),
+        executionMode: 'workflow_job_v1',
+      }
+
+      const execution = await svc.executeRule(execRule as never, {
+        sheetId: SHEET,
+        recordId: RECORD,
+        data: { title: 'No approval permission' },
+        actorId: NO_APPROVAL_PERMISSION,
+      })
+      executionIds.push(execution.id)
+
+      expect(execution.status).toBe('failed')
+      expect(execution.error).toContain('start_approval requester lacks approvals:write')
+      expect(execution.steps).toEqual([])
+      expect(calls).toEqual([])
+
+      const bridges = await q(
+        `SELECT id FROM multitable_automation_approval_bridges WHERE execution_id = $1`,
+        [execution.id],
+      )
+      expect(bridges.rows).toHaveLength(0)
+      const approvals = await q(
+        `SELECT id FROM approval_instances WHERE template_id = $1::uuid`,
+        [templateId],
+      )
+      expect(approvals.rows).toHaveLength(0)
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  test('bridge keeps approval id and fails execution when suspended job finalization fails', async () => {
+    const svc = makeAutomationService()
+    const writeSuspendedSpy = vi
+      .spyOn(svc.jobs, 'writeSuspendedJob')
+      .mockRejectedValueOnce(new Error('job write failed'))
+    try {
+      const templateId = await createPublishedTemplate()
+      const ruleId = await createStartApprovalRule(svc, templateId)
+      await seedSheetRecord('Bridge finalization')
+      const execRule = {
+        id: ruleId,
+        name: 'W6 bridge finalization failure',
+        sheetId: SHEET,
+        trigger: { type: 'record.created', config: {} },
+        actions: [
+          {
+            type: 'start_approval',
+            config: {
+              templateId,
+              formDataMapping: { summary: 'Record {{record.title}} needs approval' },
+              requester: { mode: 'trigger_actor' },
+            },
+          },
+          { type: 'send_webhook', config: { url: 'https://example.test/w6-finalization-tail' } },
+        ],
+        enabled: true,
+        createdBy: REQUESTER,
+        createdAt: new Date(TS).toISOString(),
+        executionMode: 'workflow_job_v1',
+      }
+
+      const execution = await svc.executeRule(execRule as never, {
+        sheetId: SHEET,
+        recordId: RECORD,
+        data: { title: 'Bridge finalization' },
+        actorId: REQUESTER,
+      })
+      executionIds.push(execution.id)
+
+      expect(writeSuspendedSpy).toHaveBeenCalledOnce()
+      expect(execution.status).toBe('failed')
+      expect(execution.error).toContain('job write failed')
+      expect(execution.steps).toEqual([])
+
+      const bridge = await q(
+        `SELECT status, approval_instance_id
+           FROM multitable_automation_approval_bridges
+          WHERE execution_id = $1`,
+        [execution.id],
+      )
+      expect(bridge.rows).toHaveLength(1)
+      expect(bridge.rows[0].status).toBe('failed')
+      expect(bridge.rows[0].approval_instance_id).toBeTruthy()
+      approvalIds.push(bridge.rows[0].approval_instance_id)
+
+      const jobs = await svc.jobs.listByExecution(execution.id)
+      expect(jobs).toEqual([])
+    } finally {
+      writeSuspendedSpy.mockRestore()
+      svc.shutdown()
+    }
+  })
+
+  test('resumed wait_for_callback tail can create a pending start_approval bridge', async () => {
+    const calls: string[] = []
+    const svc = makeAutomationService((async (url: string) => {
+      calls.push(url)
+      return new Response('OK', { status: 200 })
+    }) as never)
+    try {
+      const templateId = await createPublishedTemplate()
+      const waitAction = { type: 'wait_for_callback', config: {} } as const
+      const startApproval = {
+        type: 'start_approval',
+        config: {
+          templateId,
+          formDataMapping: {
+            summary: 'Record {{record.title}} needs approval after wait',
+          },
+          requester: { mode: 'trigger_actor' },
+        },
+      } as const
+      const tailAction = { type: 'send_webhook', config: { url: 'https://example.test/w6-wait-approval-tail' } } as const
+      const created = await svc.createRule(SHEET, {
+        name: 'W6 wait then start approval',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'wait_for_callback',
+        actionConfig: waitAction.config,
+        actions: [waitAction, startApproval, tailAction] as never,
+        executionMode: 'workflow_job_v1',
+        createdBy: REQUESTER,
+      })
+      ruleIds.push(created.id)
+      await seedSheetRecord('Wait then approval')
+
+      const execRule = {
+        id: created.id,
+        name: 'W6 wait then start approval',
+        sheetId: SHEET,
+        trigger: { type: 'record.created', config: {} },
+        actions: [waitAction, startApproval, tailAction],
+        enabled: true,
+        createdBy: REQUESTER,
+        createdAt: new Date(TS).toISOString(),
+        executionMode: 'workflow_job_v1',
+      }
+
+      const execution = await svc.executeRule(execRule as never, {
+        sheetId: SHEET,
+        recordId: RECORD,
+        data: { title: 'Wait then approval' },
+        actorId: REQUESTER,
+      })
+      executionIds.push(execution.id)
+      expect(execution.status).toBe('running')
+
+      const suspension = await q(
+        `SELECT resume_token
+           FROM multitable_automation_suspensions
+          WHERE execution_id = $1`,
+        [execution.id],
+      )
+      expect(suspension.rows).toHaveLength(1)
+
+      const resumed = await svc.resumeExecution(suspension.rows[0].resume_token, REQUESTER)
+      expect('execution' in resumed).toBe(true)
+      if (!('execution' in resumed)) throw new Error(`resume failed: ${resumed.code}`)
+      expect(resumed.execution.status).toBe('running')
+      expect(calls).toEqual([])
+
+      const bridge = await q(
+        `SELECT status, root_execution_id, approval_instance_id, step_index
+           FROM multitable_automation_approval_bridges
+          WHERE execution_id = $1`,
+        [execution.id],
+      )
+      expect(bridge.rows).toHaveLength(1)
+      expect(bridge.rows[0]).toMatchObject({
+        status: 'pending',
+        root_execution_id: execution.id,
+        step_index: 1,
+      })
+      expect(bridge.rows[0].approval_instance_id).toBeTruthy()
+      approvalIds.push(bridge.rows[0].approval_instance_id)
+
+      const jobsAfterResume = await svc.jobs.listByExecution(execution.id)
+      expect(jobsAfterResume.map((job) => job.status)).toEqual(['resolved', 'suspended'])
+      jobsAfterResume.forEach((job) => expect(() => normalizeWorkflowJob(job)).not.toThrow())
+
+      const approvals = new ApprovalProductService()
+      await approvals.dispatchAction(
+        bridge.rows[0].approval_instance_id,
+        { action: 'approve', comment: 'resume tail' },
+        { userId: APPROVER, userName: APPROVER },
+      )
+
+      const completed = await waitForExecutionStatus(svc, execution.id, 'success')
+      expect(completed.steps.map((step) => [step.actionType, step.status])).toEqual([
+        ['wait_for_callback', 'success'],
+        ['start_approval', 'success'],
+        ['send_webhook', 'success'],
+      ])
+      expect(calls).toEqual(['https://example.test/w6-wait-approval-tail'])
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  test('auto-approved approvals continue immediately without missing the create-time completion event', async () => {
+    const calls: string[] = []
+    const svc = makeAutomationService((async (url: string) => {
+      calls.push(url)
+      return new Response('OK', { status: 200 })
+    }) as never)
+    try {
+      const templateId = await createPublishedTemplate(autoApproveTemplateRequest() as never, {
+        allowRevoke: true,
+        autoApproval: { mergeWithRequester: true },
+      })
+      const ruleId = await createStartApprovalRule(svc, templateId)
+      const execRule = {
+        id: ruleId,
+        name: 'W6 auto approval',
+        sheetId: SHEET,
+        trigger: { type: 'record.created', config: {} },
+        actions: [
+          {
+            type: 'start_approval',
+            config: {
+              templateId,
+              formDataMapping: { summary: 'Record {{record.title}} needs approval' },
+              requester: { mode: 'trigger_actor' },
+            },
+          },
+          { type: 'send_webhook', config: { url: 'https://example.test/w6-auto-tail' } },
+        ],
+        enabled: true,
+        createdBy: REQUESTER,
+        createdAt: new Date(TS).toISOString(),
+        executionMode: 'workflow_job_v1',
+      }
+
+      const execution = await svc.executeRule(execRule as never, {
+        sheetId: SHEET,
+        recordId: '',
+        data: { title: 'Auto path' },
+        actorId: REQUESTER,
+      })
+      executionIds.push(execution.id)
+
+      expect(execution.status).toBe('success')
+      expect(execution.steps.map((step) => [step.actionType, step.status])).toEqual([
+        ['start_approval', 'success'],
+        ['send_webhook', 'success'],
+      ])
+      expect(calls).toEqual(['https://example.test/w6-auto-tail'])
+
+      const bridge = await q(
+        `SELECT status, outcome, approval_instance_id
+           FROM multitable_automation_approval_bridges
+          WHERE execution_id = $1`,
+        [execution.id],
+      )
+      expect(bridge.rows).toHaveLength(1)
+      expect(bridge.rows[0]).toMatchObject({ status: 'resumed', outcome: 'approved' })
+      approvalIds.push(bridge.rows[0].approval_instance_id)
+
+      const jobs = await svc.jobs.listByExecution(execution.id)
+      expect(jobs.map((job) => job.status)).toEqual(['resolved', 'resolved'])
+      jobs.forEach((job) => expect(() => normalizeWorkflowJob(job)).not.toThrow())
+    } finally {
+      svc.shutdown()
+    }
+  })
+})

--- a/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-start-approval.test.ts
@@ -570,6 +570,12 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
       return new Response('OK', { status: 200 })
     }) as never)
     try {
+      await q(
+        `UPDATE users
+            SET permissions = $2::jsonb
+          WHERE id = $1`,
+        [NO_APPROVAL_PERMISSION, JSON.stringify(['approvals:write'])],
+      )
       const templateId = await createPublishedTemplate()
       const ruleId = await createStartApprovalRule(svc, templateId)
       await seedSheetRecord('No approval permission')
@@ -618,6 +624,73 @@ describeIfDatabase('multitable automation start_approval bridge (W6-1, real DB)'
         [templateId],
       )
       expect(approvals.rows).toHaveLength(0)
+    } finally {
+      svc.shutdown()
+    }
+  })
+
+  test('resumed bridge still hydrates manual_task descriptor while job row remains suspended', async () => {
+    const svc = makeAutomationService()
+    try {
+      const templateId = await createPublishedTemplate()
+      const ruleId = await createStartApprovalRule(svc, templateId)
+      await seedSheetRecord('Post-claim settle window')
+      const execRule = {
+        id: ruleId,
+        name: 'W6 post-claim settle window',
+        sheetId: SHEET,
+        trigger: { type: 'record.created', config: {} },
+        actions: [
+          {
+            type: 'start_approval',
+            config: {
+              templateId,
+              formDataMapping: { summary: 'Record {{record.title}} needs approval' },
+              requester: { mode: 'trigger_actor' },
+            },
+          },
+          { type: 'send_webhook', config: { url: 'https://example.test/w6-post-claim-tail' } },
+        ],
+        enabled: true,
+        createdBy: REQUESTER,
+        createdAt: new Date(TS).toISOString(),
+        executionMode: 'workflow_job_v1',
+      }
+
+      const execution = await svc.executeRule(execRule as never, {
+        sheetId: SHEET,
+        recordId: RECORD,
+        data: { title: 'Post-claim settle window' },
+        actorId: REQUESTER,
+      })
+      executionIds.push(execution.id)
+
+      const bridge = await q(
+        `SELECT approval_instance_id
+           FROM multitable_automation_approval_bridges
+          WHERE execution_id = $1`,
+        [execution.id],
+      )
+      expect(bridge.rows).toHaveLength(1)
+      approvalIds.push(bridge.rows[0].approval_instance_id)
+
+      await q(
+        `UPDATE multitable_automation_approval_bridges
+            SET status = 'resumed',
+                outcome = 'approved',
+                completed_at = NOW(),
+                resumed_at = NOW()
+          WHERE execution_id = $1`,
+        [execution.id],
+      )
+
+      const jobs = await svc.jobs.listByExecution(execution.id)
+      expect(jobs).toHaveLength(1)
+      expect(jobs[0]).toMatchObject({
+        status: 'suspended',
+        suspend: { reason: 'manual_task', resumeToken: bridge.rows[0].approval_instance_id },
+      })
+      expect(() => normalizeWorkflowJob(jobs[0])).not.toThrow()
     } finally {
       svc.shutdown()
     }

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -2275,6 +2275,59 @@ describe('AutomationService — Rule CRUD', () => {
     expect(rule.execution_mode).toBe('workflow_job_v1')
   })
 
+  it('W6-1: createRule accepts start_approval only with workflow_job_v1', async () => {
+    const action = {
+      type: 'start_approval',
+      config: {
+        templateId: 'tpl_1',
+        formDataMapping: { amount: '{{record.amount}}', reviewer: '{{record.reviewer}}' },
+      },
+    } as const
+
+    dbExecuteResults.push([])
+    const rule = await service.createRule('sheet_1', {
+      name: 'Approval rule',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'start_approval',
+      actionConfig: action.config,
+      actions: [action],
+      executionMode: 'workflow_job_v1',
+      createdBy: 'user_1',
+    })
+
+    expect(rule.action_type).toBe('start_approval')
+    expect(rule.actions).toEqual([action])
+    expect(rule.execution_mode).toBe('workflow_job_v1')
+
+    const promise = service.createRule('sheet_1', {
+      name: 'Approval rule legacy',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'start_approval',
+      actionConfig: action.config,
+      actions: [action],
+      createdBy: 'user_1',
+    })
+    await expect(promise).rejects.toThrow('condition_branch/start_approval requires execution_mode workflow_job_v1')
+  })
+
+  it('W6-1: createRule rejects invalid start_approval config before persistence', async () => {
+    const promise = service.createRule('sheet_1', {
+      name: 'Broken approval rule',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'start_approval',
+      actionConfig: { templateId: '', formDataMapping: {} },
+      actions: [{ type: 'start_approval', config: { templateId: '', formDataMapping: {} } }],
+      executionMode: 'workflow_job_v1',
+      createdBy: 'user_1',
+    })
+
+    await expect(promise).rejects.toThrow('actionConfig.templateId is required')
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
   it('A6-3-1: createRule accepts condition_branch only with workflow_job_v1', async () => {
     const action = {
       type: 'condition_branch',
@@ -2316,7 +2369,7 @@ describe('AutomationService — Rule CRUD', () => {
       actions: [action],
       createdBy: 'user_1',
     })
-    await expect(promise).rejects.toThrow('condition_branch requires execution_mode workflow_job_v1')
+    await expect(promise).rejects.toThrow('requires execution_mode workflow_job_v1')
   })
 
   it('A6-3-1: createRule rejects wait_for_callback inside a condition_branch branch', async () => {
@@ -2629,6 +2682,59 @@ describe('AutomationService — Rule CRUD', () => {
     expect(rule?.execution_mode).toBe('workflow_job_v1')
   })
 
+  it('W6-1: updateRule accepts start_approval with workflow_job_v1', async () => {
+    const action = {
+      type: 'start_approval',
+      config: {
+        templateId: 'tpl_1',
+        formDataMapping: { amount: '{{record.amount}}' },
+      },
+    }
+    dbExecuteTakeFirstResults.push(makeRuleRow({
+      action_type: 'update_record',
+      action_config: { fields: { status: 'before' } },
+      actions: [{ type: 'update_record', config: { fields: { status: 'before' } } }],
+    }))
+    dbExecuteResults.push([makeRuleRow({
+      action_type: 'start_approval',
+      action_config: action.config,
+      actions: [action],
+      execution_mode: 'workflow_job_v1',
+    })])
+
+    const rule = await service.updateRule('atr_1', 'sheet_1', {
+      actionType: 'start_approval',
+      actionConfig: action.config,
+      actions: [action],
+      executionMode: 'workflow_job_v1',
+    })
+
+    expect(rule?.action_type).toBe('start_approval')
+    expect(rule?.actions).toEqual([action])
+    expect(rule?.execution_mode).toBe('workflow_job_v1')
+  })
+
+  it('W6-1: updateRule rejects turning a start_approval rule back to legacy', async () => {
+    const action = {
+      type: 'start_approval',
+      config: {
+        templateId: 'tpl_1',
+        formDataMapping: { amount: '{{record.amount}}' },
+      },
+    }
+    dbExecuteTakeFirstResults.push(makeRuleRow({
+      action_type: 'start_approval',
+      action_config: action.config,
+      actions: [action],
+      execution_mode: 'workflow_job_v1',
+    }))
+
+    const promise = service.updateRule('atr_1', 'sheet_1', { executionMode: null })
+
+    await expect(promise).rejects.toThrow('condition_branch/start_approval requires execution_mode workflow_job_v1')
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
   it('A6-3-1: updateRule rejects turning a condition_branch rule back to legacy', async () => {
     const branchAction = {
       type: 'condition_branch',
@@ -2649,7 +2755,7 @@ describe('AutomationService — Rule CRUD', () => {
 
     const promise = service.updateRule('atr_1', 'sheet_1', { executionMode: null })
 
-    await expect(promise).rejects.toThrow('condition_branch requires execution_mode workflow_job_v1')
+    await expect(promise).rejects.toThrow('requires execution_mode workflow_job_v1')
     expect(dbExecuteResults).toHaveLength(0)
   })
 
@@ -2961,7 +3067,7 @@ describe('AutomationService — retryExecution (A5)', () => {
     expect(r).toEqual({ execution: newExec })
     const [, triggerEvent, retryMeta] = execSpy.mock.calls[0]
     expect(triggerEvent).toEqual({ recordId: 'rec1', data: { name: 'Bolt' } }) // original stored trigger event reused
-    expect(retryMeta).toEqual({ rerunOfExecutionId: 'axe_orig', initiatedBy: 'admin1' })
+    expect(retryMeta).toEqual({ rerunOfExecutionId: 'axe_orig', initiatedBy: 'admin1', rootExecutionId: 'axe_orig' })
   })
 
   it('D1 — retry uses the CURRENT rule (live token), never the redacted rule_snapshot', async () => {

--- a/packages/core-backend/tests/unit/condition-branch-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/condition-branch-automation-action-migration.test.ts
@@ -1,18 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { ALL_ACTION_TYPES } from '../../src/multitable/automation-actions'
 import {
   AUTOMATION_ACTION_TYPES_BEFORE_CONDITION_BRANCH,
   AUTOMATION_ACTION_TYPES_WITH_CONDITION_BRANCH,
 } from '../../src/db/migrations/zzzz20260605130000_add_condition_branch_automation_action'
 
 describe('condition_branch automation action migration (A6-3-1)', () => {
-  it('keeps the latest database action constraint in sync with app-level action types', () => {
-    // The LATEST chk_automation_action_type constraint must accept EVERY app action type.
-    for (const actionType of ALL_ACTION_TYPES) {
-      expect(AUTOMATION_ACTION_TYPES_WITH_CONDITION_BRANCH).toContain(actionType)
-    }
-  })
-
   it('adds condition_branch on top of the prior wait_for_callback action set, and nothing else', () => {
     expect(AUTOMATION_ACTION_TYPES_WITH_CONDITION_BRANCH).toContain('condition_branch')
     expect(AUTOMATION_ACTION_TYPES_BEFORE_CONDITION_BRANCH).not.toContain('condition_branch')

--- a/packages/core-backend/tests/unit/multitable-automation-service.test.ts
+++ b/packages/core-backend/tests/unit/multitable-automation-service.test.ts
@@ -327,7 +327,7 @@ describe('AutomationService', () => {
       const unsubscribeSpy = vi.spyOn(bus, 'unsubscribe')
 
       service.init()
-      expect(subscribeSpy).toHaveBeenCalledTimes(3)
+      expect(subscribeSpy).toHaveBeenCalledTimes(7)
       expect(subscribeSpy).toHaveBeenCalledWith(
         'multitable.record.created',
         expect.any(Function),
@@ -340,9 +340,25 @@ describe('AutomationService', () => {
         'multitable.record.deleted',
         expect.any(Function),
       )
+      expect(subscribeSpy).toHaveBeenCalledWith(
+        'approval.approved',
+        expect.any(Function),
+      )
+      expect(subscribeSpy).toHaveBeenCalledWith(
+        'approval.rejected',
+        expect.any(Function),
+      )
+      expect(subscribeSpy).toHaveBeenCalledWith(
+        'approval.revoked',
+        expect.any(Function),
+      )
+      expect(subscribeSpy).toHaveBeenCalledWith(
+        'approval.cancelled',
+        expect.any(Function),
+      )
 
       service.shutdown()
-      expect(unsubscribeSpy).toHaveBeenCalledTimes(3)
+      expect(unsubscribeSpy).toHaveBeenCalledTimes(7)
     })
   })
 })

--- a/packages/core-backend/tests/unit/start-approval-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/start-approval-automation-action-migration.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { ALL_ACTION_TYPES } from '../../src/multitable/automation-actions'
+import {
+  AUTOMATION_ACTION_TYPES_BEFORE_START_APPROVAL,
+  AUTOMATION_ACTION_TYPES_WITH_START_APPROVAL,
+} from '../../src/db/migrations/zzzz20260610150000_create_automation_approval_bridges'
+
+describe('start_approval automation action migration (W6-1)', () => {
+  it('keeps the latest database action constraint in sync with app-level action types', () => {
+    for (const actionType of ALL_ACTION_TYPES) {
+      expect(AUTOMATION_ACTION_TYPES_WITH_START_APPROVAL).toContain(actionType)
+    }
+  })
+
+  it('adds start_approval on top of the prior condition_branch action set, and nothing else', () => {
+    expect(AUTOMATION_ACTION_TYPES_WITH_START_APPROVAL).toContain('start_approval')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_START_APPROVAL).not.toContain('start_approval')
+    expect(AUTOMATION_ACTION_TYPES_WITH_START_APPROVAL.filter((a) => a !== 'start_approval'))
+      .toEqual([...AUTOMATION_ACTION_TYPES_BEFORE_START_APPROVAL])
+  })
+
+  it('rolls back only the start_approval widening', () => {
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_START_APPROVAL).not.toContain('start_approval')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_START_APPROVAL).toContain('condition_branch')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_START_APPROVAL).toContain('wait_for_callback')
+  })
+})


### PR DESCRIPTION
## Summary

Adds W6-1 `start_approval` runtime for opted-in multitable automations (`execution_mode = workflow_job_v1`). This lets an automation action create one approval instance from an approval template, suspend as a C1 `manual_task`, and resume the remaining automation tail from approval-product terminal events.

## Scope

- Add `start_approval` to the automation action registry and DB action-type constraint.
- Add `multitable_automation_approval_bridges` for durable automation execution/job ↔ approval instance linkage.
- Wire `AutomationApprovalBridgeService` into `AutomationService` and `AutomationExecutor`.
- Hydrate pending approval bridges as C1 `suspended` jobs with `suspend.reason = manual_task`.
- Block A5 whole-execution retry for executions that already created approvals in their lineage.
- Add targeted CI coverage in `plugin-tests.yml` for the real-DB W6 seam.

## Guardrails

- `start_approval` requires `workflow_job_v1`; legacy/off-path rules fail closed.
- No automation UI changes in this PR.
- No approval trigger bindings, result backwrite, BPMN, public webhook emitter, or A6-3-3 nesting unlock.
- Branch/default nested `start_approval` remains rejected until a separate named gate.
- Requester must pass the narrowed approvals write authorization path; raw `users.permissions` and raw `users.is_admin` are not trusted for this bridge.

## Review loop

Subagent review was used as requested. Raman reviewed the diff through three rounds:

1. REQUEST CHANGES: retry lineage, bridge finalization, auth width, terminal negative, migration checks.
2. REQUEST CHANGES: resumed `wait_for_callback` tail lacked `onStartApproval` lifecycle.
3. APPROVE: no blocking findings.

## Tests

- `pnpm --filter @metasheet/core-backend build`
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/automation-v1.test.ts tests/unit/start-approval-automation-action-migration.test.ts tests/unit/condition-branch-automation-action-migration.test.ts --reporter=dot`
- `DATABASE_URL=postgresql://chouhua@localhost:5432/metasheet_test pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-automation-start-approval.test.ts --reporter=dot`
- `git diff --check HEAD~1 HEAD`

Real-DB W6 test coverage includes:

- pending approval suspends a C1 job and approved completion resumes the tail;
- rejected approval fails the automation and does not run the tail;
- root retry lineage guard blocks duplicate approval creation;
- requester without `approvals:write` fails closed before bridge/approval creation;
- bridge retains `approval_instance_id` when job finalization fails;
- resumed `wait_for_callback` tail can create a pending `start_approval` bridge;
- auto-approved approval continues immediately without missing create-time completion.
