### PR TITLE
docs(multitable): close out start approval bridge

### DIFF
--- a/docs/development/automation-start-approval-scope-gate-20260610.md
+++ b/docs/development/automation-start-approval-scope-gate-20260610.md
@@ -325,5 +325,29 @@ W6 is complete only when:
 5. `docs/development/workflow-automation-completion-plan-20260609.md` is updated
    to mark W6 landed.
 
-After W6 lands, W7 result backwrite may be scoped. W7 still needs a separate
+After W6 landed, W7 result backwrite may be scoped. W7 still needs a separate
 gate because it writes business data and changes record state.
+
+## 12. Closeout — PR #2469
+
+W6-1 landed in #2469 under this scope gate:
+
+- canonical `start_approval` automation action;
+- `workflow_job_v1`-only execution;
+- durable automation/approval bridge row;
+- exactly one approval instance per successful bridge start;
+- suspended C1 job while waiting for approval terminal completion;
+- W5 `approval.approved/rejected/revoked/cancelled` completion events resume or
+  fail the automation tail;
+- auto-approval-on-create is handled without leaving the automation stuck;
+- A5 retry guard blocks duplicate approvals after an approval instance exists,
+  while allowing retry after a pre-instance start failure;
+- asynchronous rejected/revoked/cancelled outcomes mark the `start_approval`
+  step failed and downstream actions skipped, matching executor fail-stop/C1
+  semantics;
+- real-DB tests cover the bridge and resume seam.
+
+The Runtime Red Lines above remain active. #2469 did **not** add result
+backwrite, generic approval triggers, public webhook endpoints, BPMN runtime,
+approval publish/assignment semantic changes, full approval form snapshots in
+automation tables, `return`-as-completion, or legacy/non-job execution.

--- a/docs/development/multitable-automation-a6-execution-plan-20260601.md
+++ b/docs/development/multitable-automation-a6-execution-plan-20260601.md
@@ -30,13 +30,16 @@ treatment **on purpose**:
   approval coupling). Their *shape* is undefined until a concrete use-case names it.
   A6-3's first runtime slice (A6-3-1 `condition_branch` / exclusive branch v1) **landed via #2321**;
   the A6-3-2 frontend/readability slice **landed via #2339 + #2348**; parallel/join +
-  A6-3-3 stay deferred. A6-4/A6-5 remain plan-level only:
-  scope boundary, dependency order, gate posture, and a pointer to the test surface the
-  A6-0 scout already enumerated.
+  A6-3-3 stay deferred. A6-5's first `start_approval` bridge slice **landed via #2469**
+  as a named cross-surface carve-out on top of A6-2 + W5 completion events. A6-4 remains
+  plan-level only.
 
