### PR TITLE
ops(multitable): perf-baseline harness — undici dispatcher + error-cause logging (S5a)

### DIFF
--- a/docs/development/multitable-perf-gate-d2-baseline-operator-runbook-20260524.md
+++ b/docs/development/multitable-perf-gate-d2-baseline-operator-runbook-20260524.md
@@ -647,6 +647,7 @@ unset TOKEN API_BASE BASE_ID ROOT
 | dispatch 立即 fail @ "Validate required env" | secrets/vars 配置缺失 — 回 §1 + §2 + §3 检查 |
 | dispatch 失败 @ "Backend seed + measure" with `[d2-perf] BASE_ID required` | `MULTITABLE_PERF_BASE_ID` 没设 — 回 §2 |
 | dispatch 失败 @ "Backend seed + measure" with `Cannot find module 'xlsx'` | pnpm install 未跑或 xlsx 不在 `packages/core-backend` deps — 检 `pnpm-lock.yaml` |
+| dispatch 失败 @ "Backend seed + measure" with `Cannot resolve undici package` | pnpm install 未跑或 root devDeps 缺 `undici`（S5a 起 seed-upload dispatcher 依赖）— 检 root `package.json` + `pnpm-lock.yaml` |
 | dispatch 失败 @ backend insert with `success ratio X% below MIN_SAMPLE_SUCCESS_RATIO=80%` | staging 后端不稳 / auth token 过期 — 检 logs，单独 curl POST /records 验证 |
 | dispatch 失败 @ backend query with `Unknown fieldId` | 不应再发生（precision pass 2 fix）— 如果发生说明 mjs 代码回归，开 fix PR |
 | dispatch 失败 @ "Frontend measure (Playwright)" with `Perf gate requires reachable API/FE` | API_BASE_URL / FE_BASE_URL 不可达 — 排查 staging 状态 |
@@ -657,6 +658,16 @@ unset TOKEN API_BASE BASE_ID ROOT
 ---
 
 ## 11. Changelog
+
+### v5 (2026-06-11) — S5a harness fix addendum：seed 现可承受 >300s chunk（undici dispatcher + err.cause 日志）
+
+按 verdict（`multitable-perf-gate-d2-baseline-verdict-20260525.md` §6）的两条 harness-side 处方落地，**harness-only，不触 `packages/core-backend/src/**`，不含任何实际 perf run**：
+
+- **Seed-upload-only undici dispatcher**：`scripts/ops/multitable-perf-baseline.mjs` 的 XLSX chunk 上传改走自定义 `undici.Agent`（`headersTimeout`/`bodyTimeout` = 1800s，env `SEED_UPLOAD_TIMEOUT_MS` 只可上调不可低于 1800s）；其余 API 调用保持 Node 默认 dispatcher 不变。此前 50k/100k seed 全部死于客户端 undici 默认 300s `headersTimeout`（~307s 墙），现在 >300s 的同步 import chunk 可存活。`undici@^6` 加为 root devDependency（lockfile 同步更新）。
+- **错误日志补 `err.cause`**：harness 此前只打 `err.message`（"fetch failed"），掩盖了底层 `UND_ERR_HEADERS_TIMEOUT`；现统一经 `formatErrorWithCause()`（含 cause 链 + code）输出。
+- **Chunk 大小指引（belt-and-braces）**：默认 `XLSX_CHUNK_SIZE=50000` 不变；如想让单 chunk 服务端耗时落在 verdict 验证过的安全区（~≤200s；10k chunk 实测 ~100s），设 `XLSX_CHUNK_SIZE=20000`（50k→3 chunks、100k→5 chunks）。
+- 新增单测 `scripts/ops/multitable-perf-baseline-upload.test.mjs`（`pnpm run verify:multitable-perf:baseline-harness:test`，无网络）。
+- **本 runbook 操作流程不变**：staging run 程序照旧；**runs 仍必须串行**（verdict §5 contention 教训：一次只 dispatch 一个）；实际 50k/100k staging run（S5b）仍是 operator-gated 的独立 opt-in，本次未执行。
 
 ### v4 (2026-05-24) — Pre-push precision pass 3 — 2 Medium + 1 Low fixes
 

