### PR TITLE
feat(multitable): add AI provider readiness gate

### DIFF
--- a/package.json
+++ b/package.json
@@ -54,6 +54,7 @@
     "verify:multitable-rc:staging": "node scripts/verify-multitable-rc-staging-smoke.mjs",
     "verify:multitable-rc:ui": "bash scripts/verify-multitable-rc-ui-smoke.sh",
     "verify:multitable-views:ui": "bash scripts/verify-multitable-views-ui-smoke.sh",
+    "verify:multitable-ai:readiness": "tsx scripts/ops/multitable-ai-readiness-gate.ts",
     "verify:multitable-email:readiness": "tsx scripts/ops/multitable-email-transport-readiness.ts",
     "verify:multitable-email:real-send": "tsx scripts/ops/multitable-email-real-send-smoke.ts",
     "verify:multitable-pilot:staging:test": "node --test scripts/ops/multitable-pilot-staging.test.mjs",

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -137,6 +137,7 @@ import { univerMockRouter } from './routes/univer-mock'
 import { univerMetaRouter } from './routes/univer-meta'
 import { dashboardRouter } from './routes/dashboard'
 import { createAutomationRoutes } from './routes/automation'
+import { createMultitableAiRouter } from './routes/multitable-ai'
 import { apiTokensRouter } from './routes/api-tokens'
 import { SnapshotService } from './services/SnapshotService'
 import { MetricsStreamService } from './services/MetricsStreamService'
