### PR TITLE
feat(attendance): produce C5 comp-time expiry reminders

### DIFF
--- a/.github/workflows/plugin-tests.yml
+++ b/.github/workflows/plugin-tests.yml
@@ -256,6 +256,7 @@ jobs:
             tests/integration/attendance-unscheduled-reminder.test.ts \
             tests/integration/attendance-outdoor-punch.test.ts \
             tests/integration/attendance-notification-deliveries.test.ts \
+            tests/integration/attendance-comp-time-expiry-reminder.test.ts \
             --reporter=dot
 
       - name: Upload test results

--- a/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
+++ b/docs/development/attendance-dingtalk-benchmark-target-and-tracker-20260601.md
@@ -78,14 +78,14 @@
 |---|---|---|---|
 | 1 | **C5 design-lock** | ✅ #2483 | 锁定 `dispatched_at` 不是 delivery success、outbox/delivery-status/retry、本人 + owner/sub_owner fan-out、channel env-gating、staging smoke 口径 |
 | 2 | **C5-0 outbox DDL** | ✅ #2487 | `attendance_notification_deliveries` 表 + CHECK/unique/index；不发送 |
-| 3 | **C5-1a unscheduled fan-out producer** | 🟡 本 PR | 未排班 intent row → 本人 + 负责人 delivery rows，幂等 source_key，重复不建 dup；pending CI/review/merge 后回填 ✅ |
-| 4 | **C5-1b comp-time expiry reminder producer** | 🔒 | 即将到期 active lot → 本人 + 负责人 delivery rows，不改余额；重复不建 dup |
+| 3 | **C5-1a unscheduled fan-out producer** | ✅ #2498 | 未排班 intent row → 本人 + 负责人 delivery rows，幂等 source_key，重复不建 dup；CI real-DB gate 实跑 `attendance-unscheduled-reminder` + outbox spec |
+| 4 | **C5-1b comp-time expiry reminder producer** | 🟡 本 PR | 即将到期 active `comp_time` lot → 本人 + 负责人 delivery rows，不改余额；重复不建 dup；pending CI/review/merge 后回填 ✅ |
 | 5 | **C5-2 delivery worker + fake channel** | 🔒 | pending/retrying claim → sent/retrying/failed/skipped 状态流 + retry/backoff；无真实外网依赖 |
 | 6 | **C5-3 DingTalk work-notification channel** | 🔒 | env/store-gated，复用现有 DingTalk work-notification runtime；缺配置/缺绑定 fail-visible |
 | 7 | **C5-4 admin observability** | 🔒 | read-only delivery status view/counters；不默认加手动 retry |
 | 8 | **C5-5 staging closeout** | 🔒 | C5-5a fake-channel 只证明 delivery-state（仍 🟡）；C5-5b 真实 DingTalk work-notification smoke 证明未排班 + 调休到期两 source、fan-out、delivery 状态流、retry/idempotency、scheduler 共存、cleanup residue=0 后才 ✅ |
 
-> 2026-06-11 回填：C5 design-lock #2483 与 C5-0 outbox DDL #2487 已落 main；C5-1a 正在本 PR 中接入未排班提醒 producer（仅写 outbox，不直发真实 channel），C5 整体仍保持 🟡，直到 C5-1b/C5-2/C5-3/C5-5b 完整闭环。
+> 2026-06-11 回填：C5 design-lock #2483 与 C5-0 outbox DDL #2487 已落 main；C5-1a #2498 已接入未排班提醒 producer（仅写 outbox，不直发真实 channel），C5-1b 正在本 PR 中接入调休到期提醒 producer。C5 整体仍保持 🟡，直到 C5-1b/C5-2/C5-3/C5-5b 完整闭环。
 
 ### Out of this target
 

--- a/packages/core-backend/package.json
+++ b/packages/core-backend/package.json
@@ -26,7 +26,7 @@
     "test:unit": "vitest run tests/unit --reporter=dot",
     "test:integration": "vitest --config vitest.integration.config.ts run tests/integration --reporter=dot",
     "test:integration:after-sales": "vitest --config vitest.integration.config.ts run tests/integration/after-sales-plugin.install.test.ts --reporter=dot",
