### PR TITLE
docs(multitable): scope parallel join-all automation

### DIFF
--- a/docs/development/multitable-automation-a6-3-parallel-join-all-scope-gate-20260611.md
+++ b/docs/development/multitable-automation-a6-3-parallel-join-all-scope-gate-20260611.md
@@ -1,0 +1,318 @@
+# Multitable Automation A6-3-4 Parallel Fan-Out + Join-All Scope Gate - 2026-06-11
+
+Type: **A6-3-4 docs-only scope-gate**.
+
+Grounded on: `origin/main@699a1b15`.
+
+Companion:
+
+- `docs/development/multitable-automation-a6-3-branch-parallel-design-20260605.md`
+- `docs/development/multitable-automation-a6-execution-plan-20260601.md`
+- `docs/development/multitable-automation-run-governance-todo-20260527.md`
+- `docs/development/workflow-automation-completion-plan-20260609.md`
+- `packages/core-backend/src/multitable/automation-executor.ts`
+- `packages/core-backend/src/multitable/automation-job-service.ts`
+- `packages/core-backend/src/multitable/automation-actions.ts`
+- `apps/web/src/multitable/utils/conditionBranchAuthoring.ts`
+
+## 0. Verdict
+
+A6-3-4 may be scoped as the next automation graph rung, but runtime remains
+gated. This document locks the first parallel slice as **fan-out + join-all
+only**.
+
+The runtime PR may add a `parallel_branch` action that runs all configured
+branches, records branch child jobs in the existing C1 job plane, and continues
+only after all branches are terminal.
+
+It must **not** add `join_any`, cancellation semantics, branch-local waits,
+nested branches, BPMN, approval coupling, public webhooks, or a new workflow
+runtime.
+
+## 1. Current Code Facts
+
+| ID | Fact | Evidence |
+|---|---|---|
+| F1 | A6-3-1 `condition_branch` landed exclusive first-match/default branch runtime. It reuses the C1 job plane and nested step keys for selected child jobs. | `automation-executor.ts`; `automation-job-service.ts`; `multitable-automation-a6-3-branch-parallel-design-20260605.md` |
+| F2 | A6-3-2 frontend can author only flat branch conditions and the `update_record` / `send_notification` subset; richer branch shapes open read-only rather than flattening. | `conditionBranchAuthoring.ts`; `MetaAutomationRuleEditor.vue` |
+| F3 | A6-2 suspend/resume still uses a top-level cursor and explicitly defers branch-local wait/nesting. | `multitable-automation-a6-2-suspend-resume-design-20260603.md` |
+| F4 | The current executor is still effectively inline/sequential. A6-3-4 can model fan-out/fan-in in the job graph without promising worker-level concurrent execution. | `AutomationExecutor` |
+| F5 | A6-4 BPMN preview depends on branch/parallel semantics. Without A6-3-4, BPMN parallel gateways must remain gap-report only. | `workflow-automation-completion-plan-20260609.md` |
+
+## 2. Scope
+
+### In Scope For A6-3-4
+
+- Add one canonical action type: `parallel_branch`.
+- Run every configured branch exactly once.
+- Support only `joinMode: 'all'`.
+- Persist a parent parallel job plus branch child jobs in the existing
+  `multitable_automation_jobs` C1 plane.
+- Continue to the next top-level action only after every branch is terminal.
+- Fail the parent and execution if any branch fails.
+- Continue sibling branches after one branch fails, so `join_all` still means
+  every configured branch is attempted.
+- Mark top-level downstream actions skipped when the parent fails.
+- Preserve branch child outputs/errors through existing A1 redaction.
+- Add backend real-DB tests for C1 lineage and failure/skip behavior.
+
+### Out Of Scope
+
+- `join_any` or first-winner cancellation.
+- True worker-concurrent branch execution.
+- Delay/timer resume.
+- `wait_for_callback` inside parallel branches.
+- `condition_branch` nested inside parallel branches.
+- `start_approval` inside parallel branches.
+- Approval result backwrite.
+- BPMN parse/compile/preview.
+- Public webhook endpoints or token emitters.
+- New workflow runtime tables outside the automation job plane.
+- New status vocabulary outside C1.
+
+## 3. Action Contract
+
+Recommended v1 config:
+
+```ts
+type ParallelBranchConfig = {
+  joinMode: 'all'
+  branches: Array<{
+    key: string
+    label?: string
+    actions: AutomationAction[]
+  }>
+}
+```
+
+Rules:
+
+1. `branches` must be a non-empty array.
+2. Branch keys must be non-empty, unique, deterministic-id-safe strings.
+3. `joinMode` must be exactly `all` in A6-3-4.
+4. Every branch must contain at least one action.
+5. Branch action types must be a minimal safe subset for v1. Recommended first
+   subset: `update_record` and `send_notification`, matching A6-3-2 authoring.
+6. `wait_for_callback`, nested `condition_branch`, nested `parallel_branch`,
+   and `start_approval` must be rejected in A6-3-4.
+
+The runtime PR may narrow the branch action subset further, but it must not
+widen beyond this contract without updating this scope gate.
+
+## 4. Runtime Model
+
+A6-3-4 should be graph-shaped but may run inline in v1.
+
+Recommended sequence:
+
+1. Parent `parallel_branch` job starts as `running`.
+2. Each configured branch is selected. There is no condition filter in A6-3-4;
+   all branches run.
+3. Branches run independently in the job graph. Inline execution is acceptable
+   if the persisted graph still represents fan-out/fan-in.
+4. Branch child jobs settle independently.
+5. If all branch tails resolve, the parent settles `resolved` and the next
+   top-level action upstreams from the parent.
+6. If one branch fails, the rest of that branch settles according to fail-stop
+   semantics, but sibling branches still run to terminal state.
+7. After every branch is terminal, the parent settles `failed` if any branch
+   failed; downstream top-level actions settle `skipped`.
+
+The parent job is the join point. Do not model join-all by simply appending one
+branch after another into the linear chain without explicit branch lineage.
+The existing schema has a singular `upstream_job_id`, so v1 should model fan-in
+by settling the parent join job only after all child branches are terminal and
+by recording child job ids / branch summaries in parent output. Do not add a
+second workflow table or status plane.
+
+## 5. Job Identity And C1 Graph
+
+Reuse the existing `multitable_automation_jobs` table.
+
+Recommended deterministic ids:
+
+```text
+parent: ${executionId}:job:${stepIndex}
+child:  ${executionId}:job:${stepIndex}:parallel:${branchKey}:${actionIndex}
+```
+
+Recommended step keys:
+
+```text
+parent: ${stepIndex}
+child:  ${stepIndex}.parallel.${branchKey}.${actionIndex}
+```
+
+`upstream_job_id`:
+
+- Parent upstream is the previous top-level job.
+- First child in every branch upstreams to the parent job.
+- Later children in the same branch upstream to the previous child in that
+  branch.
+- The next top-level job upstreams to the parent join job, not to an arbitrary
+  child.
+
+Parent job output should include:
+
+```json
+{
+  "joinMode": "all",
+  "branchCount": 2,
+  "childJobIds": ["axe_1:job:0:parallel:ops:0"],
+  "resolvedBranchKeys": ["ops", "finance"],
+  "failedBranchKeys": [],
+  "skippedBranchKeys": [],
+  "branchStatuses": {
+    "ops": "resolved",
+    "finance": "resolved"
+  }
+}
+```
+
+Runs view may later group children under the parent using `stepKey`, but the
+backend contract remains the C1 job list.
+
+## 6. Failure Semantics
+
+| Case | Required behavior |
+|---|---|
+| Invalid branch config | Reject at rule save/update, not at runtime. |
+| Branch action fails | That child job fails; later actions in the same branch are skipped; sibling branches still run; parent fails after every branch is terminal; execution fails; downstream top-level actions skipped. |
+| Branch action throws after side effects | Failure is recorded; no automatic rollback of already-run branch side effects. |
+| One branch fails before sibling branches run | Sibling branches still run. `join_all` must not short-circuit the whole fan-out on the first failed branch. |
+| Multiple branches fail | Parent output lists all observed failed branch keys. |
+| All branches succeed | Parent resolves and execution continues. |
+| Branch list empty | Reject at rule save/update. |
+| Branch contains forbidden action | Reject at rule save/update. |
+
+## 7. Side Effects And Ordering
+
+Because v1 may execute inline, A6-3-4 must be honest about ordering:
+
+- It may call the feature "parallel fan-out" because the persisted C1 graph fans
+  out, but it must not claim worker-level concurrent execution unless branches
+  truly run concurrently.
+- If branch order is deterministic array order, document and test that order.
+- If a later action in the same branch is skipped because an earlier branch
+  action failed, the skipped job must make that explicit.
+- Side effects from already-run successful branches are durable even if a later
+  branch fails.
+- All branches should read the same trigger event and rule snapshot captured for
+  the execution. V1 must not promise sibling branches observe each other's
+  writes unless a later runtime deliberately adds that contract.
+- A5 whole-execution retry remains the only retry mechanism in scope. It reruns
+  the whole execution with confirmation and must create a new execution/job
+  graph; A6-3-4 must not add automatic branch-only retry.
+- A6-2 / W6 resume remains top-level-cursor based. A6-3-4 must not introduce
+  branch-local resume tokens, branch-local `start_approval`, or nested
+  suspension cursor semantics.
+
+## 8. Redaction And Observability
+
+Parent and child job output may include:
+
+- branch key;
+- branch label;
+- join mode;
+- child action type;
+- updated field ids or notification ids already allowed by those action outputs;
+- aggregate lists of resolved/failed/skipped branch keys.
+
+Output must not include:
+
+- full record data;
+- hidden field values;
+- notification message bodies if existing action redaction excludes them;
+- automation credentials or full rule snapshot;
+- approval data.
+
+All output must continue through existing A1 redaction and C1 normalization.
+Do not add a branch-specific redactor or an unredacted branch input/result cache.
+
+## 9. Validation Requirements
+
+Service-level validation is mandatory. Route-level validation is not enough.
+
+Validate:
+
+- `parallel_branch` exists in the canonical action registry and database CHECK
+  constraint.
+- `parallel_branch` requires `execution_mode='workflow_job_v1'`.
+- `branches` is non-empty.
+- branch keys are unique and deterministic-id-safe.
+- branch actions are in the allowed A6-3-4 subset.
+- action configs inside branches pass the same validation used for top-level
+  actions.
+- branch count and total branch-action count are bounded by tested runtime
+  limits, or the runtime PR explicitly proves it reuses an existing bounded
+  automation action limit. Unbounded fan-out is not allowed.
+- forbidden nested actions are rejected:
+  - `wait_for_callback`;
+  - `condition_branch`;
+  - `parallel_branch`;
+  - `start_approval`.
+
+## 10. Test Matrix For A6-3-4
+
+| ID | Test | Risk covered |
+|---|---|---|
+| T1 | Create/update rejects `parallel_branch` unless `executionMode='workflow_job_v1'`. | Legacy path cannot half-run graph jobs. |
+| T2 | Valid two-branch `join_all` rule persists and executes. | Happy path. |
+| T3 | All branches run exactly once; non-branch top-level next action runs after parent resolves. | Join-all success semantics. |
+| T4 | Parent job has correct C1 output and child job `stepKey`/`upstreamJobId` fan-out shape. | Observability graph. |
+| T5 | Failure in one branch still lets sibling branches run to terminal; parent fails only after all branches are terminal; downstream top-level actions are skipped. | Join-all failure semantics. |
+| T6 | Failure inside one branch skips the rest of that branch while sibling branches still run. | Branch-local fail-stop. |
+| T7 | Duplicate/retry execution does not duplicate jobs within one execution. | Idempotency inside job plane. |
+| T8 | A5 whole-execution retry reruns the whole execution with confirmation and creates a new execution/job graph; there is no automatic branch-only retry. | Retry/provenance boundary. |
+| T9 | Branch config containing `wait_for_callback`, nested `condition_branch`, nested `parallel_branch`, or `start_approval` is rejected at save time. | Boundary enforcement. |
+| T10 | Redaction test proves parent/child job outputs exclude full record data, credentials, approval data, and hidden values. | Privacy. |
+| T11 | Real-DB integration traverses opt-in rule trigger -> parallel parent -> branch children -> join-all parent resolution. | Wire-vs-fixture seam. |
+| T12 | Admin runs detail can render the C1 job list without a second read model. | A2/A3 compatibility. |
+
+At least one test must use the actual `AutomationService.executeRule()` path and
+the actual job persistence path. Hand-built job fixtures alone are not enough.
+
+## 11. Frontend Posture
+
+No frontend builder is required in the first backend runtime PR unless the owner
+explicitly asks for it.
+
+The first frontend slice, when opened, should:
+
+- use a form-based branch list, not a canvas;
+- lock `workflow_job_v1` when `parallel_branch` is present;
+- enforce the same action subset as the backend;
+- show parent + branch child jobs in Admin runs;
+- open richer/unknown loaded parallel shapes read-only rather than flattening.
+
+## 12. Runtime Red Lines
+
+A6-3-4 must not:
+
+- add `join_any`;
+- add cancellation semantics;
+- add branch-local wait/resume;
+- add nested branches;
+- add approval start/backwrite inside parallel branches;
+- add BPMN parse/compile/runtime;
+- add public webhooks;
+- create a second job/read/audit model;
+- invent statuses outside C1;
+- silently run in legacy/non-job rules.
+
+## 13. Completion Criteria
+
+W3-0 is complete when this docs-only scope gate is merged.
+
+A6-3-4/W3-1 runtime is complete only when:
+
+1. A runtime PR lands `parallel_branch` with `joinMode: 'all'` under this
+   contract.
+2. Real-DB tests prove fan-out/fan-in C1 job shape and fail/skip behavior.
+3. Admin runs can explain parent/child jobs without leaking sensitive data.
+4. `workflow-automation-completion-plan-20260609.md`,
+   `multitable-automation-run-governance-todo-20260527.md`, and
+   `multitable-automation-a6-execution-plan-20260601.md` are updated to mark
+   W3-1 runtime landed.
+
+Until then, A6-3-4 remains scoped but not implemented.

