### PR TITLE
feat(multitable): A3 AI shortcut frontend — config section, drawer/cell triggers, usage visibility (M3)

### DIFF
--- a/apps/web/src/multitable/api/client.ts
+++ b/apps/web/src/multitable/api/client.ts
@@ -818,6 +818,59 @@ export interface DryRunResult {
   diagnostics: DryRunDiagnostic[]
 }
 
+// AI field shortcut (A3, design multitable-ai-shortcut-frontend-a3-design-20260611).
+// These types mirror the PINNED A2 wire contract 1:1
+// (packages/core-backend/src/routes/multitable-ai.ts; the run key set is
+// asserted route-level in the backend integration suite). Do not reshape here —
+// the useAiShortcut adapter owns the PatchResult synthesis.
+export type AiShortcutKind = 'summarize' | 'classify' | 'extract' | 'translate'
+
+export interface AiShortcutConfigInput {
+  kind: AiShortcutKind
+  sourceFieldIds: string[]
+  params?: { options?: string[]; targetLang?: string; instruction?: string }
+}
+
+export interface AiShortcutUsage {
+  promptTokens: number
+  completionTokens: number
+}
+
+export interface AiShortcutPreviewData {
+  status: 'succeeded'
+  action: 'preview'
+  output: string
+  usage: AiShortcutUsage | null
+  estimatedCostUsd: number
+  provider: string | null
+  model: string | null
+}
+
+export interface AiShortcutRunData {
+  status: 'succeeded'
+  action: 'run'
+  recordId: string
+  fieldId: string
+  /** null when the write landed without a reported version — the adapter must skip the version merge. */
+  version: number | null
+  output: string
+  usage: AiShortcutUsage | null
+  estimatedCostUsd: number
+  provider: string | null
+  model: string | null
+}
+
+export interface AiUsageSummary {
+  callerDayTokens: number
+  callerWeekTokens: number
+  instanceDayUsd: number
+  caps: {
+    tenantDailyTokenCap: number
+    tenantWeeklyTokenCap: number
+    accountDailyUsdCap: number
+  }
+}
+
 export class MultitableApiClient {
   private fetch: FetchFn
   private readonly isZhOption?: ApiErrorLocaleOption
@@ -1119,6 +1172,46 @@ export class MultitableApiClient {
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ expression, sampleValues, ...(recordId ? { recordId } : {}) }),
     })