-Dependency order is fixed (each rung is the next one's floor):
+The original ladder was:
 **A6-1 enable-writer → A6-2 suspend/resume → A6-3 branch/parallel DAG → A6-4 BPMN
-compile/preview adapter → A6-5 approval-as-job.**
+compile/preview adapter → A6-5 approval-as-job.** #2469 intentionally lands only the
+minimal W6-1 `start_approval` bridge slice of A6-5 before A6-4, without unlocking BPMN
+compile/preview, public webhook/token emitters, branch-local wait/nesting, or parallel/join.
+W7 result backwrite remains a separate rung.
 
 ---
 
@@ -203,23 +206,24 @@ join-any stay separate follow rungs.
 - **Test surface:** see A6-0 scout "→ A6-4" (preview side-effect-free, deterministic gap
   report, gateway mappings backed by A6-3 tests, no live BPMN route).
 
-## 5. A6-5 approval-as-job — PLAN-LEVEL (double-gated; last; design deferred)
+## 5. A6-5 approval-as-job — LANDED first slice (#2469); W7 backwrite still separate
 
-- **Adds:** an automation job that starts an approval instance and resumes after the
-  approval completes; approved/rejected/revoked/cancelled terminal outcomes map to
-  C1 outcomes explicitly. `return` is a rework transition, not completion, and
-  must not resume the approval-as-job bridge unless a future non-completion
-  transition scope says otherwise.
-- **Must not:** fold approval state into automation tables; pull in approval trigger
-  bindings or result backwrite implicitly. Approval remains source-of-truth for graphs,
-  assignments, permissions, and version freezing; automation stores only the waiting job
-  and resume linkage. The **approval-completion event contract lands first**, before any
-  bridge.
-- **Depends on:** A6-2 (suspend/resume) and the completion-event contract.
-- **Gate:** **double-gated** — highest value + highest risk; explicitly last.
-- **Test surface:** see A6-0 scout "→ A6-5" (start_approval creates suspended job + one
-  instance, status mapping unambiguous, version-freezing stays with approval, completion
-  resumes exactly one job, missing/deleted instance fails closed).
+- **Adds:** an automation `start_approval` action that starts exactly one approval
+  instance, persists a durable automation/approval bridge row, writes a suspended C1
+  job, and resumes or fails the automation tail from the W5 terminal completion event.
+  Approved / rejected / revoked / cancelled terminal outcomes are mapped explicitly.
+  `return` remains a rework transition, not completion, and does not resume the bridge.
+- **As-built guardrails:** the bridge has deterministic idempotency, exactly-once
+  claim/resume semantics, auto-approval-on-create handling, and an A5 retry guard that
+  blocks duplicate approvals once an approval instance was created while allowing retry
+  after a pre-instance start failure.
+- **Still must not:** fold approval state into automation tables; pull in approval
+  trigger bindings or result backwrite implicitly. Approval remains source-of-truth for
+  graphs, assignments, permissions, and version freezing; automation stores only the
+  waiting job, bridge lineage, and terminal outcome needed to continue the job plane.
+- **Still separate:** W7 approval result backwrite, approval trigger bindings, public
+  webhook/token emitters, branch-local wait/nesting, parallel/join, and BPMN
+  compile/preview all require separate named gates.
 
 ---
 
@@ -243,5 +247,7 @@ join-any stay separate follow rungs.
 - References the TODO checklist for status (does not re-derive or duplicate it) and the
   A6-0/A6-1 scouts for test surface and runtime rationale.
 - A6-1 enable-writer **landed** (#2130/#2191/#2193) and A6-2 suspend/resume **landed**
-  2026-06-03 (#2236 design-lock + #2237 impl, admin-gated v1); A6-3 … A6-5 remain
-  design-deferred and demand-gated, with no schema/mechanics designed here.
+  2026-06-03 (#2236 design-lock + #2237 impl, admin-gated v1); A6-3 exclusive branch
+  v1 **landed** (#2321/#2339/#2348); A6-5 `start_approval` bridge **landed** (#2469).
+  A6-3-3, A6-3 parallel/join, A6-4 BPMN compile/preview, public webhook/token emitter,
+  and W7 result backwrite remain demand-gated.

--- a/docs/development/multitable-automation-run-governance-todo-20260527.md
+++ b/docs/development/multitable-automation-run-governance-todo-20260527.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-27
 Scope: multitable automation run governance + whole-execution retry only
-Status: A0-A5 closed (2026-05-29); A6-1 COMPLETE end-to-end (runtime #2130 + enable-writer #2191 + admin UI toggle #2193, 2026-06) — rules can opt into the per-action WorkflowJob plane from the editor, no longer dormant; A6-2 suspend/resume backend (admin-gated v1, webhook/external resume) LANDED #2237 c363a78db (2026-06-03) + A6-2b frontend (admin Resume UI + `wait_for_callback` editor) LANDED #2245 cee99c8e4 (2026-06-04) + operator UAT PASS #2257 (2026-06-04) — A6-2 now closed end-to-end; delay/timer resume deferred; A6-3-1 `condition_branch` exclusive-branch runtime LANDED #2321 `127b29dd9` (2026-06-05; design-lock `multitable-automation-a6-3-branch-parallel-design-20260605.md`) + A6-3-2a editor LANDED #2339 `960ea9315` + A6-3-2b admin-runs readability LANDED #2348 `4b44f25c6`; A6-3 v1 operator/API/UI trial PASS (#2367/#2371), with no current A6-3-3 unlock signal; A6-3-3 (wait/nesting in branches) / parallel fan-out·join still gated; A6-4..A6-5 remain frozen / demand-gated
+Status: A0-A5 closed (2026-05-29); A6-1 COMPLETE end-to-end (runtime #2130 + enable-writer #2191 + admin UI toggle #2193, 2026-06) — rules can opt into the per-action WorkflowJob plane from the editor, no longer dormant; A6-2 suspend/resume backend (admin-gated v1, webhook/external resume) LANDED #2237 c363a78db (2026-06-03) + A6-2b frontend (admin Resume UI + `wait_for_callback` editor) LANDED #2245 cee99c8e4 (2026-06-04) + operator UAT PASS #2257 (2026-06-04) — A6-2 now closed end-to-end; delay/timer resume deferred; A6-3-1 `condition_branch` exclusive-branch runtime LANDED #2321 `127b29dd9` (2026-06-05; design-lock `multitable-automation-a6-3-branch-parallel-design-20260605.md`) + A6-3-2a editor LANDED #2339 `960ea9315` + A6-3-2b admin-runs readability LANDED #2348 `4b44f25c6`; A6-3 v1 operator/API/UI trial PASS (#2367/#2371), with no current A6-3-3 unlock signal; A6-5 / W6-1 `start_approval` bridge LANDED #2469; A6-3-3 (wait/nesting in branches) / parallel fan-out·join still gated; A6-4 BPMN compile/preview and public webhook/token emitter remain demand-gated; W7 approval result backwrite remains separate / not started.
 Companion: multitable-automation-run-governance-development-20260527.md
 Depends on (landed): C1 contract workflow-job-contract.ts (#1889, read-boundary wired only); RFC #1885
 
@@ -28,7 +28,8 @@ The governance half and named A5 retry runtime are complete on `origin/main`:
 This closeout did NOT mark the convergence engine complete at the time. Current status:
 A6-1 and A6-2 are complete end-to-end; A6-3-1 `condition_branch` exclusive-branch runtime
 landed (#2321), and A6-3-2 frontend/runs readability landed (#2339 + #2348). A6-3-3 /
-parallel-join remain gated; A6-4/A6-5 remain separate future unlocks. Later trial
+parallel-join remain gated; A6-5/W6-1 `start_approval` later landed separately in #2469;
+A6-4 remains a separate future unlock. Later trial
 evidence (#2367/#2371) confirmed the A6-3 v1 surface is enough for the tested
 condition-branch flow and did not produce a branch-local wait/nesting demand.
 
@@ -63,6 +64,11 @@ By itself, the governance-half line did not unlock:
 
 The K3 Stage-1 blanket lock is retired (#1993; #1792 = M1 one-record Material Save-only PASS) — replaced by post-GATE scoped gates (see `k3-post-gate-scoped-governance-20260528.md`). This does NOT open the capability half: each item above still requires a separate named unlock / demand gate.
 
+Later status note: automation `start_approval` was separately unlocked and
+landed as the A6-5 / W6-1 bridge in #2469. That does not unlock approval
+trigger bindings, approval result backwrite, public webhook/token emitters, BPMN
+runtime, or branch-local wait/nesting.
+
 ## Lock posture (per milestone)
 
 - A0: docs-only, can do now.
@@ -71,8 +77,9 @@ The K3 Stage-1 blanket lock is retired (#1993; #1792 = M1 one-record Material Sa
 - A4 / A5: completed by explicit opt-in (#2039 + #2047); retry UI,
   idempotency keys, and re-fetch-current-record context remain future opt-ins.
 - A6: A6-0/A6-3 design-locks are docs-only; A6-1/A6-2 + A6-3-1 `condition_branch` runtime
-  + A6-3-2 frontend/readability landed by explicit opt-in; A6-3-3 + parallel-join and
-  A6-4/A6-5 remain frozen / demand-gated.
+  + A6-3-2 frontend/readability + A6-5/W6-1 `start_approval` bridge landed by explicit
+  opt-in; A6-3-3 + parallel-join, A6-4 BPMN, public webhook/token emitter, and W7 result
+  backwrite remain demand-gated.
 
 ## Current Baseline
 
@@ -121,7 +128,8 @@ Landed (capability half) — A6-1 COMPLETE, end-to-end & reachable in production
 Deferred (capability half — A6, frozen/demand-gated):
 - A6-2 delay/timer resume (v1 was webhook/external only; delay/timer later forces a durable
   scheduler/worker/leader)
-- A6-3 branch/parallel; A6-4 BPMN compile/preview adapter; A6-5 approval-as-job bridge
+- A6-3-3 branch-local wait/nesting; A6-3 parallel/join; A6-4 BPMN compile/preview adapter;
+  public webhook/token emitter; W7 approval result backwrite
 
 ## Milestones
 
@@ -294,4 +302,4 @@ complete.
 - [ ] A6-3-3 `wait_for_callback` / nested `condition_branch` inside branches — gated (forbidden in A6-3-1); open only for a named branch-local wait/nesting scenario.
 - [ ] A6-3 parallel fan-out / join-all / join-any — gated (separate follow rungs after the exclusive slice).
 - [ ] A6-4 BPMN compile/preview adapter — not started.
-- [ ] A6-5 approval-as-job bridge — not started.
+- [x] A6-5 / W6-1 `start_approval` approval-as-job bridge — LANDED #2469: creates one approval instance from a published template, persists the bridge row, writes suspended / terminal C1 jobs, resumes/fails from W5 completion events, and guards A5 retry duplicates.

--- a/docs/development/workflow-automation-completion-plan-20260609.md
+++ b/docs/development/workflow-automation-completion-plan-20260609.md
@@ -2,7 +2,7 @@
 
 Date: 2026-06-09
 
-Grounded on: `origin/main@6690bade5`
+Grounded on: `origin/main@275644e81`
 
 Scope: MetaSheet2 workflow, approval, and multitable automation as one product
 target. This is a completion definition and execution ledger, not a sprint
@@ -38,7 +38,7 @@ Current main already contains the governance and first convergence slices:
 | A6-2 suspend/resume | Landed end-to-end: `wait_for_callback`, `multitable_automation_suspensions`, admin resume route, editor config, admin runs resume UI, UAT recorded. |
 | A6-3-1 condition branch runtime | Landed: `condition_branch`, exclusive first-match/default branch, C1 parent/child/downstream lineage. |
 | A6-3-2 frontend and runs readability | Landed in code: editor builder in `MetaAutomationRuleEditor.vue` and `conditionBranchAuthoring.ts`; runs readability in `AutomationExecutionsView.vue`. |
-| Still missing | Branch-local wait/nesting, parallel fan-out/join, BPMN compile/preview mapping, approval-as-job bridge, public webhook token emitter. |
+| Still missing | Branch-local wait/nesting, parallel fan-out/join, BPMN compile/preview mapping, public webhook token emitter. |
 
 ### 1.2 Approval
 
@@ -53,7 +53,7 @@ Current main already contains substantial approval product runtime:
 | Real DB authoring UAT guard | Landed integration test for create -> publish -> start -> resolve on real DB. |
 | Deployed/browser UAT | Passed: #2318 and #2371 accepted UI-created template -> publish -> `/approvals/new/:templateId` -> `form_field_user` resolution, plus unsupported-template read-only/save-disabled safety. |
 | Completion event contract | Landed: #2413 locked the W5 scope; #2414 emits typed, redacted, idempotent approval terminal completion events after commit. |
-| Still missing | Field-visibility authoring UI, richer template constructs, trigger bindings, result backwrite, automation `start_approval`. |
+| Still missing | Field-visibility authoring UI, richer template constructs, trigger bindings, result backwrite. |
 
 ### 1.3 Workflow Designer / BPMN
 
@@ -120,7 +120,7 @@ operate a practical business workflow using existing product surfaces:
 | W5-0 | Approval completion event contract scope-gate | Landed #2413 | Defines terminal approval event taxonomy, redacted payload, idempotency key, post-commit emission boundary, and test matrix without adding automation behavior. |
 | W5-1 | Approval completion event contract implementation | Landed #2414 (`184f2293c`) | `approval.approved/rejected/revoked/cancelled` payload is versioned, redacted, idempotent, emitted post-commit, and tested without adding automation action yet. `return` remains a non-terminal rework transition. |
 | W6-0 | Automation `start_approval` scope-gate | Scope-gate document added; runtime not started | `automation-start-approval-scope-gate-20260610.md` locks action config, idempotency, bridge persistence, waiting/resume semantics, redaction, and tests. |
-| W6-1 | Automation `start_approval` runtime | Not started; after W6-0 | Starts one approval instance from a published template, creates a waiting job, and resumes from W5 completion event. |
+| W6-1 | Automation `start_approval` runtime | Landed #2469 | Starts one approval instance from a published template, persists the approval bridge, creates a suspended C1 job, resumes/fails from W5 terminal completion events, and guards retry duplicates. |
 | W7 | Approval result backwrite | Not started; after W5/W6 | Explicit mapping writes approved/rejected/revoked/cancelled outcomes to multitable record fields with audit and permission checks; `return` transition backwrite needs a separate named scope if required. |
 | W8 | BPMN compile/preview adapter | Not started; after W3 minimum | Constrained BPMN subset compiles into automation/approval preview plus gap report; no live execution route. |
 | W9 | Public webhook resume token emitter | Not started; use-case gated | External consumer can receive a token/callback URL safely; auth, expiry, replay, and redaction are locked before public route. |
@@ -128,8 +128,7 @@ operate a practical business workflow using existing product surfaces:
 
 ## 4. Recommended Next Slice
 
-The next implementation after W5 should be **W6: automation `start_approval`**,
-starting with the dedicated W6-0 scope-gate:
+W6 **automation `start_approval`** landed after the dedicated W6-0 scope-gate:
 `docs/development/automation-start-approval-scope-gate-20260610.md`.
 
 Why:
@@ -137,15 +136,15 @@ Why:
 1. **W1 is closed by issue evidence** (#2318 + #2371 + #2375).
 2. **W2 is intentionally held** because #2367 found no concrete
    branch-internal wait/nesting demand for the current trial flow.
-3. The v1 completion gap is now cross-surface closure: automation still cannot
-   start an approval. W5-1 gives W6 a stable approval completion signal, but it
-   intentionally does not add automation behavior.
+3. The v1 cross-surface start gap is now closed: automation can explicitly
+   start an approval through `start_approval`, and W5-1 gives it a stable
+   terminal completion signal.
 
-Do not jump straight to result backwrite or BPMN before W6 lands.
-Approval-as-job now has stable suspend/resume plus an approval completion event contract; it
-now also has a W6 scope-gate. The runtime still needs a separate W6-1 PR
-proving idempotency, waiting/resume semantics, and side-effect boundaries.
-BPMN gateway preview needs branch/parallel semantics to map to.
+The next cross-surface candidate is **W7 approval result backwrite**, but it
+must still start from a separate scope gate because it writes business data and
+changes record state. Do not jump straight to BPMN before the remaining graph
+prerequisites are named. BPMN gateway preview still needs branch/parallel
+semantics to map to.
 
 ## 5. Non-goals for v1
 


### PR DESCRIPTION
## Summary
- mark W6/A6-5 `start_approval` bridge as landed after #2469
- reconcile workflow completion plan, A6 execution plan, run-governance TODO, and the W6 scope gate
- keep W7 result backwrite, BPMN compile/preview, public webhook/token emitter, branch-local wait/nesting, and parallel/join explicitly gated

## Verification
- git diff --check
- rg stale wording scan for A6-5/not-started/frozen contradictions
- subagent review: Gauss APPROVE for the post-merge docs draft after wording fix

Docs-only closeout.