--- a/package.json
+++ b/package.json
@@ -76,6 +76,7 @@
     "verify:multitable-yjs:contract": "node --test scripts/ops/multitable-yjs-contract-parity.test.mjs",
     "verify:multitable-release:phase3": "node scripts/ops/multitable-phase3-release-gate.mjs --gate release:phase3",
     "verify:multitable-perf:large-table": "node scripts/ops/multitable-phase3-release-gate.mjs --gate perf:large-table",
+    "verify:multitable-perf:baseline-harness:test": "node --test scripts/ops/multitable-perf-baseline-upload.test.mjs",
     "verify:multitable-permissions:matrix": "node scripts/ops/multitable-phase3-release-gate.mjs --gate permissions:matrix",
     "verify:multitable-automation:soak": "node scripts/ops/multitable-automation-soak.mjs",
     "prepare:multitable-pilot:handoff": "node scripts/ops/multitable-pilot-handoff.mjs",
@@ -163,6 +164,7 @@
     "prettier": "^3.1.1",
     "tsx": "^4.20.6",
     "typescript": "^5.3.3",
+    "undici": "^6.21.3",
     "vitest": "^1.1.0"
   },
   "keywords": [

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -57,6 +57,9 @@ importers:
       typescript:
         specifier: ^5.3.3
         version: 5.8.3
+      undici:
+        specifier: ^6.21.3
+        version: 6.26.0
       vitest:
         specifier: ^1.1.0
         version: 1.6.1(@types/node@20.19.25)(jsdom@27.2.0)(less@4.4.2)
@@ -4263,6 +4266,10 @@ packages:
 
   undici-types@6.21.0:
     resolution: {integrity: sha512-iwDZqg0QAGrg9Rav5H4n0M64c3mkR59cJ6wQp+7C4nI0gsmExaedaYLNO44eT4AtBBwjbTiGPMlt2Md0T9H9JQ==}
+
+  undici@6.26.0:
+    resolution: {integrity: sha512-4yqz8a3n5HmGTlsbADNtr/dJlhkh/55Rq798G6ibiULcXbDtaLpTl1pvdqcbFfeoj3iSi52lePFM7h9H21cw/A==}
+    engines: {node: '>=18.17'}
 
   universalify@2.0.1:
     resolution: {integrity: sha512-gptHNQghINnc/vTGIk0SOFGFNXw7JVrlRUtConJRlvaw6DuX0wO5Jeko9sWrMBhh+PsYAZ7oXAiOnf/UKogyiw==}
@@ -8788,6 +8795,8 @@ snapshots:
       which-boxed-primitive: 1.1.1
 
   undici-types@6.21.0: {}
+
+  undici@6.26.0: {}
 
   universalify@2.0.1: {}
 

--- a/scripts/ops/multitable-perf-baseline-upload.mjs
+++ b/scripts/ops/multitable-perf-baseline-upload.mjs
@@ -1,0 +1,106 @@
+/**
+ * Multitable D2 Perf Baseline — seed-upload helpers (S5a harness fix)
+ *
+ * Extracted, network-free helpers behind the §6 design-delta fix in
+ * docs/development/multitable-perf-gate-d2-baseline-verdict-20260525.md:
+ * all 50k/100k seed attempts died at ~307s with `TypeError: fetch failed`
+ * because Node/undici's DEFAULT `headersTimeout` (300000 ms) fired while the
+ * server synchronously processed the XLSX import chunk. The verdict's
+ * prescribed harness-side fixes (no packages/core-backend/src/** change):
+ *
+ *   1. a custom undici dispatcher with headersTimeout/bodyTimeout raised for
+ *      the upload (seed) calls ONLY — implemented by createUploadDispatcher();
+ *   2. error logging that surfaces `err.cause` (the literal
+ *      UND_ERR_HEADERS_TIMEOUT was masked because only `err.message` was
+ *      printed) — implemented by formatErrorWithCause().
+ *
+ * Kept dependency-free so the unit test (multitable-perf-baseline-upload.test.mjs)
+ * runs without network and without importing the harness (which exits on
+ * missing API_BASE/AUTH_TOKEN at module load).
+ */
+
+/** Server cap XLSX_MAX_ROWS=50_000 — a chunk may never exceed it. */
+export const XLSX_SERVER_MAX_ROWS = 50_000
+
+/** Default chunk size (= server cap; one upload per 50k rows). */
+export const DEFAULT_XLSX_CHUNK_SIZE = 50_000
+
+/**
+ * Default seed-upload headers/body timeout: 1800s (≥ the 1800s the operator
+ * proved harmless server-side via the moot nginx bump; 6× the undici default
+ * 300s wall that killed every ≥50k chunk).
+ */
+export const DEFAULT_SEED_UPLOAD_TIMEOUT_MS = 1_800_000
+
+/**
+ * Resolve XLSX_CHUNK_SIZE from a raw env string.
+ * Clamped to [1, XLSX_SERVER_MAX_ROWS]; empty/non-numeric input falls back to
+ * the default (the previous inline math propagated NaN for non-numeric input).
+ */
+export function resolveXlsxChunkSize(raw) {
+  if (raw === undefined || raw === null || raw === '') return DEFAULT_XLSX_CHUNK_SIZE
+  const n = Number(raw)
+  if (!Number.isFinite(n)) return DEFAULT_XLSX_CHUNK_SIZE
+  return Math.max(1, Math.min(XLSX_SERVER_MAX_ROWS, n))
+}
+
+/**
+ * Resolve the seed-upload timeout from a raw env string (SEED_UPLOAD_TIMEOUT_MS).
+ * Floored at DEFAULT_SEED_UPLOAD_TIMEOUT_MS so the harness always satisfies the
+ * verdict's "≥1800s for upload calls" requirement — operators may only raise it.
+ */
+export function resolveSeedUploadTimeoutMs(raw) {
+  if (raw === undefined || raw === null || raw === '') return DEFAULT_SEED_UPLOAD_TIMEOUT_MS
+  const n = Number(raw)
+  if (!Number.isFinite(n)) return DEFAULT_SEED_UPLOAD_TIMEOUT_MS
+  return Math.max(DEFAULT_SEED_UPLOAD_TIMEOUT_MS, Math.round(n))
+}
+
+/**
+ * Build the undici Agent options for the seed-upload dispatcher.
+ * headersTimeout is THE limit that produced the 307s wall (server returns no
+ * response headers until the synchronous per-row import loop finishes);
+ * bodyTimeout is raised alongside as the same class of idle limit.
+ */
+export function buildUploadDispatcherOptions(timeoutMs) {
+  const t = resolveSeedUploadTimeoutMs(timeoutMs)
+  return { headersTimeout: t, bodyTimeout: t }
+}
+
+/**
+ * Construct the upload-only dispatcher from an undici Agent constructor.
+ * The Agent class is injected (not imported here) so unit tests can assert the
+ * applied options with a fake constructor, and so the harness can lazy-import
+ * undici only on the seed path (rollback phase stays dependency-light).
+ */
+export function createUploadDispatcher(AgentCtor, timeoutMs) {
+  return new AgentCtor(buildUploadDispatcherOptions(timeoutMs))
+}
+
+const MAX_CAUSE_DEPTH = 5
+
+/**
+ * Format an error INCLUDING its `cause` chain (and `code` when present).
+ * The verdict's evidence caveat: the harness printed only `err.message`
+ * ("fetch failed"), masking the underlying UND_ERR_HEADERS_TIMEOUT cause.
+ * Depth-capped so cyclic cause chains terminate.
+ */
+export function formatErrorWithCause(err) {
+  const parts = []
+  let current = err
+  for (let depth = 0; depth <= MAX_CAUSE_DEPTH && current !== undefined && current !== null; depth++) {
+    const code = typeof current === 'object' && current.code ? ` [code=${current.code}]` : ''
+    const message =
+      current instanceof Error
+        ? current.message || String(current)
+        : typeof current === 'object'
+          ? JSON.stringify(current)
+          : String(current)
+    parts.push(`${message}${code}`)
+    current = typeof current === 'object' ? current.cause : undefined
+    if (current !== undefined && current !== null && depth === MAX_CAUSE_DEPTH) {
+      parts.push('(cause chain truncated)')
+    }
+  }
+  return parts.join(' ← caused by: ')
+}

--- a/scripts/ops/multitable-perf-baseline-upload.test.mjs
+++ b/scripts/ops/multitable-perf-baseline-upload.test.mjs
@@ -1,0 +1,127 @@
+import assert from 'node:assert/strict'
+import test from 'node:test'
+
+import {
+  DEFAULT_SEED_UPLOAD_TIMEOUT_MS,
+  DEFAULT_XLSX_CHUNK_SIZE,
+  XLSX_SERVER_MAX_ROWS,
+  buildUploadDispatcherOptions,
+  createUploadDispatcher,
+  formatErrorWithCause,
+  resolveSeedUploadTimeoutMs,
+  resolveXlsxChunkSize,
+} from './multitable-perf-baseline-upload.mjs'
+
+// ---------------------------------------------------------------------------
+// Dispatcher construction (verdict §6 fix #2 — timeouts applied; no network)
+// ---------------------------------------------------------------------------
+
+class FakeAgent {
+  constructor(opts) {
+    this.opts = opts
+  }
+}
+
+test('createUploadDispatcher applies 1800s headers/body timeouts by default', () => {
+  const dispatcher = createUploadDispatcher(FakeAgent, undefined)
+  assert.deepEqual(dispatcher.opts, {
+    headersTimeout: 1_800_000,
+    bodyTimeout: 1_800_000,
+  })
+})
+
+test('default seed-upload timeout is ≥1800s (the verdict requirement)', () => {
+  assert.equal(DEFAULT_SEED_UPLOAD_TIMEOUT_MS, 1_800_000)
+  assert.ok(DEFAULT_SEED_UPLOAD_TIMEOUT_MS >= 1_800_000)
+  // …and strictly above the undici default 300s headersTimeout that produced
+  // the 307s wall on every ≥50k chunk.
+  assert.ok(DEFAULT_SEED_UPLOAD_TIMEOUT_MS > 300_000)
+})
+
+test('resolveSeedUploadTimeoutMs allows raising but floors at 1800s', () => {
+  assert.equal(resolveSeedUploadTimeoutMs('3600000'), 3_600_000) // raise OK
+  assert.equal(resolveSeedUploadTimeoutMs('1000'), 1_800_000) // cannot go below
+  assert.equal(resolveSeedUploadTimeoutMs('300000'), 1_800_000) // undici default rejected
+  assert.equal(resolveSeedUploadTimeoutMs(''), DEFAULT_SEED_UPLOAD_TIMEOUT_MS)
+  assert.equal(resolveSeedUploadTimeoutMs(undefined), DEFAULT_SEED_UPLOAD_TIMEOUT_MS)
+  assert.equal(resolveSeedUploadTimeoutMs('not-a-number'), DEFAULT_SEED_UPLOAD_TIMEOUT_MS)
+})
+
+test('buildUploadDispatcherOptions sets ONLY headers/body timeouts', () => {
+  const opts = buildUploadDispatcherOptions('2400000')
+  assert.deepEqual(Object.keys(opts).sort(), ['bodyTimeout', 'headersTimeout'])
+  assert.equal(opts.headersTimeout, 2_400_000)
+  assert.equal(opts.bodyTimeout, 2_400_000)
+})
+
+test('real undici Agent constructs with the raised timeouts (no network)', async () => {
+  const { Agent } = await import('undici')
+  const dispatcher = createUploadDispatcher(Agent, undefined)
+  assert.equal(typeof dispatcher.dispatch, 'function') // fetch dispatcher contract
+  assert.equal(typeof dispatcher.close, 'function')
+  await dispatcher.close()
+})
+
+// ---------------------------------------------------------------------------
+// Chunk-size math
+// ---------------------------------------------------------------------------
+
+test('resolveXlsxChunkSize default stays at the 50k server cap', () => {
+  assert.equal(DEFAULT_XLSX_CHUNK_SIZE, 50_000)
+  assert.equal(XLSX_SERVER_MAX_ROWS, 50_000)
+  assert.equal(resolveXlsxChunkSize(undefined), 50_000)
+  assert.equal(resolveXlsxChunkSize(''), 50_000)
+})
+
+test('resolveXlsxChunkSize honors the recommended ~≤200s belt-and-braces value', () => {
+  // 10k chunks measured ~100s on staging → 20k ≈ 200s per chunk.
+  assert.equal(resolveXlsxChunkSize('20000'), 20_000)
+  // 50k → 3 chunks, 100k → 5 chunks at that size (verdict §6 fix #1 math).
+  assert.equal(Math.ceil(50_000 / resolveXlsxChunkSize('20000')), 3)
+  assert.equal(Math.ceil(100_000 / resolveXlsxChunkSize('20000')), 5)
+})
+
+test('resolveXlsxChunkSize clamps to [1, 50_000] and rejects NaN', () => {
+  assert.equal(resolveXlsxChunkSize('999999'), 50_000) // server cap
+  assert.equal(resolveXlsxChunkSize('0'), 1)
+  assert.equal(resolveXlsxChunkSize('-5'), 1)
+  // Previous inline math propagated NaN for non-numeric input; now → default.
+  assert.equal(resolveXlsxChunkSize('not-a-number'), 50_000)
+})
+
+// ---------------------------------------------------------------------------
+// Error-cause logging (verdict §6 evidence caveat — err.cause was masked)
+// ---------------------------------------------------------------------------
+
+test('formatErrorWithCause surfaces the undici cause code masked by err.message', () => {
+  // Reproduces the exact masking scenario from the verdict: fetch throws
+  // TypeError("fetch failed") with the real reason only on err.cause.
+  const cause = new Error('Headers Timeout Error')
+  cause.code = 'UND_ERR_HEADERS_TIMEOUT'
+  const err = new TypeError('fetch failed', { cause })
+  const out = formatErrorWithCause(err)
+  assert.match(out, /fetch failed/)
+  assert.match(out, /Headers Timeout Error/)
+  assert.match(out, /\[code=UND_ERR_HEADERS_TIMEOUT\]/)
+})
+
+test('formatErrorWithCause without a cause prints just the message', () => {
+  assert.equal(formatErrorWithCause(new Error('plain failure')), 'plain failure')
+})
+
+test('formatErrorWithCause walks nested cause chains and non-Error causes', () => {
+  const err = new Error('layer-1', {
+    cause: new Error('layer-2', { cause: 'string-cause' }),
+  })
+  const out = formatErrorWithCause(err)
+  assert.equal(out, 'layer-1 ← caused by: layer-2 ← caused by: string-cause')
+})
+
+test('formatErrorWithCause terminates on cyclic cause chains', () => {
+  const a = new Error('a')
+  const b = new Error('b')
+  a.cause = b
+  b.cause = a
+  const out = formatErrorWithCause(a)
+  assert.match(out, /cause chain truncated/)
+})

--- a/scripts/ops/multitable-perf-baseline.mjs
+++ b/scripts/ops/multitable-perf-baseline.mjs
@@ -24,6 +24,13 @@ import path from 'path'
 import { performance } from 'perf_hooks'
 import { createRequire } from 'module'
 
+import {
+  createUploadDispatcher,
+  formatErrorWithCause,
+  resolveSeedUploadTimeoutMs,
+  resolveXlsxChunkSize,
+} from './multitable-perf-baseline-upload.mjs'
+
 // --- env config ---
 // API_BASE normalized: strip trailing slashes AND trailing /api suffix.
 // Both 'http://host:8081' and 'http://host:8081/api' work — we always
@@ -38,7 +45,18 @@ const PERF_PROFILE = String(process.env.PERF_PROFILE || 'multitable-d2-baseline'
 const PHASE = String(process.env.PHASE || 'seed_and_backend')
 const SCENARIO = String(process.env.SCENARIO || 'primary')
 const ROLLBACK = process.env.ROLLBACK !== 'false'
-const XLSX_CHUNK_SIZE = Math.max(1, Math.min(50_000, Number(process.env.XLSX_CHUNK_SIZE || 50_000)))
+// XLSX_CHUNK_SIZE: default stays 50_000 (= server cap XLSX_MAX_ROWS).
+// Chunk guidance (S5a, belt-and-braces with the upload dispatcher below): the
+// server processes each chunk SYNCHRONOUSLY (~10 ms/row → 50k ≈ 500s before
+// any response headers). The dispatcher's 1800s headersTimeout now survives
+// that, but if you want per-chunk server time to stay in verdict-proven safe
+// territory (~≤200s — 10k chunks measured ~100s on staging), set
+// XLSX_CHUNK_SIZE=20000 (50k→3 chunks, 100k→5 chunks). There is no
+// --max-chunk-seconds flag; this env is the knob.
+const XLSX_CHUNK_SIZE = resolveXlsxChunkSize(process.env.XLSX_CHUNK_SIZE)
+// Seed-upload-only headers/body timeout (≥1800s enforced; see verdict §6 —
+// undici's default 300s headersTimeout killed every ≥50k chunk at ~307s).
+const SEED_UPLOAD_TIMEOUT_MS = resolveSeedUploadTimeoutMs(process.env.SEED_UPLOAD_TIMEOUT_MS)
 const BACKEND_INSERT_SAMPLE_SIZE = Math.max(10, Number(process.env.BACKEND_INSERT_SAMPLE_SIZE || 200))
 const BACKEND_QUERY_SAMPLE_SIZE = Math.max(10, Number(process.env.BACKEND_QUERY_SAMPLE_SIZE || 50))
 const OUTPUT_DIR = String(process.env.OUTPUT_DIR || 'output/multitable-perf')
@@ -86,6 +104,9 @@ async function apiFetch(method, pathSuffix, body, opts = {}) {
   if (body && !opts.isMultipart) headers['Content-Type'] = 'application/json'
   const init = { method, headers }
   if (body) init.body = opts.isMultipart ? body : JSON.stringify(body)
+  // Seed-upload calls pass a custom undici dispatcher (raised headers/body
+  // timeouts); every other call keeps Node's default global dispatcher.
+  if (opts.dispatcher) init.dispatcher = opts.dispatcher
   const res = await fetch(url, init)
   const text = await res.text()
   let json
@@ -221,7 +242,23 @@ async function buildXlsxBuffer(xlsx, rowCount) {
   return Buffer.isBuffer(out) ? out : Buffer.from(out)
 }
 
-async function uploadXlsxChunk(xlsx, sheetId, rowsInChunk) {
+// undici is a root devDependency (added with the S5a fix); lazy-loaded so the
+// rollback phase never depends on it. Node's GLOBAL fetch ships a bundled
+// undici whose Agent is not importable — the supported way to override
+// headersTimeout/bodyTimeout per call is `import { Agent } from 'undici'` and
+// pass the instance via the (undici-specific) `dispatcher` fetch init option.
+async function loadUndiciAgent() {
+  try {
+    const mod = await import('undici')
+    return mod.Agent
+  } catch (err) {
+    throw new Error(
+      `Cannot resolve undici package (needed for the seed-upload dispatcher; root devDependency since S5a). Run pnpm install at the repo root. Error: ${err.message}`,
+    )
+  }
+}
+
+async function uploadXlsxChunk(xlsx, sheetId, rowsInChunk, dispatcher) {
   const buf = await buildXlsxBuffer(xlsx, rowsInChunk)
   const fd = new FormData()
   fd.append(
@@ -235,7 +272,7 @@ async function uploadXlsxChunk(xlsx, sheetId, rowsInChunk) {
     'POST',
     `/api/multitable/sheets/${encodeURIComponent(sheetId)}/import-xlsx`,
     fd,
-    { isMultipart: true },
+    { isMultipart: true, dispatcher },
   )
   const elapsed = performance.now() - start
   const data = env.data || env
@@ -250,23 +287,35 @@ async function uploadXlsxChunk(xlsx, sheetId, rowsInChunk) {
 
 async function seedRows(sheetId) {
   const xlsx = await loadXlsx()
-  const chunks = []
-  let remaining = ROWS
-  while (remaining > 0) {
-    const chunkSize = Math.min(XLSX_CHUNK_SIZE, remaining)
-    console.log(
-      `[seed] chunk ${chunks.length + 1}: ${chunkSize} rows (after this, remaining=${remaining - chunkSize})`,
-    )
-    const result = await uploadXlsxChunk(xlsx, sheetId, chunkSize)
-    chunks.push(result)
-    if ((result.imported ?? 0) === 0 && remaining > 0) {
-      throw new Error(
-        `Chunk upload produced 0 imports while ${remaining} rows still remaining (attempted=${result.attempted}, failed=${result.failed})`,
+  const Agent = await loadUndiciAgent()
+  // Upload-only dispatcher (verdict §6 fix #2): raised headersTimeout/
+  // bodyTimeout so a chunk whose synchronous server-side import takes >300s
+  // no longer dies on the client's default undici headersTimeout.
+  const dispatcher = createUploadDispatcher(Agent, SEED_UPLOAD_TIMEOUT_MS)
+  console.log(
+    `[seed] upload dispatcher: headersTimeout=bodyTimeout=${SEED_UPLOAD_TIMEOUT_MS}ms (seed uploads only; other calls use defaults)`,
+  )
+  try {
+    const chunks = []
+    let remaining = ROWS
+    while (remaining > 0) {
+      const chunkSize = Math.min(XLSX_CHUNK_SIZE, remaining)
+      console.log(
+        `[seed] chunk ${chunks.length + 1}: ${chunkSize} rows (after this, remaining=${remaining - chunkSize})`,
       )
+      const result = await uploadXlsxChunk(xlsx, sheetId, chunkSize, dispatcher)
+      chunks.push(result)
+      if ((result.imported ?? 0) === 0 && remaining > 0) {
+        throw new Error(
+          `Chunk upload produced 0 imports while ${remaining} rows still remaining (attempted=${result.attempted}, failed=${result.failed})`,
+        )
+      }
+      remaining -= (result.imported ?? chunkSize)
     }
-    remaining -= (result.imported ?? chunkSize)
+    return chunks
+  } finally {
+    await dispatcher.close().catch(() => {})
   }
-  return chunks
 }
 
 function assertSampleSuccessRate(label, successCount, requested) {
@@ -296,7 +345,7 @@ async function measureBackendInsertDistribution(sheetId, fields) {
       await apiFetch('POST', '/api/multitable/records', { sheetId, data })
       samples.push(performance.now() - start)
     } catch (err) {
-      console.warn(`[measure-insert] sample ${i} failed: ${err.message}`)
+      console.warn(`[measure-insert] sample ${i} failed: ${formatErrorWithCause(err)}`)
     }
   }
   assertSampleSuccessRate('backend-insert', samples.length, BACKEND_INSERT_SAMPLE_SIZE)
@@ -329,7 +378,7 @@ async function measureBackendQueryDistribution(sheetId, fields) {
       await apiFetch('GET', url)
       samples.push(performance.now() - start)
     } catch (err) {
-      console.warn(`[measure-query] sample ${i} failed: ${err.message}`)
+      console.warn(`[measure-query] sample ${i} failed: ${formatErrorWithCause(err)}`)
     }
   }
   assertSampleSuccessRate('backend-query', samples.length, BACKEND_QUERY_SAMPLE_SIZE)
@@ -447,7 +496,7 @@ async function runRollback() {
   try {
     state = await readState()
   } catch (err) {
-    console.warn(`[rollback] state file unavailable (${err.message}); ROLLBACK skipped`)
+    console.warn(`[rollback] state file unavailable (${formatErrorWithCause(err)}); ROLLBACK skipped`)
     return
   }
   console.log(`[d2-perf] PHASE=rollback sheetId=${state.sheetId}`)
@@ -471,7 +520,9 @@ async function main() {
 }
 
 main().catch((err) => {
-  console.error('[d2-perf] FAILED:', err.message || err)
+  // S5a: include err.cause — the 2026-05-25 verdict's UND_ERR_HEADERS_TIMEOUT
+  // diagnosis was masked because only err.message ("fetch failed") was logged.
+  console.error('[d2-perf] FAILED:', formatErrorWithCause(err))
   if (err.stack) console.error(err.stack)
   process.exit(1)
 })


### PR DESCRIPTION
## What

S5a — harness-only fix for the D2 perf-baseline seed path, implementing **exactly the two fixes the baseline verdict itself prescribed** (`docs/development/multitable-perf-gate-d2-baseline-verdict-20260525.md` §6 "Fix options"):

> 1. Lower `XLSX_CHUNK_SIZE` … so each chunk's server response returns < 300s.
> 2. **Custom undici dispatcher** in `scripts/ops/multitable-perf-baseline.mjs` with `headersTimeout`/`bodyTimeout` raised … **for the upload call only**.

Root cause (verdict §6, empirically proven via the moot 1800s nginx bump): every ≥50k seed attempt died at ~307s on **Node/undici's default client-side `headersTimeout` (300s)** while the server synchronously processed the XLSX import chunk — and the literal `UND_ERR_HEADERS_TIMEOUT` was masked because the harness logged only `err.message` ("fetch failed").

## Changes

- **Seed-upload-only dispatcher** — `import { Agent } from 'undici'` (lazy-loaded; rollback phase stays dependency-free), `headersTimeout`/`bodyTimeout` = **1800s** (env `SEED_UPLOAD_TIMEOUT_MS` may raise; floor enforced at 1800s), passed per-call via the `dispatcher` fetch init option **only on `uploadXlsxChunk`** — all other API calls keep Node's default dispatcher. Dispatcher closed in `finally`.
  - `undici@^6.21.3` added as **root devDependency** with `pnpm-lock.yaml` updated in the same change (`pnpm install --frozen-lockfile` verified locally). undici 6 engines `>=18.17` match repo `node >=18` + workflow node 20.
  - Loopback-verified locally (throwaway script, 127.0.0.1 only): Node's global fetch routes the request through the installed undici Agent passed via `init.dispatcher`.
- **Error-cause logging** — new `formatErrorWithCause()` (cause chain + `code`, cycle-safe, depth-capped) replaces bare `err.message` at all four log sites (measure-insert / measure-query / rollback / main catch), so a future timeout prints `fetch failed ← caused by: Headers Timeout Error [code=UND_ERR_HEADERS_TIMEOUT]`.
- **Chunk guidance (belt-and-braces)** — default `XLSX_CHUNK_SIZE=50000` unchanged; harness comment + runbook recommend `XLSX_CHUNK_SIZE=20000` to keep per-chunk server time ~≤200s (verdict-proven safe: 10k chunk ≈ 100s; 50k→3 chunks, 100k→5 chunks).
- **Tests** — `scripts/ops/multitable-perf-baseline-upload.test.mjs` (node:test, **12/12 pass**, no network): dispatcher options construction (default + floor + raise + real-undici construct/close), chunk-size clamp math (incl. the old NaN propagation now falling back to default), error-cause formatting (masking scenario / nested chain / non-Error cause / cycle). npm script: `verify:multitable-perf:baseline-harness:test`.
- **Runbook v5 addendum** — `docs/development/multitable-perf-gate-d2-baseline-operator-runbook-20260524.md`: harness now survives >300s chunks; §10 troubleshooting row for missing undici; **staging run procedure unchanged; runs still must serialize** (verdict §5 contention lesson).

## Scope discipline

- **NO `packages/core-backend/src/**` changes** (Path A discipline preserved).
- Async-commit import / dedicated seed endpoint: **not touched** — named out-of-scope in the verdict; remain separate named opt-ins.
- **No seed/perf run executed** against staging or local in this PR.
- **S5b (actual 50k/100k staging runs) remains operator-gated** — this PR only makes the harness capable of surviving them.

## Verification

- `node --test scripts/ops/multitable-perf-baseline-upload.test.mjs` → 12/12 pass
- `node --check` on harness + lib → OK
- `node scripts/ops/multitable-perf-baseline.mjs` (no env) → still exits 1 with `API_BASE required` (no import-time regression)
- `pnpm install --frozen-lockfile` → passes with the updated lockfile

🤖 Generated with [Claude Code](https://claude.com/claude-code)