### PR TITLE
feat(attendance): add auto-shift auto-write admin operations UI

### DIFF
--- a/apps/web/src/views/AttendanceView.vue
+++ b/apps/web/src/views/AttendanceView.vue
@@ -2201,6 +2201,7 @@
                     >
                       <option value="preview">{{ tr('Preview only', '仅预览') }}</option>
                       <option value="apply">{{ tr('Preview + selected apply', '预览 + 手动应用所选') }}</option>
+                      <option value="auto">{{ tr('Background auto-write (configure below)', '后台自动写入（在下方配置）') }}</option>
                     </select>
                   </label>
                   <label class="attendance__field" for="attendance-auto-shift-tolerance">
@@ -2376,6 +2377,124 @@
                     </tbody>
                   </table>
                 </div>
+              </div>
+
+              <div class="attendance__admin-subsection" data-admin-card="auto-shift-auto-write">
+                <div class="attendance__admin-section-header">
+                  <div>
+                    <h4>{{ tr('Auto shift background write', '自动对班后台写入') }}</h4>
+                    <p class="attendance__field-hint">
+                      {{ tr('Runs through the attendance scheduler when the server runtime flag is also enabled. No force-write action is exposed here.', '仅在服务端运行开关同时开启时由考勤调度器执行；本卡片不提供强制写入。') }}
+                    </p>
+                  </div>
+                  <button class="attendance__btn" :disabled="autoShiftAutoWriteRunsLoading" data-auto-shift-auto="reload-runs" @click="loadAutoShiftAutoWriteRuns">
+                    {{ autoShiftAutoWriteRunsLoading ? tr('Loading...', '加载中...') : tr('Reload runs', '刷新运行记录') }}
+                  </button>
+                </div>
+                <div class="attendance__admin-grid">
+                  <label class="attendance__field attendance__field--checkbox" for="attendance-auto-shift-auto-enabled">
+                    <span>{{ tr('Enable auto matching for this org', '启用本组织自动对班') }}</span>
+                    <input
+                      id="attendance-auto-shift-auto-enabled"
+                      v-model="autoShiftAutoWriteForm.enabled"
+                      type="checkbox"
+                      data-auto-shift-auto="enabled"
+                    />
+                  </label>
+                  <label class="attendance__field attendance__field--checkbox" for="attendance-auto-shift-auto-write-enabled">
+                    <span>{{ tr('Enable background writes', '启用后台自动写入') }}</span>
+                    <input
+                      id="attendance-auto-shift-auto-write-enabled"
+                      v-model="autoShiftAutoWriteForm.autoWriteEnabled"
+                      type="checkbox"
+                      data-auto-shift-auto="auto-write-enabled"
+                    />
+                  </label>
+                  <label class="attendance__field" for="attendance-auto-shift-auto-lookahead">
+                    <span>{{ tr('Lookahead days', '向前扫描天数') }}</span>
+                    <input
+                      id="attendance-auto-shift-auto-lookahead"
+                      v-model="autoShiftAutoWriteForm.lookaheadDays"
+                      type="number"
+                      min="1"
+                      max="3"
+                      inputmode="numeric"
+                      data-auto-shift-auto="lookahead-days"
+                    />
+                  </label>
+                  <label class="attendance__field" for="attendance-auto-shift-auto-max">
+                    <span>{{ tr('Max assignments per run', '单次最多写入') }}</span>
+                    <input
+                      id="attendance-auto-shift-auto-max"
+                      v-model="autoShiftAutoWriteForm.maxAssignmentsPerRun"
+                      type="number"
+                      min="1"
+                      max="100"
+                      inputmode="numeric"
+                      data-auto-shift-auto="max-assignments"
+                    />
+                  </label>
+                  <label class="attendance__field" for="attendance-auto-shift-auto-confidence">
+                    <span>{{ tr('Auto-write confidence', '自动写入置信度') }}</span>
+                    <select
+                      id="attendance-auto-shift-auto-confidence"
+                      v-model="autoShiftAutoWriteForm.minConfidence"
+                      disabled
+                      data-auto-shift-auto="min-confidence"
+                    >
+                      <option value="high">{{ tr('High only', '仅高置信度') }}</option>
+                    </select>
+                  </label>
+                </div>
+                <button
+                  class="attendance__btn attendance__btn--primary"
+                  :disabled="settingsLoading"
+                  data-auto-shift-auto="save"
+                  @click="saveAutoShiftAutoWriteSettings"
+                >
+                  {{ settingsLoading ? tr('Saving...', '保存中...') : tr('Save auto-write settings', '保存后台写入设置') }}
+                </button>
+                <p class="attendance__field-hint" data-auto-shift-auto="runtime-flag">
+                  {{ tr('Server runtime flag: not exposed in this UI; if it is off, runs stay disabled even when this card is enabled.', '服务端运行开关：此界面不展示；若服务端关闭，即使本卡片开启也不会执行写入。') }}
+                </p>
+                <p v-if="autoShiftAutoWriteRunsError" class="attendance__field-hint attendance__field-hint--error" data-auto-shift-auto="runs-error">
+                  {{ autoShiftAutoWriteRunsError }}
+                </p>
+                <div v-if="!autoShiftAutoWriteRunsLoading && autoShiftAutoWriteRuns.length === 0" class="attendance__empty" data-auto-shift-auto="runs-empty">
+                  {{ tr('No auto-write runs yet.', '暂无后台写入运行记录。') }}
+                </div>
+                <div v-if="autoShiftAutoWriteRuns.length > 0" class="attendance__table-wrapper">
+                  <table class="attendance__table" data-auto-shift-auto="runs">
+                    <thead>
+                      <tr>
+                        <th>{{ tr('Window', '窗口') }}</th>
+                        <th>{{ tr('Status', '状态') }}</th>
+                        <th>{{ tr('Counts', '计数') }}</th>
+                        <th>{{ tr('Skipped reasons', '跳过原因') }}</th>
+                        <th>{{ tr('Started', '开始时间') }}</th>
+                      </tr>
+                    </thead>
+                    <tbody>
+                      <tr v-for="run in autoShiftAutoWriteRuns" :key="run.id" data-auto-shift-auto="run-row">
+                        <td>{{ run.targetFrom }} - {{ run.targetTo }}</td>
+                        <td>{{ formatStatus(run.status) }}</td>
+                        <td>
+                          {{
+                            tr(
+                              `scanned ${run.scannedCount}; candidates ${run.candidateCount}; applied ${run.appliedCount}; skipped ${run.skippedCount}; errors ${run.errorCount}`,
+                              `扫描 ${run.scannedCount}；候选 ${run.candidateCount}；写入 ${run.appliedCount}；跳过 ${run.skippedCount}；错误 ${run.errorCount}`,
+                            )
+                          }}
+                        </td>
+                        <td>{{ formatAutoShiftAutoWriteSkipReasons(run) }}</td>
+                        <td>{{ formatDateTime(run.startedAt ?? null) }}</td>
+                      </tr>
+                    </tbody>
+                  </table>
+                </div>
+                <p v-if="autoShiftAutoWriteRunsTotal > autoShiftAutoWriteRuns.length" class="attendance__field-hint" data-auto-shift-auto="runs-cap">
+                  {{ tr(`Showing first ${autoShiftAutoWriteRuns.length} of ${autoShiftAutoWriteRunsTotal}`, `仅显示前 ${autoShiftAutoWriteRuns.length}/${autoShiftAutoWriteRunsTotal} 条`) }}
+                </p>
               </div>
             </div>
 
