### PR TITLE
feat(attendance): add C5 notification delivery outbox schema

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -255,6 +255,7 @@ jobs:
             tests/integration/attendance-expiry-service.test.ts \
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \
+            tests/integration/attendance-notification-deliveries.test.ts \
             --reporter=dot
 
       - name: Upload test results

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -26,7 +26,7 @@
     "test:unit": "vitest run tests/unit --reporter=dot",
     "test:integration": "vitest --config vitest.integration.config.ts run tests/integration --reporter=dot",
     "test:integration:after-sales": "vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot",
-    "test:integration:attendance": "vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts tests/integration/attendance-expiry-service.test.ts tests/integration/attendance-unscheduled-reminder.test.ts tests/integration/attendance-outdoor-punch.test.ts --reporter=dot",
+    "test:integration:attendance": "vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts tests/integration/attendance-expiry-service.test.ts tests/integration/attendance-unscheduled-reminder.test.ts tests/integration/attendance-outdoor-punch.test.ts tests/integration/attendance-notification-deliveries.test.ts --reporter=dot",
     "test:contract": "vitest run tests/contract --reporter=dot",
     "test:e2e:handoff": "npx playwright test --config tests/e2e/playwright.config.ts",
     "test:cache": "npm run build:cache && TEST_USE_DIST=true vitest --config vitest.cache.config.ts run --reporter=dot",

--- a/packages/core-backend/src/db/migrations/zzzz20260611120000_create_attendance_notification_deliveries.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260611120000_create_attendance_notification_deliveries.ts
@@ -1,0 +1,54 @@
+import type { Kysely } from 'kysely'
+import { sql } from 'kysely'
+import { checkTableExists, createIndexIfNotExists } from './_patterns'
+
+const DEFAULT_ORG_ID = 'default'
+const TABLE = 'attendance_notification_deliveries'
+
+// C5-0 (design-lock #2483). LATENT outbox schema only: no producer, worker, or channel
+// writes this table yet. The table separates source intent from delivery truth so later
+// C5 slices can retry per recipient/channel without treating source dispatched_at as
+// external delivery success.
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await sql`CREATE EXTENSION IF NOT EXISTS pgcrypto`.execute(db)
+
+  const exists = await checkTableExists(db, TABLE)
+  if (!exists) {
+    await db.schema
+      .createTable(TABLE)
+      .ifNotExists()
+      .addColumn('id', 'uuid', col => col.primaryKey().defaultTo(sql`gen_random_uuid()`))
+      .addColumn('org_id', 'text', col => col.notNull().defaultTo(DEFAULT_ORG_ID))
+      .addColumn('source_type', 'text', col => col.notNull())
+      .addColumn('source_id', 'text')
+      .addColumn('source_key', 'text', col => col.notNull())
+      .addColumn('recipient_user_id', 'text', col => col.notNull())
+      .addColumn('recipient_role', 'text', col => col.notNull())
+      .addColumn('channel', 'text', col => col.notNull())
+      .addColumn('status', 'text', col => col.notNull().defaultTo('pending'))
+      .addColumn('attempt_count', 'integer', col => col.notNull().defaultTo(0))
+      .addColumn('next_attempt_at', 'timestamptz', col => col.notNull().defaultTo(sql`now()`))
+      .addColumn('last_attempt_at', 'timestamptz')
+      .addColumn('claimed_at', 'timestamptz')
+      .addColumn('claim_expires_at', 'timestamptz')
+      .addColumn('claim_worker_id', 'text')
+      .addColumn('delivered_at', 'timestamptz')
+      .addColumn('last_error', 'text')
+      .addColumn('payload', 'jsonb', col => col.notNull().defaultTo(sql`'{}'::jsonb`))
+      .addColumn('created_at', 'timestamptz', col => col.notNull().defaultTo(sql`now()`))
+      .addColumn('updated_at', 'timestamptz', col => col.notNull().defaultTo(sql`now()`))
+      .addCheckConstraint('chk_attendance_notification_deliveries_status', sql`status IN ('pending', 'sending', 'sent', 'retrying', 'failed', 'skipped')`)
+      .addCheckConstraint('chk_attendance_notification_deliveries_attempt_count', sql`attempt_count >= 0`)
+      .addCheckConstraint('chk_attendance_notification_deliveries_delivered_status', sql`delivered_at IS NULL OR status = 'sent'`)
+      .execute()
+  }
+
+  await createIndexIfNotExists(db, 'uq_attendance_notification_deliveries_source_key', TABLE, ['org_id', 'source_key'], { unique: true })
+  await createIndexIfNotExists(db, 'idx_attendance_notification_deliveries_claim', TABLE, ['status', 'next_attempt_at'])
+  await createIndexIfNotExists(db, 'idx_attendance_notification_deliveries_reclaim', TABLE, ['status', 'claim_expires_at'])
+  await createIndexIfNotExists(db, 'idx_attendance_notification_deliveries_source', TABLE, ['org_id', 'source_type', 'source_id'])
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await db.schema.dropTable(TABLE).ifExists().execute()
+}