@@ -1089,6 +1090,9 @@ export class MetaSheetServer {
     // Uses a lazy resolver because AutomationService is initialized later
     // in the startup sequence than route mounting happens.
     this.app.use('/api/multitable', createAutomationRoutes(() => this.automationService))
+    // Internal admin-only AI readiness (A1/M1b). Kept out of OpenAPI and does not
+    // perform live provider calls.
+    this.app.use('/api/multitable', createMultitableAiRouter())
     this.app.use(apiTokensRouter())
     // Keep the legacy dev alias while existing tools/worktrees still reference it.
     if (process.env.NODE_ENV !== 'production') {

--- a/packages/core-backend/src/routes/multitable-ai.ts
+++ b/packages/core-backend/src/routes/multitable-ai.ts
@@ -1,0 +1,35 @@
+/**
+ * Internal multitable AI readiness routes.
+ *
+ * Mount point: `/api/multitable` (via index.ts).
+ *
+ * A1/M1b deliberately keeps this route out of OpenAPI: it is an admin-only
+ * declarative readiness surface for provider env, not a public product API.
+ */
+
+import type { RequestHandler } from 'express'
+import { Router } from 'express'
+import { requireAdminRole } from '../guards/audit-integration'
+import { redactValue } from '../multitable/automation-log-redact'
+import {
+  resolveAiProviderReadiness,
+  type AiProviderReadinessReport,
+} from '../services/ai-provider-readiness'
+
+export interface MultitableAiRouterOptions {
+  adminGuard?: RequestHandler
+  resolveReadiness?: () => AiProviderReadinessReport
+}
+
+export function createMultitableAiRouter(options: MultitableAiRouterOptions = {}): Router {
+  const router = Router()
+  const adminGuard = options.adminGuard ?? requireAdminRole()
+  const resolveReadiness = options.resolveReadiness ?? (() => resolveAiProviderReadiness(process.env))
+
+  router.get('/ai/readiness', adminGuard, (_req, res) => {
+    const report = resolveReadiness()
+    return res.json(redactValue(report))
+  })
+
+  return router
+}

--- a/packages/core-backend/src/services/ai-provider-readiness.ts
+++ b/packages/core-backend/src/services/ai-provider-readiness.ts
@@ -1,0 +1,258 @@
+export const MULTITABLE_AI_ENABLED_ENV = 'MULTITABLE_AI_ENABLED'
+export const MULTITABLE_AI_PROVIDER_ENV = 'MULTITABLE_AI_PROVIDER'
+export const MULTITABLE_AI_API_KEY_ENV = 'MULTITABLE_AI_API_KEY'
+export const MULTITABLE_AI_BASE_URL_ENV = 'MULTITABLE_AI_BASE_URL'
+export const MULTITABLE_AI_MODEL_ENV = 'MULTITABLE_AI_MODEL'
+export const MULTITABLE_AI_REQUEST_TIMEOUT_MS_ENV = 'MULTITABLE_AI_REQUEST_TIMEOUT_MS'
+export const MULTITABLE_AI_MAX_OUTPUT_TOKENS_ENV = 'MULTITABLE_AI_MAX_OUTPUT_TOKENS'
+export const MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP_ENV = 'MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP'
+export const MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP_ENV = 'MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP'
+export const MULTITABLE_AI_TENANT_BURST_RPM_ENV = 'MULTITABLE_AI_TENANT_BURST_RPM'
+export const MULTITABLE_AI_ACCOUNT_DAILY_USD_CAP_ENV = 'MULTITABLE_AI_ACCOUNT_DAILY_USD_CAP'
+export const MULTITABLE_AI_CONFIRM_LIVE_REQUESTS_ENV = 'MULTITABLE_AI_CONFIRM_LIVE_REQUESTS'
+
+export const AI_REQUIRED_ENV = [
+  MULTITABLE_AI_ENABLED_ENV,
+  MULTITABLE_AI_PROVIDER_ENV,
+  MULTITABLE_AI_API_KEY_ENV,
+  MULTITABLE_AI_MODEL_ENV,
+] as const
+
+export const AI_OPTIONAL_ENV = [
+  MULTITABLE_AI_BASE_URL_ENV,
+  MULTITABLE_AI_CONFIRM_LIVE_REQUESTS_ENV,
+] as const
+
+export type AiProvider = 'anthropic' | 'openai'
+
+export type AiProviderReadinessStatus =
+  | 'disabled'
+  | 'blocked'
+  | 'ready'
+  | 'rate_limited'
+  | 'quota_exhausted'
+  | 'provider_error'
+  | 'unsafe_input'
+
+export interface AiProviderCaps {
+  requestTimeoutMs: number
+  maxOutputTokens: number
+  tenantDailyTokenCap: number
+  tenantWeeklyTokenCap: number
+  tenantBurstRpm: number
+  accountDailyUsdCap: number
+}
+
+export interface AiProviderReadinessReport {
+  ok: boolean
+  status: AiProviderReadinessStatus
+  provider?: AiProvider
+  model?: string
+  caps: AiProviderCaps
+  messages: string[]
+  requiredEnv: string[]
+  optionalEnv: string[]
+}
+
+export type AiProviderEnv = Record<string, string | undefined>
+
+export const AI_DEFAULT_MODELS: Record<AiProvider, string> = {
+  anthropic: 'claude-3-5-sonnet-latest',
+  openai: 'gpt-4o-mini',
+}
+
+export const AI_ALLOWED_MODELS: Record<AiProvider, readonly string[]> = {
+  anthropic: [
+    'claude-3-5-sonnet-latest',
+    'claude-3-5-haiku-latest',
+    'claude-sonnet-4-20250514',
+  ],
+  openai: [
+    'gpt-4o-mini',
+    'gpt-4o',
+    'gpt-4.1-mini',
+    'gpt-4.1',
+  ],
+}
+
+const DEFAULT_CAPS: AiProviderCaps = Object.freeze({
+  requestTimeoutMs: 15_000,
+  maxOutputTokens: 1_024,
+  tenantDailyTokenCap: 100_000,
+  tenantWeeklyTokenCap: 500_000,
+  tenantBurstRpm: 30,
+  accountDailyUsdCap: 10,
+})
+
+function envString(env: AiProviderEnv, name: string): string {
+  const value = env[name]
+  return typeof value === 'string' ? value.trim() : ''
+}
+
+function isEnabled(value: string): boolean {
+  return value === '1'
+}
+
+function resolveProvider(value: string): AiProvider | undefined {
+  if (value === 'anthropic' || value === 'openai') return value
+  return undefined
+}
+
+function parseIntegerEnv(
+  env: AiProviderEnv,
+  name: string,
+  fallback: number,
+  messages: string[],
+  options: { min?: number; max?: number } = {},
+): number {
+  const raw = envString(env, name)
+  if (!raw) return fallback
+  const parsed = Number(raw)
+  if (!Number.isInteger(parsed)) {
+    messages.push(`${name} is invalid; using default ${fallback}.`)
+    return fallback
+  }
+  if (typeof options.min === 'number' && parsed < options.min) {
+    messages.push(`${name} is below minimum; clamped to ${options.min}.`)
+    return options.min
+  }
+  if (typeof options.max === 'number' && parsed > options.max) {
+    messages.push(`${name} is above maximum; clamped to ${options.max}.`)
+    return options.max
+  }
+  return parsed
+}
+
+function resolveCaps(env: AiProviderEnv, messages: string[]): AiProviderCaps {
+  return {
+    requestTimeoutMs: parseIntegerEnv(env, MULTITABLE_AI_REQUEST_TIMEOUT_MS_ENV, DEFAULT_CAPS.requestTimeoutMs, messages, {
+      min: 1_000,
+      max: 60_000,
+    }),
+    maxOutputTokens: parseIntegerEnv(env, MULTITABLE_AI_MAX_OUTPUT_TOKENS_ENV, DEFAULT_CAPS.maxOutputTokens, messages, {
+      min: 64,
+      max: 4_096,
+    }),
+    tenantDailyTokenCap: parseIntegerEnv(env, MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP_ENV, DEFAULT_CAPS.tenantDailyTokenCap, messages, {
+      min: 1_000,
+    }),
+    tenantWeeklyTokenCap: parseIntegerEnv(env, MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP_ENV, DEFAULT_CAPS.tenantWeeklyTokenCap, messages),
+    tenantBurstRpm: parseIntegerEnv(env, MULTITABLE_AI_TENANT_BURST_RPM_ENV, DEFAULT_CAPS.tenantBurstRpm, messages),
+    accountDailyUsdCap: parseIntegerEnv(env, MULTITABLE_AI_ACCOUNT_DAILY_USD_CAP_ENV, DEFAULT_CAPS.accountDailyUsdCap, messages),
+  }
+}
+
+function isValidBaseUrl(value: string): boolean {
+  if (!value) return true
+  try {
+    const url = new URL(value)
+    return url.protocol === 'https:' || url.protocol === 'http:'
+  } catch {
+    return false
+  }
+}
+
+function resolveModel(provider: AiProvider, explicitModel: string, messages: string[]): string | undefined {
+  const model = explicitModel || AI_DEFAULT_MODELS[provider]
+  if (AI_ALLOWED_MODELS[provider].includes(model)) return model
+  messages.push(`${MULTITABLE_AI_MODEL_ENV} is <invalid> for provider ${provider}.`)
+  return undefined
+}
+
+export function resolveAiProviderReadiness(
+  env: AiProviderEnv = process.env,
+): AiProviderReadinessReport {
+  const messages: string[] = []
+  const caps = resolveCaps(env, messages)
+  const enabled = isEnabled(envString(env, MULTITABLE_AI_ENABLED_ENV))
+
+  if (!enabled) {
+    messages.push('AI provider is disabled; set MULTITABLE_AI_ENABLED=1 to evaluate provider readiness.')
+    return {
+      ok: false,
+      status: 'disabled',
+      caps,
+      messages,
+      requiredEnv: [...AI_REQUIRED_ENV],
+      optionalEnv: [...AI_OPTIONAL_ENV],
+    }
+  }
+
+  const providerRaw = envString(env, MULTITABLE_AI_PROVIDER_ENV)
+  const provider = resolveProvider(providerRaw)
+  if (!provider) {
+    messages.push(`${MULTITABLE_AI_PROVIDER_ENV} is <invalid>; allowed values are anthropic or openai.`)
+  }
+
+  const apiKey = envString(env, MULTITABLE_AI_API_KEY_ENV)
+  if (!apiKey) {
+    messages.push(`${MULTITABLE_AI_API_KEY_ENV} is required when AI is enabled.`)
+  }
+
+  const baseUrl = envString(env, MULTITABLE_AI_BASE_URL_ENV)
+  if (!isValidBaseUrl(baseUrl)) {
+    messages.push(`${MULTITABLE_AI_BASE_URL_ENV} is <invalid>.`)
+  }
+
+  const model = provider
+    ? resolveModel(provider, envString(env, MULTITABLE_AI_MODEL_ENV), messages)
+    : undefined
+
+  if (envString(env, MULTITABLE_AI_CONFIRM_LIVE_REQUESTS_ENV)) {
+    messages.push(`${MULTITABLE_AI_CONFIRM_LIVE_REQUESTS_ENV} is informational in A1; live provider calls remain disabled.`)
+  }
+
+  const blocked = !provider || !apiKey || !model || !isValidBaseUrl(baseUrl)
+
+  if (!blocked) {
+    messages.push('AI provider env is present; declarative readiness only, no live provider request was sent.')
+  }
+
+  return {
+    ok: !blocked,
+    status: blocked ? 'blocked' : 'ready',
+    ...(provider ? { provider } : {}),
+    ...(model ? { model } : {}),
+    caps,
+    messages,
+    requiredEnv: [...AI_REQUIRED_ENV],
+    optionalEnv: [...AI_OPTIONAL_ENV],
+  }
+}
+
+export function renderAiProviderReadinessMarkdown(report: AiProviderReadinessReport): string {
+  const lines = [
+    '# Multitable AI Provider Readiness',
+    '',
+    `- Status: \`${report.status}\``,
+    `- Provider: \`${report.provider ?? '<unset>'}\``,
+    `- Model: \`${report.model ?? '<unset>'}\``,
+    '',
+    '## Messages',
+    '',
+    ...report.messages.map((message) => `- ${message}`),
+    '',
+    '## Caps',
+    '',
+    '| Name | Value |',
+    '| --- | ---: |',
+    `| requestTimeoutMs | ${report.caps.requestTimeoutMs} |`,
+    `| maxOutputTokens | ${report.caps.maxOutputTokens} |`,
+    `| tenantDailyTokenCap | ${report.caps.tenantDailyTokenCap} |`,
+    `| tenantWeeklyTokenCap | ${report.caps.tenantWeeklyTokenCap} |`,
+    `| tenantBurstRpm | ${report.caps.tenantBurstRpm} |`,
+    `| accountDailyUsdCap | ${report.caps.accountDailyUsdCap} |`,
+    '',
+    '## Environment Contract',
+    '',
+    `- Required env: ${report.requiredEnv.map((name) => `\`${name}\``).join(', ')}`,
+    `- Optional env: ${report.optionalEnv.map((name) => `\`${name}\``).join(', ')}`,
+    '',
+    '## Notes',
+    '',
+    '- This gate validates declarative provider configuration only; it never calls an AI provider.',
+    '- API keys, custom endpoint credentials, auth tokens, and raw secret-shaped values are not rendered in this report.',
+  ]
+
+  return `${lines.join('\n')}\n`
+}

--- a/packages/core-backend/tests/unit/ai-provider-readiness.test.ts
+++ b/packages/core-backend/tests/unit/ai-provider-readiness.test.ts
@@ -1,0 +1,171 @@
+import { describe, expect, it } from 'vitest'
+import {
+  AI_REQUIRED_ENV,
+  MULTITABLE_AI_ACCOUNT_DAILY_USD_CAP_ENV,
+  MULTITABLE_AI_API_KEY_ENV,
+  MULTITABLE_AI_BASE_URL_ENV,
+  MULTITABLE_AI_CONFIRM_LIVE_REQUESTS_ENV,
+  MULTITABLE_AI_ENABLED_ENV,
+  MULTITABLE_AI_MAX_OUTPUT_TOKENS_ENV,
+  MULTITABLE_AI_MODEL_ENV,
+  MULTITABLE_AI_PROVIDER_ENV,
+  MULTITABLE_AI_REQUEST_TIMEOUT_MS_ENV,
+  MULTITABLE_AI_TENANT_BURST_RPM_ENV,
+  MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP_ENV,
+  MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP_ENV,
+  renderAiProviderReadinessMarkdown,
+  resolveAiProviderReadiness,
+} from '../../src/services/ai-provider-readiness'
+
+const READY_ENV = {
+  [MULTITABLE_AI_ENABLED_ENV]: '1',
+  [MULTITABLE_AI_PROVIDER_ENV]: 'openai',
+  [MULTITABLE_AI_API_KEY_ENV]: 'sk-test-secret-00000000000000000000',
+  [MULTITABLE_AI_MODEL_ENV]: 'gpt-4o-mini',
+}
+
+function serialized(value: unknown): string {
+  return JSON.stringify(value)
+}
+
+describe('AI provider readiness', () => {
+  it('keeps AI disabled by default and declares the env contract', () => {
+    const report = resolveAiProviderReadiness({})
+
+    expect(report.ok).toBe(false)
+    expect(report.status).toBe('disabled')
+    expect(report.requiredEnv).toEqual([...AI_REQUIRED_ENV])
+    expect(report.optionalEnv).toEqual([
+      MULTITABLE_AI_BASE_URL_ENV,
+      MULTITABLE_AI_CONFIRM_LIVE_REQUESTS_ENV,
+    ])
+    expect(report.messages.join('\n')).toContain('disabled')
+  })
+
+  it('blocks non-allowlisted providers without echoing the raw value', () => {
+    const report = resolveAiProviderReadiness({
+      ...READY_ENV,
+      [MULTITABLE_AI_PROVIDER_ENV]: 'azure-openai',
+    })
+
+    expect(report.ok).toBe(false)
+    expect(report.status).toBe('blocked')
+    expect(report.provider).toBeUndefined()
+    expect(report.messages.join('\n')).toContain('<invalid>')
+    expect(serialized(report)).not.toContain('azure-openai')
+  })
+
+  it('blocks non-allowlisted models without echoing the raw model value', () => {
+    const report = resolveAiProviderReadiness({
+      ...READY_ENV,
+      [MULTITABLE_AI_MODEL_ENV]: 'sk-model-shaped-secret-0000000000',
+    })
+
+    expect(report.ok).toBe(false)
+    expect(report.status).toBe('blocked')
+    expect(report.model).toBeUndefined()
+    expect(report.messages.join('\n')).toContain('<invalid>')
+    expect(serialized(report)).not.toContain('sk-model-shaped-secret')
+  })
+
+  it('blocks invalid base URLs without leaking embedded credentials', () => {
+    const report = resolveAiProviderReadiness({
+      ...READY_ENV,
+      [MULTITABLE_AI_BASE_URL_ENV]: 'https://user:secret-pass@example.com:bad',
+    })
+
+    expect(report.ok).toBe(false)
+    expect(report.status).toBe('blocked')
+    expect(report.messages.join('\n')).toContain('<invalid>')
+    expect(serialized(report)).not.toContain('secret-pass')
+    expect(serialized(report)).not.toContain('user:secret-pass')
+  })
+
+  it('blocks enabled providers when API key is missing', () => {
+    const report = resolveAiProviderReadiness({
+      [MULTITABLE_AI_ENABLED_ENV]: '1',
+      [MULTITABLE_AI_PROVIDER_ENV]: 'anthropic',
+      [MULTITABLE_AI_MODEL_ENV]: 'claude-3-5-sonnet-latest',
+    })
+
+    expect(report.ok).toBe(false)
+    expect(report.status).toBe('blocked')
+    expect(report.provider).toBe('anthropic')
+    expect(report.messages.join('\n')).toContain(MULTITABLE_AI_API_KEY_ENV)
+  })
+
+  it('passes ready configuration without sending a live provider request', () => {
+    const report = resolveAiProviderReadiness({
+      ...READY_ENV,
+      [MULTITABLE_AI_REQUEST_TIMEOUT_MS_ENV]: '25000',
+      [MULTITABLE_AI_MAX_OUTPUT_TOKENS_ENV]: '2048',
+      [MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP_ENV]: '200000',
+      [MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP_ENV]: '700000',
+      [MULTITABLE_AI_TENANT_BURST_RPM_ENV]: '15',
+      [MULTITABLE_AI_ACCOUNT_DAILY_USD_CAP_ENV]: '4',
+    })
+
+    expect(report.ok).toBe(true)
+    expect(report.status).toBe('ready')
+    expect(report.provider).toBe('openai')
+    expect(report.model).toBe('gpt-4o-mini')
+    expect(report.caps).toEqual({
+      requestTimeoutMs: 25000,
+      maxOutputTokens: 2048,
+      tenantDailyTokenCap: 200000,
+      tenantWeeklyTokenCap: 700000,
+      tenantBurstRpm: 15,
+      accountDailyUsdCap: 4,
+    })
+    expect(report.messages.join('\n')).toContain('declarative readiness only')
+  })
+
+  it('does not consume the live-request confirmation flag in A1', () => {
+    const base = resolveAiProviderReadiness({})
+    const withConfirm = resolveAiProviderReadiness({
+      [MULTITABLE_AI_CONFIRM_LIVE_REQUESTS_ENV]: '1',
+    })
+
+    expect(withConfirm).toEqual(base)
+  })
+
+  it('clamps bounded caps and defaults unbounded invalid caps without blocking readiness', () => {
+    const report = resolveAiProviderReadiness({
+      ...READY_ENV,
+      [MULTITABLE_AI_REQUEST_TIMEOUT_MS_ENV]: '999999',
+      [MULTITABLE_AI_MAX_OUTPUT_TOKENS_ENV]: '8',
+      [MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP_ENV]: '1',
+      [MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP_ENV]: 'not-a-number',
+      [MULTITABLE_AI_TENANT_BURST_RPM_ENV]: 'nope',
+      [MULTITABLE_AI_ACCOUNT_DAILY_USD_CAP_ENV]: 'NaN',
+    })
+
+    expect(report.ok).toBe(true)
+    expect(report.status).toBe('ready')
+    expect(report.caps).toEqual({
+      requestTimeoutMs: 60000,
+      maxOutputTokens: 64,
+      tenantDailyTokenCap: 1000,
+      tenantWeeklyTokenCap: 500000,
+      tenantBurstRpm: 30,
+      accountDailyUsdCap: 10,
+    })
+    expect(report.messages.join('\n')).toContain('clamped')
+    expect(report.messages.join('\n')).toContain('using default')
+  })
+
+  it('does not leak secret-shaped env values in JSON or Markdown reports', () => {
+    const skSecret = 'sk-live-secret-abcdefghijklmnopqrstuvwxyz'
+    const baseUrlSecret = 'base-url-password'
+    const report = resolveAiProviderReadiness({
+      ...READY_ENV,
+      [MULTITABLE_AI_API_KEY_ENV]: skSecret,
+      [MULTITABLE_AI_BASE_URL_ENV]: `https://user:${baseUrlSecret}@gateway.example.com`,
+    })
+    const combined = `${JSON.stringify(report)}\n${renderAiProviderReadinessMarkdown(report)}`
+
+    expect(combined).not.toContain(skSecret)
+    expect(combined).not.toContain(baseUrlSecret)
+    expect(combined).not.toContain('user:base-url-password')
+  })
+})