@@ -7849,9 +7968,15 @@ interface AttendanceSettings {
   }
   autoShiftMatching?: {
     enabled?: boolean
-    mode?: 'preview' | 'apply'
+    mode?: 'preview' | 'apply' | 'auto'
     maxToleranceMinutes?: number
     minConfidenceToApply?: 'high' | 'medium' | 'low'
+    autoWrite?: {
+      enabled?: boolean
+      lookaheadDays?: number
+      maxAssignmentsPerRun?: number
+      minConfidence?: 'high'
+    }
   }
   // ② S3 punch-policy outdoor approval (backend #2308). Frontend type only — the admin card reads/writes
   // these via PUT { punchPolicy: { outdoor: ... } }. requirePhoto stays latent (no UI in S3-2).
@@ -7872,7 +7997,23 @@ interface AttendanceSettings {
 }
 
 type AutoShiftConfidence = 'high' | 'medium' | 'low'
-type AutoShiftMode = 'preview' | 'apply'
+type AutoShiftMode = 'preview' | 'apply' | 'auto'
+
+interface AutoShiftAutoWriteRun {
+  id: string
+  status: string
+  targetFrom: string
+  targetTo: string
+  scannedCount: number
+  candidateCount: number
+  appliedCount: number
+  skippedCount: number
+  errorCount: number
+  errorMessage?: string | null
+  startedAt?: string | null
+  finishedAt?: string | null
+  skipReasons: Array<{ reason: string; count: number }>
+}
 
 interface AutoShiftPreviewItem {
   userId: string
@@ -11730,6 +11871,19 @@ const autoShiftMatchingForm = reactive({
   maxToleranceMinutes: '120',
   minConfidenceToApply: 'high' as AutoShiftConfidence,
 })
+// 自动对班 A2: background auto-write operations card. Saving this card explicitly puts the org in
+// mode=auto and writes ONLY the autoWrite sub-config plus the top-level enabled/mode gates.
+const autoShiftAutoWriteForm = reactive({
+  enabled: false,
+  autoWriteEnabled: false,
+  lookaheadDays: '1',
+  maxAssignmentsPerRun: '25',
+  minConfidence: 'high' as 'high',
+})
+const autoShiftAutoWriteRuns = ref<AutoShiftAutoWriteRun[]>([])
+const autoShiftAutoWriteRunsTotal = ref(0)
+const autoShiftAutoWriteRunsLoading = ref(false)
+const autoShiftAutoWriteRunsError = ref('')
 const autoShiftPreviewForm = reactive({
   from: toDateInput(new Date()),
   to: toDateInput(new Date()),
@@ -17119,6 +17273,7 @@ async function loadSettings() {
     applyOutdoorToForm(data.data || {})
     applyInOutMergeToForm(data.data || {})
     applyAutoShiftMatchingToForm(data.data || {})
+    applyAutoShiftAutoWriteToForm(data.data || {})
   } catch (error: any) {
     attendanceSettings.value = null
     setStatusFromError(error, tr('Failed to load settings', '加载设置失败'), 'admin')
@@ -17291,13 +17446,21 @@ function normalizeAutoShiftConfidence(value: unknown): AutoShiftConfidence {
 }
 
 function normalizeAutoShiftMode(value: unknown): AutoShiftMode {
-  return value === 'apply' ? 'apply' : 'preview'
+  if (value === 'apply' || value === 'auto') return value
+  return 'preview'
 }
 
 function normalizeAutoShiftTolerance(value: string | number | null | undefined, fallback = 120): number {
   const raw = String(value ?? '').trim()
   const parsed = raw ? Number(raw) : fallback
   return Number.isFinite(parsed) && parsed > 0 ? Math.floor(parsed) : fallback
+}
+
+function normalizeAutoShiftAutoWriteInt(value: string | number | null | undefined, fallback: number, min: number, max: number): number {
+  const raw = String(value ?? '').trim()
+  const parsed = raw ? Number(raw) : fallback
+  if (!Number.isFinite(parsed)) return fallback
+  return Math.max(min, Math.min(max, Math.floor(parsed)))
 }
 
 function autoShiftPreviewItemKey(item: AutoShiftPreviewItem): string {
@@ -17326,6 +17489,54 @@ function applyAutoShiftMatchingToForm(settings: AttendanceSettings) {
     normalizeAutoShiftTolerance(autoShift.maxToleranceMinutes, 120),
   )
   autoShiftMatchingForm.minConfidenceToApply = normalizeAutoShiftConfidence(autoShift.minConfidenceToApply)
+}
+
+function applyAutoShiftAutoWriteToForm(settings: AttendanceSettings) {
+  const autoShift = settings.autoShiftMatching || {}
+  const autoWrite = autoShift.autoWrite || {}
+  autoShiftAutoWriteForm.enabled = autoShift.enabled === true
+  autoShiftAutoWriteForm.autoWriteEnabled = autoWrite.enabled === true
+  autoShiftAutoWriteForm.lookaheadDays = String(
+    normalizeAutoShiftAutoWriteInt(autoWrite.lookaheadDays, 1, 1, 3),
+  )
+  autoShiftAutoWriteForm.maxAssignmentsPerRun = String(
+    normalizeAutoShiftAutoWriteInt(autoWrite.maxAssignmentsPerRun, 25, 1, 100),
+  )
+  autoShiftAutoWriteForm.minConfidence = 'high'
+}
+
+function normalizeAutoShiftAutoWriteRun(value: any): AutoShiftAutoWriteRun | null {
+  if (!value || typeof value !== 'object') return null
+  const id = String(value.id || '').trim()
+  if (!id) return null
+  const skipReasons = Array.isArray(value.skipReasons)
+    ? value.skipReasons
+        .map((item: any) => ({
+          reason: String(item?.reason || '').trim(),
+          count: Number(item?.count ?? 0),
+        }))
+        .filter((item: { reason: string; count: number }) => item.reason && Number.isFinite(item.count) && item.count > 0)
+    : []
+  return {
+    id,
+    status: String(value.status || ''),
+    targetFrom: String(value.targetFrom || ''),
+    targetTo: String(value.targetTo || ''),
+    scannedCount: Number(value.scannedCount ?? 0) || 0,
+    candidateCount: Number(value.candidateCount ?? 0) || 0,
+    appliedCount: Number(value.appliedCount ?? 0) || 0,
+    skippedCount: Number(value.skippedCount ?? 0) || 0,
+    errorCount: Number(value.errorCount ?? 0) || 0,
+    errorMessage: value.errorMessage == null ? null : String(value.errorMessage),
+    startedAt: value.startedAt == null ? null : String(value.startedAt),
+    finishedAt: value.finishedAt == null ? null : String(value.finishedAt),
+    skipReasons,
+  }
+}
+
+function formatAutoShiftAutoWriteSkipReasons(run: AutoShiftAutoWriteRun): string {
+  if (!run.skipReasons.length) return run.errorMessage || '--'
+  return run.skipReasons.map(item => `${item.reason} × ${item.count}`).join(' · ')
 }
 
 async function saveShiftCompliance() {
@@ -17501,9 +17712,51 @@ async function saveAutoShiftMatchingSettings() {
     }
     adminForbidden.value = false
     applyAutoShiftMatchingToForm((data.data || payload) as AttendanceSettings)
+    applyAutoShiftAutoWriteToForm((data.data || payload) as AttendanceSettings)
     setStatus(tr('Auto shift matching settings updated.', '自动对班设置已更新。'))
   } catch (error: any) {
     setStatusFromError(error, tr('Failed to save auto shift matching', '保存自动对班失败'), 'save-settings')
+  } finally {
+    settingsLoading.value = false
+  }
+}
+
+async function saveAutoShiftAutoWriteSettings() {
+  settingsLoading.value = true
+  try {
+    // PUT ONLY the A2 gates and autoWrite sub-config. maxToleranceMinutes/minConfidenceToApply stay owned by
+    // the A1 preview/apply card and are preserved by the backend merge.
+    const payload = {
+      autoShiftMatching: {
+        enabled: autoShiftAutoWriteForm.enabled === true,
+        mode: 'auto' as AutoShiftMode,
+        autoWrite: {
+          enabled: autoShiftAutoWriteForm.autoWriteEnabled === true,
+          lookaheadDays: normalizeAutoShiftAutoWriteInt(autoShiftAutoWriteForm.lookaheadDays, 1, 1, 3),
+          maxAssignmentsPerRun: normalizeAutoShiftAutoWriteInt(autoShiftAutoWriteForm.maxAssignmentsPerRun, 25, 1, 100),
+          minConfidence: 'high' as const,
+        },
+      },
+    }
+    const response = await apiFetchWithTimeout('/api/attendance/settings', {
+      method: 'PUT',
+      body: JSON.stringify(payload),
+    }, ATTENDANCE_ADMIN_REQUEST_TIMEOUT_MS)
+    if (response.status === 403) {
+      adminForbidden.value = true
+      throw createForbiddenError()
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw createApiError(response, data, tr('Failed to save auto-write settings', '保存后台写入设置失败'))
+    }
+    adminForbidden.value = false
+    applyAutoShiftMatchingToForm((data.data || payload) as AttendanceSettings)
+    applyAutoShiftAutoWriteToForm((data.data || payload) as AttendanceSettings)
+    await loadAutoShiftAutoWriteRuns()
+    setStatus(tr('Auto-write settings updated.', '后台写入设置已更新。'))
+  } catch (error: any) {
+    setStatusFromError(error, tr('Failed to save auto-write settings', '保存后台写入设置失败'), 'save-settings')
   } finally {
     settingsLoading.value = false
   }
@@ -20884,6 +21137,35 @@ async function loadSchedulerScopes() {
   }
 }
 
+async function loadAutoShiftAutoWriteRuns() {
+  autoShiftAutoWriteRunsLoading.value = true
+  autoShiftAutoWriteRunsError.value = ''
+  try {
+    const query = buildQuery({ orgId: normalizedOrgId(), page: '1', pageSize: '5' })
+    const response = await apiFetch(`/api/attendance/auto-shift-matching/auto-write-runs?${query.toString()}`)
+    if (response.status === 403) {
+      adminForbidden.value = true
+      return
+    }
+    const data = await response.json()
+    if (!response.ok || !data.ok) {
+      throw new Error(readErrorMessage(data, tr('Failed to load auto-write runs', '加载后台写入运行记录失败')))
+    }
+    adminForbidden.value = false
+    const items = Array.isArray(data.data?.items) ? data.data.items : []
+    autoShiftAutoWriteRuns.value = items
+      .map(normalizeAutoShiftAutoWriteRun)
+      .filter((item: AutoShiftAutoWriteRun | null): item is AutoShiftAutoWriteRun => item !== null)
+    const total = Number(data.data?.total)
+    autoShiftAutoWriteRunsTotal.value = Number.isFinite(total) && total >= 0 ? total : autoShiftAutoWriteRuns.value.length
+  } catch (error: unknown) {
+    autoShiftAutoWriteRunsError.value = readErrorMessage(error, tr('Failed to load auto-write runs', '加载后台写入运行记录失败'))
+    setStatus(autoShiftAutoWriteRunsError.value, 'error')
+  } finally {
+    autoShiftAutoWriteRunsLoading.value = false
+  }
+}
+
 function schedulerScopeSubjectLabel(subjectType: string): string {
   if (subjectType === 'user') return tr('Employee', '员工')
   if (subjectType === 'role') return tr('Role', '角色')
@@ -20944,6 +21226,7 @@ async function loadAdminData() {
       loadAssignments(),
       loadRotationAssignments(),
       loadSchedulerScopes(),
+      loadAutoShiftAutoWriteRuns(),
       loadHolidays(),
     ])
   } catch (error) {

--- a/apps/web/tests/attendance-admin-regressions.spec.ts
+++ b/apps/web/tests/attendance-admin-regressions.spec.ts
@@ -120,6 +120,7 @@ describe('Attendance admin regressions', () => {
   let autoShiftPreviewData: Record<string, unknown> | null = null
   let autoShiftApplyStatus = 200
   let autoShiftApplyData: Record<string, unknown> | null = null
+  let autoShiftAutoWriteRunsData: Record<string, unknown> | null = null
 
   beforeEach(() => {
     vi.clearAllMocks()
@@ -132,6 +133,7 @@ describe('Attendance admin regressions', () => {
     autoShiftPreviewData = null
     autoShiftApplyStatus = 200
     autoShiftApplyData = null
+    autoShiftAutoWriteRunsData = null
     exportReportFieldFingerprint = 'records-unit-test-fingerprint'
     exportReportFieldCodes = 'work_date,employee_name'
     exportReportFieldCount = '2'
@@ -616,6 +618,12 @@ describe('Attendance admin regressions', () => {
         return jsonResponse(200, {
           ok: true,
           data: autoShiftApplyData ?? { runId: 'apply-run-1', applied: [], skipped: [] },
+        })
+      }
+      if (url.includes('/api/attendance/auto-shift-matching/auto-write-runs')) {
+        return jsonResponse(200, {
+          ok: true,
+          data: autoShiftAutoWriteRunsData ?? { items: [], total: 0, page: 1, pageSize: 5 },
         })
       }
       if (url.includes('/api/attendance/auto-shift-matching/preview')) {
@@ -2563,6 +2571,106 @@ describe('Attendance admin regressions', () => {
     expect(container!.querySelector('[data-auto-shift="error"]')?.textContent || '').toContain('Auto shift matching preview is disabled')
     expect(container!.querySelector('[data-auto-shift="suggestion-row"]')).toBeNull()
     expect(container!.querySelector('[data-auto-shift="apply"]')).toBeNull()
+  })
+
+  it('loads A2 auto-write settings and PUTs ONLY the auto-write gates/sub-config', async () => {
+    attendanceSettingsData = {
+      autoShiftMatching: {
+        enabled: true,
+        mode: 'auto',
+        maxToleranceMinutes: 80,
+        minConfidenceToApply: 'medium',
+        autoWrite: {
+          enabled: true,
+          lookaheadDays: 3,
+          maxAssignmentsPerRun: 40,
+          minConfidence: 'high',
+        },
+      },
+    }
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(16)
+
+    const enabled = container!.querySelector<HTMLInputElement>('[data-auto-shift-auto="enabled"]')
+    const autoWriteEnabled = container!.querySelector<HTMLInputElement>('[data-auto-shift-auto="auto-write-enabled"]')
+    const lookahead = container!.querySelector<HTMLInputElement>('[data-auto-shift-auto="lookahead-days"]')
+    const maxAssignments = container!.querySelector<HTMLInputElement>('[data-auto-shift-auto="max-assignments"]')
+    const minConfidence = container!.querySelector<HTMLSelectElement>('[data-auto-shift-auto="min-confidence"]')
+    expect(Boolean(enabled && autoWriteEnabled && lookahead && maxAssignments && minConfidence)).toBe(true)
+    expect(enabled!.checked).toBe(true)
+    expect(autoWriteEnabled!.checked).toBe(true)
+    expect(lookahead!.value).toBe('3')
+    expect(maxAssignments!.value).toBe('40')
+    expect(minConfidence!.value).toBe('high')
+
+    autoWriteEnabled!.checked = false
+    autoWriteEnabled!.dispatchEvent(new Event('change'))
+    lookahead!.value = '2'
+    lookahead!.dispatchEvent(new Event('input'))
+    maxAssignments!.value = '12'
+    maxAssignments!.dispatchEvent(new Event('input'))
+    await flushUi(2)
+    container!.querySelector<HTMLButtonElement>('[data-auto-shift-auto="save"]')!.click()
+    await flushUi(8)
+
+    expect(lastSettingsPutBody()).toEqual({
+      autoShiftMatching: {
+        enabled: true,
+        mode: 'auto',
+        autoWrite: {
+          enabled: false,
+          lookaheadDays: 2,
+          maxAssignmentsPerRun: 12,
+          minConfidence: 'high',
+        },
+      },
+    })
+  })
+
+  it('renders A2 auto-write run summaries and skipped reasons from the operations route', async () => {
+    autoShiftAutoWriteRunsData = {
+      items: [
+        {
+          id: 'run-a2-1',
+          status: 'partial',
+          targetFrom: '2026-06-15',
+          targetTo: '2026-06-16',
+          scannedCount: 8,
+          candidateCount: 4,
+          appliedCount: 2,
+          skippedCount: 2,
+          errorCount: 1,
+          startedAt: '2026-06-14T00:00:00.000Z',
+          skipReasons: [
+            { reason: 'scheduler_scope_forbidden', count: 2 },
+            { reason: 'max_assignments_per_run', count: 1 },
+          ],
+        },
+      ],
+      total: 3,
+      page: 1,
+      pageSize: 5,
+    }
+    app = createApp(AttendanceView, { mode: 'admin' })
+    app.mount(container!)
+    await flushUi(16)
+
+    const runsTable = container!.querySelector<HTMLElement>('[data-auto-shift-auto="runs"]')
+    expect(runsTable).toBeTruthy()
+    const text = runsTable!.textContent || ''
+    expect(text).toContain('2026-06-15 - 2026-06-16')
+    expect(text).toContain('scheduler_scope_forbidden × 2')
+    expect(text).toContain('max_assignments_per_run × 1')
+    expect(text).toContain('scanned 8; candidates 4; applied 2; skipped 2; errors 1')
+    expect(container!.querySelector('[data-auto-shift-auto="runs-cap"]')?.textContent || '').toContain('Showing first 1 of 3')
+    expect(
+      vi.mocked(apiFetch).mock.calls.some(([url]) =>
+        String(url).includes('/api/attendance/auto-shift-matching/auto-write-runs')
+        && String(url).includes('page=1')
+        && String(url).includes('pageSize=5'),
+      ),
+    ).toBe(true)
   })
 
   it('loads punchPolicy.outdoor into the card and PUTs ONLY { punchPolicy: { outdoor } } (flow id round-trips)', async () => {

--- a/packages/core-backend/tests/integration/attendance-plugin.test.ts
+++ b/packages/core-backend/tests/integration/attendance-plugin.test.ts
@@ -7379,6 +7379,105 @@ attendanceIntegrationDescribe(
       }
     })
 
+    it('returns auto-write run summaries with skipped reason counts for admin operations UI', async () => {
+      if (!baseUrl) return
+      const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+      if (!dbUrl) return
+      const runSuffix = Date.now().toString(36)
+      const orgId = `a2-ui-${runSuffix}`
+      const adminToken = await getAdminToken(`attendance-autoshift-ui-admin-${runSuffix}`)
+      expect(adminToken).toBeTruthy()
+      if (!adminToken) return
+      const pool = new Pool({ connectionString: dbUrl })
+      try {
+        await requireAttendanceTable(pool, 'attendance_auto_shift_auto_write_runs')
+        await requireAttendanceTable(pool, 'attendance_auto_shift_auto_write_run_items')
+        const runRows = await pool.query(
+          `INSERT INTO attendance_auto_shift_auto_write_runs
+             (org_id, source, status, target_from, target_to, config_snapshot,
+              scanned_count, candidate_count, applied_count, skipped_count, error_count, started_at, finished_at, created_at)
+           VALUES ($1, 'scheduler', 'partial', '2026-06-15', '2026-06-16',
+                   '{"autoShiftMatching":{"autoWrite":{"enabled":true,"lookaheadDays":2}}}'::jsonb,
+                   7, 4, 2, 2, 1,
+                   '2026-06-14T00:00:00.000Z'::timestamptz,
+                   '2026-06-14T00:00:02.000Z'::timestamptz,
+                   '2026-06-14T00:00:00.000Z'::timestamptz)
+           RETURNING id`,
+          [orgId],
+        )
+        const runId = runRows.rows[0]?.id as string | undefined
+        expect(runId).toBeTruthy()
+        await pool.query(
+          `INSERT INTO attendance_auto_shift_auto_write_run_items
+             (run_id, org_id, user_id, work_date, candidate_shift_id, confidence, status, reason, evidence_event_ids)
+           VALUES
+             ($1, $2, 'a2-ui-u1', '2026-06-15', $3::uuid, 'high', 'skipped', 'scheduler_scope_forbidden', '[]'::jsonb),
+             ($1, $2, 'a2-ui-u2', '2026-06-15', $4::uuid, 'high', 'skipped', 'max_assignments_per_run', '[]'::jsonb),
+             ($1, $2, 'a2-ui-u3', '2026-06-16', $5::uuid, 'high', 'skipped', 'scheduler_scope_forbidden', '[]'::jsonb)`,
+          [runId, orgId, randomUuidV4(), randomUuidV4(), randomUuidV4()],
+        )
+
+        const res = await requestJson(`${baseUrl}/api/attendance/auto-shift-matching/auto-write-runs?orgId=${encodeURIComponent(orgId)}&page=1&pageSize=5`, {
+          headers: { Authorization: `Bearer ${adminToken}` },
+        })
+        expect(res.status, JSON.stringify(res.body)).toBe(200)
+        const body = res.body as {
+          data?: {
+            items?: Array<{
+              id?: string
+              status?: string
+              targetFrom?: string
+              targetTo?: string
+              scannedCount?: number
+              candidateCount?: number
+              appliedCount?: number
+              skippedCount?: number
+              errorCount?: number
+              errorMessage?: string | null
+              startedAt?: string | null
+              finishedAt?: string | null
+              createdAt?: string | null
+              orgId?: string
+              source?: string
+              configSnapshot?: Record<string, unknown>
+              skipReasons?: Array<{ reason?: string; count?: number }>
+            }>
+            total?: number
+            page?: number
+            pageSize?: number
+          }
+        }
+        expect(body.data?.total).toBe(1)
+        expect(body.data?.page).toBe(1)
+        expect(body.data?.pageSize).toBe(5)
+        expect(body.data?.items).toEqual([{
+          id: runId,
+          orgId,
+          source: 'scheduler',
+          status: 'partial',
+          targetFrom: '2026-06-15',
+          targetTo: '2026-06-16',
+          configSnapshot: { autoShiftMatching: { autoWrite: { enabled: true, lookaheadDays: 2 } } },
+          scannedCount: 7,
+          candidateCount: 4,
+          appliedCount: 2,
+          skippedCount: 2,
+          errorCount: 1,
+          errorMessage: null,
+          startedAt: '2026-06-14T00:00:00.000Z',
+          finishedAt: '2026-06-14T00:00:02.000Z',
+          createdAt: '2026-06-14T00:00:00.000Z',
+          skipReasons: [
+            { reason: 'scheduler_scope_forbidden', count: 2 },
+            { reason: 'max_assignments_per_run', count: 1 },
+          ],
+        }])
+      } finally {
+        await pool.query('DELETE FROM attendance_auto_shift_auto_write_runs WHERE org_id = $1', [orgId]).catch(() => undefined)
+        await pool.end().catch(() => undefined)
+      }
+    })
+
     async function createShiftForAutoShift(token: string, name: string, start: string, end: string): Promise<string> {
       if (!baseUrl) throw new Error('baseUrl missing')
       const res = await requestJson(`${baseUrl}/api/attendance/shifts`, {

--- a/plugins/plugin-attendance/index.cjs
+++ b/plugins/plugin-attendance/index.cjs
@@ -158,15 +158,14 @@ const DEFAULT_SETTINGS = {
   overtimeSegmentation: {
     enabled: false,
   },
-  // 自动对班 (auto shift matching) — preview-only A0 foundation. Requires BOTH the
-  // runtime env flag and this org setting before the read-only preview endpoint can run.
+  // 自动对班 (auto shift matching) — A1 preview/manual apply plus A2 scheduler auto-write.
+  // Runtime still requires env flags in addition to these org settings.
   autoShiftMatching: {
     enabled: false,
     mode: 'preview',
     maxToleranceMinutes: 120,
     minConfidenceToApply: 'high',
-    // A2-0 dormant shape only. The background writer stays unavailable until
-    // mode='auto' + the scheduler slice are wired.
+    // A2 background writes require mode='auto', autoWrite.enabled=true, and the server runtime flag.
     autoWrite: {
       enabled: false,
       lookaheadDays: 1,
@@ -13174,6 +13173,34 @@ function resolveAutoShiftAutoWriteWindow(now = new Date(), lookaheadDays = DEFAU
   const from = addDaysToDateKey(today, 1) ?? today
   const to = addDaysToDateKey(from, days - 1) ?? from
   return { from, to, days }
+}
+
+function normalizeAutoShiftAutoWriteRunTimestamp(value) {
+  if (!value) return null
+  const date = value instanceof Date ? value : new Date(value)
+  return Number.isNaN(date.getTime()) ? null : date.toISOString()
+}
+
+function mapAutoShiftAutoWriteRunRow(row, skipReasons = []) {
+  return {
+    id: row.id,
+    orgId: row.org_id ?? DEFAULT_ORG_ID,
+    source: row.source ?? AUTO_SHIFT_AUTO_WRITE_SOURCE,
+    status: row.status,
+    targetFrom: normalizeDateOnly(row.target_from) ?? String(row.target_from ?? '').slice(0, 10),
+    targetTo: normalizeDateOnly(row.target_to) ?? String(row.target_to ?? '').slice(0, 10),
+    configSnapshot: normalizeMetadata(row.config_snapshot),
+    scannedCount: Number(row.scanned_count ?? 0),
+    candidateCount: Number(row.candidate_count ?? 0),
+    appliedCount: Number(row.applied_count ?? 0),
+    skippedCount: Number(row.skipped_count ?? 0),
+    errorCount: Number(row.error_count ?? 0),
+    errorMessage: row.error_message ?? null,
+    startedAt: normalizeAutoShiftAutoWriteRunTimestamp(row.started_at),
+    finishedAt: normalizeAutoShiftAutoWriteRunTimestamp(row.finished_at),
+    createdAt: normalizeAutoShiftAutoWriteRunTimestamp(row.created_at),
+    skipReasons,
+  }
 }
 
 async function loadAutoShiftAutoWriteTargetUserIds(db, orgId) {
@@ -32410,6 +32437,67 @@ module.exports = {
           }
           logger.error('Attendance shift delete failed', error)
           res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to delete shift' } })
+        }
+      })
+    )
+
+    context.api.http.addRoute(
+      'GET',
+      '/api/attendance/auto-shift-matching/auto-write-runs',
+      withPermission('attendance:admin', async (req, res) => {
+        const orgId = getOrgId(req)
+        const { page, pageSize, offset } = parsePagination(req.query, { defaultPageSize: 5, maxPageSize: 20 })
+
+        try {
+          const countRows = await db.query(
+            'SELECT COUNT(*)::int AS total FROM attendance_auto_shift_auto_write_runs WHERE org_id = $1',
+            [orgId],
+          )
+          const rows = await db.query(
+            `SELECT *
+               FROM attendance_auto_shift_auto_write_runs
+              WHERE org_id = $1
+              ORDER BY started_at DESC, created_at DESC
+              LIMIT $2 OFFSET $3`,
+            [orgId, pageSize, offset],
+          )
+          const runIds = rows.map(row => row.id).filter(Boolean)
+          const reasonRows = runIds.length
+            ? await db.query(
+                `SELECT run_id, reason, COUNT(*)::int AS count
+                   FROM attendance_auto_shift_auto_write_run_items
+                  WHERE org_id = $1
+                    AND run_id = ANY($2::uuid[])
+                    AND status = 'skipped'
+                    AND reason IS NOT NULL
+                  GROUP BY run_id, reason
+                  ORDER BY run_id ASC, count DESC, reason ASC`,
+                [orgId, runIds],
+              )
+            : []
+          const reasonsByRun = new Map()
+          for (const row of reasonRows) {
+            const runId = String(row.run_id)
+            const list = reasonsByRun.get(runId) ?? []
+            list.push({ reason: String(row.reason), count: Number(row.count ?? 0) })
+            reasonsByRun.set(runId, list)
+          }
+          res.json({
+            ok: true,
+            data: {
+              items: rows.map(row => mapAutoShiftAutoWriteRunRow(row, reasonsByRun.get(String(row.id)) ?? [])),
+              total: Number(countRows[0]?.total ?? 0),
+              page,
+              pageSize,
+            },
+          })
+        } catch (error) {
+          if (isDatabaseSchemaError(error)) {
+            res.status(503).json({ ok: false, error: { code: 'DB_NOT_READY', message: 'Attendance auto-shift auto-write tables missing' } })
+            return
+          }
+          logger.error('Attendance auto-shift auto-write runs query failed', error)
+          res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load auto-shift auto-write runs' } })
         }
       })
     )


### PR DESCRIPTION
## Summary
- add a read-only auto-shift auto-write run summary API with skip-reason aggregation for admin operations
- add the Attendance admin A2 operations card for mode=auto / autoWrite gates, lookahead, per-run cap, and recent run visibility
- extend real-wire backend and frontend mount coverage for the A2 admin UI shape

## Scope
- A2-3 admin operations UI only; no scheduler/runtime write-path changes
- no force-write action exposed
- A2 remains pending staging closeout before tracker flips to done

## Verification
- node --check plugins/plugin-attendance/index.cjs
- git diff --check
- pnpm --filter @metasheet/core-backend build
- pnpm --filter @metasheet/web exec vue-tsc -b
- pnpm --filter @metasheet/web exec vitest run tests/attendance-admin-regressions.spec.ts tests/attendance-admin-anchor-nav.spec.ts --reporter=dot
- pnpm --filter @metasheet/core-backend test:integration:attendance (local no DB: 127 skipped; CI should run real postgres)