--- a/docs/development/multitable-automation-a6-execution-plan-20260601.md
+++ b/docs/development/multitable-automation-a6-execution-plan-20260601.md
@@ -177,18 +177,22 @@ Design-lock: `multitable-automation-a6-3-branch-parallel-design-20260605.md`.
 > never-flatten guard for richer loaded shapes, `workflow_job_v1` auto-lock), and the admin runs detail
 > shows selected branch `label (key)` plus branch child jobs. **Still deferred, each its own opt-in:**
 > A6-3-3 `wait_for_callback` / nested-`condition_branch` inside branches; A6-3 parallel fan-out /
-> join-all / join-any. Design-lock detail below retained for the record.
+> join-all runtime / join-any. A6-3-4/W3-0 now has a docs-only scope gate:
+> `multitable-automation-a6-3-parallel-join-all-scope-gate-20260611.md`.
+> Design-lock detail below retained for the record.
 
 The design-lock pins the first runtime slice as **A6-3-1 `condition_branch` /
 exclusive branch v1**, not full parallel DAG. Parallel fan-out, join-all, and
-join-any stay separate follow rungs.
+join-any stay separate follow rungs. The first parallel follow rung is scoped as
+A6-3-4/W3-0 (`join_all` only); runtime remains gated.
 
 - **Adds:** graph fields (upstream/downstream edges, branch discriminator, join mode,
   branch result aggregation) and generalizes the linear executor into a DAG. This is the
   **largest single engine change** on the ladder.
 - **Must not (this rung):** no BPMN import; no approval coupling.
 - **Depends on:** A6-2 (job persistence + resume stable before fan-out/join).