--- a/packages/core-backend/tests/unit/multitable-ai-readiness-route.test.ts
+++ b/packages/core-backend/tests/unit/multitable-ai-readiness-route.test.ts
@@ -1,0 +1,93 @@
+import { describe, expect, it, vi } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+import { createMultitableAiRouter } from '../../src/routes/multitable-ai'
+import { requireAdminRole } from '../../src/guards/audit-integration'
+
+vi.mock('../../src/guards/audit-integration', () => ({
+  requireAdminRole: vi.fn(() => (_req: unknown, _res: unknown, next: () => void) => next()),
+}))
+
+function buildApp(resolveReadiness = () => ({
+  ok: true,
+  status: 'ready' as const,
+  provider: 'openai' as const,
+  model: 'gpt-4o-mini',
+  caps: {
+    requestTimeoutMs: 15000,
+    maxOutputTokens: 1024,
+    tenantDailyTokenCap: 100000,
+    tenantWeeklyTokenCap: 500000,
+    tenantBurstRpm: 30,
+    accountDailyUsdCap: 10,
+  },
+  messages: ['declarative readiness only'],
+  requiredEnv: ['MULTITABLE_AI_ENABLED'],
+  optionalEnv: ['MULTITABLE_AI_BASE_URL'],
+})) {
+  const app = express()
+  app.use(express.json())
+  app.use('/api/multitable', createMultitableAiRouter({ resolveReadiness }))
+  return app
+}
+
+describe('multitable AI readiness route', () => {
+  it('is gated by requireAdminRole and returns a flat readiness report', async () => {
+    vi.mocked(requireAdminRole).mockClear()
+    const res = await request(buildApp())
+      .get('/api/multitable/ai/readiness')
+      .expect(200)
+
+    expect(requireAdminRole).toHaveBeenCalledTimes(1)
+    expect(res.body).toMatchObject({
+      ok: true,
+      status: 'ready',
+      provider: 'openai',
+      model: 'gpt-4o-mini',
+    })
+    expect(res.body).toHaveProperty('caps')
+    expect(res.body).not.toHaveProperty('data')
+  })
+
+  it('defensively redacts secret-shaped values before responding', async () => {
+    const response = await request(buildApp(() => ({
+      ok: false,
+      status: 'blocked' as const,
+      caps: {
+        requestTimeoutMs: 15000,
+        maxOutputTokens: 1024,
+        tenantDailyTokenCap: 100000,
+        tenantWeeklyTokenCap: 500000,
+        tenantBurstRpm: 30,
+        accountDailyUsdCap: 10,
+      },
+      messages: ['bad key sk-live-secret-abcdefghijklmnopqrstuvwxyz'],
+      requiredEnv: ['MULTITABLE_AI_API_KEY'],
+      optionalEnv: [],
+      apiKey: 'sk-route-secret-abcdefghijklmnopqrstuvwxyz',
+    } as any)))
+      .get('/api/multitable/ai/readiness')
+      .expect(200)
+
+    const text = JSON.stringify(response.body)
+    expect(text).not.toContain('sk-live-secret-abcdefghijklmnopqrstuvwxyz')
+    expect(text).not.toContain('sk-route-secret-abcdefghijklmnopqrstuvwxyz')
+    expect(text).toContain('sk-<redacted>')
+  })
+
+  it('propagates the admin guard denial response', async () => {
+    const deny = (_req: unknown, res: any) => res.status(403).json({
+      error: 'AccessDenied',
+      code: 'ADMIN_REQUIRED',
+      message: 'This operation requires admin privileges',
+    })
+    const app = express()
+    app.use('/api/multitable', createMultitableAiRouter({ adminGuard: deny as any }))
+
+    const res = await request(app)
+      .get('/api/multitable/ai/readiness')
+      .expect(403)
+
+    expect(res.body.code).toBe('ADMIN_REQUIRED')
+  })
+})

