### PR TITLE
feat(multitable): add parallel branch editor

### DIFF
--- a/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
+++ b/apps/web/src/multitable/components/MetaAutomationRuleEditor.vue
@@ -494,7 +494,7 @@
               </div>
               <template
                 v-for="accessState in [publicFormAccessState(action.config.publicFormViewId)]"
-                :key="`group-public-form-access-${idx}`"
+                :key="`group-public-form-access-${idx}-${accessState.level}`"
               >
                 <div
                   v-if="accessState.hasSelection"
@@ -812,7 +812,7 @@
               </div>
               <template
                 v-for="accessState in [publicFormAccessState(action.config.publicFormViewId)]"
-                :key="`person-public-form-access-${idx}`"
+                :key="`person-public-form-access-${idx}-${accessState.level}`"
               >
                 <div
                   v-if="accessState.hasSelection"
@@ -983,6 +983,48 @@
                 <div v-if="conditionBranchKeyError" class="meta-rule-editor__error" data-field="branch-key-error">{{ conditionBranchKeyError }}</div>
               </template>
             </div>
+
+            <!-- A6-3-4/W3-2a parallel_branch builder (join-all only; no canvas / worker-parallel controls) -->
+            <div v-if="action.type === 'parallel_branch'" class="meta-rule-editor__action-config" data-action-config="parallel_branch">
+              <div v-if="action.config.parallelBranchUnsupportedReason" class="meta-rule-editor__alert" data-field="parallel-branch-readonly">
+                {{ automationLabel('parallelBranch.readOnly', isZh) }}
+              </div>
+              <template v-else>
+                <div class="meta-rule-editor__hint">{{ automationLabel('parallelBranch.hint', isZh) }}</div>
+                <div v-for="(branch, bIdx) in action.config.parallelBranches" :key="bIdx" class="meta-rule-editor__branch" :data-parallel-branch-index="bIdx">
+                  <div class="meta-rule-editor__branch-header">
+                    <input v-model="branch.key" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('parallelBranch.key', isZh)" data-field="parallel-branch-key" />
+                    <input v-model="branch.label" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('parallelBranch.label', isZh)" data-field="parallel-branch-label" />
+                    <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" data-action="remove-parallel-branch" @click="removeParallelBranch(action, bIdx)">&times;</button>
+                  </div>
+                  <div v-for="(bAct, aIdx) in branch.actions" :key="aIdx" class="meta-rule-editor__branch-action" :data-parallel-branch-action-index="aIdx">
+                    <select v-model="bAct.type" class="meta-rule-editor__select meta-rule-editor__select--sm" @change="onBranchActionTypeChange(bAct)">
+                      <option v-for="t in BRANCH_AUTHORABLE_ACTION_TYPES" :key="t" :value="t">{{ automationActionTypeLabel(t, isZh) }}</option>
+                    </select>
+                    <template v-if="bAct.type === 'update_record'">
+                      <div v-for="(pair, pIdx) in bAct.fieldUpdates" :key="pIdx" class="meta-rule-editor__field-pair">
+                        <select v-model="pair.fieldId" class="meta-rule-editor__select meta-rule-editor__select--sm">
+                          <option value="">{{ automationLabel('condition.selectField', isZh) }}</option>
+                          <option v-for="f in fields" :key="f.id" :value="f.id">{{ f.name }}</option>
+                        </select>
+                        <input v-model="pair.value" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('parallelBranch.value', isZh)" />
+                        <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeBranchFieldPair(bAct, pIdx)">&times;</button>
+                      </div>
+                      <button class="meta-rule-editor__btn" type="button" data-action="add-parallel-branch-field" @click="addBranchFieldPair(bAct)">{{ automationLabel('parallelBranch.addField', isZh) }}</button>
+                    </template>
+                    <template v-else-if="bAct.type === 'send_notification'">
+                      <input v-model="bAct.userId" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('parallelBranch.userIds', isZh)" />
+                      <input v-model="bAct.message" class="meta-rule-editor__input meta-rule-editor__input--sm" :placeholder="automationLabel('parallelBranch.message', isZh)" />
+                    </template>
+                    <button class="meta-rule-editor__btn meta-rule-editor__btn--icon" type="button" @click="removeBranchAction(branch, aIdx)">&times;</button>
+                  </div>
+                  <button class="meta-rule-editor__btn" type="button" data-action="add-parallel-branch-action" @click="addBranchAction(branch)">{{ automationLabel('parallelBranch.addAction', isZh) }}</button>
+                </div>
+                <button class="meta-rule-editor__btn" type="button" data-action="add-parallel-branch" @click="addParallelBranch(action)">{{ automationLabel('parallelBranch.addBranch', isZh) }}</button>
+                <div v-if="parallelBranchKeyError" class="meta-rule-editor__error" data-field="parallel-branch-key-error">{{ parallelBranchKeyError }}</div>
+                <div v-if="parallelBranchActionError" class="meta-rule-editor__error" data-field="parallel-branch-action-error">{{ parallelBranchActionError }}</div>
+              </template>
+            </div>
           </div>
           <button
             v-if="draft.actions.length < 3"
