### PR TITLE
feat(attendance): produce C5 outbox rows for unscheduled reminders

### DIFF
--- a/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
+++ b/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
@@ -76,14 +76,16 @@
 
 | 顺序 | 项 | 当前状态 | 完成口径 |
 |---|---|---|---|
-| 1 | **C5 design-lock** | 🟡 本 PR | 锁定 `dispatched_at` 不是 delivery success、outbox/delivery-status/retry、本人 + owner/sub_owner fan-out、channel env-gating、staging smoke 口径 |
-| 2 | **C5-0 outbox DDL** | 🔒 | `attendance_notification_deliveries` 表 + CHECK/unique/index；不发送 |
-| 3 | **C5-1a unscheduled fan-out producer** | 🔒 | 未排班 intent row → 本人 + 负责人 delivery rows，幂等 source_key，重复不建 dup |
+| 1 | **C5 design-lock** | ✅ #2483 | 锁定 `dispatched_at` 不是 delivery success、outbox/delivery-status/retry、本人 + owner/sub_owner fan-out、channel env-gating、staging smoke 口径 |
+| 2 | **C5-0 outbox DDL** | ✅ #2487 | `attendance_notification_deliveries` 表 + CHECK/unique/index；不发送 |
+| 3 | **C5-1a unscheduled fan-out producer** | 🟡 本 PR | 未排班 intent row → 本人 + 负责人 delivery rows，幂等 source_key，重复不建 dup；pending CI/review/merge 后回填 ✅ |
 | 4 | **C5-1b comp-time expiry reminder producer** | 🔒 | 即将到期 active lot → 本人 + 负责人 delivery rows，不改余额；重复不建 dup |
 | 5 | **C5-2 delivery worker + fake channel** | 🔒 | pending/retrying claim → sent/retrying/failed/skipped 状态流 + retry/backoff；无真实外网依赖 |
 | 6 | **C5-3 DingTalk work-notification channel** | 🔒 | env/store-gated，复用现有 DingTalk work-notification runtime；缺配置/缺绑定 fail-visible |
 | 7 | **C5-4 admin observability** | 🔒 | read-only delivery status view/counters；不默认加手动 retry |
 | 8 | **C5-5 staging closeout** | 🔒 | C5-5a fake-channel 只证明 delivery-state（仍 🟡）；C5-5b 真实 DingTalk work-notification smoke 证明未排班 + 调休到期两 source、fan-out、delivery 状态流、retry/idempotency、scheduler 共存、cleanup residue=0 后才 ✅ |
+
+> 2026-06-11 回填：C5 design-lock #2483 与 C5-0 outbox DDL #2487 已落 main；C5-1a 正在本 PR 中接入未排班提醒 producer（仅写 outbox，不直发真实 channel），C5 整体仍保持 🟡，直到 C5-1b/C5-2/C5-3/C5-5b 完整闭环。
 
 ### Out of this target
 

--- a/packages/core-backend/src/services/AttendanceScheduler.ts
+++ b/packages/core-backend/src/services/AttendanceScheduler.ts
@@ -15,8 +15,8 @@
  * Jobs per cycle (each independently guarded, one failing never affects the others):
  *   - the comp-time EXPIRY job (④ C4, always present);
  *   - registered secondary jobs such as the ⑤ UNSCHEDULED-REMINDER job and future A2 auto-shift jobs.