+    return this.parseJson(res)
+  }
+
+  // --- AI shortcut (A3) ---
+  // Preview accepts EITHER a persisted fieldId (drawer path) OR an inline
+  // DRAFT config (field-manager config-time preview — a REAL provider call
+  // that consumes quota). A real readable recordId is mandatory (no
+  // hand-typed-sample path on the backend).
+  async aiShortcutPreview(
+    sheetId: string,
+    input: { recordId: string; fieldId?: string; config?: AiShortcutConfigInput },
+  ): Promise<AiShortcutPreviewData> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/ai/shortcut/preview`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({
+        recordId: input.recordId,
+        ...(input.fieldId ? { fieldId: input.fieldId } : {}),
+        ...(input.config ? { config: input.config } : {}),
+      }),
+    })
+    return this.parseJson(res)
+  }
+
+  // Run executes ONLY the persisted field.property.aiShortcut config — the
+  // backend rejects any inline config (400 AI_INLINE_CONFIG_REJECTED), so the
+  // body is deliberately limited to {recordId, fieldId}.
+  async aiShortcutRun(sheetId: string, input: { recordId: string; fieldId: string }): Promise<AiShortcutRunData> {
+    const res = await this.fetch(`/api/multitable/sheets/${encodeURIComponent(sheetId)}/ai/shortcut/run`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ recordId: input.recordId, fieldId: input.fieldId }),
+    })
+    return this.parseJson(res)
+  }
+
+  // Admin usage summary (flat single-object response, readiness-route
+  // precedent). 403 for non-admins — callers cache the probe per session.
+  async aiUsageSummary(): Promise<AiUsageSummary> {
+    const res = await this.fetch('/api/multitable/ai/usage-summary')
     return this.parseJson(res)
   }
 

--- a/apps/web/src/multitable/components/MetaFieldManager.vue
+++ b/apps/web/src/multitable/components/MetaFieldManager.vue
@@ -368,6 +368,115 @@
           </div>
         </template>
 
+        <!-- A3 §2.1: AI shortcut config section (string/longText targets only) -->
+        <div v-if="aiShortcutSectionVisible" class="meta-field-mgr__ai" data-test="ai-shortcut-section">
+          <div class="meta-field-mgr__ai-header">
+            <strong>{{ ml('field.ai.title') }}</strong>
+          </div>
+          <label class="meta-field-mgr__toggle">
+            <input v-model="aiDraft.enabled" type="checkbox" data-test="ai-shortcut-enable" />
+            <span>{{ ml('field.ai.enable') }}</span>
+          </label>
+          <template v-if="aiDraft.enabled">
+            <label class="meta-field-mgr__field">
+              <span>{{ ml('field.ai.kind') }}</span>
+              <select v-model="aiDraft.kind" class="meta-field-mgr__select" data-test="ai-shortcut-kind">
+                <option v-for="kind in AI_SHORTCUT_KINDS" :key="kind" :value="kind">{{ aiShortcutKindLabel(kind, isZh) }}</option>
+              </select>
+            </label>
+            <div class="meta-field-mgr__field">
+              <span>{{ ml('field.ai.sourceFields') }}</span>
+              <div class="meta-field-mgr__ai-sources">
+                <label v-for="sourceField in aiSourceFieldCandidates" :key="sourceField.id" class="meta-field-mgr__ai-source">
+                  <input
+                    type="checkbox"
+                    :checked="aiDraft.sourceFieldIds.includes(sourceField.id)"
+                    :disabled="!aiDraft.sourceFieldIds.includes(sourceField.id) && aiDraft.sourceFieldIds.length >= AI_SHORTCUT_MAX_SOURCE_FIELDS"
+                    :data-test="`ai-shortcut-source-${sourceField.id}`"
+                    @change="toggleAiSourceField(sourceField.id, $event)"
+                  />
+                  <span>{{ sourceField.name }}</span>
+                </label>
+              </div>
+              <span class="meta-field-mgr__hint">{{ ml('field.ai.sourceHint') }}</span>
+            </div>
+            <div v-if="aiDraft.kind === 'classify'" class="meta-field-mgr__field">
+              <span>{{ ml('field.ai.options') }}</span>
+              <div class="meta-field-mgr__stack">
+                <div v-for="(option, idx) in aiDraft.options" :key="idx" class="meta-field-mgr__option-row">
+                  <input
+                    class="meta-field-mgr__input"
+                    :maxlength="AI_SHORTCUT_MAX_OPTION_LENGTH"
+                    :placeholder="ml('field.ai.optionPlaceholder')"
+                    :value="option"
+                    data-test="ai-shortcut-option-input"
+                    @input="onAiOptionInput(idx, $event)"
+                  />
+                  <button class="meta-field-mgr__action meta-field-mgr__action--danger" type="button" @click="removeAiOption(idx)">&times;</button>
+                </div>
+                <button
+                  class="meta-field-mgr__btn-inline"
+                  type="button"
+                  :disabled="aiDraft.options.length >= AI_SHORTCUT_MAX_OPTIONS"
+                  data-test="ai-shortcut-add-option"
+                  @click="addAiOption"
+                >{{ ml('action.addOption') }}</button>
+              </div>
+            </div>
+            <label v-if="aiDraft.kind === 'translate'" class="meta-field-mgr__field">
+              <span>{{ ml('field.ai.targetLang') }}</span>
+              <input
+                v-model="aiDraft.targetLang"
+                class="meta-field-mgr__input"
+                :maxlength="AI_SHORTCUT_MAX_TARGET_LANG_LENGTH"
+                data-test="ai-shortcut-target-lang"
+              />
+            </label>
+            <label class="meta-field-mgr__field">
+              <span>{{ ml('field.ai.instruction') }} ({{ aiDraft.instruction.length }}/{{ AI_SHORTCUT_MAX_INSTRUCTION_LENGTH }})</span>
+              <textarea
+                v-model="aiDraft.instruction"
+                class="meta-field-mgr__textarea"
+                :maxlength="AI_SHORTCUT_MAX_INSTRUCTION_LENGTH"
+                data-test="ai-shortcut-instruction"
+              ></textarea>
+            </label>
+            <!-- §2.1 LOCKED copy: REAL call consuming quota; validates the DRAFT. -->
+            <div class="meta-field-mgr__ai-preview">
+              <div class="meta-field-mgr__hint">
+                {{ ml('field.ai.previewRealCallHint') }} {{ ml('field.ai.previewDraftHint') }}
+              </div>
+              <button
+                type="button"
+                class="meta-field-mgr__dryrun-btn"
+                :disabled="!aiPreviewCanRun"
+                data-test="ai-shortcut-preview-btn"
+                @click="runAiPreview"
+              >
+                {{ aiPreviewRunning ? ml('field.ai.previewing') : ml('field.ai.previewWithRecord') }}
+              </button>
+              <div v-if="!currentRecordId" class="meta-field-mgr__hint">{{ ml('field.ai.previewNeedsRecord') }}</div>
+              <div v-if="aiPreviewError" class="meta-field-mgr__formula-diagnostic meta-field-mgr__formula-diagnostic--error" data-test="ai-shortcut-preview-error">{{ aiPreviewError }}</div>
+              <div v-else-if="aiPreviewData" class="meta-field-mgr__dryrun-result" data-test="ai-shortcut-preview-result">
+                <div class="meta-field-mgr__dryrun-result-head">
+                  <strong>{{ ml('field.ai.previewResult') }}</strong>
+                </div>
+                <div class="meta-field-mgr__ai-preview-output">{{ aiPreviewData.output }}</div>
+                <div v-if="aiPreviewTokensText" class="meta-field-mgr__hint">{{ aiPreviewTokensText }}</div>
+              </div>
+            </div>
+          </template>
+          <!-- §2.4 admin usage card (automation stats-card styling family; hidden after a cached 403 probe) -->
+          <div v-if="aiUsageSummary" class="meta-field-mgr__ai-usage" data-test="ai-usage-card">
+            <strong>{{ ml('field.aiUsage.title') }}</strong>
+            <div class="meta-field-mgr__ai-usage-stats">
+              <span class="meta-field-mgr__ai-stat meta-field-mgr__ai-stat--day">{{ ml('field.aiUsage.today') }}: {{ aiUsageSummary.callerDayTokens }} / {{ aiUsageSummary.caps.tenantDailyTokenCap }}</span>
+              <span class="meta-field-mgr__ai-stat meta-field-mgr__ai-stat--week">{{ ml('field.aiUsage.week') }}: {{ aiUsageSummary.callerWeekTokens }} / {{ aiUsageSummary.caps.tenantWeeklyTokenCap }}</span>
+              <span class="meta-field-mgr__ai-stat meta-field-mgr__ai-stat--usd">{{ ml('field.aiUsage.instance') }}: {{ aiUsageSummary.instanceDayUsd }} / {{ aiUsageSummary.caps.accountDailyUsdCap }}</span>
+            </div>
+          </div>
+        </div>
+
         <MetaFieldValidationPanel
           v-if="configTarget && validationPanelVisible"
           class="meta-field-mgr__validation"
@@ -464,6 +573,7 @@ import {
   systemFieldHint,
 } from '../utils/system-fields'
 import {
+  aiShortcutKindLabel,
   configureField,
   configureNewField,
   deleteFieldConfirm,
@@ -473,7 +583,20 @@ import {
   insertFieldTokenTitle,
   managerLabel,
 } from '../utils/meta-manager-labels'
-import { fieldTypeLabel } from '../utils/meta-core-labels'
+import { aiTokensConsumed, fieldTypeLabel } from '../utils/meta-core-labels'
+import { aiShortcutErrorMessage } from '../utils/meta-api-error-labels'
+import {
+  AI_SHORTCUT_COMPUTED_SOURCE_TYPES,
+  AI_SHORTCUT_KINDS,
+  AI_SHORTCUT_MAX_INSTRUCTION_LENGTH,
+  AI_SHORTCUT_MAX_OPTIONS,
+  AI_SHORTCUT_MAX_OPTION_LENGTH,
+  AI_SHORTCUT_MAX_SOURCE_FIELDS,
+  AI_SHORTCUT_MAX_TARGET_LANG_LENGTH,
+  fetchAiUsageSummaryWithProbeCache,
+  type AiShortcutPreviewOutcome,
+} from '../composables/useAiShortcut'
+import type { AiShortcutConfigInput, AiShortcutKind, AiShortcutPreviewData, AiUsageSummary } from '../api/client'
 import MetaFieldValidationPanel from './MetaFieldValidationPanel.vue'
 
 /** Field types where the validation panel is configurable. */
@@ -588,6 +711,17 @@ const props = defineProps<{
   // #5c: the currently-selected record, if any. When present, a "preview with current record" button
   // appears that samples this record's real values server-side (manual samples still override).
   currentRecordId?: string | null
+  // A3 §2.1: config-time AI shortcut preview over the inline DRAFT config.
+  // The workbench wires this to useAiShortcut.previewWithConfig so the
+  // unified in-flight guard covers this entry point too. null outcome =
+  // guarded no-op (another AI request is in flight / countdown active).
+  aiPreviewFn?: (params: { recordId: string; config: AiShortcutConfigInput }) => Promise<AiShortcutPreviewOutcome | null>
+  // Review F3: unified AI busy state (request in flight on ANY surface, or a
+  // RATE_LIMITED countdown). The preview button disables on it — same as the
+  // drawer's aiBusy — instead of offering a click the guard silently refuses.
+  aiPreviewBusy?: boolean
+  // A3 §2.4: admin usage summary (403 probe is session-cached by the helper).
+  aiUsageSummaryFn?: () => Promise<AiUsageSummary>
 }>()
 
 const emit = defineEmits<{
@@ -662,6 +796,22 @@ const autoNumberDraft = reactive<{ prefix: string; digits: number; start: number
   prefix: '',
   digits: 0,
   start: 1,
+})
+// --- A3 §2.1: aiShortcut config draft (string/longText targets) ---
+const aiDraft = reactive<{
+  enabled: boolean
+  kind: AiShortcutKind
+  sourceFieldIds: string[]
+  options: string[]
+  targetLang: string
+  instruction: string
+}>({
+  enabled: false,
+  kind: 'summarize',
+  sourceFieldIds: [],
+  options: [],
+  targetLang: '',
+  instruction: '',
 })
 const validationDraft = ref<FieldValidationRule[]>([])
 // True when the field had explicit validation rules stored OR the user
@@ -883,7 +1033,21 @@ function fieldTypeName(field: MetaField): string {
   return fieldTypeLabel(displayFieldType(field), isZh.value)
 }
 
+function resetAiDraft() {
+  aiDraft.enabled = false
+  aiDraft.kind = 'summarize'
+  aiDraft.sourceFieldIds = []
+  aiDraft.options = []
+  aiDraft.targetLang = ''
+  aiDraft.instruction = ''
+  aiPreviewSeq++
+  aiPreviewRunning.value = false
+  aiPreviewData.value = null
+  aiPreviewError.value = ''
+}
+
 function resetDrafts() {
+  resetAiDraft()
   selectDraft.options = [{ value: '', color: '' }]
   linkDraft.foreignSheetId = ''
   linkDraft.limitSingleRecord = false
@@ -989,10 +1153,27 @@ function serializeFieldDraft(type: string | null): string {
       startAt: autoNumberDraft.start,
     })
   }
-  if (type === 'string' || type === 'longText' || type === 'number') {
+  if (type === 'string' || type === 'longText') {
+    // A3: the ai draft participates in dirty/outdated detection so an
+    // aiShortcut-only edit marks the config dirty (and a background field
+    // change while editing flips the outdated banner, same as validation).
+    return JSON.stringify({ validation, aiShortcut: serializeAiDraft() })
+  }
+  if (type === 'number') {
     return JSON.stringify({ validation })
   }
   return ''
+}
+
+function serializeAiDraft(): Record<string, unknown> | null {
+  if (!aiDraft.enabled) return null
+  return {
+    kind: aiDraft.kind,
+    sourceFieldIds: [...aiDraft.sourceFieldIds],
+    options: [...aiDraft.options],
+    targetLang: aiDraft.targetLang,
+    instruction: aiDraft.instruction,
+  }
 }
 
 function serializeFieldSourceSignature(field: MetaField | null): string {
@@ -1072,6 +1253,12 @@ function hydrateExistingFieldConfig(field: MetaField, options?: { liveRefreshTex
     autoNumberDraft.prefix = property.prefix
     autoNumberDraft.digits = property.digits
     autoNumberDraft.start = property.start
+  } else if (fieldType === 'string' || fieldType === 'longText') {
+    // A3 CLOBBER GUARD leg 1 (LOCKED §2.1): hydrate the persisted aiShortcut
+    // into the draft so EVERY subsequent save re-emits it (see
+    // currentDraftProperty). Without this, any validation-only save would
+    // silently delete the configured shortcut (property is replaced wholesale).
+    hydrateAiShortcutDraft(field.property)
   }
   if (VALIDATION_PANEL_TYPES.has(fieldType)) {
     const loaded = rulesFromProperty(field.property ?? null)
@@ -1138,6 +1325,210 @@ function openNewFieldConfigIfNeeded() {
   fieldConfigLiveRefreshText.value = ''
   fieldConfigSourceSignature.value = ''
 }
+
+// --- A3: aiShortcut config section logic (string/longText targets) ---
+
+const aiShortcutSectionVisible = computed(() =>
+  configTargetType.value === 'string' || configTargetType.value === 'longText',
+)
+
+// Constraint mirror (A2): existing, non-computed, not the target field itself.
+const aiSourceFieldCandidates = computed(() =>
+  props.fields.filter((field) =>
+    field.id !== configTarget.value?.id && !AI_SHORTCUT_COMPUTED_SOURCE_TYPES.has(field.type),
+  ),
+)
+
+function hydrateAiShortcutDraft(property: Record<string, unknown> | null | undefined) {
+  const raw = property?.aiShortcut
+  if (!raw || typeof raw !== 'object' || Array.isArray(raw)) {
+    aiDraft.enabled = false
+    return
+  }
+  const obj = raw as Record<string, unknown>
+  const params = obj.params && typeof obj.params === 'object' && !Array.isArray(obj.params)
+    ? (obj.params as Record<string, unknown>)
+    : {}
+  aiDraft.enabled = true
+  aiDraft.kind = (AI_SHORTCUT_KINDS as readonly string[]).includes(String(obj.kind))
+    ? (obj.kind as AiShortcutKind)
+    : 'summarize'
+  aiDraft.sourceFieldIds = Array.isArray(obj.sourceFieldIds)
+    ? obj.sourceFieldIds.filter((entry): entry is string => typeof entry === 'string')
+    : []
+  aiDraft.options = Array.isArray(params.options)
+    ? params.options.filter((entry): entry is string => typeof entry === 'string')
+    : []
+  aiDraft.targetLang = typeof params.targetLang === 'string' ? params.targetLang : ''
+  aiDraft.instruction = typeof params.instruction === 'string' ? params.instruction : ''
+}
+
+function toggleAiSourceField(fieldId: string, event: Event) {
+  const checked = (event.target as HTMLInputElement).checked
+  if (checked) {
+    if (aiDraft.sourceFieldIds.includes(fieldId)) return
+    aiDraft.sourceFieldIds = [...aiDraft.sourceFieldIds, fieldId]
+  } else {
+    aiDraft.sourceFieldIds = aiDraft.sourceFieldIds.filter((id) => id !== fieldId)
+  }
+}
+
+function addAiOption() {
+  if (aiDraft.options.length >= AI_SHORTCUT_MAX_OPTIONS) return
+  aiDraft.options = [...aiDraft.options, '']
+}
+
+function removeAiOption(index: number) {
+  aiDraft.options = aiDraft.options.filter((_, i) => i !== index)
+}
+
+function onAiOptionInput(index: number, event: Event) {
+  const next = [...aiDraft.options]
+  next[index] = (event.target as HTMLInputElement).value
+  aiDraft.options = next
+}
+
+/**
+ * Resolve the draft into the canonical wire config, mirroring the A2 caps
+ * client-side. ok:false → fieldConfigError is already set. ok:true with no
+ * config = the toggle is off (removal-by-key-omission, §2.1 LOCK — never
+ * `aiShortcut: null`, which the backend 400s).
+ */
+function resolveAiShortcutDraft(): { ok: boolean; config?: AiShortcutConfigInput } {
+  if (!aiDraft.enabled) return { ok: true }
+  const candidateIds = new Set(aiSourceFieldCandidates.value.map((field) => field.id))
+  const sourceFieldIds = aiDraft.sourceFieldIds.filter((id) => candidateIds.has(id))
+  if (sourceFieldIds.length === 0) {
+    fieldConfigError.value = ml('field.error.aiSourceRequired')
+    return { ok: false }
+  }
+  if (sourceFieldIds.length > AI_SHORTCUT_MAX_SOURCE_FIELDS) {
+    fieldConfigError.value = ml('field.error.aiSourceTooMany')
+    return { ok: false }
+  }
+  const options = aiDraft.options.map((option) => option.trim()).filter((option) => option.length > 0)
+  if (options.length > AI_SHORTCUT_MAX_OPTIONS) {
+    fieldConfigError.value = ml('field.error.aiOptionsTooMany')
+    return { ok: false }
+  }
+  if (options.some((option) => option.length > AI_SHORTCUT_MAX_OPTION_LENGTH)) {
+    fieldConfigError.value = ml('field.error.aiOptionTooLong')
+    return { ok: false }
+  }
+  const targetLang = aiDraft.targetLang.trim()
+  if (targetLang.length > AI_SHORTCUT_MAX_TARGET_LANG_LENGTH) {
+    fieldConfigError.value = ml('field.error.aiTargetLangTooLong')
+    return { ok: false }
+  }
+  const instruction = aiDraft.instruction.trim()
+  if (instruction.length > AI_SHORTCUT_MAX_INSTRUCTION_LENGTH) {
+    fieldConfigError.value = ml('field.error.aiInstructionTooLong')
+    return { ok: false }
+  }
+  const params: AiShortcutConfigInput['params'] = {
+    ...(aiDraft.kind === 'classify' && options.length > 0 ? { options } : {}),
+    ...(aiDraft.kind === 'translate' && targetLang ? { targetLang } : {}),
+    ...(instruction ? { instruction } : {}),
+  }
+  return {
+    ok: true,
+    config: {
+      kind: aiDraft.kind,
+      sourceFieldIds,
+      ...(Object.keys(params).length > 0 ? { params } : {}),
+    },
+  }
+}
+
+// dirty leg for the save no-op skip (mirrors fieldConfigDirty's serialization).
+const aiShortcutDirty = computed(() => {
+  if (!configTarget.value) return false
+  if (!aiShortcutSectionVisible.value) return false
+  const baseline = safeParseBaseline(fieldConfigBaseline.value)
+  return JSON.stringify(baseline?.aiShortcut ?? null) !== JSON.stringify(serializeAiDraft())
+})
+
+function safeParseBaseline(raw: string): { aiShortcut?: unknown } | null {
+  if (!raw) return null
+  try {
+    return JSON.parse(raw) as { aiShortcut?: unknown }
+  } catch {
+    return null
+  }
+}
+
+// --- A3 §2.1: config-time preview ("用当前记录预览", inline DRAFT config) ---
+const aiPreviewRunning = ref(false)
+const aiPreviewData = ref<AiShortcutPreviewData | null>(null)
+const aiPreviewError = ref('')
+let aiPreviewSeq = 0
+
+const aiPreviewCanRun = computed(() =>
+  Boolean(props.aiPreviewFn) &&
+  Boolean(props.currentRecordId) &&
+  aiDraft.enabled &&
+  !aiPreviewRunning.value &&
+  // Review F3: countdown / cross-surface in-flight → disable, like the drawer.
+  !props.aiPreviewBusy,
+)
+
+async function runAiPreview() {
+  if (!props.aiPreviewFn || !props.currentRecordId || !aiPreviewCanRun.value) return
+  fieldConfigError.value = ''
+  const resolved = resolveAiShortcutDraft()
+  if (!resolved.ok || !resolved.config) return // constraint mirror already set fieldConfigError
+  const seq = ++aiPreviewSeq
+  aiPreviewRunning.value = true
+  aiPreviewError.value = ''
+  aiPreviewData.value = null
+  try {
+    const outcome = await props.aiPreviewFn({ recordId: props.currentRecordId, config: resolved.config })
+    if (seq !== aiPreviewSeq) return
+    if (!outcome) return // unified in-flight guard refused (another AI request active)
+    if ('error' in outcome) {
+      if (outcome.error.code === 'VALIDATION_ERROR') {
+        // A2 server-side config rejection → the EXISTING fieldConfigError inline (§2.1).
+        fieldConfigError.value = outcome.error.message || ml('field.error.aiSourceRequired')
+      } else {
+        // AI-state errors use the §2.3 copy (fall back to the raw message for unknown codes).
+        aiPreviewError.value = aiShortcutErrorMessage(outcome.error.code, isZh.value) ?? outcome.error.message
+      }
+      return
+    }
+    aiPreviewData.value = outcome.data
+  } finally {
+    if (seq === aiPreviewSeq) aiPreviewRunning.value = false
+  }
+}
+
+const aiPreviewTokensText = computed(() => {
+  const usage = aiPreviewData.value?.usage
+  if (!usage) return ''
+  return aiTokensConsumed(usage.promptTokens + usage.completionTokens, isZh.value)
+})
+
+// --- A3 §2.4: admin usage card (403 probe session-cached in useAiShortcut) ---
+const aiUsageSummary = ref<AiUsageSummary | null>(null)
+let aiUsageSeq = 0
+
+async function loadAiUsageSummary() {
+  const fn = props.aiUsageSummaryFn
+  if (!fn) return
+  const seq = ++aiUsageSeq
+  try {
+    const summary = await fetchAiUsageSummaryWithProbeCache(fn)
+    if (seq === aiUsageSeq) aiUsageSummary.value = summary
+  } catch {
+    // Non-403 read failure: hide the card quietly — it is admin telemetry,
+    // never a blocker for field configuration.
+    if (seq === aiUsageSeq) aiUsageSummary.value = null
+  }
+}
+
+watch(aiShortcutSectionVisible, (visible) => {
+  if (visible) void loadAiUsageSummary()
+  else aiUsageSummary.value = null
+})
 
 function currentDraftProperty(type: MetaFieldCreateType | string): Record<string, unknown> | undefined {
   const normalizedType = type === 'link' || type === 'select' || type === 'multiSelect' || type === 'lookup' || type === 'rollup' || type === 'formula' || type === 'attachment' || type === 'person' || type === 'number' || type === 'currency' || type === 'percent' || type === 'rating' || type === 'autoNumber'
@@ -1291,7 +1682,14 @@ function currentDraftProperty(type: MetaFieldCreateType | string): Record<string
     }
   }
   if (type === 'string' || type === 'longText') {
-    return { ...validationProperty }
+    // A3 CLOBBER GUARD leg 2 (LOCKED §2.1, regression-tested A3-T1b): EVERY
+    // string/longText save re-emits the aiShortcut carried by the draft
+    // (hydrated from the persisted field), because update-field replaces the
+    // property wholesale. Removal = key omission via the enable toggle
+    // (A3-T1c) — never `aiShortcut: null` (the backend 400s null).
+    const ai = resolveAiShortcutDraft()
+    if (!ai.ok) return undefined
+    return { ...validationProperty, ...(ai.config ? { aiShortcut: ai.config } : {}) }
   }
   return undefined
 }
@@ -1333,13 +1731,13 @@ function saveConfig() {
   const property = currentDraftProperty(fieldType)
   if (!property && fieldConfigError.value) return
   if (!property) return
-  // Skip no-op saves for types that only expose validation: if the user
-  // never touched the panel there is nothing to persist, and emitting
-  // an empty `property: {}` would otherwise clobber existing values on
-  // the server. Types with mandatory structural config (select/link/
+  // Skip no-op saves for types that only expose validation + aiShortcut: if
+  // the user touched neither surface there is nothing to persist, and
+  // emitting an empty `property: {}` would otherwise clobber existing values
+  // on the server. Types with mandatory structural config (select/link/
   // lookup/rollup/formula/attachment) always have keys to persist.
   const onlyValidationSurface = (fieldType === 'string' || fieldType === 'longText')
-  if (onlyValidationSurface && !validationDraftTouched.value) {
+  if (onlyValidationSurface && !validationDraftTouched.value && !aiShortcutDirty.value) {
     closeConfig()
     return
   }
@@ -1546,6 +1944,21 @@ onBeforeUnmount(() => {
 .meta-field-mgr__btn-delete { padding: 4px 12px; background: #f56c6c; color: #fff; border: none; border-radius: 3px; cursor: pointer; font-size: 12px; }
 .meta-field-mgr__error { color: #f56c6c; font-size: 12px; }
 .meta-field-mgr__validation { margin-top: 4px; }
+/* A3: AI shortcut config section */
+.meta-field-mgr__ai { display: flex; flex-direction: column; gap: 10px; padding: 10px 12px; border: 1px solid #e0e7ff; border-radius: 8px; background: #fafbff; }
+.meta-field-mgr__ai-header { font-size: 12px; color: #4338ca; }
+.meta-field-mgr__ai-sources { display: flex; flex-wrap: wrap; gap: 6px 12px; }
+.meta-field-mgr__ai-source { display: inline-flex; align-items: center; gap: 4px; font-size: 12px; color: #444; }
+.meta-field-mgr__ai-preview { display: flex; flex-direction: column; gap: 6px; }
+.meta-field-mgr__ai-preview-output { font-size: 12px; color: #334155; white-space: pre-wrap; word-break: break-word; }
+/* §2.4 admin usage card — automation stats-card styling family
+   (MetaAutomationManager .meta-automation__card-stats / __stat). */
+.meta-field-mgr__ai-usage { display: flex; flex-direction: column; gap: 6px; padding: 8px 10px; border: 1px solid #e2e8f0; border-radius: 6px; background: #fff; font-size: 12px; }
+.meta-field-mgr__ai-usage-stats { display: flex; flex-wrap: wrap; gap: 10px; font-size: 12px; }
+.meta-field-mgr__ai-stat { font-weight: 600; }
+.meta-field-mgr__ai-stat--day { color: #16a34a; }
+.meta-field-mgr__ai-stat--week { color: #1d4ed8; }
+.meta-field-mgr__ai-stat--usd { color: #b45309; }
 .meta-field-mgr__rename-wrap { flex: 1; display: flex; flex-direction: column; gap: 2px; }
 .meta-field-mgr__rename--invalid { border-color: #f56c6c; }
 .meta-field-mgr__input--invalid { border-color: #f56c6c; }

--- a/apps/web/src/multitable/components/MetaGridTable.vue
+++ b/apps/web/src/multitable/components/MetaGridTable.vue
@@ -85,10 +85,12 @@
                     :delete-attachment-fn="props.deleteAttachmentFn"
                     :attachment-summaries="props.attachmentSummaries?.[row.id]?.[field.id]"
                     :upload-context="{ recordId: row.id, fieldId: field.id }"
+                    :ai-run-state="aiRunState"
                     @update:model-value="editCell!.value = $event"
                     @confirm="confirmEdit(row)"
                     @cancel="cancelEdit"
                     @open-link-picker="openLinkPickerFromCell(row.id, field)"
+                    @ai-run="onAiRunFromCell(row.id, field)"
                   />
                   <MetaCellRenderer
                     v-else
@@ -187,11 +189,13 @@
                   :delete-attachment-fn="props.deleteAttachmentFn"
                   :attachment-summaries="props.attachmentSummaries?.[row.id]?.[field.id]"
                   :upload-context="{ recordId: row.id, fieldId: field.id }"
+                  :ai-run-state="aiRunState"
                   @update:model-value="editCell!.value = $event"
                   @confirm="confirmEdit(row)"
                   @yjs-commit="markYjsHandled(row.id, field.id)"
                   @cancel="cancelEdit"
                   @open-link-picker="openLinkPickerFromCell(row.id, field)"
+                  @ai-run="onAiRunFromCell(row.id, field)"
                 />
                 <MetaCellRenderer
                   v-else
@@ -374,6 +378,13 @@ const props = defineProps<{
   // #4-3b-2a: server-computed per-group subtotals (full filtered set, NOT page). Matched to the
   // client's rendered groups by key. Value rendered from this prop only — no local group aggregation.
   aggregateGroups?: Array<{ key: string | number | boolean | null; count: number; aggregates: Record<string, { fn: string; value: number }> }>
+  // A3: AI shortcut run opt-in for the cell editor. `aiRunEnabled` gates the
+  // button; `aiRunPending` is the UNIFIED in-flight state from useAiShortcut;
+  // `aiRunBusy` (review F3) additionally covers the RATE_LIMITED countdown —
+  // the button disables on it so a click can never be silently refused.
+  aiRunEnabled?: boolean
+  aiRunPending?: boolean
+  aiRunBusy?: boolean
 }>()
 
 const emit = defineEmits<{
@@ -392,6 +403,8 @@ const emit = defineEmits<{
   (e: 'create-record'): void
   (e: 'set-frozen', frozenLeftColumnIds: string[]): void
   (e: 'set-aggregation', payload: { fieldId: string; fn: string | null }): void
+  // A3: AI shortcut run requested from a cell editor.
+  (e: 'ai-run', recordId: string, field: MetaField): void
 }>()
 
 const { isZh } = useLocale()
@@ -674,6 +687,25 @@ function cancelEdit() { editCell.value = null; yjsHandledCellKey.value = null }
 function openLinkPickerFromCell(recordId: string, field: MetaField) {
   cancelEdit()
   emit('open-link-picker', { recordId, field })
+}
+
+// A3: cell-editor opt-in payload (null = host did not enable → no button).
+// `busy` (review F3) folds in the rate-limit countdown so the run button
+// disables exactly like the drawer's aiBusy — never an enabled click that
+// would only be refused by the composable guard.
+const aiRunState = computed(() => (props.aiRunEnabled
+  ? { pending: Boolean(props.aiRunPending), busy: Boolean(props.aiRunPending) || Boolean(props.aiRunBusy) }
+  : null))
+
+// A3: an AI run replaces the cell value server-side — close the edit session
+// first so a stale editor draft can never overwrite the AI output on confirm.
+// Review F3 guard: while the unified AI state is busy (in-flight elsewhere or
+// rate-limit countdown) the composable would refuse the run anyway, so do NOT
+// destroy the user's edit session — keep the editor open and no-op here.
+function onAiRunFromCell(recordId: string, field: MetaField) {
+  if (props.aiRunPending || props.aiRunBusy) return
+  cancelEdit()
+  emit('ai-run', recordId, field)
 }
 
 function copyFocusedCell() {

--- a/apps/web/src/multitable/components/MetaRecordDrawer.vue
+++ b/apps/web/src/multitable/components/MetaRecordDrawer.vue
@@ -59,6 +59,32 @@
       <div v-for="field in visibleFields" :key="field.id" class="meta-record-drawer__field">
         <div class="meta-record-drawer__field-header">
           <label class="meta-record-drawer__label" :for="`drawer_field_${field.id}`">{{ field.name }}</label>
+          <!--
+            A3-T3 AI shortcut actions: a field rendered here IS readable
+            (visibleFields filters visible===false), so preview mirrors the
+            backend's record-read gate; run additionally requires
+            canEditField — the same layer the backend's run pre-check
+            enforces (#2106 F3).
+          -->
+          <div v-if="fieldHasAiShortcut(field)" class="meta-record-drawer__ai-actions">
+            <button
+              type="button"
+              class="meta-record-drawer__ai-btn"
+              :disabled="aiBusy"
+              :title="l('record.aiPreviewTitle')"
+              :data-ai-preview="field.id"
+              @click="emit('ai-preview', field)"
+            >{{ l('record.aiPreview') }}</button>
+            <button
+              v-if="canEditField(field.id)"
+              type="button"
+              class="meta-record-drawer__ai-btn meta-record-drawer__ai-btn--run"
+              :disabled="aiBusy"
+              :title="l('record.aiRunTitle')"
+              :data-ai-run="field.id"
+              @click="emit('ai-run', field)"
+            >{{ l('record.aiRun') }}</button>
+          </div>
           <button
             v-if="resolvedCanComment"
             type="button"
@@ -193,6 +219,18 @@
           <span v-else class="meta-record-drawer__text">{{ formatValue(field, record.data[field.id]) }}</span>
           <div v-if="field.type === 'link' && linkPreview(field.id)" class="meta-record-drawer__link-summary">{{ linkPreview(field.id) }}</div>
         </div>
+        <!-- A3 §2.3/§2.4: per-field AI state — pending / error copy (by code) / per-run tokens. -->
+        <div
+          v-if="aiStatusTextFor(field.id)"
+          class="meta-record-drawer__ai-status"
+          :class="{ 'meta-record-drawer__ai-status--error': aiStatusIsError(field.id) }"
+          :data-ai-status="field.id"
+        >{{ aiStatusTextFor(field.id) }}</div>
+        <div
+          v-if="aiPreviewOutputFor(field.id)"
+          class="meta-record-drawer__ai-output"
+          :data-ai-output="field.id"
+        >{{ aiPreviewOutputFor(field.id) }}</div>
       </div>
       </div>
       <div v-else class="meta-record-drawer__history">
@@ -267,10 +305,13 @@ import {
 } from '../utils/meta-record-labels'
 import {
   metaCoreLabel,
+  aiTokensConsumed,
   attachmentActionHint as attachmentActionHintFn,
   attachmentActivityLabel,
   type MetaCoreLabelKey,
 } from '../utils/meta-core-labels'
+import { aiRetryCountdown, aiShortcutErrorMessage } from '../utils/meta-api-error-labels'
+import type { AiShortcutState } from '../composables/useAiShortcut'
 import {
   dateTimeInputValue,
   dateTimeValueFromLocalInput,
@@ -299,6 +340,8 @@ const props = withDefaults(defineProps<{
   canManageRecordPermissions?: boolean
   sheetId?: string
   apiClient?: MultitableApiClient
+  /** A3: shared AI shortcut UI state from the workbench useAiShortcut instance. */
+  aiShortcut?: AiShortcutState | null
 }>(), {
   recordIds: () => [],
 })
@@ -312,6 +355,9 @@ const emit = defineEmits<{
   (e: 'open-automation'): void
   (e: 'open-link-picker', field: MetaField): void
   (e: 'navigate', recordId: string): void
+  /** A3: AI shortcut triggers (workbench resolves them through useAiShortcut). */
+  (e: 'ai-preview', field: MetaField): void
+  (e: 'ai-run', field: MetaField): void
 }>()
 
 const { isZh } = useLocale()
@@ -381,6 +427,68 @@ function canEditField(fieldId: string): boolean {
     && props.rowActions?.canEdit !== false
     && props.fieldPermissions?.[fieldId]?.readOnly !== true
     && !isSystemField(field)
+}
+
+// --- A3 AI shortcut (drawer = primary trigger surface) ---
+
+function fieldHasAiShortcut(field: MetaField): boolean {
+  if (field.type !== 'string' && field.type !== 'longText') return false
+  const raw = (field.property ?? {}).aiShortcut
+  return Boolean(raw) && typeof raw === 'object' && !Array.isArray(raw)
+}
+
+// Unified in-flight + rate-limit countdown disable across ALL fields (§2.2).
+const aiBusy = computed(() =>
+  Boolean(props.aiShortcut?.pending) || (props.aiShortcut?.retryRemainingMs ?? 0) > 0,
+)
+
+function aiStateTargets(fieldId: string): {
+  pending: boolean
+  error: AiShortcutState['error']
+  result: AiShortcutState['result']
+} {
+  const ai = props.aiShortcut
+  const recordId = props.record?.id
+  if (!ai || !recordId) return { pending: false, error: null, result: null }
+  return {
+    pending: Boolean(ai.pending && ai.pending.recordId === recordId && ai.pending.fieldId === fieldId),
+    error: ai.error && ai.error.recordId === recordId && ai.error.fieldId === fieldId ? ai.error : null,
+    result: ai.result && ai.result.recordId === recordId && ai.result.fieldId === fieldId ? ai.result : null,
+  }
+}
+
+function aiStatusIsError(fieldId: string): boolean {
+  const { error, result } = aiStateTargets(fieldId)
+  return Boolean(error) || Boolean(result?.refreshHint)
+}
+
+/** §2.3 state copy by error.code; per-run tokens; drift shares the 409 refresh copy. */
+function aiStatusTextFor(fieldId: string): string {
+  const { pending, error, result } = aiStateTargets(fieldId)
+  if (pending) return l('record.aiPending')
+  if (error) {
+    const mapped = aiShortcutErrorMessage(error.code, isZh.value) ?? error.message
+    const remaining = props.aiShortcut?.retryRemainingMs
+    if (error.code === 'RATE_LIMITED' && typeof remaining === 'number' && remaining > 0) {
+      return `${mapped} ${aiRetryCountdown(Math.ceil(remaining / 1000), isZh.value)}`
+    }
+    return mapped
+  }
+  if (result) {
+    const tokens = aiTokensConsumed(result.totalTokens, isZh.value)
+    if (result.refreshHint) {
+      // Drift-skipped merge: SAME recovery copy as 409 (LOCKED §2.2).
+      return `${aiShortcutErrorMessage('VERSION_CONFLICT', isZh.value)} · ${tokens}`
+    }
+    return tokens
+  }
+  return ''
+}
+
+/** Preview output is shown inline (a preview never writes the record). */
+function aiPreviewOutputFor(fieldId: string): string {
+  const { result } = aiStateTargets(fieldId)
+  return result && result.kind === 'preview' ? result.output : ''
 }
 
 function recordFieldAffordance(fieldId: string) {
@@ -750,6 +858,13 @@ function attachmentAllowsMultiple(field: MetaField): boolean {
 .meta-record-drawer__field { margin-bottom: 14px; }
 .meta-record-drawer__field-header { display: flex; align-items: center; justify-content: space-between; gap: 8px; margin-bottom: 4px; }
 .meta-record-drawer__label { display: block; font-size: 12px; color: #999; }
+.meta-record-drawer__ai-actions { display: inline-flex; gap: 4px; margin-left: auto; }
+.meta-record-drawer__ai-btn { padding: 1px 8px; border: 1px solid #c7d2fe; border-radius: 999px; background: #eef2ff; color: #4338ca; cursor: pointer; font-size: 11px; }
+.meta-record-drawer__ai-btn--run { border-color: #a7f3d0; background: #ecfdf5; color: #047857; }
+.meta-record-drawer__ai-btn:disabled { opacity: 0.5; cursor: not-allowed; }
+.meta-record-drawer__ai-status { margin-top: 4px; font-size: 11px; color: #4338ca; }
+.meta-record-drawer__ai-status--error { color: #b91c1c; }
+.meta-record-drawer__ai-output { margin-top: 4px; padding: 6px 8px; border: 1px dashed #c7d2fe; border-radius: 6px; background: #f8faff; font-size: 12px; color: #334155; white-space: pre-wrap; word-break: break-word; }
 .meta-record-drawer__comment-anchor { display: inline-flex; align-items: center; justify-content: center; min-width: 28px; height: 24px; padding: 0 6px; border: 1px solid #d8e1ee; border-radius: 999px; background: #fff; cursor: pointer; color: #64748b; }
 .meta-record-drawer__comment-anchor:hover { border-color: #93c5fd; background: #eff6ff; color: #2563eb; }
 .meta-record-drawer__comment-anchor--active { border-color: #f59e0b; background: #fff7ed; color: #b45309; }

--- a/apps/web/src/multitable/components/cells/MetaCellEditor.vue
+++ b/apps/web/src/multitable/components/cells/MetaCellEditor.vue
@@ -263,6 +263,24 @@
 
     <!-- readonly fallback -->
     <span v-else class="meta-cell-editor__readonly">{{ readonlyDisplayValue }}</span>
+
+    <!--
+      A3-T6: edit-mode AI run trigger (link-btn precedent).
+      RBAC INVARIANT (LOCKED A3 §2.2): this button's safety relies on the
+      upstream invariant that the cell editor only opens for cells the actor
+      can edit — MetaCellEditor has NO fieldPermissions of its own. Any
+      follow-up that moves this button OUTSIDE the edit mode MUST wire
+      explicit fieldPermissions gating. Hosts opt in via `aiRunState`
+      (only MetaGridTable does; MetaBulkEditDialog stays untouched).
+    -->
+    <button
+      v-if="aiRunVisible"
+      type="button"
+      class="meta-cell-editor__link-btn meta-cell-editor__ai-run"
+      :disabled="aiRunState?.pending || aiRunState?.busy"
+      data-test="cell-ai-run"
+      @click="emit('ai-run')"
+    >{{ aiRunState?.pending ? l('cell.aiRunning') : l('cell.aiRun') }}</button>
   </div>
 </template>
 
@@ -311,6 +329,14 @@ const props = defineProps<{
    * existing REST path regardless of the build-time flag.
    */
   recordId?: string | null
+  /**
+   * A3 AI shortcut run opt-in. Present (non-null) only when the HOST wires
+   * an `ai-run` listener (MetaGridTable). `pending` is the unified in-flight
+   * state (drives the "running" label); `busy` (review F3) additionally
+   * covers the RATE_LIMITED countdown — the button disables on either, same
+   * as the drawer's aiBusy. See the RBAC invariant note in the template.
+   */
+  aiRunState?: { pending: boolean; busy: boolean } | null
 }>()
 
 const DATE_RE = /^\d{4}-\d{2}-\d{2}/
@@ -334,10 +360,20 @@ const emit = defineEmits<{
    * change via `meta_records`. Pass-through REST is safe but redundant.
    */
   (e: 'yjs-commit'): void
+  /** A3: AI shortcut run requested for this cell (host resolves record/field). */
+  (e: 'ai-run'): void
 }>()
 
 const { isZh } = useLocale()
 const l = (key: MetaCoreLabelKey) => metaCoreLabel(key, isZh.value)
+
+// A3-T6: host opt-in (aiRunState) ∧ text target type ∧ persisted aiShortcut config.
+const aiRunVisible = computed(() => {
+  if (!props.aiRunState) return false
+  if (props.field.type !== 'string' && props.field.type !== 'longText') return false
+  const raw = (props.field.property ?? {}).aiShortcut
+  return Boolean(raw) && typeof raw === 'object' && !Array.isArray(raw)
+})
 
 const readonlyDisplayValue = computed(() =>
   formatFieldDisplay({

--- a/apps/web/src/multitable/composables/useAiShortcut.ts
+++ b/apps/web/src/multitable/composables/useAiShortcut.ts
@@ -1,0 +1,343 @@
+/**
+ * useAiShortcut — A3 trigger-surface state machine for the AI field shortcut
+ * (docs/development/multitable-ai-shortcut-frontend-a3-design-20260611.md §2.2/§2.3).
+ *
+ * One instance per workbench drives ALL THREE entry points (record drawer
+ * preview/run, cell-editor run, field-manager config-time preview) so the
+ * in-flight pending guard is unified (LOCKED §2.2 reentrancy).
+ *
+ * Wire discipline:
+ *  - The run response is NOT a PatchResult. `adaptAiShortcutRunResult`
+ *    synthesizes `{updated, records}` for the grid's `applyPatchResult()`;
+ *    `version === null` skips the version write and merges the value only.
+ *    The consumed key set is pinned route-level by the backend integration
+ *    suite (A2-T5 Object.keys assertion) — fixture-drift rule.
+ *  - Errors branch STRICTLY on `error.code` (the body's top-level `status`
+ *    discriminator never reaches the client). RATE_LIMITED (429 + Retry-After)
+ *    starts a countdown that gates every entry point; AI_QUOTA_EXHAUSTED
+ *    (429, no Retry-After) gets no countdown. AI_BLOCKED (503) keeps its own
+ *    code — never a generic-5xx bucket. UI copy for known codes lives in
+ *    meta-api-error-labels (aiShortcutErrorMessage); the raw backend message
+ *    is kept for unknown codes only.
+ *  - Drift guard (LOCKED §2.2, review-F4 refinement): the local row version is
+ *    captured when the run starts. If it changed by the time the response
+ *    lands AND differs from the RESPONSE version (genuine collaborative
+ *    edit), the merge is SKIPPED and `refreshHint` surfaces the same refresh
+ *    recovery copy as 409. If the local version EQUALS the response version,
+ *    the bump was the run's OWN write echoed back through a live Yjs session
+ *    before the HTTP response landed — the output is already applied, so the
+ *    (redundant) merge is skipped silently with a success state and NO
+ *    refresh warning (tokens still shown).
+ *  - `busy` (review F3): single disable signal for ALL trigger surfaces —
+ *    true exactly when `begin()` would refuse (in-flight request OR an active
+ *    RATE_LIMITED countdown). Surfaces must disable on it so a guarded click
+ *    can never silently no-op (the cell path would otherwise destroy the
+ *    user's edit session for nothing).
+ */
+import { computed, getCurrentScope, onScopeDispose, reactive } from 'vue'
+import type {
+  AiShortcutConfigInput,
+  AiShortcutPreviewData,
+  AiShortcutRunData,
+  AiShortcutUsage,
+  AiUsageSummary,
+} from '../api/client'
+import type { PatchResult } from '../types'
+
+// Client-side mirrors of the A2 config governance caps (ai-shortcut-config.ts).
+export const AI_SHORTCUT_KINDS = ['summarize', 'classify', 'extract', 'translate'] as const
+export const AI_SHORTCUT_MAX_SOURCE_FIELDS = 20
+export const AI_SHORTCUT_MAX_OPTIONS = 50
+export const AI_SHORTCUT_MAX_OPTION_LENGTH = 100
+export const AI_SHORTCUT_MAX_TARGET_LANG_LENGTH = 32
+export const AI_SHORTCUT_MAX_INSTRUCTION_LENGTH = 500
+/** Computed field types are server-derived — forbidden as shortcut sources (A2 mirror). */
+export const AI_SHORTCUT_COMPUTED_SOURCE_TYPES: ReadonlySet<string> = new Set(['formula', 'lookup', 'rollup'])
+
+/** Known §2.3 codes plus raw passthrough for anything else (`(string & {})` keeps autocomplete). */
+export type AiShortcutErrorCode =
+  | 'AI_BLOCKED'
+  | 'RATE_LIMITED'
+  | 'AI_QUOTA_EXHAUSTED'
+  | 'AI_UNSAFE_INPUT'
+  | 'AI_PROVIDER_ERROR'
+  | 'VERSION_CONFLICT'
+  | 'UNKNOWN'
+  | (string & {})
+
+export interface AiShortcutUiError {
+  code: AiShortcutErrorCode
+  /** Raw backend message (server-side redacted) — display copy comes from meta-api-error-labels by code. */
+  message: string
+  status?: number
+  retryAfterMs?: number
+  recordId?: string
+  fieldId?: string
+}
+
+export interface AiShortcutUiResult {
+  kind: 'preview' | 'run'
+  recordId: string
+  fieldId: string | null
+  output: string
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+  /**
+   * run only: true when the output is reflected locally — either we applied
+   * the merge, or the run's own Yjs echo already did (review F4). false only
+   * when the drift guard skipped the merge on genuine third-party drift.
+   */
+  merged: boolean
+  /** true → show the SAME refresh recovery copy as 409 (error.aiVersionConflict). */
+  refreshHint: boolean
+}
+
+export interface AiShortcutState {
+  pending: { kind: 'preview' | 'run'; recordId: string; fieldId: string | null } | null
+  result: AiShortcutUiResult | null
+  error: AiShortcutUiError | null
+  /** RATE_LIMITED countdown (ms); null when no countdown is active. */
+  retryRemainingMs: number | null
+}
+
+export type AiShortcutPreviewOutcome =
+  | { data: AiShortcutPreviewData }
+  | { error: AiShortcutUiError }
+
+interface AiShortcutClientLike {
+  aiShortcutPreview(
+    sheetId: string,
+    input: { recordId: string; fieldId?: string; config?: AiShortcutConfigInput },
+  ): Promise<AiShortcutPreviewData>
+  aiShortcutRun(sheetId: string, input: { recordId: string; fieldId: string }): Promise<AiShortcutRunData>
+}
+
+export interface UseAiShortcutOptions {
+  client: AiShortcutClientLike
+  sheetId: () => string
+  /** Local grid row version for the drift guard; undefined when the row is not loaded locally. */
+  getLocalRecordVersion: (recordId: string) => number | undefined
+  /** The grid's applyPatchResult — the single echo application seam. */
+  applyPatchResult: (result: PatchResult) => void
+}
+
+/**
+ * A3-T4 adapter (LOCKED §2.2): synthesize a PatchResult from the run wire.
+ * `output` mirrors what the backend wrote (`result.text ?? ''`); a null
+ * version yields NO `updated` entry (value merge only).
+ */
+export function adaptAiShortcutRunResult(data: AiShortcutRunData): PatchResult {
+  return {
+    updated: typeof data.version === 'number' ? [{ recordId: data.recordId, version: data.version }] : [],
+    records: [{ recordId: data.recordId, data: { [data.fieldId]: data.output ?? '' } }],
+  }
+}
+
+/** Normalize a thrown MultitableApiError into the §2.3 UI error (branch by code, never by status alone). */
+export function mapAiShortcutError(err: unknown): AiShortcutUiError {
+  const e = (err ?? {}) as { code?: unknown; message?: unknown; status?: unknown; retryAfterMs?: unknown }
+  const code = typeof e.code === 'string' && e.code.length > 0 ? e.code : 'UNKNOWN'
+  return {
+    code,
+    message: typeof e.message === 'string' ? e.message : '',
+    ...(typeof e.status === 'number' ? { status: e.status } : {}),
+    ...(typeof e.retryAfterMs === 'number' ? { retryAfterMs: e.retryAfterMs } : {}),
+  }
+}
+
+function usageNumbers(usage: AiShortcutUsage | null | undefined): {
+  promptTokens: number
+  completionTokens: number
+  totalTokens: number
+} {
+  const promptTokens = usage?.promptTokens ?? 0
+  const completionTokens = usage?.completionTokens ?? 0
+  return { promptTokens, completionTokens, totalTokens: promptTokens + completionTokens }
+}
+
+// --- A3-T7: admin usage-summary 403 probe cache (per browser session) ---
+// A non-admin's first probe 403s once; afterwards the card stays silently
+// hidden for the whole session (module-level on purpose — survives remounts).
+let aiUsageSummaryForbiddenThisSession = false
+
+export function resetAiUsageSummarySessionCache(): void {
+  aiUsageSummaryForbiddenThisSession = false
+}
+
+/**
+ * Fetch the admin usage summary through the session 403 cache: null means
+ * "hide the card" (non-admin), other failures propagate (NOT cached).
+ */
+export async function fetchAiUsageSummaryWithProbeCache(
+  fetchFn: () => Promise<AiUsageSummary>,
+): Promise<AiUsageSummary | null> {
+  if (aiUsageSummaryForbiddenThisSession) return null
+  try {
+    return await fetchFn()
+  } catch (err) {
+    if ((err as { status?: number }).status === 403) {
+      aiUsageSummaryForbiddenThisSession = true
+      return null
+    }
+    throw err
+  }
+}
+
+export function useAiShortcut(opts: UseAiShortcutOptions) {
+  const state = reactive<AiShortcutState>({
+    pending: null,
+    result: null,
+    error: null,
+    retryRemainingMs: null,
+  })
+
+  let countdownTimer: ReturnType<typeof setInterval> | null = null
+
+  function clearCountdown(): void {
+    if (countdownTimer) {
+      clearInterval(countdownTimer)
+      countdownTimer = null
+    }
+    state.retryRemainingMs = null
+  }
+
+  function startCountdown(ms: number): void {
+    clearCountdown()
+    state.retryRemainingMs = ms
+    const startedAt = Date.now()
+    countdownTimer = setInterval(() => {
+      const left = ms - (Date.now() - startedAt)
+      if (left <= 0) clearCountdown()
+      else state.retryRemainingMs = left
+    }, 1000)
+  }
+
+  /**
+   * Unified entry gate (LOCKED §2.2): one in-flight request across all three
+   * trigger surfaces, and the RATE_LIMITED countdown blocks new sends (the
+   * limiter budget is shared between preview and run server-side).
+   */
+  function begin(kind: 'preview' | 'run', recordId: string, fieldId: string | null): boolean {
+    if (state.pending) return false
+    if (state.retryRemainingMs !== null) return false
+    state.pending = { kind, recordId, fieldId }
+    state.result = null
+    state.error = null
+    return true
+  }
+
+  function fail(err: unknown, recordId: string, fieldId: string | null): AiShortcutUiError {
+    const mapped = mapAiShortcutError(err)
+    state.error = { ...mapped, recordId, ...(fieldId ? { fieldId } : {}) }
+    if (mapped.code === 'RATE_LIMITED' && typeof mapped.retryAfterMs === 'number' && mapped.retryAfterMs > 0) {
+      startCountdown(mapped.retryAfterMs)
+    }
+    return mapped
+  }
+
+  /** Drawer path: preview the PERSISTED config of a readable field. */
+  async function preview(recordId: string, fieldId: string): Promise<AiShortcutPreviewData | null> {
+    if (!begin('preview', recordId, fieldId)) return null
+    try {
+      const data = await opts.client.aiShortcutPreview(opts.sheetId(), { recordId, fieldId })
+      state.result = {
+        kind: 'preview',
+        recordId,
+        fieldId,
+        output: data.output ?? '',
+        ...usageNumbers(data.usage),
+        merged: false,
+        refreshHint: false,
+      }
+      return data
+    } catch (err) {
+      fail(err, recordId, fieldId)
+      return null
+    } finally {
+      state.pending = null
+    }
+  }
+
+  /**
+   * Field-manager path: preview the inline DRAFT config (real call, consumes
+   * quota — §2.1 locked copy lives in the manager). Outcome is returned
+   * inline so the manager renders result/errors next to the draft; the
+   * shared pending guard + countdown still apply. null = guarded no-op.
+   */
+  async function previewWithConfig(
+    recordId: string,
+    config: AiShortcutConfigInput,
+  ): Promise<AiShortcutPreviewOutcome | null> {
+    if (!begin('preview', recordId, null)) return null
+    try {
+      const data = await opts.client.aiShortcutPreview(opts.sheetId(), { recordId, config })
+      return { data }
+    } catch (err) {
+      const mapped = mapAiShortcutError(err)
+      if (mapped.code === 'RATE_LIMITED' && typeof mapped.retryAfterMs === 'number' && mapped.retryAfterMs > 0) {
+        startCountdown(mapped.retryAfterMs)
+      }
+      return { error: mapped }
+    } finally {
+      state.pending = null
+    }
+  }
+
+  /** Run the persisted config and merge the echo through applyPatchResult. */
+  async function run(recordId: string, fieldId: string): Promise<void> {
+    if (!begin('run', recordId, fieldId)) return
+    const capturedVersion = opts.getLocalRecordVersion(recordId)
+    try {
+      const data = await opts.client.aiShortcutRun(opts.sheetId(), { recordId, fieldId })
+      const localVersion = opts.getLocalRecordVersion(recordId)
+      const responseVersion = typeof data.version === 'number' ? data.version : null
+      const changedLocally = capturedVersion !== undefined && localVersion !== capturedVersion
+      // Own-echo guard (review F4): in a Yjs-live session the run's OWN write
+      // can bump the local version via the realtime echo before the HTTP
+      // response lands. Local version === response version → the output is
+      // already applied; skip the redundant merge silently (success, no
+      // refresh warning). Only a local version differing from BOTH the
+      // captured and the response version is genuine third-party drift.
+      const alreadyApplied = changedLocally && responseVersion !== null && localVersion === responseVersion
+      const drifted = changedLocally && !alreadyApplied
+      if (!drifted && !alreadyApplied) {
+        opts.applyPatchResult(adaptAiShortcutRunResult(data))
+      }
+      state.result = {
+        kind: 'run',
+        recordId,
+        fieldId,
+        output: data.output ?? '',
+        ...usageNumbers(data.usage),
+        merged: !drifted,
+        refreshHint: drifted,
+      }
+    } catch (err) {
+      fail(err, recordId, fieldId)
+    } finally {
+      state.pending = null
+    }
+  }
+
+  function clear(): void {
+    state.result = null
+    state.error = null
+  }
+
+  /**
+   * Review F3: unified disable signal for EVERY trigger surface (drawer
+   * buttons, cell-editor run button, field-manager config preview).
+   * Definitionally identical to the `begin()` refusal condition so a surface
+   * that disables on `busy` can never fire a click that silently no-ops.
+   */
+  const busy = computed(() => state.pending !== null || state.retryRemainingMs !== null)
+
+  if (getCurrentScope()) {
+    onScopeDispose(() => {
+      if (countdownTimer) clearInterval(countdownTimer)
+    })
+  }
+
+  return { state, busy, preview, previewWithConfig, run, clear }
+}

--- a/apps/web/src/multitable/composables/useMultitableGrid.ts
+++ b/apps/web/src/multitable/composables/useMultitableGrid.ts
@@ -1008,6 +1008,9 @@ export function useMultitableGrid(opts: {
     addFilterRule, updateFilterRule, removeFilterRule, clearFilters,
     applySortFilter,
     createRecord, deleteRecord, patchCell, bulkPatch,
+    // A3: exposed as the single echo-application seam for the AI shortcut
+    // run adapter (useAiShortcut synthesizes a PatchResult and feeds it here).
+    applyPatchResult,
     mergeRemoteRecord, applyRemoteRecordPatch, removeRemoteRecord,
     undo, redo, clearEditHistory, dismissConflict, retryConflict,
     setColumnWidth, setGroupField,

--- a/apps/web/src/multitable/utils/meta-api-error-labels.ts
+++ b/apps/web/src/multitable/utils/meta-api-error-labels.ts
@@ -11,12 +11,30 @@ export type MetaApiErrorLabelKey =
   | 'error.unauthenticated'
   | 'error.validation'
   | 'error.fieldValidation'
+  // AI shortcut state copy (A3 §2.3) — keyed STRICTLY on error.code; the body
+  // top-level `status` discriminator never reaches the frontend.
+  | 'error.aiBlocked'
+  | 'error.aiRateLimited'
+  | 'error.aiQuotaExhausted'
+  | 'error.aiUnsafeInput'
+  | 'error.aiProviderError'
+  | 'error.aiVersionConflict'
 
 const META_API_ERROR_LABELS: Record<MetaApiErrorLabelKey, LocaleText> = {
   'error.forbidden': { en: 'Insufficient permissions', zh: '权限不足' },
   'error.unauthenticated': { en: 'Please sign in to continue.', zh: '请先登录后继续。' },
   'error.validation': { en: 'Please check the submitted data and try again.', zh: '请检查提交的数据后重试。' },
   'error.fieldValidation': { en: 'Validation failed', zh: '验证失败' },
+  // AI_BLOCKED is a deliberate readiness state, NOT a generic 5xx outage —
+  // admins diagnose it via the A1 readiness endpoint.
+  'error.aiBlocked': { en: 'AI is not enabled or not ready. Contact an administrator.', zh: 'AI 能力未启用或未就绪，请联系管理员' },
+  'error.aiRateLimited': { en: 'Too many AI requests.', zh: '操作过于频繁' },
+  'error.aiQuotaExhausted': { en: 'AI usage quota reached.', zh: 'AI 用量已达上限' },
+  'error.aiUnsafeInput': { en: 'The content contains secret-shaped text; the request was not sent.', zh: '内容含敏感形态，已拒绝发送' },
+  'error.aiProviderError': { en: 'The AI service is temporarily unavailable. Please retry.', zh: 'AI 服务暂时不可用，请重试' },
+  // Shared recovery copy for BOTH the 409 write conflict AND the local-version
+  // drift guard (A3 §2.2: same refresh recovery copy).
+  'error.aiVersionConflict': { en: 'The record changed during the AI run. Refresh and retry.', zh: '记录已被他人更新，请刷新后重试' },
 }
 
 export const META_API_ERROR_LABEL_KEYS = Object.freeze(
@@ -42,4 +60,29 @@ export function apiDefaultErrorMessage(code: string | undefined, status: number,
     default:
       return `API ${status}`
   }
+}
+
+// --- AI shortcut error copy (A3 §2.3) ---
+
+const AI_SHORTCUT_ERROR_KEY_BY_CODE: Record<string, MetaApiErrorLabelKey> = {
+  AI_BLOCKED: 'error.aiBlocked',
+  RATE_LIMITED: 'error.aiRateLimited',
+  AI_QUOTA_EXHAUSTED: 'error.aiQuotaExhausted',
+  AI_UNSAFE_INPUT: 'error.aiUnsafeInput',
+  AI_PROVIDER_ERROR: 'error.aiProviderError',
+  VERSION_CONFLICT: 'error.aiVersionConflict',
+}
+
+/**
+ * UI copy for a known AI shortcut error code (§2.3 table), or null when the
+ * code is not an AI state — callers fall back to the raw backend message.
+ */
+export function aiShortcutErrorMessage(code: string | undefined, isZh: boolean): string | null {
+  const key = code ? AI_SHORTCUT_ERROR_KEY_BY_CODE[code] : undefined
+  return key ? metaApiErrorLabel(key, isZh) : null
+}
+
+/** RATE_LIMITED countdown suffix (the seconds value is numeric data, interpolated raw). */
+export function aiRetryCountdown(seconds: number, isZh: boolean): string {
+  return isZh ? `${seconds} 秒后可重试` : `Retry in ${seconds}s`
 }

--- a/apps/web/src/multitable/utils/meta-core-labels.ts
+++ b/apps/web/src/multitable/utils/meta-core-labels.ts
@@ -70,6 +70,8 @@ export type MetaCoreLabelKey =
   | 'cell.yes' | 'cell.no' | 'cell.clear'
   | 'cell.noAttachments' | 'cell.clearAll'
   | 'cell.uploadFailed' | 'cell.removeFailed' | 'cell.clearFailed'
+  // --- MetaCellEditor AI shortcut run button (A3-T6) ---
+  | 'cell.aiRun' | 'cell.aiRunning'
   // --- Auth chrome (file-location closure tightening per #1803) ---
   | 'auth.notAuthenticated'
 
@@ -209,6 +211,9 @@ const META_CORE_LABELS: Record<MetaCoreLabelKey, { en: string; zh: string }> = {
   'cell.uploadFailed': { en: 'Failed to upload attachment', zh: '附件上传失败' },
   'cell.removeFailed': { en: 'Failed to remove attachment', zh: '附件移除失败' },
   'cell.clearFailed': { en: 'Failed to clear attachments', zh: '附件清空失败' },
+  // A3-T6: in-cell AI run trigger (host opt-in; RBAC rides the editor-open invariant).
+  'cell.aiRun': { en: 'Run AI', zh: '运行 AI' },
+  'cell.aiRunning': { en: 'Running AI...', zh: 'AI 处理中...' },
 }
 
 export function metaCoreLabel(key: MetaCoreLabelKey, isZh: boolean): string {
@@ -339,4 +344,12 @@ export function attachmentActivityLabel(
   if (activity === 'removing') return isZh ? '正在移除...' : 'Removing...'
   if (activity === 'clearing') return isZh ? '正在清空...' : 'Clearing...'
   return isZh ? '正在上传...' : 'Uploading...'
+}
+
+// --- A3: AI shortcut per-run tokens (§2.4 user visibility) ---
+// Shared by MetaRecordDrawer (run/preview result) and MetaFieldManager
+// (config-time preview result). Lives HERE once — never redeclared in
+// meta-record-labels / meta-manager-labels (cross-module reuse, documented).
+export function aiTokensConsumed(tokens: number, isZh: boolean): string {
+  return isZh ? `本次消耗 ~${tokens} tokens` : `~${tokens} tokens used`
 }

--- a/apps/web/src/multitable/utils/meta-manager-labels.ts
+++ b/apps/web/src/multitable/utils/meta-manager-labels.ts
@@ -55,6 +55,18 @@ export type MetaManagerLabelKey =
   | 'field.error.autoNumberPrefix'
   | 'field.error.autoNumberDigits'
   | 'field.error.autoNumberStart'
+  // --- AI shortcut config section (A3 §2.1) ---
+  | 'field.ai.title' | 'field.ai.enable'
+  | 'field.ai.kind' | 'field.ai.sourceFields' | 'field.ai.sourceHint'
+  | 'field.ai.options' | 'field.ai.optionPlaceholder'
+  | 'field.ai.targetLang' | 'field.ai.instruction'
+  | 'field.ai.previewWithRecord' | 'field.ai.previewNeedsRecord'
+  | 'field.ai.previewRealCallHint' | 'field.ai.previewDraftHint'
+  | 'field.ai.previewing' | 'field.ai.previewResult'
+  | 'field.error.aiSourceRequired' | 'field.error.aiSourceTooMany'
+  | 'field.error.aiOptionsTooMany' | 'field.error.aiOptionTooLong'
+  | 'field.error.aiTargetLangTooLong' | 'field.error.aiInstructionTooLong'
+  | 'field.aiUsage.title' | 'field.aiUsage.today' | 'field.aiUsage.week' | 'field.aiUsage.instance'
   | 'view.title' | 'view.empty' | 'view.saveSettings'
   | 'view.namePlaceholder' | 'view.addButton'
   | 'view.titleField' | 'view.coverField' | 'view.cardFields'
@@ -219,6 +231,38 @@ const LABELS: Record<MetaManagerLabelKey, { en: string; zh: string }> = {
   'field.error.autoNumberDigits': { en: 'Auto number digits must be between 0 and 12', zh: '自动编号位数必须在 0 到 12 之间' },
   'field.error.autoNumberStart': { en: 'Auto number start must be at least 1', zh: '自动编号起始值至少为 1' },
 
+  // --- AI shortcut config section (A3 §2.1). zh keeps the product term
+  // "AI shortcut" / "token" raw (same convention as persisted enum values). ---
+  'field.ai.title': { en: 'AI shortcut', zh: 'AI shortcut' },
+  'field.ai.enable': { en: 'Enable AI shortcut', zh: '启用 AI shortcut' },
+  'field.ai.kind': { en: 'Task type', zh: '任务类型' },
+  'field.ai.sourceFields': { en: 'Source fields', zh: '来源字段' },
+  'field.ai.sourceHint': { en: 'Up to 20 source fields. Computed fields (formula/lookup/rollup) and the target field itself are excluded.', zh: '最多 20 个来源字段；公式/查找/汇总等计算字段及目标字段自身不可选。' },
+  'field.ai.options': { en: 'Categories', zh: '分类选项' },
+  'field.ai.optionPlaceholder': { en: 'Category text', zh: '分类文本' },
+  'field.ai.targetLang': { en: 'Target language', zh: '目标语言' },
+  'field.ai.instruction': { en: 'Additional instruction', zh: '附加指令' },
+  // §2.1 LOCKED preview copy: a config-time preview is a REAL provider call
+  // (consumes quota/tokens) and validates the DRAFT, not the saved config.
+  'field.ai.previewWithRecord': { en: 'Preview with current record', zh: '用当前记录预览' },
+  'field.ai.previewNeedsRecord': { en: 'Select a record in the grid to enable preview.', zh: '请先在表格中选择一条记录后再预览。' },
+  'field.ai.previewRealCallHint': { en: 'Preview makes a real AI call and consumes quota and tokens.', zh: '预览为真实 AI 调用，会消耗配额与 token。' },
+  'field.ai.previewDraftHint': { en: 'Preview validates the current draft config, not the saved one.', zh: '预览验证的是当前草稿配置，而非已保存的配置。' },
+  'field.ai.previewing': { en: 'Previewing...', zh: '正在预览...' },
+  'field.ai.previewResult': { en: 'Preview result', zh: '预览结果' },
+  // Client-side constraint mirrors of the A2 config governance caps.
+  'field.error.aiSourceRequired': { en: 'Select at least one source field for the AI shortcut', zh: '请为 AI shortcut 至少选择一个来源字段' },
+  'field.error.aiSourceTooMany': { en: 'AI shortcut allows at most 20 source fields', zh: 'AI shortcut 来源字段最多 20 个' },
+  'field.error.aiOptionsTooMany': { en: 'AI shortcut allows at most 50 categories', zh: 'AI shortcut 分类选项最多 50 个' },
+  'field.error.aiOptionTooLong': { en: 'Each category must be at most 100 characters', zh: '每个分类选项最长 100 字符' },
+  'field.error.aiTargetLangTooLong': { en: 'Target language must be at most 32 characters', zh: '目标语言最长 32 字符' },
+  'field.error.aiInstructionTooLong': { en: 'Instruction must be at most 500 characters', zh: '附加指令最长 500 字符' },
+  // Admin usage card (§2.4): caller's own token windows + instance USD.
+  'field.aiUsage.title': { en: 'AI usage (admin)', zh: 'AI 用量（管理员）' },
+  'field.aiUsage.today': { en: 'My tokens today', zh: '我今日 tokens' },
+  'field.aiUsage.week': { en: 'My tokens this week', zh: '我本周 tokens' },
+  'field.aiUsage.instance': { en: 'Instance USD today', zh: '实例今日 USD' },
+
   'view.title': { en: 'Manage Views', zh: '管理视图' },
   'view.empty': { en: 'No views defined', zh: '暂无视图' },
   'view.saveSettings': { en: 'Save view settings', zh: '保存视图设置' },
@@ -338,6 +382,22 @@ export function fieldOptionRequired(type: string, isZh: boolean): string {
 
 export function configureView(name: string, isZh: boolean): string {
   return isZh ? `配置 ${name}` : `Configure ${name}`
+}
+
+// aiShortcutKindLabel: display labels for the A2-pinned kind enum. The
+// persisted enum VALUES (summarize/classify/extract/translate) stay raw —
+// only the display text localizes (persisted-enum bucketing convention).
+const AI_SHORTCUT_KIND_LABELS: Record<string, { en: string; zh: string }> = {
+  summarize: { en: 'Summarize', zh: '摘要' },
+  classify: { en: 'Classify', zh: '分类' },
+  extract: { en: 'Extract', zh: '提取' },
+  translate: { en: 'Translate', zh: '翻译' },
+}
+
+export function aiShortcutKindLabel(kind: string, isZh: boolean): string {
+  const entry = AI_SHORTCUT_KIND_LABELS[kind]
+  if (!entry) return kind
+  return isZh ? entry.zh : entry.en
 }
 
 const VIEW_TYPE_LABELS: Record<string, { en: string; zh: string }> = {

--- a/apps/web/src/multitable/utils/meta-record-labels.ts
+++ b/apps/web/src/multitable/utils/meta-record-labels.ts
@@ -39,6 +39,10 @@ export type MetaRecordLabelKey =
   // pattern from T3A2). Backend error.message remains raw when present.
   | 'record.errorHistoryLoad' | 'record.errorWatchLoad' | 'record.errorWatchUpdate'
   | 'record.noRecord'
+  // --- AI shortcut field-header actions (A3-T3) ---
+  | 'record.aiPreview' | 'record.aiRun'
+  | 'record.aiPreviewTitle' | 'record.aiRunTitle'
+  | 'record.aiPending'
   // --- MetaFormView static ---
   | 'form.loading' | 'form.readOnly'
   | 'form.discardConfirm'
@@ -72,6 +76,14 @@ const META_RECORD_LABELS: Record<MetaRecordLabelKey, { en: string; zh: string }>
   'record.errorWatchLoad': { en: 'Failed to load watch status', zh: '加载关注状态失败' },
   'record.errorWatchUpdate': { en: 'Failed to update watch status', zh: '更新关注状态失败' },
   'record.noRecord': { en: 'No record selected', zh: '未选择记录' },
+  // A3: AI shortcut actions. Preview is gated on field readability (a visible
+  // drawer field IS readable); run is additionally gated on canEditField —
+  // mirroring the backend preview/run gates.
+  'record.aiPreview': { en: 'AI preview', zh: 'AI 预览' },
+  'record.aiRun': { en: 'AI run', zh: 'AI 运行' },
+  'record.aiPreviewTitle': { en: 'Preview the AI output (real call, consumes quota)', zh: '预览 AI 输出（真实调用，消耗配额）' },
+  'record.aiRunTitle': { en: 'Run AI and write the output into this field', zh: '运行 AI 并将结果写入此字段' },
+  'record.aiPending': { en: 'AI request in progress...', zh: 'AI 请求处理中...' },
 
   'form.loading': { en: 'Loading...', zh: '正在加载...' },
   'form.readOnly': { en: 'This form is read-only', zh: '此表单为只读' },

--- a/apps/web/src/multitable/views/MultitableWorkbench.vue
+++ b/apps/web/src/multitable/views/MultitableWorkbench.vue
@@ -258,6 +258,9 @@
           :can-comment="effectiveRowActions.canComment"
           :comment-presence="commentPresenceState.presenceByRecordId.value"
           :conditional-formatting="conditionalFormattingByRecord"
+          :ai-run-enabled="effectiveRowActions.canEdit"
+          :ai-run-pending="Boolean(aiShortcut.state.pending)"
+          :ai-run-busy="aiShortcutBusy"
           @select-record="onSelectRecord" @toggle-sort="onToggleSort" @patch-cell="onPatchCell"
           @go-to-page="grid.goToPage" @open-link-picker="onGridLinkPicker" @resize-column="grid.setColumnWidth"
           @bulk-delete="onBulkDelete" @bulk-edit="onBulkEditRequest" @reorder-field="onReorderField"
@@ -266,6 +269,7 @@
           @set-aggregation="onSetAggregation"
           @open-comments="onOpenRecordComments"
           @open-field-comments="onOpenGridFieldComments"
+          @ai-run="onGridAiRun"
         />
       </div>
       <MetaRecordDrawer
@@ -280,9 +284,11 @@
         :record-ids="drawerRecordIds"
         :upload-fn="uploadAttachmentFn"
         :delete-attachment-fn="deleteAttachmentFn"
+        :ai-shortcut="aiShortcut.state"
         @close="onCloseDrawer" @delete="onDeleteRecord" @patch="onDrawerPatch"
         @toggle-comments="onToggleComments" @comment-field="onToggleFieldComments" @open-automation="openWorkflowDesigner(selectedRecordId ?? undefined)" @open-link-picker="openLinkPicker"
         @navigate="onDrawerNavigate"
+        @ai-preview="onAiPreviewField" @ai-run="onAiRunField"
       />
       <MetaCommentsDrawer
         :visible="showComments && !!selectedRecordId" :comments="commentsState.comments.value"
@@ -354,6 +360,9 @@
       :visible="showFieldManager" :fields="propertyVisibleWorkbenchFields" :sheets="workbench.sheets.value" :sheet-id="workbench.activeSheetId.value"
       :dry-run-fn="dryRunFormulaFn"
       :current-record-id="selectedRecordId"
+      :ai-preview-fn="aiPreviewFn"
+      :ai-preview-busy="aiShortcutBusy"
+      :ai-usage-summary-fn="aiUsageSummaryFn"
       @update:dirty="fieldManagerDirty = $event"
       @close="showFieldManager = false" @create-field="onCreateField" @update-field="onUpdateField" @delete-field="onDeleteField"
     />
@@ -514,6 +523,8 @@ import {
 } from '../utils/calendar-holiday-notice'
 import { addPeopleLookupToken, inferPeopleLookupKind, resolvePeopleImportValue } from '../utils/people-import'
 import { parseFrozenIds } from '../utils/frozen-columns'
+import { useAiShortcut } from '../composables/useAiShortcut'
+import type { AiShortcutConfigInput } from '../api/client'
 import { buildRecordFormattingMap, extractRulesFromConfig } from '../utils/conditional-formatting'
 import {
   decorateAndSortBases,
@@ -562,6 +573,43 @@ const sheetPresenceState = useMultitableSheetPresence({
 })
 
 const selectedRecordId = ref<string | null>(null)
+
+// --- A3: AI field shortcut — ONE instance drives all three trigger surfaces
+// (drawer preview/run, cell-editor run, field-manager config-time preview) so
+// the in-flight pending guard is unified (LOCKED §2.2).
+const aiShortcut = useAiShortcut({
+  client: workbench.client,
+  sheetId: () => workbench.activeSheetId.value,
+  getLocalRecordVersion: (recordId) => grid.rows.value.find((row) => row.id === recordId)?.version,
+  applyPatchResult: grid.applyPatchResult,
+})
+// Review F3: the unified busy signal (in-flight OR rate-limit countdown)
+// reaches ALL trigger surfaces — drawer (via aiShortcut.state), cell-editor
+// run button (aiRunBusy) and field-manager config preview (aiPreviewBusy) —
+// so no surface offers a click the composable guard would silently refuse.
+const aiShortcutBusy = aiShortcut.busy
+
+function onAiPreviewField(field: MetaField) {
+  const recordId = selectedRecordId.value
+  if (recordId) void aiShortcut.preview(recordId, field.id)
+}
+
+function onAiRunField(field: MetaField) {
+  const recordId = selectedRecordId.value
+  if (recordId) void aiShortcut.run(recordId, field.id)
+}
+
+function onGridAiRun(recordId: string, field: MetaField) {
+  void aiShortcut.run(recordId, field.id)
+}
+
+// MetaFieldManager is emit/fn-prop based (dryRunFn precedent): config-time
+// preview routes through the SAME composable guard; usage summary is the raw
+// client call (403 probe caching lives in fetchAiUsageSummaryWithProbeCache).
+const aiPreviewFn = (params: { recordId: string; config: AiShortcutConfigInput }) =>
+  aiShortcut.previewWithConfig(params.recordId, params.config)
+const aiUsageSummaryFn = () => workbench.client.aiUsageSummary()
+
 const showComments = ref(false)
 const selectedCommentFieldId = ref<string | null>(null)
 const selectedReplyCommentId = ref<string | null>(null)

--- a/apps/web/tests/meta-api-error-labels.spec.ts
+++ b/apps/web/tests/meta-api-error-labels.spec.ts
@@ -2,6 +2,8 @@ import { describe, expect, it } from 'vitest'
 
 import {
   META_API_ERROR_LABEL_KEYS,
+  aiRetryCountdown,
+  aiShortcutErrorMessage,
   apiDefaultErrorMessage,
   apiFieldValidationFallback,
   metaApiErrorLabel,
@@ -14,12 +16,37 @@ describe('meta-api-error-labels', () => {
       'error.unauthenticated',
       'error.validation',
       'error.fieldValidation',
+      // A3 AI shortcut state copy (§2.3) — keyed on error.code.
+      'error.aiBlocked',
+      'error.aiRateLimited',
+      'error.aiQuotaExhausted',
+      'error.aiUnsafeInput',
+      'error.aiProviderError',
+      'error.aiVersionConflict',
     ])
 
     for (const key of META_API_ERROR_LABEL_KEYS) {
       expect(metaApiErrorLabel(key, false)).toBeTruthy()
       expect(metaApiErrorLabel(key, true)).toBeTruthy()
     }
+  })
+
+  it('A3-T8: maps every AI shortcut error code to §2.3 copy in both locales; unknown codes → null', () => {
+    const codes = ['AI_BLOCKED', 'RATE_LIMITED', 'AI_QUOTA_EXHAUSTED', 'AI_UNSAFE_INPUT', 'AI_PROVIDER_ERROR', 'VERSION_CONFLICT']
+    for (const code of codes) {
+      expect(aiShortcutErrorMessage(code, false)).toBeTruthy()
+      expect(aiShortcutErrorMessage(code, true)).toBeTruthy()
+    }
+    // AI_BLOCKED has dedicated readiness copy — never a generic 5xx message.
+    expect(aiShortcutErrorMessage('AI_BLOCKED', true)).toContain('管理员')
+    // Unknown codes fall back to the raw backend message at the caller.
+    expect(aiShortcutErrorMessage('SOMETHING_NEW', false)).toBeNull()
+    expect(aiShortcutErrorMessage(undefined, false)).toBeNull()
+  })
+
+  it('A3-T8: rate-limit countdown copy interpolates the seconds in both locales', () => {
+    expect(aiRetryCountdown(5, false)).toBe('Retry in 5s')
+    expect(aiRetryCountdown(5, true)).toBe('5 秒后可重试')
   })
 
   it('localizes static fallback labels', () => {

--- a/apps/web/tests/multitable-ai-shortcut-cell-editor.spec.ts
+++ b/apps/web/tests/multitable-ai-shortcut-cell-editor.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * A3 MetaCellEditor edit-mode run button — matrix leg A3-T6. The button's
+ * RBAC safety relies on the upstream invariant that the editor only opens for
+ * editable cells (LOCKED §2.2 — invariant documented in the component).
+ *
+ * Review F3: the RATE_LIMITED countdown (busy) disables this surface exactly
+ * like the drawer's aiBusy, and the MetaGridTable host must NOT close the
+ * edit session for a click the composable guard would silently refuse.
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import MetaCellEditor from '../src/multitable/components/cells/MetaCellEditor.vue'
+import MetaGridTable from '../src/multitable/components/MetaGridTable.vue'
+import type { MetaField } from '../src/multitable/types'
+import { useLocale } from '../src/composables/useLocale'
+
+const AI_FIELD = {
+  id: 'fld_t',
+  name: 'Summary',
+  type: 'string',
+  property: { aiShortcut: { kind: 'summarize', sourceFieldIds: ['fld_src'] } },
+} as unknown as MetaField
+
+const PLAIN_FIELD = { id: 'fld_p', name: 'Plain', type: 'string', property: {} } as unknown as MetaField
+
+interface HarnessOptions {
+  field?: MetaField
+  aiRunState?: { pending: boolean; busy: boolean } | null
+  onAiRun?: () => void
+}
+
+function mountEditor(options: HarnessOptions = {}): { container: HTMLElement; app: App } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({
+    render() {
+      return h(MetaCellEditor, {
+        field: options.field ?? AI_FIELD,
+        modelValue: 'text',
+        aiRunState: options.aiRunState ?? null,
+        ...(options.onAiRun ? { onAiRun: options.onAiRun } : {}),
+      })
+    },
+  })
+  app.mount(container)
+  return { container, app }
+}
+
+describe('MetaCellEditor AI run button (A3-T6)', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('renders in edit mode for an aiShortcut-configured string field when the host opts in', async () => {
+    const runSpy = vi.fn()
+    const { container, app } = mountEditor({ aiRunState: { pending: false, busy: false }, onAiRun: runSpy })
+    await nextTick()
+
+    const button = container.querySelector('[data-test="cell-ai-run"]') as HTMLButtonElement
+    expect(button).toBeTruthy()
+    expect(button.disabled).toBe(false)
+    button.click()
+    expect(runSpy).toHaveBeenCalledTimes(1)
+    app.unmount()
+  })
+
+  it('pending state disables the button (reentrancy at the entry point)', async () => {
+    const { container, app } = mountEditor({ aiRunState: { pending: true, busy: true } })
+    await nextTick()
+    expect((container.querySelector('[data-test="cell-ai-run"]') as HTMLButtonElement).disabled).toBe(true)
+    app.unmount()
+  })
+
+  it('review F3: RATE_LIMITED countdown (busy, not pending) disables the button — click never fires', async () => {
+    useLocale().setLocale('en')
+    const runSpy = vi.fn()
+    const { container, app } = mountEditor({ aiRunState: { pending: false, busy: true }, onAiRun: runSpy })
+    await nextTick()
+
+    const button = container.querySelector('[data-test="cell-ai-run"]') as HTMLButtonElement
+    expect(button.disabled).toBe(true)
+    // Countdown is NOT a running request — the label must not lie.
+    expect(button.textContent).toBe('Run AI')
+    button.click() // disabled → activation suppressed, no emit
+    expect(runSpy).not.toHaveBeenCalled()
+    app.unmount()
+  })
+
+  it('absent without host opt-in (aiRunState null) — bulk-edit and other hosts stay untouched', async () => {
+    const { container, app } = mountEditor({ aiRunState: null })
+    await nextTick()
+    expect(container.querySelector('[data-test="cell-ai-run"]')).toBeNull()
+    app.unmount()
+  })
+
+  it('absent for fields without a persisted aiShortcut config', async () => {
+    const { container, app } = mountEditor({ field: PLAIN_FIELD, aiRunState: { pending: false, busy: false } })
+    await nextTick()
+    expect(container.querySelector('[data-test="cell-ai-run"]')).toBeNull()
+    app.unmount()
+  })
+})
+
+// --- Review F3: grid-level guard — a busy click must NOT destroy the edit session ---
+
+function mountGrid(options: { aiRunBusy: boolean; onAiRun?: (recordId: string, field: MetaField) => void }): {
+  container: HTMLElement
+  app: App
+} {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({
+    render() {
+      return h(MetaGridTable, {
+        rows: [{ id: 'rec_1', version: 1, data: { fld_t: 'text' } }],
+        visibleFields: [AI_FIELD],
+        sortRules: [],
+        loading: false,
+        currentPage: 1,
+        totalPages: 1,
+        startIndex: 0,
+        canEdit: true,
+        searchText: '',
+        rowDensity: 'normal',
+        aiRunEnabled: true,
+        aiRunPending: false,
+        aiRunBusy: options.aiRunBusy,
+        ...(options.onAiRun ? { onAiRun: options.onAiRun } : {}),
+      })
+    },
+  })
+  app.mount(container)
+  return { container, app }
+}
+
+async function openCellEditor(container: HTMLElement): Promise<HTMLButtonElement> {
+  const cell = container.querySelector('.meta-grid__cell') as HTMLElement
+  cell.dispatchEvent(new MouseEvent('dblclick', { bubbles: true }))
+  await nextTick()
+  const button = container.querySelector('[data-test="cell-ai-run"]') as HTMLButtonElement
+  expect(button, 'cell AI run button after entering edit mode').toBeTruthy()
+  return button
+}
+
+describe('MetaGridTable AI run during countdown (review F3)', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('busy (countdown): button disabled; even a forced click keeps the edit session open and emits nothing', async () => {
+    const runSpy = vi.fn()
+    const { container, app } = mountGrid({ aiRunBusy: true, onAiRun: runSpy })
+    const button = await openCellEditor(container)
+
+    expect(button.disabled).toBe(true)
+    // dispatchEvent bypasses the disabled activation suppression — the host
+    // guard must still refuse without calling cancelEdit().
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await nextTick()
+
+    expect(runSpy).not.toHaveBeenCalled()
+    // Edit session survives — the editor (and its run button) is still mounted.
+    expect(container.querySelector('[data-test="cell-ai-run"]')).toBeTruthy()
+    app.unmount()
+  })
+
+  it('not busy: click closes the edit session first, then emits ai-run (stale-draft hazard stays closed)', async () => {
+    const runSpy = vi.fn()
+    const { container, app } = mountGrid({ aiRunBusy: false, onAiRun: runSpy })
+    const button = await openCellEditor(container)
+
+    expect(button.disabled).toBe(false)
+    button.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await nextTick()
+
+    expect(runSpy).toHaveBeenCalledTimes(1)
+    expect(runSpy.mock.calls[0][0]).toBe('rec_1')
+    expect(container.querySelector('[data-test="cell-ai-run"]')).toBeNull() // editor closed before the run
+    app.unmount()
+  })
+})

--- a/apps/web/tests/multitable-ai-shortcut-client.spec.ts
+++ b/apps/web/tests/multitable-ai-shortcut-client.spec.ts
@@ -1,0 +1,162 @@
+/**
+ * A3 client functions — aiShortcutPreview / aiShortcutRun / aiUsageSummary
+ * (docs/development/multitable-ai-shortcut-frontend-a3-design-20260611.md §2.3,
+ * matrix legs A3-T2 (client) / A3-T4 (wire parse) / A3-T5 (dual-429)).
+ *
+ * The wire fixtures mirror the PINNED A2 route responses
+ * (packages/core-backend/src/routes/multitable-ai.ts:555-569 +
+ * tests/integration/multitable-ai-shortcut-run.test.ts key-set pin).
+ */
+import { describe, expect, it, vi } from 'vitest'
+import { MultitableApiClient } from '../src/multitable/api/client'
+
+type ApiErr = Error & {
+  status?: number
+  code?: string
+  serverVersion?: number
+  retryAfterMs?: number
+}
+
+function jsonResponse(body: unknown, init?: { status?: number; headers?: Record<string, string> }): Response {
+  return new Response(JSON.stringify(body), {
+    status: init?.status ?? 200,
+    headers: { 'content-type': 'application/json', ...(init?.headers ?? {}) },
+  })
+}
+
+const PREVIEW_WIRE = {
+  ok: true,
+  data: {
+    status: 'succeeded',
+    action: 'preview',
+    output: 'PREVIEW OUT',
+    usage: { promptTokens: 9, completionTokens: 4 },
+    estimatedCostUsd: 0.0001,
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
+  },
+}
+
+const RUN_WIRE = {
+  ok: true,
+  data: {
+    status: 'succeeded',
+    action: 'run',
+    recordId: 'rec_1',
+    fieldId: 'fld_t',
+    version: 2,
+    output: 'AI OUT',
+    usage: { promptTokens: 21, completionTokens: 13 },
+    estimatedCostUsd: 0.0002,
+    provider: 'anthropic',
+    model: 'claude-sonnet-4-6',
+  },
+}
+
+describe('MultitableApiClient AI shortcut (A3)', () => {
+  it('aiShortcutPreview posts inline draft config + recordId and unwraps the data envelope (A3-T2)', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse(PREVIEW_WIRE))
+    const client = new MultitableApiClient({ fetchFn })
+
+    const config = { kind: 'classify' as const, sourceFieldIds: ['fld_src'], params: { options: ['A', 'B'] } }
+    const data = await client.aiShortcutPreview('sheet_1', { recordId: 'rec_1', config })
+
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/multitable/sheets/sheet_1/ai/shortcut/preview')
+    expect(init.method).toBe('POST')
+    expect(JSON.parse(String(init.body))).toEqual({ recordId: 'rec_1', config })
+    expect(data).toEqual(PREVIEW_WIRE.data)
+  })
+
+  it('aiShortcutPreview posts a persisted fieldId without a config key (drawer path)', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse(PREVIEW_WIRE))
+    const client = new MultitableApiClient({ fetchFn })
+
+    await client.aiShortcutPreview('sheet_1', { recordId: 'rec_1', fieldId: 'fld_t' })
+
+    const body = JSON.parse(String((fetchFn.mock.calls[0] as [string, RequestInit])[1].body))
+    expect(body).toEqual({ recordId: 'rec_1', fieldId: 'fld_t' })
+    expect('config' in body).toBe(false)
+  })
+
+  it('aiShortcutRun posts ONLY {recordId, fieldId} (run rejects inline config server-side) and parses the run wire', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse(RUN_WIRE))
+    const client = new MultitableApiClient({ fetchFn })
+
+    const data = await client.aiShortcutRun('sheet_1', { recordId: 'rec_1', fieldId: 'fld_t' })
+
+    const [url, init] = fetchFn.mock.calls[0] as [string, RequestInit]
+    expect(url).toBe('/api/multitable/sheets/sheet_1/ai/shortcut/run')
+    expect(JSON.parse(String(init.body))).toEqual({ recordId: 'rec_1', fieldId: 'fld_t' })
+    expect(data).toEqual(RUN_WIRE.data)
+  })
+
+  it('aiShortcutRun keeps version === null intact (adapter must skip the version merge)', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ ok: true, data: { ...RUN_WIRE.data, version: null } }))
+    const client = new MultitableApiClient({ fetchFn })
+
+    const data = await client.aiShortcutRun('sheet_1', { recordId: 'rec_1', fieldId: 'fld_t' })
+    expect(data.version).toBeNull()
+  })
+
+  it('aiUsageSummary GETs the admin summary (flat single-object response)', async () => {
+    const summary = {
+      callerDayTokens: 123,
+      callerWeekTokens: 456,
+      instanceDayUsd: 7.89,
+      caps: { tenantDailyTokenCap: 111000, tenantWeeklyTokenCap: 555000, accountDailyUsdCap: 12 },
+    }
+    const fetchFn = vi.fn(async () => jsonResponse(summary))
+    const client = new MultitableApiClient({ fetchFn })
+
+    const data = await client.aiUsageSummary()
+    expect(fetchFn.mock.calls[0][0]).toBe('/api/multitable/ai/usage-summary')
+    expect(data).toEqual(summary)
+  })
+
+  it('A3-T5 dual-429: RATE_LIMITED carries retryAfterMs from Retry-After; AI_QUOTA_EXHAUSTED has none', async () => {
+    const limited = new MultitableApiClient({
+      fetchFn: vi.fn(async () => jsonResponse(
+        { ok: false, status: 'rate_limited', error: { code: 'RATE_LIMITED', message: 'Too many AI shortcut requests.', retryAfter: 7 } },
+        { status: 429, headers: { 'Retry-After': '7' } },
+      )),
+    })
+    const limitedErr = await limited.aiShortcutRun('sheet_1', { recordId: 'rec_1', fieldId: 'fld_t' }).catch((e: ApiErr) => e)
+    expect(limitedErr.status).toBe(429)
+    expect(limitedErr.code).toBe('RATE_LIMITED')
+    expect(limitedErr.retryAfterMs).toBe(7000)
+
+    const quota = new MultitableApiClient({
+      fetchFn: vi.fn(async () => jsonResponse(
+        { ok: false, status: 'quota_exhausted', error: { code: 'AI_QUOTA_EXHAUSTED', message: 'AI usage quota exhausted (user_daily_tokens).' } },
+        { status: 429 }, // quota 429 has NO Retry-After (pinned contract)
+      )),
+    })
+    const quotaErr = await quota.aiShortcutRun('sheet_1', { recordId: 'rec_1', fieldId: 'fld_t' }).catch((e: ApiErr) => e)
+    expect(quotaErr.status).toBe(429)
+    expect(quotaErr.code).toBe('AI_QUOTA_EXHAUSTED')
+    expect(quotaErr.retryAfterMs).toBeUndefined()
+  })
+
+  it('A3-T5: 503 AI_BLOCKED / 422 AI_UNSAFE_INPUT / 502 AI_PROVIDER_ERROR / 409 VERSION_CONFLICT codes survive parseJson', async () => {
+    const cases: Array<{ status: number; code: string; extra?: Record<string, unknown> }> = [
+      { status: 503, code: 'AI_BLOCKED' },
+      { status: 422, code: 'AI_UNSAFE_INPUT' },
+      { status: 502, code: 'AI_PROVIDER_ERROR' },
+      { status: 409, code: 'VERSION_CONFLICT', extra: { serverVersion: 9 } },
+    ]
+    for (const testCase of cases) {
+      const client = new MultitableApiClient({
+        fetchFn: vi.fn(async () => jsonResponse(
+          { ok: false, error: { code: testCase.code, message: `${testCase.code} happened`, ...(testCase.extra ?? {}) } },
+          { status: testCase.status },
+        )),
+      })
+      const err = await client.aiShortcutRun('sheet_1', { recordId: 'rec_1', fieldId: 'fld_t' }).catch((e: ApiErr) => e)
+      expect(err.status).toBe(testCase.status)
+      expect(err.code).toBe(testCase.code)
+      if (testCase.extra?.serverVersion) expect(err.serverVersion).toBe(9)
+    }
+  })
+})

--- a/apps/web/tests/multitable-ai-shortcut-composable.spec.ts
+++ b/apps/web/tests/multitable-ai-shortcut-composable.spec.ts
@@ -1,0 +1,314 @@
+/**
+ * A3 useAiShortcut composable — matrix legs A3-T4 (run-response adapter against
+ * the REAL wire shape) / A3-T4b (local-version drift guard + review-F4
+ * own-Yjs-echo carve-out) / A3-T5 (error states keyed on error.code, dual-429
+ * semantics) / A3-T5b (reentrancy + review-F3 unified `busy` exposure).
+ *
+ * Wire fidelity: every test drives the REAL MultitableApiClient.parseJson over
+ * route-shaped JSON — the RUN_WIRE fixture key set is PINNED route-level by
+ * packages/core-backend/tests/integration/multitable-ai-shortcut-run.test.ts
+ * (A2-T5 Object.keys assertion). Zero real provider calls: fetchFn is stubbed.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { MultitableApiClient } from '../src/multitable/api/client'
+import {
+  adaptAiShortcutRunResult,
+  fetchAiUsageSummaryWithProbeCache,
+  resetAiUsageSummarySessionCache,
+  useAiShortcut,
+} from '../src/multitable/composables/useAiShortcut'
+import type { PatchResult } from '../src/multitable/types'
+
+// PINNED run wire shape (backend integration A2-T5 key-set assertion mirrors this).
+const RUN_WIRE_DATA = {
+  status: 'succeeded',
+  action: 'run',
+  recordId: 'rec_1',
+  fieldId: 'fld_t',
+  version: 2,
+  output: 'AI OUT',
+  usage: { promptTokens: 21, completionTokens: 13 },
+  estimatedCostUsd: 0.0002,
+  provider: 'anthropic',
+  model: 'claude-sonnet-4-6',
+}
+
+const PREVIEW_WIRE_DATA = {
+  status: 'succeeded',
+  action: 'preview',
+  output: 'PREVIEW OUT',
+  usage: { promptTokens: 9, completionTokens: 4 },
+  estimatedCostUsd: 0.0001,
+  provider: 'anthropic',
+  model: 'claude-sonnet-4-6',
+}
+
+function jsonResponse(body: unknown, init?: { status?: number; headers?: Record<string, string> }): Response {
+  return new Response(JSON.stringify(body), {
+    status: init?.status ?? 200,
+    headers: { 'content-type': 'application/json', ...(init?.headers ?? {}) },
+  })
+}
+
+function setup(fetchFn: (input: string, init?: RequestInit) => Promise<Response>) {
+  const client = new MultitableApiClient({ fetchFn })
+  const applied: PatchResult[] = []
+  const versionRef = { current: 1 as number | undefined }
+  const ai = useAiShortcut({
+    client,
+    sheetId: () => 'sheet_1',
+    getLocalRecordVersion: () => versionRef.current,
+    applyPatchResult: (result) => applied.push(result),
+  })
+  return { ai, applied, versionRef }
+}
+
+describe('adaptAiShortcutRunResult (A3-T4 adapter)', () => {
+  it('synthesizes {updated, records} for applyPatchResult from the pinned run wire', () => {
+    expect(adaptAiShortcutRunResult(RUN_WIRE_DATA as never)).toEqual({
+      updated: [{ recordId: 'rec_1', version: 2 }],
+      records: [{ recordId: 'rec_1', data: { fld_t: 'AI OUT' } }],
+    })
+  })
+
+  it('version === null → skips the version write, still merges the value', () => {
+    expect(adaptAiShortcutRunResult({ ...RUN_WIRE_DATA, version: null } as never)).toEqual({
+      updated: [],
+      records: [{ recordId: 'rec_1', data: { fld_t: 'AI OUT' } }],
+    })
+  })
+})
+
+describe('useAiShortcut', () => {
+  beforeEach(() => {
+    resetAiUsageSummarySessionCache()
+  })
+
+  afterEach(() => {
+    vi.useRealTimers()
+  })
+
+  it('A3-T4: run feeds the adapter output through applyPatchResult and exposes per-run tokens', async () => {
+    const { ai, applied } = setup(async () => jsonResponse({ ok: true, data: RUN_WIRE_DATA }))
+
+    await ai.run('rec_1', 'fld_t')
+
+    expect(applied).toEqual([{
+      updated: [{ recordId: 'rec_1', version: 2 }],
+      records: [{ recordId: 'rec_1', data: { fld_t: 'AI OUT' } }],
+    }])
+    expect(ai.state.result).toMatchObject({
+      kind: 'run',
+      recordId: 'rec_1',
+      fieldId: 'fld_t',
+      output: 'AI OUT',
+      promptTokens: 21,
+      completionTokens: 13,
+      totalTokens: 34,
+      merged: true,
+      refreshHint: false,
+    })
+    expect(ai.state.error).toBeNull()
+    expect(ai.state.pending).toBeNull()
+  })
+
+  it('A3-T4: version === null on the wire → merge value only (no version entry)', async () => {
+    const { ai, applied } = setup(async () => jsonResponse({ ok: true, data: { ...RUN_WIRE_DATA, version: null } }))
+
+    await ai.run('rec_1', 'fld_t')
+    expect(applied[0].updated).toEqual([])
+    expect(applied[0].records).toEqual([{ recordId: 'rec_1', data: { fld_t: 'AI OUT' } }])
+  })
+
+  it('A3-T4b: genuine drift (local version ≠ captured AND ≠ response) → skip merge + refresh hint', async () => {
+    let bump: (() => void) | null = null
+    const { ai, applied, versionRef } = setup(async () => {
+      bump?.()
+      return jsonResponse({ ok: true, data: RUN_WIRE_DATA })
+    })
+    versionRef.current = 1
+    bump = () => { versionRef.current = 5 } // collaborator edit lands mid-flight (5 ≠ captured 1, ≠ response 2)
+
+    await ai.run('rec_1', 'fld_t')
+
+    expect(applied).toEqual([]) // merge skipped entirely — no silent overwrite
+    expect(ai.state.result).toMatchObject({ merged: false, refreshHint: true })
+  })
+
+  it('review F4: own Yjs echo (local version bumped to the RESPONSE version mid-flight) → success, NO refresh warning', async () => {
+    let bump: (() => void) | null = null
+    const { ai, applied, versionRef } = setup(async () => {
+      bump?.()
+      return jsonResponse({ ok: true, data: RUN_WIRE_DATA })
+    })
+    versionRef.current = 1
+    // The run's OWN write echoes back through the live Yjs session before the
+    // HTTP response lands: local version === response version (2).
+    bump = () => { versionRef.current = RUN_WIRE_DATA.version }
+
+    await ai.run('rec_1', 'fld_t')
+
+    expect(applied).toEqual([]) // already applied by the echo — redundant merge skipped silently
+    expect(ai.state.result).toMatchObject({
+      kind: 'run',
+      output: 'AI OUT',
+      totalTokens: 34, // tokens still shown
+      merged: true, // the output IS reflected locally
+      refreshHint: false, // and no false '记录已被他人更新' alarm
+    })
+    expect(ai.state.error).toBeNull()
+  })
+
+  it('A3-T5b: reentrancy — pending run blocks a second request (single fetch)', async () => {
+    let resolveFetch: ((res: Response) => void) | null = null
+    const fetchFn = vi.fn(() => new Promise<Response>((resolve) => { resolveFetch = resolve }))
+    const { ai } = setup(fetchFn as never)
+
+    const first = ai.run('rec_1', 'fld_t')
+    expect(ai.state.pending).toEqual({ kind: 'run', recordId: 'rec_1', fieldId: 'fld_t' })
+    await ai.run('rec_1', 'fld_t') // second entry while pending → no-op
+    await ai.preview('rec_1', 'fld_t') // any entry shares the guard
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+
+    resolveFetch!(jsonResponse({ ok: true, data: RUN_WIRE_DATA }))
+    await first
+    expect(ai.state.pending).toBeNull()
+  })
+
+  it('A3-T5: RATE_LIMITED → error code + retryAfterMs countdown that gates new requests', async () => {
+    vi.useFakeTimers()
+    const fetchFn = vi.fn(async () => jsonResponse(
+      { ok: false, status: 'rate_limited', error: { code: 'RATE_LIMITED', message: 'slow down', retryAfter: 3 } },
+      { status: 429, headers: { 'Retry-After': '3' } },
+    ))
+    const { ai } = setup(fetchFn as never)
+
+    await ai.run('rec_1', 'fld_t')
+    expect(ai.state.error?.code).toBe('RATE_LIMITED')
+    expect(ai.state.retryRemainingMs).toBe(3000)
+
+    await ai.run('rec_1', 'fld_t') // countdown gates all entries
+    expect(fetchFn).toHaveBeenCalledTimes(1)
+
+    await vi.advanceTimersByTimeAsync(4000)
+    expect(ai.state.retryRemainingMs).toBeNull()
+  })
+
+  it('review F3: `busy` mirrors the begin() guard — true while pending AND while the countdown runs', async () => {
+    vi.useFakeTimers()
+    let resolveFetch: ((res: Response) => void) | null = null
+    const fetchFn = vi.fn(() => new Promise<Response>((resolve) => { resolveFetch = resolve }))
+    const { ai } = setup(fetchFn as never)
+    expect(ai.busy.value).toBe(false)
+
+    const first = ai.run('rec_1', 'fld_t')
+    expect(ai.busy.value).toBe(true) // in-flight
+
+    resolveFetch!(jsonResponse(
+      { ok: false, status: 'rate_limited', error: { code: 'RATE_LIMITED', message: 'slow down', retryAfter: 3 } },
+      { status: 429, headers: { 'Retry-After': '3' } },
+    ))
+    await first
+    expect(ai.state.pending).toBeNull()
+    expect(ai.busy.value).toBe(true) // countdown active — every surface stays disabled
+
+    await vi.advanceTimersByTimeAsync(4000)
+    expect(ai.busy.value).toBe(false) // countdown expired — surfaces re-enable
+  })
+
+  it('A3-T5: AI_QUOTA_EXHAUSTED (429 WITHOUT Retry-After) → no countdown', async () => {
+    const { ai } = setup(async () => jsonResponse(
+      { ok: false, status: 'quota_exhausted', error: { code: 'AI_QUOTA_EXHAUSTED', message: 'quota' } },
+      { status: 429 },
+    ))
+    await ai.run('rec_1', 'fld_t')
+    expect(ai.state.error?.code).toBe('AI_QUOTA_EXHAUSTED')
+    expect(ai.state.retryRemainingMs).toBeNull()
+  })
+
+  it('A3-T5: AI_BLOCKED (503) keeps its own code — never collapsed into a generic 5xx bucket', async () => {
+    const { ai } = setup(async () => jsonResponse(
+      { ok: false, status: 'blocked', error: { code: 'AI_BLOCKED', message: 'not enabled' } },
+      { status: 503 },
+    ))
+    await ai.run('rec_1', 'fld_t')
+    expect(ai.state.error?.code).toBe('AI_BLOCKED')
+    expect(ai.state.error?.status).toBe(503)
+  })
+
+  it('A3-T5: AI_UNSAFE_INPUT (422) / AI_PROVIDER_ERROR (502) / VERSION_CONFLICT (409) map by error.code', async () => {
+    const cases = [
+      { status: 422, code: 'AI_UNSAFE_INPUT' },
+      { status: 502, code: 'AI_PROVIDER_ERROR' },
+      { status: 409, code: 'VERSION_CONFLICT' },
+    ]
+    for (const testCase of cases) {
+      const { ai, applied } = setup(async () => jsonResponse(
+        { ok: false, error: { code: testCase.code, message: 'x' } },
+        { status: testCase.status },
+      ))
+      await ai.run('rec_1', 'fld_t')
+      expect(ai.state.error?.code).toBe(testCase.code)
+      expect(applied).toEqual([]) // failed runs never merge
+    }
+  })
+
+  it('preview (persisted fieldId) records a preview result with tokens and no merge', async () => {
+    const { ai, applied } = setup(async () => jsonResponse({ ok: true, data: PREVIEW_WIRE_DATA }))
+    const data = await ai.preview('rec_1', 'fld_t')
+    expect(data?.output).toBe('PREVIEW OUT')
+    expect(applied).toEqual([])
+    expect(ai.state.result).toMatchObject({ kind: 'preview', totalTokens: 13, merged: false })
+  })
+
+  it('previewWithConfig posts the inline draft config and returns the outcome inline (manager path)', async () => {
+    const fetchFn = vi.fn(async () => jsonResponse({ ok: true, data: PREVIEW_WIRE_DATA }))
+    const { ai } = setup(fetchFn as never)
+
+    const config = { kind: 'summarize' as const, sourceFieldIds: ['fld_src'] }
+    const outcome = await ai.previewWithConfig('rec_cur', config)
+
+    const body = JSON.parse(String((fetchFn.mock.calls[0] as [string, RequestInit])[1].body))
+    expect(body).toEqual({ recordId: 'rec_cur', config })
+    expect(outcome && 'data' in outcome && outcome.data.output).toBe('PREVIEW OUT')
+  })
+
+  it('previewWithConfig surfaces errors inline (server config rejection keeps its code/message)', async () => {
+    const { ai } = setup(async () => jsonResponse(
+      { ok: false, error: { code: 'VALIDATION_ERROR', message: 'aiShortcut.kind must be one of...' } },
+      { status: 400 },
+    ))
+    const outcome = await ai.previewWithConfig('rec_cur', { kind: 'summarize', sourceFieldIds: ['fld_src'] })
+    expect(outcome && 'error' in outcome && outcome.error.code).toBe('VALIDATION_ERROR')
+    expect(outcome && 'error' in outcome && outcome.error.message).toContain('aiShortcut.kind')
+  })
+})
+
+describe('fetchAiUsageSummaryWithProbeCache (A3-T7 FE 403 session cache)', () => {
+  beforeEach(() => {
+    resetAiUsageSummarySessionCache()
+  })
+
+  it('403 probe is cached per session — the fetch fn is never re-invoked', async () => {
+    const forbidden = Object.assign(new Error('Insufficient permissions'), { status: 403 })
+    const fn = vi.fn(async () => { throw forbidden })
+
+    expect(await fetchAiUsageSummaryWithProbeCache(fn)).toBeNull()
+    expect(await fetchAiUsageSummaryWithProbeCache(fn)).toBeNull()
+    expect(fn).toHaveBeenCalledTimes(1)
+  })
+
+  it('success returns the summary; non-403 failures are NOT cached', async () => {
+    const summary = {
+      callerDayTokens: 1, callerWeekTokens: 2, instanceDayUsd: 0.3,
+      caps: { tenantDailyTokenCap: 10, tenantWeeklyTokenCap: 20, accountDailyUsdCap: 5 },
+    }
+    const flaky = vi.fn()
+      .mockRejectedValueOnce(Object.assign(new Error('boom'), { status: 500 }))
+      .mockResolvedValue(summary)
+
+    await expect(fetchAiUsageSummaryWithProbeCache(flaky as never)).rejects.toThrow('boom')
+    expect(await fetchAiUsageSummaryWithProbeCache(flaky as never)).toEqual(summary)
+    expect(flaky).toHaveBeenCalledTimes(2)
+  })
+})

--- a/apps/web/tests/multitable-ai-shortcut-drawer.spec.ts
+++ b/apps/web/tests/multitable-ai-shortcut-drawer.spec.ts
@@ -1,0 +1,183 @@
+/**
+ * A3 MetaRecordDrawer AI buttons — matrix leg A3-T3 (RBAC three-state:
+ * readable→preview / editable→run / invisible→nothing) + per-run tokens
+ * display + pending/countdown states (§2.2 / §2.4).
+ */
+import { afterEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, type App } from 'vue'
+import MetaRecordDrawer from '../src/multitable/components/MetaRecordDrawer.vue'
+import type { AiShortcutState } from '../src/multitable/composables/useAiShortcut'
+import type { MetaField, MetaFieldPermission, MetaRecord } from '../src/multitable/types'
+
+const AI_CONFIG = { kind: 'summarize', sourceFieldIds: ['fld_src'] }
+
+const FIELDS = [
+  { id: 'fld_t', name: 'Summary', type: 'string', property: { aiShortcut: AI_CONFIG } },
+  { id: 'fld_ro', name: 'Summary RO', type: 'string', property: { aiShortcut: AI_CONFIG } },
+  { id: 'fld_hidden', name: 'Hidden', type: 'string', property: { aiShortcut: AI_CONFIG } },
+  { id: 'fld_plain', name: 'Plain', type: 'string', property: {} },
+] as unknown as MetaField[]
+
+const RECORD = { id: 'rec_1', version: 1, data: { fld_t: 'v', fld_ro: 'v', fld_plain: 'v' } } as unknown as MetaRecord
+
+interface HarnessOptions {
+  aiShortcut?: AiShortcutState | null
+  fieldPermissions?: Record<string, MetaFieldPermission>
+  onAiPreview?: (field: MetaField) => void
+  onAiRun?: (field: MetaField) => void
+}
+
+function mountDrawer(options: HarnessOptions = {}): { container: HTMLElement; app: App } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({
+    render() {
+      return h(MetaRecordDrawer, {
+        visible: true,
+        record: RECORD,
+        fields: FIELDS,
+        canEdit: true,
+        canComment: false,
+        canDelete: false,
+        fieldPermissions: options.fieldPermissions ?? {
+          fld_ro: { visible: true, readOnly: true },
+          fld_hidden: { visible: false, readOnly: false },
+        },
+        aiShortcut: options.aiShortcut ?? null,
+        ...(options.onAiPreview ? { onAiPreview: options.onAiPreview } : {}),
+        ...(options.onAiRun ? { onAiRun: options.onAiRun } : {}),
+      })
+    },
+  })
+  app.mount(container)
+  return { container, app }
+}
+
+describe('MetaRecordDrawer AI shortcut buttons (A3-T3)', () => {
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('editable field with aiShortcut → BOTH preview and run buttons', async () => {
+    const { container, app } = mountDrawer()
+    await nextTick()
+    expect(container.querySelector('[data-ai-preview="fld_t"]')).toBeTruthy()
+    expect(container.querySelector('[data-ai-run="fld_t"]')).toBeTruthy()
+    app.unmount()
+  })
+
+  it('read-only field with aiShortcut → preview ONLY (run gated by canEditField)', async () => {
+    const { container, app } = mountDrawer()
+    await nextTick()
+    expect(container.querySelector('[data-ai-preview="fld_ro"]')).toBeTruthy()
+    expect(container.querySelector('[data-ai-run="fld_ro"]')).toBeNull()
+    app.unmount()
+  })
+
+  it('invisible field → no field row, no buttons; field without aiShortcut → no buttons', async () => {
+    const { container, app } = mountDrawer()
+    await nextTick()
+    expect(container.querySelector('[data-ai-preview="fld_hidden"]')).toBeNull()
+    expect(container.querySelector('[data-ai-run="fld_hidden"]')).toBeNull()
+    expect(container.querySelector('[data-ai-preview="fld_plain"]')).toBeNull()
+    expect(container.querySelector('[data-ai-run="fld_plain"]')).toBeNull()
+    app.unmount()
+  })
+
+  it('clicking the buttons emits ai-preview / ai-run with the field', async () => {
+    const previewSpy = vi.fn()
+    const runSpy = vi.fn()
+    const { container, app } = mountDrawer({ onAiPreview: previewSpy, onAiRun: runSpy })
+    await nextTick()
+
+    ;(container.querySelector('[data-ai-preview="fld_t"]') as HTMLButtonElement).click()
+    ;(container.querySelector('[data-ai-run="fld_t"]') as HTMLButtonElement).click()
+    expect(previewSpy).toHaveBeenCalledTimes(1)
+    expect(previewSpy.mock.calls[0][0].id).toBe('fld_t')
+    expect(runSpy).toHaveBeenCalledTimes(1)
+    expect(runSpy.mock.calls[0][0].id).toBe('fld_t')
+    app.unmount()
+  })
+
+  it('pending state disables the buttons and shows in-progress copy for the active field', async () => {
+    const { container, app } = mountDrawer({
+      aiShortcut: {
+        pending: { kind: 'run', recordId: 'rec_1', fieldId: 'fld_t' },
+        result: null,
+        error: null,
+        retryRemainingMs: null,
+      },
+    })
+    await nextTick()
+    expect((container.querySelector('[data-ai-preview="fld_t"]') as HTMLButtonElement).disabled).toBe(true)
+    expect((container.querySelector('[data-ai-run="fld_t"]') as HTMLButtonElement).disabled).toBe(true)
+    expect((container.querySelector('[data-ai-preview="fld_ro"]') as HTMLButtonElement).disabled).toBe(true)
+    expect(container.querySelector('[data-ai-status="fld_t"]')?.textContent).toContain('AI')
+    app.unmount()
+  })
+
+  it('per-run tokens are displayed for the field a run succeeded on (T7 user-visibility leg)', async () => {
+    const { container, app } = mountDrawer({
+      aiShortcut: {
+        pending: null,
+        result: {
+          kind: 'run', recordId: 'rec_1', fieldId: 'fld_t', output: 'AI OUT',
+          promptTokens: 21, completionTokens: 13, totalTokens: 34, merged: true, refreshHint: false,
+        },
+        error: null,
+        retryRemainingMs: null,
+      },
+    })
+    await nextTick()
+    expect(container.querySelector('[data-ai-status="fld_t"]')?.textContent).toContain('34 tokens')
+    app.unmount()
+  })
+
+  it('drift-skipped merge shows the SAME refresh recovery copy as 409', async () => {
+    const { container, app } = mountDrawer({
+      aiShortcut: {
+        pending: null,
+        result: {
+          kind: 'run', recordId: 'rec_1', fieldId: 'fld_t', output: 'AI OUT',
+          promptTokens: 21, completionTokens: 13, totalTokens: 34, merged: false, refreshHint: true,
+        },
+        error: null,
+        retryRemainingMs: null,
+      },
+    })
+    await nextTick()
+    expect(container.querySelector('[data-ai-status="fld_t"]')?.textContent).toContain('Refresh')
+    app.unmount()
+  })
+
+  it('RATE_LIMITED error renders the §2.3 copy with the countdown; quota copy has no countdown', async () => {
+    const limited = mountDrawer({
+      aiShortcut: {
+        pending: null,
+        result: null,
+        error: { code: 'RATE_LIMITED', message: 'raw', recordId: 'rec_1', fieldId: 'fld_t', retryAfterMs: 5000 },
+        retryRemainingMs: 5000,
+      },
+    })
+    await nextTick()
+    const limitedText = limited.container.querySelector('[data-ai-status="fld_t"]')?.textContent ?? ''
+    expect(limitedText).toContain('Retry in 5s')
+    limited.app.unmount()
+    document.body.innerHTML = ''
+
+    const quota = mountDrawer({
+      aiShortcut: {
+        pending: null,
+        result: null,
+        error: { code: 'AI_QUOTA_EXHAUSTED', message: 'raw', recordId: 'rec_1', fieldId: 'fld_t' },
+        retryRemainingMs: null,
+      },
+    })
+    await nextTick()
+    const quotaText = quota.container.querySelector('[data-ai-status="fld_t"]')?.textContent ?? ''
+    expect(quotaText).toContain('quota')
+    expect(quotaText).not.toContain('Retry in')
+    quota.app.unmount()
+  })
+})

--- a/apps/web/tests/multitable-ai-shortcut-field-manager.spec.ts
+++ b/apps/web/tests/multitable-ai-shortcut-field-manager.spec.ts
@@ -1,0 +1,372 @@
+/**
+ * A3 MetaFieldManager aiShortcut config section — matrix legs A3-T1 (render/
+ * hydrate/save shape/constraint mirrors) / A3-T1b (clobber regression) /
+ * A3-T1c (removal round-trip) / A3-T2 (config-time preview) / A3-T7 (admin
+ * usage card render + 403 session-cache hiding).
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick, ref, type App, type Ref } from 'vue'
+import MetaFieldManager from '../src/multitable/components/MetaFieldManager.vue'
+import { resetAiUsageSummarySessionCache } from '../src/multitable/composables/useAiShortcut'
+import type { MetaField } from '../src/multitable/types'
+
+const AI_CONFIG = {
+  kind: 'classify',
+  sourceFieldIds: ['fld_src'],
+  params: { options: ['A', 'B'], instruction: 'pick one' },
+}
+
+function baseFields(): MetaField[] {
+  return [
+    {
+      id: 'fld_target',
+      name: 'Summary',
+      type: 'string',
+      property: { aiShortcut: structuredClone(AI_CONFIG), validation: [{ type: 'required' }] },
+    } as unknown as MetaField,
+    { id: 'fld_src', name: 'Notes', type: 'string', property: {} } as unknown as MetaField,
+    { id: 'fld_formula', name: 'Calc', type: 'formula', property: { expression: '=1' } } as unknown as MetaField,
+    { id: 'fld_plain', name: 'Plain', type: 'string', property: {} } as unknown as MetaField,
+  ]
+}
+
+interface HarnessOptions {
+  fields?: MetaField[]
+  currentRecordId?: string | null
+  aiPreviewFn?: (params: { recordId: string; config: unknown }) => Promise<unknown>
+  aiPreviewBusy?: boolean
+  aiUsageSummaryFn?: () => Promise<unknown>
+  onUpdateField?: (fieldId: string, input: Record<string, unknown>) => void
+}
+
+function mountManager(options: HarnessOptions = {}): { container: HTMLElement; app: App; fields: Ref<MetaField[]> } {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const fields = ref<MetaField[]>(options.fields ?? baseFields())
+
+  const app = createApp({
+    render() {
+      return h(MetaFieldManager, {
+        visible: true,
+        sheetId: 'sheet_1',
+        sheets: [],
+        fields: fields.value,
+        currentRecordId: options.currentRecordId ?? null,
+        ...(options.aiPreviewFn ? { aiPreviewFn: options.aiPreviewFn } : {}),
+        ...(options.aiPreviewBusy !== undefined ? { aiPreviewBusy: options.aiPreviewBusy } : {}),
+        ...(options.aiUsageSummaryFn ? { aiUsageSummaryFn: options.aiUsageSummaryFn } : {}),
+        ...(options.onUpdateField ? { onUpdateField: options.onUpdateField } : {}),
+      })
+    },
+  })
+  app.mount(container)
+  return { container, app, fields }
+}
+
+async function openConfigFor(container: HTMLElement, fieldName: string): Promise<void> {
+  const row = Array.from(container.querySelectorAll('.meta-field-mgr__row'))
+    .find((candidate) => candidate.querySelector('.meta-field-mgr__name')?.textContent === fieldName)
+  expect(row, `field row for ${fieldName}`).toBeTruthy()
+  ;(row!.querySelector('[title="Configure"]') as HTMLButtonElement).click()
+  await nextTick()
+}
+
+function saveButton(container: HTMLElement): HTMLButtonElement {
+  const button = Array.from(container.querySelectorAll('.meta-field-mgr__btn-add'))
+    .find((candidate) => candidate.textContent?.includes('Save field settings'))
+  expect(button, 'save button').toBeTruthy()
+  return button as HTMLButtonElement
+}
+
+function setInput(el: Element | null, value: string): void {
+  expect(el, 'input element').toBeTruthy()
+  ;(el as HTMLInputElement).value = value
+  el!.dispatchEvent(new Event('input', { bubbles: true }))
+}
+
+/** Drain ALL pending microtasks (multi-hop async chains) + a render tick. */
+async function flush(): Promise<void> {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await nextTick()
+}
+
+describe('MetaFieldManager aiShortcut config section (A3)', () => {
+  beforeEach(() => {
+    resetAiUsageSummarySessionCache()
+  })
+
+  afterEach(() => {
+    document.body.innerHTML = ''
+    vi.restoreAllMocks()
+  })
+
+  it('A3-T1: hydrates the existing aiShortcut into the draft (toggle/kind/sources/params)', async () => {
+    const { container, app } = mountManager()
+    await openConfigFor(container, 'Summary')
+
+    const section = container.querySelector('[data-test="ai-shortcut-section"]')
+    expect(section).toBeTruthy()
+    expect((container.querySelector('[data-test="ai-shortcut-enable"]') as HTMLInputElement).checked).toBe(true)
+    expect((container.querySelector('[data-test="ai-shortcut-kind"]') as HTMLSelectElement).value).toBe('classify')
+    expect((container.querySelector('[data-test="ai-shortcut-source-fld_src"]') as HTMLInputElement).checked).toBe(true)
+    // Constraint mirror: computed fields and the target itself are NOT candidates.
+    expect(container.querySelector('[data-test="ai-shortcut-source-fld_formula"]')).toBeNull()
+    expect(container.querySelector('[data-test="ai-shortcut-source-fld_target"]')).toBeNull()
+    const optionInputs = Array.from(container.querySelectorAll('[data-test="ai-shortcut-option-input"]')) as HTMLInputElement[]
+    expect(optionInputs.map((input) => input.value)).toEqual(['A', 'B'])
+    const instruction = container.querySelector('[data-test="ai-shortcut-instruction"]') as HTMLTextAreaElement
+    expect(instruction.value).toBe('pick one')
+    // Constraint mirrors as hard input caps.
+    expect(instruction.maxLength).toBe(500)
+
+    app.unmount()
+  })
+
+  it('A3-T1: save emits the update-field property with the canonical aiShortcut shape', async () => {
+    const updateSpy = vi.fn()
+    const { container, app } = mountManager({ onUpdateField: updateSpy })
+    await openConfigFor(container, 'Summary')
+
+    setInput(container.querySelector('[data-test="ai-shortcut-instruction"]'), 'edited instruction')
+    saveButton(container).click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledTimes(1)
+    const [fieldId, input] = updateSpy.mock.calls[0] as [string, { property: Record<string, unknown> }]
+    expect(fieldId).toBe('fld_target')
+    expect(input.property.aiShortcut).toEqual({
+      kind: 'classify',
+      sourceFieldIds: ['fld_src'],
+      params: { options: ['A', 'B'], instruction: 'edited instruction' },
+    })
+    // Hydrated validation rules ride along (no reverse clobber of validation).
+    expect(input.property.validation).toEqual([{ type: 'required' }])
+
+    app.unmount()
+  })
+
+  it('A3-T1b CLOBBER GUARD: a validation-only save re-emits the existing aiShortcut untouched', async () => {
+    const updateSpy = vi.fn()
+    const { container, app } = mountManager({ onUpdateField: updateSpy })
+    await openConfigFor(container, 'Summary')
+
+    // Touch ONLY the validation panel (uncheck `required`) — never the AI section.
+    const requiredToggle = container.querySelector('[data-rule-toggle="required"]') as HTMLInputElement
+    requiredToggle.checked = false
+    requiredToggle.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    saveButton(container).click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledTimes(1)
+    const [, input] = updateSpy.mock.calls[0] as [string, { property: Record<string, unknown> }]
+    // Wire-shape assertion: the persisted config survives byte-identically.
+    expect(input.property.aiShortcut).toEqual(AI_CONFIG)
+
+    app.unmount()
+  })
+
+  it('A3-T1c REMOVAL ROUND-TRIP: unchecking the toggle saves a property WITHOUT the key; reopen shows未配置', async () => {
+    const updateSpy = vi.fn()
+    const { container, app, fields } = mountManager({ onUpdateField: updateSpy })
+    await openConfigFor(container, 'Summary')
+
+    const enable = container.querySelector('[data-test="ai-shortcut-enable"]') as HTMLInputElement
+    enable.checked = false
+    enable.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    saveButton(container).click()
+    await nextTick()
+
+    expect(updateSpy).toHaveBeenCalledTimes(1)
+    const [, input] = updateSpy.mock.calls[0] as [string, { property: Record<string, unknown> }]
+    // Removal = KEY OMISSION (never aiShortcut:null — the backend 400s null).
+    expect('aiShortcut' in input.property).toBe(false)
+
+    // Round-trip: parent persists the keyless property → reopen hydrates as未配置.
+    fields.value = fields.value.map((field) => field.id === 'fld_target'
+      ? ({ ...field, property: { validation: [{ type: 'required' }] } } as unknown as MetaField)
+      : field)
+    await nextTick()
+    await openConfigFor(container, 'Summary')
+    expect((container.querySelector('[data-test="ai-shortcut-enable"]') as HTMLInputElement).checked).toBe(false)
+
+    app.unmount()
+  })
+
+  it('A3-T1: enabling with zero source fields blocks the save with an inline error (constraint mirror)', async () => {
+    const updateSpy = vi.fn()
+    const { container, app } = mountManager({ onUpdateField: updateSpy })
+    await openConfigFor(container, 'Plain')
+
+    const enable = container.querySelector('[data-test="ai-shortcut-enable"]') as HTMLInputElement
+    enable.checked = true
+    enable.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    saveButton(container).click()
+    await nextTick()
+
+    expect(updateSpy).not.toHaveBeenCalled()
+    expect(container.querySelector('.meta-field-mgr__error')?.textContent).toContain('source field')
+
+    app.unmount()
+  })
+
+  it('A3-T1: translate kind exposes a targetLang input capped at 32 chars', async () => {
+    const { container, app } = mountManager()
+    await openConfigFor(container, 'Summary')
+
+    const kind = container.querySelector('[data-test="ai-shortcut-kind"]') as HTMLSelectElement
+    kind.value = 'translate'
+    kind.dispatchEvent(new Event('change', { bubbles: true }))
+    await nextTick()
+
+    const targetLang = container.querySelector('[data-test="ai-shortcut-target-lang"]') as HTMLInputElement
+    expect(targetLang).toBeTruthy()
+    expect(targetLang.maxLength).toBe(32)
+
+    app.unmount()
+  })
+
+  it('A3-T2: preview button posts the inline DRAFT config with the current record id', async () => {
+    const previewSpy = vi.fn(async () => ({
+      data: {
+        status: 'succeeded', action: 'preview', output: 'DRAFT PREVIEW',
+        usage: { promptTokens: 5, completionTokens: 7 }, estimatedCostUsd: 0.0001,
+        provider: 'anthropic', model: 'claude-sonnet-4-6',
+      },
+    }))
+    const { container, app } = mountManager({ currentRecordId: 'rec_cur', aiPreviewFn: previewSpy })
+    await openConfigFor(container, 'Summary')
+
+    // Edit the draft BEFORE previewing — the call must carry the DRAFT, not the persisted config.
+    setInput(container.querySelector('[data-test="ai-shortcut-instruction"]'), 'draft instruction')
+
+    const previewBtn = container.querySelector('[data-test="ai-shortcut-preview-btn"]') as HTMLButtonElement
+    expect(previewBtn.disabled).toBe(false)
+    previewBtn.click()
+    await flush()
+
+    expect(previewSpy).toHaveBeenCalledWith({
+      recordId: 'rec_cur',
+      config: {
+        kind: 'classify',
+        sourceFieldIds: ['fld_src'],
+        params: { options: ['A', 'B'], instruction: 'draft instruction' },
+      },
+    })
+    const result = container.querySelector('[data-test="ai-shortcut-preview-result"]')
+    expect(result?.textContent).toContain('DRAFT PREVIEW')
+    expect(result?.textContent).toContain('12 tokens')
+
+    app.unmount()
+  })
+
+  it('A3-T2: no current record → preview disabled with the record hint; quota/draft copy is shown', async () => {
+    const previewSpy = vi.fn()
+    const { container, app } = mountManager({ currentRecordId: null, aiPreviewFn: previewSpy })
+    await openConfigFor(container, 'Summary')
+
+    const previewBtn = container.querySelector('[data-test="ai-shortcut-preview-btn"]') as HTMLButtonElement
+    expect(previewBtn.disabled).toBe(true)
+    previewBtn.click()
+    await nextTick()
+    expect(previewSpy).not.toHaveBeenCalled()
+
+    const sectionText = container.querySelector('[data-test="ai-shortcut-section"]')?.textContent ?? ''
+    expect(sectionText).toContain('Select a record')
+    // Locked copy: REAL call consuming quota + validates the DRAFT.
+    expect(sectionText).toContain('real AI call')
+    expect(sectionText).toContain('draft')
+
+    app.unmount()
+  })
+
+  it('review F3: shared AI busy (countdown / in-flight elsewhere) disables the preview button — no silent no-op click', async () => {
+    const previewSpy = vi.fn()
+    const { container, app } = mountManager({ currentRecordId: 'rec_cur', aiPreviewFn: previewSpy, aiPreviewBusy: true })
+    await openConfigFor(container, 'Summary')
+
+    const previewBtn = container.querySelector('[data-test="ai-shortcut-preview-btn"]') as HTMLButtonElement
+    expect(previewBtn.disabled).toBe(true)
+    // Even a forced (synthetic) click must be refused by the runAiPreview guard.
+    previewBtn.dispatchEvent(new MouseEvent('click', { bubbles: true }))
+    await flush()
+    expect(previewSpy).not.toHaveBeenCalled()
+
+    app.unmount()
+  })
+
+  it('A3-T2: a server-side config rejection lands in the existing fieldConfigError inline', async () => {
+    const previewSpy = vi.fn(async () => ({
+      error: { code: 'VALIDATION_ERROR', message: 'aiShortcut.sourceFieldIds entries must be non-empty', status: 400 },
+    }))
+    const { container, app } = mountManager({ currentRecordId: 'rec_cur', aiPreviewFn: previewSpy })
+    await openConfigFor(container, 'Summary')
+
+    ;(container.querySelector('[data-test="ai-shortcut-preview-btn"]') as HTMLButtonElement).click()
+    await flush()
+
+    expect(container.querySelector('.meta-field-mgr__error')?.textContent).toContain('sourceFieldIds')
+
+    app.unmount()
+  })
+
+  it('A3-T2: AI-state errors (e.g. quota) use the §2.3 copy in the preview area', async () => {
+    const previewSpy = vi.fn(async () => ({
+      error: { code: 'AI_QUOTA_EXHAUSTED', message: 'AI usage quota exhausted (user_daily_tokens).', status: 429 },
+    }))
+    const { container, app } = mountManager({ currentRecordId: 'rec_cur', aiPreviewFn: previewSpy })
+    await openConfigFor(container, 'Summary')
+
+    ;(container.querySelector('[data-test="ai-shortcut-preview-btn"]') as HTMLButtonElement).click()
+    await flush()
+
+    expect(container.querySelector('[data-test="ai-shortcut-preview-error"]')?.textContent)
+      .toContain('quota')
+
+    app.unmount()
+  })
+
+  it('A3-T7: admin usage card renders the summary numbers (automation stats card styling family)', async () => {
+    const summaryFn = vi.fn(async () => ({
+      callerDayTokens: 123, callerWeekTokens: 456, instanceDayUsd: 7.89,
+      caps: { tenantDailyTokenCap: 111000, tenantWeeklyTokenCap: 555000, accountDailyUsdCap: 12 },
+    }))
+    const { container, app } = mountManager({ aiUsageSummaryFn: summaryFn })
+    await openConfigFor(container, 'Summary')
+    await flush()
+
+    const card = container.querySelector('[data-test="ai-usage-card"]')
+    expect(card).toBeTruthy()
+    expect(card?.textContent).toContain('123')
+    expect(card?.textContent).toContain('456')
+    expect(card?.textContent).toContain('7.89')
+    expect(card?.textContent).toContain('111000')
+
+    app.unmount()
+  })
+
+  it('A3-T7: a 403 probe hides the card silently and is cached for the session (no re-probe)', async () => {
+    const summaryFn = vi.fn(async () => {
+      throw Object.assign(new Error('Insufficient permissions'), { status: 403 })
+    })
+    const first = mountManager({ aiUsageSummaryFn: summaryFn })
+    await openConfigFor(first.container, 'Summary')
+    await flush()
+    expect(first.container.querySelector('[data-test="ai-usage-card"]')).toBeNull()
+    expect(summaryFn).toHaveBeenCalledTimes(1)
+    first.app.unmount()
+    document.body.innerHTML = ''
+
+    const second = mountManager({ aiUsageSummaryFn: summaryFn })
+    await openConfigFor(second.container, 'Summary')
+    await flush()
+    expect(second.container.querySelector('[data-test="ai-usage-card"]')).toBeNull()
+    expect(summaryFn).toHaveBeenCalledTimes(1) // session cache — never re-probed
+    second.app.unmount()
+  })
+})

--- a/docs/development/multitable-ai-shortcut-frontend-a3-design-20260611.md
+++ b/docs/development/multitable-ai-shortcut-frontend-a3-design-20260611.md
@@ -39,8 +39,8 @@ M3 = 体验层:①字段管理器 aiShortcut 配置区(含"用当前记录预览
 - **抽屉(主)**:字段头动作区按钮组——`fieldPermissions` 可读→"预览",`canEditField`→"运行"(与后端门一致)。
 - **单元格编辑器(辅)**:编辑态内嵌"运行"按钮(link-btn 先例);**RBAC 不变式入注释**:按钮安全性依赖编辑器仅为可编辑单元格打开;任何把按钮挪出编辑态的 follow-up 必须显式接 fieldPermissions。
 - **run 响应适配器(锁;核验 refuted 修正)**:`useAiShortcut` 从 run 响应**合成** `{updated:[{recordId,version}], records:[{recordId,data:{[fieldId]:output}}]}` 再喂 `applyPatchResult()`;**`version===null` 时跳过 version 写入只合值**;合成逻辑必须有**对真实 wire 形状的路由级断言**(fixture-drift 纪律)。
-- **运行中漂移(锁)**:run 发起时捕获本地 row.version;返回时若本地 version 已变(协作编辑),**跳过合并**并提示刷新(与 409 同一条恢复文案);409 原样走网格既有冲突语义。
-- **重入防护(锁)**:三个入口统一 in-flight pending 态(按钮禁用 + spinner);文案提示预览与运行共享频率额度。
+- **运行中漂移(锁;review-F4 细化)**:run 发起时捕获本地 row.version;返回时若本地 version 已变:**= 响应 version(本人 run 的写入经 Yjs 实时回声先于 HTTP 响应落地)→ 视为已应用,静默跳过(冗余)合并,成功态、不提示刷新(tokens 照常展示)**;**≠ 捕获 version 且 ≠ 响应 version(真协作漂移)→ 跳过合并并提示刷新**(与 409 同一条恢复文案);409 原样走网格既有冲突语义。
+- **重入防护(锁;review-F3 细化)**:三个入口统一 in-flight pending 态(按钮禁用 + spinner);**RATE_LIMITED 倒计时禁用同样覆盖全部三个入口(抽屉 aiBusy / 单元格运行按钮 / 配置区预览按钮)——不允许"可点击但被守卫静默拒绝"的入口,单元格路径在 busy 时也不得关闭编辑会话**;文案提示预览与运行共享频率额度。
 
 ### 2.3 状态 UX(契约已验证钉死;client 按 `error.code` 分支)
 
@@ -75,10 +75,10 @@ A2 后端语义不动(新增:ledger summary 导出 + 一只读路由);无 OpenAP
 | A3-T2 | 配置时 preview:inline 草稿 config + currentRecordId 调用形状;无 currentRecordId → 禁用;真实调用/草稿语义提示文案存在 | 组件 + client spec |
 | A3-T3 | 抽屉按钮 RBAC 三态(可读/可编辑/均无) | 组件 spec |
 | A3-T4 | **适配器**:对真实 wire 形状(路由级响应)合成 PatchResult;version null 跳过;成功落值 + tokens 展示 | composable + 路由级 spec |
-| A3-T4b | 漂移守卫:返回时本地 version 已变 → 跳过合并 + 刷新提示 | composable spec |
+| A3-T4b | 漂移守卫:本地 version ≠ 捕获且 ≠ 响应 version → 跳过合并 + 刷新提示;**= 响应 version(本人 Yjs 回声)→ 视为已应用,静默成功不提示(review F4)** | composable spec |
 | A3-T5 | 状态全集按 error.code 分支:**429 双语义**(RATE_LIMITED 有倒计时/AI_QUOTA_EXHAUSTED 无)、503 AI_BLOCKED 不按通用故障、422/502/409 | client + 组件 spec |
 | A3-T5b | 重入:pending 中再点 → 无第二次请求 | composable spec |
-| A3-T6 | 单元格编辑器按钮(编辑态出现,同 composable) | 组件 spec |
+| A3-T6 | 单元格编辑器按钮(编辑态出现,同 composable);**倒计时/busy → 按钮禁用,点击不关闭编辑会话(review F3)** | 组件 spec |
 | A3-T7 | usage-summary:后端 admin 200 形状/非 admin 403/不挂 burst limiter;FE admin 卡渲染/403 缓存隐藏 | 后端路由 + 组件 spec |
 | A3-T8 | i18n 双语/模块归属/无跨模块重声明 | 静态 |
 | A3-T9 | vue-tsc -b + 后端 tsc + 全套回归 | gates |

--- a/packages/core-backend/src/routes/multitable-ai.ts
+++ b/packages/core-backend/src/routes/multitable-ai.ts
@@ -15,6 +15,7 @@ import {
   insertAiUsageLedgerEntry,
   reserveAiUsage,
   settleAiUsageReservation,
+  sumAiUsageWindows,
   type AiUsageAction,
   type AiUsageLedgerEntry,
   type AiUsageLedgerStatus,
@@ -176,6 +177,42 @@ export function createMultitableAiRoutes(deps: MultitableAiRouteDeps = {}): Rout
   router.get('/ai/readiness', requireAdminRole(), (_req: Request, res: Response) => {
     const report = resolveAiProviderReadiness(process.env)
     res.json(redactValue(report))
+  })
+
+  /**
+   * A3 §2.4 — admin usage summary (INTERNAL, not in OpenAPI). Deliberately
+   * NOT behind the AI burst limiter: a read-only ledger aggregate must never
+   * consume (or be starved by) the preview/run budget. Subject semantics are
+   * LOCKED: token windows are the CALLER's own (authenticated user id), the
+   * USD window is instance-wide. No readiness info here — blocked diagnosis
+   * stays on GET /ai/readiness (A1).
+   */
+  router.get('/ai/usage-summary', requireAdminRole(), async (req: Request, res: Response) => {
+    try {
+      const subjectKey = resolveRequestUserKey(req)
+      if (!subjectKey) {
+        // requireAdminRole already rejected anonymous callers; this guards the
+        // exotic "admin without a usable id" shape instead of summing garbage.
+        return res.status(403).json({ ok: false, error: { code: 'FORBIDDEN', message: 'No usable caller identity' } })
+      }
+      const pool = poolManager.get() as unknown as PoolLike
+      const query = pool.query.bind(pool) as AiUsageQueryFn
+      const sums = await sumAiUsageWindows(query, subjectKey)
+      const caps = resolveAiProviderReadiness(process.env).caps
+      res.json({
+        callerDayTokens: sums.userDailyTokens,
+        callerWeekTokens: sums.userWeeklyTokens,
+        instanceDayUsd: sums.instanceDailyUsd,
+        caps: {
+          tenantDailyTokenCap: caps.tenantDailyTokenCap,
+          tenantWeeklyTokenCap: caps.tenantWeeklyTokenCap,
+          accountDailyUsdCap: caps.accountDailyUsdCap,
+        },
+      })
+    } catch (err) {
+      console.error('[multitable-ai] usage summary failed:', err)
+      res.status(500).json({ ok: false, error: { code: 'INTERNAL_ERROR', message: 'Failed to load AI usage summary' } })
+    }
   })
 
   /**

--- a/packages/core-backend/src/services/ai-usage-ledger.ts
+++ b/packages/core-backend/src/services/ai-usage-ledger.ts
@@ -131,16 +131,23 @@ export async function insertAiUsageLedgerEntry(query: AiUsageQueryFn, entry: AiU
   )
 }
 
+/** Numeric window sums shared by the quota decision and the A3 usage summary. */
+export interface AiUsageWindowSums {
+  userDailyTokens: number
+  userWeeklyTokens: number
+  instanceDailyUsd: number
+}
+
 /**
- * Aggregate consumed tokens/USD for the quota windows. SUMs are NOT filtered
- * by status (§2.5: usage counts whatever the downstream outcome). Caller runs
- * this under `withAiUsageQuotaLock` and FAILS CLOSED (blocked) when it throws.
+ * Aggregate consumed tokens/USD for the quota windows — the SINGLE SUM source
+ * (A3 §2.4): `checkAiUsageQuota` derives its decision from these numbers and
+ * the admin usage-summary route reports them directly. SUMs are NOT filtered
+ * by status (§2.5: usage counts whatever the downstream outcome).
  */
-export async function checkAiUsageQuota(
+export async function sumAiUsageWindows(
   query: AiUsageQueryFn,
   subjectKey: string,
-  caps: AiUsageQuotaCaps,
-): Promise<AiUsageQuotaDecision> {
+): Promise<AiUsageWindowSums> {
   const result = await query(
     `SELECT
        COALESCE(SUM(prompt_tokens + completion_tokens) FILTER (
@@ -157,17 +164,31 @@ export async function checkAiUsageQuota(
     [subjectKey],
   )
   const row = (result.rows[0] ?? {}) as Record<string, unknown>
-  const userDailyTokens = Number(row.user_daily_tokens ?? 0)
-  const userWeeklyTokens = Number(row.user_weekly_tokens ?? 0)
-  const instanceDailyUsd = Number(row.instance_daily_usd ?? 0)
+  return {
+    userDailyTokens: Number(row.user_daily_tokens ?? 0),
+    userWeeklyTokens: Number(row.user_weekly_tokens ?? 0),
+    instanceDailyUsd: Number(row.instance_daily_usd ?? 0),
+  }
+}
 
-  if (userDailyTokens >= caps.tenantDailyTokenCap) {
+/**
+ * Quota decision over the shared window sums. Caller runs this under
+ * `withAiUsageQuotaLock` and FAILS CLOSED (blocked) when it throws.
+ */
+export async function checkAiUsageQuota(
+  query: AiUsageQueryFn,
+  subjectKey: string,
+  caps: AiUsageQuotaCaps,
+): Promise<AiUsageQuotaDecision> {
+  const sums = await sumAiUsageWindows(query, subjectKey)
+
+  if (sums.userDailyTokens >= caps.tenantDailyTokenCap) {
     return { allowed: false, reason: 'user_daily_tokens' }
   }
-  if (userWeeklyTokens >= caps.tenantWeeklyTokenCap) {
+  if (sums.userWeeklyTokens >= caps.tenantWeeklyTokenCap) {
     return { allowed: false, reason: 'user_weekly_tokens' }
   }
-  if (instanceDailyUsd >= caps.accountDailyUsdCap) {
+  if (sums.instanceDailyUsd >= caps.accountDailyUsdCap) {
     return { allowed: false, reason: 'instance_daily_usd' }
   }
   return { allowed: true }

--- a/packages/core-backend/tests/integration/multitable-ai-shortcut-run.test.ts
+++ b/packages/core-backend/tests/integration/multitable-ai-shortcut-run.test.ts
@@ -202,6 +202,15 @@ describeIfDatabase('A2 shortcut run (real DB)', () => {
     expect(res.body.data.output).toBe('AI OUT')
     expect(res.body.data.usage).toEqual({ promptTokens: 21, completionTokens: 13 })
     expect(res.body.data.version).toBe(2) // optimistic-lock increment through RWS
+    // A3-T4 route-level wire pin (fixture-drift discipline): the frontend run
+    // adapter (useAiShortcut) synthesizes a PatchResult from EXACTLY this key
+    // set — any key change here must update the composable + its spec fixture.
+    expect(Object.keys(res.body.data).sort()).toEqual([
+      'action', 'estimatedCostUsd', 'fieldId', 'model', 'output', 'provider', 'recordId', 'status', 'usage', 'version',
+    ])
+    expect(res.body.data.action).toBe('run')
+    expect(res.body.data.recordId).toBe(REC_MAIN)
+    expect(res.body.data.fieldId).toBe(FLD_TARGET)
 
     const row = await recordRow(REC_MAIN)
     expect(row.data[FLD_TARGET]).toBe('AI OUT') // value landed via the authoritative write path

--- a/packages/core-backend/tests/unit/ai-usage-ledger.test.ts
+++ b/packages/core-backend/tests/unit/ai-usage-ledger.test.ts
@@ -16,6 +16,7 @@ import {
   insertAiUsageLedgerEntry,
   reserveAiUsage,
   settleAiUsageReservation,
+  sumAiUsageWindows,
   withAiUsageQuotaLock,
   type AiUsageReservationInput,
 } from '../../src/services/ai-usage-ledger'
@@ -111,6 +112,29 @@ describe('checkAiUsageQuota', () => {
     ])
     const decision = await checkAiUsageQuota(query, 'user-1', caps)
     expect(decision).toEqual({ allowed: false, reason: 'instance_daily_usd' })
+  })
+})
+
+describe('sumAiUsageWindows (A3 §2.4 — shared SUM source for quota + summary)', () => {
+  it('returns the numeric window sums from ONE query (the same SQL the quota check uses)', async () => {
+    const { calls, query } = captureQuery([
+      { user_daily_tokens: '123', user_weekly_tokens: '456', instance_daily_usd: '7.89' },
+    ])
+    const sums = await sumAiUsageWindows(query, 'user-1')
+    expect(sums).toEqual({ userDailyTokens: 123, userWeeklyTokens: 456, instanceDailyUsd: 7.89 })
+    expect(calls).toHaveLength(1)
+    expect(calls[0].sql).toContain(AI_USAGE_LEDGER_TABLE)
+    expect(calls[0].sql.toLowerCase()).not.toContain('status')
+    expect(calls[0].params).toEqual(['user-1'])
+  })
+
+  it('checkAiUsageQuota consumes the SAME shared sums (no duplicated SQL path)', async () => {
+    const { calls, query } = captureQuery([
+      { user_daily_tokens: '0', user_weekly_tokens: '0', instance_daily_usd: '0' },
+    ])
+    await checkAiUsageQuota(query, 'user-1', { tenantDailyTokenCap: 1, tenantWeeklyTokenCap: 1, accountDailyUsdCap: 1 })
+    const sumsCalls = calls.filter((call) => call.sql.includes('user_daily_tokens'))
+    expect(sumsCalls).toHaveLength(1)
   })
 })
 

--- a/packages/core-backend/tests/unit/multitable-ai-usage-summary-route.test.ts
+++ b/packages/core-backend/tests/unit/multitable-ai-usage-summary-route.test.ts
@@ -1,0 +1,171 @@
+/**
+ * A3 usage-summary route — backend leg of A3-T7
+ * (docs/development/multitable-ai-shortcut-frontend-a3-design-20260611.md §2.4 / §3).
+ *
+ * GET /api/multitable/ai/usage-summary (internal, requireAdminRole, NOT under
+ * the AI burst limiter): returns the caller's own token windows + the
+ * instance-wide daily USD + the boot-time caps —
+ * `{ callerDayTokens, callerWeekTokens, instanceDayUsd, caps }`.
+ *
+ * Mount pattern: fresh Express app + `rbac/service` and `db/pg` mocked
+ * (precedent: tests/unit/multitable-ai-routes.test.ts), poolManager.get()
+ * spied to a mock pool that serves the shared SUM SQL.
+ */
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import express, { type Express } from 'express'
+import request from 'supertest'
+import { isAdmin } from '../../src/rbac/service'
+
+vi.mock('../../src/rbac/service', () => ({
+  isAdmin: vi.fn().mockResolvedValue(true),
+}))
+
+vi.mock('../../src/db/pg', () => ({
+  pool: null,
+}))
+
+const AI_ENV_KEYS = [
+  'MULTITABLE_AI_ENABLED',
+  'MULTITABLE_AI_PROVIDER',
+  'MULTITABLE_AI_API_KEY',
+  'MULTITABLE_AI_BASE_URL',
+  'MULTITABLE_AI_MODEL',
+  'MULTITABLE_AI_REQUEST_TIMEOUT_MS',
+  'MULTITABLE_AI_MAX_OUTPUT_TOKENS',
+  'MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP',
+  'MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP',
+  'MULTITABLE_AI_TENANT_BURST_RPM',
+  'MULTITABLE_AI_ACCOUNT_DAILY_USD_CAP',
+  'MULTITABLE_AI_CONFIRM_LIVE_REQUESTS',
+] as const
+
+let sumQueryCalls: Array<{ sql: string; params: unknown[] }>
+let sumRow: Record<string, unknown> | null
+let sumQueryError: Error | null
+
+function createMockPool() {
+  const query = vi.fn(async (sql: string, params?: unknown[]) => {
+    if (sql.includes('FROM multitable_ai_usage_ledger')) {
+      sumQueryCalls.push({ sql, params: params ?? [] })
+      if (sumQueryError) throw sumQueryError
+      return { rows: sumRow ? [sumRow] : [] }
+    }
+    return { rows: [], rowCount: 0 }
+  })
+  const transaction = vi.fn(async (fn: (client: { query: typeof query }) => Promise<unknown>) => fn({ query }))
+  return { query, transaction }
+}
+
+async function buildApp(user?: { id: string }): Promise<Express> {
+  const { poolManager } = await import('../../src/integration/db/connection-pool')
+  const { createMultitableAiRoutes } = await import('../../src/routes/multitable-ai')
+  vi.spyOn(poolManager, 'get').mockReturnValue(createMockPool() as never)
+
+  const app = express()
+  app.use(express.json())
+  if (user) {
+    app.use((req, _res, next) => {
+      ;(req as express.Request & { user?: { id: string } }).user = user
+      next()
+    })
+  }
+  app.use('/api/multitable', createMultitableAiRoutes())
+  return app
+}
+
+const SUMMARY_URL = '/api/multitable/ai/usage-summary'
+const savedEnv = new Map<string, string | undefined>()
+
+describe('GET /api/multitable/ai/usage-summary (internal, admin-only, limiter-free)', () => {
+  beforeEach(() => {
+    for (const key of AI_ENV_KEYS) {
+      savedEnv.set(key, process.env[key])
+      delete process.env[key]
+    }
+    // Cap envs are integer-only (resolveCap falls back to defaults otherwise — A1 semantics).
+    process.env.MULTITABLE_AI_TENANT_DAILY_TOKEN_CAP = '111000'
+    process.env.MULTITABLE_AI_TENANT_WEEKLY_TOKEN_CAP = '555000'
+    process.env.MULTITABLE_AI_ACCOUNT_DAILY_USD_CAP = '12'
+
+    sumQueryCalls = []
+    sumRow = { user_daily_tokens: '123', user_weekly_tokens: '456', instance_daily_usd: '7.89' }
+    sumQueryError = null
+    vi.mocked(isAdmin).mockReset()
+    vi.mocked(isAdmin).mockResolvedValue(true)
+  })
+
+  afterEach(() => {
+    for (const key of AI_ENV_KEYS) {
+      const value = savedEnv.get(key)
+      if (value === undefined) delete process.env[key]
+      else process.env[key] = value
+    }
+    vi.restoreAllMocks()
+  })
+
+  it('A3-T7: admin gets a 200 flat summary {callerDayTokens, callerWeekTokens, instanceDayUsd, caps}', async () => {
+    const app = await buildApp({ id: 'admin-1' })
+    const res = await request(app).get(SUMMARY_URL).expect(200)
+
+    expect(res.body).toEqual({
+      callerDayTokens: 123,
+      callerWeekTokens: 456,
+      instanceDayUsd: 7.89,
+      caps: {
+        tenantDailyTokenCap: 111000,
+        tenantWeeklyTokenCap: 555000,
+        accountDailyUsdCap: 12,
+      },
+    })
+
+    // Subject semantics (§2.4 locked): the caller's OWN authenticated user id
+    // is the token subject — never a header-backfilled tenant.
+    expect(sumQueryCalls).toHaveLength(1)
+    expect(sumQueryCalls[0].params).toEqual(['admin-1'])
+  })
+
+  it('A3-T7: the summary read shares the quota SUM SQL (no status filter, same windows)', async () => {
+    const app = await buildApp({ id: 'admin-1' })
+    await request(app).get(SUMMARY_URL).expect(200)
+
+    const sql = sumQueryCalls[0].sql
+    expect(sql).toContain('user_daily_tokens')
+    expect(sql).toContain('user_weekly_tokens')
+    expect(sql).toContain('instance_daily_usd')
+    expect(sql.toLowerCase()).not.toContain('status')
+  })
+
+  it('A3-T7: non-admin → 403; unauthenticated → 403 (ADMIN_REQUIRED — 401 belongs upstream)', async () => {
+    vi.mocked(isAdmin).mockResolvedValue(false)
+    const nonAdminApp = await buildApp({ id: 'user-1' })
+    const nonAdmin = await request(nonAdminApp).get(SUMMARY_URL).expect(403)
+    expect(nonAdmin.body.code).toBe('ADMIN_REQUIRED')
+    expect(sumQueryCalls).toHaveLength(0)
+
+    vi.restoreAllMocks()
+    vi.mocked(isAdmin).mockResolvedValue(true)
+    const anonApp = await buildApp()
+    await request(anonApp).get(SUMMARY_URL).expect(403)
+    expect(sumQueryCalls).toHaveLength(0)
+  })
+
+  it('A3-T7: NOT under the AI burst limiter — burst rpm 1 still serves repeated reads', async () => {
+    process.env.MULTITABLE_AI_TENANT_BURST_RPM = '1'
+    const app = await buildApp({ id: 'admin-1' })
+
+    // The shortcut limiter at rpm=1 would 429 the second request; the summary
+    // route must never consume (or be blocked by) that budget.
+    await request(app).get(SUMMARY_URL).expect(200)
+    await request(app).get(SUMMARY_URL).expect(200)
+    await request(app).get(SUMMARY_URL).expect(200)
+    expect(sumQueryCalls).toHaveLength(3)
+  })
+
+  it('A3-T7: ledger read failure → 500 INTERNAL_ERROR (read-only route, no fail-open numbers)', async () => {
+    sumQueryError = new Error('ledger down')
+    const app = await buildApp({ id: 'admin-1' })
+    const res = await request(app).get(SUMMARY_URL).expect(500)
+    expect(res.body.ok).toBe(false)
+    expect(res.body.error.code).toBe('INTERNAL_ERROR')
+  })
+})


### PR DESCRIPTION
## Summary

Implements **M3** (final main-line stage) of the AI-field staged arc per the merged design-lock (`multitable-ai-shortcut-frontend-a3-design-20260611.md`, #2491). Closes **T3 display** — with M0/M1/M2 already landed, the staged main line M0→M3 is complete.

- **Field-manager aiShortcut config section** (string/longText targets): draft hydration + the two-leg **clobber guard** (hydrate-into-draft + re-emit-on-every-save; removal = key omission — both regression-locked); client-side A2 constraint mirrors; config-time preview over the inline **draft** (currentRecordId-gated, real-call/draft-semantics copy); server rejection → existing `fieldConfigError`.
- **Triggers**: record-drawer two-button surface (preview=readable, run=canEditField) with per-run tokens; cell-editor opt-in run button (RBAC invariant documented; grid closes the edit session before running). **Unified `busy` across all three surfaces** — pending OR rate-limit countdown disables every trigger, and the grid guards before `cancelEdit()` so a refused click can never destroy an edit session.
- **Run adapter** (the design's refuted-claim fix): synthesizes `{updated, records}` for `applyPatchResult` from the pinned wire shape; version-null guarded; drift guard with an **own-Yjs-echo carve-out** (local version bumped to the response version mid-flight = own write echo → success, no false "edited by others" warning).
- **Status UX keyed on error.code**: dual-429 disambiguated (RATE_LIMITED countdown vs AI_QUOTA_EXHAUSTED), AI_BLOCKED 503 non-generic, 422/502/409 mapped; 409 uses refresh-recovery copy (the grid retry-dialog re-patches a user value, which doesn't exist for an AI run — documented deviation).
- **Usage visibility**: backend `sumAiUsageWindows` extraction (checkAiUsageQuota consumes the same SQL — no drift) + limiter-free admin `GET /ai/usage-summary`; admin usage card with per-session 403 probe cache.
- i18n confined to the four named modules (EN+zh).

## Tests (fail-first both sides)

Backend red (route 404, export missing) → 42 AI tests green; full backend unit 235 files / 2982; real-DB suite 9/9 incl. the route-level run wire key-set pin. Frontend red (5 new spec files, 16 failed) → post-fix-round **59/59** AI specs + 170/170 affected suites; `vue-tsc -b` clean. Full web suite 3259 passed / 16 failed — **stash-verified byte-identical** to the pre-existing baseline set (zero net-new).

## Review

Adversarial review (`/tmp/a3-frontend-review-claude-20260611.md`): **APPROVE-WITH-NITS** — F3 (countdown disable missing on cell-editor; click destroyed edit session then no-opped) and F4 (drift-guard false positive on the run's own Yjs echo) **fixed pre-merge** (+6 spec legs, design doc updated for MD↔spec parity). F1/F2 recorded as known edges: the clobber guard canonicalizes API-authored configs on unrelated saves (UI-authored configs round-trip exactly; inert-options drop / instruction trim / deleted-source self-heal), and an all-sources-deleted config blocks saves until fixed or disabled (recovery exists, error names the section).

Arc: #2491 design → this. Main line M0→M3 complete; T1/T3/T6 all closed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)