@@ -1040,7 +1082,6 @@ import type {
   AutomationTriggerType,
   AutomationActionType,
   ConditionOperator,
-  AutomationAction,
   AutomationCondition,
   AutomationConditionNode,
   ConditionGroup,
@@ -1097,6 +1138,14 @@ import {
   parseConditionBranchDraft,
   validateConditionBranchKeys,
 } from '../utils/conditionBranchAuthoring'
+import {
+  type ParallelBranchDraft,
+  buildParallelBranchConfig,
+  parallelBranchUnsupportedReason,
+  parseParallelBranchDraft,
+  validateParallelBranchActions,
+  validateParallelBranchKeys,
+} from '../utils/parallelBranchAuthoring'
 
 interface FieldPair {
   fieldId: string
@@ -1133,6 +1182,10 @@ type DraftActionConfig = Record<string, unknown> & {
   defaultBranch?: DefaultBranchDraft | null
   branchUnsupportedReason?: string | null
   branchOriginal?: Record<string, unknown> | null
+  // A6-3-4/W3-2a parallel_branch authoring (supported → editable draft; unsupported → read-only + original preserved)
+  parallelBranches?: ParallelBranchDraft[]
+  parallelBranchUnsupportedReason?: string | null
+  parallelBranchOriginal?: Record<string, unknown> | null
 }
 
 interface DraftAction {
@@ -1210,6 +1263,7 @@ const SUPPORTED_SELECTABLE_ACTION_TYPES: AutomationActionType[] = [
   'send_dingtalk_person_message',
   'wait_for_callback',
   'condition_branch',
+  'parallel_branch',
 ]
 
 // A6-3-2a: BRANCH_AUTHORABLE_ACTION_TYPES (the v1 in-branch action subset) is imported from
@@ -1647,6 +1701,14 @@ function draftConfigFromAction(type: AutomationActionType, config: Record<string
     const parsed = parseConditionBranchDraft(config)
     return { branches: parsed.branches, defaultBranch: parsed.defaultBranch, branchUnsupportedReason: null, branchOriginal: null }
   }
+  if (type === 'parallel_branch') {
+    const reason = parallelBranchUnsupportedReason(config)
+    if (reason) {
+      return { parallelBranchUnsupportedReason: reason, parallelBranchOriginal: config, parallelBranches: [] }
+    }
+    const parsed = parseParallelBranchDraft(config)
+    return { parallelBranches: parsed.branches, parallelBranchUnsupportedReason: null, parallelBranchOriginal: null }
+  }
   if (type === 'update_record') {
     const fields = isPlainRecord(config.fields)
       ? config.fields
@@ -1745,11 +1807,11 @@ function draftFromRule(rule: AutomationRule): Draft {
 const draft = ref<Draft>(emptyDraft())
 const conditionEditorEntries = computed(() => collectConditionEditorEntries(draft.value.conditions.conditions))
 
-// A6-2b/A6-3-2a: wait_for_callback AND condition_branch both REQUIRE execution_mode
+// A6-2b/A6-3-2a/A6-3-4: wait_for_callback, condition_branch, and parallel_branch all REQUIRE execution_mode
 // 'workflow_job_v1' — the backend fail-closes a legacy rule that contains either. So whenever such
 // an action is present the job-mode toggle is forced on (and disabled), and buildPayload enforces it
 // regardless of toggle/loaded state.
-const JOB_MODE_REQUIRING_ACTION_TYPES: AutomationActionType[] = ['wait_for_callback', 'condition_branch']
+const JOB_MODE_REQUIRING_ACTION_TYPES: AutomationActionType[] = ['wait_for_callback', 'condition_branch', 'parallel_branch']
 const requiresJobMode = computed(() =>
   draft.value.actions.some((a) => JOB_MODE_REQUIRING_ACTION_TYPES.includes(a.type)),
 )
@@ -1763,6 +1825,9 @@ function createEmptyBranchDraft(index = 1): BranchDraft {
 }
 function createEmptyDefaultBranchDraft(): DefaultBranchDraft {
   return { key: 'default', label: '', actions: [createEmptyBranchActionDraft()] }
+}
+function createEmptyParallelBranchDraft(index = 1): ParallelBranchDraft {
+  return { key: `branch_${index}`, label: '', actions: [createEmptyBranchActionDraft()] }
 }
 
 // A6-3-2a read-only guard (point #3) + branch-key validation (point #1) over the draft's
@@ -1785,6 +1850,30 @@ const conditionBranchKeyError = computed<string | null>(() => {
   }
   return null
 })
+const parallelBranchReadOnlyReason = computed<string | null>(() => {
+  for (const a of draft.value.actions) {
+    if (a.type === 'parallel_branch' && a.config.parallelBranchUnsupportedReason) return a.config.parallelBranchUnsupportedReason
+  }
+  return null
+})
+const parallelBranchKeyError = computed<string | null>(() => {
+  for (const a of draft.value.actions) {
+    if (a.type === 'parallel_branch' && !a.config.parallelBranchUnsupportedReason) {
+      const err = validateParallelBranchKeys({ branches: a.config.parallelBranches ?? [] })
+      if (err) return err
+    }
+  }
+  return null
+})
+const parallelBranchActionError = computed<string | null>(() => {
+  for (const a of draft.value.actions) {
+    if (a.type === 'parallel_branch' && !a.config.parallelBranchUnsupportedReason) {
+      const err = validateParallelBranchActions({ branches: a.config.parallelBranches ?? [] })
+      if (err) return err
+    }
+  }
+  return null
+})
 
 // A6-3-2a branch-builder mutations (operate on the draft action's config in place; Vue deep-reactive).
 function addBranch(action: DraftAction): void {
@@ -1800,10 +1889,10 @@ function addBranchCondition(branch: BranchDraft): void {
 function removeBranchCondition(branch: BranchDraft, index: number): void {
   branch.conditions.splice(index, 1)
 }
-function addBranchAction(branch: BranchDraft | DefaultBranchDraft): void {
+function addBranchAction(branch: BranchDraft | DefaultBranchDraft | ParallelBranchDraft): void {
   branch.actions.push(createEmptyBranchActionDraft())
 }
-function removeBranchAction(branch: BranchDraft | DefaultBranchDraft, index: number): void {
+function removeBranchAction(branch: BranchDraft | DefaultBranchDraft | ParallelBranchDraft, index: number): void {
   branch.actions.splice(index, 1)
 }
 function onBranchActionTypeChange(action: BranchActionDraft): void {
@@ -1829,6 +1918,13 @@ function addDefaultBranch(action: DraftAction): void {
 }
 function removeDefaultBranch(action: DraftAction): void {
   action.config.defaultBranch = null
+}
+function addParallelBranch(action: DraftAction): void {
+  const branches = action.config.parallelBranches ?? (action.config.parallelBranches = [])
+  branches.push(createEmptyParallelBranchDraft(branches.length + 1))
+}
+function removeParallelBranch(action: DraftAction, index: number): void {
+  action.config.parallelBranches?.splice(index, 1)
 }
 
 function setExecutionMode(checked: boolean): void {
@@ -1949,6 +2045,9 @@ const canSave = computed(() => {
   if (draft.value.actions.length < 1) return false
   if (conditionBranchReadOnlyReason.value) return false // A6-3-2a point #3: never save a non-round-trippable loaded branch
   if (conditionBranchKeyError.value) return false // A6-3-2a point #1: branch key safe/unique mirror
+  if (parallelBranchReadOnlyReason.value) return false // A6-3-4/W3-2a: never save a non-round-trippable loaded join
+  if (parallelBranchKeyError.value) return false // W3-2a: frontend mirror of backend branch bounds/keys
+  if (parallelBranchActionError.value) return false // W3-2a: nested branch actions must be executable, not executor-failing shells
   if (!draft.value.conditions.conditions.every(areConditionsComplete)) return false
   for (const action of draft.value.actions) {
     if (action.type === 'send_dingtalk_group_message') {
@@ -1996,10 +2095,6 @@ function addGroupToGroup(path: ConditionPath) {
   const group = groupAtPath(path)
   if (!group) return
   group.conditions.push(createBlankConditionGroup())
-}
-
-function removeCondition(idx: number) {
-  removeConditionNode([idx])
 }
 
 function removeConditionNode(path: ConditionPath) {
@@ -2555,6 +2650,8 @@ function defaultConfigForActionType(type: AutomationActionType): DraftActionConf
   switch (type) {
     case 'condition_branch':
       return { branches: [createEmptyBranchDraft(1)], defaultBranch: null, branchUnsupportedReason: null, branchOriginal: null }
+    case 'parallel_branch':
+      return { parallelBranches: [createEmptyParallelBranchDraft(1)], parallelBranchUnsupportedReason: null, parallelBranchOriginal: null }
     case 'update_record':
       return { fieldUpdates: [] }
     case 'create_record':
@@ -2599,9 +2696,7 @@ function defaultConfigForActionType(type: AutomationActionType): DraftActionConf
 
 function onDraftActionTypeChange(action: DraftAction) {
   action.config = defaultConfigForActionType(action.type)
-  // A6-2b: selecting wait_for_callback auto-enables the REQUIRED job mode (the backend fail-closes a
-  // legacy rule containing a wait step) — so the UI can't create a "suspends" rule that fails at runtime.
-  if (action.type === 'wait_for_callback') draft.value.executionMode = 'workflow_job_v1'
+  if (JOB_MODE_REQUIRING_ACTION_TYPES.includes(action.type)) draft.value.executionMode = 'workflow_job_v1'
 }
 
 function removeAction(idx: number) {
@@ -2660,6 +2755,17 @@ function buildPayload(): Partial<AutomationRule> {
         config: {
           fields: fieldPairsToRecord(action.config.fieldUpdates),
         },
+      }
+    }
+    if (action.type === 'parallel_branch') {
+      if (action.config.parallelBranchUnsupportedReason && action.config.parallelBranchOriginal) {
+        return { type: action.type, config: action.config.parallelBranchOriginal }
+      }
+      return {
+        type: action.type,
+        config: buildParallelBranchConfig({
+          branches: action.config.parallelBranches ?? [],
+        }),
       }
     }
     if (action.type === 'create_record') {

--- a/apps/web/src/multitable/types.ts
+++ b/apps/web/src/multitable/types.ts
@@ -815,6 +815,7 @@ export type AutomationActionType =
   | 'lock_record'
   | 'wait_for_callback'
   | 'condition_branch'
+  | 'parallel_branch'
   // Legacy aliases
   | 'notify'
   | 'update_field'

--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -142,6 +142,16 @@ export type AutomationLabelKey =
   | 'conditionBranch.addBranch'
   | 'conditionBranch.default'
   | 'conditionBranch.addDefault'
+  | 'parallelBranch.readOnly'
+  | 'parallelBranch.hint'
+  | 'parallelBranch.key'
+  | 'parallelBranch.label'
+  | 'parallelBranch.value'
+  | 'parallelBranch.userIds'
+  | 'parallelBranch.message'
+  | 'parallelBranch.addField'
+  | 'parallelBranch.addAction'
+  | 'parallelBranch.addBranch'
   | 'testRun.warning'
   | 'testRun.confirmSuffix'
   | 'testRun.unsavedHint'
@@ -374,6 +384,16 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'conditionBranch.addBranch',
   'conditionBranch.default',
   'conditionBranch.addDefault',
+  'parallelBranch.readOnly',
+  'parallelBranch.hint',
+  'parallelBranch.key',
+  'parallelBranch.label',
+  'parallelBranch.value',
+  'parallelBranch.userIds',
+  'parallelBranch.message',
+  'parallelBranch.addField',
+  'parallelBranch.addAction',
+  'parallelBranch.addBranch',
   'testRun.warning',
   'testRun.confirmSuffix',
   'testRun.unsavedHint',
@@ -565,8 +585,8 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
     zh: '开启后，本规则每个动作的运行都会保存为持久的 WorkflowJob 记录；关闭则使用默认的轻量日志。',
   },
   'editor.executionModeRequiredHint': {
-    en: 'Required and locked on: this rule has an action that requires durable WorkflowJob records (wait for callback or condition branch).',
-    zh: '已强制开启并锁定：本规则包含需要持久 WorkflowJob 记录的动作（等待回调或条件分支），无法关闭。',
+    en: 'Required and locked on: this rule has an action that requires durable WorkflowJob records (wait for callback, condition branch, or parallel branch).',
+    zh: '已强制开启并锁定：本规则包含需要持久 WorkflowJob 记录的动作（等待回调、条件分支或并行分支），无法关闭。',
   },
   'trigger.title': { en: 'Trigger', zh: '触发器' },
   'trigger.watchField': { en: 'Watch field', zh: '监听字段' },
@@ -625,6 +645,22 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'conditionBranch.addBranch': { en: '+ Branch', zh: '+ 分支' },
   'conditionBranch.default': { en: 'Default branch (no condition)', zh: '默认分支（无条件）' },
   'conditionBranch.addDefault': { en: '+ Default branch', zh: '+ 默认分支' },
+  'parallelBranch.readOnly': {
+    en: 'This parallel branch rule uses constructs not editable in this version — read-only (save is disabled to avoid flattening it).',
+    zh: '该并行分支规则包含本版本不可编辑的结构 —— 只读（已禁用保存以避免压扁丢失）。',
+  },
+  'parallelBranch.hint': {
+    en: 'Run all branches and join after every branch finishes. Branch actions are limited to update-record / send-notification in v1.',
+    zh: '同时运行所有分支，并在所有分支结束后汇合。v1 分支内动作限更新记录 / 发送通知。',
+  },
+  'parallelBranch.key': { en: 'Branch key', zh: '分支 key' },
+  'parallelBranch.label': { en: 'Label (optional)', zh: '标签（可选）' },
+  'parallelBranch.value': { en: 'Value', zh: '值' },
+  'parallelBranch.userIds': { en: 'User IDs (comma-separated)', zh: '用户 ID（逗号分隔）' },
+  'parallelBranch.message': { en: 'Message', zh: '消息' },
+  'parallelBranch.addField': { en: '+ Field', zh: '+ 字段' },
+  'parallelBranch.addAction': { en: '+ Action', zh: '+ 动作' },
+  'parallelBranch.addBranch': { en: '+ Branch', zh: '+ 分支' },
   'testRun.warning': { en: 'Test Run executes the saved rule and can send real DingTalk messages to configured groups or users.', zh: '测试运行会执行已保存规则，并可能向已配置的钉钉群或用户发送真实消息。' },
   'testRun.confirmSuffix': { en: 'Unsaved changes are not included. Continue?', zh: '未保存的更改不会包含在内。是否继续？' },
   'testRun.unsavedHint': { en: 'Save this automation before running a test.', zh: '请先保存此自动化，再运行测试。' },
@@ -770,12 +806,14 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'runs.resumeError.generic': { en: 'Resume failed.', zh: '恢复失败。' },
 }
 
+type UnknownAutomationString = string & Record<never, never>
+
 export function automationLabel(key: AutomationLabelKey, isZh: boolean): string {
   const entry = LABELS[key]
   return isZh ? entry.zh : entry.en
 }
 
-export function automationStatusLabel(status: AutomationStatus | (string & {}), isZh: boolean): string {
+export function automationStatusLabel(status: AutomationStatus | UnknownAutomationString, isZh: boolean): string {
   if (status === 'success') return automationLabel('status.success', isZh)
   if (status === 'failed') return automationLabel('status.failed', isZh)
   if (status === 'skipped') return automationLabel('status.skipped', isZh)
@@ -788,7 +826,7 @@ export function automationStatusLabel(status: AutomationStatus | (string & {}), 
   return String(status)
 }
 
-export function automationActionTypeLabel(type: AutomationActionType | (string & {}), isZh: boolean): string {
+export function automationActionTypeLabel(type: AutomationActionType | UnknownAutomationString, isZh: boolean): string {
   switch (type) {
     case 'update_record':
       return isZh ? '更新记录' : 'Update record'
@@ -811,6 +849,8 @@ export function automationActionTypeLabel(type: AutomationActionType | (string &
       return isZh ? '等待回调（挂起）' : 'Wait for callback (suspend)'
     case 'condition_branch':
       return isZh ? '条件分支' : 'Condition branch'
+    case 'parallel_branch':
+      return isZh ? '并行分支' : 'Parallel branch'
     case 'update_field':
       return isZh ? '更新字段值' : 'Update field value'
     default:
@@ -818,7 +858,7 @@ export function automationActionTypeLabel(type: AutomationActionType | (string &
   }
 }
 
-export function automationTriggerTypeLabel(type: AutomationTriggerType | (string & {}), isZh: boolean): string {
+export function automationTriggerTypeLabel(type: AutomationTriggerType | UnknownAutomationString, isZh: boolean): string {
   switch (type) {
     case 'record.created':
       return isZh ? '当记录创建时' : 'When record created'
@@ -841,7 +881,7 @@ export function automationTriggerTypeLabel(type: AutomationTriggerType | (string
   }
 }
 
-export function automationTriggerConditionLabel(condition: AutomationTriggerCondition | (string & {}), isZh: boolean): string {
+export function automationTriggerConditionLabel(condition: AutomationTriggerCondition | UnknownAutomationString, isZh: boolean): string {
   switch (condition) {
     case 'any':
       return isZh ? '任意变化' : 'Any change'
@@ -854,7 +894,7 @@ export function automationTriggerConditionLabel(condition: AutomationTriggerCond
   }
 }
 
-export function automationCronPresetLabel(value: AutomationCronPresetValue | (string & {}), isZh: boolean): string {
+export function automationCronPresetLabel(value: AutomationCronPresetValue | UnknownAutomationString, isZh: boolean): string {
   switch (value) {
     case '*/5 * * * *':
       return isZh ? '每 5 分钟' : 'Every 5 minutes'
@@ -871,7 +911,7 @@ export function automationCronPresetLabel(value: AutomationCronPresetValue | (st
   }
 }
 
-export function automationConditionOperatorLabel(operator: ConditionOperator | (string & {}), isZh: boolean): string {
+export function automationConditionOperatorLabel(operator: ConditionOperator | UnknownAutomationString, isZh: boolean): string {
   switch (operator) {
     case 'equals':
       return isZh ? '等于' : 'Equals'
@@ -911,7 +951,7 @@ export function automationConditionValuePlaceholder(widget: AutomationConditionV
 }
 
 export function automationCardTriggerSummary(
-  triggerType: AutomationTriggerType | (string & {}),
+  triggerType: AutomationTriggerType | UnknownAutomationString,
   fieldName: string,
   isZh: boolean,
 ): string {
@@ -926,7 +966,7 @@ export function automationCardTriggerSummary(
 }
 
 export function automationCardActionSummary(
-  actionType: AutomationActionType | (string & {}),
+  actionType: AutomationActionType | UnknownAutomationString,
   fieldName: string,
   isZh: boolean,
 ): string {
@@ -953,7 +993,7 @@ export function automationCardStats(count: number, status: AutomationCardStatTyp
   return `${count} ${automationLabel(key, isZh)}`
 }
 
-export function automationDingTalkPresetLabel(preset: AutomationDingTalkPreset | (string & {}), isZh: boolean): string {
+export function automationDingTalkPresetLabel(preset: AutomationDingTalkPreset | UnknownAutomationString, isZh: boolean): string {
   switch (preset) {
     case 'form_request':
       return isZh ? '表单填写' : 'Form request'
@@ -966,7 +1006,7 @@ export function automationDingTalkPresetLabel(preset: AutomationDingTalkPreset |
   }
 }
 
-export function automationDingTalkTemplateTokenLabel(token: AutomationDingTalkTemplateTokenKey | (string & {}), isZh: boolean): string {
+export function automationDingTalkTemplateTokenLabel(token: AutomationDingTalkTemplateTokenKey | UnknownAutomationString, isZh: boolean): string {
   switch (token) {
     case 'recordId':
       return isZh ? '记录 ID' : 'Record ID'
@@ -981,7 +1021,7 @@ export function automationDingTalkTemplateTokenLabel(token: AutomationDingTalkTe
   }
 }
 
-export function automationDingTalkDestinationScopeLabel(scope: AutomationDingTalkDestinationScope | (string & {}), isZh: boolean): string {
+export function automationDingTalkDestinationScopeLabel(scope: AutomationDingTalkDestinationScope | UnknownAutomationString, isZh: boolean): string {
   switch (scope) {
     case 'org':
       return isZh ? '组织目录' : 'Organization catalog'
@@ -1006,7 +1046,7 @@ export function automationDingTalkDestinationSubtitle(scope: AutomationDingTalkD
   return isZh ? '私有' : 'private'
 }
 
-export function automationDingTalkPersonSubjectLabel(subject: AutomationDingTalkPersonSubject | (string & {}), isZh: boolean): string {
+export function automationDingTalkPersonSubjectLabel(subject: AutomationDingTalkPersonSubject | UnknownAutomationString, isZh: boolean): string {
   switch (subject) {
     case 'member-group':
       return isZh ? '成员组' : 'Member group'
@@ -1021,7 +1061,7 @@ export function automationDingTalkPersonAccessLabel(accessLevel: string, isZh: b
   return accessLevel ? `${isZh ? '权限：' : 'Access: '}${accessLevel}` : ''
 }
 
-export function automationDingTalkPersonStatusLabel(status: AutomationDingTalkPersonStatus | (string & {}), isZh: boolean): string {
+export function automationDingTalkPersonStatusLabel(status: AutomationDingTalkPersonStatus | UnknownAutomationString, isZh: boolean): string {
   switch (status) {
     case 'memberGroupCheckedIndividually':
       return isZh ? '成员组成员会逐个检查钉钉投递条件' : 'Member group members are checked individually for DingTalk delivery'

--- a/apps/web/src/multitable/utils/parallelBranchAuthoring.ts
+++ b/apps/web/src/multitable/utils/parallelBranchAuthoring.ts
@@ -1,0 +1,180 @@
+// A6-3-4/W3-2a — pure save/load seam for the `parallel_branch` editor.
+//
+// The v1 UI edits only the join-all, flat branch shape that the backend runtime currently
+// supports. Anything richer or lossy opens read-only and is re-emitted verbatim by the editor.
+import type {
+  AutomationAction,
+  AutomationActionType,
+} from '../types'
+import {
+  type BranchActionDraft,
+  BRANCH_AUTHORABLE_ACTION_TYPES,
+  SAFE_BRANCH_KEY,
+} from './conditionBranchAuthoring'
+
+export interface ParallelBranchDraft {
+  key: string
+  label: string
+  actions: BranchActionDraft[]
+}
+
+export interface ParallelBranchConfigDraft {
+  branches: ParallelBranchDraft[]
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return Boolean(value) && typeof value === 'object' && !Array.isArray(value)
+}
+
+const UPDATE_RECORD_ALLOWED_KEYS = new Set(['fields'])
+function updateRecordRoundTrippable(config: unknown): boolean {
+  if (!isPlainRecord(config)) return false
+  if (Object.keys(config).some((key) => !UPDATE_RECORD_ALLOWED_KEYS.has(key))) return false
+  const fields = config.fields
+  if (!isPlainRecord(fields)) return false
+  return Object.values(fields).every((value) => typeof value === 'string')
+}
+
+const SEND_NOTIFICATION_ALLOWED_KEYS = new Set(['userIds', 'message'])
+const SIMPLE_USER_ID = /^[^\s,]+$/
+function sendNotificationRoundTrippable(config: unknown): boolean {
+  if (!isPlainRecord(config)) return false
+  if (Object.keys(config).some((key) => !SEND_NOTIFICATION_ALLOWED_KEYS.has(key))) return false
+  const userIds = config.userIds
+  if (!Array.isArray(userIds)) return false
+  if (!userIds.every((id) => typeof id === 'string' && SIMPLE_USER_ID.test(id))) return false
+  return typeof config.message === 'string'
+}
+
+function branchActionRoundTrippable(action: unknown): boolean {
+  if (!isPlainRecord(action)) return false
+  if (Object.keys(action).some((key) => key !== 'type' && key !== 'config')) return false
+  if (action.type === 'update_record') return updateRecordRoundTrippable(action.config)
+  if (action.type === 'send_notification') return sendNotificationRoundTrippable(action.config)
+  return false
+}
+
+export function parallelBranchUnsupportedReason(config: unknown): string | null {
+  if (!isPlainRecord(config)) return null
+  const allowedTopKeys = new Set(['joinMode', 'branches'])
+  if (Object.keys(config).some((key) => !allowedTopKeys.has(key))) return 'parallel_branch has unsupported top-level keys'
+  if (config.joinMode !== undefined && config.joinMode !== 'all') return 'parallel_branch joinMode must be all'
+  const branches = config.branches
+  if (branches !== undefined && !Array.isArray(branches)) return 'parallel_branch branches must be an array'
+  for (const branch of Array.isArray(branches) ? branches : []) {
+    if (!isPlainRecord(branch)) return 'a parallel branch is not an object'
+    const allowedBranchKeys = new Set(['key', 'label', 'actions'])
+    if (Object.keys(branch).some((key) => !allowedBranchKeys.has(key))) return 'a parallel branch has unsupported keys'
+    if (branch.label !== undefined && typeof branch.label !== 'string') return 'a parallel branch label is not a string'
+    if (!Array.isArray(branch.actions)) return 'a parallel branch actions value is not an array'
+    if (branch.actions.length === 0) return 'a parallel branch has no actions'
+    for (const action of branch.actions) {
+      if (!branchActionRoundTrippable(action)) return 'a parallel branch action is outside the v1 editable set'
+    }
+  }
+  return null
+}
+
+function actionToDraft(action: AutomationAction): BranchActionDraft {
+  if (action.type === 'update_record') {
+    const fields = isPlainRecord(action.config.fields) ? action.config.fields : {}
+    return {
+      type: 'update_record',
+      fieldUpdates: Object.entries(fields).map(([fieldId, value]) => ({ fieldId, value: String(value ?? '') })),
+    }
+  }
+  const userIds = Array.isArray(action.config.userIds) ? action.config.userIds : []
+  return {
+    type: 'send_notification',
+    userId: userIds.map((id) => String(id)).join(', '),
+    message: typeof action.config.message === 'string' ? action.config.message : '',
+  }
+}
+
+function draftToAction(action: BranchActionDraft): AutomationAction {
+  if (action.type === 'update_record') {
+    const fields: Record<string, string> = {}
+    for (const pair of action.fieldUpdates ?? []) {
+      const fieldId = pair.fieldId.trim()
+      if (fieldId) fields[fieldId] = pair.value
+    }
+    return { type: 'update_record', config: { fields } }
+  }
+  return {
+    type: 'send_notification',
+    config: {
+      userIds: (action.userId ?? '')
+        .split(/[\s,]+/)
+        .map((id) => id.trim())
+        .filter(Boolean),
+      message: (action.message ?? '').trim(),
+    },
+  }
+}
+
+export function parseParallelBranchDraft(config: Record<string, unknown>): ParallelBranchConfigDraft {
+  const branches = (Array.isArray(config.branches) ? config.branches : []).map((raw): ParallelBranchDraft => {
+    const branch = isPlainRecord(raw) ? raw : {}
+    return {
+      key: typeof branch.key === 'string' ? branch.key : '',
+      label: typeof branch.label === 'string' ? branch.label : '',
+      actions: (Array.isArray(branch.actions) ? branch.actions : []).map((action) => actionToDraft(action as AutomationAction)),
+    }
+  })
+  return { branches }
+}
+
+export function buildParallelBranchConfig(draft: ParallelBranchConfigDraft): Record<string, unknown> {
+  return {
+    joinMode: 'all',
+    branches: draft.branches.map((branch) => ({
+      key: branch.key.trim(),
+      ...(branch.label.trim() ? { label: branch.label.trim() } : {}),
+      actions: branch.actions.map(draftToAction),
+    })),
+  }
+}
+
+export function validateParallelBranchKeys(draft: ParallelBranchConfigDraft): string | null {
+  if (draft.branches.length === 0) return 'at least one branch is required'
+  if (draft.branches.length > 10) return 'at most 10 branches are allowed'
+  let totalActions = 0
+  const seen = new Set<string>()
+  for (const branch of draft.branches) {
+    const key = branch.key.trim()
+    if (!SAFE_BRANCH_KEY.test(key)) return `branch key "${branch.key}" must be 1-64 of [A-Za-z0-9_-]`
+    if (seen.has(key)) return `branch key "${key}" must be unique`
+    seen.add(key)
+    if (branch.actions.length === 0) return `branch "${key}" must contain at least one action`
+    totalActions += branch.actions.length
+    if (totalActions > 20) return 'at most 20 branch actions are allowed'
+  }
+  return null
+}
+
+function userIdsFromDraft(action: BranchActionDraft): string[] {
+  return (action.userId ?? '')
+    .split(/[\s,]+/)
+    .map((id) => id.trim())
+    .filter(Boolean)
+}
+
+export function validateParallelBranchActions(draft: ParallelBranchConfigDraft): string | null {
+  for (const branch of draft.branches) {
+    const key = branch.key.trim() || '(unnamed)'
+    for (const action of branch.actions) {
+      if (action.type === 'update_record') {
+        const hasField = (action.fieldUpdates ?? []).some((pair) => pair.fieldId.trim())
+        if (!hasField) return `branch "${key}" update_record must set at least one field`
+      } else if (action.type === 'send_notification') {
+        if (userIdsFromDraft(action).length === 0) return `branch "${key}" send_notification must include at least one user`
+        if (!(action.message ?? '').trim()) return `branch "${key}" send_notification must include a message`
+      }
+    }
+  }
+  return null
+}
+
+export function isParallelBranchAuthorableActionType(type: AutomationActionType): boolean {
+  return (BRANCH_AUTHORABLE_ACTION_TYPES as readonly string[]).includes(type)
+}

--- a/apps/web/tests/meta-automation-labels.spec.ts
+++ b/apps/web/tests/meta-automation-labels.spec.ts
@@ -56,15 +56,19 @@ describe('meta-automation-labels', () => {
     expect(automationActionTypeLabel('send_email', false)).toBe('Send email')
     expect(automationActionTypeLabel('send_email', true)).toBe('发送邮件')
     expect(automationActionTypeLabel('send_dingtalk_group_message', true)).toBe('发送钉钉群消息')
+    expect(automationActionTypeLabel('parallel_branch', false)).toBe('Parallel branch')
+    expect(automationActionTypeLabel('parallel_branch', true)).toBe('并行分支')
     expect(automationActionTypeLabel('notify', true)).toBe('发送通知')
     expect(automationActionTypeLabel('update_field', true)).toBe('更新字段值')
     expect(automationActionTypeLabel('future_action', true)).toBe('future_action')
   })
 
-  it('explains required WorkflowJob mode for both wait and branch actions', () => {
+  it('explains required WorkflowJob mode for wait and branch actions', () => {
     expect(automationLabel('editor.executionModeRequiredHint', false)).toContain('condition branch')
+    expect(automationLabel('editor.executionModeRequiredHint', false)).toContain('parallel branch')
     expect(automationLabel('editor.executionModeRequiredHint', false)).toContain('wait for callback')
     expect(automationLabel('editor.executionModeRequiredHint', true)).toContain('条件分支')
+    expect(automationLabel('editor.executionModeRequiredHint', true)).toContain('并行分支')
     expect(automationLabel('editor.executionModeRequiredHint', true)).toContain('等待回调')
   })
 

--- a/apps/web/tests/parallelBranchAuthoring.spec.ts
+++ b/apps/web/tests/parallelBranchAuthoring.spec.ts
@@ -1,0 +1,115 @@
+import { describe, expect, it } from 'vitest'
+import {
+  buildParallelBranchConfig,
+  parallelBranchUnsupportedReason,
+  parseParallelBranchDraft,
+  validateParallelBranchActions,
+  validateParallelBranchKeys,
+} from '../src/multitable/utils/parallelBranchAuthoring'
+
+const SUPPORTED = {
+  joinMode: 'all',
+  branches: [
+    {
+      key: 'ops',
+      label: 'Ops',
+      actions: [{ type: 'update_record', config: { fields: { status: 'ops' } } }],
+    },
+    {
+      key: 'notify',
+      actions: [{ type: 'send_notification', config: { userIds: ['u1', 'u2'], message: 'ready' } }],
+    },
+  ],
+}
+
+describe('parallelBranchAuthoring — round-trip invariant', () => {
+  it('round-trips a supported join_all parallel_branch config losslessly', () => {
+    expect(buildParallelBranchConfig(parseParallelBranchDraft(SUPPORTED))).toEqual(SUPPORTED)
+  })
+
+  it('always builds joinMode all from the editable draft', () => {
+    const built = buildParallelBranchConfig(parseParallelBranchDraft({ branches: SUPPORTED.branches }))
+    expect(built.joinMode).toBe('all')
+  })
+})
+
+describe('parallelBranchUnsupportedReason — read-only guard', () => {
+  it('returns null for supported and empty fresh configs', () => {
+    expect(parallelBranchUnsupportedReason(SUPPORTED)).toBeNull()
+    expect(parallelBranchUnsupportedReason({})).toBeNull()
+    expect(parallelBranchUnsupportedReason(undefined)).toBeNull()
+  })
+
+  const unsupported: Array<[string, unknown]> = [
+    ['joinMode any', { joinMode: 'any', branches: SUPPORTED.branches }],
+    ['top-level extra key', { ...SUPPORTED, mode: 'future' }],
+    ['branch extra key', { joinMode: 'all', branches: [{ ...SUPPORTED.branches[0], condition: {} }] }],
+    ['action extra key', { joinMode: 'all', branches: [{ key: 'a', actions: [{ type: 'update_record', config: { fields: { status: 'done' } }, metadata: { future: true } }] }] }],
+    ['empty branch actions', { joinMode: 'all', branches: [{ key: 'a', actions: [] }] }],
+    ['non-string update value', { joinMode: 'all', branches: [{ key: 'a', actions: [{ type: 'update_record', config: { fields: { qty: 5 } } }] }] }],
+    ['comma-bearing user id', { joinMode: 'all', branches: [{ key: 'a', actions: [{ type: 'send_notification', config: { userIds: ['a,b'], message: 'm' } }] }] }],
+    ['nested wait', { joinMode: 'all', branches: [{ key: 'a', actions: [{ type: 'wait_for_callback', config: {} }] }] }],
+    ['nested parallel', { joinMode: 'all', branches: [{ key: 'a', actions: [{ type: 'parallel_branch', config: { joinMode: 'all', branches: [] } }] }] }],
+  ]
+
+  it.each(unsupported)('flags %s as read-only', (_label, config) => {
+    expect(parallelBranchUnsupportedReason(config)).not.toBeNull()
+  })
+})
+
+describe('validateParallelBranchActions — executable nested actions', () => {
+  it('rejects update_record branches without a field update', () => {
+    expect(validateParallelBranchActions({
+      branches: [{ key: 'a', label: '', actions: [{ type: 'update_record', fieldUpdates: [] }] }],
+    })).toContain('at least one field')
+    expect(validateParallelBranchActions({
+      branches: [{ key: 'a', label: '', actions: [{ type: 'update_record', fieldUpdates: [{ fieldId: '', value: 'done' }] }] }],
+    })).toContain('at least one field')
+  })
+
+  it('rejects send_notification branches without recipients or message', () => {
+    expect(validateParallelBranchActions({
+      branches: [{ key: 'notify', label: '', actions: [{ type: 'send_notification', userId: '', message: 'ready' }] }],
+    })).toContain('at least one user')
+    expect(validateParallelBranchActions({
+      branches: [{ key: 'notify', label: '', actions: [{ type: 'send_notification', userId: 'u1', message: ' ' }] }],
+    })).toContain('message')
+  })
+
+  it('accepts executable update_record and send_notification branch actions', () => {
+    expect(validateParallelBranchActions({
+      branches: [
+        { key: 'a', label: '', actions: [{ type: 'update_record', fieldUpdates: [{ fieldId: 'status', value: 'done' }] }] },
+        { key: 'notify', label: '', actions: [{ type: 'send_notification', userId: 'u1, u2', message: 'ready' }] },
+      ],
+    })).toBeNull()
+  })
+})
+
+describe('validateParallelBranchKeys — frontend mirror of backend bounds', () => {
+  const make = (branches: Array<{ key: string; actions?: unknown[] }>) => ({
+    branches: branches.map((branch) => ({
+      key: branch.key,
+      label: '',
+      actions: (branch.actions ?? [{}]) as never[],
+    })),
+  })
+
+  it('accepts safe, non-empty, unique keys', () => {
+    expect(validateParallelBranchKeys(make([{ key: 'a' }, { key: 'b' }]))).toBeNull()
+  })
+
+  it('rejects empty branch list', () => {
+    expect(validateParallelBranchKeys(make([]))).toContain('at least one')
+  })
+
+  it('rejects unsafe and duplicate keys', () => {
+    expect(validateParallelBranchKeys(make([{ key: 'bad key' }]))).toContain('A-Za-z0-9_-')
+    expect(validateParallelBranchKeys(make([{ key: 'a' }, { key: 'a' }]))).toContain('unique')
+  })
+
+  it('rejects a branch without actions and a config with too many actions', () => {
+    expect(validateParallelBranchKeys(make([{ key: 'a', actions: [] }]))).toContain('at least one action')
+    expect(validateParallelBranchKeys(make([{ key: 'a', actions: Array.from({ length: 21 }, () => ({})) }]))).toContain('at most 20')
+  })
+})

--- a/apps/web/tests/parallelBranchEditor.spec.ts
+++ b/apps/web/tests/parallelBranchEditor.spec.ts
@@ -1,0 +1,179 @@
+// A6-3-4/W3-2a UI tests — parallel_branch editor through the real component.
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import MetaAutomationRuleEditor from '../src/multitable/components/MetaAutomationRuleEditor.vue'
+import { useLocale } from '../src/composables/useLocale'
+import type { AutomationRule } from '../src/multitable/types'
+
+function flush() {
+  return new Promise<void>((resolve) => setTimeout(resolve, 0)).then(() => nextTick())
+}
+
+const fields = [
+  { id: 'fld_1', name: 'Status', type: 'select', options: [{ value: 'done', label: 'Done' }] },
+  { id: 'fld_2', name: 'Name', type: 'string' },
+]
+
+function mount(props: Record<string, unknown>) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(MetaAutomationRuleEditor, props) })
+  app.mount(container)
+  return { container, app }
+}
+
+function setInput(container: HTMLElement, selector: string, value: string) {
+  const input = container.querySelector(selector) as HTMLInputElement
+  input.value = value
+  input.dispatchEvent(new Event('input'))
+}
+
+function selectAction0(container: HTMLElement, type: string) {
+  const select = container.querySelector('[data-action-index="0"] .meta-rule-editor__action-header select') as HTMLSelectElement
+  select.value = type
+  select.dispatchEvent(new Event('change'))
+}
+
+function ruleWithParallel(config: Record<string, unknown>): AutomationRule {
+  return {
+    id: 'rule_pb',
+    sheetId: 'sheet_1',
+    name: 'Parallel rule',
+    triggerType: 'record.created',
+    triggerConfig: {},
+    actionType: 'parallel_branch',
+    actionConfig: config,
+    enabled: true,
+    executionMode: 'workflow_job_v1',
+    actions: [{ type: 'parallel_branch', config }],
+  } as AutomationRule
+}
+
+beforeEach(() => useLocale().setLocale('en'))
+afterEach(() => { document.body.innerHTML = ''; vi.restoreAllMocks() })
+
+describe('A6-3-4/W3-2a parallel_branch editor', () => {
+  it('auto-locks workflow_job_v1 but blocks saving the default empty branch action', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flush()
+
+    setInput(container, '[data-field="name"]', 'Parallel rule')
+    selectAction0(container, 'parallel_branch')
+    await flush()
+
+    const toggle = container.querySelector('[data-field="executionMode"]') as HTMLInputElement
+    expect(toggle.checked).toBe(true)
+    expect(toggle.disabled).toBe(true)
+    expect(container.querySelector('[data-action-config="parallel_branch"]')).not.toBeNull()
+    expect(container.querySelector('[data-field="parallel-branch-action-error"]')?.textContent ?? '').toContain('at least one field')
+    expect((container.querySelector('[data-action="save"]') as HTMLButtonElement).disabled).toBe(true)
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flush()
+
+    expect(saved).not.toHaveBeenCalled()
+  })
+
+  it('creates a branch with update_record field config in the executor shape', async () => {
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, onSave: saved })
+    await flush()
+
+    setInput(container, '[data-field="name"]', 'Parallel update')
+    selectAction0(container, 'parallel_branch')
+    await flush()
+
+    ;(container.querySelector('[data-parallel-branch-index="0"] [data-action="add-parallel-branch-field"]') as HTMLButtonElement).click()
+    await flush()
+    const pair = container.querySelector('[data-parallel-branch-index="0"] .meta-rule-editor__field-pair') as HTMLElement
+    const pairField = pair.querySelector('select') as HTMLSelectElement
+    pairField.value = 'fld_1'
+    pairField.dispatchEvent(new Event('change'))
+    const pairValue = pair.querySelector('input') as HTMLInputElement
+    pairValue.value = 'done'
+    pairValue.dispatchEvent(new Event('input'))
+    await flush()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flush()
+
+    const branch = saved.mock.calls[0][0].actions[0].config.branches[0]
+    expect(branch).toEqual({
+      key: 'branch_1',
+      actions: [{ type: 'update_record', config: { fields: { fld_1: 'done' } } }],
+    })
+  })
+
+  it('loads a supported parallel_branch rule and round-trips it on save', async () => {
+    const config = {
+      joinMode: 'all',
+      branches: [
+        { key: 'ops', label: 'Ops', actions: [{ type: 'update_record', config: { fields: { status: 'ops' } } }] },
+        { key: 'notify', actions: [{ type: 'send_notification', config: { userIds: ['u1', 'u2'], message: 'ready' } }] },
+      ],
+    }
+    const saved = vi.fn()
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule: ruleWithParallel(config), onSave: saved })
+    await flush()
+
+    expect((container.querySelector('[data-parallel-branch-index="0"] [data-field="parallel-branch-key"]') as HTMLInputElement).value).toBe('ops')
+    expect(container.querySelector('[data-field="parallel-branch-readonly"]')).toBeNull()
+
+    ;(container.querySelector('[data-action="save"]') as HTMLButtonElement).click()
+    await flush()
+
+    expect(saved.mock.calls[0][0].actions[0].config).toEqual(config)
+  })
+
+  it('opens unsupported loaded parallel_branch shapes read-only and blocks save', async () => {
+    const config = {
+      joinMode: 'all',
+      branches: [{ key: 'a', actions: [{ type: 'wait_for_callback', config: {} }] }],
+    }
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields, rule: ruleWithParallel(config) })
+    await flush()
+
+    expect(container.querySelector('[data-field="parallel-branch-readonly"]')).not.toBeNull()
+    expect((container.querySelector('[data-action="save"]') as HTMLButtonElement).disabled).toBe(true)
+    expect(container.querySelector('[data-action-config="parallel_branch"] [data-parallel-branch-index="0"]')).toBeNull()
+  })
+
+  it('blocks duplicate parallel branch keys before save', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flush()
+
+    setInput(container, '[data-field="name"]', 'Duplicate branch')
+    selectAction0(container, 'parallel_branch')
+    await flush()
+    ;(container.querySelector('[data-action-config="parallel_branch"] [data-action="add-parallel-branch"]') as HTMLButtonElement).click()
+    await flush()
+
+    const keyInputs = container.querySelectorAll('[data-parallel-branch-index] [data-field="parallel-branch-key"]')
+    ;(keyInputs[1] as HTMLInputElement).value = 'branch_1'
+    ;(keyInputs[1] as HTMLInputElement).dispatchEvent(new Event('input'))
+    await flush()
+
+    expect(container.querySelector('[data-field="parallel-branch-key-error"]')).not.toBeNull()
+    expect((container.querySelector('[data-action="save"]') as HTMLButtonElement).disabled).toBe(true)
+  })
+
+  it('blocks saving when the component draft exceeds the branch cap', async () => {
+    const { container } = mount({ visible: true, sheetId: 'sheet_1', fields })
+    await flush()
+
+    setInput(container, '[data-field="name"]', 'Too many branches')
+    selectAction0(container, 'parallel_branch')
+    await flush()
+
+    const addBranch = container.querySelector('[data-action-config="parallel_branch"] [data-action="add-parallel-branch"]') as HTMLButtonElement
+    for (let i = 0; i < 10; i += 1) {
+      addBranch.click()
+      await flush()
+    }
+
+    expect(container.querySelectorAll('[data-parallel-branch-index]')).toHaveLength(11)
+    expect(container.querySelector('[data-field="parallel-branch-key-error"]')?.textContent ?? '').toContain('at most 10')
+    expect((container.querySelector('[data-action="save"]') as HTMLButtonElement).disabled).toBe(true)
+  })
+})


### PR DESCRIPTION
## Summary
- add the A6-3-4/W3-2a `parallel_branch` editor surface, stacked on #2496 runtime
- author join-all branches with the v1 safe subset: branch `key`/`label`, and per-branch `update_record` / `send_notification` actions
- force `workflow_job_v1` whenever `parallel_branch` is present, matching the backend fail-closed contract
- add a pure `parallelBranchAuthoring` seam for round-trip, key/count validation, and read-only-never-flatten handling of richer loaded shapes

## Scope
- Frontend-only editor slice.
- Base is `codex/a6-3-join-all-runtime-20260611` / PR #2496.
- No backend, migration, public webhook, branch-local wait/resume, nested branch, join-any, BPMN, or approval-as-job changes.
- Runs-detail readability remains a separate follow-up after runtime/editor land.

## Verification
- `git diff --check`
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/web exec vitest run tests/parallelBranchAuthoring.spec.ts tests/parallelBranchEditor.spec.ts tests/conditionBranchAuthoring.spec.ts tests/conditionBranchEditor.spec.ts tests/meta-automation-labels.spec.ts tests/multitable-automation-rule-editor.spec.ts --watch=false` — 151 tests passed
- `pnpm --filter @metasheet/web build`

## Review
- Subagent Plato reviewed the worktree read-only and returned APPROVE with no blockers.