-- **Gate:** a named per-record branch/parallel demand with audit.
+- **Gate:** A6-3-4/W3-0 docs-only scope gate exists; runtime still needs a named
+  parallel/join-all opt-in.
 - **Test surface:** see A6-0 scout "→ A6-3" (branch picks exactly one, parallel fan-out
   independent, join-all waits, join-any cancels with explicit audit, branch failures
   isolated).
@@ -251,5 +255,6 @@ join-any stay separate follow rungs.
 - A6-1 enable-writer **landed** (#2130/#2191/#2193) and A6-2 suspend/resume **landed**
   2026-06-03 (#2236 design-lock + #2237 impl, admin-gated v1); A6-3 exclusive branch
   v1 **landed** (#2321/#2339/#2348); A6-5 `start_approval` bridge **landed** (#2469).
-  A6-3-3, A6-3 parallel/join, A6-4 BPMN compile/preview, public webhook/token emitter,
-  and W7 result backwrite runtime remain demand-gated.
+  A6-3-3, A6-3-4/W3-1 parallel join-all runtime, A6-3-5 join-any, A6-4 BPMN
+  compile/preview, public webhook/token emitter, and W7 result backwrite
+  runtime remain demand-gated.

--- a/docs/development/multitable-automation-run-governance-todo-20260527.md
+++ b/docs/development/multitable-automation-run-governance-todo-20260527.md
@@ -2,7 +2,7 @@
 
 Date: 2026-05-27
 Scope: multitable automation run governance + whole-execution retry only
-Status: A0-A5 closed (2026-05-29); A6-1 COMPLETE end-to-end (runtime #2130 + enable-writer #2191 + admin UI toggle #2193, 2026-06) — rules can opt into the per-action WorkflowJob plane from the editor, no longer dormant; A6-2 suspend/resume backend (admin-gated v1, webhook/external resume) LANDED #2237 c363a78db (2026-06-03) + A6-2b frontend (admin Resume UI + `wait_for_callback` editor) LANDED #2245 cee99c8e4 (2026-06-04) + operator UAT PASS #2257 (2026-06-04) — A6-2 now closed end-to-end; delay/timer resume deferred; A6-3-1 `condition_branch` exclusive-branch runtime LANDED #2321 `127b29dd9` (2026-06-05; design-lock `multitable-automation-a6-3-branch-parallel-design-20260605.md`) + A6-3-2a editor LANDED #2339 `960ea9315` + A6-3-2b admin-runs readability LANDED #2348 `4b44f25c6`; A6-3 v1 operator/API/UI trial PASS (#2367/#2371), with no current A6-3-3 unlock signal; A6-5 / W6-1 `start_approval` bridge LANDED #2469; W7-0 approval result backwrite scope-gate added (runtime not started); A6-3-3 (wait/nesting in branches) / parallel fan-out·join still gated; A6-4 BPMN compile/preview and public webhook/token emitter remain demand-gated.
+Status: A0-A5 closed (2026-05-29); A6-1 COMPLETE end-to-end (runtime #2130 + enable-writer #2191 + admin UI toggle #2193, 2026-06) — rules can opt into the per-action WorkflowJob plane from the editor, no longer dormant; A6-2 suspend/resume backend (admin-gated v1, webhook/external resume) LANDED #2237 c363a78db (2026-06-03) + A6-2b frontend (admin Resume UI + `wait_for_callback` editor) LANDED #2245 cee99c8e4 (2026-06-04) + operator UAT PASS #2257 (2026-06-04) — A6-2 now closed end-to-end; delay/timer resume deferred; A6-3-1 `condition_branch` exclusive-branch runtime LANDED #2321 `127b29dd9` (2026-06-05; design-lock `multitable-automation-a6-3-branch-parallel-design-20260605.md`) + A6-3-2a editor LANDED #2339 `960ea9315` + A6-3-2b admin-runs readability LANDED #2348 `4b44f25c6`; A6-3 v1 operator/API/UI trial PASS (#2367/#2371), with no current A6-3-3 unlock signal; A6-3-4/W3-0 parallel join-all scope-gate added (runtime not started); A6-5 / W6-1 `start_approval` bridge LANDED #2469; W7-0 approval result backwrite scope-gate added (runtime not started); A6-3-3 (wait/nesting in branches) / parallel join-all runtime / join-any still gated; A6-4 BPMN compile/preview and public webhook/token emitter remain demand-gated.
 Companion: multitable-automation-run-governance-development-20260527.md
 Depends on (landed): C1 contract workflow-job-contract.ts (#1889, read-boundary wired only); RFC #1885
 
@@ -129,8 +129,8 @@ Landed (capability half) — A6-1 COMPLETE, end-to-end & reachable in production
 Deferred (capability half — A6, frozen/demand-gated):
 - A6-2 delay/timer resume (v1 was webhook/external only; delay/timer later forces a durable
   scheduler/worker/leader)
-- A6-3-3 branch-local wait/nesting; A6-3 parallel/join; A6-4 BPMN compile/preview adapter;
-  public webhook/token emitter; W7 approval result backwrite
+- A6-3-3 branch-local wait/nesting; A6-3-4/W3-1 parallel join-all runtime; A6-3-5 join-any;
+  A6-4 BPMN compile/preview adapter; public webhook/token emitter; W7 approval result backwrite
 
 ## Milestones
 
@@ -301,7 +301,9 @@ complete.
       readable line.
 - [x] A6-3 v1 operator/API/UI trial — PASS #2367/#2371; no A6-3-3 demand surfaced.
 - [ ] A6-3-3 `wait_for_callback` / nested `condition_branch` inside branches — gated (forbidden in A6-3-1); open only for a named branch-local wait/nesting scenario.
-- [ ] A6-3 parallel fan-out / join-all / join-any — gated (separate follow rungs after the exclusive slice).
+- [x] A6-3-4 / W3-0 parallel fan-out + join-all scope-gate — `multitable-automation-a6-3-parallel-join-all-scope-gate-20260611.md`: `parallel_branch`, `joinMode: all` only, C1 fan-out/fan-in graph, fail/skip semantics, and no BPMN/approval/webhook expansion.
+- [ ] A6-3-4 / W3-1 parallel fan-out + join-all runtime — not started; named opt-in required.
+- [ ] A6-3-5 join-any / cancellation semantics — gated after join-all runtime.
 - [ ] A6-4 BPMN compile/preview adapter — not started.
 - [x] A6-5 / W6-1 `start_approval` approval-as-job bridge — LANDED #2469: creates one approval instance from a published template, persists the bridge row, writes suspended / terminal C1 jobs, resumes/fails from W5 completion events, and guards A5 retry duplicates.
 - [x] W7-0 approval result backwrite scope-gate — `automation-approval-result-backwrite-scope-gate-20260611.md`: explicit mapping only; durable idempotent attempt state; permission/field guards; no approval form/comment/profile leakage; runtime remains gated.

--- a/docs/development/workflow-automation-completion-plan-20260609.md
+++ b/docs/development/workflow-automation-completion-plan-20260609.md
@@ -38,7 +38,7 @@ Current main already contains the governance and first convergence slices:
 | A6-2 suspend/resume | Landed end-to-end: `wait_for_callback`, `multitable_automation_suspensions`, admin resume route, editor config, admin runs resume UI, UAT recorded. |
 | A6-3-1 condition branch runtime | Landed: `condition_branch`, exclusive first-match/default branch, C1 parent/child/downstream lineage. |
 | A6-3-2 frontend and runs readability | Landed in code: editor builder in `MetaAutomationRuleEditor.vue` and `conditionBranchAuthoring.ts`; runs readability in `AutomationExecutionsView.vue`. |
-| Still missing | Branch-local wait/nesting, parallel fan-out/join, BPMN compile/preview mapping, public webhook token emitter. |
+| Still missing | Branch-local wait/nesting, parallel join-all runtime, join-any/cancellation, BPMN compile/preview mapping, public webhook token emitter. |
 
 ### 1.2 Approval
 
@@ -115,7 +115,8 @@ operate a practical business workflow using existing product surfaces:
 | W0 | Re-ground status docs against current main | Landed #2411/#2412 | Existing TODOs no longer say A6-3-2 is not started after #2339/#2348. |
 | W1 | Approval authoring deployed-browser smoke | Done | #2318 PASS accepted: UI-created template published, `/approvals/new/:templateId` started, submitted user field resolved to expected assignee, unsupported rich template was read-only/save-disabled. #2375/#2371 reconfirmed current deployment. |
 | W2 | Automation A6-3-3 branch-local wait/nesting | Not started; demand-gated; no current unlock | `wait_for_callback` can live inside selected branch with stable nested step cursor, rule-drift guard, resume tests, and no silent flattening in editor. #2367 trial found A6-3 v1 sufficient for the tested flow, so do not start W2 without a new named scenario. |
-| W3 | Automation parallel fan-out + join-all | Not started; demand-gated | Parallel branches persist independent job lineage; join-all waits for all branches; failures and skipped branches are audited. |
+| W3-0 | Automation parallel fan-out + join-all scope-gate | Scope-gate document added; runtime not started | `multitable-automation-a6-3-parallel-join-all-scope-gate-20260611.md` locks fan-out/fan-in C1 graph shape, `join_all` only, fail/skip semantics, redaction, and tests. |
+| W3-1 | Automation parallel fan-out + join-all runtime | Not started; named opt-in required | Parallel branches persist independent job lineage; join-all waits for all branches; failures and skipped branches are audited. |
 | W4 | Automation join-any / cancellation semantics | Not started; demand-gated after W3 | First completed branch continues; ignored/cancelled siblings are explicit in C1 jobs and audit. |
 | W5-0 | Approval completion event contract scope-gate | Landed #2413 | Defines terminal approval event taxonomy, redacted payload, idempotency key, post-commit emission boundary, and test matrix without adding automation behavior. |
 | W5-1 | Approval completion event contract implementation | Landed #2414 (`184f2293c`) | `approval.approved/rejected/revoked/cancelled` payload is versioned, redacted, idempotent, emitted post-commit, and tested without adding automation action yet. `return` remains a non-terminal rework transition. |
@@ -144,7 +145,8 @@ Why:
 The next cross-surface candidate is **W7 approval result backwrite**. W7-0 now
 has a scope-gate document, but W7-1 runtime remains gated because it writes
 business data and changes record state. Do not jump straight to BPMN before the
-remaining graph prerequisites are named. BPMN gateway preview still needs
+remaining graph prerequisites are named. W3-0 now scopes the `join_all` slice,
+but W3-1 runtime remains gated. BPMN gateway preview still needs
 branch/parallel semantics to map to.
 
 ## 5. Non-goals for v1
@@ -172,6 +174,8 @@ needed, one verification/runbook:
   `automation-start-approval-scope-gate-20260610.md`.
 - W7 approval result backwrite scope:
   `automation-approval-result-backwrite-scope-gate-20260611.md`.
+- A6-3-4 / W3 parallel join-all scope:
+  `multitable-automation-a6-3-parallel-join-all-scope-gate-20260611.md`.
 
 If code lands but the tracker still says "not started", the tracker is wrong
 and should be corrected before starting a new rung.


### PR DESCRIPTION
## Summary

- add the A6-3-4 / W3-0 docs-only scope gate for `parallel_branch` fan-out + `joinMode: all`
- split W3 into W3-0 scope-gate and W3-1 runtime in the workflow completion plan and run-governance TODO
- pin runtime boundaries: existing C1 job plane only, no `join_any`, no branch-local wait/resume, no approval coupling, no BPMN/public webhook expansion

## Review notes

- This is docs-only. It does not start the W3-1 runtime.
- Incorporated subagent review feedback before opening: sibling branches still run under `join_all`; branch-local failures skip only that branch tail; parent join settles after every branch is terminal; A5 retry and A6-2/W6 resume boundaries are explicit.

## Verification

- `git diff --check`
- docs-only guard: changed files are `.md` only
