### PR TITLE
feat(multitable): add parallel branch join-all runtime

### DIFF
--- a/packages/core-backend/src/db/migrations/zzzz20260611120000_add_parallel_branch_automation_action.ts
+++ b/packages/core-backend/src/db/migrations/zzzz20260611120000_add_parallel_branch_automation_action.ts
@@ -1,0 +1,67 @@
+/**
+ * Migration: A6-3-4 / W3-1 — widen the automation action-type CHECK
+ * constraint to include `parallel_branch` (fan-out + join-all v1).
+ *
+ * Keeps `chk_automation_action_type` aligned with the app-level
+ * `ALL_ACTION_TYPES`. NULL-safe: only the enum widens; no table or column is
+ * added in this slice.
+ */
+
+import { sql, type Kysely } from 'kysely'
+
+export const AUTOMATION_ACTION_TYPES_WITH_PARALLEL_BRANCH = [
+  'notify',
+  'update_field',
+  'update_record',
+  'create_record',
+  'send_webhook',
+  'send_notification',
+  'send_email',
+  'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
+  'lock_record',
+  'wait_for_callback',
+  'condition_branch',
+  'start_approval',
+  'parallel_branch',
+] as const
+
+export const AUTOMATION_ACTION_TYPES_BEFORE_PARALLEL_BRANCH = [
+  'notify',
+  'update_field',
+  'update_record',
+  'create_record',
+  'send_webhook',
+  'send_notification',
+  'send_email',
+  'send_dingtalk_group_message',
+  'send_dingtalk_person_message',
+  'lock_record',
+  'wait_for_callback',
+  'condition_branch',
+  'start_approval',
+] as const
+
+function quotedActions(actions: readonly string[]): string {
+  return actions.map((action) => `'${action}'`).join(', ')
+}
+
+async function replaceAutomationActionTypeConstraint(
+  db: Kysely<unknown>,
+  actions: readonly string[],
+): Promise<void> {
+  await sql`ALTER TABLE automation_rules DROP CONSTRAINT IF EXISTS chk_automation_action_type`.execute(db)
+  await sql.raw(`
+    ALTER TABLE automation_rules
+    ADD CONSTRAINT chk_automation_action_type
+    CHECK (action_type IN (${quotedActions(actions)}))
+  `).execute(db)
+}
+
+export async function up(db: Kysely<unknown>): Promise<void> {
+  await replaceAutomationActionTypeConstraint(db, AUTOMATION_ACTION_TYPES_WITH_PARALLEL_BRANCH)
+}
+
+export async function down(db: Kysely<unknown>): Promise<void> {
+  await replaceAutomationActionTypeConstraint(db, AUTOMATION_ACTION_TYPES_BEFORE_PARALLEL_BRANCH)
+}

--- a/packages/core-backend/src/multitable/automation-actions.ts
+++ b/packages/core-backend/src/multitable/automation-actions.ts
@@ -15,6 +15,7 @@ export type AutomationActionType =
   | 'wait_for_callback'
   | 'condition_branch'
   | 'start_approval'
