### PR TITLE
feat(multitable): require single-value link for hierarchy parent field (S4)

### DIFF
--- a/apps/web/src/multitable/components/MetaHierarchyView.vue
+++ b/apps/web/src/multitable/components/MetaHierarchyView.vue
@@ -5,6 +5,7 @@
         <span>{{ managerLabel('view.parentField', isZh) }}</span>
         <select :value="hierarchyDraft.parentFieldId ?? ''" @change="onPickParentField">
           <option value="">{{ viewRenderLabel('hierarchy.autoLinkField', isZh) }}</option>
+          <option v-if="legacyParentFieldOption" :value="legacyParentFieldOption.id" disabled>{{ legacyParentFieldOption.name }}</option>
           <option v-for="field in linkFields" :key="field.id" :value="field.id">{{ field.name }}</option>
         </select>
       </label>
@@ -88,7 +89,7 @@
 import { computed, defineComponent, h, reactive, ref, watch, type PropType, type VNode } from 'vue'
 import type { MetaField, MetaHierarchyViewConfig, MetaRecord, MultitableCommentPresenceSummary } from '../types'
 import { formatFieldDisplay } from '../utils/field-display'
-import { resolveHierarchyViewConfig } from '../utils/view-config'
+import { isSingleValueLinkField, resolveHierarchyViewConfig } from '../utils/view-config'
 import { useLocale } from '../../composables/useLocale'
 import MetaCommentActionChip from './MetaCommentActionChip.vue'
 import {
@@ -162,10 +163,21 @@ watch(
   { immediate: true },
 )
 
-const linkFields = computed(() => props.fields.filter((field) => field.type === 'link'))
+// S4 — only single-value links may be picked as parent: reparent writes `[parentRecordId]`
+// over this field, so a multi-value link would be silently overwritten on every drag.
+// Existing configs pointing at a multi-value link keep rendering (parentField below stays
+// type-only) but cannot be re-selected, and the backend rejects saving them.
+const linkFields = computed(() => props.fields.filter((field) => isSingleValueLinkField(field)))
 const parentField = computed(() =>
   hierarchyDraft.parentFieldId
     ? props.fields.find((field) => field.id === hierarchyDraft.parentFieldId && field.type === 'link') ?? null
+    : null,
+)
+// A legacy config may point at a link field that is no longer offered (multi-value): render it
+// as a disabled option so the select reflects the field the tree still uses instead of blank.
+const legacyParentFieldOption = computed(() =>
+  parentField.value && !linkFields.value.some((field) => field.id === parentField.value?.id)
+    ? parentField.value
     : null,
 )
 const titleField = computed(() =>

--- a/apps/web/src/multitable/components/MetaViewManager.vue
+++ b/apps/web/src/multitable/components/MetaViewManager.vue
@@ -53,6 +53,9 @@
           <span>{{ viewConfigWarningText }}</span>
           <button class="meta-view-mgr__btn-inline" @click="reloadLatestConfig">{{ ml('action.reloadLatest') }}</button>
         </div>
+        <div v-else-if="viewConfigBlockingReason" class="meta-view-mgr__warning">
+          <span>{{ viewConfigBlockingReason }}</span>
+        </div>
         <div v-else-if="viewConfigLiveRefreshText" class="meta-view-mgr__refresh">
           <span>{{ viewConfigLiveRefreshText }}</span>
           <button class="meta-view-mgr__btn-inline" @click="dismissLiveRefreshNotice">{{ ml('action.dismiss') }}</button>
@@ -454,6 +457,7 @@ import {
 } from '../composables/useMultitableGrid'
 import {
   isSelfTableLinkField,
+  isSingleValueLinkField,
   resolveCalendarViewConfig,
   resolveGanttViewConfig,
   resolveGalleryViewConfig,
@@ -591,7 +595,10 @@ const dateFields = computed(() => props.fields.filter((field) => field.type === 
 const dateLikeFields = computed(() => props.fields.filter((field) => field.type === 'date' || field.type === 'dateTime' || field.type === 'string' || field.type === 'number'))
 const numericFields = computed(() => props.fields.filter((field) => ['number', 'currency', 'percent', 'rating'].includes(field.type)))
 const selectFields = computed(() => props.fields.filter((field) => field.type === 'select'))
-const linkFields = computed(() => props.fields.filter((field) => field.type === 'link'))
+// S4 — hierarchy parent candidates only: reparent writes `[parentRecordId]` over this field,
+// so multi-value links are excluded here (and from validLinkFieldIds below, which makes a
+// legacy multi-value parent surface `view.error.parentInvalid` instead of silently nulling).
+const linkFields = computed(() => props.fields.filter((field) => isSingleValueLinkField(field)))
 const dependencyFields = computed(() => props.fields.filter((field) => isSelfTableLinkField(field, props.sheetId)))
 const stringFields = computed(() => props.fields.filter((field) => ['string', 'formula', 'lookup'].includes(field.type)))
 const groupableFields = computed(() => props.fields.filter((field) => ['select', 'string', 'boolean', 'number', 'date', 'dateTime'].includes(field.type)))
@@ -607,7 +614,14 @@ const validGroupableFieldIds = computed(() => new Set(groupableFields.value.map(
 
 const viewConfigBlockingReason = computed(() => {
   const target = configTarget.value
-  if (!target || !viewConfigOutdated.value) return ''
+  if (!target) return ''
+  // S4 — checked even when the draft is not outdated: a LEGACY hierarchy config may point at a
+  // multi-value link (hydrated as-is by resolveHierarchyViewConfig, which stays type-only), and
+  // without this block the saveConfig sanitization would silently null the parent field.
+  if (target.type === 'hierarchy' && hierarchyDraft.parentFieldId && !validLinkFieldIds.value.has(hierarchyDraft.parentFieldId)) {
+    return ml('view.error.parentInvalid')
+  }
+  if (!viewConfigOutdated.value) return ''
 
   if (target.type === 'gallery') {
     if (galleryDraft.titleFieldId && !validStringFieldIds.value.has(galleryDraft.titleFieldId)) {
@@ -676,9 +690,7 @@ const viewConfigBlockingReason = computed(() => {
   }
 
   if (target.type === 'hierarchy') {
-    if (hierarchyDraft.parentFieldId && !validLinkFieldIds.value.has(hierarchyDraft.parentFieldId)) {
-      return ml('view.error.parentInvalid')
-    }
+    // parentFieldId is covered by the unconditional S4 check above.
     if (hierarchyDraft.titleFieldId && !validFieldIds.value.has(hierarchyDraft.titleFieldId)) {
       return ml('view.error.titleMissing')
     }

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -279,7 +279,7 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'view.error.ganttGroupInvalid': { en: 'The selected Gantt group field is no longer groupable. Reload latest before saving.', zh: '已选择的甘特分组字段不再可分组。保存前请重新加载最新设置。' },
   'view.error.dependencyInvalid': { en: 'The selected dependency field is no longer supported. Reload latest before saving.', zh: '已选择的依赖字段不再受支持。保存前请重新加载最新设置。' },
   'view.error.kanbanGroupInvalid': { en: 'The selected group field is no longer a select field. Reload latest before saving.', zh: '已选择的分组字段不再是单选字段。保存前请重新加载最新设置。' },
-  'view.error.parentInvalid': { en: 'The selected parent field is no longer a link field. Reload latest before saving.', zh: '已选择的父级字段不再是关联字段。保存前请重新加载最新设置。' },
+  'view.error.parentInvalid': { en: 'The selected parent field is not a single-value link field. Pick a single-value link field or Auto before saving.', zh: '已选择的父级字段不是单值关联字段。保存前请改选单值关联字段或自动。' },
   'view.error.filterMissing': { en: 'One or more selected filter fields disappeared in the background. Reload latest before saving.', zh: '一个或多个已选择的筛选字段已在后台消失。保存前请重新加载最新设置。' },
   'view.error.sortMissing': { en: 'One or more selected sort fields disappeared in the background. Reload latest before saving.', zh: '一个或多个已选择的排序字段已在后台消失。保存前请重新加载最新设置。' },
   'view.error.groupInvalid': { en: 'The selected group field is no longer groupable. Reload latest before saving.', zh: '已选择的分组字段不再可分组。保存前请重新加载最新设置。' },

--- a/apps/web/src/multitable/utils/view-config.ts
+++ b/apps/web/src/multitable/utils/view-config.ts
@@ -41,6 +41,14 @@ function firstNonMatchingFieldId(fields: MetaField[], excludedIds: Array<string 
   return firstFieldId(candidates, types)
 }
 
+// S4 — hierarchy reparent writes `[parentRecordId]` over the configured parent link field via
+// a generic record patch, so only single-value links are safe parent candidates; a multi-value
+// link would be silently overwritten on every drag-to-reparent. Shared by MetaHierarchyView
+// (toolbar picker) and MetaViewManager (view-config dialog picker + client validation).
+export function isSingleValueLinkField(field: MetaField): boolean {
+  return field.type === 'link' && field.property?.limitSingleRecord === true
+}
+
 export function isSelfTableLinkField(field: MetaField, sheetId?: string | null): boolean {
   if (field.type !== 'link') return false
   const currentSheetId = typeof sheetId === 'string' ? sheetId.trim() : ''

--- a/apps/web/tests/multitable-hierarchy-view.spec.ts
+++ b/apps/web/tests/multitable-hierarchy-view.spec.ts
@@ -11,6 +11,7 @@ const fields: MetaField[] = [
 
 function mountHierarchy(props: {
   rows: MetaRecord[]
+  fields?: MetaField[]
   viewConfig?: Record<string, unknown>
   canCreate?: boolean
   canEdit?: boolean
@@ -124,6 +125,49 @@ describe('MetaHierarchyView', () => {
         orphanMode: 'hidden',
       },
     })
+
+    unmount()
+  })
+
+  it('lists only single-value link fields as parent-field candidates (S4 multi-value silent-overwrite guard)', async () => {
+    const { container, unmount } = mountHierarchy({
+      rows: [],
+      fields: [
+        { id: 'fld_title', name: 'Title', type: 'string' },
+        { id: 'fld_parent_multi', name: 'Parent Multi', type: 'link', property: { limitSingleRecord: false } },
+        { id: 'fld_parent_single', name: 'Parent Single', type: 'link', property: { limitSingleRecord: true } },
+      ],
+      viewConfig: { parentFieldId: 'fld_parent_single', titleFieldId: 'fld_title' },
+    })
+    await nextTick()
+
+    const parentSelect = container.querySelector('.meta-hierarchy__control select') as HTMLSelectElement
+    const optionValues = Array.from(parentSelect.options).map((option) => option.value)
+    expect(optionValues).toContain('fld_parent_single')
+    expect(optionValues).not.toContain('fld_parent_multi')
+
+    unmount()
+  })
+
+  it('renders a legacy multi-value parent as a disabled option instead of a blank select (S4 F4)', async () => {
+    const { container, unmount } = mountHierarchy({
+      rows: [],
+      fields: [
+        { id: 'fld_title', name: 'Title', type: 'string' },
+        { id: 'fld_parent_multi', name: 'Parent Multi', type: 'link', property: { limitSingleRecord: false } },
+        { id: 'fld_parent_single', name: 'Parent Single', type: 'link', property: { limitSingleRecord: true } },
+      ],
+      viewConfig: { parentFieldId: 'fld_parent_multi', titleFieldId: 'fld_title' },
+    })
+    await nextTick()
+
+    const parentSelect = container.querySelector('.meta-hierarchy__control select') as HTMLSelectElement
+    // The legacy field stays visible (the tree still uses it) but cannot be re-selected.
+    expect(parentSelect.value).toBe('fld_parent_multi')
+    const legacyOption = Array.from(parentSelect.options).find((option) => option.value === 'fld_parent_multi')
+    expect(legacyOption?.disabled).toBe(true)
+    const singleOption = Array.from(parentSelect.options).find((option) => option.value === 'fld_parent_single')
+    expect(singleOption?.disabled).toBe(false)
 
     unmount()
   })

--- a/apps/web/tests/multitable-view-manager.spec.ts
+++ b/apps/web/tests/multitable-view-manager.spec.ts
@@ -152,8 +152,8 @@ describe('MetaViewManager', () => {
           activeViewId: 'view_hierarchy',
           fields: [
             { id: 'fld_name', name: 'Name', type: 'string' },
-            { id: 'fld_parent', name: 'Parent', type: 'link' },
-            { id: 'fld_alt_parent', name: 'Alt Parent', type: 'link' },
+            { id: 'fld_parent', name: 'Parent', type: 'link', property: { limitSingleRecord: true } },
+            { id: 'fld_alt_parent', name: 'Alt Parent', type: 'link', property: { limitSingleRecord: true } },
           ],
           views: [
             {
@@ -196,6 +196,118 @@ describe('MetaViewManager', () => {
         titleFieldId: 'fld_name',
         defaultExpandDepth: 3,
         orphanMode: 'hidden',
+      },
+    })
+
+    app.unmount()
+  })
+
+  it('excludes multi-value link fields from the hierarchy parent picker (S4 silent-overwrite guard)', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+
+    const app = createApp({
+      render() {
+        return h(MetaViewManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          activeViewId: 'view_hierarchy',
+          fields: [
+            { id: 'fld_name', name: 'Name', type: 'string' },
+            { id: 'fld_parent_multi', name: 'Parent Multi', type: 'link', property: { limitSingleRecord: false } },
+            { id: 'fld_parent_single', name: 'Parent Single', type: 'link', property: { limitSingleRecord: true } },
+          ],
+          views: [
+            {
+              id: 'view_hierarchy',
+              sheetId: 'sheet_1',
+              name: 'Hierarchy',
+              type: 'hierarchy',
+              config: { parentFieldId: 'fld_parent_single', titleFieldId: 'fld_name' },
+            },
+          ],
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    ;(container.querySelector('.meta-view-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await nextTick()
+
+    const selects = Array.from(container.querySelectorAll('.meta-view-mgr__config select')) as HTMLSelectElement[]
+    const parentOptionValues = Array.from(selects[0].options).map((option) => option.value)
+    expect(parentOptionValues).toContain('fld_parent_single')
+    expect(parentOptionValues).not.toContain('fld_parent_multi')
+
+    app.unmount()
+  })
+
+  it('blocks saving a legacy hierarchy config with a multi-value parent instead of silently nulling it (S4)', async () => {
+    const container = document.createElement('div')
+    document.body.appendChild(container)
+    const updateSpy = vi.fn()
+
+    const app = createApp({
+      render() {
+        return h(MetaViewManager, {
+          visible: true,
+          sheetId: 'sheet_1',
+          activeViewId: 'view_hierarchy',
+          fields: [
+            { id: 'fld_name', name: 'Name', type: 'string' },
+            { id: 'fld_parent_multi', name: 'Parent Multi', type: 'link', property: { limitSingleRecord: false } },
+            { id: 'fld_parent_single', name: 'Parent Single', type: 'link', property: { limitSingleRecord: true } },
+          ],
+          views: [
+            {
+              id: 'view_hierarchy',
+              sheetId: 'sheet_1',
+              name: 'Hierarchy',
+              type: 'hierarchy',
+              // Legacy config saved before the S4 guard: parent points at a multi-value link.
+              config: { parentFieldId: 'fld_parent_multi', titleFieldId: 'fld_name' },
+            },
+          ],
+          onUpdateView: updateSpy,
+        })
+      },
+    })
+
+    app.mount(container)
+    await nextTick()
+
+    ;(container.querySelector('.meta-view-mgr__action[title="Configure"]') as HTMLButtonElement | null)?.click()
+    await nextTick()
+
+    // The parentInvalid validation surfaces and save is blocked — no silent null at save time.
+    const warning = container.querySelector('.meta-view-mgr__warning')
+    expect(warning?.textContent).toContain('The selected parent field is not a single-value link field')
+    const saveButton = (Array.from(container.querySelectorAll('.meta-view-mgr__btn-add')) as HTMLButtonElement[])
+      .find((button) => button.textContent?.includes('Save view settings')) as HTMLButtonElement
+    expect(saveButton.disabled).toBe(true)
+    saveButton.click()
+    await nextTick()
+    expect(updateSpy).not.toHaveBeenCalled()
+
+    // Unbrick path: picking a single-value link clears the block and saves that field.
+    const selects = Array.from(container.querySelectorAll('.meta-view-mgr__config select')) as HTMLSelectElement[]
+    selects[0].value = 'fld_parent_single'
+    selects[0].dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    expect(container.querySelector('.meta-view-mgr__warning')).toBeNull()
+    expect(saveButton.disabled).toBe(false)
+    saveButton.click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledWith('view_hierarchy', {
+      config: {
+        parentFieldId: 'fld_parent_single',
+        titleFieldId: 'fld_name',
+        defaultExpandDepth: 2,
+        orphanMode: 'root',
       },
     })
 

--- a/packages/core-backend/src/routes/univer-meta.ts
+++ b/packages/core-backend/src/routes/univer-meta.ts
@@ -3440,6 +3440,42 @@ async function validateGanttDependencyConfig(
   return null
 }
 
+// S4 — the hierarchy view reparents by writing `[parentRecordId]` over the configured parent
+// link field via a generic record patch (no dedicated reparent endpoint), so a MULTI-value
+// link used as parent gets silently overwritten on every drag-to-reparent. Reject saving a
+// hierarchy view whose explicit parentFieldId is not a single-value (`limitSingleRecord`)
+// link field. An absent parentFieldId is allowed (runtime auto/first-link fallback unchanged).
+// Documented residuals (accepted): (a) PATCH /fields/:fieldId can later flip limitSingleRecord
+// or the field type without view re-validation — same pre-existing class as gantt's dependency
+// field, follow-up candidate; (b) provisioning ensureView/createView bypass route-layer view
+// validation by design (template library ships no hierarchy views today).
+async function validateHierarchyParentLinkConfig(
+  query: QueryFn,
+  sheetId: string,
+  viewType: string,
+  config: Record<string, unknown>,
+): Promise<string | null> {
+  if (viewType !== 'hierarchy') return null
+  const parentFieldId = typeof config.parentFieldId === 'string' ? config.parentFieldId.trim() : ''
+  if (!parentFieldId) return null
+
+  const fieldRes = await query(
+    'SELECT id, name, type, property, "order" FROM meta_fields WHERE sheet_id = $1 AND id = $2',
+    [sheetId, parentFieldId],
+  )
+  const fieldRow = (fieldRes.rows as any[])[0]
+  if (!fieldRow) {
+    return `Hierarchy parent field must be a single-value link field: ${parentFieldId}`
+  }
+
+  const field = serializeFieldRow(fieldRow)
+  if (field.type !== 'link' || (field.property ?? {}).limitSingleRecord !== true) {
+    return `Hierarchy parent field must be a single-value link field: ${parentFieldId}`
+  }
+
+  return null
+}
+
 class PermissionError extends Error {
   constructor(public message: string) {
     super(message)
@@ -5397,6 +5433,10 @@ export function univerMetaRouter(): Router {
       if (ganttConfigError) {
         return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: ganttConfigError } })
       }
+      const hierarchyConfigError = await validateHierarchyParentLinkConfig(pool.query.bind(pool), sheetId, type, incomingConfig)
+      if (hierarchyConfigError) {
+        return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: hierarchyConfigError } })
+      }
 
       await pool.query(
         `INSERT INTO meta_views (id, sheet_id, name, type, filter_info, sort_info, group_info, hidden_field_ids, config)
@@ -5512,6 +5552,15 @@ export function univerMetaRouter(): Router {
         )
         if (ganttConfigError) {
           return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: ganttConfigError } })
+        }
+        const hierarchyConfigError = await validateHierarchyParentLinkConfig(
+          pool.query.bind(pool),
+          String(row.sheet_id),
+          nextType,
+          nextConfig as Record<string, unknown>,
+        )
+        if (hierarchyConfigError) {
+          return res.status(400).json({ ok: false, error: { code: 'VALIDATION_ERROR', message: hierarchyConfigError } })
         }
       }
 

--- a/packages/core-backend/tests/unit/multitable-hierarchy-parent-link-guard.test.ts
+++ b/packages/core-backend/tests/unit/multitable-hierarchy-parent-link-guard.test.ts
@@ -1,0 +1,240 @@
+/**
+ * S4 — hierarchy parent link single-value guard (route-level).
+ *
+ * The hierarchy view reparents records by writing `[parentRecordId]` over the
+ * configured parent link field (a generic record patch — there is no dedicated
+ * reparent endpoint). If that field is a MULTI-value link (`limitSingleRecord`
+ * absent/false), every drag-to-reparent silently overwrites the other linked
+ * records. The view-config save path is the one place that knows a link field
+ * is being used AS a hierarchy parent, so POST /views and PATCH /views/:viewId
+ * must reject a hierarchy `config.parentFieldId` that does not resolve to a
+ * single-value (`limitSingleRecord: true`) link field.
+ *
+ * These tests bind the REAL router (mock pool — see the wire-vs-fixture rule
+ * and tests/unit/multitable-formula-reference-guard.test.ts precedent):
+ *
+ *   1. PATCH rejects a multi-value link parent (400, no UPDATE).
+ *   2. PATCH accepts a single-value link parent (200, UPDATE persisted).
+ *   3. POST rejects a non-link parent field (400, no INSERT).
+ *   4. POST rejects a nonexistent parent field (400, no INSERT).
+ *
+ * Discriminating cases prove we did NOT over-reject:
+ *   - POST hierarchy WITHOUT parentFieldId stays allowed (auto/first-link mode).
+ *   - POST a non-hierarchy view whose config carries a stray `parentFieldId`
+ *     pointing at a multi-value link stays allowed (guard is hierarchy-scoped).
+ */
+import { describe, expect, it, vi, afterEach } from 'vitest'
+import express from 'express'
+import request from 'supertest'
+
+const SHEET_ID = 'sheet_hier'
+const VIEW_ID = 'view_hier'
+
+type StoredField = {
+  id: string
+  name: string
+  type: string
+  property: Record<string, unknown>
+  order: number
+}
+type QueryResult = { rows: any[]; rowCount?: number }
+
+function createStore(fields: StoredField[]) {
+  const fieldById = new Map(fields.map((f) => [f.id, f]))
+  const inserts: unknown[][] = []
+  const updates: unknown[][] = []
+
+  const handler = (sql: string, params?: unknown[]): QueryResult => {
+    if (sql.includes('FROM meta_sheets WHERE id = $1')) {
+      return { rows: [{ id: SHEET_ID }] }
+    }
+    if (sql.includes('FROM meta_views WHERE id = $1')) {
+      return {
+        rows: [{
+          id: VIEW_ID,
+          sheet_id: SHEET_ID,
+          name: 'Hierarchy',
+          type: 'hierarchy',
+          filter_info: {},
+          sort_info: {},
+          group_info: {},
+          hidden_field_ids: [],
+          config: {},
+        }],
+      }
+    }
+    // S4 guard — single-field lookup for the configured parent field.
+    if (sql.includes('FROM meta_fields WHERE sheet_id = $1 AND id = $2')) {
+      const f = fieldById.get(params?.[1] as string)
+      return { rows: f ? [{ ...f }] : [] }
+    }
+    // loadAllowedFieldIds → loadFieldsForSheet (response redaction path).
+    if (sql.includes('FROM meta_fields WHERE sheet_id = $1 ORDER BY')) {
+      return { rows: fields.map((f) => ({ ...f })) }
+    }
+    if (sql.includes('INSERT INTO meta_views')) {
+      inserts.push(params ?? [])
+      return { rows: [], rowCount: 1 }
+    }
+    if (sql.includes('UPDATE meta_views')) {
+      updates.push(params ?? [])
+      return { rows: [], rowCount: 1 }
+    }
+    return { rows: [], rowCount: 0 }
+  }
+
+  return { inserts, updates, handler }
+}
+
+function createMockPool(handler: (sql: string, params?: unknown[]) => QueryResult) {
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    if (
+      sql.includes('FROM spreadsheet_permissions')
+      || sql.includes('FROM field_permissions')
+      || sql.includes('FROM view_permissions')
+      || sql.includes('FROM meta_view_permissions')
+      || sql.includes('FROM record_permissions')
+    ) {
+      return { rows: [], rowCount: 0 }
+    }
+    return handler(sql, params)
+  })
+  const transaction = vi.fn(async (fn: (client: { query: typeof query }) => Promise<unknown>) => fn({ query }))
+  return { query, transaction }
+}
+
+async function createApp(handler: (sql: string, params?: unknown[]) => QueryResult) {
+  vi.resetModules()
+  vi.doMock('../../src/rbac/service', () => ({
+    isAdmin: vi.fn().mockResolvedValue(false),
+    userHasPermission: vi.fn().mockResolvedValue(false),
+    listUserPermissions: vi.fn().mockResolvedValue(['multitable:write']),
+    invalidateUserPerms: vi.fn(),
+    getPermCacheStatus: vi.fn(),
+  }))
+
+  const { poolManager } = await import('../../src/integration/db/connection-pool')
+  const { univerMetaRouter } = await import('../../src/routes/univer-meta')
+  const mockPool = createMockPool(handler)
+  vi.spyOn(poolManager, 'get').mockReturnValue(mockPool as any)
+
+  const app = express()
+  app.use(express.json())
+  app.use((req, _res, next) => {
+    req.user = { id: 'user_hier', roles: [], perms: ['multitable:read', 'multitable:write'] }
+    next()
+  })
+  app.use('/api/multitable', univerMetaRouter())
+  return app
+}
+
+function field(over: Partial<StoredField> & { id: string; type: string }): StoredField {
+  return { name: over.id, property: {}, order: 0, ...over }
+}
+
+const MULTI_LINK = field({
+  id: 'fld_parent_multi',
+  type: 'link',
+  property: { foreignSheetId: SHEET_ID, limitSingleRecord: false },
+})
+const SINGLE_LINK = field({
+  id: 'fld_parent_single',
+  type: 'link',
+  property: { foreignSheetId: SHEET_ID, limitSingleRecord: true },
+})
+const TEXT_FIELD = field({ id: 'fld_notes', type: 'string' })
+
+describe('S4 — hierarchy parent link single-value guard', () => {
+  afterEach(() => {
+    vi.restoreAllMocks()
+    vi.resetModules()
+  })
+
+  it('PATCH rejects a hierarchy parentFieldId that resolves to a multi-value link field', async () => {
+    const { updates, handler } = createStore([MULTI_LINK, SINGLE_LINK])
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .patch(`/api/multitable/views/${VIEW_ID}`)
+      .send({ config: { parentFieldId: 'fld_parent_multi', orphanMode: 'root' } })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toBe(
+      'Hierarchy parent field must be a single-value link field: fld_parent_multi',
+    )
+    expect(updates).toHaveLength(0)
+  })
+
+  it('PATCH accepts a hierarchy parentFieldId that resolves to a single-value link field', async () => {
+    const { updates, handler } = createStore([MULTI_LINK, SINGLE_LINK])
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .patch(`/api/multitable/views/${VIEW_ID}`)
+      .send({ config: { parentFieldId: 'fld_parent_single', orphanMode: 'root' } })
+
+    expect(res.status).toBe(200)
+    expect(res.body.ok).toBe(true)
+    expect(updates).toHaveLength(1)
+    expect(updates[0]?.[7]).toBe(JSON.stringify({ parentFieldId: 'fld_parent_single', orphanMode: 'root' }))
+  })
+
+  it('POST rejects a hierarchy parentFieldId that resolves to a non-link field', async () => {
+    const { inserts, handler } = createStore([TEXT_FIELD])
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .post('/api/multitable/views')
+      .send({ sheetId: SHEET_ID, name: 'Tree', type: 'hierarchy', config: { parentFieldId: 'fld_notes' } })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toBe(
+      'Hierarchy parent field must be a single-value link field: fld_notes',
+    )
+    expect(inserts).toHaveLength(0)
+  })
+
+  it('POST rejects a hierarchy parentFieldId that resolves to no field at all', async () => {
+    const { inserts, handler } = createStore([SINGLE_LINK])
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .post('/api/multitable/views')
+      .send({ sheetId: SHEET_ID, name: 'Tree', type: 'hierarchy', config: { parentFieldId: 'fld_ghost' } })
+
+    expect(res.status).toBe(400)
+    expect(res.body.error.code).toBe('VALIDATION_ERROR')
+    expect(res.body.error.message).toBe(
+      'Hierarchy parent field must be a single-value link field: fld_ghost',
+    )
+    expect(inserts).toHaveLength(0)
+  })
+
+  it('POST ALLOWS a hierarchy view without an explicit parentFieldId (auto mode preserved)', async () => {
+    const { inserts, handler } = createStore([MULTI_LINK])
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .post('/api/multitable/views')
+      .send({ sheetId: SHEET_ID, name: 'Tree', type: 'hierarchy', config: { orphanMode: 'hidden' } })
+
+    expect(res.status).toBe(201)
+    expect(res.body.ok).toBe(true)
+    expect(inserts).toHaveLength(1)
+  })
+
+  it('POST ALLOWS a non-hierarchy view whose config carries a stray parentFieldId (guard is hierarchy-scoped)', async () => {
+    const { inserts, handler } = createStore([MULTI_LINK])
+    const app = await createApp(handler)
+
+    const res = await request(app)
+      .post('/api/multitable/views')
+      .send({ sheetId: SHEET_ID, name: 'Grid', type: 'grid', config: { parentFieldId: 'fld_parent_multi' } })
+
+    expect(res.status).toBe(201)
+    expect(res.body.ok).toBe(true)
+    expect(inserts).toHaveLength(1)
+  })
+})


### PR DESCRIPTION
## Summary

Implements **S4** of the AI-field staged arc side line (`multitable-ai-field-staged-arc-todo-20260610.md`): the hierarchy view's parent link field is now pinned to **single-value** link fields, eliminating the multi-value-link silent-overwrite risk on reparent (three-lane discussion C1 residual, premise re-verified on current main before coding).

- **Backend**: `validateHierarchyParentLinkConfig` on POST/PATCH `/views` (mirrors the gantt dependency validator exactly): parent must be an existing link field with `property.limitSingleRecord === true` (the repo's REAL single-value concept — the slice title's "maxValues=1" has no codebase counterpart). Absent `parentFieldId` stays allowed (auto/first-link mode preserved).
- **Frontend (both pickers)**: shared `isSingleValueLinkField()` util; `MetaHierarchyView` toolbar picker + `MetaViewManager` config-dialog picker both narrowed; legacy multi-value parent renders as a disabled option (not blank) in the toolbar; in the config dialog it now surfaces `parentInvalid` validation **before** save — fixing a discovered gating bug where the check sat behind `viewConfigOutdated` and the save-time sanitization would silently null the parent.
- **Documented residuals** (validator comment): field-PATCH `limitSingleRecord` flip without view re-validation (same pre-existing class as gantt) and provisioning-layer bypass (no hierarchy templates today) — follow-up candidates.

## Tests (fail-first, both rounds)

- Round 1: backend guard suite — 3 reject cases red pre-impl (`expected 201 to be 400`), 6/6 green post; FE dropdown spec red pre-impl.
- Review-fix round: 3 new specs verified red against pre-fix src (dialog exclusion, legacy-parent block/unbrick, disabled legacy option).
- Backend `test:unit` 230 files / 2913 green; FE related specs 42/42; `tsc` + `vue-tsc -b` + eslint clean. (Two unrelated FE workbench spec failures reproduce identically at the branch base — pre-existing.)

## Review

Adversarial review (`/tmp/s4-review-claude-20260610.md`): REQUEST-CHANGES → all findings fixed (F1 second picker per the reviewer's prescription — reviewer noted "with it this becomes APPROVE"; F2/F3 documented; F4 disabled-option).

Also surfaced for follow-up: `tests/integration/multitable-view-config.api.test.ts` is red on current main (4/7, mock pool missing the #2052/#2068 loadAllowedFieldIds query; CI doesn't run it) — separate small fix PR recommended.

🤖 Generated with [Claude Code](https://claude.com/claude-code)