--- a/packages/core-backend/tests/integration/attendance-notification-deliveries.test.ts
+++ b/packages/core-backend/tests/integration/attendance-notification-deliveries.test.ts
@@ -1,0 +1,190 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { randomUUID } from 'crypto'
+import { Kysely, PostgresDialect } from 'kysely'
+import { Pool } from 'pg'
+import { up as createAttendanceNotificationDeliveries } from '../../src/db/migrations/zzzz20260611120000_create_attendance_notification_deliveries'
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeIfDatabase = dbUrl ? describe : describe.skip
+
+async function requireTable(pool: Pool, tableName: string): Promise<void> {
+  const tableCheck = await pool.query(`SELECT to_regclass(current_schema() || '.' || $1) AS name`, [tableName])
+  if (!tableCheck.rows[0]?.name) {
+    throw new Error(`Integration database is missing ${tableName}; run core-backend migrations before executing this suite.`)
+  }
+}
+
+function createIsolatedSchemaName(): string {
+  return `attendance_c5_outbox_${Date.now()}_${Math.random().toString(16).slice(2, 10)}`
+}
+
+function withSearchPath(connectionString: string, schemaName: string): string {
+  const url = new URL(connectionString)
+  const existingOptions = url.searchParams.get('options')
+  const schemaOption = `-c search_path=${schemaName}`
+  url.searchParams.set('options', existingOptions ? `${existingOptions} ${schemaOption}` : schemaOption)
+  return url.toString()
+}
+
+async function createSchema(connectionString: string, schemaName: string): Promise<void> {
+  const adminPool = new Pool({ connectionString })
+  try {
+    await adminPool.query(`CREATE SCHEMA IF NOT EXISTS "${schemaName}"`)
+  } finally {
+    await adminPool.end()
+  }
+}
+
+async function dropSchema(connectionString: string, schemaName: string): Promise<void> {
+  const adminPool = new Pool({ connectionString })
+  try {
+    await adminPool.query(`DROP SCHEMA IF EXISTS "${schemaName}" CASCADE`)
+  } finally {
+    await adminPool.end()
+  }
+}
+
+async function tableExistsInPublic(connectionString: string, tableName: string): Promise<boolean> {
+  const adminPool = new Pool({ connectionString })
+  try {
+    const result = await adminPool.query(`SELECT to_regclass($1) AS name`, [`public.${tableName}`])
+    return Boolean(result.rows[0]?.name)
+  } finally {
+    await adminPool.end()
+  }
+}
+
+function createTestDb(connectionString: string): Kysely<unknown> {
+  return new Kysely<unknown>({
+    dialect: new PostgresDialect({
+      pool: new Pool({ connectionString }),
+    }),
+  })
+}
+
+describeIfDatabase('Attendance C5 notification delivery outbox', () => {
+  let schemaName = ''
+  let isolatedDbUrl = ''
+  let testDb: Kysely<unknown> | undefined
+  let pool: Pool | undefined
+
+  beforeAll(async () => {
+    if (!dbUrl) throw new Error('DATABASE_URL is required for this integration test')
+    if (await tableExistsInPublic(dbUrl, 'attendance_notification_deliveries')) {
+      // CI runs the full migration stack before the attendance integration step. In that case, test
+      // the real public table so the dedicated gate proves the actual migration output.
+      pool = new Pool({ connectionString: dbUrl })
+      return
+    }
+
+    // Local dev databases are often stale or partially migrated. Fall back to an isolated schema and
+    // execute only the C5-0 migration so the DB-level invariants still get real Postgres coverage.
+    schemaName = createIsolatedSchemaName()
+    await createSchema(dbUrl, schemaName)
+    isolatedDbUrl = withSearchPath(dbUrl, schemaName)
+    testDb = createTestDb(isolatedDbUrl)
+    pool = new Pool({ connectionString: isolatedDbUrl })
+    await createAttendanceNotificationDeliveries(testDb)
+  })
+
+  afterAll(async () => {
+    if (testDb) await testDb.destroy()
+    if (pool) await pool.end()
+    if (schemaName && dbUrl) await dropSchema(dbUrl, schemaName)
+  })
+
+  it('C5-0 notification delivery outbox — source_key uniqueness + status invariants are DB-enforced (latent schema)', async () => {
+    if (!pool) throw new Error('C5 outbox test pool was not initialized')
+    const runSuffix = Date.now().toString(36)
+    const orgId = `c5-outbox-${runSuffix}`
+    const sourceId = randomUUID()
+    const subjectUserId = `c5-subject-${runSuffix}`
+    const ownerUserId = `c5-owner-${runSuffix}`
+    const sourceInstanceKey = `comp_time_expiry_reminder:${sourceId}:2026-06-15`
+    const subjectKey = `${sourceInstanceKey}:recipient:${subjectUserId}:channel:fake`
+    const ownerKey = `${sourceInstanceKey}:recipient:${ownerUserId}:channel:fake`
+    const rejects = async (text: string, params: unknown[], code: string, label: string) => {
+      let err: { code?: string } | null = null
+      try { await pool.query(text, params) } catch (e) { err = e as { code?: string } }
+      expect({ label, code: err?.code }).toEqual({ label, code })
+    }
+    try {
+      await requireTable(pool, 'attendance_notification_deliveries')
+
+      const insert = `INSERT INTO attendance_notification_deliveries
+        (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, status, payload)
+        VALUES ($1, 'comp_time_expiry_reminder', $2, $3, $4, $5, 'fake', $6, $7::jsonb)
+        RETURNING id`
+
+      const subject = await pool.query(insert, [orgId, sourceId, subjectKey, subjectUserId, 'subject', 'pending', JSON.stringify({ recipientRoles: ['subject'] })])
+      expect(subject.rows[0]?.id).toBeTruthy()
+
+      // One delivery row per recipient/channel: the same source instance may fan out to an owner with a
+      // distinct delivery source_key. This would collide if the key only used balance/window.
+      const owner = await pool.query(insert, [orgId, sourceId, ownerKey, ownerUserId, 'owner', 'pending', JSON.stringify({ recipientRoles: ['owner'] })])
+      expect(owner.rows[0]?.id).toBeTruthy()
+
+      // Idempotency backstop: exact same (org_id, source_key) cannot create another row.
+      await rejects(insert, [orgId, sourceId, subjectKey, subjectUserId, 'subject', 'pending', '{}'], '23505', 'source_key unique')
+
+      await rejects(insert, [orgId, `${sourceId}-status`, `${subjectKey}:bad-status`, `${subjectUserId}-s`, 'subject', 'bogus', '{}'], '23514', 'status enum')
+      await rejects(
+        `INSERT INTO attendance_notification_deliveries
+           (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, attempt_count)
+         VALUES ($1, 'unscheduled_reminder', $2, $3, $4, 'subject', 'fake', -1)`,
+        [orgId, `${sourceId}-attempts`, `${subjectKey}:attempts`, `${subjectUserId}-a`],
+        '23514',
+        'attempt_count non-negative',
+      )
+      await rejects(
+        `INSERT INTO attendance_notification_deliveries
+           (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, status, delivered_at)
+         VALUES ($1, 'unscheduled_reminder', $2, $3, $4, 'subject', 'fake', 'pending', now())`,
+        [orgId, `${sourceId}-delivered`, `${subjectKey}:delivered`, `${subjectUserId}-d`],
+        '23514',
+        'delivered_at only when sent',
+      )
+
+      const sent = await pool.query(
+        `INSERT INTO attendance_notification_deliveries
+           (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, status, delivered_at)
+         VALUES ($1, 'unscheduled_reminder', $2, $3, $4, 'subject', 'fake', 'sent', now())
+         RETURNING id`,
+        [orgId, `${sourceId}-sent`, `${subjectKey}:sent`, `${subjectUserId}-sent`],
+      )
+      expect(sent.rows[0]?.id).toBeTruthy()
+
+      const sending = await pool.query(
+        `INSERT INTO attendance_notification_deliveries
+           (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, status, claimed_at, claim_expires_at, claim_worker_id)
+         VALUES ($1, 'unscheduled_reminder', $2, $3, $4, 'subject', 'fake', 'sending', now(), now() - interval '1 minute', 'worker-a')
+         RETURNING id, claim_expires_at`,
+        [orgId, `${sourceId}-sending`, `${subjectKey}:sending`, `${subjectUserId}-sending`],
+      )
+      expect(sending.rows[0]?.id).toBeTruthy()
+      expect(sending.rows[0]?.claim_expires_at).toBeTruthy()
+
+      const indexes = await pool.query<{ indexname: string }>(
+        `SELECT indexname
+           FROM pg_indexes
+          WHERE schemaname = current_schema()
+            AND tablename = 'attendance_notification_deliveries'
+            AND indexname = ANY($1::text[])`,
+        [[
+          'uq_attendance_notification_deliveries_source_key',
+          'idx_attendance_notification_deliveries_claim',
+          'idx_attendance_notification_deliveries_reclaim',
+          'idx_attendance_notification_deliveries_source',
+        ]],
+      )
+      expect(new Set(indexes.rows.map(row => row.indexname))).toEqual(new Set([
+        'uq_attendance_notification_deliveries_source_key',
+        'idx_attendance_notification_deliveries_claim',
+        'idx_attendance_notification_deliveries_reclaim',
+        'idx_attendance_notification_deliveries_source',
+      ]))
+    } finally {
+      await pool.query('DELETE FROM attendance_notification_deliveries WHERE org_id = $1', [orgId]).catch(() => undefined)
+    }
+  })
+})

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -22,6 +22,7 @@ export default defineConfig({
       'tests/integration/after-sales-registry-backfill.test.ts',
       'tests/integration/approval-pack1a-lifecycle.api.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
+      'tests/integration/attendance-notification-deliveries.test.ts',
       'tests/integration/attendance-outdoor-punch.test.ts',
       'tests/integration/attendance-plugin.test.ts',
       'tests/integration/attendance-unscheduled-reminder.test.ts',

--- a/scripts/ops/attendance-regression-local.sh
+++ b/scripts/ops/attendance-regression-local.sh
@@ -53,7 +53,7 @@ fi
 
 run_check \
   "backend-attendance-integration" \
-  "cd packages/core-backend && pnpm exec vitest --config ${backend_vitest_config} run tests/integration/attendance-plugin.test.ts"
+  "cd packages/core-backend && pnpm exec vitest --config ${backend_vitest_config} run tests/integration/attendance-plugin.test.ts tests/integration/attendance-expiry-service.test.ts tests/integration/attendance-unscheduled-reminder.test.ts tests/integration/attendance-outdoor-punch.test.ts tests/integration/attendance-notification-deliveries.test.ts"
 
 run_check \
   "web-unit-tests" \


### PR DESCRIPTION
## Summary
- Adds the latent C5 `attendance_notification_deliveries` outbox table.
- Locks DB-level invariants for delivery state: status enum, non-negative attempts, delivered_at only when sent, source_key idempotency, and claim/reclaim indexes.
- Adds a focused real-DB integration spec for the outbox migration and wires it into the attendance integration gate/script while excluding it from default non-DB Vitest.

## Scope
C5-0 only. No producers, no delivery worker, no notifier/channel wiring, no external sends. The table is inert until later C5 slices opt in.

## Verification
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false`
- `DATABASE_URL=postgresql://metasheet:metasheet123@localhost:5432/metasheet_v2 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-notification-deliveries.test.ts --reporter=dot`
- `git diff --check origin/main...HEAD`

## Notes
The integration spec tests the real public table when the full migration stack has run (CI), and falls back to an isolated schema running only the C5-0 migration for stale local dev databases.