+  | 'parallel_branch'
 
 export const ALL_ACTION_TYPES: AutomationActionType[] = [
   'update_record',
@@ -28,6 +29,7 @@ export const ALL_ACTION_TYPES: AutomationActionType[] = [
   'wait_for_callback',
   'condition_branch',
   'start_approval',
+  'parallel_branch',
 ]
 
 /** Config shape for update_record */
@@ -121,6 +123,22 @@ export interface StartApprovalConfig {
   requester?: {
     mode?: 'trigger_actor' | 'rule_creator'
   }
+}
+
+/**
+ * Config shape for parallel_branch (A6-3-4 / W3-1 join-all runtime).
+ *
+ * v1 is fan-out + join-all only: all branches run, the parent job settles after
+ * every branch is terminal, and join_any/cancellation/branch-local waits stay
+ * out of scope.
+ */
+export interface ParallelBranchConfig {
+  joinMode: 'all'
+  branches: Array<{
+    key: string
+    label?: string
+    actions: AutomationAction[]
+  }>
 }
 
 export interface AutomationAction {

--- a/packages/core-backend/src/multitable/automation-executor.ts
+++ b/packages/core-backend/src/multitable/automation-executor.ts
@@ -67,6 +67,20 @@ function maxWebhookRetries(): number {
 }
 const DINGTALK_PERSON_BATCH_SIZE = 100
 const DINGTALK_FAILURE_ALERT_CONTENT_LIMIT = 1_000
+const SAFE_PARALLEL_BRANCH_KEY = /^[A-Za-z0-9_-]{1,64}$/
+const MAX_PARALLEL_BRANCHES = 10
+const MAX_PARALLEL_BRANCH_ACTIONS = 20
+const PARALLEL_BRANCH_RUNTIME_ACTION_TYPES = new Set<AutomationActionType>(['update_record', 'send_notification'])
+
+type RuntimeParallelBranch = {
+  key: string
+  label?: string
+  actions: AutomationAction[]
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === 'object' && value !== null && !Array.isArray(value)
+}
 
 function readJsonSafely(response: Response): Promise<unknown> {
   return response.json().catch(() => null)
@@ -97,6 +111,72 @@ export function renderAutomationTemplate(template: string, data: Record<string, 
   return template.replace(/\{\{\s*([\w.]+)\s*\}\}/g, (_match, key: string) =>
     renderTemplateValue(lookupTemplateValue(key, data)),
   )
+}
+
+function validateParallelBranchRuntimeConfig(config: unknown): { branches: RuntimeParallelBranch[] } | { error: string } {
+  if (!isPlainRecord(config)) {
+    return { error: 'parallel_branch config must be an object' }
+  }
+  if (config.joinMode !== 'all') {
+    return { error: 'parallel_branch requires joinMode all and non-empty branches' }
+  }
+  if (!Array.isArray(config.branches) || config.branches.length === 0) {
+    return { error: 'parallel_branch requires joinMode all and non-empty branches' }
+  }
+  if (config.branches.length > MAX_PARALLEL_BRANCHES) {
+    return { error: `parallel_branch.branches exceeds max ${MAX_PARALLEL_BRANCHES}` }
+  }
+
+  const seen = new Set<string>()
+  const branches: RuntimeParallelBranch[] = []
+  let totalActions = 0
+  for (const [branchIndex, branch] of config.branches.entries()) {
+    const branchPath = `parallel_branch.branches[${branchIndex}]`
+    if (!isPlainRecord(branch)) {
+      return { error: `${branchPath} must be an object` }
+    }
+    if (typeof branch.key !== 'string' || !SAFE_PARALLEL_BRANCH_KEY.test(branch.key)) {
+      return { error: `${branchPath}.key must be a safe non-empty string` }
+    }
+    if (seen.has(branch.key)) {
+      return { error: `${branchPath}.key must be unique` }
+    }
+    seen.add(branch.key)
+    if (branch.label !== undefined && typeof branch.label !== 'string') {
+      return { error: `${branchPath}.label must be a string` }
+    }
+    const label = typeof branch.label === 'string' ? branch.label : undefined
+    if (!Array.isArray(branch.actions) || branch.actions.length === 0) {
+      return { error: `${branchPath}.actions must be a non-empty array` }
+    }
+    totalActions += branch.actions.length
+    if (totalActions > MAX_PARALLEL_BRANCH_ACTIONS) {
+      return { error: `parallel_branch.branches total actions exceeds max ${MAX_PARALLEL_BRANCH_ACTIONS}` }
+    }
+
+    const actions: AutomationAction[] = []
+    for (const [actionIndex, branchAction] of branch.actions.entries()) {
+      const actionPath = `${branchPath}.actions[${actionIndex}]`
+      if (!isPlainRecord(branchAction) || typeof branchAction.type !== 'string') {
+        return { error: `${actionPath}.type is invalid` }
+      }
+      if (!PARALLEL_BRANCH_RUNTIME_ACTION_TYPES.has(branchAction.type as AutomationActionType)) {
+        return { error: `${branchPath}.actions cannot contain ${branchAction.type} in A6-3-4` }
+      }
+      actions.push({
+        type: branchAction.type as AutomationActionType,
+        config: isPlainRecord(branchAction.config) ? branchAction.config : {},
+      })
+    }
+
+    branches.push({
+      key: branch.key,
+      ...(label ? { label } : {}),
+      actions,
+    })
+  }
+
+  return { branches }
 }
 
 function normalizeUserIds(value: unknown): string[] {
@@ -861,6 +941,41 @@ export class AutomationExecutor {
         continue
       }
 
+      // A6-3-4 / W3-1 parallel branch. V1 is graph-shaped fan-out + join-all:
+      // every branch is attempted, the parent join job settles only after every
+      // branch is terminal, and the next top-level action upstreams from the
+      // parent join job (not an arbitrary child).
+      if (action.type === 'parallel_branch') {
+        if (!jobLifecycle) {
+          results.push({
+            actionType: 'parallel_branch',
+            status: 'failed',
+            error: 'parallel_branch requires execution_mode workflow_job_v1',
+            durationMs: 0,
+          })
+          for (let i = index + 1; i < actions.length; i++) {
+            results.push({ actionType: actions[i].type, status: 'skipped', durationMs: 0 })
+          }
+          return { suspended: false }
+        }
+
+        await jobLifecycle.onStart(index, action, topLevelMeta)
+        const parallelResult = await this.executeParallelBranch(index, action, context, jobLifecycle)
+        results.push(parallelResult.result)
+        await jobLifecycle.onSettled(index, action, parallelResult.result)
+
+        if (parallelResult.result.status === 'failed') {
+          for (let i = index + 1; i < actions.length; i++) {
+            await jobLifecycle.onSkipped(i, actions[i])
+            results.push({ actionType: actions[i].type, status: 'skipped', durationMs: 0 })
+          }
+          break
+        }
+
+        nextTopLevelUpstreamJobId = parallelResult.joinJobId
+        continue
+      }
+
       // A6-1 fail-closed: onStart runs BEFORE the inner try, so a job-create failure propagates
       // to execute()'s outer catch (execution fails) — and the action's side effect never runs.
       if (jobLifecycle) await jobLifecycle.onStart(index, action, topLevelMeta)
@@ -890,6 +1005,106 @@ export class AutomationExecutor {
     }
 
     return { suspended: false }
+  }
+
+  private async executeParallelBranch(
+    stepIndex: number,
+    action: AutomationAction,
+    context: ExecutionContext,
+    jobLifecycle: ActionJobLifecycle,
+  ): Promise<{ result: AutomationStepResult; joinJobId: string }> {
+    const startMs = Date.now()
+    const parentJobId = `${context.executionId}:job:${stepIndex}`
+    const validation = validateParallelBranchRuntimeConfig(action.config)
+    const childJobIds: string[] = []
+    const resolvedBranchKeys: string[] = []
+    const failedBranchKeys: string[] = []
+    const skippedBranchKeys: string[] = []
+    const branchStatuses: Record<string, 'resolved' | 'failed' | 'skipped'> = {}
+    const branchLabels: Record<string, string> = {}
+
+    if ('error' in validation) {
+      return {
+        joinJobId: parentJobId,
+        result: {
+          actionType: 'parallel_branch',
+          status: 'failed',
+          error: validation.error,
+          durationMs: Date.now() - startMs,
+        },
+      }
+    }
+
+    const branches = validation.branches
+    for (const branch of branches) {
+      const branchKey = branch.key
+      const branchLabel = branch.label
+      const branchActions = branch.actions
+
+      if (branchLabel) branchLabels[branchKey] = branchLabel
+
+      let upstreamJobId: string | null = parentJobId
+      let branchFailed = false
+      for (let actionIndex = 0; actionIndex < branchActions.length; actionIndex++) {
+        const branchAction = branchActions[actionIndex]
+        const stepKey = `${stepIndex}.parallel.${branchKey}.${actionIndex}`
+        const jobId = `${context.executionId}:job:${stepIndex}:parallel:${branchKey}:${actionIndex}`
+        const meta = { stepKey, jobId, upstreamJobId }
+        childJobIds.push(jobId)
+
+        await jobLifecycle.onStart(stepIndex, branchAction, meta)
+        const branchActionResult = await this.executeSingleAction(branchAction, context)
+        await jobLifecycle.onSettled(stepIndex, branchAction, branchActionResult, meta)
+
+        upstreamJobId = jobId
+
+        if (branchActionResult.status === 'failed') {
+          branchFailed = true
+          for (let skippedIndex = actionIndex + 1; skippedIndex < branchActions.length; skippedIndex++) {
+            const skippedAction = branchActions[skippedIndex]
+            const skippedStepKey = `${stepIndex}.parallel.${branchKey}.${skippedIndex}`
+            const skippedJobId = `${context.executionId}:job:${stepIndex}:parallel:${branchKey}:${skippedIndex}`
+            await jobLifecycle.onSkipped(stepIndex, skippedAction, {
+              stepKey: skippedStepKey,
+              jobId: skippedJobId,
+              upstreamJobId,
+            })
+            childJobIds.push(skippedJobId)
+            upstreamJobId = skippedJobId
+          }
+          failedBranchKeys.push(branchKey)
+          branchStatuses[branchKey] = 'failed'
+          break
+        }
+      }
+
+      if (!branchFailed) {
+        resolvedBranchKeys.push(branchKey)
+        branchStatuses[branchKey] = 'resolved'
+      }
+    }
+
+    const output: Record<string, unknown> = {
+      joinMode: 'all',
+      branchCount: branches.length,
+      childJobIds,
+      resolvedBranchKeys,
+      failedBranchKeys,
+      skippedBranchKeys,
+      branchStatuses,
+    }
+    if (Object.keys(branchLabels).length > 0) output.branchLabels = branchLabels
+
+    return {
+      joinJobId: parentJobId,
+      result: {
+        actionType: 'parallel_branch',
+        status: failedBranchKeys.length > 0 ? 'failed' : 'success',
+        ...(failedBranchKeys.length > 0 ? { error: `parallel_branch failed branches: ${failedBranchKeys.join(', ')}` } : {}),
+        output,
+        durationMs: Date.now() - startMs,
+      },
+    }
   }
 
   private async executeConditionBranch(

--- a/packages/core-backend/src/multitable/automation-service.ts
+++ b/packages/core-backend/src/multitable/automation-service.ts
@@ -68,6 +68,9 @@ const VALID_ACTION_TYPES = new Set<string>([
 ])
 const CANONICAL_ACTION_TYPES = new Set<string>(ALL_ACTION_TYPES)
 const SAFE_BRANCH_KEY = /^[A-Za-z0-9_-]{1,64}$/
+const PARALLEL_BRANCH_ACTION_TYPES = new Set(['update_record', 'send_notification'])
+const MAX_PARALLEL_BRANCHES = 10
+const MAX_PARALLEL_BRANCH_ACTIONS = 20
 
 // A6-1 opt-in (#2130 runtime): a rule may persist one C1 WorkflowJob row per action.
 // `null`/`'legacy'` both mean the legacy fire-and-forget path (no job rows); only
@@ -221,6 +224,9 @@ function validateConditionBranchConfig(config: unknown, path: string): Automatio
       if (nested.type === 'condition_branch') {
         throw new AutomationRuleValidationError(`${branchPath}.actions cannot contain nested condition_branch in A6-3-1`)
       }
+      if (nested.type === 'parallel_branch') {
+        throw new AutomationRuleValidationError(`${branchPath}.actions cannot contain parallel_branch until a later nested-DAG slice`)
+      }
       if (nested.type === 'wait_for_callback') {
         throw new AutomationRuleValidationError(`${branchPath}.actions cannot contain wait_for_callback until A6-3-3`)
       }
@@ -247,11 +253,66 @@ function validateConditionBranchConfig(config: unknown, path: string): Automatio
       if (nested.type === 'condition_branch') {
         throw new AutomationRuleValidationError(`${defaultPath}.actions cannot contain nested condition_branch in A6-3-1`)
       }
+      if (nested.type === 'parallel_branch') {
+        throw new AutomationRuleValidationError(`${defaultPath}.actions cannot contain parallel_branch until a later nested-DAG slice`)
+      }
       if (nested.type === 'wait_for_callback') {
         throw new AutomationRuleValidationError(`${defaultPath}.actions cannot contain wait_for_callback until A6-3-3`)
       }
       if (nested.type === 'start_approval') {
         throw new AutomationRuleValidationError(`${defaultPath}.actions cannot contain start_approval until A6-3-3`)
+      }
+    }
+    nestedActions.push(...actions)
+  }
+
+  return nestedActions
+}
+
+function validateParallelBranchConfig(config: unknown, path: string): AutomationAction[] {
+  if (!isRecord(config)) {
+    throw new AutomationRuleValidationError(`${path} must be an object`)
+  }
+  if (config.joinMode !== 'all') {
+    throw new AutomationRuleValidationError(`${path}.joinMode must be all`)
+  }
+  if (!Array.isArray(config.branches) || config.branches.length === 0) {
+    throw new AutomationRuleValidationError(`${path}.branches must be a non-empty array`)
+  }
+  if (config.branches.length > MAX_PARALLEL_BRANCHES) {
+    throw new AutomationRuleValidationError(`${path}.branches exceeds max ${MAX_PARALLEL_BRANCHES}`)
+  }
+
+  const seen = new Set<string>()
+  const nestedActions: AutomationAction[] = []
+  let totalActions = 0
+  for (const [index, branch] of config.branches.entries()) {
+    const branchPath = `${path}.branches[${index}]`
+    if (!isRecord(branch)) {
+      throw new AutomationRuleValidationError(`${branchPath} must be an object`)
+    }
+    if (typeof branch.key !== 'string' || !SAFE_BRANCH_KEY.test(branch.key)) {
+      throw new AutomationRuleValidationError(`${branchPath}.key must be a safe non-empty string`)
+    }
+    if (seen.has(branch.key)) {
+      throw new AutomationRuleValidationError(`${branchPath}.key must be unique`)
+    }
+    seen.add(branch.key)
+    if (branch.label !== undefined && typeof branch.label !== 'string') {
+      throw new AutomationRuleValidationError(`${branchPath}.label must be a string`)
+    }
+
+    const actions = readBranchActions(branch.actions, `${branchPath}.actions`)
+    if (actions.length === 0) {
+      throw new AutomationRuleValidationError(`${branchPath}.actions must be a non-empty array`)
+    }
+    totalActions += actions.length
+    if (totalActions > MAX_PARALLEL_BRANCH_ACTIONS) {
+      throw new AutomationRuleValidationError(`${path}.branches total actions exceeds max ${MAX_PARALLEL_BRANCH_ACTIONS}`)
+    }
+    for (const nested of actions) {
+      if (!PARALLEL_BRANCH_ACTION_TYPES.has(nested.type)) {
+        throw new AutomationRuleValidationError(`${branchPath}.actions cannot contain ${nested.type} in A6-3-4`)
       }
     }
     nestedActions.push(...actions)
@@ -267,10 +328,15 @@ function collectNestedAutomationActions(
   executionMode: string | null,
 ): AutomationAction[] {
   const collected: AutomationAction[] = []
-  const requiresWorkflowJobMode = actionType === 'condition_branch' || actionType === 'start_approval'
+  const requiresWorkflowJobMode = actionType === 'condition_branch'
+    || actionType === 'start_approval'
+    || actionType === 'parallel_branch'
 
   if (actionType === 'condition_branch') {
     collected.push(...validateConditionBranchConfig(actionConfig, 'actionConfig'))
+  }
+  if (actionType === 'parallel_branch') {
+    collected.push(...validateParallelBranchConfig(actionConfig, 'actionConfig'))
   }
 
   for (const [index, action] of (actions ?? []).entries()) {
@@ -278,13 +344,20 @@ function collectNestedAutomationActions(
     if (current.type === 'condition_branch') {
       collected.push(...validateConditionBranchConfig(current.config, `actions[${index}].config`))
     }
+    if (current.type === 'parallel_branch') {
+      collected.push(...validateParallelBranchConfig(current.config, `actions[${index}].config`))
+    }
     collected.push(current)
   }
 
   const hasWorkflowAction = requiresWorkflowJobMode
-    || collected.some((action) => action.type === 'condition_branch' || action.type === 'start_approval')
+    || collected.some((action) => (
+      action.type === 'condition_branch'
+      || action.type === 'start_approval'
+      || action.type === 'parallel_branch'
+    ))
   if (hasWorkflowAction && executionMode !== 'workflow_job_v1') {
-    throw new AutomationRuleValidationError('condition_branch/start_approval requires execution_mode workflow_job_v1')
+    throw new AutomationRuleValidationError('condition_branch/start_approval/parallel_branch requires execution_mode workflow_job_v1')
   }
 
   return collected

--- a/packages/core-backend/tests/integration/multitable-automation-jobs.test.ts
+++ b/packages/core-backend/tests/integration/multitable-automation-jobs.test.ts
@@ -316,4 +316,240 @@ describeIfDatabase('multitable automation jobs (A6-1, real DB)', () => {
       }
     }
   })
+
+  test('A6-3-4 seam: parallel_branch join_all persists parent, all child jobs, and downstream C1 lineage', async () => {
+    const notifications: unknown[] = []
+    const bus = new EventBus()
+    const svc = new AutomationService(
+      bus,
+      db as never,
+      (async () => ({ rows: [], rowCount: 0 })) as never,
+    )
+    const subscription = bus.subscribe('automation.notification', (payload) => {
+      notifications.push(payload)
+    })
+    const sheetId = `sheet_parallel_${TS}`
+    const parallelAction = {
+      type: 'parallel_branch',
+      config: {
+        joinMode: 'all',
+        branches: [
+          {
+            key: 'ops',
+            label: 'Ops',
+            actions: [{ type: 'update_record', config: { fields: { status: 'ops' } } }],
+          },
+          {
+            key: 'notify',
+            label: 'Notify',
+            actions: [{ type: 'send_notification', config: { userIds: ['u1'], message: 'ready' } }],
+          },
+        ],
+      },
+    } as const
+    const execIds: string[] = []
+    const ruleIds: string[] = []
+    try {
+      const persisted = await svc.createRule(sheetId, {
+        name: 'A6-3-4 parallel real DB',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'parallel_branch',
+        actionConfig: parallelAction.config,
+        actions: [parallelAction],
+        executionMode: 'workflow_job_v1',
+        createdBy: 'u1',
+      })
+      ruleIds.push(persisted.id)
+      expect(persisted.action_type).toBe('parallel_branch')
+      expect(persisted.execution_mode).toBe('workflow_job_v1')
+
+      const optIn = await svc.executeRule(
+        {
+          id: `atr_parallel_in_${TS}`,
+          name: 'A6-3-4 parallel opt-in',
+          sheetId,
+          trigger: { type: 'record.created', config: {} },
+          actions: [
+            parallelAction,
+            { type: 'update_record', config: { fields: { after_parallel: true } } },
+          ],
+          enabled: true,
+          createdBy: 'u1',
+          createdAt: new Date(TS).toISOString(),
+          executionMode: 'workflow_job_v1',
+        } as never,
+        { sheetId, recordId: `rec_parallel_${TS}`, data: {} },
+      )
+      execIds.push(optIn.id)
+      expect(optIn.status).toBe('success')
+      expect(optIn.steps[0]).toMatchObject({
+        actionType: 'parallel_branch',
+        status: 'success',
+        output: {
+          joinMode: 'all',
+          resolvedBranchKeys: ['ops', 'notify'],
+          failedBranchKeys: [],
+          branchStatuses: { ops: 'resolved', notify: 'resolved' },
+        },
+      })
+      expect(notifications).toHaveLength(1)
+
+      const raw = await q(
+        `SELECT id, step_index, step_key, action_type, status, upstream_job_id, result
+           FROM multitable_automation_jobs
+          WHERE execution_id = $1
+          ORDER BY step_index ASC, created_at ASC, step_key ASC`,
+        [optIn.id],
+      )
+      expect(raw.rows.map((r) => ({
+        id: r.id,
+        step_index: r.step_index,
+        step_key: r.step_key,
+        action_type: r.action_type,
+        status: r.status,
+        upstream_job_id: r.upstream_job_id,
+      }))).toEqual([
+        {
+          id: `${optIn.id}:job:0`,
+          step_index: 0,
+          step_key: '0',
+          action_type: 'parallel_branch',
+          status: 'resolved',
+          upstream_job_id: null,
+        },
+        {
+          id: `${optIn.id}:job:0:parallel:ops:0`,
+          step_index: 0,
+          step_key: '0.parallel.ops.0',
+          action_type: 'update_record',
+          status: 'resolved',
+          upstream_job_id: `${optIn.id}:job:0`,
+        },
+        {
+          id: `${optIn.id}:job:0:parallel:notify:0`,
+          step_index: 0,
+          step_key: '0.parallel.notify.0',
+          action_type: 'send_notification',
+          status: 'resolved',
+          upstream_job_id: `${optIn.id}:job:0`,
+        },
+        {
+          id: `${optIn.id}:job:1`,
+          step_index: 1,
+          step_key: '1',
+          action_type: 'update_record',
+          status: 'resolved',
+          upstream_job_id: `${optIn.id}:job:0`,
+        },
+      ])
+      expect(JSON.stringify(raw.rows[0].result)).toContain('childJobIds')
+
+      const views = await jobs.listByExecution(optIn.id)
+      expect(views.map((v) => [v.stepKey, v.status, v.upstreamJobId])).toEqual([
+        ['0', 'resolved', null],
+        ['0.parallel.ops.0', 'resolved', `${optIn.id}:job:0`],
+        ['0.parallel.notify.0', 'resolved', `${optIn.id}:job:0`],
+        ['1', 'resolved', `${optIn.id}:job:0`],
+      ])
+    } finally {
+      bus.unsubscribe(subscription)
+      for (const id of execIds) {
+        await q('DELETE FROM multitable_automation_jobs WHERE execution_id = $1', [id])
+        await q('DELETE FROM multitable_automation_executions WHERE id = $1', [id])
+      }
+      for (const id of ruleIds) {
+        await q('DELETE FROM automation_rules WHERE id = $1', [id])
+      }
+    }
+  })
+
+  test('A6-3-4 seam: parallel_branch branch failure still runs siblings, skips branch tail and downstream', async () => {
+    const notifications: unknown[] = []
+    const bus = new EventBus()
+    const svc = new AutomationService(
+      bus,
+      db as never,
+      (async () => ({ rows: [], rowCount: 0 })) as never,
+    )
+    const subscription = bus.subscribe('automation.notification', (payload) => {
+      notifications.push(payload)
+    })
+    const sheetId = `sheet_parallel_fail_${TS}`
+    const parallelAction = {
+      type: 'parallel_branch',
+      config: {
+        joinMode: 'all',
+        branches: [
+          {
+            key: 'bad',
+            actions: [
+              { type: 'send_notification', config: { userIds: [], message: 'missing users' } },
+              { type: 'update_record', config: { fields: { should_not_run: true } } },
+            ],
+          },
+          {
+            key: 'good',
+            actions: [{ type: 'send_notification', config: { userIds: ['u2'], message: 'still runs' } }],
+          },
+        ],
+      },
+    } as const
+    const execIds: string[] = []
+    try {
+      const exec = await svc.executeRule(
+        {
+          id: `atr_parallel_fail_${TS}`,
+          name: 'A6-3-4 parallel failure',
+          sheetId,
+          trigger: { type: 'record.created', config: {} },
+          actions: [
+            parallelAction,
+            { type: 'update_record', config: { fields: { after_parallel: true } } },
+          ],
+          enabled: true,
+          createdBy: 'u1',
+          createdAt: new Date(TS).toISOString(),
+          executionMode: 'workflow_job_v1',
+        } as never,
+        { sheetId, recordId: `rec_parallel_fail_${TS}`, data: {} },
+      )
+      execIds.push(exec.id)
+      expect(exec.status).toBe('failed')
+      expect(exec.steps).toEqual([
+        expect.objectContaining({
+          actionType: 'parallel_branch',
+          status: 'failed',
+          output: expect.objectContaining({
+            resolvedBranchKeys: ['good'],
+            failedBranchKeys: ['bad'],
+            branchStatuses: { bad: 'failed', good: 'resolved' },
+          }),
+        }),
+        { actionType: 'update_record', status: 'skipped', durationMs: 0 },
+      ])
+      expect(notifications).toHaveLength(1) // good sibling still ran
+
+      const raw = await q(
+        `SELECT step_key, action_type, status, upstream_job_id
+           FROM multitable_automation_jobs
+          WHERE execution_id = $1
+          ORDER BY step_index ASC, created_at ASC, step_key ASC`,
+        [exec.id],
+      )
+      expect(raw.rows).toEqual([
+        { step_key: '0', action_type: 'parallel_branch', status: 'failed', upstream_job_id: null },
+        { step_key: '0.parallel.bad.0', action_type: 'send_notification', status: 'failed', upstream_job_id: `${exec.id}:job:0` },
+        { step_key: '0.parallel.bad.1', action_type: 'update_record', status: 'skipped', upstream_job_id: `${exec.id}:job:0:parallel:bad:0` },
+        { step_key: '0.parallel.good.0', action_type: 'send_notification', status: 'resolved', upstream_job_id: `${exec.id}:job:0` },
+        { step_key: '1', action_type: 'update_record', status: 'skipped', upstream_job_id: `${exec.id}:job:0` },
+      ])
+    } finally {
+      bus.unsubscribe(subscription)
+      for (const id of execIds) {
+        await q('DELETE FROM multitable_automation_jobs WHERE execution_id = $1', [id])
+        await q('DELETE FROM multitable_automation_executions WHERE id = $1', [id])
+      }
+    }
+  })
 })

--- a/packages/core-backend/tests/unit/automation-v1.test.ts
+++ b/packages/core-backend/tests/unit/automation-v1.test.ts
@@ -2309,7 +2309,7 @@ describe('AutomationService — Rule CRUD', () => {
       actions: [action],
       createdBy: 'user_1',
     })
-    await expect(promise).rejects.toThrow('condition_branch/start_approval requires execution_mode workflow_job_v1')
+    await expect(promise).rejects.toThrow('condition_branch/start_approval/parallel_branch requires execution_mode workflow_job_v1')
   })
 
   it('W6-1: createRule rejects invalid start_approval config before persistence', async () => {
@@ -2400,6 +2400,142 @@ describe('AutomationService — Rule CRUD', () => {
     })
 
     await expect(promise).rejects.toThrow('cannot contain wait_for_callback until A6-3-3')
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
+  it('A6-3-1: createRule rejects parallel_branch inside a condition_branch branch', async () => {
+    const nestedParallel = {
+      type: 'parallel_branch',
+      config: {
+        joinMode: 'all',
+        branches: [{
+          key: 'nested',
+          actions: [{ type: 'update_record', config: { fields: { status: 'nested' } } }],
+        }],
+      },
+    }
+    const promise = service.createRule('sheet_1', {
+      name: 'Nested parallel branch',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'condition_branch',
+      actionConfig: {
+        branches: [{
+          key: 'needs_parallel',
+          conditions: { logic: 'and', conditions: [{ fieldId: 'status', operator: 'equals', value: 'pending' }] },
+          actions: [nestedParallel],
+        }],
+      },
+      actions: [{
+        type: 'condition_branch',
+        config: {
+          branches: [{
+            key: 'needs_parallel',
+            conditions: { logic: 'and', conditions: [{ fieldId: 'status', operator: 'equals', value: 'pending' }] },
+            actions: [nestedParallel],
+          }],
+        },
+      }],
+      executionMode: 'workflow_job_v1',
+      createdBy: 'user_1',
+    })
+
+    await expect(promise).rejects.toThrow('cannot contain parallel_branch until a later nested-DAG slice')
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
+  it('A6-3-4: createRule accepts parallel_branch only with workflow_job_v1', async () => {
+    const action = {
+      type: 'parallel_branch',
+      config: {
+        joinMode: 'all',
+        branches: [
+          {
+            key: 'ops',
+            label: 'Ops',
+            actions: [{ type: 'update_record', config: { fields: { status: 'ops' } } }],
+          },
+          {
+            key: 'notify',
+            actions: [{ type: 'send_notification', config: { userIds: ['u1'], message: 'ready' } }],
+          },
+        ],
+      },
+    } as const
+
+    dbExecuteResults.push([])
+    const rule = await service.createRule('sheet_1', {
+      name: 'Parallel rule',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'parallel_branch',
+      actionConfig: action.config,
+      actions: [action],
+      executionMode: 'workflow_job_v1',
+      createdBy: 'user_1',
+    })
+
+    expect(rule.action_type).toBe('parallel_branch')
+    expect(rule.actions).toEqual([action])
+    expect(rule.execution_mode).toBe('workflow_job_v1')
+
+    const promise = service.createRule('sheet_1', {
+      name: 'Parallel rule legacy',
+      triggerType: 'record.created',
+      triggerConfig: {},
+      actionType: 'parallel_branch',
+      actionConfig: action.config,
+      actions: [action],
+      createdBy: 'user_1',
+    })
+    await expect(promise).rejects.toThrow('requires execution_mode workflow_job_v1')
+  })
+
+  it('A6-3-4: createRule rejects unsupported actions inside parallel_branch branches', async () => {
+    const unsupportedActions = [
+      { type: 'wait_for_callback', config: {}, expected: 'cannot contain wait_for_callback in A6-3-4' },
+      {
+        type: 'parallel_branch',
+        config: {
+          joinMode: 'all',
+          branches: [{
+            key: 'nested',
+            actions: [{ type: 'update_record', config: { fields: { status: 'nested' } } }],
+          }],
+        },
+        expected: 'cannot contain parallel_branch in A6-3-4',
+      },
+    ]
+
+    for (const unsupportedAction of unsupportedActions) {
+      const promise = service.createRule('sheet_1', {
+        name: 'Parallel bad branch',
+        triggerType: 'record.created',
+        triggerConfig: {},
+        actionType: 'parallel_branch',
+        actionConfig: {
+          joinMode: 'all',
+          branches: [{
+            key: 'unsupported',
+            actions: [{ type: unsupportedAction.type, config: unsupportedAction.config }],
+          }],
+        },
+        actions: [{
+          type: 'parallel_branch',
+          config: {
+            joinMode: 'all',
+            branches: [{
+              key: 'unsupported',
+              actions: [{ type: unsupportedAction.type, config: unsupportedAction.config }],
+            }],
+          },
+        }],
+        executionMode: 'workflow_job_v1',
+        createdBy: 'user_1',
+      })
+
+      await expect(promise).rejects.toThrow(unsupportedAction.expected)
+    }
     expect(dbExecuteResults).toHaveLength(0)
   })
 
@@ -2731,7 +2867,65 @@ describe('AutomationService — Rule CRUD', () => {
 
     const promise = service.updateRule('atr_1', 'sheet_1', { executionMode: null })
 
-    await expect(promise).rejects.toThrow('condition_branch/start_approval requires execution_mode workflow_job_v1')
+    await expect(promise).rejects.toThrow('condition_branch/start_approval/parallel_branch requires execution_mode workflow_job_v1')
+    expect(dbExecuteResults).toHaveLength(0)
+  })
+
+  it('A6-3-4: updateRule accepts parallel_branch with workflow_job_v1', async () => {
+    const action = {
+      type: 'parallel_branch',
+      config: {
+        joinMode: 'all',
+        branches: [
+          { key: 'ops', actions: [{ type: 'update_record', config: { fields: { status: 'ops' } } }] },
+          { key: 'notify', actions: [{ type: 'send_notification', config: { userIds: ['u1'], message: 'ok' } }] },
+        ],
+      },
+    }
+    dbExecuteTakeFirstResults.push(makeRuleRow({
+      action_type: 'update_record',
+      action_config: { fields: { status: 'before' } },
+      actions: [{ type: 'update_record', config: { fields: { status: 'before' } } }],
+    }))
+    dbExecuteResults.push([makeRuleRow({
+      action_type: 'parallel_branch',
+      action_config: action.config,
+      actions: [action],
+      execution_mode: 'workflow_job_v1',
+    })])
+
+    const rule = await service.updateRule('atr_1', 'sheet_1', {
+      actionType: 'parallel_branch',
+      actionConfig: action.config,
+      actions: [action],
+      executionMode: 'workflow_job_v1',
+    })
+
+    expect(rule?.action_type).toBe('parallel_branch')
+    expect(rule?.actions).toEqual([action])
+    expect(rule?.execution_mode).toBe('workflow_job_v1')
+  })
+
+  it('A6-3-4: updateRule rejects turning a parallel_branch rule back to legacy', async () => {
+    const action = {
+      type: 'parallel_branch',
+      config: {
+        joinMode: 'all',
+        branches: [
+          { key: 'ops', actions: [{ type: 'update_record', config: { fields: { status: 'ops' } } }] },
+        ],
+      },
+    }
+    dbExecuteTakeFirstResults.push(makeRuleRow({
+      action_type: 'parallel_branch',
+      action_config: action.config,
+      actions: [action],
+      execution_mode: 'workflow_job_v1',
+    }))
+
+    const promise = service.updateRule('atr_1', 'sheet_1', { executionMode: null })
+
+    await expect(promise).rejects.toThrow('requires execution_mode workflow_job_v1')
     expect(dbExecuteResults).toHaveLength(0)
   })
 
@@ -3313,6 +3507,345 @@ describe('AutomationExecutor — A6-1 job lifecycle hooks', () => {
       { actionType: 'send_webhook', status: 'skipped', durationMs: 0 },
     ])
     expect(deps.fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('A6-3-4: parallel_branch runs all branches and upstreams the next top-level job from the parent join', async () => {
+    let executionId = ''
+    const events: Array<{
+      phase: string
+      index: number
+      type: string
+      status?: string
+      stepKey?: string
+      jobId?: string
+      upstreamJobId?: string | null
+    }> = []
+    const lifecycle = {
+      factory: (id: string) => {
+        executionId = id
+        return {
+          onStart: async (index: number, action: { type: string }, meta?: { stepKey?: string; jobId?: string; upstreamJobId?: string | null }) => {
+            events.push({ phase: 'start', index, type: action.type, ...meta })
+          },
+          onSettled: async (index: number, action: { type: string }, result: { status: string }, meta?: { stepKey?: string; jobId?: string; upstreamJobId?: string | null }) => {
+            events.push({ phase: 'settled', index, type: action.type, status: result.status, ...meta })
+          },
+          onSkipped: async (index: number, action: { type: string }, meta?: { stepKey?: string; jobId?: string; upstreamJobId?: string | null }) => {
+            events.push({ phase: 'skipped', index, type: action.type, ...meta })
+          },
+        }
+      },
+    }
+    const rule = createMockRule({
+      actions: [
+        {
+          type: 'parallel_branch',
+          config: {
+            joinMode: 'all',
+            branches: [
+              {
+                key: 'ops',
+                label: 'Ops',
+                actions: [{ type: 'update_record', config: { fields: { status: 'ops' } } }],
+              },
+              {
+                key: 'notify',
+                actions: [{ type: 'send_notification', config: { userIds: ['u1'], message: 'done' } }],
+              },
+            ],
+          },
+        },
+        { type: 'send_webhook', config: { url: 'https://example.com/after' } },
+      ],
+    })
+
+    const execution = await executor.execute(rule, {
+      recordId: 'r1',
+      data: {},
+      sheetId: 'sheet_1',
+    }, lifecycle.factory)
+
+    expect(execution.status).toBe('success')
+    expect(execution.steps).toHaveLength(2)
+    expect(execution.steps[0]).toMatchObject({
+      actionType: 'parallel_branch',
+      status: 'success',
+      output: {
+        joinMode: 'all',
+        branchCount: 2,
+        resolvedBranchKeys: ['ops', 'notify'],
+        failedBranchKeys: [],
+        branchStatuses: { ops: 'resolved', notify: 'resolved' },
+      },
+    })
+    expect(events).toEqual([
+      { phase: 'start', index: 0, type: 'parallel_branch' },
+      {
+        phase: 'start',
+        index: 0,
+        type: 'update_record',
+        stepKey: '0.parallel.ops.0',
+        jobId: `${executionId}:job:0:parallel:ops:0`,
+        upstreamJobId: `${executionId}:job:0`,
+      },
+      {
+        phase: 'settled',
+        index: 0,
+        type: 'update_record',
+        status: 'success',
+        stepKey: '0.parallel.ops.0',
+        jobId: `${executionId}:job:0:parallel:ops:0`,
+        upstreamJobId: `${executionId}:job:0`,
+      },
+      {
+        phase: 'start',
+        index: 0,
+        type: 'send_notification',
+        stepKey: '0.parallel.notify.0',
+        jobId: `${executionId}:job:0:parallel:notify:0`,
+        upstreamJobId: `${executionId}:job:0`,
+      },
+      {
+        phase: 'settled',
+        index: 0,
+        type: 'send_notification',
+        status: 'success',
+        stepKey: '0.parallel.notify.0',
+        jobId: `${executionId}:job:0:parallel:notify:0`,
+        upstreamJobId: `${executionId}:job:0`,
+      },
+      { phase: 'settled', index: 0, type: 'parallel_branch', status: 'success' },
+      {
+        phase: 'start',
+        index: 1,
+        type: 'send_webhook',
+        upstreamJobId: `${executionId}:job:0`,
+      },
+      { phase: 'settled', index: 1, type: 'send_webhook', status: 'success' },
+    ])
+    expect(deps.fetchFn).toHaveBeenCalledTimes(1) // only the after action uses fetch
+  })
+
+  it('A6-3-4: branch failure skips only that branch tail, still runs siblings, then fails parent and skips downstream', async () => {
+    let executionId = ''
+    const events: Array<{
+      phase: string
+      index: number
+      type: string
+      status?: string
+      stepKey?: string
+      jobId?: string
+      upstreamJobId?: string | null
+    }> = []
+    const lifecycle = {
+      factory: (id: string) => {
+        executionId = id
+        return {
+          onStart: async (index: number, action: { type: string }, meta?: { stepKey?: string; jobId?: string; upstreamJobId?: string | null }) => {
+            events.push({ phase: 'start', index, type: action.type, ...meta })
+          },
+          onSettled: async (index: number, action: { type: string }, result: { status: string }, meta?: { stepKey?: string; jobId?: string; upstreamJobId?: string | null }) => {
+            events.push({ phase: 'settled', index, type: action.type, status: result.status, ...meta })
+          },
+          onSkipped: async (index: number, action: { type: string }, meta?: { stepKey?: string; jobId?: string; upstreamJobId?: string | null }) => {
+            events.push({ phase: 'skipped', index, type: action.type, ...meta })
+          },
+        }
+      },
+    }
+    const rule = createMockRule({
+      actions: [
+        {
+          type: 'parallel_branch',
+          config: {
+            joinMode: 'all',
+            branches: [
+              {
+                key: 'bad',
+                actions: [
+                  { type: 'send_notification', config: { userIds: [], message: 'missing users' } },
+                  { type: 'update_record', config: { fields: { should_not_run: true } } },
+                ],
+              },
+              {
+                key: 'good',
+                actions: [{ type: 'update_record', config: { fields: { status: 'good' } } }],
+              },
+            ],
+          },
+        },
+        { type: 'send_webhook', config: { url: 'https://example.com/after' } },
+      ],
+    })
+
+    const execution = await executor.execute(rule, {
+      recordId: 'r1',
+      data: {},
+      sheetId: 'sheet_1',
+    }, lifecycle.factory)
+
+    expect(execution.status).toBe('failed')
+    expect(execution.steps).toEqual([
+      expect.objectContaining({
+        actionType: 'parallel_branch',
+        status: 'failed',
+        output: expect.objectContaining({
+          resolvedBranchKeys: ['good'],
+          failedBranchKeys: ['bad'],
+          branchStatuses: { bad: 'failed', good: 'resolved' },
+        }),
+      }),
+      { actionType: 'send_webhook', status: 'skipped', durationMs: 0 },
+    ])
+    expect(events).toEqual([
+      { phase: 'start', index: 0, type: 'parallel_branch' },
+      {
+        phase: 'start',
+        index: 0,
+        type: 'send_notification',
+        stepKey: '0.parallel.bad.0',
+        jobId: `${executionId}:job:0:parallel:bad:0`,
+        upstreamJobId: `${executionId}:job:0`,
+      },
+      {
+        phase: 'settled',
+        index: 0,
+        type: 'send_notification',
+        status: 'failed',
+        stepKey: '0.parallel.bad.0',
+        jobId: `${executionId}:job:0:parallel:bad:0`,
+        upstreamJobId: `${executionId}:job:0`,
+      },
+      {
+        phase: 'skipped',
+        index: 0,
+        type: 'update_record',
+        stepKey: '0.parallel.bad.1',
+        jobId: `${executionId}:job:0:parallel:bad:1`,
+        upstreamJobId: `${executionId}:job:0:parallel:bad:0`,
+      },
+      {
+        phase: 'start',
+        index: 0,
+        type: 'update_record',
+        stepKey: '0.parallel.good.0',
+        jobId: `${executionId}:job:0:parallel:good:0`,
+        upstreamJobId: `${executionId}:job:0`,
+      },
+      {
+        phase: 'settled',
+        index: 0,
+        type: 'update_record',
+        status: 'success',
+        stepKey: '0.parallel.good.0',
+        jobId: `${executionId}:job:0:parallel:good:0`,
+        upstreamJobId: `${executionId}:job:0`,
+      },
+      { phase: 'settled', index: 0, type: 'parallel_branch', status: 'failed' },
+      { phase: 'skipped', index: 1, type: 'send_webhook' },
+    ])
+    expect(deps.fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('A6-3-4: parallel_branch runtime rejects unsupported persisted child actions before child jobs or side effects', async () => {
+    const events: Array<{ phase: string; index: number; type: string; status?: string }> = []
+    const lifecycle = {
+      factory: () => ({
+        onStart: async (index: number, action: { type: string }) => {
+          events.push({ phase: 'start', index, type: action.type })
+        },
+        onSettled: async (index: number, action: { type: string }, result: { status: string }) => {
+          events.push({ phase: 'settled', index, type: action.type, status: result.status })
+        },
+        onSkipped: async (index: number, action: { type: string }) => {
+          events.push({ phase: 'skipped', index, type: action.type })
+        },
+      }),
+    }
+    const rule = createMockRule({
+      actions: [
+        {
+          type: 'parallel_branch',
+          config: {
+            joinMode: 'all',
+            branches: [{
+              key: 'bad',
+              actions: [{ type: 'send_webhook', config: { url: 'https://example.com/should-not-run' } }],
+            }],
+          },
+        },
+        { type: 'send_webhook', config: { url: 'https://example.com/after' } },
+      ],
+    })
+
+    const execution = await executor.execute(rule, {
+      recordId: 'r1',
+      data: {},
+      sheetId: 'sheet_1',
+    }, lifecycle.factory)
+
+    expect(execution.status).toBe('failed')
+    expect(execution.steps).toEqual([
+      expect.objectContaining({
+        actionType: 'parallel_branch',
+        status: 'failed',
+        error: 'parallel_branch.branches[0].actions cannot contain send_webhook in A6-3-4',
+      }),
+      { actionType: 'send_webhook', status: 'skipped', durationMs: 0 },
+    ])
+    expect(events).toEqual([
+      { phase: 'start', index: 0, type: 'parallel_branch' },
+      { phase: 'settled', index: 0, type: 'parallel_branch', status: 'failed' },
+      { phase: 'skipped', index: 1, type: 'send_webhook' },
+    ])
+    expect(deps.fetchFn).not.toHaveBeenCalled()
+  })
+
+  it('A6-3-4: parallel_branch runtime rejects persisted configs over branch/action bounds before child jobs', async () => {
+    const events: Array<{ phase: string; index: number; type: string; status?: string }> = []
+    const lifecycle = {
+      factory: () => ({
+        onStart: async (index: number, action: { type: string }) => {
+          events.push({ phase: 'start', index, type: action.type })
+        },
+        onSettled: async (index: number, action: { type: string }, result: { status: string }) => {
+          events.push({ phase: 'settled', index, type: action.type, status: result.status })
+        },
+        onSkipped: async (index: number, action: { type: string }) => {
+          events.push({ phase: 'skipped', index, type: action.type })
+        },
+      }),
+    }
+    const branches = Array.from({ length: 11 }, (_unused, index) => ({
+      key: `branch_${index}`,
+      actions: [{ type: 'update_record', config: { fields: { status: `b${index}` } } }],
+    }))
+    const rule = createMockRule({
+      actions: [{
+        type: 'parallel_branch',
+        config: { joinMode: 'all', branches },
+      }],
+    })
+
+    const execution = await executor.execute(rule, {
+      recordId: 'r1',
+      data: {},
+      sheetId: 'sheet_1',
+    }, lifecycle.factory)
+
+    expect(execution.status).toBe('failed')
+    expect(execution.steps).toEqual([
+      expect.objectContaining({
+        actionType: 'parallel_branch',
+        status: 'failed',
+        error: 'parallel_branch.branches exceeds max 10',
+      }),
+    ])
+    expect(events).toEqual([
+      { phase: 'start', index: 0, type: 'parallel_branch' },
+      { phase: 'settled', index: 0, type: 'parallel_branch', status: 'failed' },
+    ])
+    expect(deps.queryFn).not.toHaveBeenCalled()
   })
 })
 

--- a/packages/core-backend/tests/unit/parallel-branch-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/parallel-branch-automation-action-migration.test.ts
@@ -1,0 +1,27 @@
+import { describe, expect, it } from 'vitest'
+import { ALL_ACTION_TYPES } from '../../src/multitable/automation-actions'
+import {
+  AUTOMATION_ACTION_TYPES_BEFORE_PARALLEL_BRANCH,
+  AUTOMATION_ACTION_TYPES_WITH_PARALLEL_BRANCH,
+} from '../../src/db/migrations/zzzz20260611120000_add_parallel_branch_automation_action'
+
+describe('parallel_branch automation action migration (A6-3-4 / W3-1)', () => {
+  it('keeps the latest database action constraint in sync with app-level action types', () => {
+    for (const actionType of ALL_ACTION_TYPES) {
+      expect(AUTOMATION_ACTION_TYPES_WITH_PARALLEL_BRANCH).toContain(actionType)
+    }
+  })
+
+  it('adds parallel_branch on top of the prior start_approval action set, and nothing else', () => {
+    expect(AUTOMATION_ACTION_TYPES_WITH_PARALLEL_BRANCH).toContain('parallel_branch')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_PARALLEL_BRANCH).not.toContain('parallel_branch')
+    expect(AUTOMATION_ACTION_TYPES_WITH_PARALLEL_BRANCH.filter((a) => a !== 'parallel_branch'))
+      .toEqual([...AUTOMATION_ACTION_TYPES_BEFORE_PARALLEL_BRANCH])
+  })
+
+  it('rolls back only the parallel_branch widening', () => {
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_PARALLEL_BRANCH).not.toContain('parallel_branch')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_PARALLEL_BRANCH).toContain('start_approval')
+    expect(AUTOMATION_ACTION_TYPES_BEFORE_PARALLEL_BRANCH).toContain('condition_branch')
+  })
+})

--- a/packages/core-backend/tests/unit/start-approval-automation-action-migration.test.ts
+++ b/packages/core-backend/tests/unit/start-approval-automation-action-migration.test.ts
@@ -1,17 +1,10 @@
 import { describe, expect, it } from 'vitest'
-import { ALL_ACTION_TYPES } from '../../src/multitable/automation-actions'
 import {
   AUTOMATION_ACTION_TYPES_BEFORE_START_APPROVAL,
   AUTOMATION_ACTION_TYPES_WITH_START_APPROVAL,
 } from '../../src/db/migrations/zzzz20260610150000_create_automation_approval_bridges'
 
 describe('start_approval automation action migration (W6-1)', () => {
-  it('keeps the latest database action constraint in sync with app-level action types', () => {
-    for (const actionType of ALL_ACTION_TYPES) {
-      expect(AUTOMATION_ACTION_TYPES_WITH_START_APPROVAL).toContain(actionType)
-    }
-  })
-
   it('adds start_approval on top of the prior condition_branch action set, and nothing else', () => {
     expect(AUTOMATION_ACTION_TYPES_WITH_START_APPROVAL).toContain('start_approval')
     expect(AUTOMATION_ACTION_TYPES_BEFORE_START_APPROVAL).not.toContain('start_approval')


### PR DESCRIPTION
## Summary

Implements A6-3-4 / W3-1 `parallel_branch` `join_all` runtime for the multitable automation convergence engine.

This slice adds the backend action contract, DB CHECK widening, executor semantics, and C1 job lineage for exclusive backend runtime support. It intentionally does **not** add frontend authoring/readability UI, worker-level true parallelism, BPMN, approval-as-job, public webhook token emitter, or any A6-4/A6-5 surface.

## Behavior

- Adds canonical `parallel_branch` automation action type and DB constraint migration.
- Requires `execution_mode: workflow_job_v1` for `parallel_branch` rules.
- Supports bounded `joinMode: 'all'` branches with simple branch actions only:
  - `update_record`
  - `send_notification`
- Rejects nested DAG/suspend surfaces in this slice:
  - `wait_for_callback`
  - `condition_branch`
  - `parallel_branch`
  - `start_approval`
- Executes all branches and then settles the parent join.
- On one branch failure:
  - skips only that branch tail,
  - still runs sibling branches,
  - marks parent `parallel_branch` failed after all branches terminal,
  - skips downstream top-level actions.
- Persists C1 job lineage:
  - parent job: `${executionId}:job:${stepIndex}`
  - branch child jobs: `${executionId}:job:${stepIndex}:parallel:${branchKey}:${actionIndex}`
  - child step keys: `${stepIndex}.parallel.${branchKey}.${actionIndex}`
  - downstream top-level job upstreams from the parent join job.

## Verification

Local verification on this branch:

- `pnpm --filter @metasheet/core-backend exec vitest run tests/unit/parallel-branch-automation-action-migration.test.ts tests/unit/start-approval-automation-action-migration.test.ts tests/unit/automation-v1.test.ts --watch=false`
  - 3 files / 181 tests passed
- `pnpm --filter @metasheet/core-backend build`
  - passed
- `git diff --check HEAD~1..HEAD`
  - passed
- Real Postgres seam after applying the new migration to local `metasheet_test`:
  - `pnpm --filter @metasheet/core-backend migrate`
  - migration executed successfully
  - `pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/multitable-automation-jobs.test.ts --reporter=dot`
  - 1 file / 8 tests passed

## Subagent review

Read-only subagent review: APPROVE, no blocker findings.

Residual awareness only:

- Branches run inline in config order, not worker-parallel; C1 still represents fan-out/fan-in.
- Resume drift guard remains top-level only; branch-local suspend/resume is still blocked by validation in this slice.

## Boundaries

Not included here:

- A6-3 frontend builder/readability for `parallel_branch`.
- Real worker parallelism.
- Branch-local `wait_for_callback` / resume.
- Nested `condition_branch` / nested `parallel_branch`.
- BPMN compile/preview.
- Approval-as-job.