- * Reuses THIS scheduler base — never a second scheduler. The notification path lives in AttendanceNotifier
- * (no channels by default ⇒ the scheduler sends nothing externally; ⑤'s reminder record is internal).
+ * Reuses THIS scheduler base — never a second scheduler. Notification delivery is a separate C5 worker
+ * path; scheduler jobs may produce outbox rows but must not call external channels directly.
  */
 
 import { randomBytes } from 'crypto'
@@ -28,7 +28,6 @@ import {
   type AttendanceExpiryService,
   type ExpiredCompTimeBalance,
 } from './AttendanceExpiryService'
-import { AttendanceNotifier, createAttendanceNotifierChannelsFromEnv } from './AttendanceNotifier'
 import { UnscheduledReminderService } from './UnscheduledReminderService'
 
 const DEFAULT_INTERVAL_MS = 60 * 60 * 1000
@@ -350,16 +349,13 @@ export function resolveAttendanceSchedulerIntervalMs(): number | undefined {
 
 /**
  * ⑤ Opt-in: the unscheduled-reminder job, only when ATTENDANCE_UNSCHEDULED_REMINDER_ENABLED=true
- * (default OFF → null → the scheduler runs expiry only, ④ unchanged). The notifier is built from env
- * channels (createAttendanceNotifierChannelsFromEnv → [] today), so the job's only effect is the internal
- * dispatch record — no external send until a channel is configured (C5). Lookahead defaults to 1 day and
- * is clamped inside the service.
+ * (default OFF → null → the scheduler runs expiry only, ④ unchanged). The job produces C5 outbox rows
+ * only; the delivery worker is the only path that may call a real notification channel. Lookahead defaults
+ * to 1 day and is clamped inside the service.
  */
 export function resolveUnscheduledReminderJob(): AttendanceSchedulerJob | null {
   if (process.env.ATTENDANCE_UNSCHEDULED_REMINDER_ENABLED !== 'true') return null
-  const notifier = new AttendanceNotifier({ channels: createAttendanceNotifierChannelsFromEnv() })
   const service = new UnscheduledReminderService({
-    notifier,
     lookaheadDays: Number(process.env.ATTENDANCE_UNSCHEDULED_REMINDER_LOOKAHEAD_DAYS),
   })
   return {

--- a/packages/core-backend/src/services/UnscheduledReminderService.ts
+++ b/packages/core-backend/src/services/UnscheduledReminderService.ts
@@ -1,18 +1,13 @@
 import { query as defaultQuery } from '../db/pg'
 import { Logger } from '../core/logger'
-import {
-  AttendanceNotifier,
-  type AttendanceNotificationMessage,
-} from './AttendanceNotifier'
 
 /**
  * ⑤ Unscheduled-shift reminder job (design-lock attendance-unscheduled-reminder-design-lock-20260604).
  *
  * A SECOND job for the C4 AttendanceScheduler (NOT a second scheduler). Each tick it scans for members of
  * `scheduled_shift` attendance groups who have NO schedule coverage for an upcoming date, CLAIMS each as a
- * dispatch row (UNIQUE index → at-most-once, mirrors ④'s status-claim), and routes the newly-claimed rows
- * through the AttendanceNotifier. Default = no channels ⇒ no external send; the claimed dispatch row is the
- * v1 internal reminder record. Real channels = C5.
+ * dispatch row (UNIQUE index → at-most-once, mirrors ④'s status-claim), and produces per-recipient C5
+ * outbox rows. The delivery worker is the only component that may turn those rows into external sends.
  *
  * Default OFF: only wired when ATTENDANCE_UNSCHEDULED_REMINDER_ENABLED=true (see AttendanceScheduler).
  */
@@ -30,12 +25,11 @@ export interface UnscheduledReminderCandidate {
 export interface UnscheduledReminderResult {
   targetDate: string
   claimed: number
-  dispatched: number
+  deliveries: number
 }
 
 export interface UnscheduledReminderServiceOptions {
   query?: UnscheduledReminderQuery
-  notifier?: AttendanceNotifier
   lookaheadDays?: number
   now?: () => Date
   logger?: Logger
@@ -46,10 +40,21 @@ interface CandidateRow {
   user_id: string
 }
 
+interface DispatchRow {
+  id: string
+  org_id: string
+  user_id: string
+  target_date: string
+  reminder_type: string
+}
+
 const DEFAULT_LOOKAHEAD_DAYS = 1
 const MIN_LOOKAHEAD_DAYS = 1
 const MAX_LOOKAHEAD_DAYS = 14
 const REMINDER_TYPE = 'unscheduled'
+const SOURCE_TYPE = 'unscheduled_reminder'
+const DELIVERY_CHANNEL = 'dingtalk_work_notification'
+const INACTIVE_RECIPIENT_ERROR = 'recipient_inactive_or_missing'
 // Must equal the plugin predicate's ATTENDANCE_SCHEDULE_OPEN_END_DATE (index.cjs) — parity-locked by the
 // integration test that compares scanCandidates() to isUserScheduledForDate().
 const OPEN_END_DATE = '9999-12-31'
@@ -90,6 +95,7 @@ const SCAN_SQL = `
   AND NOT EXISTS (
     SELECT 1 FROM attendance_shift_assignments sa
     WHERE sa.org_id = e.org_id AND sa.user_id = e.user_id AND COALESCE(sa.is_active, true) = true
+      AND COALESCE(sa.publish_status, 'published') = 'published'
       AND sa.start_date <= $1::date
       AND COALESCE(sa.end_date, DATE '${OPEN_END_DATE}') >= $1::date
   )
@@ -97,7 +103,6 @@ const SCAN_SQL = `
 
 export class UnscheduledReminderService {
   private readonly query: UnscheduledReminderQuery
-  private readonly notifier: AttendanceNotifier
   private readonly lookaheadDays: number
   private readonly now: () => Date
   private readonly logger: Logger
@@ -105,7 +110,6 @@ export class UnscheduledReminderService {
 
   constructor(options: UnscheduledReminderServiceOptions = {}) {
     this.query = options.query ?? (defaultQuery as UnscheduledReminderQuery)
-    this.notifier = options.notifier ?? new AttendanceNotifier()
     this.lookaheadDays = clampLookaheadDays(options.lookaheadDays)
     this.now = options.now ?? (() => new Date())
     this.logger = options.logger ?? new Logger('UnscheduledReminderService')
@@ -125,40 +129,130 @@ export class UnscheduledReminderService {
     return rows.map((row) => ({ orgId: row.org_id, userId: row.user_id }))
   }
 
+  async claimDispatches(targetDate: string): Promise<DispatchRow[]> {
+    const { rows } = await this.query<DispatchRow>(
+      `INSERT INTO attendance_unscheduled_reminder_dispatch (org_id, user_id, target_date, reminder_type)
+       SELECT c.org_id, c.user_id, $1::date, '${REMINDER_TYPE}'
+       FROM ( ${SCAN_SQL} ) c
+       ON CONFLICT (org_id, user_id, target_date, reminder_type) DO NOTHING
+       RETURNING id::text AS id, org_id, user_id, target_date::text AS target_date, reminder_type`,
+      [targetDate],
+    )
+    return rows
+  }
+
+  async findDispatchesMissingDeliveries(): Promise<DispatchRow[]> {
+    const { rows } = await this.query<DispatchRow>(
+      `SELECT d.id::text AS id, d.org_id, d.user_id, d.target_date::text AS target_date, d.reminder_type
+       FROM attendance_unscheduled_reminder_dispatch d
+       WHERE NOT EXISTS (
+         SELECT 1
+         FROM attendance_notification_deliveries nd
+         WHERE nd.org_id = d.org_id
+           AND nd.source_type = '${SOURCE_TYPE}'
+           AND nd.source_id = d.id::text
+       )
+       ORDER BY d.created_at ASC, d.id ASC`,
+    )
+    return rows
+  }
+
+  async produceDeliveriesForDispatches(dispatches: DispatchRow[]): Promise<number> {
+    if (dispatches.length === 0) return 0
+    const { rows } = await this.query<{ id: string }>(
+      `WITH dispatches AS (
+         SELECT id, org_id, user_id, target_date, reminder_type
+         FROM attendance_unscheduled_reminder_dispatch
+         WHERE id = ANY($1::uuid[])
+       ),
+       candidate_recipients AS (
+         SELECT d.id::text AS id, d.org_id, d.user_id, d.target_date::text AS target_date, d.reminder_type,
+                d.user_id AS recipient_user_id, 'subject'::text AS recipient_role, NULL::uuid AS group_id
+         FROM dispatches d
+         UNION ALL
+         SELECT d.id::text AS id, d.org_id, d.user_id, d.target_date::text AS target_date, d.reminder_type,
+                gm.user_id AS recipient_user_id, gm.role AS recipient_role, gm.group_id
+         FROM dispatches d
+         JOIN attendance_group_members m
+           ON m.org_id = d.org_id
+          AND m.user_id = d.user_id
+         JOIN attendance_group_managers gm
+           ON gm.org_id = d.org_id
+          AND gm.group_id = m.group_id
+          AND gm.role IN ('owner','sub_owner')
+       ),
+       recipient_rows AS (
+         SELECT c.id, c.org_id, c.user_id, c.target_date::text AS target_date, c.reminder_type,
+                c.recipient_user_id,
+                CASE
+                  WHEN bool_or(c.recipient_role = 'subject') THEN 'subject'
+                  WHEN bool_or(c.recipient_role = 'owner') THEN 'owner'
+                  ELSE 'sub_owner'
+                END AS recipient_role,
+                array_remove(ARRAY[
+                  CASE WHEN bool_or(c.recipient_role = 'subject') THEN 'subject' END,
+                  CASE WHEN bool_or(c.recipient_role = 'owner') THEN 'owner' END,
+                  CASE WHEN bool_or(c.recipient_role = 'sub_owner') THEN 'sub_owner' END
+                ], NULL) AS recipient_roles,
+                COALESCE(
+                  array_agg(DISTINCT c.group_id::text) FILTER (WHERE c.group_id IS NOT NULL),
+                  ARRAY[]::text[]
+                ) AS group_ids,
+                COALESCE(bool_or(u.is_active IS TRUE), false) AS is_active
+         FROM candidate_recipients c
+         LEFT JOIN users u ON u.id = c.recipient_user_id
+         GROUP BY c.id, c.org_id, c.user_id, c.target_date, c.reminder_type, c.recipient_user_id
+       )
+       INSERT INTO attendance_notification_deliveries
+         (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, status, last_error, payload)
+       SELECT r.org_id,
+              '${SOURCE_TYPE}',
+              r.id::text,
+              'unscheduled:' || r.id::text || ':recipient:' || r.recipient_user_id || ':channel:${DELIVERY_CHANNEL}',
+              r.recipient_user_id,
+              r.recipient_role,
+              '${DELIVERY_CHANNEL}',
+              CASE WHEN r.is_active THEN 'pending' ELSE 'skipped' END,
+              CASE WHEN r.is_active THEN NULL ELSE '${INACTIVE_RECIPIENT_ERROR}' END,
+              jsonb_build_object(
+                'kind', 'unscheduled_shift_reminder',
+                'title', 'Unscheduled shift reminder',
+                'body', 'No schedule is assigned for ' || r.target_date || '.',
+                'sourceType', '${SOURCE_TYPE}',
+                'dispatchId', r.id::text,
+                'targetDate', r.target_date,
+                'reminderType', r.reminder_type,
+                'subjectUserId', r.user_id,
+                'recipientUserId', r.recipient_user_id,
+                'recipientRole', r.recipient_role,
+                'recipientRoles', r.recipient_roles,
+                'groupIds', r.group_ids
+              )
+       FROM recipient_rows r
+       ON CONFLICT (org_id, source_key) DO NOTHING
+       RETURNING id::text AS id`,
+      [dispatches.map((dispatch) => dispatch.id)],
+    )
+    return rows.length
+  }
+
   /**
-   * Scan → claim (at-most-once) → dispatch. A re-entrancy guard (mirrors the expiry tick's `running` flag)
-   * keeps a slow scan from overlapping itself; the UNIQUE-constraint claim already makes overlap merely
-   * wasteful, not wrong.
+   * Scan → claim (at-most-once) → produce C5 outbox rows. A re-entrancy guard (mirrors the expiry
+   * tick's `running` flag) keeps a slow scan from overlapping itself; the UNIQUE-constraint claim and
+   * delivery source_key already make overlap merely wasteful, not wrong.
    */
   async run(): Promise<UnscheduledReminderResult> {
     const targetDate = this.computeTargetDate()
-    if (this.running) return { targetDate, claimed: 0, dispatched: 0 }
+    if (this.running) return { targetDate, claimed: 0, deliveries: 0 }
     this.running = true
     try {
-      // Scan + claim atomically. RETURNING yields ONLY the rows this statement inserted (won the claim);
-      // a repeat/concurrent tick conflicts on the unique index and returns nothing → no double reminder.
-      const { rows } = await this.query<CandidateRow>(
-        `INSERT INTO attendance_unscheduled_reminder_dispatch (org_id, user_id, target_date, reminder_type)
-         SELECT c.org_id, c.user_id, $1::date, '${REMINDER_TYPE}'
-         FROM ( ${SCAN_SQL} ) c
-         ON CONFLICT (org_id, user_id, target_date, reminder_type) DO NOTHING
-         RETURNING org_id, user_id`,
-        [targetDate],
-      )
-      const claimed = rows.map((row) => ({ orgId: row.org_id, userId: row.user_id }))
-      if (claimed.length === 0) return { targetDate, claimed: 0, dispatched: 0 }
-
-      const messages: AttendanceNotificationMessage[] = claimed.map((c) => ({
-        orgId: c.orgId,
-        userId: c.userId,
-        kind: 'unscheduled_shift_reminder',
-        text: `No schedule is assigned for ${targetDate}.`,
-      }))
-      const dispatch = await this.notifier.notify(messages)
+      const claimed = await this.claimDispatches(targetDate)
+      const pendingDispatches = await this.findDispatchesMissingDeliveries()
+      const deliveries = await this.produceDeliveriesForDispatches(pendingDispatches)
       this.logger.info(
-        `Unscheduled-shift reminders claimed=${claimed.length} dispatched=${dispatch.sent} target=${targetDate}`,
+        `Unscheduled-shift reminders claimed=${claimed.length} deliveries=${deliveries} target=${targetDate}`,
       )
-      return { targetDate, claimed: claimed.length, dispatched: dispatch.sent }
+      return { targetDate, claimed: claimed.length, deliveries }
     } finally {
       this.running = false
     }

--- a/packages/core-backend/tests/integration/attendance-unscheduled-reminder.test.ts
+++ b/packages/core-backend/tests/integration/attendance-unscheduled-reminder.test.ts
@@ -7,7 +7,6 @@ import {
   UnscheduledReminderService,
   type UnscheduledReminderQuery,
 } from '../../src/services/UnscheduledReminderService'
-import { AttendanceNotifier, type AttendanceNotificationMessage } from '../../src/services/AttendanceNotifier'
 
 // The shared predicate the punch path uses (plugins/plugin-attendance/index.cjs, exported). The §f parity
 // assertion compares our set-based scan to it so a future change to either side that diverges fails CI.
@@ -49,24 +48,38 @@ describeDb('⑤ unscheduled-shift reminder (real DB)', () => {
     await pool?.end().catch(() => undefined)
   })
 
-  it('scan parity with isUserScheduledForDate; claims only unscheduled scheduled_shift members; dedup; no-channel still records', async () => {
+  it('scan parity with isUserScheduledForDate; claims only unscheduled scheduled_shift members; produces C5 outbox fan-out; reconciles pre-existing dispatches', async () => {
     const suffix = `ur${Date.now().toString(36)}`
     const org = `org-${suffix}`
     const at0701 = () => new Date('2026-07-01T00:00:00.000Z')
     const target = '2026-07-02' // = 0701 + lookahead 1
-    const targetE = '2026-07-03' // = 0701 + lookahead 2 (case e, distinct claim)
+    const targetE = '2026-07-03' // pre-existing dispatch reconcile target
 
     const gSched = randomUUID(), gFixed = randomUUID(), gFree = randomUUID()
     const shiftId = randomUUID(), schedGroupId = randomUUID()
     const uNoAssign = `u-noassign-${suffix}`
     const uShift = `u-shift-${suffix}`
+    const uDraft = `u-draft-${suffix}`
     const uSchedGrp = `u-schedgrp-${suffix}`
     const uFixed = `u-fixed-${suffix}`
     const uFree = `u-free-${suffix}`
     const uMixed = `u-mixed-${suffix}`
-    const allUsers = [uNoAssign, uShift, uSchedGrp, uFixed, uFree, uMixed]
+    const ownerActive = `u-owner-${suffix}`
+    const subOwnerInactive = `u-subowner-inactive-${suffix}`
+    const ownerMissing = `u-owner-missing-${suffix}`
+    const allUsers = [uNoAssign, uShift, uDraft, uSchedGrp, uFixed, uFree, uMixed]
 
     try {
+      const seedUser = (uid: string, active = true) =>
+        pool.query(
+          `INSERT INTO users (id, email, password_hash, name, role, is_active)
+           VALUES ($1,$2,'hash',$3,'user',$4)
+           ON CONFLICT (id) DO UPDATE SET is_active = EXCLUDED.is_active`,
+          [uid, `${uid}@example.test`, uid, active],
+        )
+      for (const u of [...allUsers, ownerActive]) await seedUser(u)
+      await seedUser(subOwnerInactive, false)
+
       // --- seed groups (one of each type), a shift, a schedule group ---
       await pool.query(
         `INSERT INTO attendance_groups (id, org_id, name, attendance_type) VALUES
@@ -88,16 +101,29 @@ describeDb('⑤ unscheduled-shift reminder (real DB)', () => {
           [randomUUID(), org, gid, uid])
       await member(uNoAssign, gSched)
       await member(uShift, gSched)
+      await member(uDraft, gSched)
       await member(uSchedGrp, gSched)
       await member(uFixed, gFixed)
       await member(uFree, gFree)
       await member(uMixed, gSched)
       await member(uMixed, gFixed) // mixed → applicability guard excludes (not ALL scheduled_shift)
+      await pool.query(
+        `INSERT INTO attendance_group_managers (id, org_id, group_id, user_id, role) VALUES
+           ($1,$5,$4,$6,'owner'),
+           ($2,$5,$4,$7,'sub_owner'),
+           ($3,$5,$4,$8,'owner')`,
+        [randomUUID(), randomUUID(), randomUUID(), gSched, org, ownerActive, subOwnerInactive, ownerMissing],
+      )
       // --- coverage for the two that SHOULD be covered on the target date ---
       await pool.query(
         `INSERT INTO attendance_shift_assignments (id, org_id, user_id, shift_id, start_date, end_date, is_active)
          VALUES ($1,$2,$3,$4,'2026-07-01','2026-07-31',true)`,
         [randomUUID(), org, uShift, shiftId],
+      )
+      await pool.query(
+        `INSERT INTO attendance_shift_assignments (id, org_id, user_id, shift_id, start_date, end_date, is_active, publish_status)
+         VALUES ($1,$2,$3,$4,'2026-07-01','2026-07-31',true,'draft')`,
+        [randomUUID(), org, uDraft, shiftId],
       )
       await pool.query(
         `INSERT INTO attendance_schedule_group_members (id, org_id, schedule_group_id, user_id, effective_from, effective_to)
@@ -113,40 +139,98 @@ describeDb('⑤ unscheduled-shift reminder (real DB)', () => {
         const scheduled = await isUserScheduledForDate(pluginDb, org, u, target)
         expect(scannedMine.has(u)).toBe(!scheduled) // candidate ⇔ predicate says "unscheduled"
       }
-      // (a/b/c) only the no-coverage all-scheduled_shift member is a candidate
-      expect(scannedMine).toEqual(new Set([uNoAssign]))
+      // (a/b/c) no-coverage and draft-only all-scheduled_shift members are candidates.
+      expect(scannedMine).toEqual(new Set([uNoAssign, uDraft]))
 
-      // === run with a capture channel: claims + dispatches uNoAssign (scope assertions to our org; scan is global) ===
-      const captured: AttendanceNotificationMessage[] = []
-      const notifier = new AttendanceNotifier({ channels: [{ name: 'cap', async send(m) { captured.push(m); return { ok: true } } }] })
-      const svcCap = new UnscheduledReminderService({ query: serviceQuery, notifier, now: at0701, lookaheadDays: 1 })
-      await svcCap.run()
+      // === run: claims uNoAssign and produces C5 delivery rows (scope assertions to our org; scan is global) ===
+      const svcCap = new UnscheduledReminderService({ query: serviceQuery, now: at0701, lookaheadDays: 1 })
+      const firstRun = await svcCap.run()
+      expect(firstRun.claimed).toBeGreaterThanOrEqual(1)
       const rowCount = async (uid: string, d: string) =>
         Number((await pool.query(
           `SELECT count(*)::int AS n FROM attendance_unscheduled_reminder_dispatch WHERE org_id=$1 AND user_id=$2 AND target_date=$3`,
           [org, uid, d])).rows[0].n)
+      const deliveryRows = async (uid: string, d: string) =>
+        (await pool.query(
+          `SELECT nd.*, disp.user_id AS subject_user_id, disp.target_date::text AS target_date
+           FROM attendance_notification_deliveries nd
+           JOIN attendance_unscheduled_reminder_dispatch disp
+             ON disp.org_id = nd.org_id
+            AND disp.id::text = nd.source_id
+           WHERE nd.org_id=$1
+             AND nd.source_type='unscheduled_reminder'
+             AND disp.user_id=$2
+             AND disp.target_date=$3
+           ORDER BY nd.recipient_user_id`,
+          [org, uid, d],
+        )).rows
       expect(await rowCount(uNoAssign, target)).toBe(1)
+      expect(await rowCount(uDraft, target)).toBe(1)
       for (const u of [uShift, uSchedGrp, uFixed, uFree, uMixed]) expect(await rowCount(u, target)).toBe(0)
-      expect(captured.filter((m) => m.orgId === org).map((m) => m.userId)).toEqual([uNoAssign])
+      const rows = await deliveryRows(uNoAssign, target)
+      expect(rows).toHaveLength(4)
+      const byRecipient = new Map(rows.map((row) => [row.recipient_user_id, row]))
+      expect(byRecipient.get(uNoAssign)).toMatchObject({
+        recipient_role: 'subject',
+        channel: 'dingtalk_work_notification',
+        status: 'pending',
+        last_error: null,
+      })
+      expect(byRecipient.get(ownerActive)).toMatchObject({
+        recipient_role: 'owner',
+        channel: 'dingtalk_work_notification',
+        status: 'pending',
+        last_error: null,
+      })
+      expect(byRecipient.get(subOwnerInactive)).toMatchObject({
+        recipient_role: 'sub_owner',
+        status: 'skipped',
+        last_error: 'recipient_inactive_or_missing',
+      })
+      expect(byRecipient.get(ownerMissing)).toMatchObject({
+        recipient_role: 'owner',
+        status: 'skipped',
+        last_error: 'recipient_inactive_or_missing',
+      })
+      const ownerPayload = parsePayload(byRecipient.get(ownerActive)?.payload)
+      expect(ownerPayload.recipientRoles).toEqual(['owner'])
+      expect(ownerPayload.groupIds).toEqual([gSched])
+      expect(ownerPayload.subjectUserId).toBe(uNoAssign)
+      expect(ownerPayload.targetDate).toBe(target)
 
-      // === (d) repeat tick → no duplicate row, no second dispatch ===
+      // === (d) repeat tick → no duplicate dispatch or delivery rows ===
       await svcCap.run()
       expect(await rowCount(uNoAssign, target)).toBe(1) // unique-constraint claim held
-      expect(captured.filter((m) => m.orgId === org).length).toBe(1) // dispatched once total
+      expect(await deliveryRows(uNoAssign, target)).toHaveLength(4) // delivery source_key held
 
-      // === (e) default notifier (0 channels) → no external send, but the internal row IS recorded ===
-      const svcNoCh = new UnscheduledReminderService({ query: serviceQuery, notifier: new AttendanceNotifier(), now: at0701, lookaheadDays: 2 })
-      const eResult = await svcNoCh.run()
-      expect(eResult.dispatched).toBe(0) // no channel → nothing sent
-      expect(await rowCount(uNoAssign, targetE)).toBe(1) // but the reminder is recorded
+      // === (e) pre-existing dispatch row with no deliveries is reconciled into C5 outbox rows ===
+      const preExistingDispatchId = randomUUID()
+      await pool.query(
+        `INSERT INTO attendance_unscheduled_reminder_dispatch (id, org_id, user_id, target_date, reminder_type)
+         VALUES ($1,$2,$3,$4,'unscheduled')`,
+        [preExistingDispatchId, org, uNoAssign, targetE],
+      )
+      const reconcile = await svcCap.run()
+      expect(reconcile.deliveries).toBeGreaterThanOrEqual(4)
+      expect(await rowCount(uNoAssign, targetE)).toBe(1)
+      const reconciledRows = await deliveryRows(uNoAssign, targetE)
+      expect(reconciledRows).toHaveLength(4)
+      expect(new Set(reconciledRows.map((row) => row.source_id))).toEqual(new Set([preExistingDispatchId]))
     } finally {
+      await pool.query('DELETE FROM attendance_notification_deliveries WHERE org_id = $1', [org]).catch(() => undefined)
       await pool.query('DELETE FROM attendance_unscheduled_reminder_dispatch WHERE org_id = $1', [org]).catch(() => undefined)
       await pool.query('DELETE FROM attendance_schedule_group_members WHERE org_id = $1', [org]).catch(() => undefined)
       await pool.query('DELETE FROM attendance_shift_assignments WHERE org_id = $1', [org]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_group_managers WHERE org_id = $1', [org]).catch(() => undefined)
       await pool.query('DELETE FROM attendance_group_members WHERE org_id = $1', [org]).catch(() => undefined)
       await pool.query('DELETE FROM attendance_schedule_groups WHERE org_id = $1', [org]).catch(() => undefined)
       await pool.query('DELETE FROM attendance_shifts WHERE org_id = $1', [org]).catch(() => undefined)
       await pool.query('DELETE FROM attendance_groups WHERE org_id = $1', [org]).catch(() => undefined)
+      await pool.query('DELETE FROM users WHERE id = ANY($1::text[])', [[...allUsers, ownerActive, subOwnerInactive]]).catch(() => undefined)
     }
   })
 })
+
+function parsePayload(value: unknown): Record<string, unknown> {
+  return typeof value === 'string' ? JSON.parse(value) as Record<string, unknown> : value as Record<string, unknown>
+}

--- a/packages/core-backend/tests/unit/attendance-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduler.test.ts
@@ -121,7 +121,7 @@ describe('AttendanceScheduler (④ C4)', () => {
     const instances = new Set<unknown>()
     vi.spyOn(UnscheduledReminderService.prototype, 'run').mockImplementation(function (this: UnscheduledReminderService) {
       instances.add(this)
-      return Promise.resolve({ targetDate: '2026-06-11', claimed: 0, dispatched: 0 })
+      return Promise.resolve({ targetDate: '2026-06-11', claimed: 0, deliveries: 0 })
     })
 
     const job = resolveUnscheduledReminderJob()

--- a/packages/core-backend/tests/unit/attendance-unscheduled-reminder.test.ts
+++ b/packages/core-backend/tests/unit/attendance-unscheduled-reminder.test.ts
@@ -5,7 +5,6 @@ import {
   resolveUnscheduledReminderJob,
 } from '../../src/services/AttendanceScheduler'
 import type { AttendanceExpiryService } from '../../src/services/AttendanceExpiryService'
-import { AttendanceNotifier, type AttendanceNotificationMessage } from '../../src/services/AttendanceNotifier'
 import {
   UnscheduledReminderService,
   clampLookaheadDays,
@@ -37,31 +36,44 @@ describe('UnscheduledReminderService.computeTargetDate', () => {
   })
 })
 
-describe('UnscheduledReminderService.run (claim + dispatch)', () => {
-  it('claims candidates and dispatches the claimed set through the notifier', async () => {
-    const captured: AttendanceNotificationMessage[] = []
-    const notifier = new AttendanceNotifier({
-      channels: [{ name: 'cap', async send(m) { captured.push(m); return { ok: true } } }],
-    })
+describe('UnscheduledReminderService.run (claim + C5 outbox production)', () => {
+  it('claims candidates and produces delivery rows for claimed dispatches', async () => {
     let insertCalls = 0
+    let deliveryCalls = 0
     const query: UnscheduledReminderQuery = async (sql) => {
       if (sql.includes('INSERT INTO attendance_unscheduled_reminder_dispatch')) {
         insertCalls += 1
-        return { rows: [{ org_id: 'default', user_id: 'u1' }, { org_id: 'default', user_id: 'u2' }] as never }
+        return {
+          rows: [
+            { id: '00000000-0000-0000-0000-000000000001', org_id: 'default', user_id: 'u1', target_date: '2026-06-05', reminder_type: 'unscheduled' },
+            { id: '00000000-0000-0000-0000-000000000002', org_id: 'default', user_id: 'u2', target_date: '2026-06-05', reminder_type: 'unscheduled' },
+          ] as never,
+        }
+      }
+      if (sql.includes('FROM attendance_unscheduled_reminder_dispatch d') && sql.includes('NOT EXISTS')) {
+        return {
+          rows: [
+            { id: '00000000-0000-0000-0000-000000000001', org_id: 'default', user_id: 'u1', target_date: '2026-06-05', reminder_type: 'unscheduled' },
+            { id: '00000000-0000-0000-0000-000000000002', org_id: 'default', user_id: 'u2', target_date: '2026-06-05', reminder_type: 'unscheduled' },
+          ] as never,
+        }
+      }
+      if (sql.includes('INSERT INTO attendance_notification_deliveries')) {
+        deliveryCalls += 1
+        return { rows: [{ id: `delivery-${deliveryCalls}-1` }, { id: `delivery-${deliveryCalls}-2` }] as never }
       }
       return { rows: [] }
     }
-    const svc = new UnscheduledReminderService({ query, notifier, now: fixedNow, lookaheadDays: 1 })
+    const svc = new UnscheduledReminderService({ query, now: fixedNow, lookaheadDays: 1 })
     const result = await svc.run()
-    expect(result).toEqual({ targetDate: '2026-06-05', claimed: 2, dispatched: 2 })
-    expect(captured.map((m) => m.userId)).toEqual(['u1', 'u2'])
-    expect(captured[0].kind).toBe('unscheduled_shift_reminder')
+    expect(result).toEqual({ targetDate: '2026-06-05', claimed: 2, deliveries: 2 })
     expect(insertCalls).toBe(1)
+    expect(deliveryCalls).toBe(1)
   })
 
-  it('claims nothing → no dispatch, dispatched=0 (and never throws with 0 channels)', async () => {
-    const svc = new UnscheduledReminderService({ query: emptyQuery, notifier: new AttendanceNotifier(), now: fixedNow })
-    expect(await svc.run()).toEqual({ targetDate: '2026-06-05', claimed: 0, dispatched: 0 })
+  it('claims/reconciles nothing → produces no deliveries', async () => {
+    const svc = new UnscheduledReminderService({ query: emptyQuery, now: fixedNow })
+    expect(await svc.run()).toEqual({ targetDate: '2026-06-05', claimed: 0, deliveries: 0 })
   })
 
   it('re-entrancy guard: a second run while the first is in-flight is an immediate no-op', async () => {
@@ -71,10 +83,10 @@ describe('UnscheduledReminderService.run (claim + dispatch)', () => {
       if (sql.includes('INSERT')) { await gate; return { rows: [{ org_id: 'default', user_id: 'u1' }] as never } }
       return { rows: [] }
     }
-    const svc = new UnscheduledReminderService({ query, notifier: new AttendanceNotifier(), now: fixedNow })
+    const svc = new UnscheduledReminderService({ query, now: fixedNow })
     const first = svc.run()
     const second = await svc.run() // running guard → returns before touching the DB
-    expect(second).toEqual({ targetDate: '2026-06-05', claimed: 0, dispatched: 0 })
+    expect(second).toEqual({ targetDate: '2026-06-05', claimed: 0, deliveries: 0 })
     release()
     expect((await first).claimed).toBe(1)
   })


### PR DESCRIPTION
## Summary

C5-1a unscheduled fan-out producer.

- Refactors `UnscheduledReminderService` from `claim -> AttendanceNotifier.notify()` to `claim/reconcile -> attendance_notification_deliveries` outbox rows.
- Claim now returns identity-bearing dispatch rows (`id/org/user/target_date/reminder_type`), then reconciles previously claimed dispatch rows that still have no C5 deliveries.
- Produces one delivery per deduped `(recipient_user_id, channel)` for the subject plus current attendance-group `owner` / `sub_owner` managers.
- Uses `source_key = unscheduled:{dispatchId}:recipient:{recipientUserId}:channel:{channel}` for idempotency and marks inactive/missing recipients as visible `skipped` rows with `last_error='recipient_inactive_or_missing'`.
- Removes the source-scan direct notification path; the scheduler now only produces outbox rows. Delivery worker remains the only future path to external sends.
- Tightens the unscheduled scan parity with the plugin shared predicate by respecting `publish_status='published'` assignments.
- Backfills the tracker: C5 design-lock #2483 and C5-0 #2487 are ✅; C5-1a is this PR and C5 overall stays 🟡.

## Verification

Local targeted checks:

- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/attendance-unscheduled-reminder.test.ts tests/unit/attendance-scheduler.test.ts --reporter=dot` → 18/18 pass.
- `DATABASE_URL=postgresql://metasheet:metasheet123@localhost:5432/metasheet_v2 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-unscheduled-reminder.test.ts --reporter=dot` → 1/1 pass after applying the missing local attendance migrations to the stale local test DB.
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false` → pass.
- `git diff --check` → pass.

Local broad attendance aggregation note:

- `DATABASE_URL=postgresql://metasheet:metasheet123@localhost:5432/metasheet_v2 pnpm --filter @metasheet/core-backend test:integration:attendance` does **not** pass on my local stale `metasheet_v2` database. The failures are missing historical migrations/schema drift outside this slice (`attendance_leave_balances`, `attendance_requests` outdoor_punch check, `attendance_holidays.origin`, automation tables, etc.). The C5-1a target spec and C5-0 outbox spec both pass in that run; CI fresh DB is the broad gate for the full attendance matrix.

## Scope / Deferred

- No delivery worker state machine yet (C5-2).
- No comp-time expiry reminder producer yet (C5-1b).
- No DingTalk work-notification channel yet (C5-3).
- No admin delivery observability yet (C5-4).
- C5 tracker does not flip ✅; real DingTalk staging smoke remains required.
