### PR TITLE
feat(multitable): show parallel branch runs

### DIFF
--- a/apps/web/src/multitable/utils/meta-automation-labels.ts
+++ b/apps/web/src/multitable/utils/meta-automation-labels.ts
@@ -281,8 +281,10 @@ export type AutomationLabelKey =
   | 'runs.ruleSnapshot'
   | 'runs.steps'
   | 'runs.branchStep'
+  | 'runs.parallelBranchStep'
   | 'runs.selectedBranch'
   | 'runs.branchNoMatch'
+  | 'runs.parallelJoinAll'
   | 'runs.loadingDetail'
   | 'runs.resume'
   | 'runs.resumeConfirm'
@@ -523,8 +525,10 @@ export const AUTOMATION_LABEL_KEYS: readonly AutomationLabelKey[] = [
   'runs.ruleSnapshot',
   'runs.steps',
   'runs.branchStep',
+  'runs.parallelBranchStep',
   'runs.selectedBranch',
   'runs.branchNoMatch',
+  'runs.parallelJoinAll',
   'runs.loadingDetail',
   'runs.resume',
   'runs.resumeConfirm',
@@ -790,8 +794,10 @@ const LABELS: Record<AutomationLabelKey, { en: string; zh: string }> = {
   'runs.ruleSnapshot': { en: 'Rule snapshot', zh: '规则快照' },
   'runs.steps': { en: 'Steps', zh: '步骤' },
   'runs.branchStep': { en: 'branch', zh: '分支' },
+  'runs.parallelBranchStep': { en: 'parallel branch', zh: '并行分支' },
   'runs.selectedBranch': { en: 'Selected branch:', zh: '命中分支：' },
   'runs.branchNoMatch': { en: 'No branch matched (no default)', zh: '无分支命中（无默认分支）' },
+  'runs.parallelJoinAll': { en: 'Parallel join-all:', zh: '并行全部汇合：' },
   'runs.loadingDetail': { en: 'Loading detail…', zh: '加载详情…' },
   'runs.resume': { en: 'Resume', zh: '恢复执行' },
   'runs.resumeConfirm': {

--- a/apps/web/src/views/AutomationExecutionsView.vue
+++ b/apps/web/src/views/AutomationExecutionsView.vue
@@ -66,11 +66,14 @@
               v-for="step in detail.steps"
               :key="step.id"
               class="automation-runs__step"
-              :class="{ 'automation-runs__step--branch-child': branchChildStep(step.stepKey) }"
+              :class="{ 'automation-runs__step--branch-child': branchChildStep(step.stepKey) || parallelChildStep(step.stepKey) }"
             >
               <span class="automation-runs__step-key">{{ step.stepKey }}</span>
               <span v-if="branchChildStep(step.stepKey)" class="automation-runs__branch-child" data-field="branch-child">
                 ↳ {{ automationLabel('runs.branchStep', isZh) }} {{ branchChildStep(step.stepKey)?.branchKey }} · #{{ branchChildStep(step.stepKey)?.actionIndex }}
+              </span>
+              <span v-else-if="parallelChildStep(step.stepKey)" class="automation-runs__branch-child" data-field="parallel-child">
+                ↳ {{ automationLabel('runs.parallelBranchStep', isZh) }} {{ parallelChildStep(step.stepKey)?.branchKey }} · #{{ parallelChildStep(step.stepKey)?.actionIndex }}
               </span>
               <span class="automation-runs__badge automation-runs__badge--sm" :class="`automation-runs__badge--${step.status}`">
                 {{ automationStatusLabel(step.status, isZh) }}
@@ -91,7 +94,13 @@
                 <template v-if="conditionBranchSelection(step)?.key">{{ automationLabel('runs.selectedBranch', isZh) }} {{ conditionBranchSelection(step)?.label ? `${conditionBranchSelection(step)?.label} (${conditionBranchSelection(step)?.key})` : conditionBranchSelection(step)?.key }}</template>
                 <template v-else>{{ automationLabel('runs.branchNoMatch', isZh) }}</template>
               </div>
-              <div v-if="step.result !== undefined && step.result !== null && !conditionBranchSelection(step)" class="automation-runs__step-output" data-field="step-output">
+              <div v-if="parallelBranchSummary(step)" class="automation-runs__branch-selection" data-field="parallel-summary">
+                {{ automationLabel('runs.parallelJoinAll', isZh) }}
+                <span v-for="branch in parallelBranchSummary(step)?.branches" :key="branch.key" class="automation-runs__parallel-branch" data-field="parallel-branch-status">
+                  {{ branch.label ? `${branch.label} (${branch.key})` : branch.key }}: {{ automationStatusLabel(branch.status, isZh) }}
+                </span>
+              </div>
+              <div v-if="step.result !== undefined && step.result !== null && !conditionBranchSelection(step) && !parallelBranchSummary(step)" class="automation-runs__step-output" data-field="step-output">
                 {{ summarizeStepOutput(step.result) }}
               </div>
             </div>
@@ -142,9 +151,11 @@ const detailLoading = ref(false)
 const resuming = ref<string | null>(null)
 const resumeError = ref<string | null>(null)
 
-// A6-3-2b (read-only): surface condition_branch lineage from the persisted C1 jobs.
+// A6-3-2b/A6-3-4 (read-only): surface branch lineage from the persisted C1 jobs.
 // Parent step's result carries { selectedBranchKey, matched }; nested branch-action jobs use a
-// `${stepIndex}.branch.${key}.${i}` stepKey. Pure readers over the existing run-view shape.
+// `${stepIndex}.branch.${key}.${i}` stepKey. parallel_branch uses the same shape with
+// `${stepIndex}.parallel.${key}.${i}` and a parent result containing branchStatuses.
+// Pure readers over the existing run-view shape.
 function conditionBranchSelection(step: AutomationRunStepView): { key: string; label: string; matched: boolean } | null {
   const r = step.result
   if (r && typeof r === 'object' && !Array.isArray(r) && 'selectedBranchKey' in r) {
@@ -160,6 +171,26 @@ function conditionBranchSelection(step: AutomationRunStepView): { key: string; l
 function branchChildStep(stepKey: string): { branchKey: string; actionIndex: string } | null {
   const m = /\.branch\.([A-Za-z0-9_-]+)\.(\d+)$/.exec(stepKey)
   return m ? { branchKey: m[1], actionIndex: m[2] } : null
+}
+function parallelChildStep(stepKey: string): { branchKey: string; actionIndex: string } | null {
+  const m = /\.parallel\.([A-Za-z0-9_-]+)\.(\d+)$/.exec(stepKey)
+  return m ? { branchKey: m[1], actionIndex: m[2] } : null
+}
+function parallelBranchSummary(step: AutomationRunStepView): { branches: Array<{ key: string; label: string; status: WorkflowJobStatus }> } | null {
+  const r = step.result
+  if (!r || typeof r !== 'object' || Array.isArray(r)) return null
+  const rec = r as Record<string, unknown>
+  if (rec.joinMode !== 'all' || !rec.branchStatuses || typeof rec.branchStatuses !== 'object' || Array.isArray(rec.branchStatuses)) return null
+  const labels = rec.branchLabels && typeof rec.branchLabels === 'object' && !Array.isArray(rec.branchLabels)
+    ? rec.branchLabels as Record<string, unknown>
+    : {}
+  const branches = Object.entries(rec.branchStatuses as Record<string, unknown>)
+    .map(([key, status]) => ({
+      key,
+      label: typeof labels[key] === 'string' ? labels[key] : '',
+      status: (typeof status === 'string' ? status : 'running') as WorkflowJobStatus,
+    }))
+  return { branches }
 }
 
 async function loadData() {

--- a/apps/web/tests/meta-automation-labels.spec.ts
+++ b/apps/web/tests/meta-automation-labels.spec.ts
@@ -72,6 +72,13 @@ describe('meta-automation-labels', () => {
     expect(automationLabel('editor.executionModeRequiredHint', true)).toContain('等待回调')
   })
 
+  it('localizes branch run-readability labels', () => {
+    expect(automationLabel('runs.parallelBranchStep', false)).toBe('parallel branch')
+    expect(automationLabel('runs.parallelBranchStep', true)).toBe('并行分支')
+    expect(automationLabel('runs.parallelJoinAll', false)).toBe('Parallel join-all:')
+    expect(automationLabel('runs.parallelJoinAll', true)).toBe('并行全部汇合：')
+  })
+
   it('localizes trigger types, trigger conditions, and cron presets with raw fallbacks', () => {
     expect(automationTriggerTypeLabel('record.created', false)).toBe('When record created')
     expect(automationTriggerTypeLabel('record.created', true)).toBe('当记录创建时')

--- a/apps/web/tests/parallelBranchRunsView.spec.ts
+++ b/apps/web/tests/parallelBranchRunsView.spec.ts
@@ -1,0 +1,146 @@
+// A6-3-4/W3-2b — parallel_branch readability in the admin runs view (read-only).
+import { afterEach, beforeEach, describe, expect, it, vi } from 'vitest'
+import { createApp, h, nextTick } from 'vue'
+import AutomationExecutionsView from '../src/views/AutomationExecutionsView.vue'
+import { useLocale } from '../src/composables/useLocale'
+import type { AutomationRunView } from '../src/multitable/types'
+
+let mockIsAdmin = true
+vi.mock('../src/composables/useAuth', () => ({ useAuth: () => ({ hasAdminAccess: () => mockIsAdmin }) }))
+
+async function settle() {
+  await new Promise((resolve) => setTimeout(resolve, 0))
+  await nextTick()
+}
+
+const LIST = {
+  id: 'axe_pb', ruleId: 'rule-parallel', sheetId: 'sheet-a', status: 'resolved', statusLegacy: 'success',
+  triggeredBy: 'event', triggeredAt: '2026-06-11T00:00:00.000Z', finishedAt: '2026-06-11T00:00:01.000Z',
+  duration: 1, error: null, schemaVersion: 1, steps: [],
+}
+
+function detailWith(steps: unknown[]): AutomationRunView {
+  return { ...LIST, triggerEvent: { recordId: 'rec1' }, ruleSnapshot: { id: 'rule-parallel', name: 'Parallel' }, steps } as AutomationRunView
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function makeClient(detail: AutomationRunView): any {
+  return { listAutomationRuns: vi.fn().mockResolvedValue([LIST]), getAutomationRun: vi.fn().mockResolvedValue(detail) }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+function mount(client: any) {
+  const container = document.createElement('div')
+  document.body.appendChild(container)
+  const app = createApp({ render: () => h(AutomationExecutionsView, { client }) })
+  app.mount(container)
+  return { container, app }
+}
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+let mounted: { container: HTMLElement; app: any } | null = null
+
+beforeEach(() => { mockIsAdmin = true; useLocale().setLocale('en') })
+afterEach(() => { if (mounted) { mounted.app.unmount(); mounted.container.remove(); mounted = null } })
+
+async function expand(detail: AutomationRunView) {
+  mounted = mount(makeClient(detail))
+  await settle()
+  ;(mounted.container.querySelector('[data-run-id="axe_pb"]') as HTMLElement).click()
+  await settle()
+  return mounted.container
+}
+
+describe('A6-3-4/W3-2b parallel_branch runs readability', () => {
+  it('shows join-all branch statuses and nested parallel child jobs without raw parent JSON', async () => {
+    const c = await expand(detailWith([
+      {
+        id: 'axe_pb:step:0',
+        executionId: 'axe_pb',
+        stepKey: '0',
+        status: 'resolved',
+        upstreamJobId: null,
+        result: {
+          joinMode: 'all',
+          branchCount: 2,
+          childJobIds: ['axe_pb:job:0:parallel:ops:0', 'axe_pb:job:0:parallel:notify:0'],
+          resolvedBranchKeys: ['ops', 'notify'],
+          failedBranchKeys: [],
+          branchStatuses: { ops: 'resolved', notify: 'resolved' },
+          branchLabels: { ops: 'Ops team', notify: 'Notify team' },
+        },
+      },
+      { id: 'axe_pb:step:0a', executionId: 'axe_pb', stepKey: '0.parallel.ops.0', status: 'resolved', upstreamJobId: 'axe_pb:step:0', result: { updated: 1 } },
+      { id: 'axe_pb:step:0b', executionId: 'axe_pb', stepKey: '0.parallel.notify.0', status: 'resolved', upstreamJobId: 'axe_pb:step:0', result: { notified: 1 } },
+    ]))
+
+    const summary = c.querySelector('[data-field="parallel-summary"]')
+    expect(summary).not.toBeNull()
+    expect(summary?.textContent ?? '').toContain('Parallel join-all:')
+    expect(summary?.textContent ?? '').toContain('Ops team (ops): resolved')
+    expect(summary?.textContent ?? '').toContain('Notify team (notify): resolved')
+    expect(c.querySelector('[data-field="step-output"]')?.textContent ?? '').not.toContain('childJobIds')
+
+    const child = c.querySelector('[data-field="parallel-child"]')
+    expect(child).not.toBeNull()
+    expect(child?.textContent ?? '').toContain('parallel branch ops')
+    expect(child?.textContent ?? '').toContain('#0')
+    expect(c.querySelector('.automation-runs__step--branch-child')).not.toBeNull()
+  })
+
+  it('surfaces failed branch status while keeping sibling child jobs visible', async () => {
+    const c = await expand(detailWith([
+      {
+        id: 'axe_pb:step:0',
+        executionId: 'axe_pb',
+        stepKey: '0',
+        status: 'failed',
+        upstreamJobId: null,
+        error: 'parallel_branch failed branches: bad',
+        result: {
+          joinMode: 'all',
+          branchStatuses: { bad: 'failed', good: 'resolved' },
+          branchLabels: { good: 'Good path' },
+        },
+      },
+      { id: 'axe_pb:step:0a', executionId: 'axe_pb', stepKey: '0.parallel.bad.0', status: 'failed', upstreamJobId: 'axe_pb:step:0', error: 'missing recipient' },
+      { id: 'axe_pb:step:0b', executionId: 'axe_pb', stepKey: '0.parallel.good.0', status: 'resolved', upstreamJobId: 'axe_pb:step:0', result: { notified: 1 } },
+    ]))
+
+    const summary = c.querySelector('[data-field="parallel-summary"]')
+    expect(summary?.textContent ?? '').toContain('bad: failed')
+    expect(summary?.textContent ?? '').toContain('Good path (good): resolved')
+    expect(c.querySelectorAll('[data-field="parallel-child"]')).toHaveLength(2)
+  })
+
+  it('keeps skipped parallel child jobs and downstream skipped steps visible', async () => {
+    const c = await expand(detailWith([
+      {
+        id: 'axe_pb:step:0',
+        executionId: 'axe_pb',
+        stepKey: '0',
+        status: 'failed',
+        upstreamJobId: null,
+        error: 'parallel_branch failed branches: bad',
+        result: {
+          joinMode: 'all',
+          branchStatuses: { bad: 'failed', tail: 'skipped' },
+          branchLabels: { tail: 'Tail path' },
+        },
+      },
+      { id: 'axe_pb:step:0a', executionId: 'axe_pb', stepKey: '0.parallel.bad.0', status: 'failed', upstreamJobId: 'axe_pb:step:0', error: 'missing recipient' },
+      { id: 'axe_pb:step:0b', executionId: 'axe_pb', stepKey: '0.parallel.tail.1', status: 'skipped', upstreamJobId: 'axe_pb:step:0', result: null },
+      { id: 'axe_pb:step:1', executionId: 'axe_pb', stepKey: '1', status: 'skipped', upstreamJobId: 'axe_pb:step:0', result: null },
+    ]))
+
+    const summary = c.querySelector('[data-field="parallel-summary"]')
+    expect(summary?.textContent ?? '').toContain('bad: failed')
+    expect(summary?.textContent ?? '').toContain('Tail path (tail): skipped')
+    const childRows = Array.from(c.querySelectorAll('[data-field="parallel-child"]'))
+    expect(childRows).toHaveLength(2)
+    expect(childRows[1]?.textContent ?? '').toContain('parallel branch tail')
+    expect(childRows[1]?.textContent ?? '').toContain('#1')
+    expect(c.textContent ?? '').toContain('skipped')
+    expect(c.querySelectorAll('.automation-runs__badge--skipped').length).toBeGreaterThanOrEqual(2)
+  })
+})


### PR DESCRIPTION
## Summary
- add read-only admin-runs readability for A6-3-4/W3-2b `parallel_branch`
- render parent `joinMode: all` branch statuses as a compact summary instead of raw `childJobIds` JSON
- label/indent nested child jobs from `N.parallel.<branchKey>.<actionIndex>` stepKeys
- keep existing `condition_branch` runs readability intact

## Scope
- Frontend-only runs-detail slice, stacked on #2500.
- No backend/API/migration/runtime changes.
- No editor changes, public webhook, branch-local wait/resume, join-any, BPMN, or approval-as-job surface.

## Verification
- `git diff --check`
- `pnpm --filter @metasheet/web type-check`
- `pnpm --filter @metasheet/web exec vitest run tests/parallelBranchRunsView.spec.ts tests/conditionBranchRunsView.spec.ts tests/meta-automation-labels.spec.ts --watch=false` — 15 tests passed
- `pnpm --filter @metasheet/web exec vitest run tests/AutomationExecutionsView.spec.ts tests/conditionBranchRunsView.spec.ts tests/parallelBranchRunsView.spec.ts tests/meta-automation-labels.spec.ts --watch=false` — 23 tests passed
- `pnpm --filter @metasheet/web build`

## Review
- Subagent Poincare reviewed the worktree read-only and returned APPROVE with no blockers.