--- a/scripts/ops/multitable-ai-readiness-gate.test.mjs
+++ b/scripts/ops/multitable-ai-readiness-gate.test.mjs
@@ -1,0 +1,171 @@
+import assert from 'node:assert/strict'
+import fs from 'node:fs'
+import os from 'node:os'
+import path from 'node:path'
+import test from 'node:test'
+import { execFileSync, spawnSync } from 'node:child_process'
+import { fileURLToPath } from 'node:url'
+
+const repoRoot = path.resolve(path.dirname(fileURLToPath(import.meta.url)), '../..')
+
+const AI_ENV_KEYS = [
+  'MULTITABLE_AI_ENABLED',
+  'MULTITABLE_AI_PROVIDER',
+  'MULTITABLE_AI_API_KEY',
+  'MULTITABLE_AI_BASE_URL',
+  'MULTITABLE_AI_MODEL',
+  'MULTITABLE_AI_REQUEST_TIMEOUT_MS',
+  'MULTITABLE_AI_MAX_OUTPUT_TOKENS',
+  'MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP',
+  'MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP',
+  'MULTITABLE_AI_TENANT_BURST_RPM',
+  'MULTITABLE_AI_ACCOUNT_DAILY_USD_CAP',
+  'MULTITABLE_AI_CONFIRM_LIVE_REQUESTS',
+]
+
+function withCleanAiEnv(env = {}) {
+  const next = { ...process.env }
+  for (const key of AI_ENV_KEYS) next[key] = ''
+  return { ...next, ...env }
+}
+
+function runReadiness(env = {}, extraArgs = []) {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2-ai-readiness-'))
+  const jsonPath = path.join(tmpRoot, 'report.json')
+  const mdPath = path.join(tmpRoot, 'report.md')
+  const result = spawnSync('pnpm', [
+    'exec',
+    'tsx',
+    'scripts/ops/multitable-ai-readiness-gate.ts',
+    '--output-json',
+    jsonPath,
+    '--output-md',
+    mdPath,
+    ...extraArgs,
+  ], {
+    cwd: repoRoot,
+    env: withCleanAiEnv(env),
+    encoding: 'utf8',
+  })
+
+  return {
+    ...result,
+    jsonPath,
+    mdPath,
+    json: fs.existsSync(jsonPath) ? JSON.parse(fs.readFileSync(jsonPath, 'utf8')) : null,
+    markdown: fs.existsSync(mdPath) ? fs.readFileSync(mdPath, 'utf8') : '',
+  }
+}
+
+test('AI readiness script exits 2 in default disabled mode', () => {
+  const result = runReadiness()
+
+  assert.equal(result.status, 2)
+  assert.equal(result.json.ok, false)
+  assert.equal(result.json.status, 'disabled')
+  assert.match(result.markdown, /Status: `disabled`/)
+})
+
+test('AI readiness script exits 0 when declarative provider env is ready', () => {
+  const result = runReadiness({
+    MULTITABLE_AI_ENABLED: '1',
+    MULTITABLE_AI_PROVIDER: 'anthropic',
+    MULTITABLE_AI_API_KEY: 'sk-ready-secret-abcdefghijklmnopqrstuvwxyz',
+    MULTITABLE_AI_MODEL: 'claude-3-5-sonnet-latest',
+  })
+
+  assert.equal(result.status, 0)
+  assert.equal(result.json.ok, true)
+  assert.equal(result.json.status, 'ready')
+  assert.match(result.markdown, /declarative readiness only/)
+})
+
+test('AI readiness script redacts API keys and endpoint credentials from artifacts', () => {
+  const skSecret = 'sk-artifact-secret-abcdefghijklmnopqrstuvwxyz'
+  const urlSecret = 'url-password-secret'
+  const result = runReadiness({
+    MULTITABLE_AI_ENABLED: '1',
+    MULTITABLE_AI_PROVIDER: 'openai',
+    MULTITABLE_AI_API_KEY: skSecret,
+    MULTITABLE_AI_MODEL: 'gpt-4o-mini',
+    MULTITABLE_AI_BASE_URL: `https://user:${urlSecret}@gateway.example.com`,
+  })
+
+  assert.equal(result.status, 0)
+  const combined = [
+    result.stdout,
+    result.stderr,
+    result.markdown,
+    JSON.stringify(result.json),
+  ].join('\n')
+  assert.doesNotMatch(combined, new RegExp(skSecret))
+  assert.doesNotMatch(combined, new RegExp(urlSecret))
+  assert.doesNotMatch(combined, /user:url-password-secret/)
+})
+
+test('AI readiness script redacts secret-shaped output paths in stdout', () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2-ai-readiness-path-'))
+  const secretSegment = 'sk-path-secret-abcdefghijklmnopqrstuvwxyz'
+  const jsonPath = path.join(tmpRoot, secretSegment, 'report.json')
+  const mdPath = path.join(tmpRoot, secretSegment, 'report.md')
+  const result = spawnSync('pnpm', [
+    'exec',
+    'tsx',
+    'scripts/ops/multitable-ai-readiness-gate.ts',
+  ], {
+    cwd: repoRoot,
+    env: withCleanAiEnv({
+      AI_READINESS_JSON: jsonPath,
+      AI_READINESS_MD: mdPath,
+    }),
+    encoding: 'utf8',
+  })
+
+  assert.equal(result.status, 2)
+  assert.equal(fs.existsSync(jsonPath), true)
+  assert.equal(fs.existsSync(mdPath), true)
+  assert.doesNotMatch(result.stdout, new RegExp(secretSegment))
+  assert.match(result.stdout, /sk-<redacted>/)
+})
+
+test('AI readiness script exits 1 on script usage errors', () => {
+  const result = spawnSync('pnpm', [
+    'exec',
+    'tsx',
+    'scripts/ops/multitable-ai-readiness-gate.ts',
+    '--bogus',
+  ], {
+    cwd: repoRoot,
+    env: withCleanAiEnv(),
+    encoding: 'utf8',
+  })
+
+  assert.equal(result.status, 1)
+  assert.match(result.stderr, /Unknown option: --bogus/)
+})
+
+test('AI readiness script can be launched through package script', () => {
+  const tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'ms2-ai-readiness-script-'))
+  const jsonPath = path.join(tmpRoot, 'report.json')
+  const mdPath = path.join(tmpRoot, 'report.md')
+
+  execFileSync('pnpm', [
+    'verify:multitable-ai:readiness',
+    '--output-json',
+    jsonPath,
+    '--output-md',
+    mdPath,
+  ], {
+    cwd: repoRoot,
+    env: withCleanAiEnv({
+      MULTITABLE_AI_ENABLED: '1',
+      MULTITABLE_AI_PROVIDER: 'openai',
+      MULTITABLE_AI_API_KEY: 'sk-package-secret-abcdefghijklmnopqrstuvwxyz',
+      MULTITABLE_AI_MODEL: 'gpt-4o-mini',
+    }),
+    stdio: 'pipe',
+  })
+
+  const report = JSON.parse(fs.readFileSync(jsonPath, 'utf8'))
+  assert.equal(report.status, 'ready')
+})