-    "test:integration:attendance": "vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts tests/integration/attendance-expiry-service.test.ts tests/integration/attendance-unscheduled-reminder.test.ts tests/integration/attendance-outdoor-punch.test.ts tests/integration/attendance-notification-deliveries.test.ts --reporter=dot",
+    "test:integration:attendance": "vitest --config vitest.integration.config.ts run tests/integration/attendance-plugin.test.ts tests/integration/attendance-expiry-service.test.ts tests/integration/attendance-unscheduled-reminder.test.ts tests/integration/attendance-outdoor-punch.test.ts tests/integration/attendance-notification-deliveries.test.ts tests/integration/attendance-comp-time-expiry-reminder.test.ts --reporter=dot",
     "test:contract": "vitest run tests/contract --reporter=dot",
     "test:e2e:handoff": "npx playwright test --config tests/e2e/playwright.config.ts",
     "test:cache": "npm run build:cache && TEST_USE_DIST=true vitest --config vitest.cache.config.ts run --reporter=dot",

--- a/packages/core-backend/src/index.ts
+++ b/packages/core-backend/src/index.ts
@@ -93,6 +93,7 @@ import {
 import {
   resolveAttendanceSchedulerIntervalMs,
   resolveAttendanceSchedulerLeaderOptions,
+  resolveCompTimeExpiryReminderJob,
   resolveUnscheduledReminderJob,
   registerAttendanceSchedulerJob,
   startAttendanceScheduler,
@@ -2029,13 +2030,13 @@ export class MetaSheetServer {
 
     // ④ C4 — attendance comp-time expiry scheduler. Opt-in (ATTENDANCE_SCHEDULER_ENABLED=true, default
     // OFF); returns null and no-ops when disabled. The expiry claim is idempotent + concurrency-safe on
-    // its own, so the optional Redis leader lock only sheds load. ⑤ adds the unscheduled-reminder job as a
-    // SECOND job on the same scheduler, itself opt-in (ATTENDANCE_UNSCHEDULED_REMINDER_ENABLED=true, default
-    // OFF → null → expiry only).
+    // its own, so the optional Redis leader lock only sheds load. ⑤/C5 source producers are SECONDARY jobs
+    // on the same scheduler, each opt-in (default OFF → null → expiry only).
     try {
       const attendanceLeaderOptions = await resolveAttendanceSchedulerLeaderOptions()
       const unscheduledReminderJob = resolveUnscheduledReminderJob()
-      const attendanceSchedulerJobs = unscheduledReminderJob ? [unscheduledReminderJob] : []
+      const compTimeExpiryReminderJob = resolveCompTimeExpiryReminderJob()
+      const attendanceSchedulerJobs = [unscheduledReminderJob, compTimeExpiryReminderJob].filter((job): job is NonNullable<typeof job> => Boolean(job))
       const scheduler = startAttendanceScheduler({
         leaderOptions: attendanceLeaderOptions,
         intervalMs: resolveAttendanceSchedulerIntervalMs(),

--- a/packages/core-backend/src/services/AttendanceScheduler.ts
+++ b/packages/core-backend/src/services/AttendanceScheduler.ts
@@ -28,6 +28,7 @@ import {
   type AttendanceExpiryService,
   type ExpiredCompTimeBalance,
 } from './AttendanceExpiryService'
+import { CompTimeExpiryReminderService } from './CompTimeExpiryReminderService'
 import { UnscheduledReminderService } from './UnscheduledReminderService'
 
 const DEFAULT_INTERVAL_MS = 60 * 60 * 1000
@@ -360,6 +361,23 @@ export function resolveUnscheduledReminderJob(): AttendanceSchedulerJob | null {
   })
   return {
     name: 'unscheduled-reminder',
+    run: () => service.run(),
+  }
+}
+
+/**
+ * C5-1b opt-in: comp-time expiry reminder producer, only when
+ * ATTENDANCE_COMP_TIME_EXPIRY_REMINDER_ENABLED=true. It produces C5 outbox rows only; the delivery
+ * worker is the only path that may call a real channel. Lookahead defaults to 7 days and is clamped
+ * inside the service.
+ */
+export function resolveCompTimeExpiryReminderJob(): AttendanceSchedulerJob | null {
+  if (process.env.ATTENDANCE_COMP_TIME_EXPIRY_REMINDER_ENABLED !== 'true') return null
+  const service = new CompTimeExpiryReminderService({
+    lookaheadDays: Number(process.env.ATTENDANCE_COMP_TIME_EXPIRY_REMINDER_LOOKAHEAD_DAYS),
+  })
+  return {
+    name: 'comp-time-expiry-reminder',
     run: () => service.run(),
   }
 }

--- a/packages/core-backend/src/services/CompTimeExpiryReminderService.ts
+++ b/packages/core-backend/src/services/CompTimeExpiryReminderService.ts
@@ -1,0 +1,204 @@
+import { query as defaultQuery } from '../db/pg'
+import { Logger } from '../core/logger'
+
+/**
+ * C5-1b comp-time expiry reminder producer.
+ *
+ * This job scans active `comp_time` grant lots approaching `expires_at` and produces C5 delivery
+ * outbox rows for the balance owner plus current attendance group owners/sub-owners. It never mutates
+ * the balance lot; C4's expiry state-flow remains the only path that changes lot status/remaining.
+ */
+
+export type CompTimeExpiryReminderQuery = <T = unknown>(
+  sql: string,
+  params?: unknown[],
+) => Promise<{ rows: T[]; rowCount?: number | null }>
+
+export interface CompTimeExpiryReminderCandidate {
+  orgId: string
+  userId: string
+  balanceId: string
+  expiresAt: string
+  windowDate: string
+  remainingMinutes: number
+}
+
+export interface CompTimeExpiryReminderResult {
+  candidates: number
+  deliveries: number
+}
+
+export interface CompTimeExpiryReminderServiceOptions {
+  query?: CompTimeExpiryReminderQuery
+  lookaheadDays?: number
+  now?: () => Date
+  logger?: Logger
+}
+
+interface CandidateRow {
+  org_id: string
+  user_id: string
+  balance_id: string
+  expires_at: string
+  window_date: string
+  remaining_minutes: number | string
+}
+
+const DEFAULT_LOOKAHEAD_DAYS = 7
+const MIN_LOOKAHEAD_DAYS = 1
+const MAX_LOOKAHEAD_DAYS = 30
+const SOURCE_TYPE = 'comp_time_expiry_reminder'
+const DELIVERY_CHANNEL = 'dingtalk_work_notification'
+const INACTIVE_RECIPIENT_ERROR = 'recipient_inactive_or_missing'
+
+export function clampCompTimeExpiryReminderLookaheadDays(value: number | undefined): number {
+  const n = Number(value)
+  if (!Number.isFinite(n)) return DEFAULT_LOOKAHEAD_DAYS
+  return Math.min(MAX_LOOKAHEAD_DAYS, Math.max(MIN_LOOKAHEAD_DAYS, Math.floor(n)))
+}
+
+const CANDIDATE_SQL = `
+  SELECT b.org_id,
+         b.user_id,
+         b.id::text AS balance_id,
+         b.expires_at::text AS expires_at,
+         ((b.expires_at AT TIME ZONE 'UTC')::date)::text AS window_date,
+         b.remaining_minutes
+    FROM attendance_leave_balances b
+   WHERE b.leave_type_code = 'comp_time'
+     AND b.status = 'active'
+     AND b.remaining_minutes > 0
+     AND b.expires_at IS NOT NULL
+     AND b.expires_at > $1::timestamptz
+     AND b.expires_at <= $1::timestamptz + ($2::int * interval '24 hours')
+`
+
+export class CompTimeExpiryReminderService {
+  private readonly query: CompTimeExpiryReminderQuery
+  private readonly lookaheadDays: number
+  private readonly now: () => Date
+  private readonly logger: Logger
+  private running = false
+
+  constructor(options: CompTimeExpiryReminderServiceOptions = {}) {
+    this.query = options.query ?? (defaultQuery as CompTimeExpiryReminderQuery)
+    this.lookaheadDays = clampCompTimeExpiryReminderLookaheadDays(options.lookaheadDays)
+    this.now = options.now ?? (() => new Date())
+    this.logger = options.logger ?? new Logger('CompTimeExpiryReminderService')
+  }
+
+  async scanCandidates(): Promise<CompTimeExpiryReminderCandidate[]> {
+    const asOf = this.now().toISOString()
+    const { rows } = await this.query<CandidateRow>(
+      `${CANDIDATE_SQL}
+       ORDER BY b.expires_at ASC, b.id ASC`,
+      [asOf, this.lookaheadDays],
+    )
+    return rows.map((row) => ({
+      orgId: row.org_id,
+      userId: row.user_id,
+      balanceId: row.balance_id,
+      expiresAt: row.expires_at,
+      windowDate: row.window_date,
+      remainingMinutes: Number(row.remaining_minutes),
+    }))
+  }
+
+  async produceDeliveries(): Promise<number> {
+    const asOf = this.now().toISOString()
+    const { rows } = await this.query<{ id: string }>(
+      `WITH candidate_balances AS (
+         ${CANDIDATE_SQL}
+       ),
+       candidate_recipients AS (
+         SELECT b.org_id, b.user_id, b.balance_id, b.expires_at, b.window_date, b.remaining_minutes,
+                b.user_id AS recipient_user_id, 'subject'::text AS recipient_role, NULL::uuid AS group_id
+         FROM candidate_balances b
+         UNION ALL
+         SELECT b.org_id, b.user_id, b.balance_id, b.expires_at, b.window_date, b.remaining_minutes,
+                gm.user_id AS recipient_user_id, gm.role AS recipient_role, gm.group_id
+         FROM candidate_balances b
+         JOIN attendance_group_members m
+           ON m.org_id = b.org_id
+          AND m.user_id = b.user_id
+         JOIN attendance_group_managers gm
+           ON gm.org_id = b.org_id
+          AND gm.group_id = m.group_id
+          AND gm.role IN ('owner','sub_owner')
+       ),
+       recipient_rows AS (
+         SELECT c.org_id,
+                c.user_id,
+                c.balance_id,
+                c.expires_at,
+                c.window_date,
+                c.remaining_minutes,
+                c.recipient_user_id,
+                CASE
+                  WHEN bool_or(c.recipient_role = 'subject') THEN 'subject'
+                  WHEN bool_or(c.recipient_role = 'owner') THEN 'owner'
+                  ELSE 'sub_owner'
+                END AS recipient_role,
+                array_remove(ARRAY[
+                  CASE WHEN bool_or(c.recipient_role = 'subject') THEN 'subject' END,
+                  CASE WHEN bool_or(c.recipient_role = 'owner') THEN 'owner' END,
+                  CASE WHEN bool_or(c.recipient_role = 'sub_owner') THEN 'sub_owner' END
+                ], NULL) AS recipient_roles,
+                COALESCE(
+                  array_agg(DISTINCT c.group_id::text) FILTER (WHERE c.group_id IS NOT NULL),
+                  ARRAY[]::text[]
+                ) AS group_ids,
+                COALESCE(bool_or(u.is_active IS TRUE), false) AS is_active
+         FROM candidate_recipients c
+         LEFT JOIN users u ON u.id = c.recipient_user_id
+         GROUP BY c.org_id, c.user_id, c.balance_id, c.expires_at, c.window_date, c.remaining_minutes, c.recipient_user_id
+       )
+       INSERT INTO attendance_notification_deliveries
+         (org_id, source_type, source_id, source_key, recipient_user_id, recipient_role, channel, status, last_error, payload)
+       SELECT r.org_id,
+              '${SOURCE_TYPE}',
+              r.balance_id,
+              '${SOURCE_TYPE}:' || r.balance_id || ':' || r.window_date || ':recipient:' || r.recipient_user_id || ':channel:${DELIVERY_CHANNEL}',
+              r.recipient_user_id,
+              r.recipient_role,
+              '${DELIVERY_CHANNEL}',
+              CASE WHEN r.is_active THEN 'pending' ELSE 'skipped' END,
+              CASE WHEN r.is_active THEN NULL ELSE '${INACTIVE_RECIPIENT_ERROR}' END,
+              jsonb_build_object(
+                'kind', 'comp_time_expiry_reminder',
+                'title', 'Comp-time expiry reminder',
+                'body', 'Comp-time balance expires on ' || r.window_date || '.',
+                'sourceType', '${SOURCE_TYPE}',
+                'balanceId', r.balance_id,
+                'expiresAt', r.expires_at,
+                'windowDate', r.window_date,
+                'remainingMinutes', r.remaining_minutes,
+                'subjectUserId', r.user_id,
+                'recipientUserId', r.recipient_user_id,
+                'recipientRole', r.recipient_role,
+                'recipientRoles', r.recipient_roles,
+                'groupIds', r.group_ids
+              )
+       FROM recipient_rows r
+       ON CONFLICT (org_id, source_key) DO NOTHING
+       RETURNING id::text AS id`,
+      [asOf, this.lookaheadDays],
+    )
+    return rows.length
+  }
+
+  async run(): Promise<CompTimeExpiryReminderResult> {
+    if (this.running) return { candidates: 0, deliveries: 0 }
+    this.running = true
+    try {
+      const candidates = await this.scanCandidates()
+      const deliveries = await this.produceDeliveries()
+      this.logger.info(
+        `Comp-time expiry reminders candidates=${candidates.length} deliveries=${deliveries} lookaheadDays=${this.lookaheadDays}`,
+      )
+      return { candidates: candidates.length, deliveries }
+    } finally {
+      this.running = false
+    }
+  }
+}

--- a/packages/core-backend/tests/integration/attendance-comp-time-expiry-reminder.test.ts
+++ b/packages/core-backend/tests/integration/attendance-comp-time-expiry-reminder.test.ts
@@ -1,0 +1,203 @@
+import { afterAll, beforeAll, describe, expect, it } from 'vitest'
+import { Pool } from 'pg'
+import { randomUUID } from 'crypto'
+
+import {
+  CompTimeExpiryReminderService,
+  type CompTimeExpiryReminderQuery,
+} from '../../src/services/CompTimeExpiryReminderService'
+
+const dbUrl = process.env.ATTENDANCE_TEST_DATABASE_URL || process.env.DATABASE_URL
+const describeDb = dbUrl ? describe : describe.skip
+
+async function requireTable(pool: Pool, tableName: string): Promise<void> {
+  const tableCheck = await pool.query(`SELECT to_regclass(current_schema() || '.' || $1) AS name`, [tableName])
+  if (!tableCheck.rows[0]?.name) {
+    throw new Error(`Integration database is missing ${tableName}; run core-backend migrations before executing this suite.`)
+  }
+}
+
+describeDb('C5-1b comp-time expiry reminder producer (real DB)', () => {
+  let pool: Pool
+  let serviceQuery: CompTimeExpiryReminderQuery
+
+  beforeAll(() => {
+    pool = new Pool({ connectionString: dbUrl })
+    serviceQuery = async (sql, params) => {
+      const r = await pool.query(sql, params as unknown[])
+      return { rows: r.rows, rowCount: r.rowCount }
+    }
+  })
+
+  afterAll(async () => {
+    await pool?.end().catch(() => undefined)
+  })
+
+  it('produces subject + owner/sub_owner delivery rows for in-window comp-time lots, skips non-candidates, and never mutates balances', async () => {
+    const suffix = `ctexp${Date.now().toString(36)}`
+    const org = `org-${suffix}`
+    const subject = `u-expiring-${suffix}`
+    const ownerActive = `u-owner-${suffix}`
+    const subOwnerInactive = `u-subowner-inactive-${suffix}`
+    const ownerMissing = `u-owner-missing-${suffix}`
+    const groupId = randomUUID()
+    const sourceId = (label: string) => `manual-${label}-${suffix}`
+    const sourceKey = (label: string) => `manual:${label}:${suffix}`
+    let inWindowBalanceId = ''
+    let futureBalanceId = ''
+    let nullExpiryBalanceId = ''
+    let expiredBalanceId = ''
+    let nonCompBalanceId = ''
+    let exhaustedBalanceId = ''
+
+    const seedUser = (uid: string, active = true) =>
+      pool.query(
+        `INSERT INTO users (id, email, password_hash, name, role, is_active)
+         VALUES ($1,$2,'hash',$3,'user',$4)
+         ON CONFLICT (id) DO UPDATE SET is_active = EXCLUDED.is_active`,
+        [uid, `${uid}@example.test`, uid, active],
+      )
+
+    const insertBalance = async (label: string, leaveType: string, remaining: number, expiresAt: string | null, status = 'active') => {
+      const result = await pool.query<{ id: string }>(
+        `INSERT INTO attendance_leave_balances
+           (org_id, user_id, leave_type_code, amount_minutes, remaining_minutes, source_type, source_id, source_key, expires_at, status)
+         VALUES ($1,$2,$3,120,$4,'manual_grant',$5,$6,$7::timestamptz,$8)
+         RETURNING id::text AS id`,
+        [org, subject, leaveType, remaining, sourceId(label), sourceKey(label), expiresAt, status],
+      )
+      return result.rows[0].id
+    }
+
+    try {
+      await requireTable(pool, 'attendance_leave_balances')
+      await requireTable(pool, 'attendance_notification_deliveries')
+      await requireTable(pool, 'attendance_group_managers')
+
+      await seedUser(subject)
+      await seedUser(ownerActive)
+      await seedUser(subOwnerInactive, false)
+      await pool.query(
+        `INSERT INTO attendance_groups (id, org_id, name, attendance_type)
+         VALUES ($1,$2,'expiry-reminder-group','scheduled_shift')`,
+        [groupId, org],
+      )
+      await pool.query(
+        `INSERT INTO attendance_group_members (id, org_id, group_id, user_id)
+         VALUES ($1,$2,$3,$4)`,
+        [randomUUID(), org, groupId, subject],
+      )
+      await pool.query(
+        `INSERT INTO attendance_group_managers (id, org_id, group_id, user_id, role) VALUES
+           ($1,$5,$4,$6,'owner'),
+           ($2,$5,$4,$7,'sub_owner'),
+           ($3,$5,$4,$8,'owner')`,
+        [randomUUID(), randomUUID(), randomUUID(), groupId, org, ownerActive, subOwnerInactive, ownerMissing],
+      )
+
+      inWindowBalanceId = await insertBalance('in-window', 'comp_time', 120, '2026-07-04T12:00:00.000Z')
+      futureBalanceId = await insertBalance('future', 'comp_time', 120, '2026-07-20T12:00:00.000Z')
+      nullExpiryBalanceId = await insertBalance('null-expiry', 'comp_time', 120, null)
+      expiredBalanceId = await insertBalance('expired', 'comp_time', 120, '2026-06-30T12:00:00.000Z')
+      nonCompBalanceId = await insertBalance('non-comp', 'annual_leave', 120, '2026-07-04T12:00:00.000Z')
+      exhaustedBalanceId = await insertBalance('exhausted', 'comp_time', 0, '2026-07-04T12:00:00.000Z', 'exhausted')
+
+      const svc = new CompTimeExpiryReminderService({
+        query: serviceQuery,
+        now: () => new Date('2026-07-01T00:00:00.000Z'),
+        lookaheadDays: 7,
+      })
+
+      const candidates = await svc.scanCandidates()
+      const mine = candidates.filter((candidate) => candidate.orgId === org)
+      expect(mine).toEqual([expect.objectContaining({
+        balanceId: inWindowBalanceId,
+        userId: subject,
+        windowDate: '2026-07-04',
+        remainingMinutes: 120,
+      })])
+
+      const firstRun = await svc.run()
+      expect(firstRun.deliveries).toBeGreaterThanOrEqual(4)
+
+      const deliveryRows = async (balanceId: string) => (await pool.query(
+        `SELECT *
+           FROM attendance_notification_deliveries
+          WHERE org_id = $1
+            AND source_type = 'comp_time_expiry_reminder'
+            AND source_id = $2
+          ORDER BY recipient_user_id`,
+        [org, balanceId],
+      )).rows
+      const deliveries = await deliveryRows(inWindowBalanceId)
+      expect(deliveries).toHaveLength(4)
+      const byRecipient = new Map(deliveries.map((row) => [row.recipient_user_id, row]))
+      expect(byRecipient.get(subject)).toMatchObject({
+        recipient_role: 'subject',
+        channel: 'dingtalk_work_notification',
+        status: 'pending',
+        last_error: null,
+      })
+      expect(byRecipient.get(ownerActive)).toMatchObject({
+        recipient_role: 'owner',
+        channel: 'dingtalk_work_notification',
+        status: 'pending',
+        last_error: null,
+      })
+      expect(byRecipient.get(subOwnerInactive)).toMatchObject({
+        recipient_role: 'sub_owner',
+        status: 'skipped',
+        last_error: 'recipient_inactive_or_missing',
+      })
+      expect(byRecipient.get(ownerMissing)).toMatchObject({
+        recipient_role: 'owner',
+        status: 'skipped',
+        last_error: 'recipient_inactive_or_missing',
+      })
+      const subjectPayload = parsePayload(byRecipient.get(subject)?.payload)
+      expect(subjectPayload).toMatchObject({
+        kind: 'comp_time_expiry_reminder',
+        balanceId: inWindowBalanceId,
+        sourceType: 'comp_time_expiry_reminder',
+        subjectUserId: subject,
+        recipientUserId: subject,
+        recipientRole: 'subject',
+        windowDate: '2026-07-04',
+        remainingMinutes: 120,
+      })
+      const ownerPayload = parsePayload(byRecipient.get(ownerActive)?.payload)
+      expect(ownerPayload.recipientRoles).toEqual(['owner'])
+      expect(ownerPayload.groupIds).toEqual([groupId])
+
+      for (const skipped of [futureBalanceId, nullExpiryBalanceId, expiredBalanceId, nonCompBalanceId, exhaustedBalanceId]) {
+        expect(await deliveryRows(skipped)).toHaveLength(0)
+      }
+
+      const beforeRepeat = await deliveryRows(inWindowBalanceId)
+      await svc.run()
+      expect(await deliveryRows(inWindowBalanceId)).toHaveLength(beforeRepeat.length)
+
+      const balance = (await pool.query(
+        `SELECT remaining_minutes, status, expires_at::text AS expires_at
+           FROM attendance_leave_balances
+          WHERE id = $1`,
+        [inWindowBalanceId],
+      )).rows[0]
+      expect(Number(balance.remaining_minutes)).toBe(120)
+      expect(balance.status).toBe('active')
+      expect(balance.expires_at).toBeTruthy()
+    } finally {
+      await pool.query('DELETE FROM attendance_notification_deliveries WHERE org_id = $1', [org]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_leave_balance_events WHERE user_id = $1', [subject]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_leave_balances WHERE user_id = $1', [subject]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_group_managers WHERE org_id = $1', [org]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_group_members WHERE org_id = $1', [org]).catch(() => undefined)
+      await pool.query('DELETE FROM attendance_groups WHERE org_id = $1', [org]).catch(() => undefined)
+      await pool.query('DELETE FROM users WHERE id = ANY($1::text[])', [[subject, ownerActive, subOwnerInactive]]).catch(() => undefined)
+    }
+  })
+})
+
+function parsePayload(value: unknown): Record<string, unknown> {
+  return typeof value === 'string' ? JSON.parse(value) as Record<string, unknown> : value as Record<string, unknown>
+}

--- a/packages/core-backend/tests/unit/attendance-scheduler.test.ts
+++ b/packages/core-backend/tests/unit/attendance-scheduler.test.ts
@@ -3,6 +3,7 @@ import { afterEach, describe, expect, it, vi } from 'vitest'
 import {
   AttendanceScheduler,
   registerAttendanceSchedulerJob,
+  resolveCompTimeExpiryReminderJob,
   resolveUnscheduledReminderJob,
   startAttendanceScheduler,
   stopAttendanceScheduler,
@@ -12,6 +13,7 @@ import {
   AttendanceNotifier,
   createAttendanceNotifierChannelsFromEnv,
 } from '../../src/services/AttendanceNotifier'
+import { CompTimeExpiryReminderService } from '../../src/services/CompTimeExpiryReminderService'
 import { UnscheduledReminderService } from '../../src/services/UnscheduledReminderService'
 
 function fakeExpiryService(rows: ExpiredCompTimeBalance[], spy?: () => void): AttendanceExpiryService {
@@ -28,6 +30,7 @@ describe('AttendanceScheduler (④ C4)', () => {
     stopAttendanceScheduler()
     delete process.env.ATTENDANCE_SCHEDULER_ENABLED
     delete process.env.ATTENDANCE_UNSCHEDULED_REMINDER_ENABLED
+    delete process.env.ATTENDANCE_COMP_TIME_EXPIRY_REMINDER_ENABLED
     vi.restoreAllMocks()
   })
 
@@ -126,6 +129,25 @@ describe('AttendanceScheduler (④ C4)', () => {
 
     const job = resolveUnscheduledReminderJob()
     expect(job?.name).toBe('unscheduled-reminder')
+
+    await job?.run()
+    await job?.run()
+
+    expect(instances.size).toBe(1)
+  })
+
+  it('resolves the comp-time expiry reminder job with one stable service instance', async () => {
+    expect(resolveCompTimeExpiryReminderJob()).toBeNull()
+
+    process.env.ATTENDANCE_COMP_TIME_EXPIRY_REMINDER_ENABLED = 'true'
+    const instances = new Set<unknown>()
+    vi.spyOn(CompTimeExpiryReminderService.prototype, 'run').mockImplementation(function (this: CompTimeExpiryReminderService) {
+      instances.add(this)
+      return Promise.resolve({ candidates: 0, deliveries: 0 })
+    })
+
+    const job = resolveCompTimeExpiryReminderJob()
+    expect(job?.name).toBe('comp-time-expiry-reminder')
 
     await job?.run()
     await job?.run()

--- a/packages/core-backend/vitest.config.ts
+++ b/packages/core-backend/vitest.config.ts
@@ -21,6 +21,7 @@ export default defineConfig({
       'tests/integration/after-sales-plugin.install.test.ts',
       'tests/integration/after-sales-registry-backfill.test.ts',
       'tests/integration/approval-pack1a-lifecycle.api.test.ts',
+      'tests/integration/attendance-comp-time-expiry-reminder.test.ts',
       'tests/integration/attendance-expiry-service.test.ts',
       'tests/integration/attendance-notification-deliveries.test.ts',
       'tests/integration/attendance-outdoor-punch.test.ts',

--- a/scripts/ops/attendance-regression-local.sh
+++ b/scripts/ops/attendance-regression-local.sh
@@ -53,7 +53,7 @@ fi
 
 run_check \
   "backend-attendance-integration" \
-  "cd packages/core-backend && pnpm exec vitest --config ${backend_vitest_config} run tests/integration/attendance-plugin.test.ts tests/integration/attendance-expiry-service.test.ts tests/integration/attendance-unscheduled-reminder.test.ts tests/integration/attendance-outdoor-punch.test.ts tests/integration/attendance-notification-deliveries.test.ts"
+  "cd packages/core-backend && pnpm exec vitest --config ${backend_vitest_config} run tests/integration/attendance-plugin.test.ts tests/integration/attendance-expiry-service.test.ts tests/integration/attendance-unscheduled-reminder.test.ts tests/integration/attendance-outdoor-punch.test.ts tests/integration/attendance-notification-deliveries.test.ts tests/integration/attendance-comp-time-expiry-reminder.test.ts"
 
 run_check \
   "web-unit-tests" \


### PR DESCRIPTION
## Summary

C5-1b: produce delivery outbox rows for comp-time expiry reminders.

- Adds `CompTimeExpiryReminderService`, scanning active `comp_time` leave-balance lots whose `expires_at` falls within the env-configured reminder window.
- Produces `attendance_notification_deliveries` rows for the balance owner plus current attendance group `owner` / `sub_owner` recipients.
- Uses deterministic source keys: `comp_time_expiry_reminder:{balanceId}:{windowDate}:recipient:{recipientUserId}:channel:dingtalk_work_notification`.
- Does not mutate the source balance lot; C4 expiry remains the only state-flow writer.
- Wires the producer as an opt-in secondary `AttendanceScheduler` job via `ATTENDANCE_COMP_TIME_EXPIRY_REMINDER_ENABLED=true`.
- Adds the new DB-gated spec to `test:integration:attendance`, CI's attendance integration step, default vitest excludes, and the local attendance regression script.
- Backfills the tracker: C5-1a #2498 is now ✅; C5-1b is this PR and remains 🟡 until CI/review/merge.

## Verification

Local targeted checks:

- `pnpm --filter @metasheet/core-backend exec vitest --config vitest.config.ts run tests/unit/attendance-scheduler.test.ts --reporter=dot` → 11/11 pass.
- `pnpm --filter @metasheet/core-backend exec tsc --noEmit --pretty false` → pass.
- `git diff --check` → pass.
- After applying the already-main C1 ledger migration to my stale local DB, `DATABASE_URL=postgresql://metasheet:metasheet123@localhost:5432/metasheet_v2 pnpm --filter @metasheet/core-backend exec vitest --config vitest.integration.config.ts run tests/integration/attendance-comp-time-expiry-reminder.test.ts --reporter=dot` → 1/1 pass.
- Same local DB, C4/C5 DB-gated subset: `attendance-expiry-service`, `attendance-unscheduled-reminder`, `attendance-notification-deliveries`, `attendance-comp-time-expiry-reminder` → 4 files / 4 tests pass.

Local caveat:

- `test:integration:attendance` on my existing local DB still fails in the old route-heavy specs because the local DB is historically stale (`automation_rules`, `attendance_requests` outdoor-punch check, `attendance_holidays.origin`, etc.). The new C5-1b spec and related C4/C5 DB specs pass; CI's fresh migrated DB should be the full-suite authority.

## Deferred

- C5-2 delivery worker + fake channel.
- C5-3 DingTalk work-notification channel.
- C5-4 admin observability.
- C5-5 staging closeout.