--- a/scripts/ops/multitable-ai-readiness-gate.ts
+++ b/scripts/ops/multitable-ai-readiness-gate.ts
@@ -1,0 +1,123 @@
+#!/usr/bin/env tsx
+
+import fs from 'node:fs/promises'
+import path from 'node:path'
+import { fileURLToPath } from 'node:url'
+import aiProviderReadinessModule from '../../packages/core-backend/src/services/ai-provider-readiness.ts'
+import { redactString, redactValue } from './multitable-phase3-release-gate-redact.mjs'
+
+const {
+  renderAiProviderReadinessMarkdown,
+  resolveAiProviderReadiness,
+} = aiProviderReadinessModule as typeof import('../../packages/core-backend/src/services/ai-provider-readiness')
+
+const PASS = 0
+const FAIL = 1
+const BLOCKED = 2
+
+const scriptDir = path.dirname(fileURLToPath(import.meta.url))
+const repoRoot = path.resolve(scriptDir, '../..')
+const defaultOutputDir = 'output/multitable-ai-provider-readiness'
+
+interface GateOptions {
+  outputDir: string
+  outputJson: string
+  outputMd: string
+}
+
+function readRequiredValue(argv: string[], index: number, flag: string): string {
+  const value = argv[index + 1]
+  if (!value || value.startsWith('--')) {
+    throw new Error(`${flag} requires a value`)
+  }
+  return value
+}
+
+function resolveOutputPath(value: string): string {
+  return path.resolve(repoRoot, value)
+}
+
+function outputPathFromEnv(envName: string, fallback: string): string {
+  const raw = process.env[envName]?.trim()
+  return resolveOutputPath(raw || fallback)
+}
+
+function parseArgs(argv: string[]): GateOptions {
+  let outputDir = process.env.AI_READINESS_OUTPUT_DIR?.trim() || ''
+  let outputJson = process.env.AI_READINESS_JSON?.trim() || ''
+  let outputMd = process.env.AI_READINESS_MD?.trim() || ''
+
+  for (let i = 0; i < argv.length; i += 1) {
+    const arg = argv[i]
+    if (arg === '--help') {
+      printHelp()
+      process.exit(PASS)
+    }
+    if (arg === '--output-dir') {
+      outputDir = readRequiredValue(argv, i, arg)
+      i += 1
+      continue
+    }
+    if (arg === '--output-json') {
+      outputJson = readRequiredValue(argv, i, arg)
+      i += 1
+      continue
+    }
+    if (arg === '--output-md') {
+      outputMd = readRequiredValue(argv, i, arg)
+      i += 1
+      continue
+    }
+    throw new Error(`Unknown option: ${arg}`)
+  }
+
+  const resolvedOutputDir = outputDir ? resolveOutputPath(outputDir) : resolveOutputPath(defaultOutputDir)
+  return {
+    outputDir: resolvedOutputDir,
+    outputJson: outputJson ? resolveOutputPath(outputJson) : outputPathFromEnv('AI_READINESS_JSON', path.join(resolvedOutputDir, 'report.json')),
+    outputMd: outputMd ? resolveOutputPath(outputMd) : outputPathFromEnv('AI_READINESS_MD', path.join(resolvedOutputDir, 'report.md')),
+  }
+}
+
+function printHelp(): void {
+  process.stdout.write(`Usage: pnpm verify:multitable-ai:readiness [options]
+
+Runs the Multitable AI provider readiness gate. This is a declarative A1 gate:
+it validates env shape only and never sends a live provider request.
+
+Options:
+  --output-dir <dir>     Output directory, default ${defaultOutputDir}
+  --output-json <file>   Output JSON path, default <output-dir>/report.json
+  --output-md <file>     Output Markdown path, default <output-dir>/report.md
+  --help                 Show this help.
+
+Exit codes:
+  0  ready
+  1  script failure
+  2  disabled or blocked
+`)
+}
+
+async function main(): Promise<void> {
+  const options = parseArgs(process.argv.slice(2))
+  const report = resolveAiProviderReadiness(process.env)
+  const safeReport = redactValue(report)
+  const markdown = redactString(renderAiProviderReadinessMarkdown(safeReport as typeof report))
+  const json = `${redactString(JSON.stringify(safeReport, null, 2))}\n`
+
+  await fs.mkdir(path.dirname(options.outputJson), { recursive: true })
+  await fs.mkdir(path.dirname(options.outputMd), { recursive: true })
+  await fs.writeFile(options.outputJson, json)
+  await fs.writeFile(options.outputMd, markdown)
+
+  process.stdout.write(markdown)
+  process.stdout.write(`\nJSON report: ${redactString(options.outputJson)}\nMarkdown report: ${redactString(options.outputMd)}\n`)
+
+  process.exitCode = report.status === 'ready' ? PASS : BLOCKED
+}
+
+main().catch((error: unknown) => {
+  const message = redactString(error instanceof Error ? error.message : String(error))
+  process.stderr.write(`multitable AI provider readiness failed: ${message}\n`)
+  process.exitCode = FAIL
+})


### PR DESCRIPTION
## Summary
- add pure A1 AI provider readiness resolver for the ratified env contract (disabled/blocked/ready only; reserved statuses exported for M2)
- add internal admin-only GET `/api/multitable/ai/readiness` route, flat response, defensive backend redaction, no OpenAPI surface
- add `verify:multitable-ai:readiness` TSX ops gate with JSON/MD artifacts and exit 0/1/2 semantics

## Boundaries
- no DB, no migrations, no OpenAPI source changes
- no live provider call or API-key validation request
- no new permission primitive; route uses existing platform JWT + admin guard
- `MULTITABLE_AI_CONFIRM_LIVE_REQUESTS` is informational only in A1

## Verification
- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/ai-provider-readiness.test.ts tests/unit/multitable-ai-readiness-route.test.ts --reporter=dot`
- `node --test scripts/ops/multitable-ai-readiness-gate.test.mjs`
- `pnpm --filter @metasheet/core-backend build`
- `git diff --check`
- `pnpm verify:multitable-openapi:parity`
